### PR TITLE
core: don't scale emulator background image

### DIFF
--- a/core/embed/extmod/modtrezorui/display-unix.h
+++ b/core/embed/extmod/modtrezorui/display-unix.h
@@ -191,7 +191,8 @@ void display_refresh(void) {
     display_init();
   }
   if (BACKGROUND) {
-    SDL_RenderCopy(RENDERER, BACKGROUND, NULL, NULL);
+    const SDL_Rect r = {0, 0, WINDOW_WIDTH, WINDOW_HEIGHT};
+    SDL_RenderCopy(RENDERER, BACKGROUND, NULL, &r);
   } else {
     SDL_RenderClear(RENDERER);
   }


### PR DESCRIPTION
Makes the emulator look nicer in tiling window managers. Not tested on a non-tiling WM.

