### PR TITLE
feat(core): headless emulator implies disabled animations

### DIFF
--- a/core/emu.py
+++ b/core/emu.py
@@ -96,7 +96,7 @@ def _from_env(name):
 @click.option("--executable", type=click.Path(exists=True, dir_okay=False), default=os.environ.get("MICROPYTHON"), help="Alternate emulator executable")
 @click.option("-g", "--profiling/--no-profiling", default=_from_env("TREZOR_PROFILING"), help="Run with profiler wrapper")
 @click.option("-G", "--alloc-profiling/--no-alloc-profiling", default=_from_env("TREZOR_MEMPERF"), help="Profile memory allocation (requires special micropython build)")
-@click.option("-h", "--headless", is_flag=True, help="Headless mode (no display)")
+@click.option("-h", "--headless", is_flag=True, help="Headless mode (no display, disables animation)")
 @click.option("--heap-size", metavar="SIZE", default="20M", help="Configure heap size")
 @click.option("--main", help="Path to python main file")
 @click.option("--mnemonic", "mnemonics", multiple=True, help="Initialize device with given mnemonic. Specify multiple times for Shamir shares.")

--- a/python/src/trezorlib/_internal/emulator.py
+++ b/python/src/trezorlib/_internal/emulator.py
@@ -236,7 +236,7 @@ class CoreEmulator(Emulator):
         )
         if self.headless:
             env["SDL_VIDEODRIVER"] = "dummy"
-        if self.disable_animation:
+        if self.headless or self.disable_animation:
             env["TREZOR_DISABLE_FADE"] = "1"
             env["TREZOR_DISABLE_ANIMATION"] = "1"
 


### PR DESCRIPTION
I was under impression that headless mode disables animation. However, this is not the case.

If we do not want this by default (for some reason I don't see/understand), feel free to close this PR.