### PR TITLE
Keep bootloader image in non-production builds

### DIFF
--- a/core/embed/firmware/memory_T.ld
+++ b/core/embed/firmware/memory_T.ld
@@ -55,6 +55,7 @@ SECTIONS {
     . = ALIGN(4);
     *(.rodata*);
     . = ALIGN(4);
+    KEEP(*(.bootloader));
     *(.bootloader*);
     . = ALIGN(512);
   } >FLASH AT>FLASH


### PR DESCRIPTION
This is supposed to catch early cases when `PRODUCTION=1` build would overflow, but doesn't overflow for developer since linker normally drops the bootloader image, as `check_and_replace_bootloader` is ifdef-ed out.

Obviously the size still differs a bit from full production build, but not by so much.