### PR TITLE
ci: use autoPatchelfHook from pinned nixpkgs for emulators

### DIFF
--- a/ci/shell.nix
+++ b/ci/shell.nix
@@ -72,6 +72,7 @@ stdenvNoCC.mkDerivation ({
     SDL2
     SDL2_image
     autoflake
+    autoPatchelfHook
     bash
     check
     curl  # for connect tests

--- a/tests/download_emulators.sh
+++ b/tests/download_emulators.sh
@@ -18,5 +18,6 @@ wget -e robots=off \
 
 chmod u+x emulators/trezor-emu-*
 
+cd ..
 # are we in Nix(OS)?
-command -v nix-shell >/dev/null && nix-shell -p autoPatchelfHook SDL2 SDL2_image --run "autoPatchelf emulators/trezor-emu-*"
+command -v nix-shell >/dev/null && nix-shell --run "autoPatchelf tests/emulators/trezor-emu-*"


### PR DESCRIPTION
NixOS recently switched to different autoPatchelfHook implementation which doesn't work for us in NixOS/nixpkgs#149731. This PR forces the use of the older implementation as a temporary measure.