### PR TITLE
core/embed: add hint in fatal error on unix

### DIFF
--- a/core/embed/unix/common.c
+++ b/core/embed/unix/common.c
@@ -62,8 +62,8 @@ __fatal_error(const char *expr, const char *msg, const char *file, int line,
   display_printf("rev : %s\n", XSTR(GITREV));
   printf("rev : %s\n", XSTR(GITREV));
 #endif
-  display_printf("\nPlease contact Trezor support.\n");
-  printf("\nPlease contact Trezor support.\n");
+  display_printf("\n\n\nHint:\nIsn't the emulator already running?\n");
+  printf("Hint:\nIsn't the emulator already running?\n");
   hal_delay(3000);
   __shutdown();
   for (;;)


### PR DESCRIPTION
It seems to me 99% I'm getting this red screen on unix is because the emulator is already running. Just an idea..