### PR TITLE
core/monero: add confirmation dialog for unlock_time

### DIFF
--- a/core/src/apps/lisk/layout.py
+++ b/core/src/apps/lisk/layout.py
@@ -15,7 +15,7 @@ async def require_confirm_tx(ctx, to, value):
     text.bold(format_coin_amount(value))
     text.normal("to")
     text.mono(*split_address(to))
-    return await require_confirm(ctx, text, ButtonRequestType.SignTx)
+    await require_confirm(ctx, text, ButtonRequestType.SignTx)
 
 
 async def require_confirm_delegate_registration(ctx, delegate_name):
@@ -23,13 +23,13 @@ async def require_confirm_delegate_registration(ctx, delegate_name):
     text.normal("Do you really want to")
     text.normal("register a delegate?")
     text.bold(*chunks(delegate_name, 20))
-    return await require_confirm(ctx, text, ButtonRequestType.SignTx)
+    await require_confirm(ctx, text, ButtonRequestType.SignTx)
 
 
 async def require_confirm_vote_tx(ctx, votes):
     text = Text("Confirm transaction", ui.ICON_SEND, ui.GREEN)
     text.normal(*get_vote_tx_text(votes))
-    return await require_confirm(ctx, text, ButtonRequestType.SignTx)
+    await require_confirm(ctx, text, ButtonRequestType.SignTx)
 
 
 async def require_confirm_public_key(ctx, public_key):
@@ -41,7 +41,7 @@ async def require_confirm_multisig(ctx, multisignature):
     text.normal("Keys group length: %s" % len(multisignature.keys_group))
     text.normal("Life time: %s" % multisignature.life_time)
     text.normal("Min: %s" % multisignature.min)
-    return await require_confirm(ctx, text, ButtonRequestType.SignTx)
+    await require_confirm(ctx, text, ButtonRequestType.SignTx)
 
 
 async def require_confirm_fee(ctx, value, fee):

--- a/core/src/apps/monero/layout/confirms.py
+++ b/core/src/apps/monero/layout/confirms.py
@@ -15,19 +15,19 @@ DUMMY_PAYMENT_ID = b"\x00" * 8
 async def require_confirm_watchkey(ctx):
     content = Text("Confirm export", ui.ICON_SEND, ui.GREEN)
     content.normal("Do you really want to", "export watch-only", "credentials?")
-    return await require_confirm(ctx, content, ButtonRequestType.SignTx)
+    await require_confirm(ctx, content, ButtonRequestType.SignTx)
 
 
 async def require_confirm_keyimage_sync(ctx):
     content = Text("Confirm ki sync", ui.ICON_SEND, ui.GREEN)
     content.normal("Do you really want to", "sync key images?")
-    return await require_confirm(ctx, content, ButtonRequestType.SignTx)
+    await require_confirm(ctx, content, ButtonRequestType.SignTx)
 
 
 async def require_confirm_live_refresh(ctx):
     content = Text("Confirm refresh", ui.ICON_SEND, ui.GREEN)
     content.normal("Do you really want to", "start refresh?")
-    return await require_confirm(ctx, content, ButtonRequestType.SignTx)
+    await require_confirm(ctx, content, ButtonRequestType.SignTx)
 
 
 async def require_confirm_tx_key(ctx, export_key=False):
@@ -40,7 +40,7 @@ async def require_confirm_tx_key(ctx, export_key=False):
         txt.append("for tx_proof?")
 
     content.normal(*txt)
-    return await require_confirm(ctx, content, ButtonRequestType.SignTx)
+    await require_confirm(ctx, content, ButtonRequestType.SignTx)
 
 
 async def require_confirm_transaction(ctx, state, tsx_data, network_type):

--- a/core/src/apps/monero/layout/confirms.py
+++ b/core/src/apps/monero/layout/confirms.py
@@ -54,6 +54,9 @@ async def require_confirm_transaction(ctx, state, tsx_data, network_type):
     has_integrated = bool(tsx_data.integrated_indices)
     has_payment = bool(tsx_data.payment_id)
 
