### PR TITLE
Avoid busy loop in legacy emulator

### DIFF
--- a/legacy/emulator/emulator.h
+++ b/legacy/emulator/emulator.h
@@ -30,7 +30,8 @@ void emulatorPoll(void);
 void emulatorRandom(void *buffer, size_t size);
 
 void emulatorSocketInit(void);
-size_t emulatorSocketRead(int *iface, void *buffer, size_t size);
+size_t emulatorSocketRead(int *iface, void *buffer, size_t size,
+                          int timeout_ms);
 size_t emulatorSocketWrite(int iface, const void *buffer, size_t size);
 
 #endif

--- a/legacy/firmware/.changelog.d/1743.changed
+++ b/legacy/firmware/.changelog.d/1743.changed
@@ -1,0 +1,1 @@
+Emulator properly waits for IO without busy loop

--- a/legacy/firmware/trezor.c
+++ b/legacy/firmware/trezor.c
@@ -157,7 +157,11 @@ int main(void) {
   layoutHome();
   usbInit();
   for (;;) {
+#if EMULATOR
+    usbSleep(10);
+#else
     usbPoll();
+#endif
     check_lock_screen();
   }
 


### PR DESCRIPTION
1. I use `poll()` to check data on normal and debug interfaces at the same time...
2. which allows me to use timeout on the `poll()` call...
3. so I can implement `usbSleep(millis)` in terms of that timeout, instead of busy-looping over `usbPoll()`

So I changed current `usbPoll()` to `usbSleep()`, and implement `usbPoll()` as `usbSleep(0)`

The more important busy loop is in `main.c`. In order to make that sleep sensibly, I had to modify the `usbSleep()` function so that it will send/receive the whole protobuf message in a single call -- otherwise we'd be inserting delays in the middle of messages.