### PR TITLE
Build legacy bootloader with size optimization

### DIFF
--- a/legacy/bootloader/Makefile
+++ b/legacy/bootloader/Makefile
@@ -4,11 +4,30 @@ OBJS += bootloader.o
 OBJS += signatures.o
 OBJS += usb.o
 
-# overrides from libtrezor
+# Overrides from libtrezor. Objects ending with 'small.o' are built with -Os to
+# make bootloader smaller.
 CFLAGS += -DFONT_SKIP_FIXED=1
 OBJS += ../gen/fonts.small.o
+OBJS += ../startup.o
+OBJS += ../buttons.small.o
+OBJS += ../common.small.o
+OBJS += ../flash.small.o
+OBJS += ../layout.small.o
+OBJS += ../oled.small.o
+OBJS += ../random_delays.small.o
+OBJS += ../rng.small.o
+OBJS += ../setup.small.o
+OBJS += ../util.small.o
+OBJS += ../memory.small.o
+OBJS += ../supervise.small.o
+OBJS += ../timer.small.o
+OBJS += ../usb_standard.small.o
+OBJS += ../usb21_standard.small.o
+OBJS += ../webusb.small.o
+OBJS += ../winusb.small.o
+OBJS += ../gen/bitmaps.small.o
 
-# overrides from trezor-crypto
+# Overrides from trezor-crypto
 CFLAGS += -DUSE_PRECOMPUTED_IV=0
 CFLAGS += -DUSE_PRECOMPUTED_CP=0
 OBJS += ../vendor/trezor-crypto/bignum.small.o
@@ -21,6 +40,9 @@ OBJS += ../vendor/trezor-crypto/hmac_drbg.small.o
 OPTFLAGS ?= -Os
 
 include ../Makefile.include
+
+# Remove libtrezor from linking since we specified the small versions
+LDLIBS := $(filter-out -ltrezor,$(LDLIBS))
 
 align: $(NAME).bin
 	./firmware_align.py $(NAME).bin


### PR DESCRIPTION
Some objects from libtrezor were compiled with `-O3` even when used in bootloader. This changes their compilation to size optimization `-Os`, saving currently 1116 bytes in legacy bootloader.