### PR TITLE
coininfo: Add Decred Simnet params.

### DIFF
--- a/core/src/apps/common/coininfo.py
+++ b/core/src/apps/common/coininfo.py
@@ -607,6 +607,32 @@ def by_name(name: str) -> CoinInfo:
                 overwintered=False,
                 confidential_assets=None,
             )
+        elif name == "Decred Simnet":
+            return CoinInfo(
+                coin_name=name,
+                coin_shortcut="SDCR",
+                decimals=8,
+                address_type=3729,
+                address_type_p2sh=5180,
+                maxfee_kb=10000000,
+                signed_message_header="Decred Signed Message:\n",
+                xpub_magic=0x0420bd3d,
+                xpub_magic_segwit_p2sh=None,
+                xpub_magic_segwit_native=None,
+                bech32_prefix=None,
+                cashaddr_prefix=None,
+                slip44=1,
+                segwit=False,
+                fork_id=None,
+                force_bip143=False,
+                decred=True,
+                negative_fee=False,
+                curve_name='secp256k1-decred',
+                extra_data=False,
+                timestamp=False,
+                overwintered=False,
+                confidential_assets=None,
+            )
         elif name == "DigiByte":
             return CoinInfo(
                 coin_name=name,


### PR DESCRIPTION
Adds simnet parameters for decred.

For some reason these changes are not persistant when building, they get copied over. Will mark as ready when I figure out why...