### PR TITLE
core/recovery: fix Info dialog

### DIFF
--- a/core/src/apps/management/recovery_device/homescreen.py
+++ b/core/src/apps/management/recovery_device/homescreen.py
@@ -215,10 +215,10 @@ async def _show_remaining_groups_and_shares(ctx: wire.Context) -> None:
     share = None
     for i, r in enumerate(shares_remaining):
         if 0 < r < slip39.MAX_SHARE_COUNT:
+            m = storage.recovery_shares.fetch_group(i)[0]
             if not share:
-                m = storage.recovery_shares.fetch_group(i)[0]
                 share = slip39.decode_mnemonic(m)
-            identifier = mnemonic.split(" ")[0:3]
+            identifier = m.split(" ")[0:3]
             identifiers.append([r, identifier])
         elif r == slip39.MAX_SHARE_COUNT:
             identifier = storage.recovery_shares.fetch_group(first_entered_index)[


### PR DESCRIPTION
If something does not have a test it does not work :(. We need to do #487 as soon as possible.

I don't like naming the variable just `m`, but I didn't want to shadow the module name. Should I come up with another name? Or keep `mnemonic` since we are not using the module in the function?

closes #562
