### PR TITLE
tests(crypto): update wycheproof testcase source and parsing

### DIFF
--- a/crypto/tests/test_wycheproof.py
+++ b/crypto/tests/test_wycheproof.py
@@ -387,22 +387,24 @@ def generate_curve25519_dh(filename):
     if not keys_in_dict(data, {"algorithm", "testGroups"}):
         raise DataError()
 
-    if data["algorithm"] != "X25519":
+    if data["algorithm"] != "XDH":
         raise DataError()
 
     for test_group in data["testGroups"]:
-        if not keys_in_dict(test_group, {"tests"}):
+        if not keys_in_dict(test_group, {"tests", "curve"}):
+            raise DataError()
+
+        try:
+            curve_name = parse_curve_name(test_group["curve"])
+        except Exception:
             raise DataError()
 
         for test in test_group["tests"]:
-            if not keys_in_dict(
-                test, {"public", "private", "shared", "result", "curve"}
-            ):
+            if not keys_in_dict(test, {"public", "private", "shared", "result"}):
                 raise DataError()
 
             try:
                 public_key = unhexlify(test["public"])
-                curve_name = parse_curve_name(test["curve"])
                 private_key = unhexlify(test["private"])
                 shared = unhexlify(test["shared"])
                 result = parse_result(test["result"])
@@ -433,18 +435,20 @@ def generate_ecdh(filename):
         raise DataError()
 
     for test_group in data["testGroups"]:
-        if not keys_in_dict(test_group, {"tests"}):
+        if not keys_in_dict(test_group, {"tests", "curve"}):
+            raise DataError()
+
+        try:
+            curve_name = parse_curve_name(test_group["curve"])
+        except Exception:
             raise DataError()
 
         for test in test_group["tests"]:
-            if not keys_in_dict(
-                test, {"public", "private", "shared", "result", "curve"}
-            ):
+            if not keys_in_dict(test, {"public", "private", "shared", "result"}):
                 raise DataError()
 
             try:
                 public_key = unhexlify(test["public"])
-                curve_name = parse_curve_name(test["curve"])
                 private_key = parse_signed_hex(test["private"])
                 shared = unhexlify(test["shared"])
                 result = parse_result(test["result"])
@@ -604,7 +608,6 @@ if not lib.zkp_context_is_initialized():
 testvectors_directory = os.path.join(dir, "wycheproof/testvectors")
 context_structure_length = 1024
 
-ecdh_vectors = generate_ecdh("ecdh_test.json")
 curve25519_dh_vectors = generate_curve25519_dh("x25519_test.json")
 eddsa_vectors = generate_eddsa("eddsa_test.json")
 ecdsa_vectors = (


### PR DESCRIPTION
The JSON schema of the test cases has slightly changed.
The "curve" field has moved to the "testGroups" level and the X25519 algorithm has been renamed, which requires adjustments in the parsing code.

A duplicate definition of "ecdh_vectors" has also been removed.