### PR TITLE
Remove underscores in symbols used externally

### DIFF
--- a/core/src/apps/common/storage/__init__.py
+++ b/core/src/apps/common/storage/__init__.py
@@ -5,7 +5,7 @@ from apps.common.storage import common, device
 
 
 def set_current_version() -> None:
-    device.set_version(common._STORAGE_VERSION_CURRENT)
+    device.set_version(common.STORAGE_VERSION_CURRENT)
 
 
 def is_initialized() -> bool:
@@ -20,16 +20,16 @@ def wipe() -> None:
 def init_unlocked() -> None:
     # Check for storage version upgrade.
     version = device.get_version()
-    if version == common._STORAGE_VERSION_01:
+    if version == common.STORAGE_VERSION_01:
         _migrate_from_version_01()
 
 
 def _migrate_from_version_01() -> None:
     # Make the U2F counter public and writable even when storage is locked.
     # U2F counter wasn't public, so we are intentionally not using storage.device module.
-    counter = common._get(common._APP_DEVICE, device.U2F_COUNTER)
+    counter = common.get(common.APP_DEVICE, device.U2F_COUNTER)
     if counter is not None:
         device.set_u2f_counter(int.from_bytes(counter, "big"))
         # Delete the old, non-public U2F_COUNTER.
-        common._delete(common._APP_DEVICE, device.U2F_COUNTER)
+        common.delete(common.APP_DEVICE, device.U2F_COUNTER)
     set_current_version()

--- a/core/src/apps/common/storage/common.py
+++ b/core/src/apps/common/storage/common.py
@@ -1,3 +1,5 @@
+from micropython import const
+
 from trezor import config
 
 if False:
@@ -5,74 +7,73 @@ if False:
 
 # Namespaces:
 # fmt: off
-# Intentionally not using const() to allow import in submodules.
-_APP_DEVICE             = 0x01
-_APP_RECOVERY           = 0x02
-_APP_RECOVERY_SHARES    = 0x03
+APP_DEVICE             = const(0x01)
+APP_RECOVERY           = const(0x02)
+APP_RECOVERY_SHARES    = const(0x03)
 # fmt: on
 
 _FALSE_BYTE = b"\x00"
 _TRUE_BYTE = b"\x01"
 
-_STORAGE_VERSION_01 = b"\x01"
-_STORAGE_VERSION_CURRENT = b"\x02"
+STORAGE_VERSION_01 = b"\x01"
+STORAGE_VERSION_CURRENT = b"\x02"
 
 
-def _set(app: int, key: int, data: bytes, public: bool = False) -> None:
+def set(app: int, key: int, data: bytes, public: bool = False) -> None:
     config.set(app, key, data, public)
 
 
-def _get(app: int, key: int, public: bool = False) -> Optional[bytes]:
+def get(app: int, key: int, public: bool = False) -> Optional[bytes]:
     return config.get(app, key, public)
 
 
-def _delete(app: int, key: int) -> None:
+def delete(app: int, key: int) -> None:
     config.delete(app, key)
 
 
-def _set_true_or_delete(app: int, key: int, value: bool) -> None:
+def set_true_or_delete(app: int, key: int, value: bool) -> None:
     if value:
-        _set_bool(app, key, value)
+        set_bool(app, key, value)
     else:
-        _delete(app, key)
+        delete(app, key)
 
 
-def _set_bool(app: int, key: int, value: bool, public: bool = False) -> None:
+def set_bool(app: int, key: int, value: bool, public: bool = False) -> None:
     if value:
-        _set(app, key, _TRUE_BYTE, public)
+        set(app, key, _TRUE_BYTE, public)
     else:
