### PR TITLE
fix(tests): run test_softlock_instability on emulator only

### DIFF
--- a/python/src/trezorlib/debuglink.py
+++ b/python/src/trezorlib/debuglink.py
@@ -163,7 +163,7 @@ class DebugLink:
         self._call(messages.DebugLinkStop(), nowait=True)
 
     def reseed(self, value):
-        self._call(messages.DebugLinkReseedRandom(value=value))
+        return self._call(messages.DebugLinkReseedRandom(value=value))
 
     def start_recording(self, directory):
         self._call(messages.DebugLinkRecordScreen(target_directory=directory))

--- a/tests/device_tests/test_debuglink.py
+++ b/tests/device_tests/test_debuglink.py
@@ -17,6 +17,7 @@
 import pytest
 
 from trezorlib import debuglink, device, messages, misc
+from trezorlib.transport import udp
 
 from ..common import MNEMONIC12
 
@@ -63,7 +64,11 @@ def test_softlock_instability(client):
         )
 
     # start from a clean slate:
-    client.debug.reseed(0)
+    resp = client.debug.reseed(0)
+    if isinstance(resp, messages.Failure) and not isinstance(
+        client.transport, udp.UdpTransport
+    ):
+        pytest.xfail("reseed only supported on emulator")
     device.wipe(client)
     entropy_after_wipe = misc.get_entropy(client, 16)
 


### PR DESCRIPTION
Reseeding does not make sense on actual hardware so skip the test.

Please let me know if there's a better way to detect we're testing an emulator.

Also not sure whether skip/xfail makes a difference here.