### PR TITLE
trezorlib 0.13 backwards compatibility

### DIFF
--- a/python/CHANGELOG.md
+++ b/python/CHANGELOG.md
@@ -2,9 +2,37 @@
 
 All notable changes to this project will be documented in this file.
 
-The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-_At the moment, the project does **not** adhere to [Semantic Versioning](https://semver.org/spec/v2.0.0.html). That is expected to change with version 1.0._
+## [0.13.0] - Unreleased
+[0.13.0]: https://github.com/trezor/trezor-firmware/compare/python/v0.12.2...master
+
+### Added
+
+- Enabled session management via `EndSession`  [#1227]
+- Support for temporary or permanent `safety-checks` setting
+
+### Changed
+
+- protobuf is aware of `required` fields and default values
+- `btc.sign_tx()` accepts keyword arguments for transaction metadata  [#1266]
+
+### Deprecated
+
+- instantiating protobuf objects with positional arguments is deprecated
+- values of required fields must be supplied at instantiation time. Omitting them is deprecated.
+- `details` argument to `btc.sign_tx()` is deprecated. Use keyword arguments instead.
+
+### Fixed
+
+- added missing dependency on `attrs`  [#1232]
+- fixed number imprecision in `build_tx.py` that could cause "invalid prevhash" errors
+
+### Removed
+
+- dropped Python 3.5 support  [#810]
+
 
 ## [0.12.2] - 2020-08-27
 [0.12.2]: https://github.com/trezor/trezor-firmware/compare/python/v0.12.1...python/v0.12.2
@@ -474,9 +502,13 @@ _At the moment, the project does **not** adhere to [Semantic Versioning](https:/
 [#349]: https://github.com/trezor/python-trezor/issues/349
 [#351]: https://github.com/trezor/python-trezor/issues/351
 [#352]: https://github.com/trezor/python-trezor/issues/352
+[#810]: https://github.com/trezor/trezor-firmware/issues/810
 [#948]: https://github.com/trezor/trezor-firmware/issues/948
 [#1052]: https://github.com/trezor/trezor-firmware/issues/1052
 [#1126]: https://github.com/trezor/trezor-firmware/issues/1126
 [#1179]: https://github.com/trezor/trezor-firmware/issues/1179
 [#1196]: https://github.com/trezor/trezor-firmware/issues/1196
 [#1210]: https://github.com/trezor/trezor-firmware/issues/1210
+[#1227]: https://github.com/trezor/trezor-firmware/issues/1227
+[#1232]: https://github.com/trezor/trezor-firmware/issues/1232
+[#1266]: https://github.com/trezor/trezor-firmware/issues/1266

--- a/python/docs/transaction-format.md
+++ b/python/docs/transaction-format.md
@@ -15,7 +15,7 @@ The root is an object with the following attributes:
   missing, `"Bitcoin"` is used.
 * __`inputs`__: array of `TxInputType` objects. Must be present.
 * __`outputs`__: array of `TxOutputType` objects. Must be present.
-* __`details`__: object of type `SignTx`, specifying transaction metadata. Can be
+* __`details`__: object whose keys correspond to metadata on the `SignTx` type. Can be
   omitted.
 * __`prev_txes`__: object whose keys are hex-encoded transaction hashes, and values are
   objects of type `TransactionType`. When signing a transaction with non-SegWit inputs,
@@ -112,10 +112,8 @@ set.
 
 ### Transaction metadata
 
-The following is a shortened definition of the `SignTx` protobuf message. Note that it
-is possible to set fields `outputs_count`, `inputs_count` and `coin_name`, but their
-values will be ignored. Instead, the number of elements in `outputs`, `inputs`, and the
-value of `coin_name` from root object will be used.
+The following is a shortened definition of the `SignTx` protobuf message, containing
+all possible fields that are accepted in the `details` object.
 
 All fields are optional unless required by your currency.
 
@@ -124,7 +122,6 @@ message SignTx {
     optional uint32 version = 4;           // transaction version
     optional uint32 lock_time = 5;         // transaction lock_time
     optional uint32 expiry = 6;            // only for Decred and Zcash
-    optional bool overwintered = 7;        // only for Zcash
     optional uint32 version_group_id = 8;  // only for Zcash, nVersionGroupId when overwintered is set
     optional uint32 timestamp = 9;         // only for Peercoin, transaction timestamp
     optional uint32 branch_id = 10;        // only for Zcash, BRANCH_ID when overwintered is set

--- a/python/setup.py
+++ b/python/setup.py
@@ -59,7 +59,7 @@ setup(
     entry_points={"console_scripts": ["trezorctl=trezorlib.cli.trezorctl:cli"]},
     install_requires=install_requires,
     extras_require=extras_require,
-    python_requires=">=3.5",
+    python_requires=">=3.6",
     include_package_data=True,
     zip_safe=False,
     classifiers=[

--- a/python/src/trezorlib/btc.py
+++ b/python/src/trezorlib/btc.py
@@ -199,6 +199,9 @@ def sign_tx(
     (`inputs_count`, `outputs_count`, `coin_name`) will be inferred from the arguments
     and cannot be overriden by kwargs.
     """
+    if prev_txes is None:
+        prev_txes = {}
+
     if details is not None:
         warnings.warn(
             "'details' argument is deprecated, use kwargs instead",

--- a/python/src/trezorlib/btc.py
+++ b/python/src/trezorlib/btc.py
@@ -15,6 +15,7 @@
 # If not, see <https://www.gnu.org/licenses/lgpl-3.0.html>.
 
 import warnings
+from copy import copy
 from decimal import Decimal
 from typing import TYPE_CHECKING, Any, Dict, Sequence, Tuple
 
@@ -235,7 +236,7 @@ def sign_tx(
     serialized_tx = b""
 
     def copy_tx_meta(tx: messages.TransactionType) -> messages.TransactionType:
-        tx_copy = messages.TransactionType(**tx)
+        tx_copy = copy(tx)
         # clear fields
         tx_copy.inputs_cnt = len(tx.inputs)
         tx_copy.inputs = []

--- a/python/src/trezorlib/cli/btc.py
+++ b/python/src/trezorlib/cli/btc.py
@@ -199,7 +199,7 @@ def sign_tx(client, json_file):
     """
     data = json.load(json_file)
     coin = data.get("coin_name", DEFAULT_COIN)
-    details = protobuf.dict_to_proto(messages.SignTx, data.get("details", {}))
+    details = data.get("details", {})
     inputs = [
         protobuf.dict_to_proto(messages.TxInputType, i) for i in data.get("inputs", ())
     ]
@@ -212,7 +212,14 @@ def sign_tx(client, json_file):
         for txid, tx in data.get("prev_txes", {}).items()
     }
 
-    _, serialized_tx = btc.sign_tx(client, coin, inputs, outputs, details, prev_txes)
+    _, serialized_tx = btc.sign_tx(
+        client,
+        coin,
+        inputs,
+        outputs,
+        prev_txes=prev_txes,
+        **details,
+    )
 
     click.echo()
     click.echo("Signed Transaction:")

--- a/python/src/trezorlib/cli/btc.py
+++ b/python/src/trezorlib/cli/btc.py
@@ -52,16 +52,21 @@ XpubStruct = c.Struct(
 def xpub_deserialize(xpubstr):
     xpub_bytes = tools.b58check_decode(xpubstr)
     data = XpubStruct.parse(xpub_bytes)
+    if data.key[0] == 0:
+        private_key = data.key[1:]
+        public_key = None
+    else:
+        public_key = data.key
+        private_key = None
+
     node = messages.HDNodeType(
         depth=data.depth,
         fingerprint=data.fingerprint,
         child_num=data.child_num,
         chain_code=data.chain_code,
+        public_key=public_key,
+        private_key=private_key,
     )
-    if data.key[0] == 0:
-        node.private_key = data.key[1:]
-    else:
-        node.public_key = data.key
 
     return data.version, node
 

--- a/python/src/trezorlib/debuglink.py
+++ b/python/src/trezorlib/debuglink.py
@@ -276,11 +276,11 @@ class MessageFilter:
     @classmethod
     def from_message(cls, message):
         fields = {}
-        for field in message.keys():
-            value = getattr(message, field)
-            if value in (None, []):
+        for fname, _, _ in message.get_fields().values():
+            value = getattr(message, fname)
+            if value in (None, [], protobuf.FLAG_REQUIRED):
                 continue
-            fields[field] = value
+            fields[fname] = value
         return cls(type(message), **fields)
 
     def match(self, message):

--- a/python/src/trezorlib/protobuf.py
+++ b/python/src/trezorlib/protobuf.py
@@ -23,6 +23,7 @@ For serializing (dumping) protobuf types, object with `Writer` interface is requ
 """
 
 import logging
+import warnings
 from io import BytesIO
 from itertools import zip_longest
 from typing import (
@@ -30,7 +31,6 @@ from typing import (
     Callable,
     Dict,
     Iterable,
-    Iterator,
     List,
     Optional,
     Tuple,
@@ -38,7 +38,6 @@ from typing import (
     TypeVar,
     Union,
 )
-import warnings
 
 from typing_extensions import Protocol
 
@@ -279,15 +278,6 @@ class MessageType(metaclass=_MessageTypeMeta):
                 continue
             d[key] = value
         return "<%s: %s>" % (self.__class__.__name__, d)
-
-    def __iter__(self) -> Iterator[str]:
-        return iter(self.keys())
-
-    def keys(self) -> Iterator[str]:
-        return (name for name, _, _ in self.get_fields().values())
-
-    def __getitem__(self, key: str) -> Any:
-        return getattr(self, key)
 
     def ByteSize(self) -> int:
         data = BytesIO()

--- a/python/tests/test_protobuf_encoding.py
+++ b/python/tests/test_protobuf_encoding.py
@@ -239,9 +239,11 @@ def test_required():
 
     assert msg_ok == msg
 
-    with pytest.raises(ValueError):
-        # cannot construct instance without the required fields
+    with pytest.deprecated_call():
         msg = RequiredFields(uvarint=3)
+    with pytest.raises(ValueError):
+        # cannot encode instance without the required fields
+        dump_message(msg)
 
     msg = RequiredFields(uvarint=3, nested=None)
     # we can always encode an invalid message

--- a/python/tests/test_protobuf_misc.py
+++ b/python/tests/test_protobuf_misc.py
@@ -53,6 +53,14 @@ class NestedMessage(protobuf.MessageType):
         }
 
 
+class RequiredFields(protobuf.MessageType):
+    @classmethod
+    def get_fields(cls):
+        return {
+            1: ("scalar", protobuf.UVarintType, protobuf.FLAG_REQUIRED),
+        }
+
+
 def test_get_field_type():
     # smoke test
     assert SimpleMessage.get_field_type("bool") is protobuf.BoolType
@@ -234,3 +242,24 @@ def test_unknown_enum_to_dict():
     simple = SimpleMessage(enum=6000)
     converted = protobuf.to_dict(simple)
     assert converted["enum"] == 6000
+
+
+def test_constructor_deprecations():
+    # ok:
+    RequiredFields(scalar=0)
+
+    # positional argument
+    with pytest.deprecated_call():
+        RequiredFields(0)
+
+    # missing required value
+    with pytest.deprecated_call():
+        RequiredFields()
+
+    # more args than fields
+    with pytest.deprecated_call(), pytest.raises(TypeError):
+        RequiredFields(0, 0)
+
+    # colliding arg and kwarg
+    with pytest.deprecated_call(), pytest.raises(TypeError):
+        RequiredFields(0, scalar=0)

--- a/python/tools/build_tx.py
+++ b/python/tools/build_tx.py
@@ -159,15 +159,17 @@ def sign_interactive():
     inputs, txes = _get_inputs_interactive(blockbook_url)
     outputs = _get_outputs_interactive()
 
-    signtx = messages.SignTx()
-    signtx.version = prompt("Transaction version", type=int, default=2)
-    signtx.lock_time = prompt("Transaction locktime", type=int, default=0)
+    version = prompt("Transaction version", type=int, default=2)
+    lock_time = prompt("Transaction locktime", type=int, default=0)
 
     result = {
         "coin_name": coin,
         "inputs": [to_dict(i, hexlify_bytes=True) for i in inputs],
         "outputs": [to_dict(o, hexlify_bytes=True) for o in outputs],
-        "details": to_dict(signtx, hexlify_bytes=True),
+        "details": {
+            "version": version,
+            "lock_time": lock_time,
+        },
         "prev_txes": {
             txhash: to_dict(txdata, hexlify_bytes=True)
             for txhash, txdata in txes.items()

--- a/python/tox.ini
+++ b/python/tox.ini
@@ -1,9 +1,9 @@
 [tox]
 envlist =
-#    py35,  XXX revisit, see also https://github.com/trezor/trezor-firmware/issues/810
     py36,
     py37,
     py38,
+    py39,
 
 [testenv]
 deps =

--- a/tests/bip32.py
+++ b/tests/bip32.py
@@ -17,6 +17,7 @@
 import hashlib
 import hmac
 import struct
+from copy import copy
 
 import ecdsa
 from ecdsa.curves import SECP256k1
@@ -67,7 +68,7 @@ def public_ckd(public_node, n):
     if not isinstance(n, list):
         raise ValueError("Parameter must be a list")
 
-    node = messages.HDNodeType(**public_node)
+    node = copy(public_node)
 
     for i in n:
         node = get_subnode(node, i)


### PR DESCRIPTION
This PR implements a bunch of tricks to make sure that code built on trezorlib 0.12 continues to work on trezorlib 0.13, namely:

* old-style `btc.sign_tx` with `details` argument continues to be accepted
* constructing protobuf classes with positional arguments, or with no arguments, is still possible. (sending a protobuf message without filling out required fields will fail, of course)

both are guarded by deprecation warnings and might be removed in trezorlib 0.14.