### PR TITLE
Deploy firmwares and emulators to an internal website

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -29,7 +29,7 @@ stages:
   - deploy
 
 before_script:
-  - pipenv sync
+  - command -v pipenv >/dev/null && pipenv sync
 
 include:
   - ci/environment.yml

--- a/ci/build.yml
+++ b/ci/build.yml
@@ -126,17 +126,17 @@ build core unix regular darwin:
   tags:
     - darwin
   script:
-    - sed -i '' 's/pkg-config/pkg-config --static/' core/SConscript.unix
     - . $HOME/.nix-profile/etc/profile.d/nix.sh
     - nix-shell --run "cd core && make build_unix"
-    - cp -v core/build/unix/micropython trezor-darwin-$VERSION-$CI_COMMIT_SHORT_SHA.bin
+    - mkdir -p TrezorEmu-$CI_COMMIT_SHORT_SHA.app/Contents/{MacOS,libs}
+    - cp -v core/build/unix/micropython TrezorEmu-$CI_COMMIT_SHORT_SHA.app/Contents/MacOS/TrezorEmu-$CI_COMMIT_SHORT_SHA
+    - dylibbundler -of -b -i /usr/lib/system -d TrezorEmu-$CI_COMMIT_SHORT_SHA.app/Contents/libs -x TrezorEmu-$CI_COMMIT_SHORT_SHA.app/Contents/MacOS/TrezorEmu-$CI_COMMIT_SHORT_SHA
   allow_failure: true
   artifacts:
     name: "$CI_JOB_NAME-$CI_COMMIT_SHORT_SHA"
     paths:
-      - trezor-darwin-*
+      - TrezorEmu-$CI_COMMIT_SHORT_SHA.app
     expire_in: 1 week
-
 
 # Crypto
 

--- a/ci/build.yml
+++ b/ci/build.yml
@@ -121,6 +121,22 @@ core unix frozen debug build:
     untracked: true
     expire_in: 1 week
 
+build core unix regular darwin:
+  stage: build
+  tags:
+    - darwin
+  script:
+    - sed -i '' 's/pkg-config/pkg-config --static/' core/SConscript.unix
+    - . $HOME/.nix-profile/etc/profile.d/nix.sh
+    - nix-shell --run "cd core && make build_unix"
+    - cp -v core/build/unix/micropython trezor-darwin-$VERSION-$CI_COMMIT_SHORT_SHA.bin
+  allow_failure: true
+  artifacts:
+    name: "$CI_JOB_NAME-$CI_COMMIT_SHORT_SHA"
+    paths:
+      - trezor-darwin-*
+    expire_in: 1 week
+
 
 # Crypto
 

--- a/ci/build.yml
+++ b/ci/build.yml
@@ -121,13 +121,13 @@ core unix frozen debug build:
     untracked: true
     expire_in: 1 week
 
-build core unix regular darwin:
+build core unix frozen regular darwin:
   stage: build
   tags:
     - darwin
   script:
     - . $HOME/.nix-profile/etc/profile.d/nix.sh
-    - nix-shell --run "cd core && make build_unix"
+    - nix-shell --run "cd core && make build_unix_frozen"
     - mkdir -p TrezorEmu-$CI_COMMIT_SHORT_SHA.app/Contents/{MacOS,libs}
     - cp -v core/build/unix/micropython TrezorEmu-$CI_COMMIT_SHORT_SHA.app/Contents/MacOS/TrezorEmu-$CI_COMMIT_SHORT_SHA
     - dylibbundler -of -b -i /usr/lib/system -d TrezorEmu-$CI_COMMIT_SHORT_SHA.app/Contents/libs -x TrezorEmu-$CI_COMMIT_SHORT_SHA.app/Contents/MacOS/TrezorEmu-$CI_COMMIT_SHORT_SHA

--- a/ci/build.yml
+++ b/ci/build.yml
@@ -46,11 +46,11 @@ core fw regular build:
     - pipenv run make sizecheck
     - cd ..
     - export VERSION=$(./tools/version.sh core/embed/firmware/version.h)
-    - cp core/build/firmware/firmware.bin trezor-$VERSION-$CI_COMMIT_SHORT_SHA.bin
+    - cp core/build/firmware/firmware.bin trezor-fw-regular-$VERSION-$CI_COMMIT_SHORT_SHA.bin
   artifacts:
     name: "$CI_JOB_NAME-$CI_COMMIT_SHORT_SHA"
     paths:
-    - trezor-*.*.*-$CI_COMMIT_SHORT_SHA.bin
+    - trezor-fw-regular-*.*.*-$CI_COMMIT_SHORT_SHA.bin
     expire_in: 1 week
 
 core fw btconly build:
@@ -65,11 +65,11 @@ core fw btconly build:
     - cd ..
     - pipenv run ./tools/check-bitcoin-only core/build/firmware/firmware-bitcoinonly.bin
     - export VERSION=$(./tools/version.sh core/embed/firmware/version.h)
-    - cp core/build/firmware/firmware-bitcoinonly.bin trezor-$VERSION-$CI_COMMIT_SHORT_SHA-bitcoinonly.bin
+    - cp core/build/firmware/firmware-bitcoinonly.bin trezor-fw-btconly-$VERSION-$CI_COMMIT_SHORT_SHA.bin
   artifacts:
     name: "$CI_JOB_NAME-$CI_COMMIT_SHORT_SHA"
     paths:
