### PR TITLE
Fix Click 8.x problem when a ChoiceType argument has a default value

### DIFF
--- a/python/CHANGELOG.md
+++ b/python/CHANGELOG.md
@@ -6,6 +6,13 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 _At the moment, the project does **not** adhere to [Semantic Versioning](https://semver.org/spec/v2.0.0.html). That is expected to change with version 1.0._
 
+## [0.12.4] - 2021-09-07
+[0.12.4]: https://github.com/trezor/trezor-firmware/compare/python/v0.12.3...python/v0.12.4
+
+### Fixed
+
+- trezorctl: fixed "Invalid value for <param>" when using Click 8 and param is not specified [#1798]
+
 ## [0.12.3] - 2021-07-29
 [0.12.3]: https://github.com/trezor/trezor-firmware/compare/python/v0.12.2...python/v0.12.3
 
@@ -508,3 +515,4 @@ _At the moment, the project does **not** adhere to [Semantic Versioning](https:/
 [#1296]: https://github.com/trezor/trezor-firmware/issues/1296
 [#1363]: https://github.com/trezor/trezor-firmware/issues/1363
 [#1738]: https://github.com/trezor/trezor-firmware/issues/1738
+[#1798]: https://github.com/trezor/trezor-firmware/issues/1798

--- a/python/src/trezorlib/__init__.py
+++ b/python/src/trezorlib/__init__.py
@@ -1,4 +1,4 @@
-__version__ = "0.12.3"
+__version__ = "0.12.4"
 
 # fmt: off
 MINIMUM_FIRMWARE_VERSION = {

--- a/python/src/trezorlib/cli/__init__.py
+++ b/python/src/trezorlib/cli/__init__.py
@@ -31,6 +31,8 @@ class ChoiceType(click.Choice):
         self.typemap = typemap
 
     def convert(self, value, param, ctx):
+        if value in self.typemap.values():
+            return value
         value = super().convert(value, param, ctx)
         return self.typemap[value]
 


### PR DESCRIPTION
the following option definition:
```
@click.option("-t", "--script-type", type=ChoiceType(INPUT_SCRIPTS), default="address")
```
```
Options:
  -t, --script-type [address|segwit|p2shsegwit|pkh|wpkh|sh-wpkh]
```
works fine in Click 7.x
and we use this in several places

in 8.x, if `-t` is not specified, the following error appears:
```
Error: Invalid value for '-t' / '--script-type': 0 is not one of 'address', 'segwit', 'p2shsegwit', 'pkh', 'wpkh', 'sh-wpkh'.
```
This is because Click 8.0 first converts the _default value_ to the destination type (which is `int` for trezorlib 0.12.x and `IntEnum` in master), and then runs `ChoiceType.convert` on it again as a part of some subsequent step.

This is not strictly a Click bug, as their docs explicitly state that "The custom type should check at the top if the value is already valid and pass it through to support those cases."