### PR TITLE
Support Zcash v5 transaction format on TT

### DIFF
--- a/core/.changelog.d/2166.added
+++ b/core/.changelog.d/2166.added
@@ -1,0 +1,1 @@
+Support Zcash version 5 transaction format

--- a/core/SConscript.firmware
+++ b/core/SConscript.firmware
@@ -616,7 +616,7 @@ if FROZEN:
         exclude=[
             SOURCE_PY_DIR + 'apps/bitcoin/sign_tx/decred.py',
             SOURCE_PY_DIR + 'apps/bitcoin/sign_tx/bitcoinlike.py',
-            SOURCE_PY_DIR + 'apps/bitcoin/sign_tx/zcash.py',
+            SOURCE_PY_DIR + 'apps/bitcoin/sign_tx/zcash_v4.py',
         ])
     )
 
@@ -655,11 +655,13 @@ if FROZEN:
         SOURCE_PY.extend(Glob(SOURCE_PY_DIR + 'apps/tezos/*.py'))
         SOURCE_PY.extend(Glob(SOURCE_PY_DIR + 'trezor/enums/Tezos*.py'))
 
+        SOURCE_PY.extend(Glob(SOURCE_PY_DIR + 'apps/zcash/*.py'))
+
         SOURCE_PY.extend(Glob(SOURCE_PY_DIR + 'apps/webauthn/*.py'))
 
         SOURCE_PY.extend(Glob(SOURCE_PY_DIR + 'apps/bitcoin/sign_tx/decred.py'))
         SOURCE_PY.extend(Glob(SOURCE_PY_DIR + 'apps/bitcoin/sign_tx/bitcoinlike.py'))
-        SOURCE_PY.extend(Glob(SOURCE_PY_DIR + 'apps/bitcoin/sign_tx/zcash.py'))
+        SOURCE_PY.extend(Glob(SOURCE_PY_DIR + 'apps/bitcoin/sign_tx/zcash_v4.py'))
 
     source_mpy = env.FrozenModule(source=SOURCE_PY, source_dir=SOURCE_PY_DIR, bitcoin_only=BITCOIN_ONLY)
 

--- a/core/SConscript.unix
+++ b/core/SConscript.unix
@@ -577,7 +577,7 @@ if FROZEN:
         exclude=[
             SOURCE_PY_DIR + 'apps/bitcoin/sign_tx/decred.py',
             SOURCE_PY_DIR + 'apps/bitcoin/sign_tx/bitcoinlike.py',
-            SOURCE_PY_DIR + 'apps/bitcoin/sign_tx/zcash.py',
+            SOURCE_PY_DIR + 'apps/bitcoin/sign_tx/zcash_v4.py',
         ])
     )
 
@@ -616,11 +616,13 @@ if FROZEN:
         SOURCE_PY.extend(Glob(SOURCE_PY_DIR + 'apps/tezos/*.py'))
         SOURCE_PY.extend(Glob(SOURCE_PY_DIR + 'trezor/enums/Tezos*.py'))
 
+        SOURCE_PY.extend(Glob(SOURCE_PY_DIR + 'apps/zcash/*.py'))
+
         SOURCE_PY.extend(Glob(SOURCE_PY_DIR + 'apps/webauthn/*.py'))
 
         SOURCE_PY.extend(Glob(SOURCE_PY_DIR + 'apps/bitcoin/sign_tx/decred.py'))
         SOURCE_PY.extend(Glob(SOURCE_PY_DIR + 'apps/bitcoin/sign_tx/bitcoinlike.py'))
-        SOURCE_PY.extend(Glob(SOURCE_PY_DIR + 'apps/bitcoin/sign_tx/zcash.py'))
+        SOURCE_PY.extend(Glob(SOURCE_PY_DIR + 'apps/bitcoin/sign_tx/zcash_v4.py'))
 
     source_mpy = env.FrozenModule(source=SOURCE_PY, source_dir=SOURCE_PY_DIR, bitcoin_only=BITCOIN_ONLY)
 

--- a/core/src/all_modules.py
+++ b/core/src/all_modules.py
@@ -450,8 +450,8 @@ if not utils.BITCOIN_ONLY:
     import apps.binance.layout
     apps.binance.sign_tx
     import apps.binance.sign_tx
-    apps.bitcoin.sign_tx.zcash
-    import apps.bitcoin.sign_tx.zcash
+    apps.bitcoin.sign_tx.zcash_v4
+    import apps.bitcoin.sign_tx.zcash_v4
     apps.cardano
     import apps.cardano
     apps.cardano.address
@@ -734,6 +734,12 @@ if not utils.BITCOIN_ONLY:
     import apps.webauthn.remove_resident_credential
     apps.webauthn.resident_credentials
     import apps.webauthn.resident_credentials
+    apps.zcash
+    import apps.zcash
+    apps.zcash.hasher
+    import apps.zcash.hasher
+    apps.zcash.signer
+    import apps.zcash.signer
 
 # generate full alphabet
 a

--- a/core/src/apps/bitcoin/sign_tx/__init__.py
+++ b/core/src/apps/bitcoin/sign_tx/__init__.py
@@ -9,7 +9,8 @@ from ..keychain import with_keychain
 from . import approvers, bitcoin, helpers, progress
 
 if not utils.BITCOIN_ONLY:
-    from . import bitcoinlike, decred, zcash
+    from . import bitcoinlike, decred, zcash_v4
+    from apps.zcash.signer import Zcash
 
 if TYPE_CHECKING:
     from typing import Protocol
