### PR TITLE
crypto big endian support

### DIFF
--- a/crypto/blake2_common.h
+++ b/crypto/blake2_common.h
@@ -1,20 +1,39 @@
+
+#include "byte_order.h"
+
 static inline uint32_t load32(const void *src) {
   uint32_t w;
   memcpy(&w, src, sizeof w);
+#if BYTE_ORDER == BIG_ENDIAN
+  REVERSE32(w, w);
+#endif
   return w;
 }
 
 static inline uint64_t load64(const void *src) {
   uint64_t w;
   memcpy(&w, src, sizeof w);
+#if BYTE_ORDER == BIG_ENDIAN
+  REVERSE64(w, w);
+#endif
   return w;
 }
 
 static inline void store16(void *dst, uint16_t w) { memcpy(dst, &w, sizeof w); }
 
-static inline void store32(void *dst, uint32_t w) { memcpy(dst, &w, sizeof w); }
+static inline void store32(void *dst, uint32_t w) {
+#if BYTE_ORDER == BIG_ENDIAN
+  REVERSE32(w, w);
+#endif
+  memcpy(dst, &w, sizeof w);
+}
 
-static inline void store64(void *dst, uint64_t w) { memcpy(dst, &w, sizeof w); }
+static inline void store64(void *dst, uint64_t w) {
+#if BYTE_ORDER == BIG_ENDIAN
+  REVERSE64(w, w);
+#endif
+  memcpy(dst, &w, sizeof w);
+}
 
 static inline uint32_t rotr32(const uint32_t w, const unsigned c) {
   return (w >> c) | (w << (32 - c));

--- a/crypto/byte_order.h
+++ b/crypto/byte_order.h
@@ -1,0 +1,59 @@
+#ifndef __BYTE_ORDER_H__
+#define __BYTE_ORDER_H__
+
+// FROM sha2.h:
+/*
+ * BYTE_ORDER NOTE:
+ *
+ * Please make sure that your system defines BYTE_ORDER.  If your
+ * architecture is little-endian, make sure it also defines
+ * LITTLE_ENDIAN and that the two (BYTE_ORDER and LITTLE_ENDIAN) are
+ * equivalent.
+ *
+ * If your system does not define the above, then you can do so by
+ * hand like this:
+ *
+ *   #define LITTLE_ENDIAN 1234
+ *   #define BIG_ENDIAN    4321
+ *
+ * And for little-endian machines, add:
+ *
+ *   #define BYTE_ORDER LITTLE_ENDIAN
+ *
+ * Or for big-endian machines:
+ *
+ *   #define BYTE_ORDER BIG_ENDIAN
+ *
+ * The FreeBSD machine this was written on defines BYTE_ORDER
+ * appropriately by including <sys/types.h> (which in turn includes
+ * <machine/endian.h> where the appropriate definitions are actually
+ * made).
+ */
+
+#ifndef LITTLE_ENDIAN
+#define LITTLE_ENDIAN 1234
+#define BIG_ENDIAN 4321
+#endif
+
+#ifndef BYTE_ORDER
+#define BYTE_ORDER LITTLE_ENDIAN
+#endif
+
+#define REVERSE32(w, x)                                              \
+  {                                                                  \
+    uint32_t tmp = (w);                                              \
+    tmp = (tmp >> 16) | (tmp << 16);                                 \
+    (x) = ((tmp & 0xff00ff00UL) >> 8) | ((tmp & 0x00ff00ffUL) << 8); \
+  }
+
+#define REVERSE64(w, x)                           \
+  {                                               \
+    uint64_t tmp = (w);                           \
+    tmp = (tmp >> 32) | (tmp << 32);              \
+    tmp = ((tmp & 0xff00ff00ff00ff00ULL) >> 8) |  \
+          ((tmp & 0x00ff00ff00ff00ffULL) << 8);   \
+    (x) = ((tmp & 0xffff0000ffff0000ULL) >> 16) | \
+          ((tmp & 0x0000ffff0000ffffULL) << 16);  \
+  }
+
+#endif

--- a/crypto/monero/base58.c
+++ b/crypto/monero/base58.c
@@ -36,6 +36,7 @@
 #include "int-util.h"
 #include "sha2.h"
 #include "../base58.h"
+#include "../byte_order.h"
 
 const size_t alphabet_size = 58; // sizeof(b58digits_ordered) - 1;
 const size_t encoded_block_sizes[] = {0, 2, 3, 5, 6, 7, 9, 10, 11};
@@ -71,7 +72,11 @@ void uint_64_to_8be(uint64_t num, size_t size, uint8_t* data)
 {
 	assert(1 <= size && size <= sizeof(uint64_t));
 
+#if BYTE_ORDER == LITTLE_ENDIAN
 	uint64_t num_be = SWAP64(num);
+#else
+	uint64_t num_be = num;
+#endif
 	memcpy(data, (uint8_t*)(&num_be) + sizeof(uint64_t) - size, size);
 }
 

--- a/crypto/monero/xmr.c
+++ b/crypto/monero/xmr.c
@@ -3,6 +3,7 @@
 //
 
 #include "xmr.h"
+#include "../byte_order.h"
 #include "int-util.h"
 #include "rand.h"
 #include "serialize.h"
@@ -128,6 +129,12 @@ void xmr_get_subaddress_secret_key(bignum256modm r, uint32_t major,
   char data[sizeof(prefix) + sizeof(buff) + 2 * sizeof(uint32_t)] = {0};
   memcpy(data, prefix, sizeof(prefix));
   memcpy(data + sizeof(prefix), buff, sizeof(buff));
+
+#if BYTE_ORDER == BIG_ENDIAN
+  REVERSE32(major, major);
+  REVERSE32(minor, minor);
+#endif
+
   memcpy(data + sizeof(prefix) + sizeof(buff), &major, sizeof(uint32_t));
   memcpy(data + sizeof(prefix) + sizeof(buff) + sizeof(uint32_t), &minor,
          sizeof(uint32_t));

--- a/crypto/sha2.c
+++ b/crypto/sha2.c
@@ -32,6 +32,7 @@
 #include <stdint.h>
 #include "sha2.h"
 #include "memzero.h"
+#include "byte_order.h"
 
 /*
  * ASSERT NOTE:

--- a/crypto/sha2.h
+++ b/crypto/sha2.h
@@ -33,6 +33,7 @@
 
 #include <stdint.h>
 #include <stddef.h>
+#include "byte_order.h"
 
 #define   SHA1_BLOCK_LENGTH		64
 #define   SHA1_DIGEST_LENGTH		20
@@ -59,32 +60,6 @@ typedef struct _SHA512_CTX {
 	uint64_t	bitcount[2];
 	uint64_t	buffer[SHA512_BLOCK_LENGTH/sizeof(uint64_t)];
 } SHA512_CTX;
-
-/*** ENDIAN REVERSAL MACROS *******************************************/
-#ifndef LITTLE_ENDIAN
-#define LITTLE_ENDIAN 1234
-#define BIG_ENDIAN    4321
-#endif
-
-#ifndef BYTE_ORDER
-#define BYTE_ORDER LITTLE_ENDIAN
-#endif
-
-#if BYTE_ORDER == LITTLE_ENDIAN
-#define REVERSE32(w,x)	{ \
-	uint32_t tmp = (w); \
-	tmp = (tmp >> 16) | (tmp << 16); \
-	(x) = ((tmp & 0xff00ff00UL) >> 8) | ((tmp & 0x00ff00ffUL) << 8); \
-}
-#define REVERSE64(w,x)	{ \
-	uint64_t tmp = (w); \
-	tmp = (tmp >> 32) | (tmp << 32); \
-	tmp = ((tmp & 0xff00ff00ff00ff00ULL) >> 8) | \
-	      ((tmp & 0x00ff00ff00ff00ffULL) << 8); \
-	(x) = ((tmp & 0xffff0000ffff0000ULL) >> 16) | \
-	      ((tmp & 0x0000ffff0000ffffULL) << 16); \
-}
-#endif /* BYTE_ORDER == LITTLE_ENDIAN */
 
 extern const uint32_t sha256_initial_hash_value[8];
 extern const uint64_t sha512_initial_hash_value[8];

