### PR TITLE
feat(legacy): Implement EIP-712 signing

### DIFF
--- a/ci/check_changelog.sh
+++ b/ci/check_changelog.sh
@@ -6,11 +6,11 @@ subdirs="core core/embed/boardloader core/embed/bootloader core/embed/bootloader
 
 # $ignored_files is a newline-separated list of patterns for grep
 # therefore there must not be empty lines at start or end
-ignored_files="core/src/apps/ethereum/networks.py
-core/src/apps/ethereum/tokens.py
-core/src/trezor/enums/*
-core/src/trezor/messages.py
-python/src/trezorlib/messages.py"
+ignored_files="^core/src/apps/ethereum/networks.py$
+^core/src/apps/ethereum/tokens.py$
+^core/src/trezor/enums/.*
+^core/src/trezor/messages.py$
+^python/src/trezorlib/messages.py$"
 
 changed_files=$(mktemp)
 trap 'rm -- $changed_files' EXIT
@@ -26,7 +26,7 @@ check_feature_branch () {
             continue
         fi
 
-        git show --pretty=format: --name-only "$commit" | grep -vF "$ignored_files" >> "$changed_files"
+        git show --pretty=format: --name-only "$commit" | grep -v "$ignored_files" >> "$changed_files"
     done
 
     for subdir in $subdirs

--- a/common/protob/messages-ethereum-eip712.proto
+++ b/common/protob/messages-ethereum-eip712.proto
@@ -87,12 +87,3 @@ message EthereumTypedDataValueAck {
     // * array types: number of elements, encoded as uint16.
     // * struct types: undefined, Trezor will not query a struct field.
 }
-
-/**
- * Response: Signed typed data
- * @end
- */
-message EthereumTypedDataSignature {
-    required bytes signature = 1;    // signature of the typed data
-    required string address = 2;     // address used to sign the typed data
-}

--- a/common/protob/messages-ethereum.proto
+++ b/common/protob/messages-ethereum.proto
@@ -149,3 +149,24 @@ message EthereumVerifyMessage {
     required bytes message = 3;     // message to verify
     required string address = 4;     // address to verify
 }
+
+/**
+ * Request: Ask device to sign hash of typed data
+ * @start
+ * @next EthereumTypedDataSignature
+ * @next Failure
+ */
+message EthereumSignTypedHash {
+    repeated uint32 address_n = 1;              // BIP-32 path to derive the key from master node
+    required bytes domain_separator_hash = 2;   // Hash of domainSeparator of typed data to be signed
+    required bytes message_hash = 3;               // Hash of the data of typed data to be signed
+}
+
+/**
+ * Response: Signed typed data
+ * @end
+ */
+message EthereumTypedDataSignature {
+    required bytes signature = 1;    // signature of the typed data
+    required string address = 2;     // address used to sign the typed data
+}

--- a/common/protob/messages.proto
+++ b/common/protob/messages.proto
@@ -191,6 +191,7 @@ enum MessageType {
     MessageType_EthereumTypedDataValueRequest = 467 [(wire_out) = true];
     MessageType_EthereumTypedDataValueAck = 468 [(wire_in) = true];
     MessageType_EthereumTypedDataSignature = 469 [(wire_out) = true];
+    MessageType_EthereumSignTypedHash = 470 [(wire_in) = true];
 
     // NEM
     MessageType_NEMGetAddress = 67 [(wire_in) = true];

--- a/common/tests/fixtures/ethereum/sign_typed_data.json
+++ b/common/tests/fixtures/ethereum/sign_typed_data.json
@@ -72,7 +72,9 @@
                         },
                         "contents": "Hello, Bob!"
                     }
-                }
+                },
+                "message_hash": "0xea6529f0ee9eb0b207b5a8b0ebfa673d398d6a78262818da1d270bd138f81f03",
+                "domain_separator_hash": "0x97d6f53774b810fbda27e091c03c6a6d6815dd1270c2e62e82c6917c1eff774b"
             },
             "result": {
                 "address": "0x73d0385F4d8E00C5e6504C6030F47BF6212736A8",
@@ -209,7 +211,9 @@
                             "Hope you're fine"
                         ]
                     }
