### PR TITLE
Allow building python-trezor from master on NixOS

### DIFF
--- a/python/default.nix
+++ b/python/default.nix
@@ -1,0 +1,20 @@
+with import <nixpkgs> {};
+
+let
+  python = let
+    packageOverrides = self: super: {
+      trezor = super.trezor.overridePythonAttrs(old: rec {
+        version = "master";
+        src =  ./.;
+        doCheck = true; # set to false if you want to skip tests
+        checkPhase = ''
+          runHook preCheck
+          pytest --pyargs tests --ignore tests/test_tx_api.py
+          runHook postCheck
+        '';
+      });
+    };
+  in pkgs.python3.override {inherit packageOverrides; self = python;};
+
+in python.withPackages(ps:[ps.trezor])
+


### PR DESCRIPTION
This PR allows building and testing python-trezor from master locally on NixOS.

Example usage:
`[example@example:~/trezor-firmware/python]$ nix-build .`

`$ /nix/store/<hash>/bin/trezorctl version`