### PR TITLE
core: basic UI support for T1

### DIFF
--- a/core/SConscript.firmware
+++ b/core/SConscript.firmware
@@ -469,6 +469,15 @@ if FROZEN:
     SOURCE_PY.extend(Glob(SOURCE_PY_DIR + 'trezor/crypto/*.py'))
     SOURCE_PY.extend(Glob(SOURCE_PY_DIR + 'trezor/res/*.py'))
     SOURCE_PY.extend(Glob(SOURCE_PY_DIR + 'trezor/ui/*.py'))
+    SOURCE_PY.extend(Glob(SOURCE_PY_DIR + 'trezor/ui/model/*.py'))
+    SOURCE_PY.extend(Glob(SOURCE_PY_DIR + 'trezor/ui/model/*/__init__.py'))
+    if TREZOR_MODEL == 'T':
+        SOURCE_PY.extend(Glob(SOURCE_PY_DIR + 'trezor/ui/model/*/tt.py'))
+    elif TREZOR_MODEL == '1':
+        SOURCE_PY.extend(Glob(SOURCE_PY_DIR + 'trezor/ui/model/*/t1.py'))
+    else:
+        raise ValueError('Unknown Trezor model')
+
     SOURCE_PY.extend(Glob(SOURCE_PY_DIR + 'trezor/wire/*.py'))
 
     SOURCE_PY.extend(Glob(SOURCE_PY_DIR + 'storage/*.py'))

--- a/core/SConscript.unix
+++ b/core/SConscript.unix
@@ -434,6 +434,15 @@ if FROZEN:
     SOURCE_PY.extend(Glob(SOURCE_PY_DIR + 'trezor/crypto/*.py'))
     SOURCE_PY.extend(Glob(SOURCE_PY_DIR + 'trezor/res/*.py'))
     SOURCE_PY.extend(Glob(SOURCE_PY_DIR + 'trezor/ui/*.py'))
+    SOURCE_PY.extend(Glob(SOURCE_PY_DIR + 'trezor/ui/model/*.py'))
+    SOURCE_PY.extend(Glob(SOURCE_PY_DIR + 'trezor/ui/model/*/__init__.py'))
+    if TREZOR_MODEL == 'T':
+        SOURCE_PY.extend(Glob(SOURCE_PY_DIR + 'trezor/ui/model/*/tt.py'))
+    elif TREZOR_MODEL == '1':
+        SOURCE_PY.extend(Glob(SOURCE_PY_DIR + 'trezor/ui/model/*/t1.py'))
+    else:
+        raise ValueError('Unknown Trezor model')
+
     SOURCE_PY.extend(Glob(SOURCE_PY_DIR + 'trezor/wire/*.py'))
 
     SOURCE_PY.extend(Glob(SOURCE_PY_DIR + 'storage/*.py'))

--- a/core/src/trezor/ui/button.py
+++ b/core/src/trezor/ui/button.py
@@ -1,118 +1,28 @@
 from micropython import const
 
 from trezor import ui
-from trezor.ui import display, in_area
+from trezor.ui import in_area
+
+from .model.button import (  # noqa: F401
+    ButtonAbort,
+    ButtonCancel,
+    ButtonClear,
+    ButtonConfirm,
+    ButtonDefault,
+    ButtonMono,
+    ButtonMonoConfirm,
+    ButtonMonoDark,
+    render_button,
+)
 
 if False:
-    from typing import List, Optional, Type, Union
+    from typing import List
 
