### PR TITLE
xmr: UI QR code fix, zoom by swipe

### DIFF
--- a/core/src/apps/monero/get_address.py
+++ b/core/src/apps/monero/get_address.py
@@ -1,10 +1,10 @@
 from trezor.messages.MoneroAddress import MoneroAddress
 
 from apps.common import paths
-from apps.common.layout import address_n_to_str, show_qr
+from apps.common.layout import address_n_to_str
 from apps.common.seed import with_slip44_keychain
 from apps.monero import CURVE, SLIP44_ID, misc
-from apps.monero.layout import confirms
+from apps.monero.layout import address as layout_address
 from apps.monero.xmr import addresses, crypto, monero
 from apps.monero.xmr.networks import net_version
 
@@ -45,9 +45,9 @@ async def get_address(ctx, msg, keychain):
     if msg.show_display:
         desc = address_n_to_str(msg.address_n)
         while True:
-            if await confirms.show_address(ctx, addr.decode(), desc=desc):
+            if await layout_address.show_address(ctx, addr.decode(), desc=desc):
                 break
-            if await show_qr(ctx, "monero:" + addr.decode(), desc=desc):
+            if await layout_address.show_qr(ctx, "monero:" + addr.decode(), desc=desc):
                 break
 
     return MoneroAddress(address=addr)

