### PR TITLE
fix(python/trezorctl): fix operator precedence issue for ethereum sign-tx command

### DIFF
--- a/python/.changelog.d/1867.fixed
+++ b/python/.changelog.d/1867.fixed
@@ -1,0 +1,1 @@
+fix operator precedence issue for ethereum sign-tx command

--- a/python/src/trezorlib/cli/ethereum.py
+++ b/python/src/trezorlib/cli/ethereum.py
@@ -268,8 +268,7 @@ def sign_tx(
         (not is_eip1559 and gas_price is None)
         or any(x is None for x in (gas_limit, nonce))
         or publish
-        and not w3.isConnected()
-    ):
+    ) and not w3.isConnected():
         click.echo("Failed to connect to Ethereum node.")
         click.echo(
             "If you want to sign offline, make sure you provide --gas-price, "


### PR DESCRIPTION
I have noticed that cli command fails despite the web3 connection is available. I suppose it meant to be that way (and has higher precedence than or).