### PR TITLE
fix(core): avoid accidental build with broken stack protector (boardloader)

### DIFF
--- a/core/embed/boardloader/.changelog.d/1642.security
+++ b/core/embed/boardloader/.changelog.d/1642.security
@@ -1,0 +1,1 @@
+Avoid accidental build with broken stack protector

--- a/core/embed/boardloader/main.c
+++ b/core/embed/boardloader/main.c
@@ -20,6 +20,7 @@
 #include <string.h>
 
 #include "common.h"
+#include "compiler_traits.h"
 #include "display.h"
 #include "flash.h"
 #include "image.h"


### PR DESCRIPTION
We omitted boardloader from https://github.com/trezor/trezor-firmware/pull/1642

This PR fixes this.