### PR TITLE
Increase minimum auto-lock delay to 1 minute

### DIFF
--- a/core/src/storage/device.py
+++ b/core/src/storage/device.py
@@ -48,7 +48,11 @@ if False:
 # fmt: on
 
 HOMESCREEN_MAXSIZE = 16384
-AUTOLOCK_DELAY_MINIMUM = 10 * 1000  # 10 seconds
+
+if __debug__:
+    AUTOLOCK_DELAY_MINIMUM = 10 * 1000  # 10 seconds
+else:
+    AUTOLOCK_DELAY_MINIMUM = 60 * 1000  # 1 minute
 AUTOLOCK_DELAY_DEFAULT = 10 * 60 * 1000  # 10 minutes
 # autolock intervals larger than AUTOLOCK_DELAY_MAXIMUM cause issues in the scheduler
 AUTOLOCK_DELAY_MAXIMUM = 0x2000_0000  # ~6 days
@@ -217,17 +221,22 @@ def set_flags(flags: int) -> None:
         common.set(_NAMESPACE, _FLAGS, flags.to_bytes(4, "big"))
 
 
+def _normalize_autolock_delay(delay_ms: int) -> int:
+    delay_ms = max(delay_ms, AUTOLOCK_DELAY_MINIMUM)
+    delay_ms = min(delay_ms, AUTOLOCK_DELAY_MAXIMUM)
+    return delay_ms
+
+
 def get_autolock_delay_ms() -> int:
     b = common.get(_NAMESPACE, _AUTOLOCK_DELAY_MS)
     if b is None:
         return AUTOLOCK_DELAY_DEFAULT
     else:
-        return int.from_bytes(b, "big")
+        return _normalize_autolock_delay(int.from_bytes(b, "big"))
 
 
 def set_autolock_delay_ms(delay_ms: int) -> None:
-    delay_ms = max(delay_ms, AUTOLOCK_DELAY_MINIMUM)
-    delay_ms = min(delay_ms, AUTOLOCK_DELAY_MAXIMUM)
+    delay_ms = _normalize_autolock_delay(delay_ms)
     common.set(_NAMESPACE, _AUTOLOCK_DELAY_MS, delay_ms.to_bytes(4, "big"))
 
 

--- a/legacy/firmware/config.c
+++ b/legacy/firmware/config.c
@@ -962,6 +962,7 @@ uint32_t config_getAutoLockDelayMs() {
   if (sectrue != config_get_uint32(KEY_AUTO_LOCK_DELAY_MS, &autoLockDelayMs)) {
     autoLockDelayMs = autoLockDelayMsDefault;
   }
+  autoLockDelayMs = MAX(autoLockDelayMs, MIN_AUTOLOCK_DELAY_MS);
   autoLockDelayMsCached = sectrue;
   return autoLockDelayMs;
 }

--- a/legacy/firmware/config.h
+++ b/legacy/firmware/config.h
@@ -85,8 +85,13 @@ extern Storage configUpdate;
 #define MAX_MNEMONIC_LEN 240
 #define HOMESCREEN_SIZE 1024
 #define UUID_SIZE 12
+
+#if DEBUG_LINK
 #define MIN_AUTOLOCK_DELAY_MS (10 * 1000U)  // 10 seconds
-#define MAX_AUTOLOCK_DELAY_MS 0x20000000U   // ~6 days
+#else
+#define MIN_AUTOLOCK_DELAY_MS (60 * 1000U)  // 1 minute
+#endif
+#define MAX_AUTOLOCK_DELAY_MS 0x20000000U  // ~6 days
 
 void config_init(void);
 void session_clear(bool lock);


### PR DESCRIPTION
Fixes #1351. Core + legacy.

Upgrade: if storage has <1minute the effective value is 1 minute. Less than one minute cannot be set.
Downgrade: the new set of valid timeouts is subset of the old one so downgrade should always be safe.

We've discussed lowering the minimum if `experimental_features` is set but I haven't implemented this (yet). Is it something that would make life easier for @trezor/qa?