### PR TITLE
Rework USB interfaces for debug firmware

### DIFF
--- a/core/src/apps/webauthn/__init__.py
+++ b/core/src/apps/webauthn/__init__.py
@@ -1,4 +1,4 @@
-from trezor import loop, utils, wire
+from trezor import loop, wire
 from trezor.messages import MessageType
 
 from apps.webauthn.fido2 import handle_reports
@@ -18,7 +18,6 @@ def boot() -> None:
         __name__,
         "remove_resident_credential",
     )
-    if not __debug__ or utils.EMULATOR:
-        import usb
+    import usb
 
-        loop.schedule(handle_reports(usb.iface_webauthn))
+    loop.schedule(handle_reports(usb.iface_webauthn))

--- a/core/src/usb.py
+++ b/core/src/usb.py
@@ -4,42 +4,51 @@ from trezor import io, utils
 # interface used for trezor wire protocol
 iface_wire = io.WebUSB(iface_num=0, ep_in=0x81, ep_out=0x01)
 
-# we cannot use simultaneously iface_webauthn and debug interfaces,
-# as we have only limited number of endpoints
 if __debug__:
     # interface used for debug messages with trezor wire protocol
     iface_debug = io.WebUSB(iface_num=1, ep_in=0x82, ep_out=0x02)
-    # interface used for cdc/vcp console emulation (debug messages)
-    iface_vcp = io.VCP(
-        iface_num=2, data_iface_num=3, ep_in=0x83, ep_out=0x03, ep_cmd=0x84
-    )
+
 if not utils.BITCOIN_ONLY:
