### PR TITLE
CI bootloader: wipe storage without confirmation

### DIFF
--- a/core/embed/bootloader_ci/README.md
+++ b/core/embed/bootloader_ci/README.md
@@ -3,7 +3,8 @@
 This bootloader always runs into bootloader mode, waits for firmware to be
 uploaded, then runs the firmware.
 
-Storage is not erased. If you wish to erase storage, do it inside your test.
+Storage is not erased. If you wish to erase storage you can send WipeDevice
+message to the bootloader.
 
 All user interaction is removed (no clicking or confirmations required)
 so that it can be used in an automated way for tests.

--- a/core/embed/bootloader_ci/main.c
+++ b/core/embed/bootloader_ci/main.c
@@ -115,17 +115,6 @@ static secbool bootloader_usb_loop(const vendor_header *const vhdr,
         break;
       case 5:  // WipeDevice
         ui_fadeout();
-        ui_screen_wipe_confirm();
-        ui_fadein();
-        int response = ui_user_input(INPUT_CONFIRM | INPUT_CANCEL);
-        if (INPUT_CANCEL == response) {
-          ui_fadeout();
-          ui_screen_info(secfalse, vhdr, hdr);
-          ui_fadein();
-          send_user_abort(USB_IFACE_NUM, "Wipe cancelled");
-          break;
-        }
-        ui_fadeout();
         ui_screen_wipe();
         ui_fadein();
         r = process_msg_WipeDevice(USB_IFACE_NUM, msg_size, buf);

--- a/core/embed/bootloader_ci/main.c
+++ b/core/embed/bootloader_ci/main.c
@@ -114,21 +114,15 @@ static secbool bootloader_usb_loop(const vendor_header *const vhdr,
         process_msg_Ping(USB_IFACE_NUM, msg_size, buf);
         break;
       case 5:  // WipeDevice
-        ui_fadeout();
         ui_screen_wipe();
-        ui_fadein();
         r = process_msg_WipeDevice(USB_IFACE_NUM, msg_size, buf);
         if (r < 0) {  // error
-          ui_fadeout();
           ui_screen_fail();
-          ui_fadein();
           usb_stop();
           usb_deinit();
           return secfalse;  // shutdown
         } else {            // success
-          ui_fadeout();
           ui_screen_done(0, sectrue);
-          ui_fadein();
           usb_stop();
           usb_deinit();
           return secfalse;  // shutdown
@@ -140,17 +134,13 @@ static secbool bootloader_usb_loop(const vendor_header *const vhdr,
       case 7:  // FirmwareUpload
         r = process_msg_FirmwareUpload(USB_IFACE_NUM, msg_size, buf);
         if (r < 0 && r != -4) {  // error, but not user abort (-4)
-          ui_fadeout();
           ui_screen_fail();
-          ui_fadein();
           usb_stop();
           usb_deinit();
           return secfalse;    // shutdown
         } else if (r == 0) {  // last chunk received
           ui_screen_install_progress_upload(1000);
-          ui_fadeout();
           ui_screen_done(4, sectrue);
-          ui_fadein();
           ui_screen_done(3, secfalse);
           hal_delay(1000);
           ui_screen_done(2, secfalse);
@@ -159,7 +149,6 @@ static secbool bootloader_usb_loop(const vendor_header *const vhdr,
           hal_delay(1000);
           usb_stop();
           usb_deinit();
-          ui_fadeout();
           return sectrue;  // jump to firmware
         }
         break;


### PR DESCRIPTION
Currently if the device is rebooted in a state where it has pin set there's not much you can do with it without someone physically entering the pin. This PR removes confirmation dialog for wiping the storage so that we can automatically do it before flashing new firmware to be tested.