### PR TITLE
Option to turn off stack protector on legacy build

### DIFF
--- a/legacy/Makefile.include
+++ b/legacy/Makefile.include
@@ -33,7 +33,7 @@ OPENOCD  := openocd -f interface/stlink.cfg -c "transport select hla_swd" -f tar
 
 GDB      := $(PREFIX)gdb --nx -ex 'set remotetimeout unlimited' -ex 'set confirm off' -ex 'target remote 127.0.0.1:3333' -ex 'monitor reset halt'
 
-CONFFLAG ?= -DCONFIDENTIAL='__attribute__((section("confidential")))'
+CONFFLAG ?= -DCONFIDENTIAL='__attribute__((section("confidential")))' -fstack-protector-all
 OPTFLAGS ?= -O3
 DBGFLAGS ?= -g -DNDEBUG
 CPUFLAGS ?= -mcpu=cortex-m3 -mthumb
@@ -67,7 +67,6 @@ CFLAGS   += $(OPTFLAGS) \
             -fvisibility=internal \
             -ffunction-sections \
             -fdata-sections \
-            -fstack-protector-all \
             $(CPUFLAGS) \
             $(FPUFLAGS) \
             $(CONFFLAG) \


### PR DESCRIPTION
This creates option to turn off stack protector on ARM builds which fixes emulator stack smashing bug for @vdovhanych .

Setting `NO_STACK_PROTECT=1` environment variable when building removes stack smash protector.

(Default build is with stack protector enabled)