### PR TITLE
mod fujicoin tx fees

### DIFF
--- a/common/defs/bitcoin/fujicoin.json
+++ b/common/defs/bitcoin/fujicoin.json
@@ -8,8 +8,8 @@
   "curve_name": "secp256k1",
   "address_type": 36,
   "address_type_p2sh": 16,
-  "maxfee_kb": 10000000,
-  "minfee_kb": 100000,
+  "maxfee_kb": 1000000000,
+  "minfee_kb": 10000000,
   "signed_message_header": "FujiCoin Signed Message:\n",
   "hash_genesis_block": "adb6d9cfd74075e7f91608add4bd2a2ea636f70856183086842667a1597714a0",
   "xpub_magic": 76067358,
@@ -25,10 +25,10 @@
   "force_bip143": false,
   "bip115": false,
   "default_fee_b": {
-    "Low": 100,
-    "Economy": 200,
-    "Normal": 500,
-    "High": 1000
+    "Low": 10000,
+    "Economy": 20000,
+    "Normal": 50000,
+    "High": 100000
   },
   "dust_limit": 546,
   "blocktime_seconds": 60,


### PR DESCRIPTION
The following changes will be made to the minimum remittance fee from now on as Fujicoin was attacked by Spam Tx.
Before change: 0.001 FJC / kB
After change: 0.1 FJC / kB

Currently, the pool equivalent to about 95% of the network hash rate has completed measures. These pools do not handle low fee remittances. Therefore, the low fee remittance takes about 20 blocks (20 minutes) on average.

Please change Fujicoin remittance fee.

Thanks.