### PR TITLE
legacy: remove last mentions of TREZOR_TRANSPORT_V1

### DIFF
--- a/legacy/README.md
+++ b/legacy/README.md
@@ -60,7 +60,7 @@ If you want to build device firmware, make sure you have the
 [GNU ARM Embedded toolchain](https://developer.arm.com/open-source/gnu-toolchain/gnu-rm/downloads) installed.
 You will also need Python 3.5 or later and [pipenv](https://pipenv.readthedocs.io/en/latest/install/).
 
-* If you want to build the emulator instead of the firmware, run `export EMULATOR=1 TREZOR_TRANSPORT_V1=1`
+* If you want to build the emulator instead of the firmware, run `export EMULATOR=1`
 * If you want to build with the debug link, run `export DEBUG_LINK=1`. Use this if you want to run the device tests.
 * When you change these variables, use `script/setup` to clean the repository
 

--- a/legacy/script/test
+++ b/legacy/script/test
@@ -14,5 +14,4 @@ if [ "$EMULATOR" = 1 ]; then
     "${PYTHON:-python}" script/wait_for_emulator.py
 fi
 
-export TREZOR_TRANSPORT_V1=1
 "${PYTHON:-python}" -m pytest --pyarg trezorlib.tests.device_tests "$@"


### PR DESCRIPTION
A search seems to indicate that this environment variable is not attached to anything.