### PR TITLE
U2F UX improvements

### DIFF
--- a/core/src/apps/webauthn/fido2.py
+++ b/core/src/apps/webauthn/fido2.py
@@ -1414,7 +1414,9 @@ def cbor_make_credential(req: Cmd, dialog_mgr: DialogManager) -> Optional[Cmd]:
         # User verification requested, but PIN is not enabled.
         state_set = dialog_mgr.set_state(Fido2ConfirmNoPin(req.cid, dialog_mgr.iface))
         if state_set:
-            return cbor_error(req.cid, _ERR_UNSUPPORTED_OPTION)
+            # We should return _ERR_UNSUPPORTED_OPTION, but since we claim in GetInfo that the PIN
+            # is set even when it's not, it makes more sense to return _ERR_OPERATION_DENIED.
+            return cbor_error(req.cid, _ERR_OPERATION_DENIED)
         else:
             return cmd_error(req.cid, _ERR_CHANNEL_BUSY)
 
@@ -1571,7 +1573,9 @@ def cbor_get_assertion(req: Cmd, dialog_mgr: DialogManager) -> Optional[Cmd]:
         # User verification requested, but PIN is not enabled.
         state_set = dialog_mgr.set_state(Fido2ConfirmNoPin(req.cid, dialog_mgr.iface))
         if state_set:
-            return cbor_error(req.cid, _ERR_UNSUPPORTED_OPTION)
+            # We should return _ERR_UNSUPPORTED_OPTION, but since we claim in GetInfo that the PIN
+            # is set even when it's not, it makes more sense to return _ERR_OPERATION_DENIED.
+            return cbor_error(req.cid, _ERR_OPERATION_DENIED)
         else:
             return cmd_error(req.cid, _ERR_CHANNEL_BUSY)
 
@@ -1729,6 +1733,8 @@ def cbor_get_assertion_sign(
 
 
 def cbor_get_info(req: Cmd) -> Cmd:
+    # Note: We claim that the PIN is set even when it's not, because otherwise
+    # login.live.com shows an error, but doesn't instruct the user to set a PIN.
     response_data = {
         _GETINFO_RESP_VERSIONS: ["U2F_V2", "FIDO_2_0"],
         _GETINFO_RESP_EXTENSIONS: ["hmac-secret"],

--- a/core/src/apps/webauthn/fido2.py
+++ b/core/src/apps/webauthn/fido2.py
@@ -1027,7 +1027,7 @@ def dispatch_cmd(req: Cmd, dialog_mgr: DialogManager) -> Optional[Cmd]:
     elif req.cmd == _CMD_WINK:
         if __debug__:
             log.debug(__name__, "_CMD_WINK")
-        loop.schedule(ui.alert())
+        ui.alert()
         return req
     elif req.cmd == _CMD_CBOR and _ALLOW_FIDO2:
         if not req.data:

--- a/core/src/apps/webauthn/fido2.py
+++ b/core/src/apps/webauthn/fido2.py
@@ -215,6 +215,9 @@ _ALLOW_RESIDENT_CREDENTIALS = True
 # The attestation type to use in MakeCredential responses. If false, then self attestation will be used.
 _USE_BASIC_ATTESTATION = False
 
+# The CID of the last WINK command. Used to ensure that we do only one WINK at a time on any given CID.
+_last_wink_cid = 0
+
 
 class CborError(Exception):
     def __init__(self, code: int):
@@ -1027,8 +1030,7 @@ def dispatch_cmd(req: Cmd, dialog_mgr: DialogManager) -> Optional[Cmd]:
     elif req.cmd == _CMD_WINK:
         if __debug__:
             log.debug(__name__, "_CMD_WINK")
-        ui.alert()
-        return req
+        return cmd_wink(req)
     elif req.cmd == _CMD_CBOR and _ALLOW_FIDO2:
         if not req.data:
             return cmd_error(req.cid, _ERR_INVALID_LEN)
@@ -1090,6 +1092,14 @@ def cmd_init(req: Cmd) -> Cmd:
     resp.capFlags = _CAPFLAG_WINK | _CAPFLAG_CBOR
 
     return Cmd(req.cid, req.cmd, buf)
+
+
+def cmd_wink(req: Cmd) -> Cmd:
+    global _last_wink_cid
+    if _last_wink_cid != req.cid:
+        _last_wink_cid = req.cid
+        ui.alert()
+    return req
 
 
 def msg_register(req: Msg, dialog_mgr: DialogManager) -> Cmd:

--- a/core/src/apps/webauthn/fido2.py
+++ b/core/src/apps/webauthn/fido2.py
@@ -1140,10 +1140,17 @@ def msg_register(req: Msg, dialog_mgr: DialogManager) -> Cmd:
     dialog_mgr.reset_timeout()
 
     # wait for a button or continue
-    if dialog_mgr.result != _RESULT_CONFIRM:
+    if dialog_mgr.result == _RESULT_NONE:
         if __debug__:
             log.info(__name__, "waiting for button")
         return msg_error(req.cid, _SW_CONDITIONS_NOT_SATISFIED)
+
+    if dialog_mgr.result != _RESULT_CONFIRM:
+        if __debug__:
+            log.info(__name__, "request declined")
+        # There is no standard way to decline a U2F request, but responding with ERR_CHANNEL_BUSY
+        # doesn't seem to violate the protocol and at least stops Chrome from polling.
+        return cmd_error(req.cid, _ERR_CHANNEL_BUSY)
 
     # sign the registration challenge and return
     if __debug__:
@@ -1229,10 +1236,17 @@ def msg_authenticate(req: Msg, dialog_mgr: DialogManager) -> Cmd:
     dialog_mgr.reset_timeout()
 
     # wait for a button or continue
-    if dialog_mgr.result != _RESULT_CONFIRM:
+    if dialog_mgr.result == _RESULT_NONE:
         if __debug__:
             log.info(__name__, "waiting for button")
         return msg_error(req.cid, _SW_CONDITIONS_NOT_SATISFIED)
+
+    if dialog_mgr.result != _RESULT_CONFIRM:
+        if __debug__:
+            log.info(__name__, "request declined")
+        # There is no standard way to decline a U2F request, but responding with ERR_CHANNEL_BUSY
+        # doesn't seem to violate the protocol and at least stops Chrome from polling.
+        return cmd_error(req.cid, _ERR_CHANNEL_BUSY)
 
     # sign the authentication challenge and return
     if __debug__:


### PR DESCRIPTION
Note that this is branched off of andrewkozlik/733 (Fix continuous display blinking with Android #734), so preferably review that first.

This resolves https://github.com/trezor/trezor-firmware/issues/731 and introduces some improvements to the UX such as automatically closing the U2F confirmation screen if the browser stops polling for more than 3 seconds. This is especially relevant when there are two devices connected to the computer. When the user confirms the registration or login on one of them, the other used to be left hanging on the U2F screen until the user pressed something. Chrome normally polls every 200ms and Firefox appears to be polling at around the same rate, so a 3 second timeout should be more than enough. However, I didn't find any official minimum polling interval in the specs. When I tried setting the timeout to 2 seconds, the U2F tests started failing. It has probably something to do with how long WaitForUserPresence takes, but I didn't investigate further. 3 seconds seems to be working fine.