### PR TITLE
Call base class __init__ in subclasses

### DIFF
--- a/core/src/apps/bitcoin/sign_tx/bitcoin.py
+++ b/core/src/apps/bitcoin/sign_tx/bitcoin.py
@@ -15,7 +15,7 @@ from ..common import SIGHASH_ALL, ecdsa_sign, input_is_external, input_is_segwit
 from ..ownership import verify_nonownership
 from ..verification import SignatureVerifier
 from . import approvers, helpers, progress
-from .hash143 import Hash143
+from .hash143 import Bip143Hash
 from .tx_info import OriginalTxInfo, TxInfo
 
 if False:
@@ -31,6 +31,8 @@ if False:
 
     from apps.common.coininfo import CoinInfo
     from apps.common.keychain import Keychain
+
+    from .hash143 import Hash143
 
 
 # the number of bytes to preallocate for serialized transaction chunks
@@ -108,7 +110,7 @@ class Bitcoin:
         return HashWriter(sha256())
 
     def create_hash143(self) -> Hash143:
-        return Hash143()
+        return Bip143Hash()
 
     async def step1_process_inputs(self) -> None:
         for i in range(self.tx_info.tx.inputs_count):

--- a/core/src/apps/bitcoin/sign_tx/decred.py
+++ b/core/src/apps/bitcoin/sign_tx/decred.py
@@ -12,7 +12,6 @@ from .. import multisig, scripts, writers
 from ..common import ecdsa_hash_pubkey, ecdsa_sign
 from . import approvers, helpers, progress
 from .bitcoin import Bitcoin
-from .hash143 import Hash143
 
 DECRED_SERIALIZE_FULL = const(0 << 16)
 DECRED_SERIALIZE_NO_WITNESS = const(1 << 16)
@@ -22,7 +21,7 @@ DECRED_SCRIPT_VERSION = const(0)
 DECRED_SIGHASH_ALL = const(1)
 
 if False:
-    from typing import Optional, Union
+    from typing import Optional, Union, List
 
     from trezor.messages.SignTx import SignTx
     from trezor.messages.TxInput import TxInput
@@ -33,8 +32,10 @@ if False:
     from apps.common.coininfo import CoinInfo
     from apps.common.keychain import Keychain
 
+    from .hash143 import Hash143
 
-class DecredHash(Hash143):
+
+class DecredHash:
     def __init__(self, h_prefix: HashWriter) -> None:
         self.h_prefix = h_prefix
 
@@ -43,6 +44,17 @@ class DecredHash(Hash143):
 
     def add_output(self, txo: TxOutput, script_pubkey: bytes) -> None:
         Decred.write_tx_output(self.h_prefix, txo, script_pubkey)
+
+    def preimage_hash(
+        self,
+        txi: TxInput,
+        public_keys: List[bytes],
+        threshold: int,
+        tx: Union[SignTx, PrevTx],
+        coin: CoinInfo,
+        sighash_type: int,
+    ) -> bytes:
+        raise NotImplementedError
 
 
 class Decred(Bitcoin):

--- a/core/src/apps/bitcoin/sign_tx/hash143.py
+++ b/core/src/apps/bitcoin/sign_tx/hash143.py
@@ -10,11 +10,29 @@ from apps.common import coininfo
 from .. import scripts, writers
 
 if False:
-    from typing import List, Union
+    from typing import List, Union, Protocol
+
+    class Hash143(Protocol):
+        def add_input(self, txi: TxInput) -> None:
+            ...
+
+        def add_output(self, txo: TxOutput, script_pubkey: bytes) -> None:
+            ...
+
+        def preimage_hash(
+            self,
+            txi: TxInput,
+            public_keys: List[bytes],
+            threshold: int,
+            tx: Union[SignTx, PrevTx],
+            coin: coininfo.CoinInfo,
+            sighash_type: int,
+        ) -> bytes:
+            ...
 
 
 # BIP-0143 hash
-class Hash143:
+class Bip143Hash:
     def __init__(self) -> None:
         self.h_prevouts = HashWriter(sha256())
         self.h_sequence = HashWriter(sha256())

--- a/core/src/apps/homescreen/__init__.py
+++ b/core/src/apps/homescreen/__init__.py
@@ -6,11 +6,11 @@ class HomescreenBase(ui.Layout):
     RENDER_SLEEP = loop.SLEEP_FOREVER
 
     def __init__(self) -> None:
