### PR TITLE
legacy: add ToS dialog to recovery

### DIFF
--- a/legacy/firmware/recovery.c
+++ b/legacy/firmware/recovery.c
@@ -482,7 +482,8 @@ void recovery_init(uint32_t _word_count, bool passphrase_protection,
   if (!dry_run) {
     layoutDialogSwipe(&bmp_icon_question, _("Cancel"), _("Confirm"), NULL,
                       _("Do you really want to"), _("recover the device?"),
-                      NULL, NULL, NULL, NULL);
+                      NULL, _("By continuing you"), _("agree to trezor.io/tos"),
+                      NULL);
     if (!protectButton(ButtonRequestType_ButtonRequest_ProtectCall, false)) {
       fsm_sendFailure(FailureType_Failure_ActionCancelled, NULL);
       layoutHome();


### PR DESCRIPTION
Before:
![Screenshot from 2020-05-25 20-32-19](https://user-images.githubusercontent.com/1835345/82837163-92194980-9ec8-11ea-8dca-895e3bcd838a.png)

After:
![Screenshot from 2020-05-25 20-40-14](https://user-images.githubusercontent.com/1835345/82837164-92b1e000-9ec8-11ea-9cf8-1451499a71ec.png)

I was unable to come up with any better wording.

---

Closes #972.

---

I am also wondering we might backport this to 2020/06 (1.9.1) because it will take a long time to publish another T1 FW (I guess).