### PR TITLE
tests: fix test_msg_webauthn on-device

### DIFF
--- a/tests/device_tests/test_msg_webauthn.py
+++ b/tests/device_tests/test_msg_webauthn.py
@@ -27,85 +27,75 @@ RK_CAPACITY = 100
 
 @pytest.mark.skip_t1
 @pytest.mark.altcoin
-class TestMsgWebAuthn:
-    @pytest.mark.setup_client(mnemonic=MNEMONIC12)
-    def test_add_remove(self, client):
-        # Remove index 0 should fail.
-        with pytest.raises(TrezorFailure):
-            fido.remove_credential(client, 0)
+@pytest.mark.setup_client(mnemonic=MNEMONIC12)
+def test_add_remove(client):
+    # Remove index 0 should fail.
+    with pytest.raises(TrezorFailure):
+        fido.remove_credential(client, 0)
 
-        # List should be empty.
-        assert fido.list_credentials(client) == []
+    # List should be empty.
+    assert fido.list_credentials(client) == []
 
-        # Add valid credential #1.
-        fido.add_credential(client, CRED1)
+    # Add valid credential #1.
+    fido.add_credential(client, CRED1)
 
-        # Check that the credential was added and parameters are correct.
-        creds = fido.list_credentials(client)
-        assert len(creds) == 1
-        assert creds[0].rp_id == "example.com"
-        assert creds[0].rp_name == "Example"
-        assert creds[0].user_id == bytes.fromhex(
-            "3082019330820138A0030201023082019330820138A003020102308201933082"
-        )
-        assert creds[0].user_name == "johnpsmith@example.com"
-        assert creds[0].user_display_name == "John P. Smith"
-        assert creds[0].creation_time == 3
-        assert creds[0].hmac_secret is True
+    # Check that the credential was added and parameters are correct.
+    creds = fido.list_credentials(client)
+    assert len(creds) == 1
+    assert creds[0].rp_id == "example.com"
+    assert creds[0].rp_name == "Example"
+    assert creds[0].user_id == bytes.fromhex(
+        "3082019330820138A0030201023082019330820138A003020102308201933082"
+    )
+    assert creds[0].user_name == "johnpsmith@example.com"
+    assert creds[0].user_display_name == "John P. Smith"
+    assert creds[0].creation_time == 3
+    assert creds[0].hmac_secret is True
 
-        # Add valid credential #2, which has same rpId and userId as credential #1.
-        fido.add_credential(client, CRED2)
+    # Add valid credential #2, which has same rpId and userId as credential #1.
+    fido.add_credential(client, CRED2)
 
-        # Check that the credential #2 replaced credential #1 and parameters are correct.
-        creds = fido.list_credentials(client)
-        assert len(creds) == 1
-        assert creds[0].rp_id == "example.com"
-        assert creds[0].rp_name is None
-        assert creds[0].user_id == bytes.fromhex(
-            "3082019330820138A0030201023082019330820138A003020102308201933082"
-        )
-        assert creds[0].user_name == "johnpsmith@example.com"
-        assert creds[0].user_display_name is None
-        assert creds[0].creation_time == 2
-        assert creds[0].hmac_secret is True
+    # Check that the credential #2 replaced credential #1 and parameters are correct.
+    creds = fido.list_credentials(client)
+    assert len(creds) == 1
+    assert creds[0].rp_id == "example.com"
+    assert creds[0].rp_name is None
+    assert creds[0].user_id == bytes.fromhex(
+        "3082019330820138A0030201023082019330820138A003020102308201933082"
+    )
+    assert creds[0].user_name == "johnpsmith@example.com"
+    assert creds[0].user_display_name is None
+    assert creds[0].creation_time == 2
+    assert creds[0].hmac_secret is True
 
-        # Adding an invalid credential should appear as if user cancelled.
-        with pytest.raises(Cancelled):
-            fido.add_credential(client, CRED1[:-2])
+    # Adding an invalid credential should appear as if user cancelled.
+    with pytest.raises(Cancelled):
+        fido.add_credential(client, CRED1[:-2])
 
