### PR TITLE
fix(legacy): refactor oledInvertPixel to not use static bool variable, but ifdef constant

### DIFF
--- a/legacy/Makefile.include
+++ b/legacy/Makefile.include
@@ -43,6 +43,9 @@ CPUFLAGS ?= -mcpu=cortex-m3 -mthumb
 FPUFLAGS ?= -msoft-float
 endif
 
+DEBUG_LINK ?= 0
+DEBUG_LOG  ?= 0
+
 CFLAGS   += $(OPTFLAGS) \
             $(DBGFLAGS) \
             $(SANFLAGS) \
@@ -75,6 +78,8 @@ CFLAGS   += $(OPTFLAGS) \
             $(FPUFLAGS) \
             $(CONFFLAG) \
             -DSTM32F2 \
+            -DDEBUG_LINK=$(DEBUG_LINK) \
+            -DDEBUG_LOG=$(DEBUG_LOG) \
             -I$(TOOLCHAIN_DIR)/include \
             -I$(TOP_DIR) \
             -I$(TOP_DIR)gen \

--- a/legacy/firmware/Makefile
+++ b/legacy/firmware/Makefile
@@ -155,13 +155,9 @@ OPTFLAGS ?= -Os
 
 include ../Makefile.include
 
-DEBUG_LINK ?= 0
-DEBUG_LOG  ?= 0
 
 CFLAGS += -Wno-sequence-point
 CFLAGS += -I../vendor/nanopb -Iprotob -DPB_FIELD_16BIT=1 -DPB_ENCODE_ARRAYS_UNPACKED=1 -DPB_VALIDATE_UTF8=1
-CFLAGS += -DDEBUG_LINK=$(DEBUG_LINK)
-CFLAGS += -DDEBUG_LOG=$(DEBUG_LOG)
 CFLAGS += -DSCM_REVISION='"$(shell git rev-parse HEAD | sed 's:\(..\):\\x\1:g')"'
 CFLAGS += -DUSE_MONERO=0
 ifneq ($(BITCOIN_ONLY),1)

--- a/legacy/firmware/trezor.c
+++ b/legacy/firmware/trezor.c
@@ -165,7 +165,6 @@ int main(void) {
 #endif
 
 #if DEBUG_LINK
-  oledSetDebugLink(1);
 #if !EMULATOR
   config_wipe();
 #endif

--- a/legacy/oled.c
+++ b/legacy/oled.c
@@ -65,7 +65,6 @@
  */
 
 static uint8_t _oledbuffer[OLED_BUFSIZE];
-static bool is_debug_link = 0;
 
 /*
  * macros to convert coordinate to bit position
@@ -181,23 +180,23 @@ void oledInit() {
 void oledClear() { memzero(_oledbuffer, sizeof(_oledbuffer)); }
 
 void oledInvertDebugLink() {
-  if (is_debug_link) {
-    oledInvertPixel(OLED_WIDTH - 5, 0);
-    oledInvertPixel(OLED_WIDTH - 4, 0);
-    oledInvertPixel(OLED_WIDTH - 3, 0);
-    oledInvertPixel(OLED_WIDTH - 2, 0);
-    oledInvertPixel(OLED_WIDTH - 1, 0);
-    oledInvertPixel(OLED_WIDTH - 4, 1);
-    oledInvertPixel(OLED_WIDTH - 3, 1);
-    oledInvertPixel(OLED_WIDTH - 2, 1);
-    oledInvertPixel(OLED_WIDTH - 1, 1);
-    oledInvertPixel(OLED_WIDTH - 3, 2);
-    oledInvertPixel(OLED_WIDTH - 2, 2);
-    oledInvertPixel(OLED_WIDTH - 1, 2);
-    oledInvertPixel(OLED_WIDTH - 2, 3);
-    oledInvertPixel(OLED_WIDTH - 1, 3);
-    oledInvertPixel(OLED_WIDTH - 1, 4);
-  }
+#if DEBUG_LINK
+  oledInvertPixel(OLED_WIDTH - 5, 0);
+  oledInvertPixel(OLED_WIDTH - 4, 0);
+  oledInvertPixel(OLED_WIDTH - 3, 0);
+  oledInvertPixel(OLED_WIDTH - 2, 0);
+  oledInvertPixel(OLED_WIDTH - 1, 0);
+  oledInvertPixel(OLED_WIDTH - 4, 1);
+  oledInvertPixel(OLED_WIDTH - 3, 1);
+  oledInvertPixel(OLED_WIDTH - 2, 1);
+  oledInvertPixel(OLED_WIDTH - 1, 1);
+  oledInvertPixel(OLED_WIDTH - 3, 2);
+  oledInvertPixel(OLED_WIDTH - 2, 2);
+  oledInvertPixel(OLED_WIDTH - 1, 2);
+  oledInvertPixel(OLED_WIDTH - 2, 3);
+  oledInvertPixel(OLED_WIDTH - 1, 3);
+  oledInvertPixel(OLED_WIDTH - 1, 4);
+#endif
 }
 
 /*
@@ -231,11 +230,6 @@ void oledRefresh() {
 #endif
 
 const uint8_t *oledGetBuffer() { return _oledbuffer; }
-
-void oledSetDebugLink(bool set) {
-  is_debug_link = set;
-  oledRefresh();
-}
 
 void oledSetBuffer(uint8_t *buf) {
   memcpy(_oledbuffer, buf, sizeof(_oledbuffer));

--- a/legacy/oled.h
+++ b/legacy/oled.h
@@ -34,7 +34,6 @@ void oledInit(void);
 void oledClear(void);
 void oledRefresh(void);
 
-void oledSetDebugLink(bool set);
 void oledInvertDebugLink(void);
 
 void oledSetBuffer(uint8_t *buf);


### PR DESCRIPTION
Fixes https://github.com/trezor/trezor-firmware/issues/2184

Before the change:
```
$ ls -l legacy/bootloader/bootloader-unaligned.bin 
-rwxr-xr-x 1 stick staff 31400 Mar 22 20:36 legacy/bootloader/bootloader-unaligned.bin
```

After the change:
```
$ ls -l legacy/bootloader/bootloader-unaligned.bin 
-rwxr-xr-x 1 stick staff 31276 Mar 22 20:32 legacy/bootloader/bootloader-unaligned.bin
```

Difference: -124 bytes