### PR TITLE
fixed log message levels

### DIFF
--- a/python/src/trezorlib/client.py
+++ b/python/src/trezorlib/client.py
@@ -85,7 +85,9 @@ class TrezorClient:
     def __init__(
         self, transport, ui, session_id=None,
     ):
-        LOG.info("creating client instance for device: {}".format(transport.get_path()))
+        LOG.debug(
+            "creating client instance for device: {}".format(transport.get_path())
+        )
         self.transport = transport
         self.ui = ui
         self.session_id = session_id

--- a/python/src/trezorlib/device.py
+++ b/python/src/trezorlib/device.py
@@ -190,7 +190,6 @@ def reset(
         raise RuntimeError("Invalid response, expected EntropyRequest")
 
     external_entropy = os.urandom(32)
-    # LOG.debug("Computer generated entropy: " + external_entropy.hex())
     ret = client.call(messages.EntropyAck(entropy=external_entropy))
     client.init_device()
     return ret

--- a/python/src/trezorlib/transport/__init__.py
+++ b/python/src/trezorlib/transport/__init__.py
@@ -117,7 +117,7 @@ def enumerate_devices() -> Iterable[Transport]:
         name = transport.__name__
         try:
             found = list(transport.enumerate())
-            LOG.info("Enumerating {}: found {} devices".format(name, len(found)))
+            LOG.debug("Enumerating {}: found {} devices".format(name, len(found)))
             devices.extend(found)
         except NotImplementedError:
             LOG.error("{} does not implement device enumeration".format(name))


### PR DESCRIPTION
Downgraded some LOG.info to LOG.debug

Upgraded the LOG.info in trezorlib/transport/hid.py to LOG.warning (similarly to trezorlib/transport/webusb.py)

Re-enabled the LOG.debug that was commented out in trezorlib/device.py

See: https://github.com/bitcoin-core/HWI/pull/372