### PR TITLE
core: Add --enable-debuglink option to emu.sh to enable debug mode emulator

### DIFF
--- a/core/emu.sh
+++ b/core/emu.sh
@@ -7,7 +7,12 @@ PYOPT="${PYOPT:-1}"
 MAIN="${MAIN:-src/main.py}"
 HEAPSIZE="${HEAPSIZE:-50M}"
 
-ARGS="-O${PYOPT} -X heapsize=${HEAPSIZE}"
+case "$1" in
+    "--enable-debuglink")
+        shift
+        PYOPT=0
+        ;;
+esac
 
 cd `dirname $0`
 


### PR DESCRIPTION
Adds an option `--debug` to `emu.sh` so that the emulator can be run in debug mode so that the debuglink works.