### PR TITLE
build-docker.sh: print firmware fingerprints after build

### DIFF
--- a/build-docker.sh
+++ b/build-docker.sh
@@ -45,6 +45,9 @@ for BITCOIN_ONLY in 0 1; do
       git submodule update --init --recursive && \
       pipenv install && \
       pipenv run make clean vendor build_firmware && \
+      pipenv run ../python/tools/firmware-fingerprint.py \
+          -o build/firmware/firmware.bin.fingerprint \
+          build/firmware/firmware.bin && \
       chown -R $USER:$GROUP /build"
 
 done
@@ -74,6 +77,24 @@ for BITCOIN_ONLY in 0 1; do
       mkdir -p build/firmware && \
       cp firmware/trezor.bin build/firmware/firmware.bin && \
       cp firmware/trezor.elf build/firmware/firmware.elf && \
+      pipenv run ../python/tools/firmware-fingerprint.py \
+          -o build/firmware/firmware.bin.fingerprint \
+          build/firmware/firmware.bin && \
       chown -R $USER:$GROUP /build"
 
+done
+
+# all built, show fingerprints
+
+echo "Fingerprints:"
+for VARIANT in core legacy; do
+  for BITCOIN_ONLY in 0 1; do
+
+    DIRSUFFIX=${BITCOIN_ONLY/1/-bitcoinonly}
+    DIRSUFFIX=${DIRSUFFIX/0/}
+
+    FWPATH=build/${VARIANT}${DIRSUFFIX}/firmware/firmware.bin
+    FINGERPRINT=$(tr -d '\n' < $FWPATH.fingerprint)
+    echo "$FINGERPRINT $FWPATH"
+  done
 done

--- a/python/tools/firmware-fingerprint.py
+++ b/python/tools/firmware-fingerprint.py
@@ -1,0 +1,27 @@
+#!/usr/bin/env python3
+
+import sys
+import click
+
+from trezorlib import firmware
+
+
+@click.command()
+@click.argument("filename", type=click.File("rb"))
+@click.option("-o", "--output", type=click.File("w"), default="-")
+def firmware_fingerprint(filename, output):
+    """Display fingerprint of a firmware file."""
+    data = filename.read()
+
+    try:
+        version, fw = firmware.parse(data)
+    except Exception as e:
+        click.echo(e, err=True)
+        sys.exit(2)
+
+    fingerprint = firmware.digest(version, fw).hex()
+    click.echo(fingerprint, file=output)
+
+
+if __name__ == "__main__":
+    firmware_fingerprint()


### PR DESCRIPTION
Fixes #1033. I was thinking that displaying firmware fingerprints could be useful to have in `trezorctl`, however it probably doesn't warrant its own top-level subcommand.

```
$ ./build-docker.sh
...

  LD      trezor.elf
  OBJCOPY trezor.bin
make: Leaving directory '/tmp/trezor-firmware/legacy/firmware'
make: Entering directory '/tmp/trezor-firmware/legacy/firmware'
MEMORY_PROTECT=1
python ../bootloader/firmware_sign.py -f trezor.bin
Firmware size 402012 bytes
Firmware fingerprint: 6d8f20dfd7dd0a29c07e8386257d83515ea0507b57def37e8740ebbdceb1e244
Slot #1 is empty
Slot #2 is empty
Slot #3 is empty
HASHES OK
make: Leaving directory '/tmp/trezor-firmware/legacy/firmware'
Fingerprints:
900a99b86063ffc44cde2a2d4d3fc393bcdc681400add105834f7478bdeae710 build/core/firmware/firmware.bin
73dfe0b7424d005ce53c44d41cdf8feddf579b3dfcd1d4fdd772e7bb789424d7 build/core-bitcoinonly/firmware/firmware.bin
e172adc677df20ba07565dd0488aa1af95dd47c565c164f1b1468626558938a4 build/legacy/firmware/firmware.bin
6d8f20dfd7dd0a29c07e8386257d83515ea0507b57def37e8740ebbdceb1e244 build/legacy-bitcoinonly/firmware/firmware.bin
```