### PR TITLE
Added input/output counts to comply with new SignTx class creation

### DIFF
--- a/python/tools/build_tx.py
+++ b/python/tools/build_tx.py
@@ -159,7 +159,7 @@ def sign_interactive():
     inputs, txes = _get_inputs_interactive(blockbook_url)
     outputs = _get_outputs_interactive()
 
-    signtx = messages.SignTx()
+    signtx = messages.SignTx(outputs_count=len(outputs), inputs_count=len(inputs))
     signtx.version = prompt("Transaction version", type=int, default=2)
     signtx.lock_time = prompt("Transaction locktime", type=int, default=0)
 


### PR DESCRIPTION
On `master` the SignTx class creation has changed from v0.12.2.  Since we have already created the inputs and outputs, it costs us nothing to name them in the class creation to avoid the instantiation error.  This also makes the call backwards compatible with v0.12.*, should that be desired for any reason.