### PR TITLE
Add public_key to ECDHSessionKey

### DIFF
--- a/common/protob/messages-crypto.proto
+++ b/common/protob/messages-crypto.proto
@@ -83,6 +83,7 @@ message GetECDHSessionKey {
  */
 message ECDHSessionKey {
     required bytes session_key = 1;     // ECDH session key
+    optional bytes public_key = 2;  // identity public key
 }
 
 /**

--- a/core/src/apps/misc/get_ecdh_session_key.py
+++ b/core/src/apps/misc/get_ecdh_session_key.py
@@ -39,7 +39,7 @@ async def get_ecdh_session_key(
         peer_public_key=msg.peer_public_key,
         curve=msg.ecdsa_curve_name,
     )
-    return ECDHSessionKey(session_key=session_key)
+    return ECDHSessionKey(session_key=session_key, public_key=node.public_key())
 
 
 async def require_confirm_ecdh_session_key(

--- a/core/src/trezor/messages/ECDHSessionKey.py
+++ b/core/src/trezor/messages/ECDHSessionKey.py
@@ -17,11 +17,14 @@ class ECDHSessionKey(p.MessageType):
         self,
         *,
         session_key: bytes,
+        public_key: bytes = None,
     ) -> None:
         self.session_key = session_key
+        self.public_key = public_key
 
     @classmethod
     def get_fields(cls) -> Dict:
         return {
             1: ('session_key', p.BytesType, p.FLAG_REQUIRED),
+            2: ('public_key', p.BytesType, None),
         }

--- a/legacy/firmware/fsm_msg_crypto.h
+++ b/legacy/firmware/fsm_msg_crypto.h
@@ -200,13 +200,17 @@ void fsm_msgGetECDHSessionKey(const GetECDHSessionKey *msg) {
     curve = msg->ecdsa_curve_name;
   }
 
-  const HDNode *node = fsm_getDerivedNode(curve, address_n, 5, NULL);
+  HDNode *node = fsm_getDerivedNode(curve, address_n, 5, NULL);
   if (!node) return;
 
   int result_size = 0;
   if (hdnode_get_shared_key(node, msg->peer_public_key.bytes,
                             resp->session_key.bytes, &result_size) == 0) {
     resp->session_key.size = result_size;
+    hdnode_fill_public_key(node);
+    memcpy(resp->public_key.bytes, node->public_key, 33);
+    resp->public_key.size = 33;
+    resp->has_public_key = true;
     msg_write(MessageType_MessageType_ECDHSessionKey, resp);
   } else {
     fsm_sendFailure(FailureType_Failure_ProcessError,

--- a/legacy/firmware/protob/messages-crypto.options
+++ b/legacy/firmware/protob/messages-crypto.options
@@ -36,3 +36,4 @@ GetECDHSessionKey.peer_public_key       max_size:65
 GetECDHSessionKey.ecdsa_curve_name      max_size:32
 
 ECDHSessionKey.session_key              max_size:65
+ECDHSessionKey.public_key               max_size:33

--- a/python/src/trezorlib/messages/ECDHSessionKey.py
+++ b/python/src/trezorlib/messages/ECDHSessionKey.py
@@ -17,11 +17,14 @@ class ECDHSessionKey(p.MessageType):
         self,
         *,
         session_key: bytes,
+        public_key: bytes = None,
     ) -> None:
         self.session_key = session_key
+        self.public_key = public_key
 
     @classmethod
     def get_fields(cls) -> Dict:
         return {
             1: ('session_key', p.BytesType, p.FLAG_REQUIRED),
+            2: ('public_key', p.BytesType, None),
         }

--- a/tests/device_tests/test_msg_getecdhsessionkey.py
+++ b/tests/device_tests/test_msg_getecdhsessionkey.py
@@ -46,6 +46,10 @@ class TestMsgGetECDHSessionKey:
             result.session_key.hex()
             == "0495e5d8c9e5cc09e7cf4908774f52decb381ce97f2fc9ba56e959c13f03f9f47a03dd151cbc908bc1db84d46e2c33e7bbb9daddc800f985244c924fd64adf6647"
         )
+        assert (
+            result.public_key.hex()
+            == "02a3b34db999f994aa91accb7b73ecafe0ce8ce228e17a45525ccbf73feeb7c809"
+        )
 
         peer_public_key = bytes.fromhex(
             "04811a6c2bd2a547d0dd84747297fec47719e7c3f9b0024f027c2b237be99aac39a9230acbd163d0cb1524a0f5ea4bfed6058cec6f18368f72a12aa0c4d083ff64"
@@ -60,6 +64,10 @@ class TestMsgGetECDHSessionKey:
             result.session_key.hex()
             == "046d1f5c48af2cf2c57076ac2c9d7808db2086f614cb7b8107119ff2c6270cd209749809efe0196f01a0cc633788cef1f4a2bd650c99570d06962f923fca6d8fdf"
         )
+        assert (
+            result.public_key.hex()
+            == "03fda61bc6e6be9b1dd99f7f9d04836d1bf2a6ea2426095210c8ce65091b09000a"
+        )
 
         peer_public_key = bytes.fromhex(
             "40a8cf4b6a64c4314e80f15a8ea55812bd735fbb365936a48b2d78807b575fa17a"
@@ -73,4 +81,8 @@ class TestMsgGetECDHSessionKey:
         assert (
             result.session_key.hex()
             == "04e24516669e0b7d3d72e5129fddd07b6644c30915f5c8b7f1f62324afb3624311"
+        )
+        assert (
+            result.public_key.hex()
+            == "019753a0738c55c7ba7c17dd4a9a975ce9b0d2b62e8a1ecef4a76767fad99d3c71"
         )


### PR DESCRIPTION
This would allow implementing [age](https://age-encryption.org/) decryption plugin without caching the public key on the host: https://github.com/romanz/trezor-agent/commit/13531b8fd2ce09c5fbe0f0c588f507e6ea8791ef
 