### PR TITLE
docs(core): Launch bridge w/ emulator support via suite

### DIFF
--- a/docs/core/emulator/index.md
+++ b/docs/core/emulator/index.md
@@ -14,7 +14,9 @@ Emulator significantly speeds up development and has several features to help yo
 2. run `emu.py` inside the poetry environment:
    - either enter `poetry shell` first, and then use `./emu.py`
    - or always use `poetry run ./emu.py`
-3. to use [bridge](https://github.com/trezor/trezord-go) with the emulator support, start it with `trezord-go -e 21324`
+3. start the bridge:
+   - to initalise the [bridge](https://github.com/trezor/trezord-go) with emulator support, start it with `trezord-go -e 21324`
+   - alternatively, launch the [desktop suite](https://suite.trezor.io/) from the command line with the argument `--bridge-dev` 
 
 Now you can use the emulator the same way as you use the device, for example you can use [Trezor Suite](https://suite.trezor.io), use our Python CLI tool (`trezorctl`), etc. Simply click to emulate screen touches.
 


### PR DESCRIPTION
After managing to build and run the emulator, it is handy to launch the TREZOR bridge via the suite with emulator support.