+    if tsx_data.unlock_time != 0:
+        await _require_confirm_unlock_time(ctx, tsx_data.unlock_time)
+
     for idx, dst in enumerate(outputs):
         is_change = change_idx is not None and idx == change_idx
         if is_change:
@@ -115,6 +118,14 @@ async def _require_confirm_fee(ctx, fee):
     content = Text("Confirm fee", ui.ICON_SEND, ui.GREEN)
     content.bold(common.format_amount(fee))
     await require_hold_to_confirm(ctx, content, ButtonRequestType.ConfirmOutput)
+
+
+async def _require_confirm_unlock_time(ctx, unlock_time):
+    content = Text("Confirm unlock time", ui.ICON_SEND, ui.GREEN)
+    content.normal("Unlock time for this transaction is set to")
+    content.bold(str(unlock_time))
+    content.normal("Continue?")
+    await require_confirm(ctx, content, ButtonRequestType.SignTx)
 
 
 class TransactionStep(ui.Component):

--- a/core/src/apps/ripple/layout.py
+++ b/core/src/apps/ripple/layout.py
@@ -24,9 +24,8 @@ async def require_confirm_destination_tag(ctx, tag):
 
 
 async def require_confirm_tx(ctx, to, value):
-
     text = Text("Confirm sending", ui.ICON_SEND, ui.GREEN)
     text.bold(format_amount(value, helpers.DECIMALS) + " XRP")
     text.normal("to")
     text.mono(*split_address(to))
-    return await require_hold_to_confirm(ctx, text, ButtonRequestType.SignTx)
+    await require_hold_to_confirm(ctx, text, ButtonRequestType.SignTx)

--- a/core/src/apps/tezos/get_public_key.py
+++ b/core/src/apps/tezos/get_public_key.py
@@ -28,4 +28,4 @@ async def _show_tezos_pubkey(ctx, pubkey):
     lines = chunks(pubkey, 18)
     text = Text("Confirm public key", ui.ICON_RECEIVE, ui.GREEN)
     text.mono(*lines)
-    return await require_confirm(ctx, text, code=ButtonRequestType.PublicKey)
+    await require_confirm(ctx, text, code=ButtonRequestType.PublicKey)

--- a/core/src/apps/tezos/layout.py
+++ b/core/src/apps/tezos/layout.py
@@ -14,7 +14,7 @@ async def require_confirm_tx(ctx, to, value):
     text.bold(format_tezos_amount(value))
     text.normal("to")
     text.mono(*split_address(to))
-    return await require_confirm(ctx, text, ButtonRequestType.SignTx)
+    await require_confirm(ctx, text, ButtonRequestType.SignTx)
 
 
 async def require_confirm_fee(ctx, value, fee):
@@ -30,7 +30,7 @@ async def require_confirm_origination(ctx, address):
     text = Text("Confirm origination", ui.ICON_SEND, ui.ORANGE)
     text.normal("Address:")
     text.mono(*split_address(address))
-    return await require_confirm(ctx, text, ButtonRequestType.SignTx)
+    await require_confirm(ctx, text, ButtonRequestType.SignTx)
 
 
 async def require_confirm_origination_fee(ctx, balance, fee):
@@ -46,7 +46,7 @@ async def require_confirm_delegation_baker(ctx, baker):
     text = Text("Confirm delegation", ui.ICON_SEND, ui.BLUE)
     text.normal("Baker address:")
     text.mono(*split_address(baker))
-    return await require_confirm(ctx, text, ButtonRequestType.SignTx)
+    await require_confirm(ctx, text, ButtonRequestType.SignTx)
 
 
 async def require_confirm_set_delegate(ctx, fee):


### PR DESCRIPTION
This changeset also includes fix where `await require_confirm` was called with superfluous `return`
