### PR TITLE
Fix of red screen

### DIFF
--- a/core/.changelog.d/1658.fixed
+++ b/core/.changelog.d/1658.fixed
@@ -1,0 +1,1 @@
+Fix red screen on shutdown.

--- a/core/SConscript.firmware
+++ b/core/SConscript.firmware
@@ -354,6 +354,8 @@ SOURCE_TREZORHAL = [
     'embed/trezorhal/vectortable.s',
 ]
 
+CPPDEFINES_MOD += ['USE_SVC_SHUTDOWN']
+
 if FEATURE_FLAGS["RDI"]:
     CPPDEFINES_MOD += ['RDI']
 

--- a/core/embed/boardloader/startup.s
+++ b/core/embed/boardloader/startup.s
@@ -55,6 +55,6 @@ reset_handler:
   // enter the application code
   bl main
 
-  b shutdown
+  b shutdown_privileged
 
   .end

--- a/core/embed/bootloader/startup.s
+++ b/core/embed/bootloader/startup.s
@@ -36,6 +36,6 @@ reset_handler:
   // enter the application code
   bl main
 
-  b shutdown
+  b shutdown_privileged
 
   .end

--- a/core/embed/bootloader_ci/startup.s
+++ b/core/embed/bootloader_ci/startup.s
@@ -36,6 +36,6 @@ reset_handler:
   // enter the application code
   bl main
 
-  b shutdown
+  b shutdown_privileged
 
   .end

--- a/core/embed/firmware/main.c
+++ b/core/embed/firmware/main.c
@@ -40,9 +40,7 @@
 #include "display.h"
 #include "flash.h"
 #include "mpu.h"
-#ifdef RDI
 #include "random_delays.h"
-#endif
 #ifdef SYSTEM_VIEW
 #include "systemview.h"
 #endif

--- a/core/embed/firmware/main.c
+++ b/core/embed/firmware/main.c
@@ -49,6 +49,9 @@
 #include "supervise.h"
 #include "touch.h"
 
+// from util.s
+extern void shutdown_privileged(void);
+
 int main(void) {
   random_delays_init();
 
@@ -180,6 +183,11 @@ void SVC_C_Handler(uint32_t *stack) {
       cyccnt_cycles = *DWT_CYCCNT_ADDR;
       break;
 #endif
+    case SVC_SHUTDOWN:
+      shutdown_privileged();
+      for (;;)
+        ;
+      break;
     default:
       stack[0] = 0xffffffff;
       break;

--- a/core/embed/firmware/startup.S
+++ b/core/embed/firmware/startup.S
@@ -52,6 +52,6 @@ reset_handler:
   // enter the application code
   bl main
 
-  b shutdown
+  b shutdown_privileged
 
   .end

--- a/core/embed/prodtest/startup.s
+++ b/core/embed/prodtest/startup.s
@@ -36,6 +36,6 @@ reset_handler:
   // enter the application code
   bl main
 
-  b shutdown
+  b shutdown_privileged
 
   .end

--- a/core/embed/reflash/startup.s
+++ b/core/embed/reflash/startup.s
@@ -36,6 +36,6 @@ reset_handler:
   // enter the application code
   bl main
 
-  b shutdown
+  b shutdown_privileged
 
   .end

--- a/core/embed/trezorhal/common.c
+++ b/core/embed/trezorhal/common.c
@@ -25,6 +25,7 @@
 #include "display.h"
 #include "flash.h"
 #include "rand.h"
+#include "supervise.h"
 
 #include "stm32f4xx_ll_utils.h"
 
@@ -32,6 +33,18 @@
 extern void shutdown_privileged(void);
 
 #define COLOR_FATAL_ERROR RGB16(0x7F, 0x00, 0x00)
+
+// from util.s
+extern void shutdown_privileged(void);
+
+void shutdown(void) {
+#ifdef USE_SVC_SHUTDOWN
+  svc_shutdown();
+#else
+  // It won't work properly unless called from the privileged mode
+  shutdown_privileged();
+#endif
+}
 
 void __attribute__((noreturn))
 __fatal_error(const char *expr, const char *msg, const char *file, int line,

--- a/core/embed/trezorhal/common.c
+++ b/core/embed/trezorhal/common.c
@@ -29,9 +29,6 @@
 
 #include "stm32f4xx_ll_utils.h"
 
-// from util.s
-extern void shutdown_privileged(void);
-
 #define COLOR_FATAL_ERROR RGB16(0x7F, 0x00, 0x00)
 
 // from util.s
@@ -71,7 +68,7 @@ __fatal_error(const char *expr, const char *msg, const char *file, int line,
                  rev[4]);
 #endif
   display_printf("\nPlease contact Trezor support.\n");
-  shutdown_privileged();
+  shutdown();
   for (;;)
     ;
 }
@@ -120,7 +117,7 @@ error_shutdown(const char *line1, const char *line2, const char *line3,
   display_printf("\nPlease unplug the device.\n");
 #endif
   display_backlight(255);
-  shutdown_privileged();
+  shutdown();
   for (;;)
     ;
 }

--- a/core/embed/trezorhal/common.c
+++ b/core/embed/trezorhal/common.c
@@ -29,7 +29,7 @@
 #include "stm32f4xx_ll_utils.h"
 
 // from util.s
-extern void shutdown(void);
+extern void shutdown_privileged(void);
 
 #define COLOR_FATAL_ERROR RGB16(0x7F, 0x00, 0x00)
 
@@ -58,7 +58,7 @@ __fatal_error(const char *expr, const char *msg, const char *file, int line,
                  rev[4]);
 #endif
   display_printf("\nPlease contact Trezor support.\n");
-  shutdown();
+  shutdown_privileged();
   for (;;)
     ;
 }
@@ -107,7 +107,7 @@ error_shutdown(const char *line1, const char *line2, const char *line3,
   display_printf("\nPlease unplug the device.\n");
 #endif
   display_backlight(255);
-  shutdown();
+  shutdown_privileged();
   for (;;)
     ;
 }

--- a/core/embed/trezorhal/common.h
+++ b/core/embed/trezorhal/common.h
@@ -49,6 +49,8 @@
   })
 #endif
 
