### PR TITLE
Use BufferReader for CBOR decoding

### DIFF
--- a/core/src/apps/common/readers.py
+++ b/core/src/apps/common/readers.py
@@ -18,9 +18,20 @@ def read_bitcoin_varint(r: BufferReader) -> int:
     return n
 
 
+def read_uint16_be(r: BufferReader) -> int:
+    n = r.get()
+    return (n << 8) + r.get()
+
+
 def read_uint32_be(r: BufferReader) -> int:
-    n = r.get() << 24
-    n += r.get() << 16
-    n += r.get() << 8
-    n += r.get()
+    n = r.get()
+    for _ in range(3):
+        n = (n << 8) + r.get()
+    return n
+
+
+def read_uint64_be(r: BufferReader) -> int:
+    n = r.get()
+    for _ in range(7):
+        n = (n << 8) + r.get()
     return n

--- a/core/tests/test_apps.common.cbor.py
+++ b/core/tests/test_apps.common.cbor.py
@@ -69,9 +69,10 @@ class TestCardanoCbor(unittest.TestCase):
             # null
             (None, 'f6'),
         ]
-        for val, encoded in test_vectors:
-            self.assertEqual(unhexlify(encoded), encode(val))
-            self.assertEqual(val, decode(unhexlify(encoded)))
+        for val, encoded_hex in test_vectors:
+            encoded = unhexlify(encoded_hex)
+            self.assertEqual(encode(val), encoded)
+            self.assertEqual(decode(encoded), val)
 
     def test_cbor_tuples(self):
         """
@@ -83,10 +84,11 @@ class TestCardanoCbor(unittest.TestCase):
             ([1, [2, 3], [4, 5]], '8301820203820405'),
             (list(range(1, 26)), '98190102030405060708090a0b0c0d0e0f101112131415161718181819'),
         ]
-        for val, encoded in test_vectors:
+        for val, encoded_hex in test_vectors:
             value_tuple = tuple(val)
-            self.assertEqual(unhexlify(encoded), encode(value_tuple))
-            self.assertEqual(val, decode(unhexlify(encoded)))
+            encoded = unhexlify(encoded_hex)
+            self.assertEqual(encode(value_tuple), encoded)
+            self.assertEqual(decode(encoded), val)
 
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
I was hoping that using a BufferReader for CBOR decoding would save some memory allocations and reduce fragmentation, but it turns out that there is practically no difference. In fact, it occasionally seems to add a few allocations, which we were not able to explain. Still, it makes the code a bit cleaner, so seems worth merging.