### PR TITLE
Allow host to specify commitment data in TxInputType

### DIFF
--- a/common/protob/messages-bitcoin.proto
+++ b/common/protob/messages-bitcoin.proto
@@ -240,6 +240,7 @@ message TxAck {
             // optional uint32 prev_block_height_bip115 = 12;  // BIP-115 support dropped
             optional bytes witness = 13;                                        // witness data, only set for EXTERNAL inputs
             optional bytes ownership_proof = 14;                                // SLIP-0019 proof of ownership, only set for EXTERNAL inputs
+            optional bytes commitment_data = 15;                                // optional commitment data for the SLIP-0019 proof of ownership
 
         }
         /**

--- a/core/src/apps/bitcoin/ownership.py
+++ b/core/src/apps/bitcoin/ownership.py
@@ -66,7 +66,7 @@ def generate_proof(
 def verify_nonownership(
     proof: bytes,
     script_pubkey: bytes,
-    commitment_data: bytes,
+    commitment_data: Optional[bytes],
     keychain: Keychain,
     coin: CoinInfo,
 ) -> bool:
@@ -92,7 +92,8 @@ def verify_nonownership(
         proof_body = proof[: r.offset]
         sighash = hashlib.sha256(proof_body)
         sighash.update(script_pubkey)
-        sighash.update(commitment_data)
+        if commitment_data:
+            sighash.update(commitment_data)
         script_sig, witness = read_bip322_signature_proof(r)
 
         # We don't call verifier.ensure_hash_type() to avoid possible compatibility

--- a/core/src/apps/bitcoin/sign_tx/bitcoin.py
+++ b/core/src/apps/bitcoin/sign_tx/bitcoin.py
@@ -245,7 +245,11 @@ class Bitcoin:
     ) -> None:
         if txi.ownership_proof:
             if not verify_nonownership(
-                txi.ownership_proof, script_pubkey, bytes(), self.keychain, self.coin
+                txi.ownership_proof,
+                script_pubkey,
+                txi.commitment_data,
+                self.keychain,
+                self.coin,
             ):
                 raise wire.DataError("Invalid external input")
         else:

--- a/core/src/apps/bitcoin/sign_tx/helpers.py
+++ b/core/src/apps/bitcoin/sign_tx/helpers.py
@@ -276,6 +276,8 @@ def sanitize_tx_input(tx: TransactionType, coin: CoinInfo) -> TxInputType:
     if txi.script_type in common.SEGWIT_INPUT_SCRIPT_TYPES or txi.witness is not None:
         if not coin.segwit:
             raise wire.DataError("Segwit not enabled on this coin")
+    if txi.commitment_data and not txi.ownership_proof:
+        raise wire.DataError("commitment_data field provided but not expected.")
     return txi
 
 

--- a/core/src/trezor/messages/TxInputType.py
+++ b/core/src/trezor/messages/TxInputType.py
@@ -28,6 +28,7 @@ class TxInputType(p.MessageType):
         decred_tree: int = None,
         witness: bytes = None,
         ownership_proof: bytes = None,
+        commitment_data: bytes = None,
     ) -> None:
         self.address_n = address_n if address_n is not None else []
         self.prev_hash = prev_hash
@@ -40,6 +41,7 @@ class TxInputType(p.MessageType):
         self.decred_tree = decred_tree
         self.witness = witness
         self.ownership_proof = ownership_proof
+        self.commitment_data = commitment_data
 
     @classmethod
     def get_fields(cls) -> Dict:
@@ -55,4 +57,5 @@ class TxInputType(p.MessageType):
             9: ('decred_tree', p.UVarintType, 0),
             13: ('witness', p.BytesType, 0),
             14: ('ownership_proof', p.BytesType, 0),
+            15: ('commitment_data', p.BytesType, 0),
         }

--- a/legacy/firmware/protob/messages-bitcoin.options
+++ b/legacy/firmware/protob/messages-bitcoin.options
@@ -33,6 +33,7 @@ TxInputType.prev_hash                                       max_size:32
 TxInputType.script_sig                                      max_size:1650
 TxInputType.witness                                         max_size:109
 TxInputType.ownership_proof                                 max_size:171
+TxInputType.commitment_data                                 max_size:32
 
 TxOutputType.address                                        max_size:130
 TxOutputType.address_n                                      max_count:8

--- a/python/src/trezorlib/messages/TxInputType.py
+++ b/python/src/trezorlib/messages/TxInputType.py
@@ -28,6 +28,7 @@ class TxInputType(p.MessageType):
         decred_tree: int = None,
         witness: bytes = None,
         ownership_proof: bytes = None,
+        commitment_data: bytes = None,
     ) -> None:
         self.address_n = address_n if address_n is not None else []
         self.prev_hash = prev_hash
@@ -40,6 +41,7 @@ class TxInputType(p.MessageType):
         self.decred_tree = decred_tree
         self.witness = witness
         self.ownership_proof = ownership_proof
+        self.commitment_data = commitment_data
 
     @classmethod
     def get_fields(cls) -> Dict:
@@ -55,4 +57,5 @@ class TxInputType(p.MessageType):
             9: ('decred_tree', p.UVarintType, 0),
             13: ('witness', p.BytesType, 0),
             14: ('ownership_proof', p.BytesType, 0),
+            15: ('commitment_data', p.BytesType, 0),
         }

--- a/tests/device_tests/test_msg_authorize_coinjoin.py
+++ b/tests/device_tests/test_msg_authorize_coinjoin.py
@@ -43,6 +43,8 @@ pytestmark = pytest.mark.skip_t1
 
 @pytest.mark.setup_client(pin=PIN)
 def test_sign_tx(client):
+    commitment_data = b"www.example.com" + (1).to_bytes(ROUND_ID_LEN, "big")
+
     with client:
         client.use_pin_sequence([PIN])
         btc.authorize_coinjoin(
@@ -67,7 +69,7 @@ def test_sign_tx(client):
             parse_path("84'/1'/0'/1/0"),
             script_type=messages.InputScriptType.SPENDWITNESS,
             user_confirmation=True,
-            commitment_data=b"www.example.com" + (1).to_bytes(ROUND_ID_LEN, "big"),
+            commitment_data=commitment_data,
             preauthorized=True,
         )
 
@@ -81,7 +83,7 @@ def test_sign_tx(client):
             parse_path("84'/1'/0'/1/5"),
             script_type=messages.InputScriptType.SPENDWITNESS,
             user_confirmation=True,
-            commitment_data=b"www.example.com" + (1).to_bytes(ROUND_ID_LEN, "big"),
+            commitment_data=commitment_data,
             preauthorized=True,
         )
 
@@ -94,8 +96,9 @@ def test_sign_tx(client):
         prev_index=0,
         script_type=messages.InputScriptType.EXTERNAL,
         ownership_proof=bytearray.fromhex(
-            "534c001900016b2055d8190244b2ed2d46513c40658a574d3bc2deb6969c0535bb818b44d2c40002483045022100d4ad0374c922848c71d913fba59c81b9075e0d33e884d953f0c4b4806b8ffd0c022024740e6717a2b6a5aa03148c3a28b02c713b4e30fc8aeae67fa69eb20e8ddcd9012103505f0d82bbdd251511591b34f36ad5eea37d3220c2b81a1189084431ddb3aa3d"
+            "534c001900016b2055d8190244b2ed2d46513c40658a574d3bc2deb6969c0535bb818b44d2c40002473044022072b4376c1b6c9e9e4d45158e1b6b4edfbe7b2292d8b4a60e8b0d273bcfef6b4a0220786169ab42a7663cb7d5f27ecb468da76dc2d1b7a10d1d18fbe5120e7890b9d2012103505f0d82bbdd251511591b34f36ad5eea37d3220c2b81a1189084431ddb3aa3d"
         ),
+        commitment_data=commitment_data,
     )
     inp2 = messages.TxInputType(
         address_n=parse_path("84'/1'/0'/1/0"),
@@ -227,8 +230,9 @@ def test_unfair_fee(client):
         prev_index=0,
         script_type=messages.InputScriptType.EXTERNAL,
         ownership_proof=bytearray.fromhex(
-            "534c001900016b2055d8190244b2ed2d46513c40658a574d3bc2deb6969c0535bb818b44d2c40002483045022100d4ad0374c922848c71d913fba59c81b9075e0d33e884d953f0c4b4806b8ffd0c022024740e6717a2b6a5aa03148c3a28b02c713b4e30fc8aeae67fa69eb20e8ddcd9012103505f0d82bbdd251511591b34f36ad5eea37d3220c2b81a1189084431ddb3aa3d"
+            "534c001900016b2055d8190244b2ed2d46513c40658a574d3bc2deb6969c0535bb818b44d2c40002473044022072b4376c1b6c9e9e4d45158e1b6b4edfbe7b2292d8b4a60e8b0d273bcfef6b4a0220786169ab42a7663cb7d5f27ecb468da76dc2d1b7a10d1d18fbe5120e7890b9d2012103505f0d82bbdd251511591b34f36ad5eea37d3220c2b81a1189084431ddb3aa3d"
         ),
+        commitment_data=b"www.example.org" + (1).to_bytes(ROUND_ID_LEN, "big"),
     )
     inp2 = messages.TxInputType(
         address_n=parse_path("84'/1'/0'/1/0"),
@@ -303,8 +307,9 @@ def test_no_anonymity(client):
         prev_index=0,
         script_type=messages.InputScriptType.EXTERNAL,
         ownership_proof=bytearray.fromhex(
-            "534c001900016b2055d8190244b2ed2d46513c40658a574d3bc2deb6969c0535bb818b44d2c40002483045022100d4ad0374c922848c71d913fba59c81b9075e0d33e884d953f0c4b4806b8ffd0c022024740e6717a2b6a5aa03148c3a28b02c713b4e30fc8aeae67fa69eb20e8ddcd9012103505f0d82bbdd251511591b34f36ad5eea37d3220c2b81a1189084431ddb3aa3d"
+            "534c001900016b2055d8190244b2ed2d46513c40658a574d3bc2deb6969c0535bb818b44d2c40002473044022072b4376c1b6c9e9e4d45158e1b6b4edfbe7b2292d8b4a60e8b0d273bcfef6b4a0220786169ab42a7663cb7d5f27ecb468da76dc2d1b7a10d1d18fbe5120e7890b9d2012103505f0d82bbdd251511591b34f36ad5eea37d3220c2b81a1189084431ddb3aa3d"
         ),
+        commitment_data=b"www.example.org" + (1).to_bytes(ROUND_ID_LEN, "big"),
     )
     inp2 = messages.TxInputType(
         address_n=parse_path("84'/1'/0'/1/0"),


### PR DESCRIPTION
When proving non-ownership of an input we need to allow the host to specify the commitment data that was used to create the ownership proof. This PR adds the new field to `TxInputType` and uses it in `authorize_coinjoin` tests.