### PR TITLE
common/connect: ltc and tltc coin def fee updates; add litecoin testnet blockbook node

### DIFF
--- a/common/defs/bitcoin/litecoin.json
+++ b/common/defs/bitcoin/litecoin.json
@@ -27,7 +27,10 @@
   "fork_id": null,
   "force_bip143": false,
   "default_fee_b": {
-    "Normal": 1000
+    "Low": 1,
+    "Economy": 1,
+    "Normal": 1,
+    "High": 2
   },
   "dust_limit": 546,
   "blocktime_seconds": 150,

--- a/common/defs/bitcoin/litecoin_testnet.json
+++ b/common/defs/bitcoin/litecoin_testnet.json
@@ -27,7 +27,10 @@
   "fork_id": null,
   "force_bip143": false,
   "default_fee_b": {
-    "Normal": 10
+    "Low": 1,
+    "Economy": 1,
+    "Normal": 1,
+    "High": 2
   },
   "dust_limit": 54600,
   "blocktime_seconds": 150,

--- a/common/defs/blockchain_link.json
+++ b/common/defs/blockchain_link.json
@@ -223,6 +223,12 @@
       "https://blockbook-test.groestlcoin.org"
     ]
   },
+  "bitcoin:tLTC": {
+    "type": "blockbook",
+    "url": [
+      "https://tltc1.test"
+    ]
+  },
   "bitcoin:tPIVX": {
     "type": "blockbook",
     "url": [


### PR DESCRIPTION
These changes stem from and support my work on the trezor-suite support for LTC and TLTC. I'm open to feedback on these if someone thinks they should be different.

First, I added a blockbook URL for TLTC. I chose to use `https://tltc1.test` because I didn't want to presume that trezor would run a TLTC blockbook node. If you guys will, that would be great, and I'll change the url to be `https://tltc1.trezor.io`. If not, this is what I've been testing with (I quickly stood up a temporary TLTC blockbook node on one of the usual cloud providers -- not `localhost`). I didn't ask around to see if someone would fund a full-time testnet node (a possibility, I've just been working on this stuff). The `test` TLD is a good stub and compromise for having support included in trezor-connect, while not taking on the burden of running a node all the time. A simple edit to `/etc/hosts` allows testing with the node of your choice. If the config is not in trezor-connect then one has to tinker with and then run another connect node locally (it's kind of a pain). More info about the `test` TLD:
https://www.iana.org/domains/reserved
https://tools.ietf.org/html/rfc2606
https://tools.ietf.org/html/rfc6761

Second, I updated the default fee rates for LTC and TLTC. I added the same fee levels that BTC has just for completeness. I've been using 1 sat/vbyte on both networks for a while with no trouble. I wanted to keep the configs similar for LTC and TLTC so that testing is more similar. The fee estimates for the different levels update from the blockbook node as network activity dictates. So, it's probable that these levels will be 1 most of the time. Consistency with BTC was the tradeoff that I chose.