### PR TITLE
Disable "at least one output in tx" restriction for Cardano, warn instead

### DIFF
--- a/common/tests/fixtures/cardano/sign_tx.json
+++ b/common/tests/fixtures/cardano/sign_tx.json
@@ -331,6 +331,37 @@
       }
     },
     {
+      "description": "transaction with stake registration certificate (no outputs)",
+      "parameters": {
+        "protocol_magic": 764824073,
+        "network_id": 1,
+        "fee": 42,
+        "ttl": 10,
+        "certificates": [
+          {
+            "type": 0,
+            "path": "m/1852'/1815'/0'/2/0"
+          }
+        ],
+        "withdrawals": [],
+        "metadata": "",
+        "input_flow": [["YES"], ["SWIPE", "YES"], ["SWIPE", "YES"]],
+        "inputs": [
+          {
+            "path": "m/1852'/1815'/0'/0/0",
+            "prev_hash": "3b40265111d8bb3c3c608d95b3a0bf83461ace32d79336579a1939b3aad1c0b7",
+            "prev_index": 0
+          }
+        ],
+        "outputs": [
+        ]
+      },
+      "result": {
+        "tx_hash": "03535791d04fc1b4457fada025f1c1f7778b5c2d7fa580bbac8abd53b85d3255",
+        "serialized_tx": "83a500818258203b40265111d8bb3c3c608d95b3a0bf83461ace32d79336579a1939b3aad1c0b700018002182a030a048182008200581c122a946b9ad3d2ddf029d3a828f0468aece76895f15c9efbd69b4277a100818258205d010cf16fdeff40955633d6c565f3844a288a24967cf6b76acbeb271b4f13c1584047e6e902e81bbba5596cfabaa4f9a70f36b367e28ee81181771ccd32d38b19c1d8ae9b0afb2a79057b87f8de7862e8d2317d86246909aaa66e54445d47aa990bf6"
+      }
+    },
+    {
       "description": "transaction with stake registration and stake delegation certificates",
       "parameters": {
         "protocol_magic": 764824073,

--- a/core/src/apps/cardano/layout.py
+++ b/core/src/apps/cardano/layout.py
@@ -152,7 +152,13 @@ async def show_warning_tx_staking_key_hash(
 
 
 async def confirm_transaction(
-    ctx, amount: int, fee: int, protocol_magic: int, ttl: int, has_metadata: bool
+    ctx,
+    amount: int,
+    fee: int,
+    protocol_magic: int,
+    ttl: int,
+    has_metadata: bool,
+    is_network_id_verifiable: bool,
 ) -> None:
     pages = []
 
@@ -164,8 +170,9 @@ async def confirm_transaction(
     pages.append(page1)
 
     page2 = Text("Confirm transaction", ui.ICON_SEND, ui.GREEN)
-    page2.normal("Network:")
-    page2.bold(protocol_magics.to_ui_string(protocol_magic))
+    if is_network_id_verifiable:
+        page2.normal("Network:")
+        page2.bold(protocol_magics.to_ui_string(protocol_magic))
     page2.normal("Transaction TTL:")
     page2.bold(str(ttl))
     pages.append(page2)
@@ -419,6 +426,15 @@ async def show_warning_address_foreign_staking_key(
         staking_key_message,
         button="Ok",
     )
+
+
+async def show_warning_tx_network_unverifiable(ctx: wire.Context) -> None:
+    page1 = Text("Warning", ui.ICON_SEND, ui.GREEN)
+    page1.normal("Transaction has no outputs, network cannot be verified.")
+    page1.br_half()
+    page1.normal("Continue?")
+
+    await require_confirm(ctx, page1)
 
 
 async def show_warning_address_pointer(


### PR DESCRIPTION
Motivation: IOHK (namely Daedalus wallet devs) requested being able to send transactions without outputs, for example in case of transactions with stake delegation certificates. This PR relaxes the requirement of sending at least one output to ensure verifiablilty of the transaction network id, replacing it with a warning at the beginning instead.

Until now, at least 1 output was required; now we allow transactions without outputs. This has minor security implications: a tx that contains no outputs, no withdrawals and no pool registration certificates does not contain any identification of the particular blockchain it will be submitted to, hence Trezor user can be theoretically fooled into signing a tx that (on his computer) appears to be for a testnet, but will actually be submitted to mainnet. In such a case, we display a warning ("no outputs, cannot verify network id"). (It is an actual concern only for users that use the same HD keys on more than one network/blockchain.)

Trezor-connect needs to be updated as well as having at least one tx output was being enforced there as well, here's the corresponding PR: https://github.com/trezor/connect/pull/729

Changes: Apart from relaxing tx-outputs count validation, introduce logic to determine whether network id is verifiable into the "standard transaction signature flow" and display the warning based on that. For stake pool registration the warning is not required given that the pool registration certificate already contains a reward address which explicitly references the network it belongs to

Testing:
* by running integration tests `pytest tests/device_tests -k "cardano and test_sign_tx"`

Screen capture of tx without outputs:
![trezor-cardano-no-output](https://user-images.githubusercontent.com/4980147/104592227-27429b80-566e-11eb-9e01-c24c2fcae652.gif)


