### PR TITLE
shell.nix: do not enforce purity

### DIFF
--- a/shell.nix
+++ b/shell.nix
@@ -38,6 +38,7 @@ stdenv.mkDerivation {
   ];
   LD_LIBRARY_PATH="${libffi}/lib:${libjpeg.out}/lib:${libusb1}/lib:${libressl.out}/lib";
   shellHook = ''
+    export NIX_ENFORCE_PURITY=0
     pipenv shell
     exit
   '';


### PR DESCRIPTION
Make sure we [allow the compiler to use vendored libraries](https://github.com/NixOS/nixpkgs/blob/master/pkgs/build-support/cc-wrapper/cc-wrapper.sh#L87) outside of the nix store. 

Fixes #793.
