### PR TITLE
ci: auto add new issues to backlog project

### DIFF
--- a/.github/workflows/project_automation.yml
+++ b/.github/workflows/project_automation.yml
@@ -1,0 +1,13 @@
+name: Add to GitHub Project
+on: [issues]
+jobs:
+  github-actions-automate-projects:
+    runs-on: ubuntu-latest
+    steps:
+      - name: add-new-issues-to-repository-based-project-column
+        uses: docker://takanabe/github-actions-automate-projects:v0.0.1
+        if: github.event_name == 'issues' && github.event.action == 'opened'
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GITHUB_PROJECT_URL: https://github.com/trezor/trezor-firmware/projects/1
+          GITHUB_PROJECT_COLUMN_NAME: 📥 Inbox


### PR DESCRIPTION
This GitHub workflow automatically adds every newly created issue to the Inbox column in the Backlog project. This is the same setup as we have for the trezor-suite.