@@ -70,7 +71,10 @@ async def sign_tx(
         if coin.decred:
             signer_class = decred.Decred
         elif coin.overwintered:
-            signer_class = zcash.Zcashlike
+            if msg.version == 5:
+                signer_class = Zcash
+            else:
+                signer_class = zcash_v4.ZcashV4
         else:
             signer_class = bitcoinlike.Bitcoinlike
 

--- a/core/src/apps/bitcoin/sign_tx/bitcoin.py
+++ b/core/src/apps/bitcoin/sign_tx/bitcoin.py
@@ -135,7 +135,7 @@ class Bitcoin:
     def create_hash_writer(self) -> HashWriter:
         return HashWriter(sha256())
 
-    def create_sig_hasher(self) -> SigHasher:
+    def create_sig_hasher(self, tx: SignTx | PrevTx) -> SigHasher:
         return BitcoinSigHasher()
 
     async def step1_process_inputs(self) -> None:

--- a/core/src/apps/bitcoin/sign_tx/decred.py
+++ b/core/src/apps/bitcoin/sign_tx/decred.py
@@ -79,6 +79,13 @@ class DecredSigHasher:
     ) -> bytes:
         raise NotImplementedError
 
+    def hash_zip244(
+        self,
+        txi: TxInput | None,
+        script_pubkey: bytes | None,
+    ) -> bytes:
+        raise NotImplementedError
+
 
 class Decred(Bitcoin):
     def __init__(

--- a/core/src/apps/bitcoin/sign_tx/decred.py
+++ b/core/src/apps/bitcoin/sign_tx/decred.py
@@ -106,7 +106,7 @@ class Decred(Bitcoin):
     def create_hash_writer(self) -> HashWriter:
         return HashWriter(blake256())
 
-    def create_sig_hasher(self) -> SigHasher:
+    def create_sig_hasher(self, tx: SignTx | PrevTx) -> SigHasher:
         return DecredSigHasher(self.h_prefix)
 
     async def step2_approve_outputs(self) -> None:

--- a/core/src/apps/bitcoin/sign_tx/sig_hasher.py
+++ b/core/src/apps/bitcoin/sign_tx/sig_hasher.py
@@ -39,6 +39,13 @@ if TYPE_CHECKING:
         ) -> bytes:
             ...
 
+        def hash_zip244(
+            self,
+            txi: TxInput | None,
+            script_pubkey: bytes | None,
+        ) -> bytes:
+            ...
+
 
 # BIP-0143 hash
 class BitcoinSigHasher:
@@ -166,3 +173,10 @@ class BitcoinSigHasher:
         writers.write_uint32(h_sigmsg, i)
 
         return h_sigmsg.get_digest()
+
+    def hash_zip244(
+        self,
+        txi: TxInput | None,
+        script_pubkey: bytes | None,
+    ) -> bytes:
+        raise NotImplementedError

--- a/core/src/apps/bitcoin/sign_tx/zcash.py
+++ b/core/src/apps/bitcoin/sign_tx/zcash.py
@@ -128,7 +128,7 @@ class Zcashlike(Bitcoinlike):
         if tx.version != 4:
             raise wire.DataError("Unsupported transaction version.")
 
-    def create_sig_hasher(self) -> SigHasher:
+    def create_sig_hasher(self, tx: SignTx | PrevTx) -> SigHasher:
         return ZcashSigHasher()
 
     async def step7_finish(self) -> None:

--- a/core/src/apps/bitcoin/sign_tx/zcash_v4.py
+++ b/core/src/apps/bitcoin/sign_tx/zcash_v4.py
@@ -35,7 +35,7 @@ if TYPE_CHECKING:
 OVERWINTERED = const(0x8000_0000)
 
 
-class ZcashSigHasher:
+class Zip243SigHasher:
     def __init__(self) -> None:
         self.h_prevouts = HashWriter(blake2b(outlen=32, personal=b"ZcashPrevoutHash"))
         self.h_sequence = HashWriter(blake2b(outlen=32, personal=b"ZcashSequencHash"))
@@ -113,8 +113,15 @@ class ZcashSigHasher:
     ) -> bytes:
         raise NotImplementedError
 
+    def hash_zip244(
+        self,
+        txi: TxInput | None,
+        script_pubkey: bytes | None,
+    ) -> bytes:
+        raise NotImplementedError
 
