### PR TITLE
chore(common): include error explanation in protobuf messages check

### DIFF
--- a/common/protob/check.py
+++ b/common/protob/check.py
@@ -10,10 +10,12 @@ MYDIR = os.path.dirname(__file__)
 
 EXPECTED_PREFIX_RE = re.compile(r"messages-(\w+)(?:-.*)?\.proto")
 
+# Checking all protobuf files for their `enum` and `message` declarations
+# and making sure their names start with expected prefix
 for fn in sorted(glob(os.path.join(MYDIR, "messages-*.proto"))):
     with open(fn, "rt") as f:
         prefix = EXPECTED_PREFIX_RE.search(fn).group(1).capitalize()
-        if prefix in ["Bitcoin", "Bootloader", "Common", "Crypto", "Management"]:
+        if prefix in ("Bitcoin", "Bootloader", "Common", "Crypto", "Management"):
             continue
         if prefix == "Nem":
             prefix = "NEM"
@@ -21,12 +23,14 @@ for fn in sorted(glob(os.path.join(MYDIR, "messages-*.proto"))):
             prefix = "WebAuthn"
         for line in f:
             line = line.strip().split(" ")
-            if line[0] not in ["enum", "message"]:
+            if line[0] not in ("enum", "message"):
                 continue
-            if not line[1].startswith(prefix) and not line[1].startswith(
-                "Debug" + prefix
-            ):
-                print("ERROR:", fn, line[1])
+            expected_prefixes = (prefix, f"Debug{prefix}")
+            if not line[1].startswith(expected_prefixes):
+                print("ERROR: protobuf message does not start with expected prefix")
+                print(f"    file: {fn}")
+                print(f"    message: {line[1]}")
+                print(f"    expected prefixes: {expected_prefixes}")
                 error = True
 
 if error:


### PR DESCRIPTION
Adding error explanation to protobuf messages check, which is part of `common prebuild` job in `CI`.

Currently, the error message does not say why it happened.