### PR TITLE
ci: wait longer for T1 bootup

### DIFF
--- a/ci/hardware_tests/device/t1.py
+++ b/ci/hardware_tests/device/t1.py
@@ -43,7 +43,7 @@ class TrezorOne(Device):
             self.touch("right", "click")
             self.wait(5)
             self.touch("right", "click")
-        self.wait(5)
+        self.wait(10)
         return self.check_model("Trezor 1")
 
     def _enter_bootloader(self):


### PR DESCRIPTION
Fix for https://gitlab.com/satoshilabs/trezor/trezor-firmware/-/jobs/1012382702. According to the [video](https://gitlab.com/satoshilabs/trezor/trezor-firmware/-/jobs/1012382702/artifacts/file/ci/hardware_tests/video_48d1a7a8_1612600513.mp4) we may just need to wait a little bit longer before the fw boots up.