### PR TITLE
Set extra_data to true for FLO

### DIFF
--- a/common/defs/bitcoin/florincoin.json
+++ b/common/defs/bitcoin/florincoin.json
@@ -39,7 +39,7 @@
   "negative_fee": false,
   "cooldown": 100,
   "consensus_branch_id": null,
-  "extra_data": false,
+  "extra_data": true,
   "timestamp": false,
   "confidential_assets": null
 }


### PR DESCRIPTION
FLO's distinguishing feature is the ability to add up to 1040 characters of extra metadata to regular transactions. The new extra_data attribute needs to be set to true to avoid the "Extra data not enabled on this coin" error.