### PR TITLE
Add Connect support indicator for Ritocoin

### DIFF
--- a/common/defs/support.json
+++ b/common/defs/support.json
@@ -32,6 +32,7 @@
       "bitcoin:PIVX": true,
       "bitcoin:POLIS": true,
       "bitcoin:PTC": true,
+      "bitcoin:RITO": true,
       "bitcoin:RVN": true,
       "bitcoin:TAZ": true,
       "bitcoin:TBCH": true,


### PR DESCRIPTION
The wallet software is ready now. It's a Trezor-only wallet. It's currently deployed for another coin (FLO) at https://wallet.chaintek.net. It's my understanding that this PR is needed to get Ritocoin details pulled into Trezor Connect so the wallet can work for that coin as well.