### PR TITLE
Reboot the device into the recovery mode as soon as possible

### DIFF
--- a/core/src/apps/management/recovery_device/__init__.py
+++ b/core/src/apps/management/recovery_device/__init__.py
@@ -1,4 +1,4 @@
-from trezor import config, ui, wire
+from trezor import config, restart, ui, wire
 from trezor.messages import ButtonRequestType
 from trezor.messages.Success import Success
 from trezor.pin import pin_to_int
@@ -11,13 +11,12 @@ from apps.common.request_pin import (
     request_pin_confirm,
     show_pin_invalid,
 )
-from apps.management.recovery_device.homescreen import recovery_process
 
 if False:
     from trezor.messages.RecoveryDevice import RecoveryDevice
 
 
-async def recovery_device(ctx: wire.Context, msg: RecoveryDevice) -> Success:
+async def recovery_device(ctx: wire.Context, msg: RecoveryDevice) -> None:
     """
     Recover BIP39/SLIP39 seed into empty device.
     Recovery is also possible with replugged Trezor. We call this process Persistance.
@@ -51,9 +50,10 @@ async def recovery_device(ctx: wire.Context, msg: RecoveryDevice) -> Success:
     if msg.dry_run:
         storage.recovery.set_dry_run(msg.dry_run)
 
-    result = await recovery_process(ctx)
+    await ctx.write(Success("Device has entered the recovery mode successfully."))
 
-    return result
+    # reboot the device to start in recovery mode
+    await restart.restart()
 
 
 def _check_state(msg: RecoveryDevice) -> None:

--- a/core/src/apps/management/recovery_device/homescreen.py
+++ b/core/src/apps/management/recovery_device/homescreen.py
@@ -1,4 +1,4 @@
-from trezor import loop, utils, wire
+from trezor import restart, utils, wire
 from trezor.crypto import slip39
 from trezor.crypto.hashlib import sha256
 from trezor.errors import MnemonicError
@@ -23,10 +23,7 @@ async def recovery_homescreen() -> None:
     try:
         await recovery_process(ctx)
     finally:
-        # clear the loop state, so loop.run will exit
-        loop.clear()
-        # clear the registered wire handlers to avoid conflicts
-        wire.clear()
+        await restart.restart()
 
 
 async def recovery_process(ctx: wire.Context) -> Success:

--- a/core/src/main.py
+++ b/core/src/main.py
@@ -82,6 +82,7 @@ from trezor import loop, wire, workflow
 from apps.common.storage import recovery
 
 while True:
+    modules = utils.unimport_begin()
     # initialize the wire codec
     wire.setup(usb.iface_wire)
     if __debug__:
@@ -93,5 +94,5 @@ while True:
     else:
         _boot_default()
     loop.run()
-
     # loop is empty, reboot
+    utils.unimport_end(modules)

--- a/core/src/trezor/restart.py
+++ b/core/src/trezor/restart.py
@@ -1,0 +1,27 @@
+from trezor import loop, wire, workflow
+
+if __debug__:
+    from trezor import log
+
+
+async def _perform_restart() -> None:
+    if __debug__:
+        log.debug(__name__, "restarting")
+
+    workflow.clear()
+    loop.clear()
+    wire.clear()
+
+
+class no_return(loop.Syscall):
+    def handle(self, task: loop.Task) -> None:
+        pass
+
+
+def restart() -> loop.Task:
+    """
+    Clears the loop state, leading to main.py
+    performing the booting sequence again.
+    """
+    loop.schedule(_perform_restart())
+    return no_return()

--- a/core/src/trezor/wire/__init__.py
+++ b/core/src/trezor/wire/__init__.py
@@ -40,7 +40,7 @@ from trezor import log, loop, messages, ui, utils, workflow
 from trezor.messages import FailureType
 from trezor.messages.Failure import Failure
 from trezor.wire import codec_v1
-from trezor.wire.errors import Error
+from trezor.wire.errors import ActionCancelled, Error
 
 # Import all errors into namespace, so that `wire.Error` is available from
 # other packages.
@@ -339,7 +339,10 @@ async def handle_session(iface: WireInterface, session_id: int) -> None:
                     # - the first workflow message was not a valid protobuf
                     # - workflow raised some kind of an exception while running
                     if __debug__:
-                        log.exception(__name__, exc)
+                        if isinstance(exc, ActionCancelled):
+                            log.debug(__name__, "cancelled: {}".format(exc.message))
+                        else:
+                            log.exception(__name__, exc)
                     res_msg = failure(exc)
 
                 finally:

--- a/core/src/trezor/workflow.py
+++ b/core/src/trezor/workflow.py
@@ -27,6 +27,8 @@ def on_start(workflow: loop.Task) -> None:
     Call after creating a workflow task, but before running it.  You should
     make sure to always call `on_close` when the task is finished.
     """
+    if __debug__:
+        log.debug(__name__, "start: %s", workflow)
     # Take note that this workflow task is running.
     tasks.add(workflow)
 
@@ -73,6 +75,23 @@ def close_default() -> None:
             log.debug(__name__, "close default")
         # We let the `_finalize_default` reset the global.
         loop.close(default_task)
+
+
+def clear() -> None:
+    """
+    Call close on default workflow, clear default constructor and the task list.
+    """
+    global default_task
+    global default_constructor
+    if __debug__:
+        log.debug(__name__, "resetting default")
+
+    close_default()
+    # We need to set the default_constructor to None so the
+    # the default is not started again in `start_default.`
+    default_constructor = None
+    default_task = None
+    tasks.clear()
 
 
 def _finalize_default(task, value) -> None:

--- a/python/src/trezorlib/device.py
+++ b/python/src/trezorlib/device.py
@@ -156,6 +156,7 @@ def recover(
         except Cancelled:
             res = client.call(proto.Cancel())
 
+    time.sleep(1)
     client.init_device()
     return res
 


### PR DESCRIPTION
This is a PoC to get your opinions on this. This PR restarts the device into the recovery mode as soon as the RecoveryDevice msg is processed.

This changes the current behaviour. The host calls RecoveryDevice and Trezor responds with `Success("Device has entered the recovery mode successfully.")` and the device reboots itself to the recovery mode, which is a software equivalent to a replug.

I believe this the way we should go, because it brings consistency into the recovery process. But we need to discuss how to solve #530 / #232.

The tests are obviously failing because of #530 / #232. Updates #558.

