### PR TITLE
python: Allow specifying USB ids in HID and WebUsb enumerate

### DIFF
--- a/python/src/trezorlib/transport/hid.py
+++ b/python/src/trezorlib/transport/hid.py
@@ -17,7 +17,7 @@
 import logging
 import sys
 import time
-from typing import Any, Dict, Iterable
+from typing import Any, Dict, Iterable, Optional, Set, Tuple
 
 from ..log import DUMP_PACKETS
 from . import DEV_TREZOR1, UDEV_RULES_STR, TransportException
@@ -130,11 +130,11 @@ class HidTransport(ProtocolBasedTransport):
         return "%s:%s" % (self.PATH_PREFIX, self.device["path"].decode())
 
     @classmethod
-    def enumerate(cls, debug: bool = False) -> Iterable["HidTransport"]:
+    def enumerate(cls, debug: bool = False, usb_ids: Optional[Set[Tuple[int, int]]] = {DEV_TREZOR1}) -> Iterable["HidTransport"]:
         devices = []
         for dev in hid.enumerate(0, 0):
             usb_id = (dev["vendor_id"], dev["product_id"])
-            if usb_id != DEV_TREZOR1:
+            if usb_ids is not None and usb_id not in usb_ids:
                 continue
             if debug:
                 if not is_debuglink(dev):

--- a/python/src/trezorlib/transport/webusb.py
+++ b/python/src/trezorlib/transport/webusb.py
@@ -18,7 +18,7 @@ import atexit
 import logging
 import sys
 import time
-from typing import Iterable, Optional
+from typing import Iterable, Optional, Set, Tuple
 
 from ..log import DUMP_PACKETS
 from . import TREZORS, UDEV_RULES_STR, TransportException
@@ -109,7 +109,7 @@ class WebUsbTransport(ProtocolBasedTransport):
         return "%s:%s" % (self.PATH_PREFIX, dev_to_str(self.device))
 
     @classmethod
-    def enumerate(cls, usb_reset=False) -> Iterable["WebUsbTransport"]:
+    def enumerate(cls, usb_reset=False, usb_ids: Optional[Set[Tuple[int, int]]] = TREZORS) -> Iterable["WebUsbTransport"]:
         if cls.context is None:
             cls.context = usb1.USBContext()
             cls.context.open()
@@ -117,7 +117,7 @@ class WebUsbTransport(ProtocolBasedTransport):
         devices = []
         for dev in cls.context.getDeviceIterator(skip_on_error=True):
             usb_id = (dev.getVendorID(), dev.getProductID())
-            if usb_id not in TREZORS:
+            if usb_ds is not None and usb_id not in usb_ids:
                 continue
             if not is_vendor_class(dev):
                 continue


### PR DESCRIPTION
When working with Trezor clones, it's useful to be able to use trezorlib instead of the fork of it that those clones made. As such, it is necessary to allow `HidTransport` and `WebUsbTransport` be able to enumerate them. To allow this, I've added an optional `usb_ids` parameter to their `enumerate` method. By default, this use the Trezor USB IDs. However callers can specify alternative IDs to use, or alternatively, `None` can be provided to enumerate any and all usb devices.