### PR TITLE
python: fix cli --file handling

### DIFF
--- a/python/src/trezorlib/cli/binance.py
+++ b/python/src/trezorlib/cli/binance.py
@@ -52,7 +52,7 @@ def get_public_key(client, address, show_display):
 @cli.command()
 @click.argument("file", type=click.File("r"))
 @click.option("-n", "--address", required=True, help=PATH_HELP)
-@click.option("-f", "--file", is_flag=True, hidden=True, expose_value=False)
+@click.option("-f", "--file", "_ignore", is_flag=True, hidden=True, expose_value=False)
 @with_client
 def sign_tx(client, address, file):
     """Sign Binance transaction.

--- a/python/src/trezorlib/cli/cardano.py
+++ b/python/src/trezorlib/cli/cardano.py
@@ -39,7 +39,7 @@ def cli():
 
 @cli.command()
 @click.argument("file", type=click.File("r"))
-@click.option("-f", "--file", is_flag=True, hidden=True, expose_value=False)
+@click.option("-f", "--file", "_ignore", is_flag=True, hidden=True, expose_value=False)
 @click.option(
     "-p", "--protocol-magic", type=int, default=cardano.PROTOCOL_MAGICS["mainnet"]
 )

--- a/python/src/trezorlib/cli/eos.py
+++ b/python/src/trezorlib/cli/eos.py
@@ -43,7 +43,7 @@ def get_public_key(client, address, show_display):
 @cli.command()
 @click.argument("file", type=click.File("r"))
 @click.option("-n", "--address", required=True, help=PATH_HELP)
-@click.option("-f", "--file", is_flag=True, hidden=True, expose_value=False)
+@click.option("-f", "--file", "_ignore", is_flag=True, hidden=True, expose_value=False)
 @with_client
 def sign_transaction(client, address, file):
     """Sign EOS transaction."""

--- a/python/src/trezorlib/cli/lisk.py
+++ b/python/src/trezorlib/cli/lisk.py
@@ -54,7 +54,7 @@ def get_public_key(client, address, show_display):
 @cli.command()
 @click.argument("file", type=click.File("r"))
 @click.option("-n", "--address", required=True, help=PATH_HELP)
-@click.option("-f", "--file", is_flag=True, hidden=True, expose_value=False)
+@click.option("-f", "--file", "_ignore", is_flag=True, hidden=True, expose_value=False)
 @with_client
 def sign_tx(client, address, file):
     """Sign Lisk transaction."""

--- a/python/src/trezorlib/cli/nem.py
+++ b/python/src/trezorlib/cli/nem.py
@@ -44,7 +44,7 @@ def get_address(client, address, network, show_display):
 @cli.command()
 @click.argument("file", type=click.File("r"))
 @click.option("-n", "--address", required=True, help=PATH_HELP)
-@click.option("-f", "--file", is_flag=True, hidden=True, expose_value=False)
+@click.option("-f", "--file", "_ignore", is_flag=True, hidden=True, expose_value=False)
 @click.option("-b", "--broadcast", help="NIS to announce transaction to")
 @with_client
 def sign_tx(client, address, file, broadcast):

--- a/python/src/trezorlib/cli/ripple.py
+++ b/python/src/trezorlib/cli/ripple.py
@@ -42,7 +42,7 @@ def get_address(client, address, show_display):
 @cli.command()
 @click.argument("file", type=click.File("r"))
 @click.option("-n", "--address", required=True, help=PATH_HELP)
-@click.option("-f", "--file", is_flag=True, hidden=True, expose_value=False)
+@click.option("-f", "--file", "_ignore", is_flag=True, hidden=True, expose_value=False)
 @with_client
 def sign_tx(client, address, file):
     """Sign Ripple transaction"""

--- a/python/src/trezorlib/cli/settings.py
+++ b/python/src/trezorlib/cli/settings.py
@@ -111,7 +111,9 @@ def flags(client, flags):
 @click.argument(
     "filename", type=click.Path(dir_okay=False, readable=True), required=False
 )
-@click.option("-f", "--filename", is_flag=True, hidden=True, expose_value=False)
+@click.option(
+    "-f", "--filename", "_ignore", is_flag=True, hidden=True, expose_value=False
+)
 @with_client
 def homescreen(client, filename):
     """Set new homescreen."""

--- a/python/src/trezorlib/cli/tezos.py
+++ b/python/src/trezorlib/cli/tezos.py
@@ -52,7 +52,7 @@ def get_public_key(client, address, show_display):
 @cli.command()
 @click.argument("file", type=click.File("r"))
 @click.option("-n", "--address", required=True, help=PATH_HELP)
-@click.option("-f", "--file", is_flag=True, hidden=True, expose_value=False)
+@click.option("-f", "--file", "_ignore", is_flag=True, hidden=True, expose_value=False)
 @with_client
 def sign_tx(client, address, file):
     """Sign Tezos transaction."""


### PR DESCRIPTION
It seems that Click doesn't do the right thing when argument and hidden option with the same name exist, which was introduced in commit 2678e64a9923e56345054daf6eb87ba17b9d3169.

```
$ trezorctl set homescreen /some/image.png 
Usage: trezorctl set homescreen [OPTIONS] [FILENAME]
Try 'trezorctl set homescreen --help' for help.

Error: Invalid value for '-f' / '--filename': /some/image.png is not a valid boolean
```

Not familiar with Click so this might not be the best fix. Renaming the argument also works.