### PR TITLE
Update networks.json

### DIFF
--- a/common/defs/ethereum/networks.json
+++ b/common/defs/ethereum/networks.json
@@ -367,5 +367,25 @@
     "rskip60": false,
     "url": "https://pirl.io",
     "blockbook": []
+  },
+{
+    "chain": "volta",
+    "chain_id": 73799,
+    "slip44": 44,
+    "shortcut": "VT",
+    "name": "Volta",
+    "rskip60": false,
+    "url": "https://www.energyweb.org/",
+    "blockbook": []
+  },
+  {
+    "chain": "energyweb",
+    "chain_id": 246,
+    "slip44": 44,
+    "shortcut": "EWT",
+    "name": "Energyweb chain",
+    "rskip60": false,
+    "url": "https://www.energyweb.org/technology/energy-web-chain/",
+    "blockbook": []
   }
 ]

--- a/common/defs/ethereum/networks.json
+++ b/common/defs/ethereum/networks.json
@@ -371,7 +371,7 @@
 {
     "chain": "volta",
     "chain_id": 73799,
-    "slip44": 44,
+    "slip44": 1,
     "shortcut": "VT",
     "name": "Volta",
     "rskip60": false,
@@ -381,7 +381,7 @@
   {
     "chain": "energyweb",
     "chain_id": 246,
-    "slip44": 44,
+    "slip44": 246,
     "shortcut": "EWT",
     "name": "Energyweb chain",
     "rskip60": false,


### PR DESCRIPTION
Added Volta and EWC (EnergyWeb Chain) to the known EVM networks. Trezor T requires the chain_id to be present in this file in order to sign transactions.

About Energy Web:
Energy Web is accelerating a low-carbon, customer-centric electricity system by enabling any energy asset owned by any customer to participate in any energy market. ... It's all anchored by the Energy Web Chain, the first open-source, enterprise blockchain platform tailored to the energy sector.

About Volta:
=Testnet of Energy Web; governed by the same validators