### PR TITLE
fix(python): allowing PIN/passphrase input for Git Bash

### DIFF
--- a/python/.changelog.d/1959.fixed
+++ b/python/.changelog.d/1959.fixed
@@ -1,0 +1,1 @@
+Fix PIN and passphrase entry in certain terminals on Windows


### PR DESCRIPTION
Trying to solve https://github.com/trezor/trezor-firmware/issues/1737

Allowing the input for PIN/passphrase on Windows in Git Bash, which has issues with hidden input.

Recognizing the situation (through `sys.stdin.isatty()`) and in negative case disallowing the hidden feature and reporting this to the user.

Screenshot from Git Bash on Windows:

![image](https://user-images.githubusercontent.com/42543243/144034303-3a326cc9-d90d-4bde-b58a-8a1b8366bab6.png)
