### PR TITLE
core/bootloader: split long vendor string

### DIFF
--- a/core/embed/bootloader/bootui.c
+++ b/core/embed/bootloader/bootui.c
@@ -144,6 +144,23 @@ void ui_screen_third(void) {
 
 // info UI
 
+static int display_vendor_string(const char *text, int textlen,
+                                 uint16_t fgcolor) {
+  int split = display_text_split(text, textlen, FONT_NORMAL, DISPLAY_RESX - 55);
+  if (split >= textlen) {
+    display_text(55, 95, text, textlen, FONT_NORMAL, fgcolor, COLOR_WHITE);
+    return 120;
+  } else {
+    display_text(55, 95, text, split, FONT_NORMAL, fgcolor, COLOR_WHITE);
+    if (text[split] == ' ') {
+      split++;
+    }
+    display_text(55, 120, text + split, textlen - split, FONT_NORMAL, fgcolor,
+                 COLOR_WHITE);
+    return 145;
+  }
+}
+
 void ui_screen_info(secbool buttons, const vendor_header *const vhdr,
                     const image_header *const hdr) {
   display_bar(0, 0, DISPLAY_RESX, DISPLAY_RESY, COLOR_WHITE);
@@ -153,11 +170,9 @@ void ui_screen_info(secbool buttons, const vendor_header *const vhdr,
   display_icon(16, 54, 32, 32, toi_icon_info + 12, sizeof(toi_icon_info) - 12,
                COLOR_BL_GRAY, COLOR_WHITE);
   if (vhdr && hdr) {
-    ver_str = format_ver("Firmware %d.%d.%d", (hdr->version));
+    ver_str = format_ver("Firmware %d.%d.%d by", (hdr->version));
     display_text(55, 70, ver_str, -1, FONT_NORMAL, COLOR_BL_GRAY, COLOR_WHITE);
-    display_text(55, 95, "by", -1, FONT_NORMAL, COLOR_BL_GRAY, COLOR_WHITE);
-    display_text(55, 120, vhdr->vstr, vhdr->vstr_len, FONT_NORMAL,
-                 COLOR_BL_GRAY, COLOR_WHITE);
+    display_vendor_string(vhdr->vstr, vhdr->vstr_len, COLOR_BL_GRAY);
   } else {
     display_text(55, 70, "No Firmware", -1, FONT_NORMAL, COLOR_BL_GRAY,
                  COLOR_WHITE);
@@ -208,10 +223,9 @@ void ui_screen_install_confirm_upgrade(const vendor_header *const vhdr,
                COLOR_BLACK, COLOR_WHITE);
   display_text(55, 70, "Update firmware by", -1, FONT_NORMAL, COLOR_BLACK,
                COLOR_WHITE);
-  display_text(55, 95, vhdr->vstr, vhdr->vstr_len, FONT_NORMAL, COLOR_BLACK,
-               COLOR_WHITE);
+  int next_y = display_vendor_string(vhdr->vstr, vhdr->vstr_len, COLOR_BLACK);
   const char *ver_str = format_ver("to version %d.%d.%d?", hdr->version);
-  display_text(55, 120, ver_str, -1, FONT_NORMAL, COLOR_BLACK, COLOR_WHITE);
+  display_text(55, next_y, ver_str, -1, FONT_NORMAL, COLOR_BLACK, COLOR_WHITE);
   ui_confirm_cancel_buttons();
 }
 
@@ -225,10 +239,9 @@ void ui_screen_install_confirm_newvendor(const vendor_header *const vhdr,
                COLOR_BLACK, COLOR_WHITE);
   display_text(55, 70, "Install firmware by", -1, FONT_NORMAL, COLOR_BLACK,
                COLOR_WHITE);
-  display_text(55, 95, vhdr->vstr, vhdr->vstr_len, FONT_NORMAL, COLOR_BLACK,
-               COLOR_WHITE);
+  int next_y = display_vendor_string(vhdr->vstr, vhdr->vstr_len, COLOR_BLACK);
   const char *ver_str = format_ver("(version %d.%d.%d)?", hdr->version);
-  display_text(55, 120, ver_str, -1, FONT_NORMAL, COLOR_BLACK, COLOR_WHITE);
+  display_text(55, next_y, ver_str, -1, FONT_NORMAL, COLOR_BLACK, COLOR_WHITE);
   display_text_center(120, 170, "Seed will be erased!", -1, FONT_NORMAL,
                       COLOR_BL_FAIL, COLOR_WHITE);
   ui_confirm_cancel_buttons();

--- a/core/embed/extmod/modtrezorui/display.c
+++ b/core/embed/extmod/modtrezorui/display.c
@@ -692,6 +692,37 @@ int display_text_width(const char *text, int textlen, int font) {
   return width;
 }
 
+// Returns how many characters of the string can be used before exceeding
+// the requested width. Tries to avoid breaking words if possible.
+int display_text_split(const char *text, int textlen, int font,
+                       int requested_width) {
+  int width = 0;
+  int lastspace = 0;
+#if TREZOR_MODEL == T
+  // determine text length if not provided
+  if (textlen < 0) {
+    textlen = strlen(text);
+  }
+  for (int i = 0; i < textlen; i++) {
+    if (text[i] == ' ') {
+      lastspace = i;
+    }
+    const uint8_t *g = get_glyph(font, (uint8_t)text[i]);
+    if (!g) continue;
+    const uint8_t adv = g[2];  // advance
+    width += adv;
+    if (width > requested_width) {
+      if (lastspace > 0) {
+        return lastspace;
+      } else {
+        return i;
+      }
+    }
+  }
+#endif
+  return textlen;
+}
+
 #define QR_MAX_VERSION 9
 
 void display_qrcode(int x, int y, const char *data, uint32_t datalen,

--- a/core/embed/extmod/modtrezorui/display.h
+++ b/core/embed/extmod/modtrezorui/display.h
@@ -103,6 +103,8 @@ void display_text_center(int x, int y, const char *text, int textlen, int font,
 void display_text_right(int x, int y, const char *text, int textlen, int font,
                         uint16_t fgcolor, uint16_t bgcolor);
 int display_text_width(const char *text, int textlen, int font);
+int display_text_split(const char *text, int textlen, int font,
+                       int requested_width);
 
 void display_qrcode(int x, int y, const char *data, uint32_t datalen,
                     uint8_t scale);

--- a/core/embed/extmod/modtrezorui/modtrezorui-display.h
+++ b/core/embed/extmod/modtrezorui/modtrezorui-display.h
@@ -414,6 +414,25 @@ STATIC mp_obj_t mod_trezorui_Display_text_width(mp_obj_t self, mp_obj_t text,
 STATIC MP_DEFINE_CONST_FUN_OBJ_3(mod_trezorui_Display_text_width_obj,
                                  mod_trezorui_Display_text_width);
 
+/// def text_split(self, text: str, font: int, requested_width: int) -> int:
+///     """
+///     Returns how many characters of the string can be used before exceeding
+///     the requested width. Tries to avoid breaking words if possible. Font
+///     font is used for rendering.
+///     """
+STATIC mp_obj_t mod_trezorui_Display_text_split(size_t n_args,
+                                                const mp_obj_t *args) {
+  mp_buffer_info_t text;
+  mp_get_buffer_raise(args[1], &text, MP_BUFFER_READ);
+  mp_int_t font = mp_obj_get_int(args[2]);
+  mp_int_t requested_width = mp_obj_get_int(args[3]);
+  int chars = display_text_split(text.buf, text.len, font, requested_width);
+  return mp_obj_new_int(chars);
+}
+STATIC MP_DEFINE_CONST_FUN_OBJ_VAR_BETWEEN(mod_trezorui_Display_text_split_obj,
+                                           4, 4,
+                                           mod_trezorui_Display_text_split);
+
 /// def qrcode(self, x: int, y: int, data: bytes, scale: int) -> None:
 ///     """
 ///     Renders data encoded as a QR code centered at position (x,y).
@@ -563,6 +582,8 @@ STATIC const mp_rom_map_elem_t mod_trezorui_Display_locals_dict_table[] = {
      MP_ROM_PTR(&mod_trezorui_Display_text_right_obj)},
     {MP_ROM_QSTR(MP_QSTR_text_width),
      MP_ROM_PTR(&mod_trezorui_Display_text_width_obj)},
+    {MP_ROM_QSTR(MP_QSTR_text_split),
+     MP_ROM_PTR(&mod_trezorui_Display_text_split_obj)},
     {MP_ROM_QSTR(MP_QSTR_qrcode), MP_ROM_PTR(&mod_trezorui_Display_qrcode_obj)},
     {MP_ROM_QSTR(MP_QSTR_orientation),
      MP_ROM_PTR(&mod_trezorui_Display_orientation_obj)},

--- a/core/mocks/generated/trezorui.pyi
+++ b/core/mocks/generated/trezorui.pyi
@@ -157,6 +157,13 @@ class Display:
         Returns a width of text in pixels. Font font is used for rendering.
         """
 
+    def text_split(self, text: str, font: int, requested_width: int) -> int:
+        """
+        Returns how many characters of the string can be used before exceeding
+        the requested width. Tries to avoid breaking words if possible. Font
+        font is used for rendering.
+        """
+
     def qrcode(self, x: int, y: int, data: bytes, scale: int) -> None:
         """
         Renders data encoded as a QR code centered at position (x,y).


### PR DESCRIPTION
Fixes https://github.com/trezor/trezor-firmware/issues/36