### PR TITLE
Debugging helpers

### DIFF
--- a/core/embed/firmware/firmware_flash_t1.jlink
+++ b/core/embed/firmware/firmware_flash_t1.jlink
@@ -1,4 +1,4 @@
-device CORTEX-M3
+device STM32F205RG
 if swd
 speed 50000
 loadbin build/firmware/firmware.bin 0x08010000

--- a/core/embed/firmware/main.c
+++ b/core/embed/firmware/main.c
@@ -63,7 +63,9 @@ int main(void) {
   collect_hw_entropy();
 
 #if TREZOR_MODEL == T
+#if PRODUCTION
   check_and_replace_bootloader();
+#endif
   // Enable MPU
   mpu_config_firmware();
 #endif


### PR DESCRIPTION
- replace bootloader in core firmware's `main` only when `PRODUCTION` is set.
- proper device description for T1 core port when flashing via JLink