### PR TITLE
fix(core): fix emulator build on Apple Silicon

### DIFF
--- a/ci/shell.nix
+++ b/ci/shell.nix
@@ -54,7 +54,6 @@ stdenv.mkDerivation ({
     clang
     editorconfig-checker
     gcc
-    gcc-arm-embedded
     git
     gitAndTools.git-subrepo
     gnumake
@@ -74,6 +73,8 @@ stdenv.mkDerivation ({
   ] ++ lib.optionals (!stdenv.isDarwin) [
     procps
     valgrind
+  ] ++ lib.optionals (!stdenv.isDarwin || !stdenv.isAarch64) [
+    gcc-arm-embedded  # not yet available for aarch64-darwin
   ] ++ lib.optionals (stdenv.isDarwin) [
     darwin.apple_sdk.frameworks.CoreAudio
     darwin.apple_sdk.frameworks.AudioToolbox
@@ -99,6 +100,11 @@ stdenv.mkDerivation ({
 
   # Used by rust bindgen
   LIBCLANG_PATH = "${llvmPackages.libclang.lib}/lib";
+
+  # don't try to use stack protector for Apple Silicon (emulator) binaries
+  # it's broken at the moment
+  hardeningDisable = lib.optionals (stdenv.isDarwin && stdenv.isAarch64) [ "stackprotector" ];
+
 } // (lib.optionalAttrs fullDeps) {
   TREZOR_MONERO_TESTS_PATH = moneroTestsPatched;
 })

--- a/core/embed/unix/mpconfigport.h
+++ b/core/embed/unix/mpconfigport.h
@@ -180,6 +180,11 @@
 
 extern const struct _mp_print_t mp_stderr_print;
 
+#if !(defined(MICROPY_GCREGS_SETJMP) || defined(__x86_64__) || defined(__i386__) || defined(__thumb2__) || defined(__thumb__) || defined(__arm__))
+// Fall back to setjmp() implementation for discovery of GC pointers in registers.
+#define MICROPY_GCREGS_SETJMP (1)
+#endif
+
 // coverage support
 #define MICROPY_PY_SYS_ATEXIT       (1)
 #define MICROPY_PY_SYS_SETTRACE     (1)


### PR DESCRIPTION
Supersedes https://github.com/trezor/trezor-firmware/pull/1899

ifdef from https://github.com/micropython/micropython/blob/ff4f1f3ab395a6be426cc1b6ce0839bf65574f45/ports/unix/mpconfigport.h#L189-L192

Also let's not try to harden emulator binaries via stackprotector, it does not work on Apple Silicon atm.