### PR TITLE
Allow PIN entry without SD card

### DIFF
--- a/core/embed/extmod/modtrezorconfig/modtrezorconfig.c
+++ b/core/embed/extmod/modtrezorconfig/modtrezorconfig.c
@@ -173,6 +173,18 @@ STATIC mp_obj_t mod_trezorconfig_change_pin(size_t n_args,
 STATIC MP_DEFINE_CONST_FUN_OBJ_VAR_BETWEEN(mod_trezorconfig_change_pin_obj, 4,
                                            4, mod_trezorconfig_change_pin);
 
+/// def ensure_not_wipe_code(pin: int) -> None:
+///     """
+///     Wipes the device if the entered PIN is the wipe code.
+///     """
+STATIC mp_obj_t mod_trezorconfig_ensure_not_wipe_code(mp_obj_t pin) {
+  uint32_t pin_i = trezor_obj_get_uint(pin);
+  storage_ensure_not_wipe_code(pin_i);
+  return mp_const_none;
+}
+STATIC MP_DEFINE_CONST_FUN_OBJ_1(mod_trezorconfig_ensure_not_wipe_code_obj,
+                                 mod_trezorconfig_ensure_not_wipe_code);
+
 /// def has_wipe_code() -> bool:
 ///     """
 ///     Returns True if storage has a configured wipe code, False otherwise.
@@ -367,6 +379,8 @@ STATIC const mp_rom_map_elem_t mp_module_trezorconfig_globals_table[] = {
      MP_ROM_PTR(&mod_trezorconfig_get_pin_rem_obj)},
     {MP_ROM_QSTR(MP_QSTR_change_pin),
      MP_ROM_PTR(&mod_trezorconfig_change_pin_obj)},
+    {MP_ROM_QSTR(MP_QSTR_ensure_not_wipe_code),
+     MP_ROM_PTR(&mod_trezorconfig_ensure_not_wipe_code_obj)},
     {MP_ROM_QSTR(MP_QSTR_has_wipe_code),
      MP_ROM_PTR(&mod_trezorconfig_has_wipe_code_obj)},
     {MP_ROM_QSTR(MP_QSTR_change_wipe_code),

--- a/core/mocks/generated/trezorconfig.pyi
+++ b/core/mocks/generated/trezorconfig.pyi
@@ -61,6 +61,13 @@ def change_pin(
 
 
 # extmod/modtrezorconfig/modtrezorconfig.c
+def ensure_not_wipe_code(pin: int) -> None:
+    """
+    Wipes the device if the entered PIN is the wipe code.
+    """
+
+
+# extmod/modtrezorconfig/modtrezorconfig.c
 def has_wipe_code() -> bool:
     """
     Returns True if storage has a configured wipe code, False otherwise.

--- a/storage/storage.c
+++ b/storage/storage.c
@@ -950,12 +950,7 @@ static secbool unlock(uint32_t pin, const uint8_t *ext_salt) {
     return secfalse;
   }
 
-  // Check whether the user entered the wipe code.
-  if (sectrue != is_not_wipe_code(pin)) {
-    storage_wipe();
-    error_shutdown("You have entered the", "wipe code. All private",
-                   "data has been erased.", NULL);
-  }
+  storage_ensure_not_wipe_code(pin);
 
   // Get the pin failure counter
   uint32_t ctr = 0;
@@ -1337,6 +1332,14 @@ secbool storage_change_pin(uint32_t oldpin, uint32_t newpin,
   memzero(&oldpin, sizeof(oldpin));
   memzero(&newpin, sizeof(newpin));
   return ret;
+}
+
+void storage_ensure_not_wipe_code(uint32_t pin) {
+  if (sectrue != is_not_wipe_code(pin)) {
+    storage_wipe();
+    error_shutdown("You have entered the", "wipe code. All private",
+                   "data has been erased.", NULL);
+  }
 }
 
 secbool storage_has_wipe_code(void) {

--- a/storage/storage.h
+++ b/storage/storage.h
@@ -52,6 +52,7 @@ uint32_t storage_get_pin_rem(void);
 secbool storage_change_pin(uint32_t oldpin, uint32_t newpin,
                            const uint8_t *old_ext_salt,
                            const uint8_t *new_ext_salt);
+void storage_ensure_not_wipe_code(uint32_t pin);
 secbool storage_has_wipe_code(void);
 secbool storage_change_wipe_code(uint32_t pin, const uint8_t *ext_salt,
                                  uint32_t wipe_code);

--- a/tests/device_tests/test_sdcard.py
+++ b/tests/device_tests/test_sdcard.py
@@ -97,6 +97,10 @@ def test_sd_protect_unlock(client):
         assert "Change PIN" in client.debug.wait_layout().text
         client.debug.press_yes()
 
+        yield  # enter current PIN
+        assert "PinDialog" == client.debug.wait_layout().text
+        client.debug.input("1234")
+
         yield  # SD card problem
         assert "SD card problem" in client.debug.wait_layout().text
         client.debug.press_yes()  # retry

--- a/tests/ui_tests/fixtures.json
+++ b/tests/ui_tests/fixtures.json
@@ -384,7 +384,7 @@
 "test_reset_backup.py::test_skip_backup_msg[2-backup_flow_slip39_advanced]": "25a4e8a2ca91518b481538c7c9e70e1769f1aa26c85455bfaadf33c47ae185c2",
 "test_sdcard.py::test_sd_format": "6bb7486932a5d38cdbb9b1368ee92aca3fad384115c744feadfade80c1605dd8",
 "test_sdcard.py::test_sd_no_format": "f47e897caee95cf98c1b4506732825f853c4b8afcdc2713e38e3b4055973c9ac",
-"test_sdcard.py::test_sd_protect_unlock": "ff6ab20979234230a6f4d67d7ff3a7ed3ddc536e1a8b8ad6a2c693b48e0006a9",
+"test_sdcard.py::test_sd_protect_unlock": "23fdb2acb8d19edcca95d90512d53aea6c9d42d8bfb8712af5f7f0ef9fbed72d",
 "test_u2f_counter.py::test_u2f_counter": "7d96a4d262b9d8a2c1158ac1e5f0f7b2c3ed5f2ba9d6235a014320313f9488fe",
 "test_zerosig.py-test_one_zero_signature": "4099761c664ac57e9506abeb6a52cf898297c0dd592e2a394d008c5db7e62356",
 "test_zerosig.py-test_two_zero_signature": "46e0f1749af632a75a6c6ccc2deb4591a925428db000c52008ecb940ec673a6f"


### PR DESCRIPTION
Note that in `verify_user_pin()` I started using `config.unlock()` instead of `config.check_pin()`. The functions are actually identical, `check_pin()` just calls `unlock()` at the moment. If we start to differentiate the behavior one day, then we will need to have something like `verify_user_pin()` and `verify_user_pin_unlock()` for use in boot.py, but no point doing that now.