### PR TITLE
build(core): skip rust library for now

### DIFF
--- a/ci/shell.nix
+++ b/ci/shell.nix
@@ -3,15 +3,11 @@
  }:
 
 let
-  rustOverlay = import (builtins.fetchTarball {
-    url = "https://github.com/oxalica/rust-overlay/archive/4d5d8e4288a8e0efd074e56a448e450b0f8df975.tar.gz";
-    sha256 = "1v3xlpna3q5klnhrn3p43bdh24ynaf31s2980r98ypvdpi2wi018";
-  });
   # the last successful build of nixpkgs-unstable as of 2021-05-07
   nixpkgs = import (builtins.fetchTarball {
     url = "https://github.com/NixOS/nixpkgs/archive/e62feb3bf4a603e26755238303bda0c24651e155.tar.gz";
     sha256 = "1gkamm044jrksjrisr7h9grg8p2y6rk01x6391asrx988hm2rh9s";
-  }) { overlays = [ rustOverlay ]; };
+  }) { };
   moneroTests = nixpkgs.fetchurl {
     url = "https://github.com/ph4r05/monero/releases/download/v0.17.1.9-tests/trezor_tests";
     sha256 = "410bc4ff2ff1edc65e17f15b549bd1bf8a3776cf67abdea86aed52cf4bce8d9d";
@@ -22,12 +18,6 @@ let
     ${nixpkgs.patchelf}/bin/patchelf --set-interpreter "$(cat $NIX_CC/nix-support/dynamic-linker)" "$out"
     chmod -w $out
   '';
-  rustStable = nixpkgs.rust-bin.stable."1.52.1".default.override {
-    targets = [
-      "thumbv7em-none-eabihf" # TT
-      "thumbv7m-none-eabi"    # T1
-    ];
-  };
 in
 with nixpkgs;
 stdenv.mkDerivation ({
@@ -63,7 +53,6 @@ stdenv.mkDerivation ({
     poetry
     protobuf3_6
     rustfmt
-    rustStable
     wget
     zlib
   ] ++ lib.optionals (!stdenv.isDarwin) [

--- a/core/SConscript.firmware
+++ b/core/SConscript.firmware
@@ -623,28 +623,28 @@ if FEATURE_FLAGS["SECP256K1_ZKP"]:
 # Rust library
 #
 
-RUST_PROFILE = 'release'
-RUST_LIB = 'trezor_lib'
-RUST_LIBDIR = f'build/rust/{RUST_TARGET}/{RUST_PROFILE}'
-RUST_LIBPATH = f'{RUST_LIBDIR}/lib{RUST_LIB}.a'
-
-def cargo_build():
-    # Determine the profile build flags.
-    if RUST_PROFILE == 'release':
-        profile = '--release'
-    else:
-        profile = ''
-    return f'cd embed/rust; cargo build {profile} --target={RUST_TARGET}'
-
-rust = env.Command(
-    target=RUST_LIBPATH,
-    source='',
-    action=cargo_build(), )
-
-env.Depends(rust, qstr_generated)
-
-env.Append(LINKFLAGS=f' -L{RUST_LIBDIR}')
-env.Append(LINKFLAGS=f' -l{RUST_LIB}')
+#RUST_PROFILE = 'release'
+#RUST_LIB = 'trezor_lib'
+#RUST_LIBDIR = f'build/rust/{RUST_TARGET}/{RUST_PROFILE}'
+#RUST_LIBPATH = f'{RUST_LIBDIR}/lib{RUST_LIB}.a'
+#
+#def cargo_build():
+#    # Determine the profile build flags.
+#    if RUST_PROFILE == 'release':
+#        profile = '--release'
+#    else:
+#        profile = ''
+#    return f'cd embed/rust; cargo build {profile} --target={RUST_TARGET}'
+#
+#rust = env.Command(
+#    target=RUST_LIBPATH,
+#    source='',
+#    action=cargo_build(), )
+#
+#env.Depends(rust, qstr_generated)
+#
+#env.Append(LINKFLAGS=f' -L{RUST_LIBDIR}')
+#env.Append(LINKFLAGS=f' -l{RUST_LIB}')
 
 #
 # Program objects
@@ -691,7 +691,7 @@ program_elf = env.Command(
     '$LINK -o $TARGET $CCFLAGS $CFLAGS $SOURCES $LINKFLAGS -lc_nano -lm -lgcc',
 )
 
-env.Depends(program_elf, rust)
+#env.Depends(program_elf, rust)
 
 if TREZOR_MODEL == 'T':
     action_bin=[

--- a/core/SConscript.unix
+++ b/core/SConscript.unix
@@ -575,28 +575,28 @@ if FEATURE_FLAGS["SECP256K1_ZKP"]:
 # Rust library
 #
 
-RUST_PROFILE = 'release'
-RUST_LIB = 'trezor_lib'
-RUST_LIBDIR = f'build/rust/{RUST_PROFILE}'
-RUST_LIBPATH = f'{RUST_LIBDIR}/lib{RUST_LIB}.a'
-
-def cargo_build():
-    # Determine the profile build flags.
-    if RUST_PROFILE == 'release':
-        profile = '--release'
-    else:
-        profile = ''
-    return f'cd embed/rust; cargo build {profile}'
-
-rust = env.Command(
-    target=RUST_LIBPATH,
-    source='',
-    action=cargo_build(), )
-
-env.Depends(rust, qstr_generated)
-
-env.Append(LINKFLAGS=f'-L{RUST_LIBDIR}')
-env.Append(LINKFLAGS=f'-l{RUST_LIB}')
+#RUST_PROFILE = 'release'
+#RUST_LIB = 'trezor_lib'
+#RUST_LIBDIR = f'build/rust/{RUST_PROFILE}'
+#RUST_LIBPATH = f'{RUST_LIBDIR}/lib{RUST_LIB}.a'
+#
+#def cargo_build():
+#    # Determine the profile build flags.
+#    if RUST_PROFILE == 'release':
+#        profile = '--release'
+#    else:
+#        profile = ''
+#    return f'cd embed/rust; cargo build {profile}'
+#
+#rust = env.Command(
+#    target=RUST_LIBPATH,
+#    source='',
+#    action=cargo_build(), )
+#
+#env.Depends(rust, qstr_generated)
+#
+#env.Append(LINKFLAGS=f'-L{RUST_LIBDIR}')
+#env.Append(LINKFLAGS=f'-l{RUST_LIB}')
 
 #
 # Program objects
@@ -620,4 +620,4 @@ program = env.Command(
     source=obj_program,
     action='$CC -o $TARGET $SOURCES $_LIBDIRFLAGS $_LIBFLAGS $LINKFLAGS', )
 
-env.Depends(program, rust)
+#env.Depends(program, rust)


### PR DESCRIPTION
Disable linking in of `trezor_lib.a` into the final image, for this release.