### PR TITLE
Run device tests on an actual T1 in CI

### DIFF
--- a/Pipfile
+++ b/Pipfile
@@ -23,6 +23,9 @@ pytest-timeout = "*"
 tox = "*"
 dominate = "*"
 
+# hardware tests
+pyserial = "*"
+
 ## test requirements
 shamir-mnemonic = "*"
 fido2 = ">=0.8.0"

--- a/Pipfile.lock
+++ b/Pipfile.lock
@@ -1,7 +1,7 @@
 {
     "_meta": {
         "hash": {
-            "sha256": "cd0bea17b8297d361dfa185570d431e1d151f34fbe375db56ba6e51b8e912f8b"
+            "sha256": "c629a9e3114cb34d93e6d80dde6e2a458deb5082017ab91f0ed9144a00756b19"
         },
         "pipfile-spec": 6,
         "requires": {},
@@ -570,6 +570,14 @@
             ],
             "index": "pypi",
             "version": "==4.79"
+        },
+        "pyserial": {
+            "hashes": [
+                "sha256:6e2d401fdee0eab996cf734e67773a0143b932772ca8b42451440cfed942c627",
+                "sha256:e0770fadba80c31013896c7e6ef703f72e7834965954a78e71a3049488d4d7d8"
+            ],
+            "index": "pypi",
+            "version": "==3.4"
         },
         "pytest": {
             "hashes": [

--- a/ci/deploy.yml
+++ b/ci/deploy.yml
@@ -16,7 +16,7 @@ release core fw regular deploy:
     - mkdir -p "${DEPLOY_BASE_DIR}/${DEPLOY_DIRECTORY}"
     - rsync --delete -va $NAME "${DEPLOY_BASE_DIR}/${DEPLOY_DIRECTORY}/$NAME"
   only:
-    - /^core\/v[0-9.]*$/
+    - /^core\//
   except:
     - branches  # run for tags only
   tags:
@@ -36,7 +36,7 @@ release core fw btconly deploy:
     - mkdir -p "${DEPLOY_BASE_DIR}/${DEPLOY_DIRECTORY}"
     - rsync --delete -va $NAME "${DEPLOY_BASE_DIR}/${DEPLOY_DIRECTORY}/$NAME"
   only:
-    - /^core\/v[0-9.]*$/
+    - /^core\//
   except:
     - branches  # run for tags only
   tags:
@@ -56,7 +56,7 @@ release legacy fw regular deploy:
     - mkdir -p "${DEPLOY_BASE_DIR}/${DEPLOY_DIRECTORY}"
     - rsync --delete -va $NAME "${DEPLOY_BASE_DIR}/${DEPLOY_DIRECTORY}/$NAME"
   only:
-    - /^legacy\/v[0-9.]*$/
+    - /^legacy\//
   except:
     - branches  # run for tags only
   tags:
@@ -76,7 +76,7 @@ legacy fw btconly deploy:
     - mkdir -p "${DEPLOY_BASE_DIR}/${DEPLOY_DIRECTORY}"
     - rsync --delete -va $NAME "${DEPLOY_BASE_DIR}/${DEPLOY_DIRECTORY}/$NAME"
   only:
-    - /^legacy\/v[0-9.]*$/
+    - /^legacy\//
   except:
     - branches  # run for tags only
   tags:
@@ -98,7 +98,7 @@ rc core fw regular deploy:
     - mkdir -p "${DEPLOY_BASE_DIR}/${DEPLOY_DIRECTORY}"
     - rsync --delete -va $NAME "${DEPLOY_BASE_DIR}/${DEPLOY_DIRECTORY}/$NAME"
   only:
-    - /^release\/[0-9]{4}-[0-9]{2}$/
+    - /^release\//
   tags:
     - deploy
 
@@ -115,7 +115,7 @@ rc core fw btconly deploy:
     - mkdir -p "${DEPLOY_BASE_DIR}/${DEPLOY_DIRECTORY}"
     - rsync --delete -va $NAME "${DEPLOY_BASE_DIR}/${DEPLOY_DIRECTORY}/$NAME"
   only:
-    - /^release\/[0-9]{4}-[0-9]{2}$/
+    - /^release\//
   tags:
     - deploy
 
@@ -132,7 +132,7 @@ rc legacy fw regular deploy:
     - mkdir -p "${DEPLOY_BASE_DIR}/${DEPLOY_DIRECTORY}"
     - rsync --delete -va $NAME "${DEPLOY_BASE_DIR}/${DEPLOY_DIRECTORY}/$NAME"
   only:
-    - /^release\/[0-9]{4}-[0-9]{2}$/
+    - /^release\//
   tags:
     - deploy
 
@@ -149,7 +149,7 @@ rc legacy fw btconly deploy:
     - mkdir -p "${DEPLOY_BASE_DIR}/${DEPLOY_DIRECTORY}"
     - rsync --delete -va $NAME "${DEPLOY_BASE_DIR}/${DEPLOY_DIRECTORY}/$NAME"
   only:
-    - /^release\/[0-9]{4}-[0-9]{2}$/
+    - /^release\//
   tags:
     - deploy
 
@@ -169,7 +169,7 @@ upgrade tests core deploy:
     - echo "Deploying to $DEST"
     - rsync --delete -va core/build/unix/micropython "$DEST"
   only:
-    - /^core\/v[0-9.]*$/
+    - /^core\//
   except:
     - branches  # run for tags only
   tags:
@@ -189,7 +189,7 @@ upgrade tests legacy deploy:
     - echo "Deploying to $DEST"
     - rsync --delete -va legacy/firmware/trezor.elf "$DEST"
   only:
-    - /^legacy\/v[0-9.]*$/
+    - /^legacy\//
   except:
     - branches  # run for tags only
   tags:

--- a/ci/hardware_tests/README.md
+++ b/ci/hardware_tests/README.md
@@ -1,0 +1,8 @@
+# Hardware tests
+
+Hardware tests are device tests that run against an actual device instead of an emulator.
+This works thanks to [tpmb](https://github.com/mmahut/tpmb), which is a small arduino
+device capable of pushing an actual buttons on the device. Currently T1 is supported
+but TT might follow.
+
+See `ci/test.yml` "hardware legacy device test" what exactly is run.

--- a/ci/hardware_tests/bootstrap.py
+++ b/ci/hardware_tests/bootstrap.py
@@ -1,0 +1,20 @@
+import configparser
+import sys
+
+from device.t1 import TrezorOne
+
+
+def main(file: str = None):
+    config = configparser.ConfigParser()
+    config.read_file(open("hardware.cfg"))
+    t1 = TrezorOne(
+        config["t1"]["location"], config["t1"]["port"], config["t1"]["arduino_serial"],
+    )
+    t1.update_firmware(file)
+
+
+if __name__ == "__main__":
+    file = None
+    if len(sys.argv) == 2:
+        file = sys.argv[1]
+    main(file)

--- a/ci/hardware_tests/default.nix
+++ b/ci/hardware_tests/default.nix
@@ -1,0 +1,14 @@
+with import <nixpkgs> {};
+
+stdenv.mkDerivation rec {
+  name = "trezor-firmware-hardware-tests";
+  buildInputs = [
+    uhubctl
+    ffmpeg
+    pipenv
+    libusb1
+    dejavu_fonts
+  ];
+  LD_LIBRARY_PATH = "${libusb1}/lib";
+  NIX_ENFORCE_PURITY = 0;
+}

--- a/ci/hardware_tests/device/device.py
+++ b/ci/hardware_tests/device/device.py
@@ -1,0 +1,46 @@
+import datetime
+import os
+import time
+
+import serial
+
+
+class Device:
+    def __init__(self, uhub_location, uhub_port, arduino_serial):
+        self.uhub_location = uhub_location
+        self.uhub_port = uhub_port
+        self.arduino_serial = arduino_serial
+        self.serial = serial.Serial(arduino_serial, 9600)
+
+    def power_on(self):
+        self.now()
+        print("[hardware/usb] Turning power on...")
+        os.system(
+            "uhubctl -l {} -p {} -a on > /dev/null".format(
+                self.uhub_location, self.uhub_port
+            )
+        )
+        self.wait(3)
+
+    def power_off(self):
+        self.now()
+        print("[hardware/usb] Turning power off...")
+        os.system(
+            "uhubctl -l {} -p {} -r 100 -a off > /dev/null".format(
+                self.uhub_location, self.uhub_port
+            )
+        )
+        self.wait(3)
+
+    def touch(self, location, action):
+        raise NotImplementedError
+
+    @staticmethod
+    def wait(seconds):
+        Device.now()
+        print("[software] Waiting for {} seconds...".format(seconds))
+        time.sleep(seconds)
+
+    @staticmethod
+    def now():
+        print("\n[timestamp] {}".format(datetime.datetime.now()))

--- a/ci/hardware_tests/device/t1.py
+++ b/ci/hardware_tests/device/t1.py
@@ -1,0 +1,47 @@
+import os
+
+from .device import Device
+
+
+class TrezorOne(Device):
+    def touch(self, location, action):
+        self.now()
+        print(
+            "[hardware/trezor] Touching the {} button by {}...".format(location, action)
+        )
+        self.serial.write(("{} {}\n".format(location, action)).encode())
+
+    def update_firmware(self, file=None):
+        if file:
+            unofficial = True
+            trezorctlcmd = "trezorctl firmware-update -s -f {} &".format(file)
+            print("[software/trezorctl] Updating the firmware to {}...".format(file))
+        else:
+            unofficial = False
+            trezorctlcmd = "trezorctl firmware-update &"
+            print("[software/trezorctl] Updating the firmware to latest...")
+        self._enter_bootloader()
+
+        os.system(trezorctlcmd)
+        self.wait(3)
+        self.touch("right", "click")
+        self.wait(20)
+        if unofficial:
+            self.touch("right", "click")
+        self.wait(10)
+        self.power_off()
+        self.power_on()
+        if unofficial:
+            self.touch("right", "click")
+            self.wait(5)
+            self.touch("right", "click")
+        self.wait(5)
+        os.system("trezorctl get-features|grep version")
+
+    def _enter_bootloader(self):
+        self.power_off()
+        self.touch("all", "press")
+        self.wait(2)
+        self.power_on()
+        self.wait(2)
+        self.touch("all", "unpress")

--- a/ci/hardware_tests/hardware.cfg
+++ b/ci/hardware_tests/hardware.cfg
@@ -1,0 +1,4 @@
+[t1]
+location = 3-1.4
+port = 3
+arduino_serial = /dev/ttyACM0

--- a/ci/hardware_tests/record_video.sh
+++ b/ci/hardware_tests/record_video.sh
@@ -1,0 +1,20 @@
+#!/usr/bin/env bash 
+if [ $# -ne 2 ]
+  then
+    echo "Usage: $0 commit_id [start|stop]"
+fi
+
+OUTPUTFILE=video_$1_$(date +%s).mp4
+INPUTDEVICE=/dev/video0
+
+if [ "$2" == "start" ]; then
+  echo "[software/video] Starting record to $OUTPUTFILE"
+  ffmpeg -loglevel panic -f oss -f video4linux2 -i $INPUTDEVICE \
+    -vf "drawtext=font=Dejavu Sans: \
+    text='$1 | %{localtime} | %{pts}': x=(w-tw)/2: y=h-(2*lh): fontcolor=white: box=1: boxcolor=0x00000000@1: fontsize=15" $OUTPUTFILE &
+  export VPID=$!
+elif [ "$2" == "stop" ]; then
+  echo "[software/video] Stopping the recording of $OUTPUTFILE"
+  pkill ffmpeg
+  sync
+fi

--- a/ci/test.yml
+++ b/ci/test.yml
@@ -326,8 +326,8 @@ hardware legacy device test:
   extends: .legacy_job
   only:
     - schedules  # nightly build
-    - /^legacy\/v[0-9.]*$/
-    - /^release\/[0-9]{4}-[0-9]{2}$/
+    - /^legacy\//
+    - /^release\//
   tags:
     - tpmb
   dependencies:

--- a/ci/test.yml
+++ b/ci/test.yml
@@ -319,3 +319,25 @@ storage test:
       junit: tests/junit.xml
     expire_in: 1 week
     when: always
+
+# Hardware
+hardware legacy device test:
+  stage: test
+  extends: .legacy_job
+  tags:
+    - tpmb
+  dependencies:
+    - legacy fw debug build
+  script:
+    - cd ci/hardware_tests
+    - nix-shell --run "./record_video.sh ${CI_COMMIT_SHORT_SHA} start"
+    - nix-shell --run "cd ../.. && pipenv sync"
+    - nix-shell --run "pipenv run python bootstrap.py"
+    - nix-shell --run "pipenv run python bootstrap.py ../../trezor-*.bin"
+    - nix-shell --run "pipenv run pytest ../../tests/device_tests"
+    - nix-shell --run "./record_video.sh ${CI_COMMIT_SHORT_SHA} stop"
+  artifacts:
+    name: "$CI_JOB_NAME-$CI_COMMIT_SHORT_SHA"
+    paths:
+      - ci/hardware_tests/video*.mp4
+    expire_in: 2 days

--- a/ci/test.yml
+++ b/ci/test.yml
@@ -324,6 +324,10 @@ storage test:
 hardware legacy device test:
   stage: test
   extends: .legacy_job
+  only:
+    - schedules  # nightly build
+    - /^legacy\/v[0-9.]*$/
+    - /^release\/[0-9]{4}-[0-9]{2}$/
   tags:
     - tpmb
   dependencies:


### PR DESCRIPTION
Based on the great work by @mmahut and his [tpmb](https://github.com/mmahut/tpmb) we have an actual T1 connected to our CI:

![demo](https://user-images.githubusercontent.com/1835345/78680080-55c76500-78eb-11ea-9f34-a72d16ff6d7e.gif)

---------

This enables us to test the firmware on an actual device! This PR in particular adds a job to GitLab, which uploads the currently build debug firmware to the device and then runs the device tests on it. It uses the _tpmb_ to access the bootloader and confirm the firmware update, the rest is done using the debug link.

--------

This is a draft and although I do not think we should spend too much time fine-tuning it (now), there are a few things that should be considered before merging this:

- It uses `trezorctl` to update the firmware. I guess there is no reason not to use trezorlib directly, right?
- Wrap the `uhubctl` usage somehow?
- Should this be in `ci/` or `tests/`?
- Do we want to merge the whole _tpmb_ into our monerepo? Although there are many things we do not need for the testing it concerns _trezor firmware_ after all. (of course if @mmahut agrees)
- How often do we want to run this? I think I will brought this up on the next standup.
- `prestyle` is currently commented out because of #934, although it might be fixed by removing the `pipenv update` most likely.

----------

Possible next steps:
- Add TT support.
- Run the tests against a production firmware. That means using the _tpmb_ to mechanically click on the buttons instead of using debug link.
- Add TT support for above.

-----

Updates #935.