### PR TITLE
Reduce string manipulations in BTC signing

### DIFF
--- a/core/.changelog.d/1581.changed
+++ b/core/.changelog.d/1581.changed
@@ -1,0 +1,1 @@
+Memory optimization of BTC signing and CBOR decoding.

--- a/core/src/apps/binance/helpers.py
+++ b/core/src/apps/binance/helpers.py
@@ -1,7 +1,7 @@
 from micropython import const
 
 from trezor.crypto import bech32
-from trezor.crypto.scripts import sha256_ripemd160_digest
+from trezor.crypto.scripts import sha256_ripemd160
 from trezor.messages import (
     BinanceCancelMsg,
     BinanceInputOutput,
@@ -86,7 +86,7 @@ def address_from_public_key(pubkey: bytes, hrp: str) -> str:
     HRP - bnb for productions, tbnb for tests
     """
 
-    h = sha256_ripemd160_digest(pubkey)
+    h = sha256_ripemd160(pubkey).digest()
 
     convertedbits = bech32.convertbits(h, 8, 5, False)
 

--- a/core/src/apps/bitcoin/addresses.py
+++ b/core/src/apps/bitcoin/addresses.py
@@ -97,7 +97,7 @@ def address_multisig_p2wsh(pubkeys: list[bytes], m: int, hrp: str) -> str:
 
 
 def address_pkh(pubkey: bytes, coin: CoinInfo) -> str:
-    s = address_type.tobytes(coin.address_type) + coin.script_hash(pubkey)
+    s = address_type.tobytes(coin.address_type) + coin.script_hash(pubkey).digest()
     return base58.encode_check(bytes(s), coin.b58_hash)
 
 
@@ -109,13 +109,13 @@ def address_p2sh(redeem_script_hash: bytes, coin: CoinInfo) -> str:
 def address_p2wpkh_in_p2sh(pubkey: bytes, coin: CoinInfo) -> str:
     pubkey_hash = ecdsa_hash_pubkey(pubkey, coin)
     redeem_script = output_script_native_p2wpkh_or_p2wsh(pubkey_hash)
-    redeem_script_hash = coin.script_hash(redeem_script)
+    redeem_script_hash = coin.script_hash(redeem_script).digest()
     return address_p2sh(redeem_script_hash, coin)
 
 
 def address_p2wsh_in_p2sh(witness_script_hash: bytes, coin: CoinInfo) -> str:
     redeem_script = output_script_native_p2wpkh_or_p2wsh(witness_script_hash)
-    redeem_script_hash = coin.script_hash(redeem_script)
+    redeem_script_hash = coin.script_hash(redeem_script).digest()
     return address_p2sh(redeem_script_hash, coin)
 
 

--- a/core/src/apps/bitcoin/addresses.py
+++ b/core/src/apps/bitcoin/addresses.py
@@ -3,13 +3,14 @@ from trezor.crypto import base58, cashaddr
 from trezor.crypto.hashlib import sha256
 from trezor.enums import InputScriptType
 from trezor.messages import MultisigRedeemScriptType
+from trezor.utils import HashWriter
 
 from apps.common import address_type
 from apps.common.coininfo import CoinInfo
 
 from .common import ecdsa_hash_pubkey, encode_bech32_address
 from .multisig import multisig_get_pubkeys, multisig_pubkey_index
-from .scripts import output_script_multisig, output_script_native_p2wpkh_or_p2wsh
+from .scripts import output_script_native_p2wpkh_or_p2wsh, write_output_script_multisig
 
 if False:
     from trezor.crypto import bip32
@@ -75,25 +76,25 @@ def get_address(
 def address_multisig_p2sh(pubkeys: list[bytes], m: int, coin: CoinInfo) -> str:
     if coin.address_type_p2sh is None:
         raise wire.ProcessError("Multisig not enabled on this coin")
-    redeem_script = output_script_multisig(pubkeys, m)
-    redeem_script_hash = coin.script_hash(redeem_script)
-    return address_p2sh(redeem_script_hash, coin)
+    redeem_script = HashWriter(coin.script_hash())
+    write_output_script_multisig(redeem_script, pubkeys, m)
+    return address_p2sh(redeem_script.get_digest(), coin)
 
 
 def address_multisig_p2wsh_in_p2sh(pubkeys: list[bytes], m: int, coin: CoinInfo) -> str:
     if coin.address_type_p2sh is None:
         raise wire.ProcessError("Multisig not enabled on this coin")
-    witness_script = output_script_multisig(pubkeys, m)
-    witness_script_hash = sha256(witness_script).digest()
-    return address_p2wsh_in_p2sh(witness_script_hash, coin)
+    witness_script_h = HashWriter(sha256())
+    write_output_script_multisig(witness_script_h, pubkeys, m)
+    return address_p2wsh_in_p2sh(witness_script_h.get_digest(), coin)
 
 
 def address_multisig_p2wsh(pubkeys: list[bytes], m: int, hrp: str) -> str:
     if not hrp:
         raise wire.ProcessError("Multisig not enabled on this coin")
-    witness_script = output_script_multisig(pubkeys, m)
-    witness_script_hash = sha256(witness_script).digest()
-    return address_p2wsh(witness_script_hash, hrp)
+    witness_script_h = HashWriter(sha256())
+    write_output_script_multisig(witness_script_h, pubkeys, m)
+    return address_p2wsh(witness_script_h.get_digest(), hrp)
 
 
 def address_pkh(pubkey: bytes, coin: CoinInfo) -> str:

--- a/core/src/apps/bitcoin/common.py
+++ b/core/src/apps/bitcoin/common.py
@@ -73,7 +73,7 @@ def ecdsa_hash_pubkey(pubkey: bytes, coin: CoinInfo) -> bytes:
     else:
         ensure(len(pubkey) == 33)  # compresssed format
 
-    return coin.script_hash(pubkey)
+    return coin.script_hash(pubkey).digest()
 
 
 def encode_bech32_address(prefix: str, script: bytes) -> str:

--- a/core/src/apps/bitcoin/ownership.py
+++ b/core/src/apps/bitcoin/ownership.py
@@ -67,7 +67,7 @@ def verify_nonownership(
 ) -> bool:
     try:
         r = utils.BufferReader(proof)
-        if r.read(4) != _VERSION_MAGIC:
+        if r.read_memoryview(4) != _VERSION_MAGIC:
             raise wire.DataError("Unknown format of proof of ownership")
 
         flags = r.get()
@@ -79,7 +79,7 @@ def verify_nonownership(
         ownership_id = get_identifier(script_pubkey, keychain)
         not_owned = True
         for _ in range(id_count):
-            if utils.consteq(ownership_id, r.read(_OWNERSHIP_ID_LEN)):
+            if utils.consteq(ownership_id, r.read_memoryview(_OWNERSHIP_ID_LEN)):
                 not_owned = False
 
         # Verify the BIP-322 SignatureProof.

--- a/core/src/apps/bitcoin/readers.py
+++ b/core/src/apps/bitcoin/readers.py
@@ -3,9 +3,9 @@ from trezor.utils import BufferReader
 from apps.common.readers import read_bitcoin_varint
 
 
-def read_bytes_prefixed(r: BufferReader) -> bytes:
+def read_memoryview_prefixed(r: BufferReader) -> memoryview:
     n = read_bitcoin_varint(r)
-    return r.read(n)
+    return r.read_memoryview(n)
 
 
 def read_op_push(r: BufferReader) -> int:

--- a/core/src/apps/bitcoin/scripts.py
+++ b/core/src/apps/bitcoin/scripts.py
@@ -15,6 +15,7 @@ from .multisig import (
 )
 from .readers import read_bytes_prefixed, read_op_push
 from .writers import (
+    op_push_length,
     write_bytes_fixed,
     write_bytes_prefixed,
     write_bytes_unchecked,
@@ -29,40 +30,44 @@ if False:
     from .writers import Writer
 
 
-def input_derive_script(
+def write_input_script_prefixed(
+    w: Writer,
     script_type: InputScriptType,
     multisig: MultisigRedeemScriptType | None,
     coin: CoinInfo,
     hash_type: int,
     pubkey: bytes,
     signature: bytes,
-) -> bytes:
+) -> None:
     if script_type == InputScriptType.SPENDADDRESS:
         # p2pkh or p2sh
-        return input_script_p2pkh_or_p2sh(pubkey, signature, hash_type)
-
-    if script_type == InputScriptType.SPENDP2SHWITNESS:
+        write_input_script_p2pkh_or_p2sh_prefixed(w, pubkey, signature, hash_type)
+    elif script_type == InputScriptType.SPENDP2SHWITNESS:
         # p2wpkh or p2wsh using p2sh
 
         if multisig is not None:
             # p2wsh in p2sh
             pubkeys = multisig_get_pubkeys(multisig)
-            witness_script_hasher = utils.HashWriter(sha256())
-            write_output_script_multisig(witness_script_hasher, pubkeys, multisig.m)
-            witness_script_hash = witness_script_hasher.get_digest()
-            return input_script_p2wsh_in_p2sh(witness_script_hash)
-
-        # p2wpkh in p2sh
-        return input_script_p2wpkh_in_p2sh(common.ecdsa_hash_pubkey(pubkey, coin))
+            witness_script_h = utils.HashWriter(sha256())
+            write_output_script_multisig(witness_script_h, pubkeys, multisig.m)
+            write_input_script_p2wsh_in_p2sh(
+                w, witness_script_h.get_digest(), prefixed=True
+            )
+        else:
+            # p2wpkh in p2sh
+            write_input_script_p2wpkh_in_p2sh(
+                w, common.ecdsa_hash_pubkey(pubkey, coin), prefixed=True
+            )
     elif script_type == InputScriptType.SPENDWITNESS:
         # native p2wpkh or p2wsh
-        return input_script_native_p2wpkh_or_p2wsh()
+        script_sig = input_script_native_p2wpkh_or_p2wsh()
+        write_bytes_prefixed(w, script_sig)
     elif script_type == InputScriptType.SPENDMULTISIG:
         # p2sh multisig
         assert multisig is not None  # checked in sanitize_tx_input
         signature_index = multisig_pubkey_index(multisig, pubkey)
-        return input_script_multisig(
-            multisig, signature, signature_index, hash_type, coin
+        write_input_script_multisig_prefixed(
+            w, multisig, signature, signature_index, hash_type, coin
         )
     else:
         raise wire.ProcessError("Invalid script type")
@@ -110,11 +115,12 @@ def output_derive_script(address: str, coin: CoinInfo) -> bytes:
 
 # see https://github.com/bitcoin/bips/blob/master/bip-0143.mediawiki#specification
 # item 5 for details
-def bip143_derive_script_code(
-    txi: TxInput, public_keys: list[bytes], threshold: int, coin: CoinInfo
-) -> bytearray:
+def write_bip143_script_code_prefixed(
+    w: Writer, txi: TxInput, public_keys: list[bytes], threshold: int, coin: CoinInfo
+) -> None:
     if len(public_keys) > 1:
-        return output_script_multisig(public_keys, threshold)
+        write_output_script_multisig(w, public_keys, threshold, prefixed=True)
+        return
 
     p2pkh = (
         txi.script_type == InputScriptType.SPENDWITNESS
@@ -122,11 +128,13 @@ def bip143_derive_script_code(
         or txi.script_type == InputScriptType.SPENDADDRESS
         or txi.script_type == InputScriptType.EXTERNAL
     )
+
     if p2pkh:
         # for p2wpkh in p2sh or native p2wpkh
         # the scriptCode is a classic p2pkh
-        return output_script_p2pkh(common.ecdsa_hash_pubkey(public_keys[0], coin))
-
+        write_output_script_p2pkh(
+            w, common.ecdsa_hash_pubkey(public_keys[0], coin), prefixed=True
+        )
     else:
         raise wire.DataError("Unknown input script type for bip143 script code")
 
@@ -136,13 +144,12 @@ def bip143_derive_script_code(
 # https://github.com/bitcoin/bips/blob/master/bip-0016.mediawiki
 
 
-def input_script_p2pkh_or_p2sh(
-    pubkey: bytes, signature: bytes, hash_type: int
-) -> bytearray:
-    w = utils.empty_bytearray(5 + len(signature) + 1 + 5 + len(pubkey))
+def write_input_script_p2pkh_or_p2sh_prefixed(
+    w: Writer, pubkey: bytes, signature: bytes, hash_type: int
+) -> None:
+    write_bitcoin_varint(w, 1 + len(signature) + 1 + 1 + len(pubkey))
     append_signature(w, signature, hash_type)
     append_pubkey(w, pubkey)
-    return w
 
 
 def parse_input_script_p2pkh(script_sig: bytes) -> tuple[bytes, bytes, int]:
@@ -162,15 +169,22 @@ def parse_input_script_p2pkh(script_sig: bytes) -> tuple[bytes, bytes, int]:
     return pubkey, signature, hash_type
 
 
+def write_output_script_p2pkh(
+    w: Writer, pubkeyhash: bytes, prefixed: bool = False
+) -> None:
+    if prefixed:
+        write_bitcoin_varint(w, 25)
+    w.append(0x76)  # OP_DUP
+    w.append(0xA9)  # OP_HASH160
+    w.append(0x14)  # OP_DATA_20
+    write_bytes_fixed(w, pubkeyhash, 20)
+    w.append(0x88)  # OP_EQUALVERIFY
+    w.append(0xAC)  # OP_CHECKSIG
+
+
 def output_script_p2pkh(pubkeyhash: bytes) -> bytearray:
-    utils.ensure(len(pubkeyhash) == 20)
-    s = bytearray(25)
-    s[0] = 0x76  # OP_DUP
-    s[1] = 0xA9  # OP_HASH_160
-    s[2] = 0x14  # pushing 20 bytes
-    s[3:23] = pubkeyhash
-    s[23] = 0x88  # OP_EQUALVERIFY
-    s[24] = 0xAC  # OP_CHECKSIG
+    s = utils.empty_bytearray(25)
+    write_output_script_p2pkh(s, pubkeyhash)
     return s
 
 
@@ -224,17 +238,18 @@ def output_script_native_p2wpkh_or_p2wsh(witprog: bytes) -> bytearray:
 # Uses normal P2SH output scripts.
 
 
-def input_script_p2wpkh_in_p2sh(pubkeyhash: bytes) -> bytearray:
+def write_input_script_p2wpkh_in_p2sh(
+    w: Writer, pubkeyhash: bytes, prefixed: bool = False
+) -> None:
     # 16 00 14 <pubkeyhash>
     # Signature is moved to the witness.
-    utils.ensure(len(pubkeyhash) == 20)
+    if prefixed:
+        write_bitcoin_varint(w, 23)
 
-    w = utils.empty_bytearray(3 + len(pubkeyhash))
     w.append(0x16)  # length of the data
     w.append(0x00)  # witness version byte
     w.append(0x14)  # P2WPKH witness program (pub key hash length)
     write_bytes_fixed(w, pubkeyhash, 20)  # pub key hash
-    return w
 
 
 # SegWit: P2WSH nested in P2SH
@@ -245,31 +260,30 @@ def input_script_p2wpkh_in_p2sh(pubkeyhash: bytes) -> bytearray:
 # Uses normal P2SH output scripts.
 
 
-def input_script_p2wsh_in_p2sh(script_hash: bytes) -> bytearray:
+def write_input_script_p2wsh_in_p2sh(
+    w: Writer, script_hash: bytes, prefixed: bool = False
+) -> None:
     # 22 00 20 <redeem script hash>
     # Signature is moved to the witness.
+    if prefixed:
+        write_bitcoin_varint(w, 35)
 
-    if len(script_hash) != 32:
-        raise wire.DataError("Redeem script hash should be 32 bytes long")
-
-    w = utils.empty_bytearray(3 + len(script_hash))
     w.append(0x22)  # length of the data
     w.append(0x00)  # witness version byte
     w.append(0x20)  # P2WSH witness program (redeem script hash length)
     write_bytes_fixed(w, script_hash, 32)
-    return w
 
 
 # SegWit: Witness getters
 # ===
 
 
-def witness_p2wpkh(signature: bytes, pubkey: bytes, hash_type: int) -> bytearray:
-    w = utils.empty_bytearray(1 + 5 + len(signature) + 1 + 5 + len(pubkey))
+def write_witness_p2wpkh(
+    w: Writer, signature: bytes, pubkey: bytes, hash_type: int
+) -> None:
     write_bitcoin_varint(w, 0x02)  # num of segwit items, in P2WPKH it's always 2
     write_signature_prefixed(w, signature, hash_type)
     write_bytes_prefixed(w, pubkey)
-    return w
 
 
 def parse_witness_p2wpkh(witness: bytes) -> tuple[bytes, bytes, int]:
@@ -293,53 +307,39 @@ def parse_witness_p2wpkh(witness: bytes) -> tuple[bytes, bytes, int]:
     return pubkey, signature, hash_type
 
 
-def witness_multisig(
+def write_witness_multisig(
+    w: Writer,
     multisig: MultisigRedeemScriptType,
     signature: bytes,
     signature_index: int,
     hash_type: int,
-) -> bytearray:
+) -> None:
     # get other signatures, stretch with empty bytes to the number of the pubkeys
     signatures = multisig.signatures + [b""] * (
         multisig_get_pubkey_count(multisig) - len(multisig.signatures)
     )
+
     # fill in our signature
     if signatures[signature_index]:
         raise wire.DataError("Invalid multisig parameters")
     signatures[signature_index] = signature
 
-    # filter empty
-    signatures = [s for s in signatures if s]
-
     # witness program + signatures + redeem script
-    num_of_witness_items = 1 + len(signatures) + 1
-
-    # length of the redeem script
-    pubkeys = multisig_get_pubkeys(multisig)
-    redeem_script_length = output_script_multisig_length(pubkeys, multisig.m)
-
-    # length of the result
-    total_length = 1 + 1  # number of items, OP_FALSE
-    for s in signatures:
-        total_length += 1 + len(s) + 1  # length, signature, hash_type
-    total_length += 1 + redeem_script_length  # length, script
-
-    w = utils.empty_bytearray(total_length)
-
+    num_of_witness_items = 1 + sum(1 for s in signatures if s) + 1
     write_bitcoin_varint(w, num_of_witness_items)
+
     # Starts with OP_FALSE because of an old OP_CHECKMULTISIG bug, which
     # consumes one additional item on the stack:
     # https://bitcoin.org/en/developer-guide#standard-transactions
     write_bitcoin_varint(w, 0)
 
     for s in signatures:
-        write_signature_prefixed(w, s, hash_type)  # size of the witness included
+        if s:
+            write_signature_prefixed(w, s, hash_type)  # size of the witness included
 
     # redeem script
-    write_bitcoin_varint(w, redeem_script_length)
-    write_output_script_multisig(w, pubkeys, multisig.m)
-
-    return w
+    pubkeys = multisig_get_pubkeys(multisig)
+    write_output_script_multisig(w, pubkeys, multisig.m, prefixed=True)
 
 
 def parse_witness_multisig(witness: bytes) -> tuple[bytes, list[tuple[bytes, int]]]:
@@ -375,13 +375,14 @@ def parse_witness_multisig(witness: bytes) -> tuple[bytes, list[tuple[bytes, int
 # Used either as P2SH, P2WSH, or P2WSH nested in P2SH.
 
 
-def input_script_multisig(
+def write_input_script_multisig_prefixed(
+    w: Writer,
     multisig: MultisigRedeemScriptType,
     signature: bytes,
     signature_index: int,
     hash_type: int,
     coin: CoinInfo,
-) -> bytearray:
+) -> None:
     signatures = multisig.signatures  # other signatures
     if len(signatures[signature_index]) > 0:
         raise wire.DataError("Invalid multisig parameters")
@@ -394,10 +395,10 @@ def input_script_multisig(
     # length of the result
     total_length = 1  # OP_FALSE
     for s in signatures:
-        total_length += 1 + len(s) + 1  # length, signature, hash_type
-    total_length += 1 + redeem_script_length  # length, script
-
-    w = utils.empty_bytearray(total_length)
+        if s:
+            total_length += 1 + len(s) + 1  # length, signature, hash_type
+    total_length += op_push_length(redeem_script_length) + redeem_script_length
+    write_bitcoin_varint(w, total_length)
 
     # Starts with OP_FALSE because of an old OP_CHECKMULTISIG bug, which
     # consumes one additional item on the stack:
@@ -405,14 +406,12 @@ def input_script_multisig(
     w.append(0x00)
 
     for s in signatures:
-        if len(s):
+        if s:
             append_signature(w, s, hash_type)
 
     # redeem script
     write_op_push(w, redeem_script_length)
     write_output_script_multisig(w, pubkeys, multisig.m)
-
-    return w
 
 
 def parse_input_script_multisig(
@@ -448,13 +447,21 @@ def output_script_multisig(pubkeys: list[bytes], m: int) -> bytearray:
     return w
 
 
-def write_output_script_multisig(w: Writer, pubkeys: list[bytes], m: int) -> None:
+def write_output_script_multisig(
+    w: Writer,
+    pubkeys: list[bytes],
+    m: int,
+    prefixed: bool = False,
+) -> None:
     n = len(pubkeys)
     if n < 1 or n > 15 or m < 1 or m > 15 or m > n:
         raise wire.DataError("Invalid multisig parameters")
     for pubkey in pubkeys:
         if len(pubkey) != 33:
             raise wire.DataError("Invalid multisig parameters")
+
+    if prefixed:
+        write_bitcoin_varint(w, output_script_multisig_length(pubkeys, m))
 
     w.append(0x50 + m)  # numbers 1 to 16 are pushed as 0x50 + value
     for p in pubkeys:
@@ -525,24 +532,22 @@ def write_bip322_signature_proof(
     public_key: bytes,
     signature: bytes,
 ) -> None:
-    script_sig = input_derive_script(
-        script_type, multisig, coin, common.SIGHASH_ALL, public_key, signature
+    write_input_script_prefixed(
+        w, script_type, multisig, coin, common.SIGHASH_ALL, public_key, signature
     )
+
     if script_type in common.SEGWIT_INPUT_SCRIPT_TYPES:
         if multisig:
             # find the place of our signature based on the public key
             signature_index = multisig_pubkey_index(multisig, public_key)
-            witness = witness_multisig(
-                multisig, signature, signature_index, common.SIGHASH_ALL
+            write_witness_multisig(
+                w, multisig, signature, signature_index, common.SIGHASH_ALL
             )
         else:
-            witness = witness_p2wpkh(signature, public_key, common.SIGHASH_ALL)
+            write_witness_p2wpkh(w, signature, public_key, common.SIGHASH_ALL)
     else:
         # Zero entries in witness stack.
-        witness = bytearray(b"\x00")
-
-    write_bytes_prefixed(w, script_sig)
-    w.extend(witness)
+        w.append(0x00)
 
 
 def read_bip322_signature_proof(r: utils.BufferReader) -> tuple[bytes, bytes]:

--- a/core/src/apps/bitcoin/scripts_decred.py
+++ b/core/src/apps/bitcoin/scripts_decred.py
@@ -8,47 +8,53 @@ from apps.common.writers import write_bytes_fixed, write_uint64_le
 from . import scripts
 from .multisig import multisig_get_pubkeys, multisig_pubkey_index
 from .scripts import (  # noqa: F401
-    output_script_multisig,
-    output_script_p2pkh,
     output_script_paytoopreturn,
+    write_output_script_multisig,
+    write_output_script_p2pkh,
 )
-from .writers import write_op_push
+from .writers import op_push_length, write_bitcoin_varint, write_op_push
 
 if False:
     from trezor.messages import MultisigRedeemScriptType
 
     from apps.common.coininfo import CoinInfo
 
+    from .writers import Writer
 
-def input_derive_script(
+
+def write_input_script_prefixed(
+    w: Writer,
     script_type: InputScriptType,
     multisig: MultisigRedeemScriptType | None,
     coin: CoinInfo,
     hash_type: int,
     pubkey: bytes,
     signature: bytes,
-) -> bytes:
+) -> None:
     if script_type == InputScriptType.SPENDADDRESS:
         # p2pkh or p2sh
-        return scripts.input_script_p2pkh_or_p2sh(pubkey, signature, hash_type)
+        scripts.write_input_script_p2pkh_or_p2sh_prefixed(
+            w, pubkey, signature, hash_type
+        )
     elif script_type == InputScriptType.SPENDMULTISIG:
         # p2sh multisig
         assert multisig is not None  # checked in sanitize_tx_input
         signature_index = multisig_pubkey_index(multisig, pubkey)
-        return input_script_multisig(
-            multisig, signature, signature_index, hash_type, coin
+        return write_input_script_multisig_prefixed(
+            w, multisig, signature, signature_index, hash_type, coin
         )
     else:
         raise wire.ProcessError("Invalid script type")
 
 
-def input_script_multisig(
+def write_input_script_multisig_prefixed(
+    w: Writer,
     multisig: MultisigRedeemScriptType,
     signature: bytes,
     signature_index: int,
     hash_type: int,
     coin: CoinInfo,
-) -> bytearray:
+) -> None:
     signatures = multisig.signatures  # other signatures
     if len(signatures[signature_index]) > 0:
         raise wire.DataError("Invalid multisig parameters")
@@ -61,20 +67,18 @@ def input_script_multisig(
     # length of the result
     total_length = 0
     for s in signatures:
-        total_length += 1 + len(s) + 1  # length, signature, hash_type
-    total_length += 1 + redeem_script_length  # length, script
-
-    w = utils.empty_bytearray(total_length)
+        if s:
+            total_length += 1 + len(s) + 1  # length, signature, hash_type
+    total_length += op_push_length(redeem_script_length) + redeem_script_length
+    write_bitcoin_varint(w, total_length)
 
     for s in signatures:
-        if len(s):
+        if s:
             scripts.append_signature(w, s, hash_type)
 
     # redeem script
     write_op_push(w, redeem_script_length)
     scripts.write_output_script_multisig(w, pubkeys, multisig.m)
-
-    return w
 
 
 # A ticket purchase submission for an address hash.
@@ -86,12 +90,7 @@ def output_script_sstxsubmissionpkh(addr: str) -> bytearray:
 
     w = utils.empty_bytearray(26)
     w.append(0xBA)  # OP_SSTX
-    w.append(0x76)  # OP_DUP
-    w.append(0xA9)  # OP_HASH160
-    w.append(0x14)  # OP_DATA_20
-    write_bytes_fixed(w, raw_address[2:], 20)
-    w.append(0x88)  # OP_EQUALVERIFY
-    w.append(0xAC)  # OP_CHECKSIG
+    scripts.write_output_script_p2pkh(w, raw_address[2:])
     return w
 
 
@@ -104,44 +103,27 @@ def output_script_sstxchange(addr: str) -> bytearray:
 
     w = utils.empty_bytearray(26)
     w.append(0xBD)  # OP_SSTXCHANGE
-    w.append(0x76)  # OP_DUP
-    w.append(0xA9)  # OP_HASH160
-    w.append(0x14)  # OP_DATA_20
-    write_bytes_fixed(w, raw_address[2:], 20)
-    w.append(0x88)  # OP_EQUALVERIFY
-    w.append(0xAC)  # OP_CHECKSIG
+    scripts.write_output_script_p2pkh(w, raw_address[2:])
     return w
 
 
 # Spend from a stake revocation.
-def output_script_ssrtx(pkh: bytes) -> bytearray:
+def write_output_script_ssrtx_prefixed(w: Writer, pkh: bytes) -> None:
     utils.ensure(len(pkh) == 20)
-    s = bytearray(26)
-    s[0] = 0xBC  # OP_SSRTX
-    s[1] = 0x76  # OP_DUP
-    s[2] = 0xA9  # OP_HASH160
-    s[3] = 0x14  # OP_DATA_20
-    s[4:24] = pkh
-    s[24] = 0x88  # OP_EQUALVERIFY
-    s[25] = 0xAC  # OP_CHECKSIG
-    return s
+    write_bitcoin_varint(w, 26)
+    w.append(0xBC)  # OP_SSRTX
+    scripts.write_output_script_p2pkh(w, pkh)
 
 
 # Spend from a stake generation.
-def output_script_ssgen(pkh: bytes) -> bytearray:
+def write_output_script_ssgen_prefixed(w: Writer, pkh: bytes) -> None:
     utils.ensure(len(pkh) == 20)
-    s = bytearray(26)
-    s[0] = 0xBB  # OP_SSGEN
-    s[1] = 0x76  # OP_DUP
-    s[2] = 0xA9  # OP_HASH160
-    s[3] = 0x14  # OP_DATA_20
-    s[4:24] = pkh
-    s[24] = 0x88  # OP_EQUALVERIFY
-    s[25] = 0xAC  # OP_CHECKSIG
-    return s
+    write_bitcoin_varint(w, 26)
+    w.append(0xBB)  # OP_SSGEN
+    scripts.write_output_script_p2pkh(w, pkh)
 
 
-# Retrieve pkh bytes from a stake commitment OPRETURN.
+# Stake commitment OPRETURN.
 def sstxcommitment_pkh(pkh: bytes, amount: int) -> bytes:
     w = utils.empty_bytearray(30)
     write_bytes_fixed(w, pkh, 20)

--- a/core/src/apps/bitcoin/sign_tx/bitcoin.py
+++ b/core/src/apps/bitcoin/sign_tx/bitcoin.py
@@ -36,6 +36,7 @@ if False:
 
 # the number of bytes to preallocate for serialized transaction chunks
 _MAX_SERIALIZED_CHUNK_SIZE = const(2048)
+_SERIALIZED_TX_BUFFER = empty_bytearray(_MAX_SERIALIZED_CHUNK_SIZE)
 
 
 class Bitcoin:
@@ -77,6 +78,8 @@ class Bitcoin:
         coin: CoinInfo,
         approver: approvers.Approver | None,
     ) -> None:
+        global _SERIALIZED_TX_BUFFER
+
         self.tx_info = TxInfo(self, helpers.sanitize_sign_tx(tx, coin))
         self.keychain = keychain
         self.coin = coin
@@ -93,7 +96,8 @@ class Bitcoin:
         self.external: set[int] = set()
 
         # transaction and signature serialization
-        self.serialized_tx = empty_bytearray(_MAX_SERIALIZED_CHUNK_SIZE)
+        _SERIALIZED_TX_BUFFER[:] = bytes()
+        self.serialized_tx = _SERIALIZED_TX_BUFFER
         self.tx_req = TxRequest()
         self.tx_req.details = TxRequestDetailsType()
         self.tx_req.serialized = TxRequestSerializedType()

--- a/core/src/apps/bitcoin/sign_tx/bitcoin.py
+++ b/core/src/apps/bitcoin/sign_tx/bitcoin.py
@@ -17,6 +17,8 @@ from .hash143 import Bip143Hash
 from .tx_info import OriginalTxInfo, TxInfo
 
 if False:
+    from typing import Sequence
+
     from trezor.crypto import bip32
 
     from trezor.messages import (
@@ -396,7 +398,7 @@ class Bitcoin:
         i: int,
         txi: TxInput,
         tx_info: TxInfo | OriginalTxInfo,
-        public_keys: list[bytes],
+        public_keys: Sequence[bytes | memoryview],
         threshold: int,
         script_pubkey: bytes,
     ) -> bytes:

--- a/core/src/apps/bitcoin/sign_tx/bitcoinlike.py
+++ b/core/src/apps/bitcoin/sign_tx/bitcoinlike.py
@@ -11,6 +11,7 @@ from . import helpers
 from .bitcoin import Bitcoin
 
 if False:
+    from typing import Sequence
     from .tx_info import OriginalTxInfo, TxInfo
 
 _SIGHASH_FORKID = const(0x40)
@@ -43,7 +44,7 @@ class Bitcoinlike(Bitcoin):
         i: int,
         txi: TxInput,
         tx_info: TxInfo | OriginalTxInfo,
-        public_keys: list[bytes],
+        public_keys: Sequence[bytes | memoryview],
         threshold: int,
         script_pubkey: bytes,
         tx_hash: bytes | None = None,

--- a/core/src/apps/bitcoin/sign_tx/bitcoinlike.py
+++ b/core/src/apps/bitcoin/sign_tx/bitcoinlike.py
@@ -29,8 +29,7 @@ class Bitcoinlike(Bitcoin):
             multisig.multisig_pubkey_index(txi.multisig, public_key)
 
         # serialize input with correct signature
-        script_sig = self.input_derive_script(txi, public_key, signature)
-        self.write_tx_input(self.serialized_tx, txi, script_sig)
+        self.write_tx_input_derived(self.serialized_tx, txi, public_key, signature)
         self.set_serialized_signature(i_sign, signature)
 
     async def sign_nonsegwit_input(self, i_sign: int) -> None:

--- a/core/src/apps/bitcoin/sign_tx/decred.py
+++ b/core/src/apps/bitcoin/sign_tx/decred.py
@@ -147,27 +147,6 @@ class Decred(Bitcoin):
             key_sign = self.keychain.derive(txi_sign.address_n)
             key_sign_pub = key_sign.public_key()
 
-            if txi_sign.decred_staking_spend == DecredStakingSpendType.SSRTX:
-                prev_pkscript = scripts_decred.output_script_ssrtx(
-                    ecdsa_hash_pubkey(key_sign_pub, self.coin)
-                )
-            elif txi_sign.decred_staking_spend == DecredStakingSpendType.SSGen:
-                prev_pkscript = scripts_decred.output_script_ssgen(
-                    ecdsa_hash_pubkey(key_sign_pub, self.coin)
-                )
-            elif txi_sign.script_type == InputScriptType.SPENDMULTISIG:
-                assert txi_sign.multisig is not None
-                prev_pkscript = scripts_decred.output_script_multisig(
-                    multisig.multisig_get_pubkeys(txi_sign.multisig),
-                    txi_sign.multisig.m,
-                )
-            elif txi_sign.script_type == InputScriptType.SPENDADDRESS:
-                prev_pkscript = scripts_decred.output_script_p2pkh(
-                    ecdsa_hash_pubkey(key_sign_pub, self.coin)
-                )
-            else:
-                raise wire.DataError("Unsupported input script type")
-
             h_witness = self.create_hash_writer()
             writers.write_uint32(
                 h_witness, self.tx_info.tx.version | DECRED_SERIALIZE_WITNESS_SIGNING
@@ -176,7 +155,30 @@ class Decred(Bitcoin):
 
             for ii in range(self.tx_info.tx.inputs_count):
                 if ii == i_sign:
-                    writers.write_bytes_prefixed(h_witness, prev_pkscript)
+                    if txi_sign.decred_staking_spend == DecredStakingSpendType.SSRTX:
+                        scripts_decred.write_output_script_ssrtx_prefixed(
+                            h_witness, ecdsa_hash_pubkey(key_sign_pub, self.coin)
+                        )
+                    elif txi_sign.decred_staking_spend == DecredStakingSpendType.SSGen:
+                        scripts_decred.write_output_script_ssgen_prefixed(
+                            h_witness, ecdsa_hash_pubkey(key_sign_pub, self.coin)
+                        )
+                    elif txi_sign.script_type == InputScriptType.SPENDMULTISIG:
+                        assert txi_sign.multisig is not None
+                        scripts_decred.write_output_script_multisig(
+                            h_witness,
+                            multisig.multisig_get_pubkeys(txi_sign.multisig),
+                            txi_sign.multisig.m,
+                            prefixed=True,
+                        )
+                    elif txi_sign.script_type == InputScriptType.SPENDADDRESS:
+                        scripts_decred.write_output_script_p2pkh(
+                            h_witness,
+                            ecdsa_hash_pubkey(key_sign_pub, self.coin),
+                            prefixed=True,
+                        )
+                    else:
+                        raise wire.DataError("Unsupported input script type")
                 else:
                     write_bitcoin_varint(h_witness, 0)
 
@@ -193,8 +195,9 @@ class Decred(Bitcoin):
             signature = ecdsa_sign(key_sign, sig_hash)
 
             # serialize input with correct signature
-            script_sig = self.input_derive_script(txi_sign, key_sign_pub, signature)
-            self.write_tx_input_witness(self.serialized_tx, txi_sign, script_sig)
+            self.write_tx_input_witness(
+                self.serialized_tx, txi_sign, key_sign_pub, signature
+            )
             self.set_serialized_signature(i_sign, signature)
 
     async def step5_serialize_outputs(self) -> None:
@@ -306,17 +309,13 @@ class Decred(Bitcoin):
         writers.write_uint32(w, tx.expiry)
 
     def write_tx_input_witness(
-        self, w: writers.Writer, i: TxInput, script_sig: bytes
+        self, w: writers.Writer, txi: TxInput, pubkey: bytes, signature: bytes
     ) -> None:
-        writers.write_uint64(w, i.amount)
+        writers.write_uint64(w, txi.amount)
         writers.write_uint32(w, 0)  # block height fraud proof
         writers.write_uint32(w, 0xFFFF_FFFF)  # block index fraud proof
-        writers.write_bytes_prefixed(w, script_sig)
-
-    def input_derive_script(
-        self, txi: TxInput, pubkey: bytes, signature: bytes
-    ) -> bytes:
-        return scripts_decred.input_derive_script(
+        scripts_decred.write_input_script_prefixed(
+            w,
             txi.script_type,
             txi.multisig,
             self.coin,

--- a/core/src/apps/bitcoin/sign_tx/decred.py
+++ b/core/src/apps/bitcoin/sign_tx/decred.py
@@ -24,6 +24,8 @@ OUTPUT_SCRIPT_NULL_SSTXCHANGE = (
 )
 
 if False:
+    from typing import Sequence
+
     from trezor.messages import (
         SignTx,
         TxInput,
@@ -61,7 +63,7 @@ class DecredHash:
     def preimage_hash(
         self,
         txi: TxInput,
-        public_keys: list[bytes],
+        public_keys: Sequence[bytes | memoryview],
         threshold: int,
         tx: SignTx | PrevTx,
         coin: CoinInfo,

--- a/core/src/apps/bitcoin/sign_tx/hash143.py
+++ b/core/src/apps/bitcoin/sign_tx/hash143.py
@@ -7,7 +7,7 @@ from apps.common import coininfo
 from .. import scripts, writers
 
 if False:
-    from typing import Protocol
+    from typing import Protocol, Sequence
 
     class Hash143(Protocol):
         def add_input(self, txi: TxInput) -> None:
@@ -19,7 +19,7 @@ if False:
         def preimage_hash(
             self,
             txi: TxInput,
-            public_keys: list[bytes],
+            public_keys: Sequence[bytes | memoryview],
             threshold: int,
             tx: SignTx | PrevTx,
             coin: coininfo.CoinInfo,
@@ -48,7 +48,7 @@ class Bip143Hash:
     def preimage_hash(
         self,
         txi: TxInput,
-        public_keys: list[bytes],
+        public_keys: Sequence[bytes | memoryview],
         threshold: int,
         tx: SignTx | PrevTx,
         coin: coininfo.CoinInfo,

--- a/core/src/apps/bitcoin/sign_tx/hash143.py
+++ b/core/src/apps/bitcoin/sign_tx/hash143.py
@@ -76,10 +76,9 @@ class Bip143Hash:
         writers.write_uint32(h_preimage, txi.prev_index)
 
         # scriptCode
-        script_code = scripts.bip143_derive_script_code(
-            txi, public_keys, threshold, coin
+        scripts.write_bip143_script_code_prefixed(
+            h_preimage, txi, public_keys, threshold, coin
         )
-        writers.write_bytes_prefixed(h_preimage, script_code)
 
         # amount
         writers.write_uint64(h_preimage, txi.amount)

--- a/core/src/apps/bitcoin/sign_tx/tx_info.py
+++ b/core/src/apps/bitcoin/sign_tx/tx_info.py
@@ -11,8 +11,6 @@ from .matchcheck import MultisigFingerprintChecker, WalletPathChecker
 if False:
     from typing import Protocol
     from trezor.messages import (
-        PrevInput,
-        PrevOutput,
         PrevTx,
         SignTx,
         TxInput,
@@ -36,22 +34,6 @@ if False:
             w: writers.Writer,
             tx: SignTx | PrevTx,
             witness_marker: bool,
-        ) -> None:
-            ...
-
-        @staticmethod
-        def write_tx_input(
-            w: writers.Writer,
-            txi: TxInput | PrevInput,
-            script: bytes,
-        ) -> None:
-            ...
-
-        @staticmethod
-        def write_tx_output(
-            w: writers.Writer,
-            txo: TxOutput | PrevOutput,
-            script_pubkey: bytes,
         ) -> None:
             ...
 
@@ -167,7 +149,7 @@ class OriginalTxInfo(TxInfoBase):
 
     def add_input(self, txi: TxInput) -> None:
         super().add_input(txi)
-        self.signer.write_tx_input(self.h_tx, txi, txi.script_sig or bytes())
+        writers.write_tx_input(self.h_tx, txi, txi.script_sig or bytes())
 
         # For verification use the first original input that specifies address_n.
         if not self.verification_input and txi.address_n:
@@ -180,7 +162,7 @@ class OriginalTxInfo(TxInfoBase):
         if self.index == 0:
             writers.write_bitcoin_varint(self.h_tx, self.tx.outputs_count)
 
-        self.signer.write_tx_output(self.h_tx, txo, script_pubkey)
+        writers.write_tx_output(self.h_tx, txo, script_pubkey)
 
     async def finalize_tx_hash(self) -> None:
         await self.signer.write_prev_tx_footer(self.h_tx, self.tx, self.orig_hash)

--- a/core/src/apps/bitcoin/sign_tx/zcash.py
+++ b/core/src/apps/bitcoin/sign_tx/zcash.py
@@ -3,7 +3,6 @@ from micropython import const
 
 from trezor import wire
 from trezor.crypto.hashlib import blake2b
-from trezor.enums import InputScriptType
 from trezor.messages import PrevTx, SignTx, TxInput, TxOutput
 from trezor.utils import HashWriter, ensure
 
@@ -11,13 +10,11 @@ from apps.common.coininfo import CoinInfo
 from apps.common.keychain import Keychain
 from apps.common.writers import write_bitcoin_varint
 
-from ..common import ecdsa_hash_pubkey
-from ..scripts import output_script_multisig, output_script_p2pkh
+from ..scripts import write_bip143_script_code_prefixed
 from ..writers import (
     TX_HASH_SIZE,
     get_tx_hash,
     write_bytes_fixed,
-    write_bytes_prefixed,
     write_bytes_reversed,
     write_tx_output,
     write_uint32,
@@ -97,8 +94,7 @@ class Zip243Hash:
         write_bytes_reversed(h_preimage, txi.prev_hash, TX_HASH_SIZE)
         write_uint32(h_preimage, txi.prev_index)
         # 13b. scriptCode
-        script_code = derive_script_code(txi, public_keys, threshold, coin)
-        write_bytes_prefixed(h_preimage, script_code)
+        write_bip143_script_code_prefixed(h_preimage, txi, public_keys, threshold, coin)
         # 13c. value
         write_uint64(h_preimage, txi.amount)
         # 13d. nSequence
@@ -174,17 +170,3 @@ class Zcashlike(Bitcoinlike):
         write_uint32(w, tx.lock_time)
         if tx.version >= 3:
             write_uint32(w, tx.expiry)  # expiryHeight
-
-
-def derive_script_code(
-    txi: TxInput, public_keys: list[bytes], threshold: int, coin: CoinInfo
-) -> bytearray:
-    if len(public_keys) > 1:
-        return output_script_multisig(public_keys, threshold)
-
-    p2pkh = txi.script_type in (InputScriptType.SPENDADDRESS, InputScriptType.EXTERNAL)
-    if p2pkh:
-        return output_script_p2pkh(ecdsa_hash_pubkey(public_keys[0], coin))
-
-    else:
-        raise wire.DataError("Unknown input script type for zip143 script code")

--- a/core/src/apps/bitcoin/sign_tx/zcash.py
+++ b/core/src/apps/bitcoin/sign_tx/zcash.py
@@ -24,6 +24,7 @@ from . import approvers, helpers
 from .bitcoinlike import Bitcoinlike
 
 if False:
+    from typing import Sequence
     from apps.common import coininfo
     from .hash143 import Hash143
     from .tx_info import OriginalTxInfo, TxInfo
@@ -49,7 +50,7 @@ class Zip243Hash:
     def preimage_hash(
         self,
         txi: TxInput,
-        public_keys: list[bytes],
+        public_keys: Sequence[bytes | memoryview],
         threshold: int,
         tx: SignTx | PrevTx,
         coin: coininfo.CoinInfo,
@@ -138,7 +139,7 @@ class Zcashlike(Bitcoinlike):
         i: int,
         txi: TxInput,
         tx_info: TxInfo | OriginalTxInfo,
-        public_keys: list[bytes],
+        public_keys: Sequence[bytes | memoryview],
         threshold: int,
         script_pubkey: bytes,
         tx_hash: bytes | None = None,

--- a/core/src/apps/bitcoin/verification.py
+++ b/core/src/apps/bitcoin/verification.py
@@ -1,12 +1,10 @@
-from trezor import wire
+from trezor import utils, wire
 from trezor.crypto import der
 from trezor.crypto.curve import secp256k1
 from trezor.crypto.hashlib import sha256
 
 from .common import ecdsa_hash_pubkey
 from .scripts import (
-    input_script_p2wpkh_in_p2sh,
-    input_script_p2wsh_in_p2sh,
     output_script_native_p2wpkh_or_p2wsh,
     output_script_p2pkh,
     output_script_p2sh,
@@ -15,6 +13,8 @@ from .scripts import (
     parse_output_script_multisig,
     parse_witness_multisig,
     parse_witness_p2wpkh,
+    write_input_script_p2wpkh_in_p2sh,
+    write_input_script_p2wsh_in_p2sh,
 )
 
 if False:
@@ -56,7 +56,9 @@ class SignatureVerifier:
             if len(script_sig) == 23:  # P2WPKH nested in BIP16 P2SH
                 public_key, signature, hash_type = parse_witness_p2wpkh(witness)
                 pubkey_hash = ecdsa_hash_pubkey(public_key, coin)
-                if input_script_p2wpkh_in_p2sh(pubkey_hash) != script_sig:
+                w = utils.empty_bytearray(23)
+                write_input_script_p2wpkh_in_p2sh(w, pubkey_hash)
+                if w != script_sig:
                     raise wire.DataError("Invalid public key hash")
                 script_hash = coin.script_hash(script_sig[1:])
                 if output_script_p2sh(script_hash) != script_pubkey:
@@ -66,7 +68,9 @@ class SignatureVerifier:
             elif len(script_sig) == 35:  # P2WSH nested in BIP16 P2SH
                 script, self.signatures = parse_witness_multisig(witness)
                 script_hash = sha256(script).digest()
-                if input_script_p2wsh_in_p2sh(script_hash) != script_sig:
+                w = utils.empty_bytearray(35)
+                write_input_script_p2wsh_in_p2sh(w, script_hash)
+                if w != script_sig:
                     raise wire.DataError("Invalid script hash")
                 script_hash = coin.script_hash(script_sig[1:])
                 if output_script_p2sh(script_hash) != script_pubkey:

--- a/core/src/apps/bitcoin/verification.py
+++ b/core/src/apps/bitcoin/verification.py
@@ -30,8 +30,8 @@ class SignatureVerifier:
         coin: CoinInfo,
     ):
         self.threshold = 1
-        self.public_keys: list[bytes] = []
-        self.signatures: list[tuple[bytes, int]] = []
+        self.public_keys: list[memoryview] = []
+        self.signatures: list[tuple[memoryview, int]] = []
 
         if not script_sig:
             if not witness:
@@ -118,7 +118,7 @@ class SignatureVerifier:
             raise wire.DataError("Invalid signature")
 
 
-def decode_der_signature(der_signature: bytes) -> bytearray:
+def decode_der_signature(der_signature: memoryview) -> bytearray:
     seq = der.decode_seq(der_signature)
     if len(seq) != 2 or any(len(i) > 32 for i in seq):
         raise ValueError

--- a/core/src/apps/bitcoin/verification.py
+++ b/core/src/apps/bitcoin/verification.py
@@ -60,7 +60,7 @@ class SignatureVerifier:
                 write_input_script_p2wpkh_in_p2sh(w, pubkey_hash)
                 if w != script_sig:
                     raise wire.DataError("Invalid public key hash")
-                script_hash = coin.script_hash(script_sig[1:])
+                script_hash = coin.script_hash(script_sig[1:]).digest()
                 if output_script_p2sh(script_hash) != script_pubkey:
                     raise wire.DataError("Invalid script hash")
                 self.public_keys = [public_key]
@@ -72,7 +72,7 @@ class SignatureVerifier:
                 write_input_script_p2wsh_in_p2sh(w, script_hash)
                 if w != script_sig:
                     raise wire.DataError("Invalid script hash")
-                script_hash = coin.script_hash(script_sig[1:])
+                script_hash = coin.script_hash(script_sig[1:]).digest()
                 if output_script_p2sh(script_hash) != script_pubkey:
                     raise wire.DataError("Invalid script hash")
                 self.public_keys, self.threshold = parse_output_script_multisig(script)
@@ -88,7 +88,7 @@ class SignatureVerifier:
                 self.signatures = [(signature, hash_type)]
             elif len(script_pubkey) == 23:  # P2SH
                 script, self.signatures = parse_input_script_multisig(script_sig)
-                script_hash = coin.script_hash(script)
+                script_hash = coin.script_hash(script).digest()
                 if output_script_p2sh(script_hash) != script_pubkey:
                     raise wire.DataError("Invalid script hash")
                 self.public_keys, self.threshold = parse_output_script_multisig(script)

--- a/core/src/apps/bitcoin/writers.py
+++ b/core/src/apps/bitcoin/writers.py
@@ -79,6 +79,18 @@ def write_op_push(w: Writer, n: int) -> None:
         w.append((n >> 24) & 0xFF)
 
 
+def op_push_length(n: int) -> int:
+    ensure(n >= 0 and n <= 0xFFFF_FFFF)
+    if n < 0x4C:
+        return 1
+    elif n < 0xFF:
+        return 2
+    elif n < 0xFFFF:
+        return 3
+    else:
+        return 4
+
+
 def get_tx_hash(w: HashWriter, double: bool = False, reverse: bool = False) -> bytes:
     d = w.get_digest()
     if double:

--- a/core/src/apps/cardano/helpers/utils.py
+++ b/core/src/apps/cardano/helpers/utils.py
@@ -18,17 +18,12 @@ def variable_length_encode(number: int) -> bytes:
     if number < 0:
         raise ValueError("Negative numbers not supported. Number supplied: %s" % number)
 
-    encoded = []
-
-    bit_length = len(bin(number)[2:])
-    encoded.append(number & 127)
-
-    while bit_length > 7:
+    encoded = [number & 0x7F]
+    while number > 0x7F:
         number >>= 7
-        bit_length -= 7
-        encoded.insert(0, (number & 127) + 128)
+        encoded.append((number & 0x7F) + 0x80)
 
-    return bytes(encoded)
+    return bytes(reversed(encoded))
 
 
 def to_account_path(path: list[int]) -> list[int]:

--- a/core/src/apps/common/cbor.py
+++ b/core/src/apps/common/cbor.py
@@ -302,8 +302,9 @@ def encode_chunked(value: Value, max_chunk_size: int) -> Iterator[bytes]:
             yield chunk_buffer
 
 
-def decode(cbor: bytes) -> Value:
+def decode(cbor: bytes, offset: int = 0) -> Value:
     r = utils.BufferReader(cbor)
+    r.seek(offset)
     res = _cbor_decode(r)
     if r.remaining_count():
         raise ValueError

--- a/core/src/apps/common/coininfo.py
+++ b/core/src/apps/common/coininfo.py
@@ -2,10 +2,10 @@
 # do not edit manually!
 from trezor import utils
 from trezor.crypto.base58 import blake256d_32, groestl512d_32, keccak_32, sha256d_32
-from trezor.crypto.scripts import blake256_ripemd160_digest, sha256_ripemd160_digest
+from trezor.crypto.scripts import blake256_ripemd160, sha256_ripemd160
 
 if False:
-    from typing import Any
+    from typing import Any, Type
 
 # flake8: noqa
 
@@ -67,19 +67,19 @@ class CoinInfo:
         if curve_name == "secp256k1-groestl":
             self.b58_hash = groestl512d_32
             self.sign_hash_double = False
-            self.script_hash = sha256_ripemd160_digest
+            self.script_hash: Type[utils.HashContext] = sha256_ripemd160
         elif curve_name == "secp256k1-decred":
             self.b58_hash = blake256d_32
             self.sign_hash_double = False
-            self.script_hash = blake256_ripemd160_digest
+            self.script_hash = blake256_ripemd160
         elif curve_name == "secp256k1-smart":
             self.b58_hash = keccak_32
             self.sign_hash_double = False
-            self.script_hash = sha256_ripemd160_digest
+            self.script_hash = sha256_ripemd160
         else:
             self.b58_hash = sha256d_32
             self.sign_hash_double = True
-            self.script_hash = sha256_ripemd160_digest
+            self.script_hash = sha256_ripemd160
 
     def __eq__(self, other: Any) -> bool:
         if not isinstance(other, CoinInfo):

--- a/core/src/apps/common/coininfo.py.mako
+++ b/core/src/apps/common/coininfo.py.mako
@@ -2,10 +2,10 @@
 # do not edit manually!
 from trezor import utils
 from trezor.crypto.base58 import blake256d_32, groestl512d_32, keccak_32, sha256d_32
-from trezor.crypto.scripts import blake256_ripemd160_digest, sha256_ripemd160_digest
+from trezor.crypto.scripts import blake256_ripemd160, sha256_ripemd160
 
 if False:
-    from typing import Any
+    from typing import Any, Type
 
 # flake8: noqa
 
@@ -67,19 +67,19 @@ class CoinInfo:
         if curve_name == "secp256k1-groestl":
             self.b58_hash = groestl512d_32
             self.sign_hash_double = False
-            self.script_hash = sha256_ripemd160_digest
+            self.script_hash: Type[utils.HashContext] = sha256_ripemd160
         elif curve_name == "secp256k1-decred":
             self.b58_hash = blake256d_32
             self.sign_hash_double = False
-            self.script_hash = blake256_ripemd160_digest
+            self.script_hash = blake256_ripemd160
         elif curve_name == "secp256k1-smart":
             self.b58_hash = keccak_32
             self.sign_hash_double = False
-            self.script_hash = sha256_ripemd160_digest
+            self.script_hash = sha256_ripemd160
         else:
             self.b58_hash = sha256d_32
             self.sign_hash_double = True
-            self.script_hash = sha256_ripemd160_digest
+            self.script_hash = sha256_ripemd160
 
     def __eq__(self, other: Any) -> bool:
         if not isinstance(other, CoinInfo):

--- a/core/src/apps/common/writers.py
+++ b/core/src/apps/common/writers.py
@@ -1,6 +1,7 @@
 from trezor.utils import ensure
 
 if False:
+    from typing import Union
     from trezor.utils import Writer
 
 
@@ -68,7 +69,7 @@ def write_uint64_be(w: Writer, n: int) -> int:
     return 8
 
 
-def write_bytes_unchecked(w: Writer, b: bytes) -> int:
+def write_bytes_unchecked(w: Writer, b: Union[bytes, memoryview]) -> int:
     w.extend(b)
     return len(b)
 

--- a/core/src/apps/webauthn/fido2.py
+++ b/core/src/apps/webauthn/fido2.py
@@ -1479,7 +1479,7 @@ def cbor_make_credential_process(req: Cmd, dialog_mgr: DialogManager) -> State |
         return cbor_error(req.cid, _ERR_OTHER)
 
     try:
-        param = cbor.decode(req.data[1:])
+        param = cbor.decode(req.data, offset=1)
         rp = param[_MAKECRED_CMD_RP]
         rp_id = rp["id"]
         rp_id_hash = hashlib.sha256(rp_id).digest()
@@ -1657,7 +1657,7 @@ def cbor_get_assertion_process(req: Cmd, dialog_mgr: DialogManager) -> State | C
         return cbor_error(req.cid, _ERR_OTHER)
 
     try:
-        param = cbor.decode(req.data[1:])
+        param = cbor.decode(req.data, offset=1)
         rp_id = param[_GETASSERT_CMD_RP_ID]
         rp_id_hash = hashlib.sha256(rp_id).digest()
 
@@ -1879,7 +1879,7 @@ def cbor_get_info(req: Cmd) -> Cmd:
 
 def cbor_client_pin(req: Cmd) -> Cmd:
     try:
-        param = cbor.decode(req.data[1:])
+        param = cbor.decode(req.data, offset=1)
         pin_protocol = param[_CLIENTPIN_CMD_PIN_PROTOCOL]
         subcommand = param[_CLIENTPIN_CMD_SUBCOMMAND]
     except Exception:

--- a/core/src/trezor/crypto/der.py
+++ b/core/src/trezor/crypto/der.py
@@ -1,4 +1,12 @@
-from trezor.utils import BufferReader
+from micropython import const
+
+from trezor.utils import BufferReader, empty_bytearray
+
+if False:
+    from trezor.utils import Writer
+
+# Maximum length of a DER-encoded secp256k1 or secp256p1 signature.
+MAX_DER_SIGNATURE_LENGTH = const(72)
 
 
 def encode_length(l: int) -> bytes:
@@ -12,7 +20,7 @@ def encode_length(l: int) -> bytes:
         raise ValueError
 
 
-def decode_length(r: BufferReader) -> int:
+def read_length(r: BufferReader) -> int:
     init = r.get()
     if init < 0x80:
         # short form encodes length in initial octet
@@ -32,21 +40,27 @@ def decode_length(r: BufferReader) -> int:
     return n
 
 
-def encode_int(i: bytes) -> bytes:
-    i = i.lstrip(b"\x00")
-    if not i:
-        i = b"\00"
+def write_int(w: Writer, number: bytes) -> None:
+    i = 0
+    while i < len(number) and number[i] == 0:
+        i += 1
 
-    if i[0] >= 0x80:
-        i = b"\x00" + i
-    return b"\x02" + encode_length(len(i)) + i
+    length = len(number) - i
+    w.append(0x02)
+    if length == 0 or number[i] >= 0x80:
+        w.extend(encode_length(length + 1))
+        w.append(0x00)
+    else:
+        w.extend(encode_length(length))
+
+    w.extend(memoryview(number)[i:])
 
 
-def decode_int(r: BufferReader) -> memoryview:
+def read_int(r: BufferReader) -> memoryview:
     if r.get() != 0x02:
         raise ValueError
 
-    n = decode_length(r)
+    n = read_length(r)
     if n == 0:
         raise ValueError
 
@@ -66,10 +80,13 @@ def decode_int(r: BufferReader) -> memoryview:
 
 
 def encode_seq(seq: tuple) -> bytes:
-    res = b""
+    # Preallocate space for a signature, which is all that this function ever encodes.
+    buffer = empty_bytearray(MAX_DER_SIGNATURE_LENGTH)
+    buffer.append(0x30)
     for i in seq:
-        res += encode_int(i)
-    return b"\x30" + encode_length(len(res)) + res
+        write_int(buffer, i)
+    buffer[1:1] = encode_length(len(buffer) - 1)
+    return buffer
 
 
 def decode_seq(data: memoryview) -> list[memoryview]:
@@ -77,12 +94,12 @@ def decode_seq(data: memoryview) -> list[memoryview]:
 
     if r.get() != 0x30:
         raise ValueError
-    n = decode_length(r)
+    n = read_length(r)
 
     seq = []
     end = r.offset + n
     while r.offset < end:
-        i = decode_int(r)
+        i = read_int(r)
         seq.append(i)
 
     if r.offset != end or r.remaining_count():

--- a/core/src/trezor/crypto/der.py
+++ b/core/src/trezor/crypto/der.py
@@ -42,7 +42,7 @@ def encode_int(i: bytes) -> bytes:
     return b"\x02" + encode_length(len(i)) + i
 
 
-def decode_int(r: BufferReader) -> bytes:
+def decode_int(r: BufferReader) -> memoryview:
     if r.get() != 0x02:
         raise ValueError
 
@@ -62,7 +62,7 @@ def decode_int(r: BufferReader) -> bytes:
         if r.peek() == 0x00:
             raise ValueError  # excessive zero-padding
 
-    return r.read(n)
+    return r.read_memoryview(n)
 
 
 def encode_seq(seq: tuple) -> bytes:
@@ -72,7 +72,7 @@ def encode_seq(seq: tuple) -> bytes:
     return b"\x30" + encode_length(len(res)) + res
 
 
-def decode_seq(data: bytes) -> list[bytes]:
+def decode_seq(data: memoryview) -> list[memoryview]:
     r = BufferReader(data)
 
     if r.get() != 0x30:

--- a/core/src/trezor/crypto/scripts.py
+++ b/core/src/trezor/crypto/scripts.py
@@ -1,13 +1,11 @@
 from trezor.crypto.hashlib import blake256, ripemd160, sha256
 
 
-def sha256_ripemd160_digest(b: bytes) -> bytes:
-    h = sha256(b).digest()
-    h = ripemd160(h).digest()
-    return h
+class sha256_ripemd160(sha256):
+    def digest(self) -> bytes:
+        return ripemd160(super().digest()).digest()
 
 
-def blake256_ripemd160_digest(b: bytes) -> bytes:
-    h = blake256(b).digest()
-    h = ripemd160(h).digest()
-    return h
+class blake256_ripemd160(blake256):
+    def digest(self) -> bytes:
+        return ripemd160(super().digest()).digest()

--- a/core/src/trezor/utils.py
+++ b/core/src/trezor/utils.py
@@ -219,8 +219,11 @@ class BufferWriter:
 class BufferReader:
     """Seekable and readable view into a buffer."""
 
-    def __init__(self, buffer: bytes) -> None:
-        self.buffer = buffer
+    def __init__(self, buffer: Union[bytes, memoryview]) -> None:
+        if isinstance(buffer, memoryview):
+            self.buffer = buffer
+        else:
+            self.buffer = memoryview(buffer)
         self.offset = 0
 
     def seek(self, offset: int) -> None:
@@ -251,7 +254,15 @@ class BufferReader:
         If `length` is unspecified, reads all remaining data.
 
         Note that this method makes a copy of the data. To avoid allocation, use
-        `readinto()`.
+        `readinto()`. To avoid copying use `read_memoryview()`.
+        """
+        return bytes(self.read_memoryview(length))
+
+    def read_memoryview(self, length: int | None = None) -> memoryview:
+        """Read and return a memoryview of exactly `length` bytes, or raise
+        EOFError.
+
+        If `length` is unspecified, reads all remaining data.
         """
         if length is None:
             ret = self.buffer[self.offset :]

--- a/core/src/trezor/utils.py
+++ b/core/src/trezor/utils.py
@@ -146,6 +146,9 @@ def chunks_intersperse(
 if False:
 
     class HashContext(Protocol):
+        def __init__(self, data: bytes = None) -> None:
+            ...
+
         def update(self, buf: bytes) -> None:
             ...
 

--- a/crypto/tests/test_check_cashaddr.h
+++ b/crypto/tests/test_check_cashaddr.h
@@ -55,9 +55,17 @@ START_TEST(test_cashaddr) {
     rawdata_len = base58_decode_check(valid_cashaddr[i].legacy, HASHER_SHA2D,
                                       rawdata, sizeof(rawdata));
     ck_assert_uint_eq(rawdata_len, 21);
-    ck_assert_uint_eq(prog[0], rawdata[0] == 0   ? 0x00
-                               : rawdata[0] == 5 ? 0x08
-                                                 : -1);
+
+    int addr_type = -1;
+    if (rawdata[0] == 0) {
+      addr_type = 0x00;  // P2PKH
+    } else if (rawdata[0] == 5) {
+      addr_type = 0x08;  // P2SH
+    } else {
+      ck_abort();
+    }
+    ck_assert_uint_eq(prog[0], addr_type);
+
     ck_assert_int_eq(memcmp(rawdata + 1, prog + 1, 20), 0);
     ret = cash_addr_encode(rebuild, hrp, prog, 21);
     ck_assert_int_eq(ret, 1);

--- a/legacy/firmware/layout2.c
+++ b/legacy/firmware/layout2.c
@@ -779,10 +779,14 @@ void layoutAddress(const char *address, const char *desc, bool qrcode,
       oledDrawString(0, 0 * 9, desc, FONT_STANDARD);
     }
     if (addrlen > 10) {  // don't split short addresses
-      uint32_t rowlen = (addrlen - 1) / (addrlen <= 42   ? 2
-                                         : addrlen <= 63 ? 3
-                                                         : 4) +
-                        1;
+      uint32_t rowcount = 4;
+      if (addrlen <= 42) {
+        rowcount = 2;
+      } else if (addrlen <= 63) {
+        rowcount = 3;
+      }
+
+      uint32_t rowlen = (addrlen - 1) / rowcount + 1;
       const char **str =
           split_message((const uint8_t *)address, addrlen, rowlen);
       for (int i = 0; i < 4; i++) {

--- a/legacy/firmware/recovery.c
+++ b/legacy/firmware/recovery.c
@@ -146,9 +146,13 @@ static void recovery_request(void) {
   WordRequest resp = {0};
   memzero(&resp, sizeof(WordRequest));
   resp.has_type = true;
-  resp.type = awaiting_word == 1      ? WordRequestType_WordRequestType_Plain
-              : (word_index % 4 == 3) ? WordRequestType_WordRequestType_Matrix6
-                                      : WordRequestType_WordRequestType_Matrix9;
+  if (awaiting_word == 1) {
+    resp.type = WordRequestType_WordRequestType_Plain;
+  } else if (word_index % 4 == 3) {
+    resp.type = WordRequestType_WordRequestType_Matrix6;
+  } else {
+    resp.type = WordRequestType_WordRequestType_Matrix9;
+  }
   msg_write(MessageType_MessageType_WordRequest, &resp);
 }
 


### PR DESCRIPTION
This PR aims to reduce memory allocations and fragmentation mainly in Bitcoin signing by using writer semantics and memoryviews instead of string manipulations. I am not sure how effective the individual changes are, for example the global static buffer for Tx serialization might be pointless now that we have the workflow restarts.