-class Zcashlike(Bitcoinlike):
+
+class ZcashV4(Bitcoinlike):
     def __init__(
         self,
         tx: SignTx,
@@ -129,7 +136,7 @@ class Zcashlike(Bitcoinlike):
             raise wire.DataError("Unsupported transaction version.")
 
     def create_sig_hasher(self, tx: SignTx | PrevTx) -> SigHasher:
-        return ZcashSigHasher()
+        return Zip243SigHasher()
 
     async def step7_finish(self) -> None:
         self.write_tx_footer(self.serialized_tx, self.tx_info.tx)

--- a/core/src/apps/zcash/hasher.py
+++ b/core/src/apps/zcash/hasher.py
@@ -1,0 +1,279 @@
+"""
+Implementation of Zcash txid and sighash algorithms
+according to the ZIP-0244.
+
+specification: https://zips.z.cash/zip-0244
+"""
+
+from typing import TYPE_CHECKING
+
+from trezor.crypto.hashlib import blake2b
+from trezor.utils import HashWriter, empty_bytearray
+
+from apps.bitcoin.common import SigHashType
+from apps.bitcoin.writers import (
+    TX_HASH_SIZE,
+    write_bytes_fixed,
+    write_bytes_prefixed,
+    write_bytes_reversed,
+    write_tx_output,
+    write_uint8,
+    write_uint32,
+    write_uint64,
+)
+
+if TYPE_CHECKING:
+    from trezor.messages import TxInput, TxOutput, SignTx, PrevTx
+    from trezor.utils import Writer
+    from apps.common.coininfo import CoinInfo
+    from typing import Sequence
+
+
+def write_hash(w: Writer, hash: bytes) -> None:
+    write_bytes_fixed(w, hash, TX_HASH_SIZE)
+
+
+def write_prevout(w: Writer, txi: TxInput) -> None:
+    write_bytes_reversed(w, txi.prev_hash, TX_HASH_SIZE)
+    write_uint32(w, txi.prev_index)
+
+
+class ZcashHasher:
+    def __init__(self, tx: SignTx | PrevTx):
+        self.header = HeaderHasher(tx)
+        self.transparent = TransparentHasher()
+        self.sapling = SaplingHasher()
+        self.orchard = OrchardHasher()
+
+        assert tx.branch_id is not None  # checked in sanitize_sign_tx
+        tx_hash_person = empty_bytearray(16)
+        write_bytes_fixed(tx_hash_person, b"ZcashTxHash_", 12)
+        write_uint32(tx_hash_person, tx.branch_id)
+        self.tx_hash_person = bytes(tx_hash_person)
+
+    # The `txid_digest` method is currently a dead code,
+    # but we keep it for future use cases.
+    def txid_digest(self) -> bytes:
+        """
+        Returns the transaction identifier.
+
+        see: https://zips.z.cash/zip-0244#id4
+        """
+        h = HashWriter(blake2b(outlen=32, personal=self.tx_hash_person))
+
+        write_hash(h, self.header.digest())  # T.1
+        write_hash(h, self.transparent.digest())  # T.2
+        write_hash(h, self.sapling.digest())  # T.3
+        write_hash(h, self.orchard.digest())  # T.4
+
+        return h.get_digest()
+
+    def signature_digest(
+        self, txi: TxInput | None, script_pubkey: bytes | None
+    ) -> bytes:
+        """
+        Returns the transaction signature digest.
+
+        see: https://zips.z.cash/zip-0244#id13
+        """
+        h = HashWriter(blake2b(outlen=32, personal=self.tx_hash_person))
+
+        write_hash(h, self.header.digest())  # S.1
+        write_hash(h, self.transparent.sig_digest(txi, script_pubkey))  # S.2
+        write_hash(h, self.sapling.digest())  # S.3
+        write_hash(h, self.orchard.digest())  # S.4
+
+        return h.get_digest()
+
+    # implement `SigHasher` interface:
+
+    def add_input(self, txi: TxInput, script_pubkey: bytes) -> None:
+        self.transparent.add_input(txi, script_pubkey)
+
+    def add_output(self, txo: TxOutput, script_pubkey: bytes) -> None:
+        self.transparent.add_output(txo, script_pubkey)
+
+    def hash143(
+        self,
+        txi: TxInput,
+        public_keys: Sequence[bytes | memoryview],
+        threshold: int,
+        tx: SignTx | PrevTx,
+        coin: CoinInfo,
+        hash_type: int,
+    ) -> bytes:
+        raise NotImplementedError
+
+    def hash341(
+        self,
+        i: int,
+        tx: SignTx | PrevTx,
+        sighash_type: SigHashType,
+    ) -> bytes:
+        raise NotImplementedError
+
+    def hash_zip244(
+        self,
+        txi: TxInput | None,
+        script_pubkey: bytes | None,
+    ) -> bytes:
+        return self.signature_digest(txi, script_pubkey)
+
+
+class HeaderHasher:
+    def __init__(self, tx: SignTx | PrevTx):
+        h = HashWriter(blake2b(outlen=32, personal=b"ZTxIdHeadersHash"))
+
+        assert tx.version_group_id is not None
+        assert tx.branch_id is not None  # checked in sanitize_*
+        assert tx.expiry is not None
+
+        write_uint32(h, tx.version | (1 << 31))  # T.1a
+        write_uint32(h, tx.version_group_id)  # T.1b
+        write_uint32(h, tx.branch_id)  # T.1c
+        write_uint32(h, tx.lock_time)  # T.1d
+        write_uint32(h, tx.expiry)  # T.1e
+
+        self._digest = h.get_digest()
+
+    def digest(self) -> bytes:
+        """
+        Returns `T.1: header_digest` field.
+
+        see: https://zips.z.cash/zip-0244#t-1-header-digest
+        """
+        return self._digest
+
+
+class TransparentHasher:
+    def __init__(self) -> None:
+        self.prevouts = HashWriter(
+            blake2b(outlen=32, personal=b"ZTxIdPrevoutHash")
+        )  # a hasher for fields T.2a & S.2b
+
+        self.amounts = HashWriter(
+            blake2b(outlen=32, personal=b"ZTxTrAmountsHash")
+        )  # a hasher for field S.2c
+
+        self.scriptpubkeys = HashWriter(
+            blake2b(outlen=32, personal=b"ZTxTrScriptsHash")
+        )  # a hasher for field S.2d
+
+        self.sequence = HashWriter(
+            blake2b(outlen=32, personal=b"ZTxIdSequencHash")
+        )  # a hasher for fields T.2b & S.2e
+
+        self.outputs = HashWriter(
+            blake2b(outlen=32, personal=b"ZTxIdOutputsHash")
+        )  # a hasher for fields T.2c & S.2f
+
+        self.empty = True  # inputs_amount + outputs_amount == 0
+
+    def add_input(self, txi: TxInput, script_pubkey: bytes) -> None:
+        self.empty = False
+
+        write_prevout(self.prevouts, txi)
+        write_uint64(self.amounts, txi.amount)
+        write_bytes_prefixed(self.scriptpubkeys, script_pubkey)
+        write_uint32(self.sequence, txi.sequence)
+
+    def add_output(self, txo: TxOutput, script_pubkey: bytes) -> None:
+        self.empty = False
+
+        write_tx_output(self.outputs, txo, script_pubkey)
+
+    def digest(self) -> bytes:
+        """
+        Returns `T.2: transparent_digest` field for txid computation.
+
+        see: https://zips.z.cash/zip-0244#t-2-transparent-digest
+        """
+        h = HashWriter(blake2b(outlen=32, personal=b"ZTxIdTranspaHash"))
+
+        if not self.empty:
+            write_hash(h, self.prevouts.get_digest())  # T.2a
+            write_hash(h, self.sequence.get_digest())  # T.2b
+            write_hash(h, self.outputs.get_digest())  # T.2c
+
+        return h.get_digest()
+
+    def sig_digest(
+        self,
+        txi: TxInput | None,
+        script_pubkey: bytes | None,
+    ) -> bytes:
+        """
+        Returns `S.2: transparent_sig_digest` field for signature
+        digest computation.
+
+        see: https://zips.z.cash/zip-0244#s-2-transparent-sig-digest
+        """
+
+        if self.empty:
+            assert txi is None
+            assert script_pubkey is None
+            return self.digest()
+
+        h = HashWriter(blake2b(outlen=32, personal=b"ZTxIdTranspaHash"))
+
+        # only SIGHASH_ALL is supported in Trezor
+        write_uint8(h, SigHashType.SIGHASH_ALL)  # S.2a
+        write_hash(h, self.prevouts.get_digest())  # S.2b
+        write_hash(h, self.amounts.get_digest())  # S.2c
+        write_hash(h, self.scriptpubkeys.get_digest())  # S.2d
+        write_hash(h, self.sequence.get_digest())  # S.2e
+        write_hash(h, self.outputs.get_digest())  # S.2f
+        write_hash(h, _txin_sig_digest(txi, script_pubkey))  # S.2g
+
+        return h.get_digest()
+
+
+def _txin_sig_digest(
+    txi: TxInput | None,
+    script_pubkey: bytes | None,
+) -> bytes:
+    """
+    Returns `S.2g: txin_sig_digest` field for signature digest computation.
+
+    see: https://zips.z.cash/zip-0244#s-2g-txin-sig-digest
+    """
+
+    h = HashWriter(blake2b(outlen=32, personal=b"Zcash___TxInHash"))
+
+    if txi is not None:
+        assert script_pubkey is not None
+
+        write_prevout(h, txi)  # 2.Sg.i
+        write_uint64(h, txi.amount)  # 2.Sg.ii
+        write_bytes_prefixed(h, script_pubkey)  # 2.Sg.iii
+        write_uint32(h, txi.sequence)  # 2.Sg.iv
+
+    return h.get_digest()
+
+
+class SaplingHasher:
+    """
+    Empty Sapling bundle hasher.
+    """
+
+    def digest(self) -> bytes:
+        """
+        Returns `T.3: sapling_digest` field.
+
+        see: https://zips.z.cash/zip-0244#t-3-sapling-digest
+        """
+        return blake2b(outlen=32, personal=b"ZTxIdSaplingHash").digest()
+
+
+class OrchardHasher:
+    """
+    Empty Orchard bundle hasher.
+    """
+
+    def digest(self) -> bytes:
+        """
+        Returns `T.4: orchard_digest` field.
+
+        see: https://zips.z.cash/zip-0244#t-4-orchard-digest
+        """
+        return blake2b(outlen=32, personal=b"ZTxIdOrchardHash").digest()

--- a/core/src/apps/zcash/signer.py
+++ b/core/src/apps/zcash/signer.py
@@ -1,0 +1,112 @@
+from micropython import const
+from typing import TYPE_CHECKING
+
+from trezor.messages import SignTx
+from trezor.utils import ensure
+from trezor.wire import DataError, ProcessError
+
+from apps.bitcoin.common import ecdsa_sign
+from apps.bitcoin.sign_tx.bitcoinlike import Bitcoinlike
+from apps.common.writers import write_compact_size, write_uint32_le
+
+from .hasher import ZcashHasher
+
+if TYPE_CHECKING:
+    from typing import Sequence
+    from apps.common.coininfo import CoinInfo
+    from apps.bitcoin.sign_tx.tx_info import OriginalTxInfo, TxInfo
+    from apps.bitcoin.writers import Writer
+    from apps.bitcoin.sign_tx.approvers import Approver
+    from trezor.utils import HashWriter
+    from trezor.messages import (
+        PrevTx,
+        TxInput,
+    )
+    from apps.bitcoin.keychain import Keychain
+
+OVERWINTERED = const(0x8000_0000)
+
+
+class Zcash(Bitcoinlike):
+    def __init__(
+        self,
+        tx: SignTx,
+        keychain: Keychain,
+        coin: CoinInfo,
+        approver: Approver | None,
+    ) -> None:
+        ensure(coin.overwintered)
+        if tx.version != 5:
+            raise DataError("Expected transaction version 5.")
+
+        super().__init__(tx, keychain, coin, approver)
+
+    def create_sig_hasher(self, tx: SignTx | PrevTx) -> ZcashHasher:
+        return ZcashHasher(tx)
+
+    def create_hash_writer(self) -> HashWriter:
+        # Replacement transactions are not supported
+        # so this should never be called.
+        raise NotImplementedError
+
+    async def step3_verify_inputs(self) -> None:
+        # Replacement transactions are not supported.
+
+        # We don't check prevouts, because BIP-341 techniques
+        # were adapted in ZIP-244 sighash algorithm.
+        # see: https://github.com/zcash/zips/issues/574
+        self.taproot_only = True  # turn on taproot behavior
+        await super().step3_verify_inputs()
+        self.taproot_only = False  # turn off taproot behavior
+
+    async def step5_serialize_outputs(self) -> None:
+        await super().step5_serialize_outputs()
+
+    async def sign_nonsegwit_input(self, i_sign: int) -> None:
+        await self.sign_nonsegwit_bip143_input(i_sign)
+
+    def sign_bip143_input(self, i: int, txi: TxInput) -> tuple[bytes, bytes]:
+        signature_digest = self.tx_info.sig_hasher.hash_zip244(
+            txi, self.input_derive_script(txi)
+        )
+        node = self.keychain.derive(txi.address_n)
+        signature = ecdsa_sign(node, signature_digest)
+        return node.public_key(), signature
+
+    async def process_original_input(self, txi: TxInput, script_pubkey: bytes) -> None:
+        raise ProcessError("Replacement transactions are not supported.")
+        # Zcash transaction fees are very low
+        # so there is no need to bump the fee.
+
+    async def get_tx_digest(
+        self,
+        i: int,
+        txi: TxInput,
+        tx_info: TxInfo | OriginalTxInfo,
+        public_keys: Sequence[bytes | memoryview],
+        threshold: int,
+        script_pubkey: bytes,
+        tx_hash: bytes | None = None,
+    ) -> bytes:
+        return self.tx_info.sig_hasher.hash_zip244(txi, script_pubkey)
+
+    def write_tx_header(
+        self, w: Writer, tx: SignTx | PrevTx, witness_marker: bool
+    ) -> None:
+        # defined in ZIP-225 (see https://zips.z.cash/zip-0225)
+        assert tx.version_group_id is not None
+        assert tx.branch_id is not None  # checked in sanitize_*
+        assert tx.expiry is not None
+
+        write_uint32_le(w, tx.version | OVERWINTERED)  # nVersion | fOverwintered
+        write_uint32_le(w, tx.version_group_id)  # nVersionGroupId
+        write_uint32_le(w, tx.branch_id)  # nConsensusBranchId
+        write_uint32_le(w, tx.lock_time)  # lock_time
+        write_uint32_le(w, tx.expiry)  # expiryHeight
+
+    def write_tx_footer(self, w: Writer, tx: SignTx | PrevTx) -> None:
+        # serialize Sapling bundle
+        write_compact_size(w, 0)  # nSpendsSapling
+        write_compact_size(w, 0)  # nOutputsSapling
+        # serialize Orchard bundle
+        write_compact_size(w, 0)  # nActionsOrchard

--- a/core/tests/test_apps.bitcoin.zcash.zip243.py
+++ b/core/tests/test_apps.bitcoin.zcash.zip243.py
@@ -9,7 +9,7 @@ from apps.bitcoin.common import SigHashType
 from apps.bitcoin.writers import get_tx_hash
 
 if not utils.BITCOIN_ONLY:
-    from apps.bitcoin.sign_tx.zcash import ZcashSigHasher
+    from apps.bitcoin.sign_tx.zcash_v4 import Zip243SigHasher
 
 
 # test vectors inspired from https://github.com/zcash-hackworks/zcash-test-vectors/blob/master/zip_0243.py
@@ -191,7 +191,7 @@ class TestZcashZip243(unittest.TestCase):
                 branch_id=v["branch_id"],
             )
 
