### PR TITLE
Avoid accidental build with broken stack protector, especially for bundled bootloader.bin

### DIFF
--- a/core/.changelog.d/1642.security
+++ b/core/.changelog.d/1642.security
@@ -1,0 +1,1 @@
+Avoid accidental build with broken stack protector

--- a/core/embed/bootloader/.changelog.d/1642.security
+++ b/core/embed/bootloader/.changelog.d/1642.security
@@ -1,0 +1,1 @@
+Avoid accidental build with broken stack protector

--- a/core/embed/bootloader/main.c
+++ b/core/embed/bootloader/main.c
@@ -36,6 +36,20 @@
 #include "messages.h"
 // #include "mpu.h"
 
+/*
+ * Avoid accidental build with gcc versions having broken stack protector 9.2.1 - 10.2
+ */
+#if defined(__GNUC__) && !defined(__llvm__)
+
+#define GCC_VERSION (__GNUC__ * 10000 \
+                     + __GNUC_MINOR__ * 100 \
+                     + __GNUC_PATCHLEVEL__)
+
+#if GCC_VERSION >= 90201 && GCC_VERSION <= 100200
+#error "ARM GCC versions 9.2.1 - 10.2 have broken stack smash protector, preventing build"
+#endif
+#endif
+
 const uint8_t BOOTLOADER_KEY_M = 2;
 const uint8_t BOOTLOADER_KEY_N = 3;
 static const uint8_t * const BOOTLOADER_KEYS[] = {

--- a/core/embed/bootloader/main.c
+++ b/core/embed/bootloader/main.c
@@ -21,6 +21,7 @@
 #include <sys/types.h>
 
 #include "common.h"
+#include "compiler_traits.h"
 #include "display.h"
 #include "flash.h"
 #include "image.h"
@@ -35,20 +36,6 @@
 #include "bootui.h"
 #include "messages.h"
 // #include "mpu.h"
-
-/*
- * Avoid accidental build with gcc versions having broken stack protector 9.2.1 - 10.2
- */
-#if defined(__GNUC__) && !defined(__llvm__)
-
-#define GCC_VERSION (__GNUC__ * 10000 \
-                     + __GNUC_MINOR__ * 100 \
-                     + __GNUC_PATCHLEVEL__)
-
-#if GCC_VERSION >= 90201 && GCC_VERSION <= 100200
-#error "ARM GCC versions 9.2.1 - 10.2 have broken stack smash protector, preventing build"
-#endif
-#endif
 
 const uint8_t BOOTLOADER_KEY_M = 2;
 const uint8_t BOOTLOADER_KEY_N = 3;

--- a/core/embed/firmware/main.c
+++ b/core/embed/firmware/main.c
@@ -38,6 +38,7 @@
 #include "bl_check.h"
 #include "button.h"
 #include "common.h"
+#include "compiler_traits.h"
 #include "display.h"
 #include "flash.h"
 #include "mpu.h"
@@ -52,20 +53,6 @@
 
 // from util.s
 extern void shutdown_privileged(void);