-                }
+                },
+                "message_hash": "0xdbafe746b1c47e4870f6f77205660d3c49a94db9a80939809bfca7bf43919df5",
+                "domain_separator_hash": "0xc4f4e0cd1376e27837fe933e3f77b7bd6213211b377f0e19815a0dbd194731cc"
             },
             "result": {
                 "address": "0x73d0385F4d8E00C5e6504C6030F47BF6212736A8",
@@ -290,7 +294,9 @@
                         ],
                         "contents": "Hello, guys!"
                     }
-                }
+                },
+                "message_hash": "0xc16c4b0b9a45a8e9c34c4074d8deb589686f7de3b83e80596ec79f815a17276e",
+                "domain_separator_hash": "0x97d6f53774b810fbda27e091c03c6a6d6815dd1270c2e62e82c6917c1eff774b"
             },
             "result": {
                 "address": "0x73d0385F4d8E00C5e6504C6030F47BF6212736A8",
@@ -371,11 +377,110 @@
                         ],
                         "contents": "Hello, guys!"
                     }
-                }
+                },
+                "message_hash": "0x6ba2528513daa98abdbec7363a77751fc79ca38fe6d37bdbb983e310e5c1444e",
+                "domain_separator_hash": "0x97d6f53774b810fbda27e091c03c6a6d6815dd1270c2e62e82c6917c1eff774b"
             },
             "result": {
                 "address": "0x73d0385F4d8E00C5e6504C6030F47BF6212736A8",
                 "sig": "0xba6658fd95d8f6048150c8ac64a596d974184522d1069237a57d0e170835fff661ff6f10c5049906a8a508c18d58145dcff91508e70e7e3c186193e3e3bb7dd61b"
+            }
+        },
+        {
+            "name": "structs_arrays_v4",
+            "parameters": {
+                "path": "m/44'/60'/0'/0/0",
+                "metamask_v4_compat": true,
+                "data": {
+                    "domain": {
+                        "chainId": 1,
+                        "name": "Ether Mail",
+                        "verifyingContract": "0xCcCCccccCCCCcCCCCCCcCcCccCcCCCcCcccccccC",
+                        "version": "1"
+                    },
+                    "message": {
+                        "contents": "Hello, Bob!",
+                        "attachedMoneyInEth": 4.2,
+                        "from": {
+                            "name": "Cow",
+                            "wallets": [
+                                "0xCD2a3d9F938E13CD947Ec05AbC7FE734Df8DD826",
+                                "0xDeaDbeefdEAdbeefdEadbEEFdeadbeEFdEaDbeeF"
+                            ]
+                        },
+                        "to": [
+                            {
+                                "name": "Bob",
+                                "wallets": [
+                                    "0xbBbBBBBbbBBBbbbBbbBbbbbBBbBbbbbBbBbbBBbB",
+                                    "0xB0BdaBea57B0BDABeA57b0bdABEA57b0BDabEa57",
+                                    "0xB0B0b0b0b0b0B000000000000000000000000000"
+                                ]
+                            }
+                        ]
+                    },
+                    "primaryType": "Mail",
+                    "types": {
+                        "EIP712Domain": [
+                            {
+                                "name": "name",
+                                "type": "string"
+                            },
+                            {
+                                "name": "version",
+                                "type": "string"
+                            },
+                            {
+                                "name": "chainId",
+                                "type": "uint256"
+                            },
+                            {
+                                "name": "verifyingContract",
+                                "type": "address"
+                            }
+                        ],
+                        "Group": [
+                            {
+                                "name": "name",
+                                "type": "string"
+                            },
+                            {
+                                "name": "members",
+                                "type": "Person[]"
+                            }
+                        ],
+                        "Mail": [
+                            {
+                                "name": "from",
+                                "type": "Person"
+                            },
+                            {
+                                "name": "to",
+                                "type": "Person[]"
+                            },
+                            {
+                                "name": "contents",
+                                "type": "string"
+                            }
+                        ],
+                        "Person": [
+                            {
+                                "name": "name",
+                                "type": "string"
+                            },
+                            {
+                                "name": "wallets",
+                                "type": "address[]"
+                            }
+                        ]
+                    }
+                },
+                "domain_separator_hash": "0xf2cee375fa42b42143804025fc449deafd50cc031ca257e0b194a650a912090f",
+                "message_hash": "eb4221181ff3f1a83ea7313993ca9218496e424604ba9492bb4052c03d5c3df8"
+            },
+            "result": {
+                "address": "0x73d0385F4d8E00C5e6504C6030F47BF6212736A8",
+                "sig": "0x1d778d9ae559161f4ea57aad9135035eb7e26e5e4cf5b571c58736ee265b649b17c38730ede957efbcf7de4f30906b133a4262b9e4bb8e4ba3927a48512e3a561c"
             }
         }
     ]

