### PR TITLE
remove Wanchain special handling

### DIFF
--- a/core/src/apps/ethereum/keychain.py
+++ b/core/src/apps/ethereum/keychain.py
@@ -73,10 +73,6 @@ def _schemas_from_chain_id(msg: EthereumSignTx) -> Iterable[paths.PathSchema]:
     if info is None:
         # allow Ethereum or testnet paths for unknown networks
         slip44_id = (60, 1)
-    elif not EthereumSignTxEIP1559.is_type_of(msg) and networks.is_wanchain(
-        msg.chain_id, msg.tx_type
-    ):
-        slip44_id = (networks.SLIP44_WANCHAIN,)
     elif info.slip44 != 60 and info.slip44 != 1:
         # allow cross-signing with Ethereum unless it's testnet
         slip44_id = (info.slip44, 60)

--- a/core/src/apps/ethereum/layout.py
+++ b/core/src/apps/ethereum/layout.py
@@ -15,7 +15,7 @@ from . import networks, tokens
 from .address import address_from_bytes
 
 
-async def require_confirm_tx(ctx, to_bytes, value, chain_id, token=None, tx_type=None):
+async def require_confirm_tx(ctx, to_bytes, value, chain_id, token=None):
     if to_bytes:
         to_str = address_from_bytes(to_bytes, networks.by_chain_id(chain_id))
     else:
@@ -23,7 +23,7 @@ async def require_confirm_tx(ctx, to_bytes, value, chain_id, token=None, tx_type
     await confirm_output(
         ctx,
         address=to_str,
-        amount=format_ethereum_amount(value, token, chain_id, tx_type),
+        amount=format_ethereum_amount(value, token, chain_id),
         font_amount=ui.BOLD,
         color_to=ui.GREY,
         br_code=ButtonRequestType.SignTx,
@@ -31,13 +31,13 @@ async def require_confirm_tx(ctx, to_bytes, value, chain_id, token=None, tx_type
 
 
 async def require_confirm_fee(
-    ctx, spending, gas_price, gas_limit, chain_id, token=None, tx_type=None
+    ctx, spending, gas_price, gas_limit, chain_id, token=None
 ):
     await confirm_total_ethereum(
         ctx,
-        format_ethereum_amount(spending, token, chain_id, tx_type),
-        format_ethereum_amount(gas_price, None, chain_id, tx_type),
-        format_ethereum_amount(gas_price * gas_limit, None, chain_id, tx_type),
+        format_ethereum_amount(spending, token, chain_id),
+        format_ethereum_amount(gas_price, None, chain_id),
+        format_ethereum_amount(gas_price * gas_limit, None, chain_id),
     )
 
 
@@ -88,7 +88,7 @@ async def require_confirm_data(ctx, data, data_total):
     )
 
 
-def format_ethereum_amount(value: int, token, chain_id: int, tx_type=None):
+def format_ethereum_amount(value: int, token, chain_id: int):
     if token is tokens.UNKNOWN_TOKEN:
         suffix = "Wei UNKN"
         decimals = 0
@@ -96,7 +96,7 @@ def format_ethereum_amount(value: int, token, chain_id: int, tx_type=None):
         suffix = token[2]
         decimals = token[3]
     else:
-        suffix = networks.shortcut_by_chain_id(chain_id, tx_type)
+        suffix = networks.shortcut_by_chain_id(chain_id)
         decimals = 18
 
     # Don't want to display wei values for tokens with small decimal numbers

--- a/core/src/apps/ethereum/networks.py
+++ b/core/src/apps/ethereum/networks.py
@@ -5,23 +5,13 @@ from micropython import const
 
 from apps.common.paths import HARDENED
 
-SLIP44_WANCHAIN = const(5718350)
-SLIP44_ETHEREUM = const(60)
-
 if False:
     from typing import Iterator
 
 
-def is_wanchain(chain_id: int, tx_type: int) -> bool:
-    return tx_type in (1, 6) and chain_id in (1, 3)
-
-
-def shortcut_by_chain_id(chain_id: int, tx_type: int = None) -> str:
-    if is_wanchain(chain_id, tx_type):
-        return "WAN"
-    else:
-        n = by_chain_id(chain_id)
-        return n.shortcut if n is not None else "UNKN"
+def shortcut_by_chain_id(chain_id: int) -> str:
+    n = by_chain_id(chain_id)
+    return n.shortcut if n is not None else "UNKN"
 
 
 def by_chain_id(chain_id: int) -> "NetworkInfo" | None:
@@ -32,9 +22,6 @@ def by_chain_id(chain_id: int) -> "NetworkInfo" | None:
 
 
 def by_slip44(slip44: int) -> "NetworkInfo" | None:
-    if slip44 == SLIP44_WANCHAIN:
-        # Coerce to Ethereum
-        slip44 = SLIP44_ETHEREUM
     for n in _networks_iterator():
         if n.slip44 == slip44:
             return n
@@ -44,7 +31,6 @@ def by_slip44(slip44: int) -> "NetworkInfo" | None:
 def all_slip44_ids_hardened() -> Iterator[int]:
     for n in _networks_iterator():
         yield n.slip44 | HARDENED
-    yield SLIP44_WANCHAIN | HARDENED
 
 
 class NetworkInfo:
@@ -629,7 +615,7 @@ def _networks_iterator() -> Iterator[NetworkInfo]:
     )
     yield NetworkInfo(
         chain_id=888,
-        slip44=60,
+        slip44=5718350,
         shortcut="WAN",
         name="Wanchain",
         rskip60=False,

--- a/core/src/apps/ethereum/networks.py.mako
+++ b/core/src/apps/ethereum/networks.py.mako
@@ -5,23 +5,13 @@ from micropython import const
 
 from apps.common.paths import HARDENED
 
-SLIP44_WANCHAIN = const(5718350)
-SLIP44_ETHEREUM = const(60)
-
 if False:
     from typing import Iterator
 
 
-def is_wanchain(chain_id: int, tx_type: int) -> bool:
-    return tx_type in (1, 6) and chain_id in (1, 3)
-
-
-def shortcut_by_chain_id(chain_id: int, tx_type: int = None) -> str:
-    if is_wanchain(chain_id, tx_type):
-        return "WAN"
-    else:
-        n = by_chain_id(chain_id)
-        return n.shortcut if n is not None else "UNKN"
+def shortcut_by_chain_id(chain_id: int) -> str:
+    n = by_chain_id(chain_id)
+    return n.shortcut if n is not None else "UNKN"
 
 
 def by_chain_id(chain_id: int) -> "NetworkInfo" | None:
@@ -32,9 +22,6 @@ def by_chain_id(chain_id: int) -> "NetworkInfo" | None:
 
 
 def by_slip44(slip44: int) -> "NetworkInfo" | None:
-    if slip44 == SLIP44_WANCHAIN:
-        # Coerce to Ethereum
-        slip44 = SLIP44_ETHEREUM
     for n in _networks_iterator():
         if n.slip44 == slip44:
             return n
@@ -44,7 +31,6 @@ def by_slip44(slip44: int) -> "NetworkInfo" | None:
 def all_slip44_ids_hardened() -> Iterator[int]:
     for n in _networks_iterator():
         yield n.slip44 | HARDENED
-    yield SLIP44_WANCHAIN | HARDENED
 
 
 class NetworkInfo:

--- a/core/src/apps/ethereum/sign_tx.py
+++ b/core/src/apps/ethereum/sign_tx.py
@@ -32,7 +32,7 @@ async def sign_tx(ctx, msg, keychain):
 
     data_total = msg.data_length
 
-    await require_confirm_tx(ctx, recipient, value, msg.chain_id, token, msg.tx_type)
+    await require_confirm_tx(ctx, recipient, value, msg.chain_id, token)
     if token is None and msg.data_length > 0:
         await require_confirm_data(ctx, msg.data_initial_chunk, data_total)
 
@@ -43,7 +43,6 @@ async def sign_tx(ctx, msg, keychain):
         int.from_bytes(msg.gas_limit, "big"),
         msg.chain_id,
         token,
-        msg.tx_type,
     )
 
     data = bytearray()

--- a/legacy/firmware/ethereum.c
+++ b/legacy/firmware/ethereum.c
@@ -248,11 +248,7 @@ static void ethereumFormatAmount(const bignum256 *amnt, const TokenType *token,
     suffix = " Wei";
     decimals = 0;
   } else {
-    if (tx_type == 1 || tx_type == 6) {
-      suffix = " WAN";
-    } else {
-      ASSIGN_ETHEREUM_SUFFIX(suffix, chain_id);
-    }
+    ASSIGN_ETHEREUM_SUFFIX(suffix, chain_id);
   }
   bn_format(amnt, NULL, suffix, decimals, 0, false, buf, buflen);
 }

