### PR TITLE
Add script_pubkey field to TxInput message

### DIFF
--- a/common/protob/messages-bitcoin.proto
+++ b/common/protob/messages-bitcoin.proto
@@ -300,6 +300,7 @@ message TxAck {
             optional bytes orig_hash = 16;                                      // tx_hash of the original transaction where this input was spent (used when creating a replacement transaction)
             optional uint32 orig_index = 17;                                    // index of the input in the original transaction (used when creating a replacement transaction)
             optional DecredStakingSpendType decred_staking_spend = 18;          // if not None this holds the type of stake spend: revocation or stake generation
+            optional bytes script_pubkey = 19;                                  // scriptPubKey of the previous output spent by this input, only set of EXTERNAL inputs
         }
         /**
         * Structure representing compiled transaction output
@@ -351,6 +352,7 @@ message TxInput {
     optional bytes orig_hash = 16;                                      // tx_hash of the original transaction where this input was spent (used when creating a replacement transaction)
     optional uint32 orig_index = 17;                                    // index of the input in the original transaction (used when creating a replacement transaction)
     optional DecredStakingSpendType decred_staking_spend = 18; 	        // if not None this holds the type of stake spend: revocation or stake generation
+    optional bytes script_pubkey = 19;                                  // scriptPubKey of the previous output spent by this input, only set of EXTERNAL inputs
 }
 
 /** Data type for transaction output to be signed.
@@ -399,7 +401,7 @@ message PrevInput {
     optional uint32 decred_tree = 9;                                    // only for Decred
 
     // fields that are in use, or have been in the past, in TxInputType
-    reserved 1, 6, 7, 8, 10, 11, 12, 13, 14, 15;
+    reserved 1, 6, 7, 8, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19;
 }
 
 /** Data type for outputs of previous transactions.

--- a/core/.changelog.d/1857.added
+++ b/core/.changelog.d/1857.added
@@ -1,0 +1,1 @@
+Add script_pubkey field to TxInput message.

--- a/core/src/trezor/messages.py
+++ b/core/src/trezor/messages.py
@@ -643,6 +643,7 @@ if TYPE_CHECKING:
         orig_hash: "bytes | None"
         orig_index: "int | None"
         decred_staking_spend: "DecredStakingSpendType | None"
+        script_pubkey: "bytes | None"
 
         def __init__(
             self,
@@ -662,6 +663,7 @@ if TYPE_CHECKING:
             orig_hash: "bytes | None" = None,
             orig_index: "int | None" = None,
             decred_staking_spend: "DecredStakingSpendType | None" = None,
+            script_pubkey: "bytes | None" = None,
         ) -> None:
             pass
 

--- a/docs/common/communication/bitcoin-signing.md
+++ b/docs/common/communication/bitcoin-signing.md
@@ -154,7 +154,7 @@ signing party hasn't signed their input yet (i.e., with two Trezors, one must si
 so that the other can include a pre-signed input), they can instead provide a
 [SLIP-19](https://github.com/satoshilabs/slips/blob/master/slip-0019.md)
 ownership proof in the `ownership_proof` field, with optional commitment data in
-`commitment_data`.
+`commitment_data`. The `script_pubkey` field is required for all external inputs.
 
 ### Transaction output
 

--- a/legacy/firmware/.changelog.d/1857.added
+++ b/legacy/firmware/.changelog.d/1857.added
@@ -1,0 +1,1 @@
+Add script_pubkey field to TxInput message.

--- a/legacy/firmware/messages.h
+++ b/legacy/firmware/messages.h
@@ -32,7 +32,7 @@
 #define MSG_IN_ENCODED_SIZE (16 * 1024)
 
 // Maximum size of a C struct containing a decoded incoming message.
-#define MSG_IN_DECODED_SIZE (15 * 1024)
+#define MSG_IN_DECODED_SIZE (16 * 1024)
 
 // Buffer size for outgoing USB packets with headers.
 #define MSG_OUT_BUFFER_SIZE (3 * 1024)

--- a/legacy/firmware/protob/messages-bitcoin.options
+++ b/legacy/firmware/protob/messages-bitcoin.options
@@ -35,6 +35,7 @@ TxInputType.witness                                         max_size:109
 TxInputType.ownership_proof                                 max_size:171
 TxInputType.commitment_data                                 max_size:32
 TxInputType.orig_hash                                       max_size:32
+TxInputType.script_pubkey                                   max_size:520
 
 TxOutputType.address                                        max_size:130
 TxOutputType.address_n                                      max_count:8
@@ -62,6 +63,7 @@ TxInput.witness                                             max_size:109
 TxInput.ownership_proof                                     max_size:171
 TxInput.commitment_data                                     max_size:32
 TxInput.orig_hash                                           max_size:32
+TxInput.script_pubkey                                       max_size:520
 
 TxOutput.address                                            max_size:130
 TxOutput.address_n                                          max_count:8

--- a/python/.changelog.d/1857.added
+++ b/python/.changelog.d/1857.added
@@ -1,0 +1,1 @@
+Add script_pubkey field to TxInput message.

--- a/python/src/trezorlib/messages.py
+++ b/python/src/trezorlib/messages.py
@@ -1197,6 +1197,7 @@ class TxInput(protobuf.MessageType):
         16: protobuf.Field("orig_hash", "bytes", repeated=False, required=False),
         17: protobuf.Field("orig_index", "uint32", repeated=False, required=False),
         18: protobuf.Field("decred_staking_spend", "DecredStakingSpendType", repeated=False, required=False),
+        19: protobuf.Field("script_pubkey", "bytes", repeated=False, required=False),
     }
 
     def __init__(
@@ -1217,6 +1218,7 @@ class TxInput(protobuf.MessageType):
         orig_hash: Optional["bytes"] = None,
         orig_index: Optional["int"] = None,
         decred_staking_spend: Optional["DecredStakingSpendType"] = None,
+        script_pubkey: Optional["bytes"] = None,
     ) -> None:
         self.address_n = address_n if address_n is not None else []
         self.prev_hash = prev_hash
@@ -1233,6 +1235,7 @@ class TxInput(protobuf.MessageType):
         self.orig_hash = orig_hash
         self.orig_index = orig_index
         self.decred_staking_spend = decred_staking_spend
+        self.script_pubkey = script_pubkey
 
 
 class TxOutput(protobuf.MessageType):
@@ -1650,6 +1653,7 @@ class TxInputType(protobuf.MessageType):
         16: protobuf.Field("orig_hash", "bytes", repeated=False, required=False),
         17: protobuf.Field("orig_index", "uint32", repeated=False, required=False),
         18: protobuf.Field("decred_staking_spend", "DecredStakingSpendType", repeated=False, required=False),
+        19: protobuf.Field("script_pubkey", "bytes", repeated=False, required=False),
     }
 
     def __init__(
@@ -1670,6 +1674,7 @@ class TxInputType(protobuf.MessageType):
         orig_hash: Optional["bytes"] = None,
         orig_index: Optional["int"] = None,
         decred_staking_spend: Optional["DecredStakingSpendType"] = None,
+        script_pubkey: Optional["bytes"] = None,
     ) -> None:
         self.address_n = address_n if address_n is not None else []
         self.prev_hash = prev_hash
@@ -1686,6 +1691,7 @@ class TxInputType(protobuf.MessageType):
         self.orig_hash = orig_hash
         self.orig_index = orig_index
         self.decred_staking_spend = decred_staking_spend
+        self.script_pubkey = script_pubkey
 
 
 class TxOutputBinType(protobuf.MessageType):


### PR DESCRIPTION
Signing Taproot UTXOs involves computing the new BIP341 hash, which hashes all previous scriptPubKeys, not just the one we are signing. If we own the input, then we can (and should) derive its scriptPubKey inside Trezor. If it's an external input, then we need the scriptPubKey to be supplied. We can already do that with the present API by requesting the corresponding `PrevOutput`, i.e. just the one previous output, not the entire previous transaction. An alternative is to change the API by adding a `script_pubkey` field to the `TxInput` message, which will have to be filled in for external inputs only. We have decided to go with the latter option. For the record, the reasons considered are summarized below.

Reasons to keep the API as is:
- The extra `PrevOutput` message will be needed only for external inputs (once for signature hashing and once for verification of externality). Apparently the only disadvantage is that in CoinJoin it will mean `2*(N-1)` extra messages during signing, where `N` is the number of participants, which seems acceptable.
- The factor of size. By adding `script_pubkey` to `TxInput` we increase the maximum size of the message by another 520 bytes. `TxInput` is already the biggest message type we have with a theoretical maximum size of 7767 bytes and a practical maximum of ~4000 bytes.
- The `PrevOutput` solution seems nicer from a defensive coding point of view. we wouldn't need to check yet another optional field, we're guaranteed that an attacker isn't slipping in a value that gets accidentally used when it shouldn't, etc.

Reasons to add the `script_pubkey field` to the `TxInput` message:
- Fewer messages exchanged between host PC and Trezor.
- In the future this will make the API simpler for apps that use Trezor, because they won't have to implement `PrevOutput` message handling if they only sign Taproot inputs.
- In `TxInput` we already have fields like `witness` and `ownership_proof` which have very similar rules, e.g. `ownership_proof` may be present only for external inputs. The main difference between the addition of these fields and the question of adding `script_pubkey` is that there exists an alternative way to get `script_pubkey` via `PrevOutput`.
- `TxInput` already has the field `amount`, which also wouldn't have to be there and could be obtained via `PrevOutput`. The main difference between `amount` and `script_pubkey` is that `amount` is mandatory for every input whereas `script_pubkey` only for external inputs.
- Slightly simpler implementation of Taproot signing in `legacy`, where requesting the `PrevInput` means adding a new state to the state machine.