### PR TITLE
test: mark test_show_multisig_xpubs as flaky

### DIFF
--- a/tests/device_tests/bitcoin/test_getaddress_show.py
+++ b/tests/device_tests/bitcoin/test_getaddress_show.py
@@ -171,6 +171,8 @@ VECTORS_MULTISIG = (  # script_type, bip48_type, address, xpubs, ignore_xpub_mag
 )
 
 
+# NOTE: contains wait_layout race that manifests on hw sometimes
+@pytest.mark.flaky(max_runs=5)
 @pytest.mark.skip_t1
 @pytest.mark.multisig
 @pytest.mark.parametrize(


### PR DESCRIPTION
Reading the screen lines seems to be time-sensitive, e.g. https://gitlab.com/satoshilabs/trezor/trezor-firmware/-/jobs/2125107052

Should be ultimately fixed by switching to the new UI.