### PR TITLE
Add micropython to required brew packages

### DIFF
--- a/core/docs/build/emulator.md
+++ b/core/docs/build/emulator.md
@@ -41,7 +41,7 @@ nix-shell
 * __Mac OS X__:
 
 ```sh
-brew install scons sdl2 sdl2_image pkg-config
+brew install scons sdl2 sdl2_image pkg-config micropython
 ```
 
 * __Windows__: not supported yet, sorry.


### PR DESCRIPTION
Without micropython the build obviously fails