### PR TITLE
fix(crypto): fix undefined behaviour of IS_ALIGNED_64 macro

### DIFF
--- a/crypto/sha3.c
+++ b/crypto/sha3.c
@@ -26,7 +26,7 @@
 #define I64(x) x##LL
 #define ROTL64(qword, n) ((qword) << (n) ^ ((qword) >> (64 - (n))))
 #define le2me_64(x) (x)
-#define IS_ALIGNED_64(p) (0 == (7 & ((const char*)(p) - (const char*)0)))
+#define IS_ALIGNED_64(p) (0 == (((uintptr_t)(const void *)(p) & 0x7)))
 # define me64_to_le_str(to, from, length) memcpy((to), (from), (length))
 
 /* constants */


### PR DESCRIPTION
Fixes https://github.com/satoshilabs/trezor-firmware/issues/121.