-        _set(app, key, _FALSE_BYTE, public)
+        set(app, key, _FALSE_BYTE, public)
 
 
-def _get_bool(app: int, key: int, public: bool = False) -> bool:
-    return _get(app, key, public) == _TRUE_BYTE
+def get_bool(app: int, key: int, public: bool = False) -> bool:
+    return get(app, key, public) == _TRUE_BYTE
 
 
-def _set_uint8(app: int, key: int, val: int) -> None:
-    _set(app, key, val.to_bytes(1, "big"))
+def set_uint8(app: int, key: int, val: int) -> None:
+    set(app, key, val.to_bytes(1, "big"))
 
 
-def _get_uint8(app: int, key: int) -> Optional[int]:
-    val = _get(app, key)
+def get_uint8(app: int, key: int) -> Optional[int]:
+    val = get(app, key)
     if not val:
         return None
     return int.from_bytes(val, "big")
 
 
-def _set_uint16(app: int, key: int, val: int) -> None:
-    _set(app, key, val.to_bytes(2, "big"))
+def set_uint16(app: int, key: int, val: int) -> None:
+    set(app, key, val.to_bytes(2, "big"))
 
 
-def _get_uint16(app: int, key: int) -> Optional[int]:
-    val = _get(app, key)
+def get_uint16(app: int, key: int) -> Optional[int]:
+    val = get(app, key)
     if not val:
         return None
     return int.from_bytes(val, "big")
 
 
-def _next_counter(app: int, key: int, public: bool = False) -> Optional[int]:
+def next_counter(app: int, key: int, public: bool = False) -> Optional[int]:
     return config.next_counter(app, key, public)
 
 
-def _set_counter(app: int, key: int, count: int, public: bool = False) -> None:
+def set_counter(app: int, key: int, count: int, public: bool = False) -> None:
     config.set_counter(app, key, count, public)

--- a/core/src/apps/common/storage/device.py
+++ b/core/src/apps/common/storage/device.py
@@ -9,7 +9,7 @@ if False:
     from typing import Optional
 
 # Namespace:
-_NAMESPACE = common._APP_DEVICE
+_NAMESPACE = common.APP_DEVICE
 
 # fmt: off
 # Keys:
@@ -37,15 +37,15 @@ HOMESCREEN_MAXSIZE = 16384
 
 
 def is_version_stored() -> bool:
-    return bool(common._get(_NAMESPACE, _VERSION))
+    return bool(common.get(_NAMESPACE, _VERSION))
 
 
 def get_version() -> Optional[bytes]:
-    return common._get(_NAMESPACE, _VERSION)
+    return common.get(_NAMESPACE, _VERSION)
 
 
 def set_version(version: bytes) -> None:
-    common._set(_NAMESPACE, _VERSION, version)
+    common.set(_NAMESPACE, _VERSION, version)
 
 
 def _new_device_id() -> str:
@@ -53,41 +53,41 @@ def _new_device_id() -> str:
 
 
 def get_device_id() -> str:
-    dev_id = common._get(_NAMESPACE, _DEVICE_ID, True)  # public
+    dev_id = common.get(_NAMESPACE, _DEVICE_ID, True)  # public
     if not dev_id:
         dev_id = _new_device_id().encode()
-        common._set(_NAMESPACE, _DEVICE_ID, dev_id, True)  # public
+        common.set(_NAMESPACE, _DEVICE_ID, dev_id, True)  # public
     return dev_id.decode()
 
 
 def get_rotation() -> int:
-    rotation = common._get(_NAMESPACE, _ROTATION, True)  # public
+    rotation = common.get(_NAMESPACE, _ROTATION, True)  # public
     if not rotation:
         return 0
     return int.from_bytes(rotation, "big")
 
 
 def get_label() -> Optional[str]:
-    label = common._get(_NAMESPACE, _LABEL, True)  # public
+    label = common.get(_NAMESPACE, _LABEL, True)  # public
     if label is None:
         return None
     return label.decode()
 
 
 def get_mnemonic_secret() -> Optional[bytes]:
-    return common._get(_NAMESPACE, _MNEMONIC_SECRET)
+    return common.get(_NAMESPACE, _MNEMONIC_SECRET)
 
 
 def get_mnemonic_type() -> Optional[int]:
