### PR TITLE
ci: github project automation update

### DIFF
--- a/.github/workflows/project_automation.yml
+++ b/.github/workflows/project_automation.yml
@@ -9,20 +9,19 @@ permissions:
   repository-projects: write
 
 jobs:
-  github-actions-automate-projects:
+  gh-automate-projects:
     runs-on: ubuntu-latest
     steps:
-      - name: add-new-issues-to-repository-based-project-column
-        uses: docker://takanabe/github-actions-automate-projects:v0.0.1
+      - name: Add new issue to the Backlog 🗂  project board
         if: github.event_name == 'issues' && github.event.action == 'opened'
+        run: gh issue edit $ISSUE --add-project "Backlog 🗂  "
         env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          GITHUB_PROJECT_URL: https://github.com/trezor/trezor-firmware/projects/1
-          GITHUB_PROJECT_COLUMN_NAME: 📥 Inbox
-      - name: add-new-prs-to-repository-based-project-column
-        uses: docker://takanabe/github-actions-automate-projects:v0.0.1
+          ISSUE: ${{github.event.issue.html_url}}
+          GITHUB_TOKEN: ${{ secrets.GH_BOT_TOKEN }}
+
+      - name: Add new pull request to the Pull Requests project board
         if: github.event_name == 'pull_request' && github.event.action == 'opened'
+        run: gh pr edit $PULL_REQUEST --add-project "Pull Requests"
         env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          GITHUB_PROJECT_URL: https://github.com/trezor/trezor-firmware/projects/2
-          GITHUB_PROJECT_COLUMN_NAME: To be reviewed
+          PULL_REQUEST: ${{github.event.pull_request.html_url}}
+          GITHUB_TOKEN: ${{ secrets.GH_BOT_TOKEN }}


### PR DESCRIPTION
An alternative way of automating adding issues and pull requests to project boards
This uses "native" cli utility from github `gh` this modifies the Pull request or issue with this cli utility and uses bot toke for this. 

Some prequisities for this setup.
1. add `GH_BOT_TOKEN` actions repository secret with personal access token of bot user
2. setup project automation for assigning columns for newly added issues or prs (pull requests project already setup like this)