### PR TITLE
python: Fix UnboundLocalError in trezorctl btc get-address.

### DIFF
--- a/python/CHANGELOG.md
+++ b/python/CHANGELOG.md
@@ -6,6 +6,13 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 _At the moment, the project does **not** adhere to [Semantic Versioning](https://semver.org/spec/v2.0.0.html). That is expected to change with version 1.0._
 
+## [0.12.2] - unreleased
+[0.12.2]: https://github.com/trezor/trezor-firmware/compare/python/v0.12.1...master
+
+### Fixed
+
+- fix `UnboundLocalError` in `trezorctl btc get-address`  [#1179]
+
 ## [0.12.1] - 2020-08-05
 [0.12.1]: https://github.com/trezor/trezor-firmware/compare/python/v0.12.0...python/v0.12.1
 
@@ -452,3 +459,4 @@ _At the moment, the project does **not** adhere to [Semantic Versioning](https:/
 [#948]: https://github.com/trezor/trezor-firmware/issues/948
 [#1052]: https://github.com/trezor/trezor-firmware/issues/1052
 [#1126]: https://github.com/trezor/trezor-firmware/issues/1126
+[#1179]: https://github.com/trezor/trezor-firmware/issues/1179

--- a/python/src/trezorlib/__init__.py
+++ b/python/src/trezorlib/__init__.py
@@ -1,4 +1,4 @@
-__version__ = "0.12.1"
+__version__ = "0.12.2"
 
 # fmt: off
 MINIMUM_FIRMWARE_VERSION = {

--- a/python/src/trezorlib/cli/btc.py
+++ b/python/src/trezorlib/cli/btc.py
@@ -134,6 +134,9 @@ def get_address(
         )
         if script_type == messages.InputScriptType.SPENDADDRESS:
             script_type = messages.InputScriptType.SPENDMULTISIG
+    else:
+        multisig = None
+
     return btc.get_address(
         client,
         coin,


### PR DESCRIPTION
Fixes a bug introduced in 95f33a77c737e0f1c20cf20c1fd3aebb99f48eb0:
```
  File "/home/andrew/firmware/python/src/trezorlib/cli/btc.py", line 143, in get_address
    multisig=multisig,
UnboundLocalError: local variable 'multisig' referenced before assignment
```