### PR TITLE
Remove persistence boot and set recovery as a default workflow

### DIFF
--- a/core/src/apps/common/mnemonic.py
+++ b/core/src/apps/common/mnemonic.py
@@ -59,7 +59,7 @@ def _start_progress() -> None:
     # Because we are drawing to the screen manually, without a layout, we
     # should make sure that no other layout is running.  At this point, only
     # the homescreen should be on, so shut it down.
-    workflow.close_default()
+    workflow.kill_default()
     ui.backlight_fade(ui.BACKLIGHT_DIM)
     ui.display.clear()
     ui.header("Please wait")

--- a/core/src/apps/homescreen/__init__.py
+++ b/core/src/apps/homescreen/__init__.py
@@ -104,10 +104,9 @@ async def handle_Ping(ctx: wire.Context, msg: Ping) -> Success:
     return Success(message=msg.message)
 
 
-def boot(features_only: bool = False) -> None:
+def boot() -> None:
     register(MessageType.Initialize, handle_Initialize)
     register(MessageType.GetFeatures, handle_GetFeatures)
-    if not features_only:
-        register(MessageType.Cancel, handle_Cancel)
-        register(MessageType.ClearSession, handle_ClearSession)
-        register(MessageType.Ping, handle_Ping)
+    register(MessageType.Cancel, handle_Cancel)
+    register(MessageType.ClearSession, handle_ClearSession)
+    register(MessageType.Ping, handle_Ping)

--- a/core/src/apps/management/recovery_device/__init__.py
+++ b/core/src/apps/management/recovery_device/__init__.py
@@ -1,4 +1,4 @@
-from trezor import config, ui, wire
+from trezor import config, ui, wire, workflow
 from trezor.messages import ButtonRequestType
 from trezor.messages.Success import Success
 from trezor.pin import pin_to_int
@@ -12,7 +12,10 @@ from apps.common.request_pin import (
     show_pin_invalid,
 )
 from apps.common.storage import device as storage_device, recovery as storage_recovery
-from apps.management.recovery_device.homescreen import recovery_process
+from apps.management.recovery_device.homescreen import (
+    recovery_homescreen,
+    recovery_process,
+)
 
 if False:
     from trezor.messages.RecoveryDevice import RecoveryDevice
@@ -55,6 +58,7 @@ async def recovery_device(ctx: wire.Context, msg: RecoveryDevice) -> Success:
     if msg.dry_run:
         storage_recovery.set_dry_run(msg.dry_run)
 
+    workflow.replace_default(recovery_homescreen)
     return await recovery_process(ctx)
 
 

