### PR TITLE
core/wallet: fix 'pubkeys' type to be list

### DIFF
--- a/core/src/apps/wallet/sign_tx/addresses.py
+++ b/core/src/apps/wallet/sign_tx/addresses.py
@@ -85,7 +85,7 @@ def get_address(
         raise AddressError(FailureType.ProcessError, "Invalid script type")
 
 
-def address_multisig_p2sh(pubkeys: bytes, m: int, coin: CoinInfo):
+def address_multisig_p2sh(pubkeys: list, m: int, coin: CoinInfo):
     if coin.address_type_p2sh is None:
         raise AddressError(
             FailureType.ProcessError, "Multisig not enabled on this coin"
@@ -95,7 +95,7 @@ def address_multisig_p2sh(pubkeys: bytes, m: int, coin: CoinInfo):
     return address_p2sh(redeem_script_hash, coin)
 
 
-def address_multisig_p2wsh_in_p2sh(pubkeys: bytes, m: int, coin: CoinInfo):
+def address_multisig_p2wsh_in_p2sh(pubkeys: list, m: int, coin: CoinInfo):
     if coin.address_type_p2sh is None:
         raise AddressError(
             FailureType.ProcessError, "Multisig not enabled on this coin"
@@ -105,7 +105,7 @@ def address_multisig_p2wsh_in_p2sh(pubkeys: bytes, m: int, coin: CoinInfo):
     return address_p2wsh_in_p2sh(witness_script_hash, coin)
 
 
-def address_multisig_p2wsh(pubkeys: bytes, m: int, hrp: str):
+def address_multisig_p2wsh(pubkeys: list, m: int, hrp: str):
     if not hrp:
         raise AddressError(
             FailureType.ProcessError, "Multisig not enabled on this coin"


### PR DESCRIPTION
OTOH, would it be clearer if it would be marked as `List[bytes]`?