-    - trezor-*.*.*-$CI_COMMIT_SHORT_SHA-bitcoinonly.bin
+    - trezor-fw-btconly-*.*.*-$CI_COMMIT_SHORT_SHA.bin
     expire_in: 1 week
 
 core unix regular build:
@@ -131,11 +131,12 @@ build core unix frozen regular darwin:
     - mkdir -p TrezorEmu-$CI_COMMIT_SHORT_SHA.app/Contents/{MacOS,libs}
     - cp -v core/build/unix/micropython TrezorEmu-$CI_COMMIT_SHORT_SHA.app/Contents/MacOS/TrezorEmu-$CI_COMMIT_SHORT_SHA
     - dylibbundler -of -b -i /usr/lib/system -d TrezorEmu-$CI_COMMIT_SHORT_SHA.app/Contents/libs -x TrezorEmu-$CI_COMMIT_SHORT_SHA.app/Contents/MacOS/TrezorEmu-$CI_COMMIT_SHORT_SHA
+    - mv TrezorEmu-$CI_COMMIT_SHORT_SHA.app trezor-emu-regular-macos-$VERSION-$CI_COMMIT_SHORT_SHA.app
   allow_failure: true
   artifacts:
     name: "$CI_JOB_NAME-$CI_COMMIT_SHORT_SHA"
     paths:
-      - TrezorEmu-$CI_COMMIT_SHORT_SHA.app
+      - trezor-emu-regular-macos-$VERSION-$CI_COMMIT_SHORT_SHA.app
     expire_in: 1 week
 
 # Crypto
@@ -174,11 +175,11 @@ legacy fw regular build:
     - pipenv run make -C demo
     - cd ..
     - export VERSION=$(./tools/version.sh legacy/firmware/version.h)
-    - cp legacy/firmware/trezor.bin trezor-$VERSION-$CI_COMMIT_SHORT_SHA.bin
+    - mv legacy/firmware/trezor.bin trezor-fw-regular-$VERSION-$CI_COMMIT_SHORT_SHA.bin
   artifacts:
     name: "$CI_JOB_NAME-$CI_COMMIT_SHORT_SHA"
     paths:
-    - trezor-*.*.*-$CI_COMMIT_SHORT_SHA.bin
+    - trezor-fw-regular-*.*.*-$CI_COMMIT_SHORT_SHA.bin
     expire_in: 1 week
 
 legacy fw debug build:
@@ -204,11 +205,11 @@ legacy fw btconly build:
     - cd ..
     - pipenv run ./tools/check-bitcoin-only legacy/firmware/trezor-bitcoinonly.bin
     - export VERSION=$(./tools/version.sh legacy/firmware/version.h)
-    - cp legacy/firmware/trezor-bitcoinonly.bin trezor-$VERSION-$CI_COMMIT_SHORT_SHA-bitcoinonly.bin
+    - mv legacy/firmware/trezor-bitcoinonly.bin trezor-fw-btconly-$VERSION-$CI_COMMIT_SHORT_SHA.bin
   artifacts:
     name: "$CI_JOB_NAME-$CI_COMMIT_SHORT_SHA"
     paths:
-    - trezor-*.*.*-$CI_COMMIT_SHORT_SHA-bitcoinonly.bin
+    - trezor-fw-btconly-*.*.*-$CI_COMMIT_SHORT_SHA.bin
     expire_in: 1 week
 
 legacy emu regular build:

--- a/ci/deploy.yml
+++ b/ci/deploy.yml
@@ -2,10 +2,90 @@ image: registry.gitlab.com/satoshilabs/trezor/trezor-firmware/environment
 
 # Core
 
-core upgrade tests deploy:
+core emu regular deploy:
   stage: deploy
   variables:
