### PR TITLE
Adding darwin static build

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -29,7 +29,7 @@ stages:
   - deploy
 
 before_script:
-  - pipenv sync
+  - command -v pipenv >/dev/null && pipenv sync
 
 include:
   - ci/environment.yml

--- a/ci/build.yml
+++ b/ci/build.yml
@@ -94,17 +94,17 @@ build core unix regular darwin:
   tags:
     - darwin
   script:
-    - sed -i '' 's/pkg-config/pkg-config --static/' core/SConscript.unix
     - . $HOME/.nix-profile/etc/profile.d/nix.sh
     - nix-shell --run "cd core && make build_unix"
-    - cp -v core/build/unix/micropython trezor-darwin-$VERSION-$CI_COMMIT_SHORT_SHA.bin
+    - mkdir -p TrezorEmu-$CI_COMMIT_SHORT_SHA.app/Contents/{MacOS,libs}
+    - cp -v core/build/unix/micropython TrezorEmu-$CI_COMMIT_SHORT_SHA.app/Contents/MacOS/TrezorEmu-$CI_COMMIT_SHORT_SHA
+    - dylibbundler -of -b -i /usr/lib/system -d TrezorEmu-$CI_COMMIT_SHORT_SHA.app/Contents/libs -x TrezorEmu-$CI_COMMIT_SHORT_SHA.app/Contents/MacOS/TrezorEmu-$CI_COMMIT_SHORT_SHA
   allow_failure: true
   artifacts:
     name: "$CI_JOB_NAME-$CI_COMMIT_SHORT_SHA"
     paths:
-      - trezor-darwin-*
+      - TrezorEmu-$CI_COMMIT_SHORT_SHA.app
     expire_in: 1 week
-
 
 # Crypto
 

--- a/ci/build.yml
+++ b/ci/build.yml
@@ -89,13 +89,13 @@ build core unix frozen debug:
     untracked: true
     expire_in: 1 week
 
-build core unix regular darwin:
+build core unix frozen regular darwin:
   stage: build
   tags:
     - darwin
   script:
     - . $HOME/.nix-profile/etc/profile.d/nix.sh
-    - nix-shell --run "cd core && make build_unix"
+    - nix-shell --run "cd core && make build_unix_frozen"
     - mkdir -p TrezorEmu-$CI_COMMIT_SHORT_SHA.app/Contents/{MacOS,libs}
     - cp -v core/build/unix/micropython TrezorEmu-$CI_COMMIT_SHORT_SHA.app/Contents/MacOS/TrezorEmu-$CI_COMMIT_SHORT_SHA
     - dylibbundler -of -b -i /usr/lib/system -d TrezorEmu-$CI_COMMIT_SHORT_SHA.app/Contents/libs -x TrezorEmu-$CI_COMMIT_SHORT_SHA.app/Contents/MacOS/TrezorEmu-$CI_COMMIT_SHORT_SHA

--- a/ci/build.yml
+++ b/ci/build.yml
@@ -89,6 +89,22 @@ build core unix frozen debug:
     untracked: true
     expire_in: 1 week
 
+build core unix regular darwin:
+  stage: build
+  tags:
+    - darwin
+  script:
+    - sed -i '' 's/pkg-config/pkg-config --static/' core/SConscript.unix
+    - . $HOME/.nix-profile/etc/profile.d/nix.sh
+    - nix-shell --run "cd core && make build_unix"
+    - cp -v core/build/unix/micropython trezor-darwin-$VERSION-$CI_COMMIT_SHORT_SHA.bin
+  allow_failure: true
+  artifacts:
+    name: "$CI_JOB_NAME-$CI_COMMIT_SHORT_SHA"
+    paths:
+      - trezor-darwin-*
+    expire_in: 1 week
+
 
 # Crypto
 

--- a/shell.nix
+++ b/shell.nix
@@ -14,7 +14,6 @@ let
     ps.munch
     ps.pillow
     ps.pytest
-    ps.pytest-random-order
     ps.trezor
   ]);
 in
@@ -28,7 +27,6 @@ in
       check
       clang-tools
       gcc
-      gcc-arm-embedded
       gnumake
       graphviz
       openssl
@@ -39,5 +37,19 @@ in
       scons
       valgrind
       zlib
+    ] ++ stdenv.lib.optionals (!stdenv.isDarwin) [
+      gcc-arm-embedded
+    ] ++ stdenv.lib.optionals (stdenv.isDarwin) [
+      darwin.apple_sdk.frameworks.CoreAudio
+      darwin.apple_sdk.frameworks.AudioToolbox
+      darwin.apple_sdk.frameworks.ForceFeedback
+      darwin.apple_sdk.frameworks.CoreVideo
+      darwin.apple_sdk.frameworks.Cocoa
+      darwin.apple_sdk.frameworks.Carbon
+      darwin.apple_sdk.frameworks.IOKit
+      darwin.apple_sdk.frameworks.QuartzCore
+      darwin.apple_sdk.frameworks.Metal
+      darwin.libobjc
+      libiconv
     ];
   }


### PR DESCRIPTION
The following changes are a proof of concept of builds on darwin.

- The job is for now marked as ``allowed_failure`` as we are still seeing some slowness and glitches on the darwin builder, this will help us troubleshoot the issue
- We ask ``pkg-config`` to build it as a static library so Mac OS users don't have to install SDL2 and dependencies (I thought of making it as a default on darwin, but it's specific to our use case)
- We do check if pipenv is installed