### PR TITLE
fix(core): change logic of vendor header comparison

### DIFF
--- a/common/protob/messages-management.proto
+++ b/common/protob/messages-management.proto
@@ -75,7 +75,7 @@ message Features {
     optional uint32 fw_minor = 23;              // reported firmware version if in bootloader mode
     optional uint32 fw_patch = 24;              // reported firmware version if in bootloader mode
     optional string fw_vendor = 25;             // reported firmware vendor if in bootloader mode
-    optional bytes fw_vendor_keys = 26;         // reported firmware vendor keys (their hash)
+    // optional bytes fw_vendor_keys = 26;      // obsoleted, use fw_vendor
     optional bool unfinished_backup = 27;       // report unfinished backup (equals to Storage.unfinished_backup)
     optional bool no_backup = 28;               // report no backup (equals to Storage.no_backup)
     optional bool recovery_mode = 29;           // is recovery mode in progress

--- a/core/embed/bootloader/.changelog.d/1599.changed
+++ b/core/embed/bootloader/.changelog.d/1599.changed
@@ -1,0 +1,1 @@
+Update logic of vendor header comparison.

--- a/core/embed/bootloader/main.c
+++ b/core/embed/bootloader/main.c
@@ -191,9 +191,9 @@ secbool load_vendor_header_keys(const uint8_t *const data,
                             BOOTLOADER_KEYS, vhdr);
 }
 
