### PR TITLE
core/fido2: Check for HID timeout in send_cmd().

### DIFF
--- a/core/src/apps/webauthn/fido2.py
+++ b/core/src/apps/webauthn/fido2.py
@@ -477,7 +477,10 @@ async def send_cmd(cmd: Cmd, iface: io.HID) -> None:
         if copied < _FRAME_CONT_SIZE:
             frm.data[copied:] = bytearray(_FRAME_CONT_SIZE - copied)
         while True:
-            await write
+            ret = await loop.race(write, loop.sleep(_CTAP_HID_TIMEOUT_MS * 1000))
+            if ret is not None:
+                raise TimeoutError
+
             if iface.write(buf) > 0:
                 break
         seq += 1


### PR DESCRIPTION
Fixes FIDO2 Register screen freezes with no error message #790.