--- a/core/src/trezor/enums/MessageType.py
+++ b/core/src/trezor/enums/MessageType.py
@@ -103,6 +103,7 @@ if not utils.BITCOIN_ONLY:
     EthereumTypedDataValueRequest = 467
     EthereumTypedDataValueAck = 468
     EthereumTypedDataSignature = 469
+    EthereumSignTypedHash = 470
     NEMGetAddress = 67
     NEMAddress = 68
     NEMSignTx = 69

--- a/core/src/trezor/enums/__init__.py
+++ b/core/src/trezor/enums/__init__.py
@@ -108,6 +108,7 @@ if TYPE_CHECKING:
         EthereumTypedDataValueRequest = 467
         EthereumTypedDataValueAck = 468
         EthereumTypedDataSignature = 469
+        EthereumSignTypedHash = 470
         NEMGetAddress = 67
         NEMAddress = 68
         NEMSignTx = 69

--- a/core/src/trezor/messages.py
+++ b/core/src/trezor/messages.py
@@ -3235,6 +3235,40 @@ if TYPE_CHECKING:
         def is_type_of(cls, msg: protobuf.MessageType) -> TypeGuard["EthereumVerifyMessage"]:
             return isinstance(msg, cls)
 
+    class EthereumSignTypedHash(protobuf.MessageType):
+        address_n: "list[int]"
+        domain_separator_hash: "bytes"
+        message_hash: "bytes"
+
+        def __init__(
+            self,
+            *,
+            domain_separator_hash: "bytes",
+            message_hash: "bytes",
+            address_n: "list[int] | None" = None,
+        ) -> None:
+            pass
+
+        @classmethod
+        def is_type_of(cls, msg: protobuf.MessageType) -> TypeGuard["EthereumSignTypedHash"]:
+            return isinstance(msg, cls)
+
+    class EthereumTypedDataSignature(protobuf.MessageType):
+        signature: "bytes"
+        address: "str"
+
+        def __init__(
+            self,
+            *,
+            signature: "bytes",
+            address: "str",
+        ) -> None:
+            pass
+
+        @classmethod
+        def is_type_of(cls, msg: protobuf.MessageType) -> TypeGuard["EthereumTypedDataSignature"]:
+            return isinstance(msg, cls)
+
     class EthereumAccessList(protobuf.MessageType):
         address: "str"
         storage_keys: "list[bytes]"
@@ -3323,22 +3357,6 @@ if TYPE_CHECKING:
 
         @classmethod
         def is_type_of(cls, msg: protobuf.MessageType) -> TypeGuard["EthereumTypedDataValueAck"]:
-            return isinstance(msg, cls)
-
-    class EthereumTypedDataSignature(protobuf.MessageType):
-        signature: "bytes"
-        address: "str"
-
-        def __init__(
-            self,
-            *,
-            signature: "bytes",
-            address: "str",
-        ) -> None:
-            pass
-
-        @classmethod
-        def is_type_of(cls, msg: protobuf.MessageType) -> TypeGuard["EthereumTypedDataSignature"]:
             return isinstance(msg, cls)
 
     class EthereumStructMember(protobuf.MessageType):

--- a/legacy/firmware/.changelog.d/131.added
+++ b/legacy/firmware/.changelog.d/131.added
@@ -1,0 +1,1 @@
+Support for blindly signing EIP-712 data.

