### PR TITLE
ci: build base docker image once a week on schedule

### DIFF
--- a/ci/environment.yml
+++ b/ci/environment.yml
@@ -1,7 +1,6 @@
-environment:
+.environment:
   stage: environment
   image: docker
-  when: manual
   variables:
     GIT_SUBMODULE_STRATEGY: none  # no need to fetch submodules
     CONTAINER_NAME: "$CI_REGISTRY/satoshilabs/trezor/trezor-firmware/trezor-firmware-env.nix"
@@ -20,3 +19,13 @@ environment:
     - docker build --tag $CONTAINER_NAME:$CI_COMMIT_SHA --tag $CONTAINER_NAME:latest --build-arg ALPINE_VERSION="$ALPINE_VERSION" --build-arg ALPINE_ARCH="$ALPINE_ARCH" --build-arg NIX_VERSION="$NIX_VERSION" --build-arg FULLDEPS_TESTING=1 ci/
     - docker push $CONTAINER_NAME:$CI_COMMIT_SHA
     - docker push $CONTAINER_NAME:latest
+
+environment manual:
+  extends: .environment
+  when: manual
+
+environment scheduled:
+  extends: .environment
+  only:
+    variables:
+      - $SCHEDULED_ENVIRONMENR_BUILD == "true"


### PR DESCRIPTION
This will allow us to have the base docker image be built once a week and keep the manual build of the image if needed.
<img width="747" alt="Screenshot 2022-01-22 at 12 19 42" src="https://user-images.githubusercontent.com/45185420/150636412-435272e8-2773-45b6-ada3-83bcfbae6ad5.png">
