### PR TITLE
ci(nix): remove clang-tools

### DIFF
--- a/ci/shell.nix
+++ b/ci/shell.nix
@@ -55,7 +55,6 @@ stdenv.mkDerivation ({
     autoflake
     bash
     check
-    clang-tools
     clang
     editorconfig-checker
     gcc


### PR DESCRIPTION
We have added clang-tools explicitly earlier because we needed
clang-format v9 which was only in that package (while clang shipped v7).

Things are different now and clang package now ships clang-format v11.

Fixes https://github.com/trezor/trezor-firmware/issues/1934