### PR TITLE
style(all): reformat with clang-format 13.0

### DIFF
--- a/ci/shell.nix
+++ b/ci/shell.nix
@@ -65,6 +65,7 @@ stdenv.mkDerivation ({
     pkgconfig
     poetry
     protobuf3_6
+    pyright
     rustfmt
     rustStable
     wget

--- a/ci/shell.nix
+++ b/ci/shell.nix
@@ -8,10 +8,10 @@ let
     url = "https://github.com/oxalica/rust-overlay/archive/9fd1c36484a844683153896f37d6fd28b365b931.tar.gz";
     sha256 = "1nylnc16y9jwjajvq2zj314lla2g16p77jhaj3vapfgq17n78i12";
   });
-  # the last successful build of nixpkgs-unstable as of 2021-07-09
+  # the last successful build of nixpkgs-unstable as of 2021-11-18
   nixpkgs = import (builtins.fetchTarball {
-    url = "https://github.com/NixOS/nixpkgs/archive/7b4ff2184e4cab274ecb2b2eb49d20ef2142ddf1.tar.gz";
-    sha256 = "1gdjm0qv5x9jx3zps7vz6yh10rkhmrbk7vf0b2hx5x6wi8yngfnb";
+    url = "https://github.com/NixOS/nixpkgs/archive/7fad01d9d5a3f82081c00fb57918d64145dc904c.tar.gz";
+    sha256 = "0g0jn8cp1f3zgs7xk2xb2vwa44gb98qlp7k0dvigs0zh163c2kim";
   }) { overlays = [ rustOverlay ]; };
   moneroTests = nixpkgs.fetchurl {
     url = "https://github.com/ph4r05/monero/releases/download/v0.17.1.9-tests/trezor_tests";

--- a/core/embed/extmod/modtrezorui/display.c
+++ b/core/embed/extmod/modtrezorui/display.c
@@ -288,15 +288,14 @@ void display_avatar(int x, int y, const void *data, uint32_t datalen,
     if (px >= x0 && px <= x1 && py >= y0 && py <= y1) {
       int d = (px - AVATAR_IMAGE_SIZE / 2) * (px - AVATAR_IMAGE_SIZE / 2) +
               (py - AVATAR_IMAGE_SIZE / 2) * (py - AVATAR_IMAGE_SIZE / 2);
-      // inside border area
       if (d < AVATAR_BORDER_LOW) {
+        // inside border area
         PIXELDATA((decomp_out[0] << 8) | decomp_out[1]);
-      } else
-          // outside border area
-          if (d > AVATAR_BORDER_HIGH) {
+      } else if (d > AVATAR_BORDER_HIGH) {
+        // outside border area
         PIXELDATA(bgcolor);
-        // border area
       } else {
+        // border area
 #if AVATAR_ANTIALIAS
         d = 31 * (d - AVATAR_BORDER_LOW) /
             (AVATAR_BORDER_HIGH - AVATAR_BORDER_LOW);

--- a/legacy/firmware/crypto.c
+++ b/legacy/firmware/crypto.c
@@ -223,9 +223,8 @@ int cryptoMessageVerify(const CoinInfo *coin, const uint8_t *message,
         len != address_prefix_bytes_len(coin->address_type) + 20) {
       return 2;
     }
-  } else
-      // segwit-in-p2sh
-      if (signature[0] >= 35 && signature[0] <= 38) {
+  } else if (signature[0] >= 35 && signature[0] <= 38) {
+    // segwit-in-p2sh
     size_t len = base58_decode_check(address, coin->curve->hasher_base58,
                                      addr_raw, MAX_ADDR_RAW_SIZE);
     ecdsa_get_address_segwit_p2sh_raw(pubkey, coin->address_type_p2sh,
@@ -235,9 +234,8 @@ int cryptoMessageVerify(const CoinInfo *coin, const uint8_t *message,
         len != address_prefix_bytes_len(coin->address_type_p2sh) + 20) {
       return 2;
     }
-  } else
-      // segwit
-      if (signature[0] >= 39 && signature[0] <= 42) {
+  } else if (signature[0] >= 39 && signature[0] <= 42) {
+    // segwit
     int witver = 0;
     size_t len = 0;
     if (!coin->bech32_prefix ||


### PR DESCRIPTION
New clang-format does weird thing with `} else // comment<lf> if (...) {`: https://github.com/trezor/trezor-firmware/commit/7a35984591e2efbaa38bd6ef5a96221a89052677 . I don't know [which new option](https://releases.llvm.org/13.0.0/tools/clang/docs/ReleaseNotes.html#clang-format) disables this behavior, if any, so I moved the comments inside the `if` body instead.

Requires #1924.