### PR TITLE
feat(core): avoid restarting session for select messages (fixes #1631)

### DIFF
--- a/core/src/apps/management/recovery_device/homescreen.py
+++ b/core/src/apps/management/recovery_device/homescreen.py
@@ -6,7 +6,7 @@ from trezor import strings, utils, wire, workflow
 from trezor.crypto import slip39
 from trezor.crypto.hashlib import sha256
 from trezor.errors import MnemonicError
-from trezor.messages import BackupType
+from trezor.messages import BackupType, MessageType
 from trezor.messages.Success import Success
 from trezor.ui.layouts import show_success
 
@@ -31,6 +31,7 @@ async def recovery_homescreen() -> None:
 
 
 async def recovery_process(ctx: wire.GenericContext) -> Success:
+    wire.AVOID_RESTARTING_FOR = (MessageType.Initialize, MessageType.GetFeatures)
     try:
         return await _continue_recovery_process(ctx)
     except recover.RecoveryAborted:

--- a/core/src/session.py
+++ b/core/src/session.py
@@ -1,4 +1,4 @@
-from trezor import loop, utils, wire, workflow
+from trezor import log, loop, utils, wire, workflow
 
 import apps.base
 import usb
@@ -25,3 +25,6 @@ if __debug__:
     wire.setup(usb.iface_debug, is_debug_session=True)
 
 loop.run()
+
+if __debug__:
+    log.debug(__name__, "Restarting main loop")

--- a/core/src/trezor/wire/__init__.py
+++ b/core/src/trezor/wire/__init__.py
@@ -52,6 +52,7 @@ if False:
         Any,
         Awaitable,
         Callable,
+        Container,
         Coroutine,
         Iterable,
         TypeVar,
@@ -431,7 +432,7 @@ async def handle_session(
                     # workflow running on wire.
                     utils.unimport_end(modules)
 
-                    if next_msg is None:
+                    if next_msg is None and msg.type not in AVOID_RESTARTING_FOR:
                         # Shut down the loop if there is no next message waiting.
                         # Let the session be restarted from `main`.
                         loop.clear()
@@ -450,6 +451,7 @@ def _find_handler_placeholder(iface: WireInterface, msg_type: int) -> Handler | 
 
 
 find_handler = _find_handler_placeholder
+AVOID_RESTARTING_FOR: Container[int] = ()
 
 
 def failure(exc: BaseException) -> Failure:


### PR DESCRIPTION
Introduces `wire.AVOID_RESTARTING_FOR` and the recovery workflow will set it whenever it runs.

This also allows us to e.g. avoid restarting for GetPublicKey and thus make the old Wallet significantly faster, at the cost of some memory fragmentation. I am not doing that now, but it would be easy if we actually needed it.