### PR TITLE
build: workaround poetry x gitlab-runner bug

### DIFF
--- a/poetry.toml
+++ b/poetry.toml
@@ -1,3 +1,5 @@
 cache-dir = "/tmp/.poetry-cache"
 [virtualenvs]
 in-project = true
+[experimental]
+new-installer = false


### PR DESCRIPTION
This is supposed to help with occasional CI failures like https://gitlab.com/satoshilabs/trezor/trezor-firmware/-/jobs/992276339  probably caused by https://github.com/python-poetry/poetry/issues/3199.

IIUC it disables parallel installation which seems to make each CI job ~45s slower. It's questionable whether not having to retry a CI job manually from time to time is worth couple of minutes longer pipeline.