### PR TITLE
feat(crypto): improve trezor-crypto fuzzer

### DIFF
--- a/crypto/Makefile
+++ b/crypto/Makefile
@@ -2,6 +2,13 @@ ifeq ($(FUZZER),1)
 CC       ?= clang
 LD       ?= $(CC)
 SANFLAGS += -fsanitize=fuzzer
+CFLAGS   += -fsanitize-ignorelist=fuzzer/sanitizer_ignorelist.txt
+
+# this works around clang optimization issues in relation with -fsanitize=undefined
+# TODO is there a better solution, for example by disabling a specific optimization technique?
+blake2b.o: OPTFLAGS += -O0
+blake2s.o: OPTFLAGS += -O0
+
 else ifeq ($(ADDRESS_SANITIZER),1)
 SANFLAGS += -fsanitize=address,undefined
 endif

--- a/crypto/Makefile
+++ b/crypto/Makefile
@@ -1,15 +1,33 @@
+# CLANG_VERSION is empty if the compiler is not clang-based
+CLANG_VERSION = $(shell $(CC) --version | grep -Po "clang version \K[\d\.]+")
+CLANG_VERSION_MAJOR = $(shell echo $(CLANG_VERSION) | cut -f1 -d.)
+
+# determine specific version ranges
+ifneq ($(CLANG_VERSION),)
+$(if $(shell [ $(CLANG_VERSION_MAJOR) -ge 13 ] && echo "OK"), \
+    $(eval CLANG_AT_LEAST_13 := true), \
+    $(eval CLANG_AT_LEAST_13 := false))
+$(if $(shell [ $(CLANG_VERSION_MAJOR) -ge 14 ] && echo "OK"), \
+    $(eval CLANG_AT_LEAST_14 := true), \
+    $(eval CLANG_AT_LEAST_14 := false))
+endif
+
 ifeq ($(FUZZER),1)
 CC       ?= clang
 LD       ?= $(CC)
 SANFLAGS += -fsanitize=fuzzer
 
-# TODO gcc as well as older clang versions <= 12 do not support this feature
+# only clang versions >= 13 support this feature
+ifeq ($(CLANG_AT_LEAST_13),true)
 $(info "info: using -fsanitize-ignorelist")
-SANFLAGS   += -fsanitize-ignorelist=fuzzer/sanitizer_ignorelist.txt
+SANFLAGS += -fsanitize-ignorelist=fuzzer/sanitizer_ignorelist.txt
+else
+$(info "info: not using -fsanitize-ignorelist")
+endif
 
 # TODO is there a better solution, for example by disabling a specific optimization technique?
 # there is a clang optimization issue in relation with the blake2 code at -fsanitize=undefined
-$(warning "warning: disable optimization on blake2 code as workaround")
+$(warning "warning: disabling optimization on blake2 code as workaround")
 blake2b.o: OPTFLAGS += -O0
 blake2s.o: OPTFLAGS += -O0
 
@@ -61,8 +79,8 @@ ZKP_PATH = ../vendor/secp256k1-zkp
 CFLAGS += -DSECP256K1_CONTEXT_SIZE=208
 
 # TODO remove this workaround once possible
-ifeq ($(CC),clang-14)
-$(warning "warning: suppress clang-14 compiler warning for secp256k1-zkp code")
+ifeq ($(CLANG_AT_LEAST_14),true)
+$(warning "warning: suppressing clang-14 compiler warning for secp256k1-zkp code")
 ZKP_CFLAGS += -Wno-bitwise-instead-of-logical
 endif
 

--- a/crypto/Makefile
+++ b/crypto/Makefile
@@ -2,10 +2,14 @@ ifeq ($(FUZZER),1)
 CC       ?= clang
 LD       ?= $(CC)
 SANFLAGS += -fsanitize=fuzzer
-CFLAGS   += -fsanitize-ignorelist=fuzzer/sanitizer_ignorelist.txt
 
-# this works around clang optimization issues in relation with -fsanitize=undefined
+# TODO gcc as well as older clang versions <= 12 do not support this feature
+$(info "info: using -fsanitize-ignorelist")
+SANFLAGS   += -fsanitize-ignorelist=fuzzer/sanitizer_ignorelist.txt
+
 # TODO is there a better solution, for example by disabling a specific optimization technique?
