### PR TITLE
Prevent recursing in handling RebootToBootloader

### DIFF
--- a/legacy/firmware/fsm.c
+++ b/legacy/firmware/fsm.c
@@ -66,6 +66,8 @@
 
 // message methods
 
+bool reset_flag = false;
+
 static uint8_t msg_resp[MSG_OUT_DECODED_SIZE] __attribute__((aligned));
 
 #define RESP_INIT(TYPE)                                                    \
@@ -359,14 +361,7 @@ void fsm_msgRebootToBootloader(void) {
   oledClear();
   oledRefresh();
   fsm_sendSuccess(_("Rebooting"));
-  // make sure the outgoing message is sent
-  usbPoll();
-  usbSleep(500);
-#if !EMULATOR
-  svc_reboot_to_bootloader();
-#else
-  printf("Reboot!\n");
-#endif
+  reset_flag = true;
 }
 
 #include "fsm_msg_coin.h"


### PR DESCRIPTION
This fixes showing reboot dialog twice from #1983, but reorders the way USB handler works with messages.

Before it was: read, then write message if pending

Now the fix is: write message if pending, reset if reset flag was set, then read message.

The reset before reading and handling message prevents next message. However it seems that any message will be lost until reset finishes, so sending them too quickly from client will result in LIBUSB error.