### PR TITLE
test: wait longer for autolock

### DIFF
--- a/tests/device_tests/test_autolock.py
+++ b/tests/device_tests/test_autolock.py
@@ -59,7 +59,7 @@ def test_apply_auto_lock_delay(client):
         client.set_expected_responses([messages.Address])
         get_test_address(client)
 
-    time.sleep(10.1)  # sleep more than auto-lock delay
+    time.sleep(10.5)  # sleep more than auto-lock delay
     with client:
         client.use_pin_sequence([PIN4])
         client.set_expected_responses([pin_request(client), messages.Address])
@@ -127,7 +127,7 @@ def test_autolock_cancels_ui(client):
     # send an ack, do not read response
     client._raw_write(messages.ButtonAck())
     # sleep more than auto-lock delay
-    time.sleep(10.1)
+    time.sleep(10.5)
     resp = client._raw_read()
 
     assert isinstance(resp, messages.Failure)

--- a/tests/device_tests/test_msg_wipedevice.py
+++ b/tests/device_tests/test_msg_wipedevice.py
@@ -55,7 +55,7 @@ def test_autolock_not_retained(client):
         client.use_pin_sequence([PIN4, PIN4])
         device.reset(client, skip_backup=True, pin_protection=True)
 
-    time.sleep(10.1)
+    time.sleep(10.5)
     with client:
         # after sleeping for the pre-wipe autolock amount, Trezor must still be unlocked
         client.set_expected_responses([messages.Address])


### PR DESCRIPTION
We've probably hit a race condition in https://gitlab.com/satoshilabs/trezor/trezor-firmware/-/jobs/1045486303

Increase the sleep a bit to reduce probability of this happening again.