### PR TITLE
Fix bitcoin-only strings check, make legacy conform

### DIFF
--- a/legacy/firmware/signing.c
+++ b/legacy/firmware/signing.c
@@ -1070,9 +1070,14 @@ static bool signing_validate_output(TxOutputType *txoutput) {
 
 static bool signing_validate_bin_output(TxOutputBinType *tx_bin_output) {
   if (!coin->decred && tx_bin_output->has_decred_script_version) {
+#if BITCOIN_ONLY
+    fsm_sendFailure(FailureType_Failure_DataError,
+                    _("Unsupported output type."));
+#else
     fsm_sendFailure(
         FailureType_Failure_DataError,
         _("Decred details provided but Decred coin not specified."));
+#endif
     signing_abort();
     return false;
   }

--- a/tools/check-bitcoin-only
+++ b/tools/check-bitcoin-only
@@ -2,11 +2,17 @@
 RETURN=0
 
 # dump all coins except the first 3 (Bitcoin, Testnet, Regtest)
-./common/tools/cointool.py dump -l -p -t | grep '"name"' | cut -d '"' -f 4 | tail -n +4 | while read altcoin; do
+ALTCOINS=$(./common/tools/cointool.py dump -l -p -t | grep '"name"' | cut -d '"' -f 4 | tail -n +4)
+# split on newlines only
+OLDIFS=$IFS
+IFS="
+"
+for altcoin in $ALTCOINS; do
     # echo :"$altcoin":
-    if strings $1 | grep "$altcoin" | grep -v TEXT_MARGIN_LEFT | grep -v _MIN_MNEMONIC_LENGTH_WORD ; then
+    if strings "$1" | grep "$altcoin" | grep -v TEXT_MARGIN_LEFT | grep -v _MIN_MNEMONIC_LENGTH_WORD ; then
         RETURN=1
     fi
 done
+IFS=$OLDIFS
 
 exit $RETURN


### PR DESCRIPTION
I propose merging this after *core* is made conformant, otherwise the `core fw btconly build` is gonna be red in every CI pipeline run.

Regarding legacy ISTM that the check should stay in the `BITCOIN_ONLY`, so only the error messages differ. Perhaps we can use the generic one even in full firmware?