### PR TITLE
python/trezorctl: make bitcoin regtest a supported coin for trezorctl btc get-descriptor

### DIFF
--- a/python/src/trezorlib/cli/btc.py
+++ b/python/src/trezorlib/cli/btc.py
@@ -211,7 +211,7 @@ def _get_descriptor(client, coin, account, script_type, show_display):
 
     if coin is None or coin == "Bitcoin":
         coin_type = 0
-    elif coin == "Testnet":
+    elif coin == "Testnet" or coin == "Regtest":
         coin_type = 1
     else:
         raise ValueError("Unsupported coin")


### PR DESCRIPTION
`trezorctl btc get-descriptor -c Regtest -t wpkh -n 0`
was returning: `ValueError: Unsupported coin`

the current workaround is to use the output of: `trezorctl btc get-descriptor -c Testnet -t wpkh -n 0`
the workaround may not be immediately obvious without looking at the chain params.

this PR makes the Regtest version work. this is useful for tinkering with psbt and the trezor t in a regtest environment.

a quick test is to start a fresh regtest node: `bitcoin-qt -regtest -txindex -datadir=/tmp/node1`
get an address to geneate coins to: `trezorctl btc get-address -t wpkh -n "m/84h/1h/0h/0/0" -c Regtest`
in node console: `generatetoaddress 1 address-from-last-step`
in node console: `createwallet trezor_t true true "" true true true`
get the descriptor from the trezor t: `trezorctl btc get-descriptor -c Regtest -t wpkh -n 0`
in node console, import the descriptor to populate the wallet: `importdescriptors "[{\"desc\": \"descriptor-from-last-step\", \"range\": [0, 10], \"timestamp\": 0}]"`
