### PR TITLE
xmr: fix new transaction type for CLSAG, HF=13

### DIFF
--- a/core/src/apps/monero/signing/__init__.py
+++ b/core/src/apps/monero/signing/__init__.py
@@ -20,3 +20,4 @@ class RctType:
     """
 
     Bulletproof2 = 4
+    CLSAG = 5

--- a/core/src/apps/monero/signing/state.py
+++ b/core/src/apps/monero/signing/state.py
@@ -71,6 +71,7 @@ class State:
 
         self.output_change = None
         self.fee = 0
+        self.tx_type = 0
 
         # wallet sub-address major index
         self.account_idx = 0

--- a/core/src/apps/monero/signing/step_01_init_transaction.py
+++ b/core/src/apps/monero/signing/step_01_init_transaction.py
@@ -68,6 +68,10 @@ async def init_transaction(
     if tsx_data.hard_fork:
         state.hard_fork = tsx_data.hard_fork
 
+    state.tx_type = (
+        signing.RctType.CLSAG if state.hard_fork >= 13 else signing.RctType.Bulletproof2
+    )
+
     # Ensure change is correct
     _check_change(state, tsx_data.outputs)
 
@@ -92,7 +96,7 @@ async def init_transaction(
 
     # Final message hasher
     state.full_message_hasher.init()
-    state.full_message_hasher.set_type_fee(signing.RctType.Bulletproof2, state.fee)
+    state.full_message_hasher.set_type_fee(state.tx_type, state.fee)
 
     # Sub address precomputation
     if tsx_data.account is not None and tsx_data.minor_indices:

--- a/core/src/apps/monero/signing/step_07_all_outputs_set.py
+++ b/core/src/apps/monero/signing/step_07_all_outputs_set.py
@@ -9,7 +9,6 @@ import gc
 from trezor import utils
 
 from apps.monero.layout import confirms
-from apps.monero.signing import RctType
 from apps.monero.xmr import crypto
 
 from .state import State
@@ -56,7 +55,7 @@ async def all_outputs_set(state: State) -> MoneroTransactionAllOutSetAck:
 
     # Initializes RCTsig structure (fee, tx prefix hash, type)
     rv_pb = MoneroRingCtSig(
-        txn_fee=state.fee, message=state.tx_prefix_hash, rv_type=RctType.Bulletproof2,
+        txn_fee=state.fee, message=state.tx_prefix_hash, rv_type=state.tx_type,
     )
 
     _out_pk(state)

--- a/core/src/apps/monero/signing/step_09_sign_input.py
+++ b/core/src/apps/monero/signing/step_09_sign_input.py
@@ -174,6 +174,7 @@ async def sign_input(
     state.mem_trace(4, True)
 
     from apps.monero.xmr import mlsag
+    from apps.monero import signing
 
     mg_buffer = []
     ring_pubkeys = [x.key for x in src_entr.outputs if x]
@@ -182,7 +183,7 @@ async def sign_input(
 
     state.mem_trace(5, True)
 
-    if state.hard_fork and state.hard_fork >= 13:
+    if state.tx_type == signing.RctType.CLSAG:
         state.mem_trace("CLSAG")
         mlsag.generate_clsag_simple(
             state.full_message,


### PR DESCRIPTION
- Changes required to make CLSAG working.
- Transaction type was not set accordingly
- Related to the https://github.com/monero-project/monero/pull/6798
- New binary tests testing both HF=12 and HF=13: https://github.com/ph4r05/monero/releases/tag/v16.0.0.0-tests-u18.04-01