### PR TITLE
Fix BackupDevice layout on 18-word seed wallets

### DIFF
--- a/core/src/apps/management/reset_device/layout.py
+++ b/core/src/apps/management/reset_device/layout.py
@@ -137,7 +137,7 @@ def _split_share_into_pages(share_words):
     if length == 12 or length == 20 or length == 24:
         middle = share[2:-2]
         last = share[-2:]  # two words on the last page
-    elif length == 33:
+    elif length == 33 or length == 18:
         middle = share[2:]
         last = []  # no words at the last page, because it does not add up
     else:


### PR DESCRIPTION
Backups on 18-word seed phrases are currently broken on `master` as the code does not check for 18 word phrases when deciding what layout to render when viewing the mnemonic. 

To replicate the bug which this PR fixes:
- Start with wiped model T
- Create fresh wallet of 18 words
- Attempt to backup
- Firmware Error, [raised here](https://github.com/trezor/trezor-firmware/blob/2f905a115749ae7e3d4da8f7c65fd9632e0136db/core/src/apps/management/reset_device/layout.py#L145)

This PR fixes the bug by also checking for 18 word seed lengths. 

Tested using Emulator with 18 word seed.