### PR TITLE
Improve error handling for msg_tiny

### DIFF
--- a/legacy/firmware/fsm.c
+++ b/legacy/firmware/fsm.c
@@ -67,7 +67,7 @@
 
 // message methods
 
-static uint8_t msg_resp[MSG_OUT_SIZE] __attribute__((aligned));
+static uint8_t msg_resp[MSG_OUT_DECODED_SIZE] __attribute__((aligned));
 
 #define RESP_INIT(TYPE)                                                    \
   TYPE *resp = (TYPE *)(void *)msg_resp;                                   \

--- a/legacy/firmware/messages.c
+++ b/legacy/firmware/messages.c
@@ -308,14 +308,28 @@ const uint8_t *msg_debug_out_data(void) {
 
 CONFIDENTIAL uint8_t msg_tiny[128];
 _Static_assert(sizeof(msg_tiny) >= sizeof(Cancel), "msg_tiny too tiny");
+_Static_assert(USB_PACKET_SIZE >= MSG_HEADER_SIZE + Cancel_size,
+               "msg_tiny too tiny");
 _Static_assert(sizeof(msg_tiny) >= sizeof(Initialize), "msg_tiny too tiny");
+_Static_assert(USB_PACKET_SIZE >= MSG_HEADER_SIZE + Initialize_size,
+               "msg_tiny too tiny");
 _Static_assert(sizeof(msg_tiny) >= sizeof(PassphraseAck), "msg_tiny too tiny");
+_Static_assert(USB_PACKET_SIZE >= MSG_HEADER_SIZE + PassphraseAck_size,
+               "msg_tiny too tiny");
 _Static_assert(sizeof(msg_tiny) >= sizeof(ButtonAck), "msg_tiny too tiny");
+_Static_assert(USB_PACKET_SIZE >= MSG_HEADER_SIZE + ButtonAck_size,
+               "msg_tiny too tiny");
 _Static_assert(sizeof(msg_tiny) >= sizeof(PinMatrixAck), "msg_tiny too tiny");
+_Static_assert(USB_PACKET_SIZE >= MSG_HEADER_SIZE + PinMatrixAck_size,
+               "msg_tiny too tiny");
 #if DEBUG_LINK
 _Static_assert(sizeof(msg_tiny) >= sizeof(DebugLinkDecision),
                "msg_tiny too tiny");
+_Static_assert(USB_PACKET_SIZE >= MSG_HEADER_SIZE + DebugLinkDecision_size,
+               "msg_tiny too tiny");
 _Static_assert(sizeof(msg_tiny) >= sizeof(DebugLinkGetState),
+               "msg_tiny too tiny");
+_Static_assert(USB_PACKET_SIZE >= MSG_HEADER_SIZE + DebugLinkGetState_size,
                "msg_tiny too tiny");
 #endif
 uint16_t msg_tiny_id = 0xFFFF;

--- a/legacy/firmware/messages.c
+++ b/legacy/firmware/messages.c
@@ -25,15 +25,11 @@
 #include "memzero.h"
 #include "messages.h"
 #include "trezor.h"
-#include "usb.h"
 #include "util.h"
 
 #include "messages.pb.h"
 #include "pb_decode.h"
 #include "pb_encode.h"
-
-// The size of the message header "?##<2 bytes msg_id><4 bytes msg_size>".
-#define MSG_HEADER_SIZE 9
 
 struct MessagesMap_t {
   char type;  // n = normal, d = debug
@@ -72,17 +68,22 @@ void MessageProcessFunc(char type, char dir, uint16_t msg_id, void *ptr) {
   }
 }
 
+// Buffer for outgoing USB packets.
 static uint32_t msg_out_start = 0;
 static uint32_t msg_out_end = 0;
 static uint32_t msg_out_cur = 0;
-static uint8_t msg_out[MSG_OUT_SIZE];
+static uint8_t msg_out[MSG_OUT_BUFFER_SIZE];
+_Static_assert(MSG_OUT_BUFFER_SIZE % USB_PACKET_SIZE == 0,
+               "MSG_OUT_BUFFER_SIZE");
 
 #if DEBUG_LINK
 
 static uint32_t msg_debug_out_start = 0;
 static uint32_t msg_debug_out_end = 0;
 static uint32_t msg_debug_out_cur = 0;
-static uint8_t msg_debug_out[MSG_DEBUG_OUT_SIZE];
+static uint8_t msg_debug_out[MSG_DEBUG_OUT_BUFFER_SIZE];
+_Static_assert(MSG_DEBUG_OUT_BUFFER_SIZE % USB_PACKET_SIZE == 0,
+               "MSG_DEBUG_OUT_BUFFER_SIZE");
 
 #endif
 
@@ -95,7 +96,7 @@ static inline void msg_out_append(uint8_t c) {
   msg_out_cur++;
   if (msg_out_cur == USB_PACKET_SIZE) {
     msg_out_cur = 0;
-    msg_out_end = (msg_out_end + 1) % (MSG_OUT_SIZE / USB_PACKET_SIZE);
+    msg_out_end = (msg_out_end + 1) % (MSG_OUT_BUFFER_SIZE / USB_PACKET_SIZE);
   }
 }
 
@@ -111,7 +112,7 @@ static inline void msg_debug_out_append(uint8_t c) {
   if (msg_debug_out_cur == USB_PACKET_SIZE) {
     msg_debug_out_cur = 0;
     msg_debug_out_end =
-        (msg_debug_out_end + 1) % (MSG_DEBUG_OUT_SIZE / USB_PACKET_SIZE);
+        (msg_debug_out_end + 1) % (MSG_DEBUG_OUT_BUFFER_SIZE / USB_PACKET_SIZE);
   }
 }
 
@@ -124,7 +125,7 @@ static inline void msg_out_pad(void) {
     msg_out_cur++;
   }
   msg_out_cur = 0;
-  msg_out_end = (msg_out_end + 1) % (MSG_OUT_SIZE / USB_PACKET_SIZE);
+  msg_out_end = (msg_out_end + 1) % (MSG_OUT_BUFFER_SIZE / USB_PACKET_SIZE);
 }
 
 #if DEBUG_LINK
