### PR TITLE
Rename Features.pin_cached to unlocked and unify

### DIFF
--- a/common/protob/messages-management.proto
+++ b/common/protob/messages-management.proto
@@ -50,7 +50,7 @@ message Features {
     optional bytes revision = 13;               // SCM revision of firmware
     optional bytes bootloader_hash = 14;        // hash of the bootloader
     optional bool imported = 15;                // was storage imported from an external source?
-    optional bool pin_cached = 16;              // is PIN already cached in session?
+    optional bool unlocked = 16;                // is the device unlocked? called "pin_cached" previously
 //    optional bool passphrase_cached = 17;       // is passphrase already cached in session?  DEPRECATED
     optional bool firmware_present = 18;        // is valid firmware loaded?
     optional bool needs_backup = 19;            // does storage need backup? (equals to Storage.needs_backup)

--- a/core/src/apps/base.py
+++ b/core/src/apps/base.py
@@ -33,7 +33,7 @@ def get_features() -> Features:
     f.device_id = storage.device.get_device_id()
     f.label = storage.device.get_label()
     f.pin_protection = config.has_pin()
-    f.pin_cached = config.is_unlocked()
+    f.unlocked = config.is_unlocked()
     f.passphrase_protection = storage.device.is_passphrase_enabled()
 
     if utils.BITCOIN_ONLY:

--- a/core/src/trezor/messages/Features.py
+++ b/core/src/trezor/messages/Features.py
@@ -31,7 +31,7 @@ class Features(p.MessageType):
         revision: bytes = None,
         bootloader_hash: bytes = None,
         imported: bool = None,
-        pin_cached: bool = None,
+        unlocked: bool = None,
         firmware_present: bool = None,
         needs_backup: bool = None,
         flags: int = None,
@@ -66,7 +66,7 @@ class Features(p.MessageType):
         self.revision = revision
         self.bootloader_hash = bootloader_hash
         self.imported = imported
-        self.pin_cached = pin_cached
+        self.unlocked = unlocked
         self.firmware_present = firmware_present
         self.needs_backup = needs_backup
         self.flags = flags
@@ -104,7 +104,7 @@ class Features(p.MessageType):
             13: ('revision', p.BytesType, 0),
             14: ('bootloader_hash', p.BytesType, 0),
             15: ('imported', p.BoolType, 0),
-            16: ('pin_cached', p.BoolType, 0),
+            16: ('unlocked', p.BoolType, 0),
             18: ('firmware_present', p.BoolType, 0),
             19: ('needs_backup', p.BoolType, 0),
             20: ('flags', p.UVarintType, 0),

--- a/legacy/firmware/fsm_msg_common.h
+++ b/legacy/firmware/fsm_msg_common.h
@@ -48,8 +48,8 @@ bool get_features(Features *resp) {
   resp->has_initialized = true;
   resp->initialized = config_isInitialized();
   resp->has_imported = config_getImported(&(resp->imported));
-  resp->has_pin_cached = true;
-  resp->pin_cached = session_isUnlocked() && config_hasPin();
+  resp->has_unlocked = true;
+  resp->unlocked = session_isUnlocked();
   resp->has_needs_backup = true;
   config_getNeedsBackup(&(resp->needs_backup));
   resp->has_unfinished_backup = true;

--- a/python/src/trezorlib/messages/Features.py
+++ b/python/src/trezorlib/messages/Features.py
@@ -31,7 +31,7 @@ class Features(p.MessageType):
         revision: bytes = None,
         bootloader_hash: bytes = None,
         imported: bool = None,
-        pin_cached: bool = None,
+        unlocked: bool = None,
         firmware_present: bool = None,
         needs_backup: bool = None,
         flags: int = None,
@@ -66,7 +66,7 @@ class Features(p.MessageType):
         self.revision = revision
         self.bootloader_hash = bootloader_hash
         self.imported = imported
-        self.pin_cached = pin_cached
+        self.unlocked = unlocked
         self.firmware_present = firmware_present
         self.needs_backup = needs_backup
         self.flags = flags
@@ -104,7 +104,7 @@ class Features(p.MessageType):
             13: ('revision', p.BytesType, 0),
             14: ('bootloader_hash', p.BytesType, 0),
             15: ('imported', p.BoolType, 0),
-            16: ('pin_cached', p.BoolType, 0),
+            16: ('unlocked', p.BoolType, 0),
             18: ('firmware_present', p.BoolType, 0),
             19: ('needs_backup', p.BoolType, 0),
             20: ('flags', p.UVarintType, 0),

--- a/tests/device_tests/test_msg_changepin_t2.py
+++ b/tests/device_tests/test_msg_changepin_t2.py
@@ -29,7 +29,7 @@ pytestmark = pytest.mark.skip_t1
 def _check_pin(client, pin):
     client.clear_session()
     assert client.features.pin_protection is True
-    assert client.features.pin_cached is False
+    assert client.features.unlocked is False
 
     with client:
         client.use_pin_sequence([pin])

--- a/tests/device_tests/test_protection_levels.py
+++ b/tests/device_tests/test_protection_levels.py
@@ -233,8 +233,8 @@ class TestProtectionLevels:
     #    pass
 
     @pytest.mark.setup_client(pin=PIN4)
-    def test_pin_cached(self, client):
-        assert client.features.pin_cached is False
+    def test_unlocked(self, client):
+        assert client.features.unlocked is False
 
         with client:
             client.use_pin_sequence([PIN4])
@@ -242,7 +242,7 @@ class TestProtectionLevels:
             btc.get_address(client, "Testnet", [0])
 
         client.init_device()
-        assert client.features.pin_cached is True
+        assert client.features.unlocked is True
         with client:
             client.set_expected_responses([proto.Address()])
             btc.get_address(client, "Testnet", [0])


### PR DESCRIPTION
On a quick test on https://suite.corp.sldev.cz/suite-web/feat/232-pinentry/wallet/ (develop does not work due to the new PinEntry btn request) this seems to work just fine. But we still need to check with Suite if this is alright.

Updates  #1066.