### PR TITLE
Modify shell.nix to work with pipenv

### DIFF
--- a/shell.nix
+++ b/shell.nix
@@ -1,44 +1,27 @@
 with import <nixpkgs> {};
 
-let
-  MyPython = python3.withPackages(ps: [
-    ps.Mako
-    ps.Pyro4
-    ps.black
-    ps.coverage
-    ps.ed25519
-    ps.flake8
-    ps.flaky
-    ps.graphviz
-    ps.isort
-    ps.mock
-    ps.munch
-    ps.pillow
-    ps.pytest
-    ps.pytest-random-order
-    ps.trezor
-  ]);
-in
-  stdenv.mkDerivation {
-    name = "trezor-firmware-dev";
-    buildInputs = [
-      MyPython
-      SDL2
-      SDL2_image
-      autoflake
-      check
-      clang-tools
-      gcc
-      gcc-arm-embedded
-      gnumake
-      graphviz
-      openssl
-      pipenv
-      pkgconfig
-      protobuf
-      python2Packages.demjson
-      scons
-      valgrind
-      zlib
-    ];
-  }
+stdenv.mkDerivation {
+name = "trezor-firmware-dev";
+buildInputs = [
+  SDL2
+  SDL2_image
+  autoflake
+  check
+  clang-tools
+  gcc
+  gcc-arm-embedded
+  gnumake
+  graphviz
+  openssl
+  pipenv
+  pkgconfig
+  protobuf
+  python2Packages.demjson
+  scons
+  valgrind
+  zlib
+];
+shellHook = ''
+  pipenv shell
+'';
+}


### PR DESCRIPTION
This removes Python dependencies from the nix-shell and runs `pipenv shell` after entering the nix shell.

This has a few advantages:
1. All Python dependencies are locked based on the Pipfile.lock file.
1. `trezorctl` is taken directly from master. ([here's why](https://github.com/trezor/trezor-firmware/blob/78041d261b6d342f78e4359353cb5b2c1f01b1ed/Pipfile#L8))
