### PR TITLE
Testsuite improvements

### DIFF
--- a/python/.changelog.d/1565.added
+++ b/python/.changelog.d/1565.added
@@ -1,1 +1,0 @@
-Wait up to 1 second for emulator responses.

--- a/python/.changelog.d/1668.changed
+++ b/python/.changelog.d/1668.changed
@@ -1,0 +1,1 @@
+`UdpTransport.wait_until_ready` no longer sets socket to nonblocking

--- a/python/src/trezorlib/debuglink.py
+++ b/python/src/trezorlib/debuglink.py
@@ -407,6 +407,9 @@ class TrezorClientDebugLink(TrezorClient):
 
         Useful for test scenarios with an active malicious actor on the wire.
         """
+        if not self.in_with_statement:
+            raise RuntimeError("Must be called inside 'with' statement")
+
         self.filters[message_type] = callback
 
     def _filter_message(self, msg):
@@ -477,6 +480,7 @@ class TrezorClientDebugLink(TrezorClient):
 
         self.in_with_statement -= 1
         self.ui.clear()
+        self.filters.clear()
         self.watch_layout(False)
 
         if _type is not None:

--- a/python/src/trezorlib/debuglink.py
+++ b/python/src/trezorlib/debuglink.py
@@ -374,18 +374,20 @@ class TrezorClientDebugLink(TrezorClient):
             else:
                 raise
 
-        self.ui = DebugUI(self.debug)
-
-        self.in_with_statement = 0
-        self.screenshot_id = 0
-
-        self.filters = {}
-
-        # Do not expect any specific response from device
-        self.expected_responses = None
-        self.actual_responses = None
+        self.reset_debug_features()
 
         super().__init__(transport, ui=self.ui)
+
+    def reset_debug_features(self):
+        """Prepare the debugging client for a new testcase.
+
+        Clears all debugging state that might have been modified by a testcase.
+        """
+        self.ui = DebugUI(self.debug)
+        self.in_with_statement = False
+        self.expected_responses = None
+        self.actual_responses = None
+        self.filters = {}
 
     def open(self):
         super().open()
@@ -470,31 +472,24 @@ class TrezorClientDebugLink(TrezorClient):
 
     def __enter__(self):
         # For usage in with/expected_responses
-        self.in_with_statement += 1
-        if self.in_with_statement > 1:
+        if self.in_with_statement:
             raise RuntimeError("Do not nest!")
+        self.in_with_statement = True
         return self
 
-    def __exit__(self, _type, value, traceback):
+    def __exit__(self, exc_type, value, traceback):
         __tracebackhide__ = True  # for pytest # pylint: disable=W0612
 
-        self.in_with_statement -= 1
-        self.ui.clear()
-        self.filters.clear()
         self.watch_layout(False)
+        # copy expected/actual responses before clearing them
+        expected_responses = self.expected_responses
+        actual_responses = self.actual_responses
+        self.reset_debug_features()
 
-        if _type is not None:
-            # Another exception raised
-            return False
-
-        try:
-            # Evaluate missed responses in 'with' statement
-            self._verify_responses(self.expected_responses, self.actual_responses)
-        finally:
-            self.expected_responses = None
-            self.actual_responses = None
-
-        return False
+        if exc_type is None:
+            # If no other exception was raised, evaluate missed responses
+            # (raises AssertionError on mismatch)
+            self._verify_responses(expected_responses, actual_responses)
 
     def set_expected_responses(self, expected):
         """Set a sequence of expected responses to client calls.
@@ -561,7 +556,8 @@ class TrezorClientDebugLink(TrezorClient):
     def _raw_write(self, msg):
         return super()._raw_write(self._filter_message(msg))
 
-    def _expectation_lines(self, expected, current):
+    @staticmethod
+    def _expectation_lines(expected, current):
         start_at = max(current - EXPECTED_RESPONSES_CONTEXT_LINES, 0)
         stop_at = min(current + EXPECTED_RESPONSES_CONTEXT_LINES + 1, len(expected))
         output = []
@@ -579,7 +575,8 @@ class TrezorClientDebugLink(TrezorClient):
         output.append("")
         return output
 
