### PR TITLE
nix-shell: add deps needed

### DIFF
--- a/ci/shell.nix
+++ b/ci/shell.nix
@@ -31,6 +31,11 @@ stdenv.mkDerivation ({
     python37
     python36
   ] ++ [
+    python3Packages.click
+    python3Packages.munch
+    python3Packages.Mako
+    python3Packages.trezor
+    scons
     SDL2
     SDL2_image
     autoflake


### PR DESCRIPTION
Had issues with a few of the build steps lacking dependencies in the nix-shell from the ci build script:

https://github.com/trezor/trezor-firmware/blob/master/ci/build.yml#L13-L17

This adds scons, and python packages click, nunch, Mako and trezor to the shell.