### PR TITLE
Enable extra_data for Stakenet

### DIFF
--- a/common/defs/bitcoin/stakenet.json
+++ b/common/defs/bitcoin/stakenet.json
@@ -40,7 +40,7 @@
   "negative_fee": false,
   "cooldown": 100,
   "consensus_branch_id": null,
-  "extra_data": false,
+  "extra_data": true,
   "timestamp": false,
   "confidential_assets": null
 }

--- a/core/src/apps/common/coininfo.py
+++ b/core/src/apps/common/coininfo.py
@@ -1486,7 +1486,7 @@ def by_name(name: str) -> CoinInfo:
                 decred=False,
                 negative_fee=False,
                 curve_name='secp256k1',
-                extra_data=False,
+                extra_data=True,
                 timestamp=False,
                 overwintered=False,
                 confidential_assets=None,


### PR DESCRIPTION
Stakenet is working on a hardfork to support extra_data like Dash does, hence, we are enabling it.