-    DEPLOY_DIRECTORY: "${DEPLOY_BASE_DIR}/upgrade_tests"
+    DEPLOY_DIRECTORY: "branches/${CI_COMMIT_REF_NAME}/emulators/core"
+  before_script: []  # no pipenv
+  when: manual
+  dependencies:
+    - core unix frozen regular build
+  script:
+    - export VERSION=$(./tools/version.sh core/embed/firmware/version.h)
+    - export NAME="trezor-emu-regular-$VERSION-$CI_COMMIT_SHORT_SHA"
+    - echo "Deploying to ${DEPLOY_DIRECTORY}/$NAME"
+    - mv core/build/unix/micropython $NAME
+    - mkdir -p "${DEPLOY_BASE_DIR}/${DEPLOY_DIRECTORY}"
+    - echo "${DEPLOY_BASE_DIR}/${DEPLOY_DIRECTORY}/$NAME"
+    - rsync --delete -va $NAME "${DEPLOY_BASE_DIR}/${DEPLOY_DIRECTORY}/$NAME"
+  tags:
+    - deploy
+
+core fw regular deploy:
+  stage: deploy
+  variables:
+    DEPLOY_DIRECTORY: "branches/${CI_COMMIT_REF_NAME}/firmwares/core"
+  before_script: []  # no pipenv
+  when: manual
+  dependencies:
+    - core fw regular build
+  script:
+    - export VERSION=$(./tools/version.sh core/embed/firmware/version.h)
+    - export NAME="trezor-fw-regular-$VERSION-$CI_COMMIT_SHORT_SHA.bin"
+    - echo "Deploying to ${DEPLOY_DIRECTORY}/$NAME"
+    - mkdir -p "${DEPLOY_BASE_DIR}/${DEPLOY_DIRECTORY}"
+    - rsync --delete -va $NAME "${DEPLOY_BASE_DIR}/${DEPLOY_DIRECTORY}/$NAME"
+  tags:
+    - deploy
+
+
+# Legacy
+
+legacy emu regular deploy:
+  stage: deploy
+  variables:
+    DEPLOY_DIRECTORY: "branches/${CI_COMMIT_REF_NAME}/emulators/legacy"
+  before_script: []  # no pipenv
+  when: manual
+  dependencies:
+    - legacy emu regular build
+  script:
+    - export VERSION=$(./tools/version.sh legacy/firmware/version.h)
+    - export NAME="trezor-emu-regular-$VERSION-$CI_COMMIT_SHORT_SHA"
+    - echo "Deploying to ${DEPLOY_DIRECTORY}/$NAME"
+    - mv legacy/firmware/trezor.elf $NAME
+    - mkdir -p "${DEPLOY_BASE_DIR}/${DEPLOY_DIRECTORY}"
+    - rsync --delete -va $NAME "${DEPLOY_BASE_DIR}/${DEPLOY_DIRECTORY}/$NAME"
+  tags:
+    - deploy
+
+legacy fw regular deploy:
+  stage: deploy
+  variables:
+    DEPLOY_DIRECTORY: "branches/${CI_COMMIT_REF_NAME}/firmwares/legacy"
+  before_script: []  # no pipenv
+  when: manual
+  dependencies:
+    - legacy fw regular build
+  script:
+    - export VERSION=$(./tools/version.sh legacy/firmware/version.h)
+    - export NAME="trezor-fw-regular-$VERSION-$CI_COMMIT_SHORT_SHA.bin"
+    - echo "Deploying to ${DEPLOY_DIRECTORY}/$NAME"
+    - mkdir -p "${DEPLOY_BASE_DIR}/${DEPLOY_DIRECTORY}"
+    - rsync --delete -va $NAME "${DEPLOY_BASE_DIR}/${DEPLOY_DIRECTORY}/$NAME"
+  tags:
+    - deploy
+
+
+# Release deploys
+# These can be run only on actual releases (based on tags)
+
+## Upgrade tests
+
+upgrade tests core deploy:
+  stage: deploy
+  variables:
+    DEPLOY_PATH: "${DEPLOY_BASE_DIR}upgrade_tests/"
   before_script: []  # no pipenv
   when: manual
   dependencies:
@@ -13,49 +93,16 @@ core upgrade tests deploy:
   script:
     - TAG=`git tag --points-at HEAD | sed "s/\//-/"`
     - "[[ ! $TAG =~ 'core' ]] && echo 'Tag is not core/*: exiting.' && exit 1"
-    - DEST=${DEPLOY_DIRECTORY}/trezor-emu-`git tag --points-at HEAD | sed "s/\//-/"`
+    - DEST=${DEPLOY_PATH}/trezor-emu-`git tag --points-at HEAD | sed "s/\//-/"`
     - echo "Deploying to $DEST"
     - rsync --delete -va core/build/unix/micropython "$DEST"
   tags:
     - deploy
 
-core emu regular deploy:
+upgrade tests legacy deploy:
   stage: deploy
   variables:
-    DEPLOY_DIRECTORY: "${DEPLOY_BASE_DIR}core/emulators/${CI_COMMIT_REF_NAME}"
-  before_script: []  # no pipenv
-  when: manual
-  dependencies:
-    - core unix frozen regular build
-  script:
-    - echo "Deploying to ${DEPLOY_DIRECTORY}/`date -I`-core-emu-${CI_COMMIT_SHORT_SHA}"
-    - mkdir -p ${DEPLOY_DIRECTORY}
-    - rsync --delete -va core/build/unix/micropython "${DEPLOY_DIRECTORY}/`date -I`-core-emu-${CI_COMMIT_SHORT_SHA}"
-  tags:
-    - deploy
-
-core fw regular deploy:
-  stage: deploy
-  variables:
-    DEPLOY_DIRECTORY: "${DEPLOY_BASE_DIR}core/firmwares/${CI_COMMIT_REF_NAME}"
-  before_script: []  # no pipenv
-  when: manual
-  dependencies:
-    - core fw regular build
-  script:
-    - echo "Deploying to ${DEPLOY_DIRECTORY}/`date -I`-core-firmware-${CI_COMMIT_SHORT_SHA}"
-    - mkdir -p ${DEPLOY_DIRECTORY}
-    - rsync --delete -va core/build/firmware/firmware.bin "${DEPLOY_DIRECTORY}/`date -I`-core-firmware-${CI_COMMIT_SHORT_SHA}"
-  tags:
-    - deploy
-
-
-# Legacy
-
-legacy to upgrade tests deploy:
-  stage: deploy
-  variables:
-    DEPLOY_DIRECTORY: "${DEPLOY_BASE_DIR}/upgrade_tests"
+    DEPLOY_PATH: "${DEPLOY_BASE_DIR}upgrade_tests/"
   before_script: []  # no pipenv
   when: manual
   dependencies:
@@ -63,36 +110,91 @@ legacy to upgrade tests deploy:
   script:
     - TAG=`git tag --points-at HEAD | sed "s/\//-/"`
     - "[[ ! $TAG =~ 'legacy' ]] && echo 'Tag is not legacy/*: exiting.' && exit 1"
