### PR TITLE
core: relax path checks on GetPublicKey

### DIFF
--- a/tests/device_tests/test_msg_getpublickey.py
+++ b/tests/device_tests/test_msg_getpublickey.py
@@ -116,7 +116,7 @@ def test_get_public_node(client, coin_name, xpub_magic, path, xpub):
     assert bip32.serialize(res.node, xpub_magic) == xpub
 
 
-@pytest.mark.skip_t1
+@pytest.mark.xfail(reason="Currently path validation on get_public_node is disabled.")
 @pytest.mark.parametrize("coin_name, path", VECTORS_INVALID)
 def test_invalid_path(client, coin_name, path):
     with pytest.raises(TrezorFailure, match="Forbidden key path"):

--- a/tests/device_tests/test_msg_getpublickey_curve.py
+++ b/tests/device_tests/test_msg_getpublickey_curve.py
@@ -65,7 +65,7 @@ def test_ed25519_public(client):
         btc.get_public_node(client, PATH_PUBLIC, ecdsa_curve_name="ed25519")
 
 
-@pytest.mark.skip_t1
+@pytest.mark.xfail(reason="Currently path validation on get_public_node is disabled.")
 def test_coin_and_curve(client):
     with pytest.raises(
         TrezorFailure, match="Cannot use coin_name or script_type with ecdsa_curve_name"


### PR DESCRIPTION
fixes #1011 by removing all restrictions on path for `GetPublicKey`, thus reverting to pre-#959 levels

this seems necessary due to the sheer amount of different uses of GetPublicKey:

- in trezor-agent, SLIP-13 and SLIP-17 paths are used
- in hwi, m/0' (and m/0 due to a bug) are used to retrieve master fingerprint
- in electrum, m/ELE'/something is used to derive a password for wallet file encryption
- in mytrezor wallet, m/44/1/0 path is used to check, uh, something
- in Exodus, `GetPublicKey` is used with valid paths, but without specifying `coin_name` and also for currencies other than Bitcoin-likes.

we can still decide to implement a whitelist based on the above, but it is unclear if that is worth it.