### PR TITLE
Problems in slip39 find()

### DIFF
--- a/core/embed/extmod/modtrezorcrypto/modtrezorcrypto-slip39.h
+++ b/core/embed/extmod/modtrezorcrypto/modtrezorcrypto-slip39.h
@@ -24,7 +24,7 @@
 
 /// package: trezorcrypto.slip39
 
-/// def compute_mask(prefix: int) -> int:
+/// def word_completion_mask(prefix: int) -> int:
 ///     """
 ///     Calculates which buttons still can be pressed after some already were.
 ///     Returns a 9-bit bitmask, where each bit specifies which buttons
@@ -34,17 +34,18 @@
 ///     Example: 110000110 - second, third, eighth and ninth button still can be
 ///     pressed.
 ///     """
-STATIC mp_obj_t mod_trezorcrypto_slip39_compute_mask(mp_obj_t _prefix) {
+STATIC mp_obj_t mod_trezorcrypto_slip39_word_completion_mask(mp_obj_t _prefix) {
   uint16_t prefix = mp_obj_get_int(_prefix);
 
   if (prefix < 1 || prefix > 9999) {
     mp_raise_ValueError(
         "Invalid button prefix (range between 1 and 9999 is allowed)");
   }
-  return mp_obj_new_int_from_uint(compute_mask(prefix));
+  return mp_obj_new_int_from_uint(slip39_word_completion_mask(prefix));
 }
-STATIC MP_DEFINE_CONST_FUN_OBJ_1(mod_trezorcrypto_slip39_compute_mask_obj,
-                                 mod_trezorcrypto_slip39_compute_mask);
+STATIC MP_DEFINE_CONST_FUN_OBJ_1(
+    mod_trezorcrypto_slip39_word_completion_mask_obj,
+    mod_trezorcrypto_slip39_word_completion_mask);
 
 /// def button_sequence_to_word(prefix: int) -> str:
 ///     """
@@ -90,12 +91,12 @@ STATIC MP_DEFINE_CONST_FUN_OBJ_1(mod_trezorcrypto_slip39_word_index_obj,
 STATIC mp_obj_t mod_trezorcrypto_slip39_get_word(mp_obj_t _index) {
   uint16_t index = mp_obj_get_int(_index);
 
-  if (index > 1023) {
+  const char *word = get_word(index);
+  if (word == NULL) {
     mp_raise_ValueError(
         "Invalid wordlist index (range between 0 and 1024 is allowed)");
   }
 
-  const char *word = get_word(index);
   return mp_obj_new_str_copy(&mp_type_str, (const uint8_t *)word, strlen(word));
 }
 STATIC MP_DEFINE_CONST_FUN_OBJ_1(mod_trezorcrypto_slip39_get_word_obj,
@@ -103,8 +104,8 @@ STATIC MP_DEFINE_CONST_FUN_OBJ_1(mod_trezorcrypto_slip39_get_word_obj,
 
 STATIC const mp_rom_map_elem_t mod_trezorcrypto_slip39_globals_table[] = {
     {MP_ROM_QSTR(MP_QSTR___name__), MP_ROM_QSTR(MP_QSTR_slip39)},
-    {MP_ROM_QSTR(MP_QSTR_compute_mask),
-     MP_ROM_PTR(&mod_trezorcrypto_slip39_compute_mask_obj)},
+    {MP_ROM_QSTR(MP_QSTR_word_completion_mask),
+     MP_ROM_PTR(&mod_trezorcrypto_slip39_word_completion_mask_obj)},
     {MP_ROM_QSTR(MP_QSTR_button_sequence_to_word),
      MP_ROM_PTR(&mod_trezorcrypto_slip39_button_sequence_to_word_obj)},
     {MP_ROM_QSTR(MP_QSTR_word_index),

--- a/core/embed/extmod/modtrezorcrypto/modtrezorcrypto-slip39.h
+++ b/core/embed/extmod/modtrezorcrypto/modtrezorcrypto-slip39.h
@@ -54,11 +54,10 @@ STATIC mp_obj_t
 mod_trezorcrypto_slip39_button_sequence_to_word(mp_obj_t _prefix) {
   uint16_t prefix = mp_obj_get_int(_prefix);
 
-  if (prefix < 1 || prefix > 9999) {
-    mp_raise_ValueError(
-        "Invalid button prefix (range between 1 and 9999 is allowed)");
-  }
   const char *word = button_sequence_to_word(prefix);
+  if (word == NULL) {
+    mp_raise_ValueError("Invalid button prefix");
+  }
   return mp_obj_new_str_copy(&mp_type_str, (const uint8_t *)word, strlen(word));
 }
 STATIC MP_DEFINE_CONST_FUN_OBJ_1(

--- a/core/mocks/generated/trezorcrypto/slip39.pyi
+++ b/core/mocks/generated/trezorcrypto/slip39.pyi
@@ -2,7 +2,7 @@ from typing import *
 
 
 # extmod/modtrezorcrypto/modtrezorcrypto-slip39.h
-def compute_mask(prefix: int) -> int:
+def word_completion_mask(prefix: int) -> int:
     """
     Calculates which buttons still can be pressed after some already were.
     Returns a 9-bit bitmask, where each bit specifies which buttons

--- a/core/src/apps/management/recovery_device/keyboard_slip39.py
+++ b/core/src/apps/management/recovery_device/keyboard_slip39.py
@@ -171,7 +171,7 @@ class Slip39Keyboard(ui.Layout):
 
         # find the completions
         word = ""
-        self.mask = slip39.compute_mask(self.button_sequence)
+        self.mask = slip39.word_completion_mask(self.button_sequence)
         if self.is_input_final():
             word = slip39.button_sequence_to_word(self.button_sequence)
 

--- a/core/src/trezor/crypto/slip39.py
+++ b/core/src/trezor/crypto/slip39.py
@@ -114,10 +114,10 @@ KEYBOARD_FULL_MASK = const(0x1FF)
 """All buttons are allowed. 9-bit bitmap all set to 1."""
 
 
-def compute_mask(prefix: str) -> int:
+def word_completion_mask(prefix: str) -> int:
     if not prefix:
         return KEYBOARD_FULL_MASK
-    return slip39.compute_mask(int(prefix))
+    return slip39.word_completion_mask(int(prefix))
 
 
 def button_sequence_to_word(prefix: str) -> str:

--- a/crypto/slip39.c
+++ b/crypto/slip39.c
@@ -37,7 +37,7 @@ const char* get_word(uint16_t index) {
     return NULL;
   }
 
-  return wordlist[index];
+  return slip39_wordlist[index];
 }
 
 /**
@@ -51,13 +51,13 @@ bool word_index(uint16_t* index, const char* word, uint8_t word_length) {
 
   while ((hi - lo) > 1) {
     mid = (hi + lo) / 2;
-    if (strncmp(wordlist[mid], word, word_length) > 0) {
+    if (strncmp(slip39_wordlist[mid], word, word_length) > 0) {
       hi = mid;
     } else {
       lo = mid;
     }
   }
-  if (strncmp(wordlist[lo], word, word_length) != 0) {
+  if (strncmp(slip39_wordlist[lo], word, word_length) != 0) {
     return false;
   }
   *index = lo;

--- a/crypto/slip39.h
+++ b/crypto/slip39.h
@@ -22,6 +22,9 @@
  * OTHER DEALINGS IN THE SOFTWARE.
  */
 
+#ifndef __SLIP39_H__
+#define __SLIP39_H__
+
 #include <stdbool.h>
 #include <stdint.h>
 
@@ -29,8 +32,8 @@ const char* get_word(uint16_t index);
 
 bool word_index(uint16_t* index, const char* word, uint8_t word_length);
 
-uint16_t compute_mask(uint16_t prefix);
+uint16_t slip39_word_completion_mask(uint16_t prefix);
 
 const char* button_sequence_to_word(uint16_t prefix);
 
-uint16_t find(uint16_t prefix, bool find_index);
+#endif

--- a/crypto/slip39_wordlist.h
+++ b/crypto/slip39_wordlist.h
@@ -213,1031 +213,1034 @@ static const char* const slip39_wordlist[WORDS_COUNT] = {
  *
  * Each word is uniquely defined by four buttons.
  */
-static const uint16_t words_button_seq[WORDS_COUNT] = {
-    1212,  // academic
-    1242,  // acid
-    1263,  // acne
-    1268,  // acquire
-    1276,  // acrobat
-    1284,  // activity
-    1287,  // actress
-    1216,  // adapt
-    1236,  // adequate
-    1248,  // adjust
-    1254,  // admit
-    1267,  // adorn
-    1285,  // adult
-    1281,  // advance
-    1286,  // advocate
-    1371,  // afraid
-    1414,  // again
-    1436,  // agency
-    1473,  // agree
-    1423,  // aide
-    1472,  // aircraft
-    1475,  // airline
-    1476,  // airport
-    1417,  // ajar
-    1517,  // alarm
-    1518,  // album
-    1526,  // alcohol
-    1543,  // alien
-    1548,  // alive
-    1564,  // alpha
-    1573,  // already
-    1586,  // alto
-    1585,  // aluminum
-    1591,  // always
-    1519,  // amazing
-    1514,  // ambition
-    1568,  // amount
-    1587,  // amuse
-    1615,  // analysis
-    1618,  // anatomy
-    1623,  // ancestor
-    1624,  // ancient
-    1643,  // angel
-    1647,  // angry
-    1645,  // animal
-    1679,  // answer
-    1683,  // antenna
-    1694,  // anxiety
-    1617,  // apart
-    1681,  // aquatic
-    1721,  // arcade
-    1736,  // arena
-    1748,  // argue
-    1753,  // armed
-    1784,  // artist
-    1789,  // artwork
-    1763,  // aspect
-    1828,  // auction
-    1848,  // august
-    1868,  // aunt
-    1837,  // average
-    1841,  // aviation
-    1864,  // avoid
-    1917,  // award
-    1919,  // away
-    1947,  // axis
-    1953,  // axle
-    1315,  // beam
-    1317,  // beard
-    1318,  // beaver
-    1326,  // become
-    1327,  // bedroom
-    1341,  // behavior
-    1346,  // being
-    1354,  // believe
-    1356,  // belong
-    1363,  // benefit
-    1378,  // best
-    1396,  // beyond
-    1453,  // bike
-    1465,  // biology
-    1478,  // birthday
-    1474,  // bishop
-    1512,  // black
-    1516,  // blanket
-    1537,  // blessing
-    1545,  // blimp
-    1546,  // blind
-    1583,  // blue
-    1629,  // body
-    1658,  // bolt
-    1674,  // boring
-    1676,  // born
-    1684,  // both
-    1686,  // boundary
-    1712,  // bracelet
-    1716,  // branch
-    1718,  // brave
-    1731,  // breathe
-    1743,  // briefing
-    1765,  // broken
-    1768,  // brother
-    1769,  // browser
-    1825,  // bucket
-    1824,  // budget
-    1845,  // building
-    1851,  // bulb
-    1854,  // bulge
-    1856,  // bumpy
-    1862,  // bundle
-    1872,  // burden
-    1876,  // burning
-    1879,  // busy
-    1893,  // buyer
-    2143,  // cage
-    2152,  // calcium
-    2153,  // camera
-    2156,  // campus
-    2169,  // canyon
-    2161,  // capacity
-    2164,  // capital
-    2168,  // capture
-    2171,  // carbon
-    2172,  // cards
-    2173,  // careful
-    2174,  // cargo
-    2176,  // carpet
-    2178,  // carve
-    2183,  // category
-    2187,  // cause
-    2345,  // ceiling
-    2368,  // center
-    2371,  // ceramic
-    2415,  // champion
-    2416,  // change
-    2417,  // charity
-    2432,  // check
-    2435,  // chemical
-    2437,  // chest
-    2439,  // chew
-    2481,  // chubby
-    2463,  // cinema
-    2484,  // civil
-    2517,  // class
-    2519,  // clay
-    2531,  // cleanup
-    2543,  // client
-    2545,  // climate
-    2546,  // clinic
-    2562,  // clock
-    2564,  // clogs
-    2567,  // closet
-    2568,  // clothes
-    2581,  // club
-    2587,  // cluster
-    2615,  // coal
-    2617,  // coastal
-    2624,  // coding
-    2658,  // column
-    2656,  // company
-    2676,  // corner
-    2678,  // costume
-    2686,  // counter
-    2687,  // course
-    2683,  // cover
-    2691,  // cowboy
-    2712,  // cradle
-    2713,  // craft
-    2719,  // crazy
-    2732,  // credit
-    2742,  // cricket
-    2745,  // criminal
-    2747,  // crisis
-    2748,  // critical
-    2769,  // crowd
-    2782,  // crucial
-    2786,  // crunch
-    2787,  // crush
-    2797,  // crystal
-    2814,  // cubic
-    2858,  // cultural
-    2874,  // curious
-    2875,  // curly
-    2878,  // custody
-    2954,  // cylinder
-    2147,  // daisy
-    2151,  // damage
-    2162,  // dance
-    2175,  // darkness
-    2181,  // database
-    2184,  // daughter
-    2312,  // deadline
-    2315,  // deal
-    2317,  // debris
-    2318,  // debut
-    2323,  // decent
-    2324,  // decision
-    2325,  // declare
-    2326,  // decorate
-    2327,  // decrease
-    2354,  // deliver
-    2351,  // demand
-    2367,  // density
-    2369,  // deny
-    2361,  // depart
-    2363,  // depend
-    2364,  // depict
-    2365,  // deploy
-    2372,  // describe
-    2373,  // desert
-    2374,  // desire
-    2375,  // desktop
-    2378,  // destroy
-    2381,  // detailed
-    2383,  // detect
-    2384,  // device
-    2386,  // devote
-    2414,  // diagnose
-    2428,  // dictate
-    2438,  // diet
-    2453,  // dilemma
-    2454,  // diminish
-    2464,  // dining
-    2465,  // diploma
-    2471,  // disaster
-    2472,  // discuss
-    2473,  // disease
-    2474,  // dish
-    2475,  // dismiss
-    2476,  // display
-    2478,  // distance
-    2483,  // dive
-    2486,  // divorce
-    2628,  // document
-    2651,  // domain
-    2653,  // domestic
-    2654,  // dominant
-    2684,  // dough
-    2696,  // downtown
-    2714,  // dragon
-    2715,  // dramatic
-    2731,  // dream
-    2737,  // dress
-    2743,  // drift
-    2746,  // drink
-    2768,  // drove
-    2784,  // drug
-    2793,  // dryer
-    2825,  // duckling
-    2853,  // duke
-    2871,  // duration
-    2917,  // dwarf
-    2961,  // dynamic
-    3175,  // early
-    3178,  // earth
-    3173,  // easel
-    3179,  // easy
-    3246,  // echo
-    3254,  // eclipse
-    3265,  // ecology
-    3243,  // edge
-    3248,  // editor
-    3282,  // educate
-    3484,  // either
-    3516,  // elbow
-    3523,  // elder
-    3532,  // election
-    3534,  // elegant
-    3535,  // element
-    3536,  // elephant
-    3538,  // elevator
-    3548,  // elite
-    3573,  // else
-    3514,  // email
-    3537,  // emerald
-    3547,  // emission
-    3563,  // emperor
-    3564,  // emphasis
-    3565,  // employer
-    3568,  // empty
-    3624,  // ending
-    3625,  // endless
-    3626,  // endorse
-    3635,  // enemy
-    3637,  // energy
-    3636,  // enforce
-    3641,  // engage
-    3646,  // enjoy
-    3651,  // enlarge
-    3687,  // entrance
-    3683,  // envelope
-    3689,  // envy
-    3642,  // epidemic
-    3647,  // episode
-    3681,  // equation
-    3684,  // equip
-    3717,  // eraser
-    3762,  // erode
-    3721,  // escape
-    3781,  // estate
-    3784,  // estimate
-    3815,  // evaluate
-    3836,  // evening
-    3842,  // evidence
-    3845,  // evil
-    3865,  // evoke
-    3912,  // exact
-    3915,  // example
-    3923,  // exceed
-    3924,  // exchange
-    3925,  // exclude
-    3928,  // excuse
-    3932,  // execute
-    3937,  // exercise
-    3941,  // exhaust
-    3968,  // exotic
-    3961,  // expand
-    3963,  // expect
-    3965,  // explain
-    3967,  // express
-    3983,  // extend
-    3987,  // extra
-    3931,  // eyebrow
-    3124,  // facility
-    3128,  // fact
-    3145,  // failure
-    3146,  // faint
-    3153,  // fake
-    3157,  // false
-    3154,  // family
-    3156,  // famous
-    3162,  // fancy
-    3164,  // fangs
-    3168,  // fantasy
-    3181,  // fatal
-    3184,  // fatigue
-    3186,  // favorite
-    3196,  // fawn
-    3413,  // fiber
-    3428,  // fiction
-    3458,  // filter
-    3461,  // finance
-    3462,  // findings
-    3464,  // finger
-    3473,  // firefly
-    3475,  // firm
-    3472,  // fiscal
-    3474,  // fishing
-    3486,  // fitness
-    3515,  // flame
-    3517,  // flash
-    3518,  // flavor
-    3531,  // flea
-    3539,  // flexible
-    3546,  // flip
-    3561,  // float
-    3567,  // floral
-    3583,  // fluff
-    3628,  // focus
-    3671,  // forbid
-    3672,  // force
-    3673,  // forecast
-    3674,  // forget
-    3675,  // formal
-    3678,  // fortune
-    3679,  // forward
-    3686,  // founder
-    3712,  // fraction
-    3714,  // fragment
-    3736,  // frequent
-    3737,  // freshman
-    3741,  // friar
-    3742,  // fridge
-    3743,  // friendly
-    3767,  // frost
-    3768,  // froth
-    3769,  // frozen
-    3853,  // fumes
-    3862,  // funding
-    3875,  // furl
-    3873,  // fused
-    4151,  // galaxy
-    4153,  // game
-    4171,  // garbage
-    4172,  // garden
-    4175,  // garlic
-    4176,  // gasoline
-    4184,  // gather
-    4363,  // general
-    4364,  // genius
-    4367,  // genre
-    4368,  // genuine
-    4365,  // geology
-    4378,  // gesture
-    4512,  // glad
-    4516,  // glance
-    4517,  // glasses
-    4536,  // glen
-    4545,  // glimpse
-    4618,  // goat
-    4652,  // golden
-    4712,  // graduate
-    4716,  // grant
-    4717,  // grasp
-    4718,  // gravity
-    4719,  // gray
-    4731,  // greatest
-    4743,  // grief
-    4745,  // grill
-    4746,  // grin
-    4762,  // grocery
-    4767,  // gross
-    4768,  // group
-    4769,  // grownup
-    4785,  // grumpy
-    4817,  // guard
-    4837,  // guest
-    4845,  // guilt
-    4848,  // guitar
-    4857,  // gums
-    4147,  // hairy
-    4157,  // hamster
-    4162,  // hand
-    4164,  // hanger
-    4178,  // harvest
-    4183,  // have
-    4186,  // havoc
-    4195,  // hawk
-    4191,  // hazard
-    4312,  // headset
-    4315,  // health
-    4317,  // hearing
-    4318,  // heat
-    4356,  // helpful
-    4371,  // herald
-    4372,  // herd
-    4374,  // hesitate
-    4616,  // hobo
-    4654,  // holiday
-    4659,  // holy
-    4653,  // home
-    4675,  // hormone
-    4676,  // hospital
-    4687,  // hour
-    4843,  // huge
-    4851,  // human
-    4854,  // humidity
-    4868,  // hunting
-    4871,  // husband
-    4874,  // hush
-    4875,  // husky
-    4917,  // hybrid
-    4231,  // idea
-    4236,  // identify
-    4253,  // idle
-    4514,  // image
-    4561,  // impact
-    4565,  // imply
-    4567,  // improve
-    4568,  // impulse
-    4625,  // include
-    4626,  // income
-    4627,  // increase
-    4623,  // index
-    4624,  // indicate
-    4628,  // industry
-    4631,  // infant
-    4636,  // inform
-    4643,  // inherit
-    4648,  // injury
-    4651,  // inmate
-    4673,  // insect
-    4674,  // inside
-    4678,  // install
-    4683,  // intend
-    4684,  // intimate
-    4681,  // invasion
-    4686,  // involve
-    4747,  // iris
-    4751,  // island
-    4765,  // isolate
-    4835,  // item
-    4867,  // ivory
-    4125,  // jacket
-    4375,  // jerky
-    4393,  // jewelry
-    4646,  // join
-    4824,  // judicial
-    4842,  // juice
-    4856,  // jump
-    4862,  // junction
-    4864,  // junior
-    4865,  // junk
-    4879,  // jury
-    4878,  // justice
-    5376,  // kernel
-    5391,  // keyboard
-    5426,  // kidney
-    5462,  // kind
-    5482,  // kitchen
-    5643,  // knife
-    5648,  // knit
-    5123,  // laden
-    5125,  // ladle
-    5129,  // ladybug
-    5147,  // lair
-    5156,  // lamp
-    5164,  // language
-    5174,  // large
-    5173,  // laser
-    5186,  // laundry
-    5197,  // lawsuit
-    5312,  // leader
-    5313,  // leaf
-    5317,  // learn
-    5318,  // leaves
-    5328,  // lecture
-    5341,  // legal
-    5343,  // legend
-    5347,  // legs
-    5362,  // lend
-    5364,  // length
-    5383,  // level
-    5413,  // liberty
-    5417,  // library
-    5423,  // license
-    5438,  // lift
-    5453,  // likely
-    5451,  // lilac
-    5459,  // lily
-    5467,  // lips
-    5468,  // liquid
-    5478,  // listen
-    5483,  // literary
-    5484,  // living
-    5491,  // lizard
-    5616,  // loan
-    5613,  // lobe
-    5621,  // location
-    5674,  // losing
-    5682,  // loud
-    5691,  // loyalty
-    5825,  // luck
-    5861,  // lunar
-    5862,  // lunch
-    5864,  // lungs
-    5898,  // luxury
-    5946,  // lying
-    5974,  // lyrics
-    5124,  // machine
-    5141,  // magazine
-    5142,  // maiden
-    5145,  // mailman
-    5146,  // main
-    5153,  // makeup
-    5154,  // making
-    5151,  // mama
-    5161,  // manager
-    5162,  // mandate
-    5167,  // mansion
-    5168,  // manual
-    5171,  // marathon
-    5172,  // march
-    5175,  // market
-    5178,  // marvel
-    5176,  // mason
-    5183,  // material
-    5184,  // math
-    5194,  // maximum
-    5196,  // mayor
-    5316,  // meaning
-    5321,  // medal
-    5324,  // medical
-    5351,  // member
-    5356,  // memory
-    5368,  // mental
-    5372,  // merchant
-    5374,  // merit
-    5384,  // method
-    5387,  // metric
-    5427,  // midst
-    5452,  // mild
-    5454,  // military
-    5463,  // mineral
-    5464,  // minister
-    5471,  // miracle
-    5493,  // mixed
-    5498,  // mixture
-    5614,  // mobile
-    5623,  // modern
-    5624,  // modify
-    5647,  // moisture
-    5653,  // moment
-    5676,  // morning
-    5678,  // mortgage
-    5684,  // mother
-    5686,  // mountain
-    5687,  // mouse
-    5683,  // move
-    5824,  // much
-    5853,  // mule
-    5858,  // multiple
-    5872,  // muscle
-    5873,  // museum
-    5874,  // music
-    5878,  // mustang
-    6145,  // nail
-    6184,  // national
-    6325,  // necklace
-    6341,  // negative
-    6378,  // nervous
-    6389,  // network
-    6397,  // news
-    6825,  // nuclear
-    6851,  // numb
-    6853,  // numerous
-    6956,  // nylon
-    6174,  // oasis
-    6137,  // obesity
-    6143,  // object
-    6173,  // observe
-    6181,  // obtain
-    6231,  // ocean
-    6383,  // often
-    6595,  // olympic
-    6548,  // omit
-    6715,  // oral
-    6716,  // orange
-    6714,  // orbit
-    6723,  // order
-    6724,  // ordinary
-    6741,  // organize
-    6862,  // ounce
-    6836,  // oven
-    6837,  // overall
-    6963,  // owner
-    6123,  // paces
-    6124,  // pacific
-    6125,  // package
-    6142,  // paid
-    6146,  // painting
-    6141,  // pajamas
-    6162,  // pancake
-    6168,  // pants
-    6161,  // papa
-    6163,  // paper
-    6172,  // parcel
-    6175,  // parking
-    6178,  // party
-    6183,  // patent
-    6187,  // patrol
-    6195,  // payment
-    6197,  // payroll
-    6312,  // peaceful
-    6316,  // peanut
-    6317,  // peasant
-    6321,  // pecan
-    6361,  // penalty
-    6362,  // pencil
-    6372,  // percent
-    6373,  // perfect
-    6375,  // permit
-    6384,  // petition
-    6416,  // phantom
-    6417,  // pharmacy
-    6468,  // photo
-    6471,  // phrase
-    6497,  // physics
-    6425,  // pickup
-    6428,  // picture
-    6432,  // piece
-    6453,  // pile
-    6465,  // pink
-    6463,  // pipeline
-    6478,  // pistol
-    6482,  // pitch
-    6514,  // plains
-    6516,  // plan
-    6517,  // plastic
-    6518,  // platform
-    6519,  // playoff
-    6531,  // pleasure
-    6568,  // plot
-    6586,  // plunge
-    6712,  // practice
-    6719,  // prayer
-    6731,  // preach
-    6732,  // predator
-    6734,  // pregnant
-    6735,  // premium
-    6736,  // prepare
-    6737,  // presence
-    6738,  // prevent
-    6743,  // priest
-    6745,  // primary
-    6746,  // priority
-    6747,  // prisoner
-    6748,  // privacy
-    6749,  // prize
-    6761,  // problem
-    6762,  // process
-    6763,  // profile
-    6764,  // program
-    6765,  // promise
-    6767,  // prospect
-    6768,  // provide
-    6786,  // prune
-    6815,  // public
-    6857,  // pulse
-    6856,  // pumps
-    6864,  // punish
-    6869,  // puny
-    6861,  // pupal
-    6872,  // purchase
-    6876,  // purple
-    6984,  // python
-    6816,  // quantity
-    6817,  // quarter
-    6842,  // quick
-    6843,  // quiet
-    7123,  // race
-    7124,  // racism
-    7121,  // radar
-    7145,  // railroad
-    7146,  // rainbow
-    7147,  // raisin
-    7162,  // random
-    7165,  // ranked
-    7164,  // rapids
-    7176,  // raspy
-    7312,  // reaction
-    7315,  // realize
-    7316,  // rebound
-    7318,  // rebuild
-    7321,  // recall
-    7323,  // receiver
-    7326,  // recover
-    7347,  // regret
-    7348,  // regular
-    7343,  // reject
-    7351,  // relate
-    7353,  // remember
-    7354,  // remind
-    7356,  // remove
-    7362,  // render
-    7361,  // repair
-    7363,  // repeat
-    7365,  // replace
-    7368,  // require
-    7372,  // rescue
-    7373,  // research
-    7374,  // resident
-    7376,  // response
-    7378,  // result
-    7381,  // retailer
-    7387,  // retreat
-    7386,  // reunion
-    7383,  // revenue
-    7384,  // review
-    7391,  // reward
-    7495,  // rhyme
-    7498,  // rhythm
-    7424,  // rich
-    7481,  // rival
-    7483,  // river
-    7614,  // robin
-    7625,  // rocky
-    7651,  // romantic
-    7656,  // romp
-    7678,  // roster
-    7686,  // round
-    7691,  // royal
-    7846,  // ruin
-    7853,  // ruler
-    7856,  // rumor
-    7125,  // sack
-    7131,  // safari
-    7151,  // salary
-    7156,  // salon
-    7158,  // salt
-    7184,  // satisfy
-    7186,  // satoshi
-    7183,  // saver
-    7197,  // says
-    7216,  // scandal
-    7217,  // scared
-    7218,  // scatter
-    7236,  // scene
-    7246,  // scholar
-    7243,  // science
-    7268,  // scout
-    7271,  // scramble
-    7273,  // screw
-    7274,  // script
-    7276,  // scroll
-    7313,  // seafood
-    7317,  // season
-    7327,  // secret
-    7328,  // security
-    7345,  // segment
-    7364,  // senior
-    7412,  // shadow
-    7413,  // shaft
-    7415,  // shame
-    7416,  // shaped
-    7417,  // sharp
-    7435,  // shelter
-    7437,  // sheriff
-    7467,  // short
-    7468,  // should
-    7474,  // shrimp
-    7423,  // sidewalk
-    7453,  // silent
-    7458,  // silver
-    7454,  // similar
-    7456,  // simple
-    7464,  // single
-    7478,  // sister
-    7546,  // skin
-    7586,  // skunk
-    7516,  // slap
-    7518,  // slavery
-    7532,  // sled
-    7542,  // slice
-    7545,  // slim
-    7569,  // slow
-    7587,  // slush
-    7517,  // smart
-    7531,  // smear
-    7535,  // smell
-    7547,  // smirk
-    7548,  // smith
-    7565,  // smoking
-    7584,  // smug
-    7615,  // snake
-    7616,  // snapshot
-    7643,  // sniff
-    7624,  // society
-    7638,  // software
-    7652,  // soldier
-    7658,  // solution
-    7685,  // soul
-    7687,  // source
-    7612,  // space
-    7617,  // spark
-    7631,  // speak
-    7632,  // species
-    7635,  // spelling
-    7636,  // spend
-    7639,  // spew
-    7642,  // spider
-    7645,  // spill
-    7646,  // spine
-    7647,  // spirit
-    7648,  // spit
-    7671,  // spray
-    7674,  // sprinkle
-    7681,  // square
-    7683,  // squeeze
-    7812,  // stadium
-    7813,  // staff
-    7816,  // standard
-    7817,  // starting
-    7818,  // station
-    7819,  // stay
-    7831,  // steady
-    7836,  // step
-    7842,  // stick
-    7845,  // stilt
-    7867,  // story
-    7871,  // strategy
-    7874,  // strike
-    7895,  // style
-    7814,  // subject
-    7815,  // submit
-    7841,  // sugar
-    7848,  // suitable
-    7865,  // sunlight
-    7863,  // superior
-    7873,  // surface
-    7876,  // surprise
-    7878,  // survive
-    7931,  // sweater
-    7945,  // swimming
-    7946,  // swing
-    7948,  // switch
-    7951,  // symbolic
-    7956,  // sympathy
-    7962,  // syndrome
-    7978,  // system
-    8125,  // tackle
-    8128,  // tactics
-    8126,  // tadpole
-    8153,  // talent
-    8175,  // task
-    8178,  // taste
-    8184,  // taught
-    8194,  // taxi
-    8312,  // teacher
-    8315,  // teammate
-    8317,  // teaspoon
-    8356,  // temple
-    8361,  // tenant
-    8362,  // tendency
-    8367,  // tension
-    8375,  // terminal
-    8378,  // testify
-    8398,  // texture
-    8416,  // thank
-    8418,  // that
-    8431,  // theater
-    8436,  // theory
-    8437,  // therapy
-    8467,  // thorn
-    8473,  // threaten
-    8485,  // thumb
-    8486,  // thunder
-    8425,  // ticket
-    8429,  // tidy
-    8451,  // timber
-    8453,  // timely
-    8464,  // ting
-    8638,  // tofu
-    8643,  // together
-    8653,  // tolerate
-    8681,  // total
-    8694,  // toxic
-    8712,  // tracks
-    8713,  // traffic
-    8714,  // training
-    8716,  // transfer
-    8717,  // trash
-    8718,  // traveler
-    8731,  // treat
-    8736,  // trend
-    8741,  // trial
-    8742,  // tricycle
-    8746,  // trip
-    8748,  // triumph
-    8768,  // trouble
-    8783,  // true
-    8787,  // trust
-    8942,  // twice
-    8946,  // twin
-    8963,  // type
-    8964,  // typical
-    8459,  // ugly
-    8584,  // ultimate
-    8517,  // umbrella
-    8626,  // uncover
-    8623,  // undergo
-    8631,  // unfair
-    8636,  // unfold
-    8641,  // unhappy
-    8646,  // union
-    8648,  // universe
-    8654,  // unkind
-    8656,  // unknown
-    8687,  // unusual
-    8697,  // unwrap
-    8647,  // upgrade
-    8678,  // upstairs
-    8737,  // username
-    8743,  // usher
-    8781,  // usual
-    8154,  // valid
-    8158,  // valuable
-    8156,  // vampire
-    8164,  // vanish
-    8174,  // various
-    8341,  // vegan
-    8358,  // velvet
-    8368,  // venture
-    8372,  // verdict
-    8374,  // verify
-    8379,  // very
-    8383,  // veteran
-    8393,  // vexed
-    8428,  // victim
-    8423,  // video
-    8439,  // view
-    8468,  // vintage
-    8465,  // violence
-    8471,  // viral
-    8474,  // visitor
-    8478,  // visual
-    8481,  // vitamins
-    8621,  // vocal
-    8642,  // voice
-    8658,  // volume
-    8683,  // voter
-    8684,  // voting
-    9156,  // walnut
-    9175,  // warmth
-    9176,  // warn
-    9182,  // watch
-    9189,  // wavy
-    9315,  // wealthy
-    9316,  // weapon
-    9312,  // webcam
-    9352,  // welcome
-    9353,  // welfare
-    9378,  // western
-    9428,  // width
-    9452,  // wildlife
-    9462,  // window
-    9463,  // wine
-    9473,  // wireless
-    9472,  // wisdom
-    9484,  // withdraw
-    9487,  // wits
-    9653,  // wolf
-    9651,  // woman
-    9675,  // work
-    9678,  // worthy
-    9716,  // wrap
-    9747,  // wrist
-    9748,  // writing
-    9768,  // wrote
-    9317,  // year
-    9356,  // yelp
-    9435,  // yield
-    9641,  // yoga
-    9376,  // zero
+static const struct {
+  uint16_t sequence;
+  uint16_t index;
+} words_button_seq[WORDS_COUNT] = {
+    {1212, 0},     // academic
+    {1216, 7},     // adapt
+    {1236, 8},     // adequate
+    {1242, 1},     // acid
+    {1248, 9},     // adjust
+    {1254, 10},    // admit
+    {1263, 2},     // acne
+    {1267, 11},    // adorn
+    {1268, 3},     // acquire
+    {1276, 4},     // acrobat
+    {1281, 13},    // advance
+    {1284, 5},     // activity
+    {1285, 12},    // adult
+    {1286, 14},    // advocate
+    {1287, 6},     // actress
+    {1315, 67},    // beam
+    {1317, 68},    // beard
+    {1318, 69},    // beaver
+    {1326, 70},    // become
+    {1327, 71},    // bedroom
+    {1341, 72},    // behavior
+    {1346, 73},    // being
+    {1354, 74},    // believe
+    {1356, 75},    // belong
+    {1363, 76},    // benefit
+    {1371, 15},    // afraid
+    {1378, 77},    // best
+    {1396, 78},    // beyond
+    {1414, 16},    // again
+    {1417, 23},    // ajar
+    {1423, 19},    // aide
+    {1436, 17},    // agency
+    {1453, 79},    // bike
+    {1465, 80},    // biology
+    {1472, 20},    // aircraft
+    {1473, 18},    // agree
+    {1474, 82},    // bishop
+    {1475, 21},    // airline
+    {1476, 22},    // airport
+    {1478, 81},    // birthday
+    {1512, 83},    // black
+    {1514, 35},    // ambition
+    {1516, 84},    // blanket
+    {1517, 24},    // alarm
+    {1518, 25},    // album
+    {1519, 34},    // amazing
+    {1526, 26},    // alcohol
+    {1537, 85},    // blessing
+    {1543, 27},    // alien
+    {1545, 86},    // blimp
+    {1546, 87},    // blind
+    {1548, 28},    // alive
+    {1564, 29},    // alpha
+    {1568, 36},    // amount
+    {1573, 30},    // already
+    {1583, 88},    // blue
+    {1585, 32},    // aluminum
+    {1586, 31},    // alto
+    {1587, 37},    // amuse
+    {1591, 33},    // always
+    {1615, 38},    // analysis
+    {1617, 48},    // apart
+    {1618, 39},    // anatomy
+    {1623, 40},    // ancestor
+    {1624, 41},    // ancient
+    {1629, 89},    // body
+    {1643, 42},    // angel
+    {1645, 44},    // animal
+    {1647, 43},    // angry
+    {1658, 90},    // bolt
+    {1674, 91},    // boring
+    {1676, 92},    // born
+    {1679, 45},    // answer
+    {1681, 49},    // aquatic
+    {1683, 46},    // antenna
+    {1684, 93},    // both
+    {1686, 94},    // boundary
+    {1694, 47},    // anxiety
+    {1712, 95},    // bracelet
+    {1716, 96},    // branch
+    {1718, 97},    // brave
+    {1721, 50},    // arcade
+    {1731, 98},    // breathe
+    {1736, 51},    // arena
+    {1743, 99},    // briefing
+    {1748, 52},    // argue
+    {1753, 53},    // armed
+    {1763, 56},    // aspect
+    {1765, 100},   // broken
+    {1768, 101},   // brother
+    {1769, 102},   // browser
+    {1784, 54},    // artist
+    {1789, 55},    // artwork
+    {1824, 104},   // budget
+    {1825, 103},   // bucket
+    {1828, 57},    // auction
+    {1837, 60},    // average
+    {1841, 61},    // aviation
+    {1845, 105},   // building
+    {1848, 58},    // august
+    {1851, 106},   // bulb
+    {1854, 107},   // bulge
+    {1856, 108},   // bumpy
+    {1862, 109},   // bundle
+    {1864, 62},    // avoid
+    {1868, 59},    // aunt
+    {1872, 110},   // burden
+    {1876, 111},   // burning
+    {1879, 112},   // busy
+    {1893, 113},   // buyer
+    {1917, 63},    // award
+    {1919, 64},    // away
+    {1947, 65},    // axis
+    {1953, 66},    // axle
+    {2143, 114},   // cage
+    {2147, 185},   // daisy
+    {2151, 186},   // damage
+    {2152, 115},   // calcium
+    {2153, 116},   // camera
+    {2156, 117},   // campus
+    {2161, 119},   // capacity
+    {2162, 187},   // dance
+    {2164, 120},   // capital
+    {2168, 121},   // capture
+    {2169, 118},   // canyon
+    {2171, 122},   // carbon
+    {2172, 123},   // cards
+    {2173, 124},   // careful
+    {2174, 125},   // cargo
+    {2175, 188},   // darkness
+    {2176, 126},   // carpet
+    {2178, 127},   // carve
+    {2181, 189},   // database
+    {2183, 128},   // category
+    {2184, 190},   // daughter
+    {2187, 129},   // cause
+    {2312, 191},   // deadline
+    {2315, 192},   // deal
+    {2317, 193},   // debris
+    {2318, 194},   // debut
+    {2323, 195},   // decent
+    {2324, 196},   // decision
+    {2325, 197},   // declare
+    {2326, 198},   // decorate
+    {2327, 199},   // decrease
+    {2345, 130},   // ceiling
+    {2351, 201},   // demand
+    {2354, 200},   // deliver
+    {2361, 204},   // depart
+    {2363, 205},   // depend
+    {2364, 206},   // depict
+    {2365, 207},   // deploy
+    {2367, 202},   // density
+    {2368, 131},   // center
+    {2369, 203},   // deny
+    {2371, 132},   // ceramic
+    {2372, 208},   // describe
+    {2373, 209},   // desert
+    {2374, 210},   // desire
+    {2375, 211},   // desktop
+    {2378, 212},   // destroy
+    {2381, 213},   // detailed
+    {2383, 214},   // detect
+    {2384, 215},   // device
+    {2386, 216},   // devote
+    {2414, 217},   // diagnose
+    {2415, 133},   // champion
+    {2416, 134},   // change
+    {2417, 135},   // charity
+    {2428, 218},   // dictate
+    {2432, 136},   // check
+    {2435, 137},   // chemical
+    {2437, 138},   // chest
+    {2438, 219},   // diet
+    {2439, 139},   // chew
+    {2453, 220},   // dilemma
+    {2454, 221},   // diminish
+    {2463, 141},   // cinema
+    {2464, 222},   // dining
+    {2465, 223},   // diploma
+    {2471, 224},   // disaster
+    {2472, 225},   // discuss
+    {2473, 226},   // disease
+    {2474, 227},   // dish
+    {2475, 228},   // dismiss
+    {2476, 229},   // display
+    {2478, 230},   // distance
+    {2481, 140},   // chubby
+    {2483, 231},   // dive
+    {2484, 142},   // civil
+    {2486, 232},   // divorce
+    {2517, 143},   // class
+    {2519, 144},   // clay
+    {2531, 145},   // cleanup
+    {2543, 146},   // client
+    {2545, 147},   // climate
+    {2546, 148},   // clinic
+    {2562, 149},   // clock
+    {2564, 150},   // clogs
+    {2567, 151},   // closet
+    {2568, 152},   // clothes
+    {2581, 153},   // club
+    {2587, 154},   // cluster
+    {2615, 155},   // coal
+    {2617, 156},   // coastal
+    {2624, 157},   // coding
+    {2628, 233},   // document
+    {2651, 234},   // domain
+    {2653, 235},   // domestic
+    {2654, 236},   // dominant
+    {2656, 159},   // company
+    {2658, 158},   // column
+    {2676, 160},   // corner
+    {2678, 161},   // costume
+    {2683, 164},   // cover
+    {2684, 237},   // dough
+    {2686, 162},   // counter
+    {2687, 163},   // course
+    {2691, 165},   // cowboy
+    {2696, 238},   // downtown
+    {2712, 166},   // cradle
+    {2713, 167},   // craft
+    {2714, 239},   // dragon
+    {2715, 240},   // dramatic
+    {2719, 168},   // crazy
+    {2731, 241},   // dream
+    {2732, 169},   // credit
+    {2737, 242},   // dress
+    {2742, 170},   // cricket
+    {2743, 243},   // drift
+    {2745, 171},   // criminal
+    {2746, 244},   // drink
+    {2747, 172},   // crisis
+    {2748, 173},   // critical
+    {2768, 245},   // drove
+    {2769, 174},   // crowd
+    {2782, 175},   // crucial
+    {2784, 246},   // drug
+    {2786, 176},   // crunch
+    {2787, 177},   // crush
+    {2793, 247},   // dryer
+    {2797, 178},   // crystal
+    {2814, 179},   // cubic
+    {2825, 248},   // duckling
+    {2853, 249},   // duke
+    {2858, 180},   // cultural
+    {2871, 250},   // duration
+    {2874, 181},   // curious
+    {2875, 182},   // curly
+    {2878, 183},   // custody
+    {2917, 251},   // dwarf
+    {2954, 184},   // cylinder
+    {2961, 252},   // dynamic
+    {3124, 323},   // facility
+    {3128, 324},   // fact
+    {3145, 325},   // failure
+    {3146, 326},   // faint
+    {3153, 327},   // fake
+    {3154, 329},   // family
+    {3156, 330},   // famous
+    {3157, 328},   // false
+    {3162, 331},   // fancy
+    {3164, 332},   // fangs
+    {3168, 333},   // fantasy
+    {3173, 255},   // easel
+    {3175, 253},   // early
+    {3178, 254},   // earth
+    {3179, 256},   // easy
+    {3181, 334},   // fatal
+    {3184, 335},   // fatigue
+    {3186, 336},   // favorite
+    {3196, 337},   // fawn
+    {3243, 260},   // edge
+    {3246, 257},   // echo
+    {3248, 261},   // editor
+    {3254, 258},   // eclipse
+    {3265, 259},   // ecology
+    {3282, 262},   // educate
+    {3413, 338},   // fiber
+    {3428, 339},   // fiction
+    {3458, 340},   // filter
+    {3461, 341},   // finance
+    {3462, 342},   // findings
+    {3464, 343},   // finger
+    {3472, 346},   // fiscal
+    {3473, 344},   // firefly
+    {3474, 347},   // fishing
+    {3475, 345},   // firm
+    {3484, 263},   // either
+    {3486, 348},   // fitness
+    {3514, 273},   // email
+    {3515, 349},   // flame
+    {3516, 264},   // elbow
+    {3517, 350},   // flash
+    {3518, 351},   // flavor
+    {3523, 265},   // elder
+    {3531, 352},   // flea
+    {3532, 266},   // election
+    {3534, 267},   // elegant
+    {3535, 268},   // element
+    {3536, 269},   // elephant
+    {3537, 274},   // emerald
+    {3538, 270},   // elevator
+    {3539, 353},   // flexible
+    {3546, 354},   // flip
+    {3547, 275},   // emission
+    {3548, 271},   // elite
+    {3561, 355},   // float
+    {3563, 276},   // emperor
+    {3564, 277},   // emphasis
+    {3565, 278},   // employer
+    {3567, 356},   // floral
+    {3568, 279},   // empty
+    {3573, 272},   // else
+    {3583, 357},   // fluff
+    {3624, 280},   // ending
+    {3625, 281},   // endless
+    {3626, 282},   // endorse
+    {3628, 358},   // focus
+    {3635, 283},   // enemy
+    {3636, 285},   // enforce
+    {3637, 284},   // energy
+    {3641, 286},   // engage
+    {3642, 292},   // epidemic
+    {3646, 287},   // enjoy
+    {3647, 293},   // episode
+    {3651, 288},   // enlarge
+    {3671, 359},   // forbid
+    {3672, 360},   // force
+    {3673, 361},   // forecast
+    {3674, 362},   // forget
+    {3675, 363},   // formal
+    {3678, 364},   // fortune
+    {3679, 365},   // forward
+    {3681, 294},   // equation
+    {3683, 290},   // envelope
+    {3684, 295},   // equip
+    {3686, 366},   // founder
+    {3687, 289},   // entrance
+    {3689, 291},   // envy
+    {3712, 367},   // fraction
+    {3714, 368},   // fragment
+    {3717, 296},   // eraser
+    {3721, 298},   // escape
+    {3736, 369},   // frequent
+    {3737, 370},   // freshman
+    {3741, 371},   // friar
+    {3742, 372},   // fridge
+    {3743, 373},   // friendly
+    {3762, 297},   // erode
+    {3767, 374},   // frost
+    {3768, 375},   // froth
+    {3769, 376},   // frozen
+    {3781, 299},   // estate
+    {3784, 300},   // estimate
+    {3815, 301},   // evaluate
+    {3836, 302},   // evening
+    {3842, 303},   // evidence
+    {3845, 304},   // evil
+    {3853, 377},   // fumes
+    {3862, 378},   // funding
+    {3865, 305},   // evoke
+    {3873, 380},   // fused
+    {3875, 379},   // furl
+    {3912, 306},   // exact
+    {3915, 307},   // example
+    {3923, 308},   // exceed
+    {3924, 309},   // exchange
+    {3925, 310},   // exclude
+    {3928, 311},   // excuse
+    {3931, 322},   // eyebrow
+    {3932, 312},   // execute
+    {3937, 313},   // exercise
+    {3941, 314},   // exhaust
+    {3961, 316},   // expand
+    {3963, 317},   // expect
+    {3965, 318},   // explain
+    {3967, 319},   // express
+    {3968, 315},   // exotic
+    {3983, 320},   // extend
+    {3987, 321},   // extra
+    {4125, 483},   // jacket
+    {4147, 420},   // hairy
+    {4151, 381},   // galaxy
+    {4153, 382},   // game
+    {4157, 421},   // hamster
+    {4162, 422},   // hand
+    {4164, 423},   // hanger
+    {4171, 383},   // garbage
+    {4172, 384},   // garden
+    {4175, 385},   // garlic
+    {4176, 386},   // gasoline
+    {4178, 424},   // harvest
+    {4183, 425},   // have
+    {4184, 387},   // gather
+    {4186, 426},   // havoc
+    {4191, 428},   // hazard
+    {4195, 427},   // hawk
+    {4231, 452},   // idea
+    {4236, 453},   // identify
+    {4253, 454},   // idle
+    {4312, 429},   // headset
+    {4315, 430},   // health
+    {4317, 431},   // hearing
+    {4318, 432},   // heat
+    {4356, 433},   // helpful
+    {4363, 388},   // general
+    {4364, 389},   // genius
+    {4365, 392},   // geology
+    {4367, 390},   // genre
+    {4368, 391},   // genuine
+    {4371, 434},   // herald
+    {4372, 435},   // herd
+    {4374, 436},   // hesitate
+    {4375, 484},   // jerky
+    {4378, 393},   // gesture
+    {4393, 485},   // jewelry
+    {4512, 394},   // glad
+    {4514, 455},   // image
+    {4516, 395},   // glance
+    {4517, 396},   // glasses
+    {4536, 397},   // glen
+    {4545, 398},   // glimpse
+    {4561, 456},   // impact
+    {4565, 457},   // imply
+    {4567, 458},   // improve
+    {4568, 459},   // impulse
+    {4616, 437},   // hobo
+    {4618, 399},   // goat
+    {4623, 463},   // index
+    {4624, 464},   // indicate
+    {4625, 460},   // include
+    {4626, 461},   // income
+    {4627, 462},   // increase
+    {4628, 465},   // industry
+    {4631, 466},   // infant
+    {4636, 467},   // inform
+    {4643, 468},   // inherit
+    {4646, 486},   // join
+    {4648, 469},   // injury
+    {4651, 470},   // inmate
+    {4652, 400},   // golden
+    {4653, 440},   // home
+    {4654, 438},   // holiday
+    {4659, 439},   // holy
+    {4673, 471},   // insect
+    {4674, 472},   // inside
+    {4675, 441},   // hormone
+    {4676, 442},   // hospital
+    {4678, 473},   // install
+    {4681, 476},   // invasion
+    {4683, 474},   // intend
+    {4684, 475},   // intimate
+    {4686, 477},   // involve
+    {4687, 443},   // hour
+    {4712, 401},   // graduate
+    {4716, 402},   // grant
+    {4717, 403},   // grasp
+    {4718, 404},   // gravity
+    {4719, 405},   // gray
+    {4731, 406},   // greatest
+    {4743, 407},   // grief
+    {4745, 408},   // grill
+    {4746, 409},   // grin
+    {4747, 478},   // iris
+    {4751, 479},   // island
+    {4762, 410},   // grocery
+    {4765, 480},   // isolate
+    {4767, 411},   // gross
+    {4768, 412},   // group
+    {4769, 413},   // grownup
+    {4785, 414},   // grumpy
+    {4817, 415},   // guard
+    {4824, 487},   // judicial
+    {4835, 481},   // item
+    {4837, 416},   // guest
+    {4842, 488},   // juice
+    {4843, 444},   // huge
+    {4845, 417},   // guilt
+    {4848, 418},   // guitar
+    {4851, 445},   // human
+    {4854, 446},   // humidity
+    {4856, 489},   // jump
+    {4857, 419},   // gums
+    {4862, 490},   // junction
+    {4864, 491},   // junior
+    {4865, 492},   // junk
+    {4867, 482},   // ivory
+    {4868, 447},   // hunting
+    {4871, 448},   // husband
+    {4874, 449},   // hush
+    {4875, 450},   // husky
+    {4878, 494},   // justice
+    {4879, 493},   // jury
+    {4917, 451},   // hybrid
+    {5123, 502},   // laden
+    {5124, 549},   // machine
+    {5125, 503},   // ladle
+    {5129, 504},   // ladybug
+    {5141, 550},   // magazine
+    {5142, 551},   // maiden
+    {5145, 552},   // mailman
+    {5146, 553},   // main
+    {5147, 505},   // lair
+    {5151, 556},   // mama
+    {5153, 554},   // makeup
+    {5154, 555},   // making
+    {5156, 506},   // lamp
+    {5161, 557},   // manager
+    {5162, 558},   // mandate
+    {5164, 507},   // language
+    {5167, 559},   // mansion
+    {5168, 560},   // manual
+    {5171, 561},   // marathon
+    {5172, 562},   // march
+    {5173, 509},   // laser
+    {5174, 508},   // large
+    {5175, 563},   // market
+    {5176, 565},   // mason
+    {5178, 564},   // marvel
+    {5183, 566},   // material
+    {5184, 567},   // math
+    {5186, 510},   // laundry
+    {5194, 568},   // maximum
+    {5196, 569},   // mayor
+    {5197, 511},   // lawsuit
+    {5312, 512},   // leader
+    {5313, 513},   // leaf
+    {5316, 570},   // meaning
+    {5317, 514},   // learn
+    {5318, 515},   // leaves
+    {5321, 571},   // medal
+    {5324, 572},   // medical
+    {5328, 516},   // lecture
+    {5341, 517},   // legal
+    {5343, 518},   // legend
+    {5347, 519},   // legs
+    {5351, 573},   // member
+    {5356, 574},   // memory
+    {5362, 520},   // lend
+    {5364, 521},   // length
+    {5368, 575},   // mental
+    {5372, 576},   // merchant
+    {5374, 577},   // merit
+    {5376, 495},   // kernel
+    {5383, 522},   // level
+    {5384, 578},   // method
+    {5387, 579},   // metric
+    {5391, 496},   // keyboard
+    {5413, 523},   // liberty
+    {5417, 524},   // library
+    {5423, 525},   // license
+    {5426, 497},   // kidney
+    {5427, 580},   // midst
+    {5438, 526},   // lift
+    {5451, 528},   // lilac
+    {5452, 581},   // mild
+    {5453, 527},   // likely
+    {5454, 582},   // military
+    {5459, 529},   // lily
+    {5462, 498},   // kind
+    {5463, 583},   // mineral
+    {5464, 584},   // minister
+    {5467, 530},   // lips
+    {5468, 531},   // liquid
+    {5471, 585},   // miracle
+    {5478, 532},   // listen
+    {5482, 499},   // kitchen
+    {5483, 533},   // literary
+    {5484, 534},   // living
+    {5491, 535},   // lizard
+    {5493, 586},   // mixed
+    {5498, 587},   // mixture
+    {5613, 537},   // lobe
+    {5614, 588},   // mobile
+    {5616, 536},   // loan
+    {5621, 538},   // location
+    {5623, 589},   // modern
+    {5624, 590},   // modify
+    {5643, 500},   // knife
+    {5647, 591},   // moisture
+    {5648, 501},   // knit
+    {5653, 592},   // moment
+    {5674, 539},   // losing
+    {5676, 593},   // morning
+    {5678, 594},   // mortgage
+    {5682, 540},   // loud
+    {5683, 598},   // move
+    {5684, 595},   // mother
+    {5686, 596},   // mountain
+    {5687, 597},   // mouse
+    {5691, 541},   // loyalty
+    {5824, 599},   // much
+    {5825, 542},   // luck
+    {5853, 600},   // mule
+    {5858, 601},   // multiple
+    {5861, 543},   // lunar
+    {5862, 544},   // lunch
+    {5864, 545},   // lungs
+    {5872, 602},   // muscle
+    {5873, 603},   // museum
+    {5874, 604},   // music
+    {5878, 605},   // mustang
+    {5898, 546},   // luxury
+    {5946, 547},   // lying
+    {5974, 548},   // lyrics
+    {6123, 636},   // paces
+    {6124, 637},   // pacific
+    {6125, 638},   // package
+    {6137, 618},   // obesity
+    {6141, 641},   // pajamas
+    {6142, 639},   // paid
+    {6143, 619},   // object
+    {6145, 606},   // nail
+    {6146, 640},   // painting
+    {6161, 644},   // papa
+    {6162, 642},   // pancake
+    {6163, 645},   // paper
+    {6168, 643},   // pants
+    {6172, 646},   // parcel
+    {6173, 620},   // observe
+    {6174, 617},   // oasis
+    {6175, 647},   // parking
+    {6178, 648},   // party
+    {6181, 621},   // obtain
+    {6183, 649},   // patent
+    {6184, 607},   // national
+    {6187, 650},   // patrol
+    {6195, 651},   // payment
+    {6197, 652},   // payroll
+    {6231, 622},   // ocean
+    {6312, 653},   // peaceful
+    {6316, 654},   // peanut
+    {6317, 655},   // peasant
+    {6321, 656},   // pecan
+    {6325, 608},   // necklace
+    {6341, 609},   // negative
+    {6361, 657},   // penalty
+    {6362, 658},   // pencil
+    {6372, 659},   // percent
+    {6373, 660},   // perfect
+    {6375, 661},   // permit
+    {6378, 610},   // nervous
+    {6383, 623},   // often
+    {6384, 662},   // petition
+    {6389, 611},   // network
+    {6397, 612},   // news
+    {6416, 663},   // phantom
+    {6417, 664},   // pharmacy
+    {6425, 668},   // pickup
+    {6428, 669},   // picture
+    {6432, 670},   // piece
+    {6453, 671},   // pile
+    {6463, 673},   // pipeline
+    {6465, 672},   // pink
+    {6468, 665},   // photo
+    {6471, 666},   // phrase
+    {6478, 674},   // pistol
+    {6482, 675},   // pitch
+    {6497, 667},   // physics
+    {6514, 676},   // plains
+    {6516, 677},   // plan
+    {6517, 678},   // plastic
+    {6518, 679},   // platform
+    {6519, 680},   // playoff
+    {6531, 681},   // pleasure
+    {6548, 625},   // omit
+    {6568, 682},   // plot
+    {6586, 683},   // plunge
+    {6595, 624},   // olympic
+    {6712, 684},   // practice
+    {6714, 628},   // orbit
+    {6715, 626},   // oral
+    {6716, 627},   // orange
+    {6719, 685},   // prayer
+    {6723, 629},   // order
+    {6724, 630},   // ordinary
+    {6731, 686},   // preach
+    {6732, 687},   // predator
+    {6734, 688},   // pregnant
+    {6735, 689},   // premium
+    {6736, 690},   // prepare
+    {6737, 691},   // presence
+    {6738, 692},   // prevent
+    {6741, 631},   // organize
+    {6743, 693},   // priest
+    {6745, 694},   // primary
+    {6746, 695},   // priority
+    {6747, 696},   // prisoner
+    {6748, 697},   // privacy
+    {6749, 698},   // prize
+    {6761, 699},   // problem
+    {6762, 700},   // process
+    {6763, 701},   // profile
+    {6764, 702},   // program
+    {6765, 703},   // promise
+    {6767, 704},   // prospect
+    {6768, 705},   // provide
+    {6786, 706},   // prune
+    {6815, 707},   // public
+    {6816, 716},   // quantity
+    {6817, 717},   // quarter
+    {6825, 613},   // nuclear
+    {6836, 633},   // oven
+    {6837, 634},   // overall
+    {6842, 718},   // quick
+    {6843, 719},   // quiet
+    {6851, 614},   // numb
+    {6853, 615},   // numerous
+    {6856, 709},   // pumps
+    {6857, 708},   // pulse
+    {6861, 712},   // pupal
+    {6862, 632},   // ounce
+    {6864, 710},   // punish
+    {6869, 711},   // puny
+    {6872, 713},   // purchase
+    {6876, 714},   // purple
+    {6956, 616},   // nylon
+    {6963, 635},   // owner
+    {6984, 715},   // python
+    {7121, 722},   // radar
+    {7123, 720},   // race
+    {7124, 721},   // racism
+    {7125, 775},   // sack
+    {7131, 776},   // safari
+    {7145, 723},   // railroad
+    {7146, 724},   // rainbow
+    {7147, 725},   // raisin
+    {7151, 777},   // salary
+    {7156, 778},   // salon
+    {7158, 779},   // salt
+    {7162, 726},   // random
+    {7164, 728},   // rapids
+    {7165, 727},   // ranked
+    {7176, 729},   // raspy
+    {7183, 782},   // saver
+    {7184, 780},   // satisfy
+    {7186, 781},   // satoshi
+    {7197, 783},   // says
+    {7216, 784},   // scandal
+    {7217, 785},   // scared
+    {7218, 786},   // scatter
+    {7236, 787},   // scene
+    {7243, 789},   // science
+    {7246, 788},   // scholar
+    {7268, 790},   // scout
+    {7271, 791},   // scramble
+    {7273, 792},   // screw
+    {7274, 793},   // script
+    {7276, 794},   // scroll
+    {7312, 730},   // reaction
+    {7313, 795},   // seafood
+    {7315, 731},   // realize
+    {7316, 732},   // rebound
+    {7317, 796},   // season
+    {7318, 733},   // rebuild
+    {7321, 734},   // recall
+    {7323, 735},   // receiver
+    {7326, 736},   // recover
+    {7327, 797},   // secret
+    {7328, 798},   // security
+    {7343, 739},   // reject
+    {7345, 799},   // segment
+    {7347, 737},   // regret
+    {7348, 738},   // regular
+    {7351, 740},   // relate
+    {7353, 741},   // remember
+    {7354, 742},   // remind
+    {7356, 743},   // remove
+    {7361, 745},   // repair
+    {7362, 744},   // render
+    {7363, 746},   // repeat
+    {7364, 800},   // senior
+    {7365, 747},   // replace
+    {7368, 748},   // require
+    {7372, 749},   // rescue
+    {7373, 750},   // research
+    {7374, 751},   // resident
+    {7376, 752},   // response
+    {7378, 753},   // result
+    {7381, 754},   // retailer
+    {7383, 757},   // revenue
+    {7384, 758},   // review
+    {7386, 756},   // reunion
+    {7387, 755},   // retreat
+    {7391, 759},   // reward
+    {7412, 801},   // shadow
+    {7413, 802},   // shaft
+    {7415, 803},   // shame
+    {7416, 804},   // shaped
+    {7417, 805},   // sharp
+    {7423, 811},   // sidewalk
+    {7424, 762},   // rich
+    {7435, 806},   // shelter
+    {7437, 807},   // sheriff
+    {7453, 812},   // silent
+    {7454, 814},   // similar
+    {7456, 815},   // simple
+    {7458, 813},   // silver
+    {7464, 816},   // single
+    {7467, 808},   // short
+    {7468, 809},   // should
+    {7474, 810},   // shrimp
+    {7478, 817},   // sister
+    {7481, 763},   // rival
+    {7483, 764},   // river
+    {7495, 760},   // rhyme
+    {7498, 761},   // rhythm
+    {7516, 820},   // slap
+    {7517, 827},   // smart
+    {7518, 821},   // slavery
+    {7531, 828},   // smear
+    {7532, 822},   // sled
+    {7535, 829},   // smell
+    {7542, 823},   // slice
+    {7545, 824},   // slim
+    {7546, 818},   // skin
+    {7547, 830},   // smirk
+    {7548, 831},   // smith
+    {7565, 832},   // smoking
+    {7569, 825},   // slow
+    {7584, 833},   // smug
+    {7586, 819},   // skunk
+    {7587, 826},   // slush
+    {7612, 843},   // space
+    {7614, 765},   // robin
+    {7615, 834},   // snake
+    {7616, 835},   // snapshot
+    {7617, 844},   // spark
+    {7624, 837},   // society
+    {7625, 766},   // rocky
+    {7631, 845},   // speak
+    {7632, 846},   // species
+    {7635, 847},   // spelling
+    {7636, 848},   // spend
+    {7638, 838},   // software
+    {7639, 849},   // spew
+    {7642, 850},   // spider
+    {7643, 836},   // sniff
+    {7645, 851},   // spill
+    {7646, 852},   // spine
+    {7647, 853},   // spirit
+    {7648, 854},   // spit
+    {7651, 767},   // romantic
+    {7652, 839},   // soldier
+    {7656, 768},   // romp
+    {7658, 840},   // solution
+    {7671, 855},   // spray
+    {7674, 856},   // sprinkle
+    {7678, 769},   // roster
+    {7681, 857},   // square
+    {7683, 858},   // squeeze
+    {7685, 841},   // soul
+    {7686, 770},   // round
+    {7687, 842},   // source
+    {7691, 771},   // royal
+    {7812, 859},   // stadium
+    {7813, 860},   // staff
+    {7814, 873},   // subject
+    {7815, 874},   // submit
+    {7816, 861},   // standard
+    {7817, 862},   // starting
+    {7818, 863},   // station
+    {7819, 864},   // stay
+    {7831, 865},   // steady
+    {7836, 866},   // step
+    {7841, 875},   // sugar
+    {7842, 867},   // stick
+    {7845, 868},   // stilt
+    {7846, 772},   // ruin
+    {7848, 876},   // suitable
+    {7853, 773},   // ruler
+    {7856, 774},   // rumor
+    {7863, 878},   // superior
+    {7865, 877},   // sunlight
+    {7867, 869},   // story
+    {7871, 870},   // strategy
+    {7873, 879},   // surface
+    {7874, 871},   // strike
+    {7876, 880},   // surprise
+    {7878, 881},   // survive
+    {7895, 872},   // style
+    {7931, 882},   // sweater
+    {7945, 883},   // swimming
+    {7946, 884},   // swing
+    {7948, 885},   // switch
+    {7951, 886},   // symbolic
+    {7956, 887},   // sympathy
+    {7962, 888},   // syndrome
+    {7978, 889},   // system
+    {8125, 890},   // tackle
+    {8126, 892},   // tadpole
+    {8128, 891},   // tactics
+    {8153, 893},   // talent
+    {8154, 965},   // valid
+    {8156, 967},   // vampire
+    {8158, 966},   // valuable
+    {8164, 968},   // vanish
+    {8174, 969},   // various
+    {8175, 894},   // task
+    {8178, 895},   // taste
+    {8184, 896},   // taught
+    {8194, 897},   // taxi
+    {8312, 898},   // teacher
+    {8315, 899},   // teammate
+    {8317, 900},   // teaspoon
+    {8341, 970},   // vegan
+    {8356, 901},   // temple
+    {8358, 971},   // velvet
+    {8361, 902},   // tenant
+    {8362, 903},   // tendency
+    {8367, 904},   // tension
+    {8368, 972},   // venture
+    {8372, 973},   // verdict
+    {8374, 974},   // verify
+    {8375, 905},   // terminal
+    {8378, 906},   // testify
+    {8379, 975},   // very
+    {8383, 976},   // veteran
+    {8393, 977},   // vexed
+    {8398, 907},   // texture
+    {8416, 908},   // thank
+    {8418, 909},   // that
+    {8423, 979},   // video
+    {8425, 917},   // ticket
+    {8428, 978},   // victim
+    {8429, 918},   // tidy
+    {8431, 910},   // theater
+    {8436, 911},   // theory
+    {8437, 912},   // therapy
+    {8439, 980},   // view
+    {8451, 919},   // timber
+    {8453, 920},   // timely
+    {8459, 946},   // ugly
+    {8464, 921},   // ting
+    {8465, 982},   // violence
+    {8467, 913},   // thorn
+    {8468, 981},   // vintage
+    {8471, 983},   // viral
+    {8473, 914},   // threaten
+    {8474, 984},   // visitor
+    {8478, 985},   // visual
+    {8481, 986},   // vitamins
+    {8485, 915},   // thumb
+    {8486, 916},   // thunder
+    {8517, 948},   // umbrella
+    {8584, 947},   // ultimate
+    {8621, 987},   // vocal
+    {8623, 950},   // undergo
+    {8626, 949},   // uncover
+    {8631, 951},   // unfair
+    {8636, 952},   // unfold
+    {8638, 922},   // tofu
+    {8641, 953},   // unhappy
+    {8642, 988},   // voice
+    {8643, 923},   // together
+    {8646, 954},   // union
+    {8647, 960},   // upgrade
+    {8648, 955},   // universe
+    {8653, 924},   // tolerate
+    {8654, 956},   // unkind
+    {8656, 957},   // unknown
+    {8658, 989},   // volume
+    {8678, 961},   // upstairs
+    {8681, 925},   // total
+    {8683, 990},   // voter
+    {8684, 991},   // voting
+    {8687, 958},   // unusual
+    {8694, 926},   // toxic
+    {8697, 959},   // unwrap
+    {8712, 927},   // tracks
+    {8713, 928},   // traffic
+    {8714, 929},   // training
+    {8716, 930},   // transfer
+    {8717, 931},   // trash
+    {8718, 932},   // traveler
+    {8731, 933},   // treat
+    {8736, 934},   // trend
+    {8737, 962},   // username
+    {8741, 935},   // trial
+    {8742, 936},   // tricycle
+    {8743, 963},   // usher
+    {8746, 937},   // trip
+    {8748, 938},   // triumph
+    {8768, 939},   // trouble
+    {8781, 964},   // usual
+    {8783, 940},   // true
+    {8787, 941},   // trust
+    {8942, 942},   // twice
+    {8946, 943},   // twin
+    {8963, 944},   // type
+    {8964, 945},   // typical
+    {9156, 992},   // walnut
+    {9175, 993},   // warmth
+    {9176, 994},   // warn
+    {9182, 995},   // watch
+    {9189, 996},   // wavy
+    {9312, 999},   // webcam
+    {9315, 997},   // wealthy
+    {9316, 998},   // weapon
+    {9317, 1019},  // year
+    {9352, 1000},  // welcome
+    {9353, 1001},  // welfare
+    {9356, 1020},  // yelp
+    {9376, 1023},  // zero
+    {9378, 1002},  // western
+    {9428, 1003},  // width
+    {9435, 1021},  // yield
+    {9452, 1004},  // wildlife
+    {9462, 1005},  // window
+    {9463, 1006},  // wine
+    {9472, 1008},  // wisdom
+    {9473, 1007},  // wireless
+    {9484, 1009},  // withdraw
+    {9487, 1010},  // wits
+    {9641, 1022},  // yoga
+    {9651, 1012},  // woman
+    {9653, 1011},  // wolf
+    {9675, 1013},  // work
+    {9678, 1014},  // worthy
+    {9716, 1015},  // wrap
+    {9747, 1016},  // wrist
+    {9748, 1017},  // writing
+    {9768, 1018},  // wrote
 };
 
 #endif

--- a/crypto/slip39_wordlist.h
+++ b/crypto/slip39_wordlist.h
@@ -22,11 +22,14 @@
  * OTHER DEALINGS IN THE SOFTWARE.
  */
 
+#ifndef __SLIP39_WORDLIST_H__
+#define __SLIP39_WORDLIST_H__
+
 #include <stdint.h>
 
 #define WORDS_COUNT 1024
 
-static const char* const wordlist[WORDS_COUNT] = {
+static const char* const slip39_wordlist[WORDS_COUNT] = {
     "academic", "acid",     "acne",     "acquire",  "acrobat",  "activity",
     "actress",  "adapt",    "adequate", "adjust",   "admit",    "adorn",
     "adult",    "advance",  "advocate", "afraid",   "again",    "agency",
@@ -1236,3 +1239,5 @@ static const uint16_t words_button_seq[WORDS_COUNT] = {
     9641,  // yoga
     9376,  // zero
 };
+
+#endif

--- a/crypto/tests/test_check.c
+++ b/crypto/tests/test_check.c
@@ -5263,36 +5263,50 @@ START_TEST(test_slip39_word_index) {
 }
 END_TEST
 
-START_TEST(test_slip39_compute_mask) {
+START_TEST(test_slip39_word_completion_mask) {
   static const struct {
     const uint16_t prefix;
     const uint16_t expected_mask;
-  } vectors[] = {{
-                     12,
-                     0xFD  // 011111101
-                 },
-                 {
-                     21,
-                     0xF8  // 011111000
-                 },
-                 {
-                     75,
-                     0xAD  // 010101101
-                 },
-                 {
-                     4,
-                     0x1F7  // 111110111
-                 },
-                 {
-                     738,
-                     0x6D  // 001101101
-                 },
-                 {
-                     9,
-                     0x6D  // 001101101
-                 }};
+  } vectors[] = {
+      {
+          12,
+          0xFD  // 011111101
+      },
+      {
+          21,
+          0xF8  // 011111000
+      },
+      {
+          75,
+          0xAD  // 010101101
+      },
+      {
+          4,
+          0x1F7  // 111110111
+      },
+      {
+          738,
+          0x6D  // 001101101
+      },
+      {
+          9,
+          0x6D  // 001101101
+      },
+      {
+          0,
+          0x1FF  // 111111111
+      },
+      {
+          9999,
+          0x00  // 000000000
+      },
+      {
+          20000,
+          0x00  // 000000000
+      },
+  };
   for (size_t i = 0; i < (sizeof(vectors) / sizeof(*vectors)); i++) {
-    uint16_t mask = compute_mask(vectors[i].prefix);
+    uint16_t mask = slip39_word_completion_mask(vectors[i].prefix);
     ck_assert_int_eq(mask, vectors[i].expected_mask);
   }
 }
@@ -5302,15 +5316,16 @@ START_TEST(test_slip39_sequence_to_word) {
   static const struct {
     const uint16_t prefix;
     const char *expected_word;
-  } vectors[] = {{7945, "swimming"},
-                 {646, "photo"},
-                 {5, "kernel"},
-                 {34, "either"},
-                 {62, "ocean"}};
+  } vectors[] = {
+      {7945, "swimming"}, {646, "photo"}, {5, "kernel"},
+      {34, "either"},     {62, "ocean"},  {0, "academic"},
+  };
   for (size_t i = 0; i < (sizeof(vectors) / sizeof(*vectors)); i++) {
     const char *word = button_sequence_to_word(vectors[i].prefix);
     ck_assert_str_eq(word, vectors[i].expected_word);
   }
+  ck_assert_ptr_eq(button_sequence_to_word(9999), NULL);
+  ck_assert_ptr_eq(button_sequence_to_word(20000), NULL);
 }
 END_TEST
 
@@ -8904,7 +8919,7 @@ Suite *test_suite(void) {
   tc = tcase_create("slip39");
   tcase_add_test(tc, test_slip39_get_word);
   tcase_add_test(tc, test_slip39_word_index);
-  tcase_add_test(tc, test_slip39_compute_mask);
+  tcase_add_test(tc, test_slip39_word_completion_mask);
   tcase_add_test(tc, test_slip39_sequence_to_word);
   suite_add_tcase(s, tc);
 

--- a/crypto/tests/test_check.c
+++ b/crypto/tests/test_check.c
@@ -5269,42 +5269,18 @@ START_TEST(test_slip39_word_completion_mask) {
     const uint16_t prefix;
     const uint16_t expected_mask;
   } vectors[] = {
-      {
-          12,
-          0xFD  // 011111101
-      },
-      {
-          21,
-          0xF8  // 011111000
-      },
-      {
-          75,
-          0xAD  // 010101101
-      },
-      {
-          4,
-          0x1F7  // 111110111
-      },
-      {
-          738,
-          0x6D  // 001101101
-      },
-      {
-          9,
-          0x6D  // 001101101
-      },
-      {
-          0,
-          0x1FF  // 111111111
-      },
-      {
-          9999,
-          0x00  // 000000000
-      },
-      {
-          20000,
-          0x00  // 000000000
-      },
+      {12, 0xFD},     // 011111101
+      {21, 0xF8},     // 011111000
+      {75, 0xAD},     // 010101101
+      {4, 0x1F7},     // 111110111
+      {738, 0x6D},    // 001101101
+      {9, 0x6D},      // 001101101
+      {0, 0x1FF},     // 111111111
+      {10, 0x00},     // 000000000
+      {255, 0x00},    // 000000000
+      {203, 0x00},    // 000000000
+      {9999, 0x00},   // 000000000
+      {20000, 0x00},  // 000000000
   };
   for (size_t i = 0; i < (sizeof(vectors) / sizeof(*vectors)); i++) {
     uint16_t mask = slip39_word_completion_mask(vectors[i].prefix);
@@ -5318,15 +5294,18 @@ START_TEST(test_slip39_sequence_to_word) {
     const uint16_t prefix;
     const char *expected_word;
   } vectors[] = {
-      {7945, "swimming"}, {646, "pipeline"}, {5, "laden"},
-      {34, "fiber"},      {62, "ocean"},     {0, "academic"},
+      {7945, "swimming"}, {646, "pipeline"}, {5, "laden"},  {34, "fiber"},
+      {62, "ocean"},      {0, "academic"},   {10, NULL},    {255, NULL},
+      {203, NULL},        {9999, NULL},      {20000, NULL},
   };
   for (size_t i = 0; i < (sizeof(vectors) / sizeof(*vectors)); i++) {
     const char *word = button_sequence_to_word(vectors[i].prefix);
-    ck_assert_str_eq(word, vectors[i].expected_word);
+    if (vectors[i].expected_word != NULL) {
+      ck_assert_str_eq(word, vectors[i].expected_word);
+    } else {
+      ck_assert_ptr_eq(word, NULL);
+    }
   }
-  ck_assert_ptr_eq(button_sequence_to_word(9999), NULL);
-  ck_assert_ptr_eq(button_sequence_to_word(20000), NULL);
 }
 END_TEST
 

--- a/crypto/tests/test_check.c
+++ b/crypto/tests/test_check.c
@@ -69,6 +69,7 @@
 #include "sha3.h"
 #include "shamir.h"
 #include "slip39.h"
+#include "slip39_wordlist.h"
 
 #if VALGRIND
 /*
@@ -5329,6 +5330,23 @@ START_TEST(test_slip39_sequence_to_word) {
 }
 END_TEST
 
+START_TEST(test_slip39_word_completion) {
+  const char t9[] = {1, 1, 2, 2, 3, 3, 4, 4, 4, 4, 5, 5, 5,
+                     6, 6, 6, 6, 7, 7, 8, 8, 8, 9, 9, 9, 9};
+  for (size_t i = 0; i < WORDS_COUNT; ++i) {
+    const char *word = slip39_wordlist[i];
+    uint16_t prefix = t9[word[0] - 'a'];
+    for (size_t j = 1; j < 4; ++j) {
+      uint16_t mask = slip39_word_completion_mask(prefix);
+      uint8_t next = t9[word[j] - 'a'];
+      ck_assert_uint_ne(mask & (1 << (next - 1)), 0);
+      prefix = prefix * 10 + next;
+    }
+    ck_assert_str_eq(button_sequence_to_word(prefix), word);
+  }
+}
+END_TEST
+
 START_TEST(test_shamir) {
 #define SHAMIR_MAX_COUNT 16
   static const struct {
@@ -8921,6 +8939,7 @@ Suite *test_suite(void) {
   tcase_add_test(tc, test_slip39_word_index);
   tcase_add_test(tc, test_slip39_word_completion_mask);
   tcase_add_test(tc, test_slip39_sequence_to_word);
+  tcase_add_test(tc, test_slip39_word_completion);
   suite_add_tcase(s, tc);
 
   tc = tcase_create("shamir");

--- a/crypto/tests/test_check.c
+++ b/crypto/tests/test_check.c
@@ -5318,8 +5318,8 @@ START_TEST(test_slip39_sequence_to_word) {
     const uint16_t prefix;
     const char *expected_word;
   } vectors[] = {
-      {7945, "swimming"}, {646, "photo"}, {5, "kernel"},
-      {34, "either"},     {62, "ocean"},  {0, "academic"},
+      {7945, "swimming"}, {646, "pipeline"}, {5, "laden"},
+      {34, "fiber"},      {62, "ocean"},     {0, "academic"},
   };
   for (size_t i = 0; i < (sizeof(vectors) / sizeof(*vectors)); i++) {
     const char *word = button_sequence_to_word(vectors[i].prefix);


### PR DESCRIPTION
Resolves https://github.com/satoshilabs/trezor-firmware/issues/99.

I made the following changes:
- Made the crypto/slip39.c functions more robust and moved any input validation from core to slip39.c.
- Added tests for the edge cases that @invd encountered.
- Renamed `compute_mask()` in slip39.c to `slip39_word_completion_mask()` to better correspond with the naming from bip39.c. There is an unrelated Python function `compute_mask()` in keyboard_bip39.py which makes things confusing because it does something different (computes the mask for a button).
- Added a proper SLIP39 word completion test, which goes through all the words in the wordlist and checks that they can be written with the masks that are returned by `slip39_word_completion_mask()`.
- Made the `find()` function static, since it's an internal function and cleaned it up to make it more legible. 
- I still wasn't satisfied with the legibility of `find()`, so in the last commit 7ce5a2b I reworked it in a way that I find more comprehensible. It is also more efficient since it locates the relevant prefixes using binary searches instead of a bounded linear search. The only downside I can see is that it might bloat the firmware by 2kB because it replaces the list of prefixes by a map. However, when I compared the firmware size there was no difference. I didn't want to squash the changes, because if this problem pops-up later then we can rever this commit.