### PR TITLE
Autolock delay setting: raise error when out of range

### DIFF
--- a/core/src/trezor/strings.py
+++ b/core/src/trezor/strings.py
@@ -45,3 +45,22 @@ def format_plural(string: str, count: int, plural: str) -> str:
             plural = plural + "s"
 
     return string.format(count=count, plural=plural)
+
+
+def format_duration_ms(milliseconds: int) -> str:
+    """
+    Returns human-friendly representation of a duration. Truncates all decimals.
+    """
+    units = (
+        ("hour", 60 * 60 * 1000),
+        ("minute", 60 * 1000),
+        ("second", 1000),
+    )
+    for unit, divisor in units:
+        if milliseconds >= divisor:
+            break
+    else:
+        unit = "millisecond"
+        divisor = 1
+
+    return format_plural("{count} {plural}", milliseconds // divisor, unit)

--- a/core/tests/test_trezor.strings.py
+++ b/core/tests/test_trezor.strings.py
@@ -32,6 +32,27 @@ class TestStrings(unittest.TestCase):
         with self.assertRaises(ValueError):
             strings.format_plural("Hello", 1, "share")
 
+    def test_format_duration_ms(self):
+        VECTORS = [
+            (0, "0 milliseconds"),
+            (1, "1 millisecond"),
+            (999, "999 milliseconds"),
+            (1000, "1 second"),
+            (2345, "2 seconds"),
+            (59999, "59 seconds"),
+            (60 * 1000, "1 minute"),
+            (119 * 1000, "1 minute"),
+            (120 * 1000, "2 minutes"),
+            (59 * 60 * 1000, "59 minutes"),
+            (60 * 60 * 1000, "1 hour"),
+            (119 * 60 * 1000, "1 hour"),
+            (3 * 60 * 60 * 1000, "3 hours"),
+            (48 * 60 * 60 * 1000, "48 hours"),
+        ]
+
+        for v in VECTORS:
+            self.assertEqual(strings.format_duration_ms(v[0]), v[1])
+
 
 if __name__ == '__main__':
     unittest.main()

--- a/legacy/firmware/config.c
+++ b/legacy/firmware/config.c
@@ -937,8 +937,7 @@ uint32_t config_getAutoLockDelayMs() {
 }
 
 void config_setAutoLockDelayMs(uint32_t auto_lock_delay_ms) {
-  const uint32_t min_delay_ms = 10 * 1000U;  // 10 seconds
-  auto_lock_delay_ms = MAX(auto_lock_delay_ms, min_delay_ms);
+  auto_lock_delay_ms = MAX(auto_lock_delay_ms, MIN_AUTOLOCK_DELAY_MS);
   if (sectrue == storage_set(KEY_AUTO_LOCK_DELAY_MS, &auto_lock_delay_ms,
                              sizeof(auto_lock_delay_ms))) {
     autoLockDelayMs = auto_lock_delay_ms;

--- a/legacy/firmware/config.h
+++ b/legacy/firmware/config.h
@@ -85,6 +85,8 @@ extern Storage configUpdate;
 #define MAX_MNEMONIC_LEN 240
 #define HOMESCREEN_SIZE 1024
 #define UUID_SIZE 12
+#define MIN_AUTOLOCK_DELAY_MS (10 * 1000U)  // 10 seconds
+#define MAX_AUTOLOCK_DELAY_MS 0x20000000U   // ~6 days
 
 void config_init(void);
 void session_clear(bool lock);

--- a/legacy/firmware/fsm_msg_common.h
+++ b/legacy/firmware/fsm_msg_common.h
@@ -413,9 +413,19 @@ void fsm_msgApplySettings(const ApplySettings *msg) {
   }
 
   if (msg->has_auto_lock_delay_ms) {
-    layoutDialogSwipe(&bmp_icon_question, _("Cancel"), _("Confirm"), NULL,
-                      _("Do you really want to"), _("change auto-lock"),
-                      _("delay?"), NULL, NULL, NULL);
+    if (msg->auto_lock_delay_ms < MIN_AUTOLOCK_DELAY_MS) {
+      fsm_sendFailure(FailureType_Failure_ProcessError,
+                      _("Auto-lock delay too short"));
+      layoutHome();
+      return;
+    }
+    if (msg->auto_lock_delay_ms > MAX_AUTOLOCK_DELAY_MS) {
+      fsm_sendFailure(FailureType_Failure_ProcessError,
+                      _("Auto-lock delay too long"));
+      layoutHome();
+      return;
+    }
+    layoutConfirmAutoLockDelay(msg->auto_lock_delay_ms);
     if (!protectButton(ButtonRequestType_ButtonRequest_ProtectCall, false)) {
       fsm_sendFailure(FailureType_Failure_ActionCancelled, NULL);
       layoutHome();

--- a/legacy/firmware/layout2.c
+++ b/legacy/firmware/layout2.c
@@ -1022,3 +1022,32 @@ void layoutCosiCommitSign(const uint32_t *address_n, size_t address_n_count,
   layoutDialogSwipe(&bmp_icon_question, _("Cancel"), _("Confirm"), desc, str[0],
                     str[1], str[2], str[3], NULL, NULL);
 }
+
+void layoutConfirmAutoLockDelay(uint32_t delay_ms) {
+  char line[sizeof("after 4294967296 minutes?")] = {0};
+
+  const char *unit = _("second");
+  uint32_t num = delay_ms / 1000U;
+
+  if (delay_ms >= 60 * 60 * 1000) {
+    unit = _("hour");
+    num /= 60 * 60U;
+  } else if (delay_ms >= 60 * 1000) {
+    unit = _("minute");
+    num /= 60U;
+  }
+
+  strlcpy(line, _("after "), sizeof(line));
+  size_t off = strlen(line);
+  bn_format_uint64(num, NULL, NULL, 0, 0, false, &line[off],
+                   sizeof(line) - off);
+  strlcat(line, " ", sizeof(line));
+  strlcat(line, unit, sizeof(line));
+  if (num > 1) {
+    strlcat(line, "s", sizeof(line));
+  }
+  strlcat(line, "?", sizeof(line));
+  layoutDialogSwipe(&bmp_icon_question, _("Cancel"), _("Confirm"), NULL,
+                    _("Do you really want to"), _("auto-lock your device"),
+                    line, NULL, NULL, NULL);
+}

--- a/legacy/firmware/layout2.h
+++ b/legacy/firmware/layout2.h
@@ -90,6 +90,8 @@ void layoutNEMLevy(const NEMMosaicDefinition *definition, uint8_t network);
 void layoutCosiCommitSign(const uint32_t *address_n, size_t address_n_count,
                           const uint8_t *data, uint32_t len, bool final_sign);
 
+void layoutConfirmAutoLockDelay(uint32_t delay_ms);
+
 const char **split_message(const uint8_t *msg, uint32_t len, uint32_t rowlen);
 const char **split_message_hex(const uint8_t *msg, uint32_t len);
 

--- a/tests/ui_tests/fixtures.json
+++ b/tests/ui_tests/fixtures.json
@@ -1,6 +1,11 @@
 {
 "test_autolock.py::test_apply_auto_lock_delay": "1997527e85989f3ca5719f93cd76bcfb8f125fb96ef3025073b13fd4de7a5fa2",
-"test_autolock.py::test_apply_minimal_auto_lock_delay": "adc5da99fcc8b4023d6989fa59f69c3918e70165bdeb693a887364e2009ee2fa",
+"test_autolock.py::test_apply_auto_lock_delay_valid[10]": "d03aca645ebd8a44c8a1bb24a275e31441245c3211f7c82365b2f432370b05bc",
+"test_autolock.py::test_apply_auto_lock_delay_valid[123]": "7588a745923a732cd8715ab76f95b7abb9c2caf043075ec1a73e31b2453743a1",
+"test_autolock.py::test_apply_auto_lock_delay_valid[3601]": "904323c7f7a27393c4a192680340d571a2a4899f0300da4d0e439f55f32768e8",
+"test_autolock.py::test_apply_auto_lock_delay_valid[536870]": "ff8b1d62a60d581504779cb7bb3dcf7882e960914bac4981d52fa714880c3d1e",
+"test_autolock.py::test_apply_auto_lock_delay_valid[60]": "02f813f809bec7b303998fe288f02bfa4cd1a30990c0dc071ad51ff86f2739e6",
+"test_autolock.py::test_apply_auto_lock_delay_valid[7227]": "41bca947f7834baa9968cbb164b70005aee4dbf23586187ab3bef336ff42a422",
 "test_autolock.py::test_autolock_cancels_ui": "eedc6196565bf6d53bc9c3f8984acc2bb91d2d71e57f3a28f8afbe35b02fb4dc",
 "test_basic.py-test_device_id_different": "bc6acd0386b9d009e6550519917d6e08632b3badde0b0cf04c95abe5f773038a",
 "test_basic.py-test_device_id_same": "5a80508a71a9ef64f94762b07636f90e464832f0f4a3102af8fa1a8c69e94586",


### PR DESCRIPTION
Fixes #1093. The confirmation screen was changed to show the value in more human-readable units.