### PR TITLE
fix(legacy): don't erase firmware and storage in intermediate firmware ...

### DIFF
--- a/docs/legacy/index.md
+++ b/docs/legacy/index.md
@@ -117,7 +117,7 @@ This table shows the result for bootloader 1.8.0+ and 1.9.1+:
 | ------------------------- | ----------------------- | ------------------------------ | ------------------------------------------------------------------------------------------ |
 |  1                        |  1                      | yes                            | works, official configuration                                                              |
 |  1                        |  1                      | no                             | hardfault in header.S when setting VTOR and stack                                          |
-|  0                        |  1                      | no                             | works, but don't forget to comment out `check_bootloader`, otherwise it'll get overwritten |
+|  0                        |  1                      | no                             | works, but don't forget to comment out `check_and_replace_bootloader`, otherwise it'll get overwritten |
 |  0                        |  0                      | no                             | hard fault because header.S doesn't set VTOR and stack right                               |
 |  1                        |  0                      | no                             | works                                                                                      |
 

--- a/legacy/firmware/bl_check.c
+++ b/legacy/firmware/bl_check.c
@@ -140,9 +140,9 @@ static int known_bootloader(int r, const uint8_t *hash) {
  * If bootloader is older and known, replace with newer bootloader.
  * If bootloader is unknown, halt with error message.
  *
- * @param shutdown_on_success: if true, shuts down device instead of return
+ * @param shutdown_on_replace: if true, shuts down device instead of return
  */
-void check_bootloader(bool shutdown_on_success) {
+void check_and_replace_bootloader(bool shutdown_on_replace) {
 #if MEMORY_PROTECT
   uint8_t hash[32] = {0};
   int r = memory_bootloader_hash(hash);
@@ -190,7 +190,7 @@ void check_bootloader(bool shutdown_on_success) {
     // check whether the write was OK
     r = memory_bootloader_hash(hash);
     if (r == 32 && 0 == memcmp(hash, bl_hash, 32)) {
-      if (shutdown_on_success) {
+      if (shutdown_on_replace) {
         // OK -> show info and halt
         layoutDialog(&bmp_icon_info, NULL, NULL, NULL, _("Update finished"),
                      _("successfully."), NULL, _("Please reconnect"),
@@ -207,5 +207,5 @@ void check_bootloader(bool shutdown_on_success) {
   shutdown();
 #endif
   // prevent compiler warning when MEMORY_PROTECT==0
-  (void)shutdown_on_success;
+  (void)shutdown_on_replace;
 }

--- a/legacy/firmware/bl_check.h
+++ b/legacy/firmware/bl_check.h
@@ -22,6 +22,6 @@
 
 #include <stdbool.h>
 
-void check_bootloader(bool shutdown_on_success);
+void check_and_replace_bootloader(bool shutdown_on_replace);
 
 #endif

--- a/legacy/firmware/trezor.c
+++ b/legacy/firmware/trezor.c
@@ -123,7 +123,7 @@ int main(void) {
                                    // unpredictable stack protection checks
   oledInit();
 #else
-  check_bootloader(true);
+  check_and_replace_bootloader(true);
   setupApp();
   __stack_chk_guard = random32();  // this supports compiler provided
                                    // unpredictable stack protection checks

--- a/legacy/intermediate_fw/.gitignore
+++ b/legacy/intermediate_fw/.gitignore
@@ -1,0 +1,1 @@
+bl_data.h

--- a/legacy/intermediate_fw/trezor.c
+++ b/legacy/intermediate_fw/trezor.c
@@ -112,7 +112,7 @@ int main(void) {
 
   mpu_config_off();  // needed for flash writable, RAM RWX
   timer_init();
-  check_bootloader(false);
+  check_and_replace_bootloader(false);
 
   layoutDialog(&bmp_icon_warning, NULL, NULL, NULL, "Erasing old data", NULL,
                NULL, "DO NOT UNPLUG", "YOUR TREZOR!", NULL);


### PR DESCRIPTION
... if the storage has been already initialized

Possible fix for https://github.com/trezor/trezor-firmware/issues/1597

