### PR TITLE
core: add InfoConfirm

### DIFF
--- a/core/src/apps/common/confirm.py
+++ b/core/src/apps/common/confirm.py
@@ -71,7 +71,7 @@ async def info_confirm(
         else:
             result = await ctx.wait(dialog)
 
-        if result == INFO:
+        if result is INFO:
             await info_func(ctx)
 
         else:

--- a/core/src/apps/management/recovery_device/homescreen.py
+++ b/core/src/apps/management/recovery_device/homescreen.py
@@ -74,10 +74,6 @@ async def _request_secret(
 
     secret = None
     while secret is None:
-        # show info dialog for Slip39 Advanced - what shares are to be entered
-        if backup_type == BackupType.Slip39_Advanced:
-            await _show_remaining_groups_and_shares(ctx)
-
         # ask for mnemonic words one by one
         words = await layout.request_mnemonic(ctx, word_count, backup_type)
 
@@ -243,7 +239,9 @@ async def _request_share_next_screen(ctx: wire.Context) -> None:
 
     if group_count > 1:
         content = layout.RecoveryHomescreen("More shares needed")
-        await layout.homescreen_dialog(ctx, content, "Enter share")
+        await layout.homescreen_dialog(
+            ctx, content, "Enter", _show_remaining_groups_and_shares
+        )
     else:
         if remaining[0] == 1:
             text = "1 more share"
@@ -254,6 +252,9 @@ async def _request_share_next_screen(ctx: wire.Context) -> None:
 
 
 async def _show_remaining_groups_and_shares(ctx: wire.Context) -> None:
+    """
+    Show info dialog for Slip39 Advanced - what shares are to be entered.
+    """
     shares_remaining = storage.recovery.fetch_slip39_remaining_shares()
 
     identifiers = []

--- a/core/src/apps/management/recovery_device/layout.py
+++ b/core/src/apps/management/recovery_device/layout.py
@@ -13,14 +13,14 @@ from .keyboard_slip39 import Slip39Keyboard
 from .recover import RecoveryAborted
 
 from apps.common import storage
-from apps.common.confirm import confirm, require_confirm
+from apps.common.confirm import confirm, info_confirm, require_confirm
 from apps.common.layout import show_success, show_warning
 
 if __debug__:
     from apps.debug import input_signal
 
 if False:
-    from typing import List, Optional
+    from typing import List, Optional, Callable
     from trezor.messages.ResetDevice import EnumTypeBackupType
 
 
@@ -144,7 +144,7 @@ async def show_remaining_shares(
                 text.normal(word)
             pages.append(text)
 
-    return await confirm(ctx, Paginated(pages), confirm="Continue", cancel=None)
+    return await confirm(ctx, Paginated(pages), cancel=None)
 
 
 async def show_group_share_success(
@@ -271,16 +271,30 @@ class RecoveryHomescreen(ui.Component):
 
 
 async def homescreen_dialog(
-    ctx: wire.Context, homepage: RecoveryHomescreen, button_label: str
+    ctx: wire.Context,
+    homepage: RecoveryHomescreen,
+    button_label: str,
+    info_func: Callable = None,
 ) -> None:
     while True:
-        continue_recovery = await confirm(
-            ctx,
-            homepage,
-            code=ButtonRequestType.RecoveryHomepage,
-            confirm=button_label,
-            major_confirm=True,
-        )
+        if info_func:
+            continue_recovery = await info_confirm(
+                ctx,
+                homepage,
+                code=ButtonRequestType.RecoveryHomepage,
+                confirm=button_label,
+                info_func=info_func,
+                info="Info",
+                cancel="Abort",
+            )
+        else:
+            continue_recovery = await confirm(
+                ctx,
+                homepage,
+                code=ButtonRequestType.RecoveryHomepage,
+                confirm=button_label,
+                major_confirm=True,
+            )
         if continue_recovery:
             # go forward in the recovery process
             break

--- a/tests/common.py
+++ b/tests/common.py
@@ -90,13 +90,6 @@ def recovery_enter_shares(debug, shares, groups=False):
     debug.press_yes()
     # Enter shares
     for index, share in enumerate(shares):
-        if groups and index >= 1:
-            # confirm remaining shares
-            debug.swipe_down()
-            code = yield
-            assert code == B.Other
-            debug.press_yes()
-
         code = yield
         assert code == B.MnemonicInput
         # Enter mnemonic words


### PR DESCRIPTION
This adds another Confirm dialog with an Info button and closes #512.

Although the Confirm dialogs bloat a little I think we might use the Info button somwhere else as well. Or we refactor this as soon as we have a new styleguide.