### PR TITLE
fix(ci): gh actions set to fetch all history for changelog check

### DIFF
--- a/.github/workflows/prebuild.yml
+++ b/.github/workflows/prebuild.yml
@@ -50,5 +50,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2.3.4
+        with:
+          fetch-depth: 0
         name: "Run check changelog"
       - run: ./ci/check_changelog.sh


### PR DESCRIPTION
Set to fetch all history for GitHub actions changelog check. Possible fix for changelog script not working correctly on GitHub actions.