### PR TITLE
cardano: Implement SLIP-0023 and add SLIP-0039 support for Cardano.

### DIFF
--- a/core/mocks/generated/trezorcrypto/bip32.pyi
+++ b/core/mocks/generated/trezorcrypto/bip32.pyi
@@ -133,5 +133,6 @@ def from_seed(seed: bytes, curve_name: str) -> HDNode:
 # extmod/modtrezorcrypto/modtrezorcrypto-bip32.h
 def from_mnemonic_cardano(mnemonic: str, passphrase: str) -> bytes:
     """
-    Convert mnemonic to hdnode
+    Construct a HD node from a BIP-0039 mnemonic using the Icarus derivation
+    scheme, aka v2 derivation scheme.
     """

--- a/core/src/apps/cardano/seed.py
+++ b/core/src/apps/cardano/seed.py
@@ -28,22 +28,30 @@ class Keychain:
         return node
 
 
-async def get_keychain(ctx: wire.Context) -> Keychain:
-    if not storage.is_initialized():
-        raise wire.ProcessError("Device is not initialized")
-
-    # derive the root node from mnemonic and passphrase
+async def _get_passphrase(ctx: wire.Context) -> bytes:
     passphrase = cache.get_passphrase()
     if passphrase is None:
         passphrase = await protect_by_passphrase(ctx)
         cache.set_passphrase(passphrase)
-    # TODO fix for SLIP-39!
-    mnemonic_secret, mnemonic_module = mnemonic.get()
-    if mnemonic_module == mnemonic.slip39:
-        # TODO: we need to modify bip32.from_mnemonic_cardano to accept entropy directly
-        raise NotImplementedError("SLIP-39 currently does not support Cardano")
+
+    return passphrase
+
+
+async def get_keychain(ctx: wire.Context) -> Keychain:
+    if not storage.is_initialized():
+        raise wire.ProcessError("Device is not initialized")
+
+    if mnemonic.get_type() == mnemonic.TYPE_SLIP39:
+        seed = cache.get_seed()
+        if seed is None:
+            passphrase = await _get_passphrase(ctx)
+            seed = mnemonic.get_seed(passphrase)
+            cache.set_seed(seed)
+        root = bip32.from_seed(seed, "ed25519 cardano seed")
     else:
-        root = bip32.from_mnemonic_cardano(mnemonic_secret.decode(), passphrase)
+        # derive the root node from mnemonic and passphrase
+        passphrase = await _get_passphrase(ctx)
+        root = bip32.from_mnemonic_cardano(mnemonic.get_secret().decode(), passphrase)
 
     # derive the namespaced root node
     for i in SEED_NAMESPACE:

--- a/core/src/apps/common/mnemonic.py
+++ b/core/src/apps/common/mnemonic.py
@@ -6,7 +6,7 @@ from trezor.crypto import bip39, slip39
 from apps.common import storage
 
 if False:
-    from typing import Tuple
+    from typing import Optional, Tuple
 
 TYPE_BIP39 = const(0)
 TYPE_SLIP39 = const(1)
@@ -20,16 +20,25 @@ TYPES_WORD_COUNT = {
 }
 
 
-def get() -> Tuple[bytes, int]:
-    mnemonic_secret = storage.device.get_mnemonic_secret()
+def get() -> Tuple[Optional[bytes], int]:
+    return get_secret(), get_type()
+
+
+def get_secret() -> Optional[bytes]:
+    return storage.device.get_mnemonic_secret()
+
+
+def get_type() -> int:
     mnemonic_type = storage.device.get_mnemonic_type() or TYPE_BIP39
     if mnemonic_type not in (TYPE_BIP39, TYPE_SLIP39):
         raise RuntimeError("Invalid mnemonic type")
-    return mnemonic_secret, mnemonic_type
+    return mnemonic_type
 
 
 def get_seed(passphrase: str = "", progress_bar: bool = True) -> bytes:
     mnemonic_secret, mnemonic_type = get()
+    if mnemonic_secret is None:
+        raise ValueError("Mnemonic not set")
 
     render_func = None
     if progress_bar:

--- a/crypto/bip32.h
+++ b/crypto/bip32.h
@@ -71,8 +71,10 @@ int hdnode_private_ckd(HDNode *inout, uint32_t i);
 
 #if USE_CARDANO
 int hdnode_private_ckd_cardano(HDNode *inout, uint32_t i);
