### PR TITLE
ci: introduce upgrade tests (WIP)

### DIFF
--- a/ci/build.yml
+++ b/ci/build.yml
@@ -71,6 +71,18 @@ build core unix frozen bitcoinonly:
     - core/src/trezor/res/resources.py
     expire_in: 1 day
 
+build core unix frozen debug:
+  stage: build
+  variables:
+    PYOPT: "0"
+  script:
+    - cd core
+    - pipenv run make build_unix_frozen
+  artifacts:
+    name: "$CI_JOB_NAME-$CI_COMMIT_SHORT_SHA"
+    untracked: true
+    expire_in: 1 day
+
 
 # Crypto
 

--- a/ci/test.yml
+++ b/ci/test.yml
@@ -96,3 +96,15 @@ test storage:
     - cd storage/tests
     - pipenv run make build
     - pipenv run make tests_all
+
+
+# Other
+
+test upgrade:
+  stage: test
+  dependencies:
+    - build core unix frozen debug
+    - build legacy emu
+  script:
+    - tests/upgrade_tests/download_emulators.sh
+    - pipenv run pytest tests/upgrade_tests

--- a/core/tests/run_tests_device_emu.sh
+++ b/core/tests/run_tests_device_emu.sh
@@ -22,7 +22,7 @@ export TREZOR_PATH=udp:127.0.0.1:21324
 
 # run tests
 error=0
-if ! pytest ../../tests "$@"; then
+if ! pytest ../../tests/device_tests "$@"; then
   error=1
 fi
 kill $upy_pid

--- a/legacy/script/test
+++ b/legacy/script/test
@@ -16,4 +16,4 @@ if [ "$EMULATOR" = 1 ]; then
     "${PYTHON:-python}" script/wait_for_emulator.py
 fi
 
-"${PYTHON:-python}" -m pytest ../tests "$@"
+"${PYTHON:-python}" -m pytest ../tests/device_tests "$@"

--- a/tests/upgrade_tests/download_emulators.sh
+++ b/tests/upgrade_tests/download_emulators.sh
@@ -1,0 +1,9 @@
+#!/bin/bash
+SITE="https://firmware.corp.sldev.cz/upgrade_tests/"
+cd "$(dirname "$0")"
+
+# download all emulators without index files, without directories and only if not present
+wget --no-verbose --no-clobber --no-parent --cut-dirs=2 --no-host-directories --recursive --reject "index.html*" -P emulators/ $SITE
+
+# TODO: is this a good idea?
+chmod u+x emulators/trezor-emu-*

--- a/tests/upgrade_tests/emulator_wrapper.py
+++ b/tests/upgrade_tests/emulator_wrapper.py
@@ -1,0 +1,63 @@
+import os
+import subprocess
+import tempfile
+import time
+
+from trezorlib.debuglink import TrezorClientDebugLink
+from trezorlib.transport import TransportException, get_transport
+
+BINDIR = os.path.dirname(os.path.abspath(__file__)) + "/emulators"
+ENV = {"SDL_VIDEODRIVER": "dummy"}
+
+
+class EmulatorWrapper:
+    def __init__(self, gen, tag, storage=None):
+        self.gen = gen
+        self.tag = tag
+        self.workdir = tempfile.TemporaryDirectory()
+        if storage:
+            open(self._storage_file(), "wb").write(storage)
+
+    def __enter__(self):
+        if self.tag.startswith("/"):  # full path+filename provided
+            args = [self.tag]
+        else:  # only gen+tag provided
+            args = ["%s/trezor-emu-%s-%s" % (BINDIR, self.gen, self.tag)]
+        env = ENV
+        if self.gen == "core":
+            args += ["-m", "main"]
+            env["TREZOR_PROFILE_DIR"] = self.workdir.name
+        self.process = subprocess.Popen(
+            args, cwd=self.workdir.name, env=ENV, stdout=open(os.devnull, "w")
+        )
+        # wait until emulator is started
+        while True:
+            try:
+                self.transport = get_transport("udp:127.0.0.1:21324")
+            except TransportException:
+                time.sleep(0.1)
+                continue
+            break
+        self.client = TrezorClientDebugLink(self.transport)
+        self.client.open()
+        return self
+
+    def __exit__(self, exc_type, exc_value, traceback):
+        self.client.close()
+        self.process.terminate()
+        try:
+            self.process.wait(1)
+        except subprocess.TimeoutExpired:
+            self.process.kill()
+        self.workdir.cleanup()
+
+    def _storage_file(self):
+        if self.gen == "legacy":
+            return self.workdir.name + "/emulator.img"
+        elif self.gen == "core":
+            return self.workdir.name + "/trezor.flash"
+        else:
+            raise ValueError("Unknown gen")
+
+    def storage(self):
+        return open(self._storage_file(), "rb").read()

