### PR TITLE
Use wire errors where applicable

### DIFF
--- a/core/src/apps/binance/sign_tx.py
+++ b/core/src/apps/binance/sign_tx.py
@@ -1,3 +1,4 @@
+from trezor import wire
 from trezor.crypto.curve import secp256k1
 from trezor.crypto.hashlib import sha256
 from trezor.messages import MessageType
@@ -14,7 +15,7 @@ from apps.common import paths
 async def sign_tx(ctx, envelope, keychain):
     # create transaction message -> sign it -> create signature/pubkey message -> serialize all
     if envelope.msg_count > 1:
-        raise ValueError("Multiple messages not supported")
+        raise wire.DataError("Multiple messages not supported.")
     await paths.validate_path(
         ctx, helpers.validate_full_path, keychain, envelope.address_n, CURVE
     )
@@ -29,6 +30,9 @@ async def sign_tx(ctx, envelope, keychain):
         MessageType.BinanceOrderMsg,
         MessageType.BinanceTransferMsg,
     )
+
+    if envelope.source is None or envelope.source < 0:
+        raise wire.DataError("Source missing or invalid.")
 
     msg_json = helpers.produce_json_for_signing(envelope, msg)
 

--- a/core/src/apps/common/address_type.py
+++ b/core/src/apps/common/address_type.py
@@ -1,8 +1,3 @@
-if False:
-    from typing import Tuple
-    from apps.common.coininfo import CoinType
-
-
 def length(address_type: int) -> int:
     if address_type <= 0xFF:
         return 1
@@ -24,19 +19,5 @@ def check(address_type: int, raw_address: bytes) -> bool:
 
 def strip(address_type: int, raw_address: bytes) -> bytes:
     if not check(address_type, raw_address):
-        raise ValueError("Invalid address")
+        raise ValueError
     return raw_address[length(address_type) :]
-
-
-def split(coin: CoinType, raw_address: bytes) -> Tuple[bytes, bytes]:
-    for f in (
-        "address_type",
-        "address_type_p2sh",
-        "address_type_p2wpkh",
-        "address_type_p2wsh",
-    ):
-        at = getattr(coin, f)
-        if at is not None and check(at, raw_address):
-            l = length(at)
-            return raw_address[:l], raw_address[l:]
-    raise ValueError("Invalid address")

--- a/core/src/apps/debug/load_device.py
+++ b/core/src/apps/debug/load_device.py
@@ -33,7 +33,7 @@ async def load_device(ctx, msg):
         elif share.group_count > 1:
             backup_type = BackupType.Slip39_Advanced
         else:
-            raise RuntimeError("Invalid group count")
+            raise wire.ProcessError("Invalid group count")
 
         storage.device.set_slip39_identifier(identifier)
         storage.device.set_slip39_iteration_exponent(iteration_exponent)

--- a/core/src/apps/nem/sign_tx.py
+++ b/core/src/apps/nem/sign_tx.py
@@ -1,3 +1,4 @@
+from trezor import wire
 from trezor.crypto.curve import ed25519
 from trezor.messages.NEMSignedTx import NEMSignedTx
 from trezor.messages.NEMSignTx import NEMSignTx
@@ -52,7 +53,7 @@ async def sign_tx(ctx, msg: NEMSignTx, keychain):
             ctx, public_key, common, msg.importance_transfer
         )
     else:
-        raise ValueError("No transaction provided")
+        raise wire.DataError("No transaction provided")
 
     if msg.multisig:
         # wrap transaction in multisig wrapper

--- a/core/src/apps/ripple/sign_tx.py
+++ b/core/src/apps/ripple/sign_tx.py
@@ -77,3 +77,7 @@ def validate(msg: RippleSignTx):
         raise ProcessError(
             "Some of the required fields are missing (fee, sequence, payment.amount, payment.destination)"
         )
+    if msg.payment.amount < 0:
+        raise ProcessError("Only non-negative amounts are allowed.")
+    if msg.payment.amount > helpers.MAX_ALLOWED_AMOUNT:
+        raise ProcessError("Amount exceeds maximum allowed amount.")

--- a/core/src/apps/wallet/get_ecdh_session_key.py
+++ b/core/src/apps/wallet/get_ecdh_session_key.py
@@ -1,5 +1,6 @@
 from ustruct import pack, unpack
 
+from trezor import wire
 from trezor.crypto.hashlib import sha256
 from trezor.messages.ECDHSessionKey import ECDHSessionKey
 from trezor.ui.text import Text
@@ -62,9 +63,9 @@ def ecdh(seckey: bytes, peer_public_key: bytes, curve: str) -> bytes:
         from trezor.crypto.curve import curve25519
 
         if peer_public_key[0] != 0x40:
-            raise ValueError("Curve25519 public key should start with 0x40")
+            raise wire.DataError("Curve25519 public key should start with 0x40")
         session_key = b"\x04" + curve25519.multiply(seckey, peer_public_key[1:])
     else:
-        raise ValueError("Unsupported curve for ECDH: " + curve)
+        raise wire.DataError("Unsupported curve for ECDH: " + curve)
 
     return session_key


### PR DESCRIPTION
Fixes #332.

At most places we have used wire.errors correctly so this was not that big of a deal. There still might be places where wire.error si more appropriate but I did not want to fix something that does not seem broken. So I have fixed the two bugs mentioned in #332, explored the rest and fixed it in places where it seemed reasonable.
