### PR TITLE
Unlock storage after wipe

### DIFF
--- a/storage/storage.c
+++ b/storage/storage.c
@@ -642,9 +642,7 @@ static void init_wiped_storage(void) {
   ui_rem = ui_total;
   ui_message = PROCESSING_MSG;
   ensure(set_pin(PIN_EMPTY, NULL), "init_pin failed");
-  if (unlocked != sectrue) {
-    memzero(cached_keys, sizeof(cached_keys));
-  }
+  unlocked = sectrue;
 }
 
 void storage_init(PIN_UI_WAIT_CALLBACK callback, const uint8_t *salt,
@@ -669,6 +667,7 @@ void storage_init(PIN_UI_WAIT_CALLBACK callback, const uint8_t *salt,
   uint16_t len = 0;
   if (secfalse == norcow_get(EDEK_PVC_KEY, &val, &len)) {
     init_wiped_storage();
+    storage_lock();
   }
   memzero(cached_keys, sizeof(cached_keys));
 }

--- a/storage/storage.c
+++ b/storage/storage.c
@@ -629,6 +629,7 @@ static void init_wiped_storage(void) {
     return;
   }
   random_buffer(cached_keys, sizeof(cached_keys));
+  unlocked = sectrue;
   uint32_t version = NORCOW_VERSION;
   ensure(auth_init(), "set_storage_auth_tag failed");
   ensure(storage_set_encrypted(VERSION_KEY, &version, sizeof(version)),
@@ -642,7 +643,6 @@ static void init_wiped_storage(void) {
   ui_rem = ui_total;
   ui_message = PROCESSING_MSG;
   ensure(set_pin(PIN_EMPTY, NULL), "init_pin failed");
-  unlocked = sectrue;
 }
 
 void storage_init(PIN_UI_WAIT_CALLBACK callback, const uint8_t *salt,

--- a/storage/tests/python/src/storage.py
+++ b/storage/tests/python/src/storage.py
@@ -130,8 +130,12 @@ class Storage:
             # public fields can be read from an unlocked device
             raise RuntimeError("Storage locked")
         if consts.is_app_public(app):
-            return self.nc.get(key)
-        return self._get_encrypted(key)
+            value = self.nc.get(key)
+        else:
+            value = self._get_encrypted(key)
+        if value is False:
+            raise RuntimeError("Failed to find key in storage.")
+        return value
 
     def set(self, key: int, val: bytes) -> bool:
         app = key >> 8
@@ -153,7 +157,7 @@ class Storage:
         app = key >> 8
         self._check_lock(app)
 
-        current = self.get(key)
+        current = self.nc.get(key)
         if current is False:
             self.set_counter(key, 0)
             return 0

--- a/storage/tests/tests/test_set_get.py
+++ b/storage/tests/tests/test_set_get.py
@@ -83,6 +83,13 @@ def test_invalid_key():
             s.set(0xFFFF, b"Hello")
 
 
+def test_non_existing_key():
+    sc, sp = common.init()
+    for s in (sc, sp):
+        with pytest.raises(RuntimeError):
+            s.get(0xABCD)
+
+
 def test_chacha_strings():
     sc, sp = common.init(unlock=True)
     for s in (sc, sp):


### PR DESCRIPTION
As brought up by @andrewkozlik, the storage lock state was based on the previous one. Probably because of some tests failing. However, it seems this is not the case anymore, tests are passing.

We have decided to always unlock the storage after wipe because the storage is empty anyway.

@andrewkozlik please review this thoroughly. I have also added a fix and test for non-existing key, because the python implementation acted differently.
