### PR TITLE
core: fix initialized to be unrelated to recovery

### DIFF
--- a/core/src/apps/common/storage/__init__.py
+++ b/core/src/apps/common/storage/__init__.py
@@ -1,7 +1,7 @@
 from trezor import config
 
 from apps.common import cache
-from apps.common.storage import common, device, recovery
+from apps.common.storage import common, device
 
 
 def set_current_version() -> None:
@@ -9,7 +9,7 @@ def set_current_version() -> None:
 
 
 def is_initialized() -> bool:
-    return device.is_version_stored() and not recovery.is_in_progress()
+    return device.is_version_stored()
 
 
 def wipe() -> None:


### PR DESCRIPTION
I can't remember why I have written `and not recovery.is_in_progress()` but I don't think it is needed at this moment.

We call `device.is_version_stored()` in `is_initialized()` and we store the version in `store_mnemonic_secret()`, which is called only after the reset/recovery/load is done.

@ciny @jpochyla plrease review just to make sure

closes #387