### PR TITLE
core: reduce gc.collect calls during bitcon sign_tx

### DIFF
--- a/core/src/apps/bitcoin/sign_tx/bitcoin.py
+++ b/core/src/apps/bitcoin/sign_tx/bitcoin.py
@@ -1,4 +1,3 @@
-import gc
 from micropython import const
 
 from trezor import wire
@@ -438,7 +437,6 @@ class Bitcoin:
         signature = ecdsa_sign(node, tx_digest)
 
         # serialize input with correct signature
-        gc.collect()
         script_sig = self.input_derive_script(txi, node.public_key(), signature)
         self.write_tx_input(self.serialized_tx, txi, script_sig)
         self.set_serialized_signature(i, signature)

--- a/core/src/apps/bitcoin/sign_tx/bitcoinlike.py
+++ b/core/src/apps/bitcoin/sign_tx/bitcoinlike.py
@@ -1,4 +1,3 @@
-import gc
 from micropython import const
 
 from trezor import wire
@@ -31,7 +30,6 @@ class Bitcoinlike(Bitcoin):
             multisig.multisig_pubkey_index(txi.multisig, public_key)
 
         # serialize input with correct signature
-        gc.collect()
         script_sig = self.input_derive_script(txi, public_key, signature)
         self.write_tx_input(self.serialized_tx, txi, script_sig)
         self.set_serialized_signature(i_sign, signature)

--- a/core/src/apps/bitcoin/sign_tx/decred.py
+++ b/core/src/apps/bitcoin/sign_tx/decred.py
@@ -1,4 +1,3 @@
-import gc
 from micropython import const
 
 from trezor import wire
@@ -123,7 +122,6 @@ class Decred(Bitcoin):
             signature = ecdsa_sign(key_sign, sig_hash)
 
             # serialize input with correct signature
-            gc.collect()
             script_sig = self.input_derive_script(txi_sign, key_sign_pub, signature)
             self.write_tx_input_witness(self.serialized_tx, txi_sign, script_sig)
             self.set_serialized_signature(i_sign, signature)

--- a/core/src/apps/bitcoin/sign_tx/helpers.py
+++ b/core/src/apps/bitcoin/sign_tx/helpers.py
@@ -1,5 +1,3 @@
-import gc
-
 from trezor import utils, wire
 from trezor.messages import InputScriptType, OutputScriptType
 from trezor.messages.RequestType import (
@@ -117,7 +115,6 @@ def request_tx_meta(tx_req: TxRequest, coin: CoinInfo, tx_hash: bytes = None) ->
     tx_req.details.tx_hash = tx_hash
     ack = yield tx_req
     _clear_tx_request(tx_req)
-    gc.collect()
     return sanitize_tx_meta(ack.tx, coin)
 
 
@@ -130,7 +127,6 @@ def request_tx_extra_data(  # type: ignore
     tx_req.details.tx_hash = tx_hash
     ack = yield tx_req
     _clear_tx_request(tx_req)
-    gc.collect()
     return ack.tx.extra_data
 
 
@@ -140,7 +136,6 @@ def request_tx_input(tx_req: TxRequest, i: int, coin: CoinInfo, tx_hash: bytes =
     tx_req.details.tx_hash = tx_hash
     ack = yield tx_req
     _clear_tx_request(tx_req)
-    gc.collect()
     return sanitize_tx_input(ack.tx, coin)
 
 
@@ -150,7 +145,6 @@ def request_tx_output(tx_req: TxRequest, i: int, coin: CoinInfo, tx_hash: bytes 
     tx_req.details.tx_hash = tx_hash
     ack = yield tx_req
     _clear_tx_request(tx_req)
-    gc.collect()
     if tx_hash is None:
         return sanitize_tx_output(ack.tx, coin)
     else:
@@ -161,7 +155,6 @@ def request_tx_finish(tx_req: TxRequest) -> Awaitable[Any]:  # type: ignore
     tx_req.request_type = TXFINISHED
     yield tx_req
     _clear_tx_request(tx_req)
-    gc.collect()
 
 
 def _clear_tx_request(tx_req: TxRequest) -> None:


### PR DESCRIPTION
Fixes (partially) #1108.

TT runtime for `test_msg_signtx.py::TestMsgSigntx::test_lots_of_inputs` :
* master (48e1dc9): ~23m30s
* this branch: ~17m30s
* this branch + [another gc.collect removed](https://github.com/trezor/trezor-firmware/blob/48e1dc957f00d95585fefb3e8b362abef75977f4/core/src/apps/bitcoin/sign_tx/bitcoin.py#L441): ~17m30s
* removing unimports in [\_\_init.py__](https://github.com/trezor/trezor-firmware/blob/48e1dc957f00d95585fefb3e8b362abef75977f4/core/src/apps/bitcoin/sign_tx/__init__.py) also doesn't seem to make any difference in speed

Not really sure how to benchmark this better or how to verify that the changes don't break anything - tests on hardware are pretty slow. Suggestions appreciated.