### PR TITLE
ci: improve changelog check, longer timeout for T1 hw test

### DIFF
--- a/ci/prebuild.yml
+++ b/ci/prebuild.yml
@@ -44,6 +44,8 @@ release commit messages prebuild:
 
 changelog prebuild:
   stage: prebuild
+  except:
+    - master
   before_script: []  # nothing needed
   variables:
     GIT_SUBMODULE_STRATEGY: "none"

--- a/ci/test-hw.yml
+++ b/ci/test-hw.yml
@@ -109,6 +109,7 @@ hardware legacy regular device test:
   script:
     - cd ci/hardware_tests
     - nix-shell --run "./t1_hw_test.sh"
+  timeout: 1h10m
   artifacts:
     name: "$CI_JOB_NAME-$CI_COMMIT_SHORT_SHA"
     paths:

--- a/docs/misc/changelog.md
+++ b/docs/misc/changelog.md
@@ -41,6 +41,13 @@ type you can add numeral suffix, e.g. `1234.fixed.1`, `1234.fixed.2`, etc.
 You can also add this entry using your `$VISUAL` editor by running `towncrier
 create --edit 1234.fixed` in the `core` directory.
 
+## Not adding changelog entry
+
+If you don't add an entry for changes in your branch, the `changelog prebuild`
+CI job will remind you by failing. Sometimes adding an entry does not really make
+sense, in that case you can include `[no changelog]` anywhere in the commit
+message to exclude that commit from the check.
+
 ## Generating changelog at the time of release
 
 When it's time to release new version of a repository component the formatted


### PR DESCRIPTION
`check_changelog.sh`:
- ignore `master` branch
- treat `secfix/` same as `release/` branches
- allow skiping check with `[no changelog]` in commit message