### PR TITLE
Adding @jonathancross to AUTHORS

### DIFF
--- a/python/AUTHORS
+++ b/python/AUTHORS
@@ -8,6 +8,7 @@ alepop <https://github.com/alepop>
 Jan 'matejcik' Matějek <jan.matejek@satoshilabs.com>
 Jan Pochyla <jan.pochyla@satoshilabs.com>
 Jochen Hoenicke <hoenicke@gmail.com>
+Jonathan Cross <https://github.com/jonathancross>
 Karel Bílek <karel.bilek@satoshilabs.com>
 Marek Palatinus <slush@satoshilabs.com>
 mruddy <https://github.com/mruddy>


### PR DESCRIPTION
Seems that some commit history vanished during the MONOREPO merge last year.
Example: The old [docs/EXAMPLES.rst](https://github.com/trezor/trezor-firmware/blob/6dd261f4c040a32a5ff6d7472b7cdbfd4deb4eb5/docs/EXAMPLES.rst) was moved to [python/docs/EXAMPLES.rst](https://github.com/trezor/trezor-firmware/blob/master/python/docs/EXAMPLES.rst) and all history was lost.

Although I clearly have not done as much as most on this list, I would like to humbly request that my contributions ([commits](https://github.com/search?q=org%3Atrezor+author%3Ajonathancross&type=Commits), [issues](https://github.com/search?q=org%3Atrezor+type%3Aissue+author%3Ajonathancross&type=Issues)) be acknowledged with this PR adding my name to the list.
Thanks. :-)