### PR TITLE
Start backup mechanism after confirming the first screen

### DIFF
--- a/core/src/apps/management/backup_device.py
+++ b/core/src/apps/management/backup_device.py
@@ -15,10 +15,7 @@ async def backup_device(ctx, msg):
 
     mnemonic_secret, mnemonic_type = mnemonic.get()
 
-    storage.device.set_unfinished_backup(True)
-    storage.device.set_backed_up()
-
-    await backup_seed(ctx, mnemonic_type, mnemonic_secret)
+    await backup_seed(ctx, mnemonic_type, mnemonic_secret, delayed_backup=True)
 
     storage.device.set_unfinished_backup(False)
 

--- a/core/src/apps/management/reset_device/layout.py
+++ b/core/src/apps/management/reset_device/layout.py
@@ -1,5 +1,6 @@
 import ubinascii
 
+import storage.device
 from trezor import ui, utils
 from trezor.crypto import random
 from trezor.messages import BackupType, ButtonRequestType
@@ -269,9 +270,13 @@ async def show_backup_success(ctx):
 # ===
 
 
-async def bip39_show_and_confirm_mnemonic(ctx, mnemonic: str):
+async def bip39_show_and_confirm_mnemonic(ctx, mnemonic: str, delayed_backup=False):
     # warn user about mnemonic safety
     await show_backup_warning(ctx)
+
+    if delayed_backup:
+        storage.device.set_unfinished_backup(True)
+        storage.device.set_backed_up()
 
     words = mnemonic.split()
 


### PR DESCRIPTION
I did not like this at first (adding just an argument seems like a lazy solution), but maybe it is not that bad - it is quite clear and we might use `delayed_backup` flag at some point in future.

I also considered setting `storage.device.set_unfinished_backup(True)` for the "direct" backup as well. But the situation there is different as the mnemonic is stored *after* the backup is completed. If the Trezor would be disconnected, the flag would stay there and on the next intialization with a delayed backup it would forbid the backup right away. We would have to clear it during the next intialization I guess?

Closes #822.

cc @mroz22 FYI