### PR TITLE
ci: add arm build for core unix and legacy emulators

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -28,7 +28,7 @@ stages:
   - deploy
 
 before_script:
-  - . $HOME/.nix-profile/etc/profile.d/nix.sh || true
+  - . /nix/var/nix/profiles/default/etc/profile.d/nix-daemon.sh
   - nix-shell --run "poetry install"
   - export LEGACY_VERSION=$(nix-shell --run "./tools/version.sh legacy/firmware/version.h")
   - export CORE_VERSION=$(nix-shell --run "./tools/version.sh core/embed/firmware/version.h")

--- a/ci/build.yml
+++ b/ci/build.yml
@@ -153,6 +153,27 @@ core unix frozen debug build:
     untracked: true
     expire_in: 1 week
 
+core unix frozen debug build arm:
+  image: vdovhanych/nixos
+  stage: build
+  <<: *gitlab_caching
+  needs: []
+  only:
+    - master
+    - /^release\//
+    - /^secfix\//
+  variables:
+    PYOPT: "0"
+  script:
+    - nix-shell --run "poetry run make -C core build_unix_frozen"
+    - mv core/build/unix/trezor-emu-core core/build/unix/trezor-emu-core-arm
+  artifacts:
+    name: "$CI_JOB_NAME-$CI_COMMIT_SHORT_SHA"
+    untracked: true
+    expire_in: 1 week
+  tags:
+    - docker_darwin_arm
+
 core unix frozen btconly debug t1 build:
   stage: build
   needs: []
@@ -174,9 +195,9 @@ core macos frozen regular build:
   needs: []
   when: manual
   tags:
-    - darwin
+    - darwin_arm
   script:
-    - nix-shell --run "poetry run make -C core build_unix_frozen"
+    - nix-shell --option system x86_64-darwin --run "poetry run make -C core build_unix_frozen"
     - export NAME="trezor-emu-core.darwin"
     - cp -v core/build/unix/trezor-emu-core ./$NAME
     - chmod +x $NAME
@@ -300,6 +321,29 @@ legacy emu regular debug build:
     paths:
       - legacy/firmware/trezor.elf
     expire_in: 1 week
+
+legacy emu regular debug build arm:
+  image: vdovhanych/nixos
+  stage: build
+  <<: *gitlab_caching
+  needs: []
+  only:
+    - master
+    - /^release\//
+    - /^secfix\//
+  variables:
+    DEBUG_LINK: "1"
+    EMULATOR: "1"
+  script:
+    - nix-shell --run "poetry run legacy/script/cibuild"
+    - mv legacy/firmware/trezor.elf  legacy/firmware/trezor-arm.elf
+  artifacts:
+    name: "$CI_JOB_NAME-$CI_COMMIT_SHORT_SHA"
+    paths:
+      - legacy/firmware/trezor-arm.elf
+    expire_in: 1 week
+  tags:
+    - docker_darwin_arm
 
 legacy emu btconly debug build:
   stage: build

--- a/ci/deploy.yml
+++ b/ci/deploy.yml
@@ -182,12 +182,16 @@ release core unix debug deploy:
   before_script: []  # no poetry
   needs:
     - core unix frozen debug build
+    - core unix frozen debug build arm
   script:
     - export VERSION=$(./tools/version.sh core/embed/firmware/version.h)
     - DEST="$DEPLOY_PATH/trezor-emu-core-v$VERSION"
-    - echo "Deploying to $DEST"
+    - DEST_ARM="$DEPLOY_PATH/trezor-emu-core-arm-v$VERSION"
+    - echo "Deploying to $DEST and $DEST_ARM"
     - nix-shell -p patchelf --run "patchelf --set-interpreter /lib64/ld-linux-x86-64.so.2 core/build/unix/trezor-emu-core"
+    - nix-shell -p patchelf --run "patchelf --set-interpreter /lib/ld-linux-aarch64.so.1 core/build/unix/trezor-emu-core-arm"
     - rsync --delete -va core/build/unix/trezor-emu-core "$DEST"
+    - rsync --delete -va core/build/unix/trezor-emu-core-arm "$DEST_ARM"
   only:
     - /^core\//
   except:
@@ -203,12 +207,16 @@ release legacy unix debug deploy:
   before_script: []  # no poetry
   needs:
     - legacy emu regular debug build
+    - legacy emu regular debug build arm
   script:
     - export VERSION=$(./tools/version.sh legacy/firmware/version.h)
     - DEST="$DEPLOY_PATH/trezor-emu-legacy-v$VERSION"
-    - echo "Deploying to $DEST"
+    - DEST_ARM="$DEPLOY_PATH/trezor-emu-legacy-arm-v$VERSION"
+    - echo "Deploying to $DEST and $DEST_ARM"
     - nix-shell -p patchelf --run "patchelf --set-interpreter /lib64/ld-linux-x86-64.so.2 legacy/firmware/trezor.elf"
+    - nix-shell -p patchelf --run "patchelf --set-interpreter /lib/ld-linux-aarch64.so.1 legacy/firmware/trezor-arm.elf"
     - rsync --delete -va legacy/firmware/trezor.elf "$DEST"
+    - rsync --delete -va legacy/firmware/trezor-arm.elf "$DEST_ARM"
   only:
     - /^legacy\//
   except:


### PR DESCRIPTION
This PR adds a build for arm emulators needed for trezor-user-env running on arm version of nix. See why [here](https://github.com/trezor/trezor-user-env/pull/114).
This is now done with our m1 runner as docker executor.  I used my nixos image as nixos/nix is completely broken since they switched from alpine to native nixos one. See [here](https://github.com/NixOS/nix/issues/5777#issuecomment-996242619). Once the upstream image is fixed, we can change to that.

This pr also adds native fixes manual macOS build using our runner and built on x86_64 via rosseta2.