### PR TITLE
ci: introduce gitlab cache for vnev

### DIFF
--- a/ci/build.yml
+++ b/ci/build.yml
@@ -1,5 +1,12 @@
 image: registry.gitlab.com/satoshilabs/trezor/trezor-firmware/trezor-firmware-env.nix
 
+# Caching
+.gitlab_caching: &gitlab_caching
+  cache:
+    key: "$CI_COMMIT_REF_SLUG"
+    paths:
+      - .venv/
+
 variables:
   SDL_VIDEODRIVER: "dummy"
   XDG_RUNTIME_DIR: "/var/tmp"
@@ -8,6 +15,7 @@ variables:
 
 core fw regular build:
   stage: build
+  <<: *gitlab_caching
   needs: []
   script:
     - nix-shell --run "poetry run make -C core build_boardloader"
@@ -25,6 +33,7 @@ core fw regular build:
 
 core fw regular debug build:
   stage: build
+  <<: *gitlab_caching
   needs: []
   script:
     - nix-shell --run "PYOPT=0 poetry run make -C core build_firmware"
@@ -37,6 +46,7 @@ core fw regular debug build:
 
 core fw btconly build:
   stage: build
+  <<: *gitlab_caching
   needs: []
   variables:
     BITCOIN_ONLY: "1"
@@ -53,6 +63,7 @@ core fw btconly build:
 
 core fw btconly debug build:
   stage: build
+  <<: *gitlab_caching
   needs: []
   variables:
     BITCOIN_ONLY: "1"
@@ -75,6 +86,7 @@ core fw btconly debug build:
 
 core fw btconly t1 build:
   stage: build
+  <<: *gitlab_caching
   needs: []
   variables:
     BITCOIN_ONLY: "1"
@@ -90,6 +102,7 @@ core fw btconly t1 build:
 
 core unix regular build:
   stage: build
+  <<: *gitlab_caching
   needs: []
   script:
     - nix-shell --run "poetry run make -C core build_unix"
@@ -101,6 +114,7 @@ core unix regular build:
 
 core unix frozen regular build:
   stage: build
+  <<: *gitlab_caching
   needs: []
   script:
     - nix-shell --run "poetry run make -C core build_unix_frozen"
@@ -112,6 +126,7 @@ core unix frozen regular build:
 
 core unix frozen btconly debug build:
   stage: build
+  <<: *gitlab_caching
   needs: []
   variables:
     PYOPT: "0"
@@ -127,6 +142,7 @@ core unix frozen btconly debug build:
 
 core unix frozen debug build:
   stage: build
+  <<: *gitlab_caching
   needs: []
   variables:
     PYOPT: "0"
@@ -139,6 +155,7 @@ core unix frozen debug build:
 
 core macos frozen regular build:
   stage: build
+  <<: *gitlab_caching
   needs: []
   when: manual
   tags:
@@ -162,6 +179,7 @@ core macos frozen regular build:
 
 crypto build:
   stage: build
+  <<: *gitlab_caching
   needs: []
   only:
     changes:
@@ -184,6 +202,7 @@ crypto build:
 
 legacy fw regular build:
   stage: build
+  <<: *gitlab_caching
   needs: []
   script:
     - nix-shell --run "export MEMORY_PROTECT=1 && poetry run legacy/script/cibuild"
@@ -199,6 +218,7 @@ legacy fw regular build:
 
 legacy fw regular debug build:
   stage: build
+  <<: *gitlab_caching
   needs: []
   variables:
     DEBUG_LINK: "1"
@@ -215,6 +235,7 @@ legacy fw regular debug build:
 
 legacy fw btconly build:
   stage: build
+  <<: *gitlab_caching
   needs: []
   variables:
     BITCOIN_ONLY: "1"
@@ -233,6 +254,7 @@ legacy fw btconly build:
 
 legacy fw btconly debug build:
   stage: build
+  <<: *gitlab_caching
   needs: []
   variables:
     BITCOIN_ONLY: "1"
@@ -251,6 +273,7 @@ legacy fw btconly debug build:
 
 legacy emu regular debug build:
   stage: build
+  <<: *gitlab_caching
   needs: []
   variables:
     DEBUG_LINK: "1"
@@ -265,6 +288,7 @@ legacy emu regular debug build:
 
 legacy emu btconly debug build:
   stage: build
+  <<: *gitlab_caching
   needs: []
   variables:
     BITCOIN_ONLY: "1"

--- a/ci/posttest.yml
+++ b/ci/posttest.yml
@@ -1,9 +1,17 @@
 image: registry.gitlab.com/satoshilabs/trezor/trezor-firmware/trezor-firmware-env.nix
 
+# Caching
+.gitlab_caching: &gitlab_caching
+  cache:
+    key: "$CI_COMMIT_REF_SLUG"
+    paths:
+      - .venv/
+
 core unix coverage posttest:
   stage: posttest
   variables:
     COVERAGE_THRESHOLD: "78"
+  <<: *gitlab_caching
   needs:
     - core device test
     - core monero test
@@ -24,6 +32,7 @@ core unix ui changes:
   stage: posttest
   except:
     - master
+  <<: *gitlab_caching
   needs:
     - core device ui test
   script:

--- a/ci/prebuild.yml
+++ b/ci/prebuild.yml
@@ -1,29 +1,41 @@
 image: registry.gitlab.com/satoshilabs/trezor/trezor-firmware/trezor-firmware-env.nix
 
