### PR TITLE
docs: fix dead links

### DIFF
--- a/docs/SUMMARY.md
+++ b/docs/SUMMARY.md
@@ -9,6 +9,7 @@
   - [Event Loop](core/src/event-loop.md)
   - [Apps](core/src/apps.md)
   - [Tests](core/tests/index.md)
+  - [SystemView instrumentation](core/systemview/index.md)
   - [Miscellaneous](core/misc/index.md)
     - [SLIP-39](core/misc/slip0039.md)
     - [Exceptions usage](core/misc/exceptions.md)

--- a/docs/hardware/model-t/boot.md
+++ b/docs/hardware/model-t/boot.md
@@ -123,7 +123,7 @@ of 512 bytes.
 | ?      | 1      | vstr_len | vendor string length |
 | ?      | ?      | vstr | vendor string |
 | ?      | ?      | vstrpad | padding to a multiple of 4 bytes |
-| ?      | ?      | vimg | vendor image (120x120 pixels in [TOIf format](toif.md)) |
+| ?      | ?      | vimg | vendor image (120x120 pixels in [TOIf format](../../misc/toif.md)) |
 | ?      | ?      | reserved | padding to an address that is -65 modulo 512 (zeroed) |
 | ?      | 1      | sigmask | SatoshiLabs signature indexes (bitmap) |
 | ?      | 64     | sig | SatoshiLabs aggregated signature of the vendor header |

