### PR TITLE
chore(vendor): bump micropython to 1.14

### DIFF
--- a/core/embed/firmware/mpconfigport.h
+++ b/core/embed/firmware/mpconfigport.h
@@ -186,7 +186,12 @@ typedef long mp_off_t;
 
 #define MICROPY_BEGIN_ATOMIC_SECTION()     disable_irq()
 #define MICROPY_END_ATOMIC_SECTION(state)  enable_irq(state)
-#define MICROPY_EVENT_POLL_HOOK            __WFI();
+#define MICROPY_EVENT_POLL_HOOK \
+    do { \
+        extern void mp_handle_pending(bool); \
+        mp_handle_pending(true); \
+        __WFI(); \
+    } while (0);
 
 #define MICROPY_HW_BOARD_NAME "TREZORv2"
 #define MICROPY_HW_MCU_NAME "STM32F427xx"

--- a/core/embed/unix/mpconfigport.h
+++ b/core/embed/unix/mpconfigport.h
@@ -226,7 +226,12 @@ typedef unsigned int mp_uint_t; // must be pointer size
 #endif
 #endif
 
-#define MICROPY_EVENT_POLL_HOOK mp_hal_delay_ms(1);
+#define MICROPY_EVENT_POLL_HOOK \
+    do { \
+        extern void mp_handle_pending(bool); \
+        mp_handle_pending(true); \
+        mp_hal_delay_us(500); \
+    } while (0);
 
 // Cannot include <sys/types.h>, as it may lead to symbol name clashes
 #if _FILE_OFFSET_BITS == 64 && !defined(__LP64__)


### PR DESCRIPTION
Full changelog: https://github.com/micropython/micropython/releases/tag/v1.14

Relevant changes:
* rename `sys` module to `usys` - but `sys` should still work with both unix and stm32 ports as they both enable `MICROPY_MODULE_WEAK_LINKS`
* add `utime.gmtime()` function - can be used in https://github.com/trezor/trezor-firmware/pull/1535