--- a/crypto/sha3.c
+++ b/crypto/sha3.c
@@ -22,6 +22,7 @@
 
 #include "sha3.h"
 #include "memzero.h"
+#include "byte_order.h"
 
 #define I64(x) x##LL
 #define ROTL64(qword, n) ((qword) << (n) ^ ((qword) >> (64 - (n))))
@@ -165,6 +166,13 @@ static void keccak_chi(uint64_t *A)
 
 static void sha3_permutation(uint64_t *state)
 {
+#if BYTE_ORDER == BIG_ENDIAN
+	int i;
+	for (i = 0; i < 25; i++)
+	{
+		REVERSE64(state[i], state[i]);
+	}
+#endif
 	int round = 0;
 	for (round = 0; round < NumberOfRounds; round++)
 	{
@@ -202,6 +210,12 @@ static void sha3_permutation(uint64_t *state)
 		/* apply iota(state, round) */
 		*state ^= keccak_round_constants[round];
 	}
+#if BYTE_ORDER == BIG_ENDIAN
+	for (i = 0; i < 25; i++)
+	{
+		REVERSE64(state[i], state[i]);
+	}
+#endif
 }
 
 /**


### PR DESCRIPTION
This patch fixes multiple errors in the crypto routines, related to lack of big-endian support.  Correctness is measured by using test_check.

Big-endian builds already needed `CFLAGS="-DSPH_BIG_ENDIAN=1 -DSPH_LITTLE_ENDIAN=0 -DBYTE_ORDER=BIG_ENDIAN"` for some existing endian support; this does not change.

## Before Patch

x86_64 (little-endian, 64-bit): `test_check` passes 100%
MIPS (big-endian, 32-bit): `test_check` **passes 81%, 28 failures** (and 0 errors)

## After Patch

x86_64 (little-endian, 64-bit): `test_check` passes 100%
MIPS (big-endian, 32-bit): `test_check` passes 100%

## Change descriptions

- All adjustments re-use the `BIG_ENDIAN` / `LITTLE_ENDIAN` / `BYTE_ORDER` defines and swap functions already present in `sha2.h`, for consistency
- Fixed endian issues in `sha3` (this fixes many failed tests, as sha3 is a dependency to much other stuff)
- Fixed endian issues in `blake2b` and `blake2s`
- Added `test_check` coverage for blake2b-256-personalized using ZCash test vectors, to ensure the big-endian fixes to blake2b personalize are correct (`test_check` only covered Key, not Personalize)
- Fixed endian issue in `xmr_base58` and `xmr_subaddress_get_secret_key`
- Fixed bug in `test_check` slip39 word to index test (test was using `sizeof(char*)` instead of `strlen(char*)` as `word_length`)
- ~~Because the codebase allows easy include / exclude of different crypto functions, I opted to mildly replicate the endian defines into each `.h` that needs them~~
- Common `byte_order.h`, using the code from `sha2.h`, was created

~~A common header + consistent setting for all these endian defines and endian detection would eventually be ideal, but that further pulls in groestl rework (which used it's own set of defines, separate from sha2).  For now, the changes are the bare minimum just to get big endian systems to produce correct crypto calculations.~~


## Testing

All existing (little-endian) systems should be unaffected by any change. 

To test the big endian changes, you need to just build and run `test_check` on a big-endian system.  QEMU MIPS is sufficient, you can loosely follow steps to set it up here: https://aircrack-ng.blogspot.com/2018/10/to-be-or-not-to-be-using-qemu-to-run.html

If you test on QEMU, you will need to extend the default test timeout or you will likely get test timeout errors.

```
cd crypto/
export CK_DEFAULT_TIMEOUT=20
export CFLAGS="-DSPH_BIG_ENDIAN=1 -DSPH_LITTLE_ENDIAN=0 -DBYTE_ORDER=BIG_ENDIAN"
make tests/test_check
tests/test_check
```