-
-class ButtonDefault:
-    class normal:
-        bg_color = ui.BLACKISH
-        fg_color = ui.FG
-        text_style = ui.BOLD
-        border_color = ui.BG
-        radius = ui.RADIUS
-
-    class active(normal):
-        bg_color = ui.FG
-        fg_color = ui.BLACKISH
-        text_style = ui.BOLD
-        border_color = ui.FG
-        radius = ui.RADIUS
-
-    class disabled(normal):
-        bg_color = ui.BG
-        fg_color = ui.GREY
-        text_style = ui.NORMAL
-        border_color = ui.BG
-        radius = ui.RADIUS
-
-
-class ButtonMono(ButtonDefault):
-    class normal(ButtonDefault.normal):
-        text_style = ui.MONO
-
-    class active(ButtonDefault.active):
-        text_style = ui.MONO
-
-    class disabled(ButtonDefault.disabled):
-        text_style = ui.MONO
-
-
-class ButtonMonoDark(ButtonDefault):
-    class normal:
-        bg_color = ui.DARK_BLACK
-        fg_color = ui.DARK_WHITE
-        text_style = ui.MONO
-        border_color = ui.BG
-        radius = ui.RADIUS
-
-    class active(normal):
-        bg_color = ui.FG
-        fg_color = ui.DARK_BLACK
-        text_style = ui.MONO
-        border_color = ui.FG
-        radius = ui.RADIUS
-
-    class disabled(normal):
-        bg_color = ui.DARK_BLACK
-        fg_color = ui.GREY
-        text_style = ui.MONO
-        border_color = ui.BG
-        radius = ui.RADIUS
-
-
-class ButtonConfirm(ButtonDefault):
-    class normal(ButtonDefault.normal):
-        bg_color = ui.GREEN
-
-    class active(ButtonDefault.active):
-        fg_color = ui.GREEN
-
-
-class ButtonCancel(ButtonDefault):
-    class normal(ButtonDefault.normal):
-        bg_color = ui.RED
-
-    class active(ButtonDefault.active):
-        fg_color = ui.RED
-
-
-class ButtonAbort(ButtonDefault):
-    class normal(ButtonDefault.normal):
-        bg_color = ui.DARK_GREY
-
-    class active(ButtonDefault.active):
-        fg_color = ui.DARK_GREY
-
-
-class ButtonClear(ButtonDefault):
-    class normal(ButtonDefault.normal):
-        bg_color = ui.ORANGE
-
-    class active(ButtonDefault.active):
-        fg_color = ui.ORANGE
-
-
-class ButtonMonoConfirm(ButtonDefault):
-    class normal(ButtonDefault.normal):
-        text_style = ui.MONO
-        bg_color = ui.GREEN
-
-    class active(ButtonDefault.active):
-        text_style = ui.MONO
-        fg_color = ui.GREEN
-
-    class disabled(ButtonDefault.disabled):
-        text_style = ui.MONO
-
-
-if False:
-    ButtonContent = Optional[Union[str, bytes]]
-    ButtonStyleType = Type[ButtonDefault]
-    ButtonStyleStateType = Type[ButtonDefault.normal]
+    from .model.button import (  # noqa: F401
+        ButtonContent,
+        ButtonStyleType,
+        ButtonStyleStateType,
+    )
 
 
 # button states
@@ -120,10 +30,6 @@ _INITIAL = const(0)
 _PRESSED = const(1)
 _RELEASED = const(2)
 _DISABLED = const(3)
-
-# button constants
-_ICON = const(16)  # icon size in pixels
-_BORDER = const(4)  # border size in pixels
 
 
 class Button(ui.Component):
@@ -166,46 +72,8 @@ class Button(ui.Component):
                 s = self.disabled_style
             elif self.state is _PRESSED:
                 s = self.active_style
-            ax, ay, aw, ah = self.area
-            self.render_background(s, ax, ay, aw, ah)
-            self.render_content(s, ax, ay, aw, ah)
+            render_button(self.text, self.icon, s, self.area)
             self.repaint = False