+# there is a clang optimization issue in relation with the blake2 code at -fsanitize=undefined
+$(warning "warning: disable optimization on blake2 code as workaround")
 blake2b.o: OPTFLAGS += -O0
 blake2s.o: OPTFLAGS += -O0
 
@@ -55,6 +59,12 @@ ZKP_CFLAGS = \
 	-DENABLE_MODULE_EXTRAKEYS
 ZKP_PATH = ../vendor/secp256k1-zkp
 CFLAGS += -DSECP256K1_CONTEXT_SIZE=208
+
+# TODO remove this workaround once possible
+ifeq ($(CC),clang-14)
+$(warning "warning: suppress clang-14 compiler warning for secp256k1-zkp code")
+ZKP_CFLAGS += -Wno-bitwise-instead-of-logical
+endif
 
 VALGRIND ?= 1
 ifeq ($(VALGRIND),1)

--- a/crypto/fuzzer/README.md
+++ b/crypto/fuzzer/README.md
@@ -18,8 +18,8 @@ Recommended: ASAN / UBSAN / MSAN flags for error detection can be specified via 
 
 Examples:
 
-  * `SANFLAGS="-fsanitize=address,undefined"`
-  * `SANFLAGS="-fsanitize=memory -fsanitize-memory-track-origins"`
+* `SANFLAGS="-fsanitize=address,undefined"`
+* `SANFLAGS="-fsanitize=memory -fsanitize-memory-track-origins"`
 
 ### Optimizations
 
@@ -27,18 +27,26 @@ Override `OPTFLAGS` to test the library at different optimization levels or simp
 
 Examples:
 
-  * `OPTFLAGS="-O0 -ggdb3"`
-  * `OPTFLAGS="-O3 -march=native"`
+* `OPTFLAGS="-O0 -ggdb3"`
+* `OPTFLAGS="-O3 -march=native"`
 
-To be determined: use of `-fsanitize-ignorelist` to reduce sanitizer overhead on hot functions
+To be determined:
 
