### PR TITLE
Fix case of windows.h

### DIFF
--- a/crypto/memzero.c
+++ b/crypto/memzero.c
@@ -4,7 +4,7 @@
 #include <string.h>
 
 #ifdef _WIN32
-#include <Windows.h>
+#include <windows.h>
 #endif
 
 #ifdef __unix__


### PR DESCRIPTION
When building for windows on a case-sensitive system, mingw always comes with a lower-case windows.h .

Fixing this case prevents build failure when cross-compiling for windows.