### PR TITLE
Solve the problem of failure to generate protobuf

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -77,7 +77,7 @@ icons_check: ## generate FIDO service icons
 	python3 core/tools/build_icons.py --check
 
 protobuf: ## generate python protobuf headers
-	./tools/build_protobuf
+	./tools/build_protobuf --build
 
 protobuf_check: ## check that generated protobuf headers are up to date
 	./tools/build_protobuf --check


### PR DESCRIPTION
I want generate python protobuf headers, So i execute makefile like this "make protobuf",but an error occurred.
```
./tools/build_protobuf
++ dirname ./tools/build_protobuf
+ cd ./tools/..
+ PROTOB=common/protob
+ CORE_PROTOBUF_SOURCES='    common/protob/messages.proto     common/protob/messages-binance.proto     common/protob/messages-bitcoin.proto     common/protob/messages-cardano.proto     common/protob/messages-common.proto     common/protob/messages-crypto.proto     common/protob/messages-debug.proto     common/protob/messages-eos.proto     common/protob/messages-ethereum.proto     common/protob/messages-lisk.proto     common/protob/messages-management.proto     common/protob/messages-monero.proto     common/protob/messages-nem.proto     common/protob/messages-ripple.proto     common/protob/messages-stellar.proto     common/protob/messages-tezos.proto     common/protob/messages-webauthn.proto '
+ PYTHON_PROTOBUF_SOURCES='common/protob/*.proto'
+ CORE_MESSAGES_IGNORE='    CosiCommit     CosiCommitment     CosiSign     CosiSignature     DebugLinkFlashErase     DebugLinkLog     DebugLinkMemory     DebugLinkMemoryRead     DebugLinkMemoryWrite     DebugLinkStop     NEMDecryptMessage     NEMDecryptedMessage     PinMatrixAck     PinMatrixRequest     PinMatrixRequestType     WordAck     WordRequest     WordRequestType '
+ PYTHON_MESSAGES_IGNORE=
+ RETURN=0
./tools/build_protobuf: 行 111: $1: 未绑定的变量
Makefile:80: recipe for target 'protobuf' failed
make: *** [protobuf] Error 1

```
If you want to reproduce, you only need to do the following two steps.
   1.Add code "set -eux" on the second line in the file "trezor-firmware/tools/build_protobuf"
   2.make protobuf 