-    - DEST=${DEPLOY_DIRECTORY}/trezor-emu-`git tag --points-at HEAD | sed "s/\//-/"`
+    - DEST=${DEPLOY_PATH}/trezor-emu-`git tag --points-at HEAD | sed "s/\//-/"`
     - echo "Deploying to $DEST"
     - rsync --delete -va legacy/firmware/trezor.elf "$DEST"
 
-legacy emu regular deploy:
+## Releases
+
+### Core
+
+release core emu regular deploy:
   stage: deploy
   variables:
-    DEPLOY_DIRECTORY: "${DEPLOY_BASE_DIR}legacy/emulators/${CI_COMMIT_REF_NAME}"
+    DEPLOY_DIRECTORY: "releases/${CI_COMMIT_REF_NAME}/emulators"
+  before_script: []  # no pipenv
+  when: manual
+  dependencies:
+    - core unix frozen regular build
+  script:
+    - TAG=`git tag --points-at HEAD | sed "s/\//-/"`
+    - "[[ ! $TAG =~ 'core' ]] && echo 'Tag is not core/*: exiting.' && exit 1"
+    - export VERSION=$(./tools/version.sh core/embed/firmware/version.h)
+    - export NAME="trezor-emu-regular-$VERSION-$CI_COMMIT_SHORT_SHA"
+    - echo "Deploying to ${DEPLOY_DIRECTORY}/$NAME"
+    - mv core/build/unix/micropython $NAME
+    - mkdir -p "${DEPLOY_BASE_DIR}/${DEPLOY_DIRECTORY}"
+    - rsync --delete -va $NAME "${DEPLOY_BASE_DIR}/${DEPLOY_DIRECTORY}/$NAME"
+  tags:
+    - deploy
+
+release core fw regular deploy:
+  stage: deploy
+  variables:
+    DEPLOY_DIRECTORY: "releases/${CI_COMMIT_REF_NAME}/firmwares"
+  before_script: []  # no pipenv
+  when: manual
+  dependencies:
+    - core fw regular build
+  script:
+    - TAG=`git tag --points-at HEAD | sed "s/\//-/"`
+    - "[[ ! $TAG =~ 'core' ]] && echo 'Tag is not core/*: exiting.' && exit 1"
+    - export VERSION=$(./tools/version.sh core/embed/firmware/version.h)
+    - export NAME="trezor-fw-regular-$VERSION-$CI_COMMIT_SHORT_SHA.bin"
+    - echo "Deploying to ${DEPLOY_DIRECTORY}/$NAME"
+    - mkdir -p "${DEPLOY_BASE_DIR}/${DEPLOY_DIRECTORY}"
+    - rsync --delete -va $NAME "${DEPLOY_BASE_DIR}/${DEPLOY_DIRECTORY}/$NAME"
+  tags:
+    - deploy
+
+
+### Legacy
+
+release legacy emu regular deploy:
+  stage: deploy
+  variables:
+    DEPLOY_DIRECTORY: "releases/${CI_COMMIT_REF_NAME}/emulators"
   before_script: []  # no pipenv
   when: manual
   dependencies:
     - legacy emu regular build
   script:
-    - echo "Deploying to ${DEPLOY_DIRECTORY}/`date -I`-legacy-emu-${CI_COMMIT_SHORT_SHA}"
-    - mkdir -p ${DEPLOY_DIRECTORY}
-    - rsync --delete -va legacy/firmware/trezor.elf "${DEPLOY_DIRECTORY}/`date -I`-legacy-emu-${CI_COMMIT_SHORT_SHA}"
+    - TAG=`git tag --points-at HEAD | sed "s/\//-/"`
+    - "[[ ! $TAG =~ 'legacy' ]] && echo 'Tag is not legacy/*: exiting.' && exit 1"
+    - export VERSION=$(./tools/version.sh legacy/firmware/version.h)
+    - export NAME="trezor-emu-regular-$VERSION-$CI_COMMIT_SHORT_SHA"
+    - echo "Deploying to ${DEPLOY_DIRECTORY}/$NAME"
+    - mv legacy/firmware/trezor.elf $NAME
+    - mkdir -p "${DEPLOY_BASE_DIR}/${DEPLOY_DIRECTORY}"
+    - rsync --delete -va $NAME "${DEPLOY_BASE_DIR}/${DEPLOY_DIRECTORY}/$NAME"
   tags:
     - deploy
 
-legacy fw regular deploy:
+release legacy fw regular deploy:
   stage: deploy
   variables:
-    DEPLOY_DIRECTORY: "${DEPLOY_BASE_DIR}legacy/firmwares/${CI_COMMIT_REF_NAME}"
+    DEPLOY_DIRECTORY: "releases/${CI_COMMIT_REF_NAME}/firmwares"
   before_script: []  # no pipenv
   when: manual
   dependencies:
     - legacy fw regular build
   script:
