### PR TITLE
docs(python): update changelog for 0.12.3

### DIFF
--- a/python/.changelog.d/1167.changed
+++ b/python/.changelog.d/1167.changed
@@ -1,1 +1,0 @@
-Support long PIN of up to 50 digits.

--- a/python/.changelog.d/1193.added
+++ b/python/.changelog.d/1193.added
@@ -1,1 +1,0 @@
-Support for temporary or permanent `safety-checks` setting

--- a/python/.changelog.d/1232.fixed
+++ b/python/.changelog.d/1232.fixed
@@ -1,1 +1,0 @@
-added missing dependency on `attrs`

--- a/python/.changelog.d/1257.fixed
+++ b/python/.changelog.d/1257.fixed
@@ -1,1 +1,0 @@
-fixed number imprecision in `build_tx.py` that could cause "invalid prevhash" errors

--- a/python/.changelog.d/1363.added
+++ b/python/.changelog.d/1363.added
@@ -1,1 +1,0 @@
-Support for Output Descriptors export

--- a/python/.changelog.d/1496.added
+++ b/python/.changelog.d/1496.added
@@ -1,1 +1,0 @@
-PIN entry via letters

--- a/python/.changelog.d/1682.changed
+++ b/python/.changelog.d/1682.changed
@@ -1,1 +1,0 @@
-Allow using Click v8.x

--- a/python/.changelog.d/1738.added
+++ b/python/.changelog.d/1738.added
@@ -1,1 +1,0 @@
-trezorctl: new command `device reboot-to-bootloader` reboots T1 to bootloader

--- a/python/CHANGELOG.md
+++ b/python/CHANGELOG.md
@@ -5,6 +5,30 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.12.3] - 2021-07-29
+[0.12.3]: https://github.com/trezor/trezor-firmware/compare/python/v0.12.2...python/v0.12.3
+
+### Added
+
+- `trezorctl btc get-descriptor` support [#1363]
+- `trezorctl btc reboot-to-bootloader` support [#1738]
+- distinguishing between temporary and permanent safety checks
+- trezorctl accepts PIN entered by letters (useful on laptops)
+- support for 50-digit PIN for T1
+
+### Changed
+
+- allowed Click 8.x as a requirement
+- replaced all references to Trezor Wallet with Trezor Suite, and modified all mentions
+  of Beta Wallet
+
+### Fixed
+
+- added missing requirement `attrs`
+- properly parse big numbers in `tools/build_tx.py` [#1257], [#1296]
+- it is now possible to set safety checks for T1
+
+
 ## [0.12.2] - 2020-08-27
 [0.12.2]: https://github.com/trezor/trezor-firmware/compare/python/v0.12.1...python/v0.12.2
 
@@ -479,3 +503,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 [#1179]: https://github.com/trezor/trezor-firmware/issues/1179
 [#1196]: https://github.com/trezor/trezor-firmware/issues/1196
 [#1210]: https://github.com/trezor/trezor-firmware/issues/1210
+[#1257]: https://github.com/trezor/trezor-firmware/issues/1257
+[#1296]: https://github.com/trezor/trezor-firmware/issues/1296
+[#1363]: https://github.com/trezor/trezor-firmware/issues/1363
+[#1738]: https://github.com/trezor/trezor-firmware/issues/1738


### PR DESCRIPTION
Merge changelog entries from branch python/v0.12.x, delete towncrier snippets that were already included.