--- a/docs/hardware/model-t/index.md
+++ b/docs/hardware/model-t/index.md
@@ -43,7 +43,7 @@
 * 1 x USB Cable Type A Plug/Male to Type Mini-B Plug/Male
 * 1 x USB Cable Type A Plug/Male to Type Micro-B Plug/Male
 * 1 x [ER-TFTM028-4 Display + Capacitive Touch Panel Module](https://www.ebay.com/itm/302049581340) (Note: specify 40-Pin Header, 8080 8-bit Parallel, VDD=3.3V, Capacitive Touch Panel) (note: [Manual](https://www.buydisplay.com/download/manual/ER-TFTM028-4_Datasheet.pdf))
-* 1 x [microSD Board](https://www.waveshare.com/product/modules/storage/sd-tf-storage/micro-sd-storage-board.htm)
+* 1 x [microSD Board](https://www.waveshare.com/micro-sd-storage-board.htm)
 * 1 x [Pack of 40 Female to female jumper wires with 0.1" header contacts](https://www.adafruit.com/product/266)
 
 ### Display

--- a/docs/index.md
+++ b/docs/index.md
@@ -11,7 +11,6 @@ Welcome to the Trezor Firmware repository. This repository is so called _monorep
 * **[`common/protob`](https://github.com/trezor/trezor-firmware/tree/master/common/protob/)**: Common protobuf definitions for the Trezor protocol
 * **[`common/tools`](https://github.com/trezor/trezor-firmware/tree/master/common/tools/)**: Tools for managing coin definitions and related data
 * **[`core`](https://github.com/trezor/trezor-firmware/tree/master/core/)**: Trezor Core, firmware implementation for Trezor T
-* **[`core/systemview`](https://github.com/trezor/trezor-firmware/tree/master/core/systemview)**: Hardware instrumentation and debugging with SystemView for Trezor T
 * **[`crypto`](https://github.com/trezor/trezor-firmware/tree/master/crypto/)**: Stand-alone cryptography library used by both Trezor Core and the Trezor One firmware
 * **[`docs`](https://github.com/trezor/trezor-firmware/tree/master/docs/)**: Assorted documentation
 * **[`legacy`](https://github.com/trezor/trezor-firmware/tree/master/legacy/)**: Trezor One firmware implementation

--- a/docs/misc/coins-bip44-paths.md
+++ b/docs/misc/coins-bip44-paths.md
@@ -73,10 +73,10 @@ sends `44'/60'/0'/0` for getPublicKey.
 3. <a name="Ripple"></a> Similar to Ethereum this should be `44'/c'/a'`. But for
    compatibility with other HW vendors we use `44'/c'/a'/0/0`.
 
-4. <a name="Cardano"></a> Cardano has a [custom derivation] algorithm that allows
+4. <a name="Cardano"></a> Cardano has [CIP-0003] algorithm that allows
    non-hardened derivation on ed25519.
 
-[custom derivation]: https://cardanolaunch.com/assets/Ed25519_BIP.pdf
+[cip-0003]: https://cips.cardano.org/cips/cip3/
 
 5. <a name="NEM"></a> NEM's path should be `44'/43'/a'` as per SEP-0005, but we allow
    `44'/43'/a'/0'/0'` as well for compatibility reasons with NanoWallet.

--- a/docs/misc/monorepo.md
+++ b/docs/misc/monorepo.md
@@ -7,7 +7,7 @@ Generating
 
 Use the [create_monorepo] script to regenerate from current master(s).
 
-[create_monorepo]: create_monorepo.py
+[create_monorepo]: ../../create_monorepo.py
 
 
 Structure

--- a/docs/tests/device-tests.md
+++ b/docs/tests/device-tests.md
@@ -71,7 +71,7 @@ If the test should only run on T1, mark it with `@pytest.mark.skip_t2`.
 You must not use both on the same test.
 
 [pytest-random-order]: https://pypi.org/project/pytest-random-order/
-[REGISTERED_MARKERS]: ../REGISTERED_MARKERS
+[REGISTERED_MARKERS]: ../../tests/REGISTERED_MARKERS
 
 ## Extended testing and debugging
 


### PR DESCRIPTION
Tried to run the docs through https://github.com/Michael-F-Bryan/mdbook-linkcheck. It prints a bunch of false positives so integrating it in CI is probably not worth it now.

@gabrielKerekes do you know where to find `Ed25519_BIP.pdf`?

```
error: File not found: docs/
   ┌─ python/trezorlib.md:98:29
   │
98 │ info and addresses. See the [docs/](docs/) sub folder for detailed
   │                             ^^^^^^^^^^^^^^ File not found: docs/

error: File not found: tools/
    ┌─ python/trezorlib.md:108:44
    │
108 │ your application. See examples here in the [tools/](tools/) sub folder.
    │                                            ^^^^^^^^^^^^^^^^ File not found: tools/

error: Server returned 404 Not Found for https://cardano.org/assets/Ed25519_BIP.pdf
   ┌─ misc/coins-bip44-paths.md:76:41
   │
76 │ 4. <a name="Cardano"></a> Cardano has a [custom derivation] algorithm that allows
   │                                         ^^^^^^^^^^^^^^^^^^^ Server returned 404 Not Found for https://cardano.org/assets/Ed25519_BIP.pdf

warning: Potential incomplete link
   ┌─ misc/update-wipes.md:12:15
   │
12 │ _fix_version_ [1].
   │               ^^^ Did you forget to define a URL for `1`?
   │
   = hint: declare the link's URL. For example: `[1]: http://example.com/`

warning: Potential incomplete link
   ┌─ misc/update-wipes.md:35:86
   │
35 │ - If the firmware to be installed is from different vendor than the present firmware [2].
   │                                                                                      ^^^ Did you forget to define a URL for `2`?
   │
   = hint: declare the link's URL. For example: `[2]: http://example.com/`

warning: Potential incomplete link
   ┌─ misc/update-wipes.md:37:15
   │
37 │ _fix_version_ [1].
   │               ^^^ Did you forget to define a URL for `1`?
   │
   = hint: declare the link's URL. For example: `[1]: http://example.com/`

warning: Potential incomplete link
   ┌─ misc/update-wipes.md:44:1
   │
44 │ [1] Firmware contains a _fix_version_, which is the lowest version to which that
   │ ^^^ Did you forget to define a URL for `1`?
   │
   = hint: declare the link's URL. For example: `[1]: http://example.com/`

warning: Potential incomplete link
   ┌─ misc/update-wipes.md:50:1
   │
50 │ [2] The most common example is if you have a device with the official firmware
   │ ^^^ Did you forget to define a URL for `2`?
   │
   = hint: declare the link's URL. For example: `[2]: http://example.com/`

warning: Potential incomplete link
   ┌─ misc/review.md:20:92
   │
20 │      `git commit --fixup [commithash]` which creates a new commit with the message "fixup! [orig_message]",
   │                                                                                            ^^^^^^^^^^^^^^ Did you forget to define a URL for `orig_message`?
   │
   = hint: declare the link's URL. For example: `[orig_message]: http://example.com/`

Error: One or more incorrect links
```