### PR TITLE
fix(legacy): set STAY_IN_BOOTLOADER_FLAG before the reboot of intermediate_fw

### DIFF
--- a/legacy/intermediate_fw/trezor.c
+++ b/legacy/intermediate_fw/trezor.c
@@ -31,6 +31,7 @@
 #include "oled.h"
 #include "rng.h"
 #include "setup.h"
+#include "supervise.h"
 #include "timer.h"
 #include "util.h"
 
@@ -86,6 +87,7 @@ static void __attribute__((noinline, section(".data"))) erase_firmware(void) {
 
 void __attribute__((noinline, noreturn, section(".data"))) reboot_device(void) {
   __disable_irq();
+  *STAY_IN_BOOTLOADER_FLAG_ADDR = STAY_IN_BOOTLOADER_FLAG;
   SCB_AIRCR = SCB_AIRCR_VECTKEY | SCB_AIRCR_SYSRESETREQ;
   while (1)
     ;


### PR DESCRIPTION
Fixes https://github.com/trezor/trezor-firmware/issues/1619