### PR TITLE
Make RDI work also on T1

### DIFF
--- a/core/embed/firmware/main.c
+++ b/core/embed/firmware/main.c
@@ -52,6 +52,8 @@
 #include "touch.h"
 
 int main(void) {
+  random_delays_init();
+
 #ifdef RDI
   rdi_start();
 #endif

--- a/core/embed/firmware/main.c
+++ b/core/embed/firmware/main.c
@@ -52,8 +52,6 @@
 #include "touch.h"
 
 int main(void) {
-  random_delays_init();
-
 #ifdef RDI
   rdi_start();
 #endif

--- a/core/embed/firmware/startup.S
+++ b/core/embed/firmware/startup.S
@@ -11,6 +11,7 @@ reset_handler:
 // (cf mpu_config_firmware in legacy bootloader)
 
 #if TREZOR_MODEL == 1
+  cpsid if
   ldr r0, =0xE000ED08  // r0 = VTOR address
   ldr r1, =0x08010400  // r1 = FLASH_APP_START
   str r1, [r0]         // assign
@@ -43,11 +44,19 @@ reset_handler:
   ldr r1, = __stack_chk_guard
   str r0, [r1]
 
+#ifdef RDI
+  bl random_delays_init
+#endif
+
   // re-enable exceptions
   // according to "ARM Cortex-M Programming Guide to Memory Barrier Instructions" Application Note 321, section 4.7:
   // "If it is not necessary to ensure that a pended interrupt is recognized immediately before
   // subsequent operations, it is not necessary to insert a memory barrier instruction."
+#if TREZOR_MODEL == T
   cpsie f
+#elif TREZOR_MODEL == 1
+  cpsie if
+#endif
 
   // enter the application code
   bl main

--- a/core/embed/firmware/startup.S
+++ b/core/embed/firmware/startup.S
@@ -44,10 +44,6 @@ reset_handler:
   ldr r1, = __stack_chk_guard
   str r0, [r1]
 
-#ifdef RDI
-  bl random_delays_init
-#endif
-
   // re-enable exceptions
   // according to "ARM Cortex-M Programming Guide to Memory Barrier Instructions" Application Note 321, section 4.7:
   // "If it is not necessary to ensure that a pended interrupt is recognized immediately before


### PR DESCRIPTION
This requires moving the DRBG initialization in `reset_handler` while interrupts are still forbidden, otherwise SysTick will fail when called before DRBG is initialized.

Tested both on T1 and TT.

Needs a bit more though, as I found out disabling RDI from SConscript still leaves some code behind, e.g. T1 will trip up on `drbg_generate` even if RDI is off. So probably some `#ifdef` is missing somewhere.