### PR TITLE
Add support for recursive protobuf messages

### DIFF
--- a/common/protob/pb2py
+++ b/common/protob/pb2py
@@ -379,42 +379,6 @@ class Descriptor:
         for enum in self.enums:
             self.convert_enum_value_names(enum)
 
-        self.depsort_messages()
-
-    def depsort_messages(self):
-        # sort messages according to dependencies
-        messages_dict = {m.name: m for m in reversed(self.messages)}
-        messages_sorted = []
-        seen_messages = set()
-
-        # pop first message
-        _, message = messages_dict.popitem()
-
-        while True:
-            dependent_type = next(
-                (
-                    f.type_name
-                    for f in message.fields
-                    if f.is_message and f.type_name not in seen_messages
-                ),
-                None,
-            )
-            if dependent_type:
-                # return current message to unprocessed
-                messages_dict[message.name] = message
-                # pop the dependency
-                message = messages_dict.pop(dependent_type)
-            else:
-                # see message
-                seen_messages.add(message.name)
-                messages_sorted.append(message)
-                if not messages_dict:
-                    break
-                else:
-                    _, message = messages_dict.popitem()
-
-        assert len(messages_sorted) == len(self.messages)
-        self.messages[:] = messages_sorted
 
     def _filter_items(self, iter):
         return [

--- a/core/src/trezor/_proto_messages.mako
+++ b/core/src/trezor/_proto_messages.mako
@@ -41,20 +41,20 @@ def member_type(field):
     class ${message.name}(protobuf.MessageType):
 % if message.fields:
 % for field in message.fields:
-        ${field.name}: ${member_type(field)}
+        ${field.name}: "${member_type(field)}"
 % endfor
 
         def __init__(
             self,
             *,
 % for field in required_fields:
-            ${field.name}: ${field.python_type},
+            ${field.name}: "${field.python_type}",
 % endfor
 % for field in repeated_fields:
-            ${field.name}: list[${field.python_type}] | None = None,
+            ${field.name}: "list[${field.python_type}] | None" = None,
 % endfor
 % for field in optional_fields:
-            ${field.name}: ${field.python_type} | None = None,
+            ${field.name}: "${field.python_type} | None" = None,
 % endfor
         ) -> None:
             pass

--- a/core/src/trezor/messages.py
+++ b/core/src/trezor/messages.py
@@ -49,14 +49,14 @@ if TYPE_CHECKING:
     from trezor.enums import WordRequestType  # noqa: F401
 
     class BinanceGetAddress(protobuf.MessageType):
-        address_n: list[int]
-        show_display: bool | None
+        address_n: "list[int]"
+        show_display: "bool | None"
 
         def __init__(
             self,
             *,
-            address_n: list[int] | None = None,
-            show_display: bool | None = None,
+            address_n: "list[int] | None" = None,
+            show_display: "bool | None" = None,
         ) -> None:
             pass
 
@@ -65,12 +65,12 @@ if TYPE_CHECKING:
             return isinstance(msg, cls)
 
     class BinanceAddress(protobuf.MessageType):
-        address: str
+        address: "str"
 
         def __init__(
             self,
             *,
-            address: str,
+            address: "str",
         ) -> None:
             pass
 
@@ -79,14 +79,14 @@ if TYPE_CHECKING:
             return isinstance(msg, cls)
 
     class BinanceGetPublicKey(protobuf.MessageType):
-        address_n: list[int]
-        show_display: bool | None
+        address_n: "list[int]"
+        show_display: "bool | None"
 
         def __init__(
             self,
             *,
-            address_n: list[int] | None = None,
-            show_display: bool | None = None,
+            address_n: "list[int] | None" = None,
+            show_display: "bool | None" = None,
         ) -> None:
             pass
 
@@ -95,12 +95,12 @@ if TYPE_CHECKING:
             return isinstance(msg, cls)
 
     class BinancePublicKey(protobuf.MessageType):
-        public_key: bytes
+        public_key: "bytes"
 
         def __init__(
             self,
             *,
-            public_key: bytes,
+            public_key: "bytes",
         ) -> None:
             pass
 
@@ -109,24 +109,24 @@ if TYPE_CHECKING:
             return isinstance(msg, cls)
 
     class BinanceSignTx(protobuf.MessageType):
-        address_n: list[int]
-        msg_count: int | None
-        account_number: int | None
-        chain_id: str | None
-        memo: str | None
-        sequence: int | None
-        source: int | None
+        address_n: "list[int]"
+        msg_count: "int | None"
+        account_number: "int | None"
+        chain_id: "str | None"
+        memo: "str | None"
+        sequence: "int | None"
+        source: "int | None"
 
         def __init__(
             self,
             *,
-            address_n: list[int] | None = None,
-            msg_count: int | None = None,
-            account_number: int | None = None,
-            chain_id: str | None = None,
-            memo: str | None = None,
-            sequence: int | None = None,
-            source: int | None = None,
+            address_n: "list[int] | None" = None,
+            msg_count: "int | None" = None,
+            account_number: "int | None" = None,
+            chain_id: "str | None" = None,
+            memo: "str | None" = None,
+            sequence: "int | None" = None,
+            source: "int | None" = None,
         ) -> None:
             pass
 
@@ -140,47 +140,15 @@ if TYPE_CHECKING:
         def is_type_of(cls, msg: protobuf.MessageType) -> TypeGuard["BinanceTxRequest"]:
             return isinstance(msg, cls)
 
-    class BinanceCoin(protobuf.MessageType):
-        amount: int | None
-        denom: str | None
-
-        def __init__(
-            self,
-            *,
-            amount: int | None = None,
-            denom: str | None = None,
-        ) -> None:
-            pass
-
-        @classmethod
-        def is_type_of(cls, msg: protobuf.MessageType) -> TypeGuard["BinanceCoin"]:
-            return isinstance(msg, cls)
-
-    class BinanceInputOutput(protobuf.MessageType):
-        address: str | None
-        coins: list[BinanceCoin]
-
-        def __init__(
-            self,
-            *,
-            coins: list[BinanceCoin] | None = None,
-            address: str | None = None,
-        ) -> None:
-            pass
-
-        @classmethod
-        def is_type_of(cls, msg: protobuf.MessageType) -> TypeGuard["BinanceInputOutput"]:
-            return isinstance(msg, cls)
-
     class BinanceTransferMsg(protobuf.MessageType):
-        inputs: list[BinanceInputOutput]
-        outputs: list[BinanceInputOutput]
+        inputs: "list[BinanceInputOutput]"
+        outputs: "list[BinanceInputOutput]"
 
         def __init__(
             self,
             *,
-            inputs: list[BinanceInputOutput] | None = None,
-            outputs: list[BinanceInputOutput] | None = None,
+            inputs: "list[BinanceInputOutput] | None" = None,
+            outputs: "list[BinanceInputOutput] | None" = None,
         ) -> None:
             pass
 
@@ -189,26 +157,26 @@ if TYPE_CHECKING:
             return isinstance(msg, cls)
 
     class BinanceOrderMsg(protobuf.MessageType):
-        id: str | None
-        ordertype: BinanceOrderType | None
-        price: int | None
-        quantity: int | None
-        sender: str | None
-        side: BinanceOrderSide | None
-        symbol: str | None
-        timeinforce: BinanceTimeInForce | None
+        id: "str | None"
+        ordertype: "BinanceOrderType | None"
+        price: "int | None"
+        quantity: "int | None"
+        sender: "str | None"
+        side: "BinanceOrderSide | None"
+        symbol: "str | None"
+        timeinforce: "BinanceTimeInForce | None"
 
         def __init__(
             self,
             *,
-            id: str | None = None,
-            ordertype: BinanceOrderType | None = None,
-            price: int | None = None,
-            quantity: int | None = None,
-            sender: str | None = None,
-            side: BinanceOrderSide | None = None,
-            symbol: str | None = None,
-            timeinforce: BinanceTimeInForce | None = None,
+            id: "str | None" = None,
+            ordertype: "BinanceOrderType | None" = None,
+            price: "int | None" = None,
+            quantity: "int | None" = None,
+            sender: "str | None" = None,
+            side: "BinanceOrderSide | None" = None,
+            symbol: "str | None" = None,
+            timeinforce: "BinanceTimeInForce | None" = None,
         ) -> None:
             pass
 
@@ -217,16 +185,16 @@ if TYPE_CHECKING:
             return isinstance(msg, cls)
 
     class BinanceCancelMsg(protobuf.MessageType):
-        refid: str | None
-        sender: str | None
-        symbol: str | None
+        refid: "str | None"
+        sender: "str | None"
+        symbol: "str | None"
 
         def __init__(
             self,
             *,
-            refid: str | None = None,
-            sender: str | None = None,
-            symbol: str | None = None,
+            refid: "str | None" = None,
+            sender: "str | None" = None,
+            symbol: "str | None" = None,
         ) -> None:
             pass
 
@@ -235,14 +203,14 @@ if TYPE_CHECKING:
             return isinstance(msg, cls)
 
     class BinanceSignedTx(protobuf.MessageType):
-        signature: bytes
-        public_key: bytes
+        signature: "bytes"
+        public_key: "bytes"
 
         def __init__(
             self,
             *,
-            signature: bytes,
-            public_key: bytes,
+            signature: "bytes",
+            public_key: "bytes",
         ) -> None:
             pass
 
@@ -250,13 +218,45 @@ if TYPE_CHECKING:
         def is_type_of(cls, msg: protobuf.MessageType) -> TypeGuard["BinanceSignedTx"]:
             return isinstance(msg, cls)
 
-    class Success(protobuf.MessageType):
-        message: str
+    class BinanceInputOutput(protobuf.MessageType):
+        address: "str | None"
+        coins: "list[BinanceCoin]"
 
         def __init__(
             self,
             *,
-            message: str | None = None,
+            coins: "list[BinanceCoin] | None" = None,
+            address: "str | None" = None,
+        ) -> None:
+            pass
+
+        @classmethod
+        def is_type_of(cls, msg: protobuf.MessageType) -> TypeGuard["BinanceInputOutput"]:
+            return isinstance(msg, cls)
+
+    class BinanceCoin(protobuf.MessageType):
+        amount: "int | None"
+        denom: "str | None"
+
+        def __init__(
+            self,
+            *,
+            amount: "int | None" = None,
+            denom: "str | None" = None,
+        ) -> None:
+            pass
+
+        @classmethod
+        def is_type_of(cls, msg: protobuf.MessageType) -> TypeGuard["BinanceCoin"]:
+            return isinstance(msg, cls)
+
+    class Success(protobuf.MessageType):
+        message: "str"
+
+        def __init__(
+            self,
+            *,
+            message: "str | None" = None,
         ) -> None:
             pass
 
@@ -265,14 +265,14 @@ if TYPE_CHECKING:
             return isinstance(msg, cls)
 
     class Failure(protobuf.MessageType):
-        code: FailureType | None
-        message: str | None
+        code: "FailureType | None"
+        message: "str | None"
 
         def __init__(
             self,
             *,
-            code: FailureType | None = None,
-            message: str | None = None,
+            code: "FailureType | None" = None,
+            message: "str | None" = None,
         ) -> None:
             pass
 
@@ -281,14 +281,14 @@ if TYPE_CHECKING:
             return isinstance(msg, cls)
 
     class ButtonRequest(protobuf.MessageType):
-        code: ButtonRequestType | None
-        pages: int | None
+        code: "ButtonRequestType | None"
+        pages: "int | None"
 
         def __init__(
             self,
             *,
-            code: ButtonRequestType | None = None,
-            pages: int | None = None,
+            code: "ButtonRequestType | None" = None,
+            pages: "int | None" = None,
         ) -> None:
             pass
 
@@ -303,12 +303,12 @@ if TYPE_CHECKING:
             return isinstance(msg, cls)
 
     class PinMatrixRequest(protobuf.MessageType):
-        type: PinMatrixRequestType | None
+        type: "PinMatrixRequestType | None"
 
         def __init__(
             self,
             *,
-            type: PinMatrixRequestType | None = None,
+            type: "PinMatrixRequestType | None" = None,
         ) -> None:
             pass
 
@@ -317,12 +317,12 @@ if TYPE_CHECKING:
             return isinstance(msg, cls)
 
     class PinMatrixAck(protobuf.MessageType):
-        pin: str
+        pin: "str"
 
         def __init__(
             self,
             *,
-            pin: str,
+            pin: "str",
         ) -> None:
             pass
 
@@ -337,14 +337,14 @@ if TYPE_CHECKING:
             return isinstance(msg, cls)
 
     class PassphraseAck(protobuf.MessageType):
-        passphrase: str | None
-        on_device: bool | None
+        passphrase: "str | None"
+        on_device: "bool | None"
 
         def __init__(
             self,
             *,
-            passphrase: str | None = None,
-            on_device: bool | None = None,
+            passphrase: "str | None" = None,
+            on_device: "bool | None" = None,
         ) -> None:
             pass
 
@@ -353,22 +353,22 @@ if TYPE_CHECKING:
             return isinstance(msg, cls)
 
     class HDNodeType(protobuf.MessageType):
-        depth: int
-        fingerprint: int
-        child_num: int
-        chain_code: bytes
-        private_key: bytes | None
-        public_key: bytes
+        depth: "int"
+        fingerprint: "int"
+        child_num: "int"
+        chain_code: "bytes"
+        private_key: "bytes | None"
+        public_key: "bytes"
 
         def __init__(
             self,
             *,
-            depth: int,
-            fingerprint: int,
-            child_num: int,
-            chain_code: bytes,
-            public_key: bytes,
-            private_key: bytes | None = None,
+            depth: "int",
+            fingerprint: "int",
+            child_num: "int",
+            chain_code: "bytes",
+            public_key: "bytes",
+            private_key: "bytes | None" = None,
         ) -> None:
             pass
 
@@ -376,37 +376,21 @@ if TYPE_CHECKING:
         def is_type_of(cls, msg: protobuf.MessageType) -> TypeGuard["HDNodeType"]:
             return isinstance(msg, cls)
 
-    class HDNodePathType(protobuf.MessageType):
-        node: HDNodeType
-        address_n: list[int]
-
-        def __init__(
-            self,
-            *,
-            node: HDNodeType,
-            address_n: list[int] | None = None,
-        ) -> None:
-            pass
-
-        @classmethod
-        def is_type_of(cls, msg: protobuf.MessageType) -> TypeGuard["HDNodePathType"]:
-            return isinstance(msg, cls)
-
     class MultisigRedeemScriptType(protobuf.MessageType):
-        pubkeys: list[HDNodePathType]
-        signatures: list[bytes]
-        m: int
-        nodes: list[HDNodeType]
-        address_n: list[int]
+        pubkeys: "list[HDNodePathType]"
+        signatures: "list[bytes]"
+        m: "int"
+        nodes: "list[HDNodeType]"
+        address_n: "list[int]"
 
         def __init__(
             self,
             *,
-            m: int,
-            pubkeys: list[HDNodePathType] | None = None,
-            signatures: list[bytes] | None = None,
-            nodes: list[HDNodeType] | None = None,
-            address_n: list[int] | None = None,
+            m: "int",
+            pubkeys: "list[HDNodePathType] | None" = None,
+            signatures: "list[bytes] | None" = None,
+            nodes: "list[HDNodeType] | None" = None,
+            address_n: "list[int] | None" = None,
         ) -> None:
             pass
 
@@ -415,22 +399,22 @@ if TYPE_CHECKING:
             return isinstance(msg, cls)
 
     class GetPublicKey(protobuf.MessageType):
-        address_n: list[int]
-        ecdsa_curve_name: str | None
-        show_display: bool | None
-        coin_name: str
-        script_type: InputScriptType
-        ignore_xpub_magic: bool | None
+        address_n: "list[int]"
+        ecdsa_curve_name: "str | None"
+        show_display: "bool | None"
+        coin_name: "str"
+        script_type: "InputScriptType"
+        ignore_xpub_magic: "bool | None"
 
         def __init__(
             self,
             *,
-            address_n: list[int] | None = None,
-            ecdsa_curve_name: str | None = None,
-            show_display: bool | None = None,
-            coin_name: str | None = None,
-            script_type: InputScriptType | None = None,
-            ignore_xpub_magic: bool | None = None,
+            address_n: "list[int] | None" = None,
+            ecdsa_curve_name: "str | None" = None,
+            show_display: "bool | None" = None,
+            coin_name: "str | None" = None,
+            script_type: "InputScriptType | None" = None,
+            ignore_xpub_magic: "bool | None" = None,
         ) -> None:
             pass
 
@@ -439,16 +423,16 @@ if TYPE_CHECKING:
             return isinstance(msg, cls)
 
     class PublicKey(protobuf.MessageType):
-        node: HDNodeType
-        xpub: str
-        root_fingerprint: int | None
+        node: "HDNodeType"
+        xpub: "str"
+        root_fingerprint: "int | None"
 
         def __init__(
             self,
             *,
-            node: HDNodeType,
-            xpub: str,
-            root_fingerprint: int | None = None,
+            node: "HDNodeType",
+            xpub: "str",
+            root_fingerprint: "int | None" = None,
         ) -> None:
             pass
 
@@ -457,22 +441,22 @@ if TYPE_CHECKING:
             return isinstance(msg, cls)
 
     class GetAddress(protobuf.MessageType):
-        address_n: list[int]
-        coin_name: str
-        show_display: bool | None
-        multisig: MultisigRedeemScriptType | None
-        script_type: InputScriptType
-        ignore_xpub_magic: bool | None
+        address_n: "list[int]"
+        coin_name: "str"
+        show_display: "bool | None"
+        multisig: "MultisigRedeemScriptType | None"
+        script_type: "InputScriptType"
+        ignore_xpub_magic: "bool | None"
 
         def __init__(
             self,
             *,
-            address_n: list[int] | None = None,
-            coin_name: str | None = None,
-            show_display: bool | None = None,
-            multisig: MultisigRedeemScriptType | None = None,
-            script_type: InputScriptType | None = None,
-            ignore_xpub_magic: bool | None = None,
+            address_n: "list[int] | None" = None,
+            coin_name: "str | None" = None,
+            show_display: "bool | None" = None,
+            multisig: "MultisigRedeemScriptType | None" = None,
+            script_type: "InputScriptType | None" = None,
+            ignore_xpub_magic: "bool | None" = None,
         ) -> None:
             pass
 
@@ -481,12 +465,12 @@ if TYPE_CHECKING:
             return isinstance(msg, cls)
 
     class Address(protobuf.MessageType):
-        address: str
+        address: "str"
 
         def __init__(
             self,
             *,
-            address: str,
+            address: "str",
         ) -> None:
             pass
 
@@ -495,18 +479,18 @@ if TYPE_CHECKING:
             return isinstance(msg, cls)
 
     class GetOwnershipId(protobuf.MessageType):
-        address_n: list[int]
-        coin_name: str
-        multisig: MultisigRedeemScriptType | None
-        script_type: InputScriptType
+        address_n: "list[int]"
+        coin_name: "str"
+        multisig: "MultisigRedeemScriptType | None"
+        script_type: "InputScriptType"
 
         def __init__(
             self,
             *,
-            address_n: list[int] | None = None,
-            coin_name: str | None = None,
-            multisig: MultisigRedeemScriptType | None = None,
-            script_type: InputScriptType | None = None,
+            address_n: "list[int] | None" = None,
+            coin_name: "str | None" = None,
+            multisig: "MultisigRedeemScriptType | None" = None,
+            script_type: "InputScriptType | None" = None,
         ) -> None:
             pass
 
@@ -515,12 +499,12 @@ if TYPE_CHECKING:
             return isinstance(msg, cls)
 
     class OwnershipId(protobuf.MessageType):
-        ownership_id: bytes
+        ownership_id: "bytes"
 
         def __init__(
             self,
             *,
-            ownership_id: bytes,
+            ownership_id: "bytes",
         ) -> None:
             pass
 
@@ -529,18 +513,18 @@ if TYPE_CHECKING:
             return isinstance(msg, cls)
 
     class SignMessage(protobuf.MessageType):
-        address_n: list[int]
-        message: bytes
-        coin_name: str
-        script_type: InputScriptType
+        address_n: "list[int]"
+        message: "bytes"
+        coin_name: "str"
+        script_type: "InputScriptType"
 
         def __init__(
             self,
             *,
-            message: bytes,
-            address_n: list[int] | None = None,
-            coin_name: str | None = None,
-            script_type: InputScriptType | None = None,
+            message: "bytes",
+            address_n: "list[int] | None" = None,
+            coin_name: "str | None" = None,
+            script_type: "InputScriptType | None" = None,
         ) -> None:
             pass
 
@@ -549,14 +533,14 @@ if TYPE_CHECKING:
             return isinstance(msg, cls)
 
     class MessageSignature(protobuf.MessageType):
-        address: str
-        signature: bytes
+        address: "str"
+        signature: "bytes"
 
         def __init__(
             self,
             *,
-            address: str,
-            signature: bytes,
+            address: "str",
+            signature: "bytes",
         ) -> None:
             pass
 
@@ -565,18 +549,18 @@ if TYPE_CHECKING:
             return isinstance(msg, cls)
 
     class VerifyMessage(protobuf.MessageType):
-        address: str
-        signature: bytes
-        message: bytes
-        coin_name: str
+        address: "str"
+        signature: "bytes"
+        message: "bytes"
+        coin_name: "str"
 
         def __init__(
             self,
             *,
-            address: str,
-            signature: bytes,
-            message: bytes,
-            coin_name: str | None = None,
+            address: "str",
+            signature: "bytes",
+            message: "bytes",
+            coin_name: "str | None" = None,
         ) -> None:
             pass
 
@@ -585,32 +569,32 @@ if TYPE_CHECKING:
             return isinstance(msg, cls)
 
     class SignTx(protobuf.MessageType):
-        outputs_count: int
-        inputs_count: int
-        coin_name: str
-        version: int
-        lock_time: int
-        expiry: int | None
-        version_group_id: int | None
-        timestamp: int | None
-        branch_id: int | None
-        amount_unit: AmountUnit
-        decred_staking_ticket: bool
+        outputs_count: "int"
+        inputs_count: "int"
+        coin_name: "str"
+        version: "int"
+        lock_time: "int"
+        expiry: "int | None"
+        version_group_id: "int | None"
+        timestamp: "int | None"
+        branch_id: "int | None"
+        amount_unit: "AmountUnit"
+        decred_staking_ticket: "bool"
 
         def __init__(
             self,
             *,
-            outputs_count: int,
-            inputs_count: int,
-            coin_name: str | None = None,
-            version: int | None = None,
-            lock_time: int | None = None,
-            expiry: int | None = None,
-            version_group_id: int | None = None,
-            timestamp: int | None = None,
-            branch_id: int | None = None,
-            amount_unit: AmountUnit | None = None,
-            decred_staking_ticket: bool | None = None,
+            outputs_count: "int",
+            inputs_count: "int",
+            coin_name: "str | None" = None,
+            version: "int | None" = None,
+            lock_time: "int | None" = None,
+            expiry: "int | None" = None,
+            version_group_id: "int | None" = None,
+            timestamp: "int | None" = None,
+            branch_id: "int | None" = None,
+            amount_unit: "AmountUnit | None" = None,
+            decred_staking_ticket: "bool | None" = None,
         ) -> None:
             pass
 
@@ -618,55 +602,17 @@ if TYPE_CHECKING:
         def is_type_of(cls, msg: protobuf.MessageType) -> TypeGuard["SignTx"]:
             return isinstance(msg, cls)
 
-    class TxRequestDetailsType(protobuf.MessageType):
-        request_index: int | None
-        tx_hash: bytes | None
-        extra_data_len: int | None
-        extra_data_offset: int | None
-
-        def __init__(
-            self,
-            *,
-            request_index: int | None = None,
-            tx_hash: bytes | None = None,
-            extra_data_len: int | None = None,
-            extra_data_offset: int | None = None,
-        ) -> None:
-            pass
-
-        @classmethod
-        def is_type_of(cls, msg: protobuf.MessageType) -> TypeGuard["TxRequestDetailsType"]:
-            return isinstance(msg, cls)
-
-    class TxRequestSerializedType(protobuf.MessageType):
-        signature_index: int | None
-        signature: bytes | None
-        serialized_tx: bytes | None
-
-        def __init__(
-            self,
-            *,
-            signature_index: int | None = None,
-            signature: bytes | None = None,
-            serialized_tx: bytes | None = None,
-        ) -> None:
-            pass
-
-        @classmethod
-        def is_type_of(cls, msg: protobuf.MessageType) -> TypeGuard["TxRequestSerializedType"]:
-            return isinstance(msg, cls)
-
     class TxRequest(protobuf.MessageType):
-        request_type: RequestType | None
-        details: TxRequestDetailsType | None
-        serialized: TxRequestSerializedType | None
+        request_type: "RequestType | None"
+        details: "TxRequestDetailsType | None"
+        serialized: "TxRequestSerializedType | None"
 
         def __init__(
             self,
             *,
-            request_type: RequestType | None = None,
-            details: TxRequestDetailsType | None = None,
-            serialized: TxRequestSerializedType | None = None,
+            request_type: "RequestType | None" = None,
+            details: "TxRequestDetailsType | None" = None,
+            serialized: "TxRequestSerializedType | None" = None,
         ) -> None:
             pass
 
@@ -675,40 +621,40 @@ if TYPE_CHECKING:
             return isinstance(msg, cls)
 
     class TxInput(protobuf.MessageType):
-        address_n: list[int]
-        prev_hash: bytes
-        prev_index: int
-        script_sig: bytes | None
-        sequence: int
-        script_type: InputScriptType
-        multisig: MultisigRedeemScriptType | None
-        amount: int
-        decred_tree: int | None
-        witness: bytes | None
-        ownership_proof: bytes | None
-        commitment_data: bytes | None
-        orig_hash: bytes | None
-        orig_index: int | None
-        decred_staking_spend: DecredStakingSpendType | None
+        address_n: "list[int]"
+        prev_hash: "bytes"
+        prev_index: "int"
+        script_sig: "bytes | None"
+        sequence: "int"
+        script_type: "InputScriptType"
+        multisig: "MultisigRedeemScriptType | None"
+        amount: "int"
+        decred_tree: "int | None"
+        witness: "bytes | None"
+        ownership_proof: "bytes | None"
+        commitment_data: "bytes | None"
+        orig_hash: "bytes | None"
+        orig_index: "int | None"
+        decred_staking_spend: "DecredStakingSpendType | None"
 
         def __init__(
             self,
             *,
-            prev_hash: bytes,
-            prev_index: int,
-            amount: int,
-            address_n: list[int] | None = None,
-            script_sig: bytes | None = None,
-            sequence: int | None = None,
-            script_type: InputScriptType | None = None,
-            multisig: MultisigRedeemScriptType | None = None,
-            decred_tree: int | None = None,
-            witness: bytes | None = None,
-            ownership_proof: bytes | None = None,
-            commitment_data: bytes | None = None,
-            orig_hash: bytes | None = None,
-            orig_index: int | None = None,
-            decred_staking_spend: DecredStakingSpendType | None = None,
+            prev_hash: "bytes",
+            prev_index: "int",
+            amount: "int",
+            address_n: "list[int] | None" = None,
+            script_sig: "bytes | None" = None,
+            sequence: "int | None" = None,
+            script_type: "InputScriptType | None" = None,
+            multisig: "MultisigRedeemScriptType | None" = None,
+            decred_tree: "int | None" = None,
+            witness: "bytes | None" = None,
+            ownership_proof: "bytes | None" = None,
+            commitment_data: "bytes | None" = None,
+            orig_hash: "bytes | None" = None,
+            orig_index: "int | None" = None,
+            decred_staking_spend: "DecredStakingSpendType | None" = None,
         ) -> None:
             pass
 
@@ -717,26 +663,26 @@ if TYPE_CHECKING:
             return isinstance(msg, cls)
 
     class TxOutput(protobuf.MessageType):
-        address: str | None
-        address_n: list[int]
-        amount: int
-        script_type: OutputScriptType
-        multisig: MultisigRedeemScriptType | None
-        op_return_data: bytes | None
-        orig_hash: bytes | None
-        orig_index: int | None
+        address: "str | None"
+        address_n: "list[int]"
+        amount: "int"
+        script_type: "OutputScriptType"
+        multisig: "MultisigRedeemScriptType | None"
+        op_return_data: "bytes | None"
+        orig_hash: "bytes | None"
+        orig_index: "int | None"
 
         def __init__(
             self,
             *,
-            amount: int,
-            address_n: list[int] | None = None,
-            address: str | None = None,
-            script_type: OutputScriptType | None = None,
-            multisig: MultisigRedeemScriptType | None = None,
-            op_return_data: bytes | None = None,
-            orig_hash: bytes | None = None,
-            orig_index: int | None = None,
+            amount: "int",
+            address_n: "list[int] | None" = None,
+            address: "str | None" = None,
+            script_type: "OutputScriptType | None" = None,
+            multisig: "MultisigRedeemScriptType | None" = None,
+            op_return_data: "bytes | None" = None,
+            orig_hash: "bytes | None" = None,
+            orig_index: "int | None" = None,
         ) -> None:
             pass
 
@@ -745,28 +691,28 @@ if TYPE_CHECKING:
             return isinstance(msg, cls)
 
     class PrevTx(protobuf.MessageType):
-        version: int
-        lock_time: int
-        inputs_count: int
-        outputs_count: int
-        extra_data_len: int
-        expiry: int | None
-        version_group_id: int | None
-        timestamp: int | None
-        branch_id: int | None
+        version: "int"
+        lock_time: "int"
+        inputs_count: "int"
+        outputs_count: "int"
+        extra_data_len: "int"
+        expiry: "int | None"
+        version_group_id: "int | None"
+        timestamp: "int | None"
+        branch_id: "int | None"
 
         def __init__(
             self,
             *,
-            version: int,
-            lock_time: int,
-            inputs_count: int,
-            outputs_count: int,
-            extra_data_len: int | None = None,
-            expiry: int | None = None,
-            version_group_id: int | None = None,
-            timestamp: int | None = None,
-            branch_id: int | None = None,
+            version: "int",
+            lock_time: "int",
+            inputs_count: "int",
+            outputs_count: "int",
+            extra_data_len: "int | None" = None,
+            expiry: "int | None" = None,
+            version_group_id: "int | None" = None,
+            timestamp: "int | None" = None,
+            branch_id: "int | None" = None,
         ) -> None:
             pass
 
@@ -775,20 +721,20 @@ if TYPE_CHECKING:
             return isinstance(msg, cls)
 
     class PrevInput(protobuf.MessageType):
-        prev_hash: bytes
-        prev_index: int
-        script_sig: bytes
-        sequence: int
-        decred_tree: int | None
+        prev_hash: "bytes"
+        prev_index: "int"
+        script_sig: "bytes"
+        sequence: "int"
+        decred_tree: "int | None"
 
         def __init__(
             self,
             *,
-            prev_hash: bytes,
-            prev_index: int,
-            script_sig: bytes,
-            sequence: int,
-            decred_tree: int | None = None,
+            prev_hash: "bytes",
+            prev_index: "int",
+            script_sig: "bytes",
+            sequence: "int",
+            decred_tree: "int | None" = None,
         ) -> None:
             pass
 
@@ -797,16 +743,16 @@ if TYPE_CHECKING:
             return isinstance(msg, cls)
 
     class PrevOutput(protobuf.MessageType):
-        amount: int
-        script_pubkey: bytes
-        decred_script_version: int | None
+        amount: "int"
+        script_pubkey: "bytes"
+        decred_script_version: "int | None"
 
         def __init__(
             self,
             *,
-            amount: int,
-            script_pubkey: bytes,
-            decred_script_version: int | None = None,
+            amount: "int",
+            script_pubkey: "bytes",
+            decred_script_version: "int | None" = None,
         ) -> None:
             pass
 
@@ -814,27 +760,13 @@ if TYPE_CHECKING:
         def is_type_of(cls, msg: protobuf.MessageType) -> TypeGuard["PrevOutput"]:
             return isinstance(msg, cls)
 
-    class TxAckInputWrapper(protobuf.MessageType):
-        input: TxInput
-
-        def __init__(
-            self,
-            *,
-            input: TxInput,
-        ) -> None:
-            pass
-
-        @classmethod
-        def is_type_of(cls, msg: protobuf.MessageType) -> TypeGuard["TxAckInputWrapper"]:
-            return isinstance(msg, cls)
-
     class TxAckInput(protobuf.MessageType):
-        tx: TxAckInputWrapper
+        tx: "TxAckInputWrapper"
 
         def __init__(
             self,
             *,
-            tx: TxAckInputWrapper,
+            tx: "TxAckInputWrapper",
         ) -> None:
             pass
 
@@ -842,27 +774,13 @@ if TYPE_CHECKING:
         def is_type_of(cls, msg: protobuf.MessageType) -> TypeGuard["TxAckInput"]:
             return isinstance(msg, cls)
 
-    class TxAckOutputWrapper(protobuf.MessageType):
-        output: TxOutput
-
-        def __init__(
-            self,
-            *,
-            output: TxOutput,
-        ) -> None:
-            pass
-
-        @classmethod
-        def is_type_of(cls, msg: protobuf.MessageType) -> TypeGuard["TxAckOutputWrapper"]:
-            return isinstance(msg, cls)
-
     class TxAckOutput(protobuf.MessageType):
-        tx: TxAckOutputWrapper
+        tx: "TxAckOutputWrapper"
 
         def __init__(
             self,
             *,
-            tx: TxAckOutputWrapper,
+            tx: "TxAckOutputWrapper",
         ) -> None:
             pass
 
@@ -871,12 +789,12 @@ if TYPE_CHECKING:
             return isinstance(msg, cls)
 
     class TxAckPrevMeta(protobuf.MessageType):
-        tx: PrevTx
+        tx: "PrevTx"
 
         def __init__(
             self,
             *,
-            tx: PrevTx,
+            tx: "PrevTx",
         ) -> None:
             pass
 
@@ -884,27 +802,13 @@ if TYPE_CHECKING:
         def is_type_of(cls, msg: protobuf.MessageType) -> TypeGuard["TxAckPrevMeta"]:
             return isinstance(msg, cls)
 
-    class TxAckPrevInputWrapper(protobuf.MessageType):
-        input: PrevInput
-
-        def __init__(
-            self,
-            *,
-            input: PrevInput,
-        ) -> None:
-            pass
-
-        @classmethod
-        def is_type_of(cls, msg: protobuf.MessageType) -> TypeGuard["TxAckPrevInputWrapper"]:
-            return isinstance(msg, cls)
-
     class TxAckPrevInput(protobuf.MessageType):
-        tx: TxAckPrevInputWrapper
+        tx: "TxAckPrevInputWrapper"
 
         def __init__(
             self,
             *,
-            tx: TxAckPrevInputWrapper,
+            tx: "TxAckPrevInputWrapper",
         ) -> None:
             pass
 
@@ -912,27 +816,13 @@ if TYPE_CHECKING:
         def is_type_of(cls, msg: protobuf.MessageType) -> TypeGuard["TxAckPrevInput"]:
             return isinstance(msg, cls)
 
-    class TxAckPrevOutputWrapper(protobuf.MessageType):
-        output: PrevOutput
-
-        def __init__(
-            self,
-            *,
-            output: PrevOutput,
-        ) -> None:
-            pass
-
-        @classmethod
-        def is_type_of(cls, msg: protobuf.MessageType) -> TypeGuard["TxAckPrevOutputWrapper"]:
-            return isinstance(msg, cls)
-
     class TxAckPrevOutput(protobuf.MessageType):
-        tx: TxAckPrevOutputWrapper
+        tx: "TxAckPrevOutputWrapper"
 
         def __init__(
             self,
             *,
-            tx: TxAckPrevOutputWrapper,
+            tx: "TxAckPrevOutputWrapper",
         ) -> None:
             pass
 
@@ -940,27 +830,13 @@ if TYPE_CHECKING:
         def is_type_of(cls, msg: protobuf.MessageType) -> TypeGuard["TxAckPrevOutput"]:
             return isinstance(msg, cls)
 
-    class TxAckPrevExtraDataWrapper(protobuf.MessageType):
-        extra_data_chunk: bytes
-
-        def __init__(
-            self,
-            *,
-            extra_data_chunk: bytes,
-        ) -> None:
-            pass
-
-        @classmethod
-        def is_type_of(cls, msg: protobuf.MessageType) -> TypeGuard["TxAckPrevExtraDataWrapper"]:
-            return isinstance(msg, cls)
-
     class TxAckPrevExtraData(protobuf.MessageType):
-        tx: TxAckPrevExtraDataWrapper
+        tx: "TxAckPrevExtraDataWrapper"
 
         def __init__(
             self,
             *,
-            tx: TxAckPrevExtraDataWrapper,
+            tx: "TxAckPrevExtraDataWrapper",
         ) -> None:
             pass
 
@@ -969,24 +845,24 @@ if TYPE_CHECKING:
             return isinstance(msg, cls)
 
     class GetOwnershipProof(protobuf.MessageType):
-        address_n: list[int]
-        coin_name: str
-        script_type: InputScriptType
-        multisig: MultisigRedeemScriptType | None
-        user_confirmation: bool
-        ownership_ids: list[bytes]
-        commitment_data: bytes
+        address_n: "list[int]"
+        coin_name: "str"
+        script_type: "InputScriptType"
+        multisig: "MultisigRedeemScriptType | None"
+        user_confirmation: "bool"
+        ownership_ids: "list[bytes]"
+        commitment_data: "bytes"
 
         def __init__(
             self,
             *,
-            address_n: list[int] | None = None,
-            ownership_ids: list[bytes] | None = None,
-            coin_name: str | None = None,
-            script_type: InputScriptType | None = None,
-            multisig: MultisigRedeemScriptType | None = None,
-            user_confirmation: bool | None = None,
-            commitment_data: bytes | None = None,
+            address_n: "list[int] | None" = None,
+            ownership_ids: "list[bytes] | None" = None,
+            coin_name: "str | None" = None,
+            script_type: "InputScriptType | None" = None,
+            multisig: "MultisigRedeemScriptType | None" = None,
+            user_confirmation: "bool | None" = None,
+            commitment_data: "bytes | None" = None,
         ) -> None:
             pass
 
@@ -995,14 +871,14 @@ if TYPE_CHECKING:
             return isinstance(msg, cls)
 
     class OwnershipProof(protobuf.MessageType):
-        ownership_proof: bytes
-        signature: bytes
+        ownership_proof: "bytes"
+        signature: "bytes"
 
         def __init__(
             self,
             *,
-            ownership_proof: bytes,
-            signature: bytes,
+            ownership_proof: "bytes",
+            signature: "bytes",
         ) -> None:
             pass
 
@@ -1011,24 +887,24 @@ if TYPE_CHECKING:
             return isinstance(msg, cls)
 
     class AuthorizeCoinJoin(protobuf.MessageType):
-        coordinator: str
-        max_total_fee: int
-        fee_per_anonymity: int
-        address_n: list[int]
-        coin_name: str
-        script_type: InputScriptType
-        amount_unit: AmountUnit
+        coordinator: "str"
+        max_total_fee: "int"
+        fee_per_anonymity: "int"
+        address_n: "list[int]"
+        coin_name: "str"
+        script_type: "InputScriptType"
+        amount_unit: "AmountUnit"
 
         def __init__(
             self,
             *,
-            coordinator: str,
-            max_total_fee: int,
-            address_n: list[int] | None = None,
-            fee_per_anonymity: int | None = None,
-            coin_name: str | None = None,
-            script_type: InputScriptType | None = None,
-            amount_unit: AmountUnit | None = None,
+            coordinator: "str",
+            max_total_fee: "int",
+            address_n: "list[int] | None" = None,
+            fee_per_anonymity: "int | None" = None,
+            coin_name: "str | None" = None,
+            script_type: "InputScriptType | None" = None,
+            amount_unit: "AmountUnit | None" = None,
         ) -> None:
             pass
 
@@ -1036,17 +912,141 @@ if TYPE_CHECKING:
         def is_type_of(cls, msg: protobuf.MessageType) -> TypeGuard["AuthorizeCoinJoin"]:
             return isinstance(msg, cls)
 
-    class CardanoBlockchainPointerType(protobuf.MessageType):
-        block_index: int
-        tx_index: int
-        certificate_index: int
+    class HDNodePathType(protobuf.MessageType):
+        node: "HDNodeType"
+        address_n: "list[int]"
 
         def __init__(
             self,
             *,
-            block_index: int,
-            tx_index: int,
-            certificate_index: int,
+            node: "HDNodeType",
+            address_n: "list[int] | None" = None,
+        ) -> None:
+            pass
+
+        @classmethod
+        def is_type_of(cls, msg: protobuf.MessageType) -> TypeGuard["HDNodePathType"]:
+            return isinstance(msg, cls)
+
+    class TxRequestDetailsType(protobuf.MessageType):
+        request_index: "int | None"
+        tx_hash: "bytes | None"
+        extra_data_len: "int | None"
+        extra_data_offset: "int | None"
+
+        def __init__(
+            self,
+            *,
+            request_index: "int | None" = None,
+            tx_hash: "bytes | None" = None,
+            extra_data_len: "int | None" = None,
+            extra_data_offset: "int | None" = None,
+        ) -> None:
+            pass
+
+        @classmethod
+        def is_type_of(cls, msg: protobuf.MessageType) -> TypeGuard["TxRequestDetailsType"]:
+            return isinstance(msg, cls)
+
+    class TxRequestSerializedType(protobuf.MessageType):
+        signature_index: "int | None"
+        signature: "bytes | None"
+        serialized_tx: "bytes | None"
+
+        def __init__(
+            self,
+            *,
+            signature_index: "int | None" = None,
+            signature: "bytes | None" = None,
+            serialized_tx: "bytes | None" = None,
+        ) -> None:
+            pass
+
+        @classmethod
+        def is_type_of(cls, msg: protobuf.MessageType) -> TypeGuard["TxRequestSerializedType"]:
+            return isinstance(msg, cls)
+
+    class TxAckInputWrapper(protobuf.MessageType):
+        input: "TxInput"
+
+        def __init__(
+            self,
+            *,
+            input: "TxInput",
+        ) -> None:
+            pass
+
+        @classmethod
+        def is_type_of(cls, msg: protobuf.MessageType) -> TypeGuard["TxAckInputWrapper"]:
+            return isinstance(msg, cls)
+
+    class TxAckOutputWrapper(protobuf.MessageType):
+        output: "TxOutput"
+
+        def __init__(
+            self,
+            *,
+            output: "TxOutput",
+        ) -> None:
+            pass
+
+        @classmethod
+        def is_type_of(cls, msg: protobuf.MessageType) -> TypeGuard["TxAckOutputWrapper"]:
+            return isinstance(msg, cls)
+
+    class TxAckPrevInputWrapper(protobuf.MessageType):
+        input: "PrevInput"
+
+        def __init__(
+            self,
+            *,
+            input: "PrevInput",
+        ) -> None:
+            pass
+
+        @classmethod
+        def is_type_of(cls, msg: protobuf.MessageType) -> TypeGuard["TxAckPrevInputWrapper"]:
+            return isinstance(msg, cls)
+
+    class TxAckPrevOutputWrapper(protobuf.MessageType):
+        output: "PrevOutput"
+
+        def __init__(
+            self,
+            *,
+            output: "PrevOutput",
+        ) -> None:
+            pass
+
+        @classmethod
+        def is_type_of(cls, msg: protobuf.MessageType) -> TypeGuard["TxAckPrevOutputWrapper"]:
+            return isinstance(msg, cls)
+
+    class TxAckPrevExtraDataWrapper(protobuf.MessageType):
+        extra_data_chunk: "bytes"
+
+        def __init__(
+            self,
+            *,
+            extra_data_chunk: "bytes",
+        ) -> None:
+            pass
+
+        @classmethod
+        def is_type_of(cls, msg: protobuf.MessageType) -> TypeGuard["TxAckPrevExtraDataWrapper"]:
+            return isinstance(msg, cls)
+
+    class CardanoBlockchainPointerType(protobuf.MessageType):
+        block_index: "int"
+        tx_index: "int"
+        certificate_index: "int"
+
+        def __init__(
+            self,
+            *,
+            block_index: "int",
+            tx_index: "int",
+            certificate_index: "int",
         ) -> None:
             pass
 
@@ -1055,20 +1055,20 @@ if TYPE_CHECKING:
             return isinstance(msg, cls)
 
     class CardanoAddressParametersType(protobuf.MessageType):
-        address_type: CardanoAddressType
-        address_n: list[int]
-        address_n_staking: list[int]
-        staking_key_hash: bytes | None
-        certificate_pointer: CardanoBlockchainPointerType | None
+        address_type: "CardanoAddressType"
+        address_n: "list[int]"
+        address_n_staking: "list[int]"
+        staking_key_hash: "bytes | None"
+        certificate_pointer: "CardanoBlockchainPointerType | None"
 
         def __init__(
             self,
             *,
-            address_type: CardanoAddressType,
-            address_n: list[int] | None = None,
-            address_n_staking: list[int] | None = None,
-            staking_key_hash: bytes | None = None,
-            certificate_pointer: CardanoBlockchainPointerType | None = None,
+            address_type: "CardanoAddressType",
+            address_n: "list[int] | None" = None,
+            address_n_staking: "list[int] | None" = None,
+            staking_key_hash: "bytes | None" = None,
+            certificate_pointer: "CardanoBlockchainPointerType | None" = None,
         ) -> None:
             pass
 
@@ -1077,18 +1077,18 @@ if TYPE_CHECKING:
             return isinstance(msg, cls)
 
     class CardanoGetAddress(protobuf.MessageType):
-        show_display: bool
-        protocol_magic: int
-        network_id: int
-        address_parameters: CardanoAddressParametersType
+        show_display: "bool"
+        protocol_magic: "int"
+        network_id: "int"
+        address_parameters: "CardanoAddressParametersType"
 
         def __init__(
             self,
             *,
-            protocol_magic: int,
-            network_id: int,
-            address_parameters: CardanoAddressParametersType,
-            show_display: bool | None = None,
+            protocol_magic: "int",
+            network_id: "int",
+            address_parameters: "CardanoAddressParametersType",
+            show_display: "bool | None" = None,
         ) -> None:
             pass
 
@@ -1097,12 +1097,12 @@ if TYPE_CHECKING:
             return isinstance(msg, cls)
 
     class CardanoAddress(protobuf.MessageType):
-        address: str
+        address: "str"
 
         def __init__(
             self,
             *,
-            address: str,
+            address: "str",
         ) -> None:
             pass
 
@@ -1111,14 +1111,14 @@ if TYPE_CHECKING:
             return isinstance(msg, cls)
 
     class CardanoGetPublicKey(protobuf.MessageType):
-        address_n: list[int]
-        show_display: bool | None
+        address_n: "list[int]"
+        show_display: "bool | None"
 
         def __init__(
             self,
             *,
-            address_n: list[int] | None = None,
-            show_display: bool | None = None,
+            address_n: "list[int] | None" = None,
+            show_display: "bool | None" = None,
         ) -> None:
             pass
 
@@ -1127,14 +1127,14 @@ if TYPE_CHECKING:
             return isinstance(msg, cls)
 
     class CardanoPublicKey(protobuf.MessageType):
-        xpub: str
-        node: HDNodeType
+        xpub: "str"
+        node: "HDNodeType"
 
         def __init__(
             self,
             *,
-            xpub: str,
-            node: HDNodeType,
+            xpub: "str",
+            node: "HDNodeType",
         ) -> None:
             pass
 
@@ -1142,259 +1142,31 @@ if TYPE_CHECKING:
         def is_type_of(cls, msg: protobuf.MessageType) -> TypeGuard["CardanoPublicKey"]:
             return isinstance(msg, cls)
 
-    class CardanoTxInputType(protobuf.MessageType):
-        address_n: list[int]
-        prev_hash: bytes
-        prev_index: int
-
-        def __init__(
-            self,
-            *,
-            prev_hash: bytes,
-            prev_index: int,
-            address_n: list[int] | None = None,
-        ) -> None:
-            pass
-
-        @classmethod
-        def is_type_of(cls, msg: protobuf.MessageType) -> TypeGuard["CardanoTxInputType"]:
-            return isinstance(msg, cls)
-
-    class CardanoTokenType(protobuf.MessageType):
-        asset_name_bytes: bytes
-        amount: int
-
-        def __init__(
-            self,
-            *,
-            asset_name_bytes: bytes,
-            amount: int,
-        ) -> None:
-            pass
-
-        @classmethod
-        def is_type_of(cls, msg: protobuf.MessageType) -> TypeGuard["CardanoTokenType"]:
-            return isinstance(msg, cls)
-
-    class CardanoAssetGroupType(protobuf.MessageType):
-        policy_id: bytes
-        tokens: list[CardanoTokenType]
-
-        def __init__(
-            self,
-            *,
-            policy_id: bytes,
-            tokens: list[CardanoTokenType] | None = None,
-        ) -> None:
-            pass
-
-        @classmethod
-        def is_type_of(cls, msg: protobuf.MessageType) -> TypeGuard["CardanoAssetGroupType"]:
-            return isinstance(msg, cls)
-
-    class CardanoTxOutputType(protobuf.MessageType):
-        address: str | None
-        amount: int
-        address_parameters: CardanoAddressParametersType | None
-        token_bundle: list[CardanoAssetGroupType]
-
-        def __init__(
-            self,
-            *,
-            amount: int,
-            token_bundle: list[CardanoAssetGroupType] | None = None,
-            address: str | None = None,
-            address_parameters: CardanoAddressParametersType | None = None,
-        ) -> None:
-            pass
-
-        @classmethod
-        def is_type_of(cls, msg: protobuf.MessageType) -> TypeGuard["CardanoTxOutputType"]:
-            return isinstance(msg, cls)
-
-    class CardanoPoolOwnerType(protobuf.MessageType):
-        staking_key_path: list[int]
-        staking_key_hash: bytes | None
-
-        def __init__(
-            self,
-            *,
-            staking_key_path: list[int] | None = None,
-            staking_key_hash: bytes | None = None,
-        ) -> None:
-            pass
-
-        @classmethod
-        def is_type_of(cls, msg: protobuf.MessageType) -> TypeGuard["CardanoPoolOwnerType"]:
-            return isinstance(msg, cls)
-
-    class CardanoPoolRelayParametersType(protobuf.MessageType):
-        type: CardanoPoolRelayType
-        ipv4_address: bytes | None
-        ipv6_address: bytes | None
-        host_name: str | None
-        port: int | None
-
-        def __init__(
-            self,
-            *,
-            type: CardanoPoolRelayType,
-            ipv4_address: bytes | None = None,
-            ipv6_address: bytes | None = None,
-            host_name: str | None = None,
-            port: int | None = None,
-        ) -> None:
-            pass
-
-        @classmethod
-        def is_type_of(cls, msg: protobuf.MessageType) -> TypeGuard["CardanoPoolRelayParametersType"]:
-            return isinstance(msg, cls)
-
-    class CardanoPoolMetadataType(protobuf.MessageType):
-        url: str
-        hash: bytes
-
-        def __init__(
-            self,
-            *,
-            url: str,
-            hash: bytes,
-        ) -> None:
-            pass
-
-        @classmethod
-        def is_type_of(cls, msg: protobuf.MessageType) -> TypeGuard["CardanoPoolMetadataType"]:
-            return isinstance(msg, cls)
-
-    class CardanoPoolParametersType(protobuf.MessageType):
-        pool_id: bytes
-        vrf_key_hash: bytes
-        pledge: int
-        cost: int
-        margin_numerator: int
-        margin_denominator: int
-        reward_account: str
-        owners: list[CardanoPoolOwnerType]
-        relays: list[CardanoPoolRelayParametersType]
-        metadata: CardanoPoolMetadataType | None
-
-        def __init__(
-            self,
-            *,
-            pool_id: bytes,
-            vrf_key_hash: bytes,
-            pledge: int,
-            cost: int,
-            margin_numerator: int,
-            margin_denominator: int,
-            reward_account: str,
-            owners: list[CardanoPoolOwnerType] | None = None,
-            relays: list[CardanoPoolRelayParametersType] | None = None,
-            metadata: CardanoPoolMetadataType | None = None,
-        ) -> None:
-            pass
-
-        @classmethod
-        def is_type_of(cls, msg: protobuf.MessageType) -> TypeGuard["CardanoPoolParametersType"]:
-            return isinstance(msg, cls)
-
-    class CardanoTxCertificateType(protobuf.MessageType):
-        type: CardanoCertificateType
-        path: list[int]
-        pool: bytes | None
-        pool_parameters: CardanoPoolParametersType | None
-
-        def __init__(
-            self,
-            *,
-            type: CardanoCertificateType,
-            path: list[int] | None = None,
-            pool: bytes | None = None,
-            pool_parameters: CardanoPoolParametersType | None = None,
-        ) -> None:
-            pass
-
-        @classmethod
-        def is_type_of(cls, msg: protobuf.MessageType) -> TypeGuard["CardanoTxCertificateType"]:
-            return isinstance(msg, cls)
-
-    class CardanoTxWithdrawalType(protobuf.MessageType):
-        path: list[int]
-        amount: int
-
-        def __init__(
-            self,
-            *,
-            amount: int,
-            path: list[int] | None = None,
-        ) -> None:
-            pass
-
-        @classmethod
-        def is_type_of(cls, msg: protobuf.MessageType) -> TypeGuard["CardanoTxWithdrawalType"]:
-            return isinstance(msg, cls)
-
-    class CardanoCatalystRegistrationParametersType(protobuf.MessageType):
-        voting_public_key: bytes
-        staking_path: list[int]
-        reward_address_parameters: CardanoAddressParametersType
-        nonce: int
-
-        def __init__(
-            self,
-            *,
-            voting_public_key: bytes,
-            reward_address_parameters: CardanoAddressParametersType,
-            nonce: int,
-            staking_path: list[int] | None = None,
-        ) -> None:
-            pass
-
-        @classmethod
-        def is_type_of(cls, msg: protobuf.MessageType) -> TypeGuard["CardanoCatalystRegistrationParametersType"]:
-            return isinstance(msg, cls)
-
-    class CardanoTxAuxiliaryDataType(protobuf.MessageType):
-        blob: bytes | None
-        catalyst_registration_parameters: CardanoCatalystRegistrationParametersType | None
-
-        def __init__(
-            self,
-            *,
-            blob: bytes | None = None,
-            catalyst_registration_parameters: CardanoCatalystRegistrationParametersType | None = None,
-        ) -> None:
-            pass
-
-        @classmethod
-        def is_type_of(cls, msg: protobuf.MessageType) -> TypeGuard["CardanoTxAuxiliaryDataType"]:
-            return isinstance(msg, cls)
-
     class CardanoSignTx(protobuf.MessageType):
-        inputs: list[CardanoTxInputType]
-        outputs: list[CardanoTxOutputType]
-        protocol_magic: int
-        fee: int
-        ttl: int | None
-        network_id: int
-        certificates: list[CardanoTxCertificateType]
-        withdrawals: list[CardanoTxWithdrawalType]
-        validity_interval_start: int | None
-        auxiliary_data: CardanoTxAuxiliaryDataType | None
+        inputs: "list[CardanoTxInputType]"
+        outputs: "list[CardanoTxOutputType]"
+        protocol_magic: "int"
+        fee: "int"
+        ttl: "int | None"
+        network_id: "int"
+        certificates: "list[CardanoTxCertificateType]"
+        withdrawals: "list[CardanoTxWithdrawalType]"
+        validity_interval_start: "int | None"
+        auxiliary_data: "CardanoTxAuxiliaryDataType | None"
 
         def __init__(
             self,
             *,
-            protocol_magic: int,
-            fee: int,
-            network_id: int,
-            inputs: list[CardanoTxInputType] | None = None,
-            outputs: list[CardanoTxOutputType] | None = None,
-            certificates: list[CardanoTxCertificateType] | None = None,
-            withdrawals: list[CardanoTxWithdrawalType] | None = None,
-            ttl: int | None = None,
-            validity_interval_start: int | None = None,
-            auxiliary_data: CardanoTxAuxiliaryDataType | None = None,
+            protocol_magic: "int",
+            fee: "int",
+            network_id: "int",
+            inputs: "list[CardanoTxInputType] | None" = None,
+            outputs: "list[CardanoTxOutputType] | None" = None,
+            certificates: "list[CardanoTxCertificateType] | None" = None,
+            withdrawals: "list[CardanoTxWithdrawalType] | None" = None,
+            ttl: "int | None" = None,
+            validity_interval_start: "int | None" = None,
+            auxiliary_data: "CardanoTxAuxiliaryDataType | None" = None,
         ) -> None:
             pass
 
@@ -1403,12 +1175,12 @@ if TYPE_CHECKING:
             return isinstance(msg, cls)
 
     class CardanoSignedTxChunk(protobuf.MessageType):
-        signed_tx_chunk: bytes
+        signed_tx_chunk: "bytes"
 
         def __init__(
             self,
             *,
-            signed_tx_chunk: bytes,
+            signed_tx_chunk: "bytes",
         ) -> None:
             pass
 
@@ -1423,14 +1195,14 @@ if TYPE_CHECKING:
             return isinstance(msg, cls)
 
     class CardanoSignedTx(protobuf.MessageType):
-        tx_hash: bytes
-        serialized_tx: bytes | None
+        tx_hash: "bytes"
+        serialized_tx: "bytes | None"
 
         def __init__(
             self,
             *,
-            tx_hash: bytes,
-            serialized_tx: bytes | None = None,
+            tx_hash: "bytes",
+            serialized_tx: "bytes | None" = None,
         ) -> None:
             pass
 
@@ -1438,25 +1210,253 @@ if TYPE_CHECKING:
         def is_type_of(cls, msg: protobuf.MessageType) -> TypeGuard["CardanoSignedTx"]:
             return isinstance(msg, cls)
 
-    class CipherKeyValue(protobuf.MessageType):
-        address_n: list[int]
-        key: str
-        value: bytes
-        encrypt: bool | None
-        ask_on_encrypt: bool | None
-        ask_on_decrypt: bool | None
-        iv: bytes | None
+    class CardanoTxInputType(protobuf.MessageType):
+        address_n: "list[int]"
+        prev_hash: "bytes"
+        prev_index: "int"
 
         def __init__(
             self,
             *,
-            key: str,
-            value: bytes,
-            address_n: list[int] | None = None,
-            encrypt: bool | None = None,
-            ask_on_encrypt: bool | None = None,
-            ask_on_decrypt: bool | None = None,
-            iv: bytes | None = None,
+            prev_hash: "bytes",
+            prev_index: "int",
+            address_n: "list[int] | None" = None,
+        ) -> None:
+            pass
+
+        @classmethod
+        def is_type_of(cls, msg: protobuf.MessageType) -> TypeGuard["CardanoTxInputType"]:
+            return isinstance(msg, cls)
+
+    class CardanoTxOutputType(protobuf.MessageType):
+        address: "str | None"
+        amount: "int"
+        address_parameters: "CardanoAddressParametersType | None"
+        token_bundle: "list[CardanoAssetGroupType]"
+
+        def __init__(
+            self,
+            *,
+            amount: "int",
+            token_bundle: "list[CardanoAssetGroupType] | None" = None,
+            address: "str | None" = None,
+            address_parameters: "CardanoAddressParametersType | None" = None,
+        ) -> None:
+            pass
+
+        @classmethod
+        def is_type_of(cls, msg: protobuf.MessageType) -> TypeGuard["CardanoTxOutputType"]:
+            return isinstance(msg, cls)
+
+    class CardanoAssetGroupType(protobuf.MessageType):
+        policy_id: "bytes"
+        tokens: "list[CardanoTokenType]"
+
+        def __init__(
+            self,
+            *,
+            policy_id: "bytes",
+            tokens: "list[CardanoTokenType] | None" = None,
+        ) -> None:
+            pass
+
+        @classmethod
+        def is_type_of(cls, msg: protobuf.MessageType) -> TypeGuard["CardanoAssetGroupType"]:
+            return isinstance(msg, cls)
+
+    class CardanoTokenType(protobuf.MessageType):
+        asset_name_bytes: "bytes"
+        amount: "int"
+
+        def __init__(
+            self,
+            *,
+            asset_name_bytes: "bytes",
+            amount: "int",
+        ) -> None:
+            pass
+
+        @classmethod
+        def is_type_of(cls, msg: protobuf.MessageType) -> TypeGuard["CardanoTokenType"]:
+            return isinstance(msg, cls)
+
+    class CardanoPoolOwnerType(protobuf.MessageType):
+        staking_key_path: "list[int]"
+        staking_key_hash: "bytes | None"
+
+        def __init__(
+            self,
+            *,
+            staking_key_path: "list[int] | None" = None,
+            staking_key_hash: "bytes | None" = None,
+        ) -> None:
+            pass
+
+        @classmethod
+        def is_type_of(cls, msg: protobuf.MessageType) -> TypeGuard["CardanoPoolOwnerType"]:
+            return isinstance(msg, cls)
+
+    class CardanoPoolRelayParametersType(protobuf.MessageType):
+        type: "CardanoPoolRelayType"
+        ipv4_address: "bytes | None"
+        ipv6_address: "bytes | None"
+        host_name: "str | None"
+        port: "int | None"
+
+        def __init__(
+            self,
+            *,
+            type: "CardanoPoolRelayType",
+            ipv4_address: "bytes | None" = None,
+            ipv6_address: "bytes | None" = None,
+            host_name: "str | None" = None,
+            port: "int | None" = None,
+        ) -> None:
+            pass
+
+        @classmethod
+        def is_type_of(cls, msg: protobuf.MessageType) -> TypeGuard["CardanoPoolRelayParametersType"]:
+            return isinstance(msg, cls)
+
+    class CardanoPoolMetadataType(protobuf.MessageType):
+        url: "str"
+        hash: "bytes"
+
+        def __init__(
+            self,
+            *,
+            url: "str",
+            hash: "bytes",
+        ) -> None:
+            pass
+
+        @classmethod
+        def is_type_of(cls, msg: protobuf.MessageType) -> TypeGuard["CardanoPoolMetadataType"]:
+            return isinstance(msg, cls)
+
+    class CardanoPoolParametersType(protobuf.MessageType):
+        pool_id: "bytes"
+        vrf_key_hash: "bytes"
+        pledge: "int"
+        cost: "int"
+        margin_numerator: "int"
+        margin_denominator: "int"
+        reward_account: "str"
+        owners: "list[CardanoPoolOwnerType]"
+        relays: "list[CardanoPoolRelayParametersType]"
+        metadata: "CardanoPoolMetadataType | None"
+
+        def __init__(
+            self,
+            *,
+            pool_id: "bytes",
+            vrf_key_hash: "bytes",
+            pledge: "int",
+            cost: "int",
+            margin_numerator: "int",
+            margin_denominator: "int",
+            reward_account: "str",
+            owners: "list[CardanoPoolOwnerType] | None" = None,
+            relays: "list[CardanoPoolRelayParametersType] | None" = None,
+            metadata: "CardanoPoolMetadataType | None" = None,
+        ) -> None:
+            pass
+
+        @classmethod
+        def is_type_of(cls, msg: protobuf.MessageType) -> TypeGuard["CardanoPoolParametersType"]:
+            return isinstance(msg, cls)
+
+    class CardanoTxCertificateType(protobuf.MessageType):
+        type: "CardanoCertificateType"
+        path: "list[int]"
+        pool: "bytes | None"
+        pool_parameters: "CardanoPoolParametersType | None"
+
+        def __init__(
+            self,
+            *,
+            type: "CardanoCertificateType",
+            path: "list[int] | None" = None,
+            pool: "bytes | None" = None,
+            pool_parameters: "CardanoPoolParametersType | None" = None,
+        ) -> None:
+            pass
+
+        @classmethod
+        def is_type_of(cls, msg: protobuf.MessageType) -> TypeGuard["CardanoTxCertificateType"]:
+            return isinstance(msg, cls)
+
+    class CardanoTxWithdrawalType(protobuf.MessageType):
+        path: "list[int]"
+        amount: "int"
+
+        def __init__(
+            self,
+            *,
+            amount: "int",
+            path: "list[int] | None" = None,
+        ) -> None:
+            pass
+
+        @classmethod
+        def is_type_of(cls, msg: protobuf.MessageType) -> TypeGuard["CardanoTxWithdrawalType"]:
+            return isinstance(msg, cls)
+
+    class CardanoCatalystRegistrationParametersType(protobuf.MessageType):
+        voting_public_key: "bytes"
+        staking_path: "list[int]"
+        reward_address_parameters: "CardanoAddressParametersType"
+        nonce: "int"
+
+        def __init__(
+            self,
+            *,
+            voting_public_key: "bytes",
+            reward_address_parameters: "CardanoAddressParametersType",
+            nonce: "int",
+            staking_path: "list[int] | None" = None,
+        ) -> None:
+            pass
+
+        @classmethod
+        def is_type_of(cls, msg: protobuf.MessageType) -> TypeGuard["CardanoCatalystRegistrationParametersType"]:
+            return isinstance(msg, cls)
+
+    class CardanoTxAuxiliaryDataType(protobuf.MessageType):
+        blob: "bytes | None"
+        catalyst_registration_parameters: "CardanoCatalystRegistrationParametersType | None"
+
+        def __init__(
+            self,
+            *,
+            blob: "bytes | None" = None,
+            catalyst_registration_parameters: "CardanoCatalystRegistrationParametersType | None" = None,
+        ) -> None:
+            pass
+
+        @classmethod
+        def is_type_of(cls, msg: protobuf.MessageType) -> TypeGuard["CardanoTxAuxiliaryDataType"]:
+            return isinstance(msg, cls)
+
+    class CipherKeyValue(protobuf.MessageType):
+        address_n: "list[int]"
+        key: "str"
+        value: "bytes"
+        encrypt: "bool | None"
+        ask_on_encrypt: "bool | None"
+        ask_on_decrypt: "bool | None"
+        iv: "bytes | None"
+
+        def __init__(
+            self,
+            *,
+            key: "str",
+            value: "bytes",
+            address_n: "list[int] | None" = None,
+            encrypt: "bool | None" = None,
+            ask_on_encrypt: "bool | None" = None,
+            ask_on_decrypt: "bool | None" = None,
+            iv: "bytes | None" = None,
         ) -> None:
             pass
 
@@ -1465,12 +1465,12 @@ if TYPE_CHECKING:
             return isinstance(msg, cls)
 
     class CipheredKeyValue(protobuf.MessageType):
-        value: bytes
+        value: "bytes"
 
         def __init__(
             self,
             *,
-            value: bytes,
+            value: "bytes",
         ) -> None:
             pass
 
@@ -1479,22 +1479,22 @@ if TYPE_CHECKING:
             return isinstance(msg, cls)
 
     class IdentityType(protobuf.MessageType):
-        proto: str | None
-        user: str | None
-        host: str | None
-        port: str | None
-        path: str | None
-        index: int
+        proto: "str | None"
+        user: "str | None"
+        host: "str | None"
+        port: "str | None"
+        path: "str | None"
+        index: "int"
 
         def __init__(
             self,
             *,
-            proto: str | None = None,
-            user: str | None = None,
-            host: str | None = None,
-            port: str | None = None,
-            path: str | None = None,
-            index: int | None = None,
+            proto: "str | None" = None,
+            user: "str | None" = None,
+            host: "str | None" = None,
+            port: "str | None" = None,
+            path: "str | None" = None,
+            index: "int | None" = None,
         ) -> None:
             pass
 
@@ -1503,18 +1503,18 @@ if TYPE_CHECKING:
             return isinstance(msg, cls)
 
     class SignIdentity(protobuf.MessageType):
-        identity: IdentityType
-        challenge_hidden: bytes
-        challenge_visual: str
-        ecdsa_curve_name: str | None
+        identity: "IdentityType"
+        challenge_hidden: "bytes"
+        challenge_visual: "str"
+        ecdsa_curve_name: "str | None"
 
         def __init__(
             self,
             *,
-            identity: IdentityType,
-            challenge_hidden: bytes | None = None,
-            challenge_visual: str | None = None,
-            ecdsa_curve_name: str | None = None,
+            identity: "IdentityType",
+            challenge_hidden: "bytes | None" = None,
+            challenge_visual: "str | None" = None,
+            ecdsa_curve_name: "str | None" = None,
         ) -> None:
             pass
 
@@ -1523,16 +1523,16 @@ if TYPE_CHECKING:
             return isinstance(msg, cls)
 
     class SignedIdentity(protobuf.MessageType):
-        address: str | None
-        public_key: bytes
-        signature: bytes
+        address: "str | None"
+        public_key: "bytes"
+        signature: "bytes"
 
         def __init__(
             self,
             *,
-            public_key: bytes,
-            signature: bytes,
-            address: str | None = None,
+            public_key: "bytes",
+            signature: "bytes",
+            address: "str | None" = None,
         ) -> None:
             pass
 
@@ -1541,16 +1541,16 @@ if TYPE_CHECKING:
             return isinstance(msg, cls)
 
     class GetECDHSessionKey(protobuf.MessageType):
-        identity: IdentityType
-        peer_public_key: bytes
-        ecdsa_curve_name: str | None
+        identity: "IdentityType"
+        peer_public_key: "bytes"
+        ecdsa_curve_name: "str | None"
 
         def __init__(
             self,
             *,
-            identity: IdentityType,
-            peer_public_key: bytes,
-            ecdsa_curve_name: str | None = None,
+            identity: "IdentityType",
+            peer_public_key: "bytes",
+            ecdsa_curve_name: "str | None" = None,
         ) -> None:
             pass
 
@@ -1559,14 +1559,14 @@ if TYPE_CHECKING:
             return isinstance(msg, cls)
 
     class ECDHSessionKey(protobuf.MessageType):
-        session_key: bytes
-        public_key: bytes | None
+        session_key: "bytes"
+        public_key: "bytes | None"
 
         def __init__(
             self,
             *,
-            session_key: bytes,
-            public_key: bytes | None = None,
+            session_key: "bytes",
+            public_key: "bytes | None" = None,
         ) -> None:
             pass
 
@@ -1575,14 +1575,14 @@ if TYPE_CHECKING:
             return isinstance(msg, cls)
 
     class CosiCommit(protobuf.MessageType):
-        address_n: list[int]
-        data: bytes | None
+        address_n: "list[int]"
+        data: "bytes | None"
 
         def __init__(
             self,
             *,
-            address_n: list[int] | None = None,
-            data: bytes | None = None,
+            address_n: "list[int] | None" = None,
+            data: "bytes | None" = None,
         ) -> None:
             pass
 
@@ -1591,14 +1591,14 @@ if TYPE_CHECKING:
             return isinstance(msg, cls)
 
     class CosiCommitment(protobuf.MessageType):
-        commitment: bytes | None
-        pubkey: bytes | None
+        commitment: "bytes | None"
+        pubkey: "bytes | None"
 
         def __init__(
             self,
             *,
-            commitment: bytes | None = None,
-            pubkey: bytes | None = None,
+            commitment: "bytes | None" = None,
+            pubkey: "bytes | None" = None,
         ) -> None:
             pass
 
@@ -1607,18 +1607,18 @@ if TYPE_CHECKING:
             return isinstance(msg, cls)
 
     class CosiSign(protobuf.MessageType):
-        address_n: list[int]
-        data: bytes | None
-        global_commitment: bytes | None
-        global_pubkey: bytes | None
+        address_n: "list[int]"
+        data: "bytes | None"
+        global_commitment: "bytes | None"
+        global_pubkey: "bytes | None"
 
         def __init__(
             self,
             *,
-            address_n: list[int] | None = None,
-            data: bytes | None = None,
-            global_commitment: bytes | None = None,
-            global_pubkey: bytes | None = None,
+            address_n: "list[int] | None" = None,
+            data: "bytes | None" = None,
+            global_commitment: "bytes | None" = None,
+            global_pubkey: "bytes | None" = None,
         ) -> None:
             pass
 
@@ -1627,12 +1627,12 @@ if TYPE_CHECKING:
             return isinstance(msg, cls)
 
     class CosiSignature(protobuf.MessageType):
-        signature: bytes
+        signature: "bytes"
 
         def __init__(
             self,
             *,
-            signature: bytes,
+            signature: "bytes",
         ) -> None:
             pass
 
@@ -1641,12 +1641,12 @@ if TYPE_CHECKING:
             return isinstance(msg, cls)
 
     class Initialize(protobuf.MessageType):
-        session_id: bytes | None
+        session_id: "bytes | None"
 
         def __init__(
             self,
             *,
-            session_id: bytes | None = None,
+            session_id: "bytes | None" = None,
         ) -> None:
             pass
 
@@ -1661,86 +1661,86 @@ if TYPE_CHECKING:
             return isinstance(msg, cls)
 
     class Features(protobuf.MessageType):
-        vendor: str | None
-        major_version: int
-        minor_version: int
-        patch_version: int
-        bootloader_mode: bool | None
-        device_id: str | None
-        pin_protection: bool | None
-        passphrase_protection: bool | None
-        language: str | None
-        label: str | None
-        initialized: bool | None
-        revision: bytes | None
-        bootloader_hash: bytes | None
-        imported: bool | None
-        unlocked: bool | None
-        firmware_present: bool | None
-        needs_backup: bool | None
-        flags: int | None
-        model: str | None
-        fw_major: int | None
-        fw_minor: int | None
-        fw_patch: int | None
-        fw_vendor: str | None
-        fw_vendor_keys: bytes | None
-        unfinished_backup: bool | None
-        no_backup: bool | None
-        recovery_mode: bool | None
-        capabilities: list[Capability]
-        backup_type: BackupType | None
-        sd_card_present: bool | None
-        sd_protection: bool | None
-        wipe_code_protection: bool | None
-        session_id: bytes | None
-        passphrase_always_on_device: bool | None
-        safety_checks: SafetyCheckLevel | None
-        auto_lock_delay_ms: int | None
-        display_rotation: int | None
-        experimental_features: bool | None
+        vendor: "str | None"
+        major_version: "int"
+        minor_version: "int"
+        patch_version: "int"
+        bootloader_mode: "bool | None"
+        device_id: "str | None"
+        pin_protection: "bool | None"
+        passphrase_protection: "bool | None"
+        language: "str | None"
+        label: "str | None"
+        initialized: "bool | None"
+        revision: "bytes | None"
+        bootloader_hash: "bytes | None"
+        imported: "bool | None"
+        unlocked: "bool | None"
+        firmware_present: "bool | None"
+        needs_backup: "bool | None"
+        flags: "int | None"
+        model: "str | None"
+        fw_major: "int | None"
+        fw_minor: "int | None"
+        fw_patch: "int | None"
+        fw_vendor: "str | None"
+        fw_vendor_keys: "bytes | None"
+        unfinished_backup: "bool | None"
+        no_backup: "bool | None"
+        recovery_mode: "bool | None"
+        capabilities: "list[Capability]"
+        backup_type: "BackupType | None"
+        sd_card_present: "bool | None"
+        sd_protection: "bool | None"
+        wipe_code_protection: "bool | None"
+        session_id: "bytes | None"
+        passphrase_always_on_device: "bool | None"
+        safety_checks: "SafetyCheckLevel | None"
+        auto_lock_delay_ms: "int | None"
+        display_rotation: "int | None"
+        experimental_features: "bool | None"
 
         def __init__(
             self,
             *,
-            major_version: int,
-            minor_version: int,
-            patch_version: int,
-            capabilities: list[Capability] | None = None,
-            vendor: str | None = None,
-            bootloader_mode: bool | None = None,
-            device_id: str | None = None,
-            pin_protection: bool | None = None,
-            passphrase_protection: bool | None = None,
-            language: str | None = None,
-            label: str | None = None,
-            initialized: bool | None = None,
-            revision: bytes | None = None,
-            bootloader_hash: bytes | None = None,
-            imported: bool | None = None,
-            unlocked: bool | None = None,
-            firmware_present: bool | None = None,
-            needs_backup: bool | None = None,
-            flags: int | None = None,
-            model: str | None = None,
-            fw_major: int | None = None,
-            fw_minor: int | None = None,
-            fw_patch: int | None = None,
-            fw_vendor: str | None = None,
-            fw_vendor_keys: bytes | None = None,
-            unfinished_backup: bool | None = None,
-            no_backup: bool | None = None,
-            recovery_mode: bool | None = None,
-            backup_type: BackupType | None = None,
-            sd_card_present: bool | None = None,
-            sd_protection: bool | None = None,
-            wipe_code_protection: bool | None = None,
-            session_id: bytes | None = None,
-            passphrase_always_on_device: bool | None = None,
-            safety_checks: SafetyCheckLevel | None = None,
-            auto_lock_delay_ms: int | None = None,
-            display_rotation: int | None = None,
-            experimental_features: bool | None = None,
+            major_version: "int",
+            minor_version: "int",
+            patch_version: "int",
+            capabilities: "list[Capability] | None" = None,
+            vendor: "str | None" = None,
+            bootloader_mode: "bool | None" = None,
+            device_id: "str | None" = None,
+            pin_protection: "bool | None" = None,
+            passphrase_protection: "bool | None" = None,
+            language: "str | None" = None,
+            label: "str | None" = None,
+            initialized: "bool | None" = None,
+            revision: "bytes | None" = None,
+            bootloader_hash: "bytes | None" = None,
+            imported: "bool | None" = None,
+            unlocked: "bool | None" = None,
+            firmware_present: "bool | None" = None,
+            needs_backup: "bool | None" = None,
+            flags: "int | None" = None,
+            model: "str | None" = None,
+            fw_major: "int | None" = None,
+            fw_minor: "int | None" = None,
+            fw_patch: "int | None" = None,
+            fw_vendor: "str | None" = None,
+            fw_vendor_keys: "bytes | None" = None,
+            unfinished_backup: "bool | None" = None,
+            no_backup: "bool | None" = None,
+            recovery_mode: "bool | None" = None,
+            backup_type: "BackupType | None" = None,
+            sd_card_present: "bool | None" = None,
+            sd_protection: "bool | None" = None,
+            wipe_code_protection: "bool | None" = None,
+            session_id: "bytes | None" = None,
+            passphrase_always_on_device: "bool | None" = None,
+            safety_checks: "SafetyCheckLevel | None" = None,
+            auto_lock_delay_ms: "int | None" = None,
+            display_rotation: "int | None" = None,
+            experimental_features: "bool | None" = None,
         ) -> None:
             pass
 
@@ -1761,28 +1761,28 @@ if TYPE_CHECKING:
             return isinstance(msg, cls)
 
     class ApplySettings(protobuf.MessageType):
-        language: str | None
-        label: str | None
-        use_passphrase: bool | None
-        homescreen: bytes | None
-        auto_lock_delay_ms: int | None
-        display_rotation: int | None
-        passphrase_always_on_device: bool | None
-        safety_checks: SafetyCheckLevel | None
-        experimental_features: bool | None
+        language: "str | None"
+        label: "str | None"
+        use_passphrase: "bool | None"
+        homescreen: "bytes | None"
+        auto_lock_delay_ms: "int | None"
+        display_rotation: "int | None"
+        passphrase_always_on_device: "bool | None"
+        safety_checks: "SafetyCheckLevel | None"
+        experimental_features: "bool | None"
 
         def __init__(
             self,
             *,
-            language: str | None = None,
-            label: str | None = None,
-            use_passphrase: bool | None = None,
-            homescreen: bytes | None = None,
-            auto_lock_delay_ms: int | None = None,
-            display_rotation: int | None = None,
-            passphrase_always_on_device: bool | None = None,
-            safety_checks: SafetyCheckLevel | None = None,
-            experimental_features: bool | None = None,
+            language: "str | None" = None,
+            label: "str | None" = None,
+            use_passphrase: "bool | None" = None,
+            homescreen: "bytes | None" = None,
+            auto_lock_delay_ms: "int | None" = None,
+            display_rotation: "int | None" = None,
+            passphrase_always_on_device: "bool | None" = None,
+            safety_checks: "SafetyCheckLevel | None" = None,
+            experimental_features: "bool | None" = None,
         ) -> None:
             pass
 
@@ -1791,12 +1791,12 @@ if TYPE_CHECKING:
             return isinstance(msg, cls)
 
     class ApplyFlags(protobuf.MessageType):
-        flags: int | None
+        flags: "int | None"
 
         def __init__(
             self,
             *,
-            flags: int | None = None,
+            flags: "int | None" = None,
         ) -> None:
             pass
 
@@ -1805,12 +1805,12 @@ if TYPE_CHECKING:
             return isinstance(msg, cls)
 
     class ChangePin(protobuf.MessageType):
-        remove: bool | None
+        remove: "bool | None"
 
         def __init__(
             self,
             *,
-            remove: bool | None = None,
+            remove: "bool | None" = None,
         ) -> None:
             pass
 
@@ -1819,12 +1819,12 @@ if TYPE_CHECKING:
             return isinstance(msg, cls)
 
     class ChangeWipeCode(protobuf.MessageType):
-        remove: bool | None
+        remove: "bool | None"
 
         def __init__(
             self,
             *,
-            remove: bool | None = None,
+            remove: "bool | None" = None,
         ) -> None:
             pass
 
@@ -1833,12 +1833,12 @@ if TYPE_CHECKING:
             return isinstance(msg, cls)
 
     class SdProtect(protobuf.MessageType):
-        operation: SdProtectOperationType | None
+        operation: "SdProtectOperationType | None"
 
         def __init__(
             self,
             *,
-            operation: SdProtectOperationType | None = None,
+            operation: "SdProtectOperationType | None" = None,
         ) -> None:
             pass
 
@@ -1847,14 +1847,14 @@ if TYPE_CHECKING:
             return isinstance(msg, cls)
 
     class Ping(protobuf.MessageType):
-        message: str
-        button_protection: bool | None
+        message: "str"
+        button_protection: "bool | None"
 
         def __init__(
             self,
             *,
-            message: str | None = None,
-            button_protection: bool | None = None,
+            message: "str | None" = None,
+            button_protection: "bool | None" = None,
         ) -> None:
             pass
 
@@ -1869,12 +1869,12 @@ if TYPE_CHECKING:
             return isinstance(msg, cls)
 
     class GetEntropy(protobuf.MessageType):
-        size: int
+        size: "int"
 
         def __init__(
             self,
             *,
-            size: int,
+            size: "int",
         ) -> None:
             pass
 
@@ -1883,12 +1883,12 @@ if TYPE_CHECKING:
             return isinstance(msg, cls)
 
     class Entropy(protobuf.MessageType):
-        entropy: bytes
+        entropy: "bytes"
 
         def __init__(
             self,
             *,
-            entropy: bytes,
+            entropy: "bytes",
         ) -> None:
             pass
 
@@ -1903,28 +1903,28 @@ if TYPE_CHECKING:
             return isinstance(msg, cls)
 
     class LoadDevice(protobuf.MessageType):
-        mnemonics: list[str]
-        pin: str | None
-        passphrase_protection: bool | None
-        language: str
-        label: str | None
-        skip_checksum: bool | None
-        u2f_counter: int | None
-        needs_backup: bool | None
-        no_backup: bool | None
+        mnemonics: "list[str]"
+        pin: "str | None"
+        passphrase_protection: "bool | None"
+        language: "str"
+        label: "str | None"
+        skip_checksum: "bool | None"
+        u2f_counter: "int | None"
+        needs_backup: "bool | None"
+        no_backup: "bool | None"
 
         def __init__(
             self,
             *,
-            mnemonics: list[str] | None = None,
-            pin: str | None = None,
-            passphrase_protection: bool | None = None,
-            language: str | None = None,
-            label: str | None = None,
-            skip_checksum: bool | None = None,
-            u2f_counter: int | None = None,
-            needs_backup: bool | None = None,
-            no_backup: bool | None = None,
+            mnemonics: "list[str] | None" = None,
+            pin: "str | None" = None,
+            passphrase_protection: "bool | None" = None,
+            language: "str | None" = None,
+            label: "str | None" = None,
+            skip_checksum: "bool | None" = None,
+            u2f_counter: "int | None" = None,
+            needs_backup: "bool | None" = None,
+            no_backup: "bool | None" = None,
         ) -> None:
             pass
 
@@ -1933,30 +1933,30 @@ if TYPE_CHECKING:
             return isinstance(msg, cls)
 
     class ResetDevice(protobuf.MessageType):
-        display_random: bool | None
-        strength: int
-        passphrase_protection: bool | None
-        pin_protection: bool | None
-        language: str
-        label: str | None
-        u2f_counter: int | None
-        skip_backup: bool | None
-        no_backup: bool | None
-        backup_type: BackupType
+        display_random: "bool | None"
+        strength: "int"
+        passphrase_protection: "bool | None"
+        pin_protection: "bool | None"
+        language: "str"
+        label: "str | None"
+        u2f_counter: "int | None"
+        skip_backup: "bool | None"
+        no_backup: "bool | None"
+        backup_type: "BackupType"
 
         def __init__(
             self,
             *,
-            display_random: bool | None = None,
-            strength: int | None = None,
-            passphrase_protection: bool | None = None,
-            pin_protection: bool | None = None,
-            language: str | None = None,
-            label: str | None = None,
-            u2f_counter: int | None = None,
-            skip_backup: bool | None = None,
-            no_backup: bool | None = None,
-            backup_type: BackupType | None = None,
+            display_random: "bool | None" = None,
+            strength: "int | None" = None,
+            passphrase_protection: "bool | None" = None,
+            pin_protection: "bool | None" = None,
+            language: "str | None" = None,
+            label: "str | None" = None,
+            u2f_counter: "int | None" = None,
+            skip_backup: "bool | None" = None,
+            no_backup: "bool | None" = None,
+            backup_type: "BackupType | None" = None,
         ) -> None:
             pass
 
@@ -1977,12 +1977,12 @@ if TYPE_CHECKING:
             return isinstance(msg, cls)
 
     class EntropyAck(protobuf.MessageType):
-        entropy: bytes | None
+        entropy: "bytes | None"
 
         def __init__(
             self,
             *,
-            entropy: bytes | None = None,
+            entropy: "bytes | None" = None,
         ) -> None:
             pass
 
@@ -1991,28 +1991,28 @@ if TYPE_CHECKING:
             return isinstance(msg, cls)
 
     class RecoveryDevice(protobuf.MessageType):
-        word_count: int | None
-        passphrase_protection: bool | None
-        pin_protection: bool | None
-        language: str | None
-        label: str | None
-        enforce_wordlist: bool | None
-        type: RecoveryDeviceType | None
-        u2f_counter: int | None
-        dry_run: bool | None
+        word_count: "int | None"
+        passphrase_protection: "bool | None"
+        pin_protection: "bool | None"
+        language: "str | None"
+        label: "str | None"
+        enforce_wordlist: "bool | None"
+        type: "RecoveryDeviceType | None"
+        u2f_counter: "int | None"
+        dry_run: "bool | None"
 
         def __init__(
             self,
             *,
-            word_count: int | None = None,
-            passphrase_protection: bool | None = None,
-            pin_protection: bool | None = None,
-            language: str | None = None,
-            label: str | None = None,
-            enforce_wordlist: bool | None = None,
-            type: RecoveryDeviceType | None = None,
-            u2f_counter: int | None = None,
-            dry_run: bool | None = None,
+            word_count: "int | None" = None,
+            passphrase_protection: "bool | None" = None,
+            pin_protection: "bool | None" = None,
+            language: "str | None" = None,
+            label: "str | None" = None,
+            enforce_wordlist: "bool | None" = None,
+            type: "RecoveryDeviceType | None" = None,
+            u2f_counter: "int | None" = None,
+            dry_run: "bool | None" = None,
         ) -> None:
             pass
 
@@ -2021,12 +2021,12 @@ if TYPE_CHECKING:
             return isinstance(msg, cls)
 
     class WordRequest(protobuf.MessageType):
-        type: WordRequestType | None
+        type: "WordRequestType | None"
 
         def __init__(
             self,
             *,
-            type: WordRequestType | None = None,
+            type: "WordRequestType | None" = None,
         ) -> None:
             pass
 
@@ -2035,12 +2035,12 @@ if TYPE_CHECKING:
             return isinstance(msg, cls)
 
     class WordAck(protobuf.MessageType):
-        word: str
+        word: "str"
 
         def __init__(
             self,
             *,
-            word: str,
+            word: "str",
         ) -> None:
             pass
 
@@ -2049,12 +2049,12 @@ if TYPE_CHECKING:
             return isinstance(msg, cls)
 
     class SetU2FCounter(protobuf.MessageType):
-        u2f_counter: int | None
+        u2f_counter: "int | None"
 
         def __init__(
             self,
             *,
-            u2f_counter: int | None = None,
+            u2f_counter: "int | None" = None,
         ) -> None:
             pass
 
@@ -2069,12 +2069,12 @@ if TYPE_CHECKING:
             return isinstance(msg, cls)
 
     class NextU2FCounter(protobuf.MessageType):
-        u2f_counter: int | None
+        u2f_counter: "int | None"
 
         def __init__(
             self,
             *,
-            u2f_counter: int | None = None,
+            u2f_counter: "int | None" = None,
         ) -> None:
             pass
 
@@ -2107,24 +2107,24 @@ if TYPE_CHECKING:
             return isinstance(msg, cls)
 
     class DebugLinkDecision(protobuf.MessageType):
-        yes_no: bool | None
-        swipe: DebugSwipeDirection | None
-        input: str | None
-        x: int | None
-        y: int | None
-        wait: bool | None
-        hold_ms: int | None
+        yes_no: "bool | None"
+        swipe: "DebugSwipeDirection | None"
+        input: "str | None"
+        x: "int | None"
+        y: "int | None"
+        wait: "bool | None"
+        hold_ms: "int | None"
 
         def __init__(
             self,
             *,
-            yes_no: bool | None = None,
-            swipe: DebugSwipeDirection | None = None,
-            input: str | None = None,
-            x: int | None = None,
-            y: int | None = None,
-            wait: bool | None = None,
-            hold_ms: int | None = None,
+            yes_no: "bool | None" = None,
+            swipe: "DebugSwipeDirection | None" = None,
+            input: "str | None" = None,
+            x: "int | None" = None,
+            y: "int | None" = None,
+            wait: "bool | None" = None,
+            hold_ms: "int | None" = None,
         ) -> None:
             pass
 
@@ -2133,12 +2133,12 @@ if TYPE_CHECKING:
             return isinstance(msg, cls)
 
     class DebugLinkLayout(protobuf.MessageType):
-        lines: list[str]
+        lines: "list[str]"
 
         def __init__(
             self,
             *,
-            lines: list[str] | None = None,
+            lines: "list[str] | None" = None,
         ) -> None:
             pass
 
@@ -2147,12 +2147,12 @@ if TYPE_CHECKING:
             return isinstance(msg, cls)
 
     class DebugLinkReseedRandom(protobuf.MessageType):
-        value: int | None
+        value: "int | None"
 
         def __init__(
             self,
             *,
-            value: int | None = None,
+            value: "int | None" = None,
         ) -> None:
             pass
 
@@ -2161,12 +2161,12 @@ if TYPE_CHECKING:
             return isinstance(msg, cls)
 
     class DebugLinkRecordScreen(protobuf.MessageType):
-        target_directory: str | None
+        target_directory: "str | None"
 
         def __init__(
             self,
             *,
-            target_directory: str | None = None,
+            target_directory: "str | None" = None,
         ) -> None:
             pass
 
@@ -2175,16 +2175,16 @@ if TYPE_CHECKING:
             return isinstance(msg, cls)
 
     class DebugLinkGetState(protobuf.MessageType):
-        wait_word_list: bool | None
-        wait_word_pos: bool | None
-        wait_layout: bool | None
+        wait_word_list: "bool | None"
+        wait_word_pos: "bool | None"
+        wait_layout: "bool | None"
 
         def __init__(
             self,
             *,
-            wait_word_list: bool | None = None,
-            wait_word_pos: bool | None = None,
-            wait_layout: bool | None = None,
+            wait_word_list: "bool | None" = None,
+            wait_word_pos: "bool | None" = None,
+            wait_layout: "bool | None" = None,
         ) -> None:
             pass
 
@@ -2193,36 +2193,36 @@ if TYPE_CHECKING:
             return isinstance(msg, cls)
 
     class DebugLinkState(protobuf.MessageType):
-        layout: bytes | None
-        pin: str | None
-        matrix: str | None
-        mnemonic_secret: bytes | None
-        node: HDNodeType | None
-        passphrase_protection: bool | None
-        reset_word: str | None
-        reset_entropy: bytes | None
-        recovery_fake_word: str | None
-        recovery_word_pos: int | None
-        reset_word_pos: int | None
-        mnemonic_type: BackupType | None
-        layout_lines: list[str]
+        layout: "bytes | None"
+        pin: "str | None"
+        matrix: "str | None"
+        mnemonic_secret: "bytes | None"
+        node: "HDNodeType | None"
+        passphrase_protection: "bool | None"
+        reset_word: "str | None"
+        reset_entropy: "bytes | None"
+        recovery_fake_word: "str | None"
+        recovery_word_pos: "int | None"
+        reset_word_pos: "int | None"
+        mnemonic_type: "BackupType | None"
+        layout_lines: "list[str]"
 
         def __init__(
             self,
             *,
-            layout_lines: list[str] | None = None,
-            layout: bytes | None = None,
-            pin: str | None = None,
-            matrix: str | None = None,
-            mnemonic_secret: bytes | None = None,
-            node: HDNodeType | None = None,
-            passphrase_protection: bool | None = None,
-            reset_word: str | None = None,
-            reset_entropy: bytes | None = None,
-            recovery_fake_word: str | None = None,
-            recovery_word_pos: int | None = None,
-            reset_word_pos: int | None = None,
-            mnemonic_type: BackupType | None = None,
+            layout_lines: "list[str] | None" = None,
+            layout: "bytes | None" = None,
+            pin: "str | None" = None,
+            matrix: "str | None" = None,
+            mnemonic_secret: "bytes | None" = None,
+            node: "HDNodeType | None" = None,
+            passphrase_protection: "bool | None" = None,
+            reset_word: "str | None" = None,
+            reset_entropy: "bytes | None" = None,
+            recovery_fake_word: "str | None" = None,
+            recovery_word_pos: "int | None" = None,
+            reset_word_pos: "int | None" = None,
+            mnemonic_type: "BackupType | None" = None,
         ) -> None:
             pass
 
@@ -2237,16 +2237,16 @@ if TYPE_CHECKING:
             return isinstance(msg, cls)
 
     class DebugLinkLog(protobuf.MessageType):
-        level: int | None
-        bucket: str | None
-        text: str | None
+        level: "int | None"
+        bucket: "str | None"
+        text: "str | None"
 
         def __init__(
             self,
             *,
-            level: int | None = None,
-            bucket: str | None = None,
-            text: str | None = None,
+            level: "int | None" = None,
+            bucket: "str | None" = None,
+            text: "str | None" = None,
         ) -> None:
             pass
 
@@ -2255,14 +2255,14 @@ if TYPE_CHECKING:
             return isinstance(msg, cls)
 
     class DebugLinkMemoryRead(protobuf.MessageType):
-        address: int | None
-        length: int | None
+        address: "int | None"
+        length: "int | None"
 
         def __init__(
             self,
             *,
-            address: int | None = None,
-            length: int | None = None,
+            address: "int | None" = None,
+            length: "int | None" = None,
         ) -> None:
             pass
 
@@ -2271,12 +2271,12 @@ if TYPE_CHECKING:
             return isinstance(msg, cls)
 
     class DebugLinkMemory(protobuf.MessageType):
-        memory: bytes | None
+        memory: "bytes | None"
 
         def __init__(
             self,
             *,
-            memory: bytes | None = None,
+            memory: "bytes | None" = None,
         ) -> None:
             pass
 
@@ -2285,16 +2285,16 @@ if TYPE_CHECKING:
             return isinstance(msg, cls)
 
     class DebugLinkMemoryWrite(protobuf.MessageType):
-        address: int | None
-        memory: bytes | None
-        flash: bool | None
+        address: "int | None"
+        memory: "bytes | None"
+        flash: "bool | None"
 
         def __init__(
             self,
             *,
-            address: int | None = None,
-            memory: bytes | None = None,
-            flash: bool | None = None,
+            address: "int | None" = None,
+            memory: "bytes | None" = None,
+            flash: "bool | None" = None,
         ) -> None:
             pass
 
@@ -2303,12 +2303,12 @@ if TYPE_CHECKING:
             return isinstance(msg, cls)
 
     class DebugLinkFlashErase(protobuf.MessageType):
-        sector: int | None
+        sector: "int | None"
 
         def __init__(
             self,
             *,
-            sector: int | None = None,
+            sector: "int | None" = None,
         ) -> None:
             pass
 
@@ -2317,12 +2317,12 @@ if TYPE_CHECKING:
             return isinstance(msg, cls)
 
     class DebugLinkEraseSdCard(protobuf.MessageType):
-        format: bool | None
+        format: "bool | None"
 
         def __init__(
             self,
             *,
-            format: bool | None = None,
+            format: "bool | None" = None,
         ) -> None:
             pass
 
@@ -2331,12 +2331,12 @@ if TYPE_CHECKING:
             return isinstance(msg, cls)
 
     class DebugLinkWatchLayout(protobuf.MessageType):
-        watch: bool | None
+        watch: "bool | None"
 
         def __init__(
             self,
             *,
-            watch: bool | None = None,
+            watch: "bool | None" = None,
         ) -> None:
             pass
 
@@ -2345,14 +2345,14 @@ if TYPE_CHECKING:
             return isinstance(msg, cls)
 
     class EosGetPublicKey(protobuf.MessageType):
-        address_n: list[int]
-        show_display: bool | None
+        address_n: "list[int]"
+        show_display: "bool | None"
 
         def __init__(
             self,
             *,
-            address_n: list[int] | None = None,
-            show_display: bool | None = None,
+            address_n: "list[int] | None" = None,
+            show_display: "bool | None" = None,
         ) -> None:
             pass
 
@@ -2361,14 +2361,14 @@ if TYPE_CHECKING:
             return isinstance(msg, cls)
 
     class EosPublicKey(protobuf.MessageType):
-        wif_public_key: str
-        raw_public_key: bytes
+        wif_public_key: "str"
+        raw_public_key: "bytes"
 
         def __init__(
             self,
             *,
-            wif_public_key: str,
-            raw_public_key: bytes,
+            wif_public_key: "str",
+            raw_public_key: "bytes",
         ) -> None:
             pass
 
@@ -2376,43 +2376,19 @@ if TYPE_CHECKING:
         def is_type_of(cls, msg: protobuf.MessageType) -> TypeGuard["EosPublicKey"]:
             return isinstance(msg, cls)
 
-    class EosTxHeader(protobuf.MessageType):
-        expiration: int
-        ref_block_num: int
-        ref_block_prefix: int
-        max_net_usage_words: int
-        max_cpu_usage_ms: int
-        delay_sec: int
-
-        def __init__(
-            self,
-            *,
-            expiration: int,
-            ref_block_num: int,
-            ref_block_prefix: int,
-            max_net_usage_words: int,
-            max_cpu_usage_ms: int,
-            delay_sec: int,
-        ) -> None:
-            pass
-
-        @classmethod
-        def is_type_of(cls, msg: protobuf.MessageType) -> TypeGuard["EosTxHeader"]:
-            return isinstance(msg, cls)
-
     class EosSignTx(protobuf.MessageType):
-        address_n: list[int]
-        chain_id: bytes | None
-        header: EosTxHeader | None
-        num_actions: int | None
+        address_n: "list[int]"
+        chain_id: "bytes | None"
+        header: "EosTxHeader | None"
+        num_actions: "int | None"
 
         def __init__(
             self,
             *,
-            address_n: list[int] | None = None,
-            chain_id: bytes | None = None,
-            header: EosTxHeader | None = None,
-            num_actions: int | None = None,
+            address_n: "list[int] | None" = None,
+            chain_id: "bytes | None" = None,
+            header: "EosTxHeader | None" = None,
+            num_actions: "int | None" = None,
         ) -> None:
             pass
 
@@ -2421,12 +2397,12 @@ if TYPE_CHECKING:
             return isinstance(msg, cls)
 
     class EosTxActionRequest(protobuf.MessageType):
-        data_size: int | None
+        data_size: "int | None"
 
         def __init__(
             self,
             *,
-            data_size: int | None = None,
+            data_size: "int | None" = None,
         ) -> None:
             pass
 
@@ -2434,419 +2410,41 @@ if TYPE_CHECKING:
         def is_type_of(cls, msg: protobuf.MessageType) -> TypeGuard["EosTxActionRequest"]:
             return isinstance(msg, cls)
 
-    class EosPermissionLevel(protobuf.MessageType):
-        actor: int | None
-        permission: int | None
-
-        def __init__(
-            self,
-            *,
-            actor: int | None = None,
-            permission: int | None = None,
-        ) -> None:
-            pass
-
-        @classmethod
-        def is_type_of(cls, msg: protobuf.MessageType) -> TypeGuard["EosPermissionLevel"]:
-            return isinstance(msg, cls)
-
-    class EosActionCommon(protobuf.MessageType):
-        account: int | None
-        name: int | None
-        authorization: list[EosPermissionLevel]
-
-        def __init__(
-            self,
-            *,
-            authorization: list[EosPermissionLevel] | None = None,
-            account: int | None = None,
-            name: int | None = None,
-        ) -> None:
-            pass
-
-        @classmethod
-        def is_type_of(cls, msg: protobuf.MessageType) -> TypeGuard["EosActionCommon"]:
-            return isinstance(msg, cls)
-
-    class EosAsset(protobuf.MessageType):
-        amount: int | None
-        symbol: int | None
-
-        def __init__(
-            self,
-            *,
-            amount: int | None = None,
-            symbol: int | None = None,
-        ) -> None:
-            pass
-
-        @classmethod
-        def is_type_of(cls, msg: protobuf.MessageType) -> TypeGuard["EosAsset"]:
-            return isinstance(msg, cls)
-
-    class EosActionTransfer(protobuf.MessageType):
-        sender: int | None
-        receiver: int | None
-        quantity: EosAsset | None
-        memo: str | None
-
-        def __init__(
-            self,
-            *,
-            sender: int | None = None,
-            receiver: int | None = None,
-            quantity: EosAsset | None = None,
-            memo: str | None = None,
-        ) -> None:
-            pass
-
-        @classmethod
-        def is_type_of(cls, msg: protobuf.MessageType) -> TypeGuard["EosActionTransfer"]:
-            return isinstance(msg, cls)
-
-    class EosActionDelegate(protobuf.MessageType):
-        sender: int | None
-        receiver: int | None
-        net_quantity: EosAsset | None
-        cpu_quantity: EosAsset | None
-        transfer: bool | None
-
-        def __init__(
-            self,
-            *,
-            sender: int | None = None,
-            receiver: int | None = None,
-            net_quantity: EosAsset | None = None,
-            cpu_quantity: EosAsset | None = None,
-            transfer: bool | None = None,
-        ) -> None:
-            pass
-
-        @classmethod
-        def is_type_of(cls, msg: protobuf.MessageType) -> TypeGuard["EosActionDelegate"]:
-            return isinstance(msg, cls)
-
-    class EosActionUndelegate(protobuf.MessageType):
-        sender: int | None
-        receiver: int | None
-        net_quantity: EosAsset | None
-        cpu_quantity: EosAsset | None
-
-        def __init__(
-            self,
-            *,
-            sender: int | None = None,
-            receiver: int | None = None,
-            net_quantity: EosAsset | None = None,
-            cpu_quantity: EosAsset | None = None,
-        ) -> None:
-            pass
-
-        @classmethod
-        def is_type_of(cls, msg: protobuf.MessageType) -> TypeGuard["EosActionUndelegate"]:
-            return isinstance(msg, cls)
-
-    class EosActionRefund(protobuf.MessageType):
-        owner: int | None
-
-        def __init__(
-            self,
-            *,
-            owner: int | None = None,
-        ) -> None:
-            pass
-
-        @classmethod
-        def is_type_of(cls, msg: protobuf.MessageType) -> TypeGuard["EosActionRefund"]:
-            return isinstance(msg, cls)
-
-    class EosActionBuyRam(protobuf.MessageType):
-        payer: int | None
-        receiver: int | None
-        quantity: EosAsset | None
-
-        def __init__(
-            self,
-            *,
-            payer: int | None = None,
-            receiver: int | None = None,
-            quantity: EosAsset | None = None,
-        ) -> None:
-            pass
-
-        @classmethod
-        def is_type_of(cls, msg: protobuf.MessageType) -> TypeGuard["EosActionBuyRam"]:
-            return isinstance(msg, cls)
-
-    class EosActionBuyRamBytes(protobuf.MessageType):
-        payer: int | None
-        receiver: int | None
-        bytes: int | None
-
-        def __init__(
-            self,
-            *,
-            payer: int | None = None,
-            receiver: int | None = None,
-            bytes: int | None = None,
-        ) -> None:
-            pass
-
-        @classmethod
-        def is_type_of(cls, msg: protobuf.MessageType) -> TypeGuard["EosActionBuyRamBytes"]:
-            return isinstance(msg, cls)
-
-    class EosActionSellRam(protobuf.MessageType):
-        account: int | None
-        bytes: int | None
-
-        def __init__(
-            self,
-            *,
-            account: int | None = None,
-            bytes: int | None = None,
-        ) -> None:
-            pass
-
-        @classmethod
-        def is_type_of(cls, msg: protobuf.MessageType) -> TypeGuard["EosActionSellRam"]:
-            return isinstance(msg, cls)
-
-    class EosActionVoteProducer(protobuf.MessageType):
-        voter: int | None
-        proxy: int | None
-        producers: list[int]
-
-        def __init__(
-            self,
-            *,
-            producers: list[int] | None = None,
-            voter: int | None = None,
-            proxy: int | None = None,
-        ) -> None:
-            pass
-
-        @classmethod
-        def is_type_of(cls, msg: protobuf.MessageType) -> TypeGuard["EosActionVoteProducer"]:
-            return isinstance(msg, cls)
-
-    class EosAuthorizationKey(protobuf.MessageType):
-        type: int
-        key: bytes | None
-        address_n: list[int]
-        weight: int
-
-        def __init__(
-            self,
-            *,
-            type: int,
-            weight: int,
-            address_n: list[int] | None = None,
-            key: bytes | None = None,
-        ) -> None:
-            pass
-
-        @classmethod
-        def is_type_of(cls, msg: protobuf.MessageType) -> TypeGuard["EosAuthorizationKey"]:
-            return isinstance(msg, cls)
-
-    class EosAuthorizationAccount(protobuf.MessageType):
-        account: EosPermissionLevel | None
-        weight: int | None
-
-        def __init__(
-            self,
-            *,
-            account: EosPermissionLevel | None = None,
-            weight: int | None = None,
-        ) -> None:
-            pass
-
-        @classmethod
-        def is_type_of(cls, msg: protobuf.MessageType) -> TypeGuard["EosAuthorizationAccount"]:
-            return isinstance(msg, cls)
-
-    class EosAuthorizationWait(protobuf.MessageType):
-        wait_sec: int | None
-        weight: int | None
-
-        def __init__(
-            self,
-            *,
-            wait_sec: int | None = None,
-            weight: int | None = None,
-        ) -> None:
-            pass
-
-        @classmethod
-        def is_type_of(cls, msg: protobuf.MessageType) -> TypeGuard["EosAuthorizationWait"]:
-            return isinstance(msg, cls)
-
-    class EosAuthorization(protobuf.MessageType):
-        threshold: int | None
-        keys: list[EosAuthorizationKey]
-        accounts: list[EosAuthorizationAccount]
-        waits: list[EosAuthorizationWait]
-
-        def __init__(
-            self,
-            *,
-            keys: list[EosAuthorizationKey] | None = None,
-            accounts: list[EosAuthorizationAccount] | None = None,
-            waits: list[EosAuthorizationWait] | None = None,
-            threshold: int | None = None,
-        ) -> None:
-            pass
-
-        @classmethod
-        def is_type_of(cls, msg: protobuf.MessageType) -> TypeGuard["EosAuthorization"]:
-            return isinstance(msg, cls)
-
-    class EosActionUpdateAuth(protobuf.MessageType):
-        account: int | None
-        permission: int | None
-        parent: int | None
-        auth: EosAuthorization | None
-
-        def __init__(
-            self,
-            *,
-            account: int | None = None,
-            permission: int | None = None,
-            parent: int | None = None,
-            auth: EosAuthorization | None = None,
-        ) -> None:
-            pass
-
-        @classmethod
-        def is_type_of(cls, msg: protobuf.MessageType) -> TypeGuard["EosActionUpdateAuth"]:
-            return isinstance(msg, cls)
-
-    class EosActionDeleteAuth(protobuf.MessageType):
-        account: int | None
-        permission: int | None
-
-        def __init__(
-            self,
-            *,
-            account: int | None = None,
-            permission: int | None = None,
-        ) -> None:
-            pass
-
-        @classmethod
-        def is_type_of(cls, msg: protobuf.MessageType) -> TypeGuard["EosActionDeleteAuth"]:
-            return isinstance(msg, cls)
-
-    class EosActionLinkAuth(protobuf.MessageType):
-        account: int | None
-        code: int | None
-        type: int | None
-        requirement: int | None
-
-        def __init__(
-            self,
-            *,
-            account: int | None = None,
-            code: int | None = None,
-            type: int | None = None,
-            requirement: int | None = None,
-        ) -> None:
-            pass
-
-        @classmethod
-        def is_type_of(cls, msg: protobuf.MessageType) -> TypeGuard["EosActionLinkAuth"]:
-            return isinstance(msg, cls)
-
-    class EosActionUnlinkAuth(protobuf.MessageType):
-        account: int | None
-        code: int | None
-        type: int | None
-
-        def __init__(
-            self,
-            *,
-            account: int | None = None,
-            code: int | None = None,
-            type: int | None = None,
-        ) -> None:
-            pass
-
-        @classmethod
-        def is_type_of(cls, msg: protobuf.MessageType) -> TypeGuard["EosActionUnlinkAuth"]:
-            return isinstance(msg, cls)
-
-    class EosActionNewAccount(protobuf.MessageType):
-        creator: int | None
-        name: int | None
-        owner: EosAuthorization | None
-        active: EosAuthorization | None
-
-        def __init__(
-            self,
-            *,
-            creator: int | None = None,
-            name: int | None = None,
-            owner: EosAuthorization | None = None,
-            active: EosAuthorization | None = None,
-        ) -> None:
-            pass
-
-        @classmethod
-        def is_type_of(cls, msg: protobuf.MessageType) -> TypeGuard["EosActionNewAccount"]:
-            return isinstance(msg, cls)
-
-    class EosActionUnknown(protobuf.MessageType):
-        data_size: int
-        data_chunk: bytes | None
-
-        def __init__(
-            self,
-            *,
-            data_size: int,
-            data_chunk: bytes | None = None,
-        ) -> None:
-            pass
-
-        @classmethod
-        def is_type_of(cls, msg: protobuf.MessageType) -> TypeGuard["EosActionUnknown"]:
-            return isinstance(msg, cls)
-
     class EosTxActionAck(protobuf.MessageType):
-        common: EosActionCommon | None
-        transfer: EosActionTransfer | None
-        delegate: EosActionDelegate | None
-        undelegate: EosActionUndelegate | None
-        refund: EosActionRefund | None
-        buy_ram: EosActionBuyRam | None
-        buy_ram_bytes: EosActionBuyRamBytes | None
-        sell_ram: EosActionSellRam | None
-        vote_producer: EosActionVoteProducer | None
-        update_auth: EosActionUpdateAuth | None
-        delete_auth: EosActionDeleteAuth | None
-        link_auth: EosActionLinkAuth | None
-        unlink_auth: EosActionUnlinkAuth | None
-        new_account: EosActionNewAccount | None
-        unknown: EosActionUnknown | None
+        common: "EosActionCommon | None"
+        transfer: "EosActionTransfer | None"
+        delegate: "EosActionDelegate | None"
+        undelegate: "EosActionUndelegate | None"
+        refund: "EosActionRefund | None"
+        buy_ram: "EosActionBuyRam | None"
+        buy_ram_bytes: "EosActionBuyRamBytes | None"
+        sell_ram: "EosActionSellRam | None"
+        vote_producer: "EosActionVoteProducer | None"
+        update_auth: "EosActionUpdateAuth | None"
+        delete_auth: "EosActionDeleteAuth | None"
+        link_auth: "EosActionLinkAuth | None"
+        unlink_auth: "EosActionUnlinkAuth | None"
+        new_account: "EosActionNewAccount | None"
+        unknown: "EosActionUnknown | None"
 
         def __init__(
             self,
             *,
-            common: EosActionCommon | None = None,
-            transfer: EosActionTransfer | None = None,
-            delegate: EosActionDelegate | None = None,
-            undelegate: EosActionUndelegate | None = None,
-            refund: EosActionRefund | None = None,
-            buy_ram: EosActionBuyRam | None = None,
-            buy_ram_bytes: EosActionBuyRamBytes | None = None,
-            sell_ram: EosActionSellRam | None = None,
-            vote_producer: EosActionVoteProducer | None = None,
-            update_auth: EosActionUpdateAuth | None = None,
-            delete_auth: EosActionDeleteAuth | None = None,
-            link_auth: EosActionLinkAuth | None = None,
-            unlink_auth: EosActionUnlinkAuth | None = None,
-            new_account: EosActionNewAccount | None = None,
-            unknown: EosActionUnknown | None = None,
+            common: "EosActionCommon | None" = None,
+            transfer: "EosActionTransfer | None" = None,
+            delegate: "EosActionDelegate | None" = None,
+            undelegate: "EosActionUndelegate | None" = None,
+            refund: "EosActionRefund | None" = None,
+            buy_ram: "EosActionBuyRam | None" = None,
+            buy_ram_bytes: "EosActionBuyRamBytes | None" = None,
+            sell_ram: "EosActionSellRam | None" = None,
+            vote_producer: "EosActionVoteProducer | None" = None,
+            update_auth: "EosActionUpdateAuth | None" = None,
+            delete_auth: "EosActionDeleteAuth | None" = None,
+            link_auth: "EosActionLinkAuth | None" = None,
+            unlink_auth: "EosActionUnlinkAuth | None" = None,
+            new_account: "EosActionNewAccount | None" = None,
+            unknown: "EosActionUnknown | None" = None,
         ) -> None:
             pass
 
@@ -2855,12 +2453,12 @@ if TYPE_CHECKING:
             return isinstance(msg, cls)
 
     class EosSignedTx(protobuf.MessageType):
-        signature: str
+        signature: "str"
 
         def __init__(
             self,
             *,
-            signature: str,
+            signature: "str",
         ) -> None:
             pass
 
@@ -2868,15 +2466,417 @@ if TYPE_CHECKING:
         def is_type_of(cls, msg: protobuf.MessageType) -> TypeGuard["EosSignedTx"]:
             return isinstance(msg, cls)
 
-    class EthereumGetPublicKey(protobuf.MessageType):
-        address_n: list[int]
-        show_display: bool | None
+    class EosTxHeader(protobuf.MessageType):
+        expiration: "int"
+        ref_block_num: "int"
+        ref_block_prefix: "int"
+        max_net_usage_words: "int"
+        max_cpu_usage_ms: "int"
+        delay_sec: "int"
 
         def __init__(
             self,
             *,
-            address_n: list[int] | None = None,
-            show_display: bool | None = None,
+            expiration: "int",
+            ref_block_num: "int",
+            ref_block_prefix: "int",
+            max_net_usage_words: "int",
+            max_cpu_usage_ms: "int",
+            delay_sec: "int",
+        ) -> None:
+            pass
+
+        @classmethod
+        def is_type_of(cls, msg: protobuf.MessageType) -> TypeGuard["EosTxHeader"]:
+            return isinstance(msg, cls)
+
+    class EosAsset(protobuf.MessageType):
+        amount: "int | None"
+        symbol: "int | None"
+
+        def __init__(
+            self,
+            *,
+            amount: "int | None" = None,
+            symbol: "int | None" = None,
+        ) -> None:
+            pass
+
+        @classmethod
+        def is_type_of(cls, msg: protobuf.MessageType) -> TypeGuard["EosAsset"]:
+            return isinstance(msg, cls)
+
+    class EosPermissionLevel(protobuf.MessageType):
+        actor: "int | None"
+        permission: "int | None"
+
+        def __init__(
+            self,
+            *,
+            actor: "int | None" = None,
+            permission: "int | None" = None,
+        ) -> None:
+            pass
+
+        @classmethod
+        def is_type_of(cls, msg: protobuf.MessageType) -> TypeGuard["EosPermissionLevel"]:
+            return isinstance(msg, cls)
+
+    class EosAuthorizationKey(protobuf.MessageType):
+        type: "int"
+        key: "bytes | None"
+        address_n: "list[int]"
+        weight: "int"
+
+        def __init__(
+            self,
+            *,
+            type: "int",
+            weight: "int",
+            address_n: "list[int] | None" = None,
+            key: "bytes | None" = None,
+        ) -> None:
+            pass
+
+        @classmethod
+        def is_type_of(cls, msg: protobuf.MessageType) -> TypeGuard["EosAuthorizationKey"]:
+            return isinstance(msg, cls)
+
+    class EosAuthorizationAccount(protobuf.MessageType):
+        account: "EosPermissionLevel | None"
+        weight: "int | None"
+
+        def __init__(
+            self,
+            *,
+            account: "EosPermissionLevel | None" = None,
+            weight: "int | None" = None,
+        ) -> None:
+            pass
+
+        @classmethod
+        def is_type_of(cls, msg: protobuf.MessageType) -> TypeGuard["EosAuthorizationAccount"]:
+            return isinstance(msg, cls)
+
+    class EosAuthorizationWait(protobuf.MessageType):
+        wait_sec: "int | None"
+        weight: "int | None"
+
+        def __init__(
+            self,
+            *,
+            wait_sec: "int | None" = None,
+            weight: "int | None" = None,
+        ) -> None:
+            pass
+
+        @classmethod
+        def is_type_of(cls, msg: protobuf.MessageType) -> TypeGuard["EosAuthorizationWait"]:
+            return isinstance(msg, cls)
+
+    class EosAuthorization(protobuf.MessageType):
+        threshold: "int | None"
+        keys: "list[EosAuthorizationKey]"
+        accounts: "list[EosAuthorizationAccount]"
+        waits: "list[EosAuthorizationWait]"
+
+        def __init__(
+            self,
+            *,
+            keys: "list[EosAuthorizationKey] | None" = None,
+            accounts: "list[EosAuthorizationAccount] | None" = None,
+            waits: "list[EosAuthorizationWait] | None" = None,
+            threshold: "int | None" = None,
+        ) -> None:
+            pass
+
+        @classmethod
+        def is_type_of(cls, msg: protobuf.MessageType) -> TypeGuard["EosAuthorization"]:
+            return isinstance(msg, cls)
+
+    class EosActionCommon(protobuf.MessageType):
+        account: "int | None"
+        name: "int | None"
+        authorization: "list[EosPermissionLevel]"
+
+        def __init__(
+            self,
+            *,
+            authorization: "list[EosPermissionLevel] | None" = None,
+            account: "int | None" = None,
+            name: "int | None" = None,
+        ) -> None:
+            pass
+
+        @classmethod
+        def is_type_of(cls, msg: protobuf.MessageType) -> TypeGuard["EosActionCommon"]:
+            return isinstance(msg, cls)
+
+    class EosActionTransfer(protobuf.MessageType):
+        sender: "int | None"
+        receiver: "int | None"
+        quantity: "EosAsset | None"
+        memo: "str | None"
+
+        def __init__(
+            self,
+            *,
+            sender: "int | None" = None,
+            receiver: "int | None" = None,
+            quantity: "EosAsset | None" = None,
+            memo: "str | None" = None,
+        ) -> None:
+            pass
+
+        @classmethod
+        def is_type_of(cls, msg: protobuf.MessageType) -> TypeGuard["EosActionTransfer"]:
+            return isinstance(msg, cls)
+
+    class EosActionDelegate(protobuf.MessageType):
+        sender: "int | None"
+        receiver: "int | None"
+        net_quantity: "EosAsset | None"
+        cpu_quantity: "EosAsset | None"
+        transfer: "bool | None"
+
+        def __init__(
+            self,
+            *,
+            sender: "int | None" = None,
+            receiver: "int | None" = None,
+            net_quantity: "EosAsset | None" = None,
+            cpu_quantity: "EosAsset | None" = None,
+            transfer: "bool | None" = None,
+        ) -> None:
+            pass
+
+        @classmethod
+        def is_type_of(cls, msg: protobuf.MessageType) -> TypeGuard["EosActionDelegate"]:
+            return isinstance(msg, cls)
+
+    class EosActionUndelegate(protobuf.MessageType):
+        sender: "int | None"
+        receiver: "int | None"
+        net_quantity: "EosAsset | None"
+        cpu_quantity: "EosAsset | None"
+
+        def __init__(
+            self,
+            *,
+            sender: "int | None" = None,
+            receiver: "int | None" = None,
+            net_quantity: "EosAsset | None" = None,
+            cpu_quantity: "EosAsset | None" = None,
+        ) -> None:
+            pass
+
+        @classmethod
+        def is_type_of(cls, msg: protobuf.MessageType) -> TypeGuard["EosActionUndelegate"]:
+            return isinstance(msg, cls)
+
+    class EosActionRefund(protobuf.MessageType):
+        owner: "int | None"
+
+        def __init__(
+            self,
+            *,
+            owner: "int | None" = None,
+        ) -> None:
+            pass
+
+        @classmethod
+        def is_type_of(cls, msg: protobuf.MessageType) -> TypeGuard["EosActionRefund"]:
+            return isinstance(msg, cls)
+
+    class EosActionBuyRam(protobuf.MessageType):
+        payer: "int | None"
+        receiver: "int | None"
+        quantity: "EosAsset | None"
+
+        def __init__(
+            self,
+            *,
+            payer: "int | None" = None,
+            receiver: "int | None" = None,
+            quantity: "EosAsset | None" = None,
+        ) -> None:
+            pass
+
+        @classmethod
+        def is_type_of(cls, msg: protobuf.MessageType) -> TypeGuard["EosActionBuyRam"]:
+            return isinstance(msg, cls)
+
+    class EosActionBuyRamBytes(protobuf.MessageType):
+        payer: "int | None"
+        receiver: "int | None"
+        bytes: "int | None"
+
+        def __init__(
+            self,
+            *,
+            payer: "int | None" = None,
+            receiver: "int | None" = None,
+            bytes: "int | None" = None,
+        ) -> None:
+            pass
+
+        @classmethod
+        def is_type_of(cls, msg: protobuf.MessageType) -> TypeGuard["EosActionBuyRamBytes"]:
+            return isinstance(msg, cls)
+
+    class EosActionSellRam(protobuf.MessageType):
+        account: "int | None"
+        bytes: "int | None"
+
+        def __init__(
+            self,
+            *,
+            account: "int | None" = None,
+            bytes: "int | None" = None,
+        ) -> None:
+            pass
+
+        @classmethod
+        def is_type_of(cls, msg: protobuf.MessageType) -> TypeGuard["EosActionSellRam"]:
+            return isinstance(msg, cls)
+
+    class EosActionVoteProducer(protobuf.MessageType):
+        voter: "int | None"
+        proxy: "int | None"
+        producers: "list[int]"
+
+        def __init__(
+            self,
+            *,
+            producers: "list[int] | None" = None,
+            voter: "int | None" = None,
+            proxy: "int | None" = None,
+        ) -> None:
+            pass
+
+        @classmethod
+        def is_type_of(cls, msg: protobuf.MessageType) -> TypeGuard["EosActionVoteProducer"]:
+            return isinstance(msg, cls)
+
+    class EosActionUpdateAuth(protobuf.MessageType):
+        account: "int | None"
+        permission: "int | None"
+        parent: "int | None"
+        auth: "EosAuthorization | None"
+
+        def __init__(
+            self,
+            *,
+            account: "int | None" = None,
+            permission: "int | None" = None,
+            parent: "int | None" = None,
+            auth: "EosAuthorization | None" = None,
+        ) -> None:
+            pass
+
+        @classmethod
+        def is_type_of(cls, msg: protobuf.MessageType) -> TypeGuard["EosActionUpdateAuth"]:
+            return isinstance(msg, cls)
+
+    class EosActionDeleteAuth(protobuf.MessageType):
+        account: "int | None"
+        permission: "int | None"
+
+        def __init__(
+            self,
+            *,
+            account: "int | None" = None,
+            permission: "int | None" = None,
+        ) -> None:
+            pass
+
+        @classmethod
+        def is_type_of(cls, msg: protobuf.MessageType) -> TypeGuard["EosActionDeleteAuth"]:
+            return isinstance(msg, cls)
+
+    class EosActionLinkAuth(protobuf.MessageType):
+        account: "int | None"
+        code: "int | None"
+        type: "int | None"
+        requirement: "int | None"
+
+        def __init__(
+            self,
+            *,
+            account: "int | None" = None,
+            code: "int | None" = None,
+            type: "int | None" = None,
+            requirement: "int | None" = None,
+        ) -> None:
+            pass
+
+        @classmethod
+        def is_type_of(cls, msg: protobuf.MessageType) -> TypeGuard["EosActionLinkAuth"]:
+            return isinstance(msg, cls)
+
+    class EosActionUnlinkAuth(protobuf.MessageType):
+        account: "int | None"
+        code: "int | None"
+        type: "int | None"
+
+        def __init__(
+            self,
+            *,
+            account: "int | None" = None,
+            code: "int | None" = None,
+            type: "int | None" = None,
+        ) -> None:
+            pass
+
+        @classmethod
+        def is_type_of(cls, msg: protobuf.MessageType) -> TypeGuard["EosActionUnlinkAuth"]:
+            return isinstance(msg, cls)
+
+    class EosActionNewAccount(protobuf.MessageType):
+        creator: "int | None"
+        name: "int | None"
+        owner: "EosAuthorization | None"
+        active: "EosAuthorization | None"
+
+        def __init__(
+            self,
+            *,
+            creator: "int | None" = None,
+            name: "int | None" = None,
+            owner: "EosAuthorization | None" = None,
+            active: "EosAuthorization | None" = None,
+        ) -> None:
+            pass
+
+        @classmethod
+        def is_type_of(cls, msg: protobuf.MessageType) -> TypeGuard["EosActionNewAccount"]:
+            return isinstance(msg, cls)
+
+    class EosActionUnknown(protobuf.MessageType):
+        data_size: "int"
+        data_chunk: "bytes | None"
+
+        def __init__(
+            self,
+            *,
+            data_size: "int",
+            data_chunk: "bytes | None" = None,
+        ) -> None:
+            pass
+
+        @classmethod
+        def is_type_of(cls, msg: protobuf.MessageType) -> TypeGuard["EosActionUnknown"]:
+            return isinstance(msg, cls)
+
+    class EthereumGetPublicKey(protobuf.MessageType):
+        address_n: "list[int]"
+        show_display: "bool | None"
+
+        def __init__(
+            self,
+            *,
+            address_n: "list[int] | None" = None,
+            show_display: "bool | None" = None,
         ) -> None:
             pass
 
@@ -2885,14 +2885,14 @@ if TYPE_CHECKING:
             return isinstance(msg, cls)
 
     class EthereumPublicKey(protobuf.MessageType):
-        node: HDNodeType
-        xpub: str
+        node: "HDNodeType"
+        xpub: "str"
 
         def __init__(
             self,
             *,
-            node: HDNodeType,
-            xpub: str,
+            node: "HDNodeType",
+            xpub: "str",
         ) -> None:
             pass
 
@@ -2901,14 +2901,14 @@ if TYPE_CHECKING:
             return isinstance(msg, cls)
 
     class EthereumGetAddress(protobuf.MessageType):
-        address_n: list[int]
-        show_display: bool | None
+        address_n: "list[int]"
+        show_display: "bool | None"
 
         def __init__(
             self,
             *,
-            address_n: list[int] | None = None,
-            show_display: bool | None = None,
+            address_n: "list[int] | None" = None,
+            show_display: "bool | None" = None,
         ) -> None:
             pass
 
@@ -2917,12 +2917,12 @@ if TYPE_CHECKING:
             return isinstance(msg, cls)
 
     class EthereumAddress(protobuf.MessageType):
-        address: str | None
+        address: "str | None"
 
         def __init__(
             self,
             *,
-            address: str | None = None,
+            address: "str | None" = None,
         ) -> None:
             pass
 
@@ -2931,30 +2931,30 @@ if TYPE_CHECKING:
             return isinstance(msg, cls)
 
     class EthereumSignTx(protobuf.MessageType):
-        address_n: list[int]
-        nonce: bytes | None
-        gas_price: bytes | None
-        gas_limit: bytes | None
-        to: str | None
-        value: bytes | None
-        data_initial_chunk: bytes | None
-        data_length: int | None
-        chain_id: int | None
-        tx_type: int | None
+        address_n: "list[int]"
+        nonce: "bytes | None"
+        gas_price: "bytes | None"
+        gas_limit: "bytes | None"
+        to: "str | None"
+        value: "bytes | None"
+        data_initial_chunk: "bytes | None"
+        data_length: "int | None"
+        chain_id: "int | None"
+        tx_type: "int | None"
 
         def __init__(
             self,
             *,
-            address_n: list[int] | None = None,
-            nonce: bytes | None = None,
-            gas_price: bytes | None = None,
-            gas_limit: bytes | None = None,
-            to: str | None = None,
-            value: bytes | None = None,
-            data_initial_chunk: bytes | None = None,
-            data_length: int | None = None,
-            chain_id: int | None = None,
-            tx_type: int | None = None,
+            address_n: "list[int] | None" = None,
+            nonce: "bytes | None" = None,
+            gas_price: "bytes | None" = None,
+            gas_limit: "bytes | None" = None,
+            to: "str | None" = None,
+            value: "bytes | None" = None,
+            data_initial_chunk: "bytes | None" = None,
+            data_length: "int | None" = None,
+            chain_id: "int | None" = None,
+            tx_type: "int | None" = None,
         ) -> None:
             pass
 
@@ -2963,18 +2963,18 @@ if TYPE_CHECKING:
             return isinstance(msg, cls)
 
     class EthereumTxRequest(protobuf.MessageType):
-        data_length: int | None
-        signature_v: int | None
-        signature_r: bytes | None
-        signature_s: bytes | None
+        data_length: "int | None"
+        signature_v: "int | None"
+        signature_r: "bytes | None"
+        signature_s: "bytes | None"
 
         def __init__(
             self,
             *,
-            data_length: int | None = None,
-            signature_v: int | None = None,
-            signature_r: bytes | None = None,
-            signature_s: bytes | None = None,
+            data_length: "int | None" = None,
+            signature_v: "int | None" = None,
+            signature_r: "bytes | None" = None,
+            signature_s: "bytes | None" = None,
         ) -> None:
             pass
 
@@ -2983,12 +2983,12 @@ if TYPE_CHECKING:
             return isinstance(msg, cls)
 
     class EthereumTxAck(protobuf.MessageType):
-        data_chunk: bytes | None
+        data_chunk: "bytes | None"
 
         def __init__(
             self,
             *,
-            data_chunk: bytes | None = None,
+            data_chunk: "bytes | None" = None,
         ) -> None:
             pass
 
@@ -2997,14 +2997,14 @@ if TYPE_CHECKING:
             return isinstance(msg, cls)
 
     class EthereumSignMessage(protobuf.MessageType):
-        address_n: list[int]
-        message: bytes | None
+        address_n: "list[int]"
+        message: "bytes | None"
 
         def __init__(
             self,
             *,
-            address_n: list[int] | None = None,
-            message: bytes | None = None,
+            address_n: "list[int] | None" = None,
+            message: "bytes | None" = None,
         ) -> None:
             pass
 
@@ -3013,14 +3013,14 @@ if TYPE_CHECKING:
             return isinstance(msg, cls)
 
     class EthereumMessageSignature(protobuf.MessageType):
-        signature: bytes
-        address: str
+        signature: "bytes"
+        address: "str"
 
         def __init__(
             self,
             *,
-            signature: bytes,
-            address: str,
+            signature: "bytes",
+            address: "str",
         ) -> None:
             pass
 
@@ -3029,16 +3029,16 @@ if TYPE_CHECKING:
             return isinstance(msg, cls)
 
     class EthereumVerifyMessage(protobuf.MessageType):
-        signature: bytes | None
-        message: bytes | None
-        address: str | None
+        signature: "bytes | None"
+        message: "bytes | None"
+        address: "str | None"
 
         def __init__(
             self,
             *,
-            signature: bytes | None = None,
-            message: bytes | None = None,
-            address: str | None = None,
+            signature: "bytes | None" = None,
+            message: "bytes | None" = None,
+            address: "str | None" = None,
         ) -> None:
             pass
 
@@ -3047,14 +3047,14 @@ if TYPE_CHECKING:
             return isinstance(msg, cls)
 
     class LiskGetAddress(protobuf.MessageType):
-        address_n: list[int]
-        show_display: bool | None
+        address_n: "list[int]"
+        show_display: "bool | None"
 
         def __init__(
             self,
             *,
-            address_n: list[int] | None = None,
-            show_display: bool | None = None,
+            address_n: "list[int] | None" = None,
+            show_display: "bool | None" = None,
         ) -> None:
             pass
 
@@ -3063,12 +3063,12 @@ if TYPE_CHECKING:
             return isinstance(msg, cls)
 
     class LiskAddress(protobuf.MessageType):
-        address: str
+        address: "str"
 
         def __init__(
             self,
             *,
-            address: str,
+            address: "str",
         ) -> None:
             pass
 
@@ -3077,14 +3077,14 @@ if TYPE_CHECKING:
             return isinstance(msg, cls)
 
     class LiskGetPublicKey(protobuf.MessageType):
-        address_n: list[int]
-        show_display: bool | None
+        address_n: "list[int]"
+        show_display: "bool | None"
 
         def __init__(
             self,
             *,
-            address_n: list[int] | None = None,
-            show_display: bool | None = None,
+            address_n: "list[int] | None" = None,
+            show_display: "bool | None" = None,
         ) -> None:
             pass
 
@@ -3093,12 +3093,12 @@ if TYPE_CHECKING:
             return isinstance(msg, cls)
 
     class LiskPublicKey(protobuf.MessageType):
-        public_key: bytes
+        public_key: "bytes"
 
         def __init__(
             self,
             *,
-            public_key: bytes,
+            public_key: "bytes",
         ) -> None:
             pass
 
@@ -3106,113 +3106,15 @@ if TYPE_CHECKING:
         def is_type_of(cls, msg: protobuf.MessageType) -> TypeGuard["LiskPublicKey"]:
             return isinstance(msg, cls)
 
-    class LiskSignatureType(protobuf.MessageType):
-        public_key: bytes | None
-
-        def __init__(
-            self,
-            *,
-            public_key: bytes | None = None,
-        ) -> None:
-            pass
-
-        @classmethod
-        def is_type_of(cls, msg: protobuf.MessageType) -> TypeGuard["LiskSignatureType"]:
-            return isinstance(msg, cls)
-
-    class LiskDelegateType(protobuf.MessageType):
-        username: str | None
-
-        def __init__(
-            self,
-            *,
-            username: str | None = None,
-        ) -> None:
-            pass
-
-        @classmethod
-        def is_type_of(cls, msg: protobuf.MessageType) -> TypeGuard["LiskDelegateType"]:
-            return isinstance(msg, cls)
-
-    class LiskMultisignatureType(protobuf.MessageType):
-        min: int | None
-        life_time: int | None
-        keys_group: list[str]
-
-        def __init__(
-            self,
-            *,
-            keys_group: list[str] | None = None,
-            min: int | None = None,
-            life_time: int | None = None,
-        ) -> None:
-            pass
-
-        @classmethod
-        def is_type_of(cls, msg: protobuf.MessageType) -> TypeGuard["LiskMultisignatureType"]:
-            return isinstance(msg, cls)
-
-    class LiskTransactionAsset(protobuf.MessageType):
-        signature: LiskSignatureType | None
-        delegate: LiskDelegateType | None
-        votes: list[str]
-        multisignature: LiskMultisignatureType | None
-        data: str | None
-
-        def __init__(
-            self,
-            *,
-            votes: list[str] | None = None,
-            signature: LiskSignatureType | None = None,
-            delegate: LiskDelegateType | None = None,
-            multisignature: LiskMultisignatureType | None = None,
-            data: str | None = None,
-        ) -> None:
-            pass
-
-        @classmethod
-        def is_type_of(cls, msg: protobuf.MessageType) -> TypeGuard["LiskTransactionAsset"]:
-            return isinstance(msg, cls)
-
-    class LiskTransactionCommon(protobuf.MessageType):
-        type: LiskTransactionType | None
-        amount: int | None
-        fee: int | None
-        recipient_id: str | None
-        sender_public_key: bytes | None
-        requester_public_key: bytes | None
-        signature: bytes | None
-        timestamp: int | None
-        asset: LiskTransactionAsset | None
-
-        def __init__(
-            self,
-            *,
-            type: LiskTransactionType | None = None,
-            amount: int | None = None,
-            fee: int | None = None,
-            recipient_id: str | None = None,
-            sender_public_key: bytes | None = None,
-            requester_public_key: bytes | None = None,
-            signature: bytes | None = None,
-            timestamp: int | None = None,
-            asset: LiskTransactionAsset | None = None,
-        ) -> None:
-            pass
-
-        @classmethod
-        def is_type_of(cls, msg: protobuf.MessageType) -> TypeGuard["LiskTransactionCommon"]:
-            return isinstance(msg, cls)
-
     class LiskSignTx(protobuf.MessageType):
-        address_n: list[int]
-        transaction: LiskTransactionCommon
+        address_n: "list[int]"
+        transaction: "LiskTransactionCommon"
 
         def __init__(
             self,
             *,
-            transaction: LiskTransactionCommon,
-            address_n: list[int] | None = None,
+            transaction: "LiskTransactionCommon",
+            address_n: "list[int] | None" = None,
         ) -> None:
             pass
 
@@ -3221,12 +3123,12 @@ if TYPE_CHECKING:
             return isinstance(msg, cls)
 
     class LiskSignedTx(protobuf.MessageType):
-        signature: bytes
+        signature: "bytes"
 
         def __init__(
             self,
             *,
-            signature: bytes,
+            signature: "bytes",
         ) -> None:
             pass
 
@@ -3235,14 +3137,14 @@ if TYPE_CHECKING:
             return isinstance(msg, cls)
 
     class LiskSignMessage(protobuf.MessageType):
-        address_n: list[int]
-        message: bytes
+        address_n: "list[int]"
+        message: "bytes"
 
         def __init__(
             self,
             *,
-            message: bytes,
-            address_n: list[int] | None = None,
+            message: "bytes",
+            address_n: "list[int] | None" = None,
         ) -> None:
             pass
 
@@ -3251,14 +3153,14 @@ if TYPE_CHECKING:
             return isinstance(msg, cls)
 
     class LiskMessageSignature(protobuf.MessageType):
-        public_key: bytes
-        signature: bytes
+        public_key: "bytes"
+        signature: "bytes"
 
         def __init__(
             self,
             *,
-            public_key: bytes,
-            signature: bytes,
+            public_key: "bytes",
+            signature: "bytes",
         ) -> None:
             pass
 
@@ -3267,16 +3169,16 @@ if TYPE_CHECKING:
             return isinstance(msg, cls)
 
     class LiskVerifyMessage(protobuf.MessageType):
-        public_key: bytes
-        signature: bytes
-        message: bytes
+        public_key: "bytes"
+        signature: "bytes"
+        message: "bytes"
 
         def __init__(
             self,
             *,
-            public_key: bytes,
-            signature: bytes,
-            message: bytes,
+            public_key: "bytes",
+            signature: "bytes",
+            message: "bytes",
         ) -> None:
             pass
 
@@ -3284,83 +3186,129 @@ if TYPE_CHECKING:
         def is_type_of(cls, msg: protobuf.MessageType) -> TypeGuard["LiskVerifyMessage"]:
             return isinstance(msg, cls)
 
-    class MoneroRctKeyPublic(protobuf.MessageType):
-        dest: bytes | None
-        commitment: bytes | None
+    class LiskTransactionCommon(protobuf.MessageType):
+        type: "LiskTransactionType | None"
+        amount: "int | None"
+        fee: "int | None"
+        recipient_id: "str | None"
+        sender_public_key: "bytes | None"
+        requester_public_key: "bytes | None"
+        signature: "bytes | None"
+        timestamp: "int | None"
+        asset: "LiskTransactionAsset | None"
 
         def __init__(
             self,
             *,
-            dest: bytes | None = None,
-            commitment: bytes | None = None,
+            type: "LiskTransactionType | None" = None,
+            amount: "int | None" = None,
+            fee: "int | None" = None,
+            recipient_id: "str | None" = None,
+            sender_public_key: "bytes | None" = None,
+            requester_public_key: "bytes | None" = None,
+            signature: "bytes | None" = None,
+            timestamp: "int | None" = None,
+            asset: "LiskTransactionAsset | None" = None,
         ) -> None:
             pass
 
         @classmethod
-        def is_type_of(cls, msg: protobuf.MessageType) -> TypeGuard["MoneroRctKeyPublic"]:
+        def is_type_of(cls, msg: protobuf.MessageType) -> TypeGuard["LiskTransactionCommon"]:
             return isinstance(msg, cls)
 
-    class MoneroOutputEntry(protobuf.MessageType):
-        idx: int | None
-        key: MoneroRctKeyPublic | None
+    class LiskTransactionAsset(protobuf.MessageType):
+        signature: "LiskSignatureType | None"
+        delegate: "LiskDelegateType | None"
+        votes: "list[str]"
+        multisignature: "LiskMultisignatureType | None"
+        data: "str | None"
 
         def __init__(
             self,
             *,
-            idx: int | None = None,
-            key: MoneroRctKeyPublic | None = None,
+            votes: "list[str] | None" = None,
+            signature: "LiskSignatureType | None" = None,
+            delegate: "LiskDelegateType | None" = None,
+            multisignature: "LiskMultisignatureType | None" = None,
+            data: "str | None" = None,
         ) -> None:
             pass
 
         @classmethod
-        def is_type_of(cls, msg: protobuf.MessageType) -> TypeGuard["MoneroOutputEntry"]:
+        def is_type_of(cls, msg: protobuf.MessageType) -> TypeGuard["LiskTransactionAsset"]:
             return isinstance(msg, cls)
 
-    class MoneroMultisigKLRki(protobuf.MessageType):
-        K: bytes | None
-        L: bytes | None
-        R: bytes | None
-        ki: bytes | None
+    class LiskSignatureType(protobuf.MessageType):
+        public_key: "bytes | None"
 
         def __init__(
             self,
             *,
-            K: bytes | None = None,
-            L: bytes | None = None,
-            R: bytes | None = None,
-            ki: bytes | None = None,
+            public_key: "bytes | None" = None,
         ) -> None:
             pass
 
         @classmethod
-        def is_type_of(cls, msg: protobuf.MessageType) -> TypeGuard["MoneroMultisigKLRki"]:
+        def is_type_of(cls, msg: protobuf.MessageType) -> TypeGuard["LiskSignatureType"]:
+            return isinstance(msg, cls)
+
+    class LiskDelegateType(protobuf.MessageType):
+        username: "str | None"
+
+        def __init__(
+            self,
+            *,
+            username: "str | None" = None,
+        ) -> None:
+            pass
+
+        @classmethod
+        def is_type_of(cls, msg: protobuf.MessageType) -> TypeGuard["LiskDelegateType"]:
+            return isinstance(msg, cls)
+
+    class LiskMultisignatureType(protobuf.MessageType):
+        min: "int | None"
+        life_time: "int | None"
+        keys_group: "list[str]"
+
+        def __init__(
+            self,
+            *,
+            keys_group: "list[str] | None" = None,
+            min: "int | None" = None,
+            life_time: "int | None" = None,
+        ) -> None:
+            pass
+
+        @classmethod
+        def is_type_of(cls, msg: protobuf.MessageType) -> TypeGuard["LiskMultisignatureType"]:
             return isinstance(msg, cls)
 
     class MoneroTransactionSourceEntry(protobuf.MessageType):
-        outputs: list[MoneroOutputEntry]
-        real_output: int | None
-        real_out_tx_key: bytes | None
-        real_out_additional_tx_keys: list[bytes]
-        real_output_in_tx_index: int | None
-        amount: int | None
-        rct: bool | None
-        mask: bytes | None
-        multisig_kLRki: MoneroMultisigKLRki | None
-        subaddr_minor: int | None
+        outputs: "list[MoneroOutputEntry]"
+        real_output: "int | None"
+        real_out_tx_key: "bytes | None"
+        real_out_additional_tx_keys: "list[bytes]"
+        real_output_in_tx_index: "int | None"
+        amount: "int | None"
+        rct: "bool | None"
+        mask: "bytes | None"
+        multisig_kLRki: "MoneroMultisigKLRki | None"
+        subaddr_minor: "int | None"
 
         def __init__(
             self,
             *,
-            outputs: list[MoneroOutputEntry] | None = None,
-            real_out_additional_tx_keys: list[bytes] | None = None,
-            real_output: int | None = None,
-            real_out_tx_key: bytes | None = None,
-            real_output_in_tx_index: int | None = None,
-            amount: int | None = None,
-            rct: bool | None = None,
-            mask: bytes | None = None,
-            multisig_kLRki: MoneroMultisigKLRki | None = None,
-            subaddr_minor: int | None = None,
+            outputs: "list[MoneroOutputEntry] | None" = None,
+            real_out_additional_tx_keys: "list[bytes] | None" = None,
+            real_output: "int | None" = None,
+            real_out_tx_key: "bytes | None" = None,
+            real_output_in_tx_index: "int | None" = None,
+            amount: "int | None" = None,
+            rct: "bool | None" = None,
+            mask: "bytes | None" = None,
+            multisig_kLRki: "MoneroMultisigKLRki | None" = None,
+            subaddr_minor: "int | None" = None,
         ) -> None:
             pass
 
@@ -3368,37 +3316,21 @@ if TYPE_CHECKING:
         def is_type_of(cls, msg: protobuf.MessageType) -> TypeGuard["MoneroTransactionSourceEntry"]:
             return isinstance(msg, cls)
 
-    class MoneroAccountPublicAddress(protobuf.MessageType):
-        spend_public_key: bytes | None
-        view_public_key: bytes | None
-
-        def __init__(
-            self,
-            *,
-            spend_public_key: bytes | None = None,
-            view_public_key: bytes | None = None,
-        ) -> None:
-            pass
-
-        @classmethod
-        def is_type_of(cls, msg: protobuf.MessageType) -> TypeGuard["MoneroAccountPublicAddress"]:
-            return isinstance(msg, cls)
-
     class MoneroTransactionDestinationEntry(protobuf.MessageType):
-        amount: int | None
-        addr: MoneroAccountPublicAddress | None
-        is_subaddress: bool | None
-        original: bytes | None
-        is_integrated: bool | None
+        amount: "int | None"
+        addr: "MoneroAccountPublicAddress | None"
+        is_subaddress: "bool | None"
+        original: "bytes | None"
+        is_integrated: "bool | None"
 
         def __init__(
             self,
             *,
-            amount: int | None = None,
-            addr: MoneroAccountPublicAddress | None = None,
-            is_subaddress: bool | None = None,
-            original: bytes | None = None,
-            is_integrated: bool | None = None,
+            amount: "int | None" = None,
+            addr: "MoneroAccountPublicAddress | None" = None,
+            is_subaddress: "bool | None" = None,
+            original: "bytes | None" = None,
+            is_integrated: "bool | None" = None,
         ) -> None:
             pass
 
@@ -3407,24 +3339,24 @@ if TYPE_CHECKING:
             return isinstance(msg, cls)
 
     class MoneroTransactionRsigData(protobuf.MessageType):
-        rsig_type: int | None
-        offload_type: int | None
-        grouping: list[int]
-        mask: bytes | None
-        rsig: bytes | None
-        rsig_parts: list[bytes]
-        bp_version: int | None
+        rsig_type: "int | None"
+        offload_type: "int | None"
+        grouping: "list[int]"
+        mask: "bytes | None"
+        rsig: "bytes | None"
+        rsig_parts: "list[bytes]"
+        bp_version: "int | None"
 
         def __init__(
             self,
             *,
-            grouping: list[int] | None = None,
-            rsig_parts: list[bytes] | None = None,
-            rsig_type: int | None = None,
-            offload_type: int | None = None,
-            mask: bytes | None = None,
-            rsig: bytes | None = None,
-            bp_version: int | None = None,
+            grouping: "list[int] | None" = None,
+            rsig_parts: "list[bytes] | None" = None,
+            rsig_type: "int | None" = None,
+            offload_type: "int | None" = None,
+            mask: "bytes | None" = None,
+            rsig: "bytes | None" = None,
+            bp_version: "int | None" = None,
         ) -> None:
             pass
 
@@ -3433,22 +3365,22 @@ if TYPE_CHECKING:
             return isinstance(msg, cls)
 
     class MoneroGetAddress(protobuf.MessageType):
-        address_n: list[int]
-        show_display: bool | None
-        network_type: int | None
-        account: int | None
-        minor: int | None
-        payment_id: bytes | None
+        address_n: "list[int]"
+        show_display: "bool | None"
+        network_type: "int | None"
+        account: "int | None"
+        minor: "int | None"
+        payment_id: "bytes | None"
 
         def __init__(
             self,
             *,
-            address_n: list[int] | None = None,
-            show_display: bool | None = None,
-            network_type: int | None = None,
-            account: int | None = None,
-            minor: int | None = None,
-            payment_id: bytes | None = None,
+            address_n: "list[int] | None" = None,
+            show_display: "bool | None" = None,
+            network_type: "int | None" = None,
+            account: "int | None" = None,
+            minor: "int | None" = None,
+            payment_id: "bytes | None" = None,
         ) -> None:
             pass
 
@@ -3457,12 +3389,12 @@ if TYPE_CHECKING:
             return isinstance(msg, cls)
 
     class MoneroAddress(protobuf.MessageType):
-        address: bytes | None
+        address: "bytes | None"
 
         def __init__(
             self,
             *,
-            address: bytes | None = None,
+            address: "bytes | None" = None,
         ) -> None:
             pass
 
@@ -3471,14 +3403,14 @@ if TYPE_CHECKING:
             return isinstance(msg, cls)
 
     class MoneroGetWatchKey(protobuf.MessageType):
-        address_n: list[int]
-        network_type: int | None
+        address_n: "list[int]"
+        network_type: "int | None"
 
         def __init__(
             self,
             *,
-            address_n: list[int] | None = None,
-            network_type: int | None = None,
+            address_n: "list[int] | None" = None,
+            network_type: "int | None" = None,
         ) -> None:
             pass
 
@@ -3487,14 +3419,14 @@ if TYPE_CHECKING:
             return isinstance(msg, cls)
 
     class MoneroWatchKey(protobuf.MessageType):
-        watch_key: bytes | None
-        address: bytes | None
+        watch_key: "bytes | None"
+        address: "bytes | None"
 
         def __init__(
             self,
             *,
-            watch_key: bytes | None = None,
-            address: bytes | None = None,
+            watch_key: "bytes | None" = None,
+            address: "bytes | None" = None,
         ) -> None:
             pass
 
@@ -3502,61 +3434,19 @@ if TYPE_CHECKING:
         def is_type_of(cls, msg: protobuf.MessageType) -> TypeGuard["MoneroWatchKey"]:
             return isinstance(msg, cls)
 
-    class MoneroTransactionData(protobuf.MessageType):
-        version: int | None
-        payment_id: bytes | None
-        unlock_time: int | None
-        outputs: list[MoneroTransactionDestinationEntry]
-        change_dts: MoneroTransactionDestinationEntry | None
-        num_inputs: int | None
-        mixin: int | None
-        fee: int | None
-        account: int | None
-        minor_indices: list[int]
-        rsig_data: MoneroTransactionRsigData | None
-        integrated_indices: list[int]
-        client_version: int | None
-        hard_fork: int | None
-        monero_version: bytes | None
-
-        def __init__(
-            self,
-            *,
-            outputs: list[MoneroTransactionDestinationEntry] | None = None,
-            minor_indices: list[int] | None = None,
-            integrated_indices: list[int] | None = None,
-            version: int | None = None,
-            payment_id: bytes | None = None,
-            unlock_time: int | None = None,
-            change_dts: MoneroTransactionDestinationEntry | None = None,
-            num_inputs: int | None = None,
-            mixin: int | None = None,
-            fee: int | None = None,
-            account: int | None = None,
-            rsig_data: MoneroTransactionRsigData | None = None,
-            client_version: int | None = None,
-            hard_fork: int | None = None,
-            monero_version: bytes | None = None,
-        ) -> None:
-            pass
-
-        @classmethod
-        def is_type_of(cls, msg: protobuf.MessageType) -> TypeGuard["MoneroTransactionData"]:
-            return isinstance(msg, cls)
-
     class MoneroTransactionInitRequest(protobuf.MessageType):
-        version: int | None
-        address_n: list[int]
-        network_type: int | None
-        tsx_data: MoneroTransactionData | None
+        version: "int | None"
+        address_n: "list[int]"
+        network_type: "int | None"
+        tsx_data: "MoneroTransactionData | None"
 
         def __init__(
             self,
             *,
-            address_n: list[int] | None = None,
-            version: int | None = None,
-            network_type: int | None = None,
-            tsx_data: MoneroTransactionData | None = None,
+            address_n: "list[int] | None" = None,
+            version: "int | None" = None,
+            network_type: "int | None" = None,
+            tsx_data: "MoneroTransactionData | None" = None,
         ) -> None:
             pass
 
@@ -3565,14 +3455,14 @@ if TYPE_CHECKING:
             return isinstance(msg, cls)
 
     class MoneroTransactionInitAck(protobuf.MessageType):
-        hmacs: list[bytes]
-        rsig_data: MoneroTransactionRsigData | None
+        hmacs: "list[bytes]"
+        rsig_data: "MoneroTransactionRsigData | None"
 
         def __init__(
             self,
             *,
-            hmacs: list[bytes] | None = None,
-            rsig_data: MoneroTransactionRsigData | None = None,
+            hmacs: "list[bytes] | None" = None,
+            rsig_data: "MoneroTransactionRsigData | None" = None,
         ) -> None:
             pass
 
@@ -3581,12 +3471,12 @@ if TYPE_CHECKING:
             return isinstance(msg, cls)
 
     class MoneroTransactionSetInputRequest(protobuf.MessageType):
-        src_entr: MoneroTransactionSourceEntry | None
+        src_entr: "MoneroTransactionSourceEntry | None"
 
         def __init__(
             self,
             *,
-            src_entr: MoneroTransactionSourceEntry | None = None,
+            src_entr: "MoneroTransactionSourceEntry | None" = None,
         ) -> None:
             pass
 
@@ -3595,22 +3485,22 @@ if TYPE_CHECKING:
             return isinstance(msg, cls)
 
     class MoneroTransactionSetInputAck(protobuf.MessageType):
-        vini: bytes | None
-        vini_hmac: bytes | None
-        pseudo_out: bytes | None
-        pseudo_out_hmac: bytes | None
-        pseudo_out_alpha: bytes | None
-        spend_key: bytes | None
+        vini: "bytes | None"
+        vini_hmac: "bytes | None"
+        pseudo_out: "bytes | None"
+        pseudo_out_hmac: "bytes | None"
+        pseudo_out_alpha: "bytes | None"
+        spend_key: "bytes | None"
 
         def __init__(
             self,
             *,
-            vini: bytes | None = None,
-            vini_hmac: bytes | None = None,
-            pseudo_out: bytes | None = None,
-            pseudo_out_hmac: bytes | None = None,
-            pseudo_out_alpha: bytes | None = None,
-            spend_key: bytes | None = None,
+            vini: "bytes | None" = None,
+            vini_hmac: "bytes | None" = None,
+            pseudo_out: "bytes | None" = None,
+            pseudo_out_hmac: "bytes | None" = None,
+            pseudo_out_alpha: "bytes | None" = None,
+            spend_key: "bytes | None" = None,
         ) -> None:
             pass
 
@@ -3619,12 +3509,12 @@ if TYPE_CHECKING:
             return isinstance(msg, cls)
 
     class MoneroTransactionInputsPermutationRequest(protobuf.MessageType):
-        perm: list[int]
+        perm: "list[int]"
 
         def __init__(
             self,
             *,
-            perm: list[int] | None = None,
+            perm: "list[int] | None" = None,
         ) -> None:
             pass
 
@@ -3639,22 +3529,22 @@ if TYPE_CHECKING:
             return isinstance(msg, cls)
 
     class MoneroTransactionInputViniRequest(protobuf.MessageType):
-        src_entr: MoneroTransactionSourceEntry | None
-        vini: bytes | None
-        vini_hmac: bytes | None
-        pseudo_out: bytes | None
-        pseudo_out_hmac: bytes | None
-        orig_idx: int | None
+        src_entr: "MoneroTransactionSourceEntry | None"
+        vini: "bytes | None"
+        vini_hmac: "bytes | None"
+        pseudo_out: "bytes | None"
+        pseudo_out_hmac: "bytes | None"
+        orig_idx: "int | None"
 
         def __init__(
             self,
             *,
-            src_entr: MoneroTransactionSourceEntry | None = None,
-            vini: bytes | None = None,
-            vini_hmac: bytes | None = None,
-            pseudo_out: bytes | None = None,
-            pseudo_out_hmac: bytes | None = None,
-            orig_idx: int | None = None,
+            src_entr: "MoneroTransactionSourceEntry | None" = None,
+            vini: "bytes | None" = None,
+            vini_hmac: "bytes | None" = None,
+            pseudo_out: "bytes | None" = None,
+            pseudo_out_hmac: "bytes | None" = None,
+            orig_idx: "int | None" = None,
         ) -> None:
             pass
 
@@ -3675,12 +3565,12 @@ if TYPE_CHECKING:
             return isinstance(msg, cls)
 
     class MoneroTransactionAllInputsSetAck(protobuf.MessageType):
-        rsig_data: MoneroTransactionRsigData | None
+        rsig_data: "MoneroTransactionRsigData | None"
 
         def __init__(
             self,
             *,
-            rsig_data: MoneroTransactionRsigData | None = None,
+            rsig_data: "MoneroTransactionRsigData | None" = None,
         ) -> None:
             pass
 
@@ -3689,18 +3579,18 @@ if TYPE_CHECKING:
             return isinstance(msg, cls)
 
     class MoneroTransactionSetOutputRequest(protobuf.MessageType):
-        dst_entr: MoneroTransactionDestinationEntry | None
-        dst_entr_hmac: bytes | None
-        rsig_data: MoneroTransactionRsigData | None
-        is_offloaded_bp: bool | None
+        dst_entr: "MoneroTransactionDestinationEntry | None"
+        dst_entr_hmac: "bytes | None"
+        rsig_data: "MoneroTransactionRsigData | None"
+        is_offloaded_bp: "bool | None"
 
         def __init__(
             self,
             *,
-            dst_entr: MoneroTransactionDestinationEntry | None = None,
-            dst_entr_hmac: bytes | None = None,
-            rsig_data: MoneroTransactionRsigData | None = None,
-            is_offloaded_bp: bool | None = None,
+            dst_entr: "MoneroTransactionDestinationEntry | None" = None,
+            dst_entr_hmac: "bytes | None" = None,
+            rsig_data: "MoneroTransactionRsigData | None" = None,
+            is_offloaded_bp: "bool | None" = None,
         ) -> None:
             pass
 
@@ -3709,20 +3599,20 @@ if TYPE_CHECKING:
             return isinstance(msg, cls)
 
     class MoneroTransactionSetOutputAck(protobuf.MessageType):
-        tx_out: bytes | None
-        vouti_hmac: bytes | None
-        rsig_data: MoneroTransactionRsigData | None
-        out_pk: bytes | None
-        ecdh_info: bytes | None
+        tx_out: "bytes | None"
+        vouti_hmac: "bytes | None"
+        rsig_data: "MoneroTransactionRsigData | None"
+        out_pk: "bytes | None"
+        ecdh_info: "bytes | None"
 
         def __init__(
             self,
             *,
-            tx_out: bytes | None = None,
-            vouti_hmac: bytes | None = None,
-            rsig_data: MoneroTransactionRsigData | None = None,
-            out_pk: bytes | None = None,
-            ecdh_info: bytes | None = None,
+            tx_out: "bytes | None" = None,
+            vouti_hmac: "bytes | None" = None,
+            rsig_data: "MoneroTransactionRsigData | None" = None,
+            out_pk: "bytes | None" = None,
+            ecdh_info: "bytes | None" = None,
         ) -> None:
             pass
 
@@ -3731,12 +3621,12 @@ if TYPE_CHECKING:
             return isinstance(msg, cls)
 
     class MoneroTransactionAllOutSetRequest(protobuf.MessageType):
-        rsig_data: MoneroTransactionRsigData | None
+        rsig_data: "MoneroTransactionRsigData | None"
 
         def __init__(
             self,
             *,
-            rsig_data: MoneroTransactionRsigData | None = None,
+            rsig_data: "MoneroTransactionRsigData | None" = None,
         ) -> None:
             pass
 
@@ -3744,37 +3634,19 @@ if TYPE_CHECKING:
         def is_type_of(cls, msg: protobuf.MessageType) -> TypeGuard["MoneroTransactionAllOutSetRequest"]:
             return isinstance(msg, cls)
 
-    class MoneroRingCtSig(protobuf.MessageType):
-        txn_fee: int | None
-        message: bytes | None
-        rv_type: int | None
-
-        def __init__(
-            self,
-            *,
-            txn_fee: int | None = None,
-            message: bytes | None = None,
-            rv_type: int | None = None,
-        ) -> None:
-            pass
-
-        @classmethod
-        def is_type_of(cls, msg: protobuf.MessageType) -> TypeGuard["MoneroRingCtSig"]:
-            return isinstance(msg, cls)
-
     class MoneroTransactionAllOutSetAck(protobuf.MessageType):
-        extra: bytes | None
-        tx_prefix_hash: bytes | None
-        rv: MoneroRingCtSig | None
-        full_message_hash: bytes | None
+        extra: "bytes | None"
+        tx_prefix_hash: "bytes | None"
+        rv: "MoneroRingCtSig | None"
+        full_message_hash: "bytes | None"
 
         def __init__(
             self,
             *,
-            extra: bytes | None = None,
-            tx_prefix_hash: bytes | None = None,
-            rv: MoneroRingCtSig | None = None,
-            full_message_hash: bytes | None = None,
+            extra: "bytes | None" = None,
+            tx_prefix_hash: "bytes | None" = None,
+            rv: "MoneroRingCtSig | None" = None,
+            full_message_hash: "bytes | None" = None,
         ) -> None:
             pass
 
@@ -3783,26 +3655,26 @@ if TYPE_CHECKING:
             return isinstance(msg, cls)
 
     class MoneroTransactionSignInputRequest(protobuf.MessageType):
-        src_entr: MoneroTransactionSourceEntry | None
-        vini: bytes | None
-        vini_hmac: bytes | None
-        pseudo_out: bytes | None
-        pseudo_out_hmac: bytes | None
-        pseudo_out_alpha: bytes | None
-        spend_key: bytes | None
-        orig_idx: int | None
+        src_entr: "MoneroTransactionSourceEntry | None"
+        vini: "bytes | None"
+        vini_hmac: "bytes | None"
+        pseudo_out: "bytes | None"
+        pseudo_out_hmac: "bytes | None"
+        pseudo_out_alpha: "bytes | None"
+        spend_key: "bytes | None"
+        orig_idx: "int | None"
 
         def __init__(
             self,
             *,
-            src_entr: MoneroTransactionSourceEntry | None = None,
-            vini: bytes | None = None,
-            vini_hmac: bytes | None = None,
-            pseudo_out: bytes | None = None,
-            pseudo_out_hmac: bytes | None = None,
-            pseudo_out_alpha: bytes | None = None,
-            spend_key: bytes | None = None,
-            orig_idx: int | None = None,
+            src_entr: "MoneroTransactionSourceEntry | None" = None,
+            vini: "bytes | None" = None,
+            vini_hmac: "bytes | None" = None,
+            pseudo_out: "bytes | None" = None,
+            pseudo_out_hmac: "bytes | None" = None,
+            pseudo_out_alpha: "bytes | None" = None,
+            spend_key: "bytes | None" = None,
+            orig_idx: "int | None" = None,
         ) -> None:
             pass
 
@@ -3811,14 +3683,14 @@ if TYPE_CHECKING:
             return isinstance(msg, cls)
 
     class MoneroTransactionSignInputAck(protobuf.MessageType):
-        signature: bytes | None
-        pseudo_out: bytes | None
+        signature: "bytes | None"
+        pseudo_out: "bytes | None"
 
         def __init__(
             self,
             *,
-            signature: bytes | None = None,
-            pseudo_out: bytes | None = None,
+            signature: "bytes | None" = None,
+            pseudo_out: "bytes | None" = None,
         ) -> None:
             pass
 
@@ -3833,20 +3705,20 @@ if TYPE_CHECKING:
             return isinstance(msg, cls)
 
     class MoneroTransactionFinalAck(protobuf.MessageType):
-        cout_key: bytes | None
-        salt: bytes | None
-        rand_mult: bytes | None
-        tx_enc_keys: bytes | None
-        opening_key: bytes | None
+        cout_key: "bytes | None"
+        salt: "bytes | None"
+        rand_mult: "bytes | None"
+        tx_enc_keys: "bytes | None"
+        opening_key: "bytes | None"
 
         def __init__(
             self,
             *,
-            cout_key: bytes | None = None,
-            salt: bytes | None = None,
-            rand_mult: bytes | None = None,
-            tx_enc_keys: bytes | None = None,
-            opening_key: bytes | None = None,
+            cout_key: "bytes | None" = None,
+            salt: "bytes | None" = None,
+            rand_mult: "bytes | None" = None,
+            tx_enc_keys: "bytes | None" = None,
+            opening_key: "bytes | None" = None,
         ) -> None:
             pass
 
@@ -3854,37 +3726,21 @@ if TYPE_CHECKING:
         def is_type_of(cls, msg: protobuf.MessageType) -> TypeGuard["MoneroTransactionFinalAck"]:
             return isinstance(msg, cls)
 
-    class MoneroSubAddressIndicesList(protobuf.MessageType):
-        account: int | None
-        minor_indices: list[int]
-
-        def __init__(
-            self,
-            *,
-            minor_indices: list[int] | None = None,
-            account: int | None = None,
-        ) -> None:
-            pass
-
-        @classmethod
-        def is_type_of(cls, msg: protobuf.MessageType) -> TypeGuard["MoneroSubAddressIndicesList"]:
-            return isinstance(msg, cls)
-
     class MoneroKeyImageExportInitRequest(protobuf.MessageType):
-        num: int | None
-        hash: bytes | None
-        address_n: list[int]
-        network_type: int | None
-        subs: list[MoneroSubAddressIndicesList]
+        num: "int | None"
+        hash: "bytes | None"
+        address_n: "list[int]"
+        network_type: "int | None"
+        subs: "list[MoneroSubAddressIndicesList]"
 
         def __init__(
             self,
             *,
-            address_n: list[int] | None = None,
-            subs: list[MoneroSubAddressIndicesList] | None = None,
-            num: int | None = None,
-            hash: bytes | None = None,
-            network_type: int | None = None,
+            address_n: "list[int] | None" = None,
+            subs: "list[MoneroSubAddressIndicesList] | None" = None,
+            num: "int | None" = None,
+            hash: "bytes | None" = None,
+            network_type: "int | None" = None,
         ) -> None:
             pass
 
@@ -3898,37 +3754,13 @@ if TYPE_CHECKING:
         def is_type_of(cls, msg: protobuf.MessageType) -> TypeGuard["MoneroKeyImageExportInitAck"]:
             return isinstance(msg, cls)
 
-    class MoneroTransferDetails(protobuf.MessageType):
-        out_key: bytes | None
-        tx_pub_key: bytes | None
-        additional_tx_pub_keys: list[bytes]
-        internal_output_index: int | None
-        sub_addr_major: int | None
-        sub_addr_minor: int | None
-
-        def __init__(
-            self,
-            *,
-            additional_tx_pub_keys: list[bytes] | None = None,
-            out_key: bytes | None = None,
-            tx_pub_key: bytes | None = None,
-            internal_output_index: int | None = None,
-            sub_addr_major: int | None = None,
-            sub_addr_minor: int | None = None,
-        ) -> None:
-            pass
-
-        @classmethod
-        def is_type_of(cls, msg: protobuf.MessageType) -> TypeGuard["MoneroTransferDetails"]:
-            return isinstance(msg, cls)
-
     class MoneroKeyImageSyncStepRequest(protobuf.MessageType):
-        tdis: list[MoneroTransferDetails]
+        tdis: "list[MoneroTransferDetails]"
 
         def __init__(
             self,
             *,
-            tdis: list[MoneroTransferDetails] | None = None,
+            tdis: "list[MoneroTransferDetails] | None" = None,
         ) -> None:
             pass
 
@@ -3936,29 +3768,13 @@ if TYPE_CHECKING:
         def is_type_of(cls, msg: protobuf.MessageType) -> TypeGuard["MoneroKeyImageSyncStepRequest"]:
             return isinstance(msg, cls)
 
-    class MoneroExportedKeyImage(protobuf.MessageType):
-        iv: bytes | None
-        blob: bytes | None
-
-        def __init__(
-            self,
-            *,
-            iv: bytes | None = None,
-            blob: bytes | None = None,
-        ) -> None:
-            pass
-
-        @classmethod
-        def is_type_of(cls, msg: protobuf.MessageType) -> TypeGuard["MoneroExportedKeyImage"]:
-            return isinstance(msg, cls)
-
     class MoneroKeyImageSyncStepAck(protobuf.MessageType):
-        kis: list[MoneroExportedKeyImage]
+        kis: "list[MoneroExportedKeyImage]"
 
         def __init__(
             self,
             *,
-            kis: list[MoneroExportedKeyImage] | None = None,
+            kis: "list[MoneroExportedKeyImage] | None" = None,
         ) -> None:
             pass
 
@@ -3973,12 +3789,12 @@ if TYPE_CHECKING:
             return isinstance(msg, cls)
 
     class MoneroKeyImageSyncFinalAck(protobuf.MessageType):
-        enc_key: bytes | None
+        enc_key: "bytes | None"
 
         def __init__(
             self,
             *,
-            enc_key: bytes | None = None,
+            enc_key: "bytes | None" = None,
         ) -> None:
             pass
 
@@ -3987,26 +3803,26 @@ if TYPE_CHECKING:
             return isinstance(msg, cls)
 
     class MoneroGetTxKeyRequest(protobuf.MessageType):
-        address_n: list[int]
-        network_type: int | None
-        salt1: bytes | None
-        salt2: bytes | None
-        tx_enc_keys: bytes | None
-        tx_prefix_hash: bytes | None
-        reason: int | None
-        view_public_key: bytes | None
+        address_n: "list[int]"
+        network_type: "int | None"
+        salt1: "bytes | None"
+        salt2: "bytes | None"
+        tx_enc_keys: "bytes | None"
+        tx_prefix_hash: "bytes | None"
+        reason: "int | None"
+        view_public_key: "bytes | None"
 
         def __init__(
             self,
             *,
-            address_n: list[int] | None = None,
-            network_type: int | None = None,
-            salt1: bytes | None = None,
-            salt2: bytes | None = None,
-            tx_enc_keys: bytes | None = None,
-            tx_prefix_hash: bytes | None = None,
-            reason: int | None = None,
-            view_public_key: bytes | None = None,
+            address_n: "list[int] | None" = None,
+            network_type: "int | None" = None,
+            salt1: "bytes | None" = None,
+            salt2: "bytes | None" = None,
+            tx_enc_keys: "bytes | None" = None,
+            tx_prefix_hash: "bytes | None" = None,
+            reason: "int | None" = None,
+            view_public_key: "bytes | None" = None,
         ) -> None:
             pass
 
@@ -4015,16 +3831,16 @@ if TYPE_CHECKING:
             return isinstance(msg, cls)
 
     class MoneroGetTxKeyAck(protobuf.MessageType):
-        salt: bytes | None
-        tx_keys: bytes | None
-        tx_derivations: bytes | None
+        salt: "bytes | None"
+        tx_keys: "bytes | None"
+        tx_derivations: "bytes | None"
 
         def __init__(
             self,
             *,
-            salt: bytes | None = None,
-            tx_keys: bytes | None = None,
-            tx_derivations: bytes | None = None,
+            salt: "bytes | None" = None,
+            tx_keys: "bytes | None" = None,
+            tx_derivations: "bytes | None" = None,
         ) -> None:
             pass
 
@@ -4033,14 +3849,14 @@ if TYPE_CHECKING:
             return isinstance(msg, cls)
 
     class MoneroLiveRefreshStartRequest(protobuf.MessageType):
-        address_n: list[int]
-        network_type: int | None
+        address_n: "list[int]"
+        network_type: "int | None"
 
         def __init__(
             self,
             *,
-            address_n: list[int] | None = None,
-            network_type: int | None = None,
+            address_n: "list[int] | None" = None,
+            network_type: "int | None" = None,
         ) -> None:
             pass
 
@@ -4055,20 +3871,20 @@ if TYPE_CHECKING:
             return isinstance(msg, cls)
 
     class MoneroLiveRefreshStepRequest(protobuf.MessageType):
-        out_key: bytes | None
-        recv_deriv: bytes | None
-        real_out_idx: int | None
-        sub_addr_major: int | None
-        sub_addr_minor: int | None
+        out_key: "bytes | None"
+        recv_deriv: "bytes | None"
+        real_out_idx: "int | None"
+        sub_addr_major: "int | None"
+        sub_addr_minor: "int | None"
 
         def __init__(
             self,
             *,
-            out_key: bytes | None = None,
-            recv_deriv: bytes | None = None,
-            real_out_idx: int | None = None,
-            sub_addr_major: int | None = None,
-            sub_addr_minor: int | None = None,
+            out_key: "bytes | None" = None,
+            recv_deriv: "bytes | None" = None,
+            real_out_idx: "int | None" = None,
+            sub_addr_major: "int | None" = None,
+            sub_addr_minor: "int | None" = None,
         ) -> None:
             pass
 
@@ -4077,14 +3893,14 @@ if TYPE_CHECKING:
             return isinstance(msg, cls)
 
     class MoneroLiveRefreshStepAck(protobuf.MessageType):
-        salt: bytes | None
-        key_image: bytes | None
+        salt: "bytes | None"
+        key_image: "bytes | None"
 
         def __init__(
             self,
             *,
-            salt: bytes | None = None,
-            key_image: bytes | None = None,
+            salt: "bytes | None" = None,
+            key_image: "bytes | None" = None,
         ) -> None:
             pass
 
@@ -4105,22 +3921,22 @@ if TYPE_CHECKING:
             return isinstance(msg, cls)
 
     class DebugMoneroDiagRequest(protobuf.MessageType):
-        ins: int | None
-        p1: int | None
-        p2: int | None
-        pd: list[int]
-        data1: bytes | None
-        data2: bytes | None
+        ins: "int | None"
+        p1: "int | None"
+        p2: "int | None"
+        pd: "list[int]"
+        data1: "bytes | None"
+        data2: "bytes | None"
 
         def __init__(
             self,
             *,
-            pd: list[int] | None = None,
-            ins: int | None = None,
-            p1: int | None = None,
-            p2: int | None = None,
-            data1: bytes | None = None,
-            data2: bytes | None = None,
+            pd: "list[int] | None" = None,
+            ins: "int | None" = None,
+            p1: "int | None" = None,
+            p2: "int | None" = None,
+            data1: "bytes | None" = None,
+            data2: "bytes | None" = None,
         ) -> None:
             pass
 
@@ -4129,22 +3945,22 @@ if TYPE_CHECKING:
             return isinstance(msg, cls)
 
     class DebugMoneroDiagAck(protobuf.MessageType):
-        ins: int | None
-        p1: int | None
-        p2: int | None
-        pd: list[int]
-        data1: bytes | None
-        data2: bytes | None
+        ins: "int | None"
+        p1: "int | None"
+        p2: "int | None"
+        pd: "list[int]"
+        data1: "bytes | None"
+        data2: "bytes | None"
 
         def __init__(
             self,
             *,
-            pd: list[int] | None = None,
-            ins: int | None = None,
-            p1: int | None = None,
-            p2: int | None = None,
-            data1: bytes | None = None,
-            data2: bytes | None = None,
+            pd: "list[int] | None" = None,
+            ins: "int | None" = None,
+            p1: "int | None" = None,
+            p2: "int | None" = None,
+            data1: "bytes | None" = None,
+            data2: "bytes | None" = None,
         ) -> None:
             pass
 
@@ -4152,17 +3968,201 @@ if TYPE_CHECKING:
         def is_type_of(cls, msg: protobuf.MessageType) -> TypeGuard["DebugMoneroDiagAck"]:
             return isinstance(msg, cls)
 
-    class NEMGetAddress(protobuf.MessageType):
-        address_n: list[int]
-        network: int | None
-        show_display: bool | None
+    class MoneroOutputEntry(protobuf.MessageType):
+        idx: "int | None"
+        key: "MoneroRctKeyPublic | None"
 
         def __init__(
             self,
             *,
-            address_n: list[int] | None = None,
-            network: int | None = None,
-            show_display: bool | None = None,
+            idx: "int | None" = None,
+            key: "MoneroRctKeyPublic | None" = None,
+        ) -> None:
+            pass
+
+        @classmethod
+        def is_type_of(cls, msg: protobuf.MessageType) -> TypeGuard["MoneroOutputEntry"]:
+            return isinstance(msg, cls)
+
+    class MoneroMultisigKLRki(protobuf.MessageType):
+        K: "bytes | None"
+        L: "bytes | None"
+        R: "bytes | None"
+        ki: "bytes | None"
+
+        def __init__(
+            self,
+            *,
+            K: "bytes | None" = None,
+            L: "bytes | None" = None,
+            R: "bytes | None" = None,
+            ki: "bytes | None" = None,
+        ) -> None:
+            pass
+
+        @classmethod
+        def is_type_of(cls, msg: protobuf.MessageType) -> TypeGuard["MoneroMultisigKLRki"]:
+            return isinstance(msg, cls)
+
+    class MoneroRctKeyPublic(protobuf.MessageType):
+        dest: "bytes | None"
+        commitment: "bytes | None"
+
+        def __init__(
+            self,
+            *,
+            dest: "bytes | None" = None,
+            commitment: "bytes | None" = None,
+        ) -> None:
+            pass
+
+        @classmethod
+        def is_type_of(cls, msg: protobuf.MessageType) -> TypeGuard["MoneroRctKeyPublic"]:
+            return isinstance(msg, cls)
+
+    class MoneroAccountPublicAddress(protobuf.MessageType):
+        spend_public_key: "bytes | None"
+        view_public_key: "bytes | None"
+
+        def __init__(
+            self,
+            *,
+            spend_public_key: "bytes | None" = None,
+            view_public_key: "bytes | None" = None,
+        ) -> None:
+            pass
+
+        @classmethod
+        def is_type_of(cls, msg: protobuf.MessageType) -> TypeGuard["MoneroAccountPublicAddress"]:
+            return isinstance(msg, cls)
+
+    class MoneroTransactionData(protobuf.MessageType):
+        version: "int | None"
+        payment_id: "bytes | None"
+        unlock_time: "int | None"
+        outputs: "list[MoneroTransactionDestinationEntry]"
+        change_dts: "MoneroTransactionDestinationEntry | None"
+        num_inputs: "int | None"
+        mixin: "int | None"
+        fee: "int | None"
+        account: "int | None"
+        minor_indices: "list[int]"
+        rsig_data: "MoneroTransactionRsigData | None"
+        integrated_indices: "list[int]"
+        client_version: "int | None"
+        hard_fork: "int | None"
+        monero_version: "bytes | None"
+
+        def __init__(
+            self,
+            *,
+            outputs: "list[MoneroTransactionDestinationEntry] | None" = None,
+            minor_indices: "list[int] | None" = None,
+            integrated_indices: "list[int] | None" = None,
+            version: "int | None" = None,
+            payment_id: "bytes | None" = None,
+            unlock_time: "int | None" = None,
+            change_dts: "MoneroTransactionDestinationEntry | None" = None,
+            num_inputs: "int | None" = None,
+            mixin: "int | None" = None,
+            fee: "int | None" = None,
+            account: "int | None" = None,
+            rsig_data: "MoneroTransactionRsigData | None" = None,
+            client_version: "int | None" = None,
+            hard_fork: "int | None" = None,
+            monero_version: "bytes | None" = None,
+        ) -> None:
+            pass
+
+        @classmethod
+        def is_type_of(cls, msg: protobuf.MessageType) -> TypeGuard["MoneroTransactionData"]:
+            return isinstance(msg, cls)
+
+    class MoneroRingCtSig(protobuf.MessageType):
+        txn_fee: "int | None"
+        message: "bytes | None"
+        rv_type: "int | None"
+
+        def __init__(
+            self,
+            *,
+            txn_fee: "int | None" = None,
+            message: "bytes | None" = None,
+            rv_type: "int | None" = None,
+        ) -> None:
+            pass
+
+        @classmethod
+        def is_type_of(cls, msg: protobuf.MessageType) -> TypeGuard["MoneroRingCtSig"]:
+            return isinstance(msg, cls)
+
+    class MoneroSubAddressIndicesList(protobuf.MessageType):
+        account: "int | None"
+        minor_indices: "list[int]"
+
+        def __init__(
+            self,
+            *,
+            minor_indices: "list[int] | None" = None,
+            account: "int | None" = None,
+        ) -> None:
+            pass
+
+        @classmethod
+        def is_type_of(cls, msg: protobuf.MessageType) -> TypeGuard["MoneroSubAddressIndicesList"]:
+            return isinstance(msg, cls)
+
+    class MoneroTransferDetails(protobuf.MessageType):
+        out_key: "bytes | None"
+        tx_pub_key: "bytes | None"
+        additional_tx_pub_keys: "list[bytes]"
+        internal_output_index: "int | None"
+        sub_addr_major: "int | None"
+        sub_addr_minor: "int | None"
+
+        def __init__(
+            self,
+            *,
+            additional_tx_pub_keys: "list[bytes] | None" = None,
+            out_key: "bytes | None" = None,
+            tx_pub_key: "bytes | None" = None,
+            internal_output_index: "int | None" = None,
+            sub_addr_major: "int | None" = None,
+            sub_addr_minor: "int | None" = None,
+        ) -> None:
+            pass
+
+        @classmethod
+        def is_type_of(cls, msg: protobuf.MessageType) -> TypeGuard["MoneroTransferDetails"]:
+            return isinstance(msg, cls)
+
+    class MoneroExportedKeyImage(protobuf.MessageType):
+        iv: "bytes | None"
+        blob: "bytes | None"
+
+        def __init__(
+            self,
+            *,
+            iv: "bytes | None" = None,
+            blob: "bytes | None" = None,
+        ) -> None:
+            pass
+
+        @classmethod
+        def is_type_of(cls, msg: protobuf.MessageType) -> TypeGuard["MoneroExportedKeyImage"]:
+            return isinstance(msg, cls)
+
+    class NEMGetAddress(protobuf.MessageType):
+        address_n: "list[int]"
+        network: "int | None"
+        show_display: "bool | None"
+
+        def __init__(
+            self,
+            *,
+            address_n: "list[int] | None" = None,
+            network: "int | None" = None,
+            show_display: "bool | None" = None,
         ) -> None:
             pass
 
@@ -4171,12 +4171,12 @@ if TYPE_CHECKING:
             return isinstance(msg, cls)
 
     class NEMAddress(protobuf.MessageType):
-        address: str
+        address: "str"
 
         def __init__(
             self,
             *,
-            address: str,
+            address: "str",
         ) -> None:
             pass
 
@@ -4184,241 +4184,29 @@ if TYPE_CHECKING:
         def is_type_of(cls, msg: protobuf.MessageType) -> TypeGuard["NEMAddress"]:
             return isinstance(msg, cls)
 
-    class NEMTransactionCommon(protobuf.MessageType):
-        address_n: list[int]
-        network: int | None
-        timestamp: int | None
-        fee: int | None
-        deadline: int | None
-        signer: bytes | None
-
-        def __init__(
-            self,
-            *,
-            address_n: list[int] | None = None,
-            network: int | None = None,
-            timestamp: int | None = None,
-            fee: int | None = None,
-            deadline: int | None = None,
-            signer: bytes | None = None,
-        ) -> None:
-            pass
-
-        @classmethod
-        def is_type_of(cls, msg: protobuf.MessageType) -> TypeGuard["NEMTransactionCommon"]:
-            return isinstance(msg, cls)
-
-    class NEMMosaic(protobuf.MessageType):
-        namespace: str | None
-        mosaic: str | None
-        quantity: int | None
-
-        def __init__(
-            self,
-            *,
-            namespace: str | None = None,
-            mosaic: str | None = None,
-            quantity: int | None = None,
-        ) -> None:
-            pass
-
-        @classmethod
-        def is_type_of(cls, msg: protobuf.MessageType) -> TypeGuard["NEMMosaic"]:
-            return isinstance(msg, cls)
-
-    class NEMTransfer(protobuf.MessageType):
-        recipient: str | None
-        amount: int | None
-        payload: bytes | None
-        public_key: bytes | None
-        mosaics: list[NEMMosaic]
-
-        def __init__(
-            self,
-            *,
-            mosaics: list[NEMMosaic] | None = None,
-            recipient: str | None = None,
-            amount: int | None = None,
-            payload: bytes | None = None,
-            public_key: bytes | None = None,
-        ) -> None:
-            pass
-
-        @classmethod
-        def is_type_of(cls, msg: protobuf.MessageType) -> TypeGuard["NEMTransfer"]:
-            return isinstance(msg, cls)
-
-    class NEMProvisionNamespace(protobuf.MessageType):
-        namespace: str | None
-        parent: str | None
-        sink: str | None
-        fee: int | None
-
-        def __init__(
-            self,
-            *,
-            namespace: str | None = None,
-            parent: str | None = None,
-            sink: str | None = None,
-            fee: int | None = None,
-        ) -> None:
-            pass
-
-        @classmethod
-        def is_type_of(cls, msg: protobuf.MessageType) -> TypeGuard["NEMProvisionNamespace"]:
-            return isinstance(msg, cls)
-
-    class NEMMosaicDefinition(protobuf.MessageType):
-        name: str | None
-        ticker: str | None
-        namespace: str | None
-        mosaic: str | None
-        divisibility: int | None
-        levy: NEMMosaicLevy | None
-        fee: int | None
-        levy_address: str | None
-        levy_namespace: str | None
-        levy_mosaic: str | None
-        supply: int | None
-        mutable_supply: bool | None
-        transferable: bool | None
-        description: str | None
-        networks: list[int]
-
-        def __init__(
-            self,
-            *,
-            networks: list[int] | None = None,
-            name: str | None = None,
-            ticker: str | None = None,
-            namespace: str | None = None,
-            mosaic: str | None = None,
-            divisibility: int | None = None,
-            levy: NEMMosaicLevy | None = None,
-            fee: int | None = None,
-            levy_address: str | None = None,
-            levy_namespace: str | None = None,
-            levy_mosaic: str | None = None,
-            supply: int | None = None,
-            mutable_supply: bool | None = None,
-            transferable: bool | None = None,
-            description: str | None = None,
-        ) -> None:
-            pass
-
-        @classmethod
-        def is_type_of(cls, msg: protobuf.MessageType) -> TypeGuard["NEMMosaicDefinition"]:
-            return isinstance(msg, cls)
-
-    class NEMMosaicCreation(protobuf.MessageType):
-        definition: NEMMosaicDefinition | None
-        sink: str | None
-        fee: int | None
-
-        def __init__(
-            self,
-            *,
-            definition: NEMMosaicDefinition | None = None,
-            sink: str | None = None,
-            fee: int | None = None,
-        ) -> None:
-            pass
-
-        @classmethod
-        def is_type_of(cls, msg: protobuf.MessageType) -> TypeGuard["NEMMosaicCreation"]:
-            return isinstance(msg, cls)
-
-    class NEMMosaicSupplyChange(protobuf.MessageType):
-        namespace: str | None
-        mosaic: str | None
-        type: NEMSupplyChangeType | None
-        delta: int | None
-
-        def __init__(
-            self,
-            *,
-            namespace: str | None = None,
-            mosaic: str | None = None,
-            type: NEMSupplyChangeType | None = None,
-            delta: int | None = None,
-        ) -> None:
-            pass
-
-        @classmethod
-        def is_type_of(cls, msg: protobuf.MessageType) -> TypeGuard["NEMMosaicSupplyChange"]:
-            return isinstance(msg, cls)
-
-    class NEMCosignatoryModification(protobuf.MessageType):
-        type: NEMModificationType | None
-        public_key: bytes | None
-
-        def __init__(
-            self,
-            *,
-            type: NEMModificationType | None = None,
-            public_key: bytes | None = None,
-        ) -> None:
-            pass
-
-        @classmethod
-        def is_type_of(cls, msg: protobuf.MessageType) -> TypeGuard["NEMCosignatoryModification"]:
-            return isinstance(msg, cls)
-
-    class NEMAggregateModification(protobuf.MessageType):
-        modifications: list[NEMCosignatoryModification]
-        relative_change: int | None
-
-        def __init__(
-            self,
-            *,
-            modifications: list[NEMCosignatoryModification] | None = None,
-            relative_change: int | None = None,
-        ) -> None:
-            pass
-
-        @classmethod
-        def is_type_of(cls, msg: protobuf.MessageType) -> TypeGuard["NEMAggregateModification"]:
-            return isinstance(msg, cls)
-
-    class NEMImportanceTransfer(protobuf.MessageType):
-        mode: NEMImportanceTransferMode | None
-        public_key: bytes | None
-
-        def __init__(
-            self,
-            *,
-            mode: NEMImportanceTransferMode | None = None,
-            public_key: bytes | None = None,
-        ) -> None:
-            pass
-
-        @classmethod
-        def is_type_of(cls, msg: protobuf.MessageType) -> TypeGuard["NEMImportanceTransfer"]:
-            return isinstance(msg, cls)
-
     class NEMSignTx(protobuf.MessageType):
-        transaction: NEMTransactionCommon | None
-        multisig: NEMTransactionCommon | None
-        transfer: NEMTransfer | None
-        cosigning: bool | None
-        provision_namespace: NEMProvisionNamespace | None
-        mosaic_creation: NEMMosaicCreation | None
-        supply_change: NEMMosaicSupplyChange | None
-        aggregate_modification: NEMAggregateModification | None
-        importance_transfer: NEMImportanceTransfer | None
+        transaction: "NEMTransactionCommon | None"
+        multisig: "NEMTransactionCommon | None"
+        transfer: "NEMTransfer | None"
+        cosigning: "bool | None"
+        provision_namespace: "NEMProvisionNamespace | None"
+        mosaic_creation: "NEMMosaicCreation | None"
+        supply_change: "NEMMosaicSupplyChange | None"
+        aggregate_modification: "NEMAggregateModification | None"
+        importance_transfer: "NEMImportanceTransfer | None"
 
         def __init__(
             self,
             *,
-            transaction: NEMTransactionCommon | None = None,
-            multisig: NEMTransactionCommon | None = None,
-            transfer: NEMTransfer | None = None,
-            cosigning: bool | None = None,
-            provision_namespace: NEMProvisionNamespace | None = None,
-            mosaic_creation: NEMMosaicCreation | None = None,
-            supply_change: NEMMosaicSupplyChange | None = None,
-            aggregate_modification: NEMAggregateModification | None = None,
-            importance_transfer: NEMImportanceTransfer | None = None,
+            transaction: "NEMTransactionCommon | None" = None,
+            multisig: "NEMTransactionCommon | None" = None,
+            transfer: "NEMTransfer | None" = None,
+            cosigning: "bool | None" = None,
+            provision_namespace: "NEMProvisionNamespace | None" = None,
+            mosaic_creation: "NEMMosaicCreation | None" = None,
+            supply_change: "NEMMosaicSupplyChange | None" = None,
+            aggregate_modification: "NEMAggregateModification | None" = None,
+            importance_transfer: "NEMImportanceTransfer | None" = None,
         ) -> None:
             pass
 
@@ -4427,14 +4215,14 @@ if TYPE_CHECKING:
             return isinstance(msg, cls)
 
     class NEMSignedTx(protobuf.MessageType):
-        data: bytes
-        signature: bytes
+        data: "bytes"
+        signature: "bytes"
 
         def __init__(
             self,
             *,
-            data: bytes,
-            signature: bytes,
+            data: "bytes",
+            signature: "bytes",
         ) -> None:
             pass
 
@@ -4443,18 +4231,18 @@ if TYPE_CHECKING:
             return isinstance(msg, cls)
 
     class NEMDecryptMessage(protobuf.MessageType):
-        address_n: list[int]
-        network: int | None
-        public_key: bytes | None
-        payload: bytes | None
+        address_n: "list[int]"
+        network: "int | None"
+        public_key: "bytes | None"
+        payload: "bytes | None"
 
         def __init__(
             self,
             *,
-            address_n: list[int] | None = None,
-            network: int | None = None,
-            public_key: bytes | None = None,
-            payload: bytes | None = None,
+            address_n: "list[int] | None" = None,
+            network: "int | None" = None,
+            public_key: "bytes | None" = None,
+            payload: "bytes | None" = None,
         ) -> None:
             pass
 
@@ -4463,12 +4251,12 @@ if TYPE_CHECKING:
             return isinstance(msg, cls)
 
     class NEMDecryptedMessage(protobuf.MessageType):
-        payload: bytes
+        payload: "bytes"
 
         def __init__(
             self,
             *,
-            payload: bytes,
+            payload: "bytes",
         ) -> None:
             pass
 
@@ -4476,15 +4264,227 @@ if TYPE_CHECKING:
         def is_type_of(cls, msg: protobuf.MessageType) -> TypeGuard["NEMDecryptedMessage"]:
             return isinstance(msg, cls)
 
-    class RippleGetAddress(protobuf.MessageType):
-        address_n: list[int]
-        show_display: bool | None
+    class NEMTransactionCommon(protobuf.MessageType):
+        address_n: "list[int]"
+        network: "int | None"
+        timestamp: "int | None"
+        fee: "int | None"
+        deadline: "int | None"
+        signer: "bytes | None"
 
         def __init__(
             self,
             *,
-            address_n: list[int] | None = None,
-            show_display: bool | None = None,
+            address_n: "list[int] | None" = None,
+            network: "int | None" = None,
+            timestamp: "int | None" = None,
+            fee: "int | None" = None,
+            deadline: "int | None" = None,
+            signer: "bytes | None" = None,
+        ) -> None:
+            pass
+
+        @classmethod
+        def is_type_of(cls, msg: protobuf.MessageType) -> TypeGuard["NEMTransactionCommon"]:
+            return isinstance(msg, cls)
+
+    class NEMTransfer(protobuf.MessageType):
+        recipient: "str | None"
+        amount: "int | None"
+        payload: "bytes | None"
+        public_key: "bytes | None"
+        mosaics: "list[NEMMosaic]"
+
+        def __init__(
+            self,
+            *,
+            mosaics: "list[NEMMosaic] | None" = None,
+            recipient: "str | None" = None,
+            amount: "int | None" = None,
+            payload: "bytes | None" = None,
+            public_key: "bytes | None" = None,
+        ) -> None:
+            pass
+
+        @classmethod
+        def is_type_of(cls, msg: protobuf.MessageType) -> TypeGuard["NEMTransfer"]:
+            return isinstance(msg, cls)
+
+    class NEMProvisionNamespace(protobuf.MessageType):
+        namespace: "str | None"
+        parent: "str | None"
+        sink: "str | None"
+        fee: "int | None"
+
+        def __init__(
+            self,
+            *,
+            namespace: "str | None" = None,
+            parent: "str | None" = None,
+            sink: "str | None" = None,
+            fee: "int | None" = None,
+        ) -> None:
+            pass
+
+        @classmethod
+        def is_type_of(cls, msg: protobuf.MessageType) -> TypeGuard["NEMProvisionNamespace"]:
+            return isinstance(msg, cls)
+
+    class NEMMosaicCreation(protobuf.MessageType):
+        definition: "NEMMosaicDefinition | None"
+        sink: "str | None"
+        fee: "int | None"
+
+        def __init__(
+            self,
+            *,
+            definition: "NEMMosaicDefinition | None" = None,
+            sink: "str | None" = None,
+            fee: "int | None" = None,
+        ) -> None:
+            pass
+
+        @classmethod
+        def is_type_of(cls, msg: protobuf.MessageType) -> TypeGuard["NEMMosaicCreation"]:
+            return isinstance(msg, cls)
+
+    class NEMMosaicSupplyChange(protobuf.MessageType):
+        namespace: "str | None"
+        mosaic: "str | None"
+        type: "NEMSupplyChangeType | None"
+        delta: "int | None"
+
+        def __init__(
+            self,
+            *,
+            namespace: "str | None" = None,
+            mosaic: "str | None" = None,
+            type: "NEMSupplyChangeType | None" = None,
+            delta: "int | None" = None,
+        ) -> None:
+            pass
+
+        @classmethod
+        def is_type_of(cls, msg: protobuf.MessageType) -> TypeGuard["NEMMosaicSupplyChange"]:
+            return isinstance(msg, cls)
+
+    class NEMAggregateModification(protobuf.MessageType):
+        modifications: "list[NEMCosignatoryModification]"
+        relative_change: "int | None"
+
+        def __init__(
+            self,
+            *,
+            modifications: "list[NEMCosignatoryModification] | None" = None,
+            relative_change: "int | None" = None,
+        ) -> None:
+            pass
+
+        @classmethod
+        def is_type_of(cls, msg: protobuf.MessageType) -> TypeGuard["NEMAggregateModification"]:
+            return isinstance(msg, cls)
+
+    class NEMImportanceTransfer(protobuf.MessageType):
+        mode: "NEMImportanceTransferMode | None"
+        public_key: "bytes | None"
+
+        def __init__(
+            self,
+            *,
+            mode: "NEMImportanceTransferMode | None" = None,
+            public_key: "bytes | None" = None,
+        ) -> None:
+            pass
+
+        @classmethod
+        def is_type_of(cls, msg: protobuf.MessageType) -> TypeGuard["NEMImportanceTransfer"]:
+            return isinstance(msg, cls)
+
+    class NEMMosaic(protobuf.MessageType):
+        namespace: "str | None"
+        mosaic: "str | None"
+        quantity: "int | None"
+
+        def __init__(
+            self,
+            *,
+            namespace: "str | None" = None,
+            mosaic: "str | None" = None,
+            quantity: "int | None" = None,
+        ) -> None:
+            pass
+
+        @classmethod
+        def is_type_of(cls, msg: protobuf.MessageType) -> TypeGuard["NEMMosaic"]:
+            return isinstance(msg, cls)
+
+    class NEMMosaicDefinition(protobuf.MessageType):
+        name: "str | None"
+        ticker: "str | None"
+        namespace: "str | None"
+        mosaic: "str | None"
+        divisibility: "int | None"
+        levy: "NEMMosaicLevy | None"
+        fee: "int | None"
+        levy_address: "str | None"
+        levy_namespace: "str | None"
+        levy_mosaic: "str | None"
+        supply: "int | None"
+        mutable_supply: "bool | None"
+        transferable: "bool | None"
+        description: "str | None"
+        networks: "list[int]"
+
+        def __init__(
+            self,
+            *,
+            networks: "list[int] | None" = None,
+            name: "str | None" = None,
+            ticker: "str | None" = None,
+            namespace: "str | None" = None,
+            mosaic: "str | None" = None,
+            divisibility: "int | None" = None,
+            levy: "NEMMosaicLevy | None" = None,
+            fee: "int | None" = None,
+            levy_address: "str | None" = None,
+            levy_namespace: "str | None" = None,
+            levy_mosaic: "str | None" = None,
+            supply: "int | None" = None,
+            mutable_supply: "bool | None" = None,
+            transferable: "bool | None" = None,
+            description: "str | None" = None,
+        ) -> None:
+            pass
+
+        @classmethod
+        def is_type_of(cls, msg: protobuf.MessageType) -> TypeGuard["NEMMosaicDefinition"]:
+            return isinstance(msg, cls)
+
+    class NEMCosignatoryModification(protobuf.MessageType):
+        type: "NEMModificationType | None"
+        public_key: "bytes | None"
+
+        def __init__(
+            self,
+            *,
+            type: "NEMModificationType | None" = None,
+            public_key: "bytes | None" = None,
+        ) -> None:
+            pass
+
+        @classmethod
+        def is_type_of(cls, msg: protobuf.MessageType) -> TypeGuard["NEMCosignatoryModification"]:
+            return isinstance(msg, cls)
+
+    class RippleGetAddress(protobuf.MessageType):
+        address_n: "list[int]"
+        show_display: "bool | None"
+
+        def __init__(
+            self,
+            *,
+            address_n: "list[int] | None" = None,
+            show_display: "bool | None" = None,
         ) -> None:
             pass
 
@@ -4493,12 +4493,12 @@ if TYPE_CHECKING:
             return isinstance(msg, cls)
 
     class RippleAddress(protobuf.MessageType):
-        address: str
+        address: "str"
 
         def __init__(
             self,
             *,
-            address: str,
+            address: "str",
         ) -> None:
             pass
 
@@ -4506,41 +4506,23 @@ if TYPE_CHECKING:
         def is_type_of(cls, msg: protobuf.MessageType) -> TypeGuard["RippleAddress"]:
             return isinstance(msg, cls)
 
-    class RipplePayment(protobuf.MessageType):
-        amount: int
-        destination: str
-        destination_tag: int | None
-
-        def __init__(
-            self,
-            *,
-            amount: int,
-            destination: str,
-            destination_tag: int | None = None,
-        ) -> None:
-            pass
-
-        @classmethod
-        def is_type_of(cls, msg: protobuf.MessageType) -> TypeGuard["RipplePayment"]:
-            return isinstance(msg, cls)
-
     class RippleSignTx(protobuf.MessageType):
-        address_n: list[int]
-        fee: int | None
-        flags: int | None
-        sequence: int | None
-        last_ledger_sequence: int | None
-        payment: RipplePayment | None
+        address_n: "list[int]"
+        fee: "int | None"
+        flags: "int | None"
+        sequence: "int | None"
+        last_ledger_sequence: "int | None"
+        payment: "RipplePayment | None"
 
         def __init__(
             self,
             *,
-            address_n: list[int] | None = None,
-            fee: int | None = None,
-            flags: int | None = None,
-            sequence: int | None = None,
-            last_ledger_sequence: int | None = None,
-            payment: RipplePayment | None = None,
+            address_n: "list[int] | None" = None,
+            fee: "int | None" = None,
+            flags: "int | None" = None,
+            sequence: "int | None" = None,
+            last_ledger_sequence: "int | None" = None,
+            payment: "RipplePayment | None" = None,
         ) -> None:
             pass
 
@@ -4549,14 +4531,14 @@ if TYPE_CHECKING:
             return isinstance(msg, cls)
 
     class RippleSignedTx(protobuf.MessageType):
-        signature: bytes
-        serialized_tx: bytes
+        signature: "bytes"
+        serialized_tx: "bytes"
 
         def __init__(
             self,
             *,
-            signature: bytes,
-            serialized_tx: bytes,
+            signature: "bytes",
+            serialized_tx: "bytes",
         ) -> None:
             pass
 
@@ -4564,17 +4546,35 @@ if TYPE_CHECKING:
         def is_type_of(cls, msg: protobuf.MessageType) -> TypeGuard["RippleSignedTx"]:
             return isinstance(msg, cls)
 
-    class StellarAssetType(protobuf.MessageType):
-        type: int
-        code: str | None
-        issuer: str | None
+    class RipplePayment(protobuf.MessageType):
+        amount: "int"
+        destination: "str"
+        destination_tag: "int | None"
 
         def __init__(
             self,
             *,
-            type: int,
-            code: str | None = None,
-            issuer: str | None = None,
+            amount: "int",
+            destination: "str",
+            destination_tag: "int | None" = None,
+        ) -> None:
+            pass
+
+        @classmethod
+        def is_type_of(cls, msg: protobuf.MessageType) -> TypeGuard["RipplePayment"]:
+            return isinstance(msg, cls)
+
+    class StellarAssetType(protobuf.MessageType):
+        type: "int"
+        code: "str | None"
+        issuer: "str | None"
+
+        def __init__(
+            self,
+            *,
+            type: "int",
+            code: "str | None" = None,
+            issuer: "str | None" = None,
         ) -> None:
             pass
 
@@ -4583,14 +4583,14 @@ if TYPE_CHECKING:
             return isinstance(msg, cls)
 
     class StellarGetAddress(protobuf.MessageType):
-        address_n: list[int]
-        show_display: bool | None
+        address_n: "list[int]"
+        show_display: "bool | None"
 
         def __init__(
             self,
             *,
-            address_n: list[int] | None = None,
-            show_display: bool | None = None,
+            address_n: "list[int] | None" = None,
+            show_display: "bool | None" = None,
         ) -> None:
             pass
 
@@ -4599,12 +4599,12 @@ if TYPE_CHECKING:
             return isinstance(msg, cls)
 
     class StellarAddress(protobuf.MessageType):
-        address: str
+        address: "str"
 
         def __init__(
             self,
             *,
-            address: str,
+            address: "str",
         ) -> None:
             pass
 
@@ -4613,34 +4613,34 @@ if TYPE_CHECKING:
             return isinstance(msg, cls)
 
     class StellarSignTx(protobuf.MessageType):
-        address_n: list[int]
-        network_passphrase: str | None
-        source_account: str | None
-        fee: int | None
-        sequence_number: int | None
-        timebounds_start: int | None
-        timebounds_end: int | None
-        memo_type: int | None
-        memo_text: str | None
-        memo_id: int | None
-        memo_hash: bytes | None
-        num_operations: int | None
+        address_n: "list[int]"
+        network_passphrase: "str | None"
+        source_account: "str | None"
+        fee: "int | None"
+        sequence_number: "int | None"
+        timebounds_start: "int | None"
+        timebounds_end: "int | None"
+        memo_type: "int | None"
+        memo_text: "str | None"
+        memo_id: "int | None"
+        memo_hash: "bytes | None"
+        num_operations: "int | None"
 
         def __init__(
             self,
             *,
-            address_n: list[int] | None = None,
-            network_passphrase: str | None = None,
-            source_account: str | None = None,
-            fee: int | None = None,
-            sequence_number: int | None = None,
-            timebounds_start: int | None = None,
-            timebounds_end: int | None = None,
-            memo_type: int | None = None,
-            memo_text: str | None = None,
-            memo_id: int | None = None,
-            memo_hash: bytes | None = None,
-            num_operations: int | None = None,
+            address_n: "list[int] | None" = None,
+            network_passphrase: "str | None" = None,
+            source_account: "str | None" = None,
+            fee: "int | None" = None,
+            sequence_number: "int | None" = None,
+            timebounds_start: "int | None" = None,
+            timebounds_end: "int | None" = None,
+            memo_type: "int | None" = None,
+            memo_text: "str | None" = None,
+            memo_id: "int | None" = None,
+            memo_hash: "bytes | None" = None,
+            num_operations: "int | None" = None,
         ) -> None:
             pass
 
@@ -4655,18 +4655,18 @@ if TYPE_CHECKING:
             return isinstance(msg, cls)
 
     class StellarPaymentOp(protobuf.MessageType):
-        source_account: str | None
-        destination_account: str | None
-        asset: StellarAssetType | None
-        amount: int | None
+        source_account: "str | None"
+        destination_account: "str | None"
+        asset: "StellarAssetType | None"
+        amount: "int | None"
 
         def __init__(
             self,
             *,
-            source_account: str | None = None,
-            destination_account: str | None = None,
-            asset: StellarAssetType | None = None,
-            amount: int | None = None,
+            source_account: "str | None" = None,
+            destination_account: "str | None" = None,
+            asset: "StellarAssetType | None" = None,
+            amount: "int | None" = None,
         ) -> None:
             pass
 
@@ -4675,16 +4675,16 @@ if TYPE_CHECKING:
             return isinstance(msg, cls)
 
     class StellarCreateAccountOp(protobuf.MessageType):
-        source_account: str | None
-        new_account: str | None
-        starting_balance: int | None
+        source_account: "str | None"
+        new_account: "str | None"
+        starting_balance: "int | None"
 
         def __init__(
             self,
             *,
-            source_account: str | None = None,
-            new_account: str | None = None,
-            starting_balance: int | None = None,
+            source_account: "str | None" = None,
+            new_account: "str | None" = None,
+            starting_balance: "int | None" = None,
         ) -> None:
             pass
 
@@ -4693,24 +4693,24 @@ if TYPE_CHECKING:
             return isinstance(msg, cls)
 
     class StellarPathPaymentOp(protobuf.MessageType):
-        source_account: str | None
-        send_asset: StellarAssetType | None
-        send_max: int | None
-        destination_account: str | None
-        destination_asset: StellarAssetType | None
-        destination_amount: int | None
-        paths: list[StellarAssetType]
+        source_account: "str | None"
+        send_asset: "StellarAssetType | None"
+        send_max: "int | None"
+        destination_account: "str | None"
+        destination_asset: "StellarAssetType | None"
+        destination_amount: "int | None"
+        paths: "list[StellarAssetType]"
 
         def __init__(
             self,
             *,
-            paths: list[StellarAssetType] | None = None,
-            source_account: str | None = None,
-            send_asset: StellarAssetType | None = None,
-            send_max: int | None = None,
-            destination_account: str | None = None,
-            destination_asset: StellarAssetType | None = None,
-            destination_amount: int | None = None,
+            paths: "list[StellarAssetType] | None" = None,
+            source_account: "str | None" = None,
+            send_asset: "StellarAssetType | None" = None,
+            send_max: "int | None" = None,
+            destination_account: "str | None" = None,
+            destination_asset: "StellarAssetType | None" = None,
+            destination_amount: "int | None" = None,
         ) -> None:
             pass
 
@@ -4719,24 +4719,24 @@ if TYPE_CHECKING:
             return isinstance(msg, cls)
 
     class StellarManageOfferOp(protobuf.MessageType):
-        source_account: str | None
-        selling_asset: StellarAssetType | None
-        buying_asset: StellarAssetType | None
-        amount: int | None
-        price_n: int | None
-        price_d: int | None
-        offer_id: int | None
+        source_account: "str | None"
+        selling_asset: "StellarAssetType | None"
+        buying_asset: "StellarAssetType | None"
+        amount: "int | None"
+        price_n: "int | None"
+        price_d: "int | None"
+        offer_id: "int | None"
 
         def __init__(
             self,
             *,
-            source_account: str | None = None,
-            selling_asset: StellarAssetType | None = None,
-            buying_asset: StellarAssetType | None = None,
-            amount: int | None = None,
-            price_n: int | None = None,
-            price_d: int | None = None,
-            offer_id: int | None = None,
+            source_account: "str | None" = None,
+            selling_asset: "StellarAssetType | None" = None,
+            buying_asset: "StellarAssetType | None" = None,
+            amount: "int | None" = None,
+            price_n: "int | None" = None,
+            price_d: "int | None" = None,
+            offer_id: "int | None" = None,
         ) -> None:
             pass
 
@@ -4745,22 +4745,22 @@ if TYPE_CHECKING:
             return isinstance(msg, cls)
 
     class StellarCreatePassiveOfferOp(protobuf.MessageType):
-        source_account: str | None
-        selling_asset: StellarAssetType | None
-        buying_asset: StellarAssetType | None
-        amount: int | None
-        price_n: int | None
-        price_d: int | None
+        source_account: "str | None"
+        selling_asset: "StellarAssetType | None"
+        buying_asset: "StellarAssetType | None"
+        amount: "int | None"
+        price_n: "int | None"
+        price_d: "int | None"
 
         def __init__(
             self,
             *,
-            source_account: str | None = None,
-            selling_asset: StellarAssetType | None = None,
-            buying_asset: StellarAssetType | None = None,
-            amount: int | None = None,
-            price_n: int | None = None,
-            price_d: int | None = None,
+            source_account: "str | None" = None,
+            selling_asset: "StellarAssetType | None" = None,
+            buying_asset: "StellarAssetType | None" = None,
+            amount: "int | None" = None,
+            price_n: "int | None" = None,
+            price_d: "int | None" = None,
         ) -> None:
             pass
 
@@ -4769,34 +4769,34 @@ if TYPE_CHECKING:
             return isinstance(msg, cls)
 
     class StellarSetOptionsOp(protobuf.MessageType):
-        source_account: str | None
-        inflation_destination_account: str | None
-        clear_flags: int | None
-        set_flags: int | None
-        master_weight: int | None
-        low_threshold: int | None
-        medium_threshold: int | None
-        high_threshold: int | None
-        home_domain: str | None
-        signer_type: int | None
-        signer_key: bytes | None
-        signer_weight: int | None
+        source_account: "str | None"
+        inflation_destination_account: "str | None"
+        clear_flags: "int | None"
+        set_flags: "int | None"
+        master_weight: "int | None"
+        low_threshold: "int | None"
+        medium_threshold: "int | None"
+        high_threshold: "int | None"
+        home_domain: "str | None"
+        signer_type: "int | None"
+        signer_key: "bytes | None"
+        signer_weight: "int | None"
 
         def __init__(
             self,
             *,
-            source_account: str | None = None,
-            inflation_destination_account: str | None = None,
-            clear_flags: int | None = None,
-            set_flags: int | None = None,
-            master_weight: int | None = None,
-            low_threshold: int | None = None,
-            medium_threshold: int | None = None,
-            high_threshold: int | None = None,
-            home_domain: str | None = None,
-            signer_type: int | None = None,
-            signer_key: bytes | None = None,
-            signer_weight: int | None = None,
+            source_account: "str | None" = None,
+            inflation_destination_account: "str | None" = None,
+            clear_flags: "int | None" = None,
+            set_flags: "int | None" = None,
+            master_weight: "int | None" = None,
+            low_threshold: "int | None" = None,
+            medium_threshold: "int | None" = None,
+            high_threshold: "int | None" = None,
+            home_domain: "str | None" = None,
+            signer_type: "int | None" = None,
+            signer_key: "bytes | None" = None,
+            signer_weight: "int | None" = None,
         ) -> None:
             pass
 
@@ -4805,16 +4805,16 @@ if TYPE_CHECKING:
             return isinstance(msg, cls)
 
     class StellarChangeTrustOp(protobuf.MessageType):
-        source_account: str | None
-        asset: StellarAssetType | None
-        limit: int | None
+        source_account: "str | None"
+        asset: "StellarAssetType | None"
+        limit: "int | None"
 
         def __init__(
             self,
             *,
-            source_account: str | None = None,
-            asset: StellarAssetType | None = None,
-            limit: int | None = None,
+            source_account: "str | None" = None,
+            asset: "StellarAssetType | None" = None,
+            limit: "int | None" = None,
         ) -> None:
             pass
 
@@ -4823,20 +4823,20 @@ if TYPE_CHECKING:
             return isinstance(msg, cls)
 
     class StellarAllowTrustOp(protobuf.MessageType):
-        source_account: str | None
-        trusted_account: str | None
-        asset_type: int | None
-        asset_code: str | None
-        is_authorized: int | None
+        source_account: "str | None"
+        trusted_account: "str | None"
+        asset_type: "int | None"
+        asset_code: "str | None"
+        is_authorized: "int | None"
 
         def __init__(
             self,
             *,
-            source_account: str | None = None,
-            trusted_account: str | None = None,
-            asset_type: int | None = None,
-            asset_code: str | None = None,
-            is_authorized: int | None = None,
+            source_account: "str | None" = None,
+            trusted_account: "str | None" = None,
+            asset_type: "int | None" = None,
+            asset_code: "str | None" = None,
+            is_authorized: "int | None" = None,
         ) -> None:
             pass
 
@@ -4845,14 +4845,14 @@ if TYPE_CHECKING:
             return isinstance(msg, cls)
 
     class StellarAccountMergeOp(protobuf.MessageType):
-        source_account: str | None
-        destination_account: str | None
+        source_account: "str | None"
+        destination_account: "str | None"
 
         def __init__(
             self,
             *,
-            source_account: str | None = None,
-            destination_account: str | None = None,
+            source_account: "str | None" = None,
+            destination_account: "str | None" = None,
         ) -> None:
             pass
 
@@ -4861,16 +4861,16 @@ if TYPE_CHECKING:
             return isinstance(msg, cls)
 
     class StellarManageDataOp(protobuf.MessageType):
-        source_account: str | None
-        key: str | None
-        value: bytes | None
+        source_account: "str | None"
+        key: "str | None"
+        value: "bytes | None"
 
         def __init__(
             self,
             *,
-            source_account: str | None = None,
-            key: str | None = None,
-            value: bytes | None = None,
+            source_account: "str | None" = None,
+            key: "str | None" = None,
+            value: "bytes | None" = None,
         ) -> None:
             pass
 
@@ -4879,14 +4879,14 @@ if TYPE_CHECKING:
             return isinstance(msg, cls)
 
     class StellarBumpSequenceOp(protobuf.MessageType):
-        source_account: str | None
-        bump_to: int | None
+        source_account: "str | None"
+        bump_to: "int | None"
 
         def __init__(
             self,
             *,
-            source_account: str | None = None,
-            bump_to: int | None = None,
+            source_account: "str | None" = None,
+            bump_to: "int | None" = None,
         ) -> None:
             pass
 
@@ -4895,14 +4895,14 @@ if TYPE_CHECKING:
             return isinstance(msg, cls)
 
     class StellarSignedTx(protobuf.MessageType):
-        public_key: bytes
-        signature: bytes
+        public_key: "bytes"
+        signature: "bytes"
 
         def __init__(
             self,
             *,
-            public_key: bytes,
-            signature: bytes,
+            public_key: "bytes",
+            signature: "bytes",
         ) -> None:
             pass
 
@@ -4911,14 +4911,14 @@ if TYPE_CHECKING:
             return isinstance(msg, cls)
 
     class TezosGetAddress(protobuf.MessageType):
-        address_n: list[int]
-        show_display: bool | None
+        address_n: "list[int]"
+        show_display: "bool | None"
 
         def __init__(
             self,
             *,
-            address_n: list[int] | None = None,
-            show_display: bool | None = None,
+            address_n: "list[int] | None" = None,
+            show_display: "bool | None" = None,
         ) -> None:
             pass
 
@@ -4927,12 +4927,12 @@ if TYPE_CHECKING:
             return isinstance(msg, cls)
 
     class TezosAddress(protobuf.MessageType):
-        address: str
+        address: "str"
 
         def __init__(
             self,
             *,
-            address: str,
+            address: "str",
         ) -> None:
             pass
 
@@ -4941,14 +4941,14 @@ if TYPE_CHECKING:
             return isinstance(msg, cls)
 
     class TezosGetPublicKey(protobuf.MessageType):
-        address_n: list[int]
-        show_display: bool | None
+        address_n: "list[int]"
+        show_display: "bool | None"
 
         def __init__(
             self,
             *,
-            address_n: list[int] | None = None,
-            show_display: bool | None = None,
+            address_n: "list[int] | None" = None,
+            show_display: "bool | None" = None,
         ) -> None:
             pass
 
@@ -4957,12 +4957,12 @@ if TYPE_CHECKING:
             return isinstance(msg, cls)
 
     class TezosPublicKey(protobuf.MessageType):
-        public_key: str
+        public_key: "str"
 
         def __init__(
             self,
             *,
-            public_key: str,
+            public_key: "str",
         ) -> None:
             pass
 
@@ -4970,227 +4970,27 @@ if TYPE_CHECKING:
         def is_type_of(cls, msg: protobuf.MessageType) -> TypeGuard["TezosPublicKey"]:
             return isinstance(msg, cls)
 
-    class TezosRevealOp(protobuf.MessageType):
-        source: bytes
-        fee: int
-        counter: int
-        gas_limit: int
-        storage_limit: int
-        public_key: bytes
-
-        def __init__(
-            self,
-            *,
-            source: bytes,
-            fee: int,
-            counter: int,
-            gas_limit: int,
-            storage_limit: int,
-            public_key: bytes,
-        ) -> None:
-            pass
-
-        @classmethod
-        def is_type_of(cls, msg: protobuf.MessageType) -> TypeGuard["TezosRevealOp"]:
-            return isinstance(msg, cls)
-
-    class TezosContractID(protobuf.MessageType):
-        tag: TezosContractType
-        hash: bytes
-
-        def __init__(
-            self,
-            *,
-            tag: TezosContractType,
-            hash: bytes,
-        ) -> None:
-            pass
-
-        @classmethod
-        def is_type_of(cls, msg: protobuf.MessageType) -> TypeGuard["TezosContractID"]:
-            return isinstance(msg, cls)
-
-    class TezosManagerTransfer(protobuf.MessageType):
-        destination: TezosContractID | None
-        amount: int | None
-
-        def __init__(
-            self,
-            *,
-            destination: TezosContractID | None = None,
-            amount: int | None = None,
-        ) -> None:
-            pass
-
-        @classmethod
-        def is_type_of(cls, msg: protobuf.MessageType) -> TypeGuard["TezosManagerTransfer"]:
-            return isinstance(msg, cls)
-
-    class TezosParametersManager(protobuf.MessageType):
-        set_delegate: bytes | None
-        cancel_delegate: bool | None
-        transfer: TezosManagerTransfer | None
-
-        def __init__(
-            self,
-            *,
-            set_delegate: bytes | None = None,
-            cancel_delegate: bool | None = None,
-            transfer: TezosManagerTransfer | None = None,
-        ) -> None:
-            pass
-
-        @classmethod
-        def is_type_of(cls, msg: protobuf.MessageType) -> TypeGuard["TezosParametersManager"]:
-            return isinstance(msg, cls)
-
-    class TezosTransactionOp(protobuf.MessageType):
-        source: bytes
-        fee: int
-        counter: int
-        gas_limit: int
-        storage_limit: int
-        amount: int
-        destination: TezosContractID
-        parameters: bytes | None
-        parameters_manager: TezosParametersManager | None
-
-        def __init__(
-            self,
-            *,
-            source: bytes,
-            fee: int,
-            counter: int,
-            gas_limit: int,
-            storage_limit: int,
-            amount: int,
-            destination: TezosContractID,
-            parameters: bytes | None = None,
-            parameters_manager: TezosParametersManager | None = None,
-        ) -> None:
-            pass
-
-        @classmethod
-        def is_type_of(cls, msg: protobuf.MessageType) -> TypeGuard["TezosTransactionOp"]:
-            return isinstance(msg, cls)
-
-    class TezosOriginationOp(protobuf.MessageType):
-        source: bytes
-        fee: int
-        counter: int
-        gas_limit: int
-        storage_limit: int
-        manager_pubkey: bytes | None
-        balance: int
-        spendable: bool | None
-        delegatable: bool | None
-        delegate: bytes | None
-        script: bytes
-
-        def __init__(
-            self,
-            *,
-            source: bytes,
-            fee: int,
-            counter: int,
-            gas_limit: int,
-            storage_limit: int,
-            balance: int,
-            script: bytes,
-            manager_pubkey: bytes | None = None,
-            spendable: bool | None = None,
-            delegatable: bool | None = None,
-            delegate: bytes | None = None,
-        ) -> None:
-            pass
-
-        @classmethod
-        def is_type_of(cls, msg: protobuf.MessageType) -> TypeGuard["TezosOriginationOp"]:
-            return isinstance(msg, cls)
-
-    class TezosDelegationOp(protobuf.MessageType):
-        source: bytes
-        fee: int
-        counter: int
-        gas_limit: int
-        storage_limit: int
-        delegate: bytes
-
-        def __init__(
-            self,
-            *,
-            source: bytes,
-            fee: int,
-            counter: int,
-            gas_limit: int,
-            storage_limit: int,
-            delegate: bytes,
-        ) -> None:
-            pass
-
-        @classmethod
-        def is_type_of(cls, msg: protobuf.MessageType) -> TypeGuard["TezosDelegationOp"]:
-            return isinstance(msg, cls)
-
-    class TezosProposalOp(protobuf.MessageType):
-        source: bytes | None
-        period: int | None
-        proposals: list[bytes]
-
-        def __init__(
-            self,
-            *,
-            proposals: list[bytes] | None = None,
-            source: bytes | None = None,
-            period: int | None = None,
-        ) -> None:
-            pass
-
-        @classmethod
-        def is_type_of(cls, msg: protobuf.MessageType) -> TypeGuard["TezosProposalOp"]:
-            return isinstance(msg, cls)
-
-    class TezosBallotOp(protobuf.MessageType):
-        source: bytes | None
-        period: int | None
-        proposal: bytes | None
-        ballot: TezosBallotType | None
-
-        def __init__(
-            self,
-            *,
-            source: bytes | None = None,
-            period: int | None = None,
-            proposal: bytes | None = None,
-            ballot: TezosBallotType | None = None,
-        ) -> None:
-            pass
-
-        @classmethod
-        def is_type_of(cls, msg: protobuf.MessageType) -> TypeGuard["TezosBallotOp"]:
-            return isinstance(msg, cls)
-
     class TezosSignTx(protobuf.MessageType):
-        address_n: list[int]
-        branch: bytes
-        reveal: TezosRevealOp | None
-        transaction: TezosTransactionOp | None
-        origination: TezosOriginationOp | None
-        delegation: TezosDelegationOp | None
-        proposal: TezosProposalOp | None
-        ballot: TezosBallotOp | None
+        address_n: "list[int]"
+        branch: "bytes"
+        reveal: "TezosRevealOp | None"
+        transaction: "TezosTransactionOp | None"
+        origination: "TezosOriginationOp | None"
+        delegation: "TezosDelegationOp | None"
+        proposal: "TezosProposalOp | None"
+        ballot: "TezosBallotOp | None"
 
         def __init__(
             self,
             *,
-            branch: bytes,
-            address_n: list[int] | None = None,
-            reveal: TezosRevealOp | None = None,
-            transaction: TezosTransactionOp | None = None,
-            origination: TezosOriginationOp | None = None,
-            delegation: TezosDelegationOp | None = None,
-            proposal: TezosProposalOp | None = None,
-            ballot: TezosBallotOp | None = None,
+            branch: "bytes",
+            address_n: "list[int] | None" = None,
+            reveal: "TezosRevealOp | None" = None,
+            transaction: "TezosTransactionOp | None" = None,
+            origination: "TezosOriginationOp | None" = None,
+            delegation: "TezosDelegationOp | None" = None,
+            proposal: "TezosProposalOp | None" = None,
+            ballot: "TezosBallotOp | None" = None,
         ) -> None:
             pass
 
@@ -5199,21 +4999,221 @@ if TYPE_CHECKING:
             return isinstance(msg, cls)
 
     class TezosSignedTx(protobuf.MessageType):
-        signature: str
-        sig_op_contents: bytes
-        operation_hash: str
+        signature: "str"
+        sig_op_contents: "bytes"
+        operation_hash: "str"
 
         def __init__(
             self,
             *,
-            signature: str,
-            sig_op_contents: bytes,
-            operation_hash: str,
+            signature: "str",
+            sig_op_contents: "bytes",
+            operation_hash: "str",
         ) -> None:
             pass
 
         @classmethod
         def is_type_of(cls, msg: protobuf.MessageType) -> TypeGuard["TezosSignedTx"]:
+            return isinstance(msg, cls)
+
+    class TezosContractID(protobuf.MessageType):
+        tag: "TezosContractType"
+        hash: "bytes"
+
+        def __init__(
+            self,
+            *,
+            tag: "TezosContractType",
+            hash: "bytes",
+        ) -> None:
+            pass
+
+        @classmethod
+        def is_type_of(cls, msg: protobuf.MessageType) -> TypeGuard["TezosContractID"]:
+            return isinstance(msg, cls)
+
+    class TezosRevealOp(protobuf.MessageType):
+        source: "bytes"
+        fee: "int"
+        counter: "int"
+        gas_limit: "int"
+        storage_limit: "int"
+        public_key: "bytes"
+
+        def __init__(
+            self,
+            *,
+            source: "bytes",
+            fee: "int",
+            counter: "int",
+            gas_limit: "int",
+            storage_limit: "int",
+            public_key: "bytes",
+        ) -> None:
+            pass
+
+        @classmethod
+        def is_type_of(cls, msg: protobuf.MessageType) -> TypeGuard["TezosRevealOp"]:
+            return isinstance(msg, cls)
+
+    class TezosTransactionOp(protobuf.MessageType):
+        source: "bytes"
+        fee: "int"
+        counter: "int"
+        gas_limit: "int"
+        storage_limit: "int"
+        amount: "int"
+        destination: "TezosContractID"
+        parameters: "bytes | None"
+        parameters_manager: "TezosParametersManager | None"
+
+        def __init__(
+            self,
+            *,
+            source: "bytes",
+            fee: "int",
+            counter: "int",
+            gas_limit: "int",
+            storage_limit: "int",
+            amount: "int",
+            destination: "TezosContractID",
+            parameters: "bytes | None" = None,
+            parameters_manager: "TezosParametersManager | None" = None,
+        ) -> None:
+            pass
+
+        @classmethod
+        def is_type_of(cls, msg: protobuf.MessageType) -> TypeGuard["TezosTransactionOp"]:
+            return isinstance(msg, cls)
+
+    class TezosOriginationOp(protobuf.MessageType):
+        source: "bytes"
+        fee: "int"
+        counter: "int"
+        gas_limit: "int"
+        storage_limit: "int"
+        manager_pubkey: "bytes | None"
+        balance: "int"
+        spendable: "bool | None"
+        delegatable: "bool | None"
+        delegate: "bytes | None"
+        script: "bytes"
+
+        def __init__(
+            self,
+            *,
+            source: "bytes",
+            fee: "int",
+            counter: "int",
+            gas_limit: "int",
+            storage_limit: "int",
+            balance: "int",
+            script: "bytes",
+            manager_pubkey: "bytes | None" = None,
+            spendable: "bool | None" = None,
+            delegatable: "bool | None" = None,
+            delegate: "bytes | None" = None,
+        ) -> None:
+            pass
+
+        @classmethod
+        def is_type_of(cls, msg: protobuf.MessageType) -> TypeGuard["TezosOriginationOp"]:
+            return isinstance(msg, cls)
+
+    class TezosDelegationOp(protobuf.MessageType):
+        source: "bytes"
+        fee: "int"
+        counter: "int"
+        gas_limit: "int"
+        storage_limit: "int"
+        delegate: "bytes"
+
+        def __init__(
+            self,
+            *,
+            source: "bytes",
+            fee: "int",
+            counter: "int",
+            gas_limit: "int",
+            storage_limit: "int",
+            delegate: "bytes",
+        ) -> None:
+            pass
+
+        @classmethod
+        def is_type_of(cls, msg: protobuf.MessageType) -> TypeGuard["TezosDelegationOp"]:
+            return isinstance(msg, cls)
+
+    class TezosProposalOp(protobuf.MessageType):
+        source: "bytes | None"
+        period: "int | None"
+        proposals: "list[bytes]"
+
+        def __init__(
+            self,
+            *,
+            proposals: "list[bytes] | None" = None,
+            source: "bytes | None" = None,
+            period: "int | None" = None,
+        ) -> None:
+            pass
+
+        @classmethod
+        def is_type_of(cls, msg: protobuf.MessageType) -> TypeGuard["TezosProposalOp"]:
+            return isinstance(msg, cls)
+
+    class TezosBallotOp(protobuf.MessageType):
+        source: "bytes | None"
+        period: "int | None"
+        proposal: "bytes | None"
+        ballot: "TezosBallotType | None"
+
+        def __init__(
+            self,
+            *,
+            source: "bytes | None" = None,
+            period: "int | None" = None,
+            proposal: "bytes | None" = None,
+            ballot: "TezosBallotType | None" = None,
+        ) -> None:
+            pass
+
+        @classmethod
+        def is_type_of(cls, msg: protobuf.MessageType) -> TypeGuard["TezosBallotOp"]:
+            return isinstance(msg, cls)
+
+    class TezosParametersManager(protobuf.MessageType):
+        set_delegate: "bytes | None"
+        cancel_delegate: "bool | None"
+        transfer: "TezosManagerTransfer | None"
+
+        def __init__(
+            self,
+            *,
+            set_delegate: "bytes | None" = None,
+            cancel_delegate: "bool | None" = None,
+            transfer: "TezosManagerTransfer | None" = None,
+        ) -> None:
+            pass
+
+        @classmethod
+        def is_type_of(cls, msg: protobuf.MessageType) -> TypeGuard["TezosParametersManager"]:
+            return isinstance(msg, cls)
+
+    class TezosManagerTransfer(protobuf.MessageType):
+        destination: "TezosContractID | None"
+        amount: "int | None"
+
+        def __init__(
+            self,
+            *,
+            destination: "TezosContractID | None" = None,
+            amount: "int | None" = None,
+        ) -> None:
+            pass
+
+        @classmethod
+        def is_type_of(cls, msg: protobuf.MessageType) -> TypeGuard["TezosManagerTransfer"]:
             return isinstance(msg, cls)
 
     class WebAuthnListResidentCredentials(protobuf.MessageType):
@@ -5223,12 +5223,12 @@ if TYPE_CHECKING:
             return isinstance(msg, cls)
 
     class WebAuthnAddResidentCredential(protobuf.MessageType):
-        credential_id: bytes | None
+        credential_id: "bytes | None"
 
         def __init__(
             self,
             *,
-            credential_id: bytes | None = None,
+            credential_id: "bytes | None" = None,
         ) -> None:
             pass
 
@@ -5237,12 +5237,12 @@ if TYPE_CHECKING:
             return isinstance(msg, cls)
 
     class WebAuthnRemoveResidentCredential(protobuf.MessageType):
-        index: int | None
+        index: "int | None"
 
         def __init__(
             self,
             *,
-            index: int | None = None,
+            index: "int | None" = None,
         ) -> None:
             pass
 
@@ -5250,52 +5250,52 @@ if TYPE_CHECKING:
         def is_type_of(cls, msg: protobuf.MessageType) -> TypeGuard["WebAuthnRemoveResidentCredential"]:
             return isinstance(msg, cls)
 
-    class WebAuthnCredential(protobuf.MessageType):
-        index: int | None
-        id: bytes | None
-        rp_id: str | None
-        rp_name: str | None
-        user_id: bytes | None
-        user_name: str | None
-        user_display_name: str | None
-        creation_time: int | None
-        hmac_secret: bool | None
-        use_sign_count: bool | None
-        algorithm: int | None
-        curve: int | None
-
-        def __init__(
-            self,
-            *,
-            index: int | None = None,
-            id: bytes | None = None,
-            rp_id: str | None = None,
-            rp_name: str | None = None,
-            user_id: bytes | None = None,
-            user_name: str | None = None,
-            user_display_name: str | None = None,
-            creation_time: int | None = None,
-            hmac_secret: bool | None = None,
-            use_sign_count: bool | None = None,
-            algorithm: int | None = None,
-            curve: int | None = None,
-        ) -> None:
-            pass
-
-        @classmethod
-        def is_type_of(cls, msg: protobuf.MessageType) -> TypeGuard["WebAuthnCredential"]:
-            return isinstance(msg, cls)
-
     class WebAuthnCredentials(protobuf.MessageType):
-        credentials: list[WebAuthnCredential]
+        credentials: "list[WebAuthnCredential]"
 
         def __init__(
             self,
             *,
-            credentials: list[WebAuthnCredential] | None = None,
+            credentials: "list[WebAuthnCredential] | None" = None,
         ) -> None:
             pass
 
         @classmethod
         def is_type_of(cls, msg: protobuf.MessageType) -> TypeGuard["WebAuthnCredentials"]:
+            return isinstance(msg, cls)
+
+    class WebAuthnCredential(protobuf.MessageType):
+        index: "int | None"
+        id: "bytes | None"
+        rp_id: "str | None"
+        rp_name: "str | None"
+        user_id: "bytes | None"
+        user_name: "str | None"
+        user_display_name: "str | None"
+        creation_time: "int | None"
+        hmac_secret: "bool | None"
+        use_sign_count: "bool | None"
+        algorithm: "int | None"
+        curve: "int | None"
+
+        def __init__(
+            self,
+            *,
+            index: "int | None" = None,
+            id: "bytes | None" = None,
+            rp_id: "str | None" = None,
+            rp_name: "str | None" = None,
+            user_id: "bytes | None" = None,
+            user_name: "str | None" = None,
+            user_display_name: "str | None" = None,
+            creation_time: "int | None" = None,
+            hmac_secret: "bool | None" = None,
+            use_sign_count: "bool | None" = None,
+            algorithm: "int | None" = None,
+            curve: "int | None" = None,
+        ) -> None:
+            pass
+
+        @classmethod
+        def is_type_of(cls, msg: protobuf.MessageType) -> TypeGuard["WebAuthnCredential"]:
             return isinstance(msg, cls)

--- a/python/src/trezorlib/_proto_messages.mako
+++ b/python/src/trezorlib/_proto_messages.mako
@@ -21,22 +21,13 @@ class ${enum.name}(IntEnum):
 required_fields = [f for f in message.fields if f.required]
 repeated_fields = [f for f in message.fields if f.repeated]
 optional_fields = [f for f in message.fields if f.optional]
-
-
-def type_name(field):
-    if field.type_object is not None:
-        return field.type_name
-    else:
-        return '"' + field.type_name + '"'
-
-
 %>\
 class ${message.name}(protobuf.MessageType):
     MESSAGE_WIRE_TYPE = ${message.wire_type}
 % if message.fields:
     FIELDS = {
 % for field in message.fields:
-        ${field.number}: protobuf.Field("${field.name}", ${type_name(field)}, repeated=${field.repeated}, required=${field.required}),
+        ${field.number}: protobuf.Field("${field.name}", "${field.type_name}", repeated=${field.repeated}, required=${field.required}),
 % endfor
     }
 
@@ -44,13 +35,13 @@ class ${message.name}(protobuf.MessageType):
         self,
         *,
 % for field in required_fields:
-        ${field.name}: ${field.python_type},
+        ${field.name}: "${field.python_type}",
 % endfor
 % for field in repeated_fields:
-        ${field.name}: Optional[List[${field.python_type}]] = None,
+        ${field.name}: Optional[List["${field.python_type}"]] = None,
 % endfor
 % for field in optional_fields:
-        ${field.name}: Optional[${field.python_type}] = ${field.default_value_repr},
+        ${field.name}: Optional["${field.python_type}"] = ${field.default_value_repr},
 % endfor
     ) -> None:
 % for field in repeated_fields:

--- a/python/src/trezorlib/messages.py
+++ b/python/src/trezorlib/messages.py
@@ -454,8 +454,8 @@ class BinanceGetAddress(protobuf.MessageType):
     def __init__(
         self,
         *,
-        address_n: Optional[List[int]] = None,
-        show_display: Optional[bool] = None,
+        address_n: Optional[List["int"]] = None,
+        show_display: Optional["bool"] = None,
     ) -> None:
         self.address_n = address_n if address_n is not None else []
         self.show_display = show_display
@@ -470,7 +470,7 @@ class BinanceAddress(protobuf.MessageType):
     def __init__(
         self,
         *,
-        address: str,
+        address: "str",
     ) -> None:
         self.address = address
 
@@ -485,8 +485,8 @@ class BinanceGetPublicKey(protobuf.MessageType):
     def __init__(
         self,
         *,
-        address_n: Optional[List[int]] = None,
-        show_display: Optional[bool] = None,
+        address_n: Optional[List["int"]] = None,
+        show_display: Optional["bool"] = None,
     ) -> None:
         self.address_n = address_n if address_n is not None else []
         self.show_display = show_display
@@ -501,7 +501,7 @@ class BinancePublicKey(protobuf.MessageType):
     def __init__(
         self,
         *,
-        public_key: bytes,
+        public_key: "bytes",
     ) -> None:
         self.public_key = public_key
 
@@ -521,13 +521,13 @@ class BinanceSignTx(protobuf.MessageType):
     def __init__(
         self,
         *,
-        address_n: Optional[List[int]] = None,
-        msg_count: Optional[int] = None,
-        account_number: Optional[int] = None,
-        chain_id: Optional[str] = None,
-        memo: Optional[str] = None,
-        sequence: Optional[int] = None,
-        source: Optional[int] = None,
+        address_n: Optional[List["int"]] = None,
+        msg_count: Optional["int"] = None,
+        account_number: Optional["int"] = None,
+        chain_id: Optional["str"] = None,
+        memo: Optional["str"] = None,
+        sequence: Optional["int"] = None,
+        source: Optional["int"] = None,
     ) -> None:
         self.address_n = address_n if address_n is not None else []
         self.msg_count = msg_count
@@ -542,52 +542,18 @@ class BinanceTxRequest(protobuf.MessageType):
     MESSAGE_WIRE_TYPE = 705
 
 
-class BinanceCoin(protobuf.MessageType):
-    MESSAGE_WIRE_TYPE = None
-    FIELDS = {
-        1: protobuf.Field("amount", "sint64", repeated=False, required=False),
-        2: protobuf.Field("denom", "string", repeated=False, required=False),
-    }
-
-    def __init__(
-        self,
-        *,
-        amount: Optional[int] = None,
-        denom: Optional[str] = None,
-    ) -> None:
-        self.amount = amount
-        self.denom = denom
-
-
-class BinanceInputOutput(protobuf.MessageType):
-    MESSAGE_WIRE_TYPE = None
-    FIELDS = {
-        1: protobuf.Field("address", "string", repeated=False, required=False),
-        2: protobuf.Field("coins", BinanceCoin, repeated=True, required=False),
-    }
-
-    def __init__(
-        self,
-        *,
-        coins: Optional[List[BinanceCoin]] = None,
-        address: Optional[str] = None,
-    ) -> None:
-        self.coins = coins if coins is not None else []
-        self.address = address
-
-
 class BinanceTransferMsg(protobuf.MessageType):
     MESSAGE_WIRE_TYPE = 706
     FIELDS = {
-        1: protobuf.Field("inputs", BinanceInputOutput, repeated=True, required=False),
-        2: protobuf.Field("outputs", BinanceInputOutput, repeated=True, required=False),
+        1: protobuf.Field("inputs", "BinanceInputOutput", repeated=True, required=False),
+        2: protobuf.Field("outputs", "BinanceInputOutput", repeated=True, required=False),
     }
 
     def __init__(
         self,
         *,
-        inputs: Optional[List[BinanceInputOutput]] = None,
-        outputs: Optional[List[BinanceInputOutput]] = None,
+        inputs: Optional[List["BinanceInputOutput"]] = None,
+        outputs: Optional[List["BinanceInputOutput"]] = None,
     ) -> None:
         self.inputs = inputs if inputs is not None else []
         self.outputs = outputs if outputs is not None else []
@@ -597,26 +563,26 @@ class BinanceOrderMsg(protobuf.MessageType):
     MESSAGE_WIRE_TYPE = 707
     FIELDS = {
         1: protobuf.Field("id", "string", repeated=False, required=False),
-        2: protobuf.Field("ordertype", BinanceOrderType, repeated=False, required=False),
+        2: protobuf.Field("ordertype", "BinanceOrderType", repeated=False, required=False),
         3: protobuf.Field("price", "sint64", repeated=False, required=False),
         4: protobuf.Field("quantity", "sint64", repeated=False, required=False),
         5: protobuf.Field("sender", "string", repeated=False, required=False),
-        6: protobuf.Field("side", BinanceOrderSide, repeated=False, required=False),
+        6: protobuf.Field("side", "BinanceOrderSide", repeated=False, required=False),
         7: protobuf.Field("symbol", "string", repeated=False, required=False),
-        8: protobuf.Field("timeinforce", BinanceTimeInForce, repeated=False, required=False),
+        8: protobuf.Field("timeinforce", "BinanceTimeInForce", repeated=False, required=False),
     }
 
     def __init__(
         self,
         *,
-        id: Optional[str] = None,
-        ordertype: Optional[BinanceOrderType] = None,
-        price: Optional[int] = None,
-        quantity: Optional[int] = None,
-        sender: Optional[str] = None,
-        side: Optional[BinanceOrderSide] = None,
-        symbol: Optional[str] = None,
-        timeinforce: Optional[BinanceTimeInForce] = None,
+        id: Optional["str"] = None,
+        ordertype: Optional["BinanceOrderType"] = None,
+        price: Optional["int"] = None,
+        quantity: Optional["int"] = None,
+        sender: Optional["str"] = None,
+        side: Optional["BinanceOrderSide"] = None,
+        symbol: Optional["str"] = None,
+        timeinforce: Optional["BinanceTimeInForce"] = None,
     ) -> None:
         self.id = id
         self.ordertype = ordertype
@@ -639,9 +605,9 @@ class BinanceCancelMsg(protobuf.MessageType):
     def __init__(
         self,
         *,
-        refid: Optional[str] = None,
-        sender: Optional[str] = None,
-        symbol: Optional[str] = None,
+        refid: Optional["str"] = None,
+        sender: Optional["str"] = None,
+        symbol: Optional["str"] = None,
     ) -> None:
         self.refid = refid
         self.sender = sender
@@ -658,11 +624,45 @@ class BinanceSignedTx(protobuf.MessageType):
     def __init__(
         self,
         *,
-        signature: bytes,
-        public_key: bytes,
+        signature: "bytes",
+        public_key: "bytes",
     ) -> None:
         self.signature = signature
         self.public_key = public_key
+
+
+class BinanceInputOutput(protobuf.MessageType):
+    MESSAGE_WIRE_TYPE = None
+    FIELDS = {
+        1: protobuf.Field("address", "string", repeated=False, required=False),
+        2: protobuf.Field("coins", "BinanceCoin", repeated=True, required=False),
+    }
+
+    def __init__(
+        self,
+        *,
+        coins: Optional[List["BinanceCoin"]] = None,
+        address: Optional["str"] = None,
+    ) -> None:
+        self.coins = coins if coins is not None else []
+        self.address = address
+
+
+class BinanceCoin(protobuf.MessageType):
+    MESSAGE_WIRE_TYPE = None
+    FIELDS = {
+        1: protobuf.Field("amount", "sint64", repeated=False, required=False),
+        2: protobuf.Field("denom", "string", repeated=False, required=False),
+    }
+
+    def __init__(
+        self,
+        *,
+        amount: Optional["int"] = None,
+        denom: Optional["str"] = None,
+    ) -> None:
+        self.amount = amount
+        self.denom = denom
 
 
 class Success(protobuf.MessageType):
@@ -674,7 +674,7 @@ class Success(protobuf.MessageType):
     def __init__(
         self,
         *,
-        message: Optional[str] = '',
+        message: Optional["str"] = '',
     ) -> None:
         self.message = message
 
@@ -682,15 +682,15 @@ class Success(protobuf.MessageType):
 class Failure(protobuf.MessageType):
     MESSAGE_WIRE_TYPE = 3
     FIELDS = {
-        1: protobuf.Field("code", FailureType, repeated=False, required=False),
+        1: protobuf.Field("code", "FailureType", repeated=False, required=False),
         2: protobuf.Field("message", "string", repeated=False, required=False),
     }
 
     def __init__(
         self,
         *,
-        code: Optional[FailureType] = None,
-        message: Optional[str] = None,
+        code: Optional["FailureType"] = None,
+        message: Optional["str"] = None,
     ) -> None:
         self.code = code
         self.message = message
@@ -699,15 +699,15 @@ class Failure(protobuf.MessageType):
 class ButtonRequest(protobuf.MessageType):
     MESSAGE_WIRE_TYPE = 26
     FIELDS = {
-        1: protobuf.Field("code", ButtonRequestType, repeated=False, required=False),
+        1: protobuf.Field("code", "ButtonRequestType", repeated=False, required=False),
         2: protobuf.Field("pages", "uint32", repeated=False, required=False),
     }
 
     def __init__(
         self,
         *,
-        code: Optional[ButtonRequestType] = None,
-        pages: Optional[int] = None,
+        code: Optional["ButtonRequestType"] = None,
+        pages: Optional["int"] = None,
     ) -> None:
         self.code = code
         self.pages = pages
@@ -720,13 +720,13 @@ class ButtonAck(protobuf.MessageType):
 class PinMatrixRequest(protobuf.MessageType):
     MESSAGE_WIRE_TYPE = 18
     FIELDS = {
-        1: protobuf.Field("type", PinMatrixRequestType, repeated=False, required=False),
+        1: protobuf.Field("type", "PinMatrixRequestType", repeated=False, required=False),
     }
 
     def __init__(
         self,
         *,
-        type: Optional[PinMatrixRequestType] = None,
+        type: Optional["PinMatrixRequestType"] = None,
     ) -> None:
         self.type = type
 
@@ -740,7 +740,7 @@ class PinMatrixAck(protobuf.MessageType):
     def __init__(
         self,
         *,
-        pin: str,
+        pin: "str",
     ) -> None:
         self.pin = pin
 
@@ -754,7 +754,7 @@ class PassphraseRequest(protobuf.MessageType):
     def __init__(
         self,
         *,
-        _on_device: Optional[bool] = None,
+        _on_device: Optional["bool"] = None,
     ) -> None:
         self._on_device = _on_device
 
@@ -770,9 +770,9 @@ class PassphraseAck(protobuf.MessageType):
     def __init__(
         self,
         *,
-        passphrase: Optional[str] = None,
-        _state: Optional[bytes] = None,
-        on_device: Optional[bool] = None,
+        passphrase: Optional["str"] = None,
+        _state: Optional["bytes"] = None,
+        on_device: Optional["bool"] = None,
     ) -> None:
         self.passphrase = passphrase
         self._state = _state
@@ -788,7 +788,7 @@ class Deprecated_PassphraseStateRequest(protobuf.MessageType):
     def __init__(
         self,
         *,
-        state: Optional[bytes] = None,
+        state: Optional["bytes"] = None,
     ) -> None:
         self.state = state
 
@@ -811,12 +811,12 @@ class HDNodeType(protobuf.MessageType):
     def __init__(
         self,
         *,
-        depth: int,
-        fingerprint: int,
-        child_num: int,
-        chain_code: bytes,
-        public_key: bytes,
-        private_key: Optional[bytes] = None,
+        depth: "int",
+        fingerprint: "int",
+        child_num: "int",
+        chain_code: "bytes",
+        public_key: "bytes",
+        private_key: Optional["bytes"] = None,
     ) -> None:
         self.depth = depth
         self.fingerprint = fingerprint
@@ -826,41 +826,24 @@ class HDNodeType(protobuf.MessageType):
         self.private_key = private_key
 
 
-class HDNodePathType(protobuf.MessageType):
-    MESSAGE_WIRE_TYPE = None
-    FIELDS = {
-        1: protobuf.Field("node", HDNodeType, repeated=False, required=True),
-        2: protobuf.Field("address_n", "uint32", repeated=True, required=False),
-    }
-
-    def __init__(
-        self,
-        *,
-        node: HDNodeType,
-        address_n: Optional[List[int]] = None,
-    ) -> None:
-        self.address_n = address_n if address_n is not None else []
-        self.node = node
-
-
 class MultisigRedeemScriptType(protobuf.MessageType):
     MESSAGE_WIRE_TYPE = None
     FIELDS = {
-        1: protobuf.Field("pubkeys", HDNodePathType, repeated=True, required=False),
+        1: protobuf.Field("pubkeys", "HDNodePathType", repeated=True, required=False),
         2: protobuf.Field("signatures", "bytes", repeated=True, required=False),
         3: protobuf.Field("m", "uint32", repeated=False, required=True),
-        4: protobuf.Field("nodes", HDNodeType, repeated=True, required=False),
+        4: protobuf.Field("nodes", "HDNodeType", repeated=True, required=False),
         5: protobuf.Field("address_n", "uint32", repeated=True, required=False),
     }
 
     def __init__(
         self,
         *,
-        m: int,
-        pubkeys: Optional[List[HDNodePathType]] = None,
-        signatures: Optional[List[bytes]] = None,
-        nodes: Optional[List[HDNodeType]] = None,
-        address_n: Optional[List[int]] = None,
+        m: "int",
+        pubkeys: Optional[List["HDNodePathType"]] = None,
+        signatures: Optional[List["bytes"]] = None,
+        nodes: Optional[List["HDNodeType"]] = None,
+        address_n: Optional[List["int"]] = None,
     ) -> None:
         self.pubkeys = pubkeys if pubkeys is not None else []
         self.signatures = signatures if signatures is not None else []
@@ -876,19 +859,19 @@ class GetPublicKey(protobuf.MessageType):
         2: protobuf.Field("ecdsa_curve_name", "string", repeated=False, required=False),
         3: protobuf.Field("show_display", "bool", repeated=False, required=False),
         4: protobuf.Field("coin_name", "string", repeated=False, required=False),
-        5: protobuf.Field("script_type", InputScriptType, repeated=False, required=False),
+        5: protobuf.Field("script_type", "InputScriptType", repeated=False, required=False),
         6: protobuf.Field("ignore_xpub_magic", "bool", repeated=False, required=False),
     }
 
     def __init__(
         self,
         *,
-        address_n: Optional[List[int]] = None,
-        ecdsa_curve_name: Optional[str] = None,
-        show_display: Optional[bool] = None,
-        coin_name: Optional[str] = 'Bitcoin',
-        script_type: Optional[InputScriptType] = InputScriptType.SPENDADDRESS,
-        ignore_xpub_magic: Optional[bool] = None,
+        address_n: Optional[List["int"]] = None,
+        ecdsa_curve_name: Optional["str"] = None,
+        show_display: Optional["bool"] = None,
+        coin_name: Optional["str"] = 'Bitcoin',
+        script_type: Optional["InputScriptType"] = InputScriptType.SPENDADDRESS,
+        ignore_xpub_magic: Optional["bool"] = None,
     ) -> None:
         self.address_n = address_n if address_n is not None else []
         self.ecdsa_curve_name = ecdsa_curve_name
@@ -901,7 +884,7 @@ class GetPublicKey(protobuf.MessageType):
 class PublicKey(protobuf.MessageType):
     MESSAGE_WIRE_TYPE = 12
     FIELDS = {
-        1: protobuf.Field("node", HDNodeType, repeated=False, required=True),
+        1: protobuf.Field("node", "HDNodeType", repeated=False, required=True),
         2: protobuf.Field("xpub", "string", repeated=False, required=True),
         3: protobuf.Field("root_fingerprint", "uint32", repeated=False, required=False),
     }
@@ -909,9 +892,9 @@ class PublicKey(protobuf.MessageType):
     def __init__(
         self,
         *,
-        node: HDNodeType,
-        xpub: str,
-        root_fingerprint: Optional[int] = None,
+        node: "HDNodeType",
+        xpub: "str",
+        root_fingerprint: Optional["int"] = None,
     ) -> None:
         self.node = node
         self.xpub = xpub
@@ -924,20 +907,20 @@ class GetAddress(protobuf.MessageType):
         1: protobuf.Field("address_n", "uint32", repeated=True, required=False),
         2: protobuf.Field("coin_name", "string", repeated=False, required=False),
         3: protobuf.Field("show_display", "bool", repeated=False, required=False),
-        4: protobuf.Field("multisig", MultisigRedeemScriptType, repeated=False, required=False),
-        5: protobuf.Field("script_type", InputScriptType, repeated=False, required=False),
+        4: protobuf.Field("multisig", "MultisigRedeemScriptType", repeated=False, required=False),
+        5: protobuf.Field("script_type", "InputScriptType", repeated=False, required=False),
         6: protobuf.Field("ignore_xpub_magic", "bool", repeated=False, required=False),
     }
 
     def __init__(
         self,
         *,
-        address_n: Optional[List[int]] = None,
-        coin_name: Optional[str] = 'Bitcoin',
-        show_display: Optional[bool] = None,
-        multisig: Optional[MultisigRedeemScriptType] = None,
-        script_type: Optional[InputScriptType] = InputScriptType.SPENDADDRESS,
-        ignore_xpub_magic: Optional[bool] = None,
+        address_n: Optional[List["int"]] = None,
+        coin_name: Optional["str"] = 'Bitcoin',
+        show_display: Optional["bool"] = None,
+        multisig: Optional["MultisigRedeemScriptType"] = None,
+        script_type: Optional["InputScriptType"] = InputScriptType.SPENDADDRESS,
+        ignore_xpub_magic: Optional["bool"] = None,
     ) -> None:
         self.address_n = address_n if address_n is not None else []
         self.coin_name = coin_name
@@ -956,7 +939,7 @@ class Address(protobuf.MessageType):
     def __init__(
         self,
         *,
-        address: str,
+        address: "str",
     ) -> None:
         self.address = address
 
@@ -966,17 +949,17 @@ class GetOwnershipId(protobuf.MessageType):
     FIELDS = {
         1: protobuf.Field("address_n", "uint32", repeated=True, required=False),
         2: protobuf.Field("coin_name", "string", repeated=False, required=False),
-        3: protobuf.Field("multisig", MultisigRedeemScriptType, repeated=False, required=False),
-        4: protobuf.Field("script_type", InputScriptType, repeated=False, required=False),
+        3: protobuf.Field("multisig", "MultisigRedeemScriptType", repeated=False, required=False),
+        4: protobuf.Field("script_type", "InputScriptType", repeated=False, required=False),
     }
 
     def __init__(
         self,
         *,
-        address_n: Optional[List[int]] = None,
-        coin_name: Optional[str] = 'Bitcoin',
-        multisig: Optional[MultisigRedeemScriptType] = None,
-        script_type: Optional[InputScriptType] = InputScriptType.SPENDADDRESS,
+        address_n: Optional[List["int"]] = None,
+        coin_name: Optional["str"] = 'Bitcoin',
+        multisig: Optional["MultisigRedeemScriptType"] = None,
+        script_type: Optional["InputScriptType"] = InputScriptType.SPENDADDRESS,
     ) -> None:
         self.address_n = address_n if address_n is not None else []
         self.coin_name = coin_name
@@ -993,7 +976,7 @@ class OwnershipId(protobuf.MessageType):
     def __init__(
         self,
         *,
-        ownership_id: bytes,
+        ownership_id: "bytes",
     ) -> None:
         self.ownership_id = ownership_id
 
@@ -1004,16 +987,16 @@ class SignMessage(protobuf.MessageType):
         1: protobuf.Field("address_n", "uint32", repeated=True, required=False),
         2: protobuf.Field("message", "bytes", repeated=False, required=True),
         3: protobuf.Field("coin_name", "string", repeated=False, required=False),
-        4: protobuf.Field("script_type", InputScriptType, repeated=False, required=False),
+        4: protobuf.Field("script_type", "InputScriptType", repeated=False, required=False),
     }
 
     def __init__(
         self,
         *,
-        message: bytes,
-        address_n: Optional[List[int]] = None,
-        coin_name: Optional[str] = 'Bitcoin',
-        script_type: Optional[InputScriptType] = InputScriptType.SPENDADDRESS,
+        message: "bytes",
+        address_n: Optional[List["int"]] = None,
+        coin_name: Optional["str"] = 'Bitcoin',
+        script_type: Optional["InputScriptType"] = InputScriptType.SPENDADDRESS,
     ) -> None:
         self.address_n = address_n if address_n is not None else []
         self.message = message
@@ -1031,8 +1014,8 @@ class MessageSignature(protobuf.MessageType):
     def __init__(
         self,
         *,
-        address: str,
-        signature: bytes,
+        address: "str",
+        signature: "bytes",
     ) -> None:
         self.address = address
         self.signature = signature
@@ -1050,10 +1033,10 @@ class VerifyMessage(protobuf.MessageType):
     def __init__(
         self,
         *,
-        address: str,
-        signature: bytes,
-        message: bytes,
-        coin_name: Optional[str] = 'Bitcoin',
+        address: "str",
+        signature: "bytes",
+        message: "bytes",
+        coin_name: Optional["str"] = 'Bitcoin',
     ) -> None:
         self.address = address
         self.signature = signature
@@ -1074,25 +1057,25 @@ class SignTx(protobuf.MessageType):
         8: protobuf.Field("version_group_id", "uint32", repeated=False, required=False),
         9: protobuf.Field("timestamp", "uint32", repeated=False, required=False),
         10: protobuf.Field("branch_id", "uint32", repeated=False, required=False),
-        11: protobuf.Field("amount_unit", AmountUnit, repeated=False, required=False),
+        11: protobuf.Field("amount_unit", "AmountUnit", repeated=False, required=False),
         12: protobuf.Field("decred_staking_ticket", "bool", repeated=False, required=False),
     }
 
     def __init__(
         self,
         *,
-        outputs_count: int,
-        inputs_count: int,
-        coin_name: Optional[str] = 'Bitcoin',
-        version: Optional[int] = 1,
-        lock_time: Optional[int] = 0,
-        expiry: Optional[int] = None,
-        overwintered: Optional[bool] = None,
-        version_group_id: Optional[int] = None,
-        timestamp: Optional[int] = None,
-        branch_id: Optional[int] = None,
-        amount_unit: Optional[AmountUnit] = AmountUnit.BITCOIN,
-        decred_staking_ticket: Optional[bool] = False,
+        outputs_count: "int",
+        inputs_count: "int",
+        coin_name: Optional["str"] = 'Bitcoin',
+        version: Optional["int"] = 1,
+        lock_time: Optional["int"] = 0,
+        expiry: Optional["int"] = None,
+        overwintered: Optional["bool"] = None,
+        version_group_id: Optional["int"] = None,
+        timestamp: Optional["int"] = None,
+        branch_id: Optional["int"] = None,
+        amount_unit: Optional["AmountUnit"] = AmountUnit.BITCOIN,
+        decred_staking_ticket: Optional["bool"] = False,
     ) -> None:
         self.outputs_count = outputs_count
         self.inputs_count = inputs_count
@@ -1108,6 +1091,397 @@ class SignTx(protobuf.MessageType):
         self.decred_staking_ticket = decred_staking_ticket
 
 
+class TxRequest(protobuf.MessageType):
+    MESSAGE_WIRE_TYPE = 21
+    FIELDS = {
+        1: protobuf.Field("request_type", "RequestType", repeated=False, required=False),
+        2: protobuf.Field("details", "TxRequestDetailsType", repeated=False, required=False),
+        3: protobuf.Field("serialized", "TxRequestSerializedType", repeated=False, required=False),
+    }
+
+    def __init__(
+        self,
+        *,
+        request_type: Optional["RequestType"] = None,
+        details: Optional["TxRequestDetailsType"] = None,
+        serialized: Optional["TxRequestSerializedType"] = None,
+    ) -> None:
+        self.request_type = request_type
+        self.details = details
+        self.serialized = serialized
+
+
+class TxAck(protobuf.MessageType):
+    MESSAGE_WIRE_TYPE = 22
+    FIELDS = {
+        1: protobuf.Field("tx", "TransactionType", repeated=False, required=False),
+    }
+
+    def __init__(
+        self,
+        *,
+        tx: Optional["TransactionType"] = None,
+    ) -> None:
+        self.tx = tx
+
+
+class TxInput(protobuf.MessageType):
+    MESSAGE_WIRE_TYPE = None
+    FIELDS = {
+        1: protobuf.Field("address_n", "uint32", repeated=True, required=False),
+        2: protobuf.Field("prev_hash", "bytes", repeated=False, required=True),
+        3: protobuf.Field("prev_index", "uint32", repeated=False, required=True),
+        4: protobuf.Field("script_sig", "bytes", repeated=False, required=False),
+        5: protobuf.Field("sequence", "uint32", repeated=False, required=False),
+        6: protobuf.Field("script_type", "InputScriptType", repeated=False, required=False),
+        7: protobuf.Field("multisig", "MultisigRedeemScriptType", repeated=False, required=False),
+        8: protobuf.Field("amount", "uint64", repeated=False, required=True),
+        9: protobuf.Field("decred_tree", "uint32", repeated=False, required=False),
+        13: protobuf.Field("witness", "bytes", repeated=False, required=False),
+        14: protobuf.Field("ownership_proof", "bytes", repeated=False, required=False),
+        15: protobuf.Field("commitment_data", "bytes", repeated=False, required=False),
+        16: protobuf.Field("orig_hash", "bytes", repeated=False, required=False),
+        17: protobuf.Field("orig_index", "uint32", repeated=False, required=False),
+        18: protobuf.Field("decred_staking_spend", "DecredStakingSpendType", repeated=False, required=False),
+    }
+
+    def __init__(
+        self,
+        *,
+        prev_hash: "bytes",
+        prev_index: "int",
+        amount: "int",
+        address_n: Optional[List["int"]] = None,
+        script_sig: Optional["bytes"] = None,
+        sequence: Optional["int"] = 4294967295,
+        script_type: Optional["InputScriptType"] = InputScriptType.SPENDADDRESS,
+        multisig: Optional["MultisigRedeemScriptType"] = None,
+        decred_tree: Optional["int"] = None,
+        witness: Optional["bytes"] = None,
+        ownership_proof: Optional["bytes"] = None,
+        commitment_data: Optional["bytes"] = None,
+        orig_hash: Optional["bytes"] = None,
+        orig_index: Optional["int"] = None,
+        decred_staking_spend: Optional["DecredStakingSpendType"] = None,
+    ) -> None:
+        self.address_n = address_n if address_n is not None else []
+        self.prev_hash = prev_hash
+        self.prev_index = prev_index
+        self.amount = amount
+        self.script_sig = script_sig
+        self.sequence = sequence
+        self.script_type = script_type
+        self.multisig = multisig
+        self.decred_tree = decred_tree
+        self.witness = witness
+        self.ownership_proof = ownership_proof
+        self.commitment_data = commitment_data
+        self.orig_hash = orig_hash
+        self.orig_index = orig_index
+        self.decred_staking_spend = decred_staking_spend
+
+
+class TxOutput(protobuf.MessageType):
+    MESSAGE_WIRE_TYPE = None
+    FIELDS = {
+        1: protobuf.Field("address", "string", repeated=False, required=False),
+        2: protobuf.Field("address_n", "uint32", repeated=True, required=False),
+        3: protobuf.Field("amount", "uint64", repeated=False, required=True),
+        4: protobuf.Field("script_type", "OutputScriptType", repeated=False, required=False),
+        5: protobuf.Field("multisig", "MultisigRedeemScriptType", repeated=False, required=False),
+        6: protobuf.Field("op_return_data", "bytes", repeated=False, required=False),
+        10: protobuf.Field("orig_hash", "bytes", repeated=False, required=False),
+        11: protobuf.Field("orig_index", "uint32", repeated=False, required=False),
+    }
+
+    def __init__(
+        self,
+        *,
+        amount: "int",
+        address_n: Optional[List["int"]] = None,
+        address: Optional["str"] = None,
+        script_type: Optional["OutputScriptType"] = OutputScriptType.PAYTOADDRESS,
+        multisig: Optional["MultisigRedeemScriptType"] = None,
+        op_return_data: Optional["bytes"] = None,
+        orig_hash: Optional["bytes"] = None,
+        orig_index: Optional["int"] = None,
+    ) -> None:
+        self.address_n = address_n if address_n is not None else []
+        self.amount = amount
+        self.address = address
+        self.script_type = script_type
+        self.multisig = multisig
+        self.op_return_data = op_return_data
+        self.orig_hash = orig_hash
+        self.orig_index = orig_index
+
+
+class PrevTx(protobuf.MessageType):
+    MESSAGE_WIRE_TYPE = None
+    FIELDS = {
+        1: protobuf.Field("version", "uint32", repeated=False, required=True),
+        4: protobuf.Field("lock_time", "uint32", repeated=False, required=True),
+        6: protobuf.Field("inputs_count", "uint32", repeated=False, required=True),
+        7: protobuf.Field("outputs_count", "uint32", repeated=False, required=True),
+        9: protobuf.Field("extra_data_len", "uint32", repeated=False, required=False),
+        10: protobuf.Field("expiry", "uint32", repeated=False, required=False),
+        12: protobuf.Field("version_group_id", "uint32", repeated=False, required=False),
+        13: protobuf.Field("timestamp", "uint32", repeated=False, required=False),
+        14: protobuf.Field("branch_id", "uint32", repeated=False, required=False),
+    }
+
+    def __init__(
+        self,
+        *,
+        version: "int",
+        lock_time: "int",
+        inputs_count: "int",
+        outputs_count: "int",
+        extra_data_len: Optional["int"] = 0,
+        expiry: Optional["int"] = None,
+        version_group_id: Optional["int"] = None,
+        timestamp: Optional["int"] = None,
+        branch_id: Optional["int"] = None,
+    ) -> None:
+        self.version = version
+        self.lock_time = lock_time
+        self.inputs_count = inputs_count
+        self.outputs_count = outputs_count
+        self.extra_data_len = extra_data_len
+        self.expiry = expiry
+        self.version_group_id = version_group_id
+        self.timestamp = timestamp
+        self.branch_id = branch_id
+
+
+class PrevInput(protobuf.MessageType):
+    MESSAGE_WIRE_TYPE = None
+    FIELDS = {
+        2: protobuf.Field("prev_hash", "bytes", repeated=False, required=True),
+        3: protobuf.Field("prev_index", "uint32", repeated=False, required=True),
+        4: protobuf.Field("script_sig", "bytes", repeated=False, required=True),
+        5: protobuf.Field("sequence", "uint32", repeated=False, required=True),
+        9: protobuf.Field("decred_tree", "uint32", repeated=False, required=False),
+    }
+
+    def __init__(
+        self,
+        *,
+        prev_hash: "bytes",
+        prev_index: "int",
+        script_sig: "bytes",
+        sequence: "int",
+        decred_tree: Optional["int"] = None,
+    ) -> None:
+        self.prev_hash = prev_hash
+        self.prev_index = prev_index
+        self.script_sig = script_sig
+        self.sequence = sequence
+        self.decred_tree = decred_tree
+
+
+class PrevOutput(protobuf.MessageType):
+    MESSAGE_WIRE_TYPE = None
+    FIELDS = {
+        1: protobuf.Field("amount", "uint64", repeated=False, required=True),
+        2: protobuf.Field("script_pubkey", "bytes", repeated=False, required=True),
+        3: protobuf.Field("decred_script_version", "uint32", repeated=False, required=False),
+    }
+
+    def __init__(
+        self,
+        *,
+        amount: "int",
+        script_pubkey: "bytes",
+        decred_script_version: Optional["int"] = None,
+    ) -> None:
+        self.amount = amount
+        self.script_pubkey = script_pubkey
+        self.decred_script_version = decred_script_version
+
+
+class TxAckInput(protobuf.MessageType):
+    MESSAGE_WIRE_TYPE = 22
+    FIELDS = {
+        1: protobuf.Field("tx", "TxAckInputWrapper", repeated=False, required=True),
+    }
+
+    def __init__(
+        self,
+        *,
+        tx: "TxAckInputWrapper",
+    ) -> None:
+        self.tx = tx
+
+
+class TxAckOutput(protobuf.MessageType):
+    MESSAGE_WIRE_TYPE = 22
+    FIELDS = {
+        1: protobuf.Field("tx", "TxAckOutputWrapper", repeated=False, required=True),
+    }
+
+    def __init__(
+        self,
+        *,
+        tx: "TxAckOutputWrapper",
+    ) -> None:
+        self.tx = tx
+
+
+class TxAckPrevMeta(protobuf.MessageType):
+    MESSAGE_WIRE_TYPE = 22
+    FIELDS = {
+        1: protobuf.Field("tx", "PrevTx", repeated=False, required=True),
+    }
+
+    def __init__(
+        self,
+        *,
+        tx: "PrevTx",
+    ) -> None:
+        self.tx = tx
+
+
+class TxAckPrevInput(protobuf.MessageType):
+    MESSAGE_WIRE_TYPE = 22
+    FIELDS = {
+        1: protobuf.Field("tx", "TxAckPrevInputWrapper", repeated=False, required=True),
+    }
+
+    def __init__(
+        self,
+        *,
+        tx: "TxAckPrevInputWrapper",
+    ) -> None:
+        self.tx = tx
+
+
+class TxAckPrevOutput(protobuf.MessageType):
+    MESSAGE_WIRE_TYPE = 22
+    FIELDS = {
+        1: protobuf.Field("tx", "TxAckPrevOutputWrapper", repeated=False, required=True),
+    }
+
+    def __init__(
+        self,
+        *,
+        tx: "TxAckPrevOutputWrapper",
+    ) -> None:
+        self.tx = tx
+
+
+class TxAckPrevExtraData(protobuf.MessageType):
+    MESSAGE_WIRE_TYPE = 22
+    FIELDS = {
+        1: protobuf.Field("tx", "TxAckPrevExtraDataWrapper", repeated=False, required=True),
+    }
+
+    def __init__(
+        self,
+        *,
+        tx: "TxAckPrevExtraDataWrapper",
+    ) -> None:
+        self.tx = tx
+
+
+class GetOwnershipProof(protobuf.MessageType):
+    MESSAGE_WIRE_TYPE = 49
+    FIELDS = {
+        1: protobuf.Field("address_n", "uint32", repeated=True, required=False),
+        2: protobuf.Field("coin_name", "string", repeated=False, required=False),
+        3: protobuf.Field("script_type", "InputScriptType", repeated=False, required=False),
+        4: protobuf.Field("multisig", "MultisigRedeemScriptType", repeated=False, required=False),
+        5: protobuf.Field("user_confirmation", "bool", repeated=False, required=False),
+        6: protobuf.Field("ownership_ids", "bytes", repeated=True, required=False),
+        7: protobuf.Field("commitment_data", "bytes", repeated=False, required=False),
+    }
+
+    def __init__(
+        self,
+        *,
+        address_n: Optional[List["int"]] = None,
+        ownership_ids: Optional[List["bytes"]] = None,
+        coin_name: Optional["str"] = 'Bitcoin',
+        script_type: Optional["InputScriptType"] = InputScriptType.SPENDWITNESS,
+        multisig: Optional["MultisigRedeemScriptType"] = None,
+        user_confirmation: Optional["bool"] = False,
+        commitment_data: Optional["bytes"] = b'',
+    ) -> None:
+        self.address_n = address_n if address_n is not None else []
+        self.ownership_ids = ownership_ids if ownership_ids is not None else []
+        self.coin_name = coin_name
+        self.script_type = script_type
+        self.multisig = multisig
+        self.user_confirmation = user_confirmation
+        self.commitment_data = commitment_data
+
+
+class OwnershipProof(protobuf.MessageType):
+    MESSAGE_WIRE_TYPE = 50
+    FIELDS = {
+        1: protobuf.Field("ownership_proof", "bytes", repeated=False, required=True),
+        2: protobuf.Field("signature", "bytes", repeated=False, required=True),
+    }
+
+    def __init__(
+        self,
+        *,
+        ownership_proof: "bytes",
+        signature: "bytes",
+    ) -> None:
+        self.ownership_proof = ownership_proof
+        self.signature = signature
+
+
+class AuthorizeCoinJoin(protobuf.MessageType):
+    MESSAGE_WIRE_TYPE = 51
+    FIELDS = {
+        1: protobuf.Field("coordinator", "string", repeated=False, required=True),
+        2: protobuf.Field("max_total_fee", "uint64", repeated=False, required=True),
+        3: protobuf.Field("fee_per_anonymity", "uint32", repeated=False, required=False),
+        4: protobuf.Field("address_n", "uint32", repeated=True, required=False),
+        5: protobuf.Field("coin_name", "string", repeated=False, required=False),
+        6: protobuf.Field("script_type", "InputScriptType", repeated=False, required=False),
+        11: protobuf.Field("amount_unit", "AmountUnit", repeated=False, required=False),
+    }
+
+    def __init__(
+        self,
+        *,
+        coordinator: "str",
+        max_total_fee: "int",
+        address_n: Optional[List["int"]] = None,
+        fee_per_anonymity: Optional["int"] = 0,
+        coin_name: Optional["str"] = 'Bitcoin',
+        script_type: Optional["InputScriptType"] = InputScriptType.SPENDADDRESS,
+        amount_unit: Optional["AmountUnit"] = AmountUnit.BITCOIN,
+    ) -> None:
+        self.address_n = address_n if address_n is not None else []
+        self.coordinator = coordinator
+        self.max_total_fee = max_total_fee
+        self.fee_per_anonymity = fee_per_anonymity
+        self.coin_name = coin_name
+        self.script_type = script_type
+        self.amount_unit = amount_unit
+
+
+class HDNodePathType(protobuf.MessageType):
+    MESSAGE_WIRE_TYPE = None
+    FIELDS = {
+        1: protobuf.Field("node", "HDNodeType", repeated=False, required=True),
+        2: protobuf.Field("address_n", "uint32", repeated=True, required=False),
+    }
+
+    def __init__(
+        self,
+        *,
+        node: "HDNodeType",
+        address_n: Optional[List["int"]] = None,
+    ) -> None:
+        self.address_n = address_n if address_n is not None else []
+        self.node = node
+
+
 class TxRequestDetailsType(protobuf.MessageType):
     MESSAGE_WIRE_TYPE = None
     FIELDS = {
@@ -1120,10 +1494,10 @@ class TxRequestDetailsType(protobuf.MessageType):
     def __init__(
         self,
         *,
-        request_index: Optional[int] = None,
-        tx_hash: Optional[bytes] = None,
-        extra_data_len: Optional[int] = None,
-        extra_data_offset: Optional[int] = None,
+        request_index: Optional["int"] = None,
+        tx_hash: Optional["bytes"] = None,
+        extra_data_len: Optional["int"] = None,
+        extra_data_offset: Optional["int"] = None,
     ) -> None:
         self.request_index = request_index
         self.tx_hash = tx_hash
@@ -1142,33 +1516,66 @@ class TxRequestSerializedType(protobuf.MessageType):
     def __init__(
         self,
         *,
-        signature_index: Optional[int] = None,
-        signature: Optional[bytes] = None,
-        serialized_tx: Optional[bytes] = None,
+        signature_index: Optional["int"] = None,
+        signature: Optional["bytes"] = None,
+        serialized_tx: Optional["bytes"] = None,
     ) -> None:
         self.signature_index = signature_index
         self.signature = signature
         self.serialized_tx = serialized_tx
 
 
-class TxRequest(protobuf.MessageType):
-    MESSAGE_WIRE_TYPE = 21
+class TransactionType(protobuf.MessageType):
+    MESSAGE_WIRE_TYPE = None
     FIELDS = {
-        1: protobuf.Field("request_type", RequestType, repeated=False, required=False),
-        2: protobuf.Field("details", TxRequestDetailsType, repeated=False, required=False),
-        3: protobuf.Field("serialized", TxRequestSerializedType, repeated=False, required=False),
+        1: protobuf.Field("version", "uint32", repeated=False, required=False),
+        2: protobuf.Field("inputs", "TxInputType", repeated=True, required=False),
+        3: protobuf.Field("bin_outputs", "TxOutputBinType", repeated=True, required=False),
+        4: protobuf.Field("lock_time", "uint32", repeated=False, required=False),
+        5: protobuf.Field("outputs", "TxOutputType", repeated=True, required=False),
+        6: protobuf.Field("inputs_cnt", "uint32", repeated=False, required=False),
+        7: protobuf.Field("outputs_cnt", "uint32", repeated=False, required=False),
+        8: protobuf.Field("extra_data", "bytes", repeated=False, required=False),
+        9: protobuf.Field("extra_data_len", "uint32", repeated=False, required=False),
+        10: protobuf.Field("expiry", "uint32", repeated=False, required=False),
+        11: protobuf.Field("overwintered", "bool", repeated=False, required=False),
+        12: protobuf.Field("version_group_id", "uint32", repeated=False, required=False),
+        13: protobuf.Field("timestamp", "uint32", repeated=False, required=False),
+        14: protobuf.Field("branch_id", "uint32", repeated=False, required=False),
     }
 
     def __init__(
         self,
         *,
-        request_type: Optional[RequestType] = None,
-        details: Optional[TxRequestDetailsType] = None,
-        serialized: Optional[TxRequestSerializedType] = None,
+        inputs: Optional[List["TxInputType"]] = None,
+        bin_outputs: Optional[List["TxOutputBinType"]] = None,
+        outputs: Optional[List["TxOutputType"]] = None,
+        version: Optional["int"] = None,
+        lock_time: Optional["int"] = None,
+        inputs_cnt: Optional["int"] = None,
+        outputs_cnt: Optional["int"] = None,
+        extra_data: Optional["bytes"] = None,
+        extra_data_len: Optional["int"] = None,
+        expiry: Optional["int"] = None,
+        overwintered: Optional["bool"] = None,
+        version_group_id: Optional["int"] = None,
+        timestamp: Optional["int"] = None,
+        branch_id: Optional["int"] = None,
     ) -> None:
-        self.request_type = request_type
-        self.details = details
-        self.serialized = serialized
+        self.inputs = inputs if inputs is not None else []
+        self.bin_outputs = bin_outputs if bin_outputs is not None else []
+        self.outputs = outputs if outputs is not None else []
+        self.version = version
+        self.lock_time = lock_time
+        self.inputs_cnt = inputs_cnt
+        self.outputs_cnt = outputs_cnt
+        self.extra_data = extra_data
+        self.extra_data_len = extra_data_len
+        self.expiry = expiry
+        self.overwintered = overwintered
+        self.version_group_id = version_group_id
+        self.timestamp = timestamp
+        self.branch_id = branch_id
 
 
 class TxInputType(protobuf.MessageType):
@@ -1179,8 +1586,8 @@ class TxInputType(protobuf.MessageType):
         3: protobuf.Field("prev_index", "uint32", repeated=False, required=True),
         4: protobuf.Field("script_sig", "bytes", repeated=False, required=False),
         5: protobuf.Field("sequence", "uint32", repeated=False, required=False),
-        6: protobuf.Field("script_type", InputScriptType, repeated=False, required=False),
-        7: protobuf.Field("multisig", MultisigRedeemScriptType, repeated=False, required=False),
+        6: protobuf.Field("script_type", "InputScriptType", repeated=False, required=False),
+        7: protobuf.Field("multisig", "MultisigRedeemScriptType", repeated=False, required=False),
         8: protobuf.Field("amount", "uint64", repeated=False, required=False),
         9: protobuf.Field("decred_tree", "uint32", repeated=False, required=False),
         13: protobuf.Field("witness", "bytes", repeated=False, required=False),
@@ -1188,27 +1595,27 @@ class TxInputType(protobuf.MessageType):
         15: protobuf.Field("commitment_data", "bytes", repeated=False, required=False),
         16: protobuf.Field("orig_hash", "bytes", repeated=False, required=False),
         17: protobuf.Field("orig_index", "uint32", repeated=False, required=False),
-        18: protobuf.Field("decred_staking_spend", DecredStakingSpendType, repeated=False, required=False),
+        18: protobuf.Field("decred_staking_spend", "DecredStakingSpendType", repeated=False, required=False),
     }
 
     def __init__(
         self,
         *,
-        prev_hash: bytes,
-        prev_index: int,
-        address_n: Optional[List[int]] = None,
-        script_sig: Optional[bytes] = None,
-        sequence: Optional[int] = 4294967295,
-        script_type: Optional[InputScriptType] = InputScriptType.SPENDADDRESS,
-        multisig: Optional[MultisigRedeemScriptType] = None,
-        amount: Optional[int] = None,
-        decred_tree: Optional[int] = None,
-        witness: Optional[bytes] = None,
-        ownership_proof: Optional[bytes] = None,
-        commitment_data: Optional[bytes] = None,
-        orig_hash: Optional[bytes] = None,
-        orig_index: Optional[int] = None,
-        decred_staking_spend: Optional[DecredStakingSpendType] = None,
+        prev_hash: "bytes",
+        prev_index: "int",
+        address_n: Optional[List["int"]] = None,
+        script_sig: Optional["bytes"] = None,
+        sequence: Optional["int"] = 4294967295,
+        script_type: Optional["InputScriptType"] = InputScriptType.SPENDADDRESS,
+        multisig: Optional["MultisigRedeemScriptType"] = None,
+        amount: Optional["int"] = None,
+        decred_tree: Optional["int"] = None,
+        witness: Optional["bytes"] = None,
+        ownership_proof: Optional["bytes"] = None,
+        commitment_data: Optional["bytes"] = None,
+        orig_hash: Optional["bytes"] = None,
+        orig_index: Optional["int"] = None,
+        decred_staking_spend: Optional["DecredStakingSpendType"] = None,
     ) -> None:
         self.address_n = address_n if address_n is not None else []
         self.prev_hash = prev_hash
@@ -1238,9 +1645,9 @@ class TxOutputBinType(protobuf.MessageType):
     def __init__(
         self,
         *,
-        amount: int,
-        script_pubkey: bytes,
-        decred_script_version: Optional[int] = None,
+        amount: "int",
+        script_pubkey: "bytes",
+        decred_script_version: Optional["int"] = None,
     ) -> None:
         self.amount = amount
         self.script_pubkey = script_pubkey
@@ -1253,8 +1660,8 @@ class TxOutputType(protobuf.MessageType):
         1: protobuf.Field("address", "string", repeated=False, required=False),
         2: protobuf.Field("address_n", "uint32", repeated=True, required=False),
         3: protobuf.Field("amount", "uint64", repeated=False, required=True),
-        4: protobuf.Field("script_type", OutputScriptType, repeated=False, required=False),
-        5: protobuf.Field("multisig", MultisigRedeemScriptType, repeated=False, required=False),
+        4: protobuf.Field("script_type", "OutputScriptType", repeated=False, required=False),
+        5: protobuf.Field("multisig", "MultisigRedeemScriptType", repeated=False, required=False),
         6: protobuf.Field("op_return_data", "bytes", repeated=False, required=False),
         10: protobuf.Field("orig_hash", "bytes", repeated=False, required=False),
         11: protobuf.Field("orig_index", "uint32", repeated=False, required=False),
@@ -1263,14 +1670,14 @@ class TxOutputType(protobuf.MessageType):
     def __init__(
         self,
         *,
-        amount: int,
-        address_n: Optional[List[int]] = None,
-        address: Optional[str] = None,
-        script_type: Optional[OutputScriptType] = OutputScriptType.PAYTOADDRESS,
-        multisig: Optional[MultisigRedeemScriptType] = None,
-        op_return_data: Optional[bytes] = None,
-        orig_hash: Optional[bytes] = None,
-        orig_index: Optional[int] = None,
+        amount: "int",
+        address_n: Optional[List["int"]] = None,
+        address: Optional["str"] = None,
+        script_type: Optional["OutputScriptType"] = OutputScriptType.PAYTOADDRESS,
+        multisig: Optional["MultisigRedeemScriptType"] = None,
+        op_return_data: Optional["bytes"] = None,
+        orig_hash: Optional["bytes"] = None,
+        orig_index: Optional["int"] = None,
     ) -> None:
         self.address_n = address_n if address_n is not None else []
         self.amount = amount
@@ -1280,374 +1687,62 @@ class TxOutputType(protobuf.MessageType):
         self.op_return_data = op_return_data
         self.orig_hash = orig_hash
         self.orig_index = orig_index
-
-
-class TransactionType(protobuf.MessageType):
-    MESSAGE_WIRE_TYPE = None
-    FIELDS = {
-        1: protobuf.Field("version", "uint32", repeated=False, required=False),
-        2: protobuf.Field("inputs", TxInputType, repeated=True, required=False),
-        3: protobuf.Field("bin_outputs", TxOutputBinType, repeated=True, required=False),
-        4: protobuf.Field("lock_time", "uint32", repeated=False, required=False),
-        5: protobuf.Field("outputs", TxOutputType, repeated=True, required=False),
-        6: protobuf.Field("inputs_cnt", "uint32", repeated=False, required=False),
-        7: protobuf.Field("outputs_cnt", "uint32", repeated=False, required=False),
-        8: protobuf.Field("extra_data", "bytes", repeated=False, required=False),
-        9: protobuf.Field("extra_data_len", "uint32", repeated=False, required=False),
-        10: protobuf.Field("expiry", "uint32", repeated=False, required=False),
-        11: protobuf.Field("overwintered", "bool", repeated=False, required=False),
-        12: protobuf.Field("version_group_id", "uint32", repeated=False, required=False),
-        13: protobuf.Field("timestamp", "uint32", repeated=False, required=False),
-        14: protobuf.Field("branch_id", "uint32", repeated=False, required=False),
-    }
-
-    def __init__(
-        self,
-        *,
-        inputs: Optional[List[TxInputType]] = None,
-        bin_outputs: Optional[List[TxOutputBinType]] = None,
-        outputs: Optional[List[TxOutputType]] = None,
-        version: Optional[int] = None,
-        lock_time: Optional[int] = None,
-        inputs_cnt: Optional[int] = None,
-        outputs_cnt: Optional[int] = None,
-        extra_data: Optional[bytes] = None,
-        extra_data_len: Optional[int] = None,
-        expiry: Optional[int] = None,
-        overwintered: Optional[bool] = None,
-        version_group_id: Optional[int] = None,
-        timestamp: Optional[int] = None,
-        branch_id: Optional[int] = None,
-    ) -> None:
-        self.inputs = inputs if inputs is not None else []
-        self.bin_outputs = bin_outputs if bin_outputs is not None else []
-        self.outputs = outputs if outputs is not None else []
-        self.version = version
-        self.lock_time = lock_time
-        self.inputs_cnt = inputs_cnt
-        self.outputs_cnt = outputs_cnt
-        self.extra_data = extra_data
-        self.extra_data_len = extra_data_len
-        self.expiry = expiry
-        self.overwintered = overwintered
-        self.version_group_id = version_group_id
-        self.timestamp = timestamp
-        self.branch_id = branch_id
-
-
-class TxAck(protobuf.MessageType):
-    MESSAGE_WIRE_TYPE = 22
-    FIELDS = {
-        1: protobuf.Field("tx", TransactionType, repeated=False, required=False),
-    }
-
-    def __init__(
-        self,
-        *,
-        tx: Optional[TransactionType] = None,
-    ) -> None:
-        self.tx = tx
-
-
-class TxInput(protobuf.MessageType):
-    MESSAGE_WIRE_TYPE = None
-    FIELDS = {
-        1: protobuf.Field("address_n", "uint32", repeated=True, required=False),
-        2: protobuf.Field("prev_hash", "bytes", repeated=False, required=True),
-        3: protobuf.Field("prev_index", "uint32", repeated=False, required=True),
-        4: protobuf.Field("script_sig", "bytes", repeated=False, required=False),
-        5: protobuf.Field("sequence", "uint32", repeated=False, required=False),
-        6: protobuf.Field("script_type", InputScriptType, repeated=False, required=False),
-        7: protobuf.Field("multisig", MultisigRedeemScriptType, repeated=False, required=False),
-        8: protobuf.Field("amount", "uint64", repeated=False, required=True),
-        9: protobuf.Field("decred_tree", "uint32", repeated=False, required=False),
-        13: protobuf.Field("witness", "bytes", repeated=False, required=False),
-        14: protobuf.Field("ownership_proof", "bytes", repeated=False, required=False),
-        15: protobuf.Field("commitment_data", "bytes", repeated=False, required=False),
-        16: protobuf.Field("orig_hash", "bytes", repeated=False, required=False),
-        17: protobuf.Field("orig_index", "uint32", repeated=False, required=False),
-        18: protobuf.Field("decred_staking_spend", DecredStakingSpendType, repeated=False, required=False),
-    }
-
-    def __init__(
-        self,
-        *,
-        prev_hash: bytes,
-        prev_index: int,
-        amount: int,
-        address_n: Optional[List[int]] = None,
-        script_sig: Optional[bytes] = None,
-        sequence: Optional[int] = 4294967295,
-        script_type: Optional[InputScriptType] = InputScriptType.SPENDADDRESS,
-        multisig: Optional[MultisigRedeemScriptType] = None,
-        decred_tree: Optional[int] = None,
-        witness: Optional[bytes] = None,
-        ownership_proof: Optional[bytes] = None,
-        commitment_data: Optional[bytes] = None,
-        orig_hash: Optional[bytes] = None,
-        orig_index: Optional[int] = None,
-        decred_staking_spend: Optional[DecredStakingSpendType] = None,
-    ) -> None:
-        self.address_n = address_n if address_n is not None else []
-        self.prev_hash = prev_hash
-        self.prev_index = prev_index
-        self.amount = amount
-        self.script_sig = script_sig
-        self.sequence = sequence
-        self.script_type = script_type
-        self.multisig = multisig
-        self.decred_tree = decred_tree
-        self.witness = witness
-        self.ownership_proof = ownership_proof
-        self.commitment_data = commitment_data
-        self.orig_hash = orig_hash
-        self.orig_index = orig_index
-        self.decred_staking_spend = decred_staking_spend
-
-
-class TxOutput(protobuf.MessageType):
-    MESSAGE_WIRE_TYPE = None
-    FIELDS = {
-        1: protobuf.Field("address", "string", repeated=False, required=False),
-        2: protobuf.Field("address_n", "uint32", repeated=True, required=False),
-        3: protobuf.Field("amount", "uint64", repeated=False, required=True),
-        4: protobuf.Field("script_type", OutputScriptType, repeated=False, required=False),
-        5: protobuf.Field("multisig", MultisigRedeemScriptType, repeated=False, required=False),
-        6: protobuf.Field("op_return_data", "bytes", repeated=False, required=False),
-        10: protobuf.Field("orig_hash", "bytes", repeated=False, required=False),
-        11: protobuf.Field("orig_index", "uint32", repeated=False, required=False),
-    }
-
-    def __init__(
-        self,
-        *,
-        amount: int,
-        address_n: Optional[List[int]] = None,
-        address: Optional[str] = None,
-        script_type: Optional[OutputScriptType] = OutputScriptType.PAYTOADDRESS,
-        multisig: Optional[MultisigRedeemScriptType] = None,
-        op_return_data: Optional[bytes] = None,
-        orig_hash: Optional[bytes] = None,
-        orig_index: Optional[int] = None,
-    ) -> None:
-        self.address_n = address_n if address_n is not None else []
-        self.amount = amount
-        self.address = address
-        self.script_type = script_type
-        self.multisig = multisig
-        self.op_return_data = op_return_data
-        self.orig_hash = orig_hash
-        self.orig_index = orig_index
-
-
-class PrevTx(protobuf.MessageType):
-    MESSAGE_WIRE_TYPE = None
-    FIELDS = {
-        1: protobuf.Field("version", "uint32", repeated=False, required=True),
-        4: protobuf.Field("lock_time", "uint32", repeated=False, required=True),
-        6: protobuf.Field("inputs_count", "uint32", repeated=False, required=True),
-        7: protobuf.Field("outputs_count", "uint32", repeated=False, required=True),
-        9: protobuf.Field("extra_data_len", "uint32", repeated=False, required=False),
-        10: protobuf.Field("expiry", "uint32", repeated=False, required=False),
-        12: protobuf.Field("version_group_id", "uint32", repeated=False, required=False),
-        13: protobuf.Field("timestamp", "uint32", repeated=False, required=False),
-        14: protobuf.Field("branch_id", "uint32", repeated=False, required=False),
-    }
-
-    def __init__(
-        self,
-        *,
-        version: int,
-        lock_time: int,
-        inputs_count: int,
-        outputs_count: int,
-        extra_data_len: Optional[int] = 0,
-        expiry: Optional[int] = None,
-        version_group_id: Optional[int] = None,
-        timestamp: Optional[int] = None,
-        branch_id: Optional[int] = None,
-    ) -> None:
-        self.version = version
-        self.lock_time = lock_time
-        self.inputs_count = inputs_count
-        self.outputs_count = outputs_count
-        self.extra_data_len = extra_data_len
-        self.expiry = expiry
-        self.version_group_id = version_group_id
-        self.timestamp = timestamp
-        self.branch_id = branch_id
-
-
-class PrevInput(protobuf.MessageType):
-    MESSAGE_WIRE_TYPE = None
-    FIELDS = {
-        2: protobuf.Field("prev_hash", "bytes", repeated=False, required=True),
-        3: protobuf.Field("prev_index", "uint32", repeated=False, required=True),
-        4: protobuf.Field("script_sig", "bytes", repeated=False, required=True),
-        5: protobuf.Field("sequence", "uint32", repeated=False, required=True),
-        9: protobuf.Field("decred_tree", "uint32", repeated=False, required=False),
-    }
-
-    def __init__(
-        self,
-        *,
-        prev_hash: bytes,
-        prev_index: int,
-        script_sig: bytes,
-        sequence: int,
-        decred_tree: Optional[int] = None,
-    ) -> None:
-        self.prev_hash = prev_hash
-        self.prev_index = prev_index
-        self.script_sig = script_sig
-        self.sequence = sequence
-        self.decred_tree = decred_tree
-
-
-class PrevOutput(protobuf.MessageType):
-    MESSAGE_WIRE_TYPE = None
-    FIELDS = {
-        1: protobuf.Field("amount", "uint64", repeated=False, required=True),
-        2: protobuf.Field("script_pubkey", "bytes", repeated=False, required=True),
-        3: protobuf.Field("decred_script_version", "uint32", repeated=False, required=False),
-    }
-
-    def __init__(
-        self,
-        *,
-        amount: int,
-        script_pubkey: bytes,
-        decred_script_version: Optional[int] = None,
-    ) -> None:
-        self.amount = amount
-        self.script_pubkey = script_pubkey
-        self.decred_script_version = decred_script_version
 
 
 class TxAckInputWrapper(protobuf.MessageType):
     MESSAGE_WIRE_TYPE = None
     FIELDS = {
-        2: protobuf.Field("input", TxInput, repeated=False, required=True),
+        2: protobuf.Field("input", "TxInput", repeated=False, required=True),
     }
 
     def __init__(
         self,
         *,
-        input: TxInput,
+        input: "TxInput",
     ) -> None:
         self.input = input
-
-
-class TxAckInput(protobuf.MessageType):
-    MESSAGE_WIRE_TYPE = 22
-    FIELDS = {
-        1: protobuf.Field("tx", TxAckInputWrapper, repeated=False, required=True),
-    }
-
-    def __init__(
-        self,
-        *,
-        tx: TxAckInputWrapper,
-    ) -> None:
-        self.tx = tx
 
 
 class TxAckOutputWrapper(protobuf.MessageType):
     MESSAGE_WIRE_TYPE = None
     FIELDS = {
-        5: protobuf.Field("output", TxOutput, repeated=False, required=True),
+        5: protobuf.Field("output", "TxOutput", repeated=False, required=True),
     }
 
     def __init__(
         self,
         *,
-        output: TxOutput,
+        output: "TxOutput",
     ) -> None:
         self.output = output
-
-
-class TxAckOutput(protobuf.MessageType):
-    MESSAGE_WIRE_TYPE = 22
-    FIELDS = {
-        1: protobuf.Field("tx", TxAckOutputWrapper, repeated=False, required=True),
-    }
-
-    def __init__(
-        self,
-        *,
-        tx: TxAckOutputWrapper,
-    ) -> None:
-        self.tx = tx
-
-
-class TxAckPrevMeta(protobuf.MessageType):
-    MESSAGE_WIRE_TYPE = 22
-    FIELDS = {
-        1: protobuf.Field("tx", PrevTx, repeated=False, required=True),
-    }
-
-    def __init__(
-        self,
-        *,
-        tx: PrevTx,
-    ) -> None:
-        self.tx = tx
 
 
 class TxAckPrevInputWrapper(protobuf.MessageType):
     MESSAGE_WIRE_TYPE = None
     FIELDS = {
-        2: protobuf.Field("input", PrevInput, repeated=False, required=True),
+        2: protobuf.Field("input", "PrevInput", repeated=False, required=True),
     }
 
     def __init__(
         self,
         *,
-        input: PrevInput,
+        input: "PrevInput",
     ) -> None:
         self.input = input
-
-
-class TxAckPrevInput(protobuf.MessageType):
-    MESSAGE_WIRE_TYPE = 22
-    FIELDS = {
-        1: protobuf.Field("tx", TxAckPrevInputWrapper, repeated=False, required=True),
-    }
-
-    def __init__(
-        self,
-        *,
-        tx: TxAckPrevInputWrapper,
-    ) -> None:
-        self.tx = tx
 
 
 class TxAckPrevOutputWrapper(protobuf.MessageType):
     MESSAGE_WIRE_TYPE = None
     FIELDS = {
-        3: protobuf.Field("output", PrevOutput, repeated=False, required=True),
+        3: protobuf.Field("output", "PrevOutput", repeated=False, required=True),
     }
 
     def __init__(
         self,
         *,
-        output: PrevOutput,
+        output: "PrevOutput",
     ) -> None:
         self.output = output
-
-
-class TxAckPrevOutput(protobuf.MessageType):
-    MESSAGE_WIRE_TYPE = 22
-    FIELDS = {
-        1: protobuf.Field("tx", TxAckPrevOutputWrapper, repeated=False, required=True),
-    }
-
-    def __init__(
-        self,
-        *,
-        tx: TxAckPrevOutputWrapper,
-    ) -> None:
-        self.tx = tx
 
 
 class TxAckPrevExtraDataWrapper(protobuf.MessageType):
@@ -1659,104 +1754,9 @@ class TxAckPrevExtraDataWrapper(protobuf.MessageType):
     def __init__(
         self,
         *,
-        extra_data_chunk: bytes,
+        extra_data_chunk: "bytes",
     ) -> None:
         self.extra_data_chunk = extra_data_chunk
-
-
-class TxAckPrevExtraData(protobuf.MessageType):
-    MESSAGE_WIRE_TYPE = 22
-    FIELDS = {
-        1: protobuf.Field("tx", TxAckPrevExtraDataWrapper, repeated=False, required=True),
-    }
-
-    def __init__(
-        self,
-        *,
-        tx: TxAckPrevExtraDataWrapper,
-    ) -> None:
-        self.tx = tx
-
-
-class GetOwnershipProof(protobuf.MessageType):
-    MESSAGE_WIRE_TYPE = 49
-    FIELDS = {
-        1: protobuf.Field("address_n", "uint32", repeated=True, required=False),
-        2: protobuf.Field("coin_name", "string", repeated=False, required=False),
-        3: protobuf.Field("script_type", InputScriptType, repeated=False, required=False),
-        4: protobuf.Field("multisig", MultisigRedeemScriptType, repeated=False, required=False),
-        5: protobuf.Field("user_confirmation", "bool", repeated=False, required=False),
-        6: protobuf.Field("ownership_ids", "bytes", repeated=True, required=False),
-        7: protobuf.Field("commitment_data", "bytes", repeated=False, required=False),
-    }
-
-    def __init__(
-        self,
-        *,
-        address_n: Optional[List[int]] = None,
-        ownership_ids: Optional[List[bytes]] = None,
-        coin_name: Optional[str] = 'Bitcoin',
-        script_type: Optional[InputScriptType] = InputScriptType.SPENDWITNESS,
-        multisig: Optional[MultisigRedeemScriptType] = None,
-        user_confirmation: Optional[bool] = False,
-        commitment_data: Optional[bytes] = b'',
-    ) -> None:
-        self.address_n = address_n if address_n is not None else []
-        self.ownership_ids = ownership_ids if ownership_ids is not None else []
-        self.coin_name = coin_name
-        self.script_type = script_type
-        self.multisig = multisig
-        self.user_confirmation = user_confirmation
-        self.commitment_data = commitment_data
-
-
-class OwnershipProof(protobuf.MessageType):
-    MESSAGE_WIRE_TYPE = 50
-    FIELDS = {
-        1: protobuf.Field("ownership_proof", "bytes", repeated=False, required=True),
-        2: protobuf.Field("signature", "bytes", repeated=False, required=True),
-    }
-
-    def __init__(
-        self,
-        *,
-        ownership_proof: bytes,
-        signature: bytes,
-    ) -> None:
-        self.ownership_proof = ownership_proof
-        self.signature = signature
-
-
-class AuthorizeCoinJoin(protobuf.MessageType):
-    MESSAGE_WIRE_TYPE = 51
-    FIELDS = {
-        1: protobuf.Field("coordinator", "string", repeated=False, required=True),
-        2: protobuf.Field("max_total_fee", "uint64", repeated=False, required=True),
-        3: protobuf.Field("fee_per_anonymity", "uint32", repeated=False, required=False),
-        4: protobuf.Field("address_n", "uint32", repeated=True, required=False),
-        5: protobuf.Field("coin_name", "string", repeated=False, required=False),
-        6: protobuf.Field("script_type", InputScriptType, repeated=False, required=False),
-        11: protobuf.Field("amount_unit", AmountUnit, repeated=False, required=False),
-    }
-
-    def __init__(
-        self,
-        *,
-        coordinator: str,
-        max_total_fee: int,
-        address_n: Optional[List[int]] = None,
-        fee_per_anonymity: Optional[int] = 0,
-        coin_name: Optional[str] = 'Bitcoin',
-        script_type: Optional[InputScriptType] = InputScriptType.SPENDADDRESS,
-        amount_unit: Optional[AmountUnit] = AmountUnit.BITCOIN,
-    ) -> None:
-        self.address_n = address_n if address_n is not None else []
-        self.coordinator = coordinator
-        self.max_total_fee = max_total_fee
-        self.fee_per_anonymity = fee_per_anonymity
-        self.coin_name = coin_name
-        self.script_type = script_type
-        self.amount_unit = amount_unit
 
 
 class FirmwareErase(protobuf.MessageType):
@@ -1768,7 +1768,7 @@ class FirmwareErase(protobuf.MessageType):
     def __init__(
         self,
         *,
-        length: Optional[int] = None,
+        length: Optional["int"] = None,
     ) -> None:
         self.length = length
 
@@ -1783,8 +1783,8 @@ class FirmwareRequest(protobuf.MessageType):
     def __init__(
         self,
         *,
-        offset: Optional[int] = None,
-        length: Optional[int] = None,
+        offset: Optional["int"] = None,
+        length: Optional["int"] = None,
     ) -> None:
         self.offset = offset
         self.length = length
@@ -1800,8 +1800,8 @@ class FirmwareUpload(protobuf.MessageType):
     def __init__(
         self,
         *,
-        payload: bytes,
-        hash: Optional[bytes] = None,
+        payload: "bytes",
+        hash: Optional["bytes"] = None,
     ) -> None:
         self.payload = payload
         self.hash = hash
@@ -1816,7 +1816,7 @@ class SelfTest(protobuf.MessageType):
     def __init__(
         self,
         *,
-        payload: Optional[bytes] = None,
+        payload: Optional["bytes"] = None,
     ) -> None:
         self.payload = payload
 
@@ -1832,9 +1832,9 @@ class CardanoBlockchainPointerType(protobuf.MessageType):
     def __init__(
         self,
         *,
-        block_index: int,
-        tx_index: int,
-        certificate_index: int,
+        block_index: "int",
+        tx_index: "int",
+        certificate_index: "int",
     ) -> None:
         self.block_index = block_index
         self.tx_index = tx_index
@@ -1844,21 +1844,21 @@ class CardanoBlockchainPointerType(protobuf.MessageType):
 class CardanoAddressParametersType(protobuf.MessageType):
     MESSAGE_WIRE_TYPE = None
     FIELDS = {
-        1: protobuf.Field("address_type", CardanoAddressType, repeated=False, required=True),
+        1: protobuf.Field("address_type", "CardanoAddressType", repeated=False, required=True),
         2: protobuf.Field("address_n", "uint32", repeated=True, required=False),
         3: protobuf.Field("address_n_staking", "uint32", repeated=True, required=False),
         4: protobuf.Field("staking_key_hash", "bytes", repeated=False, required=False),
-        5: protobuf.Field("certificate_pointer", CardanoBlockchainPointerType, repeated=False, required=False),
+        5: protobuf.Field("certificate_pointer", "CardanoBlockchainPointerType", repeated=False, required=False),
     }
 
     def __init__(
         self,
         *,
-        address_type: CardanoAddressType,
-        address_n: Optional[List[int]] = None,
-        address_n_staking: Optional[List[int]] = None,
-        staking_key_hash: Optional[bytes] = None,
-        certificate_pointer: Optional[CardanoBlockchainPointerType] = None,
+        address_type: "CardanoAddressType",
+        address_n: Optional[List["int"]] = None,
+        address_n_staking: Optional[List["int"]] = None,
+        staking_key_hash: Optional["bytes"] = None,
+        certificate_pointer: Optional["CardanoBlockchainPointerType"] = None,
     ) -> None:
         self.address_n = address_n if address_n is not None else []
         self.address_n_staking = address_n_staking if address_n_staking is not None else []
@@ -1873,16 +1873,16 @@ class CardanoGetAddress(protobuf.MessageType):
         2: protobuf.Field("show_display", "bool", repeated=False, required=False),
         3: protobuf.Field("protocol_magic", "uint32", repeated=False, required=True),
         4: protobuf.Field("network_id", "uint32", repeated=False, required=True),
-        5: protobuf.Field("address_parameters", CardanoAddressParametersType, repeated=False, required=True),
+        5: protobuf.Field("address_parameters", "CardanoAddressParametersType", repeated=False, required=True),
     }
 
     def __init__(
         self,
         *,
-        protocol_magic: int,
-        network_id: int,
-        address_parameters: CardanoAddressParametersType,
-        show_display: Optional[bool] = False,
+        protocol_magic: "int",
+        network_id: "int",
+        address_parameters: "CardanoAddressParametersType",
+        show_display: Optional["bool"] = False,
     ) -> None:
         self.protocol_magic = protocol_magic
         self.network_id = network_id
@@ -1899,7 +1899,7 @@ class CardanoAddress(protobuf.MessageType):
     def __init__(
         self,
         *,
-        address: str,
+        address: "str",
     ) -> None:
         self.address = address
 
@@ -1914,8 +1914,8 @@ class CardanoGetPublicKey(protobuf.MessageType):
     def __init__(
         self,
         *,
-        address_n: Optional[List[int]] = None,
-        show_display: Optional[bool] = None,
+        address_n: Optional[List["int"]] = None,
+        show_display: Optional["bool"] = None,
     ) -> None:
         self.address_n = address_n if address_n is not None else []
         self.show_display = show_display
@@ -1925,305 +1925,47 @@ class CardanoPublicKey(protobuf.MessageType):
     MESSAGE_WIRE_TYPE = 306
     FIELDS = {
         1: protobuf.Field("xpub", "string", repeated=False, required=True),
-        2: protobuf.Field("node", HDNodeType, repeated=False, required=True),
+        2: protobuf.Field("node", "HDNodeType", repeated=False, required=True),
     }
 
     def __init__(
         self,
         *,
-        xpub: str,
-        node: HDNodeType,
+        xpub: "str",
+        node: "HDNodeType",
     ) -> None:
         self.xpub = xpub
         self.node = node
 
 
-class CardanoTxInputType(protobuf.MessageType):
-    MESSAGE_WIRE_TYPE = None
-    FIELDS = {
-        1: protobuf.Field("address_n", "uint32", repeated=True, required=False),
-        2: protobuf.Field("prev_hash", "bytes", repeated=False, required=True),
-        3: protobuf.Field("prev_index", "uint32", repeated=False, required=True),
-    }
-
-    def __init__(
-        self,
-        *,
-        prev_hash: bytes,
-        prev_index: int,
-        address_n: Optional[List[int]] = None,
-    ) -> None:
-        self.address_n = address_n if address_n is not None else []
-        self.prev_hash = prev_hash
-        self.prev_index = prev_index
-
-
-class CardanoTokenType(protobuf.MessageType):
-    MESSAGE_WIRE_TYPE = None
-    FIELDS = {
-        1: protobuf.Field("asset_name_bytes", "bytes", repeated=False, required=True),
-        2: protobuf.Field("amount", "uint64", repeated=False, required=True),
-    }
-
-    def __init__(
-        self,
-        *,
-        asset_name_bytes: bytes,
-        amount: int,
-    ) -> None:
-        self.asset_name_bytes = asset_name_bytes
-        self.amount = amount
-
-
-class CardanoAssetGroupType(protobuf.MessageType):
-    MESSAGE_WIRE_TYPE = None
-    FIELDS = {
-        1: protobuf.Field("policy_id", "bytes", repeated=False, required=True),
-        2: protobuf.Field("tokens", CardanoTokenType, repeated=True, required=False),
-    }
-
-    def __init__(
-        self,
-        *,
-        policy_id: bytes,
-        tokens: Optional[List[CardanoTokenType]] = None,
-    ) -> None:
-        self.tokens = tokens if tokens is not None else []
-        self.policy_id = policy_id
-
-
-class CardanoTxOutputType(protobuf.MessageType):
-    MESSAGE_WIRE_TYPE = None
-    FIELDS = {
-        1: protobuf.Field("address", "string", repeated=False, required=False),
-        3: protobuf.Field("amount", "uint64", repeated=False, required=True),
-        4: protobuf.Field("address_parameters", CardanoAddressParametersType, repeated=False, required=False),
-        5: protobuf.Field("token_bundle", CardanoAssetGroupType, repeated=True, required=False),
-    }
-
-    def __init__(
-        self,
-        *,
-        amount: int,
-        token_bundle: Optional[List[CardanoAssetGroupType]] = None,
-        address: Optional[str] = None,
-        address_parameters: Optional[CardanoAddressParametersType] = None,
-    ) -> None:
-        self.token_bundle = token_bundle if token_bundle is not None else []
-        self.amount = amount
-        self.address = address
-        self.address_parameters = address_parameters
-
-
-class CardanoPoolOwnerType(protobuf.MessageType):
-    MESSAGE_WIRE_TYPE = None
-    FIELDS = {
-        1: protobuf.Field("staking_key_path", "uint32", repeated=True, required=False),
-        2: protobuf.Field("staking_key_hash", "bytes", repeated=False, required=False),
-    }
-
-    def __init__(
-        self,
-        *,
-        staking_key_path: Optional[List[int]] = None,
-        staking_key_hash: Optional[bytes] = None,
-    ) -> None:
-        self.staking_key_path = staking_key_path if staking_key_path is not None else []
-        self.staking_key_hash = staking_key_hash
-
-
-class CardanoPoolRelayParametersType(protobuf.MessageType):
-    MESSAGE_WIRE_TYPE = None
-    FIELDS = {
-        1: protobuf.Field("type", CardanoPoolRelayType, repeated=False, required=True),
-        2: protobuf.Field("ipv4_address", "bytes", repeated=False, required=False),
-        3: protobuf.Field("ipv6_address", "bytes", repeated=False, required=False),
-        4: protobuf.Field("host_name", "string", repeated=False, required=False),
-        5: protobuf.Field("port", "uint32", repeated=False, required=False),
-    }
-
-    def __init__(
-        self,
-        *,
-        type: CardanoPoolRelayType,
-        ipv4_address: Optional[bytes] = None,
-        ipv6_address: Optional[bytes] = None,
-        host_name: Optional[str] = None,
-        port: Optional[int] = None,
-    ) -> None:
-        self.type = type
-        self.ipv4_address = ipv4_address
-        self.ipv6_address = ipv6_address
-        self.host_name = host_name
-        self.port = port
-
-
-class CardanoPoolMetadataType(protobuf.MessageType):
-    MESSAGE_WIRE_TYPE = None
-    FIELDS = {
-        1: protobuf.Field("url", "string", repeated=False, required=True),
-        2: protobuf.Field("hash", "bytes", repeated=False, required=True),
-    }
-
-    def __init__(
-        self,
-        *,
-        url: str,
-        hash: bytes,
-    ) -> None:
-        self.url = url
-        self.hash = hash
-
-
-class CardanoPoolParametersType(protobuf.MessageType):
-    MESSAGE_WIRE_TYPE = None
-    FIELDS = {
-        1: protobuf.Field("pool_id", "bytes", repeated=False, required=True),
-        2: protobuf.Field("vrf_key_hash", "bytes", repeated=False, required=True),
-        3: protobuf.Field("pledge", "uint64", repeated=False, required=True),
-        4: protobuf.Field("cost", "uint64", repeated=False, required=True),
-        5: protobuf.Field("margin_numerator", "uint64", repeated=False, required=True),
-        6: protobuf.Field("margin_denominator", "uint64", repeated=False, required=True),
-        7: protobuf.Field("reward_account", "string", repeated=False, required=True),
-        8: protobuf.Field("owners", CardanoPoolOwnerType, repeated=True, required=False),
-        9: protobuf.Field("relays", CardanoPoolRelayParametersType, repeated=True, required=False),
-        10: protobuf.Field("metadata", CardanoPoolMetadataType, repeated=False, required=False),
-    }
-
-    def __init__(
-        self,
-        *,
-        pool_id: bytes,
-        vrf_key_hash: bytes,
-        pledge: int,
-        cost: int,
-        margin_numerator: int,
-        margin_denominator: int,
-        reward_account: str,
-        owners: Optional[List[CardanoPoolOwnerType]] = None,
-        relays: Optional[List[CardanoPoolRelayParametersType]] = None,
-        metadata: Optional[CardanoPoolMetadataType] = None,
-    ) -> None:
-        self.owners = owners if owners is not None else []
-        self.relays = relays if relays is not None else []
-        self.pool_id = pool_id
-        self.vrf_key_hash = vrf_key_hash
-        self.pledge = pledge
-        self.cost = cost
-        self.margin_numerator = margin_numerator
-        self.margin_denominator = margin_denominator
-        self.reward_account = reward_account
-        self.metadata = metadata
-
-
-class CardanoTxCertificateType(protobuf.MessageType):
-    MESSAGE_WIRE_TYPE = None
-    FIELDS = {
-        1: protobuf.Field("type", CardanoCertificateType, repeated=False, required=True),
-        2: protobuf.Field("path", "uint32", repeated=True, required=False),
-        3: protobuf.Field("pool", "bytes", repeated=False, required=False),
-        4: protobuf.Field("pool_parameters", CardanoPoolParametersType, repeated=False, required=False),
-    }
-
-    def __init__(
-        self,
-        *,
-        type: CardanoCertificateType,
-        path: Optional[List[int]] = None,
-        pool: Optional[bytes] = None,
-        pool_parameters: Optional[CardanoPoolParametersType] = None,
-    ) -> None:
-        self.path = path if path is not None else []
-        self.type = type
-        self.pool = pool
-        self.pool_parameters = pool_parameters
-
-
-class CardanoTxWithdrawalType(protobuf.MessageType):
-    MESSAGE_WIRE_TYPE = None
-    FIELDS = {
-        1: protobuf.Field("path", "uint32", repeated=True, required=False),
-        2: protobuf.Field("amount", "uint64", repeated=False, required=True),
-    }
-
-    def __init__(
-        self,
-        *,
-        amount: int,
-        path: Optional[List[int]] = None,
-    ) -> None:
-        self.path = path if path is not None else []
-        self.amount = amount
-
-
-class CardanoCatalystRegistrationParametersType(protobuf.MessageType):
-    MESSAGE_WIRE_TYPE = None
-    FIELDS = {
-        1: protobuf.Field("voting_public_key", "bytes", repeated=False, required=True),
-        2: protobuf.Field("staking_path", "uint32", repeated=True, required=False),
-        3: protobuf.Field("reward_address_parameters", CardanoAddressParametersType, repeated=False, required=True),
-        4: protobuf.Field("nonce", "uint64", repeated=False, required=True),
-    }
-
-    def __init__(
-        self,
-        *,
-        voting_public_key: bytes,
-        reward_address_parameters: CardanoAddressParametersType,
-        nonce: int,
-        staking_path: Optional[List[int]] = None,
-    ) -> None:
-        self.staking_path = staking_path if staking_path is not None else []
-        self.voting_public_key = voting_public_key
-        self.reward_address_parameters = reward_address_parameters
-        self.nonce = nonce
-
-
-class CardanoTxAuxiliaryDataType(protobuf.MessageType):
-    MESSAGE_WIRE_TYPE = None
-    FIELDS = {
-        1: protobuf.Field("blob", "bytes", repeated=False, required=False),
-        2: protobuf.Field("catalyst_registration_parameters", CardanoCatalystRegistrationParametersType, repeated=False, required=False),
-    }
-
-    def __init__(
-        self,
-        *,
-        blob: Optional[bytes] = None,
-        catalyst_registration_parameters: Optional[CardanoCatalystRegistrationParametersType] = None,
-    ) -> None:
-        self.blob = blob
-        self.catalyst_registration_parameters = catalyst_registration_parameters
-
-
 class CardanoSignTx(protobuf.MessageType):
     MESSAGE_WIRE_TYPE = 303
     FIELDS = {
-        1: protobuf.Field("inputs", CardanoTxInputType, repeated=True, required=False),
-        2: protobuf.Field("outputs", CardanoTxOutputType, repeated=True, required=False),
+        1: protobuf.Field("inputs", "CardanoTxInputType", repeated=True, required=False),
+        2: protobuf.Field("outputs", "CardanoTxOutputType", repeated=True, required=False),
         5: protobuf.Field("protocol_magic", "uint32", repeated=False, required=True),
         6: protobuf.Field("fee", "uint64", repeated=False, required=True),
         7: protobuf.Field("ttl", "uint64", repeated=False, required=False),
         8: protobuf.Field("network_id", "uint32", repeated=False, required=True),
-        9: protobuf.Field("certificates", CardanoTxCertificateType, repeated=True, required=False),
-        10: protobuf.Field("withdrawals", CardanoTxWithdrawalType, repeated=True, required=False),
+        9: protobuf.Field("certificates", "CardanoTxCertificateType", repeated=True, required=False),
+        10: protobuf.Field("withdrawals", "CardanoTxWithdrawalType", repeated=True, required=False),
         12: protobuf.Field("validity_interval_start", "uint64", repeated=False, required=False),
-        13: protobuf.Field("auxiliary_data", CardanoTxAuxiliaryDataType, repeated=False, required=False),
+        13: protobuf.Field("auxiliary_data", "CardanoTxAuxiliaryDataType", repeated=False, required=False),
     }
 
     def __init__(
         self,
         *,
-        protocol_magic: int,
-        fee: int,
-        network_id: int,
-        inputs: Optional[List[CardanoTxInputType]] = None,
-        outputs: Optional[List[CardanoTxOutputType]] = None,
-        certificates: Optional[List[CardanoTxCertificateType]] = None,
-        withdrawals: Optional[List[CardanoTxWithdrawalType]] = None,
-        ttl: Optional[int] = None,
-        validity_interval_start: Optional[int] = None,
-        auxiliary_data: Optional[CardanoTxAuxiliaryDataType] = None,
+        protocol_magic: "int",
+        fee: "int",
+        network_id: "int",
+        inputs: Optional[List["CardanoTxInputType"]] = None,
+        outputs: Optional[List["CardanoTxOutputType"]] = None,
+        certificates: Optional[List["CardanoTxCertificateType"]] = None,
+        withdrawals: Optional[List["CardanoTxWithdrawalType"]] = None,
+        ttl: Optional["int"] = None,
+        validity_interval_start: Optional["int"] = None,
+        auxiliary_data: Optional["CardanoTxAuxiliaryDataType"] = None,
     ) -> None:
         self.inputs = inputs if inputs is not None else []
         self.outputs = outputs if outputs is not None else []
@@ -2246,7 +1988,7 @@ class CardanoSignedTxChunk(protobuf.MessageType):
     def __init__(
         self,
         *,
-        signed_tx_chunk: bytes,
+        signed_tx_chunk: "bytes",
     ) -> None:
         self.signed_tx_chunk = signed_tx_chunk
 
@@ -2265,11 +2007,269 @@ class CardanoSignedTx(protobuf.MessageType):
     def __init__(
         self,
         *,
-        tx_hash: bytes,
-        serialized_tx: Optional[bytes] = None,
+        tx_hash: "bytes",
+        serialized_tx: Optional["bytes"] = None,
     ) -> None:
         self.tx_hash = tx_hash
         self.serialized_tx = serialized_tx
+
+
+class CardanoTxInputType(protobuf.MessageType):
+    MESSAGE_WIRE_TYPE = None
+    FIELDS = {
+        1: protobuf.Field("address_n", "uint32", repeated=True, required=False),
+        2: protobuf.Field("prev_hash", "bytes", repeated=False, required=True),
+        3: protobuf.Field("prev_index", "uint32", repeated=False, required=True),
+    }
+
+    def __init__(
+        self,
+        *,
+        prev_hash: "bytes",
+        prev_index: "int",
+        address_n: Optional[List["int"]] = None,
+    ) -> None:
+        self.address_n = address_n if address_n is not None else []
+        self.prev_hash = prev_hash
+        self.prev_index = prev_index
+
+
+class CardanoTxOutputType(protobuf.MessageType):
+    MESSAGE_WIRE_TYPE = None
+    FIELDS = {
+        1: protobuf.Field("address", "string", repeated=False, required=False),
+        3: protobuf.Field("amount", "uint64", repeated=False, required=True),
+        4: protobuf.Field("address_parameters", "CardanoAddressParametersType", repeated=False, required=False),
+        5: protobuf.Field("token_bundle", "CardanoAssetGroupType", repeated=True, required=False),
+    }
+
+    def __init__(
+        self,
+        *,
+        amount: "int",
+        token_bundle: Optional[List["CardanoAssetGroupType"]] = None,
+        address: Optional["str"] = None,
+        address_parameters: Optional["CardanoAddressParametersType"] = None,
+    ) -> None:
+        self.token_bundle = token_bundle if token_bundle is not None else []
+        self.amount = amount
+        self.address = address
+        self.address_parameters = address_parameters
+
+
+class CardanoAssetGroupType(protobuf.MessageType):
+    MESSAGE_WIRE_TYPE = None
+    FIELDS = {
+        1: protobuf.Field("policy_id", "bytes", repeated=False, required=True),
+        2: protobuf.Field("tokens", "CardanoTokenType", repeated=True, required=False),
+    }
+
+    def __init__(
+        self,
+        *,
+        policy_id: "bytes",
+        tokens: Optional[List["CardanoTokenType"]] = None,
+    ) -> None:
+        self.tokens = tokens if tokens is not None else []
+        self.policy_id = policy_id
+
+
+class CardanoTokenType(protobuf.MessageType):
+    MESSAGE_WIRE_TYPE = None
+    FIELDS = {
+        1: protobuf.Field("asset_name_bytes", "bytes", repeated=False, required=True),
+        2: protobuf.Field("amount", "uint64", repeated=False, required=True),
+    }
+
+    def __init__(
+        self,
+        *,
+        asset_name_bytes: "bytes",
+        amount: "int",
+    ) -> None:
+        self.asset_name_bytes = asset_name_bytes
+        self.amount = amount
+
+
+class CardanoPoolOwnerType(protobuf.MessageType):
+    MESSAGE_WIRE_TYPE = None
+    FIELDS = {
+        1: protobuf.Field("staking_key_path", "uint32", repeated=True, required=False),
+        2: protobuf.Field("staking_key_hash", "bytes", repeated=False, required=False),
+    }
+
+    def __init__(
+        self,
+        *,
+        staking_key_path: Optional[List["int"]] = None,
+        staking_key_hash: Optional["bytes"] = None,
+    ) -> None:
+        self.staking_key_path = staking_key_path if staking_key_path is not None else []
+        self.staking_key_hash = staking_key_hash
+
+
+class CardanoPoolRelayParametersType(protobuf.MessageType):
+    MESSAGE_WIRE_TYPE = None
+    FIELDS = {
+        1: protobuf.Field("type", "CardanoPoolRelayType", repeated=False, required=True),
+        2: protobuf.Field("ipv4_address", "bytes", repeated=False, required=False),
+        3: protobuf.Field("ipv6_address", "bytes", repeated=False, required=False),
+        4: protobuf.Field("host_name", "string", repeated=False, required=False),
+        5: protobuf.Field("port", "uint32", repeated=False, required=False),
+    }
+
+    def __init__(
+        self,
+        *,
+        type: "CardanoPoolRelayType",
+        ipv4_address: Optional["bytes"] = None,
+        ipv6_address: Optional["bytes"] = None,
+        host_name: Optional["str"] = None,
+        port: Optional["int"] = None,
+    ) -> None:
+        self.type = type
+        self.ipv4_address = ipv4_address
+        self.ipv6_address = ipv6_address
+        self.host_name = host_name
+        self.port = port
+
+
+class CardanoPoolMetadataType(protobuf.MessageType):
+    MESSAGE_WIRE_TYPE = None
+    FIELDS = {
+        1: protobuf.Field("url", "string", repeated=False, required=True),
+        2: protobuf.Field("hash", "bytes", repeated=False, required=True),
+    }
+
+    def __init__(
+        self,
+        *,
+        url: "str",
+        hash: "bytes",
+    ) -> None:
+        self.url = url
+        self.hash = hash
+
+
+class CardanoPoolParametersType(protobuf.MessageType):
+    MESSAGE_WIRE_TYPE = None
+    FIELDS = {
+        1: protobuf.Field("pool_id", "bytes", repeated=False, required=True),
+        2: protobuf.Field("vrf_key_hash", "bytes", repeated=False, required=True),
+        3: protobuf.Field("pledge", "uint64", repeated=False, required=True),
+        4: protobuf.Field("cost", "uint64", repeated=False, required=True),
+        5: protobuf.Field("margin_numerator", "uint64", repeated=False, required=True),
+        6: protobuf.Field("margin_denominator", "uint64", repeated=False, required=True),
+        7: protobuf.Field("reward_account", "string", repeated=False, required=True),
+        8: protobuf.Field("owners", "CardanoPoolOwnerType", repeated=True, required=False),
+        9: protobuf.Field("relays", "CardanoPoolRelayParametersType", repeated=True, required=False),
+        10: protobuf.Field("metadata", "CardanoPoolMetadataType", repeated=False, required=False),
+    }
+
+    def __init__(
+        self,
+        *,
+        pool_id: "bytes",
+        vrf_key_hash: "bytes",
+        pledge: "int",
+        cost: "int",
+        margin_numerator: "int",
+        margin_denominator: "int",
+        reward_account: "str",
+        owners: Optional[List["CardanoPoolOwnerType"]] = None,
+        relays: Optional[List["CardanoPoolRelayParametersType"]] = None,
+        metadata: Optional["CardanoPoolMetadataType"] = None,
+    ) -> None:
+        self.owners = owners if owners is not None else []
+        self.relays = relays if relays is not None else []
+        self.pool_id = pool_id
+        self.vrf_key_hash = vrf_key_hash
+        self.pledge = pledge
+        self.cost = cost
+        self.margin_numerator = margin_numerator
+        self.margin_denominator = margin_denominator
+        self.reward_account = reward_account
+        self.metadata = metadata
+
+
+class CardanoTxCertificateType(protobuf.MessageType):
+    MESSAGE_WIRE_TYPE = None
+    FIELDS = {
+        1: protobuf.Field("type", "CardanoCertificateType", repeated=False, required=True),
+        2: protobuf.Field("path", "uint32", repeated=True, required=False),
+        3: protobuf.Field("pool", "bytes", repeated=False, required=False),
+        4: protobuf.Field("pool_parameters", "CardanoPoolParametersType", repeated=False, required=False),
+    }
+
+    def __init__(
+        self,
+        *,
+        type: "CardanoCertificateType",
+        path: Optional[List["int"]] = None,
+        pool: Optional["bytes"] = None,
+        pool_parameters: Optional["CardanoPoolParametersType"] = None,
+    ) -> None:
+        self.path = path if path is not None else []
+        self.type = type
+        self.pool = pool
+        self.pool_parameters = pool_parameters
+
+
+class CardanoTxWithdrawalType(protobuf.MessageType):
+    MESSAGE_WIRE_TYPE = None
+    FIELDS = {
+        1: protobuf.Field("path", "uint32", repeated=True, required=False),
+        2: protobuf.Field("amount", "uint64", repeated=False, required=True),
+    }
+
+    def __init__(
+        self,
+        *,
+        amount: "int",
+        path: Optional[List["int"]] = None,
+    ) -> None:
+        self.path = path if path is not None else []
+        self.amount = amount
+
+
+class CardanoCatalystRegistrationParametersType(protobuf.MessageType):
+    MESSAGE_WIRE_TYPE = None
+    FIELDS = {
+        1: protobuf.Field("voting_public_key", "bytes", repeated=False, required=True),
+        2: protobuf.Field("staking_path", "uint32", repeated=True, required=False),
+        3: protobuf.Field("reward_address_parameters", "CardanoAddressParametersType", repeated=False, required=True),
+        4: protobuf.Field("nonce", "uint64", repeated=False, required=True),
+    }
+
+    def __init__(
+        self,
+        *,
+        voting_public_key: "bytes",
+        reward_address_parameters: "CardanoAddressParametersType",
+        nonce: "int",
+        staking_path: Optional[List["int"]] = None,
+    ) -> None:
+        self.staking_path = staking_path if staking_path is not None else []
+        self.voting_public_key = voting_public_key
+        self.reward_address_parameters = reward_address_parameters
+        self.nonce = nonce
+
+
+class CardanoTxAuxiliaryDataType(protobuf.MessageType):
+    MESSAGE_WIRE_TYPE = None
+    FIELDS = {
+        1: protobuf.Field("blob", "bytes", repeated=False, required=False),
+        2: protobuf.Field("catalyst_registration_parameters", "CardanoCatalystRegistrationParametersType", repeated=False, required=False),
+    }
+
+    def __init__(
+        self,
+        *,
+        blob: Optional["bytes"] = None,
+        catalyst_registration_parameters: Optional["CardanoCatalystRegistrationParametersType"] = None,
+    ) -> None:
+        self.blob = blob
+        self.catalyst_registration_parameters = catalyst_registration_parameters
 
 
 class CipherKeyValue(protobuf.MessageType):
@@ -2287,13 +2287,13 @@ class CipherKeyValue(protobuf.MessageType):
     def __init__(
         self,
         *,
-        key: str,
-        value: bytes,
-        address_n: Optional[List[int]] = None,
-        encrypt: Optional[bool] = None,
-        ask_on_encrypt: Optional[bool] = None,
-        ask_on_decrypt: Optional[bool] = None,
-        iv: Optional[bytes] = None,
+        key: "str",
+        value: "bytes",
+        address_n: Optional[List["int"]] = None,
+        encrypt: Optional["bool"] = None,
+        ask_on_encrypt: Optional["bool"] = None,
+        ask_on_decrypt: Optional["bool"] = None,
+        iv: Optional["bytes"] = None,
     ) -> None:
         self.address_n = address_n if address_n is not None else []
         self.key = key
@@ -2313,7 +2313,7 @@ class CipheredKeyValue(protobuf.MessageType):
     def __init__(
         self,
         *,
-        value: bytes,
+        value: "bytes",
     ) -> None:
         self.value = value
 
@@ -2332,12 +2332,12 @@ class IdentityType(protobuf.MessageType):
     def __init__(
         self,
         *,
-        proto: Optional[str] = None,
-        user: Optional[str] = None,
-        host: Optional[str] = None,
-        port: Optional[str] = None,
-        path: Optional[str] = None,
-        index: Optional[int] = 0,
+        proto: Optional["str"] = None,
+        user: Optional["str"] = None,
+        host: Optional["str"] = None,
+        port: Optional["str"] = None,
+        path: Optional["str"] = None,
+        index: Optional["int"] = 0,
     ) -> None:
         self.proto = proto
         self.user = user
@@ -2350,7 +2350,7 @@ class IdentityType(protobuf.MessageType):
 class SignIdentity(protobuf.MessageType):
     MESSAGE_WIRE_TYPE = 53
     FIELDS = {
-        1: protobuf.Field("identity", IdentityType, repeated=False, required=True),
+        1: protobuf.Field("identity", "IdentityType", repeated=False, required=True),
         2: protobuf.Field("challenge_hidden", "bytes", repeated=False, required=False),
         3: protobuf.Field("challenge_visual", "string", repeated=False, required=False),
         4: protobuf.Field("ecdsa_curve_name", "string", repeated=False, required=False),
@@ -2359,10 +2359,10 @@ class SignIdentity(protobuf.MessageType):
     def __init__(
         self,
         *,
-        identity: IdentityType,
-        challenge_hidden: Optional[bytes] = b'',
-        challenge_visual: Optional[str] = '',
-        ecdsa_curve_name: Optional[str] = None,
+        identity: "IdentityType",
+        challenge_hidden: Optional["bytes"] = b'',
+        challenge_visual: Optional["str"] = '',
+        ecdsa_curve_name: Optional["str"] = None,
     ) -> None:
         self.identity = identity
         self.challenge_hidden = challenge_hidden
@@ -2381,9 +2381,9 @@ class SignedIdentity(protobuf.MessageType):
     def __init__(
         self,
         *,
-        public_key: bytes,
-        signature: bytes,
-        address: Optional[str] = None,
+        public_key: "bytes",
+        signature: "bytes",
+        address: Optional["str"] = None,
     ) -> None:
         self.public_key = public_key
         self.signature = signature
@@ -2393,7 +2393,7 @@ class SignedIdentity(protobuf.MessageType):
 class GetECDHSessionKey(protobuf.MessageType):
     MESSAGE_WIRE_TYPE = 61
     FIELDS = {
-        1: protobuf.Field("identity", IdentityType, repeated=False, required=True),
+        1: protobuf.Field("identity", "IdentityType", repeated=False, required=True),
         2: protobuf.Field("peer_public_key", "bytes", repeated=False, required=True),
         3: protobuf.Field("ecdsa_curve_name", "string", repeated=False, required=False),
     }
@@ -2401,9 +2401,9 @@ class GetECDHSessionKey(protobuf.MessageType):
     def __init__(
         self,
         *,
-        identity: IdentityType,
-        peer_public_key: bytes,
-        ecdsa_curve_name: Optional[str] = None,
+        identity: "IdentityType",
+        peer_public_key: "bytes",
+        ecdsa_curve_name: Optional["str"] = None,
     ) -> None:
         self.identity = identity
         self.peer_public_key = peer_public_key
@@ -2420,8 +2420,8 @@ class ECDHSessionKey(protobuf.MessageType):
     def __init__(
         self,
         *,
-        session_key: bytes,
-        public_key: Optional[bytes] = None,
+        session_key: "bytes",
+        public_key: Optional["bytes"] = None,
     ) -> None:
         self.session_key = session_key
         self.public_key = public_key
@@ -2437,8 +2437,8 @@ class CosiCommit(protobuf.MessageType):
     def __init__(
         self,
         *,
-        address_n: Optional[List[int]] = None,
-        data: Optional[bytes] = None,
+        address_n: Optional[List["int"]] = None,
+        data: Optional["bytes"] = None,
     ) -> None:
         self.address_n = address_n if address_n is not None else []
         self.data = data
@@ -2454,8 +2454,8 @@ class CosiCommitment(protobuf.MessageType):
     def __init__(
         self,
         *,
-        commitment: Optional[bytes] = None,
-        pubkey: Optional[bytes] = None,
+        commitment: Optional["bytes"] = None,
+        pubkey: Optional["bytes"] = None,
     ) -> None:
         self.commitment = commitment
         self.pubkey = pubkey
@@ -2473,10 +2473,10 @@ class CosiSign(protobuf.MessageType):
     def __init__(
         self,
         *,
-        address_n: Optional[List[int]] = None,
-        data: Optional[bytes] = None,
-        global_commitment: Optional[bytes] = None,
-        global_pubkey: Optional[bytes] = None,
+        address_n: Optional[List["int"]] = None,
+        data: Optional["bytes"] = None,
+        global_commitment: Optional["bytes"] = None,
+        global_pubkey: Optional["bytes"] = None,
     ) -> None:
         self.address_n = address_n if address_n is not None else []
         self.data = data
@@ -2493,7 +2493,7 @@ class CosiSignature(protobuf.MessageType):
     def __init__(
         self,
         *,
-        signature: bytes,
+        signature: "bytes",
     ) -> None:
         self.signature = signature
 
@@ -2507,7 +2507,7 @@ class Initialize(protobuf.MessageType):
     def __init__(
         self,
         *,
-        session_id: Optional[bytes] = None,
+        session_id: Optional["bytes"] = None,
     ) -> None:
         self.session_id = session_id
 
@@ -2546,14 +2546,14 @@ class Features(protobuf.MessageType):
         27: protobuf.Field("unfinished_backup", "bool", repeated=False, required=False),
         28: protobuf.Field("no_backup", "bool", repeated=False, required=False),
         29: protobuf.Field("recovery_mode", "bool", repeated=False, required=False),
-        30: protobuf.Field("capabilities", Capability, repeated=True, required=False),
-        31: protobuf.Field("backup_type", BackupType, repeated=False, required=False),
+        30: protobuf.Field("capabilities", "Capability", repeated=True, required=False),
+        31: protobuf.Field("backup_type", "BackupType", repeated=False, required=False),
         32: protobuf.Field("sd_card_present", "bool", repeated=False, required=False),
         33: protobuf.Field("sd_protection", "bool", repeated=False, required=False),
         34: protobuf.Field("wipe_code_protection", "bool", repeated=False, required=False),
         35: protobuf.Field("session_id", "bytes", repeated=False, required=False),
         36: protobuf.Field("passphrase_always_on_device", "bool", repeated=False, required=False),
-        37: protobuf.Field("safety_checks", SafetyCheckLevel, repeated=False, required=False),
+        37: protobuf.Field("safety_checks", "SafetyCheckLevel", repeated=False, required=False),
         38: protobuf.Field("auto_lock_delay_ms", "uint32", repeated=False, required=False),
         39: protobuf.Field("display_rotation", "uint32", repeated=False, required=False),
         40: protobuf.Field("experimental_features", "bool", repeated=False, required=False),
@@ -2562,44 +2562,44 @@ class Features(protobuf.MessageType):
     def __init__(
         self,
         *,
-        major_version: int,
-        minor_version: int,
-        patch_version: int,
-        capabilities: Optional[List[Capability]] = None,
-        vendor: Optional[str] = None,
-        bootloader_mode: Optional[bool] = None,
-        device_id: Optional[str] = None,
-        pin_protection: Optional[bool] = None,
-        passphrase_protection: Optional[bool] = None,
-        language: Optional[str] = None,
-        label: Optional[str] = None,
-        initialized: Optional[bool] = None,
-        revision: Optional[bytes] = None,
-        bootloader_hash: Optional[bytes] = None,
-        imported: Optional[bool] = None,
-        unlocked: Optional[bool] = None,
-        firmware_present: Optional[bool] = None,
-        needs_backup: Optional[bool] = None,
-        flags: Optional[int] = None,
-        model: Optional[str] = None,
-        fw_major: Optional[int] = None,
-        fw_minor: Optional[int] = None,
-        fw_patch: Optional[int] = None,
-        fw_vendor: Optional[str] = None,
-        fw_vendor_keys: Optional[bytes] = None,
-        unfinished_backup: Optional[bool] = None,
-        no_backup: Optional[bool] = None,
-        recovery_mode: Optional[bool] = None,
-        backup_type: Optional[BackupType] = None,
-        sd_card_present: Optional[bool] = None,
-        sd_protection: Optional[bool] = None,
-        wipe_code_protection: Optional[bool] = None,
-        session_id: Optional[bytes] = None,
-        passphrase_always_on_device: Optional[bool] = None,
-        safety_checks: Optional[SafetyCheckLevel] = None,
-        auto_lock_delay_ms: Optional[int] = None,
-        display_rotation: Optional[int] = None,
-        experimental_features: Optional[bool] = None,
+        major_version: "int",
+        minor_version: "int",
+        patch_version: "int",
+        capabilities: Optional[List["Capability"]] = None,
+        vendor: Optional["str"] = None,
+        bootloader_mode: Optional["bool"] = None,
+        device_id: Optional["str"] = None,
+        pin_protection: Optional["bool"] = None,
+        passphrase_protection: Optional["bool"] = None,
+        language: Optional["str"] = None,
+        label: Optional["str"] = None,
+        initialized: Optional["bool"] = None,
+        revision: Optional["bytes"] = None,
+        bootloader_hash: Optional["bytes"] = None,
+        imported: Optional["bool"] = None,
+        unlocked: Optional["bool"] = None,
+        firmware_present: Optional["bool"] = None,
+        needs_backup: Optional["bool"] = None,
+        flags: Optional["int"] = None,
+        model: Optional["str"] = None,
+        fw_major: Optional["int"] = None,
+        fw_minor: Optional["int"] = None,
+        fw_patch: Optional["int"] = None,
+        fw_vendor: Optional["str"] = None,
+        fw_vendor_keys: Optional["bytes"] = None,
+        unfinished_backup: Optional["bool"] = None,
+        no_backup: Optional["bool"] = None,
+        recovery_mode: Optional["bool"] = None,
+        backup_type: Optional["BackupType"] = None,
+        sd_card_present: Optional["bool"] = None,
+        sd_protection: Optional["bool"] = None,
+        wipe_code_protection: Optional["bool"] = None,
+        session_id: Optional["bytes"] = None,
+        passphrase_always_on_device: Optional["bool"] = None,
+        safety_checks: Optional["SafetyCheckLevel"] = None,
+        auto_lock_delay_ms: Optional["int"] = None,
+        display_rotation: Optional["int"] = None,
+        experimental_features: Optional["bool"] = None,
     ) -> None:
         self.capabilities = capabilities if capabilities is not None else []
         self.major_version = major_version
@@ -2659,22 +2659,22 @@ class ApplySettings(protobuf.MessageType):
         6: protobuf.Field("auto_lock_delay_ms", "uint32", repeated=False, required=False),
         7: protobuf.Field("display_rotation", "uint32", repeated=False, required=False),
         8: protobuf.Field("passphrase_always_on_device", "bool", repeated=False, required=False),
-        9: protobuf.Field("safety_checks", SafetyCheckLevel, repeated=False, required=False),
+        9: protobuf.Field("safety_checks", "SafetyCheckLevel", repeated=False, required=False),
         10: protobuf.Field("experimental_features", "bool", repeated=False, required=False),
     }
 
     def __init__(
         self,
         *,
-        language: Optional[str] = None,
-        label: Optional[str] = None,
-        use_passphrase: Optional[bool] = None,
-        homescreen: Optional[bytes] = None,
-        auto_lock_delay_ms: Optional[int] = None,
-        display_rotation: Optional[int] = None,
-        passphrase_always_on_device: Optional[bool] = None,
-        safety_checks: Optional[SafetyCheckLevel] = None,
-        experimental_features: Optional[bool] = None,
+        language: Optional["str"] = None,
+        label: Optional["str"] = None,
+        use_passphrase: Optional["bool"] = None,
+        homescreen: Optional["bytes"] = None,
+        auto_lock_delay_ms: Optional["int"] = None,
+        display_rotation: Optional["int"] = None,
+        passphrase_always_on_device: Optional["bool"] = None,
+        safety_checks: Optional["SafetyCheckLevel"] = None,
+        experimental_features: Optional["bool"] = None,
     ) -> None:
         self.language = language
         self.label = label
@@ -2696,7 +2696,7 @@ class ApplyFlags(protobuf.MessageType):
     def __init__(
         self,
         *,
-        flags: Optional[int] = None,
+        flags: Optional["int"] = None,
     ) -> None:
         self.flags = flags
 
@@ -2710,7 +2710,7 @@ class ChangePin(protobuf.MessageType):
     def __init__(
         self,
         *,
-        remove: Optional[bool] = None,
+        remove: Optional["bool"] = None,
     ) -> None:
         self.remove = remove
 
@@ -2724,7 +2724,7 @@ class ChangeWipeCode(protobuf.MessageType):
     def __init__(
         self,
         *,
-        remove: Optional[bool] = None,
+        remove: Optional["bool"] = None,
     ) -> None:
         self.remove = remove
 
@@ -2732,13 +2732,13 @@ class ChangeWipeCode(protobuf.MessageType):
 class SdProtect(protobuf.MessageType):
     MESSAGE_WIRE_TYPE = 79
     FIELDS = {
-        1: protobuf.Field("operation", SdProtectOperationType, repeated=False, required=False),
+        1: protobuf.Field("operation", "SdProtectOperationType", repeated=False, required=False),
     }
 
     def __init__(
         self,
         *,
-        operation: Optional[SdProtectOperationType] = None,
+        operation: Optional["SdProtectOperationType"] = None,
     ) -> None:
         self.operation = operation
 
@@ -2753,8 +2753,8 @@ class Ping(protobuf.MessageType):
     def __init__(
         self,
         *,
-        message: Optional[str] = '',
-        button_protection: Optional[bool] = None,
+        message: Optional["str"] = '',
+        button_protection: Optional["bool"] = None,
     ) -> None:
         self.message = message
         self.button_protection = button_protection
@@ -2773,7 +2773,7 @@ class GetEntropy(protobuf.MessageType):
     def __init__(
         self,
         *,
-        size: int,
+        size: "int",
     ) -> None:
         self.size = size
 
@@ -2787,7 +2787,7 @@ class Entropy(protobuf.MessageType):
     def __init__(
         self,
         *,
-        entropy: bytes,
+        entropy: "bytes",
     ) -> None:
         self.entropy = entropy
 
@@ -2813,15 +2813,15 @@ class LoadDevice(protobuf.MessageType):
     def __init__(
         self,
         *,
-        mnemonics: Optional[List[str]] = None,
-        pin: Optional[str] = None,
-        passphrase_protection: Optional[bool] = None,
-        language: Optional[str] = 'en-US',
-        label: Optional[str] = None,
-        skip_checksum: Optional[bool] = None,
-        u2f_counter: Optional[int] = None,
-        needs_backup: Optional[bool] = None,
-        no_backup: Optional[bool] = None,
+        mnemonics: Optional[List["str"]] = None,
+        pin: Optional["str"] = None,
+        passphrase_protection: Optional["bool"] = None,
+        language: Optional["str"] = 'en-US',
+        label: Optional["str"] = None,
+        skip_checksum: Optional["bool"] = None,
+        u2f_counter: Optional["int"] = None,
+        needs_backup: Optional["bool"] = None,
+        no_backup: Optional["bool"] = None,
     ) -> None:
         self.mnemonics = mnemonics if mnemonics is not None else []
         self.pin = pin
@@ -2846,22 +2846,22 @@ class ResetDevice(protobuf.MessageType):
         7: protobuf.Field("u2f_counter", "uint32", repeated=False, required=False),
         8: protobuf.Field("skip_backup", "bool", repeated=False, required=False),
         9: protobuf.Field("no_backup", "bool", repeated=False, required=False),
-        10: protobuf.Field("backup_type", BackupType, repeated=False, required=False),
+        10: protobuf.Field("backup_type", "BackupType", repeated=False, required=False),
     }
 
     def __init__(
         self,
         *,
-        display_random: Optional[bool] = None,
-        strength: Optional[int] = 256,
-        passphrase_protection: Optional[bool] = None,
-        pin_protection: Optional[bool] = None,
-        language: Optional[str] = 'en-US',
-        label: Optional[str] = None,
-        u2f_counter: Optional[int] = None,
-        skip_backup: Optional[bool] = None,
-        no_backup: Optional[bool] = None,
-        backup_type: Optional[BackupType] = BackupType.Bip39,
+        display_random: Optional["bool"] = None,
+        strength: Optional["int"] = 256,
+        passphrase_protection: Optional["bool"] = None,
+        pin_protection: Optional["bool"] = None,
+        language: Optional["str"] = 'en-US',
+        label: Optional["str"] = None,
+        u2f_counter: Optional["int"] = None,
+        skip_backup: Optional["bool"] = None,
+        no_backup: Optional["bool"] = None,
+        backup_type: Optional["BackupType"] = BackupType.Bip39,
     ) -> None:
         self.display_random = display_random
         self.strength = strength
@@ -2892,7 +2892,7 @@ class EntropyAck(protobuf.MessageType):
     def __init__(
         self,
         *,
-        entropy: Optional[bytes] = None,
+        entropy: Optional["bytes"] = None,
     ) -> None:
         self.entropy = entropy
 
@@ -2906,7 +2906,7 @@ class RecoveryDevice(protobuf.MessageType):
         4: protobuf.Field("language", "string", repeated=False, required=False),
         5: protobuf.Field("label", "string", repeated=False, required=False),
         6: protobuf.Field("enforce_wordlist", "bool", repeated=False, required=False),
-        8: protobuf.Field("type", RecoveryDeviceType, repeated=False, required=False),
+        8: protobuf.Field("type", "RecoveryDeviceType", repeated=False, required=False),
         9: protobuf.Field("u2f_counter", "uint32", repeated=False, required=False),
         10: protobuf.Field("dry_run", "bool", repeated=False, required=False),
     }
@@ -2914,15 +2914,15 @@ class RecoveryDevice(protobuf.MessageType):
     def __init__(
         self,
         *,
-        word_count: Optional[int] = None,
-        passphrase_protection: Optional[bool] = None,
-        pin_protection: Optional[bool] = None,
-        language: Optional[str] = None,
-        label: Optional[str] = None,
-        enforce_wordlist: Optional[bool] = None,
-        type: Optional[RecoveryDeviceType] = None,
-        u2f_counter: Optional[int] = None,
-        dry_run: Optional[bool] = None,
+        word_count: Optional["int"] = None,
+        passphrase_protection: Optional["bool"] = None,
+        pin_protection: Optional["bool"] = None,
+        language: Optional["str"] = None,
+        label: Optional["str"] = None,
+        enforce_wordlist: Optional["bool"] = None,
+        type: Optional["RecoveryDeviceType"] = None,
+        u2f_counter: Optional["int"] = None,
+        dry_run: Optional["bool"] = None,
     ) -> None:
         self.word_count = word_count
         self.passphrase_protection = passphrase_protection
@@ -2938,13 +2938,13 @@ class RecoveryDevice(protobuf.MessageType):
 class WordRequest(protobuf.MessageType):
     MESSAGE_WIRE_TYPE = 46
     FIELDS = {
-        1: protobuf.Field("type", WordRequestType, repeated=False, required=False),
+        1: protobuf.Field("type", "WordRequestType", repeated=False, required=False),
     }
 
     def __init__(
         self,
         *,
-        type: Optional[WordRequestType] = None,
+        type: Optional["WordRequestType"] = None,
     ) -> None:
         self.type = type
 
@@ -2958,7 +2958,7 @@ class WordAck(protobuf.MessageType):
     def __init__(
         self,
         *,
-        word: str,
+        word: "str",
     ) -> None:
         self.word = word
 
@@ -2972,7 +2972,7 @@ class SetU2FCounter(protobuf.MessageType):
     def __init__(
         self,
         *,
-        u2f_counter: Optional[int] = None,
+        u2f_counter: Optional["int"] = None,
     ) -> None:
         self.u2f_counter = u2f_counter
 
@@ -2990,7 +2990,7 @@ class NextU2FCounter(protobuf.MessageType):
     def __init__(
         self,
         *,
-        u2f_counter: Optional[int] = None,
+        u2f_counter: Optional["int"] = None,
     ) -> None:
         self.u2f_counter = u2f_counter
 
@@ -3015,7 +3015,7 @@ class DebugLinkDecision(protobuf.MessageType):
     MESSAGE_WIRE_TYPE = 100
     FIELDS = {
         1: protobuf.Field("yes_no", "bool", repeated=False, required=False),
-        2: protobuf.Field("swipe", DebugSwipeDirection, repeated=False, required=False),
+        2: protobuf.Field("swipe", "DebugSwipeDirection", repeated=False, required=False),
         3: protobuf.Field("input", "string", repeated=False, required=False),
         4: protobuf.Field("x", "uint32", repeated=False, required=False),
         5: protobuf.Field("y", "uint32", repeated=False, required=False),
@@ -3026,13 +3026,13 @@ class DebugLinkDecision(protobuf.MessageType):
     def __init__(
         self,
         *,
-        yes_no: Optional[bool] = None,
-        swipe: Optional[DebugSwipeDirection] = None,
-        input: Optional[str] = None,
-        x: Optional[int] = None,
-        y: Optional[int] = None,
-        wait: Optional[bool] = None,
-        hold_ms: Optional[int] = None,
+        yes_no: Optional["bool"] = None,
+        swipe: Optional["DebugSwipeDirection"] = None,
+        input: Optional["str"] = None,
+        x: Optional["int"] = None,
+        y: Optional["int"] = None,
+        wait: Optional["bool"] = None,
+        hold_ms: Optional["int"] = None,
     ) -> None:
         self.yes_no = yes_no
         self.swipe = swipe
@@ -3052,7 +3052,7 @@ class DebugLinkLayout(protobuf.MessageType):
     def __init__(
         self,
         *,
-        lines: Optional[List[str]] = None,
+        lines: Optional[List["str"]] = None,
     ) -> None:
         self.lines = lines if lines is not None else []
 
@@ -3066,7 +3066,7 @@ class DebugLinkReseedRandom(protobuf.MessageType):
     def __init__(
         self,
         *,
-        value: Optional[int] = None,
+        value: Optional["int"] = None,
     ) -> None:
         self.value = value
 
@@ -3080,7 +3080,7 @@ class DebugLinkRecordScreen(protobuf.MessageType):
     def __init__(
         self,
         *,
-        target_directory: Optional[str] = None,
+        target_directory: Optional["str"] = None,
     ) -> None:
         self.target_directory = target_directory
 
@@ -3096,9 +3096,9 @@ class DebugLinkGetState(protobuf.MessageType):
     def __init__(
         self,
         *,
-        wait_word_list: Optional[bool] = None,
-        wait_word_pos: Optional[bool] = None,
-        wait_layout: Optional[bool] = None,
+        wait_word_list: Optional["bool"] = None,
+        wait_word_pos: Optional["bool"] = None,
+        wait_layout: Optional["bool"] = None,
     ) -> None:
         self.wait_word_list = wait_word_list
         self.wait_word_pos = wait_word_pos
@@ -3112,33 +3112,33 @@ class DebugLinkState(protobuf.MessageType):
         2: protobuf.Field("pin", "string", repeated=False, required=False),
         3: protobuf.Field("matrix", "string", repeated=False, required=False),
         4: protobuf.Field("mnemonic_secret", "bytes", repeated=False, required=False),
-        5: protobuf.Field("node", HDNodeType, repeated=False, required=False),
+        5: protobuf.Field("node", "HDNodeType", repeated=False, required=False),
         6: protobuf.Field("passphrase_protection", "bool", repeated=False, required=False),
         7: protobuf.Field("reset_word", "string", repeated=False, required=False),
         8: protobuf.Field("reset_entropy", "bytes", repeated=False, required=False),
         9: protobuf.Field("recovery_fake_word", "string", repeated=False, required=False),
         10: protobuf.Field("recovery_word_pos", "uint32", repeated=False, required=False),
         11: protobuf.Field("reset_word_pos", "uint32", repeated=False, required=False),
-        12: protobuf.Field("mnemonic_type", BackupType, repeated=False, required=False),
+        12: protobuf.Field("mnemonic_type", "BackupType", repeated=False, required=False),
         13: protobuf.Field("layout_lines", "string", repeated=True, required=False),
     }
 
     def __init__(
         self,
         *,
-        layout_lines: Optional[List[str]] = None,
-        layout: Optional[bytes] = None,
-        pin: Optional[str] = None,
-        matrix: Optional[str] = None,
-        mnemonic_secret: Optional[bytes] = None,
-        node: Optional[HDNodeType] = None,
-        passphrase_protection: Optional[bool] = None,
-        reset_word: Optional[str] = None,
-        reset_entropy: Optional[bytes] = None,
-        recovery_fake_word: Optional[str] = None,
-        recovery_word_pos: Optional[int] = None,
-        reset_word_pos: Optional[int] = None,
-        mnemonic_type: Optional[BackupType] = None,
+        layout_lines: Optional[List["str"]] = None,
+        layout: Optional["bytes"] = None,
+        pin: Optional["str"] = None,
+        matrix: Optional["str"] = None,
+        mnemonic_secret: Optional["bytes"] = None,
+        node: Optional["HDNodeType"] = None,
+        passphrase_protection: Optional["bool"] = None,
+        reset_word: Optional["str"] = None,
+        reset_entropy: Optional["bytes"] = None,
+        recovery_fake_word: Optional["str"] = None,
+        recovery_word_pos: Optional["int"] = None,
+        reset_word_pos: Optional["int"] = None,
+        mnemonic_type: Optional["BackupType"] = None,
     ) -> None:
         self.layout_lines = layout_lines if layout_lines is not None else []
         self.layout = layout
@@ -3170,9 +3170,9 @@ class DebugLinkLog(protobuf.MessageType):
     def __init__(
         self,
         *,
-        level: Optional[int] = None,
-        bucket: Optional[str] = None,
-        text: Optional[str] = None,
+        level: Optional["int"] = None,
+        bucket: Optional["str"] = None,
+        text: Optional["str"] = None,
     ) -> None:
         self.level = level
         self.bucket = bucket
@@ -3189,8 +3189,8 @@ class DebugLinkMemoryRead(protobuf.MessageType):
     def __init__(
         self,
         *,
-        address: Optional[int] = None,
-        length: Optional[int] = None,
+        address: Optional["int"] = None,
+        length: Optional["int"] = None,
     ) -> None:
         self.address = address
         self.length = length
@@ -3205,7 +3205,7 @@ class DebugLinkMemory(protobuf.MessageType):
     def __init__(
         self,
         *,
-        memory: Optional[bytes] = None,
+        memory: Optional["bytes"] = None,
     ) -> None:
         self.memory = memory
 
@@ -3221,9 +3221,9 @@ class DebugLinkMemoryWrite(protobuf.MessageType):
     def __init__(
         self,
         *,
-        address: Optional[int] = None,
-        memory: Optional[bytes] = None,
-        flash: Optional[bool] = None,
+        address: Optional["int"] = None,
+        memory: Optional["bytes"] = None,
+        flash: Optional["bool"] = None,
     ) -> None:
         self.address = address
         self.memory = memory
@@ -3239,7 +3239,7 @@ class DebugLinkFlashErase(protobuf.MessageType):
     def __init__(
         self,
         *,
-        sector: Optional[int] = None,
+        sector: Optional["int"] = None,
     ) -> None:
         self.sector = sector
 
@@ -3253,7 +3253,7 @@ class DebugLinkEraseSdCard(protobuf.MessageType):
     def __init__(
         self,
         *,
-        format: Optional[bool] = None,
+        format: Optional["bool"] = None,
     ) -> None:
         self.format = format
 
@@ -3267,7 +3267,7 @@ class DebugLinkWatchLayout(protobuf.MessageType):
     def __init__(
         self,
         *,
-        watch: Optional[bool] = None,
+        watch: Optional["bool"] = None,
     ) -> None:
         self.watch = watch
 
@@ -3282,8 +3282,8 @@ class EosGetPublicKey(protobuf.MessageType):
     def __init__(
         self,
         *,
-        address_n: Optional[List[int]] = None,
-        show_display: Optional[bool] = None,
+        address_n: Optional[List["int"]] = None,
+        show_display: Optional["bool"] = None,
     ) -> None:
         self.address_n = address_n if address_n is not None else []
         self.show_display = show_display
@@ -3299,40 +3299,11 @@ class EosPublicKey(protobuf.MessageType):
     def __init__(
         self,
         *,
-        wif_public_key: str,
-        raw_public_key: bytes,
+        wif_public_key: "str",
+        raw_public_key: "bytes",
     ) -> None:
         self.wif_public_key = wif_public_key
         self.raw_public_key = raw_public_key
-
-
-class EosTxHeader(protobuf.MessageType):
-    MESSAGE_WIRE_TYPE = None
-    FIELDS = {
-        1: protobuf.Field("expiration", "uint32", repeated=False, required=True),
-        2: protobuf.Field("ref_block_num", "uint32", repeated=False, required=True),
-        3: protobuf.Field("ref_block_prefix", "uint32", repeated=False, required=True),
-        4: protobuf.Field("max_net_usage_words", "uint32", repeated=False, required=True),
-        5: protobuf.Field("max_cpu_usage_ms", "uint32", repeated=False, required=True),
-        6: protobuf.Field("delay_sec", "uint32", repeated=False, required=True),
-    }
-
-    def __init__(
-        self,
-        *,
-        expiration: int,
-        ref_block_num: int,
-        ref_block_prefix: int,
-        max_net_usage_words: int,
-        max_cpu_usage_ms: int,
-        delay_sec: int,
-    ) -> None:
-        self.expiration = expiration
-        self.ref_block_num = ref_block_num
-        self.ref_block_prefix = ref_block_prefix
-        self.max_net_usage_words = max_net_usage_words
-        self.max_cpu_usage_ms = max_cpu_usage_ms
-        self.delay_sec = delay_sec
 
 
 class EosSignTx(protobuf.MessageType):
@@ -3340,17 +3311,17 @@ class EosSignTx(protobuf.MessageType):
     FIELDS = {
         1: protobuf.Field("address_n", "uint32", repeated=True, required=False),
         2: protobuf.Field("chain_id", "bytes", repeated=False, required=False),
-        3: protobuf.Field("header", EosTxHeader, repeated=False, required=False),
+        3: protobuf.Field("header", "EosTxHeader", repeated=False, required=False),
         4: protobuf.Field("num_actions", "uint32", repeated=False, required=False),
     }
 
     def __init__(
         self,
         *,
-        address_n: Optional[List[int]] = None,
-        chain_id: Optional[bytes] = None,
-        header: Optional[EosTxHeader] = None,
-        num_actions: Optional[int] = None,
+        address_n: Optional[List["int"]] = None,
+        chain_id: Optional["bytes"] = None,
+        header: Optional["EosTxHeader"] = None,
+        num_actions: Optional["int"] = None,
     ) -> None:
         self.address_n = address_n if address_n is not None else []
         self.chain_id = chain_id
@@ -3367,469 +3338,49 @@ class EosTxActionRequest(protobuf.MessageType):
     def __init__(
         self,
         *,
-        data_size: Optional[int] = None,
+        data_size: Optional["int"] = None,
     ) -> None:
         self.data_size = data_size
-
-
-class EosPermissionLevel(protobuf.MessageType):
-    MESSAGE_WIRE_TYPE = None
-    FIELDS = {
-        1: protobuf.Field("actor", "uint64", repeated=False, required=False),
-        2: protobuf.Field("permission", "uint64", repeated=False, required=False),
-    }
-
-    def __init__(
-        self,
-        *,
-        actor: Optional[int] = None,
-        permission: Optional[int] = None,
-    ) -> None:
-        self.actor = actor
-        self.permission = permission
-
-
-class EosActionCommon(protobuf.MessageType):
-    MESSAGE_WIRE_TYPE = None
-    FIELDS = {
-        1: protobuf.Field("account", "uint64", repeated=False, required=False),
-        2: protobuf.Field("name", "uint64", repeated=False, required=False),
-        3: protobuf.Field("authorization", EosPermissionLevel, repeated=True, required=False),
-    }
-
-    def __init__(
-        self,
-        *,
-        authorization: Optional[List[EosPermissionLevel]] = None,
-        account: Optional[int] = None,
-        name: Optional[int] = None,
-    ) -> None:
-        self.authorization = authorization if authorization is not None else []
-        self.account = account
-        self.name = name
-
-
-class EosAsset(protobuf.MessageType):
-    MESSAGE_WIRE_TYPE = None
-    FIELDS = {
-        1: protobuf.Field("amount", "sint64", repeated=False, required=False),
-        2: protobuf.Field("symbol", "uint64", repeated=False, required=False),
-    }
-
-    def __init__(
-        self,
-        *,
-        amount: Optional[int] = None,
-        symbol: Optional[int] = None,
-    ) -> None:
-        self.amount = amount
-        self.symbol = symbol
-
-
-class EosActionTransfer(protobuf.MessageType):
-    MESSAGE_WIRE_TYPE = None
-    FIELDS = {
-        1: protobuf.Field("sender", "uint64", repeated=False, required=False),
-        2: protobuf.Field("receiver", "uint64", repeated=False, required=False),
-        3: protobuf.Field("quantity", EosAsset, repeated=False, required=False),
-        4: protobuf.Field("memo", "string", repeated=False, required=False),
-    }
-
-    def __init__(
-        self,
-        *,
-        sender: Optional[int] = None,
-        receiver: Optional[int] = None,
-        quantity: Optional[EosAsset] = None,
-        memo: Optional[str] = None,
-    ) -> None:
-        self.sender = sender
-        self.receiver = receiver
-        self.quantity = quantity
-        self.memo = memo
-
-
-class EosActionDelegate(protobuf.MessageType):
-    MESSAGE_WIRE_TYPE = None
-    FIELDS = {
-        1: protobuf.Field("sender", "uint64", repeated=False, required=False),
-        2: protobuf.Field("receiver", "uint64", repeated=False, required=False),
-        3: protobuf.Field("net_quantity", EosAsset, repeated=False, required=False),
-        4: protobuf.Field("cpu_quantity", EosAsset, repeated=False, required=False),
-        5: protobuf.Field("transfer", "bool", repeated=False, required=False),
-    }
-
-    def __init__(
-        self,
-        *,
-        sender: Optional[int] = None,
-        receiver: Optional[int] = None,
-        net_quantity: Optional[EosAsset] = None,
-        cpu_quantity: Optional[EosAsset] = None,
-        transfer: Optional[bool] = None,
-    ) -> None:
-        self.sender = sender
-        self.receiver = receiver
-        self.net_quantity = net_quantity
-        self.cpu_quantity = cpu_quantity
-        self.transfer = transfer
-
-
-class EosActionUndelegate(protobuf.MessageType):
-    MESSAGE_WIRE_TYPE = None
-    FIELDS = {
-        1: protobuf.Field("sender", "uint64", repeated=False, required=False),
-        2: protobuf.Field("receiver", "uint64", repeated=False, required=False),
-        3: protobuf.Field("net_quantity", EosAsset, repeated=False, required=False),
-        4: protobuf.Field("cpu_quantity", EosAsset, repeated=False, required=False),
-    }
-
-    def __init__(
-        self,
-        *,
-        sender: Optional[int] = None,
-        receiver: Optional[int] = None,
-        net_quantity: Optional[EosAsset] = None,
-        cpu_quantity: Optional[EosAsset] = None,
-    ) -> None:
-        self.sender = sender
-        self.receiver = receiver
-        self.net_quantity = net_quantity
-        self.cpu_quantity = cpu_quantity
-
-
-class EosActionRefund(protobuf.MessageType):
-    MESSAGE_WIRE_TYPE = None
-    FIELDS = {
-        1: protobuf.Field("owner", "uint64", repeated=False, required=False),
-    }
-
-    def __init__(
-        self,
-        *,
-        owner: Optional[int] = None,
-    ) -> None:
-        self.owner = owner
-
-
-class EosActionBuyRam(protobuf.MessageType):
-    MESSAGE_WIRE_TYPE = None
-    FIELDS = {
-        1: protobuf.Field("payer", "uint64", repeated=False, required=False),
-        2: protobuf.Field("receiver", "uint64", repeated=False, required=False),
-        3: protobuf.Field("quantity", EosAsset, repeated=False, required=False),
-    }
-
-    def __init__(
-        self,
-        *,
-        payer: Optional[int] = None,
-        receiver: Optional[int] = None,
-        quantity: Optional[EosAsset] = None,
-    ) -> None:
-        self.payer = payer
-        self.receiver = receiver
-        self.quantity = quantity
-
-
-class EosActionBuyRamBytes(protobuf.MessageType):
-    MESSAGE_WIRE_TYPE = None
-    FIELDS = {
-        1: protobuf.Field("payer", "uint64", repeated=False, required=False),
-        2: protobuf.Field("receiver", "uint64", repeated=False, required=False),
-        3: protobuf.Field("bytes", "uint32", repeated=False, required=False),
-    }
-
-    def __init__(
-        self,
-        *,
-        payer: Optional[int] = None,
-        receiver: Optional[int] = None,
-        bytes: Optional[int] = None,
-    ) -> None:
-        self.payer = payer
-        self.receiver = receiver
-        self.bytes = bytes
-
-
-class EosActionSellRam(protobuf.MessageType):
-    MESSAGE_WIRE_TYPE = None
-    FIELDS = {
-        1: protobuf.Field("account", "uint64", repeated=False, required=False),
-        2: protobuf.Field("bytes", "uint64", repeated=False, required=False),
-    }
-
-    def __init__(
-        self,
-        *,
-        account: Optional[int] = None,
-        bytes: Optional[int] = None,
-    ) -> None:
-        self.account = account
-        self.bytes = bytes
-
-
-class EosActionVoteProducer(protobuf.MessageType):
-    MESSAGE_WIRE_TYPE = None
-    FIELDS = {
-        1: protobuf.Field("voter", "uint64", repeated=False, required=False),
-        2: protobuf.Field("proxy", "uint64", repeated=False, required=False),
-        3: protobuf.Field("producers", "uint64", repeated=True, required=False),
-    }
-
-    def __init__(
-        self,
-        *,
-        producers: Optional[List[int]] = None,
-        voter: Optional[int] = None,
-        proxy: Optional[int] = None,
-    ) -> None:
-        self.producers = producers if producers is not None else []
-        self.voter = voter
-        self.proxy = proxy
-
-
-class EosAuthorizationKey(protobuf.MessageType):
-    MESSAGE_WIRE_TYPE = None
-    FIELDS = {
-        1: protobuf.Field("type", "uint32", repeated=False, required=True),
-        2: protobuf.Field("key", "bytes", repeated=False, required=False),
-        3: protobuf.Field("address_n", "uint32", repeated=True, required=False),
-        4: protobuf.Field("weight", "uint32", repeated=False, required=True),
-    }
-
-    def __init__(
-        self,
-        *,
-        type: int,
-        weight: int,
-        address_n: Optional[List[int]] = None,
-        key: Optional[bytes] = None,
-    ) -> None:
-        self.address_n = address_n if address_n is not None else []
-        self.type = type
-        self.weight = weight
-        self.key = key
-
-
-class EosAuthorizationAccount(protobuf.MessageType):
-    MESSAGE_WIRE_TYPE = None
-    FIELDS = {
-        1: protobuf.Field("account", EosPermissionLevel, repeated=False, required=False),
-        2: protobuf.Field("weight", "uint32", repeated=False, required=False),
-    }
-
-    def __init__(
-        self,
-        *,
-        account: Optional[EosPermissionLevel] = None,
-        weight: Optional[int] = None,
-    ) -> None:
-        self.account = account
-        self.weight = weight
-
-
-class EosAuthorizationWait(protobuf.MessageType):
-    MESSAGE_WIRE_TYPE = None
-    FIELDS = {
-        1: protobuf.Field("wait_sec", "uint32", repeated=False, required=False),
-        2: protobuf.Field("weight", "uint32", repeated=False, required=False),
-    }
-
-    def __init__(
-        self,
-        *,
-        wait_sec: Optional[int] = None,
-        weight: Optional[int] = None,
-    ) -> None:
-        self.wait_sec = wait_sec
-        self.weight = weight
-
-
-class EosAuthorization(protobuf.MessageType):
-    MESSAGE_WIRE_TYPE = None
-    FIELDS = {
-        1: protobuf.Field("threshold", "uint32", repeated=False, required=False),
-        2: protobuf.Field("keys", EosAuthorizationKey, repeated=True, required=False),
-        3: protobuf.Field("accounts", EosAuthorizationAccount, repeated=True, required=False),
-        4: protobuf.Field("waits", EosAuthorizationWait, repeated=True, required=False),
-    }
-
-    def __init__(
-        self,
-        *,
-        keys: Optional[List[EosAuthorizationKey]] = None,
-        accounts: Optional[List[EosAuthorizationAccount]] = None,
-        waits: Optional[List[EosAuthorizationWait]] = None,
-        threshold: Optional[int] = None,
-    ) -> None:
-        self.keys = keys if keys is not None else []
-        self.accounts = accounts if accounts is not None else []
-        self.waits = waits if waits is not None else []
-        self.threshold = threshold
-
-
-class EosActionUpdateAuth(protobuf.MessageType):
-    MESSAGE_WIRE_TYPE = None
-    FIELDS = {
-        1: protobuf.Field("account", "uint64", repeated=False, required=False),
-        2: protobuf.Field("permission", "uint64", repeated=False, required=False),
-        3: protobuf.Field("parent", "uint64", repeated=False, required=False),
-        4: protobuf.Field("auth", EosAuthorization, repeated=False, required=False),
-    }
-
-    def __init__(
-        self,
-        *,
-        account: Optional[int] = None,
-        permission: Optional[int] = None,
-        parent: Optional[int] = None,
-        auth: Optional[EosAuthorization] = None,
-    ) -> None:
-        self.account = account
-        self.permission = permission
-        self.parent = parent
-        self.auth = auth
-
-
-class EosActionDeleteAuth(protobuf.MessageType):
-    MESSAGE_WIRE_TYPE = None
-    FIELDS = {
-        1: protobuf.Field("account", "uint64", repeated=False, required=False),
-        2: protobuf.Field("permission", "uint64", repeated=False, required=False),
-    }
-
-    def __init__(
-        self,
-        *,
-        account: Optional[int] = None,
-        permission: Optional[int] = None,
-    ) -> None:
-        self.account = account
-        self.permission = permission
-
-
-class EosActionLinkAuth(protobuf.MessageType):
-    MESSAGE_WIRE_TYPE = None
-    FIELDS = {
-        1: protobuf.Field("account", "uint64", repeated=False, required=False),
-        2: protobuf.Field("code", "uint64", repeated=False, required=False),
-        3: protobuf.Field("type", "uint64", repeated=False, required=False),
-        4: protobuf.Field("requirement", "uint64", repeated=False, required=False),
-    }
-
-    def __init__(
-        self,
-        *,
-        account: Optional[int] = None,
-        code: Optional[int] = None,
-        type: Optional[int] = None,
-        requirement: Optional[int] = None,
-    ) -> None:
-        self.account = account
-        self.code = code
-        self.type = type
-        self.requirement = requirement
-
-
-class EosActionUnlinkAuth(protobuf.MessageType):
-    MESSAGE_WIRE_TYPE = None
-    FIELDS = {
-        1: protobuf.Field("account", "uint64", repeated=False, required=False),
-        2: protobuf.Field("code", "uint64", repeated=False, required=False),
-        3: protobuf.Field("type", "uint64", repeated=False, required=False),
-    }
-
-    def __init__(
-        self,
-        *,
-        account: Optional[int] = None,
-        code: Optional[int] = None,
-        type: Optional[int] = None,
-    ) -> None:
-        self.account = account
-        self.code = code
-        self.type = type
-
-
-class EosActionNewAccount(protobuf.MessageType):
-    MESSAGE_WIRE_TYPE = None
-    FIELDS = {
-        1: protobuf.Field("creator", "uint64", repeated=False, required=False),
-        2: protobuf.Field("name", "uint64", repeated=False, required=False),
-        3: protobuf.Field("owner", EosAuthorization, repeated=False, required=False),
-        4: protobuf.Field("active", EosAuthorization, repeated=False, required=False),
-    }
-
-    def __init__(
-        self,
-        *,
-        creator: Optional[int] = None,
-        name: Optional[int] = None,
-        owner: Optional[EosAuthorization] = None,
-        active: Optional[EosAuthorization] = None,
-    ) -> None:
-        self.creator = creator
-        self.name = name
-        self.owner = owner
-        self.active = active
-
-
-class EosActionUnknown(protobuf.MessageType):
-    MESSAGE_WIRE_TYPE = None
-    FIELDS = {
-        1: protobuf.Field("data_size", "uint32", repeated=False, required=True),
-        2: protobuf.Field("data_chunk", "bytes", repeated=False, required=False),
-    }
-
-    def __init__(
-        self,
-        *,
-        data_size: int,
-        data_chunk: Optional[bytes] = None,
-    ) -> None:
-        self.data_size = data_size
-        self.data_chunk = data_chunk
 
 
 class EosTxActionAck(protobuf.MessageType):
     MESSAGE_WIRE_TYPE = 604
     FIELDS = {
-        1: protobuf.Field("common", EosActionCommon, repeated=False, required=False),
-        2: protobuf.Field("transfer", EosActionTransfer, repeated=False, required=False),
-        3: protobuf.Field("delegate", EosActionDelegate, repeated=False, required=False),
-        4: protobuf.Field("undelegate", EosActionUndelegate, repeated=False, required=False),
-        5: protobuf.Field("refund", EosActionRefund, repeated=False, required=False),
-        6: protobuf.Field("buy_ram", EosActionBuyRam, repeated=False, required=False),
-        7: protobuf.Field("buy_ram_bytes", EosActionBuyRamBytes, repeated=False, required=False),
-        8: protobuf.Field("sell_ram", EosActionSellRam, repeated=False, required=False),
-        9: protobuf.Field("vote_producer", EosActionVoteProducer, repeated=False, required=False),
-        10: protobuf.Field("update_auth", EosActionUpdateAuth, repeated=False, required=False),
-        11: protobuf.Field("delete_auth", EosActionDeleteAuth, repeated=False, required=False),
-        12: protobuf.Field("link_auth", EosActionLinkAuth, repeated=False, required=False),
-        13: protobuf.Field("unlink_auth", EosActionUnlinkAuth, repeated=False, required=False),
-        14: protobuf.Field("new_account", EosActionNewAccount, repeated=False, required=False),
-        15: protobuf.Field("unknown", EosActionUnknown, repeated=False, required=False),
+        1: protobuf.Field("common", "EosActionCommon", repeated=False, required=False),
+        2: protobuf.Field("transfer", "EosActionTransfer", repeated=False, required=False),
+        3: protobuf.Field("delegate", "EosActionDelegate", repeated=False, required=False),
+        4: protobuf.Field("undelegate", "EosActionUndelegate", repeated=False, required=False),
+        5: protobuf.Field("refund", "EosActionRefund", repeated=False, required=False),
+        6: protobuf.Field("buy_ram", "EosActionBuyRam", repeated=False, required=False),
+        7: protobuf.Field("buy_ram_bytes", "EosActionBuyRamBytes", repeated=False, required=False),
+        8: protobuf.Field("sell_ram", "EosActionSellRam", repeated=False, required=False),
+        9: protobuf.Field("vote_producer", "EosActionVoteProducer", repeated=False, required=False),
+        10: protobuf.Field("update_auth", "EosActionUpdateAuth", repeated=False, required=False),
+        11: protobuf.Field("delete_auth", "EosActionDeleteAuth", repeated=False, required=False),
+        12: protobuf.Field("link_auth", "EosActionLinkAuth", repeated=False, required=False),
+        13: protobuf.Field("unlink_auth", "EosActionUnlinkAuth", repeated=False, required=False),
+        14: protobuf.Field("new_account", "EosActionNewAccount", repeated=False, required=False),
+        15: protobuf.Field("unknown", "EosActionUnknown", repeated=False, required=False),
     }
 
     def __init__(
         self,
         *,
-        common: Optional[EosActionCommon] = None,
-        transfer: Optional[EosActionTransfer] = None,
-        delegate: Optional[EosActionDelegate] = None,
-        undelegate: Optional[EosActionUndelegate] = None,
-        refund: Optional[EosActionRefund] = None,
-        buy_ram: Optional[EosActionBuyRam] = None,
-        buy_ram_bytes: Optional[EosActionBuyRamBytes] = None,
-        sell_ram: Optional[EosActionSellRam] = None,
-        vote_producer: Optional[EosActionVoteProducer] = None,
-        update_auth: Optional[EosActionUpdateAuth] = None,
-        delete_auth: Optional[EosActionDeleteAuth] = None,
-        link_auth: Optional[EosActionLinkAuth] = None,
-        unlink_auth: Optional[EosActionUnlinkAuth] = None,
-        new_account: Optional[EosActionNewAccount] = None,
-        unknown: Optional[EosActionUnknown] = None,
+        common: Optional["EosActionCommon"] = None,
+        transfer: Optional["EosActionTransfer"] = None,
+        delegate: Optional["EosActionDelegate"] = None,
+        undelegate: Optional["EosActionUndelegate"] = None,
+        refund: Optional["EosActionRefund"] = None,
+        buy_ram: Optional["EosActionBuyRam"] = None,
+        buy_ram_bytes: Optional["EosActionBuyRamBytes"] = None,
+        sell_ram: Optional["EosActionSellRam"] = None,
+        vote_producer: Optional["EosActionVoteProducer"] = None,
+        update_auth: Optional["EosActionUpdateAuth"] = None,
+        delete_auth: Optional["EosActionDeleteAuth"] = None,
+        link_auth: Optional["EosActionLinkAuth"] = None,
+        unlink_auth: Optional["EosActionUnlinkAuth"] = None,
+        new_account: Optional["EosActionNewAccount"] = None,
+        unknown: Optional["EosActionUnknown"] = None,
     ) -> None:
         self.common = common
         self.transfer = transfer
@@ -3857,9 +3408,458 @@ class EosSignedTx(protobuf.MessageType):
     def __init__(
         self,
         *,
-        signature: str,
+        signature: "str",
     ) -> None:
         self.signature = signature
+
+
+class EosTxHeader(protobuf.MessageType):
+    MESSAGE_WIRE_TYPE = None
+    FIELDS = {
+        1: protobuf.Field("expiration", "uint32", repeated=False, required=True),
+        2: protobuf.Field("ref_block_num", "uint32", repeated=False, required=True),
+        3: protobuf.Field("ref_block_prefix", "uint32", repeated=False, required=True),
+        4: protobuf.Field("max_net_usage_words", "uint32", repeated=False, required=True),
+        5: protobuf.Field("max_cpu_usage_ms", "uint32", repeated=False, required=True),
+        6: protobuf.Field("delay_sec", "uint32", repeated=False, required=True),
+    }
+
+    def __init__(
+        self,
+        *,
+        expiration: "int",
+        ref_block_num: "int",
+        ref_block_prefix: "int",
+        max_net_usage_words: "int",
+        max_cpu_usage_ms: "int",
+        delay_sec: "int",
+    ) -> None:
+        self.expiration = expiration
+        self.ref_block_num = ref_block_num
+        self.ref_block_prefix = ref_block_prefix
+        self.max_net_usage_words = max_net_usage_words
+        self.max_cpu_usage_ms = max_cpu_usage_ms
+        self.delay_sec = delay_sec
+
+
+class EosAsset(protobuf.MessageType):
+    MESSAGE_WIRE_TYPE = None
+    FIELDS = {
+        1: protobuf.Field("amount", "sint64", repeated=False, required=False),
+        2: protobuf.Field("symbol", "uint64", repeated=False, required=False),
+    }
+
+    def __init__(
+        self,
+        *,
+        amount: Optional["int"] = None,
+        symbol: Optional["int"] = None,
+    ) -> None:
+        self.amount = amount
+        self.symbol = symbol
+
+
+class EosPermissionLevel(protobuf.MessageType):
+    MESSAGE_WIRE_TYPE = None
+    FIELDS = {
+        1: protobuf.Field("actor", "uint64", repeated=False, required=False),
+        2: protobuf.Field("permission", "uint64", repeated=False, required=False),
+    }
+
+    def __init__(
+        self,
+        *,
+        actor: Optional["int"] = None,
+        permission: Optional["int"] = None,
+    ) -> None:
+        self.actor = actor
+        self.permission = permission
+
+
+class EosAuthorizationKey(protobuf.MessageType):
+    MESSAGE_WIRE_TYPE = None
+    FIELDS = {
+        1: protobuf.Field("type", "uint32", repeated=False, required=True),
+        2: protobuf.Field("key", "bytes", repeated=False, required=False),
+        3: protobuf.Field("address_n", "uint32", repeated=True, required=False),
+        4: protobuf.Field("weight", "uint32", repeated=False, required=True),
+    }
+
+    def __init__(
+        self,
+        *,
+        type: "int",
+        weight: "int",
+        address_n: Optional[List["int"]] = None,
+        key: Optional["bytes"] = None,
+    ) -> None:
+        self.address_n = address_n if address_n is not None else []
+        self.type = type
+        self.weight = weight
+        self.key = key
+
+
+class EosAuthorizationAccount(protobuf.MessageType):
+    MESSAGE_WIRE_TYPE = None
+    FIELDS = {
+        1: protobuf.Field("account", "EosPermissionLevel", repeated=False, required=False),
+        2: protobuf.Field("weight", "uint32", repeated=False, required=False),
+    }
+
+    def __init__(
+        self,
+        *,
+        account: Optional["EosPermissionLevel"] = None,
+        weight: Optional["int"] = None,
+    ) -> None:
+        self.account = account
+        self.weight = weight
+
+
+class EosAuthorizationWait(protobuf.MessageType):
+    MESSAGE_WIRE_TYPE = None
+    FIELDS = {
+        1: protobuf.Field("wait_sec", "uint32", repeated=False, required=False),
+        2: protobuf.Field("weight", "uint32", repeated=False, required=False),
+    }
+
+    def __init__(
+        self,
+        *,
+        wait_sec: Optional["int"] = None,
+        weight: Optional["int"] = None,
+    ) -> None:
+        self.wait_sec = wait_sec
+        self.weight = weight
+
+
+class EosAuthorization(protobuf.MessageType):
+    MESSAGE_WIRE_TYPE = None
+    FIELDS = {
+        1: protobuf.Field("threshold", "uint32", repeated=False, required=False),
+        2: protobuf.Field("keys", "EosAuthorizationKey", repeated=True, required=False),
+        3: protobuf.Field("accounts", "EosAuthorizationAccount", repeated=True, required=False),
+        4: protobuf.Field("waits", "EosAuthorizationWait", repeated=True, required=False),
+    }
+
+    def __init__(
+        self,
+        *,
+        keys: Optional[List["EosAuthorizationKey"]] = None,
+        accounts: Optional[List["EosAuthorizationAccount"]] = None,
+        waits: Optional[List["EosAuthorizationWait"]] = None,
+        threshold: Optional["int"] = None,
+    ) -> None:
+        self.keys = keys if keys is not None else []
+        self.accounts = accounts if accounts is not None else []
+        self.waits = waits if waits is not None else []
+        self.threshold = threshold
+
+
+class EosActionCommon(protobuf.MessageType):
+    MESSAGE_WIRE_TYPE = None
+    FIELDS = {
+        1: protobuf.Field("account", "uint64", repeated=False, required=False),
+        2: protobuf.Field("name", "uint64", repeated=False, required=False),
+        3: protobuf.Field("authorization", "EosPermissionLevel", repeated=True, required=False),
+    }
+
+    def __init__(
+        self,
+        *,
+        authorization: Optional[List["EosPermissionLevel"]] = None,
+        account: Optional["int"] = None,
+        name: Optional["int"] = None,
+    ) -> None:
+        self.authorization = authorization if authorization is not None else []
+        self.account = account
+        self.name = name
+
+
+class EosActionTransfer(protobuf.MessageType):
+    MESSAGE_WIRE_TYPE = None
+    FIELDS = {
+        1: protobuf.Field("sender", "uint64", repeated=False, required=False),
+        2: protobuf.Field("receiver", "uint64", repeated=False, required=False),
+        3: protobuf.Field("quantity", "EosAsset", repeated=False, required=False),
+        4: protobuf.Field("memo", "string", repeated=False, required=False),
+    }
+
+    def __init__(
+        self,
+        *,
+        sender: Optional["int"] = None,
+        receiver: Optional["int"] = None,
+        quantity: Optional["EosAsset"] = None,
+        memo: Optional["str"] = None,
+    ) -> None:
+        self.sender = sender
+        self.receiver = receiver
+        self.quantity = quantity
+        self.memo = memo
+
+
+class EosActionDelegate(protobuf.MessageType):
+    MESSAGE_WIRE_TYPE = None
+    FIELDS = {
+        1: protobuf.Field("sender", "uint64", repeated=False, required=False),
+        2: protobuf.Field("receiver", "uint64", repeated=False, required=False),
+        3: protobuf.Field("net_quantity", "EosAsset", repeated=False, required=False),
+        4: protobuf.Field("cpu_quantity", "EosAsset", repeated=False, required=False),
+        5: protobuf.Field("transfer", "bool", repeated=False, required=False),
+    }
+
+    def __init__(
+        self,
+        *,
+        sender: Optional["int"] = None,
+        receiver: Optional["int"] = None,
+        net_quantity: Optional["EosAsset"] = None,
+        cpu_quantity: Optional["EosAsset"] = None,
+        transfer: Optional["bool"] = None,
+    ) -> None:
+        self.sender = sender
+        self.receiver = receiver
+        self.net_quantity = net_quantity
+        self.cpu_quantity = cpu_quantity
+        self.transfer = transfer
+
+
+class EosActionUndelegate(protobuf.MessageType):
+    MESSAGE_WIRE_TYPE = None
+    FIELDS = {
+        1: protobuf.Field("sender", "uint64", repeated=False, required=False),
+        2: protobuf.Field("receiver", "uint64", repeated=False, required=False),
+        3: protobuf.Field("net_quantity", "EosAsset", repeated=False, required=False),
+        4: protobuf.Field("cpu_quantity", "EosAsset", repeated=False, required=False),
+    }
+
+    def __init__(
+        self,
+        *,
+        sender: Optional["int"] = None,
+        receiver: Optional["int"] = None,
+        net_quantity: Optional["EosAsset"] = None,
+        cpu_quantity: Optional["EosAsset"] = None,
+    ) -> None:
+        self.sender = sender
+        self.receiver = receiver
+        self.net_quantity = net_quantity
+        self.cpu_quantity = cpu_quantity
+
+
+class EosActionRefund(protobuf.MessageType):
+    MESSAGE_WIRE_TYPE = None
+    FIELDS = {
+        1: protobuf.Field("owner", "uint64", repeated=False, required=False),
+    }
+
+    def __init__(
+        self,
+        *,
+        owner: Optional["int"] = None,
+    ) -> None:
+        self.owner = owner
+
+
+class EosActionBuyRam(protobuf.MessageType):
+    MESSAGE_WIRE_TYPE = None
+    FIELDS = {
+        1: protobuf.Field("payer", "uint64", repeated=False, required=False),
+        2: protobuf.Field("receiver", "uint64", repeated=False, required=False),
+        3: protobuf.Field("quantity", "EosAsset", repeated=False, required=False),
+    }
+
+    def __init__(
+        self,
+        *,
+        payer: Optional["int"] = None,
+        receiver: Optional["int"] = None,
+        quantity: Optional["EosAsset"] = None,
+    ) -> None:
+        self.payer = payer
+        self.receiver = receiver
+        self.quantity = quantity
+
+
+class EosActionBuyRamBytes(protobuf.MessageType):
+    MESSAGE_WIRE_TYPE = None
+    FIELDS = {
+        1: protobuf.Field("payer", "uint64", repeated=False, required=False),
+        2: protobuf.Field("receiver", "uint64", repeated=False, required=False),
+        3: protobuf.Field("bytes", "uint32", repeated=False, required=False),
+    }
+
+    def __init__(
+        self,
+        *,
+        payer: Optional["int"] = None,
+        receiver: Optional["int"] = None,
+        bytes: Optional["int"] = None,
+    ) -> None:
+        self.payer = payer
+        self.receiver = receiver
+        self.bytes = bytes
+
+
+class EosActionSellRam(protobuf.MessageType):
+    MESSAGE_WIRE_TYPE = None
+    FIELDS = {
+        1: protobuf.Field("account", "uint64", repeated=False, required=False),
+        2: protobuf.Field("bytes", "uint64", repeated=False, required=False),
+    }
+
+    def __init__(
+        self,
+        *,
+        account: Optional["int"] = None,
+        bytes: Optional["int"] = None,
+    ) -> None:
+        self.account = account
+        self.bytes = bytes
+
+
+class EosActionVoteProducer(protobuf.MessageType):
+    MESSAGE_WIRE_TYPE = None
+    FIELDS = {
+        1: protobuf.Field("voter", "uint64", repeated=False, required=False),
+        2: protobuf.Field("proxy", "uint64", repeated=False, required=False),
+        3: protobuf.Field("producers", "uint64", repeated=True, required=False),
+    }
+
+    def __init__(
+        self,
+        *,
+        producers: Optional[List["int"]] = None,
+        voter: Optional["int"] = None,
+        proxy: Optional["int"] = None,
+    ) -> None:
+        self.producers = producers if producers is not None else []
+        self.voter = voter
+        self.proxy = proxy
+
+
+class EosActionUpdateAuth(protobuf.MessageType):
+    MESSAGE_WIRE_TYPE = None
+    FIELDS = {
+        1: protobuf.Field("account", "uint64", repeated=False, required=False),
+        2: protobuf.Field("permission", "uint64", repeated=False, required=False),
+        3: protobuf.Field("parent", "uint64", repeated=False, required=False),
+        4: protobuf.Field("auth", "EosAuthorization", repeated=False, required=False),
+    }
+
+    def __init__(
+        self,
+        *,
+        account: Optional["int"] = None,
+        permission: Optional["int"] = None,
+        parent: Optional["int"] = None,
+        auth: Optional["EosAuthorization"] = None,
+    ) -> None:
+        self.account = account
+        self.permission = permission
+        self.parent = parent
+        self.auth = auth
+
+
+class EosActionDeleteAuth(protobuf.MessageType):
+    MESSAGE_WIRE_TYPE = None
+    FIELDS = {
+        1: protobuf.Field("account", "uint64", repeated=False, required=False),
+        2: protobuf.Field("permission", "uint64", repeated=False, required=False),
+    }
+
+    def __init__(
+        self,
+        *,
+        account: Optional["int"] = None,
+        permission: Optional["int"] = None,
+    ) -> None:
+        self.account = account
+        self.permission = permission
+
+
+class EosActionLinkAuth(protobuf.MessageType):
+    MESSAGE_WIRE_TYPE = None
+    FIELDS = {
+        1: protobuf.Field("account", "uint64", repeated=False, required=False),
+        2: protobuf.Field("code", "uint64", repeated=False, required=False),
+        3: protobuf.Field("type", "uint64", repeated=False, required=False),
+        4: protobuf.Field("requirement", "uint64", repeated=False, required=False),
+    }
+
+    def __init__(
+        self,
+        *,
+        account: Optional["int"] = None,
+        code: Optional["int"] = None,
+        type: Optional["int"] = None,
+        requirement: Optional["int"] = None,
+    ) -> None:
+        self.account = account
+        self.code = code
+        self.type = type
+        self.requirement = requirement
+
+
+class EosActionUnlinkAuth(protobuf.MessageType):
+    MESSAGE_WIRE_TYPE = None
+    FIELDS = {
+        1: protobuf.Field("account", "uint64", repeated=False, required=False),
+        2: protobuf.Field("code", "uint64", repeated=False, required=False),
+        3: protobuf.Field("type", "uint64", repeated=False, required=False),
+    }
+
+    def __init__(
+        self,
+        *,
+        account: Optional["int"] = None,
+        code: Optional["int"] = None,
+        type: Optional["int"] = None,
+    ) -> None:
+        self.account = account
+        self.code = code
+        self.type = type
+
+
+class EosActionNewAccount(protobuf.MessageType):
+    MESSAGE_WIRE_TYPE = None
+    FIELDS = {
+        1: protobuf.Field("creator", "uint64", repeated=False, required=False),
+        2: protobuf.Field("name", "uint64", repeated=False, required=False),
+        3: protobuf.Field("owner", "EosAuthorization", repeated=False, required=False),
+        4: protobuf.Field("active", "EosAuthorization", repeated=False, required=False),
+    }
+
+    def __init__(
+        self,
+        *,
+        creator: Optional["int"] = None,
+        name: Optional["int"] = None,
+        owner: Optional["EosAuthorization"] = None,
+        active: Optional["EosAuthorization"] = None,
+    ) -> None:
+        self.creator = creator
+        self.name = name
+        self.owner = owner
+        self.active = active
+
+
+class EosActionUnknown(protobuf.MessageType):
+    MESSAGE_WIRE_TYPE = None
+    FIELDS = {
+        1: protobuf.Field("data_size", "uint32", repeated=False, required=True),
+        2: protobuf.Field("data_chunk", "bytes", repeated=False, required=False),
+    }
+
+    def __init__(
+        self,
+        *,
+        data_size: "int",
+        data_chunk: Optional["bytes"] = None,
+    ) -> None:
+        self.data_size = data_size
+        self.data_chunk = data_chunk
 
 
 class EthereumGetPublicKey(protobuf.MessageType):
@@ -3872,8 +3872,8 @@ class EthereumGetPublicKey(protobuf.MessageType):
     def __init__(
         self,
         *,
-        address_n: Optional[List[int]] = None,
-        show_display: Optional[bool] = None,
+        address_n: Optional[List["int"]] = None,
+        show_display: Optional["bool"] = None,
     ) -> None:
         self.address_n = address_n if address_n is not None else []
         self.show_display = show_display
@@ -3882,15 +3882,15 @@ class EthereumGetPublicKey(protobuf.MessageType):
 class EthereumPublicKey(protobuf.MessageType):
     MESSAGE_WIRE_TYPE = 451
     FIELDS = {
-        1: protobuf.Field("node", HDNodeType, repeated=False, required=True),
+        1: protobuf.Field("node", "HDNodeType", repeated=False, required=True),
         2: protobuf.Field("xpub", "string", repeated=False, required=True),
     }
 
     def __init__(
         self,
         *,
-        node: HDNodeType,
-        xpub: str,
+        node: "HDNodeType",
+        xpub: "str",
     ) -> None:
         self.node = node
         self.xpub = xpub
@@ -3906,8 +3906,8 @@ class EthereumGetAddress(protobuf.MessageType):
     def __init__(
         self,
         *,
-        address_n: Optional[List[int]] = None,
-        show_display: Optional[bool] = None,
+        address_n: Optional[List["int"]] = None,
+        show_display: Optional["bool"] = None,
     ) -> None:
         self.address_n = address_n if address_n is not None else []
         self.show_display = show_display
@@ -3923,8 +3923,8 @@ class EthereumAddress(protobuf.MessageType):
     def __init__(
         self,
         *,
-        _old_address: Optional[bytes] = None,
-        address: Optional[str] = None,
+        _old_address: Optional["bytes"] = None,
+        address: Optional["str"] = None,
     ) -> None:
         self._old_address = _old_address
         self.address = address
@@ -3948,16 +3948,16 @@ class EthereumSignTx(protobuf.MessageType):
     def __init__(
         self,
         *,
-        address_n: Optional[List[int]] = None,
-        nonce: Optional[bytes] = None,
-        gas_price: Optional[bytes] = None,
-        gas_limit: Optional[bytes] = None,
-        to: Optional[str] = None,
-        value: Optional[bytes] = None,
-        data_initial_chunk: Optional[bytes] = None,
-        data_length: Optional[int] = None,
-        chain_id: Optional[int] = None,
-        tx_type: Optional[int] = None,
+        address_n: Optional[List["int"]] = None,
+        nonce: Optional["bytes"] = None,
+        gas_price: Optional["bytes"] = None,
+        gas_limit: Optional["bytes"] = None,
+        to: Optional["str"] = None,
+        value: Optional["bytes"] = None,
+        data_initial_chunk: Optional["bytes"] = None,
+        data_length: Optional["int"] = None,
+        chain_id: Optional["int"] = None,
+        tx_type: Optional["int"] = None,
     ) -> None:
         self.address_n = address_n if address_n is not None else []
         self.nonce = nonce
@@ -3983,10 +3983,10 @@ class EthereumTxRequest(protobuf.MessageType):
     def __init__(
         self,
         *,
-        data_length: Optional[int] = None,
-        signature_v: Optional[int] = None,
-        signature_r: Optional[bytes] = None,
-        signature_s: Optional[bytes] = None,
+        data_length: Optional["int"] = None,
+        signature_v: Optional["int"] = None,
+        signature_r: Optional["bytes"] = None,
+        signature_s: Optional["bytes"] = None,
     ) -> None:
         self.data_length = data_length
         self.signature_v = signature_v
@@ -4003,7 +4003,7 @@ class EthereumTxAck(protobuf.MessageType):
     def __init__(
         self,
         *,
-        data_chunk: Optional[bytes] = None,
+        data_chunk: Optional["bytes"] = None,
     ) -> None:
         self.data_chunk = data_chunk
 
@@ -4018,8 +4018,8 @@ class EthereumSignMessage(protobuf.MessageType):
     def __init__(
         self,
         *,
-        address_n: Optional[List[int]] = None,
-        message: Optional[bytes] = None,
+        address_n: Optional[List["int"]] = None,
+        message: Optional["bytes"] = None,
     ) -> None:
         self.address_n = address_n if address_n is not None else []
         self.message = message
@@ -4035,8 +4035,8 @@ class EthereumMessageSignature(protobuf.MessageType):
     def __init__(
         self,
         *,
-        signature: bytes,
-        address: str,
+        signature: "bytes",
+        address: "str",
     ) -> None:
         self.signature = signature
         self.address = address
@@ -4053,9 +4053,9 @@ class EthereumVerifyMessage(protobuf.MessageType):
     def __init__(
         self,
         *,
-        signature: Optional[bytes] = None,
-        message: Optional[bytes] = None,
-        address: Optional[str] = None,
+        signature: Optional["bytes"] = None,
+        message: Optional["bytes"] = None,
+        address: Optional["str"] = None,
     ) -> None:
         self.signature = signature
         self.message = message
@@ -4072,8 +4072,8 @@ class LiskGetAddress(protobuf.MessageType):
     def __init__(
         self,
         *,
-        address_n: Optional[List[int]] = None,
-        show_display: Optional[bool] = None,
+        address_n: Optional[List["int"]] = None,
+        show_display: Optional["bool"] = None,
     ) -> None:
         self.address_n = address_n if address_n is not None else []
         self.show_display = show_display
@@ -4088,7 +4088,7 @@ class LiskAddress(protobuf.MessageType):
     def __init__(
         self,
         *,
-        address: str,
+        address: "str",
     ) -> None:
         self.address = address
 
@@ -4103,8 +4103,8 @@ class LiskGetPublicKey(protobuf.MessageType):
     def __init__(
         self,
         *,
-        address_n: Optional[List[int]] = None,
-        show_display: Optional[bool] = None,
+        address_n: Optional[List["int"]] = None,
+        show_display: Optional["bool"] = None,
     ) -> None:
         self.address_n = address_n if address_n is not None else []
         self.show_display = show_display
@@ -4119,135 +4119,23 @@ class LiskPublicKey(protobuf.MessageType):
     def __init__(
         self,
         *,
-        public_key: bytes,
+        public_key: "bytes",
     ) -> None:
         self.public_key = public_key
-
-
-class LiskSignatureType(protobuf.MessageType):
-    MESSAGE_WIRE_TYPE = None
-    FIELDS = {
-        1: protobuf.Field("public_key", "bytes", repeated=False, required=False),
-    }
-
-    def __init__(
-        self,
-        *,
-        public_key: Optional[bytes] = None,
-    ) -> None:
-        self.public_key = public_key
-
-
-class LiskDelegateType(protobuf.MessageType):
-    MESSAGE_WIRE_TYPE = None
-    FIELDS = {
-        1: protobuf.Field("username", "string", repeated=False, required=False),
-    }
-
-    def __init__(
-        self,
-        *,
-        username: Optional[str] = None,
-    ) -> None:
-        self.username = username
-
-
-class LiskMultisignatureType(protobuf.MessageType):
-    MESSAGE_WIRE_TYPE = None
-    FIELDS = {
-        1: protobuf.Field("min", "uint32", repeated=False, required=False),
-        2: protobuf.Field("life_time", "uint32", repeated=False, required=False),
-        3: protobuf.Field("keys_group", "string", repeated=True, required=False),
-    }
-
-    def __init__(
-        self,
-        *,
-        keys_group: Optional[List[str]] = None,
-        min: Optional[int] = None,
-        life_time: Optional[int] = None,
-    ) -> None:
-        self.keys_group = keys_group if keys_group is not None else []
-        self.min = min
-        self.life_time = life_time
-
-
-class LiskTransactionAsset(protobuf.MessageType):
-    MESSAGE_WIRE_TYPE = None
-    FIELDS = {
-        1: protobuf.Field("signature", LiskSignatureType, repeated=False, required=False),
-        2: protobuf.Field("delegate", LiskDelegateType, repeated=False, required=False),
-        3: protobuf.Field("votes", "string", repeated=True, required=False),
-        4: protobuf.Field("multisignature", LiskMultisignatureType, repeated=False, required=False),
-        5: protobuf.Field("data", "string", repeated=False, required=False),
-    }
-
-    def __init__(
-        self,
-        *,
-        votes: Optional[List[str]] = None,
-        signature: Optional[LiskSignatureType] = None,
-        delegate: Optional[LiskDelegateType] = None,
-        multisignature: Optional[LiskMultisignatureType] = None,
-        data: Optional[str] = None,
-    ) -> None:
-        self.votes = votes if votes is not None else []
-        self.signature = signature
-        self.delegate = delegate
-        self.multisignature = multisignature
-        self.data = data
-
-
-class LiskTransactionCommon(protobuf.MessageType):
-    MESSAGE_WIRE_TYPE = None
-    FIELDS = {
-        1: protobuf.Field("type", LiskTransactionType, repeated=False, required=False),
-        2: protobuf.Field("amount", "uint64", repeated=False, required=False),
-        3: protobuf.Field("fee", "uint64", repeated=False, required=False),
-        4: protobuf.Field("recipient_id", "string", repeated=False, required=False),
-        5: protobuf.Field("sender_public_key", "bytes", repeated=False, required=False),
-        6: protobuf.Field("requester_public_key", "bytes", repeated=False, required=False),
-        7: protobuf.Field("signature", "bytes", repeated=False, required=False),
-        8: protobuf.Field("timestamp", "uint32", repeated=False, required=False),
-        9: protobuf.Field("asset", LiskTransactionAsset, repeated=False, required=False),
-    }
-
-    def __init__(
-        self,
-        *,
-        type: Optional[LiskTransactionType] = None,
-        amount: Optional[int] = None,
-        fee: Optional[int] = None,
-        recipient_id: Optional[str] = None,
-        sender_public_key: Optional[bytes] = None,
-        requester_public_key: Optional[bytes] = None,
-        signature: Optional[bytes] = None,
-        timestamp: Optional[int] = None,
-        asset: Optional[LiskTransactionAsset] = None,
-    ) -> None:
-        self.type = type
-        self.amount = amount
-        self.fee = fee
-        self.recipient_id = recipient_id
-        self.sender_public_key = sender_public_key
-        self.requester_public_key = requester_public_key
-        self.signature = signature
-        self.timestamp = timestamp
-        self.asset = asset
 
 
 class LiskSignTx(protobuf.MessageType):
     MESSAGE_WIRE_TYPE = 116
     FIELDS = {
         1: protobuf.Field("address_n", "uint32", repeated=True, required=False),
-        2: protobuf.Field("transaction", LiskTransactionCommon, repeated=False, required=True),
+        2: protobuf.Field("transaction", "LiskTransactionCommon", repeated=False, required=True),
     }
 
     def __init__(
         self,
         *,
-        transaction: LiskTransactionCommon,
-        address_n: Optional[List[int]] = None,
+        transaction: "LiskTransactionCommon",
+        address_n: Optional[List["int"]] = None,
     ) -> None:
         self.address_n = address_n if address_n is not None else []
         self.transaction = transaction
@@ -4262,7 +4150,7 @@ class LiskSignedTx(protobuf.MessageType):
     def __init__(
         self,
         *,
-        signature: bytes,
+        signature: "bytes",
     ) -> None:
         self.signature = signature
 
@@ -4277,8 +4165,8 @@ class LiskSignMessage(protobuf.MessageType):
     def __init__(
         self,
         *,
-        message: bytes,
-        address_n: Optional[List[int]] = None,
+        message: "bytes",
+        address_n: Optional[List["int"]] = None,
     ) -> None:
         self.address_n = address_n if address_n is not None else []
         self.message = message
@@ -4294,8 +4182,8 @@ class LiskMessageSignature(protobuf.MessageType):
     def __init__(
         self,
         *,
-        public_key: bytes,
-        signature: bytes,
+        public_key: "bytes",
+        signature: "bytes",
     ) -> None:
         self.public_key = public_key
         self.signature = signature
@@ -4312,76 +4200,131 @@ class LiskVerifyMessage(protobuf.MessageType):
     def __init__(
         self,
         *,
-        public_key: bytes,
-        signature: bytes,
-        message: bytes,
+        public_key: "bytes",
+        signature: "bytes",
+        message: "bytes",
     ) -> None:
         self.public_key = public_key
         self.signature = signature
         self.message = message
 
 
-class MoneroRctKeyPublic(protobuf.MessageType):
+class LiskTransactionCommon(protobuf.MessageType):
     MESSAGE_WIRE_TYPE = None
     FIELDS = {
-        1: protobuf.Field("dest", "bytes", repeated=False, required=False),
-        2: protobuf.Field("commitment", "bytes", repeated=False, required=False),
+        1: protobuf.Field("type", "LiskTransactionType", repeated=False, required=False),
+        2: protobuf.Field("amount", "uint64", repeated=False, required=False),
+        3: protobuf.Field("fee", "uint64", repeated=False, required=False),
+        4: protobuf.Field("recipient_id", "string", repeated=False, required=False),
+        5: protobuf.Field("sender_public_key", "bytes", repeated=False, required=False),
+        6: protobuf.Field("requester_public_key", "bytes", repeated=False, required=False),
+        7: protobuf.Field("signature", "bytes", repeated=False, required=False),
+        8: protobuf.Field("timestamp", "uint32", repeated=False, required=False),
+        9: protobuf.Field("asset", "LiskTransactionAsset", repeated=False, required=False),
     }
 
     def __init__(
         self,
         *,
-        dest: Optional[bytes] = None,
-        commitment: Optional[bytes] = None,
+        type: Optional["LiskTransactionType"] = None,
+        amount: Optional["int"] = None,
+        fee: Optional["int"] = None,
+        recipient_id: Optional["str"] = None,
+        sender_public_key: Optional["bytes"] = None,
+        requester_public_key: Optional["bytes"] = None,
+        signature: Optional["bytes"] = None,
+        timestamp: Optional["int"] = None,
+        asset: Optional["LiskTransactionAsset"] = None,
     ) -> None:
-        self.dest = dest
-        self.commitment = commitment
+        self.type = type
+        self.amount = amount
+        self.fee = fee
+        self.recipient_id = recipient_id
+        self.sender_public_key = sender_public_key
+        self.requester_public_key = requester_public_key
+        self.signature = signature
+        self.timestamp = timestamp
+        self.asset = asset
 
 
-class MoneroOutputEntry(protobuf.MessageType):
+class LiskTransactionAsset(protobuf.MessageType):
     MESSAGE_WIRE_TYPE = None
     FIELDS = {
-        1: protobuf.Field("idx", "uint64", repeated=False, required=False),
-        2: protobuf.Field("key", MoneroRctKeyPublic, repeated=False, required=False),
+        1: protobuf.Field("signature", "LiskSignatureType", repeated=False, required=False),
+        2: protobuf.Field("delegate", "LiskDelegateType", repeated=False, required=False),
+        3: protobuf.Field("votes", "string", repeated=True, required=False),
+        4: protobuf.Field("multisignature", "LiskMultisignatureType", repeated=False, required=False),
+        5: protobuf.Field("data", "string", repeated=False, required=False),
     }
 
     def __init__(
         self,
         *,
-        idx: Optional[int] = None,
-        key: Optional[MoneroRctKeyPublic] = None,
+        votes: Optional[List["str"]] = None,
+        signature: Optional["LiskSignatureType"] = None,
+        delegate: Optional["LiskDelegateType"] = None,
+        multisignature: Optional["LiskMultisignatureType"] = None,
+        data: Optional["str"] = None,
     ) -> None:
-        self.idx = idx
-        self.key = key
+        self.votes = votes if votes is not None else []
+        self.signature = signature
+        self.delegate = delegate
+        self.multisignature = multisignature
+        self.data = data
 
 
-class MoneroMultisigKLRki(protobuf.MessageType):
+class LiskSignatureType(protobuf.MessageType):
     MESSAGE_WIRE_TYPE = None
     FIELDS = {
-        1: protobuf.Field("K", "bytes", repeated=False, required=False),
-        2: protobuf.Field("L", "bytes", repeated=False, required=False),
-        3: protobuf.Field("R", "bytes", repeated=False, required=False),
-        4: protobuf.Field("ki", "bytes", repeated=False, required=False),
+        1: protobuf.Field("public_key", "bytes", repeated=False, required=False),
     }
 
     def __init__(
         self,
         *,
-        K: Optional[bytes] = None,
-        L: Optional[bytes] = None,
-        R: Optional[bytes] = None,
-        ki: Optional[bytes] = None,
+        public_key: Optional["bytes"] = None,
     ) -> None:
-        self.K = K
-        self.L = L
-        self.R = R
-        self.ki = ki
+        self.public_key = public_key
+
+
+class LiskDelegateType(protobuf.MessageType):
+    MESSAGE_WIRE_TYPE = None
+    FIELDS = {
+        1: protobuf.Field("username", "string", repeated=False, required=False),
+    }
+
+    def __init__(
+        self,
+        *,
+        username: Optional["str"] = None,
+    ) -> None:
+        self.username = username
+
+
+class LiskMultisignatureType(protobuf.MessageType):
+    MESSAGE_WIRE_TYPE = None
+    FIELDS = {
+        1: protobuf.Field("min", "uint32", repeated=False, required=False),
+        2: protobuf.Field("life_time", "uint32", repeated=False, required=False),
+        3: protobuf.Field("keys_group", "string", repeated=True, required=False),
+    }
+
+    def __init__(
+        self,
+        *,
+        keys_group: Optional[List["str"]] = None,
+        min: Optional["int"] = None,
+        life_time: Optional["int"] = None,
+    ) -> None:
+        self.keys_group = keys_group if keys_group is not None else []
+        self.min = min
+        self.life_time = life_time
 
 
 class MoneroTransactionSourceEntry(protobuf.MessageType):
     MESSAGE_WIRE_TYPE = None
     FIELDS = {
-        1: protobuf.Field("outputs", MoneroOutputEntry, repeated=True, required=False),
+        1: protobuf.Field("outputs", "MoneroOutputEntry", repeated=True, required=False),
         2: protobuf.Field("real_output", "uint64", repeated=False, required=False),
         3: protobuf.Field("real_out_tx_key", "bytes", repeated=False, required=False),
         4: protobuf.Field("real_out_additional_tx_keys", "bytes", repeated=True, required=False),
@@ -4389,23 +4332,23 @@ class MoneroTransactionSourceEntry(protobuf.MessageType):
         6: protobuf.Field("amount", "uint64", repeated=False, required=False),
         7: protobuf.Field("rct", "bool", repeated=False, required=False),
         8: protobuf.Field("mask", "bytes", repeated=False, required=False),
-        9: protobuf.Field("multisig_kLRki", MoneroMultisigKLRki, repeated=False, required=False),
+        9: protobuf.Field("multisig_kLRki", "MoneroMultisigKLRki", repeated=False, required=False),
         10: protobuf.Field("subaddr_minor", "uint32", repeated=False, required=False),
     }
 
     def __init__(
         self,
         *,
-        outputs: Optional[List[MoneroOutputEntry]] = None,
-        real_out_additional_tx_keys: Optional[List[bytes]] = None,
-        real_output: Optional[int] = None,
-        real_out_tx_key: Optional[bytes] = None,
-        real_output_in_tx_index: Optional[int] = None,
-        amount: Optional[int] = None,
-        rct: Optional[bool] = None,
-        mask: Optional[bytes] = None,
-        multisig_kLRki: Optional[MoneroMultisigKLRki] = None,
-        subaddr_minor: Optional[int] = None,
+        outputs: Optional[List["MoneroOutputEntry"]] = None,
+        real_out_additional_tx_keys: Optional[List["bytes"]] = None,
+        real_output: Optional["int"] = None,
+        real_out_tx_key: Optional["bytes"] = None,
+        real_output_in_tx_index: Optional["int"] = None,
+        amount: Optional["int"] = None,
+        rct: Optional["bool"] = None,
+        mask: Optional["bytes"] = None,
+        multisig_kLRki: Optional["MoneroMultisigKLRki"] = None,
+        subaddr_minor: Optional["int"] = None,
     ) -> None:
         self.outputs = outputs if outputs is not None else []
         self.real_out_additional_tx_keys = real_out_additional_tx_keys if real_out_additional_tx_keys is not None else []
@@ -4419,28 +4362,11 @@ class MoneroTransactionSourceEntry(protobuf.MessageType):
         self.subaddr_minor = subaddr_minor
 
 
-class MoneroAccountPublicAddress(protobuf.MessageType):
-    MESSAGE_WIRE_TYPE = None
-    FIELDS = {
-        1: protobuf.Field("spend_public_key", "bytes", repeated=False, required=False),
-        2: protobuf.Field("view_public_key", "bytes", repeated=False, required=False),
-    }
-
-    def __init__(
-        self,
-        *,
-        spend_public_key: Optional[bytes] = None,
-        view_public_key: Optional[bytes] = None,
-    ) -> None:
-        self.spend_public_key = spend_public_key
-        self.view_public_key = view_public_key
-
-
 class MoneroTransactionDestinationEntry(protobuf.MessageType):
     MESSAGE_WIRE_TYPE = None
     FIELDS = {
         1: protobuf.Field("amount", "uint64", repeated=False, required=False),
-        2: protobuf.Field("addr", MoneroAccountPublicAddress, repeated=False, required=False),
+        2: protobuf.Field("addr", "MoneroAccountPublicAddress", repeated=False, required=False),
         3: protobuf.Field("is_subaddress", "bool", repeated=False, required=False),
         4: protobuf.Field("original", "bytes", repeated=False, required=False),
         5: protobuf.Field("is_integrated", "bool", repeated=False, required=False),
@@ -4449,11 +4375,11 @@ class MoneroTransactionDestinationEntry(protobuf.MessageType):
     def __init__(
         self,
         *,
-        amount: Optional[int] = None,
-        addr: Optional[MoneroAccountPublicAddress] = None,
-        is_subaddress: Optional[bool] = None,
-        original: Optional[bytes] = None,
-        is_integrated: Optional[bool] = None,
+        amount: Optional["int"] = None,
+        addr: Optional["MoneroAccountPublicAddress"] = None,
+        is_subaddress: Optional["bool"] = None,
+        original: Optional["bytes"] = None,
+        is_integrated: Optional["bool"] = None,
     ) -> None:
         self.amount = amount
         self.addr = addr
@@ -4477,13 +4403,13 @@ class MoneroTransactionRsigData(protobuf.MessageType):
     def __init__(
         self,
         *,
-        grouping: Optional[List[int]] = None,
-        rsig_parts: Optional[List[bytes]] = None,
-        rsig_type: Optional[int] = None,
-        offload_type: Optional[int] = None,
-        mask: Optional[bytes] = None,
-        rsig: Optional[bytes] = None,
-        bp_version: Optional[int] = None,
+        grouping: Optional[List["int"]] = None,
+        rsig_parts: Optional[List["bytes"]] = None,
+        rsig_type: Optional["int"] = None,
+        offload_type: Optional["int"] = None,
+        mask: Optional["bytes"] = None,
+        rsig: Optional["bytes"] = None,
+        bp_version: Optional["int"] = None,
     ) -> None:
         self.grouping = grouping if grouping is not None else []
         self.rsig_parts = rsig_parts if rsig_parts is not None else []
@@ -4508,12 +4434,12 @@ class MoneroGetAddress(protobuf.MessageType):
     def __init__(
         self,
         *,
-        address_n: Optional[List[int]] = None,
-        show_display: Optional[bool] = None,
-        network_type: Optional[int] = None,
-        account: Optional[int] = None,
-        minor: Optional[int] = None,
-        payment_id: Optional[bytes] = None,
+        address_n: Optional[List["int"]] = None,
+        show_display: Optional["bool"] = None,
+        network_type: Optional["int"] = None,
+        account: Optional["int"] = None,
+        minor: Optional["int"] = None,
+        payment_id: Optional["bytes"] = None,
     ) -> None:
         self.address_n = address_n if address_n is not None else []
         self.show_display = show_display
@@ -4532,7 +4458,7 @@ class MoneroAddress(protobuf.MessageType):
     def __init__(
         self,
         *,
-        address: Optional[bytes] = None,
+        address: Optional["bytes"] = None,
     ) -> None:
         self.address = address
 
@@ -4547,8 +4473,8 @@ class MoneroGetWatchKey(protobuf.MessageType):
     def __init__(
         self,
         *,
-        address_n: Optional[List[int]] = None,
-        network_type: Optional[int] = None,
+        address_n: Optional[List["int"]] = None,
+        network_type: Optional["int"] = None,
     ) -> None:
         self.address_n = address_n if address_n is not None else []
         self.network_type = network_type
@@ -4564,67 +4490,11 @@ class MoneroWatchKey(protobuf.MessageType):
     def __init__(
         self,
         *,
-        watch_key: Optional[bytes] = None,
-        address: Optional[bytes] = None,
+        watch_key: Optional["bytes"] = None,
+        address: Optional["bytes"] = None,
     ) -> None:
         self.watch_key = watch_key
         self.address = address
-
-
-class MoneroTransactionData(protobuf.MessageType):
-    MESSAGE_WIRE_TYPE = None
-    FIELDS = {
-        1: protobuf.Field("version", "uint32", repeated=False, required=False),
-        2: protobuf.Field("payment_id", "bytes", repeated=False, required=False),
-        3: protobuf.Field("unlock_time", "uint64", repeated=False, required=False),
-        4: protobuf.Field("outputs", MoneroTransactionDestinationEntry, repeated=True, required=False),
-        5: protobuf.Field("change_dts", MoneroTransactionDestinationEntry, repeated=False, required=False),
-        6: protobuf.Field("num_inputs", "uint32", repeated=False, required=False),
-        7: protobuf.Field("mixin", "uint32", repeated=False, required=False),
-        8: protobuf.Field("fee", "uint64", repeated=False, required=False),
-        9: protobuf.Field("account", "uint32", repeated=False, required=False),
-        10: protobuf.Field("minor_indices", "uint32", repeated=True, required=False),
-        11: protobuf.Field("rsig_data", MoneroTransactionRsigData, repeated=False, required=False),
-        12: protobuf.Field("integrated_indices", "uint32", repeated=True, required=False),
-        13: protobuf.Field("client_version", "uint32", repeated=False, required=False),
-        14: protobuf.Field("hard_fork", "uint32", repeated=False, required=False),
-        15: protobuf.Field("monero_version", "bytes", repeated=False, required=False),
-    }
-
-    def __init__(
-        self,
-        *,
-        outputs: Optional[List[MoneroTransactionDestinationEntry]] = None,
-        minor_indices: Optional[List[int]] = None,
-        integrated_indices: Optional[List[int]] = None,
-        version: Optional[int] = None,
-        payment_id: Optional[bytes] = None,
-        unlock_time: Optional[int] = None,
-        change_dts: Optional[MoneroTransactionDestinationEntry] = None,
-        num_inputs: Optional[int] = None,
-        mixin: Optional[int] = None,
-        fee: Optional[int] = None,
-        account: Optional[int] = None,
-        rsig_data: Optional[MoneroTransactionRsigData] = None,
-        client_version: Optional[int] = None,
-        hard_fork: Optional[int] = None,
-        monero_version: Optional[bytes] = None,
-    ) -> None:
-        self.outputs = outputs if outputs is not None else []
-        self.minor_indices = minor_indices if minor_indices is not None else []
-        self.integrated_indices = integrated_indices if integrated_indices is not None else []
-        self.version = version
-        self.payment_id = payment_id
-        self.unlock_time = unlock_time
-        self.change_dts = change_dts
-        self.num_inputs = num_inputs
-        self.mixin = mixin
-        self.fee = fee
-        self.account = account
-        self.rsig_data = rsig_data
-        self.client_version = client_version
-        self.hard_fork = hard_fork
-        self.monero_version = monero_version
 
 
 class MoneroTransactionInitRequest(protobuf.MessageType):
@@ -4633,16 +4503,16 @@ class MoneroTransactionInitRequest(protobuf.MessageType):
         1: protobuf.Field("version", "uint32", repeated=False, required=False),
         2: protobuf.Field("address_n", "uint32", repeated=True, required=False),
         3: protobuf.Field("network_type", "uint32", repeated=False, required=False),
-        4: protobuf.Field("tsx_data", MoneroTransactionData, repeated=False, required=False),
+        4: protobuf.Field("tsx_data", "MoneroTransactionData", repeated=False, required=False),
     }
 
     def __init__(
         self,
         *,
-        address_n: Optional[List[int]] = None,
-        version: Optional[int] = None,
-        network_type: Optional[int] = None,
-        tsx_data: Optional[MoneroTransactionData] = None,
+        address_n: Optional[List["int"]] = None,
+        version: Optional["int"] = None,
+        network_type: Optional["int"] = None,
+        tsx_data: Optional["MoneroTransactionData"] = None,
     ) -> None:
         self.address_n = address_n if address_n is not None else []
         self.version = version
@@ -4654,14 +4524,14 @@ class MoneroTransactionInitAck(protobuf.MessageType):
     MESSAGE_WIRE_TYPE = 502
     FIELDS = {
         1: protobuf.Field("hmacs", "bytes", repeated=True, required=False),
-        2: protobuf.Field("rsig_data", MoneroTransactionRsigData, repeated=False, required=False),
+        2: protobuf.Field("rsig_data", "MoneroTransactionRsigData", repeated=False, required=False),
     }
 
     def __init__(
         self,
         *,
-        hmacs: Optional[List[bytes]] = None,
-        rsig_data: Optional[MoneroTransactionRsigData] = None,
+        hmacs: Optional[List["bytes"]] = None,
+        rsig_data: Optional["MoneroTransactionRsigData"] = None,
     ) -> None:
         self.hmacs = hmacs if hmacs is not None else []
         self.rsig_data = rsig_data
@@ -4670,13 +4540,13 @@ class MoneroTransactionInitAck(protobuf.MessageType):
 class MoneroTransactionSetInputRequest(protobuf.MessageType):
     MESSAGE_WIRE_TYPE = 503
     FIELDS = {
-        1: protobuf.Field("src_entr", MoneroTransactionSourceEntry, repeated=False, required=False),
+        1: protobuf.Field("src_entr", "MoneroTransactionSourceEntry", repeated=False, required=False),
     }
 
     def __init__(
         self,
         *,
-        src_entr: Optional[MoneroTransactionSourceEntry] = None,
+        src_entr: Optional["MoneroTransactionSourceEntry"] = None,
     ) -> None:
         self.src_entr = src_entr
 
@@ -4695,12 +4565,12 @@ class MoneroTransactionSetInputAck(protobuf.MessageType):
     def __init__(
         self,
         *,
-        vini: Optional[bytes] = None,
-        vini_hmac: Optional[bytes] = None,
-        pseudo_out: Optional[bytes] = None,
-        pseudo_out_hmac: Optional[bytes] = None,
-        pseudo_out_alpha: Optional[bytes] = None,
-        spend_key: Optional[bytes] = None,
+        vini: Optional["bytes"] = None,
+        vini_hmac: Optional["bytes"] = None,
+        pseudo_out: Optional["bytes"] = None,
+        pseudo_out_hmac: Optional["bytes"] = None,
+        pseudo_out_alpha: Optional["bytes"] = None,
+        spend_key: Optional["bytes"] = None,
     ) -> None:
         self.vini = vini
         self.vini_hmac = vini_hmac
@@ -4719,7 +4589,7 @@ class MoneroTransactionInputsPermutationRequest(protobuf.MessageType):
     def __init__(
         self,
         *,
-        perm: Optional[List[int]] = None,
+        perm: Optional[List["int"]] = None,
     ) -> None:
         self.perm = perm if perm is not None else []
 
@@ -4731,7 +4601,7 @@ class MoneroTransactionInputsPermutationAck(protobuf.MessageType):
 class MoneroTransactionInputViniRequest(protobuf.MessageType):
     MESSAGE_WIRE_TYPE = 507
     FIELDS = {
-        1: protobuf.Field("src_entr", MoneroTransactionSourceEntry, repeated=False, required=False),
+        1: protobuf.Field("src_entr", "MoneroTransactionSourceEntry", repeated=False, required=False),
         2: protobuf.Field("vini", "bytes", repeated=False, required=False),
         3: protobuf.Field("vini_hmac", "bytes", repeated=False, required=False),
         4: protobuf.Field("pseudo_out", "bytes", repeated=False, required=False),
@@ -4742,12 +4612,12 @@ class MoneroTransactionInputViniRequest(protobuf.MessageType):
     def __init__(
         self,
         *,
-        src_entr: Optional[MoneroTransactionSourceEntry] = None,
-        vini: Optional[bytes] = None,
-        vini_hmac: Optional[bytes] = None,
-        pseudo_out: Optional[bytes] = None,
-        pseudo_out_hmac: Optional[bytes] = None,
-        orig_idx: Optional[int] = None,
+        src_entr: Optional["MoneroTransactionSourceEntry"] = None,
+        vini: Optional["bytes"] = None,
+        vini_hmac: Optional["bytes"] = None,
+        pseudo_out: Optional["bytes"] = None,
+        pseudo_out_hmac: Optional["bytes"] = None,
+        orig_idx: Optional["int"] = None,
     ) -> None:
         self.src_entr = src_entr
         self.vini = vini
@@ -4768,13 +4638,13 @@ class MoneroTransactionAllInputsSetRequest(protobuf.MessageType):
 class MoneroTransactionAllInputsSetAck(protobuf.MessageType):
     MESSAGE_WIRE_TYPE = 510
     FIELDS = {
-        1: protobuf.Field("rsig_data", MoneroTransactionRsigData, repeated=False, required=False),
+        1: protobuf.Field("rsig_data", "MoneroTransactionRsigData", repeated=False, required=False),
     }
 
     def __init__(
         self,
         *,
-        rsig_data: Optional[MoneroTransactionRsigData] = None,
+        rsig_data: Optional["MoneroTransactionRsigData"] = None,
     ) -> None:
         self.rsig_data = rsig_data
 
@@ -4782,19 +4652,19 @@ class MoneroTransactionAllInputsSetAck(protobuf.MessageType):
 class MoneroTransactionSetOutputRequest(protobuf.MessageType):
     MESSAGE_WIRE_TYPE = 511
     FIELDS = {
-        1: protobuf.Field("dst_entr", MoneroTransactionDestinationEntry, repeated=False, required=False),
+        1: protobuf.Field("dst_entr", "MoneroTransactionDestinationEntry", repeated=False, required=False),
         2: protobuf.Field("dst_entr_hmac", "bytes", repeated=False, required=False),
-        3: protobuf.Field("rsig_data", MoneroTransactionRsigData, repeated=False, required=False),
+        3: protobuf.Field("rsig_data", "MoneroTransactionRsigData", repeated=False, required=False),
         4: protobuf.Field("is_offloaded_bp", "bool", repeated=False, required=False),
     }
 
     def __init__(
         self,
         *,
-        dst_entr: Optional[MoneroTransactionDestinationEntry] = None,
-        dst_entr_hmac: Optional[bytes] = None,
-        rsig_data: Optional[MoneroTransactionRsigData] = None,
-        is_offloaded_bp: Optional[bool] = None,
+        dst_entr: Optional["MoneroTransactionDestinationEntry"] = None,
+        dst_entr_hmac: Optional["bytes"] = None,
+        rsig_data: Optional["MoneroTransactionRsigData"] = None,
+        is_offloaded_bp: Optional["bool"] = None,
     ) -> None:
         self.dst_entr = dst_entr
         self.dst_entr_hmac = dst_entr_hmac
@@ -4807,7 +4677,7 @@ class MoneroTransactionSetOutputAck(protobuf.MessageType):
     FIELDS = {
         1: protobuf.Field("tx_out", "bytes", repeated=False, required=False),
         2: protobuf.Field("vouti_hmac", "bytes", repeated=False, required=False),
-        3: protobuf.Field("rsig_data", MoneroTransactionRsigData, repeated=False, required=False),
+        3: protobuf.Field("rsig_data", "MoneroTransactionRsigData", repeated=False, required=False),
         4: protobuf.Field("out_pk", "bytes", repeated=False, required=False),
         5: protobuf.Field("ecdh_info", "bytes", repeated=False, required=False),
     }
@@ -4815,11 +4685,11 @@ class MoneroTransactionSetOutputAck(protobuf.MessageType):
     def __init__(
         self,
         *,
-        tx_out: Optional[bytes] = None,
-        vouti_hmac: Optional[bytes] = None,
-        rsig_data: Optional[MoneroTransactionRsigData] = None,
-        out_pk: Optional[bytes] = None,
-        ecdh_info: Optional[bytes] = None,
+        tx_out: Optional["bytes"] = None,
+        vouti_hmac: Optional["bytes"] = None,
+        rsig_data: Optional["MoneroTransactionRsigData"] = None,
+        out_pk: Optional["bytes"] = None,
+        ecdh_info: Optional["bytes"] = None,
     ) -> None:
         self.tx_out = tx_out
         self.vouti_hmac = vouti_hmac
@@ -4831,35 +4701,15 @@ class MoneroTransactionSetOutputAck(protobuf.MessageType):
 class MoneroTransactionAllOutSetRequest(protobuf.MessageType):
     MESSAGE_WIRE_TYPE = 513
     FIELDS = {
-        1: protobuf.Field("rsig_data", MoneroTransactionRsigData, repeated=False, required=False),
+        1: protobuf.Field("rsig_data", "MoneroTransactionRsigData", repeated=False, required=False),
     }
 
     def __init__(
         self,
         *,
-        rsig_data: Optional[MoneroTransactionRsigData] = None,
+        rsig_data: Optional["MoneroTransactionRsigData"] = None,
     ) -> None:
         self.rsig_data = rsig_data
-
-
-class MoneroRingCtSig(protobuf.MessageType):
-    MESSAGE_WIRE_TYPE = None
-    FIELDS = {
-        1: protobuf.Field("txn_fee", "uint64", repeated=False, required=False),
-        2: protobuf.Field("message", "bytes", repeated=False, required=False),
-        3: protobuf.Field("rv_type", "uint32", repeated=False, required=False),
-    }
-
-    def __init__(
-        self,
-        *,
-        txn_fee: Optional[int] = None,
-        message: Optional[bytes] = None,
-        rv_type: Optional[int] = None,
-    ) -> None:
-        self.txn_fee = txn_fee
-        self.message = message
-        self.rv_type = rv_type
 
 
 class MoneroTransactionAllOutSetAck(protobuf.MessageType):
@@ -4867,17 +4717,17 @@ class MoneroTransactionAllOutSetAck(protobuf.MessageType):
     FIELDS = {
         1: protobuf.Field("extra", "bytes", repeated=False, required=False),
         2: protobuf.Field("tx_prefix_hash", "bytes", repeated=False, required=False),
-        4: protobuf.Field("rv", MoneroRingCtSig, repeated=False, required=False),
+        4: protobuf.Field("rv", "MoneroRingCtSig", repeated=False, required=False),
         5: protobuf.Field("full_message_hash", "bytes", repeated=False, required=False),
     }
 
     def __init__(
         self,
         *,
-        extra: Optional[bytes] = None,
-        tx_prefix_hash: Optional[bytes] = None,
-        rv: Optional[MoneroRingCtSig] = None,
-        full_message_hash: Optional[bytes] = None,
+        extra: Optional["bytes"] = None,
+        tx_prefix_hash: Optional["bytes"] = None,
+        rv: Optional["MoneroRingCtSig"] = None,
+        full_message_hash: Optional["bytes"] = None,
     ) -> None:
         self.extra = extra
         self.tx_prefix_hash = tx_prefix_hash
@@ -4888,7 +4738,7 @@ class MoneroTransactionAllOutSetAck(protobuf.MessageType):
 class MoneroTransactionSignInputRequest(protobuf.MessageType):
     MESSAGE_WIRE_TYPE = 515
     FIELDS = {
-        1: protobuf.Field("src_entr", MoneroTransactionSourceEntry, repeated=False, required=False),
+        1: protobuf.Field("src_entr", "MoneroTransactionSourceEntry", repeated=False, required=False),
         2: protobuf.Field("vini", "bytes", repeated=False, required=False),
         3: protobuf.Field("vini_hmac", "bytes", repeated=False, required=False),
         4: protobuf.Field("pseudo_out", "bytes", repeated=False, required=False),
@@ -4901,14 +4751,14 @@ class MoneroTransactionSignInputRequest(protobuf.MessageType):
     def __init__(
         self,
         *,
-        src_entr: Optional[MoneroTransactionSourceEntry] = None,
-        vini: Optional[bytes] = None,
-        vini_hmac: Optional[bytes] = None,
-        pseudo_out: Optional[bytes] = None,
-        pseudo_out_hmac: Optional[bytes] = None,
-        pseudo_out_alpha: Optional[bytes] = None,
-        spend_key: Optional[bytes] = None,
-        orig_idx: Optional[int] = None,
+        src_entr: Optional["MoneroTransactionSourceEntry"] = None,
+        vini: Optional["bytes"] = None,
+        vini_hmac: Optional["bytes"] = None,
+        pseudo_out: Optional["bytes"] = None,
+        pseudo_out_hmac: Optional["bytes"] = None,
+        pseudo_out_alpha: Optional["bytes"] = None,
+        spend_key: Optional["bytes"] = None,
+        orig_idx: Optional["int"] = None,
     ) -> None:
         self.src_entr = src_entr
         self.vini = vini
@@ -4930,8 +4780,8 @@ class MoneroTransactionSignInputAck(protobuf.MessageType):
     def __init__(
         self,
         *,
-        signature: Optional[bytes] = None,
-        pseudo_out: Optional[bytes] = None,
+        signature: Optional["bytes"] = None,
+        pseudo_out: Optional["bytes"] = None,
     ) -> None:
         self.signature = signature
         self.pseudo_out = pseudo_out
@@ -4954,34 +4804,17 @@ class MoneroTransactionFinalAck(protobuf.MessageType):
     def __init__(
         self,
         *,
-        cout_key: Optional[bytes] = None,
-        salt: Optional[bytes] = None,
-        rand_mult: Optional[bytes] = None,
-        tx_enc_keys: Optional[bytes] = None,
-        opening_key: Optional[bytes] = None,
+        cout_key: Optional["bytes"] = None,
+        salt: Optional["bytes"] = None,
+        rand_mult: Optional["bytes"] = None,
+        tx_enc_keys: Optional["bytes"] = None,
+        opening_key: Optional["bytes"] = None,
     ) -> None:
         self.cout_key = cout_key
         self.salt = salt
         self.rand_mult = rand_mult
         self.tx_enc_keys = tx_enc_keys
         self.opening_key = opening_key
-
-
-class MoneroSubAddressIndicesList(protobuf.MessageType):
-    MESSAGE_WIRE_TYPE = None
-    FIELDS = {
-        1: protobuf.Field("account", "uint32", repeated=False, required=False),
-        2: protobuf.Field("minor_indices", "uint32", repeated=True, required=False),
-    }
-
-    def __init__(
-        self,
-        *,
-        minor_indices: Optional[List[int]] = None,
-        account: Optional[int] = None,
-    ) -> None:
-        self.minor_indices = minor_indices if minor_indices is not None else []
-        self.account = account
 
 
 class MoneroKeyImageExportInitRequest(protobuf.MessageType):
@@ -4991,17 +4824,17 @@ class MoneroKeyImageExportInitRequest(protobuf.MessageType):
         2: protobuf.Field("hash", "bytes", repeated=False, required=False),
         3: protobuf.Field("address_n", "uint32", repeated=True, required=False),
         4: protobuf.Field("network_type", "uint32", repeated=False, required=False),
-        5: protobuf.Field("subs", MoneroSubAddressIndicesList, repeated=True, required=False),
+        5: protobuf.Field("subs", "MoneroSubAddressIndicesList", repeated=True, required=False),
     }
 
     def __init__(
         self,
         *,
-        address_n: Optional[List[int]] = None,
-        subs: Optional[List[MoneroSubAddressIndicesList]] = None,
-        num: Optional[int] = None,
-        hash: Optional[bytes] = None,
-        network_type: Optional[int] = None,
+        address_n: Optional[List["int"]] = None,
+        subs: Optional[List["MoneroSubAddressIndicesList"]] = None,
+        num: Optional["int"] = None,
+        hash: Optional["bytes"] = None,
+        network_type: Optional["int"] = None,
     ) -> None:
         self.address_n = address_n if address_n is not None else []
         self.subs = subs if subs is not None else []
@@ -5014,76 +4847,30 @@ class MoneroKeyImageExportInitAck(protobuf.MessageType):
     MESSAGE_WIRE_TYPE = 531
 
 
-class MoneroTransferDetails(protobuf.MessageType):
-    MESSAGE_WIRE_TYPE = None
-    FIELDS = {
-        1: protobuf.Field("out_key", "bytes", repeated=False, required=False),
-        2: protobuf.Field("tx_pub_key", "bytes", repeated=False, required=False),
-        3: protobuf.Field("additional_tx_pub_keys", "bytes", repeated=True, required=False),
-        4: protobuf.Field("internal_output_index", "uint64", repeated=False, required=False),
-        5: protobuf.Field("sub_addr_major", "uint32", repeated=False, required=False),
-        6: protobuf.Field("sub_addr_minor", "uint32", repeated=False, required=False),
-    }
-
-    def __init__(
-        self,
-        *,
-        additional_tx_pub_keys: Optional[List[bytes]] = None,
-        out_key: Optional[bytes] = None,
-        tx_pub_key: Optional[bytes] = None,
-        internal_output_index: Optional[int] = None,
-        sub_addr_major: Optional[int] = None,
-        sub_addr_minor: Optional[int] = None,
-    ) -> None:
-        self.additional_tx_pub_keys = additional_tx_pub_keys if additional_tx_pub_keys is not None else []
-        self.out_key = out_key
-        self.tx_pub_key = tx_pub_key
-        self.internal_output_index = internal_output_index
-        self.sub_addr_major = sub_addr_major
-        self.sub_addr_minor = sub_addr_minor
-
-
 class MoneroKeyImageSyncStepRequest(protobuf.MessageType):
     MESSAGE_WIRE_TYPE = 532
     FIELDS = {
-        1: protobuf.Field("tdis", MoneroTransferDetails, repeated=True, required=False),
+        1: protobuf.Field("tdis", "MoneroTransferDetails", repeated=True, required=False),
     }
 
     def __init__(
         self,
         *,
-        tdis: Optional[List[MoneroTransferDetails]] = None,
+        tdis: Optional[List["MoneroTransferDetails"]] = None,
     ) -> None:
         self.tdis = tdis if tdis is not None else []
-
-
-class MoneroExportedKeyImage(protobuf.MessageType):
-    MESSAGE_WIRE_TYPE = None
-    FIELDS = {
-        1: protobuf.Field("iv", "bytes", repeated=False, required=False),
-        3: protobuf.Field("blob", "bytes", repeated=False, required=False),
-    }
-
-    def __init__(
-        self,
-        *,
-        iv: Optional[bytes] = None,
-        blob: Optional[bytes] = None,
-    ) -> None:
-        self.iv = iv
-        self.blob = blob
 
 
 class MoneroKeyImageSyncStepAck(protobuf.MessageType):
     MESSAGE_WIRE_TYPE = 533
     FIELDS = {
-        1: protobuf.Field("kis", MoneroExportedKeyImage, repeated=True, required=False),
+        1: protobuf.Field("kis", "MoneroExportedKeyImage", repeated=True, required=False),
     }
 
     def __init__(
         self,
         *,
-        kis: Optional[List[MoneroExportedKeyImage]] = None,
+        kis: Optional[List["MoneroExportedKeyImage"]] = None,
     ) -> None:
         self.kis = kis if kis is not None else []
 
@@ -5101,7 +4888,7 @@ class MoneroKeyImageSyncFinalAck(protobuf.MessageType):
     def __init__(
         self,
         *,
-        enc_key: Optional[bytes] = None,
+        enc_key: Optional["bytes"] = None,
     ) -> None:
         self.enc_key = enc_key
 
@@ -5122,14 +4909,14 @@ class MoneroGetTxKeyRequest(protobuf.MessageType):
     def __init__(
         self,
         *,
-        address_n: Optional[List[int]] = None,
-        network_type: Optional[int] = None,
-        salt1: Optional[bytes] = None,
-        salt2: Optional[bytes] = None,
-        tx_enc_keys: Optional[bytes] = None,
-        tx_prefix_hash: Optional[bytes] = None,
-        reason: Optional[int] = None,
-        view_public_key: Optional[bytes] = None,
+        address_n: Optional[List["int"]] = None,
+        network_type: Optional["int"] = None,
+        salt1: Optional["bytes"] = None,
+        salt2: Optional["bytes"] = None,
+        tx_enc_keys: Optional["bytes"] = None,
+        tx_prefix_hash: Optional["bytes"] = None,
+        reason: Optional["int"] = None,
+        view_public_key: Optional["bytes"] = None,
     ) -> None:
         self.address_n = address_n if address_n is not None else []
         self.network_type = network_type
@@ -5152,9 +4939,9 @@ class MoneroGetTxKeyAck(protobuf.MessageType):
     def __init__(
         self,
         *,
-        salt: Optional[bytes] = None,
-        tx_keys: Optional[bytes] = None,
-        tx_derivations: Optional[bytes] = None,
+        salt: Optional["bytes"] = None,
+        tx_keys: Optional["bytes"] = None,
+        tx_derivations: Optional["bytes"] = None,
     ) -> None:
         self.salt = salt
         self.tx_keys = tx_keys
@@ -5171,8 +4958,8 @@ class MoneroLiveRefreshStartRequest(protobuf.MessageType):
     def __init__(
         self,
         *,
-        address_n: Optional[List[int]] = None,
-        network_type: Optional[int] = None,
+        address_n: Optional[List["int"]] = None,
+        network_type: Optional["int"] = None,
     ) -> None:
         self.address_n = address_n if address_n is not None else []
         self.network_type = network_type
@@ -5195,11 +4982,11 @@ class MoneroLiveRefreshStepRequest(protobuf.MessageType):
     def __init__(
         self,
         *,
-        out_key: Optional[bytes] = None,
-        recv_deriv: Optional[bytes] = None,
-        real_out_idx: Optional[int] = None,
-        sub_addr_major: Optional[int] = None,
-        sub_addr_minor: Optional[int] = None,
+        out_key: Optional["bytes"] = None,
+        recv_deriv: Optional["bytes"] = None,
+        real_out_idx: Optional["int"] = None,
+        sub_addr_major: Optional["int"] = None,
+        sub_addr_minor: Optional["int"] = None,
     ) -> None:
         self.out_key = out_key
         self.recv_deriv = recv_deriv
@@ -5218,8 +5005,8 @@ class MoneroLiveRefreshStepAck(protobuf.MessageType):
     def __init__(
         self,
         *,
-        salt: Optional[bytes] = None,
-        key_image: Optional[bytes] = None,
+        salt: Optional["bytes"] = None,
+        key_image: Optional["bytes"] = None,
     ) -> None:
         self.salt = salt
         self.key_image = key_image
@@ -5247,12 +5034,12 @@ class DebugMoneroDiagRequest(protobuf.MessageType):
     def __init__(
         self,
         *,
-        pd: Optional[List[int]] = None,
-        ins: Optional[int] = None,
-        p1: Optional[int] = None,
-        p2: Optional[int] = None,
-        data1: Optional[bytes] = None,
-        data2: Optional[bytes] = None,
+        pd: Optional[List["int"]] = None,
+        ins: Optional["int"] = None,
+        p1: Optional["int"] = None,
+        p2: Optional["int"] = None,
+        data1: Optional["bytes"] = None,
+        data2: Optional["bytes"] = None,
     ) -> None:
         self.pd = pd if pd is not None else []
         self.ins = ins
@@ -5276,12 +5063,12 @@ class DebugMoneroDiagAck(protobuf.MessageType):
     def __init__(
         self,
         *,
-        pd: Optional[List[int]] = None,
-        ins: Optional[int] = None,
-        p1: Optional[int] = None,
-        p2: Optional[int] = None,
-        data1: Optional[bytes] = None,
-        data2: Optional[bytes] = None,
+        pd: Optional[List["int"]] = None,
+        ins: Optional["int"] = None,
+        p1: Optional["int"] = None,
+        p2: Optional["int"] = None,
+        data1: Optional["bytes"] = None,
+        data2: Optional["bytes"] = None,
     ) -> None:
         self.pd = pd if pd is not None else []
         self.ins = ins
@@ -5289,6 +5076,219 @@ class DebugMoneroDiagAck(protobuf.MessageType):
         self.p2 = p2
         self.data1 = data1
         self.data2 = data2
+
+
+class MoneroOutputEntry(protobuf.MessageType):
+    MESSAGE_WIRE_TYPE = None
+    FIELDS = {
+        1: protobuf.Field("idx", "uint64", repeated=False, required=False),
+        2: protobuf.Field("key", "MoneroRctKeyPublic", repeated=False, required=False),
+    }
+
+    def __init__(
+        self,
+        *,
+        idx: Optional["int"] = None,
+        key: Optional["MoneroRctKeyPublic"] = None,
+    ) -> None:
+        self.idx = idx
+        self.key = key
+
+
+class MoneroMultisigKLRki(protobuf.MessageType):
+    MESSAGE_WIRE_TYPE = None
+    FIELDS = {
+        1: protobuf.Field("K", "bytes", repeated=False, required=False),
+        2: protobuf.Field("L", "bytes", repeated=False, required=False),
+        3: protobuf.Field("R", "bytes", repeated=False, required=False),
+        4: protobuf.Field("ki", "bytes", repeated=False, required=False),
+    }
+
+    def __init__(
+        self,
+        *,
+        K: Optional["bytes"] = None,
+        L: Optional["bytes"] = None,
+        R: Optional["bytes"] = None,
+        ki: Optional["bytes"] = None,
+    ) -> None:
+        self.K = K
+        self.L = L
+        self.R = R
+        self.ki = ki
+
+
+class MoneroRctKeyPublic(protobuf.MessageType):
+    MESSAGE_WIRE_TYPE = None
+    FIELDS = {
+        1: protobuf.Field("dest", "bytes", repeated=False, required=False),
+        2: protobuf.Field("commitment", "bytes", repeated=False, required=False),
+    }
+
+    def __init__(
+        self,
+        *,
+        dest: Optional["bytes"] = None,
+        commitment: Optional["bytes"] = None,
+    ) -> None:
+        self.dest = dest
+        self.commitment = commitment
+
+
+class MoneroAccountPublicAddress(protobuf.MessageType):
+    MESSAGE_WIRE_TYPE = None
+    FIELDS = {
+        1: protobuf.Field("spend_public_key", "bytes", repeated=False, required=False),
+        2: protobuf.Field("view_public_key", "bytes", repeated=False, required=False),
+    }
+
+    def __init__(
+        self,
+        *,
+        spend_public_key: Optional["bytes"] = None,
+        view_public_key: Optional["bytes"] = None,
+    ) -> None:
+        self.spend_public_key = spend_public_key
+        self.view_public_key = view_public_key
+
+
+class MoneroTransactionData(protobuf.MessageType):
+    MESSAGE_WIRE_TYPE = None
+    FIELDS = {
+        1: protobuf.Field("version", "uint32", repeated=False, required=False),
+        2: protobuf.Field("payment_id", "bytes", repeated=False, required=False),
+        3: protobuf.Field("unlock_time", "uint64", repeated=False, required=False),
+        4: protobuf.Field("outputs", "MoneroTransactionDestinationEntry", repeated=True, required=False),
+        5: protobuf.Field("change_dts", "MoneroTransactionDestinationEntry", repeated=False, required=False),
+        6: protobuf.Field("num_inputs", "uint32", repeated=False, required=False),
+        7: protobuf.Field("mixin", "uint32", repeated=False, required=False),
+        8: protobuf.Field("fee", "uint64", repeated=False, required=False),
+        9: protobuf.Field("account", "uint32", repeated=False, required=False),
+        10: protobuf.Field("minor_indices", "uint32", repeated=True, required=False),
+        11: protobuf.Field("rsig_data", "MoneroTransactionRsigData", repeated=False, required=False),
+        12: protobuf.Field("integrated_indices", "uint32", repeated=True, required=False),
+        13: protobuf.Field("client_version", "uint32", repeated=False, required=False),
+        14: protobuf.Field("hard_fork", "uint32", repeated=False, required=False),
+        15: protobuf.Field("monero_version", "bytes", repeated=False, required=False),
+    }
+
+    def __init__(
+        self,
+        *,
+        outputs: Optional[List["MoneroTransactionDestinationEntry"]] = None,
+        minor_indices: Optional[List["int"]] = None,
+        integrated_indices: Optional[List["int"]] = None,
+        version: Optional["int"] = None,
+        payment_id: Optional["bytes"] = None,
+        unlock_time: Optional["int"] = None,
+        change_dts: Optional["MoneroTransactionDestinationEntry"] = None,
+        num_inputs: Optional["int"] = None,
+        mixin: Optional["int"] = None,
+        fee: Optional["int"] = None,
+        account: Optional["int"] = None,
+        rsig_data: Optional["MoneroTransactionRsigData"] = None,
+        client_version: Optional["int"] = None,
+        hard_fork: Optional["int"] = None,
+        monero_version: Optional["bytes"] = None,
+    ) -> None:
+        self.outputs = outputs if outputs is not None else []
+        self.minor_indices = minor_indices if minor_indices is not None else []
+        self.integrated_indices = integrated_indices if integrated_indices is not None else []
+        self.version = version
+        self.payment_id = payment_id
+        self.unlock_time = unlock_time
+        self.change_dts = change_dts
+        self.num_inputs = num_inputs
+        self.mixin = mixin
+        self.fee = fee
+        self.account = account
+        self.rsig_data = rsig_data
+        self.client_version = client_version
+        self.hard_fork = hard_fork
+        self.monero_version = monero_version
+
+
+class MoneroRingCtSig(protobuf.MessageType):
+    MESSAGE_WIRE_TYPE = None
+    FIELDS = {
+        1: protobuf.Field("txn_fee", "uint64", repeated=False, required=False),
+        2: protobuf.Field("message", "bytes", repeated=False, required=False),
+        3: protobuf.Field("rv_type", "uint32", repeated=False, required=False),
+    }
+
+    def __init__(
+        self,
+        *,
+        txn_fee: Optional["int"] = None,
+        message: Optional["bytes"] = None,
+        rv_type: Optional["int"] = None,
+    ) -> None:
+        self.txn_fee = txn_fee
+        self.message = message
+        self.rv_type = rv_type
+
+
+class MoneroSubAddressIndicesList(protobuf.MessageType):
+    MESSAGE_WIRE_TYPE = None
+    FIELDS = {
+        1: protobuf.Field("account", "uint32", repeated=False, required=False),
+        2: protobuf.Field("minor_indices", "uint32", repeated=True, required=False),
+    }
+
+    def __init__(
+        self,
+        *,
+        minor_indices: Optional[List["int"]] = None,
+        account: Optional["int"] = None,
+    ) -> None:
+        self.minor_indices = minor_indices if minor_indices is not None else []
+        self.account = account
+
+
+class MoneroTransferDetails(protobuf.MessageType):
+    MESSAGE_WIRE_TYPE = None
+    FIELDS = {
+        1: protobuf.Field("out_key", "bytes", repeated=False, required=False),
+        2: protobuf.Field("tx_pub_key", "bytes", repeated=False, required=False),
+        3: protobuf.Field("additional_tx_pub_keys", "bytes", repeated=True, required=False),
+        4: protobuf.Field("internal_output_index", "uint64", repeated=False, required=False),
+        5: protobuf.Field("sub_addr_major", "uint32", repeated=False, required=False),
+        6: protobuf.Field("sub_addr_minor", "uint32", repeated=False, required=False),
+    }
+
+    def __init__(
+        self,
+        *,
+        additional_tx_pub_keys: Optional[List["bytes"]] = None,
+        out_key: Optional["bytes"] = None,
+        tx_pub_key: Optional["bytes"] = None,
+        internal_output_index: Optional["int"] = None,
+        sub_addr_major: Optional["int"] = None,
+        sub_addr_minor: Optional["int"] = None,
+    ) -> None:
+        self.additional_tx_pub_keys = additional_tx_pub_keys if additional_tx_pub_keys is not None else []
+        self.out_key = out_key
+        self.tx_pub_key = tx_pub_key
+        self.internal_output_index = internal_output_index
+        self.sub_addr_major = sub_addr_major
+        self.sub_addr_minor = sub_addr_minor
+
+
+class MoneroExportedKeyImage(protobuf.MessageType):
+    MESSAGE_WIRE_TYPE = None
+    FIELDS = {
+        1: protobuf.Field("iv", "bytes", repeated=False, required=False),
+        3: protobuf.Field("blob", "bytes", repeated=False, required=False),
+    }
+
+    def __init__(
+        self,
+        *,
+        iv: Optional["bytes"] = None,
+        blob: Optional["bytes"] = None,
+    ) -> None:
+        self.iv = iv
+        self.blob = blob
 
 
 class NEMGetAddress(protobuf.MessageType):
@@ -5302,9 +5302,9 @@ class NEMGetAddress(protobuf.MessageType):
     def __init__(
         self,
         *,
-        address_n: Optional[List[int]] = None,
-        network: Optional[int] = None,
-        show_display: Optional[bool] = None,
+        address_n: Optional[List["int"]] = None,
+        network: Optional["int"] = None,
+        show_display: Optional["bool"] = None,
     ) -> None:
         self.address_n = address_n if address_n is not None else []
         self.network = network
@@ -5320,285 +5320,37 @@ class NEMAddress(protobuf.MessageType):
     def __init__(
         self,
         *,
-        address: str,
+        address: "str",
     ) -> None:
         self.address = address
-
-
-class NEMTransactionCommon(protobuf.MessageType):
-    MESSAGE_WIRE_TYPE = None
-    FIELDS = {
-        1: protobuf.Field("address_n", "uint32", repeated=True, required=False),
-        2: protobuf.Field("network", "uint32", repeated=False, required=False),
-        3: protobuf.Field("timestamp", "uint32", repeated=False, required=False),
-        4: protobuf.Field("fee", "uint64", repeated=False, required=False),
-        5: protobuf.Field("deadline", "uint32", repeated=False, required=False),
-        6: protobuf.Field("signer", "bytes", repeated=False, required=False),
-    }
-
-    def __init__(
-        self,
-        *,
-        address_n: Optional[List[int]] = None,
-        network: Optional[int] = None,
-        timestamp: Optional[int] = None,
-        fee: Optional[int] = None,
-        deadline: Optional[int] = None,
-        signer: Optional[bytes] = None,
-    ) -> None:
-        self.address_n = address_n if address_n is not None else []
-        self.network = network
-        self.timestamp = timestamp
-        self.fee = fee
-        self.deadline = deadline
-        self.signer = signer
-
-
-class NEMMosaic(protobuf.MessageType):
-    MESSAGE_WIRE_TYPE = None
-    FIELDS = {
-        1: protobuf.Field("namespace", "string", repeated=False, required=False),
-        2: protobuf.Field("mosaic", "string", repeated=False, required=False),
-        3: protobuf.Field("quantity", "uint64", repeated=False, required=False),
-    }
-
-    def __init__(
-        self,
-        *,
-        namespace: Optional[str] = None,
-        mosaic: Optional[str] = None,
-        quantity: Optional[int] = None,
-    ) -> None:
-        self.namespace = namespace
-        self.mosaic = mosaic
-        self.quantity = quantity
-
-
-class NEMTransfer(protobuf.MessageType):
-    MESSAGE_WIRE_TYPE = None
-    FIELDS = {
-        1: protobuf.Field("recipient", "string", repeated=False, required=False),
-        2: protobuf.Field("amount", "uint64", repeated=False, required=False),
-        3: protobuf.Field("payload", "bytes", repeated=False, required=False),
-        4: protobuf.Field("public_key", "bytes", repeated=False, required=False),
-        5: protobuf.Field("mosaics", NEMMosaic, repeated=True, required=False),
-    }
-
-    def __init__(
-        self,
-        *,
-        mosaics: Optional[List[NEMMosaic]] = None,
-        recipient: Optional[str] = None,
-        amount: Optional[int] = None,
-        payload: Optional[bytes] = None,
-        public_key: Optional[bytes] = None,
-    ) -> None:
-        self.mosaics = mosaics if mosaics is not None else []
-        self.recipient = recipient
-        self.amount = amount
-        self.payload = payload
-        self.public_key = public_key
-
-
-class NEMProvisionNamespace(protobuf.MessageType):
-    MESSAGE_WIRE_TYPE = None
-    FIELDS = {
-        1: protobuf.Field("namespace", "string", repeated=False, required=False),
-        2: protobuf.Field("parent", "string", repeated=False, required=False),
-        3: protobuf.Field("sink", "string", repeated=False, required=False),
-        4: protobuf.Field("fee", "uint64", repeated=False, required=False),
-    }
-
-    def __init__(
-        self,
-        *,
-        namespace: Optional[str] = None,
-        parent: Optional[str] = None,
-        sink: Optional[str] = None,
-        fee: Optional[int] = None,
-    ) -> None:
-        self.namespace = namespace
-        self.parent = parent
-        self.sink = sink
-        self.fee = fee
-
-
-class NEMMosaicDefinition(protobuf.MessageType):
-    MESSAGE_WIRE_TYPE = None
-    FIELDS = {
-        1: protobuf.Field("name", "string", repeated=False, required=False),
-        2: protobuf.Field("ticker", "string", repeated=False, required=False),
-        3: protobuf.Field("namespace", "string", repeated=False, required=False),
-        4: protobuf.Field("mosaic", "string", repeated=False, required=False),
-        5: protobuf.Field("divisibility", "uint32", repeated=False, required=False),
-        6: protobuf.Field("levy", NEMMosaicLevy, repeated=False, required=False),
-        7: protobuf.Field("fee", "uint64", repeated=False, required=False),
-        8: protobuf.Field("levy_address", "string", repeated=False, required=False),
-        9: protobuf.Field("levy_namespace", "string", repeated=False, required=False),
-        10: protobuf.Field("levy_mosaic", "string", repeated=False, required=False),
-        11: protobuf.Field("supply", "uint64", repeated=False, required=False),
-        12: protobuf.Field("mutable_supply", "bool", repeated=False, required=False),
-        13: protobuf.Field("transferable", "bool", repeated=False, required=False),
-        14: protobuf.Field("description", "string", repeated=False, required=False),
-        15: protobuf.Field("networks", "uint32", repeated=True, required=False),
-    }
-
-    def __init__(
-        self,
-        *,
-        networks: Optional[List[int]] = None,
-        name: Optional[str] = None,
-        ticker: Optional[str] = None,
-        namespace: Optional[str] = None,
-        mosaic: Optional[str] = None,
-        divisibility: Optional[int] = None,
-        levy: Optional[NEMMosaicLevy] = None,
-        fee: Optional[int] = None,
-        levy_address: Optional[str] = None,
-        levy_namespace: Optional[str] = None,
-        levy_mosaic: Optional[str] = None,
-        supply: Optional[int] = None,
-        mutable_supply: Optional[bool] = None,
-        transferable: Optional[bool] = None,
-        description: Optional[str] = None,
-    ) -> None:
-        self.networks = networks if networks is not None else []
-        self.name = name
-        self.ticker = ticker
-        self.namespace = namespace
-        self.mosaic = mosaic
-        self.divisibility = divisibility
-        self.levy = levy
-        self.fee = fee
-        self.levy_address = levy_address
-        self.levy_namespace = levy_namespace
-        self.levy_mosaic = levy_mosaic
-        self.supply = supply
-        self.mutable_supply = mutable_supply
-        self.transferable = transferable
-        self.description = description
-
-
-class NEMMosaicCreation(protobuf.MessageType):
-    MESSAGE_WIRE_TYPE = None
-    FIELDS = {
-        1: protobuf.Field("definition", NEMMosaicDefinition, repeated=False, required=False),
-        2: protobuf.Field("sink", "string", repeated=False, required=False),
-        3: protobuf.Field("fee", "uint64", repeated=False, required=False),
-    }
-
-    def __init__(
-        self,
-        *,
-        definition: Optional[NEMMosaicDefinition] = None,
-        sink: Optional[str] = None,
-        fee: Optional[int] = None,
-    ) -> None:
-        self.definition = definition
-        self.sink = sink
-        self.fee = fee
-
-
-class NEMMosaicSupplyChange(protobuf.MessageType):
-    MESSAGE_WIRE_TYPE = None
-    FIELDS = {
-        1: protobuf.Field("namespace", "string", repeated=False, required=False),
-        2: protobuf.Field("mosaic", "string", repeated=False, required=False),
-        3: protobuf.Field("type", NEMSupplyChangeType, repeated=False, required=False),
-        4: protobuf.Field("delta", "uint64", repeated=False, required=False),
-    }
-
-    def __init__(
-        self,
-        *,
-        namespace: Optional[str] = None,
-        mosaic: Optional[str] = None,
-        type: Optional[NEMSupplyChangeType] = None,
-        delta: Optional[int] = None,
-    ) -> None:
-        self.namespace = namespace
-        self.mosaic = mosaic
-        self.type = type
-        self.delta = delta
-
-
-class NEMCosignatoryModification(protobuf.MessageType):
-    MESSAGE_WIRE_TYPE = None
-    FIELDS = {
-        1: protobuf.Field("type", NEMModificationType, repeated=False, required=False),
-        2: protobuf.Field("public_key", "bytes", repeated=False, required=False),
-    }
-
-    def __init__(
-        self,
-        *,
-        type: Optional[NEMModificationType] = None,
-        public_key: Optional[bytes] = None,
-    ) -> None:
-        self.type = type
-        self.public_key = public_key
-
-
-class NEMAggregateModification(protobuf.MessageType):
-    MESSAGE_WIRE_TYPE = None
-    FIELDS = {
-        1: protobuf.Field("modifications", NEMCosignatoryModification, repeated=True, required=False),
-        2: protobuf.Field("relative_change", "sint32", repeated=False, required=False),
-    }
-
-    def __init__(
-        self,
-        *,
-        modifications: Optional[List[NEMCosignatoryModification]] = None,
-        relative_change: Optional[int] = None,
-    ) -> None:
-        self.modifications = modifications if modifications is not None else []
-        self.relative_change = relative_change
-
-
-class NEMImportanceTransfer(protobuf.MessageType):
-    MESSAGE_WIRE_TYPE = None
-    FIELDS = {
-        1: protobuf.Field("mode", NEMImportanceTransferMode, repeated=False, required=False),
-        2: protobuf.Field("public_key", "bytes", repeated=False, required=False),
-    }
-
-    def __init__(
-        self,
-        *,
-        mode: Optional[NEMImportanceTransferMode] = None,
-        public_key: Optional[bytes] = None,
-    ) -> None:
-        self.mode = mode
-        self.public_key = public_key
 
 
 class NEMSignTx(protobuf.MessageType):
     MESSAGE_WIRE_TYPE = 69
     FIELDS = {
-        1: protobuf.Field("transaction", NEMTransactionCommon, repeated=False, required=False),
-        2: protobuf.Field("multisig", NEMTransactionCommon, repeated=False, required=False),
-        3: protobuf.Field("transfer", NEMTransfer, repeated=False, required=False),
+        1: protobuf.Field("transaction", "NEMTransactionCommon", repeated=False, required=False),
+        2: protobuf.Field("multisig", "NEMTransactionCommon", repeated=False, required=False),
+        3: protobuf.Field("transfer", "NEMTransfer", repeated=False, required=False),
         4: protobuf.Field("cosigning", "bool", repeated=False, required=False),
-        5: protobuf.Field("provision_namespace", NEMProvisionNamespace, repeated=False, required=False),
-        6: protobuf.Field("mosaic_creation", NEMMosaicCreation, repeated=False, required=False),
-        7: protobuf.Field("supply_change", NEMMosaicSupplyChange, repeated=False, required=False),
-        8: protobuf.Field("aggregate_modification", NEMAggregateModification, repeated=False, required=False),
-        9: protobuf.Field("importance_transfer", NEMImportanceTransfer, repeated=False, required=False),
+        5: protobuf.Field("provision_namespace", "NEMProvisionNamespace", repeated=False, required=False),
+        6: protobuf.Field("mosaic_creation", "NEMMosaicCreation", repeated=False, required=False),
+        7: protobuf.Field("supply_change", "NEMMosaicSupplyChange", repeated=False, required=False),
+        8: protobuf.Field("aggregate_modification", "NEMAggregateModification", repeated=False, required=False),
+        9: protobuf.Field("importance_transfer", "NEMImportanceTransfer", repeated=False, required=False),
     }
 
     def __init__(
         self,
         *,
-        transaction: Optional[NEMTransactionCommon] = None,
-        multisig: Optional[NEMTransactionCommon] = None,
-        transfer: Optional[NEMTransfer] = None,
-        cosigning: Optional[bool] = None,
-        provision_namespace: Optional[NEMProvisionNamespace] = None,
-        mosaic_creation: Optional[NEMMosaicCreation] = None,
-        supply_change: Optional[NEMMosaicSupplyChange] = None,
-        aggregate_modification: Optional[NEMAggregateModification] = None,
-        importance_transfer: Optional[NEMImportanceTransfer] = None,
+        transaction: Optional["NEMTransactionCommon"] = None,
+        multisig: Optional["NEMTransactionCommon"] = None,
+        transfer: Optional["NEMTransfer"] = None,
+        cosigning: Optional["bool"] = None,
+        provision_namespace: Optional["NEMProvisionNamespace"] = None,
+        mosaic_creation: Optional["NEMMosaicCreation"] = None,
+        supply_change: Optional["NEMMosaicSupplyChange"] = None,
+        aggregate_modification: Optional["NEMAggregateModification"] = None,
+        importance_transfer: Optional["NEMImportanceTransfer"] = None,
     ) -> None:
         self.transaction = transaction
         self.multisig = multisig
@@ -5621,8 +5373,8 @@ class NEMSignedTx(protobuf.MessageType):
     def __init__(
         self,
         *,
-        data: bytes,
-        signature: bytes,
+        data: "bytes",
+        signature: "bytes",
     ) -> None:
         self.data = data
         self.signature = signature
@@ -5640,10 +5392,10 @@ class NEMDecryptMessage(protobuf.MessageType):
     def __init__(
         self,
         *,
-        address_n: Optional[List[int]] = None,
-        network: Optional[int] = None,
-        public_key: Optional[bytes] = None,
-        payload: Optional[bytes] = None,
+        address_n: Optional[List["int"]] = None,
+        network: Optional["int"] = None,
+        public_key: Optional["bytes"] = None,
+        payload: Optional["bytes"] = None,
     ) -> None:
         self.address_n = address_n if address_n is not None else []
         self.network = network
@@ -5660,9 +5412,257 @@ class NEMDecryptedMessage(protobuf.MessageType):
     def __init__(
         self,
         *,
-        payload: bytes,
+        payload: "bytes",
     ) -> None:
         self.payload = payload
+
+
+class NEMTransactionCommon(protobuf.MessageType):
+    MESSAGE_WIRE_TYPE = None
+    FIELDS = {
+        1: protobuf.Field("address_n", "uint32", repeated=True, required=False),
+        2: protobuf.Field("network", "uint32", repeated=False, required=False),
+        3: protobuf.Field("timestamp", "uint32", repeated=False, required=False),
+        4: protobuf.Field("fee", "uint64", repeated=False, required=False),
+        5: protobuf.Field("deadline", "uint32", repeated=False, required=False),
+        6: protobuf.Field("signer", "bytes", repeated=False, required=False),
+    }
+
+    def __init__(
+        self,
+        *,
+        address_n: Optional[List["int"]] = None,
+        network: Optional["int"] = None,
+        timestamp: Optional["int"] = None,
+        fee: Optional["int"] = None,
+        deadline: Optional["int"] = None,
+        signer: Optional["bytes"] = None,
+    ) -> None:
+        self.address_n = address_n if address_n is not None else []
+        self.network = network
+        self.timestamp = timestamp
+        self.fee = fee
+        self.deadline = deadline
+        self.signer = signer
+
+
+class NEMTransfer(protobuf.MessageType):
+    MESSAGE_WIRE_TYPE = None
+    FIELDS = {
+        1: protobuf.Field("recipient", "string", repeated=False, required=False),
+        2: protobuf.Field("amount", "uint64", repeated=False, required=False),
+        3: protobuf.Field("payload", "bytes", repeated=False, required=False),
+        4: protobuf.Field("public_key", "bytes", repeated=False, required=False),
+        5: protobuf.Field("mosaics", "NEMMosaic", repeated=True, required=False),
+    }
+
+    def __init__(
+        self,
+        *,
+        mosaics: Optional[List["NEMMosaic"]] = None,
+        recipient: Optional["str"] = None,
+        amount: Optional["int"] = None,
+        payload: Optional["bytes"] = None,
+        public_key: Optional["bytes"] = None,
+    ) -> None:
+        self.mosaics = mosaics if mosaics is not None else []
+        self.recipient = recipient
+        self.amount = amount
+        self.payload = payload
+        self.public_key = public_key
+
+
+class NEMProvisionNamespace(protobuf.MessageType):
+    MESSAGE_WIRE_TYPE = None
+    FIELDS = {
+        1: protobuf.Field("namespace", "string", repeated=False, required=False),
+        2: protobuf.Field("parent", "string", repeated=False, required=False),
+        3: protobuf.Field("sink", "string", repeated=False, required=False),
+        4: protobuf.Field("fee", "uint64", repeated=False, required=False),
+    }
+
+    def __init__(
+        self,
+        *,
+        namespace: Optional["str"] = None,
+        parent: Optional["str"] = None,
+        sink: Optional["str"] = None,
+        fee: Optional["int"] = None,
+    ) -> None:
+        self.namespace = namespace
+        self.parent = parent
+        self.sink = sink
+        self.fee = fee
+
+
+class NEMMosaicCreation(protobuf.MessageType):
+    MESSAGE_WIRE_TYPE = None
+    FIELDS = {
+        1: protobuf.Field("definition", "NEMMosaicDefinition", repeated=False, required=False),
+        2: protobuf.Field("sink", "string", repeated=False, required=False),
+        3: protobuf.Field("fee", "uint64", repeated=False, required=False),
+    }
+
+    def __init__(
+        self,
+        *,
+        definition: Optional["NEMMosaicDefinition"] = None,
+        sink: Optional["str"] = None,
+        fee: Optional["int"] = None,
+    ) -> None:
+        self.definition = definition
+        self.sink = sink
+        self.fee = fee
+
+
+class NEMMosaicSupplyChange(protobuf.MessageType):
+    MESSAGE_WIRE_TYPE = None
+    FIELDS = {
+        1: protobuf.Field("namespace", "string", repeated=False, required=False),
+        2: protobuf.Field("mosaic", "string", repeated=False, required=False),
+        3: protobuf.Field("type", "NEMSupplyChangeType", repeated=False, required=False),
+        4: protobuf.Field("delta", "uint64", repeated=False, required=False),
+    }
+
+    def __init__(
+        self,
+        *,
+        namespace: Optional["str"] = None,
+        mosaic: Optional["str"] = None,
+        type: Optional["NEMSupplyChangeType"] = None,
+        delta: Optional["int"] = None,
+    ) -> None:
+        self.namespace = namespace
+        self.mosaic = mosaic
+        self.type = type
+        self.delta = delta
+
+
+class NEMAggregateModification(protobuf.MessageType):
+    MESSAGE_WIRE_TYPE = None
+    FIELDS = {
+        1: protobuf.Field("modifications", "NEMCosignatoryModification", repeated=True, required=False),
+        2: protobuf.Field("relative_change", "sint32", repeated=False, required=False),
+    }
+
+    def __init__(
+        self,
+        *,
+        modifications: Optional[List["NEMCosignatoryModification"]] = None,
+        relative_change: Optional["int"] = None,
+    ) -> None:
+        self.modifications = modifications if modifications is not None else []
+        self.relative_change = relative_change
+
+
+class NEMImportanceTransfer(protobuf.MessageType):
+    MESSAGE_WIRE_TYPE = None
+    FIELDS = {
+        1: protobuf.Field("mode", "NEMImportanceTransferMode", repeated=False, required=False),
+        2: protobuf.Field("public_key", "bytes", repeated=False, required=False),
+    }
+
+    def __init__(
+        self,
+        *,
+        mode: Optional["NEMImportanceTransferMode"] = None,
+        public_key: Optional["bytes"] = None,
+    ) -> None:
+        self.mode = mode
+        self.public_key = public_key
+
+
+class NEMMosaic(protobuf.MessageType):
+    MESSAGE_WIRE_TYPE = None
+    FIELDS = {
+        1: protobuf.Field("namespace", "string", repeated=False, required=False),
+        2: protobuf.Field("mosaic", "string", repeated=False, required=False),
+        3: protobuf.Field("quantity", "uint64", repeated=False, required=False),
+    }
+
+    def __init__(
+        self,
+        *,
+        namespace: Optional["str"] = None,
+        mosaic: Optional["str"] = None,
+        quantity: Optional["int"] = None,
+    ) -> None:
+        self.namespace = namespace
+        self.mosaic = mosaic
+        self.quantity = quantity
+
+
+class NEMMosaicDefinition(protobuf.MessageType):
+    MESSAGE_WIRE_TYPE = None
+    FIELDS = {
+        1: protobuf.Field("name", "string", repeated=False, required=False),
+        2: protobuf.Field("ticker", "string", repeated=False, required=False),
+        3: protobuf.Field("namespace", "string", repeated=False, required=False),
+        4: protobuf.Field("mosaic", "string", repeated=False, required=False),
+        5: protobuf.Field("divisibility", "uint32", repeated=False, required=False),
+        6: protobuf.Field("levy", "NEMMosaicLevy", repeated=False, required=False),
+        7: protobuf.Field("fee", "uint64", repeated=False, required=False),
+        8: protobuf.Field("levy_address", "string", repeated=False, required=False),
+        9: protobuf.Field("levy_namespace", "string", repeated=False, required=False),
+        10: protobuf.Field("levy_mosaic", "string", repeated=False, required=False),
+        11: protobuf.Field("supply", "uint64", repeated=False, required=False),
+        12: protobuf.Field("mutable_supply", "bool", repeated=False, required=False),
+        13: protobuf.Field("transferable", "bool", repeated=False, required=False),
+        14: protobuf.Field("description", "string", repeated=False, required=False),
+        15: protobuf.Field("networks", "uint32", repeated=True, required=False),
+    }
+
+    def __init__(
+        self,
+        *,
+        networks: Optional[List["int"]] = None,
+        name: Optional["str"] = None,
+        ticker: Optional["str"] = None,
+        namespace: Optional["str"] = None,
+        mosaic: Optional["str"] = None,
+        divisibility: Optional["int"] = None,
+        levy: Optional["NEMMosaicLevy"] = None,
+        fee: Optional["int"] = None,
+        levy_address: Optional["str"] = None,
+        levy_namespace: Optional["str"] = None,
+        levy_mosaic: Optional["str"] = None,
+        supply: Optional["int"] = None,
+        mutable_supply: Optional["bool"] = None,
+        transferable: Optional["bool"] = None,
+        description: Optional["str"] = None,
+    ) -> None:
+        self.networks = networks if networks is not None else []
+        self.name = name
+        self.ticker = ticker
+        self.namespace = namespace
+        self.mosaic = mosaic
+        self.divisibility = divisibility
+        self.levy = levy
+        self.fee = fee
+        self.levy_address = levy_address
+        self.levy_namespace = levy_namespace
+        self.levy_mosaic = levy_mosaic
+        self.supply = supply
+        self.mutable_supply = mutable_supply
+        self.transferable = transferable
+        self.description = description
+
+
+class NEMCosignatoryModification(protobuf.MessageType):
+    MESSAGE_WIRE_TYPE = None
+    FIELDS = {
+        1: protobuf.Field("type", "NEMModificationType", repeated=False, required=False),
+        2: protobuf.Field("public_key", "bytes", repeated=False, required=False),
+    }
+
+    def __init__(
+        self,
+        *,
+        type: Optional["NEMModificationType"] = None,
+        public_key: Optional["bytes"] = None,
+    ) -> None:
+        self.type = type
+        self.public_key = public_key
 
 
 class RippleGetAddress(protobuf.MessageType):
@@ -5675,8 +5675,8 @@ class RippleGetAddress(protobuf.MessageType):
     def __init__(
         self,
         *,
-        address_n: Optional[List[int]] = None,
-        show_display: Optional[bool] = None,
+        address_n: Optional[List["int"]] = None,
+        show_display: Optional["bool"] = None,
     ) -> None:
         self.address_n = address_n if address_n is not None else []
         self.show_display = show_display
@@ -5691,29 +5691,9 @@ class RippleAddress(protobuf.MessageType):
     def __init__(
         self,
         *,
-        address: str,
+        address: "str",
     ) -> None:
         self.address = address
-
-
-class RipplePayment(protobuf.MessageType):
-    MESSAGE_WIRE_TYPE = None
-    FIELDS = {
-        1: protobuf.Field("amount", "uint64", repeated=False, required=True),
-        2: protobuf.Field("destination", "string", repeated=False, required=True),
-        3: protobuf.Field("destination_tag", "uint32", repeated=False, required=False),
-    }
-
-    def __init__(
-        self,
-        *,
-        amount: int,
-        destination: str,
-        destination_tag: Optional[int] = None,
-    ) -> None:
-        self.amount = amount
-        self.destination = destination
-        self.destination_tag = destination_tag
 
 
 class RippleSignTx(protobuf.MessageType):
@@ -5724,18 +5704,18 @@ class RippleSignTx(protobuf.MessageType):
         3: protobuf.Field("flags", "uint32", repeated=False, required=False),
         4: protobuf.Field("sequence", "uint32", repeated=False, required=False),
         5: protobuf.Field("last_ledger_sequence", "uint32", repeated=False, required=False),
-        6: protobuf.Field("payment", RipplePayment, repeated=False, required=False),
+        6: protobuf.Field("payment", "RipplePayment", repeated=False, required=False),
     }
 
     def __init__(
         self,
         *,
-        address_n: Optional[List[int]] = None,
-        fee: Optional[int] = None,
-        flags: Optional[int] = None,
-        sequence: Optional[int] = None,
-        last_ledger_sequence: Optional[int] = None,
-        payment: Optional[RipplePayment] = None,
+        address_n: Optional[List["int"]] = None,
+        fee: Optional["int"] = None,
+        flags: Optional["int"] = None,
+        sequence: Optional["int"] = None,
+        last_ledger_sequence: Optional["int"] = None,
+        payment: Optional["RipplePayment"] = None,
     ) -> None:
         self.address_n = address_n if address_n is not None else []
         self.fee = fee
@@ -5755,11 +5735,31 @@ class RippleSignedTx(protobuf.MessageType):
     def __init__(
         self,
         *,
-        signature: bytes,
-        serialized_tx: bytes,
+        signature: "bytes",
+        serialized_tx: "bytes",
     ) -> None:
         self.signature = signature
         self.serialized_tx = serialized_tx
+
+
+class RipplePayment(protobuf.MessageType):
+    MESSAGE_WIRE_TYPE = None
+    FIELDS = {
+        1: protobuf.Field("amount", "uint64", repeated=False, required=True),
+        2: protobuf.Field("destination", "string", repeated=False, required=True),
+        3: protobuf.Field("destination_tag", "uint32", repeated=False, required=False),
+    }
+
+    def __init__(
+        self,
+        *,
+        amount: "int",
+        destination: "str",
+        destination_tag: Optional["int"] = None,
+    ) -> None:
+        self.amount = amount
+        self.destination = destination
+        self.destination_tag = destination_tag
 
 
 class StellarAssetType(protobuf.MessageType):
@@ -5773,9 +5773,9 @@ class StellarAssetType(protobuf.MessageType):
     def __init__(
         self,
         *,
-        type: int,
-        code: Optional[str] = None,
-        issuer: Optional[str] = None,
+        type: "int",
+        code: Optional["str"] = None,
+        issuer: Optional["str"] = None,
     ) -> None:
         self.type = type
         self.code = code
@@ -5792,8 +5792,8 @@ class StellarGetAddress(protobuf.MessageType):
     def __init__(
         self,
         *,
-        address_n: Optional[List[int]] = None,
-        show_display: Optional[bool] = None,
+        address_n: Optional[List["int"]] = None,
+        show_display: Optional["bool"] = None,
     ) -> None:
         self.address_n = address_n if address_n is not None else []
         self.show_display = show_display
@@ -5808,7 +5808,7 @@ class StellarAddress(protobuf.MessageType):
     def __init__(
         self,
         *,
-        address: str,
+        address: "str",
     ) -> None:
         self.address = address
 
@@ -5833,18 +5833,18 @@ class StellarSignTx(protobuf.MessageType):
     def __init__(
         self,
         *,
-        address_n: Optional[List[int]] = None,
-        network_passphrase: Optional[str] = None,
-        source_account: Optional[str] = None,
-        fee: Optional[int] = None,
-        sequence_number: Optional[int] = None,
-        timebounds_start: Optional[int] = None,
-        timebounds_end: Optional[int] = None,
-        memo_type: Optional[int] = None,
-        memo_text: Optional[str] = None,
-        memo_id: Optional[int] = None,
-        memo_hash: Optional[bytes] = None,
-        num_operations: Optional[int] = None,
+        address_n: Optional[List["int"]] = None,
+        network_passphrase: Optional["str"] = None,
+        source_account: Optional["str"] = None,
+        fee: Optional["int"] = None,
+        sequence_number: Optional["int"] = None,
+        timebounds_start: Optional["int"] = None,
+        timebounds_end: Optional["int"] = None,
+        memo_type: Optional["int"] = None,
+        memo_text: Optional["str"] = None,
+        memo_id: Optional["int"] = None,
+        memo_hash: Optional["bytes"] = None,
+        num_operations: Optional["int"] = None,
     ) -> None:
         self.address_n = address_n if address_n is not None else []
         self.network_passphrase = network_passphrase
@@ -5869,17 +5869,17 @@ class StellarPaymentOp(protobuf.MessageType):
     FIELDS = {
         1: protobuf.Field("source_account", "string", repeated=False, required=False),
         2: protobuf.Field("destination_account", "string", repeated=False, required=False),
-        3: protobuf.Field("asset", StellarAssetType, repeated=False, required=False),
+        3: protobuf.Field("asset", "StellarAssetType", repeated=False, required=False),
         4: protobuf.Field("amount", "sint64", repeated=False, required=False),
     }
 
     def __init__(
         self,
         *,
-        source_account: Optional[str] = None,
-        destination_account: Optional[str] = None,
-        asset: Optional[StellarAssetType] = None,
-        amount: Optional[int] = None,
+        source_account: Optional["str"] = None,
+        destination_account: Optional["str"] = None,
+        asset: Optional["StellarAssetType"] = None,
+        amount: Optional["int"] = None,
     ) -> None:
         self.source_account = source_account
         self.destination_account = destination_account
@@ -5898,9 +5898,9 @@ class StellarCreateAccountOp(protobuf.MessageType):
     def __init__(
         self,
         *,
-        source_account: Optional[str] = None,
-        new_account: Optional[str] = None,
-        starting_balance: Optional[int] = None,
+        source_account: Optional["str"] = None,
+        new_account: Optional["str"] = None,
+        starting_balance: Optional["int"] = None,
     ) -> None:
         self.source_account = source_account
         self.new_account = new_account
@@ -5911,24 +5911,24 @@ class StellarPathPaymentOp(protobuf.MessageType):
     MESSAGE_WIRE_TYPE = 212
     FIELDS = {
         1: protobuf.Field("source_account", "string", repeated=False, required=False),
-        2: protobuf.Field("send_asset", StellarAssetType, repeated=False, required=False),
+        2: protobuf.Field("send_asset", "StellarAssetType", repeated=False, required=False),
         3: protobuf.Field("send_max", "sint64", repeated=False, required=False),
         4: protobuf.Field("destination_account", "string", repeated=False, required=False),
-        5: protobuf.Field("destination_asset", StellarAssetType, repeated=False, required=False),
+        5: protobuf.Field("destination_asset", "StellarAssetType", repeated=False, required=False),
         6: protobuf.Field("destination_amount", "sint64", repeated=False, required=False),
-        7: protobuf.Field("paths", StellarAssetType, repeated=True, required=False),
+        7: protobuf.Field("paths", "StellarAssetType", repeated=True, required=False),
     }
 
     def __init__(
         self,
         *,
-        paths: Optional[List[StellarAssetType]] = None,
-        source_account: Optional[str] = None,
-        send_asset: Optional[StellarAssetType] = None,
-        send_max: Optional[int] = None,
-        destination_account: Optional[str] = None,
-        destination_asset: Optional[StellarAssetType] = None,
-        destination_amount: Optional[int] = None,
+        paths: Optional[List["StellarAssetType"]] = None,
+        source_account: Optional["str"] = None,
+        send_asset: Optional["StellarAssetType"] = None,
+        send_max: Optional["int"] = None,
+        destination_account: Optional["str"] = None,
+        destination_asset: Optional["StellarAssetType"] = None,
+        destination_amount: Optional["int"] = None,
     ) -> None:
         self.paths = paths if paths is not None else []
         self.source_account = source_account
@@ -5943,8 +5943,8 @@ class StellarManageOfferOp(protobuf.MessageType):
     MESSAGE_WIRE_TYPE = 213
     FIELDS = {
         1: protobuf.Field("source_account", "string", repeated=False, required=False),
-        2: protobuf.Field("selling_asset", StellarAssetType, repeated=False, required=False),
-        3: protobuf.Field("buying_asset", StellarAssetType, repeated=False, required=False),
+        2: protobuf.Field("selling_asset", "StellarAssetType", repeated=False, required=False),
+        3: protobuf.Field("buying_asset", "StellarAssetType", repeated=False, required=False),
         4: protobuf.Field("amount", "sint64", repeated=False, required=False),
         5: protobuf.Field("price_n", "uint32", repeated=False, required=False),
         6: protobuf.Field("price_d", "uint32", repeated=False, required=False),
@@ -5954,13 +5954,13 @@ class StellarManageOfferOp(protobuf.MessageType):
     def __init__(
         self,
         *,
-        source_account: Optional[str] = None,
-        selling_asset: Optional[StellarAssetType] = None,
-        buying_asset: Optional[StellarAssetType] = None,
-        amount: Optional[int] = None,
-        price_n: Optional[int] = None,
-        price_d: Optional[int] = None,
-        offer_id: Optional[int] = None,
+        source_account: Optional["str"] = None,
+        selling_asset: Optional["StellarAssetType"] = None,
+        buying_asset: Optional["StellarAssetType"] = None,
+        amount: Optional["int"] = None,
+        price_n: Optional["int"] = None,
+        price_d: Optional["int"] = None,
+        offer_id: Optional["int"] = None,
     ) -> None:
         self.source_account = source_account
         self.selling_asset = selling_asset
@@ -5975,8 +5975,8 @@ class StellarCreatePassiveOfferOp(protobuf.MessageType):
     MESSAGE_WIRE_TYPE = 214
     FIELDS = {
         1: protobuf.Field("source_account", "string", repeated=False, required=False),
-        2: protobuf.Field("selling_asset", StellarAssetType, repeated=False, required=False),
-        3: protobuf.Field("buying_asset", StellarAssetType, repeated=False, required=False),
+        2: protobuf.Field("selling_asset", "StellarAssetType", repeated=False, required=False),
+        3: protobuf.Field("buying_asset", "StellarAssetType", repeated=False, required=False),
         4: protobuf.Field("amount", "sint64", repeated=False, required=False),
         5: protobuf.Field("price_n", "uint32", repeated=False, required=False),
         6: protobuf.Field("price_d", "uint32", repeated=False, required=False),
@@ -5985,12 +5985,12 @@ class StellarCreatePassiveOfferOp(protobuf.MessageType):
     def __init__(
         self,
         *,
-        source_account: Optional[str] = None,
-        selling_asset: Optional[StellarAssetType] = None,
-        buying_asset: Optional[StellarAssetType] = None,
-        amount: Optional[int] = None,
-        price_n: Optional[int] = None,
-        price_d: Optional[int] = None,
+        source_account: Optional["str"] = None,
+        selling_asset: Optional["StellarAssetType"] = None,
+        buying_asset: Optional["StellarAssetType"] = None,
+        amount: Optional["int"] = None,
+        price_n: Optional["int"] = None,
+        price_d: Optional["int"] = None,
     ) -> None:
         self.source_account = source_account
         self.selling_asset = selling_asset
@@ -6020,18 +6020,18 @@ class StellarSetOptionsOp(protobuf.MessageType):
     def __init__(
         self,
         *,
-        source_account: Optional[str] = None,
-        inflation_destination_account: Optional[str] = None,
-        clear_flags: Optional[int] = None,
-        set_flags: Optional[int] = None,
-        master_weight: Optional[int] = None,
-        low_threshold: Optional[int] = None,
-        medium_threshold: Optional[int] = None,
-        high_threshold: Optional[int] = None,
-        home_domain: Optional[str] = None,
-        signer_type: Optional[int] = None,
-        signer_key: Optional[bytes] = None,
-        signer_weight: Optional[int] = None,
+        source_account: Optional["str"] = None,
+        inflation_destination_account: Optional["str"] = None,
+        clear_flags: Optional["int"] = None,
+        set_flags: Optional["int"] = None,
+        master_weight: Optional["int"] = None,
+        low_threshold: Optional["int"] = None,
+        medium_threshold: Optional["int"] = None,
+        high_threshold: Optional["int"] = None,
+        home_domain: Optional["str"] = None,
+        signer_type: Optional["int"] = None,
+        signer_key: Optional["bytes"] = None,
+        signer_weight: Optional["int"] = None,
     ) -> None:
         self.source_account = source_account
         self.inflation_destination_account = inflation_destination_account
@@ -6051,16 +6051,16 @@ class StellarChangeTrustOp(protobuf.MessageType):
     MESSAGE_WIRE_TYPE = 216
     FIELDS = {
         1: protobuf.Field("source_account", "string", repeated=False, required=False),
-        2: protobuf.Field("asset", StellarAssetType, repeated=False, required=False),
+        2: protobuf.Field("asset", "StellarAssetType", repeated=False, required=False),
         3: protobuf.Field("limit", "uint64", repeated=False, required=False),
     }
 
     def __init__(
         self,
         *,
-        source_account: Optional[str] = None,
-        asset: Optional[StellarAssetType] = None,
-        limit: Optional[int] = None,
+        source_account: Optional["str"] = None,
+        asset: Optional["StellarAssetType"] = None,
+        limit: Optional["int"] = None,
     ) -> None:
         self.source_account = source_account
         self.asset = asset
@@ -6080,11 +6080,11 @@ class StellarAllowTrustOp(protobuf.MessageType):
     def __init__(
         self,
         *,
-        source_account: Optional[str] = None,
-        trusted_account: Optional[str] = None,
-        asset_type: Optional[int] = None,
-        asset_code: Optional[str] = None,
-        is_authorized: Optional[int] = None,
+        source_account: Optional["str"] = None,
+        trusted_account: Optional["str"] = None,
+        asset_type: Optional["int"] = None,
+        asset_code: Optional["str"] = None,
+        is_authorized: Optional["int"] = None,
     ) -> None:
         self.source_account = source_account
         self.trusted_account = trusted_account
@@ -6103,8 +6103,8 @@ class StellarAccountMergeOp(protobuf.MessageType):
     def __init__(
         self,
         *,
-        source_account: Optional[str] = None,
-        destination_account: Optional[str] = None,
+        source_account: Optional["str"] = None,
+        destination_account: Optional["str"] = None,
     ) -> None:
         self.source_account = source_account
         self.destination_account = destination_account
@@ -6121,9 +6121,9 @@ class StellarManageDataOp(protobuf.MessageType):
     def __init__(
         self,
         *,
-        source_account: Optional[str] = None,
-        key: Optional[str] = None,
-        value: Optional[bytes] = None,
+        source_account: Optional["str"] = None,
+        key: Optional["str"] = None,
+        value: Optional["bytes"] = None,
     ) -> None:
         self.source_account = source_account
         self.key = key
@@ -6140,8 +6140,8 @@ class StellarBumpSequenceOp(protobuf.MessageType):
     def __init__(
         self,
         *,
-        source_account: Optional[str] = None,
-        bump_to: Optional[int] = None,
+        source_account: Optional["str"] = None,
+        bump_to: Optional["int"] = None,
     ) -> None:
         self.source_account = source_account
         self.bump_to = bump_to
@@ -6157,8 +6157,8 @@ class StellarSignedTx(protobuf.MessageType):
     def __init__(
         self,
         *,
-        public_key: bytes,
-        signature: bytes,
+        public_key: "bytes",
+        signature: "bytes",
     ) -> None:
         self.public_key = public_key
         self.signature = signature
@@ -6174,8 +6174,8 @@ class TezosGetAddress(protobuf.MessageType):
     def __init__(
         self,
         *,
-        address_n: Optional[List[int]] = None,
-        show_display: Optional[bool] = None,
+        address_n: Optional[List["int"]] = None,
+        show_display: Optional["bool"] = None,
     ) -> None:
         self.address_n = address_n if address_n is not None else []
         self.show_display = show_display
@@ -6190,7 +6190,7 @@ class TezosAddress(protobuf.MessageType):
     def __init__(
         self,
         *,
-        address: str,
+        address: "str",
     ) -> None:
         self.address = address
 
@@ -6205,8 +6205,8 @@ class TezosGetPublicKey(protobuf.MessageType):
     def __init__(
         self,
         *,
-        address_n: Optional[List[int]] = None,
-        show_display: Optional[bool] = None,
+        address_n: Optional[List["int"]] = None,
+        show_display: Optional["bool"] = None,
     ) -> None:
         self.address_n = address_n if address_n is not None else []
         self.show_display = show_display
@@ -6221,9 +6221,81 @@ class TezosPublicKey(protobuf.MessageType):
     def __init__(
         self,
         *,
-        public_key: str,
+        public_key: "str",
     ) -> None:
         self.public_key = public_key
+
+
+class TezosSignTx(protobuf.MessageType):
+    MESSAGE_WIRE_TYPE = 152
+    FIELDS = {
+        1: protobuf.Field("address_n", "uint32", repeated=True, required=False),
+        2: protobuf.Field("branch", "bytes", repeated=False, required=True),
+        3: protobuf.Field("reveal", "TezosRevealOp", repeated=False, required=False),
+        4: protobuf.Field("transaction", "TezosTransactionOp", repeated=False, required=False),
+        5: protobuf.Field("origination", "TezosOriginationOp", repeated=False, required=False),
+        6: protobuf.Field("delegation", "TezosDelegationOp", repeated=False, required=False),
+        7: protobuf.Field("proposal", "TezosProposalOp", repeated=False, required=False),
+        8: protobuf.Field("ballot", "TezosBallotOp", repeated=False, required=False),
+    }
+
+    def __init__(
+        self,
+        *,
+        branch: "bytes",
+        address_n: Optional[List["int"]] = None,
+        reveal: Optional["TezosRevealOp"] = None,
+        transaction: Optional["TezosTransactionOp"] = None,
+        origination: Optional["TezosOriginationOp"] = None,
+        delegation: Optional["TezosDelegationOp"] = None,
+        proposal: Optional["TezosProposalOp"] = None,
+        ballot: Optional["TezosBallotOp"] = None,
+    ) -> None:
+        self.address_n = address_n if address_n is not None else []
+        self.branch = branch
+        self.reveal = reveal
+        self.transaction = transaction
+        self.origination = origination
+        self.delegation = delegation
+        self.proposal = proposal
+        self.ballot = ballot
+
+
+class TezosSignedTx(protobuf.MessageType):
+    MESSAGE_WIRE_TYPE = 153
+    FIELDS = {
+        1: protobuf.Field("signature", "string", repeated=False, required=True),
+        2: protobuf.Field("sig_op_contents", "bytes", repeated=False, required=True),
+        3: protobuf.Field("operation_hash", "string", repeated=False, required=True),
+    }
+
+    def __init__(
+        self,
+        *,
+        signature: "str",
+        sig_op_contents: "bytes",
+        operation_hash: "str",
+    ) -> None:
+        self.signature = signature
+        self.sig_op_contents = sig_op_contents
+        self.operation_hash = operation_hash
+
+
+class TezosContractID(protobuf.MessageType):
+    MESSAGE_WIRE_TYPE = None
+    FIELDS = {
+        1: protobuf.Field("tag", "TezosContractType", repeated=False, required=True),
+        2: protobuf.Field("hash", "bytes", repeated=False, required=True),
+    }
+
+    def __init__(
+        self,
+        *,
+        tag: "TezosContractType",
+        hash: "bytes",
+    ) -> None:
+        self.tag = tag
+        self.hash = hash
 
 
 class TezosRevealOp(protobuf.MessageType):
@@ -6240,12 +6312,12 @@ class TezosRevealOp(protobuf.MessageType):
     def __init__(
         self,
         *,
-        source: bytes,
-        fee: int,
-        counter: int,
-        gas_limit: int,
-        storage_limit: int,
-        public_key: bytes,
+        source: "bytes",
+        fee: "int",
+        counter: "int",
+        gas_limit: "int",
+        storage_limit: "int",
+        public_key: "bytes",
     ) -> None:
         self.source = source
         self.fee = fee
@@ -6253,60 +6325,6 @@ class TezosRevealOp(protobuf.MessageType):
         self.gas_limit = gas_limit
         self.storage_limit = storage_limit
         self.public_key = public_key
-
-
-class TezosContractID(protobuf.MessageType):
-    MESSAGE_WIRE_TYPE = None
-    FIELDS = {
-        1: protobuf.Field("tag", TezosContractType, repeated=False, required=True),
-        2: protobuf.Field("hash", "bytes", repeated=False, required=True),
-    }
-
-    def __init__(
-        self,
-        *,
-        tag: TezosContractType,
-        hash: bytes,
-    ) -> None:
-        self.tag = tag
-        self.hash = hash
-
-
-class TezosManagerTransfer(protobuf.MessageType):
-    MESSAGE_WIRE_TYPE = None
-    FIELDS = {
-        1: protobuf.Field("destination", TezosContractID, repeated=False, required=False),
-        2: protobuf.Field("amount", "uint64", repeated=False, required=False),
-    }
-
-    def __init__(
-        self,
-        *,
-        destination: Optional[TezosContractID] = None,
-        amount: Optional[int] = None,
-    ) -> None:
-        self.destination = destination
-        self.amount = amount
-
-
-class TezosParametersManager(protobuf.MessageType):
-    MESSAGE_WIRE_TYPE = None
-    FIELDS = {
-        1: protobuf.Field("set_delegate", "bytes", repeated=False, required=False),
-        2: protobuf.Field("cancel_delegate", "bool", repeated=False, required=False),
-        3: protobuf.Field("transfer", TezosManagerTransfer, repeated=False, required=False),
-    }
-
-    def __init__(
-        self,
-        *,
-        set_delegate: Optional[bytes] = None,
-        cancel_delegate: Optional[bool] = None,
-        transfer: Optional[TezosManagerTransfer] = None,
-    ) -> None:
-        self.set_delegate = set_delegate
-        self.cancel_delegate = cancel_delegate
-        self.transfer = transfer
 
 
 class TezosTransactionOp(protobuf.MessageType):
@@ -6318,23 +6336,23 @@ class TezosTransactionOp(protobuf.MessageType):
         4: protobuf.Field("gas_limit", "uint64", repeated=False, required=True),
         5: protobuf.Field("storage_limit", "uint64", repeated=False, required=True),
         6: protobuf.Field("amount", "uint64", repeated=False, required=True),
-        7: protobuf.Field("destination", TezosContractID, repeated=False, required=True),
+        7: protobuf.Field("destination", "TezosContractID", repeated=False, required=True),
         8: protobuf.Field("parameters", "bytes", repeated=False, required=False),
-        10: protobuf.Field("parameters_manager", TezosParametersManager, repeated=False, required=False),
+        10: protobuf.Field("parameters_manager", "TezosParametersManager", repeated=False, required=False),
     }
 
     def __init__(
         self,
         *,
-        source: bytes,
-        fee: int,
-        counter: int,
-        gas_limit: int,
-        storage_limit: int,
-        amount: int,
-        destination: TezosContractID,
-        parameters: Optional[bytes] = None,
-        parameters_manager: Optional[TezosParametersManager] = None,
+        source: "bytes",
+        fee: "int",
+        counter: "int",
+        gas_limit: "int",
+        storage_limit: "int",
+        amount: "int",
+        destination: "TezosContractID",
+        parameters: Optional["bytes"] = None,
+        parameters_manager: Optional["TezosParametersManager"] = None,
     ) -> None:
         self.source = source
         self.fee = fee
@@ -6366,17 +6384,17 @@ class TezosOriginationOp(protobuf.MessageType):
     def __init__(
         self,
         *,
-        source: bytes,
-        fee: int,
-        counter: int,
-        gas_limit: int,
-        storage_limit: int,
-        balance: int,
-        script: bytes,
-        manager_pubkey: Optional[bytes] = None,
-        spendable: Optional[bool] = None,
-        delegatable: Optional[bool] = None,
-        delegate: Optional[bytes] = None,
+        source: "bytes",
+        fee: "int",
+        counter: "int",
+        gas_limit: "int",
+        storage_limit: "int",
+        balance: "int",
+        script: "bytes",
+        manager_pubkey: Optional["bytes"] = None,
+        spendable: Optional["bool"] = None,
+        delegatable: Optional["bool"] = None,
+        delegate: Optional["bytes"] = None,
     ) -> None:
         self.source = source
         self.fee = fee
@@ -6405,12 +6423,12 @@ class TezosDelegationOp(protobuf.MessageType):
     def __init__(
         self,
         *,
-        source: bytes,
-        fee: int,
-        counter: int,
-        gas_limit: int,
-        storage_limit: int,
-        delegate: bytes,
+        source: "bytes",
+        fee: "int",
+        counter: "int",
+        gas_limit: "int",
+        storage_limit: "int",
+        delegate: "bytes",
     ) -> None:
         self.source = source
         self.fee = fee
@@ -6431,9 +6449,9 @@ class TezosProposalOp(protobuf.MessageType):
     def __init__(
         self,
         *,
-        proposals: Optional[List[bytes]] = None,
-        source: Optional[bytes] = None,
-        period: Optional[int] = None,
+        proposals: Optional[List["bytes"]] = None,
+        source: Optional["bytes"] = None,
+        period: Optional["int"] = None,
     ) -> None:
         self.proposals = proposals if proposals is not None else []
         self.source = source
@@ -6446,16 +6464,16 @@ class TezosBallotOp(protobuf.MessageType):
         1: protobuf.Field("source", "bytes", repeated=False, required=False),
         2: protobuf.Field("period", "uint64", repeated=False, required=False),
         3: protobuf.Field("proposal", "bytes", repeated=False, required=False),
-        4: protobuf.Field("ballot", TezosBallotType, repeated=False, required=False),
+        4: protobuf.Field("ballot", "TezosBallotType", repeated=False, required=False),
     }
 
     def __init__(
         self,
         *,
-        source: Optional[bytes] = None,
-        period: Optional[int] = None,
-        proposal: Optional[bytes] = None,
-        ballot: Optional[TezosBallotType] = None,
+        source: Optional["bytes"] = None,
+        period: Optional["int"] = None,
+        proposal: Optional["bytes"] = None,
+        ballot: Optional["TezosBallotType"] = None,
     ) -> None:
         self.source = source
         self.period = period
@@ -6463,59 +6481,41 @@ class TezosBallotOp(protobuf.MessageType):
         self.ballot = ballot
 
 
-class TezosSignTx(protobuf.MessageType):
-    MESSAGE_WIRE_TYPE = 152
+class TezosParametersManager(protobuf.MessageType):
+    MESSAGE_WIRE_TYPE = None
     FIELDS = {
-        1: protobuf.Field("address_n", "uint32", repeated=True, required=False),
-        2: protobuf.Field("branch", "bytes", repeated=False, required=True),
-        3: protobuf.Field("reveal", TezosRevealOp, repeated=False, required=False),
-        4: protobuf.Field("transaction", TezosTransactionOp, repeated=False, required=False),
-        5: protobuf.Field("origination", TezosOriginationOp, repeated=False, required=False),
-        6: protobuf.Field("delegation", TezosDelegationOp, repeated=False, required=False),
-        7: protobuf.Field("proposal", TezosProposalOp, repeated=False, required=False),
-        8: protobuf.Field("ballot", TezosBallotOp, repeated=False, required=False),
+        1: protobuf.Field("set_delegate", "bytes", repeated=False, required=False),
+        2: protobuf.Field("cancel_delegate", "bool", repeated=False, required=False),
+        3: protobuf.Field("transfer", "TezosManagerTransfer", repeated=False, required=False),
     }
 
     def __init__(
         self,
         *,
-        branch: bytes,
-        address_n: Optional[List[int]] = None,
-        reveal: Optional[TezosRevealOp] = None,
-        transaction: Optional[TezosTransactionOp] = None,
-        origination: Optional[TezosOriginationOp] = None,
-        delegation: Optional[TezosDelegationOp] = None,
-        proposal: Optional[TezosProposalOp] = None,
-        ballot: Optional[TezosBallotOp] = None,
+        set_delegate: Optional["bytes"] = None,
+        cancel_delegate: Optional["bool"] = None,
+        transfer: Optional["TezosManagerTransfer"] = None,
     ) -> None:
-        self.address_n = address_n if address_n is not None else []
-        self.branch = branch
-        self.reveal = reveal
-        self.transaction = transaction
-        self.origination = origination
-        self.delegation = delegation
-        self.proposal = proposal
-        self.ballot = ballot
+        self.set_delegate = set_delegate
+        self.cancel_delegate = cancel_delegate
+        self.transfer = transfer
 
 
-class TezosSignedTx(protobuf.MessageType):
-    MESSAGE_WIRE_TYPE = 153
+class TezosManagerTransfer(protobuf.MessageType):
+    MESSAGE_WIRE_TYPE = None
     FIELDS = {
-        1: protobuf.Field("signature", "string", repeated=False, required=True),
-        2: protobuf.Field("sig_op_contents", "bytes", repeated=False, required=True),
-        3: protobuf.Field("operation_hash", "string", repeated=False, required=True),
+        1: protobuf.Field("destination", "TezosContractID", repeated=False, required=False),
+        2: protobuf.Field("amount", "uint64", repeated=False, required=False),
     }
 
     def __init__(
         self,
         *,
-        signature: str,
-        sig_op_contents: bytes,
-        operation_hash: str,
+        destination: Optional["TezosContractID"] = None,
+        amount: Optional["int"] = None,
     ) -> None:
-        self.signature = signature
-        self.sig_op_contents = sig_op_contents
-        self.operation_hash = operation_hash
+        self.destination = destination
+        self.amount = amount
 
 
 class WebAuthnListResidentCredentials(protobuf.MessageType):
@@ -6531,7 +6531,7 @@ class WebAuthnAddResidentCredential(protobuf.MessageType):
     def __init__(
         self,
         *,
-        credential_id: Optional[bytes] = None,
+        credential_id: Optional["bytes"] = None,
     ) -> None:
         self.credential_id = credential_id
 
@@ -6545,9 +6545,23 @@ class WebAuthnRemoveResidentCredential(protobuf.MessageType):
     def __init__(
         self,
         *,
-        index: Optional[int] = None,
+        index: Optional["int"] = None,
     ) -> None:
         self.index = index
+
+
+class WebAuthnCredentials(protobuf.MessageType):
+    MESSAGE_WIRE_TYPE = 801
+    FIELDS = {
+        1: protobuf.Field("credentials", "WebAuthnCredential", repeated=True, required=False),
+    }
+
+    def __init__(
+        self,
+        *,
+        credentials: Optional[List["WebAuthnCredential"]] = None,
+    ) -> None:
+        self.credentials = credentials if credentials is not None else []
 
 
 class WebAuthnCredential(protobuf.MessageType):
@@ -6570,18 +6584,18 @@ class WebAuthnCredential(protobuf.MessageType):
     def __init__(
         self,
         *,
-        index: Optional[int] = None,
-        id: Optional[bytes] = None,
-        rp_id: Optional[str] = None,
-        rp_name: Optional[str] = None,
-        user_id: Optional[bytes] = None,
-        user_name: Optional[str] = None,
-        user_display_name: Optional[str] = None,
-        creation_time: Optional[int] = None,
-        hmac_secret: Optional[bool] = None,
-        use_sign_count: Optional[bool] = None,
-        algorithm: Optional[int] = None,
-        curve: Optional[int] = None,
+        index: Optional["int"] = None,
+        id: Optional["bytes"] = None,
+        rp_id: Optional["str"] = None,
+        rp_name: Optional["str"] = None,
+        user_id: Optional["bytes"] = None,
+        user_name: Optional["str"] = None,
+        user_display_name: Optional["str"] = None,
+        creation_time: Optional["int"] = None,
+        hmac_secret: Optional["bool"] = None,
+        use_sign_count: Optional["bool"] = None,
+        algorithm: Optional["int"] = None,
+        curve: Optional["int"] = None,
     ) -> None:
         self.index = index
         self.id = id
@@ -6595,17 +6609,3 @@ class WebAuthnCredential(protobuf.MessageType):
         self.use_sign_count = use_sign_count
         self.algorithm = algorithm
         self.curve = curve
-
-
-class WebAuthnCredentials(protobuf.MessageType):
-    MESSAGE_WIRE_TYPE = 801
-    FIELDS = {
-        1: protobuf.Field("credentials", WebAuthnCredential, repeated=True, required=False),
-    }
-
-    def __init__(
-        self,
-        *,
-        credentials: Optional[List[WebAuthnCredential]] = None,
-    ) -> None:
-        self.credentials = credentials if credentials is not None else []

--- a/python/tests/test_protobuf_misc.py
+++ b/python/tests/test_protobuf_misc.py
@@ -18,7 +18,7 @@ from enum import IntEnum
 
 import pytest
 
-from trezorlib import protobuf
+from trezorlib import messages, protobuf
 
 
 class SimpleEnum(IntEnum):
@@ -34,18 +34,18 @@ class SimpleMessage(protobuf.MessageType):
         3: protobuf.Field("bool", "bool"),
         4: protobuf.Field("bytes", "bytes"),
         5: protobuf.Field("unicode", "string"),
-        6: protobuf.Field("enum", SimpleEnum),
+        6: protobuf.Field("enum", "SimpleEnum"),
         7: protobuf.Field("rep_int", "uint64", repeated=True),
         8: protobuf.Field("rep_str", "string", repeated=True),
-        9: protobuf.Field("rep_enum", SimpleEnum, repeated=True),
+        9: protobuf.Field("rep_enum", "SimpleEnum", repeated=True),
     }
 
 
 class NestedMessage(protobuf.MessageType):
     FIELDS = {
         1: protobuf.Field("scalar", "uint64"),
-        2: protobuf.Field("nested", SimpleMessage),
-        3: protobuf.Field("repeated", SimpleMessage, repeated=True),
+        2: protobuf.Field("nested", "SimpleMessage"),
+        3: protobuf.Field("repeated", "SimpleMessage", repeated=True),
     }
 
 
@@ -53,6 +53,13 @@ class RequiredFields(protobuf.MessageType):
     FIELDS = {
         1: protobuf.Field("scalar", "uint64", required=True),
     }
+
+
+# message types are read from the messages module so we need to "include" these messages there for now
+messages.SimpleEnum = SimpleEnum
+messages.SimpleMessage = SimpleMessage
+messages.NestedMessage = NestedMessage
+messages.RequiredFields = RequiredFields
 
 
 def test_get_field():


### PR DESCRIPTION
Hello, I'm currently implementing the next Cardano updates. As a part of this I've come upon an issue I was able to solve but since it touches `pb2py` and the mako templates I would appreciate your feedback on the proposed solution or perhaps you will be able to come up with a more elegant solution.

The issue is that I'm adding a recursive protobuf message to `messages-cardano.proto`:
```
message CardanoScript {
    required CardanoScriptType type = 1;
    repeated CardanoScript scripts = 2;

    optional bytes key_hash = 3;
    repeated uint32 key_path = 4;
    optional uint32 required_signatures_count = 5;
    optional uint64 invalid_before = 6;
    optional uint64 invalid_hereafter = 7;
}
```
Without any changes `pb2py` gets stuck in an infinte loop - I've fixed that [here](https://github.com/trezor/trezor-firmware/pull/1706/files#diff-c20641a3c126c8673a1b3524439ddcb77cb667475f6381820eb3cb4ec567c314R402). Then when the message is already generated Python and mypy don't recognize the type of the recursive fields since it's nested in the class. So I've updated the templates to wrap recursive types in double quotes. I couldn't do the same thing for the types in the `FIELDS` field since the type of the field would then get interpreted as a string in `trezorlib/protobuf.py:L163`. That's why I've moved the `FIELDS` declaration after the recursive class declaration in the trezorlib template so that the recursive type would be recognized.