### PR TITLE
core/ui: Initialize Qr class properly.

### DIFF
--- a/core/src/trezor/ui/qr.py
+++ b/core/src/trezor/ui/qr.py
@@ -7,6 +7,7 @@ class Qr(ui.Component):
         self.x = x
         self.y = y
         self.scale = scale
+        self.repaint = True
 
     def on_render(self) -> None:
         if self.repaint:


### PR DESCRIPTION
Looks like I found another issue like https://github.com/trezor/trezor-firmware/commit/cea634158a92e69587471477748b1c9eba435c5f, but not as serious as #1095. I was able to produce it only once and it won't end in a RSOD.

This fix is OK, but in my opinion we really should be calling `super().__init__()` whenever we define an initializer in a derived class and then the proper way to do this would be to initialize `repaint` in the initializer of `Component`, because that's the topmost class that uses it, even though it doesn't read it: https://github.com/trezor/trezor-firmware/blob/5536fbb98a8214279d6d45052d1c30109f5f79a7/core/src/trezor/ui/__init__.py#L242-L252