### PR TITLE
fix(legacy): update account naming

### DIFF
--- a/legacy/firmware/layout2.c
+++ b/legacy/firmware/layout2.c
@@ -123,17 +123,19 @@ static const char *address_n_str(const uint32_t *address_n,
     if (abbr && accnum < 100) {
       memzero(path, sizeof(path));
       strlcpy(path, abbr, sizeof(path));
-      // TODO: how to name accounts?
-      // currently we have
-      // "legacy account", "account", "segwit account" and "taproot account"
+      // account naming:
+      // "Legacy", "Legacy SegWit", "SegWit" and "Taproot"
       // for BIP44/P2PKH, BIP49/P2SH-P2WPKH, BIP84/P2WPKH and BIP86/P2TR
-      // respectively
+      // respectively.
+      // For non-segwit coins we use only BIP44 with no special naming.
       if (legacy) {
-        strlcat(path, " legacy", sizeof(path));
+        strlcat(path, " Legacy", sizeof(path));
+      } else if (p2sh_segwit) {
+        strlcat(path, " L.SegWit", sizeof(path));
       } else if (native_segwit) {
-        strlcat(path, " segwit", sizeof(path));
+        strlcat(path, " SegWit", sizeof(path));
       } else if (taproot) {
-        strlcat(path, " taproot", sizeof(path));
+        strlcat(path, " Taproot", sizeof(path));
       }
       if (address_is_account) {
         strlcat(path, " address #", sizeof(path));


### PR DESCRIPTION
Fixes https://github.com/trezor/trezor-firmware/issues/1341

Relevant to https://github.com/trezor/trezor-suite/issues/4534

----

The only thing I am not happy about is the need to abbreviate the "Legacy Segwit" to "L.SegWit" because of not enough pixel estate. 

"Legacy"

<img width="511" alt="Screenshot 2021-11-22 at 11 00 33" src="https://user-images.githubusercontent.com/42201/142842754-566d20fe-294f-4230-a390-c79ecb7c720c.png">

"Legacy Segwit"

<img width="511" alt="Screenshot 2021-11-22 at 11 07 37" src="https://user-images.githubusercontent.com/42201/142842767-b2511036-7540-49a1-8cfd-6946a82e7a56.png">

"SegWit"

<img width="511" alt="Screenshot 2021-11-22 at 11 00 07" src="https://user-images.githubusercontent.com/42201/142842748-e711202b-2c8e-4239-a7e9-a833fb640fc3.png">

"Taproot"

<img width="511" alt="Screenshot 2021-11-22 at 11 01 58" src="https://user-images.githubusercontent.com/42201/142842761-91b4e8db-5e4b-4244-af86-86a4983d0722.png">
