### PR TITLE
T1 core port able to run on T1 bootloader if it has MEMORY_PROTECT=0 or FW is signed

### DIFF
--- a/core/Makefile
+++ b/core/Makefile
@@ -23,12 +23,14 @@ RDI        ?= 1
 
 STLINK_VER ?= v2
 OPENOCD = openocd -f interface/stlink-$(STLINK_VER).cfg -c "transport select hla_swd" -f target/stm32f4x.cfg
+OPENOCD_T1 = openocd -f interface/stlink-$(STLINK_VER).cfg -c "transport select hla_swd" -f target/stm32f2x.cfg
 
 BOARDLOADER_START   = 0x08000000
 BOOTLOADER_START    = 0x08020000
 FIRMWARE_P1_START   = 0x08040000
 FIRMWARE_P2_START   = 0x08120000
 PRODTEST_START      = 0x08040000
+FIRMWARE_T1_START   = 0x08010000
 
 BOARDLOADER_MAXSIZE = 49152
 BOOTLOADER_MAXSIZE  = 131072
@@ -191,6 +193,9 @@ flash_prodtest: $(PRODTEST_BUILD_DIR)/prodtest.bin ## flash prodtest using OpenO
 flash_firmware: $(FIRMWARE_BUILD_DIR)/firmware.bin ## flash firmware using OpenOCD
 	$(OPENOCD) -c "init; reset halt; flash write_image erase $<.p1 $(FIRMWARE_P1_START); flash write_image erase $<.p2 $(FIRMWARE_P2_START); exit"
 
+flash_firmware_t1: $(FIRMWARE_BUILD_DIR)/firmware.bin ## flash T1 core port on T1 using OpenOCD
+	$(OPENOCD_T1) -c "init; reset halt; flash write_image erase $< $(FIRMWARE_T1_START); exit"
+
 flash_combine: $(PRODTEST_BUILD_DIR)/combined.bin ## flash combined using OpenOCD
 	$(OPENOCD) -c "init; reset halt; flash write_image erase $< $(BOARDLOADER_START); exit"
 
@@ -210,6 +215,9 @@ flash_firmware_jlink: $(FIRMWARE_BUILD_DIR)/firmware.bin ## flash firmware using
 	cp -f $<.p1 $<.p1.bin
 	cp -f $<.p2 $<.p2.bin
 	JLinkExe -commanderscript embed/firmware/firmware_flash.jlink
+
+flash_firmware_t1_jlink: $(FIRMWARE_BUILD_DIR)/firmware.bin ## flash T1 core port via JLink
+	JLinkExe -commanderscript embed/firmware/firmware_flash_t1.jlink
 
 ## openocd debug commands:
 

--- a/core/embed/firmware/firmware_flash_t1.jlink
+++ b/core/embed/firmware/firmware_flash_t1.jlink
@@ -1,0 +1,7 @@
+device CORTEX-M3
+if swd
+speed 50000
+loadbin build/firmware/firmware.bin 0x08010000
+r
+g
+exit

--- a/core/embed/firmware/startup.s
+++ b/core/embed/firmware/startup.s
@@ -6,7 +6,15 @@
   .type reset_handler, STT_FUNC
 reset_handler:
 
+// The following loading of VTOR address only works if T1 bootloader was built with MEMORY_PROTECT=0
+// or the firmware was properly signed. All other variants end up in hard fault due to MPU 
+// (cf mpu_config_firmware in legacy bootloader)
+
 #if TREZOR_MODEL == 1
+  ldr r0, =0xE000ED08  // r0 = VTOR address
+  ldr r1, =0x08010400  // r1 = FLASH_APP_START
+  str r1, [r0]         // assign
+
   ldr r0, =_estack - 8  // r0 = stack pointer, T1 bootloader had 8 bytes reserved at end
   msr msp, r0           // set stack pointer
   dsb


### PR DESCRIPTION
Added a few flashing commands for openocd and jlink as well.