-    if not __debug__ or utils.EMULATOR:
-        # interface used for FIDO/U2F and FIDO2/WebAuthn HID transport
-        iface_webauthn = io.HID(
-            iface_num=4 if __debug__ else 1,
-            ep_in=0x85 if __debug__ else 0x82,
-            ep_out=0x04 if __debug__ else 0x02,
-            # fmt: off
-            report_desc=bytes([
-                0x06, 0xd0, 0xf1,  # USAGE_PAGE (FIDO Alliance)
-                0x09, 0x01,        # USAGE (U2F HID Authenticator Device)
-                0xa1, 0x01,        # COLLECTION (Application)
-                0x09, 0x20,        # USAGE (Input Report Data)
-                0x15, 0x00,        # LOGICAL_MINIMUM (0)
-                0x26, 0xff, 0x00,  # LOGICAL_MAXIMUM (255)
-                0x75, 0x08,        # REPORT_SIZE (8)
-                0x95, 0x40,        # REPORT_COUNT (64)
-                0x81, 0x02,        # INPUT (Data,Var,Abs)
-                0x09, 0x21,        # USAGE (Output Report Data)
-                0x15, 0x00,        # LOGICAL_MINIMUM (0)
-                0x26, 0xff, 0x00,  # LOGICAL_MAXIMUM (255)
-                0x75, 0x08,        # REPORT_SIZE (8)
-                0x95, 0x40,        # REPORT_COUNT (64)
-                0x91, 0x02,        # OUTPUT (Data,Var,Abs)
-                0xc0,              # END_COLLECTION
-            ]),
-            # fmt: on
+    # interface used for FIDO/U2F and FIDO2/WebAuthn HID transport
+    iface_webauthn = io.HID(
+        iface_num=2 if __debug__ else 1,
+        ep_in=0x83 if __debug__ else 0x82,
+        ep_out=0x03 if __debug__ else 0x02,
+        # fmt: off
+        report_desc=bytes([
+            0x06, 0xd0, 0xf1,  # USAGE_PAGE (FIDO Alliance)
+            0x09, 0x01,        # USAGE (U2F HID Authenticator Device)
+            0xa1, 0x01,        # COLLECTION (Application)
+            0x09, 0x20,        # USAGE (Input Report Data)
+            0x15, 0x00,        # LOGICAL_MINIMUM (0)
+            0x26, 0xff, 0x00,  # LOGICAL_MAXIMUM (255)
+            0x75, 0x08,        # REPORT_SIZE (8)
+            0x95, 0x40,        # REPORT_COUNT (64)
+            0x81, 0x02,        # INPUT (Data,Var,Abs)
+            0x09, 0x21,        # USAGE (Output Report Data)
+            0x15, 0x00,        # LOGICAL_MINIMUM (0)
+            0x26, 0xff, 0x00,  # LOGICAL_MAXIMUM (255)
+            0x75, 0x08,        # REPORT_SIZE (8)
+            0x95, 0x40,        # REPORT_COUNT (64)
+            0x91, 0x02,        # OUTPUT (Data,Var,Abs)
+            0xc0,              # END_COLLECTION
+        ]),
+        # fmt: on
+    )
+
+if __debug__:
+    # We cannot use this on real device simultaneously with the iface_webauthn
+    # interface, because we have only limited number of endpoints (10).
+    # We start this only for bitcoin-only firmware or for emulator.
+    ENABLE_VCP_IFACE = utils.EMULATOR or utils.BITCOIN_ONLY
+    if ENABLE_VCP_IFACE:
+        # interface used for cdc/vcp console emulation (debug messages)
+        iface_vcp = io.VCP(
+            iface_num=2 if utils.BITCOIN_ONLY else 3,
+            data_iface_num=3 if utils.BITCOIN_ONLY else 4,
+            ep_in=0x83 if utils.BITCOIN_ONLY else 0x84,
+            ep_out=0x03 if utils.BITCOIN_ONLY else 0x04,
+            ep_cmd=0x84 if utils.BITCOIN_ONLY else 0x85,
         )
 
 bus = io.USB(
@@ -54,7 +63,8 @@ bus = io.USB(
 bus.add(iface_wire)
 if __debug__:
     bus.add(iface_debug)
-    bus.add(iface_vcp)
 if not utils.BITCOIN_ONLY:
-    if not __debug__ or utils.EMULATOR:
-        bus.add(iface_webauthn)
+    bus.add(iface_webauthn)
+if __debug__:
+    if ENABLE_VCP_IFACE:
+        bus.add(iface_vcp)

--- a/core/tests/run_tests_device_emu_fido2.sh
+++ b/core/tests/run_tests_device_emu_fido2.sh
@@ -32,6 +32,7 @@ fi
 cd ../../tests/fido_tests/fido2
 # run tests
 error=0
+export TREZOR_FIDO2_UDP_PORT=21326
 if ! pytest --random-order-seed=414020 --sim tests/standard/ --vendor trezor "$@"; then  # hardcoded order seed, which succeeds
   error=1
 fi

--- a/core/tests/run_tests_device_emu_u2f.sh
+++ b/core/tests/run_tests_device_emu_u2f.sh
@@ -31,14 +31,15 @@ fi
 
 # run tests
 error=0
+TREZOR_FIDO2_UDP_PORT=21326
 # missuse loaddevice test to initialize the device
 if ! pytest ../../tests/device_tests -k "test_msg_loaddevice" "$@"; then
   error=1
 fi
-if ! ../../tests/fido_tests/u2f-tests-hid/HIDTest 21328 "$@"; then
+if ! ../../tests/fido_tests/u2f-tests-hid/HIDTest "${TREZOR_FIDO2_UDP_PORT}" "$@"; then
   error=1
 fi
-if ! ../../tests/fido_tests/u2f-tests-hid/U2FTest 21328 "$@"; then
+if ! ../../tests/fido_tests/u2f-tests-hid/U2FTest "${TREZOR_FIDO2_UDP_PORT}" "$@"; then
   error=1
 fi
 kill $upy_pid


### PR DESCRIPTION
Let's have WebAuthn interface available for the Debug firmware.

Fixes https://github.com/trezor/trezor-firmware/issues/677

There is no configuration present, but arguably someone in need of having VCP interface for the debug firmware can edit `usb.py` easily. (Plus VCP is enabled for Bitcoin-only debug firmware).