### PR TITLE
Expand cardano account index range from 20 to 100

### DIFF
--- a/core/src/apps/cardano/address.py
+++ b/core/src/apps/cardano/address.py
@@ -44,7 +44,7 @@ def validate_full_path(path: List[int]) -> bool:
         return False
     if path[1] != 1815 | HARDENED:
         return False
-    if path[2] < HARDENED or path[2] > 20 | HARDENED:
+    if path[2] < HARDENED or path[2] > 100 | HARDENED:
         return False
     if path[3] not in (0, 1, 2):
         return False

--- a/core/src/apps/cardano/get_public_key.py
+++ b/core/src/apps/cardano/get_public_key.py
@@ -73,7 +73,7 @@ def _validate_path_for_get_public_key(path: List[int]) -> bool:
         return False
     if path[1] != 1815 | HARDENED:
         return False
-    if path[2] < HARDENED or path[2] > 20 | HARDENED:
+    if path[2] < HARDENED or path[2] > 100 | HARDENED:
         return False
     if length > 3 and paths.is_hardened(path[3]):
         return False


### PR DESCRIPTION
Motivation: update max account index from 20 to 100 on IOHK request

Related to https://github.com/trezor/trezor-firmware/issues/1245 , namely

> we would like to improve the UX for working with accounts and also review the existing security limitations related to accounts (such as display warnings for exports of keys for account 20+, etc)