### PR TITLE
do not send state in PassphraseAck

### DIFF
--- a/common/protob/messages-common.proto
+++ b/common/protob/messages-common.proto
@@ -120,7 +120,7 @@ message PassphraseRequest {
  */
 message PassphraseAck {
     optional string passphrase = 1;
-    optional bytes _state = 2 [deprecated=true];  // <2.3.0
+    // optional bytes state = 2;  DEPRECATED since 2.3.0
     optional bool on_device = 3;    // user wants to enter passphrase on the device
 }
 

--- a/core/src/trezor/messages/PassphraseAck.py
+++ b/core/src/trezor/messages/PassphraseAck.py
@@ -16,17 +16,14 @@ class PassphraseAck(p.MessageType):
     def __init__(
         self,
         passphrase: str = None,
-        _state: bytes = None,
         on_device: bool = None,
     ) -> None:
         self.passphrase = passphrase
-        self._state = _state
         self.on_device = on_device
 
     @classmethod
     def get_fields(cls) -> Dict:
         return {
             1: ('passphrase', p.UnicodeType, 0),
-            2: ('_state', p.BytesType, 0),
             3: ('on_device', p.BoolType, 0),
         }

--- a/legacy/firmware/protob/messages-common.options
+++ b/legacy/firmware/protob/messages-common.options
@@ -5,7 +5,6 @@ Failure.message                         max_size:256
 PinMatrixAck.pin                        max_size:10
 
 PassphraseAck.passphrase                max_size:51
-PassphraseAck._state                    max_size:32
 
 Deprecated_PassphraseStateRequest.state max_size:1
 

--- a/python/src/trezorlib/client.py
+++ b/python/src/trezorlib/client.py
@@ -187,9 +187,7 @@ class TrezorClient:
         available_on_device = Capability.PassphraseEntry in self.features.capabilities
 
         def send_passphrase(passphrase=None, on_device=None):
-            msg = messages.PassphraseAck(
-                _state=self.session_id, passphrase=passphrase, on_device=on_device
-            )
+            msg = messages.PassphraseAck(passphrase=passphrase, on_device=on_device)
             resp = self.call_raw(msg)
             if isinstance(resp, messages.Deprecated_PassphraseStateRequest):
                 self.session_id = resp.state

--- a/python/src/trezorlib/messages/PassphraseAck.py
+++ b/python/src/trezorlib/messages/PassphraseAck.py
@@ -16,17 +16,14 @@ class PassphraseAck(p.MessageType):
     def __init__(
         self,
         passphrase: str = None,
-        _state: bytes = None,
         on_device: bool = None,
     ) -> None:
         self.passphrase = passphrase
-        self._state = _state
         self.on_device = on_device
 
     @classmethod
     def get_fields(cls) -> Dict:
         return {
             1: ('passphrase', p.UnicodeType, 0),
-            2: ('_state', p.BytesType, 0),
             3: ('on_device', p.BoolType, 0),
         }

--- a/python/src/trezorlib/protobuf.py
+++ b/python/src/trezorlib/protobuf.py
@@ -161,7 +161,7 @@ class EnumType:
     def validate(self, fvalue: int) -> int:
         if fvalue not in self.enum_values:
             # raise TypeError("Invalid enum value")
-            LOG.warning("Value {} unknown for type {}".format(fvalue, self.enum_name))
+            LOG.info("Value {} unknown for type {}".format(fvalue, self.enum_name))
         return fvalue
 
     def to_str(self, fvalue: int) -> str:
@@ -485,7 +485,10 @@ def format_message(
             return "{} bytes {}{}".format(length, output, suffix)
 
         if isinstance(value, int) and isinstance(ftype, EnumType):
-            return "{} ({})".format(ftype.to_str(value), value)
+            try:
+                return "{} ({})".format(ftype.to_str(value), value)
+            except TypeError:
+                return str(value)
 
         return repr(value)
 
@@ -558,7 +561,10 @@ def to_dict(msg: MessageType, hexlify_bytes: bool = True) -> Dict[str, Any]:
         elif isinstance(value, list):
             return [convert_value(ftype, v) for v in value]
         elif isinstance(value, int) and isinstance(ftype, EnumType):
-            return ftype.to_str(value)
+            try:
+                return ftype.to_str(value)
+            except TypeError:
+                return value
         else:
             return value
 

--- a/python/tests/test_protobuf_encoding.py
+++ b/python/tests/test_protobuf_encoding.py
@@ -15,6 +15,7 @@
 # If not, see <https://www.gnu.org/licenses/lgpl-3.0.html>.
 
 from io import BytesIO
+import logging
 
 import pytest
 
@@ -137,6 +138,7 @@ def test_simple_message():
 
 
 def test_validate_enum(caplog):
+    caplog.set_level(logging.INFO)
     # round-trip of a valid value
     msg = EnumMessageMoreValues(enum=0)
     buf = BytesIO()
@@ -154,7 +156,7 @@ def test_validate_enum(caplog):
 
     assert len(caplog.records) == 1
     record = caplog.records.pop(0)
-    assert record.levelname == "WARNING"
+    assert record.levelname == "INFO"
     assert record.getMessage() == "Value 19 unknown for type t"
 
     msg.enum = 3
@@ -165,7 +167,7 @@ def test_validate_enum(caplog):
 
     assert len(caplog.records) == 1
     record = caplog.records.pop(0)
-    assert record.levelname == "WARNING"
+    assert record.levelname == "INFO"
     assert record.getMessage() == "Value 3 unknown for type t"
 
 
@@ -182,12 +184,14 @@ def test_repeated():
 
 
 def test_enum_in_repeated(caplog):
+    caplog.set_level(logging.INFO)
+
     msg = RepeatedFields(enumlist=[0, 1, 2, 3])
     buf = BytesIO()
     protobuf.dump_message(buf, msg)
     assert len(caplog.records) == 2
     for record in caplog.records:
-        assert record.levelname == "WARNING"
+        assert record.levelname == "INFO"
         assert "unknown for type t" in record.getMessage()
 
 

--- a/python/tests/test_protobuf_misc.py
+++ b/python/tests/test_protobuf_misc.py
@@ -216,3 +216,21 @@ def test_nested_recover():
     dictdata = {"nested": {}}
     recovered = protobuf.dict_to_proto(NestedMessage, dictdata)
     assert isinstance(recovered.nested, SimpleMessage)
+
+
+@with_simple_enum
+def test_unknown_enum_to_str():
+    simple = SimpleMessage(enum=SimpleEnum.QUUX)
+    string = protobuf.format_message(simple)
+    assert "enum: QUUX (13)" in string
+
+    simple = SimpleMessage(enum=6000)
+    string = protobuf.format_message(simple)
+    assert "enum: 6000" in string
+
+
+@with_simple_enum
+def test_unknown_enum_to_dict():
+    simple = SimpleMessage(enum=6000)
+    converted = protobuf.to_dict(simple)
+    assert converted["enum"] == 6000

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -35,8 +35,8 @@ def get_device():
         try:
             transport = get_transport(path)
             return TrezorClientDebugLink(transport, auto_interact=not interact)
-        except Exception:
-            pytest.exit("Failed to open debuglink for {}".format(path), 3)
+        except Exception as e:
+            raise RuntimeError("Failed to open debuglink for {}".format(path)) from e
 
     else:
         devices = enumerate_devices()
@@ -46,7 +46,7 @@ def get_device():
             except Exception:
                 pass
         else:
-            pytest.exit("No debuggable device found", 3)
+            raise RuntimeError("No debuggable device found")
 
 
 @pytest.fixture(scope="function")
@@ -73,6 +73,7 @@ def client(request):
     try:
         client = get_device()
     except RuntimeError:
+        request.session.shouldstop = "No debuggable Trezor is available"
         pytest.fail("No debuggable Trezor is available")
 
     if request.node.get_closest_marker("skip_t2") and client.features.model == "T":

--- a/tests/upgrade_tests/__init__.py
+++ b/tests/upgrade_tests/__init__.py
@@ -1,8 +1,24 @@
+# This file is part of the Trezor project.
+#
+# Copyright (C) 2012-2019 SatoshiLabs and contributors
+#
+# This library is free software: you can redistribute it and/or modify
+# it under the terms of the GNU Lesser General Public License version 3
+# as published by the Free Software Foundation.
+#
+# This library is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU Lesser General Public License for more details.
+#
+# You should have received a copy of the License along with this library.
+# If not, see <https://www.gnu.org/licenses/lgpl-3.0.html>.
+
 import os
 
 import pytest
 
-from ..emulators import LOCAL_BUILD_PATHS
+from ..emulators import ALL_TAGS, LOCAL_BUILD_PATHS
 
 SELECTED_GENS = [
     gen.strip() for gen in os.environ.get("TREZOR_UPGRADE_TEST", "").split(",") if gen
@@ -26,3 +42,54 @@ legacy_only = pytest.mark.skipif(
 core_only = pytest.mark.skipif(
     not CORE_ENABLED, reason="This test requires core emulator"
 )
+
+
+def for_all(*args, legacy_minimum_version=(1, 0, 0), core_minimum_version=(2, 0, 0)):
+    """Parametrizing decorator for test cases.
+
+    Usage example:
+
+    >>> @for_all()
+    >>> def test_runs_for_all_old_versions(gen, tag):
+    >>>     assert True
+
+    Arguments can be "core" and "legacy", and you can specify core_minimum_version and
+    legacy_minimum_version as triplets.
+
+    The test function should have arguments `gen` ("core" or "legacy") and `tag`
+    (version tag usable in EmulatorWrapper call)
+    """
+    if not args:
+        args = ("core", "legacy")
+
+    # If any gens were selected, use them. If none, select all.
+    enabled_gens = SELECTED_GENS or args
+
+    all_params = []
+    for gen in args:
+        if gen == "legacy":
+            minimum_version = legacy_minimum_version
+        elif gen == "core":
+            minimum_version = core_minimum_version
+        else:
+            raise ValueError
+
+        if gen not in enabled_gens:
+            continue
+        try:
+            for tag in ALL_TAGS[gen]:
+                if tag.startswith("v"):
+                    tag_version = tuple(int(n) for n in tag[1:].split("."))
+                    if tag_version < minimum_version:
+                        continue
+                all_params.append((gen, tag))
+
+            # at end, add None tag, which is the current master
+            all_params.append((gen, None))
+        except KeyError:
+            pass
+
+    if not all_params:
+        return pytest.mark.skip("no versions are applicable")
+
+    return pytest.mark.parametrize("gen, tag", all_params)

--- a/tests/upgrade_tests/test_firmware_upgrades.py
+++ b/tests/upgrade_tests/test_firmware_upgrades.py
@@ -14,8 +14,6 @@
 # You should have received a copy of the License along with this library.
 # If not, see <https://www.gnu.org/licenses/lgpl-3.0.html>.
 
-import pytest
-
 from trezorlib import MINIMUM_FIRMWARE_VERSION, btc, debuglink, device, fido
 from trezorlib.messages import BackupType
 from trezorlib.tools import H_
@@ -24,7 +22,7 @@ from ..click_tests import recovery
 from ..common import MNEMONIC_SLIP39_BASIC_20_3of6, MNEMONIC_SLIP39_BASIC_20_3of6_SECRET
 from ..device_handler import BackgroundDeviceHandler
 from ..emulators import ALL_TAGS, EmulatorWrapper
-from . import SELECTED_GENS
+from . import for_all
 
 MINIMUM_FIRMWARE_VERSION["1"] = (1, 0, 0)
 MINIMUM_FIRMWARE_VERSION["T"] = (2, 0, 0)
@@ -40,52 +38,16 @@ LANGUAGE = "en-US"
 STRENGTH = 128
 
 
-def for_all(*args, legacy_minimum_version=(1, 0, 0), core_minimum_version=(2, 0, 0)):
-    if not args:
-        args = ("core", "legacy")
-
-    # If any gens were selected, use them. If none, select all.
-    enabled_gens = SELECTED_GENS or args
-
-    all_params = []
-    for gen in args:
-        if gen == "legacy":
-            minimum_version = legacy_minimum_version
-        elif gen == "core":
-            minimum_version = core_minimum_version
-        else:
-            raise ValueError
-
-        if gen not in enabled_gens:
-            continue
-        try:
-            to_tag = None
-            from_tags = ALL_TAGS[gen] + [to_tag]
-            for from_tag in from_tags:
-                if from_tag is not None and from_tag.startswith("v"):
-                    tag_version = tuple(int(n) for n in from_tag[1:].split("."))
-                    if tag_version < minimum_version:
-                        continue
-                all_params.append((gen, from_tag, to_tag))
-        except KeyError:
-            pass
-
-    if not all_params:
-        return pytest.mark.skip("no versions are applicable")
-
-    return pytest.mark.parametrize("gen, from_tag, to_tag", all_params)
-
-
 @for_all()
-def test_upgrade_load(gen, from_tag, to_tag):
-    def asserts(tag, client):
+def test_upgrade_load(gen, tag):
+    def asserts(client):
         assert not client.features.pin_protection
         assert not client.features.passphrase_protection
         assert client.features.initialized
         assert client.features.label == LABEL
         assert btc.get_address(client, "Bitcoin", PATH) == ADDRESS
 
-    with EmulatorWrapper(gen, from_tag) as emu:
+    with EmulatorWrapper(gen, tag) as emu:
         debuglink.load_device_by_mnemonic(
             emu.client,
             mnemonic=MNEMONIC,
@@ -95,18 +57,18 @@ def test_upgrade_load(gen, from_tag, to_tag):
             language=LANGUAGE,
         )
         device_id = emu.client.features.device_id
-        asserts(from_tag, emu.client)
+        asserts(emu.client)
         storage = emu.get_storage()
 
-    with EmulatorWrapper(gen, to_tag, storage=storage) as emu:
+    with EmulatorWrapper(gen, storage=storage) as emu:
         assert device_id == emu.client.features.device_id
-        asserts(to_tag, emu.client)
+        asserts(emu.client)
         assert emu.client.features.language == LANGUAGE
 
 
 @for_all("legacy")
-def test_upgrade_reset(gen, from_tag, to_tag):
-    def asserts(tag, client):
+def test_upgrade_reset(gen, tag):
+    def asserts(client):
         assert not client.features.pin_protection
         assert not client.features.passphrase_protection
         assert client.features.initialized
@@ -115,7 +77,7 @@ def test_upgrade_reset(gen, from_tag, to_tag):
         assert not client.features.unfinished_backup
         assert not client.features.no_backup
 
-    with EmulatorWrapper(gen, from_tag) as emu:
+    with EmulatorWrapper(gen, tag) as emu:
         device.reset(
             emu.client,
             display_random=False,
@@ -126,20 +88,20 @@ def test_upgrade_reset(gen, from_tag, to_tag):
             language=LANGUAGE,
         )
         device_id = emu.client.features.device_id
-        asserts(from_tag, emu.client)
+        asserts(emu.client)
         address = btc.get_address(emu.client, "Bitcoin", PATH)
         storage = emu.get_storage()
 
-    with EmulatorWrapper(gen, to_tag, storage=storage) as emu:
+    with EmulatorWrapper(gen, storage=storage) as emu:
         assert device_id == emu.client.features.device_id
-        asserts(to_tag, emu.client)
+        asserts(emu.client)
         assert emu.client.features.language == LANGUAGE
         assert btc.get_address(emu.client, "Bitcoin", PATH) == address
 
 
 @for_all()
-def test_upgrade_reset_skip_backup(gen, from_tag, to_tag):
-    def asserts(tag, client):
+def test_upgrade_reset_skip_backup(gen, tag):
+    def asserts(client):
         assert not client.features.pin_protection
         assert not client.features.passphrase_protection
         assert client.features.initialized
@@ -148,7 +110,7 @@ def test_upgrade_reset_skip_backup(gen, from_tag, to_tag):
         assert not client.features.unfinished_backup
         assert not client.features.no_backup
 
-    with EmulatorWrapper(gen, from_tag) as emu:
+    with EmulatorWrapper(gen, tag) as emu:
         device.reset(
             emu.client,
             display_random=False,
@@ -160,20 +122,20 @@ def test_upgrade_reset_skip_backup(gen, from_tag, to_tag):
             skip_backup=True,
         )
         device_id = emu.client.features.device_id
-        asserts(from_tag, emu.client)
+        asserts(emu.client)
         address = btc.get_address(emu.client, "Bitcoin", PATH)
         storage = emu.get_storage()
 
-    with EmulatorWrapper(gen, to_tag, storage=storage) as emu:
+    with EmulatorWrapper(gen, storage=storage) as emu:
         assert device_id == emu.client.features.device_id
-        asserts(to_tag, emu.client)
+        asserts(emu.client)
         assert emu.client.features.language == LANGUAGE
         assert btc.get_address(emu.client, "Bitcoin", PATH) == address
 
 
 @for_all(legacy_minimum_version=(1, 7, 2))
-def test_upgrade_reset_no_backup(gen, from_tag, to_tag):
-    def asserts(tag, client):
+def test_upgrade_reset_no_backup(gen, tag):
+    def asserts(client):
         assert not client.features.pin_protection
         assert not client.features.passphrase_protection
         assert client.features.initialized
@@ -182,7 +144,7 @@ def test_upgrade_reset_no_backup(gen, from_tag, to_tag):
         assert not client.features.unfinished_backup
         assert client.features.no_backup
 
-    with EmulatorWrapper(gen, from_tag) as emu:
+    with EmulatorWrapper(gen, tag) as emu:
         device.reset(
             emu.client,
             display_random=False,
@@ -194,21 +156,21 @@ def test_upgrade_reset_no_backup(gen, from_tag, to_tag):
             no_backup=True,
         )
         device_id = emu.client.features.device_id
-        asserts(from_tag, emu.client)
+        asserts(emu.client)
         address = btc.get_address(emu.client, "Bitcoin", PATH)
         storage = emu.get_storage()
 
-    with EmulatorWrapper(gen, to_tag, storage=storage) as emu:
+    with EmulatorWrapper(gen, storage=storage) as emu:
         assert device_id == emu.client.features.device_id
-        asserts(to_tag, emu.client)
+        asserts(emu.client)
         assert emu.client.features.language == LANGUAGE
         assert btc.get_address(emu.client, "Bitcoin", PATH) == address
 
 
 # Although Shamir was introduced in 2.1.2 already, the debug instrumentation was not present until 2.1.9.
 @for_all("core", core_minimum_version=(2, 1, 9))
-def test_upgrade_shamir_recovery(gen, from_tag, to_tag):
-    with EmulatorWrapper(gen, from_tag) as emu, BackgroundDeviceHandler(
+def test_upgrade_shamir_recovery(gen, tag):
+    with EmulatorWrapper(gen, tag) as emu, BackgroundDeviceHandler(
         emu.client
     ) as device_handler:
         assert emu.client.features.recovery_mode is False
@@ -225,12 +187,10 @@ def test_upgrade_shamir_recovery(gen, from_tag, to_tag):
         storage = emu.get_storage()
         device_handler.check_finalize()
 
-    with EmulatorWrapper(gen, to_tag, storage=storage) as emu, BackgroundDeviceHandler(
-        emu.client
-    ) as device_handler:
+    with EmulatorWrapper(gen, storage=storage) as emu:
         assert device_id == emu.client.features.device_id
         assert emu.client.features.recovery_mode
-        debug = device_handler.debuglink()
+        debug = emu.client.debug
 
         # second share
         layout = recovery.enter_share(debug, MNEMONIC_SLIP39_BASIC_20_3of6[2])
@@ -244,15 +204,12 @@ def test_upgrade_shamir_recovery(gen, from_tag, to_tag):
         state = debug.state()
         assert state.mnemonic_secret.hex() == MNEMONIC_SLIP39_BASIC_20_3of6_SECRET
         assert state.mnemonic_type == BackupType.Slip39_Basic
-        device_handler.check_finalize()
 
 
 @for_all(legacy_minimum_version=(1, 8, 4), core_minimum_version=(2, 1, 9))
-def test_upgrade_u2f(gen, from_tag, to_tag):
-    """
-    Check U2F counter stayed the same after an upgrade.
-    """
-    with EmulatorWrapper(gen, from_tag) as emu:
+def test_upgrade_u2f(gen, tag):
+    """Check U2F counter stayed the same after an upgrade."""
+    with EmulatorWrapper(gen, tag) as emu:
         success = fido.set_counter(emu.client, 10)
         assert "U2F counter set" in success
 
@@ -260,7 +217,7 @@ def test_upgrade_u2f(gen, from_tag, to_tag):
         assert counter == 11
         storage = emu.get_storage()
 
-    with EmulatorWrapper(gen, to_tag, storage=storage) as emu:
+    with EmulatorWrapper(gen, storage=storage) as emu:
         counter = fido.get_next_counter(emu.client)
         assert counter == 12
 

--- a/tests/upgrade_tests/test_passphrase_consistency.py
+++ b/tests/upgrade_tests/test_passphrase_consistency.py
@@ -1,0 +1,116 @@
+# This file is part of the Trezor project.
+#
+# Copyright (C) 2012-2019 SatoshiLabs and contributors
+#
+# This library is free software: you can redistribute it and/or modify
+# it under the terms of the GNU Lesser General Public License version 3
+# as published by the Free Software Foundation.
+#
+# This library is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU Lesser General Public License for more details.
+#
+# You should have received a copy of the License along with this library.
+# If not, see <https://www.gnu.org/licenses/lgpl-3.0.html>.
+
+import pytest
+
+from trezorlib import MINIMUM_FIRMWARE_VERSION, btc, device, mapping, messages, protobuf
+from trezorlib.tools import parse_path
+
+from ..emulators import EmulatorWrapper
+from . import for_all
+
+SOURCE_ASK = 0
+SOURCE_DEVICE = 1
+SOURCE_HOST = 2
+
+
+class ApplySettingsCompat(protobuf.MessageType):
+    MESSAGE_WIRE_TYPE = 25
+
+    @classmethod
+    def get_fields(cls):
+        return {
+            3: ("use_passphrase", protobuf.BoolType, 0),
+            5: ("passphrase_source", protobuf.UVarintType, 0),
+        }
+
+
+mapping.map_class_to_type[ApplySettingsCompat] = ApplySettingsCompat.MESSAGE_WIRE_TYPE
+
+
+@pytest.fixture
+def emulator(gen, tag):
+    with EmulatorWrapper(gen, tag) as emu:
+        # set up a passphrase-protected device
+        device.reset(
+            emu.client, pin_protection=False, skip_backup=True,
+        )
+        resp = emu.client.call(
+            ApplySettingsCompat(use_passphrase=True, passphrase_source=SOURCE_HOST)
+        )
+        assert isinstance(resp, messages.Success)
+
+        yield emu
+
+
+@for_all(
+    core_minimum_version=MINIMUM_FIRMWARE_VERSION["T"],
+    legacy_minimum_version=MINIMUM_FIRMWARE_VERSION["1"],
+)
+def test_passphrase_works(emulator):
+    """Check that passphrase handling in trezorlib works correctly in all versions."""
+    if emulator.client.features.model == "T" and emulator.client.version < (2, 3, 0):
+        expected_responses = [
+            messages.PassphraseRequest(),
+            messages.Deprecated_PassphraseStateRequest(),
+            messages.Address(),
+        ]
+    else:
+        expected_responses = [
+            messages.PassphraseRequest(),
+            messages.Address(),
+        ]
+
+    with emulator.client:
+        emulator.client.use_passphrase("TREZOR")
+        emulator.client.set_expected_responses(expected_responses)
+        btc.get_address(emulator.client, "Testnet", parse_path("44h/1h/0h/0/0"))
+
+
+@for_all(
+    core_minimum_version=MINIMUM_FIRMWARE_VERSION["T"],
+    legacy_minimum_version=(1, 9, 0),
+)
+def test_init_device(emulator):
+    """Check that passphrase caching and session_id retaining works correctly across
+    supported versions.
+    """
+    if emulator.client.features.model == "T" and emulator.client.version < (2, 3, 0):
+        expected_responses = [
+            messages.PassphraseRequest(),
+            messages.Deprecated_PassphraseStateRequest(),
+            messages.Address(),
+            messages.Features(),
+            messages.Address(),
+        ]
+    else:
+        expected_responses = [
+            messages.PassphraseRequest(),
+            messages.Address(),
+            messages.Features(),
+            messages.Address(),
+        ]
+
+    with emulator.client:
+        emulator.client.use_passphrase("TREZOR")
+        emulator.client.set_expected_responses(expected_responses)
+
+        btc.get_address(emulator.client, "Testnet", parse_path("44h/1h/0h/0/0"))
+        # in TT < 2.3.0 session_id will only be available after PassphraseStateRequest
+        session_id = emulator.client.session_id
+        emulator.client.init_device()
+        btc.get_address(emulator.client, "Testnet", parse_path("44h/1h/0h/0/0"))
+        assert session_id == emulator.client.session_id


### PR DESCRIPTION
This removes the `state` field from PassphraseAck, which is not needed for backwards-compatibility after all. The removal fixes legacy CI failure in master.

Also adding an upgrade-test for the trezorlib "retain passphrased session" feature.

Unrelated, the fix for #832 is included, because as it turns out the same code caused problems when testing on old emulators.