### PR TITLE
common: adding Yoroi wallet for Cardano

### DIFF
--- a/common/defs/misc/misc.json
+++ b/common/defs/misc/misc.json
@@ -97,7 +97,8 @@
             "Github": "https://github.com/input-output-hk/cardano-sl"
         },
         "wallet": {
-            "AdaLite": "https://adalite.io/app"
+            "AdaLite": "https://adalite.io/app",
+            "Yoroi": "https://yoroi-wallet.com"
         },
         "blockchain_link": null
     },


### PR DESCRIPTION
Adding [Yoroi](https://yoroi-wallet.com) as another wallet that supports integration with Trezor.