-            zip243 = ZcashSigHasher()
+            zip243 = Zip243SigHasher()
 
             for i in v["inputs"]:
                 txi = TxInput(

--- a/core/tests/test_apps.zcash.zip244.py
+++ b/core/tests/test_apps.zcash.zip244.py
@@ -1,0 +1,101 @@
+from common import *
+from trezor.messages import TxInput, SignTx, PrevOutput
+from trezor.enums import InputScriptType
+from apps.zcash.hasher import ZcashHasher
+from apps.bitcoin.common import SigHashType
+from apps.common.coininfo import by_name
+
+
+ZCASH_COININFO = by_name("Zcash")
+
+
+@unittest.skipUnless(not utils.BITCOIN_ONLY, "altcoin")
+class TestZcashSigHasher(unittest.TestCase):
+    def test_zcash_hasher(self):
+        # this test vector was generated using
+        # https://github.com/zcash-hackworks/zcash-test-vectors
+        tx = SignTx(
+            coin_name="Zcash",
+            version=5,
+            version_group_id=648488714,
+            branch_id=928093729,
+            lock_time=2591264634,
+            expiry=36466477,
+            inputs_count=3,
+            outputs_count=3,
+        )
+        inputs = [
+            TxInput(
+                prev_hash=unhexlify("4f61d91843ccb386dd1c482169eef62efaaf9d9364b1666e4d4c299e04a852e1"),
+                prev_index=1569726664,
+                multisig=None,
+                amount=1249971475008092,
+                script_type=InputScriptType.SPENDADDRESS,
+                sequence=0x8849f2a3,
+                script_pubkey=unhexlify("76a9149466817faf329208fc3c3ef42ce4513d22fc1f9b88ac"),
+            ),
+            TxInput(
+                prev_hash=unhexlify("368e9c7e1fe01f6c54db9379a94c2941ef180c25b869bf8dcdb1cf014253b3c7"),
+                prev_index=2648876502,
+                multisig=None,
+                amount=1353789347081201,
+                script_type=InputScriptType.SPENDADDRESS,
+                sequence=0x8a37691c,
+                script_pubkey=unhexlify("76a9142275979f97043edd9a6083ee27d136727ce5f42888ac"),
+            ),
+            TxInput(
+                prev_hash=unhexlify("f5621d6ad566c13dce81632a9168694bb6bcec2f7bfac2626f9425e1640fe4f1"),
+                prev_index=492165032,
+                multisig=None,
+                amount=1672802384749611,
+                script_type=InputScriptType.SPENDADDRESS,
+                sequence=0x6a993d20,
+                script_pubkey=unhexlify("76a914682c89bfc3940621bd4a4bfc349a79b46ce707e388ac"),
+            ),
+        ]
+        outputs = [
+            PrevOutput(
+                amount=865034086766210,
+                script_pubkey=unhexlify("76a9140d06a745f44ab023752cb5b406ed8985e18130ab88ac"),
+            ),
+            PrevOutput(
+                amount=2088955338922857,
+                script_pubkey=unhexlify("76a91463ccb8f676495c222f7fba1e31defa3d5a57efc288ac"),
+            ),
+            PrevOutput(
+                amount=1760123755646275,
+                script_pubkey=unhexlify("76a914fb1a38e01d94903d3c3e0ad3360c1d3710acd20b88ac"),
+            ),
+        ]
+        pubkeys = [
+            unhexlify("02ed9c769c787fda78a7da13764707d14217e74e26428b47a2a8fe6d5a0bc46196"),
+            unhexlify("0219ac5de9a45f76e7efede5259acd94bb047ab8e7cc60fe844cb32317072ebbf3"),
+            unhexlify("02829099a7cf1f617c956c0222e7b77ae331813d6a736eab3c5f6344d961843d39"),
+        ]
+        expected_txid = unhexlify("c91d34ecc44484b07ee573f385d80e57e4e57571bb86aa6ec6c44d654123e4e9")
+        expected_sighashes = [
+            unhexlify("4d82669c8c0e9b1f26d59bcb347212f2d044eeb839fce21e039d8bb082bbc343"),
+            unhexlify("2e2a27d78d117e28760d3c972f9614547ec57688c970f06c19c515cded6b030c"),
+            unhexlify("d0a92ffd4a4d262f5b84598bcfca741a42c17b8e9d26cf4fd87839df8f33e4ee"),
+        ]
+
+        hasher = ZcashHasher(tx)
+        for txi in inputs:
+            hasher.add_input(txi, txi.script_pubkey)
+        for txo in outputs:
+            hasher.add_output(txo, txo.script_pubkey)
+
+        # test ZcashSigHasher.txid_digest
+        computed_txid = hasher.txid_digest()
+        self.assertEqual(computed_txid, expected_txid)
+
+        # test ZcashSigHasher.signature_digest
+        for txi, expected_sighash, pk in zip(inputs, expected_sighashes, pubkeys):
+            computed_sighash = hasher.signature_digest(
+                txi, txi.script_pubkey
+            )
+            self.assertEqual(computed_sighash, expected_sighash)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/device_tests/zcash/test_sign_tx.py
+++ b/tests/device_tests/zcash/test_sign_tx.py
@@ -1,0 +1,258 @@
+# This file is part of the Trezor project.
+#
+# Copyright (C) 2012-2019 SatoshiLabs and contributors
+#
+# This library is free software: you can redistribute it and/or modify
+# it under the terms of the GNU Lesser General Public License version 3
+# as published by the Free Software Foundation.
+#
+# This library is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU Lesser General Public License for more details.
+#
+# You should have received a copy of the License along with this library.
+# If not, see <https://www.gnu.org/licenses/lgpl-3.0.html>.
+
+import pytest
+
+from trezorlib import btc, messages
+from trezorlib.exceptions import TrezorFailure
+from trezorlib.tools import parse_path
+
+from ..bitcoin.signtx import request_finished, request_input, request_output
+
+B = messages.ButtonRequestType
+
+TXHASH_aaf51e = bytes.fromhex(
+    "aaf51e4606c264e47e5c42c958fe4cf1539c5172684721e38e69f4ef634d75dc"
+)
+TXHASH_e38206 = bytes.fromhex(
+    "e3820602226974b1dd87b7113cc8aea8c63e5ae29293991e7bfa80c126930368"
+)
+
+pytestmark = [pytest.mark.altcoin, pytest.mark.zcash, pytest.mark.skip_t1]
+
+
+def test_version_group_id_missing(client):
+    inp1 = messages.TxInputType(
+        # tmQoJ3PTXgQLaRRZZYT6xk8XtjRbr2kCqwu
+        address_n=parse_path("m/44h/1h/0h/0/0"),
+        amount=300000000,
+        prev_hash=TXHASH_e38206,
+        prev_index=0,
+    )
+    out1 = messages.TxOutputType(
+        address="tmJ1xYxP8XNTtCoDgvdmQPSrxh5qZJgy65Z",
+        amount=300000000 - 1940,
+        script_type=messages.OutputScriptType.PAYTOADDRESS,
+    )
+
+    with pytest.raises(TrezorFailure, match="Version group ID must be set."):
+        btc.sign_tx(
+            client,
+            "Zcash Testnet",
+            [inp1],
+            [out1],
+            version=5,
+        )
+
+
+def test_one_one(client):
+    inp1 = messages.TxInputType(
+        # tmQoJ3PTXgQLaRRZZYT6xk8XtjRbr2kCqwu
+        address_n=parse_path("m/44h/1h/0h/0/0"),
+        amount=300000000,
+        prev_hash=TXHASH_e38206,
+        prev_index=0,
+    )
+
+    out1 = messages.TxOutputType(
+        address="tmJ1xYxP8XNTtCoDgvdmQPSrxh5qZJgy65Z",
+        amount=300000000 - 1940,
+        script_type=messages.OutputScriptType.PAYTOADDRESS,
+    )
+
+    with client:
+        client.set_expected_responses(
+            [
+                request_input(0),
+                request_output(0),
+                messages.ButtonRequest(code=B.ConfirmOutput),
+                messages.ButtonRequest(code=B.SignTx),
+                request_input(0),
+                request_output(0),
+                request_finished(),
+            ]
+        )
+
+        btc.sign_tx(
+            client,
+            "Zcash Testnet",
+            [inp1],
+            [out1],
+            version=5,
+            version_group_id=0x892F2085,
+            branch_id=0x76B809BB,
+        )
+
+        # TODO: send tx to testnet
+        # TODO: check serialized_tx
+
+
+def test_one_two(client):
+    inp1 = messages.TxInputType(
+        # tmQoJ3PTXgQLaRRZZYT6xk8XtjRbr2kCqwu
+        address_n=parse_path("m/44h/1h/0h/0/0"),
+        amount=300000000,
+        prev_hash=TXHASH_e38206,
+        prev_index=0,
+    )
+
+    out1 = messages.TxOutputType(
+        address="tmNvfeKR5PkcQazLEqddTskFr6Ev9tsovfQ",
+        amount=100000000,
+        script_type=messages.OutputScriptType.PAYTOADDRESS,
+    )
+
+    out2 = messages.TxOutputType(
+        address_n=parse_path("m/44h/1h/0h/0/0"),
+        amount=200000000 - 2000,
+        script_type=messages.OutputScriptType.PAYTOADDRESS,
+    )
+
+    with client:
+        client.set_expected_responses(
+            [
+                request_input(0),
+                request_output(0),
+                messages.ButtonRequest(code=B.ConfirmOutput),
+                request_output(1),
+                messages.ButtonRequest(code=B.SignTx),
+                request_input(0),
+                request_output(0),
+                request_output(1),
+                request_finished(),
+            ]
+        )
+
+        btc.sign_tx(
+            client,
+            "Zcash Testnet",
+            [inp1],
+            [out1, out2],
+            version=5,
+            version_group_id=0x892F2085,
+            branch_id=0x76B809BB,
+        )
+
+        # TODO: send tx to testnet
+        # TODO: check serialized_tx
+
+
+def test_external_presigned(client):
+    inp1 = messages.TxInputType(
+        # tmQoJ3PTXgQLaRRZZYT6xk8XtjRbr2kCqwu
+        address_n=parse_path("m/44h/1h/0h/0/0"),
+        amount=300000000,
+        prev_hash=TXHASH_e38206,
+        prev_index=0,
+    )
+
+    inp2 = messages.TxInputType(
+        # tmQoJ3PTXgQLaRRZZYT6xk8XtjRbr2kCqwu
+        # address_n=parse_path("m/44h/1h/0h/0/0"),
+        amount=300000000,
+        prev_hash=TXHASH_aaf51e,
+        prev_index=1,
+        script_type=messages.InputScriptType.EXTERNAL,
+        script_pubkey=bytes.fromhex(
+            "76a914a579388225827d9f2fe9014add644487808c695d88ac"
+        ),
+        script_sig=bytes.fromhex(
+            "48304502210090020ba5d1c945145f04e940c4b6026a24d2b9e58e7ae53834eca6f606e457e4022040d214cb7ad2bd2cff14bac8d7b8eab0bb603c239a962ecd8535ea49ca25071e0121030e669acac1f280d1ddf441cd2ba5e97417bf2689e4bbec86df4f831bf9f7ffd0"
+        ),
+    )
+
+    out1 = messages.TxOutputType(
+        address="tmJ1xYxP8XNTtCoDgvdmQPSrxh5qZJgy65Z",
+        amount=300000000 + 300000000 - 1940,
+        script_type=messages.OutputScriptType.PAYTOADDRESS,
+    )
+
+    with client:
+        client.set_expected_responses(
+            [
+                request_input(0),
+                request_input(1),
+                request_output(0),
+                messages.ButtonRequest(code=B.ConfirmOutput),
+                messages.ButtonRequest(code=B.SignTx),
+                request_input(1),
+                request_input(0),
+                request_input(1),
+                request_output(0),
+                request_finished(),
+            ]
+        )
+
+        btc.sign_tx(
+            client,
+            "Zcash Testnet",
+            [inp1, inp2],
+            [out1],
+            version=5,
+            version_group_id=0x892F2085,
+            branch_id=0x76B809BB,
+        )
+
+    # TODO: send tx to testnet
+    # TODO: check serialized
+
+
+def test_refuse_replacement_tx(client):
+    inp1 = messages.TxInputType(
+        address_n=parse_path("m/44h/1h/0h/0/4"),
+        amount=174998,
+        prev_hash=bytes.fromhex(
+            "beafc7cbd873d06dbee88a7002768ad5864228639db514c81cfb29f108bb1e7a"
+        ),
+        prev_index=0,
+        orig_hash=bytes.fromhex(
+            "50f6f1209ca92d7359564be803cb2c932cde7d370f7cee50fd1fad6790f6206d"
+        ),
+        orig_index=0,
+    )
+
+    out1 = messages.TxOutputType(
+        address_n=parse_path("m/44h/1h/0h/1/2"),
+        amount=174998 - 50000 - 1111,
+        script_type=messages.OutputScriptType.PAYTOADDRESS,
+        orig_hash=bytes.fromhex(
+            "50f6f1209ca92d7359564be803cb2c932cde7d370f7cee50fd1fad6790f6206d"
+        ),
+        orig_index=0,
+    )
+
+    out2 = messages.TxOutputType(
+        address="tmJ1xYxP8XNTtCoDgvdmQPSrxh5qZJgy65Z",
+        amount=50000,
+        script_type=messages.OutputScriptType.PAYTOADDRESS,
+        orig_hash=bytes.fromhex(
+            "50f6f1209ca92d7359564be803cb2c932cde7d370f7cee50fd1fad6790f6206d"
+        ),
+        orig_index=1,
+    )
+
+    with pytest.raises(
+        TrezorFailure, match="Replacement transactions are not supported."
+    ):
+        btc.sign_tx(
+            client,
+            "Zcash Testnet",
+            [inp1],
+            [out1, out2],
+            version=5,
+            version_group_id=0x892F2085,
+            branch_id=0x76B809BB,
+        )

--- a/tests/ui_tests/fixtures.json
+++ b/tests/ui_tests/fixtures.json
@@ -249,9 +249,9 @@
 "T1_bitcoin-test_signtx_amount_unit.py::test_signtx[AmountUnit.MILLIBITCOIN]": "8081910bd937c704fb65226dc85e8fc58a7331102aa036a5a97652638a0bde20",
 "T1_bitcoin-test_signtx_amount_unit.py::test_signtx[AmountUnit.SATOSHI]": "a565b50e63776aad284c42c71bf53e5844dff12f159cbd00679b97d2fb74fd20",
 "T1_bitcoin-test_signtx_amount_unit.py::test_signtx[None]": "367fd3c75f30f7224435e3309562d210d9ac6809ce2fae392f7fe75070fda094",
-"T1_bitcoin-test_signtx_invalid_path.py::test_attack_path_segwit": "473636ae4c43d8a349db09187b74eb4c1aa2b7fe02742d5fa928cdbc2a9e4cfd",
 "T1_bitcoin-test_signtx_external.py::test_p2tr_external_unverified": "9640b4d0bdcde8fec8a4c077e1d12da211d02989458ad34115731237b3dad4f9",
 "T1_bitcoin-test_signtx_external.py::test_p2wpkh_external_unverified": "c478ef5c111b38c0fee1f79df1e0d00ecd5c0e81913e59051047cb0db65ece69",
+"T1_bitcoin-test_signtx_invalid_path.py::test_attack_path_segwit": "473636ae4c43d8a349db09187b74eb4c1aa2b7fe02742d5fa928cdbc2a9e4cfd",
 "T1_bitcoin-test_signtx_invalid_path.py::test_invalid_path_fail": "75e45c0b6039244afae5cb138aeb4eec2c01e71b91a3ce0d73797ca3b04ca94a",
 "T1_bitcoin-test_signtx_invalid_path.py::test_invalid_path_pass_forkid": "9c35bfcc194afff453802147f5b4a2d033492e564835be649c3293a62857de59",
 "T1_bitcoin-test_signtx_invalid_path.py::test_invalid_path_prompt": "57b20ea95e26ee7f675cbb177b9c781389ef36a02f2815f7939ab83c2d0f8f36",
@@ -1600,5 +1600,10 @@
 "TT_tezos-test_sign_tx.py::test_tezos_smart_contract_transfer": "f4c0775f55db8718ef56e684f376d5326afa4ee97b0ea85c42820a356ebff0d4",
 "TT_tezos-test_sign_tx.py::test_tezos_smart_contract_transfer_to_contract": "cadca03c9ce7db592663bc0224364c0d4bf99fcae60e0982b4a844ce629e500c",
 "TT_webauthn-test_msg_webauthn.py::test_add_remove": "3219e5ad2719319e74b5c75b1096ca7e3d30467215c15f57e57e475afdaa188f",
-"TT_webauthn-test_u2f_counter.py::test_u2f_counter": "19f77e2d284431da5fadac938f5822c1a6b17c07ee6c801085efd84974f3163f"
+"TT_webauthn-test_u2f_counter.py::test_u2f_counter": "19f77e2d284431da5fadac938f5822c1a6b17c07ee6c801085efd84974f3163f",
+"TT_zcash-test_sign_tx.py::test_external_presigned": "08a22a49793201f8387a085a554f006387d1df1b37ed8a34bef7aa79b363b44b",
+"TT_zcash-test_sign_tx.py::test_one_one": "b8aff4ae3c9b417acadf1ede52d7d45870dd4ef1f9251bf8e8f2ebf5280b9f3b",
+"TT_zcash-test_sign_tx.py::test_one_two": "d59aa3d5d03a276a31d3023c8214af940dbb8dec3cd686576608881965789fcb",
+"TT_zcash-test_sign_tx.py::test_refuse_replacement_tx": "1c100ce4b7c1e47e72428f390de0846c1ff933e9f07894872644a369a9422738",
+"TT_zcash-test_sign_tx.py::test_version_group_id_missing": "c09de07fbbf1e047442180e2facb5482d06a1a428891b875b7dd93c9e4704ae1"
 }


### PR DESCRIPTION
Implements #2031 for Trezor T. (not for Trezor 1, so the this PR does not close the issue)

This PR implements

- new Zcash transaction format ([ZIP-225](https://zips.z.cash/zip-0225)) and
- new Zcash sighash algorithm ([ZIP-244](https://zips.z.cash/zip-0244))

to support Zcash Network Upgrade 5.

I moved Zcash code into the separated app to prepare it for future extensions (like unified addresses and shielded transactions).

I kept old Zcash code to preserve Zcash-like altcoins like Komodo and Koto.