+        super().__init__()
         self.label = storage.device.get_label() or "My Trezor"
         self.image = storage.device.get_homescreen() or res.load(
             "apps/homescreen/res/bg.toif"
         )
-        self.repaint = True
 
     def on_tap(self) -> None:
         """Called when the user taps the screen."""

--- a/core/src/apps/management/recovery_device/keyboard_bip39.py
+++ b/core/src/apps/management/recovery_device/keyboard_bip39.py
@@ -87,8 +87,8 @@ class InputButton(Button):
 
 class Prompt(ui.Component):
     def __init__(self, prompt: str) -> None:
+        super().__init__()
         self.prompt = prompt
-        self.repaint = True
 
     def on_render(self) -> None:
         if self.repaint:
@@ -99,6 +99,7 @@ class Prompt(ui.Component):
 
 class Bip39Keyboard(ui.Layout):
     def __init__(self, prompt: str) -> None:
+        super().__init__()
         self.prompt = Prompt(prompt)
 
         icon_back = res.load(ui.ICON_BACK)

--- a/core/src/apps/management/recovery_device/keyboard_slip39.py
+++ b/core/src/apps/management/recovery_device/keyboard_slip39.py
@@ -90,8 +90,8 @@ class InputButton(Button):
 
 class Prompt(ui.Component):
     def __init__(self, prompt: str) -> None:
+        super().__init__()
         self.prompt = prompt
-        self.repaint = True
 
     def on_render(self) -> None:
         if self.repaint:
@@ -102,6 +102,7 @@ class Prompt(ui.Component):
 
 class Slip39Keyboard(ui.Layout):
     def __init__(self, prompt: str) -> None:
+        super().__init__()
         self.prompt = Prompt(prompt)
 
         icon_back = res.load(ui.ICON_BACK)

--- a/core/src/apps/management/recovery_device/layout.py
+++ b/core/src/apps/management/recovery_device/layout.py
@@ -206,10 +206,10 @@ async def show_group_threshold_reached(ctx: wire.GenericContext) -> None:
 
 class RecoveryHomescreen(ui.Component):
     def __init__(self, text: str, subtext: str = None):
+        super().__init__()
         self.text = text
         self.subtext = subtext
         self.dry_run = storage.recovery.is_dry_run()
-        self.repaint = True
 
     def on_render(self) -> None:
         if not self.repaint:

--- a/core/src/apps/management/reset_device/layout.py
+++ b/core/src/apps/management/reset_device/layout.py
@@ -524,10 +524,10 @@ class Slip39NumInput(ui.Component):
     SET_GROUP_THRESHOLD = object()
 
     def __init__(self, step, count, min_count, max_count, group_id=None):
+        super().__init__()
         self.step = step
         self.input = NumInput(count, min_count=min_count, max_count=max_count)
         self.input.on_change = self.on_change
-        self.repaint = True
         self.group_id = group_id
 
     def dispatch(self, event, x, y):
@@ -605,6 +605,7 @@ class MnemonicWordSelect(ui.Layout):
     NUM_OF_CHOICES = 3
 
     def __init__(self, words, share_index, word_index, count, group_index=None):
+        super().__init__()
         self.words = words
         self.share_index = share_index
         self.word_index = word_index

--- a/core/src/apps/monero/layout/confirms.py
+++ b/core/src/apps/monero/layout/confirms.py
@@ -143,6 +143,7 @@ async def _require_confirm_unlock_time(ctx, unlock_time):
 
 class TransactionStep(ui.Component):
     def __init__(self, state, info):
+        super().__init__()
         self.state = state
         self.info = info
 
@@ -159,6 +160,7 @@ class TransactionStep(ui.Component):
 
 class KeyImageSyncStep(ui.Component):
     def __init__(self, current, total_num):
+        super().__init__()
         self.current = current
         self.total_num = total_num
 
@@ -172,6 +174,7 @@ class KeyImageSyncStep(ui.Component):
 
 class LiveRefreshStep(ui.Component):
     def __init__(self, current):
+        super().__init__()
         self.current = current
 
     def on_render(self):

--- a/core/src/apps/webauthn/add_resident_credential.py
+++ b/core/src/apps/webauthn/add_resident_credential.py
@@ -16,6 +16,7 @@ if False:
 
 class ConfirmAddCredential(ConfirmInfo):
     def __init__(self, cred: Fido2Credential):
+        super().__init__()
         self._cred = cred
         self.load_icon(cred.rp_id_hash)
 