-        # Check that the invalid credential was not added.
-        creds = fido.list_credentials(client)
-        assert len(creds) == 1
+    # Check that the invalid credential was not added.
+    creds = fido.list_credentials(client)
+    assert len(creds) == 1
 
-        # Add valid credential, which has same userId as #2, but different rpId.
-        fido.add_credential(client, CRED3)
+    # Add valid credential, which has same userId as #2, but different rpId.
+    fido.add_credential(client, CRED3)
 
-        # Check that the credential was added.
-        creds = fido.list_credentials(client)
-        assert len(creds) == 2
+    # Check that the credential was added.
+    creds = fido.list_credentials(client)
+    assert len(creds) == 2
 
-        # Fill up the credential storage to maximum capacity.
-        for cred in CREDS[: RK_CAPACITY - 2]:
-            fido.add_credential(client, cred)
+    # Fill up the credential storage to maximum capacity.
+    for cred in CREDS[: RK_CAPACITY - 2]:
+        fido.add_credential(client, cred)
 
-        # Adding one more valid credential to full storage should fail.
-        with pytest.raises(TrezorFailure):
-            fido.add_credential(client, CREDS[-1])
-
-        # Removing the index, which is one past the end, should fail.
-        with pytest.raises(TrezorFailure):
-            fido.remove_credential(client, RK_CAPACITY)
-
-        # Remove index 2.
-        fido.remove_credential(client, 2)
-
-        # Check that the credential was removed.
-        creds = fido.list_credentials(client)
-        assert len(creds) == RK_CAPACITY - 1
-
-        # Adding another valid credential should succeed now.
+    # Adding one more valid credential to full storage should fail.
+    with pytest.raises(TrezorFailure):
         fido.add_credential(client, CREDS[-1])
 
-        # Check that the credential was added.
-        creds = fido.list_credentials(client)
-        assert len(creds) == RK_CAPACITY
+    # Removing the index, which is one past the end, should fail.
+    with pytest.raises(TrezorFailure):
+        fido.remove_credential(client, RK_CAPACITY)
+
+    # Remove index 2.
+    fido.remove_credential(client, 2)
+    # Adding another valid credential should succeed now.
+    fido.add_credential(client, CREDS[-1])

--- a/tests/ui_tests/fixtures.json
+++ b/tests/ui_tests/fixtures.json
@@ -398,7 +398,7 @@
 "test_msg_verifymessage_segwit_native.py-test_message_testnet": "113ad2d6389810b542e5ae5aba5d0de2aa52661e321c3f1d9f45cc91637b3c1d",
 "test_msg_verifymessage_segwit_native.py-test_message_verify": "b206b7a79c40525efa765718376d5f369caf424e11e93dd0eab97861dc1f4f8d",
 "test_msg_verifymessage_segwit_native.py-test_verify_utf": "118265328951cb575b2a044acabaec0d80597b730cd06b3dbcbc66193dab8315",
-"test_msg_webauthn.py-test_add_remove": "820eac5b32863356b967dc70b0afbc4b9faa9c39ec40d55923f4fb07bd5f3707",
+"test_msg_webauthn.py::test_add_remove": "a9cdefeb089f197427257e097d07179b23de4fcad4ee91af0191ed767f80577c",
 "test_msg_wipedevice.py::test_wipe_device": "bc6acd0386b9d009e6550519917d6e08632b3badde0b0cf04c95abe5f773038a",
 "test_multisig.py-test_15_of_15": "9d1799a199b45785ac69ae6af715c251b10aebb60f981c9b73d78e53e1a91374",
 "test_multisig.py-test_2_of_3": "2be92556edf4ff8eed340d535f379ee6915eae34fef25d669ce865848e7b4705",


### PR DESCRIPTION
by not asking for a full-capacity list of credentials, which will
usually not fit in an unfragmented chunk of memory

i also moved the test function to top-level so make sure to [hide whitespace changes](https://github.blog/2018-05-01-ignore-white-space-in-code-review/)