### PR TITLE
Fix legacy technical debt in USB handling

### DIFF
--- a/legacy/common.c
+++ b/legacy/common.c
@@ -19,6 +19,7 @@
 
 #include "common.h"
 #include <stdio.h>
+#include <unistd.h>
 #include "bitmaps.h"
 #include "firmware/usb.h"
 #include "hmac_drbg.h"
@@ -83,7 +84,17 @@ void __assert_func(const char *file, int line, const char *func,
 }
 #endif
 
-void hal_delay(uint32_t ms) { usbSleep(ms); }
+void hal_delay(uint32_t ms) {
+#if EMULATOR
+  usleep(ms * 1000);
+#else
+  uint32_t start = timer_ms();
+
+  while ((timer_ms() - start) < ms) {
+    asm("nop");
+  }
+#endif
+}
 
 void drbg_init() {
   uint8_t entropy[48] = {0};

--- a/legacy/firmware/.changelog.d/2107.fixed
+++ b/legacy/firmware/.changelog.d/2107.fixed
@@ -1,0 +1,1 @@
+Fix legacy technical debt in USB handling (readability and FSM unwanted states).

--- a/legacy/firmware/config.c
+++ b/legacy/firmware/config.c
@@ -564,7 +564,7 @@ void config_setHomescreen(const uint8_t *data, uint32_t size) {
 }
 
 static void get_root_node_callback(uint32_t iter, uint32_t total) {
-  usbSleep(1);
+  waitAndProcessUSBRequests(1);
   layoutProgress(_("Waking up"), 1000 * iter / total);
 }
 

--- a/legacy/firmware/protect.c
+++ b/legacy/firmware/protect.c
@@ -64,7 +64,7 @@ bool protectButton(ButtonRequestType type, bool confirm_only) {
 
     // button acked - check buttons
     if (acked) {
-      usbSleep(5);
+      waitAndProcessUSBRequests(5);
       buttonUpdate();
       if (button.YesUp) {
         result = true;

--- a/legacy/firmware/recovery.c
+++ b/legacy/firmware/recovery.c
@@ -421,7 +421,7 @@ static void recovery_digit(const char digit) {
     oledInvert(x + 1, y, x + 62, y + 9);
     oledRefresh();
     usbTiny(1);
-    usbSleep(250);
+    waitAndProcessUSBRequests(250);
     usbTiny(0);
 
     /* index of the chosen word */

--- a/legacy/firmware/trezor.c
+++ b/legacy/firmware/trezor.c
@@ -77,13 +77,13 @@ void check_lock_screen(void) {
     // wait until NoButton is released
     usbTiny(1);
     do {
-      usbSleep(5);
+      waitAndProcessUSBRequests(5);
       buttonUpdate();
     } while (!button.NoUp);
 
     // wait for confirmation/cancellation of the dialog
     do {
-      usbSleep(5);
+      waitAndProcessUSBRequests(5);
       buttonUpdate();
     } while (!button.YesUp && !button.NoUp);
     usbTiny(0);
@@ -180,7 +180,7 @@ int main(void) {
   usbInit();
   for (;;) {
 #if EMULATOR
-    usbSleep(10);
+    waitAndProcessUSBRequests(10);
 #else
     usbPoll();
 #endif

--- a/legacy/firmware/usb.c
+++ b/legacy/firmware/usb.c
@@ -448,7 +448,7 @@ char usbTiny(char set) {
   return old;
 }
 
-void usbSleep(uint32_t millis) {
+void waitAndProcessUSBRequests(uint32_t millis) {
   uint32_t start = timer_ms();
 
   while ((timer_ms() - start) < millis) {

--- a/legacy/firmware/usb.h
+++ b/legacy/firmware/usb.h
@@ -25,8 +25,34 @@
 void usbInit(void);
 void usbPoll(void);
 void usbReconnect(void);
+
+/*
+ * Setting this value to 1 will limit the protobuf messages `usbPoll` and
+ * `waitAndProcessUSBRequests` can handle to a few defined in `msg_read_tiny`.
+ *
+ * Also affects U2F and DebugLink messages.
+ *
+ * Setting to 1 is meant to prevent infinite recursion when you need to read a
+ * message while being called from FSM.
+ *
+ * Setting to 0 allows processing all messages.
+ */
 char usbTiny(char set);
-void usbSleep(uint32_t millis);
+
+/*
+ * This will wait given number of milliseconds for arrival of protobuf message.
+ * If it arrives, it will service it before returning.
+ *
+ * If you call this function from any function that is called from FSM,
+ * you must use `usbTiny(1)` before and `usbTiny(oldTinyValue)` or `usbTiny(0)`
+ * after, otherwise there is possibility of stack exhaustion.
+ */
+void waitAndProcessUSBRequests(uint32_t millis);
+
+/*
+ * Flush out any messages still in USB bus FIFO while waiting given number
+ * of milliseconds. Any incoming USB protobuf messages are not serviced.
+ */
 void usbFlush(uint32_t millis);
 
 #endif


### PR DESCRIPTION
This change is aimed to make USB handling in T1 legacy more readable and also remove states where handling of USB protobuf messages should not happen (even if not exploitable right now, it helps prevent accidental bugs in future).

FSM and message handling is already complicated due to call graph being complex.