### PR TITLE
Add CI job for generating memory usage report

### DIFF
--- a/ci/test.yml
+++ b/ci/test.yml
@@ -359,3 +359,24 @@ hardware legacy btconly device test:
       - ci/hardware_tests/video*.mp4
     expire_in: 2 days
     when: always
+
+core unix memory profiler:
+  stage: test
+  when: manual
+  needs: []
+  variables:
+    PYOPT: "0"
+    TREZOR_MEMPERF: "1"
+    PYTEST_TIMEOUT: "600"
+  script:
+    - nix-shell --run "poetry run make -C core build_unix_frozen"
+    - nix-shell --run "poetry run make -C core test_emu"
+    - nix-shell --run "mkdir core/prof/memperf-html"
+    - nix-shell --run "poetry run core/tools/alloc.py --alloc-data=core/src/alloc_data.txt html core/prof/memperf-html"
+  artifacts:
+    name: "$CI_JOB_NAME-$CI_COMMIT_SHORT_SHA"
+    paths:
+      - tests/trezor.log
+      - core/prof/memperf-html
+    expire_in: 1 week
+    when: always

--- a/core/Makefile
+++ b/core/Makefile
@@ -22,6 +22,7 @@ PYOPT      ?= 1
 BITCOIN_ONLY ?= 0
 RDI        ?= 1
 TREZOR_MODEL ?= T
+TREZOR_MEMPERF ?= 0
 
 STLINK_VER ?= v2
 OPENOCD = openocd -f interface/stlink-$(STLINK_VER).cfg -c "transport select hla_swd" -f target/stm32f4x.cfg
@@ -149,7 +150,7 @@ build_unix: res ## build unix port
 	$(SCONS) CFLAGS="$(CFLAGS)" $(UNIX_BUILD_DIR)/trezor-emu-core $(UNIX_PORT_OPTS) TREZOR_MODEL="$(TREZOR_MODEL)" BITCOIN_ONLY="$(BITCOIN_ONLY)"
 
 build_unix_frozen: res build_cross ## build unix port with frozen modules
-	$(SCONS) CFLAGS="$(CFLAGS)" $(UNIX_BUILD_DIR)/trezor-emu-core $(UNIX_PORT_OPTS) TREZOR_MODEL="$(TREZOR_MODEL)" PYOPT="$(PYOPT)" BITCOIN_ONLY="$(BITCOIN_ONLY)" TREZOR_EMULATOR_FROZEN=1
+	$(SCONS) CFLAGS="$(CFLAGS)" $(UNIX_BUILD_DIR)/trezor-emu-core $(UNIX_PORT_OPTS) TREZOR_MODEL="$(TREZOR_MODEL)" PYOPT="$(PYOPT)" BITCOIN_ONLY="$(BITCOIN_ONLY)" TREZOR_MEMPERF=$(TREZOR_MEMPERF) TREZOR_EMULATOR_FROZEN=1
 
 build_unix_debug: res ## build unix port
 	$(SCONS) --max-drift=1 CFLAGS="$(CFLAGS)" $(UNIX_BUILD_DIR)/trezor-emu-core $(UNIX_PORT_OPTS) TREZOR_MODEL="$(TREZOR_MODEL)" TREZOR_EMULATOR_ASAN=1 TREZOR_EMULATOR_DEBUGGABLE=1

--- a/core/SConscript.unix
+++ b/core/SConscript.unix
@@ -348,6 +348,11 @@ if ARGUMENTS.get('TREZOR_EMULATOR_DEBUGGABLE', 0):
         COPT=' -O0 -ggdb',
         STRIP='true', )
 
+if ARGUMENTS.get('TREZOR_MEMPERF', '0') == '1':
+    CPPDEFINES_MOD += [
+        ('MICROPY_TREZOR_MEMPERF', '\(1\)')
+    ]
+
 env.Replace(
     TREZOR_MODEL=TREZOR_MODEL, )
 

--- a/core/emu.py
+++ b/core/emu.py
@@ -89,6 +89,7 @@ def _from_env(name):
 @click.option("-D", "--debugger", is_flag=True, help="Run emulator in debugger (gdb/lldb)")
 @click.option("--executable", type=click.Path(exists=True, dir_okay=False), default=os.environ.get("MICROPYTHON"), help="Alternate emulator executable")
 @click.option("-g", "--profiling/--no-profiling", default=_from_env("TREZOR_PROFILING"), help="Run with profiler wrapper")
