### PR TITLE
core/embed/usb: use all available usb endpoints and update the usb fifo sizing

### DIFF
--- a/core/embed/trezorhal/usbd_conf.c
+++ b/core/embed/trezorhal/usbd_conf.c
@@ -407,103 +407,44 @@ void HAL_PCD_DisconnectCallback(PCD_HandleTypeDef *hpcd)
   */
 USBD_StatusTypeDef  USBD_LL_Init (USBD_HandleTypeDef *pdev)
 {
-#if defined(USE_USB_FS)
-if (pdev->id ==  USB_PHY_FS_ID)
-{
-  /*Set LL Driver parameters */
-  pcd_fs_handle.Instance = USB_OTG_FS;
-  pcd_fs_handle.Init.dev_endpoints = 4;
-  pcd_fs_handle.Init.use_dedicated_ep1 = 0;
-  pcd_fs_handle.Init.ep0_mps = 0x40;
-  pcd_fs_handle.Init.dma_enable = 0;
-  pcd_fs_handle.Init.low_power_enable = 0;
-  pcd_fs_handle.Init.phy_itface = PCD_PHY_EMBEDDED;
-  pcd_fs_handle.Init.Sof_enable = 1;
-  pcd_fs_handle.Init.speed = PCD_SPEED_FULL;
-#if defined(MCU_SERIES_L4)
-  pcd_fs_handle.Init.lpm_enable = DISABLE;
-  pcd_fs_handle.Init.battery_charging_enable = DISABLE;
-#endif
-#if !defined(MICROPY_HW_USB_VBUS_DETECT_PIN)
-  pcd_fs_handle.Init.vbus_sensing_enable = 0; // No VBUS Sensing on USB0
-#else
-  pcd_fs_handle.Init.vbus_sensing_enable = 1;
-#endif
-  /* Link The driver to the stack */
-  pcd_fs_handle.pData = pdev;
-  pdev->pData = &pcd_fs_handle;
-  /*Initialize LL Driver */
-  HAL_PCD_Init(&pcd_fs_handle);
+  if (pdev->id == USB_PHY_HS_ID) {
+    /* Set LL Driver parameters */
+    pcd_hs_handle.Instance = USB_OTG_HS;
+    pcd_hs_handle.Init.dev_endpoints = 6;
+    pcd_hs_handle.Init.use_dedicated_ep1 = 0;
 
-  HAL_PCDEx_SetRxFiFo(&pcd_fs_handle, 0x80);
-  HAL_PCDEx_SetTxFiFo(&pcd_fs_handle, 0, 0x20);
-  HAL_PCDEx_SetTxFiFo(&pcd_fs_handle, 1, 0x40);
-  HAL_PCDEx_SetTxFiFo(&pcd_fs_handle, 2, 0x20);
-  HAL_PCDEx_SetTxFiFo(&pcd_fs_handle, 3, 0x40);
-}
-#endif
-#if defined(USE_USB_HS)
-if (pdev->id == USB_PHY_HS_ID)
-{
-#if defined(USE_USB_HS_IN_FS)
-  /*Set LL Driver parameters */
-  pcd_hs_handle.Instance = USB_OTG_HS;
-  pcd_hs_handle.Init.dev_endpoints = 4;
-  pcd_hs_handle.Init.use_dedicated_ep1 = 0;
-  pcd_hs_handle.Init.ep0_mps = 0x40;
-  pcd_hs_handle.Init.dma_enable = 0;
-  pcd_hs_handle.Init.low_power_enable = 0;
-  pcd_hs_handle.Init.phy_itface = PCD_PHY_EMBEDDED;
-  pcd_hs_handle.Init.Sof_enable = 1;
-  pcd_hs_handle.Init.speed = PCD_SPEED_HIGH_IN_FULL;
-#if !defined(MICROPY_HW_USB_VBUS_DETECT_PIN)
-  pcd_hs_handle.Init.vbus_sensing_enable = 0; // No VBUS Sensing on USB0
-#else
-  pcd_hs_handle.Init.vbus_sensing_enable = 1;
-#endif
-  /* Link The driver to the stack */
-  pcd_hs_handle.pData = pdev;
-  pdev->pData = &pcd_hs_handle;
-  /*Initialize LL Driver */
-  HAL_PCD_Init(&pcd_hs_handle);
+    pcd_hs_handle.Init.ep0_mps = 0x40;
+    pcd_hs_handle.Init.dma_enable = 0;
+    pcd_hs_handle.Init.low_power_enable = 0;
 
-  HAL_PCDEx_SetRxFiFo(&pcd_hs_handle, 0x80);
-  HAL_PCDEx_SetTxFiFo(&pcd_hs_handle, 0, 0x20);
-  HAL_PCDEx_SetTxFiFo(&pcd_hs_handle, 1, 0x40);
-  HAL_PCDEx_SetTxFiFo(&pcd_hs_handle, 2, 0x20);
-  HAL_PCDEx_SetTxFiFo(&pcd_hs_handle, 3, 0x40);
-#else // !defined(USE_USB_HS_IN_FS)
-  /*Set LL Driver parameters */
-  pcd_hs_handle.Instance = USB_OTG_HS;
-  pcd_hs_handle.Init.dev_endpoints = 6;
-  pcd_hs_handle.Init.use_dedicated_ep1 = 0;
-  pcd_hs_handle.Init.ep0_mps = 0x40;
+    pcd_hs_handle.Init.phy_itface = PCD_PHY_EMBEDDED;
+    pcd_hs_handle.Init.Sof_enable = 1;
+    pcd_hs_handle.Init.speed = PCD_SPEED_HIGH_IN_FULL;
+    // Trezor T hardware has PB13 connected to HS_VBUS
+    // but we leave vbus sensing disabled because
+    // we don't use it for anything. the device is a bus powered peripheral.
+    pcd_hs_handle.Init.vbus_sensing_enable = 0;
+    /* Link The driver to the stack */
+    pcd_hs_handle.pData = pdev;
+    pdev->pData = &pcd_hs_handle;
+    /* Initialize LL Driver */
+    HAL_PCD_Init(&pcd_hs_handle);
 
-  /* Be aware that enabling USB-DMA mode will result in data being sent only by
-     multiple of 4 packet sizes. This is due to the fact that USB-DMA does
-     not allow sending data from non word-aligned addresses.
-     For this specific application, it is advised to not enable this option
-     unless required. */
-  pcd_hs_handle.Init.dma_enable = 0;
-
-  pcd_hs_handle.Init.low_power_enable = 0;
-  pcd_hs_handle.Init.phy_itface = PCD_PHY_ULPI;
-  pcd_hs_handle.Init.Sof_enable = 1;
-  pcd_hs_handle.Init.speed = PCD_SPEED_HIGH;
-  pcd_hs_handle.Init.vbus_sensing_enable = 1;
-  /* Link The driver to the stack */
-  pcd_hs_handle.pData = pdev;
-  pdev->pData = &pcd_hs_handle;
-  /*Initialize LL Driver */
-  HAL_PCD_Init(&pcd_hs_handle);
-
-  HAL_PCDEx_SetRxFiFo(&pcd_hs_handle, 0x200);
-  HAL_PCDEx_SetTxFiFo(&pcd_hs_handle, 0, 0x80);
-  HAL_PCDEx_SetTxFiFo(&pcd_hs_handle, 1, 0x174);
-
-#endif  // !USE_USB_HS_IN_FS
-}
-#endif  // USE_USB_HS
+    // the OTG_HS peripheral has a dedicated 4KiB data RAM from which we
+    // allocate an area for each transmit FIFO and the single shared receive FIFO.
+    // the configuration is in terms of 32-bit words, so we have 1024 32-bit words
+    // in this dedicated 4KiB data RAM to use. see section 35.10.1 and 34.11 in RM0090.
+    // the reference to section 34.11 is for the OTG_FS device, but the FIFO architecture
+    // diagram seems to apply similarly to the FIFO in the OTG_HS that we are using.
+    // USB packets that we deal with are 64 bytes in size which equates to 16 32-bit words.
+    // we size the transmit FIFO's equally and give the rest of the space to the receive FIFO.
+    const uint16_t transmit_fifo_size = 144; // 144 = 16 * 9 meaning that we give 9 packets of space for each transmit fifo
+    const uint16_t receive_fifo_zie = 160; // 160 = 1024 - 6 * 144 section 35.10.1 details what some of this is used for besides storing packets
+    HAL_PCDEx_SetRxFiFo(&pcd_hs_handle, receive_fifo_zie);
+    for (uint16_t i = 0; i < 6; i++) {
+      HAL_PCDEx_SetTxFiFo(&pcd_hs_handle, i, transmit_fifo_size);
+    }
+  }
   return USBD_OK;
 }
 

