### PR TITLE
perf(legacy/bootloader): use slow but small implementation of bn_inverse

### DIFF
--- a/legacy/bootloader/Makefile
+++ b/legacy/bootloader/Makefile
@@ -11,6 +11,7 @@ OBJS += ../gen/fonts.small.o
 # overrides from trezor-crypto
 CFLAGS += -DUSE_PRECOMPUTED_IV=0
 CFLAGS += -DUSE_PRECOMPUTED_CP=0
+CFLAGS += -DUSE_INVERSE_FAST=0
 OBJS += ../vendor/trezor-crypto/bignum.small.o
 OBJS += ../vendor/trezor-crypto/ecdsa.small.o
 OBJS += ../vendor/trezor-crypto/secp256k1.small.o


### PR DESCRIPTION
|            | bootloader size | `ecdsa_verify_digest` time |
|------------|-----------------|----------------------------|
| before     | 32760 B         | 230 ms                     |
| after      | 32060 B         | 390 ms                     |
| difference | -700 B          | +160 ms                    |

The execution times were measured on TT in python and multiplied by `168/120`. The bootloader verifies 3 signatures on startup, which means the total execution time increases from 700 ms to 1200 ms.

Do you think it's worth it?