-
-/*
- * Avoid accidental build with gcc versions having broken stack protector 9.2.1 - 10.2
- */
-#if defined(__GNUC__) && !defined(__llvm__)
-
-#define GCC_VERSION (__GNUC__ * 10000 \
-                     + __GNUC_MINOR__ * 100 \
-                     + __GNUC_PATCHLEVEL__)
-
-#if GCC_VERSION >= 90201 && GCC_VERSION <= 100200
-#error "ARM GCC versions 9.2.1 - 10.2 have broken stack smash protector, preventing build"
-#endif
-#endif
 
 int main(void) {
   random_delays_init();

--- a/core/embed/firmware/main.c
+++ b/core/embed/firmware/main.c
@@ -53,6 +53,20 @@
 // from util.s
 extern void shutdown_privileged(void);
 
+/*
+ * Avoid accidental build with gcc versions having broken stack protector 9.2.1 - 10.2
+ */
+#if defined(__GNUC__) && !defined(__llvm__)
+
+#define GCC_VERSION (__GNUC__ * 10000 \
+                     + __GNUC_MINOR__ * 100 \
+                     + __GNUC_PATCHLEVEL__)
+
+#if GCC_VERSION >= 90201 && GCC_VERSION <= 100200
+#error "ARM GCC versions 9.2.1 - 10.2 have broken stack smash protector, preventing build"
+#endif
+#endif
+
 int main(void) {
   random_delays_init();
 

--- a/core/embed/trezorhal/compiler_traits.h
+++ b/core/embed/trezorhal/compiler_traits.h
@@ -1,0 +1,38 @@
+/*
+ * This file is part of the Trezor project, https://trezor.io/
+ *
+ * Copyright (c) SatoshiLabs
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#ifndef __COMPILER_TRAITS_H__
+#define __COMPILER_TRAITS_H__
+
+/*
+ * Avoid accidental build with gcc versions having broken stack protector 9.2.1 - 10.2
+ */
+#if defined(__GNUC__) && !defined(__llvm__)
+
+#define GCC_VERSION (__GNUC__ * 10000 \
+                     + __GNUC_MINOR__ * 100 \
+                     + __GNUC_PATCHLEVEL__)
+
+#if GCC_VERSION >= 90201 && GCC_VERSION <= 100200
+#pragma message "Only remove this GCC check if you are sure your compiler is patched or not used for production."
+#error "ARM GCC versions 9.2.1 - 10.2 have broken stack smash protector, aborting build."
+#endif
+#endif
+
+#endif

--- a/core/embed/trezorhal/compiler_traits.h
+++ b/core/embed/trezorhal/compiler_traits.h
@@ -21,17 +21,19 @@
 #define __COMPILER_TRAITS_H__
 
 /*
- * Avoid accidental build with gcc versions having broken stack protector 9.2.1 - 10.2
+ * Avoid accidental build with gcc versions having broken stack protector.
+ * Affected versions range 9.2.1 - 10.2
  */
 #if defined(__GNUC__) && !defined(__llvm__)
 
-#define GCC_VERSION (__GNUC__ * 10000 \
-                     + __GNUC_MINOR__ * 100 \
-                     + __GNUC_PATCHLEVEL__)
+#define GCC_VERSION \
+  (__GNUC__ * 10000 + __GNUC_MINOR__ * 100 + __GNUC_PATCHLEVEL__)
 
 #if GCC_VERSION >= 90201 && GCC_VERSION <= 100200
-#pragma message "Only remove this GCC check if you are sure your compiler is patched or not used for production."
-#error "ARM GCC versions 9.2.1 - 10.2 have broken stack smash protector, aborting build."
+#pragma message \
+    "Only remove this GCC check if you are sure your compiler is patched or not used for production."
+#error \
+    "ARM GCC versions 9.2.1 - 10.2 have broken stack smash protector, aborting build."
 #endif
 #endif
 

--- a/core/embed/trezorhal/compiler_traits.h
+++ b/core/embed/trezorhal/compiler_traits.h
@@ -22,7 +22,7 @@
 
 /*
  * Avoid accidental build with gcc versions having broken stack protector.
- * Affected versions range 9.2.1 - 10.2
+ * Affected versions range 9.2.1 - 10.2.0
  */
 #if defined(__GNUC__) && !defined(__llvm__)
 
@@ -33,7 +33,7 @@
 #pragma message \
     "Only remove this GCC check if you are sure your compiler is patched or not used for production."
 #error \
-    "ARM GCC versions 9.2.1 - 10.2 have broken stack smash protector, aborting build."
+    "ARM GCC versions 9.2.1 - 10.2.0 have broken stack smash protector, aborting build."
 #endif
 #endif
 

--- a/legacy/bootloader/.changelog.d/1642.security
+++ b/legacy/bootloader/.changelog.d/1642.security
@@ -1,0 +1,1 @@
+Avoid accidental build with broken stack protector

