### PR TITLE
feat(python): add possibility to enter PIN via letters

### DIFF
--- a/python/CHANGELOG.md
+++ b/python/CHANGELOG.md
@@ -13,6 +13,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Enabled session management via `EndSession`  [#1227]
 - Support for temporary or permanent `safety-checks` setting
 - Support for Output Descriptors export [#1363]
+- PIN entry via letters  [#1496]
 
 ### Changed
 
@@ -514,3 +515,4 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 [#1232]: https://github.com/trezor/trezor-firmware/issues/1232
 [#1266]: https://github.com/trezor/trezor-firmware/issues/1266
 [#1363]: https://github.com/trezor/trezor-firmware/pull/1363
+[#1496]: https://github.com/trezor/trezor-firmware/pull/1496

--- a/python/src/trezorlib/ui.py
+++ b/python/src/trezorlib/ui.py
@@ -25,10 +25,13 @@ from .exceptions import Cancelled
 from .messages import PinMatrixRequestType, WordRequestType
 
 PIN_MATRIX_DESCRIPTION = """
-Use the numeric keypad to describe number positions. The layout is:
-    7 8 9
-    4 5 6
-    1 2 3
+Use the numeric keypad or lowercase letters to describe number positions.
+
+The layout is:
+
+    7 8 9        e r t
+    4 5 6  -or-  d f g
+    1 2 3        c v b
 """.strip()
 
 RECOVERY_MATRIX_DESCRIPTION = """
@@ -95,8 +98,15 @@ class ClickUI:
                 pin = prompt("Please enter {}".format(desc), hide_input=True)
             except click.Abort:
                 raise Cancelled from None
+
+            # translate letters to numbers if letters were used
+            if all(d in "cvbdfgert" for d in pin):
+                pin = pin.translate(str.maketrans("cvbdfgert", "123456789"))
+
             if any(d not in "123456789" for d in pin):
-                echo("The value may only consist of digits 1 to 9.")
+                echo(
+                    "The value may only consist of digits 1 to 9 or letters cvbdfgert."
+                )
             elif len(pin) > 9:
                 echo("The value must be at most 9 digits in length.")
             else:


### PR DESCRIPTION
When I enter the PIN on computer without the numeric keypad (most of the laptops), the operation is quite tedious.

Let's allow also PIN entry via (lowercase) letters.

I chose the following layout for couple of reasons:

```
e r t
d f g
c v b
```

* this layout avoids using Y/Z keys which are commonly swapped on localized keyboard layouts (qwerty vs qwertz)
* this layout avoids using AS/QW keys which are commonly swapped on localized keyboard layouts (qwerty vs azerty)