-    def _verify_responses(self, expected, actual):
+    @classmethod
+    def _verify_responses(cls, expected, actual):
         __tracebackhide__ = True  # for pytest # pylint: disable=W0612
 
         if expected is None and actual is None:
@@ -587,7 +584,7 @@ class TrezorClientDebugLink(TrezorClient):
 
         for i, (exp, act) in enumerate(zip_longest(expected, actual)):
             if exp is None:
-                output = self._expectation_lines(expected, i)
+                output = cls._expectation_lines(expected, i)
                 output.append("No more messages were expected, but we got:")
                 for resp in actual[i:]:
                     output.append(
@@ -596,12 +593,12 @@ class TrezorClientDebugLink(TrezorClient):
                 raise AssertionError("\n".join(output))
 
             if act is None:
-                output = self._expectation_lines(expected, i)
+                output = cls._expectation_lines(expected, i)
                 output.append("This and the following message was not received.")
                 raise AssertionError("\n".join(output))
 
             if not exp.match(act):
-                output = self._expectation_lines(expected, i)
+                output = cls._expectation_lines(expected, i)
                 output.append("Actually received:")
                 output.append(textwrap.indent(protobuf.format_message(act), "    "))
                 raise AssertionError("\n".join(output))

--- a/python/src/trezorlib/transport/udp.py
+++ b/python/src/trezorlib/transport/udp.py
@@ -91,7 +91,6 @@ class UdpTransport(ProtocolBasedTransport):
     def wait_until_ready(self, timeout: float = 10) -> None:
         try:
             self.open()
-            self.socket.settimeout(0)
             start = time.monotonic()
             while True:
                 if self._ping():

--- a/python/src/trezorlib/transport/udp.py
+++ b/python/src/trezorlib/transport/udp.py
@@ -24,7 +24,6 @@ from . import TransportException
 from .protocol import ProtocolBasedTransport, ProtocolV1
 
 SOCKET_TIMEOUT = 10
-TRY_PATH_TIMEOUT = 1
 
 LOG = logging.getLogger(__name__)
 
@@ -60,12 +59,15 @@ class UdpTransport(ProtocolBasedTransport):
     def _try_path(cls, path: str) -> "UdpTransport":
         d = cls(path)
         try:
-            d.wait_until_ready(timeout=TRY_PATH_TIMEOUT)
-            return d
-        except Exception as e:
-            raise TransportException(
-                "No Trezor device found at address {}".format(d.get_path())
-            ) from e
+            d.open()
+            if d._ping():
+                return d
+            else:
+                raise TransportException(
+                    "No Trezor device found at address {}".format(d.get_path())
+                )
+        finally:
+            d.close()
 
     @classmethod
     def enumerate(cls) -> Iterable["UdpTransport"]:

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -28,7 +28,8 @@ from .device_handler import BackgroundDeviceHandler
 from .ui_tests.reporting import testreport
 
 
-def get_device():
+@pytest.fixture(scope="session")
+def _raw_client(request):
     path = os.environ.get("TREZOR_PATH")
     interact = int(os.environ.get("INTERACT", 0))
     if path:
@@ -36,6 +37,7 @@ def get_device():
             transport = get_transport(path)
             return TrezorClientDebugLink(transport, auto_interact=not interact)
         except Exception as e:
+            request.session.shouldstop = "Failed to communicate with Trezor"
             raise RuntimeError("Failed to open debuglink for {}".format(path)) from e
 
     else:
@@ -46,11 +48,12 @@ def get_device():
             except Exception:
                 pass
         else:
+            request.session.shouldstop = "Failed to communicate with Trezor"
             raise RuntimeError("No debuggable device found")
 
 
 @pytest.fixture(scope="function")
-def client(request):
+def client(request, _raw_client):
     """Client fixture.
 
     Every test function that requires a client instance will get it from here.
@@ -70,19 +73,13 @@ def client(request):
 
     @pytest.mark.setup_client(uninitialized=True)
     """
-    try:
-        client = get_device()
-    except RuntimeError:
-        request.session.shouldstop = "No debuggable Trezor is available"
-        pytest.fail("No debuggable Trezor is available")
-
-    if request.node.get_closest_marker("skip_t2") and client.features.model == "T":
+    if request.node.get_closest_marker("skip_t2") and _raw_client.features.model == "T":
         pytest.skip("Test excluded on Trezor T")
-    if request.node.get_closest_marker("skip_t1") and client.features.model == "1":
+    if request.node.get_closest_marker("skip_t1") and _raw_client.features.model == "1":
         pytest.skip("Test excluded on Trezor 1")
 
     sd_marker = request.node.get_closest_marker("sd_card")
-    if sd_marker and not client.features.sd_card_present:
+    if sd_marker and not _raw_client.features.sd_card_present:
         raise RuntimeError(
             "This test requires SD card.\n"
             "To skip all such tests, run:\n"
@@ -92,16 +89,23 @@ def client(request):
     test_ui = request.config.getoption("ui")
     run_ui_tests = not request.node.get_closest_marker("skip_ui") and test_ui
 
-    client.open()
+    _raw_client.reset_debug_features()
+    _raw_client.open()
+    try:
+        _raw_client.init_device()
+    except Exception:
+        request.session.shouldstop = "Failed to communicate with Trezor"
+        pytest.fail("Failed to communicate with Trezor")
+
     if run_ui_tests:
         # we need to reseed before the wipe
-        client.debug.reseed(0)
+        _raw_client.debug.reseed(0)
 
     if sd_marker:
         should_format = sd_marker.kwargs.get("formatted", True)
-        client.debug.erase_sd_card(format=should_format)
+        _raw_client.debug.erase_sd_card(format=should_format)
 
-    wipe_device(client)
+    wipe_device(_raw_client)
 
     setup_params = dict(
         uninitialized=False,
@@ -122,7 +126,7 @@ def client(request):
 
     if not setup_params["uninitialized"]:
         debuglink.load_device(
-            client,
+            _raw_client,
             mnemonic=setup_params["mnemonic"],
             pin=setup_params["pin"],
             passphrase_protection=use_passphrase,
@@ -132,21 +136,21 @@ def client(request):
             no_backup=setup_params["no_backup"],
         )
 
-        if client.features.model == "T":
-            apply_settings(client, experimental_features=True)
+        if _raw_client.features.model == "T":
+            apply_settings(_raw_client, experimental_features=True)
 
         if use_passphrase and isinstance(setup_params["passphrase"], str):
-            client.use_passphrase(setup_params["passphrase"])
+            _raw_client.use_passphrase(setup_params["passphrase"])
 
-        client.clear_session()
+        _raw_client.clear_session()
 
     if run_ui_tests:
-        with ui_tests.screen_recording(client, request):
-            yield client
+        with ui_tests.screen_recording(_raw_client, request):
+            yield _raw_client
     else:
-        yield client
+        yield _raw_client
 
-    client.close()
+    _raw_client.close()
 
 
 def pytest_sessionstart(session):

--- a/tests/device_tests/test_msg_recoverydevice_bip39.py
+++ b/tests/device_tests/test_msg_recoverydevice_bip39.py
@@ -68,8 +68,6 @@ class TestMsgRecoverydevice:
                 ret = client.call_raw(proto.WordAck(word=word))
                 fakes += 1
 
-            print(mnemonic)
-
         # Workflow succesfully ended
         assert isinstance(ret, proto.Success)
 
@@ -119,8 +117,6 @@ class TestMsgRecoverydevice:
             else:
                 ret = client.call_raw(proto.WordAck(word=word))
                 fakes += 1
-
-            print(mnemonic)
 
         # Workflow succesfully ended
         assert isinstance(ret, proto.Success)

--- a/tests/device_tests/test_msg_signidentity.py
+++ b/tests/device_tests/test_msg_signidentity.py
@@ -14,37 +14,11 @@
 # You should have received a copy of the License along with this library.
 # If not, see <https://www.gnu.org/licenses/lgpl-3.0.html>.
 
-import struct
-
 import pytest
 
 from trezorlib import messages as proto, misc
-from trezorlib.tools import H_
 
 from ..common import MNEMONIC12
-
-
-def check_path(identity):
-    from hashlib import sha256
-
-    m = sha256()
-    m.update(struct.pack("<I", identity.index))
-    uri = ""
-    if identity.proto:
-        uri += identity.proto + "://"
-    if identity.user:
-        uri += identity.user + "@"
-    if identity.host:
-        uri += identity.host
-    if identity.port:
-        uri += ":" + identity.port
-    if identity.path:
-        uri += identity.path
-    m.update(uri)
-    print("hash:", m.hexdigest())
-    (a, b, c, d, _, _, _, _) = struct.unpack("<8I", m.digest())
-    address_n = [H_(13), H_(a), H_(b), H_(c), H_(d)]
-    print("path:", "m/" + "/".join([str(x) for x in address_n]))
 
 
 class TestMsgSignidentity:

--- a/tests/device_tests/test_msg_signtx.py
+++ b/tests/device_tests/test_msg_signtx.py
@@ -826,12 +826,12 @@ class TestMsgSigntx:
 
             return msg
 
-        # Set up attack processors
-        client.set_filter(messages.TxAck, attack_processor)
-
-        with pytest.raises(
+        with client, pytest.raises(
             TrezorFailure, match="Transaction has changed during signing"
         ):
+            # Set up attack processors
+            client.set_filter(messages.TxAck, attack_processor)
+
             btc.sign_tx(
                 client,
                 "Bitcoin",
@@ -879,12 +879,12 @@ class TestMsgSigntx:
 
             return msg
 
-        # Set up attack processors
-        client.set_filter(messages.TxAck, attack_processor)
-
-        with pytest.raises(
+        with client, pytest.raises(
             TrezorFailure, match="Transaction has changed during signing"
         ):
+            # Set up attack processors
+            client.set_filter(messages.TxAck, attack_processor)
+
             btc.sign_tx(
                 client, "Testnet", [inp1], [out1, out2], prev_txes=TX_CACHE_TESTNET
             )
@@ -933,9 +933,9 @@ class TestMsgSigntx:
 
             return msg
 
-        client.set_filter(messages.TxAck, attack_processor)
         # Now run the attack, must trigger the exception
         with client:
+            client.set_filter(messages.TxAck, attack_processor)
             client.set_expected_responses(
                 [
                     request_input(0),

--- a/tests/device_tests/test_msg_signtx_bcash.py
+++ b/tests/device_tests/test_msg_signtx_bcash.py
@@ -230,9 +230,8 @@ class TestMsgSigntxBch:
 
             return msg
 
-        client.set_filter(proto.TxAck, attack_processor)
-
         with client:
+            client.set_filter(proto.TxAck, attack_processor)
             client.set_expected_responses(
                 [
                     request_input(0),

--- a/tests/device_tests/test_msg_signtx_bgold.py
+++ b/tests/device_tests/test_msg_signtx_bgold.py
@@ -172,8 +172,8 @@ class TestMsgSigntxBitcoinGold:
 
             return msg
 
-        client.set_filter(proto.TxAck, attack_processor)
         with client:
+            client.set_filter(proto.TxAck, attack_processor)
             client.set_expected_responses(
                 [
                     request_input(0),

--- a/tests/device_tests/test_msg_signtx_segwit.py
+++ b/tests/device_tests/test_msg_signtx_segwit.py
@@ -319,8 +319,8 @@ class TestMsgSigntxSegwit:
             return msg
 
         # Now run the attack, must trigger the exception
-        client.set_filter(proto.TxAck, attack_processor)
         with client:
+            client.set_filter(proto.TxAck, attack_processor)
             client.set_expected_responses(
                 [
                     request_input(0),

--- a/tests/device_tests/test_multisig.py
+++ b/tests/device_tests/test_multisig.py
@@ -294,8 +294,8 @@ class TestMultisig:
                 attack_count -= 1
             return msg
 
-        client.set_filter(proto.TxAck, attack_processor)
         with client:
+            client.set_filter(proto.TxAck, attack_processor)
             client.set_expected_responses(
                 [
                     request_input(0),


### PR DESCRIPTION
Main part is reusing `client` across test runs, which makes skipping tests significantly faster because we don't have to wait to figure out the model of the device every time.
Locally this speeds up legacy emulator test by 30 seconds, which is nice.

Also makes sure the whole suite always runs against the same device (modulo emulator being restarted).

0deffdb should help with the "invalid chunk size" occasional CI failure, as described in #1668. This is not proven however, we will see in practice.