### PR TITLE
legacy/stellar: change price format

### DIFF
--- a/legacy/firmware/stellar.c
+++ b/legacy/firmware/stellar.c
@@ -1241,7 +1241,7 @@ void stellar_format_price(uint32_t numerator, uint32_t denominator, char *out,
   }
 
   // Format with bn_format_uint64
-  bn_format_uint64(value, NULL, NULL, scale, 0, false, out, outlen);
+  bn_format_uint64(value, NULL, NULL, 6, 6 - scale, true, out, outlen);
 }
 
 /*


### PR DESCRIPTION
Solves the second part of https://github.com/trezor/trezor-firmware/issues/921.

It makes price format in stellar on trezor one same as it is on trezor T (that is `"%f" % (op.price_n / op.price_d)`).

| price | trezor one old       | trezor one new | trezor T  |
|-------|----------------------|----------------|-----------|
| 13/1  | 13                   | 13.000000      | 13.000000 |
| 1/13  | 0.076923076923076923 | 0.076923       | 0.076923  |