### PR TITLE
Add common page for success and warning

### DIFF
--- a/core/src/apps/common/layout.py
+++ b/core/src/apps/common/layout.py
@@ -13,7 +13,7 @@ from apps.common import HARDENED
 from apps.common.confirm import confirm, require_confirm
 
 if False:
-    from typing import Iterable
+    from typing import Iterable, List
     from trezor import wire
 
 
@@ -75,3 +75,40 @@ def address_n_to_str(address_n: list) -> str:
         return "m"
 
     return "m/" + "/".join([path_item(i) for i in address_n])
+
+
+async def show_warning(
+    ctx: wire.Context,
+    content: List[str],
+    subheader: str = None,
+    button: str = "Continue",
+) -> None:
+    text = Text("Warning", ui.ICON_WRONG, ui.RED)
+    await _message(ctx, text, content, subheader, button)
+
+
+async def show_success(
+    ctx: wire.Context,
+    content: List[str],
+    subheader: str = None,
+    button: str = "Continue",
+) -> None:
+    text = Text("Success", ui.ICON_CONFIRM, ui.GREEN)
+    await _message(ctx, text, content, subheader, button)
+
+
+async def _message(
+    ctx: wire.Context,
+    text: Text,
+    content: List[str],
+    subheader: str = None,
+    button: str = "Continue",
+) -> None:
+    if subheader:
+        text.bold(subheader)
+        text.br_half()
+    for row in content:
+        text.normal(row)
+    await require_confirm(
+        ctx, text, ButtonRequestType.Other, confirm=button, cancel=None
+    )


### PR DESCRIPTION
We've disccussed with UX, it'd be desired to have a single page for Success and Warning, which will be used everywhere.

We came up with this:
![01](https://user-images.githubusercontent.com/1835345/61296084-bc46a900-a7d9-11e9-89fb-6de4b13f9e8d.png) ![02](https://user-images.githubusercontent.com/1835345/61296085-bc46a900-a7d9-11e9-8bcf-5eaaa7f53324.png)

Where the bold text is voluntary:
![emu00000000](https://user-images.githubusercontent.com/1835345/61296128-cff20f80-a7d9-11e9-9bbd-ec0da9efcbf8.png)

Also any redesign of those pages will then be quite easy.
