### PR TITLE
Replace /bin/bash with /usr/bin/env bash

### DIFF
--- a/core/tests/check_coverage.sh
+++ b/core/tests/check_coverage.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 find ../mocks -name '*.py' | sort | while read module; do
     module=$(echo $module | sed 's:^\.\./mocks/::')
     base=$(basename $module)

--- a/core/tests/run_tests.sh
+++ b/core/tests/run_tests.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 declare -a results
 declare -i PYOPT=1 passed=0 failed=0 exit_code=0

--- a/core/tests/run_tests_device_emu.sh
+++ b/core/tests/run_tests_device_emu.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 : "${RUN_TEST_EMU:=1}"
 

--- a/core/tests/run_tests_device_emu_monero.sh
+++ b/core/tests/run_tests_device_emu_monero.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 : "${RUN_PYTHON_TESTS:=0}"
 : "${FORCE_DOCKER_USE:=0}"

--- a/core/trezor_cmd.sh
+++ b/core/trezor_cmd.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 # expected inputs:
 # TREZOR_SRC -- directory containing python code for uMP

--- a/legacy/bootloader/combine/write.sh
+++ b/legacy/bootloader/combine/write.sh
@@ -1,2 +1,2 @@
-#!/bin/bash
+#!/usr/bin/env bash
 st-flash write combined.bin 0x8000000

--- a/legacy/firmware/u2f/genkeys.sh
+++ b/legacy/firmware/u2f/genkeys.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 set -e
 
 cat > u2f_keys.h <<EOF

--- a/legacy/script/bootstrap
+++ b/legacy/script/bootstrap
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 # script/bootstrap: Resolve all dependencies that the application requires to
 #                   run.

--- a/legacy/script/cibuild
+++ b/legacy/script/cibuild
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 # script/cibuild: Setup environment for CI to run tests. This is primarily
 #                 designed to run on the continuous integration server.

--- a/legacy/script/setup
+++ b/legacy/script/setup
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 # script/setup: Set up application for the first time after cloning, or set it
 #               back to the initial first unused state.

--- a/legacy/script/test
+++ b/legacy/script/test
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 # script/test: Run test suite for application.
 

--- a/legacy/script/toolchain-download
+++ b/legacy/script/toolchain-download
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 # script/toolchain-download: Download and extract the GNU Arm Embedded toolchain
 #                            for building the Trezor firmware.

--- a/legacy/script/toolchain-run
+++ b/legacy/script/toolchain-run
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 # script/toolchain-run: Run command with downloaded GNU Arm Embedded toolchain.
 #

--- a/python/helper-scripts/build-coins-json.sh
+++ b/python/helper-scripts/build-coins-json.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 cd $(dirname $0)/..
 
 DEST=src/trezorlib/coins.json

--- a/tests/upgrade_tests/download_emulators.sh
+++ b/tests/upgrade_tests/download_emulators.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 SITE="https://firmware.corp.sldev.cz/upgrade_tests/"
 cd "$(dirname "$0")"
 

--- a/tools/build_protobuf
+++ b/tools/build_protobuf
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 cd $(dirname $0)/..
 
 PROTOB=common/protob

--- a/tools/clang-format-check
+++ b/tools/clang-format-check
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 error=0
 for f in $*; do
     changes=$(clang-format -output-replacements-xml "$f" | grep -c '^<replacement '; exit ${PIPESTATUS[0]})


### PR DESCRIPTION
Isn't this needed for proper functioning on NixOS? I guess lot of NixOS users have a fix for this, but isn't this the favorable approach?