--- a/tests/upgrade_tests/emulators/.gitignore
+++ b/tests/upgrade_tests/emulators/.gitignore
@@ -1,0 +1,2 @@
+*
+!.gitignore

--- a/tests/upgrade_tests/test_firmware_upgrades.py
+++ b/tests/upgrade_tests/test_firmware_upgrades.py
@@ -1,0 +1,223 @@
+import os
+from collections import defaultdict
+
+import pytest
+
+from trezorlib import MINIMUM_FIRMWARE_VERSION, btc, debuglink, device
+from trezorlib.tools import H_
+
+MINIMUM_FIRMWARE_VERSION["1"] = (1, 0, 0)
+MINIMUM_FIRMWARE_VERSION["T"] = (2, 0, 0)
+
+try:
+    from .emulator_wrapper import EmulatorWrapper
+except ImportError:
+    pass
+
+# **** COMMON DEFINITIONS ****
+
+MNEMONIC = " ".join(["all"] * 12)
+PATH = [H_(44), H_(0), H_(0), 0, 0]
+ADDRESS = "1JAd7XCBzGudGpJQSDSfpmJhiygtLQWaGL"
+LABEL = "test"
+LANGUAGE = "english"
+STRENGTH = 128
+
+ROOT = os.path.dirname(os.path.abspath(__file__)) + "/../../"
+LOCAL_BUILDS = {
+    "core": ROOT + "core/build/unix/micropython",
+    "legacy": ROOT + "legacy/firmware/trezor.elf",
+}
+BIN_DIR = os.path.dirname(os.path.abspath(__file__)) + "/emulators"
+
+
+def check_version(tag, ver_emu):
+    if tag.startswith("v") and len(tag.split(".")) == 3:
+        assert tag == "v" + ".".join(["%d" % i for i in ver_emu])
+
+
+def check_file(gen, tag):
+    if tag.startswith("/"):
+        filename = tag
+    else:
+        filename = "%s/trezor-emu-%s-%s" % (BIN_DIR, gen, tag)
+    if not os.path.exists(filename):
+        raise ValueError(filename + " not found. Do not forget to build firmware.")
+
+
+def get_tags():
+    files = os.listdir(BIN_DIR)
+    if not files:
+        raise ValueError(
+            "No files found. Use download_emulators.sh to download emulators."
+        )
+
+    result = defaultdict(list)
+    for f in sorted(files):
+        try:
+            _, _, gen, tag = f.split("-", maxsplit=3)
+            result[gen].append(tag)
+        except ValueError:
+            pass
+    return result
+
+
+ALL_TAGS = get_tags()
+
+
+def for_all(*args, minimum_version=(1, 0, 0)):
+    if not args:
+        args = ("core", "legacy")
+
+    all_params = []
+    for gen in args:
+        try:
+            to_tag = LOCAL_BUILDS[gen]
+            from_tags = ALL_TAGS[gen] + [to_tag]
+            for from_tag in from_tags:
+                if from_tag.startswith("v"):
+                    tag_version = tuple(int(n) for n in from_tag[1:].split("."))
+                    if tag_version < minimum_version:
+                        continue
+                check_file(gen, from_tag)
+                all_params.append((gen, from_tag, to_tag))
+        except KeyError:
+            pass
+
+    return pytest.mark.parametrize("gen, from_tag, to_tag", all_params)
+
+
+@for_all()
+def test_upgrade_load(gen, from_tag, to_tag):
+    def asserts(tag, client):
+        check_version(tag, emu.client.version)
+        assert not client.features.pin_protection
+        assert not client.features.passphrase_protection
+        assert client.features.initialized
+        assert client.features.label == LABEL
+        assert client.features.language == LANGUAGE
+        assert btc.get_address(client, "Bitcoin", PATH) == ADDRESS
+
+    with EmulatorWrapper(gen, from_tag) as emu:
+        debuglink.load_device_by_mnemonic(
+            emu.client,
+            mnemonic=MNEMONIC,
+            pin="",
+            passphrase_protection=False,
+            label=LABEL,
+            language=LANGUAGE,
+        )
+        device_id = emu.client.features.device_id
+        asserts(from_tag, emu.client)
+        storage = emu.storage()
+
+    with EmulatorWrapper(gen, to_tag, storage=storage) as emu:
+        assert device_id == emu.client.features.device_id
+        asserts(to_tag, emu.client)
+
+
+@for_all("legacy")
+def test_upgrade_reset(gen, from_tag, to_tag):
+    def asserts(tag, client):
+        check_version(tag, emu.client.version)
+        assert not client.features.pin_protection
+        assert not client.features.passphrase_protection
+        assert client.features.initialized
+        assert client.features.label == LABEL
+        assert client.features.language == LANGUAGE
+        assert not client.features.needs_backup
+        assert not client.features.unfinished_backup
+        assert not client.features.no_backup
+
+    with EmulatorWrapper(gen, from_tag) as emu:
+        device.reset(
+            emu.client,
+            display_random=False,
+            strength=STRENGTH,
+            passphrase_protection=False,
+            pin_protection=False,
+            label=LABEL,
+            language=LANGUAGE,
+        )
+        device_id = emu.client.features.device_id
+        asserts(from_tag, emu.client)
+        storage = emu.storage()
+
+    with EmulatorWrapper(gen, to_tag, storage=storage) as emu:
+        assert device_id == emu.client.features.device_id
+        asserts(to_tag, emu.client)
+
+
+@for_all()
+def test_upgrade_reset_skip_backup(gen, from_tag, to_tag):
+    def asserts(tag, client):
+        check_version(tag, emu.client.version)
+        assert not client.features.pin_protection
+        assert not client.features.passphrase_protection
+        assert client.features.initialized
+        assert client.features.label == LABEL
+        assert client.features.language == LANGUAGE
+        assert client.features.needs_backup
+        assert not client.features.unfinished_backup
+        assert not client.features.no_backup
+
+    with EmulatorWrapper(gen, from_tag) as emu:
+        device.reset(
+            emu.client,
+            display_random=False,
+            strength=STRENGTH,
+            passphrase_protection=False,
+            pin_protection=False,
+            label=LABEL,
+            language=LANGUAGE,
+            skip_backup=True,
+        )
+        device_id = emu.client.features.device_id
+        asserts(from_tag, emu.client)
+        storage = emu.storage()
+
+    with EmulatorWrapper(gen, to_tag, storage=storage) as emu:
+        assert device_id == emu.client.features.device_id
+        asserts(to_tag, emu.client)
+
+
+@for_all(minimum_version=(1, 7, 2))
+def test_upgrade_reset_no_backup(gen, from_tag, to_tag):
+    def asserts(tag, client):
+        check_version(tag, emu.client.version)
+        assert not client.features.pin_protection
+        assert not client.features.passphrase_protection
+        assert client.features.initialized
+        assert client.features.label == LABEL
+        assert client.features.language == LANGUAGE
+        assert not client.features.needs_backup
+        assert not client.features.unfinished_backup
+        assert client.features.no_backup
+
+    with EmulatorWrapper(gen, from_tag) as emu:
+        device.reset(
+            emu.client,
+            display_random=False,
+            strength=STRENGTH,
+            passphrase_protection=False,
+            pin_protection=False,
+            label=LABEL,
+            language=LANGUAGE,
+            no_backup=True,
+        )
+        device_id = emu.client.features.device_id
+        asserts(from_tag, emu.client)
+        storage = emu.storage()
+
+    with EmulatorWrapper(gen, to_tag, storage=storage) as emu:
+        assert device_id == emu.client.features.device_id
+        asserts(to_tag, emu.client)
+
+
+if __name__ == "__main__":
+    if not ALL_TAGS:
+        print("No versions found. Remember to run download_emulators.sh")
+    for k, v in ALL_TAGS.items():
+        print("Found versions for {}:".format(k), v)
+    print()
+    print("Use `pytest {}` to run tests".format(__file__))


