### PR TITLE
Fixing compilation for different trezor models 

### DIFF
--- a/core/SConscript.boardloader
+++ b/core/SConscript.boardloader
@@ -131,6 +131,7 @@ env.Replace(
     ] + CPPPATH_MOD,
     CPPDEFINES=[
         ('TREZOR_MODEL', '$TREZOR_MODEL'),
+        'MODEL_'+TREZOR_MODEL,
         CPU_MODEL,
         'USE_HAL_DRIVER',
         ('STM32_HAL_H', '"<stm32f4xx.h>"'),

--- a/core/SConscript.bootloader
+++ b/core/SConscript.bootloader
@@ -159,6 +159,7 @@ env.Replace(
     ] + CPPPATH_MOD,
     CPPDEFINES=[
         ('TREZOR_MODEL', '$TREZOR_MODEL'),
+        'MODEL_'+TREZOR_MODEL,
         CPU_MODEL,
         'USE_HAL_DRIVER',
         ('STM32_HAL_H', '"<stm32f4xx.h>"'),

--- a/core/SConscript.bootloader_ci
+++ b/core/SConscript.bootloader_ci
@@ -159,6 +159,7 @@ env.Replace(
     ] + CPPPATH_MOD,
     CPPDEFINES=[
         ('TREZOR_MODEL', '$TREZOR_MODEL'),
+        'MODEL_'+TREZOR_MODEL,
         CPU_MODEL,
         'USE_HAL_DRIVER',
         ('STM32_HAL_H', '"<stm32f4xx.h>"'),

--- a/core/SConscript.firmware
+++ b/core/SConscript.firmware
@@ -472,6 +472,7 @@ env.Replace(
     ] + CPPPATH_MOD,
     CPPDEFINES=[
         ('TREZOR_MODEL', '$TREZOR_MODEL'),
+        'MODEL_'+TREZOR_MODEL,
         CPU_MODEL,
         'USE_HAL_DRIVER',
         ('STM32_HAL_H', '"<stm32f4xx.h>"'),

--- a/core/SConscript.reflash
+++ b/core/SConscript.reflash
@@ -128,6 +128,7 @@ env.Replace(
     ] + CPPPATH_MOD,
     CPPDEFINES=[
         ('TREZOR_MODEL', '$TREZOR_MODEL'),
+        'MODEL_'+TREZOR_MODEL,
         CPU_MODEL,
         'USE_HAL_DRIVER',
         ('STM32_HAL_H', '"<stm32f4xx.h>"'),

--- a/core/SConscript.unix
+++ b/core/SConscript.unix
@@ -432,6 +432,7 @@ env.Replace(
     CPPDEFINES=[
         'TREZOR_EMULATOR',
         ('TREZOR_MODEL', '$TREZOR_MODEL'),
+        'MODEL_'+TREZOR_MODEL,
         ('MP_CONFIGFILE', '\\"embed/unix/mpconfigport.h\\"'),
     ] + CPPDEFINES_MOD,
     ASPPFLAGS='$CFLAGS $CCFLAGS', )

--- a/core/embed/extmod/modtrezorconfig/norcow_config.h
+++ b/core/embed/extmod/modtrezorconfig/norcow_config.h
@@ -25,9 +25,9 @@
 #define NORCOW_HEADER_LEN 0
 #define NORCOW_SECTOR_COUNT 2
 
-#if TREZOR_MODEL == T
+#if defined MODEL_T
 #define NORCOW_SECTOR_SIZE (64 * 1024)
-#elif TREZOR_MODEL == 1
+#elif defined MODEL_1
 #define NORCOW_SECTOR_SIZE (16 * 1024)
 #else
 #error Unknown Trezor model

--- a/core/embed/extmod/modtrezorio/modtrezorio-poll.h
+++ b/core/embed/extmod/modtrezorio/modtrezorio-poll.h
@@ -74,7 +74,7 @@ STATIC mp_obj_t mod_trezorio_poll(mp_obj_t ifaces, mp_obj_t list_ref,
 
       if (false) {
       }
-#if TREZOR_MODEL == T
+#if defined MODEL_T
       else if (iface == TOUCH_IFACE) {
         const uint32_t evt = touch_read();
         if (evt) {
@@ -110,7 +110,7 @@ STATIC mp_obj_t mod_trezorio_poll(mp_obj_t ifaces, mp_obj_t list_ref,
           return mp_const_true;
         }
       }
-#elif TREZOR_MODEL == 1
+#elif defined MODEL_1
       else if (iface == BUTTON_IFACE) {
         const uint32_t evt = button_read();
         if (evt & (BTN_EVT_DOWN | BTN_EVT_UP)) {

--- a/core/embed/extmod/modtrezorio/modtrezorio.c
+++ b/core/embed/extmod/modtrezorio/modtrezorio.c
@@ -44,7 +44,7 @@
 #include "modtrezorio-webusb.h"
 #include "modtrezorio-usb.h"
 // clang-format on
-#if TREZOR_MODEL == T
+#if defined MODEL_T
 #include "modtrezorio-fatfs.h"
 #include "modtrezorio-sbu.h"
 #include "modtrezorio-sdcard.h"
@@ -72,7 +72,7 @@
 STATIC const mp_rom_map_elem_t mp_module_trezorio_globals_table[] = {
     {MP_ROM_QSTR(MP_QSTR___name__), MP_ROM_QSTR(MP_QSTR_trezorio)},
 
-#if TREZOR_MODEL == T
+#if defined MODEL_T
     {MP_ROM_QSTR(MP_QSTR_fatfs), MP_ROM_PTR(&mod_trezorio_fatfs_module)},
     {MP_ROM_QSTR(MP_QSTR_SBU), MP_ROM_PTR(&mod_trezorio_SBU_type)},
     {MP_ROM_QSTR(MP_QSTR_sdcard), MP_ROM_PTR(&mod_trezorio_sdcard_module)},
@@ -81,7 +81,7 @@ STATIC const mp_rom_map_elem_t mp_module_trezorio_globals_table[] = {
     {MP_ROM_QSTR(MP_QSTR_TOUCH_START), MP_ROM_INT((TOUCH_START >> 24) & 0xFFU)},
     {MP_ROM_QSTR(MP_QSTR_TOUCH_MOVE), MP_ROM_INT((TOUCH_MOVE >> 24) & 0xFFU)},
     {MP_ROM_QSTR(MP_QSTR_TOUCH_END), MP_ROM_INT((TOUCH_END >> 24) & 0xFFU)},
-#elif TREZOR_MODEL == 1
+#elif defined MODEL_1
     {MP_ROM_QSTR(MP_QSTR_BUTTON), MP_ROM_INT(BUTTON_IFACE)},
     {MP_ROM_QSTR(MP_QSTR_BUTTON_PRESSED),
      MP_ROM_INT((BTN_EVT_DOWN >> 24) & 0x3U)},

--- a/core/embed/extmod/modtrezorui/display-unix.h
+++ b/core/embed/extmod/modtrezorui/display-unix.h
@@ -25,7 +25,7 @@
 
 #define EMULATOR_BORDER 16
 
-#if TREZOR_MODEL == T
+#if defined MODEL_T
 
 #ifdef TREZOR_EMULATOR_RASPI
 #define WINDOW_WIDTH 480
@@ -39,7 +39,7 @@
 #define TOUCH_OFFSET_Y 110
 #endif
 
-#elif TREZOR_MODEL == 1
+#elif defined MODEL_1
 
 #define WINDOW_WIDTH 200
 #define WINDOW_HEIGHT 340
@@ -76,7 +76,7 @@ static struct {
 #define PIXELDATA_DIRTY()
 
 void PIXELDATA(uint16_t c) {
-#if TREZOR_MODEL == 1
+#if defined MODEL_1
   // set to white if highest bits of all R, G, B values are set to 1
   // bin(10000 100000 10000) = hex(0x8410)
   // otherwise set to black
@@ -173,11 +173,11 @@ void display_init(void) {
       RENDERER, SDL_RWFromMem(background_raspi_jpg, background_raspi_jpg_len),
       0);
 #else
-#if TREZOR_MODEL == T
+#if defined MODEL_T
 #include "background_T.h"
   BACKGROUND = IMG_LoadTexture_RW(
       RENDERER, SDL_RWFromMem(background_T_jpg, background_T_jpg_len), 0);
-#elif TREZOR_MODEL == 1
+#elif defined MODEL_1
 #include "background_1.h"
   BACKGROUND = IMG_LoadTexture_RW(
       RENDERER, SDL_RWFromMem(background_1_jpg, background_1_jpg_len), 0);

--- a/core/embed/extmod/modtrezorui/display.c
+++ b/core/embed/extmod/modtrezorui/display.c
@@ -28,7 +28,7 @@
 
 #include "font_bitmap.h"
 
-#if TREZOR_MODEL == T
+#if defined MODEL_T
 
 // TT new rust UI
 #if TREZOR_UI2
@@ -75,7 +75,7 @@
 
 #endif
 
-#elif TREZOR_MODEL == 1
+#elif defined MODEL_1
 
 #ifdef TREZOR_FONT_NORMAL_ENABLE
 #include "font_pixeloperator_regular_8.h"
@@ -115,9 +115,9 @@ static struct { int x, y; } DISPLAY_OFFSET;
 #ifdef TREZOR_EMULATOR
 #include "display-unix.h"
 #else
-#if TREZOR_MODEL == T
+#if defined MODEL_T
 #include "display-stm32_T.h"
-#elif TREZOR_MODEL == 1
+#elif defined MODEL_1
 #include "display-stm32_1.h"
 #else
 #error Unknown Trezor model
@@ -261,7 +261,7 @@ static void uzlib_prepare(struct uzlib_uncomp *decomp, uint8_t *window,
 
 void display_image(int x, int y, int w, int h, const void *data,
                    uint32_t datalen) {
-#if TREZOR_MODEL == T
+#if defined MODEL_T
   x += DISPLAY_OFFSET.x;
   y += DISPLAY_OFFSET.y;
   int x0 = 0, y0 = 0, x1 = 0, y1 = 0;
@@ -302,7 +302,7 @@ void display_image(int x, int y, int w, int h, const void *data,
 
 void display_avatar(int x, int y, const void *data, uint32_t datalen,
                     uint16_t fgcolor, uint16_t bgcolor) {
-#if TREZOR_MODEL == T
+#if defined MODEL_T
   x += DISPLAY_OFFSET.x;
   y += DISPLAY_OFFSET.y;
   int x0 = 0, y0 = 0, x1 = 0, y1 = 0;
@@ -426,14 +426,14 @@ bool display_toif_info(const uint8_t *data, uint32_t len, uint16_t *out_w,
   return true;
 }
 
-#if TREZOR_MODEL == T
+#if defined MODEL_T
 #include "loader.h"
 #endif
 
 void display_loader(uint16_t progress, bool indeterminate, int yoffset,
                     uint16_t fgcolor, uint16_t bgcolor, const uint8_t *icon,
                     uint32_t iconlen, uint16_t iconfgcolor) {
-#if TREZOR_MODEL == T
+#if defined MODEL_T
   uint16_t colortable[16] = {0}, iconcolortable[16] = {0};
   set_color_table(colortable, fgcolor, bgcolor);
   if (icon) {
@@ -915,9 +915,9 @@ void display_offset(int set_xy[2], int *get_x, int *get_y) {
 
 int display_orientation(int degrees) {
   if (degrees != DISPLAY_ORIENTATION) {
-#if TREZOR_MODEL == T
+#if defined MODEL_T
     if (degrees == 0 || degrees == 90 || degrees == 180 || degrees == 270) {
-#elif TREZOR_MODEL == 1
+#elif defined MODEL_1
     if (degrees == 0 || degrees == 180) {
 #else
 #error Unknown Trezor model
@@ -930,7 +930,7 @@ int display_orientation(int degrees) {
 }
 
 int display_backlight(int val) {
-#if TREZOR_MODEL == 1
+#if defined MODEL_1
   val = 255;
 #endif
   if (DISPLAY_BACKLIGHT != val && val >= 0 && val <= 255) {

--- a/core/embed/extmod/modtrezorui/display.h
+++ b/core/embed/extmod/modtrezorui/display.h
@@ -23,7 +23,7 @@
 #include <stdbool.h>
 #include <stdint.h>
 
-#if TREZOR_MODEL == T
+#if defined MODEL_T
 
 // ILI9341V, GC9307 and ST7789V drivers support 240px x 320px display resolution
 #define MAX_DISPLAY_RESX 240
@@ -32,7 +32,7 @@
 #define DISPLAY_RESY 240
 #define TREZOR_FONT_BPP 4
 
-#elif TREZOR_MODEL == 1
+#elif defined MODEL_1
 
 #define MAX_DISPLAY_RESX 128
 #define MAX_DISPLAY_RESY 64

--- a/core/embed/firmware/main.c
+++ b/core/embed/firmware/main.c
@@ -65,7 +65,7 @@ int main(void) {
 #endif
 
   // reinitialize HAL for Trezor One
-#if TREZOR_MODEL == 1
+#if defined MODEL_1
   HAL_Init();
 #endif
 
@@ -75,7 +75,7 @@ int main(void) {
   enable_systemview();
 #endif
 
-#if TREZOR_MODEL == T
+#if defined MODEL_T
 #if PRODUCTION
   check_and_replace_bootloader();
 #endif
@@ -86,12 +86,12 @@ int main(void) {
   // Init peripherals
   pendsv_init();
 
-#if TREZOR_MODEL == 1
+#if defined MODEL_1
   display_init();
   button_init();
 #endif
 
-#if TREZOR_MODEL == T
+#if defined MODEL_T
   // display_init_seq();
   sdcard_init();
   touch_init();

--- a/core/embed/trezorhal/flash.c
+++ b/core/embed/trezorhal/flash.c
@@ -39,7 +39,7 @@ static const uint32_t FLASH_SECTOR_TABLE[FLASH_SECTOR_COUNT + 1] = {
     [9] = 0x080A0000,   // - 0x080BFFFF | 128 KiB
     [10] = 0x080C0000,  // - 0x080DFFFF | 128 KiB
     [11] = 0x080E0000,  // - 0x080FFFFF | 128 KiB
-#if TREZOR_MODEL == T
+#if defined MODEL_T
     [12] = 0x08100000,  // - 0x08103FFF |  16 KiB
     [13] = 0x08104000,  // - 0x08107FFF |  16 KiB
     [14] = 0x08108000,  // - 0x0810BFFF |  16 KiB
@@ -53,7 +53,7 @@ static const uint32_t FLASH_SECTOR_TABLE[FLASH_SECTOR_COUNT + 1] = {
     [22] = 0x081C0000,  // - 0x081DFFFF | 128 KiB
     [23] = 0x081E0000,  // - 0x081FFFFF | 128 KiB
     [24] = 0x08200000,  // last element - not a valid sector
-#elif TREZOR_MODEL == 1
+#elif defined MODEL_1
     [12] = 0x08100000,  // last element - not a valid sector
 #else
 #error Unknown Trezor model

--- a/core/embed/trezorhal/flash.h
+++ b/core/embed/trezorhal/flash.h
@@ -26,9 +26,9 @@
 
 // see docs/memory.md for more information
 
-#if TREZOR_MODEL == T
+#if defined MODEL_T
 #define FLASH_SECTOR_COUNT 24
-#elif TREZOR_MODEL == 1
+#elif defined MODEL_1
 #define FLASH_SECTOR_COUNT 12
 #else
 #error Unknown Trezor model
@@ -40,10 +40,10 @@
 
 //                                           3
 
-#if TREZOR_MODEL == T
+#if defined MODEL_T
 #define FLASH_SECTOR_STORAGE_1 4
 #define FLASH_SECTOR_STORAGE_2 16
-#elif TREZOR_MODEL == 1
+#elif defined MODEL_1
 #define FLASH_SECTOR_STORAGE_1 2
 #define FLASH_SECTOR_STORAGE_2 3
 #else

--- a/core/embed/unix/flash.c
+++ b/core/embed/unix/flash.c
@@ -47,7 +47,7 @@ static const uint32_t FLASH_SECTOR_TABLE[FLASH_SECTOR_COUNT + 1] = {
     [9] = 0x080A0000,   // - 0x080BFFFF | 128 KiB
     [10] = 0x080C0000,  // - 0x080DFFFF | 128 KiB
     [11] = 0x080E0000,  // - 0x080FFFFF | 128 KiB
-#if TREZOR_MODEL == T
+#if defined MODEL_T
     [12] = 0x08100000,  // - 0x08103FFF |  16 KiB
     [13] = 0x08104000,  // - 0x08107FFF |  16 KiB
     [14] = 0x08108000,  // - 0x0810BFFF |  16 KiB
@@ -61,7 +61,7 @@ static const uint32_t FLASH_SECTOR_TABLE[FLASH_SECTOR_COUNT + 1] = {
     [22] = 0x081C0000,  // - 0x081DFFFF | 128 KiB
     [23] = 0x081E0000,  // - 0x081FFFFF | 128 KiB
     [24] = 0x08200000,  // last element - not a valid sector
-#elif TREZOR_MODEL == 1
+#elif defined MODEL_1
     [12] = 0x08100000,  // last element - not a valid sector
 #else
 #error Unknown Trezor model

--- a/core/embed/unix/touch.c
+++ b/core/embed/unix/touch.c
@@ -46,7 +46,7 @@ static bool handle_emulator_events(const SDL_Event *event) {
   return false;
 }
 
-#if TREZOR_MODEL == T
+#if defined MODEL_T
 
 #include "touch.h"
 
@@ -102,7 +102,7 @@ uint32_t touch_read(void) {
   return 0;
 }
 
-#elif TREZOR_MODEL == 1
+#elif defined MODEL_1
 
 #include "button.h"
 

--- a/storage/tests/c/norcow_config.h
+++ b/storage/tests/c/norcow_config.h
@@ -31,9 +31,9 @@
  * The length of the sector header in bytes. The header is preserved between
  * sector erasures.
  */
-#if TREZOR_MODEL == T
+#if defined MODEL_T
 #define NORCOW_HEADER_LEN 0
-#elif TREZOR_MODEL == 1
+#elif defined MODEL_1
 #define NORCOW_HEADER_LEN (0x100)
 #else
 #error Unknown Trezor model


### PR DESCRIPTION
Fixing compilation for different trezor models (1, T, etc)

Compiling core for different trezor models works only partially. TREZOR_MODEL is defined in makefile (or via command line) as 1 or T, these are then passed to gcc and is interpreted as a number or a preprocessor token T, which is undefined. The preprocessor directives compare TREZOR_MODEL to either 1 or undefined token T. Undefined token ultimately evaluates to 0, thus the distinction works. But if another model is added, for example Model X, the undefined X in comparison would also evaluate to 0 and both conditions for T and X would be satisfied. 

To fix this, another -D macro (using SConscript) is added for gcc invocation - MODEL_T or MODEL_1, and in C files then use this token for evaluation what to build via `#if defined`. (It would be also possible to pass the constant to gcc as a char and then compare with char, but it only works for single character model names, and we would still need the original TREZOR_MODEL constant with the undefined T, since it is used for generating QSTR for micropython environment and it actually relies on the T symbol being undefined). 

Developers don't need to change anything when compiling, but for correct IDE indexing function, the corresponding MODEL_x macro has to be added.

This PR only affects C portion of the core code.