### PR TITLE
Fix message composing in ethereum signature

### DIFF
--- a/legacy/firmware/ethereum.c
+++ b/legacy/firmware/ethereum.c
@@ -630,39 +630,39 @@ static void ethereum_message_hash(const uint8_t *message, size_t message_len,
   sha3_256_Init(&ctx);
   sha3_Update(&ctx, (const uint8_t *)"\x19" "Ethereum Signed Message:\n", 26);
   uint8_t c;
-  if (message_len > 1000000000) {
+  if (message_len >= 1000000000) {
     c = '0' + message_len / 1000000000 % 10;
     sha3_Update(&ctx, &c, 1);
   }
-  if (message_len > 100000000) {
+  if (message_len >= 100000000) {
     c = '0' + message_len / 100000000 % 10;
     sha3_Update(&ctx, &c, 1);
   }
-  if (message_len > 10000000) {
+  if (message_len >= 10000000) {
     c = '0' + message_len / 10000000 % 10;
     sha3_Update(&ctx, &c, 1);
   }
-  if (message_len > 1000000) {
+  if (message_len >= 1000000) {
     c = '0' + message_len / 1000000 % 10;
     sha3_Update(&ctx, &c, 1);
   }
-  if (message_len > 100000) {
+  if (message_len >= 100000) {
     c = '0' + message_len / 100000 % 10;
     sha3_Update(&ctx, &c, 1);
   }
-  if (message_len > 10000) {
+  if (message_len >= 10000) {
     c = '0' + message_len / 10000 % 10;
     sha3_Update(&ctx, &c, 1);
   }
-  if (message_len > 1000) {
+  if (message_len >= 1000) {
     c = '0' + message_len / 1000 % 10;
     sha3_Update(&ctx, &c, 1);
   }
-  if (message_len > 100) {
+  if (message_len >= 100) {
     c = '0' + message_len / 100 % 10;
     sha3_Update(&ctx, &c, 1);
   }
-  if (message_len > 10) {
+  if (message_len >= 10) {
     c = '0' + message_len / 10 % 10;
     sha3_Update(&ctx, &c, 1);
   }


### PR DESCRIPTION
If the length of the message was exactly a power of `10` the initial `1` was omitted.