### PR TITLE
python: Raise ValueError for non-existant tx hashes

### DIFF
--- a/python/CHANGELOG.md
+++ b/python/CHANGELOG.md
@@ -13,6 +13,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Enabled session management via `EndSession`  [#1227]
 - Support for temporary or permanent `safety-checks` setting
 - Support for Output Descriptors export [#1363]
+- Raises `ValueError` when the txid for an input is not present in `prev_txes` during `btc.sign_tx` [#1442]
 
 ### Changed
 

--- a/python/src/trezorlib/btc.py
+++ b/python/src/trezorlib/btc.py
@@ -279,6 +279,8 @@ def sign_tx(
 
         # Device asked for one more information, let's process it.
         if res.details.tx_hash is not None:
+            if res.details.tx_hash not in prev_txes:
+                raise ValueError(f"Previous transaction {res.details.tx_hash.hex()} not available")
             current_tx = prev_txes[res.details.tx_hash]
         else:
             current_tx = this_tx


### PR DESCRIPTION
If the device asks for a tx_hash which is not present in prev_txes,
raise a ValueError with some more detailed messaging about the missing
hash rather than the default dictionary lookup failure of KeyError.