### PR TITLE
Lock TT by holding finger on home screen

### DIFF
--- a/common/protob/messages-debug.proto
+++ b/common/protob/messages-debug.proto
@@ -26,9 +26,10 @@ message DebugLinkDecision {
         RIGHT = 3;
     }
 
-    optional uint32 x = 4;   // touch X coordinate
-    optional uint32 y = 5;   // touch Y coordinate
-    optional bool wait = 6;  // wait for layout change
+    optional uint32 x = 4;        // touch X coordinate
+    optional uint32 y = 5;        // touch Y coordinate
+    optional bool wait = 6;       // wait for layout change
+    optional uint32 hold_ms = 7;  // touch hold duration
 }
 
 /**

--- a/core/CHANGELOG.md
+++ b/core/CHANGELOG.md
@@ -7,6 +7,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 ## 2.3.7 [unreleased]
 
 ### Added
+- Locking the device by holding finger on the homescreen for 2.5 seconds.  [#1404]
 
 ### Changed
 
@@ -368,5 +369,6 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 [#1384]: https://github.com/trezor/trezor-firmware/issues/1384
 [#1399]: https://github.com/trezor/trezor-firmware/issues/1399
 [#1402]: https://github.com/trezor/trezor-firmware/pull/1402
+[#1404]: https://github.com/trezor/trezor-firmware/issues/1404
 [#1415]: https://github.com/trezor/trezor-firmware/pull/1415
 [#1467]: https://github.com/trezor/trezor-firmware/issues/1467

--- a/core/src/apps/base.py
+++ b/core/src/apps/base.py
@@ -216,6 +216,11 @@ def lock_device() -> None:
         workflow.close_others()
 
 
+def lock_device_if_unlocked() -> None:
+    if config.is_unlocked():
+        lock_device()
+
+
 async def unlock_device(ctx: wire.GenericContext = wire.DUMMY_CONTEXT) -> None:
     """Ensure the device is in unlocked state.
 
@@ -267,4 +272,6 @@ def boot() -> None:
 
     wire.experimental_enabled = storage.device.get_experimental_features()
 
-    workflow.idle_timer.set(storage.device.get_autolock_delay_ms(), lock_device)
+    workflow.idle_timer.set(
+        storage.device.get_autolock_delay_ms(), lock_device_if_unlocked
+    )

--- a/core/src/apps/homescreen/__init__.py
+++ b/core/src/apps/homescreen/__init__.py
@@ -1,26 +1,11 @@
 import storage.device
-from trezor import io, loop, res, ui
+from trezor import res, ui
 
 
 class HomescreenBase(ui.Layout):
-    RENDER_SLEEP = loop.SLEEP_FOREVER
-
     def __init__(self) -> None:
         super().__init__()
         self.label = storage.device.get_label() or "My Trezor"
         self.image = storage.device.get_homescreen() or res.load(
             "apps/homescreen/res/bg.toif"
         )
-
-    def on_tap(self) -> None:
-        """Called when the user taps the screen."""
-        pass
-
-    def dispatch(self, event: int, x: int, y: int) -> None:
-        if event is ui.REPAINT:
-            self.repaint = True
-        elif event is ui.RENDER and self.repaint:
-            self.repaint = False
-            self.on_render()
-        elif event is io.TOUCH_END:
-            self.on_tap()

--- a/core/src/apps/homescreen/homescreen.py
+++ b/core/src/apps/homescreen/homescreen.py
@@ -32,6 +32,7 @@ class Homescreen(HomescreenBase):
             style=LoaderNeutral,
             target_ms=_LOADER_TOTAL_MS - _LOADER_DELAY_MS,
             offset_y=-10,
+            reverse_speedup=3,
         )
         self.touch_ms: Optional[int] = None
 

--- a/core/src/apps/homescreen/homescreen.py
+++ b/core/src/apps/homescreen/homescreen.py
@@ -1,12 +1,25 @@
+import utime
+from micropython import const
+
 import storage
 import storage.device
 from trezor import config, ui
+from trezor.ui.loader import Loader, LoaderNeutral
+
+from apps.base import lock_device
 
 from . import HomescreenBase
+
+if False:
+    from typing import Optional
+
+_LOADER_DELAY_MS = const(500)
+_LOADER_TOTAL_MS = const(2500)
 
 
 async def homescreen() -> None:
     await Homescreen()
+    lock_device()
 
 
 class Homescreen(HomescreenBase):
@@ -15,7 +28,17 @@ class Homescreen(HomescreenBase):
         if not storage.device.is_initialized():
             self.label = "Go to trezor.io/start"
 
+        self.loader = Loader(
+            style=LoaderNeutral,
+            target_ms=_LOADER_TOTAL_MS - _LOADER_DELAY_MS,
+            offset_y=-10,
+        )
+        self.touch_ms: Optional[int] = None
+
     def on_render(self) -> None:
+        if not self.repaint:
+            return
+
         # warning bar on top
         if storage.device.is_initialized() and storage.device.no_backup():
             ui.header_error("SEEDLESS")
@@ -33,3 +56,39 @@ class Homescreen(HomescreenBase):
         # homescreen with shifted avatar and text on bottom
         ui.display.avatar(48, 48 - 10, self.image, ui.WHITE, ui.BLACK)
         ui.display.text_center(ui.WIDTH // 2, 220, self.label, ui.BOLD, ui.FG, ui.BG)
+
+        self.repaint = False
+
+    def on_touch_start(self, _x: int, _y: int) -> None:
+        if self.loader.start_ms is not None:
+            self.loader.start()
+        elif config.has_pin():
+            self.touch_ms = utime.ticks_ms()
+
+    def on_touch_end(self, _x: int, _y: int) -> None:
+        if self.loader.start_ms is not None:
+            self.repaint = True
+        self.loader.stop()
+        self.touch_ms = None
+
+        # raise here instead of self.loader.on_finish so as not to send TOUCH_END to the lockscreen
+        if self.loader.elapsed_ms() >= self.loader.target_ms:
+            raise ui.Result(None)
+
+    def _loader_start(self) -> None:
+        ui.display.clear()
+        ui.display.text_center(ui.WIDTH // 2, 35, "Hold to lock", ui.BOLD, ui.FG, ui.BG)
+        self.loader.start()
+
+    def dispatch(self, event: int, x: int, y: int) -> None:
+        if (
+            self.touch_ms is not None
+            and self.touch_ms + _LOADER_DELAY_MS < utime.ticks_ms()
+        ):
+            self.touch_ms = None
+            self._loader_start()
+
+        if event is ui.RENDER and self.loader.start_ms is not None:
+            self.loader.dispatch(event, x, y)
+        else:
+            super().dispatch(event, x, y)

--- a/core/src/apps/homescreen/lockscreen.py
+++ b/core/src/apps/homescreen/lockscreen.py
@@ -1,4 +1,4 @@
-from trezor import res, ui, wire
+from trezor import loop, res, ui, wire
 
 from . import HomescreenBase
 
@@ -21,6 +21,7 @@ async def lockscreen() -> None:
 
 class Lockscreen(HomescreenBase):
     BACKLIGHT_LEVEL = ui.BACKLIGHT_LOW
+    RENDER_SLEEP = loop.SLEEP_FOREVER
 
     def __init__(self, bootscreen: bool = False) -> None:
         if bootscreen:
@@ -34,6 +35,9 @@ class Lockscreen(HomescreenBase):
         super().__init__()
 
     def on_render(self) -> None:
+        if not self.repaint:
+            return
+
         # homescreen with label text on top
         ui.display.text_center(
             ui.WIDTH // 2, 35, self.label, ui.BOLD, ui.TITLE_GREY, ui.BG
@@ -53,5 +57,7 @@ class Lockscreen(HomescreenBase):
         )
         ui.display.icon(45, 202, res.load(ui.ICON_CLICK), ui.TITLE_GREY, ui.BG)
 
-    def on_tap(self) -> None:
+        self.repaint = False
+
+    def on_touch_end(self, _x: int, _y: int) -> None:
         raise ui.Result(None)

--- a/core/src/apps/management/apply_settings.py
+++ b/core/src/apps/management/apply_settings.py
@@ -1,11 +1,11 @@
 import storage.device
-from trezor import ui, wire, workflow
+from trezor import ui, wire
 from trezor.messages import ButtonRequestType, SafetyCheckLevel
 from trezor.messages.Success import Success
 from trezor.strings import format_duration_ms
 from trezor.ui.components.tt.text import Text
 
-from apps.base import lock_device_if_unlocked
+from apps.base import reload_settings_from_storage
 from apps.common import safety_checks
 from apps.common.confirm import require_confirm, require_hold_to_confirm
 
@@ -98,14 +98,6 @@ async def apply_settings(ctx: wire.Context, msg: ApplySettings):
     reload_settings_from_storage()
 
     return Success(message="Settings applied")
-
-
-def reload_settings_from_storage() -> None:
-    workflow.idle_timer.set(
-        storage.device.get_autolock_delay_ms(), lock_device_if_unlocked
-    )
-    ui.display.orientation(storage.device.get_rotation())
-    wire.experimental_enabled = storage.device.get_experimental_features()
 
 
 async def require_confirm_change_homescreen(ctx):

--- a/core/src/apps/management/apply_settings.py
+++ b/core/src/apps/management/apply_settings.py
@@ -5,7 +5,7 @@ from trezor.messages.Success import Success
 from trezor.strings import format_duration_ms
 from trezor.ui.components.tt.text import Text
 
-from apps.base import lock_device
+from apps.base import lock_device_if_unlocked
 from apps.common import safety_checks
 from apps.common.confirm import require_confirm, require_hold_to_confirm
 
@@ -101,7 +101,9 @@ async def apply_settings(ctx: wire.Context, msg: ApplySettings):
 
 
 def reload_settings_from_storage() -> None:
-    workflow.idle_timer.set(storage.device.get_autolock_delay_ms(), lock_device)
+    workflow.idle_timer.set(
+        storage.device.get_autolock_delay_ms(), lock_device_if_unlocked
+    )
     ui.display.orientation(storage.device.get_rotation())
     wire.experimental_enabled = storage.device.get_experimental_features()
 

--- a/core/src/trezor/messages/DebugLinkDecision.py
+++ b/core/src/trezor/messages/DebugLinkDecision.py
@@ -23,6 +23,7 @@ class DebugLinkDecision(p.MessageType):
         x: int = None,
         y: int = None,
         wait: bool = None,
+        hold_ms: int = None,
     ) -> None:
         self.yes_no = yes_no
         self.swipe = swipe
@@ -30,6 +31,7 @@ class DebugLinkDecision(p.MessageType):
         self.x = x
         self.y = y
         self.wait = wait
+        self.hold_ms = hold_ms
 
     @classmethod
     def get_fields(cls) -> Dict:
@@ -40,4 +42,5 @@ class DebugLinkDecision(p.MessageType):
             4: ('x', p.UVarintType, None),
             5: ('y', p.UVarintType, None),
             6: ('wait', p.BoolType, None),
+            7: ('hold_ms', p.UVarintType, None),
         }

--- a/core/src/trezor/ui/loader.py
+++ b/core/src/trezor/ui/loader.py
@@ -18,8 +18,8 @@ class LoaderDefault:
     class active(normal):
         bg_color = ui.BG
         fg_color = ui.GREEN
-        icon = ui.ICON_CHECK
-        icon_fg_color = ui.WHITE
+        icon: Optional[str] = ui.ICON_CHECK
+        icon_fg_color: Optional[int] = ui.WHITE
 
 
 class LoaderDanger(LoaderDefault):
@@ -30,21 +30,36 @@ class LoaderDanger(LoaderDefault):
         fg_color = ui.RED
 
 
+class LoaderNeutral(LoaderDefault):
+    class normal(LoaderDefault.normal):
+        fg_color = ui.FG
+
+    class active(LoaderDefault.active):
+        fg_color = ui.FG
+
+
 if False:
     LoaderStyleType = Type[LoaderDefault]
 
 
 _TARGET_MS = const(1000)
+_OFFSET_Y = const(-24)
 
 
 class Loader(ui.Component):
-    def __init__(self, style: LoaderStyleType = LoaderDefault) -> None:
+    def __init__(
+        self,
+        style: LoaderStyleType = LoaderDefault,
+        target_ms: int = _TARGET_MS,
+        offset_y: int = _OFFSET_Y,
+    ) -> None:
         super().__init__()
         self.normal_style = style.normal
         self.active_style = style.active
-        self.target_ms = _TARGET_MS
+        self.target_ms = target_ms
         self.start_ms: Optional[int] = None
         self.stop_ms: Optional[int] = None
+        self.offset_y = offset_y
 
     def start(self) -> None:
         self.start_ms = utime.ticks_ms()
@@ -75,13 +90,18 @@ class Loader(ui.Component):
         else:
             s = self.active_style
 
-        _Y = const(-24)
-
+        progress = r * 1000 // target
         if s.icon is None:
-            display.loader(r, False, _Y, s.fg_color, s.bg_color)
+            display.loader(progress, False, self.offset_y, s.fg_color, s.bg_color)
         else:
             display.loader(
-                r, False, _Y, s.fg_color, s.bg_color, res.load(s.icon), s.icon_fg_color
+                progress,
+                False,
+                self.offset_y,
+                s.fg_color,
+                s.bg_color,
+                res.load(s.icon),
+                s.icon_fg_color,
             )
         if (r == 0) and (self.stop_ms is not None):
             self.start_ms = None

--- a/python/src/trezorlib/debuglink.py
+++ b/python/src/trezorlib/debuglink.py
@@ -122,7 +122,16 @@ class DebugLink:
         state = self._call(messages.DebugLinkGetState(wait_word_pos=True))
         return state.reset_word_pos
 
-    def input(self, word=None, button=None, swipe=None, x=None, y=None, wait=False):
+    def input(
+        self,
+        word=None,
+        button=None,
+        swipe=None,
+        x=None,
+        y=None,
+        wait=False,
+        hold_ms=None,
+    ):
         if not self.allow_interactions:
             return
 
@@ -131,7 +140,7 @@ class DebugLink:
             raise ValueError("Invalid input - must use one of word, button, swipe")
 
         decision = messages.DebugLinkDecision(
-            yes_no=button, swipe=swipe, input=word, x=x, y=y, wait=wait
+            yes_no=button, swipe=swipe, input=word, x=x, y=y, wait=wait, hold_ms=hold_ms
         )
         ret = self._call(decision, nowait=not wait)
         if ret is not None:

--- a/python/src/trezorlib/messages/DebugLinkDecision.py
+++ b/python/src/trezorlib/messages/DebugLinkDecision.py
@@ -23,6 +23,7 @@ class DebugLinkDecision(p.MessageType):
         x: int = None,
         y: int = None,
         wait: bool = None,
+        hold_ms: int = None,
     ) -> None:
         self.yes_no = yes_no
         self.swipe = swipe
@@ -30,6 +31,7 @@ class DebugLinkDecision(p.MessageType):
         self.x = x
         self.y = y
         self.wait = wait
+        self.hold_ms = hold_ms
 
     @classmethod
     def get_fields(cls) -> Dict:
@@ -40,4 +42,5 @@ class DebugLinkDecision(p.MessageType):
             4: ('x', p.UVarintType, None),
             5: ('y', p.UVarintType, None),
             6: ('wait', p.BoolType, None),
+            7: ('hold_ms', p.UVarintType, None),
         }

--- a/tests/click_tests/test_lock.py
+++ b/tests/click_tests/test_lock.py
@@ -1,0 +1,62 @@
+# This file is part of the Trezor project.
+#
+# Copyright (C) 2012-2021 SatoshiLabs and contributors
+#
+# This library is free software: you can redistribute it and/or modify
+# it under the terms of the GNU Lesser General Public License version 3
+# as published by the Free Software Foundation.
+#
+# This library is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU Lesser General Public License for more details.
+#
+# You should have received a copy of the License along with this library.
+# If not, see <https://www.gnu.org/licenses/lgpl-3.0.html>.
+
+import time
+
+import pytest
+
+from .. import buttons, common
+
+PIN4 = "1234"
+
+
+@pytest.mark.setup_client(pin=PIN4)
+def test_hold_to_lock(device_handler):
+    debug = device_handler.debuglink()
+
+    def hold(duration, wait=True):
+        debug.input(x=13, y=37, hold_ms=duration, wait=wait)
+        time.sleep(duration / 1000 + 0.5)
+
+    assert device_handler.features().unlocked is False
+
+    # unlock with message
+    device_handler.run(common.get_test_address)
+    layout = debug.wait_layout()
+    assert layout.text == "PinDialog"
+    debug.input("1234", wait=True)
+    assert device_handler.result()
+
+    assert device_handler.features().unlocked is True
+
+    # short touch
+    hold(1000, wait=False)
+    assert device_handler.features().unlocked is True
+
+    # lock
+    hold(3500)
+    assert device_handler.features().unlocked is False
+
+    # unlock by touching
+    layout = debug.click(buttons.INFO, wait=True)
+    assert layout.text == "PinDialog"
+    debug.input("1234", wait=True)
+
+    assert device_handler.features().unlocked is True
+
+    # lock
+    hold(3500)
+    assert device_handler.features().unlocked is False


### PR DESCRIPTION
Fixes #1404. The usual hold-to-confirm animation is shown after first 500ms and finishes in 5s in total. The PR also extends debuglink to support touch hold events.

Please test on actual device as the overall impression can be very different from emulator:)
([regular debug build](https://gitlab.com/satoshilabs/trezor/trezor-firmware/-/jobs/972529766/artifacts/file/trezor-fw-regular-debug-2.3.6-6ce0745b.bin))

![Peek 2021-01-19 16-47](https://user-images.githubusercontent.com/85857/105058011-15019c80-5a76-11eb-8d9d-0d8648d1bdc0.gif)