-
-    def render_background(
-        self, s: ButtonStyleStateType, ax: int, ay: int, aw: int, ah: int
-    ) -> None:
-        radius = s.radius
-        bg_color = s.bg_color
-        border_color = s.border_color
-        if border_color == bg_color:
-            # we don't need to render the border
-            display.bar_radius(ax, ay, aw, ah, bg_color, ui.BG, radius)
-        else:
-            # render border and background on top of it
-            display.bar_radius(ax, ay, aw, ah, border_color, ui.BG, radius)
-            display.bar_radius(
-                ax + _BORDER,
-                ay + _BORDER,
-                aw - _BORDER * 2,
-                ah - _BORDER * 2,
-                bg_color,
-                border_color,
-                radius,
-            )
-
-    def render_content(
-        self, s: ButtonStyleStateType, ax: int, ay: int, aw: int, ah: int
-    ) -> None:
-        tx = ax + aw // 2
-        ty = ay + ah // 2 + 8
-        t = self.text
-        if t:
-            display.text_center(tx, ty, t, s.text_style, s.fg_color, s.bg_color)
-            return
-        i = self.icon
-        if i:
-            display.icon(tx - _ICON // 2, ty - _ICON, i, s.fg_color, s.bg_color)
-            return
 
     def on_touch_start(self, x: int, y: int) -> None:
         if self.state is _DISABLED:

--- a/core/src/trezor/ui/confirm.py
+++ b/core/src/trezor/ui/confirm.py
@@ -10,6 +10,8 @@ from trezor.ui.button import (
 )
 from trezor.ui.loader import Loader, LoaderDefault
 
+from .model import confirm as model
+
 if __debug__:
     from apps.debug import swipe_signal, confirm_signal
 
@@ -24,10 +26,10 @@ INFO = object()
 
 
 class Confirm(ui.Layout):
-    DEFAULT_CONFIRM = res.load(ui.ICON_CONFIRM)
-    DEFAULT_CONFIRM_STYLE = ButtonConfirm
-    DEFAULT_CANCEL = res.load(ui.ICON_CANCEL)
-    DEFAULT_CANCEL_STYLE = ButtonCancel
+    DEFAULT_CONFIRM = model.DEFAULT_CONFIRM
+    DEFAULT_CONFIRM_STYLE = model.DEFAULT_CONFIRM_STYLE
+    DEFAULT_CANCEL = model.DEFAULT_CANCEL
+    DEFAULT_CANCEL_STYLE = model.DEFAULT_CANCEL_STYLE
 
     def __init__(
         self,
@@ -41,12 +43,8 @@ class Confirm(ui.Layout):
         self.content = content
 
         if confirm is not None:
-            if cancel is None:
-                area = ui.grid(4, n_x=1)
-            elif major_confirm:
-                area = ui.grid(13, cells_x=2)
-            else:
-                area = ui.grid(9, n_x=2)
+
+            area = model.confirm_button_area(True, cancel is None, major_confirm)
             self.confirm = Button(
                 area, confirm, confirm_style
             )  # type: Optional[Button]
@@ -55,12 +53,7 @@ class Confirm(ui.Layout):
             self.confirm = None
 
         if cancel is not None:
-            if confirm is None:
-                area = ui.grid(4, n_x=1)
-            elif major_confirm:
-                area = ui.grid(12, cells_x=1)
-            else:
-                area = ui.grid(8, n_x=2)
+            area = model.confirm_button_area(False, confirm is None, major_confirm)
             self.cancel = Button(area, cancel, cancel_style)  # type: Optional[Button]
             self.cancel.on_click = self.on_cancel  # type: ignore
         else:

--- a/core/src/trezor/ui/model/__init__.py
+++ b/core/src/trezor/ui/model/__init__.py
@@ -1,0 +1,4 @@
+"""
+This module contains constants and functions that are different across
+hardware, e.g. T1 and TT.
+"""

--- a/core/src/trezor/ui/model/button/__init__.py
+++ b/core/src/trezor/ui/model/button/__init__.py
@@ -1,0 +1,17 @@
+from trezor import utils
+
+if False:
+    from typing import TYPE_CHECKING
+else:
+    TYPE_CHECKING = False
+
+if utils.MODEL == "1":
+    from .t1 import *  # noqa: F401,F403
+
+elif utils.MODEL == "T":
+    # FIXME: without the condition mypy complains about Incompatible import
+    if not TYPE_CHECKING:
+        from .tt import *  # noqa: F401,F403
+
+else:
+    raise ValueError("Unknown Trezor model")

--- a/core/src/trezor/ui/model/button/t1.py
+++ b/core/src/trezor/ui/model/button/t1.py
@@ -1,0 +1,175 @@
+from trezor import ui
+from trezor.ui import display, in_area
+
+from ..types import ButtonStyle, ButtonStyleState
+
+if False:
+    from typing import Optional
+    from ..types import (  # noqa: F401
+        ButtonStyleStateType,
+        ButtonStyleType,
+        ButtonContent,
+    )
+
+
+class ButtonDefault(ButtonStyle):
+    class normal(ButtonStyleState):
+        bg_color = ui.FG
+        fg_color = ui.BG
+        text_style = ui.BOLD
+        border_color = ui.FG
+        radius = 1
+
+    class active(normal):
+        bg_color = ui.BG
+        fg_color = ui.FG
+        text_style = ui.BOLD
+        border_color = ui.BG
+        radius = 1
+
+    class disabled(normal):
+        bg_color = ui.FG
+        fg_color = ui.BG
+        text_style = ui.NORMAL
+        border_color = ui.FG
+        radius = 1
+
+
+class ButtonMono(ButtonDefault):
+    class normal(ButtonDefault.normal):
+        text_style = ui.MONO
+
+    class active(ButtonDefault.active):
+        text_style = ui.MONO
+
+    class disabled(ButtonDefault.disabled):
+        text_style = ui.MONO
+
+
+class ButtonMonoDark(ButtonDefault):
+    class normal(ButtonDefault.normal):
+        bg_color = ui.BG
+        fg_color = ui.FG
+        text_style = ui.MONO
+        border_color = ui.BG
+        radius = 0
+
+    class active(normal):
+        bg_color = ui.FG
+        fg_color = ui.BG
+        text_style = ui.MONO
+        border_color = ui.FG
+        radius = 0
+
+    class disabled(normal):
+        bg_color = ui.BG
+        fg_color = ui.FG
+        text_style = ui.MONO
+        border_color = ui.BG
+        radius = 0
+
+
+class ButtonConfirm(ButtonDefault):
+    pass
+
+
+class ButtonCancel(ButtonDefault):
+    class normal(ButtonDefault.normal):
+        bg_color = ui.BG
+        fg_color = ui.FG
+        border_color = ui.BG
+        radius = 0
+
+    class active(ButtonDefault.active):
+        bg_color = ui.FG
+        fg_color = ui.BG
+        border_color = ui.FG
+        radius = 0
+
+    class disabled(ButtonDefault.disabled):
+        bg_color = ui.BG
+        fg_color = ui.FG
+        border_color = ui.BG
+        radius = 0
+
+
+class ButtonAbort(ButtonDefault):
+    pass
+
+
+class ButtonClear(ButtonCancel):
+    pass
+
+
+class ButtonMonoConfirm(ButtonDefault):
+    class normal(ButtonDefault.normal):
+        text_style = ui.MONO
+
+    class active(ButtonDefault.active):
+        text_style = ui.MONO
+
+    class disabled(ButtonDefault.disabled):
+        text_style = ui.MONO
+
+
+def render_button(
+    text: Optional[str], icon: Optional[bytes], s: ButtonStyleStateType, area: ui.Area
+) -> None:
+    if in_area(area, 0, ui.HEIGHT - 1):
+        is_right = False
+    elif in_area(area, ui.WIDTH - 1, ui.HEIGHT - 1):
+        is_right = True
+    else:
+        raise AssertionError
+
+    ax, ay, aw, ah = area
+    _render_background(text or "", s, is_right, area)
+    _render_content(text or "", s, is_right, area)
+
+
+def _bar_radius1(x: int, y: int, w: int, h: int, color: int) -> None:
+    display.bar(x + 1, y, w - 2, h, color)
+    display.bar(x, y + 1, 1, h - 2, color)
+    display.bar(x + w - 1, y + 1, 1, h - 2, color)
+
+
+def _render_background(
+    text: str, s: ButtonStyleStateType, is_right: bool, area: ui.Area,
+) -> None:
+    text_width = display.text_width(text, s.text_style)
+    _ax, ay, _aw, ah = area
+    if s.radius > 0:
+        _bar_radius1(
+            ui.WIDTH - text_width - 2 if is_right else 0,  # x
+            ay,  # y
+            text_width + 2,  # w
+            ah,  # h
+            s.bg_color,  # fgcolor
+        )
+    else:
+        display.bar(
+            ui.WIDTH - text_width + 2 if is_right else 0,  # x
+            ay,  # y
+            text_width - 1,  # w
+            ah,  # h
+            s.bg_color,  # fgcolor
+        )
+
+
+def _render_content(
+    text: str, s: ButtonStyleStateType, is_right: bool, _area: ui.Area,
+) -> None:
+    h_border = 1 if s.radius > 0 else 0
+    if is_right:
+        display.text_right(
+            ui.WIDTH - 2 * h_border + 1,
+            ui.HEIGHT - 2,
+            text,
+            s.text_style,
+            s.fg_color,
+            s.bg_color,
+        )
+    else:
+        display.text(
+            h_border, ui.HEIGHT - 2, text, s.text_style, s.fg_color, s.bg_color
+        )

--- a/core/src/trezor/ui/model/button/t1.py
+++ b/core/src/trezor/ui/model/button/t1.py
@@ -140,15 +140,15 @@ def _render_background(
     _ax, ay, _aw, ah = area
     if s.radius > 0:
         _bar_radius1(
-            ui.WIDTH - text_width - 2 if is_right else 0,  # x
+            ui.WIDTH - text_width - 3 if is_right else 0,  # x
             ay,  # y
-            text_width + 2,  # w
+            text_width + 3,  # w
             ah,  # h
             s.bg_color,  # fgcolor
         )
     else:
         display.bar(
-            ui.WIDTH - text_width + 2 if is_right else 0,  # x
+            ui.WIDTH - text_width + 1 if is_right else 0,  # x
             ay,  # y
             text_width - 1,  # w
             ah,  # h
@@ -159,10 +159,10 @@ def _render_background(
 def _render_content(
     text: str, s: ButtonStyleStateType, is_right: bool, _area: ui.Area,
 ) -> None:
-    h_border = 1 if s.radius > 0 else 0
+    h_border = 2 if s.radius > 0 else 0
     if is_right:
         display.text_right(
-            ui.WIDTH - 2 * h_border + 1,
+            ui.WIDTH - h_border + 1,
             ui.HEIGHT - 2,
             text,
             s.text_style,

--- a/core/src/trezor/ui/model/button/tt.py
+++ b/core/src/trezor/ui/model/button/tt.py
@@ -1,0 +1,170 @@
+from micropython import const
+
+from trezor import ui
+from trezor.ui import display
+
+from ..types import ButtonStyle, ButtonStyleState
+
+if False:
+    from typing import Optional
+    from ..types import (  # noqa: F401
+        ButtonStyleStateType,
+        ButtonStyleType,
+        ButtonContent,
+    )
+
+# button constants
+_ICON = const(16)  # icon size in pixels
+_BORDER = const(4)  # border size in pixels
+
+
+class ButtonDefault(ButtonStyle):
+    class normal(ButtonStyleState):
+        bg_color = ui.BLACKISH
+        fg_color = ui.FG
+        text_style = ui.BOLD
+        border_color = ui.BG
+        radius = ui.RADIUS
+
+    class active(normal):
+        bg_color = ui.FG
+        fg_color = ui.BLACKISH
+        text_style = ui.BOLD
+        border_color = ui.FG
+        radius = ui.RADIUS
+
+    class disabled(normal):
+        bg_color = ui.BG
+        fg_color = ui.GREY
+        text_style = ui.NORMAL
+        border_color = ui.BG
+        radius = ui.RADIUS
+
+
+class ButtonMono(ButtonDefault):
+    class normal(ButtonDefault.normal):
+        text_style = ui.MONO
+
+    class active(ButtonDefault.active):
+        text_style = ui.MONO
+
+    class disabled(ButtonDefault.disabled):
+        text_style = ui.MONO
+
+
+class ButtonMonoDark(ButtonDefault):
+    class normal(ButtonDefault.normal):
+        bg_color = ui.DARK_BLACK
+        fg_color = ui.DARK_WHITE
+        text_style = ui.MONO
+        border_color = ui.BG
+        radius = ui.RADIUS
+
+    class active(normal):
+        bg_color = ui.FG
+        fg_color = ui.DARK_BLACK
+        text_style = ui.MONO
+        border_color = ui.FG
+        radius = ui.RADIUS
+
+    class disabled(normal):
+        bg_color = ui.DARK_BLACK
+        fg_color = ui.GREY
+        text_style = ui.MONO
+        border_color = ui.BG
+        radius = ui.RADIUS
+
+
+class ButtonConfirm(ButtonDefault):
+    class normal(ButtonDefault.normal):
+        bg_color = ui.GREEN
+
+    class active(ButtonDefault.active):
+        fg_color = ui.GREEN
+
+
+class ButtonCancel(ButtonDefault):
+    class normal(ButtonDefault.normal):
+        bg_color = ui.RED
+
+    class active(ButtonDefault.active):
+        fg_color = ui.RED
+
+
+class ButtonAbort(ButtonDefault):
+    class normal(ButtonDefault.normal):
+        bg_color = ui.DARK_GREY
+
+    class active(ButtonDefault.active):
+        fg_color = ui.DARK_GREY
+
+
+class ButtonClear(ButtonDefault):
+    class normal(ButtonDefault.normal):
+        bg_color = ui.ORANGE
+
+    class active(ButtonDefault.active):
+        fg_color = ui.ORANGE
+
+
+class ButtonMonoConfirm(ButtonDefault):
+    class normal(ButtonDefault.normal):
+        text_style = ui.MONO
+        bg_color = ui.GREEN
+
+    class active(ButtonDefault.active):
+        text_style = ui.MONO
+        fg_color = ui.GREEN
+
+    class disabled(ButtonDefault.disabled):
+        text_style = ui.MONO
+
+
+def render_button(
+    text: Optional[str], icon: Optional[bytes], s: ButtonStyleStateType, area: ui.Area
+) -> None:
+    ax, ay, aw, ah = area
+    _render_background(s, ax, ay, aw, ah)
+    _render_content(text, icon, s, ax, ay, aw, ah)
+
+
+def _render_background(
+    s: ButtonStyleStateType, ax: int, ay: int, aw: int, ah: int
+) -> None:
+    radius = s.radius
+    bg_color = s.bg_color
+    border_color = s.border_color
+    if border_color == bg_color:
+        # we don't need to render the border
+        display.bar_radius(ax, ay, aw, ah, bg_color, ui.BG, radius)
+    else:
+        # render border and background on top of it
+        display.bar_radius(ax, ay, aw, ah, border_color, ui.BG, radius)
+        display.bar_radius(
+            ax + _BORDER,
+            ay + _BORDER,
+            aw - _BORDER * 2,
+            ah - _BORDER * 2,
+            bg_color,
+            border_color,
+            radius,
+        )
+
+
+def _render_content(
+    t: Optional[str],
+    i: Optional[bytes],
+    s: ButtonStyleStateType,
+    ax: int,
+    ay: int,
+    aw: int,
+    ah: int,
+) -> None:
+    tx = ax + aw // 2
+    ty = ay + ah // 2 + 8
+    if t:
+        display.text_center(tx, ty, t, s.text_style, s.fg_color, s.bg_color)
+        return
+    if i:
+        display.icon(tx - _ICON // 2, ty - _ICON, i, s.fg_color, s.bg_color)
+        return

--- a/core/src/trezor/ui/model/confirm/__init__.py
+++ b/core/src/trezor/ui/model/confirm/__init__.py
@@ -1,0 +1,8 @@
+from trezor import utils
+
+if utils.MODEL == "1":
+    from .t1 import *  # noqa: F401,F403
+elif utils.MODEL == "T":
+    from .tt import *  # noqa: F401,F403
+else:
+    raise ValueError("Unknown Trezor model")

--- a/core/src/trezor/ui/model/confirm/t1.py
+++ b/core/src/trezor/ui/model/confirm/t1.py
@@ -1,0 +1,26 @@
+from trezor import ui
+
+from ..button import ButtonCancel, ButtonConfirm
+
+if False:
+    from typing import Union
+
+DEFAULT_CONFIRM = "CONFIRM"  # type: Union[bytes, str]
+DEFAULT_CONFIRM_STYLE = ButtonConfirm
+DEFAULT_CANCEL = "CANCEL"  # type: Union[bytes, str]
+DEFAULT_CANCEL_STYLE = ButtonCancel
+
+
+def confirm_button_area(
+    is_right: bool, only_one: bool = False, major_confirm: bool = False
+) -> ui.Area:
+    if is_right:
+        if only_one or major_confirm:
+            return (ui.WIDTH // 3, ui.HEIGHT - 11, 2 * ui.WIDTH // 3, 11)
+        else:
+            return (ui.WIDTH // 2, ui.HEIGHT - 11, ui.WIDTH // 2, 11)
+    else:
+        if only_one or major_confirm:
+            return (0, ui.HEIGHT - 11, 2 * ui.WIDTH // 3, 11)
+        else:
+            return (0, ui.HEIGHT - 11, ui.WIDTH // 2, 11)

--- a/core/src/trezor/ui/model/confirm/tt.py
+++ b/core/src/trezor/ui/model/confirm/tt.py
@@ -1,0 +1,30 @@
+from trezor import res, ui
+
+from ..button import ButtonCancel, ButtonConfirm
+
+if False:
+    from typing import Union
+
+DEFAULT_CONFIRM = res.load(ui.ICON_CONFIRM)  # type: Union[bytes, str]
+DEFAULT_CONFIRM_STYLE = ButtonConfirm
+DEFAULT_CANCEL = res.load(ui.ICON_CANCEL)  # type: Union[bytes, str]
+DEFAULT_CANCEL_STYLE = ButtonCancel
+
+
+def confirm_button_area(
+    is_right: bool, only_one: bool = False, major_confirm: bool = False
+) -> ui.Area:
+    if is_right:
+        if only_one:
+            return ui.grid(4, n_x=1)
+        elif major_confirm:
+            return ui.grid(13, cells_x=2)
+        else:
+            return ui.grid(9, n_x=2)
+    else:
+        if only_one:
+            return ui.grid(4, n_x=1)
+        elif major_confirm:
+            return ui.grid(12, cells_x=1)
+        else:
+            return ui.grid(8, n_x=2)

--- a/core/src/trezor/ui/model/text/__init__.py
+++ b/core/src/trezor/ui/model/text/__init__.py
@@ -1,0 +1,8 @@
+from trezor import utils
+
+if utils.MODEL == "1":
+    from .t1 import *  # noqa: F401,F403
+elif utils.MODEL == "T":
+    from .tt import *  # noqa: F401,F403
+else:
+    raise ValueError("Unknown Trezor model")

--- a/core/src/trezor/ui/model/text/t1.py
+++ b/core/src/trezor/ui/model/text/t1.py
@@ -1,0 +1,23 @@
+from micropython import const
+
+from trezor import ui
+from trezor.ui import display, style
+
+TEXT_HEADER_HEIGHT = const(13)
+TEXT_LINE_HEIGHT = const(9)
+TEXT_LINE_HEIGHT_HALF = const(4)
+TEXT_MARGIN_LEFT = const(0)
+TEXT_MAX_LINES = const(4)
+
+
+def header(
+    title: str,
+    icon: str = style.ICON_DEFAULT,
+    fg: int = style.FG,
+    bg: int = style.BG,
+    ifg: int = style.GREEN,
+) -> None:
+    # icon is ignored
+    display.text(0, 7, title, ui.BOLD, fg, bg)
+    for x in range(0, ui.WIDTH, 2):
+        display.bar(x, 9, 1, 1, ui.FG)

--- a/core/src/trezor/ui/model/text/tt.py
+++ b/core/src/trezor/ui/model/text/tt.py
@@ -1,0 +1,22 @@
+from micropython import const
+
+from trezor import res, ui
+from trezor.ui import display, style
+
+TEXT_HEADER_HEIGHT = const(48)
+TEXT_LINE_HEIGHT = const(26)
+TEXT_LINE_HEIGHT_HALF = const(13)
+TEXT_MARGIN_LEFT = const(14)
+TEXT_MAX_LINES = const(5)
+
+
+def header(
+    title: str,
+    icon: str = style.ICON_DEFAULT,
+    fg: int = style.FG,
+    bg: int = style.BG,
+    ifg: int = style.GREEN,
+) -> None:
+    if icon is not None:
+        display.icon(14, 15, res.load(icon), ifg, bg)
+    display.text(44, 35, title, ui.BOLD, fg, bg)

--- a/core/src/trezor/ui/model/types.py
+++ b/core/src/trezor/ui/model/types.py
@@ -1,0 +1,23 @@
+class ButtonStyleState:
+    bg_color = None  # type: int
+    fg_color = None  # type: int
+    text_style = None  # type: int
+    border_color = None  # type: int
+    radius = None  # type: int
+
+
+if False:
+    from typing import Optional, Type, Union
+
+    ButtonStyleStateType = Type[ButtonStyleState]
+    ButtonContent = Optional[Union[str, bytes]]
+
+
+class ButtonStyle:
+    normal = None  # type: ButtonStyleStateType
+    active = None  # type: ButtonStyleStateType
+    disabled = None  # type: ButtonStyleStateType
+
+
+if False:
+    ButtonStyleType = Type[ButtonStyle]

--- a/core/src/trezor/ui/text.py
+++ b/core/src/trezor/ui/text.py
@@ -2,14 +2,18 @@ from micropython import const
 
 from trezor import ui
 
+from .model import text as model
+from .model.text import (
+    TEXT_HEADER_HEIGHT,
+    TEXT_LINE_HEIGHT,
+    TEXT_LINE_HEIGHT_HALF,
+    TEXT_MARGIN_LEFT,
+    TEXT_MAX_LINES,
+)
+
 if False:
     from typing import List, Union
 
-TEXT_HEADER_HEIGHT = const(48)
-TEXT_LINE_HEIGHT = const(26)
-TEXT_LINE_HEIGHT_HALF = const(13)
-TEXT_MARGIN_LEFT = const(14)
-TEXT_MAX_LINES = const(5)
 
 # needs to be different from all colors and font ids
 BR = const(-256)
@@ -157,7 +161,7 @@ class Text(ui.Component):
 
     def on_render(self) -> None:
         if self.repaint:
-            ui.header(
+            model.header(
                 self.header_text,
                 self.header_icon,
                 ui.TITLE_GREY,


### PR DESCRIPTION
Just enough UI ported for `trezorctl ping ping -b` to work. Implementations of `Button`, `Confirm`, and `Text` were moved under `src/trezor/ui/formfactor/{common,t1,tt}/` (not sure if formfactor is even the correct word here).

Known issues:
- [x] fonts are rendered with 23px high rectangle of background color - fixed in https://github.com/trezor/trezor-firmware/pull/1173
- [x] glyphs seem to be rendered too far apart - seems to be the property of the font, we need to decide whether to keep it or trim the advances
- [x] does not typecheck
- [ ] could use some docstrings