### PR TITLE
Use &str in place of &[u8] where appropriate

### DIFF
--- a/core/embed/rust/build.rs
+++ b/core/embed/rust/build.rs
@@ -72,6 +72,7 @@ fn generate_micropython_bindings() {
         .allowlist_var("MP_BUFFER_READ")
         .allowlist_var("MP_BUFFER_WRITE")
         .allowlist_var("MP_BUFFER_RW")
+        .allowlist_var("mp_type_str")
         // dict
         .allowlist_type("mp_obj_dict_t")
         .allowlist_function("mp_obj_new_dict")

--- a/core/embed/rust/src/micropython/buffer.rs
+++ b/core/embed/rust/src/micropython/buffer.rs
@@ -165,8 +165,11 @@ impl Deref for StrBuffer {
 
 impl AsRef<str> for StrBuffer {
     fn as_ref(&self) -> &str {
-        // SAFETY: MicroPython ensures that values of type `str` are UTF-8
-        unsafe { str::from_utf8_unchecked(self.0.as_ref()) }
+        // MicroPython _should_ ensure that values of type `str` are UTF-8.
+        // Rust seems to be stricter in what it considers UTF-8 though.
+        // In case there's a mismatch, this code will cleanly panic
+        // before attempting to use the data.
+        str::from_utf8(self.0.as_ref()).unwrap()
     }
 }
 

--- a/core/embed/rust/src/micropython/buffer.rs
+++ b/core/embed/rust/src/micropython/buffer.rs
@@ -24,7 +24,7 @@ pub struct Buffer {
 
 impl Buffer {
     pub fn empty() -> Self {
-        Self::from("")
+        Self::from(b"")
     }
 }
 
@@ -70,8 +70,8 @@ impl From<&'static [u8]> for Buffer {
     }
 }
 
-impl From<&'static str> for Buffer {
-    fn from(val: &'static str) -> Self {
+impl<const N: usize> From<&'static [u8; N]> for Buffer {
+    fn from(val: &'static [u8; N]) -> Self {
         Buffer {
             ptr: val.as_ptr(),
             len: val.len(),

--- a/core/embed/rust/src/micropython/buffer.rs
+++ b/core/embed/rust/src/micropython/buffer.rs
@@ -1,7 +1,7 @@
 use core::{
     convert::TryFrom,
     ops::{Deref, DerefMut},
-    ptr, slice,
+    ptr, slice, str,
 };
 
 use crate::{error::Error, micropython::obj::Obj};
@@ -132,6 +132,50 @@ impl AsMut<[u8]> for BufferMut {
     }
 }
 
+/// Represents an immutable UTF-8 string stored on the MicroPython heap and
+/// owned by a `str` object.
+///
+/// # Safety
+///
+/// In most cases, it is unsound to store `StrBuffer` values in a GC-unreachable
+/// location, such as static data. It is also unsound to let the contents be
+/// modified while a reference to them is being held.
+#[derive(Default)]
+pub struct StrBuffer(Buffer);
+
+impl TryFrom<Obj> for StrBuffer {
+    type Error = Error;
+
+    fn try_from(obj: Obj) -> Result<Self, Self::Error> {
+        if obj.is_qstr() || unsafe { ffi::mp_type_str.is_type_of(obj) } {
+            Ok(Self(Buffer::try_from(obj)?))
+        } else {
+            Err(Error::TypeError)
+        }
+    }
+}
+
+impl Deref for StrBuffer {
+    type Target = str;
+
+    fn deref(&self) -> &Self::Target {
+        self.as_ref()
+    }
+}
+
+impl AsRef<str> for StrBuffer {
+    fn as_ref(&self) -> &str {
+        // SAFETY: MicroPython ensures that values of type `str` are UTF-8
+        unsafe { str::from_utf8_unchecked(self.0.as_ref()) }
+    }
+}
+
+impl From<&'static str> for StrBuffer {
+    fn from(val: &'static str) -> Self {
+        Self(Buffer::from(val.as_bytes()))
+    }
+}
+
 fn get_buffer_info(obj: Obj, flags: u32) -> Result<ffi::mp_buffer_info_t, Error> {
     let mut bufinfo = ffi::mp_buffer_info_t {
         buf: ptr::null_mut(),
@@ -179,6 +223,13 @@ fn buffer_as_mut<'a>(ptr: *mut u8, len: usize) -> &'a mut [u8] {
 
 #[cfg(feature = "ui_debug")]
 impl crate::trace::Trace for Buffer {
+    fn trace(&self, t: &mut dyn crate::trace::Tracer) {
+        self.as_ref().trace(t)
+    }
+}
+
+#[cfg(feature = "ui_debug")]
+impl crate::trace::Trace for StrBuffer {
     fn trace(&self, t: &mut dyn crate::trace::Tracer) {
         self.as_ref().trace(t)
     }

--- a/core/embed/rust/src/trezorhal/display.rs
+++ b/core/embed/rust/src/trezorhal/display.rs
@@ -67,7 +67,7 @@ pub fn backlight(val: i32) -> i32 {
     unsafe { display_backlight(val) }
 }
 
-pub fn text(baseline_x: i32, baseline_y: i32, text: &[u8], font: i32, fgcolor: u16, bgcolor: u16) {
+pub fn text(baseline_x: i32, baseline_y: i32, text: &str, font: i32, fgcolor: u16, bgcolor: u16) {
     unsafe {
         display_text(
             baseline_x,
@@ -81,8 +81,14 @@ pub fn text(baseline_x: i32, baseline_y: i32, text: &[u8], font: i32, fgcolor: u
     }
 }
 
-pub fn text_width(text: &[u8], font: i32) -> i32 {
+pub fn text_width(text: &str, font: i32) -> i32 {
     unsafe { display_text_width(text.as_ptr() as _, text.len() as _, font) }
+}
+
+pub fn char_width(ch: char, font: i32) -> i32 {
+    let mut buf = [0u8; 4];
+    let encoding = ch.encode_utf8(&mut buf);
+    text_width(encoding, font)
 }
 
 pub fn text_height(font: i32) -> i32 {

--- a/core/embed/rust/src/ui/component/label.rs
+++ b/core/embed/rust/src/ui/component/label.rs
@@ -21,7 +21,7 @@ pub struct Label<T> {
 
 impl<T> Label<T>
 where
-    T: Deref<Target = [u8]>,
+    T: Deref<Target = str>,
 {
     pub fn new(text: T, align: Alignment, style: LabelStyle) -> Self {
         Self {
@@ -58,7 +58,7 @@ where
 
 impl<T> Component for Label<T>
 where
-    T: Deref<Target = [u8]>,
+    T: Deref<Target = str>,
 {
     type Msg = Never;
 

--- a/core/embed/rust/src/ui/component/paginated.rs
+++ b/core/embed/rust/src/ui/component/paginated.rs
@@ -20,8 +20,8 @@ pub trait Paginate {
 
 impl<F, T> Paginate for FormattedText<F, T>
 where
-    F: AsRef<[u8]>,
-    T: AsRef<[u8]>,
+    F: AsRef<str>,
+    T: AsRef<str>,
 {
     fn page_count(&mut self) -> usize {
         let mut page_count = 1; // There's always at least one page.

--- a/core/embed/rust/src/ui/component/text/iter.rs
+++ b/core/embed/rust/src/ui/component/text/iter.rs
@@ -169,7 +169,7 @@ trait GlyphMetrics {
 
 impl GlyphMetrics for Font {
     fn char_width(&self, ch: char) -> i32 {
-        self.text_width(&[ch as u8])
+        Font::char_width(*self, ch)
     }
 
     fn line_height(&self) -> i32 {

--- a/core/embed/rust/src/ui/component/text/paragraphs.rs
+++ b/core/embed/rust/src/ui/component/text/paragraphs.rs
@@ -29,7 +29,7 @@ pub struct Paragraphs<T> {
 
 impl<T> Paragraphs<T>
 where
-    T: AsRef<[u8]>,
+    T: AsRef<str>,
 {
     pub fn new() -> Self {
         Self {
@@ -114,7 +114,7 @@ where
 
 impl<T> Component for Paragraphs<T>
 where
-    T: AsRef<[u8]>,
+    T: AsRef<str>,
 {
     type Msg = Never;
 
@@ -146,7 +146,7 @@ where
 
 impl<T> Paginate for Paragraphs<T>
 where
-    T: AsRef<[u8]>,
+    T: AsRef<str>,
 {
     fn page_count(&mut self) -> usize {
         // There's always at least one page.
@@ -175,7 +175,7 @@ pub mod trace {
 
     impl<T> crate::trace::Trace for Paragraphs<T>
     where
-        T: AsRef<[u8]>,
+        T: AsRef<str>,
     {
         fn trace(&self, t: &mut dyn crate::trace::Tracer) {
             t.open("Paragraphs");
@@ -201,20 +201,20 @@ pub struct Paragraph<T> {
 
 impl<T> Paragraph<T>
 where
-    T: AsRef<[u8]>,
+    T: AsRef<str>,
 {
     pub fn new(content: T, layout: TextLayout) -> Self {
         Self { content, layout }
     }
 
-    pub fn content(&self, char_offset: usize) -> &[u8] {
+    pub fn content(&self, char_offset: usize) -> &str {
         &self.content.as_ref()[char_offset..]
     }
 }
 
 impl<T> Dimensions for Paragraph<T>
 where
-    T: AsRef<[u8]>,
+    T: AsRef<str>,
 {
     fn fit(&mut self, area: Rect) {
         self.layout.bounds = area;
@@ -246,7 +246,7 @@ struct PageBreakIterator<'a, T> {
 /// `PageOffset { 0, 0 }` even if the paragraph vector is empty.
 impl<'a, T> Iterator for PageBreakIterator<'a, T>
 where
-    T: AsRef<[u8]>,
+    T: AsRef<str>,
 {
     /// `PageOffset` denotes the first paragraph that is rendered and a
     /// character offset in that paragraph.

--- a/core/embed/rust/src/ui/display.rs
+++ b/core/embed/rust/src/ui/display.rs
@@ -152,7 +152,7 @@ pub fn loader_indeterminate(
     );
 }
 
-pub fn text(baseline: Point, text: &[u8], font: Font, fg_color: Color, bg_color: Color) {
+pub fn text(baseline: Point, text: &str, font: Font, fg_color: Color, bg_color: Color) {
     display::text(
         baseline.x,
         baseline.y,
@@ -163,7 +163,7 @@ pub fn text(baseline: Point, text: &[u8], font: Font, fg_color: Color, bg_color:
     );
 }
 
-pub fn text_center(baseline: Point, text: &[u8], font: Font, fg_color: Color, bg_color: Color) {
+pub fn text_center(baseline: Point, text: &str, font: Font, fg_color: Color, bg_color: Color) {
     let w = font.text_width(text);
     display::text(
         baseline.x - w / 2,
@@ -183,8 +183,12 @@ impl Font {
         Self(id)
     }
 
-    pub fn text_width(self, text: &[u8]) -> i32 {
+    pub fn text_width(self, text: &str) -> i32 {
         display::text_width(text, self.0)
+    }
+
+    pub fn char_width(self, ch: char) -> i32 {
+        display::char_width(ch, self.0)
     }
 
     pub fn text_height(self) -> i32 {

--- a/core/embed/rust/src/ui/model_t1/component/button.rs
+++ b/core/embed/rust/src/ui/model_t1/component/button.rs
@@ -37,7 +37,7 @@ pub struct Button<T> {
     state: State,
 }
 
-impl<T: AsRef<[u8]>> Button<T> {
+impl<T: AsRef<str>> Button<T> {
     pub fn new(pos: ButtonPos, content: ButtonContent<T>, styles: ButtonStyleSheet) -> Self {
         Self {
             pos,
@@ -100,7 +100,7 @@ impl<T: AsRef<[u8]>> Button<T> {
 
 impl<T> Component for Button<T>
 where
-    T: AsRef<[u8]>,
+    T: AsRef<str>,
 {
     type Msg = ButtonMsg;
 
@@ -157,7 +157,7 @@ where
 #[cfg(feature = "ui_debug")]
 impl<T> crate::trace::Trace for Button<T>
 where
-    T: AsRef<[u8]> + crate::trace::Trace,
+    T: AsRef<str> + crate::trace::Trace,
 {
     fn trace(&self, t: &mut dyn crate::trace::Tracer) {
         t.open("Button");

--- a/core/embed/rust/src/ui/model_t1/component/dialog.rs
+++ b/core/embed/rust/src/ui/model_t1/component/dialog.rs
@@ -22,7 +22,7 @@ pub struct Dialog<T, U> {
 impl<T, U> Dialog<T, U>
 where
     T: Component,
-    U: AsRef<[u8]>,
+    U: AsRef<str>,
 {
     pub fn new(content: T, left: Option<Button<U>>, right: Option<Button<U>>) -> Self {
         Self {
@@ -40,7 +40,7 @@ where
 impl<T, U> Component for Dialog<T, U>
 where
     T: Component,
-    U: AsRef<[u8]>,
+    U: AsRef<str>,
 {
     type Msg = DialogMsg<T::Msg>;
 
@@ -80,7 +80,7 @@ where
 impl<T, U> crate::trace::Trace for Dialog<T, U>
 where
     T: crate::trace::Trace,
-    U: crate::trace::Trace + AsRef<[u8]>,
+    U: crate::trace::Trace + AsRef<str>,
 {
     fn trace(&self, t: &mut dyn crate::trace::Tracer) {
         t.open("Dialog");

--- a/core/embed/rust/src/ui/model_t1/component/frame.rs
+++ b/core/embed/rust/src/ui/model_t1/component/frame.rs
@@ -14,7 +14,7 @@ pub struct Frame<T, U> {
 impl<T, U> Frame<T, U>
 where
     T: Component,
-    U: AsRef<[u8]>,
+    U: AsRef<str>,
 {
     pub fn new(title: U, content: T) -> Self {
         Self {
@@ -32,7 +32,7 @@ where
 impl<T, U> Component for Frame<T, U>
 where
     T: Component,
-    U: AsRef<[u8]>,
+    U: AsRef<str>,
 {
     type Msg = T::Msg;
 
@@ -68,7 +68,7 @@ where
 impl<T, U> crate::trace::Trace for Frame<T, U>
 where
     T: crate::trace::Trace,
-    U: crate::trace::Trace + AsRef<[u8]>,
+    U: crate::trace::Trace + AsRef<str>,
 {
     fn trace(&self, t: &mut dyn crate::trace::Tracer) {
         t.open("Frame");

--- a/core/embed/rust/src/ui/model_t1/layout.rs
+++ b/core/embed/rust/src/ui/model_t1/layout.rs
@@ -2,7 +2,7 @@ use core::convert::TryInto;
 
 use crate::{
     error::Error,
-    micropython::{buffer::Buffer, map::Map, module::Module, obj::Obj, qstr::Qstr},
+    micropython::{buffer::StrBuffer, map::Map, module::Module, obj::Obj, qstr::Qstr},
     ui::{
         component::{
             base::Component,
@@ -39,7 +39,7 @@ where
 impl<T, U> ComponentMsgObj for Frame<T, U>
 where
     T: ComponentMsgObj,
-    U: AsRef<[u8]>,
+    U: AsRef<str>,
 {
     fn msg_try_into_obj(&self, msg: Self::Msg) -> Result<Obj, Error> {
         self.inner().msg_try_into_obj(msg)
@@ -48,12 +48,12 @@ where
 
 extern "C" fn new_confirm_action(n_args: usize, args: *const Obj, kwargs: *mut Map) -> Obj {
     let block = |_args: &[Obj], kwargs: &Map| {
-        let title: Buffer = kwargs.get(Qstr::MP_QSTR_title)?.try_into()?;
-        let action: Option<Buffer> = kwargs.get(Qstr::MP_QSTR_action)?.try_into_option()?;
-        let description: Option<Buffer> =
+        let title: StrBuffer = kwargs.get(Qstr::MP_QSTR_title)?.try_into()?;
+        let action: Option<StrBuffer> = kwargs.get(Qstr::MP_QSTR_action)?.try_into_option()?;
+        let description: Option<StrBuffer> =
             kwargs.get(Qstr::MP_QSTR_description)?.try_into_option()?;
-        let verb: Option<Buffer> = kwargs.get(Qstr::MP_QSTR_verb)?.try_into_option()?;
-        let verb_cancel: Option<Buffer> =
+        let verb: Option<StrBuffer> = kwargs.get(Qstr::MP_QSTR_verb)?.try_into_option()?;
+        let verb_cancel: Option<StrBuffer> =
             kwargs.get(Qstr::MP_QSTR_verb_cancel)?.try_into_option()?;
         let reverse: bool = kwargs.get(Qstr::MP_QSTR_reverse)?.try_into()?;
 
@@ -74,8 +74,8 @@ extern "C" fn new_confirm_action(n_args: usize, args: *const Obj, kwargs: *mut M
             title,
             ButtonPage::new(
                 FormattedText::new::<theme::T1DefaultText>(format)
-                    .with(b"action", action.unwrap_or_default())
-                    .with(b"description", description.unwrap_or_default()),
+                    .with("action", action.unwrap_or_default())
+                    .with("description", description.unwrap_or_default()),
                 theme::BG,
             ),
         ))?;
@@ -86,9 +86,9 @@ extern "C" fn new_confirm_action(n_args: usize, args: *const Obj, kwargs: *mut M
 
 extern "C" fn new_confirm_text(n_args: usize, args: *const Obj, kwargs: *mut Map) -> Obj {
     let block = |_args: &[Obj], kwargs: &Map| {
-        let title: Buffer = kwargs.get(Qstr::MP_QSTR_title)?.try_into()?;
-        let data: Buffer = kwargs.get(Qstr::MP_QSTR_data)?.try_into()?;
-        let description: Option<Buffer> =
+        let title: StrBuffer = kwargs.get(Qstr::MP_QSTR_title)?.try_into()?;
+        let data: StrBuffer = kwargs.get(Qstr::MP_QSTR_data)?.try_into()?;
+        let description: Option<StrBuffer> =
             kwargs.get(Qstr::MP_QSTR_description)?.try_into_option()?;
 
         let obj = LayoutObj::new(Frame::new(
@@ -165,7 +165,7 @@ mod tests {
     impl<T, U> ComponentMsgObj for Dialog<T, U>
     where
         T: ComponentMsgObj,
-        U: AsRef<[u8]>,
+        U: AsRef<str>,
     {
         fn msg_try_into_obj(&self, msg: Self::Msg) -> Result<Obj, Error> {
             match msg {
@@ -182,7 +182,7 @@ mod tests {
             FormattedText::new::<theme::T1DefaultText>(
                 "Testing text layout, with some text, and some more text. And {param}",
             )
-            .with(b"param", b"parameters!"),
+            .with("param", "parameters!"),
             Some(Button::with_text(
                 ButtonPos::Left,
                 "Left",
@@ -212,7 +212,7 @@ arameters! > left:<Button text:Left > right:<Button text:Right > >"#
                 FormattedText::new::<theme::T1DefaultText>(
                     "Testing text layout, with some text, and some more text. And {param}",
                 )
-                .with(b"param", b"parameters!"),
+                .with("param", "parameters!"),
                 Some(Button::with_text(
                     ButtonPos::Left,
                     "Left",

--- a/core/embed/rust/src/ui/model_tt/component/button.rs
+++ b/core/embed/rust/src/ui/model_tt/component/button.rs
@@ -156,7 +156,7 @@ impl<T> Button<T> {
 
     pub fn paint_content(&self, style: &ButtonStyle)
     where
-        T: AsRef<[u8]>,
+        T: AsRef<str>,
     {
         match &self.content {
             ButtonContent::Empty => {}
@@ -189,7 +189,7 @@ impl<T> Button<T> {
 
 impl<T> Component for Button<T>
 where
-    T: AsRef<[u8]>,
+    T: AsRef<str>,
 {
     type Msg = ButtonMsg;
 
@@ -266,7 +266,7 @@ where
 #[cfg(feature = "ui_debug")]
 impl<T> crate::trace::Trace for Button<T>
 where
-    T: AsRef<[u8]> + crate::trace::Trace,
+    T: AsRef<str> + crate::trace::Trace,
 {
     fn trace(&self, t: &mut dyn crate::trace::Tracer) {
         t.open("Button");
@@ -322,7 +322,7 @@ impl<T> Button<T> {
     where
         F0: Fn(ButtonMsg) -> Option<R>,
         F1: Fn(ButtonMsg) -> Option<R>,
-        T: AsRef<[u8]>,
+        T: AsRef<str>,
     {
         const BUTTON_SPACING: i32 = 6;
         (

--- a/core/embed/rust/src/ui/model_tt/component/frame.rs
+++ b/core/embed/rust/src/ui/model_tt/component/frame.rs
@@ -14,7 +14,7 @@ pub struct Frame<T, U> {
 impl<T, U> Frame<T, U>
 where
     T: Component,
-    U: AsRef<[u8]>,
+    U: AsRef<str>,
 {
     pub fn new(title: U, content: T) -> Self {
         Self {
@@ -32,7 +32,7 @@ where
 impl<T, U> Component for Frame<T, U>
 where
     T: Component,
-    U: AsRef<[u8]>,
+    U: AsRef<str>,
 {
     type Msg = T::Msg;
 
@@ -76,7 +76,7 @@ where
 impl<T, U> crate::trace::Trace for Frame<T, U>
 where
     T: crate::trace::Trace,
-    U: crate::trace::Trace + AsRef<[u8]>,
+    U: crate::trace::Trace + AsRef<str>,
 {
     fn trace(&self, t: &mut dyn crate::trace::Tracer) {
         t.open("Frame");

--- a/core/embed/rust/src/ui/model_tt/component/keyboard/bip39.rs
+++ b/core/embed/rust/src/ui/model_tt/component/keyboard/bip39.rs
@@ -20,7 +20,7 @@ use crate::{
 const MAX_LENGTH: usize = 8;
 
 pub struct Bip39Input {
-    button: Button<&'static [u8]>,
+    button: Button<&'static str>,
     textbox: TextBox<MAX_LENGTH>,
     multi_tap: MultiTapKeyboard,
     suggested_word: Option<&'static str>,
@@ -95,7 +95,7 @@ impl Component for Bip39Input {
         self.button.paint_background(&style);
 
         // Paint the entered content (the prefix of the suggested word).
-        let text = self.textbox.content().as_bytes();
+        let text = self.textbox.content();
         let width = style.font.text_width(text);
         // Content starts in the left-center point, offset by 16px to the right and 8px
         // to the bottom.
@@ -113,7 +113,7 @@ impl Component for Bip39Input {
             let word_baseline = text_baseline + Offset::new(width, 0);
             display::text(
                 word_baseline,
-                word.as_bytes(),
+                word,
                 style.font,
                 theme::GREY_LIGHT,
                 style.button_color,
@@ -211,7 +211,7 @@ impl Bip39Input {
             // Disabled button.
             self.button.disable(ctx);
             self.button.set_stylesheet(ctx, theme::button_default());
-            self.button.set_content(ctx, ButtonContent::Text(b""));
+            self.button.set_content(ctx, ButtonContent::Text(""));
         }
     }
 }

--- a/core/embed/rust/src/ui/model_tt/component/keyboard/mnemonic.rs
+++ b/core/embed/rust/src/ui/model_tt/component/keyboard/mnemonic.rs
@@ -19,17 +19,17 @@ pub struct MnemonicKeyboard<T, U> {
     /// Initial prompt, displayed on empty input.
     prompt: Child<Maybe<Label<U>>>,
     /// Backspace button.
-    back: Child<Maybe<Button<&'static [u8]>>>,
+    back: Child<Maybe<Button<&'static str>>>,
     /// Input area, acting as the auto-complete and confirm button.
     input: Child<Maybe<T>>,
     /// Key buttons.
-    keys: [Child<Button<&'static [u8]>>; MNEMONIC_KEY_COUNT],
+    keys: [Child<Button<&'static str>>; MNEMONIC_KEY_COUNT],
 }
 
 impl<T, U> MnemonicKeyboard<T, U>
 where
     T: MnemonicInput,
-    U: Deref<Target = [u8]>,
+    U: Deref<Target = str>,
 {
     pub fn new(input: T, prompt: U) -> Self {
         Self {
@@ -42,10 +42,7 @@ where
                 Button::with_icon(theme::ICON_BACK).styled(theme::button_clear()),
             )),
             input: Child::new(Maybe::hidden(theme::BG, input)),
-            keys: T::keys()
-                .map(str::as_bytes)
-                .map(Button::with_text)
-                .map(Child::new),
+            keys: T::keys().map(Button::with_text).map(Child::new),
         }
     }
 
@@ -87,7 +84,7 @@ where
 impl<T, U> Component for MnemonicKeyboard<T, U>
 where
     T: MnemonicInput,
-    U: Deref<Target = [u8]>,
+    U: Deref<Target = str>,
 {
     type Msg = MnemonicKeyboardMsg;
 

--- a/core/embed/rust/src/ui/model_tt/component/keyboard/passphrase.rs
+++ b/core/embed/rust/src/ui/model_tt/component/keyboard/passphrase.rs
@@ -250,7 +250,7 @@ impl Component for Input {
 
         let style = theme::label_default();
         let text_baseline = self.area.bottom_left() - TEXT_OFFSET;
-        let text = self.textbox.content().as_bytes();
+        let text = self.textbox.content();
 
         // Possible optimization is to redraw the background only when pending character
         // is replaced, or only draw rectangle over the pending character and

--- a/core/embed/rust/src/ui/model_tt/component/keyboard/slip39.rs
+++ b/core/embed/rust/src/ui/model_tt/component/keyboard/slip39.rs
@@ -25,7 +25,7 @@ use crate::{
 const MAX_LENGTH: usize = 8;
 
 pub struct Slip39Input {
-    button: Button<&'static [u8]>,
+    button: Button<&'static str>,
     textbox: TextBox<MAX_LENGTH>,
     multi_tap: MultiTapKeyboard,
     final_word: Option<&'static str>,
@@ -139,8 +139,9 @@ impl Component for Slip39Input {
             if let (Some(key), Some(press)) =
                 (self.multi_tap.pending_key(), self.multi_tap.pending_press())
             {
-                let ascii_text = Self::keys()[key].as_bytes();
-                let ch = ascii_text[press % ascii_text.len()] as char;
+                assert!(!Self::keys()[key].is_empty());
+                // Now we can be sure that the looped iterator will return a value.
+                let ch = Self::keys()[key].chars().cycle().nth(press).unwrap();
                 text.pop();
                 text.push(ch)
                     .assert_if_debugging_ui("Text buffer is too small");
@@ -148,7 +149,7 @@ impl Component for Slip39Input {
         }
         display::text(
             text_baseline,
-            text.as_bytes(),
+            text.as_str(),
             style.font,
             style.text_color,
             style.button_color,
@@ -156,7 +157,7 @@ impl Component for Slip39Input {
 
         // Paint the pending marker.
         if self.multi_tap.pending_key().is_some() && self.final_word.is_none() {
-            paint_pending_marker(text_baseline, text.as_bytes(), style.font, style.text_color);
+            paint_pending_marker(text_baseline, text.as_str(), style.font, style.text_color);
         }
 
         // Paint the icon.
@@ -221,7 +222,7 @@ impl Slip39Input {
             // Disabled button.
             self.button.disable(ctx);
             self.button.set_stylesheet(ctx, theme::button_default());
-            self.button.set_content(ctx, ButtonContent::Text(b""));
+            self.button.set_content(ctx, ButtonContent::Text(""));
         }
     }
 

--- a/core/embed/rust/src/ui/model_tt/component/page.rs
+++ b/core/embed/rust/src/ui/model_tt/component/page.rs
@@ -57,7 +57,7 @@ where
     fn paint_hint(&mut self) {
         display::text_center(
             self.pad.area.bottom_center() - Offset::y(3),
-            b"SWIPE TO CONTINUE",
+            "SWIPE TO CONTINUE",
             theme::FONT_BOLD, // FIXME: Figma has this as 14px but bold is 16px
             theme::GREY_LIGHT,
             theme::BG,


### PR DESCRIPTION
The current Rust layout is not string-aware and passes bytes everywhere.

This PR converts most usage sites to &str, String and friends, so that we have UTF-8 enforced in the type system.

A `StrBuffer` type is introduced in the FFI to load `str` from MicroPython side properly.