### PR TITLE
allow using all four USB endpoints at the same time

### DIFF
--- a/core/embed/trezorhal/usbd_conf.c
+++ b/core/embed/trezorhal/usbd_conf.c
@@ -427,7 +427,7 @@ USBD_StatusTypeDef  USBD_LL_Init (USBD_HandleTypeDef *pdev)
     HAL_PCD_Init(&pcd_hs_handle);
 
     // use 130 + 149 * 6 = the 1024 32-bit words in the USB OTG_HS data RAM
-    HAL_PCDEx_SetRxFiFo(&pcd_hs_handle, 130); // 128 32-bit words
+    HAL_PCDEx_SetRxFiFo(&pcd_hs_handle, 130); // 130 32-bit words
     HAL_PCDEx_SetTxFiFo(&pcd_hs_handle, 0, 149); // 149 32-bit words
     HAL_PCDEx_SetTxFiFo(&pcd_hs_handle, 1, 149); // 149 32-bit words
     HAL_PCDEx_SetTxFiFo(&pcd_hs_handle, 2, 149); // 149 32-bit words

--- a/core/embed/trezorhal/usbd_conf.c
+++ b/core/embed/trezorhal/usbd_conf.c
@@ -426,13 +426,13 @@ USBD_StatusTypeDef  USBD_LL_Init (USBD_HandleTypeDef *pdev)
     /* Initialize LL Driver */
     HAL_PCD_Init(&pcd_hs_handle);
 
-    HAL_PCDEx_SetRxFiFo(&pcd_hs_handle, 0x2e);
-    HAL_PCDEx_SetTxFiFo(&pcd_hs_handle, 0, 0xa3);
-    HAL_PCDEx_SetTxFiFo(&pcd_hs_handle, 1, 0xa3);
-    HAL_PCDEx_SetTxFiFo(&pcd_hs_handle, 2, 0xa3);
-    HAL_PCDEx_SetTxFiFo(&pcd_hs_handle, 3, 0xa3);
-    HAL_PCDEx_SetTxFiFo(&pcd_hs_handle, 4, 0xa3);
-    HAL_PCDEx_SetTxFiFo(&pcd_hs_handle, 5, 0xa3);
+    HAL_PCDEx_SetRxFiFo(&pcd_hs_handle, 1024); // 1024 32-bit words (4KiB)
+    HAL_PCDEx_SetTxFiFo(&pcd_hs_handle, 0, 256); // 256 32-bit words (1KiB)
+    HAL_PCDEx_SetTxFiFo(&pcd_hs_handle, 1, 512); // 512 32-bit words (2KiB)
+    HAL_PCDEx_SetTxFiFo(&pcd_hs_handle, 2, 512); // 512 32-bit words (2KiB)
+    HAL_PCDEx_SetTxFiFo(&pcd_hs_handle, 3, 512); // 512 32-bit words (2KiB)
+    HAL_PCDEx_SetTxFiFo(&pcd_hs_handle, 4, 512); // 512 32-bit words (2KiB)
+    HAL_PCDEx_SetTxFiFo(&pcd_hs_handle, 5, 512); // 512 32-bit words (2KiB)
   }
   return USBD_OK;
 }

--- a/core/embed/trezorhal/usbd_conf.c
+++ b/core/embed/trezorhal/usbd_conf.c
@@ -426,13 +426,14 @@ USBD_StatusTypeDef  USBD_LL_Init (USBD_HandleTypeDef *pdev)
     /* Initialize LL Driver */
     HAL_PCD_Init(&pcd_hs_handle);
 
-    HAL_PCDEx_SetRxFiFo(&pcd_hs_handle, 1024); // 1024 32-bit words (4KiB)
-    HAL_PCDEx_SetTxFiFo(&pcd_hs_handle, 0, 256); // 256 32-bit words (1KiB)
-    HAL_PCDEx_SetTxFiFo(&pcd_hs_handle, 1, 512); // 512 32-bit words (2KiB)
-    HAL_PCDEx_SetTxFiFo(&pcd_hs_handle, 2, 512); // 512 32-bit words (2KiB)
-    HAL_PCDEx_SetTxFiFo(&pcd_hs_handle, 3, 512); // 512 32-bit words (2KiB)
-    HAL_PCDEx_SetTxFiFo(&pcd_hs_handle, 4, 512); // 512 32-bit words (2KiB)
-    HAL_PCDEx_SetTxFiFo(&pcd_hs_handle, 5, 512); // 512 32-bit words (2KiB)
+    // use 130 + 149 * 6 = the 1024 32-bit words in the USB OTG_HS data RAM
+    HAL_PCDEx_SetRxFiFo(&pcd_hs_handle, 130); // 128 32-bit words
+    HAL_PCDEx_SetTxFiFo(&pcd_hs_handle, 0, 149); // 149 32-bit words
+    HAL_PCDEx_SetTxFiFo(&pcd_hs_handle, 1, 149); // 149 32-bit words
+    HAL_PCDEx_SetTxFiFo(&pcd_hs_handle, 2, 149); // 149 32-bit words
+    HAL_PCDEx_SetTxFiFo(&pcd_hs_handle, 3, 149); // 149 32-bit words
+    HAL_PCDEx_SetTxFiFo(&pcd_hs_handle, 4, 149); // 149 32-bit words
+    HAL_PCDEx_SetTxFiFo(&pcd_hs_handle, 5, 149); // 149 32-bit words
   }
   return USBD_OK;
 }

