### PR TITLE
core: forbid all settings if not initialized

### DIFF
--- a/core/src/apps/management/apply_flags.py
+++ b/core/src/apps/management/apply_flags.py
@@ -1,7 +1,12 @@
+import storage.device
 from storage.device import set_flags
 from trezor.messages.Success import Success
 
+import wire
+
 
 async def apply_flags(ctx, msg):
+    if not storage.is_initialized():
+        raise wire.NotInitialized("Device is not initialized")
     set_flags(msg.flags)
     return Success(message="Flags applied")

--- a/core/src/apps/management/apply_settings.py
+++ b/core/src/apps/management/apply_settings.py
@@ -12,6 +12,8 @@ if False:
 
 
 async def apply_settings(ctx: wire.Context, msg: ApplySettings):
+    if not storage.is_initialized():
+        raise wire.NotInitialized("Device is not initialized")
     if (
         msg.homescreen is None
         and msg.label is None

--- a/core/src/apps/management/get_next_u2f_counter.py
+++ b/core/src/apps/management/get_next_u2f_counter.py
@@ -11,6 +11,8 @@ from apps.common.confirm import require_confirm
 async def get_next_u2f_counter(
     ctx: wire.Context, msg: GetNextU2FCounter
 ) -> NextU2FCounter:
+    if not storage.is_initialized():
+        raise wire.NotInitialized("Device is not initialized")
     text = Text("Get next U2F counter", ui.ICON_CONFIG)
     text.normal("Do you really want to")
     text.bold("increase and retrieve")

--- a/core/src/apps/management/set_u2f_counter.py
+++ b/core/src/apps/management/set_u2f_counter.py
@@ -9,6 +9,8 @@ from apps.common.confirm import require_confirm
 
 
 async def set_u2f_counter(ctx: wire.Context, msg: SetU2FCounter) -> Success:
+    if not storage.is_initialized():
+        raise wire.NotInitialized("Device is not initialized")
     if msg.u2f_counter is None:
         raise wire.ProcessError("No value provided")
 

--- a/core/src/apps/webauthn/add_resident_credential.py
+++ b/core/src/apps/webauthn/add_resident_credential.py
@@ -1,3 +1,4 @@
+import storage
 from trezor import ui, wire
 from trezor.messages.Success import Success
 from trezor.messages.WebAuthnAddResidentCredential import WebAuthnAddResidentCredential
@@ -30,6 +31,8 @@ class ConfirmAddCredential(ConfirmInfo):
 async def add_resident_credential(
     ctx: wire.Context, msg: WebAuthnAddResidentCredential
 ) -> Success:
+    if not storage.is_initialized():
+        raise wire.NotInitialized("Device is not initialized")
     if not msg.credential_id:
         raise wire.ProcessError("Missing credential ID parameter.")
 

--- a/core/src/apps/webauthn/remove_resident_credential.py
+++ b/core/src/apps/webauthn/remove_resident_credential.py
@@ -32,6 +32,8 @@ class ConfirmRemoveCredential(ConfirmInfo):
 async def remove_resident_credential(
     ctx: wire.Context, msg: WebAuthnRemoveResidentCredential
 ) -> Success:
+    if not storage.is_initialized():
+        raise wire.NotInitialized("Device is not initialized")
     if msg.index is None:
         raise wire.ProcessError("Missing credential index parameter.")
 

--- a/tests/upgrade_tests/test_firmware_upgrades.py
+++ b/tests/upgrade_tests/test_firmware_upgrades.py
@@ -212,6 +212,14 @@ def test_upgrade_shamir_recovery(gen, tag):
 def test_upgrade_u2f(gen, tag):
     """Check U2F counter stayed the same after an upgrade."""
     with EmulatorWrapper(gen, tag) as emu:
+        debuglink.load_device_by_mnemonic(
+            emu.client,
+            mnemonic=MNEMONIC,
+            pin="",
+            passphrase_protection=False,
+            label=LABEL,
+        )
+
         success = fido.set_counter(emu.client, 10)
         assert "U2F counter set" in success
 


### PR DESCRIPTION
I have added the check everywhere (hopefully) where something was being stored in the storage. it is something to be discussed however. The check does not have to be in places where the seed is touched obviously.

I am still wondering if we should wipe the device before reset/recovery to make sure it is in the expected state. What do you think?

Closes #1056.