### PR TITLE
Ping idle timer while in recovery mode

### DIFF
--- a/core/src/apps/management/recovery_device/keyboard_bip39.py
+++ b/core/src/apps/management/recovery_device/keyboard_bip39.py
@@ -1,4 +1,4 @@
-from trezor import io, loop, res, ui
+from trezor import io, loop, res, ui, workflow
 from trezor.crypto import bip39
 from trezor.ui import display
 from trezor.ui.button import Button, ButtonClear, ButtonMono, ButtonMonoConfirm
@@ -204,6 +204,7 @@ class Bip39Keyboard(ui.Layout):
 
             if touch in race.finished:
                 event, x, y = result
+                workflow.idle_timer.touch()
                 self.dispatch(event, x, y)
             else:
                 self.on_timeout()

--- a/core/src/apps/management/recovery_device/keyboard_slip39.py
+++ b/core/src/apps/management/recovery_device/keyboard_slip39.py
@@ -1,4 +1,4 @@
-from trezor import io, loop, res, ui
+from trezor import io, loop, res, ui, workflow
 from trezor.crypto import slip39
 from trezor.ui import display
 from trezor.ui.button import Button, ButtonClear, ButtonMono, ButtonMonoConfirm
@@ -214,6 +214,7 @@ class Slip39Keyboard(ui.Layout):
 
             if touch in race.finished:
                 event, x, y = result
+                workflow.idle_timer.touch()
                 self.dispatch(event, x, y)
             else:
                 self.on_timeout()

--- a/core/src/trezor/loop.py
+++ b/core/src/trezor/loop.py
@@ -121,12 +121,6 @@ def run() -> None:
     task_entry = [0, 0, 0]  # deadline, task, value
     msg_entry = [0, 0]  # iface | flags, value
     while _queue or _paused:
-        # compute the maximum amount of time we can wait for a message
-        if _queue:
-            delay = utime.ticks_diff(_queue.peektime(), utime.ticks_ms())
-        else:
-            delay = 1000  # wait for 1 sec maximum if queue is empty
-
         if __debug__:
             # process synthetic events
             if synthetic_events:
@@ -136,6 +130,16 @@ def run() -> None:
                     synthetic_events.pop(0)
                     for task in msg_tasks:
                         _step(task, event)
+
+                    # XXX: we assume that synthetic events are rare. If there is a lot of them,
+                    # this degrades to "while synthetic_events" and would ignore all real ones.
+                    continue
+
+        # compute the maximum amount of time we can wait for a message
+        if _queue:
+            delay = utime.ticks_diff(_queue.peektime(), utime.ticks_ms())
+        else:
+            delay = 1000  # wait for 1 sec maximum if queue is empty
 
         if io.poll(_paused, msg_entry, delay):
             # message received, run tasks paused on the interface

--- a/core/src/trezor/ui/passphrase.py
+++ b/core/src/trezor/ui/passphrase.py
@@ -1,6 +1,6 @@
 from micropython import const
 
-from trezor import io, loop, res, ui
+from trezor import io, loop, res, ui, workflow
 from trezor.ui import display
 from trezor.ui.button import Button, ButtonClear, ButtonConfirm
 from trezor.ui.swipe import SWIPE_HORIZONTAL, SWIPE_LEFT, Swipe
@@ -221,6 +221,7 @@ class PassphraseKeyboard(ui.Layout):
 
             if touch in race.finished:
                 event, x, y = result
+                workflow.idle_timer.touch()
                 self.dispatch(event, x, y)
             else:
                 self.on_timeout()

--- a/docs/SUMMARY.md
+++ b/docs/SUMMARY.md
@@ -30,6 +30,7 @@
   - [Device Tests](tests/device-tests.md)
   - [Upgrade Tests](tests/upgrade-tests.md)
   - [UI Tests](tests/ui-tests.md)
+  - [Click Tests](tests/click-tests.md)
 - [CI](ci/index.md)
   - [GitLab CI Jobs](ci/jobs.md)
 - [Miscellaneous](misc/index.md)

