### PR TITLE
build-docker.sh: fix fingerprint calculation for model T production builds

### DIFF
--- a/python/tools/firmware-fingerprint.py
+++ b/python/tools/firmware-fingerprint.py
@@ -15,13 +15,13 @@ def firmware_fingerprint(filename, output):
     data = filename.read()
 
     try:
+        version, fw = firmware.parse(data)
+
         # Unsigned production builds for Trezor T do not have valid code hashes.
         # Use the internal module which recomputes them first.
-        if data[:4] == b"TRZV":
-            fw = firmware_headers.parse_image(data)
-            fingerprint = fw.digest()
+        if version == firmware.FirmwareFormat.TREZOR_T:
+            fingerprint = firmware_headers.FirmwareImage(fw).digest()
         else:
-            version, fw = firmware.parse(data)
             fingerprint = firmware.digest(version, fw)
     except Exception as e:
         click.echo(e, err=True)


### PR DESCRIPTION
Fixes #1256. 

For core the fingerprints now match https://wallet.trezor.io/data/firmware/2/releases.json:
```
$ ./build-docker.sh core/v2.3.3
...
$ python/tools/firmware-fingerprint.py build/core/firmware/firmware.bin
46326222f8afcb82e1cd07867bc3bf8836f4e9d0f367e23b58d1e9bc32cd032e

$ python/tools/firmware-fingerprint.py build/core-bitcoinonly/firmware/firmware.bin
dda77cd7893a5f413f8fc4b2f44d1d43ed4b26e8ced5e6e578cc6b302c1a2310
```

For legacy the fingerprints still do not match as documented on https://wiki.trezor.io/Developers_guide:Deterministic_firmware_build