+void shutdown(void);
+
 void __attribute__((noreturn))
 __fatal_error(const char *expr, const char *msg, const char *file, int line,
               const char *func);

--- a/core/embed/trezorhal/random_delays.c
+++ b/core/embed/trezorhal/random_delays.c
@@ -45,7 +45,7 @@ https://link.springer.com/content/pdf/10.1007%2F978-3-540-72354-7_3.pdf
 #include "rand.h"
 
 // from util.s
-extern void shutdown(void);
+extern void shutdown_privileged(void);
 
 #define DRBG_RESEED_INTERVAL_CALLS 1000
 #define DRBG_TRNG_ENTROPY_LENGTH 50
@@ -197,13 +197,13 @@ void wait_random(void) {
   volatile int j = wait;
   while (i < wait) {
     if (i + j != wait) {
-      shutdown();
+      shutdown_privileged();
     }
     ++i;
     --j;
   }
   // Double-check loop completion.
   if (i != wait || j != 0) {
-    shutdown();
+    shutdown_privileged();
   }
 }

--- a/core/embed/trezorhal/stm32.c
+++ b/core/embed/trezorhal/stm32.c
@@ -87,9 +87,9 @@ void SystemInit(void) {
 }
 
 // from util.s
-extern void shutdown(void);
+extern void shutdown_privileged(void);
 
 void PVD_IRQHandler(void) {
   TIM1->CCR1 = 0;  // turn off display backlight
-  shutdown();
+  shutdown_privileged();
 }

--- a/core/embed/trezorhal/supervise.h
+++ b/core/embed/trezorhal/supervise.h
@@ -3,6 +3,10 @@
 #define SVC_ENABLE_IRQ 0
 #define SVC_DISABLE_IRQ 1
 #define SVC_SET_PRIORITY 2
+#define SVC_SHUTDOWN 4
+
+// from util.s
+extern void shutdown_privileged(void);
 
 static inline uint32_t is_mode_unprivileged(void) {
   uint32_t r0;
@@ -36,5 +40,13 @@ static inline void svc_setpriority(uint32_t IRQn, uint32_t priority) {
                          : "memory");
   } else {
     NVIC_SetPriority(IRQn, priority);
+  }
+}
+
+static inline void svc_shutdown(void) {
+  if (is_mode_unprivileged()) {
+    __asm__ __volatile__("svc %0" ::"i"(SVC_SHUTDOWN) : "memory");
+  } else {
+    shutdown_privileged();
   }
 }

--- a/core/embed/trezorhal/util.s
+++ b/core/embed/trezorhal/util.s
@@ -151,6 +151,9 @@ shutdown_privileged:
   // set to value in r2
   bl memset_reg
   bl clear_otg_hs_memory
+  ldr r0, =1
+  msr control, r0 // jump to unprivileged mode
+  ldr r0, =0
   b . // loop forever
 
   .end

--- a/core/embed/trezorhal/util.s
+++ b/core/embed/trezorhal/util.s
@@ -121,9 +121,9 @@ jump_to_unprivileged:
   // jump
   bx lr
 
-  .global shutdown
-  .type shutdown, STT_FUNC
-shutdown:
+  .global shutdown_privileged
+  .type shutdown_privileged, STT_FUNC
+shutdown_privileged:
   cpsid f
   ldr r0, =0
   mov r1, r0

--- a/core/embed/trezorhal/util.s
+++ b/core/embed/trezorhal/util.s
@@ -123,8 +123,11 @@ jump_to_unprivileged:
 
   .global shutdown_privileged
   .type shutdown_privileged, STT_FUNC
+  // The function must be called from the privileged mode
 shutdown_privileged:
-  cpsid f
+  cpsid f // disable all exceptions (except for NMI), the instruction is ignored in unprivileged mode
+  // if the exceptions weren't disabled, an exception handler (for example systick handler)
+  // could be called after the memory is erased, which would lead to another exception
   ldr r0, =0
   mov r1, r0
   mov r2, r0

--- a/core/embed/trezorhal/vectortable.s
+++ b/core/embed/trezorhal/vectortable.s
@@ -5,7 +5,7 @@
   .global default_handler
   .type default_handler, STT_FUNC
 default_handler:
-  b shutdown
+  b shutdown_privileged
 
   .macro add_handler symbol_name:req
     .word \symbol_name


### PR DESCRIPTION
This PR fixes https://github.com/trezor/trezor-firmware/issues/1658.

From my point of view, the cause of the issue is that `shutdown()` is called from the unprivileged mode (see [this comment](https://github.com/trezor/trezor-firmware/issues/1658#issuecomment-865883049)). To solve that, I implemented a SVC handler that calls `shutdown()` from the privileged mode.