### PR TITLE
fix(core): root ui callback for trezorconfig mod

### DIFF
--- a/core/embed/extmod/modtrezorconfig/modtrezorconfig.c
+++ b/core/embed/extmod/modtrezorconfig/modtrezorconfig.c
@@ -38,8 +38,8 @@ STATIC secbool wrapped_ui_wait_callback(uint32_t wait, uint32_t progress,
     args[0] = mp_obj_new_int(wait);
     args[1] = mp_obj_new_int(progress);
     args[2] = mp_obj_new_str(message, strlen(message));
-    if (mp_call_function_n_kw(MP_STATE_VM(trezorconfig_ui_wait_callback), 3, 0, args) ==
-        mp_const_true) {
+    if (mp_call_function_n_kw(MP_STATE_VM(trezorconfig_ui_wait_callback), 3, 0,
+                              args) == mp_const_true) {
       return sectrue;
     }
   }

--- a/core/embed/extmod/modtrezorconfig/modtrezorconfig.c
+++ b/core/embed/extmod/modtrezorconfig/modtrezorconfig.c
@@ -31,16 +31,15 @@
 #include "memzero.h"
 #include "storage.h"
 
-STATIC mp_obj_t ui_wait_callback = mp_const_none;
-
 STATIC secbool wrapped_ui_wait_callback(uint32_t wait, uint32_t progress,
                                         const char *message) {
-  if (mp_obj_is_callable(ui_wait_callback)) {
+  if (mp_obj_is_callable(MP_STATE_VM(trezorconfig_ui_wait_callback))) {
     mp_obj_t args[3] = {0};
     args[0] = mp_obj_new_int(wait);
     args[1] = mp_obj_new_int(progress);
     args[2] = mp_obj_new_str(message, strlen(message));
-    if (mp_call_function_n_kw(ui_wait_callback, 3, 0, args) == mp_const_true) {
+    if (mp_call_function_n_kw(MP_STATE_VM(trezorconfig_ui_wait_callback), 3, 0, args) ==
+        mp_const_true) {
       return sectrue;
     }
   }
@@ -56,7 +55,7 @@ STATIC secbool wrapped_ui_wait_callback(uint32_t wait, uint32_t progress,
 ///     """
 STATIC mp_obj_t mod_trezorconfig_init(size_t n_args, const mp_obj_t *args) {
   if (n_args > 0) {
-    ui_wait_callback = args[0];
+    MP_STATE_VM(trezorconfig_ui_wait_callback) = args[0];
     storage_init(wrapped_ui_wait_callback, HW_ENTROPY_DATA, HW_ENTROPY_LEN);
   } else {
     storage_init(NULL, HW_ENTROPY_DATA, HW_ENTROPY_LEN);

--- a/core/embed/firmware/mpconfigport.h
+++ b/core/embed/firmware/mpconfigport.h
@@ -158,6 +158,8 @@
 
 #define MP_STATE_PORT MP_STATE_VM
 
+#define MICROPY_PORT_ROOT_POINTERS mp_obj_t trezorconfig_ui_wait_callback;
+
 // ============= this ends common config section ===================
 
 

--- a/core/embed/firmware/mpconfigport.h
+++ b/core/embed/firmware/mpconfigport.h
@@ -158,8 +158,6 @@
 
 #define MP_STATE_PORT MP_STATE_VM
 
-#define MICROPY_PORT_ROOT_POINTERS mp_obj_t trezorconfig_ui_wait_callback;
-
 // ============= this ends common config section ===================
 
 
@@ -192,6 +190,9 @@ typedef long mp_off_t;
 #define malloc(n) m_malloc(n)
 #define free(p) m_free(p)
 #define realloc(p, n) m_realloc(p, n)
+
+#define MICROPY_PORT_ROOT_POINTERS \
+    mp_obj_t trezorconfig_ui_wait_callback; \
 
 // We need to provide a declaration/definition of alloca()
 #include <alloca.h>

--- a/core/embed/unix/mpconfigport.h
+++ b/core/embed/unix/mpconfigport.h
@@ -258,6 +258,7 @@ void mp_unix_mark_exec(void);
 #define MICROPY_PORT_ROOT_POINTERS \
     const char *readline_hist[50]; \
     void *mmap_region_head; \
+    mp_obj_t trezorconfig_ui_wait_callback; \
 
 // We need to provide a declaration/definition of alloca()
 // unless support for it is disabled.


### PR DESCRIPTION
Previously, the static could contain a pointer to the upy heap. It needs to be rooted properly in order for GC to find it.