### PR TITLE
reset i2c bus when busy condition detected

### DIFF
--- a/core/embed/trezorhal/touch_t.h
+++ b/core/embed/trezorhal/touch_t.h
@@ -1,4 +1,4 @@
-#include <py/mpprint.h>
+// #include <py/mpprint.h>
 #include <string.h>
 
 #include "common.h"
@@ -132,7 +132,7 @@ void _i2c_cycle(void) {
   // set above pins to OUTPUT / NOPULL
   GPIO_InitTypeDef GPIO_InitStructure;
 
-  mp_printf(&mp_plat_print, "reset GPIOs...\n");
+  // mp_printf(&mp_plat_print, "reset GPIOs...\n");
   GPIO_InitStructure.Mode = GPIO_MODE_OUTPUT_PP;
   GPIO_InitStructure.Pull = GPIO_NOPULL;
   GPIO_InitStructure.Speed = GPIO_SPEED_FREQ_LOW;
@@ -142,19 +142,19 @@ void _i2c_cycle(void) {
 
   // PIN6 is SCL, PIN7 is SDA
 
-  mp_printf(&mp_plat_print, "set high...\n");
+  // mp_printf(&mp_plat_print, "set high...\n");
   _i2c_ensure_pin(GPIO_PIN_6, GPIO_PIN_SET);
   _i2c_ensure_pin(GPIO_PIN_7, GPIO_PIN_SET);
-  mp_printf(&mp_plat_print, "SDA low...\n");
+  // mp_printf(&mp_plat_print, "SDA low...\n");
   _i2c_ensure_pin(GPIO_PIN_7, GPIO_PIN_RESET);
-  mp_printf(&mp_plat_print, "SCL low...\n");
+  // mp_printf(&mp_plat_print, "SCL low...\n");
   _i2c_ensure_pin(GPIO_PIN_6, GPIO_PIN_RESET);
-  mp_printf(&mp_plat_print, "SCL high...\n");
+  // mp_printf(&mp_plat_print, "SCL high...\n");
   _i2c_ensure_pin(GPIO_PIN_6, GPIO_PIN_SET);
-  mp_printf(&mp_plat_print, "SDA high...\n");
+  // mp_printf(&mp_plat_print, "SDA high...\n");
   _i2c_ensure_pin(GPIO_PIN_7, GPIO_PIN_SET);
 
-  mp_printf(&mp_plat_print, "reinit I2C...\n");
+  // mp_printf(&mp_plat_print, "reinit I2C...\n");
   GPIO_InitStructure.Mode = GPIO_MODE_AF_OD;
   GPIO_InitStructure.Pull = GPIO_NOPULL;
   GPIO_InitStructure.Speed =
@@ -165,14 +165,14 @@ void _i2c_cycle(void) {
   HAL_GPIO_Init(GPIOB, &GPIO_InitStructure);
   HAL_Delay(50);
 
-  mp_printf(&mp_plat_print, "toggle reset flag...\n");
+  // mp_printf(&mp_plat_print, "toggle reset flag...\n");
   __HAL_RCC_I2C1_FORCE_RESET();
   HAL_Delay(50);
   __HAL_RCC_I2C1_RELEASE_RESET();
 
   _i2c_init();
   HAL_Delay(10);
-  mp_printf(&mp_plat_print, "i2c cycle finished\n");
+  // mp_printf(&mp_plat_print, "i2c cycle finished\n");
 }
 
 void touch_power_on(void) {


### PR DESCRIPTION
The touch problem in #144 is indicated by `HAL_I2C_Master_Transmit` call returning busy status. There's a workaround described [here](https://www.st.com/content/ccc/resource/technical/document/errata_sheet/7f/05/b0/bc/34/2f/4c/21/CD00288116.pdf/files/CD00288116.pdf/jcr:content/translations/en.CD00288116.pdf) in section 2.9.7; basically, one needs to twiddle SDA and SCL lines before restarting the I2C hardware. This PR implements that workaround whenever busy condition is detected.

The document relates to a different chip and presumably electrostatic problems, but the workaround works. We also determined that this problem was introduced with commit https://github.com/trezor/trezor-firmware/commit/828ba7b5b01f9997a2f8e63e2e5f19d4a3f607af - namely, reading from RNG for USB delays is what triggers it.
Which makes sense; presumably the RNG-reads can interfere with the analog filters or whatnot is the problem of the i2c-busy condition.

It's questionable whether this is the right thing to do, and if we should use deterministic RNG for USB delays. We can't reasonably avoid using the true RNG for Python calls, but maybe that would be infrequent enough (or not interleaved enough) to not trigger this problem.