--- a/core/src/apps/management/recovery_device/__init__.py
+++ b/core/src/apps/management/recovery_device/__init__.py
@@ -27,6 +27,9 @@ async def recovery_device(ctx: wire.Context, msg: RecoveryDevice) -> Success:
     """
     _check_state(msg)
 
+    if storage_recovery.is_in_progress():
+        return await recovery_process(ctx)
+
     await _continue_dialog(ctx, msg)
 
     # for dry run pin needs to be entered
@@ -52,9 +55,7 @@ async def recovery_device(ctx: wire.Context, msg: RecoveryDevice) -> Success:
     if msg.dry_run:
         storage_recovery.set_dry_run(msg.dry_run)
 
-    result = await recovery_process(ctx)
-
-    return result
+    return await recovery_process(ctx)
 
 
 def _check_state(msg: RecoveryDevice) -> None:
@@ -62,11 +63,6 @@ def _check_state(msg: RecoveryDevice) -> None:
         raise wire.UnexpectedMessage("Already initialized")
     if msg.dry_run and not storage.is_initialized():
         raise wire.NotInitialized("Device is not initialized")
-
-    if storage_recovery.is_in_progress():
-        raise RuntimeError(
-            "Function recovery_device should not be invoked when recovery is already in progress"
-        )
 
     if msg.enforce_wordlist is False:
         raise wire.ProcessError(

--- a/core/src/apps/management/recovery_device/homescreen.py
+++ b/core/src/apps/management/recovery_device/homescreen.py
@@ -1,4 +1,4 @@
-from trezor import loop, utils, wire
+from trezor import utils, wire, workflow
 from trezor.crypto import slip39
 from trezor.crypto.hashlib import sha256
 from trezor.errors import MnemonicError
@@ -14,6 +14,7 @@ from apps.common.storage import (
     recovery as storage_recovery,
     recovery_shares as storage_recovery_shares,
 )
+from apps.homescreen.homescreen import homescreen
 from apps.management import backup_types
 from apps.management.recovery_device import layout
 
@@ -25,13 +26,7 @@ if False:
 async def recovery_homescreen() -> None:
     # recovery process does not communicate on the wire
     ctx = wire.DummyContext()
-    try:
-        await recovery_process(ctx)
-    finally:
-        # clear the loop state, so loop.run will exit
-        loop.clear()
-        # clear the registered wire handlers to avoid conflicts
-        wire.clear()
+    await recovery_process(ctx)
 
 
 async def recovery_process(ctx: wire.GenericContext) -> Success:
@@ -43,6 +38,7 @@ async def recovery_process(ctx: wire.GenericContext) -> Success:
             storage_recovery.end_progress()
         else:
             storage.wipe()
+        workflow.replace_default(homescreen)
         raise wire.ActionCancelled("Cancelled")
     return result
 

--- a/core/src/apps/management/recovery_device/homescreen.py
+++ b/core/src/apps/management/recovery_device/homescreen.py
@@ -24,6 +24,10 @@ if False:
 
 
 async def recovery_homescreen() -> None:
+    if not storage.recovery.is_in_progress():
+        workflow.replace_default(homescreen)
+        return
+
     # recovery process does not communicate on the wire
     ctx = wire.DummyContext()
     await recovery_process(ctx)
@@ -31,16 +35,14 @@ async def recovery_homescreen() -> None:
 
 async def recovery_process(ctx: wire.GenericContext) -> Success:
     try:
-        result = await _continue_recovery_process(ctx)
+        return await _continue_recovery_process(ctx)
     except recover.RecoveryAborted:
         dry_run = storage_recovery.is_dry_run()
         if dry_run:
             storage_recovery.end_progress()
         else:
             storage.wipe()
-        workflow.replace_default(homescreen)
         raise wire.ActionCancelled("Cancelled")
-    return result
 
 
 async def _continue_recovery_process(ctx: wire.GenericContext) -> Success:

--- a/core/src/boot.py
+++ b/core/src/boot.py
@@ -42,7 +42,7 @@ async def bootscreen() -> None:
         except (OSError, PinCancelled, SdProtectCancelled) as e:
             if __debug__:
                 log.exception(__name__, e)
-        except Exception as e:
+        except BaseException as e:
             utils.halt(e.__class__.__name__)
 
 

--- a/core/src/main.py
+++ b/core/src/main.py
@@ -71,13 +71,13 @@ def _boot_apps() -> None:
 
 from trezor import loop, wire, workflow
 
-while True:
-    # initialize the wire codec
-    wire.setup(usb.iface_wire)
-    if __debug__:
-        wire.setup(usb.iface_debug)
+# initialize the wire codec
+wire.setup(usb.iface_wire)
+if __debug__:
+    wire.setup(usb.iface_debug)
 
-    _boot_apps()
-    loop.run()
+_boot_apps()
+loop.run()
 
-    # loop is empty, reboot
+# loop is empty. That should not happen
+utils.halt("All tasks have died.")

--- a/core/src/trezor/workflow.py
+++ b/core/src/trezor/workflow.py
@@ -79,9 +79,15 @@ def replace_default(constructor: Callable[[], loop.Task]) -> None:
         loop.finalize(default_task, None)  # TODO: why not close_default()
     start_default(constructor)
 
+def kill_default() -> None:
+    """Forcefully shut down default task.
 
-def close_default() -> None:
-    """Explicitly close the default workflow task."""
+    The purpose of the call is to prevent the default task from interfering with
+    a synchronous layout-less workflow (e.g., the progress bar in `mnemonic.get_seed`).
+
+    This function should only be called from a workflow registered with `on_start`.
+    Otherwise the default will be restarted immediately.
+    """
     if default_task:
         if __debug__:
             log.debug(__name__, "close default")

--- a/core/src/trezor/workflow.py
+++ b/core/src/trezor/workflow.py
@@ -104,11 +104,14 @@ def _finalize_default(task: loop.Task, value: Any) -> None:
             log.debug(__name__, "default closed: %s", task)
         default_task = None
 
-        if not tasks and default_constructor:
+        if not tasks:
             # No registered workflows are running and we are in the default task
             # finalizer, so when this function finished, nothing will be running.
             # We must schedule a new instance of the default now.
-            start_default(default_constructor)
+            if default_constructor is not None:
+                start_default(default_constructor)
+            else:
+                raise RuntimeError  # no tasks and no default constructor
 
     else:
         if __debug__:


### PR DESCRIPTION
This was a great idea! We set the recovery homescreen as a default workflow and return to that if some message is received. We do not unregister anything.

The work in workflow.py was based on a fair amount of guessing, so I would like to discuss that part mainly. I'm not sure why I can't call `close_default` (or `loop.close` respectively), in that case the emulator exits.

Closes #558.