### PR TITLE
tests: patch ELF interpreter in download_emulators.sh

### DIFF
--- a/tests/download_emulators.sh
+++ b/tests/download_emulators.sh
@@ -10,4 +10,11 @@ wget -e robots=off --no-verbose --no-clobber --no-parent --cut-dirs=2 --no-host-
 chmod u+x emulators/trezor-emu-*
 
 # are we in Nix(OS)?
-command -v nix-shell >/dev/null && nix-shell -p autoPatchelfHook SDL2 SDL2_image --run "autoPatchelf emulators/trezor-emu-*"
+if command -v nix-shell >/dev/null; then
+  nix-shell -p autoPatchelfHook SDL2 SDL2_image --run "autoPatchelf emulators/trezor-emu-*"
+# remove NixOS specific interpreter
+elif command -v patchelf >/dev/null; then
+  patchelf --set-interpreter /lib64/ld-linux-x86-64.so.2 emulators/trezor-emu-*
+else
+  echo "Not on NixOS and patchelf not found: emulators probably have wrong ELF interpreter."
+fi


### PR DESCRIPTION
This is a simple fix - ideally we'd run `patchelf` in the [CI job](https://github.com/trezor/trezor-firmware/blob/c52c93aea0ad248768d4ce033b01a737a9924529/ci/deploy.yml#L153-L189) before uploading the emulator (and manually patch the existing emulators). Fixes #1198.