-    - echo "Deploying to ${DEPLOY_DIRECTORY}/`date -I`-legacy-firmware-${CI_COMMIT_SHORT_SHA}"
-    - mkdir -p ${DEPLOY_DIRECTORY}
-    - rsync --delete -va legacy/firmware/trezor.bin "${DEPLOY_DIRECTORY}/`date -I`-legacy-firmware-${CI_COMMIT_SHORT_SHA}"
+    - TAG=`git tag --points-at HEAD | sed "s/\//-/"`
+    - "[[ ! $TAG =~ 'legacy' ]] && echo 'Tag is not legacy/*: exiting.' && exit 1"
+    - export VERSION=$(./tools/version.sh legacy/firmware/version.h)
+    - export NAME="trezor-fw-regular-$VERSION-$CI_COMMIT_SHORT_SHA.bin"
+    - echo "Deploying to ${DEPLOY_DIRECTORY}/$NAME"
+    - mkdir -p "${DEPLOY_BASE_DIR}/${DEPLOY_DIRECTORY}"
+    - rsync --delete -va $NAME "${DEPLOY_BASE_DIR}/${DEPLOY_DIRECTORY}/$NAME"
   tags:
     - deploy

--- a/ci/deploy.yml
+++ b/ci/deploy.yml
@@ -1,142 +1,6 @@
 image: registry.gitlab.com/satoshilabs/trezor/trezor-firmware/environment
 
-# Core
-
-core emu regular deploy:
-  stage: deploy
-  variables:
-    DEPLOY_DIRECTORY: "branches/${CI_COMMIT_REF_NAME}/emulators/core"
-  before_script: []  # no pipenv
-  when: manual
-  dependencies:
-    - core unix frozen regular build
-  script:
-    - export VERSION=$(./tools/version.sh core/embed/firmware/version.h)
-    - export NAME="trezor-emu-regular-$VERSION-$CI_COMMIT_SHORT_SHA"
-    - echo "Deploying to ${DEPLOY_DIRECTORY}/$NAME"
-    - mv core/build/unix/micropython $NAME
-    - mkdir -p "${DEPLOY_BASE_DIR}/${DEPLOY_DIRECTORY}"
-    - echo "${DEPLOY_BASE_DIR}/${DEPLOY_DIRECTORY}/$NAME"
-    - rsync --delete -va $NAME "${DEPLOY_BASE_DIR}/${DEPLOY_DIRECTORY}/$NAME"
-  tags:
-    - deploy
-
-core fw regular deploy:
-  stage: deploy
-  variables:
-    DEPLOY_DIRECTORY: "branches/${CI_COMMIT_REF_NAME}/firmwares/core"
-  before_script: []  # no pipenv
-  when: manual
-  dependencies:
-    - core fw regular build
-  script:
-    - export VERSION=$(./tools/version.sh core/embed/firmware/version.h)
-    - export NAME="trezor-fw-regular-$VERSION-$CI_COMMIT_SHORT_SHA.bin"
-    - echo "Deploying to ${DEPLOY_DIRECTORY}/$NAME"
-    - mkdir -p "${DEPLOY_BASE_DIR}/${DEPLOY_DIRECTORY}"
-    - rsync --delete -va $NAME "${DEPLOY_BASE_DIR}/${DEPLOY_DIRECTORY}/$NAME"
-  tags:
-    - deploy
-
-
-# Legacy
-
-legacy emu regular deploy:
-  stage: deploy
-  variables:
-    DEPLOY_DIRECTORY: "branches/${CI_COMMIT_REF_NAME}/emulators/legacy"
-  before_script: []  # no pipenv
-  when: manual
-  dependencies:
-    - legacy emu regular build
-  script:
-    - export VERSION=$(./tools/version.sh legacy/firmware/version.h)
-    - export NAME="trezor-emu-regular-$VERSION-$CI_COMMIT_SHORT_SHA"
-    - echo "Deploying to ${DEPLOY_DIRECTORY}/$NAME"
-    - mv legacy/firmware/trezor.elf $NAME
-    - mkdir -p "${DEPLOY_BASE_DIR}/${DEPLOY_DIRECTORY}"
-    - rsync --delete -va $NAME "${DEPLOY_BASE_DIR}/${DEPLOY_DIRECTORY}/$NAME"
-  tags:
-    - deploy
-
-legacy fw regular deploy:
-  stage: deploy
-  variables:
-    DEPLOY_DIRECTORY: "branches/${CI_COMMIT_REF_NAME}/firmwares/legacy"
-  before_script: []  # no pipenv
-  when: manual
-  dependencies:
-    - legacy fw regular build
-  script:
-    - export VERSION=$(./tools/version.sh legacy/firmware/version.h)
-    - export NAME="trezor-fw-regular-$VERSION-$CI_COMMIT_SHORT_SHA.bin"
-    - echo "Deploying to ${DEPLOY_DIRECTORY}/$NAME"
-    - mkdir -p "${DEPLOY_BASE_DIR}/${DEPLOY_DIRECTORY}"
-    - rsync --delete -va $NAME "${DEPLOY_BASE_DIR}/${DEPLOY_DIRECTORY}/$NAME"
-  tags:
-    - deploy
-
-
-# Release deploys
-# These can be run only on actual releases (based on tags)
-
-## Upgrade tests
-
-upgrade tests core deploy:
-  stage: deploy
-  variables:
-    DEPLOY_PATH: "${DEPLOY_BASE_DIR}upgrade_tests/"
-  before_script: []  # no pipenv
-  when: manual
-  dependencies:
-    - core unix frozen debug build
-  script:
-    - TAG=`git tag --points-at HEAD | sed "s/\//-/"`
-    - "[[ ! $TAG =~ 'core' ]] && echo 'Tag is not core/*: exiting.' && exit 1"
-    - DEST=${DEPLOY_PATH}/trezor-emu-`git tag --points-at HEAD | sed "s/\//-/"`
-    - echo "Deploying to $DEST"
-    - rsync --delete -va core/build/unix/micropython "$DEST"
-  tags:
-    - deploy
-
-upgrade tests legacy deploy:
-  stage: deploy
-  variables:
-    DEPLOY_PATH: "${DEPLOY_BASE_DIR}upgrade_tests/"
-  before_script: []  # no pipenv
-  when: manual
-  dependencies:
-    - legacy emu regular build
-  script:
-    - TAG=`git tag --points-at HEAD | sed "s/\//-/"`
-    - "[[ ! $TAG =~ 'legacy' ]] && echo 'Tag is not legacy/*: exiting.' && exit 1"
-    - DEST=${DEPLOY_PATH}/trezor-emu-`git tag --points-at HEAD | sed "s/\//-/"`
-    - echo "Deploying to $DEST"
-    - rsync --delete -va legacy/firmware/trezor.elf "$DEST"
-
-## Releases
-
-### Core
-
-release core emu regular deploy:
-  stage: deploy
-  variables:
-    DEPLOY_DIRECTORY: "releases/${CI_COMMIT_REF_NAME}/emulators"
-  before_script: []  # no pipenv
-  when: manual
-  dependencies:
-    - core unix frozen regular build
-  script:
-    - TAG=`git tag --points-at HEAD | sed "s/\//-/"`
-    - "[[ ! $TAG =~ 'core' ]] && echo 'Tag is not core/*: exiting.' && exit 1"
-    - export VERSION=$(./tools/version.sh core/embed/firmware/version.h)
-    - export NAME="trezor-emu-regular-$VERSION-$CI_COMMIT_SHORT_SHA"
-    - echo "Deploying to ${DEPLOY_DIRECTORY}/$NAME"
-    - mv core/build/unix/micropython $NAME
-    - mkdir -p "${DEPLOY_BASE_DIR}/${DEPLOY_DIRECTORY}"
-    - rsync --delete -va $NAME "${DEPLOY_BASE_DIR}/${DEPLOY_DIRECTORY}/$NAME"
-  tags:
-    - deploy
+# Releases
 
 release core fw regular deploy:
   stage: deploy