--- a/core/src/apps/webauthn/confirm.py
+++ b/core/src/apps/webauthn/confirm.py
@@ -34,8 +34,8 @@ class ConfirmInfo:
 
 class ConfirmContent(ui.Component):
     def __init__(self, info: ConfirmInfo) -> None:
+        super().__init__()
         self.info = info
-        self.repaint = True
 
     def on_render(self) -> None:
         if self.repaint:

--- a/core/src/apps/webauthn/fido2.py
+++ b/core/src/apps/webauthn/fido2.py
@@ -237,6 +237,7 @@ _last_good_auth_check_cid = 0
 
 class CborError(Exception):
     def __init__(self, code: int):
+        super().__init__()
         self.code = code
 
 

--- a/core/src/apps/webauthn/remove_resident_credential.py
+++ b/core/src/apps/webauthn/remove_resident_credential.py
@@ -18,6 +18,7 @@ if False:
 
 class ConfirmRemoveCredential(ConfirmInfo):
     def __init__(self, cred: Fido2Credential):
+        super().__init__()
         self._cred = cred
         self.load_icon(cred.rp_id_hash)
 

--- a/core/src/protobuf.py
+++ b/core/src/protobuf.py
@@ -152,10 +152,6 @@ class MessageType:
     def get_fields(cls) -> "FieldDict":
         return {}
 
-    def __init__(self, **kwargs: Any) -> None:
-        for kw in kwargs:
-            setattr(self, kw, kwargs[kw])
-
     def __eq__(self, rhs: Any) -> bool:
         return self.__class__ is rhs.__class__ and self.__dict__ == rhs.__dict__
 

--- a/core/src/trezor/ui/__init__.py
+++ b/core/src/trezor/ui/__init__.py
@@ -280,6 +280,7 @@ class Result(Exception):
     """
 
     def __init__(self, value: ResultValue) -> None:
+        super().__init__()
         self.value = value
 
 

--- a/core/src/trezor/ui/__init__.py
+++ b/core/src/trezor/ui/__init__.py
@@ -238,6 +238,9 @@ class Component:
     an instance of `Result`.
     """
 
+    def __init__(self) -> None:
+        self.repaint = True
+
     def dispatch(self, event: int, x: int, y: int) -> None:
         if event is RENDER:
             self.on_render()

--- a/core/src/trezor/ui/button.py
+++ b/core/src/trezor/ui/button.py
@@ -133,6 +133,7 @@ class Button(ui.Component):
         content: ButtonContent,
         style: ButtonStyleType = ButtonDefault,
     ) -> None:
+        super().__init__()
         if isinstance(content, str):
             self.text = content
             self.icon = b""
@@ -146,7 +147,6 @@ class Button(ui.Component):
         self.active_style = style.active
         self.disabled_style = style.disabled
         self.state = _INITIAL
-        self.repaint = True
 
     def enable(self) -> None:
         if self.state is not _INITIAL:

--- a/core/src/trezor/ui/checklist.py
+++ b/core/src/trezor/ui/checklist.py
@@ -15,11 +15,11 @@ _CHECKLIST_OFFSET_X_ICON = const(0)
 
 class Checklist(ui.Component):
     def __init__(self, title: str, icon: str) -> None:
+        super().__init__()
         self.title = title
         self.icon = icon
         self.items = []  # type: List[ChecklistItem]
         self.active = 0
-        self.repaint = True
 
     def add(self, item: ChecklistItem) -> None:
         self.items.append(item)

--- a/core/src/trezor/ui/confirm.py
+++ b/core/src/trezor/ui/confirm.py
@@ -38,6 +38,7 @@ class Confirm(ui.Layout):
         cancel_style: ButtonStyleType = DEFAULT_CANCEL_STYLE,
         major_confirm: bool = False,
     ) -> None:
+        super().__init__()
         self.content = content
 
         if confirm is not None:
@@ -192,6 +193,7 @@ class InfoConfirm(ui.Layout):
         info: ButtonContent = DEFAULT_INFO,
         info_style: ButtonStyleType = DEFAULT_INFO_STYLE,
     ) -> None:
+        super().__init__()
         self.content = content
 
         self.confirm = Button(ui.grid(14), confirm, confirm_style)
@@ -243,6 +245,7 @@ class HoldToConfirm(ui.Layout):
         loader_style: LoaderStyleType = DEFAULT_LOADER_STYLE,
         cancel: bool = True,
     ):
+        super().__init__()
         self.content = content
 
         self.loader = Loader(loader_style)