--- a/core/embed/trezorhal/usbd_conf.c
+++ b/core/embed/trezorhal/usbd_conf.c
@@ -406,103 +406,34 @@ void HAL_PCD_DisconnectCallback(PCD_HandleTypeDef *hpcd)
   */
 USBD_StatusTypeDef  USBD_LL_Init (USBD_HandleTypeDef *pdev)
 {
-#if defined(USE_USB_FS)
-if (pdev->id ==  USB_PHY_FS_ID)
-{
-  /*Set LL Driver parameters */
-  pcd_fs_handle.Instance = USB_OTG_FS;
-  pcd_fs_handle.Init.dev_endpoints = 4;
-  pcd_fs_handle.Init.use_dedicated_ep1 = 0;
-  pcd_fs_handle.Init.ep0_mps = 0x40;
-  pcd_fs_handle.Init.dma_enable = 0;
-  pcd_fs_handle.Init.low_power_enable = 0;
-  pcd_fs_handle.Init.phy_itface = PCD_PHY_EMBEDDED;
-  pcd_fs_handle.Init.Sof_enable = 1;
-  pcd_fs_handle.Init.speed = PCD_SPEED_FULL;
-#if defined(MCU_SERIES_L4)
-  pcd_fs_handle.Init.lpm_enable = DISABLE;
-  pcd_fs_handle.Init.battery_charging_enable = DISABLE;
-#endif
-#if !defined(MICROPY_HW_USB_VBUS_DETECT_PIN)
-  pcd_fs_handle.Init.vbus_sensing_enable = 0; // No VBUS Sensing on USB0
-#else
-  pcd_fs_handle.Init.vbus_sensing_enable = 1;
-#endif
-  /* Link The driver to the stack */
-  pcd_fs_handle.pData = pdev;
-  pdev->pData = &pcd_fs_handle;
-  /*Initialize LL Driver */
-  HAL_PCD_Init(&pcd_fs_handle);
+  if (pdev->id == USB_PHY_HS_ID) {
+    /* Set LL Driver parameters */
+    pcd_hs_handle.Instance = USB_OTG_HS;
+    pcd_hs_handle.Init.dev_endpoints = 6;
+    pcd_hs_handle.Init.use_dedicated_ep1 = 0;
 
-  HAL_PCDEx_SetRxFiFo(&pcd_fs_handle, 0x80);
-  HAL_PCDEx_SetTxFiFo(&pcd_fs_handle, 0, 0x20);
-  HAL_PCDEx_SetTxFiFo(&pcd_fs_handle, 1, 0x40);
-  HAL_PCDEx_SetTxFiFo(&pcd_fs_handle, 2, 0x20);
-  HAL_PCDEx_SetTxFiFo(&pcd_fs_handle, 3, 0x40);
-}
-#endif
-#if defined(USE_USB_HS)
-if (pdev->id == USB_PHY_HS_ID)
-{
-#if defined(USE_USB_HS_IN_FS)
-  /*Set LL Driver parameters */
-  pcd_hs_handle.Instance = USB_OTG_HS;
-  pcd_hs_handle.Init.dev_endpoints = 4;
-  pcd_hs_handle.Init.use_dedicated_ep1 = 0;
-  pcd_hs_handle.Init.ep0_mps = 0x40;
-  pcd_hs_handle.Init.dma_enable = 0;
-  pcd_hs_handle.Init.low_power_enable = 0;
-  pcd_hs_handle.Init.phy_itface = PCD_PHY_EMBEDDED;
-  pcd_hs_handle.Init.Sof_enable = 1;
-  pcd_hs_handle.Init.speed = PCD_SPEED_HIGH_IN_FULL;
-#if !defined(MICROPY_HW_USB_VBUS_DETECT_PIN)
-  pcd_hs_handle.Init.vbus_sensing_enable = 0; // No VBUS Sensing on USB0
-#else
-  pcd_hs_handle.Init.vbus_sensing_enable = 1;
-#endif
-  /* Link The driver to the stack */
-  pcd_hs_handle.pData = pdev;
-  pdev->pData = &pcd_hs_handle;
-  /*Initialize LL Driver */
-  HAL_PCD_Init(&pcd_hs_handle);
+    pcd_hs_handle.Init.ep0_mps = 0x40;
+    pcd_hs_handle.Init.dma_enable = 0;
+    pcd_hs_handle.Init.low_power_enable = 0;
 
-  HAL_PCDEx_SetRxFiFo(&pcd_hs_handle, 0x80);
-  HAL_PCDEx_SetTxFiFo(&pcd_hs_handle, 0, 0x20);
-  HAL_PCDEx_SetTxFiFo(&pcd_hs_handle, 1, 0x40);
-  HAL_PCDEx_SetTxFiFo(&pcd_hs_handle, 2, 0x20);
-  HAL_PCDEx_SetTxFiFo(&pcd_hs_handle, 3, 0x40);
-#else // !defined(USE_USB_HS_IN_FS)
-  /*Set LL Driver parameters */
-  pcd_hs_handle.Instance = USB_OTG_HS;
-  pcd_hs_handle.Init.dev_endpoints = 6;
-  pcd_hs_handle.Init.use_dedicated_ep1 = 0;
-  pcd_hs_handle.Init.ep0_mps = 0x40;
+    pcd_hs_handle.Init.phy_itface = PCD_PHY_EMBEDDED;
+    pcd_hs_handle.Init.Sof_enable = 1;
+    pcd_hs_handle.Init.speed = PCD_SPEED_HIGH_IN_FULL;
+    pcd_hs_handle.Init.vbus_sensing_enable = 1;
+    /* Link The driver to the stack */
+    pcd_hs_handle.pData = pdev;
+    pdev->pData = &pcd_hs_handle;
+    /* Initialize LL Driver */
+    HAL_PCD_Init(&pcd_hs_handle);
 
-  /* Be aware that enabling USB-DMA mode will result in data being sent only by
-     multiple of 4 packet sizes. This is due to the fact that USB-DMA does
-     not allow sending data from non word-aligned addresses.
-     For this specific application, it is advised to not enable this option
-     unless required. */
-  pcd_hs_handle.Init.dma_enable = 0;
-
-  pcd_hs_handle.Init.low_power_enable = 0;
-  pcd_hs_handle.Init.phy_itface = PCD_PHY_ULPI;
-  pcd_hs_handle.Init.Sof_enable = 1;
-  pcd_hs_handle.Init.speed = PCD_SPEED_HIGH;
-  pcd_hs_handle.Init.vbus_sensing_enable = 1;
-  /* Link The driver to the stack */
-  pcd_hs_handle.pData = pdev;
-  pdev->pData = &pcd_hs_handle;
-  /*Initialize LL Driver */
-  HAL_PCD_Init(&pcd_hs_handle);
-
-  HAL_PCDEx_SetRxFiFo(&pcd_hs_handle, 0x200);
-  HAL_PCDEx_SetTxFiFo(&pcd_hs_handle, 0, 0x80);
-  HAL_PCDEx_SetTxFiFo(&pcd_hs_handle, 1, 0x174);
-
-#endif  // !USE_USB_HS_IN_FS
-}
-#endif  // USE_USB_HS
+    HAL_PCDEx_SetRxFiFo(&pcd_hs_handle, 0x2e);
+    HAL_PCDEx_SetTxFiFo(&pcd_hs_handle, 0, 0xa3);
+    HAL_PCDEx_SetTxFiFo(&pcd_hs_handle, 1, 0xa3);
+    HAL_PCDEx_SetTxFiFo(&pcd_hs_handle, 2, 0xa3);
+    HAL_PCDEx_SetTxFiFo(&pcd_hs_handle, 3, 0xa3);
+    HAL_PCDEx_SetTxFiFo(&pcd_hs_handle, 4, 0xa3);
+    HAL_PCDEx_SetTxFiFo(&pcd_hs_handle, 5, 0xa3);
+  }
   return USBD_OK;
 }
 

