### PR TITLE
xmr: message changes optimizing runtime and memory

### DIFF
--- a/common/protob/messages-monero.proto
+++ b/common/protob/messages-monero.proto
@@ -19,6 +19,7 @@ message MoneroTransactionSourceEntry {
     optional bool rct = 7;  // is RingCT used (true for newer UTXOs)
     optional bytes mask = 8;
     optional MoneroMultisigKLRki multisig_kLRki = 9;
+    optional uint32 subaddr_minor = 10;  // minor subaddr index UTXO was sent to
     message MoneroOutputEntry {
         optional uint64 idx = 1;
         optional MoneroRctKeyPublic key = 2;
@@ -200,6 +201,7 @@ message MoneroTransactionInputViniRequest {
     optional bytes vini_hmac = 3;
     optional bytes pseudo_out = 4;
     optional bytes pseudo_out_hmac = 5;
+    optional uint32 orig_idx = 6;  // original sort index, before sorting by key-images
 }
 
 /**
@@ -289,6 +291,7 @@ message MoneroTransactionSignInputRequest {
     optional bytes pseudo_out_hmac = 5;
     optional bytes pseudo_out_alpha = 6;
     optional bytes spend_key = 7;
+    optional uint32 orig_idx = 8;  // original sort index, before sorting by key-images
 }
 
 /**
@@ -317,6 +320,7 @@ message MoneroTransactionFinalAck {
     optional bytes salt = 2;
     optional bytes rand_mult = 3;
     optional bytes tx_enc_keys = 4;
+    optional bytes opening_key = 5;  // enc master key to decrypt MLSAGs after protocol finishes correctly
 }
 
 /**

--- a/core/src/trezor/messages/MoneroTransactionFinalAck.py
+++ b/core/src/trezor/messages/MoneroTransactionFinalAck.py
@@ -19,11 +19,13 @@ class MoneroTransactionFinalAck(p.MessageType):
         salt: bytes = None,
         rand_mult: bytes = None,
         tx_enc_keys: bytes = None,
+        opening_key: bytes = None,
     ) -> None:
         self.cout_key = cout_key
         self.salt = salt
         self.rand_mult = rand_mult
         self.tx_enc_keys = tx_enc_keys
+        self.opening_key = opening_key
 
     @classmethod
     def get_fields(cls) -> Dict:
@@ -32,4 +34,5 @@ class MoneroTransactionFinalAck(p.MessageType):
             2: ('salt', p.BytesType, 0),
             3: ('rand_mult', p.BytesType, 0),
             4: ('tx_enc_keys', p.BytesType, 0),
+            5: ('opening_key', p.BytesType, 0),
         }

--- a/core/src/trezor/messages/MoneroTransactionInputViniRequest.py
+++ b/core/src/trezor/messages/MoneroTransactionInputViniRequest.py
@@ -22,12 +22,14 @@ class MoneroTransactionInputViniRequest(p.MessageType):
         vini_hmac: bytes = None,
         pseudo_out: bytes = None,
         pseudo_out_hmac: bytes = None,
+        orig_idx: int = None,
     ) -> None:
         self.src_entr = src_entr
         self.vini = vini
         self.vini_hmac = vini_hmac
         self.pseudo_out = pseudo_out
         self.pseudo_out_hmac = pseudo_out_hmac
+        self.orig_idx = orig_idx
 
     @classmethod
     def get_fields(cls) -> Dict:
@@ -37,4 +39,5 @@ class MoneroTransactionInputViniRequest(p.MessageType):
             3: ('vini_hmac', p.BytesType, 0),
             4: ('pseudo_out', p.BytesType, 0),
             5: ('pseudo_out_hmac', p.BytesType, 0),
+            6: ('orig_idx', p.UVarintType, 0),
         }

--- a/core/src/trezor/messages/MoneroTransactionSignInputRequest.py
+++ b/core/src/trezor/messages/MoneroTransactionSignInputRequest.py
@@ -24,6 +24,7 @@ class MoneroTransactionSignInputRequest(p.MessageType):
         pseudo_out_hmac: bytes = None,
         pseudo_out_alpha: bytes = None,
         spend_key: bytes = None,
+        orig_idx: int = None,
     ) -> None:
         self.src_entr = src_entr
         self.vini = vini
@@ -32,6 +33,7 @@ class MoneroTransactionSignInputRequest(p.MessageType):
         self.pseudo_out_hmac = pseudo_out_hmac
         self.pseudo_out_alpha = pseudo_out_alpha
         self.spend_key = spend_key
+        self.orig_idx = orig_idx
 
     @classmethod
     def get_fields(cls) -> Dict:
@@ -43,4 +45,5 @@ class MoneroTransactionSignInputRequest(p.MessageType):
             5: ('pseudo_out_hmac', p.BytesType, 0),
             6: ('pseudo_out_alpha', p.BytesType, 0),
             7: ('spend_key', p.BytesType, 0),
+            8: ('orig_idx', p.UVarintType, 0),
         }

--- a/core/src/trezor/messages/MoneroTransactionSourceEntry.py
+++ b/core/src/trezor/messages/MoneroTransactionSourceEntry.py
@@ -26,6 +26,7 @@ class MoneroTransactionSourceEntry(p.MessageType):
         rct: bool = None,
         mask: bytes = None,
         multisig_kLRki: MoneroMultisigKLRki = None,
+        subaddr_minor: int = None,
     ) -> None:
         self.outputs = outputs if outputs is not None else []
         self.real_output = real_output
@@ -36,6 +37,7 @@ class MoneroTransactionSourceEntry(p.MessageType):
         self.rct = rct
         self.mask = mask
         self.multisig_kLRki = multisig_kLRki
+        self.subaddr_minor = subaddr_minor
 
     @classmethod
     def get_fields(cls) -> Dict:
@@ -49,4 +51,5 @@ class MoneroTransactionSourceEntry(p.MessageType):
             7: ('rct', p.BoolType, 0),
             8: ('mask', p.BytesType, 0),
             9: ('multisig_kLRki', MoneroMultisigKLRki, 0),
+            10: ('subaddr_minor', p.UVarintType, 0),
         }

--- a/python/src/trezorlib/messages/MoneroTransactionFinalAck.py
+++ b/python/src/trezorlib/messages/MoneroTransactionFinalAck.py
@@ -19,11 +19,13 @@ class MoneroTransactionFinalAck(p.MessageType):
         salt: bytes = None,
         rand_mult: bytes = None,
         tx_enc_keys: bytes = None,
+        opening_key: bytes = None,
     ) -> None:
         self.cout_key = cout_key
         self.salt = salt
         self.rand_mult = rand_mult
         self.tx_enc_keys = tx_enc_keys
+        self.opening_key = opening_key
 
     @classmethod
     def get_fields(cls) -> Dict:
@@ -32,4 +34,5 @@ class MoneroTransactionFinalAck(p.MessageType):
             2: ('salt', p.BytesType, 0),
             3: ('rand_mult', p.BytesType, 0),
             4: ('tx_enc_keys', p.BytesType, 0),
+            5: ('opening_key', p.BytesType, 0),
         }

--- a/python/src/trezorlib/messages/MoneroTransactionInputViniRequest.py
+++ b/python/src/trezorlib/messages/MoneroTransactionInputViniRequest.py
@@ -22,12 +22,14 @@ class MoneroTransactionInputViniRequest(p.MessageType):
         vini_hmac: bytes = None,
         pseudo_out: bytes = None,
         pseudo_out_hmac: bytes = None,
+        orig_idx: int = None,
     ) -> None:
         self.src_entr = src_entr
         self.vini = vini
         self.vini_hmac = vini_hmac
         self.pseudo_out = pseudo_out
         self.pseudo_out_hmac = pseudo_out_hmac
+        self.orig_idx = orig_idx
 
     @classmethod
     def get_fields(cls) -> Dict:
@@ -37,4 +39,5 @@ class MoneroTransactionInputViniRequest(p.MessageType):
             3: ('vini_hmac', p.BytesType, 0),
             4: ('pseudo_out', p.BytesType, 0),
             5: ('pseudo_out_hmac', p.BytesType, 0),
+            6: ('orig_idx', p.UVarintType, 0),
         }

--- a/python/src/trezorlib/messages/MoneroTransactionSignInputRequest.py
+++ b/python/src/trezorlib/messages/MoneroTransactionSignInputRequest.py
@@ -24,6 +24,7 @@ class MoneroTransactionSignInputRequest(p.MessageType):
         pseudo_out_hmac: bytes = None,
         pseudo_out_alpha: bytes = None,
         spend_key: bytes = None,
+        orig_idx: int = None,
     ) -> None:
         self.src_entr = src_entr
         self.vini = vini
@@ -32,6 +33,7 @@ class MoneroTransactionSignInputRequest(p.MessageType):
         self.pseudo_out_hmac = pseudo_out_hmac
         self.pseudo_out_alpha = pseudo_out_alpha
         self.spend_key = spend_key
+        self.orig_idx = orig_idx
 
     @classmethod
     def get_fields(cls) -> Dict:
@@ -43,4 +45,5 @@ class MoneroTransactionSignInputRequest(p.MessageType):
             5: ('pseudo_out_hmac', p.BytesType, 0),
             6: ('pseudo_out_alpha', p.BytesType, 0),
             7: ('spend_key', p.BytesType, 0),
+            8: ('orig_idx', p.UVarintType, 0),
         }

--- a/python/src/trezorlib/messages/MoneroTransactionSourceEntry.py
+++ b/python/src/trezorlib/messages/MoneroTransactionSourceEntry.py
@@ -26,6 +26,7 @@ class MoneroTransactionSourceEntry(p.MessageType):
         rct: bool = None,
         mask: bytes = None,
         multisig_kLRki: MoneroMultisigKLRki = None,
+        subaddr_minor: int = None,
     ) -> None:
         self.outputs = outputs if outputs is not None else []
         self.real_output = real_output
@@ -36,6 +37,7 @@ class MoneroTransactionSourceEntry(p.MessageType):
         self.rct = rct
         self.mask = mask
         self.multisig_kLRki = multisig_kLRki
+        self.subaddr_minor = subaddr_minor
 
     @classmethod
     def get_fields(cls) -> Dict:
@@ -49,4 +51,5 @@ class MoneroTransactionSourceEntry(p.MessageType):
             7: ('rct', p.BoolType, 0),
             8: ('mask', p.BytesType, 0),
             9: ('multisig_kLRki', MoneroMultisigKLRki, 0),
+            10: ('subaddr_minor', p.UVarintType, 0),
         }


### PR DESCRIPTION
This change allows further improvements:

* *Subaddresses*: Do not compute subaddr array as it can grow as large as |UTXO|. 
    * Compute subaddr per UTXO as it now contains subaddr minor index (major is shared, sent in step 1). 
    * Step 2 recomputes subaddr and checks the keys. This saves UTXO-related memory (quite a lot).
    * If each UTXO is sent to a subaddr (preferred now), size savings are based on the UTXO size: `{4: 496B, 8: 994B, 16: 1856B, 32: 2712B, 64: 7360B, 128: 15008B}`
* *Decoy keys*: Sort UTXO ring on the host such that real key is always at 0 position. Randomize ring later in Trezor when doing MLSAG.
    * step 2 and 4 do not need decoys, mixin independent. faster comm, faster HMAC. 
    * decoys do not need to be HMACed, needed only in step 9, thus no need to commit to them. Increases mixin scalability. No message structure changes.
    * It's safer to randomize index in Trezor. However, attacker could still construct ring that leaks data without us noticing - cannot be prevented. 
    * Saves 3704B in the current setting (ring size 12), if mixin changes to 23, saving is 7768B
* Send only `real_out_additional_tx_keys[0]` which was previously `real_out_additional_tx_keys[real_output_in_tx_index]`, algorithm does not need other additional keys
    * faster comm, hmac, CPU savings (no decodings, derivations, ...)
* *Permutations*: Do not send permutation in step 3, not needed. Just check HMAC on input data & key image ordering. 
    * The ordering has to be strictly decreasing, no duplication. Thus check on a strict ordering + size check + hmac enforces the correctness of the permutation. No elements can be duplicated (strictness), added (hmac), or dropped (size).
    * Saves one comm round trip, and permutation storage space, based on UTXO numbers: `{8: 160B, 32: 544B, 64: 1056B, 128: 2080B}`.
    * Step9 - MLSAG returned encrypted in-place, enc-then-open mechanism. Step 10 returns encryption key once the protocol run was correct (not HMAC corruption). Required to ensure permutation correctness, increases overall security as full protocol completion is required to reveal the values. 
    * Key per mlsag: `H("mlsag-key" || master || index)`, IV: `H("mlsag-iv" || master || index)`. master key is returned in the final step if everything went OK.

This is a separate PR as I need the message changes first so I can adapt Monero code as well.

-------------
Savings computed as
```python
def sisub(N):
  return {(b'\x00'*30)+i.to_bytes(2,'big'): (1,i) for i in range(N)}

def sizesub(N):
  return sys.getsizeof(sisub(N)) + N*sys.getsizeof(bytes(bytearray32))) + N*sys.getsizeof((1,2)) + 2*sys.getsizeof(1)

def permsize(N):
  return sys.getsizeof(list(range(N))) + N*sys.getsizeof(N)

def ringsize(N):
  SIZE_MessageType = 32
  SIZE_MoneroRctKeyPublic = 64
  SIZE_MoneroOutputEntry = 64
  return sys.getsizeof(list(range(N))) + N*(SIZE_MoneroOutputEntry+ SIZE_MoneroRctKeyPublic+2* SIZE_MessageType + sys.getsizeof(1) + 2*sys.getsizeof(bytes(bytearray(32)))) 
```

Note: I had to add some missing functionality to Micropython for sys.getsizeof(), I may PR it as well if interested.