### PR TITLE
chore(proto): backwards compatibility changes for protobuf defs

### DIFF
--- a/common/protob/messages-management.proto
+++ b/common/protob/messages-management.proto
@@ -34,8 +34,7 @@ enum SafetyCheckLevel {
  */
 message Initialize {
     optional bytes session_id = 1;     // assumed device session id; Trezor clears caches if it is different or empty
-    // optional bool skip_passphrase = 2;  // removed as part of passphrase redesign
-    reserved 2;
+    optional boolean _skip_passphrase = 2 [deprecated=true]; // removed as part of passphrase redesign
     optional bool derive_cardano = 3;  // whether to derive Cardano Icarus root keys in this session
 }
 
@@ -67,7 +66,7 @@ message Features {
     optional bytes bootloader_hash = 14;        // hash of the bootloader
     optional bool imported = 15;                // was storage imported from an external source?
     optional bool unlocked = 16;                // is the device unlocked? called "pin_cached" previously
-//    optional bool passphrase_cached = 17;       // is passphrase already cached in session?  DEPRECATED
+    optional bool _passphrase_cached = 17 [deprecated=true]; // is passphrase already cached in session?
     optional bool firmware_present = 18;        // is valid firmware loaded?
     optional bool needs_backup = 19;            // does storage need backup? (equals to Storage.needs_backup)
     optional uint32 flags = 20;                 // device flags (equals to Storage.flags)
@@ -143,7 +142,7 @@ message ApplySettings {
     optional string label = 2;
     optional bool use_passphrase = 3;
     optional bytes homescreen = 4;
-//    optional PassphraseSourceType passphrase_source = 5;  DEPRECATED
+    optional uint32 _passphrase_source = 5 [deprecated=true];   // ASK = 0; DEVICE = 1; HOST = 2;
     optional uint32 auto_lock_delay_ms = 6;
     optional uint32 display_rotation = 7;  // in degrees from North
     optional bool passphrase_always_on_device = 8;  // do not prompt for passphrase, enforce device entry


### PR DESCRIPTION
At the moment trezor-connect holds [4 sets of protobuf definitions](https://github.com/trezor/connect/tree/develop/src/data/messages) and loads them dynamically based on the version of currently connected device.

We would like to upgrade to the [new trezor-link version](https://github.com/trezor/trezor-link/pull/44). To be able to do that we kind of need to get rid of multiple messages.json files. 

So we started digging into "what got wrong" to find out why we needed to introduce this workaround in the past. Obviously it was because of some backwards incompatible changes to .proto files and our lack of assertiveness probably :joy_cat: 

We (me and @szymonlesisz) propose re-introducing some of the fields that used to exist in past. ack @matejcik 

So far I have added those that seem to be the most important to us. There were also some backwards incompatible changes in altcoins specific .proto files (eth, stallar) but we are thinking of increasing minimal supported version for methods specific to these coins in trezor connect instead. This should be discussed with @tsusanka probably? 

