### PR TITLE
Connect tests against current firmware branch in CI

### DIFF
--- a/ci/shell.nix
+++ b/ci/shell.nix
@@ -57,6 +57,7 @@ stdenvNoCC.mkDerivation ({
     autoflake
     bash
     check
+    curl  # for connect tests
     editorconfig-checker
     gcc
     gcc-arm-embedded

--- a/ci/test.yml
+++ b/ci/test.yml
@@ -373,3 +373,27 @@ core unix memory profiler:
       - core/prof/memperf-html
     expire_in: 1 week
     when: always
+
+# Connect
+
+connect test core:
+  image: registry.gitlab.com/satoshilabs/trezor/trezor-user-env/trezor-user-env:latest
+  stage: test
+  needs:
+    - core unix frozen debug build
+  variables:
+    SDL_VIDEODRIVER: "dummy"
+  before_script:
+    - cp /builds/satoshilabs/trezor/trezor-firmware/core/build/unix/trezor-emu-core /trezor-user-env/src/binaries/firmware/bin/trezor-emu-core-v2.99.99
+    - chmod u+x /trezor-user-env/src/binaries/firmware/bin/trezor-emu-core-v2.99.99
+    - nix-shell -p autoPatchelfHook SDL2 SDL2_image --run "autoPatchelf /trezor-user-env/src/binaries/firmware/bin/trezor-emu-core-v2.99.99"
+  script:
+    - /trezor-user-env/run.sh &
+    - nix-shell --run "tests/connect_tests/connect_tests.sh 2.99.99"
+  after_script:
+    - cp /trezor-user-env/logs/debugging.log trezor-user-env-debugging.log
+  artifacts:
+    paths:
+      - trezor-user-env-debugging.log
+    expire_in: 1 week
+    when: always

--- a/tests/.gitignore
+++ b/tests/.gitignore
@@ -1,2 +1,3 @@
 junit.xml
 trezor.log
+connect_tests/connect

--- a/tests/connect_tests/connect_tests.sh
+++ b/tests/connect_tests/connect_tests.sh
@@ -1,0 +1,30 @@
+#!/usr/bin/env bash
+
+# Cloning connect repository and running the tests from there
+
+FILE_DIR="$(dirname "${0}")"
+cd ${FILE_DIR}
+
+CONNECT_DIR="connect"
+
+# For quicker local usage, do not cloning connect repo if it already exists
+if [[ ! -d "${CONNECT_DIR}" ]]
+then
+    git clone https://github.com/trezor/connect.git
+    cd ${CONNECT_DIR}
+    git submodule update --init --recursive
+else
+    cd ${CONNECT_DIR}
+fi
+
+# Taking an optional script argument with emulator version
+if [ ! -z "${1}" ]
+then
+    EMU_VERSION="${1}"
+else
+    EMU_VERSION="2-master"
+fi
+echo "Will be running with ${EMU_VERSION} emulator"
+
+# Using -d flag to disable docker, as tenv is already running on the background
+nix-shell --run "yarn && tests/run.sh -d -f ${EMU_VERSION}"


### PR DESCRIPTION
Starting to experiment with https://github.com/trezor/trezor-firmware/issues/1932

Goal is to get the `connect` repository and run all its tests in our CI using out freshly-build emulator.

For quicker feedback loop, I have disabled all other CI stages apart from the new `connect`.

To be done:
- `tenv` image being able to run a local emulator (as we will have the build emulator as artifact on CI server and we could use it to the tests)
  - other possibility is just sending it the URL with the CI artifact (this is already implemented [in this PR](https://github.com/trezor/trezor-user-env/pull/120)