@@ -147,36 +11,15 @@ release core fw regular deploy:
   dependencies:
     - core fw regular build
   script:
-    - TAG=`git tag --points-at HEAD | sed "s/\//-/"`
-    - "[[ ! $TAG =~ 'core' ]] && echo 'Tag is not core/*: exiting.' && exit 1"
     - export VERSION=$(./tools/version.sh core/embed/firmware/version.h)
     - export NAME="trezor-fw-regular-$VERSION-$CI_COMMIT_SHORT_SHA.bin"
     - echo "Deploying to ${DEPLOY_DIRECTORY}/$NAME"
     - mkdir -p "${DEPLOY_BASE_DIR}/${DEPLOY_DIRECTORY}"
     - rsync --delete -va $NAME "${DEPLOY_BASE_DIR}/${DEPLOY_DIRECTORY}/$NAME"
-  tags:
-    - deploy
-
-
-### Legacy
-
-release legacy emu regular deploy:
-  stage: deploy
-  variables:
-    DEPLOY_DIRECTORY: "releases/${CI_COMMIT_REF_NAME}/emulators"
-  before_script: []  # no pipenv
-  when: manual
-  dependencies:
-    - legacy emu regular build
-  script:
-    - TAG=`git tag --points-at HEAD | sed "s/\//-/"`
-    - "[[ ! $TAG =~ 'legacy' ]] && echo 'Tag is not legacy/*: exiting.' && exit 1"
-    - export VERSION=$(./tools/version.sh legacy/firmware/version.h)
-    - export NAME="trezor-emu-regular-$VERSION-$CI_COMMIT_SHORT_SHA"
-    - echo "Deploying to ${DEPLOY_DIRECTORY}/$NAME"
-    - mv legacy/firmware/trezor.elf $NAME
-    - mkdir -p "${DEPLOY_BASE_DIR}/${DEPLOY_DIRECTORY}"
-    - rsync --delete -va $NAME "${DEPLOY_BASE_DIR}/${DEPLOY_DIRECTORY}/$NAME"
+  only:
+    - /^core\/[0-9.]*$/
+  except:
+    - branches  # run for tags only
   tags:
     - deploy
 
@@ -189,12 +32,97 @@ release legacy fw regular deploy:
   dependencies:
     - legacy fw regular build
   script:
-    - TAG=`git tag --points-at HEAD | sed "s/\//-/"`
-    - "[[ ! $TAG =~ 'legacy' ]] && echo 'Tag is not legacy/*: exiting.' && exit 1"
     - export VERSION=$(./tools/version.sh legacy/firmware/version.h)
     - export NAME="trezor-fw-regular-$VERSION-$CI_COMMIT_SHORT_SHA.bin"
     - echo "Deploying to ${DEPLOY_DIRECTORY}/$NAME"
     - mkdir -p "${DEPLOY_BASE_DIR}/${DEPLOY_DIRECTORY}"
     - rsync --delete -va $NAME "${DEPLOY_BASE_DIR}/${DEPLOY_DIRECTORY}/$NAME"