+* use of `-fsanitize-ignorelist` to reduce sanitizer overhead on hot functions
+* `-flto` and `-flto=thin` link time optimization
+
+Advanced usage:
+* [Profile guided optimization](https://clang.llvm.org/docs/UsersManual.html#profile-guided-optimization)
 ### Other Flags
 
 To be determined:
+
 * `-DNDEBUG`
-* `-DUSE_BIP39_CACHE=0 -DUSE_BIP32_CACHE=0`
-* `-D_FORTIFY_SOURCE=2`
+* `-DUSE_BIP39_CACHE=0 -DUSE_BIP32_CACHE=0` to avoid persistent side effects through the cache
+* `-D_FORTIFY_SOURCE=2` together with optimization flag -O2 or above
 * `-fstack-protector-strong` or `-fstack-protector-all`
+* `-m32` to closer evaluate the 32 bit behavior
+    * this requires 32bit build support for gcc-multilib, libc and others
 
 ## Operation
 
@@ -79,3 +87,8 @@ The resulting file can be used as a fuzzer dictionary.
   1. render the data `llvm-cov show fuzzer/fuzzer -instr-profile=default.profdata -format=html -output-dir=coverage-report`
   1. analyze report at `coverage-report/index.html`
   1. (optional) remove artifacts with `rm default.profraw default.profdata && rm -r coverage-report`
+
+## Using Honggfuzz Fuzzer
+
+Although this code is designed primarily for libFuzzer, it can also be used with [Honggfuzz](https://honggfuzz.dev).
+However, the usage details are out of scope of this document.

--- a/crypto/fuzzer/README.md
+++ b/crypto/fuzzer/README.md
@@ -47,6 +47,9 @@ To be determined:
 * `-fstack-protector-strong` or `-fstack-protector-all`
 * `-m32` to closer evaluate the 32 bit behavior
     * this requires 32bit build support for gcc-multilib, libc and others
+    * adjust Makefile to `CFLAGS += -DSECP256K1_CONTEXT_SIZE=192`
+* `-DSHA2_UNROLL_TRANSFORM` SHA2 optimization flags
+* `-fsanitize-coverage=edge,trace-cmp,trace-div,indirect-calls,trace-gep,no-prune` to add program counter granularity
 
 ## Operation
 

--- a/crypto/fuzzer/README.md
+++ b/crypto/fuzzer/README.md
@@ -30,6 +30,8 @@ Examples:
   * `OPTFLAGS="-O0 -ggdb3"`
   * `OPTFLAGS="-O3 -march=native"`
 
+To be determined: use of `-fsanitize-ignorelist` to reduce sanitizer overhead on hot functions
+
 ### Other Flags
 
 To be determined:

--- a/crypto/fuzzer/README.md
+++ b/crypto/fuzzer/README.md
@@ -35,6 +35,8 @@ Examples:
 To be determined:
 * `-DNDEBUG`
 * `-DUSE_BIP39_CACHE=0 -DUSE_BIP32_CACHE=0`
+* `-D_FORTIFY_SOURCE=2`
+* `-fstack-protector-strong` or `-fstack-protector-all`
 
 ## Operation
 

--- a/crypto/fuzzer/extract_fuzzer_dictionary.py
+++ b/crypto/fuzzer/extract_fuzzer_dictionary.py
@@ -1,0 +1,389 @@
+#!/usr/bin/env python3
+# -*- coding: utf-8 -*-
+"""
+This experimental program is designed to extract a subset of interesting test
+case snippets from the trezor-crypto test directory and output them as a
+standard fuzzer dictionary file.
+
+The program is built on quick-and-dirty regex matching that is known to be
+incorrect for parsing code files, but is considered "good enough" for this
+specific purpose.
+Note that there are target-specific configurations and internal filter settings.
+"""
+
+import argparse
+import binascii
+import glob
+import re
+
+# re2 is considered for future use
+# it requires a system installation and the google-re2 python package
+# import re2
+
+
+# Expected target format for strings in code:
+# Most strings are defined in the general form "example"
+# There are a few test vectors in crypto/tests/wycheproof/javascript/EcUtil.js
+# with 'example' style string definitions, these are ignored for now
+
+TARGET_DIR = "../tests"
+
+# intentionally excluded file types that currently do not provide enough value:
+# *.js, *.md, *.sh, *.html and others from the wycheproof subdirectory
+
+targeted_filetypes_multiline_classA = ("*.c", "*.h", "*.py")
+# Java files have different multiline strings that are handled differently
+targeted_filetypes_multiline_classB = ("*.java",)
+targeted_filetypes_multiline = (
+    targeted_filetypes_multiline_classA + targeted_filetypes_multiline_classB
+)
+
+# files without multiline string content
+# Note: consider switching to actual JSON parsing?
+# Note: the wycheproof repository has a number of test cases for other
+# cryptography such as DSA and RSA which are currently less interesting for the
+# fuzzer dictionary and therefore excluded
+targeted_filetypes_singleline = (
+    "aes*.json",
+    "ecdh*.json",
+    "ecdsa*.json",
+    "x25519*.json",
+    "chacha20*.json",
+    "kw*.json",
+)
+
+verbose = False
+
+# patterns to extract
+# singleline:
+# "4a1e76f133afb"
+# 0xAF8BBDFE8CDD5 and 0x0488b21e
+# m/0'/2147483647'/1'/2147483646'/2' in test_check.c via m/[\d'/]+
+#
+# multiline:
+# "fffc" \n "99"
+# "dpubZ9169K" \n "bTYbcY"
+# "\x65\xf9" \\n  "\xa0\x6a"
+# { 0x086d8bd5, 0x1018f82f, \n 0xc55ece} , see rg "0x([a-zA-Z0-9])+"
+
+# patterns to ignore
+# lines with print statements
+# lines with exceptions
+# comments and other metadata in the testvector JSON files
+# filenames
+# import statements and other package names
+
+# patterns to investigate further
+# public keys with the form BEGIN PUBLIC KEY
+# TODO "abc" + "def" string concatenation on the same line without newline
+# strings in comments
+
+# TODO briefly describe the desired dictionary export file format and its quirks
+
+# match everything in quotes that doesn't have an internal quote character and
+# at least one internal character
+regex_string_general_definition = r"\"[^\"]+\""
+regex_string_general = re.compile(regex_string_general_definition)
+# the capturing group ignores prefix and suffix outside of the quotes
+# Note that this is prone to matching the last line of a C-style multiline string,
+# which is addressed via extra state handling during the file processing
+regex_oneline_string = re.compile(
+    r"(" + regex_string_general_definition + r")\s*[\,\)]+"
+)
+# ignore lines that have a "+" character preceding a string
+regex_oneline_string_java_ignore1 = re.compile(r"^\s*\+\s*\"")
+
+regex_hex_character_segment_inner_definition = "[0-9a-fA-F]+"
+regex_hex_character_input_complete = re.compile(
+    '^"' + regex_hex_character_segment_inner_definition + '"$'
+)
+regex_hex_character_input_inner = re.compile(
+    regex_hex_character_segment_inner_definition
+)
+# most constants are preceded by a space, but some have a "(" "[" or "{" before them
+regex_hex_constant_singleline = re.compile(r"(?<=\(|\[|\{| )0x[a-fA-F0-9]+")
+
+regex_c_style_multiline = re.compile(r"(?:\".+\"\s*\n\s*)+(?:\".+\")", re.MULTILINE)
+regex_c_intermediary_content = re.compile(r"\"\s*\n\s*\"", re.MULTILINE)
+# TODO how to prevent matching in the middle of a multi-line string concatenation?
+# negative lookbehind for "+" is not possible generically and
+# (?<!\+ ) and similar patterns are too static
+
+regex_java_style_multiline = re.compile(
+    r"(?:\".+\"\s*\n\s*\+\s*)+(?:\".+\")", re.MULTILINE
+)
+regex_java_intermediary_content = re.compile(r"\"\s*\n\s*\+\s*\"", re.MULTILINE)
+
+regex_text_newline = re.compile(r"\\n")
+
+# primitive regex that catches most filenames in the data set
+regex_filename_heuristic = re.compile(r"\.[a-zA-Z]+")
+
+counter_hex_content = 0
+counter_wycheproof_hex_reconstruction = 0
+
+# TODO add '"curve"' to capture algorithm names?
+allowlist_keywords_json = (
+    '"uncompressed"',
+    '"wx"',
+    '"wy"',
+    '"msg"',
+    '"sig"',
+    '"key"',
+    '"iv"',
+    '"ct"',
+    '"aad"',
+    '"tag"',
+    '"public"',
+    '"private"',
+    '"shared"',
+    '"padding"',
+    '"x"',
+    '"d"',
+)
+
+# TODO the "keyPem" entry is only a workaround for an encoding issue
+ignore_keywords_java = (
+    "println(",
+    "Exception(",
+    '"keyPem"',
+)
+ignore_keywords_c = ("printf(",)
+
+
+def ignore_single_line_json(data):
+    """return True if the input should be ignored"""
+    # ignore everything that is not matched by the allowlist
+    for keyword in allowlist_keywords_json:
+        if data.find(keyword) > -1:
+            return False
+    return True
+
+
+def ignore_single_line_java(data):
+    """return True if the input should be ignored"""
+    for keyword in ignore_keywords_java:
+        if data.find(keyword) > -1:
+            return True
+    return False
+
+
+def ignore_single_line_c(data):
+    """return True if the input should be ignored"""
+    for keyword in ignore_keywords_c:
+        if data.find(keyword) > -1:
+            return True
+    return False
+
+
+def ignore_general(data):
+    """return True if the input should be ignored"""
+    if regex_filename_heuristic.search(data):
+        return True
+    return False
+
+
+def encode_strings_for_dictionary(data):
+    """
+    Assumes that inputs are already in string quotes
+
+    Handles dictionary-specific encoding steps
+    """
+    # libfuzzer does not like "\n" string patterns in dictionary files, replace
+    # it with an encoded newline
+    data = regex_text_newline.sub("\\\\x0a", data)
+    return data
+
+
+def detect_and_convert_hex(data):
+    """
+    Convert hex strings
+
+    Directly pass through non-hex content
+    """
+    global counter_hex_content
+    global counter_wycheproof_hex_reconstruction
+    match_result1 = regex_hex_character_input_complete.search(data)
+    if match_result1:
+
+        match_result2 = regex_hex_character_input_inner.search(match_result1.string)
+        isolated_substring = match_result2.group(0)
+        if len(isolated_substring) % 2 == 1:
+            # Note: the test cases in the wycheproof testvector JSON files have
+            # a custom binary hex format to represent keys
+            # among other things, this results in hex strings with an uneven
+            # number of characters
+            # see tests/wycheproof/java/com/google/security/wycheproof/JsonUtil.java
+            # specifically the asBigInteger() function for more information
+            if isolated_substring[0] >= "0" and isolated_substring[0] <= "7":
+                isolated_substring = "0" + isolated_substring
+            else:
+                isolated_substring = "f" + isolated_substring
+            counter_wycheproof_hex_reconstruction += 1
+
+        converted_result = ""
+        try:
+            # test error-free conversion to binary
+            binascii.unhexlify(isolated_substring)
+            hex_with_c_style_formatting = ""
+            pos = 0
+            while pos < len(isolated_substring) - 1:
+                hex_with_c_style_formatting += "\\x" + isolated_substring[pos : pos + 2]
+                pos += 2
+
+            converted_result = '"%s"' % hex_with_c_style_formatting
+        # TODO binascii.Incomplete exception also relevant?
+        except binascii.Error:
+            # default to the original input
+            return data
+        counter_hex_content += 1
+        return converted_result
+    return data
+
+
+def search_files_recursively(directory, filetype_glob):
+    """returns glob search results"""
+    target_files = []
+    print_verbose("searching in %s" % directory)
+    for filetype in filetype_glob:
+        print_verbose("searching for %s" % filetype)
+        target_files.extend(glob.glob(f"{directory}/**/{filetype}", recursive=True))
+    return target_files
+
+
+def print_verbose(text):
+    """print wrapper"""
+    if verbose:
+        print(text)
+
+
+def recursive_dictionary_extraction(directory):
+    """handle the central extraction logic"""
+    # TODO split this function up into subfunctions
+    global counter_hex_content
+    # handle as a set structure to de-duplicate results automatically
+    candidate_lines = set()
+
+    target_files = search_files_recursively(directory, targeted_filetypes_singleline)
+    for filepath in target_files:
+        per_file_result_counter = 0
+        with open(filepath) as _file:
+            print_verbose("processing %s" % filepath)
+            for _, line in enumerate(_file.readlines()):
+                if ignore_single_line_json(line):
+                    continue
+                results = regex_oneline_string.findall(line)
+                for result in results:
+                    candidate_lines.add(result)
+                    per_file_result_counter += 1
+            if per_file_result_counter > 0:
+                print_verbose("results: %d" % per_file_result_counter)
+
+    print_verbose("number of candidate entries: %d" % len(candidate_lines))
+
+    target_files = search_files_recursively(directory, targeted_filetypes_multiline)
+    for filepath in target_files:
+        per_file_result_counter = 0
+        with open(filepath) as _file:
+            last_line_was_multiline_string = False
+            print_verbose("processing %s for single-line strings" % filepath)
+            for _, line in enumerate(_file.readlines()):
+                if ignore_single_line_java(line):
+                    last_line_was_multiline_string = False
+                    continue
+                if ignore_single_line_c(line):
+                    last_line_was_multiline_string = False
+                    continue
+                if regex_oneline_string_java_ignore1.search(line):
+                    last_line_was_multiline_string = True
+                    if regex_oneline_string.search(line):
+                        # the Java multiline string apparently ends on this line
+                        last_line_was_multiline_string = False
+                    continue
+
+                result_general_string = regex_string_general.search(line)
+                if result_general_string:
+                    # at least one general string is matched, see if it is
+                    # a single-line string
+                    results = regex_oneline_string.findall(line)
+                    for result in results:
+                        if not last_line_was_multiline_string:
+                            candidate_lines.add(result)
+                            per_file_result_counter += 1
+                        last_line_was_multiline_string = False
+                    if len(results) == 0:
+                        last_line_was_multiline_string = True
+                else:
+                    last_line_was_multiline_string = False
+
+                # TODO split this into a separate loop?
+                results = regex_hex_constant_singleline.findall(line)
+                for result in results:
+                    # remove the "0x" prefix, add quotes
+                    candidate_lines.add('"%s"' % result[2:])
+                    per_file_result_counter += 1
+
+            if per_file_result_counter > 0:
+                print_verbose("results: %d" % per_file_result_counter)
+
+    target_files = search_files_recursively(
+        directory, targeted_filetypes_multiline_classA
+    )
+
+    for filepath in target_files:
+        with open(filepath) as _file:
+            print_verbose("processing %s for C-style multi-line strings" % filepath)
+            filecontent = _file.read()
+            multiline_results = regex_c_style_multiline.findall(filecontent)
+            if len(multiline_results) > 0:
+                print_verbose("results: %d" % len(multiline_results))
+            for result in multiline_results:
+                cleanup = regex_c_intermediary_content.sub("", result)
+                candidate_lines.add(cleanup)
+
+    target_files = search_files_recursively(
+        directory, targeted_filetypes_multiline_classB
+    )
+
+    for filepath in target_files:
+        with open(filepath) as _file:
+            print_verbose("processing %s for Java-style multi-line strings" % filepath)
+            filecontent = _file.read()
+            multiline_results = regex_java_style_multiline.findall(filecontent)
+            if len(multiline_results) > 0:
+                print_verbose("results: %d" % len(multiline_results))
+            for result in multiline_results:
+                cleanup = regex_java_intermediary_content.sub("", result)
+                candidate_lines.add(cleanup)
+
+    return candidate_lines
+
+
+if __name__ == "__main__":
+    parser = argparse.ArgumentParser()
+    parser.add_argument("dictionary_output_file", help="output file", type=str)
+    parser.add_argument("--verbose", action="store_true", help="verbose stdout output")
+
+    args = parser.parse_args()
+    verbose = args.verbose
+
+    collected_candidate_lines = recursive_dictionary_extraction(TARGET_DIR)
+    sorted_candidate_lines = sorted(collected_candidate_lines)
+    result_lines = []
+    for candidate_line in sorted_candidate_lines:
+        if ignore_general(candidate_line):
+            continue
+        result_lines.append(
+            encode_strings_for_dictionary(detect_and_convert_hex(candidate_line))
+        )
+
+    print_verbose("counter_hex_content: %d" % counter_hex_content)
+    print_verbose(
+        "counter_wycheproof_hex_reconstruction: %d"
+        % counter_wycheproof_hex_reconstruction
+    )
+    print_verbose("overall deduplicated entries: %d" % len(sorted_candidate_lines))
+
+    with open(args.dictionary_output_file, "w") as _file:
+        for result_line in result_lines:
+            _file.write("%s\n" % result_line)

--- a/crypto/fuzzer/extract_fuzzer_dictionary.py
+++ b/crypto/fuzzer/extract_fuzzer_dictionary.py
@@ -78,7 +78,17 @@ verbose = False
 # TODO "abc" + "def" string concatenation on the same line without newline
 # strings in comments
 
-# TODO briefly describe the desired dictionary export file format and its quirks
+# dictionary text export file format
+# general description:
+# https://github.com/AFLplusplus/AFLplusplus/blob/stable/dictionaries/README.md
+#
+# the exported file is primarly designed for use with a recent libFuzzer version
+# and is known to be partially incompatible with other fuzzers that impose
+# other limitations
+#
+# known incompatibilities:
+# * honggfuzz only reads a limited number of dictionary entries (8192 with version 2.5)
+# * afl++ only reads line content with up to 128 byte
 
 # match everything in quotes that doesn't have an internal quote character and
 # at least one internal character

--- a/crypto/fuzzer/extract_fuzzer_dictionary.sh
+++ b/crypto/fuzzer/extract_fuzzer_dictionary.sh
@@ -24,6 +24,8 @@ done
 
 # extract and convert binary input data from the unit tests
 # find each file, cat it, concatenate multiline strings, look for hex strings in quotes
+# note that this returns multiple megabyte of result strings due to the large amount
+# of test cases in the wycheproof project subfolder
 find $TARGET_DIR -type f | xargs cat | perl -p0e 's/"\s*\n\s*\"//smg' | grep -P -o "\"([0-9a-fA-F][0-9a-fA-F])+\"" | grep -P -o "([0-9a-fA-F][0-9a-fA-F])+" | sort | uniq | while read -r line ; do
   # turn ascii hex strings AA into \xaa for the fuzzer format and add quotes
   # extra backslash escape due to the bash nesting

--- a/crypto/fuzzer/extract_fuzzer_dictionary.sh
+++ b/crypto/fuzzer/extract_fuzzer_dictionary.sh
@@ -2,19 +2,28 @@
 
 # usage: script.sh target-dictionary-filename
 
-# this script searches for interesting strings in the source code and converts
+# This script searches for interesting strings in the source code and converts
 # them into a standard fuzzer dictionary file.
+#
+# Note that this script is phased out in favor of the more sophisticated
+# extract_fuzzer_dictionary.py program
 
+# TODO known issues: the end result has some duplicates in it
 
 TARGET_DIR=../tests
 OUTPUT_FILE=${1:-fuzzer_crypto_tests_strings_dictionary1.txt}
 
-# empty file
+multiline_string_search() {
+  # TODO the `find` regex behavior is Linux-specific
+  find $TARGET_DIR -type f -regextype posix-extended -regex '.*\.(c|h|py|json|java|js)' | xargs cat | perl -p0e 's/"\s*\n\s*\"//smg'
+}
+
+# ensure empty file
 echo -n "" > $OUTPUT_FILE
 
 # strip multiline strings and extract them
 # exclude some hex strings, but allow hex strings with mixed capitalization (Ethereum, rskip60)
-find $TARGET_DIR -type f | xargs cat | perl -p0e 's/"\s*\n\s*\"//smg' | grep -P -o  "\"[\w ]+\"" | grep -v -P "\"(([0-9a-f][0-9a-f])+|([0-9A-F][0-9A-F])+)\"" | sort | uniq | while read -r line ; do
+multiline_string_search | grep -P -o  "\"[\w ]+\"" | grep -v -P "\"(([0-9a-f][0-9a-f])+|([0-9A-F][0-9A-F])+)\"" | sort | uniq | while read -r line ; do
   echo "$line" >> $OUTPUT_FILE
 done
 
@@ -26,7 +35,7 @@ done
 # find each file, cat it, concatenate multiline strings, look for hex strings in quotes
 # note that this returns multiple megabyte of result strings due to the large amount
 # of test cases in the wycheproof project subfolder
-find $TARGET_DIR -type f | xargs cat | perl -p0e 's/"\s*\n\s*\"//smg' | grep -P -o "\"([0-9a-fA-F][0-9a-fA-F])+\"" | grep -P -o "([0-9a-fA-F][0-9a-fA-F])+" | sort | uniq | while read -r line ; do
+multiline_string_search | grep -P -o "\"([0-9a-fA-F][0-9a-fA-F])+\"" | grep -P -o "([0-9a-fA-F][0-9a-fA-F])+" | sort | uniq | while read -r line ; do
   # turn ascii hex strings AA into \xaa for the fuzzer format and add quotes
   # extra backslash escape due to the bash nesting
   escaped_hex=`echo $line | sed -e 's/../\\\\x&/g'`
@@ -35,7 +44,6 @@ done
 
 # search and reassemble BIP39 test seeds that span multiple lines
 # find each file, cat it, concatenate multiline strings, look for BIP39 seed combinations with reasonable length
-find $TARGET_DIR -type f | xargs cat | perl -p0e 's/"\s*\n\s*\"//smg' | grep -Po "(\w{3,10} ){11,23}(\w{3,10})" | sort | uniq | while read -r line ; do
+multiline_string_search | grep -Po "(\w{3,10} ){11,23}(\w{3,10})" | sort | uniq | while read -r line ; do
   echo "\"$line\"" >> $OUTPUT_FILE
 done
-

--- a/crypto/fuzzer/fuzzer.c
+++ b/crypto/fuzzer/fuzzer.c
@@ -381,19 +381,19 @@ int fuzz_nem_validate_address(void) {
 }
 
 int fuzz_nem_get_address(void) {
-  unsigned char ed25519_public_key[32] = {0};
+  unsigned char ed25519_public_key_fuzz[32] = {0};
   uint32_t network = 0;
 
-  if (fuzzer_length != (sizeof(ed25519_public_key) + sizeof(network))) {
+  if (fuzzer_length != (sizeof(ed25519_public_key_fuzz) + sizeof(network))) {
     return 0;
   }
 
   char address[NEM_ADDRESS_SIZE + 1] = {0};
 
-  memcpy(ed25519_public_key, fuzzer_input(32), 32);
+  memcpy(ed25519_public_key_fuzz, fuzzer_input(32), 32);
   memcpy(&network, fuzzer_input(4), 4);
 
-  nem_get_address(ed25519_public_key, network, address);
+  nem_get_address(ed25519_public_key_fuzz, network, address);
 
 #if defined(__has_feature)
 #if __has_feature(memory_sanitizer)
@@ -616,15 +616,15 @@ int fuzz_slip39_word_completion_mask(void) {
 }
 
 int fuzz_mnemonic_to_bits(void) {
-  // length chosen somewhat arbitrarily
-#define MAX_MNEMONIC_LENGTH 256
+  // regular MAX_MNEMONIC_LEN is 240, try some extra bytes
+#define MAX_MNEMONIC_FUZZ_LENGTH 256
 
-  if (fuzzer_length < MAX_MNEMONIC_LENGTH) {
+  if (fuzzer_length < MAX_MNEMONIC_FUZZ_LENGTH) {
     return 0;
   }
 
-  char mnemonic[MAX_MNEMONIC_LENGTH + 1] = {0};
-  memcpy(&mnemonic, fuzzer_ptr, MAX_MNEMONIC_LENGTH);
+  char mnemonic[MAX_MNEMONIC_FUZZ_LENGTH + 1] = {0};
+  memcpy(&mnemonic, fuzzer_ptr, MAX_MNEMONIC_FUZZ_LENGTH);
   uint8_t mnemonic_bits[32 + 1] = {0};
 
   mnemonic_to_bits((const char *)&mnemonic, mnemonic_bits);

--- a/crypto/fuzzer/fuzzer.c
+++ b/crypto/fuzzer/fuzzer.c
@@ -716,7 +716,7 @@ int fuzz_mnemonic_to_seed(void) {
 
 int fuzz_ethereum_address_checksum(void) {
   uint8_t addr[20] = {0};
-  char address[41] = {0};
+  char address[43] = {0};
   uint64_t chain_id = 0;
   bool rskip60 = false;
 

--- a/crypto/fuzzer/fuzzer.c
+++ b/crypto/fuzzer/fuzzer.c
@@ -84,6 +84,15 @@ void fuzzer_reset_state(void) {
   // reset the PRNGs to make individual fuzzer runs deterministic
   srand(0);
   random_reseed(0);
+
+  // clear internal caches
+  // note: this is not strictly required for all fuzzer targets
+#if USE_BIP32_CACHE
+  bip32_cache_clear();
+#endif
+#if USE_BIP39_CACHE
+  bip39_cache_clear();
+#endif
 }
 
 void crash(void) {

--- a/crypto/fuzzer/sanitizer_ignorelist.txt
+++ b/crypto/fuzzer/sanitizer_ignorelist.txt
@@ -1,0 +1,21 @@
+# ignore bignum math operations and other hot crypto primitives
+
+fun:*sha256_Update*
+fun:*sha256_Raw*
+fun:*sha256_Transform*
+fun:*sha512_Transform*
+fun:*pbkdf2_hmac_sha512_Update*
+fun:*pbkdf2_*
+fun:*hmac_*
+fun:*sha256_*
+# TODO this is very broad
+fun:*bn_*
+fun:*bn_inverse*
+fun:*bn_multiply*
+fun:*bn_multiply_long*
+fun:*bn_multiply_reduce_step*
+fun:*bn_multiply_step*
+fun:*curve25519_mul*
+fun:*point_multiply*
+fun:*point_jacobian_add*
+fun:*scalar_multiply*


### PR DESCRIPTION
Introduce fuzzing harnesses for zkp* and other functions
Adapt some differential fuzzing and other logical checks
Add a new dictionary extraction program
Additional documentation and minor cleanup
Add a temporary workaround for clang-14 and more explicit Makefile behavior