### PR TITLE
docs: introduce conventional-commits

### DIFF
--- a/COMMITS.md
+++ b/COMMITS.md
@@ -1,0 +1,29 @@
+# Commits
+
+Using [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/) is strongly recommended and might be enforced in future.
+
+### Examples
+
+```
+docs: correct spelling of CHANGELOG
+feat: allow provided config object to extend other configs
+feat(lang): added polish language
+```
+
+### Git hook
+
+Use this git hook to auto-check your commit messages. Save the following snippet into `.git/hooks/commit-msg`
+
+```
+#!/bin/sh
+if ! grep -qE "^(build|ci|docs|feat|fix|perf|refactor|style|test|chore|revert)(\((common|core|crypto|legacy|python|storage|tools|vendor)\))?: " "$1" ; then
+  echo "Conventional Commits validation failed"
+  exit 1
+fi
+```
+
+If you want to bypass commit-msg hook check, you may always use
+
+```
+git commit -m "foobar" --no-verify
+```

--- a/README.md
+++ b/README.md
@@ -23,6 +23,8 @@
 
 See [CONTRIBUTING.md](docs/misc/contributing.md).
 
+Using [Conventional Commits](COMMITS.md) is strongly recommended and might be enforced in future.
+
 Also please have a look at the docs, either in the `docs` folder or at  [docs.trezor.io](https://docs.trezor.io) before contributing. The [misc](docs/misc/index.md) chapter should be read in particular because it contains some useful assorted knowledge.
 
 ## Security vulnerability disclosure


### PR DESCRIPTION
Sending this PR to start a discussion whether we want to do this.

I am thinking about making the "scope" mandatory (we have a monorepo so having a scope is important), so the structure would go like this:

```
<type>(<scope>): <description>

[optional body]

[optional footer(s)]
```

Should we make a list of allowed scopes?

Similar PR sent to trezor-suite by Martin: https://github.com/trezor/trezor-suite/pull/2007