--- a/legacy/firmware/ethereum.c
+++ b/legacy/firmware/ethereum.c
@@ -976,6 +976,36 @@ int ethereum_message_verify(const EthereumVerifyMessage *msg) {
   return 0;
 }
 
+static void ethereum_typed_hash(const uint8_t domain_separator_hash[32],
+                                const uint8_t message_hash[32],
+                                uint8_t hash[32]) {
+  struct SHA3_CTX ctx = {0};
+  sha3_256_Init(&ctx);
+  sha3_Update(&ctx, (const uint8_t *)"\x19\x01", 2);
+  sha3_Update(&ctx, domain_separator_hash, 32);
+  sha3_Update(&ctx, message_hash, 32);
+  keccak_Final(&ctx, hash);
+}
+
+void ethereum_typed_hash_sign(const EthereumSignTypedHash *msg,
+                              const HDNode *node,
+                              EthereumTypedDataSignature *resp) {
+  uint8_t hash[32] = {0};
+  ethereum_typed_hash(msg->domain_separator_hash.bytes, msg->message_hash.bytes,
+                      hash);
+
+  uint8_t v = 0;
+  if (ecdsa_sign_digest(&secp256k1, node->private_key, hash,
+                        resp->signature.bytes, &v, ethereum_is_canonic) != 0) {
+    fsm_sendFailure(FailureType_Failure_ProcessError, _("Signing failed"));
+    return;
+  }
+
+  resp->signature.bytes[64] = 27 + v;
+  resp->signature.size = 65;
+  msg_write(MessageType_MessageType_EthereumTypedDataSignature, resp);
+}
+
 bool ethereum_parse(const char *address, uint8_t pubkeyhash[20]) {
   memzero(pubkeyhash, 20);
   size_t len = strlen(address);

--- a/legacy/firmware/ethereum.h
+++ b/legacy/firmware/ethereum.h
@@ -34,6 +34,9 @@ void ethereum_signing_txack(const EthereumTxAck *msg);
 void ethereum_message_sign(const EthereumSignMessage *msg, const HDNode *node,
                            EthereumMessageSignature *resp);
 int ethereum_message_verify(const EthereumVerifyMessage *msg);
+void ethereum_typed_hash_sign(const EthereumSignTypedHash *msg,
+                              const HDNode *node,
+                              EthereumTypedDataSignature *resp);
 bool ethereum_parse(const char *address, uint8_t pubkeyhash[20]);
 
 #endif

--- a/legacy/firmware/fsm.h
+++ b/legacy/firmware/fsm.h
@@ -104,6 +104,7 @@ void fsm_msgEthereumSignTxEIP1559(const EthereumSignTxEIP1559 *msg);
 void fsm_msgEthereumTxAck(const EthereumTxAck *msg);
 void fsm_msgEthereumSignMessage(const EthereumSignMessage *msg);
 void fsm_msgEthereumVerifyMessage(const EthereumVerifyMessage *msg);
+void fsm_msgEthereumSignTypedHash(const EthereumSignTypedHash *msg);
 
 // nem
 void fsm_msgNEMGetAddress(

--- a/legacy/firmware/layout2.c
+++ b/legacy/firmware/layout2.c
@@ -1253,3 +1253,22 @@ void layoutConfirmSafetyChecks(SafetyCheckLevel safety_ckeck_level) {
                       _("be unsafe?"), NULL);
   }
 }
+
+void layoutConfirmHash(const BITMAP *icon, const char *description,
+                       const uint8_t *hash, uint32_t len) {
+  const char **str = split_message_hex(hash, len);
+
+  layoutSwipe();
+  oledClear();
+  oledDrawBitmap(0, 0, icon);
+  oledDrawString(20, 0 * 9, description, FONT_STANDARD);
+  oledDrawString(20, 1 * 9, str[0], FONT_FIXED);
+  oledDrawString(20, 2 * 9, str[1], FONT_FIXED);
+  oledDrawString(20, 3 * 9, str[2], FONT_FIXED);
+  oledDrawString(20, 4 * 9, str[3], FONT_FIXED);
+  oledHLine(OLED_HEIGHT - 13);
+
+  layoutButtonNo(_("Cancel"), &bmp_btn_cancel);
+  layoutButtonYes(_("Confirm"), &bmp_btn_confirm);
+  oledRefresh();
+}

