### PR TITLE
Cardano get address - swap path with address type to fit longer paths

### DIFF
--- a/common/tests/fixtures/cardano/get_address_byron.json
+++ b/common/tests/fixtures/cardano/get_address_byron.json
@@ -42,7 +42,7 @@
         "path": "m/44'/1815'/0'/0/0",
         "address_type": "byron",
         "protocol_magic": 42,
-        "network_id": 1
+        "network_id": 0
       },
       "result": {
         "expected_address": "2657WMsDfac5F3zbgs9BwNWx3dhGAJERkAL93gPa68NJ2i8mbCHm2pLUHWSj8Mfea"
@@ -53,7 +53,7 @@
         "path": "m/44'/1815'/0'/0/1",
         "address_type": "byron",
         "protocol_magic": 42,
-        "network_id": 1
+        "network_id": 0
       },
       "result": {
         "expected_address": "2657WMsDfac6ezKWszxLFqJjSUgpg9NgxKc1koqi24sVpRaPhiwMaExk4useKn5HA"
@@ -64,7 +64,7 @@
         "path": "m/44'/1815'/0'/0/2",
         "address_type": "byron",
         "protocol_magic": 42,
-        "network_id": 1
+        "network_id": 0
       },
       "result":  {
         "expected_address": "2657WMsDfac7hr1ioJGr6g7r6JRx4r1My8Rj91tcPTeVjJDpfBYKURrPG2zVLx2Sq"

--- a/common/tests/fixtures/cardano/get_address_byron.slip39.json
+++ b/common/tests/fixtures/cardano/get_address_byron.slip39.json
@@ -46,7 +46,7 @@
         "path": "m/44'/1815'/0'/0/0",
         "address_type": "byron",
         "protocol_magic": 42,
-        "network_id": 1
+        "network_id": 0
       },
       "result": {
         "expected_address": "2657WMsDfac7SH1rhA2PWBggGAPrKyLt1r9SL9gajPxxcH15ZxuCUb4aK9mQ9w7dU"
@@ -57,7 +57,7 @@
         "path": "m/44'/1815'/0'/0/1",
         "address_type": "byron",
         "protocol_magic": 42,
-        "network_id": 1
+        "network_id": 0
       },
       "result": {
         "expected_address": "2657WMsDfac6Cmfg4Varph2qyLKGi2K9E8jrtvjHVzfSjmbTMGy5sY3HpxCKsmtDA"
@@ -68,7 +68,7 @@
         "path": "m/44'/1815'/0'/0/2",
         "address_type": "byron",
         "protocol_magic": 42,
-        "network_id": 1
+        "network_id": 0
       },
       "result": {
         "expected_address": "2657WMsDfac5ANb5Mw6Rbgdz6nvs2Tu675vGbbVSzXQbAkQuMWtqBvEeKTrHNtXY7"

--- a/common/tests/fixtures/cardano/get_base_address.json
+++ b/common/tests/fixtures/cardano/get_base_address.json
@@ -22,7 +22,7 @@
         "address_type": "base",
         "staking_path": "m/1852'/1815'/4'/2/0",
         "network_id": 0,
-        "protocol_magic": 764824073
+        "protocol_magic": 42
       },
       "result": {
         "expected_address": "addr_test1qrv42wjda8r6mpfj40d36znlgfdcqp7jtj03ah8skh6u8wnrqua2vw243tmjfjt0h5wsru6appuz8c0pfd75ur7myyeqnsc9fs"

--- a/common/tests/fixtures/cardano/get_base_address_with_staking_key_hash.json
+++ b/common/tests/fixtures/cardano/get_base_address_with_staking_key_hash.json
@@ -22,7 +22,7 @@
         "address_type": "base",
         "staking_key_hash": "1bc428e4720702ebd5dab4fb175324c192dc9bb76cc5da956e3c8dff",
         "network_id": 0,
-        "protocol_magic": 764824073
+        "protocol_magic": 42
       },
       "result": {
         "expected_address": "addr_test1qrv42wjda8r6mpfj40d36znlgfdcqp7jtj03ah8skh6u8wsmcs5wgus8qt4atk45lvt4xfxpjtwfhdmvchdf2m3u3hls8m96xf"
@@ -46,7 +46,7 @@
         "address_type": "base",
         "staking_key_hash": "122a946b9ad3d2ddf029d3a828f0468aece76895f15c9efbd69b4277",
         "network_id": 0,
-        "protocol_magic": 764824073
+        "protocol_magic": 42
       },
       "result": {
         "expected_address": "addr_test1qzq0nckg3ekgzuqg7w5p9mvgnd9ym28qh5grlph8xd2z92sj922xhxkn6twlq2wn4q50q352annk3903tj00h45mgfmsu8d9w5"
@@ -58,7 +58,7 @@
         "address_type": "base",
         "staking_key_hash": "122a946b9ad3d2ddf029d3a828f0468aece76895f15c9efbd69b4277",
         "network_id": 0,
-        "protocol_magic": 764824073
+        "protocol_magic": 42
       },
       "result": {
         "expected_address": "addr_test1qrv42wjda8r6mpfj40d36znlgfdcqp7jtj03ah8skh6u8wsj922xhxkn6twlq2wn4q50q352annk3903tj00h45mgfmsvvdk2q"

--- a/common/tests/fixtures/cardano/get_enterprise_address.json
+++ b/common/tests/fixtures/cardano/get_enterprise_address.json
@@ -22,7 +22,7 @@
         "address_type": "enterprise",
         "staking_key_hash": "1bc428e4720702ebd5dab4fb175324c192dc9bb76cc5da956e3c8dff",
         "network_id": 0,
-        "protocol_magic": 764824073
+        "protocol_magic": 42
       },
       "result": {
         "expected_address": "addr_test1vzq0nckg3ekgzuqg7w5p9mvgnd9ym28qh5grlph8xd2z92s8k2y47"

--- a/common/tests/fixtures/cardano/get_pointer_address.json
+++ b/common/tests/fixtures/cardano/get_pointer_address.json
@@ -26,7 +26,7 @@
         "tx_index": 177,
         "certificate_index": 42,
         "network_id": 0,
-        "protocol_magic": 764824073
+        "protocol_magic": 42
       },
       "result": {
         "expected_address": "addr_test1gzq0nckg3ekgzuqg7w5p9mvgnd9ym28qh5grlph8xd2z925ph3wczvf2ag2x9t"

--- a/common/tests/fixtures/cardano/get_reward_address.json
+++ b/common/tests/fixtures/cardano/get_reward_address.json
@@ -20,7 +20,7 @@
         "path": "m/1852'/1815'/0'/2/0",
         "address_type": "reward",
         "network_id": 0,
-        "protocol_magic": 764824073
+        "protocol_magic": 42
       },
       "result": {
         "expected_address": "stake_test1uqfz49rtntfa9h0s98f6s28sg69weemgjhc4e8hm66d5yac643znq"

--- a/core/src/apps/cardano/get_address.py
+++ b/core/src/apps/cardano/get_address.py
@@ -13,6 +13,7 @@ from .layout import (
     show_warning_address_foreign_staking_key,
     show_warning_address_pointer,
 )
+from .sign_tx import validate_network_info
 
 if False:
     from trezor.messages import CardanoAddressParametersType, CardanoGetAddress
@@ -27,6 +28,8 @@ async def get_address(
     await paths.validate_path(
         ctx, validate_full_path, keychain, address_parameters.address_n, CURVE
     )
+
+    validate_network_info(msg.network_id, msg.protocol_magic)
 
     try:
         address = derive_human_readable_address(
@@ -54,9 +57,9 @@ async def _display_address(
 ) -> None:
     await _show_staking_warnings(ctx, keychain, address_parameters)
 
-    network = None
+    network_name = None
     if not protocol_magics.is_mainnet(protocol_magic):
-        network = protocol_magic
+        network_name = protocol_magics.to_ui_string(protocol_magic)
 
     while True:
         if await show_address(
@@ -64,7 +67,7 @@ async def _display_address(
             address,
             address_parameters.address_type,
             address_parameters.address_n,
-            network=network,
+            network=network_name,
         ):
             break
         if await show_qr(

--- a/core/src/apps/cardano/layout.py
+++ b/core/src/apps/cardano/layout.py
@@ -193,7 +193,7 @@ async def show_address(
     address: str,
     address_type: EnumTypeCardanoAddressType,
     path: List[int],
-    network: int = None,
+    network: str = None,
 ) -> bool:
     """
     Custom show_address function is needed because cardano addresses don't
@@ -204,28 +204,28 @@ async def show_address(
     t1 = Text(address_type_label, ui.ICON_RECEIVE, ui.GREEN)
 
     lines_per_page = 5
-    first_page_lines_used = 0
+    lines_used_on_first_page = 0
 
     # assemble first page to be displayed (path + network + whatever part of the address fits)
     if network is not None:
-        t1.normal("%s network" % protocol_magics.to_ui_string(network))
-        first_page_lines_used += 1
+        t1.normal("%s network" % network)
+        lines_used_on_first_page += 1
 
     path_str = address_n_to_str(path)
     t1.mono(path_str)
-    first_page_lines_used = min(
-        first_page_lines_used + math.ceil(len(path_str) / _MAX_MONO_LINE),
+    lines_used_on_first_page = min(
+        lines_used_on_first_page + math.ceil(len(path_str) / _MAX_MONO_LINE),
         lines_per_page,
     )
 
     address_lines = list(chunks(address, 17))
-    for address_line in address_lines[: lines_per_page - first_page_lines_used]:
+    for address_line in address_lines[: lines_per_page - lines_used_on_first_page]:
         t1.bold(address_line)
 
     # append remaining pages containing the rest of the address
     pages = [t1] + _paginate_lines(
         address_lines,
-        lines_per_page - first_page_lines_used,
+        lines_per_page - lines_used_on_first_page,
         address_type_label,
         ui.ICON_RECEIVE,
         lines_per_page,

--- a/core/src/apps/cardano/layout.py
+++ b/core/src/apps/cardano/layout.py
@@ -1,3 +1,4 @@
+import math
 from ubinascii import hexlify
 
 from trezor import ui
@@ -42,6 +43,9 @@ CERTIFICATE_TYPE_NAMES = {
     CardanoCertificateType.STAKE_DEREGISTRATION: "Stake key deregistration",
     CardanoCertificateType.STAKE_DELEGATION: "Stake delegation",
 }
+
+# Maximum number of characters per line in monospace font.
+_MAX_MONO_LINE = 18
 
 
 def format_coin_amount(amount: int) -> str:
@@ -195,18 +199,37 @@ async def show_address(
     Custom show_address function is needed because cardano addresses don't
     fit on a single screen.
     """
-    path_str = address_n_to_str(path)
-    t1 = Text(path_str, ui.ICON_RECEIVE, ui.GREEN)
+
+    address_type_label = "%s address" % ADDRESS_TYPE_NAMES[address_type]
+    t1 = Text(address_type_label, ui.ICON_RECEIVE, ui.GREEN)
+
+    lines_per_page = 5
+    first_page_lines_used = 0
+
+    # assemble first page to be displayed (path + network + whatever part of the address fits)
     if network is not None:
         t1.normal("%s network" % protocol_magics.to_ui_string(network))
-    t1.normal("%s address" % ADDRESS_TYPE_NAMES[address_type])
+        first_page_lines_used += 1
+
+    path_str = address_n_to_str(path)
+    t1.mono(path_str)
+    first_page_lines_used = min(
+        first_page_lines_used + math.ceil(len(path_str) / _MAX_MONO_LINE),
+        lines_per_page,
+    )
 
     address_lines = list(chunks(address, 17))
-    t1.bold(address_lines[0])
-    t1.bold(address_lines[1])
-    t1.bold(address_lines[2])
+    for address_line in address_lines[: lines_per_page - first_page_lines_used]:
+        t1.bold(address_line)
 
-    pages = [t1] + _paginate_lines(address_lines, 3, path_str, ui.ICON_RECEIVE)
+    # append remaining pages containing the rest of the address
+    pages = [t1] + _paginate_lines(
+        address_lines,
+        lines_per_page - first_page_lines_used,
+        address_type_label,
+        ui.ICON_RECEIVE,
+        lines_per_page,
+    )
 
     return await confirm(
         ctx,
@@ -218,11 +241,11 @@ async def show_address(
 
 
 def _paginate_lines(
-    lines: List[str], offset: int, desc: str, icon: str, per_page: int = 4
+    lines: List[str], offset: int, desc: str, icon: str, lines_per_page: int = 4
 ) -> List[ui.Component]:
     pages = []
     if len(lines) > offset:
-        to_pages = list(chunks(lines[offset:], per_page))
+        to_pages = list(chunks(lines[offset:], lines_per_page))
         for page in to_pages:
             t = Text(desc, icon, ui.GREEN)
             for line in page:

--- a/core/src/apps/cardano/layout.py
+++ b/core/src/apps/cardano/layout.py
@@ -53,15 +53,15 @@ def format_coin_amount(amount: int) -> str:
 
 
 async def confirm_sending(ctx: wire.Context, amount: int, to: str):
-    t1 = Text("Confirm transaction", ui.ICON_SEND, ui.GREEN)
-    t1.normal("Confirm sending:")
-    t1.bold(format_coin_amount(amount))
-    t1.normal("to")
+    page1 = Text("Confirm transaction", ui.ICON_SEND, ui.GREEN)
+    page1.normal("Confirm sending:")
+    page1.bold(format_coin_amount(amount))
+    page1.normal("to")
 
     to_lines = list(chunks(to, 17))
-    t1.bold(to_lines[0])
+    page1.bold(to_lines[0])
 
-    pages = [t1] + _paginate_lines(to_lines, 1, "Confirm transaction", ui.ICON_SEND)
+    pages = [page1] + _paginate_lines(to_lines, 1, "Confirm transaction", ui.ICON_SEND)
 
     await require_confirm(ctx, Paginated(pages))
 
@@ -69,89 +69,89 @@ async def confirm_sending(ctx: wire.Context, amount: int, to: str):
 async def show_warning_tx_no_staking_info(
     ctx: wire.Context, address_type: EnumTypeCardanoAddressType, amount: int
 ):
-    t1 = Text("Confirm transaction", ui.ICON_SEND, ui.GREEN)
-    t1.normal("Change " + ADDRESS_TYPE_NAMES[address_type].lower())
-    t1.normal("address has no stake")
-    t1.normal("rights.")
-    t1.normal("Change amount:")
-    t1.bold(format_coin_amount(amount))
+    page1 = Text("Confirm transaction", ui.ICON_SEND, ui.GREEN)
+    page1.normal("Change " + ADDRESS_TYPE_NAMES[address_type].lower())
+    page1.normal("address has no stake")
+    page1.normal("rights.")
+    page1.normal("Change amount:")
+    page1.bold(format_coin_amount(amount))
 
-    await require_confirm(ctx, t1)
+    await require_confirm(ctx, page1)
 
 
 async def show_warning_tx_pointer_address(
     ctx: wire.Context, pointer: CardanoBlockchainPointerType, amount: int,
 ):
-    t1 = Text("Confirm transaction", ui.ICON_SEND, ui.GREEN)
-    t1.normal("Change address has a")
-    t1.normal("pointer with staking")
-    t1.normal("rights.")
+    page1 = Text("Confirm transaction", ui.ICON_SEND, ui.GREEN)
+    page1.normal("Change address has a")
+    page1.normal("pointer with staking")
+    page1.normal("rights.")
 
-    t2 = Text("Confirm transaction", ui.ICON_SEND, ui.GREEN)
-    t2.normal("Pointer:")
-    t2.bold(
+    page2 = Text("Confirm transaction", ui.ICON_SEND, ui.GREEN)
+    page2.normal("Pointer:")
+    page2.bold(
         "%s, %s, %s"
         % (pointer.block_index, pointer.tx_index, pointer.certificate_index)
     )
-    t2.normal("Change amount:")
-    t2.bold(format_coin_amount(amount))
+    page2.normal("Change amount:")
+    page2.bold(format_coin_amount(amount))
 
-    await require_confirm(ctx, Paginated([t1, t2]))
+    await require_confirm(ctx, Paginated([page1, page2]))
 
 
 async def show_warning_tx_different_staking_account(
     ctx: wire.Context, staking_account_path: List[int], amount: int,
 ):
-    t1 = Text("Confirm transaction", ui.ICON_SEND, ui.GREEN)
-    t1.normal("Change address staking")
-    t1.normal("rights do not match")
-    t1.normal("the current account.")
+    page1 = Text("Confirm transaction", ui.ICON_SEND, ui.GREEN)
+    page1.normal("Change address staking")
+    page1.normal("rights do not match")
+    page1.normal("the current account.")
 
-    t2 = Text("Confirm transaction", ui.ICON_SEND, ui.GREEN)
-    t2.normal("Staking account:")
-    t2.bold(address_n_to_str(staking_account_path))
-    t2.normal("Change amount:")
-    t2.bold(format_coin_amount(amount))
+    page2 = Text("Confirm transaction", ui.ICON_SEND, ui.GREEN)
+    page2.normal("Staking account:")
+    page2.bold(address_n_to_str(staking_account_path))
+    page2.normal("Change amount:")
+    page2.bold(format_coin_amount(amount))
 
-    await require_confirm(ctx, Paginated([t1, t2]))
+    await require_confirm(ctx, Paginated([page1, page2]))
 
 
 async def show_warning_tx_staking_key_hash(
     ctx: wire.Context, staking_key_hash: bytes, amount: int,
 ):
-    t1 = Text("Confirm transaction", ui.ICON_SEND, ui.GREEN)
-    t1.normal("Change address staking")
-    t1.normal("rights do not match")
-    t1.normal("the current account.")
+    page1 = Text("Confirm transaction", ui.ICON_SEND, ui.GREEN)
+    page1.normal("Change address staking")
+    page1.normal("rights do not match")
+    page1.normal("the current account.")
 
-    t2 = Text("Confirm transaction", ui.ICON_SEND, ui.GREEN)
-    t2.normal("Staking key hash:")
-    t2.mono(*chunks(hexlify(staking_key_hash), 17))
+    page2 = Text("Confirm transaction", ui.ICON_SEND, ui.GREEN)
+    page2.normal("Staking key hash:")
+    page2.mono(*chunks(hexlify(staking_key_hash), 17))
 
-    t3 = Text("Confirm transaction", ui.ICON_SEND, ui.GREEN)
-    t3.normal("Change amount:")
-    t3.bold(format_coin_amount(amount))
+    page3 = Text("Confirm transaction", ui.ICON_SEND, ui.GREEN)
+    page3.normal("Change amount:")
+    page3.bold(format_coin_amount(amount))
 
-    await require_confirm(ctx, Paginated([t1, t2, t3]))
+    await require_confirm(ctx, Paginated([page1, page2, page3]))
 
 
 async def confirm_transaction(
     ctx, amount: int, fee: int, protocol_magic: int, has_metadata: bool
 ) -> None:
-    t1 = Text("Confirm transaction", ui.ICON_SEND, ui.GREEN)
-    t1.normal("Transaction amount:")
-    t1.bold(format_coin_amount(amount))
-    t1.normal("Transaction fee:")
-    t1.bold(format_coin_amount(fee))
+    page1 = Text("Confirm transaction", ui.ICON_SEND, ui.GREEN)
+    page1.normal("Transaction amount:")
+    page1.bold(format_coin_amount(amount))
+    page1.normal("Transaction fee:")
+    page1.bold(format_coin_amount(fee))
 
-    t2 = Text("Confirm transaction", ui.ICON_SEND, ui.GREEN)
-    t2.normal("Network:")
-    t2.bold(protocol_magics.to_ui_string(protocol_magic))
+    page2 = Text("Confirm transaction", ui.ICON_SEND, ui.GREEN)
+    page2.normal("Network:")
+    page2.bold(protocol_magics.to_ui_string(protocol_magic))
     if has_metadata:
-        t2.normal("Transaction contains")
-        t2.normal("metadata")
+        page2.normal("Transaction contains")
+        page2.normal("metadata")
 
-    await require_hold_to_confirm(ctx, Paginated([t1, t2]))
+    await require_hold_to_confirm(ctx, Paginated([page1, page2]))
 
 
 async def confirm_certificate(
@@ -159,18 +159,18 @@ async def confirm_certificate(
 ) -> bool:
     pages = []
 
-    t1 = Text("Confirm transaction", ui.ICON_SEND, ui.GREEN)
-    t1.normal("Confirm:")
-    t1.bold(CERTIFICATE_TYPE_NAMES[certificate.type])
-    t1.normal("for account:")
-    t1.bold(address_n_to_str(to_account_path(certificate.path)))
-    pages.append(t1)
+    page1 = Text("Confirm transaction", ui.ICON_SEND, ui.GREEN)
+    page1.normal("Confirm:")
+    page1.bold(CERTIFICATE_TYPE_NAMES[certificate.type])
+    page1.normal("for account:")
+    page1.bold(address_n_to_str(to_account_path(certificate.path)))
+    pages.append(page1)
 
     if certificate.type == CardanoCertificateType.STAKE_DELEGATION:
-        t2 = Text("Confirm transaction", ui.ICON_SEND, ui.GREEN)
-        t2.normal("to pool:")
-        t2.bold(hexlify(certificate.pool).decode())
-        pages.append(t2)
+        page2 = Text("Confirm transaction", ui.ICON_SEND, ui.GREEN)
+        page2.normal("to pool:")
+        page2.bold(hexlify(certificate.pool).decode())
+        pages.append(page2)
 
     await require_confirm(ctx, Paginated(pages))
 
@@ -178,14 +178,14 @@ async def confirm_certificate(
 async def confirm_withdrawal(
     ctx: wire.Context, withdrawal: CardanoTxWithdrawalType
 ) -> bool:
-    t1 = Text("Confirm transaction", ui.ICON_SEND, ui.GREEN)
-    t1.normal("Confirm withdrawal")
-    t1.normal("for account:")
-    t1.bold(address_n_to_str(to_account_path(withdrawal.path)))
-    t1.normal("Amount:")
-    t1.bold(format_coin_amount(withdrawal.amount))
+    page1 = Text("Confirm transaction", ui.ICON_SEND, ui.GREEN)
+    page1.normal("Confirm withdrawal")
+    page1.normal("for account:")
+    page1.bold(address_n_to_str(to_account_path(withdrawal.path)))
+    page1.normal("Amount:")
+    page1.bold(format_coin_amount(withdrawal.amount))
 
-    await require_confirm(ctx, t1)
+    await require_confirm(ctx, page1)
 
 
 async def show_address(
@@ -201,18 +201,18 @@ async def show_address(
     """
 
     address_type_label = "%s address" % ADDRESS_TYPE_NAMES[address_type]
-    t1 = Text(address_type_label, ui.ICON_RECEIVE, ui.GREEN)
+    page1 = Text(address_type_label, ui.ICON_RECEIVE, ui.GREEN)
 
     lines_per_page = 5
     lines_used_on_first_page = 0
 
     # assemble first page to be displayed (path + network + whatever part of the address fits)
     if network is not None:
-        t1.normal("%s network" % network)
+        page1.normal("%s network" % network)
         lines_used_on_first_page += 1
 
     path_str = address_n_to_str(path)
-    t1.mono(path_str)
+    page1.mono(path_str)
     lines_used_on_first_page = min(
         lines_used_on_first_page + math.ceil(len(path_str) / _MAX_MONO_LINE),
         lines_per_page,
@@ -220,10 +220,10 @@ async def show_address(
 
     address_lines = list(chunks(address, 17))
     for address_line in address_lines[: lines_per_page - lines_used_on_first_page]:
-        t1.bold(address_line)
+        page1.bold(address_line)
 
     # append remaining pages containing the rest of the address
-    pages = [t1] + _paginate_lines(
+    pages = [page1] + _paginate_lines(
         address_lines,
         lines_per_page - lines_used_on_first_page,
         address_type_label,

--- a/core/src/apps/cardano/sign_tx.py
+++ b/core/src/apps/cardano/sign_tx.py
@@ -72,7 +72,7 @@ async def sign_tx(
         if msg.fee > LOVELACE_MAX_SUPPLY:
             raise wire.ProcessError("Fee is out of range!")
 
-        _validate_network_info(msg.network_id, msg.protocol_magic)
+        validate_network_info(msg.network_id, msg.protocol_magic)
 
         for i in msg.inputs:
             await validate_path(ctx, validate_full_path, keychain, i.address_n, CURVE)
@@ -97,7 +97,7 @@ async def sign_tx(
     return tx
 
 
-def _validate_network_info(network_id: int, protocol_magic: int) -> None:
+def validate_network_info(network_id: int, protocol_magic: int) -> None:
     """
     We are only concerned about checking that both network_id and protocol_magic
     belong to the mainnet or that both belong to a testnet. We don't need to check for


### PR DESCRIPTION
Problem: Trezor's call to verify the address on-screen cuts the path for basically any kind of address, given that the new derivation paths introduced by shelley became longer with the `m/1852'/1815'/` common prefix. Example below:

```trezorctl cardano get-address -n "m/1852'/1815'/15'/0/100" -s "m/1852'/1815'/0'/2/0" -t enterprise -d``` results in

![shelley_old](https://user-images.githubusercontent.com/4980147/93787209-7df41780-fc30-11ea-9f0a-68f882089d3a.png)

So the `m/1852'/1815'/15'/0/100` gets cut to just `m/1852'/1815'/15'/0` which provides an incomplete information to the user wanting to verify the given address (same problem for double digit address indices for single digit account numbers which is the most common case indeed)

Sugested fix: swap the address type information (fittable on a single line) with the derivation path, like this

![shelley_mainnet_example](https://user-images.githubusercontent.com/4980147/93787409-bd226880-fc30-11ea-994a-c314dd8b9a96.png)

Other examples:
long path:
![shelley_address_long_path_example](https://user-images.githubusercontent.com/4980147/93788893-784b0180-fc31-11ea-87b3-488094f7982a.png)

legacy (byron) address
![legacy path](https://user-images.githubusercontent.com/4980147/93788917-7e40e280-fc31-11ea-96e6-4b9533e741ee.png)


Additional bugfix:
Along the way we noticed that even though the call to get the address receives both the protocol magic (used for legacy addresses) and network id (used for "shelley" addresses), the logic to display whether it's a testnet or not checks only for the protocol magic which causes inconsistent behavior for mainnet shelley addresses (where the user can potentially see "Testnet network" even for mainnet shelley addresses, if the caller passes an inconsistent network id/protocol magic. So we added a check already done in the sign tx call - namely whether the protocol magic and network id match (i.e. both are mainnet or neither). This required fixing the test fixtures as well, as they did not have consistent protocol magic/network ids either.

Testing/validation:
* for path length fix try `trezorctl cardano get-address -n "m/1852'/1815'/15'/0/100" -s "m/1852'/1815'/0'/2/0" -t enterprise -d`
* after the network id/protocol magic consistency fix device tests are passing: `pytest tests/device_tests -k test_address_public_key`

Notes:
* the changes are split into two commits, the first one is the address type <-> derivation path swap, the second one is the additional network id/protocol magic consistency check

Question: Any plans to support carrousel displaying of the title line (if it's feasible at all)? That would allow even in the old layout to fit longer paths which would be a lot simpler to implement and an (IMHO) cleaner UI
