### PR TITLE
Keep call stack clean in modtrezorcrypto

### DIFF
--- a/core/embed/extmod/modtrezorcrypto/modtrezorcrypto-bip32.h
+++ b/core/embed/extmod/modtrezorcrypto/modtrezorcrypto-bip32.h
@@ -43,8 +43,8 @@ typedef struct _mp_obj_HDNode_t {
 
 STATIC const mp_obj_type_t mod_trezorcrypto_HDNode_type;
 
-#define XPUB_MAXLEN 128
-#define ADDRESS_MAXLEN 40
+#define XPUB_MAXLEN 112
+#define ADDRESS_MAXLEN 39
 
 /// def __init__(
 ///     self,
@@ -266,15 +266,18 @@ STATIC mp_obj_t mod_trezorcrypto_HDNode_serialize_public(mp_obj_t self,
                                                          mp_obj_t version) {
   uint32_t ver = trezor_obj_get_uint(version);
   mp_obj_HDNode_t *o = MP_OBJ_TO_PTR(self);
-  char xpub[XPUB_MAXLEN] = {0};
+  vstr_t xpub = {0};
+  vstr_init_len(&xpub, XPUB_MAXLEN);
   hdnode_fill_public_key(&o->hdnode);
-  int written = hdnode_serialize_public(&o->hdnode, o->fingerprint, ver, xpub,
-                                        XPUB_MAXLEN);
+  int written = hdnode_serialize_public(&o->hdnode, o->fingerprint, ver,
+                                        xpub.buf, xpub.alloc);
   if (written <= 0) {
+    vstr_clear(&xpub);
     mp_raise_ValueError("Failed to serialize");
   }
   // written includes NULL at the end of the string
-  return mp_obj_new_str_copy(&mp_type_str, (const uint8_t *)xpub, written - 1);
+  xpub.len = written - 1;
+  return mp_obj_new_str_from_vstr(&mp_type_str, &xpub);
 }
 STATIC MP_DEFINE_CONST_FUN_OBJ_2(mod_trezorcrypto_HDNode_serialize_public_obj,
                                  mod_trezorcrypto_HDNode_serialize_public);
@@ -383,10 +386,11 @@ STATIC mp_obj_t mod_trezorcrypto_HDNode_address(mp_obj_t self,
 
   uint32_t v = trezor_obj_get_uint(version);
 
-  char address[ADDRESS_MAXLEN] = {0};
-  hdnode_get_address(&o->hdnode, v, address, ADDRESS_MAXLEN);
-  return mp_obj_new_str_copy(&mp_type_str, (const uint8_t *)address,
-                             strlen(address));
+  vstr_t address = {0};
+  vstr_init_len(&address, ADDRESS_MAXLEN);
+  hdnode_get_address(&o->hdnode, v, address.buf, address.alloc);
+  address.len = strlen(address.buf);
+  return mp_obj_new_str_from_vstr(&mp_type_str, &address);
 }
 STATIC MP_DEFINE_CONST_FUN_OBJ_2(mod_trezorcrypto_HDNode_address_obj,
                                  mod_trezorcrypto_HDNode_address);
@@ -403,12 +407,14 @@ STATIC mp_obj_t mod_trezorcrypto_HDNode_nem_address(mp_obj_t self,
 
   uint8_t n = trezor_obj_get_uint8(network);
 
-  char address[NEM_ADDRESS_SIZE + 1] = {0};  // + 1 for the 0 byte
-  if (!hdnode_get_nem_address(&o->hdnode, n, address)) {
+  vstr_t address = {0};
+  vstr_init_len(&address, NEM_ADDRESS_SIZE);
+  if (!hdnode_get_nem_address(&o->hdnode, n, address.buf)) {
+    vstr_clear(&address);
     mp_raise_ValueError("Failed to compute a NEM address");
   }
-  return mp_obj_new_str_copy(&mp_type_str, (const uint8_t *)address,
-                             strlen(address));
+  address.len = strlen(address.buf);
+  return mp_obj_new_str_from_vstr(&mp_type_str, &address);
 }
 STATIC MP_DEFINE_CONST_FUN_OBJ_2(mod_trezorcrypto_HDNode_nem_address_obj,
                                  mod_trezorcrypto_HDNode_nem_address);
@@ -465,9 +471,10 @@ STATIC MP_DEFINE_CONST_FUN_OBJ_VAR_BETWEEN(
 STATIC mp_obj_t mod_trezorcrypto_HDNode_ethereum_pubkeyhash(mp_obj_t self) {
   mp_obj_HDNode_t *o = MP_OBJ_TO_PTR(self);
 
-  uint8_t pkh[20] = {0};
-  hdnode_get_ethereum_pubkeyhash(&o->hdnode, pkh);
-  return mp_obj_new_bytes(pkh, sizeof(pkh));
+  vstr_t pkh = {0};
+  vstr_init_len(&pkh, 20);
+  hdnode_get_ethereum_pubkeyhash(&o->hdnode, (uint8_t *)pkh.buf);
+  return mp_obj_new_str_from_vstr(&mp_type_bytes, &pkh);
 }
 STATIC MP_DEFINE_CONST_FUN_OBJ_1(
     mod_trezorcrypto_HDNode_ethereum_pubkeyhash_obj,

--- a/core/embed/extmod/modtrezorcrypto/modtrezorcrypto-bip32.h
+++ b/core/embed/extmod/modtrezorcrypto/modtrezorcrypto-bip32.h
@@ -43,9 +43,6 @@ typedef struct _mp_obj_HDNode_t {
 
 STATIC const mp_obj_type_t mod_trezorcrypto_HDNode_type;
 
-#define XPUB_MAXLEN 112
-#define ADDRESS_MAXLEN 39
-
 /// def __init__(
 ///     self,
 ///     depth: int,

--- a/core/embed/extmod/modtrezorcrypto/modtrezorcrypto-bip39.h
+++ b/core/embed/extmod/modtrezorcrypto/modtrezorcrypto-bip39.h
@@ -21,6 +21,7 @@
 #include "py/runtime.h"
 
 #include "bip39.h"
+#include "sha2.h"
 
 /// package: trezorcrypto.bip39
 
@@ -135,19 +136,21 @@ STATIC mp_obj_t mod_trezorcrypto_bip39_seed(size_t n_args,
   mp_buffer_info_t phrase = {0};
   mp_get_buffer_raise(args[0], &mnemo, MP_BUFFER_READ);
   mp_get_buffer_raise(args[1], &phrase, MP_BUFFER_READ);
-  uint8_t seed[64] = {0};
+  vstr_t seed = {0};
+  vstr_init_len(&seed, SHA512_DIGEST_LENGTH);
   const char *pmnemonic = mnemo.len > 0 ? mnemo.buf : "";
   const char *ppassphrase = phrase.len > 0 ? phrase.buf : "";
   if (n_args > 2) {
     // generate with a progress callback
     ui_wait_callback = args[2];
-    mnemonic_to_seed(pmnemonic, ppassphrase, seed, wrapped_ui_wait_callback);
+    mnemonic_to_seed(pmnemonic, ppassphrase, (uint8_t *)seed.buf,
+                     wrapped_ui_wait_callback);
     ui_wait_callback = mp_const_none;
   } else {
     // generate without callback
-    mnemonic_to_seed(pmnemonic, ppassphrase, seed, NULL);
+    mnemonic_to_seed(pmnemonic, ppassphrase, (uint8_t *)seed.buf, NULL);
   }
-  return mp_obj_new_bytes(seed, sizeof(seed));
+  return mp_obj_new_str_from_vstr(&mp_type_bytes, &seed);
 }
 STATIC MP_DEFINE_CONST_FUN_OBJ_VAR_BETWEEN(mod_trezorcrypto_bip39_seed_obj, 2,
                                            3, mod_trezorcrypto_bip39_seed);

--- a/core/embed/extmod/modtrezorcrypto/modtrezorcrypto-blake256.h
+++ b/core/embed/extmod/modtrezorcrypto/modtrezorcrypto-blake256.h
@@ -77,12 +77,13 @@ STATIC MP_DEFINE_CONST_FUN_OBJ_2(mod_trezorcrypto_Blake256_update_obj,
 ///     """
 STATIC mp_obj_t mod_trezorcrypto_Blake256_digest(mp_obj_t self) {
   mp_obj_Blake256_t *o = MP_OBJ_TO_PTR(self);
-  uint8_t hash[BLAKE256_DIGEST_LENGTH] = {0};
+  vstr_t hash = {0};
+  vstr_init_len(&hash, BLAKE256_DIGEST_LENGTH);
   BLAKE256_CTX ctx = {0};
   memcpy(&ctx, &(o->ctx), sizeof(BLAKE256_CTX));
-  blake256_Final(&ctx, hash);
+  blake256_Final(&ctx, (uint8_t *)hash.buf);
   memzero(&ctx, sizeof(BLAKE256_CTX));
-  return mp_obj_new_bytes(hash, sizeof(hash));
+  return mp_obj_new_str_from_vstr(&mp_type_bytes, &hash);
 }
 STATIC MP_DEFINE_CONST_FUN_OBJ_1(mod_trezorcrypto_Blake256_digest_obj,
                                  mod_trezorcrypto_Blake256_digest);

--- a/core/embed/extmod/modtrezorcrypto/modtrezorcrypto-blake2b.h
+++ b/core/embed/extmod/modtrezorcrypto/modtrezorcrypto-blake2b.h
@@ -131,12 +131,13 @@ STATIC MP_DEFINE_CONST_FUN_OBJ_2(mod_trezorcrypto_Blake2b_update_obj,
 ///     """
 STATIC mp_obj_t mod_trezorcrypto_Blake2b_digest(mp_obj_t self) {
   mp_obj_Blake2b_t *o = MP_OBJ_TO_PTR(self);
-  uint8_t out[BLAKE2B_DIGEST_LENGTH] = {0};
   BLAKE2B_CTX ctx = {0};
   memcpy(&ctx, &(o->ctx), sizeof(BLAKE2B_CTX));
-  blake2b_Final(&ctx, out, ctx.outlen);
+  vstr_t hash = {0};
+  vstr_init_len(&hash, ctx.outlen);
+  blake2b_Final(&ctx, (uint8_t *)hash.buf, hash.len);
   memzero(&ctx, sizeof(BLAKE2B_CTX));
-  return mp_obj_new_bytes(out, o->ctx.outlen);
+  return mp_obj_new_str_from_vstr(&mp_type_bytes, &hash);
 }
 STATIC MP_DEFINE_CONST_FUN_OBJ_1(mod_trezorcrypto_Blake2b_digest_obj,
                                  mod_trezorcrypto_Blake2b_digest);

--- a/core/embed/extmod/modtrezorcrypto/modtrezorcrypto-blake2s.h
+++ b/core/embed/extmod/modtrezorcrypto/modtrezorcrypto-blake2s.h
@@ -131,12 +131,13 @@ STATIC MP_DEFINE_CONST_FUN_OBJ_2(mod_trezorcrypto_Blake2s_update_obj,
 ///     """
 STATIC mp_obj_t mod_trezorcrypto_Blake2s_digest(mp_obj_t self) {
   mp_obj_Blake2s_t *o = MP_OBJ_TO_PTR(self);
-  uint8_t out[BLAKE2S_DIGEST_LENGTH] = {0};
   BLAKE2S_CTX ctx = {0};
   memcpy(&ctx, &(o->ctx), sizeof(BLAKE2S_CTX));
-  blake2s_Final(&ctx, out, ctx.outlen);
+  vstr_t hash = {0};
+  vstr_init_len(&hash, ctx.outlen);
+  blake2s_Final(&ctx, (uint8_t *)hash.buf, hash.len);
   memzero(&ctx, sizeof(BLAKE2S_CTX));
-  return mp_obj_new_bytes(out, o->ctx.outlen);
+  return mp_obj_new_str_from_vstr(&mp_type_bytes, &hash);
 }
 STATIC MP_DEFINE_CONST_FUN_OBJ_1(mod_trezorcrypto_Blake2s_digest_obj,
                                  mod_trezorcrypto_Blake2s_digest);

--- a/core/embed/extmod/modtrezorcrypto/modtrezorcrypto-chacha20poly1305.h
+++ b/core/embed/extmod/modtrezorcrypto/modtrezorcrypto-chacha20poly1305.h
@@ -123,9 +123,10 @@ STATIC MP_DEFINE_CONST_FUN_OBJ_2(mod_trezorcrypto_ChaCha20Poly1305_auth_obj,
 ///     """
 STATIC mp_obj_t mod_trezorcrypto_ChaCha20Poly1305_finish(mp_obj_t self) {
   mp_obj_ChaCha20Poly1305_t *o = MP_OBJ_TO_PTR(self);
-  uint8_t out[16] = {0};
-  rfc7539_finish(&(o->ctx), o->alen, o->plen, out);
-  return mp_obj_new_bytes(out, sizeof(out));
+  vstr_t mac = {0};
+  vstr_init_len(&mac, 16);
+  rfc7539_finish(&(o->ctx), o->alen, o->plen, (uint8_t *)mac.buf);
+  return mp_obj_new_str_from_vstr(&mp_type_bytes, &mac);
 }
 STATIC MP_DEFINE_CONST_FUN_OBJ_1(mod_trezorcrypto_ChaCha20Poly1305_finish_obj,
                                  mod_trezorcrypto_ChaCha20Poly1305_finish);

--- a/core/embed/extmod/modtrezorcrypto/modtrezorcrypto-curve25519.h
+++ b/core/embed/extmod/modtrezorcrypto/modtrezorcrypto-curve25519.h
@@ -30,13 +30,14 @@
 ///     Generate secret key.
 ///     """
 STATIC mp_obj_t mod_trezorcrypto_curve25519_generate_secret() {
-  uint8_t out[32] = {0};
-  random_buffer(out, 32);
+  vstr_t sk = {0};
+  vstr_init_len(&sk, 32);
+  random_buffer((uint8_t *)sk.buf, sk.len);
   // taken from https://cr.yp.to/ecdh.html
-  out[0] &= 248;
-  out[31] &= 127;
-  out[31] |= 64;
-  return mp_obj_new_bytes(out, sizeof(out));
+  sk.buf[0] &= 248;
+  sk.buf[31] &= 127;
+  sk.buf[31] |= 64;
+  return mp_obj_new_str_from_vstr(&mp_type_bytes, &sk);
 }
 STATIC MP_DEFINE_CONST_FUN_OBJ_0(
     mod_trezorcrypto_curve25519_generate_secret_obj,
@@ -52,9 +53,10 @@ STATIC mp_obj_t mod_trezorcrypto_curve25519_publickey(mp_obj_t secret_key) {
   if (sk.len != 32) {
     mp_raise_ValueError("Invalid length of secret key");
   }
-  uint8_t out[32] = {0};
-  curve25519_scalarmult_basepoint(out, (const uint8_t *)sk.buf);
-  return mp_obj_new_bytes(out, sizeof(out));
+  vstr_t pk = {0};
+  vstr_init_len(&pk, 32);
+  curve25519_scalarmult_basepoint((uint8_t *)pk.buf, (const uint8_t *)sk.buf);
+  return mp_obj_new_str_from_vstr(&mp_type_bytes, &pk);
 }
 STATIC MP_DEFINE_CONST_FUN_OBJ_1(mod_trezorcrypto_curve25519_publickey_obj,
                                  mod_trezorcrypto_curve25519_publickey);
@@ -75,9 +77,11 @@ STATIC mp_obj_t mod_trezorcrypto_curve25519_multiply(mp_obj_t secret_key,
   if (pk.len != 32) {
     mp_raise_ValueError("Invalid length of public key");
   }
-  uint8_t out[32] = {0};
-  curve25519_scalarmult(out, (const uint8_t *)sk.buf, (const uint8_t *)pk.buf);
-  return mp_obj_new_bytes(out, sizeof(out));
+  vstr_t out = {0};
+  vstr_init_len(&out, 32);
+  curve25519_scalarmult((uint8_t *)out.buf, (const uint8_t *)sk.buf,
+                        (const uint8_t *)pk.buf);
+  return mp_obj_new_str_from_vstr(&mp_type_bytes, &out);
 }
 STATIC MP_DEFINE_CONST_FUN_OBJ_2(mod_trezorcrypto_curve25519_multiply_obj,
                                  mod_trezorcrypto_curve25519_multiply);

--- a/core/embed/extmod/modtrezorcrypto/modtrezorcrypto-groestl.h
+++ b/core/embed/extmod/modtrezorcrypto/modtrezorcrypto-groestl.h
@@ -81,12 +81,13 @@ STATIC MP_DEFINE_CONST_FUN_OBJ_2(mod_trezorcrypto_Groestl512_update_obj,
 ///     """
 STATIC mp_obj_t mod_trezorcrypto_Groestl512_digest(mp_obj_t self) {
   mp_obj_Groestl512_t *o = MP_OBJ_TO_PTR(self);
-  uint8_t out[GROESTL512_DIGEST_LENGTH] = {0};
+  vstr_t hash = {0};
+  vstr_init_len(&hash, GROESTL512_DIGEST_LENGTH);
   GROESTL512_CTX ctx = {0};
   memcpy(&ctx, &(o->ctx), sizeof(GROESTL512_CTX));
-  groestl512_Final(&ctx, out);
+  groestl512_Final(&ctx, (uint8_t *)hash.buf);
   memzero(&ctx, sizeof(GROESTL512_CTX));
-  return mp_obj_new_bytes(out, sizeof(out));
+  return mp_obj_new_str_from_vstr(&mp_type_bytes, &hash);
 }
 STATIC MP_DEFINE_CONST_FUN_OBJ_1(mod_trezorcrypto_Groestl512_digest_obj,
                                  mod_trezorcrypto_Groestl512_digest);

--- a/core/embed/extmod/modtrezorcrypto/modtrezorcrypto-nist256p1.h
+++ b/core/embed/extmod/modtrezorcrypto/modtrezorcrypto-nist256p1.h
@@ -29,27 +29,28 @@
 ///     Generate secret key.
 ///     """
 STATIC mp_obj_t mod_trezorcrypto_nist256p1_generate_secret() {
-  uint8_t out[32] = {0};
+  vstr_t sk = {0};
+  vstr_init_len(&sk, 32);
   for (;;) {
-    random_buffer(out, 32);
+    random_buffer((uint8_t *)sk.buf, sk.len);
     // check whether secret > 0 && secret < curve_order
     if (0 ==
         memcmp(
-            out,
+            sk.buf,
             "\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00"
             "\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00",
-            32))
+            sk.len))
       continue;
     if (0 <=
         memcmp(
-            out,
+            sk.buf,
             "\xFF\xFF\xFF\xFF\x00\x00\x00\x00\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF"
             "\xBC\xE6\xFA\xAD\xA7\x17\x9E\x84\xF3\xB9\xCA\xC2\xFC\x63\x25\x51",
-            32))
+            sk.len))
       continue;
     break;
   }
-  return mp_obj_new_bytes(out, sizeof(out));
+  return mp_obj_new_str_from_vstr(&mp_type_bytes, &sk);
 }
 STATIC MP_DEFINE_CONST_FUN_OBJ_0(mod_trezorcrypto_nist256p1_generate_secret_obj,
                                  mod_trezorcrypto_nist256p1_generate_secret);
@@ -65,16 +66,18 @@ STATIC mp_obj_t mod_trezorcrypto_nist256p1_publickey(size_t n_args,
   if (sk.len != 32) {
     mp_raise_ValueError("Invalid length of secret key");
   }
+  vstr_t pk = {0};
   bool compressed = n_args < 2 || args[1] == mp_const_true;
   if (compressed) {
-    uint8_t out[33] = {0};
-    ecdsa_get_public_key33(&nist256p1, (const uint8_t *)sk.buf, out);
-    return mp_obj_new_bytes(out, sizeof(out));
+    vstr_init_len(&pk, 33);
+    ecdsa_get_public_key33(&nist256p1, (const uint8_t *)sk.buf,
+                           (uint8_t *)pk.buf);
   } else {
-    uint8_t out[65] = {0};
-    ecdsa_get_public_key65(&nist256p1, (const uint8_t *)sk.buf, out);
-    return mp_obj_new_bytes(out, sizeof(out));
+    vstr_init_len(&pk, 65);
+    ecdsa_get_public_key65(&nist256p1, (const uint8_t *)sk.buf,
+                           (uint8_t *)pk.buf);
   }
+  return mp_obj_new_str_from_vstr(&mp_type_bytes, &pk);
 }
 STATIC MP_DEFINE_CONST_FUN_OBJ_VAR_BETWEEN(
     mod_trezorcrypto_nist256p1_publickey_obj, 1, 2,
@@ -88,7 +91,8 @@ STATIC MP_DEFINE_CONST_FUN_OBJ_VAR_BETWEEN(
 ///     """
 STATIC mp_obj_t mod_trezorcrypto_nist256p1_sign(size_t n_args,
                                                 const mp_obj_t *args) {
-  mp_buffer_info_t sk = {0}, dig = {0};
+  mp_buffer_info_t sk = {0};
+  mp_buffer_info_t dig = {0};
   mp_get_buffer_raise(args[0], &sk, MP_BUFFER_READ);
   mp_get_buffer_raise(args[1], &dig, MP_BUFFER_READ);
   bool compressed = n_args < 3 || args[2] == mp_const_true;
@@ -98,13 +102,17 @@ STATIC mp_obj_t mod_trezorcrypto_nist256p1_sign(size_t n_args,
   if (dig.len != 32) {
     mp_raise_ValueError("Invalid length of digest");
   }
-  uint8_t out[65] = {0}, pby = 0;
+  vstr_t sig = {0};
+  vstr_init_len(&sig, 65);
+  uint8_t pby = 0;
   if (0 != ecdsa_sign_digest(&nist256p1, (const uint8_t *)sk.buf,
-                             (const uint8_t *)dig.buf, out + 1, &pby, NULL)) {
+                             (const uint8_t *)dig.buf, (uint8_t *)sig.buf + 1,
+                             &pby, NULL)) {
+    vstr_clear(&sig);
     mp_raise_ValueError("Signing failed");
   }
-  out[0] = 27 + pby + compressed * 4;
-  return mp_obj_new_bytes(out, sizeof(out));
+  sig.buf[0] = 27 + pby + compressed * 4;
+  return mp_obj_new_str_from_vstr(&mp_type_bytes, &sig);
 }
 STATIC MP_DEFINE_CONST_FUN_OBJ_VAR_BETWEEN(mod_trezorcrypto_nist256p1_sign_obj,
                                            2, 3,
@@ -162,15 +170,16 @@ STATIC mp_obj_t mod_trezorcrypto_nist256p1_verify_recover(mp_obj_t signature,
   }
   bool compressed = (recid >= 4);
   recid &= 3;
-  uint8_t out[65] = {0};
-  if (0 == ecdsa_recover_pub_from_sig(&nist256p1, out,
+  vstr_t pk = {0};
+  vstr_init_len(&pk, 65);
+  if (0 == ecdsa_recover_pub_from_sig(&nist256p1, (uint8_t *)pk.buf,
                                       (const uint8_t *)sig.buf + 1,
                                       (const uint8_t *)dig.buf, recid)) {
     if (compressed) {
-      out[0] = 0x02 | (out[64] & 1);
-      return mp_obj_new_bytes(out, 33);
+      pk.buf[0] = 0x02 | (pk.buf[64] & 1);
+      pk.len = 33;
     }
-    return mp_obj_new_bytes(out, sizeof(out));
+    return mp_obj_new_str_from_vstr(&mp_type_bytes, &pk);
   } else {
     return mp_const_none;
   }
@@ -194,12 +203,14 @@ STATIC mp_obj_t mod_trezorcrypto_nist256p1_multiply(mp_obj_t secret_key,
   if (pk.len != 33 && pk.len != 65) {
     mp_raise_ValueError("Invalid length of public key");
   }
-  uint8_t out[65] = {0};
+  vstr_t out = {0};
+  vstr_init_len(&out, 65);
   if (0 != ecdh_multiply(&nist256p1, (const uint8_t *)sk.buf,
-                         (const uint8_t *)pk.buf, out)) {
+                         (const uint8_t *)pk.buf, (uint8_t *)out.buf)) {
+    vstr_clear(&out);
     mp_raise_ValueError("Multiply failed");
   }
-  return mp_obj_new_bytes(out, sizeof(out));
+  return mp_obj_new_str_from_vstr(&mp_type_bytes, &out);
 }
 STATIC MP_DEFINE_CONST_FUN_OBJ_2(mod_trezorcrypto_nist256p1_multiply_obj,
                                  mod_trezorcrypto_nist256p1_multiply);

--- a/core/embed/extmod/modtrezorcrypto/modtrezorcrypto-ripemd160.h
+++ b/core/embed/extmod/modtrezorcrypto/modtrezorcrypto-ripemd160.h
@@ -78,12 +78,13 @@ STATIC MP_DEFINE_CONST_FUN_OBJ_2(mod_trezorcrypto_Ripemd160_update_obj,
 ///     """
 STATIC mp_obj_t mod_trezorcrypto_Ripemd160_digest(mp_obj_t self) {
   mp_obj_Ripemd160_t *o = MP_OBJ_TO_PTR(self);
-  uint8_t out[RIPEMD160_DIGEST_LENGTH] = {0};
+  vstr_t hash = {0};
+  vstr_init_len(&hash, RIPEMD160_DIGEST_LENGTH);
   RIPEMD160_CTX ctx = {0};
   memcpy(&ctx, &(o->ctx), sizeof(RIPEMD160_CTX));
-  ripemd160_Final(&ctx, out);
+  ripemd160_Final(&ctx, (uint8_t *)hash.buf);
   memzero(&ctx, sizeof(RIPEMD160_CTX));
-  return mp_obj_new_bytes(out, sizeof(out));
+  return mp_obj_new_str_from_vstr(&mp_type_bytes, &hash);
 }
 STATIC MP_DEFINE_CONST_FUN_OBJ_1(mod_trezorcrypto_Ripemd160_digest_obj,
                                  mod_trezorcrypto_Ripemd160_digest);

--- a/core/embed/extmod/modtrezorcrypto/modtrezorcrypto-secp256k1.h
+++ b/core/embed/extmod/modtrezorcrypto/modtrezorcrypto-secp256k1.h
@@ -29,27 +29,28 @@
 ///     Generate secret key.
 ///     """
 STATIC mp_obj_t mod_trezorcrypto_secp256k1_generate_secret() {
-  uint8_t out[32] = {0};
+  vstr_t sk = {0};
+  vstr_init_len(&sk, 32);
   for (;;) {
-    random_buffer(out, 32);
+    random_buffer((uint8_t *)sk.buf, sk.len);
     // check whether secret > 0 && secret < curve_order
     if (0 ==
         memcmp(
-            out,
+            sk.buf,
             "\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00"
             "\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00",
             32))
       continue;
     if (0 <=
         memcmp(
-            out,
+            sk.buf,
             "\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFE"
             "\xBA\xAE\xDC\xE6\xAF\x48\xA0\x3B\xBF\xD2\x5E\x8C\xD0\x36\x41\x41",
             32))
       continue;
     break;
   }
-  return mp_obj_new_bytes(out, sizeof(out));
+  return mp_obj_new_str_from_vstr(&mp_type_bytes, &sk);
 }
 STATIC MP_DEFINE_CONST_FUN_OBJ_0(mod_trezorcrypto_secp256k1_generate_secret_obj,
                                  mod_trezorcrypto_secp256k1_generate_secret);
@@ -65,16 +66,18 @@ STATIC mp_obj_t mod_trezorcrypto_secp256k1_publickey(size_t n_args,
   if (sk.len != 32) {
     mp_raise_ValueError("Invalid length of secret key");
   }
+  vstr_t pk = {0};
   bool compressed = n_args < 2 || args[1] == mp_const_true;
   if (compressed) {
-    uint8_t out[33] = {0};
-    ecdsa_get_public_key33(&secp256k1, (const uint8_t *)sk.buf, out);
-    return mp_obj_new_bytes(out, sizeof(out));
+    vstr_init_len(&pk, 33);
+    ecdsa_get_public_key33(&secp256k1, (const uint8_t *)sk.buf,
+                           (uint8_t *)pk.buf);
   } else {
-    uint8_t out[65] = {0};
-    ecdsa_get_public_key65(&secp256k1, (const uint8_t *)sk.buf, out);
-    return mp_obj_new_bytes(out, sizeof(out));
+    vstr_init_len(&pk, 65);
+    ecdsa_get_public_key65(&secp256k1, (const uint8_t *)sk.buf,
+                           (uint8_t *)pk.buf);
   }
+  return mp_obj_new_str_from_vstr(&mp_type_bytes, &pk);
 }
 STATIC MP_DEFINE_CONST_FUN_OBJ_VAR_BETWEEN(
     mod_trezorcrypto_secp256k1_publickey_obj, 1, 2,
@@ -117,7 +120,8 @@ enum {
 ///     """
 STATIC mp_obj_t mod_trezorcrypto_secp256k1_sign(size_t n_args,
                                                 const mp_obj_t *args) {
-  mp_buffer_info_t sk = {0}, dig = {0};
+  mp_buffer_info_t sk = {0};
+  mp_buffer_info_t dig = {0};
   mp_get_buffer_raise(args[0], &sk, MP_BUFFER_READ);
   mp_get_buffer_raise(args[1], &dig, MP_BUFFER_READ);
   bool compressed = (n_args < 3) || (args[2] == mp_const_true);
@@ -139,14 +143,17 @@ STATIC mp_obj_t mod_trezorcrypto_secp256k1_sign(size_t n_args,
   if (dig.len != 32) {
     mp_raise_ValueError("Invalid length of digest");
   }
-  uint8_t out[65] = {0}, pby = 0;
+  vstr_t sig = {0};
+  vstr_init_len(&sig, 65);
+  uint8_t pby = 0;
   if (0 != ecdsa_sign_digest(&secp256k1, (const uint8_t *)sk.buf,
-                             (const uint8_t *)dig.buf, out + 1, &pby,
-                             is_canonical)) {
+                             (const uint8_t *)dig.buf, (uint8_t *)sig.buf + 1,
+                             &pby, is_canonical)) {
+    vstr_clear(&sig);
     mp_raise_ValueError("Signing failed");
   }
-  out[0] = 27 + pby + compressed * 4;
-  return mp_obj_new_bytes(out, sizeof(out));
+  sig.buf[0] = 27 + pby + compressed * 4;
+  return mp_obj_new_str_from_vstr(&mp_type_bytes, &sig);
 }
 STATIC MP_DEFINE_CONST_FUN_OBJ_VAR_BETWEEN(mod_trezorcrypto_secp256k1_sign_obj,
                                            2, 4,
@@ -204,15 +211,16 @@ STATIC mp_obj_t mod_trezorcrypto_secp256k1_verify_recover(mp_obj_t signature,
   }
   bool compressed = (recid >= 4);
   recid &= 3;
-  uint8_t out[65] = {0};
-  if (0 == ecdsa_recover_pub_from_sig(&secp256k1, out,
+  vstr_t pk = {0};
+  vstr_init_len(&pk, 65);
+  if (0 == ecdsa_recover_pub_from_sig(&secp256k1, (uint8_t *)pk.buf,
                                       (const uint8_t *)sig.buf + 1,
                                       (const uint8_t *)dig.buf, recid)) {
     if (compressed) {
-      out[0] = 0x02 | (out[64] & 1);
-      return mp_obj_new_bytes(out, 33);
+      pk.buf[0] = 0x02 | (pk.buf[64] & 1);
+      pk.len = 33;
     }
-    return mp_obj_new_bytes(out, sizeof(out));
+    return mp_obj_new_str_from_vstr(&mp_type_bytes, &pk);
   } else {
     return mp_const_none;
   }
@@ -236,12 +244,14 @@ STATIC mp_obj_t mod_trezorcrypto_secp256k1_multiply(mp_obj_t secret_key,
   if (pk.len != 33 && pk.len != 65) {
     mp_raise_ValueError("Invalid length of public key");
   }
-  uint8_t out[65] = {0};
+  vstr_t out = {0};
+  vstr_init_len(&out, 65);
   if (0 != ecdh_multiply(&secp256k1, (const uint8_t *)sk.buf,
-                         (const uint8_t *)pk.buf, out)) {
+                         (const uint8_t *)pk.buf, (uint8_t *)out.buf)) {
+    vstr_clear(&out);
     mp_raise_ValueError("Multiply failed");
   }
-  return mp_obj_new_bytes(out, sizeof(out));
+  return mp_obj_new_str_from_vstr(&mp_type_bytes, &out);
 }
 STATIC MP_DEFINE_CONST_FUN_OBJ_2(mod_trezorcrypto_secp256k1_multiply_obj,
                                  mod_trezorcrypto_secp256k1_multiply);

--- a/core/embed/extmod/modtrezorcrypto/modtrezorcrypto-sha1.h
+++ b/core/embed/extmod/modtrezorcrypto/modtrezorcrypto-sha1.h
@@ -77,12 +77,13 @@ STATIC MP_DEFINE_CONST_FUN_OBJ_2(mod_trezorcrypto_Sha1_update_obj,
 ///     """
 STATIC mp_obj_t mod_trezorcrypto_Sha1_digest(mp_obj_t self) {
   mp_obj_Sha1_t *o = MP_OBJ_TO_PTR(self);
-  uint8_t out[SHA1_DIGEST_LENGTH] = {0};
+  vstr_t hash = {0};
+  vstr_init_len(&hash, SHA1_DIGEST_LENGTH);
   SHA1_CTX ctx = {0};
   memcpy(&ctx, &(o->ctx), sizeof(SHA1_CTX));
-  sha1_Final(&ctx, out);
+  sha1_Final(&ctx, (uint8_t *)hash.buf);
   memzero(&ctx, sizeof(SHA1_CTX));
-  return mp_obj_new_bytes(out, sizeof(out));
+  return mp_obj_new_str_from_vstr(&mp_type_bytes, &hash);
 }
 STATIC MP_DEFINE_CONST_FUN_OBJ_1(mod_trezorcrypto_Sha1_digest_obj,
                                  mod_trezorcrypto_Sha1_digest);

--- a/core/embed/extmod/modtrezorcrypto/modtrezorcrypto-sha256.h
+++ b/core/embed/extmod/modtrezorcrypto/modtrezorcrypto-sha256.h
@@ -77,12 +77,13 @@ STATIC MP_DEFINE_CONST_FUN_OBJ_2(mod_trezorcrypto_Sha256_update_obj,
 ///     """
 STATIC mp_obj_t mod_trezorcrypto_Sha256_digest(mp_obj_t self) {
   mp_obj_Sha256_t *o = MP_OBJ_TO_PTR(self);
-  uint8_t out[SHA256_DIGEST_LENGTH] = {0};
+  vstr_t hash = {0};
+  vstr_init_len(&hash, SHA256_DIGEST_LENGTH);
   SHA256_CTX ctx = {0};
   memcpy(&ctx, &(o->ctx), sizeof(SHA256_CTX));
-  sha256_Final(&ctx, out);
+  sha256_Final(&ctx, (uint8_t *)hash.buf);
   memzero(&ctx, sizeof(SHA256_CTX));
-  return mp_obj_new_bytes(out, sizeof(out));
+  return mp_obj_new_str_from_vstr(&mp_type_bytes, &hash);
 }
 STATIC MP_DEFINE_CONST_FUN_OBJ_1(mod_trezorcrypto_Sha256_digest_obj,
                                  mod_trezorcrypto_Sha256_digest);

--- a/core/embed/extmod/modtrezorcrypto/modtrezorcrypto-sha3-256.h
+++ b/core/embed/extmod/modtrezorcrypto/modtrezorcrypto-sha3-256.h
@@ -90,16 +90,17 @@ STATIC MP_DEFINE_CONST_FUN_OBJ_2(mod_trezorcrypto_Sha3_256_update_obj,
 ///     """
 STATIC mp_obj_t mod_trezorcrypto_Sha3_256_digest(mp_obj_t self) {
   mp_obj_Sha3_256_t *o = MP_OBJ_TO_PTR(self);
-  uint8_t out[SHA3_256_DIGEST_LENGTH] = {0};
+  vstr_t hash = {0};
+  vstr_init_len(&hash, SHA3_256_DIGEST_LENGTH);
   SHA3_CTX ctx = {0};
   memcpy(&ctx, &(o->ctx), sizeof(SHA3_CTX));
   if (o->keccak) {
-    keccak_Final(&ctx, out);
+    keccak_Final(&ctx, (uint8_t *)hash.buf);
   } else {
-    sha3_Final(&ctx, out);
+    sha3_Final(&ctx, (uint8_t *)hash.buf);
   }
   memzero(&ctx, sizeof(SHA3_CTX));
-  return mp_obj_new_bytes(out, sizeof(out));
+  return mp_obj_new_str_from_vstr(&mp_type_bytes, &hash);
 }
 STATIC MP_DEFINE_CONST_FUN_OBJ_1(mod_trezorcrypto_Sha3_256_digest_obj,
                                  mod_trezorcrypto_Sha3_256_digest);

--- a/core/embed/extmod/modtrezorcrypto/modtrezorcrypto-sha3-512.h
+++ b/core/embed/extmod/modtrezorcrypto/modtrezorcrypto-sha3-512.h
@@ -90,16 +90,17 @@ STATIC MP_DEFINE_CONST_FUN_OBJ_2(mod_trezorcrypto_Sha3_512_update_obj,
 ///     """
 STATIC mp_obj_t mod_trezorcrypto_Sha3_512_digest(mp_obj_t self) {
   mp_obj_Sha3_512_t *o = MP_OBJ_TO_PTR(self);
-  uint8_t out[SHA3_512_DIGEST_LENGTH] = {0};
+  vstr_t hash = {0};
+  vstr_init_len(&hash, SHA3_512_DIGEST_LENGTH);
   SHA3_CTX ctx = {0};
   memcpy(&ctx, &(o->ctx), sizeof(SHA3_CTX));
   if (o->keccak) {
-    keccak_Final(&ctx, out);
+    keccak_Final(&ctx, (uint8_t *)hash.buf);
   } else {
-    sha3_Final(&ctx, out);
+    sha3_Final(&ctx, (uint8_t *)hash.buf);
   }
   memzero(&ctx, sizeof(SHA3_CTX));
-  return mp_obj_new_bytes(out, sizeof(out));
+  return mp_obj_new_str_from_vstr(&mp_type_bytes, &hash);
 }
 STATIC MP_DEFINE_CONST_FUN_OBJ_1(mod_trezorcrypto_Sha3_512_digest_obj,
                                  mod_trezorcrypto_Sha3_512_digest);

--- a/core/embed/extmod/modtrezorcrypto/modtrezorcrypto-sha512.h
+++ b/core/embed/extmod/modtrezorcrypto/modtrezorcrypto-sha512.h
@@ -76,12 +76,13 @@ STATIC MP_DEFINE_CONST_FUN_OBJ_2(mod_trezorcrypto_Sha512_update_obj,
 ///     """
 STATIC mp_obj_t mod_trezorcrypto_Sha512_digest(mp_obj_t self) {
   mp_obj_Sha512_t *o = MP_OBJ_TO_PTR(self);
-  uint8_t out[SHA512_DIGEST_LENGTH] = {0};
+  vstr_t hash = {0};
+  vstr_init_len(&hash, SHA512_DIGEST_LENGTH);
   SHA512_CTX ctx = {0};
   memcpy(&ctx, &(o->ctx), sizeof(SHA512_CTX));
-  sha512_Final(&ctx, out);
+  sha512_Final(&ctx, (uint8_t *)hash.buf);
   memzero(&ctx, sizeof(SHA512_CTX));
-  return mp_obj_new_bytes(out, sizeof(out));
+  return mp_obj_new_str_from_vstr(&mp_type_bytes, &hash);
 }
 STATIC MP_DEFINE_CONST_FUN_OBJ_1(mod_trezorcrypto_Sha512_digest_obj,
                                  mod_trezorcrypto_Sha512_digest);

--- a/crypto/bip32.h
+++ b/crypto/bip32.h
@@ -31,6 +31,12 @@
 #include "ed25519-donna/ed25519.h"
 #include "options.h"
 
+// Maximum length of a Base58Check-encoded extended public or private key.
+#define XPUB_MAXLEN 112
+
+// Maximum length of a Base58Check-encoded address.
+#define ADDRESS_MAXLEN 39
+
 typedef struct {
   const char *bip32_name;     // string for generating BIP32 xprv from seed
   const ecdsa_curve *params;  // ecdsa curve parameters, null for ed25519

--- a/crypto/tests/test_check.c
+++ b/crypto/tests/test_check.c
@@ -1213,7 +1213,7 @@ END_TEST
 START_TEST(test_bip32_vector_1) {
   HDNode node, node2, node3;
   uint32_t fingerprint;
-  char str[112];
+  char str[XPUB_MAXLEN];
   int r;
 
   // init m
@@ -1473,7 +1473,7 @@ END_TEST
 START_TEST(test_bip32_vector_2) {
   HDNode node, node2, node3;
   uint32_t fingerprint;
-  char str[112];
+  char str[XPUB_MAXLEN];
   int r;
 
   // init m
@@ -1770,7 +1770,7 @@ END_TEST
 START_TEST(test_bip32_vector_3) {
   HDNode node, node2, node3;
   uint32_t fingerprint;
-  char str[112];
+  char str[XPUB_MAXLEN];
   int r;
 
   // init m
@@ -2758,7 +2758,7 @@ END_TEST
 START_TEST(test_bip32_decred_vector_1) {
   HDNode node, node2, node3;
   uint32_t fingerprint;
-  char str[112];
+  char str[XPUB_MAXLEN];
   int r;
 
   // init m
@@ -3028,7 +3028,7 @@ END_TEST
 START_TEST(test_bip32_decred_vector_2) {
   HDNode node, node2, node3;
   uint32_t fingerprint;
-  char str[112];
+  char str[XPUB_MAXLEN];
   int r;
 
   // init m

--- a/legacy/firmware/fsm.c
+++ b/legacy/firmware/fsm.c
@@ -262,7 +262,7 @@ static bool fsm_layoutAddress(const char *address, const char *desc,
       default: {  // show XPUBs
         int index = (screen - 2) / 2;
         int page = (screen - 2) % 2;
-        char xpub[112] = {0};
+        char xpub[XPUB_MAXLEN] = {0};
         const HDNodeType *node_ptr = NULL;
         if (multisig->nodes_count) {  // use multisig->nodes
           node_ptr = &(multisig->nodes[index]);


### PR DESCRIPTION
I replaced most of the `mp_obj_new_bytes()` calls in modtrezorcrypto with `mp_obj_new_str_from_vstr()`, because often this usage has led to sensitive data being left on the call stack. The other option would have been to clean up using `memzero()`, but this way the data isn't even placed on the stack, so there is nothing to clean up, i.e. no chance of forgetting to clean it up. There are a number of places where the data in question is not sensitive like addresses or public keys, so the changes there are not necessary. Nevertheless, I made them anyway, because based on earlier discussion we want the returning of buffers to be handled consistently throughout modtrezorcrypto. It also reduces the likelihood of repeating this mistake in future code.