### PR TITLE
fix(cardano): forbid multisig pool registration

### DIFF
--- a/common/tests/fixtures/cardano/sign_tx_stake_pool_registration.failed.json
+++ b/common/tests/fixtures/cardano/sign_tx_stake_pool_registration.failed.json
@@ -705,6 +705,91 @@
       }
     },
     {
+      "description": "With MULTISIG_TRANSACTION signing mode",
+      "parameters": {
+        "protocol_magic": 764824073,
+        "network_id": 1,
+        "fee": 42,
+        "ttl": 10,
+        "certificates": [
+          {
+            "type": 3,
+            "pool_parameters": {
+              "pool_id": "f61c42cbf7c8c53af3f520508212ad3e72f674f957fe23ff0acb4973",
+              "vrf_key_hash": "198890ad6c92e80fbdab554dda02da9fb49d001bbd96181f3e07f7a6ab0d0640",
+              "pledge": 500000000,
+              "cost": 340000000,
+              "margin": {
+                "numerator": 1,
+                "denominator": 2
+              },
+              "reward_account": "stake1uya87zwnmax0v6nnn8ptqkl6ydx4522kpsc3l3wmf3yswygwx45el",
+              "owners": [
+                {
+                  "staking_key_path": "m/1852'/1815'/0'/2/0"
+                },
+                {
+                  "staking_key_hash": "3a7f09d3df4cf66a7399c2b05bfa234d5a29560c311fc5db4c490711"
+                }
+              ],
+              "relays": [
+                {
+                  "type": 0,
+                  "ipv4_address": "192.168.0.1",
+                  "ipv6_address": "2001:0db8:85a3:0000:0000:8a2e:0370:7334",
+                  "port": 1234
+                },
+                {
+                  "type": 0,
+                  "ipv6_address": "2001:0db8:85a3:0000:0000:8a2e:0370:7334",
+                  "port": 1234
+                },
+                {
+                  "type": 0,
+                  "ipv4_address": "192.168.0.1",
+                  "port": 1234
+                },
+                {
+                  "type": 1,
+                  "host_name": "www.test.test",
+                  "port": 1234
+                },
+                {
+                  "type": 2,
+                  "host_name": "www.test2.test"
+                }
+              ],
+              "metadata": {
+                "url": "https://www.test.test",
+                "hash": "914c57c1f12bbf4a82b12d977d4f274674856a11ed4b9b95bd70f5d41c5064a6"
+              }
+            }
+          }
+        ],
+        "withdrawals": [],
+        "auxiliary_data": null,
+        "inputs": [
+          {
+            "path": null,
+            "prev_hash": "3b40265111d8bb3c3c608d95b3a0bf83461ace32d79336579a1939b3aad1c0b7",
+            "prev_index": 0
+          }
+        ],
+        "outputs": [
+          {
+            "address": "addr1q84sh2j72ux0l03fxndjnhctdg7hcppsaejafsa84vh7lwgmcs5wgus8qt4atk45lvt4xfxpjtwfhdmvchdf2m3u3hlsd5tq5r",
+            "amount": "1"
+          }
+        ],
+        "mint": [],
+        "signing_mode": "MULTISIG_TRANSACTION",
+        "additional_witness_requests": []
+      },
+      "result": {
+        "error_message": "Invalid certificate"
+      }
+    },
+    {
       "description": "Sample stake pool registration certificate with 1854 additional witness request",
       "parameters": {
         "protocol_magic": 764824073,

--- a/core/src/apps/cardano/certificates.py
+++ b/core/src/apps/cardano/certificates.py
@@ -49,7 +49,7 @@ def validate_certificate(
     account_path_checker: AccountPathChecker,
 ) -> None:
     if (
-        signing_mode == CardanoTxSigningMode.ORDINARY_TRANSACTION
+        signing_mode != CardanoTxSigningMode.POOL_REGISTRATION_AS_OWNER
         and certificate.type == CardanoCertificateType.STAKE_POOL_REGISTRATION
     ):
         raise INVALID_CERTIFICATE

--- a/tests/ui_tests/fixtures.json
+++ b/tests/ui_tests/fixtures.json
@@ -175,6 +175,7 @@
 "cardano-test_sign_tx.py::test_cardano_sign_tx_failed[transaction_with_catalyst_registration-11533421": "b77d0e79de37f1036e6924e9ce742326a95a191629acf12a0494efcb92e46350",
 "cardano-test_sign_tx.py::test_cardano_sign_tx_failed[two_owners_with_path]": "13e202aaf27c6395a2fcb7cfdb2dc6cadb613a23cdd9548f860c8e524bb76b98",
 "cardano-test_sign_tx.py::test_cardano_sign_tx_failed[unsupported_address_type]": "9e1f554bb74f847e8f09201dda808fd1e0cdb68737515f34d6ad435957671c77",
+"cardano-test_sign_tx.py::test_cardano_sign_tx_failed[with_multisig_transaction_signing_mode]": "a1f8001a566bd030249ad2d8c0dea7fbfb38ef2aafd0541c359598e3ca4053ff",
 "cardano-test_sign_tx.py::test_cardano_sign_tx_failed[with_ordinary_transaction_signing_mode]": "b77d0e79de37f1036e6924e9ce742326a95a191629acf12a0494efcb92e46350",
 "cardano-test_sign_tx.py::test_cardano_sign_tx_failed[withdrawal_amount_is_too_large]": "0a1ce9fbfcead1f0f1f03b98e2ab719f92949a9b72f5da99097edd5f45e91154",
 "cardano-test_sign_tx.py::test_cardano_sign_tx_failed[withdrawal_contains_both_path_and_script_hash]": "0a1ce9fbfcead1f0f1f03b98e2ab719f92949a9b72f5da99097edd5f45e91154",


### PR DESCRIPTION
We found an insufficient check of `signing_mode` when signing a Cardano pool registration certificate. Because of this, pool registration certificate validation passes in `MULTISIG_TRANSACTION` signing mode, which should not be possible (pool registration is the reason why there is `POOL_REGISTRATION_AS_OWNER` signing mode). Fortunately, the signing crashes later in the process ([this line](https://github.com/trezor/trezor-firmware/blob/master/core/src/apps/cardano/layout.py#L403) fails) so this should pose no security risk.

This PR fixes the validation and adds a test case that would catch this.