### PR TITLE
chore(core): monero: drop extraneous async/await

### DIFF
--- a/core/src/apps/monero/sign_tx.py
+++ b/core/src/apps/monero/sign_tx.py
@@ -135,7 +135,7 @@ async def sign_tx_dispatch(state, msg, keychain):
     elif msg.MESSAGE_WIRE_TYPE == MessageType.MoneroTransactionFinalRequest:
         from apps.monero.signing import step_10_sign_final
 
-        return await step_10_sign_final.final_msg(state), None
+        return step_10_sign_final.final_msg(state), None
 
     else:
         raise wire.DataError("Unknown message")

--- a/core/src/apps/monero/signing/step_06_set_output.py
+++ b/core/src/apps/monero/signing/step_06_set_output.py
@@ -45,7 +45,7 @@ async def set_output(
 
     state.mem_trace(1, True)
 
-    dst_entr = await _validate(state, dst_entr, dst_entr_hmac, is_offloaded_bp)
+    dst_entr = _validate(state, dst_entr, dst_entr_hmac, is_offloaded_bp)
     state.mem_trace(2, True)
 
     if not state.is_processing_offloaded:
@@ -121,7 +121,7 @@ async def set_output(
     )
 
 
-async def _validate(
+def _validate(
     state: State,
     dst_entr: MoneroTransactionDestinationEntry,
     dst_entr_hmac: bytes,

--- a/core/src/apps/monero/signing/step_10_sign_final.py
+++ b/core/src/apps/monero/signing/step_10_sign_final.py
@@ -21,7 +21,7 @@ if False:
     from apps.monero.xmr.types import Sc25519
 
 
-async def final_msg(state: State) -> MoneroTransactionFinalAck:
+def final_msg(state: State) -> MoneroTransactionFinalAck:
     if state.last_step != state.STEP_SIGN:
         raise ValueError("Invalid state transition")
     if state.current_input_index != state.input_count - 1:


### PR DESCRIPTION
Either async protobuf leftover or an optimization I don't understand.