--- a/core/src/trezor/ui/container.py
+++ b/core/src/trezor/ui/container.py
@@ -6,6 +6,7 @@ if False:
 
 class Container(ui.Component):
     def __init__(self, *children: ui.Component):
+        super().__init__()
         self.children = children
 
     def dispatch(self, event: int, x: int, y: int) -> None:

--- a/core/src/trezor/ui/info.py
+++ b/core/src/trezor/ui/info.py
@@ -35,6 +35,7 @@ class InfoConfirm(ui.Layout):
         confirm: ButtonContent = DEFAULT_CONFIRM,
         style: InfoConfirmStyleType = DEFAULT_STYLE,
     ) -> None:
+        super().__init__()
         self.text = text.split()
         self.style = style
         panel_area = ui.grid(0, n_x=1, n_y=1)
@@ -42,7 +43,6 @@ class InfoConfirm(ui.Layout):
         confirm_area = ui.grid(4, n_x=1)
         self.confirm = Button(confirm_area, confirm, style.button)
         self.confirm.on_click = self.on_confirm  # type: ignore
-        self.repaint = True
 
     def dispatch(self, event: int, x: int, y: int) -> None:
         if event == ui.RENDER:

--- a/core/src/trezor/ui/loader.py
+++ b/core/src/trezor/ui/loader.py
@@ -39,6 +39,7 @@ _TARGET_MS = const(1000)
 
 class Loader(ui.Component):
     def __init__(self, style: LoaderStyleType = LoaderDefault) -> None:
+        super().__init__()
         self.normal_style = style.normal
         self.active_style = style.active
         self.target_ms = _TARGET_MS
@@ -98,6 +99,7 @@ class Loader(ui.Component):
 
 class LoadingAnimation(ui.Layout):
     def __init__(self, style: LoaderStyleType = LoaderDefault) -> None:
+        super().__init__()
         self.loader = Loader(style)
         self.loader.on_finish = self.on_finish  # type: ignore
         self.loader.start()

--- a/core/src/trezor/ui/num_input.py
+++ b/core/src/trezor/ui/num_input.py
@@ -5,6 +5,7 @@ from trezor.ui.text import LABEL_CENTER, Label
 
 class NumInput(ui.Component):
     def __init__(self, count: int = 5, max_count: int = 16, min_count: int = 1) -> None:
+        super().__init__()
         self.count = count
         self.max_count = max_count
         self.min_count = min_count

--- a/core/src/trezor/ui/passphrase.py
+++ b/core/src/trezor/ui/passphrase.py
@@ -115,8 +115,8 @@ class Input(Button):
 
 class Prompt(ui.Component):
     def __init__(self, text: str) -> None:
+        super().__init__()
         self.text = text
-        self.repaint = True
 
     def on_render(self) -> None:
         if self.repaint:
@@ -130,6 +130,7 @@ CANCELLED = object()
 
 class PassphraseKeyboard(ui.Layout):
     def __init__(self, prompt: str, max_length: int, page: int = 1) -> None:
+        super().__init__()
         self.prompt = Prompt(prompt)
         self.max_length = max_length
         self.page = page

--- a/core/src/trezor/ui/pin.py
+++ b/core/src/trezor/ui/pin.py
@@ -32,10 +32,10 @@ def generate_digits() -> Iterable[int]:
 
 class PinInput(ui.Component):
     def __init__(self, prompt: str, subprompt: Optional[str], pin: str) -> None:
+        super().__init__()
         self.prompt = prompt
         self.subprompt = subprompt
         self.pin = pin
-        self.repaint = True
 
     def on_render(self) -> None:
         if self.repaint:

--- a/core/src/trezor/ui/popup.py
+++ b/core/src/trezor/ui/popup.py
@@ -6,6 +6,7 @@ if False:
 
 class Popup(ui.Layout):
     def __init__(self, content: ui.Component, time_ms: int = 0) -> None:
+        super().__init__()
         self.content = content
         if utils.DISABLE_ANIMATION:
             self.time_ms = 0

--- a/core/src/trezor/ui/qr.py
+++ b/core/src/trezor/ui/qr.py
@@ -3,11 +3,11 @@ from trezor import ui
 
 class Qr(ui.Component):
     def __init__(self, data: str, x: int, y: int, scale: int):
+        super().__init__()
         self.data = data
         self.x = x
         self.y = y
         self.scale = scale
-        self.repaint = True
 
     def on_render(self) -> None:
         if self.repaint:

