### PR TITLE
fix(core): fix (emulator) build on aarch64

### DIFF
--- a/core/SConscript.unix
+++ b/core/SConscript.unix
@@ -244,6 +244,7 @@ SOURCE_MICROPYTHON = [
     'vendor/micropython/py/mpz.c',
     'vendor/micropython/py/nativeglue.c',
     'vendor/micropython/py/nlr.c',
+    'vendor/micropython/py/nlraarch64.c',
     'vendor/micropython/py/nlrsetjmp.c',
     'vendor/micropython/py/nlrthumb.c',
     'vendor/micropython/py/nlrx64.c',


### PR DESCRIPTION
fix (emulator) build on aarch64 by adding nlraarch64.c to SConscript.unix

Fixed https://github.com/trezor/trezor-firmware/issues/1862