--- a/legacy/firmware/layout2.h
+++ b/legacy/firmware/layout2.h
@@ -110,6 +110,9 @@ void layoutCosiCommitSign(const uint32_t *address_n, size_t address_n_count,
 void layoutConfirmAutoLockDelay(uint32_t delay_ms);
 void layoutConfirmSafetyChecks(SafetyCheckLevel safety_checks_level);
 
+void layoutConfirmHash(const BITMAP *icon, const char *description,
+                       const uint8_t *hash, uint32_t len);
+
 const char **split_message(const uint8_t *msg, uint32_t len, uint32_t rowlen);
 const char **split_message_hex(const uint8_t *msg, uint32_t len);
 

--- a/legacy/firmware/protob/Makefile
+++ b/legacy/firmware/protob/Makefile
@@ -6,7 +6,9 @@ SKIPPED_MESSAGES := Binance Cardano DebugMonero Eos Monero Ontology Ripple SdPro
 	DebugLinkRecordScreen DebugLinkReseedRandom DebugLinkShowText DebugLinkEraseSdCard DebugLinkWatchLayout \
 	GetOwnershipProof OwnershipProof GetOwnershipId OwnershipId AuthorizeCoinJoin DoPreauthorized \
 	CancelAuthorization DebugLinkLayout \
-	TxAckInput TxAckOutput TxAckPrev EthereumSignTypedData EthereumTypedData
+	TxAckInput TxAckOutput TxAckPrev \
+	EthereumSignTypedData EthereumTypedDataStructRequest EthereumTypedDataStructAck \
+	EthereumTypedDataValueRequest EthereumTypedDataValueAck
 
 ifeq ($(BITCOIN_ONLY), 1)
 SKIPPED_MESSAGES += Ethereum NEM Stellar

--- a/legacy/firmware/protob/messages-ethereum.options
+++ b/legacy/firmware/protob/messages-ethereum.options
@@ -34,6 +34,13 @@ EthereumVerifyMessage.message           max_size:1024
 EthereumMessageSignature.address        max_size:43
 EthereumMessageSignature.signature      max_size:65
 
+EthereumSignTypedHash.address_n             max_count:8
+EthereumSignTypedHash.domain_separator_hash max_size:32
+EthereumSignTypedHash.message_hash          max_size:32
+
+EthereumTypedDataSignature.address      max_size:43
+EthereumTypedDataSignature.signature    max_size:65
+
 EthereumGetAddress.address_n            max_count:8
 EthereumGetPublicKey.address_n          max_count:8
 

--- a/python/.changelog.d/1970.added
+++ b/python/.changelog.d/1970.added
@@ -1,0 +1,1 @@
+Add support for blind EIP-712 signing for Trezor One

--- a/python/src/trezorlib/cli/ethereum.py
+++ b/python/src/trezorlib/cli/ethereum.py
@@ -441,3 +441,29 @@ def verify_message(
     """Verify message signed with Ethereum address."""
     signature_bytes = ethereum.decode_hex(signature)
     return ethereum.verify_message(client, address, signature_bytes, message)
+
+
+@cli.command()
+@click.option("-n", "--address", required=True, help=PATH_HELP)
+@click.argument("domain_hash_hex")
+@click.argument("message_hash_hex")
+@with_client
+def sign_typed_data_hash(
+    client: "TrezorClient", address: str, domain_hash_hex: str, message_hash_hex: str
+) -> Dict[str, str]:
+    """
+    Sign hash of typed data (EIP-712) with Ethereum address.
+
+    For T1 backward compatibility.
+    """
+    address_n = tools.parse_path(address)
+    domain_hash = ethereum.decode_hex(domain_hash_hex)
+    message_hash = ethereum.decode_hex(message_hash_hex)
+    ret = ethereum.sign_typed_data_hash(client, address_n, domain_hash, message_hash)
+    output = {
+        "domain_hash": domain_hash_hex,
+        "message_hash": message_hash_hex,
+        "address": ret.address,
+        "signature": f"0x{ret.signature.hex()}",
+    }
+    return output

--- a/python/src/trezorlib/ethereum.py
+++ b/python/src/trezorlib/ethereum.py
@@ -357,3 +357,16 @@ def verify_message(
     except exceptions.TrezorFailure:
         return False
     return isinstance(resp, messages.Success)
+
+
+@expect(messages.EthereumTypedDataSignature)
+def sign_typed_data_hash(
+    client: "TrezorClient", n: "Address", domain_hash: bytes, message_hash: bytes
+) -> "MessageType":
+    return client.call(
+        messages.EthereumSignTypedHash(
+            address_n=n,
+            domain_separator_hash=domain_hash,
+            message_hash=message_hash,
+        )
+    )

--- a/python/src/trezorlib/messages.py
+++ b/python/src/trezorlib/messages.py
@@ -129,6 +129,7 @@ class MessageType(IntEnum):
     EthereumTypedDataValueRequest = 467
     EthereumTypedDataValueAck = 468
     EthereumTypedDataSignature = 469
+    EthereumSignTypedHash = 470
     NEMGetAddress = 67
     NEMAddress = 68
     NEMSignTx = 69
@@ -4455,23 +4456,6 @@ class EthereumTypedDataValueAck(protobuf.MessageType):
         self.value = value
 
 
-class EthereumTypedDataSignature(protobuf.MessageType):
-    MESSAGE_WIRE_TYPE = 469
-    FIELDS = {
-        1: protobuf.Field("signature", "bytes", repeated=False, required=True),
-        2: protobuf.Field("address", "string", repeated=False, required=True),
-    }
-
-    def __init__(
-        self,
-        *,
-        signature: "bytes",
-        address: "str",
-    ) -> None:
-        self.signature = signature
-        self.address = address
-
-
 class EthereumStructMember(protobuf.MessageType):
     MESSAGE_WIRE_TYPE = None
     FIELDS = {
@@ -4753,6 +4737,43 @@ class EthereumVerifyMessage(protobuf.MessageType):
     ) -> None:
         self.signature = signature
         self.message = message
+        self.address = address
+
+
+class EthereumSignTypedHash(protobuf.MessageType):
+    MESSAGE_WIRE_TYPE = 470
+    FIELDS = {
+        1: protobuf.Field("address_n", "uint32", repeated=True, required=False),
+        2: protobuf.Field("domain_separator_hash", "bytes", repeated=False, required=True),
+        3: protobuf.Field("message_hash", "bytes", repeated=False, required=True),
+    }
+
+    def __init__(
+        self,
+        *,
+        domain_separator_hash: "bytes",
+        message_hash: "bytes",
+        address_n: Optional[Sequence["int"]] = None,
+    ) -> None:
+        self.address_n: Sequence["int"] = address_n if address_n is not None else []
+        self.domain_separator_hash = domain_separator_hash
+        self.message_hash = message_hash
+
+
+class EthereumTypedDataSignature(protobuf.MessageType):
+    MESSAGE_WIRE_TYPE = 469
+    FIELDS = {
+        1: protobuf.Field("signature", "bytes", repeated=False, required=True),
+        2: protobuf.Field("address", "string", repeated=False, required=True),
+    }
+
+    def __init__(
+        self,
+        *,
+        signature: "bytes",
+        address: "str",
+    ) -> None:
+        self.signature = signature
         self.address = address
 
 

--- a/tests/device_tests/ethereum/test_sign_typed_data.py
+++ b/tests/device_tests/ethereum/test_sign_typed_data.py
@@ -23,9 +23,10 @@ from ...common import parametrize_using_common_fixtures
 
 SHOW_MORE = (143, 167)
 
-pytestmark = [pytest.mark.altcoin, pytest.mark.ethereum, pytest.mark.skip_t1]
+pytestmark = [pytest.mark.altcoin, pytest.mark.ethereum]
 
 
+@pytest.mark.skip_t1
 @parametrize_using_common_fixtures("ethereum/sign_typed_data.json")
 def test_ethereum_sign_typed_data(client, parameters, result):
     with client:
@@ -35,6 +36,21 @@ def test_ethereum_sign_typed_data(client, parameters, result):
             address_n,
             parameters["data"],
             metamask_v4_compat=parameters["metamask_v4_compat"],
+        )
+        assert ret.address == result["address"]
+        assert f"0x{ret.signature.hex()}" == result["sig"]
+
+
+@pytest.mark.skip_t2
+@parametrize_using_common_fixtures("ethereum/sign_typed_data.json")
+def test_ethereum_sign_typed_data_blind(client, parameters, result):
+    with client:
+        address_n = parse_path(parameters["path"])
+        ret = ethereum.sign_typed_data_hash(
+            client,
+            address_n,
+            ethereum.decode_hex(parameters["domain_separator_hash"]),
+            ethereum.decode_hex(parameters["message_hash"]),
         )
         assert ret.address == result["address"]
         assert f"0x{ret.signature.hex()}" == result["sig"]
@@ -120,6 +136,7 @@ def input_flow_cancel(client):
     client.debug.press_no()
 
 
+@pytest.mark.skip_t1
 def test_ethereum_sign_typed_data_show_more_button(client):
     with client:
         client.watch_layout()
@@ -132,6 +149,7 @@ def test_ethereum_sign_typed_data_show_more_button(client):
         )
 
 
+@pytest.mark.skip_t1
 def test_ethereum_sign_typed_data_cancel(client):
     with client, pytest.raises(exceptions.Cancelled):
         client.watch_layout()

--- a/tests/ui_tests/fixtures.json
+++ b/tests/ui_tests/fixtures.json
@@ -593,6 +593,7 @@
 "ethereum-test_sign_typed_data.py::test_ethereum_sign_typed_data[complex_data]": "275a8630a795c966419f6fc6de834bb576bfc3dbc16a1fd7605aa2b8ceae666e",
 "ethereum-test_sign_typed_data.py::test_ethereum_sign_typed_data[struct_list_non_v4]": "7dd23b14bd273b937836a24cf056c745e7b3461139f895caefd4624e0d5545f5",
 "ethereum-test_sign_typed_data.py::test_ethereum_sign_typed_data[struct_list_v4]": "b7e3475d4906942bc0e8d62203ae91a13ea0d702c3a7a53b9777bea670c4a7f7",
+"ethereum-test_sign_typed_data.py::test_ethereum_sign_typed_data[structs_arrays_v4]": "31cc5b5c1d9d94f0761208f5dc6423d283b9118b12b87cf878d20fa144f4f252",
 "ethereum-test_sign_typed_data.py::test_ethereum_sign_typed_data_cancel": "08712efae2d007610289bbfb3a8fe6800547e884636c83c5bf0e25f33728789e",
 "ethereum-test_sign_typed_data.py::test_ethereum_sign_typed_data_show_more_button": "1adbea797586685ce09aae58b0a2b89e1617e4eaad23a8c1ac6fc10b041e57a5",
 "ethereum-test_sign_verify_message.py::test_signmessage[parameters0-result0]": "7aa14b29e5005d8fdc0a8b497ed5d3ebea15c7017f9c457d09214f2d05fbc532",


### PR DESCRIPTION
Hey :wave: 

In this PR I have implemented a basic EIP-712 typed data signing for T1 based on Ledger. In this approach, The client calculates sha-3 of the `domain separator` and and `message` then sends them to trezor for signing. On the device, both of the signatures will be combined and prefixed with `\x19\x01` and then get signed and sent back.

This is NOT the most secure way since an attacker can send any other message and you cannot see the actual data on the device screen, on the other hand showing a large message data is not feasible on a T1's screen and having this feature which is becoming a de-facto standard is better than not having it at all I guess.

This should not compromise anything else as the client data for signature is prefixed with `\x19\x01`.

I have also made the necessary changes in `trezor/connect` and `metamask/eth-trezor-keyring` and tested them with the emulator. If you choose to keep this, I can also make push my other changes in there. 

Please share your reviews, suggestions and concerns. I really loved working on this issue.