--- a/core/emu.py
+++ b/core/emu.py
@@ -223,7 +223,7 @@ def cli(
         TREZOR_PATH=f"udp:127.0.0.1:{emulator.port}",
         TREZOR_PROFILE_DIR=str(profile_dir.resolve()),
         TREZOR_UDP_PORT=str(emulator.port),
-        TREZOR_FIDO2_UDP_PORT=str(emulator.port + 2),
+        TREZOR_FIDO2_UDP_PORT=str(emulator.port + 1),
         TREZOR_SRC=str(SRC_DIR),
     )
     os.environ.update(emulator_env)

--- a/core/src/usb.py
+++ b/core/src/usb.py
@@ -3,9 +3,9 @@ from trezor import io, utils
 
 _iface_iter = iter(range(5))
 
-ENABLE_IFACE_DEBUG = __debug__
+ENABLE_IFACE_DEBUG = True
 # change to False to enable VCP, see below
-ENABLE_IFACE_WEBAUTHN = not utils.BITCOIN_ONLY
+ENABLE_IFACE_WEBAUTHN = True
 
 # We only have 10 available USB endpoints on real HW, of which 2 are taken up by the USB descriptor.
 # iface_wire, iface_debug and iface_webauthn also consume 2 each, iface_vcp uses 3.
