### PR TITLE
In ecdsa_verify_digest() allow the digest to be equal to the order of the group

### DIFF
--- a/crypto/tests/test_check.c
+++ b/crypto/tests/test_check.c
@@ -3336,7 +3336,29 @@ START_TEST(test_ecdsa_signature) {
   int res;
   uint8_t digest[32];
   uint8_t pubkey[65];
+  uint8_t sig[64];
   const ecdsa_curve *curve = &secp256k1;
+
+  // Signature verification for a digest which is equal to the group order.
+  // https://github.com/trezor/trezor-firmware/pull/1374
+  memcpy(
+      pubkey,
+      fromhex(
+          "0479be667ef9dcbbac55a06295ce870b07029bfcdb2dce28d959f2815b16f8179848"
+          "3ada7726a3c4655da4fbfc0e1108a8fd17b448a68554199c47d08ffb10d4b8"),
+      sizeof(pubkey));
+  memcpy(
+      digest,
+      fromhex(
+          "fffffffffffffffffffffffffffffffebaaedce6af48a03bbfd25e8cd0364141"),
+      sizeof(digest));
+  memcpy(sig,
+         fromhex(
+             "a0b37f8fba683cc68f6574cd43b39f0343a50008bf6ccea9d13231d9e7e2e1e41"
+             "1edc8d307254296264aebfc3dc76cd8b668373a072fd64665b50000e9fcce52"),
+         sizeof(sig));
+  res = ecdsa_verify_digest(curve, pubkey, sig, digest);
+  ck_assert_int_eq(res, 0);
 
   // sha2(sha2("\x18Bitcoin Signed Message:\n\x0cHello World!"))
   memcpy(


### PR DESCRIPTION
Based on a bug report from Guido Vranken:

> Here's a new discrepancy I found.
> 
> operation name: ECDSA_Verify
> ecc curve: secp256k1
> public key X: 55066263022277343669578718895168534326250603453777594175500187360389116729240
> public key Y: 32670510020758816978083085130507043184471273380659243275938904335757337482424
> in: {0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xfe,
>  0xba, 0xae, 0xdc, 0xe6, 0xaf, 0x48, 0xa0, 0x3b, 0xbf, 0xd2, 0x5e, 0x8c, 0xd0, 0x36, 0x41, 0x41} (32 bytes)
> signature R: 72687201794607335770376625339678533083457947201644627590368835286197510267364
> signature S: 8109447218838624529250472094270127202499713651044141199238310867220054199890
> 
> This fails verification in Trezor, but passes verification in libsecp256k1, Botan, wolfCrypt and the Decred secp256k1 implementation.

The reason for this is that `in` is congruent to 0 modulo the order of the group. So it's equivalent to the case `in = 0000...00` we had earlier. The other libraries are behaving correctly and Trezor should also accept the signature as valid, since I think the original argument for rejecting no longer applies in this case.