### PR TITLE
fix: cardano testnet slip44/coin_type

### DIFF
--- a/common/defs/misc/misc.json
+++ b/common/defs/misc/misc.json
@@ -90,7 +90,7 @@
     {
         "name": "Cardano Testnet",
         "shortcut": "tADA",
-        "slip44": 1,
+        "slip44": 1815,
         "curve": "ed25519",
         "decimals": 6,
         "links": {


### PR DESCRIPTION
[As discussed](https://five-binaries.slack.com/archives/C0292ULQHGD/p1645522020708709) we are changing slip44/coin_type part of cardano testnet definition to `1815`