### PR TITLE
Improve error handling in modtrezorconfig

### DIFF
--- a/core/mocks/generated/trezorconfig.pyi
+++ b/core/mocks/generated/trezorconfig.pyi
@@ -109,7 +109,9 @@ def set(app: int, key: int, value: bytes, public: bool = False) -> None:
 
 
 # extmod/modtrezorconfig/modtrezorconfig.c
-def delete(app: int, key: int, public: bool = False) -> bool:
+def delete(
+    app: int, key: int, public: bool = False, writable_locked: bool = False
+) -> bool:
     """
     Deletes the given key of the given app.
     """
@@ -118,7 +120,7 @@ def delete(app: int, key: int, public: bool = False) -> bool:
 # extmod/modtrezorconfig/modtrezorconfig.c
 def set_counter(
     app: int, key: int, count: int, writable_locked: bool = False
-) -> bool:
+) -> None:
     """
     Sets the given key of the given app as a counter with the given value.
     """
@@ -127,7 +129,7 @@ def set_counter(
 # extmod/modtrezorconfig/modtrezorconfig.c
 def next_counter(
    app: int, key: int, writable_locked: bool = False,
-) -> Optional[int]:
+) -> int:
     """
     Increments the counter stored under the given key of the given app and
     returns the new value.

--- a/core/src/storage/common.py
+++ b/core/src/storage/common.py
@@ -28,8 +28,10 @@ def get(app: int, key: int, public: bool = False) -> Optional[bytes]:
     return config.get(app, key, public)
 
 
-def delete(app: int, key: int, public: bool = False) -> None:
-    config.delete(app, key, public)
+def delete(
+    app: int, key: int, public: bool = False, writable_locked: bool = False
+) -> None:
+    config.delete(app, key, public, writable_locked)
 
 
 def set_true_or_delete(app: int, key: int, value: bool) -> None:
@@ -72,9 +74,9 @@ def get_uint16(app: int, key: int) -> Optional[int]:
     return int.from_bytes(val, "big")
 
 
-def next_counter(app: int, key: int, public: bool = False) -> Optional[int]:
-    return config.next_counter(app, key, public)
+def next_counter(app: int, key: int, writable_locked: bool = False) -> int:
+    return config.next_counter(app, key, writable_locked)
 
 
-def set_counter(app: int, key: int, count: int, public: bool = False) -> None:
-    config.set_counter(app, key, count, public)
+def set_counter(app: int, key: int, count: int, writable_locked: bool = False) -> None:
+    config.set_counter(app, key, count, writable_locked)

--- a/core/src/storage/device.py
+++ b/core/src/storage/device.py
@@ -243,12 +243,12 @@ def set_autolock_delay_ms(delay_ms: int) -> None:
     common.set(_NAMESPACE, _AUTOLOCK_DELAY_MS, delay_ms.to_bytes(4, "big"))
 
 
-def next_u2f_counter() -> Optional[int]:
-    return common.next_counter(_NAMESPACE, U2F_COUNTER, True)  # writable when locked
+def next_u2f_counter() -> int:
+    return common.next_counter(_NAMESPACE, U2F_COUNTER, writable_locked=True)
 
 
 def set_u2f_counter(count: int) -> None:
-    common.set_counter(_NAMESPACE, U2F_COUNTER, count, True)  # writable when locked
+    common.set_counter(_NAMESPACE, U2F_COUNTER, count, writable_locked=True)
 
 
 def set_slip39_identifier(identifier: int) -> None:

--- a/core/tests/test_storage.py
+++ b/core/tests/test_storage.py
@@ -15,8 +15,6 @@ class TestConfig(unittest.TestCase):
             self.assertEqual(device.next_u2f_counter(), i)
         device.set_u2f_counter(0)
         self.assertEqual(device.next_u2f_counter(), 1)
-        device.set_u2f_counter(None)
-        self.assertEqual(device.next_u2f_counter(), 0)
 
 
 if __name__ == '__main__':

--- a/core/tests/test_trezor.config.py
+++ b/core/tests/test_trezor.config.py
@@ -92,7 +92,7 @@ class TestConfig(unittest.TestCase):
 
             # The APP namespace which is reserved for storage related values is inaccessible even
             # when unlocked.
-            with self.assertRaises(RuntimeError):
+            with self.assertRaises(ValueError):
                 config.set(PINAPP, PINKEY, b'value')
 
             self.assertTrue(config.change_pin(old_pin, new_pin, None, None))
@@ -106,7 +106,8 @@ class TestConfig(unittest.TestCase):
 
             # The APP namespace which is reserved for storage related values is inaccessible even
             # when unlocked.
-            self.assertEqual(config.get(PINAPP, PINKEY), None)
+            with self.assertRaises(ValueError):
+                config.get(PINAPP, PINKEY)
 
             # Old PIN cannot be used to unlock storage.
             if old_pin != new_pin:
@@ -168,6 +169,25 @@ class TestConfig(unittest.TestCase):
             config.set(appid, key, value)
             value2 = config.get(appid, key)
             self.assertEqual(value, value2)
+
+        # Test value deletion.
+        self.assertTrue(config.delete(appid, key))
+        self.assertIsNone(config.get(appid, key))
+        self.assertFalse(config.delete(appid, key))
+
+        # Test get/set for APP out ouf range.
+
+        with self.assertRaises(ValueError):
+            config.set(0, 1, b'test')
+
+        with self.assertRaises(ValueError):
+            config.get(0, 1)
+
+        with self.assertRaises(ValueError):
+            config.set(192, 1, b'test')
+
+        with self.assertRaises(ValueError):
+            config.get(192, 1)
 
     def test_compact(self):
         config.init()

--- a/storage/storage.c
+++ b/storage/storage.c
@@ -1363,9 +1363,17 @@ secbool storage_next_counter(const uint16_t key, uint32_t *count) {
   }
 
   *count = val_stored[0] + 1 + 32 * (i - 1);
+  if (*count < val_stored[0]) {
+    // Value overflow.
+    return secfalse;
+  }
 
   if (i < len_words) {
     *count += hamming_weight(~val_stored[i]);
+    if (*count < val_stored[0]) {
+      // Value overflow.
+      return secfalse;
+    }
     return norcow_update_word(key, sizeof(uint32_t) * i, val_stored[i] >> 1);
   } else {
     return storage_set_counter(key, *count);

--- a/storage/storage.h
+++ b/storage/storage.h
@@ -34,8 +34,8 @@
 // can be written even when the storage is locked.
 #define FLAGS_WRITE 0xC0
 
-// Mask for extracting the "real" app_id.
-#define FLAGS_APPID 0x3F
+// The maximum value of app_id which is the six least significant bits of APP.
+#define MAX_APPID 0x3F
 
 // The PIN value corresponding to an empty PIN.
 extern const uint8_t *PIN_EMPTY;

--- a/storage/tests/c/storage.py
+++ b/storage/tests/c/storage.py
@@ -70,17 +70,17 @@ class Storage:
         if sectrue != self.lib.storage_set(c.c_uint16(key), val, c.c_uint16(len(val))):
             raise RuntimeError("Failed to set value in storage.")
 
-    def set_counter(self, key: int, count: int) -> bool:
-        return sectrue == self.lib.storage_set_counter(
+    def set_counter(self, key: int, count: int) -> None:
+        if count > 0xFFFF_FFFF or sectrue != self.lib.storage_set_counter(
             c.c_uint16(key), c.c_uint32(count)
-        )
+        ):
+            raise RuntimeError("Failed to set value in storage.")
 
     def next_counter(self, key: int) -> int:
         count = c.c_uint32()
-        if sectrue == self.lib.storage_next_counter(c.c_uint16(key), c.byref(count)):
-            return count.value
-        else:
-            return None
+        if sectrue != self.lib.storage_next_counter(c.c_uint16(key), c.byref(count)):
+            raise RuntimeError("Failed to set value in storage.")
+        return count.value
 
     def delete(self, key: int) -> bool:
         return sectrue == self.lib.storage_delete(c.c_uint16(key))

--- a/storage/tests/python/src/consts.py
+++ b/storage/tests/python/src/consts.py
@@ -1,3 +1,6 @@
+# ----- General ----- #
+UINT32_MAX = 0xFFFF_FFFF
+
 # ----- PIN and encryption related ----- #
 
 # App ID where PIN log is stored.

--- a/storage/tests/python/src/storage.py
+++ b/storage/tests/python/src/storage.py
@@ -149,6 +149,10 @@ class Storage:
         app = key >> 8
         if not consts.is_app_public(app):
             raise RuntimeError("Counter can be set only for public items")
+
+        if val > consts.UINT32_MAX:
+            raise RuntimeError("Failed to set value in storage.")
+
         counter = val.to_bytes(4, sys.byteorder) + bytearray(
             b"\xFF" * consts.COUNTER_TAIL_SIZE
         )
@@ -167,6 +171,8 @@ class Storage:
         tail = helpers.to_int_by_words(current[4:])
         tail_count = "{0:064b}".format(tail).count("0")
         increased_count = base + tail_count + 1
+        if increased_count > consts.UINT32_MAX:
+            raise RuntimeError("Failed to set value in storage.")
 
         if tail_count == consts.COUNTER_MAX_TAIL:
             self.set_counter(key, increased_count)

--- a/storage/tests/tests/test_set_get.py
+++ b/storage/tests/tests/test_set_get.py
@@ -1,5 +1,7 @@
 import pytest
 
+from python.src import consts
+
 from . import common
 
 # Strings for testing ChaCha20 encryption.
@@ -182,4 +184,18 @@ def test_counter():
     for i in range(501, 700):
         for s in (sc, sp):
             assert i == s.next_counter(0xC001)
+    assert common.memory_equals(sc, sp)
+
+    for s in (sc, sp):
+        with pytest.raises(RuntimeError):
+            s.set_counter(0xC001, consts.UINT32_MAX + 1)
+
+        start = consts.UINT32_MAX - 100
+        s.set_counter(0xC001, start)
+        for i in range(start, consts.UINT32_MAX):
+            assert i + 1 == s.next_counter(0xC001)
+
+        with pytest.raises(RuntimeError):
+            s.next_counter(0xC001)
+
     assert common.memory_equals(sc, sp)


### PR DESCRIPTION
- Improve range checking in modtrezorconfig and raise ValueError on invalid input.
- `config.set_counter()` allowed specifying `count=None` to delete a counter, which seems like a bad choice. Counter should be deleted explicitly by calling `config.delete()`.
- Detect counter overflow when incrementing.
- Add unit tests. 