### PR TITLE
nem2: Refactor nem_canonicalizeMosaics

### DIFF
--- a/legacy/firmware/fsm_msg_nem.h
+++ b/legacy/firmware/fsm_msg_nem.h
@@ -132,8 +132,7 @@ void fsm_msgNEMSignTx(NEMSignTx *msg) {
   hdnode_get_nem_address(node, common->network, address);
 
   if (msg->has_transfer) {
-    msg->transfer.mosaics_count = nem_canonicalizeMosaics(
-        msg->transfer.mosaics, msg->transfer.mosaics_count);
+    nem_canonicalizeMosaics(&msg->transfer);
   }
 
   if (msg->has_transfer && !nem_askTransfer(common, &msg->transfer, network)) {

--- a/legacy/firmware/nem2.c
+++ b/legacy/firmware/nem2.c
@@ -700,27 +700,30 @@ static inline size_t format_amount(const NEMMosaicDefinition *definition,
       -divisor, false, str_out, size);
 }
 
-size_t nem_canonicalizeMosaics(NEMMosaic *mosaics, size_t mosaics_count) {
-  if (mosaics_count <= 1) {
-    return mosaics_count;
+void nem_canonicalizeMosaics(NEMTransfer *transfer) {
+  size_t old_count = transfer->mosaics_count;
+  NEMMosaic *const mosaics = transfer->mosaics;
+
+  if (old_count <= 1) {
+    return;
   }
 
-  size_t actual_count = 0;
-
-  bool skip[mosaics_count];
+  bool skip[old_count];
   memzero(skip, sizeof(skip));
 
+  size_t new_count = 0;
+
   // Merge duplicates
-  for (size_t i = 0; i < mosaics_count; i++) {
+  for (size_t i = 0; i < old_count; i++) {
     if (skip[i]) continue;
 
-    NEMMosaic *mosaic = &mosaics[actual_count];
+    NEMMosaic *mosaic = &mosaics[new_count];
 
-    if (actual_count++ != i) {
+    if (new_count++ != i) {
       memcpy(mosaic, &mosaics[i], sizeof(NEMMosaic));
     }
 
-    for (size_t j = i + 1; j < mosaics_count; j++) {
+    for (size_t j = i + 1; j < old_count; j++) {
       if (skip[j]) continue;
 
       const NEMMosaic *new_mosaic = &mosaics[j];
@@ -732,24 +735,23 @@ size_t nem_canonicalizeMosaics(NEMMosaic *mosaics, size_t mosaics_count) {
     }
   }
 
-  NEMMosaic temp;
+  transfer->mosaics_count = new_count;
 
   // Sort mosaics
-  for (size_t i = 0; i < actual_count - 1; i++) {
+  for (size_t i = 0; i < new_count - 1; i++) {
     NEMMosaic *a = &mosaics[i];
 
-    for (size_t j = i + 1; j < actual_count; j++) {
+    for (size_t j = i + 1; j < new_count; j++) {
       NEMMosaic *b = &mosaics[j];
 
       if (nem_mosaicCompare(a, b) > 0) {
+        NEMMosaic temp;
         memcpy(&temp, a, sizeof(NEMMosaic));
         memcpy(a, b, sizeof(NEMMosaic));
         memcpy(b, &temp, sizeof(NEMMosaic));
       }
     }
   }
-
-  return actual_count;
 }
 
 void nem_mosaicFormatAmount(const NEMMosaicDefinition *definition,

--- a/legacy/firmware/nem2.h
+++ b/legacy/firmware/nem2.h
@@ -92,7 +92,7 @@ const NEMMosaicDefinition *nem_mosaicByName(const char *namespace,
                                             const char *mosaic,
                                             uint8_t network);
 
-size_t nem_canonicalizeMosaics(NEMMosaic *mosaics, size_t mosaics_count);
+void nem_canonicalizeMosaics(NEMTransfer *transfer);
 void nem_mosaicFormatAmount(const NEMMosaicDefinition *definition,
                             uint64_t quantity, const bignum256 *multiplier,
                             char *str_out, size_t size);


### PR DESCRIPTION
This fixes compilation under `-Wvla-larger-than=`. I think using `NEMTransfer *` is more convenient than checking `mosaics_count` and returning an error condition if it's too large. Alternatively, you could refactor it to use a fixed-length array (based on the maximum size of `NEMTransfer.mosaics`)

This is completely untested (apart from that it compiles).