### PR DESCRIPTION
This introduces upgrade tests. The Emulator Wrapper and python script were written by @prusnak originally with some modifications of mine. The emulators are built on CI and stored on our [internal dev server](https://firmware.corp.sldev.cz/upgrade_tests/).

All versions that are found on the website are tested. I will also add a CI job, which will deploy new emulators to this website if a new tag occurs (meaning anytime we tag a new version, it will be deployed there automatically and therefore upgrade-tested). This closes #126.

----

We need to:

- [x] Review the Python part.
- [x] Do we want to call this using pytest? That's why other tests are failing currently, because pytest picks up the files as well (they have test_* functions). The upgrade tests themselves are [passing](https://gitlab.com/satoshilabs/trezor/trezor-firmware/-/jobs/277110968) though.
- [x] Solve the MINIMUM VERSION [override](https://github.com/trezor/trezor-firmware/compare/tsusanka/ci-upgrade-tests2?expand=1#diff-a51b8f647ebcb623f5181189925e48c1L5). I wasn't sure how to do it properly. 
- [x] @prusnak We need to build the emulator frozen with PYOPT=0. [This](https://github.com/trezor/trezor-firmware/compare/tsusanka/ci-upgrade-tests2?expand=1#diff-84be10005b1d7d80ca912486c46f07d8R48) is a bit hackish - I guess we could add a make target for this, right? And I guess I need to change SConscript.unix for that, because it is overwritten otherwise.
- [ ] Test if some "upgrade bug" is introduced, this actaully catches it.

@matejcik do you think I could leave this one for you to finish? Might be more effective than doing the review ping-ping.
