### PR TITLE
Fix test coverage reports

### DIFF
--- a/ci/posttest.yml
+++ b/ci/posttest.yml
@@ -2,16 +2,19 @@ image: registry.gitlab.com/satoshilabs/trezor/trezor-firmware/trezor-firmware-en
 
 core unix coverage posttest:
   stage: posttest
+  variables:
+    COVERAGE_THRESHOLD: "78"
   needs: ["core device test", "core monero test", "core u2f test", "core fido2 test"]
   script:
     - nix-shell --run "pipenv run make -C core res"  # we need to regenerate resources.py
     - nix-shell --run "pipenv run make -C core coverage"
-  coverage: '/>\d+%</'
+  coverage: '/COVERAGE: \d+%/'
   artifacts:
     name: core-unix-coverage-posttest
     paths:
     - core/.coverage.*
     - core/htmlcov
+    when: always
     expire_in: 1 week
 
 core unix ui changes:

--- a/core/Makefile
+++ b/core/Makefile
@@ -271,8 +271,4 @@ upload_prodtest: ## upload prodtest using trezorctl
 	trezorctl firmware_update -f $(PRODTEST_BUILD_DIR)/prodtest.bin
 
 coverage:  # generate coverage report
-	coverage run --source=./src /dev/null 2>/dev/null && \
-	mv .coverage .coverage.empty && \
-	coverage combine .coverage.* && \
-	coverage html
-	grep pc_cov htmlcov/index.html
+	./tools/coverage-report

--- a/core/tools/coverage-report
+++ b/core/tools/coverage-report
@@ -1,0 +1,16 @@
+#!/bin/sh
+
+COVERAGE_THRESHOLD=${COVERAGE_THRESHOLD:-0}
+
+coverage run --source=./src /dev/null 2>/dev/null
+mv .coverage .coverage.empty
+coverage combine .coverage.*
+
+coverage html --fail-under=${COVERAGE_THRESHOLD}
+if [ $? -eq 2 ]; then
+  echo "Code coverage is less than ${COVERAGE_THRESHOLD}%"
+  exit 1
+fi
+
+RESULT=$(grep pc_cov htmlcov/index.html | egrep -o '[0-9]{1,3}%')
+echo "COVERAGE: ${RESULT}"


### PR DESCRIPTION
Fixes #1051. 

Opening as draft until micropython/micropython#6335 is merged.

The PR also adds configurable coverage threshold which makes the CI fail if the coverage drops below. There is however a problem with the current implementation because when such failure happens, no artifact is generated and the developer won't be able to access the report. Not sure if GitLab CI allows jobs to produce artifacts even when they fail, or whether we need a separate job for this check.