### PR TITLE
fix(core): leftover TREZOR_MODEL defines

### DIFF
--- a/core/embed/rust/build.rs
+++ b/core/embed/rust/build.rs
@@ -139,7 +139,7 @@ fn generate_micropython_bindings() {
             "-I../../vendor/micropython/lib/stm32lib/STM32F4xx_HAL_Driver/Inc",
             "-I../../vendor/micropython/lib/stm32lib/CMSIS/STM32F4xx/Include",
             "-I../../vendor/micropython/lib/cmsis/inc",
-            "-DTREZOR_MODEL=T",
+            "-DTREZOR_MODEL_T",
             "-DSTM32F405xx",
             "-DUSE_HAL_DRIVER",
             "-DSTM32_HAL_H=<stm32f4xx.h>",

--- a/storage/tests/c/Makefile
+++ b/storage/tests/c/Makefile
@@ -1,5 +1,5 @@
 CC = cc
-CFLAGS = -Wall -Wshadow -Wextra -Wpedantic -Werror -Wno-missing-braces -fPIC -fsanitize=address,undefined
+CFLAGS = -Wall -Wshadow -Wextra -Wpedantic -Werror -Wno-missing-braces -fPIC -fsanitize=address,undefined -DTREZOR_MODEL_T
 LIBS =
 INC = -I ../../../crypto -I ../.. -I .
 BASE = ../../../

--- a/storage/tests/c/norcow_config.h
+++ b/storage/tests/c/norcow_config.h
@@ -31,9 +31,9 @@
  * The length of the sector header in bytes. The header is preserved between
  * sector erasures.
  */
-#if defined MODEL_T
+#if defined TREZOR_MODEL_T
 #define NORCOW_HEADER_LEN 0
-#elif defined MODEL_1
+#elif defined TREZOR_MODEL_1
 #define NORCOW_HEADER_LEN (0x100)
 #else
 #error Unknown Trezor model


### PR DESCRIPTION
Fixes [storage test](https://gitlab.com/satoshilabs/trezor/trezor-firmware/-/jobs/2386665118). Related: #2222.