### PR TITLE
Initialize all local variables explicitly

### DIFF
--- a/crypto/address.c
+++ b/crypto/address.c
@@ -66,11 +66,11 @@ void ethereum_address_checksum(const uint8_t *addr, char *address, bool rskip60,
   }
   address[40] = 0;
 
-  SHA3_CTX ctx;
-  uint8_t hash[32];
+  SHA3_CTX ctx = {0};
+  uint8_t hash[32] = {0};
   keccak_256_Init(&ctx);
   if (rskip60) {
-    char prefix[16];
+    char prefix[16] = {0};
     int prefix_size = bn_format_uint64(chain_id, NULL, "0x", 0, 0, false,
                                        prefix, sizeof(prefix));
     keccak_Update(&ctx, (const uint8_t *)prefix, prefix_size);

--- a/crypto/aes/aes_modes.c
+++ b/crypto/aes/aes_modes.c
@@ -108,7 +108,7 @@ aligned_array(unsigned long, dec_hybrid_table, 12, 16) = NEH_DEC_HYBRID_DATA;
 
 AES_RETURN aes_test_alignment_detection(unsigned int n)	/* 4 <= n <= 16 */
 {	uint8_t	p[16];
-    uint32_t i, count_eq = 0, count_neq = 0;
+    uint32_t i = 0, count_eq = 0, count_neq = 0;
 
     if(n < 4 || n > 16)
         return EXIT_FAILURE;
@@ -156,7 +156,7 @@ AES_RETURN aes_ecb_encrypt(const unsigned char *ibuf, unsigned char *obuf,
         }
         else
         {   aligned_auto(uint8_t, buf, BFR_BLOCKS * AES_BLOCK_SIZE, 16);
-            uint8_t *ip, *op;
+            uint8_t *ip = NULL, *op = NULL;
 
             while(nb)
             {
@@ -218,7 +218,7 @@ AES_RETURN aes_ecb_decrypt(const unsigned char *ibuf, unsigned char *obuf,
         }
         else
         {   aligned_auto(uint8_t, buf, BFR_BLOCKS * AES_BLOCK_SIZE, 16);
-            uint8_t *ip, *op;
+            uint8_t *ip = NULL, *op = NULL;
 
             while(nb)
             {
@@ -287,7 +287,7 @@ AES_RETURN aes_cbc_encrypt(const unsigned char *ibuf, unsigned char *obuf,
         }
         else
         {   aligned_auto(uint8_t, buf, BFR_BLOCKS * AES_BLOCK_SIZE, 16);
-            uint8_t *ip, *op;
+            uint8_t *ip = NULL, *op = NULL;
 
             while(nb)
             {
@@ -385,7 +385,7 @@ AES_RETURN aes_cbc_decrypt(const unsigned char *ibuf, unsigned char *obuf,
         }
         else
         {   aligned_auto(uint8_t, buf, BFR_BLOCKS * AES_BLOCK_SIZE, 16);
-            uint8_t *ip, *op;
+            uint8_t *ip = NULL, *op = NULL;
 
             while(nb)
             {
@@ -497,7 +497,7 @@ AES_RETURN aes_cfb_encrypt(const unsigned char *ibuf, unsigned char *obuf,
             }
             else    /* input, output or both are unaligned  */
             {   aligned_auto(uint8_t, buf, BFR_BLOCKS * AES_BLOCK_SIZE, 16);
-                uint8_t *ip, *op;
+                uint8_t *ip = NULL, *op = NULL;
 
                 while(nb)
                 {
@@ -625,7 +625,7 @@ AES_RETURN aes_cfb_decrypt(const unsigned char *ibuf, unsigned char *obuf,
             }
             else    /* input, output or both are unaligned  */
             {   aligned_auto(uint8_t, buf, BFR_BLOCKS * AES_BLOCK_SIZE, 16);
-                uint8_t *ip, *op;
+                uint8_t *ip = NULL, *op = NULL;
 
                 while(nb)
                 {
@@ -763,7 +763,7 @@ AES_RETURN aes_ofb_crypt(const unsigned char *ibuf, unsigned char *obuf,
             }
             else    /* input, output or both are unaligned  */
         {   aligned_auto(uint8_t, buf, BFR_BLOCKS * AES_BLOCK_SIZE, 16);
-            uint8_t *ip, *op;
+            uint8_t *ip = NULL, *op = NULL;
 
                 while(nb)
                 {
@@ -850,14 +850,14 @@ AES_RETURN aes_ofb_crypt(const unsigned char *ibuf, unsigned char *obuf,
 AES_RETURN aes_ctr_crypt(const unsigned char *ibuf, unsigned char *obuf,
             int len, unsigned char *cbuf, cbuf_inc ctr_inc, aes_encrypt_ctx ctx[1])
 {   unsigned char   *ip;
-    int             i, blen, b_pos = (int)(ctx->inf.b[2]);
+    int             i = 0, blen = 0, b_pos = (int)(ctx->inf.b[2]);
 
 #if defined( USE_VIA_ACE_IF_PRESENT )
     aligned_auto(uint8_t, buf, BFR_LENGTH, 16);
     if(ctx->inf.b[1] == 0xff && ALIGN_OFFSET( ctx, 16 ))
         return EXIT_FAILURE;
 #else
-    uint8_t buf[BFR_LENGTH];
+    uint8_t buf[BFR_LENGTH] = {0};
 #endif
 
     if(b_pos)

--- a/crypto/aes/aescrypt.c
+++ b/crypto/aes/aescrypt.c
@@ -96,7 +96,7 @@ extern "C"
 
 AES_RETURN aes_xi(encrypt)(const unsigned char *in, unsigned char *out, const aes_encrypt_ctx cx[1])
 {   uint32_t         locals(b0, b1);
-    const uint32_t   *kp;
+    const uint32_t *kp = NULL;
 #if defined( dec_fmvars )
     dec_fmvars; /* declare variables for fwd_mcol() if needed */
 #endif
@@ -234,7 +234,7 @@ AES_RETURN aes_xi(decrypt)(const unsigned char *in, unsigned char *out, const ae
 #if defined( dec_imvars )
     dec_imvars; /* declare variables for inv_mcol() if needed */
 #endif
-    const uint32_t *kp;
+    const uint32_t *kp = NULL;
 
 	if(cx->inf.b[0] != 10 * AES_BLOCK_SIZE && cx->inf.b[0] != 12 * AES_BLOCK_SIZE && cx->inf.b[0] != 14 * AES_BLOCK_SIZE)
 		return EXIT_FAILURE;

--- a/crypto/aes/aestab.c
+++ b/crypto/aes/aestab.c
@@ -272,7 +272,7 @@ AES_RETURN aes_init(void)
 
 #if defined(FF_TABLES)
 
-    uint8_t  pow[512], log[256];
+    uint8_t  pow[512] = {0}, log[256] = {0};
 
     if(init)
         return EXIT_SUCCESS;

--- a/crypto/base32.c
+++ b/crypto/base32.c
@@ -77,7 +77,7 @@ void base32_encode_unsafe(const uint8_t *in, size_t inlen, uint8_t *out) {
   uint8_t remainder = inlen % 5;
   size_t limit = inlen - remainder;
 
-  size_t i, j;
+  size_t i = 0, j = 0;
   for (i = 0, j = 0; i < limit; i += 5, j += 8) {
     base32_5to8(&in[i], 5, &out[j]);
   }
@@ -90,7 +90,7 @@ bool base32_decode_unsafe(const uint8_t *in, size_t inlen, uint8_t *out,
   uint8_t remainder = inlen % 8;
   size_t limit = inlen - remainder;
 
-  size_t i, j;
+  size_t i = 0, j = 0;
   for (i = 0, j = 0; i < limit; i += 8, j += 5) {
     if (!base32_8to5(&in[i], 8, &out[j], alphabet)) {
       return false;

--- a/crypto/base32.c
+++ b/crypto/base32.c
@@ -153,6 +153,7 @@ bool base32_8to5(const uint8_t *in, uint8_t length, uint8_t *out,
 
   if (alphabet) {
     uint8_t decoded[length];
+    memset(decoded, 0, sizeof(decoded));
 
     for (size_t i = 0; i < length; i++) {
       int ret = base32_decode_character(in[i], alphabet);

--- a/crypto/base58.c
+++ b/crypto/base58.c
@@ -190,6 +190,7 @@ int base58_encode_check(const uint8_t *data, int datalen,
     return 0;
   }
   uint8_t buf[datalen + 32];
+  memset(buf, 0, sizeof(buf));
   uint8_t *hash = buf + datalen;
   memcpy(buf, data, datalen);
   hasher_Raw(hasher_type, data, datalen, hash);
@@ -205,6 +206,7 @@ int base58_decode_check(const char *str, HasherType hasher_type, uint8_t *data,
     return 0;
   }
   uint8_t d[datalen + 4];
+  memset(d, 0, sizeof(d));
   size_t res = datalen + 4;
   if (b58tobin(d, &res, str) != true) {
     return 0;
@@ -241,6 +243,7 @@ int base58gph_encode_check(const uint8_t *data, int datalen, char *str,
     return 0;
   }
   uint8_t buf[datalen + 32];
+  memset(buf, 0, sizeof(buf));
   uint8_t *hash = buf + datalen;
   memcpy(buf, data, datalen);
   ripemd160(data, datalen, hash);  // No double SHA256, but a single RIPEMD160
@@ -255,6 +258,7 @@ int base58gph_decode_check(const char *str, uint8_t *data, int datalen) {
     return 0;
   }
   uint8_t d[datalen + 4];
+  memset(d, 0, sizeof(d));
   size_t res = datalen + 4;
   if (b58tobin(d, &res, str) != true) {
     return 0;

--- a/crypto/base58.c
+++ b/crypto/base58.c
@@ -58,9 +58,9 @@ bool b58tobin(void *bin, size_t *binszp, const char *b58) {
   size_t outisz =
       (binsz + sizeof(b58_almostmaxint_t) - 1) / sizeof(b58_almostmaxint_t);
   b58_almostmaxint_t outi[outisz];
-  b58_maxint_t t;
-  b58_almostmaxint_t c;
-  size_t i, j;
+  b58_maxint_t t = 0;
+  b58_almostmaxint_t c = 0;
+  size_t i = 0, j = 0;
   uint8_t bytesleft = binsz % sizeof(b58_almostmaxint_t);
   b58_almostmaxint_t zeromask =
       bytesleft ? (b58_almostmaxint_mask << (bytesleft * 8)) : 0;
@@ -128,9 +128,9 @@ bool b58tobin(void *bin, size_t *binszp, const char *b58) {
 
 int b58check(const void *bin, size_t binsz, HasherType hasher_type,
              const char *base58str) {
-  unsigned char buf[32];
+  unsigned char buf[32] = {0};
   const uint8_t *binc = bin;
-  unsigned i;
+  unsigned i = 0;
   if (binsz < 4) return -4;
   hasher_Raw(hasher_type, bin, binsz - 4, buf);
   if (memcmp(&binc[binsz - 4], buf, 4)) return -1;
@@ -146,9 +146,9 @@ int b58check(const void *bin, size_t binsz, HasherType hasher_type,
 
 bool b58enc(char *b58, size_t *b58sz, const void *data, size_t binsz) {
   const uint8_t *bin = data;
-  int carry;
-  size_t i, j, high, zcount = 0;
-  size_t size;
+  int carry = 0;
+  size_t i = 0, j = 0, high = 0, zcount = 0;
+  size_t size = 0;
 
   while (zcount < binsz && !bin[zcount]) ++zcount;
 
@@ -219,9 +219,9 @@ int base58_decode_check(const char *str, HasherType hasher_type, uint8_t *data,
 
 #if USE_GRAPHENE
 int b58gphcheck(const void *bin, size_t binsz, const char *base58str) {
-  unsigned char buf[32];
+  unsigned char buf[32] = {0};
   const uint8_t *binc = bin;
-  unsigned i;
+  unsigned i = 0;
   if (binsz < 4) return -4;
   ripemd160(bin, binsz - 4, buf);  // No double SHA256, but a single RIPEMD160
   if (memcmp(&binc[binsz - 4], buf, 4)) return -1;

--- a/crypto/bip32.c
+++ b/crypto/bip32.c
@@ -127,7 +127,7 @@ int hdnode_from_xprv(uint32_t depth, uint32_t child_num,
   if (info == 0) {
     failed = true;
   } else if (info->params) {
-    bignum256 a;
+    bignum256 a = {0};
     bn_read_be(private_key, &a);
     if (bn_is_zero(&a)) {  // == 0
       failed = true;
@@ -170,7 +170,7 @@ int hdnode_from_seed(const uint8_t *seed, int seed_len, const char *curve,
   hmac_sha512_Final(&ctx, I);
 
   if (out->curve->params) {
-    bignum256 a;
+    bignum256 a = {0};
     while (true) {
       bn_read_be(I, &a);
       if (!bn_is_zero(&a)                                   // != 0
@@ -192,8 +192,8 @@ int hdnode_from_seed(const uint8_t *seed, int seed_len, const char *curve,
 }
 
 uint32_t hdnode_fingerprint(HDNode *node) {
-  uint8_t digest[32];
-  uint32_t fingerprint;
+  uint8_t digest[32] = {0};
+  uint32_t fingerprint = 0;
 
   hdnode_fill_public_key(node);
   hasher_Raw(node->curve->hasher_pubkey, node->public_key, 33, digest);
@@ -422,9 +422,9 @@ int hdnode_from_entropy_cardano_icarus(const uint8_t *pass, int pass_len,
 int hdnode_public_ckd_cp(const ecdsa_curve *curve, const curve_point *parent,
                          const uint8_t *parent_chain_code, uint32_t i,
                          curve_point *child, uint8_t *child_chain_code) {
-  uint8_t data[1 + 32 + 4];
-  uint8_t I[32 + 32];
-  bignum256 c;
+  uint8_t data[(1 + 32) + 4] = {0};
+  uint8_t I[32 + 32] = {0};
+  bignum256 c = {0};
 
   if (i & 0x80000000) {  // private derivation
     return 0;
@@ -459,7 +459,7 @@ int hdnode_public_ckd_cp(const ecdsa_curve *curve, const curve_point *parent,
 }
 
 int hdnode_public_ckd(HDNode *inout, uint32_t i) {
-  curve_point parent, child;
+  curve_point parent = {0}, child = {0};
 
   if (!ecdsa_read_pubkey(inout->curve->params, inout->public_key, &parent)) {
     return 0;
@@ -487,8 +487,8 @@ void hdnode_public_ckd_address_optimized(const curve_point *pub,
                                          HasherType hasher_pubkey,
                                          HasherType hasher_base58, char *addr,
                                          int addrsize, int addrformat) {
-  uint8_t child_pubkey[33];
-  curve_point b;
+  uint8_t child_pubkey[33] = {0};
+  curve_point b = {0};
 
   hdnode_public_ckd_cp(&secp256k1, pub, chain_code, i, &b, NULL);
   child_pubkey[0] = 0x02 | (b.y.val[0] & 0x01);
@@ -544,7 +544,7 @@ int hdnode_private_ckd_cached(HDNode *inout, const uint32_t *i, size_t i_count,
     private_ckd_cache_root_set = true;
   } else {
     // try to find parent
-    int j;
+    int j = 0;
     for (j = 0; j < BIP32_CACHE_SIZE; j++) {
       if (private_ckd_cache[j].set &&
           private_ckd_cache[j].depth == i_count - 1 &&
@@ -560,7 +560,7 @@ int hdnode_private_ckd_cached(HDNode *inout, const uint32_t *i, size_t i_count,
 
   // else derive parent
   if (!found) {
-    size_t k;
+    size_t k = 0;
     for (k = 0; k < i_count - 1; k++) {
       if (hdnode_private_ckd(inout, i[k]) == 0) return 0;
     }
@@ -633,8 +633,8 @@ void hdnode_fill_public_key(HDNode *node) {
 
 #if USE_ETHEREUM
 int hdnode_get_ethereum_pubkeyhash(const HDNode *node, uint8_t *pubkeyhash) {
-  uint8_t buf[65];
-  SHA3_CTX ctx;
+  uint8_t buf[65] = {0};
+  SHA3_CTX ctx = {0};
 
   /* get uncompressed public key */
   ecdsa_get_public_key65(node->curve->params, node->private_key, buf);
@@ -687,7 +687,7 @@ int hdnode_get_nem_shared_key(const HDNode *node,
 int hdnode_nem_encrypt(const HDNode *node, const ed25519_public_key public_key,
                        const uint8_t *iv_immut, const uint8_t *salt,
                        const uint8_t *payload, size_t size, uint8_t *buffer) {
-  uint8_t last_block[AES_BLOCK_SIZE];
+  uint8_t last_block[AES_BLOCK_SIZE] = {0};
   uint8_t remainder = size % AES_BLOCK_SIZE;
 
   // Round down to last whole block
@@ -699,15 +699,15 @@ int hdnode_nem_encrypt(const HDNode *node, const ed25519_public_key public_key,
          AES_BLOCK_SIZE - remainder);
 
   // the IV gets mutated, so we make a copy not to touch the original
-  uint8_t iv[AES_BLOCK_SIZE];
+  uint8_t iv[AES_BLOCK_SIZE] = {0};
   memcpy(iv, iv_immut, AES_BLOCK_SIZE);
 
-  uint8_t shared_key[SHA3_256_DIGEST_LENGTH];
+  uint8_t shared_key[SHA3_256_DIGEST_LENGTH] = {0};
   if (!hdnode_get_nem_shared_key(node, public_key, salt, NULL, shared_key)) {
     return 0;
   }
 
-  aes_encrypt_ctx ctx;
+  aes_encrypt_ctx ctx = {0};
 
   int ret = aes_encrypt_key256(shared_key, &ctx);
   memzero(shared_key, sizeof(shared_key));
@@ -731,13 +731,13 @@ int hdnode_nem_encrypt(const HDNode *node, const ed25519_public_key public_key,
 int hdnode_nem_decrypt(const HDNode *node, const ed25519_public_key public_key,
                        uint8_t *iv, const uint8_t *salt, const uint8_t *payload,
                        size_t size, uint8_t *buffer) {
-  uint8_t shared_key[SHA3_256_DIGEST_LENGTH];
+  uint8_t shared_key[SHA3_256_DIGEST_LENGTH] = {0};
 
   if (!hdnode_get_nem_shared_key(node, public_key, salt, NULL, shared_key)) {
     return 0;
   }
 
-  aes_decrypt_ctx ctx;
+  aes_decrypt_ctx ctx = {0};
 
   int ret = aes_decrypt_key256(shared_key, &ctx);
   memzero(shared_key, sizeof(shared_key));
@@ -822,7 +822,7 @@ int hdnode_get_shared_key(const HDNode *node, const uint8_t *peer_public_key,
 static int hdnode_serialize(const HDNode *node, uint32_t fingerprint,
                             uint32_t version, char use_public, char *str,
                             int strsize) {
-  uint8_t node_data[78];
+  uint8_t node_data[78] = {0};
   write_be(node_data, version);
   node_data[4] = node->depth;
   write_be(node_data + 5, fingerprint);
@@ -854,7 +854,7 @@ int hdnode_serialize_private(const HDNode *node, uint32_t fingerprint,
 int hdnode_deserialize(const char *str, uint32_t version_public,
                        uint32_t version_private, const char *curve,
                        HDNode *node, uint32_t *fingerprint) {
-  uint8_t node_data[78];
+  uint8_t node_data[78] = {0};
   memzero(node, sizeof(HDNode));
   node->curve = get_curve_by_name(curve);
   if (base58_decode_check(str, node->curve->hasher_base58, node_data,

--- a/crypto/bip39.c
+++ b/crypto/bip39.c
@@ -50,7 +50,7 @@ const char *mnemonic_generate(int strength) {
   if (strength % 32 || strength < 128 || strength > 256) {
     return 0;
   }
-  uint8_t data[32];
+  uint8_t data[32] = {0};
   random_buffer(data, 32);
   const char *r = mnemonic_from_data(data, strength / 8);
   memzero(data, sizeof(data));
@@ -64,7 +64,7 @@ const char *mnemonic_from_data(const uint8_t *data, int len) {
     return 0;
   }
 
-  uint8_t bits[32 + 1];
+  uint8_t bits[32 + 1] = {0};
 
   sha256_Raw(data, len, bits);
   // checksum
@@ -74,7 +74,7 @@ const char *mnemonic_from_data(const uint8_t *data, int len) {
 
   int mlen = len * 3 / 4;
 
-  int i, j, idx;
+  int i = 0, j = 0, idx = 0;
   char *p = mnemo;
   for (i = 0; i < mlen; i++) {
     idx = 0;
@@ -114,9 +114,9 @@ int mnemonic_to_entropy(const char *mnemonic, uint8_t *entropy) {
     return 0;
   }
 
-  char current_word[10];
-  uint32_t j, k, ki, bi = 0;
-  uint8_t bits[32 + 1];
+  char current_word[10] = {0};
+  uint32_t j = 0, k = 0, ki = 0, bi = 0;
+  uint8_t bits[32 + 1] = {0};
 
   memzero(bits, sizeof(bits));
   i = 0;
@@ -159,7 +159,7 @@ int mnemonic_to_entropy(const char *mnemonic, uint8_t *entropy) {
 }
 
 int mnemonic_check(const char *mnemonic) {
-  uint8_t bits[32 + 1];
+  uint8_t bits[32 + 1] = {0};
   int seed_len = mnemonic_to_entropy(mnemonic, bits);
   if (seed_len != (12 * 11) && seed_len != (18 * 11) && seed_len != (24 * 11)) {
     return 0;
@@ -198,7 +198,7 @@ void mnemonic_to_seed(const char *mnemonic, const char *passphrase,
     }
   }
 #endif
-  uint8_t salt[8 + 256];
+  uint8_t salt[8 + 256] = {0};
   memcpy(salt, "mnemonic", 8);
   memcpy(salt + 8, passphrase, passphraselen);
   static CONFIDENTIAL PBKDF2_HMAC_SHA512_CTX pctx;

--- a/crypto/blake256.c
+++ b/crypto/blake256.c
@@ -64,7 +64,7 @@ static const uint8_t padding[129] =
 
 static void blake256_compress( BLAKE256_CTX *S, const uint8_t *block )
 {
-  uint32_t v[16], m[16], i;
+  uint32_t v[16] = {0}, m[16] = {0}, i = 0;
 #define ROT(x,n) (((x)<<(32-n))|( (x)>>(n)))
 #define G(a,b,c,d,e)          \
   v[a] += (m[sigma[i][e]] ^ u256[sigma[i][e+1]]) + v[b]; \
@@ -177,7 +177,7 @@ void blake256_Update( BLAKE256_CTX *S, const uint8_t *in, size_t inlen )
 
 void blake256_Final( BLAKE256_CTX *S, uint8_t *out )
 {
-  uint8_t msglen[8], zo = 0x01, oo = 0x81;
+  uint8_t msglen[8] = {0}, zo = 0x01, oo = 0x81;
   uint32_t lo = S->t[0] + ( S->buflen << 3 ), hi = S->t[1];
 
   /* support for hashing more than 2^32 bits */
@@ -228,7 +228,7 @@ void blake256_Final( BLAKE256_CTX *S, uint8_t *out )
 
 void blake256( const uint8_t *in, size_t inlen, uint8_t *out )
 {
-  BLAKE256_CTX S;
+  BLAKE256_CTX S = {0};
   blake256_Init( &S );
   blake256_Update( &S, in, inlen );
   blake256_Final( &S, out );

--- a/crypto/blake2b.c
+++ b/crypto/blake2b.c
@@ -86,7 +86,7 @@ static void blake2b_increment_counter( blake2b_state *S, const uint64_t inc )
 
 static void blake2b_init0( blake2b_state *S )
 {
-  size_t i;
+  size_t i = 0;
   memzero( S, sizeof( blake2b_state ) );
 
   for( i = 0; i < 8; ++i ) S->h[i] = blake2b_IV[i];
@@ -96,7 +96,7 @@ static void blake2b_init0( blake2b_state *S )
 int blake2b_init_param( blake2b_state *S, const blake2b_param *P )
 {
   const uint8_t *p = ( const uint8_t * )( P );
-  size_t i;
+  size_t i = 0;
 
   blake2b_init0( S );
 
@@ -112,7 +112,7 @@ int blake2b_init_param( blake2b_state *S, const blake2b_param *P )
 /* Sequential blake2b initialization */
 int blake2b_Init( blake2b_state *S, size_t outlen )
 {
-  blake2b_param P[1];
+  blake2b_param P[1] = {0};
 
   if ( ( !outlen ) || ( outlen > BLAKE2B_OUTBYTES ) ) return -1;
 
@@ -133,7 +133,7 @@ int blake2b_Init( blake2b_state *S, size_t outlen )
 
 int blake2b_InitPersonal( blake2b_state *S, size_t outlen, const void *personal, size_t personal_len)
 {
-  blake2b_param P[1];
+  blake2b_param P[1] = {0};
 
   if ( ( !outlen ) || ( outlen > BLAKE2B_OUTBYTES ) ) return -1;
   if ( ( !personal ) || ( personal_len != BLAKE2B_PERSONALBYTES ) ) return -1;
@@ -155,7 +155,7 @@ int blake2b_InitPersonal( blake2b_state *S, size_t outlen, const void *personal,
 
 int blake2b_InitKey( blake2b_state *S, size_t outlen, const void *key, size_t keylen )
 {
-  blake2b_param P[1];
+  blake2b_param P[1] = {0};
 
   if ( ( !outlen ) || ( outlen > BLAKE2B_OUTBYTES ) ) return -1;
 
@@ -177,7 +177,7 @@ int blake2b_InitKey( blake2b_state *S, size_t outlen, const void *key, size_t ke
   if( blake2b_init_param( S, P ) < 0 ) return -1;
 
   {
-    uint8_t block[BLAKE2B_BLOCKBYTES];
+    uint8_t block[BLAKE2B_BLOCKBYTES] = {0};
     memzero( block, BLAKE2B_BLOCKBYTES );
     memcpy( block, key, keylen );
     blake2b_Update( S, block, BLAKE2B_BLOCKBYTES );
@@ -212,9 +212,9 @@ int blake2b_InitKey( blake2b_state *S, size_t outlen, const void *key, size_t ke
 
 static void blake2b_compress( blake2b_state *S, const uint8_t block[BLAKE2B_BLOCKBYTES] )
 {
-  uint64_t m[16];
-  uint64_t v[16];
-  size_t i;
+  uint64_t m[16] = {0};
+  uint64_t v[16] = {0};
+  size_t i = 0;
 
   for( i = 0; i < 16; ++i ) {
     m[i] = load64( block + i * sizeof( m[i] ) );
@@ -284,7 +284,7 @@ int blake2b_Update( blake2b_state *S, const void *pin, size_t inlen )
 int blake2b_Final( blake2b_state *S, void *out, size_t outlen )
 {
   uint8_t buffer[BLAKE2B_OUTBYTES] = {0};
-  size_t i;
+  size_t i = 0;
 
   if( out == NULL || outlen < S->outlen )
     return -1;

--- a/crypto/blake2s.c
+++ b/crypto/blake2s.c
@@ -81,7 +81,7 @@ static void blake2s_increment_counter( blake2s_state *S, const uint32_t inc )
 
 static void blake2s_init0( blake2s_state *S )
 {
-  size_t i;
+  size_t i = 0;
   memzero( S, sizeof( blake2s_state ) );
 
   for( i = 0; i < 8; ++i ) S->h[i] = blake2s_IV[i];
@@ -91,7 +91,7 @@ static void blake2s_init0( blake2s_state *S )
 int blake2s_init_param( blake2s_state *S, const blake2s_param *P )
 {
   const unsigned char *p = ( const unsigned char * )( P );
-  size_t i;
+  size_t i = 0;
 
   blake2s_init0( S );
 
@@ -107,7 +107,7 @@ int blake2s_init_param( blake2s_state *S, const blake2s_param *P )
 /* Sequential blake2s initialization */
 int blake2s_Init( blake2s_state *S, size_t outlen )
 {
-  blake2s_param P[1];
+  blake2s_param P[1] = {0};
 
   if ( ( !outlen ) || ( outlen > BLAKE2S_OUTBYTES ) ) return -1;
 
@@ -128,7 +128,7 @@ int blake2s_Init( blake2s_state *S, size_t outlen )
 
 int blake2s_InitPersonal( blake2s_state *S, size_t outlen, const void *personal, size_t personal_len)
 {
-  blake2s_param P[1];
+  blake2s_param P[1] = {0};
 
   if ( ( !outlen ) || ( outlen > BLAKE2S_OUTBYTES ) ) return -1;
   if ( ( !personal ) || ( personal_len != BLAKE2S_PERSONALBYTES ) ) return -1;
@@ -151,7 +151,7 @@ int blake2s_InitPersonal( blake2s_state *S, size_t outlen, const void *personal,
 
 int blake2s_InitKey( blake2s_state *S, size_t outlen, const void *key, size_t keylen )
 {
-  blake2s_param P[1];
+  blake2s_param P[1] = {0};
 
   if ( ( !outlen ) || ( outlen > BLAKE2S_OUTBYTES ) ) return -1;
 
@@ -173,7 +173,7 @@ int blake2s_InitKey( blake2s_state *S, size_t outlen, const void *key, size_t ke
   if( blake2s_init_param( S, P ) < 0 ) return -1;
 
   {
-    uint8_t block[BLAKE2S_BLOCKBYTES];
+    uint8_t block[BLAKE2S_BLOCKBYTES] = {0};
     memzero( block, BLAKE2S_BLOCKBYTES );
     memcpy( block, key, keylen );
     blake2s_Update( S, block, BLAKE2S_BLOCKBYTES );
@@ -208,9 +208,9 @@ int blake2s_InitKey( blake2s_state *S, size_t outlen, const void *key, size_t ke
 
 static void blake2s_compress( blake2s_state *S, const uint8_t in[BLAKE2S_BLOCKBYTES] )
 {
-  uint32_t m[16];
-  uint32_t v[16];
-  size_t i;
+  uint32_t m[16] = {0};
+  uint32_t v[16] = {0};
+  size_t i = 0;
 
   for( i = 0; i < 16; ++i ) {
     m[i] = load32( in + i * sizeof( m[i] ) );
@@ -278,7 +278,7 @@ int blake2s_Update( blake2s_state *S, const void *pin, size_t inlen )
 int blake2s_Final( blake2s_state *S, void *out, size_t outlen )
 {
   uint8_t buffer[BLAKE2S_OUTBYTES] = {0};
-  size_t i;
+  size_t i = 0;
 
   if( out == NULL || outlen < S->outlen )
     return -1;

--- a/crypto/cash_addr.c
+++ b/crypto/cash_addr.c
@@ -87,9 +87,9 @@ int cash_encode(char* output, const char* hrp, const uint8_t* data,
 
 int cash_decode(char* hrp, uint8_t* data, size_t* data_len, const char* input) {
   uint64_t chk = 1;
-  size_t i;
+  size_t i = 0;
   size_t input_len = strlen(input);
-  size_t hrp_len;
+  size_t hrp_len = 0;
   int have_lower = 0, have_upper = 0;
   if (input_len < CHECKSUM_SIZE || input_len > MAX_CASHADDR_SIZE) {
     return 0;
@@ -167,7 +167,7 @@ static int convert_bits(uint8_t* out, size_t* outlen, int outbits,
 
 int cash_addr_encode(char* output, const char* hrp, const uint8_t* data,
                      size_t data_len) {
-  uint8_t base32[MAX_BASE32_SIZE];
+  uint8_t base32[MAX_BASE32_SIZE] = {0};
   size_t base32len = 0;
   if (data_len < 2 || data_len > MAX_DATA_SIZE) return 0;
   convert_bits(base32, &base32len, 5, data, data_len, 8, 1);
@@ -176,9 +176,9 @@ int cash_addr_encode(char* output, const char* hrp, const uint8_t* data,
 
 int cash_addr_decode(uint8_t* witdata, size_t* witdata_len, const char* hrp,
                      const char* addr) {
-  uint8_t data[MAX_BASE32_SIZE];
-  char hrp_actual[MAX_HRP_SIZE + 1];
-  size_t data_len;
+  uint8_t data[MAX_BASE32_SIZE] = {0};
+  char hrp_actual[MAX_HRP_SIZE + 1] = {0};
+  size_t data_len = 0;
   if (!cash_decode(hrp_actual, data, &data_len, addr)) return 0;
   if (data_len == 0 || data_len > MAX_BASE32_SIZE) return 0;
   if (strncmp(hrp, hrp_actual, MAX_HRP_SIZE + 1) != 0) return 0;

--- a/crypto/chacha20poly1305/chacha20poly1305.c
+++ b/crypto/chacha20poly1305/chacha20poly1305.c
@@ -13,7 +13,7 @@ void hchacha20(ECRYPT_ctx *x,u8 *c);
 void xchacha20poly1305_init(chacha20poly1305_ctx *ctx, const uint8_t key[32], const uint8_t nonce[24]) {
     unsigned char subkey[32] = {0};
     unsigned char block0[64] = {0};
-    ECRYPT_ctx tmp;
+    ECRYPT_ctx tmp = {0};
 
     // Generate the Chacha20 key by applying HChaCha20 to the
     // original key and the first 16 bytes of the nonce.

--- a/crypto/chacha20poly1305/chacha_merged.c
+++ b/crypto/chacha20poly1305/chacha_merged.c
@@ -29,7 +29,7 @@ static const char tau[16] = "expand 16-byte k";
 void ECRYPT_keysetup(ECRYPT_ctx *x,const u8 *k,u32 kbits,u32 ivbits)
 {
   (void)ivbits;
-  const char *constants;
+  const char *constants = NULL;
 
   x->input[4] = U8TO32_LITTLE(k + 0);
   x->input[5] = U8TO32_LITTLE(k + 4);
@@ -61,11 +61,11 @@ void ECRYPT_ivsetup(ECRYPT_ctx *x,const u8 *iv)
 
 void ECRYPT_encrypt_bytes(ECRYPT_ctx *x,const u8 *m,u8 *c,u32 bytes)
 {
-  u32 x0, x1, x2, x3, x4, x5, x6, x7, x8, x9, x10, x11, x12, x13, x14, x15;
-  u32 j0, j1, j2, j3, j4, j5, j6, j7, j8, j9, j10, j11, j12, j13, j14, j15;
+  u32 x0 = 0, x1 = 0, x2 = 0, x3 = 0, x4 = 0, x5 = 0, x6 = 0, x7 = 0, x8 = 0, x9 = 0, x10 = 0, x11 = 0, x12 = 0, x13 = 0, x14 = 0, x15 = 0;
+  u32 j0 = 0, j1 = 0, j2 = 0, j3 = 0, j4 = 0, j5 = 0, j6 = 0, j7 = 0, j8 = 0, j9 = 0, j10 = 0, j11 = 0, j12 = 0, j13 = 0, j14 = 0, j15 = 0;
   u8 *ctarget = 0;
-  u8 tmp[64];
-  int i;
+  u8 tmp[64] = {0};
+  int i = 0;
 
   if (!bytes) return;
 
@@ -197,15 +197,15 @@ void ECRYPT_decrypt_bytes(ECRYPT_ctx *x,const u8 *c,u8 *m,u32 bytes)
 
 void ECRYPT_keystream_bytes(ECRYPT_ctx *x,u8 *stream,u32 bytes)
 {
-  u32 i;
+  u32 i = 0;
   for (i = 0;i < bytes;++i) stream[i] = 0;
   ECRYPT_encrypt_bytes(x,stream,stream,bytes);
 }
 
 void hchacha20(ECRYPT_ctx *x,u8 *c)
 {
-  u32 x0, x1, x2, x3, x4, x5, x6, x7, x8, x9, x10, x11, x12, x13, x14, x15;
-  int i;
+  u32 x0 = 0, x1 = 0, x2 = 0, x3 = 0, x4 = 0, x5 = 0, x6 = 0, x7 = 0, x8 = 0, x9 = 0, x10 = 0, x11 = 0, x12 = 0, x13 = 0, x14 = 0, x15 = 0;
+  int i = 0;
 
   x0 = x->input[0];
   x1 = x->input[1];

--- a/crypto/chacha20poly1305/poly1305-donna.c
+++ b/crypto/chacha20poly1305/poly1305-donna.c
@@ -4,7 +4,7 @@
 void
 poly1305_update(poly1305_context *ctx, const unsigned char *m, size_t bytes) {
 	poly1305_state_internal_t *st = (poly1305_state_internal_t *)ctx;
-	size_t i;
+	size_t i = 0;
 
 	/* handle leftover */
 	if (st->leftover) {
@@ -40,7 +40,7 @@ poly1305_update(poly1305_context *ctx, const unsigned char *m, size_t bytes) {
 
 void
 poly1305_auth(unsigned char mac[16], const unsigned char *m, size_t bytes, const unsigned char key[32]) {
-	poly1305_context ctx;
+	poly1305_context ctx = {0};
 	poly1305_init(&ctx, key);
 	poly1305_update(&ctx, m, bytes);
 	poly1305_finish(&ctx, mac);
@@ -48,7 +48,7 @@ poly1305_auth(unsigned char mac[16], const unsigned char *m, size_t bytes, const
 
 int
 poly1305_verify(const unsigned char mac1[16], const unsigned char mac2[16]) {
-	size_t i;
+	size_t i = 0;
 	unsigned int dif = 0;
 	for (i = 0; i < 16; i++)
 		dif |= (mac1[i] ^ mac2[i]);
@@ -127,12 +127,12 @@ poly1305_power_on_self_test(void) {
 		0xd2,0x87,0xf9,0x7c,0x44,0x62,0x3d,0x39
 	};
 
-	poly1305_context ctx;
-	poly1305_context total_ctx;
-	unsigned char all_key[32];
-	unsigned char all_msg[256];
-	unsigned char mac[16];
-	size_t i, j;
+	poly1305_context ctx = {0};
+	poly1305_context total_ctx = {0};
+	unsigned char all_key[32] = {0};
+	unsigned char all_msg[256] = {0};
+	unsigned char mac[16] = {0};
+	size_t i = 0, j = 0;
 	int result = 1;
 
 	for (i = 0; i < sizeof(mac); i++)

--- a/crypto/ecdsa.c
+++ b/crypto/ecdsa.c
@@ -43,7 +43,7 @@ void point_copy(const curve_point *cp1, curve_point *cp2) { *cp2 = *cp1; }
 // cp2 = cp1 + cp2
 void point_add(const ecdsa_curve *curve, const curve_point *cp1,
                curve_point *cp2) {
-  bignum256 lambda, inv, xr, yr;
+  bignum256 lambda = {0}, inv = {0}, xr = {0}, yr = {0};
 
   if (point_is_infinity(cp1)) {
     return;
@@ -88,7 +88,7 @@ void point_add(const ecdsa_curve *curve, const curve_point *cp1,
 
 // cp = cp + cp
 void point_double(const ecdsa_curve *curve, curve_point *cp) {
-  bignum256 lambda, xr, yr;
+  bignum256 lambda = {0}, xr = {0}, yr = {0};
 
   if (point_is_infinity(cp)) {
     return;
@@ -165,7 +165,7 @@ int point_is_negative_of(const curve_point *p, const curve_point *q) {
 // Negate a (modulo prime) if cond is 0xffffffff, keep it if cond is 0.
 // The timing of this function does not depend on cond.
 void conditional_negate(uint32_t cond, bignum256 *a, const bignum256 *prime) {
-  int j;
+  int j = 0;
   uint32_t tmp = 1;
   assert(a->val[8] < 0x20000);
   for (j = 0; j < 8; j++) {
@@ -185,7 +185,7 @@ typedef struct jacobian_curve_point {
 // generate random K for signing/side-channel noise
 static void generate_k_random(bignum256 *k, const bignum256 *prime) {
   do {
-    int i;
+    int i = 0;
     for (i = 0; i < 8; i++) {
       k->val[i] = random32() & 0x3FFFFFFF;
     }
@@ -230,10 +230,10 @@ void jacobian_to_curve(const jacobian_curve_point *jp, curve_point *p,
 
 void point_jacobian_add(const curve_point *p1, jacobian_curve_point *p2,
                         const ecdsa_curve *curve) {
-  bignum256 r, h, r2;
-  bignum256 hcby, hsqx;
-  bignum256 xz, yz, az;
-  int is_doubling;
+  bignum256 r = {0}, h = {0}, r2 = {0};
+  bignum256 hcby = {0}, hsqx = {0};
+  bignum256 xz = {0}, yz = {0}, az = {0};
+  int is_doubling = 0;
   const bignum256 *prime = &curve->prime;
   int a = curve->a;
 
@@ -348,7 +348,7 @@ void point_jacobian_add(const curve_point *p1, jacobian_curve_point *p2,
 }
 
 void point_jacobian_double(jacobian_curve_point *p, const ecdsa_curve *curve) {
-  bignum256 az4, m, msq, ysq, xysq;
+  bignum256 az4 = {0}, m = {0}, msq = {0}, ysq = {0}, xysq = {0};
   const bignum256 *prime = &curve->prime;
 
   assert(-3 <= curve->a && curve->a <= 0);
@@ -424,15 +424,15 @@ void point_multiply(const ecdsa_curve *curve, const bignum256 *k,
   //  Side Channel Attacks.
   assert(bn_is_less(k, &curve->order));
 
-  int i, j;
+  int i = 0, j = 0;
   static CONFIDENTIAL bignum256 a;
-  uint32_t *aptr;
-  uint32_t abits;
-  int ashift;
+  uint32_t *aptr = NULL;
+  uint32_t abits = 0;
+  int ashift = 0;
   uint32_t is_even = (k->val[0] & 1) - 1;
-  uint32_t bits, sign, nsign;
+  uint32_t bits = {0}, sign = {0}, nsign = {0};
   static CONFIDENTIAL jacobian_curve_point jres;
-  curve_point pmult[8];
+  curve_point pmult[8] = {0};
   const bignum256 *prime = &curve->prime;
 
   // is_even = 0xffffffff if k is even, 0 otherwise.
@@ -545,10 +545,10 @@ void scalar_multiply(const ecdsa_curve *curve, const bignum256 *k,
                      curve_point *res) {
   assert(bn_is_less(k, &curve->order));
 
-  int i, j;
+  int i = {0}, j = {0};
   static CONFIDENTIAL bignum256 a;
   uint32_t is_even = (k->val[0] & 1) - 1;
-  uint32_t lowbits;
+  uint32_t lowbits = 0;
   static CONFIDENTIAL jacobian_curve_point jres;
   const bignum256 *prime = &curve->prime;
 
@@ -636,12 +636,12 @@ void scalar_multiply(const ecdsa_curve *curve, const bignum256 *k,
 
 int ecdh_multiply(const ecdsa_curve *curve, const uint8_t *priv_key,
                   const uint8_t *pub_key, uint8_t *session_key) {
-  curve_point point;
+  curve_point point = {0};
   if (!ecdsa_read_pubkey(curve, pub_key, &point)) {
     return 1;
   }
 
-  bignum256 k;
+  bignum256 k = {0};
   bn_read_be(priv_key, &k);
   point_multiply(curve, &k, &point, &point);
   memzero(&k, sizeof(k));
@@ -660,7 +660,7 @@ int ecdsa_sign(const ecdsa_curve *curve, HasherType hasher_sign,
                const uint8_t *priv_key, const uint8_t *msg, uint32_t msg_len,
                uint8_t *sig, uint8_t *pby,
                int (*is_canonical)(uint8_t by, uint8_t sig[64])) {
-  uint8_t hash[32];
+  uint8_t hash[32] = {0};
   hasher_Raw(hasher_sign, msg, msg_len, hash);
   int res = ecdsa_sign_digest(curve, priv_key, hash, sig, pby, is_canonical);
   memzero(hash, sizeof(hash));
@@ -676,14 +676,14 @@ int ecdsa_sign(const ecdsa_curve *curve, HasherType hasher_sign,
 int ecdsa_sign_digest(const ecdsa_curve *curve, const uint8_t *priv_key,
                       const uint8_t *digest, uint8_t *sig, uint8_t *pby,
                       int (*is_canonical)(uint8_t by, uint8_t sig[64])) {
-  int i;
-  curve_point R;
-  bignum256 k, z, randk;
+  int i = 0;
+  curve_point R = {0};
+  bignum256 k = {0}, z = {0}, randk = {0};
   bignum256 *s = &R.y;
   uint8_t by;  // signature recovery byte
 
 #if USE_RFC6979
-  rfc6979_state rng;
+  rfc6979_state rng = {0};
   init_rfc6979(priv_key, digest, &rng);
 #endif
 
@@ -768,8 +768,8 @@ int ecdsa_sign_digest(const ecdsa_curve *curve, const uint8_t *priv_key,
 
 void ecdsa_get_public_key33(const ecdsa_curve *curve, const uint8_t *priv_key,
                             uint8_t *pub_key) {
-  curve_point R;
-  bignum256 k;
+  curve_point R = {0};
+  bignum256 k = {0};
 
   bn_read_be(priv_key, &k);
   // compute k*G
@@ -782,8 +782,8 @@ void ecdsa_get_public_key33(const ecdsa_curve *curve, const uint8_t *priv_key,
 
 void ecdsa_get_public_key65(const ecdsa_curve *curve, const uint8_t *priv_key,
                             uint8_t *pub_key) {
-  curve_point R;
-  bignum256 k;
+  curve_point R = {0};
+  bignum256 k = {0};
 
   bn_read_be(priv_key, &k);
   // compute k*G
@@ -797,7 +797,7 @@ void ecdsa_get_public_key65(const ecdsa_curve *curve, const uint8_t *priv_key,
 
 int ecdsa_uncompress_pubkey(const ecdsa_curve *curve, const uint8_t *pub_key,
                             uint8_t *uncompressed) {
-  curve_point pub;
+  curve_point pub = {0};
 
   if (!ecdsa_read_pubkey(curve, pub_key, &pub)) {
     return 0;
@@ -812,7 +812,7 @@ int ecdsa_uncompress_pubkey(const ecdsa_curve *curve, const uint8_t *pub_key,
 
 void ecdsa_get_pubkeyhash(const uint8_t *pub_key, HasherType hasher_pubkey,
                           uint8_t *pubkeyhash) {
-  uint8_t h[HASHER_DIGEST_LENGTH];
+  uint8_t h[HASHER_DIGEST_LENGTH] = {0};
   if (pub_key[0] == 0x04) {  // uncompressed format
     hasher_Raw(hasher_pubkey, pub_key, 65, h);
   } else if (pub_key[0] == 0x00) {  // point at infinity
@@ -834,7 +834,7 @@ void ecdsa_get_address_raw(const uint8_t *pub_key, uint32_t version,
 void ecdsa_get_address(const uint8_t *pub_key, uint32_t version,
                        HasherType hasher_pubkey, HasherType hasher_base58,
                        char *addr, int addrsize) {
-  uint8_t raw[MAX_ADDR_RAW_SIZE];
+  uint8_t raw[MAX_ADDR_RAW_SIZE] = {0};
   size_t prefix_len = address_prefix_bytes_len(version);
   ecdsa_get_address_raw(pub_key, version, hasher_pubkey, raw);
   base58_encode_check(raw, 20 + prefix_len, hasher_base58, addr, addrsize);
@@ -845,7 +845,7 @@ void ecdsa_get_address(const uint8_t *pub_key, uint32_t version,
 void ecdsa_get_address_segwit_p2sh_raw(const uint8_t *pub_key, uint32_t version,
                                        HasherType hasher_pubkey,
                                        uint8_t *addr_raw) {
-  uint8_t buf[32 + 2];
+  uint8_t buf[32 + 2] = {0};
   buf[0] = 0;   // version byte
   buf[1] = 20;  // push 20 bytes
   ecdsa_get_pubkeyhash(pub_key, hasher_pubkey, buf + 2);
@@ -858,7 +858,7 @@ void ecdsa_get_address_segwit_p2sh(const uint8_t *pub_key, uint32_t version,
                                    HasherType hasher_pubkey,
                                    HasherType hasher_base58, char *addr,
                                    int addrsize) {
-  uint8_t raw[MAX_ADDR_RAW_SIZE];
+  uint8_t raw[MAX_ADDR_RAW_SIZE] = {0};
   size_t prefix_len = address_prefix_bytes_len(version);
   ecdsa_get_address_segwit_p2sh_raw(pub_key, version, hasher_pubkey, raw);
   base58_encode_check(raw, prefix_len + 20, hasher_base58, addr, addrsize);
@@ -867,7 +867,7 @@ void ecdsa_get_address_segwit_p2sh(const uint8_t *pub_key, uint32_t version,
 
 void ecdsa_get_wif(const uint8_t *priv_key, uint32_t version,
                    HasherType hasher_base58, char *wif, int wifsize) {
-  uint8_t wif_raw[MAX_WIF_RAW_SIZE];
+  uint8_t wif_raw[MAX_WIF_RAW_SIZE] = {0};
   size_t prefix_len = address_prefix_bytes_len(version);
   address_write_prefix_bytes(version, wif_raw);
   memcpy(wif_raw + prefix_len, priv_key, 32);
@@ -931,7 +931,7 @@ int ecdsa_read_pubkey(const ecdsa_curve *curve, const uint8_t *pub_key,
 //   - pub is on the curve.
 
 int ecdsa_validate_pubkey(const ecdsa_curve *curve, const curve_point *pub) {
-  bignum256 y_2, x3_ax_b;
+  bignum256 y_2 = {0}, x3_ax_b = {0};
 
   if (point_is_infinity(pub)) {
     return 0;
@@ -972,7 +972,7 @@ int ecdsa_validate_pubkey(const ecdsa_curve *curve, const curve_point *pub) {
 int ecdsa_verify(const ecdsa_curve *curve, HasherType hasher_sign,
                  const uint8_t *pub_key, const uint8_t *sig, const uint8_t *msg,
                  uint32_t msg_len) {
-  uint8_t hash[32];
+  uint8_t hash[32] = {0};
   hasher_Raw(hasher_sign, msg, msg_len, hash);
   int res = ecdsa_verify_digest(curve, pub_key, sig, hash);
   memzero(hash, sizeof(hash));
@@ -984,8 +984,8 @@ int ecdsa_verify(const ecdsa_curve *curve, HasherType hasher_sign,
 int ecdsa_recover_pub_from_sig(const ecdsa_curve *curve, uint8_t *pub_key,
                                const uint8_t *sig, const uint8_t *digest,
                                int recid) {
-  bignum256 r, s, e;
-  curve_point cp, cp2;
+  bignum256 r = {0}, s = {0}, e = {0};
+  curve_point cp = {0}, cp2 = {0};
 
   // read r and s
   bn_read_be(sig, &r);
@@ -1033,8 +1033,8 @@ int ecdsa_recover_pub_from_sig(const ecdsa_curve *curve, uint8_t *pub_key,
 // returns 0 if verification succeeded
 int ecdsa_verify_digest(const ecdsa_curve *curve, const uint8_t *pub_key,
                         const uint8_t *sig, const uint8_t *digest) {
-  curve_point pub, res;
-  bignum256 r, s, z;
+  curve_point pub = {0}, res = {0};
+  bignum256 r = {0}, s = {0}, z = {0};
 
   if (!ecdsa_read_pubkey(curve, pub_key, &pub)) {
     return 1;
@@ -1087,8 +1087,8 @@ int ecdsa_verify_digest(const ecdsa_curve *curve, const uint8_t *pub_key,
 }
 
 int ecdsa_sig_to_der(const uint8_t *sig, uint8_t *der) {
-  int i;
-  uint8_t *p = der, *len, *len1, *len2;
+  int i = 0;
+  uint8_t *p = der, *len = NULL, *len1 = NULL, *len2 = NULL;
   *p = 0x30;
   p++;  // sequence
   *p = 0x00;

--- a/crypto/ed25519-donna/curve25519-donna-32bit.c
+++ b/crypto/ed25519-donna/curve25519-donna-32bit.c
@@ -39,7 +39,7 @@ void curve25519_add(bignum25519 out, const bignum25519 a, const bignum25519 b) {
 }
 
 void curve25519_add_after_basic(bignum25519 out, const bignum25519 a, const bignum25519 b) {
-	uint32_t c;
+	uint32_t c = 0;
 	out[0] = a[0] + b[0]    ; c = (out[0] >> 26); out[0] &= reduce_mask_26;
 	out[1] = a[1] + b[1] + c; c = (out[1] >> 25); out[1] &= reduce_mask_25;
 	out[2] = a[2] + b[2] + c; c = (out[2] >> 26); out[2] &= reduce_mask_26;
@@ -54,7 +54,7 @@ void curve25519_add_after_basic(bignum25519 out, const bignum25519 a, const bign
 }
 
 void curve25519_add_reduce(bignum25519 out, const bignum25519 a, const bignum25519 b) {
-	uint32_t c;
+	uint32_t c = 0;
 	out[0] = a[0] + b[0]    ; c = (out[0] >> 26); out[0] &= reduce_mask_26;
 	out[1] = a[1] + b[1] + c; c = (out[1] >> 25); out[1] &= reduce_mask_25;
 	out[2] = a[2] + b[2] + c; c = (out[2] >> 26); out[2] &= reduce_mask_26;
@@ -78,7 +78,7 @@ static const uint32_t fourP2468   = 0x0ffffffc;
 
 /* out = a - b */
 void curve25519_sub(bignum25519 out, const bignum25519 a, const bignum25519 b) {
-	uint32_t c;
+	uint32_t c = 0;
 	out[0] = twoP0     + a[0] - b[0]    ; c = (out[0] >> 26); out[0] &= reduce_mask_26;
 	out[1] = twoP13579 + a[1] - b[1] + c; c = (out[1] >> 25); out[1] &= reduce_mask_25;
 	out[2] = twoP2468  + a[2] - b[2] + c; c = (out[2] >> 26); out[2] &= reduce_mask_26;
@@ -93,8 +93,8 @@ void curve25519_sub(bignum25519 out, const bignum25519 a, const bignum25519 b) {
 
 /* out = in * scalar */
 void curve25519_scalar_product(bignum25519 out, const bignum25519 in, const uint32_t scalar) {
-	uint64_t a;
-	uint32_t c;
+	uint64_t a = 0;
+	uint32_t c = 0;
 	a = mul32x32_64(in[0], scalar);     out[0] = (uint32_t)a & reduce_mask_26; c = (uint32_t)(a >> 26);
 	a = mul32x32_64(in[1], scalar) + c; out[1] = (uint32_t)a & reduce_mask_25; c = (uint32_t)(a >> 25);
 	a = mul32x32_64(in[2], scalar) + c; out[2] = (uint32_t)a & reduce_mask_26; c = (uint32_t)(a >> 26);
@@ -110,7 +110,7 @@ void curve25519_scalar_product(bignum25519 out, const bignum25519 in, const uint
 
 /* out = a - b, where a is the result of a basic op (add,sub) */
 void curve25519_sub_after_basic(bignum25519 out, const bignum25519 a, const bignum25519 b) {
-	uint32_t c;
+	uint32_t c = 0;
 	out[0] = fourP0     + a[0] - b[0]    ; c = (out[0] >> 26); out[0] &= reduce_mask_26;
 	out[1] = fourP13579 + a[1] - b[1] + c; c = (out[1] >> 25); out[1] &= reduce_mask_25;
 	out[2] = fourP2468  + a[2] - b[2] + c; c = (out[2] >> 26); out[2] &= reduce_mask_26;
@@ -125,7 +125,7 @@ void curve25519_sub_after_basic(bignum25519 out, const bignum25519 a, const bign
 }
 
 void curve25519_sub_reduce(bignum25519 out, const bignum25519 a, const bignum25519 b) {
-	uint32_t c;
+	uint32_t c = 0;
 	out[0] = fourP0     + a[0] - b[0]    ; c = (out[0] >> 26); out[0] &= reduce_mask_26;
 	out[1] = fourP13579 + a[1] - b[1] + c; c = (out[1] >> 25); out[1] &= reduce_mask_25;
 	out[2] = fourP2468  + a[2] - b[2] + c; c = (out[2] >> 26); out[2] &= reduce_mask_26;
@@ -141,7 +141,7 @@ void curve25519_sub_reduce(bignum25519 out, const bignum25519 a, const bignum255
 
 /* out = -a */
 void curve25519_neg(bignum25519 out, const bignum25519 a) {
-	uint32_t c;
+	uint32_t c = 0;
 	out[0] = twoP0     - a[0]    ; c = (out[0] >> 26); out[0] &= reduce_mask_26;
 	out[1] = twoP13579 - a[1] + c; c = (out[1] >> 25); out[1] &= reduce_mask_25;
 	out[2] = twoP2468  - a[2] + c; c = (out[2] >> 26); out[2] &= reduce_mask_26;
@@ -158,10 +158,10 @@ void curve25519_neg(bignum25519 out, const bignum25519 a) {
 /* out = a * b */
 #define curve25519_mul_noinline curve25519_mul
 void curve25519_mul(bignum25519 out, const bignum25519 a, const bignum25519 b) {
-	uint32_t r0,r1,r2,r3,r4,r5,r6,r7,r8,r9;
-	uint32_t s0,s1,s2,s3,s4,s5,s6,s7,s8,s9;
-	uint64_t m0,m1,m2,m3,m4,m5,m6,m7,m8,m9,c;
-	uint32_t p;
+	uint32_t r0 = 0, r1 = 0, r2 = 0, r3 = 0, r4 = 0, r5 = 0, r6 = 0, r7 = 0, r8 = 0, r9 = 0;
+	uint32_t s0 = 0, s1 = 0, s2 = 0, s3 = 0, s4 = 0, s5 = 0, s6 = 0, s7 = 0, s8 = 0, s9 = 0;
+	uint64_t m0 = 0, m1 = 0, m2 = 0, m3 = 0, m4 = 0, m5 = 0, m6 = 0, m7 = 0, m8 = 0, m9 = 0, c = 0;
+	uint32_t p = 0;
 
 	r0 = b[0];
 	r1 = b[1];
@@ -255,10 +255,10 @@ void curve25519_mul(bignum25519 out, const bignum25519 a, const bignum25519 b) {
 
 /* out = in * in */
 void curve25519_square(bignum25519 out, const bignum25519 in) {
-	uint32_t r0,r1,r2,r3,r4,r5,r6,r7,r8,r9;
-	uint32_t d6,d7,d8,d9;
-	uint64_t m0,m1,m2,m3,m4,m5,m6,m7,m8,m9,c;
-	uint32_t p;
+	uint32_t r0 = 0, r1 = 0, r2 = 0, r3 = 0, r4 = 0, r5 = 0, r6 = 0, r7 = 0, r8 = 0, r9 = 0;
+	uint32_t d6 = 0, d7 = 0, d8 = 0, d9 = 0;
+	uint64_t m0 = 0, m1 = 0, m2 = 0, m3 = 0, m4 = 0, m5 = 0, m6 = 0, m7 = 0, m8 = 0, m9 = 0, c = 0;
+	uint32_t p = 0;
 
 	r0 = in[0];
 	r1 = in[1];
@@ -328,10 +328,10 @@ void curve25519_square(bignum25519 out, const bignum25519 in) {
 
 /* out = in ^ (2 * count) */
 void curve25519_square_times(bignum25519 out, const bignum25519 in, int count) {
-	uint32_t r0,r1,r2,r3,r4,r5,r6,r7,r8,r9;
-	uint32_t d6,d7,d8,d9;
-	uint64_t m0,m1,m2,m3,m4,m5,m6,m7,m8,m9,c;
-	uint32_t p;
+	uint32_t r0 = 0, r1 = 0, r2 = 0, r3 = 0, r4 = 0, r5 = 0, r6 = 0, r7 = 0, r8 = 0, r9 = 0;
+	uint32_t d6 = 0, d7 = 0, d8 = 0, d9 = 0;
+	uint64_t m0 = 0, m1 = 0, m2 = 0, m3 = 0, m4 = 0, m5 = 0, m6 = 0, m7 = 0, m8 = 0, m9 = 0, c = 0;
+	uint32_t p = 0;
 
 	r0 = in[0];
 	r1 = in[1];
@@ -403,7 +403,7 @@ void curve25519_square_times(bignum25519 out, const bignum25519 in, int count) {
 
 /* Take a little-endian, 32-byte number and expand it into polynomial form */
 void curve25519_expand(bignum25519 out, const unsigned char in[32]) {
-	uint32_t x0,x1,x2,x3,x4,x5,x6,x7;
+	uint32_t x0 = 0, x1 = 0, x2 = 0, x3 = 0, x4 = 0, x5 = 0, x6 = 0, x7 = 0;
 	#define F(s)							 \
 			((((uint32_t)in[s + 0])      ) | \
 			 (((uint32_t)in[s + 1]) <<  8) | \
@@ -435,7 +435,7 @@ void curve25519_expand(bignum25519 out, const unsigned char in[32]) {
  * little-endian, 32-byte array
  */
 void curve25519_contract(unsigned char out[32], const bignum25519 in) {
-	bignum25519 f;
+	bignum25519 f = {0};
 	curve25519_copy(f, in);
 
 	#define carry_pass() \
@@ -517,7 +517,7 @@ void curve25519_contract(unsigned char out[32], const bignum25519 in) {
 /* if (iswap) swap(a, b) */
 void curve25519_swap_conditional(bignum25519 a, bignum25519 b, uint32_t iswap) {
 	const uint32_t swap = (uint32_t)(-(int32_t)iswap);
-	uint32_t x0,x1,x2,x3,x4,x5,x6,x7,x8,x9;
+	uint32_t x0 = 0, x1 = 0, x2 = 0, x3 = 0, x4 = 0, x5 = 0, x6 = 0, x7 = 0, x8 = 0, x9 = 0;
 
 	x0 = swap & (a[0] ^ b[0]); a[0] ^= x0; b[0] ^= x0;
 	x1 = swap & (a[1] ^ b[1]); a[1] ^= x1; b[1] ^= x1;
@@ -557,13 +557,13 @@ void curve25519_set_sqrtneg1(bignum25519 r){
 }
 
 int curve25519_isnegative(const bignum25519 f) {
-	unsigned char s[32];
+	unsigned char s[32] = {0};
 	curve25519_contract(s, f);
 	return s[0] & 1;
 }
 
 int curve25519_isnonzero(const bignum25519 f) {
-	unsigned char s[32];
+	unsigned char s[32] = {0};
 	curve25519_contract(s, f);
 	return ((((int) (s[0] | s[1] | s[2] | s[3] | s[4] | s[5] | s[6] | s[7] | s[8] |
 									s[9] | s[10] | s[11] | s[12] | s[13] | s[14] | s[15] | s[16] | s[17] |
@@ -572,7 +572,7 @@ int curve25519_isnonzero(const bignum25519 f) {
 }
 
 void curve25519_reduce(bignum25519 out, const bignum25519 in) {
-	uint32_t c;
+	uint32_t c = 0;
 	out[0] = in[0]    ; c = (out[0] >> 26); out[0] &= reduce_mask_26;
 	out[1] = in[1] + c; c = (out[1] >> 25); out[1] &= reduce_mask_25;
 	out[2] = in[2] + c; c = (out[2] >> 26); out[2] &= reduce_mask_26;
@@ -588,7 +588,7 @@ void curve25519_reduce(bignum25519 out, const bignum25519 in) {
 
 void curve25519_divpowm1(bignum25519 r, const bignum25519 u, const bignum25519 v) {
 	bignum25519 v3={0}, uv7={0}, t0={0}, t1={0}, t2={0};
-	int i;
+	int i = 0;
 
 	curve25519_square(v3, v);
 	curve25519_mul(v3, v3, v); /* v3 = v^3 */
@@ -650,7 +650,7 @@ void curve25519_divpowm1(bignum25519 r, const bignum25519 u, const bignum25519 v
 }
 
 void curve25519_expand_reduce(bignum25519 out, const unsigned char in[32]) {
-  uint32_t x0,x1,x2,x3,x4,x5,x6,x7;
+  uint32_t x0 = 0, x1 = 0, x2 = 0, x3 = 0, x4 = 0, x5 = 0, x6 = 0, x7 = 0;
 #define F(s) \
 			((((uint32_t)in[s + 0])      ) | \
 			 (((uint32_t)in[s + 1]) <<  8) | \

--- a/crypto/ed25519-donna/curve25519-donna-scalarmult-base.c
+++ b/crypto/ed25519-donna/curve25519-donna-scalarmult-base.c
@@ -9,10 +9,10 @@
  */
 
 void curve25519_scalarmult_donna(curve25519_key mypublic, const curve25519_key n, const curve25519_key basepoint) {
-	bignum25519 nqpqx = {1}, nqpqz = {0}, nqz = {1}, nqx;
-	bignum25519 q, qx, qpqx, qqx, zzz, zmone;
-	size_t bit, lastbit;
-	int32_t i;
+	bignum25519 nqpqx = {1}, nqpqz = {0}, nqz = {1}, nqx = {0};
+	bignum25519 q = {0}, qx = {0}, qpqx = {0}, qqx = {0}, zzz = {0}, zmone = {0};
+	size_t bit = 0, lastbit = 0;
+	int32_t i = 0;
 
 	curve25519_expand(q, basepoint);
 	curve25519_copy(nqx, q);

--- a/crypto/ed25519-donna/ed25519-donna-impl-base.c
+++ b/crypto/ed25519-donna/ed25519-donna-impl-base.c
@@ -67,7 +67,7 @@ void ge25519_full_to_pniels(ge25519_pniels *p, const ge25519 *r) {
 */
 
 void ge25519_double_p1p1(ge25519_p1p1 *r, const ge25519 *p) {
-	bignum25519 a,b,c;
+	bignum25519 a = {0}, b = {0}, c = {0};
 
 	curve25519_square(a, p->x);
 	curve25519_square(b, p->y);
@@ -85,7 +85,7 @@ void ge25519_double_p1p1(ge25519_p1p1 *r, const ge25519 *p) {
 void ge25519_nielsadd2_p1p1(ge25519_p1p1 *r, const ge25519 *p, const ge25519_niels *q, unsigned char signbit) {
 	const bignum25519 *qb = (const bignum25519 *)q;
 	bignum25519 *rb = (bignum25519 *)r;
-	bignum25519 a,b,c;
+	bignum25519 a = {0}, b = {0}, c = {0};
 
 	curve25519_sub(a, p->y, p->x);
 	curve25519_add(b, p->y, p->x);
@@ -104,7 +104,7 @@ void ge25519_nielsadd2_p1p1(ge25519_p1p1 *r, const ge25519 *p, const ge25519_nie
 void ge25519_pnielsadd_p1p1(ge25519_p1p1 *r, const ge25519 *p, const ge25519_pniels *q, unsigned char signbit) {
 	const bignum25519 *qb = (const bignum25519 *)q;
 	bignum25519 *rb = (bignum25519 *)r;
-	bignum25519 a,b,c;
+	bignum25519 a = {0}, b = {0}, c = {0};
 
 	curve25519_sub(a, p->y, p->x);
 	curve25519_add(b, p->y, p->x);
@@ -121,19 +121,19 @@ void ge25519_pnielsadd_p1p1(ge25519_p1p1 *r, const ge25519 *p, const ge25519_pni
 }
 
 void ge25519_double_partial(ge25519 *r, const ge25519 *p) {
-	ge25519_p1p1 t;
+	ge25519_p1p1 t = {0};
 	ge25519_double_p1p1(&t, p);
 	ge25519_p1p1_to_partial(r, &t);
 }
 
 void ge25519_double(ge25519 *r, const ge25519 *p) {
-	ge25519_p1p1 t;
+	ge25519_p1p1 t = {0};
 	ge25519_double_p1p1(&t, p);
 	ge25519_p1p1_to_full(r, &t);
 }
 
 void ge25519_nielsadd2(ge25519 *r, const ge25519_niels *q) {
-	bignum25519 a,b,c,e,f,g,h;
+	bignum25519 a = {0}, b = {0}, c = {0}, e = {0}, f = {0}, g = {0}, h = {0};
 
 	curve25519_sub(a, r->y, r->x);
 	curve25519_add(b, r->y, r->x);
@@ -152,7 +152,7 @@ void ge25519_nielsadd2(ge25519 *r, const ge25519_niels *q) {
 }
 
 void ge25519_pnielsadd(ge25519_pniels *r, const ge25519 *p, const ge25519_pniels *q) {
-	bignum25519 a,b,c,x,y,z,t;
+	bignum25519 a = {0}, b = {0}, c = {0}, x = {0}, y = {0}, z = {0}, t = {0};
 
 	curve25519_sub(a, p->y, p->x);
 	curve25519_add(b, p->y, p->x);
@@ -181,8 +181,8 @@ void ge25519_pnielsadd(ge25519_pniels *r, const ge25519 *p, const ge25519_pniels
 */
 
 void ge25519_pack(unsigned char r[32], const ge25519 *p) {
-	bignum25519 tx, ty, zi;
-	unsigned char parity[32];
+	bignum25519 tx = {0}, ty = {0}, zi = {0};
+	unsigned char parity[32] = {0};
 	curve25519_recip(zi, p->z);
 	curve25519_mul(tx, p->x, zi);
 	curve25519_mul(ty, p->y, zi);
@@ -195,8 +195,8 @@ int ge25519_unpack_negative_vartime(ge25519 *r, const unsigned char p[32]) {
 	const unsigned char zero[32] = {0};
 	const bignum25519 one = {1};
 	unsigned char parity = p[31] >> 7;
-	unsigned char check[32];
-	bignum25519 t, root, num, den, d3;
+	unsigned char check[32] = {0};
+	bignum25519 t = {0}, root = {0}, num = {0}, den = {0}, d3 = {0};
 
 	curve25519_expand(r->y, p);
 	curve25519_copy(r->z, one);
@@ -262,14 +262,14 @@ void ge25519_set_neutral(ge25519 *r)
 
 /* computes [s1]p1 + [s2]base */
 void ge25519_double_scalarmult_vartime(ge25519 *r, const ge25519 *p1, const bignum256modm s1, const bignum256modm s2) {
-	signed char slide1[256], slide2[256];
-	ge25519_pniels pre1[S1_TABLE_SIZE];
+	signed char slide1[256] = {0}, slide2[256] = {0};
+	ge25519_pniels pre1[S1_TABLE_SIZE] = {0};
 #ifdef ED25519_NO_PRECOMP
-	ge25519_pniels pre2[S2_TABLE_SIZE];
+	ge25519_pniels pre2[S2_TABLE_SIZE] = {0};
 #endif
-	ge25519 dp;
-	ge25519_p1p1 t;
-	int32_t i;
+	ge25519 dp = {0};
+	ge25519_p1p1 t = {0};
+	int32_t i = 0;
 
 	memzero(&t, sizeof(ge25519_p1p1));
 	contract256_slidingwindow_modm(slide1, s1, S1_SWINDOWSIZE);
@@ -320,12 +320,12 @@ void ge25519_double_scalarmult_vartime(ge25519 *r, const ge25519 *p1, const bign
 /* computes [s1]p1 + [s2]p2 */
 #if USE_MONERO
 void ge25519_double_scalarmult_vartime2(ge25519 *r, const ge25519 *p1, const bignum256modm s1, const ge25519 *p2, const bignum256modm s2) {
-	signed char slide1[256], slide2[256];
-	ge25519_pniels pre1[S1_TABLE_SIZE];
-	ge25519_pniels pre2[S1_TABLE_SIZE];
-	ge25519 dp;
-	ge25519_p1p1 t;
-	int32_t i;
+	signed char slide1[256] = {0}, slide2[256] = {0};
+	ge25519_pniels pre1[S1_TABLE_SIZE] = {0};
+	ge25519_pniels pre2[S1_TABLE_SIZE] = {0};
+	ge25519 dp = {0};
+	ge25519_p1p1 t = {0};
+	int32_t i = 0;
 
 	memzero(&t, sizeof(ge25519_p1p1));
 	contract256_slidingwindow_modm(slide1, s1, S1_SWINDOWSIZE);
@@ -378,7 +378,7 @@ void ge25519_double_scalarmult_vartime2(ge25519 *r, const ge25519 *p1, const big
  * with less than i686 on x86
  */
 static void ge25519_cmove_stride4(long * r, long * p, long * pos, long * n, int stride) {
-  long x0=r[0], x1=r[1], x2=r[2], x3=r[3], y0, y1, y2, y3;
+  long x0=r[0], x1=r[1], x2=r[2], x3=r[3], y0 = 0, y1 = 0, y2 = 0, y3 = 0;
   for(; p<n; p+=stride) {
     volatile int flag=(p==pos);
     y0 = p[0];
@@ -398,7 +398,7 @@ static void ge25519_cmove_stride4(long * r, long * p, long * pos, long * n, int 
 #define HAS_CMOVE_STRIDE4
 
 static void ge25519_cmove_stride4b(long * r, long * p, long * pos, long * n, int stride) {
-  long x0=p[0], x1=p[1], x2=p[2], x3=p[3], y0, y1, y2, y3;
+  long x0=p[0], x1=p[1], x2=p[2], x3=p[3], y0 = 0, y1 = 0, y2 = 0, y3 = 0;
   for(p+=stride; p<n; p+=stride) {
     volatile int flag=(p==pos);
     y0 = p[0];
@@ -419,7 +419,7 @@ static void ge25519_cmove_stride4b(long * r, long * p, long * pos, long * n, int
 
 void ge25519_move_conditional_pniels_array(ge25519_pniels * r, const ge25519_pniels * p, int pos, int n) {
 #ifdef HAS_CMOVE_STRIDE4B
-  size_t i;
+  size_t i = 0;
   for(i=0; i<sizeof(ge25519_pniels)/sizeof(long); i+=4) {
     ge25519_cmove_stride4b(((long*)r)+i,
 			   ((long*)p)+i,
@@ -428,7 +428,7 @@ void ge25519_move_conditional_pniels_array(ge25519_pniels * r, const ge25519_pni
 			   sizeof(ge25519_pniels)/sizeof(long));
   }
 #else
-  size_t i;
+  size_t i = 0;
   for(i=0; i<n; i++) {
     ge25519_move_conditional_pniels(r, p+i, pos==i);
   }
@@ -436,7 +436,7 @@ void ge25519_move_conditional_pniels_array(ge25519_pniels * r, const ge25519_pni
 }
 
 void ge25519_move_conditional_niels_array(ge25519_niels * r, const uint8_t p[8][96], int pos, int n) {
-  size_t i;
+  size_t i = 0;
   for(i=0; i<96/sizeof(long); i+=4) {
     ge25519_cmove_stride4(((long*)r)+i,
 			  ((long*)p)+i,
@@ -448,12 +448,12 @@ void ge25519_move_conditional_niels_array(ge25519_niels * r, const uint8_t p[8][
 
 /* computes [s1]p1, constant time */
 void ge25519_scalarmult(ge25519 *r, const ge25519 *p1, const bignum256modm s1) {
-	signed char slide1[64];
-	ge25519_pniels pre1[9];
-	ge25519_pniels pre;
-	ge25519 d1;
-	ge25519_p1p1 t;
-	int32_t i;
+	signed char slide1[64] = {0};
+	ge25519_pniels pre1[9] = {0};
+	ge25519_pniels pre = {0};
+	ge25519 d1 = {0};
+	ge25519_p1p1 t = {0};
+	int32_t i = 0;
 
 	contract256_window4_modm(slide1, s1);
 
@@ -484,7 +484,7 @@ void ge25519_scalarmult(ge25519 *r, const ge25519 *p1, const bignum256modm s1) {
 }
 
 void ge25519_scalarmult_base_choose_niels(ge25519_niels *t, const uint8_t table[256][96], uint32_t pos, signed char b) {
-	bignum25519 neg;
+	bignum25519 neg = {0};
 	uint32_t sign = (uint32_t)((unsigned char)b >> 7);
 	uint32_t mask = ~(sign - 1);
 	uint32_t u = (b + mask) ^ mask;
@@ -509,9 +509,9 @@ void ge25519_scalarmult_base_choose_niels(ge25519_niels *t, const uint8_t table[
 
 /* computes [s]basepoint */
 void ge25519_scalarmult_base_niels(ge25519 *r, const uint8_t basepoint_table[256][96], const bignum256modm s) {
-	signed char b[64];
-	uint32_t i;
-	ge25519_niels t;
+	signed char b[64] = {0};
+	uint32_t i = 0;
+	ge25519_niels t = {0};
 
 	contract256_window4_modm(b, s);
 
@@ -620,7 +620,7 @@ void ge25519_reduce(ge25519 *r, const ge25519 *t){
 }
 
 void ge25519_norm(ge25519 *r, const ge25519 * t){
-	bignum25519 zinv;
+	bignum25519 zinv = {0};
 	curve25519_recip(zinv, t->z);
 	curve25519_mul(r->x, t->x, zinv);
 	curve25519_mul(r->y, t->y, zinv);
@@ -629,8 +629,8 @@ void ge25519_norm(ge25519 *r, const ge25519 * t){
 }
 
 void ge25519_add(ge25519 *r, const ge25519 *p, const ge25519 *q, unsigned char signbit) {
-	ge25519_pniels P_ni;
-	ge25519_p1p1 P_11;
+	ge25519_pniels P_ni = {0};
+	ge25519_p1p1 P_11 = {0};
 
 	ge25519_full_to_pniels(&P_ni, q);
 	ge25519_pnielsadd_p1p1(&P_11, p, &P_ni, signbit);
@@ -639,7 +639,7 @@ void ge25519_add(ge25519 *r, const ge25519 *p, const ge25519 *q, unsigned char s
 
 void ge25519_fromfe_frombytes_vartime(ge25519 *r, const unsigned char *s){
 	bignum25519 u={0}, v={0}, w={0}, x={0}, y={0}, z={0};
-	unsigned char sign;
+	unsigned char sign = 0;
 
 	curve25519_expand_reduce(u, s);
 

--- a/crypto/ed25519-donna/ed25519.c
+++ b/crypto/ed25519-donna/ed25519.c
@@ -42,9 +42,9 @@ ed25519_hram(hash_512bits hram, const ed25519_signature RS, const ed25519_public
 
 void
 ED25519_FN(ed25519_publickey) (const ed25519_secret_key sk, ed25519_public_key pk) {
-	bignum256modm a;
+	bignum256modm a = {0};
 	ge25519 ALIGN(16) A;
-	hash_512bits extsk;
+	hash_512bits extsk = {0};
 
 	/* A = aB */
 	ed25519_extsk(extsk, sk);
@@ -57,9 +57,9 @@ ED25519_FN(ed25519_publickey) (const ed25519_secret_key sk, ed25519_public_key p
 #if USE_CARDANO
 void
 ED25519_FN(ed25519_publickey_ext) (const ed25519_secret_key sk, const ed25519_secret_key skext, ed25519_public_key pk) {
-	bignum256modm a;
+	bignum256modm a = {0};
 	ge25519 ALIGN(16) A;
-	hash_512bits extsk;
+	hash_512bits extsk = {0};
 
 	/* we don't stretch the key through hashing first since its already 64 bytes */
 
@@ -73,8 +73,8 @@ ED25519_FN(ed25519_publickey_ext) (const ed25519_secret_key sk, const ed25519_se
 
 void
 ED25519_FN(ed25519_cosi_sign) (const unsigned char *m, size_t mlen, const ed25519_secret_key sk, const ed25519_secret_key nonce, const ed25519_public_key R, const ed25519_public_key pk, ed25519_cosi_signature sig) {
-	bignum256modm r, S, a;
-	hash_512bits extsk, extnonce, hram;
+	bignum256modm r = {0}, S = {0}, a = {0};
+	hash_512bits extsk = {0}, extnonce = {0}, hram = {0};
 
 	ed25519_extsk(extsk, sk);
 	ed25519_extsk(extnonce, nonce);
@@ -100,9 +100,9 @@ ED25519_FN(ed25519_cosi_sign) (const unsigned char *m, size_t mlen, const ed2551
 void
 ED25519_FN(ed25519_sign) (const unsigned char *m, size_t mlen, const ed25519_secret_key sk, const ed25519_public_key pk, ed25519_signature RS) {
 	ed25519_hash_context ctx;
-	bignum256modm r, S, a;
-	ge25519 ALIGN(16) R;
-	hash_512bits extsk, hashr, hram;
+	bignum256modm r = {0}, S = {0}, a = {0};
+	ge25519 ALIGN(16) R = {0};
+	hash_512bits extsk = {0}, hashr = {0}, hram = {0};
 
 	ed25519_extsk(extsk, sk);
 
@@ -137,9 +137,9 @@ ED25519_FN(ed25519_sign) (const unsigned char *m, size_t mlen, const ed25519_sec
 void
 ED25519_FN(ed25519_sign_ext) (const unsigned char *m, size_t mlen, const ed25519_secret_key sk, const ed25519_secret_key skext, const ed25519_public_key pk, ed25519_signature RS) {
 	ed25519_hash_context ctx;
-	bignum256modm r, S, a;
-	ge25519 ALIGN(16) R;
-	hash_512bits extsk, hashr, hram;
+	bignum256modm r = {0}, S = {0}, a = {0};
+	ge25519 ALIGN(16) R = {0};
+	hash_512bits extsk = {0}, hashr = {0}, hram = {0};
 
 	/* we don't stretch the key through hashing first since its already 64 bytes */
 	
@@ -177,9 +177,9 @@ ED25519_FN(ed25519_sign_ext) (const unsigned char *m, size_t mlen, const ed25519
 int
 ED25519_FN(ed25519_sign_open) (const unsigned char *m, size_t mlen, const ed25519_public_key pk, const ed25519_signature RS) {
 	ge25519 ALIGN(16) R, A;
-	hash_512bits hash;
-	bignum256modm hram, S;
-	unsigned char checkR[32];
+	hash_512bits hash = {0};
+	bignum256modm hram = {0}, S = {0};
+	unsigned char checkR[32] = {0};
 
 	if ((RS[63] & 224) || !ge25519_unpack_negative_vartime(&A, pk))
 		return -1;
@@ -203,9 +203,9 @@ ED25519_FN(ed25519_sign_open) (const unsigned char *m, size_t mlen, const ed2551
 
 int
 ED25519_FN(ed25519_scalarmult) (ed25519_public_key res, const ed25519_secret_key sk, const ed25519_public_key pk) {
-	bignum256modm a;
+	bignum256modm a = {0};
 	ge25519 ALIGN(16) A, P;
-	hash_512bits extsk;
+	hash_512bits extsk = {0};
 
 	ed25519_extsk(extsk, sk);
 	expand256_modm(a, extsk, 32);
@@ -228,9 +228,9 @@ ED25519_FN(ed25519_scalarmult) (ed25519_public_key res, const ed25519_secret_key
 int
 ed25519_cosi_combine_publickeys(ed25519_public_key res, CONST ed25519_public_key *pks, size_t n) {
 	size_t i = 0;
-	ge25519 P;
-	ge25519_pniels sump;
-	ge25519_p1p1 sump1;
+	ge25519 P = {0};
+	ge25519_pniels sump = {0};
+	ge25519_p1p1 sump1 = {0};
 
 	if (n == 1) {
 		memcpy(res, pks, sizeof(ed25519_public_key));
@@ -258,7 +258,7 @@ ed25519_cosi_combine_publickeys(ed25519_public_key res, CONST ed25519_public_key
 
 void
 ed25519_cosi_combine_signatures(ed25519_signature res, const ed25519_public_key R, CONST ed25519_cosi_signature *sigs, size_t n) {
-	bignum256modm s, t;
+	bignum256modm s = {0}, t = {0};
 	size_t i = 0;
 
 	expand256_modm(s, sigs[i++], 32);
@@ -275,11 +275,11 @@ ed25519_cosi_combine_signatures(ed25519_signature res, const ed25519_public_key 
 */
 void
 curve25519_scalarmult_basepoint(curve25519_key pk, const curve25519_key e) {
-	curve25519_key ec;
-	bignum256modm s;
+	curve25519_key ec = {0};
+	bignum256modm s = {0};
 	bignum25519 ALIGN(16) yplusz, zminusy;
 	ge25519 ALIGN(16) p;
-	size_t i;
+	size_t i = 0;
 
 	/* clamp */
 	for (i = 0; i < 32; i++) ec[i] = e[i];
@@ -302,8 +302,8 @@ curve25519_scalarmult_basepoint(curve25519_key pk, const curve25519_key e) {
 
 void
 curve25519_scalarmult(curve25519_key mypublic, const curve25519_key secret, const curve25519_key basepoint) {
-	curve25519_key e;
-	size_t i;
+	curve25519_key e = {0};
+	size_t i = 0;
 
 	for (i = 0;i < 32;++i) e[i] = secret[i];
 	e[0] &= 0xf8;

--- a/crypto/ed25519-donna/modm-donna-32bit.c
+++ b/crypto/ed25519-donna/modm-donna-32bit.c
@@ -32,8 +32,8 @@ lt_modm(bignum256modm_element_t a, bignum256modm_element_t b) {
 
 /* see HAC, Alg. 14.42 Step 4 */
 void reduce256_modm(bignum256modm r) {
-	bignum256modm t;
-	bignum256modm_element_t b = 0, pb, mask;
+	bignum256modm t = {0};
+	bignum256modm_element_t b = 0, pb = 0, mask = 0;
 
 	/* t = r - m */
 	pb = 0;
@@ -66,9 +66,9 @@ void reduce256_modm(bignum256modm r) {
 	Instead of passing in x, pre-process in to q1 and r1 for efficiency
 */
 void barrett_reduce256_modm(bignum256modm r, const bignum256modm q1, const bignum256modm r1) {
-	bignum256modm q3, r2;
-	uint64_t c;
-	bignum256modm_element_t f, b, pb;
+	bignum256modm q3 = {0}, r2 = {0};
+	uint64_t c = 0;
+	bignum256modm_element_t f = 0, b = 0, pb = 0;
 
 	/* q1 = x >> 248 = 264 bits = 9 30 bit elements
 	   q2 = mu * q1
@@ -134,7 +134,7 @@ void barrett_reduce256_modm(bignum256modm r, const bignum256modm q1, const bignu
 
 /* addition modulo m */
 void add256_modm(bignum256modm r, const bignum256modm x, const bignum256modm y) {
-	bignum256modm_element_t c;
+	bignum256modm_element_t c = 0;
 
 	c  = x[0] + y[0]; r[0] = c & 0x3fffffff; c >>= 30;
 	c += x[1] + y[1]; r[1] = c & 0x3fffffff; c >>= 30;
@@ -151,7 +151,7 @@ void add256_modm(bignum256modm r, const bignum256modm x, const bignum256modm y) 
 
 /* -x modulo m */
 void neg256_modm(bignum256modm r, const bignum256modm x) {
-	bignum256modm_element_t b = 0, pb;
+	bignum256modm_element_t b = 0, pb = 0;
 
 	/* r = m - x */
 	pb = 0;
@@ -191,9 +191,9 @@ void sub256_modm(bignum256modm r, const bignum256modm x, const bignum256modm y) 
 
 /* multiplication modulo m */
 void mul256_modm(bignum256modm r, const bignum256modm x, const bignum256modm y) {
-	bignum256modm r1, q1;
-	uint64_t c;
-	bignum256modm_element_t f;
+	bignum256modm r1 = {0}, q1 = {0};
+	uint64_t c = 0;
+	bignum256modm_element_t f = 0;
 
 	/* r1 = (x mod 256^(32+1)) = x mod (2^8)(31+1) = x & ((1 << 264) - 1)
 	   q1 = x >> 248 = 264 bits = 9 30 bit elements */
@@ -237,8 +237,8 @@ void mul256_modm(bignum256modm r, const bignum256modm x, const bignum256modm y) 
 
 void expand256_modm(bignum256modm out, const unsigned char *in, size_t len) {
 	unsigned char work[64] = {0};
-	bignum256modm_element_t x[16];
-	bignum256modm q1;
+	bignum256modm_element_t x[16] = {0};
+	bignum256modm q1 = {0};
 
 	memcpy(work, in, len);
 	x[0] = U8TO32_LE(work +  0);
@@ -288,7 +288,7 @@ void expand256_modm(bignum256modm out, const unsigned char *in, size_t len) {
 }
 
 void expand_raw256_modm(bignum256modm out, const unsigned char in[32]) {
-	bignum256modm_element_t x[8];
+	bignum256modm_element_t x[8] = {0};
 
 	x[0] = U8TO32_LE(in +  0);
 	x[1] = U8TO32_LE(in +  4);
@@ -312,7 +312,7 @@ void expand_raw256_modm(bignum256modm out, const unsigned char in[32]) {
 
 int is_reduced256_modm(const bignum256modm in)
 {
-	int i;
+	int i = 0;
 	uint32_t res1 = 0;
 	uint32_t res2 = 0;
 	for (i = 8; i >= 0; i--) {
@@ -334,9 +334,9 @@ void contract256_modm(unsigned char out[32], const bignum256modm in) {
 }
 
 void contract256_window4_modm(signed char r[64], const bignum256modm in) {
-	char carry;
+	char carry = 0;
 	signed char *quads = r;
-	bignum256modm_element_t i, j, v;
+	bignum256modm_element_t i = 0, j = 0, v = 0;
 
 	for (i = 0; i < 8; i += 2) {
 		v = in[i];
@@ -369,10 +369,10 @@ void contract256_window4_modm(signed char r[64], const bignum256modm in) {
 }
 
 void contract256_slidingwindow_modm(signed char r[256], const bignum256modm s, int windowsize) {
-	int i,j,k,b;
+	int i = 0, j = 0, k = 0, b = 0;
 	int m = (1 << (windowsize - 1)) - 1, soplen = 256;
 	signed char *bits = r;
-	bignum256modm_element_t v;
+	bignum256modm_element_t v = 0;
 
 	/* first put the binary expansion into r  */
 	for (i = 0; i < 8; i++) {

--- a/crypto/groestl.c
+++ b/crypto/groestl.c
@@ -350,7 +350,7 @@ static const sph_u32 T1dn[] = {
 };
 
 #define DECL_STATE_SMALL \
-	sph_u32 H[16];
+	sph_u32 H[16] = {0};
 
 #define READ_STATE_SMALL(sc)   do { \
 		memcpy(H, (sc)->state.narrow, sizeof H); \
@@ -476,7 +476,7 @@ static const sph_u32 T1dn[] = {
 	} while (0)
 
 #define DECL_STATE_BIG \
-	sph_u32 H[32];
+	sph_u32 H[32] = {0};
 
 #define READ_STATE_BIG(sc)   do { \
 		memcpy(H, (sc)->state.narrow, sizeof H); \
@@ -675,7 +675,7 @@ static const sph_u32 T1dn[] = {
 static void
 groestl_big_init(sph_groestl_big_context *sc, unsigned out_size)
 {
-	size_t u;
+	size_t u = 0;
 
 	sc->ptr = 0;
 	for (u = 0; u < 31; u ++)
@@ -688,8 +688,8 @@ groestl_big_init(sph_groestl_big_context *sc, unsigned out_size)
 static void
 groestl_big_core(sph_groestl_big_context *sc, const void *data, size_t len)
 {
-	unsigned char *buf;
-	size_t ptr;
+	unsigned char *buf = NULL;
+	size_t ptr = 0;
 	DECL_STATE_BIG
 
 	buf = sc->buf;
@@ -703,7 +703,7 @@ groestl_big_core(sph_groestl_big_context *sc, const void *data, size_t len)
 
 	READ_STATE_BIG(sc);
 	while (len > 0) {
-		size_t clen;
+		size_t clen = 0;
 
 		clen = (sizeof sc->buf) - ptr;
 		if (clen > len)
@@ -726,10 +726,10 @@ static void
 groestl_big_close(sph_groestl_big_context *sc,
 	unsigned ub, unsigned n, void *dst, size_t out_len)
 {
-	unsigned char pad[136];
-	size_t ptr, pad_len, u2;
-	sph_u64 count;
-	unsigned z;
+	unsigned char pad[136] = {0};
+	size_t ptr = 0, pad_len = 0, u2 = 0;
+	sph_u64 count = 0;
+	unsigned z = 0;
 	DECL_STATE_BIG
 
 	ptr = sc->ptr;
@@ -774,7 +774,7 @@ groestl512_Final(void *cc, void *dst)
 void
 groestl512_DoubleTrunc(void *cc, void *dst)
 {
-	char buf[64];
+	char buf[64] = {0};
 
 	groestl512_Final(cc, buf);
 	groestl512_Update(cc, buf, sizeof(buf));

--- a/crypto/hasher.c
+++ b/crypto/hasher.c
@@ -139,7 +139,7 @@ void hasher_Final(Hasher *hasher, uint8_t hash[HASHER_DIGEST_LENGTH]) {
 
 void hasher_Raw(HasherType type, const uint8_t *data, size_t length,
                 uint8_t hash[HASHER_DIGEST_LENGTH]) {
-  Hasher hasher;
+  Hasher hasher = {0};
 
   hasher_Init(&hasher, type);
   hasher_Update(&hasher, data, length);

--- a/crypto/hmac.c
+++ b/crypto/hmac.c
@@ -83,7 +83,7 @@ void hmac_sha256_prepare(const uint8_t *key, const uint32_t keylen,
 
   /* compute o_key_pad and its digest */
   for (int i = 0; i < SHA256_BLOCK_LENGTH / (int)sizeof(uint32_t); i++) {
-    uint32_t data;
+    uint32_t data = 0;
 #if BYTE_ORDER == LITTLE_ENDIAN
     REVERSE32(key_pad[i], data);
 #else
@@ -135,7 +135,7 @@ void hmac_sha512_Final(HMAC_SHA512_CTX *hctx, uint8_t *hmac) {
 
 void hmac_sha512(const uint8_t *key, const uint32_t keylen, const uint8_t *msg,
                  const uint32_t msglen, uint8_t *hmac) {
-  HMAC_SHA512_CTX hctx;
+  HMAC_SHA512_CTX hctx = {0};
   hmac_sha512_Init(&hctx, key, keylen);
   hmac_sha512_Update(&hctx, msg, msglen);
   hmac_sha512_Final(&hctx, hmac);
@@ -157,7 +157,7 @@ void hmac_sha512_prepare(const uint8_t *key, const uint32_t keylen,
 
   /* compute o_key_pad and its digest */
   for (int i = 0; i < SHA512_BLOCK_LENGTH / (int)sizeof(uint64_t); i++) {
-    uint64_t data;
+    uint64_t data = 0;
 #if BYTE_ORDER == LITTLE_ENDIAN
     REVERSE64(key_pad[i], data);
 #else

--- a/crypto/hmac_drbg.c
+++ b/crypto/hmac_drbg.c
@@ -38,7 +38,7 @@ static void update_k(HMAC_DRBG_CTX *ctx, uint8_t domain, const uint8_t *data1,
     ctx->v[8] = 0x80000000;
     ctx->v[15] = (SHA256_BLOCK_LENGTH + SHA256_DIGEST_LENGTH) * 8;
   } else {
-    SHA256_CTX sha_ctx;
+    SHA256_CTX sha_ctx = {0};
     memcpy(sha_ctx.state, ctx->idig, SHA256_DIGEST_LENGTH);
     for (size_t i = 0; i < SHA256_DIGEST_LENGTH / sizeof(uint32_t); i++) {
 #if BYTE_ORDER == LITTLE_ENDIAN
@@ -86,7 +86,7 @@ static void update_v(HMAC_DRBG_CTX *ctx) {
 void hmac_drbg_init(HMAC_DRBG_CTX *ctx, const uint8_t *entropy,
                     size_t entropy_len, const uint8_t *nonce,
                     size_t nonce_len) {
-  uint32_t h[SHA256_BLOCK_LENGTH / sizeof(uint32_t)];
+  uint32_t h[SHA256_BLOCK_LENGTH / sizeof(uint32_t)] = {0};
 
   // Precompute the inner digest and outer digest of K = 0x00 ... 0x00.
   memset(h, 0x36, sizeof(h));

--- a/crypto/monero/base58.c
+++ b/crypto/monero/base58.c
@@ -106,7 +106,7 @@ bool decode_block(const char* block, size_t size, char* res)
 		if (digit < 0)
 			return false; // Invalid symbol
 
-		uint64_t product_hi;
+		uint64_t product_hi = 0;
 		uint64_t tmp = res_num + mul128(order, (uint64_t) digit, &product_hi);
 		if (tmp < res_num || 0 != product_hi)
 			return false; // Overflow
@@ -199,7 +199,7 @@ int xmr_base58_addr_encode_check(uint64_t tag, const uint8_t *data, size_t binsz
 	}
 
 	size_t b58size = b58sz;
-	uint8_t buf[binsz + 1 + HASHER_DIGEST_LENGTH];
+	uint8_t buf[(binsz + 1) + HASHER_DIGEST_LENGTH];
 	uint8_t *hash = buf + binsz + 1;
 	buf[0] = (uint8_t) tag;
 	memcpy(buf + 1, data, binsz);
@@ -213,7 +213,7 @@ int xmr_base58_addr_decode_check(const char *addr, size_t sz, uint64_t *tag, voi
 {
 	size_t buflen = 1 + 64 + addr_checksum_size;
 	uint8_t buf[buflen];
-	uint8_t hash[HASHER_DIGEST_LENGTH];
+	uint8_t hash[HASHER_DIGEST_LENGTH] = {0};
 
 	if (!xmr_base58_decode(addr, sz, buf, &buflen)){
 		return 0;

--- a/crypto/monero/base58.c
+++ b/crypto/monero/base58.c
@@ -200,6 +200,7 @@ int xmr_base58_addr_encode_check(uint64_t tag, const uint8_t *data, size_t binsz
 
 	size_t b58size = b58sz;
 	uint8_t buf[(binsz + 1) + HASHER_DIGEST_LENGTH];
+	memset(buf, 0, sizeof(buf));
 	uint8_t *hash = buf + binsz + 1;
 	buf[0] = (uint8_t) tag;
 	memcpy(buf + 1, data, binsz);
@@ -213,6 +214,7 @@ int xmr_base58_addr_decode_check(const char *addr, size_t sz, uint64_t *tag, voi
 {
 	size_t buflen = 1 + 64 + addr_checksum_size;
 	uint8_t buf[buflen];
+	memset(buf, 0, sizeof(buf));
 	uint8_t hash[HASHER_DIGEST_LENGTH] = {0};
 
 	if (!xmr_base58_decode(addr, sz, buf, &buflen)){

--- a/crypto/monero/range_proof.c
+++ b/crypto/monero/range_proof.c
@@ -5,15 +5,15 @@
 #include "range_proof.h"
 
 static void xmr_hash_ge25519_to_scalar(bignum256modm r, const ge25519 *p) {
-  unsigned char buff[32];
+  unsigned char buff[32] = {0};
   ge25519_pack(buff, p);
   xmr_hash_to_scalar(r, buff, sizeof(buff));
 }
 
 void xmr_gen_range_sig(xmr_range_sig_t *sig, ge25519 *C, bignum256modm mask,
                        xmr_amount amount, bignum256modm *last_mask) {
-  bignum256modm ai[64];
-  bignum256modm alpha[64];
+  bignum256modm ai[64] = {0};
+  bignum256modm alpha[64] = {0};
   xmr_gen_range_sig_ex(sig, C, mask, amount, last_mask, ai, alpha);
 }
 
@@ -25,16 +25,16 @@ void xmr_gen_range_sig_ex(xmr_range_sig_t *sig, ge25519 *C, bignum256modm mask,
   bignum256modm si = {0};
   bignum256modm c = {0};
   bignum256modm ee = {0};
-  unsigned char buff[32];
+  unsigned char buff[32] = {0};
 
-  Hasher kck;
+  Hasher kck = {0};
   xmr_hasher_init(&kck);
 
-  ge25519 C_acc;
-  ge25519 C_h;
-  ge25519 C_tmp;
-  ge25519 L;
-  ge25519 Zero;
+  ge25519 C_acc = {0};
+  ge25519 C_h = {0};
+  ge25519 C_tmp = {0};
+  ge25519 L = {0};
+  ge25519 Zero = {0};
 
   ge25519_set_neutral(&Zero);
   ge25519_set_neutral(&C_acc);

--- a/crypto/monero/xmr.c
+++ b/crypto/monero/xmr.c
@@ -44,14 +44,14 @@ void xmr_hasher_copy(Hasher *dst, const Hasher *src) {
 }
 
 void xmr_hash_to_scalar(bignum256modm r, const void *data, size_t length) {
-  uint8_t hash[HASHER_DIGEST_LENGTH];
+  uint8_t hash[HASHER_DIGEST_LENGTH] = {0};
   hasher_Raw(HASHER_SHA3K, data, length, hash);
   expand256_modm(r, hash, HASHER_DIGEST_LENGTH);
 }
 
 void xmr_hash_to_ec(ge25519 *P, const void *data, size_t length) {
-  ge25519 point2;
-  uint8_t hash[HASHER_DIGEST_LENGTH];
+  ge25519 point2 = {0};
+  uint8_t hash[HASHER_DIGEST_LENGTH] = {0};
   hasher_Raw(HASHER_SHA3K, data, length, hash);
 
   ge25519_fromfe_frombytes_vartime(&point2, hash);
@@ -60,7 +60,7 @@ void xmr_hash_to_ec(ge25519 *P, const void *data, size_t length) {
 
 void xmr_derivation_to_scalar(bignum256modm s, const ge25519 *p,
                               uint32_t output_index) {
-  uint8_t buff[32 + 8];
+  uint8_t buff[32 + 8] = {0};
   ge25519_pack(buff, p);
   int written = xmr_write_varint(buff + 32, 8, output_index);
   xmr_hash_to_scalar(s, buff, 32u + written);
@@ -68,7 +68,7 @@ void xmr_derivation_to_scalar(bignum256modm s, const ge25519 *p,
 
 void xmr_generate_key_derivation(ge25519 *r, const ge25519 *A,
                                  const bignum256modm b) {
-  ge25519 bA;
+  ge25519 bA = {0};
   ge25519_scalarmult(&bA, A, b);
   ge25519_mul8(r, &bA);
 }
@@ -82,7 +82,7 @@ void xmr_derive_private_key(bignum256modm s, const ge25519 *deriv, uint32_t idx,
 void xmr_derive_public_key(ge25519 *r, const ge25519 *deriv, uint32_t idx,
                            const ge25519 *base) {
   bignum256modm s = {0};
-  ge25519 p2;
+  ge25519 p2 = {0};
 
   xmr_derivation_to_scalar(s, deriv, idx);
   ge25519_scalarmult_base_niels(&p2, ge25519_niels_base_multiples, s);
@@ -92,7 +92,7 @@ void xmr_derive_public_key(ge25519 *r, const ge25519 *deriv, uint32_t idx,
 void xmr_add_keys2(ge25519 *r, const bignum256modm a, const bignum256modm b,
                    const ge25519 *B) {
   // aG + bB, G is basepoint
-  ge25519 aG, bB;
+  ge25519 aG = {0}, bB = {0};
   ge25519_scalarmult_base_niels(&aG, ge25519_niels_base_multiples, a);
   ge25519_scalarmult(&bB, B, b);
   ge25519_add(r, &aG, &bB, 0);
@@ -107,7 +107,7 @@ void xmr_add_keys2_vartime(ge25519 *r, const bignum256modm a,
 void xmr_add_keys3(ge25519 *r, const bignum256modm a, const ge25519 *A,
                    const bignum256modm b, const ge25519 *B) {
   // aA + bB
-  ge25519 aA, bB;
+  ge25519 aA = {0}, bB = {0};
   ge25519_scalarmult(&aA, A, a);
   ge25519_scalarmult(&bB, B, b);
   ge25519_add(r, &aA, &bB, 0);
@@ -122,10 +122,10 @@ void xmr_add_keys3_vartime(ge25519 *r, const bignum256modm a, const ge25519 *A,
 void xmr_get_subaddress_secret_key(bignum256modm r, uint32_t major,
                                    uint32_t minor, const bignum256modm m) {
   const char prefix[] = "SubAddr";
-  unsigned char buff[32];
+  unsigned char buff[32] = {0};
   contract256_modm(buff, m);
 
-  char data[sizeof(prefix) + sizeof(buff) + 2 * sizeof(uint32_t)];
+  char data[sizeof(prefix) + sizeof(buff) + 2 * sizeof(uint32_t)] = {0};
   memcpy(data, prefix, sizeof(prefix));
   memcpy(data + sizeof(prefix), buff, sizeof(buff));
   memcpy(data + sizeof(prefix) + sizeof(buff), &major, sizeof(uint32_t));

--- a/crypto/nem.c
+++ b/crypto/nem.c
@@ -116,7 +116,7 @@ static inline bool nem_write_mosaic_bool(nem_transaction_ctx *ctx,
 
 static inline bool nem_write_mosaic_u64(nem_transaction_ctx *ctx,
                                         const char *name, uint64_t value) {
-  char buffer[21];
+  char buffer[21] = {0};
 
   if (bn_format_uint64(value, NULL, NULL, 0, 0, false, buffer,
                        sizeof(buffer)) == 0) {
@@ -128,7 +128,7 @@ static inline bool nem_write_mosaic_u64(nem_transaction_ctx *ctx,
 
 void nem_get_address_raw(const ed25519_public_key public_key, uint8_t version,
                          uint8_t *address) {
-  uint8_t hash[SHA3_256_DIGEST_LENGTH];
+  uint8_t hash[SHA3_256_DIGEST_LENGTH] = {0};
 
   /* 1.  Perform 256-bit Sha3 on the public key */
   keccak_256(public_key, sizeof(ed25519_public_key), hash);
@@ -151,7 +151,7 @@ void nem_get_address_raw(const ed25519_public_key public_key, uint8_t version,
 
 bool nem_get_address(const ed25519_public_key public_key, uint8_t version,
                      char *address) {
-  uint8_t pubkeyhash[NEM_ADDRESS_SIZE_RAW];
+  uint8_t pubkeyhash[NEM_ADDRESS_SIZE_RAW] = {0};
 
   nem_get_address_raw(public_key, version, pubkeyhash);
 
@@ -167,7 +167,7 @@ bool nem_validate_address_raw(const uint8_t *address, uint8_t network) {
     return false;
   }
 
-  uint8_t hash[SHA3_256_DIGEST_LENGTH];
+  uint8_t hash[SHA3_256_DIGEST_LENGTH] = {0};
 
   keccak_256(address, 1 + RIPEMD160_DIGEST_LENGTH, hash);
   bool valid = (memcmp(&address[1 + RIPEMD160_DIGEST_LENGTH], hash, 4) == 0);
@@ -177,7 +177,7 @@ bool nem_validate_address_raw(const uint8_t *address, uint8_t network) {
 }
 
 bool nem_validate_address(const char *address, uint8_t network) {
-  uint8_t pubkeyhash[NEM_ADDRESS_SIZE_RAW];
+  uint8_t pubkeyhash[NEM_ADDRESS_SIZE_RAW] = {0};
 
   if (strlen(address) != NEM_ADDRESS_SIZE) {
     return false;
@@ -314,10 +314,10 @@ bool nem_transaction_create_multisig_signature(
       timestamp, signer, fee, deadline);
   if (!ret) return false;
 
-  char address[NEM_ADDRESS_SIZE + 1];
+  char address[NEM_ADDRESS_SIZE + 1] = {0};
   nem_get_address(inner->public_key, network, address);
 
-  uint8_t hash[SHA3_256_DIGEST_LENGTH];
+  uint8_t hash[SHA3_256_DIGEST_LENGTH] = {0};
   keccak_256(inner->buffer, inner->offset, hash);
 
   SERIALIZE_U32(sizeof(uint32_t) + SHA3_256_DIGEST_LENGTH);
@@ -379,7 +379,7 @@ bool nem_transaction_create_mosaic_creation(
       sizeof(uint32_t) + namespace_length + sizeof(uint32_t) + mosaic_length;
 
   // This length will be rewritten later on
-  nem_transaction_ctx state;
+  nem_transaction_ctx state = {0};
   memcpy(&state, ctx, sizeof(state));
 
   SERIALIZE_U32(0);

--- a/crypto/pbkdf2.c
+++ b/crypto/pbkdf2.c
@@ -30,7 +30,7 @@
 void pbkdf2_hmac_sha256_Init(PBKDF2_HMAC_SHA256_CTX *pctx, const uint8_t *pass,
                              int passlen, const uint8_t *salt, int saltlen,
                              uint32_t blocknr) {
-  SHA256_CTX ctx;
+  SHA256_CTX ctx = {0};
 #if BYTE_ORDER == LITTLE_ENDIAN
   REVERSE32(blocknr, blocknr);
 #endif
@@ -88,10 +88,10 @@ void pbkdf2_hmac_sha256(const uint8_t *pass, int passlen, const uint8_t *salt,
     last_block_size = SHA256_DIGEST_LENGTH;
   }
   for (uint32_t blocknr = 1; blocknr <= blocks_count; blocknr++) {
-    PBKDF2_HMAC_SHA256_CTX pctx;
+    PBKDF2_HMAC_SHA256_CTX pctx = {0};
     pbkdf2_hmac_sha256_Init(&pctx, pass, passlen, salt, saltlen, blocknr);
     pbkdf2_hmac_sha256_Update(&pctx, iterations);
-    uint8_t digest[SHA256_DIGEST_LENGTH];
+    uint8_t digest[SHA256_DIGEST_LENGTH] = {0};
     pbkdf2_hmac_sha256_Final(&pctx, digest);
     uint32_t key_offset = (blocknr - 1) * SHA256_DIGEST_LENGTH;
     if (blocknr < blocks_count) {
@@ -105,7 +105,7 @@ void pbkdf2_hmac_sha256(const uint8_t *pass, int passlen, const uint8_t *salt,
 void pbkdf2_hmac_sha512_Init(PBKDF2_HMAC_SHA512_CTX *pctx, const uint8_t *pass,
                              int passlen, const uint8_t *salt, int saltlen,
                              uint32_t blocknr) {
-  SHA512_CTX ctx;
+  SHA512_CTX ctx = {0};
 #if BYTE_ORDER == LITTLE_ENDIAN
   REVERSE32(blocknr, blocknr);
 #endif
@@ -164,10 +164,10 @@ void pbkdf2_hmac_sha512(const uint8_t *pass, int passlen, const uint8_t *salt,
     last_block_size = SHA512_DIGEST_LENGTH;
   }
   for (uint32_t blocknr = 1; blocknr <= blocks_count; blocknr++) {
-    PBKDF2_HMAC_SHA512_CTX pctx;
+    PBKDF2_HMAC_SHA512_CTX pctx = {0};
     pbkdf2_hmac_sha512_Init(&pctx, pass, passlen, salt, saltlen, blocknr);
     pbkdf2_hmac_sha512_Update(&pctx, iterations);
-    uint8_t digest[SHA512_DIGEST_LENGTH];
+    uint8_t digest[SHA512_DIGEST_LENGTH] = {0};
     pbkdf2_hmac_sha512_Final(&pctx, digest);
     uint32_t key_offset = (blocknr - 1) * SHA512_DIGEST_LENGTH;
     if (blocknr < blocks_count) {

--- a/crypto/rand.c
+++ b/crypto/rand.c
@@ -65,7 +65,7 @@ void __attribute__((weak)) random_buffer(uint8_t *buf, size_t len) {
 }
 
 uint32_t random_uniform(uint32_t n) {
-  uint32_t x, max = 0xFFFFFFFF - (0xFFFFFFFF % n);
+  uint32_t x = 0, max = 0xFFFFFFFF - (0xFFFFFFFF % n);
   while ((x = random32()) >= max)
     ;
   return x / (max / n);

--- a/crypto/rfc6979.c
+++ b/crypto/rfc6979.c
@@ -39,7 +39,7 @@ void generate_rfc6979(uint8_t rnd[32], rfc6979_state *state) {
 // generate K in a deterministic way, according to RFC6979
 // http://tools.ietf.org/html/rfc6979
 void generate_k_rfc6979(bignum256 *k, rfc6979_state *state) {
-  uint8_t buf[32];
+  uint8_t buf[32] = {0};
   generate_rfc6979(buf, state);
   bn_read_be(buf, k);
   memzero(buf, sizeof(buf));

--- a/crypto/ripemd160.c
+++ b/crypto/ripemd160.c
@@ -74,7 +74,7 @@ void ripemd160_Init(RIPEMD160_CTX *ctx)
  */
 void ripemd160_process( RIPEMD160_CTX *ctx, const uint8_t data[RIPEMD160_BLOCK_LENGTH] )
 {
-    uint32_t A, B, C, D, E, Ap, Bp, Cp, Dp, Ep, X[16];
+    uint32_t A = 0, B = 0, C = 0, D = 0, E = 0, Ap = 0, Bp = 0, Cp = 0, Dp = 0, Ep = 0, X[16] = {0};
 
     GET_UINT32_LE( X[ 0], data,  0 );
     GET_UINT32_LE( X[ 1], data,  4 );
@@ -255,8 +255,8 @@ void ripemd160_process( RIPEMD160_CTX *ctx, const uint8_t data[RIPEMD160_BLOCK_L
  */
 void ripemd160_Update( RIPEMD160_CTX *ctx, const uint8_t *input, uint32_t ilen )
 {
-    uint32_t fill;
-    uint32_t left;
+    uint32_t fill = 0;
+    uint32_t left = 0;
 
     if( ilen == 0 )
         return;
@@ -305,9 +305,9 @@ static const uint8_t ripemd160_padding[RIPEMD160_BLOCK_LENGTH] =
  */
 void ripemd160_Final( RIPEMD160_CTX *ctx, uint8_t output[RIPEMD160_DIGEST_LENGTH] )
 {
-    uint32_t last, padn;
-    uint32_t high, low;
-    uint8_t msglen[8];
+    uint32_t last = 0; uint32_t padn = 0;
+    uint32_t high = 0; uint32_t low = 0;
+    uint8_t msglen[8] = {0};
 
     high = ( ctx->total[0] >> 29 )
          | ( ctx->total[1] <<  3 );
@@ -336,7 +336,7 @@ void ripemd160_Final( RIPEMD160_CTX *ctx, uint8_t output[RIPEMD160_DIGEST_LENGTH
  */
 void ripemd160(const uint8_t *msg, uint32_t msg_len, uint8_t hash[RIPEMD160_DIGEST_LENGTH])
 {
-    RIPEMD160_CTX ctx;
+    RIPEMD160_CTX ctx = {0};
     ripemd160_Init( &ctx );
     ripemd160_Update( &ctx, msg, msg_len );
     ripemd160_Final( &ctx, hash );

--- a/crypto/script.c
+++ b/crypto/script.c
@@ -26,7 +26,7 @@
 
 int script_output_to_address(const uint8_t *script, int scriptlen, char *addr,
                              int addrsize) {
-  uint8_t raw[35];
+  uint8_t raw[35] = {0};
 
   // P2PKH
   if (scriptlen == 25 && script[0] == 0x76 && script[1] == 0xA9 &&

--- a/crypto/segwit_addr.c
+++ b/crypto/segwit_addr.c
@@ -85,9 +85,9 @@ int bech32_encode(char *output, const char *hrp, const uint8_t *data, size_t dat
 
 int bech32_decode(char* hrp, uint8_t *data, size_t *data_len, const char *input) {
     uint32_t chk = 1;
-    size_t i;
+    size_t i = 0;
     size_t input_len = strlen(input);
-    size_t hrp_len;
+    size_t hrp_len = 0;
     int have_lower = 0, have_upper = 0;
     if (input_len < 8 || input_len > 90) {
         return 0;
@@ -163,7 +163,7 @@ static int convert_bits(uint8_t* out, size_t* outlen, int outbits, const uint8_t
 }
 
 int segwit_addr_encode(char *output, const char *hrp, int witver, const uint8_t *witprog, size_t witprog_len) {
-    uint8_t data[65];
+    uint8_t data[65] = {0};
     size_t datalen = 0;
     if (witver > 16) return 0;
     if (witver == 0 && witprog_len != 20 && witprog_len != 32) return 0;
@@ -175,9 +175,9 @@ int segwit_addr_encode(char *output, const char *hrp, int witver, const uint8_t 
 }
 
 int segwit_addr_decode(int* witver, uint8_t* witdata, size_t* witdata_len, const char* hrp, const char* addr) {
-    uint8_t data[84];
-    char hrp_actual[84];
-    size_t data_len;
+    uint8_t data[84] = {0};
+    char hrp_actual[84] = {0};
+    size_t data_len = 0;
     if (!bech32_decode(hrp_actual, data, &data_len, addr)) return 0;
     if (data_len == 0 || data_len > 65) return 0;
     if (strncmp(hrp, hrp_actual, 84) != 0) return 0;

--- a/crypto/sha2.c
+++ b/crypto/sha2.c
@@ -321,10 +321,10 @@ void sha1_Init(SHA1_CTX* context) {
 	j++;
 
 void sha1_Transform(const sha2_word32* state_in, const sha2_word32* data, sha2_word32* state_out) {
-	sha2_word32	a, b, c, d, e;
-	sha2_word32	T1;
-	sha2_word32	W1[16];
-	int		j;
+	sha2_word32	a = 0, b = 0, c = 0, d = 0, e = 0;
+	sha2_word32	T1 = 0;
+	sha2_word32	W1[16] = {0};
+	int		j = 0;
 
 	/* Initialize registers with the prev. intermediate value */
 	a = state_in[0];
@@ -439,10 +439,10 @@ void sha1_Transform(const sha2_word32* state_in, const sha2_word32* data, sha2_w
 #else  /* SHA2_UNROLL_TRANSFORM */
 
 void sha1_Transform(const sha2_word32* state_in, const sha2_word32* data, sha2_word32* state_out) {
-	sha2_word32	a, b, c, d, e;
-	sha2_word32	T1;
-	sha2_word32	W1[16];
-	int		j;
+	sha2_word32	a = 0, b = 0, c = 0, d = 0, e = 0;
+	sha2_word32	T1 = 0;
+	sha2_word32	W1[16] = {0};
+	int		j = 0;
 
 	/* Initialize registers with the prev. intermediate value */
 	a = state_in[0];
@@ -520,7 +520,7 @@ void sha1_Transform(const sha2_word32* state_in, const sha2_word32* data, sha2_w
 #endif /* SHA2_UNROLL_TRANSFORM */
 
 void sha1_Update(SHA1_CTX* context, const sha2_byte *data, size_t len) {
-	unsigned int	freespace, usedspace;
+	unsigned int	freespace = 0, usedspace = 0;
 
 	if (len == 0) {
 		/* Calling with no data is valid - we do nothing */
@@ -578,7 +578,7 @@ void sha1_Update(SHA1_CTX* context, const sha2_byte *data, size_t len) {
 }
 
 void sha1_Final(SHA1_CTX* context, sha2_byte digest[]) {
-	unsigned int	usedspace;
+	unsigned int	usedspace = 0;
 
 	/* If no digest buffer is passed, we don't bother doing this: */
 	if (digest != (sha2_byte*)0) {
@@ -632,8 +632,8 @@ void sha1_Final(SHA1_CTX* context, sha2_byte digest[]) {
 }
 
 char *sha1_End(SHA1_CTX* context, char buffer[]) {
-	sha2_byte	digest[SHA1_DIGEST_LENGTH], *d = digest;
-	int		i;
+	sha2_byte	digest[SHA1_DIGEST_LENGTH] = {0}, *d = digest;
+	int		i = 0;
 
 	if (buffer != (char*)0) {
 		sha1_Final(context, digest);
@@ -652,14 +652,14 @@ char *sha1_End(SHA1_CTX* context, char buffer[]) {
 }
 
 void sha1_Raw(const sha2_byte* data, size_t len, uint8_t digest[SHA1_DIGEST_LENGTH]) {
-	SHA1_CTX	context;
+	SHA1_CTX	context = {0};
 	sha1_Init(&context);
 	sha1_Update(&context, data, len);
 	sha1_Final(&context, digest);
 }
 
 char* sha1_Data(const sha2_byte* data, size_t len, char digest[SHA1_DIGEST_STRING_LENGTH]) {
-	SHA1_CTX	context;
+	SHA1_CTX	context = {0};
 
 	sha1_Init(&context);
 	sha1_Update(&context, data, len);
@@ -699,10 +699,10 @@ void sha256_Init(SHA256_CTX* context) {
 	j++
 
 void sha256_Transform(const sha2_word32* state_in, const sha2_word32* data, sha2_word32* state_out) {
-	sha2_word32	a, b, c, d, e, f, g, h, s0, s1;
-	sha2_word32	T1;
-	sha2_word32 W256[16];
-	int		j;
+	sha2_word32	a = 0, b = 0, c = 0, d = 0, e = 0, f = 0, g = 0, h = 0, s0 = 0, s1 = 0;
+	sha2_word32	T1 = 0;
+	sha2_word32 W256[16] = {0};
+	int		j = 0;
 
 	/* Initialize registers with the prev. intermediate value */
 	a = state_in[0];
@@ -756,9 +756,9 @@ void sha256_Transform(const sha2_word32* state_in, const sha2_word32* data, sha2
 #else /* SHA2_UNROLL_TRANSFORM */
 
 void sha256_Transform(const sha2_word32* state_in, const sha2_word32* data, sha2_word32* state_out) {
-	sha2_word32	a, b, c, d, e, f, g, h, s0, s1;
-	sha2_word32	T1, T2, W256[16];
-	int		j;
+	sha2_word32	a = 0, b = 0, c = 0, d = 0, e = 0, f = 0, g = 0, h = 0, s0 = 0, s1 = 0;
+	sha2_word32	T1 = 0, T2 = 0 , W256[16] = {0};
+	int		j = 0;
 
 	/* Initialize registers with the prev. intermediate value */
 	a = state_in[0];
@@ -827,7 +827,7 @@ void sha256_Transform(const sha2_word32* state_in, const sha2_word32* data, sha2
 #endif /* SHA2_UNROLL_TRANSFORM */
 
 void sha256_Update(SHA256_CTX* context, const sha2_byte *data, size_t len) {
-	unsigned int	freespace, usedspace;
+	unsigned int	freespace = 0, usedspace = 0;
 
 	if (len == 0) {
 		/* Calling with no data is valid - we do nothing */
@@ -885,7 +885,7 @@ void sha256_Update(SHA256_CTX* context, const sha2_byte *data, size_t len) {
 }
 
 void sha256_Final(SHA256_CTX* context, sha2_byte digest[]) {
-	unsigned int	usedspace;
+	unsigned int	usedspace = 0;
 
 	/* If no digest buffer is passed, we don't bother doing this: */
 	if (digest != (sha2_byte*)0) {
@@ -939,8 +939,8 @@ void sha256_Final(SHA256_CTX* context, sha2_byte digest[]) {
 }
 
 char *sha256_End(SHA256_CTX* context, char buffer[]) {
-	sha2_byte	digest[SHA256_DIGEST_LENGTH], *d = digest;
-	int		i;
+	sha2_byte	digest[SHA256_DIGEST_LENGTH] = {0}, *d = digest;
+	int		i = 0;
 
 	if (buffer != (char*)0) {
 		sha256_Final(context, digest);
@@ -959,14 +959,14 @@ char *sha256_End(SHA256_CTX* context, char buffer[]) {
 }
 
 void sha256_Raw(const sha2_byte* data, size_t len, uint8_t digest[SHA256_DIGEST_LENGTH]) {
-	SHA256_CTX	context;
+	SHA256_CTX	context = {0};
 	sha256_Init(&context);
 	sha256_Update(&context, data, len);
 	sha256_Final(&context, digest);
 }
 
 char* sha256_Data(const sha2_byte* data, size_t len, char digest[SHA256_DIGEST_STRING_LENGTH]) {
-	SHA256_CTX	context;
+	SHA256_CTX	context = {0};
 
 	sha256_Init(&context);
 	sha256_Update(&context, data, len);
@@ -1006,9 +1006,9 @@ void sha512_Init(SHA512_CTX* context) {
 	j++
 
 void sha512_Transform(const sha2_word64* state_in, const sha2_word64* data, sha2_word64* state_out) {
-	sha2_word64	a, b, c, d, e, f, g, h, s0, s1;
-	sha2_word64	T1, W512[16];
-	int		j;
+	sha2_word64	a = 0, b = 0, c = 0, d = 0, e = 0, f = 0, g = 0, h = 0, s0 = 0, s1 = 0;
+	sha2_word64	T1 = 0, W512[16] = {0};
+	int		j = 0;
 
 	/* Initialize registers with the prev. intermediate value */
 	a = state_in[0];
@@ -1061,9 +1061,9 @@ void sha512_Transform(const sha2_word64* state_in, const sha2_word64* data, sha2
 #else /* SHA2_UNROLL_TRANSFORM */
 
 void sha512_Transform(const sha2_word64* state_in, const sha2_word64* data, sha2_word64* state_out) {
-	sha2_word64	a, b, c, d, e, f, g, h, s0, s1;
-	sha2_word64	T1, T2, W512[16];
-	int		j;
+	sha2_word64	a = 0, b = 0, c = 0, d = 0, e = 0, f = 0, g = 0, h = 0, s0 = 0, s1 = 0;
+	sha2_word64	T1 = 0, T2 = 0, W512[16] = {0};
+	int		j = 0;
 
 	/* Initialize registers with the prev. intermediate value */
 	a = state_in[0];
@@ -1132,7 +1132,7 @@ void sha512_Transform(const sha2_word64* state_in, const sha2_word64* data, sha2
 #endif /* SHA2_UNROLL_TRANSFORM */
 
 void sha512_Update(SHA512_CTX* context, const sha2_byte *data, size_t len) {
-	unsigned int	freespace, usedspace;
+	unsigned int	freespace = 0, usedspace = 0;
 
 	if (len == 0) {
 		/* Calling with no data is valid - we do nothing */
@@ -1190,7 +1190,7 @@ void sha512_Update(SHA512_CTX* context, const sha2_byte *data, size_t len) {
 }
 
 static void sha512_Last(SHA512_CTX* context) {
-	unsigned int	usedspace;
+	unsigned int	usedspace = 0;
 
 	usedspace = (context->bitcount[0] >> 3) % SHA512_BLOCK_LENGTH;
 	/* Begin padding with a 1 bit: */
@@ -1248,8 +1248,8 @@ void sha512_Final(SHA512_CTX* context, sha2_byte digest[]) {
 }
 
 char *sha512_End(SHA512_CTX* context, char buffer[]) {
-	sha2_byte	digest[SHA512_DIGEST_LENGTH], *d = digest;
-	int		i;
+	sha2_byte	digest[SHA512_DIGEST_LENGTH] = {0}, *d = digest;
+	int		i = 0;
 
 	if (buffer != (char*)0) {
 		sha512_Final(context, digest);
@@ -1268,14 +1268,14 @@ char *sha512_End(SHA512_CTX* context, char buffer[]) {
 }
 
 void sha512_Raw(const sha2_byte* data, size_t len, uint8_t digest[SHA512_DIGEST_LENGTH]) {
-	SHA512_CTX	context;
+	SHA512_CTX	context = {0};
 	sha512_Init(&context);
 	sha512_Update(&context, data, len);
 	sha512_Final(&context, digest);
 }
 
 char* sha512_Data(const sha2_byte* data, size_t len, char digest[SHA512_DIGEST_STRING_LENGTH]) {
-	SHA512_CTX	context;
+	SHA512_CTX	context = {0};
 
 	sha512_Init(&context);
 	sha512_Update(&context, data, len);

--- a/crypto/sha3.c
+++ b/crypto/sha3.c
@@ -96,8 +96,8 @@ void sha3_512_Init(SHA3_CTX *ctx)
 /* Keccak theta() transformation */
 static void keccak_theta(uint64_t *A)
 {
-	unsigned int x;
-	uint64_t C[5], D[5];
+	unsigned int x = 0;
+	uint64_t C[5] = {0}, D[5] = {0};
 
 	for (x = 0; x < 5; x++) {
 		C[x] = A[x] ^ A[x + 5] ^ A[x + 10] ^ A[x + 15] ^ A[x + 20];
@@ -120,7 +120,7 @@ static void keccak_theta(uint64_t *A)
 /* Keccak pi() transformation */
 static void keccak_pi(uint64_t *A)
 {
-	uint64_t A1;
+	uint64_t A1 = 0;
 	A1 = A[1];
 	A[ 1] = A[ 6];
 	A[ 6] = A[ 9];
@@ -152,7 +152,7 @@ static void keccak_pi(uint64_t *A)
 /* Keccak chi() transformation */
 static void keccak_chi(uint64_t *A)
 {
-	int i;
+	int i = 0;
 	for (i = 0; i < 25; i += 5) {
 		uint64_t A0 = A[0 + i], A1 = A[1 + i];
 		A[0 + i] ^= ~A1 & A[2 + i];
@@ -165,7 +165,7 @@ static void keccak_chi(uint64_t *A)
 
 static void sha3_permutation(uint64_t *state)
 {
-	int round;
+	int round = 0;
 	for (round = 0; round < NumberOfRounds; round++)
 	{
 		keccak_theta(state);
@@ -287,7 +287,7 @@ void sha3_Update(SHA3_CTX *ctx, const unsigned char *msg, size_t size)
 		size -= left;
 	}
 	while (size >= block_size) {
-		uint64_t* aligned_message_block;
+		uint64_t *aligned_message_block = NULL;
 		if (IS_ALIGNED_64(msg)) {
 			/* the most common case is processing of an already aligned message
 			without copying it */
@@ -365,7 +365,7 @@ void keccak_Final(SHA3_CTX *ctx, unsigned char* result)
 
 void keccak_256(const unsigned char* data, size_t len, unsigned char* digest)
 {
-	SHA3_CTX ctx;
+	SHA3_CTX ctx = {0};
 	keccak_256_Init(&ctx);
 	keccak_Update(&ctx, data, len);
 	keccak_Final(&ctx, digest);
@@ -373,7 +373,7 @@ void keccak_256(const unsigned char* data, size_t len, unsigned char* digest)
 
 void keccak_512(const unsigned char* data, size_t len, unsigned char* digest)
 {
-	SHA3_CTX ctx;
+	SHA3_CTX ctx = {0};
 	keccak_512_Init(&ctx);
 	keccak_Update(&ctx, data, len);
 	keccak_Final(&ctx, digest);
@@ -382,7 +382,7 @@ void keccak_512(const unsigned char* data, size_t len, unsigned char* digest)
 
 void sha3_256(const unsigned char* data, size_t len, unsigned char* digest)
 {
-	SHA3_CTX ctx;
+	SHA3_CTX ctx = {0};
 	sha3_256_Init(&ctx);
 	sha3_Update(&ctx, data, len);
 	sha3_Final(&ctx, digest);
@@ -390,7 +390,7 @@ void sha3_256(const unsigned char* data, size_t len, unsigned char* digest)
 
 void sha3_512(const unsigned char* data, size_t len, unsigned char* digest)
 {
-	SHA3_CTX ctx;
+	SHA3_CTX ctx = {0};
 	sha3_512_Init(&ctx);
 	sha3_Update(&ctx, data, len);
 	sha3_Final(&ctx, digest);

--- a/crypto/shamir.c
+++ b/crypto/shamir.c
@@ -41,8 +41,8 @@
 #include "memzero.h"
 
 static void bitslice(uint32_t r[8], const uint8_t *x, size_t len) {
-  size_t bit_idx, arr_idx;
-  uint32_t cur;
+  size_t bit_idx = 0, arr_idx = 0;
+  uint32_t cur = 0;
 
   memset(r, 0, sizeof(uint32_t[8]));
   for (arr_idx = 0; arr_idx < len; arr_idx++) {
@@ -54,8 +54,8 @@ static void bitslice(uint32_t r[8], const uint8_t *x, size_t len) {
 }
 
 static void unbitslice(uint8_t *r, const uint32_t x[8], size_t len) {
-  size_t bit_idx, arr_idx;
-  uint32_t cur;
+  size_t bit_idx = 0, arr_idx = 0;
+  uint32_t cur = 0;
 
   memset(r, 0, sizeof(uint8_t) * len);
   for (bit_idx = 0; bit_idx < 8; bit_idx++) {
@@ -67,7 +67,7 @@ static void unbitslice(uint8_t *r, const uint32_t x[8], size_t len) {
 }
 
 static void bitslice_setall(uint32_t r[8], const uint8_t x) {
-  size_t idx;
+  size_t idx = 0;
   for (idx = 0; idx < 8; idx++) {
     r[idx] = -((x >> idx) & 1);
   }
@@ -77,7 +77,7 @@ static void bitslice_setall(uint32_t r[8], const uint8_t x) {
  * Add (XOR) `r` with `x` and store the result in `r`.
  */
 static void gf256_add(uint32_t r[8], const uint32_t x[8]) {
-  size_t idx;
+  size_t idx = 0;
   for (idx = 0; idx < 8; idx++) r[idx] ^= x[idx];
 }
 
@@ -97,7 +97,7 @@ static void gf256_mul(uint32_t r[8], const uint32_t a[8], const uint32_t b[8]) {
    * However, some compilers seem to fail in optimizing these kinds of
    * loops. So we will just have to do this by hand.
    */
-  uint32_t a2[8];
+  uint32_t a2[8] = {0};
   memcpy(a2, a, sizeof(uint32_t[8]));
 
   r[0] = a2[0] & b[0]; /* add (assignment, because r is 0) */
@@ -200,7 +200,7 @@ static void gf256_mul(uint32_t r[8], const uint32_t a[8], const uint32_t b[8]) {
  * Square `x` in GF(2^8) and write the result to `r`. `r` and `x` may overlap.
  */
 static void gf256_square(uint32_t r[8], const uint32_t x[8]) {
-  uint32_t r8, r10, r12, r14;
+  uint32_t r8 = 0, r10 = 0, r12 = 0, r14 = 0;
   /* Use the Freshman's Dream rule to square the polynomial
    * Assignments are done from 7 downto 0, because this allows the user
    * to execute this function in-place (e.g. `gf256_square(r, r);`).
@@ -242,7 +242,7 @@ static void gf256_square(uint32_t r[8], const uint32_t x[8]) {
  * Invert `x` in GF(2^8) and write the result to `r`
  */
 static void gf256_inv(uint32_t r[8], uint32_t x[8]) {
-  uint32_t y[8], z[8];
+  uint32_t y[8] = {0}, z[8] = {0};
 
   gf256_square(y, x);  // y = x^2
   gf256_square(y, y);  // y = x^4
@@ -264,13 +264,13 @@ bool shamir_interpolate(uint8_t *result, uint8_t result_index,
                         const uint8_t *share_indices,
                         const uint8_t **share_values, uint8_t share_count,
                         size_t len) {
-  size_t i, j;
-  uint32_t x[8];
+  size_t i = 0, j = 0;
+  uint32_t x[8] = {0};
   uint32_t xs[share_count][8];
   uint32_t ys[share_count][8];
   uint32_t num[8] = {~0}; /* num is the numerator (=1) */
-  uint32_t denom[8];
-  uint32_t tmp[8];
+  uint32_t denom[8] = {0};
+  uint32_t tmp[8] = {0};
   uint32_t secret[8] = {0};
   bool ret = true;
 

--- a/crypto/shamir.c
+++ b/crypto/shamir.c
@@ -267,7 +267,9 @@ bool shamir_interpolate(uint8_t *result, uint8_t result_index,
   size_t i = 0, j = 0;
   uint32_t x[8] = {0};
   uint32_t xs[share_count][8];
+  memset(xs, 0, sizeof(xs));
   uint32_t ys[share_count][8];
+  memset(ys, 0, sizeof(ys));
   uint32_t num[8] = {~0}; /* num is the numerator (=1) */
   uint32_t denom[8] = {0};
   uint32_t tmp[8] = {0};

--- a/legacy/bootloader/bootloader.c
+++ b/legacy/bootloader/bootloader.c
@@ -35,7 +35,7 @@
 #include "util.h"
 
 void layoutFirmwareFingerprint(const uint8_t *hash) {
-  char str[4][17];
+  char str[4][17] = {0};
   for (int i = 0; i < 4; i++) {
     data2hex(hash + i * 8, 8, str[i]);
   }
@@ -129,7 +129,7 @@ int main(void) {
     const image_header *hdr =
         (const image_header *)FLASH_PTR(FLASH_FWHEADER_START);
 
-    uint8_t fingerprint[32];
+    uint8_t fingerprint[32] = {0};
     int signed_firmware = signatures_new_ok(hdr, fingerprint);
     if (SIG_OK != signed_firmware) {
       show_unofficial_warning(fingerprint);

--- a/legacy/bootloader/signatures.c
+++ b/legacy/bootloader/signatures.c
@@ -79,7 +79,7 @@ int signatures_old_ok(void) {
     return false;
   }
 
-  uint8_t hash[32];
+  uint8_t hash[32] = {0};
   sha256_Raw(FLASH_PTR(FLASH_OLD_APP_START), codelen, hash);
 
   if (sigindex1 < 1 || sigindex1 > PUBKEYS) return SIG_FAIL;  // invalid index
@@ -110,7 +110,7 @@ int signatures_old_ok(void) {
 }
 
 void compute_firmware_fingerprint(const image_header *hdr, uint8_t hash[32]) {
-  image_header copy;
+  image_header copy = {0};
   memcpy(&copy, hdr, sizeof(image_header));
   memzero(copy.sig1, sizeof(copy.sig1));
   memzero(copy.sig2, sizeof(copy.sig2));
@@ -137,7 +137,7 @@ bool firmware_present_new(void) {
 }
 
 int signatures_new_ok(const image_header *hdr, uint8_t store_fingerprint[32]) {
-  uint8_t hash[32];
+  uint8_t hash[32] = {0};
   compute_firmware_fingerprint(hdr, hash);
 
   if (store_fingerprint) {
@@ -179,7 +179,7 @@ int mem_is_empty(const uint8_t *src, uint32_t len) {
 }
 
 int check_firmware_hashes(const image_header *hdr) {
-  uint8_t hash[32];
+  uint8_t hash[32] = {0};
   // check hash of the first code chunk
   sha256_Raw(FLASH_PTR(FLASH_APP_START), (64 - 1) * 1024, hash);
   if (0 != memcmp(hash, hdr->hashes, 32)) return SIG_FAIL;

--- a/legacy/bootloader/usb.c
+++ b/legacy/bootloader/usb.c
@@ -66,8 +66,8 @@ static void check_and_write_chunk(void) {
   if (chunk_pos == 0) {
     chunk_pos = FW_CHUNK_SIZE;
   }
-  uint8_t hash[32];
-  SHA256_CTX ctx;
+  uint8_t hash[32] = {0};
+  SHA256_CTX ctx = {0};
   sha256_Init(&ctx);
   sha256_Update(&ctx, (const uint8_t *)FW_CHUNK + offset, chunk_pos - offset);
   if (chunk_pos < 64 * 1024) {
@@ -329,7 +329,7 @@ static void rx_callback(usbd_device *dev, uint8_t ep) {
       if (msg_id != 0x001B) {  // ButtonAck message (id 27)
         return;
       }
-      uint8_t hash[32];
+      uint8_t hash[32] = {0};
       compute_firmware_fingerprint(hdr, hash);
       layoutFirmwareFingerprint(hash);
       hash_check_ok = get_button_response();
@@ -347,7 +347,7 @@ static void rx_callback(usbd_device *dev, uint8_t ep) {
       // erase storage
       erase_storage();
       // check erasure
-      uint8_t hash[32];
+      uint8_t hash[32] = {0};
       sha256_Raw(FLASH_PTR(FLASH_STORAGE_START), FLASH_STORAGE_LEN, hash);
       if (memcmp(hash,
                  "\x2d\x86\x4c\x0b\x78\x9a\x43\x21\x4e\xee\x85\x24\xd3\x18\x20"

--- a/legacy/common.c
+++ b/legacy/common.c
@@ -103,7 +103,7 @@ void wait_random(void) {
 }
 
 void drbg_init() {
-  uint8_t entropy[48];
+  uint8_t entropy[48] = {0};
   random_buffer(entropy, sizeof(entropy));
   hmac_drbg_init(&drbg_ctx, entropy, sizeof(entropy), NULL, 0);
 }
@@ -117,7 +117,7 @@ void drbg_generate(uint8_t *buf, size_t len) {
 }
 
 uint32_t drbg_random32(void) {
-  uint32_t value;
+  uint32_t value = 0;
   drbg_generate((uint8_t *)&value, sizeof(value));
   return value;
 }

--- a/legacy/demo/demo.c
+++ b/legacy/demo/demo.c
@@ -35,9 +35,9 @@ int frame = 0;
 
 uint8_t seed[128];
 uint8_t *pass = (uint8_t *)"meadow";
-uint32_t passlen;
+uint32_t passlen = 0;
 uint8_t *salt = (uint8_t *)"TREZOR";
-uint32_t saltlen;
+uint32_t saltlen = 0;
 
 static const struct usb_device_descriptor dev_descr = {
     .bLength = USB_DT_DEVICE_SIZE,

--- a/legacy/emulator/rng.c
+++ b/legacy/emulator/rng.c
@@ -21,7 +21,7 @@
 
 uint32_t random32(void) {
   static uint32_t last = 0;
-  uint32_t new;
+  uint32_t new = 0;
 
   do {
     emulatorRandom(&new, sizeof(new));

--- a/legacy/emulator/setup.c
+++ b/legacy/emulator/setup.c
@@ -57,7 +57,7 @@ void __attribute__((noreturn)) shutdown(void) {
 }
 
 void emulatorRandom(void *buffer, size_t size) {
-  ssize_t n, len = 0;
+  ssize_t n = 0, len = 0;
   do {
     n = read(random_fd, (char *)buffer + len, size - len);
     if (n < 0) {

--- a/legacy/emulator/timer.c
+++ b/legacy/emulator/timer.c
@@ -24,7 +24,7 @@
 void timer_init(void) {}
 
 uint32_t timer_ms(void) {
-  struct timespec t;
+  struct timespec t = {0};
   clock_gettime(CLOCK_MONOTONIC, &t);
 
   uint32_t msec = t.tv_sec * 1000 + (t.tv_nsec / 1000000);

--- a/legacy/emulator/udp.c
+++ b/legacy/emulator/udp.c
@@ -42,7 +42,7 @@ static int socket_setup(int port) {
     exit(1);
   }
 
-  struct sockaddr_in addr;
+  struct sockaddr_in addr = {0};
   addr.sin_family = AF_INET;
   addr.sin_port = htons(port);
   addr.sin_addr.s_addr = htonl(INADDR_LOOPBACK);

--- a/legacy/firmware/bl_check.c
+++ b/legacy/firmware/bl_check.c
@@ -132,7 +132,7 @@ static int known_bootloader(int r, const uint8_t *hash) {
 
 void check_bootloader(void) {
 #if MEMORY_PROTECT
-  uint8_t hash[32];
+  uint8_t hash[32] = {0};
   int r = memory_bootloader_hash(hash);
 
   if (!known_bootloader(r, hash)) {

--- a/legacy/firmware/coins.c
+++ b/legacy/firmware/coins.c
@@ -54,7 +54,7 @@ const CoinInfo *coinBySlip44(uint32_t coin_type) {
 bool coinExtractAddressType(const CoinInfo *coin, const char *addr,
                             uint32_t *address_type) {
   if (!addr) return false;
-  uint8_t addr_raw[MAX_ADDR_RAW_SIZE];
+  uint8_t addr_raw[MAX_ADDR_RAW_SIZE] = {0};
   int len = base58_decode_check(addr, coin->curve->hasher_base58, addr_raw,
                                 MAX_ADDR_RAW_SIZE);
   if (len >= 21) {

--- a/legacy/firmware/crypto.c
+++ b/legacy/firmware/crypto.c
@@ -124,11 +124,11 @@ int signifyMessageSign(HDNode *node, const uint8_t *message, size_t message_len,
 static void cryptoMessageHash(const CoinInfo *coin, const uint8_t *message,
                               size_t message_len,
                               uint8_t hash[HASHER_DIGEST_LENGTH]) {
-  Hasher hasher;
+  Hasher hasher = {0};
   hasher_Init(&hasher, coin->curve->hasher_sign);
   hasher_Update(&hasher, (const uint8_t *)coin->signed_message_header,
                 strlen(coin->signed_message_header));
-  uint8_t varint[5];
+  uint8_t varint[5] = {0};
   uint32_t l = ser_length(message_len, varint);
   hasher_Update(&hasher, varint, l);
   hasher_Update(&hasher, message, message_len);
@@ -138,10 +138,10 @@ static void cryptoMessageHash(const CoinInfo *coin, const uint8_t *message,
 int cryptoMessageSign(const CoinInfo *coin, HDNode *node,
                       InputScriptType script_type, const uint8_t *message,
                       size_t message_len, uint8_t *signature) {
-  uint8_t hash[HASHER_DIGEST_LENGTH];
+  uint8_t hash[HASHER_DIGEST_LENGTH] = {0};
   cryptoMessageHash(coin, message, message_len, hash);
 
-  uint8_t pby;
+  uint8_t pby = 0;
   int result = hdnode_sign_digest(node, hash, signature + 1, &pby, NULL);
   if (result == 0) {
     switch (script_type) {
@@ -170,14 +170,14 @@ int cryptoMessageVerify(const CoinInfo *coin, const uint8_t *message,
     return 1;
   }
 
-  uint8_t hash[HASHER_DIGEST_LENGTH];
+  uint8_t hash[HASHER_DIGEST_LENGTH] = {0};
   cryptoMessageHash(coin, message, message_len, hash);
 
   uint8_t recid = (signature[0] - 27) % 4;
   bool compressed = signature[0] >= 31;
 
   // check if signature verifies the digest and recover the public key
-  uint8_t pubkey[65];
+  uint8_t pubkey[65] = {0};
   if (ecdsa_recover_pub_from_sig(coin->curve->params, pubkey, signature + 1,
                                  hash, recid) != 0) {
     return 3;
@@ -188,12 +188,12 @@ int cryptoMessageVerify(const CoinInfo *coin, const uint8_t *message,
   }
 
   // check if the address is correct
-  uint8_t addr_raw[MAX_ADDR_RAW_SIZE];
-  uint8_t recovered_raw[MAX_ADDR_RAW_SIZE];
+  uint8_t addr_raw[MAX_ADDR_RAW_SIZE] = {0};
+  uint8_t recovered_raw[MAX_ADDR_RAW_SIZE] = {0};
 
   // p2pkh
   if (signature[0] >= 27 && signature[0] <= 34) {
-    size_t len;
+    size_t len = 0;
     if (coin->cashaddr_prefix) {
       if (!cash_addr_decode(addr_raw, &len, coin->cashaddr_prefix, address)) {
         return 2;
@@ -223,8 +223,8 @@ int cryptoMessageVerify(const CoinInfo *coin, const uint8_t *message,
   } else
       // segwit
       if (signature[0] >= 39 && signature[0] <= 42) {
-    int witver;
-    size_t len;
+    int witver = 0;
+    size_t len = 0;
     if (!coin->bech32_prefix ||
         !segwit_addr_decode(&witver, recovered_raw, &len, coin->bech32_prefix,
                             address)) {
@@ -248,7 +248,7 @@ msg_size, bool display_only, uint8_t *nonce, size_t *nonce_len, uint8_t
 *privkey, const uint8_t *address_raw)
 {
         if (privkey && address_raw) { // signing == true
-                HDNode node;
+                HDNode node = {0};
                 payload[0] = display_only ? 0x81 : 0x01;
                 uint32_t l = ser_length(msg_size, payload + 1);
                 memcpy(payload + 1 + l, msg, msg_size);
@@ -265,8 +265,8 @@ msg_size, bool display_only, uint8_t *nonce, size_t *nonce_len, uint8_t
                 *payload_len = 1 + l + msg_size;
         }
         // generate random nonce
-        curve_point R;
-        bignum256 k;
+        curve_point R = {0};
+        bignum256 k = {0};
         if (generate_k_random(&secp256k1, &k) != 0) {
                 return 2;
         }
@@ -277,23 +277,23 @@ msg_size, bool display_only, uint8_t *nonce, size_t *nonce_len, uint8_t
         *nonce_len = 33;
         // compute shared secret
         point_multiply(&secp256k1, &k, pubkey, &R);
-        uint8_t shared_secret[33];
+        uint8_t shared_secret[33] = {0};
         shared_secret[0] = 0x02 | (R.y.val[0] & 0x01);
         bn_write_be(&R.x, shared_secret + 1);
         // generate keying bytes
-        uint8_t keying_bytes[80];
-        uint8_t salt[22 + 33];
+        uint8_t keying_bytes[80] = {0};
+        uint8_t salt[22 + 33] = {0};
         memcpy(salt, "Bitcoin Secure Message", 22);
         memcpy(salt + 22, nonce, 33);
         pbkdf2_hmac_sha256(shared_secret, 33, salt, 22 + 33, 2048, keying_bytes,
 80);
         // encrypt payload
-        aes_encrypt_ctx ctx;
+        aes_encrypt_ctx ctx = {0};
         aes_encrypt_key256(keying_bytes, &ctx);
         aes_cfb_encrypt(payload, payload, *payload_len, keying_bytes + 64,
 &ctx);
         // compute hmac
-        uint8_t out[32];
+        uint8_t out[32] = {0};
         hmac_sha256(keying_bytes + 32, 32, payload, *payload_len, out);
         memcpy(hmac, out, 8);
         *hmac_len = 8;
@@ -310,29 +310,29 @@ uint8_t *msg, size_t *msg_len, bool *display_only, bool *signing, uint8_t
                 return 1;
         }
         // compute shared secret
-        curve_point R;
-        bignum256 k;
+        curve_point R = {0};
+        bignum256 k = {0};
         bn_read_be(privkey, &k);
         point_multiply(&secp256k1, &k, nonce, &R);
-        uint8_t shared_secret[33];
+        uint8_t shared_secret[33] = {0};
         shared_secret[0] = 0x02 | (R.y.val[0] & 0x01);
         bn_write_be(&R.x, shared_secret + 1);
         // generate keying bytes
-        uint8_t keying_bytes[80];
-        uint8_t salt[22 + 33];
+        uint8_t keying_bytes[80] = {0};
+        uint8_t salt[22 + 33] = {0};
         memcpy(salt, "Bitcoin Secure Message", 22);
         salt[22] = 0x02 | (nonce->y.val[0] & 0x01);
         bn_write_be(&(nonce->x), salt + 23);
         pbkdf2_hmac_sha256(shared_secret, 33, salt, 22 + 33, 2048, keying_bytes,
 80);
         // compute hmac
-        uint8_t out[32];
+        uint8_t out[32] = {0};
         hmac_sha256(keying_bytes + 32, 32, payload, payload_len, out);
         if (memcmp(hmac, out, 8) != 0) {
                 return 2;
         }
         // decrypt payload
-        aes_encrypt_ctx ctx;
+        aes_encrypt_ctx ctx = {0};
         aes_encrypt_key256(keying_bytes, &ctx);
         aes_cfb_decrypt(payload, payload, payload_len, keying_bytes + 64, &ctx);
         // check first byte
@@ -341,7 +341,7 @@ payload[0] != 0x81) { return 3;
         }
         *signing = payload[0] & 0x01;
         *display_only = payload[0] & 0x80;
-        uint32_t l, o;
+        uint32_t l = 0; uint32_t o = 0;
         l = deser_length(payload + 1, &o);
         if (*signing) {
                 // FIXME: assumes a raw address is 21 bytes (also below).
@@ -367,9 +367,9 @@ payload + 1 + l + o + 21) != 0) { return 5;
 const HDNode *cryptoMultisigPubkey(const CoinInfo *coin,
                                    const MultisigRedeemScriptType *multisig,
                                    uint32_t index) {
-  const HDNodeType *node_ptr;
-  const uint32_t *address_n;
-  uint32_t address_n_count;
+  const HDNodeType *node_ptr = NULL;
+  const uint32_t *address_n = NULL;
+  uint32_t address_n_count = 0;
   if (multisig->nodes_count) {  // use multisig->nodes
     if (index >= multisig->nodes_count) {
       return 0;
@@ -458,7 +458,7 @@ int cryptoMultisigFingerprint(const MultisigRedeemScriptType *multisig,
     }
   }
   // hash sorted nodes
-  SHA256_CTX ctx;
+  SHA256_CTX ctx = {0};
   sha256_Init(&ctx);
   sha256_Update(&ctx, (const uint8_t *)&(multisig->m), sizeof(uint32_t));
   for (uint32_t i = 0; i < n; i++) {
@@ -478,7 +478,7 @@ int cryptoMultisigFingerprint(const MultisigRedeemScriptType *multisig,
 }
 
 int cryptoIdentityFingerprint(const IdentityType *identity, uint8_t *hash) {
-  SHA256_CTX ctx;
+  SHA256_CTX ctx = {0};
   sha256_Init(&ctx);
   sha256_Update(&ctx, (const uint8_t *)&(identity->index), sizeof(uint32_t));
   if (identity->has_proto && identity->proto[0]) {

--- a/legacy/firmware/fsm.c
+++ b/legacy/firmware/fsm.c
@@ -188,7 +188,7 @@ void fsm_sendFailure(FailureType code, const char *text)
 }
 
 static const CoinInfo *fsm_getCoin(bool has_name, const char *name) {
-  const CoinInfo *coin;
+  const CoinInfo *coin = NULL;
   if (has_name) {
     coin = coinByName(name);
   } else {

--- a/legacy/firmware/layout2.c
+++ b/legacy/firmware/layout2.c
@@ -574,6 +574,7 @@ void layoutAddress(const char *address, const char *desc, bool qrcode,
   uint32_t addrlen = strlen(address);
   if (qrcode) {
     char address_upcase[addrlen + 1];
+    memset(address_upcase, 0, sizeof(address_upcase));
     if (ignorecase) {
       for (uint32_t i = 0; i < addrlen + 1; i++) {
         address_upcase[i] = address[i] >= 'a' && address[i] <= 'z'

--- a/legacy/firmware/layout2.c
+++ b/legacy/firmware/layout2.c
@@ -128,7 +128,7 @@ static const char *address_n_str(const uint32_t *address_n,
       } else {
         strlcat(path, " account #", sizeof(path));
       }
-      char acc[3];
+      char acc[3] = {0};
       memzero(acc, sizeof(acc));
       if (accnum < 10) {
         acc[0] = '0' + accnum;
@@ -207,7 +207,7 @@ const char **split_message(const uint8_t *msg, uint32_t len, uint32_t rowlen) {
 }
 
 const char **split_message_hex(const uint8_t *msg, uint32_t len) {
-  char hex[32 * 2 + 1];
+  char hex[32 * 2 + 1] = {0};
   memzero(hex, sizeof(hex));
   uint32_t size = len;
   if (len > 32) {
@@ -262,9 +262,9 @@ void layoutHome(void) {
     config_getLabel(label, sizeof(label));
   }
 
-  uint8_t homescreen[HOMESCREEN_SIZE];
+  uint8_t homescreen[HOMESCREEN_SIZE] = {0};
   if (config_getHomescreen(homescreen, sizeof(homescreen))) {
-    BITMAP b;
+    BITMAP b = {0};
     b.width = 128;
     b.height = 64;
     b.data = homescreen;
@@ -345,7 +345,7 @@ static void render_address_dialog(const CoinInfo *coin, const char *address,
 }
 
 void layoutConfirmOutput(const CoinInfo *coin, const TxOutputType *out) {
-  char str_out[32 + 3];
+  char str_out[32 + 3] = {0};
   bn_format_uint64(out->amount, NULL, coin->coin_shortcut, BITCOIN_DIVISIBILITY,
                    0, false, str_out, sizeof(str_out) - 3);
   strlcat(str_out, " to", sizeof(str_out));
@@ -359,9 +359,9 @@ void layoutConfirmOutput(const CoinInfo *coin, const TxOutputType *out) {
 }
 
 void layoutConfirmOmni(const uint8_t *data, uint32_t size) {
-  const char *desc;
-  char str_out[32];
-  uint32_t tx_type, currency;
+  const char *desc = NULL;
+  char str_out[32] = {0};
+  uint32_t tx_type = 0, currency = 0;
   REVERSE32(*(const uint32_t *)(data + 4), tx_type);
   if (tx_type == 0x00000000 && size == 20) {  // OMNI simple send
     desc = _("Simple send of ");
@@ -386,7 +386,7 @@ void layoutConfirmOmni(const uint8_t *data, uint32_t size) {
         divisible = true;
         break;
     }
-    uint64_t amount_be, amount;
+    uint64_t amount_be = 0, amount = 0;
     memcpy(&amount_be, data + 12, sizeof(uint64_t));
     REVERSE64(amount_be, amount);
     bn_format_uint64(amount, NULL, suffix, divisible ? BITCOIN_DIVISIBILITY : 0,
@@ -410,7 +410,7 @@ static bool is_valid_ascii(const uint8_t *data, uint32_t size) {
 }
 
 void layoutConfirmOpReturn(const uint8_t *data, uint32_t size) {
-  const char **str;
+  const char **str = NULL;
   if (!is_valid_ascii(data, size)) {
     str = split_message_hex(data, size);
   } else {
@@ -423,7 +423,7 @@ void layoutConfirmOpReturn(const uint8_t *data, uint32_t size) {
 
 void layoutConfirmTx(const CoinInfo *coin, uint64_t amount_out,
                      uint64_t amount_fee) {
-  char str_out[32], str_fee[32];
+  char str_out[32] = {0}, str_fee[32] = {0};
   bn_format_uint64(amount_out, NULL, coin->coin_shortcut, BITCOIN_DIVISIBILITY,
                    0, false, str_out, sizeof(str_out));
   bn_format_uint64(amount_fee, NULL, coin->coin_shortcut, BITCOIN_DIVISIBILITY,
@@ -434,7 +434,7 @@ void layoutConfirmTx(const CoinInfo *coin, uint64_t amount_out,
 }
 
 void layoutFeeOverThreshold(const CoinInfo *coin, uint64_t fee) {
-  char str_fee[32];
+  char str_fee[32] = {0};
   bn_format_uint64(fee, NULL, coin->coin_shortcut, BITCOIN_DIVISIBILITY, 0,
                    false, str_fee, sizeof(str_fee));
   layoutDialogSwipe(&bmp_icon_question, _("Cancel"), _("Confirm"), NULL,
@@ -443,7 +443,7 @@ void layoutFeeOverThreshold(const CoinInfo *coin, uint64_t fee) {
 }
 
 void layoutSignMessage(const uint8_t *msg, uint32_t len) {
-  const char **str;
+  const char **str = NULL;
   if (!is_valid_ascii(msg, len)) {
     str = split_message_hex(msg, len);
     layoutDialogSwipe(&bmp_icon_question, _("Cancel"), _("Confirm"),
@@ -458,7 +458,7 @@ void layoutSignMessage(const uint8_t *msg, uint32_t len) {
 }
 
 void layoutVerifyMessage(const uint8_t *msg, uint32_t len) {
-  const char **str;
+  const char **str = NULL;
   if (!is_valid_ascii(msg, len)) {
     str = split_message_hex(msg, len);
     layoutDialogSwipe(&bmp_icon_info, _("Cancel"), _("Confirm"),
@@ -506,7 +506,7 @@ void layoutResetWord(const char *word, int pass, int word_pos, bool last) {
   layoutLast = layoutResetWord;
   layoutSwipe();
 
-  const char *btnYes;
+  const char *btnYes = NULL;
   if (last) {
     if (pass == 1) {
       btnYes = _("Finish");
@@ -517,7 +517,7 @@ void layoutResetWord(const char *word, int pass, int word_pos, bool last) {
     btnYes = _("Next");
   }
 
-  const char *action;
+  const char *action = NULL;
   if (pass == 1) {
     action = _("Please check the seed");
   } else {
@@ -581,8 +581,8 @@ void layoutAddress(const char *address, const char *desc, bool qrcode,
                                 : address[i];
       }
     }
-    uint8_t codedata[qrcodegen_BUFFER_LEN_FOR_VERSION(QR_MAX_VERSION)];
-    uint8_t tempdata[qrcodegen_BUFFER_LEN_FOR_VERSION(QR_MAX_VERSION)];
+    uint8_t codedata[qrcodegen_BUFFER_LEN_FOR_VERSION(QR_MAX_VERSION)] = {0};
+    uint8_t tempdata[qrcodegen_BUFFER_LEN_FOR_VERSION(QR_MAX_VERSION)] = {0};
 
     int side = 0;
     if (qrcodegen_encodeText(ignorecase ? address_upcase : address, tempdata,
@@ -641,7 +641,7 @@ void layoutAddress(const char *address, const char *desc, bool qrcode,
 }
 
 void layoutPublicKey(const uint8_t *pubkey) {
-  char desc[16];
+  char desc[16] = {0};
   strlcpy(desc, "Public Key: 00", sizeof(desc));
   if (pubkey[0] == 1) {
     /* ed25519 public key */
@@ -655,9 +655,9 @@ void layoutPublicKey(const uint8_t *pubkey) {
 }
 
 void layoutSignIdentity(const IdentityType *identity, const char *challenge) {
-  char row_proto[8 + 11 + 1];
-  char row_hostport[64 + 6 + 1];
-  char row_user[64 + 8 + 1];
+  char row_proto[8 + 11 + 1] = {0};
+  char row_hostport[64 + 6 + 1] = {0};
+  char row_user[64 + 8 + 1] = {0};
 
   bool is_gpg = (strcmp(identity->proto, "gpg") == 0);
 
@@ -719,9 +719,9 @@ void layoutSignIdentity(const IdentityType *identity, const char *challenge) {
 }
 
 void layoutDecryptIdentity(const IdentityType *identity) {
-  char row_proto[8 + 11 + 1];
-  char row_hostport[64 + 6 + 1];
-  char row_user[64 + 8 + 1];
+  char row_proto[8 + 11 + 1] = {0};
+  char row_hostport[64 + 6 + 1] = {0};
+  char row_user[64 + 8 + 1] = {0};
 
   if (identity->has_proto && identity->proto[0]) {
     strlcpy(row_proto, identity->proto, sizeof(row_proto));
@@ -786,7 +786,7 @@ void layoutNEMDialog(const BITMAP *icon, const char *btnNo, const char *btnYes,
 
 void layoutNEMTransferXEM(const char *desc, uint64_t quantity,
                           const bignum256 *multiplier, uint64_t fee) {
-  char str_out[32], str_fee[32];
+  char str_out[32] = {0}, str_fee[32] = {0};
 
   nem_mosaicFormatAmount(NEM_MOSAIC_DEFINITION_XEM, quantity, multiplier,
                          str_out, sizeof(str_out));
@@ -800,7 +800,7 @@ void layoutNEMTransferXEM(const char *desc, uint64_t quantity,
 
 void layoutNEMNetworkFee(const char *desc, bool confirm, const char *fee1_desc,
                          uint64_t fee1, const char *fee2_desc, uint64_t fee2) {
-  char str_fee1[32], str_fee2[32];
+  char str_fee1[32] = {0}, str_fee2[32] = {0};
 
   nem_mosaicFormatAmount(NEM_MOSAIC_DEFINITION_XEM, fee1, NULL, str_fee1,
                          sizeof(str_fee1));
@@ -818,7 +818,7 @@ void layoutNEMNetworkFee(const char *desc, bool confirm, const char *fee1_desc,
 void layoutNEMTransferMosaic(const NEMMosaicDefinition *definition,
                              uint64_t quantity, const bignum256 *multiplier,
                              uint8_t network) {
-  char str_out[32], str_levy[32];
+  char str_out[32] = {0}, str_levy[32] = {0};
 
   nem_mosaicFormatAmount(definition, quantity, multiplier, str_out,
                          sizeof(str_out));
@@ -838,10 +838,10 @@ void layoutNEMTransferMosaic(const NEMMosaicDefinition *definition,
 void layoutNEMTransferUnknownMosaic(const char *namespace, const char *mosaic,
                                     uint64_t quantity,
                                     const bignum256 *multiplier) {
-  char mosaic_name[32];
+  char mosaic_name[32] = {0};
   nem_mosaicFormatName(namespace, mosaic, mosaic_name, sizeof(mosaic_name));
 
-  char str_out[32];
+  char str_out[32] = {0};
   nem_mosaicFormatAmount(NULL, quantity, multiplier, str_out, sizeof(str_out));
 
   char *decimal = strchr(str_out, '.');
@@ -858,6 +858,8 @@ void layoutNEMTransferPayload(const uint8_t *payload, size_t length,
                               bool encrypted) {
   if (length >= 1 && payload[0] == 0xFE) {
     char encoded[(length - 1) * 2 + 1];
+    memset(encoded, 0, sizeof(encoded));
+
     data2hex(&payload[1], length - 1, encoded);
 
     const char **str =
@@ -884,7 +886,7 @@ void layoutNEMMosaicDescription(const char *description) {
 }
 
 void layoutNEMLevy(const NEMMosaicDefinition *definition, uint8_t network) {
-  const NEMMosaicDefinition *mosaic;
+  const NEMMosaicDefinition *mosaic = NULL;
   if (nem_mosaicMatches(definition, definition->levy_namespace,
                         definition->levy_mosaic, network)) {
     mosaic = definition;
@@ -893,13 +895,13 @@ void layoutNEMLevy(const NEMMosaicDefinition *definition, uint8_t network) {
                               definition->levy_mosaic, network);
   }
 
-  char mosaic_name[32];
+  char mosaic_name[32] = {0};
   if (mosaic == NULL) {
     nem_mosaicFormatName(definition->levy_namespace, definition->levy_mosaic,
                          mosaic_name, sizeof(mosaic_name));
   }
 
-  char str_out[32];
+  char str_out[32] = {0};
 
   switch (definition->levy) {
     case NEMMosaicLevy_MosaicLevy_Percentile:
@@ -939,7 +941,7 @@ static inline bool is_slip18(const uint32_t *address_n,
 void layoutCosiCommitSign(const uint32_t *address_n, size_t address_n_count,
                           const uint8_t *data, uint32_t len, bool final_sign) {
   char *desc = final_sign ? _("CoSi sign message?") : _("CoSi commit message?");
-  char desc_buf[32];
+  char desc_buf[32] = {0};
   if (is_slip18(address_n, address_n_count)) {
     if (final_sign) {
       strlcpy(desc_buf, _("CoSi sign index #?"), sizeof(desc_buf));
@@ -950,7 +952,7 @@ void layoutCosiCommitSign(const uint32_t *address_n, size_t address_n_count,
     }
     desc = desc_buf;
   }
-  char str[4][17];
+  char str[4][17] = {0};
   if (len == 32) {
     data2hex(data, 8, str[0]);
     data2hex(data + 8, 8, str[1]);

--- a/legacy/firmware/lisk.c
+++ b/legacy/firmware/lisk.c
@@ -30,7 +30,7 @@
 
 void lisk_get_address_from_public_key(const uint8_t *public_key,
                                       char *address) {
-  uint64_t digest[4];
+  uint64_t digest[4] = {0};
   sha256_Raw(public_key, 32, (uint8_t *)digest);
   bn_format_uint64(digest[0], NULL, "L", 0, 0, false, address,
                    MAX_LISK_ADDRESS_SIZE);
@@ -38,10 +38,10 @@ void lisk_get_address_from_public_key(const uint8_t *public_key,
 
 void lisk_message_hash(const uint8_t *message, size_t message_len,
                        uint8_t hash[32]) {
-  SHA256_CTX ctx;
+  SHA256_CTX ctx = {0};
   sha256_Init(&ctx);
   sha256_Update(&ctx, (const uint8_t *)"\x15" "Lisk Signed Message:\n", 22);
-  uint8_t varint[5];
+  uint8_t varint[5] = {0};
   uint32_t l = ser_length(message_len, varint);
   sha256_Update(&ctx, varint, l);
   sha256_Update(&ctx, message, message_len);
@@ -60,8 +60,8 @@ void lisk_sign_message(const HDNode *node, const LiskSignMessage *msg,
 
   layoutProgressSwipe(_("Signing"), 0);
 
-  uint8_t signature[64];
-  uint8_t hash[32];
+  uint8_t signature[64] = {0};
+  uint8_t hash[32] = {0};
   lisk_message_hash(msg->message.bytes, msg->message.size, hash);
 
   ed25519_sign(hash, 32, node->private_key, &node->public_key[1], signature);
@@ -76,7 +76,7 @@ void lisk_sign_message(const HDNode *node, const LiskSignMessage *msg,
 }
 
 bool lisk_verify_message(const LiskVerifyMessage *msg) {
-  uint8_t hash[32];
+  uint8_t hash[32] = {0};
   lisk_message_hash(msg->message.bytes, msg->message.size, hash);
   return 0 == ed25519_sign_open(hash, 32, msg->public_key.bytes,
                                 msg->signature.bytes);
@@ -98,7 +98,7 @@ static void lisk_update_raw_tx(const HDNode *node, LiskSignTx *msg) {
 }
 
 static void lisk_hashupdate_uint32(SHA256_CTX *ctx, uint32_t value) {
-  uint8_t data[4];
+  uint8_t data[4] = {0};
   write_le(data, value);
   sha256_Update(ctx, data, sizeof(data));
 }
@@ -108,7 +108,7 @@ static void lisk_hashupdate_uint64_le(SHA256_CTX *ctx, uint64_t value) {
 }
 
 static void lisk_hashupdate_uint64_be(SHA256_CTX *ctx, uint64_t value) {
-  uint8_t data[8];
+  uint8_t data[8] = {0};
   data[0] = value >> 56;
   data[1] = value >> 48;
   data[2] = value >> 40;
@@ -174,7 +174,7 @@ void lisk_sign_tx(const HDNode *node, LiskSignTx *msg, LiskSignedTx *resp) {
   lisk_update_raw_tx(node, msg);
 
   if (msg->has_transaction) {
-    SHA256_CTX ctx;
+    SHA256_CTX ctx = {0};
     sha256_Init(&ctx);
 
     switch (msg->transaction.type) {
@@ -256,7 +256,7 @@ void lisk_sign_tx(const HDNode *node, LiskSignTx *msg, LiskSignedTx *resp) {
                     msg->transaction.signature.size);
     }
 
-    uint8_t hash[32];
+    uint8_t hash[32] = {0};
     sha256_Final(&ctx, hash);
     ed25519_sign(hash, 32, node->private_key, &node->public_key[1],
                  resp->signature.bytes);
@@ -282,7 +282,7 @@ void layoutLiskVerifyAddress(const char *address) {
 }
 
 void layoutRequireConfirmTx(char *recipient_id, uint64_t amount) {
-  char formated_amount[MAX_LISK_VALUE_SIZE];
+  char formated_amount[MAX_LISK_VALUE_SIZE] = {0};
   const char **str =
       split_message((const uint8_t *)recipient_id, strlen(recipient_id), 16);
   lisk_format_value(amount, formated_amount);
@@ -292,8 +292,8 @@ void layoutRequireConfirmTx(char *recipient_id, uint64_t amount) {
 }
 
 void layoutRequireConfirmFee(uint64_t fee, uint64_t amount) {
-  char formated_amount[MAX_LISK_VALUE_SIZE];
-  char formated_fee[MAX_LISK_VALUE_SIZE];
+  char formated_amount[MAX_LISK_VALUE_SIZE] = {0};
+  char formated_fee[MAX_LISK_VALUE_SIZE] = {0};
   lisk_format_value(amount, formated_amount);
   lisk_format_value(fee, formated_fee);
   layoutDialogSwipe(&bmp_icon_question, _("Cancel"), _("Confirm"), NULL,
@@ -314,8 +314,8 @@ void layoutRequireConfirmDelegateRegistration(LiskTransactionAsset *asset) {
 void layoutRequireConfirmCastVotes(LiskTransactionAsset *asset) {
   uint8_t plus = 0;
   uint8_t minus = 0;
-  char add_votes_txt[13];
-  char remove_votes_txt[16];
+  char add_votes_txt[13] = {0};
+  char remove_votes_txt[16] = {0};
 
   for (int i = 0; i < asset->votes_count; i++) {
     if (asset->votes[i][0] == '+') {
@@ -336,9 +336,9 @@ void layoutRequireConfirmCastVotes(LiskTransactionAsset *asset) {
 }
 
 void layoutRequireConfirmMultisig(LiskTransactionAsset *asset) {
-  char keys_group_str[25];
-  char life_time_str[14];
-  char min_str[8];
+  char keys_group_str[25] = {0};
+  char life_time_str[14] = {0};
+  char min_str[8] = {0};
 
   bn_format_uint64(asset->multisignature.keys_group_count,
                    "Keys group length: ", NULL, 0, 0, false, keys_group_str,

--- a/legacy/firmware/messages.c
+++ b/legacy/firmware/messages.c
@@ -164,12 +164,12 @@ bool msg_write_common(char type, uint16_t msg_id, const void *msg_ptr) {
     return false;
   }
 
-  size_t len;
+  size_t len = 0;
   if (!pb_get_encoded_size(&len, fields, msg_ptr)) {
     return false;
   }
 
-  void (*append)(uint8_t);
+  void (*append)(uint8_t) = NULL;
   bool (*pb_callback)(pb_ostream_t *, const uint8_t *, size_t);
 
   if (type == 'n') {

--- a/legacy/firmware/nem2.c
+++ b/legacy/firmware/nem2.c
@@ -224,7 +224,7 @@ bool nem_askTransfer(const NEMTransactionCommon *common,
       }
     }
 
-    bignum256 multiplier;
+    bignum256 multiplier = {0};
     bn_read_uint64(transfer->amount, &multiplier);
 
     if (unknownMosaic) {
@@ -399,7 +399,7 @@ bool nem_askMosaicCreation(const NEMTransactionCommon *common,
     return false;
   }
 
-  char str_out[32];
+  char str_out[32] = {0};
 
   bn_format_uint64(mosaic_creation->definition.supply, NULL, NULL,
                    mosaic_creation->definition.divisibility,
@@ -478,7 +478,7 @@ bool nem_askSupplyChange(const NEMTransactionCommon *common,
     return false;
   }
 
-  char str_out[32];
+  char str_out[32] = {0};
   bn_format_uint64(supply_change->delta, NULL, NULL, 0, 0, false, str_out,
                    sizeof(str_out));
 
@@ -523,7 +523,7 @@ bool nem_askAggregateModification(
     }
   }
 
-  char address[NEM_ADDRESS_SIZE + 1];
+  char address[NEM_ADDRESS_SIZE + 1] = {0};
 
   for (size_t i = 0; i < aggregate_modification->modifications_count; i++) {
     const NEMCosignatoryModification *modification =
@@ -543,7 +543,7 @@ bool nem_askAggregateModification(
 
   int32_t relative_change = aggregate_modification->relative_change;
   if (relative_change) {
-    char str_out[32];
+    char str_out[32] = {0};
     bn_format_uint64(relative_change < 0 ? -relative_change : relative_change,
                      NULL, NULL, 0, 0, false, str_out, sizeof(str_out));
 
@@ -685,7 +685,7 @@ static inline size_t format_amount(const NEMMosaicDefinition *definition,
                                    const bignum256 *amnt,
                                    const bignum256 *multiplier, int divisor,
                                    char *str_out, size_t size) {
-  bignum256 val;
+  bignum256 val = {0};
   memcpy(&val, amnt, sizeof(bignum256));
 
   if (multiplier) {
@@ -746,7 +746,7 @@ void nem_canonicalizeMosaics(NEMTransfer *transfer) {
       NEMMosaic *b = &mosaics[j];
 
       if (nem_mosaicCompare(a, b) > 0) {
-        NEMMosaic temp;
+        NEMMosaic temp = {0};
         memcpy(&temp, a, sizeof(NEMMosaic));
         memcpy(a, b, sizeof(NEMMosaic));
         memcpy(b, &temp, sizeof(NEMMosaic));
@@ -758,7 +758,7 @@ void nem_canonicalizeMosaics(NEMTransfer *transfer) {
 void nem_mosaicFormatAmount(const NEMMosaicDefinition *definition,
                             uint64_t quantity, const bignum256 *multiplier,
                             char *str_out, size_t size) {
-  bignum256 amnt;
+  bignum256 amnt = {0};
   bn_read_uint64(quantity, &amnt);
 
   format_amount(definition, &amnt, multiplier, 0, str_out, size);
@@ -771,7 +771,7 @@ bool nem_mosaicFormatLevy(const NEMMosaicDefinition *definition,
     return false;
   }
 
-  bignum256 amnt, fee;
+  bignum256 amnt = {0}, fee = {0};
   bn_read_uint64(quantity, &amnt);
   bn_read_uint64(definition->fee, &fee);
 

--- a/legacy/firmware/nem2.c
+++ b/legacy/firmware/nem2.c
@@ -210,6 +210,7 @@ bool nem_askTransfer(const NEMTransactionCommon *common,
     bool unknownMosaic = false;
 
     const NEMMosaicDefinition *definitions[transfer->mosaics_count];
+    memset(definitions, 0, sizeof(definitions));
 
     for (size_t i = 0; i < transfer->mosaics_count; i++) {
       const NEMMosaic *mosaic = &transfer->mosaics[i];

--- a/legacy/firmware/pb_encode.c
+++ b/legacy/firmware/pb_encode.c
@@ -73,7 +73,7 @@ static const pb_encoder_t PB_ENCODERS[PB_LTYPES_COUNT] = {
 
 static bool checkreturn buf_write(pb_ostream_t *stream, const pb_byte_t *buf, size_t count)
 {
-    size_t i;
+    size_t i = 0;
     pb_byte_t *dest = (pb_byte_t*)stream->state;
     stream->state = dest + count;
     
@@ -128,9 +128,9 @@ bool checkreturn pb_write(pb_ostream_t *stream, const pb_byte_t *buf, size_t cou
 static bool checkreturn encode_array(pb_ostream_t *stream, const pb_field_t *field,
                          const void *pData, size_t count, pb_encoder_t func)
 {
-    size_t i;
-    const void *p;
-    size_t size;
+    size_t i = 0;
+    const void *p = NULL;
+    size_t size = 0;
     
     if (count == 0)
         return true;
@@ -688,7 +688,7 @@ bool checkreturn pb_encode_submessage(pb_ostream_t *stream, const pb_field_t fie
 {
     /* First calculate the message size using a non-writing substream. */
     pb_ostream_t substream = PB_OSTREAM_SIZING;
-    size_t size;
+    size_t size = 0;
     bool status;
     
     if (!pb_encode(&substream, fields, src_struct))

--- a/legacy/firmware/pinmatrix.c
+++ b/legacy/firmware/pinmatrix.c
@@ -64,7 +64,7 @@ void pinmatrix_start(const char *text) {
 }
 
 void pinmatrix_done(char *pin) {
-  int k, i = 0;
+  int i = 0, k = 0;
   while (pin && pin[i]) {
     k = pin[i] - '1';
     if (k >= 0 && k <= 8) {

--- a/legacy/firmware/protect.c
+++ b/legacy/firmware/protect.c
@@ -39,7 +39,7 @@ bool protectAbortedByCancel = false;
 bool protectAbortedByInitialize = false;
 
 bool protectButton(ButtonRequestType type, bool confirm_only) {
-  ButtonRequest resp;
+  ButtonRequest resp = {0};
   bool result = false;
   bool acked = false;
 #if DEBUG_LINK
@@ -112,7 +112,7 @@ bool protectButton(ButtonRequestType type, bool confirm_only) {
 }
 
 const char *requestPin(PinMatrixRequestType type, const char *text) {
-  PinMatrixRequest resp;
+  PinMatrixRequest resp = {0};
   memzero(&resp, sizeof(PinMatrixRequest));
   resp.has_type = true;
   resp.type = type;
@@ -283,7 +283,7 @@ bool protectPassphrase(void) {
     return true;
   }
 
-  PassphraseRequest resp;
+  PassphraseRequest resp = {0};
   memzero(&resp, sizeof(PassphraseRequest));
   usbTiny(1);
   msg_write(MessageType_MessageType_PassphraseRequest, &resp);

--- a/legacy/firmware/recovery.c
+++ b/legacy/firmware/recovery.c
@@ -143,7 +143,7 @@ static void format_number(char *dest, int number) {
 /* Send a request for a new word/matrix code to the PC.
  */
 static void recovery_request(void) {
-  WordRequest resp;
+  WordRequest resp = {0};
   memzero(&resp, sizeof(WordRequest));
   resp.has_type = true;
   resp.type = awaiting_word == 1
@@ -323,8 +323,8 @@ static void display_choices(bool twoColumn, char choices[9][12], int num) {
  * Generates a new matrix and requests the next pin.
  */
 static void next_matrix(void) {
-  char word_choices[9][12];
-  uint32_t idx, num;
+  char word_choices[9][12] = {0};
+  uint32_t idx = 0, num = 0;
   bool last = (word_index % 4) == 3;
 
   /* Build the matrix:

--- a/legacy/firmware/reset.c
+++ b/legacy/firmware/reset.c
@@ -68,7 +68,7 @@ void reset_init(bool display_random, uint32_t _strength,
 
   if (display_random) {
     for (int start = 0; start < 2; start++) {
-      char ent_str[4][17];
+      char ent_str[4][17] = {0};
       char desc[] = "Internal entropy _/2:";
       data2hex(int_entropy + start * 16, 4, ent_str[0]);
       data2hex(int_entropy + start * 16 + 4, 4, ent_str[1]);
@@ -109,7 +109,7 @@ void reset_init(bool display_random, uint32_t _strength,
   config_setLabel(label);
   config_setU2FCounter(u2f_counter);
 
-  EntropyRequest resp;
+  EntropyRequest resp = {0};
   memzero(&resp, sizeof(EntropyRequest));
   msg_write(MessageType_MessageType_EntropyRequest, &resp);
   awaiting_entropy = true;
@@ -123,7 +123,7 @@ void reset_entropy(const uint8_t *ext_entropy, uint32_t len) {
   }
   awaiting_entropy = false;
 
-  SHA256_CTX ctx;
+  SHA256_CTX ctx = {0};
   sha256_Init(&ctx);
   sha256_Update(&ctx, int_entropy, 32);
   sha256_Update(&ctx, ext_entropy, len);

--- a/legacy/firmware/stellar.c
+++ b/legacy/firmware/stellar.c
@@ -1339,6 +1339,8 @@ size_t stellar_publicAddressAsStr(const uint8_t *bytes, char *out,
   // version + key bytes + checksum
   uint8_t keylen = 1 + 32 + 2;
   uint8_t bytes_full[keylen];
+  memset(bytes_full, 0, sizeof(bytes_full));
+
   bytes_full[0] = 6 << 3;  // 'G'
 
   memcpy(bytes_full + 1, bytes, 32);

--- a/legacy/firmware/stellar.c
+++ b/legacy/firmware/stellar.c
@@ -62,7 +62,7 @@ bool stellar_signingInit(const StellarSignTx *msg) {
 
   // Calculate sha256 for network passphrase
   // max length defined in messages.options
-  uint8_t network_hash[32];
+  uint8_t network_hash[32] = {0};
   sha256_Raw((uint8_t *)msg->network_passphrase,
              strnlen(msg->network_passphrase, 1024), network_hash);
 
@@ -171,7 +171,7 @@ bool stellar_confirmSourceAccount(bool has_source_account,
   }
 
   // Convert account string to public key bytes
-  uint8_t bytes[32];
+  uint8_t bytes[32] = {0};
   if (!stellar_getAddressBytes(str_account, bytes)) {
     return false;
   }
@@ -205,7 +205,7 @@ bool stellar_confirmCreateAccountOp(const StellarCreateAccountOp *msg) {
   stellar_hashupdate_uint32(0);
 
   // Validate new account and convert to bytes
-  uint8_t new_account_bytes[STELLAR_KEY_SIZE];
+  uint8_t new_account_bytes[STELLAR_KEY_SIZE] = {0};
   if (!stellar_getAddressBytes(msg->new_account, new_account_bytes)) {
     stellar_signingAbort(_("Invalid new account address"));
     return false;
@@ -214,8 +214,8 @@ bool stellar_confirmCreateAccountOp(const StellarCreateAccountOp *msg) {
   const char **str_addr_rows = stellar_lineBreakAddress(new_account_bytes);
 
   // Amount being funded
-  char str_amount_line[32];
-  char str_amount[32];
+  char str_amount_line[32] = {0};
+  char str_amount[32] = {0};
   stellar_format_stroops(msg->starting_balance, str_amount, sizeof(str_amount));
 
   strlcpy(str_amount_line, _("With "), sizeof(str_amount_line));
@@ -252,7 +252,7 @@ bool stellar_confirmPaymentOp(const StellarPaymentOp *msg) {
   stellar_hashupdate_uint32(1);
 
   // Validate destination account and convert to bytes
-  uint8_t destination_account_bytes[STELLAR_KEY_SIZE];
+  uint8_t destination_account_bytes[STELLAR_KEY_SIZE] = {0};
   if (!stellar_getAddressBytes(msg->destination_account,
                                destination_account_bytes)) {
     stellar_signingAbort(_("Invalid destination account"));
@@ -263,16 +263,16 @@ bool stellar_confirmPaymentOp(const StellarPaymentOp *msg) {
       stellar_lineBreakAddress(destination_account_bytes);
 
   // To: G...
-  char str_to[32];
+  char str_to[32] = {0};
   strlcpy(str_to, _("To: "), sizeof(str_to));
   strlcat(str_to, str_addr_rows[0], sizeof(str_to));
 
-  char str_asset_row[32];
+  char str_asset_row[32] = {0};
   memzero(str_asset_row, sizeof(str_asset_row));
   stellar_format_asset(&(msg->asset), str_asset_row, sizeof(str_asset_row));
 
-  char str_pay_amount[32];
-  char str_amount[32];
+  char str_pay_amount[32] = {0};
+  char str_amount[32] = {0};
   stellar_format_stroops(msg->amount, str_amount, sizeof(str_amount));
 
   strlcpy(str_pay_amount, _("Pay "), sizeof(str_pay_amount));
@@ -310,7 +310,7 @@ bool stellar_confirmPathPaymentOp(const StellarPathPaymentOp *msg) {
   stellar_hashupdate_uint32(2);
 
   // Validate destination account and convert to bytes
-  uint8_t destination_account_bytes[STELLAR_KEY_SIZE];
+  uint8_t destination_account_bytes[STELLAR_KEY_SIZE] = {0};
   if (!stellar_getAddressBytes(msg->destination_account,
                                destination_account_bytes)) {
     stellar_signingAbort(_("Invalid destination account"));
@@ -320,19 +320,19 @@ bool stellar_confirmPathPaymentOp(const StellarPathPaymentOp *msg) {
       stellar_lineBreakAddress(destination_account_bytes);
 
   // To: G...
-  char str_to[32];
+  char str_to[32] = {0};
   strlcpy(str_to, _("To: "), sizeof(str_to));
   strlcat(str_to, str_dest_rows[0], sizeof(str_to));
 
-  char str_send_asset[32];
-  char str_dest_asset[32];
+  char str_send_asset[32] = {0};
+  char str_dest_asset[32] = {0};
   stellar_format_asset(&(msg->send_asset), str_send_asset,
                        sizeof(str_send_asset));
   stellar_format_asset(&(msg->destination_asset), str_dest_asset,
                        sizeof(str_dest_asset));
 
-  char str_pay_amount[32];
-  char str_amount[32];
+  char str_pay_amount[32] = {0};
+  char str_amount[32] = {0};
   stellar_format_stroops(msg->destination_amount, str_amount,
                          sizeof(str_amount));
 
@@ -355,8 +355,8 @@ bool stellar_confirmPathPaymentOp(const StellarPathPaymentOp *msg) {
   }
 
   // Confirm what the sender is using to pay
-  char str_source_amount[32];
-  char str_source_number[32];
+  char str_source_amount[32] = {0};
+  char str_source_number[32] = {0};
   stellar_format_stroops(msg->send_max, str_source_number,
                          sizeof(str_source_number));
 
@@ -408,11 +408,11 @@ bool stellar_confirmManageOfferOp(const StellarManageOfferOp *msg) {
   stellar_hashupdate_uint32(3);
 
   // New Offer / Delete #123 / Update #123
-  char str_offer[32];
+  char str_offer[32] = {0};
   if (msg->offer_id == 0) {
     strlcpy(str_offer, _("New Offer"), sizeof(str_offer));
   } else {
-    char str_offer_id[20];
+    char str_offer_id[20] = {0};
     stellar_format_uint64(msg->offer_id, str_offer_id, sizeof(str_offer_id));
 
     if (msg->amount == 0) {
@@ -424,9 +424,9 @@ bool stellar_confirmManageOfferOp(const StellarManageOfferOp *msg) {
     strlcat(str_offer, str_offer_id, sizeof(str_offer));
   }
 
-  char str_selling[32];
-  char str_sell_amount[32];
-  char str_selling_asset[32];
+  char str_selling[32] = {0};
+  char str_sell_amount[32] = {0};
+  char str_selling_asset[32] = {0};
 
   stellar_format_asset(&(msg->selling_asset), str_selling_asset,
                        sizeof(str_selling_asset));
@@ -439,9 +439,9 @@ bool stellar_confirmManageOfferOp(const StellarManageOfferOp *msg) {
   strlcpy(str_selling, _("Sell "), sizeof(str_selling));
   strlcat(str_selling, str_sell_amount, sizeof(str_selling));
 
-  char str_buying[32];
-  char str_buying_asset[32];
-  char str_price[32];
+  char str_buying[32] = {0};
+  char str_buying_asset[32] = {0};
+  char str_price[32] = {0};
 
   stellar_format_asset(&(msg->buying_asset), str_buying_asset,
                        sizeof(str_buying_asset));
@@ -495,16 +495,16 @@ bool stellar_confirmCreatePassiveOfferOp(
   stellar_hashupdate_uint32(4);
 
   // New Offer / Delete #123 / Update #123
-  char str_offer[32];
+  char str_offer[32] = {0};
   if (msg->amount == 0) {
     strlcpy(str_offer, _("Delete Passive Offer"), sizeof(str_offer));
   } else {
     strlcpy(str_offer, _("New Passive Offer"), sizeof(str_offer));
   }
 
-  char str_selling[32];
-  char str_sell_amount[32];
-  char str_selling_asset[32];
+  char str_selling[32] = {0};
+  char str_sell_amount[32] = {0};
+  char str_selling_asset[32] = {0};
 
   stellar_format_asset(&(msg->selling_asset), str_selling_asset,
                        sizeof(str_selling_asset));
@@ -517,9 +517,9 @@ bool stellar_confirmCreatePassiveOfferOp(
   strlcpy(str_selling, _("Sell "), sizeof(str_selling));
   strlcat(str_selling, str_sell_amount, sizeof(str_selling));
 
-  char str_buying[32];
-  char str_buying_asset[32];
-  char str_price[32];
+  char str_buying[32] = {0};
+  char str_buying_asset[32] = {0};
+  char str_price[32] = {0};
 
   stellar_format_asset(&(msg->buying_asset), str_buying_asset,
                        sizeof(str_buying_asset));
@@ -570,8 +570,8 @@ bool stellar_confirmSetOptionsOp(const StellarSetOptionsOp *msg) {
   stellar_hashupdate_uint32(5);
 
   // Something like Set Inflation Destination
-  char str_title[32];
-  char rows[4][32];
+  char str_title[32] = {0};
+  char rows[4][32] = {0};
   int row_idx = 0;
   memzero(rows, sizeof(rows));
 
@@ -581,7 +581,7 @@ bool stellar_confirmSetOptionsOp(const StellarSetOptionsOp *msg) {
     strlcpy(str_title, _("Set Inflation Destination"), sizeof(str_title));
 
     // Validate account and convert to bytes
-    uint8_t inflation_destination_account_bytes[STELLAR_KEY_SIZE];
+    uint8_t inflation_destination_account_bytes[STELLAR_KEY_SIZE] = {0};
     if (!stellar_getAddressBytes(msg->inflation_destination_account,
                                  inflation_destination_account_bytes)) {
       stellar_signingAbort(_("Invalid inflation destination account"));
@@ -682,7 +682,7 @@ bool stellar_confirmSetOptionsOp(const StellarSetOptionsOp *msg) {
   row_idx = 0;
   stellar_hashupdate_bool(msg->has_master_weight);
   if (msg->has_master_weight) {
-    char str_master_weight[10 + 1];
+    char str_master_weight[10 + 1] = {0};
     show_thresholds_confirm = true;
     stellar_format_uint32(msg->master_weight, str_master_weight,
                           sizeof(str_master_weight));
@@ -696,7 +696,7 @@ bool stellar_confirmSetOptionsOp(const StellarSetOptionsOp *msg) {
 
   stellar_hashupdate_bool(msg->has_low_threshold);
   if (msg->has_low_threshold) {
-    char str_low_threshold[10 + 1];
+    char str_low_threshold[10 + 1] = {0};
     show_thresholds_confirm = true;
     stellar_format_uint32(msg->low_threshold, str_low_threshold,
                           sizeof(str_low_threshold));
@@ -709,7 +709,7 @@ bool stellar_confirmSetOptionsOp(const StellarSetOptionsOp *msg) {
   }
   stellar_hashupdate_bool(msg->has_medium_threshold);
   if (msg->has_medium_threshold) {
-    char str_med_threshold[10 + 1];
+    char str_med_threshold[10 + 1] = {0};
     show_thresholds_confirm = true;
     stellar_format_uint32(msg->medium_threshold, str_med_threshold,
                           sizeof(str_med_threshold));
@@ -722,7 +722,7 @@ bool stellar_confirmSetOptionsOp(const StellarSetOptionsOp *msg) {
   }
   stellar_hashupdate_bool(msg->has_high_threshold);
   if (msg->has_high_threshold) {
-    char str_high_threshold[10 + 1];
+    char str_high_threshold[10 + 1] = {0};
     show_thresholds_confirm = true;
     stellar_format_uint32(msg->high_threshold, str_high_threshold,
                           sizeof(str_high_threshold));
@@ -782,14 +782,14 @@ bool stellar_confirmSetOptionsOp(const StellarSetOptionsOp *msg) {
     }
 
     // Format weight as a string
-    char str_weight[16];
+    char str_weight[16] = {0};
     stellar_format_uint32(msg->signer_weight, str_weight, sizeof(str_weight));
-    char str_weight_row[32];
+    char str_weight_row[32] = {0};
     strlcpy(str_weight_row, _("Weight: "), sizeof(str_weight_row));
     strlcat(str_weight_row, str_weight, sizeof(str_weight_row));
 
     // 0 = account, 1 = pre-auth, 2 = hash(x)
-    char str_signer_type[16];
+    char str_signer_type[16] = {0};
     bool needs_hash_confirm = false;
     if (msg->signer_type == 0) {
       strlcpy(str_signer_type, _("account"), sizeof(str_signer_type));
@@ -873,7 +873,7 @@ bool stellar_confirmChangeTrustOp(const StellarChangeTrustOp *msg) {
   stellar_hashupdate_uint32(6);
 
   // Add Trust: USD
-  char str_title[32];
+  char str_title[32] = {0};
   if (msg->limit == 0) {
     strlcpy(str_title, _("DELETE Trust: "), sizeof(str_title));
   } else {
@@ -882,19 +882,19 @@ bool stellar_confirmChangeTrustOp(const StellarChangeTrustOp *msg) {
   strlcat(str_title, msg->asset.code, sizeof(str_title));
 
   // Amount: MAX (or a number)
-  char str_amount_row[32];
+  char str_amount_row[32] = {0};
   strlcpy(str_amount_row, _("Amount: "), sizeof(str_amount_row));
 
   if (msg->limit == 9223372036854775807) {
     strlcat(str_amount_row, _("[Maximum]"), sizeof(str_amount_row));
   } else {
-    char str_amount[32];
+    char str_amount[32] = {0};
     stellar_format_stroops(msg->limit, str_amount, sizeof(str_amount));
     strlcat(str_amount_row, str_amount, sizeof(str_amount_row));
   }
 
   // Validate destination account and convert to bytes
-  uint8_t asset_issuer_bytes[STELLAR_KEY_SIZE];
+  uint8_t asset_issuer_bytes[STELLAR_KEY_SIZE] = {0};
   if (!stellar_getAddressBytes(msg->asset.issuer, asset_issuer_bytes)) {
     stellar_signingAbort(_("User canceled"));
     fsm_sendFailure(FailureType_Failure_ProcessError,
@@ -935,7 +935,7 @@ bool stellar_confirmAllowTrustOp(const StellarAllowTrustOp *msg) {
   stellar_hashupdate_uint32(7);
 
   // Add Trust: USD
-  char str_title[32];
+  char str_title[32] = {0};
   if (msg->is_authorized) {
     strlcpy(str_title, _("Allow Trust of"), sizeof(str_title));
   } else {
@@ -943,11 +943,11 @@ bool stellar_confirmAllowTrustOp(const StellarAllowTrustOp *msg) {
   }
 
   // Asset code
-  char str_asset_row[32];
+  char str_asset_row[32] = {0};
   strlcpy(str_asset_row, msg->asset_code, sizeof(str_asset_row));
 
   // Validate account and convert to bytes
-  uint8_t trusted_account_bytes[STELLAR_KEY_SIZE];
+  uint8_t trusted_account_bytes[STELLAR_KEY_SIZE] = {0};
   if (!stellar_getAddressBytes(msg->trusted_account, trusted_account_bytes)) {
     stellar_signingAbort(_("Invalid trusted account"));
     return false;
@@ -957,7 +957,7 @@ bool stellar_confirmAllowTrustOp(const StellarAllowTrustOp *msg) {
       stellar_lineBreakAddress(trusted_account_bytes);
 
   // By: G...
-  char str_by[32];
+  char str_by[32] = {0};
   strlcpy(str_by, _("By: "), sizeof(str_by));
   strlcat(str_by, str_trustor_rows[0], sizeof(str_by));
 
@@ -974,13 +974,13 @@ bool stellar_confirmAllowTrustOp(const StellarAllowTrustOp *msg) {
   stellar_hashupdate_uint32(msg->asset_type);
   // asset code
   if (msg->asset_type == 1) {
-    char code4[4 + 1];
+    char code4[4 + 1] = {0};
     memzero(code4, sizeof(code4));
     strlcpy(code4, msg->asset_code, sizeof(code4));
     stellar_hashupdate_bytes((uint8_t *)code4, 4);
   }
   if (msg->asset_type == 2) {
-    char code12[12 + 1];
+    char code12[12 + 1] = {0};
     memzero(code12, sizeof(code12));
     strlcpy(code12, msg->asset_code, sizeof(code12));
     stellar_hashupdate_bytes((uint8_t *)code12, 12);
@@ -1006,7 +1006,7 @@ bool stellar_confirmAccountMergeOp(const StellarAccountMergeOp *msg) {
   stellar_hashupdate_uint32(8);
 
   // Validate account and convert to bytes
-  uint8_t destination_account_bytes[STELLAR_KEY_SIZE];
+  uint8_t destination_account_bytes[STELLAR_KEY_SIZE] = {0};
   if (!stellar_getAddressBytes(msg->destination_account,
                                destination_account_bytes)) {
     stellar_signingAbort(_("Invalid destination account"));
@@ -1045,7 +1045,7 @@ bool stellar_confirmManageDataOp(const StellarManageDataOp *msg) {
   // Hash: operation type
   stellar_hashupdate_uint32(10);
 
-  char str_title[32];
+  char str_title[32] = {0};
   if (msg->has_value) {
     strlcpy(str_title, _("Set data value key:"), sizeof(str_title));
   } else {
@@ -1068,7 +1068,7 @@ bool stellar_confirmManageDataOp(const StellarManageDataOp *msg) {
   if (msg->has_value) {
     strlcpy(str_title, _("Confirm sha256 of value:"), sizeof(str_title));
 
-    char str_hash_digest[SHA256_DIGEST_STRING_LENGTH];
+    char str_hash_digest[SHA256_DIGEST_STRING_LENGTH] = {0};
     sha256_Data(msg->value.bytes, msg->value.size, str_hash_digest);
     const char **str_hash_lines = split_message(
         (const uint8_t *)str_hash_digest, sizeof(str_hash_digest), 16);
@@ -1110,7 +1110,7 @@ bool stellar_confirmBumpSequenceOp(const StellarBumpSequenceOp *msg) {
   // Hash: operation type
   stellar_hashupdate_uint32(11);
 
-  char str_bump_to[20];
+  char str_bump_to[20] = {0};
   stellar_format_uint64(msg->bump_to, str_bump_to, sizeof(str_bump_to));
 
   stellar_layoutTransactionDialog(_("Bump Sequence"), _("Set sequence to:"),
@@ -1154,7 +1154,7 @@ void stellar_fillSignedTx(StellarSignedTx *resp) {
 
   // Add the signature (note that this does not include the 4-byte hint since it
   // can be calculated from the public key)
-  uint8_t signature[64];
+  uint8_t signature[64] = {0};
   // Note: this calls sha256_Final on the hash context
   stellar_getSignatureForActiveTx(signature);
   memcpy(resp->signature.bytes, signature, sizeof(signature));
@@ -1181,10 +1181,10 @@ void stellar_getSignatureForActiveTx(uint8_t *out_signature) {
 
   // Signature is the ed25519 detached signature of the sha256 of all the bytes
   // that have been read so far
-  uint8_t to_sign[32];
+  uint8_t to_sign[32] = {0};
   sha256_Final(&(stellar_activeTx.sha256_ctx), to_sign);
 
-  uint8_t signature[64];
+  uint8_t signature[64] = {0};
   ed25519_sign(to_sign, sizeof(to_sign), node->private_key,
                node->public_key + 1, signature);
 
@@ -1248,7 +1248,7 @@ void stellar_format_price(uint32_t numerator, uint32_t denominator, char *out,
  * Returns a uint32 formatted as a string
  */
 void stellar_format_uint32(uint32_t number, char *out, size_t outlen) {
-  bignum256 bn_number;
+  bignum256 bn_number = {0};
   bn_read_uint32(number, &bn_number);
   bn_format(&bn_number, NULL, NULL, 0, 0, false, out, outlen);
 }
@@ -1265,7 +1265,7 @@ void stellar_format_uint64(uint64_t number, char *out, size_t outlen) {
  * This is to allow a small label to be prepended to the first line
  */
 const char **stellar_lineBreakAddress(const uint8_t *addrbytes) {
-  char str_fulladdr[56 + 1];
+  char str_fulladdr[56 + 1] = {0};
   static char rows[3][20 + 1];
 
   memzero(rows, sizeof(rows));
@@ -1292,9 +1292,9 @@ const char **stellar_lineBreakAddress(const uint8_t *addrbytes) {
  */
 void stellar_format_asset(const StellarAssetType *asset, char *str_formatted,
                           size_t len) {
-  char str_asset_code[12 + 1];
+  char str_asset_code[12 + 1] = {0};
   // truncated asset issuer, final length depends on length of asset code
-  char str_asset_issuer_trunc[13 + 1];
+  char str_asset_issuer_trunc[13 + 1] = {0};
 
   memzero(str_formatted, len);
   memzero(str_asset_code, sizeof(str_asset_code));
@@ -1367,7 +1367,7 @@ size_t stellar_publicAddressAsStr(const uint8_t *bytes, char *out,
  */
 bool stellar_validateAddress(const char *str_address) {
   bool valid = false;
-  uint8_t decoded[STELLAR_ADDRESS_SIZE_RAW];
+  uint8_t decoded[STELLAR_ADDRESS_SIZE_RAW] = {0};
   memzero(decoded, sizeof(decoded));
 
   if (strlen(str_address) != STELLAR_ADDRESS_SIZE) {
@@ -1400,7 +1400,7 @@ bool stellar_validateAddress(const char *str_address) {
  * Converts a string address (G...) to the 32-byte raw address
  */
 bool stellar_getAddressBytes(const char *str_address, uint8_t *out_bytes) {
-  uint8_t decoded[STELLAR_ADDRESS_SIZE_RAW];
+  uint8_t decoded[STELLAR_ADDRESS_SIZE_RAW] = {0};
   memzero(decoded, sizeof(decoded));
 
   // Ensure address is valid
@@ -1426,11 +1426,11 @@ uint16_t stellar_crc16(uint8_t *bytes, uint32_t length) {
   // Calculate checksum for existing bytes
   uint16_t crc = 0x0000;
   uint16_t polynomial = 0x1021;
-  uint32_t i;
-  uint8_t bit;
-  uint8_t byte;
-  uint8_t bitidx;
-  uint8_t c15;
+  uint32_t i = 0;
+  uint8_t bit = 0;
+  uint8_t byte = 0;
+  uint8_t bitidx = 0;
+  uint8_t c15 = 0;
 
   for (i = 0; i < length; i++) {
     byte = bytes[i];
@@ -1478,7 +1478,7 @@ void stellar_hashupdate_uint32(uint32_t value) {
 #endif
 
   // Byte values must be hashed as big endian
-  uint8_t data[4];
+  uint8_t data[4] = {0};
   data[3] = (value >> 24) & 0xFF;
   data[2] = (value >> 16) & 0xFF;
   data[1] = (value >> 8) & 0xFF;
@@ -1494,7 +1494,7 @@ void stellar_hashupdate_uint64(uint64_t value) {
 #endif
 
   // Byte values must be hashed as big endian
-  uint8_t data[8];
+  uint8_t data[8] = {0};
   data[7] = (value >> 56) & 0xFF;
   data[6] = (value >> 48) & 0xFF;
   data[5] = (value >> 40) & 0xFF;
@@ -1550,7 +1550,7 @@ void stellar_hashupdate_asset(const StellarAssetType *asset) {
   stellar_hashupdate_uint32(asset->type);
 
   // For non-native assets, validate issuer account and convert to bytes
-  uint8_t issuer_bytes[STELLAR_KEY_SIZE];
+  uint8_t issuer_bytes[STELLAR_KEY_SIZE] = {0};
   if (asset->type != 0 &&
       !stellar_getAddressBytes(asset->issuer, issuer_bytes)) {
     stellar_signingAbort(_("Invalid asset issuer"));
@@ -1559,7 +1559,7 @@ void stellar_hashupdate_asset(const StellarAssetType *asset) {
 
   // 4-character asset code
   if (asset->type == 1) {
-    char code4[4 + 1];
+    char code4[4 + 1] = {0};
     memzero(code4, sizeof(code4));
     strlcpy(code4, asset->code, sizeof(code4));
 
@@ -1569,7 +1569,7 @@ void stellar_hashupdate_asset(const StellarAssetType *asset) {
 
   // 12-character asset code
   if (asset->type == 2) {
-    char code12[12 + 1];
+    char code12[12 + 1] = {0};
     memzero(code12, sizeof(code12));
     strlcpy(code12, asset->code, sizeof(code12));
 
@@ -1586,11 +1586,11 @@ void stellar_hashupdate_bytes(const uint8_t *data, size_t len) {
  * Displays a summary of the overall transaction
  */
 void stellar_layoutTransactionSummary(const StellarSignTx *msg) {
-  char str_lines[5][32];
+  char str_lines[5][32] = {0};
   memzero(str_lines, sizeof(str_lines));
 
-  char str_fee[12];
-  char str_num_ops[12];
+  char str_fee[12] = {0};
+  char str_num_ops[12] = {0};
 
   // Will be set to true for some large hashes that don't fit on one screen
   uint8_t needs_memo_hash_confirm = 0;
@@ -1680,8 +1680,8 @@ void stellar_layoutTransactionSummary(const StellarSignTx *msg) {
   // Timebound: lower
   if (msg->timebounds_start || msg->timebounds_end) {
     time_t timebound;
-    char str_timebound[32];
-    const struct tm *tm;
+    char str_timebound[32] = {0};
+    const struct tm *tm = NULL;
 
     timebound = (time_t)msg->timebounds_start;
     strlcpy(str_lines[0], _("Valid from:"), sizeof(str_lines[0]));
@@ -1749,7 +1749,7 @@ void stellar_layoutSigningDialog(const char *line1, const char *line2,
   oledClear();
 
   // Load up public address
-  char str_pubaddr[56 + 1];
+  char str_pubaddr[56 + 1] = {0};
   memzero(str_pubaddr, sizeof(str_pubaddr));
   stellar_publicAddressAsStr(node->public_key + 1, str_pubaddr,
                              sizeof(str_pubaddr));
@@ -1757,7 +1757,7 @@ void stellar_layoutSigningDialog(const char *line1, const char *line2,
 
   // Header
   // Ends up as: Signing with GABCDEFGHIJKL
-  char str_header[32];
+  char str_header[32] = {0};
   memzero(str_header, sizeof(str_header));
   strlcpy(str_header, _("Signing with "), sizeof(str_header));
   strlcat(str_header, str_pubaddr_truncated, sizeof(str_header));
@@ -1805,7 +1805,7 @@ void stellar_layoutSigningDialog(const char *line1, const char *line2,
   }
 
   // Next / sign button
-  char str_next_label[8];
+  char str_next_label[8] = {0};
   if (is_final_step) {
     strlcpy(str_next_label, _("SIGN"), sizeof(str_next_label));
   } else {
@@ -1831,7 +1831,7 @@ void stellar_layoutSigningDialog(const char *line1, const char *line2,
 void stellar_layoutTransactionDialog(const char *line1, const char *line2,
                                      const char *line3, const char *line4,
                                      const char *line5) {
-  char str_warning[16];
+  char str_warning[16] = {0};
   memzero(str_warning, sizeof(str_warning));
 
   if (stellar_activeTx.network_type == 2) {

--- a/legacy/firmware/transaction.c
+++ b/legacy/firmware/transaction.c
@@ -105,9 +105,9 @@ bool compute_address(const CoinInfo *coin, InputScriptType script_type,
                      const HDNode *node, bool has_multisig,
                      const MultisigRedeemScriptType *multisig,
                      char address[MAX_ADDR_SIZE]) {
-  uint8_t raw[MAX_ADDR_RAW_SIZE];
-  uint8_t digest[32];
-  size_t prelen;
+  uint8_t raw[MAX_ADDR_RAW_SIZE] = {0};
+  uint8_t digest[32] = {0};
+  size_t prelen = 0;
 
   if (has_multisig) {
     if (cryptoMultisigPubkeyIndex(coin, multisig, node->public_key) < 0) {
@@ -200,8 +200,8 @@ int compile_output(const CoinInfo *coin, const HDNode *root, TxOutputType *in,
   memzero(out, sizeof(TxOutputBinType));
   out->amount = in->amount;
   out->decred_script_version = in->decred_script_version;
-  uint8_t addr_raw[MAX_ADDR_RAW_SIZE];
-  size_t addr_raw_len;
+  uint8_t addr_raw[MAX_ADDR_RAW_SIZE] = {0};
+  size_t addr_raw_len = 0;
 
   if (in->script_type == OutputScriptType_PAYTOOPRETURN) {
     // only 0 satoshi allowed for OP_RETURN
@@ -235,7 +235,7 @@ int compile_output(const CoinInfo *coin, const HDNode *root, TxOutputType *in,
 
   if (in->address_n_count > 0) {
     static CONFIDENTIAL HDNode node;
-    InputScriptType input_script_type;
+    InputScriptType input_script_type = 0;
 
     switch (in->script_type) {
       case OutputScriptType_PAYTOADDRESS:
@@ -269,7 +269,7 @@ int compile_output(const CoinInfo *coin, const HDNode *root, TxOutputType *in,
 
   addr_raw_len = base58_decode_check(in->address, coin->curve->hasher_base58,
                                      addr_raw, MAX_ADDR_RAW_SIZE);
-  size_t prefix_len;
+  size_t prefix_len = 0;
   if (coin->has_address_type  // p2pkh
       && addr_raw_len ==
              20 + (prefix_len = address_prefix_bytes_len(coin->address_type)) &&
@@ -313,7 +313,7 @@ int compile_output(const CoinInfo *coin, const HDNode *root, TxOutputType *in,
       return 0;
     }
   } else if (coin->bech32_prefix) {
-    int witver;
+    int witver = 0;
     if (!segwit_addr_decode(&witver, addr_raw, &addr_raw_len,
                             coin->bech32_prefix, in->address)) {
       return 0;
@@ -394,10 +394,10 @@ uint32_t compile_script_multisig_hash(const CoinInfo *coin,
   if (m < 1 || m > 15) return 0;
   if (n < 1 || n > 15) return 0;
 
-  Hasher hasher;
+  Hasher hasher = {0};
   hasher_Init(&hasher, coin->curve->hasher_script);
 
-  uint8_t d[2];
+  uint8_t d[2] = {0};
   d[0] = 0x50 + m;
   hasher_Update(&hasher, d, 1);
   for (uint32_t i = 0; i < n; i++) {
@@ -800,7 +800,7 @@ void tx_hash_final(TxStruct *t, uint8_t *hash, bool reverse) {
 }
 
 static uint32_t tx_input_script_size(const TxInputType *txinput) {
-  uint32_t input_script_size;
+  uint32_t input_script_size = 0;
   if (txinput->has_multisig) {
     uint32_t multisig_script_size =
         TXSIZE_MULTISIGSCRIPT +
@@ -860,9 +860,9 @@ uint32_t tx_output_weight(const CoinInfo *coin, const TxOutputType *txoutput) {
           txoutput->has_multisig ? TXSIZE_P2SCRIPT : TXSIZE_P2PKHASH;
     }
   } else {
-    uint8_t addr_raw[MAX_ADDR_RAW_SIZE];
-    int witver;
-    size_t addr_raw_len;
+    uint8_t addr_raw[MAX_ADDR_RAW_SIZE] = {0};
+    int witver = 0;
+    size_t addr_raw_len = 0;
     if (coin->cashaddr_prefix &&
         cash_addr_decode(addr_raw, &addr_raw_len, coin->cashaddr_prefix,
                          txoutput->address)) {

--- a/legacy/firmware/trezor.c
+++ b/legacy/firmware/trezor.c
@@ -39,7 +39,7 @@
 #endif
 
 /* Screen timeout */
-uint32_t system_millis_lock_start;
+uint32_t system_millis_lock_start = 0;
 
 void check_lock_screen(void) {
   buttonUpdate();
@@ -100,7 +100,7 @@ static void collect_hw_entropy(bool privileged) {
     desig_get_unique_id((uint32_t *)HW_ENTROPY_DATA);
     // set entropy in the OTP randomness block
     if (!flash_otp_is_locked(FLASH_OTP_BLOCK_RANDOMNESS)) {
-      uint8_t entropy[FLASH_OTP_BLOCK_SIZE];
+      uint8_t entropy[FLASH_OTP_BLOCK_SIZE] = {0};
       random_buffer(entropy, FLASH_OTP_BLOCK_SIZE);
       flash_otp_write(FLASH_OTP_BLOCK_RANDOMNESS, 0, entropy,
                       FLASH_OTP_BLOCK_SIZE);

--- a/legacy/firmware/u2f.c
+++ b/legacy/firmware/u2f.c
@@ -174,7 +174,7 @@ void u2fhid_init_cmd(const U2FHID_FRAME *f) {
 }
 
 void u2fhid_read_start(const U2FHID_FRAME *f) {
-  U2F_ReadBuffer readbuffer;
+  U2F_ReadBuffer readbuffer = {0};
   memzero(&readbuffer, sizeof(readbuffer));
 
   if (!(f->type & TYPE_INIT)) {
@@ -273,7 +273,7 @@ void u2fhid_wink(const uint8_t *buf, uint32_t len) {
 
   if (dialog_timeout > 0) dialog_timeout = U2F_TIMEOUT;
 
-  U2FHID_FRAME f;
+  U2FHID_FRAME f = {0};
   memzero(&f, sizeof(f));
   f.cid = cid;
   f.init.cmd = U2FHID_WINK;
@@ -283,8 +283,8 @@ void u2fhid_wink(const uint8_t *buf, uint32_t len) {
 
 void u2fhid_init(const U2FHID_FRAME *in) {
   const U2FHID_INIT_REQ *init_req = (const U2FHID_INIT_REQ *)&in->init.data;
-  U2FHID_FRAME f;
-  U2FHID_INIT_RESP resp;
+  U2FHID_FRAME f = {0};
+  U2FHID_INIT_RESP resp = {0};
   memzero(&resp, sizeof(resp));
 
   debugLog(0, "", "u2fhid_init");
@@ -367,10 +367,10 @@ void send_u2fhid_msg(const uint8_t cmd, const uint8_t *data,
     return;
   }
 
-  U2FHID_FRAME f;
+  U2FHID_FRAME f = {0};
   uint8_t *p = (uint8_t *)data;
   uint32_t l = len;
-  uint32_t psz;
+  uint32_t psz = 0;
   uint8_t seq = 0;
 
   // debugLog(0, "", "send_u2fhid_msg");
@@ -405,7 +405,7 @@ void send_u2fhid_msg(const uint8_t cmd, const uint8_t *data,
 }
 
 void send_u2fhid_error(uint32_t fcid, uint8_t err) {
-  U2FHID_FRAME f;
+  U2FHID_FRAME f = {0};
 
   memzero(&f, sizeof(f));
   f.cid = fcid;
@@ -470,10 +470,10 @@ static const HDNode *getDerivedNode(uint32_t *address_n,
 
 static const HDNode *generateKeyHandle(const uint8_t app_id[],
                                        uint8_t key_handle[]) {
-  uint8_t keybase[U2F_APPID_SIZE + KEY_PATH_LEN];
+  uint8_t keybase[U2F_APPID_SIZE + KEY_PATH_LEN] = {0};
 
   // Derivation path is m/U2F'/r'/r'/r'/r'/r'/r'/r'/r'
-  uint32_t key_path[KEY_PATH_ENTRIES];
+  uint32_t key_path[KEY_PATH_ENTRIES] = {0};
   for (uint32_t i = 0; i < KEY_PATH_ENTRIES; i++) {
     // high bit for hardened keys
     key_path[i] = 0x80000000 | random32();
@@ -499,7 +499,7 @@ static const HDNode *generateKeyHandle(const uint8_t app_id[],
 
 static const HDNode *validateKeyHandle(const uint8_t app_id[],
                                        const uint8_t key_handle[]) {
-  uint32_t key_path[KEY_PATH_ENTRIES];
+  uint32_t key_path[KEY_PATH_ENTRIES] = {0};
   memcpy(key_path, key_handle, KEY_PATH_LEN);
   for (unsigned int i = 0; i < KEY_PATH_ENTRIES; i++) {
     // check high bit for hardened keys
@@ -511,11 +511,11 @@ static const HDNode *validateKeyHandle(const uint8_t app_id[],
   const HDNode *node = getDerivedNode(key_path, KEY_PATH_ENTRIES);
   if (!node) return NULL;
 
-  uint8_t keybase[U2F_APPID_SIZE + KEY_PATH_LEN];
+  uint8_t keybase[U2F_APPID_SIZE + KEY_PATH_LEN] = {0};
   memcpy(&keybase[0], app_id, U2F_APPID_SIZE);
   memcpy(&keybase[U2F_APPID_SIZE], key_handle, KEY_PATH_LEN);
 
-  uint8_t hmac[SHA256_DIGEST_LENGTH];
+  uint8_t hmac[SHA256_DIGEST_LENGTH] = {0};
   hmac_sha256(node->private_key, sizeof(node->private_key), keybase,
               sizeof(keybase), hmac);
 
@@ -558,7 +558,7 @@ void u2f_register(const APDU *a) {
                    _("Another U2F device"), _("was used to register"),
                    _("in this application."), NULL, NULL, NULL);
     } else {
-      const char *appname;
+      const char *appname = NULL;
       getReadableAppId(req->appId, &appname);
       layoutU2FDialog(_("Register"), appname);
     }
@@ -575,7 +575,7 @@ void u2f_register(const APDU *a) {
 
   // Buttons said yes
   if (last_req_state == REG_PASS) {
-    uint8_t data[sizeof(U2F_REGISTER_RESP) + 2];
+    uint8_t data[sizeof(U2F_REGISTER_RESP) + 2] = {0};
     U2F_REGISTER_RESP *resp = (U2F_REGISTER_RESP *)&data;
     memzero(data, sizeof(data));
 
@@ -597,8 +597,8 @@ void u2f_register(const APDU *a) {
     memcpy(resp->keyHandleCertSig + resp->keyHandleLen, U2F_ATT_CERT,
            sizeof(U2F_ATT_CERT));
 
-    uint8_t sig[64];
-    U2F_REGISTER_SIG_STR sig_base;
+    uint8_t sig[64] = {0};
+    U2F_REGISTER_SIG_STR sig_base = {0};
     sig_base.reserved = 0;
     memcpy(sig_base.appId, req->appId, U2F_APPID_SIZE);
     memcpy(sig_base.chal, req->chal, U2F_CHAL_SIZE);
@@ -690,7 +690,7 @@ void u2f_authenticate(const APDU *a) {
   if (last_req_state == INIT) {
     // error: testof-user-presence is required
     buttonUpdate();  // Clear button state
-    const char *appname;
+    const char *appname = NULL;
     getReadableAppId(req->appId, &appname);
     layoutU2FDialog(_("Authenticate"), appname);
     last_req_state = AUTH;
@@ -706,7 +706,7 @@ void u2f_authenticate(const APDU *a) {
 
   // Buttons said yes
   if (last_req_state == AUTH_PASS) {
-    uint8_t buf[sizeof(U2F_AUTHENTICATE_RESP) + 2];
+    uint8_t buf[(sizeof(U2F_AUTHENTICATE_RESP)) + 2] = {0};
     U2F_AUTHENTICATE_RESP *resp = (U2F_AUTHENTICATE_RESP *)&buf;
 
     const uint32_t ctr = config_nextU2FCounter();
@@ -717,8 +717,8 @@ void u2f_authenticate(const APDU *a) {
     resp->ctr[3] = ctr & 0xff;
 
     // Build and sign response
-    U2F_AUTHENTICATE_SIG_STR sig_base;
-    uint8_t sig[64];
+    U2F_AUTHENTICATE_SIG_STR sig_base = {0};
+    uint8_t sig[64] = {0};
     memcpy(sig_base.appId, req->appId, U2F_APPID_SIZE);
     sig_base.flags = resp->flags;
     memcpy(sig_base.ctr, resp->ctr, 4);
@@ -744,7 +744,7 @@ void u2f_authenticate(const APDU *a) {
 }
 
 void send_u2f_error(const uint16_t err) {
-  uint8_t data[2];
+  uint8_t data[2] = {0};
   data[0] = err >> 8 & 0xFF;
   data[1] = err & 0xFF;
   send_u2f_msg(data, 2);

--- a/legacy/gen/strwidth.c
+++ b/legacy/gen/strwidth.c
@@ -16,7 +16,7 @@ static inline char convert(char c) {
 }
 
 int main(int argc, char **argv) {
-  char *line;
+  char *line = NULL;
   int font = FONT_STANDARD;
   while ((line = readline(NULL)) != NULL) {
     size_t length = strlen(line);

--- a/legacy/usb21_standard.c
+++ b/legacy/usb21_standard.c
@@ -25,8 +25,8 @@
 static uint16_t build_bos_descriptor(const struct usb_bos_descriptor *bos,
                                      uint8_t *buf, uint16_t len) {
   uint8_t *tmpbuf = buf;
-  uint16_t count, total = 0, totallen = 0;
-  uint16_t i;
+  uint16_t count = 0, total = 0, totallen = 0;
+  uint16_t i = 0;
 
   memcpy(buf, bos, count = MIN(len, bos->bLength));
   buf += count;

--- a/legacy/usb_standard.c
+++ b/legacy/usb_standard.c
@@ -45,7 +45,7 @@ LGPL License Terms @ref lgpl_license
 int usbd_register_set_config_callback(usbd_device *usbd_dev,
 				       usbd_set_config_callback callback)
 {
-	int i;
+	int i = 0;
 
 	for (i = 0; i < MAX_USER_SET_CONFIG_CALLBACK; i++) {
 		if (usbd_dev->user_callback_set_config[i]) {
@@ -73,8 +73,8 @@ static uint16_t build_config_descriptor(usbd_device *usbd_dev,
 {
 	uint8_t *tmpbuf = buf;
 	const struct usb_config_descriptor *cfg = &usbd_dev->config[index];
-	uint16_t count, total = 0, totallen = 0;
-	uint16_t i, j, k;
+	uint16_t count = 0, total = 0, totallen = 0;
+	uint16_t i = 0, j = 0, k = 0;
 
 	memcpy(buf, cfg, count = MIN(len, cfg->bLength));
 	buf += count;
@@ -160,8 +160,8 @@ usb_standard_get_descriptor(usbd_device *usbd_dev,
 
 	wait_random();
 
-	int i, array_idx, descr_idx;
-	struct usb_string_descriptor *sd;
+	int i = 0, array_idx = 0, descr_idx = 0;
+	struct usb_string_descriptor *sd = NULL;
 
 	descr_idx = usb_descriptor_index(req->wValue);
 
@@ -259,9 +259,9 @@ usb_standard_set_configuration(usbd_device *usbd_dev,
 			       struct usb_setup_data *req,
 			       uint8_t **buf, uint16_t *len)
 {
-	unsigned i;
+	unsigned i = 0;
 	int found_index = -1;
-	const struct usb_config_descriptor *cfg;
+	const struct usb_config_descriptor *cfg = NULL;
 
 	(void)req;
 	(void)buf;
@@ -344,7 +344,7 @@ usb_standard_set_interface(usbd_device *usbd_dev,
 {
 	const struct usb_config_descriptor *cfx =
 		&usbd_dev->config[usbd_dev->current_config - 1];
-	const struct usb_interface *iface;
+	const struct usb_interface *iface = NULL;
 
 	(void)buf;
 
@@ -380,7 +380,7 @@ usb_standard_get_interface(usbd_device *usbd_dev,
 			   struct usb_setup_data *req,
 			   uint8_t **buf, uint16_t *len)
 {
-	uint8_t *cur_altsetting;
+	uint8_t *cur_altsetting = NULL;
 	const struct usb_config_descriptor *cfx =
 		&usbd_dev->config[usbd_dev->current_config - 1];
 


### PR DESCRIPTION
Solves https://github.com/trezor/trezor-firmware/issues/571.

I explicitly initialised automatic variables in `crypto`, `legacy` and `storage`. Variable length arrays (such as `char array[i];`) are initialised with `memset`. I didn't initialise static variables and variables in `crypto/tools`, `crypto/tests`, `storage/tests`. Trezor T emulator binary increased in size by 8 kB.