### PR TITLE
Update minimal fee for Namecoin

### DIFF
--- a/common/defs/bitcoin/namecoin.json
+++ b/common/defs/bitcoin/namecoin.json
@@ -9,7 +9,7 @@
   "address_type": 52,
   "address_type_p2sh": 5,
   "maxfee_kb": 10000000,
-  "minfee_kb": 1000,
+  "minfee_kb": 100000,
   "signed_message_header": "Namecoin Signed Message:\n",
   "hash_genesis_block": "000000000062b72c5e2ceb45fbc8587e807c155b0da735e6483dfba2f0a9c770",
   "xprv_magic": 76066276,


### PR DESCRIPTION
Update Namecoin (NMC) minimal fee to 100,000 or 100 sat/B