### PR TITLE
Update UDP port based on usage at https://trezor.io/start/

### DIFF
--- a/core/embed/unix/usb.c
+++ b/core/embed/unix/usb.c
@@ -45,7 +45,7 @@ __fatal_error(const char *expr, const char *msg, const char *file, int line,
 // gracefully ignores all other USB interfaces
 
 #define USBD_MAX_NUM_INTERFACES 8
-#define TREZOR_UDP_PORT 21324
+#define TREZOR_UDP_PORT 21325
 
 static struct {
   usb_iface_type_t type;

--- a/docs/core/emulator/index.md
+++ b/docs/core/emulator/index.md
@@ -14,7 +14,7 @@ Emulator significantly speeds up development and has several features to help yo
 2. run `emu.py` inside the pipenv environment:
    - either enter `pipenv shell` first, and then use `./emu.py`
    - or always use `pipenv run ./emu.py`
-3. to use [bridge](https://github.com/trezor/trezord-go) with the emulator support, start it with `trezord -e 21324`
+3. to use [bridge](https://github.com/trezor/trezord-go) with the emulator support, start it with `trezord -e 21325`
 
 Now you can use the emulator the same way as you use the device, for example you can visit our Wallet (https://wallet.trezor.io), use our Python CLI tool (`trezorctl`) etc. Simply click to emulate screen touches.
 

--- a/legacy/emulator/udp.c
+++ b/legacy/emulator/udp.c
@@ -24,7 +24,7 @@
 #include <string.h>
 #include <sys/socket.h>
 
-#define TREZOR_UDP_PORT 21324
+#define TREZOR_UDP_PORT 21325
 
 struct usb_socket {
   int fd;

--- a/legacy/script/test
+++ b/legacy/script/test
@@ -12,7 +12,7 @@ if [ "$EMULATOR" = 1 ]; then
     trap "kill %1" EXIT
 
     "${EMULATOR_BINARY}" &
-    export TREZOR_PATH=udp:127.0.0.1:21324
+    export TREZOR_PATH=udp:127.0.0.1:21325
     "${PYTHON:-python}" script/wait_for_emulator.py
 fi
 

--- a/legacy/script/wait_for_emulator.py
+++ b/legacy/script/wait_for_emulator.py
@@ -4,7 +4,7 @@ import socket
 import sys
 import time
 
-DEFAULT_ADDR = "127.0.0.1:21324"
+DEFAULT_ADDR = "127.0.0.1:21325"
 
 if len(sys.argv) > 1:
     addr = sys.argv[1]

--- a/python/src/trezorlib/_internal/emulator.py
+++ b/python/src/trezorlib/_internal/emulator.py
@@ -75,7 +75,7 @@ class Emulator:
         self.client = None
         self.process = None
 
-        self.port = 21324
+        self.port = 21325
         self.headless = headless
         self.debug = debug
         self.extra_args = list(extra_args)

--- a/python/src/trezorlib/transport/udp.py
+++ b/python/src/trezorlib/transport/udp.py
@@ -31,7 +31,7 @@ LOG = logging.getLogger(__name__)
 class UdpTransport(ProtocolBasedTransport):
 
     DEFAULT_HOST = "127.0.0.1"
-    DEFAULT_PORT = 21324
+    DEFAULT_PORT = 21325
     PATH_PREFIX = "udp"
     ENABLED = True
 


### PR DESCRIPTION
Given the default UDP port in the repo seems to be defined as `21324`,
I do not understand why https://trezor.io/start/ would be configured to use `21325`.

Having this discrepancy makes it difficult for developers to get started with using the emulator.
Hadn't I checked the browser console on https://trezor.io/start/, it would've taken me a good while to spot the difference.

Since devs already have to set the udev rules and possibly install the trezor-bridge, why add an additional third hurdle?
Maybe I'm missing something, but possibly unifying the port number could solve some headaches :)

Apart from that, awesome job on the emulator! Great tool!