### PR TITLE
Connect tests fix

### DIFF
--- a/ci/test.yml
+++ b/ci/test.yml
@@ -632,7 +632,7 @@ core unix memory profiler:
 # Connect
 
 connect test core:
-  image: registry.gitlab.com/satoshilabs/trezor/trezor-user-env/trezor-user-env:latest
+  image: ghcr.io/trezor/trezor-user-env
   stage: test
   needs:
     - core unix frozen debug build
@@ -643,7 +643,7 @@ connect test core:
     - chmod u+x /trezor-user-env/src/binaries/firmware/bin/trezor-emu-core-v2.99.99
     - nix-shell -p autoPatchelfHook SDL2 SDL2_image --run "autoPatchelf /trezor-user-env/src/binaries/firmware/bin/trezor-emu-core-v2.99.99"
   script:
-    - /trezor-user-env/run.sh &
+    - /trezor-user-env/run-nix.sh &
     - nix-shell --run "tests/connect_tests/connect_tests.sh 2.99.99"
   after_script:
     - cp /trezor-user-env/logs/debugging.log trezor-user-env-debugging.log


### PR DESCRIPTION
Currently the `Connect` job in `CI` is broken because of `tenv` changes (the image is being uploaded on `GitHub`'s `ghcr.io` instead of `Gitlab`). This makes the relevant changes to make it work again.

Running it now also uncovered that there is **a lot** of errors caused by `Input does not match scriptPubKey` and `Failed to decode message: Missing required field collateral_inputs_count` - https://gitlab.com/satoshilabs/trezor/trezor-firmware/-/jobs/2233814735