### PR TITLE
Tests: cardano slip39 device tests

### DIFF
--- a/python/trezorlib/tests/device_tests/conftest.py
+++ b/python/trezorlib/tests/device_tests/conftest.py
@@ -21,7 +21,8 @@ import pytest
 
 from trezorlib import debuglink, log
 from trezorlib.debuglink import TrezorClientDebugLink
-from trezorlib.device import wipe as wipe_device
+from trezorlib.device import apply_settings, wipe as wipe_device
+from trezorlib.messages.PassphraseSourceType import HOST as PASSPHRASE_ON_HOST
 from trezorlib.transport import enumerate_devices, get_transport
 
 TREZOR_VERSION = None
@@ -83,7 +84,9 @@ def setup_client(mnemonic=None, pin="", passphrase=False):
                 label="test",
                 language="english",
             )
-            return function(client, *args, **kwargs)
+            if TREZOR_VERSION > 1 and passphrase:
+                apply_settings(client, passphrase_source=PASSPHRASE_ON_HOST)
+            return function(*args, client=client, **kwargs)
 
         return wrapper
 

--- a/python/trezorlib/tests/device_tests/test_msg_cardano_get_address_shamir.py
+++ b/python/trezorlib/tests/device_tests/test_msg_cardano_get_address_shamir.py
@@ -16,11 +16,18 @@
 
 import pytest
 
+from trezorlib import device
 from trezorlib.cardano import get_address
+from trezorlib.messages.PassphraseSourceType import HOST as PASSPHRASE_ON_HOST
 from trezorlib.tools import parse_path
 
-from .common import TrezorTest
 from .conftest import setup_client
+
+SLIP39_MNEMONIC = [
+    "extra extend academic bishop cricket bundle tofu goat apart victim enlarge program behavior permit course armed jerky faint language modern",
+    "extra extend academic acne away best indicate impact square oasis prospect painting voting guest either argue username racism enemy eclipse",
+    "extra extend academic arcade born dive legal hush gross briefing talent drug much home firefly toxic analysis idea umbrella slice",
+]
 
 
 @pytest.mark.cardano
@@ -30,21 +37,24 @@ from .conftest import setup_client
     [
         (
             "m/44'/1815'/0'/0/0",
-            "Ae2tdPwUPEZLCq3sFv4wVYxwqjMH2nUzBVt1HFr4v87snYrtYq3d3bq2PUQ",
+            "Ae2tdPwUPEYxF9NAMNdd3v2LZoMeWp7gCZiDb6bZzFQeeVASzoP7HC4V9s6",
         ),
         (
             "m/44'/1815'/0'/0/1",
-            "Ae2tdPwUPEZEY6pVJoyuNNdLp7VbMB7U7qfebeJ7XGunk5Z2eHarkcN1bHK",
+            "Ae2tdPwUPEZ1TjYcvfkWAbiHtGVxv4byEHHZoSyQXjPJ362DifCe1ykgqgy",
         ),
         (
             "m/44'/1815'/0'/0/2",
-            "Ae2tdPwUPEZ3gZD1QeUHvAqadAV59Zid6NP9VCR9BG5LLAja9YtBUgr6ttK",
+            "Ae2tdPwUPEZGXmSbda1kBNfyhRQGRcQxJFdk7mhWZXAGnapyejv2b2U3aRb",
         ),
     ],
 )
-@setup_client(mnemonic=TrezorTest.mnemonic12)
+@setup_client(mnemonic=SLIP39_MNEMONIC, passphrase=True)
 def test_cardano_get_address(client, path, expected_address):
-    # data from https://iancoleman.io/bip39/#english
+    # enter passphrase
+    assert client.debug.read_passphrase_protection() is True
+    device.apply_settings(client, passphrase_source=PASSPHRASE_ON_HOST)
+    client.set_passphrase("TREZOR")
 
     address = get_address(client, parse_path(path))
     assert address == expected_address

--- a/python/trezorlib/tests/device_tests/test_msg_cardano_get_address_shamir.py
+++ b/python/trezorlib/tests/device_tests/test_msg_cardano_get_address_shamir.py
@@ -16,9 +16,7 @@
 
 import pytest
 
-from trezorlib import device
 from trezorlib.cardano import get_address
