### PR TITLE
core: return exception details in debug mode

### DIFF
--- a/core/src/trezor/wire/__init__.py
+++ b/core/src/trezor/wire/__init__.py
@@ -173,11 +173,12 @@ async def protobuf_workflow(ctx, reader, handler, *args):
         # respond with specific code and message
         await ctx.write(Failure(code=exc.code, message=exc.message))
         raise
-    except Exception:
+    except Exception as e:
         # respond with a generic code and message
-        await ctx.write(
-            Failure(code=FailureType.FirmwareError, message="Firmware error")
-        )
+        message = "Firmware error"
+        if __debug__:
+            message = "{}: {}".format(type(e), e)
+        await ctx.write(Failure(code=FailureType.FirmwareError, message=message))
         raise
     if res:
         # respond with a specific response


### PR DESCRIPTION
Not sure it's the best way, but it helped me to debug a few out-of-memory errors :)