### PR TITLE
fix(core): imports needed for T1 startup

### DIFF
--- a/core/.changelog.d/24.fixed
+++ b/core/.changelog.d/24.fixed
@@ -1,0 +1,1 @@
+Import errors on T1 startup.

--- a/core/src/apps/common/request_pin.py
+++ b/core/src/apps/common/request_pin.py
@@ -4,8 +4,6 @@ import storage.cache
 import storage.sd_salt
 from trezor import config, ui, wire
 from trezor.messages import ButtonRequestType
-from trezor.ui.components.tt.pin import CANCELLED, PinDialog
-from trezor.ui.components.tt.text import Text
 from trezor.ui.popup import Popup
 
 from . import button_request
@@ -26,6 +24,8 @@ async def request_pin(
     attempts_remaining: int | None = None,
     allow_cancel: bool = True,
 ) -> str:
+    from trezor.ui.components.tt.pin import CANCELLED, PinDialog
+
     await button_request(ctx, code=ButtonRequestType.PinEntry)
 
     if attempts_remaining is None:
@@ -55,6 +55,8 @@ async def request_pin_confirm(ctx: wire.Context, *args: Any, **kwargs: Any) -> s
 
 
 async def pin_mismatch() -> None:
+    from trezor.ui.components.tt.text import Text
+
     text = Text("PIN mismatch", ui.ICON_WRONG, ui.RED)
     text.normal("The PINs you entered", "do not match.")
     text.normal("")

--- a/core/src/trezor/ui/layouts/t1.py
+++ b/core/src/trezor/ui/layouts/t1.py
@@ -1,0 +1,44 @@
+from trezor import ui, wire
+from trezor.messages import ButtonRequestType
+
+if False:
+    from typing import NoReturn, Type, Union
+
+    from trezor.messages.ButtonRequest import EnumTypeButtonRequestType
+
+    ExceptionType = Union[BaseException, Type[BaseException]]
+
+
+async def confirm_action(
+    ctx: wire.GenericContext,
+    br_type: str,
+    title: str,
+    action: str | None = None,
+    description: str | None = None,
+    description_param: str | None = None,
+    description_param_font: int = ui.BOLD,
+    verb: str | bytes | None = "OK",
+    verb_cancel: str | bytes | None = "X",
+    hold: bool = False,
+    hold_danger: bool = False,
+    icon: str | None = None,
+    icon_color: int | None = None,
+    reverse: bool = False,
+    larger_vspace: bool = False,
+    exc: ExceptionType = wire.ActionCancelled,
+    br_code: EnumTypeButtonRequestType = ButtonRequestType.Other,
+) -> None:
+    raise NotImplementedError
+
+
+async def show_error_and_raise(
+    ctx: wire.GenericContext,
+    br_type: str,
+    content: str,
+    header: str = "Error",
+    subheader: str | None = None,
+    button: str = "Close",
+    red: bool = False,
+    exc: ExceptionType = wire.ActionCancelled,
+) -> NoReturn:
+    raise NotImplementedError


### PR DESCRIPTION
Currently core on T1 errors out on ImportError before the firmware initializes USB. While this is mostly solved by #1545 it's probably not going to be in master soon so I'd like to propose this change to at least make T1 fully boot.