+# Caching
+.gitlab_caching: &gitlab_caching
+  cache:
+    key: "$CI_COMMIT_REF_SLUG"
+    paths:
+      - .venv/
+
 style prebuild:
   stage: prebuild
   variables:
     GIT_SUBMODULE_STRATEGY: "none"
+  <<: *gitlab_caching
   script:
     - nix-shell --run "poetry run make style_check"
 
 common prebuild:
   stage: prebuild
+  <<: *gitlab_caching
   script:
     - nix-shell --run "poetry run make defs_check"
 
 gen prebuild:
   stage: prebuild
+  <<: *gitlab_caching
   script:
     - nix-shell --run "poetry run make gen_check"
 
 editor prebuild:
   stage: prebuild
+  <<: *gitlab_caching
   script:
     - nix-shell --run "make editor_check"
 
 yaml prebuild:
   stage: prebuild
+  <<: *gitlab_caching
   script:
     - nix-shell --run "poetry run make yaml_check"
 

--- a/ci/test-hw.yml
+++ b/ci/test-hw.yml
@@ -1,5 +1,12 @@
 image: registry.gitlab.com/satoshilabs/trezor/trezor-firmware/trezor-firmware-env.nix
 
+# Caching
+.gitlab_caching: &gitlab_caching
+  cache:
+    key: "$CI_COMMIT_REF_SLUG"
+    paths:
+      - .venv/
+
 # Hardware
 
 # Currently it's not possible to run all regular TT tests without getting into

--- a/ci/test.yml
+++ b/ci/test.yml
@@ -1,9 +1,17 @@
 image: registry.gitlab.com/satoshilabs/trezor/trezor-firmware/trezor-firmware-env.nix
 
+# Caching
+.gitlab_caching: &gitlab_caching
+  cache:
+    key: "$CI_COMMIT_REF_SLUG"
+    paths:
+      - .venv/
+
 # Core
 
 core unit test:
   stage: test
+  <<: *gitlab_caching
   needs:
     - core unix regular build
   script:
@@ -13,6 +21,7 @@ core unit test:
 
 core device ui test:
   stage: test
+  <<: *gitlab_caching
   needs:
     - core unix frozen debug build
   script:
@@ -37,6 +46,7 @@ core device ui test:
 
 core device test:
   stage: test
+  <<: *gitlab_caching
   needs:
     - core unix frozen debug build
   variables:
@@ -57,6 +67,7 @@ core device test:
 
 core btconly device test:
   stage: test
+  <<: *gitlab_caching
   needs:
     - core unix frozen btconly debug build
   variables:
@@ -76,6 +87,7 @@ core btconly device test:
 
 core monero test:
   stage: test
+  <<: *gitlab_caching
   needs:
     - core unix frozen debug build
   variables:
@@ -94,6 +106,7 @@ core monero test:
 
 core u2f test:
   stage: test
+  <<: *gitlab_caching
   needs:
     - core unix frozen debug build
   variables:
@@ -112,6 +125,7 @@ core u2f test:
 
 core fido2 test:
   stage: test
+  <<: *gitlab_caching
   needs:
     - core unix frozen debug build
   variables:
@@ -134,6 +148,7 @@ core fido2 test:
 
 core click test:
   stage: test
+  <<: *gitlab_caching
   needs:
     - core unix frozen debug build
   script:
@@ -150,6 +165,7 @@ core click test:
 
 core upgrade test:
   stage: test
+  <<: *gitlab_caching
   needs:
     - core unix frozen debug build
   variables:
@@ -168,6 +184,7 @@ core upgrade test:
 
 core persistence test:
   stage: test
+  <<: *gitlab_caching
   needs:
     - core unix frozen debug build
   script:
@@ -191,6 +208,7 @@ crypto test:
       - .gitlab-ci.yml
       - ci/**/*
       - crypto/**/*
+  <<: *gitlab_caching
   needs:
     - crypto build
   script:
@@ -213,6 +231,7 @@ crypto test:
 
 legacy test:
   stage: test
+  <<: *gitlab_caching
   needs:
     - legacy emu regular debug build
   variables:
@@ -230,6 +249,7 @@ legacy test:
 
 legacy btconly test:
   stage: test
+  <<: *gitlab_caching
   needs:
     - legacy emu btconly debug build
   variables:
@@ -250,6 +270,7 @@ legacy btconly test:
 
 legacy upgrade test:
   stage: test
+  <<: *gitlab_caching
   needs:
     - legacy emu regular debug build
   variables:
@@ -271,6 +292,7 @@ legacy upgrade test:
 
 python test:
   stage: test
+  <<: *gitlab_caching
   needs: []
   variables:
     LC_ALL: "C.UTF-8"
@@ -304,6 +326,7 @@ storage test:
       - .gitlab-ci.yml
       - ci/**/*
       - storage/**/*
+  <<: *gitlab_caching
   needs: []
   script:
     - nix-shell --run "poetry run make -C storage/tests build | ts -s"
@@ -322,6 +345,7 @@ storage test:
 core unix memory profiler:
   stage: test
   when: manual
+  <<: *gitlab_caching
   needs: []
   variables:
     PYOPT: "0"


### PR DESCRIPTION
This introduces caching of `.venv` with GitLab cache. Related to this [issue](https://github.com/satoshilabs/devops/issues/49)

I hope I didn't miss any job that is installing poetry and would benefit from this. Also, this type of cache is per branch it means that the first time branch runs, the ci will create cache for it and use that next time that branch runs in the ci. 