### PR TITLE
Enable support for Unrecognized action types in Trezor EOS Module

### DIFF
--- a/core/src/apps/eos/actions/__init__.py
+++ b/core/src/apps/eos/actions/__init__.py
@@ -59,7 +59,7 @@ async def process_action(
             await layout.confirm_action_newaccount(ctx, action.new_account)
             writers.write_action_newaccount(w, action.new_account)
         else:
-            raise ValueError("Unrecognized action type for eosio")
+            await process_unknown_action(ctx, w, action)
     elif name == "transfer":
         await layout.confirm_action_transfer(ctx, action.transfer, account)
         writers.write_action_transfer(w, action.transfer)
@@ -100,6 +100,10 @@ async def process_unknown_action(
 
 
 def check_action(action: EosTxActionAck, name: str, account: str) -> bool:
+    # Unknown action
+    if action.unknown is not None:
+        return True
+
     if account == "eosio":
         if (
             (name == "buyram" and action.buy_ram is not None)
@@ -114,6 +118,7 @@ def check_action(action: EosTxActionAck, name: str, account: str) -> bool:
             or (name == "linkauth" and action.link_auth is not None)
             or (name == "unlinkauth" and action.unlink_auth is not None)
             or (name == "newaccount" and action.new_account is not None)
+            or (name == "newaccount" and action.new_account is not None)
         ):
             return True
         else:
@@ -121,8 +126,5 @@ def check_action(action: EosTxActionAck, name: str, account: str) -> bool:
 
     elif name == "transfer":
         return action.transfer is not None
-
-    elif action.unknown is not None:
-        return True
 
     return False

--- a/core/src/apps/eos/actions/__init__.py
+++ b/core/src/apps/eos/actions/__init__.py
@@ -118,7 +118,6 @@ def check_action(action: EosTxActionAck, name: str, account: str) -> bool:
             or (name == "linkauth" and action.link_auth is not None)
             or (name == "unlinkauth" and action.unlink_auth is not None)
             or (name == "newaccount" and action.new_account is not None)
-            or (name == "newaccount" and action.new_account is not None)
         ):
             return True
         else:

--- a/python/src/trezorlib/eos.py
+++ b/python/src/trezorlib/eos.py
@@ -282,6 +282,8 @@ def parse_action(action):
             tx_action.unlink_auth = parse_unlinkauth(data)
         elif action["name"] == "newaccount":
             tx_action.new_account = parse_new_account(data)
+        else:
+            tx_action.unknown = parse_unknown(data)
     elif action["name"] == "transfer":
         tx_action.transfer = parse_transfer(data)
     else:


### PR DESCRIPTION
This PR adds support for system eosio actions that are unsignable currently using Trezor. Users are currently not able to perform many actions across multiple EOSIO chains (EOS, WAX, Telos, BOS, Lynx, Worbli, Remme, etc).

Tested on Trezor emulator with trezord-go.

Will close https://github.com/trezor/connect/issues/443