### PR TITLE
[Trivial] Enable GRS support in trezor-connect

### DIFF
--- a/common/defs/support.json
+++ b/common/defs/support.json
@@ -16,6 +16,7 @@
       "bitcoin:FTC": true,
       "bitcoin:GAME": true,
       "bitcoin:GIN": true,
+      "bitcoin:GRS": true,
       "bitcoin:KMD": true,
       "bitcoin:KOTO": true,
       "bitcoin:LTC": true,


### PR DESCRIPTION
Apparently al GRS info was previously added but connect support was not enabled.