### PR TITLE
feat(core/emulator): support protobuf messages in memory dumps

### DIFF
--- a/core/embed/rust/librust.h
+++ b/core/embed/rust/librust.h
@@ -6,3 +6,8 @@ mp_obj_t protobuf_decode(mp_obj_t buf, mp_obj_t def,
                          mp_obj_t enable_experimental);
 mp_obj_t protobuf_len(mp_obj_t obj);
 mp_obj_t protobuf_encode(mp_obj_t buf, mp_obj_t obj);
+
+#ifdef TREZOR_EMULATOR
+mp_obj_t protobuf_debug_msg_type();
+mp_obj_t protobuf_debug_msg_def_type();
+#endif

--- a/core/embed/rust/src/protobuf/obj.rs
+++ b/core/embed/rust/src/protobuf/obj.rs
@@ -262,3 +262,13 @@ unsafe extern "C" fn msg_def_obj_is_type_of(self_in: Obj, obj: Obj) -> Obj {
 }
 
 static MSG_DEF_OBJ_IS_TYPE_OF_OBJ: ffi::mp_obj_fun_builtin_fixed_t = obj_fn_2!(msg_def_obj_is_type_of);
+
+#[no_mangle]
+pub extern "C" fn protobuf_debug_msg_type() -> &'static Type {
+    MsgObj::obj_type()
+}
+
+#[no_mangle]
+pub extern "C" fn protobuf_debug_msg_def_type() -> &'static Type {
+    MsgDefObj::obj_type()
+}

--- a/core/tools/analyze-memory-dump.py
+++ b/core/tools/analyze-memory-dump.py
@@ -56,6 +56,10 @@ def ptr_or_shortval(maybe_ptr):
         return maybe_ptr["shortval"]
 
 
+def is_ignored_ptr(ptr):
+    return (ptr == "(nil)" or ptr.startswith("0x5") or ptr.startswith("0x6"))
+
+
 def deref_or_shortval(maybe_ptr):
     if is_ptr(maybe_ptr) and maybe_ptr in MEMORY:
         return MEMORY[maybe_ptr]
@@ -154,7 +158,7 @@ allobjs.sort(key=lambda x: x.ptr)
 min_ptr = min(
     item.ptrval()
     for item in allobjs
-    if item.ptr != "(nil)" and not item.ptr.startswith("0x5")
+    if not is_ignored_ptr(item.ptr)
 )
 max_ptr = max(item.ptrval() for item in allobjs if item.ptr != "(nil)")
 
@@ -188,6 +192,8 @@ types = {
     "rawbuffer": "R",
     "qstrpool": "Q",
     "qstrdata": "q",
+    "protomsg": "P",
+    "protodef": "p",
 }
 
 pixels_per_line = len(
@@ -207,7 +213,7 @@ def pixel_index(ptrval):
 for item in MEMORY.values():
     if item.alloc == 0:
         continue
-    if item.ptr.startswith("0x5"):
+    if is_ignored_ptr(item.ptr):
         continue
     ptridx = pixel_index(item.ptrval())
     assert ptridx >= 0, item.item
@@ -217,7 +223,7 @@ for item in MEMORY.values():
 for item in MEMORY.values():
     if item.alloc > 0:
         continue
-    if item.ptr == "(nil)" or item.ptr.startswith("0x5"):
+    if is_ignored_ptr(item.ptr):
         continue
     ptridx = pixel_index(item.ptrval())
     if ptridx < 0:


### PR DESCRIPTION
Followup of #1557. Not sure whether shortval is the right place for the message name.