### PR TITLE
Drbg rework (part 1)

### DIFF
--- a/core/.changelog.d/1554.changed
+++ b/core/.changelog.d/1554.changed
@@ -1,0 +1,1 @@
+Random delays use ChaCha-based DRBG instead of HMAC-DRBG.

--- a/core/SConscript.bootloader
+++ b/core/SConscript.bootloader
@@ -22,13 +22,14 @@ CPPDEFINES_MOD += [
 ]
 SOURCE_MOD += [
     'vendor/trezor-crypto/blake2s.c',
+    'vendor/trezor-crypto/chacha_drbg.c',
+    'vendor/trezor-crypto/chacha20poly1305/chacha_merged.c',
     'vendor/trezor-crypto/ed25519-donna/curve25519-donna-32bit.c',
     'vendor/trezor-crypto/ed25519-donna/curve25519-donna-helpers.c',
     'vendor/trezor-crypto/ed25519-donna/ed25519.c',
     'vendor/trezor-crypto/ed25519-donna/ed25519-donna-32bit-tables.c',
     'vendor/trezor-crypto/ed25519-donna/ed25519-donna-impl-base.c',
     'vendor/trezor-crypto/ed25519-donna/modm-donna-32bit.c',
-    'vendor/trezor-crypto/hmac_drbg.c',
     'vendor/trezor-crypto/memzero.c',
     'vendor/trezor-crypto/rand.c',
     'vendor/trezor-crypto/sha2.c',

--- a/core/SConscript.bootloader
+++ b/core/SConscript.bootloader
@@ -94,6 +94,7 @@ SOURCE_TREZORHAL = [
     'embed/trezorhal/flash.c',
     'embed/trezorhal/mini_printf.c',
     'embed/trezorhal/mpu.c',
+    'embed/trezorhal/random_delays.c',
     'embed/trezorhal/rng.c',
     'embed/trezorhal/stm32.c',
     'embed/trezorhal/systick.c',

--- a/core/SConscript.bootloader_ci
+++ b/core/SConscript.bootloader_ci
@@ -22,13 +22,14 @@ CPPDEFINES_MOD += [
 ]
 SOURCE_MOD += [
     'vendor/trezor-crypto/blake2s.c',
+    'vendor/trezor-crypto/chacha_drbg.c',
+    'vendor/trezor-crypto/chacha20poly1305/chacha_merged.c',
     'vendor/trezor-crypto/ed25519-donna/curve25519-donna-32bit.c',
     'vendor/trezor-crypto/ed25519-donna/curve25519-donna-helpers.c',
     'vendor/trezor-crypto/ed25519-donna/ed25519.c',
     'vendor/trezor-crypto/ed25519-donna/ed25519-donna-32bit-tables.c',
     'vendor/trezor-crypto/ed25519-donna/ed25519-donna-impl-base.c',
     'vendor/trezor-crypto/ed25519-donna/modm-donna-32bit.c',
-    'vendor/trezor-crypto/hmac_drbg.c',
     'vendor/trezor-crypto/memzero.c',
     'vendor/trezor-crypto/rand.c',
     'vendor/trezor-crypto/sha2.c',

--- a/core/SConscript.bootloader_ci
+++ b/core/SConscript.bootloader_ci
@@ -94,6 +94,7 @@ SOURCE_TREZORHAL = [
     'embed/trezorhal/flash.c',
     'embed/trezorhal/mini_printf.c',
     'embed/trezorhal/mpu.c',
+    'embed/trezorhal/random_delays.c',
     'embed/trezorhal/rng.c',
     'embed/trezorhal/stm32.c',
     'embed/trezorhal/systick.c',

--- a/core/SConscript.firmware
+++ b/core/SConscript.firmware
@@ -333,6 +333,7 @@ SOURCE_TREZORHAL = [
     'embed/trezorhal/flash.c',
     'embed/trezorhal/mini_printf.c',
     'embed/trezorhal/mpu.c',
+    'embed/trezorhal/random_delays.c',
     'embed/trezorhal/rng.c',
     'embed/trezorhal/sbu.c',
     'embed/trezorhal/sdcard.c',
@@ -349,9 +350,6 @@ SOURCE_TREZORHAL = [
 ]
 
 if FEATURE_FLAGS["RDI"]:
-    SOURCE_TREZORHAL += [
-        'embed/trezorhal/rdi.c',
-    ]
     CPPDEFINES_MOD += ['RDI']
 
 if FEATURE_FLAGS["SYSTEM_VIEW"]:

--- a/core/SConscript.prodtest
+++ b/core/SConscript.prodtest
@@ -70,6 +70,7 @@ SOURCE_TREZORHAL = [
     'embed/trezorhal/dma.c',
     'embed/trezorhal/flash.c',
     'embed/trezorhal/mini_printf.c',
+    'embed/trezorhal/random_delays.c',
     'embed/trezorhal/rng.c',
     'embed/trezorhal/sbu.c',
     'embed/trezorhal/sdcard.c',

--- a/core/SConscript.prodtest
+++ b/core/SConscript.prodtest
@@ -14,7 +14,8 @@ CPPPATH_MOD += [
     'vendor/trezor-crypto',
 ]
 SOURCE_MOD += [
-    'vendor/trezor-crypto/hmac_drbg.c',
+    'vendor/trezor-crypto/chacha_drbg.c',
+    'vendor/trezor-crypto/chacha20poly1305/chacha_merged.c',
     'vendor/trezor-crypto/memzero.c',
     'vendor/trezor-crypto/rand.c',
     'vendor/trezor-crypto/sha2.c',

--- a/core/SConscript.unix
+++ b/core/SConscript.unix
@@ -305,6 +305,7 @@ SOURCE_UNIX = [
     'embed/unix/flash.c',
     'embed/unix/main.c',
     'embed/unix/profile.c',
+    'embed/unix/random_delays.c',
     'embed/unix/rng.c',
     'embed/unix/sbu.c',
     'embed/unix/sdcard.c',

--- a/core/embed/bootloader/main.c
+++ b/core/embed/bootloader/main.c
@@ -26,7 +26,7 @@
 #include "image.h"
 #include "mini_printf.h"
 #include "mpu.h"
-#include "rng.h"
+#include "random_delays.h"
 #include "secbool.h"
 #include "touch.h"
 #include "usb.h"
@@ -236,7 +236,7 @@ static void check_bootloader_version(void) {
 #endif
 
 int main(void) {
-  drbg_init();
+  random_delays_init();
   // display_init_seq();
   touch_init();
   touch_power_on();

--- a/core/embed/bootloader_ci/main.c
+++ b/core/embed/bootloader_ci/main.c
@@ -26,6 +26,7 @@
 #include "image.h"
 #include "mini_printf.h"
 #include "mpu.h"
+#include "random_delays.h"
 #include "rng.h"
 #include "secbool.h"
 #include "touch.h"
@@ -214,7 +215,7 @@ static void check_bootloader_version(void) {
 #endif
 
 int main(void) {
-  drbg_init();
+  random_delays_init();
   touch_init();
   touch_power_on();
 

--- a/core/embed/firmware/main.c
+++ b/core/embed/firmware/main.c
@@ -52,8 +52,8 @@
 #include "touch.h"
 
 int main(void) {
-  // initialize pseudo-random number generator
-  drbg_init();
+  random_delays_init();
+
 #ifdef RDI
   rdi_start();
 #endif

--- a/core/embed/firmware/main.c
+++ b/core/embed/firmware/main.c
@@ -41,7 +41,7 @@
 #include "flash.h"
 #include "mpu.h"
 #ifdef RDI
-#include "rdi.h"
+#include "random_delays.h"
 #endif
 #ifdef SYSTEM_VIEW
 #include "systemview.h"

--- a/core/embed/prodtest/main.c
+++ b/core/embed/prodtest/main.c
@@ -27,6 +27,7 @@
 #include "display.h"
 #include "flash.h"
 #include "mini_printf.h"
+#include "random_delays.h"
 #include "rng.h"
 #include "sbu.h"
 #include "sdcard.h"
@@ -371,7 +372,7 @@ static secbool startswith(const char *s, const char *prefix) {
 
 int main(void) {
   display_orientation(0);
-  drbg_init();
+  random_delays_init();
   sdcard_init();
   touch_init();
   sbu_init();

--- a/core/embed/trezorhal/common.c
+++ b/core/embed/trezorhal/common.c
@@ -122,27 +122,6 @@ void __assert_func(const char *file, int line, const char *func,
 
 void hal_delay(uint32_t ms) { HAL_Delay(ms); }
 
-/*
- * Generates a delay of random length. Use this to protect sensitive code
- * against fault injection.
- */
-void wait_random(void) {
-  int wait = drbg_random32() & 0xff;
-  volatile int i = 0;
-  volatile int j = wait;
-  while (i < wait) {
-    if (i + j != wait) {
-      shutdown();
-    }
-    ++i;
-    --j;
-  }
-  // Double-check loop completion.
-  if (i != wait || j != 0) {
-    shutdown();
-  }
-}
-
 // reference RM0090 section 35.12.1 Figure 413
 #define USB_OTG_HS_DATA_FIFO_RAM (USB_OTG_HS_PERIPH_BASE + 0x20000U)
 #define USB_OTG_HS_DATA_FIFO_SIZE (4096U)

--- a/core/embed/trezorhal/common.c
+++ b/core/embed/trezorhal/common.c
@@ -24,15 +24,12 @@
 #include "common.h"
 #include "display.h"
 #include "flash.h"
-#include "hmac_drbg.h"
 #include "rand.h"
 
 #include "stm32f4xx_ll_utils.h"
 
 // from util.s
 extern void shutdown(void);
-
-static HMAC_DRBG_CTX drbg_ctx;
 
 #define COLOR_FATAL_ERROR RGB16(0x7F, 0x00, 0x00)
 
@@ -169,24 +166,4 @@ void collect_hw_entropy(void) {
   ensure(flash_otp_read(FLASH_OTP_BLOCK_RANDOMNESS, 0, HW_ENTROPY_DATA + 12,
                         FLASH_OTP_BLOCK_SIZE),
          NULL);
-}
-
-void drbg_init(void) {
-  uint8_t entropy[48];
-  random_buffer(entropy, sizeof(entropy));
-  hmac_drbg_init(&drbg_ctx, entropy, sizeof(entropy), NULL, 0);
-}
-
-void drbg_reseed(const uint8_t *entropy, size_t len) {
-  hmac_drbg_reseed(&drbg_ctx, entropy, len, NULL, 0);
-}
-
-void drbg_generate(uint8_t *buf, size_t len) {
-  hmac_drbg_generate(&drbg_ctx, buf, len);
-}
-
-uint32_t drbg_random32(void) {
-  uint32_t value;
-  drbg_generate((uint8_t *)&value, sizeof(value));
-  return value;
 }

--- a/core/embed/trezorhal/common.h
+++ b/core/embed/trezorhal/common.h
@@ -66,8 +66,6 @@ error_shutdown(const char *line1, const char *line2, const char *line3,
 
 void hal_delay(uint32_t ms);
 
-void wait_random(void);
-
 void clear_otg_hs_memory(void);
 
 extern uint32_t __stack_chk_guard;

--- a/core/embed/trezorhal/common.h
+++ b/core/embed/trezorhal/common.h
@@ -74,11 +74,6 @@ void collect_hw_entropy(void);
 #define HW_ENTROPY_LEN (12 + 32)
 extern uint8_t HW_ENTROPY_DATA[HW_ENTROPY_LEN];
 
-void drbg_init(void);
-void drbg_reseed(const uint8_t *entropy, size_t len);
-void drbg_generate(uint8_t *buf, size_t len);
-uint32_t drbg_random32(void);
-
 // the following functions are defined in util.s
 
 void memset_reg(volatile void *start, volatile void *stop, uint32_t val);

--- a/core/embed/trezorhal/random_delays.c
+++ b/core/embed/trezorhal/random_delays.c
@@ -59,7 +59,7 @@ static secbool rdi_disabled = sectrue;
 static void rdi_reseed(void) {
   uint8_t entropy[CHACHA_DRBG_SEED_LENGTH];
   random_buffer(entropy, CHACHA_DRBG_SEED_LENGTH);
-  chacha_drbg_reseed(&drbg_ctx, entropy);
+  chacha_drbg_reseed(&drbg_ctx, entropy, sizeof(entropy), NULL, 0);
 }
 
 static void buffer_refill(void) {
@@ -128,7 +128,7 @@ void rdi_start(void) {
   if (rdi_disabled == sectrue) {  // if rdi disabled
     uint8_t entropy[CHACHA_DRBG_SEED_LENGTH];
     random_buffer(entropy, CHACHA_DRBG_SEED_LENGTH);
-    chacha_drbg_init(&drbg_ctx, entropy);
+    chacha_drbg_init(&drbg_ctx, entropy, sizeof(entropy), NULL, 0);
     buffer_refill();
     buffer_index = 0;
     refresh_session_delay = true;

--- a/core/embed/trezorhal/random_delays.c
+++ b/core/embed/trezorhal/random_delays.c
@@ -36,6 +36,7 @@ https://link.springer.com/content/pdf/10.1007%2F978-3-540-72354-7_3.pdf
 
 #include "random_delays.h"
 
+#include <stdatomic.h>
 #include <stdbool.h>
 
 #include "chacha_drbg.h"
@@ -46,35 +47,125 @@ https://link.springer.com/content/pdf/10.1007%2F978-3-540-72354-7_3.pdf
 // from util.s
 extern void shutdown(void);
 
+#define DRBG_RESEED_INTERVAL_CALLS 1000
+#define DRBG_TRNG_ENTROPY_LENGTH 50
+_Static_assert(CHACHA_DRBG_OPTIMAL_RESEED_LENGTH(1) == DRBG_TRNG_ENTROPY_LENGTH,
+               "");
 #define BUFFER_LENGTH 64
-#define RESEED_INTERVAL 65536
 
 static CHACHA_DRBG_CTX drbg_ctx;
-static uint8_t buffer[BUFFER_LENGTH];
-static size_t buffer_index;
+static secbool drbg_initialized = secfalse;
 static uint8_t session_delay;
 static bool refresh_session_delay;
 static secbool rdi_disabled = sectrue;
 
-static void rdi_reseed(void) {
-  uint8_t entropy[CHACHA_DRBG_SEED_LENGTH];
-  random_buffer(entropy, CHACHA_DRBG_SEED_LENGTH);
+static void drbg_init() {
+  uint8_t entropy[DRBG_TRNG_ENTROPY_LENGTH] = {0};
+  random_buffer(entropy, sizeof(entropy));
+  chacha_drbg_init(&drbg_ctx, entropy, sizeof(entropy), NULL, 0);
+  memzero(entropy, sizeof(entropy));
+
+  drbg_initialized = sectrue;
+}
+
+static void drbg_reseed() {
+  ensure(drbg_initialized, NULL);
+
+  uint8_t entropy[DRBG_TRNG_ENTROPY_LENGTH] = {0};
+  random_buffer(entropy, sizeof(entropy));
   chacha_drbg_reseed(&drbg_ctx, entropy, sizeof(entropy), NULL, 0);
+  memzero(entropy, sizeof(entropy));
 }
 
-static void buffer_refill(void) {
-  chacha_drbg_generate(&drbg_ctx, buffer, BUFFER_LENGTH);
-}
+static void drbg_generate(uint8_t *buffer, size_t length) {
+  ensure(drbg_initialized, NULL);
 
-static uint32_t random8(void) {
-  buffer_index += 1;
-  if (buffer_index >= BUFFER_LENGTH) {
-    buffer_refill();
-    if (RESEED_INTERVAL != 0 && drbg_ctx.reseed_counter > RESEED_INTERVAL)
-      rdi_reseed();
-    buffer_index = 0;
+  if (drbg_ctx.reseed_counter > DRBG_RESEED_INTERVAL_CALLS) {
+    drbg_reseed();
   }
-  return buffer[buffer_index];
+  chacha_drbg_generate(&drbg_ctx, buffer, length);
+}
+
+// WARNING: Returns a constant if the function's critical section is locked
+static uint32_t drbg_random8(void) {
+  // Since the function is called both from an interrupt (rdi_handler,
+  // wait_random) and the main thread (wait_random), we use a lock to
+  // synchronise access to global variables
+  static volatile atomic_flag locked = ATOMIC_FLAG_INIT;
+
+  if (atomic_flag_test_and_set(&locked))
+  // locked_old = locked; locked = true; locked_old
+  {
+    // If the critical section is locked we return a non-random value, which
+    // should be ok for our purposes
+    return 128;
+  }
+
+  static size_t buffer_index = 0;
+  static uint8_t buffer[BUFFER_LENGTH] = {0};
+
+  if (buffer_index == 0) {
+    drbg_generate(buffer, sizeof(buffer));
+  }
+
+  // To be extra sure there is no buffer overflow, we use a local copy of
+  // buffer_index
+  size_t buffer_index_local = buffer_index % sizeof(buffer);
+  uint8_t value = buffer[buffer_index_local];
+  memzero(&buffer[buffer_index_local], 1);
+  buffer_index = (buffer_index_local + 1) % sizeof(buffer);
+
+  atomic_flag_clear(&locked);  // locked = false
+  return value;
+}
+
+static void wait(uint32_t delay) {
+  // wait (30 + delay) ticks
+  asm volatile(
+      "ldr r0, %0;"  // r0 = delay
+      "loop:"
+      "subs r0, $3;"  // r0 -= 3
+      "bhs loop;"     // if (r0 >= 3): goto loop
+      // loop (delay // 3) times
+      // every loop takes 3 ticks
+      // r0 == (delay % 3) - 3
+      "add r0, $3;"  // r0 += 3
+      // r0 == delay % 3
+      "and r0, r0, $3;"  // r0 %= 4, make sure that 0 <= r0 < 4
+      "ldr r1, =table;"  // r1 = &table
+      "tbb [r1, r0];"    // jump 2*r1[r0] bytes forward, that is goto wait_r0
+      "base:"
+      "table:"  // table of branch lengths
+      ".byte (wait_0 - base)/2;"
+      ".byte (wait_1 - base)/2;"
+      ".byte (wait_2 - base)/2;"
+      ".byte (wait_2 - base)/2;"  // next instruction must be 2-byte aligned
+      "wait_2:"
+      "add r0, $1;"  // wait one tick
+      "wait_1:"
+      "add r0, $1;"  // wait one tick
+      "wait_0:"
+      :
+      : "m"(delay)
+      : "r0", "r1");
+}
+
+void random_delays_init() { drbg_init(); }
+
+void rdi_start(void) {
+  ensure(drbg_initialized, NULL);
+
+  if (rdi_disabled == sectrue) {  // if rdi disabled
+    refresh_session_delay = true;
+    rdi_disabled = secfalse;
+  }
+}
+
+void rdi_stop(void) {
+  if (rdi_disabled == secfalse) {  // if rdi enabled
+    rdi_disabled = sectrue;
+    session_delay = 0;
+  }
 }
 
 void rdi_refresh_session_delay(void) {
@@ -85,62 +176,14 @@ void rdi_refresh_session_delay(void) {
 void rdi_handler(uint32_t uw_tick) {
   if (rdi_disabled == secfalse) {  // if rdi enabled
     if (refresh_session_delay) {
-      session_delay = random8();
+      session_delay = drbg_random8();
       refresh_session_delay = false;
     }
 
-    uint32_t delay = random8() + session_delay;
+    wait(drbg_random8() + session_delay);
 
-    // wait (30 + delay) ticks
-    asm volatile(
-        "ldr r0, %0;"  // r0 = delay
-        "loop:"
-        "subs r0, $3;"  // r0 -= 3
-        "bhs loop;"     // if (r0 >= 3): goto loop
-        // loop (delay // 3) times
-        // every loop takes 3 ticks
-        // r0 == (delay % 3) - 3
-        "add r0, $3;"  // r0 += 3
-        // r0 == delay % 3
-        "and r0, r0, $3;"  // r0 %= 4, make sure that 0 <= r0 < 4
-        "ldr r1, =table;"  // r1 = &table
-        "tbb [r1, r0];"    // jump 2*r1[r0] bytes forward, that is goto wait_r0
-        "base:"
-        "table:"  // table of branch lengths
-        ".byte (wait_0 - base)/2;"
-        ".byte (wait_1 - base)/2;"
-        ".byte (wait_2 - base)/2;"
-        ".byte (wait_2 - base)/2;"  // next instruction must be 2-byte aligned
-        "wait_2:"
-        "add r0, $1;"  // wait one tick
-        "wait_1:"
-        "add r0, $1;"  // wait one tick
-        "wait_0:"
-        :
-        : "m"(delay)
-        : "r0", "r1");
   } else {  // if rdi disabled or rdi_disabled corrupted
     ensure(rdi_disabled, "Fault detected");
-  }
-}
-
-void rdi_start(void) {
-  if (rdi_disabled == sectrue) {  // if rdi disabled
-    uint8_t entropy[CHACHA_DRBG_SEED_LENGTH];
-    random_buffer(entropy, CHACHA_DRBG_SEED_LENGTH);
-    chacha_drbg_init(&drbg_ctx, entropy, sizeof(entropy), NULL, 0);
-    buffer_refill();
-    buffer_index = 0;
-    refresh_session_delay = true;
-    rdi_disabled = secfalse;
-  }
-}
-
-void rdi_stop(void) {
-  if (rdi_disabled == secfalse) {  // if rdi enabled
-    rdi_disabled = sectrue;
-    session_delay = 0;
-    memzero(&drbg_ctx, sizeof(drbg_ctx));
   }
 }
 
@@ -149,7 +192,7 @@ void rdi_stop(void) {
  * against fault injection.
  */
 void wait_random(void) {
-  int wait = drbg_random32() & 0xff;
+  int wait = drbg_random8();
   volatile int i = 0;
   volatile int j = wait;
   while (i < wait) {

--- a/core/embed/trezorhal/random_delays.h
+++ b/core/embed/trezorhal/random_delays.h
@@ -17,21 +17,15 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-#ifndef __TREZORHAL_COMMON_H__
-#define __TREZORHAL_COMMON_H__
+#ifndef __TREZORHAL_RANDOM_DELAYS_H__
+#define __TREZORHAL_RANDOM_DELAYS_H__
 
-#include "secbool.h"
+#include <stdint.h>
 
-void __fatal_error(const char *expr, const char *msg, const char *file,
-                   int line, const char *func);
-void error_shutdown(const char *line1, const char *line2, const char *line3,
-                    const char *line4);
+void rdi_start(void);
+void rdi_stop(void);
+void rdi_refresh_session_delay(void);
+void rdi_handler(uint32_t uw_tick);
 
-#define ensure(expr, msg) \
-  (((expr) == sectrue)    \
-       ? (void)0          \
-       : __fatal_error(#expr, msg, __FILE__, __LINE__, __func__))
-
-#define hal_delay(ms) (void)ms;
-
+void wait_random(void);
 #endif

--- a/core/embed/trezorhal/random_delays.h
+++ b/core/embed/trezorhal/random_delays.h
@@ -22,6 +22,8 @@
 
 #include <stdint.h>
 
+void random_delays_init(void);
+
 void rdi_start(void);
 void rdi_stop(void);
 void rdi_refresh_session_delay(void);

--- a/core/embed/trezorhal/systick.c
+++ b/core/embed/trezorhal/systick.c
@@ -49,7 +49,7 @@
 #include "systick.h"
 
 #ifdef RDI
-  #include "rdi.h"
+  #include "random_delays.h"
 #endif
 
 #include "systemview.h"

--- a/core/embed/trezorhal/usb.c
+++ b/core/embed/trezorhal/usb.c
@@ -21,7 +21,7 @@
 
 #include "usb.h"
 #include "common.h"
-#include "rdi.h"
+#include "random_delays.h"
 #include "usbd_core.h"
 
 #define USB_MAX_CONFIG_DESC_SIZE 256

--- a/core/embed/unix/common.c
+++ b/core/embed/unix/common.c
@@ -107,8 +107,6 @@ error_shutdown(const char *line1, const char *line2, const char *line3,
 
 void hal_delay(uint32_t ms) { usleep(1000 * ms); }
 
-void wait_random(void) {}
-
 uint8_t HW_ENTROPY_DATA[HW_ENTROPY_LEN];
 
 void collect_hw_entropy(void) { memzero(HW_ENTROPY_DATA, HW_ENTROPY_LEN); }

--- a/core/embed/unix/common.h
+++ b/core/embed/unix/common.h
@@ -56,7 +56,6 @@ error_shutdown(const char *line1, const char *line2, const char *line3,
        : __fatal_error(#expr, msg, __FILE__, __LINE__, __func__))
 
 void hal_delay(uint32_t ms);
-void wait_random(void);
 
 void collect_hw_entropy(void);
 #define HW_ENTROPY_LEN (12 + 32)

--- a/core/embed/unix/random_delays.c
+++ b/core/embed/unix/random_delays.c
@@ -17,21 +17,6 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-#ifndef __TREZORHAL_COMMON_H__
-#define __TREZORHAL_COMMON_H__
+#include "random_delays.h"
 
-#include "secbool.h"
-
-void __fatal_error(const char *expr, const char *msg, const char *file,
-                   int line, const char *func);
-void error_shutdown(const char *line1, const char *line2, const char *line3,
-                    const char *line4);
-
-#define ensure(expr, msg) \
-  (((expr) == sectrue)    \
-       ? (void)0          \
-       : __fatal_error(#expr, msg, __FILE__, __LINE__, __func__))
-
-#define hal_delay(ms) (void)ms;
-
-#endif
+void wait_random(void) {}

--- a/core/embed/unix/random_delays.h
+++ b/core/embed/unix/random_delays.h
@@ -17,21 +17,8 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-#ifndef __TREZORHAL_COMMON_H__
-#define __TREZORHAL_COMMON_H__
+#ifndef __TREZORHAL_RANDOM_DELAYS_H__
+#define __TREZORHAL_RANDOM_DELAYS_H__
 
-#include "secbool.h"
-
-void __fatal_error(const char *expr, const char *msg, const char *file,
-                   int line, const char *func);
-void error_shutdown(const char *line1, const char *line2, const char *line3,
-                    const char *line4);
-
-#define ensure(expr, msg) \
-  (((expr) == sectrue)    \
-       ? (void)0          \
-       : __fatal_error(#expr, msg, __FILE__, __LINE__, __func__))
-
-#define hal_delay(ms) (void)ms;
-
+void wait_random(void);
 #endif

--- a/crypto/chacha20poly1305/chacha_merged.c
+++ b/crypto/chacha20poly1305/chacha_merged.c
@@ -59,6 +59,12 @@ void ECRYPT_ivsetup(ECRYPT_ctx *x,const u8 *iv)
   x->input[15] = U8TO32_LITTLE(iv + 4);
 }
 
+void ECRYPT_ctrsetup(ECRYPT_ctx *x,const u8 *ctr)
+{
+  x->input[12] = U8TO32_LITTLE(ctr + 0);
+  x->input[13] = U8TO32_LITTLE(ctr + 4);
+}
+
 void ECRYPT_encrypt_bytes(ECRYPT_ctx *x,const u8 *m,u8 *c,u32 bytes)
 {
   u32 x0 = 0, x1 = 0, x2 = 0, x3 = 0, x4 = 0, x5 = 0, x6 = 0, x7 = 0, x8 = 0, x9 = 0, x10 = 0, x11 = 0, x12 = 0, x13 = 0, x14 = 0, x15 = 0;

--- a/crypto/chacha20poly1305/ecrypt-sync.h
+++ b/crypto/chacha20poly1305/ecrypt-sync.h
@@ -90,11 +90,20 @@ void ECRYPT_keysetup(
  * IV setup. After having called ECRYPT_keysetup(), the user is
  * allowed to call ECRYPT_ivsetup() different times in order to
  * encrypt/decrypt different messages with the same key but different
- * IV's.
+ * IV's. ECRYPT_ivsetup() also sets block counter to zero.
  */
 void ECRYPT_ivsetup(
   ECRYPT_ctx* ctx,
   const u8* iv);
+
+/*
+ * Block counter setup. It is used only for special purposes,
+ * since block counter is usually initialized with ECRYPT_ivsetup.
+ * ECRYPT_ctrsetup has to be called after ECRYPT_ivsetup.
+ */
+void ECRYPT_ctrsetup(
+  ECRYPT_ctx* ctx,
+  const u8* ctr);
 
 /*
  * Encryption/decryption of arbitrary length messages.

--- a/crypto/chacha_drbg.c
+++ b/crypto/chacha_drbg.c
@@ -19,44 +19,108 @@
 
 #include "chacha_drbg.h"
 
+#include <assert.h>
 #include <stdint.h>
+#include <string.h>
+
+#include "chacha20poly1305/ecrypt-portable.h"
+#include "memzero.h"
+#include "sha2.h"
+
+#define CHACHA_DRBG_KEY_LENGTH 32
+#define CHACHA_DRBG_COUNTER_LENGTH 8
+#define CHACHA_DRBG_IV_LENGTH 8
+#define CHACHA_DRBG_SEED_LENGTH \
+  (CHACHA_DRBG_KEY_LENGTH + CHACHA_DRBG_COUNTER_LENGTH + CHACHA_DRBG_IV_LENGTH)
 
 #define MAX(a, b) (a) > (b) ? (a) : (b)
 
-void chacha_drbg_init(CHACHA_DRBG_CTX *ctx,
-                      const uint8_t entropy[CHACHA_DRBG_SEED_LENGTH]) {
+static void derivation_function(const uint8_t *input1, size_t input1_length,
+                                const uint8_t *input2, size_t input2_length,
+                                uint8_t *output, size_t output_length) {
+  // Implementation of Hash_df from NIST SP 800-90A
+  uint32_t block_count = (output_length - 1) / SHA256_DIGEST_LENGTH + 1;
+  size_t partial_block_length = output_length % SHA256_DIGEST_LENGTH;
+  assert(block_count <= 255);
+
+  uint32_t output_length_bits = output_length * 8;
+#if BYTE_ORDER == LITTLE_ENDIAN
+  REVERSE32(output_length_bits, output_length_bits);
+#endif
+
+  SHA256_CTX ctx = {0};
+
+  for (uint8_t counter = 1; counter <= block_count; counter++) {
+    sha256_Init(&ctx);
+    sha256_Update(&ctx, &counter, sizeof(counter));
+    sha256_Update(&ctx, (uint8_t *)&output_length_bits,
+                  sizeof(output_length_bits));
+    sha256_Update(&ctx, input1, input1_length);
+    sha256_Update(&ctx, input2, input2_length);
+
+    if (counter != block_count || partial_block_length == 0) {
+      sha256_Final(&ctx, output);
+      output += SHA256_DIGEST_LENGTH;
+    } else {  // last block is partial
+      uint8_t digest[SHA256_DIGEST_LENGTH] = {0};
+      sha256_Final(&ctx, digest);
+      memcpy(output, digest, partial_block_length);
+      memzero(digest, sizeof(digest));
+    }
+  }
+
+  memzero(&ctx, sizeof(ctx));
+}
+
+void chacha_drbg_init(CHACHA_DRBG_CTX *ctx, const uint8_t *entropy,
+                      size_t entropy_length, const uint8_t *nonce,
+                      size_t nonce_length) {
   uint8_t buffer[MAX(CHACHA_DRBG_KEY_LENGTH, CHACHA_DRBG_IV_LENGTH)] = {0};
   ECRYPT_keysetup(&ctx->chacha_ctx, buffer, CHACHA_DRBG_KEY_LENGTH * 8,
                   CHACHA_DRBG_IV_LENGTH * 8);
   ECRYPT_ivsetup(&ctx->chacha_ctx, buffer);
 
-  chacha_drbg_reseed(ctx, entropy);
+  chacha_drbg_reseed(ctx, entropy, entropy_length, nonce, nonce_length);
 }
 
 static void chacha_drbg_update(CHACHA_DRBG_CTX *ctx,
                                const uint8_t data[CHACHA_DRBG_SEED_LENGTH]) {
-  uint8_t buffer[CHACHA_DRBG_SEED_LENGTH] = {0};
+  uint8_t seed[CHACHA_DRBG_SEED_LENGTH] = {0};
 
   if (data)
-    ECRYPT_encrypt_bytes(&ctx->chacha_ctx, data, buffer,
-                         CHACHA_DRBG_SEED_LENGTH);
+    ECRYPT_encrypt_bytes(&ctx->chacha_ctx, data, seed, CHACHA_DRBG_SEED_LENGTH);
   else
-    ECRYPT_keystream_bytes(&ctx->chacha_ctx, buffer, CHACHA_DRBG_SEED_LENGTH);
+    ECRYPT_keystream_bytes(&ctx->chacha_ctx, seed, CHACHA_DRBG_SEED_LENGTH);
 
-  ECRYPT_keysetup(&ctx->chacha_ctx, buffer, CHACHA_DRBG_KEY_LENGTH * 8,
+  ECRYPT_keysetup(&ctx->chacha_ctx, seed, CHACHA_DRBG_KEY_LENGTH * 8,
                   CHACHA_DRBG_IV_LENGTH * 8);
-  ECRYPT_ivsetup(&ctx->chacha_ctx, buffer + CHACHA_DRBG_KEY_LENGTH);
+
+  ECRYPT_ivsetup(&ctx->chacha_ctx,
+                 seed + CHACHA_DRBG_KEY_LENGTH + CHACHA_DRBG_COUNTER_LENGTH);
+
+  ECRYPT_ctrsetup(&ctx->chacha_ctx, seed + CHACHA_DRBG_KEY_LENGTH);
+
+  memzero(seed, sizeof(seed));
 }
 
 void chacha_drbg_generate(CHACHA_DRBG_CTX *ctx, uint8_t *output,
-                          uint8_t output_length) {
+                          size_t output_length) {
+  assert(output_length < 65536);
+  assert(ctx->reseed_counter + 1 != 0);
+
   ECRYPT_keystream_bytes(&ctx->chacha_ctx, output, output_length);
   chacha_drbg_update(ctx, NULL);
   ctx->reseed_counter++;
 }
 
-void chacha_drbg_reseed(CHACHA_DRBG_CTX *ctx,
-                        const uint8_t entropy[CHACHA_DRBG_SEED_LENGTH]) {
-  chacha_drbg_update(ctx, entropy);
+void chacha_drbg_reseed(CHACHA_DRBG_CTX *ctx, const uint8_t *entropy,
+                        size_t entropy_length, const uint8_t *additional_input,
+                        size_t additional_input_length) {
+  uint8_t seed[CHACHA_DRBG_SEED_LENGTH] = {0};
+  derivation_function(entropy, entropy_length, additional_input,
+                      additional_input_length, seed, sizeof(seed));
+  chacha_drbg_update(ctx, seed);
+  memzero(seed, sizeof(seed));
+
   ctx->reseed_counter = 1;
 }

--- a/crypto/chacha_drbg.h
+++ b/crypto/chacha_drbg.h
@@ -21,23 +21,34 @@
 #define __CHACHA_DRBG__
 
 #include "chacha20poly1305/chacha20poly1305.h"
+#include "sha2.h"
 
-// Very fast deterministic random bit generator inspired by CTR_DRBG in NIST SP
-// 800-90A
+// A very fast deterministic random bit generator based on CTR_DRBG in NIST SP
+// 800-90A. Chacha is used instead of a block cipher in the counter mode, SHA256
+// is used as a derivation function. The highest supported security strength is
+// at least 256 bits. Reseeding is left up to caller.
 
-#define CHACHA_DRBG_KEY_LENGTH 16
-#define CHACHA_DRBG_IV_LENGTH 8
-#define CHACHA_DRBG_SEED_LENGTH (CHACHA_DRBG_KEY_LENGTH + CHACHA_DRBG_IV_LENGTH)
+// Length of inputs of chacha_drbg_init (entropy and nonce) or
+// chacha_drbg_reseed (entropy and additional_input) that fill exactly
+// block_count blocks of hash function in derivation_function. There is no need
+// the input to have this length, it's just an optimalization.
+#define CHACHA_DRBG_OPTIMAL_RESEED_LENGTH(block_count) \
+  ((block_count)*SHA256_BLOCK_LENGTH - 1 - 4 - 9)
+// 1 = sizeof(counter), 4 = sizeof(output_length) in
+// derivation_function, 9 is length of SHA256 padding of message
+// aligned to bytes
 
 typedef struct _CHACHA_DRBG_CTX {
   ECRYPT_ctx chacha_ctx;
   uint32_t reseed_counter;
 } CHACHA_DRBG_CTX;
 
-void chacha_drbg_init(CHACHA_DRBG_CTX *ctx,
-                      const uint8_t entropy[CHACHA_DRBG_SEED_LENGTH]);
-void chacha_drbg_reseed(CHACHA_DRBG_CTX *ctx,
-                        const uint8_t entropy[CHACHA_DRBG_SEED_LENGTH]);
+void chacha_drbg_init(CHACHA_DRBG_CTX *ctx, const uint8_t *entropy,
+                      size_t entropy_length, const uint8_t *nonce,
+                      size_t nonce_length);
 void chacha_drbg_generate(CHACHA_DRBG_CTX *ctx, uint8_t *output,
-                          uint8_t output_length);
+                          size_t output_length);
+void chacha_drbg_reseed(CHACHA_DRBG_CTX *ctx, const uint8_t *entropy,
+                        size_t entropy_length, const uint8_t *additional_input,
+                        size_t additional_input_length);
 #endif  // __CHACHA_DRBG__

--- a/legacy/Makefile
+++ b/legacy/Makefile
@@ -7,6 +7,7 @@ OBJS += common.o
 OBJS += flash.o
 OBJS += layout.o
 OBJS += oled.o
+OBJS += random_delays.o
 OBJS += rng.o
 
 ifneq ($(EMULATOR),1)

--- a/legacy/common.c
+++ b/legacy/common.c
@@ -85,23 +85,6 @@ void __assert_func(const char *file, int line, const char *func,
 
 void hal_delay(uint32_t ms) { usbSleep(ms); }
 
-void wait_random(void) {
-  int wait = random32() & 0xff;
-  volatile int i = 0;
-  volatile int j = wait;
-  while (i < wait) {
-    if (i + j != wait) {
-      shutdown();
-    }
-    ++i;
-    --j;
-  }
-  // Double-check loop completion.
-  if (i != wait || j != 0) {
-    shutdown();
-  }
-}
-
 void drbg_init() {
   uint8_t entropy[48] = {0};
   random_buffer(entropy, sizeof(entropy));

--- a/legacy/common.h
+++ b/legacy/common.h
@@ -41,8 +41,6 @@ error_shutdown(const char *line1, const char *line2, const char *line3,
 
 void hal_delay(uint32_t ms);
 
-void wait_random(void);
-
 void drbg_init(void);
 void drbg_reseed(const uint8_t *entropy, size_t len);
 void drbg_generate(uint8_t *buf, size_t len);

--- a/legacy/firmware/usb.c
+++ b/legacy/firmware/usb.c
@@ -24,6 +24,7 @@
 #include "config.h"
 #include "debug.h"
 #include "messages.h"
+#include "random_delays.h"
 #include "timer.h"
 #include "trezor.h"
 #if U2F_ENABLED

--- a/legacy/random_delays.c
+++ b/legacy/random_delays.c
@@ -1,0 +1,41 @@
+/*
+ * This file is part of the Trezor project, https://trezor.io/
+ *
+ * Copyright (c) SatoshiLabs
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#include "random_delays.h"
+
+#include "common.h"
+#include "rng.h"
+#include "util.h"
+
+void wait_random(void) {
+  int wait = random32() & 0xff;
+  volatile int i = 0;
+  volatile int j = wait;
+  while (i < wait) {
+    if (i + j != wait) {
+      shutdown();
+    }
+    ++i;
+    --j;
+  }
+  // Double-check loop completion.
+  if (i != wait || j != 0) {
+    shutdown();
+  }
+}

--- a/legacy/random_delays.h
+++ b/legacy/random_delays.h
@@ -1,0 +1,24 @@
+/*
+ * This file is part of the Trezor project, https://trezor.io/
+ *
+ * Copyright (c) SatoshiLabs
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#ifndef __RANDOM_DELAYS_H__
+#define __RANDOM_DELAYS_H__
+
+void wait_random(void);
+#endif

--- a/legacy/usb21_standard.c
+++ b/legacy/usb21_standard.c
@@ -19,7 +19,7 @@
 #include "usb21_standard.h"
 #include <stdint.h>
 #include <string.h>
-#include "common.h"
+#include "random_delays.h"
 #include "util.h"
 
 static uint16_t build_bos_descriptor(const struct usb_bos_descriptor *bos,

--- a/legacy/usb_standard.c
+++ b/legacy/usb_standard.c
@@ -38,7 +38,7 @@ LGPL License Terms @ref lgpl_license
 
 #include <string.h>
 #include <libopencm3/usb/usbd.h>
-#include "common.h"
+#include "random_delays.h"
 #include "usb_private.h"
 #include "util.h"
 

--- a/legacy/webusb.c
+++ b/legacy/webusb.c
@@ -18,7 +18,7 @@
 
 #include <string.h>
 
-#include "common.h"
+#include "random_delays.h"
 #include "usb21_standard.h"
 #include "util.h"
 #include "webusb.h"

--- a/legacy/winusb.c
+++ b/legacy/winusb.c
@@ -18,7 +18,7 @@
 
 #include "winusb.h"
 #include <libopencm3/usb/usbd.h>
-#include "common.h"
+#include "random_delays.h"
 #include "util.h"
 
 static int usb_descriptor_type(uint16_t wValue) { return wValue >> 8; }

--- a/storage/storage.c
+++ b/storage/storage.c
@@ -27,6 +27,7 @@
 #include "norcow.h"
 #include "pbkdf2.h"
 #include "rand.h"
+#include "random_delays.h"
 #include "sha2.h"
 #include "storage.h"
 

--- a/storage/tests/c/Makefile
+++ b/storage/tests/c/Makefile
@@ -6,6 +6,7 @@ BASE = ../../../
 
 SRC  = storage/tests/c/flash.c
 SRC += storage/tests/c/common.c
+SRC += storage/tests/c/random_delays.c
 SRC += storage/storage.c
 SRC += storage/norcow.c
 SRC += crypto/pbkdf2.c

--- a/storage/tests/c/common.c
+++ b/storage/tests/c/common.c
@@ -23,8 +23,6 @@
 
 #include "common.h"
 
-void wait_random(void) {}
-
 void __shutdown(void) {
   printf("SHUTDOWN\n");
   exit(3);

--- a/storage/tests/c/random_delays.c
+++ b/storage/tests/c/random_delays.c
@@ -17,21 +17,6 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-#ifndef __TREZORHAL_COMMON_H__
-#define __TREZORHAL_COMMON_H__
+#include "random_delays.h"
 
-#include "secbool.h"
-
-void __fatal_error(const char *expr, const char *msg, const char *file,
-                   int line, const char *func);
-void error_shutdown(const char *line1, const char *line2, const char *line3,
-                    const char *line4);
-
-#define ensure(expr, msg) \
-  (((expr) == sectrue)    \
-       ? (void)0          \
-       : __fatal_error(#expr, msg, __FILE__, __LINE__, __func__))
-
-#define hal_delay(ms) (void)ms;
-
-#endif
+void wait_random(void) {}

--- a/storage/tests/c/random_delays.h
+++ b/storage/tests/c/random_delays.h
@@ -17,13 +17,9 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-#ifndef __TREZORHAL_RDI_H__
-#define __TREZORHAL_RDI_H__
+#ifndef __TREZORHAL_RANDOM_DELAYS_H__
+#define __TREZORHAL_RANDOM_DELAYS_H__
 
-#include <stdint.h>
+void wait_random(void);
 
-void rdi_start(void);
-void rdi_stop(void);
-void rdi_refresh_session_delay(void);
-void rdi_handler(uint32_t uw_tick);
 #endif


### PR DESCRIPTION
This PR replaces https://github.com/trezor/trezor-firmware/pull/1481.

The purpose of this PR is to replace hmac_drbg (that is used by random interrupts and `wait_random`) with faster chacha_drbg.