### PR TITLE
Shamir reset device tests

### DIFF
--- a/core/src/apps/management/common/layout.py
+++ b/core/src/apps/management/common/layout.py
@@ -405,7 +405,7 @@ async def _slip39_show_share_words(ctx, share_index, share_words):
 
         def export_displayed_words():
             # export currently displayed mnemonic words into debuglink
-            debug.reset_current_words = word_pages[paginated.page]
+            debug.reset_current_words = [w for _, w in word_pages[paginated.page]]
 
         paginated.on_change = export_displayed_words
         export_displayed_words()

--- a/python/trezorlib/tests/device_tests/test_msg_resetdevice_shamir.py
+++ b/python/trezorlib/tests/device_tests/test_msg_resetdevice_shamir.py
@@ -1,0 +1,167 @@
+import time
+from unittest import mock
+
+import pytest
+
+from trezorlib import device, messages as proto
+from trezorlib.messages import ButtonRequestType as B
+
+from .common import TrezorTest
+
+# TODO: uncomment when python_shamir_mnemonic is uploaded to pypi
+# import shamir_mnemonic as shamir
+# from shamir_mnemonic import MnemonicError
+
+
+EXTERNAL_ENTROPY = b"zlutoucky kun upel divoke ody" * 2
+
+
+@pytest.mark.skip_t1
+class TestMsgResetDeviceT2(TrezorTest):
+    # TODO: test with different options
+    def test_reset_device_shamir(self):
+        strength = 128
+        # TODO: uncomment when python_shamir_mnemonic is uploaded to pypi
+        # member_threshold = 2
+
+        def input_flow():
+            # Confirm Reset
+            btn_code = yield
+            assert btn_code == B.ResetDevice
+            self.client.debug.press_yes()
+
+            # Backup your seed
+            btn_code = yield
+            assert btn_code == B.ResetDevice
+            self.client.debug.press_yes()
+
+            # shares info
+            btn_code = yield
+            assert btn_code == B.ResetDevice
+            self.client.debug.press_yes()
+
+            # Set & Confirm number of shares
+            btn_code = yield
+            assert btn_code == B.ResetDevice
+            self.client.debug.press_yes()
+
+            # threshold info
+            btn_code = yield
+            assert btn_code == B.ResetDevice
+            self.client.debug.press_yes()
+
+            # Set & confirm threshold value
+            btn_code = yield
+            assert btn_code == B.ResetDevice
+            self.client.debug.press_yes()
+
+            # Confirm show seeds
+            btn_code = yield
+            assert btn_code == B.ResetDevice
+            self.client.debug.press_yes()
+
+            # show & confirm shares
+            all_mnemonics = []
+            for h in range(5):
+                words = []
+                btn_code = yield
+                assert btn_code == B.Other
+
+                # mnemonic phrases
+                # 20 word over 6 pages for strength 128, 33 words over 9 pages for strength 256
+                for i in range(6):
+                    time.sleep(1)
+                    words.extend(self.client.debug.state().reset_word.split())
+                    if i < 5:
+                        self.client.debug.swipe_down()
+                    else:
+                        # last page is confirmation
+                        self.client.debug.press_yes()
+
+                # check share
+                for _ in range(2):
+                    time.sleep(1)
+                    index = self.client.debug.state().reset_word_pos
+                    self.client.debug.input(words[index])
+
+                all_mnemonics.extend([" ".join(words)])
+
+                # Confirm continue to next share
+                btn_code = yield
+                assert btn_code == B.ResetDevice
+                self.client.debug.press_yes()
+
+            # generate secret locally
+            # internal_entropy = self.client.debug.state().reset_entropy
+            # secret = generate_entropy(strength, internal_entropy, EXTERNAL_ENTROPY)
+
+            # validate that all combinations will result in the correct master secret
+            # validate_mnemonics(all_mnemonics, member_threshold, secret)
+
+            # safety warning
+            btn_code = yield
+            assert btn_code == B.ResetDevice
+            self.client.debug.press_yes()
+
+        os_urandom = mock.Mock(return_value=EXTERNAL_ENTROPY)
+        with mock.patch("os.urandom", os_urandom), self.client:
+            self.client.set_expected_responses(
+                [
+                    proto.ButtonRequest(code=B.ResetDevice),
+                    proto.EntropyRequest(),
+                    proto.ButtonRequest(code=B.ResetDevice),
+                    proto.ButtonRequest(code=B.ResetDevice),
+                    proto.ButtonRequest(code=B.ResetDevice),
+                    proto.ButtonRequest(code=B.ResetDevice),
+                    proto.ButtonRequest(code=B.ResetDevice),
+                    proto.ButtonRequest(code=B.ResetDevice),
+                    proto.ButtonRequest(code=B.Other),
+                    proto.ButtonRequest(code=B.ResetDevice),
+                    proto.ButtonRequest(code=B.Other),
+                    proto.ButtonRequest(code=B.ResetDevice),
+                    proto.ButtonRequest(code=B.Other),
+                    proto.ButtonRequest(code=B.ResetDevice),
+                    proto.ButtonRequest(code=B.Other),
+                    proto.ButtonRequest(code=B.ResetDevice),
+                    proto.ButtonRequest(code=B.Other),
+                    proto.ButtonRequest(code=B.ResetDevice),
+                    proto.ButtonRequest(code=B.ResetDevice),
+                    proto.Success(),
+                    proto.Features(),
+                ]
+            )
+            self.client.set_input_flow(input_flow)
+
+            # No PIN, no passphrase, don't display random
+            device.reset(
+                self.client,
+                display_random=False,
+                strength=strength,
+                passphrase_protection=False,
+                pin_protection=False,
+                label="test",
+                language="english",
+                slip39=True,
+            )
+
+        # Check if device is properly initialized
+        resp = self.client.call_raw(proto.Initialize())
+        assert resp.initialized is True
+        assert resp.needs_backup is False
+        assert resp.pin_protection is False
+        assert resp.passphrase_protection is False
+
+
+# TODO: uncomment when python_shamir_mnemonic is uploaded to pypi
+
+# def validate_mnemonics(mnemonics, threshold, expected_secret):
+#     # We expect these combinations to recreate the secret properly
+#     for test_group in combinations(mnemonics, threshold):
+#         secret = shamir.combine_mnemonics(test_group)
+#         assert secret == expected_secret
+#     # We expect these combinations to raise MnemonicError
+#     for test_group in combinations(mnemonics, threshold - 1):
+#         with pytest.raises(
+#             MnemonicError, match=r".*Expected {} mnemonics.*".format(threshold)
+#         ):
+#             secret = shamir.combine_mnemonics(test_group)


### PR DESCRIPTION
- added device tests for reset device workflow using shamir backup
- comparing the resulting secret with shamir mnemonic reference implementation is commented out for now pending [#14 in python-shamir-mnemonic repo](https://github.com/trezor/python-shamir-mnemonic/issues/14)