### PR TITLE
Add Eagle schematics for current board, version 13

### DIFF
--- a/docs/hardware/model-t/assets/CYM1A113.brd
+++ b/docs/hardware/model-t/assets/CYM1A113.brd
@@ -1,0 +1,3818 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!DOCTYPE eagle SYSTEM "eagle.dtd">
+<eagle version="7.7.0">
+<drawing>
+<settings>
+<setting alwaysvectorfont="yes"/>
+<setting verticaltext="up"/>
+</settings>
+<grid distance="0.1" unitdist="mm" unit="mm" style="lines" multiple="1" display="yes" altdistance="0.01" altunitdist="mm" altunit="mm"/>
+<layers>
+<layer number="1" name="Top" color="4" fill="1" visible="yes" active="yes"/>
+<layer number="2" name="Route2" color="13" fill="1" visible="yes" active="yes"/>
+<layer number="3" name="Route3" color="4" fill="3" visible="no" active="no"/>
+<layer number="4" name="Route4" color="1" fill="4" visible="no" active="no"/>
+<layer number="5" name="Route5" color="4" fill="4" visible="no" active="no"/>
+<layer number="6" name="Route6" color="1" fill="8" visible="no" active="no"/>
+<layer number="7" name="Route7" color="4" fill="8" visible="no" active="no"/>
+<layer number="8" name="Route8" color="1" fill="2" visible="no" active="no"/>
+<layer number="9" name="Route9" color="4" fill="2" visible="no" active="no"/>
+<layer number="10" name="Route10" color="1" fill="7" visible="no" active="no"/>
+<layer number="11" name="Route11" color="4" fill="7" visible="no" active="no"/>
+<layer number="12" name="Route12" color="1" fill="5" visible="no" active="no"/>
+<layer number="13" name="Route13" color="4" fill="5" visible="no" active="no"/>
+<layer number="14" name="Route14" color="1" fill="6" visible="no" active="no"/>
+<layer number="15" name="Route15" color="11" fill="1" visible="yes" active="yes"/>
+<layer number="16" name="Bottom" color="1" fill="1" visible="yes" active="yes"/>
+<layer number="17" name="Pads" color="2" fill="1" visible="yes" active="yes"/>
+<layer number="18" name="Vias" color="2" fill="1" visible="yes" active="yes"/>
+<layer number="19" name="Unrouted" color="6" fill="1" visible="yes" active="yes"/>
+<layer number="20" name="Dimension" color="15" fill="1" visible="yes" active="yes"/>
+<layer number="21" name="tPlace" color="7" fill="1" visible="yes" active="yes"/>
+<layer number="22" name="bPlace" color="7" fill="1" visible="yes" active="yes"/>
+<layer number="23" name="tOrigins" color="15" fill="1" visible="yes" active="yes"/>
+<layer number="24" name="bOrigins" color="15" fill="1" visible="yes" active="yes"/>
+<layer number="25" name="tNames" color="7" fill="1" visible="no" active="yes"/>
+<layer number="26" name="bNames" color="7" fill="1" visible="no" active="yes"/>
+<layer number="27" name="tValues" color="7" fill="1" visible="no" active="yes"/>
+<layer number="28" name="bValues" color="7" fill="1" visible="no" active="yes"/>
+<layer number="29" name="tStop" color="7" fill="3" visible="no" active="yes"/>
+<layer number="30" name="bStop" color="7" fill="6" visible="no" active="yes"/>
+<layer number="31" name="tCream" color="7" fill="4" visible="no" active="yes"/>
+<layer number="32" name="bCream" color="7" fill="5" visible="no" active="yes"/>
+<layer number="33" name="tFinish" color="6" fill="3" visible="no" active="yes"/>
+<layer number="34" name="bFinish" color="6" fill="6" visible="no" active="yes"/>
+<layer number="35" name="tGlue" color="7" fill="4" visible="no" active="yes"/>
+<layer number="36" name="bGlue" color="7" fill="5" visible="no" active="yes"/>
+<layer number="37" name="tTest" color="7" fill="1" visible="no" active="yes"/>
+<layer number="38" name="bTest" color="7" fill="1" visible="no" active="yes"/>
+<layer number="39" name="tKeepout" color="4" fill="11" visible="no" active="yes"/>
+<layer number="40" name="bKeepout" color="1" fill="11" visible="no" active="yes"/>
+<layer number="41" name="tRestrict" color="4" fill="10" visible="no" active="yes"/>
+<layer number="42" name="bRestrict" color="1" fill="10" visible="no" active="yes"/>
+<layer number="43" name="vRestrict" color="2" fill="10" visible="no" active="yes"/>
+<layer number="44" name="Drills" color="7" fill="1" visible="no" active="yes"/>
+<layer number="45" name="Holes" color="7" fill="1" visible="no" active="yes"/>
+<layer number="46" name="Milling" color="3" fill="1" visible="no" active="yes"/>
+<layer number="47" name="Measures" color="7" fill="1" visible="no" active="yes"/>
+<layer number="48" name="Document" color="7" fill="1" visible="no" active="yes"/>
+<layer number="49" name="Reference" color="7" fill="1" visible="no" active="yes"/>
+<layer number="50" name="XPads" color="7" fill="1" visible="no" active="no"/>
+<layer number="51" name="tDocu" color="7" fill="1" visible="no" active="yes"/>
+<layer number="52" name="bDocu" color="7" fill="1" visible="no" active="yes"/>
+<layer number="53" name="tGND_GNDA" color="7" fill="1" visible="no" active="no"/>
+<layer number="54" name="bGND_GNDA" color="7" fill="1" visible="no" active="no"/>
+<layer number="56" name="wert" color="7" fill="1" visible="no" active="no"/>
+<layer number="59" name="tCarbon" color="7" fill="1" visible="no" active="no"/>
+<layer number="60" name="bCarbon" color="7" fill="1" visible="no" active="no"/>
+<layer number="90" name="Modules" color="5" fill="1" visible="no" active="no"/>
+<layer number="91" name="Nets" color="2" fill="1" visible="no" active="no"/>
+<layer number="92" name="Busses" color="1" fill="1" visible="no" active="no"/>
+<layer number="93" name="Pins" color="2" fill="1" visible="no" active="no"/>
+<layer number="94" name="Symbols" color="4" fill="1" visible="no" active="no"/>
+<layer number="95" name="Names" color="7" fill="1" visible="no" active="no"/>
+<layer number="96" name="Values" color="7" fill="1" visible="no" active="no"/>
+<layer number="97" name="Info" color="7" fill="1" visible="no" active="no"/>
+<layer number="98" name="Guide" color="6" fill="1" visible="no" active="no"/>
+<layer number="99" name="SpiceOrder" color="5" fill="1" visible="no" active="no"/>
+<layer number="100" name="Muster" color="7" fill="1" visible="no" active="yes"/>
+<layer number="101" name="Potisk" color="14" fill="1" visible="no" active="yes"/>
+<layer number="102" name="BotNames" color="7" fill="1" visible="no" active="yes"/>
+<layer number="103" name="Ramecek" color="7" fill="1" visible="no" active="yes"/>
+<layer number="104" name="DATUMY" color="7" fill="1" visible="no" active="yes"/>
+<layer number="105" name="vr_nula" color="7" fill="1" visible="no" active="yes"/>
+<layer number="106" name="Vrtaky" color="7" fill="1" visible="no" active="yes"/>
+<layer number="107" name="Uhlik" color="7" fill="1" visible="no" active="yes"/>
+<layer number="108" name="tKoment" color="7" fill="1" visible="no" active="yes"/>
+<layer number="109" name="bKoment" color="7" fill="1" visible="no" active="yes"/>
+<layer number="110" name="ram" color="7" fill="1" visible="no" active="yes"/>
+<layer number="111" name="ram_m" color="7" fill="1" visible="no" active="yes"/>
+<layer number="112" name="tSilk" color="7" fill="1" visible="no" active="yes"/>
+<layer number="113" name="113" color="7" fill="1" visible="no" active="yes"/>
+<layer number="114" name="Drill_legend" color="7" fill="1" visible="no" active="yes"/>
+<layer number="116" name="Patch_BOT" color="7" fill="1" visible="no" active="yes"/>
+<layer number="118" name="Rect_Pads" color="7" fill="1" visible="no" active="yes"/>
+<layer number="120" name="Descript" color="7" fill="1" visible="no" active="yes"/>
+<layer number="121" name="RectA" color="7" fill="1" visible="no" active="yes"/>
+<layer number="122" name="RectB" color="7" fill="1" visible="no" active="yes"/>
+<layer number="123" name="tTestmark" color="7" fill="1" visible="no" active="yes"/>
+<layer number="124" name="bTestmark" color="7" fill="1" visible="no" active="yes"/>
+<layer number="125" name="_tNames" color="7" fill="1" visible="no" active="yes"/>
+<layer number="126" name="_bNames" color="7" fill="1" visible="no" active="yes"/>
+<layer number="127" name="_tValues" color="7" fill="1" visible="no" active="yes"/>
+<layer number="128" name="_bValues" color="7" fill="1" visible="no" active="yes"/>
+<layer number="129" name="Mask" color="7" fill="1" visible="no" active="yes"/>
+<layer number="131" name="tAdjust" color="7" fill="1" visible="no" active="yes"/>
+<layer number="132" name="bAdjust" color="7" fill="1" visible="no" active="yes"/>
+<layer number="144" name="Drill_legend" color="7" fill="1" visible="no" active="yes"/>
+<layer number="151" name="Ostatni" color="14" fill="1" visible="no" active="yes"/>
+<layer number="152" name="Stineni" color="7" fill="1" visible="no" active="yes"/>
+<layer number="160" name="FAB" color="7" fill="1" visible="no" active="yes"/>
+<layer number="161" name="Rect" color="7" fill="1" visible="no" active="yes"/>
+<layer number="162" name="Desc" color="7" fill="1" visible="no" active="yes"/>
+<layer number="163" name="Mech1" color="7" fill="1" visible="no" active="yes"/>
+<layer number="199" name="Contour" color="7" fill="1" visible="no" active="yes"/>
+<layer number="200" name="200bmp" color="7" fill="1" visible="no" active="yes"/>
+<layer number="201" name="201bmp" color="7" fill="1" visible="no" active="yes"/>
+<layer number="202" name="202bmp" color="7" fill="1" visible="no" active="yes"/>
+<layer number="203" name="203bmp" color="7" fill="1" visible="no" active="yes"/>
+<layer number="204" name="204bmp" color="7" fill="1" visible="no" active="yes"/>
+<layer number="205" name="205bmp" color="7" fill="1" visible="no" active="yes"/>
+<layer number="206" name="206bmp" color="7" fill="1" visible="no" active="yes"/>
+<layer number="207" name="207bmp" color="7" fill="1" visible="no" active="yes"/>
+<layer number="208" name="208bmp" color="7" fill="1" visible="no" active="yes"/>
+<layer number="209" name="209bmp" color="7" fill="1" visible="no" active="yes"/>
+<layer number="210" name="210bmp" color="7" fill="1" visible="no" active="yes"/>
+<layer number="211" name="211bmp" color="7" fill="1" visible="no" active="yes"/>
+<layer number="212" name="212bmp" color="7" fill="1" visible="no" active="yes"/>
+<layer number="213" name="213bmp" color="7" fill="1" visible="no" active="yes"/>
+<layer number="214" name="214bmp" color="7" fill="1" visible="no" active="yes"/>
+<layer number="215" name="215bmp" color="7" fill="1" visible="no" active="yes"/>
+<layer number="216" name="216bmp" color="7" fill="1" visible="no" active="yes"/>
+<layer number="217" name="217bmp" color="7" fill="1" visible="no" active="yes"/>
+<layer number="218" name="218bmp" color="7" fill="1" visible="no" active="yes"/>
+<layer number="219" name="219bmp" color="7" fill="1" visible="no" active="yes"/>
+<layer number="220" name="220bmp" color="7" fill="1" visible="no" active="yes"/>
+<layer number="221" name="221bmp" color="7" fill="1" visible="no" active="yes"/>
+<layer number="222" name="222bmp" color="7" fill="1" visible="no" active="yes"/>
+<layer number="223" name="223bmp" color="7" fill="1" visible="no" active="yes"/>
+<layer number="224" name="224bmp" color="7" fill="1" visible="no" active="yes"/>
+<layer number="231" name="Eagle3D_PG1" color="7" fill="1" visible="no" active="yes"/>
+<layer number="232" name="Eagle3D_PG2" color="7" fill="1" visible="no" active="yes"/>
+<layer number="233" name="Eagle3D_PG3" color="7" fill="1" visible="no" active="yes"/>
+<layer number="248" name="Housing" color="7" fill="1" visible="no" active="yes"/>
+<layer number="249" name="Edge" color="7" fill="1" visible="no" active="yes"/>
+<layer number="250" name="Descript" color="3" fill="1" visible="no" active="no"/>
+<layer number="251" name="SMDround" color="12" fill="11" visible="no" active="no"/>
+<layer number="254" name="cooling" color="7" fill="1" visible="no" active="yes"/>
+</layers>
+<board>
+<plain>
+<wire x1="-5.079" y1="17" x2="72.187" y2="17" width="0.254" layer="51" style="dashdot"/>
+<wire x1="70" y1="0.1" x2="71" y2="1.1" width="0.127" layer="20" curve="90"/>
+<wire x1="71" y1="1.1" x2="71" y2="8" width="0.127" layer="20"/>
+<wire x1="71" y1="8" x2="69.1" y2="8" width="0.127" layer="20"/>
+<wire x1="69.1" y1="8" x2="68.6" y2="8.5" width="0.127" layer="20" curve="-90"/>
+<wire x1="68.6" y1="8.5" x2="68.6" y2="25.5" width="0.127" layer="20"/>
+<wire x1="68.6" y1="25.5" x2="69.1" y2="26" width="0.127" layer="20" curve="-90"/>
+<wire x1="69.1" y1="26" x2="71" y2="26" width="0.127" layer="20"/>
+<wire x1="71" y1="26" x2="71" y2="32.9" width="0.127" layer="20"/>
+<wire x1="71" y1="32.9" x2="70" y2="33.9" width="0.127" layer="20" curve="90"/>
+<wire x1="70" y1="33.9" x2="32.95" y2="33.9" width="0.127" layer="20"/>
+<wire x1="32.95" y1="33.9" x2="26.6" y2="32.5" width="0.127" layer="20"/>
+<wire x1="26.6" y1="32.5" x2="27.25" y2="31.15" width="0.127" layer="20"/>
+<wire x1="27.25" y1="31.15" x2="23.45" y2="29.35" width="0.127" layer="20"/>
+<wire x1="23.45" y1="29.35" x2="22.8" y2="30.7" width="0.127" layer="20"/>
+<wire x1="22.8" y1="30.7" x2="21.6" y2="29.8" width="0.127" layer="20"/>
+<wire x1="21.6" y1="29.8" x2="21.1" y2="28.1" width="0.127" layer="20"/>
+<wire x1="21.1" y1="28.1" x2="18" y2="26.1" width="0.127" layer="20"/>
+<wire x1="18" y1="26.1" x2="16.6" y2="26.1" width="0.127" layer="20"/>
+<wire x1="16.6" y1="26.1" x2="16.5" y2="26.05" width="0.127" layer="20"/>
+<wire x1="16.5" y1="26.05" x2="12" y2="23.875" width="0.127" layer="20"/>
+<wire x1="12" y1="10.125" x2="16.6" y2="7.9" width="0.127" layer="20"/>
+<wire x1="16.6" y1="7.9" x2="18" y2="7.9" width="0.127" layer="20"/>
+<wire x1="18" y1="7.9" x2="21.1" y2="5.9" width="0.127" layer="20"/>
+<wire x1="21.1" y1="5.9" x2="21.6" y2="4.2" width="0.127" layer="20"/>
+<wire x1="21.6" y1="4.2" x2="22.8" y2="3.3" width="0.127" layer="20"/>
+<wire x1="22.8" y1="3.3" x2="23.45" y2="4.65" width="0.127" layer="20"/>
+<wire x1="23.45" y1="4.65" x2="27.25" y2="2.85" width="0.127" layer="20"/>
+<wire x1="27.25" y1="2.85" x2="26.6" y2="1.5" width="0.127" layer="20"/>
+<wire x1="26.6" y1="1.5" x2="32.95" y2="0.1" width="0.127" layer="20"/>
+<wire x1="32.95" y1="0.1" x2="55.229" y2="0.1" width="0.127" layer="20"/>
+<wire x1="55.229" y1="0.1" x2="55.229" y2="1.016" width="0.127" layer="20"/>
+<wire x1="67.148" y1="1.016" x2="67.148" y2="0.1" width="0.127" layer="20"/>
+<wire x1="67.148" y1="0.1" x2="70" y2="0.1" width="0.127" layer="20"/>
+<wire x1="57.261" y1="3.048" x2="65.116" y2="3.048" width="0.127" layer="20"/>
+<wire x1="57.261" y1="3.048" x2="55.229" y2="1.016" width="0.127" layer="20" curve="90"/>
+<wire x1="65.116" y1="3.048" x2="67.148" y2="1.016" width="0.127" layer="20" curve="-90"/>
+<text x="61.849" y="16.383" size="1.016" layer="29" font="vector" ratio="20" rot="R90">TOP</text>
+<text x="61.849" y="18.923" size="1.016" layer="30" font="vector" ratio="20" rot="SMR270">BOT</text>
+<text x="63.981" y="16.064" size="1.016" layer="1" font="vector" ratio="20" rot="R90">1</text>
+<text x="63.981" y="17.588" size="1.016" layer="2" font="vector" ratio="20" rot="R90">2</text>
+<text x="63.981" y="19.112" size="1.016" layer="15" font="vector" ratio="20" rot="R90">3</text>
+<text x="63.981" y="21.398" size="1.016" layer="16" font="vector" ratio="20" rot="SMR270">4</text>
+<text x="-69" y="-60.8" size="1.778" layer="48">59.0 x 33.8 mm</text>
+<text x="-58.5" y="-64.7" size="1.778" layer="48">±0.1 mm</text>
+<text x="-72.5" y="-68.3" size="1.778" layer="48">SEE LAYER DETAIL</text>
+<text x="-77.5" y="-72.2" size="1.778" layer="48">FR4, Tg = min. 170°C</text>
+<text x="-53.1" y="-76" size="1.778" layer="48">ENIG</text>
+<text x="-56.2" y="-79.7" size="1.778" layer="48">milling</text>
+<text x="100.509" y="92.372" size="1.778" layer="48">LAYER DETAIL</text>
+<text x="124.004" y="84.625" size="1.27" layer="48">LAYER 1 (TOP)</text>
+<text x="126.417" y="78.275" size="1.27" layer="48">LAYER 2</text>
+<text x="126.417" y="71.925" size="1.27" layer="48">LAYER 3</text>
+<text x="122.226" y="65.575" size="1.27" layer="48">LAYER 4 (BOTTOM)</text>
+<text x="99.874" y="76.116" size="1.016" layer="48">4x PREPREG 2116</text>
+<text x="103.684" y="81.45" size="1.016" layer="48">CORE 0.2 mm</text>
+<text x="102.541" y="74.338" size="1.016" layer="48">(4x 113µm)</text>
+<text x="149.531" y="84.752" size="1.016" layer="48">18 µm Cu + (25 ± 10) µm plating</text>
+<text x="149.531" y="78.402" size="1.016" layer="48">18 µm Cu</text>
+<text x="149.531" y="72.052" size="1.016" layer="48">18 µm Cu</text>
+<text x="149.531" y="65.702" size="1.016" layer="48">18 µm Cu + (25 ± 10) µm plating</text>
+<text x="85.65" y="75.227" size="1.016" layer="48">(0.98 ± 0.1) mm</text>
+<wire x1="110.796" y1="88.181" x2="148.896" y2="88.181" width="0.2032" layer="48"/>
+<wire x1="110.796" y1="63.289" x2="148.896" y2="63.289" width="0.2032" layer="48"/>
+<text x="149.912" y="87.8" size="1.016" layer="48">SOLDERMASK (TOP SIDE)</text>
+<text x="149.912" y="62.781" size="1.016" layer="48">SOLDERMASK (BOTTOM SIDE)</text>
+<wire x1="12" y1="10.125" x2="12" y2="12.43" width="0.127" layer="20"/>
+<wire x1="12" y1="12.43" x2="16.7132" y2="12.43" width="0.127" layer="20"/>
+<wire x1="16.7132" y1="12.43" x2="16.7132" y2="21.5646" width="0.127" layer="20"/>
+<wire x1="16.7132" y1="21.5646" x2="12" y2="21.5646" width="0.127" layer="20"/>
+<wire x1="12" y1="21.5646" x2="12" y2="23.875" width="0.127" layer="20"/>
+<wire x1="18.034" y1="19.304" x2="18.288" y2="19.304" width="0.2032" layer="41"/>
+<wire x1="17.907" y1="14.732" x2="18.288" y2="14.732" width="0.2032" layer="41"/>
+<wire x1="18.161" y1="10.587" x2="18.669" y2="10.587" width="0.2032" layer="41"/>
+<wire x1="35.56" y1="30.099" x2="35.56" y2="29.845" width="0.2032" layer="41"/>
+<wire x1="35.56" y1="27.305" x2="35.56" y2="26.551" width="0.2032" layer="41"/>
+<wire x1="33.909" y1="27.686" x2="34.163" y2="27.686" width="0.2032" layer="41"/>
+<wire x1="28.067" y1="23.876" x2="28.702" y2="23.876" width="0.2032" layer="41"/>
+<text x="103.684" y="68.877" size="1.016" layer="48">CORE 0.2 mm</text>
+<circle x="69.5" y="27.55" radius="0.75" width="0.2" layer="41"/>
+<circle x="69.3" y="6.3" radius="0.75" width="0.2" layer="41"/>
+<circle x="29.047" y="31.291" radius="0.75" width="0.2" layer="41"/>
+<circle x="51.7" y="1.8" radius="0.75" width="0.2" layer="41"/>
+<circle x="69.3" y="6.3" radius="0.8" width="0.2032" layer="29"/>
+<circle x="69.5" y="27.55" radius="0.8" width="0.2032" layer="29"/>
+<circle x="29.047" y="31.291" radius="0.8" width="0.2032" layer="29"/>
+<circle x="51.7" y="1.8" radius="0.8" width="0.2032" layer="29"/>
+<wire x1="69.2" y1="-0.2" x2="69.2" y2="9.3" width="1" layer="52"/>
+<wire x1="69.2" y1="9.3" x2="60.5" y2="9.3" width="1" layer="52"/>
+<wire x1="60.5" y1="9.3" x2="60.5" y2="17" width="1" layer="52"/>
+<wire x1="43.5" y1="17" x2="43.5" y2="33.9" width="1" layer="52"/>
+<wire x1="63.4" y1="28" x2="63.8" y2="28" width="0.01" layer="41"/>
+<wire x1="63.4" y1="28.4" x2="63.8" y2="28.4" width="0.01" layer="41"/>
+<wire x1="63.4" y1="26.8" x2="63.8" y2="26.8" width="0.01" layer="41"/>
+<wire x1="63.4" y1="26.4" x2="63.8" y2="26.4" width="0.01" layer="41"/>
+<wire x1="30" y1="8.2" x2="32.1" y2="10.3" width="0.2032" layer="42"/>
+<wire x1="32.1" y1="10.3" x2="42" y2="10.3" width="0.2032" layer="42"/>
+<wire x1="42" y1="10.3" x2="42.8" y2="11.1" width="0.2032" layer="42"/>
+<wire x1="53.3" y1="18.7" x2="53.3" y2="21.1" width="0.2032" layer="42"/>
+<hole x="69.2" y="2.9" drill="1.9"/>
+<dimension x1="69.2" y1="2.9" x2="71" y2="2.7" x3="70.1" y3="-4.8" textsize="1.778" layer="47" dtype="horizontal"/>
+<dimension x1="69.2" y1="2.9" x2="69.8" y2="0.1" x3="80.1" y3="1.5" textsize="1.778" layer="47" dtype="vertical"/>
+<wire x1="24" y1="16.8" x2="24.1" y2="16.8" width="0.2" layer="41"/>
+<wire x1="24" y1="19.4" x2="24.1" y2="19.4" width="0.2" layer="41"/>
+<wire x1="20.2" y1="19.4" x2="20.5" y2="19.4" width="0.2" layer="41"/>
+<wire x1="21.4" y1="20.4" x2="21.5" y2="20.4" width="0.2" layer="41"/>
+<wire x1="20.2" y1="15" x2="20.4" y2="15" width="0.2" layer="41"/>
+<wire x1="38.3" y1="30.1" x2="38.5" y2="30.1" width="0.2" layer="41"/>
+<dimension x1="12" y1="10.125" x2="71" y2="1.2" x3="41.5" y3="-11.4" textsize="1.778" layer="47" dtype="horizontal"/>
+<dimension x1="71" y1="33.9" x2="70.4" y2="0.1" x3="90.9" y3="17" textsize="1.778" layer="47" dtype="vertical"/>
+<dimension x1="68.6" y1="8" x2="71" y2="8" x3="69.8" y3="13" textsize="1.778" layer="47" dtype="horizontal"/>
+<dimension x1="71" y1="1.1" x2="67.148" y2="1.016" x3="69.074" y3="-15.7" textsize="1.778" layer="47" dtype="horizontal"/>
+<dimension x1="69.1" y1="26" x2="69.1" y2="8" x3="86.6" y3="17" textsize="1.778" layer="47" dtype="vertical"/>
+<text x="61.849" y="20.283" size="1.016" layer="29" font="vector" ratio="20" rot="R90">13</text>
+<wire x1="43.1" y1="-1" x2="43.1" y2="5.8" width="1.6764" layer="52"/>
+<rectangle x1="47.6" y1="2.2" x2="57.5" y2="8.4" layer="52"/>
+<wire x1="63.1" y1="28.2" x2="63.1" y2="26.7" width="0.2" layer="41"/>
+<wire x1="-44.002959375" y1="-83.68791875" x2="-41.970959375" y2="-83.68791875" width="0.0762" layer="144"/>
+<wire x1="-41.970959375" y1="-82.67191875" x2="-44.002959375" y2="-84.70391875" width="0.0762" layer="144"/>
+<wire x1="-44.002959375" y1="-82.67191875" x2="-41.970959375" y2="-84.70391875" width="0.0762" layer="144"/>
+<text x="-39.176" y="-84.322" size="1.27" layer="144">0.2000 mm / 7.874 mil </text>
+<wire x1="-44.002959375" y1="-79.36991875" x2="-41.970959375" y2="-81.40191875" width="0.0762" layer="144"/>
+<wire x1="-42.986959375" y1="-81.40191875" x2="-42.986959375" y2="-79.36991875" width="0.0762" layer="144"/>
+<wire x1="-41.970959375" y1="-79.36991875" x2="-44.002959375" y2="-81.40191875" width="0.0762" layer="144"/>
+<text x="-39.176" y="-81.02" size="1.27" layer="144">0.3000 mm / 11.811 mil </text>
+<wire x1="-44.002959375" y1="-78.09991875" x2="-41.970959375" y2="-76.06791875" width="0.0762" layer="144"/>
+<wire x1="-44.002959375" y1="-76.06791875" x2="-41.970959375" y2="-78.09991875" width="0.0762" layer="144"/>
+<text x="-39.176" y="-77.718" size="1.27" layer="144">0.4000 mm / 15.748 mil </text>
+<wire x1="-44.002959375" y1="-72.76591875" x2="-41.970959375" y2="-74.79791875" width="0.0762" layer="144"/>
+<wire x1="-41.970959375" y1="-74.79791875" x2="-41.970959375" y2="-72.76591875" width="0.0762" layer="144"/>
+<wire x1="-41.970959375" y1="-72.76591875" x2="-44.002959375" y2="-74.79791875" width="0.0762" layer="144"/>
+<wire x1="-44.002959375" y1="-74.79791875" x2="-44.002959375" y2="-72.76591875" width="0.0762" layer="144"/>
+<text x="-39.176" y="-74.416" size="1.27" layer="144">0.5000 mm / 19.685 mil </text>
+<wire x1="-44.002959375" y1="-71.49591875" x2="-41.970959375" y2="-69.46391875" width="0.0762" layer="144"/>
+<wire x1="-41.970959375" y1="-69.46391875" x2="-44.002959375" y2="-69.46391875" width="0.0762" layer="144"/>
+<wire x1="-44.002959375" y1="-69.46391875" x2="-41.970959375" y2="-71.49591875" width="0.0762" layer="144"/>
+<wire x1="-41.970959375" y1="-71.49591875" x2="-44.002959375" y2="-71.49591875" width="0.0762" layer="144"/>
+<text x="-39.176" y="-71.114" size="1.27" layer="144">0.6000 mm / 23.622 mil </text>
+<wire x1="-44.002959375" y1="-67.17791875" x2="-41.970959375" y2="-67.17791875" width="0.0762" layer="144"/>
+<wire x1="-41.970959375" y1="-67.17791875" x2="-42.986959375" y2="-66.16191875" width="0.0762" layer="144"/>
+<wire x1="-42.986959375" y1="-66.16191875" x2="-42.986959375" y2="-68.19391875" width="0.0762" layer="144"/>
+<wire x1="-42.986959375" y1="-68.19391875" x2="-44.002959375" y2="-67.17791875" width="0.0762" layer="144"/>
+<text x="-39.176" y="-67.812" size="1.27" layer="144">0.7000 mm / 27.559 mil </text>
+<wire x1="-42.986959375" y1="-63.87591875" x2="-42.986959375" y2="-62.85991875" width="0.0762" layer="144"/>
+<wire x1="-44.002959375" y1="-62.85991875" x2="-41.970959375" y2="-62.85991875" width="0.0762" layer="144"/>
+<wire x1="-41.970959375" y1="-62.85991875" x2="-41.970959375" y2="-64.89191875" width="0.0762" layer="144"/>
+<wire x1="-41.970959375" y1="-64.89191875" x2="-44.002959375" y2="-64.89191875" width="0.0762" layer="144"/>
+<wire x1="-44.002959375" y1="-64.89191875" x2="-44.002959375" y2="-62.85991875" width="0.0762" layer="144"/>
+<text x="-39.176" y="-64.51" size="1.27" layer="144">0.8000 mm / 31.496 mil </text>
+<wire x1="-42.986959375" y1="-60.57391875" x2="-42.986959375" y2="-59.55791875" width="0.0762" layer="144"/>
+<wire x1="-42.986959375" y1="-59.55791875" x2="-44.002959375" y2="-60.57391875" width="0.0762" layer="144"/>
+<wire x1="-44.002959375" y1="-60.57391875" x2="-42.986959375" y2="-61.58991875" width="0.0762" layer="144"/>
+<wire x1="-42.986959375" y1="-61.58991875" x2="-41.970959375" y2="-60.57391875" width="0.0762" layer="144"/>
+<wire x1="-41.970959375" y1="-60.57391875" x2="-42.986959375" y2="-59.55791875" width="0.0762" layer="144"/>
+<text x="-39.176" y="-61.208" size="1.27" layer="144">0.9000 mm / 35.433 mil </text>
+<wire x1="-44.002959375" y1="-57.27191875" x2="-41.970959375" y2="-57.27191875" width="0.0762" layer="144"/>
+<wire x1="-42.986959375" y1="-56.25591875" x2="-42.986959375" y2="-58.28791875" width="0.0762" layer="144"/>
+<text x="-39.176" y="-57.906" size="1.27" layer="144">1.2000 mm / 47.244 mil </text>
+<wire x1="-44.002959375" y1="-53.96991875" x2="-41.970959375" y2="-53.96991875" width="0.0762" layer="144"/>
+<wire x1="-41.970959375" y1="-53.96991875" x2="-42.986959375" y2="-54.98591875" width="0.0762" layer="144"/>
+<wire x1="-42.986959375" y1="-54.98591875" x2="-42.986959375" y2="-52.95391875" width="0.0762" layer="144"/>
+<wire x1="-42.986959375" y1="-52.95391875" x2="-44.002959375" y2="-53.96991875" width="0.0762" layer="144"/>
+<text x="-39.176" y="-54.604" size="1.27" layer="144">1.9000 mm / 74.803 mil </text>
+<text x="-41.97" y="-48.889" size="1.778" layer="144">Vytvoreno : 24.7.2018 16:46</text>
+<text x="-41.97" y="-46.349" size="1.778" layer="144">Vrtaci plan</text>
+</plain>
+<libraries>
+<library name="vyber_stara_nemenit">
+<packages>
+<package name="0402">
+<wire x1="0.508" y1="0.254" x2="-0.508" y2="0.254" width="0.1" layer="21"/>
+<wire x1="-0.508" y1="-0.254" x2="-0.508" y2="0.254" width="0.1" layer="21"/>
+<wire x1="-0.508" y1="-0.254" x2="0.508" y2="-0.254" width="0.1" layer="21"/>
+<wire x1="0.508" y1="0.254" x2="0.508" y2="-0.254" width="0.1" layer="21"/>
+<smd name="P$1" x="-0.508" y="0" dx="0.5" dy="0.75" layer="1" stop="no"/>
+<smd name="P$2" x="0.508" y="0" dx="0.5" dy="0.75" layer="1" stop="no"/>
+<text x="-1.905" y="0.635" size="1.016" layer="25">&gt;NAME</text>
+<text x="-1.905" y="-1.397" size="0.8128" layer="27">&gt;VALUE</text>
+<rectangle x1="-0.1905" y1="-0.381" x2="0.1905" y2="0.381" layer="35"/>
+<rectangle x1="-0.25" y1="-0.38" x2="0.25" y2="0.38" layer="41"/>
+<rectangle x1="-0.859" y1="-0.477" x2="0.86" y2="0.477" layer="29"/>
+</package>
+<package name="0603">
+<wire x1="1.524" y1="0.762" x2="-1.524" y2="0.762" width="0.1524" layer="21"/>
+<wire x1="-1.524" y1="-0.762" x2="-1.524" y2="0.762" width="0.1524" layer="21"/>
+<wire x1="-1.524" y1="-0.762" x2="1.524" y2="-0.762" width="0.1524" layer="21"/>
+<wire x1="1.524" y1="0.762" x2="1.524" y2="-0.762" width="0.1524" layer="21"/>
+<smd name="1" x="-0.8" y="0" dx="0.8" dy="1" layer="1"/>
+<smd name="2" x="0.8" y="0" dx="0.8" dy="1" layer="1"/>
+<text x="-1.27" y="-0.508" size="1.016" layer="25">&gt;NAME</text>
+<text x="-1.397" y="-0.381" size="0.8128" layer="27">&gt;VALUE</text>
+<rectangle x1="-0.254" y1="-0.508" x2="0.254" y2="0.508" layer="35"/>
+</package>
+<package name="SOD323F">
+<smd name="K" x="1.1" y="0" dx="0.6" dy="0.6" layer="1"/>
+<smd name="A" x="-1.1" y="0" dx="0.6" dy="0.6" layer="1"/>
+<text x="-2.413" y="-2.0955" size="1.016" layer="25">&gt;NAME</text>
+<text x="-2.413" y="1.143" size="1.016" layer="27">&gt;VALUE</text>
+<wire x1="-0.9" y1="-0.675" x2="0.4" y2="-0.675" width="0.127" layer="21"/>
+<wire x1="0.4" y1="-0.675" x2="0.5" y2="-0.675" width="0.127" layer="21"/>
+<wire x1="0.5" y1="-0.675" x2="0.6" y2="-0.675" width="0.127" layer="21"/>
+<wire x1="0.6" y1="-0.675" x2="0.9" y2="-0.675" width="0.127" layer="21"/>
+<wire x1="0.9" y1="-0.675" x2="0.9" y2="0.675" width="0.127" layer="21"/>
+<wire x1="0.9" y1="0.675" x2="0.6" y2="0.675" width="0.127" layer="21"/>
+<wire x1="0.6" y1="0.675" x2="0.5" y2="0.675" width="0.127" layer="21"/>
+<wire x1="0.5" y1="0.675" x2="0.4" y2="0.675" width="0.127" layer="21"/>
+<wire x1="0.4" y1="0.675" x2="-0.9" y2="0.675" width="0.127" layer="21"/>
+<wire x1="-0.9" y1="0.675" x2="-0.9" y2="-0.675" width="0.127" layer="21"/>
+<wire x1="0.6" y1="-0.675" x2="0.6" y2="0.675" width="0.127" layer="21"/>
+<wire x1="0.5" y1="-0.675" x2="0.5" y2="0.675" width="0.127" layer="21"/>
+<wire x1="0.4" y1="-0.675" x2="0.4" y2="0.675" width="0.127" layer="21"/>
+<rectangle x1="-0.15" y1="-0.7" x2="0.15" y2="0.7" layer="35"/>
+</package>
+<package name="SOT143B_REFLOW">
+<wire x1="1.524" y1="-0.508" x2="1.143" y2="-0.508" width="0.127" layer="21"/>
+<wire x1="1.143" y1="-0.508" x2="-1.524" y2="-0.508" width="0.127" layer="21"/>
+<wire x1="-1.524" y1="-0.508" x2="-1.524" y2="0.508" width="0.127" layer="21"/>
+<wire x1="-1.524" y1="0.508" x2="1.143" y2="0.508" width="0.127" layer="21"/>
+<wire x1="1.143" y1="0.508" x2="1.524" y2="0.508" width="0.127" layer="21"/>
+<wire x1="1.524" y1="0.508" x2="1.524" y2="-0.508" width="0.127" layer="21"/>
+<wire x1="1.143" y1="-0.508" x2="1.143" y2="0.508" width="0.1524" layer="21"/>
+<smd name="1" x="-0.848" y="-1.028" dx="0.8" dy="1.2" layer="1" rot="R270"/>
+<smd name="2" x="1.053" y="-1.028" dx="0.8" dy="0.8" layer="1" rot="R90"/>
+<smd name="3" x="1.048" y="1.028" dx="0.8" dy="0.8" layer="1" rot="R90"/>
+<smd name="4" x="-1.048" y="1.028" dx="0.8" dy="0.8" layer="1" rot="R90"/>
+<text x="-1.978" y="2.5" size="1.016" layer="25">&gt;NAME</text>
+<text x="-2.13" y="-3.213" size="1.016" layer="27">&gt;VALUE</text>
+<rectangle x1="-1.651" y1="-0.0762" x2="1.651" y2="0.0762" layer="35"/>
+<rectangle x1="0.7112" y1="-1.27" x2="1.3208" y2="-0.5588" layer="27"/>
+<rectangle x1="-1.3208" y1="-1.27" x2="-0.7112" y2="-0.5588" layer="27"/>
+<rectangle x1="-1.3208" y1="-0.762" x2="-0.7112" y2="-0.381" layer="21"/>
+<rectangle x1="0.7112" y1="-0.762" x2="1.3208" y2="-0.381" layer="21"/>
+<rectangle x1="-1.3208" y1="0.381" x2="-0.7112" y2="0.762" layer="21"/>
+<rectangle x1="-1.3208" y1="0.5588" x2="-0.7112" y2="1.27" layer="27"/>
+<rectangle x1="0.7112" y1="-1.27" x2="1.3208" y2="-0.5588" layer="27"/>
+<rectangle x1="-1.3208" y1="-1.27" x2="-0.7112" y2="-0.5588" layer="27"/>
+<rectangle x1="0.7112" y1="0.381" x2="1.3208" y2="0.762" layer="21"/>
+<rectangle x1="0.7112" y1="0.5588" x2="1.3208" y2="1.27" layer="27"/>
+<rectangle x1="-0.9398" y1="-1.27" x2="-0.3302" y2="-0.5588" layer="27"/>
+<rectangle x1="-0.9398" y1="-0.762" x2="-0.3302" y2="-0.381" layer="21"/>
+<rectangle x1="-1.651" y1="-0.0762" x2="1.651" y2="0.0762" layer="35"/>
+</package>
+<package name="0805_REFLOW">
+<wire x1="1" y1="0.625" x2="-1" y2="0.625" width="0.1524" layer="21"/>
+<wire x1="-1" y1="-0.625" x2="-1" y2="0.625" width="0.1524" layer="21"/>
+<wire x1="-1" y1="-0.625" x2="1" y2="-0.625" width="0.1524" layer="21"/>
+<wire x1="1" y1="0.625" x2="1" y2="-0.625" width="0.1524" layer="21"/>
+<smd name="2" x="0.95" y="0" dx="0.7" dy="1.3" layer="1"/>
+<smd name="1" x="-0.95" y="0" dx="0.7" dy="1.3" layer="1"/>
+<text x="-0.9525" y="-0.5159375" size="1.016" layer="25">&gt;NAME</text>
+<text x="-0.9525" y="-0.5159375" size="1.016" layer="27">&gt;VALUE</text>
+<rectangle x1="-0.15" y1="-1" x2="0.15" y2="1" layer="35"/>
+</package>
+<package name="WSON-8_3X3MM">
+<smd name="8" x="-0.975" y="1.475" dx="0.85" dy="0.35" layer="1" roundness="100" rot="R90" stop="no" cream="no"/>
+<smd name="EP" x="0" y="0" dx="2" dy="1.5" layer="1" stop="no" cream="no"/>
+<wire x1="1.5" y1="1.5" x2="1.5" y2="-1.5" width="0.07" layer="21"/>
+<wire x1="1.5" y1="-1.5" x2="-1.5" y2="-1.5" width="0.07" layer="21"/>
+<wire x1="-1.5" y1="-1.5" x2="-1.5" y2="1.5" width="0.07" layer="21"/>
+<wire x1="-1.5" y1="1.5" x2="1.5" y2="1.5" width="0.07" layer="21"/>
+<text x="-1.75" y="2.175" size="0.8128" layer="25">&gt;NAME</text>
+<text x="-2.325" y="-3.025" size="0.8128" layer="27">&gt;VALUE</text>
+<circle x="-1.075" y="-1.15" radius="0.2" width="0.127" layer="21"/>
+<smd name="7" x="-0.325" y="1.475" dx="0.85" dy="0.35" layer="1" roundness="100" rot="R90" stop="no" cream="no"/>
+<smd name="6" x="0.325" y="1.475" dx="0.85" dy="0.35" layer="1" roundness="100" rot="R90" stop="no" cream="no"/>
+<smd name="5" x="0.975" y="1.475" dx="0.85" dy="0.35" layer="1" roundness="100" rot="R90" stop="no" cream="no"/>
+<smd name="1" x="-0.975" y="-1.475" dx="0.85" dy="0.35" layer="1" roundness="100" rot="R90" stop="no" cream="no"/>
+<smd name="2" x="-0.325" y="-1.475" dx="0.85" dy="0.35" layer="1" roundness="100" rot="R90" stop="no" cream="no"/>
+<smd name="3" x="0.325" y="-1.475" dx="0.85" dy="0.35" layer="1" roundness="100" rot="R90" stop="no" cream="no"/>
+<smd name="4" x="0.975" y="-1.475" dx="0.85" dy="0.35" layer="1" roundness="100" rot="R90" stop="no" cream="no"/>
+<rectangle x1="-0.775" y1="-0.65" x2="0.775" y2="0.65" layer="29"/>
+<smd name="EP$1" x="-1.425" y="0.325" dx="0.28" dy="1.025" layer="1" rot="R90" stop="no" cream="no"/>
+<smd name="EP$2" x="-1.425" y="-0.325" dx="0.28" dy="1.025" layer="1" rot="R90" stop="no" cream="no"/>
+<smd name="EP$4" x="1.425" y="0.325" dx="0.28" dy="1.025" layer="1" rot="R90" stop="no" cream="no"/>
+<smd name="EP$3" x="1.425" y="-0.325" dx="0.28" dy="1.025" layer="1" rot="R90" stop="no" cream="no"/>
+<rectangle x1="-0.7" y1="0.1" x2="-0.1" y2="0.6" layer="31"/>
+<rectangle x1="0.1" y1="0.1" x2="0.7" y2="0.6" layer="31"/>
+<rectangle x1="-0.7" y1="-0.6" x2="-0.1" y2="-0.1" layer="31"/>
+<rectangle x1="0.1" y1="-0.6" x2="0.7" y2="-0.1" layer="31"/>
+<rectangle x1="-1.93" y1="0.195" x2="-1.005" y2="0.455" layer="31"/>
+<rectangle x1="-1.945" y1="0.175" x2="-0.99" y2="0.475" layer="29"/>
+<rectangle x1="-1.93" y1="-0.455" x2="-1.005" y2="-0.195" layer="31"/>
+<rectangle x1="-1.945" y1="-0.475" x2="-0.99" y2="-0.175" layer="29"/>
+<rectangle x1="1.005" y1="-0.455" x2="1.93" y2="-0.195" layer="31"/>
+<rectangle x1="0.99" y1="-0.475" x2="1.945" y2="-0.175" layer="29"/>
+<rectangle x1="1.005" y1="0.195" x2="1.93" y2="0.455" layer="31"/>
+<rectangle x1="0.99" y1="0.175" x2="1.945" y2="0.475" layer="29"/>
+<wire x1="-0.975" y1="1.725" x2="-0.975" y2="1.225" width="0.36" layer="29"/>
+<wire x1="-0.975" y1="1.73" x2="-0.975" y2="1.22" width="0.3" layer="31"/>
+<wire x1="-0.325" y1="1.725" x2="-0.325" y2="1.225" width="0.36" layer="29"/>
+<wire x1="-0.325" y1="1.73" x2="-0.325" y2="1.22" width="0.3" layer="31"/>
+<wire x1="0.325" y1="1.725" x2="0.325" y2="1.225" width="0.36" layer="29"/>
+<wire x1="0.325" y1="1.73" x2="0.325" y2="1.22" width="0.3" layer="31"/>
+<wire x1="0.975" y1="1.725" x2="0.975" y2="1.225" width="0.36" layer="29"/>
+<wire x1="0.975" y1="1.73" x2="0.975" y2="1.22" width="0.3" layer="31"/>
+<wire x1="-0.975" y1="-1.225" x2="-0.975" y2="-1.725" width="0.36" layer="29"/>
+<wire x1="-0.975" y1="-1.22" x2="-0.975" y2="-1.73" width="0.3" layer="31"/>
+<wire x1="-0.325" y1="-1.225" x2="-0.325" y2="-1.725" width="0.36" layer="29"/>
+<wire x1="-0.325" y1="-1.22" x2="-0.325" y2="-1.73" width="0.3" layer="31"/>
+<wire x1="0.325" y1="-1.225" x2="0.325" y2="-1.725" width="0.36" layer="29"/>
+<wire x1="0.325" y1="-1.22" x2="0.325" y2="-1.73" width="0.3" layer="31"/>
+<wire x1="0.975" y1="-1.225" x2="0.975" y2="-1.725" width="0.36" layer="29"/>
+<wire x1="0.975" y1="-1.22" x2="0.975" y2="-1.73" width="0.3" layer="31"/>
+</package>
+<package name="0603_REFLOW">
+<wire x1="0.8" y1="0.425" x2="-0.8" y2="0.425" width="0.1524" layer="21"/>
+<wire x1="-0.8" y1="-0.425" x2="-0.8" y2="0.425" width="0.1524" layer="21"/>
+<wire x1="-0.8" y1="-0.425" x2="0.8" y2="-0.425" width="0.1524" layer="21"/>
+<wire x1="0.8" y1="0.425" x2="0.8" y2="-0.425" width="0.1524" layer="21"/>
+<smd name="1" x="-0.8" y="0" dx="0.5" dy="0.9" layer="1"/>
+<smd name="2" x="0.8" y="0" dx="0.5" dy="0.9" layer="1"/>
+<text x="-1.27" y="-1.778" size="1.016" layer="25">&gt;NAME</text>
+<text x="-1.397" y="0.889" size="0.8128" layer="27">&gt;VALUE</text>
+<rectangle x1="-0.254" y1="-0.508" x2="0.254" y2="0.508" layer="35"/>
+</package>
+<package name="MB1.5">
+<circle x="0" y="0" radius="0.1588" width="1" layer="37"/>
+<smd name="1" x="0" y="0" dx="1.25" dy="1.25" layer="1" roundness="100" cream="no"/>
+<text x="-3.175" y="1.5875" size="1.27" layer="37">&gt;NAME</text>
+</package>
+<package name="MB1.27">
+<circle x="0" y="0" radius="0.1588" width="0.8128" layer="37"/>
+<smd name="1" x="0" y="0" dx="1.27" dy="1.27" layer="1" roundness="100" cream="no"/>
+<text x="-3.175" y="1.5875" size="1.27" layer="37">&gt;NAME</text>
+</package>
+<package name="CENTR">
+<circle x="0" y="0" radius="0.3" width="0.6096" layer="1"/>
+<circle x="0" y="0" radius="0.3" width="0.6096" layer="49"/>
+<circle x="0" y="0" radius="0.3" width="0.6096" layer="1"/>
+<circle x="0" y="0" radius="0.8" width="0" layer="29"/>
+</package>
+<package name="BADMARK">
+<rectangle x1="-0.5" y1="-0.5" x2="0.5" y2="0.5" layer="1"/>
+<rectangle x1="-0.7" y1="-0.7" x2="0.7" y2="0.7" layer="29"/>
+<rectangle x1="-0.5" y1="-0.5" x2="0.5" y2="0.5" layer="49"/>
+</package>
+<package name="RAM_BRD_ENG">
+<wire x1="0" y1="0" x2="281.94" y2="0" width="0.1524" layer="48"/>
+<wire x1="281.94" y1="0" x2="281.94" y2="185.42" width="0.1524" layer="48"/>
+<wire x1="281.94" y1="185.42" x2="281.94" y2="193.04" width="0.1524" layer="48"/>
+<wire x1="0" y1="193.04" x2="0" y2="185.42" width="0.1524" layer="48"/>
+<wire x1="0" y1="185.42" x2="0" y2="0" width="0.1524" layer="48"/>
+<wire x1="281.94" y1="193.04" x2="0" y2="193.04" width="0.1524" layer="48"/>
+<wire x1="0" y1="185.42" x2="281.94" y2="185.42" width="0.1524" layer="48"/>
+<wire x1="1.27" y1="16.51" x2="1.27" y2="12.7" width="0.1524" layer="48"/>
+<wire x1="1.27" y1="12.7" x2="1.27" y2="8.89" width="0.1524" layer="48"/>
+<wire x1="1.27" y1="8.89" x2="1.27" y2="5.08" width="0.1524" layer="48"/>
+<wire x1="1.27" y1="5.08" x2="1.27" y2="1.27" width="0.1524" layer="48"/>
+<wire x1="160.02" y1="5.08" x2="160.02" y2="9.144" width="0.4064" layer="48"/>
+<wire x1="160.02" y1="9.144" x2="160.02" y2="12.7" width="0.4064" layer="48"/>
+<wire x1="1.27" y1="5.08" x2="51.435" y2="5.08" width="0.1524" layer="48"/>
+<wire x1="1.27" y1="8.89" x2="51.435" y2="8.89" width="0.1524" layer="48"/>
+<wire x1="1.27" y1="12.7" x2="51.435" y2="12.7" width="0.1524" layer="48"/>
+<wire x1="1.27" y1="16.51" x2="1.27" y2="1.27" width="0.3048" layer="48"/>
+<wire x1="1.27" y1="1.27" x2="51.435" y2="1.27" width="0.3048" layer="48"/>
+<wire x1="51.435" y1="1.27" x2="51.435" y2="5.08" width="0.3048" layer="48"/>
+<wire x1="51.435" y1="5.08" x2="51.435" y2="8.89" width="0.3048" layer="48"/>
+<wire x1="51.435" y1="8.89" x2="51.435" y2="12.7" width="0.3048" layer="48"/>
+<wire x1="51.435" y1="12.7" x2="51.435" y2="16.51" width="0.3048" layer="48"/>
+<wire x1="51.435" y1="16.51" x2="1.27" y2="16.51" width="0.1524" layer="48"/>
+<wire x1="223.2152" y1="5.08" x2="223.2152" y2="9.144" width="0.1524" layer="48"/>
+<wire x1="160.02" y1="5.08" x2="223.2152" y2="5.08" width="0.1524" layer="48"/>
+<wire x1="160.02" y1="9.144" x2="205.74" y2="9.144" width="0.4064" layer="48"/>
+<wire x1="205.74" y1="9.144" x2="223.2152" y2="9.144" width="0.1524" layer="48"/>
+<wire x1="160.02" y1="12.7" x2="205.74" y2="12.7" width="0.1524" layer="48"/>
+<wire x1="205.74" y1="12.7" x2="223.52" y2="12.7" width="0.4064" layer="48"/>
+<wire x1="223.2152" y1="5.08" x2="223.2152" y2="1.27" width="0.1524" layer="48"/>
+<wire x1="223.2152" y1="1.27" x2="223.52" y2="1.27" width="0.3048" layer="48"/>
+<wire x1="223.52" y1="1.27" x2="267.97" y2="1.27" width="0.4064" layer="48"/>
+<wire x1="267.97" y1="1.27" x2="280.67" y2="1.27" width="0.4064" layer="48"/>
+<wire x1="223.52" y1="9.271" x2="280.416" y2="9.271" width="0.762" layer="48"/>
+<wire x1="223.52" y1="21.5138" x2="223.52" y2="21.336" width="0.4064" layer="48"/>
+<wire x1="223.52" y1="21.336" x2="280.416" y2="21.336" width="0.762" layer="48"/>
+<wire x1="280.416" y1="21.336" x2="280.67" y2="21.336" width="0.254" layer="48"/>
+<wire x1="280.67" y1="21.336" x2="280.67" y2="1.27" width="0.4064" layer="48"/>
+<wire x1="280.67" y1="21.336" x2="280.67" y2="27.94" width="0.4064" layer="48"/>
+<wire x1="280.416" y1="21.336" x2="280.416" y2="17.145" width="0.762" layer="48"/>
+<wire x1="280.416" y1="17.145" x2="280.416" y2="9.271" width="0.762" layer="48"/>
+<wire x1="223.52" y1="17.145" x2="280.416" y2="17.145" width="0.1524" layer="48"/>
+<wire x1="267.97" y1="9.525" x2="267.97" y2="5.08" width="0.1524" layer="48"/>
+<wire x1="267.97" y1="5.08" x2="267.97" y2="1.27" width="0.1524" layer="48"/>
+<wire x1="205.74" y1="12.7" x2="205.74" y2="9.144" width="0.4064" layer="48"/>
+<wire x1="205.74" y1="9.144" x2="205.74" y2="1.27" width="0.1524" layer="48"/>
+<wire x1="205.74" y1="1.27" x2="223.2152" y2="1.27" width="0.4064" layer="48"/>
+<wire x1="205.74" y1="1.27" x2="160.02" y2="1.27" width="0.4064" layer="48"/>
+<wire x1="160.02" y1="1.27" x2="160.02" y2="5.08" width="0.4064" layer="48"/>
+<wire x1="280.67" y1="27.94" x2="223.52" y2="27.94" width="0.4064" layer="48"/>
+<wire x1="223.52" y1="27.94" x2="160.02" y2="27.94" width="0.4064" layer="48"/>
+<wire x1="160.02" y1="27.94" x2="160.02" y2="21.336" width="0.4064" layer="48"/>
+<wire x1="160.02" y1="21.336" x2="160.02" y2="12.7" width="0.4064" layer="48"/>
+<wire x1="223.52" y1="21.336" x2="223.52" y2="16.51" width="0.1524" layer="48"/>
+<wire x1="223.52" y1="16.51" x2="160.02" y2="16.51" width="0.1524" layer="48"/>
+<wire x1="160.02" y1="16.51" x2="160.02" y2="21.336" width="0.1524" layer="48"/>
+<wire x1="223.52" y1="27.94" x2="223.52" y2="21.336" width="0.1524" layer="48"/>
+<wire x1="51.435" y1="24.13" x2="1.27" y2="24.13" width="0.1524" layer="48"/>
+<wire x1="1.27" y1="24.13" x2="1.27" y2="20.32" width="0.3048" layer="48"/>
+<wire x1="1.27" y1="20.32" x2="1.27" y2="16.51" width="0.3048" layer="48"/>
+<wire x1="51.435" y1="16.51" x2="51.435" y2="20.32" width="0.3048" layer="48"/>
+<wire x1="1.27" y1="20.32" x2="51.435" y2="20.32" width="0.1524" layer="48"/>
+<wire x1="51.435" y1="20.32" x2="51.435" y2="24.13" width="0.3048" layer="48"/>
+<wire x1="51.435" y1="24.13" x2="51.435" y2="27.94" width="0.3048" layer="48"/>
+<wire x1="51.435" y1="27.94" x2="1.27" y2="27.94" width="0.3048" layer="48"/>
+<wire x1="1.27" y1="27.94" x2="1.27" y2="24.13" width="0.3048" layer="48"/>
+<wire x1="267.97" y1="5.08" x2="223.393" y2="5.08" width="0.1524" layer="48"/>
+<wire x1="223.52" y1="1.27" x2="223.3422" y2="1.397" width="0.1524" layer="48"/>
+<wire x1="223.52" y1="12.7" x2="223.52" y2="17.145" width="0.762" layer="48"/>
+<wire x1="223.52" y1="17.145" x2="223.52" y2="21.336" width="0.762" layer="48"/>
+<wire x1="223.3422" y1="1.397" x2="223.3422" y2="9.271" width="0.4064" layer="48"/>
+<wire x1="223.3422" y1="9.271" x2="223.52" y2="9.271" width="0.4064" layer="48"/>
+<wire x1="223.52" y1="9.271" x2="223.52" y2="12.7" width="0.762" layer="48"/>
+<wire x1="160.02" y1="27.94" x2="160.02" y2="33.909" width="0.4064" layer="48"/>
+<wire x1="160.02" y1="33.909" x2="280.67" y2="33.909" width="0.4064" layer="48"/>
+<wire x1="280.67" y1="33.909" x2="280.67" y2="27.94" width="0.4064" layer="48"/>
+<text x="2.54" y="13.97" size="1.524" layer="48">MATERIAL:</text>
+<text x="224.79" y="10.795" size="5.08" layer="48" ratio="15">&gt;DRAWING_NAME</text>
+<text x="266.065" y="10.795" size="5.08" layer="48" ratio="15">BRD</text>
+<text x="224.79" y="18.415" size="1.524" layer="48">FILE NAME:</text>
+<text x="160.655" y="2.54" size="1.524" layer="48">Checked by:</text>
+<text x="161.036" y="6.35" size="1.524" layer="48">AUTHOR:</text>
+<text x="210.82" y="10.16" size="1.524" layer="48">DATE:</text>
+<text x="239.395" y="2.413" size="1.524" layer="48">&gt;PLOT_DATE_TIME</text>
+<text x="239.395" y="6.223" size="1.524" layer="48">&gt;LAST_DATE_TIME</text>
+<text x="2.54" y="17.78" size="1.524" layer="48">THICKNESS / Cu:</text>
+<text x="2.54" y="10.16" size="1.524" layer="48">SURFACE:</text>
+<text x="2.54" y="6.35" size="1.524" layer="48">SIDE FINISH:</text>
+<text x="2.54" y="2.54" size="1.524" layer="48">DELIVER PCB:</text>
+<text x="269.24" y="6.223" size="1.524" layer="48">SCALE:</text>
+<text x="2.54" y="25.4" size="1.524" layer="48">DIMENSION:</text>
+<text x="224.79" y="6.223" size="1.524" layer="48">CHANGED:</text>
+<text x="224.79" y="2.413" size="1.524" layer="48">PLOT DATE:</text>
+<text x="2.54" y="21.59" size="1.524" layer="48">SCALED TOLERANCE:</text>
+<text x="161.417" y="25.4" size="1.524" layer="48">PRODUKT NAME:</text>
+<text x="161.29" y="10.16" size="1.524" layer="48">DATA FORMAT: Eagle 7.4.0</text>
+<text x="161.29" y="13.97" size="1.524" layer="48">VERSION:</text>
+<text x="225.552" y="25.4" size="1.524" layer="48">For company:</text>
+<text x="163.0426" y="30.9626" size="1.9304" layer="48" ratio="10">JabloPCB s.r.o.</text>
+<text x="163.0426" y="28.5242" size="1.524" layer="48">www.jablopcb.cz</text>
+<text x="3.175" y="187.96" size="1.9304" layer="48" ratio="15">Type page:</text>
+<text x="202.6666" y="28.6512" size="1.524" layer="48">jablopcb@jablopcb.cz</text>
+<text x="243.3066" y="28.6512" size="1.524" layer="48">tel., fax. +420 483 515 515</text>
+<text x="190.5508" y="31.0388" size="1.524" layer="48">U Prehrady 5129/67, 466 01 Jablonec n.N., CR</text>
+<text x="161.417" y="17.78" size="1.524" layer="48">ASSEMBLY VARIANT:</text>
+<text x="189.357" y="17.78" size="1.524" layer="48">&gt;assembly_variant</text>
+</package>
+</packages>
+</library>
+<library name="SDkarta">
+<packages>
+<package name="ATTEND_112J-TXAR-R01_SMALL">
+<hole x="-4.95" y="0" drill="1.2"/>
+<hole x="3.05" y="0" drill="1.2"/>
+<smd name="1" x="2.25" y="10.4" dx="1.6" dy="0.8" layer="1" rot="R90"/>
+<smd name="2" x="1.15" y="10.4" dx="1.6" dy="0.8" layer="1" rot="R90"/>
+<smd name="3" x="0.05" y="10.4" dx="1.6" dy="0.8" layer="1" rot="R90"/>
+<smd name="4" x="-1.05" y="10.4" dx="1.6" dy="0.8" layer="1" rot="R90"/>
+<smd name="5" x="-2.15" y="10.4" dx="1.6" dy="0.8" layer="1" rot="R90"/>
+<smd name="6" x="-3.25" y="10.4" dx="1.6" dy="0.8" layer="1" rot="R90"/>
+<smd name="7" x="-4.35" y="10.4" dx="1.6" dy="0.8" layer="1" rot="R90"/>
+<smd name="8" x="-5.45" y="10.4" dx="1.6" dy="0.8" layer="1" rot="R90"/>
+<smd name="CD" x="-6.5" y="10.4" dx="1.6" dy="0.7" layer="1" rot="R90"/>
+<smd name="GND@2" x="-7.75" y="0.4" dx="2.4" dy="1.4" layer="1" rot="R90"/>
+<smd name="GND@3" x="7.75" y="0.4" dx="2.4" dy="1.4" layer="1" rot="R90"/>
+<smd name="GND@1" x="-7.75" y="10" dx="1.4" dy="1.2" layer="1" rot="R90"/>
+<smd name="GND@4" x="6.85" y="10" dx="1.6" dy="1.8" layer="1" rot="R90"/>
+<wire x1="3.3" y1="-4" x2="3.5" y2="-4" width="0.127" layer="21"/>
+<wire x1="3.5" y1="-4" x2="7.35" y2="-4" width="0.127" layer="21"/>
+<wire x1="7.35" y1="-4" x2="7.35" y2="10.5" width="0.127" layer="21"/>
+<wire x1="7.35" y1="10.5" x2="-7.35" y2="10.5" width="0.127" layer="21"/>
+<wire x1="-7.35" y1="10.5" x2="-7.35" y2="-3.3" width="0.127" layer="21"/>
+<wire x1="-7.35" y1="-3.3" x2="-6.5" y2="-3.3" width="0.127" layer="21"/>
+<wire x1="-6.5" y1="-3.3" x2="2" y2="-3.3" width="0.127" layer="21"/>
+<wire x1="3.3" y1="-4" x2="3" y2="-3.7" width="0.127" layer="21"/>
+<wire x1="3" y1="-3.7" x2="2" y2="-3.3" width="0.127" layer="21" curve="46.397226"/>
+<wire x1="3.5" y1="-4" x2="3.5" y2="-5.2" width="0.127" layer="21" style="shortdash"/>
+<wire x1="3.5" y1="-5.2" x2="2.5" y2="-6.2" width="0.127" layer="21" style="shortdash" curve="-90"/>
+<wire x1="2.5" y1="-6.2" x2="-5.45" y2="-6.2" width="0.127" layer="21"/>
+<wire x1="-6.5" y1="-5.25" x2="-6.5" y2="-3.3" width="0.127" layer="21" style="shortdash"/>
+<wire x1="-5.45" y1="-6.2" x2="-5.55" y2="-6.2" width="0.127" layer="21" style="shortdash"/>
+<wire x1="-5.55" y1="-6.2" x2="-6.5" y2="-5.25" width="0.127" layer="21" style="shortdash" curve="-90"/>
+<polygon width="0.127" layer="41">
+<vertex x="3.05" y="4.5"/>
+<vertex x="3.05" y="6.5"/>
+<vertex x="-5.95" y="6.5"/>
+<vertex x="-5.95" y="4.5"/>
+</polygon>
+</package>
+</packages>
+</library>
+<library name="trezor">
+<packages>
+<package name="LQFP100_NO_CENTER_NO_TDOCU">
+<wire x1="-6.85" y1="6.85" x2="-6.25" y2="6.85" width="0.254" layer="21"/>
+<wire x1="-6.25" y1="6.85" x2="6.6" y2="6.85" width="0.254" layer="21"/>
+<wire x1="6.6" y1="6.85" x2="6.85" y2="6.6" width="0.254" layer="21"/>
+<wire x1="6.85" y1="6.6" x2="6.85" y2="-6.6" width="0.254" layer="21"/>
+<wire x1="6.85" y1="-6.6" x2="6.6" y2="-6.85" width="0.254" layer="21"/>
+<wire x1="6.6" y1="-6.85" x2="-6.6" y2="-6.85" width="0.254" layer="21"/>
+<wire x1="-6.6" y1="-6.85" x2="-6.85" y2="-6.6" width="0.254" layer="21"/>
+<wire x1="-6.85" y1="-6.6" x2="-6.85" y2="6.25" width="0.254" layer="21"/>
+<wire x1="-6.85" y1="6.25" x2="-6.85" y2="6.85" width="0.254" layer="21"/>
+<circle x="-6.1" y="6.1" radius="0.2499" width="0.254" layer="21"/>
+<smd name="1" x="-7.725" y="6" dx="1.35" dy="0.29" layer="1"/>
+<smd name="2" x="-7.725" y="5.5" dx="1.35" dy="0.29" layer="1"/>
+<smd name="3" x="-7.725" y="5" dx="1.35" dy="0.29" layer="1"/>
+<smd name="4" x="-7.725" y="4.5" dx="1.35" dy="0.29" layer="1"/>
+<smd name="5" x="-7.725" y="4" dx="1.35" dy="0.29" layer="1"/>
+<smd name="6" x="-7.725" y="3.5" dx="1.35" dy="0.29" layer="1"/>
+<smd name="7" x="-7.725" y="3" dx="1.35" dy="0.29" layer="1"/>
+<smd name="8" x="-7.725" y="2.5" dx="1.35" dy="0.29" layer="1"/>
+<smd name="9" x="-7.725" y="2" dx="1.35" dy="0.29" layer="1"/>
+<smd name="10" x="-7.725" y="1.5" dx="1.35" dy="0.29" layer="1"/>
+<smd name="11" x="-7.725" y="1" dx="1.35" dy="0.29" layer="1"/>
+<smd name="12" x="-7.725" y="0.5" dx="1.35" dy="0.29" layer="1"/>
+<smd name="13" x="-7.725" y="0" dx="1.35" dy="0.29" layer="1"/>
+<smd name="14" x="-7.725" y="-0.5" dx="1.35" dy="0.29" layer="1"/>
+<smd name="15" x="-7.725" y="-1" dx="1.35" dy="0.29" layer="1"/>
+<smd name="16" x="-7.725" y="-1.5" dx="1.35" dy="0.29" layer="1"/>
+<smd name="17" x="-7.725" y="-2" dx="1.35" dy="0.29" layer="1"/>
+<smd name="18" x="-7.725" y="-2.5" dx="1.35" dy="0.29" layer="1"/>
+<smd name="19" x="-7.725" y="-3" dx="1.35" dy="0.29" layer="1"/>
+<smd name="20" x="-7.725" y="-3.5" dx="1.35" dy="0.29" layer="1"/>
+<smd name="21" x="-7.725" y="-4" dx="1.35" dy="0.29" layer="1"/>
+<smd name="22" x="-7.725" y="-4.5" dx="1.35" dy="0.29" layer="1"/>
+<smd name="23" x="-7.725" y="-5" dx="1.35" dy="0.29" layer="1"/>
+<smd name="24" x="-7.725" y="-5.5" dx="1.35" dy="0.29" layer="1"/>
+<smd name="25" x="-7.725" y="-6" dx="1.35" dy="0.29" layer="1"/>
+<smd name="26" x="-6" y="-7.725" dx="1.35" dy="0.29" layer="1" rot="R90"/>
+<smd name="27" x="-5.5" y="-7.725" dx="1.35" dy="0.29" layer="1" rot="R90"/>
+<smd name="28" x="-5" y="-7.725" dx="1.35" dy="0.29" layer="1" rot="R90"/>
+<smd name="29" x="-4.5" y="-7.725" dx="1.35" dy="0.29" layer="1" rot="R90"/>
+<smd name="30" x="-4" y="-7.725" dx="1.35" dy="0.29" layer="1" rot="R90"/>
+<smd name="31" x="-3.5" y="-7.725" dx="1.35" dy="0.29" layer="1" rot="R90"/>
+<smd name="32" x="-3" y="-7.725" dx="1.35" dy="0.29" layer="1" rot="R90"/>
+<smd name="33" x="-2.5" y="-7.725" dx="1.35" dy="0.29" layer="1" rot="R90"/>
+<smd name="34" x="-2" y="-7.725" dx="1.35" dy="0.29" layer="1" rot="R90"/>
+<smd name="35" x="-1.5" y="-7.725" dx="1.35" dy="0.29" layer="1" rot="R90"/>
+<smd name="36" x="-1" y="-7.725" dx="1.35" dy="0.29" layer="1" rot="R90"/>
+<smd name="37" x="-0.5" y="-7.725" dx="1.35" dy="0.29" layer="1" rot="R90"/>
+<smd name="38" x="0" y="-7.725" dx="1.35" dy="0.29" layer="1" rot="R90"/>
+<smd name="39" x="0.5" y="-7.725" dx="1.35" dy="0.29" layer="1" rot="R90"/>
+<smd name="40" x="1" y="-7.725" dx="1.35" dy="0.29" layer="1" rot="R90"/>
+<smd name="41" x="1.5" y="-7.725" dx="1.35" dy="0.29" layer="1" rot="R90"/>
+<smd name="42" x="2" y="-7.725" dx="1.35" dy="0.29" layer="1" rot="R90"/>
+<smd name="43" x="2.5" y="-7.725" dx="1.35" dy="0.29" layer="1" rot="R90"/>
+<smd name="44" x="3" y="-7.725" dx="1.35" dy="0.29" layer="1" rot="R90"/>
+<smd name="45" x="3.5" y="-7.725" dx="1.35" dy="0.29" layer="1" rot="R90"/>
+<smd name="46" x="4" y="-7.725" dx="1.35" dy="0.29" layer="1" rot="R90"/>
+<smd name="47" x="4.5" y="-7.725" dx="1.35" dy="0.29" layer="1" rot="R90"/>
+<smd name="48" x="5" y="-7.725" dx="1.35" dy="0.29" layer="1" rot="R90"/>
+<smd name="49" x="5.5" y="-7.725" dx="1.35" dy="0.29" layer="1" rot="R90"/>
+<smd name="50" x="6" y="-7.725" dx="1.35" dy="0.29" layer="1" rot="R90"/>
+<smd name="51" x="7.725" y="-6" dx="1.35" dy="0.29" layer="1" rot="R180"/>
+<smd name="52" x="7.725" y="-5.5" dx="1.35" dy="0.29" layer="1" rot="R180"/>
+<smd name="53" x="7.725" y="-5" dx="1.35" dy="0.29" layer="1" rot="R180"/>
+<smd name="54" x="7.725" y="-4.5" dx="1.35" dy="0.29" layer="1" rot="R180"/>
+<smd name="55" x="7.725" y="-4" dx="1.35" dy="0.29" layer="1" rot="R180"/>
+<smd name="56" x="7.725" y="-3.5" dx="1.35" dy="0.29" layer="1" rot="R180"/>
+<smd name="57" x="7.725" y="-3" dx="1.35" dy="0.29" layer="1" rot="R180"/>
+<smd name="58" x="7.725" y="-2.5" dx="1.35" dy="0.29" layer="1" rot="R180"/>
+<smd name="59" x="7.725" y="-2" dx="1.35" dy="0.29" layer="1" rot="R180"/>
+<smd name="60" x="7.725" y="-1.5" dx="1.35" dy="0.29" layer="1" rot="R180"/>
+<smd name="61" x="7.725" y="-1" dx="1.35" dy="0.29" layer="1" rot="R180"/>
+<smd name="62" x="7.725" y="-0.5" dx="1.35" dy="0.29" layer="1" rot="R180"/>
+<smd name="63" x="7.725" y="0" dx="1.35" dy="0.29" layer="1" rot="R180"/>
+<smd name="64" x="7.725" y="0.5" dx="1.35" dy="0.29" layer="1" rot="R180"/>
+<smd name="65" x="7.725" y="1" dx="1.35" dy="0.29" layer="1" rot="R180"/>
+<smd name="66" x="7.725" y="1.5" dx="1.35" dy="0.29" layer="1" rot="R180"/>
+<smd name="67" x="7.725" y="2" dx="1.35" dy="0.29" layer="1" rot="R180"/>
+<smd name="68" x="7.725" y="2.5" dx="1.35" dy="0.29" layer="1" rot="R180"/>
+<smd name="69" x="7.725" y="3" dx="1.35" dy="0.29" layer="1" rot="R180"/>
+<smd name="70" x="7.725" y="3.5" dx="1.35" dy="0.29" layer="1" rot="R180"/>
+<smd name="71" x="7.725" y="4" dx="1.35" dy="0.29" layer="1" rot="R180"/>
+<smd name="72" x="7.725" y="4.5" dx="1.35" dy="0.29" layer="1" rot="R180"/>
+<smd name="73" x="7.725" y="5" dx="1.35" dy="0.29" layer="1" rot="R180"/>
+<smd name="74" x="7.725" y="5.5" dx="1.35" dy="0.29" layer="1" rot="R180"/>
+<smd name="75" x="7.725" y="6" dx="1.35" dy="0.29" layer="1" rot="R180"/>
+<smd name="76" x="6" y="7.725" dx="1.35" dy="0.29" layer="1" rot="R270"/>
+<smd name="77" x="5.5" y="7.725" dx="1.35" dy="0.29" layer="1" rot="R270"/>
+<smd name="78" x="5" y="7.725" dx="1.35" dy="0.29" layer="1" rot="R270"/>
+<smd name="79" x="4.5" y="7.725" dx="1.35" dy="0.29" layer="1" rot="R270"/>
+<smd name="80" x="4" y="7.725" dx="1.35" dy="0.29" layer="1" rot="R270"/>
+<smd name="81" x="3.5" y="7.725" dx="1.35" dy="0.29" layer="1" rot="R270"/>
+<smd name="82" x="3" y="7.725" dx="1.35" dy="0.29" layer="1" rot="R270"/>
+<smd name="83" x="2.5" y="7.725" dx="1.35" dy="0.29" layer="1" rot="R270"/>
+<smd name="84" x="2" y="7.725" dx="1.35" dy="0.29" layer="1" rot="R270"/>
+<smd name="85" x="1.5" y="7.725" dx="1.35" dy="0.29" layer="1" rot="R270"/>
+<smd name="86" x="1" y="7.725" dx="1.35" dy="0.29" layer="1" rot="R270"/>
+<smd name="87" x="0.5" y="7.725" dx="1.35" dy="0.29" layer="1" rot="R270"/>
+<smd name="88" x="0" y="7.725" dx="1.35" dy="0.29" layer="1" rot="R270"/>
+<smd name="89" x="-0.5" y="7.725" dx="1.35" dy="0.29" layer="1" rot="R270"/>
+<smd name="90" x="-1" y="7.725" dx="1.35" dy="0.29" layer="1" rot="R270"/>
+<smd name="91" x="-1.5" y="7.725" dx="1.35" dy="0.29" layer="1" rot="R270"/>
+<smd name="92" x="-2" y="7.725" dx="1.35" dy="0.29" layer="1" rot="R270"/>
+<smd name="93" x="-2.5" y="7.725" dx="1.35" dy="0.29" layer="1" rot="R270"/>
+<smd name="94" x="-3" y="7.725" dx="1.35" dy="0.29" layer="1" rot="R270"/>
+<smd name="95" x="-3.5" y="7.725" dx="1.35" dy="0.29" layer="1" rot="R270"/>
+<smd name="96" x="-4" y="7.725" dx="1.35" dy="0.29" layer="1" rot="R270"/>
+<smd name="97" x="-4.5" y="7.725" dx="1.35" dy="0.29" layer="1" rot="R270"/>
+<smd name="98" x="-5" y="7.725" dx="1.35" dy="0.29" layer="1" rot="R270"/>
+<smd name="99" x="-5.5" y="7.725" dx="1.35" dy="0.29" layer="1" rot="R270"/>
+<smd name="100" x="-6" y="7.725" dx="1.35" dy="0.29" layer="1" rot="R270"/>
+<text x="-3.2" y="0.5001" size="1.27" layer="25">&gt;NAME</text>
+<text x="-3.1501" y="-1.6999" size="1.27" layer="27">&gt;VALUE</text>
+<wire x1="-6.85" y1="6.25" x2="-6.25" y2="6.85" width="0.254" layer="21"/>
+<wire x1="-6.65" y1="6.8" x2="-6.65" y2="6.5" width="0.254" layer="21"/>
+</package>
+<package name="X6,0X3,5">
+<wire x1="-2.6" y1="1.446" x2="-2.346" y2="1.7" width="0.1" layer="21"/>
+<wire x1="-2.346" y1="1.7" x2="2.346" y2="1.7" width="0.1" layer="21"/>
+<wire x1="2.346" y1="1.7" x2="2.6" y2="1.446" width="0.1" layer="21"/>
+<wire x1="2.6" y1="1.446" x2="2.6" y2="-1.446" width="0.1" layer="21"/>
+<wire x1="2.6" y1="-1.446" x2="2.346" y2="-1.7" width="0.1" layer="21"/>
+<wire x1="2.346" y1="-1.7" x2="-2.346" y2="-1.7" width="0.1" layer="21"/>
+<wire x1="-2.346" y1="-1.7" x2="-2.6" y2="-1.446" width="0.1" layer="21"/>
+<wire x1="-2.6" y1="-1.446" x2="-2.6" y2="1.446" width="0.1" layer="21"/>
+<wire x1="-1.27" y1="-1.27" x2="-0.635" y2="-1.27" width="0.1" layer="21"/>
+<wire x1="-0.635" y1="-1.27" x2="-0.635" y2="0" width="0.1" layer="21"/>
+<wire x1="-0.635" y1="0" x2="-0.381" y2="0" width="0.1" layer="21"/>
+<wire x1="-0.381" y1="0" x2="-0.381" y2="0.635" width="0.1" layer="21"/>
+<wire x1="-0.381" y1="0" x2="-0.381" y2="-0.635" width="0.1" layer="21"/>
+<wire x1="-0.127" y1="0.635" x2="0.127" y2="0.635" width="0.1" layer="21"/>
+<wire x1="0.127" y1="0.635" x2="0.127" y2="-0.635" width="0.1" layer="21"/>
+<wire x1="0.127" y1="-0.635" x2="-0.127" y2="-0.635" width="0.1" layer="21"/>
+<wire x1="-0.127" y1="-0.635" x2="-0.127" y2="0.635" width="0.1" layer="21"/>
+<wire x1="0.381" y1="0.635" x2="0.381" y2="0" width="0.1" layer="21"/>
+<wire x1="0.381" y1="0" x2="0.381" y2="-0.635" width="0.1" layer="21"/>
+<wire x1="0.381" y1="0" x2="0.635" y2="0" width="0.1" layer="21"/>
+<wire x1="0.635" y1="0" x2="0.635" y2="1.27" width="0.1" layer="21"/>
+<wire x1="0.635" y1="1.27" x2="1.27" y2="1.27" width="0.1" layer="21"/>
+<smd name="1" x="-2.275" y="-1.1" dx="1.65" dy="1.3" layer="1"/>
+<smd name="2" x="2.275" y="-1.1" dx="1.65" dy="1.3" layer="1"/>
+<smd name="3" x="2.275" y="1.1" dx="1.65" dy="1.3" layer="1"/>
+<smd name="4" x="-2.275" y="1.1" dx="1.65" dy="1.3" layer="1"/>
+<text x="-2.54" y="1.905" size="1.016" layer="27" ratio="15">&gt;VALUE</text>
+<text x="-2.54" y="-3.175" size="1.016" layer="25" ratio="15">&gt;NAME</text>
+</package>
+<package name="L_2.5X2.0">
+<smd name="1" x="-1.25" y="0" dx="2" dy="0.9" layer="1" rot="R90"/>
+<smd name="2" x="1.25" y="0" dx="2" dy="0.9" layer="1" rot="R90"/>
+<wire x1="-0.6" y1="-1" x2="0.6" y2="-1" width="0.127" layer="21"/>
+<wire x1="0.6" y1="-1" x2="1.25" y2="-0.6" width="0.127" layer="21"/>
+<wire x1="1.25" y1="-0.6" x2="1.25" y2="0.6" width="0.127" layer="21"/>
+<wire x1="1.25" y1="0.6" x2="0.6" y2="1" width="0.127" layer="21"/>
+<wire x1="0.6" y1="1" x2="-0.6" y2="1" width="0.127" layer="21"/>
+<wire x1="-0.6" y1="1" x2="-1.25" y2="0.6" width="0.127" layer="21"/>
+<wire x1="-1.25" y1="0.6" x2="-1.25" y2="-0.6" width="0.127" layer="21"/>
+<wire x1="-1.25" y1="-0.6" x2="-0.6" y2="-1" width="0.127" layer="21"/>
+<circle x="0" y="0.5" radius="0.14141875" width="0.4064" layer="35"/>
+<circle x="0" y="-0.5" radius="0.14141875" width="0.4064" layer="35"/>
+<text x="-2.45" y="1.1" size="1.27" layer="25">&gt;NAME</text>
+<text x="-2.4" y="-2.6" size="1.27" layer="27">&gt;VALUE</text>
+</package>
+<package name="SOT89-5">
+<smd name="1" x="-1.5" y="-1.85" dx="1.5" dy="0.7" layer="1" rot="R90"/>
+<smd name="3" x="1.5" y="-1.85" dx="1.5" dy="0.7" layer="1" rot="R90"/>
+<smd name="4" x="1.5" y="1.85" dx="1.5" dy="0.7" layer="1" rot="R90"/>
+<smd name="5" x="-1.5" y="1.85" dx="1.5" dy="0.7" layer="1" rot="R90"/>
+<smd name="2" x="0" y="0" dx="5.2" dy="1" layer="1" rot="R90"/>
+<polygon width="0.1778" layer="1">
+<vertex x="-0.45" y="1.15"/>
+<vertex x="-1.1" y="0.5"/>
+<vertex x="-1.1" y="-0.5"/>
+<vertex x="-0.45" y="-1.15"/>
+<vertex x="0.45" y="-1.15"/>
+<vertex x="1.1" y="-0.5"/>
+<vertex x="1.1" y="0.5"/>
+<vertex x="0.45" y="1.15"/>
+</polygon>
+<polygon width="0.127" layer="29">
+<vertex x="-0.55" y="1.2"/>
+<vertex x="-1.2" y="0.55"/>
+<vertex x="-1.2" y="-0.55"/>
+<vertex x="-0.55" y="-1.2"/>
+<vertex x="0.55" y="-1.2"/>
+<vertex x="1.2" y="-0.55"/>
+<vertex x="1.2" y="0.55"/>
+<vertex x="0.55" y="1.2"/>
+</polygon>
+<wire x1="-2.3" y1="-1.3" x2="2.3" y2="-1.3" width="0.127" layer="21"/>
+<wire x1="2.3" y1="-1.3" x2="2.3" y2="1.3" width="0.127" layer="21"/>
+<wire x1="2.3" y1="1.3" x2="-2.3" y2="1.3" width="0.127" layer="21"/>
+<wire x1="-2.3" y1="1.3" x2="-2.3" y2="-1.3" width="0.127" layer="21"/>
+<text x="-2.3" y="2.85" size="1.27" layer="25">&gt;NAME</text>
+<text x="-2.3" y="2.85" size="1.27" layer="27">&gt;VALUE</text>
+<rectangle x1="-1.75" y1="1.35" x2="-1.25" y2="2.35" layer="21"/>
+<rectangle x1="1.25" y1="1.35" x2="1.75" y2="2.35" layer="21"/>
+<rectangle x1="1.25" y1="-2.35" x2="1.75" y2="-1.35" layer="21"/>
+<rectangle x1="-0.25" y1="-2.35" x2="0.25" y2="-1.35" layer="21"/>
+<rectangle x1="-1.75" y1="-2.35" x2="-1.25" y2="-1.35" layer="21"/>
+<polygon width="0.127" layer="21">
+<vertex x="-0.35" y="1.3"/>
+<vertex x="-0.35" y="1.6" curve="-90"/>
+<vertex x="-0.2" y="1.75"/>
+<vertex x="0.2" y="1.75" curve="-90"/>
+<vertex x="0.35" y="1.6"/>
+<vertex x="0.35" y="1.3"/>
+</polygon>
+<rectangle x1="-0.2" y1="1.8" x2="0.2" y2="2.35" layer="21"/>
+</package>
+<package name="DF37NB-24DS-0.4V">
+<wire x1="-3.65" y1="-1.25" x2="3.65" y2="-1.25" width="0.127" layer="21"/>
+<wire x1="3.65" y1="-1.25" x2="3.65" y2="1.25" width="0.127" layer="21"/>
+<wire x1="3.65" y1="1.25" x2="-3.65" y2="1.25" width="0.127" layer="21"/>
+<wire x1="-3.65" y1="1.25" x2="-3.65" y2="-1.25" width="0.127" layer="21"/>
+<wire x1="-3.05" y1="0.9" x2="-3.3" y2="0.65" width="0.1" layer="21"/>
+<wire x1="-3.3" y1="0.65" x2="-3.3" y2="-0.7" width="0.1" layer="21"/>
+<wire x1="-3.3" y1="-0.7" x2="-3.1" y2="-0.9" width="0.1" layer="21"/>
+<wire x1="-3.1" y1="-0.9" x2="3.1" y2="-0.9" width="0.1" layer="21"/>
+<wire x1="3.1" y1="-0.9" x2="3.3" y2="-0.7" width="0.1" layer="21"/>
+<wire x1="3.3" y1="-0.7" x2="3.3" y2="0.65" width="0.1" layer="21"/>
+<wire x1="3.3" y1="0.65" x2="3.05" y2="0.9" width="0.1" layer="21"/>
+<wire x1="3.05" y1="0.9" x2="-3.05" y2="0.9" width="0.1" layer="21"/>
+<smd name="19" x="-0.2" y="1.35" dx="0.65" dy="0.25" layer="1" rot="R90" stop="no" thermals="no" cream="no"/>
+<smd name="6" x="-0.2" y="-1.35" dx="0.65" dy="0.25" layer="1" rot="R90" stop="no" thermals="no" cream="no"/>
+<smd name="20" x="-0.6" y="1.35" dx="0.65" dy="0.25" layer="1" rot="R90" stop="no" thermals="no" cream="no"/>
+<smd name="21" x="-1" y="1.35" dx="0.65" dy="0.25" layer="1" rot="R90" stop="no" thermals="no" cream="no"/>
+<smd name="18" x="0.2" y="1.35" dx="0.65" dy="0.25" layer="1" rot="R90" stop="no" thermals="no" cream="no"/>
+<smd name="17" x="0.6" y="1.35" dx="0.65" dy="0.25" layer="1" rot="R90" stop="no" thermals="no" cream="no"/>
+<smd name="16" x="1" y="1.35" dx="0.65" dy="0.25" layer="1" rot="R90" stop="no" thermals="no" cream="no"/>
+<smd name="15" x="1.4" y="1.35" dx="0.65" dy="0.25" layer="1" rot="R90" stop="no" thermals="no" cream="no"/>
+<smd name="22" x="-1.4" y="1.35" dx="0.65" dy="0.25" layer="1" rot="R90" stop="no" thermals="no" cream="no"/>
+<smd name="23" x="-1.8" y="1.35" dx="0.65" dy="0.25" layer="1" rot="R90" stop="no" thermals="no" cream="no"/>
+<smd name="24" x="-2.2" y="1.35" dx="0.65" dy="0.25" layer="1" rot="R90" stop="no" thermals="no" cream="no"/>
+<smd name="14" x="1.8" y="1.35" dx="0.65" dy="0.25" layer="1" rot="R90" stop="no" thermals="no" cream="no"/>
+<smd name="13" x="2.2" y="1.35" dx="0.65" dy="0.25" layer="1" rot="R90" stop="no" thermals="no" cream="no"/>
+<smd name="7" x="0.2" y="-1.35" dx="0.65" dy="0.25" layer="1" rot="R90" stop="no" thermals="no" cream="no"/>
+<smd name="8" x="0.6" y="-1.35" dx="0.65" dy="0.25" layer="1" rot="R90" stop="no" thermals="no" cream="no"/>
+<smd name="9" x="1" y="-1.35" dx="0.65" dy="0.25" layer="1" rot="R90" stop="no" thermals="no" cream="no"/>
+<smd name="10" x="1.4" y="-1.35" dx="0.65" dy="0.25" layer="1" rot="R90" stop="no" thermals="no" cream="no"/>
+<smd name="11" x="1.8" y="-1.35" dx="0.65" dy="0.25" layer="1" rot="R90" stop="no" thermals="no" cream="no"/>
+<smd name="12" x="2.2" y="-1.35" dx="0.65" dy="0.25" layer="1" rot="R90" stop="no" thermals="no" cream="no"/>
+<smd name="5" x="-0.6" y="-1.35" dx="0.65" dy="0.25" layer="1" rot="R90" stop="no" thermals="no" cream="no"/>
+<smd name="4" x="-1" y="-1.35" dx="0.65" dy="0.25" layer="1" rot="R90" stop="no" thermals="no" cream="no"/>
+<smd name="3" x="-1.4" y="-1.35" dx="0.65" dy="0.25" layer="1" rot="R90" stop="no" thermals="no" cream="no"/>
+<smd name="2" x="-1.8" y="-1.35" dx="0.65" dy="0.25" layer="1" rot="R90" stop="no" thermals="no" cream="no"/>
+<smd name="1" x="-2.2" y="-1.35" dx="0.65" dy="0.25" layer="1" rot="R90" stop="no" thermals="no" cream="no"/>
+<smd name="25" x="3.45" y="0" dx="1.1" dy="0.4" layer="1" rot="R90" cream="no"/>
+<smd name="26" x="-3.45" y="0" dx="1.1" dy="0.4" layer="1" rot="R90" cream="no"/>
+<rectangle x1="-2.3" y1="1.05" x2="-2.1" y2="1.65" layer="31"/>
+<rectangle x1="-1.9" y1="1.05" x2="-1.7" y2="1.65" layer="31"/>
+<rectangle x1="-1.5" y1="1.05" x2="-1.3" y2="1.65" layer="31"/>
+<rectangle x1="-1.1" y1="1.05" x2="-0.9" y2="1.65" layer="31"/>
+<rectangle x1="-0.7" y1="1.05" x2="-0.5" y2="1.65" layer="31"/>
+<rectangle x1="-0.3" y1="1.05" x2="-0.1" y2="1.65" layer="31"/>
+<text x="-2.375" y="-0.775" size="0.4064" layer="21">1</text>
+<text x="1.9" y="-0.775" size="0.4064" layer="21">12</text>
+<text x="1.9" y="0.35" size="0.4064" layer="21">13</text>
+<text x="-2.5" y="0.35" size="0.4064" layer="21">24</text>
+<rectangle x1="0.1" y1="1.05" x2="0.3" y2="1.65" layer="31"/>
+<rectangle x1="0.5" y1="1.05" x2="0.7" y2="1.65" layer="31"/>
+<rectangle x1="0.9" y1="1.05" x2="1.1" y2="1.65" layer="31"/>
+<rectangle x1="1.3" y1="1.05" x2="1.5" y2="1.65" layer="31"/>
+<rectangle x1="1.7" y1="1.05" x2="1.9" y2="1.65" layer="31"/>
+<rectangle x1="2.1" y1="1.05" x2="2.3" y2="1.65" layer="31"/>
+<rectangle x1="-2.3" y1="-1.65" x2="-2.1" y2="-1.05" layer="31"/>
+<rectangle x1="-1.9" y1="-1.65" x2="-1.7" y2="-1.05" layer="31"/>
+<rectangle x1="-1.5" y1="-1.65" x2="-1.3" y2="-1.05" layer="31"/>
+<rectangle x1="-1.1" y1="-1.65" x2="-0.9" y2="-1.05" layer="31"/>
+<rectangle x1="-0.7" y1="-1.65" x2="-0.5" y2="-1.05" layer="31"/>
+<rectangle x1="-0.3" y1="-1.65" x2="-0.1" y2="-1.05" layer="31"/>
+<rectangle x1="0.1" y1="-1.65" x2="0.3" y2="-1.05" layer="31"/>
+<rectangle x1="0.5" y1="-1.65" x2="0.7" y2="-1.05" layer="31"/>
+<rectangle x1="0.9" y1="-1.65" x2="1.1" y2="-1.05" layer="31"/>
+<rectangle x1="1.3" y1="-1.65" x2="1.5" y2="-1.05" layer="31"/>
+<rectangle x1="1.7" y1="-1.65" x2="1.9" y2="-1.05" layer="31"/>
+<rectangle x1="2.1" y1="-1.65" x2="2.3" y2="-1.05" layer="31"/>
+<rectangle x1="-3.6" y1="-0.5" x2="-3.3" y2="0.5" layer="31"/>
+<rectangle x1="3.3" y1="-0.5" x2="3.6" y2="0.5" layer="31"/>
+<rectangle x1="-2.375" y1="0.975" x2="2.375" y2="1.725" layer="29"/>
+<rectangle x1="-2.375" y1="-1.725" x2="2.375" y2="-0.975" layer="29"/>
+<text x="-3.683" y="1.905" size="1.016" layer="25">&gt;NAME</text>
+<text x="-3.683" y="1.905" size="1.016" layer="27">&gt;VALUE</text>
+</package>
+<package name="DF37NB-10DS-0.4V">
+<wire x1="-2.25" y1="-1.25" x2="2.25" y2="-1.25" width="0.127" layer="21"/>
+<wire x1="2.25" y1="-1.25" x2="2.25" y2="1.25" width="0.127" layer="21"/>
+<wire x1="2.25" y1="1.25" x2="-2.25" y2="1.25" width="0.127" layer="21"/>
+<wire x1="-2.25" y1="1.25" x2="-2.25" y2="-1.25" width="0.127" layer="21"/>
+<wire x1="-1.6" y1="0.9" x2="-1.85" y2="0.65" width="0.1" layer="21"/>
+<wire x1="-1.85" y1="0.65" x2="-1.85" y2="-0.7" width="0.1" layer="21"/>
+<wire x1="-1.85" y1="-0.7" x2="-1.65" y2="-0.9" width="0.1" layer="21"/>
+<wire x1="-1.65" y1="-0.9" x2="1.65" y2="-0.9" width="0.1" layer="21"/>
+<wire x1="1.65" y1="-0.9" x2="1.85" y2="-0.7" width="0.1" layer="21"/>
+<wire x1="1.85" y1="-0.7" x2="1.85" y2="0.65" width="0.1" layer="21"/>
+<wire x1="1.85" y1="0.65" x2="1.6" y2="0.9" width="0.1" layer="21"/>
+<wire x1="1.6" y1="0.9" x2="-1.6" y2="0.9" width="0.1" layer="21"/>
+<smd name="5" x="0.8" y="1.35" dx="0.65" dy="0.25" layer="1" rot="R270" stop="no" cream="no"/>
+<smd name="4" x="0.4" y="1.35" dx="0.65" dy="0.25" layer="1" rot="R270" stop="no" cream="no"/>
+<smd name="3" x="0" y="1.35" dx="0.65" dy="0.25" layer="1" rot="R270" stop="no" thermals="no" cream="no"/>
+<smd name="2" x="-0.4" y="1.35" dx="0.65" dy="0.25" layer="1" rot="R270" stop="no" cream="no"/>
+<smd name="1" x="-0.8" y="1.35" dx="0.65" dy="0.25" layer="1" rot="R270" stop="no" cream="no"/>
+<smd name="6" x="0.8" y="-1.35" dx="0.65" dy="0.25" layer="1" rot="R90" stop="no" cream="no"/>
+<smd name="7" x="0.4" y="-1.35" dx="0.65" dy="0.25" layer="1" rot="R90" stop="no" cream="no"/>
+<smd name="8" x="0" y="-1.35" dx="0.65" dy="0.25" layer="1" rot="R90" stop="no" thermals="no" cream="no"/>
+<smd name="9" x="-0.4" y="-1.35" dx="0.65" dy="0.25" layer="1" rot="R90" stop="no" cream="no"/>
+<smd name="10" x="-0.8" y="-1.35" dx="0.65" dy="0.25" layer="1" rot="R90" stop="no" cream="no"/>
+<smd name="11" x="2.05" y="0" dx="1.1" dy="0.4" layer="1" rot="R90" cream="no"/>
+<smd name="12" x="-2.05" y="0" dx="1.1" dy="0.4" layer="1" rot="R90" cream="no"/>
+<text x="0.65" y="-0.65" size="0.4064" layer="21">6</text>
+<text x="-1.15" y="-0.65" size="0.4064" layer="21">10</text>
+<rectangle x1="-0.9" y1="-1.65" x2="-0.7" y2="-1.05" layer="31"/>
+<rectangle x1="-0.5" y1="-1.65" x2="-0.3" y2="-1.05" layer="31"/>
+<rectangle x1="-0.1" y1="-1.65" x2="0.1" y2="-1.05" layer="31"/>
+<rectangle x1="0.3" y1="-1.65" x2="0.5" y2="-1.05" layer="31"/>
+<rectangle x1="0.7" y1="-1.65" x2="0.9" y2="-1.05" layer="31"/>
+<rectangle x1="0.7" y1="1.05" x2="0.9" y2="1.65" layer="31" rot="R180"/>
+<rectangle x1="0.3" y1="1.05" x2="0.5" y2="1.65" layer="31" rot="R180"/>
+<rectangle x1="-0.1" y1="1.05" x2="0.1" y2="1.65" layer="31" rot="R180"/>
+<rectangle x1="-0.5" y1="1.05" x2="-0.3" y2="1.65" layer="31" rot="R180"/>
+<rectangle x1="-0.9" y1="1.05" x2="-0.7" y2="1.65" layer="31" rot="R180"/>
+<rectangle x1="-2.2" y1="-0.5" x2="-1.9" y2="0.5" layer="31"/>
+<rectangle x1="1.9" y1="-0.5" x2="2.2" y2="0.5" layer="31"/>
+<text x="-2.667" y="1.905" size="1.016" layer="25">&gt;NAME</text>
+<text x="-2.667" y="1.905" size="1.016" layer="27">&gt;VALUE</text>
+<text x="0.65" y="0.3" size="0.4064" layer="21">5</text>
+<text x="-0.95" y="0.3" size="0.4064" layer="21">1</text>
+<rectangle x1="-1" y1="0.95" x2="1" y2="1.75" layer="29"/>
+<rectangle x1="-1" y1="-1.75" x2="1" y2="-0.95" layer="29"/>
+</package>
+<package name="LAYER_STACK_4_LAYERS">
+<wire x1="-15.24" y1="-1.905" x2="-15.24" y2="-0.635" width="0.127" layer="48"/>
+<wire x1="-15.24" y1="-0.635" x2="-15.24" y2="0.635" width="0.127" layer="48"/>
+<wire x1="-15.24" y1="0.635" x2="-15.24" y2="1.905" width="0.127" layer="48"/>
+<wire x1="15.24" y1="1.905" x2="15.24" y2="0.635" width="0.127" layer="48"/>
+<wire x1="15.24" y1="0.635" x2="15.24" y2="-0.635" width="0.127" layer="48"/>
+<wire x1="15.24" y1="-0.635" x2="15.24" y2="-1.905" width="0.127" layer="48"/>
+<wire x1="15.24" y1="-1.905" x2="13.97" y2="-1.905" width="0.127" layer="48"/>
+<wire x1="13.97" y1="-1.905" x2="12.7" y2="-1.905" width="0.127" layer="48"/>
+<wire x1="12.7" y1="-1.905" x2="11.43" y2="-1.905" width="0.127" layer="48"/>
+<wire x1="11.43" y1="-1.905" x2="-15.24" y2="-1.905" width="0.127" layer="48"/>
+<wire x1="-19.05" y1="1.905" x2="-19.05" y2="4.445" width="0.127" layer="48"/>
+<wire x1="-19.05" y1="4.445" x2="-15.24" y2="4.445" width="0.127" layer="48"/>
+<wire x1="15.24" y1="4.445" x2="19.05" y2="4.445" width="0.127" layer="48"/>
+<wire x1="19.05" y1="4.445" x2="19.05" y2="1.905" width="0.127" layer="48"/>
+<wire x1="19.05" y1="1.905" x2="15.24" y2="1.905" width="0.127" layer="48"/>
+<wire x1="15.24" y1="1.905" x2="-12.7" y2="1.905" width="0.127" layer="48"/>
+<wire x1="-12.7" y1="1.905" x2="-13.97" y2="1.905" width="0.127" layer="48"/>
+<wire x1="-13.97" y1="1.905" x2="-15.24" y2="1.905" width="0.127" layer="48"/>
+<wire x1="-15.24" y1="1.905" x2="-19.05" y2="1.905" width="0.127" layer="48"/>
+<wire x1="-15.24" y1="-1.905" x2="-19.05" y2="-1.905" width="0.127" layer="48"/>
+<wire x1="-19.05" y1="-1.905" x2="-19.05" y2="-4.445" width="0.127" layer="48"/>
+<wire x1="-19.05" y1="-4.445" x2="-15.24" y2="-4.445" width="0.127" layer="48"/>
+<wire x1="15.24" y1="-4.445" x2="19.05" y2="-4.445" width="0.127" layer="48"/>
+<wire x1="19.05" y1="-4.445" x2="19.05" y2="-1.905" width="0.127" layer="48"/>
+<wire x1="19.05" y1="-1.905" x2="15.24" y2="-1.905" width="0.127" layer="48"/>
+<wire x1="-15.24" y1="8.255" x2="-15.24" y2="6.985" width="0.127" layer="48"/>
+<wire x1="-15.24" y1="6.985" x2="-15.24" y2="5.715" width="0.127" layer="48"/>
+<wire x1="-15.24" y1="5.715" x2="-15.24" y2="4.445" width="0.127" layer="48"/>
+<wire x1="-15.24" y1="4.445" x2="-13.97" y2="4.445" width="0.127" layer="48"/>
+<wire x1="-13.97" y1="4.445" x2="-12.7" y2="4.445" width="0.127" layer="48"/>
+<wire x1="-12.7" y1="4.445" x2="-11.43" y2="4.445" width="0.127" layer="48"/>
+<wire x1="-11.43" y1="4.445" x2="-10.16" y2="4.445" width="0.127" layer="48"/>
+<wire x1="-10.16" y1="4.445" x2="-8.89" y2="4.445" width="0.127" layer="48"/>
+<wire x1="-8.89" y1="4.445" x2="-7.62" y2="4.445" width="0.127" layer="48"/>
+<wire x1="-7.62" y1="4.445" x2="-6.35" y2="4.445" width="0.127" layer="48"/>
+<wire x1="-6.35" y1="4.445" x2="-5.08" y2="4.445" width="0.127" layer="48"/>
+<wire x1="-5.08" y1="4.445" x2="-3.81" y2="4.445" width="0.127" layer="48"/>
+<wire x1="-3.81" y1="4.445" x2="-2.54" y2="4.445" width="0.127" layer="48"/>
+<wire x1="-2.54" y1="4.445" x2="-1.27" y2="4.445" width="0.127" layer="48"/>
+<wire x1="-1.27" y1="4.445" x2="0" y2="4.445" width="0.127" layer="48"/>
+<wire x1="0" y1="4.445" x2="1.27" y2="4.445" width="0.127" layer="48"/>
+<wire x1="1.27" y1="4.445" x2="2.54" y2="4.445" width="0.127" layer="48"/>
+<wire x1="2.54" y1="4.445" x2="3.81" y2="4.445" width="0.127" layer="48"/>
+<wire x1="3.81" y1="4.445" x2="5.08" y2="4.445" width="0.127" layer="48"/>
+<wire x1="5.08" y1="4.445" x2="6.35" y2="4.445" width="0.127" layer="48"/>
+<wire x1="6.35" y1="4.445" x2="7.62" y2="4.445" width="0.127" layer="48"/>
+<wire x1="7.62" y1="4.445" x2="8.89" y2="4.445" width="0.127" layer="48"/>
+<wire x1="8.89" y1="4.445" x2="10.16" y2="4.445" width="0.127" layer="48"/>
+<wire x1="10.16" y1="4.445" x2="11.43" y2="4.445" width="0.127" layer="48"/>
+<wire x1="11.43" y1="4.445" x2="12.7" y2="4.445" width="0.127" layer="48"/>
+<wire x1="12.7" y1="4.445" x2="13.97" y2="4.445" width="0.127" layer="48"/>
+<wire x1="13.97" y1="4.445" x2="15.24" y2="4.445" width="0.127" layer="48"/>
+<wire x1="15.24" y1="4.445" x2="15.24" y2="5.715" width="0.127" layer="48"/>
+<wire x1="15.24" y1="5.715" x2="15.24" y2="6.985" width="0.127" layer="48"/>
+<wire x1="15.24" y1="6.985" x2="15.24" y2="8.255" width="0.127" layer="48"/>
+<wire x1="15.24" y1="8.255" x2="13.97" y2="8.255" width="0.127" layer="48"/>
+<wire x1="13.97" y1="8.255" x2="12.7" y2="8.255" width="0.127" layer="48"/>
+<wire x1="12.7" y1="8.255" x2="11.43" y2="8.255" width="0.127" layer="48"/>
+<wire x1="11.43" y1="8.255" x2="10.16" y2="8.255" width="0.127" layer="48"/>
+<wire x1="10.16" y1="8.255" x2="8.89" y2="8.255" width="0.127" layer="48"/>
+<wire x1="8.89" y1="8.255" x2="7.62" y2="8.255" width="0.127" layer="48"/>
+<wire x1="7.62" y1="8.255" x2="6.35" y2="8.255" width="0.127" layer="48"/>
+<wire x1="6.35" y1="8.255" x2="5.08" y2="8.255" width="0.127" layer="48"/>
+<wire x1="5.08" y1="8.255" x2="3.81" y2="8.255" width="0.127" layer="48"/>
+<wire x1="3.81" y1="8.255" x2="2.54" y2="8.255" width="0.127" layer="48"/>
+<wire x1="2.54" y1="8.255" x2="1.27" y2="8.255" width="0.127" layer="48"/>
+<wire x1="1.27" y1="8.255" x2="0" y2="8.255" width="0.127" layer="48"/>
+<wire x1="0" y1="8.255" x2="-1.27" y2="8.255" width="0.127" layer="48"/>
+<wire x1="-1.27" y1="8.255" x2="-2.54" y2="8.255" width="0.127" layer="48"/>
+<wire x1="-2.54" y1="8.255" x2="-3.81" y2="8.255" width="0.127" layer="48"/>
+<wire x1="-3.81" y1="8.255" x2="-5.08" y2="8.255" width="0.127" layer="48"/>
+<wire x1="-5.08" y1="8.255" x2="-6.35" y2="8.255" width="0.127" layer="48"/>
+<wire x1="-6.35" y1="8.255" x2="-7.62" y2="8.255" width="0.127" layer="48"/>
+<wire x1="-7.62" y1="8.255" x2="-8.89" y2="8.255" width="0.127" layer="48"/>
+<wire x1="-8.89" y1="8.255" x2="-10.16" y2="8.255" width="0.127" layer="48"/>
+<wire x1="-10.16" y1="8.255" x2="-11.43" y2="8.255" width="0.127" layer="48"/>
+<wire x1="-11.43" y1="8.255" x2="-12.7" y2="8.255" width="0.127" layer="48"/>
+<wire x1="-12.7" y1="8.255" x2="-13.97" y2="8.255" width="0.127" layer="48"/>
+<wire x1="-13.97" y1="8.255" x2="-15.24" y2="8.255" width="0.127" layer="48"/>
+<wire x1="-15.24" y1="-8.255" x2="-15.24" y2="-6.985" width="0.127" layer="48"/>
+<wire x1="-15.24" y1="-6.985" x2="-15.24" y2="-5.715" width="0.127" layer="48"/>
+<wire x1="-15.24" y1="-5.715" x2="-15.24" y2="-4.445" width="0.127" layer="48"/>
+<wire x1="-15.24" y1="-4.445" x2="-13.97" y2="-4.445" width="0.127" layer="48"/>
+<wire x1="-13.97" y1="-4.445" x2="-12.7" y2="-4.445" width="0.127" layer="48"/>
+<wire x1="-12.7" y1="-4.445" x2="15.24" y2="-4.445" width="0.127" layer="48"/>
+<wire x1="15.24" y1="-4.445" x2="15.24" y2="-5.715" width="0.127" layer="48"/>
+<wire x1="15.24" y1="-5.715" x2="15.24" y2="-6.985" width="0.127" layer="48"/>
+<wire x1="15.24" y1="-6.985" x2="15.24" y2="-8.255" width="0.127" layer="48"/>
+<wire x1="15.24" y1="-8.255" x2="13.97" y2="-8.255" width="0.127" layer="48"/>
+<wire x1="13.97" y1="-8.255" x2="12.7" y2="-8.255" width="0.127" layer="48"/>
+<wire x1="12.7" y1="-8.255" x2="11.43" y2="-8.255" width="0.127" layer="48"/>
+<wire x1="11.43" y1="-8.255" x2="-15.24" y2="-8.255" width="0.127" layer="48"/>
+<wire x1="-19.05" y1="-8.255" x2="-15.24" y2="-8.255" width="0.127" layer="48"/>
+<wire x1="15.24" y1="-8.255" x2="19.05" y2="-8.255" width="0.127" layer="48"/>
+<wire x1="19.05" y1="-8.255" x2="19.05" y2="-10.795" width="0.127" layer="48"/>
+<wire x1="19.05" y1="-10.795" x2="-19.05" y2="-10.795" width="0.127" layer="48"/>
+<wire x1="-19.05" y1="-10.795" x2="-19.05" y2="-8.255" width="0.127" layer="48"/>
+<wire x1="-19.05" y1="8.255" x2="-15.24" y2="8.255" width="0.127" layer="48"/>
+<wire x1="15.24" y1="8.255" x2="19.05" y2="8.255" width="0.127" layer="48"/>
+<wire x1="19.05" y1="8.255" x2="19.05" y2="10.795" width="0.127" layer="48"/>
+<wire x1="19.05" y1="10.795" x2="-19.05" y2="10.795" width="0.127" layer="48"/>
+<wire x1="-19.05" y1="10.795" x2="-19.05" y2="8.255" width="0.127" layer="48"/>
+<wire x1="-20.32" y1="10.795" x2="-31.75" y2="10.795" width="0.127" layer="48"/>
+<wire x1="-20.32" y1="-10.795" x2="-31.75" y2="-10.795" width="0.127" layer="48"/>
+<wire x1="-31.115" y1="10.16" x2="-31.115" y2="1.905" width="0.127" layer="48"/>
+<polygon width="0.127" layer="48">
+<vertex x="-31.115" y="10.795"/>
+<vertex x="-31.75" y="8.255"/>
+<vertex x="-30.48" y="8.255"/>
+</polygon>
+<wire x1="-31.115" y1="-1.905" x2="-31.115" y2="-10.16" width="0.127" layer="48"/>
+<polygon width="0.127" layer="48">
+<vertex x="-31.115" y="-10.795"/>
+<vertex x="-31.75" y="-8.255"/>
+<vertex x="-30.48" y="-8.255"/>
+</polygon>
+<wire x1="-15.24" y1="6.985" x2="-13.97" y2="8.255" width="0.127" layer="48"/>
+<wire x1="-15.24" y1="5.715" x2="-12.7" y2="8.255" width="0.127" layer="48"/>
+<wire x1="-15.24" y1="4.445" x2="-11.43" y2="8.255" width="0.127" layer="48"/>
+<wire x1="-13.97" y1="4.445" x2="-10.16" y2="8.255" width="0.127" layer="48"/>
+<wire x1="-12.7" y1="4.445" x2="-8.89" y2="8.255" width="0.127" layer="48"/>
+<wire x1="-11.43" y1="4.445" x2="-7.62" y2="8.255" width="0.127" layer="48"/>
+<wire x1="-10.16" y1="4.445" x2="-6.35" y2="8.255" width="0.127" layer="48"/>
+<wire x1="-8.89" y1="4.445" x2="-5.08" y2="8.255" width="0.127" layer="48"/>
+<wire x1="-7.62" y1="4.445" x2="-3.81" y2="8.255" width="0.127" layer="48"/>
+<wire x1="-6.35" y1="4.445" x2="-2.54" y2="8.255" width="0.127" layer="48"/>
+<wire x1="-5.08" y1="4.445" x2="-1.27" y2="8.255" width="0.127" layer="48"/>
+<wire x1="-3.81" y1="4.445" x2="0" y2="8.255" width="0.127" layer="48"/>
+<wire x1="-2.54" y1="4.445" x2="1.27" y2="8.255" width="0.127" layer="48"/>
+<wire x1="-1.27" y1="4.445" x2="2.54" y2="8.255" width="0.127" layer="48"/>
+<wire x1="0" y1="4.445" x2="3.81" y2="8.255" width="0.127" layer="48"/>
+<wire x1="1.27" y1="4.445" x2="5.08" y2="8.255" width="0.127" layer="48"/>
+<wire x1="2.54" y1="4.445" x2="6.35" y2="8.255" width="0.127" layer="48"/>
+<wire x1="3.81" y1="4.445" x2="7.62" y2="8.255" width="0.127" layer="48"/>
+<wire x1="5.08" y1="4.445" x2="8.89" y2="8.255" width="0.127" layer="48"/>
+<wire x1="6.35" y1="4.445" x2="10.16" y2="8.255" width="0.127" layer="48"/>
+<wire x1="7.62" y1="4.445" x2="11.43" y2="8.255" width="0.127" layer="48"/>
+<wire x1="8.89" y1="4.445" x2="12.7" y2="8.255" width="0.127" layer="48"/>
+<wire x1="10.16" y1="4.445" x2="13.97" y2="8.255" width="0.127" layer="48"/>
+<wire x1="11.43" y1="4.445" x2="15.24" y2="8.255" width="0.127" layer="48"/>
+<wire x1="12.7" y1="4.445" x2="15.24" y2="6.985" width="0.127" layer="48"/>
+<wire x1="13.97" y1="4.445" x2="15.24" y2="5.715" width="0.127" layer="48"/>
+<wire x1="-15.24" y1="-1.905" x2="-11.43" y2="1.905" width="0.127" layer="48"/>
+<wire x1="-13.97" y1="-1.905" x2="-10.16" y2="1.905" width="0.127" layer="48"/>
+<wire x1="-12.7" y1="-1.905" x2="-8.89" y2="1.905" width="0.127" layer="48"/>
+<wire x1="-11.43" y1="-1.905" x2="-7.62" y2="1.905" width="0.127" layer="48"/>
+<wire x1="-10.16" y1="-1.905" x2="-6.35" y2="1.905" width="0.127" layer="48"/>
+<wire x1="-8.89" y1="-1.905" x2="-5.08" y2="1.905" width="0.127" layer="48"/>
+<wire x1="-7.62" y1="-1.905" x2="-3.81" y2="1.905" width="0.127" layer="48"/>
+<wire x1="-6.35" y1="-1.905" x2="-2.54" y2="1.905" width="0.127" layer="48"/>
+<wire x1="-5.08" y1="-1.905" x2="-1.27" y2="1.905" width="0.127" layer="48"/>
+<wire x1="-3.81" y1="-1.905" x2="0" y2="1.905" width="0.127" layer="48"/>
+<wire x1="-2.54" y1="-1.905" x2="1.27" y2="1.905" width="0.127" layer="48"/>
+<wire x1="-1.27" y1="-1.905" x2="2.54" y2="1.905" width="0.127" layer="48"/>
+<wire x1="0" y1="-1.905" x2="3.81" y2="1.905" width="0.127" layer="48"/>
+<wire x1="1.27" y1="-1.905" x2="5.08" y2="1.905" width="0.127" layer="48"/>
+<wire x1="2.54" y1="-1.905" x2="6.35" y2="1.905" width="0.127" layer="48"/>
+<wire x1="3.81" y1="-1.905" x2="7.62" y2="1.905" width="0.127" layer="48"/>
+<wire x1="5.08" y1="-1.905" x2="8.89" y2="1.905" width="0.127" layer="48"/>
+<wire x1="6.35" y1="-1.905" x2="10.16" y2="1.905" width="0.127" layer="48"/>
+<wire x1="7.62" y1="-1.905" x2="11.43" y2="1.905" width="0.127" layer="48"/>
+<wire x1="8.89" y1="-1.905" x2="12.7" y2="1.905" width="0.127" layer="48"/>
+<wire x1="10.16" y1="-1.905" x2="13.97" y2="1.905" width="0.127" layer="48"/>
+<wire x1="-15.24" y1="-0.635" x2="-12.7" y2="1.905" width="0.127" layer="48"/>
+<wire x1="-15.24" y1="0.635" x2="-13.97" y2="1.905" width="0.127" layer="48"/>
+<wire x1="11.43" y1="-1.905" x2="15.24" y2="1.905" width="0.127" layer="48"/>
+<wire x1="12.7" y1="-1.905" x2="15.24" y2="0.635" width="0.127" layer="48"/>
+<wire x1="13.97" y1="-1.905" x2="15.24" y2="-0.635" width="0.127" layer="48"/>
+<wire x1="-15.24" y1="-8.255" x2="-11.43" y2="-4.445" width="0.127" layer="48"/>
+<wire x1="-13.97" y1="-8.255" x2="-10.16" y2="-4.445" width="0.127" layer="48"/>
+<wire x1="-12.7" y1="-8.255" x2="-8.89" y2="-4.445" width="0.127" layer="48"/>
+<wire x1="-11.43" y1="-8.255" x2="-7.62" y2="-4.445" width="0.127" layer="48"/>
+<wire x1="-10.16" y1="-8.255" x2="-6.35" y2="-4.445" width="0.127" layer="48"/>
+<wire x1="-8.89" y1="-8.255" x2="-5.08" y2="-4.445" width="0.127" layer="48"/>
+<wire x1="-7.62" y1="-8.255" x2="-3.81" y2="-4.445" width="0.127" layer="48"/>
+<wire x1="-6.35" y1="-8.255" x2="-2.54" y2="-4.445" width="0.127" layer="48"/>
+<wire x1="-5.08" y1="-8.255" x2="-1.27" y2="-4.445" width="0.127" layer="48"/>
+<wire x1="-3.81" y1="-8.255" x2="0" y2="-4.445" width="0.127" layer="48"/>
+<wire x1="-2.54" y1="-8.255" x2="1.27" y2="-4.445" width="0.127" layer="48"/>
+<wire x1="-1.27" y1="-8.255" x2="2.54" y2="-4.445" width="0.127" layer="48"/>
+<wire x1="0" y1="-8.255" x2="3.81" y2="-4.445" width="0.127" layer="48"/>
+<wire x1="1.27" y1="-8.255" x2="5.08" y2="-4.445" width="0.127" layer="48"/>
+<wire x1="2.54" y1="-8.255" x2="6.35" y2="-4.445" width="0.127" layer="48"/>
+<wire x1="3.81" y1="-8.255" x2="7.62" y2="-4.445" width="0.127" layer="48"/>
+<wire x1="5.08" y1="-8.255" x2="8.89" y2="-4.445" width="0.127" layer="48"/>
+<wire x1="6.35" y1="-8.255" x2="10.16" y2="-4.445" width="0.127" layer="48"/>
+<wire x1="7.62" y1="-8.255" x2="11.43" y2="-4.445" width="0.127" layer="48"/>
+<wire x1="8.89" y1="-8.255" x2="12.7" y2="-4.445" width="0.127" layer="48"/>
+<wire x1="10.16" y1="-8.255" x2="13.97" y2="-4.445" width="0.127" layer="48"/>
+<wire x1="-15.24" y1="-6.985" x2="-12.7" y2="-4.445" width="0.127" layer="48"/>
+<wire x1="-15.24" y1="-5.715" x2="-13.97" y2="-4.445" width="0.127" layer="48"/>
+<wire x1="11.43" y1="-8.255" x2="15.24" y2="-4.445" width="0.127" layer="48"/>
+<wire x1="12.7" y1="-8.255" x2="15.24" y2="-5.715" width="0.127" layer="48"/>
+<wire x1="13.97" y1="-8.255" x2="15.24" y2="-6.985" width="0.127" layer="48"/>
+</package>
+<package name="USB_C_JAE_DX07B024XJ1">
+<smd name="A6" x="-0.25" y="5.76" dx="1.1" dy="0.3" layer="1" rot="R90" stop="no" cream="no"/>
+<smd name="A7" x="0.25" y="5.76" dx="1.1" dy="0.3" layer="1" rot="R90" stop="no" cream="no"/>
+<smd name="A5" x="-0.75" y="5.76" dx="1.1" dy="0.3" layer="1" rot="R90" stop="no" cream="no"/>
+<smd name="A8" x="0.75" y="5.76" dx="1.1" dy="0.3" layer="1" rot="R90" stop="no" cream="no"/>
+<smd name="A4" x="-1.25" y="5.76" dx="1.1" dy="0.3" layer="1" rot="R90" stop="no" cream="no"/>
+<smd name="A9" x="1.25" y="5.76" dx="1.1" dy="0.3" layer="1" rot="R90" stop="no" cream="no"/>
+<smd name="A3" x="-1.75" y="5.76" dx="1.1" dy="0.3" layer="1" rot="R90" stop="no" cream="no"/>
+<smd name="A10" x="1.75" y="5.76" dx="1.1" dy="0.3" layer="1" rot="R90" stop="no" cream="no"/>
+<smd name="A2" x="-2.25" y="5.76" dx="1.1" dy="0.3" layer="1" rot="R90" stop="no" cream="no"/>
+<smd name="A11" x="2.25" y="5.76" dx="1.1" dy="0.3" layer="1" rot="R90" stop="no" cream="no"/>
+<smd name="A1" x="-2.75" y="5.76" dx="1.1" dy="0.3" layer="1" rot="R90" stop="no" cream="no"/>
+<smd name="A12" x="2.75" y="5.76" dx="1.1" dy="0.3" layer="1" rot="R90" stop="no" cream="no"/>
+<pad name="B12" x="-2.8" y="4.55" drill="0.4" diameter="0.6"/>
+<pad name="B11" x="-2.4" y="3.75" drill="0.4" diameter="0.6"/>
+<pad name="B10" x="-1.6" y="3.75" drill="0.4" diameter="0.6"/>
+<pad name="B8" x="-0.8" y="3.75" drill="0.4" diameter="0.6"/>
+<pad name="B9" x="-1.35" y="4.55" drill="0.4" diameter="0.6"/>
+<pad name="B7" x="-0.4" y="4.55" drill="0.4" diameter="0.6"/>
+<pad name="B6" x="0.4" y="4.55" drill="0.4" diameter="0.6"/>
+<pad name="B4" x="1.35" y="4.55" drill="0.4" diameter="0.6"/>
+<pad name="B5" x="0.8" y="3.75" drill="0.4" diameter="0.6"/>
+<pad name="B3" x="1.6" y="3.75" drill="0.4" diameter="0.6"/>
+<pad name="B2" x="2.4" y="3.75" drill="0.4" diameter="0.6"/>
+<pad name="B1" x="2.8" y="4.55" drill="0.4" diameter="0.6"/>
+<hole x="-3.6" y="5.1" drill="0.8"/>
+<hole x="3.6" y="5.1" drill="0.9"/>
+<wire x1="-0.04" y1="5.76" x2="0.04" y2="5.76" width="0.02" layer="21"/>
+<wire x1="0" y1="5.8" x2="0" y2="5.72" width="0.02" layer="21"/>
+<pad name="SH1" x="-4.8" y="4.225" drill="0.6" diameter="1" shape="long" rot="R90"/>
+<pad name="SH4" x="4.8" y="4.225" drill="0.6" diameter="1" shape="long" rot="R90"/>
+<pad name="SH2" x="-5.8" y="0" drill="0.6" diameter="1.1" shape="long" rot="R90"/>
+<pad name="SH3" x="5.8" y="0" drill="0.6" diameter="1.1" shape="long" rot="R90"/>
+<wire x1="-5.8" y1="-0.5" x2="-5.8" y2="0.5" width="0.6" layer="46"/>
+<wire x1="5.8" y1="-0.5" x2="5.8" y2="0.5" width="0.6" layer="46"/>
+<wire x1="-4.8" y1="3.75" x2="-4.8" y2="4.71" width="0.6" layer="46"/>
+<wire x1="4.8" y1="3.75" x2="4.8" y2="4.71" width="0.6" layer="46"/>
+<wire x1="-7" y1="-1.65" x2="-4.5" y2="-1.65" width="0.05" layer="21" style="shortdash"/>
+<wire x1="-4.5" y1="-1.65" x2="-4.5" y2="3.1" width="0.05" layer="21" style="shortdash"/>
+<wire x1="-4.5" y1="3.1" x2="4.5" y2="3.1" width="0.05" layer="21" style="shortdash"/>
+<wire x1="4.5" y1="3.1" x2="4.5" y2="-1.65" width="0.05" layer="21" style="shortdash"/>
+<wire x1="4.5" y1="-1.65" x2="7" y2="-1.65" width="0.05" layer="21" style="shortdash"/>
+<wire x1="-4.8" y1="3.75" x2="-4.8" y2="4.71" width="0.8" layer="31"/>
+<wire x1="4.8" y1="3.75" x2="4.8" y2="4.71" width="0.8" layer="31"/>
+<wire x1="5.8" y1="-0.5" x2="5.8" y2="0.5" width="0.8" layer="31"/>
+<wire x1="-5.8" y1="-0.5" x2="-5.8" y2="0.5" width="0.8" layer="31"/>
+<polygon width="0.02" layer="2" pour="cutout">
+<vertex x="-6.09" y="0.05"/>
+<vertex x="-6.09" y="0.5" curve="-90"/>
+<vertex x="-5.8" y="0.79" curve="-90"/>
+<vertex x="-5.51" y="0.5"/>
+<vertex x="-5.51" y="0.03"/>
+<vertex x="-5.51" y="-0.5" curve="-90"/>
+<vertex x="-5.8" y="-0.79" curve="-90"/>
+<vertex x="-6.09" y="-0.5"/>
+</polygon>
+<polygon width="0.02" layer="15" pour="cutout">
+<vertex x="-6.09" y="-0.5"/>
+<vertex x="-6.09" y="0.5" curve="-90"/>
+<vertex x="-5.8" y="0.79" curve="-90"/>
+<vertex x="-5.51" y="0.5"/>
+<vertex x="-5.51" y="-0.5" curve="-90"/>
+<vertex x="-5.8" y="-0.79" curve="-90"/>
+</polygon>
+<polygon width="0.02" layer="15" pour="cutout">
+<vertex x="5.51" y="-0.5"/>
+<vertex x="5.51" y="0.5" curve="-90"/>
+<vertex x="5.8" y="0.79" curve="-90"/>
+<vertex x="6.09" y="0.5"/>
+<vertex x="6.09" y="-0.5" curve="-90"/>
+<vertex x="5.8" y="-0.79" curve="-90"/>
+</polygon>
+<polygon width="0.02" layer="2" pour="cutout">
+<vertex x="5.51" y="-0.5"/>
+<vertex x="5.51" y="0.5" curve="-90"/>
+<vertex x="5.8" y="0.79" curve="-90"/>
+<vertex x="6.09" y="0.5"/>
+<vertex x="6.09" y="-0.5" curve="-90"/>
+<vertex x="5.8" y="-0.79" curve="-90"/>
+</polygon>
+<polygon width="0.02" layer="2" pour="cutout">
+<vertex x="-5.09" y="4.25"/>
+<vertex x="-5.09" y="4.71" curve="-90"/>
+<vertex x="-4.8" y="5" curve="-90"/>
+<vertex x="-4.51" y="4.71"/>
+<vertex x="-4.51" y="4.23"/>
+<vertex x="-4.51" y="3.75" curve="-90"/>
+<vertex x="-4.8" y="3.46" curve="-90"/>
+<vertex x="-5.09" y="3.75"/>
+</polygon>
+<polygon width="0.02" layer="15" pour="cutout">
+<vertex x="-5.09" y="3.75"/>
+<vertex x="-5.09" y="4.71" curve="-90"/>
+<vertex x="-4.8" y="5" curve="-90"/>
+<vertex x="-4.51" y="4.71"/>
+<vertex x="-4.51" y="3.75" curve="-90"/>
+<vertex x="-4.8" y="3.46" curve="-90"/>
+</polygon>
+<polygon width="0.02" layer="2" pour="cutout">
+<vertex x="4.51" y="3.75"/>
+<vertex x="4.51" y="4.71" curve="-90"/>
+<vertex x="4.8" y="5" curve="-90"/>
+<vertex x="5.09" y="4.71"/>
+<vertex x="5.09" y="3.75" curve="-90"/>
+<vertex x="4.8" y="3.46" curve="-90"/>
+</polygon>
+<polygon width="0.02" layer="15" pour="cutout">
+<vertex x="4.51" y="3.75"/>
+<vertex x="4.51" y="4.71" curve="-90"/>
+<vertex x="4.8" y="5" curve="-90"/>
+<vertex x="5.09" y="4.71"/>
+<vertex x="5.09" y="3.75" curve="-90"/>
+<vertex x="4.8" y="3.46" curve="-90"/>
+</polygon>
+<rectangle x1="-2.87" y1="5.24" x2="-2.63" y2="6.28" layer="31"/>
+<rectangle x1="-2.37" y1="5.24" x2="-2.13" y2="6.28" layer="31"/>
+<rectangle x1="-1.87" y1="5.24" x2="-1.63" y2="6.28" layer="31"/>
+<rectangle x1="-1.37" y1="5.24" x2="-1.13" y2="6.28" layer="31"/>
+<rectangle x1="-0.87" y1="5.24" x2="-0.63" y2="6.28" layer="31"/>
+<rectangle x1="-0.37" y1="5.24" x2="-0.13" y2="6.28" layer="31"/>
+<rectangle x1="0.13" y1="5.24" x2="0.37" y2="6.28" layer="31"/>
+<rectangle x1="0.63" y1="5.24" x2="0.87" y2="6.28" layer="31"/>
+<rectangle x1="1.13" y1="5.24" x2="1.37" y2="6.28" layer="31"/>
+<rectangle x1="1.63" y1="5.24" x2="1.87" y2="6.28" layer="31"/>
+<rectangle x1="2.13" y1="5.24" x2="2.37" y2="6.28" layer="31"/>
+<rectangle x1="2.63" y1="5.24" x2="2.87" y2="6.28" layer="31"/>
+<rectangle x1="-2.96" y1="5.15" x2="2.96" y2="6.37" layer="29"/>
+<circle x="-2.8" y="4.55" radius="0.15" width="0.3" layer="31"/>
+<circle x="-1.35" y="4.55" radius="0.15" width="0.3" layer="31"/>
+<circle x="-0.4" y="4.55" radius="0.15" width="0.3" layer="31"/>
+<circle x="0.4" y="4.55" radius="0.15" width="0.3" layer="31"/>
+<circle x="1.35" y="4.55" radius="0.15" width="0.3" layer="31"/>
+<circle x="2.8" y="4.55" radius="0.15" width="0.3" layer="31"/>
+<circle x="-2.4" y="3.75" radius="0.15" width="0.3" layer="31"/>
+<circle x="-1.6" y="3.75" radius="0.15" width="0.3" layer="31"/>
+<circle x="-0.8" y="3.75" radius="0.15" width="0.3" layer="31"/>
+<circle x="0.8" y="3.75" radius="0.15" width="0.3" layer="31"/>
+<circle x="1.6" y="3.75" radius="0.15" width="0.3" layer="31"/>
+<circle x="2.4" y="3.75" radius="0.15" width="0.3" layer="31"/>
+<hole x="-4.5" y="2.85" drill="0.5"/>
+<hole x="4.5" y="2.85" drill="0.5"/>
+<wire x1="-4.9" y1="-3.75" x2="4.9" y2="-3.75" width="0.1" layer="21"/>
+<wire x1="4.9" y1="-3.75" x2="4.9" y2="5.9" width="0.1" layer="21"/>
+<wire x1="4.9" y1="5.9" x2="-4.9" y2="5.9" width="0.1" layer="21"/>
+<wire x1="-4.9" y1="5.9" x2="-4.9" y2="-3.75" width="0.1" layer="21"/>
+<text x="0" y="-3" size="1" layer="25" align="center">&gt;NAME</text>
+<text x="0" y="-4.4" size="0.8" layer="27" align="center">&gt;VALUE</text>
+</package>
+<package name="SWD">
+<pad name="RST" x="0" y="0" drill="0.7" diameter="1" shape="square" stop="no"/>
+<pad name="GND" x="1.27" y="0" drill="0.7" diameter="1" stop="no"/>
+<pad name="SWO" x="2.54" y="0" drill="0.7" diameter="1" stop="no"/>
+<pad name="SWCLK" x="3.81" y="0" drill="0.7" diameter="1" stop="no"/>
+<pad name="SWDIO" x="5.08" y="0" drill="0.7" diameter="1" stop="no"/>
+<pad name="VCC" x="6.35" y="0" drill="0.7" diameter="1" stop="no"/>
+<circle x="1.27" y="0" radius="0.254" width="0.639" layer="29"/>
+<circle x="2.54" y="0" radius="0.254" width="0.639" layer="29"/>
+<circle x="3.81" y="0" radius="0.254" width="0.639" layer="29"/>
+<circle x="5.08" y="0" radius="0.254" width="0.639" layer="29"/>
+<circle x="6.35" y="0" radius="0.254" width="0.639" layer="29"/>
+<rectangle x1="-0.5842" y1="-0.5842" x2="0.5842" y2="0.5842" layer="29"/>
+</package>
+<package name="MB_1.00">
+<smd name="1" x="0" y="0" dx="1" dy="1" layer="1" roundness="100" stop="no" cream="no"/>
+<circle x="0" y="0" radius="0.25" width="0.6" layer="29"/>
+<circle x="0" y="0" radius="0.2" width="0.45" layer="37"/>
+<text x="0" y="1.3" size="1" layer="37" align="center">&gt;NAME</text>
+</package>
+<package name="SOT23_REFLOW">
+<wire x1="1.524" y1="-0.508" x2="1.143" y2="-0.508" width="0.127" layer="21"/>
+<wire x1="1.143" y1="-0.508" x2="-1.524" y2="-0.508" width="0.127" layer="21"/>
+<wire x1="-1.524" y1="-0.508" x2="-1.524" y2="0.508" width="0.127" layer="21"/>
+<wire x1="-1.524" y1="0.508" x2="1.143" y2="0.508" width="0.127" layer="21"/>
+<wire x1="1.143" y1="0.508" x2="1.524" y2="0.508" width="0.127" layer="21"/>
+<wire x1="1.524" y1="0.508" x2="1.524" y2="-0.508" width="0.127" layer="21"/>
+<wire x1="1.143" y1="-0.508" x2="1.143" y2="0.508" width="0.1524" layer="21"/>
+<smd name="2" x="-0.95" y="-1.2" dx="0.8" dy="1" layer="1"/>
+<smd name="1" x="0.95" y="-1.2" dx="0.8" dy="1" layer="1"/>
+<smd name="3" x="0" y="1.2" dx="0.8" dy="1" layer="1"/>
+<text x="-1.27" y="-2.54" size="1.016" layer="25">&gt;NAME</text>
+<text x="-1.27" y="-2.54" size="1.016" layer="27">&gt;VALUE</text>
+<rectangle x1="-0.3048" y1="0.5588" x2="0.3048" y2="1.27" layer="27"/>
+<rectangle x1="-1.25" y1="-0.762" x2="-0.65" y2="-0.381" layer="21"/>
+<rectangle x1="0.65" y1="-0.762" x2="1.25" y2="-0.381" layer="21"/>
+<rectangle x1="-0.3048" y1="0.381" x2="0.3048" y2="0.762" layer="21"/>
+<rectangle x1="-0.3048" y1="0.5588" x2="0.3048" y2="1.27" layer="27"/>
+<rectangle x1="0.65" y1="-1.27" x2="1.25" y2="-0.5588" layer="27"/>
+<rectangle x1="-1.25" y1="-1.27" x2="-0.65" y2="-0.5588" layer="27"/>
+<rectangle x1="-1.65" y1="-0.15" x2="1.65" y2="0.15" layer="35"/>
+</package>
+<package name="SOT23_MEDIUM_SIZE">
+<wire x1="1.524" y1="-0.508" x2="1.143" y2="-0.508" width="0.127" layer="21"/>
+<wire x1="1.143" y1="-0.508" x2="-1.524" y2="-0.508" width="0.127" layer="21"/>
+<wire x1="-1.524" y1="-0.508" x2="-1.524" y2="0.508" width="0.127" layer="21"/>
+<wire x1="-1.524" y1="0.508" x2="1.143" y2="0.508" width="0.127" layer="21"/>
+<wire x1="1.143" y1="0.508" x2="1.524" y2="0.508" width="0.127" layer="21"/>
+<wire x1="1.524" y1="0.508" x2="1.524" y2="-0.508" width="0.127" layer="21"/>
+<wire x1="1.143" y1="-0.508" x2="1.143" y2="0.508" width="0.1524" layer="21"/>
+<smd name="2" x="0.9" y="-1.1" dx="1.1" dy="1.1" layer="1" thermals="no" cream="no"/>
+<smd name="1" x="-0.9" y="-1.1" dx="1.1" dy="1.1" layer="1" thermals="no" cream="no"/>
+<smd name="3" x="0" y="1.1" dx="1.1" dy="1.1" layer="1" thermals="no" cream="no"/>
+<text x="-1.143" y="-1.905" size="1.016" layer="25">&gt;NAME</text>
+<text x="-1.778" y="-2.413" size="1.016" layer="27">&gt;VALUE</text>
+<rectangle x1="-0.3048" y1="0.5588" x2="0.3048" y2="1.27" layer="21"/>
+<rectangle x1="0.7112" y1="-1.27" x2="1.3208" y2="-0.5588" layer="21"/>
+<rectangle x1="-1.3208" y1="-1.27" x2="-0.7112" y2="-0.5588" layer="21"/>
+<rectangle x1="-1.4" y1="-1.5" x2="-0.4" y2="-0.6" layer="31"/>
+<rectangle x1="0.4" y1="-1.5" x2="1.4" y2="-0.6" layer="31"/>
+<rectangle x1="-0.45" y1="0.6" x2="0.45" y2="1.55" layer="31"/>
+</package>
+</packages>
+</library>
+<library name="DZ">
+<packages>
+<package name="SOD882D">
+<smd name="1" x="-0.4" y="0" dx="0.6" dy="0.5" layer="1" rot="R90" cream="no"/>
+<smd name="2" x="0.4" y="0" dx="0.6" dy="0.5" layer="1" rot="R90" cream="no"/>
+<rectangle x1="-0.5" y1="-0.25" x2="-0.2" y2="0.25" layer="31"/>
+<rectangle x1="0.2" y1="-0.25" x2="0.5" y2="0.25" layer="31"/>
+<text x="-0.889" y="0.635" size="0.6096" layer="25">&gt;NAME</text>
+<text x="-0.889" y="-1.27" size="0.6096" layer="27">&gt;VALUE</text>
+<wire x1="-0.75" y1="-0.45" x2="0.75" y2="-0.45" width="0.127" layer="21"/>
+<wire x1="0.75" y1="-0.45" x2="0.75" y2="0.45" width="0.127" layer="21"/>
+<wire x1="0.75" y1="0.45" x2="-0.75" y2="0.45" width="0.127" layer="21"/>
+<wire x1="-0.75" y1="0.45" x2="-0.75" y2="-0.45" width="0.127" layer="21"/>
+</package>
+</packages>
+</library>
+</libraries>
+<attributes>
+</attributes>
+<variantdefs>
+</variantdefs>
+<classes>
+<class number="0" name="default" width="0" drill="0">
+</class>
+</classes>
+<designrules name="moje_pravidla_trezor *">
+<description language="de">&lt;b&gt;EAGLE Design Rules&lt;/b&gt;
+&lt;p&gt;
+Die Standard-Design-Rules sind so gewählt, dass sie für 
+die meisten Anwendungen passen. Sollte ihre Platine 
+besondere Anforderungen haben, treffen Sie die erforderlichen
+Einstellungen hier und speichern die Design Rules unter 
+einem neuen Namen ab.</description>
+<description language="en">&lt;b&gt;EAGLE Design Rules&lt;/b&gt;
+&lt;p&gt;
+The default Design Rules have been set to cover
+a wide range of applications. Your particular design
+may have different requirements, so please make the
+necessary adjustments and save your customized
+design rules under a new name.</description>
+<param name="layerSetup" value="((1+2)*(15+16))"/>
+<param name="mtCopper" value="0.018mm 0.018mm 0.035mm 0.035mm 0.035mm 0.035mm 0.035mm 0.035mm 0.035mm 0.035mm 0.035mm 0.035mm 0.035mm 0.035mm 0.018mm 0.018mm"/>
+<param name="mtIsolate" value="0.2mm 0.452mm 0.2mm 0.15mm 0.2mm 0.15mm 0.2mm 0.15mm 0.2mm 0.15mm 0.2mm 0.15mm 0.2mm 0.15mm 0.2mm"/>
+<param name="mdWireWire" value="0.12mm"/>
+<param name="mdWirePad" value="0.12mm"/>
+<param name="mdWireVia" value="0.12mm"/>
+<param name="mdPadPad" value="0.12mm"/>
+<param name="mdPadVia" value="0.12mm"/>
+<param name="mdViaVia" value="0.12mm"/>
+<param name="mdSmdPad" value="0mil"/>
+<param name="mdSmdVia" value="0mil"/>
+<param name="mdSmdSmd" value="0mil"/>
+<param name="mdViaViaSameLayer" value="8mil"/>
+<param name="mnLayersViaInSmd" value="2"/>
+<param name="mdCopperDimension" value="8mil"/>
+<param name="mdDrill" value="8mil"/>
+<param name="mdSmdStop" value="0mil"/>
+<param name="msWidth" value="0.1mm"/>
+<param name="msDrill" value="0.2mm"/>
+<param name="msMicroVia" value="0.2mm"/>
+<param name="msBlindViaRatio" value="1"/>
+<param name="rvPadTop" value="0.25"/>
+<param name="rvPadInner" value="0.25"/>
+<param name="rvPadBottom" value="0.25"/>
+<param name="rvViaOuter" value="0.25"/>
+<param name="rvViaInner" value="0.25"/>
+<param name="rvMicroViaOuter" value="0.25"/>
+<param name="rvMicroViaInner" value="0.25"/>
+<param name="rlMinPadTop" value="3mil"/>
+<param name="rlMaxPadTop" value="20mil"/>
+<param name="rlMinPadInner" value="3mil"/>
+<param name="rlMaxPadInner" value="20mil"/>
+<param name="rlMinPadBottom" value="3mil"/>
+<param name="rlMaxPadBottom" value="20mil"/>
+<param name="rlMinViaOuter" value="7mil"/>
+<param name="rlMaxViaOuter" value="20mil"/>
+<param name="rlMinViaInner" value="7mil"/>
+<param name="rlMaxViaInner" value="20mil"/>
+<param name="rlMinMicroViaOuter" value="4mil"/>
+<param name="rlMaxMicroViaOuter" value="20mil"/>
+<param name="rlMinMicroViaInner" value="4mil"/>
+<param name="rlMaxMicroViaInner" value="20mil"/>
+<param name="psTop" value="-1"/>
+<param name="psBottom" value="-1"/>
+<param name="psFirst" value="-1"/>
+<param name="psElongationLong" value="100"/>
+<param name="psElongationOffset" value="100"/>
+<param name="mvStopFrame" value="1"/>
+<param name="mvCreamFrame" value="0"/>
+<param name="mlMinStopFrame" value="4mil"/>
+<param name="mlMaxStopFrame" value="4mil"/>
+<param name="mlMinCreamFrame" value="0mil"/>
+<param name="mlMaxCreamFrame" value="0mil"/>
+<param name="mlViaStopLimit" value="20mil"/>
+<param name="srRoundness" value="0"/>
+<param name="srMinRoundness" value="0mil"/>
+<param name="srMaxRoundness" value="0mil"/>
+<param name="slThermalIsolate" value="0.18mm"/>
+<param name="slThermalsForVias" value="0"/>
+<param name="dpMaxLengthDifference" value="10mm"/>
+<param name="dpGapFactor" value="2.5"/>
+<param name="checkGrid" value="0"/>
+<param name="checkAngle" value="1"/>
+<param name="checkFont" value="1"/>
+<param name="checkRestrict" value="1"/>
+<param name="useDiameter" value="13"/>
+<param name="maxErrors" value="50"/>
+</designrules>
+<autorouter>
+<pass name="Default">
+<param name="RoutingGrid" value="50mil"/>
+<param name="AutoGrid" value="1"/>
+<param name="Efforts" value="0"/>
+<param name="TopRouterVariant" value="1"/>
+<param name="tpViaShape" value="round"/>
+<param name="PrefDir.1" value="a"/>
+<param name="PrefDir.2" value="0"/>
+<param name="PrefDir.3" value="0"/>
+<param name="PrefDir.4" value="0"/>
+<param name="PrefDir.5" value="0"/>
+<param name="PrefDir.6" value="0"/>
+<param name="PrefDir.7" value="0"/>
+<param name="PrefDir.8" value="0"/>
+<param name="PrefDir.9" value="0"/>
+<param name="PrefDir.10" value="0"/>
+<param name="PrefDir.11" value="0"/>
+<param name="PrefDir.12" value="0"/>
+<param name="PrefDir.13" value="0"/>
+<param name="PrefDir.14" value="0"/>
+<param name="PrefDir.15" value="0"/>
+<param name="PrefDir.16" value="a"/>
+<param name="cfVia" value="8"/>
+<param name="cfNonPref" value="5"/>
+<param name="cfChangeDir" value="2"/>
+<param name="cfOrthStep" value="2"/>
+<param name="cfDiagStep" value="3"/>
+<param name="cfExtdStep" value="0"/>
+<param name="cfBonusStep" value="1"/>
+<param name="cfMalusStep" value="1"/>
+<param name="cfPadImpact" value="4"/>
+<param name="cfSmdImpact" value="4"/>
+<param name="cfBusImpact" value="0"/>
+<param name="cfHugging" value="3"/>
+<param name="cfAvoid" value="4"/>
+<param name="cfPolygon" value="10"/>
+<param name="cfBase.1" value="0"/>
+<param name="cfBase.2" value="1"/>
+<param name="cfBase.3" value="1"/>
+<param name="cfBase.4" value="1"/>
+<param name="cfBase.5" value="1"/>
+<param name="cfBase.6" value="1"/>
+<param name="cfBase.7" value="1"/>
+<param name="cfBase.8" value="1"/>
+<param name="cfBase.9" value="1"/>
+<param name="cfBase.10" value="1"/>
+<param name="cfBase.11" value="1"/>
+<param name="cfBase.12" value="1"/>
+<param name="cfBase.13" value="1"/>
+<param name="cfBase.14" value="1"/>
+<param name="cfBase.15" value="1"/>
+<param name="cfBase.16" value="0"/>
+<param name="mnVias" value="20"/>
+<param name="mnSegments" value="9999"/>
+<param name="mnExtdSteps" value="9999"/>
+<param name="mnRipupLevel" value="10"/>
+<param name="mnRipupSteps" value="100"/>
+<param name="mnRipupTotal" value="100"/>
+</pass>
+<pass name="Follow-me" refer="Default" active="yes">
+</pass>
+<pass name="Busses" refer="Default" active="yes">
+<param name="cfNonPref" value="4"/>
+<param name="cfBusImpact" value="4"/>
+<param name="cfHugging" value="0"/>
+<param name="mnVias" value="0"/>
+</pass>
+<pass name="Route" refer="Default" active="yes">
+</pass>
+<pass name="Optimize1" refer="Default" active="yes">
+<param name="cfVia" value="99"/>
+<param name="cfExtdStep" value="10"/>
+<param name="cfHugging" value="1"/>
+<param name="mnExtdSteps" value="1"/>
+<param name="mnRipupLevel" value="0"/>
+</pass>
+<pass name="Optimize2" refer="Optimize1" active="yes">
+<param name="cfNonPref" value="0"/>
+<param name="cfChangeDir" value="6"/>
+<param name="cfExtdStep" value="0"/>
+<param name="cfBonusStep" value="2"/>
+<param name="cfMalusStep" value="2"/>
+<param name="cfPadImpact" value="2"/>
+<param name="cfSmdImpact" value="2"/>
+<param name="cfHugging" value="0"/>
+</pass>
+<pass name="Optimize3" refer="Optimize2" active="yes">
+<param name="cfChangeDir" value="8"/>
+<param name="cfPadImpact" value="0"/>
+<param name="cfSmdImpact" value="0"/>
+</pass>
+<pass name="Optimize4" refer="Optimize3" active="yes">
+<param name="cfChangeDir" value="25"/>
+</pass>
+</autorouter>
+<elements>
+<element name="D1" library="vyber_stara_nemenit" package="SOD323F" value="PMEG3005" x="20.8" y="21.3" smashed="yes" rot="R90">
+<attribute name="NAME" x="19.6955" y="20.587" size="1.016" layer="25" rot="R90"/>
+<attribute name="VALUE" x="19.657" y="18.887" size="1.016" layer="27" rot="R90"/>
+</element>
+<element name="D3" library="vyber_stara_nemenit" package="SOT143B_REFLOW" value="PRTR5V0U2X" x="22.3" y="18.1" smashed="yes">
+<attribute name="NAME" x="21.222" y="16.2" size="1.016" layer="25"/>
+<attribute name="VALUE" x="20.17" y="14.887" size="1.016" layer="27"/>
+</element>
+<element name="K3" library="SDkarta" package="ATTEND_112J-TXAR-R01_SMALL" value="ATTEND_112J-TDAR-R01" x="50.5" y="30.15" smashed="yes" rot="R180"/>
+<element name="IC2" library="trezor" package="LQFP100_NO_CENTER_NO_TDOCU" value="STM32F427VIT6" x="32.766" y="13.335" rot="R180"/>
+<element name="X1" library="trezor" package="X6,0X3,5" value="CTS406 8MHz" x="47.05" y="12" smashed="yes" rot="R90">
+<attribute name="VALUE" x="45.145" y="9.46" size="1.016" layer="27" ratio="15" rot="R90"/>
+<attribute name="NAME" x="45.025" y="9.66" size="1.016" layer="25" ratio="15" rot="R90"/>
+</element>
+<element name="C2" library="vyber_stara_nemenit" package="0402" value="22p" x="49.6" y="11.15" smashed="yes" rot="R90">
+<attribute name="NAME" x="49.965" y="9.145" size="0.8" layer="25" rot="R90"/>
+<attribute name="VALUE" x="50.997" y="9.245" size="0.8128" layer="27" rot="R90"/>
+</element>
+<element name="C3" library="vyber_stara_nemenit" package="0402" value="22p" x="49.6" y="13.1" smashed="yes" rot="R270">
+<attribute name="NAME" x="49.135" y="15.305" size="0.8" layer="25" rot="R270"/>
+<attribute name="VALUE" x="48.203" y="15.005" size="0.8128" layer="27" rot="R270"/>
+</element>
+<element name="C4" library="vyber_stara_nemenit" package="0603_REFLOW" value="1u" x="21.3" y="25.1"/>
+<element name="C5" library="vyber_stara_nemenit" package="0603" value="1u" x="29.21" y="26.659" rot="R270"/>
+<element name="C6" library="vyber_stara_nemenit" package="0402" value="10n" x="24.7" y="5.7" smashed="yes" rot="R90">
+<attribute name="NAME" x="23.297" y="6.367" size="1.016" layer="25" rot="R270"/>
+<attribute name="VALUE" x="26.097" y="3.795" size="0.8128" layer="27" rot="R90"/>
+</element>
+<element name="C7" library="vyber_stara_nemenit" package="0402" value="100n" x="37.8" y="22.9" smashed="yes" rot="R270">
+<attribute name="NAME" x="36.535" y="23.505" size="0.8" layer="25" rot="R270"/>
+<attribute name="VALUE" x="36.403" y="24.805" size="0.8128" layer="27" rot="R270"/>
+</element>
+<element name="C8" library="vyber_stara_nemenit" package="0402" value="10n" x="38.85" y="3.65" smashed="yes" rot="R90">
+<attribute name="NAME" x="38.415" y="3.045" size="0.8" layer="25" rot="R90"/>
+<attribute name="VALUE" x="40.247" y="1.745" size="0.8128" layer="27" rot="R90"/>
+</element>
+<element name="C9" library="vyber_stara_nemenit" package="0402" value="100n" x="41.937" y="18.523" smashed="yes" rot="R270">
+<attribute name="NAME" x="40.572" y="19.228" size="0.8" layer="25" rot="R270"/>
+<attribute name="VALUE" x="40.54" y="20.428" size="0.8128" layer="27" rot="R270"/>
+</element>
+<element name="C10" library="vyber_stara_nemenit" package="0402" value="100n" x="25.908" y="21.717" smashed="yes" rot="R270">
+<attribute name="NAME" x="27.157" y="20.678" size="0.8" layer="25" rot="R90"/>
+<attribute name="VALUE" x="24.511" y="23.622" size="0.8128" layer="27" rot="R270"/>
+</element>
+<element name="C11" library="vyber_stara_nemenit" package="0402" value="1n" x="41.95" y="9.2" smashed="yes" rot="R90">
+<attribute name="NAME" x="41.515" y="8.195" size="0.8" layer="25" rot="R90"/>
+<attribute name="VALUE" x="43.347" y="7.295" size="0.8128" layer="27" rot="R90"/>
+</element>
+<element name="R8" library="vyber_stara_nemenit" package="0603" value="MF-FSMF020X-2" x="21.336" y="23.741" rot="R180"/>
+<element name="C12" library="vyber_stara_nemenit" package="0805_REFLOW" value="2u2" x="22.006" y="8.843" smashed="yes">
+<attribute name="NAME" x="20.9535" y="9.7270625" size="0.8" layer="25"/>
+<attribute name="VALUE" x="21.0535" y="8.3270625" size="1.016" layer="27"/>
+</element>
+<element name="C13" library="vyber_stara_nemenit" package="0805_REFLOW" value="2u2" x="29.464" y="22.86" smashed="yes" rot="R180">
+<attribute name="NAME" x="30.6165" y="24.4759375" size="0.8" layer="25" rot="R180"/>
+<attribute name="VALUE" x="30.4165" y="23.3759375" size="1.016" layer="27" rot="R180"/>
+</element>
+<element name="IC5" library="vyber_stara_nemenit" package="WSON-8_3X3MM" value="TPS61043" x="36.325" y="28.575" smashed="yes" rot="R270">
+<attribute name="NAME" x="35.675" y="28.9" size="0.8128" layer="25"/>
+<attribute name="VALUE" x="33.3" y="30.9" size="0.8128" layer="27" rot="R270"/>
+</element>
+<element name="L1" library="trezor" package="L_2.5X2.0" value="4u7 VLS252008ET-4R7M" x="32.385" y="30.607" smashed="yes" rot="R90">
+<attribute name="NAME" x="34.643" y="33.385" size="1.27" layer="25" rot="R180"/>
+<attribute name="VALUE" x="34.985" y="28.207" size="1.27" layer="27" rot="R90"/>
+</element>
+<element name="D6" library="vyber_stara_nemenit" package="SOD323F" value="PMEG4005" x="38.357" y="32.131" smashed="yes">
+<attribute name="NAME" x="39.544" y="32.7355" size="1.016" layer="25"/>
+<attribute name="VALUE" x="35.944" y="33.274" size="1.016" layer="27"/>
+</element>
+<element name="C14" library="vyber_stara_nemenit" package="0805_REFLOW" value="4u7/16V" x="31.75" y="27.178" smashed="yes" rot="R270">
+<attribute name="NAME" x="32.7305" y="25.9659375" size="0.8" layer="25" rot="R180"/>
+<attribute name="VALUE" x="31.2340625" y="28.1305" size="1.016" layer="27" rot="R270"/>
+</element>
+<element name="C15" library="vyber_stara_nemenit" package="0805_REFLOW" value="4u7/16V" x="40.55" y="29.65" smashed="yes" rot="R90">
+<attribute name="NAME" x="42.2659375" y="28.6975" size="0.8" layer="25" rot="R90"/>
+<attribute name="VALUE" x="41.0659375" y="28.6975" size="1.016" layer="27" rot="R90"/>
+</element>
+<element name="C16" library="vyber_stara_nemenit" package="0402" value="100n" x="33.277" y="27.686" smashed="yes" rot="R90">
+<attribute name="NAME" x="34.442" y="26.681" size="0.8" layer="25" rot="R90"/>
+<attribute name="VALUE" x="34.674" y="25.781" size="0.8128" layer="27" rot="R90"/>
+</element>
+<element name="R14" library="vyber_stara_nemenit" package="0402" value="27R" x="35.309" y="25.908" smashed="yes" rot="R180">
+<attribute name="NAME" x="34.827" y="25.714" size="0.8" layer="25" rot="R270"/>
+<attribute name="VALUE" x="37.214" y="27.305" size="0.8128" layer="27" rot="R180"/>
+</element>
+<element name="R25" library="vyber_stara_nemenit" package="0402" value="0R" x="39.173" y="29.972" smashed="yes" rot="R270">
+<attribute name="NAME" x="37.808" y="31.277" size="0.8" layer="25" rot="R270"/>
+<attribute name="VALUE" x="37.776" y="31.877" size="0.8128" layer="27" rot="R270"/>
+</element>
+<element name="R26" library="vyber_stara_nemenit" package="0402" value="N.C." x="39.173" y="27.813" smashed="yes" rot="R270">
+<attribute name="NAME" x="39.682" y="27.308" size="0.8" layer="25"/>
+<attribute name="VALUE" x="37.776" y="29.718" size="0.8128" layer="27" rot="R270"/>
+</element>
+<element name="R9" library="vyber_stara_nemenit" package="0402" value="330R" x="37.849" y="25.577" smashed="yes" rot="R90">
+<attribute name="NAME" x="37.414" y="24.972" size="0.8" layer="25" rot="R90"/>
+<attribute name="VALUE" x="39.246" y="23.672" size="0.8128" layer="27" rot="R90"/>
+</element>
+<element name="IC6" library="trezor" package="SOT89-5" value="XC6210B332PR" x="25.527" y="25.4" smashed="yes" rot="R180">
+<attribute name="NAME" x="26.927" y="29.35" size="1.27" layer="25" rot="R180"/>
+<attribute name="VALUE" x="27.827" y="22.55" size="1.27" layer="27" rot="R180"/>
+</element>
+<element name="R10" library="vyber_stara_nemenit" package="0402" value="68R" x="38.965" y="25.577" smashed="yes" rot="R90">
+<attribute name="NAME" x="40.23" y="24.472" size="0.8" layer="25" rot="R90"/>
+<attribute name="VALUE" x="40.362" y="23.672" size="0.8128" layer="27" rot="R90"/>
+</element>
+<element name="K5" library="trezor" package="SWD" value="SWD" x="38.882" y="1.8" rot="R180"/>
+<element name="C20" library="vyber_stara_nemenit" package="0402" value="100n" x="40.9" y="6" smashed="yes" rot="R270">
+<attribute name="NAME" x="39.735" y="7.205" size="0.8" layer="25" rot="R270"/>
+<attribute name="VALUE" x="39.503" y="7.905" size="0.8128" layer="27" rot="R270"/>
+</element>
+<element name="L2" library="vyber_stara_nemenit" package="0603_REFLOW" value="BLM18AG102SN1D" x="45" y="15.951" smashed="yes" rot="R180">
+<attribute name="NAME" x="45.47" y="15.329003125" size="0.8" layer="25" rot="R180"/>
+<attribute name="VALUE" x="46.397" y="15.062003125" size="0.8128" layer="27" rot="R180"/>
+</element>
+<element name="C21" library="vyber_stara_nemenit" package="0402" value="100n" x="44.397" y="14.321" smashed="yes" rot="R90">
+<attribute name="NAME" x="43.962" y="13.215996875" size="0.8" layer="25" rot="R90"/>
+<attribute name="VALUE" x="45.794" y="12.415996875" size="0.8128" layer="27" rot="R90"/>
+</element>
+<element name="C22" library="vyber_stara_nemenit" package="0603_REFLOW" value="1u" x="51.2" y="15.4" smashed="yes">
+<attribute name="NAME" x="50.03" y="14.992" size="0.8" layer="25"/>
+<attribute name="VALUE" x="49.803" y="15.019" size="0.8128" layer="27"/>
+</element>
+<element name="TP3" library="vyber_stara_nemenit" package="MB1.5" value="" x="49.3" y="2.95" smashed="yes">
+<attribute name="NAME" x="46.425" y="3.5375" size="1" layer="37" ratio="15"/>
+</element>
+<element name="TP7" library="vyber_stara_nemenit" package="MB1.27" value="" x="41" y="32.05" smashed="yes">
+<attribute name="NAME" x="42.025" y="31.8375" size="1" layer="37" ratio="15"/>
+</element>
+<element name="TP9" library="vyber_stara_nemenit" package="MB1.27" value="" x="48.1" y="6.6" smashed="yes">
+<attribute name="NAME" x="48.625" y="7.1875" size="1" layer="37" ratio="15"/>
+</element>
+<element name="U$45" library="vyber_stara_nemenit" package="CENTR" value="" x="69.3" y="6.3"/>
+<element name="U$46" library="vyber_stara_nemenit" package="CENTR" value="" x="69.5" y="27.55"/>
+<element name="U$47" library="vyber_stara_nemenit" package="BADMARK" value="" x="66.675" y="20.32"/>
+<element name="R1" library="vyber_stara_nemenit" package="0402" value="22R" x="23.322" y="21.717" smashed="yes" rot="R90">
+<attribute name="NAME" x="23.587" y="19.812" size="0.8" layer="25" rot="R90"/>
+<attribute name="VALUE" x="24.719" y="19.812" size="0.8128" layer="27" rot="R90"/>
+</element>
+<element name="R11" library="vyber_stara_nemenit" package="0402" value="N.C." x="24.465" y="21.717" smashed="yes" rot="R90">
+<attribute name="NAME" x="24.93" y="19.112" size="0.8" layer="25" rot="R90"/>
+<attribute name="VALUE" x="25.862" y="19.812" size="0.8128" layer="27" rot="R90"/>
+</element>
+<element name="K4" library="trezor" package="DF37NB-24DS-0.4V" value="DF37NB-24DS-0.4V" x="60.752" y="5.842" smashed="yes">
+<attribute name="NAME" x="58.269" y="7.647" size="1.016" layer="25"/>
+<attribute name="VALUE" x="57.069" y="7.747" size="1.016" layer="27"/>
+</element>
+<element name="C18" library="vyber_stara_nemenit" package="0402" value="100n" x="63.1" y="10.8" smashed="yes" rot="R270">
+<attribute name="NAME" x="63.635" y="11.905" size="0.8" layer="25" rot="R270"/>
+<attribute name="VALUE" x="61.703" y="12.705" size="0.8128" layer="27" rot="R270"/>
+</element>
+<element name="K6" library="trezor" package="DF37NB-10DS-0.4V" value="DF37NB-10DS-0.4V" x="65.105" y="27.405" smashed="yes" rot="R270">
+<attribute name="NAME" x="66.61" y="28.272" size="1.016" layer="25" rot="R270"/>
+<attribute name="VALUE" x="67.01" y="30.072" size="1.016" layer="27" rot="R270"/>
+</element>
+<element name="C19" library="vyber_stara_nemenit" package="0603_REFLOW" value="1u" x="66.3" y="31.3" smashed="yes" rot="R90">
+<attribute name="NAME" x="66.708" y="30.13" size="0.8" layer="25" rot="R90"/>
+<attribute name="VALUE" x="66.681" y="29.903" size="0.8128" layer="27" rot="R90"/>
+</element>
+<element name="C24" library="vyber_stara_nemenit" package="0402" value="100n" x="67.9" y="30.375" smashed="yes">
+<attribute name="NAME" x="66.395" y="29.11" size="0.8" layer="25"/>
+<attribute name="VALUE" x="65.995" y="28.978" size="0.8128" layer="27"/>
+</element>
+<element name="R13" library="vyber_stara_nemenit" package="0402" value="100R" x="65.9" y="24.4" smashed="yes" rot="R180">
+<attribute name="NAME" x="66.905" y="23.865" size="0.8" layer="25" rot="R180"/>
+<attribute name="VALUE" x="67.805" y="25.797" size="0.8128" layer="27" rot="R180"/>
+</element>
+<element name="R12" library="vyber_stara_nemenit" package="0402" value="10k" x="67.5" y="27.6" smashed="yes" rot="R270">
+<attribute name="NAME" x="67.699" y="24.729" size="0.8" layer="25" rot="R90"/>
+<attribute name="VALUE" x="66.103" y="29.505" size="0.8128" layer="27" rot="R270"/>
+</element>
+<element name="L3" library="vyber_stara_nemenit" package="0603_REFLOW" value="BLM18AG102SN1D" x="65" y="31.3" smashed="yes" rot="R90">
+<attribute name="NAME" x="65.955" y="33.093" size="0.8" layer="25" rot="R180"/>
+<attribute name="VALUE" x="64.111" y="29.903" size="0.8128" layer="27" rot="R90"/>
+</element>
+<element name="R15" library="vyber_stara_nemenit" package="0402" value="1k5" x="60.9" y="27.4" smashed="yes" rot="R180">
+<attribute name="NAME" x="63.705" y="27.965" size="0.8" layer="25" rot="R180"/>
+<attribute name="VALUE" x="62.805" y="28.797" size="0.8128" layer="27" rot="R180"/>
+</element>
+<element name="R16" library="vyber_stara_nemenit" package="0402" value="1k5" x="60.9" y="26.2" smashed="yes" rot="R180">
+<attribute name="NAME" x="63.705" y="26.565" size="0.8" layer="25" rot="R180"/>
+<attribute name="VALUE" x="62.805" y="27.597" size="0.8128" layer="27" rot="R180"/>
+</element>
+<element name="L4" library="vyber_stara_nemenit" package="0603_REFLOW" value="BLM18AG102SN1D" x="64.9" y="10.6" smashed="yes">
+<attribute name="NAME" x="62.53" y="10.222" size="0.8" layer="25"/>
+<attribute name="VALUE" x="63.503" y="11.489" size="0.8128" layer="27"/>
+</element>
+<element name="TP4" library="vyber_stara_nemenit" package="MB1.27" value="" x="57.85" y="13" smashed="yes">
+<attribute name="NAME" x="54.975" y="11.2875" size="1" layer="37" ratio="15"/>
+</element>
+<element name="U$48" library="vyber_stara_nemenit" package="CENTR" value="" x="29.047" y="31.291"/>
+<element name="U$49" library="vyber_stara_nemenit" package="CENTR" value="" x="51.7" y="1.8"/>
+<element name="TP5" library="vyber_stara_nemenit" package="MB1.5" value="" x="27.9" y="29.3" smashed="yes">
+<attribute name="NAME" x="24.325" y="28.1875" size="1" layer="37" ratio="15"/>
+</element>
+<element name="U$53" library="vyber_stara_nemenit" package="RAM_BRD_ENG" value="" x="-97.85" y="-86.1"/>
+<element name="U$54" library="trezor" package="LAYER_STACK_4_LAYERS" value="" x="129.846" y="75.735"/>
+<element name="K1" library="trezor" package="USB_C_JAE_DX07B024XJ1" value="DX07B024XJ1R1300" x="13.6" y="17" rot="R270"/>
+<element name="R4" library="vyber_stara_nemenit" package="0402" value="5k1" x="22.6" y="20.2" smashed="yes" rot="R180">
+<attribute name="NAME" x="23.105" y="21.365" size="0.8" layer="25" rot="R180"/>
+<attribute name="VALUE" x="24.505" y="21.597" size="0.8128" layer="27" rot="R180"/>
+</element>
+<element name="R5" library="vyber_stara_nemenit" package="0402" value="5k1" x="19.304" y="10.414" smashed="yes" rot="R90">
+<attribute name="NAME" x="19.669" y="8.309" size="0.8" layer="25" rot="R90"/>
+<attribute name="VALUE" x="20.701" y="8.509" size="0.8128" layer="27" rot="R90"/>
+</element>
+<element name="R6" library="vyber_stara_nemenit" package="0402" value="1M" x="16.383" y="10.414" smashed="yes" rot="R90">
+<attribute name="NAME" x="15.848" y="9.809" size="0.8" layer="25" rot="R90"/>
+<attribute name="VALUE" x="17.78" y="8.509" size="0.8128" layer="27" rot="R90"/>
+</element>
+<element name="C1" library="vyber_stara_nemenit" package="0402" value="1n" x="17.526" y="10.414" smashed="yes" rot="R90">
+<attribute name="NAME" x="17.891" y="8.409" size="0.8" layer="25" rot="R90"/>
+<attribute name="VALUE" x="18.923" y="8.509" size="0.8128" layer="27" rot="R90"/>
+</element>
+<element name="R7" library="vyber_stara_nemenit" package="0402" value="1M" x="17.272" y="23.622" smashed="yes" rot="R270">
+<attribute name="NAME" x="16.907" y="25.827" size="0.8" layer="25" rot="R270"/>
+<attribute name="VALUE" x="15.875" y="25.527" size="0.8128" layer="27" rot="R270"/>
+</element>
+<element name="C25" library="vyber_stara_nemenit" package="0402" value="1n" x="16.129" y="23.622" smashed="yes" rot="R270">
+<attribute name="NAME" x="14.864" y="24.927" size="0.8" layer="25" rot="R270"/>
+<attribute name="VALUE" x="14.732" y="25.527" size="0.8128" layer="27" rot="R270"/>
+</element>
+<element name="TP6" library="vyber_stara_nemenit" package="MB1.27" value="" x="41" y="26.3" smashed="yes">
+<attribute name="NAME" x="41.925" y="25.8875" size="1" layer="37" ratio="15"/>
+</element>
+<element name="D2" library="DZ" package="SOD882D" value="PESD5V0F1BLD" x="20.8" y="14" smashed="yes" rot="R90">
+<attribute name="NAME" x="21.065" y="13.511" size="0.6096" layer="25" rot="R90"/>
+<attribute name="VALUE" x="22.07" y="13.111" size="0.6096" layer="27" rot="R90"/>
+</element>
+<element name="D4" library="DZ" package="SOD882D" value="PESD5V0F1BLD" x="22.1" y="14" smashed="yes" rot="R90">
+<attribute name="NAME" x="22.365" y="13.511" size="0.6096" layer="25" rot="R90"/>
+<attribute name="VALUE" x="23.37" y="13.111" size="0.6096" layer="27" rot="R90"/>
+</element>
+<element name="TP10" library="vyber_stara_nemenit" package="MB1.5" value="" x="41" y="21.3" smashed="yes">
+<attribute name="NAME" x="41.925" y="20.7875" size="1" layer="37" ratio="15"/>
+</element>
+<element name="TP11" library="vyber_stara_nemenit" package="MB1.5" value="" x="41" y="23.8" smashed="yes">
+<attribute name="NAME" x="41.925" y="23.2875" size="1" layer="37" ratio="15"/>
+</element>
+<element name="U$56" library="vyber_stara_nemenit" package="CENTR" value="" x="69.3" y="6.3" rot="MR0"/>
+<element name="U$57" library="vyber_stara_nemenit" package="CENTR" value="" x="29.047" y="31.291" rot="MR0"/>
+<element name="C26" library="vyber_stara_nemenit" package="0402" value="100n" x="61.95" y="10.8" rot="R270"/>
+<element name="TP12" library="vyber_stara_nemenit" package="MB1.27" value="" x="31.3" y="24.65" smashed="yes">
+<attribute name="NAME" x="29.825" y="22.9375" size="1" layer="37" ratio="15"/>
+</element>
+<element name="TP13" library="vyber_stara_nemenit" package="MB1.27" value="" x="19.677" y="8.608" smashed="yes">
+<attribute name="NAME" x="19.502" y="6.9955" size="1" layer="37" ratio="15"/>
+</element>
+<element name="C28" library="vyber_stara_nemenit" package="0402" value="100n" x="40.05" y="3.65" rot="R90"/>
+<element name="C29" library="vyber_stara_nemenit" package="0402" value="100n" x="23.15" y="6.2"/>
+<element name="C30" library="vyber_stara_nemenit" package="0402" value="10n" x="36.7" y="22.9" rot="R270"/>
+<element name="C31" library="vyber_stara_nemenit" package="0402" value="100n" x="42.1" y="11.85" rot="R90"/>
+<element name="C32" library="vyber_stara_nemenit" package="0402" value="10n" x="43.15" y="7.85" rot="R90"/>
+<element name="C33" library="vyber_stara_nemenit" package="0402" value="1n" x="35.6" y="22.9" rot="R270"/>
+<element name="C34" library="vyber_stara_nemenit" package="0805_REFLOW" value="2u2" x="33.5" y="22.8"/>
+<element name="R18" library="vyber_stara_nemenit" package="0402" value="68R" x="56.4" y="17.8" rot="R270"/>
+<element name="C36" library="vyber_stara_nemenit" package="0402" value="47p" x="57.55" y="16.8" rot="R270"/>
+<element name="R19" library="vyber_stara_nemenit" package="0402" value="68R" x="46.8" y="18.5" rot="R90"/>
+<element name="C37" library="vyber_stara_nemenit" package="0402" value="47p" x="45.6" y="18.5" rot="R270"/>
+<element name="R20" library="vyber_stara_nemenit" package="0402" value="68R" x="48.7" y="17.8" rot="R270"/>
+<element name="C38" library="vyber_stara_nemenit" package="0402" value="47p" x="47.15" y="16.95" rot="R180"/>
+<element name="R21" library="vyber_stara_nemenit" package="0402" value="68R" x="49.9" y="17.8" rot="R270"/>
+<element name="C39" library="vyber_stara_nemenit" package="0402" value="47p" x="49" y="15.9" rot="R180"/>
+<element name="R22" library="vyber_stara_nemenit" package="0402" value="68R" x="53.05" y="17.8" rot="R270"/>
+<element name="C40" library="vyber_stara_nemenit" package="0402" value="47p" x="53.45" y="16.25"/>
+<element name="C41" library="vyber_stara_nemenit" package="0402" value="100n" x="42.35" y="15.75" rot="R180"/>
+<element name="C42" library="vyber_stara_nemenit" package="0402" value="10n" x="42.35" y="14.55" rot="R180"/>
+<element name="C27" library="vyber_stara_nemenit" package="0402" value="100n" x="51.5" y="16.65"/>
+<element name="R23" library="vyber_stara_nemenit" package="0402" value="68R" x="55.2" y="17.8" rot="R270"/>
+<element name="C43" library="vyber_stara_nemenit" package="0402" value="47p" x="55.8" y="16.25"/>
+<element name="C44" library="vyber_stara_nemenit" package="0402" value="100n" x="44.35" y="7.85" rot="R90"/>
+<element name="C45" library="vyber_stara_nemenit" package="0805_REFLOW" value="2u2" x="45.8" y="7.15" rot="R90"/>
+<element name="C46" library="vyber_stara_nemenit" package="0402" value="1n" x="37.65" y="3.65" rot="R90"/>
+<element name="C47" library="vyber_stara_nemenit" package="0402" value="10n" x="60.8" y="10.8" rot="R270"/>
+<element name="C49" library="vyber_stara_nemenit" package="0402" value="10n" x="67.9" y="29.2"/>
+<element name="TP1" library="vyber_stara_nemenit" package="MB1.27" value="" x="23.1" y="10.5" smashed="yes">
+<attribute name="NAME" x="21.425" y="11.3875" size="1" layer="37" ratio="15"/>
+</element>
+<element name="TP2" library="vyber_stara_nemenit" package="MB1.27" value="" x="30.95" y="2.85" smashed="yes">
+<attribute name="NAME" x="29.575" y="0.9375" size="1" layer="37" ratio="15"/>
+</element>
+<element name="TP8" library="vyber_stara_nemenit" package="MB1.27" value="" x="33.5" y="3.85" smashed="yes">
+<attribute name="NAME" x="32.125" y="4.7375" size="1" layer="37" ratio="15"/>
+</element>
+<element name="TP14" library="vyber_stara_nemenit" package="MB1.27" value="" x="41.5" y="2" smashed="yes">
+<attribute name="NAME" x="41.925" y="0.3875" size="1" layer="37" ratio="15"/>
+</element>
+<element name="TP19" library="trezor" package="MB_1.00" value="" x="19.1" y="23.7" smashed="yes">
+<attribute name="NAME" x="19.4" y="25" size="1" layer="37" ratio="15" align="center"/>
+</element>
+<element name="TP20" library="trezor" package="MB_1.00" value="" x="20.6" y="10.9" smashed="yes">
+<attribute name="NAME" x="18.6" y="10" size="1" layer="37" ratio="15" align="center"/>
+</element>
+<element name="C17" library="vyber_stara_nemenit" package="0805_REFLOW" value="2u2" x="51.65" y="11"/>
+<element name="C35" library="vyber_stara_nemenit" package="0805_REFLOW" value="2u2" x="51.65" y="9.25"/>
+<element name="C51" library="vyber_stara_nemenit" package="0805_REFLOW" value="2u2" x="54.8" y="9.25" rot="R180"/>
+<element name="C52" library="vyber_stara_nemenit" package="0603_REFLOW" value="1u" x="22.85" y="7.4"/>
+<element name="C23" library="vyber_stara_nemenit" package="0402" value="10n" x="51.5" y="17.85"/>
+<element name="C53" library="vyber_stara_nemenit" package="0603_REFLOW" value="1u" x="51.5" y="12.55"/>
+<element name="C54" library="vyber_stara_nemenit" package="0603_REFLOW" value="1u" x="35.75" y="4.1" rot="R180"/>
+<element name="C55" library="vyber_stara_nemenit" package="0402" value="100n" x="47.7" y="4.6" rot="R90"/>
+<element name="C56" library="vyber_stara_nemenit" package="0603_REFLOW" value="1u" x="44.1" y="17.9" rot="R90"/>
+<element name="T1" library="trezor" package="SOT23_REFLOW" value="DMG3415U-7" x="54.65" y="14.1" rot="R270"/>
+<element name="R2" library="vyber_stara_nemenit" package="0402" value="470k" x="54.1" y="11.85" rot="R180"/>
+<element name="C57" library="vyber_stara_nemenit" package="0402" value="220p" x="55.25" y="10.7" rot="R180"/>
+<element name="R3" library="vyber_stara_nemenit" package="0402" value="22k" x="55.95" y="12.25" rot="R270"/>
+<element name="T2" library="trezor" package="SOT23_REFLOW" value="DMG3415U-7" x="61.4" y="30.5" rot="R180"/>
+<element name="R17" library="vyber_stara_nemenit" package="0402" value="470k" x="59" y="27" rot="R270"/>
+<element name="IC1" library="trezor" package="SOT23_MEDIUM_SIZE" value="MIC803-29D2VC3" x="46" y="2.65" rot="R270"/>
+<element name="TP15" library="vyber_stara_nemenit" package="MB1.27" value="" x="51.5" y="13.95" smashed="yes">
+<attribute name="NAME" x="48.325" y="15.5375" size="1" layer="37" ratio="15"/>
+</element>
+<element name="TP16" library="vyber_stara_nemenit" package="MB1.27" value="" x="68.4" y="31.8" smashed="yes">
+<attribute name="NAME" x="65.225" y="33.3875" size="1" layer="37" ratio="15"/>
+</element>
+<element name="C48" library="vyber_stara_nemenit" package="0402" value="100n" x="57.1" y="14.725" rot="R90"/>
+<element name="R24" library="vyber_stara_nemenit" package="0402" value="22k" x="59" y="24.5" rot="R270"/>
+<element name="C50" library="vyber_stara_nemenit" package="0402" value="220p" x="60.9" y="25" rot="R180"/>
+<element name="C58" library="vyber_stara_nemenit" package="0402" value="1n" x="63.575" y="31" rot="R270"/>
+</elements>
+<signals>
+<signal name="VCC">
+<contactref element="C4" pad="2"/>
+<contactref element="R8" pad="1"/>
+<contactref element="IC5" pad="3"/>
+<contactref element="C14" pad="1"/>
+<contactref element="C16" pad="P$2"/>
+<contactref element="L1" pad="1"/>
+<contactref element="IC6" pad="4"/>
+<contactref element="IC6" pad="1"/>
+<contactref element="R1" pad="P$2"/>
+<wire x1="34.85" y1="28.25" x2="33.333" y2="28.25" width="0.254" layer="1"/>
+<wire x1="33.333" y1="28.25" x2="33.277" y2="28.194" width="0.254" layer="1"/>
+<wire x1="33.277" y1="28.194" x2="31.816" y2="28.194" width="0.3048" layer="1"/>
+<wire x1="31.816" y1="28.194" x2="31.75" y2="28.128" width="0.3048" layer="1"/>
+<wire x1="24.027" y1="23.55" x2="23.876" y2="23.55" width="0.3048" layer="1"/>
+<wire x1="27.027" y1="27.25" x2="27.051" y2="27.274" width="0.3048" layer="1"/>
+<wire x1="27.051" y1="27.274" x2="27.051" y2="27.305" width="0.3048" layer="1"/>
+<via x="27.051" y="28.448" extent="1-16" drill="0.3"/>
+<wire x1="27.051" y1="28.448" x2="23.114" y2="24.511" width="0.6556" layer="16"/>
+<wire x1="23.114" y1="24.511" x2="23.114" y2="24.003" width="0.6556" layer="16"/>
+<via x="23.114" y="24.003" extent="1-16" drill="0.3"/>
+<wire x1="27.051" y1="28.448" x2="27.94" y2="29.337" width="0.6556" layer="16"/>
+<wire x1="27.94" y1="29.337" x2="30.861" y2="29.337" width="0.6556" layer="16"/>
+<via x="30.861" y="29.337" extent="1-16" drill="0.3"/>
+<wire x1="32.385" y1="29.357" x2="33.147" y2="29.357" width="0.3048" layer="1"/>
+<wire x1="33.147" y1="29.357" x2="33.147" y2="28.194" width="0.3048" layer="1"/>
+<wire x1="33.147" y1="28.194" x2="33.277" y2="28.194" width="0.3048" layer="1"/>
+<wire x1="30.861" y1="29.337" x2="32.385" y2="29.337" width="0.3048" layer="1"/>
+<wire x1="32.385" y1="29.337" x2="32.385" y2="29.357" width="0.3048" layer="1"/>
+<contactref element="TP5" pad="1"/>
+<wire x1="22.136" y1="23.741" x2="22.136" y2="24.003" width="0.3" layer="1"/>
+<wire x1="22.136" y1="24.003" x2="23.114" y2="24.003" width="0.3" layer="1"/>
+<wire x1="23.114" y1="24.003" x2="24.027" y2="24.003" width="0.3" layer="1"/>
+<wire x1="24.027" y1="24.003" x2="24.027" y2="23.55" width="0.3" layer="1"/>
+<wire x1="23.322" y1="22.225" x2="23.322" y2="22.672" width="0.2032" layer="1"/>
+<wire x1="23.322" y1="22.672" x2="23.55" y2="22.9" width="0.2032" layer="1"/>
+<wire x1="23.55" y1="22.9" x2="24.027" y2="22.9" width="0.2032" layer="1"/>
+<wire x1="24.027" y1="22.9" x2="24.027" y2="23.55" width="0.2032" layer="1"/>
+<wire x1="22.136" y1="23.741" x2="22.1" y2="23.741" width="0.3" layer="1"/>
+<wire x1="22.1" y1="23.741" x2="22.1" y2="25.1" width="0.3" layer="1"/>
+<wire x1="27.9" y1="29.3" x2="27.9" y2="29.297" width="0.2032" layer="1"/>
+<wire x1="27.9" y1="29.297" x2="27.051" y2="28.448" width="0.2032" layer="1"/>
+<via x="23.114" y="23.353" extent="1-16" drill="0.3"/>
+<wire x1="23.114" y1="23.353" x2="23.114" y2="24.003" width="0.6556" layer="1"/>
+<wire x1="23.114" y1="23.353" x2="23.114" y2="24.003" width="0.6556" layer="16"/>
+<via x="28.956" y="29.337" extent="1-16" drill="0.3"/>
+<wire x1="28.956" y1="29.337" x2="27.94" y2="29.337" width="0.6556" layer="1"/>
+<wire x1="27.94" y1="29.337" x2="27.051" y2="28.448" width="0.6556" layer="1"/>
+<wire x1="27.051" y1="28.448" x2="27.051" y2="27.305" width="0.6556" layer="1"/>
+<via x="30.861" y="30.099" extent="1-16" drill="0.3"/>
+<wire x1="30.861" y1="30.099" x2="30.861" y2="29.337" width="0.6556" layer="1"/>
+<wire x1="30.861" y1="30.099" x2="30.861" y2="29.337" width="0.6556" layer="16"/>
+</signal>
+<signal name="GND">
+<contactref element="D3" pad="1"/>
+<contactref element="K3" pad="GND@1"/>
+<contactref element="K3" pad="GND@2"/>
+<contactref element="K3" pad="GND@3"/>
+<contactref element="C4" pad="1"/>
+<contactref element="C5" pad="1"/>
+<contactref element="IC2" pad="99"/>
+<contactref element="IC2" pad="27"/>
+<contactref element="IC2" pad="74"/>
+<contactref element="K3" pad="GND@4"/>
+<contactref element="K3" pad="6"/>
+<contactref element="C12" pad="1"/>
+<contactref element="C13" pad="1"/>
+<contactref element="IC5" pad="6"/>
+<contactref element="C16" pad="P$1"/>
+<contactref element="R26" pad="P$2"/>
+<contactref element="C15" pad="1"/>
+<contactref element="C14" pad="2"/>
+<contactref element="R14" pad="P$1"/>
+<contactref element="IC5" pad="EP$2"/>
+<contactref element="IC5" pad="EP"/>
+<contactref element="IC5" pad="EP$4"/>
+<contactref element="IC5" pad="EP$1"/>
+<contactref element="IC5" pad="EP$3"/>
+<contactref element="IC6" pad="2"/>
+<contactref element="C20" pad="P$1"/>
+<contactref element="IC2" pad="94"/>
+<contactref element="X1" pad="4"/>
+<contactref element="C2" pad="P$1"/>
+<contactref element="X1" pad="2"/>
+<contactref element="C3" pad="P$1"/>
+<contactref element="K5" pad="GND"/>
+<contactref element="IC2" pad="20"/>
+<contactref element="C21" pad="P$1"/>
+<polygon width="0.2" layer="1" isolate="0.18" thermals="no" rank="2">
+<vertex x="12.319" y="34.925"/>
+<vertex x="12.319" y="-0.508"/>
+<vertex x="72.4" y="-0.508"/>
+<vertex x="72.4" y="34.925"/>
+</polygon>
+<polygon width="0.254" layer="2" isolate="0.3048" thermals="no" rank="2">
+<vertex x="12.319" y="34.798"/>
+<vertex x="12.319" y="-0.635"/>
+<vertex x="72.6" y="-0.635"/>
+<vertex x="72.6" y="34.798"/>
+</polygon>
+<contactref element="C22" pad="1"/>
+<polygon width="0.254" layer="16" isolate="0.2032" thermals="no" rank="2">
+<vertex x="12.319" y="34.925"/>
+<vertex x="12.319" y="-0.508"/>
+<vertex x="72.8" y="-0.508"/>
+<vertex x="72.8" y="34.925"/>
+</polygon>
+<contactref element="TP9" pad="1"/>
+<contactref element="R11" pad="P$2"/>
+<contactref element="IC2" pad="10"/>
+<contactref element="K4" pad="3"/>
+<contactref element="K4" pad="21"/>
+<contactref element="K4" pad="1"/>
+<contactref element="K4" pad="25"/>
+<contactref element="K4" pad="26"/>
+<contactref element="K4" pad="24"/>
+<contactref element="K4" pad="13"/>
+<contactref element="C18" pad="P$1"/>
+<contactref element="K6" pad="7"/>
+<contactref element="K6" pad="9"/>
+<contactref element="K6" pad="6"/>
+<contactref element="K6" pad="12"/>
+<contactref element="K6" pad="10"/>
+<contactref element="K6" pad="11"/>
+<contactref element="C19" pad="1"/>
+<contactref element="C24" pad="P$1"/>
+<via x="25.708" y="4.926" extent="1-16" drill="0.3"/>
+<via x="26.67" y="7.239" extent="1-16" drill="0.3"/>
+<via x="18.415" y="8.636" extent="1-16" drill="0.3"/>
+<via x="37.846" y="17.272" extent="1-16" drill="0.3"/>
+<via x="34.3" y="18.9" extent="1-16" drill="0.3"/>
+<via x="32.912" y="9.533" extent="1-16" drill="0.3"/>
+<wire x1="58.552" y1="7.192" x2="58.552" y2="6.645" width="0.2032" layer="1"/>
+<wire x1="58.552" y1="6.645" x2="58.72" y2="6.477" width="0.2032" layer="1"/>
+<wire x1="58.72" y1="6.477" x2="59.609" y2="6.477" width="0.2032" layer="1"/>
+<wire x1="59.609" y1="6.477" x2="59.736" y2="6.604" width="0.2032" layer="1"/>
+<wire x1="59.736" y1="6.604" x2="59.736" y2="7.176" width="0.2032" layer="1"/>
+<wire x1="59.736" y1="7.176" x2="59.752" y2="7.192" width="0.2032" layer="1"/>
+<wire x1="58.552" y1="4.492" x2="58.552" y2="4.105" width="0.2032" layer="1"/>
+<wire x1="58.552" y1="4.105" x2="58.72" y2="3.937" width="0.2032" layer="1"/>
+<wire x1="58.72" y1="3.937" x2="59.228" y2="3.937" width="0.2032" layer="1"/>
+<wire x1="59.352" y1="4.492" x2="59.352" y2="4.061" width="0.2032" layer="1"/>
+<wire x1="59.352" y1="4.061" x2="59.228" y2="3.937" width="0.2032" layer="1"/>
+<via x="37.211" y="8.128" extent="1-16" drill="0.3"/>
+<via x="42.926" y="0.889" extent="1-16" drill="0.3"/>
+<via x="45.085" y="33.147" extent="1-16" drill="0.3"/>
+<polygon width="0.254" layer="15" isolate="0.3048" thermals="no" rank="3">
+<vertex x="12.319" y="34.544"/>
+<vertex x="12.319" y="-0.762"/>
+<vertex x="73" y="-0.762"/>
+<vertex x="73" y="34.544"/>
+</polygon>
+<via x="52.451" y="33.147" extent="1-16" drill="0.3"/>
+<via x="67.6" y="10.647" extent="1-16" drill="0.3"/>
+<via x="59.055" y="33.147" extent="1-16" drill="0.3"/>
+<via x="34.544" y="33.147" extent="1-16" drill="0.3"/>
+<via x="25.781" y="29.21" extent="1-16" drill="0.3"/>
+<via x="48.387" y="0.889" extent="1-16" drill="0.3"/>
+<via x="67.6" y="17.018" extent="1-16" drill="0.3"/>
+<via x="67.6" y="23.311" extent="1-16" drill="0.3"/>
+<via x="49.6" y="9.9" extent="1-16" drill="0.3"/>
+<via x="52.491" y="27.003" extent="1-16" drill="0.3"/>
+<wire x1="36.65" y1="30" x2="36.65" y2="28.575" width="0.254" layer="1"/>
+<wire x1="36.325" y1="28.575" x2="36.65" y2="28.575" width="0.254" layer="1"/>
+<wire x1="36.65" y1="28.575" x2="36.65" y2="28.194" width="0.254" layer="1"/>
+<wire x1="36.65" y1="28.194" x2="36.65" y2="27.15" width="0.254" layer="1"/>
+<via x="36.325" y="31.215" extent="1-16" drill="0.3"/>
+<contactref element="K1" pad="B12"/>
+<contactref element="K1" pad="B1"/>
+<contactref element="K1" pad="A1"/>
+<contactref element="K1" pad="A12"/>
+<contactref element="R4" pad="P$1"/>
+<contactref element="R5" pad="P$1"/>
+<contactref element="C1" pad="P$1"/>
+<contactref element="R6" pad="P$1"/>
+<contactref element="C25" pad="P$1"/>
+<contactref element="R7" pad="P$1"/>
+<wire x1="24.465" y1="22.225" x2="25.781" y2="22.225" width="0.2032" layer="1"/>
+<wire x1="25.781" y1="22.225" x2="25.781" y2="24.511" width="0.254" layer="1"/>
+<wire x1="25.781" y1="24.511" x2="25.527" y2="24.511" width="0.2032" layer="1"/>
+<wire x1="25.527" y1="24.511" x2="25.527" y2="25.4" width="0.2032" layer="1"/>
+<wire x1="16.129" y1="24.13" x2="18.034" y2="24.13" width="0.254" layer="1"/>
+<wire x1="16.129" y1="24.13" x2="15.367" y2="24.13" width="0.254" layer="1"/>
+<wire x1="16.383" y1="9.906" x2="15.775" y2="9.906" width="0.254" layer="1"/>
+<wire x1="33.277" y1="27.178" x2="33.909" y2="27.178" width="0.254" layer="1"/>
+<wire x1="33.277" y1="27.178" x2="32.512" y2="27.178" width="0.254" layer="1"/>
+<via x="62.4" y="28.5" extent="1-16" drill="0.3"/>
+<wire x1="39.173" y1="27.305" x2="38.6842" y2="27.305" width="0.254" layer="1"/>
+<contactref element="D2" pad="1"/>
+<contactref element="D4" pad="1"/>
+<wire x1="35.817" y1="25.908" x2="35.814" y2="25.905" width="0.2032" layer="1"/>
+<wire x1="35.814" y1="25.905" x2="35.814" y2="25.146" width="0.2032" layer="1"/>
+<wire x1="36" y1="27.15" x2="36" y2="26.475" width="0.2032" layer="1"/>
+<wire x1="36" y1="26.475" x2="35.941" y2="26.416" width="0.2032" layer="1"/>
+<wire x1="35.941" y1="26.416" x2="35.941" y2="26.032" width="0.2032" layer="1"/>
+<wire x1="35.941" y1="26.032" x2="35.817" y2="25.908" width="0.2032" layer="1"/>
+<wire x1="37.8" y1="28.25" x2="36.706" y2="28.25" width="0.2032" layer="1"/>
+<wire x1="36.706" y1="28.25" x2="36.65" y2="28.194" width="0.2032" layer="1"/>
+<via x="23.7998" y="12.192" extent="1-16" drill="0.3"/>
+<via x="27.473" y="18.82" extent="1-16" drill="0.3"/>
+<wire x1="17.526" y1="9.906" x2="19.304" y2="9.906" width="0.254" layer="1"/>
+<wire x1="16.383" y1="9.906" x2="17.526" y2="9.906" width="0.254" layer="1"/>
+<wire x1="19.36" y1="19.75" x2="19.36" y2="19.8" width="0.2032" layer="1"/>
+<wire x1="19.36" y1="19.8" x2="18.15" y2="19.8" width="0.2032" layer="1"/>
+<wire x1="19.36" y1="14.25" x2="19.36" y2="14.2" width="0.2032" layer="1"/>
+<wire x1="19.36" y1="14.2" x2="18.15" y2="14.2" width="0.2032" layer="1"/>
+<wire x1="19.304" y1="9.906" x2="20" y2="9.906" width="0.254" layer="1"/>
+<wire x1="20" y1="9.906" x2="20" y2="9.9" width="0.254" layer="1"/>
+<contactref element="C26" pad="P$1"/>
+<via x="68.3" y="4.7" extent="1-16" drill="0.3"/>
+<contactref element="TP12" pad="1"/>
+<contactref element="TP13" pad="1"/>
+<via x="45.691" y="20.503" extent="1-16" drill="0.3"/>
+<via x="59.9" y="14" extent="1-16" drill="0.3"/>
+<via x="55.891" y="27.003" extent="1-16" drill="0.3"/>
+<via x="41.991" y="24.503" extent="1-16" drill="0.3"/>
+<via x="53.391" y="30.503" extent="1-16" drill="0.3"/>
+<via x="45.291" y="30.503" extent="1-16" drill="0.3"/>
+<via x="18.681" y="24.91" extent="1-16" drill="0.3"/>
+<contactref element="C34" pad="1"/>
+<contactref element="C33" pad="P$1"/>
+<contactref element="C30" pad="P$1"/>
+<contactref element="C7" pad="P$1"/>
+<contactref element="C36" pad="P$2"/>
+<contactref element="C37" pad="P$2"/>
+<contactref element="C38" pad="P$2"/>
+<contactref element="C39" pad="P$2"/>
+<contactref element="C40" pad="P$2"/>
+<contactref element="C42" pad="P$1"/>
+<contactref element="C41" pad="P$1"/>
+<via x="41.875" y="16.8" extent="1-2" drill="0.2"/>
+<wire x1="40.491" y1="11.835" x2="41.5" y2="11.835" width="0.2032" layer="1"/>
+<wire x1="41.5" y1="11.835" x2="41.5" y2="11.342" width="0.2032" layer="1"/>
+<contactref element="C27" pad="P$1"/>
+<contactref element="C43" pad="P$2"/>
+<via x="54.141" y="17.453" extent="1-16" drill="0.3"/>
+<via x="35.9" y="18.9" extent="1-16" drill="0.3"/>
+<via x="30.111" y="14.528" extent="1-16" drill="0.3"/>
+<via x="44.725" y="12.9" extent="1-2" drill="0.2"/>
+<contactref element="C45" pad="1"/>
+<contactref element="C11" pad="P$1"/>
+<contactref element="C44" pad="P$1"/>
+<contactref element="C32" pad="P$1"/>
+<contactref element="C28" pad="P$1"/>
+<contactref element="C46" pad="P$1"/>
+<contactref element="C8" pad="P$1"/>
+<contactref element="C29" pad="P$1"/>
+<contactref element="C6" pad="P$1"/>
+<contactref element="C9" pad="P$1"/>
+<contactref element="C10" pad="P$1"/>
+<contactref element="C31" pad="P$1"/>
+<wire x1="42.1" y1="11.342" x2="43" y2="11.342" width="0.2032" layer="1"/>
+<wire x1="43" y1="11.342" x2="43" y2="11.4" width="0.2032" layer="1"/>
+<wire x1="59.752" y1="7.192" x2="59.752" y2="8.198" width="0.2032" layer="1"/>
+<wire x1="59.752" y1="8.198" x2="59.6" y2="8.35" width="0.2032" layer="1"/>
+<contactref element="C47" pad="P$1"/>
+<wire x1="63.755" y1="28.205" x2="63.76" y2="28.2" width="0.2032" layer="1"/>
+<wire x1="63.76" y1="28.2" x2="64.5" y2="28.2" width="0.2032" layer="1"/>
+<wire x1="64.5" y1="28.2" x2="64.5" y2="27.805" width="0.2032" layer="1"/>
+<wire x1="63.755" y1="27.805" x2="64.5" y2="27.805" width="0.2032" layer="1"/>
+<wire x1="63.755" y1="27.005" x2="64.724" y2="27.005" width="0.2032" layer="1"/>
+<wire x1="64.724" y1="27.005" x2="64.724" y2="26.605" width="0.2032" layer="1"/>
+<wire x1="63.755" y1="26.605" x2="64.724" y2="26.605" width="0.2032" layer="1"/>
+<contactref element="C49" pad="P$1"/>
+<via x="53.987" y="0.889" extent="1-16" drill="0.3"/>
+<via x="45.291" y="24.503" extent="1-16" drill="0.3"/>
+<contactref element="C17" pad="1"/>
+<contactref element="C35" pad="1"/>
+<contactref element="C51" pad="1"/>
+<contactref element="C52" pad="1"/>
+<via x="49.6" y="14.45" extent="1-16" drill="0.3"/>
+<via x="57.775" y="10.602" extent="1-16" drill="0.3"/>
+<via x="63.625" y="12.602" extent="1-16" drill="0.3"/>
+<via x="45.825" y="11.202" extent="1-16" drill="0.3"/>
+<via x="20.858" y="7.376" extent="1-16" drill="0.3"/>
+<via x="55.725" y="15.375" extent="1-16" drill="0.3"/>
+<contactref element="C23" pad="P$1"/>
+<via x="65.6" y="14.55" extent="1-16" drill="0.3"/>
+<via x="59.9" y="20.3" extent="1-16" drill="0.3"/>
+<via x="50.375" y="14.452" extent="1-16" drill="0.3"/>
+<contactref element="C54" pad="2"/>
+<contactref element="C55" pad="P$2"/>
+<contactref element="C56" pad="2"/>
+<via x="47.075" y="15.75" extent="1-2" drill="0.2"/>
+<contactref element="C53" pad="1"/>
+<contactref element="C57" pad="P$1"/>
+<via x="56.991" y="24.053" extent="1-16" drill="0.3"/>
+<via x="36.844" y="26.147" extent="1-16" drill="0.3"/>
+<via x="40.594" y="27.597" extent="1-16" drill="0.3"/>
+<via x="31.544" y="23.147" extent="1-16" drill="0.3"/>
+<wire x1="37.612" y1="1.8" x2="37.6" y2="1.8" width="0.3" layer="15"/>
+<wire x1="37.6" y1="1.8" x2="37.6" y2="0.95" width="0.3" layer="15"/>
+<via x="63.1" y="29.3" extent="1-16" drill="0.3"/>
+<via x="63.8" y="22.8" extent="1-16" drill="0.3"/>
+<via x="66.15" y="29.45" extent="1-16" drill="0.3"/>
+<via x="69.455" y="33.147" extent="1-16" drill="0.3"/>
+<contactref element="IC1" pad="1"/>
+<via x="64.7" y="26.55" extent="1-16" drill="0.3"/>
+<contactref element="R9" pad="P$1"/>
+<via x="57.025" y="11.202" extent="1-16" drill="0.3"/>
+<via x="59.9" y="14.925" extent="1-16" drill="0.3"/>
+<contactref element="C50" pad="P$1"/>
+<via x="59.991" y="24.053" extent="1-16" drill="0.3"/>
+</signal>
+<signal name="SD_DAT2">
+<contactref element="K3" pad="1"/>
+<contactref element="IC2" pad="78"/>
+<wire x1="27.766" y1="5.61" x2="27.766" y2="7.921" width="0.2032" layer="1"/>
+<wire x1="27.766" y1="7.921" x2="27.432" y2="8.255" width="0.2032" layer="1"/>
+<via x="27.432" y="8.255" extent="1-16" drill="0.3"/>
+<wire x1="27.432" y1="8.255" x2="27.432" y2="9.144" width="0.2032" layer="16"/>
+<wire x1="27.432" y1="9.144" x2="27.813" y2="9.525" width="0.2032" layer="16"/>
+<wire x1="27.813" y1="9.525" x2="27.813" y2="11.176" width="0.2032" layer="16"/>
+<wire x1="27.813" y1="11.176" x2="29.464" y2="12.827" width="0.2032" layer="16"/>
+<wire x1="29.464" y1="12.827" x2="40.305" y2="12.827" width="0.2032" layer="16"/>
+<wire x1="40.305" y1="12.827" x2="45.385" y2="17.907" width="0.2032" layer="16"/>
+<via x="47.66" y="18.304" extent="1-16" drill="0.3"/>
+<contactref element="R19" pad="P$1"/>
+<wire x1="45.385" y1="17.907" x2="47.263" y2="17.907" width="0.2032" layer="16"/>
+<wire x1="47.263" y1="17.907" x2="47.66" y2="18.304" width="0.2032" layer="16"/>
+<wire x1="47.66" y1="18.304" x2="47.66" y2="18.76" width="0.2032" layer="1"/>
+<wire x1="47.66" y1="18.76" x2="48.1" y2="19.2" width="0.2032" layer="1"/>
+<wire x1="48.1" y1="19.2" x2="48.1" y2="19.6" width="0.2032" layer="1"/>
+<wire x1="48.1" y1="19.6" x2="48.25" y2="19.75" width="0.2032" layer="1"/>
+<wire x1="46.8" y1="17.992" x2="47.348" y2="17.992" width="0.2032" layer="1"/>
+<wire x1="47.348" y1="17.992" x2="47.66" y2="18.304" width="0.2032" layer="1"/>
+</signal>
+<signal name="SD_DAT3">
+<contactref element="K3" pad="2"/>
+<contactref element="IC2" pad="79"/>
+<wire x1="28.266" y1="5.61" x2="28.266" y2="8.89" width="0.2032" layer="1"/>
+<via x="28.321" y="8.89" extent="1-16" drill="0.3"/>
+<wire x1="28.321" y1="8.89" x2="28.321" y2="10.922" width="0.2032" layer="16"/>
+<wire x1="28.321" y1="10.922" x2="29.718" y2="12.319" width="0.2032" layer="16"/>
+<wire x1="29.718" y1="12.319" x2="40.532" y2="12.319" width="0.2032" layer="16"/>
+<wire x1="40.532" y1="12.319" x2="45.612" y2="17.399" width="0.2032" layer="16"/>
+<wire x1="45.612" y1="17.399" x2="47.999" y2="17.399" width="0.2032" layer="16"/>
+<via x="49.903" y="21.004" extent="1-16" drill="0.3"/>
+<wire x1="28.266" y1="8.89" x2="28.321" y2="8.89" width="0.2032" layer="1"/>
+<contactref element="R20" pad="P$1"/>
+<wire x1="49.508" y1="19.592" x2="49.35" y2="19.75" width="0.2032" layer="1"/>
+<wire x1="49.35" y1="19.75" x2="49.35" y2="20.85" width="0.2032" layer="1"/>
+<wire x1="49.35" y1="20.85" x2="49.5" y2="21" width="0.2032" layer="1"/>
+<wire x1="49.5" y1="21" x2="49.899" y2="21" width="0.2032" layer="1"/>
+<wire x1="49.899" y1="21" x2="49.903" y2="21.004" width="0.2032" layer="1"/>
+<wire x1="47.999" y1="17.399" x2="49.903" y2="19.303" width="0.2032" layer="16"/>
+<wire x1="49.903" y1="19.303" x2="49.903" y2="21.004" width="0.2032" layer="16"/>
+<wire x1="49.35" y1="19.75" x2="49.05" y2="19.75" width="0.2032" layer="1"/>
+<wire x1="49.05" y1="19.75" x2="49.05" y2="18.658" width="0.2032" layer="1"/>
+<wire x1="49.05" y1="18.658" x2="48.7" y2="18.308" width="0.2032" layer="1"/>
+</signal>
+<signal name="SD_CMD">
+<contactref element="IC2" pad="83"/>
+<contactref element="K3" pad="3"/>
+<wire x1="30.266" y1="5.61" x2="30.266" y2="8.65" width="0.2032" layer="1"/>
+<wire x1="30.266" y1="8.65" x2="29.099" y2="9.817" width="0.2032" layer="1"/>
+<via x="29.099" y="9.817" extent="1-16" drill="0.3"/>
+<wire x1="29.099" y1="10.876" x2="30.026" y2="11.803" width="0.2032" layer="16"/>
+<wire x1="30.026" y1="11.803" x2="40.886" y2="11.803" width="0.2032" layer="16"/>
+<wire x1="40.886" y1="11.803" x2="45.966" y2="16.883" width="0.2032" layer="16"/>
+<via x="50.973" y="21.015" extent="1-16" drill="0.3"/>
+<contactref element="R21" pad="P$1"/>
+<wire x1="50.973" y1="21.015" x2="50.915" y2="21.015" width="0.2032" layer="1"/>
+<wire x1="50.915" y1="21.015" x2="50.6" y2="20.7" width="0.2032" layer="1"/>
+<wire x1="50.6" y1="20.7" x2="50.6" y2="19.9" width="0.2032" layer="1"/>
+<wire x1="50.6" y1="19.9" x2="50.45" y2="19.75" width="0.2032" layer="1"/>
+<wire x1="45.966" y1="16.883" x2="48.583" y2="16.883" width="0.2032" layer="16"/>
+<wire x1="48.583" y1="16.883" x2="50.973" y2="19.273" width="0.2032" layer="16"/>
+<wire x1="50.973" y1="19.273" x2="50.973" y2="21.015" width="0.2032" layer="16"/>
+<wire x1="29.099" y1="9.817" x2="29.099" y2="10.876" width="0.2032" layer="16"/>
+<wire x1="49.9" y1="18.308" x2="50.15" y2="18.308" width="0.2032" layer="1"/>
+<wire x1="50.15" y1="18.308" x2="50.15" y2="19.75" width="0.2032" layer="1"/>
+<wire x1="50.15" y1="19.75" x2="50.45" y2="19.75" width="0.2032" layer="1"/>
+</signal>
+<signal name="SD_CLK">
+<contactref element="K3" pad="5"/>
+<contactref element="IC2" pad="80"/>
+<wire x1="28.766" y1="5.61" x2="28.766" y2="7.811" width="0.3" layer="1"/>
+<wire x1="28.766" y1="7.811" x2="29.21" y2="8.255" width="0.3" layer="1"/>
+<via x="29.21" y="8.255" extent="1-16" drill="0.3"/>
+<via x="52.605" y="21.015" extent="1-16" drill="0.3"/>
+<contactref element="R22" pad="P$1"/>
+<wire x1="29.21" y1="8.255" x2="31.855" y2="10.9" width="0.32" layer="16"/>
+<wire x1="31.855" y1="10.9" x2="41.4" y2="10.9" width="0.32" layer="16"/>
+<wire x1="41.4" y1="10.9" x2="46.5" y2="16" width="0.32" layer="16"/>
+<wire x1="46.5" y1="16" x2="49.1" y2="16" width="0.32" layer="16"/>
+<wire x1="49.1" y1="16" x2="52.605" y2="19.505" width="0.32" layer="16"/>
+<wire x1="52.605" y1="19.505" x2="52.605" y2="21.015" width="0.32" layer="16"/>
+<wire x1="53.05" y1="18.308" x2="52.85" y2="18.308" width="0.2032" layer="1"/>
+<wire x1="52.85" y1="18.308" x2="52.85" y2="19.75" width="0.2032" layer="1"/>
+<wire x1="52.85" y1="19.75" x2="52.65" y2="19.75" width="0.2032" layer="1"/>
+<wire x1="52.605" y1="21.015" x2="52.605" y2="19.75" width="0.2032" layer="1"/>
+<wire x1="52.605" y1="19.75" x2="52.65" y2="19.75" width="0.2032" layer="1"/>
+</signal>
+<signal name="SD_DAT0">
+<contactref element="K3" pad="7"/>
+<contactref element="IC2" pad="65"/>
+<via x="55.064" y="21.004" extent="1-16" drill="0.3"/>
+<wire x1="45.974" y1="18.923" x2="44.931" y2="18.923" width="0.2032" layer="16"/>
+<wire x1="44.931" y1="18.923" x2="39.851" y2="13.843" width="0.2032" layer="16"/>
+<wire x1="39.851" y1="13.843" x2="28.575" y2="13.843" width="0.2032" layer="16"/>
+<wire x1="28.575" y1="13.843" x2="27.813" y2="13.081" width="0.2032" layer="16"/>
+<via x="27.813" y="13.081" extent="1-16" drill="0.3"/>
+<wire x1="25.041" y1="12.335" x2="27.067" y2="12.335" width="0.2032" layer="1"/>
+<wire x1="27.067" y1="12.335" x2="27.813" y2="13.081" width="0.2032" layer="1"/>
+<wire x1="55.064" y1="21.004" x2="55.064" y2="20.036" width="0.2" layer="1"/>
+<wire x1="45.974" y1="18.923" x2="49.051" y2="22" width="0.2032" layer="16"/>
+<wire x1="49.051" y1="22" x2="54.068" y2="22" width="0.2032" layer="16"/>
+<wire x1="54.068" y1="22" x2="55.064" y2="21.004" width="0.2032" layer="16"/>
+<contactref element="R23" pad="P$1"/>
+<wire x1="55.064" y1="20.036" x2="54.85" y2="19.822" width="0.2032" layer="1"/>
+<wire x1="54.85" y1="19.822" x2="54.85" y2="19.75" width="0.2032" layer="1"/>
+<wire x1="54.85" y1="19.75" x2="55" y2="19.75" width="0.2032" layer="1"/>
+<wire x1="55" y1="19.75" x2="55" y2="18.308" width="0.2032" layer="1"/>
+<wire x1="55" y1="18.308" x2="55.2" y2="18.308" width="0.2032" layer="1"/>
+</signal>
+<signal name="SD_DAT1">
+<contactref element="K3" pad="8"/>
+<contactref element="IC2" pad="66"/>
+<via x="56.007" y="21.015" extent="1-16" drill="0.3"/>
+<wire x1="46.228" y1="18.415" x2="45.158" y2="18.415" width="0.2032" layer="16"/>
+<wire x1="45.158" y1="18.415" x2="40.078" y2="13.335" width="0.2032" layer="16"/>
+<wire x1="40.078" y1="13.335" x2="29.21" y2="13.335" width="0.2032" layer="16"/>
+<wire x1="29.21" y1="13.335" x2="27.051" y2="11.176" width="0.2032" layer="16"/>
+<via x="27.051" y="11.176" extent="1-16" drill="0.3"/>
+<wire x1="27.051" y1="11.176" x2="26.392" y2="11.835" width="0.2032" layer="1"/>
+<wire x1="25.041" y1="11.835" x2="26.392" y2="11.835" width="0.2032" layer="1"/>
+<contactref element="R18" pad="P$1"/>
+<wire x1="46.228" y1="18.415" x2="49.413" y2="21.6" width="0.2032" layer="16"/>
+<wire x1="49.413" y1="21.6" x2="53.5" y2="21.6" width="0.2032" layer="16"/>
+<wire x1="53.5" y1="21.6" x2="54.7" y2="20.4" width="0.2032" layer="16"/>
+<wire x1="55.8" y1="20.4" x2="54.7" y2="20.4" width="0.2032" layer="16"/>
+<wire x1="56.007" y1="21.015" x2="56.007" y2="20.607" width="0.2032" layer="16"/>
+<wire x1="56.007" y1="20.607" x2="55.8" y2="20.4" width="0.2032" layer="16"/>
+<wire x1="56.007" y1="21.015" x2="56.007" y2="19.75" width="0.2032" layer="1"/>
+<wire x1="56.007" y1="19.75" x2="55.95" y2="19.75" width="0.2032" layer="1"/>
+<wire x1="56.007" y1="19.75" x2="56.007" y2="18.701" width="0.2032" layer="1"/>
+<wire x1="56.007" y1="18.701" x2="56.4" y2="18.308" width="0.2032" layer="1"/>
+</signal>
+<signal name="N$21">
+<contactref element="IC2" pad="12"/>
+<contactref element="C2" pad="P$2"/>
+<contactref element="X1" pad="1"/>
+<wire x1="40.491" y1="12.835" x2="42.915" y2="12.835" width="0.2032" layer="1"/>
+<wire x1="42.915" y1="12.835" x2="43.95" y2="11.8" width="0.2032" layer="1"/>
+<wire x1="43.95" y1="11.8" x2="47.9" y2="11.8" width="0.2032" layer="1"/>
+<wire x1="47.9" y1="11.8" x2="48.15" y2="11.55" width="0.2032" layer="1"/>
+<wire x1="48.15" y1="11.55" x2="49.6" y2="11.55" width="0.2032" layer="1"/>
+<wire x1="48.15" y1="9.725" x2="48.15" y2="11.55" width="0.2032" layer="1"/>
+<wire x1="49.6" y1="11.55" x2="49.6" y2="11.658" width="0.2032" layer="1"/>
+</signal>
+<signal name="N$22">
+<contactref element="IC2" pad="13"/>
+<contactref element="C3" pad="P$2"/>
+<contactref element="X1" pad="3"/>
+<wire x1="45.95" y1="14.275" x2="45.95" y2="12.5" width="0.2032" layer="1"/>
+<wire x1="45.95" y1="12.5" x2="45.75" y2="12.3" width="0.2032" layer="1"/>
+<wire x1="45.75" y1="12.3" x2="44.15" y2="12.3" width="0.2032" layer="1"/>
+<wire x1="44.15" y1="12.3" x2="43.115" y2="13.335" width="0.2032" layer="1"/>
+<wire x1="40.491" y1="13.335" x2="43.115" y2="13.335" width="0.2032" layer="1"/>
+<wire x1="49.6" y1="12.5" x2="45.95" y2="12.5" width="0.2032" layer="1"/>
+<wire x1="49.6" y1="12.5" x2="49.6" y2="12.592" width="0.2032" layer="1"/>
+</signal>
+<signal name="VCC-2">
+<contactref element="C5" pad="2"/>
+<contactref element="C9" pad="P$2"/>
+<contactref element="C10" pad="P$2"/>
+<contactref element="IC2" pad="50"/>
+<contactref element="IC2" pad="11"/>
+<contactref element="IC2" pad="19"/>
+<contactref element="IC2" pad="75"/>
+<contactref element="IC2" pad="28"/>
+<contactref element="IC2" pad="100"/>
+<contactref element="IC6" pad="5"/>
+<contactref element="K5" pad="VCC"/>
+<contactref element="IC2" pad="6"/>
+<contactref element="IC2" pad="22"/>
+<contactref element="L2" pad="1"/>
+<contactref element="TP3" pad="1"/>
+<contactref element="L4" pad="2"/>
+<wire x1="28.321" y1="25.273" x2="40.473" y2="25.273" width="0.6096" layer="15"/>
+<wire x1="59.659" y1="29.509" x2="59.659" y2="30.661" width="0.6096" layer="15"/>
+<via x="59.659" y="30.661" extent="1-16" drill="0.3"/>
+<polygon width="0.254" layer="15" isolate="0.3048" thermals="no" rank="2">
+<vertex x="14.605" y="21.971"/>
+<vertex x="14.605" y="11.938"/>
+<vertex x="33.02" y="1.8"/>
+<vertex x="52.7" y="1.8"/>
+<vertex x="52.7" y="4.445"/>
+<vertex x="66.8" y="4.445"/>
+<vertex x="66.8" y="27.4"/>
+<vertex x="59.9" y="27.4"/>
+<vertex x="59.9" y="32.258"/>
+<vertex x="34.42" y="32.258"/>
+</polygon>
+<via x="39.497" y="5.615" extent="1-16" drill="0.3"/>
+<via x="65.7" y="12.7" extent="1-16" drill="0.3"/>
+<via x="42.957" y="18.75" extent="1-16" drill="0.3"/>
+<via x="25.758" y="6.127" extent="1-16" drill="0.3"/>
+<wire x1="25.041" y1="7.335" x2="25.05" y2="7.335" width="0.2032" layer="1"/>
+<wire x1="25.05" y1="7.335" x2="25.019" y2="7.366" width="0.2032" layer="1"/>
+<wire x1="40.491" y1="12.335" x2="39.386" y2="12.335" width="0.254" layer="1"/>
+<wire x1="39.386" y1="12.335" x2="39.243" y2="12.192" width="0.254" layer="1"/>
+<wire x1="39.243" y1="12.192" x2="39.243" y2="10.033" width="0.254" layer="1"/>
+<wire x1="40.491" y1="9.835" x2="39.441" y2="9.835" width="0.254" layer="1"/>
+<wire x1="39.441" y1="9.835" x2="39.243" y2="10.033" width="0.254" layer="1"/>
+<wire x1="26.766" y1="21.06" x2="26.766" y2="21.209" width="0.254" layer="1"/>
+<wire x1="26.766" y1="21.209" x2="25.908" y2="21.209" width="0.254" layer="1"/>
+<wire x1="26.766" y1="21.06" x2="26.766" y2="22.321" width="0.2032" layer="1"/>
+<wire x1="26.766" y1="22.321" x2="27.027" y2="22.582" width="0.2032" layer="1"/>
+<wire x1="27.027" y1="23.55" x2="27.027" y2="22.582" width="0.2032" layer="1"/>
+<via x="28.321" y="24.511" extent="1-16" drill="0.3"/>
+<wire x1="27.027" y1="23.55" x2="27.027" y2="23.979" width="0.3048" layer="1"/>
+<wire x1="27.027" y1="23.979" x2="27.559" y2="24.511" width="0.3048" layer="1"/>
+<wire x1="27.559" y1="24.511" x2="28.321" y2="24.511" width="0.3048" layer="1"/>
+<wire x1="29.21" y1="25.859" x2="29.21" y2="24.511" width="0.3048" layer="1"/>
+<wire x1="29.21" y1="24.511" x2="28.321" y2="24.511" width="0.3048" layer="1"/>
+<via x="29.21" y="24.511" extent="1-16" drill="0.3"/>
+<wire x1="40.473" y1="25.273" x2="43.5" y2="28.3" width="0.6096" layer="15"/>
+<wire x1="43.5" y1="28.3" x2="58.45" y2="28.3" width="0.6096" layer="15"/>
+<wire x1="58.45" y1="28.3" x2="59.659" y2="29.509" width="0.6096" layer="15"/>
+<wire x1="28.321" y1="25.273" x2="28.321" y2="24.511" width="0.6096" layer="15"/>
+<contactref element="C31" pad="P$2"/>
+<contactref element="C34" pad="2"/>
+<contactref element="C7" pad="P$2"/>
+<contactref element="C30" pad="P$2"/>
+<contactref element="C33" pad="P$2"/>
+<contactref element="C42" pad="P$2"/>
+<contactref element="C41" pad="P$2"/>
+<via x="39.157" y="16.35" extent="1-16" drill="0.3"/>
+<via x="42.957" y="18" extent="1-16" drill="0.3"/>
+<wire x1="40.491" y1="17.835" x2="41.757" y2="17.835" width="0.2032" layer="1"/>
+<wire x1="41.757" y1="17.835" x2="41.937" y2="18.015" width="0.2032" layer="1"/>
+<wire x1="39.157" y1="16.35" x2="39.172" y2="16.335" width="0.2032" layer="1"/>
+<wire x1="39.172" y1="16.335" x2="40.491" y2="16.335" width="0.2032" layer="1"/>
+<wire x1="42.957" y1="18.75" x2="42.957" y2="18" width="0.7" layer="1"/>
+<wire x1="40.491" y1="12.335" x2="42.1" y2="12.335" width="0.2032" layer="1"/>
+<wire x1="42.1" y1="12.335" x2="42.1" y2="12.358" width="0.2032" layer="1"/>
+<contactref element="C45" pad="2"/>
+<contactref element="C11" pad="P$2"/>
+<contactref element="C44" pad="P$2"/>
+<contactref element="C32" pad="P$2"/>
+<contactref element="C28" pad="P$2"/>
+<contactref element="C46" pad="P$2"/>
+<contactref element="C8" pad="P$2"/>
+<wire x1="39.497" y1="5.615" x2="39.497" y2="5.603" width="0.3" layer="1"/>
+<wire x1="39.497" y1="5.603" x2="40.05" y2="5.05" width="0.3" layer="1"/>
+<wire x1="40.05" y1="5.05" x2="40.05" y2="4.158" width="0.3" layer="1"/>
+<contactref element="C29" pad="P$2"/>
+<contactref element="C6" pad="P$2"/>
+<via x="65.7" y="11.8" extent="1-16" drill="0.3"/>
+<wire x1="65.7" y1="12.7" x2="65.7" y2="11.8" width="0.7" layer="1"/>
+<via x="34.1" y="24.2" extent="1-16" drill="0.3"/>
+<via x="35" y="24.2" extent="1-16" drill="0.3"/>
+<wire x1="34.1" y1="24.2" x2="34.7" y2="24.2" width="0.7" layer="1"/>
+<wire x1="34.7" y1="24.2" x2="35" y2="24.2" width="0.7" layer="1"/>
+<wire x1="34.45" y1="22.8" x2="34.7" y2="22.8" width="0.3" layer="1"/>
+<wire x1="34.7" y1="22.8" x2="34.7" y2="24.2" width="0.3" layer="1"/>
+<wire x1="34.7" y1="22.8" x2="34.7" y2="22.392" width="0.3" layer="1"/>
+<wire x1="34.7" y1="22.392" x2="35.6" y2="22.392" width="0.3" layer="1"/>
+<wire x1="35.6" y1="22.392" x2="36.7" y2="22.392" width="0.3" layer="1"/>
+<wire x1="36.7" y1="22.392" x2="37.8" y2="22.392" width="0.3" layer="1"/>
+<wire x1="37.766" y1="21.06" x2="37.766" y2="22.392" width="0.3" layer="1"/>
+<wire x1="37.766" y1="22.392" x2="37.8" y2="22.392" width="0.3" layer="1"/>
+<via x="59.659" y="29.861" extent="1-16" drill="0.3"/>
+<wire x1="65.7" y1="11.8" x2="65.7" y2="10.6" width="0.3" layer="1"/>
+<contactref element="C52" pad="2"/>
+<wire x1="25.758" y1="6.127" x2="25.758" y2="6.208" width="0.4" layer="1"/>
+<wire x1="25.758" y1="6.208" x2="24.7" y2="6.208" width="0.4" layer="1"/>
+<wire x1="24.7" y1="6.208" x2="24.7" y2="6.2" width="0.4" layer="1"/>
+<wire x1="24.7" y1="6.2" x2="23.658" y2="6.2" width="0.4" layer="1"/>
+<wire x1="23.658" y1="6.2" x2="23.658" y2="7.4" width="0.4" layer="1"/>
+<wire x1="23.658" y1="7.4" x2="23.65" y2="7.4" width="0.4" layer="1"/>
+<wire x1="25.041" y1="7.335" x2="23.65" y2="7.335" width="0.3" layer="1"/>
+<wire x1="23.65" y1="7.335" x2="23.65" y2="7.4" width="0.3" layer="1"/>
+<contactref element="C54" pad="1"/>
+<via x="44.707" y="9.25" extent="1-16" drill="0.3"/>
+<contactref element="C55" pad="P$1"/>
+<via x="48.15" y="2.75" extent="1-16" drill="0.3"/>
+<via x="48.45" y="2.1" extent="1-16" drill="0.3"/>
+<polygon width="0.2" layer="1" thermals="no">
+<vertex x="46.65" y="2.2"/>
+<vertex x="46.65" y="3.1"/>
+<vertex x="47.5" y="3.1"/>
+<vertex x="47.5" y="4.25"/>
+<vertex x="47.95" y="4.25"/>
+<vertex x="47.95" y="3.65"/>
+<vertex x="49.95" y="3.65"/>
+<vertex x="49.95" y="1.8"/>
+<vertex x="47.95" y="1.8"/>
+<vertex x="47.95" y="2.2"/>
+</polygon>
+<via x="43.907" y="9.25" extent="1-16" drill="0.3"/>
+<wire x1="44.35" y1="8.358" x2="44.408" y2="8.3" width="0.3" layer="1"/>
+<wire x1="44.408" y1="8.3" x2="45.8" y2="8.3" width="0.3" layer="1"/>
+<wire x1="45.8" y1="8.3" x2="45.8" y2="8.1" width="0.3" layer="1"/>
+<wire x1="44.35" y1="8.358" x2="43.15" y2="8.358" width="0.3" layer="1"/>
+<wire x1="41.95" y1="9.708" x2="42.542" y2="9.708" width="0.3" layer="1"/>
+<wire x1="42.542" y1="9.708" x2="42.95" y2="9.3" width="0.3" layer="1"/>
+<wire x1="42.95" y1="9.3" x2="42.95" y2="8.358" width="0.3" layer="1"/>
+<wire x1="42.95" y1="8.358" x2="43.15" y2="8.358" width="0.3" layer="1"/>
+<wire x1="43.907" y1="8.358" x2="44.35" y2="8.358" width="0.3" layer="1"/>
+<polygon width="0.2" layer="1" thermals="no">
+<vertex x="43.7" y="8.25"/>
+<vertex x="43.7" y="9.45"/>
+<vertex x="44.9" y="9.45"/>
+<vertex x="44.9" y="8.25"/>
+</polygon>
+<wire x1="40.491" y1="9.835" x2="41.95" y2="9.835" width="0.2" layer="1"/>
+<wire x1="41.95" y1="9.835" x2="41.95" y2="9.708" width="0.2" layer="1"/>
+<contactref element="C56" pad="1"/>
+<wire x1="43.8" y1="17.95" x2="44.1" y2="17.65" width="0.3" layer="1"/>
+<wire x1="44.1" y1="17.65" x2="44.1" y2="17.1" width="0.3" layer="1"/>
+<wire x1="44.1" y1="17.1" x2="45.4" y2="17.1" width="0.3" layer="1"/>
+<wire x1="45.4" y1="17.1" x2="45.8" y2="16.7" width="0.3" layer="1"/>
+<wire x1="45.8" y1="16.7" x2="45.8" y2="15.951" width="0.3" layer="1"/>
+<wire x1="40.491" y1="16.335" x2="41.365" y2="16.335" width="0.2032" layer="1"/>
+<wire x1="41.365" y1="16.335" x2="41.842" y2="15.858" width="0.2032" layer="1"/>
+<wire x1="41.842" y1="15.858" x2="41.842" y2="15.75" width="0.2032" layer="1"/>
+<wire x1="41.842" y1="15.75" x2="41.842" y2="14.55" width="0.2032" layer="1"/>
+<contactref element="C51" pad="2"/>
+<contactref element="C35" pad="2"/>
+<contactref element="C17" pad="2"/>
+<contactref element="C53" pad="2"/>
+<contactref element="T1" pad="1"/>
+<contactref element="R2" pad="P$2"/>
+<polygon width="0.2" layer="1" thermals="no">
+<vertex x="54.2" y="8.7"/>
+<vertex x="52.1" y="8.7"/>
+<vertex x="52.1" y="13.05"/>
+<vertex x="52.55" y="13.5"/>
+<vertex x="54.05" y="13.5"/>
+<vertex x="54.05" y="12.7"/>
+<vertex x="53.75" y="12.4"/>
+<vertex x="53.75" y="11.4"/>
+<vertex x="54.2" y="10.95"/>
+</polygon>
+<via x="53.957" y="10.4" extent="1-16" drill="0.3"/>
+<via x="53.457" y="11" extent="1-16" drill="0.3"/>
+<wire x1="41.937" y1="18.015" x2="42.942" y2="18.015" width="0.3" layer="1"/>
+<wire x1="42.942" y1="18.015" x2="42.957" y2="18" width="0.3" layer="1"/>
+<wire x1="43.8" y1="17.95" x2="43.007" y2="17.95" width="0.3" layer="1"/>
+<wire x1="43.007" y1="17.95" x2="42.957" y2="18" width="0.3" layer="1"/>
+<polygon width="0.2" layer="1" thermals="no">
+<vertex x="36.4" y="4.45"/>
+<vertex x="40.3" y="4.45"/>
+<vertex x="40.3" y="4.05"/>
+<vertex x="37.15" y="4.05"/>
+<vertex x="36.85" y="3.75"/>
+<vertex x="36.4" y="3.75"/>
+</polygon>
+<wire x1="38.766" y1="5.61" x2="38.766" y2="4.158" width="0.3" layer="1"/>
+<wire x1="38.766" y1="4.158" x2="38.85" y2="4.158" width="0.3" layer="1"/>
+<contactref element="T2" pad="1"/>
+<via x="57.9" y="27.5" extent="1-16" drill="0.3"/>
+<wire x1="60.45" y1="31.7" x2="60.45" y2="31.452" width="0.6" layer="1"/>
+<wire x1="60.45" y1="31.452" x2="59.659" y2="30.661" width="0.6" layer="1"/>
+<wire x1="59.659" y1="29.861" x2="59.659" y2="30.661" width="0.6" layer="1"/>
+<contactref element="IC1" pad="3"/>
+<contactref element="R17" pad="P$1"/>
+<wire x1="57.9" y1="27.5" x2="59" y2="27.5" width="0.2" layer="1"/>
+<wire x1="59" y1="27.5" x2="59" y2="27.508" width="0.2" layer="1"/>
+</signal>
+<signal name="N$24">
+<contactref element="D1" pad="K"/>
+<contactref element="R8" pad="2"/>
+<wire x1="20.8" y1="22.4" x2="20.8" y2="23.741" width="0.27" layer="1"/>
+<wire x1="20.8" y1="23.741" x2="20.536" y2="23.741" width="0.28" layer="1"/>
+<contactref element="TP19" pad="1"/>
+<wire x1="19.1" y1="23.7" x2="20.536" y2="23.7" width="0.2" layer="1"/>
+<wire x1="20.536" y1="23.7" x2="20.536" y2="23.741" width="0.2" layer="1"/>
+</signal>
+<signal name="N$25">
+<contactref element="IC2" pad="73"/>
+<contactref element="C12" pad="2"/>
+<wire x1="25.041" y1="8.335" x2="22.956" y2="8.335" width="0.2032" layer="1"/>
+<wire x1="22.956" y1="8.335" x2="22.956" y2="8.843" width="0.2032" layer="1"/>
+</signal>
+<signal name="N$26">
+<contactref element="IC2" pad="49"/>
+<contactref element="C13" pad="2"/>
+<wire x1="27.266" y1="21.06" x2="27.266" y2="22.059" width="0.2032" layer="1"/>
+<wire x1="27.266" y1="22.059" x2="27.686" y2="22.479" width="0.2032" layer="1"/>
+<wire x1="27.686" y1="22.479" x2="28.514" y2="22.479" width="0.2032" layer="1"/>
+<wire x1="28.514" y1="22.479" x2="28.514" y2="22.86" width="0.2032" layer="1"/>
+</signal>
+<signal name="SW">
+<contactref element="L1" pad="2"/>
+<contactref element="D6" pad="A"/>
+<contactref element="IC5" pad="8"/>
+<wire x1="37.8" y1="29.55" x2="37.8" y2="30.783" width="0.3048" layer="1"/>
+<wire x1="37.8" y1="30.783" x2="37.214" y2="31.369" width="0.3048" layer="1"/>
+<wire x1="37.214" y1="31.369" x2="37.214" y2="32.088" width="0.3048" layer="1"/>
+<wire x1="37.214" y1="32.088" x2="37.257" y2="32.131" width="0.3048" layer="1"/>
+<wire x1="32.385" y1="31.857" x2="35.159" y2="31.857" width="0.3048" layer="1"/>
+<wire x1="35.159" y1="31.857" x2="35.433" y2="32.131" width="0.3048" layer="1"/>
+<wire x1="35.433" y1="32.131" x2="37.257" y2="32.131" width="0.3048" layer="1"/>
+</signal>
+<signal name="FB_RS">
+<contactref element="IC5" pad="2"/>
+<contactref element="R14" pad="P$2"/>
+<contactref element="IC5" pad="4"/>
+<wire x1="34.801" y1="25.908" x2="34.801" y2="26.9494" width="0.3048" layer="1"/>
+<wire x1="34.801" y1="26.9494" x2="34.801" y2="27.5256" width="0.3048" layer="1"/>
+<wire x1="34.85" y1="28.9" x2="34.8448" y2="28.9052" width="0.2032" layer="1"/>
+<wire x1="34.8448" y1="28.9052" x2="33.9344" y2="28.9052" width="0.2032" layer="1"/>
+<via x="33.9344" y="28.9052" extent="1-2" drill="0.3"/>
+<wire x1="33.9344" y1="28.9052" x2="34.798" y2="28.0416" width="0.2032" layer="2"/>
+<wire x1="34.798" y1="28.0416" x2="34.798" y2="26.9494" width="0.2032" layer="2"/>
+<via x="34.798" y="26.9494" extent="1-2" drill="0.3"/>
+<wire x1="34.801" y1="27.5256" x2="34.801" y2="27.6" width="0.2032" layer="1"/>
+<wire x1="34.801" y1="27.6" x2="34.85" y2="27.6" width="0.2032" layer="1"/>
+<wire x1="34.798" y1="26.9494" x2="34.801" y2="26.9494" width="0.2032" layer="1"/>
+</signal>
+<signal name="OVP">
+<contactref element="IC5" pad="7"/>
+<contactref element="R25" pad="P$2"/>
+<contactref element="R26" pad="P$1"/>
+<wire x1="39.173" y1="29.464" x2="39.173" y2="28.9" width="0.2032" layer="1"/>
+<wire x1="39.173" y1="28.9" x2="39.173" y2="28.321" width="0.2032" layer="1"/>
+<wire x1="37.8" y1="28.9" x2="39.173" y2="28.9" width="0.2032" layer="1"/>
+</signal>
+<signal name="CTRL">
+<contactref element="IC5" pad="5"/>
+<contactref element="R9" pad="P$2"/>
+<contactref element="R10" pad="P$2"/>
+<wire x1="37.8" y1="27.6" x2="37.8" y2="26.134" width="0.3048" layer="1"/>
+<wire x1="37.8" y1="26.134" x2="37.849" y2="26.085" width="0.3048" layer="1"/>
+<wire x1="37.849" y1="26.085" x2="38.965" y2="26.085" width="0.3048" layer="1"/>
+<contactref element="TP6" pad="1"/>
+<wire x1="38.965" y1="26.085" x2="39.885" y2="26.085" width="0.2032" layer="1"/>
+<wire x1="39.885" y1="26.085" x2="40.1" y2="26.3" width="0.2032" layer="1"/>
+<wire x1="40.1" y1="26.3" x2="41" y2="26.3" width="0.2032" layer="1"/>
+</signal>
+<signal name="LEDK">
+<contactref element="IC5" pad="1"/>
+<contactref element="K4" pad="23"/>
+<wire x1="58.952" y1="7.192" x2="58.952" y2="7.748" width="0.2032" layer="1"/>
+<wire x1="58.952" y1="7.748" x2="58.55" y2="8.15" width="0.2032" layer="1"/>
+<contactref element="TP4" pad="1"/>
+<via x="57.877" y="11.811" extent="1-16" drill="0.3"/>
+<via x="35.182" y="30.607" extent="1-16" drill="0.3"/>
+<wire x1="34.85" y1="29.55" x2="34.85" y2="30.275" width="0.3048" layer="1"/>
+<wire x1="34.85" y1="30.275" x2="35.182" y2="30.607" width="0.3048" layer="1"/>
+<wire x1="35.182" y1="30.607" x2="35.193" y2="30.607" width="0.3048" layer="16"/>
+<wire x1="35.193" y1="30.607" x2="35.8" y2="30" width="0.3048" layer="16"/>
+<wire x1="35.8" y1="30" x2="41.5" y2="30" width="0.3048" layer="16"/>
+<wire x1="57.1" y1="22.4" x2="50.9" y2="22.4" width="0.3" layer="15"/>
+<wire x1="58.55" y1="8.15" x2="58.55" y2="11.138" width="0.2032" layer="1"/>
+<wire x1="57.877" y1="11.811" x2="58.55" y2="11.138" width="0.2032" layer="1"/>
+<wire x1="57.877" y1="11.823" x2="57.877" y2="11.811" width="0.2032" layer="1"/>
+<wire x1="57.877" y1="11.811" x2="58.4" y2="12.334" width="0.3" layer="15"/>
+<wire x1="58.4" y1="12.334" x2="58.4" y2="21.1" width="0.3" layer="15"/>
+<wire x1="58.4" y1="21.1" x2="57.1" y2="22.4" width="0.3" layer="15"/>
+<wire x1="50.9" y1="22.4" x2="46.6" y2="26.7" width="0.3" layer="15"/>
+<via x="46.6" y="26.7" extent="1-16" drill="0.3"/>
+<wire x1="46.6" y1="26.7" x2="43.3" y2="30" width="0.3" layer="16"/>
+<wire x1="43.3" y1="30" x2="41.5" y2="30" width="0.3" layer="16"/>
+<wire x1="57.85" y1="13" x2="57.877" y2="13" width="0.2032" layer="1"/>
+<wire x1="57.877" y1="13" x2="57.877" y2="11.811" width="0.2032" layer="1"/>
+</signal>
+<signal name="LEDA">
+<contactref element="D6" pad="K"/>
+<contactref element="C15" pad="2"/>
+<contactref element="R25" pad="P$1"/>
+<contactref element="TP7" pad="1"/>
+<contactref element="K4" pad="22"/>
+<polygon width="0.2032" layer="1" thermals="no">
+<vertex x="38.842" y="30.326"/>
+<vertex x="41.5" y="30.326"/>
+<vertex x="41.5" y="31.95"/>
+<vertex x="42.4" y="31.95"/>
+<vertex x="42.4" y="32.662"/>
+<vertex x="38.842" y="32.662"/>
+</polygon>
+<via x="59.2" y="11.711" extent="1-16" drill="0.3"/>
+<via x="42.074" y="32.381" extent="1-16" drill="0.3"/>
+<wire x1="39.584" y1="32.004" x2="39.457" y2="32.131" width="0.2032" layer="1"/>
+<wire x1="59.2" y1="21.6" x2="57.5" y2="23.3" width="0.3" layer="15"/>
+<wire x1="57.5" y1="23.3" x2="51.5" y2="23.3" width="0.3" layer="15"/>
+<wire x1="59.352" y1="7.192" x2="59.352" y2="7.948" width="0.2032" layer="1"/>
+<wire x1="59.352" y1="7.948" x2="59" y2="8.3" width="0.2032" layer="1"/>
+<wire x1="59" y1="8.3" x2="59" y2="11.15" width="0.2032" layer="1"/>
+<wire x1="59" y1="11.15" x2="59.2" y2="11.35" width="0.2032" layer="1"/>
+<wire x1="59.2" y1="11.35" x2="59.2" y2="11.711" width="0.2032" layer="1"/>
+<wire x1="59.2" y1="21.6" x2="59.2" y2="11.711" width="0.3" layer="15"/>
+<wire x1="46.8" y1="27.4" x2="47.4" y2="27.4" width="0.3" layer="16"/>
+<wire x1="47.4" y1="27.4" x2="48.1" y2="26.7" width="0.3" layer="16"/>
+<via x="48.1" y="26.7" extent="1-16" drill="0.3"/>
+<wire x1="48.1" y1="26.7" x2="51.5" y2="23.3" width="0.3" layer="15"/>
+<wire x1="42.074" y1="32.381" x2="43.6" y2="30.855" width="0.3" layer="16"/>
+<wire x1="43.6" y1="30.855" x2="43.6" y2="30.6" width="0.3" layer="16"/>
+<wire x1="43.6" y1="30.6" x2="46.8" y2="27.4" width="0.3" layer="16"/>
+</signal>
+<signal name="PWM">
+<contactref element="R10" pad="P$1"/>
+<contactref element="IC2" pad="32"/>
+<wire x1="35.766" y1="21.06" x2="35.766" y2="20.184" width="0.2032" layer="1"/>
+<wire x1="35.766" y1="20.184" x2="36.25" y2="19.7" width="0.2032" layer="1"/>
+<via x="36.25" y="19.7" extent="1-16" drill="0.3"/>
+<wire x1="36.25" y1="19.7" x2="37.25" y2="19.7" width="0.2032" layer="15"/>
+<wire x1="37.25" y1="19.7" x2="38.85" y2="21.3" width="0.2032" layer="15"/>
+<wire x1="38.85" y1="21.3" x2="38.85" y2="24.35" width="0.2032" layer="15"/>
+<wire x1="38.965" y1="25.069" x2="38.85" y2="24.954" width="0.2032" layer="1"/>
+<wire x1="38.85" y1="24.954" x2="38.85" y2="24.35" width="0.2032" layer="1"/>
+<via x="38.85" y="24.35" extent="1-16" drill="0.3"/>
+</signal>
+<signal name="SWDIO">
+<contactref element="K5" pad="SWDIO"/>
+<contactref element="IC2" pad="72"/>
+<wire x1="25.041" y1="8.835" x2="26.471" y2="8.835" width="0.2032" layer="1"/>
+<wire x1="26.471" y1="8.835" x2="26.543" y2="8.763" width="0.2032" layer="1"/>
+<via x="26.543" y="8.763" extent="1-16" drill="0.3"/>
+<wire x1="26.543" y1="8.763" x2="26.543" y2="8.255" width="0.2032" layer="15"/>
+<wire x1="26.543" y1="8.255" x2="29.083" y2="5.715" width="0.2032" layer="15"/>
+<wire x1="29.083" y1="5.715" x2="33.313" y2="5.715" width="0.2032" layer="15"/>
+<wire x1="33.313" y1="5.715" x2="33.802" y2="5.226" width="0.2032" layer="15"/>
+<wire x1="33.802" y1="5.226" x2="33.802" y2="1.8" width="0.2032" layer="15"/>
+<contactref element="TP1" pad="1"/>
+<wire x1="23.1" y1="10.5" x2="23.8" y2="9.8" width="0.2032" layer="1"/>
+<wire x1="23.8" y1="9.8" x2="23.8" y2="9.1" width="0.2032" layer="1"/>
+<wire x1="23.8" y1="9.1" x2="24.065" y2="8.835" width="0.2032" layer="1"/>
+<wire x1="25.041" y1="8.835" x2="24.065" y2="8.835" width="0.2032" layer="1"/>
+</signal>
+<signal name="SWCLK">
+<contactref element="K5" pad="SWCLK"/>
+<contactref element="IC2" pad="76"/>
+<wire x1="26.766" y1="5.61" x2="26.766" y2="4.73" width="0.2032" layer="1"/>
+<wire x1="26.766" y1="4.73" x2="26.924" y2="4.572" width="0.2032" layer="1"/>
+<wire x1="26.924" y1="4.572" x2="28.067" y2="4.572" width="0.2032" layer="1"/>
+<wire x1="28.067" y1="4.572" x2="28.702" y2="3.937" width="0.2032" layer="1"/>
+<wire x1="28.702" y1="3.937" x2="28.702" y2="3.429" width="0.2032" layer="1"/>
+<wire x1="28.702" y1="3.429" x2="29.281" y2="2.85" width="0.2032" layer="1"/>
+<contactref element="TP2" pad="1"/>
+<wire x1="30.95" y1="2.85" x2="34.15" y2="2.85" width="0.2032" layer="1"/>
+<wire x1="30.95" y1="2.85" x2="29.281" y2="2.85" width="0.2032" layer="1"/>
+<wire x1="35.072" y1="1.8" x2="35.072" y2="1.928" width="0.2032" layer="1"/>
+<wire x1="35.072" y1="1.928" x2="34.15" y2="2.85" width="0.2032" layer="1"/>
+</signal>
+<signal name="SWO">
+<contactref element="K5" pad="SWO"/>
+<contactref element="IC2" pad="89"/>
+<wire x1="34.859" y1="3.283" x2="34.067" y2="3.283" width="0.2032" layer="1"/>
+<wire x1="33.274" y1="3.85" x2="33.274" y2="5.602" width="0.2032" layer="1"/>
+<wire x1="33.274" y1="5.602" x2="33.266" y2="5.61" width="0.2032" layer="1"/>
+<contactref element="TP8" pad="1"/>
+<wire x1="34.859" y1="3.283" x2="36.342" y2="1.8" width="0.2032" layer="1"/>
+<wire x1="33.5" y1="3.85" x2="33.274" y2="3.85" width="0.2032" layer="1"/>
+<wire x1="34.067" y1="3.283" x2="33.5" y2="3.85" width="0.2032" layer="1"/>
+</signal>
+<signal name="RST">
+<contactref element="IC2" pad="14"/>
+<contactref element="C20" pad="P$2"/>
+<contactref element="K5" pad="RST"/>
+<wire x1="40.491" y1="13.835" x2="39.235" y2="13.835" width="0.2032" layer="1"/>
+<wire x1="39.235" y1="13.835" x2="38.735" y2="13.335" width="0.2032" layer="1"/>
+<wire x1="38.735" y1="13.335" x2="38.735" y2="7.415" width="0.2032" layer="1"/>
+<contactref element="TP14" pad="1"/>
+<wire x1="38.882" y1="1.8" x2="40.1" y2="1.8" width="0.2032" layer="1"/>
+<wire x1="40.1" y1="1.8" x2="40.3" y2="2" width="0.2032" layer="1"/>
+<wire x1="40.3" y1="2" x2="41.1" y2="2" width="0.2032" layer="1"/>
+<wire x1="41.1" y1="2" x2="41.2" y2="1.9" width="0.2032" layer="1"/>
+<wire x1="41.2" y1="1.9" x2="41.4" y2="1.9" width="0.2032" layer="1"/>
+<wire x1="41.4" y1="1.9" x2="41.5" y2="2" width="0.2032" layer="1"/>
+<wire x1="40.1" y1="6.05" x2="40.658" y2="5.492" width="0.2" layer="1"/>
+<wire x1="40.658" y1="5.492" x2="40.9" y2="5.492" width="0.2" layer="1"/>
+<wire x1="40.9" y1="5.492" x2="40.9" y2="4.85" width="0.2" layer="1"/>
+<wire x1="40.9" y1="4.85" x2="41.5" y2="4.25" width="0.2" layer="1"/>
+<wire x1="41.5" y1="4.25" x2="41.5" y2="2" width="0.2" layer="1"/>
+<wire x1="40.1" y1="6.05" x2="38.735" y2="7.415" width="0.2032" layer="1"/>
+<contactref element="IC1" pad="2"/>
+<wire x1="41.5" y1="2" x2="44.9" y2="2" width="0.2" layer="1"/>
+<wire x1="44.9" y1="2" x2="44.9" y2="1.75" width="0.2" layer="1"/>
+</signal>
+<signal name="VREF+">
+<contactref element="IC2" pad="21"/>
+<contactref element="L2" pad="2"/>
+<contactref element="C21" pad="P$2"/>
+<wire x1="40.491" y1="17.335" x2="42.615" y2="17.335" width="0.2032" layer="1"/>
+<wire x1="42.615" y1="17.335" x2="43.85" y2="16.1" width="0.2032" layer="1"/>
+<wire x1="44.199" y1="16.049" x2="44.199" y2="15.95" width="0.2032" layer="1"/>
+<wire x1="44.199" y1="15.95" x2="44.2" y2="15.951" width="0.2032" layer="1"/>
+<wire x1="44.2" y1="15.951" x2="44.2" y2="14.829" width="0.3" layer="1"/>
+<wire x1="44.2" y1="14.829" x2="44.397" y2="14.829" width="0.3" layer="1"/>
+<wire x1="43.85" y1="16.1" x2="44.2" y2="16.1" width="0.2032" layer="1"/>
+<wire x1="44.2" y1="16.1" x2="44.2" y2="15.951" width="0.2032" layer="1"/>
+</signal>
+<signal name="N$54">
+</signal>
+<signal name="N$55">
+</signal>
+<signal name="N$56">
+</signal>
+<signal name="N$53">
+</signal>
+<signal name="DISP_DB8">
+<contactref element="IC2" pad="42"/>
+<contactref element="K4" pad="4"/>
+<wire x1="59.752" y1="4.492" x2="59.752" y2="5.064" width="0.2032" layer="1"/>
+<wire x1="59.752" y1="5.064" x2="59.609" y2="5.207" width="0.2032" layer="1"/>
+<wire x1="59.609" y1="5.207" x2="59.482" y2="5.207" width="0.2032" layer="1"/>
+<wire x1="59.482" y1="5.207" x2="58.974" y2="5.715" width="0.2032" layer="1"/>
+<via x="58.974" y="5.715" extent="1-2" drill="0.2"/>
+<wire x1="58.974" y1="5.715" x2="58.72" y2="5.461" width="0.2032" layer="2"/>
+<wire x1="30.766" y1="21.06" x2="30.766" y2="19.717" width="0.2032" layer="1"/>
+<wire x1="30.766" y1="19.717" x2="30.353" y2="19.304" width="0.2032" layer="1"/>
+<via x="30.353" y="19.304" extent="1-2" drill="0.2"/>
+<wire x1="30.353" y1="19.304" x2="30.353" y2="16.764" width="0.2032" layer="2"/>
+<wire x1="30.353" y1="16.764" x2="41.656" y2="5.461" width="0.2032" layer="2"/>
+<wire x1="41.656" y1="5.461" x2="58.72" y2="5.461" width="0.2032" layer="2"/>
+</signal>
+<signal name="DISP_DB7">
+<contactref element="IC2" pad="41"/>
+<contactref element="K4" pad="5"/>
+<wire x1="60.152" y1="4.492" x2="60.152" y2="5.426" width="0.2032" layer="1"/>
+<wire x1="60.152" y1="5.426" x2="59.863" y2="5.715" width="0.2032" layer="1"/>
+<via x="59.863" y="5.715" extent="1-2" drill="0.2"/>
+<wire x1="58.651" y1="6.281" x2="58.212" y2="5.842" width="0.2032" layer="2"/>
+<wire x1="58.212" y1="5.842" x2="41.91" y2="5.842" width="0.2032" layer="2"/>
+<wire x1="41.91" y1="5.842" x2="30.734" y2="17.018" width="0.2032" layer="2"/>
+<wire x1="30.734" y1="17.018" x2="30.734" y2="18.415" width="0.2032" layer="2"/>
+<wire x1="30.734" y1="18.415" x2="30.988" y2="18.669" width="0.2032" layer="2"/>
+<via x="30.988" y="18.669" extent="1-2" drill="0.2"/>
+<wire x1="30.988" y1="18.669" x2="31.266" y2="18.947" width="0.2032" layer="1"/>
+<wire x1="31.266" y1="18.947" x2="31.266" y2="21.06" width="0.2032" layer="1"/>
+<wire x1="58.651" y1="6.281" x2="59.297" y2="6.281" width="0.2032" layer="2"/>
+<wire x1="59.297" y1="6.281" x2="59.863" y2="5.715" width="0.2032" layer="2"/>
+</signal>
+<signal name="DISP_DB6">
+<contactref element="IC2" pad="40"/>
+<contactref element="K4" pad="6"/>
+<wire x1="60.552" y1="4.492" x2="60.552" y2="6.042" width="0.2032" layer="1"/>
+<wire x1="60.552" y1="6.042" x2="60.498" y2="6.096" width="0.2032" layer="1"/>
+<via x="60.498" y="6.096" extent="1-2" drill="0.2"/>
+<wire x1="60.498" y1="6.096" x2="60.498" y2="6.477" width="0.2032" layer="2"/>
+<wire x1="60.498" y1="6.477" x2="60.313" y2="6.662" width="0.2032" layer="2"/>
+<wire x1="60.313" y1="6.662" x2="58.37" y2="6.662" width="0.2032" layer="2"/>
+<wire x1="31.766" y1="21.06" x2="31.75" y2="21.044" width="0.2032" layer="1"/>
+<wire x1="31.75" y1="21.044" x2="31.75" y2="18.415" width="0.2032" layer="1"/>
+<wire x1="31.75" y1="18.415" x2="31.369" y2="18.034" width="0.2032" layer="1"/>
+<via x="31.369" y="18.034" extent="1-2" drill="0.2"/>
+<wire x1="31.369" y1="18.034" x2="31.369" y2="17.018" width="0.2032" layer="2"/>
+<wire x1="31.369" y1="17.018" x2="42.164" y2="6.223" width="0.2032" layer="2"/>
+<wire x1="42.164" y1="6.223" x2="57.931" y2="6.223" width="0.2032" layer="2"/>
+<wire x1="57.931" y1="6.223" x2="58.37" y2="6.662" width="0.2032" layer="2"/>
+</signal>
+<signal name="DISP_DB5">
+<contactref element="IC2" pad="39"/>
+<contactref element="K4" pad="7"/>
+<wire x1="60.952" y1="4.492" x2="60.952" y2="5.788" width="0.2032" layer="1"/>
+<wire x1="60.952" y1="5.788" x2="61.26" y2="6.096" width="0.2032" layer="1"/>
+<via x="61.26" y="6.096" extent="1-2" drill="0.2"/>
+<wire x1="61.26" y1="6.096" x2="61.26" y2="6.35" width="0.2032" layer="2"/>
+<wire x1="61.26" y1="6.35" x2="60.567" y2="7.043" width="0.2032" layer="2"/>
+<wire x1="60.567" y1="7.043" x2="58.089" y2="7.043" width="0.2032" layer="2"/>
+<wire x1="58.089" y1="7.043" x2="57.65" y2="6.604" width="0.2032" layer="2"/>
+<wire x1="57.65" y1="6.604" x2="42.418" y2="6.604" width="0.2032" layer="2"/>
+<wire x1="42.418" y1="6.604" x2="32.258" y2="16.764" width="0.2032" layer="2"/>
+<wire x1="32.258" y1="16.764" x2="32.258" y2="17.399" width="0.2032" layer="2"/>
+<via x="32.258" y="17.399" extent="1-2" drill="0.2"/>
+<wire x1="32.258" y1="17.399" x2="32.258" y2="21.052" width="0.2032" layer="1"/>
+<wire x1="32.258" y1="21.052" x2="32.266" y2="21.06" width="0.2032" layer="1"/>
+</signal>
+<signal name="DISP_DB4">
+<contactref element="IC2" pad="38"/>
+<contactref element="K4" pad="8"/>
+<wire x1="61.352" y1="4.492" x2="61.352" y2="5.172" width="0.2032" layer="1"/>
+<wire x1="61.352" y1="5.172" x2="61.895" y2="5.715" width="0.2032" layer="1"/>
+<via x="61.895" y="5.715" extent="1-2" drill="0.2"/>
+<wire x1="61.895" y1="5.715" x2="61.895" y2="6.35" width="0.2032" layer="2"/>
+<wire x1="61.895" y1="6.35" x2="60.821" y2="7.424" width="0.2032" layer="2"/>
+<wire x1="60.821" y1="7.424" x2="57.858" y2="7.424" width="0.2032" layer="2"/>
+<wire x1="32.766" y1="21.06" x2="32.766" y2="18.161" width="0.2032" layer="1"/>
+<wire x1="32.766" y1="18.161" x2="33.02" y2="17.907" width="0.2032" layer="1"/>
+<via x="33.02" y="17.907" extent="1-2" drill="0.2"/>
+<wire x1="33.02" y1="17.907" x2="33.02" y2="16.637" width="0.2032" layer="2"/>
+<wire x1="33.02" y1="16.637" x2="42.672" y2="6.985" width="0.2032" layer="2"/>
+<wire x1="42.672" y1="6.985" x2="57.419" y2="6.985" width="0.2032" layer="2"/>
+<wire x1="57.419" y1="6.985" x2="57.858" y2="7.424" width="0.2032" layer="2"/>
+</signal>
+<signal name="DISP_DB3">
+<contactref element="IC2" pad="82"/>
+<contactref element="K4" pad="9"/>
+<wire x1="61.752" y1="4.492" x2="61.752" y2="3.794" width="0.2032" layer="1"/>
+<wire x1="61.752" y1="3.794" x2="61.514" y2="3.556" width="0.2032" layer="1"/>
+<wire x1="61.514" y1="3.556" x2="51.054" y2="3.556" width="0.2032" layer="1"/>
+<via x="51.054" y="3.556" extent="1-2" drill="0.2"/>
+<wire x1="51.054" y1="3.556" x2="50.8" y2="3.81" width="0.2032" layer="2"/>
+<wire x1="50.8" y1="3.81" x2="31.877" y2="3.81" width="0.2032" layer="2"/>
+<wire x1="31.877" y1="3.81" x2="31.623" y2="4.064" width="0.2032" layer="2"/>
+<wire x1="31.623" y1="4.064" x2="30.226" y2="4.064" width="0.2032" layer="2"/>
+<via x="30.226" y="4.064" extent="1-2" drill="0.2"/>
+<wire x1="30.226" y1="4.064" x2="29.766" y2="4.524" width="0.2032" layer="1"/>
+<wire x1="29.766" y1="4.524" x2="29.766" y2="5.61" width="0.2032" layer="1"/>
+</signal>
+<signal name="DISP_DB2">
+<contactref element="IC2" pad="81"/>
+<contactref element="K4" pad="10"/>
+<wire x1="62.152" y1="4.492" x2="62.152" y2="3.934" width="0.2032" layer="1"/>
+<via x="62.403" y="3.683" extent="1-2" drill="0.2"/>
+<wire x1="62.403" y1="3.683" x2="62.276" y2="3.81" width="0.2032" layer="2"/>
+<wire x1="62.276" y1="3.81" x2="52.451" y2="3.81" width="0.2032" layer="2"/>
+<wire x1="52.451" y1="3.81" x2="51.535" y2="2.894" width="0.2032" layer="2"/>
+<wire x1="29.266" y1="5.61" x2="29.266" y2="3.754" width="0.2032" layer="1"/>
+<wire x1="29.266" y1="3.754" x2="29.591" y2="3.429" width="0.2032" layer="1"/>
+<via x="29.591" y="3.429" extent="1-2" drill="0.2"/>
+<wire x1="29.591" y1="3.429" x2="31.496" y2="3.429" width="0.2032" layer="2"/>
+<wire x1="31.496" y1="3.429" x2="31.523" y2="3.402" width="0.2032" layer="2"/>
+<wire x1="31.523" y1="3.402" x2="50.211" y2="3.402" width="0.2032" layer="2"/>
+<wire x1="50.211" y1="3.402" x2="50.719" y2="2.894" width="0.2032" layer="2"/>
+<wire x1="50.719" y1="2.894" x2="51.535" y2="2.894" width="0.2032" layer="2"/>
+<wire x1="62.403" y1="3.683" x2="62.152" y2="3.934" width="0.2032" layer="1"/>
+</signal>
+<signal name="DISP_DB1">
+<contactref element="IC2" pad="62"/>
+<contactref element="K4" pad="11"/>
+<wire x1="62.552" y1="4.492" x2="62.552" y2="5.864" width="0.2032" layer="1"/>
+<wire x1="62.552" y1="5.864" x2="62.784" y2="6.096" width="0.2032" layer="1"/>
+<via x="62.784" y="6.096" extent="1-2" drill="0.2"/>
+<wire x1="62.784" y1="6.096" x2="61.075" y2="7.805" width="0.2032" layer="2"/>
+<wire x1="61.075" y1="7.805" x2="57.627" y2="7.805" width="0.2032" layer="2"/>
+<wire x1="57.627" y1="7.805" x2="57.188" y2="7.366" width="0.2032" layer="2"/>
+<wire x1="57.188" y1="7.366" x2="42.926" y2="7.366" width="0.2032" layer="2"/>
+<wire x1="42.926" y1="7.366" x2="35.433" y2="14.859" width="0.2032" layer="2"/>
+<wire x1="25.041" y1="13.835" x2="26.408" y2="13.835" width="0.2032" layer="1"/>
+<wire x1="26.408" y1="13.835" x2="26.924" y2="14.351" width="0.2032" layer="1"/>
+<wire x1="26.924" y1="14.351" x2="28.575" y2="14.351" width="0.2032" layer="1"/>
+<wire x1="28.575" y1="14.351" x2="29.464" y2="15.24" width="0.2032" layer="1"/>
+<via x="29.464" y="15.24" extent="1-16" drill="0.3"/>
+<wire x1="29.464" y1="15.24" x2="29.718" y2="15.494" width="0.2032" layer="15"/>
+<wire x1="29.718" y1="15.494" x2="35.179" y2="15.494" width="0.2032" layer="15"/>
+<wire x1="35.179" y1="15.494" x2="35.433" y2="15.24" width="0.2032" layer="15"/>
+<via x="35.433" y="15.24" extent="1-16" drill="0.3"/>
+<wire x1="35.433" y1="15.24" x2="35.433" y2="14.859" width="0.2032" layer="2"/>
+</signal>
+<signal name="DISP_DB0">
+<contactref element="IC2" pad="61"/>
+<contactref element="K4" pad="12"/>
+<wire x1="62.952" y1="4.492" x2="62.952" y2="5.248" width="0.2032" layer="1"/>
+<wire x1="62.952" y1="5.248" x2="63.419" y2="5.715" width="0.2032" layer="1"/>
+<via x="63.419" y="5.715" extent="1-2" drill="0.2"/>
+<wire x1="63.419" y1="5.715" x2="63.419" y2="6.604" width="0.2032" layer="2"/>
+<wire x1="63.419" y1="6.604" x2="62.911" y2="7.112" width="0.2032" layer="2"/>
+<wire x1="62.911" y1="7.112" x2="62.403" y2="7.112" width="0.2032" layer="2"/>
+<wire x1="62.403" y1="7.112" x2="61.329" y2="8.186" width="0.2032" layer="2"/>
+<wire x1="61.329" y1="8.186" x2="57.396" y2="8.186" width="0.2032" layer="2"/>
+<wire x1="57.396" y1="8.186" x2="56.957" y2="7.747" width="0.2032" layer="2"/>
+<wire x1="56.957" y1="7.747" x2="43.18" y2="7.747" width="0.2032" layer="2"/>
+<wire x1="43.18" y1="7.747" x2="36.322" y2="14.605" width="0.2032" layer="2"/>
+<wire x1="36.322" y1="14.605" x2="36.322" y2="14.986" width="0.2032" layer="2"/>
+<wire x1="25.041" y1="14.335" x2="26.273" y2="14.335" width="0.2032" layer="1"/>
+<wire x1="26.273" y1="14.335" x2="26.67" y2="14.732" width="0.2032" layer="1"/>
+<wire x1="26.67" y1="14.732" x2="27.686" y2="14.732" width="0.2032" layer="1"/>
+<wire x1="27.686" y1="14.732" x2="28.321" y2="15.367" width="0.2032" layer="1"/>
+<via x="28.321" y="15.367" extent="1-16" drill="0.3"/>
+<wire x1="28.321" y1="15.367" x2="28.829" y2="15.875" width="0.2032" layer="15"/>
+<wire x1="28.829" y1="15.875" x2="35.814" y2="15.875" width="0.2032" layer="15"/>
+<wire x1="35.814" y1="15.875" x2="36.322" y2="15.367" width="0.2032" layer="15"/>
+<wire x1="36.322" y1="15.367" x2="36.322" y2="14.986" width="0.2032" layer="15"/>
+<via x="36.322" y="14.986" extent="1-16" drill="0.3"/>
+</signal>
+<signal name="DISP_!RD">
+<contactref element="K4" pad="14"/>
+<contactref element="IC2" pad="85"/>
+<wire x1="62.552" y1="7.192" x2="62.552" y2="7.642" width="0.2032" layer="1"/>
+<wire x1="62.552" y1="7.642" x2="62.811" y2="7.901" width="0.2032" layer="1"/>
+<wire x1="62.811" y1="7.901" x2="64.108" y2="7.901" width="0.2032" layer="1"/>
+<via x="64.108" y="7.901" extent="1-2" drill="0.2"/>
+<wire x1="64.108" y1="7.901" x2="64.108" y2="5.461" width="0.2032" layer="2"/>
+<wire x1="64.108" y1="5.461" x2="63.727" y2="5.08" width="0.2032" layer="2"/>
+<wire x1="63.727" y1="5.08" x2="61.514" y2="5.08" width="0.2032" layer="2"/>
+<wire x1="61.514" y1="5.08" x2="61.387" y2="4.953" width="0.2032" layer="2"/>
+<wire x1="61.387" y1="4.953" x2="34.544" y2="4.953" width="0.2032" layer="2"/>
+<wire x1="34.544" y1="4.953" x2="33.909" y2="5.588" width="0.2032" layer="2"/>
+<wire x1="33.909" y1="5.588" x2="33.909" y2="7.874" width="0.2032" layer="2"/>
+<wire x1="33.909" y1="7.874" x2="33.401" y2="8.382" width="0.2032" layer="2"/>
+<wire x1="33.401" y1="8.382" x2="31.877" y2="8.382" width="0.2032" layer="2"/>
+<via x="31.877" y="8.382" extent="1-2" drill="0.2"/>
+<wire x1="31.877" y1="8.382" x2="31.266" y2="7.771" width="0.2032" layer="1"/>
+<wire x1="31.266" y1="7.771" x2="31.266" y2="5.61" width="0.2032" layer="1"/>
+</signal>
+<signal name="DISP_!WR">
+<contactref element="K4" pad="15"/>
+<contactref element="IC2" pad="86"/>
+<wire x1="62.152" y1="7.192" x2="62.152" y2="7.877" width="0.2032" layer="1"/>
+<wire x1="62.152" y1="7.877" x2="62.811" y2="8.536" width="0.2032" layer="1"/>
+<wire x1="62.811" y1="8.536" x2="64.743" y2="8.536" width="0.2032" layer="1"/>
+<via x="64.743" y="8.536" extent="1-2" drill="0.2"/>
+<wire x1="64.743" y1="8.536" x2="64.743" y2="5.08" width="0.2032" layer="2"/>
+<wire x1="64.743" y1="5.08" x2="64.362" y2="4.699" width="0.2032" layer="2"/>
+<wire x1="64.362" y1="4.699" x2="61.768" y2="4.699" width="0.2032" layer="2"/>
+<wire x1="61.768" y1="4.699" x2="61.641" y2="4.572" width="0.2032" layer="2"/>
+<wire x1="61.641" y1="4.572" x2="34.163" y2="4.572" width="0.2032" layer="2"/>
+<wire x1="34.163" y1="4.572" x2="33.401" y2="5.334" width="0.2032" layer="2"/>
+<wire x1="33.401" y1="5.334" x2="33.401" y2="7.239" width="0.2032" layer="2"/>
+<wire x1="33.401" y1="7.239" x2="33.02" y2="7.62" width="0.2032" layer="2"/>
+<wire x1="33.02" y1="7.62" x2="31.877" y2="7.62" width="0.2032" layer="2"/>
+<via x="31.877" y="7.62" extent="1-2" drill="0.2"/>
+<wire x1="31.877" y1="7.62" x2="31.766" y2="7.509" width="0.2032" layer="1"/>
+<wire x1="31.766" y1="7.509" x2="31.766" y2="5.61" width="0.2032" layer="1"/>
+</signal>
+<signal name="DISP_RS">
+<contactref element="IC2" pad="58"/>
+<contactref element="K4" pad="16"/>
+<wire x1="61.752" y1="7.192" x2="61.752" y2="8.366" width="0.2032" layer="1"/>
+<wire x1="61.752" y1="8.366" x2="62.022" y2="8.636" width="0.2032" layer="1"/>
+<via x="62.022" y="8.636" extent="1-2" drill="0.2"/>
+<wire x1="57.038" y1="9.052" x2="56.495" y2="8.509" width="0.2032" layer="2"/>
+<wire x1="56.495" y1="8.509" x2="43.688" y2="8.509" width="0.2032" layer="2"/>
+<wire x1="43.688" y1="8.509" x2="37.846" y2="14.351" width="0.2032" layer="2"/>
+<wire x1="25.041" y1="15.835" x2="26.503" y2="15.835" width="0.2032" layer="1"/>
+<wire x1="26.503" y1="15.835" x2="27.305" y2="16.637" width="0.2032" layer="1"/>
+<via x="27.305" y="16.637" extent="1-16" drill="0.3"/>
+<wire x1="27.305" y1="16.637" x2="37.084" y2="16.637" width="0.2032" layer="15"/>
+<wire x1="37.084" y1="16.637" x2="37.846" y2="15.875" width="0.2032" layer="15"/>
+<via x="37.846" y="15.875" extent="1-16" drill="0.3"/>
+<wire x1="37.846" y1="15.875" x2="37.846" y2="14.351" width="0.2032" layer="2"/>
+<wire x1="57.038" y1="9.052" x2="59.452" y2="9.052" width="0.2032" layer="2"/>
+<wire x1="59.452" y1="9.052" x2="60" y2="9.6" width="0.2032" layer="2"/>
+<wire x1="60" y1="9.6" x2="61.058" y2="9.6" width="0.2032" layer="2"/>
+<wire x1="61.058" y1="9.6" x2="62.022" y2="8.636" width="0.2032" layer="2"/>
+</signal>
+<signal name="DISP_!CS">
+<contactref element="IC2" pad="88"/>
+<contactref element="K4" pad="17"/>
+<wire x1="61.352" y1="7.192" x2="61.352" y2="8.855" width="0.2032" layer="1"/>
+<wire x1="61.352" y1="8.855" x2="61.668" y2="9.171" width="0.2032" layer="1"/>
+<via x="65.528" y="8.971" extent="1-2" drill="0.2"/>
+<wire x1="65.528" y1="8.971" x2="65.528" y2="4.826" width="0.2032" layer="2"/>
+<wire x1="65.528" y1="4.826" x2="65.02" y2="4.318" width="0.2032" layer="2"/>
+<wire x1="65.02" y1="4.318" x2="62.022" y2="4.318" width="0.2032" layer="2"/>
+<wire x1="62.022" y1="4.318" x2="61.895" y2="4.191" width="0.2032" layer="2"/>
+<wire x1="61.895" y1="4.191" x2="33.782" y2="4.191" width="0.2032" layer="2"/>
+<wire x1="33.782" y1="4.191" x2="32.766" y2="5.207" width="0.2032" layer="2"/>
+<wire x1="32.766" y1="5.207" x2="32.766" y2="6.985" width="0.2032" layer="2"/>
+<via x="32.766" y="6.985" extent="1-2" drill="0.2"/>
+<wire x1="32.766" y1="6.985" x2="32.766" y2="5.61" width="0.2032" layer="1"/>
+<wire x1="61.668" y1="9.171" x2="65.328" y2="9.171" width="0.2032" layer="1"/>
+<wire x1="65.328" y1="9.171" x2="65.528" y2="8.971" width="0.2032" layer="1"/>
+</signal>
+<signal name="DISP_FMARK">
+<contactref element="IC2" pad="59"/>
+<contactref element="K4" pad="19"/>
+<wire x1="57.219" y1="8.621" x2="56.726" y2="8.128" width="0.2032" layer="2"/>
+<wire x1="56.726" y1="8.128" x2="43.434" y2="8.128" width="0.2032" layer="2"/>
+<wire x1="43.434" y1="8.128" x2="37.084" y2="14.478" width="0.2032" layer="2"/>
+<wire x1="37.084" y1="14.478" x2="37.084" y2="15.621" width="0.2032" layer="2"/>
+<wire x1="25.041" y1="15.335" x2="27.146" y2="15.335" width="0.2032" layer="1"/>
+<wire x1="27.146" y1="15.335" x2="27.178" y2="15.367" width="0.2032" layer="1"/>
+<via x="27.178" y="15.367" extent="1-16" drill="0.3"/>
+<wire x1="27.178" y1="15.367" x2="28.067" y2="16.256" width="0.2032" layer="15"/>
+<wire x1="28.067" y1="16.256" x2="36.449" y2="16.256" width="0.2032" layer="15"/>
+<wire x1="36.449" y1="16.256" x2="36.83" y2="15.875" width="0.2032" layer="15"/>
+<via x="36.83" y="15.875" extent="1-16" drill="0.3"/>
+<wire x1="36.83" y1="15.875" x2="37.084" y2="15.621" width="0.2032" layer="2"/>
+<wire x1="57.219" y1="8.621" x2="59.971" y2="8.621" width="0.2032" layer="2"/>
+<wire x1="59.971" y1="8.621" x2="60.4" y2="9.05" width="0.2032" layer="2"/>
+<via x="60.4" y="9.05" extent="1-2" drill="0.2"/>
+<wire x1="60.4" y1="9.05" x2="60.4" y2="8.7" width="0.2032" layer="1"/>
+<wire x1="60.4" y1="8.7" x2="60.55" y2="8.55" width="0.2032" layer="1"/>
+<wire x1="60.55" y1="8.55" x2="60.55" y2="7.194" width="0.2032" layer="1"/>
+<wire x1="60.55" y1="7.194" x2="60.552" y2="7.192" width="0.2032" layer="1"/>
+</signal>
+<signal name="DISP_!RESET">
+<contactref element="K4" pad="2"/>
+<contactref element="IC2" pad="8"/>
+<wire x1="40.491" y1="10.835" x2="43.865" y2="10.835" width="0.2032" layer="1"/>
+<wire x1="58.974" y1="4.514" x2="58.952" y2="4.492" width="0.2032" layer="1"/>
+<wire x1="57.049" y1="9.691" x2="57.577" y2="9.163" width="0.2032" layer="1"/>
+<wire x1="57.577" y1="9.163" x2="57.577" y2="7.112" width="0.2032" layer="1"/>
+<wire x1="57.577" y1="7.112" x2="58.085" y2="6.604" width="0.2032" layer="1"/>
+<wire x1="58.085" y1="6.604" x2="58.085" y2="5.334" width="0.2032" layer="1"/>
+<wire x1="58.085" y1="5.334" x2="58.339" y2="5.08" width="0.2032" layer="1"/>
+<wire x1="58.339" y1="5.08" x2="58.803" y2="5.08" width="0.2032" layer="1"/>
+<wire x1="58.952" y1="4.492" x2="58.952" y2="4.931" width="0.2032" layer="1"/>
+<wire x1="58.803" y1="5.08" x2="58.952" y2="4.931" width="0.2032" layer="1"/>
+<via x="44.4" y="10.3" extent="1-2" drill="0.3"/>
+<via x="57.049" y="9.691" extent="1-2" drill="0.3"/>
+<wire x1="46.6" y1="8.9" x2="56.258" y2="8.9" width="0.2032" layer="2"/>
+<wire x1="56.258" y1="8.9" x2="57.049" y2="9.691" width="0.2032" layer="2"/>
+<wire x1="43.865" y1="10.835" x2="44.4" y2="10.3" width="0.2032" layer="1"/>
+<wire x1="46.6" y1="8.9" x2="45.2" y2="10.3" width="0.2032" layer="2"/>
+<wire x1="45.2" y1="10.3" x2="44.4" y2="10.3" width="0.2032" layer="2"/>
+</signal>
+<signal name="SCL">
+<contactref element="K6" pad="2"/>
+<contactref element="IC2" pad="92"/>
+<contactref element="R15" pad="P$1"/>
+<wire x1="34.766" y1="5.61" x2="34.766" y2="7.461" width="0.2032" layer="1"/>
+<wire x1="34.766" y1="7.461" x2="35.298" y2="7.993" width="0.2032" layer="1"/>
+<via x="35.298" y="7.993" extent="1-2" drill="0.2"/>
+<wire x1="35.298" y1="10.549" x2="29.21" y2="16.637" width="0.2032" layer="2"/>
+<wire x1="29.21" y1="16.637" x2="29.21" y2="19.685" width="0.2032" layer="2"/>
+<wire x1="29.21" y1="19.685" x2="31.525" y2="22" width="0.2032" layer="2"/>
+<wire x1="43.6" y1="22" x2="44.4" y2="22.8" width="0.2032" layer="2"/>
+<wire x1="44.4" y1="22.8" x2="59.757" y2="22.8" width="0.2032" layer="2"/>
+<via x="62.2" y="27.4" extent="1-2" drill="0.2"/>
+<wire x1="66.455" y1="27.805" x2="65.975" y2="27.805" width="0.2032" layer="1"/>
+<wire x1="65.975" y1="27.805" x2="65.486" y2="28.294" width="0.2032" layer="1"/>
+<via x="65.486" y="28.294" extent="1-2" drill="0.2"/>
+<wire x1="65.486" y1="28.294" x2="65.078" y2="27.886" width="0.2032" layer="2"/>
+<wire x1="59.757" y1="22.8" x2="62.2" y2="25.243" width="0.2032" layer="2"/>
+<wire x1="31.525" y1="22" x2="43.6" y2="22" width="0.2032" layer="2"/>
+<wire x1="62.2" y1="27.4" x2="62.2" y2="25.243" width="0.2032" layer="2"/>
+<wire x1="65.078" y1="27.886" x2="62.686" y2="27.886" width="0.2032" layer="2"/>
+<wire x1="62.686" y1="27.886" x2="62.2" y2="27.4" width="0.2032" layer="2"/>
+<wire x1="61.408" y1="27.4" x2="62.2" y2="27.4" width="0.2032" layer="1"/>
+<wire x1="35.298" y1="7.993" x2="35.298" y2="10.549" width="0.2032" layer="2"/>
+<wire x1="34.766" y1="5.61" x2="34.75" y2="5.61" width="0.2032" layer="1"/>
+</signal>
+<signal name="SDA">
+<contactref element="K6" pad="3"/>
+<contactref element="IC2" pad="93"/>
+<contactref element="R16" pad="P$1"/>
+<wire x1="35.266" y1="5.61" x2="35.266" y2="6.818" width="0.2032" layer="1"/>
+<wire x1="35.266" y1="6.818" x2="35.887" y2="7.439" width="0.2032" layer="1"/>
+<via x="35.887" y="7.439" extent="1-2" drill="0.2"/>
+<wire x1="35.887" y1="10.595" x2="29.718" y2="16.764" width="0.2032" layer="2"/>
+<wire x1="29.718" y1="16.764" x2="29.718" y2="19.558" width="0.2032" layer="2"/>
+<wire x1="29.718" y1="19.558" x2="31.76" y2="21.6" width="0.2032" layer="2"/>
+<wire x1="43.9" y1="21.6" x2="44.7" y2="22.4" width="0.2032" layer="2"/>
+<wire x1="44.7" y1="22.4" x2="60.042" y2="22.4" width="0.2032" layer="2"/>
+<wire x1="66.455" y1="27.405" x2="65.486" y2="27.405" width="0.2032" layer="1"/>
+<via x="65.486" y="27.405" extent="1-2" drill="0.2"/>
+<wire x1="65.486" y1="27.405" x2="63.305" y2="27.405" width="0.2032" layer="2"/>
+<wire x1="31.76" y1="21.6" x2="43.9" y2="21.6" width="0.2032" layer="2"/>
+<wire x1="35.887" y1="7.439" x2="35.887" y2="10.595" width="0.2032" layer="2"/>
+<wire x1="60.042" y1="22.4" x2="62.8" y2="25.158" width="0.2032" layer="2"/>
+<wire x1="62.8" y1="25.158" x2="62.8" y2="26.2" width="0.2032" layer="2"/>
+<wire x1="62.8" y1="26.2" x2="62.8" y2="26.9" width="0.2032" layer="2"/>
+<wire x1="62.8" y1="26.9" x2="63.305" y2="27.405" width="0.2032" layer="2"/>
+<via x="62.8" y="26.2" extent="1-2" drill="0.2"/>
+<wire x1="61.408" y1="26.2" x2="62.8" y2="26.2" width="0.2032" layer="1"/>
+</signal>
+<signal name="EINT">
+<contactref element="K6" pad="4"/>
+<contactref element="R13" pad="P$1"/>
+<wire x1="66.455" y1="27.005" x2="66.005" y2="27.005" width="0.2032" layer="1"/>
+<wire x1="66.005" y1="27.005" x2="65.8" y2="26.8" width="0.2032" layer="1"/>
+<wire x1="65.8" y1="26.8" x2="65.8" y2="26.2" width="0.2032" layer="1"/>
+<wire x1="65.8" y1="26.2" x2="66.4" y2="25.6" width="0.2032" layer="1"/>
+<wire x1="66.4" y1="25.6" x2="66.4" y2="24.408" width="0.2032" layer="1"/>
+<wire x1="66.4" y1="24.408" x2="66.408" y2="24.4" width="0.2032" layer="1"/>
+</signal>
+<signal name="REST">
+<contactref element="K6" pad="5"/>
+<contactref element="R12" pad="P$2"/>
+<contactref element="IC2" pad="34"/>
+<wire x1="34.766" y1="21.06" x2="34.766" y2="19.866" width="0.2032" layer="1"/>
+<wire x1="34.766" y1="19.866" x2="34.6" y2="19.7" width="0.2032" layer="1"/>
+<via x="34.6" y="19.7" extent="1-2" drill="0.2"/>
+<wire x1="34.6" y1="19.7" x2="34.6" y2="20.7" width="0.2032" layer="2"/>
+<wire x1="34.6" y1="20.7" x2="35.1" y2="21.2" width="0.2032" layer="2"/>
+<wire x1="35.1" y1="21.2" x2="44.2" y2="21.2" width="0.2032" layer="2"/>
+<wire x1="44.2" y1="21.2" x2="45" y2="22" width="0.2032" layer="2"/>
+<wire x1="45" y1="22" x2="60.3" y2="22" width="0.2032" layer="2"/>
+<wire x1="60.3" y1="22" x2="64.1" y2="25.8" width="0.2032" layer="2"/>
+<wire x1="64.1" y1="25.8" x2="67.1" y2="25.8" width="0.2032" layer="2"/>
+<wire x1="67.1" y1="25.8" x2="67.5" y2="26.2" width="0.2032" layer="2"/>
+<via x="67.5" y="26.2" extent="1-2" drill="0.2"/>
+<wire x1="66.46" y1="26.6" x2="66.455" y2="26.605" width="0.2032" layer="1"/>
+<wire x1="66.455" y1="26.605" x2="67.5" y2="26.605" width="0.2" layer="1"/>
+<wire x1="67.5" y1="26.605" x2="67.5" y2="26.2" width="0.2" layer="1"/>
+<wire x1="67.5" y1="27.092" x2="67.5" y2="26.2" width="0.2" layer="1"/>
+</signal>
+<signal name="DISP_VCC">
+<contactref element="K4" pad="20"/>
+<contactref element="K4" pad="18"/>
+<contactref element="C18" pad="P$2"/>
+<contactref element="L4" pad="1"/>
+<contactref element="C26" pad="P$2"/>
+<contactref element="C47" pad="P$2"/>
+<wire x1="63.1" y1="10.292" x2="61.95" y2="10.292" width="0.3" layer="1"/>
+<wire x1="61.95" y1="10.292" x2="60.8" y2="10.292" width="0.3" layer="1"/>
+<wire x1="64.1" y1="10.6" x2="64.1" y2="10.3" width="0.3" layer="1"/>
+<wire x1="60.536" y1="10.292" x2="60.8" y2="10.292" width="0.2032" layer="1"/>
+<wire x1="64.1" y1="10.3" x2="64.092" y2="10.292" width="0.3" layer="1"/>
+<wire x1="64.092" y1="10.292" x2="63.1" y2="10.292" width="0.3" layer="1"/>
+<wire x1="60.952" y1="7.192" x2="60.952" y2="9.248" width="0.2032" layer="1"/>
+<wire x1="60.952" y1="9.248" x2="60.95" y2="9.25" width="0.2032" layer="1"/>
+<wire x1="60.152" y1="7.192" x2="60.152" y2="8.348" width="0.2032" layer="1"/>
+<wire x1="60.152" y1="8.348" x2="59.8" y2="8.7" width="0.2032" layer="1"/>
+<wire x1="59.8" y1="8.7" x2="59.8" y2="9.45" width="0.2032" layer="1"/>
+<wire x1="60.792" y1="10.3" x2="60.8" y2="10.292" width="0.2032" layer="1"/>
+<wire x1="60.952" y1="9.248" x2="60.952" y2="10.14" width="0.2032" layer="1"/>
+<wire x1="60.952" y1="10.14" x2="60.8" y2="10.292" width="0.2032" layer="1"/>
+<wire x1="59.8" y1="9.45" x2="60.642" y2="10.292" width="0.2032" layer="1"/>
+<wire x1="60.642" y1="10.292" x2="60.8" y2="10.292" width="0.2032" layer="1"/>
+</signal>
+<signal name="SD_CD">
+<contactref element="IC2" pad="7"/>
+<contactref element="K3" pad="CD"/>
+<via x="43.3" y="9.95" extent="1-16" drill="0.3"/>
+<wire x1="40.491" y1="10.335" x2="42.915" y2="10.335" width="0.2032" layer="1"/>
+<wire x1="57" y1="19.75" x2="57.1" y2="19.75" width="0.2" layer="1"/>
+<wire x1="57.1" y1="19.75" x2="57.1" y2="19.15" width="0.2032" layer="1"/>
+<wire x1="57.1" y1="19.15" x2="57.45" y2="18.8" width="0.2032" layer="1"/>
+<wire x1="57.45" y1="18.8" x2="57.45" y2="18.3" width="0.2032" layer="1"/>
+<via x="57.45" y="18.3" extent="1-16" drill="0.3"/>
+<wire x1="52.7" y1="18.3" x2="57.45" y2="18.3" width="0.2" layer="16"/>
+<wire x1="43.3" y1="11.582" x2="46.793" y2="15.075" width="0.2032" layer="16"/>
+<wire x1="46.793" y1="15.075" x2="49.475" y2="15.075" width="0.2032" layer="16"/>
+<wire x1="49.475" y1="15.075" x2="52.7" y2="18.3" width="0.2032" layer="16"/>
+<wire x1="42.915" y1="10.335" x2="43.3" y2="9.95" width="0.2032" layer="1"/>
+<wire x1="43.3" y1="11.582" x2="43.3" y2="9.95" width="0.2032" layer="16"/>
+</signal>
+<signal name="N$14">
+<wire x1="62.584" y1="21.779" x2="64.489" y2="21.779" width="0.254" layer="1"/>
+<wire x1="64.489" y1="21.779" x2="64.489" y2="20.255" width="0.254" layer="1"/>
+<wire x1="64.489" y1="20.255" x2="64.489" y2="18.731" width="0.254" layer="1"/>
+<wire x1="64.489" y1="18.731" x2="64.489" y2="17.207" width="0.254" layer="1"/>
+<wire x1="64.489" y1="17.207" x2="64.489" y2="15.683" width="0.254" layer="1"/>
+<wire x1="64.489" y1="15.683" x2="62.584" y2="15.683" width="0.254" layer="1"/>
+<wire x1="62.584" y1="15.683" x2="62.584" y2="17.207" width="0.254" layer="1"/>
+<wire x1="62.584" y1="17.207" x2="62.584" y2="18.731" width="0.254" layer="1"/>
+<wire x1="62.584" y1="18.731" x2="62.584" y2="20.255" width="0.254" layer="1"/>
+<wire x1="62.584" y1="20.255" x2="62.584" y2="21.779" width="0.254" layer="1"/>
+<wire x1="62.584" y1="18.731" x2="64.489" y2="18.731" width="0.254" layer="1"/>
+<wire x1="62.584" y1="17.207" x2="64.489" y2="17.207" width="0.254" layer="1"/>
+<wire x1="62.584" y1="20.255" x2="64.489" y2="20.255" width="0.254" layer="1"/>
+</signal>
+<signal name="N$15">
+<wire x1="62.584" y1="15.683" x2="64.489" y2="15.683" width="0.254" layer="2"/>
+<wire x1="64.489" y1="15.683" x2="64.489" y2="17.207" width="0.254" layer="2"/>
+<wire x1="64.489" y1="17.207" x2="64.489" y2="18.731" width="0.254" layer="2"/>
+<wire x1="64.489" y1="18.731" x2="64.489" y2="20.255" width="0.254" layer="2"/>
+<wire x1="64.489" y1="20.255" x2="64.489" y2="21.779" width="0.254" layer="2"/>
+<wire x1="64.489" y1="21.779" x2="62.584" y2="21.779" width="0.254" layer="2"/>
+<wire x1="62.584" y1="21.779" x2="62.584" y2="20.255" width="0.254" layer="2"/>
+<wire x1="62.584" y1="20.255" x2="62.584" y2="18.731" width="0.254" layer="2"/>
+<wire x1="62.584" y1="18.731" x2="62.584" y2="17.207" width="0.254" layer="2"/>
+<wire x1="62.584" y1="17.207" x2="62.584" y2="15.683" width="0.254" layer="2"/>
+<wire x1="62.584" y1="17.207" x2="64.489" y2="17.207" width="0.254" layer="2"/>
+<wire x1="62.584" y1="18.731" x2="64.489" y2="18.731" width="0.254" layer="2"/>
+<wire x1="62.584" y1="20.255" x2="64.489" y2="20.255" width="0.254" layer="2"/>
+</signal>
+<signal name="N$65">
+<wire x1="62.584" y1="15.683" x2="64.489" y2="15.683" width="0.254" layer="15"/>
+<wire x1="64.489" y1="15.683" x2="64.489" y2="17.207" width="0.254" layer="15"/>
+<wire x1="64.489" y1="17.207" x2="64.489" y2="18.731" width="0.254" layer="15"/>
+<wire x1="64.489" y1="18.731" x2="64.489" y2="20.255" width="0.254" layer="15"/>
+<wire x1="64.489" y1="20.255" x2="64.489" y2="21.779" width="0.254" layer="15"/>
+<wire x1="64.489" y1="21.779" x2="62.584" y2="21.779" width="0.254" layer="15"/>
+<wire x1="62.584" y1="21.779" x2="62.584" y2="20.255" width="0.254" layer="15"/>
+<wire x1="62.584" y1="20.255" x2="62.584" y2="18.731" width="0.254" layer="15"/>
+<wire x1="62.584" y1="18.731" x2="62.584" y2="17.207" width="0.254" layer="15"/>
+<wire x1="62.584" y1="17.207" x2="62.584" y2="15.683" width="0.254" layer="15"/>
+<wire x1="62.584" y1="17.207" x2="64.489" y2="17.207" width="0.254" layer="15"/>
+<wire x1="62.584" y1="18.731" x2="64.489" y2="18.731" width="0.254" layer="15"/>
+<wire x1="62.584" y1="20.255" x2="64.489" y2="20.255" width="0.254" layer="15"/>
+</signal>
+<signal name="N$66">
+<wire x1="62.584" y1="15.683" x2="64.489" y2="15.683" width="0.254" layer="16"/>
+<wire x1="64.489" y1="15.683" x2="64.489" y2="17.207" width="0.254" layer="16"/>
+<wire x1="64.489" y1="17.207" x2="64.489" y2="18.731" width="0.254" layer="16"/>
+<wire x1="64.489" y1="18.731" x2="64.489" y2="20.255" width="0.254" layer="16"/>
+<wire x1="64.489" y1="20.255" x2="64.489" y2="21.779" width="0.254" layer="16"/>
+<wire x1="64.489" y1="21.779" x2="62.584" y2="21.779" width="0.254" layer="16"/>
+<wire x1="62.584" y1="21.779" x2="62.584" y2="20.255" width="0.254" layer="16"/>
+<wire x1="62.584" y1="20.255" x2="62.584" y2="18.731" width="0.254" layer="16"/>
+<wire x1="62.584" y1="18.731" x2="62.584" y2="17.207" width="0.254" layer="16"/>
+<wire x1="62.584" y1="17.207" x2="62.584" y2="15.683" width="0.254" layer="16"/>
+<wire x1="62.584" y1="17.207" x2="64.489" y2="17.207" width="0.254" layer="16"/>
+<wire x1="62.584" y1="18.731" x2="64.489" y2="18.731" width="0.254" layer="16"/>
+<wire x1="62.584" y1="20.255" x2="64.489" y2="20.255" width="0.254" layer="16"/>
+</signal>
+<signal name="DP">
+<contactref element="K1" pad="A6"/>
+<contactref element="K1" pad="B6"/>
+<contactref element="D3" pad="2"/>
+<contactref element="IC2" pad="54"/>
+<via x="20.4" y="16.7" extent="1-2" drill="0.2"/>
+<wire x1="18.15" y1="16.6" x2="18.7" y2="16.6" width="0.2" layer="2"/>
+<wire x1="18.7" y1="16.6" x2="18.8" y2="16.7" width="0.2" layer="2"/>
+<wire x1="18.8" y1="16.7" x2="20.4" y2="16.7" width="0.2" layer="2"/>
+<wire x1="20.4" y1="16.7" x2="20.4" y2="16.8" width="0.2" layer="2"/>
+<wire x1="20.4" y1="16.8" x2="21.4" y2="17.8" width="0.2" layer="2"/>
+<wire x1="21.4" y1="17.8" x2="22.6" y2="17.8" width="0.2" layer="2"/>
+<wire x1="22.6" y1="17.8" x2="22.65" y2="17.75" width="0.2" layer="2"/>
+<via x="22.65" y="17.75" extent="1-2" drill="0.2"/>
+<wire x1="23.353" y1="17.147" x2="23.353" y2="17.072" width="0.2" layer="1"/>
+<wire x1="22.65" y1="17.75" x2="23.328" y2="17.072" width="0.2" layer="1"/>
+<wire x1="23.328" y1="17.072" x2="23.353" y2="17.072" width="0.2" layer="1"/>
+<wire x1="25.041" y1="17.835" x2="24.116" y2="17.835" width="0.2" layer="1"/>
+<wire x1="24.116" y1="17.835" x2="23.353" y2="17.072" width="0.2" layer="1"/>
+<wire x1="19.36" y1="17.25" x2="20.25" y2="17.25" width="0.15" layer="1"/>
+<wire x1="20.25" y1="17.25" x2="20.4" y2="17.1" width="0.15" layer="1"/>
+<wire x1="20.4" y1="17.1" x2="20.4" y2="16.7" width="0.15" layer="1"/>
+</signal>
+<signal name="DN">
+<contactref element="K1" pad="A7"/>
+<contactref element="K1" pad="B7"/>
+<contactref element="D3" pad="3"/>
+<contactref element="IC2" pad="53"/>
+<wire x1="18.7" y1="17.4" x2="18.8" y2="17.3" width="0.2" layer="2"/>
+<wire x1="18.8" y1="17.3" x2="20.1" y2="17.3" width="0.2" layer="2"/>
+<wire x1="20.1" y1="17.3" x2="21.2" y2="18.4" width="0.2" layer="2"/>
+<wire x1="21.2" y1="18.4" x2="22.6" y2="18.4" width="0.2" layer="2"/>
+<wire x1="22.6" y1="18.4" x2="22.65" y2="18.45" width="0.2" layer="2"/>
+<via x="22.65" y="18.45" extent="1-2" drill="0.2"/>
+<wire x1="22.65" y1="18.45" x2="22.67" y2="18.45" width="0.2" layer="1"/>
+<wire x1="22.67" y1="18.45" x2="23.348" y2="19.128" width="0.2" layer="1"/>
+<wire x1="25.041" y1="18.335" x2="24.141" y2="18.335" width="0.2" layer="1"/>
+<wire x1="24.141" y1="18.335" x2="23.348" y2="19.128" width="0.2" layer="1"/>
+<wire x1="18.225" y1="17.4" x2="18.875" y2="16.75" width="0.15" layer="1"/>
+<wire x1="18.875" y1="16.75" x2="19.36" y2="16.75" width="0.15" layer="1"/>
+<wire x1="18.7" y1="17.4" x2="18.15" y2="17.4" width="0.2" layer="2"/>
+<wire x1="18.15" y1="17.4" x2="18.225" y2="17.4" width="0.15" layer="1"/>
+</signal>
+<signal name="VBUS">
+<contactref element="K1" pad="A4"/>
+<contactref element="K1" pad="B9"/>
+<contactref element="K1" pad="B4"/>
+<contactref element="K1" pad="A9"/>
+<contactref element="D3" pad="4"/>
+<contactref element="D1" pad="A"/>
+<wire x1="19.177" y1="18.034" x2="19.177" y2="16.022" width="0.3048" layer="16"/>
+<wire x1="19.177" y1="16.022" x2="18.805" y2="15.65" width="0.3048" layer="16"/>
+<wire x1="18.15" y1="18.35" x2="18.861" y2="18.35" width="0.3048" layer="16"/>
+<wire x1="18.861" y1="18.35" x2="19.177" y2="18.034" width="0.3048" layer="16"/>
+<wire x1="18.15" y1="15.65" x2="18.805" y2="15.65" width="0.3048" layer="16"/>
+<wire x1="18.15" y1="15.65" x2="18.55" y2="15.65" width="0.2032" layer="1"/>
+<wire x1="18.55" y1="15.65" x2="18.65" y2="15.75" width="0.2032" layer="1"/>
+<wire x1="18.65" y1="15.75" x2="19.36" y2="15.75" width="0.2032" layer="1"/>
+<wire x1="18.15" y1="18.35" x2="18.55" y2="18.35" width="0.2032" layer="1"/>
+<wire x1="18.55" y1="18.35" x2="18.65" y2="18.25" width="0.2032" layer="1"/>
+<wire x1="18.65" y1="18.25" x2="19.36" y2="18.25" width="0.2032" layer="1"/>
+<wire x1="19.36" y1="18.25" x2="20.374" y2="18.25" width="0.3" layer="1"/>
+<wire x1="20.374" y1="18.25" x2="21.252" y2="19.128" width="0.3" layer="1"/>
+<wire x1="21.252" y1="19.128" x2="20.8" y2="19.58" width="0.3" layer="1"/>
+<wire x1="20.8" y1="19.58" x2="20.8" y2="20.2" width="0.3" layer="1"/>
+</signal>
+<signal name="CC1">
+<contactref element="K1" pad="A5"/>
+<contactref element="R4" pad="P$2"/>
+<wire x1="19.36" y1="17.75" x2="20.55" y2="17.75" width="0.15" layer="1"/>
+<wire x1="20.55" y1="17.75" x2="20.7" y2="17.9" width="0.15" layer="1"/>
+<wire x1="20.7" y1="17.9" x2="21.8" y2="17.9" width="0.15" layer="1"/>
+<wire x1="21.8" y1="17.9" x2="22.1" y2="18.2" width="0.15" layer="1"/>
+<wire x1="22.1" y1="18.2" x2="22.1" y2="20.192" width="0.15" layer="1"/>
+<wire x1="22.1" y1="20.192" x2="22.092" y2="20.2" width="0.15" layer="1"/>
+</signal>
+<signal name="CC2">
+<contactref element="K1" pad="B5"/>
+<contactref element="R5" pad="P$2"/>
+<wire x1="19.8374" y1="15.7517" x2="19.8374" y2="12.1674" width="0.1778" layer="2"/>
+<wire x1="19.8374" y1="12.1674" x2="19.304" y2="11.634" width="0.1778" layer="2"/>
+<via x="19.304" y="11.634" extent="1-2" drill="0.3"/>
+<wire x1="19.304" y1="11.634" x2="19.304" y2="10.922" width="0.2032" layer="1"/>
+<wire x1="19.4691" y1="16.12" x2="17.8083" y2="16.12" width="0.1" layer="2"/>
+<wire x1="19.4691" y1="16.12" x2="19.8374" y2="15.7517" width="0.1778" layer="2"/>
+<wire x1="17.8083" y1="16.12" x2="17.7283" y2="16.2" width="0.1778" layer="2"/>
+<wire x1="17.7283" y1="16.2" x2="17.35" y2="16.2" width="0.1778" layer="2"/>
+<contactref element="TP20" pad="1"/>
+<wire x1="20.6" y1="10.9" x2="19.304" y2="10.9" width="0.2032" layer="1"/>
+<wire x1="19.304" y1="10.9" x2="19.304" y2="10.922" width="0.2032" layer="1"/>
+</signal>
+<signal name="SBU1">
+<contactref element="K1" pad="A8"/>
+<contactref element="IC2" pad="25"/>
+<via x="20.972" y="15.3198" extent="1-16" drill="0.3" diameter="0.5"/>
+<wire x1="20.972" y1="15.3198" x2="24.286" y2="15.3198" width="0.2032" layer="15"/>
+<wire x1="24.286" y1="15.3198" x2="26.4922" y2="17.526" width="0.2032" layer="15"/>
+<wire x1="26.4922" y1="17.526" x2="36.703" y2="17.526" width="0.2032" layer="15"/>
+<wire x1="36.703" y1="17.526" x2="39.243" y2="20.066" width="0.2032" layer="15"/>
+<wire x1="39.243" y1="20.066" x2="40.513" y2="20.066" width="0.2032" layer="15"/>
+<via x="40.513" y="20.066" extent="1-16" drill="0.3"/>
+<wire x1="40.513" y1="20.066" x2="40.513" y2="19.357" width="0.2032" layer="1"/>
+<wire x1="40.513" y1="19.357" x2="40.491" y2="19.335" width="0.2032" layer="1"/>
+<contactref element="D2" pad="2"/>
+<contactref element="TP10" pad="1"/>
+<wire x1="40.513" y1="20.066" x2="41" y2="20.553" width="0.2032" layer="1"/>
+<wire x1="41" y1="20.553" x2="41" y2="21.3" width="0.2032" layer="1"/>
+<wire x1="19.36" y1="16.25" x2="20.0418" y2="16.25" width="0.15" layer="1"/>
+<wire x1="20.0418" y1="16.25" x2="20.972" y2="15.3198" width="0.15" layer="1"/>
+<wire x1="20.972" y1="15.3198" x2="20.972" y2="14.572" width="0.2032" layer="1"/>
+<wire x1="20.972" y1="14.572" x2="20.8" y2="14.4" width="0.2032" layer="1"/>
+</signal>
+<signal name="SBU2">
+<contactref element="K1" pad="B8"/>
+<contactref element="IC2" pad="26"/>
+<wire x1="39.6954" y1="21.3312" x2="39.6954" y2="23.0312" width="0.2032" layer="15"/>
+<via x="39.6954" y="23.0312" extent="1-16" drill="0.3"/>
+<wire x1="38.7604" y1="21.0312" x2="38.7604" y2="21.0566" width="0.2032" layer="1"/>
+<wire x1="38.7604" y1="21.0566" x2="38.7694" y2="21.0566" width="0.2032" layer="1"/>
+<wire x1="38.7694" y1="21.0566" x2="38.766" y2="21.06" width="0.2032" layer="1"/>
+<contactref element="D4" pad="2"/>
+<contactref element="TP11" pad="1"/>
+<wire x1="17.35" y1="17.8" x2="17.7" y2="17.8" width="0.1778" layer="15"/>
+<wire x1="17.7" y1="17.8" x2="17.775" y2="17.875" width="0.1778" layer="15"/>
+<wire x1="17.775" y1="17.875" x2="19.325" y2="17.875" width="0.1" layer="15"/>
+<wire x1="19.325" y1="17.875" x2="21.3" y2="15.9" width="0.2032" layer="15"/>
+<wire x1="21.3" y1="15.9" x2="22.1" y2="15.9" width="0.2032" layer="15"/>
+<via x="22.1" y="15.9" extent="1-16" drill="0.3"/>
+<wire x1="22.1" y1="15.9" x2="22.1" y2="14.4" width="0.2032" layer="1"/>
+<wire x1="36.4744" y1="18.1102" x2="26.1102" y2="18.1102" width="0.2032" layer="15"/>
+<wire x1="26.1102" y1="18.1102" x2="23.9" y2="15.9" width="0.2032" layer="15"/>
+<wire x1="23.9" y1="15.9" x2="22.1" y2="15.9" width="0.2032" layer="15"/>
+<wire x1="40.2312" y1="23.0312" x2="41" y2="23.8" width="0.2032" layer="1"/>
+<wire x1="36.4744" y1="18.1102" x2="39.6954" y2="21.3312" width="0.2032" layer="15"/>
+<wire x1="38.7694" y1="21.0566" x2="38.7694" y2="21.5694" width="0.2032" layer="1"/>
+<wire x1="38.7694" y1="21.5694" x2="39.6954" y2="22.4954" width="0.2032" layer="1"/>
+<wire x1="39.6954" y1="23.0312" x2="39.6954" y2="22.4954" width="0.2032" layer="1"/>
+<wire x1="40.2312" y1="23.0312" x2="39.6954" y2="23.0312" width="0.2032" layer="1"/>
+</signal>
+<signal name="N$2">
+<contactref element="R6" pad="P$2"/>
+<contactref element="C1" pad="P$2"/>
+<contactref element="K1" pad="SH3"/>
+<contactref element="K1" pad="SH4"/>
+<wire x1="16.383" y1="10.922" x2="17.526" y2="10.922" width="0.254" layer="1"/>
+<wire x1="16.383" y1="10.922" x2="16.361" y2="10.9" width="0.254" layer="1"/>
+<wire x1="16.361" y1="10.9" x2="15.7" y2="10.9" width="0.254" layer="1"/>
+<wire x1="15.7" y1="10.9" x2="15.4" y2="11.2" width="0.254" layer="1"/>
+<wire x1="15.4" y1="11.2" x2="13.6" y2="11.2" width="0.254" layer="1"/>
+<wire x1="17.526" y1="10.922" x2="17.526" y2="12.2" width="0.254" layer="1"/>
+<wire x1="17.526" y1="12.2" x2="17.825" y2="12.2" width="0.254" layer="1"/>
+</signal>
+<signal name="N$3">
+<contactref element="R7" pad="P$2"/>
+<contactref element="C25" pad="P$2"/>
+<contactref element="K1" pad="SH2"/>
+<contactref element="K1" pad="SH1"/>
+<wire x1="15.053" y1="22.8" x2="15.367" y2="23.114" width="0.254" layer="1"/>
+<wire x1="15.367" y1="23.114" x2="16.129" y2="23.114" width="0.254" layer="1"/>
+<wire x1="16.129" y1="23.114" x2="17.272" y2="23.114" width="0.254" layer="1"/>
+<wire x1="13.6" y1="22.8" x2="15.053" y2="22.8" width="0.254" layer="1"/>
+<wire x1="17.272" y1="23.114" x2="17.272" y2="22.028" width="0.254" layer="1"/>
+<wire x1="17.272" y1="22.028" x2="17.5" y2="21.8" width="0.254" layer="1"/>
+<wire x1="17.5" y1="21.8" x2="17.825" y2="21.8" width="0.254" layer="1"/>
+</signal>
+<signal name="N$8">
+<polygon width="0.2032" layer="2" pour="cutout" isolate="0.2032">
+<vertex x="13.5382" y="23.2156"/>
+<vertex x="14.0716" y="23.2156"/>
+<vertex x="14.097" y="23.2156" curve="-90"/>
+<vertex x="14.478" y="22.8346" curve="-90"/>
+<vertex x="14.0716" y="22.4282"/>
+<vertex x="13.5382" y="22.4282"/>
+<vertex x="13.1064" y="22.4282" curve="-90"/>
+<vertex x="12.7" y="22.8346" curve="-90"/>
+<vertex x="13.081" y="23.2156"/>
+</polygon>
+<polygon width="0.2032" layer="15" pour="cutout" isolate="0.2032">
+<vertex x="13.081" y="23.2156"/>
+<vertex x="14.097" y="23.2156" curve="-90"/>
+<vertex x="14.478" y="22.8346" curve="-90"/>
+<vertex x="14.0716" y="22.4282"/>
+<vertex x="13.1064" y="22.4282" curve="-90"/>
+<vertex x="12.7" y="22.8346" curve="-90"/>
+</polygon>
+<polygon width="0.2032" layer="2" pour="cutout" isolate="0.2032">
+<vertex x="13.081" y="11.6078"/>
+<vertex x="14.097" y="11.6078" curve="-90"/>
+<vertex x="14.478" y="11.2268" curve="-90"/>
+<vertex x="14.0716" y="10.8204"/>
+<vertex x="13.1064" y="10.8204" curve="-90"/>
+<vertex x="12.7" y="11.2268" curve="-90"/>
+</polygon>
+<polygon width="0.2032" layer="15" pour="cutout" isolate="0.2032">
+<vertex x="13.081" y="11.6078"/>
+<vertex x="14.097" y="11.6078" curve="-90"/>
+<vertex x="14.478" y="11.2268" curve="-90"/>
+<vertex x="14.0716" y="10.8204"/>
+<vertex x="13.1064" y="10.8204" curve="-90"/>
+<vertex x="12.7" y="11.2268" curve="-90"/>
+</polygon>
+</signal>
+<signal name="N$9">
+<polygon width="0.2032" layer="2" pour="cutout" isolate="0.2032">
+<vertex x="17.8308" y="22.1996"/>
+<vertex x="18.3134" y="22.1996" curve="-90"/>
+<vertex x="18.669" y="21.844" curve="-90"/>
+<vertex x="18.2626" y="21.4376"/>
+<vertex x="17.8308" y="21.4376"/>
+<vertex x="17.3228" y="21.4376" curve="-90"/>
+<vertex x="16.9672" y="21.7932" curve="-90"/>
+<vertex x="17.3736" y="22.1996"/>
+</polygon>
+<polygon width="0.2032" layer="15" pour="cutout" isolate="0.2032">
+<vertex x="17.3736" y="22.1996"/>
+<vertex x="18.3134" y="22.1996" curve="-90"/>
+<vertex x="18.669" y="21.844" curve="-90"/>
+<vertex x="18.2626" y="21.4376"/>
+<vertex x="17.3228" y="21.4376" curve="-90"/>
+<vertex x="16.9672" y="21.7932" curve="-90"/>
+</polygon>
+<polygon width="0.2032" layer="2" pour="cutout" isolate="0.2032">
+<vertex x="17.3736" y="12.5984"/>
+<vertex x="18.3134" y="12.5984" curve="-90"/>
+<vertex x="18.669" y="12.2428" curve="-90"/>
+<vertex x="18.2626" y="11.8364"/>
+<vertex x="17.3228" y="11.8364" curve="-90"/>
+<vertex x="16.9672" y="12.192" curve="-90"/>
+</polygon>
+<polygon width="0.2032" layer="15" pour="cutout" isolate="0.2032">
+<vertex x="17.3736" y="12.5984"/>
+<vertex x="18.3134" y="12.5984" curve="-90"/>
+<vertex x="18.669" y="12.2428" curve="-90"/>
+<vertex x="18.2626" y="11.8364"/>
+<vertex x="17.3228" y="11.8364" curve="-90"/>
+<vertex x="16.9672" y="12.192" curve="-90"/>
+</polygon>
+</signal>
+<signal name="N$10">
+<polygon width="0.2032" layer="2" pour="cutout">
+<vertex x="11.5" y="21.15"/>
+<vertex x="14.75" y="21.15"/>
+<vertex x="14.75" y="25.15"/>
+<vertex x="11.5" y="25.15"/>
+</polygon>
+<polygon width="0.2032" layer="2" pour="cutout">
+<vertex x="11.5" y="8.75"/>
+<vertex x="14.75" y="8.75"/>
+<vertex x="14.75" y="12.75"/>
+<vertex x="11.5" y="12.75"/>
+</polygon>
+<polygon width="0.2032" layer="15" pour="cutout">
+<vertex x="11.5" y="8.75"/>
+<vertex x="14.75" y="8.75"/>
+<vertex x="14.75" y="12.75"/>
+<vertex x="11.5" y="12.75"/>
+</polygon>
+<polygon width="0.2032" layer="15" pour="cutout">
+<vertex x="11.5" y="21.15"/>
+<vertex x="14.75" y="21.15"/>
+<vertex x="14.75" y="25.15"/>
+<vertex x="11.5" y="25.15"/>
+</polygon>
+</signal>
+<signal name="N$11">
+<polygon width="0.2032" layer="2" pour="cutout">
+<vertex x="16.85" y="22.65"/>
+<vertex x="18.9" y="22.65"/>
+<vertex x="18.9" y="20.3"/>
+<vertex x="16.85" y="20.3"/>
+</polygon>
+<polygon width="0.2032" layer="15" pour="cutout">
+<vertex x="16.85" y="22.65"/>
+<vertex x="18.9" y="22.65"/>
+<vertex x="18.9" y="20.4"/>
+<vertex x="16.85" y="20.4"/>
+</polygon>
+</signal>
+<signal name="N$12">
+<polygon width="0.2032" layer="2" pour="cutout">
+<vertex x="17.7" y="14.6"/>
+<vertex x="18.6" y="14.6"/>
+<vertex x="18.6" y="13.75"/>
+<vertex x="17.7" y="13.75"/>
+</polygon>
+</signal>
+<signal name="N$4">
+<contactref element="R18" pad="P$2"/>
+<contactref element="C36" pad="P$1"/>
+<wire x1="56.4" y1="17.292" x2="57.534" y2="17.292" width="0.2032" layer="1"/>
+<wire x1="57.534" y1="17.292" x2="57.55" y2="17.308" width="0.2032" layer="1"/>
+</signal>
+<signal name="N$6">
+<contactref element="R19" pad="P$2"/>
+<contactref element="C37" pad="P$1"/>
+<wire x1="45.6" y1="19.008" x2="46.8" y2="19.008" width="0.2032" layer="1"/>
+</signal>
+<signal name="N$7">
+<contactref element="R20" pad="P$2"/>
+<contactref element="C38" pad="P$1"/>
+<wire x1="48.7" y1="17.292" x2="48" y2="17.292" width="0.2032" layer="1"/>
+<wire x1="48" y1="17.292" x2="47.658" y2="16.95" width="0.2032" layer="1"/>
+</signal>
+<signal name="N$13">
+<contactref element="R21" pad="P$2"/>
+<contactref element="C39" pad="P$1"/>
+<wire x1="49.508" y1="15.9" x2="49.508" y2="16.508" width="0.2032" layer="1"/>
+<wire x1="49.508" y1="16.508" x2="49.7" y2="16.7" width="0.2032" layer="1"/>
+<wire x1="49.7" y1="16.7" x2="49.7" y2="17.092" width="0.2032" layer="1"/>
+<wire x1="49.7" y1="17.092" x2="49.9" y2="17.292" width="0.2032" layer="1"/>
+</signal>
+<signal name="N$16">
+<contactref element="R22" pad="P$2"/>
+<contactref element="C40" pad="P$1"/>
+<wire x1="53.05" y1="17.292" x2="53.05" y2="16.25" width="0.2032" layer="1"/>
+<wire x1="53.05" y1="16.25" x2="52.942" y2="16.25" width="0.2032" layer="1"/>
+</signal>
+<signal name="N$17">
+<contactref element="R23" pad="P$2"/>
+<contactref element="C43" pad="P$1"/>
+<wire x1="55.2" y1="17.292" x2="55.2" y2="16.25" width="0.2032" layer="1"/>
+<wire x1="55.2" y1="16.25" x2="55.292" y2="16.25" width="0.2032" layer="1"/>
+</signal>
+<signal name="HS_VBUS">
+<contactref element="R1" pad="P$1"/>
+<contactref element="R11" pad="P$1"/>
+<wire x1="23.322" y1="21.209" x2="24.465" y2="21.209" width="0.254" layer="1"/>
+<contactref element="IC2" pad="52"/>
+<wire x1="25.041" y1="18.835" x2="26.165" y2="18.835" width="0.2032" layer="1"/>
+<wire x1="26.165" y1="18.835" x2="26.5" y2="18.5" width="0.2032" layer="1"/>
+<via x="26.5" y="18.5" extent="1-2" drill="0.2"/>
+<wire x1="26.5" y1="18.5" x2="23.8" y2="21.2" width="0.2032" layer="2"/>
+<wire x1="23.8" y1="21.2" x2="22.5" y2="21.2" width="0.2032" layer="2"/>
+<via x="22.5" y="21.2" extent="1-2" drill="0.2"/>
+<wire x1="22.5" y1="21.2" x2="23.313" y2="21.2" width="0.2032" layer="1"/>
+<wire x1="23.313" y1="21.2" x2="23.322" y2="21.209" width="0.2032" layer="1"/>
+</signal>
+<signal name="MCU_EINT">
+<contactref element="R13" pad="P$2"/>
+<contactref element="IC2" pad="33"/>
+<wire x1="35.266" y1="21.06" x2="35.266" y2="19.834" width="0.2032" layer="1"/>
+<wire x1="35.266" y1="19.834" x2="35.4" y2="19.7" width="0.2032" layer="1"/>
+<via x="35.4" y="19.7" extent="1-2" drill="0.2"/>
+<wire x1="35.4" y1="19.7" x2="35.4" y2="20.6" width="0.2032" layer="2"/>
+<wire x1="35.4" y1="20.6" x2="35.6" y2="20.8" width="0.2032" layer="2"/>
+<wire x1="35.6" y1="20.8" x2="44.5" y2="20.8" width="0.2032" layer="2"/>
+<wire x1="44.5" y1="20.8" x2="45.3" y2="21.6" width="0.2032" layer="2"/>
+<wire x1="45.3" y1="21.6" x2="60.6" y2="21.6" width="0.2032" layer="2"/>
+<wire x1="60.6" y1="21.6" x2="63.4" y2="24.4" width="0.2032" layer="2"/>
+<wire x1="63.4" y1="24.4" x2="64.6" y2="24.4" width="0.2032" layer="2"/>
+<via x="64.6" y="24.4" extent="1-2" drill="0.2"/>
+<wire x1="64.6" y1="24.4" x2="65.392" y2="24.4" width="0.2032" layer="1"/>
+</signal>
+<signal name="N$5">
+<polygon width="0.2" layer="2" pour="cutout">
+<vertex x="18.8" y="17.8"/>
+<vertex x="19.9" y="17.8"/>
+<vertex x="21" y="18.9"/>
+<vertex x="23.3" y="18.9"/>
+<vertex x="23.3" y="17.3"/>
+<vertex x="21.6" y="17.3"/>
+<vertex x="20.6" y="16.3"/>
+<vertex x="20.2" y="16.3"/>
+<vertex x="20.2" y="15.9"/>
+<vertex x="21.1" y="15.9"/>
+<vertex x="22.1" y="16.9"/>
+<vertex x="23.5" y="16.9"/>
+<vertex x="23.5" y="19.3"/>
+<vertex x="21.1" y="19.3"/>
+<vertex x="19.8" y="18"/>
+<vertex x="18.8" y="18"/>
+</polygon>
+</signal>
+<signal name="N$18">
+<polygon width="0.2" layer="2" pour="cutout">
+<vertex x="62.7" y="8.6"/>
+<vertex x="64.1" y="8.6"/>
+<vertex x="64.1" y="8.9"/>
+<vertex x="62.7" y="8.9"/>
+</polygon>
+</signal>
+<signal name="N$19">
+<polygon width="0.2" layer="2" pour="cutout">
+<vertex x="63.9" y="26.9"/>
+<vertex x="64" y="26.9"/>
+<vertex x="64" y="26.4"/>
+<vertex x="63.9" y="26.4"/>
+</polygon>
+</signal>
+<signal name="N$20">
+<contactref element="C27" pad="P$2"/>
+<contactref element="C23" pad="P$2"/>
+<contactref element="K3" pad="4"/>
+<contactref element="T1" pad="3"/>
+<contactref element="C22" pad="2"/>
+<wire x1="55.85" y1="14.1" x2="55.75" y2="14.2" width="0.5" layer="1"/>
+<wire x1="55.75" y1="14.2" x2="52.75" y2="14.2" width="0.5" layer="1"/>
+<wire x1="52.75" y1="14.2" x2="52.5" y2="13.95" width="0.5" layer="1"/>
+<wire x1="52.5" y1="13.95" x2="51.5" y2="13.95" width="0.5" layer="1"/>
+<wire x1="51.5" y1="13.95" x2="51.5" y2="14.9" width="0.5" layer="1"/>
+<wire x1="51.5" y1="14.9" x2="52" y2="15.4" width="0.5" layer="1"/>
+<wire x1="52.008" y1="16.65" x2="52.008" y2="15.408" width="0.5" layer="1"/>
+<wire x1="52.008" y1="15.408" x2="52" y2="15.4" width="0.5" layer="1"/>
+<wire x1="52.008" y1="16.65" x2="52.008" y2="17.85" width="0.5" layer="1"/>
+<wire x1="52.008" y1="17.85" x2="52.008" y2="18.392" width="0.5" layer="1"/>
+<wire x1="52.008" y1="18.392" x2="51.7" y2="18.7" width="0.5" layer="1"/>
+<wire x1="51.7" y1="18.7" x2="51.7" y2="19.6" width="0.5" layer="1"/>
+<wire x1="51.7" y1="19.6" x2="51.55" y2="19.75" width="0.5" layer="1"/>
+<contactref element="TP15" pad="1"/>
+<contactref element="C48" pad="P$1"/>
+<wire x1="57.1" y1="14.217" x2="55.85" y2="14.217" width="0.2" layer="1"/>
+<wire x1="55.85" y1="14.217" x2="55.85" y2="14.1" width="0.2" layer="1"/>
+</signal>
+<signal name="N$23">
+<contactref element="R2" pad="P$1"/>
+<contactref element="C57" pad="P$2"/>
+<contactref element="T1" pad="2"/>
+<contactref element="R3" pad="P$2"/>
+<wire x1="54.742" y1="10.7" x2="54.742" y2="11.716" width="0.2032" layer="1"/>
+<wire x1="54.742" y1="11.716" x2="54.608" y2="11.85" width="0.2032" layer="1"/>
+<wire x1="55.95" y1="11.742" x2="54.8" y2="11.742" width="0.2032" layer="1"/>
+<wire x1="54.8" y1="11.742" x2="54.65" y2="11.892" width="0.2032" layer="1"/>
+<wire x1="54.608" y1="11.85" x2="54.65" y2="11.892" width="0.2032" layer="1"/>
+<wire x1="54.65" y1="11.892" x2="54.65" y2="12.7" width="0.2032" layer="1"/>
+<via x="54.65" y="12.7" extent="1-16" drill="0.3"/>
+<wire x1="54.65" y1="12.7" x2="54.65" y2="15" width="0.2032" layer="16"/>
+<via x="54.65" y="15" extent="1-16" drill="0.3"/>
+<wire x1="54.65" y1="15" x2="53.45" y2="15" width="0.2032" layer="1"/>
+<wire x1="53.45" y1="15" x2="53.45" y2="15.05" width="0.2032" layer="1"/>
+<contactref element="C48" pad="P$2"/>
+<wire x1="54.65" y1="15" x2="55.125" y2="15" width="0.2" layer="1"/>
+<wire x1="55.125" y1="15" x2="55.35" y2="14.775" width="0.2" layer="1"/>
+<wire x1="55.35" y1="14.775" x2="56.1" y2="14.775" width="0.2" layer="1"/>
+<wire x1="56.1" y1="14.775" x2="56.55" y2="15.225" width="0.2" layer="1"/>
+<wire x1="56.55" y1="15.225" x2="57.092" y2="15.225" width="0.2" layer="1"/>
+<wire x1="57.092" y1="15.225" x2="57.1" y2="15.233" width="0.2" layer="1"/>
+</signal>
+<signal name="SD_ON">
+<contactref element="R3" pad="P$1"/>
+<contactref element="IC2" pad="15"/>
+<via x="54.9" y="13.45" extent="1-2" drill="0.2"/>
+<wire x1="55.3" y1="13.05" x2="55.3" y2="9.6" width="0.2032" layer="2"/>
+<wire x1="55.3" y1="9.6" x2="55" y2="9.3" width="0.2032" layer="2"/>
+<wire x1="55" y1="9.3" x2="46.85" y2="9.3" width="0.2032" layer="2"/>
+<wire x1="46.85" y1="9.3" x2="45.45" y2="10.7" width="0.2032" layer="2"/>
+<wire x1="45.45" y1="10.7" x2="44.95" y2="10.7" width="0.2032" layer="2"/>
+<wire x1="44.95" y1="10.7" x2="44.7" y2="10.95" width="0.2032" layer="2"/>
+<wire x1="44.7" y1="10.95" x2="41.9" y2="10.95" width="0.2032" layer="2"/>
+<wire x1="41.9" y1="10.95" x2="39.15" y2="13.7" width="0.2032" layer="2"/>
+<wire x1="39.15" y1="13.7" x2="39.15" y2="14.65" width="0.2032" layer="2"/>
+<via x="39.15" y="14.65" extent="1-2" drill="0.2"/>
+<wire x1="40.491" y1="14.335" x2="39.465" y2="14.335" width="0.2032" layer="1"/>
+<wire x1="39.465" y1="14.335" x2="39.15" y2="14.65" width="0.2032" layer="1"/>
+<wire x1="54.9" y1="13.45" x2="55.45" y2="12.9" width="0.2032" layer="1"/>
+<wire x1="55.808" y1="12.9" x2="55.95" y2="12.758" width="0.2032" layer="1"/>
+<wire x1="55.808" y1="12.9" x2="55.45" y2="12.9" width="0.2032" layer="1"/>
+<wire x1="55.3" y1="13.05" x2="54.9" y2="13.45" width="0.2032" layer="2"/>
+</signal>
+<signal name="N$1">
+<contactref element="T2" pad="3"/>
+<contactref element="L3" pad="1"/>
+<wire x1="61.4" y1="29.3" x2="61.4" y2="30.2" width="0.3" layer="1"/>
+<wire x1="61.4" y1="30.2" x2="61.7" y2="30.5" width="0.3" layer="1"/>
+<contactref element="C58" pad="P$2"/>
+<wire x1="61.7" y1="30.5" x2="63.567" y2="30.5" width="0.3" layer="1"/>
+<wire x1="63.567" y1="30.5" x2="63.575" y2="30.492" width="0.3" layer="1"/>
+<wire x1="65" y1="30.5" x2="63.583" y2="30.5" width="0.3" layer="1"/>
+<wire x1="63.583" y1="30.5" x2="63.575" y2="30.492" width="0.3" layer="1"/>
+</signal>
+<signal name="TOUCH_ON">
+<via x="58.1" y="24" extent="1-2" drill="0.2"/>
+<contactref element="IC2" pad="47"/>
+<wire x1="58.1" y1="24" x2="57.3" y2="23.2" width="0.2" layer="2"/>
+<wire x1="57.3" y1="23.2" x2="44.1" y2="23.2" width="0.2" layer="2"/>
+<wire x1="44.1" y1="23.2" x2="43.3" y2="22.4" width="0.2" layer="2"/>
+<wire x1="43.3" y1="22.4" x2="31.3" y2="22.4" width="0.2" layer="2"/>
+<wire x1="31.3" y1="22.4" x2="28.5" y2="19.6" width="0.2" layer="2"/>
+<via x="28.5" y="19.6" extent="1-2" drill="0.2"/>
+<wire x1="28.266" y1="21.06" x2="28.266" y2="19.834" width="0.2" layer="1"/>
+<wire x1="28.266" y1="19.834" x2="28.5" y2="19.6" width="0.2" layer="1"/>
+<contactref element="R24" pad="P$2"/>
+<wire x1="58.1" y1="24" x2="59" y2="24" width="0.2" layer="1"/>
+<wire x1="59" y1="24" x2="59" y2="23.992" width="0.2" layer="1"/>
+</signal>
+<signal name="VDD">
+<contactref element="C24" pad="P$2"/>
+<contactref element="K6" pad="1"/>
+<contactref element="C49" pad="P$2"/>
+<contactref element="L3" pad="2"/>
+<contactref element="C19" pad="2"/>
+<contactref element="R16" pad="P$2"/>
+<contactref element="R15" pad="P$2"/>
+<contactref element="R12" pad="P$1"/>
+<wire x1="65" y1="32.1" x2="66.05" y2="32.1" width="0.3" layer="1"/>
+<wire x1="66.05" y1="32.1" x2="66.3" y2="32.1" width="0.2" layer="1"/>
+<polygon width="0.2" layer="15">
+<vertex x="60.4" y="27.9"/>
+<vertex x="60.4" y="32.6"/>
+<vertex x="68.4" y="32.6"/>
+<vertex x="68.4" y="27.9"/>
+</polygon>
+<via x="67.448" y="32.25" extent="1-16" drill="0.3"/>
+<via x="68.1" y="31.8" extent="1-16" drill="0.3"/>
+<via x="61" y="28.3" extent="1-16" drill="0.3"/>
+<wire x1="66.455" y1="28.205" x2="67.403" y2="28.205" width="0.2" layer="1"/>
+<wire x1="67.403" y1="28.205" x2="67.5" y2="28.108" width="0.2" layer="1"/>
+<wire x1="68.408" y1="29.2" x2="68.408" y2="30.375" width="0.3" layer="1"/>
+<wire x1="61" y1="28.3" x2="60.6" y2="28.3" width="0.2" layer="1"/>
+<wire x1="60.6" y1="28.3" x2="60.392" y2="28.092" width="0.2" layer="1"/>
+<wire x1="60.392" y1="27.4" x2="60.392" y2="28.092" width="0.2" layer="1"/>
+<wire x1="60.392" y1="27.4" x2="60.392" y2="26.2" width="0.2" layer="1"/>
+<polygon width="0.2" layer="1" thermals="no">
+<vertex x="64.65" y="31.8"/>
+<vertex x="67.475" y="31.8"/>
+<vertex x="68.225" y="31.05"/>
+<vertex x="68.225" y="28.8"/>
+<vertex x="68.95" y="28.8"/>
+<vertex x="68.95" y="32.6"/>
+<vertex x="64.65" y="32.6"/>
+</polygon>
+<contactref element="TP16" pad="1"/>
+<wire x1="67.5" y1="28.108" x2="68.058" y2="28.108" width="0.3" layer="1"/>
+<wire x1="68.058" y1="28.108" x2="68.408" y2="28.458" width="0.3" layer="1"/>
+<wire x1="68.408" y1="29.2" x2="68.408" y2="28.458" width="0.3" layer="1"/>
+</signal>
+<signal name="N$27">
+<contactref element="R17" pad="P$2"/>
+<contactref element="T2" pad="2"/>
+<contactref element="R24" pad="P$1"/>
+<contactref element="C50" pad="P$2"/>
+<wire x1="60.392" y1="25" x2="59" y2="25" width="0.2" layer="1"/>
+<wire x1="59" y1="25" x2="59" y2="25.008" width="0.2" layer="1"/>
+<wire x1="62.35" y1="31.7" x2="61.4" y2="31.7" width="0.2" layer="1"/>
+<via x="61.4" y="31.7" extent="1-2" drill="0.2"/>
+<wire x1="61.4" y1="31.7" x2="61.075" y2="31.7" width="0.2" layer="2"/>
+<wire x1="61.075" y1="31.7" x2="60.65" y2="31.275" width="0.2" layer="2"/>
+<wire x1="60.65" y1="31.275" x2="60.65" y2="29.425" width="0.2" layer="2"/>
+<wire x1="60.65" y1="29.425" x2="59" y2="27.775" width="0.2" layer="2"/>
+<wire x1="59" y1="27.775" x2="59" y2="25.775" width="0.2" layer="2"/>
+<via x="59" y="25.775" extent="1-2" drill="0.2"/>
+<wire x1="59" y1="25.775" x2="59" y2="26.492" width="0.2" layer="1"/>
+<wire x1="59" y1="25.008" x2="59" y2="25.775" width="0.2" layer="1"/>
+<contactref element="C58" pad="P$1"/>
+<wire x1="63.575" y1="31.508" x2="62.542" y2="31.508" width="0.2" layer="1"/>
+<wire x1="62.542" y1="31.508" x2="62.35" y2="31.7" width="0.2" layer="1"/>
+</signal>
+</signals>
+</board>
+</drawing>
+</eagle>

--- a/docs/hardware/model-t/assets/CYM1A113.sch
+++ b/docs/hardware/model-t/assets/CYM1A113.sch
@@ -1,0 +1,8474 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!DOCTYPE eagle SYSTEM "eagle.dtd">
+<eagle version="7.7.0">
+<drawing>
+<settings>
+<setting alwaysvectorfont="no"/>
+<setting verticaltext="up"/>
+</settings>
+<grid distance="50" unitdist="mil" unit="mil" style="dots" multiple="1" display="yes" altdistance="0.01" altunitdist="inch" altunit="inch"/>
+<layers>
+<layer number="1" name="Top" color="4" fill="1" visible="no" active="no"/>
+<layer number="2" name="Route2" color="1" fill="3" visible="no" active="no"/>
+<layer number="3" name="Route3" color="4" fill="3" visible="no" active="no"/>
+<layer number="4" name="Route4" color="1" fill="4" visible="no" active="no"/>
+<layer number="5" name="Route5" color="4" fill="4" visible="no" active="no"/>
+<layer number="6" name="Route6" color="1" fill="8" visible="no" active="no"/>
+<layer number="7" name="Route7" color="4" fill="8" visible="no" active="no"/>
+<layer number="8" name="Route8" color="1" fill="2" visible="no" active="no"/>
+<layer number="9" name="Route9" color="4" fill="2" visible="no" active="no"/>
+<layer number="10" name="Route10" color="1" fill="7" visible="no" active="no"/>
+<layer number="11" name="Route11" color="4" fill="7" visible="no" active="no"/>
+<layer number="12" name="Route12" color="1" fill="5" visible="no" active="no"/>
+<layer number="13" name="Route13" color="4" fill="5" visible="no" active="no"/>
+<layer number="14" name="Route14" color="1" fill="6" visible="no" active="no"/>
+<layer number="15" name="Route15" color="4" fill="6" visible="no" active="no"/>
+<layer number="16" name="Bottom" color="1" fill="1" visible="no" active="no"/>
+<layer number="17" name="Pads" color="2" fill="1" visible="no" active="no"/>
+<layer number="18" name="Vias" color="2" fill="1" visible="no" active="no"/>
+<layer number="19" name="Unrouted" color="6" fill="1" visible="no" active="no"/>
+<layer number="20" name="Dimension" color="15" fill="1" visible="no" active="no"/>
+<layer number="21" name="tPlace" color="7" fill="1" visible="no" active="no"/>
+<layer number="22" name="bPlace" color="7" fill="1" visible="no" active="no"/>
+<layer number="23" name="tOrigins" color="15" fill="1" visible="no" active="no"/>
+<layer number="24" name="bOrigins" color="15" fill="1" visible="no" active="no"/>
+<layer number="25" name="tNames" color="7" fill="1" visible="no" active="no"/>
+<layer number="26" name="bNames" color="7" fill="1" visible="no" active="no"/>
+<layer number="27" name="tValues" color="7" fill="1" visible="no" active="no"/>
+<layer number="28" name="bValues" color="7" fill="1" visible="no" active="no"/>
+<layer number="29" name="tStop" color="7" fill="3" visible="no" active="no"/>
+<layer number="30" name="bStop" color="7" fill="6" visible="no" active="no"/>
+<layer number="31" name="tCream" color="7" fill="4" visible="no" active="no"/>
+<layer number="32" name="bCream" color="7" fill="5" visible="no" active="no"/>
+<layer number="33" name="tFinish" color="6" fill="3" visible="no" active="no"/>
+<layer number="34" name="bFinish" color="6" fill="6" visible="no" active="no"/>
+<layer number="35" name="tGlue" color="7" fill="4" visible="no" active="no"/>
+<layer number="36" name="bGlue" color="7" fill="5" visible="no" active="no"/>
+<layer number="37" name="tTest" color="7" fill="1" visible="no" active="no"/>
+<layer number="38" name="bTest" color="7" fill="1" visible="no" active="no"/>
+<layer number="39" name="tKeepout" color="4" fill="11" visible="no" active="no"/>
+<layer number="40" name="bKeepout" color="1" fill="11" visible="no" active="no"/>
+<layer number="41" name="tRestrict" color="14" fill="10" visible="no" active="no"/>
+<layer number="42" name="bRestrict" color="1" fill="10" visible="no" active="no"/>
+<layer number="43" name="vRestrict" color="2" fill="10" visible="no" active="no"/>
+<layer number="44" name="Drills" color="7" fill="1" visible="no" active="no"/>
+<layer number="45" name="Holes" color="7" fill="1" visible="no" active="no"/>
+<layer number="46" name="Milling" color="3" fill="1" visible="no" active="no"/>
+<layer number="47" name="Measures" color="14" fill="1" visible="no" active="no"/>
+<layer number="48" name="Document" color="7" fill="1" visible="no" active="no"/>
+<layer number="49" name="Reference" color="7" fill="1" visible="no" active="no"/>
+<layer number="50" name="XPads" color="7" fill="1" visible="no" active="no"/>
+<layer number="51" name="tDocu" color="7" fill="1" visible="no" active="no"/>
+<layer number="52" name="bDocu" color="7" fill="1" visible="no" active="no"/>
+<layer number="53" name="tGND_GNDA" color="7" fill="1" visible="no" active="no"/>
+<layer number="54" name="bGND_GNDA" color="7" fill="1" visible="no" active="no"/>
+<layer number="56" name="wert" color="7" fill="1" visible="no" active="no"/>
+<layer number="59" name="tCarbon" color="7" fill="1" visible="no" active="no"/>
+<layer number="60" name="bCarbon" color="7" fill="1" visible="no" active="no"/>
+<layer number="90" name="Modules" color="5" fill="1" visible="yes" active="yes"/>
+<layer number="91" name="Nets" color="2" fill="1" visible="yes" active="yes"/>
+<layer number="92" name="Busses" color="1" fill="1" visible="yes" active="yes"/>
+<layer number="93" name="Pins" color="2" fill="1" visible="no" active="yes"/>
+<layer number="94" name="Symbols" color="4" fill="1" visible="yes" active="yes"/>
+<layer number="95" name="Names" color="7" fill="1" visible="yes" active="yes"/>
+<layer number="96" name="Values" color="7" fill="1" visible="yes" active="yes"/>
+<layer number="97" name="Info" color="7" fill="1" visible="yes" active="yes"/>
+<layer number="98" name="Guide" color="6" fill="1" visible="yes" active="yes"/>
+<layer number="99" name="SpiceOrder" color="5" fill="1" visible="yes" active="yes"/>
+<layer number="100" name="Muster" color="7" fill="1" visible="yes" active="yes"/>
+<layer number="101" name="Potisk" color="14" fill="1" visible="yes" active="yes"/>
+<layer number="102" name="BotNames" color="7" fill="1" visible="yes" active="yes"/>
+<layer number="103" name="Ramecek" color="7" fill="1" visible="yes" active="yes"/>
+<layer number="104" name="DATUMY" color="7" fill="1" visible="yes" active="yes"/>
+<layer number="105" name="vr_nula" color="7" fill="1" visible="yes" active="yes"/>
+<layer number="106" name="Vrtaky" color="7" fill="1" visible="yes" active="yes"/>
+<layer number="107" name="Uhlik" color="7" fill="1" visible="yes" active="yes"/>
+<layer number="108" name="tKoment" color="7" fill="1" visible="yes" active="yes"/>
+<layer number="109" name="bKoment" color="7" fill="1" visible="yes" active="yes"/>
+<layer number="110" name="ram" color="7" fill="1" visible="yes" active="yes"/>
+<layer number="111" name="ram_m" color="7" fill="1" visible="yes" active="yes"/>
+<layer number="112" name="tSilk" color="7" fill="1" visible="yes" active="yes"/>
+<layer number="113" name="113" color="7" fill="1" visible="yes" active="yes"/>
+<layer number="114" name="Drill_legend" color="7" fill="1" visible="yes" active="yes"/>
+<layer number="116" name="Patch_BOT" color="7" fill="1" visible="yes" active="yes"/>
+<layer number="118" name="Rect_Pads" color="7" fill="1" visible="yes" active="yes"/>
+<layer number="120" name="Descript" color="7" fill="1" visible="yes" active="yes"/>
+<layer number="121" name="RectA" color="7" fill="1" visible="yes" active="yes"/>
+<layer number="122" name="RectB" color="7" fill="1" visible="yes" active="yes"/>
+<layer number="123" name="tTestmark" color="7" fill="1" visible="yes" active="yes"/>
+<layer number="124" name="bTestmark" color="7" fill="1" visible="yes" active="yes"/>
+<layer number="125" name="_tNames" color="7" fill="1" visible="yes" active="yes"/>
+<layer number="126" name="_bNames" color="7" fill="1" visible="yes" active="yes"/>
+<layer number="127" name="_tValues" color="7" fill="1" visible="yes" active="yes"/>
+<layer number="128" name="_bValues" color="7" fill="1" visible="yes" active="yes"/>
+<layer number="129" name="Mask" color="7" fill="1" visible="yes" active="yes"/>
+<layer number="131" name="tAdjust" color="7" fill="1" visible="yes" active="yes"/>
+<layer number="132" name="bAdjust" color="7" fill="1" visible="yes" active="yes"/>
+<layer number="144" name="Drill_legend" color="7" fill="1" visible="yes" active="yes"/>
+<layer number="151" name="Ostatni" color="14" fill="1" visible="yes" active="yes"/>
+<layer number="152" name="Stineni" color="7" fill="1" visible="yes" active="yes"/>
+<layer number="160" name="FAB" color="7" fill="1" visible="yes" active="yes"/>
+<layer number="161" name="Rect" color="7" fill="1" visible="yes" active="yes"/>
+<layer number="162" name="Desc" color="7" fill="1" visible="yes" active="yes"/>
+<layer number="163" name="Mech1" color="7" fill="1" visible="yes" active="yes"/>
+<layer number="199" name="Contour" color="7" fill="1" visible="yes" active="yes"/>
+<layer number="200" name="200bmp" color="7" fill="1" visible="yes" active="yes"/>
+<layer number="201" name="201bmp" color="7" fill="1" visible="yes" active="yes"/>
+<layer number="202" name="202bmp" color="7" fill="1" visible="yes" active="yes"/>
+<layer number="203" name="203bmp" color="7" fill="1" visible="yes" active="yes"/>
+<layer number="204" name="204bmp" color="7" fill="1" visible="yes" active="yes"/>
+<layer number="205" name="205bmp" color="7" fill="1" visible="yes" active="yes"/>
+<layer number="206" name="206bmp" color="7" fill="1" visible="yes" active="yes"/>
+<layer number="207" name="207bmp" color="7" fill="1" visible="yes" active="yes"/>
+<layer number="208" name="208bmp" color="7" fill="1" visible="yes" active="yes"/>
+<layer number="209" name="209bmp" color="7" fill="1" visible="yes" active="yes"/>
+<layer number="210" name="210bmp" color="7" fill="1" visible="yes" active="yes"/>
+<layer number="211" name="211bmp" color="7" fill="1" visible="yes" active="yes"/>
+<layer number="212" name="212bmp" color="7" fill="1" visible="yes" active="yes"/>
+<layer number="213" name="213bmp" color="7" fill="1" visible="yes" active="yes"/>
+<layer number="214" name="214bmp" color="7" fill="1" visible="yes" active="yes"/>
+<layer number="215" name="215bmp" color="7" fill="1" visible="yes" active="yes"/>
+<layer number="216" name="216bmp" color="7" fill="1" visible="yes" active="yes"/>
+<layer number="217" name="217bmp" color="7" fill="1" visible="yes" active="yes"/>
+<layer number="218" name="218bmp" color="7" fill="1" visible="yes" active="yes"/>
+<layer number="219" name="219bmp" color="7" fill="1" visible="yes" active="yes"/>
+<layer number="220" name="220bmp" color="7" fill="1" visible="yes" active="yes"/>
+<layer number="221" name="221bmp" color="7" fill="1" visible="yes" active="yes"/>
+<layer number="222" name="222bmp" color="7" fill="1" visible="yes" active="yes"/>
+<layer number="223" name="223bmp" color="7" fill="1" visible="yes" active="yes"/>
+<layer number="224" name="224bmp" color="7" fill="1" visible="yes" active="yes"/>
+<layer number="231" name="Eagle3D_PG1" color="7" fill="1" visible="yes" active="yes"/>
+<layer number="232" name="Eagle3D_PG2" color="7" fill="1" visible="yes" active="yes"/>
+<layer number="233" name="Eagle3D_PG3" color="7" fill="1" visible="yes" active="yes"/>
+<layer number="248" name="Housing" color="7" fill="1" visible="yes" active="yes"/>
+<layer number="249" name="Edge" color="7" fill="1" visible="yes" active="yes"/>
+<layer number="250" name="Descript" color="3" fill="1" visible="no" active="no"/>
+<layer number="251" name="SMDround" color="12" fill="11" visible="no" active="no"/>
+<layer number="254" name="cooling" color="7" fill="1" visible="yes" active="yes"/>
+</layers>
+<schematic xreflabel="%F%N/%S.%C%R" xrefpart="/%S.%C%R">
+<libraries>
+<library name="vyber_stara_nemenit">
+<packages>
+<package name="SOD80">
+<wire x1="2.8448" y1="0.9398" x2="-2.8448" y2="0.9398" width="0.1524" layer="21"/>
+<wire x1="-2.8448" y1="-0.9398" x2="-2.8448" y2="0.9398" width="0.1524" layer="21"/>
+<wire x1="-2.8448" y1="-0.9398" x2="2.8448" y2="-0.9398" width="0.1524" layer="21"/>
+<wire x1="2.8448" y1="0.9398" x2="2.8448" y2="-0.9398" width="0.1524" layer="21"/>
+<wire x1="0.7112" y1="0.889" x2="0.7112" y2="-0.889" width="0.1524" layer="21"/>
+<circle x="0" y="0.4" radius="0.15" width="0.6096" layer="35"/>
+<circle x="0" y="-0.4" radius="0.15" width="0.6096" layer="35"/>
+<smd name="2" x="1.778" y="0" dx="1.8288" dy="1.5748" layer="1"/>
+<smd name="1" x="-1.778" y="0" dx="1.8288" dy="1.5748" layer="1"/>
+<text x="-2.54" y="-0.508" size="1.016" layer="27">&gt;VALUE</text>
+<text x="-2.54" y="-0.508" size="1.016" layer="25">&gt;NAME</text>
+<rectangle x1="0.762" y1="-0.889" x2="2.794" y2="0.889" layer="27"/>
+<rectangle x1="-0.15" y1="-0.3" x2="0.15" y2="0.3" layer="35"/>
+</package>
+<package name="MELF">
+<wire x1="-3.683" y1="-1.524" x2="-3.683" y2="1.524" width="0.1524" layer="21"/>
+<wire x1="-3.683" y1="-1.524" x2="3.683" y2="-1.524" width="0.1524" layer="21"/>
+<wire x1="3.683" y1="1.524" x2="3.683" y2="-1.524" width="0.1524" layer="21"/>
+<wire x1="-3.684" y1="1.524" x2="3.684" y2="1.524" width="0.1524" layer="21"/>
+<circle x="-0.65" y="0.45" radius="0.2061" width="0.508" layer="35"/>
+<circle x="-0.65" y="-0.45" radius="0.2061" width="0.508" layer="35"/>
+<circle x="0.65" y="0.45" radius="0.2061" width="0.508" layer="35"/>
+<circle x="0.65" y="-0.45" radius="0.2061" width="0.508" layer="35"/>
+<smd name="2" x="2.667" y="0" dx="1.778" dy="2.794" layer="1"/>
+<smd name="1" x="-2.667" y="0" dx="1.778" dy="2.794" layer="1"/>
+<text x="-3.429" y="-0.508" size="1.016" layer="27">&gt;VALUE</text>
+<text x="-1.143" y="-0.508" size="1.016" layer="25">&gt;NAME</text>
+<rectangle x1="2.54" y1="-1.524" x2="3.683" y2="1.524" layer="21"/>
+<rectangle x1="0.5" y1="-0.2" x2="0.8" y2="0.2" layer="35"/>
+<rectangle x1="-0.8" y1="-0.2" x2="-0.5" y2="0.2" layer="35"/>
+</package>
+<package name="SOD323F">
+<smd name="K" x="1.1" y="0" dx="0.6" dy="0.6" layer="1"/>
+<smd name="A" x="-1.1" y="0" dx="0.6" dy="0.6" layer="1"/>
+<text x="-2.413" y="-2.0955" size="1.016" layer="25">&gt;NAME</text>
+<text x="-2.413" y="1.143" size="1.016" layer="27">&gt;VALUE</text>
+<wire x1="-0.9" y1="-0.675" x2="0.4" y2="-0.675" width="0.127" layer="21"/>
+<wire x1="0.4" y1="-0.675" x2="0.5" y2="-0.675" width="0.127" layer="21"/>
+<wire x1="0.5" y1="-0.675" x2="0.6" y2="-0.675" width="0.127" layer="21"/>
+<wire x1="0.6" y1="-0.675" x2="0.9" y2="-0.675" width="0.127" layer="21"/>
+<wire x1="0.9" y1="-0.675" x2="0.9" y2="0.675" width="0.127" layer="21"/>
+<wire x1="0.9" y1="0.675" x2="0.6" y2="0.675" width="0.127" layer="21"/>
+<wire x1="0.6" y1="0.675" x2="0.5" y2="0.675" width="0.127" layer="21"/>
+<wire x1="0.5" y1="0.675" x2="0.4" y2="0.675" width="0.127" layer="21"/>
+<wire x1="0.4" y1="0.675" x2="-0.9" y2="0.675" width="0.127" layer="21"/>
+<wire x1="-0.9" y1="0.675" x2="-0.9" y2="-0.675" width="0.127" layer="21"/>
+<wire x1="0.6" y1="-0.675" x2="0.6" y2="0.675" width="0.127" layer="21"/>
+<wire x1="0.5" y1="-0.675" x2="0.5" y2="0.675" width="0.127" layer="21"/>
+<wire x1="0.4" y1="-0.675" x2="0.4" y2="0.675" width="0.127" layer="21"/>
+<rectangle x1="-0.15" y1="-0.7" x2="0.15" y2="0.7" layer="35"/>
+</package>
+<package name="SOD323">
+<smd name="K" x="1.15" y="0" dx="0.5" dy="0.6" layer="1"/>
+<smd name="A" x="-1.15" y="0" dx="0.5" dy="0.6" layer="1"/>
+<text x="-2.413" y="-2.0955" size="1.016" layer="25">&gt;NAME</text>
+<text x="-2.413" y="1.143" size="1.016" layer="27">&gt;VALUE</text>
+<wire x1="-0.9" y1="-0.675" x2="0.5" y2="-0.675" width="0.127" layer="21"/>
+<wire x1="0.5" y1="-0.675" x2="0.55" y2="-0.675" width="0.127" layer="21"/>
+<wire x1="0.55" y1="-0.675" x2="0.65" y2="-0.675" width="0.127" layer="21"/>
+<wire x1="0.65" y1="-0.675" x2="0.9" y2="-0.675" width="0.127" layer="21"/>
+<wire x1="0.9" y1="-0.675" x2="0.9" y2="0.675" width="0.127" layer="21"/>
+<wire x1="0.9" y1="0.675" x2="0.65" y2="0.675" width="0.127" layer="21"/>
+<wire x1="0.65" y1="0.675" x2="0.55" y2="0.675" width="0.127" layer="21"/>
+<wire x1="0.55" y1="0.675" x2="0.5" y2="0.675" width="0.127" layer="21"/>
+<wire x1="0.5" y1="0.675" x2="-0.9" y2="0.675" width="0.127" layer="21"/>
+<wire x1="-0.9" y1="0.675" x2="-0.9" y2="-0.675" width="0.127" layer="21"/>
+<rectangle x1="-0.1" y1="-0.7" x2="0.1" y2="0.7" layer="35"/>
+<wire x1="0.65" y1="-0.675" x2="0.65" y2="0.675" width="0.127" layer="21"/>
+<wire x1="0.55" y1="-0.675" x2="0.55" y2="0.675" width="0.127" layer="21"/>
+<wire x1="0.5" y1="-0.675" x2="0.5" y2="0.675" width="0.127" layer="21"/>
+</package>
+<package name="SOD123">
+<wire x1="1.1" y1="0.8" x2="1" y2="0.8" width="0.127" layer="21"/>
+<wire x1="1" y1="0.8" x2="0.9" y2="0.8" width="0.127" layer="21"/>
+<wire x1="0.9" y1="-0.8" x2="1" y2="-0.8" width="0.127" layer="21"/>
+<wire x1="1" y1="-0.8" x2="1.1" y2="-0.8" width="0.127" layer="21"/>
+<wire x1="1" y1="0.8" x2="1" y2="-0.8" width="0.127" layer="21"/>
+<wire x1="1.1" y1="-0.8" x2="1.1" y2="0.8" width="0.127" layer="21"/>
+<wire x1="0.9" y1="0.8" x2="0.9" y2="-0.8" width="0.127" layer="21"/>
+<text x="-2.413" y="-2.0955" size="1.016" layer="25">&gt;NAME</text>
+<text x="-2.413" y="1.143" size="1.016" layer="27">&gt;VALUE</text>
+<wire x1="1.4" y1="0.85" x2="-1.4" y2="0.85" width="0.127" layer="21"/>
+<wire x1="-1.4" y1="0.85" x2="-1.4" y2="-0.85" width="0.127" layer="21"/>
+<wire x1="-1.4" y1="-0.85" x2="1.4" y2="-0.85" width="0.127" layer="21"/>
+<wire x1="1.4" y1="-0.85" x2="1.4" y2="0.85" width="0.127" layer="21"/>
+<rectangle x1="-0.2" y1="-0.7" x2="0.2" y2="0.7" layer="35"/>
+<smd name="A" x="-1.85" y="0" dx="1.2" dy="0.7" layer="1" rot="R180"/>
+<smd name="K" x="1.85" y="0" dx="1.2" dy="0.7" layer="1" rot="R180"/>
+</package>
+<package name="DO214AC">
+<wire x1="2.413" y1="1.397" x2="-2.413" y2="1.397" width="0.1524" layer="21"/>
+<wire x1="-2.413" y1="1.397" x2="-2.413" y2="-1.397" width="0.1524" layer="21"/>
+<wire x1="-2.413" y1="-1.397" x2="2.413" y2="-1.397" width="0.1524" layer="21"/>
+<wire x1="2.413" y1="-1.397" x2="2.413" y2="1.397" width="0.1524" layer="21"/>
+<circle x="-0.65" y="0.45" radius="0.2061" width="0.508" layer="35"/>
+<circle x="-0.65" y="-0.45" radius="0.2061" width="0.508" layer="35"/>
+<circle x="0.65" y="0.45" radius="0.2061" width="0.508" layer="35"/>
+<circle x="0.65" y="-0.45" radius="0.2061" width="0.508" layer="35"/>
+<smd name="2" x="2.54" y="0" dx="2.032" dy="2.54" layer="1"/>
+<smd name="1" x="-2.54" y="0" dx="2.032" dy="2.54" layer="1"/>
+<text x="-2.286" y="-0.508" size="1.016" layer="27">&gt;VALUE</text>
+<text x="-1.778" y="-0.508" size="1.016" layer="25">&gt;NAME</text>
+<rectangle x1="1.143" y1="-1.397" x2="2.413" y2="1.397" layer="21"/>
+<rectangle x1="0.5" y1="-0.2" x2="0.8" y2="0.2" layer="35"/>
+<rectangle x1="-0.8" y1="-0.2" x2="-0.5" y2="0.2" layer="35"/>
+<rectangle x1="0.5" y1="-0.2" x2="0.8" y2="0.2" layer="35"/>
+<rectangle x1="-0.8" y1="-0.2" x2="-0.5" y2="0.2" layer="35"/>
+</package>
+<package name="SOD123W">
+<description>SOD123W 2,8x1,9mm</description>
+<wire x1="1.1" y1="0.8" x2="1" y2="0.8" width="0.127" layer="21"/>
+<wire x1="1" y1="0.8" x2="0.9" y2="0.8" width="0.127" layer="21"/>
+<wire x1="0.9" y1="-0.8" x2="1" y2="-0.8" width="0.127" layer="21"/>
+<wire x1="1" y1="-0.8" x2="1.1" y2="-0.8" width="0.127" layer="21"/>
+<wire x1="1" y1="0.8" x2="1" y2="-0.8" width="0.127" layer="21"/>
+<wire x1="1.1" y1="-0.8" x2="1.1" y2="0.8" width="0.127" layer="21"/>
+<wire x1="0.9" y1="0.8" x2="0.9" y2="-0.8" width="0.127" layer="21"/>
+<text x="-2.413" y="-2.0955" size="1.016" layer="25">&gt;NAME</text>
+<text x="-2.413" y="1.143" size="1.016" layer="27">&gt;VALUE</text>
+<smd name="A" x="-1.4" y="0" dx="1.2" dy="1.2" layer="1"/>
+<smd name="K" x="1.4" y="0" dx="1.2" dy="1.2" layer="1"/>
+<wire x1="1.4" y1="0.85" x2="-1.4" y2="0.85" width="0.127" layer="21"/>
+<wire x1="-1.4" y1="0.85" x2="-1.4" y2="-0.85" width="0.127" layer="21"/>
+<wire x1="-1.4" y1="-0.85" x2="1.4" y2="-0.85" width="0.127" layer="21"/>
+<wire x1="1.4" y1="-0.85" x2="1.4" y2="0.85" width="0.127" layer="21"/>
+<rectangle x1="-0.2" y1="-0.7" x2="0.2" y2="0.7" layer="35"/>
+</package>
+<package name="SOT143B">
+<wire x1="1.524" y1="-0.508" x2="1.143" y2="-0.508" width="0.127" layer="21"/>
+<wire x1="1.143" y1="-0.508" x2="-1.524" y2="-0.508" width="0.127" layer="21"/>
+<wire x1="-1.524" y1="-0.508" x2="-1.524" y2="0.508" width="0.127" layer="21"/>
+<wire x1="-1.524" y1="0.508" x2="1.143" y2="0.508" width="0.127" layer="21"/>
+<wire x1="1.143" y1="0.508" x2="1.524" y2="0.508" width="0.127" layer="21"/>
+<wire x1="1.524" y1="0.508" x2="1.524" y2="-0.508" width="0.127" layer="21"/>
+<wire x1="1.143" y1="-0.508" x2="1.143" y2="0.508" width="0.1524" layer="21"/>
+<smd name="1" x="-0.948" y="-1.178" dx="1.2" dy="1.5" layer="1" rot="R270"/>
+<smd name="2" x="1.103" y="-1.178" dx="1.2" dy="1.2" layer="1" rot="R90"/>
+<smd name="3" x="1.098" y="1.178" dx="1.2" dy="1.2" layer="1" rot="R90"/>
+<smd name="4" x="-1.098" y="1.178" dx="1.2" dy="1.2" layer="1" rot="R90"/>
+<text x="-1.978" y="2.5" size="1.016" layer="25">&gt;NAME</text>
+<text x="-2.13" y="-3.213" size="1.016" layer="27">&gt;VALUE</text>
+<rectangle x1="-1.651" y1="-0.0762" x2="1.651" y2="0.0762" layer="35"/>
+<rectangle x1="0.7112" y1="-1.27" x2="1.3208" y2="-0.5588" layer="27"/>
+<rectangle x1="-1.3208" y1="-1.27" x2="-0.7112" y2="-0.5588" layer="27"/>
+<rectangle x1="-1.3208" y1="-0.762" x2="-0.7112" y2="-0.381" layer="21"/>
+<rectangle x1="0.7112" y1="-0.762" x2="1.3208" y2="-0.381" layer="21"/>
+<rectangle x1="-1.3208" y1="0.381" x2="-0.7112" y2="0.762" layer="21"/>
+<rectangle x1="-1.3208" y1="0.5588" x2="-0.7112" y2="1.27" layer="27"/>
+<rectangle x1="0.7112" y1="-1.27" x2="1.3208" y2="-0.5588" layer="27"/>
+<rectangle x1="-1.3208" y1="-1.27" x2="-0.7112" y2="-0.5588" layer="27"/>
+<rectangle x1="0.7112" y1="0.381" x2="1.3208" y2="0.762" layer="21"/>
+<rectangle x1="0.7112" y1="0.5588" x2="1.3208" y2="1.27" layer="27"/>
+<rectangle x1="-0.9398" y1="-1.27" x2="-0.3302" y2="-0.5588" layer="27"/>
+<rectangle x1="-0.9398" y1="-0.762" x2="-0.3302" y2="-0.381" layer="21"/>
+<rectangle x1="-1.651" y1="-0.0762" x2="1.651" y2="0.0762" layer="35"/>
+</package>
+<package name="SOT143B_REFLOW">
+<wire x1="1.524" y1="-0.508" x2="1.143" y2="-0.508" width="0.127" layer="21"/>
+<wire x1="1.143" y1="-0.508" x2="-1.524" y2="-0.508" width="0.127" layer="21"/>
+<wire x1="-1.524" y1="-0.508" x2="-1.524" y2="0.508" width="0.127" layer="21"/>
+<wire x1="-1.524" y1="0.508" x2="1.143" y2="0.508" width="0.127" layer="21"/>
+<wire x1="1.143" y1="0.508" x2="1.524" y2="0.508" width="0.127" layer="21"/>
+<wire x1="1.524" y1="0.508" x2="1.524" y2="-0.508" width="0.127" layer="21"/>
+<wire x1="1.143" y1="-0.508" x2="1.143" y2="0.508" width="0.1524" layer="21"/>
+<smd name="1" x="-0.848" y="-1.028" dx="0.8" dy="1.2" layer="1" rot="R270"/>
+<smd name="2" x="1.053" y="-1.028" dx="0.8" dy="0.8" layer="1" rot="R90"/>
+<smd name="3" x="1.048" y="1.028" dx="0.8" dy="0.8" layer="1" rot="R90"/>
+<smd name="4" x="-1.048" y="1.028" dx="0.8" dy="0.8" layer="1" rot="R90"/>
+<text x="-1.978" y="2.5" size="1.016" layer="25">&gt;NAME</text>
+<text x="-2.13" y="-3.213" size="1.016" layer="27">&gt;VALUE</text>
+<rectangle x1="-1.651" y1="-0.0762" x2="1.651" y2="0.0762" layer="35"/>
+<rectangle x1="0.7112" y1="-1.27" x2="1.3208" y2="-0.5588" layer="27"/>
+<rectangle x1="-1.3208" y1="-1.27" x2="-0.7112" y2="-0.5588" layer="27"/>
+<rectangle x1="-1.3208" y1="-0.762" x2="-0.7112" y2="-0.381" layer="21"/>
+<rectangle x1="0.7112" y1="-0.762" x2="1.3208" y2="-0.381" layer="21"/>
+<rectangle x1="-1.3208" y1="0.381" x2="-0.7112" y2="0.762" layer="21"/>
+<rectangle x1="-1.3208" y1="0.5588" x2="-0.7112" y2="1.27" layer="27"/>
+<rectangle x1="0.7112" y1="-1.27" x2="1.3208" y2="-0.5588" layer="27"/>
+<rectangle x1="-1.3208" y1="-1.27" x2="-0.7112" y2="-0.5588" layer="27"/>
+<rectangle x1="0.7112" y1="0.381" x2="1.3208" y2="0.762" layer="21"/>
+<rectangle x1="0.7112" y1="0.5588" x2="1.3208" y2="1.27" layer="27"/>
+<rectangle x1="-0.9398" y1="-1.27" x2="-0.3302" y2="-0.5588" layer="27"/>
+<rectangle x1="-0.9398" y1="-0.762" x2="-0.3302" y2="-0.381" layer="21"/>
+<rectangle x1="-1.651" y1="-0.0762" x2="1.651" y2="0.0762" layer="35"/>
+</package>
+<package name="0805">
+<wire x1="2.032" y1="0.889" x2="-2.032" y2="0.889" width="0.1524" layer="21"/>
+<wire x1="-2.032" y1="-0.889" x2="-2.032" y2="0.889" width="0.1524" layer="21"/>
+<wire x1="-2.032" y1="-0.889" x2="2.032" y2="-0.889" width="0.1524" layer="21"/>
+<wire x1="2.032" y1="0.889" x2="2.032" y2="-0.889" width="0.1524" layer="21"/>
+<smd name="2" x="1.2192" y="0" dx="1.397" dy="1.524" layer="1"/>
+<smd name="1" x="-1.2192" y="0" dx="1.397" dy="1.524" layer="1"/>
+<text x="-1.27" y="-0.508" size="1.016" layer="25">&gt;NAME</text>
+<text x="-1.778" y="-0.508" size="1.016" layer="27">&gt;VALUE</text>
+<rectangle x1="-0.15" y1="-1" x2="0.15" y2="1" layer="35"/>
+</package>
+<package name="0207">
+<wire x1="-3.048" y1="1.016" x2="-3.048" y2="0" width="0.3048" layer="21"/>
+<wire x1="-3.048" y1="-1.016" x2="3.048" y2="-1.016" width="0.3048" layer="21"/>
+<wire x1="3.048" y1="-1.016" x2="3.048" y2="0" width="0.3048" layer="21"/>
+<wire x1="-3.048" y1="1.016" x2="3.048" y2="1.016" width="0.3048" layer="21"/>
+<wire x1="3.048" y1="0" x2="4.064" y2="0" width="0.3048" layer="21"/>
+<wire x1="3.048" y1="0" x2="3.048" y2="1.016" width="0.3048" layer="21"/>
+<wire x1="-3.048" y1="0" x2="-4.064" y2="0" width="0.3048" layer="21"/>
+<wire x1="-3.048" y1="0" x2="-3.048" y2="-1.016" width="0.3048" layer="21"/>
+<pad name="1" x="-5.08" y="0" drill="0.8128" diameter="1.524"/>
+<pad name="2" x="5.08" y="0" drill="0.8128" diameter="1.524"/>
+<text x="-1.905" y="-0.635" size="1.27" layer="25">&gt;NAME</text>
+<text x="-1.905" y="-0.635" size="1.27" layer="27">&gt;VALUE</text>
+</package>
+<package name="1206">
+<wire x1="2.8448" y1="0.9398" x2="-2.8448" y2="0.9398" width="0.1524" layer="21"/>
+<wire x1="-2.8448" y1="-0.9398" x2="-2.8448" y2="0.9398" width="0.1524" layer="21"/>
+<wire x1="-2.8448" y1="-0.9398" x2="2.8448" y2="-0.9398" width="0.1524" layer="21"/>
+<wire x1="2.8448" y1="0.9398" x2="2.8448" y2="-0.9398" width="0.1524" layer="21"/>
+<smd name="2" x="1.778" y="0" dx="1.8288" dy="1.5748" layer="1"/>
+<smd name="1" x="-1.778" y="0" dx="1.8288" dy="1.5748" layer="1"/>
+<text x="-1.651" y="-0.508" size="1.016" layer="27">&gt;VALUE</text>
+<text x="-1.143" y="-0.508" size="1.016" layer="25">&gt;NAME</text>
+<rectangle x1="-0.25" y1="-0.8" x2="0.25" y2="0.8" layer="35"/>
+</package>
+<package name="0207$ST_1">
+<wire x1="-0.635" y1="0" x2="0.635" y2="0" width="0.3048" layer="21"/>
+<circle x="-1.27" y="0" radius="1.27" width="0.3048" layer="21"/>
+<pad name="1" x="-1.27" y="0" drill="0.8128" diameter="1.524"/>
+<pad name="2" x="1.27" y="0" drill="0.8128" diameter="1.524"/>
+<text x="0" y="0.635" size="1.27" layer="25">&gt;NAME</text>
+<text x="0" y="0.635" size="1.27" layer="27">&gt;VALUE</text>
+</package>
+<package name="0207$ST_2">
+<wire x1="-0.635" y1="0" x2="0.635" y2="0" width="0.3048" layer="21"/>
+<circle x="1.27" y="0" radius="1.27" width="0.3048" layer="21"/>
+<pad name="1" x="-1.27" y="0" drill="0.8128" diameter="1.524"/>
+<pad name="2" x="1.27" y="0" drill="0.8128" diameter="1.524"/>
+<text x="0" y="1.905" size="1.27" layer="25" rot="R180">&gt;NAME</text>
+<text x="0" y="1.905" size="1.27" layer="27" rot="R180">&gt;VALUE</text>
+</package>
+<package name="0207$ST18_2">
+<wire x1="-0.635" y1="0" x2="0.635" y2="0" width="0.3048" layer="21"/>
+<circle x="-1.27" y="0" radius="1.27" width="0.3048" layer="21"/>
+<pad name="1" x="-1.27" y="0" drill="0.8128" diameter="1.524"/>
+<pad name="2" x="0.635" y="0" drill="0.8128" diameter="1.524"/>
+<text x="0" y="0.635" size="1.27" layer="25">&gt;NAME</text>
+<text x="0" y="0.635" size="1.27" layer="27">&gt;VALUE</text>
+</package>
+<package name="0207$ST18_1">
+<wire x1="-0.635" y1="0" x2="0.635" y2="0" width="0.3048" layer="21"/>
+<circle x="1.27" y="0" radius="1.27" width="0.3048" layer="21"/>
+<pad name="1" x="-0.635" y="0" drill="0.8128" diameter="1.524"/>
+<pad name="2" x="1.27" y="0" drill="0.8128" diameter="1.524"/>
+<text x="0" y="1.905" size="1.27" layer="25" rot="R180">&gt;NAME</text>
+<text x="0" y="1.905" size="1.27" layer="27" rot="R180">&gt;VALUE</text>
+</package>
+<package name="R9,5/22">
+<wire x1="-10.033" y1="4.826" x2="-10.033" y2="0" width="0.3048" layer="21"/>
+<wire x1="-10.033" y1="-4.826" x2="10.033" y2="-4.826" width="0.3048" layer="21"/>
+<wire x1="10.033" y1="-4.826" x2="10.033" y2="0" width="0.3048" layer="21"/>
+<wire x1="-10.033" y1="4.826" x2="10.033" y2="4.826" width="0.3048" layer="21"/>
+<wire x1="10.033" y1="0" x2="13.589" y2="0" width="0.3048" layer="21"/>
+<wire x1="10.033" y1="0" x2="10.033" y2="4.826" width="0.3048" layer="21"/>
+<wire x1="-10.033" y1="0" x2="-13.589" y2="0" width="0.3048" layer="21"/>
+<wire x1="-10.033" y1="0" x2="-10.033" y2="-4.826" width="0.3048" layer="21"/>
+<pad name="1" x="-13.97" y="0" drill="1.016" diameter="3.556"/>
+<pad name="2" x="13.97" y="0" drill="1.016" diameter="3.556"/>
+<text x="-0.635" y="-0.635" size="1.27" layer="25">&gt;NAME</text>
+<text x="-0.635" y="-0.635" size="1.27" layer="27">&gt;VALUE</text>
+</package>
+<package name="R9,5/22$ST">
+<wire x1="5.08" y1="5.08" x2="-5.08" y2="5.08" width="0.3048" layer="21"/>
+<wire x1="-5.08" y1="5.08" x2="-5.08" y2="-5.08" width="0.3048" layer="21"/>
+<wire x1="-5.08" y1="-5.08" x2="5.08" y2="-5.08" width="0.3048" layer="21"/>
+<wire x1="5.08" y1="-5.08" x2="5.08" y2="5.08" width="0.3048" layer="21"/>
+<pad name="1" x="-6.35" y="0" drill="1.016" diameter="3.556"/>
+<pad name="2" x="0" y="0" drill="1.016" diameter="3.556"/>
+<text x="-3.175" y="-4.445" size="1.27" layer="25">&gt;NAME</text>
+<text x="-3.175" y="3.175" size="1.27" layer="27">&gt;VALUE</text>
+</package>
+<package name="R9,5/48">
+<wire x1="-24.638" y1="4.191" x2="-24.638" y2="0" width="0.3048" layer="21"/>
+<wire x1="-24.638" y1="-4.191" x2="24.003" y2="-4.191" width="0.3048" layer="21"/>
+<wire x1="24.003" y1="-4.191" x2="24.003" y2="0" width="0.3048" layer="21"/>
+<wire x1="-24.638" y1="4.191" x2="24.003" y2="4.191" width="0.3048" layer="21"/>
+<wire x1="24.003" y1="0" x2="25.654" y2="0" width="0.3048" layer="21"/>
+<wire x1="24.003" y1="0" x2="24.003" y2="4.191" width="0.3048" layer="21"/>
+<wire x1="-24.638" y1="0" x2="-26.289" y2="0" width="0.3048" layer="21"/>
+<wire x1="-24.638" y1="0" x2="-24.638" y2="-4.191" width="0.3048" layer="21"/>
+<pad name="1" x="-27.94" y="0" drill="1.016" diameter="3.81"/>
+<pad name="2" x="27.94" y="0" drill="1.016" diameter="3.81"/>
+<text x="-1.905" y="-0.635" size="1.27" layer="25">&gt;NAME</text>
+<text x="-1.905" y="-0.635" size="1.27" layer="27">&gt;VALUE</text>
+</package>
+<package name="R_2X5W">
+<wire x1="10.16" y1="-5.08" x2="10.16" y2="5.08" width="0.3048" layer="21"/>
+<wire x1="10.16" y1="5.08" x2="0" y2="5.08" width="0.3048" layer="21"/>
+<wire x1="0" y1="5.08" x2="-10.16" y2="5.08" width="0.3048" layer="21"/>
+<wire x1="-10.16" y1="5.08" x2="-10.16" y2="-5.08" width="0.3048" layer="21"/>
+<wire x1="-10.16" y1="-5.08" x2="0" y2="-5.08" width="0.3048" layer="21"/>
+<wire x1="0" y1="-5.08" x2="10.16" y2="-5.08" width="0.3048" layer="21"/>
+<wire x1="0" y1="-5.08" x2="0" y2="5.08" width="0.3048" layer="21"/>
+<wire x1="-2.54" y1="0" x2="2.54" y2="0" width="0.3048" layer="21"/>
+<pad name="2" x="5.08" y="0" drill="1.016" diameter="3.556"/>
+<pad name="1" x="-5.08" y="0" drill="1.016" diameter="3.556"/>
+<text x="-8.255" y="-4.445" size="1.27" layer="25">&gt;NAME</text>
+<text x="-8.255" y="3.175" size="1.27" layer="27">&gt;VALUE</text>
+</package>
+<package name="0207$1S_90">
+<wire x1="-3.048" y1="1.27" x2="-3.048" y2="0" width="0.3048" layer="21"/>
+<wire x1="-3.048" y1="-1.27" x2="3.048" y2="-1.27" width="0.3048" layer="21"/>
+<wire x1="3.048" y1="-1.27" x2="3.048" y2="0" width="0.3048" layer="21"/>
+<wire x1="-3.048" y1="1.27" x2="3.048" y2="1.27" width="0.3048" layer="21"/>
+<wire x1="3.048" y1="0" x2="4.064" y2="0" width="0.3048" layer="21"/>
+<wire x1="3.048" y1="0" x2="3.048" y2="1.27" width="0.3048" layer="21"/>
+<wire x1="-3.048" y1="0" x2="-4.064" y2="0" width="0.3048" layer="21"/>
+<wire x1="-3.048" y1="0" x2="-3.048" y2="-1.27" width="0.3048" layer="21"/>
+<pad name="1" x="-5.08" y="0" drill="0.8128" diameter="1.524" shape="long" rot="R90"/>
+<pad name="2" x="5.08" y="0" drill="0.8128" diameter="1.524" shape="long" rot="R90"/>
+<text x="-1.905" y="-0.635" size="1.27" layer="25">&gt;NAME</text>
+<text x="-1.905" y="-0.635" size="1.27" layer="27">&gt;VALUE</text>
+</package>
+<package name="0207$1S">
+<wire x1="-3.048" y1="1.27" x2="-3.048" y2="0" width="0.3048" layer="21"/>
+<wire x1="-3.048" y1="-1.27" x2="3.048" y2="-1.27" width="0.3048" layer="21"/>
+<wire x1="3.048" y1="-1.27" x2="3.048" y2="0" width="0.3048" layer="21"/>
+<wire x1="-3.048" y1="1.27" x2="3.048" y2="1.27" width="0.3048" layer="21"/>
+<wire x1="3.048" y1="0" x2="4.064" y2="0" width="0.3048" layer="21"/>
+<wire x1="3.048" y1="0" x2="3.048" y2="1.27" width="0.3048" layer="21"/>
+<wire x1="-3.048" y1="0" x2="-4.064" y2="0" width="0.3048" layer="21"/>
+<wire x1="-3.048" y1="0" x2="-3.048" y2="-1.27" width="0.3048" layer="21"/>
+<pad name="1" x="-5.08" y="0" drill="0.8128" diameter="1.524" shape="long"/>
+<pad name="2" x="5.08" y="0" drill="0.8128" diameter="1.524" shape="long"/>
+<text x="-1.905" y="-0.635" size="1.27" layer="25">&gt;NAME</text>
+<text x="-1.905" y="-0.635" size="1.27" layer="27">&gt;VALUE</text>
+</package>
+<package name="R_2W">
+<wire x1="-5.588" y1="2.286" x2="-5.588" y2="0" width="0.3048" layer="21"/>
+<wire x1="-5.588" y1="-2.286" x2="5.588" y2="-2.286" width="0.3048" layer="21"/>
+<wire x1="5.588" y1="-2.286" x2="5.588" y2="0" width="0.3048" layer="21"/>
+<wire x1="-5.588" y1="2.286" x2="5.588" y2="2.286" width="0.3048" layer="21"/>
+<wire x1="5.588" y1="0" x2="7.239" y2="0" width="0.3048" layer="21"/>
+<wire x1="5.588" y1="0" x2="5.588" y2="2.286" width="0.3048" layer="21"/>
+<wire x1="-5.588" y1="0" x2="-7.239" y2="0" width="0.3048" layer="21"/>
+<wire x1="-5.588" y1="0" x2="-5.588" y2="-2.286" width="0.3048" layer="21"/>
+<pad name="1" x="-7.62" y="0" drill="1.016" diameter="1.778" shape="long" rot="R90"/>
+<pad name="2" x="7.62" y="0" drill="1.016" diameter="1.778" shape="long" rot="R90"/>
+<text x="-3.175" y="-0.635" size="1.27" layer="25">&gt;NAME</text>
+<text x="-3.175" y="-0.635" size="1.27" layer="27">&gt;VALUE</text>
+</package>
+<package name="WSC6927">
+<wire x1="-8.89" y1="3.4925" x2="-8.89" y2="-3.4925" width="0.127" layer="21"/>
+<wire x1="-8.89" y1="-3.4925" x2="8.89" y2="-3.4925" width="0.127" layer="21"/>
+<wire x1="8.89" y1="-3.4925" x2="8.89" y2="3.4925" width="0.127" layer="21"/>
+<wire x1="8.89" y1="3.4925" x2="-8.89" y2="3.4925" width="0.127" layer="21"/>
+<circle x="-2.2225" y="0" radius="0.1588" width="1.016" layer="35"/>
+<circle x="-4.2862" y="2.3813" radius="0.1588" width="1.016" layer="35"/>
+<circle x="0" y="2.3813" radius="0.1588" width="1.016" layer="35"/>
+<circle x="4.2863" y="2.3813" radius="0.1588" width="1.016" layer="35"/>
+<circle x="-4.2862" y="-2.3812" radius="0.1588" width="1.016" layer="35"/>
+<circle x="0" y="-2.3812" radius="0.1588" width="1.016" layer="35"/>
+<circle x="4.2862" y="-2.2225" radius="0.1588" width="1.016" layer="35"/>
+<circle x="2.3813" y="0" radius="0.1588" width="1.016" layer="35"/>
+<smd name="2" x="7.9375" y="0" dx="3.937" dy="5.969" layer="1"/>
+<smd name="1" x="-7.9375" y="0" dx="3.937" dy="5.969" layer="1"/>
+<text x="-3.3337" y="1.4288" size="1.27" layer="25">&gt;NAME</text>
+<text x="-3.4925" y="-2.54" size="1.27" layer="27">&gt;VALUE</text>
+</package>
+<package name="0603">
+<wire x1="1.524" y1="0.762" x2="-1.524" y2="0.762" width="0.1524" layer="21"/>
+<wire x1="-1.524" y1="-0.762" x2="-1.524" y2="0.762" width="0.1524" layer="21"/>
+<wire x1="-1.524" y1="-0.762" x2="1.524" y2="-0.762" width="0.1524" layer="21"/>
+<wire x1="1.524" y1="0.762" x2="1.524" y2="-0.762" width="0.1524" layer="21"/>
+<smd name="1" x="-0.8" y="0" dx="0.8" dy="1" layer="1"/>
+<smd name="2" x="0.8" y="0" dx="0.8" dy="1" layer="1"/>
+<text x="-1.27" y="-0.508" size="1.016" layer="25">&gt;NAME</text>
+<text x="-1.397" y="-0.381" size="0.8128" layer="27">&gt;VALUE</text>
+<rectangle x1="-0.254" y1="-0.508" x2="0.254" y2="0.508" layer="35"/>
+</package>
+<package name="2010">
+<wire x1="-1.662" y1="1.245" x2="1.662" y2="1.245" width="0.1524" layer="51"/>
+<wire x1="-1.637" y1="-1.245" x2="1.687" y2="-1.245" width="0.1524" layer="51"/>
+<wire x1="-1.027" y1="1.245" x2="1.027" y2="1.245" width="0.1524" layer="21"/>
+<wire x1="-1.002" y1="-1.245" x2="1.016" y2="-1.245" width="0.1524" layer="21"/>
+<circle x="0" y="0.635" radius="0.1588" width="0.6096" layer="35"/>
+<circle x="0" y="-0.635" radius="0.1588" width="0.6096" layer="35"/>
+<smd name="1" x="-2.2" y="0" dx="1.8" dy="2.7" layer="1"/>
+<smd name="2" x="2.2" y="0" dx="1.8" dy="2.7" layer="1"/>
+<text x="-2.159" y="1.651" size="1.27" layer="25">&gt;NAME</text>
+<text x="-2.159" y="-2.921" size="1.27" layer="27">&gt;VALUE</text>
+<rectangle x1="-2.4892" y1="-1.3208" x2="-1.6393" y2="1.3292" layer="51"/>
+<rectangle x1="1.651" y1="-1.3208" x2="2.5009" y2="1.3292" layer="51"/>
+</package>
+<package name="R_2W_1">
+<wire x1="3.1115" y1="0" x2="0" y2="0" width="0.3048" layer="21"/>
+<wire x1="-2.0955" y1="0" x2="-3.1115" y2="0" width="0.3048" layer="21"/>
+<circle x="0" y="0" radius="2" width="0.1524" layer="21"/>
+<pad name="1" x="-3.175" y="0" drill="1.016" diameter="1.778" shape="long" rot="R90"/>
+<pad name="2" x="3.175" y="0" drill="1.016" diameter="1.778" shape="long" rot="R90"/>
+<text x="-3.175" y="-3.81" size="1.27" layer="25">&gt;NAME</text>
+<text x="-3.175" y="2.54" size="1.27" layer="27">&gt;VALUE</text>
+</package>
+<package name="0402">
+<wire x1="0.508" y1="0.254" x2="-0.508" y2="0.254" width="0.1" layer="21"/>
+<wire x1="-0.508" y1="-0.254" x2="-0.508" y2="0.254" width="0.1" layer="21"/>
+<wire x1="-0.508" y1="-0.254" x2="0.508" y2="-0.254" width="0.1" layer="21"/>
+<wire x1="0.508" y1="0.254" x2="0.508" y2="-0.254" width="0.1" layer="21"/>
+<smd name="P$1" x="-0.508" y="0" dx="0.5" dy="0.75" layer="1" stop="no"/>
+<smd name="P$2" x="0.508" y="0" dx="0.5" dy="0.75" layer="1" stop="no"/>
+<text x="-1.905" y="0.635" size="1.016" layer="25">&gt;NAME</text>
+<text x="-1.905" y="-1.397" size="0.8128" layer="27">&gt;VALUE</text>
+<rectangle x1="-0.1905" y1="-0.381" x2="0.1905" y2="0.381" layer="35"/>
+<rectangle x1="-0.25" y1="-0.38" x2="0.25" y2="0.38" layer="41"/>
+<rectangle x1="-0.859" y1="-0.477" x2="0.86" y2="0.477" layer="29"/>
+</package>
+<package name="1206$SMALL">
+<wire x1="2.6" y1="0.95" x2="-2.6" y2="0.95" width="0.127" layer="21"/>
+<wire x1="-2.6" y1="0.95" x2="-2.6" y2="-0.95" width="0.127" layer="21"/>
+<wire x1="-2.6" y1="-0.95" x2="2.6" y2="-0.95" width="0.127" layer="21"/>
+<wire x1="2.6" y1="-0.95" x2="2.6" y2="0.95" width="0.127" layer="21"/>
+<smd name="2" x="1.778" y="0" dx="1.6" dy="1.5" layer="1" rot="R90"/>
+<smd name="1" x="-1.778" y="0" dx="1.6" dy="1.5" layer="1" rot="R90"/>
+<text x="-1.651" y="-0.508" size="1.016" layer="27">&gt;VALUE</text>
+<text x="-1.143" y="-0.508" size="1.016" layer="25">&gt;NAME</text>
+<rectangle x1="-0.25" y1="-0.8" x2="0.25" y2="0.8" layer="35"/>
+</package>
+<package name="0207$ST_HV">
+<wire x1="-1.905" y1="0" x2="1.905" y2="0" width="0.3048" layer="21"/>
+<circle x="-2.54" y="0" radius="1.27" width="0.3048" layer="21"/>
+<pad name="1" x="-2.54" y="0" drill="0.8128" diameter="1.524"/>
+<pad name="2" x="2.54" y="0" drill="0.8128" diameter="1.524"/>
+<text x="-1.27" y="0.635" size="1.27" layer="25">&gt;NAME</text>
+<text x="-1.27" y="0.635" size="1.27" layer="27">&gt;VALUE</text>
+</package>
+<package name="2512">
+<wire x1="-3.2" y1="-1.6" x2="3.2" y2="-1.6" width="0.127" layer="21"/>
+<wire x1="3.2" y1="-1.6" x2="3.2" y2="1.6" width="0.127" layer="21"/>
+<wire x1="3.2" y1="1.6" x2="-3.2" y2="1.6" width="0.127" layer="21"/>
+<wire x1="-3.2" y1="1.6" x2="-3.2" y2="-1.6" width="0.127" layer="21"/>
+<circle x="0" y="0.635" radius="0.3175" width="1.016" layer="35"/>
+<circle x="0" y="-0.635" radius="0.3175" width="1.016" layer="35"/>
+<smd name="1" x="-2.835" y="0" dx="3.5" dy="1.8" layer="1" rot="R90"/>
+<smd name="2" x="2.835" y="0" dx="3.5" dy="1.8" layer="1" rot="R90"/>
+<text x="-2.4765" y="-0.5715" size="1.27" layer="25">&gt;NAME</text>
+<text x="-2.4765" y="-0.6985" size="1.27" layer="27">&gt;VALUE</text>
+</package>
+<package name="R6,5/17,5">
+<wire x1="8.783" y1="0" x2="9.589" y2="0" width="0.3048" layer="21"/>
+<wire x1="-8.783" y1="0" x2="-9.839" y2="0" width="0.3048" layer="21"/>
+<pad name="1" x="-11.97" y="0" drill="1.016" diameter="3.556"/>
+<pad name="2" x="11.72" y="0" drill="1.016" diameter="3.556"/>
+<text x="-2.385" y="-0.635" size="1.27" layer="25">&gt;NAME</text>
+<text x="-3.135" y="-0.635" size="1.27" layer="27">&gt;VALUE</text>
+<wire x1="-8.75" y1="0" x2="-8.75" y2="3.25" width="0.3048" layer="21"/>
+<wire x1="-8.75" y1="3.25" x2="8.75" y2="3.25" width="0.3048" layer="21"/>
+<wire x1="8.75" y1="3.25" x2="8.75" y2="-3.25" width="0.3048" layer="21"/>
+<wire x1="8.75" y1="-3.25" x2="-8.75" y2="-3.25" width="0.3048" layer="21"/>
+<wire x1="-8.75" y1="-3.25" x2="-8.75" y2="0" width="0.3048" layer="21"/>
+</package>
+<package name="R8/44$ST">
+<pad name="1" x="-5.08" y="0" drill="1.016" diameter="3.556"/>
+<pad name="2" x="0" y="0" drill="1.016" diameter="3.556"/>
+<text x="-3.175" y="-5.715" size="1.27" layer="25">&gt;NAME</text>
+<text x="-3.175" y="4.445" size="1.27" layer="27">&gt;VALUE</text>
+<circle x="0" y="0" radius="4" width="0.3048" layer="21"/>
+<wire x1="-3.81" y1="0" x2="-5.08" y2="0" width="0.3048" layer="21"/>
+</package>
+<package name="R9,5/25">
+<wire x1="-10.033" y1="4.826" x2="-10.033" y2="0" width="0.3048" layer="21"/>
+<wire x1="-10.033" y1="-4.826" x2="10.033" y2="-4.826" width="0.3048" layer="21"/>
+<wire x1="10.033" y1="-4.826" x2="10.033" y2="0" width="0.3048" layer="21"/>
+<wire x1="-10.033" y1="4.826" x2="10.033" y2="4.826" width="0.3048" layer="21"/>
+<wire x1="10.033" y1="0" x2="12.319" y2="0" width="0.3048" layer="21"/>
+<wire x1="10.033" y1="0" x2="10.033" y2="4.826" width="0.3048" layer="21"/>
+<wire x1="-10.033" y1="0" x2="-12.319" y2="0" width="0.3048" layer="21"/>
+<wire x1="-10.033" y1="0" x2="-10.033" y2="-4.826" width="0.3048" layer="21"/>
+<pad name="1" x="-12.7" y="0" drill="1" diameter="1.9" shape="long"/>
+<pad name="2" x="12.7" y="0" drill="1" diameter="1.9" shape="long"/>
+<text x="-3.175" y="0.635" size="1.27" layer="25">&gt;NAME</text>
+<text x="-3.175" y="-1.905" size="1.27" layer="27">&gt;VALUE</text>
+</package>
+<package name="R_4X3,8_ST">
+<wire x1="3.1115" y1="0" x2="0" y2="0" width="0.3048" layer="21"/>
+<text x="-3.175" y="-3.81" size="1.27" layer="25">&gt;NAME</text>
+<text x="-3.175" y="2.54" size="1.27" layer="27">&gt;VALUE</text>
+<pad name="1" x="0" y="0" drill="1"/>
+<pad name="2" x="3.81" y="0" drill="1"/>
+<circle x="0" y="0" radius="2" width="0.127" layer="21"/>
+</package>
+<package name="R3,6X9">
+<text x="-2.385" y="-0.635" size="1.27" layer="25">&gt;NAME</text>
+<text x="-3.135" y="-0.635" size="1.27" layer="27">&gt;VALUE</text>
+<pad name="1" x="-6.35" y="0" drill="1"/>
+<pad name="2" x="6.35" y="0" drill="1"/>
+<wire x1="-4.5" y1="-1.8" x2="4.5" y2="-1.8" width="0.127" layer="21"/>
+<wire x1="4.5" y1="-1.8" x2="4.5" y2="1.8" width="0.127" layer="21"/>
+<wire x1="4.5" y1="1.8" x2="-4.5" y2="1.8" width="0.127" layer="21"/>
+<wire x1="-4.5" y1="1.8" x2="-4.5" y2="-1.8" width="0.127" layer="21"/>
+<wire x1="-5.08" y1="0" x2="-4.5186625" y2="0" width="0.127" layer="21"/>
+<wire x1="5.08" y1="0" x2="4.50088125" y2="0" width="0.127" layer="21"/>
+</package>
+<package name="R14/60">
+<wire x1="-30" y1="0" x2="-30" y2="-7" width="0.4064" layer="21"/>
+<wire x1="-30" y1="-7" x2="30" y2="-7" width="0.4064" layer="21"/>
+<wire x1="30" y1="-7" x2="30" y2="0" width="0.4064" layer="21"/>
+<wire x1="30" y1="0" x2="30" y2="7" width="0.4064" layer="21"/>
+<wire x1="30" y1="7" x2="-30" y2="7" width="0.4064" layer="21"/>
+<wire x1="-30" y1="7" x2="-30" y2="0" width="0.4064" layer="21"/>
+<text x="-5" y="3" size="1.9304" layer="25">&gt;NAME</text>
+<text x="-5" y="-5" size="1.9304" layer="27">&gt;VALUE</text>
+<pad name="1" x="-31" y="0" drill="1.1" diameter="4.5" rot="R90"/>
+<pad name="2" x="31" y="0" drill="1.1" diameter="4.5" rot="R90"/>
+<wire x1="-30" y1="0" x2="-31" y2="0" width="0.4064" layer="27"/>
+<wire x1="30" y1="0" x2="31" y2="0" width="0.4064" layer="27"/>
+</package>
+<package name="R14/60$1S">
+<wire x1="-30" y1="0" x2="-30" y2="-7" width="0.4064" layer="21"/>
+<wire x1="-30" y1="-7" x2="30" y2="-7" width="0.4064" layer="21"/>
+<wire x1="30" y1="-7" x2="30" y2="0" width="0.4064" layer="21"/>
+<wire x1="30" y1="0" x2="30" y2="7" width="0.4064" layer="21"/>
+<wire x1="30" y1="7" x2="-30" y2="7" width="0.4064" layer="21"/>
+<wire x1="-30" y1="7" x2="-30" y2="0" width="0.4064" layer="21"/>
+<text x="-5" y="3" size="1.9304" layer="25">&gt;NAME</text>
+<text x="-5" y="-5" size="1.9304" layer="27">&gt;VALUE</text>
+<pad name="1" x="-31" y="0" drill="1.1" diameter="4" shape="long" rot="R90"/>
+<pad name="2" x="31" y="0" drill="1.1" diameter="4" shape="long" rot="R90"/>
+<wire x1="-30" y1="0" x2="-31" y2="0" width="0.4064" layer="27"/>
+<wire x1="30" y1="0" x2="31" y2="0" width="0.4064" layer="27"/>
+</package>
+<package name="0207$ST_1_90">
+<wire x1="-0.635" y1="0" x2="0.635" y2="0" width="0.3048" layer="21"/>
+<circle x="-1.27" y="0" radius="1.27" width="0.3048" layer="21"/>
+<pad name="1" x="-1.27" y="0" drill="0.8128" diameter="1.524" shape="long" rot="R90"/>
+<pad name="2" x="1.27" y="0" drill="0.8128" diameter="1.524" shape="long" rot="R90"/>
+<text x="0" y="0.635" size="1.27" layer="25">&gt;NAME</text>
+<text x="0" y="0.635" size="1.27" layer="27">&gt;VALUE</text>
+</package>
+<package name="1210">
+<wire x1="2.8448" y1="1.3208" x2="-2.8448" y2="1.3208" width="0.1524" layer="21"/>
+<wire x1="-2.8448" y1="-1.3208" x2="-2.8448" y2="1.3208" width="0.1524" layer="21"/>
+<wire x1="-2.8448" y1="-1.3208" x2="2.8448" y2="-1.3208" width="0.1524" layer="21"/>
+<wire x1="2.8448" y1="1.3208" x2="2.8448" y2="-1.3208" width="0.1524" layer="21"/>
+<smd name="2" x="1.778" y="0" dx="1.8" dy="2.5" layer="1"/>
+<smd name="1" x="-1.778" y="0" dx="1.8" dy="2.5" layer="1"/>
+<text x="-1.651" y="-0.508" size="1.016" layer="27">&gt;VALUE</text>
+<text x="-1.143" y="-0.508" size="1.016" layer="25">&gt;NAME</text>
+<rectangle x1="-0.25" y1="-0.8" x2="0.25" y2="0.8" layer="35"/>
+</package>
+<package name="1812">
+<wire x1="2.365" y1="1.705" x2="2.365" y2="-1.705" width="0.127" layer="21"/>
+<wire x1="2.365" y1="-1.705" x2="-2.365" y2="-1.705" width="0.127" layer="21"/>
+<wire x1="-2.365" y1="-1.705" x2="-2.365" y2="1.705" width="0.127" layer="21"/>
+<wire x1="-2.365" y1="1.705" x2="2.365" y2="1.705" width="0.127" layer="21"/>
+<smd name="1" x="-2.54" y="0" dx="3.6" dy="1.6764" layer="1" rot="R90"/>
+<smd name="2" x="2.54" y="0" dx="3.6" dy="1.6764" layer="1" rot="R90"/>
+<text x="-3.175" y="2.54" size="1.27" layer="25">&gt;NAME</text>
+<text x="-3.175" y="-3.81" size="1.27" layer="27">&gt;VALUE</text>
+<rectangle x1="-0.635" y1="-1.27" x2="0.635" y2="1.27" layer="35"/>
+</package>
+<package name="1206$LED">
+<wire x1="3" y1="0.95" x2="-3" y2="0.95" width="0.127" layer="21"/>
+<wire x1="-3" y1="0.95" x2="-3" y2="-0.95" width="0.127" layer="21"/>
+<wire x1="-3" y1="-0.95" x2="3" y2="-0.95" width="0.127" layer="21"/>
+<wire x1="3" y1="-0.95" x2="3" y2="0.95" width="0.127" layer="21"/>
+<smd name="2" x="2.178" y="0" dx="1.6" dy="1.5" layer="1" rot="R90"/>
+<smd name="1" x="-2.178" y="0" dx="1.6" dy="1.5" layer="1" rot="R90"/>
+<text x="-2.051" y="-0.508" size="1.016" layer="27">&gt;VALUE</text>
+<text x="-1.143" y="-0.508" size="1.016" layer="25">&gt;NAME</text>
+<rectangle x1="-0.25" y1="-0.8" x2="0.25" y2="0.8" layer="35"/>
+</package>
+<package name="1210_REFLOW">
+<wire x1="1.6" y1="1.25" x2="-1.6" y2="1.25" width="0.1524" layer="21"/>
+<wire x1="-1.6" y1="-1.25" x2="-1.6" y2="1.25" width="0.1524" layer="21"/>
+<wire x1="-1.6" y1="-1.25" x2="1.6" y2="-1.25" width="0.1524" layer="21"/>
+<wire x1="1.6" y1="1.25" x2="1.6" y2="-1.25" width="0.1524" layer="21"/>
+<smd name="2" x="1.45" y="0" dx="0.9" dy="2.5" layer="1"/>
+<smd name="1" x="-1.45" y="0" dx="0.9" dy="2.5" layer="1"/>
+<text x="-1.651" y="-0.508" size="1.016" layer="27">&gt;VALUE</text>
+<text x="-1.143" y="-0.508" size="1.016" layer="25">&gt;NAME</text>
+<rectangle x1="-0.25" y1="-0.8" x2="0.25" y2="0.8" layer="35"/>
+</package>
+<package name="0603_REFLOW">
+<wire x1="0.8" y1="0.425" x2="-0.8" y2="0.425" width="0.1524" layer="21"/>
+<wire x1="-0.8" y1="-0.425" x2="-0.8" y2="0.425" width="0.1524" layer="21"/>
+<wire x1="-0.8" y1="-0.425" x2="0.8" y2="-0.425" width="0.1524" layer="21"/>
+<wire x1="0.8" y1="0.425" x2="0.8" y2="-0.425" width="0.1524" layer="21"/>
+<smd name="1" x="-0.8" y="0" dx="0.5" dy="0.9" layer="1"/>
+<smd name="2" x="0.8" y="0" dx="0.5" dy="0.9" layer="1"/>
+<text x="-1.27" y="-1.778" size="1.016" layer="25">&gt;NAME</text>
+<text x="-1.397" y="0.889" size="0.8128" layer="27">&gt;VALUE</text>
+<rectangle x1="-0.254" y1="-0.508" x2="0.254" y2="0.508" layer="35"/>
+</package>
+<package name="1206_REFLOW">
+<wire x1="1.6" y1="0.8" x2="-1.6" y2="0.8" width="0.1524" layer="21"/>
+<wire x1="-1.6" y1="-0.8" x2="-1.6" y2="0.8" width="0.1524" layer="21"/>
+<wire x1="-1.6" y1="-0.8" x2="1.6" y2="-0.8" width="0.1524" layer="21"/>
+<wire x1="1.6" y1="0.8" x2="1.6" y2="-0.8" width="0.1524" layer="21"/>
+<smd name="2" x="1.45" y="0" dx="1.7" dy="0.9" layer="1" rot="R90"/>
+<smd name="1" x="-1.45" y="0" dx="1.7" dy="0.9" layer="1" rot="R270"/>
+<text x="-1.651" y="-0.508" size="1.016" layer="27">&gt;VALUE</text>
+<text x="-1.143" y="-0.508" size="1.016" layer="25">&gt;NAME</text>
+<rectangle x1="-0.25" y1="-0.8" x2="0.25" y2="0.8" layer="35"/>
+</package>
+<package name="0805_REFLOW">
+<wire x1="1" y1="0.625" x2="-1" y2="0.625" width="0.1524" layer="21"/>
+<wire x1="-1" y1="-0.625" x2="-1" y2="0.625" width="0.1524" layer="21"/>
+<wire x1="-1" y1="-0.625" x2="1" y2="-0.625" width="0.1524" layer="21"/>
+<wire x1="1" y1="0.625" x2="1" y2="-0.625" width="0.1524" layer="21"/>
+<smd name="2" x="0.95" y="0" dx="0.7" dy="1.3" layer="1"/>
+<smd name="1" x="-0.95" y="0" dx="0.7" dy="1.3" layer="1"/>
+<text x="-0.9525" y="-0.5159375" size="1.016" layer="25">&gt;NAME</text>
+<text x="-0.9525" y="-0.5159375" size="1.016" layer="27">&gt;VALUE</text>
+<rectangle x1="-0.15" y1="-1" x2="0.15" y2="1" layer="35"/>
+</package>
+<package name="1812_REFLOW">
+<wire x1="2.25" y1="1.6" x2="2.25" y2="-1.6" width="0.127" layer="21"/>
+<wire x1="2.25" y1="-1.6" x2="-2.25" y2="-1.6" width="0.127" layer="21"/>
+<wire x1="-2.25" y1="-1.6" x2="-2.25" y2="1.6" width="0.127" layer="21"/>
+<wire x1="-2.25" y1="1.6" x2="2.25" y2="1.6" width="0.127" layer="21"/>
+<smd name="1" x="-2.1" y="0" dx="3.2" dy="1.2" layer="1" rot="R90"/>
+<smd name="2" x="2.1" y="0" dx="3.2" dy="1.2" layer="1" rot="R90"/>
+<text x="-3.175" y="2.54" size="1.27" layer="25">&gt;NAME</text>
+<text x="-3.175" y="-3.81" size="1.27" layer="27">&gt;VALUE</text>
+<rectangle x1="-0.635" y1="-1.27" x2="0.635" y2="1.27" layer="35"/>
+</package>
+<package name="RM5">
+<wire x1="-0.381" y1="-1.27" x2="-0.381" y2="0" width="0.3048" layer="21"/>
+<wire x1="-0.381" y1="0" x2="-0.381" y2="1.27" width="0.3048" layer="21"/>
+<wire x1="0.381" y1="1.27" x2="0.381" y2="0" width="0.3048" layer="21"/>
+<wire x1="0.381" y1="0" x2="0.381" y2="-1.27" width="0.3048" layer="21"/>
+<wire x1="0.381" y1="0" x2="1.905" y2="0" width="0.3048" layer="21"/>
+<wire x1="-1.905" y1="0" x2="-0.381" y2="0" width="0.3048" layer="21"/>
+<pad name="1" x="-2.54" y="0" drill="1.016" diameter="1.6256"/>
+<pad name="2" x="2.54" y="0" drill="1.016" diameter="1.6256"/>
+<text x="-3.175" y="-3.175" size="1.27" layer="27">&gt;VALUE</text>
+<text x="-2.54" y="1.905" size="1.27" layer="25">&gt;NAME</text>
+</package>
+<package name="RM5$1S">
+<wire x1="-0.381" y1="-1.27" x2="-0.381" y2="0" width="0.3048" layer="21"/>
+<wire x1="-0.381" y1="0" x2="-0.381" y2="1.27" width="0.3048" layer="21"/>
+<wire x1="0.381" y1="1.27" x2="0.381" y2="0" width="0.3048" layer="21"/>
+<wire x1="0.381" y1="0" x2="0.381" y2="-1.27" width="0.3048" layer="21"/>
+<wire x1="0.381" y1="0" x2="1.905" y2="0" width="0.3048" layer="21"/>
+<wire x1="-1.905" y1="0" x2="-0.381" y2="0" width="0.3048" layer="21"/>
+<pad name="1" x="-2.54" y="0" drill="0.8128" diameter="1.524" shape="long" rot="R90"/>
+<pad name="2" x="2.54" y="0" drill="0.8128" diameter="1.524" shape="long" rot="R90"/>
+<text x="-3.175" y="-3.175" size="1.27" layer="27">&gt;VALUE</text>
+<text x="-2.54" y="1.905" size="1.27" layer="25">&gt;NAME</text>
+</package>
+<package name="RM14$1S">
+<wire x1="-0.635" y1="0" x2="-6.35" y2="0" width="0.3048" layer="21"/>
+<wire x1="0.635" y1="0" x2="6.35" y2="0" width="0.3048" layer="21"/>
+<wire x1="0.635" y1="1.27" x2="0.635" y2="-1.27" width="0.3048" layer="21"/>
+<wire x1="-0.635" y1="-1.27" x2="-0.635" y2="1.27" width="0.3048" layer="21"/>
+<pad name="1" x="-6.985" y="0" drill="0.9144" diameter="1.905" shape="long" rot="R90"/>
+<pad name="2" x="6.985" y="0" drill="0.9144" diameter="1.905" shape="long" rot="R90"/>
+<text x="-2.54" y="2.54" size="1.27" layer="25">&gt;NAME</text>
+<text x="-3.81" y="-3.81" size="1.27" layer="27">&gt;VALUE</text>
+</package>
+<package name="C_225-074X268">
+<wire x1="-12.827" y1="3.556" x2="12.827" y2="3.556" width="0.1524" layer="21"/>
+<wire x1="13.335" y1="3.048" x2="13.335" y2="-3.048" width="0.1524" layer="21"/>
+<wire x1="12.827" y1="-3.556" x2="-12.827" y2="-3.556" width="0.1524" layer="21"/>
+<wire x1="-13.335" y1="-3.048" x2="-13.335" y2="3.048" width="0.1524" layer="21"/>
+<wire x1="-6.731" y1="1.905" x2="-6.731" y2="0" width="0.4064" layer="21"/>
+<wire x1="-6.731" y1="0" x2="-6.731" y2="-1.905" width="0.4064" layer="21"/>
+<wire x1="-7.62" y1="1.905" x2="-7.62" y2="0" width="0.4064" layer="21"/>
+<wire x1="-7.62" y1="0" x2="-7.62" y2="-1.905" width="0.4064" layer="21"/>
+<wire x1="12.827" y1="3.556" x2="13.335" y2="3.048" width="0.1524" layer="21" curve="-90"/>
+<wire x1="12.827" y1="-3.556" x2="13.335" y2="-3.048" width="0.1524" layer="21" curve="90"/>
+<wire x1="-13.335" y1="-3.048" x2="-12.827" y2="-3.556" width="0.1524" layer="21" curve="90"/>
+<wire x1="-13.335" y1="3.048" x2="-12.827" y2="3.556" width="0.1524" layer="21" curve="-90"/>
+<wire x1="-9.652" y1="0" x2="-7.62" y2="0" width="0.1524" layer="21"/>
+<wire x1="-6.731" y1="0" x2="9.652" y2="0" width="0.1524" layer="21"/>
+<pad name="1" x="-11.303" y="0" drill="1.016" diameter="1.6764" shape="octagon"/>
+<pad name="2" x="11.303" y="0" drill="1.016" diameter="1.6764" shape="octagon"/>
+<text x="-12.827" y="3.937" size="1.778" layer="25" ratio="10">&gt;NAME</text>
+<text x="-5.08" y="-2.54" size="1.778" layer="27" ratio="10">&gt;VALUE</text>
+</package>
+<package name="RM10">
+<wire x1="-0.381" y1="-1.27" x2="-0.381" y2="0" width="0.3048" layer="21"/>
+<wire x1="-0.381" y1="0" x2="-0.381" y2="1.27" width="0.3048" layer="21"/>
+<wire x1="0.381" y1="1.27" x2="0.381" y2="0" width="0.3048" layer="21"/>
+<wire x1="0.381" y1="0" x2="0.381" y2="-1.27" width="0.3048" layer="21"/>
+<wire x1="0.381" y1="0" x2="3.81" y2="0" width="0.3048" layer="21"/>
+<wire x1="-3.81" y1="0" x2="-0.381" y2="0" width="0.3048" layer="21"/>
+<pad name="1" x="-5.08" y="0" drill="1.016" diameter="1.6256"/>
+<pad name="2" x="5.08" y="0" drill="1.016" diameter="1.6256"/>
+<text x="-3.175" y="-3.175" size="1.27" layer="27">&gt;VALUE</text>
+<text x="-2.54" y="1.905" size="1.27" layer="25">&gt;NAME</text>
+</package>
+<package name="C-225-074X268$1S">
+<wire x1="-12.827" y1="3.556" x2="12.827" y2="3.556" width="0.1524" layer="21"/>
+<wire x1="13.335" y1="3.048" x2="13.335" y2="-3.048" width="0.1524" layer="21"/>
+<wire x1="12.827" y1="-3.556" x2="-12.827" y2="-3.556" width="0.1524" layer="21"/>
+<wire x1="-13.335" y1="-3.048" x2="-13.335" y2="3.048" width="0.1524" layer="21"/>
+<wire x1="-6.731" y1="1.905" x2="-6.731" y2="0" width="0.4064" layer="21"/>
+<wire x1="-6.731" y1="0" x2="-6.731" y2="-1.905" width="0.4064" layer="21"/>
+<wire x1="-7.62" y1="1.905" x2="-7.62" y2="0" width="0.4064" layer="21"/>
+<wire x1="-7.62" y1="0" x2="-7.62" y2="-1.905" width="0.4064" layer="21"/>
+<wire x1="12.827" y1="3.556" x2="13.335" y2="3.048" width="0.1524" layer="21" curve="-90"/>
+<wire x1="12.827" y1="-3.556" x2="13.335" y2="-3.048" width="0.1524" layer="21" curve="90"/>
+<wire x1="-13.335" y1="-3.048" x2="-12.827" y2="-3.556" width="0.1524" layer="21" curve="90"/>
+<wire x1="-13.335" y1="3.048" x2="-12.827" y2="3.556" width="0.1524" layer="21" curve="-90"/>
+<wire x1="-9.652" y1="0" x2="-7.62" y2="0" width="0.1524" layer="21"/>
+<wire x1="-6.731" y1="0" x2="9.652" y2="0" width="0.1524" layer="21"/>
+<pad name="1" x="-11.43" y="0.127" drill="1.016" shape="long" rot="R90"/>
+<pad name="2" x="11.43" y="-0.127" drill="1.016" shape="long" rot="R90"/>
+<text x="-12.827" y="3.937" size="1.778" layer="25" ratio="10">&gt;NAME</text>
+<text x="-5.08" y="-2.54" size="1.778" layer="27" ratio="10">&gt;VALUE</text>
+</package>
+<package name="RM10$1S">
+<wire x1="-0.381" y1="-1.27" x2="-0.381" y2="0" width="0.3048" layer="21"/>
+<wire x1="-0.381" y1="0" x2="-0.381" y2="1.27" width="0.3048" layer="21"/>
+<wire x1="0.381" y1="1.27" x2="0.381" y2="0" width="0.3048" layer="21"/>
+<wire x1="0.381" y1="0" x2="0.381" y2="-1.27" width="0.3048" layer="21"/>
+<wire x1="0.381" y1="0" x2="3.81" y2="0" width="0.3048" layer="21"/>
+<wire x1="-3.81" y1="0" x2="-0.381" y2="0" width="0.3048" layer="21"/>
+<pad name="1" x="-5.08" y="0" drill="1.016" diameter="1.6256" shape="offset" rot="R180"/>
+<pad name="2" x="5.08" y="0" drill="1.016" diameter="1.6256" shape="offset"/>
+<text x="-3.175" y="-3.175" size="1.27" layer="27">&gt;VALUE</text>
+<text x="-2.54" y="1.905" size="1.27" layer="25">&gt;NAME</text>
+</package>
+<package name="C-150-050X180$1S">
+<wire x1="-5.08" y1="1.27" x2="-5.08" y2="0" width="0.4064" layer="21"/>
+<wire x1="-5.08" y1="0" x2="-5.08" y2="-1.27" width="0.4064" layer="21"/>
+<wire x1="-4.191" y1="1.27" x2="-4.191" y2="0" width="0.4064" layer="21"/>
+<wire x1="-4.191" y1="0" x2="-4.191" y2="-1.27" width="0.4064" layer="21"/>
+<wire x1="-4.191" y1="0" x2="6.096" y2="0" width="0.1524" layer="21"/>
+<wire x1="-5.08" y1="0" x2="-6.096" y2="0" width="0.1524" layer="21"/>
+<wire x1="9.017" y1="2.032" x2="9.017" y2="-2.032" width="0.1524" layer="21"/>
+<wire x1="8.509" y1="-2.54" x2="-8.509" y2="-2.54" width="0.1524" layer="21"/>
+<wire x1="-9.017" y1="-2.032" x2="-9.017" y2="2.032" width="0.1524" layer="21"/>
+<wire x1="-8.509" y1="2.54" x2="8.509" y2="2.54" width="0.1524" layer="21"/>
+<wire x1="8.509" y1="2.54" x2="9.017" y2="2.032" width="0.1524" layer="21" curve="-90"/>
+<wire x1="8.509" y1="-2.54" x2="9.017" y2="-2.032" width="0.1524" layer="21" curve="90"/>
+<wire x1="-9.017" y1="-2.032" x2="-8.509" y2="-2.54" width="0.1524" layer="21" curve="90"/>
+<wire x1="-9.017" y1="2.032" x2="-8.509" y2="2.54" width="0.1524" layer="21" curve="-90"/>
+<pad name="1" x="-7.493" y="0" drill="1.016" shape="long"/>
+<pad name="2" x="7.493" y="0" drill="1.016" shape="long"/>
+<text x="-8.382" y="2.921" size="1.27" layer="25" ratio="10">&gt;NAME</text>
+<text x="-3.429" y="-2.032" size="1.27" layer="27" ratio="10">&gt;VALUE</text>
+</package>
+<package name="C_275_180X320">
+<wire x1="-16.002" y1="8.636" x2="16.002" y2="8.636" width="0.1524" layer="21"/>
+<wire x1="16.51" y1="8.128" x2="16.51" y2="-8.128" width="0.1524" layer="21"/>
+<wire x1="16.002" y1="-8.636" x2="-16.002" y2="-8.636" width="0.1524" layer="21"/>
+<wire x1="-16.51" y1="-8.128" x2="-16.51" y2="8.128" width="0.1524" layer="21"/>
+<wire x1="-6.731" y1="1.905" x2="-6.731" y2="0" width="0.4064" layer="21"/>
+<wire x1="-6.731" y1="0" x2="-6.731" y2="-1.905" width="0.4064" layer="21"/>
+<wire x1="-7.62" y1="1.905" x2="-7.62" y2="0" width="0.4064" layer="21"/>
+<wire x1="-7.62" y1="0" x2="-7.62" y2="-1.905" width="0.4064" layer="21"/>
+<wire x1="16.002" y1="8.636" x2="16.51" y2="8.128" width="0.1524" layer="21" curve="-90"/>
+<wire x1="16.002" y1="-8.636" x2="16.51" y2="-8.128" width="0.1524" layer="21" curve="90"/>
+<wire x1="-16.51" y1="-8.128" x2="-16.002" y2="-8.636" width="0.1524" layer="21" curve="90"/>
+<wire x1="-16.51" y1="8.128" x2="-16.002" y2="8.636" width="0.1524" layer="21" curve="-90"/>
+<wire x1="-9.652" y1="0" x2="-7.62" y2="0" width="0.1524" layer="21"/>
+<wire x1="-6.731" y1="0" x2="9.652" y2="0" width="0.1524" layer="21"/>
+<pad name="P$1" x="-13.75" y="0" drill="1.2" shape="long" rot="R90"/>
+<pad name="P$2" x="13.75" y="0" drill="1.2" shape="long" rot="R90"/>
+<text x="-5.08" y="0.762" size="1.778" layer="25" ratio="10">&gt;NAME</text>
+<text x="-5.08" y="-2.54" size="1.778" layer="27" ratio="10">&gt;VALUE</text>
+</package>
+<package name="C_375_20X40">
+<wire x1="-19.812" y1="9.906" x2="19.812" y2="9.906" width="0.1524" layer="21"/>
+<wire x1="20.32" y1="9.398" x2="20.32" y2="-9.398" width="0.1524" layer="21"/>
+<wire x1="19.812" y1="-9.906" x2="-19.812" y2="-9.906" width="0.1524" layer="21"/>
+<wire x1="-20.32" y1="-9.398" x2="-20.32" y2="9.398" width="0.1524" layer="21"/>
+<wire x1="-6.731" y1="1.905" x2="-6.731" y2="0" width="0.4064" layer="21"/>
+<wire x1="-6.731" y1="0" x2="-6.731" y2="-1.905" width="0.4064" layer="21"/>
+<wire x1="-7.62" y1="1.905" x2="-7.62" y2="0" width="0.4064" layer="21"/>
+<wire x1="-7.62" y1="0" x2="-7.62" y2="-1.905" width="0.4064" layer="21"/>
+<wire x1="19.812" y1="9.906" x2="20.32" y2="9.398" width="0.1524" layer="21" curve="-90"/>
+<wire x1="19.812" y1="-9.906" x2="20.32" y2="-9.398" width="0.1524" layer="21" curve="90"/>
+<wire x1="-20.32" y1="-9.398" x2="-19.812" y2="-9.906" width="0.1524" layer="21" curve="90"/>
+<wire x1="-20.32" y1="9.398" x2="-19.812" y2="9.906" width="0.1524" layer="21" curve="-90"/>
+<wire x1="-9.652" y1="0" x2="-7.62" y2="0" width="0.1524" layer="21"/>
+<wire x1="-6.731" y1="0" x2="9.652" y2="0" width="0.1524" layer="21"/>
+<pad name="P$1" x="-18.75" y="0" drill="1.2" shape="long" rot="R90"/>
+<pad name="P$2" x="18.75" y="0" drill="1.2" shape="long" rot="R90"/>
+<text x="-5.08" y="0.762" size="1.778" layer="25" ratio="10">&gt;NAME</text>
+<text x="-5.08" y="-2.54" size="1.778" layer="27" ratio="10">&gt;VALUE</text>
+</package>
+<package name="C-102-054X133$1S">
+<wire x1="-3.175" y1="1.27" x2="-3.175" y2="0" width="0.4064" layer="21"/>
+<wire x1="-2.286" y1="1.27" x2="-2.286" y2="0" width="0.4064" layer="21"/>
+<wire x1="3.81" y1="0" x2="-2.286" y2="0" width="0.1524" layer="21"/>
+<wire x1="-2.286" y1="0" x2="-2.286" y2="-1.27" width="0.4064" layer="21"/>
+<wire x1="-3.81" y1="0" x2="-3.175" y2="0" width="0.1524" layer="21"/>
+<wire x1="-3.175" y1="0" x2="-3.175" y2="-1.27" width="0.4064" layer="21"/>
+<wire x1="-6.096" y1="2.54" x2="6.096" y2="2.54" width="0.1524" layer="21"/>
+<wire x1="6.604" y1="2.032" x2="6.604" y2="-2.032" width="0.1524" layer="21"/>
+<wire x1="6.096" y1="-2.54" x2="-6.096" y2="-2.54" width="0.1524" layer="21"/>
+<wire x1="-6.604" y1="-2.032" x2="-6.604" y2="2.032" width="0.1524" layer="21"/>
+<wire x1="6.096" y1="2.54" x2="6.604" y2="2.032" width="0.1524" layer="21" curve="-90"/>
+<wire x1="6.096" y1="-2.54" x2="6.604" y2="-2.032" width="0.1524" layer="21" curve="90"/>
+<wire x1="-6.604" y1="-2.032" x2="-6.096" y2="-2.54" width="0.1524" layer="21" curve="90"/>
+<wire x1="-6.604" y1="2.032" x2="-6.096" y2="2.54" width="0.1524" layer="21" curve="-90"/>
+<pad name="1" x="-5.08" y="0" drill="1.016" shape="long" rot="R90"/>
+<pad name="2" x="5.08" y="0" drill="1.016" shape="long" rot="R90"/>
+<text x="-6.096" y="2.921" size="1.27" layer="25" ratio="10">&gt;NAME</text>
+<text x="-1.524" y="-1.905" size="1.27" layer="27" ratio="10">&gt;VALUE</text>
+</package>
+<package name="C-102-054X133$S1">
+<wire x1="-3.175" y1="1.27" x2="-3.175" y2="0" width="0.4064" layer="21"/>
+<wire x1="-2.286" y1="1.27" x2="-2.286" y2="0" width="0.4064" layer="21"/>
+<wire x1="3.81" y1="0" x2="-2.286" y2="0" width="0.1524" layer="21"/>
+<wire x1="-2.286" y1="0" x2="-2.286" y2="-1.27" width="0.4064" layer="21"/>
+<wire x1="-3.81" y1="0" x2="-3.175" y2="0" width="0.1524" layer="21"/>
+<wire x1="-3.175" y1="0" x2="-3.175" y2="-1.27" width="0.4064" layer="21"/>
+<wire x1="-6.096" y1="2.54" x2="6.096" y2="2.54" width="0.1524" layer="21"/>
+<wire x1="6.604" y1="2.032" x2="6.604" y2="-2.032" width="0.1524" layer="21"/>
+<wire x1="6.096" y1="-2.54" x2="-6.096" y2="-2.54" width="0.1524" layer="21"/>
+<wire x1="-6.604" y1="-2.032" x2="-6.604" y2="2.032" width="0.1524" layer="21"/>
+<wire x1="6.096" y1="2.54" x2="6.604" y2="2.032" width="0.1524" layer="21" curve="-90"/>
+<wire x1="6.096" y1="-2.54" x2="6.604" y2="-2.032" width="0.1524" layer="21" curve="90"/>
+<wire x1="-6.604" y1="-2.032" x2="-6.096" y2="-2.54" width="0.1524" layer="21" curve="90"/>
+<wire x1="-6.604" y1="2.032" x2="-6.096" y2="2.54" width="0.1524" layer="21" curve="-90"/>
+<pad name="1" x="-5.08" y="0" drill="1.016" shape="long" rot="R180"/>
+<pad name="2" x="5.08" y="0" drill="1.016" shape="long" rot="R180"/>
+<text x="-6.096" y="2.921" size="1.27" layer="25" ratio="10">&gt;NAME</text>
+<text x="-1.524" y="-1.905" size="1.27" layer="27" ratio="10">&gt;VALUE</text>
+</package>
+<package name="RM5$1S90">
+<wire x1="-0.381" y1="-1.27" x2="-0.381" y2="0" width="0.3048" layer="21"/>
+<wire x1="-0.381" y1="0" x2="-0.381" y2="1.27" width="0.3048" layer="21"/>
+<wire x1="0.381" y1="1.27" x2="0.381" y2="0" width="0.3048" layer="21"/>
+<wire x1="0.381" y1="0" x2="0.381" y2="-1.27" width="0.3048" layer="21"/>
+<wire x1="0.381" y1="0" x2="1.905" y2="0" width="0.3048" layer="21"/>
+<wire x1="-1.905" y1="0" x2="-0.381" y2="0" width="0.3048" layer="21"/>
+<pad name="1" x="-2.54" y="0" drill="0.8128" diameter="1.524" shape="long" rot="R180"/>
+<pad name="2" x="2.54" y="0" drill="0.8128" diameter="1.524" shape="long" rot="R180"/>
+<text x="-3.175" y="-3.175" size="1.27" layer="27">&gt;VALUE</text>
+<text x="-2.54" y="1.905" size="1.27" layer="25">&gt;NAME</text>
+</package>
+<package name="C-225-074X268$1S90">
+<wire x1="-12.827" y1="3.556" x2="12.827" y2="3.556" width="0.1524" layer="21"/>
+<wire x1="13.335" y1="3.048" x2="13.335" y2="-3.048" width="0.1524" layer="21"/>
+<wire x1="12.827" y1="-3.556" x2="-12.827" y2="-3.556" width="0.1524" layer="21"/>
+<wire x1="-13.335" y1="-3.048" x2="-13.335" y2="3.048" width="0.1524" layer="21"/>
+<wire x1="-6.731" y1="1.905" x2="-6.731" y2="0" width="0.4064" layer="21"/>
+<wire x1="-6.731" y1="0" x2="-6.731" y2="-1.905" width="0.4064" layer="21"/>
+<wire x1="-7.62" y1="1.905" x2="-7.62" y2="0" width="0.4064" layer="21"/>
+<wire x1="-7.62" y1="0" x2="-7.62" y2="-1.905" width="0.4064" layer="21"/>
+<wire x1="12.827" y1="3.556" x2="13.335" y2="3.048" width="0.1524" layer="21" curve="-90"/>
+<wire x1="12.827" y1="-3.556" x2="13.335" y2="-3.048" width="0.1524" layer="21" curve="90"/>
+<wire x1="-13.335" y1="-3.048" x2="-12.827" y2="-3.556" width="0.1524" layer="21" curve="90"/>
+<wire x1="-13.335" y1="3.048" x2="-12.827" y2="3.556" width="0.1524" layer="21" curve="-90"/>
+<wire x1="-9.652" y1="0" x2="-7.62" y2="0" width="0.1524" layer="21"/>
+<wire x1="-6.731" y1="0" x2="9.652" y2="0" width="0.1524" layer="21"/>
+<pad name="1" x="-11.43" y="0" drill="1.016" shape="long" rot="R180"/>
+<pad name="2" x="11.43" y="0" drill="1.016" shape="long" rot="R180"/>
+<text x="-12.827" y="3.937" size="1.778" layer="25" ratio="10">&gt;NAME</text>
+<text x="-5.08" y="-2.54" size="1.778" layer="27" ratio="10">&gt;VALUE</text>
+</package>
+<package name="C-150-050X180">
+<wire x1="-5.08" y1="1.27" x2="-5.08" y2="0" width="0.4064" layer="21"/>
+<wire x1="-5.08" y1="0" x2="-5.08" y2="-1.27" width="0.4064" layer="21"/>
+<wire x1="-4.191" y1="1.27" x2="-4.191" y2="0" width="0.4064" layer="21"/>
+<wire x1="-4.191" y1="0" x2="-4.191" y2="-1.27" width="0.4064" layer="21"/>
+<wire x1="-4.191" y1="0" x2="6.096" y2="0" width="0.1524" layer="21"/>
+<wire x1="-5.08" y1="0" x2="-6.096" y2="0" width="0.1524" layer="21"/>
+<wire x1="9.017" y1="2.032" x2="9.017" y2="-2.032" width="0.1524" layer="21"/>
+<wire x1="8.509" y1="-2.54" x2="-8.509" y2="-2.54" width="0.1524" layer="21"/>
+<wire x1="-9.017" y1="-2.032" x2="-9.017" y2="2.032" width="0.1524" layer="21"/>
+<wire x1="-8.509" y1="2.54" x2="8.509" y2="2.54" width="0.1524" layer="21"/>
+<wire x1="8.509" y1="2.54" x2="9.017" y2="2.032" width="0.1524" layer="21" curve="-90"/>
+<wire x1="8.509" y1="-2.54" x2="9.017" y2="-2.032" width="0.1524" layer="21" curve="90"/>
+<wire x1="-9.017" y1="-2.032" x2="-8.509" y2="-2.54" width="0.1524" layer="21" curve="90"/>
+<wire x1="-9.017" y1="2.032" x2="-8.509" y2="2.54" width="0.1524" layer="21" curve="-90"/>
+<text x="-3.302" y="2.921" size="1.27" layer="25" ratio="10">&gt;NAME</text>
+<text x="-3.429" y="-4.572" size="1.27" layer="27" ratio="10">&gt;VALUE</text>
+<pad name="2" x="7.5" y="0" drill="0.9"/>
+<pad name="1" x="-7.5" y="0" drill="0.9"/>
+</package>
+<package name="C-102-054X133">
+<wire x1="-3.175" y1="1.27" x2="-3.175" y2="0" width="0.4064" layer="21"/>
+<wire x1="-2.286" y1="1.27" x2="-2.286" y2="0" width="0.4064" layer="21"/>
+<wire x1="3.81" y1="0" x2="-2.286" y2="0" width="0.1524" layer="21"/>
+<wire x1="-2.286" y1="0" x2="-2.286" y2="-1.27" width="0.4064" layer="21"/>
+<wire x1="-3.81" y1="0" x2="-3.175" y2="0" width="0.1524" layer="21"/>
+<wire x1="-3.175" y1="0" x2="-3.175" y2="-1.27" width="0.4064" layer="21"/>
+<wire x1="-6.096" y1="2.54" x2="6.096" y2="2.54" width="0.1524" layer="21"/>
+<wire x1="6.604" y1="2.032" x2="6.604" y2="-2.032" width="0.1524" layer="21"/>
+<wire x1="6.096" y1="-2.54" x2="-6.096" y2="-2.54" width="0.1524" layer="21"/>
+<wire x1="-6.604" y1="-2.032" x2="-6.604" y2="2.032" width="0.1524" layer="21"/>
+<wire x1="6.096" y1="2.54" x2="6.604" y2="2.032" width="0.1524" layer="21" curve="-90"/>
+<wire x1="6.096" y1="-2.54" x2="6.604" y2="-2.032" width="0.1524" layer="21" curve="90"/>
+<wire x1="-6.604" y1="-2.032" x2="-6.096" y2="-2.54" width="0.1524" layer="21" curve="90"/>
+<wire x1="-6.604" y1="2.032" x2="-6.096" y2="2.54" width="0.1524" layer="21" curve="-90"/>
+<pad name="1" x="-5.08" y="0" drill="0.9" rot="R180"/>
+<pad name="2" x="5.08" y="0" drill="0.9" rot="R180"/>
+<text x="-6.096" y="2.921" size="1.27" layer="25" ratio="10">&gt;NAME</text>
+<text x="-1.524" y="-1.905" size="1.27" layer="27" ratio="10">&gt;VALUE</text>
+</package>
+<package name="C-075_050X105">
+<wire x1="4.953" y1="2.54" x2="-4.953" y2="2.54" width="0.1524" layer="21"/>
+<wire x1="-5.207" y1="2.286" x2="-5.207" y2="-2.286" width="0.1524" layer="21"/>
+<wire x1="-4.953" y1="-2.54" x2="4.953" y2="-2.54" width="0.1524" layer="21"/>
+<wire x1="5.207" y1="-2.286" x2="5.207" y2="2.286" width="0.1524" layer="21"/>
+<wire x1="4.953" y1="2.54" x2="5.207" y2="2.286" width="0.1524" layer="21" curve="-90"/>
+<wire x1="4.953" y1="-2.54" x2="5.207" y2="-2.286" width="0.1524" layer="21" curve="90"/>
+<wire x1="-5.207" y1="-2.286" x2="-4.953" y2="-2.54" width="0.1524" layer="21" curve="90"/>
+<wire x1="-5.207" y1="2.286" x2="-4.953" y2="2.54" width="0.1524" layer="21" curve="-90"/>
+<wire x1="-1.27" y1="0" x2="2.667" y2="0" width="0.1524" layer="21"/>
+<wire x1="-2.667" y1="0" x2="-2.159" y2="0" width="0.1524" layer="21"/>
+<wire x1="-2.159" y1="1.27" x2="-2.159" y2="0" width="0.4064" layer="21"/>
+<wire x1="-2.159" y1="0" x2="-2.159" y2="-1.27" width="0.4064" layer="21"/>
+<wire x1="-1.27" y1="1.27" x2="-1.27" y2="0" width="0.4064" layer="21"/>
+<wire x1="-1.27" y1="0" x2="-1.27" y2="-1.27" width="0.4064" layer="21"/>
+<pad name="1" x="-3.81" y="0" drill="0.9144" diameter="1.905" shape="octagon"/>
+<pad name="2" x="3.81" y="0" drill="0.9144" diameter="1.905" shape="octagon"/>
+<text x="-3.81" y="2.794" size="1.27" layer="25" ratio="10">&gt;NAME</text>
+<text x="-3.81" y="-4.064" size="1.27" layer="27" ratio="10">&gt;VALUE</text>
+</package>
+<package name="RM7,5">
+<wire x1="-0.381" y1="-1.27" x2="-0.381" y2="0" width="0.3048" layer="21"/>
+<wire x1="-0.381" y1="0" x2="-0.381" y2="1.27" width="0.3048" layer="21"/>
+<wire x1="0.381" y1="1.27" x2="0.381" y2="0" width="0.3048" layer="21"/>
+<wire x1="0.381" y1="0" x2="0.381" y2="-1.27" width="0.3048" layer="21"/>
+<wire x1="0.381" y1="0" x2="2.413" y2="0" width="0.3048" layer="21"/>
+<wire x1="-2.413" y1="0" x2="-0.381" y2="0" width="0.3048" layer="21"/>
+<pad name="1" x="-3.81" y="0" drill="1.016" diameter="1.6256"/>
+<pad name="2" x="3.81" y="0" drill="1.016" diameter="1.6256"/>
+<text x="-3.175" y="-3.175" size="1.27" layer="27">&gt;VALUE</text>
+<text x="-2.54" y="1.905" size="1.27" layer="25">&gt;NAME</text>
+</package>
+<package name="B2,5/6">
+<circle x="0" y="0" radius="3.1" width="0.3048" layer="21"/>
+<pad name="1" x="-1.27" y="0" drill="0.8128" diameter="1.524"/>
+<pad name="2" x="1.27" y="0" drill="0.8128" diameter="1.524"/>
+<text x="-2.54" y="3.81" size="1.27" layer="25">&gt;NAME</text>
+<text x="-3.81" y="-5.08" size="1.27" layer="27">&gt;VALUE</text>
+</package>
+<package name="DO241AA">
+<wire x1="2.5" y1="1.85" x2="-2.5" y2="1.85" width="0.1524" layer="21"/>
+<wire x1="2.5" y1="-1.85" x2="-2.5" y2="-1.85" width="0.1524" layer="21"/>
+<wire x1="2.5" y1="-1.85" x2="2.5" y2="1.85" width="0.1524" layer="21"/>
+<wire x1="-2.5" y1="1.85" x2="-2.5" y2="-1.85" width="0.1524" layer="21"/>
+<circle x="-0.635" y="0.7938" radius="0.1588" width="0.4064" layer="35"/>
+<circle x="0.6351" y="0.7938" radius="0.1588" width="0.4064" layer="35"/>
+<circle x="-0.635" y="-0.7938" radius="0.1588" width="0.4064" layer="35"/>
+<circle x="0.635" y="-0.7937" radius="0.1587" width="0.4064" layer="35"/>
+<smd name="A" x="-2.1" y="0" dx="2.5" dy="1.5" layer="1" rot="R270"/>
+<smd name="K" x="2.1" y="0" dx="2.5" dy="1.5" layer="1" rot="R270"/>
+<text x="-3.15" y="2.15" size="1.27" layer="25">&gt;NAME</text>
+<text x="-3.4" y="-3.4" size="1.27" layer="27">&gt;VALUE</text>
+<rectangle x1="1" y1="-1.8" x2="2.5" y2="1.85" layer="21" rot="R180"/>
+</package>
+<package name="DO15">
+<wire x1="-3.8" y1="-1.8" x2="3.8" y2="-1.8" width="0.1524" layer="21"/>
+<wire x1="3.8" y1="-1.8" x2="3.8" y2="1.8" width="0.1524" layer="21"/>
+<wire x1="3.8" y1="1.8" x2="-3.8" y2="1.8" width="0.1524" layer="21"/>
+<wire x1="-3.8" y1="1.8" x2="-3.8" y2="-1.8" width="0.1524" layer="21"/>
+<wire x1="-5.715" y1="0" x2="-3.937" y2="0" width="0.4064" layer="21"/>
+<wire x1="5.715" y1="0" x2="3.81" y2="0" width="0.4064" layer="21"/>
+<pad name="A" x="-5.715" y="0" drill="1" diameter="1.9304"/>
+<pad name="K" x="5.715" y="0" drill="1" diameter="1.9304"/>
+<text x="-3.175" y="-0.635" size="1.27" layer="25">&gt;NAME</text>
+<text x="-3.175" y="-0.635" size="1.27" layer="27">&gt;VALUE</text>
+<rectangle x1="2.54" y1="-1.905" x2="3.81" y2="1.905" layer="21"/>
+</package>
+<package name="DO15$1S">
+<wire x1="-3.8" y1="-1.8" x2="3.8" y2="-1.8" width="0.1524" layer="21"/>
+<wire x1="3.8" y1="-1.8" x2="3.8" y2="1.8" width="0.1524" layer="21"/>
+<wire x1="3.8" y1="1.8" x2="-3.8" y2="1.8" width="0.1524" layer="21"/>
+<wire x1="-3.8" y1="1.8" x2="-3.8" y2="-1.8" width="0.1524" layer="21"/>
+<wire x1="-5.715" y1="0" x2="-3.937" y2="0" width="0.4064" layer="21"/>
+<wire x1="5.715" y1="0" x2="3.81" y2="0" width="0.4064" layer="21"/>
+<pad name="A" x="-5.715" y="0" drill="1" diameter="1.9304" shape="long"/>
+<pad name="K" x="5.715" y="0" drill="1" diameter="1.9304" shape="long"/>
+<text x="-3.175" y="-0.635" size="1.27" layer="25">&gt;NAME</text>
+<text x="-3.175" y="-0.635" size="1.27" layer="27">&gt;VALUE</text>
+<rectangle x1="2.54" y1="-1.905" x2="3.81" y2="1.905" layer="21"/>
+</package>
+<package name="DO214AB">
+<wire x1="-7.3706" y1="-0.07" x2="-0.2494" y2="-0.07" width="0.1016" layer="21"/>
+<wire x1="-7.3706" y1="-6.28" x2="-0.2494" y2="-6.28" width="0.1016" layer="21"/>
+<wire x1="-7.3706" y1="-6.28" x2="-7.3706" y2="-0.07" width="0.1016" layer="51"/>
+<wire x1="-0.2494" y1="-6.28" x2="-0.2494" y2="-0.07" width="0.1016" layer="51"/>
+<wire x1="-3.267" y1="-2.175" x2="-4.64" y2="-3.175" width="0.2032" layer="21"/>
+<wire x1="-4.64" y1="-3.175" x2="-3.267" y2="-4.175" width="0.2032" layer="21"/>
+<wire x1="-3.267" y1="-4.175" x2="-3.267" y2="-2.175" width="0.2032" layer="21"/>
+<circle x="-5.095" y="-2.09" radius="0.2061" width="0.508" layer="35"/>
+<circle x="-5.095" y="-4.26" radius="0.2061" width="0.508" layer="35"/>
+<circle x="-2.525" y="-2.09" radius="0.2061" width="0.508" layer="35"/>
+<circle x="-2.525" y="-4.26" radius="0.2061" width="0.508" layer="35"/>
+<smd name="C" x="-7.51" y="-3.175" dx="2.8" dy="3.8" layer="1"/>
+<smd name="A" x="-0.11" y="-3.175" dx="2.8" dy="3.8" layer="1"/>
+<text x="-7.269" y="0.184" size="1.27" layer="25">&gt;NAME</text>
+<text x="-7.269" y="-7.804" size="1.27" layer="27">&gt;VALUE</text>
+<rectangle x1="-7.904" y1="-4.2672" x2="-7.3706" y2="-2.0828" layer="51"/>
+<rectangle x1="-0.2494" y1="-4.2672" x2="0.284" y2="-2.0828" layer="51"/>
+<rectangle x1="-5.91" y1="-6.275" x2="-4.66" y2="-0.075" layer="21"/>
+<rectangle x1="-3.31" y1="-3.375" x2="-3.01" y2="-2.975" layer="35"/>
+<rectangle x1="-4.61" y1="-3.375" x2="-4.31" y2="-2.975" layer="35"/>
+<rectangle x1="-3.31" y1="-3.375" x2="-3.01" y2="-2.975" layer="35"/>
+<rectangle x1="-4.61" y1="-3.375" x2="-4.31" y2="-2.975" layer="35"/>
+</package>
+<package name="DO214AA">
+<wire x1="2.5" y1="1.85" x2="-2.5" y2="1.85" width="0.1524" layer="21"/>
+<wire x1="2.5" y1="-1.85" x2="-2.5" y2="-1.85" width="0.1524" layer="21"/>
+<wire x1="2.5" y1="-1.85" x2="2.5" y2="1.85" width="0.1524" layer="21"/>
+<wire x1="-2.5" y1="1.85" x2="-2.5" y2="-1.85" width="0.1524" layer="21"/>
+<circle x="-0.65" y="0.45" radius="0.2061" width="0.508" layer="35"/>
+<circle x="-0.65" y="-0.45" radius="0.2061" width="0.508" layer="35"/>
+<circle x="0.65" y="0.45" radius="0.2061" width="0.508" layer="35"/>
+<circle x="0.65" y="-0.45" radius="0.2061" width="0.508" layer="35"/>
+<smd name="A" x="-2.286" y="0" dx="2.5" dy="2" layer="1" rot="R90"/>
+<smd name="K" x="2.286" y="0" dx="2.5" dy="2" layer="1" rot="R90"/>
+<text x="-3.15" y="2.15" size="1.27" layer="25">&gt;NAME</text>
+<text x="-3.4" y="-3.4" size="1.27" layer="27">&gt;VALUE</text>
+<rectangle x1="1" y1="-1.8" x2="2.5" y2="1.85" layer="21" rot="R180"/>
+<rectangle x1="0.5" y1="-0.2" x2="0.8" y2="0.2" layer="35"/>
+<rectangle x1="-0.8" y1="-0.2" x2="-0.5" y2="0.2" layer="35"/>
+<rectangle x1="0.5" y1="-0.2" x2="0.8" y2="0.2" layer="35"/>
+<rectangle x1="-0.8" y1="-0.2" x2="-0.5" y2="0.2" layer="35"/>
+</package>
+<package name="SOD128">
+<description>SOD128</description>
+<text x="-1.905" y="-2.54" size="1.016" layer="25">&gt;NAME</text>
+<text x="-1.905" y="1.905" size="1.016" layer="27">&gt;VALUE</text>
+<smd name="A" x="-2.2" y="0" dx="2.1" dy="1.4" layer="1" rot="R90"/>
+<smd name="K" x="2.2" y="0" dx="2.1" dy="1.4" layer="1" rot="R90"/>
+<wire x1="2" y1="1.35" x2="-2" y2="1.35" width="0.127" layer="21"/>
+<wire x1="-2" y1="1.35" x2="-2" y2="-1.35" width="0.127" layer="21"/>
+<wire x1="-2" y1="-1.35" x2="2" y2="-1.35" width="0.127" layer="21"/>
+<wire x1="2" y1="-1.35" x2="2" y2="1.35" width="0.127" layer="21"/>
+<rectangle x1="-0.5" y1="-1" x2="0.5" y2="1" layer="35"/>
+<wire x1="1.4" y1="-1.1" x2="1.4" y2="1.1" width="0.6096" layer="21"/>
+</package>
+<package name="SOD123F">
+<text x="-2.413" y="-2.0955" size="1.016" layer="25">&gt;NAME</text>
+<text x="-2.413" y="1.143" size="1.016" layer="27">&gt;VALUE</text>
+<smd name="A" x="-1.4" y="0" dx="1.2" dy="1.2" layer="1" rot="R180"/>
+<smd name="K" x="1.4" y="0" dx="1.2" dy="1.2" layer="1" rot="R180"/>
+<wire x1="-1.35" y1="-0.85" x2="0.7" y2="-0.85" width="0.127" layer="21"/>
+<wire x1="0.7" y1="-0.85" x2="0.75" y2="-0.85" width="0.127" layer="21"/>
+<wire x1="0.75" y1="-0.85" x2="0.8" y2="-0.85" width="0.127" layer="21"/>
+<wire x1="0.8" y1="-0.85" x2="0.85" y2="-0.85" width="0.127" layer="21"/>
+<wire x1="0.85" y1="-0.85" x2="0.95" y2="-0.85" width="0.127" layer="21"/>
+<wire x1="0.95" y1="-0.85" x2="1.35" y2="-0.85" width="0.127" layer="21"/>
+<wire x1="1.35" y1="-0.85" x2="1.35" y2="0.85" width="0.127" layer="21"/>
+<wire x1="1.35" y1="0.85" x2="0.95" y2="0.85" width="0.127" layer="21"/>
+<wire x1="0.95" y1="0.85" x2="0.85" y2="0.85" width="0.127" layer="21"/>
+<wire x1="0.85" y1="0.85" x2="0.8" y2="0.85" width="0.127" layer="21"/>
+<wire x1="0.8" y1="0.85" x2="0.75" y2="0.85" width="0.127" layer="21"/>
+<wire x1="0.75" y1="0.85" x2="0.7" y2="0.85" width="0.127" layer="21"/>
+<wire x1="0.7" y1="0.85" x2="-1.35" y2="0.85" width="0.127" layer="21"/>
+<wire x1="-1.35" y1="0.85" x2="-1.35" y2="-0.85" width="0.127" layer="21"/>
+<rectangle x1="-0.25" y1="-0.85" x2="0.25" y2="0.85" layer="35"/>
+<wire x1="0.95" y1="-0.85" x2="0.95" y2="0.85" width="0.127" layer="21"/>
+<wire x1="0.85" y1="-0.85" x2="0.85" y2="0.85" width="0.127" layer="21"/>
+<wire x1="0.8" y1="-0.85" x2="0.8" y2="0.85" width="0.127" layer="21"/>
+<wire x1="0.75" y1="-0.85" x2="0.75" y2="0.85" width="0.127" layer="21"/>
+<wire x1="0.7" y1="-0.85" x2="0.7" y2="0.85" width="0.127" layer="21"/>
+</package>
+<package name="POLY5/15">
+<wire x1="7.62" y1="1.27" x2="-7.62" y2="1.27" width="0.1524" layer="21"/>
+<wire x1="-7.62" y1="1.27" x2="-7.62" y2="-1.27" width="0.1524" layer="21"/>
+<wire x1="-7.62" y1="-1.27" x2="7.62" y2="-1.27" width="0.1524" layer="21"/>
+<wire x1="7.62" y1="1.27" x2="7.62" y2="-1.27" width="0.1524" layer="21"/>
+<pad name="P$1" x="-2.54" y="0" drill="1.1176" rot="R90"/>
+<pad name="P$2" x="2.54" y="0" drill="1.1176" rot="R90"/>
+<text x="-3.81" y="2.54" size="1.27" layer="25">&gt;NAME</text>
+<text x="-3.81" y="-3.81" size="1.27" layer="27">&gt;VALUE</text>
+</package>
+<package name="2920">
+<wire x1="-4" y1="-2.7" x2="4" y2="-2.7" width="0.127" layer="21"/>
+<wire x1="4" y1="-2.7" x2="4" y2="2.7" width="0.127" layer="21"/>
+<wire x1="4" y1="2.7" x2="-4" y2="2.7" width="0.127" layer="21"/>
+<wire x1="-4" y1="2.7" x2="-4" y2="-2.7" width="0.127" layer="21"/>
+<smd name="1" x="-3.3" y="0" dx="5.3" dy="2" layer="1" rot="R90"/>
+<smd name="2" x="3.3" y="0" dx="5.3" dy="2" layer="1" rot="R90"/>
+<text x="-2.794" y="3.07975" size="1.27" layer="25">&gt;NAME</text>
+<text x="-3.27025" y="-4.191" size="1.27" layer="27">&gt;VALUE</text>
+<circle x="0" y="1.27" radius="0.354975" width="1.27" layer="35"/>
+<circle x="0" y="-1.27" radius="0.354975" width="1.27" layer="35"/>
+</package>
+<package name="WSON-8_3X3MM">
+<smd name="8" x="-0.975" y="1.475" dx="0.85" dy="0.35" layer="1" roundness="100" rot="R90" stop="no" cream="no"/>
+<smd name="EP" x="0" y="0" dx="2" dy="1.5" layer="1" stop="no" cream="no"/>
+<wire x1="1.5" y1="1.5" x2="1.5" y2="-1.5" width="0.07" layer="21"/>
+<wire x1="1.5" y1="-1.5" x2="-1.5" y2="-1.5" width="0.07" layer="21"/>
+<wire x1="-1.5" y1="-1.5" x2="-1.5" y2="1.5" width="0.07" layer="21"/>
+<wire x1="-1.5" y1="1.5" x2="1.5" y2="1.5" width="0.07" layer="21"/>
+<text x="-1.75" y="2.175" size="0.8128" layer="25">&gt;NAME</text>
+<text x="-2.325" y="-3.025" size="0.8128" layer="27">&gt;VALUE</text>
+<circle x="-1.075" y="-1.15" radius="0.2" width="0.127" layer="21"/>
+<smd name="7" x="-0.325" y="1.475" dx="0.85" dy="0.35" layer="1" roundness="100" rot="R90" stop="no" cream="no"/>
+<smd name="6" x="0.325" y="1.475" dx="0.85" dy="0.35" layer="1" roundness="100" rot="R90" stop="no" cream="no"/>
+<smd name="5" x="0.975" y="1.475" dx="0.85" dy="0.35" layer="1" roundness="100" rot="R90" stop="no" cream="no"/>
+<smd name="1" x="-0.975" y="-1.475" dx="0.85" dy="0.35" layer="1" roundness="100" rot="R90" stop="no" cream="no"/>
+<smd name="2" x="-0.325" y="-1.475" dx="0.85" dy="0.35" layer="1" roundness="100" rot="R90" stop="no" cream="no"/>
+<smd name="3" x="0.325" y="-1.475" dx="0.85" dy="0.35" layer="1" roundness="100" rot="R90" stop="no" cream="no"/>
+<smd name="4" x="0.975" y="-1.475" dx="0.85" dy="0.35" layer="1" roundness="100" rot="R90" stop="no" cream="no"/>
+<rectangle x1="-0.775" y1="-0.65" x2="0.775" y2="0.65" layer="29"/>
+<smd name="EP$1" x="-1.425" y="0.325" dx="0.28" dy="1.025" layer="1" rot="R90" stop="no" cream="no"/>
+<smd name="EP$2" x="-1.425" y="-0.325" dx="0.28" dy="1.025" layer="1" rot="R90" stop="no" cream="no"/>
+<smd name="EP$4" x="1.425" y="0.325" dx="0.28" dy="1.025" layer="1" rot="R90" stop="no" cream="no"/>
+<smd name="EP$3" x="1.425" y="-0.325" dx="0.28" dy="1.025" layer="1" rot="R90" stop="no" cream="no"/>
+<rectangle x1="-0.7" y1="0.1" x2="-0.1" y2="0.6" layer="31"/>
+<rectangle x1="0.1" y1="0.1" x2="0.7" y2="0.6" layer="31"/>
+<rectangle x1="-0.7" y1="-0.6" x2="-0.1" y2="-0.1" layer="31"/>
+<rectangle x1="0.1" y1="-0.6" x2="0.7" y2="-0.1" layer="31"/>
+<rectangle x1="-1.93" y1="0.195" x2="-1.005" y2="0.455" layer="31"/>
+<rectangle x1="-1.945" y1="0.175" x2="-0.99" y2="0.475" layer="29"/>
+<rectangle x1="-1.93" y1="-0.455" x2="-1.005" y2="-0.195" layer="31"/>
+<rectangle x1="-1.945" y1="-0.475" x2="-0.99" y2="-0.175" layer="29"/>
+<rectangle x1="1.005" y1="-0.455" x2="1.93" y2="-0.195" layer="31"/>
+<rectangle x1="0.99" y1="-0.475" x2="1.945" y2="-0.175" layer="29"/>
+<rectangle x1="1.005" y1="0.195" x2="1.93" y2="0.455" layer="31"/>
+<rectangle x1="0.99" y1="0.175" x2="1.945" y2="0.475" layer="29"/>
+<wire x1="-0.975" y1="1.725" x2="-0.975" y2="1.225" width="0.36" layer="29"/>
+<wire x1="-0.975" y1="1.73" x2="-0.975" y2="1.22" width="0.3" layer="31"/>
+<wire x1="-0.325" y1="1.725" x2="-0.325" y2="1.225" width="0.36" layer="29"/>
+<wire x1="-0.325" y1="1.73" x2="-0.325" y2="1.22" width="0.3" layer="31"/>
+<wire x1="0.325" y1="1.725" x2="0.325" y2="1.225" width="0.36" layer="29"/>
+<wire x1="0.325" y1="1.73" x2="0.325" y2="1.22" width="0.3" layer="31"/>
+<wire x1="0.975" y1="1.725" x2="0.975" y2="1.225" width="0.36" layer="29"/>
+<wire x1="0.975" y1="1.73" x2="0.975" y2="1.22" width="0.3" layer="31"/>
+<wire x1="-0.975" y1="-1.225" x2="-0.975" y2="-1.725" width="0.36" layer="29"/>
+<wire x1="-0.975" y1="-1.22" x2="-0.975" y2="-1.73" width="0.3" layer="31"/>
+<wire x1="-0.325" y1="-1.225" x2="-0.325" y2="-1.725" width="0.36" layer="29"/>
+<wire x1="-0.325" y1="-1.22" x2="-0.325" y2="-1.73" width="0.3" layer="31"/>
+<wire x1="0.325" y1="-1.225" x2="0.325" y2="-1.725" width="0.36" layer="29"/>
+<wire x1="0.325" y1="-1.22" x2="0.325" y2="-1.73" width="0.3" layer="31"/>
+<wire x1="0.975" y1="-1.225" x2="0.975" y2="-1.725" width="0.36" layer="29"/>
+<wire x1="0.975" y1="-1.22" x2="0.975" y2="-1.73" width="0.3" layer="31"/>
+</package>
+<package name="L_5">
+<circle x="0" y="0" radius="3.937" width="0.3048" layer="21"/>
+<pad name="1" x="-2.54" y="0" drill="0.9144" diameter="1.778"/>
+<pad name="2" x="2.54" y="0" drill="0.9144" diameter="1.778"/>
+<text x="-2.54" y="-2.54" size="1.27" layer="27">&gt;VALUE</text>
+<text x="-1.27" y="1.27" size="1.27" layer="25">&gt;NAME</text>
+</package>
+<package name="L_30">
+<wire x1="-11.43" y1="-3.81" x2="-11.43" y2="0" width="0.3048" layer="21"/>
+<wire x1="-11.43" y1="0" x2="-11.43" y2="3.81" width="0.3048" layer="21"/>
+<wire x1="-11.43" y1="3.81" x2="11.43" y2="3.81" width="0.3048" layer="21"/>
+<wire x1="11.43" y1="3.81" x2="11.43" y2="0" width="0.3048" layer="21"/>
+<wire x1="11.43" y1="0" x2="11.43" y2="-3.81" width="0.3048" layer="21"/>
+<wire x1="11.43" y1="-3.81" x2="-11.43" y2="-3.81" width="0.3048" layer="21"/>
+<wire x1="-14.605" y1="0" x2="-11.43" y2="0" width="0.3048" layer="21"/>
+<wire x1="11.43" y1="0" x2="14.605" y2="0" width="0.3048" layer="21"/>
+<pad name="1" x="-15.24" y="0" drill="1.1176" diameter="2.54"/>
+<pad name="2" x="15.24" y="0" drill="1.1176" diameter="2.54"/>
+<text x="-3.175" y="-1.905" size="1.27" layer="27">&gt;VALUE</text>
+<text x="-3.175" y="0.635" size="1.27" layer="25">&gt;NAME</text>
+</package>
+<package name="L8$ST">
+<wire x1="0.635" y1="0" x2="5.715" y2="0" width="0.3048" layer="21"/>
+<circle x="0" y="0" radius="3.8625" width="0.3048" layer="21"/>
+<pad name="1" x="0" y="0" drill="1.1176" diameter="2.286"/>
+<pad name="2" x="6.35" y="0" drill="1.1176" diameter="2.286"/>
+<text x="-1.27" y="4.445" size="1.27" layer="27">&gt;VALUE</text>
+<text x="-0.635" y="4.445" size="1.27" layer="25">&gt;NAME</text>
+</package>
+<package name="L_27">
+<wire x1="-10.16" y1="-3.81" x2="-10.16" y2="0" width="0.3048" layer="21"/>
+<wire x1="-10.16" y1="0" x2="-10.16" y2="3.81" width="0.3048" layer="21"/>
+<wire x1="-10.16" y1="3.81" x2="10.16" y2="3.81" width="0.3048" layer="21"/>
+<wire x1="10.16" y1="3.81" x2="10.16" y2="0" width="0.3048" layer="21"/>
+<wire x1="10.16" y1="0" x2="10.16" y2="-3.81" width="0.3048" layer="21"/>
+<wire x1="10.16" y1="-3.81" x2="-10.16" y2="-3.81" width="0.3048" layer="21"/>
+<wire x1="-10.795" y1="0" x2="-10.16" y2="0" width="0.3048" layer="21"/>
+<wire x1="10.16" y1="0" x2="10.795" y2="0" width="0.3048" layer="21"/>
+<pad name="1" x="-12.7" y="0" drill="1.1176" diameter="2.54"/>
+<pad name="2" x="12.7" y="0" drill="1.1176" diameter="2.54"/>
+<text x="-3.175" y="-1.905" size="1.27" layer="27">&gt;VALUE</text>
+<text x="-3.175" y="0.635" size="1.27" layer="25">&gt;NAME</text>
+</package>
+<package name="L12$ST">
+<wire x1="0.635" y1="0.635" x2="3.81" y2="3.81" width="0.3048" layer="21"/>
+<circle x="0" y="0" radius="6" width="0.3048" layer="21"/>
+<pad name="1" x="0" y="0" drill="1.1176" diameter="2.286"/>
+<pad name="2" x="5.08" y="5.08" drill="1.1176" diameter="2.286"/>
+<text x="-3.175" y="-3.175" size="1.27" layer="27">&gt;VALUE</text>
+<text x="-4.445" y="1.27" size="1.27" layer="25">&gt;NAME</text>
+</package>
+<package name="L_15">
+<wire x1="-5.715" y1="-1.905" x2="-5.715" y2="0" width="0.3048" layer="21"/>
+<wire x1="-5.715" y1="0" x2="-5.715" y2="1.905" width="0.3048" layer="21"/>
+<wire x1="-5.715" y1="1.905" x2="5.715" y2="1.905" width="0.3048" layer="21"/>
+<wire x1="5.715" y1="1.905" x2="5.715" y2="0" width="0.3048" layer="21"/>
+<wire x1="5.715" y1="0" x2="5.715" y2="-1.905" width="0.3048" layer="21"/>
+<wire x1="5.715" y1="-1.905" x2="-5.715" y2="-1.905" width="0.3048" layer="21"/>
+<wire x1="-6.35" y1="0" x2="-5.715" y2="0" width="0.3048" layer="21"/>
+<wire x1="5.715" y1="0" x2="6.35" y2="0" width="0.3048" layer="21"/>
+<pad name="1" x="-7.62" y="0" drill="1.1176" diameter="2.54"/>
+<pad name="2" x="7.62" y="0" drill="1.1176" diameter="2.54"/>
+<text x="-3.175" y="-1.905" size="1.27" layer="27">&gt;VALUE</text>
+<text x="-3.175" y="0.635" size="1.27" layer="25">&gt;NAME</text>
+</package>
+<package name="L_10">
+<wire x1="-3.175" y1="-1.27" x2="-3.175" y2="0" width="0.3048" layer="21"/>
+<wire x1="-3.175" y1="0" x2="-3.175" y2="1.27" width="0.3048" layer="21"/>
+<wire x1="-3.175" y1="1.27" x2="3.175" y2="1.27" width="0.3048" layer="21"/>
+<wire x1="3.175" y1="1.27" x2="3.175" y2="0" width="0.3048" layer="21"/>
+<wire x1="3.175" y1="0" x2="3.175" y2="-1.27" width="0.3048" layer="21"/>
+<wire x1="3.175" y1="-1.27" x2="-3.175" y2="-1.27" width="0.3048" layer="21"/>
+<wire x1="-3.81" y1="0" x2="-3.175" y2="0" width="0.3048" layer="21"/>
+<wire x1="3.175" y1="0" x2="3.81" y2="0" width="0.3048" layer="21"/>
+<pad name="1" x="-5.08" y="0" drill="0.9"/>
+<pad name="2" x="5.08" y="0" drill="0.9"/>
+<text x="-3.175" y="2.54" size="1.27" layer="27">&gt;VALUE</text>
+<text x="-2.54" y="-0.635" size="1.27" layer="25">&gt;NAME</text>
+</package>
+<package name="L_5050">
+<wire x1="-3.175" y1="2.794" x2="3.175" y2="2.794" width="0.1524" layer="21"/>
+<wire x1="-3.175" y1="-2.794" x2="3.175" y2="-2.794" width="0.1524" layer="21"/>
+<circle x="0" y="-1.5875" radius="0.3175" width="0.8128" layer="35"/>
+<circle x="0" y="1.5875" radius="0.3175" width="0.8128" layer="35"/>
+<smd name="P$1" x="-2.54" y="0" dx="5.08" dy="2.54" layer="1" rot="R90"/>
+<smd name="P$2" x="2.54" y="0" dx="5.08" dy="2.54" layer="1" rot="R90"/>
+<text x="-2.54" y="3.81" size="1.4224" layer="25">&gt;NAME</text>
+<text x="-3.175" y="-5.08" size="1.4224" layer="27">&gt;VALUE</text>
+</package>
+<package name="C401X">
+<wire x1="-1.95" y1="-1.5" x2="-1.95" y2="1.5" width="0.1524" layer="21"/>
+<wire x1="1.95" y1="-1.5" x2="1.95" y2="1.5" width="0.1524" layer="21"/>
+<wire x1="1.5" y1="-1.95" x2="-1.5" y2="-1.95" width="0.1524" layer="21"/>
+<wire x1="1.5" y1="1.95" x2="-1.5" y2="1.95" width="0.1524" layer="21"/>
+<wire x1="-1.95" y1="1.5" x2="-1.5" y2="1.95" width="0.1524" layer="21" style="shortdash"/>
+<wire x1="1.5" y1="1.95" x2="1.95" y2="1.5" width="0.1524" layer="21"/>
+<wire x1="1.95" y1="-1.5" x2="1.5" y2="-1.95" width="0.1524" layer="21"/>
+<wire x1="-1.5" y1="-1.95" x2="-1.95" y2="-1.5" width="0.1524" layer="21"/>
+<smd name="P$1" x="-1.47" y="0" dx="4.4" dy="1.45" layer="1" rot="R90"/>
+<smd name="P$2" x="1.47" y="0" dx="4.4" dy="1.45" layer="1" rot="R90"/>
+<text x="-1.6" y="0.5" size="0.6096" layer="25">&gt;NAME</text>
+<text x="-1.75" y="-1.15" size="0.6096" layer="27">&gt;VALUE</text>
+</package>
+<package name="SC105F">
+<wire x1="-5.8" y1="2.4" x2="-5.8" y2="-2.4" width="0.1524" layer="21"/>
+<wire x1="5.8" y1="2.4" x2="5.8" y2="-2.4" width="0.1524" layer="21"/>
+<circle x="0" y="0" radius="6.3" width="0.1524" layer="21"/>
+<smd name="P$1" x="-6.3" y="0" dx="4.5" dy="3" layer="1" rot="R180"/>
+<smd name="P$2" x="6.3" y="0" dx="4.5" dy="3" layer="1" rot="R180"/>
+<text x="-3.2" y="2.8" size="1.27" layer="25">&gt;NAME</text>
+<text x="-3.5" y="-3.7" size="1.27" layer="27">&gt;VALUE</text>
+</package>
+<package name="SC75F">
+<wire x1="-4.5" y1="-2.1" x2="-4.5" y2="2.1" width="0.1524" layer="21"/>
+<wire x1="4.5" y1="-2.1" x2="4.5" y2="2.1" width="0.1524" layer="21"/>
+<circle x="0" y="0" radius="5" width="0.1524" layer="21"/>
+<smd name="P$1" x="-4.7" y="0" dx="4.5" dy="3" layer="1" rot="R180"/>
+<smd name="P$2" x="4.7" y="0" dx="4.5" dy="3" layer="1" rot="R180"/>
+<text x="-3" y="2" size="1.27" layer="25">&gt;NAME</text>
+<text x="-3.6" y="-3.3" size="1.27" layer="27">&gt;VALUE</text>
+</package>
+<package name="S12,3X12,3MM">
+<wire x1="6.15" y1="-6.15" x2="6.15" y2="-3.15" width="0.1524" layer="21"/>
+<wire x1="6.15" y1="-3.15" x2="6.15" y2="3.15" width="0.1524" layer="21"/>
+<wire x1="6.15" y1="3.15" x2="6.15" y2="6.15" width="0.1524" layer="21"/>
+<wire x1="6.15" y1="6.15" x2="3.15" y2="6.15" width="0.1524" layer="21"/>
+<wire x1="3.15" y1="6.15" x2="-3.15" y2="6.15" width="0.1524" layer="21"/>
+<wire x1="-3.15" y1="6.15" x2="-6.15" y2="6.15" width="0.1524" layer="21"/>
+<wire x1="-6.15" y1="6.15" x2="-6.15" y2="3.15" width="0.1524" layer="21"/>
+<wire x1="-6.15" y1="3.15" x2="-6.15" y2="-3.15" width="0.1524" layer="21"/>
+<wire x1="-6.15" y1="-3.15" x2="-6.15" y2="-6.15" width="0.1524" layer="21"/>
+<wire x1="-6.15" y1="-6.15" x2="-3.15" y2="-6.15" width="0.1524" layer="21"/>
+<wire x1="-3.15" y1="-6.15" x2="3.15" y2="-6.15" width="0.1524" layer="21"/>
+<wire x1="3.15" y1="-6.15" x2="6.15" y2="-6.15" width="0.1524" layer="21"/>
+<wire x1="-3.15" y1="-6.15" x2="-6.15" y2="-3.15" width="0.1524" layer="21"/>
+<wire x1="-3.15" y1="6.15" x2="-6.15" y2="3.15" width="0.1524" layer="21"/>
+<wire x1="6.15" y1="-3.15" x2="3.15" y2="-6.15" width="0.1524" layer="21"/>
+<wire x1="3.15" y1="6.15" x2="6.15" y2="3.15" width="0.1524" layer="21"/>
+<circle x="0" y="0" radius="5.5337" width="0.1524" layer="21"/>
+<smd name="1" x="-5" y="0" dx="7" dy="6" layer="1" rot="R90"/>
+<smd name="2" x="5" y="0" dx="7" dy="6" layer="1" rot="R90"/>
+<text x="-3.175" y="6.985" size="1.27" layer="25">&gt;NAME</text>
+<text x="-3.175" y="-7.62" size="1.27" layer="27">&gt;VALUE</text>
+</package>
+<package name="L_4,5X4,0">
+<wire x1="-2" y1="1" x2="-2" y2="-1" width="0.127" layer="21"/>
+<wire x1="2" y1="1" x2="2" y2="-1" width="0.127" layer="21"/>
+<wire x1="-2" y1="1" x2="2" y2="1" width="0.127" layer="21" curve="-126.869898"/>
+<wire x1="2" y1="-1" x2="-2" y2="-1" width="0.127" layer="21" curve="-126.869898"/>
+<circle x="0" y="0" radius="0.3175" width="0" layer="35"/>
+<circle x="1.27" y="0" radius="0.3175" width="0" layer="35"/>
+<circle x="-1.27" y="0" radius="0.3175" width="0" layer="35"/>
+<smd name="P$1" x="0" y="1.5" dx="4.5" dy="1.8" layer="1"/>
+<smd name="P$2" x="0" y="-1.5" dx="4.5" dy="1.8" layer="1"/>
+<text x="-2.54" y="2.54" size="1.27" layer="25">&gt;NAME</text>
+<text x="-2.54" y="-3.81" size="1.27" layer="27">&gt;VALUE</text>
+</package>
+<package name="L10X10">
+<wire x1="3.73" y1="-5" x2="5" y2="-3.73" width="0.254" layer="21" curve="90"/>
+<wire x1="5" y1="-3.73" x2="5" y2="4.6825" width="0.254" layer="21"/>
+<wire x1="5" y1="4.6825" x2="4.6825" y2="5" width="0.254" layer="21" curve="90"/>
+<wire x1="4.6825" y1="5" x2="-3.73" y2="5" width="0.254" layer="21"/>
+<wire x1="-3.73" y1="5" x2="-5" y2="3.73" width="0.254" layer="21" curve="90"/>
+<wire x1="-5" y1="3.73" x2="-5" y2="-4.6825" width="0.254" layer="21"/>
+<wire x1="-5" y1="-4.6825" x2="-4.6825" y2="-5" width="0.254" layer="21" curve="90"/>
+<wire x1="-4.6825" y1="-5" x2="3.73" y2="-5" width="0.254" layer="21"/>
+<circle x="-0.45" y="-2.555" radius="0.2061" width="0.508" layer="35"/>
+<circle x="0.45" y="-2.555" radius="0.2061" width="0.508" layer="35"/>
+<circle x="-0.45" y="0.015" radius="0.2061" width="0.508" layer="35"/>
+<circle x="0.45" y="0.015" radius="0.2061" width="0.508" layer="35"/>
+<circle x="-0.45" y="2.525" radius="0.2061" width="0.508" layer="35"/>
+<circle x="0.45" y="2.525" radius="0.2061" width="0.508" layer="35"/>
+<circle x="0" y="0" radius="3.5921" width="0.254" layer="21"/>
+<smd name="P$1" x="-4.5" y="0" dx="1.7" dy="3.6" layer="1"/>
+<smd name="P$2" x="4.5" y="0" dx="1.7" dy="3.6" layer="1"/>
+<text x="-3.175" y="5.334" size="1.27" layer="25">&gt;NAME</text>
+<text x="-3.175" y="-6.604" size="1.27" layer="27">&gt;VALUE</text>
+<rectangle x1="-0.15" y1="-0.185" x2="0.15" y2="0.215" layer="35" rot="R90"/>
+<rectangle x1="-0.15" y1="-2.755" x2="0.15" y2="-2.355" layer="35" rot="R90"/>
+<rectangle x1="-0.15" y1="-0.185" x2="0.15" y2="0.215" layer="35" rot="R90"/>
+<rectangle x1="-0.15" y1="-2.755" x2="0.15" y2="-2.355" layer="35" rot="R90"/>
+<rectangle x1="-0.15" y1="2.325" x2="0.15" y2="2.725" layer="35" rot="R90"/>
+<rectangle x1="-0.15" y1="2.325" x2="0.15" y2="2.725" layer="35" rot="R90"/>
+</package>
+<package name="S12,5X12,5MM">
+<wire x1="6.15" y1="-6.15" x2="6.15" y2="-3.15" width="0.1524" layer="21"/>
+<wire x1="6.15" y1="-3.15" x2="6.15" y2="3.15" width="0.1524" layer="21"/>
+<wire x1="6.15" y1="3.15" x2="6.15" y2="6.15" width="0.1524" layer="21"/>
+<wire x1="6.15" y1="6.15" x2="3.15" y2="6.15" width="0.1524" layer="21"/>
+<wire x1="3.15" y1="6.15" x2="-3.15" y2="6.15" width="0.1524" layer="21"/>
+<wire x1="-3.15" y1="6.15" x2="-6.15" y2="6.15" width="0.1524" layer="21"/>
+<wire x1="-6.15" y1="6.15" x2="-6.15" y2="3.15" width="0.1524" layer="21"/>
+<wire x1="-6.15" y1="3.15" x2="-6.15" y2="-3.15" width="0.1524" layer="21"/>
+<wire x1="-6.15" y1="-3.15" x2="-6.15" y2="-6.15" width="0.1524" layer="21"/>
+<wire x1="-6.15" y1="-6.15" x2="-3.15" y2="-6.15" width="0.1524" layer="21"/>
+<wire x1="-3.15" y1="-6.15" x2="3.15" y2="-6.15" width="0.1524" layer="21"/>
+<wire x1="3.15" y1="-6.15" x2="6.15" y2="-6.15" width="0.1524" layer="21"/>
+<wire x1="-3.15" y1="-6.15" x2="-6.15" y2="-3.15" width="0.1524" layer="21"/>
+<wire x1="-3.15" y1="6.15" x2="-6.15" y2="3.15" width="0.1524" layer="21"/>
+<wire x1="6.15" y1="-3.15" x2="3.15" y2="-6.15" width="0.1524" layer="21"/>
+<wire x1="3.15" y1="6.15" x2="6.15" y2="3.15" width="0.1524" layer="21"/>
+<wire x1="-6.25" y1="-6.25" x2="6.25" y2="-6.25" width="0.127" layer="21"/>
+<wire x1="6.25" y1="-6.25" x2="6.25" y2="6.25" width="0.127" layer="21"/>
+<wire x1="6.25" y1="6.25" x2="-6.25" y2="6.25" width="0.127" layer="21"/>
+<wire x1="-6.25" y1="6.25" x2="-6.25" y2="-6.25" width="0.127" layer="21"/>
+<circle x="0" y="0" radius="5.5337" width="0.1524" layer="21"/>
+<smd name="1" x="-6.05" y="0" dx="5" dy="6" layer="1"/>
+<smd name="2" x="6.05" y="0" dx="5" dy="6" layer="1"/>
+<text x="-3.175" y="6.985" size="1.27" layer="25">&gt;NAME</text>
+<text x="-3.175" y="-7.62" size="1.27" layer="27">&gt;VALUE</text>
+</package>
+<package name="L_SMT54">
+<wire x1="-1.27" y1="2.54" x2="1.27" y2="2.54" width="0.127" layer="21"/>
+<wire x1="-1.27" y1="-2.54" x2="1.27" y2="-2.54" width="0.127" layer="21"/>
+<wire x1="1.27" y1="2.54" x2="1.27" y2="-2.54" width="0.127" layer="21" curve="-126.869898"/>
+<wire x1="-1.27" y1="2.54" x2="-1.27" y2="-2.54" width="0.127" layer="21" curve="126.869898"/>
+<wire x1="-2.8575" y1="0.3175" x2="-2.8575" y2="-0.3175" width="0.127" layer="21" curve="-180"/>
+<wire x1="2.8575" y1="0.3175" x2="2.8575" y2="-0.3175" width="0.127" layer="21" curve="180"/>
+<circle x="0" y="-1.5875" radius="0.3175" width="0.8128" layer="35"/>
+<circle x="0" y="1.5875" radius="0.3175" width="0.8128" layer="35"/>
+<smd name="P$1" x="-2.2225" y="0" dx="5.08" dy="2.54" layer="1" rot="R90"/>
+<smd name="P$2" x="2.2225" y="0" dx="5.08" dy="2.54" layer="1" rot="R90"/>
+<text x="-3.175" y="2.8575" size="1.4224" layer="25">&gt;NAME</text>
+<text x="-3.81" y="-4.445" size="1.4224" layer="27">&gt;VALUE</text>
+</package>
+<package name="L_SMT75">
+<wire x1="-2.2225" y1="3.4925" x2="2.2225" y2="3.4925" width="0.127" layer="21"/>
+<wire x1="-2.2225" y1="-3.4925" x2="2.2225" y2="-3.4925" width="0.127" layer="21"/>
+<wire x1="2.2225" y1="3.4925" x2="2.2225" y2="-3.4925" width="0.127" layer="21" curve="-115.057615"/>
+<wire x1="-2.2225" y1="3.4925" x2="-2.2225" y2="-3.4925" width="0.127" layer="21" curve="115.057615"/>
+<wire x1="-4.1275" y1="0.635" x2="-4.1275" y2="-0.635" width="0.127" layer="21" curve="-180"/>
+<wire x1="4.1275" y1="0.635" x2="4.1275" y2="-0.635" width="0.127" layer="21" curve="180"/>
+<circle x="0" y="-1.5875" radius="0.3175" width="0.8128" layer="35"/>
+<circle x="0" y="1.5875" radius="0.3175" width="0.8128" layer="35"/>
+<smd name="P$1" x="-3.175" y="0" dx="6.4516" dy="3.2512" layer="1" rot="R90"/>
+<smd name="P$2" x="3.175" y="0" dx="6.4516" dy="3.2512" layer="1" rot="R90"/>
+<text x="-3.175" y="4.1275" size="1.4224" layer="25">&gt;NAME</text>
+<text x="-3.81" y="-5.3975" size="1.4224" layer="27">&gt;VALUE</text>
+</package>
+<package name="L_12X12">
+<wire x1="-5.3975" y1="6.0325" x2="5.3975" y2="6.0325" width="0.127" layer="21"/>
+<wire x1="6.0325" y1="5.3975" x2="6.0325" y2="-5.3975" width="0.127" layer="21"/>
+<wire x1="5.3975" y1="-6.0325" x2="-5.3975" y2="-6.0325" width="0.127" layer="21"/>
+<wire x1="-6.0325" y1="-5.3975" x2="-6.0325" y2="5.3975" width="0.127" layer="21"/>
+<wire x1="-6.0325" y1="5.3975" x2="-5.3975" y2="6.0325" width="0.127" layer="21" curve="-90"/>
+<wire x1="5.3975" y1="6.0325" x2="6.0325" y2="5.3975" width="0.127" layer="21" curve="-90"/>
+<wire x1="-6.0325" y1="-5.3975" x2="-5.3975" y2="-6.0325" width="0.127" layer="21" curve="90"/>
+<wire x1="5.3975" y1="-6.0325" x2="6.0325" y2="-5.3975" width="0.127" layer="21" curve="90"/>
+<circle x="0" y="0" radius="5.1685" width="0.127" layer="21"/>
+<circle x="0" y="3.4925" radius="0.7099" width="1.4224" layer="35"/>
+<circle x="0" y="0" radius="0.7099" width="1.4224" layer="35"/>
+<circle x="0" y="-3.4925" radius="0.7099" width="1.4224" layer="35"/>
+<smd name="P$1" x="-5.135" y="0" dx="6" dy="3.5" layer="1" rot="R90"/>
+<smd name="P$2" x="5.135" y="0" dx="6" dy="3.5" layer="1" rot="R90"/>
+<text x="-3.175" y="6.604" size="1.27" layer="25">&gt;NAME</text>
+<text x="-3.175" y="-7.874" size="1.27" layer="27">&gt;VALUE</text>
+</package>
+<package name="L_7,3X7,3">
+<wire x1="-3.81" y1="3.81" x2="3.81" y2="3.81" width="0.254" layer="21"/>
+<wire x1="3.81" y1="3.81" x2="3.81" y2="-3.81" width="0.254" layer="21"/>
+<wire x1="3.81" y1="-3.81" x2="-3.81" y2="-3.81" width="0.254" layer="21"/>
+<wire x1="-3.81" y1="-3.81" x2="-3.81" y2="3.81" width="0.254" layer="21"/>
+<circle x="0" y="0" radius="3.175" width="0.254" layer="21"/>
+<circle x="0" y="2.54" radius="0.3175" width="0.6096" layer="35"/>
+<circle x="0" y="-2.54" radius="0.3175" width="0.6096" layer="35"/>
+<circle x="0" y="0" radius="0.3175" width="0.6096" layer="35"/>
+<smd name="P$1" x="-3.23" y="0" dx="3" dy="2.2" layer="1" rot="R90"/>
+<smd name="P$2" x="3.23" y="0" dx="3" dy="2.2" layer="1" rot="R90"/>
+<text x="-3.175" y="4.3815" size="1.27" layer="25">&gt;NAME</text>
+<text x="-3.4925" y="-5.6515" size="1.27" layer="27">&gt;VALUE</text>
+</package>
+<package name="L_5$1S">
+<circle x="0" y="0" radius="3.937" width="0.3048" layer="21"/>
+<pad name="1" x="-2.54" y="0" drill="0.9144" diameter="1.778" shape="long" rot="R90"/>
+<pad name="2" x="2.54" y="0" drill="0.9144" diameter="1.778" shape="long" rot="R90"/>
+<text x="-2.54" y="-2.54" size="1.27" layer="27">&gt;VALUE</text>
+<text x="-1.27" y="1.27" size="1.27" layer="25">&gt;NAME</text>
+</package>
+<package name="L_SCB5">
+<wire x1="3" y1="3" x2="-3" y2="3" width="0.127" layer="21"/>
+<wire x1="-3" y1="3" x2="-3" y2="-3" width="0.127" layer="21"/>
+<wire x1="-3" y1="-3" x2="3" y2="-3" width="0.127" layer="21"/>
+<wire x1="3" y1="-3" x2="3" y2="3" width="0.127" layer="21"/>
+<circle x="0" y="-1.27" radius="0.3175" width="0.8128" layer="35"/>
+<circle x="0" y="1.27" radius="0.3175" width="0.8128" layer="35"/>
+<circle x="0" y="0" radius="2.9272" width="0.127" layer="21"/>
+<smd name="P$1" x="-2.54" y="0" dx="6.3" dy="3" layer="1" rot="R90"/>
+<smd name="P$2" x="2.54" y="0" dx="6.3" dy="3" layer="1" rot="R90"/>
+<text x="-2.8575" y="3.81" size="1.4224" layer="25">&gt;NAME</text>
+<text x="-3.81" y="-5.3975" size="1.4224" layer="27">&gt;VALUE</text>
+</package>
+<package name="L_WURTH_10X10">
+<wire x1="-5.08" y1="2.54" x2="-2.54" y2="5.08" width="0.127" layer="21"/>
+<wire x1="2.54" y1="5.08" x2="5.08" y2="2.54" width="0.127" layer="21"/>
+<wire x1="5.08" y1="-2.54" x2="2.54" y2="-5.08" width="0.127" layer="21"/>
+<wire x1="-5.08" y1="-2.54" x2="-2.54" y2="-5.08" width="0.127" layer="21"/>
+<wire x1="-2.54" y1="5.08" x2="2.54" y2="5.08" width="0.127" layer="21"/>
+<wire x1="5.08" y1="2.54" x2="5.08" y2="-2.54" width="0.127" layer="21"/>
+<wire x1="2.54" y1="-5.08" x2="-2.54" y2="-5.08" width="0.127" layer="21"/>
+<wire x1="-5.08" y1="-2.54" x2="-5.08" y2="2.54" width="0.127" layer="21"/>
+<circle x="-0.45" y="-2.555" radius="0.2061" width="0.508" layer="35"/>
+<circle x="0.45" y="-2.555" radius="0.2061" width="0.508" layer="35"/>
+<circle x="-0.45" y="0.015" radius="0.2061" width="0.508" layer="35"/>
+<circle x="0.45" y="0.015" radius="0.2061" width="0.508" layer="35"/>
+<circle x="-0.45" y="2.525" radius="0.2061" width="0.508" layer="35"/>
+<circle x="0.45" y="2.525" radius="0.2061" width="0.508" layer="35"/>
+<circle x="0" y="0" radius="3.5921" width="0.254" layer="21"/>
+<smd name="1" x="-4.8175" y="0" dx="4.6" dy="2.5" layer="1" rot="R90"/>
+<smd name="2" x="4.8175" y="0" dx="4.6" dy="2.5" layer="1" rot="R90"/>
+<text x="-2.8575" y="5.6515" size="1.27" layer="25">&gt;NAME</text>
+<text x="-3.175" y="-6.9215" size="1.27" layer="27">&gt;VALUE</text>
+<rectangle x1="-0.15" y1="-0.185" x2="0.15" y2="0.215" layer="35" rot="R90"/>
+<rectangle x1="-0.15" y1="-2.755" x2="0.15" y2="-2.355" layer="35" rot="R90"/>
+<rectangle x1="-0.15" y1="-0.185" x2="0.15" y2="0.215" layer="35" rot="R90"/>
+<rectangle x1="-0.15" y1="-2.755" x2="0.15" y2="-2.355" layer="35" rot="R90"/>
+<rectangle x1="-0.15" y1="2.325" x2="0.15" y2="2.725" layer="35" rot="R90"/>
+<rectangle x1="-0.15" y1="2.325" x2="0.15" y2="2.725" layer="35" rot="R90"/>
+</package>
+<package name="L_4,8X4,8">
+<wire x1="2.5" y1="2.5" x2="-2.5" y2="2.5" width="0.127" layer="21"/>
+<wire x1="-2.5" y1="2.5" x2="-2.5" y2="-2.5" width="0.127" layer="21"/>
+<wire x1="-2.5" y1="-2.5" x2="2.5" y2="-2.5" width="0.127" layer="21"/>
+<wire x1="2.5" y1="-2.5" x2="2.5" y2="2.5" width="0.127" layer="21"/>
+<circle x="0" y="0" radius="0.2245" width="0.6096" layer="35"/>
+<circle x="0" y="1.5875" radius="0.2245" width="0.6096" layer="35"/>
+<circle x="0" y="-1.5875" radius="0.2245" width="0.6096" layer="35"/>
+<circle x="0" y="0" radius="2.2895" width="0.127" layer="21"/>
+<smd name="P$1" x="-1.8013" y="0" dx="5.3" dy="2.2" layer="1" rot="R90"/>
+<smd name="P$2" x="1.8013" y="0" dx="5.3" dy="2.2" layer="1" rot="R90"/>
+<text x="-3.175" y="3.1115" size="1.27" layer="25">&gt;NAME</text>
+<text x="-3.4925" y="-4.3815" size="1.27" layer="27">&gt;VALUE</text>
+</package>
+<package name="L_MCBF7330">
+<text x="-3.175" y="8.5725" size="1.27" layer="25">&gt;NAME</text>
+<text x="-3.175" y="-9.2075" size="1.27" layer="27">&gt;VALUE</text>
+<smd name="1" x="-7.8" y="0" dx="3.5" dy="3.5" layer="1"/>
+<smd name="2" x="7.8" y="0" dx="3.5" dy="3.5" layer="1"/>
+<wire x1="-9.3" y1="-2.2" x2="-9.3" y2="2.1" width="0.127" layer="21"/>
+<wire x1="-9.3" y1="-2.2" x2="-3.9" y2="-7.6" width="0.127" layer="21"/>
+<wire x1="-3.9" y1="-7.6" x2="3.6" y2="-7.6" width="0.127" layer="21"/>
+<wire x1="3.6" y1="-7.6" x2="3.9" y2="-7.6" width="0.127" layer="21"/>
+<wire x1="3.9" y1="-7.6" x2="9.3" y2="-2.2" width="0.127" layer="21"/>
+<wire x1="9.3" y1="-2.2" x2="9.3" y2="2.1" width="0.127" layer="21"/>
+<circle x="0" y="0" radius="5.961540625" width="0.127" layer="21"/>
+<circle x="-2.5" y="-2.5" radius="1.11803125" width="2.1844" layer="35"/>
+<circle x="2.5" y="-2.5" radius="1.11803125" width="2.1844" layer="35"/>
+<circle x="-2.5" y="2.5" radius="1.11803125" width="2.1844" layer="35"/>
+<circle x="2.5" y="2.5" radius="1.11803125" width="2.1844" layer="35"/>
+<wire x1="9.3" y1="2.1" x2="9.3" y2="2.2" width="0.127" layer="21"/>
+<wire x1="9.3" y1="2.2" x2="3.9" y2="7.6" width="0.127" layer="21"/>
+<wire x1="3.9" y1="7.6" x2="-0.6" y2="7.6" width="0.127" layer="21"/>
+<wire x1="-0.6" y1="7.6" x2="-3.9" y2="7.6" width="0.127" layer="21"/>
+<wire x1="-3.9" y1="7.6" x2="-9.3" y2="2.2" width="0.127" layer="21"/>
+<wire x1="-9.3" y1="2.2" x2="-9.3" y2="2.1" width="0.127" layer="21"/>
+</package>
+<package name="L_29X13">
+<wire x1="-6.5" y1="2.5" x2="-6.5" y2="14.5" width="0.4064" layer="21"/>
+<wire x1="-6.5" y1="14.5" x2="6.5" y2="14.5" width="0.4064" layer="21"/>
+<wire x1="6.5" y1="14.5" x2="6.5" y2="2.5" width="0.4064" layer="21"/>
+<wire x1="-6.5" y1="-2.5" x2="-6.5" y2="-14.5" width="0.4064" layer="21"/>
+<wire x1="-6.5" y1="-14.5" x2="6.5" y2="-14.5" width="0.4064" layer="21"/>
+<wire x1="6.5" y1="-14.5" x2="6.5" y2="-2.5" width="0.4064" layer="21"/>
+<pad name="P$1" x="-6.5" y="0" drill="1.5" diameter="2.5" shape="long" rot="R90"/>
+<pad name="P$2" x="6.5" y="0" drill="1.5" diameter="2.5" shape="long" rot="R90"/>
+<text x="-2.54" y="2.54" size="1.27" layer="25" rot="R270">&gt;NAME</text>
+<text x="2.54" y="-3.81" size="1.27" layer="27" rot="R90">&gt;VALUE</text>
+</package>
+<package name="L10X10,2">
+<smd name="1" x="-4.5" y="0" dx="1.8" dy="4" layer="1"/>
+<smd name="2" x="4.5" y="0" dx="1.8" dy="4" layer="1"/>
+<wire x1="-5" y1="-2" x2="-5" y2="2" width="0.127" layer="21"/>
+<wire x1="-5" y1="2" x2="-2" y2="5" width="0.127" layer="21"/>
+<wire x1="-2" y1="5" x2="2" y2="5" width="0.127" layer="21"/>
+<wire x1="2" y1="5" x2="5" y2="2" width="0.127" layer="21"/>
+<wire x1="5" y1="2" x2="5" y2="-2" width="0.127" layer="21"/>
+<wire x1="5" y1="-2" x2="2" y2="-5" width="0.127" layer="21"/>
+<wire x1="2" y1="-5" x2="-2" y2="-5" width="0.127" layer="21"/>
+<wire x1="-2" y1="-5" x2="-5" y2="-2" width="0.127" layer="21"/>
+<circle x="0" y="0" radius="3.51283125" width="0.127" layer="21"/>
+<text x="-3.4" y="5.2" size="1.27" layer="25">&gt;NAME</text>
+<text x="-3.3" y="-6.5" size="1.27" layer="27">&gt;VALUE</text>
+</package>
+<package name="L_4,3X4,3">
+<wire x1="-2.15" y1="-2.15" x2="2.15" y2="-2.15" width="0.1" layer="21"/>
+<wire x1="2.15" y1="-2.15" x2="2.15" y2="2.15" width="0.1" layer="21"/>
+<wire x1="2.15" y1="2.15" x2="-2.15" y2="2.15" width="0.1" layer="21"/>
+<wire x1="-2.15" y1="2.15" x2="-2.15" y2="-2.15" width="0.1" layer="21"/>
+<circle x="0" y="0" radius="1.35" width="0.1" layer="21"/>
+<smd name="1" x="-1.65" y="0" dx="1.8" dy="4.3" layer="1"/>
+<smd name="2" x="1.65" y="0" dx="1.8" dy="4.3" layer="1"/>
+<circle x="0" y="0" radius="0.3175" width="0" layer="35"/>
+<circle x="0" y="1.52" radius="0.3175" width="0" layer="35"/>
+<circle x="0" y="-1.52" radius="0.3175" width="0" layer="35"/>
+<text x="-2.54" y="2.54" size="1.27" layer="25">&gt;NAME</text>
+<text x="-3.175" y="-3.81" size="1.27" layer="27">&gt;VALUE</text>
+</package>
+<package name="L_7,3X7,3_2">
+<smd name="P$1" x="-2.9" y="0" dx="2.6" dy="1.8" layer="1" rot="R90"/>
+<smd name="P$2" x="2.9" y="0" dx="2.6" dy="1.8" layer="1" rot="R90"/>
+<wire x1="-3.65" y1="-3.65" x2="1.825" y2="-3.65" width="0.15" layer="21"/>
+<wire x1="1.825" y1="-3.65" x2="3.65" y2="-1.825" width="0.15" layer="21"/>
+<wire x1="3.65" y1="-1.825" x2="3.65" y2="3.65" width="0.15" layer="21"/>
+<wire x1="3.65" y1="3.65" x2="-1.825" y2="3.65" width="0.15" layer="21"/>
+<wire x1="-1.825" y1="3.65" x2="-3.65" y2="1.825" width="0.15" layer="21"/>
+<wire x1="-3.65" y1="1.825" x2="-3.65" y2="-3.65" width="0.15" layer="21"/>
+<circle x="0" y="0" radius="3.4" width="0.15" layer="21"/>
+<text x="-3.7" y="-5.1" size="1.27" layer="27">&gt;VALUE</text>
+<text x="-3.7" y="3.8" size="1.27" layer="25">&gt;NAME</text>
+<circle x="0" y="2.54" radius="0.3175" width="0.6096" layer="35"/>
+<circle x="0" y="-2.54" radius="0.3175" width="0.6096" layer="35"/>
+<circle x="0" y="0" radius="0.3175" width="0.6096" layer="35"/>
+</package>
+<package name="L_2,5X5">
+<text x="-3.64" y="-4.04" size="1.27" layer="27">&gt;VALUE</text>
+<text x="-3.07" y="2.67" size="1.27" layer="25">&gt;NAME</text>
+<pad name="1" x="-1.25" y="0" drill="0.9"/>
+<pad name="2" x="1.25" y="0" drill="0.9"/>
+<circle x="0" y="0" radius="2.5" width="0.127" layer="21"/>
+</package>
+<package name="L_15X9">
+<wire x1="-4.5" y1="2" x2="-4.5" y2="7.5" width="0.4064" layer="21"/>
+<wire x1="-4.5" y1="7.5" x2="4.5" y2="7.5" width="0.4064" layer="21"/>
+<wire x1="4.5" y1="7.5" x2="4.5" y2="2" width="0.4064" layer="21"/>
+<wire x1="-4.5" y1="-2" x2="-4.5" y2="-7.5" width="0.4064" layer="21"/>
+<wire x1="-4.5" y1="-7.5" x2="4.5" y2="-7.5" width="0.4064" layer="21"/>
+<wire x1="4.5" y1="-7.5" x2="4.5" y2="-2" width="0.4064" layer="21"/>
+<pad name="P$1" x="-4.5" y="0" drill="1" diameter="2" shape="long" rot="R90"/>
+<pad name="P$2" x="4.5" y="0" drill="1" diameter="2" shape="long" rot="R90"/>
+<text x="-2.54" y="2.54" size="1.27" layer="25" rot="R270">&gt;NAME</text>
+<text x="2.54" y="-3.81" size="1.27" layer="27" rot="R90">&gt;VALUE</text>
+</package>
+<package name="L_ELL6-6X6MM">
+<circle x="0" y="0" radius="2.5" width="0.254" layer="21"/>
+<circle x="0" y="-1.27" radius="0.5" width="1.016" layer="35"/>
+<smd name="P$1" x="-2.85" y="0" dx="3.8" dy="1.7" layer="1" rot="R90"/>
+<smd name="P$2" x="2.85" y="0" dx="3.8" dy="1.7" layer="1" rot="R90"/>
+<text x="-3.175" y="3.3815" size="1.27" layer="25">&gt;NAME</text>
+<text x="-3.4925" y="-4.6515" size="1.27" layer="27">&gt;VALUE</text>
+<wire x1="-3" y1="-3" x2="3" y2="-3" width="0.254" layer="21"/>
+<wire x1="3" y1="-3" x2="3" y2="2" width="0.254" layer="21"/>
+<wire x1="2" y1="3" x2="-2" y2="3" width="0.254" layer="21"/>
+<wire x1="-3" y1="2" x2="-3" y2="-3" width="0.254" layer="21"/>
+<wire x1="-3" y1="2" x2="-2" y2="3" width="0.254" layer="21"/>
+<wire x1="3" y1="2" x2="2" y2="3" width="0.254" layer="21"/>
+<circle x="0" y="1.23" radius="0.5" width="1.016" layer="35"/>
+</package>
+<package name="0207$ST_1_2">
+<wire x1="-0.635" y1="0" x2="0.9525" y2="0" width="0.3048" layer="21"/>
+<circle x="-1.905" y="0" radius="1.27" width="0.3048" layer="21"/>
+<pad name="1" x="-1.905" y="0" drill="0.8128" diameter="1.524"/>
+<pad name="2" x="1.905" y="0" drill="0.8128" diameter="1.524"/>
+<text x="0" y="0.635" size="1.27" layer="25">&gt;NAME</text>
+<text x="0" y="0.635" size="1.27" layer="27">&gt;VALUE</text>
+</package>
+<package name="1806">
+<smd name="1" x="-2.25" y="0" dx="1.5" dy="1.8" layer="1"/>
+<smd name="2" x="2.25" y="0" dx="1.5" dy="1.8" layer="1" rot="R180"/>
+<text x="-3.175" y="2.54" size="1.27" layer="25">&gt;NAME</text>
+<text x="-3.175" y="-3.81" size="1.27" layer="27">&gt;VALUE</text>
+<wire x1="-2.25" y1="-0.8" x2="2.25" y2="-0.8" width="0.127" layer="21"/>
+<wire x1="2.25" y1="-0.8" x2="2.25" y2="0.8" width="0.127" layer="21"/>
+<wire x1="2.25" y1="0.8" x2="-2.25" y2="0.8" width="0.127" layer="21"/>
+<wire x1="-2.25" y1="0.8" x2="-2.25" y2="-0.8" width="0.127" layer="21"/>
+<rectangle x1="-0.8" y1="-0.7" x2="0.8" y2="0.7" layer="35"/>
+</package>
+<package name="L_5,8X5,2">
+<wire x1="-1.27" y1="2.9" x2="1.27" y2="2.9" width="0.127" layer="21"/>
+<wire x1="-1.27" y1="-2.9" x2="1.27" y2="-2.9" width="0.127" layer="21"/>
+<wire x1="1.27" y1="2.9" x2="1.27" y2="-2.9" width="0.127" layer="21" curve="-126.869898"/>
+<wire x1="-1.27" y1="2.9" x2="-1.27" y2="-2.9" width="0.127" layer="21" curve="126.869898"/>
+<wire x1="-2.8575" y1="0.3175" x2="-2.8575" y2="-0.3175" width="0.127" layer="21" curve="-180"/>
+<wire x1="2.8575" y1="0.3175" x2="2.8575" y2="-0.3175" width="0.127" layer="21" curve="180"/>
+<circle x="0" y="-1.5875" radius="0.3175" width="0.8128" layer="35"/>
+<circle x="0" y="1.5875" radius="0.3175" width="0.8128" layer="35"/>
+<smd name="P$1" x="-1.925" y="0" dx="5.5" dy="2.15" layer="1" rot="R90"/>
+<smd name="P$2" x="1.925" y="0" dx="5.5" dy="2.15" layer="1" rot="R90"/>
+<text x="-3.175" y="3.175" size="1.4224" layer="25">&gt;NAME</text>
+<text x="-3.81" y="-5.08" size="1.4224" layer="27">&gt;VALUE</text>
+</package>
+<package name="2010_REFLOW">
+<wire x1="-2.5" y1="1.25" x2="2.5" y2="1.25" width="0.1524" layer="51"/>
+<wire x1="-2.5" y1="-1.25" x2="2.5" y2="-1.25" width="0.1524" layer="51"/>
+<wire x1="-1.5" y1="1.245" x2="1.5" y2="1.245" width="0.1524" layer="21"/>
+<wire x1="-1.5" y1="-1.245" x2="1.5" y2="-1.245" width="0.1524" layer="21"/>
+<circle x="0" y="0.635" radius="0.1588" width="0.6096" layer="35"/>
+<circle x="0" y="-0.635" radius="0.1588" width="0.6096" layer="35"/>
+<smd name="1" x="-2.45" y="0" dx="1" dy="2.5" layer="1"/>
+<smd name="2" x="2.45" y="0" dx="1" dy="2.5" layer="1"/>
+<text x="-2.159" y="1.651" size="1.27" layer="25">&gt;NAME</text>
+<text x="-2.159" y="-2.921" size="1.27" layer="27">&gt;VALUE</text>
+<rectangle x1="-2.58" y1="-1.25" x2="-1.9" y2="1.25" layer="51"/>
+<rectangle x1="1.9" y1="-1.25" x2="2.58" y2="1.25" layer="51"/>
+</package>
+<package name="2512_REFLOW">
+<wire x1="-3.2" y1="-1.6" x2="3.2" y2="-1.6" width="0.127" layer="21"/>
+<wire x1="3.2" y1="-1.6" x2="3.2" y2="1.6" width="0.127" layer="21"/>
+<wire x1="3.2" y1="1.6" x2="-3.2" y2="1.6" width="0.127" layer="21"/>
+<wire x1="-3.2" y1="1.6" x2="-3.2" y2="-1.6" width="0.127" layer="21"/>
+<circle x="0" y="0.635" radius="0.3175" width="1.016" layer="35"/>
+<circle x="0" y="-0.635" radius="0.3175" width="1.016" layer="35"/>
+<smd name="1" x="-3.25" y="0" dx="3.1" dy="1.6" layer="1" rot="R90"/>
+<smd name="2" x="3.25" y="0" dx="3.1" dy="1.6" layer="1" rot="R90"/>
+<text x="-2.4765" y="-0.5715" size="1.27" layer="25">&gt;NAME</text>
+<text x="-2.4765" y="-0.6985" size="1.27" layer="27">&gt;VALUE</text>
+</package>
+<package name="MB100100">
+<smd name="1" x="0" y="0" dx="2.54" dy="2.54" layer="1" cream="no"/>
+<text x="-1.905" y="1.27" size="1.27" layer="37">&gt;NAME</text>
+<rectangle x1="-0.635" y1="-0.635" x2="0.635" y2="0.635" layer="37"/>
+<rectangle x1="-0.635" y1="-0.635" x2="0.635" y2="0.635" layer="37"/>
+</package>
+<package name="MB5050">
+<smd name="1" x="0" y="0" dx="1.524" dy="1.524" layer="1" cream="no"/>
+<text x="-1.905" y="0.635" size="1.27" layer="37">&gt;NAME</text>
+<rectangle x1="-0.508" y1="-0.508" x2="0.508" y2="0.508" layer="37"/>
+</package>
+<package name="MB1.27">
+<circle x="0" y="0" radius="0.1588" width="0.8128" layer="37"/>
+<smd name="1" x="0" y="0" dx="1.27" dy="1.27" layer="1" roundness="100" cream="no"/>
+<text x="-3.175" y="1.5875" size="1.27" layer="37">&gt;NAME</text>
+</package>
+<package name="MB270150">
+<smd name="1" x="0" y="0" dx="6.858" dy="3.81" layer="1" cream="no"/>
+<text x="-3.175" y="2.54" size="1.27" layer="37">&gt;NAME</text>
+<rectangle x1="-0.635" y1="-0.635" x2="0.635" y2="0.635" layer="37"/>
+<rectangle x1="-0.635" y1="-0.635" x2="0.635" y2="0.635" layer="37"/>
+</package>
+<package name="MB1.5">
+<circle x="0" y="0" radius="0.1588" width="1" layer="37"/>
+<smd name="1" x="0" y="0" dx="1.25" dy="1.25" layer="1" roundness="100" cream="no"/>
+<text x="-3.175" y="1.5875" size="1.27" layer="37">&gt;NAME</text>
+</package>
+<package name="MB2.0">
+<circle x="0" y="0" radius="0.25" width="1" layer="37"/>
+<smd name="1" x="0" y="0" dx="1.5" dy="1.5" layer="1" roundness="100" cream="no"/>
+<text x="-3.175" y="1.5875" size="1.27" layer="37">&gt;NAME</text>
+</package>
+<package name="0201">
+<smd name="1" x="-0.275" y="0" dx="0.35" dy="0.35" layer="1" stop="no"/>
+<smd name="2" x="0.275" y="0" dx="0.35" dy="0.35" layer="1" stop="no"/>
+<wire x1="-0.525" y1="0.225" x2="-0.525" y2="-0.225" width="0.05" layer="21"/>
+<wire x1="-0.525" y1="-0.225" x2="0.525" y2="-0.225" width="0.05" layer="21"/>
+<wire x1="0.525" y1="-0.225" x2="0.525" y2="0.225" width="0.05" layer="21"/>
+<wire x1="0.525" y1="0.225" x2="-0.525" y2="0.225" width="0.05" layer="21"/>
+<text x="-1.479" y="-0.979" size="0.6096" layer="27">&gt;VALUE</text>
+<rectangle x1="-0.5" y1="-0.225" x2="0.499" y2="0.225" layer="29"/>
+</package>
+<package name="R_5,5X16">
+<text x="-2.385" y="-0.635" size="1.27" layer="25">&gt;NAME</text>
+<text x="-3.135" y="-0.635" size="1.27" layer="27">&gt;VALUE</text>
+<pad name="1" x="-10" y="0" drill="1.1" diameter="1.9304"/>
+<pad name="2" x="10" y="0" drill="1.1" diameter="1.9304"/>
+<wire x1="-8" y1="-2.75" x2="8" y2="-2.75" width="0.3048" layer="21"/>
+<wire x1="8" y1="-2.75" x2="8" y2="2.75" width="0.3048" layer="21"/>
+<wire x1="8" y1="2.75" x2="-8" y2="2.75" width="0.3048" layer="21"/>
+<wire x1="-8" y1="2.75" x2="-8" y2="-2.75" width="0.3048" layer="21"/>
+</package>
+<package name="2220">
+<description>&lt;b&gt;Ceramic Chip Capacitor KEMET 2220 reflow solder&lt;/b&gt;&lt;p&gt;Metric Code Size 5650</description>
+<wire x1="-2.725" y1="2.425" x2="2.725" y2="2.425" width="0.1016" layer="51"/>
+<wire x1="2.725" y1="-2.425" x2="-2.725" y2="-2.425" width="0.1016" layer="51"/>
+<smd name="1" x="-2.55" y="0" dx="1.85" dy="5.5" layer="1"/>
+<smd name="2" x="2.55" y="0" dx="1.85" dy="5.5" layer="1"/>
+<text x="-2.8" y="2.95" size="1.016" layer="25">&gt;NAME</text>
+<text x="-2.8" y="-3.975" size="1.016" layer="27">&gt;VALUE</text>
+<rectangle x1="-2.8" y1="-2.5" x2="-2.2" y2="2.5" layer="51"/>
+<rectangle x1="2.2" y1="-2.5" x2="2.8" y2="2.5" layer="51"/>
+</package>
+<package name="L_PM2110">
+<smd name="1" x="-14" y="0" dx="17.8" dy="5.1" layer="1" rot="R90"/>
+<smd name="2" x="14" y="0" dx="17.8" dy="5.1" layer="1" rot="R90"/>
+<text x="-2.8575" y="5.6515" size="1.27" layer="25">&gt;NAME</text>
+<text x="-3.175" y="-6.9215" size="1.27" layer="27">&gt;VALUE</text>
+<wire x1="0" y1="12.7" x2="-5.08" y2="12.7" width="0.3048" layer="21"/>
+<wire x1="-5.08" y1="12.7" x2="-10.16" y2="7.62" width="0.3048" layer="21"/>
+<wire x1="-10.16" y1="7.62" x2="-12.7" y2="5.08" width="0.3048" layer="21"/>
+<wire x1="-12.7" y1="5.08" x2="-12.7" y2="0" width="0.3048" layer="21"/>
+<wire x1="-12.7" y1="0" x2="-12.7" y2="-5.08" width="0.3048" layer="21"/>
+<wire x1="-12.7" y1="-5.08" x2="-7.62" y2="-10.16" width="0.3048" layer="21"/>
+<wire x1="-7.62" y1="-10.16" x2="-5.08" y2="-12.7" width="0.3048" layer="21"/>
+<wire x1="-5.08" y1="-12.7" x2="0" y2="-12.7" width="0.3048" layer="21"/>
+<wire x1="0" y1="-12.7" x2="5.08" y2="-12.7" width="0.3048" layer="21"/>
+<wire x1="5.08" y1="-12.7" x2="10.16" y2="-7.62" width="0.3048" layer="21"/>
+<wire x1="10.16" y1="-7.62" x2="12.7" y2="-5.08" width="0.3048" layer="21"/>
+<wire x1="12.7" y1="-5.08" x2="12.7" y2="0" width="0.3048" layer="21"/>
+<wire x1="12.7" y1="0" x2="12.7" y2="5.08" width="0.3048" layer="21"/>
+<wire x1="12.7" y1="5.08" x2="8.89" y2="8.89" width="0.3048" layer="21"/>
+<wire x1="8.89" y1="8.89" x2="5.08" y2="12.7" width="0.3048" layer="21"/>
+<wire x1="5.08" y1="12.7" x2="0" y2="12.7" width="0.3048" layer="21"/>
+<circle x="0" y="0" radius="10.92495" width="0.3048" layer="21"/>
+<rectangle x1="-6.35" y1="-5.08" x2="6.35" y2="5.08" layer="35"/>
+</package>
+<package name="L_SDR1307">
+<circle x="0" y="0" radius="6.5" width="0.127" layer="21"/>
+<smd name="P$1" x="-4.625" y="0" dx="14" dy="4.75" layer="1" rot="R90"/>
+<smd name="P$2" x="4.625" y="0" dx="14" dy="4.75" layer="1" rot="R90"/>
+<text x="-3.175" y="3.1115" size="1.27" layer="25">&gt;NAME</text>
+<text x="-3.4925" y="-4.3815" size="1.27" layer="27">&gt;VALUE</text>
+<circle x="0" y="3.81" radius="0.55" width="2.54" layer="35"/>
+<circle x="0" y="-3.81" radius="0.55" width="2.54" layer="35"/>
+<circle x="0" y="0" radius="0.55" width="2.54" layer="35"/>
+</package>
+<package name="L_SRP7030">
+<wire x1="-3.81" y1="3.81" x2="3.81" y2="3.81" width="0.254" layer="21"/>
+<wire x1="3.81" y1="3.81" x2="3.81" y2="-3.81" width="0.254" layer="21"/>
+<wire x1="3.81" y1="-3.81" x2="-3.81" y2="-3.81" width="0.254" layer="21"/>
+<wire x1="-3.81" y1="-3.81" x2="-3.81" y2="3.81" width="0.254" layer="21"/>
+<circle x="0" y="0" radius="3.175" width="0.254" layer="21"/>
+<circle x="0" y="2.54" radius="0.3175" width="0.6096" layer="35"/>
+<circle x="0" y="-2.54" radius="0.3175" width="0.6096" layer="35"/>
+<circle x="0" y="0" radius="0.3175" width="0.6096" layer="35"/>
+<smd name="P$1" x="-3.1" y="0" dx="3.5" dy="2.5" layer="1" rot="R90"/>
+<smd name="P$2" x="3.1" y="0" dx="3.5" dy="2.5" layer="1" rot="R90"/>
+<text x="-3.175" y="4.3815" size="1.27" layer="25">&gt;NAME</text>
+<text x="-3.4925" y="-5.6515" size="1.27" layer="27">&gt;VALUE</text>
+</package>
+<package name="L_VLCF5028-2">
+<smd name="P$1" x="-1.725" y="0" dx="5" dy="2.15" layer="1" rot="R90"/>
+<smd name="P$2" x="1.725" y="0" dx="5" dy="2.15" layer="1" rot="R90"/>
+<text x="-3.175" y="3.175" size="1.4224" layer="25">&gt;NAME</text>
+<text x="-3.81" y="-5.08" size="1.4224" layer="27">&gt;VALUE</text>
+<wire x1="-2.5" y1="-2" x2="-2" y2="-2.5" width="0.127" layer="21"/>
+<wire x1="-2" y1="-2.5" x2="2" y2="-2.5" width="0.127" layer="21"/>
+<wire x1="2" y1="-2.5" x2="2.5" y2="-2" width="0.127" layer="21"/>
+<wire x1="2.5" y1="-2" x2="2.5" y2="2" width="0.127" layer="21"/>
+<wire x1="2.5" y1="2" x2="2" y2="2.5" width="0.127" layer="21"/>
+<wire x1="2" y1="2.5" x2="-2" y2="2.5" width="0.127" layer="21"/>
+<wire x1="-2" y1="2.5" x2="-2.5" y2="2" width="0.127" layer="21"/>
+<wire x1="-2.5" y1="2" x2="-2.5" y2="-2" width="0.127" layer="21"/>
+<circle x="0" y="0" radius="1.788853125" width="0.127" layer="21"/>
+<circle x="0" y="0" radius="1.5" width="0.127" layer="21"/>
+<circle x="-0.9" y="0" radius="0.412309375" width="0.127" layer="21"/>
+</package>
+</packages>
+<symbols>
+<symbol name="DS">
+<wire x1="-1.524" y1="-1.651" x2="1.524" y2="0" width="0.1524" layer="94"/>
+<wire x1="1.524" y1="0" x2="-1.524" y2="1.651" width="0.1524" layer="94"/>
+<wire x1="-1.524" y1="1.651" x2="-1.524" y2="0" width="0.1524" layer="94"/>
+<wire x1="-1.524" y1="0" x2="-1.524" y2="-1.651" width="0.1524" layer="94"/>
+<wire x1="1.524" y1="1.651" x2="1.524" y2="0" width="0.1524" layer="94"/>
+<wire x1="1.524" y1="0" x2="1.524" y2="-1.651" width="0.1524" layer="94"/>
+<wire x1="-5.08" y1="0" x2="-1.524" y2="0" width="0.1524" layer="94"/>
+<wire x1="1.524" y1="-1.651" x2="0.635" y2="-1.651" width="0.1524" layer="94"/>
+<wire x1="2.413" y1="1.651" x2="1.524" y2="1.651" width="0.1524" layer="94"/>
+<wire x1="1.524" y1="0" x2="5.08" y2="0" width="0.1524" layer="94"/>
+<text x="-1.27" y="1.905" size="1.27" layer="95">&gt;NAME</text>
+<text x="-3.175" y="-3.175" size="1.27" layer="96">&gt;VALUE</text>
+<pin name="1" x="-5.08" y="0" visible="off" length="point" direction="pas"/>
+<pin name="2" x="5.08" y="0" visible="off" length="point" direction="pas"/>
+</symbol>
+<symbol name="PRTR5V0">
+<wire x1="-4.191" y1="-0.762" x2="-5.08" y2="1.016" width="0.1524" layer="94"/>
+<wire x1="-5.08" y1="1.016" x2="-5.969" y2="-0.762" width="0.1524" layer="94"/>
+<wire x1="-5.969" y1="-0.762" x2="-5.08" y2="-0.762" width="0.1524" layer="94"/>
+<wire x1="-5.08" y1="-0.762" x2="-4.191" y2="-0.762" width="0.1524" layer="94"/>
+<wire x1="-5.08" y1="1.016" x2="-5.08" y2="1.1176" width="0.1524" layer="94"/>
+<wire x1="-5.588" y1="1.016" x2="-5.08" y2="1.016" width="0.1524" layer="94"/>
+<wire x1="-5.08" y1="1.016" x2="-4.572" y2="1.016" width="0.1524" layer="94"/>
+<wire x1="-5.08" y1="-5.08" x2="-5.08" y2="-3.302" width="0.1524" layer="94"/>
+<wire x1="-5.08" y1="-3.302" x2="-5.08" y2="-0.762" width="0.1524" layer="94"/>
+<wire x1="-5.08" y1="1.016" x2="-5.08" y2="3.302" width="0.1524" layer="94"/>
+<wire x1="-5.08" y1="3.302" x2="-5.08" y2="5.08" width="0.1524" layer="94"/>
+<wire x1="-4.572" y1="1.016" x2="-4.191" y2="0.762" width="0.1524" layer="94"/>
+<text x="-3.81" y="4.445" size="1.27" layer="95">&gt;NAME</text>
+<text x="-1.905" y="-5.715" size="1.27" layer="96">&gt;VALUE</text>
+<pin name="GND" x="-5.08" y="-5.08" visible="off" length="point" direction="pas" rot="R90"/>
+<pin name="VCC" x="-5.08" y="5.08" visible="off" length="point" direction="pas" rot="R90"/>
+<pin name="I/O1" x="2.54" y="5.08" visible="off" length="point" direction="pas" rot="R90"/>
+<pin name="I/O2" x="5.08" y="5.08" visible="off" length="point" direction="pas" rot="R90"/>
+<wire x1="-1.143" y1="0.762" x2="-2.032" y2="2.54" width="0.1524" layer="94"/>
+<wire x1="-2.032" y1="2.54" x2="-2.921" y2="0.762" width="0.1524" layer="94"/>
+<wire x1="-2.921" y1="0.762" x2="-2.032" y2="0.762" width="0.1524" layer="94"/>
+<wire x1="-2.032" y1="0.762" x2="-1.143" y2="0.762" width="0.1524" layer="94"/>
+<wire x1="-2.921" y1="2.54" x2="-2.032" y2="2.54" width="0.1524" layer="94"/>
+<wire x1="-2.032" y1="2.54" x2="-1.143" y2="2.54" width="0.1524" layer="94"/>
+<wire x1="-2.032" y1="2.54" x2="-2.032" y2="3.302" width="0.1524" layer="94"/>
+<wire x1="-1.143" y1="-2.54" x2="-2.032" y2="-0.762" width="0.1524" layer="94"/>
+<wire x1="-2.032" y1="-0.762" x2="-2.921" y2="-2.54" width="0.1524" layer="94"/>
+<wire x1="-2.921" y1="-2.54" x2="-2.032" y2="-2.54" width="0.1524" layer="94"/>
+<wire x1="-2.032" y1="-2.54" x2="-1.143" y2="-2.54" width="0.1524" layer="94"/>
+<wire x1="-2.032" y1="-0.762" x2="-2.032" y2="-0.6604" width="0.1524" layer="94"/>
+<wire x1="-2.921" y1="-0.762" x2="-2.032" y2="-0.762" width="0.1524" layer="94"/>
+<wire x1="-2.032" y1="-0.762" x2="-1.143" y2="-0.762" width="0.1524" layer="94"/>
+<wire x1="-2.032" y1="-0.762" x2="-2.032" y2="0.254" width="0.1524" layer="94"/>
+<wire x1="-2.032" y1="0.254" x2="-2.032" y2="0.762" width="0.1524" layer="94"/>
+<wire x1="-2.032" y1="-3.302" x2="-2.032" y2="-2.54" width="0.1524" layer="94"/>
+<wire x1="1.905" y1="0.762" x2="1.016" y2="2.54" width="0.1524" layer="94"/>
+<wire x1="1.016" y1="2.54" x2="0.127" y2="0.762" width="0.1524" layer="94"/>
+<wire x1="0.127" y1="0.762" x2="1.016" y2="0.762" width="0.1524" layer="94"/>
+<wire x1="1.016" y1="0.762" x2="1.905" y2="0.762" width="0.1524" layer="94"/>
+<wire x1="0.127" y1="2.54" x2="1.016" y2="2.54" width="0.1524" layer="94"/>
+<wire x1="1.016" y1="2.54" x2="1.905" y2="2.54" width="0.1524" layer="94"/>
+<wire x1="1.016" y1="2.54" x2="1.016" y2="3.302" width="0.1524" layer="94"/>
+<wire x1="1.905" y1="-2.54" x2="1.016" y2="-0.762" width="0.1524" layer="94"/>
+<wire x1="1.016" y1="-0.762" x2="0.127" y2="-2.54" width="0.1524" layer="94"/>
+<wire x1="0.127" y1="-2.54" x2="1.016" y2="-2.54" width="0.1524" layer="94"/>
+<wire x1="1.016" y1="-2.54" x2="1.905" y2="-2.54" width="0.1524" layer="94"/>
+<wire x1="1.016" y1="-0.762" x2="1.016" y2="-0.6604" width="0.1524" layer="94"/>
+<wire x1="0.127" y1="-0.762" x2="1.016" y2="-0.762" width="0.1524" layer="94"/>
+<wire x1="1.016" y1="-0.762" x2="1.905" y2="-0.762" width="0.1524" layer="94"/>
+<wire x1="1.016" y1="-0.762" x2="1.016" y2="-0.254" width="0.1524" layer="94"/>
+<wire x1="1.016" y1="-0.254" x2="1.016" y2="0.762" width="0.1524" layer="94"/>
+<wire x1="1.016" y1="-3.302" x2="1.016" y2="-2.54" width="0.1524" layer="94"/>
+<wire x1="1.016" y1="-3.302" x2="-5.08" y2="-3.302" width="0.1524" layer="94"/>
+<wire x1="1.016" y1="3.302" x2="-5.08" y2="3.302" width="0.1524" layer="94"/>
+<wire x1="-2.032" y1="0.254" x2="2.54" y2="0.254" width="0.1524" layer="94"/>
+<wire x1="2.54" y1="0.254" x2="2.54" y2="5.08" width="0.1524" layer="94"/>
+<wire x1="1.016" y1="-0.254" x2="5.08" y2="-0.254" width="0.1524" layer="94"/>
+<wire x1="5.08" y1="-0.254" x2="5.08" y2="5.08" width="0.1524" layer="94"/>
+<circle x="-2.032" y="0.254" radius="0.1077625" width="0.1524" layer="94"/>
+<circle x="-5.08" y="-3.302" radius="0.1077625" width="0.1524" layer="94"/>
+<circle x="1.016" y="-0.2794" radius="0.1077625" width="0.1524" layer="94"/>
+<circle x="-5.08" y="3.302" radius="0.1077625" width="0.1524" layer="94"/>
+<circle x="-2.032" y="3.302" radius="0.1077625" width="0.1524" layer="94"/>
+<circle x="-2.032" y="-3.302" radius="0.1077625" width="0.1524" layer="94"/>
+<wire x1="-5.969" y1="1.27" x2="-5.588" y2="1.016" width="0.1524" layer="94"/>
+</symbol>
+<symbol name="R">
+<wire x1="-5.08" y1="0" x2="-2.54" y2="0" width="0.1524" layer="94"/>
+<wire x1="2.54" y1="0" x2="5.08" y2="0" width="0.1524" layer="94"/>
+<wire x1="-2.54" y1="1.27" x2="-2.54" y2="0" width="0.1524" layer="94"/>
+<wire x1="-2.54" y1="0" x2="-2.54" y2="-1.27" width="0.1524" layer="94"/>
+<wire x1="-2.54" y1="-1.27" x2="2.54" y2="-1.27" width="0.1524" layer="94"/>
+<wire x1="2.54" y1="-1.27" x2="2.54" y2="0" width="0.1524" layer="94"/>
+<wire x1="2.54" y1="0" x2="2.54" y2="1.27" width="0.1524" layer="94"/>
+<wire x1="2.54" y1="1.27" x2="-2.54" y2="1.27" width="0.1524" layer="94"/>
+<text x="-1.905" y="-0.635" size="1.27" layer="95">&gt;NAME</text>
+<text x="-1.905" y="-3.175" size="1.27" layer="96">&gt;VALUE</text>
+<pin name="1" x="-5.08" y="0" visible="off" length="point" direction="pas" swaplevel="1"/>
+<pin name="2" x="5.08" y="0" visible="off" length="point" direction="pas" swaplevel="1" rot="R180"/>
+</symbol>
+<symbol name="VCC">
+<wire x1="0" y1="-2.54" x2="0" y2="0" width="0.1524" layer="94"/>
+<wire x1="0" y1="0" x2="-1.143" y2="-1.778" width="0.3048" layer="94"/>
+<wire x1="0" y1="0" x2="1.143" y2="-1.778" width="0.3048" layer="94"/>
+<text x="3.175" y="-2.54" size="1.27" layer="96" rot="R90">&gt;VALUE</text>
+<pin name="VCC" x="0" y="-2.54" visible="off" length="point" direction="sup"/>
+</symbol>
+<symbol name="GND">
+<wire x1="-1.905" y1="0" x2="0" y2="0" width="0.4064" layer="94"/>
+<wire x1="0" y1="0" x2="1.905" y2="0" width="0.4064" layer="94"/>
+<wire x1="0" y1="0" x2="0" y2="2.54" width="0.1524" layer="94"/>
+<pin name="GND" x="0" y="2.54" visible="off" length="point" direction="sup" rot="R270"/>
+</symbol>
+<symbol name="C">
+<wire x1="-5.08" y1="0" x2="-0.508" y2="0" width="0.1524" layer="94"/>
+<wire x1="-0.508" y1="1.524" x2="-0.508" y2="0" width="0.3048" layer="94"/>
+<wire x1="-0.508" y1="0" x2="-0.508" y2="-1.524" width="0.3048" layer="94"/>
+<wire x1="5.08" y1="0" x2="0.508" y2="0" width="0.1524" layer="94"/>
+<wire x1="0.508" y1="1.524" x2="0.508" y2="0" width="0.3048" layer="94"/>
+<wire x1="0.508" y1="0" x2="0.508" y2="-1.524" width="0.3048" layer="94"/>
+<text x="-1.27" y="2.54" size="1.27" layer="95">&gt;NAME</text>
+<text x="-1.905" y="-3.81" size="1.27" layer="96">&gt;VALUE</text>
+<pin name="1" x="-5.08" y="0" visible="off" length="point" direction="pas" swaplevel="1"/>
+<pin name="2" x="5.08" y="0" visible="off" length="point" direction="pas" swaplevel="1"/>
+</symbol>
+<symbol name="VCC-2">
+<wire x1="0" y1="0" x2="0" y2="2.54" width="0.1524" layer="94"/>
+<wire x1="0" y1="2.54" x2="-1.143" y2="0.762" width="0.3048" layer="94"/>
+<wire x1="0" y1="2.54" x2="1.143" y2="0.762" width="0.3048" layer="94"/>
+<text x="3.175" y="0" size="1.27" layer="96" rot="R90">&gt;VALUE</text>
+<pin name="VCC-2" x="0" y="0" visible="off" length="point" direction="sup"/>
+</symbol>
+<symbol name="POLYSW">
+<wire x1="5.08" y1="0" x2="2.54" y2="0" width="0.1524" layer="94"/>
+<wire x1="-2.54" y1="0" x2="-5.08" y2="0" width="0.1524" layer="94"/>
+<wire x1="2.54" y1="-1.27" x2="2.54" y2="0" width="0.1524" layer="94"/>
+<wire x1="2.54" y1="0" x2="2.54" y2="1.27" width="0.1524" layer="94"/>
+<wire x1="2.54" y1="1.27" x2="-2.54" y2="1.27" width="0.1524" layer="94"/>
+<wire x1="-2.54" y1="1.27" x2="-2.54" y2="0" width="0.1524" layer="94"/>
+<wire x1="-2.54" y1="0" x2="-2.54" y2="-1.27" width="0.1524" layer="94"/>
+<wire x1="-2.54" y1="-1.27" x2="2.54" y2="-1.27" width="0.1524" layer="94"/>
+<wire x1="-1.905" y1="1.905" x2="1.905" y2="-1.905" width="0.1524" layer="94"/>
+<text x="1.905" y="-1.905" size="1.27" layer="95" rot="R180">&gt;NAME</text>
+<text x="4.445" y="3.175" size="1.27" layer="96" rot="R180">&gt;VALUE</text>
+<text x="0.635" y="-0.635" size="1.27" layer="94">+t</text>
+<pin name="1" x="5.08" y="0" visible="off" length="point" direction="pas" swaplevel="1" rot="R180"/>
+<pin name="2" x="-5.08" y="0" visible="off" length="point" direction="pas" swaplevel="1"/>
+</symbol>
+<symbol name="TPS6104X">
+<wire x1="-7.62" y1="-8.255" x2="7.62" y2="-8.255" width="0.254" layer="94"/>
+<wire x1="7.62" y1="-8.255" x2="7.62" y2="13.335" width="0.254" layer="94"/>
+<wire x1="7.62" y1="13.335" x2="-7.62" y2="13.335" width="0.254" layer="94"/>
+<wire x1="-7.62" y1="13.335" x2="-7.62" y2="-8.255" width="0.254" layer="94"/>
+<pin name="FB" x="-10.16" y="-5.08" length="short" direction="pwr"/>
+<pin name="VIN" x="-10.16" y="10.16" length="short" direction="in"/>
+<pin name="CTRL" x="-10.16" y="5.08" length="short" direction="in"/>
+<pin name="GND" x="-10.16" y="0" length="short" direction="pwr"/>
+<pin name="RS" x="10.16" y="-5.08" length="short" direction="pas" rot="R180"/>
+<pin name="SW" x="10.16" y="10.16" length="short" direction="out" rot="R180"/>
+<pin name="OVP" x="10.16" y="5.08" length="short" direction="in" rot="R180"/>
+<pin name="LED" x="10.16" y="0" length="short" direction="pas" rot="R180"/>
+<pin name="EP" x="0" y="-11.43" visible="off" length="point" direction="pas"/>
+<text x="-3.175" y="13.97" size="1.27" layer="95">&gt;NAME</text>
+<text x="-9.525" y="-15.24" size="1.27" layer="96">&gt;VALUE</text>
+<text x="-3.81" y="-7.62" size="1.27" layer="94">PWR Pad</text>
+<wire x1="0" y1="-8.89" x2="0" y2="-11.43" width="0.254" layer="94" style="shortdash"/>
+</symbol>
+<symbol name="L">
+<wire x1="-3.81" y1="0" x2="-1.905" y2="0" width="0.1524" layer="94" curve="-180" cap="flat"/>
+<wire x1="-1.905" y1="0" x2="0" y2="0" width="0.1524" layer="94" curve="-180" cap="flat"/>
+<wire x1="0" y1="0" x2="1.905" y2="0" width="0.1524" layer="94" curve="-180" cap="flat"/>
+<wire x1="1.905" y1="0" x2="3.81" y2="0" width="0.1524" layer="94" curve="-180" cap="flat"/>
+<wire x1="3.81" y1="0" x2="5.08" y2="0" width="0.1524" layer="94"/>
+<wire x1="-5.08" y1="0" x2="-3.81" y2="0" width="0.1524" layer="94"/>
+<wire x1="-3.556" y1="1.905" x2="-2.159" y2="1.905" width="0.1524" layer="94"/>
+<wire x1="0.254" y1="1.905" x2="1.651" y2="1.905" width="0.1524" layer="94"/>
+<wire x1="-1.651" y1="1.905" x2="-0.254" y2="1.905" width="0.1524" layer="94"/>
+<wire x1="2.159" y1="1.905" x2="3.556" y2="1.905" width="0.1524" layer="94"/>
+<wire x1="-3.556" y1="1.524" x2="-2.159" y2="1.524" width="0.1524" layer="94"/>
+<wire x1="-1.651" y1="1.524" x2="-0.254" y2="1.524" width="0.1524" layer="94"/>
+<wire x1="0.254" y1="1.524" x2="1.651" y2="1.524" width="0.1524" layer="94"/>
+<wire x1="2.159" y1="1.524" x2="3.556" y2="1.524" width="0.1524" layer="94"/>
+<text x="-2.54" y="-1.905" size="1.27" layer="96">&gt;VALUE</text>
+<text x="-1.27" y="2.54" size="1.27" layer="95">&gt;NAME</text>
+<pin name="1" x="-5.08" y="0" visible="off" length="point" direction="pas" swaplevel="1"/>
+<pin name="2" x="5.08" y="0" visible="off" length="point" direction="pas" swaplevel="1" rot="R180"/>
+</symbol>
+<symbol name="RAM_A3">
+<wire x1="0" y1="0" x2="50.8" y2="0" width="0.1016" layer="96"/>
+<wire x1="50.8" y1="0" x2="98.425" y2="0" width="0.1016" layer="96"/>
+<wire x1="98.425" y1="0" x2="146.05" y2="0" width="0.1016" layer="96"/>
+<wire x1="146.05" y1="0" x2="193.675" y2="0" width="0.1016" layer="96"/>
+<wire x1="193.675" y1="0" x2="241.3" y2="0" width="0.1016" layer="96"/>
+<wire x1="241.3" y1="0" x2="288.925" y2="0" width="0.1016" layer="96"/>
+<wire x1="288.925" y1="0" x2="336.55" y2="0" width="0.1016" layer="96"/>
+<wire x1="336.55" y1="0" x2="387.35" y2="0" width="0.1016" layer="96"/>
+<wire x1="387.35" y1="0" x2="387.35" y2="53.975" width="0.1016" layer="96"/>
+<wire x1="387.35" y1="53.975" x2="387.35" y2="104.775" width="0.1016" layer="96"/>
+<wire x1="387.35" y1="104.775" x2="387.35" y2="155.575" width="0.1016" layer="96"/>
+<wire x1="387.35" y1="155.575" x2="387.35" y2="206.375" width="0.1016" layer="96"/>
+<wire x1="387.35" y1="206.375" x2="387.35" y2="260.35" width="0.1016" layer="96"/>
+<wire x1="146.05" y1="260.35" x2="98.425" y2="260.35" width="0.1524" layer="96"/>
+<wire x1="98.425" y1="260.35" x2="50.8" y2="260.35" width="0.1016" layer="96"/>
+<wire x1="50.8" y1="260.35" x2="0" y2="260.35" width="0.1016" layer="96"/>
+<wire x1="0" y1="260.35" x2="0" y2="206.375" width="0.1016" layer="96"/>
+<wire x1="0" y1="206.375" x2="0" y2="155.575" width="0.1016" layer="96"/>
+<wire x1="0" y1="155.575" x2="0" y2="104.775" width="0.1016" layer="96"/>
+<wire x1="0" y1="104.775" x2="0" y2="53.975" width="0.1016" layer="96"/>
+<wire x1="0" y1="53.975" x2="0" y2="0" width="0.1016" layer="96"/>
+<wire x1="3.175" y1="3.175" x2="50.8" y2="3.175" width="0.1016" layer="96"/>
+<wire x1="50.8" y1="3.175" x2="98.425" y2="3.175" width="0.1016" layer="96"/>
+<wire x1="98.425" y1="3.175" x2="146.05" y2="3.175" width="0.1016" layer="96"/>
+<wire x1="146.05" y1="3.175" x2="193.675" y2="3.175" width="0.1016" layer="96"/>
+<wire x1="193.675" y1="3.175" x2="241.3" y2="3.175" width="0.1016" layer="96"/>
+<wire x1="241.3" y1="3.175" x2="288.925" y2="3.175" width="0.1016" layer="96"/>
+<wire x1="288.925" y1="3.175" x2="336.55" y2="3.175" width="0.1016" layer="96"/>
+<wire x1="336.55" y1="3.175" x2="384.175" y2="3.175" width="0.1016" layer="96"/>
+<wire x1="384.175" y1="3.175" x2="384.175" y2="53.975" width="0.1016" layer="96"/>
+<wire x1="384.175" y1="53.975" x2="384.175" y2="104.775" width="0.1016" layer="96"/>
+<wire x1="384.175" y1="104.775" x2="384.175" y2="155.575" width="0.1016" layer="96"/>
+<wire x1="384.175" y1="155.575" x2="384.175" y2="206.375" width="0.1016" layer="96"/>
+<wire x1="384.175" y1="206.375" x2="384.175" y2="257.175" width="0.1016" layer="96"/>
+<wire x1="384.175" y1="257.175" x2="336.55" y2="257.175" width="0.1016" layer="96"/>
+<wire x1="336.55" y1="257.175" x2="288.925" y2="257.175" width="0.1016" layer="96"/>
+<wire x1="288.925" y1="257.175" x2="241.3" y2="257.175" width="0.1016" layer="96"/>
+<wire x1="241.3" y1="257.175" x2="193.675" y2="257.175" width="0.1016" layer="96"/>
+<wire x1="193.675" y1="257.175" x2="146.05" y2="257.175" width="0.1016" layer="96"/>
+<wire x1="146.05" y1="257.175" x2="98.425" y2="257.175" width="0.1524" layer="96"/>
+<wire x1="98.425" y1="257.175" x2="50.8" y2="257.175" width="0.1016" layer="96"/>
+<wire x1="50.8" y1="257.175" x2="3.175" y2="257.175" width="0.1016" layer="96"/>
+<wire x1="3.175" y1="257.175" x2="3.175" y2="206.375" width="0.1016" layer="96"/>
+<wire x1="3.175" y1="206.375" x2="3.175" y2="155.575" width="0.1016" layer="96"/>
+<wire x1="3.175" y1="155.575" x2="3.175" y2="104.775" width="0.1016" layer="96"/>
+<wire x1="3.175" y1="104.775" x2="3.175" y2="53.975" width="0.1016" layer="96"/>
+<wire x1="3.175" y1="53.975" x2="3.175" y2="3.175" width="0.1016" layer="96"/>
+<wire x1="387.35" y1="260.35" x2="336.55" y2="260.35" width="0.1016" layer="96"/>
+<wire x1="336.55" y1="260.35" x2="288.925" y2="260.35" width="0.1016" layer="96"/>
+<wire x1="288.925" y1="260.35" x2="241.3" y2="260.35" width="0.1016" layer="96"/>
+<wire x1="241.3" y1="260.35" x2="193.675" y2="260.35" width="0.1016" layer="96"/>
+<wire x1="193.675" y1="260.35" x2="146.05" y2="260.35" width="0.1016" layer="96"/>
+<wire x1="193.675" y1="260.35" x2="193.675" y2="257.175" width="0.1016" layer="96"/>
+<wire x1="193.675" y1="3.175" x2="193.675" y2="0" width="0.1016" layer="96"/>
+<wire x1="0" y1="104.775" x2="3.175" y2="104.775" width="0.1016" layer="96"/>
+<wire x1="384.175" y1="155.575" x2="387.35" y2="155.575" width="0.1016" layer="96"/>
+<wire x1="98.425" y1="257.175" x2="98.425" y2="260.35" width="0.1016" layer="96"/>
+<wire x1="98.425" y1="3.175" x2="98.425" y2="0" width="0.1016" layer="96"/>
+<wire x1="288.925" y1="260.35" x2="288.925" y2="257.175" width="0.1016" layer="96"/>
+<wire x1="288.925" y1="3.175" x2="288.925" y2="0" width="0.1016" layer="96"/>
+<wire x1="0" y1="53.975" x2="3.175" y2="53.975" width="0.1016" layer="96"/>
+<wire x1="384.175" y1="104.775" x2="387.35" y2="104.775" width="0.1016" layer="96"/>
+<wire x1="0" y1="155.575" x2="3.175" y2="155.575" width="0.1016" layer="96"/>
+<wire x1="384.175" y1="206.375" x2="387.35" y2="206.375" width="0.1016" layer="96"/>
+<wire x1="50.8" y1="257.175" x2="50.8" y2="260.35" width="0.1016" layer="96"/>
+<wire x1="0" y1="206.375" x2="3.175" y2="206.375" width="0.1016" layer="96"/>
+<wire x1="384.175" y1="53.975" x2="387.35" y2="53.975" width="0.1016" layer="96"/>
+<wire x1="146.05" y1="257.175" x2="146.05" y2="260.35" width="0.1016" layer="96"/>
+<wire x1="241.3" y1="260.35" x2="241.3" y2="257.175" width="0.1016" layer="96"/>
+<wire x1="336.55" y1="260.35" x2="336.55" y2="257.175" width="0.1016" layer="96"/>
+<wire x1="336.55" y1="3.175" x2="336.55" y2="0" width="0.1016" layer="96"/>
+<wire x1="241.3" y1="3.175" x2="241.3" y2="0" width="0.1016" layer="96"/>
+<wire x1="146.05" y1="3.175" x2="146.05" y2="0" width="0.1016" layer="96"/>
+<wire x1="50.8" y1="0" x2="50.8" y2="3.175" width="0.1016" layer="96"/>
+<text x="24.384" y="0.254" size="2.54" layer="96">A</text>
+<text x="74.422" y="0.254" size="2.54" layer="96">B</text>
+<text x="121.158" y="0.254" size="2.54" layer="96">C</text>
+<text x="169.418" y="0.254" size="2.54" layer="96">D</text>
+<text x="216.916" y="0.254" size="2.54" layer="96">E</text>
+<text x="263.652" y="0.254" size="2.54" layer="96">F</text>
+<text x="310.642" y="0.254" size="2.54" layer="96">G</text>
+<text x="360.934" y="0.254" size="2.54" layer="96">H</text>
+<text x="385.064" y="28.702" size="2.54" layer="96">1</text>
+<text x="384.81" y="79.502" size="2.54" layer="96">2</text>
+<text x="384.81" y="130.302" size="2.54" layer="96">3</text>
+<text x="384.81" y="181.864" size="2.54" layer="96">4</text>
+<text x="384.81" y="231.14" size="2.54" layer="96">5</text>
+<text x="361.188" y="257.556" size="2.54" layer="96">H</text>
+<text x="311.404" y="257.556" size="2.54" layer="96">G</text>
+<text x="262.89" y="257.556" size="2.54" layer="96">F</text>
+<text x="215.9" y="257.556" size="2.54" layer="96">E</text>
+<text x="168.148" y="257.556" size="2.54" layer="96">D</text>
+<text x="120.904" y="257.556" size="2.54" layer="96">C</text>
+<text x="72.898" y="257.556" size="2.54" layer="96">B</text>
+<text x="24.384" y="257.556" size="2.54" layer="96">A</text>
+<text x="0.762" y="231.14" size="2.54" layer="96">5</text>
+<text x="0.762" y="181.61" size="2.54" layer="96">4</text>
+<text x="0.762" y="130.302" size="2.54" layer="96">3</text>
+<text x="0.762" y="79.248" size="2.54" layer="96">2</text>
+<text x="1.016" y="26.67" size="2.54" layer="96">1</text>
+</symbol>
+<symbol name="RAM_RAZ">
+<wire x1="71.0184" y1="3.81" x2="115.57" y2="3.81" width="0.1524" layer="96"/>
+<wire x1="115.57" y1="3.81" x2="115.57" y2="0" width="0.1524" layer="96"/>
+<wire x1="115.57" y1="0" x2="132.08" y2="0" width="0.3048" layer="96"/>
+<wire x1="115.57" y1="3.81" x2="132.08" y2="3.81" width="0.1524" layer="96"/>
+<wire x1="71.247" y1="15.875" x2="71.247" y2="16.51" width="0.4064" layer="96"/>
+<wire x1="71.12" y1="7.62" x2="131.8514" y2="7.62" width="0.762" layer="96"/>
+<wire x1="71.12" y1="17.78" x2="0" y2="17.78" width="0.3048" layer="96"/>
+<wire x1="0" y1="27.305" x2="71.12" y2="27.305" width="0.3048" layer="96"/>
+<wire x1="71.12" y1="27.305" x2="132.08" y2="27.305" width="0.3048" layer="96"/>
+<wire x1="132.08" y1="3.81" x2="132.08" y2="0" width="0.3048" layer="96"/>
+<wire x1="131.8514" y1="7.62" x2="132.08" y2="7.62" width="0.3048" layer="96"/>
+<wire x1="132.08" y1="7.62" x2="132.08" y2="3.81" width="0.3048" layer="96"/>
+<wire x1="132.08" y1="27.305" x2="132.08" y2="20.193" width="0.3048" layer="96"/>
+<wire x1="132.08" y1="20.193" x2="131.826" y2="20.193" width="0.3048" layer="96"/>
+<wire x1="131.826" y1="20.193" x2="131.8514" y2="20.0914" width="0.3048" layer="96"/>
+<wire x1="71.12" y1="20.0914" x2="131.8514" y2="20.0914" width="0.762" layer="96"/>
+<wire x1="131.8514" y1="20.0914" x2="131.8514" y2="15.875" width="0.762" layer="96"/>
+<wire x1="131.8514" y1="15.875" x2="131.8514" y2="7.62" width="0.762" layer="96"/>
+<wire x1="0" y1="0" x2="52.07" y2="0" width="0.3048" layer="96"/>
+<wire x1="52.07" y1="0" x2="70.993" y2="0" width="0.3048" layer="96"/>
+<wire x1="70.993" y1="0" x2="115.57" y2="0" width="0.3048" layer="96"/>
+<wire x1="70.993" y1="12.7" x2="52.07" y2="12.7" width="0.4064" layer="96"/>
+<wire x1="52.07" y1="12.7" x2="0" y2="12.7" width="0.1524" layer="96"/>
+<wire x1="0" y1="0" x2="0" y2="5.08" width="0.3048" layer="96"/>
+<wire x1="0" y1="5.08" x2="0" y2="8.89" width="0.3048" layer="96"/>
+<wire x1="0" y1="8.89" x2="0" y2="12.7" width="0.3048" layer="96"/>
+<wire x1="0" y1="12.7" x2="0" y2="17.78" width="0.3048" layer="96"/>
+<wire x1="0" y1="17.78" x2="0" y2="27.178" width="0.3048" layer="96"/>
+<wire x1="0" y1="27.178" x2="0" y2="27.305" width="0.3048" layer="96"/>
+<wire x1="0" y1="8.89" x2="52.07" y2="8.89" width="0.4064" layer="96"/>
+<wire x1="52.07" y1="8.89" x2="71.12" y2="8.89" width="0.1524" layer="96"/>
+<wire x1="0" y1="5.08" x2="70.9168" y2="5.08" width="0.1524" layer="96"/>
+<wire x1="52.07" y1="12.7" x2="52.07" y2="8.89" width="0.4064" layer="96"/>
+<wire x1="52.07" y1="8.89" x2="52.07" y2="0" width="0.1524" layer="96"/>
+<wire x1="71.12" y1="20.0914" x2="71.12" y2="27.305" width="0.254" layer="96"/>
+<wire x1="71.247" y1="15.875" x2="131.8514" y2="15.875" width="0.254" layer="96"/>
+<wire x1="71.12" y1="7.62" x2="71.12" y2="8.89" width="0.762" layer="96"/>
+<wire x1="71.12" y1="8.89" x2="71.12" y2="17.78" width="0.762" layer="96"/>
+<wire x1="71.12" y1="17.78" x2="71.12" y2="19.9136" width="0.762" layer="96"/>
+<wire x1="71.12" y1="7.62" x2="70.993" y2="7.62" width="0.4064" layer="96"/>
+<wire x1="70.993" y1="7.62" x2="70.993" y2="0" width="0.4064" layer="96"/>
+<wire x1="0" y1="34.925" x2="132.08" y2="34.925" width="0.3048" layer="96"/>
+<wire x1="0" y1="27.178" x2="0" y2="34.925" width="0.3048" layer="96"/>
+<wire x1="132.08" y1="34.925" x2="132.08" y2="27.305" width="0.3048" layer="96"/>
+<text x="83.185" y="4.445" size="1.524" layer="96">&gt;LAST_DATE_TIME</text>
+<text x="123.825" y="1.27" size="1.524" layer="96">&gt;SHEET</text>
+<text x="116.205" y="1.27" size="1.524" layer="96">LIST:</text>
+<text x="83.185" y="0.762" size="1.524" layer="96">&gt;PLOT_DATE_TIME</text>
+<text x="117.094" y="9.525" size="5.08" layer="96" ratio="15">SCH</text>
+<text x="73.025" y="9.525" size="5.08" layer="96" ratio="15">&gt;DRAWING_NAME</text>
+<text x="1.27" y="24.13" size="1.524" layer="96">NAZEV VYROBKU:</text>
+<text x="1.27" y="6.096" size="1.524" layer="96">VYPRACOVAL:</text>
+<text x="57.404" y="9.906" size="1.524" layer="96">DATUM:</text>
+<text x="72.39" y="4.445" size="1.524" layer="96">UPRAVA:</text>
+<text x="72.39" y="0.762" size="1.524" layer="96">TISK:</text>
+<text x="1.27" y="2.032" size="1.524" layer="96">SCHVALIL:</text>
+<text x="73.025" y="17.145" size="1.524" layer="96">OZNACENI SOUBORU:</text>
+<text x="1.27" y="13.716" size="1.524" layer="96">VERZE:</text>
+<text x="1.2954" y="10.3124" size="1.524" layer="96">Format vykresu: Eagle 7.4.0</text>
+<text x="8.89" y="31.496" size="1.9304" layer="96" ratio="10">JabloPCB s.r.o.</text>
+<text x="8.89" y="28.956" size="1.524" layer="96">www.jablopcb.cz</text>
+<text x="72.644" y="24.892" size="1.524" layer="96">Urceno pro firmu:</text>
+<text x="80.01" y="28.956" size="1.524" layer="96">tel.,fax. +420 483 515 515</text>
+<text x="49.53" y="28.956" size="1.524" layer="96">jablopcb@jablopcb.cz</text>
+<text x="39.116" y="31.496" size="1.524" layer="96">U Prehrady 5129/67, 466 01 Jablonec n.N., CZ</text>
+<text x="1.27" y="24.13" size="1.524" layer="96">NAZEV VYROBKU:</text>
+<text x="1.27" y="19.05" size="1.524" layer="96">VARIANTA OSAZENI:</text>
+<text x="36.83" y="19.05" size="1.524" layer="96">&gt;assembly_variant</text>
+</symbol>
+<symbol name="MB">
+<wire x1="2.54" y1="0" x2="0" y2="0" width="0.1524" layer="94"/>
+<circle x="-0.635" y="0" radius="0.635" width="0.1524" layer="94"/>
+<circle x="-0.635" y="0" radius="0.2839" width="0.635" layer="94"/>
+<text x="-1.27" y="2.54" size="1.27" layer="95">&gt;NAME</text>
+<pin name="1" x="2.54" y="0" visible="off" length="point" direction="pas" rot="R180"/>
+</symbol>
+<symbol name="VBAT">
+<wire x1="0" y1="0" x2="0" y2="2.54" width="0.1524" layer="94"/>
+<wire x1="0" y1="2.54" x2="-1.143" y2="0.762" width="0.3048" layer="94"/>
+<wire x1="0" y1="2.54" x2="1.143" y2="0.762" width="0.3048" layer="94"/>
+<text x="3.175" y="0" size="1.27" layer="96" rot="R90">&gt;VALUE</text>
+<pin name="VBAT" x="0" y="0" visible="off" length="point" direction="sup"/>
+</symbol>
+</symbols>
+<devicesets>
+<deviceset name="DS" prefix="D" uservalue="yes">
+<gates>
+<gate name="G$1" symbol="DS" x="0" y="0"/>
+</gates>
+<devices>
+<device name="_MELF" package="MELF">
+<connects>
+<connect gate="G$1" pin="1" pad="1"/>
+<connect gate="G$1" pin="2" pad="2"/>
+</connects>
+<technologies>
+<technology name=""/>
+</technologies>
+</device>
+<device name="_DO214AC" package="DO214AC">
+<connects>
+<connect gate="G$1" pin="1" pad="1"/>
+<connect gate="G$1" pin="2" pad="2"/>
+</connects>
+<technologies>
+<technology name=""/>
+</technologies>
+</device>
+<device name="_DO241AA" package="DO241AA">
+<connects>
+<connect gate="G$1" pin="1" pad="A"/>
+<connect gate="G$1" pin="2" pad="K"/>
+</connects>
+<technologies>
+<technology name=""/>
+</technologies>
+</device>
+<device name="_DO15" package="DO15">
+<connects>
+<connect gate="G$1" pin="1" pad="A"/>
+<connect gate="G$1" pin="2" pad="K"/>
+</connects>
+<technologies>
+<technology name=""/>
+</technologies>
+</device>
+<device name="_DO15$1S" package="DO15$1S">
+<connects>
+<connect gate="G$1" pin="1" pad="A"/>
+<connect gate="G$1" pin="2" pad="K"/>
+</connects>
+<technologies>
+<technology name=""/>
+</technologies>
+</device>
+<device name="_DO214AB" package="DO214AB">
+<connects>
+<connect gate="G$1" pin="1" pad="A"/>
+<connect gate="G$1" pin="2" pad="C"/>
+</connects>
+<technologies>
+<technology name=""/>
+</technologies>
+</device>
+<device name="_DO214AA" package="DO214AA">
+<connects>
+<connect gate="G$1" pin="1" pad="A"/>
+<connect gate="G$1" pin="2" pad="K"/>
+</connects>
+<technologies>
+<technology name=""/>
+</technologies>
+</device>
+<device name="_SOD80" package="SOD80">
+<connects>
+<connect gate="G$1" pin="1" pad="1"/>
+<connect gate="G$1" pin="2" pad="2"/>
+</connects>
+<technologies>
+<technology name=""/>
+</technologies>
+</device>
+<device name="_SOD128" package="SOD128">
+<connects>
+<connect gate="G$1" pin="1" pad="A"/>
+<connect gate="G$1" pin="2" pad="K"/>
+</connects>
+<technologies>
+<technology name=""/>
+</technologies>
+</device>
+<device name="_SOD123W" package="SOD123W">
+<connects>
+<connect gate="G$1" pin="1" pad="A"/>
+<connect gate="G$1" pin="2" pad="K"/>
+</connects>
+<technologies>
+<technology name=""/>
+</technologies>
+</device>
+<device name="_SOD323" package="SOD323">
+<connects>
+<connect gate="G$1" pin="1" pad="A"/>
+<connect gate="G$1" pin="2" pad="K"/>
+</connects>
+<technologies>
+<technology name=""/>
+</technologies>
+</device>
+<device name="_SOD123" package="SOD123">
+<connects>
+<connect gate="G$1" pin="1" pad="A"/>
+<connect gate="G$1" pin="2" pad="K"/>
+</connects>
+<technologies>
+<technology name=""/>
+</technologies>
+</device>
+<device name="_SOD323F" package="SOD323F">
+<connects>
+<connect gate="G$1" pin="1" pad="A"/>
+<connect gate="G$1" pin="2" pad="K"/>
+</connects>
+<technologies>
+<technology name=""/>
+</technologies>
+</device>
+<device name="_SOD123F" package="SOD123F">
+<connects>
+<connect gate="G$1" pin="1" pad="A"/>
+<connect gate="G$1" pin="2" pad="K"/>
+</connects>
+<technologies>
+<technology name=""/>
+</technologies>
+</device>
+</devices>
+</deviceset>
+<deviceset name="PRTR5V0" prefix="D" uservalue="yes">
+<gates>
+<gate name="G$1" symbol="PRTR5V0" x="2.54" y="0"/>
+</gates>
+<devices>
+<device name="_SOT143B" package="SOT143B">
+<connects>
+<connect gate="G$1" pin="GND" pad="1"/>
+<connect gate="G$1" pin="I/O1" pad="2"/>
+<connect gate="G$1" pin="I/O2" pad="3"/>
+<connect gate="G$1" pin="VCC" pad="4"/>
+</connects>
+<technologies>
+<technology name=""/>
+</technologies>
+</device>
+<device name="_SOT143B$REFLOW" package="SOT143B_REFLOW">
+<connects>
+<connect gate="G$1" pin="GND" pad="1"/>
+<connect gate="G$1" pin="I/O1" pad="2"/>
+<connect gate="G$1" pin="I/O2" pad="3"/>
+<connect gate="G$1" pin="VCC" pad="4"/>
+</connects>
+<technologies>
+<technology name=""/>
+</technologies>
+</device>
+</devices>
+</deviceset>
+<deviceset name="R" prefix="R" uservalue="yes">
+<gates>
+<gate name="G$1" symbol="R" x="0" y="0"/>
+</gates>
+<devices>
+<device name="_0805" package="0805">
+<connects>
+<connect gate="G$1" pin="1" pad="1"/>
+<connect gate="G$1" pin="2" pad="2"/>
+</connects>
+<technologies>
+<technology name=""/>
+</technologies>
+</device>
+<device name="_0207" package="0207">
+<connects>
+<connect gate="G$1" pin="1" pad="1"/>
+<connect gate="G$1" pin="2" pad="2"/>
+</connects>
+<technologies>
+<technology name=""/>
+</technologies>
+</device>
+<device name="_1206" package="1206">
+<connects>
+<connect gate="G$1" pin="1" pad="1"/>
+<connect gate="G$1" pin="2" pad="2"/>
+</connects>
+<technologies>
+<technology name=""/>
+</technologies>
+</device>
+<device name="_0207$ST_1" package="0207$ST_1">
+<connects>
+<connect gate="G$1" pin="1" pad="1"/>
+<connect gate="G$1" pin="2" pad="2"/>
+</connects>
+<technologies>
+<technology name=""/>
+</technologies>
+</device>
+<device name="_0207$ST_2" package="0207$ST_2">
+<connects>
+<connect gate="G$1" pin="1" pad="1"/>
+<connect gate="G$1" pin="2" pad="2"/>
+</connects>
+<technologies>
+<technology name=""/>
+</technologies>
+</device>
+<device name="_0207$ST18_2" package="0207$ST18_2">
+<connects>
+<connect gate="G$1" pin="1" pad="1"/>
+<connect gate="G$1" pin="2" pad="2"/>
+</connects>
+<technologies>
+<technology name=""/>
+</technologies>
+</device>
+<device name="_0207$ST18_1" package="0207$ST18_1">
+<connects>
+<connect gate="G$1" pin="1" pad="1"/>
+<connect gate="G$1" pin="2" pad="2"/>
+</connects>
+<technologies>
+<technology name=""/>
+</technologies>
+</device>
+<device name="_9,5/22" package="R9,5/22">
+<connects>
+<connect gate="G$1" pin="1" pad="1"/>
+<connect gate="G$1" pin="2" pad="2"/>
+</connects>
+<technologies>
+<technology name=""/>
+</technologies>
+</device>
+<device name="_9,5/22$ST" package="R9,5/22$ST">
+<connects>
+<connect gate="G$1" pin="1" pad="1"/>
+<connect gate="G$1" pin="2" pad="2"/>
+</connects>
+<technologies>
+<technology name=""/>
+</technologies>
+</device>
+<device name="_9,5/48" package="R9,5/48">
+<connects>
+<connect gate="G$1" pin="1" pad="1"/>
+<connect gate="G$1" pin="2" pad="2"/>
+</connects>
+<technologies>
+<technology name=""/>
+</technologies>
+</device>
+<device name="_2X5W" package="R_2X5W">
+<connects>
+<connect gate="G$1" pin="1" pad="1"/>
+<connect gate="G$1" pin="2" pad="2"/>
+</connects>
+<technologies>
+<technology name=""/>
+</technologies>
+</device>
+<device name="_0207$1S_90" package="0207$1S_90">
+<connects>
+<connect gate="G$1" pin="1" pad="1"/>
+<connect gate="G$1" pin="2" pad="2"/>
+</connects>
+<technologies>
+<technology name=""/>
+</technologies>
+</device>
+<device name="_0207$1S" package="0207$1S">
+<connects>
+<connect gate="G$1" pin="1" pad="1"/>
+<connect gate="G$1" pin="2" pad="2"/>
+</connects>
+<technologies>
+<technology name=""/>
+</technologies>
+</device>
+<device name="_0414" package="R_2W">
+<connects>
+<connect gate="G$1" pin="1" pad="1"/>
+<connect gate="G$1" pin="2" pad="2"/>
+</connects>
+<technologies>
+<technology name=""/>
+</technologies>
+</device>
+<device name="WSC6927" package="WSC6927">
+<connects>
+<connect gate="G$1" pin="1" pad="1"/>
+<connect gate="G$1" pin="2" pad="2"/>
+</connects>
+<technologies>
+<technology name=""/>
+</technologies>
+</device>
+<device name="_0603" package="0603">
+<connects>
+<connect gate="G$1" pin="1" pad="1"/>
+<connect gate="G$1" pin="2" pad="2"/>
+</connects>
+<technologies>
+<technology name=""/>
+</technologies>
+</device>
+<device name="_2010" package="2010">
+<connects>
+<connect gate="G$1" pin="1" pad="1"/>
+<connect gate="G$1" pin="2" pad="2"/>
+</connects>
+<technologies>
+<technology name=""/>
+</technologies>
+</device>
+<device name="_2W_1" package="R_2W_1">
+<connects>
+<connect gate="G$1" pin="1" pad="1"/>
+<connect gate="G$1" pin="2" pad="2"/>
+</connects>
+<technologies>
+<technology name=""/>
+</technologies>
+</device>
+<device name="_0402" package="0402">
+<connects>
+<connect gate="G$1" pin="1" pad="P$1"/>
+<connect gate="G$1" pin="2" pad="P$2"/>
+</connects>
+<technologies>
+<technology name=""/>
+</technologies>
+</device>
+<device name="_1206$SMALL" package="1206$SMALL">
+<connects>
+<connect gate="G$1" pin="1" pad="1"/>
+<connect gate="G$1" pin="2" pad="2"/>
+</connects>
+<technologies>
+<technology name=""/>
+</technologies>
+</device>
+<device name="_0207$ST_HV" package="0207$ST_HV">
+<connects>
+<connect gate="G$1" pin="1" pad="1"/>
+<connect gate="G$1" pin="2" pad="2"/>
+</connects>
+<technologies>
+<technology name=""/>
+</technologies>
+</device>
+<device name="_2512" package="2512">
+<connects>
+<connect gate="G$1" pin="1" pad="1"/>
+<connect gate="G$1" pin="2" pad="2"/>
+</connects>
+<technologies>
+<technology name=""/>
+</technologies>
+</device>
+<device name="_6,5/17,5" package="R6,5/17,5">
+<connects>
+<connect gate="G$1" pin="1" pad="1"/>
+<connect gate="G$1" pin="2" pad="2"/>
+</connects>
+<technologies>
+<technology name=""/>
+</technologies>
+</device>
+<device name="_8X44$ST" package="R8/44$ST">
+<connects>
+<connect gate="G$1" pin="1" pad="1"/>
+<connect gate="G$1" pin="2" pad="2"/>
+</connects>
+<technologies>
+<technology name=""/>
+</technologies>
+</device>
+<device name="_9,5/25" package="R9,5/25">
+<connects>
+<connect gate="G$1" pin="1" pad="1"/>
+<connect gate="G$1" pin="2" pad="2"/>
+</connects>
+<technologies>
+<technology name=""/>
+</technologies>
+</device>
+<device name="_0201" package="0201">
+<connects>
+<connect gate="G$1" pin="1" pad="1"/>
+<connect gate="G$1" pin="2" pad="2"/>
+</connects>
+<technologies>
+<technology name=""/>
+</technologies>
+</device>
+<device name="_R_4X3,8" package="R_4X3,8_ST">
+<connects>
+<connect gate="G$1" pin="1" pad="1"/>
+<connect gate="G$1" pin="2" pad="2"/>
+</connects>
+<technologies>
+<technology name=""/>
+</technologies>
+</device>
+<device name="_3,6X9" package="R3,6X9">
+<connects>
+<connect gate="G$1" pin="1" pad="1"/>
+<connect gate="G$1" pin="2" pad="2"/>
+</connects>
+<technologies>
+<technology name=""/>
+</technologies>
+</device>
+<device name="_14/60" package="R14/60">
+<connects>
+<connect gate="G$1" pin="1" pad="1"/>
+<connect gate="G$1" pin="2" pad="2"/>
+</connects>
+<technologies>
+<technology name=""/>
+</technologies>
+</device>
+<device name="_14/16$1S" package="R14/60$1S">
+<connects>
+<connect gate="G$1" pin="1" pad="1"/>
+<connect gate="G$1" pin="2" pad="2"/>
+</connects>
+<technologies>
+<technology name=""/>
+</technologies>
+</device>
+<device name="_0207$ST_1_90" package="0207$ST_1_90">
+<connects>
+<connect gate="G$1" pin="1" pad="1"/>
+<connect gate="G$1" pin="2" pad="2"/>
+</connects>
+<technologies>
+<technology name=""/>
+</technologies>
+</device>
+<device name="_1210" package="1210">
+<connects>
+<connect gate="G$1" pin="1" pad="1"/>
+<connect gate="G$1" pin="2" pad="2"/>
+</connects>
+<technologies>
+<technology name=""/>
+</technologies>
+</device>
+<device name="_1812" package="1812">
+<connects>
+<connect gate="G$1" pin="1" pad="1"/>
+<connect gate="G$1" pin="2" pad="2"/>
+</connects>
+<technologies>
+<technology name=""/>
+</technologies>
+</device>
+<device name="_1206$LED" package="1206$LED">
+<connects>
+<connect gate="G$1" pin="1" pad="1"/>
+<connect gate="G$1" pin="2" pad="2"/>
+</connects>
+<technologies>
+<technology name=""/>
+</technologies>
+</device>
+<device name="_1210$REFLOW" package="1210_REFLOW">
+<connects>
+<connect gate="G$1" pin="1" pad="1"/>
+<connect gate="G$1" pin="2" pad="2"/>
+</connects>
+<technologies>
+<technology name=""/>
+</technologies>
+</device>
+<device name="_0603$REFLOW" package="0603_REFLOW">
+<connects>
+<connect gate="G$1" pin="1" pad="1"/>
+<connect gate="G$1" pin="2" pad="2"/>
+</connects>
+<technologies>
+<technology name=""/>
+</technologies>
+</device>
+<device name="_1206$REFLOW" package="1206_REFLOW">
+<connects>
+<connect gate="G$1" pin="1" pad="1"/>
+<connect gate="G$1" pin="2" pad="2"/>
+</connects>
+<technologies>
+<technology name=""/>
+</technologies>
+</device>
+<device name="_0805$REFLOW" package="0805_REFLOW">
+<connects>
+<connect gate="G$1" pin="1" pad="1"/>
+<connect gate="G$1" pin="2" pad="2"/>
+</connects>
+<technologies>
+<technology name=""/>
+</technologies>
+</device>
+<device name="_2010$REFLOW" package="2010_REFLOW">
+<connects>
+<connect gate="G$1" pin="1" pad="1"/>
+<connect gate="G$1" pin="2" pad="2"/>
+</connects>
+<technologies>
+<technology name=""/>
+</technologies>
+</device>
+<device name="_1812$REFLOW" package="1812_REFLOW">
+<connects>
+<connect gate="G$1" pin="1" pad="1"/>
+<connect gate="G$1" pin="2" pad="2"/>
+</connects>
+<technologies>
+<technology name=""/>
+</technologies>
+</device>
+<device name="_2512$REFLOW" package="2512_REFLOW">
+<connects>
+<connect gate="G$1" pin="1" pad="1"/>
+<connect gate="G$1" pin="2" pad="2"/>
+</connects>
+<technologies>
+<technology name=""/>
+</technologies>
+</device>
+<device name="_R_5.5X16" package="R_5,5X16">
+<connects>
+<connect gate="G$1" pin="1" pad="1"/>
+<connect gate="G$1" pin="2" pad="2"/>
+</connects>
+<technologies>
+<technology name=""/>
+</technologies>
+</device>
+</devices>
+</deviceset>
+<deviceset name="VCC">
+<gates>
+<gate name="G$1" symbol="VCC" x="0" y="0"/>
+</gates>
+<devices>
+<device name="">
+<technologies>
+<technology name=""/>
+</technologies>
+</device>
+</devices>
+</deviceset>
+<deviceset name="GND" uservalue="yes">
+<gates>
+<gate name="G$1" symbol="GND" x="0" y="0"/>
+</gates>
+<devices>
+<device name="">
+<technologies>
+<technology name=""/>
+</technologies>
+</device>
+</devices>
+</deviceset>
+<deviceset name="C" prefix="C" uservalue="yes">
+<gates>
+<gate name="G$1" symbol="C" x="2.54" y="0"/>
+</gates>
+<devices>
+<device name="_0805" package="0805">
+<connects>
+<connect gate="G$1" pin="1" pad="1"/>
+<connect gate="G$1" pin="2" pad="2"/>
+</connects>
+<technologies>
+<technology name=""/>
+</technologies>
+</device>
+<device name="_RM5" package="RM5">
+<connects>
+<connect gate="G$1" pin="1" pad="1"/>
+<connect gate="G$1" pin="2" pad="2"/>
+</connects>
+<technologies>
+<technology name=""/>
+</technologies>
+</device>
+<device name="_RM5$1S" package="RM5$1S">
+<connects>
+<connect gate="G$1" pin="1" pad="1"/>
+<connect gate="G$1" pin="2" pad="2"/>
+</connects>
+<technologies>
+<technology name=""/>
+</technologies>
+</device>
+<device name="_RM14$1S" package="RM14$1S">
+<connects>
+<connect gate="G$1" pin="1" pad="1"/>
+<connect gate="G$1" pin="2" pad="2"/>
+</connects>
+<technologies>
+<technology name=""/>
+</technologies>
+</device>
+<device name="_1206" package="1206">
+<connects>
+<connect gate="G$1" pin="1" pad="1"/>
+<connect gate="G$1" pin="2" pad="2"/>
+</connects>
+<technologies>
+<technology name=""/>
+</technologies>
+</device>
+<device name="_0603" package="0603">
+<connects>
+<connect gate="G$1" pin="1" pad="1"/>
+<connect gate="G$1" pin="2" pad="2"/>
+</connects>
+<technologies>
+<technology name=""/>
+</technologies>
+</device>
+<device name="_RM22,5" package="C_225-074X268">
+<connects>
+<connect gate="G$1" pin="1" pad="1"/>
+<connect gate="G$1" pin="2" pad="2"/>
+</connects>
+<technologies>
+<technology name=""/>
+</technologies>
+</device>
+<device name="_RM10" package="RM10">
+<connects>
+<connect gate="G$1" pin="1" pad="1"/>
+<connect gate="G$1" pin="2" pad="2"/>
+</connects>
+<technologies>
+<technology name=""/>
+</technologies>
+</device>
+<device name="_RM22,5$1S" package="C-225-074X268$1S">
+<connects>
+<connect gate="G$1" pin="1" pad="1"/>
+<connect gate="G$1" pin="2" pad="2"/>
+</connects>
+<technologies>
+<technology name=""/>
+</technologies>
+</device>
+<device name="_RM10$1S" package="RM10$1S">
+<connects>
+<connect gate="G$1" pin="1" pad="1"/>
+<connect gate="G$1" pin="2" pad="2"/>
+</connects>
+<technologies>
+<technology name=""/>
+</technologies>
+</device>
+<device name="_RM15$1S" package="C-150-050X180$1S">
+<connects>
+<connect gate="G$1" pin="1" pad="1"/>
+<connect gate="G$1" pin="2" pad="2"/>
+</connects>
+<technologies>
+<technology name=""/>
+</technologies>
+</device>
+<device name="_C127_180X320" package="C_275_180X320">
+<connects>
+<connect gate="G$1" pin="1" pad="P$1"/>
+<connect gate="G$1" pin="2" pad="P$2"/>
+</connects>
+<technologies>
+<technology name=""/>
+</technologies>
+</device>
+<device name="_375_20X40" package="C_375_20X40">
+<connects>
+<connect gate="G$1" pin="1" pad="P$1"/>
+<connect gate="G$1" pin="2" pad="P$2"/>
+</connects>
+<technologies>
+<technology name=""/>
+</technologies>
+</device>
+<device name="_0402" package="0402">
+<connects>
+<connect gate="G$1" pin="1" pad="P$1"/>
+<connect gate="G$1" pin="2" pad="P$2"/>
+</connects>
+<technologies>
+<technology name=""/>
+</technologies>
+</device>
+<device name="_1210" package="1210">
+<connects>
+<connect gate="G$1" pin="1" pad="1"/>
+<connect gate="G$1" pin="2" pad="2"/>
+</connects>
+<technologies>
+<technology name=""/>
+</technologies>
+</device>
+<device name="_C102_054X133" package="C-102-054X133$1S">
+<connects>
+<connect gate="G$1" pin="1" pad="1"/>
+<connect gate="G$1" pin="2" pad="2"/>
+</connects>
+<technologies>
+<technology name=""/>
+</technologies>
+</device>
+<device name="_1206$SMALL" package="1206$SMALL">
+<connects>
+<connect gate="G$1" pin="1" pad="1"/>
+<connect gate="G$1" pin="2" pad="2"/>
+</connects>
+<technologies>
+<technology name=""/>
+</technologies>
+</device>
+<device name="_C102_054X133$S1" package="C-102-054X133$S1">
+<connects>
+<connect gate="G$1" pin="1" pad="1"/>
+<connect gate="G$1" pin="2" pad="2"/>
+</connects>
+<technologies>
+<technology name=""/>
+</technologies>
+</device>
+<device name="_RM5$1S90" package="RM5$1S90">
+<connects>
+<connect gate="G$1" pin="1" pad="1"/>
+<connect gate="G$1" pin="2" pad="2"/>
+</connects>
+<technologies>
+<technology name=""/>
+</technologies>
+</device>
+<device name="_RM22,5$1S90" package="C-225-074X268$1S90">
+<connects>
+<connect gate="G$1" pin="1" pad="1"/>
+<connect gate="G$1" pin="2" pad="2"/>
+</connects>
+<technologies>
+<technology name=""/>
+</technologies>
+</device>
+<device name="_0201" package="0201">
+<connects>
+<connect gate="G$1" pin="1" pad="1"/>
+<connect gate="G$1" pin="2" pad="2"/>
+</connects>
+<technologies>
+<technology name=""/>
+</technologies>
+</device>
+<device name="_C-150-050X180" package="C-150-050X180">
+<connects>
+<connect gate="G$1" pin="1" pad="1"/>
+<connect gate="G$1" pin="2" pad="2"/>
+</connects>
+<technologies>
+<technology name=""/>
+</technologies>
+</device>
+<device name="_C-102-054C133" package="C-102-054X133">
+<connects>
+<connect gate="G$1" pin="1" pad="1"/>
+<connect gate="G$1" pin="2" pad="2"/>
+</connects>
+<technologies>
+<technology name=""/>
+</technologies>
+</device>
+<device name="_C-075_050X105" package="C-075_050X105">
+<connects>
+<connect gate="G$1" pin="1" pad="1"/>
+<connect gate="G$1" pin="2" pad="2"/>
+</connects>
+<technologies>
+<technology name=""/>
+</technologies>
+</device>
+<device name="_RM7,5" package="RM7,5">
+<connects>
+<connect gate="G$1" pin="1" pad="1"/>
+<connect gate="G$1" pin="2" pad="2"/>
+</connects>
+<technologies>
+<technology name=""/>
+</technologies>
+</device>
+<device name="C275_180X320" package="C_275_180X320">
+<connects>
+<connect gate="G$1" pin="1" pad="P$1"/>
+<connect gate="G$1" pin="2" pad="P$2"/>
+</connects>
+<technologies>
+<technology name=""/>
+</technologies>
+</device>
+<device name="_1812" package="1812">
+<connects>
+<connect gate="G$1" pin="1" pad="1"/>
+<connect gate="G$1" pin="2" pad="2"/>
+</connects>
+<technologies>
+<technology name=""/>
+</technologies>
+</device>
+<device name="_2,5/6" package="B2,5/6">
+<connects>
+<connect gate="G$1" pin="1" pad="1"/>
+<connect gate="G$1" pin="2" pad="2"/>
+</connects>
+<technologies>
+<technology name=""/>
+</technologies>
+</device>
+<device name="_0603$REFLOW" package="0603_REFLOW">
+<connects>
+<connect gate="G$1" pin="1" pad="1"/>
+<connect gate="G$1" pin="2" pad="2"/>
+</connects>
+<technologies>
+<technology name=""/>
+</technologies>
+</device>
+<device name="_1210$REFLOW" package="1210_REFLOW">
+<connects>
+<connect gate="G$1" pin="1" pad="1"/>
+<connect gate="G$1" pin="2" pad="2"/>
+</connects>
+<technologies>
+<technology name=""/>
+</technologies>
+</device>
+<device name="_1206$REFLOW" package="1206_REFLOW">
+<connects>
+<connect gate="G$1" pin="1" pad="1"/>
+<connect gate="G$1" pin="2" pad="2"/>
+</connects>
+<technologies>
+<technology name=""/>
+</technologies>
+</device>
+<device name="_0805$REFLOW" package="0805_REFLOW">
+<connects>
+<connect gate="G$1" pin="1" pad="1"/>
+<connect gate="G$1" pin="2" pad="2"/>
+</connects>
+<technologies>
+<technology name=""/>
+</technologies>
+</device>
+<device name="_1812$REFLOW" package="1812_REFLOW">
+<connects>
+<connect gate="G$1" pin="1" pad="1"/>
+<connect gate="G$1" pin="2" pad="2"/>
+</connects>
+<technologies>
+<technology name=""/>
+</technologies>
+</device>
+<device name="_2220" package="2220">
+<connects>
+<connect gate="G$1" pin="1" pad="1"/>
+<connect gate="G$1" pin="2" pad="2"/>
+</connects>
+<technologies>
+<technology name=""/>
+</technologies>
+</device>
+</devices>
+</deviceset>
+<deviceset name="VCC-2">
+<gates>
+<gate name="G$1" symbol="VCC-2" x="0" y="0"/>
+</gates>
+<devices>
+<device name="">
+<technologies>
+<technology name=""/>
+</technologies>
+</device>
+</devices>
+</deviceset>
+<deviceset name="POLYSWITCH" prefix="R" uservalue="yes">
+<gates>
+<gate name="G$1" symbol="POLYSW" x="0" y="0"/>
+</gates>
+<devices>
+<device name="_1812" package="1812">
+<connects>
+<connect gate="G$1" pin="1" pad="1"/>
+<connect gate="G$1" pin="2" pad="2"/>
+</connects>
+<technologies>
+<technology name=""/>
+</technologies>
+</device>
+<device name="_5/15" package="POLY5/15">
+<connects>
+<connect gate="G$1" pin="1" pad="P$1"/>
+<connect gate="G$1" pin="2" pad="P$2"/>
+</connects>
+<technologies>
+<technology name=""/>
+</technologies>
+</device>
+<device name="_1206" package="1206">
+<connects>
+<connect gate="G$1" pin="1" pad="1"/>
+<connect gate="G$1" pin="2" pad="2"/>
+</connects>
+<technologies>
+<technology name=""/>
+</technologies>
+</device>
+<device name="_1210" package="1210">
+<connects>
+<connect gate="G$1" pin="1" pad="1"/>
+<connect gate="G$1" pin="2" pad="2"/>
+</connects>
+<technologies>
+<technology name=""/>
+</technologies>
+</device>
+<device name="_0603" package="0603">
+<connects>
+<connect gate="G$1" pin="1" pad="1"/>
+<connect gate="G$1" pin="2" pad="2"/>
+</connects>
+<technologies>
+<technology name=""/>
+</technologies>
+</device>
+<device name="_2920" package="2920">
+<connects>
+<connect gate="G$1" pin="1" pad="1"/>
+<connect gate="G$1" pin="2" pad="2"/>
+</connects>
+<technologies>
+<technology name=""/>
+</technologies>
+</device>
+<device name="_1210$REFLOW" package="1210_REFLOW">
+<connects>
+<connect gate="G$1" pin="1" pad="1"/>
+<connect gate="G$1" pin="2" pad="2"/>
+</connects>
+<technologies>
+<technology name=""/>
+</technologies>
+</device>
+</devices>
+</deviceset>
+<deviceset name="TP6104X" prefix="IC" uservalue="yes">
+<gates>
+<gate name="G$1" symbol="TPS6104X" x="0" y="-2.54"/>
+</gates>
+<devices>
+<device name="_WSON-8_3X3MM" package="WSON-8_3X3MM">
+<connects>
+<connect gate="G$1" pin="CTRL" pad="5"/>
+<connect gate="G$1" pin="EP" pad="EP EP$1 EP$2 EP$3 EP$4"/>
+<connect gate="G$1" pin="FB" pad="4"/>
+<connect gate="G$1" pin="GND" pad="6"/>
+<connect gate="G$1" pin="LED" pad="1"/>
+<connect gate="G$1" pin="OVP" pad="7"/>
+<connect gate="G$1" pin="RS" pad="2"/>
+<connect gate="G$1" pin="SW" pad="8"/>
+<connect gate="G$1" pin="VIN" pad="3"/>
+</connects>
+<technologies>
+<technology name=""/>
+</technologies>
+</device>
+</devices>
+</deviceset>
+<deviceset name="L" prefix="L" uservalue="yes">
+<gates>
+<gate name="G$1" symbol="L" x="0" y="0"/>
+</gates>
+<devices>
+<device name="_0805" package="0805">
+<connects>
+<connect gate="G$1" pin="1" pad="1"/>
+<connect gate="G$1" pin="2" pad="2"/>
+</connects>
+<technologies>
+<technology name=""/>
+</technologies>
+</device>
+<device name="_5MM" package="L_5">
+<connects>
+<connect gate="G$1" pin="1" pad="1"/>
+<connect gate="G$1" pin="2" pad="2"/>
+</connects>
+<technologies>
+<technology name=""/>
+</technologies>
+</device>
+<device name="_30MM" package="L_30">
+<connects>
+<connect gate="G$1" pin="1" pad="1"/>
+<connect gate="G$1" pin="2" pad="2"/>
+</connects>
+<technologies>
+<technology name=""/>
+</technologies>
+</device>
+<device name="_8$ST" package="L8$ST">
+<connects>
+<connect gate="G$1" pin="1" pad="1"/>
+<connect gate="G$1" pin="2" pad="2"/>
+</connects>
+<technologies>
+<technology name=""/>
+</technologies>
+</device>
+<device name="_27MM" package="L_27">
+<connects>
+<connect gate="G$1" pin="1" pad="1"/>
+<connect gate="G$1" pin="2" pad="2"/>
+</connects>
+<technologies>
+<technology name=""/>
+</technologies>
+</device>
+<device name="_12$ST" package="L12$ST">
+<connects>
+<connect gate="G$1" pin="1" pad="1"/>
+<connect gate="G$1" pin="2" pad="2"/>
+</connects>
+<technologies>
+<technology name=""/>
+</technologies>
+</device>
+<device name="_15MM" package="L_15">
+<connects>
+<connect gate="G$1" pin="1" pad="1"/>
+<connect gate="G$1" pin="2" pad="2"/>
+</connects>
+<technologies>
+<technology name=""/>
+</technologies>
+</device>
+<device name="_10MM" package="L_10">
+<connects>
+<connect gate="G$1" pin="1" pad="1"/>
+<connect gate="G$1" pin="2" pad="2"/>
+</connects>
+<technologies>
+<technology name=""/>
+</technologies>
+</device>
+<device name="_5050" package="L_5050">
+<connects>
+<connect gate="G$1" pin="1" pad="P$1"/>
+<connect gate="G$1" pin="2" pad="P$2"/>
+</connects>
+<technologies>
+<technology name=""/>
+</technologies>
+</device>
+<device name="_LPS401" package="C401X">
+<connects>
+<connect gate="G$1" pin="1" pad="P$1"/>
+<connect gate="G$1" pin="2" pad="P$2"/>
+</connects>
+<technologies>
+<technology name=""/>
+</technologies>
+</device>
+<device name="_SC105F" package="SC105F">
+<connects>
+<connect gate="G$1" pin="1" pad="P$1"/>
+<connect gate="G$1" pin="2" pad="P$2"/>
+</connects>
+<technologies>
+<technology name=""/>
+</technologies>
+</device>
+<device name="_SC75F" package="SC75F">
+<connects>
+<connect gate="G$1" pin="1" pad="P$1"/>
+<connect gate="G$1" pin="2" pad="P$2"/>
+</connects>
+<technologies>
+<technology name=""/>
+</technologies>
+</device>
+<device name="_S12,3X12,3" package="S12,3X12,3MM">
+<connects>
+<connect gate="G$1" pin="1" pad="1"/>
+<connect gate="G$1" pin="2" pad="2"/>
+</connects>
+<technologies>
+<technology name=""/>
+</technologies>
+</device>
+<device name="_4,5X4,0" package="L_4,5X4,0">
+<connects>
+<connect gate="G$1" pin="1" pad="P$1"/>
+<connect gate="G$1" pin="2" pad="P$2"/>
+</connects>
+<technologies>
+<technology name=""/>
+</technologies>
+</device>
+<device name="_0603" package="0603">
+<connects>
+<connect gate="G$1" pin="1" pad="1"/>
+<connect gate="G$1" pin="2" pad="2"/>
+</connects>
+<technologies>
+<technology name=""/>
+</technologies>
+</device>
+<device name="_L10X10" package="L10X10">
+<connects>
+<connect gate="G$1" pin="1" pad="P$1"/>
+<connect gate="G$1" pin="2" pad="P$2"/>
+</connects>
+<technologies>
+<technology name=""/>
+</technologies>
+</device>
+<device name="_S12,5X12,5MM" package="S12,5X12,5MM">
+<connects>
+<connect gate="G$1" pin="1" pad="1"/>
+<connect gate="G$1" pin="2" pad="2"/>
+</connects>
+<technologies>
+<technology name=""/>
+</technologies>
+</device>
+<device name="_SMT54" package="L_SMT54">
+<connects>
+<connect gate="G$1" pin="1" pad="P$1"/>
+<connect gate="G$1" pin="2" pad="P$2"/>
+</connects>
+<technologies>
+<technology name=""/>
+</technologies>
+</device>
+<device name="_SMT75" package="L_SMT75">
+<connects>
+<connect gate="G$1" pin="1" pad="P$1"/>
+<connect gate="G$1" pin="2" pad="P$2"/>
+</connects>
+<technologies>
+<technology name=""/>
+</technologies>
+</device>
+<device name="_12X12" package="L_12X12">
+<connects>
+<connect gate="G$1" pin="1" pad="P$1"/>
+<connect gate="G$1" pin="2" pad="P$2"/>
+</connects>
+<technologies>
+<technology name=""/>
+</technologies>
+</device>
+<device name="_7,3X7,3" package="L_7,3X7,3">
+<connects>
+<connect gate="G$1" pin="1" pad="P$1"/>
+<connect gate="G$1" pin="2" pad="P$2"/>
+</connects>
+<technologies>
+<technology name=""/>
+</technologies>
+</device>
+<device name="_5MM$1S" package="L_5$1S">
+<connects>
+<connect gate="G$1" pin="1" pad="1"/>
+<connect gate="G$1" pin="2" pad="2"/>
+</connects>
+<technologies>
+<technology name=""/>
+</technologies>
+</device>
+<device name="_SCB5" package="L_SCB5">
+<connects>
+<connect gate="G$1" pin="1" pad="P$1"/>
+<connect gate="G$1" pin="2" pad="P$2"/>
+</connects>
+<technologies>
+<technology name=""/>
+</technologies>
+</device>
+<device name="_WURTH_10X10" package="L_WURTH_10X10">
+<connects>
+<connect gate="G$1" pin="1" pad="1"/>
+<connect gate="G$1" pin="2" pad="2"/>
+</connects>
+<technologies>
+<technology name=""/>
+</technologies>
+</device>
+<device name="_0402" package="0402">
+<connects>
+<connect gate="G$1" pin="1" pad="P$1"/>
+<connect gate="G$1" pin="2" pad="P$2"/>
+</connects>
+<technologies>
+<technology name=""/>
+</technologies>
+</device>
+<device name="_4,8X4,8" package="L_4,8X4,8">
+<connects>
+<connect gate="G$1" pin="1" pad="P$1"/>
+<connect gate="G$1" pin="2" pad="P$2"/>
+</connects>
+<technologies>
+<technology name=""/>
+</technologies>
+</device>
+<device name="_1210" package="1210">
+<connects>
+<connect gate="G$1" pin="1" pad="1"/>
+<connect gate="G$1" pin="2" pad="2"/>
+</connects>
+<technologies>
+<technology name=""/>
+</technologies>
+</device>
+<device name="_1812" package="1812">
+<connects>
+<connect gate="G$1" pin="1" pad="1"/>
+<connect gate="G$1" pin="2" pad="2"/>
+</connects>
+<technologies>
+<technology name=""/>
+</technologies>
+</device>
+<device name="_MCBF7330" package="L_MCBF7330">
+<connects>
+<connect gate="G$1" pin="1" pad="1"/>
+<connect gate="G$1" pin="2" pad="2"/>
+</connects>
+<technologies>
+<technology name=""/>
+</technologies>
+</device>
+<device name="_29X13MM" package="L_29X13">
+<connects>
+<connect gate="G$1" pin="1" pad="P$1"/>
+<connect gate="G$1" pin="2" pad="P$2"/>
+</connects>
+<technologies>
+<technology name=""/>
+</technologies>
+</device>
+<device name="_L10X10,2" package="L10X10,2">
+<connects>
+<connect gate="G$1" pin="1" pad="1"/>
+<connect gate="G$1" pin="2" pad="2"/>
+</connects>
+<technologies>
+<technology name=""/>
+</technologies>
+</device>
+<device name="_4,3X4,3" package="L_4,3X4,3">
+<connects>
+<connect gate="G$1" pin="1" pad="1"/>
+<connect gate="G$1" pin="2" pad="2"/>
+</connects>
+<technologies>
+<technology name=""/>
+</technologies>
+</device>
+<device name="_7,3X7,3_2" package="L_7,3X7,3_2">
+<connects>
+<connect gate="G$1" pin="1" pad="P$1"/>
+<connect gate="G$1" pin="2" pad="P$2"/>
+</connects>
+<technologies>
+<technology name=""/>
+</technologies>
+</device>
+<device name="_L_2,5X5" package="L_2,5X5">
+<connects>
+<connect gate="G$1" pin="1" pad="1"/>
+<connect gate="G$1" pin="2" pad="2"/>
+</connects>
+<technologies>
+<technology name=""/>
+</technologies>
+</device>
+<device name="_15X9MM" package="L_15X9">
+<connects>
+<connect gate="G$1" pin="1" pad="P$1"/>
+<connect gate="G$1" pin="2" pad="P$2"/>
+</connects>
+<technologies>
+<technology name=""/>
+</technologies>
+</device>
+<device name="_ELL6" package="L_ELL6-6X6MM">
+<connects>
+<connect gate="G$1" pin="1" pad="P$1"/>
+<connect gate="G$1" pin="2" pad="P$2"/>
+</connects>
+<technologies>
+<technology name=""/>
+</technologies>
+</device>
+<device name="_1206" package="1206">
+<connects>
+<connect gate="G$1" pin="1" pad="1"/>
+<connect gate="G$1" pin="2" pad="2"/>
+</connects>
+<technologies>
+<technology name=""/>
+</technologies>
+</device>
+<device name="_0207$ST_1" package="0207$ST_1">
+<connects>
+<connect gate="G$1" pin="1" pad="1"/>
+<connect gate="G$1" pin="2" pad="2"/>
+</connects>
+<technologies>
+<technology name=""/>
+</technologies>
+</device>
+<device name="_0207$ST_2" package="0207$ST_1_2">
+<connects>
+<connect gate="G$1" pin="1" pad="1"/>
+<connect gate="G$1" pin="2" pad="2"/>
+</connects>
+<technologies>
+<technology name=""/>
+</technologies>
+</device>
+<device name="_1806" package="1806">
+<connects>
+<connect gate="G$1" pin="1" pad="1"/>
+<connect gate="G$1" pin="2" pad="2"/>
+</connects>
+<technologies>
+<technology name=""/>
+</technologies>
+</device>
+<device name="_0603$REFLOW" package="0603_REFLOW">
+<connects>
+<connect gate="G$1" pin="1" pad="1"/>
+<connect gate="G$1" pin="2" pad="2"/>
+</connects>
+<technologies>
+<technology name=""/>
+</technologies>
+</device>
+<device name="_0805$REFLOW" package="0805_REFLOW">
+<connects>
+<connect gate="G$1" pin="1" pad="1"/>
+<connect gate="G$1" pin="2" pad="2"/>
+</connects>
+<technologies>
+<technology name=""/>
+</technologies>
+</device>
+<device name="_5,8X5,2MM" package="L_5,8X5,2">
+<connects>
+<connect gate="G$1" pin="1" pad="P$1"/>
+<connect gate="G$1" pin="2" pad="P$2"/>
+</connects>
+<technologies>
+<technology name=""/>
+</technologies>
+</device>
+<device name="_PM2110" package="L_PM2110">
+<connects>
+<connect gate="G$1" pin="1" pad="1"/>
+<connect gate="G$1" pin="2" pad="2"/>
+</connects>
+<technologies>
+<technology name=""/>
+</technologies>
+</device>
+<device name="_SDR1307" package="L_SDR1307">
+<connects>
+<connect gate="G$1" pin="1" pad="P$1"/>
+<connect gate="G$1" pin="2" pad="P$2"/>
+</connects>
+<technologies>
+<technology name=""/>
+</technologies>
+</device>
+<device name="_SPR7030" package="L_SRP7030">
+<connects>
+<connect gate="G$1" pin="1" pad="P$1"/>
+<connect gate="G$1" pin="2" pad="P$2"/>
+</connects>
+<technologies>
+<technology name=""/>
+</technologies>
+</device>
+<device name="_VLCF5028-2" package="L_VLCF5028-2">
+<connects>
+<connect gate="G$1" pin="1" pad="P$1"/>
+<connect gate="G$1" pin="2" pad="P$2"/>
+</connects>
+<technologies>
+<technology name=""/>
+</technologies>
+</device>
+</devices>
+</deviceset>
+<deviceset name="RAM_A3" uservalue="yes">
+<gates>
+<gate name="G$1" symbol="RAM_A3" x="0" y="0" addlevel="must"/>
+<gate name="G$2" symbol="RAM_RAZ" x="251.46" y="5.08" addlevel="always"/>
+</gates>
+<devices>
+<device name="">
+<technologies>
+<technology name=""/>
+</technologies>
+</device>
+</devices>
+</deviceset>
+<deviceset name="MB" prefix="MB" uservalue="yes">
+<gates>
+<gate name="G$1" symbol="MB" x="0" y="0"/>
+</gates>
+<devices>
+<device name="_100100" package="MB100100">
+<connects>
+<connect gate="G$1" pin="1" pad="1"/>
+</connects>
+<technologies>
+<technology name=""/>
+</technologies>
+</device>
+<device name="_5050" package="MB5050">
+<connects>
+<connect gate="G$1" pin="1" pad="1"/>
+</connects>
+<technologies>
+<technology name=""/>
+</technologies>
+</device>
+<device name="_1.27" package="MB1.27">
+<connects>
+<connect gate="G$1" pin="1" pad="1"/>
+</connects>
+<technologies>
+<technology name=""/>
+</technologies>
+</device>
+<device name="_270150" package="MB270150">
+<connects>
+<connect gate="G$1" pin="1" pad="1"/>
+</connects>
+<technologies>
+<technology name=""/>
+</technologies>
+</device>
+<device name="_1.50" package="MB1.5">
+<connects>
+<connect gate="G$1" pin="1" pad="1"/>
+</connects>
+<technologies>
+<technology name=""/>
+</technologies>
+</device>
+<device name="_2.0" package="MB2.0">
+<connects>
+<connect gate="G$1" pin="1" pad="1"/>
+</connects>
+<technologies>
+<technology name=""/>
+</technologies>
+</device>
+</devices>
+</deviceset>
+<deviceset name="VBAT">
+<gates>
+<gate name="G$1" symbol="VBAT" x="0" y="0"/>
+</gates>
+<devices>
+<device name="">
+<technologies>
+<technology name=""/>
+</technologies>
+</device>
+</devices>
+</deviceset>
+</devicesets>
+</library>
+<library name="SDkarta">
+<packages>
+<package name="ATTEND_112J-TXAR-R01">
+<hole x="-4.95" y="0" drill="1.5"/>
+<hole x="3.05" y="0" drill="1.5"/>
+<smd name="1" x="2.25" y="10.5" dx="1.8" dy="0.8" layer="1" rot="R90"/>
+<smd name="2" x="1.15" y="10.5" dx="1.8" dy="0.8" layer="1" rot="R90"/>
+<smd name="3" x="0.05" y="10.5" dx="1.8" dy="0.8" layer="1" rot="R90"/>
+<smd name="4" x="-1.05" y="10.5" dx="1.8" dy="0.8" layer="1" rot="R90"/>
+<smd name="5" x="-2.15" y="10.5" dx="1.8" dy="0.8" layer="1" rot="R90"/>
+<smd name="6" x="-3.25" y="10.5" dx="1.8" dy="0.8" layer="1" rot="R90"/>
+<smd name="7" x="-4.35" y="10.5" dx="1.8" dy="0.8" layer="1" rot="R90"/>
+<smd name="8" x="-5.45" y="10.5" dx="1.8" dy="0.8" layer="1" rot="R90"/>
+<smd name="CD" x="-6.55" y="10.5" dx="1.8" dy="0.7" layer="1" rot="R90"/>
+<smd name="GND@2" x="-7.75" y="0.4" dx="2.4" dy="1.4" layer="1" rot="R90"/>
+<smd name="GND@3" x="7.75" y="0.4" dx="2.4" dy="1.4" layer="1" rot="R90"/>
+<smd name="GND@1" x="-7.75" y="10" dx="1.4" dy="1.2" layer="1" rot="R90"/>
+<smd name="GND@4" x="6.85" y="10" dx="1.6" dy="1.8" layer="1" rot="R90"/>
+<wire x1="3.3" y1="-4" x2="3.5" y2="-4" width="0.127" layer="21"/>
+<wire x1="3.5" y1="-4" x2="7.35" y2="-4" width="0.127" layer="21"/>
+<wire x1="7.35" y1="-4" x2="7.35" y2="10.5" width="0.127" layer="21"/>
+<wire x1="7.35" y1="10.5" x2="-7.35" y2="10.5" width="0.127" layer="21"/>
+<wire x1="-7.35" y1="10.5" x2="-7.35" y2="-3.3" width="0.127" layer="21"/>
+<wire x1="-7.35" y1="-3.3" x2="-6.5" y2="-3.3" width="0.127" layer="21"/>
+<wire x1="-6.5" y1="-3.3" x2="2" y2="-3.3" width="0.127" layer="21"/>
+<wire x1="3.3" y1="-4" x2="3" y2="-3.7" width="0.127" layer="21"/>
+<wire x1="3" y1="-3.7" x2="2" y2="-3.3" width="0.127" layer="21" curve="46.397226"/>
+<wire x1="3.5" y1="-4" x2="3.5" y2="-5.2" width="0.127" layer="21" style="shortdash"/>
+<wire x1="3.5" y1="-5.2" x2="2.5" y2="-6.2" width="0.127" layer="21" style="shortdash" curve="-90"/>
+<wire x1="2.5" y1="-6.2" x2="-5.45" y2="-6.2" width="0.127" layer="21"/>
+<wire x1="-6.5" y1="-5.25" x2="-6.5" y2="-3.3" width="0.127" layer="21" style="shortdash"/>
+<wire x1="-5.45" y1="-6.2" x2="-5.55" y2="-6.2" width="0.127" layer="21" style="shortdash"/>
+<wire x1="-5.55" y1="-6.2" x2="-6.5" y2="-5.25" width="0.127" layer="21" style="shortdash" curve="-90"/>
+<polygon width="0.127" layer="41">
+<vertex x="3.05" y="4.5"/>
+<vertex x="3.05" y="6.5"/>
+<vertex x="-5.95" y="6.5"/>
+<vertex x="-5.95" y="4.5"/>
+</polygon>
+</package>
+<package name="ATTEND_112J-TXAR-R01_SMALL">
+<hole x="-4.95" y="0" drill="1.2"/>
+<hole x="3.05" y="0" drill="1.2"/>
+<smd name="1" x="2.25" y="10.4" dx="1.6" dy="0.8" layer="1" rot="R90"/>
+<smd name="2" x="1.15" y="10.4" dx="1.6" dy="0.8" layer="1" rot="R90"/>
+<smd name="3" x="0.05" y="10.4" dx="1.6" dy="0.8" layer="1" rot="R90"/>
+<smd name="4" x="-1.05" y="10.4" dx="1.6" dy="0.8" layer="1" rot="R90"/>
+<smd name="5" x="-2.15" y="10.4" dx="1.6" dy="0.8" layer="1" rot="R90"/>
+<smd name="6" x="-3.25" y="10.4" dx="1.6" dy="0.8" layer="1" rot="R90"/>
+<smd name="7" x="-4.35" y="10.4" dx="1.6" dy="0.8" layer="1" rot="R90"/>
+<smd name="8" x="-5.45" y="10.4" dx="1.6" dy="0.8" layer="1" rot="R90"/>
+<smd name="CD" x="-6.5" y="10.4" dx="1.6" dy="0.7" layer="1" rot="R90"/>
+<smd name="GND@2" x="-7.75" y="0.4" dx="2.4" dy="1.4" layer="1" rot="R90"/>
+<smd name="GND@3" x="7.75" y="0.4" dx="2.4" dy="1.4" layer="1" rot="R90"/>
+<smd name="GND@1" x="-7.75" y="10" dx="1.4" dy="1.2" layer="1" rot="R90"/>
+<smd name="GND@4" x="6.85" y="10" dx="1.6" dy="1.8" layer="1" rot="R90"/>
+<wire x1="3.3" y1="-4" x2="3.5" y2="-4" width="0.127" layer="21"/>
+<wire x1="3.5" y1="-4" x2="7.35" y2="-4" width="0.127" layer="21"/>
+<wire x1="7.35" y1="-4" x2="7.35" y2="10.5" width="0.127" layer="21"/>
+<wire x1="7.35" y1="10.5" x2="-7.35" y2="10.5" width="0.127" layer="21"/>
+<wire x1="-7.35" y1="10.5" x2="-7.35" y2="-3.3" width="0.127" layer="21"/>
+<wire x1="-7.35" y1="-3.3" x2="-6.5" y2="-3.3" width="0.127" layer="21"/>
+<wire x1="-6.5" y1="-3.3" x2="2" y2="-3.3" width="0.127" layer="21"/>
+<wire x1="3.3" y1="-4" x2="3" y2="-3.7" width="0.127" layer="21"/>
+<wire x1="3" y1="-3.7" x2="2" y2="-3.3" width="0.127" layer="21" curve="46.397226"/>
+<wire x1="3.5" y1="-4" x2="3.5" y2="-5.2" width="0.127" layer="21" style="shortdash"/>
+<wire x1="3.5" y1="-5.2" x2="2.5" y2="-6.2" width="0.127" layer="21" style="shortdash" curve="-90"/>
+<wire x1="2.5" y1="-6.2" x2="-5.45" y2="-6.2" width="0.127" layer="21"/>
+<wire x1="-6.5" y1="-5.25" x2="-6.5" y2="-3.3" width="0.127" layer="21" style="shortdash"/>
+<wire x1="-5.45" y1="-6.2" x2="-5.55" y2="-6.2" width="0.127" layer="21" style="shortdash"/>
+<wire x1="-5.55" y1="-6.2" x2="-6.5" y2="-5.25" width="0.127" layer="21" style="shortdash" curve="-90"/>
+<polygon width="0.127" layer="41">
+<vertex x="3.05" y="4.5"/>
+<vertex x="3.05" y="6.5"/>
+<vertex x="-5.95" y="6.5"/>
+<vertex x="-5.95" y="4.5"/>
+</polygon>
+</package>
+</packages>
+<symbols>
+<symbol name="KON_µSD_CARD">
+<pin name="DAT2" x="-20.32" y="10.16" length="middle"/>
+<pin name="CD/DAT3" x="-20.32" y="7.62" length="middle"/>
+<pin name="CMD" x="-20.32" y="5.08" length="middle"/>
+<pin name="VDD" x="-20.32" y="2.54" length="middle" direction="pwr"/>
+<pin name="CLK" x="-20.32" y="0" length="middle"/>
+<pin name="VSS" x="-20.32" y="-2.54" length="middle"/>
+<pin name="DAT0" x="-20.32" y="-5.08" length="middle"/>
+<pin name="DAT1" x="-20.32" y="-7.62" length="middle"/>
+<pin name="CD" x="-5.08" y="-17.78" length="middle" rot="R90"/>
+<pin name="GND@1" x="2.54" y="-17.78" visible="pin" length="middle" direction="pwr" rot="R90"/>
+<pin name="GND@2" x="7.62" y="-17.78" visible="pin" length="middle" direction="pwr" rot="R90"/>
+<pin name="GND@3" x="10.16" y="-17.78" visible="pin" length="middle" direction="pwr" rot="R90"/>
+<pin name="GND@4" x="12.7" y="-17.78" visible="pin" length="middle" direction="pwr" rot="R90"/>
+<wire x1="-15.24" y1="12.7" x2="-15.24" y2="-12.7" width="0.254" layer="94"/>
+<wire x1="-15.24" y1="-12.7" x2="-5.08" y2="-12.7" width="0.254" layer="94"/>
+<wire x1="-5.08" y1="-12.7" x2="2.54" y2="-12.7" width="0.254" layer="94"/>
+<wire x1="2.54" y1="-12.7" x2="15.24" y2="-12.7" width="0.254" layer="94"/>
+<wire x1="15.24" y1="-12.7" x2="15.24" y2="12.7" width="0.254" layer="94"/>
+<wire x1="15.24" y1="12.7" x2="-15.24" y2="12.7" width="0.254" layer="94"/>
+<wire x1="-5.08" y1="-12.7" x2="-5.08" y2="-11.43" width="0.2032" layer="94"/>
+<wire x1="-5.08" y1="-11.43" x2="-3.81" y2="-11.43" width="0.2032" layer="94"/>
+<wire x1="2.54" y1="-12.7" x2="2.54" y2="-11.43" width="0.2032" layer="94"/>
+<wire x1="2.54" y1="-11.43" x2="1.27" y2="-11.43" width="0.2032" layer="94"/>
+<wire x1="1.27" y1="-11.43" x2="-3.81" y2="-10.16" width="0.2032" layer="94"/>
+<text x="0" y="8.89" size="1.778" layer="95">&gt;NAME</text>
+<text x="0" y="6.35" size="1.778" layer="96">&gt;VALUE</text>
+</symbol>
+</symbols>
+<devicesets>
+<deviceset name="KON_µSD_CARD" prefix="K" uservalue="yes">
+<gates>
+<gate name="G$1" symbol="KON_µSD_CARD" x="2.54" y="5.08"/>
+</gates>
+<devices>
+<device name="_ATTEND_112J-TXAR-R01" package="ATTEND_112J-TXAR-R01">
+<connects>
+<connect gate="G$1" pin="CD" pad="CD"/>
+<connect gate="G$1" pin="CD/DAT3" pad="2"/>
+<connect gate="G$1" pin="CLK" pad="5"/>
+<connect gate="G$1" pin="CMD" pad="3"/>
+<connect gate="G$1" pin="DAT0" pad="7"/>
+<connect gate="G$1" pin="DAT1" pad="8"/>
+<connect gate="G$1" pin="DAT2" pad="1"/>
+<connect gate="G$1" pin="GND@1" pad="GND@1"/>
+<connect gate="G$1" pin="GND@2" pad="GND@2"/>
+<connect gate="G$1" pin="GND@3" pad="GND@3"/>
+<connect gate="G$1" pin="GND@4" pad="GND@4"/>
+<connect gate="G$1" pin="VDD" pad="4"/>
+<connect gate="G$1" pin="VSS" pad="6"/>
+</connects>
+<technologies>
+<technology name=""/>
+</technologies>
+</device>
+<device name="_ATTEND_112J_TXAR_R01_SMALL" package="ATTEND_112J-TXAR-R01_SMALL">
+<connects>
+<connect gate="G$1" pin="CD" pad="CD"/>
+<connect gate="G$1" pin="CD/DAT3" pad="2"/>
+<connect gate="G$1" pin="CLK" pad="5"/>
+<connect gate="G$1" pin="CMD" pad="3"/>
+<connect gate="G$1" pin="DAT0" pad="7"/>
+<connect gate="G$1" pin="DAT1" pad="8"/>
+<connect gate="G$1" pin="DAT2" pad="1"/>
+<connect gate="G$1" pin="GND@1" pad="GND@1"/>
+<connect gate="G$1" pin="GND@2" pad="GND@2"/>
+<connect gate="G$1" pin="GND@3" pad="GND@3"/>
+<connect gate="G$1" pin="GND@4" pad="GND@4"/>
+<connect gate="G$1" pin="VDD" pad="4"/>
+<connect gate="G$1" pin="VSS" pad="6"/>
+</connects>
+<technologies>
+<technology name=""/>
+</technologies>
+</device>
+</devices>
+</deviceset>
+</devicesets>
+</library>
+<library name="trezor">
+<packages>
+<package name="LQFP100">
+<wire x1="-6.85" y1="6.85" x2="-6.25" y2="6.85" width="0.254" layer="21"/>
+<wire x1="-6.25" y1="6.85" x2="6.6" y2="6.85" width="0.254" layer="21"/>
+<wire x1="6.6" y1="6.85" x2="6.85" y2="6.6" width="0.254" layer="21"/>
+<wire x1="6.85" y1="6.6" x2="6.85" y2="-6.6" width="0.254" layer="21"/>
+<wire x1="6.85" y1="-6.6" x2="6.6" y2="-6.85" width="0.254" layer="21"/>
+<wire x1="6.6" y1="-6.85" x2="-6.6" y2="-6.85" width="0.254" layer="21"/>
+<wire x1="-6.6" y1="-6.85" x2="-6.85" y2="-6.6" width="0.254" layer="21"/>
+<wire x1="-6.85" y1="-6.6" x2="-6.85" y2="6.25" width="0.254" layer="21"/>
+<wire x1="-6.85" y1="6.25" x2="-6.85" y2="6.85" width="0.254" layer="21"/>
+<wire x1="-6.85" y1="6.85" x2="-6.25" y2="6.85" width="0.254" layer="51"/>
+<wire x1="-6.25" y1="6.85" x2="6.6" y2="6.85" width="0.254" layer="51"/>
+<wire x1="6.6" y1="6.85" x2="6.85" y2="6.6" width="0.254" layer="51"/>
+<wire x1="6.85" y1="6.6" x2="6.85" y2="-6.6" width="0.254" layer="51"/>
+<wire x1="6.85" y1="-6.6" x2="6.6" y2="-6.85" width="0.254" layer="51"/>
+<wire x1="6.6" y1="-6.85" x2="-6.6" y2="-6.85" width="0.254" layer="51"/>
+<wire x1="-6.6" y1="-6.85" x2="-6.85" y2="-6.6" width="0.254" layer="51"/>
+<wire x1="-6.85" y1="-6.6" x2="-6.85" y2="6.25" width="0.254" layer="51"/>
+<circle x="-6.1" y="6.1" radius="0.2499" width="0.254" layer="21"/>
+<circle x="-7.8" y="-7.8" radius="0.65" width="0" layer="29"/>
+<circle x="-7.8" y="-7.8" radius="0.4" width="0" layer="1"/>
+<circle x="-7.8" y="-7.8" radius="0.65" width="0.1" layer="41"/>
+<smd name="1" x="-7.725" y="6" dx="1.35" dy="0.29" layer="1"/>
+<smd name="2" x="-7.725" y="5.5" dx="1.35" dy="0.29" layer="1"/>
+<smd name="3" x="-7.725" y="5" dx="1.35" dy="0.29" layer="1"/>
+<smd name="4" x="-7.725" y="4.5" dx="1.35" dy="0.29" layer="1"/>
+<smd name="5" x="-7.725" y="4" dx="1.35" dy="0.29" layer="1"/>
+<smd name="6" x="-7.725" y="3.5" dx="1.35" dy="0.29" layer="1"/>
+<smd name="7" x="-7.725" y="3" dx="1.35" dy="0.29" layer="1"/>
+<smd name="8" x="-7.725" y="2.5" dx="1.35" dy="0.29" layer="1"/>
+<smd name="9" x="-7.725" y="2" dx="1.35" dy="0.29" layer="1"/>
+<smd name="10" x="-7.725" y="1.5" dx="1.35" dy="0.29" layer="1"/>
+<smd name="11" x="-7.725" y="1" dx="1.35" dy="0.29" layer="1"/>
+<smd name="12" x="-7.725" y="0.5" dx="1.35" dy="0.29" layer="1"/>
+<smd name="13" x="-7.725" y="0" dx="1.35" dy="0.29" layer="1"/>
+<smd name="14" x="-7.725" y="-0.5" dx="1.35" dy="0.29" layer="1"/>
+<smd name="15" x="-7.725" y="-1" dx="1.35" dy="0.29" layer="1"/>
+<smd name="16" x="-7.725" y="-1.5" dx="1.35" dy="0.29" layer="1"/>
+<smd name="17" x="-7.725" y="-2" dx="1.35" dy="0.29" layer="1"/>
+<smd name="18" x="-7.725" y="-2.5" dx="1.35" dy="0.29" layer="1"/>
+<smd name="19" x="-7.725" y="-3" dx="1.35" dy="0.29" layer="1"/>
+<smd name="20" x="-7.725" y="-3.5" dx="1.35" dy="0.29" layer="1"/>
+<smd name="21" x="-7.725" y="-4" dx="1.35" dy="0.29" layer="1"/>
+<smd name="22" x="-7.725" y="-4.5" dx="1.35" dy="0.29" layer="1"/>
+<smd name="23" x="-7.725" y="-5" dx="1.35" dy="0.29" layer="1"/>
+<smd name="24" x="-7.725" y="-5.5" dx="1.35" dy="0.29" layer="1"/>
+<smd name="25" x="-7.725" y="-6" dx="1.35" dy="0.29" layer="1"/>
+<smd name="26" x="-6" y="-7.725" dx="1.35" dy="0.29" layer="1" rot="R90"/>
+<smd name="27" x="-5.5" y="-7.725" dx="1.35" dy="0.29" layer="1" rot="R90"/>
+<smd name="28" x="-5" y="-7.725" dx="1.35" dy="0.29" layer="1" rot="R90"/>
+<smd name="29" x="-4.5" y="-7.725" dx="1.35" dy="0.29" layer="1" rot="R90"/>
+<smd name="30" x="-4" y="-7.725" dx="1.35" dy="0.29" layer="1" rot="R90"/>
+<smd name="31" x="-3.5" y="-7.725" dx="1.35" dy="0.29" layer="1" rot="R90"/>
+<smd name="32" x="-3" y="-7.725" dx="1.35" dy="0.29" layer="1" rot="R90"/>
+<smd name="33" x="-2.5" y="-7.725" dx="1.35" dy="0.29" layer="1" rot="R90"/>
+<smd name="34" x="-2" y="-7.725" dx="1.35" dy="0.29" layer="1" rot="R90"/>
+<smd name="35" x="-1.5" y="-7.725" dx="1.35" dy="0.29" layer="1" rot="R90"/>
+<smd name="36" x="-1" y="-7.725" dx="1.35" dy="0.29" layer="1" rot="R90"/>
+<smd name="37" x="-0.5" y="-7.725" dx="1.35" dy="0.29" layer="1" rot="R90"/>
+<smd name="38" x="0" y="-7.725" dx="1.35" dy="0.29" layer="1" rot="R90"/>
+<smd name="39" x="0.5" y="-7.725" dx="1.35" dy="0.29" layer="1" rot="R90"/>
+<smd name="40" x="1" y="-7.725" dx="1.35" dy="0.29" layer="1" rot="R90"/>
+<smd name="41" x="1.5" y="-7.725" dx="1.35" dy="0.29" layer="1" rot="R90"/>
+<smd name="42" x="2" y="-7.725" dx="1.35" dy="0.29" layer="1" rot="R90"/>
+<smd name="43" x="2.5" y="-7.725" dx="1.35" dy="0.29" layer="1" rot="R90"/>
+<smd name="44" x="3" y="-7.725" dx="1.35" dy="0.29" layer="1" rot="R90"/>
+<smd name="45" x="3.5" y="-7.725" dx="1.35" dy="0.29" layer="1" rot="R90"/>
+<smd name="46" x="4" y="-7.725" dx="1.35" dy="0.29" layer="1" rot="R90"/>
+<smd name="47" x="4.5" y="-7.725" dx="1.35" dy="0.29" layer="1" rot="R90"/>
+<smd name="48" x="5" y="-7.725" dx="1.35" dy="0.29" layer="1" rot="R90"/>
+<smd name="49" x="5.5" y="-7.725" dx="1.35" dy="0.29" layer="1" rot="R90"/>
+<smd name="50" x="6" y="-7.725" dx="1.35" dy="0.29" layer="1" rot="R90"/>
+<smd name="51" x="7.725" y="-6" dx="1.35" dy="0.29" layer="1" rot="R180"/>
+<smd name="52" x="7.725" y="-5.5" dx="1.35" dy="0.29" layer="1" rot="R180"/>
+<smd name="53" x="7.725" y="-5" dx="1.35" dy="0.29" layer="1" rot="R180"/>
+<smd name="54" x="7.725" y="-4.5" dx="1.35" dy="0.29" layer="1" rot="R180"/>
+<smd name="55" x="7.725" y="-4" dx="1.35" dy="0.29" layer="1" rot="R180"/>
+<smd name="56" x="7.725" y="-3.5" dx="1.35" dy="0.29" layer="1" rot="R180"/>
+<smd name="57" x="7.725" y="-3" dx="1.35" dy="0.29" layer="1" rot="R180"/>
+<smd name="58" x="7.725" y="-2.5" dx="1.35" dy="0.29" layer="1" rot="R180"/>
+<smd name="59" x="7.725" y="-2" dx="1.35" dy="0.29" layer="1" rot="R180"/>
+<smd name="60" x="7.725" y="-1.5" dx="1.35" dy="0.29" layer="1" rot="R180"/>
+<smd name="61" x="7.725" y="-1" dx="1.35" dy="0.29" layer="1" rot="R180"/>
+<smd name="62" x="7.725" y="-0.5" dx="1.35" dy="0.29" layer="1" rot="R180"/>
+<smd name="63" x="7.725" y="0" dx="1.35" dy="0.29" layer="1" rot="R180"/>
+<smd name="64" x="7.725" y="0.5" dx="1.35" dy="0.29" layer="1" rot="R180"/>
+<smd name="65" x="7.725" y="1" dx="1.35" dy="0.29" layer="1" rot="R180"/>
+<smd name="66" x="7.725" y="1.5" dx="1.35" dy="0.29" layer="1" rot="R180"/>
+<smd name="67" x="7.725" y="2" dx="1.35" dy="0.29" layer="1" rot="R180"/>
+<smd name="68" x="7.725" y="2.5" dx="1.35" dy="0.29" layer="1" rot="R180"/>
+<smd name="69" x="7.725" y="3" dx="1.35" dy="0.29" layer="1" rot="R180"/>
+<smd name="70" x="7.725" y="3.5" dx="1.35" dy="0.29" layer="1" rot="R180"/>
+<smd name="71" x="7.725" y="4" dx="1.35" dy="0.29" layer="1" rot="R180"/>
+<smd name="72" x="7.725" y="4.5" dx="1.35" dy="0.29" layer="1" rot="R180"/>
+<smd name="73" x="7.725" y="5" dx="1.35" dy="0.29" layer="1" rot="R180"/>
+<smd name="74" x="7.725" y="5.5" dx="1.35" dy="0.29" layer="1" rot="R180"/>
+<smd name="75" x="7.725" y="6" dx="1.35" dy="0.29" layer="1" rot="R180"/>
+<smd name="76" x="6" y="7.725" dx="1.35" dy="0.29" layer="1" rot="R270"/>
+<smd name="77" x="5.5" y="7.725" dx="1.35" dy="0.29" layer="1" rot="R270"/>
+<smd name="78" x="5" y="7.725" dx="1.35" dy="0.29" layer="1" rot="R270"/>
+<smd name="79" x="4.5" y="7.725" dx="1.35" dy="0.29" layer="1" rot="R270"/>
+<smd name="80" x="4" y="7.725" dx="1.35" dy="0.29" layer="1" rot="R270"/>
+<smd name="81" x="3.5" y="7.725" dx="1.35" dy="0.29" layer="1" rot="R270"/>
+<smd name="82" x="3" y="7.725" dx="1.35" dy="0.29" layer="1" rot="R270"/>
+<smd name="83" x="2.5" y="7.725" dx="1.35" dy="0.29" layer="1" rot="R270"/>
+<smd name="84" x="2" y="7.725" dx="1.35" dy="0.29" layer="1" rot="R270"/>
+<smd name="85" x="1.5" y="7.725" dx="1.35" dy="0.29" layer="1" rot="R270"/>
+<smd name="86" x="1" y="7.725" dx="1.35" dy="0.29" layer="1" rot="R270"/>
+<smd name="87" x="0.5" y="7.725" dx="1.35" dy="0.29" layer="1" rot="R270"/>
+<smd name="88" x="0" y="7.725" dx="1.35" dy="0.29" layer="1" rot="R270"/>
+<smd name="89" x="-0.5" y="7.725" dx="1.35" dy="0.29" layer="1" rot="R270"/>
+<smd name="90" x="-1" y="7.725" dx="1.35" dy="0.29" layer="1" rot="R270"/>
+<smd name="91" x="-1.5" y="7.725" dx="1.35" dy="0.29" layer="1" rot="R270"/>
+<smd name="92" x="-2" y="7.725" dx="1.35" dy="0.29" layer="1" rot="R270"/>
+<smd name="93" x="-2.5" y="7.725" dx="1.35" dy="0.29" layer="1" rot="R270"/>
+<smd name="94" x="-3" y="7.725" dx="1.35" dy="0.29" layer="1" rot="R270"/>
+<smd name="95" x="-3.5" y="7.725" dx="1.35" dy="0.29" layer="1" rot="R270"/>
+<smd name="96" x="-4" y="7.725" dx="1.35" dy="0.29" layer="1" rot="R270"/>
+<smd name="97" x="-4.5" y="7.725" dx="1.35" dy="0.29" layer="1" rot="R270"/>
+<smd name="98" x="-5" y="7.725" dx="1.35" dy="0.29" layer="1" rot="R270"/>
+<smd name="99" x="-5.5" y="7.725" dx="1.35" dy="0.29" layer="1" rot="R270"/>
+<smd name="100" x="-6" y="7.725" dx="1.35" dy="0.29" layer="1" rot="R270"/>
+<text x="-3.2" y="0.5001" size="1.27" layer="25">&gt;NAME</text>
+<text x="-3.1501" y="-1.6999" size="1.27" layer="27">&gt;VALUE</text>
+<rectangle x1="-8" y1="5.9" x2="-6.95" y2="6.1" layer="51"/>
+<rectangle x1="-8" y1="5.4" x2="-6.95" y2="5.6" layer="51"/>
+<rectangle x1="-8" y1="4.9" x2="-6.95" y2="5.1" layer="51"/>
+<rectangle x1="-8" y1="4.4" x2="-6.95" y2="4.6" layer="51"/>
+<rectangle x1="-8" y1="3.9" x2="-6.95" y2="4.1" layer="51"/>
+<rectangle x1="-8" y1="3.4" x2="-6.95" y2="3.6" layer="51"/>
+<rectangle x1="-8" y1="2.9" x2="-6.95" y2="3.1" layer="51"/>
+<rectangle x1="-8" y1="2.4" x2="-6.95" y2="2.6" layer="51"/>
+<rectangle x1="-8" y1="1.9" x2="-6.95" y2="2.1" layer="51"/>
+<rectangle x1="-8" y1="1.4" x2="-6.95" y2="1.6" layer="51"/>
+<rectangle x1="-8" y1="0.9" x2="-6.95" y2="1.1" layer="51"/>
+<rectangle x1="-8" y1="0.4" x2="-6.95" y2="0.6" layer="51"/>
+<rectangle x1="-8" y1="-0.1" x2="-6.95" y2="0.1" layer="51"/>
+<rectangle x1="-8" y1="-0.6" x2="-6.95" y2="-0.4" layer="51"/>
+<rectangle x1="-8" y1="-1.1" x2="-6.95" y2="-0.9" layer="51"/>
+<rectangle x1="-8" y1="-1.6" x2="-6.95" y2="-1.4" layer="51"/>
+<rectangle x1="-8" y1="-2.1" x2="-6.95" y2="-1.9" layer="51"/>
+<rectangle x1="-8" y1="-2.6" x2="-6.95" y2="-2.4" layer="51"/>
+<rectangle x1="-8" y1="-3.1" x2="-6.95" y2="-2.9" layer="51"/>
+<rectangle x1="-8" y1="-3.6" x2="-6.95" y2="-3.4" layer="51"/>
+<rectangle x1="-8" y1="-4.1" x2="-6.95" y2="-3.9" layer="51"/>
+<rectangle x1="-8" y1="-4.6" x2="-6.95" y2="-4.4" layer="51"/>
+<rectangle x1="-8" y1="-5.1" x2="-6.95" y2="-4.9" layer="51"/>
+<rectangle x1="-8" y1="-5.6" x2="-6.95" y2="-5.4" layer="51"/>
+<rectangle x1="-8" y1="-6.1" x2="-6.95" y2="-5.9" layer="51"/>
+<rectangle x1="-6.525" y1="-7.575" x2="-5.475" y2="-7.375" layer="51"/>
+<rectangle x1="-6.025" y1="-7.575" x2="-4.975" y2="-7.375" layer="51"/>
+<rectangle x1="-5.525" y1="-7.575" x2="-4.475" y2="-7.375" layer="51"/>
+<rectangle x1="-5.025" y1="-7.575" x2="-3.975" y2="-7.375" layer="51"/>
+<rectangle x1="-4.525" y1="-7.575" x2="-3.475" y2="-7.375" layer="51"/>
+<rectangle x1="-4.025" y1="-7.575" x2="-2.975" y2="-7.375" layer="51"/>
+<rectangle x1="-3.525" y1="-7.575" x2="-2.475" y2="-7.375" layer="51"/>
+<rectangle x1="-3.025" y1="-7.575" x2="-1.975" y2="-7.375" layer="51"/>
+<rectangle x1="-2.525" y1="-7.575" x2="-1.475" y2="-7.375" layer="51"/>
+<rectangle x1="-2.025" y1="-7.575" x2="-0.975" y2="-7.375" layer="51"/>
+<rectangle x1="-1.525" y1="-7.575" x2="-0.475" y2="-7.375" layer="51"/>
+<rectangle x1="-1.025" y1="-7.575" x2="0.025" y2="-7.375" layer="51"/>
+<rectangle x1="-0.525" y1="-7.575" x2="0.525" y2="-7.375" layer="51"/>
+<rectangle x1="-0.025" y1="-7.575" x2="1.025" y2="-7.375" layer="51"/>
+<rectangle x1="0.475" y1="-7.575" x2="1.525" y2="-7.375" layer="51"/>
+<rectangle x1="0.975" y1="-7.575" x2="2.025" y2="-7.375" layer="51"/>
+<rectangle x1="1.475" y1="-7.575" x2="2.525" y2="-7.375" layer="51"/>
+<rectangle x1="1.975" y1="-7.575" x2="3.025" y2="-7.375" layer="51"/>
+<rectangle x1="2.475" y1="-7.575" x2="3.525" y2="-7.375" layer="51"/>
+<rectangle x1="2.975" y1="-7.575" x2="4.025" y2="-7.375" layer="51"/>
+<rectangle x1="3.475" y1="-7.575" x2="4.525" y2="-7.375" layer="51"/>
+<rectangle x1="3.975" y1="-7.575" x2="5.025" y2="-7.375" layer="51"/>
+<rectangle x1="4.475" y1="-7.575" x2="5.525" y2="-7.375" layer="51"/>
+<rectangle x1="4.975" y1="-7.575" x2="6.025" y2="-7.375" layer="51"/>
+<rectangle x1="5.475" y1="-7.575" x2="6.525" y2="-7.375" layer="51"/>
+<rectangle x1="6.95" y1="-6.1" x2="8" y2="-5.9" layer="51"/>
+<rectangle x1="6.95" y1="-5.6" x2="8" y2="-5.4" layer="51"/>
+<rectangle x1="6.95" y1="-5.1" x2="8" y2="-4.9" layer="51"/>
+<rectangle x1="6.95" y1="-4.6" x2="8" y2="-4.4" layer="51"/>
+<rectangle x1="6.95" y1="-4.1" x2="8" y2="-3.9" layer="51"/>
+<rectangle x1="6.95" y1="-3.6" x2="8" y2="-3.4" layer="51"/>
+<rectangle x1="6.95" y1="-3.1" x2="8" y2="-2.9" layer="51"/>
+<rectangle x1="6.95" y1="-2.6" x2="8" y2="-2.4" layer="51"/>
+<rectangle x1="6.95" y1="-2.1" x2="8" y2="-1.9" layer="51"/>
+<rectangle x1="6.95" y1="-1.6" x2="8" y2="-1.4" layer="51"/>
+<rectangle x1="6.95" y1="-1.1" x2="8" y2="-0.9" layer="51"/>
+<rectangle x1="6.95" y1="-0.6" x2="8" y2="-0.4" layer="51"/>
+<rectangle x1="6.95" y1="-0.1" x2="8" y2="0.1" layer="51"/>
+<rectangle x1="6.95" y1="0.4" x2="8" y2="0.6" layer="51"/>
+<rectangle x1="6.95" y1="0.9" x2="8" y2="1.1" layer="51"/>
+<rectangle x1="6.95" y1="1.4" x2="8" y2="1.6" layer="51"/>
+<rectangle x1="6.95" y1="1.9" x2="8" y2="2.1" layer="51"/>
+<rectangle x1="6.95" y1="2.4" x2="8" y2="2.6" layer="51"/>
+<rectangle x1="6.95" y1="2.9" x2="8" y2="3.1" layer="51"/>
+<rectangle x1="6.95" y1="3.4" x2="8" y2="3.6" layer="51"/>
+<rectangle x1="6.95" y1="3.9" x2="8" y2="4.1" layer="51"/>
+<rectangle x1="6.95" y1="4.4" x2="8" y2="4.6" layer="51"/>
+<rectangle x1="6.95" y1="4.9" x2="8" y2="5.1" layer="51"/>
+<rectangle x1="6.95" y1="5.4" x2="8" y2="5.6" layer="51"/>
+<rectangle x1="6.95" y1="5.9" x2="8" y2="6.1" layer="51"/>
+<rectangle x1="5.475" y1="7.375" x2="6.525" y2="7.575" layer="51"/>
+<rectangle x1="4.975" y1="7.375" x2="6.025" y2="7.575" layer="51"/>
+<rectangle x1="4.475" y1="7.375" x2="5.525" y2="7.575" layer="51"/>
+<rectangle x1="3.975" y1="7.375" x2="5.025" y2="7.575" layer="51"/>
+<rectangle x1="3.475" y1="7.375" x2="4.525" y2="7.575" layer="51"/>
+<rectangle x1="2.975" y1="7.375" x2="4.025" y2="7.575" layer="51"/>
+<rectangle x1="2.475" y1="7.375" x2="3.525" y2="7.575" layer="51"/>
+<rectangle x1="1.975" y1="7.375" x2="3.025" y2="7.575" layer="51"/>
+<rectangle x1="1.475" y1="7.375" x2="2.525" y2="7.575" layer="51"/>
+<rectangle x1="0.975" y1="7.375" x2="2.025" y2="7.575" layer="51"/>
+<rectangle x1="0.475" y1="7.375" x2="1.525" y2="7.575" layer="51"/>
+<rectangle x1="-0.025" y1="7.375" x2="1.025" y2="7.575" layer="51"/>
+<rectangle x1="-0.525" y1="7.375" x2="0.525" y2="7.575" layer="51"/>
+<rectangle x1="-1.025" y1="7.375" x2="0.025" y2="7.575" layer="51"/>
+<rectangle x1="-1.525" y1="7.375" x2="-0.475" y2="7.575" layer="51"/>
+<rectangle x1="-2.025" y1="7.375" x2="-0.975" y2="7.575" layer="51"/>
+<rectangle x1="-2.525" y1="7.375" x2="-1.475" y2="7.575" layer="51"/>
+<rectangle x1="-3.025" y1="7.375" x2="-1.975" y2="7.575" layer="51"/>
+<rectangle x1="-3.525" y1="7.375" x2="-2.475" y2="7.575" layer="51"/>
+<rectangle x1="-4.025" y1="7.375" x2="-2.975" y2="7.575" layer="51"/>
+<rectangle x1="-4.525" y1="7.375" x2="-3.475" y2="7.575" layer="51"/>
+<rectangle x1="-5.025" y1="7.375" x2="-3.975" y2="7.575" layer="51"/>
+<rectangle x1="-5.525" y1="7.375" x2="-4.475" y2="7.575" layer="51"/>
+<rectangle x1="-6.025" y1="7.375" x2="-4.975" y2="7.575" layer="51"/>
+<rectangle x1="-6.525" y1="7.375" x2="-5.475" y2="7.575" layer="51"/>
+<wire x1="-6.85" y1="6.25" x2="-6.85" y2="6.85" width="0.254" layer="51"/>
+<wire x1="-6.85" y1="6.25" x2="-6.25" y2="6.85" width="0.254" layer="21"/>
+<wire x1="-6.85" y1="6.25" x2="-6.25" y2="6.85" width="0.254" layer="51"/>
+<circle x="-6.1" y="6.1" radius="0.2499" width="0.254" layer="51"/>
+<wire x1="-6.65" y1="6.8" x2="-6.65" y2="6.55" width="0.254" layer="51"/>
+<wire x1="-6.65" y1="6.8" x2="-6.65" y2="6.5" width="0.254" layer="21"/>
+</package>
+<package name="X6,0X3,5">
+<wire x1="-2.6" y1="1.446" x2="-2.346" y2="1.7" width="0.1" layer="21"/>
+<wire x1="-2.346" y1="1.7" x2="2.346" y2="1.7" width="0.1" layer="21"/>
+<wire x1="2.346" y1="1.7" x2="2.6" y2="1.446" width="0.1" layer="21"/>
+<wire x1="2.6" y1="1.446" x2="2.6" y2="-1.446" width="0.1" layer="21"/>
+<wire x1="2.6" y1="-1.446" x2="2.346" y2="-1.7" width="0.1" layer="21"/>
+<wire x1="2.346" y1="-1.7" x2="-2.346" y2="-1.7" width="0.1" layer="21"/>
+<wire x1="-2.346" y1="-1.7" x2="-2.6" y2="-1.446" width="0.1" layer="21"/>
+<wire x1="-2.6" y1="-1.446" x2="-2.6" y2="1.446" width="0.1" layer="21"/>
+<wire x1="-1.27" y1="-1.27" x2="-0.635" y2="-1.27" width="0.1" layer="21"/>
+<wire x1="-0.635" y1="-1.27" x2="-0.635" y2="0" width="0.1" layer="21"/>
+<wire x1="-0.635" y1="0" x2="-0.381" y2="0" width="0.1" layer="21"/>
+<wire x1="-0.381" y1="0" x2="-0.381" y2="0.635" width="0.1" layer="21"/>
+<wire x1="-0.381" y1="0" x2="-0.381" y2="-0.635" width="0.1" layer="21"/>
+<wire x1="-0.127" y1="0.635" x2="0.127" y2="0.635" width="0.1" layer="21"/>
+<wire x1="0.127" y1="0.635" x2="0.127" y2="-0.635" width="0.1" layer="21"/>
+<wire x1="0.127" y1="-0.635" x2="-0.127" y2="-0.635" width="0.1" layer="21"/>
+<wire x1="-0.127" y1="-0.635" x2="-0.127" y2="0.635" width="0.1" layer="21"/>
+<wire x1="0.381" y1="0.635" x2="0.381" y2="0" width="0.1" layer="21"/>
+<wire x1="0.381" y1="0" x2="0.381" y2="-0.635" width="0.1" layer="21"/>
+<wire x1="0.381" y1="0" x2="0.635" y2="0" width="0.1" layer="21"/>
+<wire x1="0.635" y1="0" x2="0.635" y2="1.27" width="0.1" layer="21"/>
+<wire x1="0.635" y1="1.27" x2="1.27" y2="1.27" width="0.1" layer="21"/>
+<smd name="1" x="-2.275" y="-1.1" dx="1.65" dy="1.3" layer="1"/>
+<smd name="2" x="2.275" y="-1.1" dx="1.65" dy="1.3" layer="1"/>
+<smd name="3" x="2.275" y="1.1" dx="1.65" dy="1.3" layer="1"/>
+<smd name="4" x="-2.275" y="1.1" dx="1.65" dy="1.3" layer="1"/>
+<text x="-2.54" y="1.905" size="1.016" layer="27" ratio="15">&gt;VALUE</text>
+<text x="-2.54" y="-3.175" size="1.016" layer="25" ratio="15">&gt;NAME</text>
+</package>
+<package name="L_2.9X2.9">
+<smd name="2" x="1.2" y="0" dx="1.6" dy="1" layer="1" rot="R90"/>
+<smd name="1" x="-1.2" y="0" dx="1.6" dy="1" layer="1" rot="R90"/>
+<wire x1="-1.5" y1="-1.5" x2="1.5" y2="-1.5" width="0.127" layer="21"/>
+<wire x1="1.5" y1="-1.5" x2="1.5" y2="1.5" width="0.127" layer="21"/>
+<wire x1="1.5" y1="1.5" x2="-1.5" y2="1.5" width="0.127" layer="21"/>
+<wire x1="-1.5" y1="1.5" x2="-1.5" y2="-1.5" width="0.127" layer="21"/>
+<circle x="0" y="0" radius="1.3" width="0.127" layer="21"/>
+<circle x="0" y="0.6" radius="0.15" width="0.4064" layer="35"/>
+<circle x="0" y="-0.6" radius="0.15" width="0.4064" layer="35"/>
+<text x="-1.5" y="1.55" size="1.27" layer="25">&gt;NAME</text>
+<text x="-1.5" y="-2.9" size="1.27" layer="27">&gt;VALUE</text>
+</package>
+<package name="L_2.5X2.0">
+<smd name="1" x="-1.25" y="0" dx="2" dy="0.9" layer="1" rot="R90"/>
+<smd name="2" x="1.25" y="0" dx="2" dy="0.9" layer="1" rot="R90"/>
+<wire x1="-0.6" y1="-1" x2="0.6" y2="-1" width="0.127" layer="21"/>
+<wire x1="0.6" y1="-1" x2="1.25" y2="-0.6" width="0.127" layer="21"/>
+<wire x1="1.25" y1="-0.6" x2="1.25" y2="0.6" width="0.127" layer="21"/>
+<wire x1="1.25" y1="0.6" x2="0.6" y2="1" width="0.127" layer="21"/>
+<wire x1="0.6" y1="1" x2="-0.6" y2="1" width="0.127" layer="21"/>
+<wire x1="-0.6" y1="1" x2="-1.25" y2="0.6" width="0.127" layer="21"/>
+<wire x1="-1.25" y1="0.6" x2="-1.25" y2="-0.6" width="0.127" layer="21"/>
+<wire x1="-1.25" y1="-0.6" x2="-0.6" y2="-1" width="0.127" layer="21"/>
+<circle x="0" y="0.5" radius="0.14141875" width="0.4064" layer="35"/>
+<circle x="0" y="-0.5" radius="0.14141875" width="0.4064" layer="35"/>
+<text x="-2.45" y="1.1" size="1.27" layer="25">&gt;NAME</text>
+<text x="-2.4" y="-2.6" size="1.27" layer="27">&gt;VALUE</text>
+</package>
+<package name="SOT89-5">
+<smd name="1" x="-1.5" y="-1.85" dx="1.5" dy="0.7" layer="1" rot="R90"/>
+<smd name="3" x="1.5" y="-1.85" dx="1.5" dy="0.7" layer="1" rot="R90"/>
+<smd name="4" x="1.5" y="1.85" dx="1.5" dy="0.7" layer="1" rot="R90"/>
+<smd name="5" x="-1.5" y="1.85" dx="1.5" dy="0.7" layer="1" rot="R90"/>
+<smd name="2" x="0" y="0" dx="5.2" dy="1" layer="1" rot="R90"/>
+<polygon width="0.1778" layer="1">
+<vertex x="-0.45" y="1.15"/>
+<vertex x="-1.1" y="0.5"/>
+<vertex x="-1.1" y="-0.5"/>
+<vertex x="-0.45" y="-1.15"/>
+<vertex x="0.45" y="-1.15"/>
+<vertex x="1.1" y="-0.5"/>
+<vertex x="1.1" y="0.5"/>
+<vertex x="0.45" y="1.15"/>
+</polygon>
+<polygon width="0.127" layer="29">
+<vertex x="-0.55" y="1.2"/>
+<vertex x="-1.2" y="0.55"/>
+<vertex x="-1.2" y="-0.55"/>
+<vertex x="-0.55" y="-1.2"/>
+<vertex x="0.55" y="-1.2"/>
+<vertex x="1.2" y="-0.55"/>
+<vertex x="1.2" y="0.55"/>
+<vertex x="0.55" y="1.2"/>
+</polygon>
+<wire x1="-2.3" y1="-1.3" x2="2.3" y2="-1.3" width="0.127" layer="21"/>
+<wire x1="2.3" y1="-1.3" x2="2.3" y2="1.3" width="0.127" layer="21"/>
+<wire x1="2.3" y1="1.3" x2="-2.3" y2="1.3" width="0.127" layer="21"/>
+<wire x1="-2.3" y1="1.3" x2="-2.3" y2="-1.3" width="0.127" layer="21"/>
+<text x="-2.3" y="2.85" size="1.27" layer="25">&gt;NAME</text>
+<text x="-2.3" y="2.85" size="1.27" layer="27">&gt;VALUE</text>
+<rectangle x1="-1.75" y1="1.35" x2="-1.25" y2="2.35" layer="21"/>
+<rectangle x1="1.25" y1="1.35" x2="1.75" y2="2.35" layer="21"/>
+<rectangle x1="1.25" y1="-2.35" x2="1.75" y2="-1.35" layer="21"/>
+<rectangle x1="-0.25" y1="-2.35" x2="0.25" y2="-1.35" layer="21"/>
+<rectangle x1="-1.75" y1="-2.35" x2="-1.25" y2="-1.35" layer="21"/>
+<polygon width="0.127" layer="21">
+<vertex x="-0.35" y="1.3"/>
+<vertex x="-0.35" y="1.6" curve="-90"/>
+<vertex x="-0.2" y="1.75"/>
+<vertex x="0.2" y="1.75" curve="-90"/>
+<vertex x="0.35" y="1.6"/>
+<vertex x="0.35" y="1.3"/>
+</polygon>
+<rectangle x1="-0.2" y1="1.8" x2="0.2" y2="2.35" layer="21"/>
+</package>
+<package name="DF37NB-24DS-0.4V">
+<wire x1="-3.65" y1="-1.25" x2="3.65" y2="-1.25" width="0.127" layer="21"/>
+<wire x1="3.65" y1="-1.25" x2="3.65" y2="1.25" width="0.127" layer="21"/>
+<wire x1="3.65" y1="1.25" x2="-3.65" y2="1.25" width="0.127" layer="21"/>
+<wire x1="-3.65" y1="1.25" x2="-3.65" y2="-1.25" width="0.127" layer="21"/>
+<wire x1="-3.05" y1="0.9" x2="-3.3" y2="0.65" width="0.1" layer="21"/>
+<wire x1="-3.3" y1="0.65" x2="-3.3" y2="-0.7" width="0.1" layer="21"/>
+<wire x1="-3.3" y1="-0.7" x2="-3.1" y2="-0.9" width="0.1" layer="21"/>
+<wire x1="-3.1" y1="-0.9" x2="3.1" y2="-0.9" width="0.1" layer="21"/>
+<wire x1="3.1" y1="-0.9" x2="3.3" y2="-0.7" width="0.1" layer="21"/>
+<wire x1="3.3" y1="-0.7" x2="3.3" y2="0.65" width="0.1" layer="21"/>
+<wire x1="3.3" y1="0.65" x2="3.05" y2="0.9" width="0.1" layer="21"/>
+<wire x1="3.05" y1="0.9" x2="-3.05" y2="0.9" width="0.1" layer="21"/>
+<smd name="19" x="-0.2" y="1.35" dx="0.65" dy="0.25" layer="1" rot="R90" stop="no" thermals="no" cream="no"/>
+<smd name="6" x="-0.2" y="-1.35" dx="0.65" dy="0.25" layer="1" rot="R90" stop="no" thermals="no" cream="no"/>
+<smd name="20" x="-0.6" y="1.35" dx="0.65" dy="0.25" layer="1" rot="R90" stop="no" thermals="no" cream="no"/>
+<smd name="21" x="-1" y="1.35" dx="0.65" dy="0.25" layer="1" rot="R90" stop="no" thermals="no" cream="no"/>
+<smd name="18" x="0.2" y="1.35" dx="0.65" dy="0.25" layer="1" rot="R90" stop="no" thermals="no" cream="no"/>
+<smd name="17" x="0.6" y="1.35" dx="0.65" dy="0.25" layer="1" rot="R90" stop="no" thermals="no" cream="no"/>
+<smd name="16" x="1" y="1.35" dx="0.65" dy="0.25" layer="1" rot="R90" stop="no" thermals="no" cream="no"/>
+<smd name="15" x="1.4" y="1.35" dx="0.65" dy="0.25" layer="1" rot="R90" stop="no" thermals="no" cream="no"/>
+<smd name="22" x="-1.4" y="1.35" dx="0.65" dy="0.25" layer="1" rot="R90" stop="no" thermals="no" cream="no"/>
+<smd name="23" x="-1.8" y="1.35" dx="0.65" dy="0.25" layer="1" rot="R90" stop="no" thermals="no" cream="no"/>
+<smd name="24" x="-2.2" y="1.35" dx="0.65" dy="0.25" layer="1" rot="R90" stop="no" thermals="no" cream="no"/>
+<smd name="14" x="1.8" y="1.35" dx="0.65" dy="0.25" layer="1" rot="R90" stop="no" thermals="no" cream="no"/>
+<smd name="13" x="2.2" y="1.35" dx="0.65" dy="0.25" layer="1" rot="R90" stop="no" thermals="no" cream="no"/>
+<smd name="7" x="0.2" y="-1.35" dx="0.65" dy="0.25" layer="1" rot="R90" stop="no" thermals="no" cream="no"/>
+<smd name="8" x="0.6" y="-1.35" dx="0.65" dy="0.25" layer="1" rot="R90" stop="no" thermals="no" cream="no"/>
+<smd name="9" x="1" y="-1.35" dx="0.65" dy="0.25" layer="1" rot="R90" stop="no" thermals="no" cream="no"/>
+<smd name="10" x="1.4" y="-1.35" dx="0.65" dy="0.25" layer="1" rot="R90" stop="no" thermals="no" cream="no"/>
+<smd name="11" x="1.8" y="-1.35" dx="0.65" dy="0.25" layer="1" rot="R90" stop="no" thermals="no" cream="no"/>
+<smd name="12" x="2.2" y="-1.35" dx="0.65" dy="0.25" layer="1" rot="R90" stop="no" thermals="no" cream="no"/>
+<smd name="5" x="-0.6" y="-1.35" dx="0.65" dy="0.25" layer="1" rot="R90" stop="no" thermals="no" cream="no"/>
+<smd name="4" x="-1" y="-1.35" dx="0.65" dy="0.25" layer="1" rot="R90" stop="no" thermals="no" cream="no"/>
+<smd name="3" x="-1.4" y="-1.35" dx="0.65" dy="0.25" layer="1" rot="R90" stop="no" thermals="no" cream="no"/>
+<smd name="2" x="-1.8" y="-1.35" dx="0.65" dy="0.25" layer="1" rot="R90" stop="no" thermals="no" cream="no"/>
+<smd name="1" x="-2.2" y="-1.35" dx="0.65" dy="0.25" layer="1" rot="R90" stop="no" thermals="no" cream="no"/>
+<smd name="25" x="3.45" y="0" dx="1.1" dy="0.4" layer="1" rot="R90" cream="no"/>
+<smd name="26" x="-3.45" y="0" dx="1.1" dy="0.4" layer="1" rot="R90" cream="no"/>
+<rectangle x1="-2.3" y1="1.05" x2="-2.1" y2="1.65" layer="31"/>
+<rectangle x1="-1.9" y1="1.05" x2="-1.7" y2="1.65" layer="31"/>
+<rectangle x1="-1.5" y1="1.05" x2="-1.3" y2="1.65" layer="31"/>
+<rectangle x1="-1.1" y1="1.05" x2="-0.9" y2="1.65" layer="31"/>
+<rectangle x1="-0.7" y1="1.05" x2="-0.5" y2="1.65" layer="31"/>
+<rectangle x1="-0.3" y1="1.05" x2="-0.1" y2="1.65" layer="31"/>
+<text x="-2.375" y="-0.775" size="0.4064" layer="21">1</text>
+<text x="1.9" y="-0.775" size="0.4064" layer="21">12</text>
+<text x="1.9" y="0.35" size="0.4064" layer="21">13</text>
+<text x="-2.5" y="0.35" size="0.4064" layer="21">24</text>
+<rectangle x1="0.1" y1="1.05" x2="0.3" y2="1.65" layer="31"/>
+<rectangle x1="0.5" y1="1.05" x2="0.7" y2="1.65" layer="31"/>
+<rectangle x1="0.9" y1="1.05" x2="1.1" y2="1.65" layer="31"/>
+<rectangle x1="1.3" y1="1.05" x2="1.5" y2="1.65" layer="31"/>
+<rectangle x1="1.7" y1="1.05" x2="1.9" y2="1.65" layer="31"/>
+<rectangle x1="2.1" y1="1.05" x2="2.3" y2="1.65" layer="31"/>
+<rectangle x1="-2.3" y1="-1.65" x2="-2.1" y2="-1.05" layer="31"/>
+<rectangle x1="-1.9" y1="-1.65" x2="-1.7" y2="-1.05" layer="31"/>
+<rectangle x1="-1.5" y1="-1.65" x2="-1.3" y2="-1.05" layer="31"/>
+<rectangle x1="-1.1" y1="-1.65" x2="-0.9" y2="-1.05" layer="31"/>
+<rectangle x1="-0.7" y1="-1.65" x2="-0.5" y2="-1.05" layer="31"/>
+<rectangle x1="-0.3" y1="-1.65" x2="-0.1" y2="-1.05" layer="31"/>
+<rectangle x1="0.1" y1="-1.65" x2="0.3" y2="-1.05" layer="31"/>
+<rectangle x1="0.5" y1="-1.65" x2="0.7" y2="-1.05" layer="31"/>
+<rectangle x1="0.9" y1="-1.65" x2="1.1" y2="-1.05" layer="31"/>
+<rectangle x1="1.3" y1="-1.65" x2="1.5" y2="-1.05" layer="31"/>
+<rectangle x1="1.7" y1="-1.65" x2="1.9" y2="-1.05" layer="31"/>
+<rectangle x1="2.1" y1="-1.65" x2="2.3" y2="-1.05" layer="31"/>
+<rectangle x1="-3.6" y1="-0.5" x2="-3.3" y2="0.5" layer="31"/>
+<rectangle x1="3.3" y1="-0.5" x2="3.6" y2="0.5" layer="31"/>
+<rectangle x1="-2.375" y1="0.975" x2="2.375" y2="1.725" layer="29"/>
+<rectangle x1="-2.375" y1="-1.725" x2="2.375" y2="-0.975" layer="29"/>
+<text x="-3.683" y="1.905" size="1.016" layer="25">&gt;NAME</text>
+<text x="-3.683" y="1.905" size="1.016" layer="27">&gt;VALUE</text>
+</package>
+<package name="DF37NB-10DS-0.4V">
+<wire x1="-2.25" y1="-1.25" x2="2.25" y2="-1.25" width="0.127" layer="21"/>
+<wire x1="2.25" y1="-1.25" x2="2.25" y2="1.25" width="0.127" layer="21"/>
+<wire x1="2.25" y1="1.25" x2="-2.25" y2="1.25" width="0.127" layer="21"/>
+<wire x1="-2.25" y1="1.25" x2="-2.25" y2="-1.25" width="0.127" layer="21"/>
+<wire x1="-1.6" y1="0.9" x2="-1.85" y2="0.65" width="0.1" layer="21"/>
+<wire x1="-1.85" y1="0.65" x2="-1.85" y2="-0.7" width="0.1" layer="21"/>
+<wire x1="-1.85" y1="-0.7" x2="-1.65" y2="-0.9" width="0.1" layer="21"/>
+<wire x1="-1.65" y1="-0.9" x2="1.65" y2="-0.9" width="0.1" layer="21"/>
+<wire x1="1.65" y1="-0.9" x2="1.85" y2="-0.7" width="0.1" layer="21"/>
+<wire x1="1.85" y1="-0.7" x2="1.85" y2="0.65" width="0.1" layer="21"/>
+<wire x1="1.85" y1="0.65" x2="1.6" y2="0.9" width="0.1" layer="21"/>
+<wire x1="1.6" y1="0.9" x2="-1.6" y2="0.9" width="0.1" layer="21"/>
+<smd name="5" x="0.8" y="1.35" dx="0.65" dy="0.25" layer="1" rot="R270" stop="no" cream="no"/>
+<smd name="4" x="0.4" y="1.35" dx="0.65" dy="0.25" layer="1" rot="R270" stop="no" cream="no"/>
+<smd name="3" x="0" y="1.35" dx="0.65" dy="0.25" layer="1" rot="R270" stop="no" thermals="no" cream="no"/>
+<smd name="2" x="-0.4" y="1.35" dx="0.65" dy="0.25" layer="1" rot="R270" stop="no" cream="no"/>
+<smd name="1" x="-0.8" y="1.35" dx="0.65" dy="0.25" layer="1" rot="R270" stop="no" cream="no"/>
+<smd name="6" x="0.8" y="-1.35" dx="0.65" dy="0.25" layer="1" rot="R90" stop="no" cream="no"/>
+<smd name="7" x="0.4" y="-1.35" dx="0.65" dy="0.25" layer="1" rot="R90" stop="no" cream="no"/>
+<smd name="8" x="0" y="-1.35" dx="0.65" dy="0.25" layer="1" rot="R90" stop="no" thermals="no" cream="no"/>
+<smd name="9" x="-0.4" y="-1.35" dx="0.65" dy="0.25" layer="1" rot="R90" stop="no" cream="no"/>
+<smd name="10" x="-0.8" y="-1.35" dx="0.65" dy="0.25" layer="1" rot="R90" stop="no" cream="no"/>
+<smd name="11" x="2.05" y="0" dx="1.1" dy="0.4" layer="1" rot="R90" cream="no"/>
+<smd name="12" x="-2.05" y="0" dx="1.1" dy="0.4" layer="1" rot="R90" cream="no"/>
+<text x="0.65" y="-0.65" size="0.4064" layer="21">6</text>
+<text x="-1.15" y="-0.65" size="0.4064" layer="21">10</text>
+<rectangle x1="-0.9" y1="-1.65" x2="-0.7" y2="-1.05" layer="31"/>
+<rectangle x1="-0.5" y1="-1.65" x2="-0.3" y2="-1.05" layer="31"/>
+<rectangle x1="-0.1" y1="-1.65" x2="0.1" y2="-1.05" layer="31"/>
+<rectangle x1="0.3" y1="-1.65" x2="0.5" y2="-1.05" layer="31"/>
+<rectangle x1="0.7" y1="-1.65" x2="0.9" y2="-1.05" layer="31"/>
+<rectangle x1="0.7" y1="1.05" x2="0.9" y2="1.65" layer="31" rot="R180"/>
+<rectangle x1="0.3" y1="1.05" x2="0.5" y2="1.65" layer="31" rot="R180"/>
+<rectangle x1="-0.1" y1="1.05" x2="0.1" y2="1.65" layer="31" rot="R180"/>
+<rectangle x1="-0.5" y1="1.05" x2="-0.3" y2="1.65" layer="31" rot="R180"/>
+<rectangle x1="-0.9" y1="1.05" x2="-0.7" y2="1.65" layer="31" rot="R180"/>
+<rectangle x1="-2.2" y1="-0.5" x2="-1.9" y2="0.5" layer="31"/>
+<rectangle x1="1.9" y1="-0.5" x2="2.2" y2="0.5" layer="31"/>
+<text x="-2.667" y="1.905" size="1.016" layer="25">&gt;NAME</text>
+<text x="-2.667" y="1.905" size="1.016" layer="27">&gt;VALUE</text>
+<text x="0.65" y="0.3" size="0.4064" layer="21">5</text>
+<text x="-0.95" y="0.3" size="0.4064" layer="21">1</text>
+<rectangle x1="-1" y1="0.95" x2="1" y2="1.75" layer="29"/>
+<rectangle x1="-1" y1="-1.75" x2="1" y2="-0.95" layer="29"/>
+</package>
+<package name="SOT23-5_REFLOW">
+<wire x1="-1.524" y1="0.508" x2="-1.143" y2="0.508" width="0.127" layer="21"/>
+<wire x1="-1.143" y1="0.508" x2="1.524" y2="0.508" width="0.127" layer="21"/>
+<wire x1="1.524" y1="0.508" x2="1.524" y2="-0.508" width="0.127" layer="21"/>
+<wire x1="1.524" y1="-0.508" x2="-1.143" y2="-0.508" width="0.127" layer="21"/>
+<wire x1="-1.143" y1="-0.508" x2="-1.524" y2="-0.508" width="0.127" layer="21"/>
+<wire x1="-1.524" y1="-0.508" x2="-1.524" y2="0.508" width="0.127" layer="21"/>
+<wire x1="-1.143" y1="0.508" x2="-1.143" y2="-0.508" width="0.1524" layer="21"/>
+<smd name="4" x="0.95" y="1.2" dx="0.8" dy="1" layer="1" rot="R180"/>
+<smd name="5" x="-0.95" y="1.2" dx="0.8" dy="1" layer="1" rot="R180"/>
+<smd name="2" x="0" y="-1.2" dx="0.75" dy="1" layer="1" rot="R180"/>
+<text x="1.27" y="2.54" size="1.016" layer="25" rot="R180">&gt;NAME</text>
+<text x="1.27" y="2.54" size="1.016" layer="27" rot="R180">&gt;VALUE</text>
+<rectangle x1="-0.3048" y1="-1.27" x2="0.3048" y2="-0.5588" layer="27" rot="R180"/>
+<rectangle x1="0.65" y1="0.381" x2="1.25" y2="0.762" layer="21" rot="R180"/>
+<rectangle x1="-1.25" y1="0.381" x2="-0.65" y2="0.762" layer="21" rot="R180"/>
+<rectangle x1="-0.3048" y1="-0.762" x2="0.3048" y2="-0.381" layer="21" rot="R180"/>
+<rectangle x1="-0.3048" y1="-1.27" x2="0.3048" y2="-0.5588" layer="27" rot="R180"/>
+<rectangle x1="-1.25" y1="0.5588" x2="-0.65" y2="1.27" layer="27" rot="R180"/>
+<rectangle x1="0.65" y1="0.5588" x2="1.25" y2="1.27" layer="27" rot="R180"/>
+<rectangle x1="-1.65" y1="-0.15" x2="1.65" y2="0.15" layer="35" rot="R180"/>
+<smd name="1" x="-0.95" y="-1.2" dx="0.75" dy="1" layer="1" rot="R180"/>
+<rectangle x1="0.6452" y1="-1.27" x2="1.2548" y2="-0.5588" layer="27" rot="R180"/>
+<smd name="3" x="0.95" y="-1.2" dx="0.75" dy="1" layer="1" rot="R180"/>
+<rectangle x1="-0.3048" y1="-0.762" x2="0.3048" y2="-0.381" layer="21" rot="R180"/>
+<rectangle x1="-1.2548" y1="-0.762" x2="-0.6452" y2="-0.381" layer="21" rot="R180"/>
+<rectangle x1="-1.2548" y1="-1.27" x2="-0.6452" y2="-0.5588" layer="27" rot="R180"/>
+<rectangle x1="0.6452" y1="-0.762" x2="1.2548" y2="-0.381" layer="21" rot="R180"/>
+</package>
+<package name="LQFP100_NO_CENTER_NO_TDOCU">
+<wire x1="-6.85" y1="6.85" x2="-6.25" y2="6.85" width="0.254" layer="21"/>
+<wire x1="-6.25" y1="6.85" x2="6.6" y2="6.85" width="0.254" layer="21"/>
+<wire x1="6.6" y1="6.85" x2="6.85" y2="6.6" width="0.254" layer="21"/>
+<wire x1="6.85" y1="6.6" x2="6.85" y2="-6.6" width="0.254" layer="21"/>
+<wire x1="6.85" y1="-6.6" x2="6.6" y2="-6.85" width="0.254" layer="21"/>
+<wire x1="6.6" y1="-6.85" x2="-6.6" y2="-6.85" width="0.254" layer="21"/>
+<wire x1="-6.6" y1="-6.85" x2="-6.85" y2="-6.6" width="0.254" layer="21"/>
+<wire x1="-6.85" y1="-6.6" x2="-6.85" y2="6.25" width="0.254" layer="21"/>
+<wire x1="-6.85" y1="6.25" x2="-6.85" y2="6.85" width="0.254" layer="21"/>
+<circle x="-6.1" y="6.1" radius="0.2499" width="0.254" layer="21"/>
+<smd name="1" x="-7.725" y="6" dx="1.35" dy="0.29" layer="1"/>
+<smd name="2" x="-7.725" y="5.5" dx="1.35" dy="0.29" layer="1"/>
+<smd name="3" x="-7.725" y="5" dx="1.35" dy="0.29" layer="1"/>
+<smd name="4" x="-7.725" y="4.5" dx="1.35" dy="0.29" layer="1"/>
+<smd name="5" x="-7.725" y="4" dx="1.35" dy="0.29" layer="1"/>
+<smd name="6" x="-7.725" y="3.5" dx="1.35" dy="0.29" layer="1"/>
+<smd name="7" x="-7.725" y="3" dx="1.35" dy="0.29" layer="1"/>
+<smd name="8" x="-7.725" y="2.5" dx="1.35" dy="0.29" layer="1"/>
+<smd name="9" x="-7.725" y="2" dx="1.35" dy="0.29" layer="1"/>
+<smd name="10" x="-7.725" y="1.5" dx="1.35" dy="0.29" layer="1"/>
+<smd name="11" x="-7.725" y="1" dx="1.35" dy="0.29" layer="1"/>
+<smd name="12" x="-7.725" y="0.5" dx="1.35" dy="0.29" layer="1"/>
+<smd name="13" x="-7.725" y="0" dx="1.35" dy="0.29" layer="1"/>
+<smd name="14" x="-7.725" y="-0.5" dx="1.35" dy="0.29" layer="1"/>
+<smd name="15" x="-7.725" y="-1" dx="1.35" dy="0.29" layer="1"/>
+<smd name="16" x="-7.725" y="-1.5" dx="1.35" dy="0.29" layer="1"/>
+<smd name="17" x="-7.725" y="-2" dx="1.35" dy="0.29" layer="1"/>
+<smd name="18" x="-7.725" y="-2.5" dx="1.35" dy="0.29" layer="1"/>
+<smd name="19" x="-7.725" y="-3" dx="1.35" dy="0.29" layer="1"/>
+<smd name="20" x="-7.725" y="-3.5" dx="1.35" dy="0.29" layer="1"/>
+<smd name="21" x="-7.725" y="-4" dx="1.35" dy="0.29" layer="1"/>
+<smd name="22" x="-7.725" y="-4.5" dx="1.35" dy="0.29" layer="1"/>
+<smd name="23" x="-7.725" y="-5" dx="1.35" dy="0.29" layer="1"/>
+<smd name="24" x="-7.725" y="-5.5" dx="1.35" dy="0.29" layer="1"/>
+<smd name="25" x="-7.725" y="-6" dx="1.35" dy="0.29" layer="1"/>
+<smd name="26" x="-6" y="-7.725" dx="1.35" dy="0.29" layer="1" rot="R90"/>
+<smd name="27" x="-5.5" y="-7.725" dx="1.35" dy="0.29" layer="1" rot="R90"/>
+<smd name="28" x="-5" y="-7.725" dx="1.35" dy="0.29" layer="1" rot="R90"/>
+<smd name="29" x="-4.5" y="-7.725" dx="1.35" dy="0.29" layer="1" rot="R90"/>
+<smd name="30" x="-4" y="-7.725" dx="1.35" dy="0.29" layer="1" rot="R90"/>
+<smd name="31" x="-3.5" y="-7.725" dx="1.35" dy="0.29" layer="1" rot="R90"/>
+<smd name="32" x="-3" y="-7.725" dx="1.35" dy="0.29" layer="1" rot="R90"/>
+<smd name="33" x="-2.5" y="-7.725" dx="1.35" dy="0.29" layer="1" rot="R90"/>
+<smd name="34" x="-2" y="-7.725" dx="1.35" dy="0.29" layer="1" rot="R90"/>
+<smd name="35" x="-1.5" y="-7.725" dx="1.35" dy="0.29" layer="1" rot="R90"/>
+<smd name="36" x="-1" y="-7.725" dx="1.35" dy="0.29" layer="1" rot="R90"/>
+<smd name="37" x="-0.5" y="-7.725" dx="1.35" dy="0.29" layer="1" rot="R90"/>
+<smd name="38" x="0" y="-7.725" dx="1.35" dy="0.29" layer="1" rot="R90"/>
+<smd name="39" x="0.5" y="-7.725" dx="1.35" dy="0.29" layer="1" rot="R90"/>
+<smd name="40" x="1" y="-7.725" dx="1.35" dy="0.29" layer="1" rot="R90"/>
+<smd name="41" x="1.5" y="-7.725" dx="1.35" dy="0.29" layer="1" rot="R90"/>
+<smd name="42" x="2" y="-7.725" dx="1.35" dy="0.29" layer="1" rot="R90"/>
+<smd name="43" x="2.5" y="-7.725" dx="1.35" dy="0.29" layer="1" rot="R90"/>
+<smd name="44" x="3" y="-7.725" dx="1.35" dy="0.29" layer="1" rot="R90"/>
+<smd name="45" x="3.5" y="-7.725" dx="1.35" dy="0.29" layer="1" rot="R90"/>
+<smd name="46" x="4" y="-7.725" dx="1.35" dy="0.29" layer="1" rot="R90"/>
+<smd name="47" x="4.5" y="-7.725" dx="1.35" dy="0.29" layer="1" rot="R90"/>
+<smd name="48" x="5" y="-7.725" dx="1.35" dy="0.29" layer="1" rot="R90"/>
+<smd name="49" x="5.5" y="-7.725" dx="1.35" dy="0.29" layer="1" rot="R90"/>
+<smd name="50" x="6" y="-7.725" dx="1.35" dy="0.29" layer="1" rot="R90"/>
+<smd name="51" x="7.725" y="-6" dx="1.35" dy="0.29" layer="1" rot="R180"/>
+<smd name="52" x="7.725" y="-5.5" dx="1.35" dy="0.29" layer="1" rot="R180"/>
+<smd name="53" x="7.725" y="-5" dx="1.35" dy="0.29" layer="1" rot="R180"/>
+<smd name="54" x="7.725" y="-4.5" dx="1.35" dy="0.29" layer="1" rot="R180"/>
+<smd name="55" x="7.725" y="-4" dx="1.35" dy="0.29" layer="1" rot="R180"/>
+<smd name="56" x="7.725" y="-3.5" dx="1.35" dy="0.29" layer="1" rot="R180"/>
+<smd name="57" x="7.725" y="-3" dx="1.35" dy="0.29" layer="1" rot="R180"/>
+<smd name="58" x="7.725" y="-2.5" dx="1.35" dy="0.29" layer="1" rot="R180"/>
+<smd name="59" x="7.725" y="-2" dx="1.35" dy="0.29" layer="1" rot="R180"/>
+<smd name="60" x="7.725" y="-1.5" dx="1.35" dy="0.29" layer="1" rot="R180"/>
+<smd name="61" x="7.725" y="-1" dx="1.35" dy="0.29" layer="1" rot="R180"/>
+<smd name="62" x="7.725" y="-0.5" dx="1.35" dy="0.29" layer="1" rot="R180"/>
+<smd name="63" x="7.725" y="0" dx="1.35" dy="0.29" layer="1" rot="R180"/>
+<smd name="64" x="7.725" y="0.5" dx="1.35" dy="0.29" layer="1" rot="R180"/>
+<smd name="65" x="7.725" y="1" dx="1.35" dy="0.29" layer="1" rot="R180"/>
+<smd name="66" x="7.725" y="1.5" dx="1.35" dy="0.29" layer="1" rot="R180"/>
+<smd name="67" x="7.725" y="2" dx="1.35" dy="0.29" layer="1" rot="R180"/>
+<smd name="68" x="7.725" y="2.5" dx="1.35" dy="0.29" layer="1" rot="R180"/>
+<smd name="69" x="7.725" y="3" dx="1.35" dy="0.29" layer="1" rot="R180"/>
+<smd name="70" x="7.725" y="3.5" dx="1.35" dy="0.29" layer="1" rot="R180"/>
+<smd name="71" x="7.725" y="4" dx="1.35" dy="0.29" layer="1" rot="R180"/>
+<smd name="72" x="7.725" y="4.5" dx="1.35" dy="0.29" layer="1" rot="R180"/>
+<smd name="73" x="7.725" y="5" dx="1.35" dy="0.29" layer="1" rot="R180"/>
+<smd name="74" x="7.725" y="5.5" dx="1.35" dy="0.29" layer="1" rot="R180"/>
+<smd name="75" x="7.725" y="6" dx="1.35" dy="0.29" layer="1" rot="R180"/>
+<smd name="76" x="6" y="7.725" dx="1.35" dy="0.29" layer="1" rot="R270"/>
+<smd name="77" x="5.5" y="7.725" dx="1.35" dy="0.29" layer="1" rot="R270"/>
+<smd name="78" x="5" y="7.725" dx="1.35" dy="0.29" layer="1" rot="R270"/>
+<smd name="79" x="4.5" y="7.725" dx="1.35" dy="0.29" layer="1" rot="R270"/>
+<smd name="80" x="4" y="7.725" dx="1.35" dy="0.29" layer="1" rot="R270"/>
+<smd name="81" x="3.5" y="7.725" dx="1.35" dy="0.29" layer="1" rot="R270"/>
+<smd name="82" x="3" y="7.725" dx="1.35" dy="0.29" layer="1" rot="R270"/>
+<smd name="83" x="2.5" y="7.725" dx="1.35" dy="0.29" layer="1" rot="R270"/>
+<smd name="84" x="2" y="7.725" dx="1.35" dy="0.29" layer="1" rot="R270"/>
+<smd name="85" x="1.5" y="7.725" dx="1.35" dy="0.29" layer="1" rot="R270"/>
+<smd name="86" x="1" y="7.725" dx="1.35" dy="0.29" layer="1" rot="R270"/>
+<smd name="87" x="0.5" y="7.725" dx="1.35" dy="0.29" layer="1" rot="R270"/>
+<smd name="88" x="0" y="7.725" dx="1.35" dy="0.29" layer="1" rot="R270"/>
+<smd name="89" x="-0.5" y="7.725" dx="1.35" dy="0.29" layer="1" rot="R270"/>
+<smd name="90" x="-1" y="7.725" dx="1.35" dy="0.29" layer="1" rot="R270"/>
+<smd name="91" x="-1.5" y="7.725" dx="1.35" dy="0.29" layer="1" rot="R270"/>
+<smd name="92" x="-2" y="7.725" dx="1.35" dy="0.29" layer="1" rot="R270"/>
+<smd name="93" x="-2.5" y="7.725" dx="1.35" dy="0.29" layer="1" rot="R270"/>
+<smd name="94" x="-3" y="7.725" dx="1.35" dy="0.29" layer="1" rot="R270"/>
+<smd name="95" x="-3.5" y="7.725" dx="1.35" dy="0.29" layer="1" rot="R270"/>
+<smd name="96" x="-4" y="7.725" dx="1.35" dy="0.29" layer="1" rot="R270"/>
+<smd name="97" x="-4.5" y="7.725" dx="1.35" dy="0.29" layer="1" rot="R270"/>
+<smd name="98" x="-5" y="7.725" dx="1.35" dy="0.29" layer="1" rot="R270"/>
+<smd name="99" x="-5.5" y="7.725" dx="1.35" dy="0.29" layer="1" rot="R270"/>
+<smd name="100" x="-6" y="7.725" dx="1.35" dy="0.29" layer="1" rot="R270"/>
+<text x="-3.2" y="0.5001" size="1.27" layer="25">&gt;NAME</text>
+<text x="-3.1501" y="-1.6999" size="1.27" layer="27">&gt;VALUE</text>
+<wire x1="-6.85" y1="6.25" x2="-6.25" y2="6.85" width="0.254" layer="21"/>
+<wire x1="-6.65" y1="6.8" x2="-6.65" y2="6.5" width="0.254" layer="21"/>
+</package>
+<package name="LQFP100_NO_CENTER">
+<wire x1="-6.85" y1="6.85" x2="-6.25" y2="6.85" width="0.254" layer="21"/>
+<wire x1="-6.25" y1="6.85" x2="6.6" y2="6.85" width="0.254" layer="21"/>
+<wire x1="6.6" y1="6.85" x2="6.85" y2="6.6" width="0.254" layer="21"/>
+<wire x1="6.85" y1="6.6" x2="6.85" y2="-6.6" width="0.254" layer="21"/>
+<wire x1="6.85" y1="-6.6" x2="6.6" y2="-6.85" width="0.254" layer="21"/>
+<wire x1="6.6" y1="-6.85" x2="-6.6" y2="-6.85" width="0.254" layer="21"/>
+<wire x1="-6.6" y1="-6.85" x2="-6.85" y2="-6.6" width="0.254" layer="21"/>
+<wire x1="-6.85" y1="-6.6" x2="-6.85" y2="6.25" width="0.254" layer="21"/>
+<wire x1="-6.85" y1="6.25" x2="-6.85" y2="6.85" width="0.254" layer="21"/>
+<wire x1="-6.85" y1="6.85" x2="-6.25" y2="6.85" width="0.254" layer="51"/>
+<wire x1="-6.25" y1="6.85" x2="6.6" y2="6.85" width="0.254" layer="51"/>
+<wire x1="6.6" y1="6.85" x2="6.85" y2="6.6" width="0.254" layer="51"/>
+<wire x1="6.85" y1="6.6" x2="6.85" y2="-6.6" width="0.254" layer="51"/>
+<wire x1="6.85" y1="-6.6" x2="6.6" y2="-6.85" width="0.254" layer="51"/>
+<wire x1="6.6" y1="-6.85" x2="-6.6" y2="-6.85" width="0.254" layer="51"/>
+<wire x1="-6.6" y1="-6.85" x2="-6.85" y2="-6.6" width="0.254" layer="51"/>
+<wire x1="-6.85" y1="-6.6" x2="-6.85" y2="6.25" width="0.254" layer="51"/>
+<circle x="-6.1" y="6.1" radius="0.2499" width="0.254" layer="21"/>
+<smd name="1" x="-7.725" y="6" dx="1.35" dy="0.29" layer="1"/>
+<smd name="2" x="-7.725" y="5.5" dx="1.35" dy="0.29" layer="1"/>
+<smd name="3" x="-7.725" y="5" dx="1.35" dy="0.29" layer="1"/>
+<smd name="4" x="-7.725" y="4.5" dx="1.35" dy="0.29" layer="1"/>
+<smd name="5" x="-7.725" y="4" dx="1.35" dy="0.29" layer="1"/>
+<smd name="6" x="-7.725" y="3.5" dx="1.35" dy="0.29" layer="1"/>
+<smd name="7" x="-7.725" y="3" dx="1.35" dy="0.29" layer="1"/>
+<smd name="8" x="-7.725" y="2.5" dx="1.35" dy="0.29" layer="1"/>
+<smd name="9" x="-7.725" y="2" dx="1.35" dy="0.29" layer="1"/>
+<smd name="10" x="-7.725" y="1.5" dx="1.35" dy="0.29" layer="1"/>
+<smd name="11" x="-7.725" y="1" dx="1.35" dy="0.29" layer="1"/>
+<smd name="12" x="-7.725" y="0.5" dx="1.35" dy="0.29" layer="1"/>
+<smd name="13" x="-7.725" y="0" dx="1.35" dy="0.29" layer="1"/>
+<smd name="14" x="-7.725" y="-0.5" dx="1.35" dy="0.29" layer="1"/>
+<smd name="15" x="-7.725" y="-1" dx="1.35" dy="0.29" layer="1"/>
+<smd name="16" x="-7.725" y="-1.5" dx="1.35" dy="0.29" layer="1"/>
+<smd name="17" x="-7.725" y="-2" dx="1.35" dy="0.29" layer="1"/>
+<smd name="18" x="-7.725" y="-2.5" dx="1.35" dy="0.29" layer="1"/>
+<smd name="19" x="-7.725" y="-3" dx="1.35" dy="0.29" layer="1"/>
+<smd name="20" x="-7.725" y="-3.5" dx="1.35" dy="0.29" layer="1"/>
+<smd name="21" x="-7.725" y="-4" dx="1.35" dy="0.29" layer="1"/>
+<smd name="22" x="-7.725" y="-4.5" dx="1.35" dy="0.29" layer="1"/>
+<smd name="23" x="-7.725" y="-5" dx="1.35" dy="0.29" layer="1"/>
+<smd name="24" x="-7.725" y="-5.5" dx="1.35" dy="0.29" layer="1"/>
+<smd name="25" x="-7.725" y="-6" dx="1.35" dy="0.29" layer="1"/>
+<smd name="26" x="-6" y="-7.725" dx="1.35" dy="0.29" layer="1" rot="R90"/>
+<smd name="27" x="-5.5" y="-7.725" dx="1.35" dy="0.29" layer="1" rot="R90"/>
+<smd name="28" x="-5" y="-7.725" dx="1.35" dy="0.29" layer="1" rot="R90"/>
+<smd name="29" x="-4.5" y="-7.725" dx="1.35" dy="0.29" layer="1" rot="R90"/>
+<smd name="30" x="-4" y="-7.725" dx="1.35" dy="0.29" layer="1" rot="R90"/>
+<smd name="31" x="-3.5" y="-7.725" dx="1.35" dy="0.29" layer="1" rot="R90"/>
+<smd name="32" x="-3" y="-7.725" dx="1.35" dy="0.29" layer="1" rot="R90"/>
+<smd name="33" x="-2.5" y="-7.725" dx="1.35" dy="0.29" layer="1" rot="R90"/>
+<smd name="34" x="-2" y="-7.725" dx="1.35" dy="0.29" layer="1" rot="R90"/>
+<smd name="35" x="-1.5" y="-7.725" dx="1.35" dy="0.29" layer="1" rot="R90"/>
+<smd name="36" x="-1" y="-7.725" dx="1.35" dy="0.29" layer="1" rot="R90"/>
+<smd name="37" x="-0.5" y="-7.725" dx="1.35" dy="0.29" layer="1" rot="R90"/>
+<smd name="38" x="0" y="-7.725" dx="1.35" dy="0.29" layer="1" rot="R90"/>
+<smd name="39" x="0.5" y="-7.725" dx="1.35" dy="0.29" layer="1" rot="R90"/>
+<smd name="40" x="1" y="-7.725" dx="1.35" dy="0.29" layer="1" rot="R90"/>
+<smd name="41" x="1.5" y="-7.725" dx="1.35" dy="0.29" layer="1" rot="R90"/>
+<smd name="42" x="2" y="-7.725" dx="1.35" dy="0.29" layer="1" rot="R90"/>
+<smd name="43" x="2.5" y="-7.725" dx="1.35" dy="0.29" layer="1" rot="R90"/>
+<smd name="44" x="3" y="-7.725" dx="1.35" dy="0.29" layer="1" rot="R90"/>
+<smd name="45" x="3.5" y="-7.725" dx="1.35" dy="0.29" layer="1" rot="R90"/>
+<smd name="46" x="4" y="-7.725" dx="1.35" dy="0.29" layer="1" rot="R90"/>
+<smd name="47" x="4.5" y="-7.725" dx="1.35" dy="0.29" layer="1" rot="R90"/>
+<smd name="48" x="5" y="-7.725" dx="1.35" dy="0.29" layer="1" rot="R90"/>
+<smd name="49" x="5.5" y="-7.725" dx="1.35" dy="0.29" layer="1" rot="R90"/>
+<smd name="50" x="6" y="-7.725" dx="1.35" dy="0.29" layer="1" rot="R90"/>
+<smd name="51" x="7.725" y="-6" dx="1.35" dy="0.29" layer="1" rot="R180"/>
+<smd name="52" x="7.725" y="-5.5" dx="1.35" dy="0.29" layer="1" rot="R180"/>
+<smd name="53" x="7.725" y="-5" dx="1.35" dy="0.29" layer="1" rot="R180"/>
+<smd name="54" x="7.725" y="-4.5" dx="1.35" dy="0.29" layer="1" rot="R180"/>
+<smd name="55" x="7.725" y="-4" dx="1.35" dy="0.29" layer="1" rot="R180"/>
+<smd name="56" x="7.725" y="-3.5" dx="1.35" dy="0.29" layer="1" rot="R180"/>
+<smd name="57" x="7.725" y="-3" dx="1.35" dy="0.29" layer="1" rot="R180"/>
+<smd name="58" x="7.725" y="-2.5" dx="1.35" dy="0.29" layer="1" rot="R180"/>
+<smd name="59" x="7.725" y="-2" dx="1.35" dy="0.29" layer="1" rot="R180"/>
+<smd name="60" x="7.725" y="-1.5" dx="1.35" dy="0.29" layer="1" rot="R180"/>
+<smd name="61" x="7.725" y="-1" dx="1.35" dy="0.29" layer="1" rot="R180"/>
+<smd name="62" x="7.725" y="-0.5" dx="1.35" dy="0.29" layer="1" rot="R180"/>
+<smd name="63" x="7.725" y="0" dx="1.35" dy="0.29" layer="1" rot="R180"/>
+<smd name="64" x="7.725" y="0.5" dx="1.35" dy="0.29" layer="1" rot="R180"/>
+<smd name="65" x="7.725" y="1" dx="1.35" dy="0.29" layer="1" rot="R180"/>
+<smd name="66" x="7.725" y="1.5" dx="1.35" dy="0.29" layer="1" rot="R180"/>
+<smd name="67" x="7.725" y="2" dx="1.35" dy="0.29" layer="1" rot="R180"/>
+<smd name="68" x="7.725" y="2.5" dx="1.35" dy="0.29" layer="1" rot="R180"/>
+<smd name="69" x="7.725" y="3" dx="1.35" dy="0.29" layer="1" rot="R180"/>
+<smd name="70" x="7.725" y="3.5" dx="1.35" dy="0.29" layer="1" rot="R180"/>
+<smd name="71" x="7.725" y="4" dx="1.35" dy="0.29" layer="1" rot="R180"/>
+<smd name="72" x="7.725" y="4.5" dx="1.35" dy="0.29" layer="1" rot="R180"/>
+<smd name="73" x="7.725" y="5" dx="1.35" dy="0.29" layer="1" rot="R180"/>
+<smd name="74" x="7.725" y="5.5" dx="1.35" dy="0.29" layer="1" rot="R180"/>
+<smd name="75" x="7.725" y="6" dx="1.35" dy="0.29" layer="1" rot="R180"/>
+<smd name="76" x="6" y="7.725" dx="1.35" dy="0.29" layer="1" rot="R270"/>
+<smd name="77" x="5.5" y="7.725" dx="1.35" dy="0.29" layer="1" rot="R270"/>
+<smd name="78" x="5" y="7.725" dx="1.35" dy="0.29" layer="1" rot="R270"/>
+<smd name="79" x="4.5" y="7.725" dx="1.35" dy="0.29" layer="1" rot="R270"/>
+<smd name="80" x="4" y="7.725" dx="1.35" dy="0.29" layer="1" rot="R270"/>
+<smd name="81" x="3.5" y="7.725" dx="1.35" dy="0.29" layer="1" rot="R270"/>
+<smd name="82" x="3" y="7.725" dx="1.35" dy="0.29" layer="1" rot="R270"/>
+<smd name="83" x="2.5" y="7.725" dx="1.35" dy="0.29" layer="1" rot="R270"/>
+<smd name="84" x="2" y="7.725" dx="1.35" dy="0.29" layer="1" rot="R270"/>
+<smd name="85" x="1.5" y="7.725" dx="1.35" dy="0.29" layer="1" rot="R270"/>
+<smd name="86" x="1" y="7.725" dx="1.35" dy="0.29" layer="1" rot="R270"/>
+<smd name="87" x="0.5" y="7.725" dx="1.35" dy="0.29" layer="1" rot="R270"/>
+<smd name="88" x="0" y="7.725" dx="1.35" dy="0.29" layer="1" rot="R270"/>
+<smd name="89" x="-0.5" y="7.725" dx="1.35" dy="0.29" layer="1" rot="R270"/>
+<smd name="90" x="-1" y="7.725" dx="1.35" dy="0.29" layer="1" rot="R270"/>
+<smd name="91" x="-1.5" y="7.725" dx="1.35" dy="0.29" layer="1" rot="R270"/>
+<smd name="92" x="-2" y="7.725" dx="1.35" dy="0.29" layer="1" rot="R270"/>
+<smd name="93" x="-2.5" y="7.725" dx="1.35" dy="0.29" layer="1" rot="R270"/>
+<smd name="94" x="-3" y="7.725" dx="1.35" dy="0.29" layer="1" rot="R270"/>
+<smd name="95" x="-3.5" y="7.725" dx="1.35" dy="0.29" layer="1" rot="R270"/>
+<smd name="96" x="-4" y="7.725" dx="1.35" dy="0.29" layer="1" rot="R270"/>
+<smd name="97" x="-4.5" y="7.725" dx="1.35" dy="0.29" layer="1" rot="R270"/>
+<smd name="98" x="-5" y="7.725" dx="1.35" dy="0.29" layer="1" rot="R270"/>
+<smd name="99" x="-5.5" y="7.725" dx="1.35" dy="0.29" layer="1" rot="R270"/>
+<smd name="100" x="-6" y="7.725" dx="1.35" dy="0.29" layer="1" rot="R270"/>
+<text x="-3.2" y="0.5001" size="1.27" layer="25">&gt;NAME</text>
+<text x="-3.1501" y="-1.6999" size="1.27" layer="27">&gt;VALUE</text>
+<rectangle x1="-8" y1="5.9" x2="-6.95" y2="6.1" layer="51"/>
+<rectangle x1="-8" y1="5.4" x2="-6.95" y2="5.6" layer="51"/>
+<rectangle x1="-8" y1="4.9" x2="-6.95" y2="5.1" layer="51"/>
+<rectangle x1="-8" y1="4.4" x2="-6.95" y2="4.6" layer="51"/>
+<rectangle x1="-8" y1="3.9" x2="-6.95" y2="4.1" layer="51"/>
+<rectangle x1="-8" y1="3.4" x2="-6.95" y2="3.6" layer="51"/>
+<rectangle x1="-8" y1="2.9" x2="-6.95" y2="3.1" layer="51"/>
+<rectangle x1="-8" y1="2.4" x2="-6.95" y2="2.6" layer="51"/>
+<rectangle x1="-8" y1="1.9" x2="-6.95" y2="2.1" layer="51"/>
+<rectangle x1="-8" y1="1.4" x2="-6.95" y2="1.6" layer="51"/>
+<rectangle x1="-8" y1="0.9" x2="-6.95" y2="1.1" layer="51"/>
+<rectangle x1="-8" y1="0.4" x2="-6.95" y2="0.6" layer="51"/>
+<rectangle x1="-8" y1="-0.1" x2="-6.95" y2="0.1" layer="51"/>
+<rectangle x1="-8" y1="-0.6" x2="-6.95" y2="-0.4" layer="51"/>
+<rectangle x1="-8" y1="-1.1" x2="-6.95" y2="-0.9" layer="51"/>
+<rectangle x1="-8" y1="-1.6" x2="-6.95" y2="-1.4" layer="51"/>
+<rectangle x1="-8" y1="-2.1" x2="-6.95" y2="-1.9" layer="51"/>
+<rectangle x1="-8" y1="-2.6" x2="-6.95" y2="-2.4" layer="51"/>
+<rectangle x1="-8" y1="-3.1" x2="-6.95" y2="-2.9" layer="51"/>
+<rectangle x1="-8" y1="-3.6" x2="-6.95" y2="-3.4" layer="51"/>
+<rectangle x1="-8" y1="-4.1" x2="-6.95" y2="-3.9" layer="51"/>
+<rectangle x1="-8" y1="-4.6" x2="-6.95" y2="-4.4" layer="51"/>
+<rectangle x1="-8" y1="-5.1" x2="-6.95" y2="-4.9" layer="51"/>
+<rectangle x1="-8" y1="-5.6" x2="-6.95" y2="-5.4" layer="51"/>
+<rectangle x1="-8" y1="-6.1" x2="-6.95" y2="-5.9" layer="51"/>
+<rectangle x1="-6.525" y1="-7.575" x2="-5.475" y2="-7.375" layer="51"/>
+<rectangle x1="-6.025" y1="-7.575" x2="-4.975" y2="-7.375" layer="51"/>
+<rectangle x1="-5.525" y1="-7.575" x2="-4.475" y2="-7.375" layer="51"/>
+<rectangle x1="-5.025" y1="-7.575" x2="-3.975" y2="-7.375" layer="51"/>
+<rectangle x1="-4.525" y1="-7.575" x2="-3.475" y2="-7.375" layer="51"/>
+<rectangle x1="-4.025" y1="-7.575" x2="-2.975" y2="-7.375" layer="51"/>
+<rectangle x1="-3.525" y1="-7.575" x2="-2.475" y2="-7.375" layer="51"/>
+<rectangle x1="-3.025" y1="-7.575" x2="-1.975" y2="-7.375" layer="51"/>
+<rectangle x1="-2.525" y1="-7.575" x2="-1.475" y2="-7.375" layer="51"/>
+<rectangle x1="-2.025" y1="-7.575" x2="-0.975" y2="-7.375" layer="51"/>
+<rectangle x1="-1.525" y1="-7.575" x2="-0.475" y2="-7.375" layer="51"/>
+<rectangle x1="-1.025" y1="-7.575" x2="0.025" y2="-7.375" layer="51"/>
+<rectangle x1="-0.525" y1="-7.575" x2="0.525" y2="-7.375" layer="51"/>
+<rectangle x1="-0.025" y1="-7.575" x2="1.025" y2="-7.375" layer="51"/>
+<rectangle x1="0.475" y1="-7.575" x2="1.525" y2="-7.375" layer="51"/>
+<rectangle x1="0.975" y1="-7.575" x2="2.025" y2="-7.375" layer="51"/>
+<rectangle x1="1.475" y1="-7.575" x2="2.525" y2="-7.375" layer="51"/>
+<rectangle x1="1.975" y1="-7.575" x2="3.025" y2="-7.375" layer="51"/>
+<rectangle x1="2.475" y1="-7.575" x2="3.525" y2="-7.375" layer="51"/>
+<rectangle x1="2.975" y1="-7.575" x2="4.025" y2="-7.375" layer="51"/>
+<rectangle x1="3.475" y1="-7.575" x2="4.525" y2="-7.375" layer="51"/>
+<rectangle x1="3.975" y1="-7.575" x2="5.025" y2="-7.375" layer="51"/>
+<rectangle x1="4.475" y1="-7.575" x2="5.525" y2="-7.375" layer="51"/>
+<rectangle x1="4.975" y1="-7.575" x2="6.025" y2="-7.375" layer="51"/>
+<rectangle x1="5.475" y1="-7.575" x2="6.525" y2="-7.375" layer="51"/>
+<rectangle x1="6.95" y1="-6.1" x2="8" y2="-5.9" layer="51"/>
+<rectangle x1="6.95" y1="-5.6" x2="8" y2="-5.4" layer="51"/>
+<rectangle x1="6.95" y1="-5.1" x2="8" y2="-4.9" layer="51"/>
+<rectangle x1="6.95" y1="-4.6" x2="8" y2="-4.4" layer="51"/>
+<rectangle x1="6.95" y1="-4.1" x2="8" y2="-3.9" layer="51"/>
+<rectangle x1="6.95" y1="-3.6" x2="8" y2="-3.4" layer="51"/>
+<rectangle x1="6.95" y1="-3.1" x2="8" y2="-2.9" layer="51"/>
+<rectangle x1="6.95" y1="-2.6" x2="8" y2="-2.4" layer="51"/>
+<rectangle x1="6.95" y1="-2.1" x2="8" y2="-1.9" layer="51"/>
+<rectangle x1="6.95" y1="-1.6" x2="8" y2="-1.4" layer="51"/>
+<rectangle x1="6.95" y1="-1.1" x2="8" y2="-0.9" layer="51"/>
+<rectangle x1="6.95" y1="-0.6" x2="8" y2="-0.4" layer="51"/>
+<rectangle x1="6.95" y1="-0.1" x2="8" y2="0.1" layer="51"/>
+<rectangle x1="6.95" y1="0.4" x2="8" y2="0.6" layer="51"/>
+<rectangle x1="6.95" y1="0.9" x2="8" y2="1.1" layer="51"/>
+<rectangle x1="6.95" y1="1.4" x2="8" y2="1.6" layer="51"/>
+<rectangle x1="6.95" y1="1.9" x2="8" y2="2.1" layer="51"/>
+<rectangle x1="6.95" y1="2.4" x2="8" y2="2.6" layer="51"/>
+<rectangle x1="6.95" y1="2.9" x2="8" y2="3.1" layer="51"/>
+<rectangle x1="6.95" y1="3.4" x2="8" y2="3.6" layer="51"/>
+<rectangle x1="6.95" y1="3.9" x2="8" y2="4.1" layer="51"/>
+<rectangle x1="6.95" y1="4.4" x2="8" y2="4.6" layer="51"/>
+<rectangle x1="6.95" y1="4.9" x2="8" y2="5.1" layer="51"/>
+<rectangle x1="6.95" y1="5.4" x2="8" y2="5.6" layer="51"/>
+<rectangle x1="6.95" y1="5.9" x2="8" y2="6.1" layer="51"/>
+<rectangle x1="5.475" y1="7.375" x2="6.525" y2="7.575" layer="51"/>
+<rectangle x1="4.975" y1="7.375" x2="6.025" y2="7.575" layer="51"/>
+<rectangle x1="4.475" y1="7.375" x2="5.525" y2="7.575" layer="51"/>
+<rectangle x1="3.975" y1="7.375" x2="5.025" y2="7.575" layer="51"/>
+<rectangle x1="3.475" y1="7.375" x2="4.525" y2="7.575" layer="51"/>
+<rectangle x1="2.975" y1="7.375" x2="4.025" y2="7.575" layer="51"/>
+<rectangle x1="2.475" y1="7.375" x2="3.525" y2="7.575" layer="51"/>
+<rectangle x1="1.975" y1="7.375" x2="3.025" y2="7.575" layer="51"/>
+<rectangle x1="1.475" y1="7.375" x2="2.525" y2="7.575" layer="51"/>
+<rectangle x1="0.975" y1="7.375" x2="2.025" y2="7.575" layer="51"/>
+<rectangle x1="0.475" y1="7.375" x2="1.525" y2="7.575" layer="51"/>
+<rectangle x1="-0.025" y1="7.375" x2="1.025" y2="7.575" layer="51"/>
+<rectangle x1="-0.525" y1="7.375" x2="0.525" y2="7.575" layer="51"/>
+<rectangle x1="-1.025" y1="7.375" x2="0.025" y2="7.575" layer="51"/>
+<rectangle x1="-1.525" y1="7.375" x2="-0.475" y2="7.575" layer="51"/>
+<rectangle x1="-2.025" y1="7.375" x2="-0.975" y2="7.575" layer="51"/>
+<rectangle x1="-2.525" y1="7.375" x2="-1.475" y2="7.575" layer="51"/>
+<rectangle x1="-3.025" y1="7.375" x2="-1.975" y2="7.575" layer="51"/>
+<rectangle x1="-3.525" y1="7.375" x2="-2.475" y2="7.575" layer="51"/>
+<rectangle x1="-4.025" y1="7.375" x2="-2.975" y2="7.575" layer="51"/>
+<rectangle x1="-4.525" y1="7.375" x2="-3.475" y2="7.575" layer="51"/>
+<rectangle x1="-5.025" y1="7.375" x2="-3.975" y2="7.575" layer="51"/>
+<rectangle x1="-5.525" y1="7.375" x2="-4.475" y2="7.575" layer="51"/>
+<rectangle x1="-6.025" y1="7.375" x2="-4.975" y2="7.575" layer="51"/>
+<rectangle x1="-6.525" y1="7.375" x2="-5.475" y2="7.575" layer="51"/>
+<wire x1="-6.85" y1="6.25" x2="-6.85" y2="6.85" width="0.254" layer="51"/>
+<wire x1="-6.85" y1="6.25" x2="-6.25" y2="6.85" width="0.254" layer="21"/>
+<wire x1="-6.85" y1="6.25" x2="-6.25" y2="6.85" width="0.254" layer="51"/>
+<circle x="-6.1" y="6.1" radius="0.2499" width="0.254" layer="51"/>
+<wire x1="-6.65" y1="6.8" x2="-6.65" y2="6.55" width="0.254" layer="51"/>
+<wire x1="-6.65" y1="6.8" x2="-6.65" y2="6.5" width="0.254" layer="21"/>
+</package>
+<package name="USB_C_TE_1-2295018-2">
+<smd name="A6" x="-0.25" y="4.63" dx="0.8" dy="0.3" layer="1" rot="R90" stop="no" cream="no"/>
+<smd name="A7" x="0.25" y="4.63" dx="0.8" dy="0.3" layer="1" rot="R90" stop="no" cream="no"/>
+<smd name="A5" x="-0.75" y="4.63" dx="0.8" dy="0.3" layer="1" rot="R90" stop="no" cream="no"/>
+<smd name="A8" x="0.75" y="4.63" dx="0.8" dy="0.3" layer="1" rot="R90" stop="no" cream="no"/>
+<smd name="A4" x="-1.25" y="4.63" dx="0.8" dy="0.3" layer="1" rot="R90" stop="no" cream="no"/>
+<smd name="A9" x="1.25" y="4.63" dx="0.8" dy="0.3" layer="1" rot="R90" stop="no" cream="no"/>
+<smd name="A3" x="-1.75" y="4.63" dx="0.8" dy="0.3" layer="1" rot="R90" stop="no" cream="no"/>
+<smd name="A10" x="1.75" y="4.63" dx="0.8" dy="0.3" layer="1" rot="R90" stop="no" cream="no"/>
+<smd name="A2" x="-2.25" y="4.63" dx="0.8" dy="0.3" layer="1" rot="R90" stop="no" cream="no"/>
+<smd name="A11" x="2.25" y="4.63" dx="0.8" dy="0.3" layer="1" rot="R90" stop="no" cream="no"/>
+<smd name="A1" x="-2.75" y="4.63" dx="0.8" dy="0.3" layer="1" rot="R90" stop="no" cream="no"/>
+<smd name="A12" x="2.75" y="4.63" dx="0.8" dy="0.3" layer="1" rot="R90" stop="no" cream="no"/>
+<smd name="B7" x="-0.5" y="3.43" dx="0.8" dy="0.3" layer="1" rot="R90" stop="no" cream="no"/>
+<smd name="B6" x="0.5" y="3.43" dx="0.8" dy="0.3" layer="1" rot="R90" stop="no" cream="no"/>
+<smd name="B8" x="-1" y="3.43" dx="0.8" dy="0.3" layer="1" rot="R90" stop="no" cream="no"/>
+<smd name="B5" x="1" y="3.43" dx="0.8" dy="0.3" layer="1" rot="R90" stop="no" cream="no"/>
+<smd name="B9" x="-1.5" y="3.43" dx="0.8" dy="0.3" layer="1" rot="R90" stop="no" cream="no"/>
+<smd name="B4" x="1.5" y="3.43" dx="0.8" dy="0.3" layer="1" rot="R90" stop="no" cream="no"/>
+<smd name="B10" x="-2" y="3.43" dx="0.8" dy="0.3" layer="1" rot="R90" stop="no" cream="no"/>
+<smd name="B3" x="2" y="3.43" dx="0.8" dy="0.3" layer="1" rot="R90" stop="no" cream="no"/>
+<smd name="B11" x="-2.5" y="3.43" dx="0.8" dy="0.3" layer="1" rot="R90" stop="no" cream="no"/>
+<smd name="B2" x="2.5" y="3.43" dx="0.8" dy="0.3" layer="1" rot="R90" stop="no" cream="no"/>
+<smd name="B12" x="-3" y="3.43" dx="0.8" dy="0.3" layer="1" rot="R90" stop="no" cream="no"/>
+<smd name="B1" x="3" y="3.43" dx="0.8" dy="0.3" layer="1" rot="R90" stop="no" cream="no"/>
+<wire x1="4.55" y1="4.64" x2="4.55" y2="3.79" width="0.6" layer="46"/>
+<wire x1="4.55" y1="3.79" x2="4" y2="3.79" width="0.6" layer="46"/>
+<polygon width="0.02" layer="1">
+<vertex x="5.09" y="4.64"/>
+<vertex x="5.09" y="3.79" curve="-90"/>
+<vertex x="4.55" y="3.25"/>
+<vertex x="3.95" y="3.25" curve="-90"/>
+<vertex x="3.41" y="3.79" curve="-90"/>
+<vertex x="3.95" y="4.33" curve="90"/>
+<vertex x="4.01" y="4.39"/>
+<vertex x="4.01" y="4.64" curve="-90"/>
+<vertex x="4.55" y="5.18" curve="-90"/>
+</polygon>
+<polygon width="0.02" layer="2" pour="cutout">
+<vertex x="5.09" y="4.64"/>
+<vertex x="5.09" y="3.79" curve="-90"/>
+<vertex x="4.55" y="3.25"/>
+<vertex x="3.95" y="3.25" curve="-90"/>
+<vertex x="3.41" y="3.79" curve="-90"/>
+<vertex x="3.95" y="4.33" curve="90"/>
+<vertex x="4.01" y="4.39"/>
+<vertex x="4.01" y="4.64" curve="-90"/>
+<vertex x="4.55" y="5.18" curve="-90"/>
+</polygon>
+<polygon width="0.02" layer="15" pour="cutout">
+<vertex x="5.09" y="4.64"/>
+<vertex x="5.09" y="3.79" curve="-90"/>
+<vertex x="4.55" y="3.25"/>
+<vertex x="3.95" y="3.25" curve="-90"/>
+<vertex x="3.41" y="3.79" curve="-90"/>
+<vertex x="3.95" y="4.33" curve="90"/>
+<vertex x="4.01" y="4.39"/>
+<vertex x="4.01" y="4.64" curve="-90"/>
+<vertex x="4.55" y="5.18" curve="-90"/>
+</polygon>
+<polygon width="0.02" layer="16">
+<vertex x="5.09" y="4.64"/>
+<vertex x="5.09" y="3.79" curve="-90"/>
+<vertex x="4.55" y="3.25"/>
+<vertex x="3.95" y="3.25" curve="-90"/>
+<vertex x="3.41" y="3.79" curve="-90"/>
+<vertex x="3.95" y="4.33" curve="90"/>
+<vertex x="4.01" y="4.39"/>
+<vertex x="4.01" y="4.64" curve="-90"/>
+<vertex x="4.55" y="5.18" curve="-90"/>
+</polygon>
+<wire x1="-4.55" y1="4.64" x2="-4.55" y2="3.79" width="0.6" layer="46"/>
+<wire x1="-4.55" y1="3.79" x2="-4" y2="3.79" width="0.6" layer="46"/>
+<polygon width="0.02" layer="16">
+<vertex x="-5.09" y="4.64"/>
+<vertex x="-5.09" y="3.79" curve="90"/>
+<vertex x="-4.55" y="3.25"/>
+<vertex x="-3.95" y="3.25" curve="90"/>
+<vertex x="-3.41" y="3.79" curve="90"/>
+<vertex x="-3.95" y="4.33" curve="-90"/>
+<vertex x="-4.01" y="4.39"/>
+<vertex x="-4.01" y="4.64" curve="90"/>
+<vertex x="-4.55" y="5.18" curve="90"/>
+</polygon>
+<polygon width="0.02" layer="2" pour="cutout">
+<vertex x="-5.09" y="4.64"/>
+<vertex x="-5.09" y="3.79" curve="90"/>
+<vertex x="-4.55" y="3.25"/>
+<vertex x="-3.95" y="3.25" curve="90"/>
+<vertex x="-3.41" y="3.79" curve="90"/>
+<vertex x="-3.95" y="4.33" curve="-90"/>
+<vertex x="-4.01" y="4.39"/>
+<vertex x="-4.01" y="4.64" curve="90"/>
+<vertex x="-4.55" y="5.18" curve="90"/>
+</polygon>
+<polygon width="0.02" layer="15" pour="cutout">
+<vertex x="-5.09" y="4.64"/>
+<vertex x="-5.09" y="3.79" curve="90"/>
+<vertex x="-4.55" y="3.25"/>
+<vertex x="-3.95" y="3.25" curve="90"/>
+<vertex x="-3.41" y="3.79" curve="90"/>
+<vertex x="-3.95" y="4.33" curve="-90"/>
+<vertex x="-4.01" y="4.39"/>
+<vertex x="-4.01" y="4.64" curve="90"/>
+<vertex x="-4.55" y="5.18" curve="90"/>
+</polygon>
+<polygon width="0.02" layer="1">
+<vertex x="-5.09" y="4.64"/>
+<vertex x="-5.09" y="3.79" curve="90"/>
+<vertex x="-4.55" y="3.25"/>
+<vertex x="-3.95" y="3.25" curve="90"/>
+<vertex x="-3.41" y="3.79" curve="90"/>
+<vertex x="-3.95" y="4.33" curve="-90"/>
+<vertex x="-4.01" y="4.39"/>
+<vertex x="-4.01" y="4.64" curve="90"/>
+<vertex x="-4.55" y="5.18" curve="90"/>
+</polygon>
+<rectangle x1="-2.96" y1="4.17" x2="2.96" y2="5.09" layer="29"/>
+<wire x1="4.55" y1="4.64" x2="4.55" y2="3.79" width="1.2" layer="29"/>
+<wire x1="4.55" y1="3.79" x2="3.95" y2="3.79" width="1.2" layer="29"/>
+<rectangle x1="0.29" y1="2.97" x2="3.18" y2="3.89" layer="29"/>
+<wire x1="-4.55" y1="4.64" x2="-4.55" y2="3.79" width="1.2" layer="29"/>
+<wire x1="-4.55" y1="3.79" x2="-3.95" y2="3.79" width="1.2" layer="29"/>
+<rectangle x1="-3.18" y1="2.97" x2="-0.29" y2="3.89" layer="29"/>
+<pad name="SH4" x="-5.97" y="0" drill="0.5" diameter="1.1" shape="long" rot="R90"/>
+<pad name="SH3" x="5.97" y="0" drill="0.5" diameter="1.1" shape="long" rot="R90"/>
+<wire x1="-5.97" y1="0.55" x2="-5.97" y2="-0.55" width="0.5" layer="46"/>
+<wire x1="5.97" y1="0.55" x2="5.97" y2="-0.55" width="0.5" layer="46"/>
+<smd name="SH1" x="-4.55" y="4.09" dx="0.1" dy="0.1" layer="1" stop="no" thermals="no" cream="no"/>
+<smd name="SH2" x="4.55" y="4.09" dx="0.1" dy="0.1" layer="1" stop="no" thermals="no" cream="no"/>
+<wire x1="-4.55" y1="0" x2="-4.55" y2="4.89" width="0.1" layer="21"/>
+<wire x1="-4.55" y1="4.89" x2="4.55" y2="4.89" width="0.1" layer="21"/>
+<wire x1="4.55" y1="4.89" x2="4.55" y2="0" width="0.1" layer="21"/>
+<wire x1="4.55" y1="0" x2="-4.55" y2="0" width="0.1" layer="21"/>
+<wire x1="4.55" y1="0" x2="4.55" y2="-3.21" width="0.1" layer="21"/>
+<wire x1="4.55" y1="-3.21" x2="-4.55" y2="-3.21" width="0.1" layer="21"/>
+<wire x1="-4.55" y1="-3.21" x2="-4.55" y2="0" width="0.1" layer="21"/>
+<wire x1="-4.92" y1="-1.7" x2="-4.92" y2="2.84" width="0.05" layer="21" style="shortdash"/>
+<wire x1="-4.92" y1="2.84" x2="4.92" y2="2.84" width="0.05" layer="21" style="shortdash"/>
+<wire x1="4.92" y1="2.84" x2="4.92" y2="-1.7" width="0.05" layer="21" style="shortdash"/>
+<wire x1="4.92" y1="-1.7" x2="7" y2="-1.7" width="0.05" layer="21" style="shortdash"/>
+<wire x1="-4.92" y1="-1.7" x2="-7" y2="-1.7" width="0.05" layer="21" style="shortdash"/>
+<wire x1="-4.55" y1="4.64" x2="-4.55" y2="3.79" width="1.2" layer="30"/>
+<wire x1="-4.55" y1="3.79" x2="-3.95" y2="3.79" width="1.2" layer="30"/>
+<wire x1="4.55" y1="3.79" x2="3.95" y2="3.79" width="1.2" layer="30"/>
+<wire x1="4.55" y1="4.64" x2="4.55" y2="3.79" width="1.2" layer="30"/>
+<wire x1="-4.55" y1="4.64" x2="-4.55" y2="3.79" width="0.8" layer="31"/>
+<wire x1="-4.55" y1="3.79" x2="-4" y2="3.79" width="0.8" layer="31"/>
+<wire x1="4.55" y1="4.64" x2="4.55" y2="3.79" width="0.8" layer="31"/>
+<wire x1="4" y1="3.79" x2="4.55" y2="3.79" width="0.8" layer="31"/>
+<wire x1="-5.98" y1="0.55" x2="-5.98" y2="-0.55" width="0.7" layer="31"/>
+<wire x1="5.97" y1="0.55" x2="5.97" y2="-0.55" width="0.7" layer="31"/>
+<polygon width="0.02" layer="2" pour="cutout">
+<vertex x="-6.21" y="0"/>
+<vertex x="-6.21" y="0.55" curve="-90"/>
+<vertex x="-5.97" y="0.79" curve="-90"/>
+<vertex x="-5.73" y="0.55"/>
+<vertex x="-5.73" y="0"/>
+<vertex x="-5.73" y="-0.55" curve="-90"/>
+<vertex x="-5.97" y="-0.79" curve="-90"/>
+<vertex x="-6.21" y="-0.55"/>
+</polygon>
+<polygon width="0.02" layer="15" pour="cutout">
+<vertex x="-5.97" y="0.79" curve="-90"/>
+<vertex x="-5.73" y="0.55"/>
+<vertex x="-5.73" y="0"/>
+<vertex x="-5.73" y="-0.55" curve="-90"/>
+<vertex x="-5.97" y="-0.79" curve="-90"/>
+<vertex x="-6.21" y="-0.55"/>
+<vertex x="-6.21" y="0"/>
+<vertex x="-6.21" y="0.55" curve="-90"/>
+</polygon>
+<polygon width="0.02" layer="15" pour="cutout">
+<vertex x="5.97" y="0.79" curve="-90"/>
+<vertex x="6.21" y="0.55"/>
+<vertex x="6.21" y="0"/>
+<vertex x="6.21" y="-0.55" curve="-90"/>
+<vertex x="5.97" y="-0.79" curve="-90"/>
+<vertex x="5.73" y="-0.55"/>
+<vertex x="5.73" y="0"/>
+<vertex x="5.73" y="0.55" curve="-90"/>
+</polygon>
+<polygon width="0.02" layer="2" pour="cutout">
+<vertex x="5.97" y="0.79" curve="-90"/>
+<vertex x="6.21" y="0.55"/>
+<vertex x="6.21" y="0"/>
+<vertex x="6.21" y="-0.55" curve="-90"/>
+<vertex x="5.97" y="-0.79" curve="-90"/>
+<vertex x="5.73" y="-0.55"/>
+<vertex x="5.73" y="0"/>
+<vertex x="5.73" y="0.55" curve="-90"/>
+</polygon>
+<rectangle x1="-2.87" y1="4.26" x2="-2.63" y2="5" layer="31"/>
+<rectangle x1="-2.37" y1="4.26" x2="-2.13" y2="5" layer="31"/>
+<rectangle x1="-1.87" y1="4.26" x2="-1.63" y2="5" layer="31"/>
+<rectangle x1="-1.37" y1="4.26" x2="-1.13" y2="5" layer="31"/>
+<rectangle x1="-0.87" y1="4.26" x2="-0.63" y2="5" layer="31"/>
+<rectangle x1="-0.37" y1="4.26" x2="-0.13" y2="5" layer="31"/>
+<rectangle x1="0.13" y1="4.26" x2="0.37" y2="5" layer="31"/>
+<rectangle x1="0.63" y1="4.26" x2="0.87" y2="5" layer="31"/>
+<rectangle x1="1.13" y1="4.26" x2="1.37" y2="5" layer="31"/>
+<rectangle x1="1.63" y1="4.26" x2="1.87" y2="5" layer="31"/>
+<rectangle x1="2.13" y1="4.26" x2="2.37" y2="5" layer="31"/>
+<rectangle x1="2.63" y1="4.26" x2="2.87" y2="5" layer="31"/>
+<rectangle x1="2.88" y1="3.06" x2="3.12" y2="3.8" layer="31"/>
+<rectangle x1="2.38" y1="3.06" x2="2.62" y2="3.8" layer="31"/>
+<rectangle x1="1.88" y1="3.06" x2="2.12" y2="3.8" layer="31"/>
+<rectangle x1="1.38" y1="3.06" x2="1.62" y2="3.8" layer="31"/>
+<rectangle x1="0.88" y1="3.06" x2="1.12" y2="3.8" layer="31"/>
+<rectangle x1="0.38" y1="3.06" x2="0.62" y2="3.8" layer="31"/>
+<rectangle x1="-0.62" y1="3.06" x2="-0.38" y2="3.8" layer="31"/>
+<rectangle x1="-1.12" y1="3.06" x2="-0.88" y2="3.8" layer="31"/>
+<rectangle x1="-1.62" y1="3.06" x2="-1.38" y2="3.8" layer="31"/>
+<rectangle x1="-2.12" y1="3.06" x2="-1.88" y2="3.8" layer="31"/>
+<rectangle x1="-2.62" y1="3.06" x2="-2.38" y2="3.8" layer="31"/>
+<rectangle x1="-3.12" y1="3.06" x2="-2.88" y2="3.8" layer="31"/>
+</package>
+<package name="USB_C_MOLEX_105450-0101">
+<smd name="A1" x="-3" y="3.74" dx="0.3" dy="0.76" layer="1" stop="no" cream="no"/>
+<smd name="A2" x="-2.5" y="3.74" dx="0.3" dy="0.76" layer="1" stop="no" cream="no"/>
+<smd name="A3" x="-2" y="3.74" dx="0.3" dy="0.76" layer="1" stop="no" cream="no"/>
+<smd name="A4" x="-1.5" y="3.74" dx="0.3" dy="0.76" layer="1" stop="no" cream="no"/>
+<smd name="A5" x="-1" y="3.74" dx="0.3" dy="0.76" layer="1" stop="no" cream="no"/>
+<smd name="A6" x="-0.5" y="3.74" dx="0.3" dy="0.76" layer="1" stop="no" cream="no"/>
+<smd name="A7" x="0.5" y="3.74" dx="0.3" dy="0.76" layer="1" stop="no" cream="no"/>
+<smd name="A8" x="1" y="3.74" dx="0.3" dy="0.76" layer="1" stop="no" cream="no"/>
+<smd name="A9" x="1.5" y="3.74" dx="0.3" dy="0.76" layer="1" stop="no" cream="no"/>
+<smd name="A10" x="2" y="3.74" dx="0.3" dy="0.76" layer="1" stop="no" cream="no"/>
+<smd name="A11" x="2.5" y="3.74" dx="0.3" dy="0.76" layer="1" stop="no" cream="no"/>
+<smd name="A12" x="3" y="3.74" dx="0.3" dy="0.76" layer="1" stop="no" cream="no"/>
+<smd name="B2" x="2.25" y="2.47" dx="0.3" dy="0.7" layer="1" stop="no" cream="no"/>
+<smd name="B3" x="1.75" y="2.47" dx="0.3" dy="0.7" layer="1" stop="no" cream="no"/>
+<smd name="B4" x="1.25" y="2.47" dx="0.3" dy="0.7" layer="1" stop="no" cream="no"/>
+<smd name="B5" x="0.75" y="2.47" dx="0.3" dy="0.7" layer="1" stop="no" cream="no"/>
+<smd name="B6" x="0.25" y="2.47" dx="0.3" dy="0.7" layer="1" stop="no" cream="no"/>
+<smd name="B7" x="-0.25" y="2.47" dx="0.3" dy="0.7" layer="1" stop="no" cream="no"/>
+<smd name="B8" x="-0.75" y="2.47" dx="0.3" dy="0.7" layer="1" stop="no" cream="no"/>
+<smd name="B9" x="-1.25" y="2.47" dx="0.3" dy="0.7" layer="1" stop="no" cream="no"/>
+<smd name="B10" x="-1.75" y="2.47" dx="0.3" dy="0.7" layer="1" stop="no" cream="no"/>
+<smd name="B11" x="-2.25" y="2.47" dx="0.3" dy="0.7" layer="1" stop="no" cream="no"/>
+<smd name="B12" x="-3.1" y="2.47" dx="1" dy="0.7" layer="1" stop="no" cream="no"/>
+<smd name="B1" x="3.1" y="2.47" dx="1" dy="0.7" layer="1" stop="no" cream="no"/>
+<pad name="SH2" x="4.32" y="3.36" drill="0.6" diameter="1.1" shape="long" rot="R90" stop="no"/>
+<wire x1="4.32" y1="3.91" x2="4.32" y2="2.81" width="0.6" layer="46"/>
+<pad name="SH1" x="-4.32" y="3.36" drill="0.6" diameter="1.1" shape="long" rot="R90" stop="no"/>
+<wire x1="-4.32" y1="3.91" x2="-4.32" y2="2.81" width="0.6" layer="46"/>
+<pad name="SH4" x="-4.32" y="-2" drill="0.6" diameter="1.3" shape="long" rot="R90"/>
+<pad name="SH3" x="4.32" y="-2" drill="0.6" diameter="1.3" shape="long" rot="R90"/>
+<wire x1="-4.32" y1="-1.25" x2="-4.32" y2="-2.75" width="0.6" layer="46"/>
+<wire x1="4.32" y1="-1.25" x2="4.32" y2="-2.75" width="0.6" layer="46"/>
+<wire x1="-6" y1="-3.77" x2="6" y2="-3.77" width="0.05" layer="21" style="shortdash"/>
+<wire x1="-4.47" y1="-3.95" x2="4.47" y2="-3.95" width="0.1" layer="21"/>
+<wire x1="4.47" y1="-3.95" x2="4.47" y2="3.95" width="0.1" layer="21"/>
+<wire x1="4.47" y1="3.95" x2="-4.47" y2="3.95" width="0.1" layer="21"/>
+<wire x1="-4.47" y1="3.95" x2="-4.47" y2="-3.95" width="0.1" layer="21"/>
+<rectangle x1="-3.12" y1="3.39" x2="-2.88" y2="4.09" layer="31"/>
+<rectangle x1="-2.62" y1="3.39" x2="-2.38" y2="4.09" layer="31"/>
+<rectangle x1="-2.12" y1="3.39" x2="-1.88" y2="4.09" layer="31"/>
+<rectangle x1="-1.62" y1="3.39" x2="-1.38" y2="4.09" layer="31"/>
+<rectangle x1="-1.12" y1="3.39" x2="-0.88" y2="4.09" layer="31"/>
+<rectangle x1="-0.62" y1="3.39" x2="-0.38" y2="4.09" layer="31"/>
+<rectangle x1="0.38" y1="3.39" x2="0.62" y2="4.09" layer="31"/>
+<rectangle x1="0.88" y1="3.39" x2="1.12" y2="4.09" layer="31"/>
+<rectangle x1="1.38" y1="3.39" x2="1.62" y2="4.09" layer="31"/>
+<rectangle x1="1.88" y1="3.39" x2="2.12" y2="4.09" layer="31"/>
+<rectangle x1="2.38" y1="3.39" x2="2.62" y2="4.09" layer="31"/>
+<rectangle x1="2.88" y1="3.39" x2="3.12" y2="4.09" layer="31"/>
+<rectangle x1="-3.21" y1="3.3" x2="-0.29" y2="4.18" layer="29"/>
+<rectangle x1="0.29" y1="3.3" x2="3.21" y2="4.18" layer="29"/>
+<rectangle x1="-2.37" y1="2.15" x2="-2.13" y2="2.79" layer="31"/>
+<rectangle x1="-1.87" y1="2.15" x2="-1.63" y2="2.79" layer="31"/>
+<rectangle x1="-1.37" y1="2.15" x2="-1.13" y2="2.79" layer="31"/>
+<rectangle x1="-0.87" y1="2.15" x2="-0.63" y2="2.79" layer="31"/>
+<rectangle x1="-0.37" y1="2.15" x2="-0.13" y2="2.79" layer="31"/>
+<rectangle x1="0.13" y1="2.15" x2="0.37" y2="2.79" layer="31"/>
+<rectangle x1="0.63" y1="2.15" x2="0.87" y2="2.79" layer="31"/>
+<rectangle x1="1.13" y1="2.15" x2="1.37" y2="2.79" layer="31"/>
+<rectangle x1="1.63" y1="2.15" x2="1.87" y2="2.79" layer="31"/>
+<rectangle x1="2.13" y1="2.15" x2="2.37" y2="2.79" layer="31"/>
+<rectangle x1="-3.57" y1="2.15" x2="-2.63" y2="2.79" layer="31"/>
+<rectangle x1="2.63" y1="2.15" x2="3.57" y2="2.79" layer="31"/>
+<rectangle x1="-3.6" y1="2.06" x2="3.6" y2="2.88" layer="29"/>
+<wire x1="-4.32" y1="2.81" x2="-4.32" y2="3.91" width="1.2" layer="29"/>
+<wire x1="4.32" y1="2.81" x2="4.32" y2="3.91" width="1.2" layer="29"/>
+<wire x1="4.32" y1="2.81" x2="4.32" y2="3.91" width="1.2" layer="30"/>
+<wire x1="-4.32" y1="2.81" x2="-4.32" y2="3.91" width="1.2" layer="30"/>
+<wire x1="-4.32" y1="3.91" x2="-4.32" y2="2.81" width="0.8" layer="31"/>
+<wire x1="4.32" y1="3.91" x2="4.32" y2="2.81" width="0.8" layer="31"/>
+<wire x1="4.32" y1="-1.25" x2="4.32" y2="-2.75" width="0.8" layer="31"/>
+<wire x1="-4.32" y1="-1.25" x2="-4.32" y2="-2.75" width="0.8" layer="31"/>
+<text x="0" y="0" size="1" layer="25" align="center">&gt;NAME</text>
+<text x="0" y="-4.8" size="1" layer="27" align="center">&gt;VALUE</text>
+</package>
+<package name="USB_C_JAE_DX07B024XJ1">
+<smd name="A6" x="-0.25" y="5.76" dx="1.1" dy="0.3" layer="1" rot="R90" stop="no" cream="no"/>
+<smd name="A7" x="0.25" y="5.76" dx="1.1" dy="0.3" layer="1" rot="R90" stop="no" cream="no"/>
+<smd name="A5" x="-0.75" y="5.76" dx="1.1" dy="0.3" layer="1" rot="R90" stop="no" cream="no"/>
+<smd name="A8" x="0.75" y="5.76" dx="1.1" dy="0.3" layer="1" rot="R90" stop="no" cream="no"/>
+<smd name="A4" x="-1.25" y="5.76" dx="1.1" dy="0.3" layer="1" rot="R90" stop="no" cream="no"/>
+<smd name="A9" x="1.25" y="5.76" dx="1.1" dy="0.3" layer="1" rot="R90" stop="no" cream="no"/>
+<smd name="A3" x="-1.75" y="5.76" dx="1.1" dy="0.3" layer="1" rot="R90" stop="no" cream="no"/>
+<smd name="A10" x="1.75" y="5.76" dx="1.1" dy="0.3" layer="1" rot="R90" stop="no" cream="no"/>
+<smd name="A2" x="-2.25" y="5.76" dx="1.1" dy="0.3" layer="1" rot="R90" stop="no" cream="no"/>
+<smd name="A11" x="2.25" y="5.76" dx="1.1" dy="0.3" layer="1" rot="R90" stop="no" cream="no"/>
+<smd name="A1" x="-2.75" y="5.76" dx="1.1" dy="0.3" layer="1" rot="R90" stop="no" cream="no"/>
+<smd name="A12" x="2.75" y="5.76" dx="1.1" dy="0.3" layer="1" rot="R90" stop="no" cream="no"/>
+<pad name="B12" x="-2.8" y="4.55" drill="0.4" diameter="0.6"/>
+<pad name="B11" x="-2.4" y="3.75" drill="0.4" diameter="0.6"/>
+<pad name="B10" x="-1.6" y="3.75" drill="0.4" diameter="0.6"/>
+<pad name="B8" x="-0.8" y="3.75" drill="0.4" diameter="0.6"/>
+<pad name="B9" x="-1.35" y="4.55" drill="0.4" diameter="0.6"/>
+<pad name="B7" x="-0.4" y="4.55" drill="0.4" diameter="0.6"/>
+<pad name="B6" x="0.4" y="4.55" drill="0.4" diameter="0.6"/>
+<pad name="B4" x="1.35" y="4.55" drill="0.4" diameter="0.6"/>
+<pad name="B5" x="0.8" y="3.75" drill="0.4" diameter="0.6"/>
+<pad name="B3" x="1.6" y="3.75" drill="0.4" diameter="0.6"/>
+<pad name="B2" x="2.4" y="3.75" drill="0.4" diameter="0.6"/>
+<pad name="B1" x="2.8" y="4.55" drill="0.4" diameter="0.6"/>
+<hole x="-3.6" y="5.1" drill="0.8"/>
+<hole x="3.6" y="5.1" drill="0.9"/>
+<wire x1="-0.04" y1="5.76" x2="0.04" y2="5.76" width="0.02" layer="21"/>
+<wire x1="0" y1="5.8" x2="0" y2="5.72" width="0.02" layer="21"/>
+<pad name="SH1" x="-4.8" y="4.225" drill="0.6" diameter="1" shape="long" rot="R90"/>
+<pad name="SH4" x="4.8" y="4.225" drill="0.6" diameter="1" shape="long" rot="R90"/>
+<pad name="SH2" x="-5.8" y="0" drill="0.6" diameter="1.1" shape="long" rot="R90"/>
+<pad name="SH3" x="5.8" y="0" drill="0.6" diameter="1.1" shape="long" rot="R90"/>
+<wire x1="-5.8" y1="-0.5" x2="-5.8" y2="0.5" width="0.6" layer="46"/>
+<wire x1="5.8" y1="-0.5" x2="5.8" y2="0.5" width="0.6" layer="46"/>
+<wire x1="-4.8" y1="3.75" x2="-4.8" y2="4.71" width="0.6" layer="46"/>
+<wire x1="4.8" y1="3.75" x2="4.8" y2="4.71" width="0.6" layer="46"/>
+<wire x1="-7" y1="-1.65" x2="-4.5" y2="-1.65" width="0.05" layer="21" style="shortdash"/>
+<wire x1="-4.5" y1="-1.65" x2="-4.5" y2="3.1" width="0.05" layer="21" style="shortdash"/>
+<wire x1="-4.5" y1="3.1" x2="4.5" y2="3.1" width="0.05" layer="21" style="shortdash"/>
+<wire x1="4.5" y1="3.1" x2="4.5" y2="-1.65" width="0.05" layer="21" style="shortdash"/>
+<wire x1="4.5" y1="-1.65" x2="7" y2="-1.65" width="0.05" layer="21" style="shortdash"/>
+<wire x1="-4.8" y1="3.75" x2="-4.8" y2="4.71" width="0.8" layer="31"/>
+<wire x1="4.8" y1="3.75" x2="4.8" y2="4.71" width="0.8" layer="31"/>
+<wire x1="5.8" y1="-0.5" x2="5.8" y2="0.5" width="0.8" layer="31"/>
+<wire x1="-5.8" y1="-0.5" x2="-5.8" y2="0.5" width="0.8" layer="31"/>
+<polygon width="0.02" layer="2" pour="cutout">
+<vertex x="-6.09" y="0.05"/>
+<vertex x="-6.09" y="0.5" curve="-90"/>
+<vertex x="-5.8" y="0.79" curve="-90"/>
+<vertex x="-5.51" y="0.5"/>
+<vertex x="-5.51" y="0.03"/>
+<vertex x="-5.51" y="-0.5" curve="-90"/>
+<vertex x="-5.8" y="-0.79" curve="-90"/>
+<vertex x="-6.09" y="-0.5"/>
+</polygon>
+<polygon width="0.02" layer="15" pour="cutout">
+<vertex x="-6.09" y="-0.5"/>
+<vertex x="-6.09" y="0.5" curve="-90"/>
+<vertex x="-5.8" y="0.79" curve="-90"/>
+<vertex x="-5.51" y="0.5"/>
+<vertex x="-5.51" y="-0.5" curve="-90"/>
+<vertex x="-5.8" y="-0.79" curve="-90"/>
+</polygon>
+<polygon width="0.02" layer="15" pour="cutout">
+<vertex x="5.51" y="-0.5"/>
+<vertex x="5.51" y="0.5" curve="-90"/>
+<vertex x="5.8" y="0.79" curve="-90"/>
+<vertex x="6.09" y="0.5"/>
+<vertex x="6.09" y="-0.5" curve="-90"/>
+<vertex x="5.8" y="-0.79" curve="-90"/>
+</polygon>
+<polygon width="0.02" layer="2" pour="cutout">
+<vertex x="5.51" y="-0.5"/>
+<vertex x="5.51" y="0.5" curve="-90"/>
+<vertex x="5.8" y="0.79" curve="-90"/>
+<vertex x="6.09" y="0.5"/>
+<vertex x="6.09" y="-0.5" curve="-90"/>
+<vertex x="5.8" y="-0.79" curve="-90"/>
+</polygon>
+<polygon width="0.02" layer="2" pour="cutout">
+<vertex x="-5.09" y="4.25"/>
+<vertex x="-5.09" y="4.71" curve="-90"/>
+<vertex x="-4.8" y="5" curve="-90"/>
+<vertex x="-4.51" y="4.71"/>
+<vertex x="-4.51" y="4.23"/>
+<vertex x="-4.51" y="3.75" curve="-90"/>
+<vertex x="-4.8" y="3.46" curve="-90"/>
+<vertex x="-5.09" y="3.75"/>
+</polygon>
+<polygon width="0.02" layer="15" pour="cutout">
+<vertex x="-5.09" y="3.75"/>
+<vertex x="-5.09" y="4.71" curve="-90"/>
+<vertex x="-4.8" y="5" curve="-90"/>
+<vertex x="-4.51" y="4.71"/>
+<vertex x="-4.51" y="3.75" curve="-90"/>
+<vertex x="-4.8" y="3.46" curve="-90"/>
+</polygon>
+<polygon width="0.02" layer="2" pour="cutout">
+<vertex x="4.51" y="3.75"/>
+<vertex x="4.51" y="4.71" curve="-90"/>
+<vertex x="4.8" y="5" curve="-90"/>
+<vertex x="5.09" y="4.71"/>
+<vertex x="5.09" y="3.75" curve="-90"/>
+<vertex x="4.8" y="3.46" curve="-90"/>
+</polygon>
+<polygon width="0.02" layer="15" pour="cutout">
+<vertex x="4.51" y="3.75"/>
+<vertex x="4.51" y="4.71" curve="-90"/>
+<vertex x="4.8" y="5" curve="-90"/>
+<vertex x="5.09" y="4.71"/>
+<vertex x="5.09" y="3.75" curve="-90"/>
+<vertex x="4.8" y="3.46" curve="-90"/>
+</polygon>
+<rectangle x1="-2.87" y1="5.24" x2="-2.63" y2="6.28" layer="31"/>
+<rectangle x1="-2.37" y1="5.24" x2="-2.13" y2="6.28" layer="31"/>
+<rectangle x1="-1.87" y1="5.24" x2="-1.63" y2="6.28" layer="31"/>
+<rectangle x1="-1.37" y1="5.24" x2="-1.13" y2="6.28" layer="31"/>
+<rectangle x1="-0.87" y1="5.24" x2="-0.63" y2="6.28" layer="31"/>
+<rectangle x1="-0.37" y1="5.24" x2="-0.13" y2="6.28" layer="31"/>
+<rectangle x1="0.13" y1="5.24" x2="0.37" y2="6.28" layer="31"/>
+<rectangle x1="0.63" y1="5.24" x2="0.87" y2="6.28" layer="31"/>
+<rectangle x1="1.13" y1="5.24" x2="1.37" y2="6.28" layer="31"/>
+<rectangle x1="1.63" y1="5.24" x2="1.87" y2="6.28" layer="31"/>
+<rectangle x1="2.13" y1="5.24" x2="2.37" y2="6.28" layer="31"/>
+<rectangle x1="2.63" y1="5.24" x2="2.87" y2="6.28" layer="31"/>
+<rectangle x1="-2.96" y1="5.15" x2="2.96" y2="6.37" layer="29"/>
+<circle x="-2.8" y="4.55" radius="0.15" width="0.3" layer="31"/>
+<circle x="-1.35" y="4.55" radius="0.15" width="0.3" layer="31"/>
+<circle x="-0.4" y="4.55" radius="0.15" width="0.3" layer="31"/>
+<circle x="0.4" y="4.55" radius="0.15" width="0.3" layer="31"/>
+<circle x="1.35" y="4.55" radius="0.15" width="0.3" layer="31"/>
+<circle x="2.8" y="4.55" radius="0.15" width="0.3" layer="31"/>
+<circle x="-2.4" y="3.75" radius="0.15" width="0.3" layer="31"/>
+<circle x="-1.6" y="3.75" radius="0.15" width="0.3" layer="31"/>
+<circle x="-0.8" y="3.75" radius="0.15" width="0.3" layer="31"/>
+<circle x="0.8" y="3.75" radius="0.15" width="0.3" layer="31"/>
+<circle x="1.6" y="3.75" radius="0.15" width="0.3" layer="31"/>
+<circle x="2.4" y="3.75" radius="0.15" width="0.3" layer="31"/>
+<hole x="-4.5" y="2.85" drill="0.5"/>
+<hole x="4.5" y="2.85" drill="0.5"/>
+<wire x1="-4.9" y1="-3.75" x2="4.9" y2="-3.75" width="0.1" layer="21"/>
+<wire x1="4.9" y1="-3.75" x2="4.9" y2="5.9" width="0.1" layer="21"/>
+<wire x1="4.9" y1="5.9" x2="-4.9" y2="5.9" width="0.1" layer="21"/>
+<wire x1="-4.9" y1="5.9" x2="-4.9" y2="-3.75" width="0.1" layer="21"/>
+<text x="0" y="-3" size="1" layer="25" align="center">&gt;NAME</text>
+<text x="0" y="-4.4" size="0.8" layer="27" align="center">&gt;VALUE</text>
+</package>
+<package name="SWD">
+<pad name="RST" x="0" y="0" drill="0.7" diameter="1" shape="square" stop="no"/>
+<pad name="GND" x="1.27" y="0" drill="0.7" diameter="1" stop="no"/>
+<pad name="SWO" x="2.54" y="0" drill="0.7" diameter="1" stop="no"/>
+<pad name="SWCLK" x="3.81" y="0" drill="0.7" diameter="1" stop="no"/>
+<pad name="SWDIO" x="5.08" y="0" drill="0.7" diameter="1" stop="no"/>
+<pad name="VCC" x="6.35" y="0" drill="0.7" diameter="1" stop="no"/>
+<circle x="1.27" y="0" radius="0.254" width="0.639" layer="29"/>
+<circle x="2.54" y="0" radius="0.254" width="0.639" layer="29"/>
+<circle x="3.81" y="0" radius="0.254" width="0.639" layer="29"/>
+<circle x="5.08" y="0" radius="0.254" width="0.639" layer="29"/>
+<circle x="6.35" y="0" radius="0.254" width="0.639" layer="29"/>
+<rectangle x1="-0.5842" y1="-0.5842" x2="0.5842" y2="0.5842" layer="29"/>
+</package>
+<package name="MB_1.00">
+<smd name="1" x="0" y="0" dx="1" dy="1" layer="1" roundness="100" stop="no" cream="no"/>
+<circle x="0" y="0" radius="0.25" width="0.6" layer="29"/>
+<circle x="0" y="0" radius="0.2" width="0.45" layer="37"/>
+<text x="0" y="1.3" size="1" layer="37" align="center">&gt;NAME</text>
+</package>
+<package name="SOT23_REFLOW">
+<wire x1="1.524" y1="-0.508" x2="1.143" y2="-0.508" width="0.127" layer="21"/>
+<wire x1="1.143" y1="-0.508" x2="-1.524" y2="-0.508" width="0.127" layer="21"/>
+<wire x1="-1.524" y1="-0.508" x2="-1.524" y2="0.508" width="0.127" layer="21"/>
+<wire x1="-1.524" y1="0.508" x2="1.143" y2="0.508" width="0.127" layer="21"/>
+<wire x1="1.143" y1="0.508" x2="1.524" y2="0.508" width="0.127" layer="21"/>
+<wire x1="1.524" y1="0.508" x2="1.524" y2="-0.508" width="0.127" layer="21"/>
+<wire x1="1.143" y1="-0.508" x2="1.143" y2="0.508" width="0.1524" layer="21"/>
+<smd name="2" x="-0.95" y="-1.2" dx="0.8" dy="1" layer="1"/>
+<smd name="1" x="0.95" y="-1.2" dx="0.8" dy="1" layer="1"/>
+<smd name="3" x="0" y="1.2" dx="0.8" dy="1" layer="1"/>
+<text x="-1.27" y="-2.54" size="1.016" layer="25">&gt;NAME</text>
+<text x="-1.27" y="-2.54" size="1.016" layer="27">&gt;VALUE</text>
+<rectangle x1="-0.3048" y1="0.5588" x2="0.3048" y2="1.27" layer="27"/>
+<rectangle x1="-1.25" y1="-0.762" x2="-0.65" y2="-0.381" layer="21"/>
+<rectangle x1="0.65" y1="-0.762" x2="1.25" y2="-0.381" layer="21"/>
+<rectangle x1="-0.3048" y1="0.381" x2="0.3048" y2="0.762" layer="21"/>
+<rectangle x1="-0.3048" y1="0.5588" x2="0.3048" y2="1.27" layer="27"/>
+<rectangle x1="0.65" y1="-1.27" x2="1.25" y2="-0.5588" layer="27"/>
+<rectangle x1="-1.25" y1="-1.27" x2="-0.65" y2="-0.5588" layer="27"/>
+<rectangle x1="-1.65" y1="-0.15" x2="1.65" y2="0.15" layer="35"/>
+</package>
+<package name="SOT23_MEDIUM_SIZE">
+<wire x1="1.524" y1="-0.508" x2="1.143" y2="-0.508" width="0.127" layer="21"/>
+<wire x1="1.143" y1="-0.508" x2="-1.524" y2="-0.508" width="0.127" layer="21"/>
+<wire x1="-1.524" y1="-0.508" x2="-1.524" y2="0.508" width="0.127" layer="21"/>
+<wire x1="-1.524" y1="0.508" x2="1.143" y2="0.508" width="0.127" layer="21"/>
+<wire x1="1.143" y1="0.508" x2="1.524" y2="0.508" width="0.127" layer="21"/>
+<wire x1="1.524" y1="0.508" x2="1.524" y2="-0.508" width="0.127" layer="21"/>
+<wire x1="1.143" y1="-0.508" x2="1.143" y2="0.508" width="0.1524" layer="21"/>
+<smd name="2" x="0.9" y="-1.1" dx="1.1" dy="1.1" layer="1" thermals="no" cream="no"/>
+<smd name="1" x="-0.9" y="-1.1" dx="1.1" dy="1.1" layer="1" thermals="no" cream="no"/>
+<smd name="3" x="0" y="1.1" dx="1.1" dy="1.1" layer="1" thermals="no" cream="no"/>
+<text x="-1.143" y="-1.905" size="1.016" layer="25">&gt;NAME</text>
+<text x="-1.778" y="-2.413" size="1.016" layer="27">&gt;VALUE</text>
+<rectangle x1="-0.3048" y1="0.5588" x2="0.3048" y2="1.27" layer="21"/>
+<rectangle x1="0.7112" y1="-1.27" x2="1.3208" y2="-0.5588" layer="21"/>
+<rectangle x1="-1.3208" y1="-1.27" x2="-0.7112" y2="-0.5588" layer="21"/>
+<rectangle x1="-1.4" y1="-1.5" x2="-0.4" y2="-0.6" layer="31"/>
+<rectangle x1="0.4" y1="-1.5" x2="1.4" y2="-0.6" layer="31"/>
+<rectangle x1="-0.45" y1="0.6" x2="0.45" y2="1.55" layer="31"/>
+</package>
+</packages>
+<symbols>
+<symbol name="STM32F427_LQFP100">
+<pin name="PA1" x="-35.56" y="81.28" length="middle"/>
+<pin name="PA2" x="-35.56" y="78.74" length="middle"/>
+<pin name="PA3" x="-35.56" y="76.2" length="middle"/>
+<pin name="PA4/SPI1_NSS/OTG_HS_SOF" x="-35.56" y="71.12" length="middle"/>
+<pin name="PA5/SPI1_SCK" x="-35.56" y="68.58" length="middle"/>
+<pin name="PA6/SPI1_MISO" x="-35.56" y="66.04" length="middle"/>
+<pin name="PA7/SPI1_MOSI" x="-35.56" y="63.5" length="middle"/>
+<pin name="PA8/OTG_FS_SOF" x="-35.56" y="58.42" length="middle"/>
+<pin name="PA9/OTG_FS_VBUS" x="-35.56" y="55.88" length="middle"/>
+<pin name="PA10/OFG_FS_ID" x="-35.56" y="53.34" length="middle"/>
+<pin name="PA11/OTG_FS_DM" x="-35.56" y="50.8" length="middle"/>
+<pin name="PA12/OTG_FS_DP" x="-35.56" y="48.26" length="middle"/>
+<pin name="PA13/SWDIO" x="-35.56" y="43.18" length="middle"/>
+<pin name="PA14/SWCLK" x="-35.56" y="40.64" length="middle"/>
+<pin name="PA15" x="-35.56" y="38.1" length="middle"/>
+<pin name="PB1" x="-35.56" y="30.48" length="middle"/>
+<pin name="PB2" x="-35.56" y="27.94" length="middle"/>
+<pin name="PB3/SWO" x="-35.56" y="25.4" length="middle"/>
+<pin name="PB4" x="-35.56" y="22.86" length="middle"/>
+<pin name="PB5" x="-35.56" y="20.32" length="middle"/>
+<pin name="PB6" x="-35.56" y="17.78" length="middle"/>
+<pin name="PB7" x="-35.56" y="15.24" length="middle"/>
+<pin name="PB8" x="-35.56" y="12.7" length="middle"/>
+<pin name="PB9" x="-35.56" y="10.16" length="middle"/>
+<pin name="PB10" x="-35.56" y="7.62" length="middle"/>
+<pin name="PB11" x="-35.56" y="5.08" length="middle"/>
+<pin name="PB12/OTG_HS_ID" x="-35.56" y="2.54" length="middle"/>
+<pin name="PB13/OTG_HS_VBUS" x="-35.56" y="0" length="middle"/>
+<pin name="PB14/OTG_HS_DM" x="-35.56" y="-2.54" length="middle"/>
+<pin name="PB15/OTG_HS_DP" x="-35.56" y="-5.08" length="middle"/>
+<pin name="PA0-WKUP" x="-35.56" y="83.82" length="middle"/>
+<pin name="PB0" x="-35.56" y="33.02" length="middle"/>
+<pin name="PC1" x="35.56" y="81.28" length="middle" rot="R180"/>
+<pin name="PC2" x="35.56" y="78.74" length="middle" rot="R180"/>
+<pin name="PC3" x="35.56" y="76.2" length="middle" rot="R180"/>
+<pin name="PC4" x="35.56" y="73.66" length="middle" rot="R180"/>
+<pin name="PC5" x="35.56" y="71.12" length="middle" rot="R180"/>
+<pin name="PC6" x="35.56" y="68.58" length="middle" rot="R180"/>
+<pin name="PC7" x="35.56" y="66.04" length="middle" rot="R180"/>
+<pin name="PC8" x="35.56" y="63.5" length="middle" rot="R180"/>
+<pin name="PC9" x="35.56" y="60.96" length="middle" rot="R180"/>
+<pin name="PC10" x="35.56" y="58.42" length="middle" rot="R180"/>
+<pin name="PC11" x="35.56" y="55.88" length="middle" rot="R180"/>
+<pin name="PC12" x="35.56" y="53.34" length="middle" rot="R180"/>
+<pin name="PC13" x="35.56" y="50.8" length="middle" rot="R180"/>
+<pin name="PC14" x="35.56" y="48.26" length="middle" rot="R180"/>
+<pin name="PC15" x="35.56" y="45.72" length="middle" rot="R180"/>
+<pin name="PC0" x="35.56" y="83.82" length="middle" rot="R180"/>
+<pin name="PD1" x="35.56" y="30.48" length="middle" rot="R180"/>
+<pin name="PD2" x="35.56" y="27.94" length="middle" rot="R180"/>
+<pin name="PD3" x="35.56" y="25.4" length="middle" rot="R180"/>
+<pin name="PD4" x="35.56" y="22.86" length="middle" rot="R180"/>
+<pin name="PD5" x="35.56" y="20.32" length="middle" rot="R180"/>
+<pin name="PD6" x="35.56" y="17.78" length="middle" rot="R180"/>
+<pin name="PD7" x="35.56" y="15.24" length="middle" rot="R180"/>
+<pin name="PD8" x="35.56" y="12.7" length="middle" rot="R180"/>
+<pin name="PD9" x="35.56" y="10.16" length="middle" rot="R180"/>
+<pin name="PD10" x="35.56" y="7.62" length="middle" rot="R180"/>
+<pin name="PD11" x="35.56" y="5.08" length="middle" rot="R180"/>
+<pin name="PD12" x="35.56" y="2.54" length="middle" rot="R180"/>
+<pin name="PD13" x="35.56" y="0" length="middle" rot="R180"/>
+<pin name="PD14" x="35.56" y="-2.54" length="middle" rot="R180"/>
+<pin name="PD15" x="35.56" y="-5.08" length="middle" rot="R180"/>
+<pin name="PD0" x="35.56" y="33.02" length="middle" rot="R180"/>
+<pin name="PE1" x="35.56" y="-15.24" length="middle" rot="R180"/>
+<pin name="PE2" x="35.56" y="-17.78" length="middle" rot="R180"/>
+<pin name="PE3" x="35.56" y="-20.32" length="middle" rot="R180"/>
+<pin name="PE4" x="35.56" y="-22.86" length="middle" rot="R180"/>
+<pin name="PE5" x="35.56" y="-25.4" length="middle" rot="R180"/>
+<pin name="PE6" x="35.56" y="-27.94" length="middle" rot="R180"/>
+<pin name="PE7" x="35.56" y="-30.48" length="middle" rot="R180"/>
+<pin name="PE8" x="35.56" y="-33.02" length="middle" rot="R180"/>
+<pin name="PE9" x="35.56" y="-35.56" length="middle" rot="R180"/>
+<pin name="PE10" x="35.56" y="-38.1" length="middle" rot="R180"/>
+<pin name="PE11" x="35.56" y="-40.64" length="middle" rot="R180"/>
+<pin name="PE12" x="35.56" y="-43.18" length="middle" rot="R180"/>
+<pin name="PE13" x="35.56" y="-45.72" length="middle" rot="R180"/>
+<pin name="PE14" x="35.56" y="-48.26" length="middle" rot="R180"/>
+<pin name="PE15" x="35.56" y="-50.8" length="middle" rot="R180"/>
+<pin name="PE0" x="35.56" y="-12.7" length="middle" rot="R180"/>
+<pin name="VBAT" x="-35.56" y="-50.8" length="middle" direction="pwr"/>
+<pin name="VSS@1" x="35.56" y="-66.04" length="middle" direction="pwr" rot="R180"/>
+<pin name="VDD@1" x="-35.56" y="-60.96" length="middle" direction="pwr"/>
+<pin name="NRST" x="-35.56" y="-27.94" length="middle" function="dot"/>
+<pin name="VDD@2" x="-35.56" y="-63.5" length="middle" direction="pwr"/>
+<pin name="VSSA" x="-35.56" y="-55.88" length="middle" direction="pwr"/>
+<pin name="VREF+" x="-35.56" y="-40.64" length="middle" direction="pwr"/>
+<pin name="VDDA" x="-35.56" y="-53.34" length="middle" direction="pwr"/>
+<pin name="VSS@2" x="35.56" y="-68.58" length="middle" direction="pwr" rot="R180"/>
+<pin name="VDD@3" x="-35.56" y="-66.04" length="middle" direction="pwr"/>
+<pin name="VCAP_1" x="35.56" y="-60.96" length="middle" direction="pwr" rot="R180"/>
+<pin name="VDD@4" x="-35.56" y="-68.58" length="middle" direction="pwr"/>
+<pin name="VCAP_2" x="35.56" y="-63.5" length="middle" direction="pwr" rot="R180"/>
+<pin name="VSS@3" x="35.56" y="-71.12" length="middle" direction="pwr" rot="R180"/>
+<pin name="VDD@5" x="-35.56" y="-71.12" length="middle" direction="pwr"/>
+<pin name="BOOT0" x="-35.56" y="-33.02" length="middle" direction="in"/>
+<pin name="VSS@4" x="35.56" y="-73.66" length="middle" direction="pwr" rot="R180"/>
+<pin name="VDD@6" x="-35.56" y="-73.66" length="middle" direction="pwr"/>
+<pin name="PH0-OSC_IN" x="-35.56" y="-12.7" length="middle" direction="in"/>
+<pin name="PH1-OSC_OUT" x="-35.56" y="-20.32" length="middle" direction="out"/>
+<wire x1="-30.48" y1="-78.74" x2="30.48" y2="-78.74" width="0.254" layer="94"/>
+<wire x1="30.48" y1="-78.74" x2="30.48" y2="-58.42" width="0.254" layer="94"/>
+<wire x1="30.48" y1="-58.42" x2="30.48" y2="88.9" width="0.254" layer="94"/>
+<wire x1="30.48" y1="88.9" x2="-30.48" y2="88.9" width="0.254" layer="94"/>
+<wire x1="-30.48" y1="88.9" x2="-30.48" y2="73.66" width="0.254" layer="94"/>
+<wire x1="-30.48" y1="73.66" x2="-30.48" y2="60.96" width="0.254" layer="94"/>
+<wire x1="-30.48" y1="60.96" x2="-30.48" y2="45.72" width="0.254" layer="94"/>
+<wire x1="-30.48" y1="45.72" x2="-30.48" y2="3.81" width="0.254" layer="94"/>
+<wire x1="-30.48" y1="3.81" x2="-30.48" y2="-7.62" width="0.254" layer="94"/>
+<wire x1="-30.48" y1="-7.62" x2="-30.48" y2="-25.4" width="0.254" layer="94"/>
+<wire x1="-30.48" y1="-25.4" x2="-30.48" y2="-58.42" width="0.254" layer="94"/>
+<wire x1="-30.48" y1="-58.42" x2="-30.48" y2="-78.74" width="0.254" layer="94"/>
+<wire x1="-30.48" y1="-58.42" x2="0" y2="-58.42" width="0.254" layer="94"/>
+<wire x1="0" y1="-58.42" x2="30.48" y2="-58.42" width="0.254" layer="94"/>
+<wire x1="-30.48" y1="-7.62" x2="0" y2="-7.62" width="0.254" layer="94"/>
+<wire x1="0" y1="-7.62" x2="0" y2="-25.4" width="0.254" layer="94"/>
+<wire x1="0" y1="-25.4" x2="0" y2="-58.42" width="0.254" layer="94"/>
+<wire x1="-30.48" y1="-25.4" x2="0" y2="-25.4" width="0.254" layer="94"/>
+<text x="-2.54" y="-68.58" size="1.778" layer="94">Supply</text>
+<text x="-10.16" y="-17.78" size="1.778" layer="94">XTAL</text>
+<text x="-5.08" y="12.7" size="1.778" layer="94">I/O ports</text>
+<wire x1="-30.48" y1="73.66" x2="0" y2="73.66" width="0.254" layer="94"/>
+<wire x1="0" y1="73.66" x2="0" y2="60.96" width="0.254" layer="94"/>
+<wire x1="0" y1="60.96" x2="-30.48" y2="60.96" width="0.254" layer="94"/>
+<text x="-7.62" y="66.04" size="1.778" layer="94">SPI1</text>
+<wire x1="-30.48" y1="45.72" x2="0" y2="45.72" width="0.254" layer="94"/>
+<wire x1="0" y1="45.72" x2="0" y2="60.96" width="0.254" layer="94"/>
+<text x="-8.89" y="50.8" size="1.778" layer="94">USB FS</text>
+<text x="-30.48" y="88.9" size="1.778" layer="95">&gt;NAME</text>
+<text x="-30.48" y="-81.28" size="1.778" layer="96">&gt;VALUE</text>
+<wire x1="-30.48" y1="3.81" x2="0" y2="3.81" width="0.254" layer="94"/>
+<wire x1="0" y1="3.81" x2="0" y2="-7.62" width="0.254" layer="94"/>
+<text x="-8.89" y="-5.08" size="1.778" layer="94">USB HS</text>
+</symbol>
+<symbol name="X_4V">
+<wire x1="-1.27" y1="2.54" x2="-1.27" y2="0" width="0.3048" layer="94"/>
+<wire x1="-0.635" y1="2.54" x2="-0.635" y2="-2.54" width="0.3048" layer="94"/>
+<wire x1="-0.635" y1="-2.54" x2="0.635" y2="-2.54" width="0.3048" layer="94"/>
+<wire x1="0.635" y1="-2.54" x2="0.635" y2="2.54" width="0.3048" layer="94"/>
+<wire x1="0.635" y1="2.54" x2="-0.635" y2="2.54" width="0.3048" layer="94"/>
+<wire x1="1.27" y1="2.54" x2="1.27" y2="0" width="0.3048" layer="94"/>
+<wire x1="5.08" y1="0" x2="1.27" y2="0" width="0.1524" layer="94"/>
+<wire x1="1.27" y1="0" x2="1.27" y2="-2.54" width="0.3048" layer="94"/>
+<wire x1="-1.27" y1="0" x2="-5.08" y2="0" width="0.1524" layer="94"/>
+<wire x1="-1.27" y1="0" x2="-1.27" y2="-2.54" width="0.3048" layer="94"/>
+<wire x1="-1.27" y1="-5.08" x2="-1.27" y2="-3.175" width="0.1524" layer="94"/>
+<wire x1="1.27" y1="-5.08" x2="1.27" y2="-3.175" width="0.1524" layer="94"/>
+<text x="-2.54" y="3.175" size="1.27" layer="95">&gt;NAME</text>
+<text x="1.905" y="-3.175" size="1.27" layer="96">&gt;VALUE</text>
+<pin name="1" x="-5.08" y="0" visible="off" length="point" direction="pas" swaplevel="1"/>
+<pin name="2" x="5.08" y="0" visible="off" length="point" direction="pas" swaplevel="1" rot="R180"/>
+<pin name="GND1" x="-1.27" y="-5.08" visible="off" length="point" direction="pas"/>
+<pin name="GND2" x="1.27" y="-5.08" visible="off" length="point" direction="pas"/>
+</symbol>
+<symbol name="L">
+<wire x1="-3.81" y1="0" x2="-1.905" y2="0" width="0.1524" layer="94" curve="-180" cap="flat"/>
+<wire x1="-1.905" y1="0" x2="0" y2="0" width="0.1524" layer="94" curve="-180" cap="flat"/>
+<wire x1="0" y1="0" x2="1.905" y2="0" width="0.1524" layer="94" curve="-180" cap="flat"/>
+<wire x1="1.905" y1="0" x2="3.81" y2="0" width="0.1524" layer="94" curve="-180" cap="flat"/>
+<wire x1="3.81" y1="0" x2="5.08" y2="0" width="0.1524" layer="94"/>
+<wire x1="-5.08" y1="0" x2="-3.81" y2="0" width="0.1524" layer="94"/>
+<wire x1="-3.556" y1="1.905" x2="-2.159" y2="1.905" width="0.1524" layer="94"/>
+<wire x1="0.254" y1="1.905" x2="1.651" y2="1.905" width="0.1524" layer="94"/>
+<wire x1="-1.651" y1="1.905" x2="-0.254" y2="1.905" width="0.1524" layer="94"/>
+<wire x1="2.159" y1="1.905" x2="3.556" y2="1.905" width="0.1524" layer="94"/>
+<wire x1="-3.556" y1="1.524" x2="-2.159" y2="1.524" width="0.1524" layer="94"/>
+<wire x1="-1.651" y1="1.524" x2="-0.254" y2="1.524" width="0.1524" layer="94"/>
+<wire x1="0.254" y1="1.524" x2="1.651" y2="1.524" width="0.1524" layer="94"/>
+<wire x1="2.159" y1="1.524" x2="3.556" y2="1.524" width="0.1524" layer="94"/>
+<text x="-2.54" y="-1.905" size="1.27" layer="96">&gt;VALUE</text>
+<text x="-1.27" y="2.54" size="1.27" layer="95">&gt;NAME</text>
+<pin name="1" x="-5.08" y="0" visible="off" length="point" direction="pas" swaplevel="1"/>
+<pin name="2" x="5.08" y="0" visible="off" length="point" direction="pas" swaplevel="1" rot="R180"/>
+</symbol>
+<symbol name="XC6210">
+<wire x1="-5.08" y1="2.54" x2="5.08" y2="2.54" width="0.1524" layer="94"/>
+<wire x1="5.08" y1="-5.08" x2="5.08" y2="2.54" width="0.1524" layer="94"/>
+<wire x1="5.08" y1="-5.08" x2="-5.08" y2="-5.08" width="0.1524" layer="94"/>
+<wire x1="-5.08" y1="2.54" x2="-5.08" y2="-5.08" width="0.1524" layer="94"/>
+<text x="-3.81" y="0.635" size="1.27" layer="95">&gt;NAME</text>
+<text x="-4.445" y="-4.445" size="1.27" layer="96">&gt;VALUE</text>
+<text x="-5.588" y="1.651" size="1.27" layer="94" rot="R180">IN</text>
+<text x="5.715" y="0.635" size="1.27" layer="94">OUT</text>
+<text x="0.635" y="-6.985" size="1.27" layer="94">GND</text>
+<text x="-5.588" y="-0.889" size="1.27" layer="94" rot="R180">CE</text>
+<text x="5.715" y="-1.905" size="1.27" layer="94">NC</text>
+<pin name="IN" x="-7.62" y="0" visible="off" length="short" direction="pas"/>
+<pin name="OUT" x="7.62" y="0" visible="off" length="short" direction="pas" rot="R180"/>
+<pin name="GND" x="0" y="-7.62" visible="off" length="short" direction="pas" rot="R90"/>
+<pin name="CE" x="-7.62" y="-2.54" visible="off" length="short" direction="pas"/>
+<pin name="NC" x="7.62" y="-2.54" visible="off" length="short" direction="pas" rot="R180"/>
+</symbol>
+<symbol name="DISPLEJ_154A2411CTP01">
+<pin name="DB8" x="-5.08" y="22.86" length="middle"/>
+<pin name="LEDA" x="-5.08" y="-22.86" length="middle" direction="pas"/>
+<pin name="IOVCC" x="-5.08" y="-12.7" length="middle" direction="pwr"/>
+<pin name="LEDK" x="-5.08" y="-25.4" length="middle" direction="pas"/>
+<pin name="IM1" x="-5.08" y="0" length="middle"/>
+<pin name="DB7" x="-5.08" y="20.32" length="middle"/>
+<pin name="DB6" x="-5.08" y="17.78" length="middle"/>
+<pin name="DB5" x="-5.08" y="15.24" length="middle"/>
+<pin name="DB4" x="-5.08" y="12.7" length="middle"/>
+<pin name="DB3" x="-5.08" y="10.16" length="middle"/>
+<pin name="DB2" x="-5.08" y="7.62" length="middle"/>
+<pin name="DB1" x="-5.08" y="5.08" length="middle"/>
+<pin name="DB0" x="-5.08" y="2.54" length="middle"/>
+<pin name="!RD" x="-5.08" y="-2.54" length="middle"/>
+<pin name="!WR" x="-5.08" y="-5.08" length="middle"/>
+<pin name="RS" x="-5.08" y="-7.62" length="middle"/>
+<pin name="!CS" x="-5.08" y="-10.16" length="middle"/>
+<pin name="FMARK" x="-5.08" y="-15.24" length="middle"/>
+<wire x1="10.16" y1="33.02" x2="0" y2="33.02" width="0.254" layer="94"/>
+<wire x1="0" y1="33.02" x2="0" y2="-30.48" width="0.254" layer="94"/>
+<wire x1="0" y1="-30.48" x2="10.16" y2="-30.48" width="0.254" layer="94"/>
+<text x="0" y="33.02" size="1.778" layer="95">&gt;NAME</text>
+<text x="0" y="-33.02" size="1.778" layer="96">&gt;VALUE</text>
+<pin name="GND@2" x="-5.08" y="25.4" length="middle" direction="pwr"/>
+<pin name="!RESET" x="-5.08" y="27.94" length="middle"/>
+<pin name="VCI" x="-5.08" y="-17.78" length="middle" direction="pas"/>
+<pin name="GND@3" x="-5.08" y="-20.32" length="middle" direction="pwr"/>
+<pin name="GND@1" x="-5.08" y="30.48" length="middle" direction="pwr"/>
+<pin name="GND@4" x="-5.08" y="-27.94" length="middle" direction="pwr"/>
+</symbol>
+<symbol name="DISPLEJ_154A2411CTP01_TOUCH">
+<pin name="VDD" x="-5.08" y="12.7" length="middle" direction="pwr"/>
+<pin name="REST" x="-5.08" y="2.54" length="middle"/>
+<pin name="EINT" x="-5.08" y="5.08" length="middle"/>
+<pin name="SCL" x="-5.08" y="10.16" length="middle"/>
+<pin name="SDA" x="-5.08" y="7.62" length="middle"/>
+<wire x1="10.16" y1="15.24" x2="0" y2="15.24" width="0.254" layer="94"/>
+<wire x1="0" y1="15.24" x2="0" y2="-12.7" width="0.254" layer="94"/>
+<wire x1="0" y1="-12.7" x2="10.16" y2="-12.7" width="0.254" layer="94"/>
+<text x="0" y="15.24" size="1.778" layer="95">&gt;NAME</text>
+<text x="0" y="-15.24" size="1.778" layer="96">&gt;VALUE</text>
+<pin name="GND@2" x="-5.08" y="-2.54" length="middle" direction="pwr"/>
+<pin name="NC" x="-5.08" y="-5.08" length="middle" direction="pas"/>
+<pin name="GND@3" x="-5.08" y="-7.62" length="middle" direction="pwr"/>
+<pin name="GND@1" x="-5.08" y="0" length="middle" direction="pwr"/>
+<pin name="GND@4" x="-5.08" y="-10.16" length="middle" direction="pwr"/>
+</symbol>
+<symbol name="USB_TYPE_C">
+<pin name="GND" x="-12.7" y="12.7" length="short" direction="pas"/>
+<pin name="TX1+" x="-12.7" y="10.16" length="short" direction="pas"/>
+<pin name="TX1-" x="-12.7" y="7.62" length="short" direction="pas"/>
+<pin name="VBUS" x="-12.7" y="5.08" length="short" direction="pas"/>
+<pin name="CC1" x="-12.7" y="2.54" length="short" direction="pas"/>
+<pin name="DP1" x="-12.7" y="0" length="short" direction="pas"/>
+<pin name="DN1" x="-12.7" y="-2.54" length="short" direction="pas"/>
+<pin name="SBU1" x="-12.7" y="-5.08" length="short" direction="pas"/>
+<pin name="VBUS@1" x="-12.7" y="-7.62" length="short" direction="pas"/>
+<pin name="RX2-" x="-12.7" y="-10.16" length="short" direction="pas"/>
+<pin name="RX2+" x="-12.7" y="-12.7" length="short" direction="pas"/>
+<pin name="GND@1" x="-12.7" y="-15.24" length="short" direction="pas"/>
+<pin name="GND@2" x="12.7" y="-15.24" length="short" direction="pas" rot="R180"/>
+<pin name="TX2+" x="12.7" y="-12.7" length="short" direction="pas" rot="R180"/>
+<pin name="TX2-" x="12.7" y="-10.16" length="short" direction="pas" rot="R180"/>
+<pin name="VBUS@2" x="12.7" y="-7.62" length="short" direction="pas" rot="R180"/>
+<pin name="CC2" x="12.7" y="-5.08" length="short" direction="pas" rot="R180"/>
+<pin name="DP2" x="12.7" y="-2.54" length="short" direction="pas" rot="R180"/>
+<pin name="DN2" x="12.7" y="0" length="short" direction="pas" rot="R180"/>
+<pin name="SBU2" x="12.7" y="2.54" length="short" direction="pas" rot="R180"/>
+<pin name="VBUS@3" x="12.7" y="5.08" length="short" direction="pas" rot="R180"/>
+<pin name="RX1-" x="12.7" y="7.62" length="short" direction="pas" rot="R180"/>
+<pin name="RX1+" x="12.7" y="10.16" length="short" direction="pas" rot="R180"/>
+<pin name="GND@3" x="12.7" y="12.7" length="short" direction="pas" rot="R180"/>
+<pin name="SHIELD@1" x="-2.54" y="-30.48" length="short" direction="pas" rot="R90"/>
+<pin name="SHIELD" x="-5.08" y="-30.48" length="short" direction="pas" rot="R90"/>
+<pin name="SHIELD@2" x="2.54" y="-30.48" length="short" direction="pas" rot="R90"/>
+<pin name="SHIELD@3" x="5.08" y="-30.48" length="short" direction="pas" rot="R90"/>
+<wire x1="-5.08" y1="-27.94" x2="5.08" y2="-27.94" width="0.254" layer="94"/>
+<wire x1="10.16" y1="-22.86" x2="10.16" y2="12.7" width="0.254" layer="94"/>
+<wire x1="5.08" y1="17.78" x2="-5.08" y2="17.78" width="0.254" layer="94"/>
+<wire x1="-10.16" y1="12.7" x2="-10.16" y2="-22.86" width="0.254" layer="94"/>
+<wire x1="-10.16" y1="12.7" x2="-5.08" y2="17.78" width="0.254" layer="94" curve="-90"/>
+<wire x1="10.16" y1="12.7" x2="5.08" y2="17.78" width="0.254" layer="94" curve="90"/>
+<wire x1="10.16" y1="-22.86" x2="5.08" y2="-27.94" width="0.254" layer="94" curve="-90"/>
+<wire x1="-10.16" y1="-22.86" x2="-5.08" y2="-27.94" width="0.254" layer="94" curve="90"/>
+<text x="0" y="20.32" size="1.778" layer="95" align="bottom-center">&gt;NAME</text>
+<text x="0" y="17.78" size="1.27" layer="96" align="bottom-center">&gt;VALUE</text>
+<text x="-5.08" y="13.97" size="1.27" layer="94" align="bottom-center">A1</text>
+<text x="-5.08" y="-17.78" size="1.27" layer="94" align="bottom-center">A12</text>
+<text x="5.08" y="-17.78" size="1.27" layer="94" align="bottom-center">B1</text>
+<text x="5.08" y="13.97" size="1.27" layer="94" align="bottom-center">B12</text>
+</symbol>
+<symbol name="SWD">
+<pin name="RST" x="7.62" y="-5.08" visible="pin" length="short" direction="pas" rot="R180"/>
+<pin name="GND" x="7.62" y="-2.54" visible="pin" length="short" direction="pas" rot="R180"/>
+<pin name="SWO" x="7.62" y="0" visible="pin" length="short" direction="pas" rot="R180"/>
+<pin name="SWCLK" x="7.62" y="2.54" visible="pin" length="short" direction="pas" rot="R180"/>
+<pin name="SWDIO" x="7.62" y="5.08" visible="pin" length="short" direction="pas" rot="R180"/>
+<pin name="VDD" x="7.62" y="7.62" visible="pin" length="short" direction="pas" rot="R180"/>
+<wire x1="5.08" y1="10.16" x2="5.08" y2="-7.62" width="0.254" layer="94"/>
+<wire x1="5.08" y1="-7.62" x2="-5.08" y2="-7.62" width="0.254" layer="94"/>
+<wire x1="-5.08" y1="-7.62" x2="-5.08" y2="10.16" width="0.254" layer="94"/>
+<wire x1="-5.08" y1="10.16" x2="5.08" y2="10.16" width="0.254" layer="94"/>
+<text x="-2.54" y="10.16" size="1.778" layer="95">&gt;NAME</text>
+<text x="-2.54" y="-10.16" size="1.778" layer="96">&gt;VALUE</text>
+</symbol>
+<symbol name="MB">
+<wire x1="2.54" y1="0" x2="0" y2="0" width="0.1524" layer="94"/>
+<circle x="-0.635" y="0" radius="0.635" width="0.1524" layer="94"/>
+<circle x="-0.635" y="0" radius="0.2839" width="0.635" layer="94"/>
+<text x="-1.27" y="2.54" size="1.27" layer="95">&gt;NAME</text>
+<pin name="1" x="2.54" y="0" visible="off" length="point" direction="pas" rot="R180"/>
+</symbol>
+<symbol name="PMOS">
+<wire x1="-1.1176" y1="-2.667" x2="-1.1176" y2="2.54" width="0.254" layer="94"/>
+<wire x1="-1.1176" y1="2.54" x2="-2.54" y2="2.54" width="0.1524" layer="94"/>
+<wire x1="2.413" y1="0" x2="1.143" y2="0.508" width="0.1524" layer="94"/>
+<wire x1="1.143" y1="0.508" x2="1.143" y2="-0.508" width="0.1524" layer="94"/>
+<wire x1="1.143" y1="-0.508" x2="2.413" y2="0" width="0.1524" layer="94"/>
+<wire x1="2.413" y1="0" x2="2.54" y2="0" width="0.1524" layer="94"/>
+<wire x1="0" y1="0" x2="2.413" y2="0" width="0.1524" layer="94"/>
+<text x="4.826" y="0.635" size="1.27" layer="95">&gt;NAME</text>
+<text x="4.826" y="-2.413" size="1.27" layer="96">&gt;VALUE</text>
+<rectangle x1="-0.254" y1="-2.54" x2="0.508" y2="2.54" layer="94"/>
+<pin name="G" x="-5.08" y="2.54" visible="off" length="short" direction="in"/>
+<pin name="D" x="2.54" y="-5.08" visible="off" length="short" direction="pas" rot="R90"/>
+<pin name="S" x="2.54" y="5.08" visible="off" length="short" direction="pas" rot="R270"/>
+<wire x1="2.54" y1="1.905" x2="0.5334" y2="1.905" width="0.1524" layer="94"/>
+<wire x1="2.54" y1="2.54" x2="2.54" y2="1.905" width="0.1524" layer="94"/>
+<wire x1="2.413" y1="0" x2="2.54" y2="0" width="0.1524" layer="94"/>
+<wire x1="0.508" y1="-1.905" x2="2.54" y2="-1.905" width="0.1524" layer="94"/>
+<wire x1="2.54" y1="0" x2="2.54" y2="1.905" width="0.1524" layer="94"/>
+<wire x1="2.54" y1="-2.54" x2="2.54" y2="-1.905" width="0.1524" layer="94"/>
+<wire x1="2.54" y1="-2.794" x2="3.556" y2="-2.794" width="0.127" layer="94"/>
+<wire x1="3.556" y1="-2.794" x2="3.556" y2="0.508" width="0.127" layer="94"/>
+<wire x1="3.556" y1="0.508" x2="3.556" y2="2.794" width="0.127" layer="94"/>
+<wire x1="3.556" y1="0.508" x2="3.048" y2="-0.508" width="0.127" layer="94"/>
+<wire x1="3.048" y1="-0.508" x2="4.064" y2="-0.508" width="0.127" layer="94"/>
+<wire x1="4.064" y1="-0.508" x2="3.556" y2="0.508" width="0.127" layer="94"/>
+<wire x1="3.048" y1="0.508" x2="3.556" y2="0.508" width="0.127" layer="94"/>
+<wire x1="3.556" y1="0.508" x2="4.064" y2="0.508" width="0.127" layer="94"/>
+<circle x="2.54" y="-2.794" radius="0" width="0.381" layer="94"/>
+<wire x1="2.54" y1="2.794" x2="3.556" y2="2.794" width="0.127" layer="94"/>
+<circle x="2.54" y="2.794" radius="0" width="0.381" layer="94"/>
+</symbol>
+<symbol name="MIC803">
+<wire x1="-5.08" y1="2.54" x2="5.08" y2="2.54" width="0.1524" layer="94"/>
+<wire x1="5.08" y1="-2.54" x2="5.08" y2="2.54" width="0.1524" layer="94"/>
+<wire x1="5.08" y1="-2.54" x2="-5.08" y2="-2.54" width="0.1524" layer="94"/>
+<wire x1="-5.08" y1="2.54" x2="-5.08" y2="-2.54" width="0.1524" layer="94"/>
+<text x="-3.81" y="5.715" size="1.27" layer="95">&gt;NAME</text>
+<text x="-3.937" y="3.683" size="1.27" layer="96">&gt;VALUE</text>
+<text x="-1.27" y="0.635" size="1.27" layer="94" rot="R180">VDD</text>
+<text x="4.445" y="0.635" size="1.27" layer="94" rot="R180">!RST</text>
+<text x="-1.905" y="-2.159" size="1.27" layer="94">GND</text>
+<pin name="VDD" x="-7.62" y="0" visible="off" length="short" direction="pas"/>
+<pin name="RES" x="7.62" y="0" visible="off" length="short" direction="pas" rot="R180"/>
+<pin name="GND" x="0" y="-5.08" visible="off" length="short" direction="pas" rot="R90"/>
+</symbol>
+</symbols>
+<devicesets>
+<deviceset name="STM32F427_LQFP100" prefix="IC" uservalue="yes">
+<gates>
+<gate name="IC" symbol="STM32F427_LQFP100" x="0" y="0"/>
+</gates>
+<devices>
+<device name="_WITH_CENTER" package="LQFP100">
+<connects>
+<connect gate="IC" pin="BOOT0" pad="94"/>
+<connect gate="IC" pin="NRST" pad="14"/>
+<connect gate="IC" pin="PA0-WKUP" pad="23"/>
+<connect gate="IC" pin="PA1" pad="24"/>
+<connect gate="IC" pin="PA10/OFG_FS_ID" pad="69"/>
+<connect gate="IC" pin="PA11/OTG_FS_DM" pad="70"/>
+<connect gate="IC" pin="PA12/OTG_FS_DP" pad="71"/>
+<connect gate="IC" pin="PA13/SWDIO" pad="72"/>
+<connect gate="IC" pin="PA14/SWCLK" pad="76"/>
+<connect gate="IC" pin="PA15" pad="77"/>
+<connect gate="IC" pin="PA2" pad="25"/>
+<connect gate="IC" pin="PA3" pad="26"/>
+<connect gate="IC" pin="PA4/SPI1_NSS/OTG_HS_SOF" pad="29"/>
+<connect gate="IC" pin="PA5/SPI1_SCK" pad="30"/>
+<connect gate="IC" pin="PA6/SPI1_MISO" pad="31"/>
+<connect gate="IC" pin="PA7/SPI1_MOSI" pad="32"/>
+<connect gate="IC" pin="PA8/OTG_FS_SOF" pad="67"/>
+<connect gate="IC" pin="PA9/OTG_FS_VBUS" pad="68"/>
+<connect gate="IC" pin="PB0" pad="35"/>
+<connect gate="IC" pin="PB1" pad="36"/>
+<connect gate="IC" pin="PB10" pad="47"/>
+<connect gate="IC" pin="PB11" pad="48"/>
+<connect gate="IC" pin="PB12/OTG_HS_ID" pad="51"/>
+<connect gate="IC" pin="PB13/OTG_HS_VBUS" pad="52"/>
+<connect gate="IC" pin="PB14/OTG_HS_DM" pad="53"/>
+<connect gate="IC" pin="PB15/OTG_HS_DP" pad="54"/>
+<connect gate="IC" pin="PB2" pad="37"/>
+<connect gate="IC" pin="PB3/SWO" pad="89"/>
+<connect gate="IC" pin="PB4" pad="90"/>
+<connect gate="IC" pin="PB5" pad="91"/>
+<connect gate="IC" pin="PB6" pad="92"/>
+<connect gate="IC" pin="PB7" pad="93"/>
+<connect gate="IC" pin="PB8" pad="95"/>
+<connect gate="IC" pin="PB9" pad="96"/>
+<connect gate="IC" pin="PC0" pad="15"/>
+<connect gate="IC" pin="PC1" pad="16"/>
+<connect gate="IC" pin="PC10" pad="78"/>
+<connect gate="IC" pin="PC11" pad="79"/>
+<connect gate="IC" pin="PC12" pad="80"/>
+<connect gate="IC" pin="PC13" pad="7"/>
+<connect gate="IC" pin="PC14" pad="8"/>
+<connect gate="IC" pin="PC15" pad="9"/>
+<connect gate="IC" pin="PC2" pad="17"/>
+<connect gate="IC" pin="PC3" pad="18"/>
+<connect gate="IC" pin="PC4" pad="33"/>
+<connect gate="IC" pin="PC5" pad="34"/>
+<connect gate="IC" pin="PC6" pad="63"/>
+<connect gate="IC" pin="PC7" pad="64"/>
+<connect gate="IC" pin="PC8" pad="65"/>
+<connect gate="IC" pin="PC9" pad="66"/>
+<connect gate="IC" pin="PD0" pad="81"/>
+<connect gate="IC" pin="PD1" pad="82"/>
+<connect gate="IC" pin="PD10" pad="57"/>
+<connect gate="IC" pin="PD11" pad="58"/>
+<connect gate="IC" pin="PD12" pad="59"/>
+<connect gate="IC" pin="PD13" pad="60"/>
+<connect gate="IC" pin="PD14" pad="61"/>
+<connect gate="IC" pin="PD15" pad="62"/>
+<connect gate="IC" pin="PD2" pad="83"/>
+<connect gate="IC" pin="PD3" pad="84"/>
+<connect gate="IC" pin="PD4" pad="85"/>
+<connect gate="IC" pin="PD5" pad="86"/>
+<connect gate="IC" pin="PD6" pad="87"/>
+<connect gate="IC" pin="PD7" pad="88"/>
+<connect gate="IC" pin="PD8" pad="55"/>
+<connect gate="IC" pin="PD9" pad="56"/>
+<connect gate="IC" pin="PE0" pad="97"/>
+<connect gate="IC" pin="PE1" pad="98"/>
+<connect gate="IC" pin="PE10" pad="41"/>
+<connect gate="IC" pin="PE11" pad="42"/>
+<connect gate="IC" pin="PE12" pad="43"/>
+<connect gate="IC" pin="PE13" pad="44"/>
+<connect gate="IC" pin="PE14" pad="45"/>
+<connect gate="IC" pin="PE15" pad="46"/>
+<connect gate="IC" pin="PE2" pad="1"/>
+<connect gate="IC" pin="PE3" pad="2"/>
+<connect gate="IC" pin="PE4" pad="3"/>
+<connect gate="IC" pin="PE5" pad="4"/>
+<connect gate="IC" pin="PE6" pad="5"/>
+<connect gate="IC" pin="PE7" pad="38"/>
+<connect gate="IC" pin="PE8" pad="39"/>
+<connect gate="IC" pin="PE9" pad="40"/>
+<connect gate="IC" pin="PH0-OSC_IN" pad="12"/>
+<connect gate="IC" pin="PH1-OSC_OUT" pad="13"/>
+<connect gate="IC" pin="VBAT" pad="6"/>
+<connect gate="IC" pin="VCAP_1" pad="49"/>
+<connect gate="IC" pin="VCAP_2" pad="73"/>
+<connect gate="IC" pin="VDD@1" pad="11"/>
+<connect gate="IC" pin="VDD@2" pad="19"/>
+<connect gate="IC" pin="VDD@3" pad="28"/>
+<connect gate="IC" pin="VDD@4" pad="50"/>
+<connect gate="IC" pin="VDD@5" pad="75"/>
+<connect gate="IC" pin="VDD@6" pad="100"/>
+<connect gate="IC" pin="VDDA" pad="22"/>
+<connect gate="IC" pin="VREF+" pad="21"/>
+<connect gate="IC" pin="VSS@1" pad="10"/>
+<connect gate="IC" pin="VSS@2" pad="27"/>
+<connect gate="IC" pin="VSS@3" pad="74"/>
+<connect gate="IC" pin="VSS@4" pad="99"/>
+<connect gate="IC" pin="VSSA" pad="20"/>
+</connects>
+<technologies>
+<technology name=""/>
+</technologies>
+</device>
+<device name="_NO_CENTER" package="LQFP100_NO_CENTER">
+<connects>
+<connect gate="IC" pin="BOOT0" pad="94"/>
+<connect gate="IC" pin="NRST" pad="14"/>
+<connect gate="IC" pin="PA0-WKUP" pad="23"/>
+<connect gate="IC" pin="PA1" pad="24"/>
+<connect gate="IC" pin="PA10/OFG_FS_ID" pad="69"/>
+<connect gate="IC" pin="PA11/OTG_FS_DM" pad="70"/>
+<connect gate="IC" pin="PA12/OTG_FS_DP" pad="71"/>
+<connect gate="IC" pin="PA13/SWDIO" pad="72"/>
+<connect gate="IC" pin="PA14/SWCLK" pad="76"/>
+<connect gate="IC" pin="PA15" pad="77"/>
+<connect gate="IC" pin="PA2" pad="25"/>
+<connect gate="IC" pin="PA3" pad="26"/>
+<connect gate="IC" pin="PA4/SPI1_NSS/OTG_HS_SOF" pad="29"/>
+<connect gate="IC" pin="PA5/SPI1_SCK" pad="30"/>
+<connect gate="IC" pin="PA6/SPI1_MISO" pad="31"/>
+<connect gate="IC" pin="PA7/SPI1_MOSI" pad="32"/>
+<connect gate="IC" pin="PA8/OTG_FS_SOF" pad="67"/>
+<connect gate="IC" pin="PA9/OTG_FS_VBUS" pad="68"/>
+<connect gate="IC" pin="PB0" pad="35"/>
+<connect gate="IC" pin="PB1" pad="36"/>
+<connect gate="IC" pin="PB10" pad="47"/>
+<connect gate="IC" pin="PB11" pad="48"/>
+<connect gate="IC" pin="PB12/OTG_HS_ID" pad="51"/>
+<connect gate="IC" pin="PB13/OTG_HS_VBUS" pad="52"/>
+<connect gate="IC" pin="PB14/OTG_HS_DM" pad="53"/>
+<connect gate="IC" pin="PB15/OTG_HS_DP" pad="54"/>
+<connect gate="IC" pin="PB2" pad="37"/>
+<connect gate="IC" pin="PB3/SWO" pad="89"/>
+<connect gate="IC" pin="PB4" pad="90"/>
+<connect gate="IC" pin="PB5" pad="91"/>
+<connect gate="IC" pin="PB6" pad="92"/>
+<connect gate="IC" pin="PB7" pad="93"/>
+<connect gate="IC" pin="PB8" pad="95"/>
+<connect gate="IC" pin="PB9" pad="96"/>
+<connect gate="IC" pin="PC0" pad="15"/>
+<connect gate="IC" pin="PC1" pad="16"/>
+<connect gate="IC" pin="PC10" pad="78"/>
+<connect gate="IC" pin="PC11" pad="79"/>
+<connect gate="IC" pin="PC12" pad="80"/>
+<connect gate="IC" pin="PC13" pad="7"/>
+<connect gate="IC" pin="PC14" pad="8"/>
+<connect gate="IC" pin="PC15" pad="9"/>
+<connect gate="IC" pin="PC2" pad="17"/>
+<connect gate="IC" pin="PC3" pad="18"/>
+<connect gate="IC" pin="PC4" pad="33"/>
+<connect gate="IC" pin="PC5" pad="34"/>
+<connect gate="IC" pin="PC6" pad="63"/>
+<connect gate="IC" pin="PC7" pad="64"/>
+<connect gate="IC" pin="PC8" pad="65"/>
+<connect gate="IC" pin="PC9" pad="66"/>
+<connect gate="IC" pin="PD0" pad="81"/>
+<connect gate="IC" pin="PD1" pad="82"/>
+<connect gate="IC" pin="PD10" pad="57"/>
+<connect gate="IC" pin="PD11" pad="58"/>
+<connect gate="IC" pin="PD12" pad="59"/>
+<connect gate="IC" pin="PD13" pad="60"/>
+<connect gate="IC" pin="PD14" pad="61"/>
+<connect gate="IC" pin="PD15" pad="62"/>
+<connect gate="IC" pin="PD2" pad="83"/>
+<connect gate="IC" pin="PD3" pad="84"/>
+<connect gate="IC" pin="PD4" pad="85"/>
+<connect gate="IC" pin="PD5" pad="86"/>
+<connect gate="IC" pin="PD6" pad="87"/>
+<connect gate="IC" pin="PD7" pad="88"/>
+<connect gate="IC" pin="PD8" pad="55"/>
+<connect gate="IC" pin="PD9" pad="56"/>
+<connect gate="IC" pin="PE0" pad="97"/>
+<connect gate="IC" pin="PE1" pad="98"/>
+<connect gate="IC" pin="PE10" pad="41"/>
+<connect gate="IC" pin="PE11" pad="42"/>
+<connect gate="IC" pin="PE12" pad="43"/>
+<connect gate="IC" pin="PE13" pad="44"/>
+<connect gate="IC" pin="PE14" pad="45"/>
+<connect gate="IC" pin="PE15" pad="46"/>
+<connect gate="IC" pin="PE2" pad="1"/>
+<connect gate="IC" pin="PE3" pad="2"/>
+<connect gate="IC" pin="PE4" pad="3"/>
+<connect gate="IC" pin="PE5" pad="4"/>
+<connect gate="IC" pin="PE6" pad="5"/>
+<connect gate="IC" pin="PE7" pad="38"/>
+<connect gate="IC" pin="PE8" pad="39"/>
+<connect gate="IC" pin="PE9" pad="40"/>
+<connect gate="IC" pin="PH0-OSC_IN" pad="12"/>
+<connect gate="IC" pin="PH1-OSC_OUT" pad="13"/>
+<connect gate="IC" pin="VBAT" pad="6"/>
+<connect gate="IC" pin="VCAP_1" pad="49"/>
+<connect gate="IC" pin="VCAP_2" pad="73"/>
+<connect gate="IC" pin="VDD@1" pad="11"/>
+<connect gate="IC" pin="VDD@2" pad="19"/>
+<connect gate="IC" pin="VDD@3" pad="28"/>
+<connect gate="IC" pin="VDD@4" pad="50"/>
+<connect gate="IC" pin="VDD@5" pad="75"/>
+<connect gate="IC" pin="VDD@6" pad="100"/>
+<connect gate="IC" pin="VDDA" pad="22"/>
+<connect gate="IC" pin="VREF+" pad="21"/>
+<connect gate="IC" pin="VSS@1" pad="10"/>
+<connect gate="IC" pin="VSS@2" pad="27"/>
+<connect gate="IC" pin="VSS@3" pad="74"/>
+<connect gate="IC" pin="VSS@4" pad="99"/>
+<connect gate="IC" pin="VSSA" pad="20"/>
+</connects>
+<technologies>
+<technology name=""/>
+</technologies>
+</device>
+<device name="" package="LQFP100_NO_CENTER_NO_TDOCU">
+<connects>
+<connect gate="IC" pin="BOOT0" pad="94"/>
+<connect gate="IC" pin="NRST" pad="14"/>
+<connect gate="IC" pin="PA0-WKUP" pad="23"/>
+<connect gate="IC" pin="PA1" pad="24"/>
+<connect gate="IC" pin="PA10/OFG_FS_ID" pad="69"/>
+<connect gate="IC" pin="PA11/OTG_FS_DM" pad="70"/>
+<connect gate="IC" pin="PA12/OTG_FS_DP" pad="71"/>
+<connect gate="IC" pin="PA13/SWDIO" pad="72"/>
+<connect gate="IC" pin="PA14/SWCLK" pad="76"/>
+<connect gate="IC" pin="PA15" pad="77"/>
+<connect gate="IC" pin="PA2" pad="25"/>
+<connect gate="IC" pin="PA3" pad="26"/>
+<connect gate="IC" pin="PA4/SPI1_NSS/OTG_HS_SOF" pad="29"/>
+<connect gate="IC" pin="PA5/SPI1_SCK" pad="30"/>
+<connect gate="IC" pin="PA6/SPI1_MISO" pad="31"/>
+<connect gate="IC" pin="PA7/SPI1_MOSI" pad="32"/>
+<connect gate="IC" pin="PA8/OTG_FS_SOF" pad="67"/>
+<connect gate="IC" pin="PA9/OTG_FS_VBUS" pad="68"/>
+<connect gate="IC" pin="PB0" pad="35"/>
+<connect gate="IC" pin="PB1" pad="36"/>
+<connect gate="IC" pin="PB10" pad="47"/>
+<connect gate="IC" pin="PB11" pad="48"/>
+<connect gate="IC" pin="PB12/OTG_HS_ID" pad="51"/>
+<connect gate="IC" pin="PB13/OTG_HS_VBUS" pad="52"/>
+<connect gate="IC" pin="PB14/OTG_HS_DM" pad="53"/>
+<connect gate="IC" pin="PB15/OTG_HS_DP" pad="54"/>
+<connect gate="IC" pin="PB2" pad="37"/>
+<connect gate="IC" pin="PB3/SWO" pad="89"/>
+<connect gate="IC" pin="PB4" pad="90"/>
+<connect gate="IC" pin="PB5" pad="91"/>
+<connect gate="IC" pin="PB6" pad="92"/>
+<connect gate="IC" pin="PB7" pad="93"/>
+<connect gate="IC" pin="PB8" pad="95"/>
+<connect gate="IC" pin="PB9" pad="96"/>
+<connect gate="IC" pin="PC0" pad="15"/>
+<connect gate="IC" pin="PC1" pad="16"/>
+<connect gate="IC" pin="PC10" pad="78"/>
+<connect gate="IC" pin="PC11" pad="79"/>
+<connect gate="IC" pin="PC12" pad="80"/>
+<connect gate="IC" pin="PC13" pad="7"/>
+<connect gate="IC" pin="PC14" pad="8"/>
+<connect gate="IC" pin="PC15" pad="9"/>
+<connect gate="IC" pin="PC2" pad="17"/>
+<connect gate="IC" pin="PC3" pad="18"/>
+<connect gate="IC" pin="PC4" pad="33"/>
+<connect gate="IC" pin="PC5" pad="34"/>
+<connect gate="IC" pin="PC6" pad="63"/>
+<connect gate="IC" pin="PC7" pad="64"/>
+<connect gate="IC" pin="PC8" pad="65"/>
+<connect gate="IC" pin="PC9" pad="66"/>
+<connect gate="IC" pin="PD0" pad="81"/>
+<connect gate="IC" pin="PD1" pad="82"/>
+<connect gate="IC" pin="PD10" pad="57"/>
+<connect gate="IC" pin="PD11" pad="58"/>
+<connect gate="IC" pin="PD12" pad="59"/>
+<connect gate="IC" pin="PD13" pad="60"/>
+<connect gate="IC" pin="PD14" pad="61"/>
+<connect gate="IC" pin="PD15" pad="62"/>
+<connect gate="IC" pin="PD2" pad="83"/>
+<connect gate="IC" pin="PD3" pad="84"/>
+<connect gate="IC" pin="PD4" pad="85"/>
+<connect gate="IC" pin="PD5" pad="86"/>
+<connect gate="IC" pin="PD6" pad="87"/>
+<connect gate="IC" pin="PD7" pad="88"/>
+<connect gate="IC" pin="PD8" pad="55"/>
+<connect gate="IC" pin="PD9" pad="56"/>
+<connect gate="IC" pin="PE0" pad="97"/>
+<connect gate="IC" pin="PE1" pad="98"/>
+<connect gate="IC" pin="PE10" pad="41"/>
+<connect gate="IC" pin="PE11" pad="42"/>
+<connect gate="IC" pin="PE12" pad="43"/>
+<connect gate="IC" pin="PE13" pad="44"/>
+<connect gate="IC" pin="PE14" pad="45"/>
+<connect gate="IC" pin="PE15" pad="46"/>
+<connect gate="IC" pin="PE2" pad="1"/>
+<connect gate="IC" pin="PE3" pad="2"/>
+<connect gate="IC" pin="PE4" pad="3"/>
+<connect gate="IC" pin="PE5" pad="4"/>
+<connect gate="IC" pin="PE6" pad="5"/>
+<connect gate="IC" pin="PE7" pad="38"/>
+<connect gate="IC" pin="PE8" pad="39"/>
+<connect gate="IC" pin="PE9" pad="40"/>
+<connect gate="IC" pin="PH0-OSC_IN" pad="12"/>
+<connect gate="IC" pin="PH1-OSC_OUT" pad="13"/>
+<connect gate="IC" pin="VBAT" pad="6"/>
+<connect gate="IC" pin="VCAP_1" pad="49"/>
+<connect gate="IC" pin="VCAP_2" pad="73"/>
+<connect gate="IC" pin="VDD@1" pad="11"/>
+<connect gate="IC" pin="VDD@2" pad="19"/>
+<connect gate="IC" pin="VDD@3" pad="28"/>
+<connect gate="IC" pin="VDD@4" pad="50"/>
+<connect gate="IC" pin="VDD@5" pad="75"/>
+<connect gate="IC" pin="VDD@6" pad="100"/>
+<connect gate="IC" pin="VDDA" pad="22"/>
+<connect gate="IC" pin="VREF+" pad="21"/>
+<connect gate="IC" pin="VSS@1" pad="10"/>
+<connect gate="IC" pin="VSS@2" pad="27"/>
+<connect gate="IC" pin="VSS@3" pad="74"/>
+<connect gate="IC" pin="VSS@4" pad="99"/>
+<connect gate="IC" pin="VSSA" pad="20"/>
+</connects>
+<technologies>
+<technology name=""/>
+</technologies>
+</device>
+</devices>
+</deviceset>
+<deviceset name="X_4V" prefix="X" uservalue="yes">
+<gates>
+<gate name="G$1" symbol="X_4V" x="0" y="0"/>
+</gates>
+<devices>
+<device name="_6,0X3,5" package="X6,0X3,5">
+<connects>
+<connect gate="G$1" pin="1" pad="1"/>
+<connect gate="G$1" pin="2" pad="3"/>
+<connect gate="G$1" pin="GND1" pad="2"/>
+<connect gate="G$1" pin="GND2" pad="4"/>
+</connects>
+<technologies>
+<technology name=""/>
+</technologies>
+</device>
+</devices>
+</deviceset>
+<deviceset name="L" prefix="L" uservalue="yes">
+<gates>
+<gate name="G$1" symbol="L" x="0" y="0"/>
+</gates>
+<devices>
+<device name="_2.9X2.9" package="L_2.9X2.9">
+<connects>
+<connect gate="G$1" pin="1" pad="1"/>
+<connect gate="G$1" pin="2" pad="2"/>
+</connects>
+<technologies>
+<technology name=""/>
+</technologies>
+</device>
+<device name="_2.5X2.0" package="L_2.5X2.0">
+<connects>
+<connect gate="G$1" pin="1" pad="1"/>
+<connect gate="G$1" pin="2" pad="2"/>
+</connects>
+<technologies>
+<technology name=""/>
+</technologies>
+</device>
+</devices>
+</deviceset>
+<deviceset name="XC6210B" prefix="IC" uservalue="yes">
+<gates>
+<gate name="G$1" symbol="XC6210" x="0" y="0"/>
+</gates>
+<devices>
+<device name="_SOT89-5" package="SOT89-5">
+<connects>
+<connect gate="G$1" pin="CE" pad="1"/>
+<connect gate="G$1" pin="GND" pad="2"/>
+<connect gate="G$1" pin="IN" pad="4"/>
+<connect gate="G$1" pin="NC" pad="3"/>
+<connect gate="G$1" pin="OUT" pad="5"/>
+</connects>
+<technologies>
+<technology name=""/>
+</technologies>
+</device>
+<device name="_SOT23-5_REFLOW" package="SOT23-5_REFLOW">
+<connects>
+<connect gate="G$1" pin="CE" pad="3"/>
+<connect gate="G$1" pin="GND" pad="2"/>
+<connect gate="G$1" pin="IN" pad="1"/>
+<connect gate="G$1" pin="NC" pad="4"/>
+<connect gate="G$1" pin="OUT" pad="5"/>
+</connects>
+<technologies>
+<technology name=""/>
+</technologies>
+</device>
+</devices>
+</deviceset>
+<deviceset name="DISPLEJ_154A2411CTP01" prefix="K" uservalue="yes">
+<gates>
+<gate name="G$1" symbol="DISPLEJ_154A2411CTP01" x="0" y="0"/>
+</gates>
+<devices>
+<device name="" package="DF37NB-24DS-0.4V">
+<connects>
+<connect gate="G$1" pin="!CS" pad="17"/>
+<connect gate="G$1" pin="!RD" pad="14"/>
+<connect gate="G$1" pin="!RESET" pad="2"/>
+<connect gate="G$1" pin="!WR" pad="15"/>
+<connect gate="G$1" pin="DB0" pad="12"/>
+<connect gate="G$1" pin="DB1" pad="11"/>
+<connect gate="G$1" pin="DB2" pad="10"/>
+<connect gate="G$1" pin="DB3" pad="9"/>
+<connect gate="G$1" pin="DB4" pad="8"/>
+<connect gate="G$1" pin="DB5" pad="7"/>
+<connect gate="G$1" pin="DB6" pad="6"/>
+<connect gate="G$1" pin="DB7" pad="5"/>
+<connect gate="G$1" pin="DB8" pad="4"/>
+<connect gate="G$1" pin="FMARK" pad="19"/>
+<connect gate="G$1" pin="GND@1" pad="1"/>
+<connect gate="G$1" pin="GND@2" pad="3"/>
+<connect gate="G$1" pin="GND@3" pad="21"/>
+<connect gate="G$1" pin="GND@4" pad="24 25 26"/>
+<connect gate="G$1" pin="IM1" pad="13"/>
+<connect gate="G$1" pin="IOVCC" pad="18"/>
+<connect gate="G$1" pin="LEDA" pad="22"/>
+<connect gate="G$1" pin="LEDK" pad="23"/>
+<connect gate="G$1" pin="RS" pad="16"/>
+<connect gate="G$1" pin="VCI" pad="20"/>
+</connects>
+<technologies>
+<technology name=""/>
+</technologies>
+</device>
+</devices>
+</deviceset>
+<deviceset name="DISPLEJ_154A2411CTP01_TOUCH" prefix="K" uservalue="yes">
+<gates>
+<gate name="G$1" symbol="DISPLEJ_154A2411CTP01_TOUCH" x="0" y="0"/>
+</gates>
+<devices>
+<device name="" package="DF37NB-10DS-0.4V">
+<connects>
+<connect gate="G$1" pin="EINT" pad="4"/>
+<connect gate="G$1" pin="GND@1" pad="6"/>
+<connect gate="G$1" pin="GND@2" pad="7"/>
+<connect gate="G$1" pin="GND@3" pad="9"/>
+<connect gate="G$1" pin="GND@4" pad="10 11 12"/>
+<connect gate="G$1" pin="NC" pad="8"/>
+<connect gate="G$1" pin="REST" pad="5"/>
+<connect gate="G$1" pin="SCL" pad="2"/>
+<connect gate="G$1" pin="SDA" pad="3"/>
+<connect gate="G$1" pin="VDD" pad="1"/>
+</connects>
+<technologies>
+<technology name=""/>
+</technologies>
+</device>
+</devices>
+</deviceset>
+<deviceset name="USB-C" prefix="K" uservalue="yes">
+<gates>
+<gate name="K" symbol="USB_TYPE_C" x="0" y="0"/>
+</gates>
+<devices>
+<device name="_MOLEX_105450-0101" package="USB_C_MOLEX_105450-0101">
+<connects>
+<connect gate="K" pin="CC1" pad="A5"/>
+<connect gate="K" pin="CC2" pad="B5"/>
+<connect gate="K" pin="DN1" pad="A7"/>
+<connect gate="K" pin="DN2" pad="B7"/>
+<connect gate="K" pin="DP1" pad="A6"/>
+<connect gate="K" pin="DP2" pad="B6"/>
+<connect gate="K" pin="GND" pad="A1"/>
+<connect gate="K" pin="GND@1" pad="A12"/>
+<connect gate="K" pin="GND@2" pad="B1"/>
+<connect gate="K" pin="GND@3" pad="B12"/>
+<connect gate="K" pin="RX1+" pad="B11"/>
+<connect gate="K" pin="RX1-" pad="B10"/>
+<connect gate="K" pin="RX2+" pad="A11"/>
+<connect gate="K" pin="RX2-" pad="A10"/>
+<connect gate="K" pin="SBU1" pad="A8"/>
+<connect gate="K" pin="SBU2" pad="B8"/>
+<connect gate="K" pin="SHIELD" pad="SH1"/>
+<connect gate="K" pin="SHIELD@1" pad="SH4"/>
+<connect gate="K" pin="SHIELD@2" pad="SH2"/>
+<connect gate="K" pin="SHIELD@3" pad="SH3"/>
+<connect gate="K" pin="TX1+" pad="A2"/>
+<connect gate="K" pin="TX1-" pad="A3"/>
+<connect gate="K" pin="TX2+" pad="B2"/>
+<connect gate="K" pin="TX2-" pad="B3"/>
+<connect gate="K" pin="VBUS" pad="A4"/>
+<connect gate="K" pin="VBUS@1" pad="A9"/>
+<connect gate="K" pin="VBUS@2" pad="B4"/>
+<connect gate="K" pin="VBUS@3" pad="B9"/>
+</connects>
+<technologies>
+<technology name=""/>
+</technologies>
+</device>
+<device name="_TE_1-2295018-2" package="USB_C_TE_1-2295018-2">
+<connects>
+<connect gate="K" pin="CC1" pad="A5"/>
+<connect gate="K" pin="CC2" pad="B5"/>
+<connect gate="K" pin="DN1" pad="A7"/>
+<connect gate="K" pin="DN2" pad="B7"/>
+<connect gate="K" pin="DP1" pad="A6"/>
+<connect gate="K" pin="DP2" pad="B6"/>
+<connect gate="K" pin="GND" pad="A1"/>
+<connect gate="K" pin="GND@1" pad="A12"/>
+<connect gate="K" pin="GND@2" pad="B1"/>
+<connect gate="K" pin="GND@3" pad="B12"/>
+<connect gate="K" pin="RX1+" pad="B11"/>
+<connect gate="K" pin="RX1-" pad="B10"/>
+<connect gate="K" pin="RX2+" pad="A11"/>
+<connect gate="K" pin="RX2-" pad="A10"/>
+<connect gate="K" pin="SBU1" pad="A8"/>
+<connect gate="K" pin="SBU2" pad="B8"/>
+<connect gate="K" pin="SHIELD" pad="SH4"/>
+<connect gate="K" pin="SHIELD@1" pad="SH3"/>
+<connect gate="K" pin="SHIELD@2" pad="SH1"/>
+<connect gate="K" pin="SHIELD@3" pad="SH2"/>
+<connect gate="K" pin="TX1+" pad="A2"/>
+<connect gate="K" pin="TX1-" pad="A3"/>
+<connect gate="K" pin="TX2+" pad="B2"/>
+<connect gate="K" pin="TX2-" pad="B3"/>
+<connect gate="K" pin="VBUS" pad="A4"/>
+<connect gate="K" pin="VBUS@1" pad="A9"/>
+<connect gate="K" pin="VBUS@2" pad="B4"/>
+<connect gate="K" pin="VBUS@3" pad="B9"/>
+</connects>
+<technologies>
+<technology name=""/>
+</technologies>
+</device>
+<device name="_JAE_DX07B024XJ1" package="USB_C_JAE_DX07B024XJ1">
+<connects>
+<connect gate="K" pin="CC1" pad="A5"/>
+<connect gate="K" pin="CC2" pad="B5"/>
+<connect gate="K" pin="DN1" pad="A7"/>
+<connect gate="K" pin="DN2" pad="B7"/>
+<connect gate="K" pin="DP1" pad="A6"/>
+<connect gate="K" pin="DP2" pad="B6"/>
+<connect gate="K" pin="GND" pad="A1"/>
+<connect gate="K" pin="GND@1" pad="A12"/>
+<connect gate="K" pin="GND@2" pad="B1"/>
+<connect gate="K" pin="GND@3" pad="B12"/>
+<connect gate="K" pin="RX1+" pad="B11"/>
+<connect gate="K" pin="RX1-" pad="B10"/>
+<connect gate="K" pin="RX2+" pad="A11"/>
+<connect gate="K" pin="RX2-" pad="A10"/>
+<connect gate="K" pin="SBU1" pad="A8"/>
+<connect gate="K" pin="SBU2" pad="B8"/>
+<connect gate="K" pin="SHIELD" pad="SH1"/>
+<connect gate="K" pin="SHIELD@1" pad="SH4"/>
+<connect gate="K" pin="SHIELD@2" pad="SH2"/>
+<connect gate="K" pin="SHIELD@3" pad="SH3"/>
+<connect gate="K" pin="TX1+" pad="A2"/>
+<connect gate="K" pin="TX1-" pad="A3"/>
+<connect gate="K" pin="TX2+" pad="B2"/>
+<connect gate="K" pin="TX2-" pad="B3"/>
+<connect gate="K" pin="VBUS" pad="A4"/>
+<connect gate="K" pin="VBUS@1" pad="A9"/>
+<connect gate="K" pin="VBUS@2" pad="B4"/>
+<connect gate="K" pin="VBUS@3" pad="B9"/>
+</connects>
+<technologies>
+<technology name=""/>
+</technologies>
+</device>
+</devices>
+</deviceset>
+<deviceset name="SWD" prefix="K">
+<gates>
+<gate name="K" symbol="SWD" x="0" y="0"/>
+</gates>
+<devices>
+<device name="" package="SWD">
+<connects>
+<connect gate="K" pin="GND" pad="GND"/>
+<connect gate="K" pin="RST" pad="RST"/>
+<connect gate="K" pin="SWCLK" pad="SWCLK"/>
+<connect gate="K" pin="SWDIO" pad="SWDIO"/>
+<connect gate="K" pin="SWO" pad="SWO"/>
+<connect gate="K" pin="VDD" pad="VCC"/>
+</connects>
+<technologies>
+<technology name=""/>
+</technologies>
+</device>
+</devices>
+</deviceset>
+<deviceset name="MB" prefix="MB" uservalue="yes">
+<gates>
+<gate name="G$1" symbol="MB" x="0" y="0"/>
+</gates>
+<devices>
+<device name="_1.00" package="MB_1.00">
+<connects>
+<connect gate="G$1" pin="1" pad="1"/>
+</connects>
+<technologies>
+<technology name=""/>
+</technologies>
+</device>
+</devices>
+</deviceset>
+<deviceset name="PMOS" prefix="T" uservalue="yes">
+<gates>
+<gate name="G$1" symbol="PMOS" x="0" y="0"/>
+</gates>
+<devices>
+<device name="_SOT-23_REF" package="SOT23_REFLOW">
+<connects>
+<connect gate="G$1" pin="D" pad="3"/>
+<connect gate="G$1" pin="G" pad="2"/>
+<connect gate="G$1" pin="S" pad="1"/>
+</connects>
+<technologies>
+<technology name=""/>
+</technologies>
+</device>
+</devices>
+</deviceset>
+<deviceset name="MIC803" prefix="IC" uservalue="yes">
+<gates>
+<gate name="G$1" symbol="MIC803" x="0" y="0"/>
+</gates>
+<devices>
+<device name="" package="SOT23_MEDIUM_SIZE">
+<connects>
+<connect gate="G$1" pin="GND" pad="1"/>
+<connect gate="G$1" pin="RES" pad="2"/>
+<connect gate="G$1" pin="VDD" pad="3"/>
+</connects>
+<technologies>
+<technology name=""/>
+</technologies>
+</device>
+</devices>
+</deviceset>
+</devicesets>
+</library>
+<library name="DZ">
+<packages>
+<package name="SOD882D">
+<smd name="1" x="-0.4" y="0" dx="0.6" dy="0.5" layer="1" rot="R90" cream="no"/>
+<smd name="2" x="0.4" y="0" dx="0.6" dy="0.5" layer="1" rot="R90" cream="no"/>
+<rectangle x1="-0.5" y1="-0.25" x2="-0.2" y2="0.25" layer="31"/>
+<rectangle x1="0.2" y1="-0.25" x2="0.5" y2="0.25" layer="31"/>
+<text x="-0.889" y="0.635" size="0.6096" layer="25">&gt;NAME</text>
+<text x="-0.889" y="-1.27" size="0.6096" layer="27">&gt;VALUE</text>
+<wire x1="-0.75" y1="-0.45" x2="0.75" y2="-0.45" width="0.127" layer="21"/>
+<wire x1="0.75" y1="-0.45" x2="0.75" y2="0.45" width="0.127" layer="21"/>
+<wire x1="0.75" y1="0.45" x2="-0.75" y2="0.45" width="0.127" layer="21"/>
+<wire x1="-0.75" y1="0.45" x2="-0.75" y2="-0.45" width="0.127" layer="21"/>
+</package>
+</packages>
+<symbols>
+<symbol name="D_TRANSIL_BI">
+<wire x1="-3.048" y1="-1.651" x2="0" y2="0" width="0.1524" layer="94"/>
+<wire x1="0" y1="0" x2="-3.048" y2="1.651" width="0.1524" layer="94"/>
+<wire x1="-3.048" y1="1.651" x2="-3.048" y2="0" width="0.1524" layer="94"/>
+<wire x1="-3.048" y1="0" x2="-3.048" y2="-1.651" width="0.1524" layer="94"/>
+<wire x1="0" y1="1.651" x2="0" y2="0" width="0.1524" layer="94"/>
+<wire x1="0" y1="0" x2="0" y2="-1.651" width="0.1524" layer="94"/>
+<wire x1="-5.08" y1="0" x2="-3.048" y2="0" width="0.1524" layer="94"/>
+<wire x1="0" y1="-1.651" x2="-0.889" y2="-1.651" width="0.1524" layer="94"/>
+<wire x1="0.889" y1="1.651" x2="0" y2="1.651" width="0.1524" layer="94"/>
+<text x="-3.048" y="2.159" size="1.27" layer="95">&gt;NAME</text>
+<text x="-3.175" y="-3.429" size="1.27" layer="96">&gt;VALUE</text>
+<pin name="1" x="-5.08" y="0" visible="off" length="point" direction="pas"/>
+<pin name="2" x="5.08" y="0" visible="off" length="point" direction="pas" rot="R180"/>
+<wire x1="3.048" y1="-1.651" x2="0" y2="0" width="0.1524" layer="94"/>
+<wire x1="0" y1="0" x2="3.048" y2="1.651" width="0.1524" layer="94"/>
+<wire x1="3.048" y1="1.651" x2="3.048" y2="0" width="0.1524" layer="94"/>
+<wire x1="3.048" y1="0" x2="3.048" y2="-1.651" width="0.1524" layer="94"/>
+<wire x1="-5.08" y1="0" x2="-3.048" y2="0" width="0.1524" layer="94"/>
+<wire x1="3.048" y1="0" x2="5.08" y2="0" width="0.1524" layer="94"/>
+</symbol>
+</symbols>
+<devicesets>
+<deviceset name="D_TRANSIL_BI" prefix="D" uservalue="yes">
+<gates>
+<gate name="G$1" symbol="D_TRANSIL_BI" x="0" y="0"/>
+</gates>
+<devices>
+<device name="_SOD882D" package="SOD882D">
+<connects>
+<connect gate="G$1" pin="1" pad="1"/>
+<connect gate="G$1" pin="2" pad="2"/>
+</connects>
+<technologies>
+<technology name=""/>
+</technologies>
+</device>
+</devices>
+</deviceset>
+</devicesets>
+</library>
+</libraries>
+<attributes>
+</attributes>
+<variantdefs>
+</variantdefs>
+<classes>
+<class number="0" name="default" width="0" drill="0">
+</class>
+</classes>
+<parts>
+<part name="D1" library="vyber_stara_nemenit" deviceset="DS" device="_SOD323F" value="PMEG3005"/>
+<part name="D3" library="vyber_stara_nemenit" deviceset="PRTR5V0" device="_SOT143B$REFLOW" value="PRTR5V0U2X"/>
+<part name="U$1" library="vyber_stara_nemenit" deviceset="VCC" device=""/>
+<part name="U$2" library="vyber_stara_nemenit" deviceset="GND" device=""/>
+<part name="U$4" library="vyber_stara_nemenit" deviceset="GND" device=""/>
+<part name="K3" library="SDkarta" deviceset="KON_µSD_CARD" device="_ATTEND_112J_TXAR_R01_SMALL" value="ATTEND_112J-TDAR-R01"/>
+<part name="IC2" library="trezor" deviceset="STM32F427_LQFP100" device="" value="STM32F427VIT6"/>
+<part name="X1" library="trezor" deviceset="X_4V" device="_6,0X3,5" value="CTS406 8MHz"/>
+<part name="C2" library="vyber_stara_nemenit" deviceset="C" device="_0402" value="22p"/>
+<part name="C3" library="vyber_stara_nemenit" deviceset="C" device="_0402" value="22p"/>
+<part name="U$10" library="vyber_stara_nemenit" deviceset="GND" device=""/>
+<part name="C4" library="vyber_stara_nemenit" deviceset="C" device="_0603$REFLOW" value="1u"/>
+<part name="C5" library="vyber_stara_nemenit" deviceset="C" device="_0603" value="1u"/>
+<part name="U$11" library="vyber_stara_nemenit" deviceset="GND" device=""/>
+<part name="U$12" library="vyber_stara_nemenit" deviceset="VCC-2" device="" value="3V3"/>
+<part name="U$13" library="vyber_stara_nemenit" deviceset="VCC" device=""/>
+<part name="C6" library="vyber_stara_nemenit" deviceset="C" device="_0402" value="10n"/>
+<part name="C7" library="vyber_stara_nemenit" deviceset="C" device="_0402" value="100n"/>
+<part name="C8" library="vyber_stara_nemenit" deviceset="C" device="_0402" value="10n"/>
+<part name="C9" library="vyber_stara_nemenit" deviceset="C" device="_0402" value="100n"/>
+<part name="C10" library="vyber_stara_nemenit" deviceset="C" device="_0402" value="100n"/>
+<part name="C11" library="vyber_stara_nemenit" deviceset="C" device="_0402" value="1n"/>
+<part name="U$14" library="vyber_stara_nemenit" deviceset="GND" device=""/>
+<part name="U$15" library="vyber_stara_nemenit" deviceset="VCC-2" device="" value="3V3"/>
+<part name="U$16" library="vyber_stara_nemenit" deviceset="GND" device=""/>
+<part name="R8" library="vyber_stara_nemenit" deviceset="POLYSWITCH" device="_0603" value="MF-FSMF020X-2"/>
+<part name="U$5" library="vyber_stara_nemenit" deviceset="GND" device=""/>
+<part name="U$18" library="vyber_stara_nemenit" deviceset="GND" device=""/>
+<part name="U$19" library="vyber_stara_nemenit" deviceset="VCC-2" device="" value="3V3"/>
+<part name="C12" library="vyber_stara_nemenit" deviceset="C" device="_0805$REFLOW" value="2u2"/>
+<part name="C13" library="vyber_stara_nemenit" deviceset="C" device="_0805$REFLOW" value="2u2"/>
+<part name="U$20" library="vyber_stara_nemenit" deviceset="GND" device=""/>
+<part name="U$21" library="vyber_stara_nemenit" deviceset="GND" device=""/>
+<part name="IC5" library="vyber_stara_nemenit" deviceset="TP6104X" device="_WSON-8_3X3MM" value="TPS61043"/>
+<part name="L1" library="trezor" deviceset="L" device="_2.5X2.0" value="4u7 VLS252008ET-4R7M"/>
+<part name="D6" library="vyber_stara_nemenit" deviceset="DS" device="_SOD323F" value="PMEG4005"/>
+<part name="C14" library="vyber_stara_nemenit" deviceset="C" device="_0805$REFLOW" value="4u7/16V"/>
+<part name="C15" library="vyber_stara_nemenit" deviceset="C" device="_0805$REFLOW" value="4u7/16V"/>
+<part name="C16" library="vyber_stara_nemenit" deviceset="C" device="_0402" value="100n"/>
+<part name="R14" library="vyber_stara_nemenit" deviceset="R" device="_0402" value="27R"/>
+<part name="R25" library="vyber_stara_nemenit" deviceset="R" device="_0402" value="0R"/>
+<part name="R26" library="vyber_stara_nemenit" deviceset="R" device="_0402" value="N.C."/>
+<part name="U$22" library="vyber_stara_nemenit" deviceset="GND" device=""/>
+<part name="R9" library="vyber_stara_nemenit" deviceset="R" device="_0402" value="330R"/>
+<part name="U$23" library="vyber_stara_nemenit" deviceset="VCC" device=""/>
+<part name="IC6" library="trezor" deviceset="XC6210B" device="_SOT89-5" value="XC6210B332PR"/>
+<part name="R10" library="vyber_stara_nemenit" deviceset="R" device="_0402" value="68R"/>
+<part name="K5" library="trezor" deviceset="SWD" device=""/>
+<part name="C20" library="vyber_stara_nemenit" deviceset="C" device="_0402" value="100n"/>
+<part name="U$32" library="vyber_stara_nemenit" deviceset="GND" device=""/>
+<part name="U$33" library="vyber_stara_nemenit" deviceset="GND" device=""/>
+<part name="U$34" library="vyber_stara_nemenit" deviceset="VCC-2" device="" value="3V3"/>
+<part name="U$35" library="vyber_stara_nemenit" deviceset="GND" device=""/>
+<part name="U$36" library="vyber_stara_nemenit" deviceset="VCC-2" device="" value="3V3"/>
+<part name="U$37" library="vyber_stara_nemenit" deviceset="GND" device=""/>
+<part name="L2" library="vyber_stara_nemenit" deviceset="L" device="_0603$REFLOW" value="BLM18AG102SN1D"/>
+<part name="C21" library="vyber_stara_nemenit" deviceset="C" device="_0402" value="100n"/>
+<part name="U$38" library="vyber_stara_nemenit" deviceset="GND" device=""/>
+<part name="U$39" library="vyber_stara_nemenit" deviceset="VCC-2" device="" value="3V3"/>
+<part name="U$41" library="vyber_stara_nemenit" deviceset="RAM_A3" device=""/>
+<part name="C22" library="vyber_stara_nemenit" deviceset="C" device="_0603$REFLOW" value="1u"/>
+<part name="U$42" library="vyber_stara_nemenit" deviceset="GND" device=""/>
+<part name="TP3" library="vyber_stara_nemenit" deviceset="MB" device="_1.50"/>
+<part name="TP7" library="vyber_stara_nemenit" deviceset="MB" device="_1.27"/>
+<part name="TP9" library="vyber_stara_nemenit" deviceset="MB" device="_1.27"/>
+<part name="R1" library="vyber_stara_nemenit" deviceset="R" device="_0402" value="22R"/>
+<part name="R11" library="vyber_stara_nemenit" deviceset="R" device="_0402" value="N.C."/>
+<part name="U$27" library="vyber_stara_nemenit" deviceset="VCC" device=""/>
+<part name="U$28" library="vyber_stara_nemenit" deviceset="GND" device=""/>
+<part name="K4" library="trezor" deviceset="DISPLEJ_154A2411CTP01" device="" value="DF37NB-24DS-0.4V"/>
+<part name="U$24" library="vyber_stara_nemenit" deviceset="GND" device=""/>
+<part name="U$25" library="vyber_stara_nemenit" deviceset="VCC-2" device="" value="3V3"/>
+<part name="C18" library="vyber_stara_nemenit" deviceset="C" device="_0402" value="100n"/>
+<part name="U$29" library="vyber_stara_nemenit" deviceset="GND" device=""/>
+<part name="K6" library="trezor" deviceset="DISPLEJ_154A2411CTP01_TOUCH" device="" value="DF37NB-10DS-0.4V"/>
+<part name="U$30" library="vyber_stara_nemenit" deviceset="VCC-2" device="" value="3V3"/>
+<part name="C19" library="vyber_stara_nemenit" deviceset="C" device="_0603$REFLOW" value="1u"/>
+<part name="C24" library="vyber_stara_nemenit" deviceset="C" device="_0402" value="100n"/>
+<part name="U$31" library="vyber_stara_nemenit" deviceset="GND" device=""/>
+<part name="U$40" library="vyber_stara_nemenit" deviceset="GND" device=""/>
+<part name="U$50" library="vyber_stara_nemenit" deviceset="GND" device=""/>
+<part name="R13" library="vyber_stara_nemenit" deviceset="R" device="_0402" value="100R"/>
+<part name="R12" library="vyber_stara_nemenit" deviceset="R" device="_0402" value="10k"/>
+<part name="L3" library="vyber_stara_nemenit" deviceset="L" device="_0603$REFLOW" value="BLM18AG102SN1D"/>
+<part name="R15" library="vyber_stara_nemenit" deviceset="R" device="_0402" value="1k5"/>
+<part name="R16" library="vyber_stara_nemenit" deviceset="R" device="_0402" value="1k5"/>
+<part name="L4" library="vyber_stara_nemenit" deviceset="L" device="_0603$REFLOW" value="BLM18AG102SN1D"/>
+<part name="TP4" library="vyber_stara_nemenit" deviceset="MB" device="_1.27"/>
+<part name="TP5" library="vyber_stara_nemenit" deviceset="MB" device="_1.50"/>
+<part name="K1" library="trezor" deviceset="USB-C" device="_JAE_DX07B024XJ1" value="DX07B024XJ1R1300"/>
+<part name="U$3" library="vyber_stara_nemenit" deviceset="GND" device=""/>
+<part name="U$6" library="vyber_stara_nemenit" deviceset="GND" device=""/>
+<part name="R4" library="vyber_stara_nemenit" deviceset="R" device="_0402" value="5k1"/>
+<part name="R5" library="vyber_stara_nemenit" deviceset="R" device="_0402" value="5k1"/>
+<part name="U$7" library="vyber_stara_nemenit" deviceset="GND" device=""/>
+<part name="U$8" library="vyber_stara_nemenit" deviceset="GND" device=""/>
+<part name="R6" library="vyber_stara_nemenit" deviceset="R" device="_0402" value="1M"/>
+<part name="C1" library="vyber_stara_nemenit" deviceset="C" device="_0402" value="1n"/>
+<part name="U$9" library="vyber_stara_nemenit" deviceset="GND" device=""/>
+<part name="R7" library="vyber_stara_nemenit" deviceset="R" device="_0402" value="1M"/>
+<part name="C25" library="vyber_stara_nemenit" deviceset="C" device="_0402" value="1n"/>
+<part name="U$17" library="vyber_stara_nemenit" deviceset="GND" device=""/>
+<part name="TP6" library="vyber_stara_nemenit" deviceset="MB" device="_1.27"/>
+<part name="D2" library="DZ" deviceset="D_TRANSIL_BI" device="_SOD882D" value="PESD5V0F1BLD"/>
+<part name="D4" library="DZ" deviceset="D_TRANSIL_BI" device="_SOD882D" value="PESD5V0F1BLD"/>
+<part name="U$44" library="vyber_stara_nemenit" deviceset="GND" device=""/>
+<part name="U$55" library="vyber_stara_nemenit" deviceset="GND" device=""/>
+<part name="TP10" library="vyber_stara_nemenit" deviceset="MB" device="_1.50"/>
+<part name="TP11" library="vyber_stara_nemenit" deviceset="MB" device="_1.50"/>
+<part name="C26" library="vyber_stara_nemenit" deviceset="C" device="_0402" value="100n"/>
+<part name="U$58" library="vyber_stara_nemenit" deviceset="GND" device=""/>
+<part name="TP12" library="vyber_stara_nemenit" deviceset="MB" device="_1.27"/>
+<part name="TP13" library="vyber_stara_nemenit" deviceset="MB" device="_1.27"/>
+<part name="U$59" library="vyber_stara_nemenit" deviceset="GND" device=""/>
+<part name="U$60" library="vyber_stara_nemenit" deviceset="GND" device=""/>
+<part name="C28" library="vyber_stara_nemenit" deviceset="C" device="_0402" value="100n"/>
+<part name="C29" library="vyber_stara_nemenit" deviceset="C" device="_0402" value="100n"/>
+<part name="C30" library="vyber_stara_nemenit" deviceset="C" device="_0402" value="10n"/>
+<part name="C31" library="vyber_stara_nemenit" deviceset="C" device="_0402" value="100n"/>
+<part name="C32" library="vyber_stara_nemenit" deviceset="C" device="_0402" value="10n"/>
+<part name="C33" library="vyber_stara_nemenit" deviceset="C" device="_0402" value="1n"/>
+<part name="C34" library="vyber_stara_nemenit" deviceset="C" device="_0805$REFLOW" value="2u2"/>
+<part name="U$62" library="vyber_stara_nemenit" deviceset="GND" device=""/>
+<part name="R18" library="vyber_stara_nemenit" deviceset="R" device="_0402" value="68R"/>
+<part name="C36" library="vyber_stara_nemenit" deviceset="C" device="_0402" value="47p"/>
+<part name="U$64" library="vyber_stara_nemenit" deviceset="GND" device=""/>
+<part name="R19" library="vyber_stara_nemenit" deviceset="R" device="_0402" value="68R"/>
+<part name="C37" library="vyber_stara_nemenit" deviceset="C" device="_0402" value="47p"/>
+<part name="U$65" library="vyber_stara_nemenit" deviceset="GND" device=""/>
+<part name="R20" library="vyber_stara_nemenit" deviceset="R" device="_0402" value="68R"/>
+<part name="C38" library="vyber_stara_nemenit" deviceset="C" device="_0402" value="47p"/>
+<part name="U$66" library="vyber_stara_nemenit" deviceset="GND" device=""/>
+<part name="R21" library="vyber_stara_nemenit" deviceset="R" device="_0402" value="68R"/>
+<part name="C39" library="vyber_stara_nemenit" deviceset="C" device="_0402" value="47p"/>
+<part name="U$67" library="vyber_stara_nemenit" deviceset="GND" device=""/>
+<part name="R22" library="vyber_stara_nemenit" deviceset="R" device="_0402" value="68R"/>
+<part name="C40" library="vyber_stara_nemenit" deviceset="C" device="_0402" value="47p"/>
+<part name="U$68" library="vyber_stara_nemenit" deviceset="GND" device=""/>
+<part name="C41" library="vyber_stara_nemenit" deviceset="C" device="_0402" value="100n"/>
+<part name="C42" library="vyber_stara_nemenit" deviceset="C" device="_0402" value="10n"/>
+<part name="U$69" library="vyber_stara_nemenit" deviceset="VCC-2" device="" value="3V3"/>
+<part name="U$70" library="vyber_stara_nemenit" deviceset="VCC-2" device="" value="3V3"/>
+<part name="U$71" library="vyber_stara_nemenit" deviceset="GND" device=""/>
+<part name="C27" library="vyber_stara_nemenit" deviceset="C" device="_0402" value="100n"/>
+<part name="U$61" library="vyber_stara_nemenit" deviceset="GND" device=""/>
+<part name="R23" library="vyber_stara_nemenit" deviceset="R" device="_0402" value="68R"/>
+<part name="C43" library="vyber_stara_nemenit" deviceset="C" device="_0402" value="47p"/>
+<part name="U$72" library="vyber_stara_nemenit" deviceset="GND" device=""/>
+<part name="C44" library="vyber_stara_nemenit" deviceset="C" device="_0402" value="100n"/>
+<part name="C45" library="vyber_stara_nemenit" deviceset="C" device="_0805$REFLOW" value="2u2"/>
+<part name="U$73" library="vyber_stara_nemenit" deviceset="GND" device=""/>
+<part name="C46" library="vyber_stara_nemenit" deviceset="C" device="_0402" value="1n"/>
+<part name="U$74" library="vyber_stara_nemenit" deviceset="GND" device=""/>
+<part name="U$75" library="vyber_stara_nemenit" deviceset="GND" device=""/>
+<part name="C47" library="vyber_stara_nemenit" deviceset="C" device="_0402" value="10n"/>
+<part name="U$76" library="vyber_stara_nemenit" deviceset="GND" device=""/>
+<part name="C49" library="vyber_stara_nemenit" deviceset="C" device="_0402" value="10n"/>
+<part name="U$78" library="vyber_stara_nemenit" deviceset="GND" device=""/>
+<part name="TP1" library="vyber_stara_nemenit" deviceset="MB" device="_1.27"/>
+<part name="TP2" library="vyber_stara_nemenit" deviceset="MB" device="_1.27"/>
+<part name="TP8" library="vyber_stara_nemenit" deviceset="MB" device="_1.27"/>
+<part name="TP14" library="vyber_stara_nemenit" deviceset="MB" device="_1.27"/>
+<part name="TP19" library="trezor" deviceset="MB" device="_1.00"/>
+<part name="TP20" library="trezor" deviceset="MB" device="_1.00"/>
+<part name="C17" library="vyber_stara_nemenit" deviceset="C" device="_0805$REFLOW" value="2u2"/>
+<part name="C35" library="vyber_stara_nemenit" deviceset="C" device="_0805$REFLOW" value="2u2"/>
+<part name="C51" library="vyber_stara_nemenit" deviceset="C" device="_0805$REFLOW" value="2u2"/>
+<part name="U$26" library="vyber_stara_nemenit" deviceset="GND" device=""/>
+<part name="U$63" library="vyber_stara_nemenit" deviceset="GND" device=""/>
+<part name="U$80" library="vyber_stara_nemenit" deviceset="GND" device=""/>
+<part name="C52" library="vyber_stara_nemenit" deviceset="C" device="_0603$REFLOW" value="1u"/>
+<part name="C23" library="vyber_stara_nemenit" deviceset="C" device="_0402" value="10n"/>
+<part name="U$43" library="vyber_stara_nemenit" deviceset="GND" device=""/>
+<part name="C53" library="vyber_stara_nemenit" deviceset="C" device="_0603$REFLOW" value="1u"/>
+<part name="U$81" library="vyber_stara_nemenit" deviceset="GND" device=""/>
+<part name="C54" library="vyber_stara_nemenit" deviceset="C" device="_0603$REFLOW" value="1u"/>
+<part name="U$82" library="vyber_stara_nemenit" deviceset="VCC-2" device="" value="3V3"/>
+<part name="U$83" library="vyber_stara_nemenit" deviceset="GND" device=""/>
+<part name="C55" library="vyber_stara_nemenit" deviceset="C" device="_0402" value="100n"/>
+<part name="U$84" library="vyber_stara_nemenit" deviceset="GND" device=""/>
+<part name="C56" library="vyber_stara_nemenit" deviceset="C" device="_0603$REFLOW" value="1u"/>
+<part name="T1" library="trezor" deviceset="PMOS" device="_SOT-23_REF" value="DMG3415U-7"/>
+<part name="R2" library="vyber_stara_nemenit" deviceset="R" device="_0402" value="470k"/>
+<part name="C57" library="vyber_stara_nemenit" deviceset="C" device="_0402" value="220p"/>
+<part name="R3" library="vyber_stara_nemenit" deviceset="R" device="_0402" value="22k"/>
+<part name="U$85" library="vyber_stara_nemenit" deviceset="GND" device=""/>
+<part name="U$86" library="vyber_stara_nemenit" deviceset="VCC-2" device="" value="3V3"/>
+<part name="T2" library="trezor" deviceset="PMOS" device="_SOT-23_REF" value="DMG3415U-7"/>
+<part name="R17" library="vyber_stara_nemenit" deviceset="R" device="_0402" value="470k"/>
+<part name="U$51" library="vyber_stara_nemenit" deviceset="VBAT" device="" value="VDD"/>
+<part name="U$52" library="vyber_stara_nemenit" deviceset="VBAT" device="" value="VDD"/>
+<part name="IC1" library="trezor" deviceset="MIC803" device="" value="MIC803-29D2VC3"/>
+<part name="U$77" library="vyber_stara_nemenit" deviceset="GND" device=""/>
+<part name="TP15" library="vyber_stara_nemenit" deviceset="MB" device="_1.27"/>
+<part name="TP16" library="vyber_stara_nemenit" deviceset="MB" device="_1.27"/>
+<part name="C48" library="vyber_stara_nemenit" deviceset="C" device="_0402" value="100n"/>
+<part name="R24" library="vyber_stara_nemenit" deviceset="R" device="_0402" value="22k"/>
+<part name="C50" library="vyber_stara_nemenit" deviceset="C" device="_0402" value="220p"/>
+<part name="U$79" library="vyber_stara_nemenit" deviceset="GND" device=""/>
+<part name="C58" library="vyber_stara_nemenit" deviceset="C" device="_0402" value="1n"/>
+</parts>
+<sheets>
+<sheet>
+<plain>
+<text x="29.21" y="109.22" size="1.778" layer="98">Alternative DLJ3015-4.7 2.9x2.9 mm</text>
+</plain>
+<instances>
+<instance part="D1" gate="G$1" x="114.3" y="213.36"/>
+<instance part="D3" gate="G$1" x="123.19" y="189.23"/>
+<instance part="U$1" gate="G$1" x="139.7" y="218.44"/>
+<instance part="U$2" gate="G$1" x="132.08" y="170.18"/>
+<instance part="U$4" gate="G$1" x="118.11" y="180.34"/>
+<instance part="K3" gate="G$1" x="358.14" y="196.85" smashed="yes">
+<attribute name="NAME" x="358.14" y="205.74" size="1.778" layer="95"/>
+<attribute name="VALUE" x="342.9" y="210.82" size="1.778" layer="96"/>
+</instance>
+<instance part="IC2" gate="IC" x="232.41" y="143.51"/>
+<instance part="X1" gate="G$1" x="186.69" y="129.54" smashed="yes" rot="R270">
+<attribute name="NAME" x="189.865" y="132.08" size="1.27" layer="95" rot="R270"/>
+<attribute name="VALUE" x="192.405" y="135.255" size="1.27" layer="96" rot="R270"/>
+</instance>
+<instance part="C2" gate="G$1" x="180.34" y="135.89"/>
+<instance part="C3" gate="G$1" x="180.34" y="123.19"/>
+<instance part="U$10" gate="G$1" x="170.18" y="123.19"/>
+<instance part="C4" gate="G$1" x="34.29" y="140.97" rot="R90"/>
+<instance part="C5" gate="G$1" x="57.15" y="140.97" rot="R90"/>
+<instance part="U$11" gate="G$1" x="45.72" y="130.81"/>
+<instance part="U$12" gate="G$1" x="57.15" y="151.13"/>
+<instance part="U$13" gate="G$1" x="34.29" y="153.67"/>
+<instance part="C6" gate="G$1" x="163.83" y="66.04" rot="R90"/>
+<instance part="C7" gate="G$1" x="116.84" y="60.96" rot="R90"/>
+<instance part="C8" gate="G$1" x="185.42" y="50.8" rot="R90"/>
+<instance part="C9" gate="G$1" x="106.68" y="35.56" rot="R90"/>
+<instance part="C10" gate="G$1" x="115.57" y="35.56" rot="R90"/>
+<instance part="C11" gate="G$1" x="133.35" y="105.41" rot="R90"/>
+<instance part="U$14" gate="G$1" x="106.68" y="25.4"/>
+<instance part="U$15" gate="G$1" x="106.68" y="43.18"/>
+<instance part="U$16" gate="G$1" x="270.51" y="64.77"/>
+<instance part="R8" gate="G$1" x="132.08" y="213.36"/>
+<instance part="U$5" gate="G$1" x="360.68" y="173.99"/>
+<instance part="U$18" gate="G$1" x="336.55" y="173.99"/>
+<instance part="U$19" gate="G$1" x="335.28" y="261.62"/>
+<instance part="C12" gate="G$1" x="279.4" y="73.66" rot="R90"/>
+<instance part="C13" gate="G$1" x="288.29" y="73.66" rot="R90"/>
+<instance part="U$20" gate="G$1" x="279.4" y="64.77"/>
+<instance part="U$21" gate="G$1" x="288.29" y="64.77"/>
+<instance part="IC5" gate="G$1" x="50.8" y="81.28" smashed="yes">
+<attribute name="NAME" x="43.815" y="95.25" size="1.27" layer="95"/>
+<attribute name="VALUE" x="50.165" y="95.25" size="1.27" layer="96"/>
+</instance>
+<instance part="L1" gate="G$1" x="49.53" y="102.87"/>
+<instance part="D6" gate="G$1" x="69.85" y="102.87"/>
+<instance part="C14" gate="G$1" x="21.59" y="85.09" rot="R270"/>
+<instance part="C15" gate="G$1" x="81.28" y="85.09" rot="R90"/>
+<instance part="C16" gate="G$1" x="12.7" y="85.09" rot="R90"/>
+<instance part="R14" gate="G$1" x="57.15" y="63.5"/>
+<instance part="R25" gate="G$1" x="76.2" y="93.98" rot="R270"/>
+<instance part="R26" gate="G$1" x="76.2" y="78.74" rot="R270"/>
+<instance part="U$22" gate="G$1" x="50.8" y="55.88"/>
+<instance part="R9" gate="G$1" x="31.75" y="78.74" rot="R90"/>
+<instance part="U$23" gate="G$1" x="21.59" y="106.68"/>
+<instance part="IC6" gate="G$1" x="45.72" y="148.59"/>
+<instance part="R10" gate="G$1" x="26.67" y="78.74" rot="R90"/>
+<instance part="K5" gate="K" x="152.4" y="181.61" smashed="yes">
+<attribute name="VALUE" x="158.496" y="192.024" size="1.778" layer="96" rot="R180"/>
+<attribute name="NAME" x="157.48" y="173.228" size="1.778" layer="95" rot="R180"/>
+</instance>
+<instance part="C20" gate="G$1" x="181.61" y="111.76" rot="R90"/>
+<instance part="U$32" gate="G$1" x="181.61" y="102.87"/>
+<instance part="U$33" gate="G$1" x="187.96" y="102.87"/>
+<instance part="U$34" gate="G$1" x="162.56" y="190.5"/>
+<instance part="U$35" gate="G$1" x="162.56" y="171.45"/>
+<instance part="U$36" gate="G$1" x="194.31" y="93.98"/>
+<instance part="U$37" gate="G$1" x="194.31" y="83.82"/>
+<instance part="L2" gate="G$1" x="172.72" y="99.06" smashed="yes">
+<attribute name="VALUE" x="165.1" y="97.155" size="1.27" layer="96"/>
+<attribute name="NAME" x="171.45" y="101.6" size="1.27" layer="95"/>
+</instance>
+<instance part="C21" gate="G$1" x="185.42" y="92.71" rot="R90"/>
+<instance part="U$38" gate="G$1" x="185.42" y="83.82"/>
+<instance part="U$39" gate="G$1" x="163.83" y="101.6"/>
+<instance part="U$41" gate="G$1" x="1.27" y="13.97"/>
+<instance part="U$41" gate="G$2" x="252.73" y="19.05"/>
+<instance part="C22" gate="G$1" x="358.14" y="223.52" rot="R90"/>
+<instance part="U$42" gate="G$1" x="358.14" y="214.63"/>
+<instance part="TP3" gate="G$1" x="60.96" y="148.59" rot="R180"/>
+<instance part="TP7" gate="G$1" x="76.2" y="106.68" rot="R270"/>
+<instance part="TP9" gate="G$1" x="132.08" y="177.8" rot="R270"/>
+<instance part="R1" gate="G$1" x="168.91" y="242.57" rot="R180"/>
+<instance part="R11" gate="G$1" x="175.26" y="236.22" rot="R270"/>
+<instance part="U$27" gate="G$1" x="160.02" y="242.57" rot="R90"/>
+<instance part="U$28" gate="G$1" x="175.26" y="227.33"/>
+<instance part="K4" gate="G$1" x="345.44" y="125.73"/>
+<instance part="U$24" gate="G$1" x="330.2" y="88.9"/>
+<instance part="U$25" gate="G$1" x="355.6" y="78.74" rot="R270"/>
+<instance part="C18" gate="G$1" x="336.55" y="72.39" rot="R90"/>
+<instance part="U$29" gate="G$1" x="336.55" y="63.5"/>
+<instance part="K6" gate="G$1" x="134.62" y="140.97" rot="MR0"/>
+<instance part="U$30" gate="G$1" x="68.58" y="160.02" rot="R90"/>
+<instance part="C19" gate="G$1" x="100.33" y="153.67" rot="R90"/>
+<instance part="C24" gate="G$1" x="109.22" y="153.67" rot="R90"/>
+<instance part="U$31" gate="G$1" x="100.33" y="144.78"/>
+<instance part="U$40" gate="G$1" x="109.22" y="144.78"/>
+<instance part="U$50" gate="G$1" x="142.24" y="125.73"/>
+<instance part="R13" gate="G$1" x="157.48" y="146.05"/>
+<instance part="R12" gate="G$1" x="157.48" y="133.35" rot="R90"/>
+<instance part="L3" gate="G$1" x="93.98" y="160.02" smashed="yes">
+<attribute name="VALUE" x="87.63" y="164.465" size="1.27" layer="96"/>
+<attribute name="NAME" x="92.71" y="162.56" size="1.27" layer="95"/>
+</instance>
+<instance part="R15" gate="G$1" x="148.59" y="160.02" rot="R90"/>
+<instance part="R16" gate="G$1" x="153.67" y="160.02" rot="R90"/>
+<instance part="L4" gate="G$1" x="346.71" y="78.74" smashed="yes">
+<attribute name="VALUE" x="339.09" y="76.835" size="1.27" layer="96"/>
+<attribute name="NAME" x="345.44" y="81.28" size="1.27" layer="95"/>
+</instance>
+<instance part="TP4" gate="G$1" x="62.23" y="83.82" rot="R270"/>
+<instance part="TP5" gate="G$1" x="143.51" y="213.36" rot="R180"/>
+<instance part="K1" gate="K" x="53.34" y="219.71"/>
+<instance part="U$3" gate="G$1" x="85.09" y="177.8"/>
+<instance part="U$6" gate="G$1" x="19.05" y="177.8"/>
+<instance part="R4" gate="G$1" x="12.7" y="142.24" rot="R90"/>
+<instance part="R5" gate="G$1" x="20.32" y="142.24" rot="R90"/>
+<instance part="U$7" gate="G$1" x="12.7" y="130.81"/>
+<instance part="U$8" gate="G$1" x="20.32" y="130.81"/>
+<instance part="R6" gate="G$1" x="31.75" y="177.8" rot="R90"/>
+<instance part="C1" gate="G$1" x="41.91" y="177.8" rot="R90"/>
+<instance part="U$9" gate="G$1" x="31.75" y="167.64"/>
+<instance part="R7" gate="G$1" x="63.5" y="177.8" rot="R90"/>
+<instance part="C25" gate="G$1" x="73.66" y="177.8" rot="R90"/>
+<instance part="U$17" gate="G$1" x="73.66" y="167.64"/>
+<instance part="TP6" gate="G$1" x="31.75" y="90.17" rot="R270"/>
+<instance part="D2" gate="G$1" x="144.78" y="231.14" rot="R90"/>
+<instance part="D4" gate="G$1" x="152.4" y="231.14" rot="R90"/>
+<instance part="U$44" gate="G$1" x="144.78" y="222.25"/>
+<instance part="U$55" gate="G$1" x="152.4" y="222.25"/>
+<instance part="TP10" gate="G$1" x="123.19" y="243.84" rot="R270"/>
+<instance part="TP11" gate="G$1" x="130.81" y="243.84" rot="R270"/>
+<instance part="C26" gate="G$1" x="327.66" y="72.39" rot="R90"/>
+<instance part="U$58" gate="G$1" x="327.66" y="63.5"/>
+<instance part="TP12" gate="G$1" x="125.73" y="177.8" rot="R270"/>
+<instance part="TP13" gate="G$1" x="138.43" y="177.8" rot="R270"/>
+<instance part="U$59" gate="G$1" x="125.73" y="170.18"/>
+<instance part="U$60" gate="G$1" x="138.43" y="170.18"/>
+<instance part="C28" gate="G$1" x="176.53" y="50.8" rot="R90"/>
+<instance part="C29" gate="G$1" x="154.94" y="66.04" rot="R90"/>
+<instance part="C30" gate="G$1" x="106.68" y="60.96" rot="R90"/>
+<instance part="C31" gate="G$1" x="97.79" y="35.56" rot="R90"/>
+<instance part="C32" gate="G$1" x="124.46" y="105.41" rot="R90"/>
+<instance part="C33" gate="G$1" x="97.79" y="60.96" rot="R90"/>
+<instance part="C34" gate="G$1" x="125.73" y="60.96" rot="R90"/>
+<instance part="U$62" gate="G$1" x="106.68" y="49.53"/>
+<instance part="R18" gate="G$1" x="290.83" y="214.63" rot="R90"/>
+<instance part="C36" gate="G$1" x="290.83" y="231.14" rot="R90"/>
+<instance part="U$64" gate="G$1" x="290.83" y="240.03" rot="R180"/>
+<instance part="R19" gate="G$1" x="299.72" y="214.63" rot="R90"/>
+<instance part="C37" gate="G$1" x="299.72" y="226.06" rot="R90"/>
+<instance part="U$65" gate="G$1" x="299.72" y="240.03" rot="R180"/>
+<instance part="R20" gate="G$1" x="306.07" y="214.63" rot="R90"/>
+<instance part="C38" gate="G$1" x="306.07" y="231.14" rot="R90"/>
+<instance part="U$66" gate="G$1" x="306.07" y="240.03" rot="R180"/>
+<instance part="R21" gate="G$1" x="312.42" y="214.63" rot="R90"/>
+<instance part="C39" gate="G$1" x="312.42" y="226.06" rot="R90"/>
+<instance part="U$67" gate="G$1" x="312.42" y="240.03" rot="R180"/>
+<instance part="R22" gate="G$1" x="318.77" y="214.63" rot="R90"/>
+<instance part="C40" gate="G$1" x="318.77" y="231.14" rot="R90"/>
+<instance part="U$68" gate="G$1" x="318.77" y="240.03" rot="R180"/>
+<instance part="C41" gate="G$1" x="106.68" y="85.09" rot="R90"/>
+<instance part="C42" gate="G$1" x="97.79" y="85.09" rot="R90"/>
+<instance part="U$69" gate="G$1" x="106.68" y="71.12"/>
+<instance part="U$70" gate="G$1" x="97.79" y="92.71"/>
+<instance part="U$71" gate="G$1" x="97.79" y="74.93"/>
+<instance part="C27" gate="G$1" x="350.52" y="223.52" rot="R90"/>
+<instance part="U$61" gate="G$1" x="350.52" y="214.63"/>
+<instance part="R23" gate="G$1" x="325.12" y="214.63" rot="R90"/>
+<instance part="C43" gate="G$1" x="325.12" y="226.06" rot="R90"/>
+<instance part="U$72" gate="G$1" x="325.12" y="240.03" rot="R180"/>
+<instance part="C44" gate="G$1" x="115.57" y="105.41" rot="R90"/>
+<instance part="C45" gate="G$1" x="106.68" y="105.41" rot="R90"/>
+<instance part="U$73" gate="G$1" x="115.57" y="95.25"/>
+<instance part="C46" gate="G$1" x="194.31" y="50.8" rot="R90"/>
+<instance part="U$74" gate="G$1" x="185.42" y="40.64"/>
+<instance part="U$75" gate="G$1" x="154.94" y="55.88"/>
+<instance part="C47" gate="G$1" x="318.77" y="72.39" rot="R90"/>
+<instance part="U$76" gate="G$1" x="318.77" y="63.5"/>
+<instance part="C49" gate="G$1" x="118.11" y="153.67" rot="R90"/>
+<instance part="U$78" gate="G$1" x="118.11" y="144.78"/>
+<instance part="TP1" gate="G$1" x="172.72" y="191.77" rot="R270"/>
+<instance part="TP2" gate="G$1" x="179.07" y="191.77" rot="R270"/>
+<instance part="TP8" gate="G$1" x="191.77" y="191.77" rot="R270"/>
+<instance part="TP14" gate="G$1" x="167.64" y="191.77" rot="R270"/>
+<instance part="TP19" gate="G$1" x="120.65" y="218.44" smashed="yes" rot="R270">
+<attribute name="NAME" x="121.92" y="220.98" size="1.27" layer="95" rot="R270"/>
+</instance>
+<instance part="TP20" gate="G$1" x="25.4" y="149.86" smashed="yes" rot="R180">
+<attribute name="NAME" x="26.67" y="148.59" size="1.27" layer="95" rot="R180"/>
+</instance>
+<instance part="C17" gate="G$1" x="360.68" y="254" rot="R90"/>
+<instance part="C35" gate="G$1" x="370.84" y="254" rot="R90"/>
+<instance part="C51" gate="G$1" x="379.73" y="254" rot="R90"/>
+<instance part="U$26" gate="G$1" x="360.68" y="245.11"/>
+<instance part="U$63" gate="G$1" x="370.84" y="245.11"/>
+<instance part="U$80" gate="G$1" x="379.73" y="245.11"/>
+<instance part="C52" gate="G$1" x="172.72" y="66.04" rot="R90"/>
+<instance part="C23" gate="G$1" x="341.63" y="223.52" rot="R90"/>
+<instance part="U$43" gate="G$1" x="341.63" y="214.63"/>
+<instance part="C53" gate="G$1" x="351.79" y="254" rot="R90"/>
+<instance part="U$81" gate="G$1" x="351.79" y="245.11"/>
+<instance part="C54" gate="G$1" x="203.2" y="50.8" rot="R270"/>
+<instance part="U$82" gate="G$1" x="189.23" y="165.1" rot="R270"/>
+<instance part="U$83" gate="G$1" x="175.26" y="173.99" rot="R180"/>
+<instance part="C55" gate="G$1" x="185.42" y="171.45" rot="R90"/>
+<instance part="U$84" gate="G$1" x="185.42" y="180.34" rot="R180"/>
+<instance part="C56" gate="G$1" x="124.46" y="35.56" rot="R270"/>
+<instance part="T1" gate="G$1" x="337.82" y="240.03" rot="MR0"/>
+<instance part="R2" gate="G$1" x="365.76" y="236.22" rot="R90"/>
+<instance part="C57" gate="G$1" x="365.76" y="223.52" rot="R90"/>
+<instance part="R3" gate="G$1" x="373.38" y="229.87" rot="R180"/>
+<instance part="U$85" gate="G$1" x="365.76" y="214.63"/>
+<instance part="U$86" gate="G$1" x="365.76" y="242.57"/>
+<instance part="T2" gate="G$1" x="78.74" y="157.48" rot="R90"/>
+<instance part="R17" gate="G$1" x="72.39" y="152.4" rot="R270"/>
+<instance part="U$51" gate="G$1" x="109.22" y="162.56"/>
+<instance part="U$52" gate="G$1" x="157.48" y="127" rot="R180"/>
+<instance part="IC1" gate="G$1" x="175.26" y="165.1" rot="R180"/>
+<instance part="U$77" gate="G$1" x="31.75" y="68.58"/>
+<instance part="TP15" gate="G$1" x="350.52" y="233.68" rot="R270"/>
+<instance part="TP16" gate="G$1" x="118.11" y="163.83" rot="R270"/>
+<instance part="C48" gate="G$1" x="345.44" y="236.22" rot="R90"/>
+<instance part="R24" gate="G$1" x="86.36" y="143.51"/>
+<instance part="C50" gate="G$1" x="76.2" y="137.16" rot="R90"/>
+<instance part="U$79" gate="G$1" x="76.2" y="128.27"/>
+<instance part="C58" gate="G$1" x="85.09" y="152.4" rot="R90"/>
+</instances>
+<busses>
+</busses>
+<nets>
+<net name="VCC" class="0">
+<segment>
+<pinref part="U$1" gate="G$1" pin="VCC"/>
+<wire x1="139.7" y1="215.9" x2="139.7" y2="213.36" width="0.1524" layer="91"/>
+<pinref part="R8" gate="G$1" pin="1"/>
+<wire x1="137.16" y1="213.36" x2="139.7" y2="213.36" width="0.1524" layer="91"/>
+<pinref part="TP5" gate="G$1" pin="1"/>
+<wire x1="140.97" y1="213.36" x2="139.7" y2="213.36" width="0.1524" layer="91"/>
+<junction x="139.7" y="213.36"/>
+</segment>
+<segment>
+<pinref part="C4" gate="G$1" pin="2"/>
+<pinref part="U$13" gate="G$1" pin="VCC"/>
+<wire x1="34.29" y1="151.13" x2="34.29" y2="148.59" width="0.1524" layer="91"/>
+<pinref part="IC6" gate="G$1" pin="IN"/>
+<wire x1="34.29" y1="148.59" x2="34.29" y2="146.05" width="0.1524" layer="91"/>
+<wire x1="38.1" y1="148.59" x2="36.83" y2="148.59" width="0.1524" layer="91"/>
+<pinref part="IC6" gate="G$1" pin="CE"/>
+<wire x1="36.83" y1="148.59" x2="34.29" y2="148.59" width="0.1524" layer="91"/>
+<wire x1="38.1" y1="146.05" x2="36.83" y2="146.05" width="0.1524" layer="91"/>
+<wire x1="36.83" y1="146.05" x2="36.83" y2="148.59" width="0.1524" layer="91"/>
+<junction x="36.83" y="148.59"/>
+<junction x="34.29" y="148.59"/>
+</segment>
+<segment>
+<pinref part="L1" gate="G$1" pin="1"/>
+<pinref part="C16" gate="G$1" pin="2"/>
+<wire x1="44.45" y1="102.87" x2="38.1" y2="102.87" width="0.1524" layer="91"/>
+<wire x1="38.1" y1="102.87" x2="21.59" y2="102.87" width="0.1524" layer="91"/>
+<wire x1="21.59" y1="102.87" x2="12.7" y2="102.87" width="0.1524" layer="91"/>
+<wire x1="12.7" y1="102.87" x2="12.7" y2="90.17" width="0.1524" layer="91"/>
+<pinref part="C14" gate="G$1" pin="1"/>
+<wire x1="21.59" y1="90.17" x2="21.59" y2="102.87" width="0.1524" layer="91"/>
+<pinref part="IC5" gate="G$1" pin="VIN"/>
+<wire x1="40.64" y1="91.44" x2="38.1" y2="91.44" width="0.1524" layer="91"/>
+<wire x1="38.1" y1="91.44" x2="38.1" y2="102.87" width="0.1524" layer="91"/>
+<junction x="38.1" y="102.87"/>
+<junction x="21.59" y="102.87"/>
+<pinref part="U$23" gate="G$1" pin="VCC"/>
+<wire x1="21.59" y1="104.14" x2="21.59" y2="102.87" width="0.1524" layer="91"/>
+</segment>
+<segment>
+<pinref part="U$27" gate="G$1" pin="VCC"/>
+<pinref part="R1" gate="G$1" pin="2"/>
+<wire x1="162.56" y1="242.57" x2="163.83" y2="242.57" width="0.1524" layer="91"/>
+</segment>
+</net>
+<net name="GND" class="0">
+<segment>
+<pinref part="U$2" gate="G$1" pin="GND"/>
+<wire x1="132.08" y1="172.72" x2="132.08" y2="175.26" width="0.1524" layer="91"/>
+<pinref part="TP9" gate="G$1" pin="1"/>
+</segment>
+<segment>
+<pinref part="D3" gate="G$1" pin="GND"/>
+<pinref part="U$4" gate="G$1" pin="GND"/>
+<wire x1="118.11" y1="184.15" x2="118.11" y2="182.88" width="0.1524" layer="91"/>
+</segment>
+<segment>
+<pinref part="U$11" gate="G$1" pin="GND"/>
+<wire x1="45.72" y1="133.35" x2="45.72" y2="134.62" width="0.1524" layer="91"/>
+<pinref part="C4" gate="G$1" pin="1"/>
+<wire x1="34.29" y1="135.89" x2="34.29" y2="134.62" width="0.1524" layer="91"/>
+<wire x1="34.29" y1="134.62" x2="45.72" y2="134.62" width="0.1524" layer="91"/>
+<pinref part="C5" gate="G$1" pin="1"/>
+<wire x1="57.15" y1="135.89" x2="57.15" y2="134.62" width="0.1524" layer="91"/>
+<wire x1="57.15" y1="134.62" x2="45.72" y2="134.62" width="0.1524" layer="91"/>
+<junction x="45.72" y="134.62"/>
+<pinref part="IC6" gate="G$1" pin="GND"/>
+<wire x1="45.72" y1="140.97" x2="45.72" y2="134.62" width="0.1524" layer="91"/>
+</segment>
+<segment>
+<pinref part="IC2" gate="IC" pin="VSS@4"/>
+<pinref part="U$16" gate="G$1" pin="GND"/>
+<wire x1="267.97" y1="69.85" x2="270.51" y2="69.85" width="0.1524" layer="91"/>
+<wire x1="270.51" y1="69.85" x2="270.51" y2="67.31" width="0.1524" layer="91"/>
+<pinref part="IC2" gate="IC" pin="VSS@2"/>
+<wire x1="267.97" y1="74.93" x2="270.51" y2="74.93" width="0.1524" layer="91"/>
+<wire x1="270.51" y1="74.93" x2="270.51" y2="72.39" width="0.1524" layer="91"/>
+<pinref part="IC2" gate="IC" pin="VSS@3"/>
+<wire x1="270.51" y1="72.39" x2="270.51" y2="69.85" width="0.1524" layer="91"/>
+<wire x1="267.97" y1="72.39" x2="270.51" y2="72.39" width="0.1524" layer="91"/>
+<junction x="270.51" y="69.85"/>
+<junction x="270.51" y="72.39"/>
+<pinref part="IC2" gate="IC" pin="VSS@1"/>
+<wire x1="267.97" y1="77.47" x2="270.51" y2="77.47" width="0.1524" layer="91"/>
+<wire x1="270.51" y1="77.47" x2="270.51" y2="74.93" width="0.1524" layer="91"/>
+<junction x="270.51" y="74.93"/>
+</segment>
+<segment>
+<pinref part="U$5" gate="G$1" pin="GND"/>
+<pinref part="K3" gate="G$1" pin="GND@1"/>
+<wire x1="360.68" y1="176.53" x2="360.68" y2="177.8" width="0.1524" layer="91"/>
+<pinref part="K3" gate="G$1" pin="GND@4"/>
+<wire x1="360.68" y1="177.8" x2="360.68" y2="179.07" width="0.1524" layer="91"/>
+<wire x1="370.84" y1="179.07" x2="370.84" y2="177.8" width="0.1524" layer="91"/>
+<wire x1="370.84" y1="177.8" x2="368.3" y2="177.8" width="0.1524" layer="91"/>
+<pinref part="K3" gate="G$1" pin="GND@2"/>
+<wire x1="368.3" y1="177.8" x2="365.76" y2="177.8" width="0.1524" layer="91"/>
+<wire x1="365.76" y1="177.8" x2="360.68" y2="177.8" width="0.1524" layer="91"/>
+<wire x1="365.76" y1="179.07" x2="365.76" y2="177.8" width="0.1524" layer="91"/>
+<pinref part="K3" gate="G$1" pin="GND@3"/>
+<wire x1="368.3" y1="179.07" x2="368.3" y2="177.8" width="0.1524" layer="91"/>
+<junction x="360.68" y="177.8"/>
+<junction x="365.76" y="177.8"/>
+<junction x="368.3" y="177.8"/>
+</segment>
+<segment>
+<pinref part="K3" gate="G$1" pin="VSS"/>
+<pinref part="U$18" gate="G$1" pin="GND"/>
+<wire x1="337.82" y1="194.31" x2="336.55" y2="194.31" width="0.1524" layer="91"/>
+<wire x1="336.55" y1="194.31" x2="336.55" y2="176.53" width="0.1524" layer="91"/>
+</segment>
+<segment>
+<pinref part="C12" gate="G$1" pin="1"/>
+<pinref part="U$20" gate="G$1" pin="GND"/>
+<wire x1="279.4" y1="67.31" x2="279.4" y2="68.58" width="0.1524" layer="91"/>
+</segment>
+<segment>
+<pinref part="C13" gate="G$1" pin="1"/>
+<pinref part="U$21" gate="G$1" pin="GND"/>
+<wire x1="288.29" y1="67.31" x2="288.29" y2="68.58" width="0.1524" layer="91"/>
+</segment>
+<segment>
+<pinref part="IC5" gate="G$1" pin="EP"/>
+<pinref part="C14" gate="G$1" pin="2"/>
+<wire x1="21.59" y1="80.01" x2="21.59" y2="63.5" width="0.1524" layer="91"/>
+<pinref part="IC5" gate="G$1" pin="GND"/>
+<wire x1="40.64" y1="81.28" x2="36.83" y2="81.28" width="0.1524" layer="91"/>
+<wire x1="36.83" y1="81.28" x2="36.83" y2="63.5" width="0.1524" layer="91"/>
+<pinref part="R14" gate="G$1" pin="1"/>
+<wire x1="52.07" y1="63.5" x2="50.8" y2="63.5" width="0.1524" layer="91"/>
+<junction x="36.83" y="63.5"/>
+<pinref part="C16" gate="G$1" pin="1"/>
+<wire x1="50.8" y1="63.5" x2="36.83" y2="63.5" width="0.1524" layer="91"/>
+<wire x1="12.7" y1="80.01" x2="12.7" y2="63.5" width="0.1524" layer="91"/>
+<wire x1="12.7" y1="63.5" x2="21.59" y2="63.5" width="0.1524" layer="91"/>
+<wire x1="21.59" y1="63.5" x2="36.83" y2="63.5" width="0.1524" layer="91"/>
+<wire x1="50.8" y1="69.85" x2="50.8" y2="63.5" width="0.1524" layer="91"/>
+<junction x="21.59" y="63.5"/>
+<junction x="50.8" y="63.5"/>
+<pinref part="C15" gate="G$1" pin="1"/>
+<wire x1="50.8" y1="60.96" x2="50.8" y2="63.5" width="0.1524" layer="91"/>
+<wire x1="81.28" y1="80.01" x2="81.28" y2="60.96" width="0.1524" layer="91"/>
+<wire x1="81.28" y1="60.96" x2="76.2" y2="60.96" width="0.1524" layer="91"/>
+<pinref part="R26" gate="G$1" pin="2"/>
+<wire x1="76.2" y1="60.96" x2="50.8" y2="60.96" width="0.1524" layer="91"/>
+<wire x1="76.2" y1="73.66" x2="76.2" y2="60.96" width="0.1524" layer="91"/>
+<junction x="76.2" y="60.96"/>
+<pinref part="U$22" gate="G$1" pin="GND"/>
+<wire x1="50.8" y1="58.42" x2="50.8" y2="60.96" width="0.1524" layer="91"/>
+<junction x="50.8" y="60.96"/>
+</segment>
+<segment>
+<pinref part="C20" gate="G$1" pin="1"/>
+<pinref part="U$32" gate="G$1" pin="GND"/>
+<wire x1="181.61" y1="106.68" x2="181.61" y2="105.41" width="0.1524" layer="91"/>
+</segment>
+<segment>
+<pinref part="IC2" gate="IC" pin="BOOT0"/>
+<pinref part="U$33" gate="G$1" pin="GND"/>
+<wire x1="196.85" y1="110.49" x2="187.96" y2="110.49" width="0.1524" layer="91"/>
+<wire x1="187.96" y1="110.49" x2="187.96" y2="105.41" width="0.1524" layer="91"/>
+</segment>
+<segment>
+<pinref part="C2" gate="G$1" pin="1"/>
+<wire x1="173.99" y1="123.19" x2="173.99" y2="128.27" width="0.1524" layer="91"/>
+<wire x1="173.99" y1="128.27" x2="173.99" y2="130.81" width="0.1524" layer="91"/>
+<wire x1="173.99" y1="130.81" x2="173.99" y2="135.89" width="0.1524" layer="91"/>
+<wire x1="173.99" y1="135.89" x2="175.26" y2="135.89" width="0.1524" layer="91"/>
+<pinref part="C3" gate="G$1" pin="1"/>
+<wire x1="175.26" y1="123.19" x2="173.99" y2="123.19" width="0.1524" layer="91"/>
+<pinref part="X1" gate="G$1" pin="GND1"/>
+<wire x1="181.61" y1="130.81" x2="173.99" y2="130.81" width="0.1524" layer="91"/>
+<pinref part="X1" gate="G$1" pin="GND2"/>
+<wire x1="181.61" y1="128.27" x2="173.99" y2="128.27" width="0.1524" layer="91"/>
+<junction x="173.99" y="130.81"/>
+<junction x="173.99" y="128.27"/>
+<pinref part="U$10" gate="G$1" pin="GND"/>
+<wire x1="173.99" y1="128.27" x2="170.18" y2="128.27" width="0.1524" layer="91"/>
+<wire x1="170.18" y1="128.27" x2="170.18" y2="125.73" width="0.1524" layer="91"/>
+</segment>
+<segment>
+<pinref part="K5" gate="K" pin="GND"/>
+<pinref part="U$35" gate="G$1" pin="GND"/>
+<wire x1="160.02" y1="179.07" x2="162.56" y2="179.07" width="0.1524" layer="91"/>
+<wire x1="162.56" y1="179.07" x2="162.56" y2="173.99" width="0.1524" layer="91"/>
+</segment>
+<segment>
+<pinref part="IC2" gate="IC" pin="VSSA"/>
+<pinref part="U$37" gate="G$1" pin="GND"/>
+<wire x1="196.85" y1="87.63" x2="194.31" y2="87.63" width="0.1524" layer="91"/>
+<wire x1="194.31" y1="87.63" x2="194.31" y2="86.36" width="0.1524" layer="91"/>
+</segment>
+<segment>
+<pinref part="C21" gate="G$1" pin="1"/>
+<pinref part="U$38" gate="G$1" pin="GND"/>
+<wire x1="185.42" y1="86.36" x2="185.42" y2="87.63" width="0.1524" layer="91"/>
+</segment>
+<segment>
+<pinref part="C22" gate="G$1" pin="1"/>
+<pinref part="U$42" gate="G$1" pin="GND"/>
+<wire x1="358.14" y1="217.17" x2="358.14" y2="218.44" width="0.1524" layer="91"/>
+</segment>
+<segment>
+<pinref part="R11" gate="G$1" pin="2"/>
+<pinref part="U$28" gate="G$1" pin="GND"/>
+<wire x1="175.26" y1="231.14" x2="175.26" y2="229.87" width="0.1524" layer="91"/>
+</segment>
+<segment>
+<pinref part="K4" gate="G$1" pin="GND@1"/>
+<pinref part="U$24" gate="G$1" pin="GND"/>
+<wire x1="340.36" y1="156.21" x2="330.2" y2="156.21" width="0.1524" layer="91"/>
+<wire x1="330.2" y1="156.21" x2="330.2" y2="151.13" width="0.1524" layer="91"/>
+<pinref part="K4" gate="G$1" pin="GND@2"/>
+<wire x1="330.2" y1="151.13" x2="330.2" y2="125.73" width="0.1524" layer="91"/>
+<wire x1="330.2" y1="125.73" x2="330.2" y2="105.41" width="0.1524" layer="91"/>
+<wire x1="330.2" y1="105.41" x2="330.2" y2="97.79" width="0.1524" layer="91"/>
+<wire x1="330.2" y1="97.79" x2="330.2" y2="91.44" width="0.1524" layer="91"/>
+<wire x1="340.36" y1="151.13" x2="330.2" y2="151.13" width="0.1524" layer="91"/>
+<pinref part="K4" gate="G$1" pin="GND@3"/>
+<wire x1="340.36" y1="105.41" x2="330.2" y2="105.41" width="0.1524" layer="91"/>
+<pinref part="K4" gate="G$1" pin="GND@4"/>
+<wire x1="340.36" y1="97.79" x2="330.2" y2="97.79" width="0.1524" layer="91"/>
+<junction x="330.2" y="97.79"/>
+<junction x="330.2" y="105.41"/>
+<junction x="330.2" y="151.13"/>
+<pinref part="K4" gate="G$1" pin="IM1"/>
+<wire x1="340.36" y1="125.73" x2="330.2" y2="125.73" width="0.1524" layer="91"/>
+<junction x="330.2" y="125.73"/>
+</segment>
+<segment>
+<pinref part="C18" gate="G$1" pin="1"/>
+<pinref part="U$29" gate="G$1" pin="GND"/>
+<wire x1="336.55" y1="66.04" x2="336.55" y2="67.31" width="0.1524" layer="91"/>
+</segment>
+<segment>
+<pinref part="C19" gate="G$1" pin="1"/>
+<pinref part="U$31" gate="G$1" pin="GND"/>
+<wire x1="100.33" y1="147.32" x2="100.33" y2="148.59" width="0.1524" layer="91"/>
+</segment>
+<segment>
+<pinref part="C24" gate="G$1" pin="1"/>
+<pinref part="U$40" gate="G$1" pin="GND"/>
+<wire x1="109.22" y1="147.32" x2="109.22" y2="148.59" width="0.1524" layer="91"/>
+</segment>
+<segment>
+<pinref part="K6" gate="G$1" pin="GND@1"/>
+<pinref part="U$50" gate="G$1" pin="GND"/>
+<wire x1="139.7" y1="140.97" x2="142.24" y2="140.97" width="0.1524" layer="91"/>
+<wire x1="142.24" y1="140.97" x2="142.24" y2="138.43" width="0.1524" layer="91"/>
+<pinref part="K6" gate="G$1" pin="GND@2"/>
+<wire x1="142.24" y1="138.43" x2="142.24" y2="133.35" width="0.1524" layer="91"/>
+<wire x1="142.24" y1="133.35" x2="142.24" y2="130.81" width="0.1524" layer="91"/>
+<wire x1="142.24" y1="130.81" x2="142.24" y2="128.27" width="0.1524" layer="91"/>
+<wire x1="139.7" y1="138.43" x2="142.24" y2="138.43" width="0.1524" layer="91"/>
+<pinref part="K6" gate="G$1" pin="GND@3"/>
+<wire x1="139.7" y1="133.35" x2="142.24" y2="133.35" width="0.1524" layer="91"/>
+<pinref part="K6" gate="G$1" pin="GND@4"/>
+<wire x1="139.7" y1="130.81" x2="142.24" y2="130.81" width="0.1524" layer="91"/>
+<junction x="142.24" y="133.35"/>
+<junction x="142.24" y="130.81"/>
+<junction x="142.24" y="138.43"/>
+</segment>
+<segment>
+<pinref part="K1" gate="K" pin="GND@3"/>
+<pinref part="U$3" gate="G$1" pin="GND"/>
+<wire x1="66.04" y1="232.41" x2="85.09" y2="232.41" width="0.1524" layer="91"/>
+<wire x1="85.09" y1="232.41" x2="85.09" y2="204.47" width="0.1524" layer="91"/>
+<pinref part="K1" gate="K" pin="GND@2"/>
+<wire x1="85.09" y1="204.47" x2="85.09" y2="180.34" width="0.1524" layer="91"/>
+<wire x1="66.04" y1="204.47" x2="85.09" y2="204.47" width="0.1524" layer="91"/>
+<junction x="85.09" y="204.47"/>
+</segment>
+<segment>
+<pinref part="K1" gate="K" pin="GND"/>
+<pinref part="U$6" gate="G$1" pin="GND"/>
+<wire x1="40.64" y1="232.41" x2="19.05" y2="232.41" width="0.1524" layer="91"/>
+<wire x1="19.05" y1="232.41" x2="19.05" y2="204.47" width="0.1524" layer="91"/>
+<pinref part="K1" gate="K" pin="GND@1"/>
+<wire x1="19.05" y1="204.47" x2="19.05" y2="180.34" width="0.1524" layer="91"/>
+<wire x1="40.64" y1="204.47" x2="19.05" y2="204.47" width="0.1524" layer="91"/>
+<junction x="19.05" y="204.47"/>
+</segment>
+<segment>
+<pinref part="R4" gate="G$1" pin="1"/>
+<pinref part="U$7" gate="G$1" pin="GND"/>
+<wire x1="12.7" y1="133.35" x2="12.7" y2="137.16" width="0.1524" layer="91"/>
+</segment>
+<segment>
+<pinref part="R5" gate="G$1" pin="1"/>
+<pinref part="U$8" gate="G$1" pin="GND"/>
+<wire x1="20.32" y1="133.35" x2="20.32" y2="137.16" width="0.1524" layer="91"/>
+</segment>
+<segment>
+<pinref part="C1" gate="G$1" pin="1"/>
+<wire x1="41.91" y1="172.72" x2="41.91" y2="171.45" width="0.1524" layer="91"/>
+<pinref part="R6" gate="G$1" pin="1"/>
+<wire x1="41.91" y1="171.45" x2="31.75" y2="171.45" width="0.1524" layer="91"/>
+<wire x1="31.75" y1="171.45" x2="31.75" y2="172.72" width="0.1524" layer="91"/>
+<pinref part="U$9" gate="G$1" pin="GND"/>
+<wire x1="31.75" y1="170.18" x2="31.75" y2="171.45" width="0.1524" layer="91"/>
+<junction x="31.75" y="171.45"/>
+</segment>
+<segment>
+<pinref part="C25" gate="G$1" pin="1"/>
+<wire x1="73.66" y1="172.72" x2="73.66" y2="171.45" width="0.1524" layer="91"/>
+<pinref part="R7" gate="G$1" pin="1"/>
+<wire x1="73.66" y1="171.45" x2="63.5" y2="171.45" width="0.1524" layer="91"/>
+<wire x1="63.5" y1="171.45" x2="63.5" y2="172.72" width="0.1524" layer="91"/>
+<pinref part="U$17" gate="G$1" pin="GND"/>
+<wire x1="73.66" y1="170.18" x2="73.66" y2="171.45" width="0.1524" layer="91"/>
+<junction x="73.66" y="171.45"/>
+</segment>
+<segment>
+<pinref part="D2" gate="G$1" pin="1"/>
+<pinref part="U$44" gate="G$1" pin="GND"/>
+<wire x1="144.78" y1="224.79" x2="144.78" y2="226.06" width="0.1524" layer="91"/>
+</segment>
+<segment>
+<pinref part="D4" gate="G$1" pin="1"/>
+<pinref part="U$55" gate="G$1" pin="GND"/>
+<wire x1="152.4" y1="224.79" x2="152.4" y2="226.06" width="0.1524" layer="91"/>
+</segment>
+<segment>
+<pinref part="C26" gate="G$1" pin="1"/>
+<pinref part="U$58" gate="G$1" pin="GND"/>
+<wire x1="327.66" y1="66.04" x2="327.66" y2="67.31" width="0.1524" layer="91"/>
+</segment>
+<segment>
+<pinref part="TP12" gate="G$1" pin="1"/>
+<pinref part="U$59" gate="G$1" pin="GND"/>
+<wire x1="125.73" y1="172.72" x2="125.73" y2="175.26" width="0.1524" layer="91"/>
+</segment>
+<segment>
+<pinref part="TP13" gate="G$1" pin="1"/>
+<pinref part="U$60" gate="G$1" pin="GND"/>
+<wire x1="138.43" y1="175.26" x2="138.43" y2="172.72" width="0.1524" layer="91"/>
+</segment>
+<segment>
+<pinref part="C34" gate="G$1" pin="1"/>
+<wire x1="125.73" y1="55.88" x2="125.73" y2="53.34" width="0.1524" layer="91"/>
+<pinref part="C33" gate="G$1" pin="1"/>
+<wire x1="125.73" y1="53.34" x2="116.84" y2="53.34" width="0.1524" layer="91"/>
+<wire x1="116.84" y1="53.34" x2="106.68" y2="53.34" width="0.1524" layer="91"/>
+<wire x1="106.68" y1="53.34" x2="97.79" y2="53.34" width="0.1524" layer="91"/>
+<wire x1="97.79" y1="53.34" x2="97.79" y2="55.88" width="0.1524" layer="91"/>
+<pinref part="C30" gate="G$1" pin="1"/>
+<wire x1="106.68" y1="55.88" x2="106.68" y2="53.34" width="0.1524" layer="91"/>
+<pinref part="C7" gate="G$1" pin="1"/>
+<wire x1="116.84" y1="55.88" x2="116.84" y2="53.34" width="0.1524" layer="91"/>
+<pinref part="U$62" gate="G$1" pin="GND"/>
+<wire x1="106.68" y1="53.34" x2="106.68" y2="52.07" width="0.1524" layer="91"/>
+<junction x="106.68" y="53.34"/>
+<junction x="116.84" y="53.34"/>
+</segment>
+<segment>
+<pinref part="C36" gate="G$1" pin="2"/>
+<pinref part="U$64" gate="G$1" pin="GND"/>
+<wire x1="290.83" y1="237.49" x2="290.83" y2="236.22" width="0.1524" layer="91"/>
+</segment>
+<segment>
+<pinref part="C37" gate="G$1" pin="2"/>
+<pinref part="U$65" gate="G$1" pin="GND"/>
+<wire x1="299.72" y1="237.49" x2="299.72" y2="231.14" width="0.1524" layer="91"/>
+</segment>
+<segment>
+<pinref part="C38" gate="G$1" pin="2"/>
+<pinref part="U$66" gate="G$1" pin="GND"/>
+<wire x1="306.07" y1="237.49" x2="306.07" y2="236.22" width="0.1524" layer="91"/>
+</segment>
+<segment>
+<pinref part="C39" gate="G$1" pin="2"/>
+<pinref part="U$67" gate="G$1" pin="GND"/>
+<wire x1="312.42" y1="237.49" x2="312.42" y2="231.14" width="0.1524" layer="91"/>
+</segment>
+<segment>
+<pinref part="C40" gate="G$1" pin="2"/>
+<pinref part="U$68" gate="G$1" pin="GND"/>
+<wire x1="318.77" y1="237.49" x2="318.77" y2="236.22" width="0.1524" layer="91"/>
+</segment>
+<segment>
+<pinref part="U$71" gate="G$1" pin="GND"/>
+<pinref part="C42" gate="G$1" pin="1"/>
+<wire x1="97.79" y1="77.47" x2="97.79" y2="78.74" width="0.1524" layer="91"/>
+<pinref part="C41" gate="G$1" pin="1"/>
+<wire x1="97.79" y1="78.74" x2="97.79" y2="80.01" width="0.1524" layer="91"/>
+<wire x1="97.79" y1="78.74" x2="106.68" y2="78.74" width="0.1524" layer="91"/>
+<wire x1="106.68" y1="78.74" x2="106.68" y2="80.01" width="0.1524" layer="91"/>
+<junction x="97.79" y="78.74"/>
+</segment>
+<segment>
+<pinref part="C27" gate="G$1" pin="1"/>
+<pinref part="U$61" gate="G$1" pin="GND"/>
+<wire x1="350.52" y1="217.17" x2="350.52" y2="218.44" width="0.1524" layer="91"/>
+</segment>
+<segment>
+<pinref part="C43" gate="G$1" pin="2"/>
+<pinref part="U$72" gate="G$1" pin="GND"/>
+<wire x1="325.12" y1="237.49" x2="325.12" y2="231.14" width="0.1524" layer="91"/>
+</segment>
+<segment>
+<pinref part="C45" gate="G$1" pin="1"/>
+<wire x1="106.68" y1="100.33" x2="106.68" y2="99.06" width="0.1524" layer="91"/>
+<pinref part="C11" gate="G$1" pin="1"/>
+<wire x1="106.68" y1="99.06" x2="115.57" y2="99.06" width="0.1524" layer="91"/>
+<wire x1="115.57" y1="99.06" x2="124.46" y2="99.06" width="0.1524" layer="91"/>
+<wire x1="124.46" y1="99.06" x2="133.35" y2="99.06" width="0.1524" layer="91"/>
+<wire x1="133.35" y1="99.06" x2="133.35" y2="100.33" width="0.1524" layer="91"/>
+<pinref part="C44" gate="G$1" pin="1"/>
+<wire x1="115.57" y1="100.33" x2="115.57" y2="99.06" width="0.1524" layer="91"/>
+<pinref part="C32" gate="G$1" pin="1"/>
+<wire x1="124.46" y1="100.33" x2="124.46" y2="99.06" width="0.1524" layer="91"/>
+<pinref part="U$73" gate="G$1" pin="GND"/>
+<wire x1="115.57" y1="99.06" x2="115.57" y2="97.79" width="0.1524" layer="91"/>
+<junction x="115.57" y="99.06"/>
+<junction x="124.46" y="99.06"/>
+</segment>
+<segment>
+<pinref part="C28" gate="G$1" pin="1"/>
+<wire x1="176.53" y1="45.72" x2="176.53" y2="44.45" width="0.1524" layer="91"/>
+<pinref part="C46" gate="G$1" pin="1"/>
+<wire x1="176.53" y1="44.45" x2="185.42" y2="44.45" width="0.1524" layer="91"/>
+<wire x1="185.42" y1="44.45" x2="194.31" y2="44.45" width="0.1524" layer="91"/>
+<wire x1="194.31" y1="44.45" x2="194.31" y2="45.72" width="0.1524" layer="91"/>
+<pinref part="C8" gate="G$1" pin="1"/>
+<wire x1="185.42" y1="45.72" x2="185.42" y2="44.45" width="0.1524" layer="91"/>
+<junction x="185.42" y="44.45"/>
+<pinref part="U$74" gate="G$1" pin="GND"/>
+<wire x1="185.42" y1="43.18" x2="185.42" y2="44.45" width="0.1524" layer="91"/>
+<pinref part="C54" gate="G$1" pin="2"/>
+<wire x1="194.31" y1="44.45" x2="203.2" y2="44.45" width="0.1524" layer="91"/>
+<wire x1="203.2" y1="44.45" x2="203.2" y2="45.72" width="0.1524" layer="91"/>
+<junction x="194.31" y="44.45"/>
+</segment>
+<segment>
+<pinref part="C29" gate="G$1" pin="1"/>
+<wire x1="154.94" y1="60.96" x2="154.94" y2="59.69" width="0.1524" layer="91"/>
+<wire x1="154.94" y1="59.69" x2="163.83" y2="59.69" width="0.1524" layer="91"/>
+<pinref part="C6" gate="G$1" pin="1"/>
+<wire x1="163.83" y1="59.69" x2="163.83" y2="60.96" width="0.1524" layer="91"/>
+<pinref part="U$75" gate="G$1" pin="GND"/>
+<wire x1="154.94" y1="58.42" x2="154.94" y2="59.69" width="0.1524" layer="91"/>
+<junction x="154.94" y="59.69"/>
+<pinref part="C52" gate="G$1" pin="1"/>
+<wire x1="172.72" y1="60.96" x2="172.72" y2="59.69" width="0.1524" layer="91"/>
+<wire x1="172.72" y1="59.69" x2="163.83" y2="59.69" width="0.1524" layer="91"/>
+<junction x="163.83" y="59.69"/>
+</segment>
+<segment>
+<wire x1="115.57" y1="29.21" x2="106.68" y2="29.21" width="0.1524" layer="91"/>
+<wire x1="106.68" y1="29.21" x2="97.79" y2="29.21" width="0.1524" layer="91"/>
+<pinref part="C9" gate="G$1" pin="1"/>
+<wire x1="106.68" y1="30.48" x2="106.68" y2="29.21" width="0.1524" layer="91"/>
+<pinref part="C10" gate="G$1" pin="1"/>
+<wire x1="115.57" y1="30.48" x2="115.57" y2="29.21" width="0.1524" layer="91"/>
+<junction x="106.68" y="29.21"/>
+<pinref part="C31" gate="G$1" pin="1"/>
+<wire x1="97.79" y1="29.21" x2="97.79" y2="30.48" width="0.1524" layer="91"/>
+<pinref part="U$14" gate="G$1" pin="GND"/>
+<wire x1="106.68" y1="29.21" x2="106.68" y2="27.94" width="0.1524" layer="91"/>
+<pinref part="C56" gate="G$1" pin="2"/>
+<wire x1="115.57" y1="29.21" x2="124.46" y2="29.21" width="0.1524" layer="91"/>
+<wire x1="124.46" y1="29.21" x2="124.46" y2="30.48" width="0.1524" layer="91"/>
+<junction x="115.57" y="29.21"/>
+</segment>
+<segment>
+<pinref part="C47" gate="G$1" pin="1"/>
+<pinref part="U$76" gate="G$1" pin="GND"/>
+<wire x1="318.77" y1="66.04" x2="318.77" y2="67.31" width="0.1524" layer="91"/>
+</segment>
+<segment>
+<pinref part="C49" gate="G$1" pin="1"/>
+<pinref part="U$78" gate="G$1" pin="GND"/>
+<wire x1="118.11" y1="148.59" x2="118.11" y2="147.32" width="0.1524" layer="91"/>
+</segment>
+<segment>
+<pinref part="C17" gate="G$1" pin="1"/>
+<pinref part="U$26" gate="G$1" pin="GND"/>
+<wire x1="360.68" y1="247.65" x2="360.68" y2="248.92" width="0.1524" layer="91"/>
+</segment>
+<segment>
+<pinref part="C35" gate="G$1" pin="1"/>
+<pinref part="U$63" gate="G$1" pin="GND"/>
+<wire x1="370.84" y1="247.65" x2="370.84" y2="248.92" width="0.1524" layer="91"/>
+</segment>
+<segment>
+<pinref part="C51" gate="G$1" pin="1"/>
+<pinref part="U$80" gate="G$1" pin="GND"/>
+<wire x1="379.73" y1="247.65" x2="379.73" y2="248.92" width="0.1524" layer="91"/>
+</segment>
+<segment>
+<pinref part="C23" gate="G$1" pin="1"/>
+<pinref part="U$43" gate="G$1" pin="GND"/>
+<wire x1="341.63" y1="217.17" x2="341.63" y2="218.44" width="0.1524" layer="91"/>
+</segment>
+<segment>
+<pinref part="C55" gate="G$1" pin="2"/>
+<pinref part="U$84" gate="G$1" pin="GND"/>
+<wire x1="185.42" y1="177.8" x2="185.42" y2="176.53" width="0.1524" layer="91"/>
+</segment>
+<segment>
+<pinref part="U$81" gate="G$1" pin="GND"/>
+<pinref part="C53" gate="G$1" pin="1"/>
+<wire x1="351.79" y1="247.65" x2="351.79" y2="248.92" width="0.1524" layer="91"/>
+</segment>
+<segment>
+<pinref part="C57" gate="G$1" pin="1"/>
+<pinref part="U$85" gate="G$1" pin="GND"/>
+<wire x1="365.76" y1="218.44" x2="365.76" y2="217.17" width="0.1524" layer="91"/>
+</segment>
+<segment>
+<pinref part="U$83" gate="G$1" pin="GND"/>
+<pinref part="IC1" gate="G$1" pin="GND"/>
+<wire x1="175.26" y1="170.18" x2="175.26" y2="171.45" width="0.1524" layer="91"/>
+</segment>
+<segment>
+<pinref part="R9" gate="G$1" pin="1"/>
+<pinref part="U$77" gate="G$1" pin="GND"/>
+<wire x1="31.75" y1="71.12" x2="31.75" y2="73.66" width="0.1524" layer="91"/>
+</segment>
+<segment>
+<pinref part="C50" gate="G$1" pin="1"/>
+<pinref part="U$79" gate="G$1" pin="GND"/>
+<wire x1="76.2" y1="130.81" x2="76.2" y2="132.08" width="0.1524" layer="91"/>
+</segment>
+</net>
+<net name="SD_DAT2" class="0">
+<segment>
+<pinref part="K3" gate="G$1" pin="DAT2"/>
+<pinref part="IC2" gate="IC" pin="PC10"/>
+<wire x1="337.82" y1="207.01" x2="299.72" y2="207.01" width="0.1524" layer="91"/>
+<wire x1="299.72" y1="207.01" x2="295.91" y2="207.01" width="0.1524" layer="91"/>
+<wire x1="295.91" y1="207.01" x2="295.91" y2="201.93" width="0.1524" layer="91"/>
+<wire x1="295.91" y1="201.93" x2="267.97" y2="201.93" width="0.1524" layer="91"/>
+<pinref part="R19" gate="G$1" pin="1"/>
+<wire x1="299.72" y1="209.55" x2="299.72" y2="207.01" width="0.1524" layer="91"/>
+<junction x="299.72" y="207.01"/>
+</segment>
+</net>
+<net name="SD_DAT3" class="0">
+<segment>
+<pinref part="K3" gate="G$1" pin="CD/DAT3"/>
+<pinref part="IC2" gate="IC" pin="PC11"/>
+<wire x1="337.82" y1="204.47" x2="306.07" y2="204.47" width="0.1524" layer="91"/>
+<wire x1="306.07" y1="204.47" x2="298.45" y2="204.47" width="0.1524" layer="91"/>
+<wire x1="298.45" y1="204.47" x2="298.45" y2="199.39" width="0.1524" layer="91"/>
+<wire x1="298.45" y1="199.39" x2="267.97" y2="199.39" width="0.1524" layer="91"/>
+<pinref part="R20" gate="G$1" pin="1"/>
+<wire x1="306.07" y1="209.55" x2="306.07" y2="204.47" width="0.1524" layer="91"/>
+<junction x="306.07" y="204.47"/>
+</segment>
+</net>
+<net name="SD_CMD" class="0">
+<segment>
+<pinref part="IC2" gate="IC" pin="PD2"/>
+<wire x1="267.97" y1="171.45" x2="300.99" y2="171.45" width="0.1524" layer="91"/>
+<wire x1="300.99" y1="171.45" x2="300.99" y2="201.93" width="0.1524" layer="91"/>
+<pinref part="K3" gate="G$1" pin="CMD"/>
+<wire x1="300.99" y1="201.93" x2="312.42" y2="201.93" width="0.1524" layer="91"/>
+<pinref part="R21" gate="G$1" pin="1"/>
+<wire x1="312.42" y1="201.93" x2="337.82" y2="201.93" width="0.1524" layer="91"/>
+<wire x1="312.42" y1="209.55" x2="312.42" y2="201.93" width="0.1524" layer="91"/>
+<junction x="312.42" y="201.93"/>
+</segment>
+</net>
+<net name="SD_CLK" class="0">
+<segment>
+<pinref part="K3" gate="G$1" pin="CLK"/>
+<pinref part="IC2" gate="IC" pin="PC12"/>
+<pinref part="R22" gate="G$1" pin="1"/>
+<wire x1="337.82" y1="196.85" x2="318.77" y2="196.85" width="0.1524" layer="91"/>
+<wire x1="318.77" y1="196.85" x2="267.97" y2="196.85" width="0.1524" layer="91"/>
+<wire x1="318.77" y1="209.55" x2="318.77" y2="196.85" width="0.1524" layer="91"/>
+<junction x="318.77" y="196.85"/>
+</segment>
+</net>
+<net name="SD_DAT0" class="0">
+<segment>
+<pinref part="K3" gate="G$1" pin="DAT0"/>
+<wire x1="337.82" y1="191.77" x2="325.12" y2="191.77" width="0.1524" layer="91"/>
+<wire x1="325.12" y1="191.77" x2="293.37" y2="191.77" width="0.1524" layer="91"/>
+<wire x1="293.37" y1="191.77" x2="293.37" y2="207.01" width="0.1524" layer="91"/>
+<pinref part="IC2" gate="IC" pin="PC8"/>
+<wire x1="293.37" y1="207.01" x2="267.97" y2="207.01" width="0.1524" layer="91"/>
+<pinref part="R23" gate="G$1" pin="1"/>
+<wire x1="325.12" y1="209.55" x2="325.12" y2="191.77" width="0.1524" layer="91"/>
+<junction x="325.12" y="191.77"/>
+</segment>
+</net>
+<net name="SD_DAT1" class="0">
+<segment>
+<pinref part="K3" gate="G$1" pin="DAT1"/>
+<wire x1="337.82" y1="189.23" x2="290.83" y2="189.23" width="0.1524" layer="91"/>
+<wire x1="290.83" y1="189.23" x2="290.83" y2="204.47" width="0.1524" layer="91"/>
+<pinref part="IC2" gate="IC" pin="PC9"/>
+<wire x1="290.83" y1="204.47" x2="267.97" y2="204.47" width="0.1524" layer="91"/>
+<pinref part="R18" gate="G$1" pin="1"/>
+<wire x1="290.83" y1="209.55" x2="290.83" y2="204.47" width="0.1524" layer="91"/>
+<junction x="290.83" y="204.47"/>
+</segment>
+</net>
+<net name="N$21" class="0">
+<segment>
+<pinref part="IC2" gate="IC" pin="PH0-OSC_IN"/>
+<wire x1="196.85" y1="130.81" x2="194.31" y2="130.81" width="0.1524" layer="91"/>
+<wire x1="194.31" y1="130.81" x2="194.31" y2="135.89" width="0.1524" layer="91"/>
+<pinref part="C2" gate="G$1" pin="2"/>
+<wire x1="194.31" y1="135.89" x2="186.69" y2="135.89" width="0.1524" layer="91"/>
+<pinref part="X1" gate="G$1" pin="1"/>
+<wire x1="186.69" y1="135.89" x2="185.42" y2="135.89" width="0.1524" layer="91"/>
+<wire x1="186.69" y1="134.62" x2="186.69" y2="135.89" width="0.1524" layer="91"/>
+<junction x="186.69" y="135.89"/>
+</segment>
+</net>
+<net name="N$22" class="0">
+<segment>
+<pinref part="IC2" gate="IC" pin="PH1-OSC_OUT"/>
+<pinref part="C3" gate="G$1" pin="2"/>
+<wire x1="196.85" y1="123.19" x2="186.69" y2="123.19" width="0.1524" layer="91"/>
+<pinref part="X1" gate="G$1" pin="2"/>
+<wire x1="186.69" y1="123.19" x2="185.42" y2="123.19" width="0.1524" layer="91"/>
+<wire x1="186.69" y1="124.46" x2="186.69" y2="123.19" width="0.1524" layer="91"/>
+<junction x="186.69" y="123.19"/>
+</segment>
+</net>
+<net name="VCC-2" class="0">
+<segment>
+<pinref part="C5" gate="G$1" pin="2"/>
+<pinref part="U$12" gate="G$1" pin="VCC-2"/>
+<wire x1="57.15" y1="146.05" x2="57.15" y2="148.59" width="0.1524" layer="91"/>
+<pinref part="IC6" gate="G$1" pin="OUT"/>
+<wire x1="57.15" y1="148.59" x2="57.15" y2="151.13" width="0.1524" layer="91"/>
+<wire x1="53.34" y1="148.59" x2="57.15" y2="148.59" width="0.1524" layer="91"/>
+<junction x="57.15" y="148.59"/>
+<pinref part="TP3" gate="G$1" pin="1"/>
+<wire x1="58.42" y1="148.59" x2="57.15" y2="148.59" width="0.1524" layer="91"/>
+</segment>
+<segment>
+<pinref part="K5" gate="K" pin="VDD"/>
+<pinref part="U$34" gate="G$1" pin="VCC-2"/>
+<wire x1="160.02" y1="189.23" x2="162.56" y2="189.23" width="0.1524" layer="91"/>
+<wire x1="162.56" y1="189.23" x2="162.56" y2="190.5" width="0.1524" layer="91"/>
+</segment>
+<segment>
+<pinref part="IC2" gate="IC" pin="VBAT"/>
+<pinref part="U$36" gate="G$1" pin="VCC-2"/>
+<wire x1="196.85" y1="92.71" x2="194.31" y2="92.71" width="0.1524" layer="91"/>
+<wire x1="194.31" y1="92.71" x2="194.31" y2="93.98" width="0.1524" layer="91"/>
+<pinref part="IC2" gate="IC" pin="VDDA"/>
+<wire x1="196.85" y1="90.17" x2="194.31" y2="90.17" width="0.1524" layer="91"/>
+<wire x1="194.31" y1="90.17" x2="194.31" y2="92.71" width="0.1524" layer="91"/>
+<junction x="194.31" y="92.71"/>
+</segment>
+<segment>
+<pinref part="L2" gate="G$1" pin="1"/>
+<pinref part="U$39" gate="G$1" pin="VCC-2"/>
+<wire x1="167.64" y1="99.06" x2="163.83" y2="99.06" width="0.1524" layer="91"/>
+<wire x1="163.83" y1="99.06" x2="163.83" y2="101.6" width="0.1524" layer="91"/>
+</segment>
+<segment>
+<pinref part="U$25" gate="G$1" pin="VCC-2"/>
+<pinref part="L4" gate="G$1" pin="2"/>
+<wire x1="351.79" y1="78.74" x2="355.6" y2="78.74" width="0.1524" layer="91"/>
+</segment>
+<segment>
+<pinref part="U$70" gate="G$1" pin="VCC-2"/>
+<pinref part="C42" gate="G$1" pin="2"/>
+<wire x1="97.79" y1="92.71" x2="97.79" y2="91.44" width="0.1524" layer="91"/>
+<pinref part="C41" gate="G$1" pin="2"/>
+<wire x1="97.79" y1="91.44" x2="97.79" y2="90.17" width="0.1524" layer="91"/>
+<wire x1="97.79" y1="91.44" x2="106.68" y2="91.44" width="0.1524" layer="91"/>
+<wire x1="106.68" y1="91.44" x2="106.68" y2="90.17" width="0.1524" layer="91"/>
+<pinref part="IC2" gate="IC" pin="VDD@1"/>
+<wire x1="196.85" y1="82.55" x2="194.31" y2="82.55" width="0.1524" layer="91"/>
+<wire x1="193.04" y1="82.55" x2="194.31" y2="82.55" width="0.1524" layer="91"/>
+<wire x1="194.31" y1="82.55" x2="194.31" y2="74.93" width="0.1524" layer="91"/>
+<wire x1="194.31" y1="74.93" x2="132.08" y2="74.93" width="0.1524" layer="91"/>
+<wire x1="132.08" y1="74.93" x2="132.08" y2="41.91" width="0.1524" layer="91"/>
+<wire x1="132.08" y1="41.91" x2="124.46" y2="41.91" width="0.1524" layer="91"/>
+<wire x1="124.46" y1="41.91" x2="115.57" y2="41.91" width="0.1524" layer="91"/>
+<wire x1="115.57" y1="41.91" x2="106.68" y2="41.91" width="0.1524" layer="91"/>
+<pinref part="C9" gate="G$1" pin="2"/>
+<wire x1="106.68" y1="40.64" x2="106.68" y2="41.91" width="0.1524" layer="91"/>
+<pinref part="C10" gate="G$1" pin="2"/>
+<wire x1="115.57" y1="40.64" x2="115.57" y2="41.91" width="0.1524" layer="91"/>
+<pinref part="IC2" gate="IC" pin="VDD@6"/>
+<wire x1="196.85" y1="69.85" x2="194.31" y2="69.85" width="0.1524" layer="91"/>
+<wire x1="194.31" y1="69.85" x2="194.31" y2="72.39" width="0.1524" layer="91"/>
+<pinref part="IC2" gate="IC" pin="VDD@2"/>
+<wire x1="194.31" y1="72.39" x2="194.31" y2="74.93" width="0.1524" layer="91"/>
+<wire x1="194.31" y1="74.93" x2="194.31" y2="77.47" width="0.1524" layer="91"/>
+<wire x1="194.31" y1="77.47" x2="194.31" y2="80.01" width="0.1524" layer="91"/>
+<wire x1="194.31" y1="80.01" x2="194.31" y2="82.55" width="0.1524" layer="91"/>
+<wire x1="196.85" y1="80.01" x2="194.31" y2="80.01" width="0.1524" layer="91"/>
+<pinref part="IC2" gate="IC" pin="VDD@3"/>
+<wire x1="196.85" y1="77.47" x2="194.31" y2="77.47" width="0.1524" layer="91"/>
+<pinref part="IC2" gate="IC" pin="VDD@4"/>
+<wire x1="196.85" y1="74.93" x2="194.31" y2="74.93" width="0.1524" layer="91"/>
+<pinref part="IC2" gate="IC" pin="VDD@5"/>
+<wire x1="196.85" y1="72.39" x2="194.31" y2="72.39" width="0.1524" layer="91"/>
+<pinref part="U$15" gate="G$1" pin="VCC-2"/>
+<wire x1="106.68" y1="43.18" x2="106.68" y2="41.91" width="0.1524" layer="91"/>
+<junction x="106.68" y="41.91"/>
+<junction x="106.68" y="41.91"/>
+<junction x="115.57" y="41.91"/>
+<junction x="194.31" y="82.55"/>
+<junction x="194.31" y="80.01"/>
+<junction x="194.31" y="77.47"/>
+<junction x="194.31" y="74.93"/>
+<junction x="194.31" y="72.39"/>
+<pinref part="C31" gate="G$1" pin="2"/>
+<wire x1="106.68" y1="41.91" x2="97.79" y2="41.91" width="0.1524" layer="91"/>
+<wire x1="97.79" y1="41.91" x2="97.79" y2="40.64" width="0.1524" layer="91"/>
+<pinref part="C34" gate="G$1" pin="2"/>
+<wire x1="194.31" y1="77.47" x2="125.73" y2="77.47" width="0.1524" layer="91"/>
+<wire x1="125.73" y1="77.47" x2="125.73" y2="68.58" width="0.1524" layer="91"/>
+<wire x1="125.73" y1="68.58" x2="125.73" y2="66.04" width="0.1524" layer="91"/>
+<pinref part="C7" gate="G$1" pin="2"/>
+<wire x1="125.73" y1="68.58" x2="116.84" y2="68.58" width="0.1524" layer="91"/>
+<wire x1="116.84" y1="68.58" x2="116.84" y2="66.04" width="0.1524" layer="91"/>
+<pinref part="C30" gate="G$1" pin="2"/>
+<wire x1="116.84" y1="68.58" x2="106.68" y2="68.58" width="0.1524" layer="91"/>
+<wire x1="106.68" y1="68.58" x2="106.68" y2="66.04" width="0.1524" layer="91"/>
+<pinref part="C33" gate="G$1" pin="2"/>
+<wire x1="106.68" y1="68.58" x2="97.79" y2="68.58" width="0.1524" layer="91"/>
+<wire x1="97.79" y1="68.58" x2="97.79" y2="66.04" width="0.1524" layer="91"/>
+<junction x="106.68" y="68.58"/>
+<junction x="116.84" y="68.58"/>
+<junction x="125.73" y="68.58"/>
+<pinref part="U$69" gate="G$1" pin="VCC-2"/>
+<wire x1="106.68" y1="71.12" x2="106.68" y2="68.58" width="0.1524" layer="91"/>
+<wire x1="106.68" y1="91.44" x2="152.4" y2="91.44" width="0.1524" layer="91"/>
+<wire x1="152.4" y1="91.44" x2="152.4" y2="80.01" width="0.1524" layer="91"/>
+<wire x1="152.4" y1="80.01" x2="194.31" y2="80.01" width="0.1524" layer="91"/>
+<junction x="97.79" y="91.44"/>
+<junction x="106.68" y="91.44"/>
+<pinref part="C45" gate="G$1" pin="2"/>
+<wire x1="106.68" y1="110.49" x2="106.68" y2="111.76" width="0.1524" layer="91"/>
+<pinref part="C11" gate="G$1" pin="2"/>
+<wire x1="106.68" y1="111.76" x2="115.57" y2="111.76" width="0.1524" layer="91"/>
+<wire x1="115.57" y1="111.76" x2="124.46" y2="111.76" width="0.1524" layer="91"/>
+<wire x1="124.46" y1="111.76" x2="133.35" y2="111.76" width="0.1524" layer="91"/>
+<wire x1="133.35" y1="111.76" x2="133.35" y2="110.49" width="0.1524" layer="91"/>
+<pinref part="C44" gate="G$1" pin="2"/>
+<wire x1="115.57" y1="110.49" x2="115.57" y2="111.76" width="0.1524" layer="91"/>
+<pinref part="C32" gate="G$1" pin="2"/>
+<wire x1="124.46" y1="110.49" x2="124.46" y2="111.76" width="0.1524" layer="91"/>
+<wire x1="194.31" y1="82.55" x2="156.21" y2="82.55" width="0.1524" layer="91"/>
+<wire x1="156.21" y1="82.55" x2="156.21" y2="111.76" width="0.1524" layer="91"/>
+<wire x1="156.21" y1="111.76" x2="133.35" y2="111.76" width="0.1524" layer="91"/>
+<junction x="133.35" y="111.76"/>
+<junction x="124.46" y="111.76"/>
+<junction x="115.57" y="111.76"/>
+<pinref part="C28" gate="G$1" pin="2"/>
+<wire x1="176.53" y1="55.88" x2="176.53" y2="57.15" width="0.1524" layer="91"/>
+<pinref part="C46" gate="G$1" pin="2"/>
+<wire x1="176.53" y1="57.15" x2="185.42" y2="57.15" width="0.1524" layer="91"/>
+<wire x1="185.42" y1="57.15" x2="194.31" y2="57.15" width="0.1524" layer="91"/>
+<wire x1="194.31" y1="57.15" x2="194.31" y2="55.88" width="0.1524" layer="91"/>
+<pinref part="C8" gate="G$1" pin="2"/>
+<wire x1="185.42" y1="55.88" x2="185.42" y2="57.15" width="0.1524" layer="91"/>
+<junction x="185.42" y="57.15"/>
+<wire x1="194.31" y1="69.85" x2="194.31" y2="57.15" width="0.1524" layer="91"/>
+<junction x="194.31" y="69.85"/>
+<junction x="194.31" y="57.15"/>
+<pinref part="C29" gate="G$1" pin="2"/>
+<wire x1="154.94" y1="71.12" x2="154.94" y2="72.39" width="0.1524" layer="91"/>
+<wire x1="154.94" y1="72.39" x2="163.83" y2="72.39" width="0.1524" layer="91"/>
+<pinref part="C6" gate="G$1" pin="2"/>
+<wire x1="163.83" y1="72.39" x2="163.83" y2="71.12" width="0.1524" layer="91"/>
+<wire x1="194.31" y1="72.39" x2="172.72" y2="72.39" width="0.1524" layer="91"/>
+<junction x="163.83" y="72.39"/>
+<pinref part="C52" gate="G$1" pin="2"/>
+<wire x1="172.72" y1="72.39" x2="163.83" y2="72.39" width="0.1524" layer="91"/>
+<wire x1="172.72" y1="71.12" x2="172.72" y2="72.39" width="0.1524" layer="91"/>
+<junction x="172.72" y="72.39"/>
+<pinref part="C54" gate="G$1" pin="1"/>
+<wire x1="194.31" y1="57.15" x2="203.2" y2="57.15" width="0.1524" layer="91"/>
+<wire x1="203.2" y1="57.15" x2="203.2" y2="55.88" width="0.1524" layer="91"/>
+<pinref part="C56" gate="G$1" pin="1"/>
+<wire x1="124.46" y1="40.64" x2="124.46" y2="41.91" width="0.1524" layer="91"/>
+<junction x="124.46" y="41.91"/>
+</segment>
+<segment>
+<pinref part="U$82" gate="G$1" pin="VCC-2"/>
+<wire x1="189.23" y1="165.1" x2="185.42" y2="165.1" width="0.1524" layer="91"/>
+<pinref part="C55" gate="G$1" pin="1"/>
+<wire x1="185.42" y1="166.37" x2="185.42" y2="165.1" width="0.1524" layer="91"/>
+<pinref part="IC1" gate="G$1" pin="VDD"/>
+<wire x1="182.88" y1="165.1" x2="185.42" y2="165.1" width="0.1524" layer="91"/>
+<junction x="185.42" y="165.1"/>
+</segment>
+<segment>
+<pinref part="C51" gate="G$1" pin="2"/>
+<wire x1="360.68" y1="260.35" x2="370.84" y2="260.35" width="0.1524" layer="91"/>
+<wire x1="370.84" y1="260.35" x2="379.73" y2="260.35" width="0.1524" layer="91"/>
+<wire x1="379.73" y1="260.35" x2="379.73" y2="259.08" width="0.1524" layer="91"/>
+<pinref part="C35" gate="G$1" pin="2"/>
+<wire x1="370.84" y1="260.35" x2="370.84" y2="259.08" width="0.1524" layer="91"/>
+<pinref part="C17" gate="G$1" pin="2"/>
+<wire x1="360.68" y1="260.35" x2="360.68" y2="259.08" width="0.1524" layer="91"/>
+<junction x="370.84" y="260.35"/>
+<pinref part="C53" gate="G$1" pin="2"/>
+<wire x1="360.68" y1="260.35" x2="351.79" y2="260.35" width="0.1524" layer="91"/>
+<wire x1="351.79" y1="260.35" x2="351.79" y2="259.08" width="0.1524" layer="91"/>
+<pinref part="U$19" gate="G$1" pin="VCC-2"/>
+<wire x1="351.79" y1="260.35" x2="335.28" y2="260.35" width="0.1524" layer="91"/>
+<wire x1="335.28" y1="260.35" x2="335.28" y2="261.62" width="0.1524" layer="91"/>
+<pinref part="T1" gate="G$1" pin="S"/>
+<wire x1="335.28" y1="245.11" x2="335.28" y2="260.35" width="0.1524" layer="91"/>
+<junction x="335.28" y="260.35"/>
+<junction x="360.68" y="260.35"/>
+<junction x="351.79" y="260.35"/>
+</segment>
+<segment>
+<pinref part="R2" gate="G$1" pin="2"/>
+<pinref part="U$86" gate="G$1" pin="VCC-2"/>
+<wire x1="365.76" y1="242.57" x2="365.76" y2="241.3" width="0.1524" layer="91"/>
+</segment>
+<segment>
+<pinref part="U$30" gate="G$1" pin="VCC-2"/>
+<pinref part="T2" gate="G$1" pin="S"/>
+<wire x1="68.58" y1="160.02" x2="72.39" y2="160.02" width="0.1524" layer="91"/>
+<pinref part="R17" gate="G$1" pin="1"/>
+<wire x1="72.39" y1="160.02" x2="73.66" y2="160.02" width="0.1524" layer="91"/>
+<wire x1="72.39" y1="157.48" x2="72.39" y2="160.02" width="0.1524" layer="91"/>
+<junction x="72.39" y="160.02"/>
+</segment>
+</net>
+<net name="N$24" class="0">
+<segment>
+<pinref part="D1" gate="G$1" pin="2"/>
+<pinref part="R8" gate="G$1" pin="2"/>
+<wire x1="119.38" y1="213.36" x2="120.65" y2="213.36" width="0.1524" layer="91"/>
+<pinref part="TP19" gate="G$1" pin="1"/>
+<wire x1="120.65" y1="213.36" x2="127" y2="213.36" width="0.1524" layer="91"/>
+<wire x1="120.65" y1="215.9" x2="120.65" y2="213.36" width="0.1524" layer="91"/>
+<junction x="120.65" y="213.36"/>
+</segment>
+</net>
+<net name="N$25" class="0">
+<segment>
+<pinref part="IC2" gate="IC" pin="VCAP_2"/>
+<pinref part="C12" gate="G$1" pin="2"/>
+<wire x1="267.97" y1="80.01" x2="279.4" y2="80.01" width="0.1524" layer="91"/>
+<wire x1="279.4" y1="80.01" x2="279.4" y2="78.74" width="0.1524" layer="91"/>
+</segment>
+</net>
+<net name="N$26" class="0">
+<segment>
+<pinref part="IC2" gate="IC" pin="VCAP_1"/>
+<pinref part="C13" gate="G$1" pin="2"/>
+<wire x1="267.97" y1="82.55" x2="288.29" y2="82.55" width="0.1524" layer="91"/>
+<wire x1="288.29" y1="82.55" x2="288.29" y2="78.74" width="0.1524" layer="91"/>
+</segment>
+</net>
+<net name="SW" class="0">
+<segment>
+<pinref part="L1" gate="G$1" pin="2"/>
+<pinref part="D6" gate="G$1" pin="1"/>
+<wire x1="54.61" y1="102.87" x2="63.5" y2="102.87" width="0.1524" layer="91"/>
+<pinref part="IC5" gate="G$1" pin="SW"/>
+<wire x1="63.5" y1="102.87" x2="64.77" y2="102.87" width="0.1524" layer="91"/>
+<wire x1="60.96" y1="91.44" x2="63.5" y2="91.44" width="0.1524" layer="91"/>
+<wire x1="63.5" y1="91.44" x2="63.5" y2="102.87" width="0.1524" layer="91"/>
+<junction x="63.5" y="102.87"/>
+</segment>
+</net>
+<net name="FB_RS" class="0">
+<segment>
+<pinref part="IC5" gate="G$1" pin="RS"/>
+<pinref part="R14" gate="G$1" pin="2"/>
+<wire x1="60.96" y1="76.2" x2="63.5" y2="76.2" width="0.1524" layer="91"/>
+<wire x1="63.5" y1="76.2" x2="63.5" y2="68.58" width="0.1524" layer="91"/>
+<pinref part="IC5" gate="G$1" pin="FB"/>
+<wire x1="63.5" y1="68.58" x2="63.5" y2="63.5" width="0.1524" layer="91"/>
+<wire x1="63.5" y1="63.5" x2="62.23" y2="63.5" width="0.1524" layer="91"/>
+<wire x1="40.64" y1="76.2" x2="39.37" y2="76.2" width="0.1524" layer="91"/>
+<wire x1="39.37" y1="76.2" x2="39.37" y2="68.58" width="0.1524" layer="91"/>
+<wire x1="39.37" y1="68.58" x2="63.5" y2="68.58" width="0.1524" layer="91"/>
+<junction x="63.5" y="68.58"/>
+</segment>
+</net>
+<net name="OVP" class="0">
+<segment>
+<pinref part="IC5" gate="G$1" pin="OVP"/>
+<wire x1="60.96" y1="86.36" x2="76.2" y2="86.36" width="0.1524" layer="91"/>
+<pinref part="R25" gate="G$1" pin="2"/>
+<wire x1="76.2" y1="88.9" x2="76.2" y2="86.36" width="0.1524" layer="91"/>
+<pinref part="R26" gate="G$1" pin="1"/>
+<wire x1="76.2" y1="86.36" x2="76.2" y2="83.82" width="0.1524" layer="91"/>
+<junction x="76.2" y="86.36"/>
+</segment>
+</net>
+<net name="CTRL" class="0">
+<segment>
+<pinref part="IC5" gate="G$1" pin="CTRL"/>
+<pinref part="R9" gate="G$1" pin="2"/>
+<wire x1="40.64" y1="86.36" x2="31.75" y2="86.36" width="0.1524" layer="91"/>
+<wire x1="31.75" y1="86.36" x2="26.67" y2="86.36" width="0.1524" layer="91"/>
+<pinref part="R10" gate="G$1" pin="2"/>
+<wire x1="26.67" y1="86.36" x2="26.67" y2="83.82" width="0.1524" layer="91"/>
+<junction x="31.75" y="86.36"/>
+<pinref part="TP6" gate="G$1" pin="1"/>
+<wire x1="31.75" y1="87.63" x2="31.75" y2="86.36" width="0.1524" layer="91"/>
+<wire x1="31.75" y1="83.82" x2="31.75" y2="86.36" width="0.1524" layer="91"/>
+</segment>
+</net>
+<net name="LEDK" class="0">
+<segment>
+<pinref part="IC5" gate="G$1" pin="LED"/>
+<wire x1="60.96" y1="81.28" x2="62.23" y2="81.28" width="0.1524" layer="91"/>
+<label x="63.5" y="81.28" size="1.778" layer="95" xref="yes"/>
+<pinref part="TP4" gate="G$1" pin="1"/>
+<wire x1="62.23" y1="81.28" x2="63.5" y2="81.28" width="0.1524" layer="91"/>
+<junction x="62.23" y="81.28"/>
+</segment>
+<segment>
+<pinref part="K4" gate="G$1" pin="LEDK"/>
+<wire x1="340.36" y1="100.33" x2="327.66" y2="100.33" width="0.1524" layer="91"/>
+<wire x1="327.66" y1="100.33" x2="327.66" y2="99.06" width="0.1524" layer="91"/>
+<wire x1="327.66" y1="99.06" x2="325.12" y2="99.06" width="0.1524" layer="91"/>
+<label x="325.12" y="99.06" size="1.778" layer="95" rot="R180" xref="yes"/>
+</segment>
+</net>
+<net name="LEDA" class="0">
+<segment>
+<pinref part="D6" gate="G$1" pin="2"/>
+<pinref part="C15" gate="G$1" pin="2"/>
+<wire x1="74.93" y1="102.87" x2="76.2" y2="102.87" width="0.1524" layer="91"/>
+<wire x1="76.2" y1="102.87" x2="81.28" y2="102.87" width="0.1524" layer="91"/>
+<wire x1="81.28" y1="102.87" x2="81.28" y2="90.17" width="0.1524" layer="91"/>
+<junction x="76.2" y="102.87"/>
+<pinref part="R25" gate="G$1" pin="1"/>
+<wire x1="76.2" y1="99.06" x2="76.2" y2="102.87" width="0.1524" layer="91"/>
+<wire x1="81.28" y1="102.87" x2="81.28" y2="107.95" width="0.1524" layer="91"/>
+<junction x="81.28" y="102.87"/>
+<label x="81.28" y="107.95" size="1.778" layer="95" rot="R90" xref="yes"/>
+<pinref part="TP7" gate="G$1" pin="1"/>
+<wire x1="76.2" y1="104.14" x2="76.2" y2="102.87" width="0.1524" layer="91"/>
+</segment>
+<segment>
+<pinref part="K4" gate="G$1" pin="LEDA"/>
+<wire x1="340.36" y1="102.87" x2="325.12" y2="102.87" width="0.1524" layer="91"/>
+<label x="325.12" y="102.87" size="1.778" layer="95" rot="R180" xref="yes"/>
+</segment>
+</net>
+<net name="PWM" class="0">
+<segment>
+<pinref part="R10" gate="G$1" pin="1"/>
+<wire x1="26.67" y1="73.66" x2="26.67" y2="72.39" width="0.1524" layer="91"/>
+<label x="26.67" y="72.39" size="1.778" layer="95" rot="R270" xref="yes"/>
+</segment>
+<segment>
+<pinref part="IC2" gate="IC" pin="PA7/SPI1_MOSI"/>
+<wire x1="196.85" y1="207.01" x2="195.58" y2="207.01" width="0.1524" layer="91"/>
+<label x="195.58" y="207.01" size="1.778" layer="95" rot="R180" xref="yes"/>
+</segment>
+</net>
+<net name="SWDIO" class="0">
+<segment>
+<pinref part="K5" gate="K" pin="SWDIO"/>
+<pinref part="IC2" gate="IC" pin="PA13/SWDIO"/>
+<wire x1="160.02" y1="186.69" x2="172.72" y2="186.69" width="0.1524" layer="91"/>
+<pinref part="TP1" gate="G$1" pin="1"/>
+<wire x1="172.72" y1="186.69" x2="196.85" y2="186.69" width="0.1524" layer="91"/>
+<wire x1="172.72" y1="189.23" x2="172.72" y2="186.69" width="0.1524" layer="91"/>
+<junction x="172.72" y="186.69"/>
+</segment>
+</net>
+<net name="SWCLK" class="0">
+<segment>
+<pinref part="K5" gate="K" pin="SWCLK"/>
+<pinref part="IC2" gate="IC" pin="PA14/SWCLK"/>
+<wire x1="160.02" y1="184.15" x2="179.07" y2="184.15" width="0.1524" layer="91"/>
+<pinref part="TP2" gate="G$1" pin="1"/>
+<wire x1="179.07" y1="184.15" x2="196.85" y2="184.15" width="0.1524" layer="91"/>
+<wire x1="179.07" y1="189.23" x2="179.07" y2="184.15" width="0.1524" layer="91"/>
+<junction x="179.07" y="184.15"/>
+</segment>
+</net>
+<net name="SWO" class="0">
+<segment>
+<pinref part="K5" gate="K" pin="SWO"/>
+<wire x1="160.02" y1="181.61" x2="191.77" y2="181.61" width="0.1524" layer="91"/>
+<wire x1="191.77" y1="181.61" x2="191.77" y2="168.91" width="0.1524" layer="91"/>
+<pinref part="IC2" gate="IC" pin="PB3/SWO"/>
+<wire x1="191.77" y1="168.91" x2="196.85" y2="168.91" width="0.1524" layer="91"/>
+<pinref part="TP8" gate="G$1" pin="1"/>
+<wire x1="191.77" y1="189.23" x2="191.77" y2="181.61" width="0.1524" layer="91"/>
+<junction x="191.77" y="181.61"/>
+</segment>
+</net>
+<net name="RST" class="0">
+<segment>
+<pinref part="IC2" gate="IC" pin="NRST"/>
+<pinref part="C20" gate="G$1" pin="2"/>
+<wire x1="196.85" y1="115.57" x2="195.58" y2="115.57" width="0.1524" layer="91"/>
+<wire x1="195.58" y1="115.57" x2="195.58" y2="118.11" width="0.1524" layer="91"/>
+<wire x1="195.58" y1="118.11" x2="181.61" y2="118.11" width="0.1524" layer="91"/>
+<wire x1="181.61" y1="118.11" x2="181.61" y2="116.84" width="0.1524" layer="91"/>
+<wire x1="181.61" y1="118.11" x2="166.37" y2="118.11" width="0.1524" layer="91"/>
+<wire x1="166.37" y1="118.11" x2="166.37" y2="165.1" width="0.1524" layer="91"/>
+<pinref part="K5" gate="K" pin="RST"/>
+<wire x1="166.37" y1="165.1" x2="166.37" y2="176.53" width="0.1524" layer="91"/>
+<wire x1="166.37" y1="176.53" x2="160.02" y2="176.53" width="0.1524" layer="91"/>
+<junction x="181.61" y="118.11"/>
+<pinref part="TP14" gate="G$1" pin="1"/>
+<wire x1="167.64" y1="189.23" x2="167.64" y2="176.53" width="0.1524" layer="91"/>
+<wire x1="167.64" y1="176.53" x2="166.37" y2="176.53" width="0.1524" layer="91"/>
+<junction x="166.37" y="176.53"/>
+<pinref part="IC1" gate="G$1" pin="RES"/>
+<wire x1="167.64" y1="165.1" x2="166.37" y2="165.1" width="0.1524" layer="91"/>
+<junction x="166.37" y="165.1"/>
+</segment>
+</net>
+<net name="VREF+" class="0">
+<segment>
+<pinref part="IC2" gate="IC" pin="VREF+"/>
+<wire x1="196.85" y1="102.87" x2="191.77" y2="102.87" width="0.1524" layer="91"/>
+<wire x1="191.77" y1="102.87" x2="191.77" y2="99.06" width="0.1524" layer="91"/>
+<pinref part="L2" gate="G$1" pin="2"/>
+<wire x1="191.77" y1="99.06" x2="185.42" y2="99.06" width="0.1524" layer="91"/>
+<pinref part="C21" gate="G$1" pin="2"/>
+<wire x1="185.42" y1="99.06" x2="177.8" y2="99.06" width="0.1524" layer="91"/>
+<wire x1="185.42" y1="97.79" x2="185.42" y2="99.06" width="0.1524" layer="91"/>
+<junction x="185.42" y="99.06"/>
+</segment>
+</net>
+<net name="DISP_DB8" class="0">
+<segment>
+<pinref part="IC2" gate="IC" pin="PE11"/>
+<wire x1="267.97" y1="102.87" x2="281.94" y2="102.87" width="0.1524" layer="91"/>
+<wire x1="281.94" y1="102.87" x2="281.94" y2="148.59" width="0.1524" layer="91"/>
+<pinref part="K4" gate="G$1" pin="DB8"/>
+<wire x1="281.94" y1="148.59" x2="340.36" y2="148.59" width="0.1524" layer="91"/>
+</segment>
+</net>
+<net name="DISP_DB7" class="0">
+<segment>
+<pinref part="IC2" gate="IC" pin="PE10"/>
+<wire x1="267.97" y1="105.41" x2="284.48" y2="105.41" width="0.1524" layer="91"/>
+<wire x1="284.48" y1="105.41" x2="284.48" y2="146.05" width="0.1524" layer="91"/>
+<pinref part="K4" gate="G$1" pin="DB7"/>
+<wire x1="284.48" y1="146.05" x2="340.36" y2="146.05" width="0.1524" layer="91"/>
+</segment>
+</net>
+<net name="DISP_DB6" class="0">
+<segment>
+<pinref part="IC2" gate="IC" pin="PE9"/>
+<wire x1="267.97" y1="107.95" x2="287.02" y2="107.95" width="0.1524" layer="91"/>
+<wire x1="287.02" y1="107.95" x2="287.02" y2="143.51" width="0.1524" layer="91"/>
+<pinref part="K4" gate="G$1" pin="DB6"/>
+<wire x1="287.02" y1="143.51" x2="340.36" y2="143.51" width="0.1524" layer="91"/>
+</segment>
+</net>
+<net name="DISP_DB5" class="0">
+<segment>
+<pinref part="IC2" gate="IC" pin="PE8"/>
+<wire x1="267.97" y1="110.49" x2="289.56" y2="110.49" width="0.1524" layer="91"/>
+<wire x1="289.56" y1="110.49" x2="289.56" y2="140.97" width="0.1524" layer="91"/>
+<pinref part="K4" gate="G$1" pin="DB5"/>
+<wire x1="289.56" y1="140.97" x2="340.36" y2="140.97" width="0.1524" layer="91"/>
+</segment>
+</net>
+<net name="DISP_DB4" class="0">
+<segment>
+<pinref part="IC2" gate="IC" pin="PE7"/>
+<wire x1="267.97" y1="113.03" x2="292.1" y2="113.03" width="0.1524" layer="91"/>
+<wire x1="292.1" y1="113.03" x2="292.1" y2="138.43" width="0.1524" layer="91"/>
+<pinref part="K4" gate="G$1" pin="DB4"/>
+<wire x1="292.1" y1="138.43" x2="340.36" y2="138.43" width="0.1524" layer="91"/>
+</segment>
+</net>
+<net name="DISP_DB3" class="0">
+<segment>
+<pinref part="IC2" gate="IC" pin="PD1"/>
+<wire x1="267.97" y1="173.99" x2="285.75" y2="173.99" width="0.1524" layer="91"/>
+<wire x1="285.75" y1="173.99" x2="285.75" y2="156.21" width="0.1524" layer="91"/>
+<wire x1="285.75" y1="156.21" x2="325.12" y2="156.21" width="0.1524" layer="91"/>
+<wire x1="325.12" y1="156.21" x2="325.12" y2="135.89" width="0.1524" layer="91"/>
+<pinref part="K4" gate="G$1" pin="DB3"/>
+<wire x1="325.12" y1="135.89" x2="340.36" y2="135.89" width="0.1524" layer="91"/>
+</segment>
+</net>
+<net name="DISP_DB2" class="0">
+<segment>
+<pinref part="IC2" gate="IC" pin="PD0"/>
+<wire x1="267.97" y1="176.53" x2="288.29" y2="176.53" width="0.1524" layer="91"/>
+<wire x1="288.29" y1="176.53" x2="288.29" y2="158.75" width="0.1524" layer="91"/>
+<wire x1="288.29" y1="158.75" x2="327.66" y2="158.75" width="0.1524" layer="91"/>
+<wire x1="327.66" y1="158.75" x2="327.66" y2="133.35" width="0.1524" layer="91"/>
+<pinref part="K4" gate="G$1" pin="DB2"/>
+<wire x1="327.66" y1="133.35" x2="340.36" y2="133.35" width="0.1524" layer="91"/>
+</segment>
+</net>
+<net name="DISP_DB1" class="0">
+<segment>
+<pinref part="IC2" gate="IC" pin="PD15"/>
+<wire x1="267.97" y1="138.43" x2="276.86" y2="138.43" width="0.1524" layer="91"/>
+<wire x1="276.86" y1="138.43" x2="276.86" y2="133.35" width="0.1524" layer="91"/>
+<wire x1="276.86" y1="133.35" x2="322.58" y2="133.35" width="0.1524" layer="91"/>
+<wire x1="322.58" y1="133.35" x2="322.58" y2="130.81" width="0.1524" layer="91"/>
+<pinref part="K4" gate="G$1" pin="DB1"/>
+<wire x1="322.58" y1="130.81" x2="340.36" y2="130.81" width="0.1524" layer="91"/>
+</segment>
+</net>
+<net name="DISP_DB0" class="0">
+<segment>
+<pinref part="IC2" gate="IC" pin="PD14"/>
+<wire x1="267.97" y1="140.97" x2="279.4" y2="140.97" width="0.1524" layer="91"/>
+<wire x1="279.4" y1="140.97" x2="279.4" y2="135.89" width="0.1524" layer="91"/>
+<wire x1="279.4" y1="135.89" x2="320.04" y2="135.89" width="0.1524" layer="91"/>
+<wire x1="320.04" y1="135.89" x2="320.04" y2="128.27" width="0.1524" layer="91"/>
+<pinref part="K4" gate="G$1" pin="DB0"/>
+<wire x1="320.04" y1="128.27" x2="340.36" y2="128.27" width="0.1524" layer="91"/>
+</segment>
+</net>
+<net name="DISP_!RD" class="0">
+<segment>
+<pinref part="K4" gate="G$1" pin="!RD"/>
+<wire x1="340.36" y1="123.19" x2="317.5" y2="123.19" width="0.1524" layer="91"/>
+<wire x1="317.5" y1="123.19" x2="317.5" y2="166.37" width="0.1524" layer="91"/>
+<pinref part="IC2" gate="IC" pin="PD4"/>
+<wire x1="317.5" y1="166.37" x2="267.97" y2="166.37" width="0.1524" layer="91"/>
+</segment>
+</net>
+<net name="DISP_!WR" class="0">
+<segment>
+<pinref part="K4" gate="G$1" pin="!WR"/>
+<wire x1="340.36" y1="120.65" x2="314.96" y2="120.65" width="0.1524" layer="91"/>
+<wire x1="314.96" y1="120.65" x2="314.96" y2="163.83" width="0.1524" layer="91"/>
+<pinref part="IC2" gate="IC" pin="PD5"/>
+<wire x1="314.96" y1="163.83" x2="267.97" y2="163.83" width="0.1524" layer="91"/>
+</segment>
+</net>
+<net name="DISP_RS" class="0">
+<segment>
+<pinref part="IC2" gate="IC" pin="PD11"/>
+<wire x1="267.97" y1="148.59" x2="273.05" y2="148.59" width="0.1524" layer="91"/>
+<wire x1="273.05" y1="148.59" x2="273.05" y2="118.11" width="0.1524" layer="91"/>
+<wire x1="273.05" y1="118.11" x2="340.36" y2="118.11" width="0.1524" layer="91"/>
+<pinref part="K4" gate="G$1" pin="RS"/>
+</segment>
+</net>
+<net name="DISP_!CS" class="0">
+<segment>
+<pinref part="IC2" gate="IC" pin="PD7"/>
+<wire x1="267.97" y1="158.75" x2="275.59" y2="158.75" width="0.1524" layer="91"/>
+<wire x1="275.59" y1="158.75" x2="275.59" y2="115.57" width="0.1524" layer="91"/>
+<pinref part="K4" gate="G$1" pin="!CS"/>
+<wire x1="275.59" y1="115.57" x2="340.36" y2="115.57" width="0.1524" layer="91"/>
+</segment>
+</net>
+<net name="DISP_FMARK" class="0">
+<segment>
+<pinref part="IC2" gate="IC" pin="PD12"/>
+<wire x1="267.97" y1="146.05" x2="270.51" y2="146.05" width="0.1524" layer="91"/>
+<wire x1="270.51" y1="146.05" x2="270.51" y2="120.65" width="0.1524" layer="91"/>
+<wire x1="270.51" y1="120.65" x2="312.42" y2="120.65" width="0.1524" layer="91"/>
+<wire x1="312.42" y1="120.65" x2="312.42" y2="110.49" width="0.1524" layer="91"/>
+<pinref part="K4" gate="G$1" pin="FMARK"/>
+<wire x1="312.42" y1="110.49" x2="340.36" y2="110.49" width="0.1524" layer="91"/>
+</segment>
+</net>
+<net name="DISP_!RESET" class="0">
+<segment>
+<pinref part="K4" gate="G$1" pin="!RESET"/>
+<wire x1="340.36" y1="153.67" x2="332.74" y2="153.67" width="0.1524" layer="91"/>
+<wire x1="332.74" y1="153.67" x2="332.74" y2="161.29" width="0.1524" layer="91"/>
+<wire x1="332.74" y1="161.29" x2="274.32" y2="161.29" width="0.1524" layer="91"/>
+<wire x1="274.32" y1="161.29" x2="274.32" y2="191.77" width="0.1524" layer="91"/>
+<pinref part="IC2" gate="IC" pin="PC14"/>
+<wire x1="274.32" y1="191.77" x2="267.97" y2="191.77" width="0.1524" layer="91"/>
+</segment>
+</net>
+<net name="SCL" class="0">
+<segment>
+<pinref part="K6" gate="G$1" pin="SCL"/>
+<wire x1="139.7" y1="151.13" x2="148.59" y2="151.13" width="0.1524" layer="91"/>
+<wire x1="148.59" y1="151.13" x2="160.02" y2="151.13" width="0.1524" layer="91"/>
+<wire x1="160.02" y1="151.13" x2="160.02" y2="161.29" width="0.1524" layer="91"/>
+<pinref part="IC2" gate="IC" pin="PB6"/>
+<pinref part="R15" gate="G$1" pin="1"/>
+<wire x1="160.02" y1="161.29" x2="196.85" y2="161.29" width="0.1524" layer="91"/>
+<wire x1="148.59" y1="154.94" x2="148.59" y2="151.13" width="0.1524" layer="91"/>
+<junction x="148.59" y="151.13"/>
+</segment>
+</net>
+<net name="SDA" class="0">
+<segment>
+<pinref part="K6" gate="G$1" pin="SDA"/>
+<wire x1="139.7" y1="148.59" x2="153.67" y2="148.59" width="0.1524" layer="91"/>
+<wire x1="153.67" y1="148.59" x2="162.56" y2="148.59" width="0.1524" layer="91"/>
+<wire x1="162.56" y1="148.59" x2="162.56" y2="158.75" width="0.1524" layer="91"/>
+<pinref part="IC2" gate="IC" pin="PB7"/>
+<pinref part="R16" gate="G$1" pin="1"/>
+<wire x1="162.56" y1="158.75" x2="196.85" y2="158.75" width="0.1524" layer="91"/>
+<wire x1="153.67" y1="154.94" x2="153.67" y2="148.59" width="0.1524" layer="91"/>
+<junction x="153.67" y="148.59"/>
+</segment>
+</net>
+<net name="EINT" class="0">
+<segment>
+<pinref part="R13" gate="G$1" pin="1"/>
+<pinref part="K6" gate="G$1" pin="EINT"/>
+<wire x1="139.7" y1="146.05" x2="152.4" y2="146.05" width="0.1524" layer="91"/>
+</segment>
+</net>
+<net name="REST" class="0">
+<segment>
+<pinref part="K6" gate="G$1" pin="REST"/>
+<wire x1="139.7" y1="143.51" x2="148.59" y2="143.51" width="0.1524" layer="91"/>
+<wire x1="148.59" y1="143.51" x2="148.59" y2="140.97" width="0.1524" layer="91"/>
+<wire x1="148.59" y1="140.97" x2="157.48" y2="140.97" width="0.1524" layer="91"/>
+<pinref part="R12" gate="G$1" pin="2"/>
+<wire x1="157.48" y1="138.43" x2="157.48" y2="140.97" width="0.1524" layer="91"/>
+<junction x="157.48" y="140.97"/>
+<wire x1="157.48" y1="140.97" x2="168.91" y2="140.97" width="0.1524" layer="91"/>
+<label x="168.91" y="140.97" size="1.778" layer="95" xref="yes"/>
+</segment>
+<segment>
+<pinref part="IC2" gate="IC" pin="PC5"/>
+<wire x1="267.97" y1="214.63" x2="274.32" y2="214.63" width="0.1524" layer="91"/>
+<wire x1="274.32" y1="214.63" x2="274.32" y2="233.68" width="0.1524" layer="91"/>
+<label x="274.32" y="233.68" size="1.778" layer="95" rot="R90" xref="yes"/>
+</segment>
+</net>
+<net name="DISP_VCC" class="0">
+<segment>
+<pinref part="K4" gate="G$1" pin="IOVCC"/>
+<wire x1="340.36" y1="113.03" x2="336.55" y2="113.03" width="0.1524" layer="91"/>
+<wire x1="336.55" y1="113.03" x2="336.55" y2="107.95" width="0.1524" layer="91"/>
+<pinref part="K4" gate="G$1" pin="VCI"/>
+<wire x1="340.36" y1="107.95" x2="336.55" y2="107.95" width="0.1524" layer="91"/>
+<pinref part="L4" gate="G$1" pin="1"/>
+<pinref part="C18" gate="G$1" pin="2"/>
+<wire x1="341.63" y1="78.74" x2="336.55" y2="78.74" width="0.1524" layer="91"/>
+<wire x1="336.55" y1="78.74" x2="336.55" y2="77.47" width="0.1524" layer="91"/>
+<wire x1="336.55" y1="107.95" x2="336.55" y2="78.74" width="0.1524" layer="91"/>
+<junction x="336.55" y="78.74"/>
+<junction x="336.55" y="107.95"/>
+<pinref part="C26" gate="G$1" pin="2"/>
+<wire x1="336.55" y1="78.74" x2="327.66" y2="78.74" width="0.1524" layer="91"/>
+<wire x1="327.66" y1="78.74" x2="327.66" y2="77.47" width="0.1524" layer="91"/>
+<pinref part="C47" gate="G$1" pin="2"/>
+<wire x1="327.66" y1="78.74" x2="318.77" y2="78.74" width="0.1524" layer="91"/>
+<wire x1="318.77" y1="78.74" x2="318.77" y2="77.47" width="0.1524" layer="91"/>
+<junction x="327.66" y="78.74"/>
+</segment>
+</net>
+<net name="SD_CD" class="0">
+<segment>
+<pinref part="IC2" gate="IC" pin="PC13"/>
+<wire x1="267.97" y1="194.31" x2="287.02" y2="194.31" width="0.1524" layer="91"/>
+<wire x1="287.02" y1="194.31" x2="287.02" y2="186.69" width="0.1524" layer="91"/>
+<wire x1="287.02" y1="186.69" x2="340.36" y2="186.69" width="0.1524" layer="91"/>
+<wire x1="340.36" y1="186.69" x2="340.36" y2="176.53" width="0.1524" layer="91"/>
+<pinref part="K3" gate="G$1" pin="CD"/>
+<wire x1="340.36" y1="176.53" x2="353.06" y2="176.53" width="0.1524" layer="91"/>
+<wire x1="353.06" y1="176.53" x2="353.06" y2="179.07" width="0.1524" layer="91"/>
+</segment>
+</net>
+<net name="DP" class="0">
+<segment>
+<pinref part="K1" gate="K" pin="DP1"/>
+<wire x1="40.64" y1="219.71" x2="33.02" y2="219.71" width="0.1524" layer="91"/>
+<label x="33.02" y="219.71" size="1.778" layer="95" rot="R180" xref="yes"/>
+</segment>
+<segment>
+<pinref part="K1" gate="K" pin="DP2"/>
+<wire x1="66.04" y1="217.17" x2="67.31" y2="217.17" width="0.1524" layer="91"/>
+<label x="67.31" y="217.17" size="1.778" layer="95" xref="yes"/>
+</segment>
+<segment>
+<pinref part="D3" gate="G$1" pin="I/O1"/>
+<wire x1="125.73" y1="198.12" x2="105.41" y2="198.12" width="0.1524" layer="91"/>
+<wire x1="125.73" y1="194.31" x2="125.73" y2="198.12" width="0.1524" layer="91"/>
+<junction x="125.73" y="198.12"/>
+<label x="105.41" y="198.12" size="1.778" layer="95" rot="R180" xref="yes"/>
+<wire x1="125.73" y1="198.12" x2="163.83" y2="198.12" width="0.1524" layer="91"/>
+<label x="163.83" y="198.12" size="1.778" layer="95" xref="yes"/>
+</segment>
+<segment>
+<pinref part="IC2" gate="IC" pin="PB15/OTG_HS_DP"/>
+<wire x1="196.85" y1="138.43" x2="193.04" y2="138.43" width="0.1524" layer="91"/>
+<label x="193.04" y="138.43" size="1.778" layer="95" rot="R180" xref="yes"/>
+</segment>
+</net>
+<net name="DN" class="0">
+<segment>
+<pinref part="K1" gate="K" pin="DN1"/>
+<wire x1="40.64" y1="217.17" x2="39.37" y2="217.17" width="0.1524" layer="91"/>
+<label x="39.37" y="217.17" size="1.778" layer="95" rot="R180" xref="yes"/>
+</segment>
+<segment>
+<pinref part="K1" gate="K" pin="DN2"/>
+<wire x1="66.04" y1="219.71" x2="77.47" y2="219.71" width="0.1524" layer="91"/>
+<label x="77.47" y="219.71" size="1.778" layer="95" xref="yes"/>
+</segment>
+<segment>
+<pinref part="D3" gate="G$1" pin="I/O2"/>
+<wire x1="128.27" y1="203.2" x2="105.41" y2="203.2" width="0.1524" layer="91"/>
+<wire x1="128.27" y1="194.31" x2="128.27" y2="203.2" width="0.1524" layer="91"/>
+<junction x="128.27" y="203.2"/>
+<label x="105.41" y="203.2" size="1.778" layer="95" rot="R180" xref="yes"/>
+<wire x1="128.27" y1="203.2" x2="163.83" y2="203.2" width="0.1524" layer="91"/>
+<label x="163.83" y="203.2" size="1.778" layer="95" xref="yes"/>
+</segment>
+<segment>
+<pinref part="IC2" gate="IC" pin="PB14/OTG_HS_DM"/>
+<wire x1="196.85" y1="140.97" x2="194.31" y2="140.97" width="0.1524" layer="91"/>
+<wire x1="194.31" y1="140.97" x2="194.31" y2="142.24" width="0.1524" layer="91"/>
+<wire x1="194.31" y1="142.24" x2="193.04" y2="142.24" width="0.1524" layer="91"/>
+<label x="193.04" y="142.24" size="1.778" layer="95" rot="R180" xref="yes"/>
+</segment>
+</net>
+<net name="VBUS" class="0">
+<segment>
+<pinref part="K1" gate="K" pin="VBUS"/>
+<wire x1="40.64" y1="224.79" x2="39.37" y2="224.79" width="0.1524" layer="91"/>
+<label x="39.37" y="224.79" size="1.778" layer="95" rot="R180" xref="yes"/>
+</segment>
+<segment>
+<pinref part="K1" gate="K" pin="VBUS@3"/>
+<wire x1="66.04" y1="224.79" x2="74.93" y2="224.79" width="0.1524" layer="91"/>
+<label x="74.93" y="224.79" size="1.778" layer="95" xref="yes"/>
+</segment>
+<segment>
+<pinref part="K1" gate="K" pin="VBUS@2"/>
+<wire x1="66.04" y1="212.09" x2="67.31" y2="212.09" width="0.1524" layer="91"/>
+<label x="67.31" y="212.09" size="1.778" layer="95" xref="yes"/>
+</segment>
+<segment>
+<pinref part="K1" gate="K" pin="VBUS@1"/>
+<wire x1="40.64" y1="212.09" x2="39.37" y2="212.09" width="0.1524" layer="91"/>
+<label x="39.37" y="212.09" size="1.778" layer="95" rot="R180" xref="yes"/>
+</segment>
+<segment>
+<pinref part="D3" gate="G$1" pin="VCC"/>
+<wire x1="118.11" y1="194.31" x2="118.11" y2="208.28" width="0.1524" layer="91"/>
+<wire x1="118.11" y1="208.28" x2="105.41" y2="208.28" width="0.1524" layer="91"/>
+<label x="105.41" y="208.28" size="1.778" layer="95" rot="R180" xref="yes"/>
+</segment>
+<segment>
+<pinref part="D1" gate="G$1" pin="1"/>
+<label x="105.41" y="213.36" size="1.778" layer="95" rot="R180" xref="yes"/>
+<wire x1="109.22" y1="213.36" x2="105.41" y2="213.36" width="0.1524" layer="91"/>
+</segment>
+</net>
+<net name="CC1" class="0">
+<segment>
+<pinref part="K1" gate="K" pin="CC1"/>
+<wire x1="40.64" y1="222.25" x2="27.94" y2="222.25" width="0.1524" layer="91"/>
+<label x="27.94" y="222.25" size="1.778" layer="95" rot="R180" xref="yes"/>
+</segment>
+<segment>
+<pinref part="R4" gate="G$1" pin="2"/>
+<wire x1="12.7" y1="147.32" x2="12.7" y2="152.4" width="0.1524" layer="91"/>
+<label x="12.7" y="152.4" size="1.778" layer="95" rot="R90" xref="yes"/>
+</segment>
+</net>
+<net name="CC2" class="0">
+<segment>
+<pinref part="K1" gate="K" pin="CC2"/>
+<wire x1="66.04" y1="214.63" x2="76.2" y2="214.63" width="0.1524" layer="91"/>
+<label x="76.2" y="214.63" size="1.778" layer="95" xref="yes"/>
+</segment>
+<segment>
+<pinref part="R5" gate="G$1" pin="2"/>
+<wire x1="20.32" y1="147.32" x2="20.32" y2="149.86" width="0.1524" layer="91"/>
+<label x="20.32" y="152.4" size="1.778" layer="95" rot="R90" xref="yes"/>
+<pinref part="TP20" gate="G$1" pin="1"/>
+<wire x1="20.32" y1="149.86" x2="20.32" y2="152.4" width="0.1524" layer="91"/>
+<wire x1="22.86" y1="149.86" x2="20.32" y2="149.86" width="0.1524" layer="91"/>
+<junction x="20.32" y="149.86"/>
+</segment>
+</net>
+<net name="SBU1" class="0">
+<segment>
+<pinref part="K1" gate="K" pin="SBU1"/>
+<wire x1="40.64" y1="214.63" x2="29.21" y2="214.63" width="0.1524" layer="91"/>
+<label x="29.21" y="214.63" size="1.778" layer="95" rot="R180" xref="yes"/>
+</segment>
+<segment>
+<pinref part="IC2" gate="IC" pin="PA2"/>
+<wire x1="196.85" y1="222.25" x2="194.31" y2="222.25" width="0.1524" layer="91"/>
+<wire x1="194.31" y1="222.25" x2="194.31" y2="229.87" width="0.1524" layer="91"/>
+<wire x1="194.31" y1="229.87" x2="189.23" y2="229.87" width="0.1524" layer="91"/>
+<label x="189.23" y="229.87" size="1.778" layer="95" rot="R180" xref="yes"/>
+</segment>
+<segment>
+<pinref part="D2" gate="G$1" pin="2"/>
+<wire x1="144.78" y1="236.22" x2="144.78" y2="240.03" width="0.1524" layer="91"/>
+<label x="144.78" y="240.03" size="1.778" layer="95" rot="R90" xref="yes"/>
+</segment>
+<segment>
+<pinref part="TP10" gate="G$1" pin="1"/>
+<wire x1="123.19" y1="241.3" x2="123.19" y2="237.49" width="0.1524" layer="91"/>
+<label x="123.19" y="237.49" size="1.778" layer="95" rot="R270" xref="yes"/>
+</segment>
+</net>
+<net name="SBU2" class="0">
+<segment>
+<pinref part="K1" gate="K" pin="SBU2"/>
+<wire x1="66.04" y1="222.25" x2="67.31" y2="222.25" width="0.1524" layer="91"/>
+<label x="67.31" y="222.25" size="1.778" layer="95" xref="yes"/>
+</segment>
+<segment>
+<pinref part="IC2" gate="IC" pin="PA3"/>
+<wire x1="196.85" y1="219.71" x2="193.04" y2="219.71" width="0.1524" layer="91"/>
+<wire x1="193.04" y1="219.71" x2="193.04" y2="226.06" width="0.1524" layer="91"/>
+<wire x1="193.04" y1="226.06" x2="189.23" y2="226.06" width="0.1524" layer="91"/>
+<label x="189.23" y="226.06" size="1.778" layer="95" rot="R180" xref="yes"/>
+</segment>
+<segment>
+<pinref part="D4" gate="G$1" pin="2"/>
+<wire x1="152.4" y1="236.22" x2="152.4" y2="240.03" width="0.1524" layer="91"/>
+<label x="152.4" y="240.03" size="1.778" layer="95" rot="R90" xref="yes"/>
+</segment>
+<segment>
+<pinref part="TP11" gate="G$1" pin="1"/>
+<wire x1="130.81" y1="241.3" x2="130.81" y2="237.49" width="0.1524" layer="91"/>
+<label x="130.81" y="237.49" size="1.778" layer="95" rot="R270" xref="yes"/>
+</segment>
+</net>
+<net name="N$2" class="0">
+<segment>
+<pinref part="R6" gate="G$1" pin="2"/>
+<pinref part="C1" gate="G$1" pin="2"/>
+<wire x1="31.75" y1="184.15" x2="31.75" y2="182.88" width="0.1524" layer="91"/>
+<wire x1="31.75" y1="184.15" x2="41.91" y2="184.15" width="0.1524" layer="91"/>
+<wire x1="41.91" y1="184.15" x2="41.91" y2="182.88" width="0.1524" layer="91"/>
+<pinref part="K1" gate="K" pin="SHIELD@3"/>
+<wire x1="58.42" y1="189.23" x2="58.42" y2="184.15" width="0.1524" layer="91"/>
+<wire x1="58.42" y1="184.15" x2="50.8" y2="184.15" width="0.1524" layer="91"/>
+<pinref part="K1" gate="K" pin="SHIELD@1"/>
+<wire x1="50.8" y1="184.15" x2="41.91" y2="184.15" width="0.1524" layer="91"/>
+<wire x1="50.8" y1="189.23" x2="50.8" y2="184.15" width="0.1524" layer="91"/>
+<junction x="50.8" y="184.15"/>
+<junction x="41.91" y="184.15"/>
+</segment>
+</net>
+<net name="N$3" class="0">
+<segment>
+<pinref part="R7" gate="G$1" pin="2"/>
+<pinref part="C25" gate="G$1" pin="2"/>
+<wire x1="63.5" y1="186.69" x2="63.5" y2="182.88" width="0.1524" layer="91"/>
+<wire x1="63.5" y1="186.69" x2="73.66" y2="186.69" width="0.1524" layer="91"/>
+<wire x1="73.66" y1="186.69" x2="73.66" y2="182.88" width="0.1524" layer="91"/>
+<pinref part="K1" gate="K" pin="SHIELD@2"/>
+<wire x1="63.5" y1="186.69" x2="55.88" y2="186.69" width="0.1524" layer="91"/>
+<wire x1="55.88" y1="186.69" x2="55.88" y2="189.23" width="0.1524" layer="91"/>
+<pinref part="K1" gate="K" pin="SHIELD"/>
+<wire x1="55.88" y1="186.69" x2="48.26" y2="186.69" width="0.1524" layer="91"/>
+<wire x1="48.26" y1="186.69" x2="48.26" y2="189.23" width="0.1524" layer="91"/>
+<junction x="55.88" y="186.69"/>
+<junction x="63.5" y="186.69"/>
+</segment>
+</net>
+<net name="N$4" class="0">
+<segment>
+<pinref part="R18" gate="G$1" pin="2"/>
+<pinref part="C36" gate="G$1" pin="1"/>
+<wire x1="290.83" y1="226.06" x2="290.83" y2="219.71" width="0.1524" layer="91"/>
+</segment>
+</net>
+<net name="N$6" class="0">
+<segment>
+<pinref part="R19" gate="G$1" pin="2"/>
+<pinref part="C37" gate="G$1" pin="1"/>
+<wire x1="299.72" y1="220.98" x2="299.72" y2="219.71" width="0.1524" layer="91"/>
+</segment>
+</net>
+<net name="N$7" class="0">
+<segment>
+<pinref part="R20" gate="G$1" pin="2"/>
+<pinref part="C38" gate="G$1" pin="1"/>
+<wire x1="306.07" y1="226.06" x2="306.07" y2="219.71" width="0.1524" layer="91"/>
+</segment>
+</net>
+<net name="N$13" class="0">
+<segment>
+<pinref part="R21" gate="G$1" pin="2"/>
+<pinref part="C39" gate="G$1" pin="1"/>
+<wire x1="312.42" y1="220.98" x2="312.42" y2="219.71" width="0.1524" layer="91"/>
+</segment>
+</net>
+<net name="N$16" class="0">
+<segment>
+<pinref part="R22" gate="G$1" pin="2"/>
+<pinref part="C40" gate="G$1" pin="1"/>
+<wire x1="318.77" y1="226.06" x2="318.77" y2="219.71" width="0.1524" layer="91"/>
+</segment>
+</net>
+<net name="N$17" class="0">
+<segment>
+<pinref part="R23" gate="G$1" pin="2"/>
+<pinref part="C43" gate="G$1" pin="1"/>
+<wire x1="325.12" y1="220.98" x2="325.12" y2="219.71" width="0.1524" layer="91"/>
+</segment>
+</net>
+<net name="HS_VBUS" class="0">
+<segment>
+<pinref part="R11" gate="G$1" pin="1"/>
+<pinref part="R1" gate="G$1" pin="1"/>
+<wire x1="173.99" y1="242.57" x2="175.26" y2="242.57" width="0.1524" layer="91"/>
+<wire x1="175.26" y1="242.57" x2="175.26" y2="241.3" width="0.1524" layer="91"/>
+<wire x1="175.26" y1="242.57" x2="177.8" y2="242.57" width="0.1524" layer="91"/>
+<junction x="175.26" y="242.57"/>
+<label x="177.8" y="242.57" size="1.778" layer="95" xref="yes"/>
+</segment>
+<segment>
+<pinref part="IC2" gate="IC" pin="PB13/OTG_HS_VBUS"/>
+<wire x1="196.85" y1="143.51" x2="195.58" y2="143.51" width="0.1524" layer="91"/>
+<wire x1="195.58" y1="143.51" x2="195.58" y2="146.05" width="0.1524" layer="91"/>
+<wire x1="195.58" y1="146.05" x2="193.04" y2="146.05" width="0.1524" layer="91"/>
+<label x="193.04" y="146.05" size="1.778" layer="95" rot="R180" xref="yes"/>
+</segment>
+</net>
+<net name="MCU_EINT" class="0">
+<segment>
+<pinref part="R13" gate="G$1" pin="2"/>
+<wire x1="162.56" y1="146.05" x2="168.91" y2="146.05" width="0.1524" layer="91"/>
+<wire x1="168.91" y1="146.05" x2="168.91" y2="154.94" width="0.1524" layer="91"/>
+<wire x1="168.91" y1="154.94" x2="175.26" y2="154.94" width="0.1524" layer="91"/>
+<label x="175.26" y="154.94" size="1.778" layer="95" xref="yes"/>
+</segment>
+<segment>
+<pinref part="IC2" gate="IC" pin="PC4"/>
+<wire x1="267.97" y1="217.17" x2="270.51" y2="217.17" width="0.1524" layer="91"/>
+<wire x1="270.51" y1="217.17" x2="270.51" y2="233.68" width="0.1524" layer="91"/>
+<label x="270.51" y="233.68" size="1.778" layer="95" rot="R90" xref="yes"/>
+</segment>
+</net>
+<net name="N$20" class="0">
+<segment>
+<pinref part="C27" gate="G$1" pin="2"/>
+<wire x1="350.52" y1="229.87" x2="350.52" y2="228.6" width="0.1524" layer="91"/>
+<wire x1="341.63" y1="229.87" x2="345.44" y2="229.87" width="0.1524" layer="91"/>
+<pinref part="C23" gate="G$1" pin="2"/>
+<wire x1="345.44" y1="229.87" x2="350.52" y2="229.87" width="0.1524" layer="91"/>
+<wire x1="341.63" y1="228.6" x2="341.63" y2="229.87" width="0.1524" layer="91"/>
+<pinref part="K3" gate="G$1" pin="VDD"/>
+<pinref part="T1" gate="G$1" pin="D"/>
+<wire x1="337.82" y1="199.39" x2="335.28" y2="199.39" width="0.1524" layer="91"/>
+<wire x1="335.28" y1="199.39" x2="335.28" y2="229.87" width="0.1524" layer="91"/>
+<wire x1="335.28" y1="229.87" x2="335.28" y2="234.95" width="0.1524" layer="91"/>
+<wire x1="341.63" y1="229.87" x2="335.28" y2="229.87" width="0.1524" layer="91"/>
+<junction x="341.63" y="229.87"/>
+<junction x="335.28" y="229.87"/>
+<pinref part="C22" gate="G$1" pin="2"/>
+<wire x1="350.52" y1="229.87" x2="358.14" y2="229.87" width="0.1524" layer="91"/>
+<wire x1="358.14" y1="229.87" x2="358.14" y2="228.6" width="0.1524" layer="91"/>
+<junction x="350.52" y="229.87"/>
+<pinref part="TP15" gate="G$1" pin="1"/>
+<wire x1="350.52" y1="231.14" x2="350.52" y2="229.87" width="0.1524" layer="91"/>
+<pinref part="C48" gate="G$1" pin="1"/>
+<wire x1="345.44" y1="231.14" x2="345.44" y2="229.87" width="0.1524" layer="91"/>
+<junction x="345.44" y="229.87"/>
+</segment>
+</net>
+<net name="N$23" class="0">
+<segment>
+<pinref part="R2" gate="G$1" pin="1"/>
+<pinref part="C57" gate="G$1" pin="2"/>
+<wire x1="365.76" y1="228.6" x2="365.76" y2="229.87" width="0.1524" layer="91"/>
+<pinref part="T1" gate="G$1" pin="G"/>
+<wire x1="365.76" y1="229.87" x2="365.76" y2="231.14" width="0.1524" layer="91"/>
+<wire x1="342.9" y1="242.57" x2="345.44" y2="242.57" width="0.1524" layer="91"/>
+<wire x1="345.44" y1="242.57" x2="363.22" y2="242.57" width="0.1524" layer="91"/>
+<wire x1="363.22" y1="242.57" x2="363.22" y2="229.87" width="0.1524" layer="91"/>
+<wire x1="363.22" y1="229.87" x2="365.76" y2="229.87" width="0.1524" layer="91"/>
+<pinref part="R3" gate="G$1" pin="2"/>
+<wire x1="368.3" y1="229.87" x2="365.76" y2="229.87" width="0.1524" layer="91"/>
+<junction x="365.76" y="229.87"/>
+<pinref part="C48" gate="G$1" pin="2"/>
+<wire x1="345.44" y1="241.3" x2="345.44" y2="242.57" width="0.1524" layer="91"/>
+<junction x="345.44" y="242.57"/>
+</segment>
+</net>
+<net name="SD_ON" class="0">
+<segment>
+<wire x1="280.67" y1="227.33" x2="280.67" y2="233.68" width="0.1524" layer="91"/>
+<label x="280.67" y="233.68" size="1.778" layer="95" rot="R90" xref="yes"/>
+<pinref part="IC2" gate="IC" pin="PC0"/>
+<wire x1="267.97" y1="227.33" x2="280.67" y2="227.33" width="0.1524" layer="91"/>
+</segment>
+<segment>
+<pinref part="R3" gate="G$1" pin="1"/>
+<wire x1="378.46" y1="229.87" x2="379.73" y2="229.87" width="0.1524" layer="91"/>
+<wire x1="379.73" y1="229.87" x2="379.73" y2="222.25" width="0.1524" layer="91"/>
+<label x="379.73" y="222.25" size="1.778" layer="95" rot="R270" xref="yes"/>
+</segment>
+</net>
+<net name="N$1" class="0">
+<segment>
+<pinref part="T2" gate="G$1" pin="D"/>
+<pinref part="L3" gate="G$1" pin="1"/>
+<wire x1="83.82" y1="160.02" x2="85.09" y2="160.02" width="0.1524" layer="91"/>
+<pinref part="C58" gate="G$1" pin="2"/>
+<wire x1="85.09" y1="157.48" x2="85.09" y2="160.02" width="0.1524" layer="91"/>
+<wire x1="85.09" y1="160.02" x2="88.9" y2="160.02" width="0.1524" layer="91"/>
+<junction x="85.09" y="160.02"/>
+</segment>
+</net>
+<net name="TOUCH_ON" class="0">
+<segment>
+<wire x1="93.98" y1="140.97" x2="93.98" y2="143.51" width="0.1524" layer="91"/>
+<label x="93.98" y="140.97" size="1.778" layer="95" rot="R270" xref="yes"/>
+<pinref part="R24" gate="G$1" pin="2"/>
+<wire x1="93.98" y1="143.51" x2="91.44" y2="143.51" width="0.1524" layer="91"/>
+</segment>
+<segment>
+<pinref part="IC2" gate="IC" pin="PB10"/>
+<wire x1="196.85" y1="151.13" x2="193.04" y2="151.13" width="0.1524" layer="91"/>
+<label x="193.04" y="151.13" size="1.778" layer="95" rot="R180" xref="yes"/>
+</segment>
+</net>
+<net name="VDD" class="0">
+<segment>
+<pinref part="C24" gate="G$1" pin="2"/>
+<wire x1="109.22" y1="160.02" x2="109.22" y2="158.75" width="0.1524" layer="91"/>
+<pinref part="K6" gate="G$1" pin="VDD"/>
+<wire x1="140.97" y1="160.02" x2="140.97" y2="153.67" width="0.1524" layer="91"/>
+<wire x1="140.97" y1="153.67" x2="139.7" y2="153.67" width="0.1524" layer="91"/>
+<wire x1="109.22" y1="160.02" x2="118.11" y2="160.02" width="0.1524" layer="91"/>
+<pinref part="C49" gate="G$1" pin="2"/>
+<wire x1="118.11" y1="160.02" x2="140.97" y2="160.02" width="0.1524" layer="91"/>
+<wire x1="118.11" y1="158.75" x2="118.11" y2="160.02" width="0.1524" layer="91"/>
+<junction x="118.11" y="160.02"/>
+<pinref part="L3" gate="G$1" pin="2"/>
+<pinref part="C19" gate="G$1" pin="2"/>
+<wire x1="99.06" y1="160.02" x2="100.33" y2="160.02" width="0.1524" layer="91"/>
+<wire x1="100.33" y1="160.02" x2="100.33" y2="158.75" width="0.1524" layer="91"/>
+<wire x1="100.33" y1="160.02" x2="109.22" y2="160.02" width="0.1524" layer="91"/>
+<junction x="100.33" y="160.02"/>
+<junction x="109.22" y="160.02"/>
+<pinref part="R16" gate="G$1" pin="2"/>
+<wire x1="153.67" y1="165.1" x2="153.67" y2="166.37" width="0.1524" layer="91"/>
+<wire x1="153.67" y1="166.37" x2="148.59" y2="166.37" width="0.1524" layer="91"/>
+<wire x1="148.59" y1="166.37" x2="140.97" y2="166.37" width="0.1524" layer="91"/>
+<wire x1="140.97" y1="166.37" x2="140.97" y2="160.02" width="0.1524" layer="91"/>
+<junction x="140.97" y="160.02"/>
+<junction x="148.59" y="166.37"/>
+<pinref part="R15" gate="G$1" pin="2"/>
+<wire x1="148.59" y1="165.1" x2="148.59" y2="166.37" width="0.1524" layer="91"/>
+<pinref part="U$51" gate="G$1" pin="VBAT"/>
+<wire x1="109.22" y1="162.56" x2="109.22" y2="160.02" width="0.1524" layer="91"/>
+<pinref part="TP16" gate="G$1" pin="1"/>
+<wire x1="118.11" y1="161.29" x2="118.11" y2="160.02" width="0.1524" layer="91"/>
+</segment>
+<segment>
+<pinref part="U$52" gate="G$1" pin="VBAT"/>
+<pinref part="R12" gate="G$1" pin="1"/>
+<wire x1="157.48" y1="128.27" x2="157.48" y2="127" width="0.1524" layer="91"/>
+</segment>
+</net>
+<net name="N$27" class="0">
+<segment>
+<pinref part="R17" gate="G$1" pin="2"/>
+<wire x1="72.39" y1="147.32" x2="72.39" y2="143.51" width="0.1524" layer="91"/>
+<wire x1="72.39" y1="143.51" x2="76.2" y2="143.51" width="0.1524" layer="91"/>
+<pinref part="T2" gate="G$1" pin="G"/>
+<pinref part="R24" gate="G$1" pin="1"/>
+<wire x1="76.2" y1="143.51" x2="76.2" y2="152.4" width="0.1524" layer="91"/>
+<wire x1="76.2" y1="143.51" x2="78.74" y2="143.51" width="0.1524" layer="91"/>
+<pinref part="C50" gate="G$1" pin="2"/>
+<wire x1="78.74" y1="143.51" x2="81.28" y2="143.51" width="0.1524" layer="91"/>
+<wire x1="76.2" y1="142.24" x2="76.2" y2="143.51" width="0.1524" layer="91"/>
+<junction x="76.2" y="143.51"/>
+<pinref part="C58" gate="G$1" pin="1"/>
+<wire x1="85.09" y1="147.32" x2="85.09" y2="146.05" width="0.1524" layer="91"/>
+<wire x1="85.09" y1="146.05" x2="78.74" y2="146.05" width="0.1524" layer="91"/>
+<wire x1="78.74" y1="146.05" x2="78.74" y2="143.51" width="0.1524" layer="91"/>
+<junction x="78.74" y="143.51"/>
+</segment>
+</net>
+</nets>
+</sheet>
+</sheets>
+</schematic>
+</drawing>
+</eagle>


### PR DESCRIPTION
We already have schmatics in the repo, but it's only the exported PNG version. Eagle files would make it easier to work with it.

The version matches the currently produced version 13.