### PR TITLE
legacy: Update op_return max size to 150 bytes

### DIFF
--- a/legacy/firmware/protob/messages-bitcoin.options
+++ b/legacy/firmware/protob/messages-bitcoin.options
@@ -38,7 +38,7 @@ TxInputType.orig_hash                                       max_size:32
 
 TxOutputType.address                                        max_size:130
 TxOutputType.address_n                                      max_count:8
-TxOutputType.op_return_data                                 max_size:80
+TxOutputType.op_return_data                                 max_size:150
 TxOutputType.orig_hash                                      max_size:32
 
 TxOutputBinType.script_pubkey                               max_size:520
@@ -65,7 +65,7 @@ TxInput.orig_hash                                           max_size:32
 
 TxOutput.address                                            max_size:130
 TxOutput.address_n                                          max_count:8
-TxOutput.op_return_data                                     max_size:80
+TxOutput.op_return_data                                     max_size:150
 TxOutput.orig_hash                                          max_size:32
 
 PrevInput.prev_hash                                         max_size:32


### PR DESCRIPTION
The goal is to allow Trezor 1 to create TPoS contracts for Stakenet.

Last year, Stakenet introduced a hard-fork [1] to change the way TPoS contracts
are created, instead of a custom signature method, now it works with the
output from the signMessage method, while this works for Trezor T, it doesn't
work for Trezor 1 due to the 80 bytes limit on the OP_RETURN output while
Stakenet allows up to 150 bytes [2], in a gitter discussion [3] we concluded that
the change should be fine.

The hard-fork was introduced because we couldn't got our TPoS contracts PR accepted [4],
the OP_RETURN still contains the same data, its just stored in a different way:
- The TPoS address, where the coins to stake are stored, and where rewards are received.
- The merchant address, where the merchant receives its commission.
- The contract commission.
- The TPoS collateral signature (this is what uses the signMessage now).

At last, there is an example transaction creating a TPoS contract [5].

[1]: https://github.com/X9Developers/XSN/pull/154
[2]: https://github.com/X9Developers/XSN/blob/master/src/script/standard.h#L34
[3]: https://gitter.im/trezor/community?at=6064c41e940f1d555e2ea670
[4]: https://github.com/trezor/trezor-firmware/pull/140
[5]: https://xsnexplorer.io/transactions/858feb31097501cf68d698cde104cf778ec51ff3668e943404b549a5dd2f5792