--- a/legacy/bootloader/.gitignore
+++ b/legacy/bootloader/.gitignore
@@ -1,6 +1,7 @@
 *.o
 *.a
 *.d
+!.changelog.d
 *.bin
 *.elf
 *.hex

--- a/legacy/bootloader/bootloader.c
+++ b/legacy/bootloader/bootloader.c
@@ -25,6 +25,7 @@
 
 #include "bootloader.h"
 #include "buttons.h"
+#include "compiler_traits.h"
 #include "layout.h"
 #include "memory.h"
 #include "oled.h"

--- a/legacy/bootloader/bootloader.c
+++ b/legacy/bootloader/bootloader.c
@@ -36,20 +36,6 @@
 #include "usb.h"
 #include "util.h"
 
-/*
- * Avoid accidental build with gcc versions having broken stack protector 9.2.1 - 10.2
- */
-#if defined(__GNUC__) && !defined(__llvm__)
-
-#define GCC_VERSION (__GNUC__ * 10000 \
-                     + __GNUC_MINOR__ * 100 \
-                     + __GNUC_PATCHLEVEL__)
-
-#if GCC_VERSION >= 90201 && GCC_VERSION <= 100200
-#error "ARM GCC versions 9.2.1 - 10.2 have broken stack smash protector, preventing build"
-#endif
-#endif
-
 void layoutFirmwareFingerprint(const uint8_t *hash) {
   char str[4][17] = {0};
   for (int i = 0; i < 4; i++) {

--- a/legacy/bootloader/bootloader.c
+++ b/legacy/bootloader/bootloader.c
@@ -35,6 +35,20 @@
 #include "usb.h"
 #include "util.h"
 
+/*
+ * Avoid accidental build with gcc versions having broken stack protector 9.2.1 - 10.2
+ */
+#if defined(__GNUC__) && !defined(__llvm__)
+
+#define GCC_VERSION (__GNUC__ * 10000 \
+                     + __GNUC_MINOR__ * 100 \
+                     + __GNUC_PATCHLEVEL__)
+
+#if GCC_VERSION >= 90201 && GCC_VERSION <= 100200
+#error "ARM GCC versions 9.2.1 - 10.2 have broken stack smash protector, preventing build"
+#endif
+#endif
+
 void layoutFirmwareFingerprint(const uint8_t *hash) {
   char str[4][17] = {0};
   for (int i = 0; i < 4; i++) {

--- a/legacy/compiler_traits.h
+++ b/legacy/compiler_traits.h
@@ -21,19 +21,20 @@
 #define __COMPILER_TRAITS_H__
 
 /*
- * Avoid accidental build with gcc versions having broken stack protector 9.2.1 - 10.2
+ * Avoid accidental build with gcc versions having broken stack protector.
+ * Affected versions range 9.2.1 - 10.2
  */
 #if defined(__GNUC__) && !defined(__llvm__)
 
-#define GCC_VERSION (__GNUC__ * 10000 \
-                     + __GNUC_MINOR__ * 100 \
-                     + __GNUC_PATCHLEVEL__)
+#define GCC_VERSION \
+  (__GNUC__ * 10000 + __GNUC_MINOR__ * 100 + __GNUC_PATCHLEVEL__)
 
 #if GCC_VERSION >= 90201 && GCC_VERSION <= 100200
-#pragma message "Only remove this GCC check if you are sure your compiler is patched or not used for production."
-#error "ARM GCC versions 9.2.1 - 10.2 have broken stack smash protector, aborting build."
+#pragma message \
+    "Only remove this GCC check if you are sure your compiler is patched or not used for production."
+#error \
+    "ARM GCC versions 9.2.1 - 10.2 have broken stack smash protector, aborting build."
 #endif
 #endif
 
 #endif
-

--- a/legacy/compiler_traits.h
+++ b/legacy/compiler_traits.h
@@ -1,0 +1,39 @@
+/*
+ * This file is part of the Trezor project, https://trezor.io/
+ *
+ * Copyright (c) SatoshiLabs
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#ifndef __COMPILER_TRAITS_H__
+#define __COMPILER_TRAITS_H__
+
+/*
+ * Avoid accidental build with gcc versions having broken stack protector 9.2.1 - 10.2
+ */
+#if defined(__GNUC__) && !defined(__llvm__)
+
+#define GCC_VERSION (__GNUC__ * 10000 \
+                     + __GNUC_MINOR__ * 100 \
+                     + __GNUC_PATCHLEVEL__)
+
+#if GCC_VERSION >= 90201 && GCC_VERSION <= 100200
+#pragma message "Only remove this GCC check if you are sure your compiler is patched or not used for production."
+#error "ARM GCC versions 9.2.1 - 10.2 have broken stack smash protector, aborting build."
+#endif
+#endif
+
+#endif
+

--- a/legacy/compiler_traits.h
+++ b/legacy/compiler_traits.h
@@ -22,7 +22,7 @@
 
 /*
  * Avoid accidental build with gcc versions having broken stack protector.
- * Affected versions range 9.2.1 - 10.2
+ * Affected versions range 9.2.1 - 10.2.0
  */
 #if defined(__GNUC__) && !defined(__llvm__)
 
@@ -33,7 +33,7 @@
 #pragma message \
     "Only remove this GCC check if you are sure your compiler is patched or not used for production."
 #error \
-    "ARM GCC versions 9.2.1 - 10.2 have broken stack smash protector, aborting build."
+    "ARM GCC versions 9.2.1 - 10.2.0 have broken stack smash protector, aborting build."
 #endif
 #endif
 

--- a/legacy/firmware/.changelog.d/1642.security
+++ b/legacy/firmware/.changelog.d/1642.security
@@ -1,0 +1,1 @@
+Avoid accidental build with broken stack protector

--- a/legacy/firmware/trezor.c
+++ b/legacy/firmware/trezor.c
@@ -22,6 +22,7 @@
 #include "bl_check.h"
 #include "buttons.h"
 #include "common.h"
+#include "compiler_traits.h"
 #include "config.h"
 #include "gettext.h"
 #include "layout.h"
@@ -36,20 +37,6 @@
 #if !EMULATOR
 #include <libopencm3/stm32/desig.h>
 #include "otp.h"
-#endif
-
-/*
- * Avoid accidental build with gcc versions having broken stack protector 9.2.1 - 10.2
- */
-#if defined(__GNUC__) && !defined(__llvm__)
-
-#define GCC_VERSION (__GNUC__ * 10000 \
-                     + __GNUC_MINOR__ * 100 \
-                     + __GNUC_PATCHLEVEL__)
-
-#if GCC_VERSION >= 90201 && GCC_VERSION <= 100200
-#error "ARM GCC versions 9.2.1 - 10.2 have broken stack smash protector, preventing build"
-#endif
 #endif
 
 /* Screen timeout */

--- a/legacy/firmware/trezor.c
+++ b/legacy/firmware/trezor.c
@@ -38,6 +38,20 @@
 #include "otp.h"
 #endif
 
+/*
+ * Avoid accidental build with gcc versions having broken stack protector 9.2.1 - 10.2
+ */
+#if defined(__GNUC__) && !defined(__llvm__)
+
+#define GCC_VERSION (__GNUC__ * 10000 \
+                     + __GNUC_MINOR__ * 100 \
+                     + __GNUC_PATCHLEVEL__)
+
+#if GCC_VERSION >= 90201 && GCC_VERSION <= 100200
+#error "ARM GCC versions 9.2.1 - 10.2 have broken stack smash protector, preventing build"
+#endif
+#endif
+
 /* Screen timeout */
 uint32_t system_millis_lock_start = 0;
 


### PR DESCRIPTION
Per https://blog.inhq.net/posts/faulty-stack-canary-arm-systems/ ARM gcc versions 9.2.1-10.2 have broken stack smash protector. Unfortunately these are still included in distros.

The main purpose of the PR is to prevent build of bootloader.bin with broken gcc which gets bundled with firmware since that is done usually manually and not in CI.