### PR TITLE
fix(core): fix build with FEATURE_FLAGS.SECP256K1_ZKP=False

### DIFF
--- a/core/SConscript.firmware
+++ b/core/SConscript.firmware
@@ -10,7 +10,7 @@ NEW_UI = TREZOR_MODEL == '1' or os.environ.get('NEW_UI', '0') == '1'
 
 FEATURE_FLAGS = {
     "RDI": True,
-    "SECP256K1_ZKP": True,
+    "SECP256K1_ZKP": True,  # required for trezor.crypto.curve.bip340 (BIP340/Taproot)
     "SYSTEM_VIEW": False,
 }
 

--- a/core/SConscript.unix
+++ b/core/SConscript.unix
@@ -9,7 +9,7 @@ TREZOR_MODEL = ARGUMENTS.get('TREZOR_MODEL', 'T')
 NEW_UI = TREZOR_MODEL == '1' or ARGUMENTS.get('NEW_UI', '0') == '1'
 
 FEATURE_FLAGS = {
-    "SECP256K1_ZKP": True,
+    "SECP256K1_ZKP": True,  # required for trezor.crypto.curve.bip340 (BIP340/Taproot)
 }
 
 CCFLAGS_MOD = ''

--- a/core/embed/extmod/modtrezorcrypto/modtrezorcrypto-bip340.h
+++ b/core/embed/extmod/modtrezorcrypto/modtrezorcrypto-bip340.h
@@ -17,6 +17,8 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
+#if USE_SECP256K1_ZKP
+
 #include "py/objstr.h"
 
 #include "rand.h"
@@ -242,3 +244,5 @@ STATIC const mp_obj_module_t mod_trezorcrypto_bip340_module = {
     .base = {&mp_type_module},
     .globals = (mp_obj_dict_t *)&mod_trezorcrypto_bip340_globals,
 };
+
+#endif

--- a/core/embed/extmod/modtrezorcrypto/modtrezorcrypto.c
+++ b/core/embed/extmod/modtrezorcrypto/modtrezorcrypto.c
@@ -38,7 +38,9 @@ static void wrapped_ui_wait_callback(uint32_t current, uint32_t total) {
 
 #include "modtrezorcrypto-aes.h"
 #include "modtrezorcrypto-bip32.h"
+#ifdef USE_SECP256K1_ZKP
 #include "modtrezorcrypto-bip340.h"
+#endif
 #include "modtrezorcrypto-bip39.h"
 #include "modtrezorcrypto-blake256.h"
 #include "modtrezorcrypto-blake2b.h"
@@ -104,7 +106,9 @@ STATIC const mp_rom_map_elem_t mp_module_trezorcrypto_globals_table[] = {
      MP_ROM_PTR(&mod_trezorcrypto_Ripemd160_type)},
     {MP_ROM_QSTR(MP_QSTR_secp256k1),
      MP_ROM_PTR(&mod_trezorcrypto_secp256k1_module)},
+#if USE_SECP256K1_ZKP
     {MP_ROM_QSTR(MP_QSTR_bip340), MP_ROM_PTR(&mod_trezorcrypto_bip340_module)},
+#endif
     {MP_ROM_QSTR(MP_QSTR_sha1), MP_ROM_PTR(&mod_trezorcrypto_Sha1_type)},
     {MP_ROM_QSTR(MP_QSTR_sha256), MP_ROM_PTR(&mod_trezorcrypto_Sha256_type)},
     {MP_ROM_QSTR(MP_QSTR_sha512), MP_ROM_PTR(&mod_trezorcrypto_Sha512_type)},


### PR DESCRIPTION
When SECP256K1_ZKP is set to False in SConscript.{firmware,unix} the build fails.

This PR fixes the issue. However, this still does not mean the firmware is usable as is, since we use the bip340 in our codebase unconditionally. 

The change is still beneficial IMHO because this allows development of a completely custom firmware (i.e. different `core/src`) with SECP256K1_ZKP not included in the build.