### PR TITLE
ECDSA error handling

### DIFF
--- a/core/embed/extmod/modtrezorcrypto/modtrezorcrypto-nist256p1.h
+++ b/core/embed/extmod/modtrezorcrypto/modtrezorcrypto-nist256p1.h
@@ -70,12 +70,16 @@ STATIC mp_obj_t mod_trezorcrypto_nist256p1_publickey(size_t n_args,
   bool compressed = n_args < 2 || args[1] == mp_const_true;
   if (compressed) {
     vstr_init_len(&pk, 33);
-    ecdsa_get_public_key33(&nist256p1, (const uint8_t *)sk.buf,
-                           (uint8_t *)pk.buf);
+    if (ecdsa_get_public_key33(&nist256p1, (const uint8_t *)sk.buf,
+                               (uint8_t *)pk.buf) != 0) {
+      mp_raise_ValueError("Invalid secret key");
+    }
   } else {
     vstr_init_len(&pk, 65);
-    ecdsa_get_public_key65(&nist256p1, (const uint8_t *)sk.buf,
-                           (uint8_t *)pk.buf);
+    if (ecdsa_get_public_key65(&nist256p1, (const uint8_t *)sk.buf,
+                               (uint8_t *)pk.buf) != 0) {
+      mp_raise_ValueError("Invalid secret key");
+    }
   }
   return mp_obj_new_str_from_vstr(&mp_type_bytes, &pk);
 }

--- a/crypto/bip32.h
+++ b/crypto/bip32.h
@@ -103,7 +103,7 @@ int hdnode_private_ckd_cached(HDNode *inout, const uint32_t *i, size_t i_count,
 
 uint32_t hdnode_fingerprint(HDNode *node);
 
-void hdnode_fill_public_key(HDNode *node);
+int hdnode_fill_public_key(HDNode *node);
 
 #if USE_ETHEREUM
 int hdnode_get_ethereum_pubkeyhash(const HDNode *node, uint8_t *pubkeyhash);
@@ -147,9 +147,9 @@ int hdnode_deserialize_private(const char *str, uint32_t version,
                                const char *curve, HDNode *node,
                                uint32_t *fingerprint);
 
-void hdnode_get_address_raw(HDNode *node, uint32_t version, uint8_t *addr_raw);
-void hdnode_get_address(HDNode *node, uint32_t version, char *addr,
-                        int addrsize);
+int hdnode_get_address_raw(HDNode *node, uint32_t version, uint8_t *addr_raw);
+int hdnode_get_address(HDNode *node, uint32_t version, char *addr,
+                       int addrsize);
 
 const curve_info *get_curve_by_name(const char *curve_name);
 

--- a/crypto/ed25519-donna/ed25519.c
+++ b/crypto/ed25519-donna/ed25519.c
@@ -18,6 +18,7 @@
 #include "ed25519.h"
 
 #include "ed25519-hash-custom.h"
+#include "memzero.h"
 
 /*
 	Generates a (extsk[0..31]) and aExt (extsk[32..63])
@@ -46,11 +47,13 @@ ED25519_FN(ed25519_publickey) (const ed25519_secret_key sk, ed25519_public_key p
 	ge25519 ALIGN(16) A;
 	hash_512bits extsk = {0};
 
-	/* A = aB */
 	ed25519_extsk(extsk, sk);
-
 	expand256_modm(a, extsk, 32);
+	memzero(&extsk, sizeof(extsk));
+
+	/* A = aB */
 	ge25519_scalarmult_base_niels(&A, ge25519_niels_base_multiples, a);
+	memzero(&a, sizeof(a));
 	ge25519_pack(pk, &A);
 }
 
@@ -66,7 +69,9 @@ ED25519_FN(ed25519_publickey_ext) (const ed25519_secret_key sk, const ed25519_se
 	memcpy(extsk, sk, 32);
 	memcpy(extsk+32, skext, 32);
 	expand256_modm(a, extsk, 32);
+	memzero(&extsk, sizeof(extsk));
 	ge25519_scalarmult_base_niels(&A, ge25519_niels_base_multiples, a);
+	memzero(&a, sizeof(a));
 	ge25519_pack(pk, &A);
 }
 #endif
