### PR TITLE
elements: support explicit addresses (p2pkh, p2sh and bech32)

### DIFF
--- a/python/trezorlib/tests/device_tests/test_msg_getaddress.py
+++ b/python/trezorlib/tests/device_tests/test_msg_getaddress.py
@@ -116,6 +116,13 @@ class TestMsgGetaddress(TrezorTest):
             == "Fmhtxeh7YdCBkyQF7AQG4QnY8y3rJg89di"
         )
 
+    def test_elements(self):
+        self.setup_mnemonic_allallall()
+        assert (
+            btc.get_address(self.client, "Elements", parse_path("m/44'/1'/0'/0/0"))
+            == "2dpWh6jbhAowNsQ5agtFzi7j6nKscj6UnEr"
+        )
+
     def test_multisig(self):
         self.setup_mnemonic_allallall()
         xpubs = []

--- a/python/trezorlib/tests/device_tests/test_msg_getaddress_segwit.py
+++ b/python/trezorlib/tests/device_tests/test_msg_getaddress_segwit.py
@@ -79,6 +79,17 @@ class TestMsgGetaddressSegwit(TrezorTest):
             )
             == "2N4Q5FhU2497BryFfUgbqkAJE87aKDv3V3e"
         )
+        assert (
+            btc.get_address(
+                self.client,
+                "Elements",
+                parse_path("m/49'/1'/0'/0/0"),
+                False,
+                None,
+                script_type=proto.InputScriptType.SPENDP2SHWITNESS,
+            )
+            == "XNW67ZQA9K3AuXPBWvJH4zN2y5QBDTwy2Z"
+        )
 
     def test_show_multisig_3(self):
         self.setup_mnemonic_allallall()

--- a/python/trezorlib/tests/device_tests/test_msg_getaddress_segwit_native.py
+++ b/python/trezorlib/tests/device_tests/test_msg_getaddress_segwit_native.py
@@ -79,6 +79,17 @@ class TestMsgGetaddressSegwitNative(TrezorTest):
             )
             == "grs1qw4teyraux2s77nhjdwh9ar8rl9dt7zww8r6lne"
         )
+        assert (
+            btc.get_address(
+                self.client,
+                "Elements",
+                parse_path("84'/1'/0'/0/0"),
+                False,
+                None,
+                script_type=proto.InputScriptType.SPENDWITNESS,
+            )
+            == "ert1qkvwu9g3k2pdxewfqr7syz89r3gj557l3xp9k2v"
+        )
 
     def test_show_multisig_3(self):
         self.setup_mnemonic_allallall()


### PR DESCRIPTION
I have enabled Elements (#66) using the following commands:
```
$ ./common/tools/support.py set bitcoin:ELEMENTS trezor2=2.1.2
$ ./common/tools/cointool.py check
```

Also, I have regenerated `coins.json` and `coininfo.py`:
```
$ pipenv run make gen gen_check
```