### PR TITLE
chore(cardano): remove legacy types

### DIFF
--- a/common/protob/messages-cardano.proto
+++ b/common/protob/messages-cardano.proto
@@ -287,18 +287,18 @@ message CardanoPoolMetadataType {
  * @embed
  */
 message CardanoPoolParametersType {
-    required bytes pool_id = 1;                                          // stake pool cold public key hash (28 bytes)
-    required bytes vrf_key_hash = 2;                                     // VRF key hash (32 bytes)
-    required uint64 pledge = 3;                                          // pledge amount in lovelace
-    required uint64 cost = 4;                                            // cost in lovelace
-    required uint64 margin_numerator = 5;                                // pool margin numerator
-    required uint64 margin_denominator = 6;                              // pool margin denominator
-    required string reward_account = 7;                                  // bech32 reward address where the pool receives rewards
-    repeated CardanoPoolOwner owners = 8 [deprecated = true];            // pool owners list
-    repeated CardanoPoolRelayParameters relays = 9 [deprecated = true];  // pool relays list
-    optional CardanoPoolMetadataType metadata = 10;                      // pool metadata
-    required uint32 owners_count = 11;                                   // number of pool owners
-    required uint32 relays_count = 12;                                   // number of pool relays
+    required bytes pool_id = 1;                         // stake pool cold public key hash (28 bytes)
+    required bytes vrf_key_hash = 2;                    // VRF key hash (32 bytes)
+    required uint64 pledge = 3;                         // pledge amount in lovelace
+    required uint64 cost = 4;                           // cost in lovelace
+    required uint64 margin_numerator = 5;               // pool margin numerator
+    required uint64 margin_denominator = 6;             // pool margin denominator
+    required string reward_account = 7;                 // bech32 reward address where the pool receives rewards
+    // repeated CardanoPoolOwner owners = 8;            // legacy pool owners list - support for pre-tx-streaming firmwares dropped
+    // repeated CardanoPoolRelayParameters relays = 9;  // legacy pool relays list - support for pre-tx-streaming firmwares dropped
+    optional CardanoPoolMetadataType metadata = 10;     // pool metadata
+    required uint32 owners_count = 11;                  // number of pool owners
+    required uint32 relays_count = 12;                  // number of pool relays
 }
 
 /**
@@ -441,130 +441,4 @@ message CardanoTxBodyHash {
  * @end
  */
 message CardanoSignTxFinished {
-}
-
-/**
- * Request: Ask device to sign Cardano transaction
- * @start
- * @next CardanoSignedTx
- * @next Failure
- */
-message CardanoSignTx {
-    option deprecated = true;
-
-    repeated CardanoTxInputType inputs = 1;                     // inputs to be used in transaction
-    repeated CardanoTxOutputType outputs = 2;                   // outputs to be used in transaction
-    // optional uint32 transactions_count = 3;                  // left as a comment so we know to skip the id 3 in the future
-    // optional uint32 network = 4;                             // replaced with protocol_magic
-    required uint32 protocol_magic = 5;                         // network's protocol magic
-    required uint64 fee = 6;                                    // transaction fee - added in shelley
-    optional uint64 ttl = 7;                                    // transaction ttl - added in shelley
-    required uint32 network_id = 8;                             // network id - mainnet or testnet
-    repeated CardanoTxCertificateType certificates = 9;         // transaction certificates - added in shelley
-    repeated CardanoTxWithdrawalType withdrawals = 10;          // transaction withdrawals - added in shelley
-    // optional bytes metadata = 11;                            // replaced in Mary era with auxiliary data below
-    optional uint64 validity_interval_start = 12;               // transaction validity start - added in allegra
-    optional CardanoTxAuxiliaryDataType auxiliary_data = 13;    // transaction auxiliary data
-
-    /**
-     * Structure representing cardano transaction input
-     */
-    message CardanoTxInputType {
-        repeated uint32 address_n = 1;  // BIP-32 path to derive the key from master node
-        required bytes prev_hash = 2;   // hash of previous transaction output to spend by this input
-        required uint32 prev_index = 3; // index of previous output to spend
-        // left as a comment so we know to skip the id 4 in the future
-        // optional uint32 type = 4;
-    }
-    /**
-     * Structure representing cardano transaction output
-     */
-    message CardanoTxOutputType {
-        optional string address = 1;                                    // target coin address in bech32 or base58
-        // repeated uint32 address_n = 2;                               // moved to address_parameters
-        required uint64 amount = 3;                                     // amount in Lovelace
-        optional CardanoAddressParametersType address_parameters = 4;   // parameters used to derive the address
-        repeated CardanoAssetGroupType token_bundle = 5;                // custom assets - added in mary
-    }
-
-    message CardanoAssetGroupType {
-        required bytes policy_id = 1;                  // asset group policy id
-        repeated CardanoTokenType tokens = 2;          // asset name-amount pair
-    }
-
-    message CardanoTokenType {
-        required bytes asset_name_bytes = 1;     // asset name as bytestring (may be either ascii string or hash)
-        required uint64 amount = 2;              // asset amount
-    }
-
-    /**
-     * Stake pool owner parameters
-     */
-    message CardanoPoolOwnerType {
-        repeated uint32 staking_key_path = 1;   // BIP-32-style path to derive staking key of the owner
-        optional bytes staking_key_hash = 2;    // owner's staking key if it is an external owner
-    }
-
-    /**
-     * Stake pool relay parameters
-     */
-    message CardanoPoolRelayParametersType {
-        required CardanoPoolRelayType type = 1;   // pool relay type
-        optional bytes ipv4_address = 2;          // ipv4 address of the relay given as 4 bytes
-        optional bytes ipv6_address = 3;          // ipv6 address of the relay given as 16 bytes
-        optional string host_name = 4;            // relay host name given as URL, at most 64 characters
-        optional uint32 port = 5;                 // relay port number in the range 0-65535
-    }
-
-    /**
-     * Structure representing cardano transaction certificate
-     */
-     message CardanoTxCertificateType {
-        required CardanoCertificateType type = 1;                 // certificate type
-        repeated uint32 path = 2;                                 // BIP-32 path to derive (staking) key
-        optional bytes pool = 3;                                  // pool hash
-        optional CardanoPoolParametersType pool_parameters = 4;   // used for stake pool registration certificate
-    }
-    /**
-     * Structure representing cardano transaction withdrawals
-     */
-    message CardanoTxWithdrawalType {
-        repeated uint32 path = 1;
-        required uint64 amount = 2;
-    }
-
-    message CardanoTxAuxiliaryDataType {
-        optional bytes blob = 1;
-        optional CardanoCatalystRegistrationParametersType catalyst_registration_parameters = 2;
-    }
-}
-
-/**
- * Response: Serialised signed cardano transaction chunk
- * @next CardanoSignedTxChunkAck
- */
-message CardanoSignedTxChunk {
-    option deprecated = true;
-
-    required bytes signed_tx_chunk = 1;         // serialised, signed transaction chunk
-}
-
-/**
- * Request: Serialised signed cardano transaction chunk acknowledgement
- * @next CardanoSignedTxChunk
- * @next CardanoSignedTx
- */
-message CardanoSignedTxChunkAck {
-    option deprecated = true;
-}
-
-/**
- * Response: Serialised signed cardano transaction
- * @end
- */
-message CardanoSignedTx {
-    option deprecated = true;
-
-    required bytes tx_hash = 1;               // hash of the transaction body
-    optional bytes serialized_tx = 2;         // deprecated since transaction is sent in chunks now - kept for backwards compatibility
 }

--- a/common/protob/messages.proto
+++ b/common/protob/messages.proto
@@ -255,14 +255,12 @@ enum MessageType {
     // Cardano
     // dropped Sign/VerifyMessage ids 300-302
     // dropped TxRequest/TxAck ids 304 and 309 (shelley update)
-    MessageType_CardanoSignTx = 303 [(wire_in) = true];
+    // dropped SignTx/SignedTx/SignedTxChunk/SignedTxChunkAck ids 303, 310, 311 and 312
+    reserved 300 to 304, 309 to 312;
     MessageType_CardanoGetPublicKey = 305 [(wire_in) = true];
     MessageType_CardanoPublicKey = 306 [(wire_out) = true];
     MessageType_CardanoGetAddress = 307 [(wire_in) = true];
     MessageType_CardanoAddress = 308 [(wire_out) = true];
-    MessageType_CardanoSignedTx = 310 [(wire_out) = true];
-    MessageType_CardanoSignedTxChunk = 311 [(wire_out) = true];
-    MessageType_CardanoSignedTxChunkAck = 312 [(wire_in) = true];
     MessageType_CardanoTxItemAck = 313 [(wire_out) = true];
     MessageType_CardanoTxAuxiliaryDataSupplement = 314 [(wire_out) = true];
     MessageType_CardanoTxWitnessRequest = 315 [(wire_in) = true];

--- a/core/src/trezor/enums/MessageType.py
+++ b/core/src/trezor/enums/MessageType.py
@@ -142,14 +142,10 @@ if not utils.BITCOIN_ONLY:
     StellarManageBuyOfferOp = 222
     StellarPathPaymentStrictSendOp = 223
     StellarSignedTx = 230
-    CardanoSignTx = 303
     CardanoGetPublicKey = 305
     CardanoPublicKey = 306
     CardanoGetAddress = 307
     CardanoAddress = 308
-    CardanoSignedTx = 310
-    CardanoSignedTxChunk = 311
-    CardanoSignedTxChunkAck = 312
     CardanoTxItemAck = 313
     CardanoTxAuxiliaryDataSupplement = 314
     CardanoTxWitnessRequest = 315

--- a/core/src/trezor/enums/__init__.py
+++ b/core/src/trezor/enums/__init__.py
@@ -160,14 +160,10 @@ if TYPE_CHECKING:
         StellarManageBuyOfferOp = 222
         StellarPathPaymentStrictSendOp = 223
         StellarSignedTx = 230
-        CardanoSignTx = 303
         CardanoGetPublicKey = 305
         CardanoPublicKey = 306
         CardanoGetAddress = 307
         CardanoAddress = 308
-        CardanoSignedTx = 310
-        CardanoSignedTxChunk = 311
-        CardanoSignedTxChunkAck = 312
         CardanoTxItemAck = 313
         CardanoTxAuxiliaryDataSupplement = 314
         CardanoTxWitnessRequest = 315

--- a/python/src/trezorlib/messages.py
+++ b/python/src/trezorlib/messages.py
@@ -168,14 +168,10 @@ class MessageType(IntEnum):
     StellarManageBuyOfferOp = 222
     StellarPathPaymentStrictSendOp = 223
     StellarSignedTx = 230
-    CardanoSignTx = 303
     CardanoGetPublicKey = 305
     CardanoPublicKey = 306
     CardanoGetAddress = 307
     CardanoAddress = 308
-    CardanoSignedTx = 310
-    CardanoSignedTxChunk = 311
-    CardanoSignedTxChunkAck = 312
     CardanoTxItemAck = 313
     CardanoTxAuxiliaryDataSupplement = 314
     CardanoTxWitnessRequest = 315
@@ -2455,8 +2451,6 @@ class CardanoPoolParametersType(protobuf.MessageType):
         5: protobuf.Field("margin_numerator", "uint64", repeated=False, required=True),
         6: protobuf.Field("margin_denominator", "uint64", repeated=False, required=True),
         7: protobuf.Field("reward_account", "string", repeated=False, required=True),
-        8: protobuf.Field("owners", "CardanoPoolOwner", repeated=True, required=False),
-        9: protobuf.Field("relays", "CardanoPoolRelayParameters", repeated=True, required=False),
         10: protobuf.Field("metadata", "CardanoPoolMetadataType", repeated=False, required=False),
         11: protobuf.Field("owners_count", "uint32", repeated=False, required=True),
         12: protobuf.Field("relays_count", "uint32", repeated=False, required=True),
@@ -2474,12 +2468,8 @@ class CardanoPoolParametersType(protobuf.MessageType):
         reward_account: "str",
         owners_count: "int",
         relays_count: "int",
-        owners: Optional[Sequence["CardanoPoolOwner"]] = None,
-        relays: Optional[Sequence["CardanoPoolRelayParameters"]] = None,
         metadata: Optional["CardanoPoolMetadataType"] = None,
     ) -> None:
-        self.owners: Sequence["CardanoPoolOwner"] = owners if owners is not None else []
-        self.relays: Sequence["CardanoPoolRelayParameters"] = relays if relays is not None else []
         self.pool_id = pool_id
         self.vrf_key_hash = vrf_key_hash
         self.pledge = pledge
@@ -2713,259 +2703,6 @@ class CardanoTxBodyHash(protobuf.MessageType):
 
 class CardanoSignTxFinished(protobuf.MessageType):
     MESSAGE_WIRE_TYPE = 319
-
-
-class CardanoSignTx(protobuf.MessageType):
-    MESSAGE_WIRE_TYPE = 303
-    FIELDS = {
-        1: protobuf.Field("inputs", "CardanoTxInputType", repeated=True, required=False),
-        2: protobuf.Field("outputs", "CardanoTxOutputType", repeated=True, required=False),
-        5: protobuf.Field("protocol_magic", "uint32", repeated=False, required=True),
-        6: protobuf.Field("fee", "uint64", repeated=False, required=True),
-        7: protobuf.Field("ttl", "uint64", repeated=False, required=False),
-        8: protobuf.Field("network_id", "uint32", repeated=False, required=True),
-        9: protobuf.Field("certificates", "CardanoTxCertificateType", repeated=True, required=False),
-        10: protobuf.Field("withdrawals", "CardanoTxWithdrawalType", repeated=True, required=False),
-        12: protobuf.Field("validity_interval_start", "uint64", repeated=False, required=False),
-        13: protobuf.Field("auxiliary_data", "CardanoTxAuxiliaryDataType", repeated=False, required=False),
-    }
-
-    def __init__(
-        self,
-        *,
-        protocol_magic: "int",
-        fee: "int",
-        network_id: "int",
-        inputs: Optional[Sequence["CardanoTxInputType"]] = None,
-        outputs: Optional[Sequence["CardanoTxOutputType"]] = None,
-        certificates: Optional[Sequence["CardanoTxCertificateType"]] = None,
-        withdrawals: Optional[Sequence["CardanoTxWithdrawalType"]] = None,
-        ttl: Optional["int"] = None,
-        validity_interval_start: Optional["int"] = None,
-        auxiliary_data: Optional["CardanoTxAuxiliaryDataType"] = None,
-    ) -> None:
-        self.inputs: Sequence["CardanoTxInputType"] = inputs if inputs is not None else []
-        self.outputs: Sequence["CardanoTxOutputType"] = outputs if outputs is not None else []
-        self.certificates: Sequence["CardanoTxCertificateType"] = certificates if certificates is not None else []
-        self.withdrawals: Sequence["CardanoTxWithdrawalType"] = withdrawals if withdrawals is not None else []
-        self.protocol_magic = protocol_magic
-        self.fee = fee
-        self.network_id = network_id
-        self.ttl = ttl
-        self.validity_interval_start = validity_interval_start
-        self.auxiliary_data = auxiliary_data
-
-
-class CardanoSignedTxChunk(protobuf.MessageType):
-    MESSAGE_WIRE_TYPE = 311
-    FIELDS = {
-        1: protobuf.Field("signed_tx_chunk", "bytes", repeated=False, required=True),
-    }
-
-    def __init__(
-        self,
-        *,
-        signed_tx_chunk: "bytes",
-    ) -> None:
-        self.signed_tx_chunk = signed_tx_chunk
-
-
-class CardanoSignedTxChunkAck(protobuf.MessageType):
-    MESSAGE_WIRE_TYPE = 312
-
-
-class CardanoSignedTx(protobuf.MessageType):
-    MESSAGE_WIRE_TYPE = 310
-    FIELDS = {
-        1: protobuf.Field("tx_hash", "bytes", repeated=False, required=True),
-        2: protobuf.Field("serialized_tx", "bytes", repeated=False, required=False),
-    }
-
-    def __init__(
-        self,
-        *,
-        tx_hash: "bytes",
-        serialized_tx: Optional["bytes"] = None,
-    ) -> None:
-        self.tx_hash = tx_hash
-        self.serialized_tx = serialized_tx
-
-
-class CardanoTxInputType(protobuf.MessageType):
-    MESSAGE_WIRE_TYPE = None
-    FIELDS = {
-        1: protobuf.Field("address_n", "uint32", repeated=True, required=False),
-        2: protobuf.Field("prev_hash", "bytes", repeated=False, required=True),
-        3: protobuf.Field("prev_index", "uint32", repeated=False, required=True),
-    }
-
-    def __init__(
-        self,
-        *,
-        prev_hash: "bytes",
-        prev_index: "int",
-        address_n: Optional[Sequence["int"]] = None,
-    ) -> None:
-        self.address_n: Sequence["int"] = address_n if address_n is not None else []
-        self.prev_hash = prev_hash
-        self.prev_index = prev_index
-
-
-class CardanoTxOutputType(protobuf.MessageType):
-    MESSAGE_WIRE_TYPE = None
-    FIELDS = {
-        1: protobuf.Field("address", "string", repeated=False, required=False),
-        3: protobuf.Field("amount", "uint64", repeated=False, required=True),
-        4: protobuf.Field("address_parameters", "CardanoAddressParametersType", repeated=False, required=False),
-        5: protobuf.Field("token_bundle", "CardanoAssetGroupType", repeated=True, required=False),
-    }
-
-    def __init__(
-        self,
-        *,
-        amount: "int",
-        token_bundle: Optional[Sequence["CardanoAssetGroupType"]] = None,
-        address: Optional["str"] = None,
-        address_parameters: Optional["CardanoAddressParametersType"] = None,
-    ) -> None:
-        self.token_bundle: Sequence["CardanoAssetGroupType"] = token_bundle if token_bundle is not None else []
-        self.amount = amount
-        self.address = address
-        self.address_parameters = address_parameters
-
-
-class CardanoAssetGroupType(protobuf.MessageType):
-    MESSAGE_WIRE_TYPE = None
-    FIELDS = {
-        1: protobuf.Field("policy_id", "bytes", repeated=False, required=True),
-        2: protobuf.Field("tokens", "CardanoTokenType", repeated=True, required=False),
-    }
-
-    def __init__(
-        self,
-        *,
-        policy_id: "bytes",
-        tokens: Optional[Sequence["CardanoTokenType"]] = None,
-    ) -> None:
-        self.tokens: Sequence["CardanoTokenType"] = tokens if tokens is not None else []
-        self.policy_id = policy_id
-
-
-class CardanoTokenType(protobuf.MessageType):
-    MESSAGE_WIRE_TYPE = None
-    FIELDS = {
-        1: protobuf.Field("asset_name_bytes", "bytes", repeated=False, required=True),
-        2: protobuf.Field("amount", "uint64", repeated=False, required=True),
-    }
-
-    def __init__(
-        self,
-        *,
-        asset_name_bytes: "bytes",
-        amount: "int",
-    ) -> None:
-        self.asset_name_bytes = asset_name_bytes
-        self.amount = amount
-
-
-class CardanoPoolOwnerType(protobuf.MessageType):
-    MESSAGE_WIRE_TYPE = None
-    FIELDS = {
-        1: protobuf.Field("staking_key_path", "uint32", repeated=True, required=False),
-        2: protobuf.Field("staking_key_hash", "bytes", repeated=False, required=False),
-    }
-
-    def __init__(
-        self,
-        *,
-        staking_key_path: Optional[Sequence["int"]] = None,
-        staking_key_hash: Optional["bytes"] = None,
-    ) -> None:
-        self.staking_key_path: Sequence["int"] = staking_key_path if staking_key_path is not None else []
-        self.staking_key_hash = staking_key_hash
-
-
-class CardanoPoolRelayParametersType(protobuf.MessageType):
-    MESSAGE_WIRE_TYPE = None
-    FIELDS = {
-        1: protobuf.Field("type", "CardanoPoolRelayType", repeated=False, required=True),
-        2: protobuf.Field("ipv4_address", "bytes", repeated=False, required=False),
-        3: protobuf.Field("ipv6_address", "bytes", repeated=False, required=False),
-        4: protobuf.Field("host_name", "string", repeated=False, required=False),
-        5: protobuf.Field("port", "uint32", repeated=False, required=False),
-    }
-
-    def __init__(
-        self,
-        *,
-        type: "CardanoPoolRelayType",
-        ipv4_address: Optional["bytes"] = None,
-        ipv6_address: Optional["bytes"] = None,
-        host_name: Optional["str"] = None,
-        port: Optional["int"] = None,
-    ) -> None:
-        self.type = type
-        self.ipv4_address = ipv4_address
-        self.ipv6_address = ipv6_address
-        self.host_name = host_name
-        self.port = port
-
-
-class CardanoTxCertificateType(protobuf.MessageType):
-    MESSAGE_WIRE_TYPE = None
-    FIELDS = {
-        1: protobuf.Field("type", "CardanoCertificateType", repeated=False, required=True),
-        2: protobuf.Field("path", "uint32", repeated=True, required=False),
-        3: protobuf.Field("pool", "bytes", repeated=False, required=False),
-        4: protobuf.Field("pool_parameters", "CardanoPoolParametersType", repeated=False, required=False),
-    }
-
-    def __init__(
-        self,
-        *,
-        type: "CardanoCertificateType",
-        path: Optional[Sequence["int"]] = None,
-        pool: Optional["bytes"] = None,
-        pool_parameters: Optional["CardanoPoolParametersType"] = None,
-    ) -> None:
-        self.path: Sequence["int"] = path if path is not None else []
-        self.type = type
-        self.pool = pool
-        self.pool_parameters = pool_parameters
-
-
-class CardanoTxWithdrawalType(protobuf.MessageType):
-    MESSAGE_WIRE_TYPE = None
-    FIELDS = {
-        1: protobuf.Field("path", "uint32", repeated=True, required=False),
-        2: protobuf.Field("amount", "uint64", repeated=False, required=True),
-    }
-
-    def __init__(
-        self,
-        *,
-        amount: "int",
-        path: Optional[Sequence["int"]] = None,
-    ) -> None:
-        self.path: Sequence["int"] = path if path is not None else []
-        self.amount = amount
-
-
-class CardanoTxAuxiliaryDataType(protobuf.MessageType):
-    MESSAGE_WIRE_TYPE = None
-    FIELDS = {
-        1: protobuf.Field("blob", "bytes", repeated=False, required=False),
-        2: protobuf.Field("catalyst_registration_parameters", "CardanoCatalystRegistrationParametersType", repeated=False, required=False),
-    }
-
-    def __init__(
-        self,
-        *,
-        blob: Optional["bytes"] = None,
-        catalyst_registration_parameters: Optional["CardanoCatalystRegistrationParametersType"] = None,
-    ) -> None:
-        self.blob = blob
-        self.catalyst_registration_parameters = catalyst_registration_parameters
 
 
 class CipherKeyValue(protobuf.MessageType):


### PR DESCRIPTION
Since Connect's `cardanoSignTransaction` will drop support for firmware versions <2.4.2 that do not support transaction streaming ([PR](https://github.com/trezor/connect/pull/1087)), it should be safe to remove the legacy protobuf types.