### PR TITLE
Reorder tests 2

### DIFF
--- a/ci/test.yml
+++ b/ci/test.yml
@@ -89,6 +89,15 @@ core unix fido2 test:
     - cd core
     - pipenv run make test_emu_fido2
 
+core unix click test:
+  stage: test
+  <<: *only_changes_core
+  dependencies:
+    - core unix frozen debug build
+  script:
+    - cd core
+    - pipenv run make test_emu_click
+
 core unix upgrade test:
   stage: test
   <<: *only_changes_core
@@ -99,6 +108,14 @@ core unix upgrade test:
   script:
     - tests/download_emulators.sh
     - pipenv run pytest tests/upgrade_tests
+
+core unix persistence test:
+  stage: test
+  <<: *only_changes_core
+  dependencies:
+    - core unix frozen debug build
+  script:
+    - pipenv run pytest tests/persistence_tests
 
 core mypy test:
   stage: test

--- a/core/Makefile
+++ b/core/Makefile
@@ -76,6 +76,9 @@ test_emu_u2f: ## run selected u2f device tests from u2f-tests-hid
 test_emu_fido2: ## run fido2 device tests
 	cd tests ; ./run_tests_device_emu_fido2.sh $(TESTOPTS)
 
+test_emu_click: ## run click tests
+	cd tests ; ./run_tests_click_emu.sh $(TESTOPTS)
+
 pylint: ## run pylint on application sources and tests
 	pylint -E $(shell find src tests -name *.py)
 

--- a/core/tests/run_tests_click_emu.sh
+++ b/core/tests/run_tests_click_emu.sh
@@ -1,0 +1,38 @@
+#!/usr/bin/env bash
+
+: "${RUN_TEST_EMU:=1}"
+
+CORE_DIR="$(SHELL_SESSION_FILE='' && cd "$( dirname "${BASH_SOURCE[0]}" )/.." >/dev/null 2>&1 && pwd )"
+MICROPYTHON="${MICROPYTHON:-$CORE_DIR/build/unix/micropython}"
+TREZOR_SRC="${CORE_DIR}/src"
+
+DISABLE_FADE=1
+PYOPT="${PYOPT:-0}"
+upy_pid=""
+
+# run emulator if RUN_TEST_EMU
+if [[ $RUN_TEST_EMU > 0 ]]; then
+  source ../trezor_cmd.sh
+
+  # remove flash and sdcard files before run to prevent inconsistent states
+  mv "${TREZOR_PROFILE_DIR}/trezor.flash" "${TREZOR_PROFILE_DIR}/trezor.flash.bkp" 2>/dev/null
+  mv "${TREZOR_PROFILE_DIR}/trezor.sdcard" "${TREZOR_PROFILE_DIR}/trezor.sdcard.bkp" 2>/dev/null
+
+  cd "${TREZOR_SRC}"
+  echo "Starting emulator: $MICROPYTHON $ARGS ${MAIN}"
+
+  TREZOR_TEST=1 \
+  TREZOR_DISABLE_FADE=$DISABLE_FADE \
+    $MICROPYTHON $ARGS "${MAIN}" &> "${TREZOR_LOGFILE}" &
+  upy_pid=$!
+  cd -
+  sleep 30
+fi
+
+# run tests
+error=0
+if ! pytest ../../tests/click_tests "$@"; then
+  error=1
+fi
+kill $upy_pid
+exit $error

--- a/tests/README.md
+++ b/tests/README.md
@@ -6,9 +6,18 @@ These tests are doing a simple read/write operations on the device to see if the
 
 ## Device tests
 
-Device tests are integration tests that can be run against either emulator or on an actual device. The Debug mode is required. These tests can be run against both Model One and Model T.
+Device tests are integration tests that can be run against either emulator or on an actual device. 
+You are responsible to provide either an emulator or a device with Debug mode present.
+
+### Device tests
+
+The original version of device tests. These tests can be run against both Model One and Model T.
 
 See the [README](device_tests/README.md) for instructions how to run it.
+
+### Click tests
+
+Click tests are a next-generation of the Device tests. The tests are quite similar, but they are capable of imitating user's interaction with the screen.
 
 ## Fido tests
 
@@ -19,3 +28,7 @@ Implement U2F/FIDO2 tests.
 These tests test upgrade from one firmware version to another. They initialize an emulator on some specific version and then pass its storage to another version to see if the firmware operates as expected. They use fixtures from https://firmware.corp.sldev.cz/upgrade_tests/ which can be downloaded using the `download_emulators.sh` script.
 
 See the [README](upgrade_tests/README.md) for instructions how to run it.
+
+## Persistence tests
+
+These tests test the Persistence mode, which is currently used in the device recovery. These tests launch the emulator themselves and they are capable of restarting or stopping it simulating user's plugging in or plugging out the device.

--- a/tests/persistence_tests/test_shamir_persistence.py
+++ b/tests/persistence_tests/test_shamir_persistence.py
@@ -21,7 +21,7 @@ from trezorlib import device
 from .. import buttons
 from ..device_handler import BackgroundDeviceHandler
 from ..emulators import EmulatorWrapper
-from . import core_only
+from ..upgrade_tests import core_only
 
 
 def enter_word(debug, word):


### PR DESCRIPTION
The only dubious thing is now that `persistence_tests` include `from ..upgrade_tests import core_only`, which is not very nice. Should we move `upgrade_tests/__init__` to `tests/__init__`?