### PR TITLE
Amnesic mode for Trezor One

### DIFF
--- a/legacy/firmware/config.h
+++ b/legacy/firmware/config.h
@@ -108,6 +108,8 @@ bool config_getPassphraseProtection(bool *passphrase_protection);
 bool config_getHomescreen(uint8_t *dest, uint16_t dest_size);
 void config_setHomescreen(const uint8_t *data, uint32_t size);
 
+void session_setAmnesic(bool amnesic);
+
 void session_cachePassphrase(const char *passphrase);
 bool session_isPassphraseCached(void);
 bool session_getState(const uint8_t *salt, uint8_t *state,

--- a/legacy/firmware/recovery.c
+++ b/legacy/firmware/recovery.c
@@ -21,6 +21,7 @@
 #include "recovery.h"
 #include <ctype.h>
 #include "bip39.h"
+#include "buttons.h"
 #include "config.h"
 #include "fsm.h"
 #include "gettext.h"
@@ -469,6 +470,26 @@ void next_word(void) {
   recovery_request();
 }
 
+void requestAmnesicMode(void) {
+  layoutDialog(&bmp_icon_question, _("Cancel"), _("Confirm"), NULL,
+               _("Do you like to enable"), _("amnesic mode?"), NULL, NULL, NULL,
+               NULL);
+
+  buttonUpdate();
+
+  for (;;) {
+    usbSleep(5);
+    buttonUpdate();
+    if (button.YesUp || button.NoUp) {
+      break;
+    }
+  }
+
+  layoutSwipe();
+
+  session_setAmnesic(button.YesUp);
+}
+
 void recovery_init(uint32_t _word_count, bool passphrase_protection,
                    bool pin_protection, const char *language, const char *label,
                    bool _enforce_wordlist, uint32_t type, uint32_t u2f_counter,
@@ -501,6 +522,8 @@ void recovery_init(uint32_t _word_count, bool passphrase_protection,
     config_setLabel(label);
     config_setU2FCounter(u2f_counter);
   }
+
+  requestAmnesicMode();
 
   if ((type & RecoveryDeviceType_RecoveryDeviceType_Matrix) != 0) {
     awaiting_word = 2;


### PR DESCRIPTION
This is a proposal for including an amnesic/stateless mode, in which no sensitive information, such as the seed, is permanently saved on the device. The seed extraction vulnerability can be completely thwarted by amnesic mode.