+  only:
+    - /^legacy\/[0-9.]*$/
+  except:
+    - branches  # run for tags only
+  tags:
+    - deploy
+
+
+# Release candidates
+
+rc core fw regular deploy:
+  stage: deploy
+  variables:
+    DEPLOY_DIRECTORY: "release_candidates/${CI_COMMIT_REF_NAME}/firmwares"
+  before_script: []  # no pipenv
+  when: manual
+  dependencies:
+    - core fw regular build
+  script:
+    - export VERSION=$(./tools/version.sh core/embed/firmware/version.h)
+    - export NAME="trezor-fw-regular-$VERSION-$CI_COMMIT_SHORT_SHA.bin"
+    - echo "Deploying to ${DEPLOY_DIRECTORY}/$NAME"
+    - mkdir -p "${DEPLOY_BASE_DIR}/${DEPLOY_DIRECTORY}"
+    - rsync --delete -va $NAME "${DEPLOY_BASE_DIR}/${DEPLOY_DIRECTORY}/$NAME"
+  only:
+    - /^release\/[0-9]{4}-[0-9]{2}$/
+  tags:
+    - deploy
+
+rc legacy fw regular deploy:
+  stage: deploy
+  variables:
+    DEPLOY_DIRECTORY: "release_candidates/${CI_COMMIT_REF_NAME}/firmwares"
+  before_script: []  # no pipenv
+  when: manual
+  dependencies:
+    - legacy fw regular build
+  script:
+    - export VERSION=$(./tools/version.sh legacy/firmware/version.h)
+    - export NAME="trezor-fw-regular-$VERSION-$CI_COMMIT_SHORT_SHA.bin"
+    - echo "Deploying to ${DEPLOY_DIRECTORY}/$NAME"
+    - mkdir -p "${DEPLOY_BASE_DIR}/${DEPLOY_DIRECTORY}"
+    - rsync --delete -va $NAME "${DEPLOY_BASE_DIR}/${DEPLOY_DIRECTORY}/$NAME"
+  only:
+    - /^release\/[0-9]{4}-[0-9]{2}$/
+  tags:
+    - deploy
+
+# Upgrade tests
+
+upgrade tests core deploy:
+  stage: deploy
+  variables:
+    DEPLOY_PATH: "${DEPLOY_BASE_DIR}upgrade_tests/"
+  before_script: []  # no pipenv
+  dependencies:
+    - core unix frozen debug build
+  script:
+    - TAG=`git tag --points-at HEAD | sed "s/\//-/"`
+    - "[[ ! $TAG =~ 'core' ]] && echo 'Tag is not core/*: exiting.' && exit 1"
+    - DEST=${DEPLOY_PATH}/trezor-emu-`git tag --points-at HEAD | sed "s/\//-/"`
+    - echo "Deploying to $DEST"
+    - rsync --delete -va core/build/unix/micropython "$DEST"
+  only:
+    - /^core\/[0-9.]*$/
+  except:
+    - branches  # run for tags only
+  tags:
+    - deploy
+
+upgrade tests legacy deploy:
+  stage: deploy
+  variables:
+    DEPLOY_PATH: "${DEPLOY_BASE_DIR}upgrade_tests/"
+  before_script: []  # no pipenv
+  dependencies:
+    - legacy emu regular build
+  script:
+    - TAG=`git tag --points-at HEAD | sed "s/\//-/"`
+    - "[[ ! $TAG =~ 'legacy' ]] && echo 'Tag is not legacy/*: exiting.' && exit 1"
+    - DEST=${DEPLOY_PATH}/trezor-emu-`git tag --points-at HEAD | sed "s/\//-/"`
+    - echo "Deploying to $DEST"
+    - rsync --delete -va legacy/firmware/trezor.elf "$DEST"
+  only:
+    - /^legacy\/[0-9.]*$/
+  except:
+    - branches  # run for tags only
   tags:
     - deploy

--- a/ci/deploy.yml
+++ b/ci/deploy.yml
@@ -2,7 +2,7 @@ image: registry.gitlab.com/satoshilabs/trezor/trezor-firmware/environment
 
 # Core
 
-core to upgrade tests deploy:
+core upgrade tests deploy:
   stage: deploy
   variables:
     DEPLOY_DIRECTORY: "${DEPLOY_BASE_DIR}/upgrade_tests"
@@ -16,6 +16,36 @@ core to upgrade tests deploy:
     - DEST=${DEPLOY_DIRECTORY}/trezor-emu-`git tag --points-at HEAD | sed "s/\//-/"`
     - echo "Deploying to $DEST"
     - rsync --delete -va core/build/unix/micropython "$DEST"
+  tags:
+    - deploy
+
+core emu regular deploy:
+  stage: deploy
+  variables:
+    DEPLOY_DIRECTORY: "${DEPLOY_BASE_DIR}core/emulators/${CI_COMMIT_REF_NAME}"
+  before_script: []  # no pipenv
+  when: manual
+  dependencies:
+    - core unix frozen regular build
+  script:
+    - echo "Deploying to ${DEPLOY_DIRECTORY}/`date -I`-core-emu-${CI_COMMIT_SHORT_SHA}"
+    - mkdir -p ${DEPLOY_DIRECTORY}
+    - rsync --delete -va core/build/unix/micropython "${DEPLOY_DIRECTORY}/`date -I`-core-emu-${CI_COMMIT_SHORT_SHA}"
+  tags:
+    - deploy
+
+core fw regular deploy:
+  stage: deploy
+  variables:
+    DEPLOY_DIRECTORY: "${DEPLOY_BASE_DIR}core/firmwares/${CI_COMMIT_REF_NAME}"
+  before_script: []  # no pipenv
+  when: manual
+  dependencies:
+    - core fw regular build
+  script:
+    - echo "Deploying to ${DEPLOY_DIRECTORY}/`date -I`-core-firmware-${CI_COMMIT_SHORT_SHA}"
+    - mkdir -p ${DEPLOY_DIRECTORY}
+    - rsync --delete -va core/build/firmware/firmware.bin "${DEPLOY_DIRECTORY}/`date -I`-core-firmware-${CI_COMMIT_SHORT_SHA}"
   tags:
     - deploy
 
