### PR TITLE
Add unit test for process_slip39 function

### DIFF
--- a/core/src/apps/management/recovery_device/recover.py
+++ b/core/src/apps/management/recovery_device/recover.py
@@ -56,8 +56,12 @@ def process_slip39(words: str) -> Tuple[Optional[bytes], slip39.Share]:
     # These should be checked by UI before so it's a Runtime exception otherwise
     if share.identifier != storage.recovery.get_slip39_identifier():
         raise RuntimeError("Slip39: Share identifiers do not match")
+    if share.iteration_exponent != storage.recovery.get_slip39_iteration_exponent():
+        raise RuntimeError("Slip39: Share exponents do not match")
     if storage.recovery_shares.get(share.index, share.group_index):
         raise RuntimeError("Slip39: This mnemonic was already entered")
+    if share.group_count != storage.recovery.get_slip39_group_count():
+        raise RuntimeError("Slip39: Group count does not match")
 
     remaining_for_share = (
         storage.recovery.get_slip39_remaining_shares(share.group_index)

--- a/core/tests/test_apps.management.recovery_device.py
+++ b/core/tests/test_apps.management.recovery_device.py
@@ -51,7 +51,7 @@ class TestSlip39(unittest.TestCase):
         # third share (member index 3)
         third = MNEMONIC_SLIP39_BASIC_20_3of6[2]
         secret, share = process_slip39(third)
-        self.assertIsNotNone(secret)
+        self.assertEqual(secret, b'I\x1by[\x80\xfc!\xcc\xdfFl\x0f\xbc\x98\xc8\xfc')
         self.assertEqual(storage.recovery.get_slip39_remaining_shares(0), 0)
         self.assertEqual(storage.recovery_shares.get(share.index, share.group_index), third)
         self.assertEqual(storage.recovery_shares.fetch_group(share.group_index), [second, third, first])  # ordered by index
@@ -98,7 +98,7 @@ class TestSlip39(unittest.TestCase):
         # now group 2 is complete => the whole Shamir recovery is completed
         words = MNEMONIC_SLIP39_ADVANCED_20[3]
         secret, share = process_slip39(words)
-        self.assertIsNotNone(secret)
+        self.assertEqual(secret, b'\xc2\xd2\xe2j\xd0`#\xc6\x01E\xf1P\xab\xe2\xdd+')
         self.assertEqual(share.group_count, storage.recovery.get_slip39_group_count())
         self.assertEqual(share.iteration_exponent, storage.recovery.get_slip39_iteration_exponent())
         self.assertEqual(share.identifier, storage.recovery.get_slip39_identifier())


### PR DESCRIPTION
Adds unit test for `process_slip39` function. Note that it still can happen that an unfitting mnemonic is stored in the storage and then later combined together with valid ones in `combine_mnemonics`. In such case, the MnemonicError is thrown and later caught in `_continue_recovery_process` and an error is shown. I believe that's an expected behaviour since this can happen very rarely, I doubt it can happen under "real-life" circumstances.

An example of this when the user enters a second mnemonic, which has the same identifier, but different member threshold. In this case the user needs to enter all mnemonics to get an error. However, entering different identifier leads to an early error (as soon as the second word is entered) and since that is way more common case I believe that's enough.

---

closes #542