--- a/tests/device_tests/test_msg_ethereum_signtx.py
+++ b/tests/device_tests/test_msg_ethereum_signtx.py
@@ -98,7 +98,7 @@ class TestMsgEthereumSigntx:
                 gas_limit=20,
                 # ADT token address
                 to="0xd0d6d6c5fe4a677d343cc433536bb717bae167dd",
-                chain_id=1,
+                chain_id=888,
                 tx_type=1,
                 # value needs to be 0, token value is set in the contract (data)
                 value=100,
@@ -107,11 +107,11 @@ class TestMsgEthereumSigntx:
             # ad-hoc generated signature. might not be valid.
             assert (
                 sig_r.hex()
-                == "d6e197029031ec90b53ed14e8233aa78b592400513ac0386d2d55cdedc3d796f"
+                == "93648ad45524a896b1f465e868bb7c0427502e218b135e53b55f7a1e7e2293aa"
             )
             assert (
                 sig_s.hex()
-                == "326e0d600dd1b7ee606eb531b998a6a3b3293d4995fb8cfe0677962e8a43cff6"
+                == "2fd3882fbeb8968041d463d7c61526cdb36a80f53b2b217221b879b0d275d179"
             )
 
     @pytest.mark.setup_client(mnemonic=MNEMONIC12)


### PR DESCRIPTION
at some point this year, the Wanchain network hard-forked and introduced its own EIP-155 chainID distinct from the Ethereum network.

This means that we can remove logic which detects Wanchain based on presence of `tx_type` values, and rely on the common method of finding the data via looking up chainID.