### PR TITLE
ci: add hwi tests for core and legacy builds

### DIFF
--- a/ci/shell.nix
+++ b/ci/shell.nix
@@ -41,11 +41,23 @@ let
   llvmPackages = nixpkgs.llvmPackages_12;
   # see pyright/README.md for update procedure
   pyright = nixpkgs.callPackage ./pyright {};
+  # HWI tests need https://github.com/bitcoin/bitcoin/pull/22558
+  # remove this once nixpkgs version contains this patch
+  bitcoind = (nixpkgs.bitcoind.overrideAttrs (attrs: {
+    version = attrs.version + "-taproot-psbt";
+    src = nixpkgs.fetchFromGitHub {
+      owner = "achow101";
+      repo = "bitcoin";
+      rev = "taproot-psbt";
+      sha256 = "sha256-Am7SVxOTlTUjESk8O7kziwyV2GaBX6pGB1oksYPc1EE=";
+    };
+  }));
 in
 with nixpkgs;
 stdenvNoCC.mkDerivation ({
   name = "trezor-firmware-env";
   buildInputs = lib.optionals fullDeps [
+    bitcoind
     # install other python versions for tox testing
     # NOTE: running e.g. "python3" in the shell runs the first version in the following list,
     #       and poetry uses the default version (currently 3.8)

--- a/ci/test.yml
+++ b/ci/test.yml
@@ -374,6 +374,20 @@ core persistence asan test:
     expire_in: 1 week
     when: always
 
+core hwi test:
+  stage: test
+  <<: *gitlab_caching
+  needs:
+    - core unix frozen debug build
+  script:
+    - nix-shell --run "git clone https://github.com/bitcoin-core/HWI.git"
+    - nix-shell --arg fullDeps true --run "cd HWI && poetry install && poetry run ./test/test_trezor.py --model_t ../core/build/unix/trezor-emu-core bitcoind"
+  artifacts:
+    name: "$CI_JOB_NAME-$CI_COMMIT_SHORT_SHA"
+    paths:
+      - HWI/trezor-t-emulator.stdout
+    expire_in: 1 week
+    when: always
 
 # Crypto
 
@@ -512,7 +526,22 @@ legacy upgrade asan test:
     expire_in: 1 week
     when: always
 
-
+legacy hwi test:
+  stage: test
+  <<: *gitlab_caching
+  needs:
+    - legacy emu regular debug build
+  variables:
+    EMULATOR: "1"
+  script:
+    - nix-shell --run "git clone https://github.com/bitcoin-core/HWI.git"
+    - nix-shell --arg fullDeps true --run "cd HWI && poetry install && poetry run ./test/test_trezor.py --model_1 ../legacy/firmware/trezor.elf bitcoind"
+  artifacts:
+    name: "$CI_JOB_NAME-$CI_COMMIT_SHORT_SHA"
+    paths:
+      - HWI/trezor-1-emulator.stdout
+    expire_in: 1 week
+    when: always
 # Python
 
 python test:


### PR DESCRIPTION
This pr adds hwi trezor test to our CI. Not sure if this is the best solution for adding the tests to our ci. 

Also, If you have any idea how to not directly point to /nix/store for bitcoind binary, use a relative path so it doesn't break with each nix update. Suggestions welcome.