@@ -13,9 +13,7 @@ ENABLE_IFACE_WEBAUTHN = not utils.BITCOIN_ONLY
 # By default, iface_vcp is only enabled on bitcoin_only firmware, where iface_webauthn
 # is disabled. Implementation-wise, we check if any of the previous ifaces is disabled
 # in order to enable VCP.
-ENABLE_IFACE_VCP = __debug__ and (
-    utils.EMULATOR or not ENABLE_IFACE_DEBUG or not ENABLE_IFACE_WEBAUTHN
-)
+ENABLE_IFACE_VCP = True
 
 # interface used for trezor wire protocol
 id_wire = next(_iface_iter)
@@ -65,7 +63,7 @@ if not utils.BITCOIN_ONLY and ENABLE_IFACE_WEBAUTHN:
         # fmt: on
     )
 
-if __debug__ and ENABLE_IFACE_DEBUG:
+if ENABLE_IFACE_DEBUG:
     # interface used for debug messages with trezor wire protocol
     id_debug = next(_iface_iter)
     iface_debug = io.WebUSB(
@@ -74,7 +72,7 @@ if __debug__ and ENABLE_IFACE_DEBUG:
         ep_out=0x01 + id_debug,
     )
 
-if __debug__ and ENABLE_IFACE_VCP:
+if ENABLE_IFACE_VCP:
     # interface used for cdc/vcp console emulation (debug messages)
     id_vcp = next(_iface_iter)
     id_vcp_data = next(_iface_iter)
@@ -99,7 +97,7 @@ bus = io.USB(
 bus.add(iface_wire)
 if not utils.BITCOIN_ONLY and ENABLE_IFACE_WEBAUTHN:
     bus.add(iface_webauthn)
-if __debug__ and ENABLE_IFACE_DEBUG:
+if ENABLE_IFACE_DEBUG:
     bus.add(iface_debug)
-if __debug__ and ENABLE_IFACE_VCP:
+if ENABLE_IFACE_VCP:
     bus.add(iface_vcp)

--- a/core/src/usb.py
+++ b/core/src/usb.py
@@ -36,15 +36,6 @@ iface_wire = io.WebUSB(
 # Therefore, each of the following needs to include the respective static expression
 # so that it can be correctly excluded from the resulting build.
 
-if __debug__ and ENABLE_IFACE_DEBUG:
-    # interface used for debug messages with trezor wire protocol
-    id_debug = next(_iface_iter)
-    iface_debug = io.WebUSB(
-        iface_num=id_debug,
-        ep_in=0x81 + id_debug,
-        ep_out=0x01 + id_debug,
-    )
-
 if not utils.BITCOIN_ONLY and ENABLE_IFACE_WEBAUTHN:
     # interface used for FIDO/U2F and FIDO2/WebAuthn HID transport
     id_webauthn = next(_iface_iter)
@@ -74,6 +65,15 @@ if not utils.BITCOIN_ONLY and ENABLE_IFACE_WEBAUTHN:
         # fmt: on
     )
 
+if __debug__ and ENABLE_IFACE_DEBUG:
+    # interface used for debug messages with trezor wire protocol
+    id_debug = next(_iface_iter)
+    iface_debug = io.WebUSB(
+        iface_num=id_debug,
+        ep_in=0x81 + id_debug,
+        ep_out=0x01 + id_debug,
+    )
+
 if __debug__ and ENABLE_IFACE_VCP:
     # interface used for cdc/vcp console emulation (debug messages)
     id_vcp = next(_iface_iter)
@@ -97,9 +97,9 @@ bus = io.USB(
     usb21_landing=False,
 )
 bus.add(iface_wire)
-if __debug__ and ENABLE_IFACE_DEBUG:
-    bus.add(iface_debug)
 if not utils.BITCOIN_ONLY and ENABLE_IFACE_WEBAUTHN:
     bus.add(iface_webauthn)
+if __debug__ and ENABLE_IFACE_DEBUG:
+    bus.add(iface_debug)
 if __debug__ and ENABLE_IFACE_VCP:
     bus.add(iface_vcp)


### PR DESCRIPTION
In PR #1418, @mcudev seems to have fixed the limitation that prevented us from enabling the VCP interface when Webauthn is also enabled.

Someone who understands the low-level code please look this over. We should probably ignore the changes to `usb.py` and keep the original, except allow VCP whenever debug is also allowed. We will also want #1418 at the same time, in order to have the UDP port offsets fixed; otherwise either webauthn or debuglink have non-fixed ports.