### PR TITLE
legacy+core: unify error codes in bootloaders

### DIFF
--- a/core/embed/bootloader/messages.c
+++ b/core/embed/bootloader/messages.c
@@ -352,7 +352,7 @@ void process_msg_FirmwareErase(uint8_t iface_num, uint32_t msg_size,
   } else {
     // invalid firmware size
     MSG_SEND_INIT(Failure);
-    MSG_SEND_ASSIGN_VALUE(code, FailureType_Failure_DataError);
+    MSG_SEND_ASSIGN_VALUE(code, FailureType_Failure_ProcessError);
     MSG_SEND_ASSIGN_STRING(message, "Wrong firmware size");
     MSG_SEND(Failure);
   }
@@ -468,7 +468,7 @@ int process_msg_FirmwareUpload(uint8_t iface_num, uint32_t msg_size,
 
   if (sectrue != r || chunk_size != (chunk_requested + read_offset)) {
     MSG_SEND_INIT(Failure);
-    MSG_SEND_ASSIGN_VALUE(code, FailureType_Failure_DataError);
+    MSG_SEND_ASSIGN_VALUE(code, FailureType_Failure_ProcessError);
     MSG_SEND_ASSIGN_STRING(message, "Invalid chunk size");
     MSG_SEND(Failure);
     return -1;

--- a/core/embed/bootloader_ci/messages.c
+++ b/core/embed/bootloader_ci/messages.c
@@ -352,7 +352,7 @@ void process_msg_FirmwareErase(uint8_t iface_num, uint32_t msg_size,
   } else {
     // invalid firmware size
     MSG_SEND_INIT(Failure);
-    MSG_SEND_ASSIGN_VALUE(code, FailureType_Failure_DataError);
+    MSG_SEND_ASSIGN_VALUE(code, FailureType_Failure_ProcessError);
     MSG_SEND_ASSIGN_STRING(message, "Wrong firmware size");
     MSG_SEND(Failure);
   }
@@ -468,7 +468,7 @@ int process_msg_FirmwareUpload(uint8_t iface_num, uint32_t msg_size,
 
   if (sectrue != r || chunk_size != (chunk_requested + read_offset)) {
     MSG_SEND_INIT(Failure);
-    MSG_SEND_ASSIGN_VALUE(code, FailureType_Failure_DataError);
+    MSG_SEND_ASSIGN_VALUE(code, FailureType_Failure_ProcessError);
     MSG_SEND_ASSIGN_STRING(message, "Invalid chunk size");
     MSG_SEND(Failure);
     return -1;

--- a/legacy/bootloader/usb_send.h
+++ b/legacy/bootloader/usb_send.h
@@ -14,11 +14,10 @@ static void send_msg_success(usbd_device *dev) {
   }
 }
 
-static void send_msg_failure(usbd_device *dev) {
+static void send_msg_failure(usbd_device *dev, uint8_t code) {
   uint8_t response[64];
   memzero(response, sizeof(response));
   // response: Failure message (id 3), payload len 2
-  //           - code = 99 (Failure_FirmwareError)
   memcpy(response,
          // header
          "?##"
@@ -26,10 +25,11 @@ static void send_msg_failure(usbd_device *dev) {
          "\x00\x03"
          // msg_size
          "\x00\x00\x00\x02"
-         // data
-         "\x08"
-         "\x63",
-         11);
+         // code field id
+         "\x08",
+         10);
+  // assign code value
+  response[10] = code;
   while (usbd_ep_write_packet(dev, ENDPOINT_ADDRESS_IN, response, 64) != 64) {
   }
 }


### PR DESCRIPTION
Fixes https://github.com/trezor/trezor-firmware/issues/1334 by unifying the codes used in legacy and core bootloaders

I have not added text messages to legacy bootloader messages, I think it's not worth the effort.

Also legacy bootloader now sends Failure_UnexpectedMessage instead of being silent when an unexpected message is encountered (the same behaviour we see core bootloader).