### PR TITLE
Print expected fixtures in UI tests

### DIFF
--- a/ci/test.yml
+++ b/ci/test.yml
@@ -16,12 +16,14 @@ core device ui test:
   after_script:
     - mv tests/ui_tests/reporting/reports/test/ test_ui_report
     - nix-shell --run "pipenv run python ci/prepare_ui_artifacts.py"
+    - diff tests/ui_tests/fixtures.json tests/ui_tests/fixtures.suggestion.json
   artifacts:
     name: "$CI_JOB_NAME-$CI_COMMIT_SHORT_SHA"
     paths:
       - ci/ui_test_records/
       - test_ui_report
       - tests/ui_tests/screens/
+      - tests/ui_tests/fixtures.suggestion.json
       - tests/junit.xml
       - tests/trezor.log
     when: always

--- a/tests/ui_tests/.gitignore
+++ b/tests/ui_tests/.gitignore
@@ -1,3 +1,4 @@
 *.png
 *.html
 *.zip
+fixtures.suggestion.json

--- a/tests/ui_tests/__init__.py
+++ b/tests/ui_tests/__init__.py
@@ -11,7 +11,9 @@ from .reporting import testreport
 
 UI_TESTS_DIR = Path(__file__).parent.resolve()
 HASH_FILE = UI_TESTS_DIR / "fixtures.json"
-HASHES = {}
+SUGGESTION_FILE = UI_TESTS_DIR / "fixtures.suggestion.json"
+FILE_HASHES = {}
+ACTUAL_HASHES = {}
 PROCESSED = set()
 
 
@@ -29,7 +31,7 @@ def get_test_name(node_id):
 
 def _process_recorded(screen_path, test_name):
     # calculate hash
-    HASHES[test_name] = _hash_files(screen_path)
+    FILE_HASHES[test_name] = _hash_files(screen_path)
     _rename_records(screen_path)
     PROCESSED.add(test_name)
 
@@ -50,13 +52,14 @@ def _hash_files(path):
 
 
 def _process_tested(fixture_test_path, test_name):
-    expected_hash = HASHES.get(test_name)
+    expected_hash = FILE_HASHES.get(test_name)
     if expected_hash is None:
         raise ValueError("Hash for '%s' not found in fixtures.json" % test_name)
     PROCESSED.add(test_name)
 
     actual_path = fixture_test_path / "actual"
     actual_hash = _hash_files(actual_path)
+    ACTUAL_HASHES[test_name] = actual_hash
 
     _rename_records(actual_path)
 
@@ -103,20 +106,28 @@ def screen_recording(client, request):
 
 
 def list_missing():
-    return set(HASHES.keys()) - PROCESSED
+    return set(FILE_HASHES.keys()) - PROCESSED
 
 
 def read_fixtures():
     if not HASH_FILE.exists():
         raise ValueError("File fixtures.json not found.")
-    global HASHES
-    HASHES = json.loads(HASH_FILE.read_text())
+    global FILE_HASHES
+    FILE_HASHES = json.loads(HASH_FILE.read_text())
 
 
 def write_fixtures(remove_missing: bool):
-    if remove_missing:
-        write = {i: HASHES[i] for i in PROCESSED}
-    else:
-        write = HASHES
+    HASH_FILE.write_text(_get_fixtures_content(FILE_HASHES, remove_missing))
 
-    HASH_FILE.write_text(json.dumps(write, indent="", sort_keys=True) + "\n")
+
+def write_fixtures_suggestion(remove_missing: bool):
+    SUGGESTION_FILE.write_text(_get_fixtures_content(ACTUAL_HASHES, remove_missing))
+
+
+def _get_fixtures_content(fixtures: dict, remove_missing: bool):
+    if remove_missing:
+        fixtures = {i: fixtures[i] for i in PROCESSED}
+    else:
+        fixtures = fixtures
+
+    return json.dumps(fixtures, indent="", sort_keys=True) + "\n"


### PR DESCRIPTION
Closes #1263. The UI test job now prints: 

```
-------- Suggested fixtures.json diff: --------
{
"cardano-test_sign_tx.py::test_cardano_sign_tx[parameters0-result0]": "6aa71de5007b0faf1eea4b1cfda1da6a739f852c0d875a1e59d83c03178c2f98",
"cardano-test_sign_tx.py::test_cardano_sign_tx[parameters1-result1]": "7abf2e87a9b1e50afdf3502ba9480b07a59d59ccccf24915b46fb81285ae3fa8",
...
```

which you can simply copy and paste into `fixtures.json`. It does not make a git patch but simply prints the expected JSON as a whole. I can do git patch but it seemed as not necessary (although the log would be shorter).

