### PR TITLE
build(core): install trezorlib in development mode

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -7,7 +7,7 @@ authors = ["SatoshiLabs <info@satoshilabs.com>"]
 [tool.poetry.dependencies]
 # all
 python = "^3.6"
-trezor = {path = "./python"}
+trezor = {path = "./python", develop = true}
 scons = "*"
 protobuf = "*"
 pyblake2 = "*"


### PR DESCRIPTION
`poetry install` copies trezorlib under `.venv` and then uses that copy which makes it hard to work on trezorlib. IIRC pipenv did not do this? This PR avoids the copying, `python/src/trezorlib` is used directly. The option does not seem to be much documented and I'm not sure it doesn't screw up the package release process.