--- a/core/src/usb.py
+++ b/core/src/usb.py
@@ -17,18 +17,8 @@ if utils.EMULATOR:
 _iface_iter = iter(range(5))
 
 ENABLE_IFACE_DEBUG = __debug__
-# change to False to enable VCP, see below
 ENABLE_IFACE_WEBAUTHN = not utils.BITCOIN_ONLY
-
-# We only have 10 available USB endpoints on real HW, of which 2 are taken up by the USB descriptor.
-# iface_wire, iface_debug and iface_webauthn also consume 2 each, iface_vcp uses 3.
-# That is a grand total of 11. That means that we can't enable everything at the same time.
-# By default, iface_vcp is only enabled on bitcoin_only firmware, where iface_webauthn
-# is disabled. Implementation-wise, we check if any of the previous ifaces is disabled
-# in order to enable VCP.
-ENABLE_IFACE_VCP = __debug__ and (
-    utils.EMULATOR or not ENABLE_IFACE_DEBUG or not ENABLE_IFACE_WEBAUTHN
-)
+ENABLE_IFACE_VCP = __debug__
 
 # interface used for trezor wire protocol
 id_wire = next(_iface_iter)

--- a/docs/core/build/embedded.md
+++ b/docs/core/build/embedded.md
@@ -57,12 +57,14 @@ You can also build firmware in debug mode to see log output or run tests.
 PYOPT=0 make build_firmware
 ```
 
+To get a full debug build, use:
+
+```sh
+make build_firmware BITCOIN_ONLY=0 PYOPT=0
+```
+
 You can then use `screen` to enter the device's console. Do not forget to add your user to the `dialout` group or use `sudo`. Note that both the group and the tty name can differ, use `ls -l` to find out proper names on your machine.
 
 ```sh
 screen /dev/ttyACM0
 ```
-
-Debug console via serial port is enabled only for the Bitcoin-only firmware.
-If you need the console to debug non-Bitcoin features, please edit `src/usb.py`,
-disable WebAuthn USB interface and enable the VCP USB interface.


### PR DESCRIPTION
for history, see #1517. this is that work just rebased on top of the current upstream master branch commit.