### PR TITLE
fix(python): only even-width grayscale icons are supported

### DIFF
--- a/python/src/trezorlib/toif.py
+++ b/python/src/trezorlib/toif.py
@@ -155,6 +155,8 @@ def from_image(
 
     if image.mode == "L":
         toif_mode = firmware.ToifMode.grayscale
+        if image.size[0] % 2 != 0:
+            raise ValueError("Only even-width grayscale images are supported")
         toif_data = _from_pil_grayscale(image.getdata())
     elif image.mode == "RGB":
         toif_mode = firmware.ToifMode.full_color


### PR DESCRIPTION
When a grayscale icon with odd-width is provided, the conversion ends up with the following error:

``` python
  File ".../trezor-firmware/python/src/trezorlib/toif.py", line 70, in _from_pil_grayscale
    left, right = pixels[i], pixels[i + 1]
IndexError: image index out of range
```

The rendering code also assumes that provided icons are even-width.

Let's check this before conversion takes place.

Last, but not least, I checked and there are no icons with odd width in the repository. 