@@ -36,5 +66,33 @@ legacy to upgrade tests deploy:
     - DEST=${DEPLOY_DIRECTORY}/trezor-emu-`git tag --points-at HEAD | sed "s/\//-/"`
     - echo "Deploying to $DEST"
     - rsync --delete -va legacy/firmware/trezor.elf "$DEST"
+
+legacy emu regular deploy:
+  stage: deploy
+  variables:
+    DEPLOY_DIRECTORY: "${DEPLOY_BASE_DIR}legacy/emulators/${CI_COMMIT_REF_NAME}"
+  before_script: []  # no pipenv
+  when: manual
+  dependencies:
+    - legacy emu regular build
+  script:
+    - echo "Deploying to ${DEPLOY_DIRECTORY}/`date -I`-legacy-emu-${CI_COMMIT_SHORT_SHA}"
+    - mkdir -p ${DEPLOY_DIRECTORY}
+    - rsync --delete -va legacy/firmware/trezor.elf "${DEPLOY_DIRECTORY}/`date -I`-legacy-emu-${CI_COMMIT_SHORT_SHA}"
+  tags:
+    - deploy
+
+legacy fw regular deploy:
+  stage: deploy
+  variables:
+    DEPLOY_DIRECTORY: "${DEPLOY_BASE_DIR}legacy/firmwares/${CI_COMMIT_REF_NAME}"
+  before_script: []  # no pipenv
+  when: manual
+  dependencies:
+    - legacy fw regular build
+  script:
+    - echo "Deploying to ${DEPLOY_DIRECTORY}/`date -I`-legacy-firmware-${CI_COMMIT_SHORT_SHA}"
+    - mkdir -p ${DEPLOY_DIRECTORY}
+    - rsync --delete -va legacy/firmware/trezor.bin "${DEPLOY_DIRECTORY}/`date -I`-legacy-firmware-${CI_COMMIT_SHORT_SHA}"
   tags:
     - deploy

--- a/shell.nix
+++ b/shell.nix
@@ -9,7 +9,6 @@ stdenv.mkDerivation {
     check
     clang-tools
     gcc
-    gcc-arm-embedded
     gnumake
     graphviz
     libusb1
@@ -20,6 +19,20 @@ stdenv.mkDerivation {
     scons
     valgrind
     zlib
+  ] ++ stdenv.lib.optionals (!stdenv.isDarwin) [
+    gcc-arm-embedded
+  ] ++ stdenv.lib.optionals (stdenv.isDarwin) [
+    darwin.apple_sdk.frameworks.CoreAudio
+    darwin.apple_sdk.frameworks.AudioToolbox
+    darwin.apple_sdk.frameworks.ForceFeedback
+    darwin.apple_sdk.frameworks.CoreVideo
+    darwin.apple_sdk.frameworks.Cocoa
+    darwin.apple_sdk.frameworks.Carbon
+    darwin.apple_sdk.frameworks.IOKit
+    darwin.apple_sdk.frameworks.QuartzCore
+    darwin.apple_sdk.frameworks.Metal
+    darwin.libobjc
+    libiconv
   ];
   LD_LIBRARY_PATH="${libusb1}/lib";
   shellHook = ''


### PR DESCRIPTION
This PR adds deploy tasks to GitLab CI. I would like a concept ACK before merging this to master. This adds 8 more deploy tasks, which might seem as too many, so I would like to discuss this first.

These four are deployed to [firmware.corp.sldev.cz](https://firmware.corp.sldev.cz) to the subfolder `branches`:

- core emu regular deploy
- core fw regular deploy
- legacy emu regular deploy
- legacy fw regular deploy

And these four are deployed to [firmware.corp.sldev.cz](https://firmware.corp.sldev.cz) to the subfolder `releases` and can be invoked only, if they are tagged appropriately (`core/v2.*.*` or `legacy/v1.*.*`). The rational behind this is that we are naming the files in the format `trezor-emu-regular-2.1.7-ccb22fc6` even for those in master and other branches. I believe that would be very confusing for users so I wanted to seperate "regular branches" from the actual releases (actual v2.1.7).

- release core emu regular deploy
- release core fw regular deploy
- release legacy emu regular deploy
- release legacy fw regular deploy

Then we have two more for the upgrade tests which were already present.

----

Things to be done:
- Add btc only deploys?

Things to discuss:

- Do we want merge the first four into a single Job? All four variants would be deployed directly, which might make sense (but bloats the server a bit).
- Do you agree with the proposed structure? Browse firmware.corp.sldev.cz a little to get an idea.
- Should we run the release deployment automatically?

Ideas for improvement:
- Let's run the deploy jobs automatically for `release/*` branches and add a notification to Slack's #testing channel. That way on every commit to the release branch, the QA will be notified and can download the firmware directly.

---

updates #183 
