### PR TITLE
ci(nix): use explicit versions for clang and gcc

### DIFF
--- a/ci/shell.nix
+++ b/ci/shell.nix
@@ -41,7 +41,7 @@ let
   llvmPackages = nixpkgs.llvmPackages_12;
 in
 with nixpkgs;
-stdenv.mkDerivation ({
+stdenvNoCC.mkDerivation ({
   name = "trezor-firmware-env";
   buildInputs = lib.optionals fullDeps [
     # install other python versions for tox testing

--- a/ci/shell.nix
+++ b/ci/shell.nix
@@ -37,6 +37,8 @@ let
     # to use official binary, remove rustfmt from buildInputs and add it to extensions:
     extensions = [ "clippy" ];
   };
+  gcc = nixpkgs.gcc11;
+  llvmPackages = nixpkgs.llvmPackages_12;
 in
 with nixpkgs;
 stdenv.mkDerivation ({
@@ -55,8 +57,7 @@ stdenv.mkDerivation ({
     autoflake
     bash
     check
-    clang-tools
-    clang
+    llvmPackages.clang
     editorconfig-checker
     gcc
     git


### PR DESCRIPTION
Supersedes https://github.com/trezor/trezor-firmware/pull/1968

Fixes #1934