### PR TITLE
fix(core/Cardano): do not show change output in byron-shelley transfers

### DIFF
--- a/common/tests/fixtures/cardano/sign_tx.json
+++ b/common/tests/fixtures/cardano/sign_tx.json
@@ -791,6 +791,46 @@
         "tx_hash": "b621e22f7cb9aac1a70a3362fde88bdfd31fc100e20f3f3c24a7b853536b4f50",
         "serialized_tx": "83a300818258203b40265111d8bb3c3c608d95b3a0bf83461ace32d79336579a1939b3aad1c0b70001818258390180f9e2c88e6c817008f3a812ed889b4a4da8e0bd103f86e7335422aa122a946b9ad3d2ddf029d3a828f0468aece76895f15c9efbd69b42771a006ca79302182aa100818258205d010cf16fdeff40955633d6c565f3844a288a24967cf6b76acbeb271b4f13c1584088c35c125664935117d9aa1173cae5f01967b02f6b716b1a135570b2fee74728f2f3e39d56b748302c36e2407d7bfefc4054ca1e60dd857e461734ae41d00500f6"
       }
+    },
+    {
+      "description": "Byron to Shelley transfer",
+      "parameters": {
+        "protocol_magic": 764824073,
+        "network_id": 1,
+        "fee": 42,
+        "certificates": [],
+        "withdrawals": [],
+        "metadata": "",
+        "input_flow": [["YES"], ["YES"]],
+        "inputs": [
+          {
+            "path": "m/44'/1815'/0'/0/0",
+            "prev_hash": "3b40265111d8bb3c3c608d95b3a0bf83461ace32d79336579a1939b3aad1c0b7",
+            "prev_index": 0
+          },
+          {
+            "path": "m/1852'/1815'/0'/0/0",
+            "prev_hash": "3b40265111d8bb3c3c608d95b3a0bf83461ace32d79336579a1939b3aad1c0b7",
+            "prev_index": 1
+          }
+        ],
+        "outputs": [
+          {
+            "address": "addr1z90z7zqwhya6mpk5q929ur897g3pp9kkgalpreny8y304r2dcrtx0sf3dluyu4erzr3xtmdnzvcyfzekkuteu2xagx0qeva0pr",
+            "amount": "1"
+          },
+          {
+            "addressType": 0,
+            "path": "m/1852'/1815'/0'/0/0",
+            "stakingPath": "m/1852'/1815'/0'/2/0",
+            "amount": "7120787"
+          }
+        ]
+      },
+      "result": {
+        "tx_hash": "00d393f7fc9a8c17b3efccb44dad9d7e15fdaf2d942a3a455b52b5be016066dd",
+        "serialized_tx": "83a300828258203b40265111d8bb3c3c608d95b3a0bf83461ace32d79336579a1939b3aad1c0b7008258203b40265111d8bb3c3c608d95b3a0bf83461ace32d79336579a1939b3aad1c0b7010182825839115e2f080eb93bad86d401545e0ce5f2221096d6477e11e6643922fa8d4dc0d667c1316ff84e572310e265edb31330448b36b7179e28dd419e018258390180f9e2c88e6c817008f3a812ed889b4a4da8e0bd103f86e7335422aa122a946b9ad3d2ddf029d3a828f0468aece76895f15c9efbd69b42771a006ca79302182aa200818258205d010cf16fdeff40955633d6c565f3844a288a24967cf6b76acbeb271b4f13c158408393ba106a791a55ea588a124f539a02e149cc259df703ccc29f12f2ddc2734e6a07e37d645b4d0c9cc633493cb99ed7a0057b046dc18113685a1ae6d36686080281845820b90fb812a2268e9569ff1172e8daed1da3dc7e72c7bded7c5bcb7282039f90d558407782cdec14dcc5f506bb17275988771fce6ab4b744774d562c7aa120a008a9b9c28220b39382fbc8b70ef3d8a2fb2ba6aa55d732eaea1a3c71e568b387f5f40c5820fd8e71c1543de2cdc7f7623130c5f2cceb53549055fa1f5bc88199989e08cce741a0f6"
+      }
     }
   ]
 }

