### PR TITLE
[python] build_tx tool: fix amount inaccuracy by parsing with Decimal

### DIFF
--- a/python/tools/build_tx.py
+++ b/python/tools/build_tx.py
@@ -18,6 +18,7 @@
 import json
 
 import click
+import decimal
 import requests
 
 from trezorlib import btc, messages, tools
@@ -72,7 +73,7 @@ def _get_inputs_interactive(blockbook_url):
         if not r.ok:
             raise click.ClickException(f"Failed to fetch URL: {tx_url}")
 
-        tx_json = r.json()
+        tx_json = r.json(parse_float=decimal.Decimal)
         if "error" in tx_json:
             raise click.ClickException(f"Transaction not found: {txhash}")
 


### PR DESCRIPTION
The "Input amount" was being parsed and displayed incorrectly sometimes while the user was entering the previous outputs to spend.
Also, amount values in the generated bin_outputs of the prev_txes were incorrect sometimes.
Only some amounts were wrong, and each time that I witnessed this, the values were off by one in the least significant digit.
This fix of parsing the amounts with the Decimal class fixed all the problems that I encountered.