### PR TITLE
core: explicitly refresh display on T1

### DIFF
--- a/core/embed/extmod/modtrezorui/display-stm32_1.h
+++ b/core/embed/extmod/modtrezorui/display-stm32_1.h
@@ -66,6 +66,8 @@ static struct {
   } pos;
 } PIXELWINDOW;
 
+static bool pixeldata_dirty = true;
+
 void PIXELDATA(uint16_t c) {
   if (PIXELWINDOW.pos.x <= PIXELWINDOW.end.x &&
       PIXELWINDOW.pos.y <= PIXELWINDOW.end.y) {
@@ -86,6 +88,8 @@ void PIXELDATA(uint16_t c) {
     PIXELWINDOW.pos.y++;
   }
 }
+
+void PIXELDATA_DIRTY() { pixeldata_dirty = true; }
 
 static void display_set_window(uint16_t x0, uint16_t y0, uint16_t x1,
                                uint16_t y1) {
@@ -223,6 +227,11 @@ void display_refresh(void) {
   static const uint8_t s[3] = {OLED_SETLOWCOLUMN | 0x00,
                                OLED_SETHIGHCOLUMN | 0x00,
                                OLED_SETSTARTLINE | 0x00};
+
+  if (!pixeldata_dirty) {
+    return;
+  }
+  pixeldata_dirty = false;
 
   HAL_GPIO_WritePin(OLED_CS_PORT, OLED_CS_PIN, GPIO_PIN_RESET);  // SPI select
   spi_send(s, 3);

--- a/core/embed/extmod/modtrezorui/display-stm32_T.h
+++ b/core/embed/extmod/modtrezorui/display-stm32_T.h
@@ -39,6 +39,9 @@ const volatile uint8_t DISPLAY_ST7789V_INVERT_COLORS = 0;
   DATA((X) >> 8);    \
   DATA((X)&0xFF)
 
+// noop on TT as we don't need to push data to display
+#define PIXELDATA_DIRTY()
+
 #define LED_PWM_TIM_PERIOD (10000)
 
 // section "9.1.3 RDDID (04h): Read Display ID"

--- a/core/embed/extmod/modtrezorui/display-unix.h
+++ b/core/embed/extmod/modtrezorui/display-unix.h
@@ -71,6 +71,9 @@ static struct {
   } pos;
 } PIXELWINDOW;
 
+// noop on unix, display is refreshed every loop step
+#define PIXELDATA_DIRTY()
+
 void PIXELDATA(uint16_t c) {
 #if TREZOR_MODEL == 1
   // set to white if highest bits of all R, G, B values are set to 1

--- a/core/embed/extmod/modtrezorui/display.c
+++ b/core/embed/extmod/modtrezorui/display.c
@@ -128,6 +128,8 @@ void display_clear(void) {
   display_set_window(0, 0, DISPLAY_RESX - 1, DISPLAY_RESY - 1);
   // if valid, go back to the saved orientation
   display_orientation(saved_orientation);
+  // flag display for refresh
+  PIXELDATA_DIRTY();
 }
 
 void display_bar(int x, int y, int w, int h, uint16_t c) {
@@ -139,6 +141,7 @@ void display_bar(int x, int y, int w, int h, uint16_t c) {
   for (int i = 0; i < (x1 - x0 + 1) * (y1 - y0 + 1); i++) {
     PIXELDATA(c);
   }
+  PIXELDATA_DIRTY();
 }
 
 #define CORNER_RADIUS 16
@@ -196,6 +199,7 @@ void display_bar_radius(int x, int y, int w, int h, uint16_t c, uint16_t b,
       }
     }
   }
+  PIXELDATA_DIRTY();
 }
 
 #define UZLIB_WINDOW_SIZE (1 << 10)
@@ -234,6 +238,7 @@ void display_image(int x, int y, int w, int h, const void *data,
   uzlib_prepare(&decomp, decomp_window, data, datalen, decomp_out,
                 sizeof(decomp_out));
 
+  PIXELDATA_DIRTY();
   for (uint32_t pos = 0; pos < w * h; pos++) {
     int st = uzlib_uncompress(&decomp);
     if (st == TINF_DONE) break;  // all OK
@@ -310,6 +315,7 @@ void display_avatar(int x, int y, const void *data, uint32_t datalen,
     }
     decomp.dest = (uint8_t *)&decomp_out;
   }
+  PIXELDATA_DIRTY();
 #endif
 }
 
@@ -347,6 +353,7 @@ void display_icon(int x, int y, int w, int h, const void *data,
     }
     decomp.dest = (uint8_t *)&decomp_out;
   }
+  PIXELDATA_DIRTY();
 }
 
 // see docs/misc/toif.md for definition of the TOIF format
@@ -471,6 +478,7 @@ void display_loader(uint16_t progress, bool indeterminate, int yoffset,
       }
     }
   }
+  PIXELDATA_DIRTY();
 #endif
 }
 
@@ -553,6 +561,7 @@ void display_print(const char *text, int textlen) {
       PIXELDATA(display_print_bgcolor);
     }
   }
+  PIXELDATA_DIRTY();
   display_refresh();
 }
 
@@ -704,6 +713,7 @@ static void display_text_render(int x, int y, const char *text, int textlen,
     }
     x += adv;
   }
+  PIXELDATA_DIRTY();
 }
 
 void display_text(int x, int y, const char *text, int textlen, int font,
@@ -822,6 +832,7 @@ void display_qrcode(int x, int y, const char *data, uint32_t datalen,
       }
     }
   }
+  PIXELDATA_DIRTY();
 }
 
 void display_offset(int set_xy[2], int *get_x, int *get_y) {

--- a/core/src/trezor/ui/__init__.py
+++ b/core/src/trezor/ui/__init__.py
@@ -48,7 +48,7 @@ else:
 
 
 # in both debug and production, emulator needs to draw the screen explicitly
-if utils.EMULATOR:
+if utils.EMULATOR or utils.MODEL == "1":
     loop.after_step_hook = refresh
 
 


### PR DESCRIPTION
It is my understanding that we need to explicitly push pixel data to the OLED display on T1, while the TT display is mapped to memory and does not need to be told about changes.

Such explicit refresh is already implemented for emulator where it is invoked after every event loop step. This patch mostly adds tracking whether the pixel contents were modified since last refresh so that we don't spend time redrawing display needlessly.