### PR TITLE
Add custom markers to pytest.ini

### DIFF
--- a/core/pytest.ini
+++ b/core/pytest.ini
@@ -1,3 +1,21 @@
 [pytest]
 addopts = --pyargs trezorlib.tests.device_tests
 xfail_strict = true
+
+markers =
+    capricoin
+    cardano
+    decred
+    eos
+    ethereum
+    komodo
+    lisk
+    monero
+    nem
+    ontology
+    ripple
+    skip_t1
+    skip_t2
+    stellar
+    tezos
+    zcash


### PR DESCRIPTION
Following https://docs.pytest.org/en/latest/mark.html#raising-errors-on-unknown-marks:
```
/home/roman/.local/lib/python3.6/site-packages/_pytest/mark/structures.py:324
  /home/roman/.local/lib/python3.6/site-packages/_pytest/mark/structures.py:324: PytestUnknownMarkWarning: Unknown pytest.mark.skip_t2 - is this a typo?  You can register custom marks to avoid this warning - for details, see https://docs.pytest.org/en/latest/mark.html
    PytestUnknownMarkWarning,

/home/roman/.local/lib/python3.6/site-packages/_pytest/mark/structures.py:324
  /home/roman/.local/lib/python3.6/site-packages/_pytest/mark/structures.py:324: PytestUnknownMarkWarning: Unknown pytest.mark.cardano - is this a typo?  You can register custom marks to avoid this warning - for details, see https://docs.pytest.org/en/latest/mark.html
    PytestUnknownMarkWarning,

/home/roman/.local/lib/python3.6/site-packages/_pytest/mark/structures.py:324
  /home/roman/.local/lib/python3.6/site-packages/_pytest/mark/structures.py:324: PytestUnknownMarkWarning: Unknown pytest.mark.skip_t1 - is this a typo?  You can register custom marks to avoid this warning - for details, see https://docs.pytest.org/en/latest/mark.html
    PytestUnknownMarkWarning,

<snip>
```