### PR TITLE
Fix core emulator debug build segfault

### DIFF
--- a/core/SConscript.unix
+++ b/core/SConscript.unix
@@ -367,7 +367,7 @@ if ARGUMENTS.get('TREZOR_EMULATOR_ASAN', 0):
 
 if ARGUMENTS.get('TREZOR_EMULATOR_DEBUGGABLE', 0):
     env.Replace(
-        COPT=' -O0 -ggdb',
+        COPT=' -Og -ggdb',
         STRIP='true', )
 
 if ARGUMENTS.get('TREZOR_MEMPERF', '0') == '1':


### PR DESCRIPTION
Some Linux distros at least will build emulator debug build that segfaults on start - #304 

The only stable workaround is using `-Og` instead of `-O0` which is also preferred by gcc manual.