### PR TITLE
feat(crypto): API for clearing internal caches

### DIFF
--- a/crypto/bip32.c
+++ b/crypto/bip32.c
@@ -374,6 +374,13 @@ static CONFIDENTIAL struct {
   HDNode node;
 } private_ckd_cache[BIP32_CACHE_SIZE];
 
+void bip32_cache_clear(void) {
+  private_ckd_cache_root_set = false;
+  private_ckd_cache_index = 0;
+  memzero(&private_ckd_cache_root, sizeof(private_ckd_cache_root));
+  memzero(private_ckd_cache, sizeof(private_ckd_cache));
+}
+
 int hdnode_private_ckd_cached(HDNode *inout, const uint32_t *i, size_t i_count,
                               uint32_t *fingerprint) {
   if (i_count == 0) {

--- a/crypto/bip32.h
+++ b/crypto/bip32.h
@@ -89,6 +89,7 @@ void hdnode_public_ckd_address_optimized(const curve_point *pub,
                                          int addrsize, int addrformat);
 
 #if USE_BIP32_CACHE
+void bip32_cache_clear(void);
 int hdnode_private_ckd_cached(HDNode *inout, const uint32_t *i, size_t i_count,
                               uint32_t *fingerprint);
 #endif

--- a/crypto/bip39.c
+++ b/crypto/bip39.c
@@ -44,6 +44,11 @@ static CONFIDENTIAL struct {
   uint8_t seed[512 / 8];
 } bip39_cache[BIP39_CACHE_SIZE];
 
+void bip39_cache_clear(void) {
+  memzero(bip39_cache, sizeof(bip39_cache));
+  bip39_cache_index = 0;
+}
+
 #endif
 
 const char *mnemonic_generate(int strength) {

--- a/crypto/bip39.h
+++ b/crypto/bip39.h
@@ -27,8 +27,14 @@
 #include <stdbool.h>
 #include <stdint.h>
 
+#include "options.h"
+
 #define BIP39_WORDS 2048
 #define BIP39_PBKDF2_ROUNDS 2048
+
+#if USE_BIP39_CACHE
+void bip39_cache_clear(void);
+#endif
 
 const char *mnemonic_generate(int strength);  // strength in bits
 const char *mnemonic_from_data(const uint8_t *data, int len);


### PR DESCRIPTION
Internal trezor-crypto caches have messed up reproducible UI tests many times before. Let's finally have an explicit API to clear them when the device is wiped. Although it doesn't seem to matter in practice, it's cleaner anyway.

We might want to export something like `crypto_clear_caches()`, but I didn't know where to put it.