### PR TITLE
Skip sd protect test on device

### DIFF
--- a/common/protob/messages-management.proto
+++ b/common/protob/messages-management.proto
@@ -87,6 +87,8 @@ message Features {
         Capability_ShamirGroups = 16;
     }
     optional BackupType backup_type = 31;       // type of device backup (BIP-39 / SLIP-39 basic / SLIP-39 advanced)
+    optional bool sd_card_present = 32;         // is SD card present
+    optional bool sd_protection = 33;           // is SD Protect enabled
 }
 
 /**

--- a/core/src/apps/homescreen/__init__.py
+++ b/core/src/apps/homescreen/__init__.py
@@ -1,4 +1,4 @@
-from trezor import config, utils, wire
+from trezor import config, io, utils, wire
 from trezor.messages import Capability, MessageType
 from trezor.messages.Features import Features
 from trezor.messages.Success import Success
@@ -63,6 +63,8 @@ def get_features() -> Features:
             Capability.Shamir,
             Capability.ShamirGroups,
         ]
+    f.sd_card_present = io.SDCard().present()
+    f.sd_protection = storage.device.get_sd_salt_auth_key() is not None
     return f
 
 

--- a/core/src/trezor/messages/Features.py
+++ b/core/src/trezor/messages/Features.py
@@ -49,6 +49,8 @@ class Features(p.MessageType):
         recovery_mode: bool = None,
         capabilities: List[EnumTypeCapability] = None,
         backup_type: EnumTypeBackupType = None,
+        sd_card_present: bool = None,
+        sd_protection: bool = None,
     ) -> None:
         self.vendor = vendor
         self.major_version = major_version
@@ -80,6 +82,8 @@ class Features(p.MessageType):
         self.recovery_mode = recovery_mode
         self.capabilities = capabilities if capabilities is not None else []
         self.backup_type = backup_type
+        self.sd_card_present = sd_card_present
+        self.sd_protection = sd_protection
 
     @classmethod
     def get_fields(cls) -> Dict:
@@ -114,4 +118,6 @@ class Features(p.MessageType):
             29: ('recovery_mode', p.BoolType, 0),
             30: ('capabilities', p.EnumType("Capability", (1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16)), p.FLAG_REPEATED),
             31: ('backup_type', p.EnumType("BackupType", (0, 1, 2)), 0),
+            32: ('sd_card_present', p.BoolType, 0),
+            33: ('sd_protection', p.BoolType, 0),
         }

--- a/python/src/trezorlib/device.py
+++ b/python/src/trezorlib/device.py
@@ -93,6 +93,7 @@ def change_pin(client, remove=False):
 @expect(proto.Success, field="message")
 def sd_protect(client, operation):
     ret = client.call(proto.SdProtect(operation=operation))
+    client.init_device()
     return ret
 
 

--- a/python/src/trezorlib/messages/Features.py
+++ b/python/src/trezorlib/messages/Features.py
@@ -49,6 +49,8 @@ class Features(p.MessageType):
         recovery_mode: bool = None,
         capabilities: List[EnumTypeCapability] = None,
         backup_type: EnumTypeBackupType = None,
+        sd_card_present: bool = None,
+        sd_protection: bool = None,
     ) -> None:
         self.vendor = vendor
         self.major_version = major_version
@@ -80,6 +82,8 @@ class Features(p.MessageType):
         self.recovery_mode = recovery_mode
         self.capabilities = capabilities if capabilities is not None else []
         self.backup_type = backup_type
+        self.sd_card_present = sd_card_present
+        self.sd_protection = sd_protection
 
     @classmethod
     def get_fields(cls) -> Dict:
@@ -114,4 +118,6 @@ class Features(p.MessageType):
             29: ('recovery_mode', p.BoolType, 0),
             30: ('capabilities', p.EnumType("Capability", (1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16)), p.FLAG_REPEATED),
             31: ('backup_type', p.EnumType("BackupType", (0, 1, 2)), 0),
+            32: ('sd_card_present', p.BoolType, 0),
+            33: ('sd_protection', p.BoolType, 0),
         }

--- a/tests/REGISTERED_MARKERS
+++ b/tests/REGISTERED_MARKERS
@@ -11,6 +11,7 @@ monero
 nem
 ontology
 ripple
+sd_card
 stellar
 tezos
 zcash

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -77,6 +77,16 @@ def client(request):
     if request.node.get_closest_marker("skip_t1") and client.features.model == "1":
         pytest.skip("Test excluded on Trezor 1")
 
+    if (
+        request.node.get_closest_marker("sd_card")
+        and not client.features.sd_card_present
+    ):
+        raise RuntimeError(
+            "This test requires SD card.\n"
+            "To skip all such tests, run:\n"
+            "  pytest -m 'not sd_card' <test path>"
+        )
+
     wipe_device(client)
 
     # fmt: off
@@ -141,7 +151,7 @@ def pytest_runtest_setup(item):
     both T1 and TT.
     """
     if item.get_closest_marker("skip_t1") and item.get_closest_marker("skip_t2"):
-        pytest.fail("Don't skip tests for both trezors!")
+        raise RuntimeError("Don't skip tests for both trezors!")
 
     skip_altcoins = int(os.environ.get("TREZOR_PYTEST_SKIP_ALTCOINS", 0))
     if item.get_closest_marker("altcoin") and skip_altcoins:

--- a/tests/device_tests/test_msg_sd_protect.py
+++ b/tests/device_tests/test_msg_sd_protect.py
@@ -23,29 +23,41 @@ from trezorlib.messages import SdProtectOperationType as Op
 pytestmark = [pytest.mark.skip_t1, pytest.mark.sd_card]
 
 
-def test_sd_protect_enable(client):
+def test_enable_disable(client):
+    assert client.features.sd_protection is False
     # Disabling SD protection should fail
     with pytest.raises(TrezorFailure):
         device.sd_protect(client, Op.DISABLE)
 
     # Enable SD protection
     device.sd_protect(client, Op.ENABLE)
+    assert client.features.sd_protection is True
 
     # Enabling SD protection should fail
     with pytest.raises(TrezorFailure):
         device.sd_protect(client, Op.ENABLE)
-
-
-def test_sd_protect_refresh(client):
-    # Enable SD protection
-    device.sd_protect(client, Op.ENABLE)
-
-    # Refresh SD protection
-    device.sd_protect(client, Op.REFRESH)
+    assert client.features.sd_protection is True
 
     # Disable SD protection
     device.sd_protect(client, Op.DISABLE)
+    assert client.features.sd_protection is False
+
+
+def test_refresh(client):
+    assert client.features.sd_protection is False
+    # Enable SD protection
+    device.sd_protect(client, Op.ENABLE)
+    assert client.features.sd_protection is True
+
+    # Refresh SD protection
+    device.sd_protect(client, Op.REFRESH)
+    assert client.features.sd_protection is True
+
+    # Disable SD protection
+    device.sd_protect(client, Op.DISABLE)
+    assert client.features.sd_protection is False
 
     # Refreshing SD protection should fail
     with pytest.raises(TrezorFailure):
         device.sd_protect(client, Op.REFRESH)
+    assert client.features.sd_protection is False


### PR DESCRIPTION
I've added a boolean to DebugLinkState to indicate if a SD card is present or not. We may add it to Features at some point if desired.

I'll run the tests over night to see if some other stall or that's it.

Updates #591 