-from trezorlib.messages.PassphraseSourceType import HOST as PASSPHRASE_ON_HOST
 from trezorlib.tools import parse_path
 
 from .conftest import setup_client
@@ -53,7 +51,6 @@ SLIP39_MNEMONIC = [
 def test_cardano_get_address(client, path, expected_address):
     # enter passphrase
     assert client.debug.read_passphrase_protection() is True
-    device.apply_settings(client, passphrase_source=PASSPHRASE_ON_HOST)
     client.set_passphrase("TREZOR")
 
     address = get_address(client, parse_path(path))

--- a/python/trezorlib/tests/device_tests/test_msg_cardano_get_address_shamir.py
+++ b/python/trezorlib/tests/device_tests/test_msg_cardano_get_address_shamir.py
@@ -50,7 +50,7 @@ SLIP39_MNEMONIC = [
 @setup_client(mnemonic=SLIP39_MNEMONIC, passphrase=True)
 def test_cardano_get_address(client, path, expected_address):
     # enter passphrase
-    assert client.debug.read_passphrase_protection() is True
+    assert client.features.passphrase_protection is True
     client.set_passphrase("TREZOR")
 
     address = get_address(client, parse_path(path))

--- a/python/trezorlib/tests/device_tests/test_msg_cardano_get_public_key.py
+++ b/python/trezorlib/tests/device_tests/test_msg_cardano_get_public_key.py
@@ -19,42 +19,40 @@ import pytest
 from trezorlib.cardano import get_public_key
 from trezorlib.tools import parse_path
 
-from .common import TrezorTest
+from .conftest import setup_client
 
 
 @pytest.mark.cardano
 @pytest.mark.skip_t1  # T1 support is not planned
-class TestMsgCardanoGetPublicKey(TrezorTest):
-    @pytest.mark.parametrize(
-        "path,public_key,chain_code",
-        [
-            (
-                "m/44'/1815'/0'",
-                "c0fce1839f1a84c4e770293ac2f5e0875141b29017b7f56ab135352d00ad6966",
-                "07faa161c9f5464315d2855f70fdf1431d5fa39eb838767bf17b69772137452f",
-            ),
-            (
-                "m/44'/1815'/1'",
-                "ea5dde31b9f551e08a5b6b2f98b8c42c726f726c9ce0a7072102ead53bd8f21e",
-                "70f131bb799fd659c997221ad8cae7dcce4e8da701f8101cf15307fd3a3712a1",
-            ),
-            (
-                "m/44'/1815'/2'",
-                "076338cee5ab3dae19f06ccaa80e3d4428cf0e1bdc04243e41bba7be63a90da7",
-                "5dcdf129f6f2d108292e615c4b67a1fc41a64e6a96130f5c981e5e8e046a6cd7",
-            ),
-            (
-                "m/44'/1815'/3'",
-                "5f769380dc6fd17a4e0f2d23aa359442a712e5e96d7838ebb91eb020003cccc3",
-                "1197ea234f528987cbac9817ebc31344395b837a3bb7c2332f87e095e70550a5",
-            ),
-        ],
-    )
-    def test_cardano_get_public_key(self, path, public_key, chain_code):
-        self.setup_mnemonic_allallall()
+@setup_client(mnemonic=" ".join(["all"] * 12))
+@pytest.mark.parametrize(
+    "path,public_key,chain_code",
+    [
+        (
+            "m/44'/1815'/0'",
+            "c0fce1839f1a84c4e770293ac2f5e0875141b29017b7f56ab135352d00ad6966",
+            "07faa161c9f5464315d2855f70fdf1431d5fa39eb838767bf17b69772137452f",
+        ),
+        (
+            "m/44'/1815'/1'",
+            "ea5dde31b9f551e08a5b6b2f98b8c42c726f726c9ce0a7072102ead53bd8f21e",
+            "70f131bb799fd659c997221ad8cae7dcce4e8da701f8101cf15307fd3a3712a1",
+        ),
+        (
+            "m/44'/1815'/2'",
+            "076338cee5ab3dae19f06ccaa80e3d4428cf0e1bdc04243e41bba7be63a90da7",
+            "5dcdf129f6f2d108292e615c4b67a1fc41a64e6a96130f5c981e5e8e046a6cd7",
+        ),
+        (
+            "m/44'/1815'/3'",
+            "5f769380dc6fd17a4e0f2d23aa359442a712e5e96d7838ebb91eb020003cccc3",
+            "1197ea234f528987cbac9817ebc31344395b837a3bb7c2332f87e095e70550a5",
+        ),
+    ],
+)
+def test_cardano_get_public_key(client, path, public_key, chain_code):
+    key = get_public_key(client, parse_path(path))
 
-        key = get_public_key(self.client, parse_path(path))
-
-        assert key.node.public_key.hex() == public_key
-        assert key.node.chain_code.hex() == chain_code
-        assert key.xpub == public_key + chain_code
+    assert key.node.public_key.hex() == public_key
+    assert key.node.chain_code.hex() == chain_code
+    assert key.xpub == public_key + chain_code

--- a/python/trezorlib/tests/device_tests/test_msg_cardano_get_public_key_shamir.py
+++ b/python/trezorlib/tests/device_tests/test_msg_cardano_get_public_key_shamir.py
@@ -16,9 +16,7 @@
 
 import pytest
 
-from trezorlib import device
 from trezorlib.cardano import get_public_key
-from trezorlib.messages.PassphraseSourceType import HOST as PASSPHRASE_ON_HOST
 from trezorlib.tools import parse_path
 
 from .conftest import setup_client
@@ -59,7 +57,6 @@ SLIP39_MNEMONIC = [
 def test_cardano_get_public_key(client, path, public_key, chain_code):
     # enter passphrase
     assert client.debug.read_passphrase_protection() is True
-    device.apply_settings(client, passphrase_source=PASSPHRASE_ON_HOST)
     client.set_passphrase("TREZOR")
 
     key = get_public_key(client, parse_path(path))

--- a/python/trezorlib/tests/device_tests/test_msg_cardano_get_public_key_shamir.py
+++ b/python/trezorlib/tests/device_tests/test_msg_cardano_get_public_key_shamir.py
@@ -56,7 +56,7 @@ SLIP39_MNEMONIC = [
 )
 def test_cardano_get_public_key(client, path, public_key, chain_code):
     # enter passphrase
-    assert client.debug.read_passphrase_protection() is True
+    assert client.features.passphrase_protection is True
     client.set_passphrase("TREZOR")
 
     key = get_public_key(client, parse_path(path))

--- a/python/trezorlib/tests/device_tests/test_msg_cardano_get_public_key_shamir.py
+++ b/python/trezorlib/tests/device_tests/test_msg_cardano_get_public_key_shamir.py
@@ -1,0 +1,69 @@
+# This file is part of the Trezor project.
+#
+# Copyright (C) 2012-2019 SatoshiLabs and contributors
+#
+# This library is free software: you can redistribute it and/or modify
+# it under the terms of the GNU Lesser General Public License version 3
+# as published by the Free Software Foundation.
+#
+# This library is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU Lesser General Public License for more details.
+#
+# You should have received a copy of the License along with this library.
+# If not, see <https://www.gnu.org/licenses/lgpl-3.0.html>.
+
+import pytest
+
+from trezorlib import device
+from trezorlib.cardano import get_public_key
+from trezorlib.messages.PassphraseSourceType import HOST as PASSPHRASE_ON_HOST
+from trezorlib.tools import parse_path
+
+from .conftest import setup_client
+
+SLIP39_MNEMONIC = [
+    "extra extend academic bishop cricket bundle tofu goat apart victim "
+    "enlarge program behavior permit course armed jerky faint language modern",
+    "extra extend academic acne away best indicate impact square oasis "
+    "prospect painting voting guest either argue username racism enemy eclipse",
+    "extra extend academic arcade born dive legal hush gross briefing "
+    "talent drug much home firefly toxic analysis idea umbrella slice",
+]
+
+
+@pytest.mark.cardano
+@pytest.mark.skip_t1  # T1 support is not planned
+@setup_client(mnemonic=SLIP39_MNEMONIC, passphrase=True)
+@pytest.mark.parametrize(
+    "path,public_key,chain_code",
+    [
+        (
+            "m/44'/1815'/0'/0/0",
+            "bc043d84b8b891d49890edb6aced6f2d78395f255c5b6aea8878b913f83e8579",
+            "dc3f0d2b5cccb822335ef6213fd133f4ca934151ec44a6000aee43b8a101078c",
+        ),
+        (
+            "m/44'/1815'/0'/0/1",
+            "24c4fe188a39103db88818bc191fd8571eae7b284ebcbdf2462bde97b058a95c",
+            "6f7a744035f4b3ddb8f861c18446169643cc3ae85e271b4b4f0eda05cf84c65b",
+        ),
+        (
+            "m/44'/1815'/0'/0/2",
+            "831a63d381a8dab1e6e1ee991a4300fc70687aae5f97f4fcf92ed1b6c2bd99de",
+            "672d6af4707aba201b7940231e83dd357f92f8851b3dfdc224ef311e1b64cdeb",
+        ),
+    ],
+)
+def test_cardano_get_public_key(client, path, public_key, chain_code):
+    # enter passphrase
+    assert client.debug.read_passphrase_protection() is True
+    device.apply_settings(client, passphrase_source=PASSPHRASE_ON_HOST)
+    client.set_passphrase("TREZOR")
+
+    key = get_public_key(client, parse_path(path))
+
+    assert key.node.public_key.hex() == public_key
+    assert key.node.chain_code.hex() == chain_code
+    assert key.xpub == public_key + chain_code

--- a/python/trezorlib/tests/device_tests/test_msg_cardano_sign_tx_shamir.py
+++ b/python/trezorlib/tests/device_tests/test_msg_cardano_sign_tx_shamir.py
@@ -16,8 +16,7 @@
 
 import pytest
 
-from trezorlib import cardano, device, messages
-from trezorlib.messages.PassphraseSourceType import HOST as PASSPHRASE_ON_HOST
+from trezorlib import cardano, messages
 
 from .conftest import setup_client
 
@@ -139,7 +138,6 @@ def test_cardano_sign_tx(
     ]
 
     def input_flow():
-        client.set_passphrase("TREZOR")
         yield
         client.debug.swipe_down()
         client.debug.press_yes()
@@ -147,7 +145,7 @@ def test_cardano_sign_tx(
         client.debug.swipe_down()
         client.debug.press_yes()
 
-    device.apply_settings(client, passphrase_source=PASSPHRASE_ON_HOST)
+    client.set_passphrase("TREZOR")
     with client:
         client.set_expected_responses(expected_responses)
         client.set_input_flow(input_flow)

--- a/python/trezorlib/tests/device_tests/test_msg_cardano_sign_tx_shamir.py
+++ b/python/trezorlib/tests/device_tests/test_msg_cardano_sign_tx_shamir.py
@@ -1,0 +1,248 @@
+# This file is part of the Trezor project.
+#
+# Copyright (C) 2012-2019 SatoshiLabs and contributors
+#
+# This library is free software: you can redistribute it and/or modify
+# it under the terms of the GNU Lesser General Public License version 3
+# as published by the Free Software Foundation.
+#
+# This library is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU Lesser General Public License for more details.
+#
+# You should have received a copy of the License along with this library.
+# If not, see <https://www.gnu.org/licenses/lgpl-3.0.html>.
+
+import pytest
+
+from trezorlib import cardano, device, messages
+from trezorlib.exceptions import TrezorFailure
+from trezorlib.messages.PassphraseSourceType import HOST as PASSPHRASE_ON_HOST
+
+from .conftest import setup_client
+
+SHARES_20_3of6 = [
+    "extra extend academic bishop cricket bundle tofu goat apart victim enlarge program behavior permit course armed jerky faint language modern",
+    "extra extend academic acne away best indicate impact square oasis prospect painting voting guest either argue username racism enemy eclipse",
+    "extra extend academic arcade born dive legal hush gross briefing talent drug much home firefly toxic analysis idea umbrella slice",
+]
+
+PROTOCOL_MAGICS = {"mainnet": 764824073, "testnet": 1097911063}
+
+SAMPLE_INPUTS = [
+    {
+        "input": {
+            "path": "m/44'/1815'/0'/0/1",
+            "prev_hash": "1af8fa0b754ff99253d983894e63a2b09cbb56c833ba18c3384210163f63dcfc",
+            "prev_index": 0,
+            "type": 0,
+        },
+        "prev_tx": "839f8200d818582482582008abb575fac4c39d5bf80683f7f0c37e48f4e3d96e37d1f6611919a7241b456600ff9f8282d818582183581cda4da43db3fca93695e71dab839e72271204d28b9d964d306b8800a8a0001a7a6916a51a00305becffa0",
+    }
+]
+
+VALID_VECTORS = [
+    # Mainnet transaction without change
+    (
+        # protocol magic
+        PROTOCOL_MAGICS["mainnet"],
+        # inputs
+        [SAMPLE_INPUTS[0]["input"]],
+        # outputs
+        [
+            {
+                "address": "Ae2tdPwUPEZCanmBz5g2GEwFqKTKpNJcGYPKfDxoNeKZ8bRHr8366kseiK2",
+                "amount": "3003112",
+            }
+        ],
+        # transactions
+        [SAMPLE_INPUTS[0]["prev_tx"]],
+        # tx hash
+        "799c65e8a2c0b1dc4232611728c09d3f3eb0d811c077f8e9798f84605ef1b23d",
+        # tx body
+        "82839f8200d81858248258201af8fa0b754ff99253d983894e63a2b09cbb56c833ba18c3384210163f63dcfc00ff9f8282d818582183581c9e1c71de652ec8b85fec296f0685ca3988781c94a2e1a5d89d92f45fa0001a0d0c25611a002dd2e8ffa0818200d818588582584024c4fe188a39103db88818bc191fd8571eae7b284ebcbdf2462bde97b058a95c6f7a744035f4b3ddb8f861c18446169643cc3ae85e271b4b4f0eda05cf84c65b584032a773bcd60c83880de09676c45e52cc2c2189c1b46d93de596a5cf6e3e93041c22e6e5762144feb65b40e905659c9b5e51528fa6574273279c2507a2b996f0e",
+    ),
+    # Mainnet transaction with change
+    (
+        # protocol magic (mainnet)
+        PROTOCOL_MAGICS["mainnet"],
+        # inputs
+        [
+            {
+                "path": "m/44'/1815'/0'/0/1",
+                "prev_hash": "1af8fa0b754ff99253d983894e63a2b09cbb56c833ba18c3384210163f63dcfc",
+                "prev_index": 0,
+                "type": 0,
+            }
+        ],
+        # outputs
+        [
+            {
+                "address": "Ae2tdPwUPEZCanmBz5g2GEwFqKTKpNJcGYPKfDxoNeKZ8bRHr8366kseiK2",
+                "amount": "3003112",
+            },
+            {"path": "m/44'/1815'/0'/0/1", "amount": "1000000"},
+        ],
+        # transactions
+        [SAMPLE_INPUTS[0]["prev_tx"]],
+        # tx hash
+        "5a3921053daabc6a2ffc1528963352fa8ea842bd04056371effcd58256e0cd55",
+        # tx body
+        "82839f8200d81858248258201af8fa0b754ff99253d983894e63a2b09cbb56c833ba18c3384210163f63dcfc00ff9f8282d818582183581c9e1c71de652ec8b85fec296f0685ca3988781c94a2e1a5d89d92f45fa0001a0d0c25611a002dd2e88282d818582183581c2ea63b3db3a1865f59c11762a5aede800ed8f2dc0605d75df2ed7c9ca0001ae82668161a000f4240ffa0818200d818588582584024c4fe188a39103db88818bc191fd8571eae7b284ebcbdf2462bde97b058a95c6f7a744035f4b3ddb8f861c18446169643cc3ae85e271b4b4f0eda05cf84c65b5840ea38a37167d652fd35ac3517a6b3a5ec73e01a9f3b6d57d645c7727856a17a2c8d9403b497e148811cb087822c49b5ab6e14b1bc78acc21eca434c3e5147260f",
+    ),
+    # Testnet transaction
+    (
+        # protocol magic
+        PROTOCOL_MAGICS["testnet"],
+        # inputs
+        [SAMPLE_INPUTS[0]["input"]],
+        # outputs
+        [
+            {
+                "address": "Ae2tdPwUPEZCanmBz5g2GEwFqKTKpNJcGYPKfDxoNeKZ8bRHr8366kseiK2",
+                "amount": "3003112",
+            }
+        ],
+        # transactions
+        [SAMPLE_INPUTS[0]["prev_tx"]],
+        # tx hash
+        "799c65e8a2c0b1dc4232611728c09d3f3eb0d811c077f8e9798f84605ef1b23d",
+        # tx body
+        "82839f8200d81858248258201af8fa0b754ff99253d983894e63a2b09cbb56c833ba18c3384210163f63dcfc00ff9f8282d818582183581c9e1c71de652ec8b85fec296f0685ca3988781c94a2e1a5d89d92f45fa0001a0d0c25611a002dd2e8ffa0818200d818588582584024c4fe188a39103db88818bc191fd8571eae7b284ebcbdf2462bde97b058a95c6f7a744035f4b3ddb8f861c18446169643cc3ae85e271b4b4f0eda05cf84c65b58407aab2a707a6d295c0a93e396429721c48d2c09238e32112f2e1d14a8296ff463204240e7d9168e2dfe8276f426cd1f73f1254df434cdab7c942e2a920c8ce800",
+    ),
+]
+
+INVALID_VECTORS = [
+    # Output address is a valid CBOR but invalid Cardano address
+    (
+        # protocol magic
+        PROTOCOL_MAGICS["mainnet"],
+        # inputs
+        [SAMPLE_INPUTS[0]["input"]],
+        # outputs
+        [
+            {
+                "address": "jsK75PTH2esX8k4Wvxenyz83LJJWToBbVmGrWUer2CHFHanLseh7r3sW5X5q",
+                "amount": "3003112",
+            }
+        ],
+        # transactions
+        [SAMPLE_INPUTS[0]["prev_tx"]],
+        "Invalid output address!",
+    ),
+    # Output address is an invalid CBOR
+    (
+        # protocol magic
+        PROTOCOL_MAGICS["mainnet"],
+        # inputs
+        [SAMPLE_INPUTS[0]["input"]],
+        # outputs
+        [
+            {
+                "address": "jsK75PTH2esX8k4Wvxenyz83LJJWToBbVmGrWUer2CHFHanLseh7r3sW5X5q",
+                "amount": "3003112",
+            }
+        ],
+        # transactions
+        [
+            "839f8200d818582482582008abb575fac4c39d5bf80683f7f0c37e48f4e3d96e37d1f6611919a7241b456600ff9f8282d818582183581cda4da43db3fca93695e71dab839e72271204d28b9d964d306b8800a8a0001a7a6916a51a00305becffa0"
+        ],
+        "Invalid output address!",
+    ),
+    # Output address is invalid CBOR
+    (
+        # protocol magic (mainnet)
+        764824073,
+        # inputs
+        [
+            {
+                "path": "m/44'/1815'/0'/0/1",
+                "prev_hash": "1af8fa0b754ff99253d983894e63a2b09cbb56c833ba18c3384210163f63dcfc",
+                "prev_index": 0,
+                "type": 0,
+            }
+        ],
+        # outputs
+        [
+            {
+                "address": "5dnY6xgRcNUSLGa4gfqef2jGAMHb7koQs9EXErXLNC1LiMPUnhn8joXhvEJpWQtN3F4ysATcBvCn5tABgL3e4hPWapPHmcK5GJMSEaET5JafgAGwSrznzL1Mqa",
+                "amount": "3003112",
+            }
+        ],
+        # transactions
+        [SAMPLE_INPUTS[0]["prev_tx"]],
+        "Invalid output address!",
+    ),
+]
+
+
+@pytest.mark.cardano
+@pytest.mark.skip_t1  # T1 support is not planned
+@setup_client(mnemonic=SHARES_20_3of6, passphrase=True)
+@pytest.mark.parametrize(
+    "protocol_magic,inputs,outputs,transactions,tx_hash,tx_body", VALID_VECTORS
+)
+def test_cardano_sign_tx(
+    client, protocol_magic, inputs, outputs, transactions, tx_hash, tx_body
+):
+    inputs = [cardano.create_input(i) for i in inputs]
+    outputs = [cardano.create_output(o) for o in outputs]
+
+    expected_responses = [
+        messages.PassphraseRequest(),
+        messages.PassphraseStateRequest(),
+    ]
+    expected_responses += [
+        messages.CardanoTxRequest(tx_index=i) for i in range(len(transactions))
+    ]
+    expected_responses += [
+        messages.ButtonRequest(code=messages.ButtonRequestType.Other),
+        messages.ButtonRequest(code=messages.ButtonRequestType.Other),
+        messages.CardanoSignedTx(),
+    ]
+
+    def input_flow():
+        client.set_passphrase("TREZOR")
+        yield
+        client.debug.swipe_down()
+        client.debug.press_yes()
+        yield
+        client.debug.swipe_down()
+        client.debug.press_yes()
+
+    device.apply_settings(client, passphrase_source=PASSPHRASE_ON_HOST)
+    with client:
+        client.set_expected_responses(expected_responses)
+        client.set_input_flow(input_flow)
+        response = cardano.sign_tx(
+            client, inputs, outputs, transactions, protocol_magic
+        )
+        assert response.tx_hash.hex() == tx_hash
+        assert response.tx_body.hex() == tx_body
+
+
+@pytest.mark.cardano
+@pytest.mark.skip_t1  # T1 support is not planned
+@setup_client(mnemonic=SHARES_20_3of6)
+@pytest.mark.parametrize(
+    "protocol_magic,inputs,outputs,transactions,expected_error_message", INVALID_VECTORS
+)
+def test_cardano_sign_tx_validation(
+    client, protocol_magic, inputs, outputs, transactions, expected_error_message
+):
+    inputs = [cardano.create_input(i) for i in inputs]
+    outputs = [cardano.create_output(o) for o in outputs]
+
+    expected_responses = [
+        messages.CardanoTxRequest(tx_index=i) for i in range(len(transactions))
+    ]
+    expected_responses += [messages.Failure()]
+
+    with client:
+        client.set_expected_responses(expected_responses)
+
+        with pytest.raises(TrezorFailure) as exc:
+            cardano.sign_tx(client, inputs, outputs, transactions, protocol_magic)
+
+        assert exc.value.args[1] == expected_error_message

--- a/python/trezorlib/tests/device_tests/test_shamir_passphrase.py
+++ b/python/trezorlib/tests/device_tests/test_shamir_passphrase.py
@@ -17,8 +17,7 @@
 
 import pytest
 
-from trezorlib import btc, device
-from trezorlib.messages.PassphraseSourceType import HOST as PASSPHRASE_ON_HOST
+from trezorlib import btc
 
 from .conftest import setup_client
 
@@ -38,9 +37,7 @@ def test_3of6_passphrase(client):
     provided by Andrew, address calculated using T1
     xprv9s21ZrQH143K2pMWi8jrTawHaj16uKk4CSbvo4Zt61tcrmuUDMx2o1Byzcr3saXNGNvHP8zZgXVdJHsXVdzYFPavxvCyaGyGr1WkAYG83ce
     """
-    assert client.debug.read_passphrase_protection() is True
-    device.apply_settings(client, passphrase_source=PASSPHRASE_ON_HOST)
-
+    assert client.features.passphrase_protection is True
     client.set_passphrase("TREZOR")
     address = btc.get_address(client, "Bitcoin", [])
     assert address == "18oZEMRWurCZW1FeK8sWYyXuWx2bFqEKyX"
@@ -60,9 +57,7 @@ def test_2of5_passphrase(client):
     provided by Andrew, address calculated using T1
     xprv9s21ZrQH143K2o6EXEHpVy8TCYoMmkBnDCCESLdR2ieKwmcNG48ck2XJQY4waS7RUQcXqR9N7HnQbUVEDMWYyREdF1idQqxFHuCfK7fqFni
     """
-    assert client.debug.read_passphrase_protection() is True
-    device.apply_settings(client, passphrase_source=PASSPHRASE_ON_HOST)
-
+    assert client.features.passphrase_protection is True
     client.set_passphrase("TREZOR")
     address = btc.get_address(client, "Bitcoin", [])
     assert address == "19Fjs9AvT13Y2Nx8GtoVfADmFWnccsPinQ"


### PR DESCRIPTION
This PR implements #367 
the test vectors for sign_tx were generated using [this code](https://repl.it/@stanociny/JuicyShamefulAbstractions), you can uncomment various parts to verify the vectors we use. 

note: INVALID_VECTORS test in sign_tx worked without changes (or using a passphrase with slip39). Maybe it would be worth looking into whether we're testing what we think we're testing. 