### PR TITLE
core: ensure multisig (m,n) parameters are valid

### DIFF
--- a/core/src/apps/wallet/sign_tx/scripts.py
+++ b/core/src/apps/wallet/sign_tx/scripts.py
@@ -250,7 +250,7 @@ def input_script_multisig(
 
 def output_script_multisig(pubkeys, m: int, w: bytearray = None) -> bytearray:
     n = len(pubkeys)
-    if n < 1 or n > 15 or m < 1 or m > 15:
+    if n < 1 or n > 15 or m < 1 or m > 15 or m > n:
         raise ScriptsError("Invalid multisig parameters")
     for pubkey in pubkeys:
         if len(pubkey) != 33:

--- a/core/tests/test_apps.wallet.address.py
+++ b/core/tests/test_apps.wallet.address.py
@@ -110,6 +110,10 @@ class TestAddress(unittest.TestCase):
         address = address_multisig_p2sh(pubkeys, 2, coin)
         self.assertEqual(address, '39bgKC7RFbpoCRbtD5KEdkYKtNyhpsNa3Z')
 
+        for invalid_m in (-1, 0, len(pubkeys) + 1, 16):
+            with self.assertRaises(scripts.ScriptsError):
+                address_multisig_p2sh(pubkeys, invalid_m, coin)
+
     def test_multisig_address_p2wsh_in_p2sh(self):
         # test data from
         # https://bitcoin.stackexchange.com/questions/62656/generate-a-p2sh-p2wsh-address-and-spend-output-sent-to-it


### PR DESCRIPTION
`m` should be less than or equal to `n`.