### PR TITLE
Inform user about transaction finalization

### DIFF
--- a/core/src/apps/bitcoin/sign_tx/approvers.py
+++ b/core/src/apps/bitcoin/sign_tx/approvers.py
@@ -170,6 +170,10 @@ class BasicApprover(Approver):
 
             if self.external_in > self.orig_external_in:
                 description = "PayJoin"
+            elif tx_info.rbf_disabled() and any(
+                not orig.rbf_disabled() for orig in orig_txs
+            ):
+                description = "Finalize transaction"
             elif len(orig_txs) > 1:
                 description = "Transaction meld"
             else:

--- a/core/src/apps/bitcoin/sign_tx/tx_info.py
+++ b/core/src/apps/bitcoin/sign_tx/tx_info.py
@@ -69,6 +69,10 @@ _BIP32_MAX_LAST_ELEMENT = const(1000000)
 # Setting nSequence to this value for every input in a transaction disables nLockTime.
 _SEQUENCE_FINAL = const(0xFFFFFFFF)
 
+# Setting nSequence to a value greater than this for every input in a transaction
+# disables replace-by-fee opt-in.
+_MAX_BIP125_RBF_SEQUENCE = const(0xFFFFFFFD)
+
 
 class TxInfoBase:
     def __init__(self, signer: Signer) -> None:
@@ -121,6 +125,9 @@ class TxInfoBase:
 
     def lock_time_disabled(self) -> bool:
         return self.min_sequence == _SEQUENCE_FINAL
+
+    def rbf_disabled(self) -> bool:
+        return self.min_sequence > _MAX_BIP125_RBF_SEQUENCE
 
     def get_tx_check_digest(self) -> bytes:
         return self.h_tx_check.get_digest()

--- a/tests/txcache/testnet/43d273d3caf41759ad843474f960fbf80ff2ec961135d018b61e9fab3ad1fc06.json
+++ b/tests/txcache/testnet/43d273d3caf41759ad843474f960fbf80ff2ec961135d018b61e9fab3ad1fc06.json
@@ -1,0 +1,27 @@
+{
+  "bin_outputs": [
+    {
+      "amount": 10000000,
+      "script_pubkey": "a914051877a0cc43165e48975c1e62bdef3b6c942a3887"
+    },
+    {
+      "amount": 20000000,
+      "script_pubkey": "00142fde3b3d1644fd16bd18a78138ae3873398eca37"
+    },
+    {
+      "amount": 99999694,
+      "script_pubkey": "0014cc8067093f6f843d6d3e22004a4290cd0c0f336b"
+    }
+  ],
+  "inputs": [
+    {
+      "prev_hash": "e294c4c172c3d87991b0369e45d6af8584be92914d01e3060fad1ed31d12ff00",
+      "prev_index": 0,
+      "script_sig": "",
+      "script_type": "SPENDADDRESS",
+      "sequence": 4294967293
+    }
+  ],
+  "lock_time": 1287124,
+  "version": 1
+}

--- a/tests/txcache/testnet/70f9871eb03a38405cfd7a01e0e1448678132d815e2c9f552ad83ae23969509e.json
+++ b/tests/txcache/testnet/70f9871eb03a38405cfd7a01e0e1448678132d815e2c9f552ad83ae23969509e.json
@@ -13,10 +13,26 @@
     {
       "prev_hash": "43d273d3caf41759ad843474f960fbf80ff2ec961135d018b61e9fab3ad1fc06",
       "prev_index": 1,
+      "address_n": [2147483732, 2147483649, 2147483648, 0, 2],
+      "amount": 20000000,
+      "script_type": 3,
       "script_sig": "",
+      "witness": "0247304402207da4ce78bf9175ad4764794013360be569d3902861a54922aad6239659422f86022050145fc897a806b4ef06777a58471d39e9a10482cd8e61819ee18d6d22eaa6be01210357cb3a5918d15d224f14a89f0eb54478272108f6cbb9c473c1565e55260f6e93",
       "sequence": 4294967293
     }
   ],
   "lock_time": 1348713,
+  "outputs": [
+    {
+      "address": "tb1qkvwu9g3k2pdxewfqr7syz89r3gj557l3uuf9r9",
+      "amount": 100000,
+      "script_type": 4
+    },
+    {
+      "address_n": [2147483732, 2147483649, 2147483648, 1, 1],
+      "amount": 19899859,
+      "script_type": 4
+    }
+  ],
   "version": 1
 }

--- a/tests/ui_tests/fixtures.json
+++ b/tests/ui_tests/fixtures.json
@@ -342,6 +342,7 @@
 "test_msg_signtx_komodo.py-test_one_one_rewards_claim": "751e83d63bf01c6c57047b5e004629d613df75342371cd43a7b4b80a07f4b88d",
 "test_msg_signtx_peercoin.py::test_timestamp_included": "825b9bdf5238c5c6415a254a6bae4b2bd9df8fc5cb31f66f0c20145cb4e60bbb",
 "test_msg_signtx_replacement.py::test_p2pkh_fee_bump": "881f6491e9f4417cd747dda2dc0eaafdf1a4769a5e53aa303bb06547d6a9133b",
+"test_msg_signtx_replacement.py::test_p2wpkh_finalize": "1147c6996c193b904b72d38def07c692cf48d7bdbe244343c9e98ee0db497d11",
 "test_msg_signtx_replacement.py::test_p2wpkh_in_p2sh_remove_change": "f66437cc88d016ddb0b3fd4e6d2c6536d9a1745dfc92ce9cd334c3cbaaefb4a9",
 "test_msg_signtx_replacement.py::test_p2wpkh_payjoin[19909659-90000-02483045022100aa1b91fb25cc9a0ace4": "a5473b5f3931fb6530a991e45aa32507069a7b402878d1eda2ce6e8be1a673e1",
 "test_msg_signtx_replacement.py::test_p2wpkh_payjoin[19909718-90000-024730440220753f53049ca43d55f6563": "a5473b5f3931fb6530a991e45aa32507069a7b402878d1eda2ce6e8be1a673e1",


### PR DESCRIPTION
Implements https://github.com/trezor/trezor-firmware/issues/1343
Spec: https://github.com/bitcoin/bips/blob/master/bip-0125.mediawiki
UI: https://satoshilabs.gitlab.io/-/trezor/trezor-firmware/-/jobs/861475851/artifacts/master_diff/added/test_msg_signtx_replacement.py::test_p2wpkh_finalize.html
![image](https://user-images.githubusercontent.com/42678794/99713783-02cea680-2aa5-11eb-88e9-360660548f1a.png) ![image](https://user-images.githubusercontent.com/42678794/99713795-08c48780-2aa5-11eb-9d27-805d60d8a1a7.png)
