### PR TITLE
Send completion info from DebugLinkDecisions

### DIFF
--- a/common/protob/messages-debug.proto
+++ b/common/protob/messages-debug.proto
@@ -24,6 +24,8 @@ message DebugLinkDecision {
  * @next DebugLinkState
  */
 message DebugLinkGetState {
+    optional bool wait_word_list = 1;  // Trezor T only - wait until mnemonic words are shown
+    optional bool wait_word_pos = 2;   // Trezor T only - wait until reset word position is requested
 }
 
 /**

--- a/core/src/apps/management/common/layout.py
+++ b/core/src/apps/management/common/layout.py
@@ -93,7 +93,7 @@ async def _confirm_word(ctx, share_index, numbered_share_words, count):
     # we always confirm the first (random) word index
     checked_index, checked_word = numbered_choices[0]
     if __debug__:
-        debug.reset_word_index = checked_index
+        debug.reset_word_index.publish(checked_index)
 
     # shuffle again so the confirmed word is not always the first choice
     random.shuffle(numbered_choices)
@@ -200,7 +200,7 @@ async def _bip39_show_mnemonic(ctx, words: list):
 
         def export_displayed_words():
             # export currently displayed mnemonic words into debuglink
-            debug.reset_current_words = [w for _, w in words[paginated.page]]
+            debug.reset_current_words.publish([w for _, w in words[paginated.page]])
 
         paginated.on_change = export_displayed_words
         export_displayed_words()
@@ -393,7 +393,8 @@ async def _slip39_show_share_words(ctx, share_index, share_words):
 
         def export_displayed_words():
             # export currently displayed mnemonic words into debuglink
-            debug.reset_current_words = [w for _, w in word_pages[paginated.page]]
+            words = [w for _, w in word_pages[paginated.page]]
+            debug.reset_current_words.publish(words)
 
         paginated.on_change = export_displayed_words
         export_displayed_words()

--- a/core/src/trezor/loop.py
+++ b/core/src/trezor/loop.py
@@ -220,53 +220,6 @@ class wait(Syscall):
         pause(task, self.msg_iface)
 
 
-_NO_VALUE = object()
-
-
-class signal(Syscall):
-    """
-    Pause current task, and let other running task to resume it later with a
-    result value or an exception.
-
-    Example:
-
-    >>> # in task #1:
-    >>> signal = loop.signal()
-    >>> result = await signal
-    >>> print('awaited result:', result)
-    >>> # in task #2:
-    >>> signal.send('hello from task #2')
-    >>> # prints in the next iteration of the event loop
-    """
-
-    def __init__(self) -> None:
-        self.reset()
-
-    def reset(self) -> None:
-        self.value = _NO_VALUE
-        self.task = None  # type: Optional[Task]
-
-    def handle(self, task: Task) -> None:
-        self.task = task
-        self._deliver()
-
-    def send(self, value: Any) -> None:
-        self.value = value
-        self._deliver()
-
-    def _deliver(self) -> None:
-        if self.task is not None and self.value is not _NO_VALUE:
-            schedule(self.task, self.value)
-            self.reset()
-
-    def __iter__(self) -> Task:  # type: ignore
-        try:
-            return (yield self)
-        except:  # noqa: E722
-            self.task = None
-            raise
-
-
 _type_gen = type((lambda: (yield))())
 
 

--- a/core/src/trezor/messages/DebugLinkGetState.py
+++ b/core/src/trezor/messages/DebugLinkGetState.py
@@ -12,3 +12,18 @@ if __debug__:
 
 class DebugLinkGetState(p.MessageType):
     MESSAGE_WIRE_TYPE = 101
+
+    def __init__(
+        self,
+        wait_word_list: bool = None,
+        wait_word_pos: bool = None,
+    ) -> None:
+        self.wait_word_list = wait_word_list
+        self.wait_word_pos = wait_word_pos
+
+    @classmethod
+    def get_fields(cls) -> Dict:
+        return {
+            1: ('wait_word_list', p.BoolType, 0),
+            2: ('wait_word_pos', p.BoolType, 0),
+        }

--- a/core/src/trezor/ui/__init__.py
+++ b/core/src/trezor/ui/__init__.py
@@ -200,12 +200,12 @@ class Layout(Control):
     async def __iter__(self) -> ResultValue:
         value = None
         try:
-            if workflow.layout_signal.task is not None:
-                workflow.layout_signal.send(LayoutCancelled())
+            if workflow.layout_signal.takers:
+                await workflow.layout_signal.put(LayoutCancelled())
             workflow.onlayoutstart(self)
             while True:
                 layout_tasks = self.create_tasks()
-                await loop.spawn(workflow.layout_signal, *layout_tasks)
+                await loop.spawn(workflow.layout_signal.take, *layout_tasks)
         except Result as result:
             value = result.value
         finally:

--- a/core/src/trezor/wire/__init__.py
+++ b/core/src/trezor/wire/__init__.py
@@ -101,7 +101,7 @@ class Context:
 
         if __debug__:
             log.debug(
-                __name__, "%s:%x read: %s", self.iface.iface_num(), self.sid, exptype
+                __name__, "%s:%x expect: %s", self.iface.iface_num(), self.sid, exptype
             )
 
         await reader.aopen()  # wait for the message header
@@ -110,6 +110,11 @@ class Context:
         # `UnexpectedMessageError` and let the session handler deal with it
         if exptype is None or reader.type != exptype.MESSAGE_WIRE_TYPE:
             raise UnexpectedMessageError(reader)
+
+        if __debug__:
+            log.debug(
+                __name__, "%s:%x read: %s", self.iface.iface_num(), self.sid, exptype
+            )
 
         # parse the message and return it
         return await protobuf.load_message(reader, exptype)
@@ -120,7 +125,7 @@ class Context:
         if __debug__:
             log.debug(
                 __name__,
-                "%s:%x read: %s",
+                "%s:%x expect: %s",
                 self.iface.iface_num(),
                 self.sid,
                 allowed_types,
@@ -135,6 +140,11 @@ class Context:
 
         # find the protobuf type
         exptype = messages.get_type(reader.type)
+
+        if __debug__:
+            log.debug(
+                __name__, "%s:%x read: %s", self.iface.iface_num(), self.sid, exptype
+            )
 
         # parse the message and return it
         return await protobuf.load_message(reader, exptype)
@@ -223,6 +233,10 @@ async def protobuf_workflow(
     from trezor.messages.Failure import Failure
 
     req = await protobuf.load_message(reader, messages.get_type(reader.type))
+
+    if __debug__:
+        log.debug(__name__, "%s:%x request: %s", ctx.iface.iface_num(), ctx.sid, req)
+
     try:
         res = await handler(ctx, req, *args)
     except UnexpectedMessageError:

--- a/core/src/trezor/workflow.py
+++ b/core/src/trezor/workflow.py
@@ -6,7 +6,7 @@ if False:
 
 workflows = []  # type: List[loop.Task]
 layouts = []  # type: List[ui.Layout]
-layout_signal = loop.signal()
+layout_signal = loop.chan()
 default = None  # type: Optional[loop.Task]
 default_layout = None  # type: Optional[Callable[[], loop.Task]]
 

--- a/python/trezorlib/messages/DebugLinkGetState.py
+++ b/python/trezorlib/messages/DebugLinkGetState.py
@@ -12,3 +12,18 @@ if __debug__:
 
 class DebugLinkGetState(p.MessageType):
     MESSAGE_WIRE_TYPE = 101
+
+    def __init__(
+        self,
+        wait_word_list: bool = None,
+        wait_word_pos: bool = None,
+    ) -> None:
+        self.wait_word_list = wait_word_list
+        self.wait_word_pos = wait_word_pos
+
+    @classmethod
+    def get_fields(cls) -> Dict:
+        return {
+            1: ('wait_word_list', p.BoolType, 0),
+            2: ('wait_word_pos', p.BoolType, 0),
+        }

--- a/python/trezorlib/tests/device_tests/test_msg_eos_signtx.py
+++ b/python/trezorlib/tests/device_tests/test_msg_eos_signtx.py
@@ -14,7 +14,6 @@
 # You should have received a copy of the License along with this library.
 # If not, see <https://www.gnu.org/licenses/lgpl-3.0.html>.
 
-import time
 
 import pytest
 
@@ -40,7 +39,6 @@ class TestMsgEosSignTx(TrezorTest):
         yield
         for _ in range(pages - 1):
             self.client.debug.swipe_down()
-            time.sleep(1)
 
         # confirm last page
         self.client.debug.press_yes()
@@ -285,7 +283,7 @@ class TestMsgEosSignTx(TrezorTest):
         }
 
         with self.client:
-            self.client.set_input_flow(self.input_flow(pages=2))
+            self.client.set_input_flow(self.input_flow(pages=0))
             resp = eos.sign_tx(self.client, ADDRESS_N, transaction, CHAIN_ID)
             assert isinstance(resp, EosSignedTx)
             assert (
@@ -449,7 +447,7 @@ class TestMsgEosSignTx(TrezorTest):
         }
 
         with self.client:
-            self.client.set_input_flow(self.input_flow(pages=2))
+            self.client.set_input_flow(self.input_flow(pages=0))
             resp = eos.sign_tx(self.client, ADDRESS_N, transaction, CHAIN_ID)
             assert isinstance(resp, EosSignedTx)
             assert (
@@ -547,7 +545,7 @@ class TestMsgEosSignTx(TrezorTest):
         }
 
         with self.client:
-            self.client.set_input_flow(self.input_flow(pages=2))
+            self.client.set_input_flow(self.input_flow(pages=0))
             resp = eos.sign_tx(self.client, ADDRESS_N, transaction, CHAIN_ID)
             assert isinstance(resp, EosSignedTx)
             assert (
@@ -670,7 +668,6 @@ class TestMsgEosSignTx(TrezorTest):
             yield
             for _ in range(5):
                 self.client.debug.swipe_down()
-                time.sleep(1)
 
             # confirm new account
             self.client.debug.press_yes()
@@ -678,7 +675,6 @@ class TestMsgEosSignTx(TrezorTest):
             # swipe through buyrambytes
             yield
             self.client.debug.swipe_down()
-            time.sleep(1)
 
             # confirm buyrambytes
             self.client.debug.press_yes()
@@ -687,7 +683,6 @@ class TestMsgEosSignTx(TrezorTest):
             yield
             for _ in range(2):
                 self.client.debug.swipe_down()
-                time.sleep(1)
 
             # confirm delegatebw
             self.client.debug.press_yes()
@@ -741,7 +736,6 @@ class TestMsgEosSignTx(TrezorTest):
             # swipe through setcode
             yield
             self.client.debug.swipe_down()
-            time.sleep(1)
 
             # confirm setcode
             self.client.debug.press_yes()
@@ -749,7 +743,6 @@ class TestMsgEosSignTx(TrezorTest):
             # swipe through setabi
             yield
             self.client.debug.swipe_down()
-            time.sleep(1)
 
             # confirm setabi
             self.client.debug.press_yes()

--- a/python/trezorlib/tests/device_tests/test_msg_nem_signtx_mosaics_t2.py
+++ b/python/trezorlib/tests/device_tests/test_msg_nem_signtx_mosaics_t2.py
@@ -14,7 +14,6 @@
 # You should have received a copy of the License along with this library.
 # If not, see <https://www.gnu.org/licenses/lgpl-3.0.html>.
 
-import time
 
 import pytest
 
@@ -177,10 +176,9 @@ class TestMsgNEMSignTxMosaics(TrezorTest):
             self.client.debug.press_yes()
 
             # Swipe and confirm
-            time.sleep(1)
-            for i in range(num_of_swipes):
+            yield
+            for _ in range(num_of_swipes):
                 self.client.debug.swipe_down()
-                time.sleep(1)
             self.client.debug.press_yes()
 
             # Confirm Action
@@ -196,6 +194,7 @@ class TestMsgNEMSignTxMosaics(TrezorTest):
         with self.client:
             self.client.set_expected_responses(
                 [
+                    proto.ButtonRequest(code=B.ConfirmOutput),
                     proto.ButtonRequest(code=B.ConfirmOutput),
                     proto.ButtonRequest(code=B.ConfirmOutput),
                     proto.ButtonRequest(code=B.SignTx),

--- a/python/trezorlib/tests/device_tests/test_msg_recoverydevice_shamir.py
+++ b/python/trezorlib/tests/device_tests/test_msg_recoverydevice_shamir.py
@@ -14,7 +14,6 @@
 # You should have received a copy of the License along with this library.
 # If not, see <https://www.gnu.org/licenses/lgpl-3.0.html>.
 
-import time
 
 import pytest
 
@@ -62,7 +61,6 @@ def enter_all_shares(debug, shares):
         assert code == messages.ButtonRequestType.MnemonicInput
         # Enter mnemonic words
         for word in share.split(" "):
-            time.sleep(1)
             debug.input(word)
 
         # Homescreen - continue
@@ -173,14 +171,12 @@ def test_wrong_nth_word(client, nth_word):
         debug.press_yes()
         yield  # Enter first share
         for word in share:
-            time.sleep(1)
             debug.input(word)
 
         yield  # Continue to next share
         debug.press_yes()
         yield  # Enter next share
         for i, word in enumerate(share):
-            time.sleep(1)
             if i < nth_word:
                 debug.input(word)
             else:
@@ -215,14 +211,12 @@ def test_same_share(client):
         debug.press_yes()
         yield  # Enter first share
         for word in first_share:
-            time.sleep(1)
             debug.input(word)
 
         yield  # Continue to next share
         debug.press_yes()
         yield  # Enter next share
         for word in second_share:
-            time.sleep(1)
             debug.input(word)
 
         code = yield

--- a/python/trezorlib/tests/device_tests/test_msg_recoverydevice_shamir_dryrun.py
+++ b/python/trezorlib/tests/device_tests/test_msg_recoverydevice_shamir_dryrun.py
@@ -1,5 +1,3 @@
-import time
-
 import pytest
 
 from trezorlib import device, messages
@@ -94,7 +92,6 @@ def enter_all_shares(debug, shares):
         assert code == messages.ButtonRequestType.MnemonicInput
         # Enter mnemonic words
         for word in share.split(" "):
-            time.sleep(1)
             debug.input(word)
 
         # Homescreen - continue

--- a/python/trezorlib/tests/device_tests/test_msg_recoverydevice_t2.py
+++ b/python/trezorlib/tests/device_tests/test_msg_recoverydevice_t2.py
@@ -14,7 +14,6 @@
 # You should have received a copy of the License along with this library.
 # If not, see <https://www.gnu.org/licenses/lgpl-3.0.html>.
 
-import time
 
 import pytest
 
@@ -72,7 +71,6 @@ class TestMsgRecoverydeviceT2(TrezorTest):
         assert ret == proto.ButtonRequest(code=proto.ButtonRequestType.MnemonicInput)
         self.client.transport.write(proto.ButtonAck())
         for word in mnemonic:
-            time.sleep(1)
             self.client.debug.input(word)
         ret = self.client.transport.read()
 
@@ -128,7 +126,6 @@ class TestMsgRecoverydeviceT2(TrezorTest):
         assert ret == proto.ButtonRequest(code=proto.ButtonRequestType.MnemonicInput)
         self.client.transport.write(proto.ButtonAck())
         for word in mnemonic:
-            time.sleep(1)
             self.client.debug.input(word)
         ret = self.client.transport.read()
 

--- a/python/trezorlib/tests/device_tests/test_msg_resetdevice_shamir.py
+++ b/python/trezorlib/tests/device_tests/test_msg_resetdevice_shamir.py
@@ -1,4 +1,3 @@
-import time
 from itertools import combinations
 from unittest import mock
 
@@ -72,8 +71,7 @@ class TestMsgResetDeviceT2(TrezorTest):
                 # mnemonic phrases
                 # 20 word over 6 pages for strength 128, 33 words over 9 pages for strength 256
                 for i in range(6):
-                    time.sleep(1)
-                    words.extend(self.client.debug.state().reset_word.split())
+                    words.extend(self.client.debug.read_reset_word().split())
                     if i < 5:
                         self.client.debug.swipe_down()
                     else:
@@ -82,8 +80,7 @@ class TestMsgResetDeviceT2(TrezorTest):
 
                 # check share
                 for _ in range(3):
-                    time.sleep(1)
-                    index = self.client.debug.state().reset_word_pos
+                    index = self.client.debug.read_reset_word_pos()
                     self.client.debug.input(words[index])
 
                 all_mnemonics.extend([" ".join(words)])

--- a/python/trezorlib/tests/device_tests/test_msg_resetdevice_t2.py
+++ b/python/trezorlib/tests/device_tests/test_msg_resetdevice_t2.py
@@ -14,7 +14,6 @@
 # You should have received a copy of the License along with this library.
 # If not, see <https://www.gnu.org/licenses/lgpl-3.0.html>.
 
-import time
 from unittest import mock
 
 import pytest
@@ -55,8 +54,7 @@ class TestMsgResetDeviceT2(TrezorTest):
             assert btn_code == B.ResetDevice
             # 12 words, 3 pages
             for i in range(3):
-                time.sleep(1)
-                words.extend(self.client.debug.state().reset_word.split())
+                words.extend(self.client.debug.read_reset_word().split())
                 if i < 2:
                     self.client.debug.swipe_down()
                 else:
@@ -65,8 +63,7 @@ class TestMsgResetDeviceT2(TrezorTest):
 
             # check backup words
             for _ in range(3):
-                time.sleep(1)
-                index = self.client.debug.state().reset_word_pos
+                index = self.client.debug.read_reset_word_pos()
                 self.client.debug.input(words[index])
 
             # confirm recovery seed check
@@ -160,8 +157,7 @@ class TestMsgResetDeviceT2(TrezorTest):
             assert btn_code == B.ResetDevice
             # 12 words, 3 pages
             for i in range(3):
-                time.sleep(1)
-                words.extend(self.client.debug.state().reset_word.split())
+                words.extend(self.client.debug.read_reset_word().split())
                 if i < 2:
                     self.client.debug.swipe_down()
                 else:
@@ -170,8 +166,7 @@ class TestMsgResetDeviceT2(TrezorTest):
 
             # check backup words
             for _ in range(3):
-                time.sleep(1)
-                index = self.client.debug.state().reset_word_pos
+                index = self.client.debug.read_reset_word_pos()
                 self.client.debug.input(words[index])
 
             # confirm recovery seed check

--- a/python/trezorlib/tests/device_tests/test_msg_tezos_sign_tx.py
+++ b/python/trezorlib/tests/device_tests/test_msg_tezos_sign_tx.py
@@ -14,7 +14,6 @@
 # You should have received a copy of the License along with this library.
 # If not, see <https://www.gnu.org/licenses/lgpl-3.0.html>.
 
-import time
 
 import pytest
 
@@ -200,10 +199,8 @@ class TestMsgTezosSignTx(TrezorTest):
 
     def input_flow(self, num_pages):
         yield
-        time.sleep(1)
         for _ in range(num_pages - 1):
             self.client.debug.swipe_down()
-            time.sleep(1)
         self.client.debug.press_yes()
 
     def test_tezos_sign_tx_proposal(self):


### PR DESCRIPTION
This allows us to get rid of sleeps in tests for pagination and inputs. In Shamir recovery tests that's 20s per mnemonic, which taken together is A Lot(tm)

i left the shamir tests out of this PR in order not to conflict with #358 

@jpochyla plz review, i am VERY unsure about the `feedback_signal` class