@@ -137,7 +138,7 @@ static inline void msg_debug_out_pad(void) {
   }
   msg_debug_out_cur = 0;
   msg_debug_out_end =
-      (msg_debug_out_end + 1) % (MSG_DEBUG_OUT_SIZE / USB_PACKET_SIZE);
+      (msg_debug_out_end + 1) % (MSG_DEBUG_OUT_BUFFER_SIZE / USB_PACKET_SIZE);
 }
 
 #endif
@@ -219,13 +220,13 @@ enum {
 };
 
 void msg_process(char type, uint16_t msg_id, const pb_msgdesc_t *fields,
-                 uint8_t *msg_raw, uint32_t msg_size) {
-  static uint8_t msg_data[MSG_IN_SIZE];
-  memzero(msg_data, sizeof(msg_data));
-  pb_istream_t stream = pb_istream_from_buffer(msg_raw, msg_size);
-  bool status = pb_decode(&stream, fields, msg_data);
+                 uint8_t *msg_encoded, uint32_t msg_encoded_size) {
+  static uint8_t msg_decoded[MSG_IN_DECODED_SIZE];
+  memzero(msg_decoded, sizeof(msg_decoded));
+  pb_istream_t stream = pb_istream_from_buffer(msg_encoded, msg_encoded_size);
+  bool status = pb_decode(&stream, fields, msg_decoded);
   if (status) {
-    MessageProcessFunc(type, 'i', msg_id, msg_data);
+    MessageProcessFunc(type, 'i', msg_id, msg_decoded);
   } else {
     fsm_sendFailure(FailureType_Failure_DataError, stream.errmsg);
   }
@@ -233,9 +234,9 @@ void msg_process(char type, uint16_t msg_id, const pb_msgdesc_t *fields,
 
 void msg_read_common(char type, const uint8_t *buf, uint32_t len) {
   static char read_state = READSTATE_IDLE;
-  static uint8_t msg_in[MSG_IN_SIZE];
+  static uint8_t msg_encoded[MSG_IN_ENCODED_SIZE];
   static uint16_t msg_id = 0xFFFF;
-  static uint32_t msg_size = 0;
+  static uint32_t msg_encoded_size = 0;
   static uint32_t msg_pos = 0;
   static const pb_msgdesc_t *fields = 0;
 
@@ -247,7 +248,7 @@ void msg_read_common(char type, const uint8_t *buf, uint32_t len) {
       return;
     }
     msg_id = (buf[3] << 8) + buf[4];
-    msg_size =
+    msg_encoded_size =
         ((uint32_t)buf[5] << 24) + (buf[6] << 16) + (buf[7] << 8) + buf[8];
 
     fields = MessageFields(type, 'i', msg_id);
@@ -256,14 +257,14 @@ void msg_read_common(char type, const uint8_t *buf, uint32_t len) {
                       _("Unknown message"));
       return;
     }
-    if (msg_size > MSG_IN_SIZE) {  // message is too big :(
+    if (msg_encoded_size > MSG_IN_ENCODED_SIZE) {  // message is too big :(
       fsm_sendFailure(FailureType_Failure_DataError, _("Message too big"));
       return;
     }
 
     read_state = READSTATE_READING;
 
-    memcpy(msg_in, buf + MSG_HEADER_SIZE, len - MSG_HEADER_SIZE);
+    memcpy(msg_encoded, buf + MSG_HEADER_SIZE, len - MSG_HEADER_SIZE);
     msg_pos = len - MSG_HEADER_SIZE;
   } else if (read_state == READSTATE_READING) {
     if (buf[0] != '?') {  // invalid contents
@@ -272,14 +273,14 @@ void msg_read_common(char type, const uint8_t *buf, uint32_t len) {
     }
     /* raw data starts at buf + 1 with len - 1 bytes */
     buf++;
-    len = MIN(len - 1, MSG_IN_SIZE - msg_pos);
+    len = MIN(len - 1, MSG_IN_ENCODED_SIZE - msg_pos);
 
-    memcpy(msg_in + msg_pos, buf, len);
+    memcpy(msg_encoded + msg_pos, buf, len);
     msg_pos += len;
   }
 
-  if (msg_pos >= msg_size) {
-    msg_process(type, msg_id, fields, msg_in, msg_size);
+  if (msg_pos >= msg_encoded_size) {
+    msg_process(type, msg_id, fields, msg_encoded, msg_encoded_size);
     msg_pos = 0;
     read_state = READSTATE_IDLE;
   }
@@ -288,7 +289,7 @@ void msg_read_common(char type, const uint8_t *buf, uint32_t len) {
 const uint8_t *msg_out_data(void) {
   if (msg_out_start == msg_out_end) return 0;
   uint8_t *data = msg_out + (msg_out_start * USB_PACKET_SIZE);
-  msg_out_start = (msg_out_start + 1) % (MSG_OUT_SIZE / USB_PACKET_SIZE);
+  msg_out_start = (msg_out_start + 1) % (MSG_OUT_BUFFER_SIZE / USB_PACKET_SIZE);
   debugLog(0, "", "msg_out_data");
   return data;
 }
@@ -299,7 +300,7 @@ const uint8_t *msg_debug_out_data(void) {
   if (msg_debug_out_start == msg_debug_out_end) return 0;
   uint8_t *data = msg_debug_out + (msg_debug_out_start * USB_PACKET_SIZE);
   msg_debug_out_start =
-      (msg_debug_out_start + 1) % (MSG_DEBUG_OUT_SIZE / USB_PACKET_SIZE);
+      (msg_debug_out_start + 1) % (MSG_DEBUG_OUT_BUFFER_SIZE / USB_PACKET_SIZE);
   debugLog(0, "", "msg_debug_out_data");
   return data;
 }

--- a/legacy/firmware/messages.h
+++ b/legacy/firmware/messages.h
@@ -23,10 +23,28 @@
 #include <stdbool.h>
 #include <stdint.h>
 #include "trezor.h"
+#include "usb.h"
 
-#define MSG_IN_SIZE (15 * 1024)
+// The size of the message header "?##<2 bytes msg_id><4 bytes msg_size>".
+#define MSG_HEADER_SIZE 9
 
-#define MSG_OUT_SIZE (3 * 1024)
+// Maximum size of an incoming protobuf-encoded message without headers.
+#define MSG_IN_ENCODED_SIZE (15 * 1024)
+
+// Maximum size of a C struct containing a decoded incoming message.
+#define MSG_IN_DECODED_SIZE (15 * 1024)
+
+// Buffer size for outgoing USB packets with headers.
+#define MSG_OUT_BUFFER_SIZE (3 * 1024)
+
+// Maximum size of an outgoing protobuf-encoded message without headers.
+// (Continuation packets have a one byte "?" header.)
+#define MSG_OUT_ENCODED_SIZE               \
+  (MSG_OUT_BUFFER_SIZE - MSG_HEADER_SIZE - \
+   ((MSG_OUT_BUFFER_SIZE / USB_PACKET_SIZE) - 1))
+
+// Maximum size of a C struct containing a decoded outgoing message.
+#define MSG_OUT_DECODED_SIZE (3 * 1024)
 
 #define msg_read(buf, len) msg_read_common('n', (buf), (len))
 #define msg_write(id, ptr) msg_write_common('n', (id), (ptr))
@@ -34,7 +52,14 @@ const uint8_t *msg_out_data(void);
 
 #if DEBUG_LINK
 
-#define MSG_DEBUG_OUT_SIZE (2 * 1024)
+// Buffer size for outgoing debuglink USB packets with headers.
+#define MSG_DEBUG_OUT_BUFFER_SIZE (2 * 1024)
+
+// Maximum size of an outgoing protobuf-encoded debug message without headers.
+// (Continuation packets have a one byte "?" header.)
+#define MSG_DEBUG_OUT_ENCODED_SIZE               \
+  (MSG_DEBUG_OUT_BUFFER_SIZE - MSG_HEADER_SIZE - \
+   ((MSG_DEBUG_OUT_BUFFER_SIZE / USB_PACKET_SIZE) - 1))
 
 #define msg_debug_read(buf, len) msg_read_common('d', (buf), (len))
 #define msg_debug_write(id, ptr) msg_write_common('d', (id), (ptr))

--- a/legacy/firmware/protob/Makefile
+++ b/legacy/firmware/protob/Makefile
@@ -5,7 +5,7 @@ endif
 SKIPPED_MESSAGES := Binance Cardano DebugMonero Eos Monero Ontology Ripple SdProtect Tezos WebAuthn \
 	DebugLinkRecordScreen DebugLinkReseedRandom DebugLinkShowText DebugLinkEraseSdCard DebugLinkWatchLayout \
 	GetOwnershipProof OwnershipProof GetOwnershipId OwnershipId AuthorizeCoinJoin DoPreauthorized \
-	CancelAuthorization \
+	CancelAuthorization DebugLinkLayout \
 	TxAckInput TxAckOutput TxAckPrev
 
 ifeq ($(BITCOIN_ONLY), 1)

--- a/legacy/firmware/protob/messages-bitcoin.options
+++ b/legacy/firmware/protob/messages-bitcoin.options
@@ -55,23 +55,6 @@ MultisigRedeemScriptType.address_n                          max_count:8
 
 HDNodePathType.address_n                                    max_count:8
 
-GetOwnershipProof.address_n                                 max_count:8
-GetOwnershipProof.coin_name                                 max_size:21
-GetOwnershipProof.ownership_ids                             max_count:15 max_size:32
-GetOwnershipProof.commitment_data                           max_size:32
-
-OwnershipProof.ownership_proof                              max_size:171
-OwnershipProof.signature                                    max_size:65
-
-GetOwnershipId.address_n                                    max_count:8
-GetOwnershipId.coin_name                                    max_size:21
-
-OwnershipId.ownership_id                                    max_size:32
-
-AuthorizeCoinJoin.coordinator                               max_size:18
-AuthorizeCoinJoin.address_n                                 max_count:8
-AuthorizeCoinJoin.coin_name                                 max_size:21
-
 TxInput.address_n                                           max_count:8
 TxInput.prev_hash                                           max_size:32
 TxInput.script_sig                                          max_size:1650
@@ -90,4 +73,11 @@ PrevInput.script_sig                                        max_size:1650
 
 PrevOutput.script_pubkey                                    max_size:520
 
-TxAckPrevExtraDataWrapper.extra_data_chunk                  max_size:1024
+TxAckPrevExtraDataWrapper.extra_data_chunk                  type:FT_IGNORE
+
+# Unused messages.
+AuthorizeCoinJoin                                           skip_message:true
+GetOwnershipId                                              skip_message:true
+OwnershipId                                                 skip_message:true
+GetOwnershipProof                                           skip_message:true
+OwnershipProof                                              skip_message:true

--- a/legacy/firmware/protob/messages-common.options
+++ b/legacy/firmware/protob/messages-common.options
@@ -6,7 +6,8 @@ PinMatrixAck.pin                        max_size:10
 
 PassphraseAck.passphrase                max_size:51
 
-PassphraseAck._state                    max_size:1
+PassphraseAck._state                    type:FT_IGNORE
+
 Deprecated_PassphraseStateRequest.state max_size:1
 
 HDNodeType.chain_code   max_size:32

--- a/legacy/firmware/protob/messages-debug.options
+++ b/legacy/firmware/protob/messages-debug.options
@@ -1,4 +1,6 @@
 DebugLinkDecision.input                 max_size:33
+DebugLinkDecision.x                     type:FT_IGNORE
+DebugLinkDecision.y                     type:FT_IGNORE
 
 DebugLinkState.layout                   max_size:1024
 DebugLinkState.pin                      max_size:10
@@ -7,6 +9,7 @@ DebugLinkState.mnemonic_secret          max_size:240
 DebugLinkState.reset_word               max_size:12
 DebugLinkState.reset_entropy            max_size:128
 DebugLinkState.recovery_fake_word       max_size:12
+DebugLinkState.layout_lines             type:FT_IGNORE
 
 DebugLinkLog.bucket                     max_size:33
 DebugLinkLog.text                       max_size:256
@@ -14,12 +17,8 @@ DebugLinkLog.text                       max_size:256
 DebugLinkMemory.memory                  max_size:1024
 DebugLinkMemoryWrite.memory             max_size:1024
 
-# unused fields
-DebugLinkState.layout_lines             max_count:10 max_size:30
-DebugLinkLayout.lines                   max_count:10 max_size:30
-DebugLinkRecordScreen.target_directory  max_size:1
-DebugLinkShowText.header_text           max_size:1
-DebugLinkShowText.body_text             max_count:1
-DebugLinkShowText.header_icon           max_size:1
-DebugLinkShowText.icon_color            max_size:1
-DebugLinkShowTextItem.content           max_size:1
+# Unused messages.
+DebugLinkLayout                         skip_message:true
+DebugLinkRecordScreen                   skip_message:true
+DebugLinkShowText                       skip_message:true
+DebugLinkShowTextItem                   skip_message:true

--- a/legacy/firmware/protob/messages_map.py
+++ b/legacy/firmware/protob/messages_map.py
@@ -82,18 +82,29 @@ def handle_message(fh, fl, skipped, message):
         )
     )
 
-    bufsize = None
+    encoded_size = None
+    decoded_size = None
     t = interface + direction
     if t == "ni":
-        bufsize = "MSG_IN_SIZE"
+        encoded_size = "MSG_IN_ENCODED_SIZE"
+        decoded_size = "MSG_IN_DECODED_SIZE"
     elif t == "no":
-        bufsize = "MSG_OUT_SIZE"
+        encoded_size = "MSG_OUT_ENCODED_SIZE"
+        decoded_size = "MSG_OUT_DECODED_SIZE"
     elif t == "do":
-        bufsize = "MSG_DEBUG_OUT_SIZE"
-    if bufsize:
+        encoded_size = "MSG_DEBUG_OUT_ENCODED_SIZE"
+        decoded_size = "MSG_OUT_DECODED_SIZE"
+
+    if encoded_size:
+        fl.write(
+            '_Static_assert(%s >= sizeof(%s_size), "msg buffer too small");\n'
+            % (encoded_size, short_name)
+        )
+
+    if decoded_size:
         fl.write(
             '_Static_assert(%s >= sizeof(%s), "msg buffer too small");\n'
-            % (bufsize, short_name)
+            % (decoded_size, short_name)
         )
 
 

--- a/legacy/firmware/udp.c
+++ b/legacy/firmware/udp.c
@@ -38,7 +38,7 @@ void usbInit(void) { emulatorSocketInit(); }
 void usbPoll(void) {
   emulatorPoll();
 
-  static uint8_t buffer[64];
+  static uint8_t buffer[USB_PACKET_SIZE];
 
   int iface = 0;
   if (emulatorSocketRead(&iface, buffer, sizeof(buffer)) > 0) {
@@ -51,13 +51,13 @@ void usbPoll(void) {
 
   const uint8_t *data = msg_out_data();
   if (data != NULL) {
-    emulatorSocketWrite(0, data, 64);
+    emulatorSocketWrite(0, data, USB_PACKET_SIZE);
   }
 
 #if DEBUG_LINK
   data = msg_debug_out_data();
   if (data != NULL) {
-    emulatorSocketWrite(1, data, 64);
+    emulatorSocketWrite(1, data, USB_PACKET_SIZE);
   }
 #endif
 }

--- a/legacy/firmware/usb.c
+++ b/legacy/firmware/usb.c
@@ -91,7 +91,7 @@ static const struct usb_device_descriptor dev_descr = {
     .bDeviceClass = 0,
     .bDeviceSubClass = 0,
     .bDeviceProtocol = 0,
-    .bMaxPacketSize0 = 64,
+    .bMaxPacketSize0 = USB_PACKET_SIZE,
     .idVendor = 0x1209,
     .idProduct = 0x53c1,
     .bcdDevice = 0x0100,
@@ -148,7 +148,7 @@ static const struct usb_endpoint_descriptor hid_endpoints_u2f[2] = {
         .bDescriptorType = USB_DT_ENDPOINT,
         .bEndpointAddress = ENDPOINT_ADDRESS_U2F_IN,
         .bmAttributes = USB_ENDPOINT_ATTR_INTERRUPT,
-        .wMaxPacketSize = 64,
+        .wMaxPacketSize = USB_PACKET_SIZE,
         .bInterval = 1,
     },
     {
@@ -156,7 +156,7 @@ static const struct usb_endpoint_descriptor hid_endpoints_u2f[2] = {
         .bDescriptorType = USB_DT_ENDPOINT,
         .bEndpointAddress = ENDPOINT_ADDRESS_U2F_OUT,
         .bmAttributes = USB_ENDPOINT_ATTR_INTERRUPT,
-        .wMaxPacketSize = 64,
+        .wMaxPacketSize = USB_PACKET_SIZE,
         .bInterval = 1,
     }};
 
@@ -185,7 +185,7 @@ static const struct usb_endpoint_descriptor webusb_endpoints_debug[2] = {
         .bDescriptorType = USB_DT_ENDPOINT,
         .bEndpointAddress = ENDPOINT_ADDRESS_DEBUG_IN,
         .bmAttributes = USB_ENDPOINT_ATTR_INTERRUPT,
-        .wMaxPacketSize = 64,
+        .wMaxPacketSize = USB_PACKET_SIZE,
         .bInterval = 1,
     },
     {
@@ -193,7 +193,7 @@ static const struct usb_endpoint_descriptor webusb_endpoints_debug[2] = {
         .bDescriptorType = USB_DT_ENDPOINT,
         .bEndpointAddress = ENDPOINT_ADDRESS_DEBUG_OUT,
         .bmAttributes = USB_ENDPOINT_ATTR_INTERRUPT,
-        .wMaxPacketSize = 64,
+        .wMaxPacketSize = USB_PACKET_SIZE,
         .bInterval = 1,
     }};
 
@@ -220,7 +220,7 @@ static const struct usb_endpoint_descriptor webusb_endpoints_main[2] = {
         .bDescriptorType = USB_DT_ENDPOINT,
         .bEndpointAddress = ENDPOINT_ADDRESS_MAIN_IN,
         .bmAttributes = USB_ENDPOINT_ATTR_INTERRUPT,
-        .wMaxPacketSize = 64,
+        .wMaxPacketSize = USB_PACKET_SIZE,
         .bInterval = 1,
     },
     {
@@ -228,7 +228,7 @@ static const struct usb_endpoint_descriptor webusb_endpoints_main[2] = {
         .bDescriptorType = USB_DT_ENDPOINT,
         .bEndpointAddress = ENDPOINT_ADDRESS_MAIN_OUT,
         .bmAttributes = USB_ENDPOINT_ATTR_INTERRUPT,
-        .wMaxPacketSize = 64,
+        .wMaxPacketSize = USB_PACKET_SIZE,
         .bInterval = 1,
     }};
 
@@ -303,10 +303,12 @@ static enum usbd_request_return_codes hid_control_request(
 
 static void u2f_rx_callback(usbd_device *dev, uint8_t ep) {
   (void)ep;
-  static CONFIDENTIAL uint8_t buf[64] __attribute__((aligned(4)));
+  static CONFIDENTIAL uint8_t buf[USB_PACKET_SIZE] __attribute__((aligned(4)));
 
   debugLog(0, "", "u2f_rx_callback");
-  if (usbd_ep_read_packet(dev, ENDPOINT_ADDRESS_U2F_OUT, buf, 64) != 64) return;
+  if (usbd_ep_read_packet(dev, ENDPOINT_ADDRESS_U2F_OUT, buf, sizeof(buf)) !=
+      USB_PACKET_SIZE)
+    return;
   u2fhid_read(tiny, (const U2FHID_FRAME *)(void *)buf);
 }
 
@@ -314,14 +316,15 @@ static void u2f_rx_callback(usbd_device *dev, uint8_t ep) {
 
 static void main_rx_callback(usbd_device *dev, uint8_t ep) {
   (void)ep;
-  static CONFIDENTIAL uint8_t buf[64] __attribute__((aligned(4)));
-  if (usbd_ep_read_packet(dev, ENDPOINT_ADDRESS_MAIN_OUT, buf, 64) != 64)
+  static CONFIDENTIAL uint8_t buf[USB_PACKET_SIZE] __attribute__((aligned(4)));
+  if (usbd_ep_read_packet(dev, ENDPOINT_ADDRESS_MAIN_OUT, buf, sizeof(buf)) !=
+      USB_PACKET_SIZE)
     return;
   debugLog(0, "", "main_rx_callback");
   if (!tiny) {
-    msg_read(buf, 64);
+    msg_read(buf, sizeof(buf));
   } else {
-    msg_read_tiny(buf, 64);
+    msg_read_tiny(buf, sizeof(buf));
   }
 }
 
@@ -329,14 +332,15 @@ static void main_rx_callback(usbd_device *dev, uint8_t ep) {
 
 static void debug_rx_callback(usbd_device *dev, uint8_t ep) {
   (void)ep;
-  static uint8_t buf[64] __attribute__((aligned(4)));
-  if (usbd_ep_read_packet(dev, ENDPOINT_ADDRESS_DEBUG_OUT, buf, 64) != 64)
+  static uint8_t buf[USB_PACKET_SIZE] __attribute__((aligned(4)));
+  if (usbd_ep_read_packet(dev, ENDPOINT_ADDRESS_DEBUG_OUT, buf, sizeof(buf)) !=
+      USB_PACKET_SIZE)
     return;
   debugLog(0, "", "debug_rx_callback");
   if (!tiny) {
-    msg_debug_read(buf, 64);
+    msg_debug_read(buf, sizeof(buf));
   } else {
-    msg_read_tiny(buf, 64);
+    msg_read_tiny(buf, sizeof(buf));
   }
 }
 
@@ -345,21 +349,21 @@ static void debug_rx_callback(usbd_device *dev, uint8_t ep) {
 static void set_config(usbd_device *dev, uint16_t wValue) {
   (void)wValue;
 
-  usbd_ep_setup(dev, ENDPOINT_ADDRESS_MAIN_IN, USB_ENDPOINT_ATTR_INTERRUPT, 64,
-                0);
-  usbd_ep_setup(dev, ENDPOINT_ADDRESS_MAIN_OUT, USB_ENDPOINT_ATTR_INTERRUPT, 64,
-                main_rx_callback);
+  usbd_ep_setup(dev, ENDPOINT_ADDRESS_MAIN_IN, USB_ENDPOINT_ATTR_INTERRUPT,
+                USB_PACKET_SIZE, 0);
+  usbd_ep_setup(dev, ENDPOINT_ADDRESS_MAIN_OUT, USB_ENDPOINT_ATTR_INTERRUPT,
+                USB_PACKET_SIZE, main_rx_callback);
 #if U2F_ENABLED
-  usbd_ep_setup(dev, ENDPOINT_ADDRESS_U2F_IN, USB_ENDPOINT_ATTR_INTERRUPT, 64,
-                0);
-  usbd_ep_setup(dev, ENDPOINT_ADDRESS_U2F_OUT, USB_ENDPOINT_ATTR_INTERRUPT, 64,
-                u2f_rx_callback);
+  usbd_ep_setup(dev, ENDPOINT_ADDRESS_U2F_IN, USB_ENDPOINT_ATTR_INTERRUPT,
+                USB_PACKET_SIZE, 0);
+  usbd_ep_setup(dev, ENDPOINT_ADDRESS_U2F_OUT, USB_ENDPOINT_ATTR_INTERRUPT,
+                USB_PACKET_SIZE, u2f_rx_callback);
 #endif
 #if DEBUG_LINK
-  usbd_ep_setup(dev, ENDPOINT_ADDRESS_DEBUG_IN, USB_ENDPOINT_ATTR_INTERRUPT, 64,
-                0);
+  usbd_ep_setup(dev, ENDPOINT_ADDRESS_DEBUG_IN, USB_ENDPOINT_ATTR_INTERRUPT,
+                USB_PACKET_SIZE, 0);
   usbd_ep_setup(dev, ENDPOINT_ADDRESS_DEBUG_OUT, USB_ENDPOINT_ATTR_INTERRUPT,
-                64, debug_rx_callback);
+                USB_PACKET_SIZE, debug_rx_callback);
 #endif
 #if U2F_ENABLED
   usbd_register_control_callback(
@@ -406,15 +410,15 @@ void usbPoll(void) {
   // write pending data
   data = msg_out_data();
   if (data) {
-    while (usbd_ep_write_packet(usbd_dev, ENDPOINT_ADDRESS_MAIN_IN, data, 64) !=
-           64) {
+    while (usbd_ep_write_packet(usbd_dev, ENDPOINT_ADDRESS_MAIN_IN, data,
+                                USB_PACKET_SIZE) != USB_PACKET_SIZE) {
     }
   }
 #if U2F_ENABLED
   data = u2f_out_data();
   if (data) {
-    while (usbd_ep_write_packet(usbd_dev, ENDPOINT_ADDRESS_U2F_IN, data, 64) !=
-           64) {
+    while (usbd_ep_write_packet(usbd_dev, ENDPOINT_ADDRESS_U2F_IN, data,
+                                USB_PACKET_SIZE) != USB_PACKET_SIZE) {
     }
   }
 #endif
@@ -423,7 +427,7 @@ void usbPoll(void) {
   data = msg_debug_out_data();
   if (data) {
     while (usbd_ep_write_packet(usbd_dev, ENDPOINT_ADDRESS_DEBUG_IN, data,
-                                64) != 64) {
+                                USB_PACKET_SIZE) != USB_PACKET_SIZE) {
     }
   }
 #endif

--- a/legacy/firmware/usb.h
+++ b/legacy/firmware/usb.h
@@ -20,6 +20,8 @@
 #ifndef __USB_H__
 #define __USB_H__
 
+#define USB_PACKET_SIZE 64
+
 void usbInit(void);
 void usbPoll(void);
 void usbReconnect(void);


### PR DESCRIPTION
Fixes https://github.com/trezor/trezor-firmware/issues/1460.

beb64e9: Replaces the magic number 64 in with USB_PACKET_SIZE in a number of places. This would be very helpful for code legibility. I hope I didn't replace any of the magic values incorrectly. @prusnak please check.
5eefe07: Adds compile-time checks for msg_tiny sizes.
2802060: It seems to me that `msg_read_tiny()` should respond with a Failure message when the received packet is malformed, similar to what the code further down the function does. This would make debugging a bit easier, because returning basically causes the emulator to hang there and the test suite to wait for a response. Are there some instances where it makes sense to return from the function without sending a Failure message @prusnak?