### PR TITLE
Recovery: refactor word checks and add a test

### DIFF
--- a/core/src/apps/management/recovery_device/layout.py
+++ b/core/src/apps/management/recovery_device/layout.py
@@ -72,17 +72,19 @@ async def request_mnemonic(
         else:
             word = await ctx.wait(keyboard)
 
-        validity = word_validity.check(i, word, backup_type, words)
-        if validity != word_validity.OK:
-            if validity == word_validity.NOK_ALREADY_ADDED:
-                await show_share_already_added(ctx)
-            elif validity == word_validity.NOK_IDENTIFIER_MISMATCH:
-                await show_identifier_mismatch(ctx)
-            elif validity == word_validity.NOK_THRESHOLD_REACHED:
-                await show_group_threshold_reached(ctx)
-            return None
-
         words.append(word)
+
+        try:
+            word_validity.check(backup_type, words)
+        except word_validity.AlreadyAdded:
+            await show_share_already_added(ctx)
+            return None
+        except word_validity.IdentifierMismatch:
+            await show_identifier_mismatch(ctx)
+            return None
+        except word_validity.ThresholdReached:
+            await show_group_threshold_reached(ctx)
+            return None
 
     return " ".join(words)
 

--- a/core/src/apps/management/recovery_device/word_validity.py
+++ b/core/src/apps/management/recovery_device/word_validity.py
@@ -1,0 +1,103 @@
+from micropython import const
+
+import storage.recovery
+from trezor.messages import BackupType
+
+from apps.management.recovery_device import recover
+
+if False:
+    from typing import List, Optional
+    from trezor.messages.ResetDevice import EnumTypeBackupType
+
+OK = const(0)
+NOK_IDENTIFIER_MISMATCH = const(1)
+NOK_ALREADY_ADDED = const(2)
+NOK_THRESHOLD_REACHED = const(3)
+
+
+def check(
+    current_index: int,
+    current_word: str,
+    backup_type: Optional[EnumTypeBackupType],
+    previous_words: List[str],
+) -> int:
+    # we can't perform any checks if the backup type was not yet decided
+    if backup_type is None:
+        return OK
+    # there are no "on-the-fly" checks for BIP-39
+    if backup_type is BackupType.Bip39:
+        return OK
+
+    previous_mnemonics = recover.fetch_previous_mnemonics()
+    if previous_mnemonics is None:
+        # this should not happen if backup_type is set
+        raise RuntimeError
+
+    if backup_type == BackupType.Slip39_Basic:
+        return check_slip39_basic(current_index, current_word, previous_mnemonics)
+
+    if backup_type == BackupType.Slip39_Advanced:
+        return check_slip39_advanced(
+            current_index, current_word, previous_words, previous_mnemonics
+        )
+
+    # there are no other backup types
+    raise RuntimeError
+
+
+def check_slip39_basic(
+    current_index: int, current_word: str, previous_mnemonics: List[List[str]]
+) -> int:
+    # check if first 3 words of mnemonic match
+    # we can check against the first one, others were checked already
+    if current_index < 3:
+        share_list = previous_mnemonics[0][0].split(" ")
+        if share_list[current_index] != current_word:
+            return NOK_IDENTIFIER_MISMATCH
+    elif current_index == 3:
+        for share in previous_mnemonics[0]:
+            share_list = share.split(" ")
+            # check if the fourth word is different from previous shares
+            if share_list[current_index] == current_word:
+                return NOK_ALREADY_ADDED
+
+    return OK
+
+
+def check_slip39_advanced(
+    current_index: int,
+    current_word: str,
+    previous_words: List[str],
+    previous_mnemonics: List[List[str]],
+) -> int:
+    if current_index < 2:
+        share_list = next(s for s in previous_mnemonics if s)[0].split(" ")
+        if share_list[current_index] != current_word:
+            return NOK_IDENTIFIER_MISMATCH
+    # check if we reached threshold in group
+    elif current_index == 2:
+        for i, group in enumerate(previous_mnemonics):
+            if len(group) > 0:
+                if current_word == group[0].split(" ")[current_index]:
+                    remaining_shares = storage.recovery.fetch_slip39_remaining_shares()
+                    # if backup_type is not None, some share was already entered -> remaining needs to be set
+                    assert remaining_shares is not None
+                    if remaining_shares[i] == 0:
+                        return NOK_THRESHOLD_REACHED
+    # check if share was already added for group
+    elif current_index == 3:
+        # we use the 3rd word from previously entered shares to find the group id
+        group_identifier_word = previous_words[2]
+        group_index = None
+        for i, group in enumerate(previous_mnemonics):
+            if len(group) > 0:
+                if group_identifier_word == group[0].split(" ")[2]:
+                    group_index = i
+
+        if group_index is not None:
+            group = previous_mnemonics[group_index]
+            for share in group:
+                if current_word == share.split(" ")[current_index]:
+                    return NOK_ALREADY_ADDED
+
+    return OK

--- a/core/src/apps/management/recovery_device/word_validity.py
+++ b/core/src/apps/management/recovery_device/word_validity.py
@@ -16,10 +16,7 @@ NOK_THRESHOLD_REACHED = const(3)
 
 
 def check(
-    current_index: int,
-    current_word: str,
-    backup_type: Optional[EnumTypeBackupType],
-    previous_words: List[str],
+    backup_type: Optional[EnumTypeBackupType], partial_mnemonic: List[str]
 ) -> int:
     # we can't perform any checks if the backup type was not yet decided
     if backup_type is None:
@@ -34,22 +31,22 @@ def check(
         raise RuntimeError
 
     if backup_type == BackupType.Slip39_Basic:
-        return check_slip39_basic(current_index, current_word, previous_mnemonics)
+        return check_slip39_basic(partial_mnemonic, previous_mnemonics)
 
     if backup_type == BackupType.Slip39_Advanced:
-        return check_slip39_advanced(
-            current_index, current_word, previous_words, previous_mnemonics
-        )
+        return check_slip39_advanced(partial_mnemonic, previous_mnemonics)
 
     # there are no other backup types
     raise RuntimeError
 
 
 def check_slip39_basic(
-    current_index: int, current_word: str, previous_mnemonics: List[List[str]]
+    partial_mnemonic: List[str], previous_mnemonics: List[List[str]]
 ) -> int:
     # check if first 3 words of mnemonic match
     # we can check against the first one, others were checked already
+    current_index = len(partial_mnemonic) - 1
+    current_word = partial_mnemonic[-1]
     if current_index < 3:
         share_list = previous_mnemonics[0][0].split(" ")
         if share_list[current_index] != current_word:
@@ -65,11 +62,10 @@ def check_slip39_basic(
 
 
 def check_slip39_advanced(
-    current_index: int,
-    current_word: str,
-    previous_words: List[str],
-    previous_mnemonics: List[List[str]],
+    partial_mnemonic: List[str], previous_mnemonics: List[List[str]]
 ) -> int:
+    current_index = len(partial_mnemonic) - 1
+    current_word = partial_mnemonic[-1]
     if current_index < 2:
         share_list = next(s for s in previous_mnemonics if s)[0].split(" ")
         if share_list[current_index] != current_word:
@@ -87,7 +83,7 @@ def check_slip39_advanced(
     # check if share was already added for group
     elif current_index == 3:
         # we use the 3rd word from previously entered shares to find the group id
-        group_identifier_word = previous_words[2]
+        group_identifier_word = partial_mnemonic[2]
         group_index = None
         for i, group in enumerate(previous_mnemonics):
             if len(group) > 0:

--- a/core/src/apps/management/recovery_device/word_validity.py
+++ b/core/src/apps/management/recovery_device/word_validity.py
@@ -8,7 +8,7 @@ if False:
     from trezor.messages.ResetDevice import EnumTypeBackupType
 
 
-class WordValidityResult(BaseException):
+class WordValidityResult(Exception):
     pass
 
 

--- a/core/src/apps/management/recovery_device/word_validity.py
+++ b/core/src/apps/management/recovery_device/word_validity.py
@@ -1,5 +1,3 @@
-from micropython import const
-
 import storage.recovery
 from trezor.messages import BackupType
 
@@ -9,21 +7,32 @@ if False:
     from typing import List, Optional
     from trezor.messages.ResetDevice import EnumTypeBackupType
 
-OK = const(0)
-NOK_IDENTIFIER_MISMATCH = const(1)
-NOK_ALREADY_ADDED = const(2)
-NOK_THRESHOLD_REACHED = const(3)
+
+class WordValidityResult(BaseException):
+    pass
+
+
+class IdentifierMismatch(WordValidityResult):
+    pass
+
+
+class AlreadyAdded(WordValidityResult):
+    pass
+
+
+class ThresholdReached(WordValidityResult):
+    pass
 
 
 def check(
     backup_type: Optional[EnumTypeBackupType], partial_mnemonic: List[str]
-) -> int:
+) -> None:
     # we can't perform any checks if the backup type was not yet decided
     if backup_type is None:
-        return OK
+        return
     # there are no "on-the-fly" checks for BIP-39
     if backup_type is BackupType.Bip39:
-        return OK
+        return
 
     previous_mnemonics = recover.fetch_previous_mnemonics()
     if previous_mnemonics is None:
@@ -31,18 +40,17 @@ def check(
         raise RuntimeError
 
     if backup_type == BackupType.Slip39_Basic:
-        return check_slip39_basic(partial_mnemonic, previous_mnemonics)
-
-    if backup_type == BackupType.Slip39_Advanced:
-        return check_slip39_advanced(partial_mnemonic, previous_mnemonics)
-
-    # there are no other backup types
-    raise RuntimeError
+        check_slip39_basic(partial_mnemonic, previous_mnemonics)
+    elif backup_type == BackupType.Slip39_Advanced:
+        check_slip39_advanced(partial_mnemonic, previous_mnemonics)
+    else:
+        # there are no other backup types
+        raise RuntimeError
 
 
 def check_slip39_basic(
     partial_mnemonic: List[str], previous_mnemonics: List[List[str]]
-) -> int:
+) -> None:
     # check if first 3 words of mnemonic match
     # we can check against the first one, others were checked already
     current_index = len(partial_mnemonic) - 1
@@ -50,26 +58,25 @@ def check_slip39_basic(
     if current_index < 3:
         share_list = previous_mnemonics[0][0].split(" ")
         if share_list[current_index] != current_word:
-            return NOK_IDENTIFIER_MISMATCH
+            raise IdentifierMismatch
     elif current_index == 3:
         for share in previous_mnemonics[0]:
             share_list = share.split(" ")
             # check if the fourth word is different from previous shares
             if share_list[current_index] == current_word:
-                return NOK_ALREADY_ADDED
-
-    return OK
+                raise AlreadyAdded
 
 
 def check_slip39_advanced(
     partial_mnemonic: List[str], previous_mnemonics: List[List[str]]
-) -> int:
+) -> None:
     current_index = len(partial_mnemonic) - 1
     current_word = partial_mnemonic[-1]
+
     if current_index < 2:
         share_list = next(s for s in previous_mnemonics if s)[0].split(" ")
         if share_list[current_index] != current_word:
-            return NOK_IDENTIFIER_MISMATCH
+            raise IdentifierMismatch
     # check if we reached threshold in group
     elif current_index == 2:
         for i, group in enumerate(previous_mnemonics):
@@ -79,7 +86,8 @@ def check_slip39_advanced(
                     # if backup_type is not None, some share was already entered -> remaining needs to be set
                     assert remaining_shares is not None
                     if remaining_shares[i] == 0:
-                        return NOK_THRESHOLD_REACHED
+                        raise ThresholdReached
+
     # check if share was already added for group
     elif current_index == 3:
         # we use the 3rd word from previously entered shares to find the group id
@@ -94,6 +102,4 @@ def check_slip39_advanced(
             group = previous_mnemonics[group_index]
             for share in group:
                 if current_word == share.split(" ")[current_index]:
-                    return NOK_ALREADY_ADDED
-
-    return OK
+                    raise AlreadyAdded

--- a/core/tests/test_apps.management.recovery_device.py
+++ b/core/tests/test_apps.management.recovery_device.py
@@ -151,10 +151,10 @@ class TestSlip39(unittest.TestCase):
             check(BackupType.Slip39_Advanced, ["ocean"])
 
         # if backup type is not set we can not do any checks
-        self.assertIsNone(check(None, ["ocean"]))
+        check(None, ["ocean"])
 
         # BIP-39 has no "on-the-fly" checks
-        self.assertIsNone(check(BackupType.Bip39, ["ocean"]))
+        check(BackupType.Bip39, ["ocean"])
 
         # let's store two shares in the storage
         secret, share = process_slip39("trash smug adjust ambition criminal prisoner security math cover pecan response pharmacy center criminal salary elbow bracelet lunar briefing dragon")
@@ -169,6 +169,10 @@ class TestSlip39(unittest.TestCase):
         # same first word but still a different identifier
         with self.assertRaises(IdentifierMismatch):
             check(BackupType.Slip39_Advanced, ["trash", "slush"])
+
+        # same identifier but different group settings for Slip 39 Basic
+        with self.assertRaises(IdentifierMismatch):
+            check(BackupType.Slip39_Basic, ["trash", "smug", "slush"])
 
         # same mnemonic found out using the index
         with self.assertRaises(AlreadyAdded):


### PR DESCRIPTION
This started as #770 and got a bit out of hand :). But it makes sense to split the check_word_validity into more functions, since it was quite long, and also separate the evaluation logic and the display of the warnings.

The test is probably not exhaustive and might be expended later on.