### PR TITLE
embedded.md: add sdl2 install step for MacOS

### DIFF
--- a/core/docs/build/embedded.md
+++ b/core/docs/build/embedded.md
@@ -18,7 +18,8 @@ sudo apt-get install scons gcc-arm-none-eabi libnewlib-arm-none-eabi
 1. Download [gcc-arm-none-eabi](https://developer.arm.com/open-source/gnu-toolchain/gnu-rm/downloads)
 2. Follow the [install instructions](https://launchpadlibrarian.net/287100883/readme.txt)
 3. To install OpenOCD, run `brew install open-ocd`
-4. Run `pipenv run make vendor build_boardloader build_bootloader build_firmware`
+4. Make sure that `sdl2` and `pkg-config` are installed: `brew install sdl2{,_image,_mixer,_ttf,_gfx} pkg-config`
+5. Run `pipenv run make vendor build_boardloader build_bootloader build_firmware`
 
 ## Building
 


### PR DESCRIPTION
I was receiving the following build error on a near-fresh macOS install. Installing sdl2 with Homebrew resolved this.
```
Package sdl2 was not found in the pkg-config search path.
Perhaps you should add the directory containing `sdl2.pc'
to the PKG_CONFIG_PATH environment variable
No package 'sdl2' found
```