### PR TITLE
Add Connect flag for Bitcoin Rhodium

### DIFF
--- a/common/defs/support.json
+++ b/common/defs/support.json
@@ -43,6 +43,7 @@
       "bitcoin:VTC": true,
       "bitcoin:XMY": true,
       "bitcoin:XPM": true,
+      "bitcoin:XRC": true,
       "bitcoin:XSN": true,
       "bitcoin:XZC": true,
       "bitcoin:ZCL": true,


### PR DESCRIPTION
We have an integration with Magnum Wallet (https://magnumwallet.co) that supports Trezor Connect. I think we are otherwise ready for Trezor Connect since XRC support is currently supported on Trezor 1 and 2.