### PR TITLE
addition of 420coin definitions

### DIFF
--- a/common/protob/messages-fourtwentycoin.proto
+++ b/common/protob/messages-fourtwentycoin.proto
@@ -1,0 +1,127 @@
+syntax = "proto2";
+package hw.trezor.messages.Fourtwentycoin;
+
+// Sugar for easier handling in Java
+option java_package = "com.satoshilabs.trezor.lib.protobuf";
+option java_outer_classname = "TrezorMessageFourtwentycoin";
+
+import "messages-common.proto";
+
+
+/**
+ * Request: Ask device for public key corresponding to address_n path
+ * @start
+ * @next FourtwentycoinPublicKey
+ * @next Failure
+ */
+message FourtwentycoinGetPublicKey {
+    repeated uint32 address_n = 1; // BIP-32 path to derive the key from master node
+    optional bool show_display = 2; // optionally show on display before sending the result
+}
+
+/**
+ * Response: Contains public key derived from device private seed
+ * @end
+ */
+message FourtwentycoinPublicKey {
+    optional hw.trezor.messages.common.HDNodeType node = 1; // BIP32 public node
+    optional string xpub = 2; // serialized form of public node
+}
+
+/**
+ * Request: Ask device for fourtwentycoin address corresponding to address_n path
+ * @start
+ * @next FourtwentycoinAddress
+ * @next Failure
+ */
+message FourtwentycoinGetAddress {
+    repeated uint32 address_n = 1;  // BIP-32 path to derive the key from master node
+    optional bool show_display = 2; // optionally show on display before sending the result
+}
+
+/**
+ * Response: Contains an fourtwentycoin address derived from device private seed
+ * @end
+ */
+message FourtwentycoinAddress {
+    optional bytes  addressBin = 1; // 420coin address as 20 bytes (legacy firmwares)
+    optional string addressHex = 2; // 420coin address as hex string (newer firmwares)
+}
+
+/**
+ * Request: Ask device to sign transaction
+ * All fields are optional from the protocol's point of view. Each field defaults to value `0` if missing.
+ * Note: the first at most 1024 bytes of data MUST be transmitted as part of this message.
+ * @start
+ * @next FourtwentycoinTxRequest
+ * @next Failure
+ */
+message FourtwentycoinSignTx {
+    repeated uint32 address_n = 1;          // BIP-32 path to derive the key from master node
+    optional bytes nonce = 2;               // <=256 bit unsigned big endian
+    optional bytes smoke_price = 3;         // <=256 bit unsigned big endian (in marleys)
+    optional bytes smoke_limit = 4;         // <=256 bit unsigned big endian
+    optional bytes toBin = 5;               // recipient address (20 bytes, legacy firmware)
+    optional string toHex = 11;             // recipient address (hex string, newer firmware)
+    optional bytes value = 6;               // <=256 bit unsigned big endian (in marleys)
+    optional bytes data_initial_chunk = 7;  // The initial data chunk (<= 1024 bytes)
+    optional uint32 data_length = 8;        // Length of transaction payload
+    optional uint32 chain_id = 9;           // Chain Id for EIP 155
+    optional uint32 tx_type = 10;           // (only for Wanchain)
+}
+
+/**
+ * Response: Device asks for more data from transaction payload, or returns the signature.
+ * If data_length is set, device awaits that many more bytes of payload.
+ * Otherwise, the signature_* fields contain the computed transaction signature. All three fields will be present.
+ * @end
+ * @next FourtwentycoinTxAck
+ */
+message FourtwentycoinTxRequest {
+    optional uint32 data_length = 1;    // Number of bytes being requested (<= 1024)
+    optional uint32 signature_v = 2;    // Computed signature (recovery parameter, limited to 27 or 28)
+    optional bytes signature_r = 3;     // Computed signature R component (256 bit)
+    optional bytes signature_s = 4;     // Computed signature S component (256 bit)
+}
+
+/**
+ * Request: Transaction payload data.
+ * @next FourtwentycoinTxRequest
+ */
+message FourtwentycoinTxAck {
+    optional bytes data_chunk = 1;  // Bytes from transaction payload (<= 1024 bytes)
+}
+
+/**
+ * Request: Ask device to sign message
+ * @start
+ * @next FourtwentycoinMessageSignature
+ * @next Failure
+ */
+message FourtwentycoinSignMessage {
+    repeated uint32 address_n = 1;  // BIP-32 path to derive the key from master node
+    optional bytes message = 2;     // message to be signed
+}
+
+/**
+ * Response: Signed message
+ * @end
+ */
+message FourtwentycoinMessageSignature {
+    optional bytes addressBin = 1;     // address used to sign the message (20 bytes, legacy firmware)
+    optional bytes signature = 2;      // signature of the message
+    optional string addressHex = 3;    // address used to sign the message (hex string, newer firmware)
+}
+
+/**
+ * Request: Ask device to verify message
+ * @start
+ * @next Success
+ * @next Failure
+ */
+message FourtwentycoinVerifyMessage {
+    optional bytes addressBin = 1;  // address to verify (20 bytes, legacy firmware)
+    optional bytes signature = 2;   // signature to verify
+    optional bytes message = 3;     // message to verify
+    optional string addressHex = 4; // address to verify (hex string, newer firmware)
+}

--- a/common/protob/messages.proto
+++ b/common/protob/messages.proto
@@ -278,4 +278,16 @@ enum MessageType {
     MessageType_WebAuthnCredentials = 801 [(wire_out) = true];
     MessageType_WebAuthnAddResidentCredential = 802 [(wire_in) = true];
     MessageType_WebAuthnRemoveResidentCredential = 803 [(wire_in) = true];
+
+    // 420coin
+    MessageType_FourtwentycoinGetPublicKey = 900 [(wire_in) = true];
+    MessageType_FourtwentycoinPublicKey = 901 [(wire_out) = true];
+    MessageType_FourtwentycoinGetAddress = 902 [(wire_in) = true];
+    MessageType_FourtwentycoinAddress = 903 [(wire_out) = true];
+    MessageType_FourtwentycoinSignTx = 904 [(wire_in) = true];
+    MessageType_FourtwentycoinTxRequest = 905 [(wire_out) = true];
+    MessageType_FourtwentycoinTxAck = 906 [(wire_in) = true];
+    MessageType_FourtwentycoinSignMessage = 907 [(wire_in) = true];
+    MessageType_FourtwentycoinVerifyMessage = 908 [(wire_in) = true];
+    MessageType_FourtwentycoinMessageSignature = 909 [(wire_out) = true];
 }


### PR DESCRIPTION
Addition of 420coin definitions and appending to messages.proto. These actions required for the g420 client for go-420coin to initiate, as function and protocol names between 420coin and ethereum differ. (smoke instead of gas, base function calls to fourtwenty instead of eth.)