### PR TITLE
Show nLockTime in human-readable form

### DIFF
--- a/legacy/firmware/CHANGELOG.md
+++ b/legacy/firmware/CHANGELOG.md
@@ -12,6 +12,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 ### Changed
 - Allow decreasing the output value in RBF transactions.  [#1491]
 - Support long PIN of up to 50 digits.  [#1167]
+- Display nLockTime in human-readable form.  [#1549]
 
 ### Deprecated
 
@@ -384,3 +385,4 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 [#1415]: https://github.com/trezor/trezor-firmware/pull/1415
 [#1491]: https://github.com/trezor/trezor-firmware/issues/1491
 [#1518]: https://github.com/trezor/trezor-firmware/pull/1518
+[#1549]: https://github.com/trezor/trezor-firmware/issues/1549

--- a/legacy/firmware/layout2.c
+++ b/legacy/firmware/layout2.c
@@ -22,6 +22,7 @@
 #include <stdint.h>
 #include <stdio.h>
 #include <string.h>
+#include <time.h>
 
 #include "bignum.h"
 #include "bitmaps.h"
@@ -584,10 +585,17 @@ void layoutConfirmNondefaultLockTime(uint32_t lock_time,
                       _("will have no effect."), NULL, _("Continue?"), NULL);
 
   } else {
-    char str_locktime[11] = {0};
-    snprintf(str_locktime, sizeof(str_locktime), "%" PRIu32, lock_time);
-    char *str_type = (lock_time < LOCKTIME_TIMESTAMP_MIN_VALUE) ? "blockheight:"
-                                                                : "timestamp:";
+    char str_locktime[20] = {0};
+    char *str_type = NULL;
+    if (lock_time < LOCKTIME_TIMESTAMP_MIN_VALUE) {
+      str_type = "blockheight:";
+      snprintf(str_locktime, sizeof(str_locktime), "%" PRIu32, lock_time);
+    } else {
+      str_type = "timestamp (UTC):";
+      time_t time = lock_time;
+      const struct tm *tm = gmtime(&time);
+      strftime(str_locktime, sizeof(str_locktime), "%F %T", tm);
+    }
 
     layoutDialogSwipe(&bmp_icon_question, _("Cancel"), _("Confirm"), NULL,
                       _("Locktime for this"), _("transaction is set to"),

--- a/legacy/oled.c
+++ b/legacy/oled.c
@@ -342,7 +342,7 @@ void oledDrawStringRight(int x, int y, const char *text, uint8_t font) {
 
 static void oled_draw_bitmap_flip(int x, int y, const BITMAP *bmp, bool flip) {
   for (int i = 0; i < bmp->width; i++) {
-    int ii = flip ? i : (bmp->width - 1 - i);
+    int ii = flip ? (bmp->width - 1 - i) : i;
     for (int j = 0; j < bmp->height; j++) {
       if (bmp->data[(ii / 8) + j * bmp->width / 8] & (1 << (7 - ii % 8))) {
         oledDrawPixel(x + i, y + j);


### PR DESCRIPTION
`nLockTime` = 500000000:
![image](https://user-images.githubusercontent.com/42678794/112624735-4445d880-8e2e-11eb-91e2-15d429d79d71.png)

`nLockTime` = 499999999:
![image](https://user-images.githubusercontent.com/42678794/112624748-4ad45000-8e2e-11eb-94ef-28aa6847d489.png)

I also fixed a bug due to which all bitmaps we flipped incorrectly.