--- a/core/src/trezor/ui/scroll.py
+++ b/core/src/trezor/ui/scroll.py
@@ -51,10 +51,10 @@ class Paginated(ui.Layout):
     def __init__(
         self, pages: List[ui.Component], page: int = 0, one_by_one: bool = False
     ):
+        super().__init__()
         self.pages = pages
         self.page = page
         self.one_by_one = one_by_one
-        self.repaint = True
 
     def dispatch(self, event: int, x: int, y: int) -> None:
         pages = self.pages
@@ -131,6 +131,7 @@ class PageWithButtons(ui.Component):
         index: int,
         count: int,
     ) -> None:
+        super().__init__()
         self.content = content
         self.paginated = paginated
         self.index = index
@@ -188,6 +189,7 @@ class PaginatedWithButtons(ui.Layout):
     def __init__(
         self, pages: List[ui.Component], page: int = 0, one_by_one: bool = False
     ) -> None:
+        super().__init__()
         self.pages = [
             PageWithButtons(p, self, i, len(pages)) for i, p in enumerate(pages)
         ]

--- a/core/src/trezor/ui/swipe.py
+++ b/core/src/trezor/ui/swipe.py
@@ -19,6 +19,7 @@ _SWIPE_TRESHOLD = const(30)
 
 class Swipe(ui.Component):
     def __init__(self, directions: int = SWIPE_ALL, area: ui.Area = None) -> None:
+        super().__init__()
         if area is None:
             area = (0, 0, ui.WIDTH, ui.HEIGHT)
         self.area = area

--- a/core/src/trezor/ui/text.py
+++ b/core/src/trezor/ui/text.py
@@ -129,13 +129,13 @@ class Text(ui.Component):
         max_lines: int = TEXT_MAX_LINES,
         new_lines: bool = True,
     ):
+        super().__init__()
         self.header_text = header_text
         self.header_icon = header_icon
         self.icon_color = icon_color
         self.max_lines = max_lines
         self.new_lines = new_lines
         self.content = []  # type: List[TextContent]
-        self.repaint = True
 
     def normal(self, *content: TextContent) -> None:
         self.content.append(ui.NORMAL)
@@ -187,11 +187,11 @@ class Label(ui.Component):
         align: int = LABEL_LEFT,
         style: int = ui.NORMAL,
     ) -> None:
+        super().__init__()
         self.area = area
         self.content = content
         self.align = align
         self.style = style
-        self.repaint = True
 
     def on_render(self) -> None:
         if self.repaint:

--- a/core/src/trezor/ui/word_select.py
+++ b/core/src/trezor/ui/word_select.py
@@ -10,6 +10,7 @@ if False:
 
 class WordSelector(ui.Layout):
     def __init__(self, content: ui.Component) -> None:
+        super().__init__()
         self.content = content
         self.w12 = Button(ui.grid(6, n_y=4), "12")
         self.w12.on_click = self.on_w12  # type: ignore

--- a/core/src/trezor/wire/__init__.py
+++ b/core/src/trezor/wire/__init__.py
@@ -299,6 +299,7 @@ class Context:
 
 class UnexpectedMessageError(Exception):
     def __init__(self, msg: codec_v1.Message) -> None:
+        super().__init__()
         self.msg = msg
 
 

--- a/core/tests/test_apps.bitcoin.segwit.bip143.native_p2wpkh.py
+++ b/core/tests/test_apps.bitcoin.segwit.bip143.native_p2wpkh.py
@@ -2,7 +2,7 @@ from common import *
 
 from apps.bitcoin.common import SIGHASH_ALL
 from apps.bitcoin.scripts import output_derive_script
-from apps.bitcoin.sign_tx.bitcoin import Hash143
+from apps.bitcoin.sign_tx.bitcoin import Bip143Hash
 from apps.bitcoin.writers import get_tx_hash
 from apps.common import coins
 from apps.common.keychain import Keychain
@@ -49,7 +49,7 @@ class TestSegwitBip143NativeP2WPKH(unittest.TestCase):
 
     def test_prevouts(self):
         coin = coins.by_name(self.tx.coin_name)
-        bip143 = Hash143()
+        bip143 = Bip143Hash()
         bip143.add_input(self.inp1)
         bip143.add_input(self.inp2)
         prevouts_hash = get_tx_hash(bip143.h_prevouts, double=coin.sign_hash_double)
@@ -57,7 +57,7 @@ class TestSegwitBip143NativeP2WPKH(unittest.TestCase):
 
     def test_sequence(self):
         coin = coins.by_name(self.tx.coin_name)