@@ -81,6 +86,7 @@ ED25519_FN(ed25519_cosi_sign) (const unsigned char *m, size_t mlen, const ed2551
 
 	/* r = nonce */
 	expand256_modm(r, extnonce, 32);
+	memzero(&extnonce, sizeof(extnonce));
 
 	/* S = H(R,A,m).. */
 	ed25519_hram(hram, R, pk, m, mlen);
@@ -88,10 +94,13 @@ ED25519_FN(ed25519_cosi_sign) (const unsigned char *m, size_t mlen, const ed2551
 
 	/* S = H(R,A,m)a */
 	expand256_modm(a, extsk, 32);
+	memzero(&extsk, sizeof(extsk));
 	mul256_modm(S, S, a);
+	memzero(&a, sizeof(a));
 
 	/* S = (r + H(R,A,m)a) */
 	add256_modm(S, S, r);
+	memzero(&r, sizeof(r));
 
 	/* S = (r + H(R,A,m)a) mod L */
 	contract256_modm(sig, S);
@@ -113,6 +122,7 @@ ED25519_FN(ed25519_sign) (const unsigned char *m, size_t mlen, const ed25519_sec
 	ed25519_hash_update(&ctx, m, mlen);
 	ed25519_hash_final(&ctx, hashr);
 	expand256_modm(r, hashr, 64);
+	memzero(&hashr, sizeof(hashr));
 
 	/* R = rB */
 	ge25519_scalarmult_base_niels(&R, ge25519_niels_base_multiples, r);
@@ -124,10 +134,13 @@ ED25519_FN(ed25519_sign) (const unsigned char *m, size_t mlen, const ed25519_sec
 
 	/* S = H(R,A,m)a */
 	expand256_modm(a, extsk, 32);
+	memzero(&extsk, sizeof(extsk));
 	mul256_modm(S, S, a);
+	memzero(&a, sizeof(a));
 
 	/* S = (r + H(R,A,m)a) */
 	add256_modm(S, S, r);
+	memzero(&r, sizeof(r));
 
 	/* S = (r + H(R,A,m)a) mod L */
 	contract256_modm(RS + 32, S);
@@ -153,6 +166,7 @@ ED25519_FN(ed25519_sign_ext) (const unsigned char *m, size_t mlen, const ed25519
 	ed25519_hash_update(&ctx, m, mlen);
 	ed25519_hash_final(&ctx, hashr);
 	expand256_modm(r, hashr, 64);
+	memzero(&hashr, sizeof(hashr));
 
 	/* R = rB */
 	ge25519_scalarmult_base_niels(&R, ge25519_niels_base_multiples, r);
@@ -164,10 +178,13 @@ ED25519_FN(ed25519_sign_ext) (const unsigned char *m, size_t mlen, const ed25519
 
 	/* S = H(R,A,m)a */
 	expand256_modm(a, extsk, 32);
+	memzero(&extsk, sizeof(extsk));
 	mul256_modm(S, S, a);
+	memzero(&a, sizeof(a));
 
 	/* S = (r + H(R,A,m)a) */
 	add256_modm(S, S, r);
+	memzero(&r, sizeof(r));
 
 	/* S = (r + H(R,A,m)a) mod L */
 	contract256_modm(RS + 32, S);
@@ -209,12 +226,14 @@ ED25519_FN(ed25519_scalarmult) (ed25519_public_key res, const ed25519_secret_key
 
 	ed25519_extsk(extsk, sk);
 	expand256_modm(a, extsk, 32);
+	memzero(&extsk, sizeof(extsk));
 
 	if (!ge25519_unpack_negative_vartime(&P, pk)) {
 		return -1;
 	}
 
 	ge25519_scalarmult(&A, &P, a);
+	memzero(&a, sizeof(a));
 	curve25519_neg(A.x, A.x);
 	ge25519_pack(res, &A);
 	return 0;
@@ -288,9 +307,11 @@ curve25519_scalarmult_basepoint(curve25519_key pk, const curve25519_key e) {
 	ec[31] |= 64;
 
 	expand_raw256_modm(s, ec);
+	memzero(&ec, sizeof(ec));
 
 	/* scalar * basepoint */
 	ge25519_scalarmult_base_niels(&p, ge25519_niels_base_multiples, s);
+	memzero(&s, sizeof(s));
 
 	/* u = (y + z) / (z - y) */
 	curve25519_add(yplusz, p.y, p.z);
@@ -310,6 +331,7 @@ curve25519_scalarmult(curve25519_key mypublic, const curve25519_key secret, cons
 	e[31] &= 0x7f;
 	e[31] |= 0x40;
 	curve25519_scalarmult_donna(mypublic, e, basepoint);
+	memzero(&e, sizeof(e));
 }
 
 #endif // ED25519_SUFFIX

--- a/crypto/schnorr.c
+++ b/crypto/schnorr.c
@@ -135,7 +135,9 @@ int schnorr_sign_digest(const ecdsa_curve *curve, const uint8_t *priv_key,
   curve_point R = {0};
   bignum256 e = {0}, s = {0}, k = {0};
 
-  ecdsa_get_public_key33(curve, priv_key, pub_key);
+  if (ecdsa_get_public_key33(curve, priv_key, pub_key) != 0) {
+    return 1;
+  }
 
   // Compute k
   if (generate_k_schnorr(curve, priv_key, digest, &k) != 0) {

--- a/crypto/tests/test_check.c
+++ b/crypto/tests/test_check.c
@@ -8959,7 +8959,7 @@ START_TEST(test_schnorr_sign_verify_digest) {
     memcpy(priv_key, fromhex(tests[i].priv_key), 32);
     memcpy(expected, fromhex(tests[i].sig), SCHNORR_SIG_LENGTH);
 
-    ecdsa_get_public_key33(curve, priv_key, pub_key);
+    ck_assert_int_eq(ecdsa_get_public_key33(curve, priv_key, pub_key), 0);
 
     schnorr_sign_digest(curve, priv_key, digest, result);
 

--- a/crypto/tests/test_check.c
+++ b/crypto/tests/test_check.c
@@ -1238,7 +1238,7 @@ START_TEST(test_bip32_vector_1) {
       fromhex(
           "e8f32e723decf4051aefac8e2c93c9c5b214313817cdb01a1494b917c8436b35"),
       32);
-  hdnode_fill_public_key(&node);
+  ck_assert_int_eq(hdnode_fill_public_key(&node), 0);
   ck_assert_mem_eq(
       node.public_key,
       fromhex(
@@ -1252,7 +1252,7 @@ START_TEST(test_bip32_vector_1) {
   r = hdnode_deserialize_private(str, VERSION_PRIVATE, SECP256K1_NAME, &node2,
                                  NULL);
   ck_assert_int_eq(r, 0);
-  hdnode_fill_public_key(&node2);
+  ck_assert_int_eq(hdnode_fill_public_key(&node2), 0);
   ck_assert_mem_eq(&node, &node2, sizeof(HDNode));
   hdnode_serialize_public(&node, fingerprint, VERSION_PUBLIC, str, sizeof(str));
   ck_assert_str_eq(str,
@@ -1279,7 +1279,7 @@ START_TEST(test_bip32_vector_1) {
       fromhex(
           "edb2e14f9ee77d26dd93b4ecede8d16ed408ce149b6cd80b0715a2d911a0afea"),
       32);
-  hdnode_fill_public_key(&node);
+  ck_assert_int_eq(hdnode_fill_public_key(&node), 0);
   ck_assert_mem_eq(
       node.public_key,
       fromhex(
@@ -1293,7 +1293,7 @@ START_TEST(test_bip32_vector_1) {
   r = hdnode_deserialize_private(str, VERSION_PRIVATE, SECP256K1_NAME, &node2,
                                  NULL);
   ck_assert_int_eq(r, 0);
-  hdnode_fill_public_key(&node2);
+  ck_assert_int_eq(hdnode_fill_public_key(&node2), 0);
   ck_assert_mem_eq(&node, &node2, sizeof(HDNode));
   hdnode_serialize_public(&node, fingerprint, VERSION_PUBLIC, str, sizeof(str));
   ck_assert_str_eq(str,
@@ -1320,7 +1320,7 @@ START_TEST(test_bip32_vector_1) {
       fromhex(
           "3c6cb8d0f6a264c91ea8b5030fadaa8e538b020f0a387421a12de9319dc93368"),
       32);
-  hdnode_fill_public_key(&node);
+  ck_assert_int_eq(hdnode_fill_public_key(&node), 0);
   ck_assert_mem_eq(
       node.public_key,
       fromhex(
@@ -1334,7 +1334,7 @@ START_TEST(test_bip32_vector_1) {
   r = hdnode_deserialize_private(str, VERSION_PRIVATE, SECP256K1_NAME, &node2,
                                  NULL);
   ck_assert_int_eq(r, 0);
-  hdnode_fill_public_key(&node2);
+  ck_assert_int_eq(hdnode_fill_public_key(&node2), 0);
   ck_assert_mem_eq(&node, &node2, sizeof(HDNode));
   hdnode_serialize_public(&node, fingerprint, VERSION_PUBLIC, str, sizeof(str));
   ck_assert_str_eq(str,
@@ -1361,7 +1361,7 @@ START_TEST(test_bip32_vector_1) {
       fromhex(
           "cbce0d719ecf7431d88e6a89fa1483e02e35092af60c042b1df2ff59fa424dca"),
       32);
-  hdnode_fill_public_key(&node);
+  ck_assert_int_eq(hdnode_fill_public_key(&node), 0);
   ck_assert_mem_eq(
       node.public_key,
       fromhex(
@@ -1375,7 +1375,7 @@ START_TEST(test_bip32_vector_1) {
   r = hdnode_deserialize_private(str, VERSION_PRIVATE, SECP256K1_NAME, &node2,
                                  NULL);
   ck_assert_int_eq(r, 0);
-  hdnode_fill_public_key(&node2);
+  ck_assert_int_eq(hdnode_fill_public_key(&node2), 0);
   ck_assert_mem_eq(&node, &node2, sizeof(HDNode));
   hdnode_serialize_public(&node, fingerprint, VERSION_PUBLIC, str, sizeof(str));
   ck_assert_str_eq(str,
@@ -1402,7 +1402,7 @@ START_TEST(test_bip32_vector_1) {
       fromhex(
           "0f479245fb19a38a1954c5c7c0ebab2f9bdfd96a17563ef28a6a4b1a2a764ef4"),
       32);
-  hdnode_fill_public_key(&node);
+  ck_assert_int_eq(hdnode_fill_public_key(&node), 0);
   ck_assert_mem_eq(
       node.public_key,
       fromhex(
@@ -1416,7 +1416,7 @@ START_TEST(test_bip32_vector_1) {
   r = hdnode_deserialize_private(str, VERSION_PRIVATE, SECP256K1_NAME, &node2,
                                  NULL);
   ck_assert_int_eq(r, 0);
-  hdnode_fill_public_key(&node2);
+  ck_assert_int_eq(hdnode_fill_public_key(&node2), 0);
   ck_assert_mem_eq(&node, &node2, sizeof(HDNode));
   hdnode_serialize_public(&node, fingerprint, VERSION_PUBLIC, str, sizeof(str));
   ck_assert_str_eq(str,
@@ -1443,7 +1443,7 @@ START_TEST(test_bip32_vector_1) {
       fromhex(
           "471b76e389e528d6de6d816857e012c5455051cad6660850e58372a6c3e6e7c8"),
       32);
-  hdnode_fill_public_key(&node);
+  ck_assert_int_eq(hdnode_fill_public_key(&node), 0);
   ck_assert_mem_eq(
       node.public_key,
       fromhex(
@@ -1457,7 +1457,7 @@ START_TEST(test_bip32_vector_1) {
   r = hdnode_deserialize_private(str, VERSION_PRIVATE, SECP256K1_NAME, &node2,
                                  NULL);
   ck_assert_int_eq(r, 0);
-  hdnode_fill_public_key(&node2);
+  ck_assert_int_eq(hdnode_fill_public_key(&node2), 0);
   ck_assert_mem_eq(&node, &node2, sizeof(HDNode));
   hdnode_serialize_public(&node, fingerprint, VERSION_PUBLIC, str, sizeof(str));
   ck_assert_str_eq(str,
@@ -1500,7 +1500,7 @@ START_TEST(test_bip32_vector_2) {
       fromhex(
           "4b03d6fc340455b363f51020ad3ecca4f0850280cf436c70c727923f6db46c3e"),
       32);
-  hdnode_fill_public_key(&node);
+  ck_assert_int_eq(hdnode_fill_public_key(&node), 0);
   ck_assert_mem_eq(
       node.public_key,
       fromhex(
@@ -1514,7 +1514,7 @@ START_TEST(test_bip32_vector_2) {
   r = hdnode_deserialize_private(str, VERSION_PRIVATE, SECP256K1_NAME, &node2,
                                  NULL);
   ck_assert_int_eq(r, 0);
-  hdnode_fill_public_key(&node2);
+  ck_assert_int_eq(hdnode_fill_public_key(&node2), 0);
   ck_assert_mem_eq(&node, &node2, sizeof(HDNode));
   hdnode_serialize_public(&node, fingerprint, VERSION_PUBLIC, str, sizeof(str));
   ck_assert_str_eq(str,
@@ -1542,7 +1542,7 @@ START_TEST(test_bip32_vector_2) {
       fromhex(
           "abe74a98f6c7eabee0428f53798f0ab8aa1bd37873999041703c742f15ac7e1e"),
       32);
-  hdnode_fill_public_key(&node);
+  ck_assert_int_eq(hdnode_fill_public_key(&node), 0);
   ck_assert_mem_eq(
       node.public_key,
       fromhex(
@@ -1556,7 +1556,7 @@ START_TEST(test_bip32_vector_2) {
   r = hdnode_deserialize_private(str, VERSION_PRIVATE, SECP256K1_NAME, &node2,
                                  NULL);
   ck_assert_int_eq(r, 0);
-  hdnode_fill_public_key(&node2);
+  ck_assert_int_eq(hdnode_fill_public_key(&node2), 0);
   ck_assert_mem_eq(&node, &node2, sizeof(HDNode));
   hdnode_serialize_public(&node, fingerprint, VERSION_PUBLIC, str, sizeof(str));
   ck_assert_str_eq(str,
@@ -1584,7 +1584,7 @@ START_TEST(test_bip32_vector_2) {
       fromhex(
           "877c779ad9687164e9c2f4f0f4ff0340814392330693ce95a58fe18fd52e6e93"),
       32);
-  hdnode_fill_public_key(&node);
+  ck_assert_int_eq(hdnode_fill_public_key(&node), 0);
   ck_assert_mem_eq(
       node.public_key,
       fromhex(
@@ -1598,7 +1598,7 @@ START_TEST(test_bip32_vector_2) {
   r = hdnode_deserialize_private(str, VERSION_PRIVATE, SECP256K1_NAME, &node2,
                                  NULL);
   ck_assert_int_eq(r, 0);
-  hdnode_fill_public_key(&node2);
+  ck_assert_int_eq(hdnode_fill_public_key(&node2), 0);
   ck_assert_mem_eq(&node, &node2, sizeof(HDNode));
   hdnode_serialize_public(&node, fingerprint, VERSION_PUBLIC, str, sizeof(str));
   ck_assert_str_eq(str,
@@ -1626,7 +1626,7 @@ START_TEST(test_bip32_vector_2) {
       fromhex(
           "704addf544a06e5ee4bea37098463c23613da32020d604506da8c0518e1da4b7"),
       32);
-  hdnode_fill_public_key(&node);
+  ck_assert_int_eq(hdnode_fill_public_key(&node), 0);
   ck_assert_mem_eq(
       node.public_key,
       fromhex(
@@ -1640,7 +1640,7 @@ START_TEST(test_bip32_vector_2) {
   r = hdnode_deserialize_private(str, VERSION_PRIVATE, SECP256K1_NAME, &node2,
                                  NULL);
   ck_assert_int_eq(r, 0);
-  hdnode_fill_public_key(&node2);
+  ck_assert_int_eq(hdnode_fill_public_key(&node2), 0);
   ck_assert_mem_eq(&node, &node2, sizeof(HDNode));
   hdnode_serialize_public(&node, fingerprint, VERSION_PUBLIC, str, sizeof(str));
   ck_assert_str_eq(str,
@@ -1668,7 +1668,7 @@ START_TEST(test_bip32_vector_2) {
       fromhex(
           "f1c7c871a54a804afe328b4c83a1c33b8e5ff48f5087273f04efa83b247d6a2d"),
       32);
-  hdnode_fill_public_key(&node);
+  ck_assert_int_eq(hdnode_fill_public_key(&node), 0);
   ck_assert_mem_eq(
       node.public_key,
       fromhex(
@@ -1682,7 +1682,7 @@ START_TEST(test_bip32_vector_2) {
   r = hdnode_deserialize_private(str, VERSION_PRIVATE, SECP256K1_NAME, &node2,
                                  NULL);
   ck_assert_int_eq(r, 0);
-  hdnode_fill_public_key(&node2);
+  ck_assert_int_eq(hdnode_fill_public_key(&node2), 0);
   ck_assert_mem_eq(&node, &node2, sizeof(HDNode));
   hdnode_serialize_public(&node, fingerprint, VERSION_PUBLIC, str, sizeof(str));
   ck_assert_str_eq(str,
@@ -1710,7 +1710,7 @@ START_TEST(test_bip32_vector_2) {
       fromhex(
           "bb7d39bdb83ecf58f2fd82b6d918341cbef428661ef01ab97c28a4842125ac23"),
       32);
-  hdnode_fill_public_key(&node);
+  ck_assert_int_eq(hdnode_fill_public_key(&node), 0);
   ck_assert_mem_eq(
       node.public_key,
       fromhex(
@@ -1724,7 +1724,7 @@ START_TEST(test_bip32_vector_2) {
   r = hdnode_deserialize_private(str, VERSION_PRIVATE, SECP256K1_NAME, &node2,
                                  NULL);
   ck_assert_int_eq(r, 0);
-  hdnode_fill_public_key(&node2);
+  ck_assert_int_eq(hdnode_fill_public_key(&node2), 0);
   ck_assert_mem_eq(&node, &node2, sizeof(HDNode));
   hdnode_serialize_public(&node, fingerprint, VERSION_PUBLIC, str, sizeof(str));
   ck_assert_str_eq(str,
@@ -1760,7 +1760,7 @@ START_TEST(test_bip32_vector_2) {
       fromhex(
           "0000000000000000000000000000000000000000000000000000000000000000"),
       32);
-  hdnode_fill_public_key(&node);
+  ck_assert_int_eq(hdnode_fill_public_key(&node), 0);
   ck_assert_mem_eq(
       node.public_key,
       fromhex(
@@ -1787,7 +1787,7 @@ START_TEST(test_bip32_vector_3) {
   // [Chain m]
   fingerprint = 0;
   ck_assert_uint_eq(fingerprint, 0x00000000);
-  hdnode_fill_public_key(&node);
+  ck_assert_int_eq(hdnode_fill_public_key(&node), 0);
   hdnode_serialize_private(&node, fingerprint, VERSION_PRIVATE, str,
                            sizeof(str));
   ck_assert_str_eq(str,
@@ -1796,7 +1796,7 @@ START_TEST(test_bip32_vector_3) {
   r = hdnode_deserialize_private(str, VERSION_PRIVATE, SECP256K1_NAME, &node2,
                                  NULL);
   ck_assert_int_eq(r, 0);
-  hdnode_fill_public_key(&node2);
+  ck_assert_int_eq(hdnode_fill_public_key(&node2), 0);
   ck_assert_mem_eq(&node, &node2, sizeof(HDNode));
   hdnode_serialize_public(&node, fingerprint, VERSION_PUBLIC, str, sizeof(str));
   ck_assert_str_eq(str,
@@ -1813,7 +1813,7 @@ START_TEST(test_bip32_vector_3) {
   fingerprint = hdnode_fingerprint(&node);
   r = hdnode_private_ckd_prime(&node, 0);
   ck_assert_int_eq(r, 1);
-  hdnode_fill_public_key(&node);
+  ck_assert_int_eq(hdnode_fill_public_key(&node), 0);
   hdnode_serialize_private(&node, fingerprint, VERSION_PRIVATE, str,
                            sizeof(str));
   ck_assert_str_eq(str,
@@ -1822,7 +1822,7 @@ START_TEST(test_bip32_vector_3) {
   r = hdnode_deserialize_private(str, VERSION_PRIVATE, SECP256K1_NAME, &node2,
                                  NULL);
   ck_assert_int_eq(r, 0);
-  hdnode_fill_public_key(&node2);
+  ck_assert_int_eq(hdnode_fill_public_key(&node2), 0);
   ck_assert_mem_eq(&node, &node2, sizeof(HDNode));
   hdnode_serialize_public(&node, fingerprint, VERSION_PUBLIC, str, sizeof(str));
   ck_assert_str_eq(str,
@@ -1854,7 +1854,7 @@ START_TEST(test_bip32_vector_4) {
   // [Chain m]
   fingerprint = 0;
   ck_assert_int_eq(fingerprint, 0x00000000);
-  hdnode_fill_public_key(&node);
+  ck_assert_int_eq(hdnode_fill_public_key(&node), 0);
   hdnode_serialize_private(&node, fingerprint, VERSION_PRIVATE, str,
                            sizeof(str));
   ck_assert_str_eq(str,
@@ -1863,7 +1863,7 @@ START_TEST(test_bip32_vector_4) {
   r = hdnode_deserialize_private(str, VERSION_PRIVATE, SECP256K1_NAME, &node2,
                                  NULL);
   ck_assert_int_eq(r, 0);
-  hdnode_fill_public_key(&node2);
+  ck_assert_int_eq(hdnode_fill_public_key(&node2), 0);
   ck_assert_mem_eq(&node, &node2, sizeof(HDNode));
   hdnode_serialize_public(&node, fingerprint, VERSION_PUBLIC, str, sizeof(str));
   ck_assert_str_eq(str,
@@ -1880,7 +1880,7 @@ START_TEST(test_bip32_vector_4) {
   fingerprint = hdnode_fingerprint(&node);
   r = hdnode_private_ckd_prime(&node, 0);
   ck_assert_int_eq(r, 1);
-  hdnode_fill_public_key(&node);
+  ck_assert_int_eq(hdnode_fill_public_key(&node), 0);
   hdnode_serialize_private(&node, fingerprint, VERSION_PRIVATE, str,
                            sizeof(str));
   ck_assert_str_eq(str,
@@ -1889,7 +1889,7 @@ START_TEST(test_bip32_vector_4) {
   r = hdnode_deserialize_private(str, VERSION_PRIVATE, SECP256K1_NAME, &node2,
                                  NULL);
   ck_assert_int_eq(r, 0);
-  hdnode_fill_public_key(&node2);
+  ck_assert_int_eq(hdnode_fill_public_key(&node2), 0);
   ck_assert_mem_eq(&node, &node2, sizeof(HDNode));
   hdnode_serialize_public(&node, fingerprint, VERSION_PUBLIC, str, sizeof(str));
   ck_assert_str_eq(str,
@@ -1906,7 +1906,7 @@ START_TEST(test_bip32_vector_4) {
   fingerprint = hdnode_fingerprint(&node);
   r = hdnode_private_ckd_prime(&node, 1);
   ck_assert_int_eq(r, 1);
-  hdnode_fill_public_key(&node);
+  ck_assert_int_eq(hdnode_fill_public_key(&node), 0);
   hdnode_serialize_private(&node, fingerprint, VERSION_PRIVATE, str,
                            sizeof(str));
   ck_assert_str_eq(str,
@@ -1915,7 +1915,7 @@ START_TEST(test_bip32_vector_4) {
   r = hdnode_deserialize_private(str, VERSION_PRIVATE, SECP256K1_NAME, &node2,
                                  NULL);
   ck_assert_int_eq(r, 0);
-  hdnode_fill_public_key(&node2);
+  ck_assert_int_eq(hdnode_fill_public_key(&node2), 0);
   ck_assert_mem_eq(&node, &node2, sizeof(HDNode));
   hdnode_serialize_public(&node, fingerprint, VERSION_PUBLIC, str, sizeof(str));
   ck_assert_str_eq(str,
@@ -1943,10 +1943,10 @@ START_TEST(test_bip32_compare) {
           "301133282ad079cbeb59bc446ad39d333928f74c46997d3609cd3e2801ca69d62788"
           "f9f174429946ff4e9be89f67c22fae28cb296a9b37734f75e73d1477af19"),
       64, SECP256K1_NAME, &node2);
-  hdnode_fill_public_key(&node2);
+  ck_assert_int_eq(hdnode_fill_public_key(&node2), 0);
   for (i = 0; i < 100; i++) {
     memcpy(&node3, &node1, sizeof(HDNode));
-    hdnode_fill_public_key(&node3);
+    ck_assert_int_eq(hdnode_fill_public_key(&node3), 0);
     r = hdnode_private_ckd(&node1, i);
     ck_assert_int_eq(r, 1);
     r = hdnode_public_ckd(&node2, i);
@@ -1969,7 +1969,7 @@ START_TEST(test_bip32_compare) {
         fromhex(
             "0000000000000000000000000000000000000000000000000000000000000000"),
         32);
-    hdnode_fill_public_key(&node1);
+    ck_assert_int_eq(hdnode_fill_public_key(&node1), 0);
     ck_assert_mem_eq(node1.public_key, node2.public_key, 33);
     ck_assert_mem_eq(node1.public_key, node3.public_key, 33);
   }
@@ -1979,7 +1979,7 @@ END_TEST
 START_TEST(test_bip32_optimized) {
   HDNode root;
   hdnode_from_seed((uint8_t *)"NothingToSeeHere", 16, SECP256K1_NAME, &root);
-  hdnode_fill_public_key(&root);
+  ck_assert_int_eq(hdnode_fill_public_key(&root), 0);
 
   curve_point pub;
   ecdsa_read_pubkey(&secp256k1, root.public_key, &pub);
@@ -1991,7 +1991,7 @@ START_TEST(test_bip32_optimized) {
     // unoptimized
     memcpy(&node, &root, sizeof(HDNode));
     hdnode_public_ckd(&node, i);
-    hdnode_fill_public_key(&node);
+    ck_assert_int_eq(hdnode_fill_public_key(&node), 0);
     ecdsa_get_address(node.public_key, 0, HASHER_SHA2_RIPEMD, HASHER_SHA2D,
                       addr1, sizeof(addr1));
     // optimized
@@ -2136,7 +2136,7 @@ START_TEST(test_bip32_nist_seed) {
       fromhex(
           "7762f9729fed06121fd13f326884c82f59aa95c57ac492ce8c9654e60efd130c"),
       32);
-  hdnode_fill_public_key(&node);
+  ck_assert_int_eq(hdnode_fill_public_key(&node), 0);
   ck_assert_mem_eq(
       node.public_key,
       fromhex(
@@ -2160,7 +2160,7 @@ START_TEST(test_bip32_nist_seed) {
       fromhex(
           "0e49dc46ce1d8c29d9b80a05e40f5d0cd68cbf02ae98572186f5343be18084bf"),
       32);
-  hdnode_fill_public_key(&node);
+  ck_assert_int_eq(hdnode_fill_public_key(&node), 0);
   ck_assert_mem_eq(
       node.public_key,
       fromhex(
@@ -2190,7 +2190,7 @@ START_TEST(test_bip32_nist_vector_1) {
       fromhex(
           "612091aaa12e22dd2abef664f8a01a82cae99ad7441b7ef8110424915c268bc2"),
       32);
-  hdnode_fill_public_key(&node);
+  ck_assert_int_eq(hdnode_fill_public_key(&node), 0);
   ck_assert_mem_eq(
       node.public_key,
       fromhex(
@@ -2211,7 +2211,7 @@ START_TEST(test_bip32_nist_vector_1) {
       fromhex(
           "6939694369114c67917a182c59ddb8cafc3004e63ca5d3b84403ba8613debc0c"),
       32);
-  hdnode_fill_public_key(&node);
+  ck_assert_int_eq(hdnode_fill_public_key(&node), 0);
   ck_assert_mem_eq(
       node.public_key,
       fromhex(
@@ -2232,7 +2232,7 @@ START_TEST(test_bip32_nist_vector_1) {
       fromhex(
           "284e9d38d07d21e4e281b645089a94f4cf5a5a81369acf151a1c3a57f18b2129"),
       32);
-  hdnode_fill_public_key(&node);
+  ck_assert_int_eq(hdnode_fill_public_key(&node), 0);
   ck_assert_mem_eq(
       node.public_key,
       fromhex(
@@ -2253,7 +2253,7 @@ START_TEST(test_bip32_nist_vector_1) {
       fromhex(
           "694596e8a54f252c960eb771a3c41e7e32496d03b954aeb90f61635b8e092aa7"),
       32);
-  hdnode_fill_public_key(&node);
+  ck_assert_int_eq(hdnode_fill_public_key(&node), 0);
   ck_assert_mem_eq(
       node.public_key,
       fromhex(
@@ -2274,7 +2274,7 @@ START_TEST(test_bip32_nist_vector_1) {
       fromhex(
           "5996c37fd3dd2679039b23ed6f70b506c6b56b3cb5e424681fb0fa64caf82aaa"),
       32);
-  hdnode_fill_public_key(&node);
+  ck_assert_int_eq(hdnode_fill_public_key(&node), 0);
   ck_assert_mem_eq(
       node.public_key,
       fromhex(
@@ -2295,7 +2295,7 @@ START_TEST(test_bip32_nist_vector_1) {
       fromhex(
           "21c4f269ef0a5fd1badf47eeacebeeaa3de22eb8e5b0adcd0f27dd99d34d0119"),
       32);
-  hdnode_fill_public_key(&node);
+  ck_assert_int_eq(hdnode_fill_public_key(&node), 0);
   ck_assert_mem_eq(
       node.public_key,
       fromhex(
@@ -2329,7 +2329,7 @@ START_TEST(test_bip32_nist_vector_2) {
       fromhex(
           "eaa31c2e46ca2962227cf21d73a7ef0ce8b31c756897521eb6c7b39796633357"),
       32);
-  hdnode_fill_public_key(&node);
+  ck_assert_int_eq(hdnode_fill_public_key(&node), 0);
   ck_assert_mem_eq(
       node.public_key,
       fromhex(
@@ -2351,7 +2351,7 @@ START_TEST(test_bip32_nist_vector_2) {
       fromhex(
           "d7d065f63a62624888500cdb4f88b6d59c2927fee9e6d0cdff9cad555884df6e"),
       32);
-  hdnode_fill_public_key(&node);
+  ck_assert_int_eq(hdnode_fill_public_key(&node), 0);
   ck_assert_mem_eq(
       node.public_key,
       fromhex(
@@ -2373,7 +2373,7 @@ START_TEST(test_bip32_nist_vector_2) {
       fromhex(
           "96d2ec9316746a75e7793684ed01e3d51194d81a42a3276858a5b7376d4b94b9"),
       32);
-  hdnode_fill_public_key(&node);
+  ck_assert_int_eq(hdnode_fill_public_key(&node), 0);
   ck_assert_mem_eq(
       node.public_key,
       fromhex(
@@ -2395,7 +2395,7 @@ START_TEST(test_bip32_nist_vector_2) {
       fromhex(
           "974f9096ea6873a915910e82b29d7c338542ccde39d2064d1cc228f371542bbc"),
       32);
-  hdnode_fill_public_key(&node);
+  ck_assert_int_eq(hdnode_fill_public_key(&node), 0);
   ck_assert_mem_eq(
       node.public_key,
       fromhex(
@@ -2417,7 +2417,7 @@ START_TEST(test_bip32_nist_vector_2) {
       fromhex(
           "da29649bbfaff095cd43819eda9a7be74236539a29094cd8336b07ed8d4eff63"),
       32);
-  hdnode_fill_public_key(&node);
+  ck_assert_int_eq(hdnode_fill_public_key(&node), 0);
   ck_assert_mem_eq(
       node.public_key,
       fromhex(
@@ -2439,7 +2439,7 @@ START_TEST(test_bip32_nist_vector_2) {
       fromhex(
           "bb0a77ba01cc31d77205d51d08bd313b979a71ef4de9b062f8958297e746bd67"),
       32);
-  hdnode_fill_public_key(&node);
+  ck_assert_int_eq(hdnode_fill_public_key(&node), 0);
   ck_assert_mem_eq(
       node.public_key,
       fromhex(
@@ -2490,10 +2490,10 @@ START_TEST(test_bip32_nist_compare) {
           "301133282ad079cbeb59bc446ad39d333928f74c46997d3609cd3e2801ca69d62788"
           "f9f174429946ff4e9be89f67c22fae28cb296a9b37734f75e73d1477af19"),
       64, NIST256P1_NAME, &node2);
-  hdnode_fill_public_key(&node2);
+  ck_assert_int_eq(hdnode_fill_public_key(&node2), 0);
   for (i = 0; i < 100; i++) {
     memcpy(&node3, &node1, sizeof(HDNode));
-    hdnode_fill_public_key(&node3);
+    ck_assert_int_eq(hdnode_fill_public_key(&node3), 0);
     r = hdnode_private_ckd(&node1, i);
     ck_assert_int_eq(r, 1);
     r = hdnode_public_ckd(&node2, i);
@@ -2516,7 +2516,7 @@ START_TEST(test_bip32_nist_compare) {
         fromhex(
             "0000000000000000000000000000000000000000000000000000000000000000"),
         32);
-    hdnode_fill_public_key(&node1);
+    ck_assert_int_eq(hdnode_fill_public_key(&node1), 0);
     ck_assert_mem_eq(node1.public_key, node2.public_key, 33);
     ck_assert_mem_eq(node1.public_key, node3.public_key, 33);
   }
@@ -2547,7 +2547,7 @@ START_TEST(test_bip32_nist_repeat) {
       fromhex(
           "06f0db126f023755d0b8d86d4591718a5210dd8d024e3e14b6159d63f53aa669"),
       32);
-  hdnode_fill_public_key(&node);
+  ck_assert_int_eq(hdnode_fill_public_key(&node), 0);
   ck_assert_mem_eq(
       node.public_key,
       fromhex(
@@ -2569,7 +2569,7 @@ START_TEST(test_bip32_nist_repeat) {
       fromhex(
           "092154eed4af83e078ff9b84322015aefe5769e31270f62c3f66c33888335f3a"),
       32);
-  hdnode_fill_public_key(&node2);
+  ck_assert_int_eq(hdnode_fill_public_key(&node2), 0);
   ck_assert_mem_eq(
       node2.public_key,
       fromhex(
@@ -2586,7 +2586,7 @@ START_TEST(test_bip32_nist_repeat) {
       fromhex(
           "9e87fe95031f14736774cd82f25fd885065cb7c358c1edf813c72af535e83071"),
       32);
-  hdnode_fill_public_key(&node2);
+  ck_assert_int_eq(hdnode_fill_public_key(&node2), 0);
   ck_assert_mem_eq(
       node2.public_key,
       fromhex(
@@ -2614,7 +2614,7 @@ START_TEST(test_bip32_ed25519_vector_1) {
       fromhex(
           "2b4be7f19ee27bbf30c667b642d5f4aa69fd169872f8fc3059c08ebae2eb19e7"),
       32);
-  hdnode_fill_public_key(&node);
+  ck_assert_int_eq(hdnode_fill_public_key(&node), 0);
   ck_assert_mem_eq(
       node.public_key,
       fromhex(
@@ -2633,7 +2633,7 @@ START_TEST(test_bip32_ed25519_vector_1) {
       fromhex(
           "68e0fe46dfb67e368c75379acec591dad19df3cde26e63b93a8e704f1dade7a3"),
       32);
-  hdnode_fill_public_key(&node);
+  ck_assert_int_eq(hdnode_fill_public_key(&node), 0);
   ck_assert_mem_eq(
       node.public_key,
       fromhex(
@@ -2652,7 +2652,7 @@ START_TEST(test_bip32_ed25519_vector_1) {
       fromhex(
           "b1d0bad404bf35da785a64ca1ac54b2617211d2777696fbffaf208f746ae84f2"),
       32);
-  hdnode_fill_public_key(&node);
+  ck_assert_int_eq(hdnode_fill_public_key(&node), 0);
   ck_assert_mem_eq(
       node.public_key,
       fromhex(
@@ -2671,7 +2671,7 @@ START_TEST(test_bip32_ed25519_vector_1) {
       fromhex(
           "92a5b23c0b8a99e37d07df3fb9966917f5d06e02ddbd909c7e184371463e9fc9"),
       32);
-  hdnode_fill_public_key(&node);
+  ck_assert_int_eq(hdnode_fill_public_key(&node), 0);
   ck_assert_mem_eq(
       node.public_key,
       fromhex(
@@ -2690,7 +2690,7 @@ START_TEST(test_bip32_ed25519_vector_1) {
       fromhex(
           "30d1dc7e5fc04c31219ab25a27ae00b50f6fd66622f6e9c913253d6511d1e662"),
       32);
-  hdnode_fill_public_key(&node);
+  ck_assert_int_eq(hdnode_fill_public_key(&node), 0);
   ck_assert_mem_eq(
       node.public_key,
       fromhex(
@@ -2709,7 +2709,7 @@ START_TEST(test_bip32_ed25519_vector_1) {
       fromhex(
           "8f94d394a8e8fd6b1bc2f3f49f5c47e385281d5c17e65324b0f62483e37e8793"),
       32);
-  hdnode_fill_public_key(&node);
+  ck_assert_int_eq(hdnode_fill_public_key(&node), 0);
   ck_assert_mem_eq(
       node.public_key,
       fromhex(
@@ -2741,7 +2741,7 @@ START_TEST(test_bip32_ed25519_vector_2) {
       fromhex(
           "171cb88b1b3c1db25add599712e36245d75bc65a1a5c9e18d76f9f2b1eab4012"),
       32);
-  hdnode_fill_public_key(&node);
+  ck_assert_int_eq(hdnode_fill_public_key(&node), 0);
   ck_assert_mem_eq(
       node.public_key,
       fromhex(
@@ -2761,7 +2761,7 @@ START_TEST(test_bip32_ed25519_vector_2) {
       fromhex(
           "1559eb2bbec5790b0c65d8693e4d0875b1747f4970ae8b650486ed7470845635"),
       32);
-  hdnode_fill_public_key(&node);
+  ck_assert_int_eq(hdnode_fill_public_key(&node), 0);
   ck_assert_mem_eq(
       node.public_key,
       fromhex(
@@ -2781,7 +2781,7 @@ START_TEST(test_bip32_ed25519_vector_2) {
       fromhex(
           "ea4f5bfe8694d8bb74b7b59404632fd5968b774ed545e810de9c32a4fb4192f4"),
       32);
-  hdnode_fill_public_key(&node);
+  ck_assert_int_eq(hdnode_fill_public_key(&node), 0);
   ck_assert_mem_eq(
       node.public_key,
       fromhex(
@@ -2801,7 +2801,7 @@ START_TEST(test_bip32_ed25519_vector_2) {
       fromhex(
           "3757c7577170179c7868353ada796c839135b3d30554bbb74a4b1e4a5a58505c"),
       32);
-  hdnode_fill_public_key(&node);
+  ck_assert_int_eq(hdnode_fill_public_key(&node), 0);
   ck_assert_mem_eq(
       node.public_key,
       fromhex(
@@ -2821,7 +2821,7 @@ START_TEST(test_bip32_ed25519_vector_2) {
       fromhex(
           "5837736c89570de861ebc173b1086da4f505d4adb387c6a1b1342d5e4ac9ec72"),
       32);
-  hdnode_fill_public_key(&node);
+  ck_assert_int_eq(hdnode_fill_public_key(&node), 0);
   ck_assert_mem_eq(
       node.public_key,
       fromhex(
@@ -2841,7 +2841,7 @@ START_TEST(test_bip32_ed25519_vector_2) {
       fromhex(
           "551d333177df541ad876a60ea71f00447931c0a9da16f227c11ea080d7391b8d"),
       32);
-  hdnode_fill_public_key(&node);
+  ck_assert_int_eq(hdnode_fill_public_key(&node), 0);
   ck_assert_mem_eq(
       node.public_key,
       fromhex(
@@ -2879,7 +2879,7 @@ START_TEST(test_bip32_decred_vector_1) {
       fromhex(
           "e8f32e723decf4051aefac8e2c93c9c5b214313817cdb01a1494b917c8436b35"),
       32);
-  hdnode_fill_public_key(&node);
+  ck_assert_int_eq(hdnode_fill_public_key(&node), 0);
   ck_assert_mem_eq(
       node.public_key,
       fromhex(
@@ -2894,7 +2894,7 @@ START_TEST(test_bip32_decred_vector_1) {
                                  SECP256K1_DECRED_NAME, &node2, NULL);
   ck_assert_int_eq(r, 0);
   ck_assert_int_eq(r, 0);
-  hdnode_fill_public_key(&node2);
+  ck_assert_int_eq(hdnode_fill_public_key(&node2), 0);
   ck_assert_mem_eq(&node, &node2, sizeof(HDNode));
   hdnode_serialize_public(&node, fingerprint, DECRED_VERSION_PUBLIC, str,
                           sizeof(str));
@@ -2922,7 +2922,7 @@ START_TEST(test_bip32_decred_vector_1) {
       fromhex(
           "edb2e14f9ee77d26dd93b4ecede8d16ed408ce149b6cd80b0715a2d911a0afea"),
       32);
-  hdnode_fill_public_key(&node);
+  ck_assert_int_eq(hdnode_fill_public_key(&node), 0);
   ck_assert_mem_eq(
       node.public_key,
       fromhex(
@@ -2936,7 +2936,7 @@ START_TEST(test_bip32_decred_vector_1) {
   r = hdnode_deserialize_private(str, DECRED_VERSION_PRIVATE,
                                  SECP256K1_DECRED_NAME, &node2, NULL);
   ck_assert_int_eq(r, 0);
-  hdnode_fill_public_key(&node2);
+  ck_assert_int_eq(hdnode_fill_public_key(&node2), 0);
   ck_assert_mem_eq(&node, &node2, sizeof(HDNode));
   hdnode_serialize_public(&node, fingerprint, DECRED_VERSION_PUBLIC, str,
                           sizeof(str));
@@ -2964,7 +2964,7 @@ START_TEST(test_bip32_decred_vector_1) {
       fromhex(
           "3c6cb8d0f6a264c91ea8b5030fadaa8e538b020f0a387421a12de9319dc93368"),
       32);
-  hdnode_fill_public_key(&node);
+  ck_assert_int_eq(hdnode_fill_public_key(&node), 0);
   ck_assert_mem_eq(
       node.public_key,
       fromhex(
@@ -2978,7 +2978,7 @@ START_TEST(test_bip32_decred_vector_1) {
   r = hdnode_deserialize_private(str, DECRED_VERSION_PRIVATE,
                                  SECP256K1_DECRED_NAME, &node2, NULL);
   ck_assert_int_eq(r, 0);
-  hdnode_fill_public_key(&node2);
+  ck_assert_int_eq(hdnode_fill_public_key(&node2), 0);
   ck_assert_mem_eq(&node, &node2, sizeof(HDNode));
   hdnode_serialize_public(&node, fingerprint, DECRED_VERSION_PUBLIC, str,
                           sizeof(str));
@@ -3006,7 +3006,7 @@ START_TEST(test_bip32_decred_vector_1) {
       fromhex(
           "cbce0d719ecf7431d88e6a89fa1483e02e35092af60c042b1df2ff59fa424dca"),
       32);
-  hdnode_fill_public_key(&node);
+  ck_assert_int_eq(hdnode_fill_public_key(&node), 0);
   ck_assert_mem_eq(
       node.public_key,
       fromhex(
@@ -3020,7 +3020,7 @@ START_TEST(test_bip32_decred_vector_1) {
   r = hdnode_deserialize_private(str, DECRED_VERSION_PRIVATE,
                                  SECP256K1_DECRED_NAME, &node2, NULL);
   ck_assert_int_eq(r, 0);
-  hdnode_fill_public_key(&node2);
+  ck_assert_int_eq(hdnode_fill_public_key(&node2), 0);
   ck_assert_mem_eq(&node, &node2, sizeof(HDNode));
   hdnode_serialize_public(&node, fingerprint, DECRED_VERSION_PUBLIC, str,
                           sizeof(str));
@@ -3048,7 +3048,7 @@ START_TEST(test_bip32_decred_vector_1) {
       fromhex(
           "0f479245fb19a38a1954c5c7c0ebab2f9bdfd96a17563ef28a6a4b1a2a764ef4"),
       32);
-  hdnode_fill_public_key(&node);
+  ck_assert_int_eq(hdnode_fill_public_key(&node), 0);
   ck_assert_mem_eq(
       node.public_key,
       fromhex(
@@ -3062,7 +3062,7 @@ START_TEST(test_bip32_decred_vector_1) {
   r = hdnode_deserialize_private(str, DECRED_VERSION_PRIVATE,
                                  SECP256K1_DECRED_NAME, &node2, NULL);
   ck_assert_int_eq(r, 0);
-  hdnode_fill_public_key(&node2);
+  ck_assert_int_eq(hdnode_fill_public_key(&node2), 0);
   ck_assert_mem_eq(&node, &node2, sizeof(HDNode));
   hdnode_serialize_public(&node, fingerprint, DECRED_VERSION_PUBLIC, str,
                           sizeof(str));
@@ -3090,7 +3090,7 @@ START_TEST(test_bip32_decred_vector_1) {
       fromhex(
           "471b76e389e528d6de6d816857e012c5455051cad6660850e58372a6c3e6e7c8"),
       32);
-  hdnode_fill_public_key(&node);
+  ck_assert_int_eq(hdnode_fill_public_key(&node), 0);
   ck_assert_mem_eq(
       node.public_key,
       fromhex(
@@ -3104,7 +3104,7 @@ START_TEST(test_bip32_decred_vector_1) {
   r = hdnode_deserialize_private(str, DECRED_VERSION_PRIVATE,
                                  SECP256K1_DECRED_NAME, &node2, NULL);
   ck_assert_int_eq(r, 0);
-  hdnode_fill_public_key(&node2);
+  ck_assert_int_eq(hdnode_fill_public_key(&node2), 0);
   ck_assert_mem_eq(&node, &node2, sizeof(HDNode));
   hdnode_serialize_public(&node, fingerprint, DECRED_VERSION_PUBLIC, str,
                           sizeof(str));
@@ -3152,7 +3152,7 @@ START_TEST(test_bip32_decred_vector_2) {
       fromhex(
           "4b03d6fc340455b363f51020ad3ecca4f0850280cf436c70c727923f6db46c3e"),
       32);
-  hdnode_fill_public_key(&node);
+  ck_assert_int_eq(hdnode_fill_public_key(&node), 0);
   ck_assert_mem_eq(
       node.public_key,
       fromhex(
@@ -3166,7 +3166,7 @@ START_TEST(test_bip32_decred_vector_2) {
   r = hdnode_deserialize_private(str, DECRED_VERSION_PRIVATE,
                                  SECP256K1_DECRED_NAME, &node2, NULL);
   ck_assert_int_eq(r, 0);
-  hdnode_fill_public_key(&node2);
+  ck_assert_int_eq(hdnode_fill_public_key(&node2), 0);
   ck_assert_mem_eq(&node, &node2, sizeof(HDNode));
   hdnode_serialize_public(&node, fingerprint, DECRED_VERSION_PUBLIC, str,
                           sizeof(str));
@@ -3195,7 +3195,7 @@ START_TEST(test_bip32_decred_vector_2) {
       fromhex(
           "abe74a98f6c7eabee0428f53798f0ab8aa1bd37873999041703c742f15ac7e1e"),
       32);
-  hdnode_fill_public_key(&node);
+  ck_assert_int_eq(hdnode_fill_public_key(&node), 0);
   ck_assert_mem_eq(
       node.public_key,
       fromhex(
@@ -3209,7 +3209,7 @@ START_TEST(test_bip32_decred_vector_2) {
   r = hdnode_deserialize_private(str, DECRED_VERSION_PRIVATE,
                                  SECP256K1_DECRED_NAME, &node2, NULL);
   ck_assert_int_eq(r, 0);
-  hdnode_fill_public_key(&node2);
+  ck_assert_int_eq(hdnode_fill_public_key(&node2), 0);
   ck_assert_mem_eq(&node, &node2, sizeof(HDNode));
   hdnode_serialize_public(&node, fingerprint, DECRED_VERSION_PUBLIC, str,
                           sizeof(str));
@@ -3238,7 +3238,7 @@ START_TEST(test_bip32_decred_vector_2) {
       fromhex(
           "877c779ad9687164e9c2f4f0f4ff0340814392330693ce95a58fe18fd52e6e93"),
       32);
-  hdnode_fill_public_key(&node);
+  ck_assert_int_eq(hdnode_fill_public_key(&node), 0);
   ck_assert_mem_eq(
       node.public_key,
       fromhex(
@@ -3252,7 +3252,7 @@ START_TEST(test_bip32_decred_vector_2) {
   r = hdnode_deserialize_private(str, DECRED_VERSION_PRIVATE,
                                  SECP256K1_DECRED_NAME, &node2, NULL);
   ck_assert_int_eq(r, 0);
-  hdnode_fill_public_key(&node2);
+  ck_assert_int_eq(hdnode_fill_public_key(&node2), 0);
   ck_assert_mem_eq(&node, &node2, sizeof(HDNode));
   hdnode_serialize_public(&node, fingerprint, DECRED_VERSION_PUBLIC, str,
                           sizeof(str));
@@ -3281,7 +3281,7 @@ START_TEST(test_bip32_decred_vector_2) {
       fromhex(
           "704addf544a06e5ee4bea37098463c23613da32020d604506da8c0518e1da4b7"),
       32);
-  hdnode_fill_public_key(&node);
+  ck_assert_int_eq(hdnode_fill_public_key(&node), 0);
   ck_assert_mem_eq(
       node.public_key,
       fromhex(
@@ -3295,7 +3295,7 @@ START_TEST(test_bip32_decred_vector_2) {
   r = hdnode_deserialize_private(str, DECRED_VERSION_PRIVATE,
                                  SECP256K1_DECRED_NAME, &node2, NULL);
   ck_assert_int_eq(r, 0);
-  hdnode_fill_public_key(&node2);
+  ck_assert_int_eq(hdnode_fill_public_key(&node2), 0);
   ck_assert_mem_eq(&node, &node2, sizeof(HDNode));
   hdnode_serialize_public(&node, fingerprint, DECRED_VERSION_PUBLIC, str,
                           sizeof(str));
@@ -3324,7 +3324,7 @@ START_TEST(test_bip32_decred_vector_2) {
       fromhex(
           "f1c7c871a54a804afe328b4c83a1c33b8e5ff48f5087273f04efa83b247d6a2d"),
       32);
-  hdnode_fill_public_key(&node);
+  ck_assert_int_eq(hdnode_fill_public_key(&node), 0);
   ck_assert_mem_eq(
       node.public_key,
       fromhex(
@@ -3338,7 +3338,7 @@ START_TEST(test_bip32_decred_vector_2) {
   r = hdnode_deserialize_private(str, DECRED_VERSION_PRIVATE,
                                  SECP256K1_DECRED_NAME, &node2, NULL);
   ck_assert_int_eq(r, 0);
-  hdnode_fill_public_key(&node2);
+  ck_assert_int_eq(hdnode_fill_public_key(&node2), 0);
   ck_assert_mem_eq(&node, &node2, sizeof(HDNode));
   hdnode_serialize_public(&node, fingerprint, DECRED_VERSION_PUBLIC, str,
                           sizeof(str));
@@ -3367,7 +3367,7 @@ START_TEST(test_bip32_decred_vector_2) {
       fromhex(
           "bb7d39bdb83ecf58f2fd82b6d918341cbef428661ef01ab97c28a4842125ac23"),
       32);
-  hdnode_fill_public_key(&node);
+  ck_assert_int_eq(hdnode_fill_public_key(&node), 0);
   ck_assert_mem_eq(
       node.public_key,
       fromhex(
@@ -3381,7 +3381,7 @@ START_TEST(test_bip32_decred_vector_2) {
   r = hdnode_deserialize_private(str, DECRED_VERSION_PRIVATE,
                                  SECP256K1_DECRED_NAME, &node2, NULL);
   ck_assert_int_eq(r, 0);
-  hdnode_fill_public_key(&node2);
+  ck_assert_int_eq(hdnode_fill_public_key(&node2), 0);
   ck_assert_mem_eq(&node, &node2, sizeof(HDNode));
   hdnode_serialize_public(&node, fingerprint, DECRED_VERSION_PUBLIC, str,
                           sizeof(str));
@@ -7057,7 +7057,7 @@ static void test_bip32_ecdh_init_node(HDNode *node, const char *seed_str,
                                       const char *curve_name) {
   hdnode_from_seed((const uint8_t *)seed_str, strlen(seed_str), curve_name,
                    node);
-  hdnode_fill_public_key(node);
+  ck_assert_int_eq(hdnode_fill_public_key(node), 0);
   if (node->public_key[0] == 1) {
     node->public_key[0] = 0x40;  // Curve25519 public keys start with 0x40 byte
   }

--- a/crypto/tests/test_check_cardano.h
+++ b/crypto/tests/test_check_cardano.h
@@ -136,7 +136,7 @@ START_TEST(test_bip32_cardano_hdnode_vector_1) {
       fromhex(
           "daeb991f2d2128e2525415c56a07f4366baa26c1e48572a5e073934b6de35fbc"),
       32);
-  hdnode_fill_public_key(&node);
+  ck_assert_int_eq(hdnode_fill_public_key(&node), 0);
   ck_assert_mem_eq(
       node.public_key + 1,
       fromhex(
@@ -174,7 +174,7 @@ START_TEST(test_bip32_cardano_hdnode_vector_2) {
       fromhex(
           "64aa9a16331f14c981b769efcf96addcc4c6db44047fe7a7feae0be23d33bf54"),
       32);
-  hdnode_fill_public_key(&node);
+  ck_assert_int_eq(hdnode_fill_public_key(&node), 0);
   ck_assert_mem_eq(
       node.public_key + 1,
       fromhex(
@@ -212,7 +212,7 @@ START_TEST(test_bip32_cardano_hdnode_vector_3) {
       fromhex(
           "b4fc241feffe840b8a54a26ab447f5a5caa31032db3a8091fca14f38b86ed539"),
       32);
-  hdnode_fill_public_key(&node);
+  ck_assert_int_eq(hdnode_fill_public_key(&node), 0);
   ck_assert_mem_eq(
       node.public_key + 1,
       fromhex(
@@ -251,7 +251,7 @@ START_TEST(test_bip32_cardano_hdnode_vector_4) {
       fromhex(
           "a3071959013af95aaecf78a7a2e1b9838bbbc4864d6a8a2295243782078345cd"),
       32);
-  hdnode_fill_public_key(&node);
+  ck_assert_int_eq(hdnode_fill_public_key(&node), 0);
   ck_assert_mem_eq(
       node.public_key + 1,
       fromhex(
@@ -291,7 +291,7 @@ START_TEST(test_bip32_cardano_hdnode_vector_5) {
       fromhex(
           "5bebf1eea68acd04932653d944b064b10baaf5886dd73c185cc285059bf93363"),
       32);
-  hdnode_fill_public_key(&node);
+  ck_assert_int_eq(hdnode_fill_public_key(&node), 0);
   ck_assert_mem_eq(
       node.public_key + 1,
       fromhex(
@@ -332,7 +332,7 @@ START_TEST(test_bip32_cardano_hdnode_vector_6) {
       fromhex(
           "466332cb097934b43008701e7e27044aa56c7859019e4eba18d91a3bea23dff7"),
       32);
-  hdnode_fill_public_key(&node);
+  ck_assert_int_eq(hdnode_fill_public_key(&node), 0);
   ck_assert_mem_eq(
       node.public_key + 1,
       fromhex(
@@ -374,7 +374,7 @@ START_TEST(test_bip32_cardano_hdnode_vector_7) {
       fromhex(
           "01eccef768a79859f824a1d3c3e35e131184e2940c3fca9a4c9b307741f65363"),
       32);
-  hdnode_fill_public_key(&node);
+  ck_assert_int_eq(hdnode_fill_public_key(&node), 0);
   ck_assert_mem_eq(
       node.public_key + 1,
       fromhex(
@@ -416,7 +416,7 @@ START_TEST(test_bip32_cardano_hdnode_vector_8) {
       fromhex(
           "170e0d3b65ba8d71f27a6db60d0ac26dcb16e52e08cc259db72066f206b258d5"),
       32);
-  hdnode_fill_public_key(&node);
+  ck_assert_int_eq(hdnode_fill_public_key(&node), 0);
   ck_assert_mem_eq(
       node.public_key + 1,
       fromhex(
@@ -459,7 +459,7 @@ START_TEST(test_bip32_cardano_hdnode_vector_9) {
       fromhex(
           "80d2c677638e5dbd4395cdec279bf2a42077f2797c9e887949d37cdb317fce6a"),
       32);
-  hdnode_fill_public_key(&node);
+  ck_assert_int_eq(hdnode_fill_public_key(&node), 0);
   ck_assert_mem_eq(
       node.public_key + 1,
       fromhex(

--- a/crypto/tests/test_openssl.c
+++ b/crypto/tests/test_openssl.c
@@ -79,8 +79,15 @@ void openssl_check(unsigned int iterations, int nid, const ecdsa_curve *curve) {
     }
 
     // generate public key from private key
-    ecdsa_get_public_key33(curve, priv_key, pub_key33);
-    ecdsa_get_public_key65(curve, priv_key, pub_key65);
+    if (ecdsa_get_public_key33(curve, priv_key, pub_key33) != 0) {
+      printf("ecdsa_get_public_key33 failed\n");
+      return;
+    }
+
+    if (ecdsa_get_public_key65(curve, priv_key, pub_key65) != 0) {
+      printf("ecdsa_get_public_key65 failed\n");
+      return;
+    }
 
     // use our ECDSA verifier to verify the message signature
     if (ecdsa_verify(curve, HASHER_SHA2, pub_key65, sig, msg, msg_len) != 0) {

--- a/legacy/firmware/fsm_msg_ethereum.h
+++ b/legacy/firmware/fsm_msg_ethereum.h
@@ -33,7 +33,13 @@ void fsm_msgEthereumGetPublicKey(const EthereumGetPublicKey *msg) {
   HDNode *node = fsm_getDerivedNode(curve, msg->address_n, msg->address_n_count,
                                     &fingerprint);
   if (!node) return;
-  hdnode_fill_public_key(node);
+
+  if (hdnode_fill_public_key(node) != 0) {
+    fsm_sendFailure(FailureType_Failure_ProcessError,
+                    _("Failed to derive public key"));
+    layoutHome();
+    return;
+  }
 
   if (msg->has_show_display && msg->show_display) {
     layoutPublicKey(node->public_key);

--- a/legacy/firmware/fsm_msg_nem.h
+++ b/legacy/firmware/fsm_msg_nem.h
@@ -123,7 +123,12 @@ void fsm_msgNEMSignTx(NEMSignTx *msg) {
                          msg->transaction.address_n_count, NULL);
   if (!node) return;
 
-  hdnode_fill_public_key(node);
+  if (hdnode_fill_public_key(node) != 0) {
+    fsm_sendFailure(FailureType_Failure_ProcessError,
+                    _("Failed to derive public key"));
+    layoutHome();
+    return;
+  }
 
   const NEMTransactionCommon *common =
       msg->has_multisig ? &msg->multisig : &msg->transaction;

--- a/legacy/firmware/signing.c
+++ b/legacy/firmware/signing.c
@@ -652,7 +652,10 @@ static bool fill_input_script_sig(TxInputType *tinput) {
     // Failed to derive private key
     return false;
   }
-  hdnode_fill_public_key(&node);
+  if (hdnode_fill_public_key(&node) != 0) {
+    // Failed to derive public key
+    return false;
+  }
   if (tinput->has_multisig) {
     tinput->script_sig.size = compile_script_multisig(coin, &(tinput->multisig),
                                                       tinput->script_sig.bytes);

--- a/legacy/firmware/stellar.c
+++ b/legacy/firmware/stellar.c
@@ -1461,7 +1461,9 @@ const HDNode *stellar_deriveNode(const uint32_t *address_n,
     return 0;
   }
 
-  hdnode_fill_public_key(&node);
+  if (hdnode_fill_public_key(&node) != 0) {
+    return 0;
+  }
 
   return &node;
 }

--- a/legacy/firmware/transaction.c
+++ b/legacy/firmware/transaction.c
@@ -256,7 +256,9 @@ int compile_output(const CoinInfo *coin, AmountUnit amount_unit,
                                   NULL) == 0) {
       return 0;  // failed to compile output
     }
-    hdnode_fill_public_key(&node);
+    if (hdnode_fill_public_key(&node) != 0) {
+      return 0;  // failed to compile output
+    }
     if (!compute_address(coin, input_script_type, &node, in->has_multisig,
                          &in->multisig, in->address)) {
       return 0;  // failed to compile output

--- a/legacy/firmware/u2f.c
+++ b/legacy/firmware/u2f.c
@@ -604,8 +604,11 @@ void u2f_register(const APDU *a) {
       return;
     }
 
-    ecdsa_get_public_key65(node->curve->params, node->private_key,
-                           (uint8_t *)&resp->pubKey);
+    if (ecdsa_get_public_key65(node->curve->params, node->private_key,
+                               (uint8_t *)&resp->pubKey) != 0) {
+      send_u2f_error(U2F_SW_WRONG_DATA);
+      return;
+    }
 
     memcpy(resp->keyHandleCertSig + resp->keyHandleLen, U2F_ATT_CERT,
            sizeof(U2F_ATT_CERT));


### PR DESCRIPTION
Addresses https://github.com/satoshilabs/trezor-firmware/issues/111 and https://github.com/satoshilabs/trezor-firmware/issues/112, i.e.:
1. Treat edge cases in `ecdsa_sign_digest()` same as `ecdsa_verify_digest()` does (all-zero private key and all-zero digest).
2. Check private key validity when deriving public key.

For 2 I decided to propagate the error to the calling functions, namely `hdnode_fill_public_key()` and further on. I think it's not really necessary to do this, because in the vast majority of cases the error is unreachable, but in the future it might help us in catching some bug early on. So, better safe than sorry.

I also noticed that `ed25519.c` wasn't doing any stack cleanup of sensitive values, so I added that.

@onvej-sl please make sure that 1 and 2 is implemented in https://github.com/trezor/trezor-firmware/pull/1678.