### PR TITLE
core/trezor/ui/loader: fixes #655 Button hold-to-confirm press detection.

### DIFF
--- a/core/src/trezor/ui/loader.py
+++ b/core/src/trezor/ui/loader.py
@@ -82,7 +82,7 @@ class Loader(ui.Component):
             display.loader(
                 r, False, Y, s.fg_color, s.bg_color, res.load(s.icon), s.icon_fg_color
             )
-        if r == 0:
+        if (r == 0) and (self.stop_ms is not None):
             self.start_ms = None
             self.stop_ms = None
             self.on_start()


### PR DESCRIPTION
When there was no time difference between
```python
    def start(self) -> None:
        self.start_ms = utime.ticks_ms()
```
and
```python
now = utime.ticks_ms()
```
the loader wouldn't start loading.