### PR TITLE
Fix compile-time check of maximum protobuf message size

### DIFF
--- a/legacy/firmware/.changelog.d/1854.fixed
+++ b/legacy/firmware/.changelog.d/1854.fixed
@@ -1,0 +1,1 @@
+Fix incorrect compile-time check of maximum protobuf message size.

--- a/legacy/firmware/messages.h
+++ b/legacy/firmware/messages.h
@@ -29,7 +29,7 @@
 #define MSG_HEADER_SIZE 9
 
 // Maximum size of an incoming protobuf-encoded message without headers.
-#define MSG_IN_ENCODED_SIZE (15 * 1024)
+#define MSG_IN_ENCODED_SIZE (16 * 1024)
 
 // Maximum size of a C struct containing a decoded incoming message.
 #define MSG_IN_DECODED_SIZE (15 * 1024)

--- a/legacy/firmware/protob/messages_map.py
+++ b/legacy/firmware/protob/messages_map.py
@@ -97,7 +97,7 @@ def handle_message(fh, fl, skipped, message):
 
     if encoded_size:
         fl.write(
-            f'_Static_assert({encoded_size} >= sizeof({short_name}_size), "msg buffer too small");\n'
+            f'_Static_assert({encoded_size} >= {short_name}_size, "msg buffer too small");\n'
         )
 
     if decoded_size:


### PR DESCRIPTION
Fixes an incorrectly written compile-time check of maximum protobuf message size. The bug was already present in my original commit a36439a57fe5cc73a42e892192db72f0752907bc which implemented this compile-time check. The severity of the bug is zero. The check is meant to avoid runtime errors caused by the incoming message buffer being too small. The maximum message sizes are already vastly overestimated (namely `TxAck`), so there is no risk of getting a runtime error for a valid message.
