### PR TITLE
core, legacy: Don't allow change_pin if device is not initialized.

### DIFF
--- a/core/src/apps/cardano/seed.py
+++ b/core/src/apps/cardano/seed.py
@@ -39,7 +39,7 @@ async def _get_passphrase(ctx: wire.Context) -> bytes:
 
 async def get_keychain(ctx: wire.Context) -> Keychain:
     if not storage.is_initialized():
-        raise wire.ProcessError("Device is not initialized")
+        raise wire.NotInitialized("Device is not initialized")
 
     if mnemonic.is_bip39():
         # derive the root node from mnemonic and passphrase

--- a/core/src/apps/common/seed.py
+++ b/core/src/apps/common/seed.py
@@ -108,7 +108,7 @@ class Keychain:
 
 async def get_keychain(ctx: wire.Context, namespaces: list) -> Keychain:
     if not storage.is_initialized():
-        raise wire.ProcessError("Device is not initialized")
+        raise wire.NotInitialized("Device is not initialized")
     seed = cache.get_seed()
     if seed is None:
         passphrase = cache.get_passphrase()

--- a/core/src/apps/management/backup_device.py
+++ b/core/src/apps/management/backup_device.py
@@ -7,7 +7,7 @@ from apps.management.reset_device import backup_seed, layout
 
 async def backup_device(ctx, msg):
     if not storage.is_initialized():
-        raise wire.ProcessError("Device is not initialized")
+        raise wire.NotInitialized("Device is not initialized")
     if not storage.device.needs_backup():
         raise wire.ProcessError("Seed already backed up")
 

--- a/core/src/apps/management/change_pin.py
+++ b/core/src/apps/management/change_pin.py
@@ -10,12 +10,16 @@ from apps.common.request_pin import (
     request_pin_confirm,
     show_pin_invalid,
 )
+from apps.common.storage import is_initialized
 
 if False:
     from trezor.messages.ChangePin import ChangePin
 
 
 async def change_pin(ctx: wire.Context, msg: ChangePin) -> Success:
+    if not is_initialized():
+        raise wire.NotInitialized("Device is not initialized")
+
     # confirm that user wants to change the pin
     await require_confirm_change_pin(ctx, msg)
 

--- a/core/src/apps/management/recovery_device/__init__.py
+++ b/core/src/apps/management/recovery_device/__init__.py
@@ -60,7 +60,7 @@ def _check_state(msg: RecoveryDevice) -> None:
     if not msg.dry_run and storage.is_initialized():
         raise wire.UnexpectedMessage("Already initialized")
     if msg.dry_run and not storage.is_initialized():
-        raise wire.UnexpectedMessage("Device is not initialized")
+        raise wire.NotInitialized("Device is not initialized")
 
     if storage.recovery.is_in_progress():
         raise RuntimeError(

--- a/core/src/apps/management/sd_protect.py
+++ b/core/src/apps/management/sd_protect.py
@@ -30,7 +30,7 @@ if False:
 
 async def sd_protect(ctx: wire.Context, msg: SdProtect) -> Success:
     if not is_initialized():
-        raise wire.ProcessError("Device is not initialized")
+        raise wire.NotInitialized("Device is not initialized")
 
     if msg.operation == SdProtectOperationType.ENABLE:
         return await sd_protect_enable(ctx, msg)

--- a/legacy/firmware/fsm_msg_common.h
+++ b/legacy/firmware/fsm_msg_common.h
@@ -136,6 +136,8 @@ void fsm_msgPing(const Ping *msg) {
 }
 
 void fsm_msgChangePin(const ChangePin *msg) {
+  CHECK_INITIALIZED
+
   bool removal = msg->has_remove && msg->remove;
   if (removal) {
     if (config_hasPin()) {


### PR DESCRIPTION
Fixes https://github.com/trezor/trezor-firmware/issues/599.