### PR TITLE
python: Allow overriding some Trezor specific things

### DIFF
--- a/python/src/trezorlib/client.py
+++ b/python/src/trezorlib/client.py
@@ -95,6 +95,7 @@ class TrezorClient:
         self.session_id = session_id
         self.msg_type_to_class_override = {}
         self.vendors = VENDORS
+        self.minimum_versions = MINIMUM_FIRMWARE_VERSION
         self.init_device(session_id=session_id)
 
     def open(self):
@@ -319,7 +320,7 @@ class TrezorClient:
         if self.features.bootloader_mode:
             return False
         model = self.features.model or "1"
-        required_version = MINIMUM_FIRMWARE_VERSION[model]
+        required_version = self.minimum_versions[model]
         return self.version < required_version
 
     def check_firmware_version(self, warn_only=False):

--- a/python/src/trezorlib/client.py
+++ b/python/src/trezorlib/client.py
@@ -94,6 +94,7 @@ class TrezorClient:
         self.session_counter = 0
         self.session_id = session_id
         self.msg_type_to_class_override = {}
+        self.vendors = VENDORS
         self.init_device(session_id=session_id)
 
     def open(self):
@@ -230,7 +231,7 @@ class TrezorClient:
 
     def _refresh_features(self, features: messages.Features) -> None:
         """Update internal fields based on passed-in Features message."""
-        if features.vendor not in VENDORS:
+        if features.vendor not in self.vendors:
             raise RuntimeError("Unsupported device")
 
         self.features = features

--- a/python/src/trezorlib/client.py
+++ b/python/src/trezorlib/client.py
@@ -93,6 +93,7 @@ class TrezorClient:
         self.ui = ui
         self.session_counter = 0
         self.session_id = session_id
+        self.msg_type_to_class_override = {}
         self.init_device(session_id=session_id)
 
     def open(self):
@@ -138,7 +139,7 @@ class TrezorClient:
                 msg_type, len(msg_bytes), msg_bytes.hex()
             ),
         )
-        msg = mapping.decode(msg_type, msg_bytes)
+        msg = mapping.decode(msg_type, msg_bytes, self.msg_type_to_class_override)
         LOG.debug(
             "received message: {}".format(msg.__class__.__name__),
             extra={"protobuf": msg},

--- a/python/src/trezorlib/debuglink.py
+++ b/python/src/trezorlib/debuglink.py
@@ -42,6 +42,7 @@ class DebugLink:
     def __init__(self, transport, auto_interact=True):
         self.transport = transport
         self.allow_interactions = auto_interact
+        self.msg_type_to_class_override = {}
 
     def open(self):
         self.transport.begin_session()
@@ -72,7 +73,7 @@ class DebugLink:
                 msg_type, len(msg_bytes), msg_bytes.hex()
             ),
         )
-        msg = mapping.decode(ret_type, ret_bytes)
+        msg = mapping.decode(ret_type, ret_bytes, self.msg_type_to_class_override)
         LOG.debug(
             "received message: {}".format(msg.__class__.__name__),
             extra={"protobuf": msg},

--- a/python/src/trezorlib/mapping.py
+++ b/python/src/trezorlib/mapping.py
@@ -15,7 +15,7 @@
 # If not, see <https://www.gnu.org/licenses/lgpl-3.0.html>.
 
 import io
-from typing import Tuple
+from typing import Dict, Tuple
 
 from . import messages, protobuf
 
@@ -62,8 +62,8 @@ def get_type(msg):
     return map_class_to_type[msg.__class__]
 
 
-def get_class(t):
-    return map_type_to_class[t]
+def get_class(t, map_override={}):
+    return map_override.get(t, map_type_to_class[t])
 
 
 def encode(msg: protobuf.MessageType) -> Tuple[int, bytes]:
@@ -73,8 +73,8 @@ def encode(msg: protobuf.MessageType) -> Tuple[int, bytes]:
     return message_type, buf.getvalue()
 
 
-def decode(message_type: int, message_bytes: bytes) -> protobuf.MessageType:
-    cls = get_class(message_type)
+def decode(message_type: int, message_bytes: bytes, map_override: Dict = {}) -> protobuf.MessageType:
+    cls = get_class(message_type, map_override)
     buf = io.BytesIO(message_bytes)
     return protobuf.load_message(buf, cls)
 


### PR DESCRIPTION
When working with Trezor clones, it is useful to use trezorlib over their forks of the library. As such, we need to be able to specify alternative vendors, minimum firmware versions, and alternative message classes to use for those devices. This PR adds attributes to `TrezorClient` that allow a caller to override those things.

Specifically, `msg_type_to_class_override` is a map of wire types to message classes. When decoding a message, the wire type is looked up in this message first before falling back to the default Trezor messages. `vendors` is added for the vendors check. This defaults to the `VENDORS` tuple, but can be overridden with another tuple by the caller. Lastly `minimum_versions` replaces `MINIMUM_FIRMWARE_VERSION` in the `is_outdated` check. This defaults to `MINIMUM_FIRMWARE_VERSION` but can be overridden by the caller.