### PR TITLE
core/secp256k1_zkp: add blinding and rangeproof API

### DIFF
--- a/core/embed/extmod/modtrezorcrypto/modtrezorcrypto-secp256k1_zkp.h
+++ b/core/embed/extmod/modtrezorcrypto/modtrezorcrypto-secp256k1_zkp.h
@@ -20,10 +20,15 @@
 #include "common.h"
 #include "py/objstr.h"
 
+#include "embed/extmod/trezorobj.h"
+
 #include "vendor/secp256k1-zkp/include/secp256k1.h"
 #include "vendor/secp256k1-zkp/include/secp256k1_ecdh.h"
 #include "vendor/secp256k1-zkp/include/secp256k1_preallocated.h"
+#include "vendor/secp256k1-zkp/include/secp256k1_rangeproof.h"
 #include "vendor/secp256k1-zkp/include/secp256k1_recovery.h"
+
+#define RANGEPROOF_SIGN_BUFFER_SIZE 5134
 
 void secp256k1_default_illegal_callback_fn(const char *str, void *data) {
   (void)data;
@@ -37,7 +42,61 @@ void secp256k1_default_error_callback_fn(const char *str, void *data) {
   return;
 }
 
+static void _assert_result(int success, const char *str) {
+  if (!success) {
+    __fatal_error(NULL, str, __FILE__, __LINE__, __func__);
+  }
+}
+
 /// package: trezorcrypto.secp256k1_zkp
+
+/// class RangeProofConfig:
+///     """
+///     Range proof configuration.
+///     """
+///
+typedef struct _mp_obj_range_proof_config_t {
+  mp_obj_base_t base;
+  uint64_t min_value;
+  size_t exponent;
+  size_t bits;
+} mp_obj_range_proof_config_t;
+
+/// def __init__(self, min_value: int, exponent: int, bits: int):
+///     """
+///     Initialize range proof configuration.
+///     """
+STATIC mp_obj_t mod_trezorcrypto_range_proof_config_make_new(
+    const mp_obj_type_t *type, size_t n_args, size_t n_kw,
+    const mp_obj_t *args) {
+  STATIC const mp_arg_t allowed_args[] = {
+      {MP_QSTR_min_value,
+       MP_ARG_REQUIRED | MP_ARG_KW_ONLY | MP_ARG_OBJ,
+       {.u_obj = mp_const_none}},
+      {MP_QSTR_exponent,
+       MP_ARG_REQUIRED | MP_ARG_KW_ONLY | MP_ARG_OBJ,
+       {.u_obj = mp_const_none}},
+      {MP_QSTR_bits,
+       MP_ARG_REQUIRED | MP_ARG_KW_ONLY | MP_ARG_OBJ,
+       {.u_obj = mp_const_none}},
+  };
+  mp_arg_val_t vals[MP_ARRAY_SIZE(allowed_args)];
+  mp_arg_parse_all_kw_array(n_args, n_kw, args, MP_ARRAY_SIZE(allowed_args),
+                            allowed_args, vals);
+
+  mp_obj_range_proof_config_t *o = m_new_obj(mp_obj_range_proof_config_t);
+  o->base.type = type;
+  o->min_value = trezor_obj_get_uint(vals[0].u_obj);
+  o->exponent = trezor_obj_get_uint(vals[1].u_obj);
+  o->bits = trezor_obj_get_uint(vals[2].u_obj);
+  return MP_OBJ_FROM_PTR(o);
+}
+
+STATIC const mp_obj_type_t mod_trezorcrypto_range_proof_config_type = {
+    {&mp_type_type},
+    .name = MP_QSTR_RangeProofConfig,
+    .make_new = mod_trezorcrypto_range_proof_config_make_new,
+};
 
 /// class Context:
 ///     """
@@ -49,12 +108,13 @@ typedef struct _mp_obj_secp256k1_context_t {
   mp_obj_base_t base;
   secp256k1_context *secp256k1_ctx;
   size_t secp256k1_ctx_size;
-  uint8_t secp256k1_ctx_buf[0];  // to be allocate via m_new_obj_var_maybe().
+  uint8_t *secp256k1_ctx_buf;
+  uint8_t *rangeproof_buffer;
 } mp_obj_secp256k1_context_t;
 
 /// def __init__(self) -> None:
 ///     """
-///     Allocate and initialize secp256k1_context.
+///     Allocate and initialize secp256k1_zkp context object.
 ///     """
 STATIC mp_obj_t mod_trezorcrypto_secp256k1_context_make_new(
     const mp_obj_type_t *type, size_t n_args, size_t n_kw,
@@ -64,39 +124,65 @@ STATIC mp_obj_t mod_trezorcrypto_secp256k1_context_make_new(
   const size_t secp256k1_ctx_size = secp256k1_context_preallocated_size(
       SECP256K1_CONTEXT_SIGN | SECP256K1_CONTEXT_VERIFY);
 
-  mp_obj_secp256k1_context_t *o = m_new_obj_var_maybe(
-      mp_obj_secp256k1_context_t, uint8_t, secp256k1_ctx_size);
-  if (!o) {
-    mp_raise_ValueError("secp256k1_zkp context is too large");
-  }
+  mp_obj_secp256k1_context_t *o = m_new_obj(mp_obj_secp256k1_context_t);
   o->base.type = type;
   o->secp256k1_ctx_size = secp256k1_ctx_size;
+  o->secp256k1_ctx = NULL;
+  o->secp256k1_ctx_buf = NULL;
+  o->rangeproof_buffer = NULL;
+  return MP_OBJ_FROM_PTR(o);
+}
+
+/// def __enter__(self) -> None:
+///     """
+///     Allocate and initialize secp256k1_context memory.
+///     """
+STATIC mp_obj_t mod_trezorcrypto_secp256k1_context___enter__(mp_obj_t self) {
+  mp_obj_secp256k1_context_t *o = MP_OBJ_TO_PTR(self);
+  if (o->secp256k1_ctx_buf) {
+    mp_raise_msg(&mp_type_RuntimeError,
+                 "cannot enter same secp256k1_zkp.Context");
+  }
+  o->secp256k1_ctx_buf = m_new(uint8_t, o->secp256k1_ctx_size);
   o->secp256k1_ctx = secp256k1_context_preallocated_create(
       o->secp256k1_ctx_buf, SECP256K1_CONTEXT_SIGN | SECP256K1_CONTEXT_VERIFY);
-
   uint8_t rand[32] = {0};
   random_buffer(rand, 32);
   int ret = secp256k1_context_randomize(o->secp256k1_ctx, rand);
   if (ret != 1) {
     mp_raise_msg(&mp_type_RuntimeError, "secp256k1_context_randomize failed");
   }
-
-  return MP_OBJ_FROM_PTR(o);
+  o->rangeproof_buffer = m_new(uint8_t, RANGEPROOF_SIGN_BUFFER_SIZE);
+  memzero(o->rangeproof_buffer, RANGEPROOF_SIGN_BUFFER_SIZE);
+  return self;
 }
 
-/// def __del__(self) -> None:
+STATIC MP_DEFINE_CONST_FUN_OBJ_1(
+    mod_trezorcrypto_secp256k1_context___enter___obj,
+    mod_trezorcrypto_secp256k1_context___enter__);
+
+/// def __exit__(self, *args: Any) -> None:
 ///     """
-///     Destructor.
+///     Erase and free secp256k1_context memory.
 ///     """
-STATIC mp_obj_t mod_trezorcrypto_secp256k1_context___del__(mp_obj_t self) {
-  mp_obj_secp256k1_context_t *o = MP_OBJ_TO_PTR(self);
-  secp256k1_context_preallocated_destroy(o->secp256k1_ctx);
-  memzero(o->secp256k1_ctx_buf, o->secp256k1_ctx_size);
+STATIC mp_obj_t mod_trezorcrypto_secp256k1_context___exit__(
+    size_t n_args, const mp_obj_t *args) {
+  mp_obj_secp256k1_context_t *o = MP_OBJ_TO_PTR(args[0]);
+  if (o->secp256k1_ctx) {
+    secp256k1_context_preallocated_destroy(o->secp256k1_ctx);
+    o->secp256k1_ctx = NULL;
+  }
+  if (o->secp256k1_ctx_buf) {
+    memzero(o->secp256k1_ctx_buf, o->secp256k1_ctx_size);
+    m_del(uint8_t, o->secp256k1_ctx_buf, o->secp256k1_ctx_size);
+    o->secp256k1_ctx_buf = NULL;
+  }
   return mp_const_none;
 }
 
-STATIC MP_DEFINE_CONST_FUN_OBJ_1(mod_trezorcrypto_secp256k1_context___del___obj,
-                                 mod_trezorcrypto_secp256k1_context___del__);
+STATIC MP_DEFINE_CONST_FUN_OBJ_VAR_BETWEEN(
+    mod_trezorcrypto_secp256k1_context___exit___obj, 1, 4,
+    mod_trezorcrypto_secp256k1_context___exit__);
 
 /// def size(self) -> int:
 ///     """
@@ -113,6 +199,9 @@ STATIC MP_DEFINE_CONST_FUN_OBJ_1(mod_trezorcrypto_secp256k1_context_size_obj,
 static const secp256k1_context *mod_trezorcrypto_get_secp256k1_context(
     mp_obj_t self) {
   mp_obj_secp256k1_context_t *o = MP_OBJ_TO_PTR(self);
+  if (o->secp256k1_ctx == NULL) {
+    mp_raise_msg(&mp_type_RuntimeError, "not entered secp256k1_zkp.Context");
+  }
   return o->secp256k1_ctx;
 }
 
@@ -157,9 +246,10 @@ STATIC mp_obj_t mod_trezorcrypto_secp256k1_context_publickey(
   bool compressed = n_args < 3 || args[2] == mp_const_true;
   uint8_t out[65];
   size_t outlen = sizeof(out);
-  secp256k1_ec_pubkey_serialize(
+  int success = secp256k1_ec_pubkey_serialize(
       ctx, out, &outlen, &pk,
       compressed ? SECP256K1_EC_COMPRESSED : SECP256K1_EC_UNCOMPRESSED);
+  _assert_result(success == 1, "Failed to serialize public key");
   return mp_obj_new_bytes(out, outlen);
 }
 STATIC MP_DEFINE_CONST_FUN_OBJ_VAR_BETWEEN(
@@ -193,8 +283,9 @@ STATIC mp_obj_t mod_trezorcrypto_secp256k1_context_sign(size_t n_args,
                                         (const uint8_t *)sk.buf, NULL, NULL)) {
     mp_raise_ValueError("Signing failed");
   }
-  secp256k1_ecdsa_recoverable_signature_serialize_compact(ctx, &out[1], &pby,
-                                                          &sig);
+  int success = secp256k1_ecdsa_recoverable_signature_serialize_compact(
+      ctx, &out[1], &pby, &sig);
+  _assert_result(success == 1, "Failed to serialize signature");
   out[0] = 27 + pby + compressed * 4;
   return mp_obj_new_bytes(out, sizeof(out));
 }
@@ -280,9 +371,11 @@ STATIC mp_obj_t mod_trezorcrypto_secp256k1_context_verify_recover(
   }
   uint8_t out[65];
   size_t pklen = sizeof(out);
-  secp256k1_ec_pubkey_serialize(
+  int success = secp256k1_ec_pubkey_serialize(
       ctx, out, &pklen, &pk,
       compressed ? SECP256K1_EC_COMPRESSED : SECP256K1_EC_UNCOMPRESSED);
+  _assert_result(success == 1, "Failed to serialize public key");
+
   return mp_obj_new_bytes(out, pklen);
 }
 STATIC MP_DEFINE_CONST_FUN_OBJ_3(
@@ -331,12 +424,266 @@ STATIC MP_DEFINE_CONST_FUN_OBJ_3(
     mod_trezorcrypto_secp256k1_context_multiply_obj,
     mod_trezorcrypto_secp256k1_context_multiply);
 
-//////////////////////////////////////////////////////////////////////////////
+/// def blind_generator(self, asset: bytes, blinder: bytes) -> bytes:
+///     '''
+///     Generate blinded generator for the specified confidential asset.
+///     '''
+STATIC mp_obj_t mod_trezorcrypto_secp256k1_context_blind_generator(
+    mp_obj_t self, mp_obj_t asset_obj, mp_obj_t blind_obj) {
+  const secp256k1_context *ctx = mod_trezorcrypto_get_secp256k1_context(self);
+
+  mp_buffer_info_t asset;
+  mp_get_buffer_raise(asset_obj, &asset, MP_BUFFER_READ);
+  if (asset.len != 32) {
+    mp_raise_ValueError("Invalid length of asset");
+  }
+  mp_buffer_info_t blind;
+  mp_get_buffer_raise(blind_obj, &blind, MP_BUFFER_READ);
+  if (blind.len != 32) {
+    mp_raise_ValueError("Invalid length of blinding factor");
+  }
+  secp256k1_generator gen;
+  if (!secp256k1_generator_generate_blinded(ctx, &gen, asset.buf, blind.buf)) {
+    mp_raise_ValueError("Generator blinding failed");
+  }
+  uint8_t out[33] = {0};
+  int success = secp256k1_generator_serialize(ctx, out, &gen);
+  _assert_result(success == 1, "Failed to serialize generator");
+  return mp_obj_new_bytes(out, sizeof(out));
+}
+
+STATIC MP_DEFINE_CONST_FUN_OBJ_3(
+    mod_trezorcrypto_secp256k1_context_blind_generator_obj,
+    mod_trezorcrypto_secp256k1_context_blind_generator);
+
+STATIC void parse_generator(const secp256k1_context *ctx,
+                            secp256k1_generator *generator, mp_obj_t obj) {
+  mp_buffer_info_t gen;
+  mp_get_buffer_raise(obj, &gen, MP_BUFFER_READ);
+  if (gen.len != 33) {
+    mp_raise_ValueError("Invalid length of generator");
+  }
+  if (!secp256k1_generator_parse(ctx, generator, gen.buf)) {
+    mp_raise_ValueError("Generator parsing failed");
+  }
+}
+
+/// def pedersen_commit(self, value: int, blinder: bytes, gen: bytes) -> bytes:
+///     '''
+///     Commit to specified integer value, using given 32-byte blinding factor.
+///     '''
+STATIC mp_obj_t mod_trezorcrypto_secp256k1_context_pedersen_commit(
+    size_t n_args, const mp_obj_t *args) {
+  const secp256k1_context *ctx =
+      mod_trezorcrypto_get_secp256k1_context(args[0]);
+
+  const uint64_t value = trezor_obj_get_uint64(args[1]);
+
+  mp_buffer_info_t blind;
+  mp_get_buffer_raise(args[2], &blind, MP_BUFFER_READ);
+  if (blind.len != 32) {
+    mp_raise_ValueError("Invalid length of blinding factor");
+  }
+
+  secp256k1_generator generator;
+  parse_generator(ctx, &generator, args[3]);
+
+  secp256k1_pedersen_commitment commit;
+  if (!secp256k1_pedersen_commit(ctx, &commit, blind.buf, value, &generator)) {
+    mp_raise_ValueError("Pedersen commit failed");
+  }
+
+  uint8_t output[33];
+  int success = secp256k1_pedersen_commitment_serialize(ctx, output, &commit);
+  _assert_result(success == 1, "Failed to serialize pedersen commitment");
+  return mp_obj_new_bytes(output, sizeof(output));
+}
+
+STATIC MP_DEFINE_CONST_FUN_OBJ_VAR_BETWEEN(
+    mod_trezorcrypto_secp256k1_context_pedersen_commit_obj, 4, 4,
+    mod_trezorcrypto_secp256k1_context_pedersen_commit);
+
+STATIC void parse_commitment(const secp256k1_context *ctx,
+                             secp256k1_pedersen_commitment *commitment,
+                             mp_obj_t obj) {
+  mp_buffer_info_t commit;
+  mp_get_buffer_raise(obj, &commit, MP_BUFFER_READ);
+  if (commit.len != 33) {
+    mp_raise_ValueError("Invalid length of commitment");
+  }
+  if (secp256k1_pedersen_commitment_parse(ctx, commitment, commit.buf) != 1) {
+    mp_raise_ValueError("Invalid Pedersen commitment");
+  }
+}
+
+/// def balance_blinds(self, values: Tuple[int], value_blinds: bytearray,
+///                    asset_blinds: bytes, num_of_inputs: int) -> None:
+///     '''
+///     Balance value blinds (by updating value_blinds in-place).
+///     '''
+STATIC mp_obj_t mod_trezorcrypto_secp256k1_context_balance_blinds(
+    size_t n_args, const mp_obj_t *args) {
+  const secp256k1_context *ctx =
+      mod_trezorcrypto_get_secp256k1_context(args[0]);
+
+  size_t values_len = 0;
+  mp_obj_t *values_objs = NULL;
+  mp_obj_tuple_get(args[1], &values_len, &values_objs);
+
+  mp_buffer_info_t value_blinds;  // 32-byte value blinding factors
+  mp_get_buffer_raise(args[2], &value_blinds, MP_BUFFER_RW);
+  if (value_blinds.len != 32 * values_len) {
+    mp_raise_ValueError("Invalid value blind size");
+  }
+
+  mp_buffer_info_t asset_blinds;  // 32-byte asset blinding factor
+  mp_get_buffer_raise(args[3], &asset_blinds, MP_BUFFER_READ);
+  if (asset_blinds.len != 32 * values_len) {
+    mp_raise_ValueError("Invalid asset blind size");
+  }
+
+  size_t num_of_inputs = mp_obj_get_int(args[4]);
+  if (num_of_inputs >= values_len) {
+    mp_raise_ValueError("incorrect num_of_inputs");
+  }
+
+  uint64_t values[values_len];
+  uint8_t *value_blinds_ptrs[values_len];
+  const uint8_t *asset_blinds_ptrs[values_len];
+
+  for (size_t i = 0; i < values_len; ++i) {
+    values[i] = trezor_obj_get_uint64(values_objs[i]);
+  }
+  for (size_t i = 0; i < values_len; ++i) {
+    value_blinds_ptrs[i] = ((uint8_t *)value_blinds.buf) + (i * 32);
+  }
+  for (size_t i = 0; i < values_len; ++i) {
+    asset_blinds_ptrs[i] = ((const uint8_t *)asset_blinds.buf) + (i * 32);
+  }
+
+  if (!secp256k1_pedersen_blind_generator_blind_sum(
+          ctx, values, asset_blinds_ptrs, value_blinds_ptrs, values_len,
+          num_of_inputs)) {
+    mp_raise_ValueError("Balancing blinding factors failed");
+  }
+
+  return mp_const_none;
+}
+
+STATIC MP_DEFINE_CONST_FUN_OBJ_VAR_BETWEEN(
+    mod_trezorcrypto_secp256k1_context_balance_blinds_obj, 5, 5,
+    mod_trezorcrypto_secp256k1_context_balance_blinds);
+
+/// def verify_balance(self, commits: Tuple[bytes], n_inputs: int) -> None:
+///     '''
+///     Verify that Pedersen commitments are balanced.
+///     '''
+STATIC mp_obj_t mod_trezorcrypto_secp256k1_context_verify_balance(
+    size_t n_args, const mp_obj_t *args) {
+  const secp256k1_context *ctx =
+      mod_trezorcrypto_get_secp256k1_context(args[0]);
+
+  size_t n_commitments = 0;
+  mp_obj_t *commitments_objs = NULL;
+  mp_obj_tuple_get(args[1], &n_commitments, &commitments_objs);
+
+  const secp256k1_pedersen_commitment *commitments[n_commitments];
+  for (size_t i = 0; i < n_commitments; ++i) {
+    secp256k1_pedersen_commitment *commit =
+        m_new_obj(secp256k1_pedersen_commitment);
+    parse_commitment(ctx, commit, commitments_objs[i]);
+    commitments[i] = commit;
+  }
+
+  const size_t num_of_inputs = mp_obj_get_int(args[2]);
+  if (num_of_inputs < 1 || num_of_inputs >= n_commitments) {
+    mp_raise_ValueError("Invalid number of inputs");
+  }
+
+  if (!secp256k1_pedersen_verify_tally(ctx, commitments, num_of_inputs,
+                                       commitments + num_of_inputs,
+                                       n_commitments - num_of_inputs)) {
+    mp_raise_ValueError("Pedersen commitments are not balanced");
+  }
+
+  for (size_t i = 0; i < n_commitments; ++i) {
+    m_del_obj(secp256k1_pedersen_commitment, (void *)(commitments[i]));
+  }
+  return mp_const_none;
+}
+
+STATIC MP_DEFINE_CONST_FUN_OBJ_VAR_BETWEEN(
+    mod_trezorcrypto_secp256k1_context_verify_balance_obj, 3, 3,
+    mod_trezorcrypto_secp256k1_context_verify_balance);
+
+/// def rangeproof_sign(self, config: RangeProofConfig, value: int,
+///                     commit: bytes, blind: bytes, nonce: bytes,
+///                     message: bytes, extra_commit: bytes,
+///                     gen: bytes) -> memoryview:
+///     '''
+///     Return a range proof for specified value (as a memoryview of the
+///     underlying rangeproof_buffer).
+///     '''
+STATIC mp_obj_t mod_trezorcrypto_secp256k1_context_rangeproof_sign(
+    size_t n_args, const mp_obj_t *args) {
+  mp_obj_secp256k1_context_t *o = MP_OBJ_TO_PTR(args[0]);
+  if (o->secp256k1_ctx == NULL || o->rangeproof_buffer == NULL) {
+    mp_raise_msg(&mp_type_RuntimeError, "not entered secp256k1_zkp.Context");
+  }
+  secp256k1_context *ctx = o->secp256k1_ctx;
+  uint8_t *rangeproof_buffer = o->rangeproof_buffer;
+
+  mp_obj_range_proof_config_t *config = MP_OBJ_TO_PTR(args[1]);
+
+  const uint64_t value = trezor_obj_get_uint64(args[2]);
+
+  secp256k1_pedersen_commitment commitment;
+  parse_commitment(ctx, &commitment, args[3]);
+
+  mp_buffer_info_t blind;
+  mp_get_buffer_raise(args[4], &blind, MP_BUFFER_READ);
+  if (blind.len != 32) {
+    mp_raise_ValueError("Invalid length of blinding factor");
+  }
+
+  mp_buffer_info_t nonce;
+  mp_get_buffer_raise(args[5], &nonce, MP_BUFFER_READ);
+  if (nonce.len != 32) {
+    mp_raise_ValueError("Invalid length of nonce");
+  }
+
+  mp_buffer_info_t message;
+  mp_get_buffer_raise(args[6], &message, MP_BUFFER_READ);
+
+  mp_buffer_info_t extra_commit;
+  mp_get_buffer_raise(args[7], &extra_commit, MP_BUFFER_READ);
+
+  secp256k1_generator generator;
+  parse_generator(ctx, &generator, args[8]);
+
+  memzero(rangeproof_buffer, RANGEPROOF_SIGN_BUFFER_SIZE);
+  size_t rangeproof_len = RANGEPROOF_SIGN_BUFFER_SIZE;
+
+  if (!secp256k1_rangeproof_sign(
+          ctx, rangeproof_buffer, &rangeproof_len, config->min_value,
+          &commitment, blind.buf, nonce.buf, config->exponent, config->bits,
+          value, message.buf, message.len, extra_commit.buf, extra_commit.len,
+          &generator)) {
+    mp_raise_ValueError("Rangeproof sign failed");
+  }
+  return mp_obj_new_memoryview('B', rangeproof_len, rangeproof_buffer);
+}
+
+STATIC MP_DEFINE_CONST_FUN_OBJ_VAR_BETWEEN(
+    mod_trezorcrypto_secp256k1_context_rangeproof_sign_obj, 9, 9,
+    mod_trezorcrypto_secp256k1_context_rangeproof_sign);
 
 STATIC const mp_rom_map_elem_t
     mod_trezorcrypto_secp256k1_context_locals_dict_table[] = {
-        {MP_ROM_QSTR(MP_QSTR___del__),
-         MP_ROM_PTR(&mod_trezorcrypto_secp256k1_context___del___obj)},
+        {MP_ROM_QSTR(MP_QSTR___enter__),
+         MP_ROM_PTR(&mod_trezorcrypto_secp256k1_context___enter___obj)},
+        {MP_ROM_QSTR(MP_QSTR___exit__),
+         MP_ROM_PTR(&mod_trezorcrypto_secp256k1_context___exit___obj)},
         {MP_ROM_QSTR(MP_QSTR_size),
          MP_ROM_PTR(&mod_trezorcrypto_secp256k1_context_size_obj)},
         {MP_ROM_QSTR(MP_QSTR_generate_secret),
@@ -351,6 +698,16 @@ STATIC const mp_rom_map_elem_t
          MP_ROM_PTR(&mod_trezorcrypto_secp256k1_context_verify_recover_obj)},
         {MP_ROM_QSTR(MP_QSTR_multiply),
          MP_ROM_PTR(&mod_trezorcrypto_secp256k1_context_multiply_obj)},
+        {MP_ROM_QSTR(MP_QSTR_blind_generator),
+         MP_ROM_PTR(&mod_trezorcrypto_secp256k1_context_blind_generator_obj)},
+        {MP_ROM_QSTR(MP_QSTR_pedersen_commit),
+         MP_ROM_PTR(&mod_trezorcrypto_secp256k1_context_pedersen_commit_obj)},
+        {MP_ROM_QSTR(MP_QSTR_balance_blinds),
+         MP_ROM_PTR(&mod_trezorcrypto_secp256k1_context_balance_blinds_obj)},
+        {MP_ROM_QSTR(MP_QSTR_verify_balance),
+         MP_ROM_PTR(&mod_trezorcrypto_secp256k1_context_verify_balance_obj)},
+        {MP_ROM_QSTR(MP_QSTR_rangeproof_sign),
+         MP_ROM_PTR(&mod_trezorcrypto_secp256k1_context_rangeproof_sign_obj)},
 };
 
 STATIC MP_DEFINE_CONST_DICT(
@@ -367,6 +724,8 @@ STATIC const mp_obj_type_t mod_trezorcrypto_secp256k1_context_type = {
 STATIC const mp_rom_map_elem_t
     mod_trezorcrypto_secp256k1_zkp_globals_table[] = {
         {MP_ROM_QSTR(MP_QSTR___name__), MP_ROM_QSTR(MP_QSTR_secp256k1_zkp)},
+        {MP_ROM_QSTR(MP_QSTR_RangeProofConfig),
+         MP_ROM_PTR(&mod_trezorcrypto_range_proof_config_type)},
         {MP_ROM_QSTR(MP_QSTR_Context),
          MP_ROM_PTR(&mod_trezorcrypto_secp256k1_context_type)},
 };

--- a/core/embed/extmod/trezorobj.h
+++ b/core/embed/extmod/trezorobj.h
@@ -75,4 +75,33 @@ static inline uint8_t trezor_obj_get_uint8(mp_obj_t obj) {
   return u;
 }
 
+static inline uint64_t trezor_obj_get_uint64(mp_const_obj_t obj) {
+  if (obj == mp_const_false) {
+    return 0;
+  } else if (obj == mp_const_true) {
+    return 1;
+  } else if (MP_OBJ_IS_SMALL_INT(obj)) {
+    return MP_OBJ_SMALL_INT_VALUE(obj);
+  } else if (MP_OBJ_IS_TYPE(obj, &mp_type_int)) {
+    byte buff[8];
+    uint64_t res = 0;
+    mp_obj_t *o = MP_OBJ_TO_PTR(obj);
+
+    mp_obj_int_to_bytes_impl(o, true, 8, buff);
+    for (int i = 0; i < 8; i++) {
+      res <<= 8;
+      res |= (uint64_t)(buff[i] & 0xff);
+    }
+    return res;
+  } else {
+    if (MICROPY_ERROR_REPORTING == MICROPY_ERROR_REPORTING_TERSE) {
+      mp_raise_TypeError("can't convert to int");
+    } else {
+      nlr_raise(mp_obj_new_exception_msg_varg(&mp_type_TypeError,
+                                              "can't convert %s to int",
+                                              mp_obj_get_type_str(obj)));
+    }
+  }
+}
+
 #endif

--- a/core/embed/firmware/memory_T.ld
+++ b/core/embed/firmware/memory_T.ld
@@ -71,10 +71,10 @@ SECTIONS {
 
   .heap : ALIGN(4) {
     . = 37K; /* this acts as a build time assertion that at least this much memory is available for heap use */
-    . = ABSOLUTE(sram_end - 16K); /* this explicitly sets the end of the heap effectively giving the stack at most 16K */
+    . = ABSOLUTE(sram_end - 50K); /* this explicitly sets the end of the heap effectively giving the stack at most 50K */
   } >SRAM
 
   .stack : ALIGN(8) {
-    . = 4K; /* this acts as a build time assertion that at least this much memory is available for stack use */
+    . = 50K; /* this acts as a build time assertion that at least this much memory is available for stack use */
   } >SRAM
 }

--- a/core/mocks/generated/trezorcrypto/secp256k1_zkp.pyi
+++ b/core/mocks/generated/trezorcrypto/secp256k1_zkp.pyi
@@ -2,6 +2,18 @@ from typing import *
 
 
 # extmod/modtrezorcrypto/modtrezorcrypto-secp256k1_zkp.h
+class RangeProofConfig:
+    """
+    Range proof configuration.
+    """
+
+    def __init__(self, min_value: int, exponent: int, bits: int):
+        """
+        Initialize range proof configuration.
+        """
+
+
+# extmod/modtrezorcrypto/modtrezorcrypto-secp256k1_zkp.h
 class Context:
     """
     Owns a secp256k1 context.
@@ -10,12 +22,17 @@ class Context:
 
     def __init__(self) -> None:
         """
-        Allocate and initialize secp256k1_context.
+        Allocate and initialize secp256k1_zkp context object.
         """
 
-    def __del__(self) -> None:
+    def __enter__(self) -> None:
         """
-        Destructor.
+        Allocate and initialize secp256k1_context memory.
+        """
+
+    def __exit__(self, *args: Any) -> None:
+        """
+        Erase and free secp256k1_context memory.
         """
 
     def size(self) -> int:
@@ -59,3 +76,33 @@ class Context:
         Multiplies point defined by public_key with scalar defined by
         secret_key. Useful for ECDH.
         """
+
+    def blind_generator(self, asset: bytes, blinder: bytes) -> bytes:
+        '''
+        Generate blinded generator for the specified confidential asset.
+        '''
+
+    def pedersen_commit(self, value: int, blinder: bytes, gen: bytes) -> bytes:
+        '''
+        Commit to specified integer value, using given 32-byte blinding factor.
+        '''
+
+    def balance_blinds(self, values: Tuple[int], value_blinds: bytearray,
+                       asset_blinds: bytes, num_of_inputs: int) -> None:
+        '''
+        Balance value blinds (by updating value_blinds in-place).
+        '''
+
+    def verify_balance(self, commits: Tuple[bytes], n_inputs: int) -> None:
+        '''
+        Verify that Pedersen commitments are balanced.
+        '''
+
+    def rangeproof_sign(self, config: RangeProofConfig, value: int,
+                        commit: bytes, blind: bytes, nonce: bytes,
+                        message: bytes, extra_commit: bytes,
+                        gen: bytes) -> memoryview:
+        '''
+        Return a range proof for specified value (as a memoryview of the
+        underlying rangeproof_buffer).
+        '''

--- a/core/tests/test_trezor.crypto.curve.secp256k1.py
+++ b/core/tests/test_trezor.crypto.curve.secp256k1.py
@@ -71,14 +71,11 @@ class Secp256k1Common(object):
             sk = hex(sk)[2:]
             if len(sk) < 64:
                 sk = '0' * (64 - len(sk)) + sk
-            pk = pk.lower()
-            pk65 = hexlify(self.impl.publickey(unhexlify(sk), False)).decode()  # uncompressed
-            self.assertEqual(str(pk65), '04' + pk)
-            pk33 = hexlify(self.impl.publickey(unhexlify(sk))).decode()
-            if pk[-1] in '02468ace':
-                self.assertEqual(pk33, '02' + pk[:64])
-            else:
-                self.assertEqual(pk33, '03' + pk[:64])
+            pk = unhexlify('04' + pk)
+            pk65 = self.impl.publickey(unhexlify(sk), False)  # uncompressed
+            self.assertEqual(pk65, pk)
+            pk33 = self.impl.publickey(unhexlify(sk))
+            self.assertEqual(pk33, compress_pubkey(pk))
 
     def test_sign_verify_min_max(self):
         sk = self.impl.generate_secret()
@@ -137,14 +134,90 @@ class Secp256k1Common(object):
         self.assertEqual(fixed_vector1, fixed_vector2)
         self.assertEqual(hexlify(fixed_vector1), fixed_vector_hex)
 
+
+def compress_pubkey(pk: bytes) -> bytes:
+    assert pk[0] == 4, pk
+    if pk[-1] % 2 == 0:
+        return b'\x02' + pk[1:33]
+    else:
+        return b'\x03' + pk[1:33]
+
+
 class TestCryptoSecp256k1(Secp256k1Common, unittest.TestCase):
     def __init__(self):
         self.impl = secp256k1
 
+def random_value(n_bits):
+    value = 0
+    while n_bits:
+        bits = min(n_bits, 30)
+        max_value = (1 << bits)
+        value = (value << bits) | random.uniform(max_value)
+        n_bits -= bits
+    return value
+
 @unittest.skipUnless(not utils.BITCOIN_ONLY, "altcoin")
 class TestCryptoSecp256k1Zkp(Secp256k1Common, unittest.TestCase):
     def __init__(self):
-        self.impl = secp256k1_zkp.Context()
+        self.context = secp256k1_zkp.Context()
+        self.impl = None
+
+    def setUp(self):
+        self.impl = self.context.__enter__();
+
+    def tearDown(self):
+        self.context.__exit__();
+        self.impl = None
+
+    def test_balance(self):
+        for _ in range(100):
+            n_inputs = random.uniform(10) + 1
+            n_outputs = random.uniform(10) + 1
+
+            asset = random.bytes(32)
+            input_values = [random_value(40) for _ in range(n_inputs)]
+            output_values = [random_value(40) for _ in range(n_outputs)]
+
+            total_input = sum(input_values)
+            total_output = sum(output_values)
+            if total_input > total_output:
+                output_values.append(total_input - total_output)
+            elif total_input < total_output:
+                input_values.append(total_output - total_input)
+            assert sum(input_values) == sum(output_values)
+
+            n_inputs = len(input_values)
+            input_value_blinds = [random.bytes(32) for _ in range(n_inputs)]
+            input_asset_blinds = [random.bytes(32) for _ in range(n_inputs)]
+
+            n_outputs = len(output_values)
+            output_value_blinds = [random.bytes(32) for _ in range(n_outputs)]
+            output_asset_blinds = [random.bytes(32) for _ in range(n_outputs)]
+
+            values = tuple(input_values + output_values)
+            value_blinds = bytearray(b''.join(input_value_blinds + output_value_blinds))
+            asset_blinds = b''.join(input_asset_blinds + output_asset_blinds)
+
+            self.impl.balance_blinds(values, value_blinds, asset_blinds, n_inputs)
+
+            conf_values = []
+            for i in range(n_inputs + n_outputs):
+                value = values[i]
+                asset_blind = asset_blinds[i*32:(i+1)*32]
+                value_blind = value_blinds[i*32:(i+1)*32]
+                conf_asset = self.impl.blind_generator(asset, asset_blind)
+                conf_value = self.impl.pedersen_commit(value, value_blind, conf_asset)
+                conf_values.append(conf_value)
+
+            self.impl.verify_balance(tuple(conf_values), n_inputs)
+
+            bad_n_inputs = n_inputs + 1
+            try:
+                self.impl.verify_balance(tuple(conf_values), bad_n_inputs)
+            except ValueError:
+                continue
+            self.fail("Unbalanced commitments not detected")
+
 
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
Allows rangeproof generation and rewinding, surjection proof generaion and Pedersen commitments' balancing on the device.

Notes to reviewers:
- The current code requires significant stack size increase (to ~40kB), so it depends on https://github.com/trezor/trezor-firmware/issues/174  (or increasing the stack size via `memory_T.ld`) to run on the TREZOR T.
- The tests can run on the emulator via:
```
$ make build_unix
$ ./tests/run_tests.sh test_trezor.crypto.curve.secp256k1.py
```