### PR TITLE
build(core): improve GITREV format

### DIFF
--- a/core/Makefile
+++ b/core/Makefile
@@ -42,7 +42,7 @@ FIRMWARE_P1_MAXSIZE = 786432
 FIRMWARE_P2_MAXSIZE = 917504
 FIRMWARE_MAXSIZE    = 1703936
 
-GITREV=$(shell git describe --always --dirty | tr '-' '_')
+GITREV=$(shell git describe --always --dirty --match 'core/*' | tr '-' '_')
 CFLAGS += -DGITREV=$(GITREV)
 
 TESTPATH = $(CURDIR)/../tests


### PR DESCRIPTION
Currently the git revision that we store in the firmware is something like `v0-broken0-2849-g767e7b8e8-dirty` because the most recent tag on master is `v0_broken0` from 2019. This change whitelists `core/...` tags which we may be present on release branches, on master the revision will fall back to `767e7b8e8-dirty`.

As the revision gets included in the firmware, building from the same commit in a repository without tags produces image with different checksum than one built in repo with these tags.