### PR TITLE
Unify application labeling between U2F and FIDO2

### DIFF
--- a/common/defs/fido/aws.json
+++ b/common/defs/fido/aws.json
@@ -1,4 +1,9 @@
 {
-  "label": "Amazon Web Services",
-  "u2f": ["968978a29953de52d3ef0f0c71b7b7b6b1af9f08e257896a8d8126918530293b"]
+  "name": "Amazon Web Services",
+  "u2f": [
+    {
+      "app_id": "968978a29953de52d3ef0f0c71b7b7b6b1af9f08e257896a8d8126918530293b",
+      "label": "aws.amazon.com"
+    }
+  ]
 }

--- a/common/defs/fido/binance.json
+++ b/common/defs/fido/binance.json
@@ -1,5 +1,5 @@
 {
-  "label": "Binance",
+  "name": "Binance",
   "webauthn": ["www.binance.com"],
   "use_sign_count": false,
   "use_self_attestation": true

--- a/common/defs/fido/bitbucket.json
+++ b/common/defs/fido/bitbucket.json
@@ -1,4 +1,9 @@
 {
-  "label": "Bitbucket",
-  "u2f": ["12743b921297b77f1135e41fdedd4a846afe82e1f36932a9912f3b0d8dfb7d0e"]
+  "name": "Bitbucket",
+  "u2f": [
+    {
+      "app_id": "12743b921297b77f1135e41fdedd4a846afe82e1f36932a9912f3b0d8dfb7d0e",
+      "label": "bitbucket.org"
+    }
+  ]
 }

--- a/common/defs/fido/bitfinex.json
+++ b/common/defs/fido/bitfinex.json
@@ -1,4 +1,9 @@
 {
-  "label": "Bitfinex",
-  "u2f": ["302fd5b4492a07b9febb30e73269eca501205ccfe0c20bf7b472fa2d31e21e63"]
+  "name": "Bitfinex",
+  "u2f": [
+    {
+      "app_id": "302fd5b4492a07b9febb30e73269eca501205ccfe0c20bf7b472fa2d31e21e63",
+      "label": "www.bitfinex.com"
+    }
+  ]
 }

--- a/common/defs/fido/bitwarden.json
+++ b/common/defs/fido/bitwarden.json
@@ -1,4 +1,9 @@
 {
-  "label": "Bitwarden",
-  "u2f": ["a34d309ffa28c12414b8ba6c07ee1efae1a85e8a04614859a67c0493b6956190"]
+  "name": "Bitwarden",
+  "u2f": [
+    {
+      "app_id": "a34d309ffa28c12414b8ba6c07ee1efae1a85e8a04614859a67c0493b6956190",
+      "label": "vault.bitwarden.com"
+    }
+  ]
 }

--- a/common/defs/fido/dashlane.json
+++ b/common/defs/fido/dashlane.json
@@ -1,4 +1,9 @@
 {
-  "label": "Dashlane",
-  "u2f": ["68201915d74cb42af5b3cc5c95b9553e3e3a83b4d2a93b45fbadaa8469ff8e6e"]
+  "name": "Dashlane",
+  "u2f": [
+    {
+      "app_id": "68201915d74cb42af5b3cc5c95b9553e3e3a83b4d2a93b45fbadaa8469ff8e6e",
+      "label": "www.dashlane.com"
+    }
+  ]
 }

--- a/common/defs/fido/dropbox.json
+++ b/common/defs/fido/dropbox.json
@@ -1,6 +1,11 @@
 {
-  "label": "Dropbox",
-  "u2f": ["c50f8a7b708e92f82e7a50e2bdc55d8fd91a22fe6b29c0cdf7805530842af581"],
+  "name": "Dropbox",
+  "u2f": [
+    {
+      "app_id": "c50f8a7b708e92f82e7a50e2bdc55d8fd91a22fe6b29c0cdf7805530842af581",
+      "label": "www.dropbox.com"
+    }
+  ],
   "webauthn": ["www.dropbox.com"],
   "use_sign_count": false
 }

--- a/common/defs/fido/duo.json
+++ b/common/defs/fido/duo.json
@@ -1,4 +1,9 @@
 {
-  "label": "Duo",
-  "u2f": ["f3e2042f94607da0a9c1f3b95e0d2f2bb2e069c5bb4fa764affa647d847b7ed6"]
+  "name": "Duo",
+  "u2f": [
+    {
+      "app_id": "f3e2042f94607da0a9c1f3b95e0d2f2bb2e069c5bb4fa764affa647d847b7ed6",
+      "label": "duosecurity.com"
+    }
+  ]
 }

--- a/common/defs/fido/facebook.json
+++ b/common/defs/fido/facebook.json
@@ -1,4 +1,4 @@
 {
-  "label": "Facebook",
+  "name": "Facebook",
   "webauthn": ["facebook.com"]
 }

--- a/common/defs/fido/fastmail.json
+++ b/common/defs/fido/fastmail.json
@@ -1,4 +1,9 @@
 {
-  "label": "FastMail",
-  "u2f": ["6966abe3674ea2f53079eb710197848c9be6f363992fd029e9898447cb9f0084"]
+  "name": "FastMail",
+  "u2f": [
+    {
+      "app_id": "6966abe3674ea2f53079eb710197848c9be6f363992fd029e9898447cb9f0084",
+      "label": "www.fastmail.com"
+    }
+  ]
 }

--- a/common/defs/fido/fedora.json
+++ b/common/defs/fido/fedora.json
@@ -1,4 +1,9 @@
 {
-  "label": "Fedora",
-  "u2f": ["9d61442f5ce133bd46544fc42f0a6d54c0deb88840cac2b6aefa6514f89349e9"]
+  "name": "Fedora",
+  "u2f": [
+    {
+      "app_id": "9d61442f5ce133bd46544fc42f0a6d54c0deb88840cac2b6aefa6514f89349e9",
+      "label": "fedoraproject.org"
+    }
+  ]
 }

--- a/common/defs/fido/gandi.json
+++ b/common/defs/fido/gandi.json
@@ -1,6 +1,11 @@
 {
-  "label": "Gandi",
-  "u2f": ["a4e22dcafea7e90e128950113989fc45978dc9fb87767560516c1c69dfdfd196"],
+  "name": "Gandi",
+  "u2f": [
+    {
+      "app_id": "a4e22dcafea7e90e128950113989fc45978dc9fb87767560516c1c69dfdfd196",
+      "label": "gandi.net"
+    }
+  ],
   "webauthn": ["gandi.net"],
   "use_sign_count": false
 }

--- a/common/defs/fido/github.json
+++ b/common/defs/fido/github.json
@@ -1,6 +1,11 @@
 {
-  "label": "GitHub",
-  "u2f": ["70617dfed065863af47c15556c91798880828cc407fdf70ae85011569465a075"],
+  "name": "GitHub",
+  "u2f": [
+    {
+      "app_id": "70617dfed065863af47c15556c91798880828cc407fdf70ae85011569465a075",
+      "label": "github.com"
+    }
+  ],
   "webauthn": ["github.com"],
   "use_sign_count": true
 }

--- a/common/defs/fido/gitlab.json
+++ b/common/defs/fido/gitlab.json
@@ -1,4 +1,9 @@
 {
-  "label": "GitLab",
-  "u2f": ["e7be96a51bd0192a72840d2e5909f72ba82a2fe93faa624f03396b30e494c804"]
+  "name": "GitLab",
+  "u2f": [
+    {
+      "app_id": "e7be96a51bd0192a72840d2e5909f72ba82a2fe93faa624f03396b30e494c804",
+      "label": "gitlab.com"
+    }
+  ]
 }

--- a/common/defs/fido/google.json
+++ b/common/defs/fido/google.json
@@ -1,5 +1,10 @@
 {
-  "label": "Google",
-  "u2f": ["a54672b222c4cf95e151ed8d4d3c767a6cc349435943794e884f3d023a8229fd"],
+  "name": "Google",
+  "u2f": [
+    {
+      "app_id": "a54672b222c4cf95e151ed8d4d3c767a6cc349435943794e884f3d023a8229fd",
+      "label": "google.com"
+    }
+  ],
   "webauthn": ["google.com"]
 }

--- a/common/defs/fido/keeper.json
+++ b/common/defs/fido/keeper.json
@@ -1,7 +1,13 @@
 {
-  "label": "Keeper",
+  "name": "Keeper",
   "u2f": [
-    "53a15ba42a7c0325b8dbee289634a48f58aea3246645d5ff418f9bb8819885a9",
-    "d65f005ef4dea9320c9973053c95ff6020115d5fec1b7fee41a578e18df9ca8c"
+    {
+      "app_id": "53a15ba42a7c0325b8dbee289634a48f58aea3246645d5ff418f9bb8819885a9",
+      "label": "keepersecurity.com"
+    },
+    {
+      "app_id": "d65f005ef4dea9320c9973053c95ff6020115d5fec1b7fee41a578e18df9ca8c",
+      "label": "keepersecurity.eu"
+    }
   ]
 }

--- a/common/defs/fido/login.gov.json
+++ b/common/defs/fido/login.gov.json
@@ -1,5 +1,5 @@
 {
-  "label": "login.gov",
+  "name": "login.gov",
   "webauthn": ["secure.login.gov"],
   "use_sign_count": false
 }

--- a/common/defs/fido/microsoft.json
+++ b/common/defs/fido/microsoft.json
@@ -1,5 +1,5 @@
 {
-  "label": "Microsoft",
+  "name": "Microsoft",
   "webauthn": ["login.microsoft.com"],
   "use_sign_count": false,
   "use_self_attestation": false

--- a/common/defs/fido/mojeid.json
+++ b/common/defs/fido/mojeid.json
@@ -1,4 +1,4 @@
 {
-  "label": "mojeID",
+  "name": "mojeID",
   "webauthn": ["mojeid.cz"]
 }

--- a/common/defs/fido/slushpool.json
+++ b/common/defs/fido/slushpool.json
@@ -1,7 +1,13 @@
 {
-  "label": "Slush Pool",
+  "name": "Slush Pool",
   "u2f": [
-    "08b2a3d41939aa31668493cb36cdcc4f16c4d9b4c8238b73c2f672c033007197",
-    "38804f2eff74f228b74151c201aa82e7e8eefcacfecf23fa146b13a37666314f"
+    {
+      "app_id": "08b2a3d41939aa31668493cb36cdcc4f16c4d9b4c8238b73c2f672c033007197",
+      "label": "slushpool.com"
+    },
+    {
+      "app_id": "38804f2eff74f228b74151c201aa82e7e8eefcacfecf23fa146b13a37666314f",
+      "label": "slushpool.com"
+    }
   ]
 }

--- a/common/defs/fido/stripe.json
+++ b/common/defs/fido/stripe.json
@@ -1,4 +1,9 @@
 {
-  "label": "Stripe",
-  "u2f": ["2ac6ad09a6d0772c44da73a6072f9d240fc6854a70d79c1024ff7c7559593292"]
+  "name": "Stripe",
+  "u2f": [
+    {
+      "app_id": "2ac6ad09a6d0772c44da73a6072f9d240fc6854a70d79c1024ff7c7559593292",
+      "label": "stripe.com"
+    }
+  ]
 }

--- a/common/defs/fido/tutanota.json
+++ b/common/defs/fido/tutanota.json
@@ -1,4 +1,9 @@
 {
-  "label": "Tutanota",
-  "u2f": ["fabeece3982fad9ddcc98f91bd2e75afc7d1f4ca544929b2d0d04212dffa30fa"]
+  "name": "Tutanota",
+  "u2f": [
+    {
+      "app_id": "fabeece3982fad9ddcc98f91bd2e75afc7d1f4ca544929b2d0d04212dffa30fa",
+      "label": "tutanota.com"
+    }
+  ]
 }

--- a/common/defs/fido/u2f.bin.coffee.json
+++ b/common/defs/fido/u2f.bin.coffee.json
@@ -1,5 +1,10 @@
 {
-  "label": "u2f.bin.coffee",
-  "u2f": ["1b3c16dd2f7c46e2b4c289dc16746bcc60dfcf0fb818e13215526e1408e7f468"],
+  "name": "u2f.bin.coffee",
+  "u2f": [
+    {
+      "app_id": "1b3c16dd2f7c46e2b4c289dc16746bcc60dfcf0fb818e13215526e1408e7f468",
+      "label": "u2f.bin.coffee"
+    }
+  ],
   "no_icon": true
 }

--- a/common/defs/fido/webauthn.bin.coffee.json
+++ b/common/defs/fido/webauthn.bin.coffee.json
@@ -1,5 +1,5 @@
 {
-  "label": "webauthn.bin.coffee",
+  "name": "webauthn.bin.coffee",
   "webauthn": ["webauthn.bin.coffee"],
   "no_icon": true
 }

--- a/common/defs/fido/webauthn.io.json
+++ b/common/defs/fido/webauthn.io.json
@@ -1,5 +1,5 @@
 {
-  "label": "WebAuthn.io",
+  "name": "WebAuthn.io",
   "webauthn": ["webauthn.io"],
   "no_icon": true
 }

--- a/common/defs/fido/webauthn.me.json
+++ b/common/defs/fido/webauthn.me.json
@@ -1,5 +1,5 @@
 {
-  "label": "WebAuthn.me",
+  "name": "WebAuthn.me",
   "webauthn": ["webauthn.me"],
   "no_icon": true
 }

--- a/common/defs/fido/yubico-demo.json
+++ b/common/defs/fido/yubico-demo.json
@@ -1,5 +1,5 @@
 {
-  "label": "demo.yubico.com",
+  "name": "demo.yubico.com",
   "webauthn": ["demo.yubico.com"],
   "no_icon": true
 }

--- a/core/src/apps/webauthn/credential.py
+++ b/core/src/apps/webauthn/credential.py
@@ -258,6 +258,12 @@ class Fido2Credential(Credential):
         )
 
     def app_name(self) -> str:
+        from apps.webauthn import knownapps
+
+        app = knownapps.by_rp_id_hash(self.rp_id_hash)
+        if app is not None:
+            return app.label
+
         return self.rp_id
 
     def account_name(self) -> Optional[str]:

--- a/core/src/apps/webauthn/knownapps.py
+++ b/core/src/apps/webauthn/knownapps.py
@@ -28,7 +28,7 @@ def by_rp_id_hash(rp_id_hash: bytes) -> Optional[FIDOApp]:
     elif rp_id_hash == b"\x96\x89\x78\xa2\x99\x53\xde\x52\xd3\xef\x0f\x0c\x71\xb7\xb7\xb6\xb1\xaf\x9f\x08\xe2\x57\x89\x6a\x8d\x81\x26\x91\x85\x30\x29\x3b":
         # U2F key for Amazon Web Services
         return FIDOApp(
-            label="Amazon Web Services",
+            label="aws.amazon.com",
             icon="apps/webauthn/res/icon_aws.toif",
             use_sign_count=None,
             use_self_attestation=None,
@@ -36,7 +36,7 @@ def by_rp_id_hash(rp_id_hash: bytes) -> Optional[FIDOApp]:
     elif rp_id_hash == b"\xc3\x40\x8c\x04\x47\x88\xae\xa5\xb3\xdf\x30\x89\x52\xfd\x8c\xa3\xc7\x0e\x21\xfe\xf4\xf6\xc1\xc2\x37\x4c\xaa\x1d\xf9\xb2\x8d\xdd":
         # WebAuthn key for Binance
         return FIDOApp(
-            label="Binance",
+            label="www.binance.com",
             icon="apps/webauthn/res/icon_binance.toif",
             use_sign_count=False,
             use_self_attestation=True,
@@ -44,7 +44,7 @@ def by_rp_id_hash(rp_id_hash: bytes) -> Optional[FIDOApp]:
     elif rp_id_hash == b"\x12\x74\x3b\x92\x12\x97\xb7\x7f\x11\x35\xe4\x1f\xde\xdd\x4a\x84\x6a\xfe\x82\xe1\xf3\x69\x32\xa9\x91\x2f\x3b\x0d\x8d\xfb\x7d\x0e":
         # U2F key for Bitbucket
         return FIDOApp(
-            label="Bitbucket",
+            label="bitbucket.org",
             icon="apps/webauthn/res/icon_bitbucket.toif",
             use_sign_count=None,
             use_self_attestation=None,
@@ -52,7 +52,7 @@ def by_rp_id_hash(rp_id_hash: bytes) -> Optional[FIDOApp]:
     elif rp_id_hash == b"\x30\x2f\xd5\xb4\x49\x2a\x07\xb9\xfe\xbb\x30\xe7\x32\x69\xec\xa5\x01\x20\x5c\xcf\xe0\xc2\x0b\xf7\xb4\x72\xfa\x2d\x31\xe2\x1e\x63":
         # U2F key for Bitfinex
         return FIDOApp(
-            label="Bitfinex",
+            label="www.bitfinex.com",
             icon="apps/webauthn/res/icon_bitfinex.toif",
             use_sign_count=None,
             use_self_attestation=None,
@@ -60,7 +60,7 @@ def by_rp_id_hash(rp_id_hash: bytes) -> Optional[FIDOApp]:
     elif rp_id_hash == b"\xa3\x4d\x30\x9f\xfa\x28\xc1\x24\x14\xb8\xba\x6c\x07\xee\x1e\xfa\xe1\xa8\x5e\x8a\x04\x61\x48\x59\xa6\x7c\x04\x93\xb6\x95\x61\x90":
         # U2F key for Bitwarden
         return FIDOApp(
-            label="Bitwarden",
+            label="vault.bitwarden.com",
             icon="apps/webauthn/res/icon_bitwarden.toif",
             use_sign_count=None,
             use_self_attestation=None,
@@ -68,7 +68,7 @@ def by_rp_id_hash(rp_id_hash: bytes) -> Optional[FIDOApp]:
     elif rp_id_hash == b"\x68\x20\x19\x15\xd7\x4c\xb4\x2a\xf5\xb3\xcc\x5c\x95\xb9\x55\x3e\x3e\x3a\x83\xb4\xd2\xa9\x3b\x45\xfb\xad\xaa\x84\x69\xff\x8e\x6e":
         # U2F key for Dashlane
         return FIDOApp(
-            label="Dashlane",
+            label="www.dashlane.com",
             icon="apps/webauthn/res/icon_dashlane.toif",
             use_sign_count=None,
             use_self_attestation=None,
@@ -76,7 +76,7 @@ def by_rp_id_hash(rp_id_hash: bytes) -> Optional[FIDOApp]:
     elif rp_id_hash == b"\xc5\x0f\x8a\x7b\x70\x8e\x92\xf8\x2e\x7a\x50\xe2\xbd\xc5\x5d\x8f\xd9\x1a\x22\xfe\x6b\x29\xc0\xcd\xf7\x80\x55\x30\x84\x2a\xf5\x81":
         # U2F key for Dropbox
         return FIDOApp(
-            label="Dropbox",
+            label="www.dropbox.com",
             icon="apps/webauthn/res/icon_dropbox.toif",
             use_sign_count=False,
             use_self_attestation=None,
@@ -84,7 +84,7 @@ def by_rp_id_hash(rp_id_hash: bytes) -> Optional[FIDOApp]:
     elif rp_id_hash == b"\x82\xf4\xa8\xc9\x5f\xec\x94\xb2\x6b\xaf\x9e\x37\x25\x0e\x95\x63\xd9\xa3\x66\xc7\xbe\x26\x1c\xa4\xdd\x01\x01\xf4\xd5\xef\xcb\x83":
         # WebAuthn key for Dropbox
         return FIDOApp(
-            label="Dropbox",
+            label="www.dropbox.com",
             icon="apps/webauthn/res/icon_dropbox.toif",
             use_sign_count=False,
             use_self_attestation=None,
@@ -92,7 +92,7 @@ def by_rp_id_hash(rp_id_hash: bytes) -> Optional[FIDOApp]:
     elif rp_id_hash == b"\xf3\xe2\x04\x2f\x94\x60\x7d\xa0\xa9\xc1\xf3\xb9\x5e\x0d\x2f\x2b\xb2\xe0\x69\xc5\xbb\x4f\xa7\x64\xaf\xfa\x64\x7d\x84\x7b\x7e\xd6":
         # U2F key for Duo
         return FIDOApp(
-            label="Duo",
+            label="duosecurity.com",
             icon="apps/webauthn/res/icon_duo.toif",
             use_sign_count=None,
             use_self_attestation=None,
@@ -100,7 +100,7 @@ def by_rp_id_hash(rp_id_hash: bytes) -> Optional[FIDOApp]:
     elif rp_id_hash == b"\x31\x19\x33\x28\xf8\xe2\x1d\xfb\x6c\x99\xf3\x22\xd2\x2d\x7b\x0b\x50\x87\x78\xe6\x4f\xfb\xba\x86\xe5\x22\x93\x37\x90\x31\xb8\x74":
         # WebAuthn key for Facebook
         return FIDOApp(
-            label="Facebook",
+            label="facebook.com",
             icon="apps/webauthn/res/icon_facebook.toif",
             use_sign_count=None,
             use_self_attestation=None,
@@ -108,7 +108,7 @@ def by_rp_id_hash(rp_id_hash: bytes) -> Optional[FIDOApp]:
     elif rp_id_hash == b"\x69\x66\xab\xe3\x67\x4e\xa2\xf5\x30\x79\xeb\x71\x01\x97\x84\x8c\x9b\xe6\xf3\x63\x99\x2f\xd0\x29\xe9\x89\x84\x47\xcb\x9f\x00\x84":
         # U2F key for FastMail
         return FIDOApp(
-            label="FastMail",
+            label="www.fastmail.com",
             icon="apps/webauthn/res/icon_fastmail.toif",
             use_sign_count=None,
             use_self_attestation=None,
@@ -116,7 +116,7 @@ def by_rp_id_hash(rp_id_hash: bytes) -> Optional[FIDOApp]:
     elif rp_id_hash == b"\x9d\x61\x44\x2f\x5c\xe1\x33\xbd\x46\x54\x4f\xc4\x2f\x0a\x6d\x54\xc0\xde\xb8\x88\x40\xca\xc2\xb6\xae\xfa\x65\x14\xf8\x93\x49\xe9":
         # U2F key for Fedora
         return FIDOApp(
-            label="Fedora",
+            label="fedoraproject.org",
             icon="apps/webauthn/res/icon_fedora.toif",
             use_sign_count=None,
             use_self_attestation=None,
@@ -124,7 +124,7 @@ def by_rp_id_hash(rp_id_hash: bytes) -> Optional[FIDOApp]:
     elif rp_id_hash == b"\xa4\xe2\x2d\xca\xfe\xa7\xe9\x0e\x12\x89\x50\x11\x39\x89\xfc\x45\x97\x8d\xc9\xfb\x87\x76\x75\x60\x51\x6c\x1c\x69\xdf\xdf\xd1\x96":
         # U2F key for Gandi
         return FIDOApp(
-            label="Gandi",
+            label="gandi.net",
             icon="apps/webauthn/res/icon_gandi.toif",
             use_sign_count=False,
             use_self_attestation=None,
@@ -132,7 +132,7 @@ def by_rp_id_hash(rp_id_hash: bytes) -> Optional[FIDOApp]:
     elif rp_id_hash == b"\x54\xce\x65\x1e\xd7\x15\xb4\xaa\xa7\x55\xee\xce\xbd\x4e\xa0\x95\x08\x15\xb3\x34\xbd\x07\xd1\x09\x89\x3e\x96\x30\x18\xcd\xdb\xd9":
         # WebAuthn key for Gandi
         return FIDOApp(
-            label="Gandi",
+            label="gandi.net",
             icon="apps/webauthn/res/icon_gandi.toif",
             use_sign_count=False,
             use_self_attestation=None,
@@ -140,7 +140,7 @@ def by_rp_id_hash(rp_id_hash: bytes) -> Optional[FIDOApp]:
     elif rp_id_hash == b"\x70\x61\x7d\xfe\xd0\x65\x86\x3a\xf4\x7c\x15\x55\x6c\x91\x79\x88\x80\x82\x8c\xc4\x07\xfd\xf7\x0a\xe8\x50\x11\x56\x94\x65\xa0\x75":
         # U2F key for GitHub
         return FIDOApp(
-            label="GitHub",
+            label="github.com",
             icon="apps/webauthn/res/icon_github.toif",
             use_sign_count=True,
             use_self_attestation=None,
@@ -148,7 +148,7 @@ def by_rp_id_hash(rp_id_hash: bytes) -> Optional[FIDOApp]:
     elif rp_id_hash == b"\x3a\xeb\x00\x24\x60\x38\x1c\x6f\x25\x8e\x83\x95\xd3\x02\x6f\x57\x1f\x0d\x9a\x76\x48\x8d\xcd\x83\x76\x39\xb1\x3a\xed\x31\x65\x60":
         # WebAuthn key for GitHub
         return FIDOApp(
-            label="GitHub",
+            label="github.com",
             icon="apps/webauthn/res/icon_github.toif",
             use_sign_count=True,
             use_self_attestation=None,
@@ -156,7 +156,7 @@ def by_rp_id_hash(rp_id_hash: bytes) -> Optional[FIDOApp]:
     elif rp_id_hash == b"\xe7\xbe\x96\xa5\x1b\xd0\x19\x2a\x72\x84\x0d\x2e\x59\x09\xf7\x2b\xa8\x2a\x2f\xe9\x3f\xaa\x62\x4f\x03\x39\x6b\x30\xe4\x94\xc8\x04":
         # U2F key for GitLab
         return FIDOApp(
-            label="GitLab",
+            label="gitlab.com",
             icon="apps/webauthn/res/icon_gitlab.toif",
             use_sign_count=None,
             use_self_attestation=None,
@@ -164,7 +164,7 @@ def by_rp_id_hash(rp_id_hash: bytes) -> Optional[FIDOApp]:
     elif rp_id_hash == b"\xa5\x46\x72\xb2\x22\xc4\xcf\x95\xe1\x51\xed\x8d\x4d\x3c\x76\x7a\x6c\xc3\x49\x43\x59\x43\x79\x4e\x88\x4f\x3d\x02\x3a\x82\x29\xfd":
         # U2F key for Google
         return FIDOApp(
-            label="Google",
+            label="google.com",
             icon="apps/webauthn/res/icon_google.toif",
             use_sign_count=None,
             use_self_attestation=None,
@@ -172,7 +172,7 @@ def by_rp_id_hash(rp_id_hash: bytes) -> Optional[FIDOApp]:
     elif rp_id_hash == b"\xd4\xc9\xd9\x02\x73\x26\x27\x1a\x89\xce\x51\xfc\xaf\x32\x8e\xd6\x73\xf1\x7b\xe3\x34\x69\xff\x97\x9e\x8a\xb8\xdd\x50\x1e\x66\x4f":
         # WebAuthn key for Google
         return FIDOApp(
-            label="Google",
+            label="google.com",
             icon="apps/webauthn/res/icon_google.toif",
             use_sign_count=None,
             use_self_attestation=None,
@@ -180,7 +180,7 @@ def by_rp_id_hash(rp_id_hash: bytes) -> Optional[FIDOApp]:
     elif rp_id_hash == b"\x53\xa1\x5b\xa4\x2a\x7c\x03\x25\xb8\xdb\xee\x28\x96\x34\xa4\x8f\x58\xae\xa3\x24\x66\x45\xd5\xff\x41\x8f\x9b\xb8\x81\x98\x85\xa9":
         # U2F key for Keeper
         return FIDOApp(
-            label="Keeper",
+            label="keepersecurity.com",
             icon="apps/webauthn/res/icon_keeper.toif",
             use_sign_count=None,
             use_self_attestation=None,
@@ -188,7 +188,7 @@ def by_rp_id_hash(rp_id_hash: bytes) -> Optional[FIDOApp]:
     elif rp_id_hash == b"\xd6\x5f\x00\x5e\xf4\xde\xa9\x32\x0c\x99\x73\x05\x3c\x95\xff\x60\x20\x11\x5d\x5f\xec\x1b\x7f\xee\x41\xa5\x78\xe1\x8d\xf9\xca\x8c":
         # U2F key for Keeper
         return FIDOApp(
-            label="Keeper",
+            label="keepersecurity.eu",
             icon="apps/webauthn/res/icon_keeper.toif",
             use_sign_count=None,
             use_self_attestation=None,
@@ -196,7 +196,7 @@ def by_rp_id_hash(rp_id_hash: bytes) -> Optional[FIDOApp]:
     elif rp_id_hash == b"\xf8\x3f\xc3\xa1\xb2\x89\xa0\xde\xc5\xc1\xc8\xaa\x07\xe9\xb5\xdd\x9c\xbb\x76\xf6\xb2\xf5\x60\x60\x17\x66\x72\x68\xe5\xb9\xc4\x5e":
         # WebAuthn key for login.gov
         return FIDOApp(
-            label="login.gov",
+            label="secure.login.gov",
             icon="apps/webauthn/res/icon_login.gov.toif",
             use_sign_count=False,
             use_self_attestation=None,
@@ -204,7 +204,7 @@ def by_rp_id_hash(rp_id_hash: bytes) -> Optional[FIDOApp]:
     elif rp_id_hash == b"\x35\x6c\x9e\xd4\xa0\x93\x21\xb9\x69\x5f\x1e\xaf\x91\x82\x03\xf1\xb5\x5f\x68\x9d\xa6\x1f\xbc\x96\x18\x4c\x15\x7d\xda\x68\x0c\x81":
         # WebAuthn key for Microsoft
         return FIDOApp(
-            label="Microsoft",
+            label="login.microsoft.com",
             icon="apps/webauthn/res/icon_microsoft.toif",
             use_sign_count=False,
             use_self_attestation=False,
@@ -212,7 +212,7 @@ def by_rp_id_hash(rp_id_hash: bytes) -> Optional[FIDOApp]:
     elif rp_id_hash == b"\xab\x2d\xaf\x07\x43\xde\x78\x2a\x70\x18\x9a\x0f\x5e\xfc\x30\x90\x2f\x92\x5b\x9f\x9a\x18\xc5\xd7\x14\x1b\x7b\x12\xf8\xa0\x10\x0c":
         # WebAuthn key for mojeID
         return FIDOApp(
-            label="mojeID",
+            label="mojeid.cz",
             icon="apps/webauthn/res/icon_mojeid.toif",
             use_sign_count=None,
             use_self_attestation=None,
@@ -220,7 +220,7 @@ def by_rp_id_hash(rp_id_hash: bytes) -> Optional[FIDOApp]:
     elif rp_id_hash == b"\x08\xb2\xa3\xd4\x19\x39\xaa\x31\x66\x84\x93\xcb\x36\xcd\xcc\x4f\x16\xc4\xd9\xb4\xc8\x23\x8b\x73\xc2\xf6\x72\xc0\x33\x00\x71\x97":
         # U2F key for Slush Pool
         return FIDOApp(
-            label="Slush Pool",
+            label="slushpool.com",
             icon="apps/webauthn/res/icon_slushpool.toif",
             use_sign_count=None,
             use_self_attestation=None,
@@ -228,7 +228,7 @@ def by_rp_id_hash(rp_id_hash: bytes) -> Optional[FIDOApp]:
     elif rp_id_hash == b"\x38\x80\x4f\x2e\xff\x74\xf2\x28\xb7\x41\x51\xc2\x01\xaa\x82\xe7\xe8\xee\xfc\xac\xfe\xcf\x23\xfa\x14\x6b\x13\xa3\x76\x66\x31\x4f":
         # U2F key for Slush Pool
         return FIDOApp(
-            label="Slush Pool",
+            label="slushpool.com",
             icon="apps/webauthn/res/icon_slushpool.toif",
             use_sign_count=None,
             use_self_attestation=None,
@@ -236,7 +236,7 @@ def by_rp_id_hash(rp_id_hash: bytes) -> Optional[FIDOApp]:
     elif rp_id_hash == b"\x2a\xc6\xad\x09\xa6\xd0\x77\x2c\x44\xda\x73\xa6\x07\x2f\x9d\x24\x0f\xc6\x85\x4a\x70\xd7\x9c\x10\x24\xff\x7c\x75\x59\x59\x32\x92":
         # U2F key for Stripe
         return FIDOApp(
-            label="Stripe",
+            label="stripe.com",
             icon="apps/webauthn/res/icon_stripe.toif",
             use_sign_count=None,
             use_self_attestation=None,
@@ -244,7 +244,7 @@ def by_rp_id_hash(rp_id_hash: bytes) -> Optional[FIDOApp]:
     elif rp_id_hash == b"\xfa\xbe\xec\xe3\x98\x2f\xad\x9d\xdc\xc9\x8f\x91\xbd\x2e\x75\xaf\xc7\xd1\xf4\xca\x54\x49\x29\xb2\xd0\xd0\x42\x12\xdf\xfa\x30\xfa":
         # U2F key for Tutanota
         return FIDOApp(
-            label="Tutanota",
+            label="tutanota.com",
             icon="apps/webauthn/res/icon_tutanota.toif",
             use_sign_count=None,
             use_self_attestation=None,
@@ -268,7 +268,7 @@ def by_rp_id_hash(rp_id_hash: bytes) -> Optional[FIDOApp]:
     elif rp_id_hash == b"\x74\xa6\xea\x92\x13\xc9\x9c\x2f\x74\xb2\x24\x92\xb3\x20\xcf\x40\x26\x2a\x94\xc1\xa9\x50\xa0\x39\x7f\x29\x25\x0b\x60\x84\x1e\xf0":
         # WebAuthn key for WebAuthn.io
         return FIDOApp(
-            label="WebAuthn.io",
+            label="webauthn.io",
             icon=None,
             use_sign_count=None,
             use_self_attestation=None,
@@ -276,7 +276,7 @@ def by_rp_id_hash(rp_id_hash: bytes) -> Optional[FIDOApp]:
     elif rp_id_hash == b"\xf9\x5b\xc7\x38\x28\xee\x21\x0f\x9f\xd3\xbb\xe7\x2d\x97\x90\x80\x13\xb0\xa3\x75\x9e\x9a\xea\x3d\x0a\xe3\x18\x76\x6c\xd2\xe1\xad":
         # WebAuthn key for WebAuthn.me
         return FIDOApp(
-            label="WebAuthn.me",
+            label="webauthn.me",
             icon=None,
             use_sign_count=None,
             use_self_attestation=None,

--- a/core/src/apps/webauthn/knownapps.py.mako
+++ b/core/src/apps/webauthn/knownapps.py.mako
@@ -26,11 +26,11 @@ from hashlib import sha256
 
 fido_entries = []
 for app in fido:
-    for app_id in app.u2f:
-        fido_entries.append((bytes.fromhex(app_id), "U2F", app))
+    for u2f in app.u2f:
+        fido_entries.append((u2f["label"], bytes.fromhex(u2f["app_id"]), "U2F", app))
     for origin in app.webauthn:
         rp_id_hash = sha256(origin.encode()).digest()
-        fido_entries.append((rp_id_hash, "WebAuthn", app))
+        fido_entries.append((origin, rp_id_hash, "WebAuthn", app))
     if app.icon is not None:
         app.icon_res = f"apps/webauthn/res/icon_{app.key}.toif"
     else:
@@ -40,11 +40,11 @@ for app in fido:
 def by_rp_id_hash(rp_id_hash: bytes) -> Optional[FIDOApp]:
     if False:
         raise RuntimeError  # if false
-% for rp_id_hash, type, app in fido_entries:
+% for label, rp_id_hash, type, app in fido_entries:
     elif rp_id_hash == ${black_repr(rp_id_hash)}:
-        # ${type} key for ${app.label}
+        # ${type} key for ${app.name}
         return FIDOApp(
-            label=${black_repr(app.label)},
+            label=${black_repr(label)},
             icon=${black_repr(app.icon_res)},
             use_sign_count=${black_repr(app.use_sign_count)},
             use_self_attestation=${black_repr(app.use_self_attestation)},

--- a/legacy/firmware/u2f_knownapps.h.mako
+++ b/legacy/firmware/u2f_knownapps.h.mako
@@ -20,20 +20,19 @@ def c_bytes(rp_id_hash):
 
 fido_entries = []
 for app in fido:
-    for app_id in app.u2f:
-        fido_entries.append((bytes.fromhex(app_id), "U2F", "", app))
+    for u2f in app.u2f:
+        fido_entries.append((u2f["label"], bytes.fromhex(u2f["app_id"]), "U2F", app))
     for origin in app.webauthn:
         rp_id_hash = sha256(origin.encode()).digest()
-        origin_str = " ({})".format(origin)
-        fido_entries.append((rp_id_hash, "WebAuthn", origin_str, app))
+        fido_entries.append((origin, rp_id_hash, "WebAuthn", app))
 %>\
 // clang-format off
 static const U2FWellKnown u2f_well_known[] = {
-% for rp_id_hash, type, origin_str, app in fido_entries:
+% for label, rp_id_hash, type, app in fido_entries:
 	{
-		// ${type} for ${app.label}${origin_str}
+		// ${type} for ${app.name}
 		${c_bytes(rp_id_hash)},
-		${c_str(app.label)}
+		${c_str(label)}
 	},
 % endfor
 };


### PR DESCRIPTION
If someone registers Trezor as a second factor authenticator for github.com and they do it via U2F, then we show the label "GitHub" every time they use that credential, but if they register via FIDO2 we show the label "github.com" every time they use that credential. That seems inconsistent and in some odd scenarios it can result in situations like https://github.com/trezor/trezor-firmware/issues/1141.

I propose we show the same label for an app regardless of whether it's using U2F or FIDO2. This means:
1. Change labels in U2F from e.g. "GitHub" to "github.com". The FIDO2 spec tells us we should be showing the RP ID, like "github.com", so if we want to unify it, then we have to go in this direction. That's what most of this PR is about.
2. Ensure that if a U2F app name is given to us via FIDO2, like "https://github.com/u2f/trusted_facets", then it shows up the same way it would in U2F, i.e. "github.com". I wasn't even able to produce this situation, but that's what happened in the issue above. That's the change in `core/src/apps/webauthn/credential.py`.
3. Plus I added another check for collisions between U2F and FIDO2 to `cointool.py`. This is fairly unrelated to the rest of this PR.

I changed the labeling from per-app to per-app_id, because there can be minute distinctions between two names which effectively belong to the same app, like "keepersecurity.com" and "keepersecurity.eu". I still kept the old labels like "GitHub", but they don't show up anywhere in the firmware, only used as comments.