### PR TITLE
core: improve log output for ui.Result exception

### DIFF
--- a/core/src/trezor/log.py
+++ b/core/src/trezor/log.py
@@ -2,8 +2,6 @@ import sys
 import utime
 from micropython import const
 
-from trezor import ui
-
 if False:
     from typing import Any
 
@@ -61,7 +59,8 @@ def critical(name: str, msg: str, *args: Any) -> None:
 
 
 def exception(name: str, exc: BaseException) -> None:
-    if isinstance(exc, ui.Result):
+    # we are using `__class__.__name__` to avoid importing ui module
+    if exc.__class__.__name__ == "Result":
         _log(name, DEBUG, "ui.Result: %s", exc.value)
     else:
         _log(name, ERROR, "exception:")

--- a/core/src/trezor/log.py
+++ b/core/src/trezor/log.py
@@ -2,6 +2,8 @@ import sys
 import utime
 from micropython import const
 
+from trezor import ui
+
 if False:
     from typing import Any
 
@@ -59,5 +61,8 @@ def critical(name: str, msg: str, *args: Any) -> None:
 
 
 def exception(name: str, exc: BaseException) -> None:
-    _log(name, ERROR, "exception:")
-    sys.print_exception(exc)
+    if isinstance(exc, ui.Result):
+        _log(name, DEBUG, "ui.Result: %s", exc.value)
+    else:
+        _log(name, ERROR, "exception:")
+        sys.print_exception(exc)


### PR DESCRIPTION
I consider the ui.Result exceptions in log output as a bit confusing. This logs them in a nicer way without the traceback.

We might also consider adding something like ControlException, which ui.Result would extend, in case we have more such exceptions.

Also updates #373, which was closed already though.
