### PR TITLE
legacy: initialized field in Features is true only if mnemonic is stored

### DIFF
--- a/legacy/firmware/config.c
+++ b/legacy/firmware/config.c
@@ -714,6 +714,8 @@ bool config_getMnemonic(char *dest, uint16_t dest_size) {
   return sectrue == config_get_string(KEY_MNEMONIC, dest, dest_size);
 }
 
+bool config_hasMnemonic(void) { return sectrue == storage_has(KEY_MNEMONIC); }
+
 /* Check whether mnemonic matches storage. The mnemonic must be
  * a null-terminated string.
  */

--- a/legacy/firmware/config.h
+++ b/legacy/firmware/config.h
@@ -113,6 +113,7 @@ uint8_t *session_startSession(const uint8_t *received_session_id);
 
 bool config_setMnemonic(const char *mnemonic);
 bool config_containsMnemonic(const char *mnemonic);
+bool config_hasMnemonic(void);
 bool config_getMnemonic(char *dest, uint16_t dest_size);
 bool config_getMnemonicBytes(uint8_t *dest, uint16_t dest_size,
                              uint16_t *real_size);

--- a/legacy/firmware/fsm_msg_common.h
+++ b/legacy/firmware/fsm_msg_common.h
@@ -46,7 +46,8 @@ bool get_features(Features *resp) {
       config_getLanguage(resp->language, sizeof(resp->language));
   resp->has_label = config_getLabel(resp->label, sizeof(resp->label));
   resp->has_initialized = true;
-  resp->initialized = config_isInitialized();
+  // imported xprv is not supported anymore so we require mnemonic
+  resp->initialized = config_isInitialized() && config_hasMnemonic();
   resp->has_imported = config_getImported(&(resp->imported));
   resp->has_pin_cached = true;
   resp->pin_cached = session_isUnlocked() && config_hasPin();

--- a/storage/storage.c
+++ b/storage/storage.c
@@ -1104,6 +1104,11 @@ static secbool storage_get_encrypted(const uint16_t key, void *val_dest,
   return sectrue;
 }
 
+secbool storage_has(const uint16_t key) {
+  uint16_t len = 0;
+  return storage_get(key, NULL, 0, &len);
+}
+
 /*
  * Finds the data stored under key and writes its length to len. If val_dest is
  * not NULL and max_len >= len, then the data is copied to val_dest.

--- a/storage/storage.h
+++ b/storage/storage.h
@@ -56,6 +56,7 @@ void storage_ensure_not_wipe_code(uint32_t pin);
 secbool storage_has_wipe_code(void);
 secbool storage_change_wipe_code(uint32_t pin, const uint8_t *ext_salt,
                                  uint32_t wipe_code);
+secbool storage_has(const uint16_t key);
 secbool storage_get(const uint16_t key, void *val, const uint16_t max_len,
                     uint16_t *len);
 secbool storage_set(const uint16_t key, const void *val, const uint16_t len);


### PR DESCRIPTION
Older firmware supported direct mnemonic load or xprv import. This support was removed from the latest firmware. If someone used this feature and upgraded to the latest fw node deriving does not work anymore and we also incorrectly state that the device as initialized (`features.initialized`).

This PR modifies this field to `isInitialized() && hasMnemonic()` as @prusnak suggested to declare the device as initialized only if it has a mnemonic stored. Because of that I have added `storage_has` (maybe `storage_key_exists` is better?) to only check if mnemonic is present instead of fetching it.

I also had to modify the wipedevice test, which now fails on TT, but that will be fixed by the changes in #958. So I suggest to merge this after the soft lock.

Closes https://github.com/trezor/trezor-firmware/issues/965
