### PR TITLE
Add Koto full support

### DIFF
--- a/legacy/firmware/signing.c
+++ b/legacy/firmware/signing.c
@@ -611,6 +611,9 @@ void signing_init(const SignTx *msg, const CoinInfo *_coin,
     ti.version |= (DECRED_SERIALIZE_NO_WITNESS << 16);
     ti.is_decred = true;
   }
+  if (strcmp(coin->coin_name, "Koto") == 0) {
+    to.is_koto = true;
+  }
 #endif
 
   // segwit hashes for hashPrevouts and hashSequence
@@ -1464,6 +1467,9 @@ void signing_txack(TransactionType *tx) {
       if (coin->decred) {
         tp.version |= (DECRED_SERIALIZE_NO_WITNESS << 16);
         tp.is_decred = true;
+      }
+      if (strcmp(coin->coin_name, "Koto") == 0) {
+        tp.is_koto = true;
       }
 #endif
       progress_meta_step = progress_step / (tp.inputs_len + tp.outputs_len);

--- a/legacy/firmware/transaction.c
+++ b/legacy/firmware/transaction.c
@@ -623,7 +623,7 @@ uint32_t tx_serialize_input_hash(TxStruct *tx, const TxInputType *input) {
     r++;
   } else
 #endif
-  {
+  if (!tx->is_koto || tx->version < 4) {
     r += tx_script_hash(&(tx->hasher), input->script_sig.size,
                         input->script_sig.bytes);
   }
@@ -828,6 +828,7 @@ void tx_init(TxStruct *tx, uint32_t inputs_len, uint32_t outputs_len,
   tx->size = 0;
   tx->is_segwit = false;
   tx->is_decred = false;
+  tx->is_koto = false;
   tx->is_zcashlike = is_zcashlike;
   tx->version_group_id = version_group_id;
   tx->timestamp = timestamp;

--- a/legacy/firmware/transaction.c
+++ b/legacy/firmware/transaction.c
@@ -623,9 +623,10 @@ uint32_t tx_serialize_input_hash(TxStruct *tx, const TxInputType *input) {
     r++;
   } else
 #endif
-  if (!tx->is_koto || tx->version < 4) {
-    r += tx_script_hash(&(tx->hasher), input->script_sig.size,
-                        input->script_sig.bytes);
+  {
+    if (!tx->is_koto || tx->version < 4)
+      r += tx_script_hash(&(tx->hasher), input->script_sig.size,
+                          input->script_sig.bytes);
   }
   r += tx_sequence_hash(&(tx->hasher), input);
 

--- a/legacy/firmware/transaction.h
+++ b/legacy/firmware/transaction.h
@@ -41,6 +41,7 @@ typedef struct {
   uint32_t expiry;
   bool is_segwit;
   bool is_decred;
+  bool is_koto;
   bool is_zcashlike;
 
   uint32_t have_inputs;


### PR DESCRIPTION
Koto which is Zcashlike coin is supported. But, the hash calculation method of Transaction (version 4) is differ with Zcash.
Koto ignores scriptSig when calculating the ID.