### PR TITLE
feat(ci): Suite e2e tests in CI pipeline testing current emulator

### DIFF
--- a/ci/shell.nix
+++ b/ci/shell.nix
@@ -49,6 +49,8 @@ stdenv.mkDerivation ({
     check
     clang-tools
     clang
+    docker
+    docker-compose
     editorconfig-checker
     gcc
     gcc-arm-embedded

--- a/ci/test.yml
+++ b/ci/test.yml
@@ -342,7 +342,7 @@ core unix memory profiler:
 suite e2e tests:
   stage: test
   variables:
-    COMPOSE_FILE: ./docker/docker-compose.suite-e2e-tests.yml
+    COMPOSE_FILE: ./docker/docker-compose-suite-e2e-tests.yml
   before_script:
     - docker login $CI_DEPENDENCY_PROXY_SERVER -u $CI_DEPENDENCY_PROXY_USER -p $CI_DEPENDENCY_PROXY_PASSWORD
   script:

--- a/ci/test.yml
+++ b/ci/test.yml
@@ -337,3 +337,19 @@ core unix memory profiler:
       - core/prof/memperf-html
     expire_in: 1 week
     when: always
+
+# Suite e2e
+suite e2e tests:
+  stage: test
+  variables:
+    COMPOSE_FILE: ./docker/docker-compose.suite-e2e-tests.yml
+  before_script:
+    - docker login $CI_DEPENDENCY_PROXY_SERVER -u $CI_DEPENDENCY_PROXY_USER -p $CI_DEPENDENCY_PROXY_PASSWORD
+  script:
+    - docker-compose pull
+    - docker-compose up -d trezor-user-env-unix
+    - sleep 5
+    - docker-compose run e2e-tests
+  after_script:
+    - docker-compose down
+    - docker network prune -f

--- a/docker/docker-compose-suite-e2e-tests.yml
+++ b/docker/docker-compose-suite-e2e-tests.yml
@@ -1,0 +1,19 @@
+version: "3"
+services:
+  trezor-user-env-unix:
+    image: registry.gitlab.com/satoshilabs/trezor/trezor-user-env/trezor-user-env
+    environment:
+      - SDL_VIDEODRIVER=dummy
+      - XDG_RUNTIME_DIR=/var/tmp
+    network_mode: bridge # this makes docker reuse existing networks
+  e2e-tests:
+    image: registry.gitlab.com/satoshilabs/trezor/trezor-suite/trezor-suite-e2e
+    entrypoint: []
+    environment:
+    # TODO: get also the artifact with T1 emulator
+      - CYPRESS_emuVersionT2=https://gitlab.com/satoshilabs/trezor/trezor-firmware/-/jobs/$CI_JOB_ID/artifacts/file/core/build/unix/trezor-emu-core
+      - CYPRESS_baseUrl=https://suite.corp.sldev.cz/suite-web/develop
+      - CYPRESS_ASSET_PREFIX=/web
+    network_mode: service:trezor-user-env-unix
+    working_dir: /trezor-suite
+    command: bash -c "node ./packages/integration-tests/projects/suite-web/run_tests.js --project /trezor-suite/packages/integration-tests/projects/suite-web"


### PR DESCRIPTION
Trying to include Suite e2e tests into CI, which would be testing current emulators

Connected with:
- https://github.com/trezor/trezor-suite/pull/4121
- https://github.com/trezor/trezor-user-env/issues/49