### PR TITLE
ci(core): add nightly builds with PRODUCTION=1

### DIFF
--- a/ci/build.yml
+++ b/ci/build.yml
@@ -44,6 +44,28 @@ core fw regular debug build:
       - trezor-fw-regular-debug-*.*.*-$CI_COMMIT_SHORT_SHA.bin
     expire_in: 1 week
 
+core fw regular production build:
+  stage: build
+  <<: *gitlab_caching
+  needs: []
+  only:
+    - schedules  # nightly build
+  variables:
+    PRODUCTION: "1"
+  script:
+    - nix-shell --run "poetry run make -C core build_boardloader"
+    - nix-shell --run "poetry run make -C core build_bootloader"
+    - nix-shell --run "poetry run make -C core build_bootloader_ci"
+    - nix-shell --run "poetry run make -C core build_prodtest"
+    - nix-shell --run "poetry run make -C core build_firmware"
+    - nix-shell --run "poetry run make -C core sizecheck"
+    - cp core/build/firmware/firmware.bin trezor-fw-regular-production-$CORE_VERSION-$CI_COMMIT_SHORT_SHA.bin
+  artifacts:
+    name: "$CI_JOB_NAME-$CI_COMMIT_SHORT_SHA"
+    paths:
+      - trezor-fw-regular-production-*.*.*-$CI_COMMIT_SHORT_SHA.bin
+    expire_in: 1 week
+
 core fw btconly build:
   stage: build
   <<: *gitlab_caching
@@ -82,6 +104,25 @@ core fw btconly debug build:
     name: "$CI_JOB_NAME-$CI_COMMIT_SHORT_SHA"
     paths:
       - trezor-fw-btconly-*.*.*-$CI_COMMIT_SHORT_SHA.bin
+    expire_in: 1 week
+
+core fw btconly production build:
+  stage: build
+  <<: *gitlab_caching
+  needs: []
+  only:
+    - schedules  # nightly build
+  variables:
+    PRODUCTION: "1"
+    BITCOIN_ONLY: "1"
+  script:
+    - nix-shell --run "poetry run make -C core build_firmware"
+    - nix-shell --run "poetry run ./tools/check-bitcoin-only core/build/firmware/firmware.bin"
+    - cp core/build/firmware/firmware.bin trezor-fw-btconly-production-$CORE_VERSION-$CI_COMMIT_SHORT_SHA.bin
+  artifacts:
+    name: "$CI_JOB_NAME-$CI_COMMIT_SHORT_SHA"
+    paths:
+      - trezor-fw-btconly-production-*.*.*-$CI_COMMIT_SHORT_SHA.bin
     expire_in: 1 week
 
 core fw btconly t1 build:


### PR DESCRIPTION
Fixes #1937. Core only, legacy already builds with PRODUCTION=1 as part of the normal job. Relevant to #2059 if I figure out how to parametrize our jobs.

Note to self: uncomment the `only: schedules` lines before merging.