### PR TITLE
Do not display token values in Wei for low-decimal value tokens

### DIFF
--- a/core/src/apps/ethereum/layout.py
+++ b/core/src/apps/ethereum/layout.py
@@ -65,7 +65,8 @@ def format_ethereum_amount(value: int, token, chain_id: int, tx_type=None):
         suffix = networks.shortcut_by_chain_id(chain_id, tx_type)
         decimals = 18
 
-    if value <= 1e9:
+    # Don't want to display wei values for tokens with small decimal numbers
+    if value / (10 ** decimals) <= 1e-9:
         suffix = "Wei " + suffix
         decimals = 0
 

--- a/core/src/apps/ethereum/layout.py
+++ b/core/src/apps/ethereum/layout.py
@@ -66,7 +66,7 @@ def format_ethereum_amount(value: int, token, chain_id: int, tx_type=None):
         decimals = 18
 
     # Don't want to display wei values for tokens with small decimal numbers
-    if value / (10 ** decimals) <= 1e-9:
+    if decimals > 9 and value < 10 ** (decimals - 9):
         suffix = "Wei " + suffix
         decimals = 0
 

--- a/core/tests/test_apps.ethereum.layout.py
+++ b/core/tests/test_apps.ethereum.layout.py
@@ -1,5 +1,6 @@
 from common import *
 from apps.ethereum.layout import format_ethereum_amount
+from apps.ethereum.tokens import token_by_chain_address
 
 
 class TestEthereumLayout(unittest.TestCase):
@@ -16,7 +17,7 @@ class TestEthereumLayout(unittest.TestCase):
         text = format_ethereum_amount(100000000, None, 1)
         self.assertEqual(text, '100000000 Wei ETH')
         text = format_ethereum_amount(1000000000, None, 1)
-        self.assertEqual(text, '1000000000 Wei ETH')
+        self.assertEqual(text, '0.000000001 ETH')
         text = format_ethereum_amount(10000000000, None, 1)
         self.assertEqual(text, '0.00000001 ETH')
         text = format_ethereum_amount(100000000000, None, 1)
@@ -61,6 +62,27 @@ class TestEthereumLayout(unittest.TestCase):
         self.assertEqual(text, '1 Wei UNKN')
         text = format_ethereum_amount(10000000000000000001, None, 9999)
         self.assertEqual(text, '10.000000000000000001 UNKN')
+
+        # tokens with low decimal values
+        # USDC has 6 decimals
+        usdc_token = token_by_chain_address(1, bytes.fromhex("a0b86991c6218b36c1d19d4a2e9eb0ce3606eb48"))
+        # ICO has 10 decimals
+        ico_token = token_by_chain_address(1, bytes.fromhex("a33e729bf4fdeb868b534e1f20523463d9c46bee"))
+
+        # when decimals < 10, should never display 'Wei' format
+        text = format_ethereum_amount(1, usdc_token, 1)
+        self.assertEqual(text, '0.000001 USDC')
+        text = format_ethereum_amount(0, usdc_token, 1)
+        self.assertEqual(text, '0 USDC')
+
+        text = format_ethereum_amount(1, ico_token, 1)
+        self.assertEqual(text, '1 Wei ICO')
+        text = format_ethereum_amount(9, ico_token, 1)
+        self.assertEqual(text, '9 Wei ICO')
+        text = format_ethereum_amount(10, ico_token, 1)
+        self.assertEqual(text, '0.000000001 ICO')
+        text = format_ethereum_amount(11, ico_token, 1)
+        self.assertEqual(text, '0.0000000011 ICO')
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
Current behavior: 
Check the value of the ERC20 transfer in Wei - if the value is less than `10^9`, display the value on-screen as the wei value, with zero decimals.

Because of this, tokens with small decimal values will end up displaying the wei values even when the device could be displaying a very reasonable human-friendly number. 


Example when sending $25 USDC (ETH token with 6 decimals) with the model T:
![IMG_20190508_1417590](https://user-images.githubusercontent.com/31221309/57409075-2e788d00-719c-11e9-982d-c883925f9b26.jpg)

This appears to be a non-issue on the Trezor One firmware
![IMG_20190508_1424248](https://user-images.githubusercontent.com/31221309/57409389-089fb800-719d-11e9-8cb7-605fdd549aa4.jpg)


New behavior:
Measure the value of the transfer relative to the token's decimals. If the value we are going to display is less than `1e-9` (0.000000001) of that token's human-friendly format, then we display the value in Wei, setting `decimals = 0`. 

This means that tokens where `decimals == 18` should behave the same as they have before. But other tokens with smaller decimal values will be handled more gracefully when sending small values.