+@click.option("-G", "--alloc-profiling/--no-alloc-profiling", default=_from_env("TREZOR_MEMPERF"), help="Profile memory allocation (requires special micropython build)")
 @click.option("-h", "--headless", is_flag=True, help="Headless mode (no display)")
 @click.option("--heap-size", metavar="SIZE", default="20M", help="Configure heap size")
 @click.option("--main", help="Path to python main file")
@@ -111,6 +112,7 @@ def cli(
     debugger,
     executable,
     profiling,
+    alloc_profiling,
     headless,
     heap_size,
     main,
@@ -154,7 +156,7 @@ def cli(
     if watch and inotify is None:
         raise click.ClickException("inotify module is missing, install with pip")
 
-    if main and profiling:
+    if main and (profiling or alloc_profiling):
         raise click.ClickException("Cannot use --main and -g together")
 
     if slip0014 and mnemonics:
@@ -169,7 +171,7 @@ def cli(
     if mnemonics and production:
         raise click.ClickException("Cannot load mnemonics in production mode")
 
-    if profiling:
+    if profiling or alloc_profiling:
         main_args = [str(PROFILING_WRAPPER)]
     elif main:
         main_args = [main]
@@ -230,6 +232,9 @@ def cli(
 
     if log_memory:
         os.environ["TREZOR_LOG_MEMORY"] = "1"
+
+    if alloc_profiling:
+        os.environ["TREZOR_MEMPERF"] = "1"
 
     if debugger:
         run_debugger(emulator)

--- a/core/tools/alloc.py
+++ b/core/tools/alloc.py
@@ -1,0 +1,82 @@
+#!/usr/bin/env python3
+
+from types import SimpleNamespace
+import click
+
+
+def parse_alloc_data(alloc_data):
+    parsed_data = {}
+    for line in alloc_data:
+        ident, allocs, calls = line.strip().split(" ")
+        allocs = int(allocs)
+        calls = int(calls)
+        filename, lineno = ident.split(":")
+        lineno = int(lineno)
+
+        filedata = parsed_data.setdefault(filename, {})
+        filedata[lineno] = {
+            "total_allocs": allocs,
+            "total_calls": calls,
+            "avg_allocs": allocs / calls,
+        }
+    return parsed_data
+
+
+@click.group()
+@click.pass_context
+@click.option("-a", "--alloc-data", type=click.File(), default="src/alloc_data.txt")
+@click.option("-t", "--type", type=click.Choice(("total", "avg")), default="avg")
+def cli(ctx, alloc_data, type):
+    ctx.obj = SimpleNamespace(data=parse_alloc_data(alloc_data), type=type)
+
+
+@cli.command()
+@click.pass_obj
+@click.argument("filename")
+def annotate(obj, filename):
+    if obj.type == "total":
+        alloc_str = lambda line: str(line["total_allocs"])
+    else:
+        alloc_str = lambda line: "{:.2f}".format(line["avg_allocs"])
+
+    if filename.startswith("src/"):
+        filename = filename[4:]
+    filedata = obj.data[filename]
+
+    linedata = {lineno: alloc_str(line) for lineno, line in filedata.items()}
+    maxlen = max(len(l) for l in linedata.values())
+
+    lineno = 0
+    for line in open("src/" + filename):
+        lineno += 1
+        linecount = linedata.get(lineno, "")
+        print(f"{linecount:>{maxlen}}  {line}", end="")
+
+
+@cli.command()
+@click.pass_obj
+@click.option("-r", "--reverse", is_flag=True)
+def list(obj, reverse):
+    if obj.type == "total":
+        field = "total_allocs"
+        field_fmt = "{}"
+    else:
+        field = "avg_allocs"
+        field_fmt = "{:.2f}"
+
+    file_sums = {
+        filename: sum(line[field] for line in lines.values())
+        for filename, lines in obj.data.items()
+    }
+
+    maxlen = max(len(field_fmt.format(l)) for l in file_sums.values())
+
+    for filename, file_sum in sorted(
+        file_sums.items(), key=lambda x: x[1], reverse=reverse
+    ):
+        num_str = field_fmt.format(file_sum)
+        print(f"{num_str:>{maxlen}}  {filename}")
+
+
+if __name__ == "__main__":
+    cli()


### PR DESCRIPTION
Based on @matejcik 's `alloc-counter` branch. [Example report](https://satoshilabs.gitlab.io/-/trezor/trezor-firmware/-/jobs/812968996/artifacts/core/prof/memperf-html/index.html) (yeah the html output could use some improvement).

Since it needs to rerun all tests with different micropython build (that is slower than normal) the job is a manual job so as not to waste CI and developer time.

Needs corresponding micropython changes that are by default disabled at compile time:  trezor/micropython#3.

What do you think? Is this useful?