### PR TITLE
Strip old T1 header in firmware_hash.py

### DIFF
--- a/tools/firmware_hash.py
+++ b/tools/firmware_hash.py
@@ -6,24 +6,42 @@ from hashlib import blake2s
 FILE_T1 = "legacy/firmware/trezor.bin"
 FILE_T2 = "core/build/firmware/firmware.bin"
 
+T1_HEADER_MAGIC_OLD = b"TRZR"
+T1_HEADER_OLD_SIZE = 256
+T2_HEADER_MAGIC_VENDOR = b"TRZV"
+
 SIZE_T1 = (7 * 128 + 64) * 1024
 SIZE_T2 = 13 * 128 * 1024
 
-for filename, size in ((FILE_T1, SIZE_T1), (FILE_T2, SIZE_T2)):
+if len(sys.argv) > 2:
+    filenames = sys.argv[2:]
+elif len(sys.argv) == 2:
+    filenames = (FILE_T1, FILE_T2)
+else:
+    print(f"Usage: {sys.argv[0]} HEX_CHALLENGE [FILE]...")
+    print(f"       HEX_CHALLENGE: a 0-32 byte challenge in hexadecimal")
+    exit(1)
+
+
+for filename in filenames:
     try:
         data = open(filename, "rb").read()
     except FileNotFoundError:
         print(f"{filename} not found")
         continue
 
-    if len(data) > size:
-        raise ValueError(filename, "too big")
-    data = data + b"\xff" * (size - len(data))
-
-    if len(sys.argv) > 1:
-        challenge = bytes.fromhex(sys.argv[1])
-        firmware_hash = blake2s(data, key=challenge).hexdigest()
+    offset = 0
+    if data[:4] == T2_HEADER_MAGIC_VENDOR:
+        size = SIZE_T2
     else:
-        firmware_hash = blake2s(data).hexdigest()
+        size = SIZE_T1
+        if data[:4] == T1_HEADER_MAGIC_OLD:
+            offset = T1_HEADER_OLD_SIZE
 
+    if len(data) - offset > size:
+        raise ValueError(filename, "too big")
+    data = data[offset:] + b"\xff" * (size - len(data) + offset)
+
+    challenge = bytes.fromhex(sys.argv[1])
+    firmware_hash = blake2s(data, key=challenge).hexdigest()
     print(f"{filename}: {firmware_hash}")


### PR DESCRIPTION
The official T1 firmware has an extra 256 bytes at the beginning of the file, starting with "TRZR". This needs to be stripped when we compute the hash in the firmware_hash.py tool to get the right result. I am not exactly sure what this header is called, "old T1 header"? Also not entirely sure whether it's always 256 bytes. @prusnak 

I also made some improvements to the usability of the tool.