### PR TITLE
Skip protobuf deprecated fields for Core and deprecate Overwintered

### DIFF
--- a/common/protob/messages-bitcoin.proto
+++ b/common/protob/messages-bitcoin.proto
@@ -130,7 +130,7 @@ message SignTx {
     optional uint32 version = 4 [default=1];            // transaction version
     optional uint32 lock_time = 5 [default=0];          // transaction lock_time
     optional uint32 expiry = 6;                         // only for Decred and Zcash
-    // optional bool overwintered = 7;                  // deprecated - only for Zcash
+    optional bool _overwintered = 7 [deprecated=true];   // deprecated in 2.3.2, the field is not needed as it can be derived from `version`
     optional uint32 version_group_id = 8;               // only for Zcash, nVersionGroupId
     optional uint32 timestamp = 9;                      // only for Peercoin
     optional uint32 branch_id = 10;                     // only for Zcash, BRANCH_ID
@@ -196,7 +196,7 @@ message TxAck {
         optional bytes extra_data = 8;          // only for Dash, Zcash
         optional uint32 extra_data_len = 9;     // only for Dash, Zcash
         optional uint32 expiry = 10;            // only for Decred and Zcash
-        // optional bool overwintered = 11;     // deprecated - only for Zcash
+        optional bool _overwintered = 11 [deprecated=true];   // Zcash only; deprecated in 2.3.2, the field is not needed, it can be derived from `version`
         optional uint32 version_group_id = 12;  // only for Zcash, nVersionGroupId
         optional uint32 timestamp = 13;         // only for Peercoin
         optional uint32 branch_id = 14;         // only for Zcash, BRANCH_ID

--- a/common/protob/messages-ethereum.proto
+++ b/common/protob/messages-ethereum.proto
@@ -44,7 +44,7 @@ message EthereumGetAddress {
  * @end
  */
 message EthereumAddress {
-    optional bytes old_address = 1 [deprecated=true];  // trezor <1.8.0, <2.1.0 - raw bytes of Ethereum address
+    optional bytes _old_address = 1 [deprecated=true];  // trezor <1.8.0, <2.1.0 - raw bytes of Ethereum address
     optional string address = 2;                       // Ethereum address as hex-encoded string
 }
 

--- a/common/protob/pb2py
+++ b/common/protob/pb2py
@@ -265,7 +265,7 @@ class Descriptor:
         yield "        }"
         # fmt: on
 
-    def process_message(self, message):
+    def process_message(self, message, include_deprecated=False):
         logging.debug("Processing message {}".format(message.name))
         msg_id = self.message_types.get(message.name)
 
@@ -273,6 +273,8 @@ class Descriptor:
         yield self.protobuf_import + " as p"
 
         fields = [ProtoField.from_field(self, field) for field in message.field]
+        if not include_deprecated:
+            fields = [field for field in fields if not field.orig.options.deprecated]
 
         yield from self.process_subtype_imports(fields)
 
@@ -331,9 +333,9 @@ class Descriptor:
             self.enum_types[enum.name][value.name] = value.number
             yield f"{name} = {value.number}  # type: Literal[{value.number}]"
 
-    def process_messages(self, messages):
+    def process_messages(self, messages, include_deprecated=False):
         for message in sorted(messages, key=lambda m: m.name):
-            self.write_to_file(message.name, self.process_message(message))
+            self.write_to_file(message.name, self.process_message(message, include_deprecated))
 
     def process_enums(self, enums):
         for enum in sorted(enums, key=lambda e: e.name):
@@ -358,10 +360,10 @@ class Descriptor:
             for enum in sorted(self.enums, key=lambda m: m.name):
                 init_py.write("from . import {}\n".format(enum.name))
 
-    def write_classes(self, out_dir, init_py=True):
+    def write_classes(self, out_dir, init_py=True, include_deprecated=False):
         self.out_dir = out_dir
         self.process_enums(self.enums)
-        self.process_messages(self.messages)
+        self.process_messages(self.messages, include_deprecated)
         if init_py:
             self.write_init_py()
 
@@ -376,6 +378,7 @@ if __name__ == "__main__":
     parser.add_argument("--message-type", default="MessageType", help="Name of enum with message IDs")
     parser.add_argument("-I", "--protoc-include", action="append", help="protoc include path")
     parser.add_argument("-v", "--verbose", action="store_true", help="Print debug messages")
+    parser.add_argument("-d", "--include-deprecated", action="store_true", help="Include deprecated fields")
     # fmt: on
     args = parser.parse_args()
 
@@ -387,7 +390,7 @@ if __name__ == "__main__":
     descriptor = Descriptor(descriptor_proto, args.message_type, args.protobuf_module)
 
     with tempfile.TemporaryDirectory() as tmpdir:
-        descriptor.write_classes(tmpdir, not args.no_init_py)
+        descriptor.write_classes(tmpdir, not args.no_init_py, args.include_deprecated)
 
         for filename in os.listdir(args.out_dir):
             pathname = os.path.join(args.out_dir, filename)

--- a/core/ChangeLog
+++ b/core/ChangeLog
@@ -14,6 +14,7 @@ _Most likely to be released on July 1st._
 - Dedicated `initialized` field in storage.
 
 ### Deprecated
+- Deprecate `Overwintered` field in `SignTx` and `TxAck`.
 
 ### Removed
 

--- a/core/src/trezor/messages/EthereumAddress.py
+++ b/core/src/trezor/messages/EthereumAddress.py
@@ -15,15 +15,12 @@ class EthereumAddress(p.MessageType):
 
     def __init__(
         self,
-        old_address: bytes = None,
         address: str = None,
     ) -> None:
-        self.old_address = old_address
         self.address = address
 
     @classmethod
     def get_fields(cls) -> Dict:
         return {
-            1: ('old_address', p.BytesType, 0),
             2: ('address', p.UnicodeType, 0),
         }

--- a/core/src/trezor/messages/PassphraseAck.py
+++ b/core/src/trezor/messages/PassphraseAck.py
@@ -16,17 +16,14 @@ class PassphraseAck(p.MessageType):
     def __init__(
         self,
         passphrase: str = None,
-        _state: bytes = None,
         on_device: bool = None,
     ) -> None:
         self.passphrase = passphrase
-        self._state = _state
         self.on_device = on_device
 
     @classmethod
     def get_fields(cls) -> Dict:
         return {
             1: ('passphrase', p.UnicodeType, 0),
-            2: ('_state', p.BytesType, 0),
             3: ('on_device', p.BoolType, 0),
         }

--- a/core/src/trezor/messages/PassphraseRequest.py
+++ b/core/src/trezor/messages/PassphraseRequest.py
@@ -12,15 +12,3 @@ if __debug__:
 
 class PassphraseRequest(p.MessageType):
     MESSAGE_WIRE_TYPE = 41
-
-    def __init__(
-        self,
-        _on_device: bool = None,
-    ) -> None:
-        self._on_device = _on_device
-
-    @classmethod
-    def get_fields(cls) -> Dict:
-        return {
-            1: ('_on_device', p.BoolType, 0),
-        }

--- a/legacy/firmware/protob/messages-ethereum.options
+++ b/legacy/firmware/protob/messages-ethereum.options
@@ -24,6 +24,6 @@ EthereumMessageSignature.signature      max_size:65
 EthereumGetAddress.address_n            max_count:8
 EthereumGetPublicKey.address_n          max_count:8
 
-EthereumAddress.old_address             max_size:20
+EthereumAddress._old_address            max_size:20
 EthereumAddress.address                 max_size:43
 EthereumPublicKey.xpub                  max_size:113

--- a/python/src/trezorlib/messages/EthereumAddress.py
+++ b/python/src/trezorlib/messages/EthereumAddress.py
@@ -15,15 +15,15 @@ class EthereumAddress(p.MessageType):
 
     def __init__(
         self,
-        old_address: bytes = None,
+        _old_address: bytes = None,
         address: str = None,
     ) -> None:
-        self.old_address = old_address
+        self._old_address = _old_address
         self.address = address
 
     @classmethod
     def get_fields(cls) -> Dict:
         return {
-            1: ('old_address', p.BytesType, 0),
+            1: ('_old_address', p.BytesType, 0),
             2: ('address', p.UnicodeType, 0),
         }

--- a/python/src/trezorlib/messages/SignTx.py
+++ b/python/src/trezorlib/messages/SignTx.py
@@ -21,6 +21,7 @@ class SignTx(p.MessageType):
         version: int = None,
         lock_time: int = None,
         expiry: int = None,
+        _overwintered: bool = None,
         version_group_id: int = None,
         timestamp: int = None,
         branch_id: int = None,
@@ -31,6 +32,7 @@ class SignTx(p.MessageType):
         self.version = version
         self.lock_time = lock_time
         self.expiry = expiry
+        self._overwintered = _overwintered
         self.version_group_id = version_group_id
         self.timestamp = timestamp
         self.branch_id = branch_id
@@ -44,6 +46,7 @@ class SignTx(p.MessageType):
             4: ('version', p.UVarintType, 0),  # default=1
             5: ('lock_time', p.UVarintType, 0),  # default=0
             6: ('expiry', p.UVarintType, 0),
+            7: ('_overwintered', p.BoolType, 0),
             8: ('version_group_id', p.UVarintType, 0),
             9: ('timestamp', p.UVarintType, 0),
             10: ('branch_id', p.UVarintType, 0),

--- a/python/src/trezorlib/messages/TransactionType.py
+++ b/python/src/trezorlib/messages/TransactionType.py
@@ -28,6 +28,7 @@ class TransactionType(p.MessageType):
         extra_data: bytes = None,
         extra_data_len: int = None,
         expiry: int = None,
+        _overwintered: bool = None,
         version_group_id: int = None,
         timestamp: int = None,
         branch_id: int = None,
@@ -42,6 +43,7 @@ class TransactionType(p.MessageType):
         self.extra_data = extra_data
         self.extra_data_len = extra_data_len
         self.expiry = expiry
+        self._overwintered = _overwintered
         self.version_group_id = version_group_id
         self.timestamp = timestamp
         self.branch_id = branch_id
@@ -59,6 +61,7 @@ class TransactionType(p.MessageType):
             8: ('extra_data', p.BytesType, 0),
             9: ('extra_data_len', p.UVarintType, 0),
             10: ('expiry', p.UVarintType, 0),
+            11: ('_overwintered', p.BoolType, 0),
             12: ('version_group_id', p.UVarintType, 0),
             13: ('timestamp', p.UVarintType, 0),
             14: ('branch_id', p.UVarintType, 0),

--- a/tools/build_protobuf
+++ b/tools/build_protobuf
@@ -114,6 +114,6 @@ else
 fi
 
 $func core/src/trezor/messages "$CORE_PROTOBUF_SOURCES" "$CORE_MESSAGES_IGNORE" TRUE --no-init-py
-$func python/src/trezorlib/messages "$PYTHON_PROTOBUF_SOURCES" "$PYTHON_MESSAGES_IGNORE" FALSE -P ..protobuf
+$func python/src/trezorlib/messages "$PYTHON_PROTOBUF_SOURCES" "$PYTHON_MESSAGES_IGNORE" FALSE --include-deprecated -P ..protobuf
 
 exit $RETURN


### PR DESCRIPTION
We have to keep the overwintered flag for Suite otherwise Connect needs to have another copy of protobuf messages for older firmwares. We have decided with @matejcik we will solve this using the `deprecated` flag and at the same time we will not generate these fields for Core to make it a bit clearer.
