### PR TITLE
feat(python): unify option arguments in trezorctl

### DIFF
--- a/python/docs/OPTIONS.rst
+++ b/python/docs/OPTIONS.rst
@@ -30,6 +30,7 @@ on one page here.
     -v, --verbose             Show communication messages.
     -j, --json                Print result as JSON object
     -P, --passphrase-on-host  Enter passphrase on host.
+    -S, --script              Use UI for usage in scripts.
     -s, --session-id HEX      Resume given session ID.
     --version                 Show the version and exit.
     --help                    Show this message and exit.
@@ -251,12 +252,13 @@ Ethereum commands.
     --help  Show this message and exit.
 
   Commands:
-    get-address      Get Ethereum address in hex encoding.
-    get-public-node  Get Ethereum public node of given path.
-    sign-message     Sign message with Ethereum address.
-    sign-tx          Sign (and optionally publish) Ethereum transaction.
-    sign-typed-data  Sign typed data (EIP-712) with Ethereum address.
-    verify-message   Verify message signed with Ethereum address.
+    get-address           Get Ethereum address in hex encoding.
+    get-public-node       Get Ethereum public node of given path.
+    sign-message          Sign message with Ethereum address.
+    sign-tx               Sign (and optionally publish) Ethereum transaction.
+    sign-typed-data       Sign typed data (EIP-712) with Ethereum address.
+    sign-typed-data-hash  Sign hash of typed data (EIP-712) with Ethereum address.
+    verify-message        Verify message signed with Ethereum address.
 
 FIDO2, U2F and WebAuthN management commands.
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~

--- a/python/src/trezorlib/cli/settings.py
+++ b/python/src/trezorlib/cli/settings.py
@@ -95,24 +95,28 @@ def cli() -> None:
 
 
 @cli.command()
-@click.option("-r", "--remove", is_flag=True)
+@click.argument(
+    "enable", type=ChoiceType({"enable": True, "disable": False}), default=True
+)
 @with_client
-def pin(client: "TrezorClient", remove: bool) -> str:
+def pin(client: "TrezorClient", enable: bool) -> str:
     """Set, change or remove PIN."""
-    return device.change_pin(client, remove)
+    return device.change_pin(client, remove=not enable)
 
 
 @cli.command()
-@click.option("-r", "--remove", is_flag=True)
+@click.argument(
+    "enable", type=ChoiceType({"enable": True, "disable": False}), default=True
+)
 @with_client
-def wipe_code(client: "TrezorClient", remove: bool) -> str:
+def wipe_code(client: "TrezorClient", enable: bool) -> str:
     """Set or remove the wipe code.
 
     The wipe code functions as a "self-destruct PIN". If the wipe code is ever
     entered into any PIN entry dialog, then all private data will be immediately
     removed and the device will be reset to factory defaults.
     """
-    return device.change_wipe_code(client, remove)
+    return device.change_wipe_code(client, remove=not enable)
 
 
 @cli.command()
@@ -218,7 +222,7 @@ def safety_checks(
 
 
 @cli.command()
-@click.argument("enable", type=ChoiceType({"on": True, "off": False}))
+@click.argument("enable", type=ChoiceType({"enable": True, "disable": False}))
 @with_client
 def experimental_features(client: "TrezorClient", enable: bool) -> str:
     """Enable or disable experimental message types.
@@ -240,7 +244,7 @@ def passphrase() -> None:
     # and "disable-passphrase". Otherwise `passphrase` would just take an argument.
 
 
-@passphrase.command(name="enabled")
+@passphrase.command(name="enable")
 @click.option("-f/-F", "--force-on-device/--no-force-on-device", default=None)
 @with_client
 def passphrase_enable(client: "TrezorClient", force_on_device: Optional[bool]) -> str:
@@ -250,7 +254,7 @@ def passphrase_enable(client: "TrezorClient", force_on_device: Optional[bool]) -
     )
 
 
-@passphrase.command(name="disabled")
+@passphrase.command(name="disable")
 @with_client
 def passphrase_disable(client: "TrezorClient") -> str:
     """Disable passphrase."""


### PR DESCRIPTION
Connected with https://github.com/trezor/trezor-firmware/issues/1130:
- unifying how the on/off, enable/disable, enabled/disabled, -/-r arguments look like
- currently `enabled/disabled`, with `enabled` being a default one does not seem bad
- I did not go through all the commands, just the basic ones from the issue

There are some changes in OPTIONS.rst, made by the helper script (from previous commits) - could these be run now, or are we always waiting for the `trezorlib` release?