-int hdnode_from_seed_cardano(const uint8_t *pass, int pass_len,
-                             const uint8_t *seed, int seed_len, HDNode *out);
+int hdnode_from_seed_cardano(const uint8_t *seed, int seed_len, HDNode *out);
+int hdnode_from_entropy_cardano_icarus(const uint8_t *pass, int pass_len,
+                                       const uint8_t *seed, int seed_len,
+                                       HDNode *out);
 #endif
 
 int hdnode_public_ckd_cp(const ecdsa_curve *curve, const curve_point *parent,

--- a/crypto/tests/test_check_cardano.h
+++ b/crypto/tests/test_check_cardano.h
@@ -118,7 +118,8 @@ START_TEST(test_bip32_cardano_hdnode_vector_1) {
       "junk",
       seed);
   ck_assert_int_eq(seed_len, 132);
-  hdnode_from_seed_cardano((const uint8_t *)"", 0, seed, seed_len / 8, &node);
+  hdnode_from_entropy_cardano_icarus((const uint8_t *)"", 0, seed, seed_len / 8,
+                                     &node);
 
   ck_assert_mem_eq(
       node.chain_code,
@@ -153,7 +154,8 @@ START_TEST(test_bip32_cardano_hdnode_vector_2) {
       "junk",
       seed);
   ck_assert_int_eq(seed_len, 132);
-  hdnode_from_seed_cardano((const uint8_t *)"", 0, seed, seed_len / 8, &node);
+  hdnode_from_entropy_cardano_icarus((const uint8_t *)"", 0, seed, seed_len / 8,
+                                     &node);
 
   hdnode_private_ckd_cardano(&node, 0x80000000);
 
@@ -190,7 +192,8 @@ START_TEST(test_bip32_cardano_hdnode_vector_3) {
       "junk",
       seed);
   ck_assert_int_eq(seed_len, 132);
-  hdnode_from_seed_cardano((const uint8_t *)"", 0, seed, seed_len / 8, &node);
+  hdnode_from_entropy_cardano_icarus((const uint8_t *)"", 0, seed, seed_len / 8,
+                                     &node);
 
   hdnode_private_ckd_cardano(&node, 0x80000001);
 
@@ -227,7 +230,8 @@ START_TEST(test_bip32_cardano_hdnode_vector_4) {
       "junk",
       seed);
   ck_assert_int_eq(seed_len, 132);
-  hdnode_from_seed_cardano((const uint8_t *)"", 0, seed, seed_len / 8, &node);
+  hdnode_from_entropy_cardano_icarus((const uint8_t *)"", 0, seed, seed_len / 8,
+                                     &node);
 
   hdnode_private_ckd_cardano(&node, 0x80000000);
   hdnode_private_ckd_cardano(&node, 0x80000001);
@@ -265,7 +269,8 @@ START_TEST(test_bip32_cardano_hdnode_vector_5) {
       "junk",
       seed);
   ck_assert_int_eq(seed_len, 132);
-  hdnode_from_seed_cardano((const uint8_t *)"", 0, seed, seed_len / 8, &node);
+  hdnode_from_entropy_cardano_icarus((const uint8_t *)"", 0, seed, seed_len / 8,
+                                     &node);
 
   hdnode_private_ckd_cardano(&node, 0x80000000);
   hdnode_private_ckd_cardano(&node, 0x80000001);
@@ -304,7 +309,8 @@ START_TEST(test_bip32_cardano_hdnode_vector_6) {
       "junk",
       seed);
   ck_assert_int_eq(seed_len, 132);
-  hdnode_from_seed_cardano((const uint8_t *)"", 0, seed, seed_len / 8, &node);
+  hdnode_from_entropy_cardano_icarus((const uint8_t *)"", 0, seed, seed_len / 8,
+                                     &node);
 
   hdnode_private_ckd_cardano(&node, 0x80000000);
   hdnode_private_ckd_cardano(&node, 0x80000001);
@@ -344,7 +350,8 @@ START_TEST(test_bip32_cardano_hdnode_vector_7) {
       "junk",
       seed);
   ck_assert_int_eq(seed_len, 132);
-  hdnode_from_seed_cardano((const uint8_t *)"", 0, seed, seed_len / 8, &node);
+  hdnode_from_entropy_cardano_icarus((const uint8_t *)"", 0, seed, seed_len / 8,
+                                     &node);
 
   hdnode_private_ckd_cardano(&node, 0x80000000);
   hdnode_private_ckd_cardano(&node, 0x80000001);


### PR DESCRIPTION
This should fix https://github.com/trezor/trezor-firmware/issues/272

I created SLIP-0023 to solve this issue, see https://github.com/satoshilabs/slips/blob/andrewkozlik/slip-0023/slip-0023.md. In https://forum.cardano.org/t/cardano-with-slip-0039/25443 I asked people to make comments on the new specification in the pull request https://github.com/satoshilabs/slips/pull/712.

- I have not checked the code, so please review carefully.
- I have not tested this.
- I have not been able to create test vectors yet. If anybody knows about a tool like https://iancoleman.io/bip39/ for Cardano, where I can input a private key and chain code and derive an address, then please let me know.
- There is a bizzare merge conflict, that I am now too tired to resolve - mnemonic.get() now returns module instead of type, WTF?