-    return common._get_uint8(_NAMESPACE, _MNEMONIC_TYPE)
+    return common.get_uint8(_NAMESPACE, _MNEMONIC_TYPE)
 
 
 def has_passphrase() -> bool:
-    return common._get_bool(_NAMESPACE, _USE_PASSPHRASE)
+    return common.get_bool(_NAMESPACE, _USE_PASSPHRASE)
 
 
 def get_homescreen() -> Optional[bytes]:
-    return common._get(_NAMESPACE, _HOMESCREEN, True)  # public
+    return common.get(_NAMESPACE, _HOMESCREEN, True)  # public
 
 
 def store_mnemonic_secret(
@@ -96,36 +96,36 @@ def store_mnemonic_secret(
     needs_backup: bool = False,
     no_backup: bool = False,
 ) -> None:
-    set_version(common._STORAGE_VERSION_CURRENT)
-    common._set(_NAMESPACE, _MNEMONIC_SECRET, secret)
-    common._set_uint8(_NAMESPACE, _MNEMONIC_TYPE, mnemonic_type)
-    common._set_true_or_delete(_NAMESPACE, _NO_BACKUP, no_backup)
+    set_version(common.STORAGE_VERSION_CURRENT)
+    common.set(_NAMESPACE, _MNEMONIC_SECRET, secret)
+    common.set_uint8(_NAMESPACE, _MNEMONIC_TYPE, mnemonic_type)
+    common.set_true_or_delete(_NAMESPACE, _NO_BACKUP, no_backup)
     if not no_backup:
-        common._set_true_or_delete(_NAMESPACE, _NEEDS_BACKUP, needs_backup)
+        common.set_true_or_delete(_NAMESPACE, _NEEDS_BACKUP, needs_backup)
 
 
 def needs_backup() -> bool:
-    return common._get_bool(_NAMESPACE, _NEEDS_BACKUP)
+    return common.get_bool(_NAMESPACE, _NEEDS_BACKUP)
 
 
 def set_backed_up() -> None:
-    common._delete(_NAMESPACE, _NEEDS_BACKUP)
+    common.delete(_NAMESPACE, _NEEDS_BACKUP)
 
 
 def unfinished_backup() -> bool:
-    return common._get_bool(_NAMESPACE, _UNFINISHED_BACKUP)
+    return common.get_bool(_NAMESPACE, _UNFINISHED_BACKUP)
 
 
 def set_unfinished_backup(state: bool) -> None:
-    common._set_bool(_NAMESPACE, _UNFINISHED_BACKUP, state)
+    common.set_bool(_NAMESPACE, _UNFINISHED_BACKUP, state)
 
 
 def no_backup() -> bool:
-    return common._get_bool(_NAMESPACE, _NO_BACKUP)
+    return common.get_bool(_NAMESPACE, _NO_BACKUP)
 
 
 def get_passphrase_source() -> int:
-    b = common._get(_NAMESPACE, _PASSPHRASE_SOURCE)
+    b = common.get(_NAMESPACE, _PASSPHRASE_SOURCE)
     if b == b"\x01":
         return 1
     elif b == b"\x02":
@@ -142,31 +142,31 @@ def load_settings(
     display_rotation: int = None,
 ) -> None:
     if label is not None:
-        common._set(_NAMESPACE, _LABEL, label.encode(), True)  # public
+        common.set(_NAMESPACE, _LABEL, label.encode(), True)  # public
     if use_passphrase is not None:
-        common._set_bool(_NAMESPACE, _USE_PASSPHRASE, use_passphrase)
+        common.set_bool(_NAMESPACE, _USE_PASSPHRASE, use_passphrase)
     if homescreen is not None:
         if homescreen[:8] == b"TOIf\x90\x00\x90\x00":
             if len(homescreen) <= HOMESCREEN_MAXSIZE:
-                common._set(_NAMESPACE, _HOMESCREEN, homescreen, True)  # public
+                common.set(_NAMESPACE, _HOMESCREEN, homescreen, True)  # public
         else:
-            common._set(_NAMESPACE, _HOMESCREEN, b"", True)  # public
+            common.set(_NAMESPACE, _HOMESCREEN, b"", True)  # public
     if passphrase_source is not None:
         if passphrase_source in (0, 1, 2):
-            common._set(_NAMESPACE, _PASSPHRASE_SOURCE, bytes([passphrase_source]))
+            common.set(_NAMESPACE, _PASSPHRASE_SOURCE, bytes([passphrase_source]))
     if display_rotation is not None:
         if display_rotation not in (0, 90, 180, 270):
             raise ValueError(
                 "Unsupported display rotation degrees: %d" % display_rotation
             )
         else:
-            common._set(
+            common.set(
                 _NAMESPACE, _ROTATION, display_rotation.to_bytes(2, "big"), True
             )  # public
 
 
 def get_flags() -> int:
-    b = common._get(_NAMESPACE, _FLAGS)
+    b = common.get(_NAMESPACE, _FLAGS)
     if b is None:
         return 0
     else:
@@ -174,18 +174,18 @@ def get_flags() -> int:
 
 
 def set_flags(flags: int) -> None:
-    b = common._get(_NAMESPACE, _FLAGS)
+    b = common.get(_NAMESPACE, _FLAGS)
     if b is None:
         i = 0
     else:
         i = int.from_bytes(b, "big")
     flags = (flags | i) & 0xFFFFFFFF
     if flags != i:
-        common._set(_NAMESPACE, _FLAGS, flags.to_bytes(4, "big"))
+        common.set(_NAMESPACE, _FLAGS, flags.to_bytes(4, "big"))
 
 
 def get_autolock_delay_ms() -> int:
-    b = common._get(_NAMESPACE, _AUTOLOCK_DELAY_MS)
+    b = common.get(_NAMESPACE, _AUTOLOCK_DELAY_MS)
     if b is None:
         return 10 * 60 * 1000
     else:
@@ -195,15 +195,15 @@ def get_autolock_delay_ms() -> int:
 def set_autolock_delay_ms(delay_ms: int) -> None:
     if delay_ms < 60 * 1000:
         delay_ms = 60 * 1000
-    common._set(_NAMESPACE, _AUTOLOCK_DELAY_MS, delay_ms.to_bytes(4, "big"))
+    common.set(_NAMESPACE, _AUTOLOCK_DELAY_MS, delay_ms.to_bytes(4, "big"))
 
 
 def next_u2f_counter() -> Optional[int]:
-    return common._next_counter(_NAMESPACE, U2F_COUNTER, True)  # writable when locked
+    return common.next_counter(_NAMESPACE, U2F_COUNTER, True)  # writable when locked
 
 
 def set_u2f_counter(count: int) -> None:
-    common._set_counter(_NAMESPACE, U2F_COUNTER, count, True)  # writable when locked
+    common.set_counter(_NAMESPACE, U2F_COUNTER, count, True)  # writable when locked
 
 
 def set_slip39_identifier(identifier: int) -> None:
@@ -212,12 +212,12 @@ def set_slip39_identifier(identifier: int) -> None:
     Not to be confused with recovery.identifier, which is stored only during
     the recovery process and it is copied here upon success.
     """
-    common._set_uint16(_NAMESPACE, _SLIP39_IDENTIFIER, identifier)
+    common.set_uint16(_NAMESPACE, _SLIP39_IDENTIFIER, identifier)
 
 
 def get_slip39_identifier() -> Optional[int]:
     """The device's actual SLIP-39 identifier used in passphrase derivation."""
-    return common._get_uint16(_NAMESPACE, _SLIP39_IDENTIFIER)
+    return common.get_uint16(_NAMESPACE, _SLIP39_IDENTIFIER)
 
 
 def set_slip39_iteration_exponent(exponent: int) -> None:
@@ -226,11 +226,11 @@ def set_slip39_iteration_exponent(exponent: int) -> None:
     Not to be confused with recovery.iteration_exponent, which is stored only during
     the recovery process and it is copied here upon success.
     """
-    common._set_uint8(_NAMESPACE, _SLIP39_ITERATION_EXPONENT, exponent)
+    common.set_uint8(_NAMESPACE, _SLIP39_ITERATION_EXPONENT, exponent)
 
 
 def get_slip39_iteration_exponent() -> Optional[int]:
     """
     The device's actual SLIP-39 iteration exponent used in passphrase derivation.
     """
-    return common._get_uint8(_NAMESPACE, _SLIP39_ITERATION_EXPONENT)
+    return common.get_uint8(_NAMESPACE, _SLIP39_ITERATION_EXPONENT)

--- a/core/src/apps/common/storage/recovery.py
+++ b/core/src/apps/common/storage/recovery.py
@@ -5,7 +5,7 @@ from trezor.crypto import slip39
 from apps.common.storage import common, recovery_shares
 
 # Namespace:
-_NAMESPACE = common._APP_RECOVERY
+_NAMESPACE = common.APP_RECOVERY
 
 # fmt: off
 # Keys:
@@ -25,67 +25,67 @@ if False:
 
 
 def set_in_progress(val: bool) -> None:
-    common._set_bool(_NAMESPACE, _IN_PROGRESS, val)
+    common.set_bool(_NAMESPACE, _IN_PROGRESS, val)
 
 
 def is_in_progress() -> bool:
-    return common._get_bool(_NAMESPACE, _IN_PROGRESS)
+    return common.get_bool(_NAMESPACE, _IN_PROGRESS)
 
 
 def set_dry_run(val: bool) -> None:
-    common._set_bool(_NAMESPACE, _DRY_RUN, val)
+    common.set_bool(_NAMESPACE, _DRY_RUN, val)
 
 
 def is_dry_run() -> bool:
-    return common._get_bool(_NAMESPACE, _DRY_RUN)
+    return common.get_bool(_NAMESPACE, _DRY_RUN)
 
 
 def set_word_count(count: int) -> None:
-    common._set_uint8(_NAMESPACE, _WORD_COUNT, count)
+    common.set_uint8(_NAMESPACE, _WORD_COUNT, count)
 
 
 def get_word_count() -> Optional[int]:
-    return common._get_uint8(_NAMESPACE, _WORD_COUNT)
+    return common.get_uint8(_NAMESPACE, _WORD_COUNT)
 
 
 def set_slip39_identifier(identifier: int) -> None:
-    common._set_uint16(_NAMESPACE, _SLIP39_IDENTIFIER, identifier)
+    common.set_uint16(_NAMESPACE, _SLIP39_IDENTIFIER, identifier)
 
 
 def get_slip39_identifier() -> Optional[int]:
-    return common._get_uint16(_NAMESPACE, _SLIP39_IDENTIFIER)
+    return common.get_uint16(_NAMESPACE, _SLIP39_IDENTIFIER)
 
 
 def set_slip39_threshold(threshold: int) -> None:
-    common._set_uint8(_NAMESPACE, _SLIP39_THRESHOLD, threshold)
+    common.set_uint8(_NAMESPACE, _SLIP39_THRESHOLD, threshold)
 
 
 def get_slip39_threshold() -> Optional[int]:
-    return common._get_uint8(_NAMESPACE, _SLIP39_THRESHOLD)
+    return common.get_uint8(_NAMESPACE, _SLIP39_THRESHOLD)
 
 
 def set_slip39_iteration_exponent(exponent: int) -> None:
-    common._set_uint8(_NAMESPACE, _SLIP39_ITERATION_EXPONENT, exponent)
+    common.set_uint8(_NAMESPACE, _SLIP39_ITERATION_EXPONENT, exponent)
 
 
 def get_slip39_iteration_exponent() -> Optional[int]:
-    return common._get_uint8(_NAMESPACE, _SLIP39_ITERATION_EXPONENT)
+    return common.get_uint8(_NAMESPACE, _SLIP39_ITERATION_EXPONENT)
 
 
 def set_slip39_group_count(group_count: int) -> None:
-    common._set_uint8(_NAMESPACE, _SLIP39_GROUP_COUNT, group_count)
+    common.set_uint8(_NAMESPACE, _SLIP39_GROUP_COUNT, group_count)
 
 
 def get_slip39_group_count() -> Optional[int]:
-    return common._get_uint8(_NAMESPACE, _SLIP39_GROUP_COUNT)
+    return common.get_uint8(_NAMESPACE, _SLIP39_GROUP_COUNT)
 
 
 def set_slip39_group_threshold(group_threshold: int) -> None:
-    common._set_uint8(_NAMESPACE, _SLIP39_GROUP_THRESHOLD, group_threshold)
+    common.set_uint8(_NAMESPACE, _SLIP39_GROUP_THRESHOLD, group_threshold)
 
 
 def get_slip39_group_threshold() -> Optional[int]:
-    return common._get_uint8(_NAMESPACE, _SLIP39_GROUP_THRESHOLD)
+    return common.get_uint8(_NAMESPACE, _SLIP39_GROUP_THRESHOLD)
 
 
 def set_slip39_remaining_shares(shares_remaining: int, group_index: int = 0) -> None:
@@ -95,18 +95,18 @@ def set_slip39_remaining_shares(shares_remaining: int, group_index: int = 0) -> 
     0x10 (16) was chosen as the default value because it's the max
     share count for a group.
     """
-    remaining = common._get(_NAMESPACE, _REMAINING)
+    remaining = common.get(_NAMESPACE, _REMAINING)
     if not get_slip39_group_count():
         raise RuntimeError()
     if remaining is None:
         remaining = bytearray([slip39.MAX_SHARE_COUNT] * get_slip39_group_count())
     remaining = bytearray(remaining)
     remaining[group_index] = shares_remaining
-    common._set(_NAMESPACE, _REMAINING, remaining)
+    common.set(_NAMESPACE, _REMAINING, remaining)
 
 
 def get_slip39_remaining_shares(group_index: int = 0) -> Optional[int]:
-    remaining = common._get(_NAMESPACE, _REMAINING)
+    remaining = common.get(_NAMESPACE, _REMAINING)
     if remaining is None or remaining[group_index] == slip39.MAX_SHARE_COUNT:
         return None
     else:
@@ -114,7 +114,7 @@ def get_slip39_remaining_shares(group_index: int = 0) -> Optional[int]:
 
 
 def fetch_slip39_remaining_shares() -> Optional[List[int]]:
-    remaining = common._get(_NAMESPACE, _REMAINING)
+    remaining = common.get(_NAMESPACE, _REMAINING)
     if not remaining:
         return None
 
@@ -126,13 +126,13 @@ def fetch_slip39_remaining_shares() -> Optional[List[int]]:
 
 
 def end_progress() -> None:
-    common._delete(_NAMESPACE, _IN_PROGRESS)
-    common._delete(_NAMESPACE, _DRY_RUN)
-    common._delete(_NAMESPACE, _WORD_COUNT)
-    common._delete(_NAMESPACE, _SLIP39_IDENTIFIER)
-    common._delete(_NAMESPACE, _SLIP39_THRESHOLD)
-    common._delete(_NAMESPACE, _REMAINING)
-    common._delete(_NAMESPACE, _SLIP39_ITERATION_EXPONENT)
-    common._delete(_NAMESPACE, _SLIP39_GROUP_COUNT)
-    common._delete(_NAMESPACE, _SLIP39_GROUP_THRESHOLD)
+    common.delete(_NAMESPACE, _IN_PROGRESS)
+    common.delete(_NAMESPACE, _DRY_RUN)
+    common.delete(_NAMESPACE, _WORD_COUNT)
+    common.delete(_NAMESPACE, _SLIP39_IDENTIFIER)
+    common.delete(_NAMESPACE, _SLIP39_THRESHOLD)
+    common.delete(_NAMESPACE, _REMAINING)
+    common.delete(_NAMESPACE, _SLIP39_ITERATION_EXPONENT)
+    common.delete(_NAMESPACE, _SLIP39_GROUP_COUNT)
+    common.delete(_NAMESPACE, _SLIP39_GROUP_THRESHOLD)
     recovery_shares.delete()

--- a/core/src/apps/common/storage/recovery_shares.py
+++ b/core/src/apps/common/storage/recovery_shares.py
@@ -10,11 +10,11 @@ if False:
 
 
 def set(index: int, mnemonic: str) -> None:
-    common._set(common._APP_RECOVERY_SHARES, index, mnemonic.encode())
+    common.set(common.APP_RECOVERY_SHARES, index, mnemonic.encode())
 
 
 def get(index: int) -> Optional[str]:
-    m = common._get(common._APP_RECOVERY_SHARES, index)
+    m = common.get(common.APP_RECOVERY_SHARES, index)
     if m:
         return m.decode()
     return None
@@ -44,4 +44,4 @@ def fetch_group(group_index: int) -> List[str]:
 
 def delete() -> None:
     for index in range(0, slip39.MAX_SHARE_COUNT):
-        common._delete(common._APP_RECOVERY_SHARES, index)
+        common.delete(common.APP_RECOVERY_SHARES, index)

--- a/core/src/apps/eos/actions/layout.py
+++ b/core/src/apps/eos/actions/layout.py
@@ -8,7 +8,7 @@ from trezor.ui.text import Text
 from trezor.utils import chunks
 
 from apps.eos import helpers
-from apps.eos.get_public_key import _public_key_to_wif
+from apps.eos.get_public_key import public_key_to_wif
 from apps.eos.layout import require_confirm
 
 if False:
@@ -273,7 +273,7 @@ def authorization_fields(auth: EosAuthorization) -> List[str]:
     fields.append(str(auth.threshold))
 
     for i, key in enumerate(auth.keys):
-        _key = _public_key_to_wif(bytes(key.key))
+        _key = public_key_to_wif(bytes(key.key))
         _weight = str(key.weight)
 
         header = "Key #{}:".format(i + 1)

--- a/core/src/apps/eos/actions/layout.py
+++ b/core/src/apps/eos/actions/layout.py
@@ -8,7 +8,6 @@ from trezor.ui.text import Text
 from trezor.utils import chunks
 
 from apps.eos import helpers
-from apps.eos.get_public_key import public_key_to_wif
 from apps.eos.layout import require_confirm
 
 if False:
@@ -273,7 +272,7 @@ def authorization_fields(auth: EosAuthorization) -> List[str]:
     fields.append(str(auth.threshold))
 
     for i, key in enumerate(auth.keys):
-        _key = public_key_to_wif(bytes(key.key))
+        _key = helpers.public_key_to_wif(bytes(key.key))
         _weight = str(key.weight)
 
         header = "Key #{}:".format(i + 1)

--- a/core/src/apps/eos/get_public_key.py
+++ b/core/src/apps/eos/get_public_key.py
@@ -5,24 +5,13 @@ from trezor.messages.EosPublicKey import EosPublicKey
 
 from apps.common import paths
 from apps.eos import CURVE
-from apps.eos.helpers import base58_encode, validate_full_path
+from apps.eos.helpers import public_key_to_wif, validate_full_path
 from apps.eos.layout import require_get_public_key
 
 if False:
     from typing import Tuple
     from trezor.crypto import bip32
     from apps.common import seed
-
-
-def public_key_to_wif(pub_key: bytes) -> str:
-    if pub_key[0] == 0x04 and len(pub_key) == 65:
-        head = b"\x03" if pub_key[64] & 0x01 else b"\x02"
-        compressed_pub_key = head + pub_key[1:33]
-    elif pub_key[0] in [0x02, 0x03] and len(pub_key) == 33:
-        compressed_pub_key = pub_key
-    else:
-        raise wire.DataError("invalid public key")
-    return base58_encode("EOS", "", compressed_pub_key)
 
 
 def _get_public_key(node: bip32.HDNode) -> Tuple[str, bytes]:

--- a/core/src/apps/eos/get_public_key.py
+++ b/core/src/apps/eos/get_public_key.py
@@ -14,7 +14,7 @@ if False:
     from apps.common import seed
 
 
-def _public_key_to_wif(pub_key: bytes) -> str:
+def public_key_to_wif(pub_key: bytes) -> str:
     if pub_key[0] == 0x04 and len(pub_key) == 65:
         head = b"\x03" if pub_key[64] & 0x01 else b"\x02"
         compressed_pub_key = head + pub_key[1:33]
@@ -28,7 +28,7 @@ def _public_key_to_wif(pub_key: bytes) -> str:
 def _get_public_key(node: bip32.HDNode) -> Tuple[str, bytes]:
     seckey = node.private_key()
     public_key = secp256k1.publickey(seckey, True)
-    wif = _public_key_to_wif(public_key)
+    wif = public_key_to_wif(public_key)
     return wif, public_key
 
 

--- a/core/src/apps/eos/helpers.py
+++ b/core/src/apps/eos/helpers.py
@@ -1,3 +1,4 @@
+from trezor import wire
 from trezor.crypto import base58
 from trezor.messages.EosAsset import EosAsset
 
@@ -61,3 +62,14 @@ def validate_full_path(path: list) -> bool:
     if path[4] != 0:
         return False
     return True
+
+
+def public_key_to_wif(pub_key: bytes) -> str:
+    if pub_key[0] == 0x04 and len(pub_key) == 65:
+        head = b"\x03" if pub_key[64] & 0x01 else b"\x02"
+        compressed_pub_key = head + pub_key[1:33]
+    elif pub_key[0] in [0x02, 0x03] and len(pub_key) == 33:
+        compressed_pub_key = pub_key
+    else:
+        raise wire.DataError("invalid public key")
+    return base58_encode("EOS", "", compressed_pub_key)

--- a/core/tests/test_apps.eos.get_public_key.py
+++ b/core/tests/test_apps.eos.get_public_key.py
@@ -4,7 +4,7 @@ from trezor.crypto import bip32, bip39
 from apps.common.paths import HARDENED
 
 if not utils.BITCOIN_ONLY:
-    from apps.eos.get_public_key import _get_public_key, _public_key_to_wif
+    from apps.eos.get_public_key import _get_public_key, public_key_to_wif
     from apps.eos.helpers import validate_full_path
 
 
@@ -42,7 +42,7 @@ class TestEosGetPublicKey(unittest.TestCase):
 
             self.assertEqual(hexlify(public_key), public_keys[index])
             self.assertEqual(wif, wif_keys[index])
-            self.assertEqual(_public_key_to_wif(public_key), wif_keys[index])
+            self.assertEqual(public_key_to_wif(public_key), wif_keys[index])
 
     def test_paths(self):
         # 44'/194'/a'/0/0 is correct

--- a/core/tests/test_apps.eos.get_public_key.py
+++ b/core/tests/test_apps.eos.get_public_key.py
@@ -4,8 +4,8 @@ from trezor.crypto import bip32, bip39
 from apps.common.paths import HARDENED
 
 if not utils.BITCOIN_ONLY:
-    from apps.eos.get_public_key import _get_public_key, public_key_to_wif
-    from apps.eos.helpers import validate_full_path
+    from apps.eos.get_public_key import _get_public_key
+    from apps.eos.helpers import validate_full_path, public_key_to_wif
 
 
 @unittest.skipUnless(not utils.BITCOIN_ONLY, "altcoin")


### PR DESCRIPTION
I have searched using the regexp `[^self]\._[^_]` and replaced everything with the exception of the chan class where we call an internal chan's function from the subclass, which I guess is alright.

I've also realised there can be instances of `import _*`. I've found only one instance and the fix is included in this PR.

closes #504