--- a/docs/tests/click-tests.md
+++ b/docs/tests/click-tests.md
@@ -1,0 +1,67 @@
+# Click Tests
+
+This set of tests is intended for cases where USB communication must be decoupled from
+the input stream. They are mainly based on sending simulated clicks and reading screen
+contents. Unlike device tests that use the `client` fixture, click tests generally
+use the `device_handler` fixture. TODO fixture documentation, the important point is
+that `device_handler` runs `trezorlib` calls in the background and leaves the main
+thread free to interact with the device from the user's perspective.
+
+## Running the full test suite
+
+_Note: You need Pipenv, as mentioned in the core's [documentation](https://docs.trezor.io/trezor-firmware/core/) section._
+
+In the `trezor-firmware` checkout, in the root of the monorepo, install the environment:
+
+```sh
+pipenv sync
+```
+
+Switch to a shell inside theenvironment:
+
+```sh
+pipenv shell
+```
+
+If you want to test against the emulator, run it in a separate terminal:
+```sh
+./core/emu.py
+```
+
+Now you can run the test suite with `pytest` from the root directory:
+```sh
+pytest tests/click_tests
+```
+
+## Click test recorder
+
+The repository now includes a tool for automatically generating testcases from user
+interaction. The resulting test cases must still be tweaked manually, but they can
+provide a solid starting point for a complex interaction pattern.
+
+**Caveat:** The testcase recorder is in alpha-stage, both in terms of functionality
+and code quality. Your mileage may vary.
+
+Run the tool with:
+
+```sh
+python tests/click_tests/record_layout.py
+```
+
+The tool accepts the same arguments as `trezorctl`. For example, to record yourself
+getting an address, use:
+
+```sh
+python tests/click_tests/record_layout.py btc get-address -n m/44h/0h/0h/0/0 -d
+```
+
+Instead of clicking buttons on the emulator, type commands in the terminal that ran
+the tool. A list of possible button clicks will be shown in your terminal. These will
+be sent to the emulator over debuglink.
+
+(Note that if a particular click does not react through the tool, there is a good chance
+that it won't work in the testcase either. Please file an issue.)
+
+After the session is over (when you type `stop`), the tool will collect all layout
+changes and output a testcase in pytest format. Copy-paste that into your test file
+and tweak as appropriate.

--- a/python/CHANGELOG.md
+++ b/python/CHANGELOG.md
@@ -9,6 +9,11 @@ _At the moment, the project does **not** adhere to [Semantic Versioning](https:/
 ## [0.12.1] - unreleased
 [0.12.1]: https://github.com/trezor/trezor-firmware/compare/python/v0.12.0...master
 
+
+### Changed
+
+- do not allow setting auto-lock delay unless PIN is configured
+
 ### Fixed
 
 - correctly calculate hashes for very small firmwares [f#1082]

--- a/python/src/trezorlib/cli/settings.py
+++ b/python/src/trezorlib/cli/settings.py
@@ -75,6 +75,10 @@ def display_rotation(client, rotation):
 @with_client
 def auto_lock_delay(client, delay):
     """Set auto-lock delay (in seconds)."""
+
+    if not client.features.pin_protection:
+        raise click.ClickException("Set up a PIN first")
+
     value, unit = delay[:-1], delay[-1:]
     units = {"s": 1, "m": 60, "h": 3600}
     if unit in units:

--- a/tests/click_tests/record_layout.py
+++ b/tests/click_tests/record_layout.py
@@ -1,3 +1,11 @@
+# click-test generator
+#
+# Beware: This tool is alpha-stage, both in terms of functionality and code quality.
+# It is published here because it can be useful as-is. But it's full of bugs in any
+# case.
+#
+# See docs/tests/click-tests.md for a brief instruction manual.
+
 import inspect
 import sys
 import threading

--- a/tests/click_tests/record_layout.py
+++ b/tests/click_tests/record_layout.py
@@ -1,0 +1,287 @@
+import inspect
+import sys
+import threading
+import time
+from pathlib import Path
+
+import click
+
+from trezorlib import (
+    binance,
+    btc,
+    cardano,
+    cosi,
+    device,
+    eos,
+    ethereum,
+    fido,
+    firmware,
+    lisk,
+    misc,
+    monero,
+    nem,
+    ripple,
+    stellar,
+    tezos,
+)
+from trezorlib.cli.trezorctl import cli as main
+
+from trezorlib import cli, debuglink, protobuf  # isort:skip
+
+
+# make /tests part of sys.path so that we can import buttons.py as a module
+ROOT = Path(__file__).resolve().parent.parent
+sys.path.append(str(ROOT))
+import buttons  # isort:skip
+
+MODULES = (
+    binance,
+    btc,
+    cardano,
+    cosi,
+    device,
+    eos,
+    ethereum,
+    fido,
+    firmware,
+    lisk,
+    misc,
+    monero,
+    nem,
+    ripple,
+    stellar,
+    tezos,
+)
+
+
+CALLS_DONE = []
+DEBUGLINK = None
+
+get_client_orig = cli.TrezorConnection.get_client
+
+
+def get_client(conn):
+    global DEBUGLINK
+    client = get_client_orig(conn)
+    DEBUGLINK = debuglink.DebugLink(client.transport.find_debug())
+    DEBUGLINK.open()
+    DEBUGLINK.watch_layout(True)
+    return client
+
+
+cli.TrezorConnection.get_client = get_client
+
+
+def scan_layouts(dest):
+    while True:
+        try:
+            layout = DEBUGLINK.wait_layout()
+        except Exception:
+            return
+        dest.append(layout)
+
+
+CLICKS_HELP = """\
+Type 'y' or just press Enter to click the right button (usually "OK")
+Type 'n' to click the left button (usually "Cancel")
+Type a digit (0-9) to click the appropriate button as if on a numpad.
+Type 'g1,2' to click button in column 1 and row 2 of 3x5 grid (letter A on mnemonic keyboard).
+Type 'i 1234' to send text "1234" without clicking (useful for PIN, passphrase, etc.)
+Type 'u' or 'j' to swipe up, 'd' or 'k' to swipe down.
+Type 'confirm' for hold-to-confirm (or a confirmation signal without clicking).
+Type 'stop' to stop recording.
+"""
+
+
+def layout_to_output(layout):
+    if isinstance(layout, str):
+        return layout
+
+    if len(layout.lines) > 1:
+        text = " ".join(layout.lines[1:])
+        return f"assert {text!r} in layout.text"
+    else:
+        return f"assert layout.text == {layout.text!r}"
+
+
+def echo(what):
+    click.secho(what, fg="blue", err=True)
+    sys.stderr.flush()
+
+
+def send_clicks(dest):
+    echo(CLICKS_HELP)
+    while True:
+        key = click.prompt(click.style("Send click", fg="blue"), default="y")
+        sys.stderr.flush()
+
+        try:
+            layout = DEBUGLINK.read_layout()
+            echo("Please wait...")
+
+            if key == "confirm":
+                output = "debug.input(button=True)"
+                DEBUGLINK.press_yes()
+            elif key in "uj":
+                output = "debug.input(swipe=messages.DebugSwipeDirection.UP)"
+                DEBUGLINK.swipe_up()
+            elif key in "dk":
+                output = "debug.input(swipe=messages.DebugSwipeDirection.DOWN)"
+                DEBUGLINK.swipe_down()
+            elif key.startswith("i "):
+                input_str = key[2:]
+                output = f"debug.input({input_str!r})"
+                DEBUGLINK.input(input_str)
+            elif key.startswith("g"):
+                x, y = [int(s) - 1 for s in key[1:].split(",")]
+                output = f"debug.click(buttons.grid35({x}, {y}))"
+                DEBUGLINK.click(buttons.grid35(x, y))
+            elif key == "y":
+                output = "debug.click(buttons.OK)"
+                DEBUGLINK.click(buttons.OK)
+            elif key == "n":
+                output = "debug.click(buttons.CANCEL)"
+                DEBUGLINK.click(buttons.CANCEL)
+            elif key in "0123456789":
+                if key == "0":
+                    x, y = 1, 4
+                else:
+                    i = int(key) - 1
+                    x = i % 3
+                    y = 3 - (i // 3)  # trust me
+                output = f"debug.click(buttons.grid35({x}, {y}))"
+                DEBUGLINK.click(buttons.grid35(x, y))
+            elif key == "stop":
+                return
+            else:
+                raise Exception
+
+            # give emulator time to react
+            time.sleep(0.5)
+            new_layout = DEBUGLINK.read_layout()
+            if new_layout != layout:
+                # assume emulator reacted with a layout change
+                output = f"layout = {output[:-1]}, wait=True)"
+
+            dest.append(output)
+        except Exception:
+            echo("bad input")
+
+
+def record_wrapper(name, func):
+    def wrapper(*args, **kwargs):
+        clicks = []
+        layouts = []
+        call_item = [name, args, kwargs, clicks, layouts]
+
+        clicks_thr = threading.Thread(target=send_clicks, args=(clicks,), daemon=True)
+        clicks_thr.start()
+        try:
+            result = func(*args, **kwargs)
+            call_item.extend([result, None])
+            return result
+        except BaseException as e:
+            call_item.extend([None, e])
+            raise
+        finally:
+            clicks_thr.join()
+
+            thr = threading.Thread(target=scan_layouts, args=(layouts,), daemon=True)
+            thr.start()
+            # 5 seconds to download all layout changes so far should be enough
+            thr.join(timeout=5)
+
+            DEBUGLINK.close()  # this should shut down the layout scanning thread
+            thr.join()
+            DEBUGLINK.open()
+
+            CALLS_DONE.append(call_item)
+
+    return wrapper
+
+
+for module in MODULES:
+    assert inspect.ismodule(module)
+    for name, member in inspect.getmembers(module):
+        if not inspect.isfunction(member):
+            continue
+
+        sig = inspect.signature(member)
+        params = list(sig.parameters)
+        if params[0] != "client":
+            continue
+
+        func_name = f"{module.__name__}.{name}"
+        setattr(module, name, record_wrapper(func_name, member))
+
+
+def call_to_strs(call):
+    func_name, args, kwargs, clicks, layouts, result, exception = call
+    args = args[1:]
+
+    arg_text = [repr(arg) for arg in args]
+    arg_text.extend(f"{name}={value!r}" for name, value in kwargs.items())
+
+    call = f"device_handler.run({func_name}, {', '.join(arg_text)})"
+
+    result_list = []
+    if exception is None:
+        if isinstance(result, protobuf.MessageType):
+            result_list.append("result = device_handler.result()")
+            result_list.append(
+                f"assert isinstance(result, messages.{result.__class__.__name__}"
+            )
+            for k, v in result.__dict__.items():
+                if v is None or v == []:
+                    continue
+                result_list.append(f"assert result.{k} == {v!r}")
+        else:
+            result_list.append(f"assert device_handler.result() == {result!r}")
+    else:
+        result_list = [
+            f"with pytest.raises({exception.__class__.__name__}):",
+            "    device_handler.result()",
+        ]
+
+    layouts_iter = iter(layouts)
+    layout_text = ["layout = debug.wait_layout()", next(layouts_iter)]
+
+    for instr in clicks:
+        layout_text.append(instr)
+        if "wait=True" in instr:
+            layout_text.append(next(layouts_iter))
+
+    # finish layouts iterator -- should not do anything ideally
+    layout_text.extend(layouts_iter)
+
+    layout_text = [layout_to_output(l) for l in layout_text]
+
+    all_lines = "\n".join([call] + layout_text + result_list).split("\n")
+    all_lines = [f"    {l}" for l in all_lines]
+    func_name_under = func_name.replace(".", "_")
+    all_lines.insert(0, f"def test_{func_name_under}(device_handler):")
+    all_lines.insert(1, "    debug = device_handler.debuglink()")
+
+    return "\n".join(all_lines)
+
+
+if __name__ == "__main__":
+    echo(
+        """\
+Quick&Dirty Test Case Recorder.
+
+Use as you would use trezorctl, input clicking commands via host keyboard
+for best results.
+"""
+    )
+    try:
+        main()
+    finally:
+        if DEBUGLINK is not None:
+            DEBUGLINK.watch_layout(False)
+            DEBUGLINK.close()
+            echo("\n# ========== test cases ==========\n")
+            for call in CALLS_DONE:
+                testcase = call_to_strs(call)
+                echo(testcase)
+                echo("\n")

--- a/tests/click_tests/test_autolock.py
+++ b/tests/click_tests/test_autolock.py
@@ -1,0 +1,195 @@
+# This file is part of the Trezor project.
+#
+# Copyright (C) 2012-2019 SatoshiLabs and contributors
+#
+# This library is free software: you can redistribute it and/or modify
+# it under the terms of the GNU Lesser General Public License version 3
+# as published by the Free Software Foundation.
+#
+# This library is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU Lesser General Public License for more details.
+#
+# You should have received a copy of the License along with this library.
+# If not, see <https://www.gnu.org/licenses/lgpl-3.0.html>.
+
+import time
+
+import pytest
+
+from trezorlib import btc, device, exceptions, messages
+from trezorlib.tools import parse_path
+
+from .. import buttons, common
+from ..tx_cache import TxCache
+from . import recovery
+
+TX_CACHE = TxCache("Bitcoin")
+
+TXHASH_d5f65e = bytes.fromhex(
+    "d5f65ee80147b4bcc70b75e4bbf2d7382021b871bd8867ef8fa525ef50864882"
+)
+
+PIN4 = "1234"
+
+WORDS_20 = buttons.grid34(2, 2)
+
+
+def set_autolock_delay(device_handler, delay_ms):
+    debug = device_handler.debuglink()
+
+    device_handler.run(device.apply_settings, auto_lock_delay_ms=delay_ms)
+
+    layout = debug.wait_layout()
+    assert layout.text == "PinDialog"
+    debug.input("1234")
+
+    layout = debug.wait_layout()
+    assert f"auto-lock your device after {delay_ms // 1000} seconds" in layout.text
+    debug.click(buttons.OK)
+
+    layout = debug.wait_layout()
+    assert layout.text == "Homescreen"
+    assert device_handler.result() == "Settings applied"
+
+
+@pytest.mark.setup_client(pin=PIN4)
+def test_autolock_interrupts_signing(device_handler):
+    set_autolock_delay(device_handler, 10_000)
+
+    debug = device_handler.debuglink()
+    # try to sign a transaction
+    inp1 = messages.TxInputType(
+        address_n=parse_path("44h/0h/0h/0/0"),
+        # amount=390000,
+        prev_hash=TXHASH_d5f65e,
+        prev_index=0,
+    )
+
+    out1 = messages.TxOutputType(
+        address="1MJ2tj2ThBE62zXbBYA5ZaN3fdve5CPAz1",
+        amount=390000 - 10000,
+        script_type=messages.OutputScriptType.PAYTOADDRESS,
+    )
+
+    device_handler.run(btc.sign_tx, "Bitcoin", [inp1], [out1], prev_txes=TX_CACHE)
+
+    layout = debug.wait_layout()
+    assert "1MJ2tj2ThBE62zXbBYA5ZaN3fdve5CPAz1" in layout.text.replace(" ", "")
+
+    layout = debug.click(buttons.OK, wait=True)
+    assert "Total amount: 0.0039 BTC" in layout.text
+
+    # wait for autolock to kick in
+    time.sleep(10.1)
+    with pytest.raises(exceptions.Cancelled):
+        device_handler.result()
+
+
+@pytest.mark.xfail(reason="depends on #922")
+@pytest.mark.setup_client(pin=PIN4, passphrase=True)
+def test_autolock_passphrase_keyboard(device_handler):
+    set_autolock_delay(device_handler, 10_000)
+    debug = device_handler.debuglink()
+
+    # get address
+    device_handler.run(common.get_test_address)
+
+    # enter passphrase - slowly
+    layout = debug.wait_layout()
+    assert layout.text == "PassphraseKeyboard"
+
+    CENTER_BUTTON = buttons.grid35(1, 2)
+    for _ in range(11):
+        debug.click(CENTER_BUTTON)
+        time.sleep(1.1)
+
+    assert device_handler.result() == "TODO when #922 fixed"
+
+
+@pytest.mark.setup_client(pin=PIN4)
+def test_dryrun_locks_at_number_of_words(device_handler):
+    set_autolock_delay(device_handler, 10_000)
+    debug = device_handler.debuglink()
+
+    device_handler.run(device.recover, dry_run=True)
+
+    # unlock
+    layout = debug.wait_layout()
+    assert "Do you really want to check the recovery seed?" in layout.text
+    layout = debug.click(buttons.OK, wait=True)
+    assert layout.text == "PinDialog"
+    layout = debug.input(PIN4, wait=True)
+    assert "Select number of words " in layout.text
+
+    # wait for autolock to trigger
+    time.sleep(10.1)
+    layout = debug.wait_layout()
+    assert layout.text == "Lockscreen"
+    with pytest.raises(exceptions.Cancelled):
+        device_handler.result()
+
+    # unlock
+    layout = debug.click(buttons.OK, wait=True)
+    assert layout.text == "PinDialog"
+    layout = debug.input(PIN4, wait=True)
+
+    # we are back at homescreen
+    assert "Select number of words" in layout.text
+
+
+@pytest.mark.setup_client(pin=PIN4)
+def test_dryrun_locks_at_word_entry(device_handler):
+    set_autolock_delay(device_handler, 10_000)
+    debug = device_handler.debuglink()
+
+    device_handler.run(device.recover, dry_run=True)
+
+    # unlock
+    layout = debug.wait_layout()
+    assert "Do you really want to check the recovery seed?" in layout.text
+    layout = debug.click(buttons.OK, wait=True)
+    assert layout.text == "PinDialog"
+    layout = debug.input(PIN4, wait=True)
+
+    # select 20 words
+    recovery.select_number_of_words(debug, 20)
+
+    layout = debug.click(buttons.OK, wait=True)
+    # make sure keyboard locks
+    assert layout.text == "Slip39Keyboard"
+    time.sleep(10.1)
+    layout = debug.wait_layout()
+    assert layout.text == "Lockscreen"
+    with pytest.raises(exceptions.Cancelled):
+        device_handler.result()
+
+
+@pytest.mark.setup_client(pin=PIN4)
+def test_dryrun_enter_word_slowly(device_handler):
+    set_autolock_delay(device_handler, 10_000)
+    debug = device_handler.debuglink()
+
+    device_handler.run(device.recover, dry_run=True)
+
+    # unlock
+    layout = debug.wait_layout()
+    assert "Do you really want to check the recovery seed?" in layout.text
+    layout = debug.click(buttons.OK, wait=True)
+    assert layout.text == "PinDialog"
+    layout = debug.input(PIN4, wait=True)
+
+    # select 20 words
+    recovery.select_number_of_words(debug, 20)
+
+    layout = debug.click(buttons.OK, wait=True)
+    # type the word OCEAN slowly
+    assert layout.text == "Slip39Keyboard"
+    for coords in buttons.type_word("ocea"):
+        time.sleep(9)
+        debug.click(coords)
+    layout = debug.click(buttons.CONFIRM_WORD, wait=True)
+    # should not have locked, even though we took 9 seconds to type each letter
+    assert layout.text == "Slip39Keyboard"
+    device_handler.kill_task()

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -259,7 +259,12 @@ def device_handler(client, request):
     device_handler = BackgroundDeviceHandler(client)
     yield device_handler
 
-    # make sure all background tasks are done
+    # if test did not finish, e.g. interrupted by Ctrl+C, the pytest_runtest_makereport
+    # did not create the attribute we need
+    if not hasattr(request.node, "rep_call"):
+        return
+
+    # if test finished, make sure all background tasks are done
     finalized_ok = device_handler.check_finalize()
     if request.node.rep_call.passed and not finalized_ok:
         raise RuntimeError("Test did not check result of background task")

--- a/tests/device_handler.py
+++ b/tests/device_handler.py
@@ -1,5 +1,6 @@
 from concurrent.futures import ThreadPoolExecutor
 
+from trezorlib.client import PASSPHRASE_ON_DEVICE
 from trezorlib.transport import udp
 
 udp.SOCKET_TIMEOUT = 0.1
@@ -15,8 +16,11 @@ class NullUI:
         raise NotImplementedError("NullUI should not be used with T1")
 
     @staticmethod
-    def get_passphrase():
-        raise NotImplementedError("NullUI should not be used with T1")
+    def get_passphrase(available_on_device=False):
+        if available_on_device:
+            return PASSPHRASE_ON_DEVICE
+        else:
+            raise NotImplementedError("NullUI should not be used with T1")
 
 
 class BackgroundDeviceHandler:


### PR DESCRIPTION
fixes #1099 by making sure the device does not auto-lock while entering a word.

also adds a warning to trezorctl that you don't have PIN and you're trying to set up autolock. should help testers out

---

Also adds a little tool that can record and generate a click-test case from a trezorctl sequence.
It's a horrible thrown-together hack, and at this moment I'm not interested in improving the code of this tool even a little.

If you feel that a tool in this state should not be commited into our repository, I'll remove it from the PR and publish separately as a gist. If someone wants to dive in, add comments and improve it, feel free.