-static secbool check_vendor_keys_lock(const vendor_header *const vhdr) {
+static secbool check_vendor_header_lock(const vendor_header *const vhdr) {
   uint8_t lock[FLASH_OTP_BLOCK_SIZE];
-  ensure(flash_otp_read(FLASH_OTP_BLOCK_VENDOR_KEYS_LOCK, 0, lock,
+  ensure(flash_otp_read(FLASH_OTP_BLOCK_VENDOR_HEADER_LOCK, 0, lock,
                         FLASH_OTP_BLOCK_SIZE),
          NULL);
   if (0 ==
@@ -204,7 +204,7 @@ static secbool check_vendor_keys_lock(const vendor_header *const vhdr) {
     return sectrue;
   }
   uint8_t hash[32];
-  vendor_keys_hash(vhdr, hash);
+  vendor_header_hash(vhdr, hash);
   return sectrue * (0 == memcmp(lock, hash, 32));
 }
 
@@ -269,7 +269,7 @@ int main(void) {
   secbool firmware_present =
       load_vendor_header_keys((const uint8_t *)FIRMWARE_START, &vhdr);
   if (sectrue == firmware_present) {
-    firmware_present = check_vendor_keys_lock(&vhdr);
+    firmware_present = check_vendor_header_lock(&vhdr);
   }
   if (sectrue == firmware_present) {
     firmware_present = load_image_header(
@@ -328,7 +328,7 @@ int main(void) {
   ensure(load_vendor_header_keys((const uint8_t *)FIRMWARE_START, &vhdr),
          "invalid vendor header");
 
-  ensure(check_vendor_keys_lock(&vhdr), "unauthorized vendor keys");
+  ensure(check_vendor_header_lock(&vhdr), "unauthorized vendor keys");
 
   ensure(load_image_header((const uint8_t *)(FIRMWARE_START + vhdr.hdrlen),
                            FIRMWARE_IMAGE_MAGIC, FIRMWARE_IMAGE_MAXSIZE,

--- a/core/embed/bootloader/messages.c
+++ b/core/embed/bootloader/messages.c
@@ -295,7 +295,7 @@ static void send_msg_features(uint8_t iface_num,
     MSG_SEND_ASSIGN_VALUE(fw_patch, ((hdr->version >> 16) & 0xFF));
     MSG_SEND_ASSIGN_STRING_LEN(fw_vendor, vhdr->vstr, vhdr->vstr_len);
     uint8_t hash[32];
-    vendor_keys_hash(vhdr, hash);
+    vendor_header_hash(vhdr, hash);
     MSG_SEND_ASSIGN_BYTES(fw_vendor_keys, hash, 32);
   } else {
     MSG_SEND_ASSIGN_VALUE(firmware_present, false);
@@ -446,8 +446,8 @@ static void detect_installation(vendor_header *current_vhdr,
     return;
   }
   uint8_t hash1[32], hash2[32];
-  vendor_keys_hash(new_vhdr, hash1);
-  vendor_keys_hash(current_vhdr, hash2);
+  vendor_header_hash(new_vhdr, hash1);
+  vendor_header_hash(current_vhdr, hash2);
   if (0 != memcmp(hash1, hash2, 32)) {
     return;
   }

--- a/core/embed/bootloader/messages.c
+++ b/core/embed/bootloader/messages.c
@@ -294,9 +294,6 @@ static void send_msg_features(uint8_t iface_num,
     MSG_SEND_ASSIGN_VALUE(fw_minor, ((hdr->version >> 8) & 0xFF));
     MSG_SEND_ASSIGN_VALUE(fw_patch, ((hdr->version >> 16) & 0xFF));
     MSG_SEND_ASSIGN_STRING_LEN(fw_vendor, vhdr->vstr, vhdr->vstr_len);
-    uint8_t hash[32];
-    vendor_header_hash(vhdr, hash);
-    MSG_SEND_ASSIGN_BYTES(fw_vendor_keys, hash, 32);
   } else {
     MSG_SEND_ASSIGN_VALUE(firmware_present, false);
   }

--- a/core/embed/bootloader/protob/messages.options
+++ b/core/embed/bootloader/protob/messages.options
@@ -5,7 +5,6 @@ Features.label                  max_size:33
 Features.revision               max_size:20
 Features.model                  max_size:17
 Features.fw_vendor              max_size:256
-Features.fw_vendor_keys         max_size:32
 
 Ping.message                    max_size:256
 

--- a/core/embed/bootloader/protob/messages.pb.h
+++ b/core/embed/bootloader/protob/messages.pb.h
@@ -61,7 +61,6 @@ typedef struct _Failure {
 } Failure;
 
 typedef PB_BYTES_ARRAY_T(20) Features_revision_t;
-typedef PB_BYTES_ARRAY_T(32) Features_fw_vendor_keys_t;
 typedef struct _Features {
     bool has_vendor;
     char vendor[33];
@@ -92,8 +91,6 @@ typedef struct _Features {
     uint32_t fw_patch;
     bool has_fw_vendor;
     char fw_vendor[256];
-    bool has_fw_vendor_keys;
-    Features_fw_vendor_keys_t fw_vendor_keys;
 } Features;
 
 typedef struct _FirmwareErase {
@@ -147,7 +144,7 @@ extern "C" {
 /* Initializer values for message structs */
 #define Initialize_init_default                  {0}
 #define GetFeatures_init_default                 {0}
-#define Features_init_default                    {false, "", 0, 0, 0, false, 0, false, "", false, "", false, "", false, 0, false, {0, {0}}, false, 0, false, "", false, 0, false, 0, false, 0, false, "", false, {0, {0}}}
+#define Features_init_default                    {false, "", 0, 0, 0, false, 0, false, "", false, "", false, "", false, 0, false, {0, {0}}, false, 0, false, "", false, 0, false, 0, false, 0, false, ""}
 #define Ping_init_default                        {false, ""}
 #define Success_init_default                     {false, ""}
 #define Failure_init_default                     {false, _FailureType_MIN, false, ""}
@@ -158,7 +155,7 @@ extern "C" {
 #define FirmwareUpload_init_default              {{{NULL}, NULL}, false, {0, {0}}}
 #define Initialize_init_zero                     {0}
 #define GetFeatures_init_zero                    {0}
-#define Features_init_zero                       {false, "", 0, 0, 0, false, 0, false, "", false, "", false, "", false, 0, false, {0, {0}}, false, 0, false, "", false, 0, false, 0, false, 0, false, "", false, {0, {0}}}
+#define Features_init_zero                       {false, "", 0, 0, 0, false, 0, false, "", false, "", false, "", false, 0, false, {0, {0}}, false, 0, false, "", false, 0, false, 0, false, 0, false, ""}
 #define Ping_init_zero                           {false, ""}
 #define Success_init_zero                        {false, ""}
 #define Failure_init_zero                        {false, _FailureType_MIN, false, ""}
@@ -188,7 +185,6 @@ extern "C" {
 #define Features_fw_minor_tag                    23
 #define Features_fw_patch_tag                    24
 #define Features_fw_vendor_tag                   25
-#define Features_fw_vendor_keys_tag              26
 #define FirmwareErase_length_tag                 1
 #define FirmwareRequest_offset_tag               1
 #define FirmwareRequest_length_tag               2
@@ -224,8 +220,7 @@ X(a, STATIC,   OPTIONAL, STRING,   model,            21) \
 X(a, STATIC,   OPTIONAL, UINT32,   fw_major,         22) \
 X(a, STATIC,   OPTIONAL, UINT32,   fw_minor,         23) \
 X(a, STATIC,   OPTIONAL, UINT32,   fw_patch,         24) \
-X(a, STATIC,   OPTIONAL, STRING,   fw_vendor,        25) \
-X(a, STATIC,   OPTIONAL, BYTES,    fw_vendor_keys,   26)
+X(a, STATIC,   OPTIONAL, STRING,   fw_vendor,        25)
 #define Features_CALLBACK NULL
 #define Features_DEFAULT NULL
 
@@ -302,7 +297,7 @@ extern const pb_msgdesc_t FirmwareUpload_msg;
 #define ButtonAck_size                           0
 #define ButtonRequest_size                       2
 #define Failure_size                             260
-#define Features_size                            493
+#define Features_size                            458
 #define FirmwareErase_size                       6
 #define FirmwareRequest_size                     12
 #define GetFeatures_size                         0

--- a/core/embed/bootloader/protob/messages.proto
+++ b/core/embed/bootloader/protob/messages.proto
@@ -55,7 +55,7 @@ message Features {
     optional uint32 fw_minor = 23;              // reported firmware version if in bootloader mode
     optional uint32 fw_patch = 24;              // reported firmware version if in bootloader mode
     optional string fw_vendor = 25;             // reported firmware vendor if in bootloader mode
-    optional bytes fw_vendor_keys = 26;         // reported firmware vendor keys (their hash)
+    // optional bytes fw_vendor_keys = 26;      // obsoleted, use fw_vendor
 }
 
 /**

--- a/core/embed/bootloader_ci/.changelog.d/1599.changed
+++ b/core/embed/bootloader_ci/.changelog.d/1599.changed
@@ -1,0 +1,1 @@
+Update logic of vendor header comparison.

--- a/core/embed/bootloader_ci/main.c
+++ b/core/embed/bootloader_ci/main.c
@@ -169,9 +169,9 @@ secbool load_vendor_header_keys(const uint8_t *const data,
                             BOOTLOADER_KEYS, vhdr);
 }
 
-static secbool check_vendor_keys_lock(const vendor_header *const vhdr) {
+static secbool check_vendor_header_lock(const vendor_header *const vhdr) {
   uint8_t lock[FLASH_OTP_BLOCK_SIZE];
-  ensure(flash_otp_read(FLASH_OTP_BLOCK_VENDOR_KEYS_LOCK, 0, lock,
+  ensure(flash_otp_read(FLASH_OTP_BLOCK_VENDOR_HEADER_LOCK, 0, lock,
                         FLASH_OTP_BLOCK_SIZE),
          NULL);
   if (0 ==
@@ -182,7 +182,7 @@ static secbool check_vendor_keys_lock(const vendor_header *const vhdr) {
     return sectrue;
   }
   uint8_t hash[32];
-  vendor_keys_hash(vhdr, hash);
+  vendor_header_hash(vhdr, hash);
   return sectrue * (0 == memcmp(lock, hash, 32));
 }
 
@@ -235,7 +235,7 @@ int main(void) {
   secbool firmware_present =
       load_vendor_header_keys((const uint8_t *)FIRMWARE_START, &vhdr);
   if (sectrue == firmware_present) {
-    firmware_present = check_vendor_keys_lock(&vhdr);
+    firmware_present = check_vendor_header_lock(&vhdr);
   }
   if (sectrue == firmware_present) {
     firmware_present = load_image_header(
@@ -263,7 +263,7 @@ int main(void) {
   ensure(load_vendor_header_keys((const uint8_t *)FIRMWARE_START, &vhdr),
          "invalid vendor header");
 
-  ensure(check_vendor_keys_lock(&vhdr), "unauthorized vendor keys");
+  ensure(check_vendor_header_lock(&vhdr), "unauthorized vendor keys");
 
   ensure(load_image_header((const uint8_t *)(FIRMWARE_START + vhdr.hdrlen),
                            FIRMWARE_IMAGE_MAGIC, FIRMWARE_IMAGE_MAXSIZE,

--- a/core/embed/bootloader_ci/messages.c
+++ b/core/embed/bootloader_ci/messages.c
@@ -295,7 +295,7 @@ static void send_msg_features(uint8_t iface_num,
     MSG_SEND_ASSIGN_VALUE(fw_patch, ((hdr->version >> 16) & 0xFF));
     MSG_SEND_ASSIGN_STRING_LEN(fw_vendor, vhdr->vstr, vhdr->vstr_len);
     uint8_t hash[32];
-    vendor_keys_hash(vhdr, hash);
+    vendor_header_hash(vhdr, hash);
     MSG_SEND_ASSIGN_BYTES(fw_vendor_keys, hash, 32);
   } else {
     MSG_SEND_ASSIGN_VALUE(firmware_present, false);
@@ -446,8 +446,8 @@ static void detect_installation(vendor_header *current_vhdr,
     return;
   }
   uint8_t hash1[32], hash2[32];
-  vendor_keys_hash(new_vhdr, hash1);
-  vendor_keys_hash(current_vhdr, hash2);
+  vendor_header_hash(new_vhdr, hash1);
+  vendor_header_hash(current_vhdr, hash2);
   if (0 != memcmp(hash1, hash2, 32)) {
     return;
   }

--- a/core/embed/bootloader_ci/messages.c
+++ b/core/embed/bootloader_ci/messages.c
@@ -294,9 +294,6 @@ static void send_msg_features(uint8_t iface_num,
     MSG_SEND_ASSIGN_VALUE(fw_minor, ((hdr->version >> 8) & 0xFF));
     MSG_SEND_ASSIGN_VALUE(fw_patch, ((hdr->version >> 16) & 0xFF));
     MSG_SEND_ASSIGN_STRING_LEN(fw_vendor, vhdr->vstr, vhdr->vstr_len);
-    uint8_t hash[32];
-    vendor_header_hash(vhdr, hash);
-    MSG_SEND_ASSIGN_BYTES(fw_vendor_keys, hash, 32);
   } else {
     MSG_SEND_ASSIGN_VALUE(firmware_present, false);
   }

--- a/core/embed/trezorhal/flash.h
+++ b/core/embed/trezorhal/flash.h
@@ -110,7 +110,7 @@ secbool __wur flash_write_word(uint8_t sector, uint32_t offset, uint32_t data);
 // OTP blocks allocation
 #define FLASH_OTP_BLOCK_BATCH 0
 #define FLASH_OTP_BLOCK_BOOTLOADER_VERSION 1
-#define FLASH_OTP_BLOCK_VENDOR_KEYS_LOCK 2
+#define FLASH_OTP_BLOCK_VENDOR_HEADER_LOCK 2
 #define FLASH_OTP_BLOCK_RANDOMNESS 3
 
 secbool __wur flash_otp_read(uint8_t block, uint8_t offset, uint8_t *data,

--- a/core/embed/trezorhal/image.c
+++ b/core/embed/trezorhal/image.c
@@ -161,22 +161,11 @@ secbool load_vendor_header(const uint8_t *const data, uint8_t key_m,
                                  *(const ed25519_signature *)vhdr->sig));
 }
 
-void vendor_keys_hash(const vendor_header *const vhdr, uint8_t *hash) {
+void vendor_header_hash(const vendor_header *const vhdr, uint8_t *hash) {
   BLAKE2S_CTX ctx;
   blake2s_Init(&ctx, BLAKE2S_DIGEST_LENGTH);
-  blake2s_Update(&ctx, &(vhdr->vsig_m), sizeof(vhdr->vsig_m));
-  blake2s_Update(&ctx, &(vhdr->vsig_n), sizeof(vhdr->vsig_n));
-  for (int i = 0; i < MAX_VENDOR_PUBLIC_KEYS; i++) {
-    if (vhdr->vpub[i] != 0) {
-      blake2s_Update(&ctx, vhdr->vpub[i], 32);
-    } else {
-      blake2s_Update(
-          &ctx,
-          "\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00"
-          "\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00",
-          32);
-    }
-  }
+  blake2s_Update(&ctx, vhdr->vstr, vhdr->vstr_len);
+  blake2s_Update(&ctx, "Trezor Vendor Header", 20);
   blake2s_Final(&ctx, hash, BLAKE2S_DIGEST_LENGTH);
 }
 

--- a/core/embed/trezorhal/image.h
+++ b/core/embed/trezorhal/image.h
@@ -87,7 +87,7 @@ secbool __wur load_vendor_header(const uint8_t *const data, uint8_t key_m,
                                  uint8_t key_n, const uint8_t *const *keys,
                                  vendor_header *const vhdr);
 
-void vendor_keys_hash(const vendor_header *const vhdr, uint8_t *hash);
+void vendor_header_hash(const vendor_header *const vhdr, uint8_t *hash);
 
 secbool __wur check_single_hash(const uint8_t *const hash,
                                 const uint8_t *const data, int len);

--- a/core/src/trezor/messages.py
+++ b/core/src/trezor/messages.py
@@ -1839,7 +1839,6 @@ if TYPE_CHECKING:
         fw_minor: "int | None"
         fw_patch: "int | None"
         fw_vendor: "str | None"
-        fw_vendor_keys: "bytes | None"
         unfinished_backup: "bool | None"
         no_backup: "bool | None"
         recovery_mode: "bool | None"
@@ -1882,7 +1881,6 @@ if TYPE_CHECKING:
             fw_minor: "int | None" = None,
             fw_patch: "int | None" = None,
             fw_vendor: "str | None" = None,
-            fw_vendor_keys: "bytes | None" = None,
             unfinished_backup: "bool | None" = None,
             no_backup: "bool | None" = None,
             recovery_mode: "bool | None" = None,

--- a/legacy/firmware/protob/messages-management.options
+++ b/legacy/firmware/protob/messages-management.options
@@ -8,7 +8,6 @@ Features.revision                       max_size:20
 Features.bootloader_hash                max_size:32
 Features.model                          max_size:17
 Features.fw_vendor                      max_size:256
-Features.fw_vendor_keys                 max_size:32
 Features.capabilities                   max_count:32
 Features.session_id                     max_size:32
 

--- a/python/src/trezorlib/messages.py
+++ b/python/src/trezorlib/messages.py
@@ -3055,7 +3055,6 @@ class Features(protobuf.MessageType):
         23: protobuf.Field("fw_minor", "uint32", repeated=False, required=False),
         24: protobuf.Field("fw_patch", "uint32", repeated=False, required=False),
         25: protobuf.Field("fw_vendor", "string", repeated=False, required=False),
-        26: protobuf.Field("fw_vendor_keys", "bytes", repeated=False, required=False),
         27: protobuf.Field("unfinished_backup", "bool", repeated=False, required=False),
         28: protobuf.Field("no_backup", "bool", repeated=False, required=False),
         29: protobuf.Field("recovery_mode", "bool", repeated=False, required=False),
@@ -3100,7 +3099,6 @@ class Features(protobuf.MessageType):
         fw_minor: Optional["int"] = None,
         fw_patch: Optional["int"] = None,
         fw_vendor: Optional["str"] = None,
-        fw_vendor_keys: Optional["bytes"] = None,
         unfinished_backup: Optional["bool"] = None,
         no_backup: Optional["bool"] = None,
         recovery_mode: Optional["bool"] = None,
@@ -3140,7 +3138,6 @@ class Features(protobuf.MessageType):
         self.fw_minor = fw_minor
         self.fw_patch = fw_patch
         self.fw_vendor = fw_vendor
-        self.fw_vendor_keys = fw_vendor_keys
         self.unfinished_backup = unfinished_backup
         self.no_backup = no_backup
         self.recovery_mode = recovery_mode


### PR DESCRIPTION
Previously we checked whether the current vendor header and
the new vendor header are the same by comparing the embedded keyset.

What originally looked like a good idea is not that good, because
this disallows us from ever changing the vendor header signing keys
without causing erasure of the storage during the version update.

This commit fixes that by changing the logic to comparing just the
vendor string.

Change of function names is purely cosmetic:
* vendor_keys_hash -> vendor_header_hash
* check_vendor_keys_lock -> check_vendor_header_lock