### PR TITLE
ci/hardware: enable SD card tests and btc tests on regular build

### DIFF
--- a/ci/test-hw.yml
+++ b/ci/test-hw.yml
@@ -5,8 +5,7 @@ image: registry.gitlab.com/satoshilabs/trezor/trezor-firmware/trezor-firmware-en
 # Currently it's not possible to run all regular TT tests without getting into
 # a state where the micropython heap is too fragmented and allocations fail
 # (often manifesting as a stuck test case). For that reason some tests are
-# skipped and the rest is divided into several groups with device reboots in
-# between them.
+# skipped.
 # See also: https://github.com/trezor/trezor-firmware/issues/1371
 hardware core regular device test:
   stage: test
@@ -30,8 +29,8 @@ hardware core regular device test:
     - set +a
     - nix-shell --run "cd ../.. && poetry install"
     - nix-shell --run "poetry run python bootstrap.py tt ../../trezor-*.bin | ts -s"
-    - nix-shell --run "poetry run pytest -m 'altcoin and not sd_card' $TESTS_SKIP ../../tests/device_tests | ts -s"
-  timeout: 4h
+    - nix-shell --run "poetry run pytest $TESTS_SKIP ../../tests/device_tests | ts -s"
+  timeout: 6h
   artifacts:
     name: "$CI_JOB_NAME-$CI_COMMIT_SHORT_SHA"
     expire_in: 2 days
@@ -60,7 +59,7 @@ hardware core btconly device test:
     - set +a
     - nix-shell --run "cd ../.. && poetry install"
     - nix-shell --run "poetry run python bootstrap.py tt ../../trezor-*.bin | ts -s"
-    - nix-shell --run "poetry run pytest -m 'not sd_card' $TESTS_SKIP ../../tests/device_tests | ts -s"
+    - nix-shell --run "poetry run pytest $TESTS_SKIP ../../tests/device_tests | ts -s"
   timeout: 4h
   artifacts:
     name: "$CI_JOB_NAME-$CI_COMMIT_SHORT_SHA"


### PR DESCRIPTION
Increase timeout since 4h isn't always enough.