### PR TITLE
feat:Add Solana coin definition

### DIFF
--- a/common/defs/misc/misc.json
+++ b/common/defs/misc/misc.json
@@ -189,5 +189,19 @@
             "Homepage": "https://tether.to"
         },
         "wallet": {}
+    },
+    {
+        "name": "Solana",
+        "shortcut": "SOL",
+        "slip44": 501,
+        "curve": "ed25519",
+        "decimals": 9,
+        "links": {
+            "Homepage": "https://solana.com/",
+            "Github": "https://github.com/solana-labs/solana"
+        },
+        "wallet": {
+            "sollet.io": "https://www.sollet.io"
+        }
     }
 ]


### PR DESCRIPTION
This PR adds a definition for Solana coin.  What else is need to support signing Solana transactions?

Solana uses ed25519.  It is currently 19 on coinmarketcap.  https://coinmarketcap.com/currencies/solana/  There is a web wallet for Solana at https://www.sollet.io/.

See also this Solana issue to add support for Trezor to Solana's command line tools: https://github.com/solana-labs/solana/issues/4911