-        bip143 = Hash143()
+        bip143 = Bip143Hash()
         bip143.add_input(self.inp1)
         bip143.add_input(self.inp2)
         sequence_hash = get_tx_hash(bip143.h_sequence, double=coin.sign_hash_double)
@@ -67,7 +67,7 @@ class TestSegwitBip143NativeP2WPKH(unittest.TestCase):
 
         seed = bip39.seed('alcohol woman abuse must during monitor noble actual mixed trade anger aisle', '')
         coin = coins.by_name(self.tx.coin_name)
-        bip143 = Hash143()
+        bip143 = Bip143Hash()
 
         for txo in [self.out1, self.out2]:
             script_pubkey = output_derive_script(txo.address, coin)
@@ -81,7 +81,7 @@ class TestSegwitBip143NativeP2WPKH(unittest.TestCase):
 
         seed = bip39.seed('alcohol woman abuse must during monitor noble actual mixed trade anger aisle', '')
         coin = coins.by_name(self.tx.coin_name)
-        bip143 = Hash143()
+        bip143 = Bip143Hash()
         bip143.add_input(self.inp1)
         bip143.add_input(self.inp2)
 

--- a/core/tests/test_apps.bitcoin.segwit.bip143.p2wpkh_in_p2sh.py
+++ b/core/tests/test_apps.bitcoin.segwit.bip143.p2wpkh_in_p2sh.py
@@ -2,7 +2,7 @@ from common import *
 
 from apps.bitcoin.common import SIGHASH_ALL
 from apps.bitcoin.scripts import output_derive_script
-from apps.bitcoin.sign_tx.bitcoin import Hash143
+from apps.bitcoin.sign_tx.bitcoin import Bip143Hash
 from apps.bitcoin.writers import get_tx_hash
 from apps.common import coins
 from apps.common.keychain import Keychain
@@ -41,14 +41,14 @@ class TestSegwitBip143(unittest.TestCase):
 
     def test_bip143_prevouts(self):
         coin = coins.by_name(self.tx.coin_name)
-        bip143 = Hash143()
+        bip143 = Bip143Hash()
         bip143.add_input(self.inp1)
         prevouts_hash = get_tx_hash(bip143.h_prevouts, double=coin.sign_hash_double)
         self.assertEqual(hexlify(prevouts_hash), b'b0287b4a252ac05af83d2dcef00ba313af78a3e9c329afa216eb3aa2a7b4613a')
 
     def test_bip143_sequence(self):
         coin = coins.by_name(self.tx.coin_name)
-        bip143 = Hash143()
+        bip143 = Bip143Hash()
         bip143.add_input(self.inp1)
         sequence_hash = get_tx_hash(bip143.h_sequence, double=coin.sign_hash_double)
         self.assertEqual(hexlify(sequence_hash), b'18606b350cd8bf565266bc352f0caddcf01e8fa789dd8a15386327cf8cabe198')
@@ -56,7 +56,7 @@ class TestSegwitBip143(unittest.TestCase):
     def test_bip143_outputs(self):
         seed = bip39.seed('alcohol woman abuse must during monitor noble actual mixed trade anger aisle', '')
         coin = coins.by_name(self.tx.coin_name)
-        bip143 = Hash143()
+        bip143 = Bip143Hash()
 
         for txo in [self.out1, self.out2]:
             script_pubkey = output_derive_script(txo.address, coin)
@@ -69,7 +69,7 @@ class TestSegwitBip143(unittest.TestCase):
     def test_bip143_preimage_testdata(self):
         seed = bip39.seed('alcohol woman abuse must during monitor noble actual mixed trade anger aisle', '')
         coin = coins.by_name(self.tx.coin_name)
-        bip143 = Hash143()
+        bip143 = Bip143Hash()
         bip143.add_input(self.inp1)
         for txo in [self.out1, self.out2]:
             script_pubkey = output_derive_script(txo.address, coin)


### PR DESCRIPTION
Fixes #1207. I tried to copy the pylint's "super-init-not-called (W0231)" approach - child class must call the ancestor's `__init__` provided it has one. Number of allocations across device tests increases by about 0.5 %.

* The changes affect the generated protobuf classes, not sure if there can be impact on performance other than the small amount of allocations.
* Children of `Hash143` do a bit of unnecessary work now, perhaps it would be better to refactor `Hash143.__init__` or add an abstract base class ...