### PR TITLE
core: ensure pubkeyhash/scripthash have the correct length

### DIFF
--- a/core/src/apps/wallet/sign_tx/scripts.py
+++ b/core/src/apps/wallet/sign_tx/scripts.py
@@ -31,6 +31,7 @@ def input_script_p2pkh_or_p2sh(
 
 
 def output_script_p2pkh(pubkeyhash: bytes) -> bytearray:
+    ensure(len(pubkeyhash) == 20)
     s = bytearray(25)
     s[0] = 0x76  # OP_DUP
     s[1] = 0xA9  # OP_HASH_160
@@ -43,7 +44,7 @@ def output_script_p2pkh(pubkeyhash: bytes) -> bytearray:
 
 def output_script_p2sh(scripthash: bytes) -> bytearray:
     # A9 14 <scripthash> 87
-
+    ensure(len(scripthash) == 20)
     s = bytearray(23)
     s[0] = 0xA9  # OP_HASH_160
     s[1] = 0x14  # pushing 20 bytes


### PR DESCRIPTION
Otherwise, it will extend the pre-allocated bytearray and the resulting script will be incorrect:
```
>>> x = bytearray(10)                                                                                                                                                                                                                                                       
>>> x[4:6] = b'111111111111111111111111111111111111111'                                                                                                                                                                                                                     
>>> x
bytearray(b'\x00\x00\x00\x00111111111111111111111111111111111111111\x00\x00\x00\x00')
```