--- a/core/src/apps/cardano/helpers/paths.py
+++ b/core/src/apps/cardano/helpers/paths.py
@@ -18,8 +18,8 @@ SCHEMA_STAKING_ANY_ACCOUNT = PathSchema("m/1852'/coin_type'/[0-%s]'/2/0" % (HARD
 
 # the maximum allowed change address.  this should be large enough for normal
 # use and still allow to quickly brute-force the correct bip32 path
-MAX_CHANGE_ADDRESS_INDEX = const(1_000_000)
-MAX_ACCOUNT_INDEX = const(100)
+MAX_SAFE_CHANGE_ADDRESS_INDEX = const(1_000_000)
+MAX_SAFE_ACCOUNT_INDEX = const(100) | HARDENED
 ACCOUNT_PATH_INDEX = const(2)
 BIP_PATH_LENGTH = const(5)
 

--- a/core/src/apps/cardano/sign_tx.py
+++ b/core/src/apps/cardano/sign_tx.py
@@ -725,7 +725,7 @@ def _should_hide_output(output: List[int], inputs: List[CardanoTxInputType]) -> 
         inp = tx_input.address_n
         if (
             len(output) != BIP_PATH_LENGTH
-            or output[: (ACCOUNT_PATH_INDEX + 1)] != inp[: (ACCOUNT_PATH_INDEX + 1)]
+            or output[ACCOUNT_PATH_INDEX] != inp[ACCOUNT_PATH_INDEX]
             or output[(ACCOUNT_PATH_INDEX + 1)] > MAX_ACCOUNT_INDEX
             or output[-2] >= 2
             or output[-1] >= MAX_CHANGE_ADDRESS_INDEX

--- a/core/src/apps/cardano/sign_tx.py
+++ b/core/src/apps/cardano/sign_tx.py
@@ -35,8 +35,8 @@ from .helpers.paths import (
     CERTIFICATE_PATH_NAME,
     CHANGE_OUTPUT_PATH_NAME,
     CHANGE_OUTPUT_STAKING_PATH_NAME,
-    MAX_ACCOUNT_INDEX,
-    MAX_CHANGE_ADDRESS_INDEX,
+    MAX_SAFE_ACCOUNT_INDEX,
+    MAX_SAFE_CHANGE_ADDRESS_INDEX,
     POOL_OWNER_STAKING_PATH_NAME,
     SCHEMA_ADDRESS,
     SCHEMA_STAKING,
@@ -726,9 +726,9 @@ def _should_hide_output(output: List[int], inputs: List[CardanoTxInputType]) -> 
         if (
             len(output) != BIP_PATH_LENGTH
             or output[ACCOUNT_PATH_INDEX] != inp[ACCOUNT_PATH_INDEX]
-            or output[(ACCOUNT_PATH_INDEX + 1)] > MAX_ACCOUNT_INDEX
+            or output[ACCOUNT_PATH_INDEX] > MAX_SAFE_ACCOUNT_INDEX
             or output[-2] >= 2
-            or output[-1] >= MAX_CHANGE_ADDRESS_INDEX
+            or output[-1] >= MAX_SAFE_CHANGE_ADDRESS_INDEX
         ):
             return False
     return True

--- a/core/tests/test_apps.cardano.sign_tx.py
+++ b/core/tests/test_apps.cardano.sign_tx.py
@@ -9,7 +9,7 @@ if not utils.BITCOIN_ONLY:
 @unittest.skipUnless(not utils.BITCOIN_ONLY, "altcoin")
 class TestCardanoSignTransaction(unittest.TestCase):
     def test_should_show_outputs(self):
-        outputs_to_show = [
+        outputs_to_hide = [
             # output is from the same address as input
             (
                 [44 | HARDENED, 1815 | HARDENED, 0 | HARDENED, 0, 0],
@@ -33,8 +33,23 @@ class TestCardanoSignTransaction(unittest.TestCase):
                     [44 | HARDENED, 1815 | HARDENED, 2 | HARDENED, 0, 2],
                 ],
             ),
+            # byron input and shelley output
+            (
+                [1852 | HARDENED, 1815 | HARDENED, 0 | HARDENED, 0, 0],
+                [
+                    [44 | HARDENED, 1815 | HARDENED, 0 | HARDENED, 0, 0],
+                ],
+            ),
+            # mixed byron and shelley inputs
+            (
+                [1852 | HARDENED, 1815 | HARDENED, 0 | HARDENED, 0, 0],
+                [
+                    [1852 | HARDENED, 1815 | HARDENED, 0 | HARDENED, 0, 0],
+                    [44 | HARDENED, 1815 | HARDENED, 0 | HARDENED, 0, 0],
+                ],
+            ),
         ]
-        outputs_to_hide = [
+        outputs_to_show = [
             # output is from different account
             (
                 [44 | HARDENED, 1815 | HARDENED, 2 | HARDENED, 0, 0],
@@ -68,15 +83,22 @@ class TestCardanoSignTransaction(unittest.TestCase):
                 [44 | HARDENED, 1815 | HARDENED, 0 | HARDENED, 0, 1000001],
                 [[44 | HARDENED, 1815 | HARDENED, 0 | HARDENED, 0, 0]],
             ),
+            # max safe account number exceeded
+            (
+                [1852 | HARDENED, 1815 | HARDENED, 101 | HARDENED, 0, 0],
+                [
+                    [1852 | HARDENED, 1815 | HARDENED, 101 | HARDENED, 0, 0]
+                ],
+            ),
         ]
 
-        for output_path, input_paths in outputs_to_show:
+        for output_path, input_paths in outputs_to_hide:
             inputs = [
                 CardanoTxInputType(address_n=input_path, prev_hash=b"", prev_index=0) for input_path in input_paths
             ]
             self.assertTrue(_should_hide_output(output_path, inputs))
 
-        for output_path, input_paths in outputs_to_hide:
+        for output_path, input_paths in outputs_to_show:
             inputs = [
                 CardanoTxInputType(address_n=input_path, prev_hash=b"", prev_index=0) for input_path in input_paths
             ]

--- a/tests/ui_tests/fixtures.json
+++ b/tests/ui_tests/fixtures.json
@@ -1,4 +1,5 @@
 {
+"cardano-test_sign_tx.py::test_cardano_sign_tx[byron_to_shelley_transfer]": "f953ae1875b418bef8fe3bc739f49ce90b63bd73b0abf09e87c17c89af4f0198",
 "cardano-test_sign_tx.py::test_cardano_sign_tx[mainnet_transaction_with_change0]": "e962a871d51f5fb0775f291f6e266445bc947600d60558a17ae47efb494b2e56",
 "cardano-test_sign_tx.py::test_cardano_sign_tx[mainnet_transaction_with_change1]": "0514ba487672b2bd902ca39ab0665917f0eb0b804a0f857564a0f7183d2f6483",
 "cardano-test_sign_tx.py::test_cardano_sign_tx[mainnet_transaction_with_multiple_inputs]": "5ba2589aeda7cb2b707b5dd0d40ac26a5abe6eb0c3ec3d47d834701ef07a42bc",


### PR DESCRIPTION
Motivation: @tsusanka and Trezor QA noticed that Trezor shows the base address change output if some of the inputs happens to be a Byron era input. This is the result of the current `_should_hide_output()` logic in Cardano which hides outputs only if their path matches with all the inputs up to the account index which is stricter than it needs to be and causes issues when Byron/Shelley paths otherwise belonging to the same logical account are mixed.

Changes: relax the `_should_hide_output()` logic to look only at the account indices when matching the tx output with the inputs. The path roots (`m/1852'/1815'/` for Shelley and `m/44'/1815'/` for Byron) are being enforced by the Keychain (core/src/apps/cardano/seed.py) already. Also sending funds the other way around, i.e. from shelley to byron addresses is already independently accompanied by a warning that given change address has no stake rights (so users don't accidentally "unstake" their funds)

Testing:

* added testcase with a tx with a byron input and shelley output which fails with the previous logic as one more screen appeared, requiring a different input flow
* `pytest tests/device_tests -k "test_cardano_sign_tx"` passes
