### PR TITLE
xmr: authorize live refresh per passphrase

### DIFF
--- a/core/src/apps/common/cache.py
+++ b/core/src/apps/common/cache.py
@@ -56,3 +56,7 @@ def clear(skip_passphrase: bool = False):
         set_passphrase("")
     else:
         set_passphrase(None)
+
+
+def get_passphrase_fprint():
+    return _compute_state(b"", get_passphrase() or "")[:4]

--- a/core/src/apps/monero/__init__.py
+++ b/core/src/apps/monero/__init__.py
@@ -4,6 +4,7 @@ from trezor.messages import MessageType
 from apps.common import HARDENED
 
 CURVE = "ed25519"
+_LIVE_REFRESH_TOKEN = None  # live-refresh permission token
 
 
 def boot():
@@ -19,3 +20,11 @@ def boot():
 
     if __debug__ and hasattr(MessageType, "DebugMoneroDiagRequest"):
         wire.add(MessageType.DebugMoneroDiagRequest, __name__, "diag")
+
+
+def live_refresh_token(token=None):
+    global _LIVE_REFRESH_TOKEN
+    if token is None:
+        return _LIVE_REFRESH_TOKEN
+    else:
+        _LIVE_REFRESH_TOKEN = token

--- a/core/src/apps/monero/live_refresh.py
+++ b/core/src/apps/monero/live_refresh.py
@@ -9,7 +9,8 @@ from trezor.messages.MoneroLiveRefreshStepAck import MoneroLiveRefreshStepAck
 from trezor.messages.MoneroLiveRefreshStepRequest import MoneroLiveRefreshStepRequest
 
 from apps.common import paths
-from apps.monero import CURVE, misc
+from apps.monero import CURVE, misc, live_refresh_token
+from apps.common.cache import get_passphrase_fprint
 from apps.monero.layout import confirms
 from apps.monero.xmr import crypto, key_image, monero
 from apps.monero.xmr.crypto import chacha_poly
@@ -48,7 +49,10 @@ async def _init_step(
         ctx, misc.validate_full_path, keychain, msg.address_n, CURVE
     )
 
-    await confirms.require_confirm_live_refresh(ctx)
+    passphrase_fprint = get_passphrase_fprint()
+    if live_refresh_token() != passphrase_fprint:
+        await confirms.require_confirm_live_refresh(ctx)
+        live_refresh_token(passphrase_fprint)
 
     s.creds = misc.get_creds(keychain, msg.address_n, msg.network_type)
 


### PR DESCRIPTION
Improves UX as the live refresh prompts were too often.
Fixes #128.

The idea is to cache the passphrase fingerprint for which the user live-refresh authorized.
The state is stored in the main monero module.

@tsusanka @prusnak is there a better way to store the state or is my approach OK? 