### PR TITLE
docs(legacy/bootloader): fix changelog date

### DIFF
--- a/legacy/bootloader/CHANGELOG.md
+++ b/legacy/bootloader/CHANGELOG.md
@@ -4,7 +4,7 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
-## 1.10.0 [unreleased]
+## 1.10.0 [May 2021]
 
 ### Added
 - "Stay in bootloader" flag.  [#1461]


### PR DESCRIPTION
Checked the actual unreleased changes and everything seems to match except the missing date.