### PR TITLE
fix(core+legacy): fix SDL2 include path

### DIFF
--- a/core/embed/extmod/modtrezorui/display-unix.h
+++ b/core/embed/extmod/modtrezorui/display-unix.h
@@ -17,8 +17,8 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-#include <SDL2/SDL.h>
-#include <SDL2/SDL_image.h>
+#include <SDL.h>
+#include <SDL_image.h>
 #include <stdio.h>
 #include <stdlib.h>
 #include "profile.h"

--- a/core/embed/unix/touch.c
+++ b/core/embed/unix/touch.c
@@ -17,7 +17,7 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-#include <SDL2/SDL.h>
+#include <SDL.h>
 #include <stdbool.h>
 #include <stdint.h>
 

--- a/legacy/emulator/buttons.c
+++ b/legacy/emulator/buttons.c
@@ -19,7 +19,7 @@
 
 #include "buttons.h"
 
-#include <SDL2/SDL.h>
+#include <SDL.h>
 
 uint16_t buttonRead(void) {
   uint16_t state = 0;

--- a/legacy/emulator/oled.c
+++ b/legacy/emulator/oled.c
@@ -19,7 +19,7 @@
 
 #include "oled.h"
 
-#include <SDL2/SDL.h>
+#include <SDL.h>
 
 static SDL_Renderer *renderer = NULL;
 static SDL_Texture *texture = NULL;


### PR DESCRIPTION
The default include path for SDL2 is `/usr/include/SDL2` not `/usr/include`
```
$ pkg-config --cflags sdl2
-D_THREAD_SAFE -I/usr/include/SDL2
```