--- a/core/src/apps/monero/layout/address.py
+++ b/core/src/apps/monero/layout/address.py
@@ -1,0 +1,143 @@
+from micropython import const
+
+from trezor import loop, ui, wire
+from trezor.messages import ButtonRequestType
+from trezor.ui.button import ButtonDefault
+from trezor.ui.confirm import CONFIRMED, Confirm
+from trezor.ui.container import Container
+from trezor.ui.qr import Qr
+from trezor.ui.scroll import Paginated
+from trezor.ui.text import Text
+from trezor.wire import Context
+
+from apps.common import button_request
+from apps.common.confirm import confirm
+from apps.monero.layout import common
+
+if False:
+    from typing import Optional, Tuple
+
+if __debug__:
+    from apps.debug import swipe_signal
+
+
+async def show_address(
+    ctx, address: str, desc: str = "Confirm address", network: str = None
+):
+    pages = []
+    for lines in common.paginate_lines(common.split_address(address), 5):
+        text = Text(desc, ui.ICON_RECEIVE, ui.GREEN)
+        if network is not None:
+            text.normal("%s network" % network)
+        text.mono(*lines)
+        pages.append(text)
+
+    return await confirm(
+        ctx,
+        Paginated(pages),
+        code=ButtonRequestType.Address,
+        cancel="QR",
+        cancel_style=ButtonDefault,
+    )
+
+
+def render_scrollbar(pages: int, page: int) -> None:
+    BBOX = const(220)
+    SIZE = const(8)
+
+    padding = 14
+    if pages * padding > BBOX:
+        padding = BBOX // pages
+
+    X = const(232)
+    Y = (BBOX // 2) - (pages // 2) * padding
+
+    for i in range(0, pages):
+        if i == page:
+            fg = ui.FG
+        else:
+            fg = ui.GREY
+        ui.display.bar_radius(X, Y + i * padding, SIZE, SIZE, fg, ui.BG, 4)
+
+
+class ZoomingQrConfirm(Confirm):
+    def __init__(
+        self,
+        ctx: Context,
+        qr_data: str,
+        qr_text: Optional[str],
+        cancel: str,
+        qr_scales: Tuple[int] = (3, 5),
+    ) -> None:
+        self.ctx = ctx
+        self.qr_data = qr_data
+        self.qr_text = qr_text
+        self.qr_scales = qr_scales
+        self.cur_scale = len(qr_scales) - 1
+        self.content = None  # type: Optional[ui.Component]
+        self.confirm_orig = None
+        self.cancel_orig = None
+        self.gen_qr()
+        super().__init__(
+            self.content,
+            confirm=Confirm.DEFAULT_CONFIRM,
+            confirm_style=Confirm.DEFAULT_CONFIRM_STYLE,
+            cancel=cancel,
+            cancel_style=ButtonDefault,
+            major_confirm=False,
+        )
+        self.confirm_orig = self.confirm
+        self.cancel_orig = self.cancel
+
+    async def show(self):
+        await button_request(self.ctx, code=ButtonRequestType.Address)
+        return await self.ctx.wait(self) is CONFIRMED
+
+    def dispatch(self, event: int, x: int, y: int) -> None:
+        super().dispatch(event, x, y)
+        self.content.dispatch(event, x, y)
+        if event is ui.RENDER:
+            render_scrollbar(len(self.qr_scales), self.cur_scale)
+
+    def gen_qr(self):
+        QR_X = const(120)
+        QR_Y = const(115)
+        self.cur_scale = (self.cur_scale + 1) % len(self.qr_scales)
+        qr = Qr(self.qr_data, QR_X, QR_Y, self.qr_scales[self.cur_scale])
+        text = Text(self.qr_text, ui.ICON_RECEIVE, ui.GREEN) if self.qr_text else None
+        self.content = Container(qr, text) if text else qr
+
+        # Show buttons only for the small QR code
+        if self.cur_scale == 0:
+            self.cancel = self.cancel_orig
+            self.confirm = self.confirm_orig
+        else:
+            self.cancel = None
+            self.confirm = None
+
+    async def handle_paging(self) -> None:
+        from trezor.ui.swipe import SWIPE_ALL, Swipe
+
+        directions = SWIPE_ALL
+
+        if __debug__:
+            _ = await loop.race(Swipe(directions), swipe_signal())
+        else:
+            _ = await Swipe(directions)
+
+        self.gen_qr()
+        self.content.repaint = True
+
+    def create_tasks(self) -> Tuple[loop.Task, ...]:
+        tasks = super().create_tasks()
+        return tasks + (self.handle_paging(),)
+
+
+async def show_qr(
+    ctx: wire.Context,
+    address: str,
+    desc: str = "Confirm address",
+    cancel: str = "Address",
+) -> bool:
+    content = ZoomingQrConfirm(ctx, address, desc, cancel)
+    return await content.show()

--- a/core/src/apps/monero/layout/confirms.py
+++ b/core/src/apps/monero/layout/confirms.py
@@ -218,28 +218,3 @@ async def live_refresh_step(ctx, current):
     if current is None:
         return
     await Popup(LiveRefreshStep(current))
-
-
-async def show_address(
-    ctx, address: str, desc: str = "Confirm address", network: str = None
-):
-    from apps.common.confirm import confirm
-    from trezor.messages import ButtonRequestType
-    from trezor.ui.button import ButtonDefault
-    from trezor.ui.scroll import Paginated
-
-    pages = []
-    for lines in common.paginate_lines(common.split_address(address), 5):
-        text = Text(desc, ui.ICON_RECEIVE, ui.GREEN)
-        if network is not None:
-            text.normal("%s network" % network)
-        text.mono(*lines)
-        pages.append(text)
-
-    return await confirm(
-        ctx,
-        Paginated(pages),
-        code=ButtonRequestType.Address,
-        cancel="QR",
-        cancel_style=ButtonDefault,
-    )


### PR DESCRIPTION
This is a draft PR addressing https://github.com/monero-project/monero-gui/issues/2960 (reported by @bosomt) by:
- Showing down-scaled QR code so controls are clearly visible
- Enabling to zoom the QR code by swiping in any direction to up-scale to full-screen

Current state:
![](https://user-images.githubusercontent.com/31506317/84864784-7a705380-b077-11ea-89b8-74cb9ab0dc11.png)

Screen where user can activate the QR code screen:
![Screenshot 2020-06-18 at 14 46 01](https://user-images.githubusercontent.com/1052761/85022600-d0c2bc80-b173-11ea-99fb-8213a1cece47.png)

Initial QR screen state
![Screenshot 2020-06-18 at 15 04 41](https://user-images.githubusercontent.com/1052761/85023629-48451b80-b175-11ea-966d-da278e34c634.png)
Zoomed QR code after swiping to any direction (scale = 5)
![Screenshot 2020-06-18 at 15 04 46](https://user-images.githubusercontent.com/1052761/85023648-5135ed00-b175-11ea-9a78-481539d6b46e.png)

After another swipe the scale returns back to 3 (swipe toggles between 3 and 5)

This is just an idea of how to address this issue, it can be probably implemented in a more elegant way.

Edit: I've added a new scroll-bar to give a user a hint this view is scrollable. I had to offset to the right so it does not collide with the QR code. 