### PR TITLE
Make sure emulator can be shut down while waiting

### DIFF
--- a/core/.changelog.d/973.fixed
+++ b/core/.changelog.d/973.fixed
@@ -1,0 +1,1 @@
+_(Emulator)_ Emulator window will always react to shutdown events, even while waiting for USB packets.

--- a/core/embed/extmod/modtrezorio/modtrezorio-poll.h
+++ b/core/embed/extmod/modtrezorio/modtrezorio-poll.h
@@ -20,6 +20,7 @@
 #include <string.h>
 
 #include "button.h"
+#include "common.h"
 #include "display.h"
 #include "embed/extmod/trezorobj.h"
 
@@ -71,6 +72,10 @@ STATIC mp_obj_t mod_trezorio_poll(mp_obj_t ifaces, mp_obj_t list_ref,
       const mp_uint_t i = trezor_obj_get_uint(item);
       const mp_uint_t iface = i & 0x00FF;
       const mp_uint_t mode = i & 0xFF00;
+
+#if defined TREZOR_EMULATOR
+      emulator_poll_events();
+#endif
 
       if (false) {
       }

--- a/core/embed/unix/common.c
+++ b/core/embed/unix/common.c
@@ -17,6 +17,7 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
+#include <SDL.h>
 #include <stdio.h>
 #include <stdlib.h>
 #include <unistd.h>
@@ -109,6 +110,33 @@ error_shutdown(const char *line1, const char *line2, const char *line3,
 }
 
 void hal_delay(uint32_t ms) { usleep(1000 * ms); }
+
+static int SDLCALL emulator_event_filter(void *userdata, SDL_Event *event) {
+  switch (event->type) {
+    case SDL_QUIT:
+      __shutdown();
+      return 0;
+    case SDL_KEYUP:
+      if (event->key.repeat) {
+        return 0;
+      }
+      switch (event->key.keysym.sym) {
+        case SDLK_ESCAPE:
+          __shutdown();
+          return 0;
+        case SDLK_p:
+          display_save("emu");
+          return 0;
+      }
+      break;
+  }
+  return 1;
+}
+
+void emulator_poll_events(void) {
+  SDL_PumpEvents();
+  SDL_FilterEvents(emulator_event_filter, NULL);
+}
 
 uint8_t HW_ENTROPY_DATA[HW_ENTROPY_LEN];
 

--- a/core/embed/unix/common.h
+++ b/core/embed/unix/common.h
@@ -53,6 +53,7 @@ error_shutdown(const char *line1, const char *line2, const char *line3,
        : __fatal_error(#expr, msg, __FILE__, __LINE__, __func__))
 
 void hal_delay(uint32_t ms);
+void emulator_poll_events(void);
 
 void collect_hw_entropy(void);
 #define HW_ENTROPY_LEN (12 + 32)

--- a/core/embed/unix/touch.c
+++ b/core/embed/unix/touch.c
@@ -24,28 +24,6 @@
 extern void __shutdown(void);
 extern const char *display_save(const char *prefix);
 
-static bool handle_emulator_events(const SDL_Event *event) {
-  switch (event->type) {
-    case SDL_KEYUP:
-      if (event->key.repeat) {
-        break;
-      }
-      switch (event->key.keysym.sym) {
-        case SDLK_ESCAPE:
-          __shutdown();
-          return true;
-        case SDLK_p:
-          display_save("emu");
-          return true;
-      }
-      break;
-    case SDL_QUIT:
-      __shutdown();
-      return true;
-  }
-  return false;
-}
-
 #if defined TREZOR_MODEL_T
 
 #include "touch.h"
@@ -57,9 +35,6 @@ uint32_t touch_read(void) {
   SDL_Event event;
   SDL_PumpEvents();
   if (SDL_PollEvent(&event) > 0) {
-    if (handle_emulator_events(&event)) {
-      return 0;
-    }
     switch (event.type) {
       case SDL_MOUSEBUTTONDOWN:
       case SDL_MOUSEMOTION:
@@ -110,9 +85,6 @@ uint32_t button_read(void) {
   SDL_Event event;
   SDL_PumpEvents();
   if (SDL_PollEvent(&event) > 0) {
-    if (handle_emulator_events(&event)) {
-      return 0;
-    }
     switch (event.type) {
       case SDL_KEYDOWN:
         if (event.key.repeat) {


### PR DESCRIPTION
Emulator will only process quit signals (close window, ctrl+c, Esc) when polling for SDL events.

SDL events are only polled while the emulator is waiting for **user interaction**.

There are a lot of situation when emulator is NOT actually waiting for user interaction. Usually these will occur in the middle of something like a signing flow, when the firmware is expecting USB events but not user events. Such situation can also occur by programmer error.

(this is the inverse of incorrect use of `await layout_obj` instead of `await ctx.wait(layout_obj)`, where the firmware would wait for touch but not for USB events)

This PR inserts an explicit "poll for emulator events" into `trezorio.poll` so that we have a higher chance to react in more situations.
(if the poll event loop stops, we are in trouble and this solution does not help)

fixes #973 