### PR TITLE
Fix flash and openocd rules in makefile

### DIFF
--- a/core/Makefile
+++ b/core/Makefile
@@ -26,8 +26,10 @@ TREZOR_MEMPERF ?= 0
 ADDRESS_SANITIZER ?= 0
 UI2 ?= 0
 
-OPENOCD_INTERFACE ?= stlink   # -or- ftdi/olimex-arm-usb-tiny-h
-OPENOCD_TRANSPORT ?= hla_swd  # -or- jtag
+# OpenOCD interface default. Alternative: ftdi/olimex-arm-usb-tiny-h
+OPENOCD_INTERFACE ?= stlink
+# OpenOCD transport default. Alternative: jtag
+OPENOCD_TRANSPORT ?= hla_swd
 OPENOCD = openocd -f interface/$(OPENOCD_INTERFACE).cfg -c "transport select $(OPENOCD_TRANSPORT)" -f target/stm32f4x.cfg
 OPENOCD_T1 = openocd -f interface/$(OPENOCD_INTERFACE).cfg -c "transport select $(OPENOCD_TRANSPORT)" -f target/stm32f2x.cfg
 


### PR DESCRIPTION
When there are comments after make variable definition, make considers spaces between the comment and variable value as a part of the value, which breaks makefile rules when using default values (spaces are added to filename etc)

Therefore, in this PR, comments on openocd interface and transport default values are moved to separate line