### PR TITLE
disallow most RecoveryDevice fields in dry-run (fixes #666)

### DIFF
--- a/core/ChangeLog
+++ b/core/ChangeLog
@@ -2,6 +2,7 @@ Version 2.x.x [not yet released]
 * SD card protection
 * Remove unused ButtonRequest.data field
 * Rework Recovery persistence internally
+* Disallow changing of settings via dry-run recovery
 
 Version 2.1.8 [Nov 2019]
 * Support Tezos 005-BABYLON hardfork

--- a/legacy/firmware/fsm_msg_common.h
+++ b/legacy/firmware/fsm_msg_common.h
@@ -403,6 +403,12 @@ void fsm_msgRecoveryDevice(const RecoveryDevice *msg) {
   const bool dry_run = msg->has_dry_run ? msg->dry_run : false;
   if (!dry_run) {
     CHECK_NOT_INITIALIZED
+  } else {
+    CHECK_INITIALIZED
+    CHECK_PARAM(!msg->has_passphrase_protection && !msg->has_pin_protection &&
+                    !msg->has_language && !msg->has_label &&
+                    !msg->has_u2f_counter,
+                _("Forbidden field set in dry-run"))
   }
 
   CHECK_PARAM(!msg->has_word_count || msg->word_count == 12 ||

--- a/python/src/trezorlib/device.py
+++ b/python/src/trezorlib/device.py
@@ -18,7 +18,7 @@ import os
 import time
 import warnings
 
-from . import messages as proto
+from . import messages
 from .exceptions import Cancelled
 from .tools import expect, session
 from .transport import enumerate_devices, get_transport
@@ -44,7 +44,7 @@ class TrezorDevice:
         return get_transport(path, prefix_search=False)
 
 
-@expect(proto.Success, field="message")
+@expect(messages.Success, field="message")
 def apply_settings(
     client,
     label=None,
@@ -55,7 +55,7 @@ def apply_settings(
     auto_lock_delay_ms=None,
     display_rotation=None,
 ):
-    settings = proto.ApplySettings()
+    settings = messages.ApplySettings()
     if label is not None:
         settings.label = label
     if language:
@@ -76,30 +76,30 @@ def apply_settings(
     return out
 
 
-@expect(proto.Success, field="message")
+@expect(messages.Success, field="message")
 def apply_flags(client, flags):
-    out = client.call(proto.ApplyFlags(flags=flags))
+    out = client.call(messages.ApplyFlags(flags=flags))
     client.init_device()  # Reload Features
     return out
 
 
-@expect(proto.Success, field="message")
+@expect(messages.Success, field="message")
 def change_pin(client, remove=False):
-    ret = client.call(proto.ChangePin(remove=remove))
+    ret = client.call(messages.ChangePin(remove=remove))
     client.init_device()  # Re-read features
     return ret
 
 
-@expect(proto.Success, field="message")
+@expect(messages.Success, field="message")
 def sd_protect(client, operation):
-    ret = client.call(proto.SdProtect(operation=operation))
+    ret = client.call(messages.SdProtect(operation=operation))
     client.init_device()
     return ret
 
 
-@expect(proto.Success, field="message")
+@expect(messages.Success, field="message")
 def wipe(client):
-    ret = client.call(proto.WipeDevice())
+    ret = client.call(messages.WipeDevice())
     client.init_device()
     return ret
 
@@ -112,7 +112,7 @@ def recover(
     label=None,
     language="english",
     input_callback=None,
-    type=proto.RecoveryDeviceType.ScrambledWords,
+    type=messages.RecoveryDeviceType.ScrambledWords,
     dry_run=False,
     u2f_counter=None,
 ):
@@ -130,32 +130,32 @@ def recover(
     if u2f_counter is None:
         u2f_counter = int(time.time())
 
-    res = client.call(
-        proto.RecoveryDevice(
-            word_count=word_count,
-            passphrase_protection=bool(passphrase_protection),
-            pin_protection=bool(pin_protection),
-            label=label,
-            language=language,
-            enforce_wordlist=True,
-            type=type,
-            dry_run=dry_run,
-            u2f_counter=u2f_counter,
-        )
+    msg = messages.RecoveryDevice(
+        word_count=word_count, enforce_wordlist=True, type=type, dry_run=dry_run
     )
 
-    while isinstance(res, proto.WordRequest):
+    if not dry_run:
+        # set additional parameters
+        msg.passphrase_protection = passphrase_protection
+        msg.pin_protection = pin_protection
+        msg.label = label
+        msg.language = language
+        msg.u2f_counter = u2f_counter
+
+    res = client.call(msg)
+
+    while isinstance(res, messages.WordRequest):
         try:
             inp = input_callback(res.type)
-            res = client.call(proto.WordAck(word=inp))
+            res = client.call(messages.WordAck(word=inp))
         except Cancelled:
-            res = client.call(proto.Cancel())
+            res = client.call(messages.Cancel())
 
     client.init_device()
     return res
 
 
-@expect(proto.Success, field="message")
+@expect(messages.Success, field="message")
 @session
 def reset(
     client,
@@ -168,7 +168,7 @@ def reset(
     u2f_counter=0,
     skip_backup=False,
     no_backup=False,
-    backup_type=proto.BackupType.Bip39,
+    backup_type=messages.BackupType.Bip39,
 ):
     if client.features.initialized:
         raise RuntimeError(
@@ -182,7 +182,7 @@ def reset(
             strength = 128
 
     # Begin with device reset workflow
-    msg = proto.ResetDevice(
+    msg = messages.ResetDevice(
         display_random=bool(display_random),
         strength=strength,
         passphrase_protection=bool(passphrase_protection),
@@ -196,17 +196,17 @@ def reset(
     )
 
     resp = client.call(msg)
-    if not isinstance(resp, proto.EntropyRequest):
+    if not isinstance(resp, messages.EntropyRequest):
         raise RuntimeError("Invalid response, expected EntropyRequest")
 
     external_entropy = os.urandom(32)
     # LOG.debug("Computer generated entropy: " + external_entropy.hex())
-    ret = client.call(proto.EntropyAck(entropy=external_entropy))
+    ret = client.call(messages.EntropyAck(entropy=external_entropy))
     client.init_device()
     return ret
 
 
-@expect(proto.Success, field="message")
+@expect(messages.Success, field="message")
 def backup(client):
-    ret = client.call(proto.BackupDevice())
+    ret = client.call(messages.BackupDevice())
     return ret


### PR DESCRIPTION
On core, dry-run will allow four whitelisted fields: `dry_run` (obviously), `enforce_wordlist` (allowed but if sent, must be True), `word_count` and `type` (for T1 compatibility, so that it is possible to send an identical message to T1 and TT).
As an extra protection, any device settings are only done if `dry_run` is not true.

On legacy, fields other than those above are blacklisted. Also, dry-run is disallowed when the device is not initialized, to synchronize behavior with core.

An exhaustive test tries to set each field in dry-run and checks that the device reports failure.