### PR TITLE
build(core): place secp256k1-zkp in FLASH2 to make space for bootloader

### DIFF
--- a/core/embed/firmware/memory_T.ld
+++ b/core/embed/firmware/memory_T.ld
@@ -44,6 +44,7 @@ SECTIONS {
 
   .flash2 : ALIGN(512) {
     build/firmware/frozen_mpy.o(.rodata*);
+    build/firmware/vendor/secp256k1-zkp/src/secp256k1.o(.rodata*);
     . = ALIGN(512);
   } >FLASH2 AT>FLASH2
 


### PR DESCRIPTION
Since 9e0cfa678382b607664300dc1c714c48c4e4ea50 core fw fails to build with `PRODUCTION=1`:
```
/nix/store/z8qcil5m2l7xm5r4r604kikm60bli625-gcc-arm-embedded-10.3.1/bin/../lib/gcc/arm-none-eabi/10.3.1/../../../../arm-none-eabi/bin/ld: build/firmware/firmware.elf section `.flash' will not fit in region `FLASH'
/nix/store/z8qcil5m2l7xm5r4r604kikm60bli625-gcc-arm-embedded-10.3.1/bin/../lib/gcc/arm-none-eabi/10.3.1/../../../../arm-none-eabi/bin/ld: region `FLASH' overflowed by 62984 bytes
collect2: error: ld returned 1 exit status
```
This reverts to linker script with explicit secp256k1-zkp handling.