### PR TITLE
extended sign_message to also sign bytes, not only string

### DIFF
--- a/python/src/trezorlib/tools.py
+++ b/python/src/trezorlib/tools.py
@@ -191,7 +191,7 @@ def normalize_nfc(txt):
     This seems to be bitcoin-qt standard of doing things.
     """
     if isinstance(txt, bytes):
-        txt = txt.decode()
+        return txt
     return unicodedata.normalize("NFC", txt).encode()
 
 


### PR DESCRIPTION
Bitcoin message signing is usually used to sign an input string which, as first step, is encoded to bytes. The rest of the implementation assumes bytes, operates on bytes, ecdsa-signs bytes.

This PR proposes to skip the string encoding if bytes, instead of a string, are provided as input: this allow to "bitcoin message sign" an arbitrary byte sequence (note that arbitrary byte sequences cannot be always decoded to strings).

See also https://github.com/bitcoin-core/HWI/pull/366