### PR TITLE
ci: update arm jobs to run on tags and use the official nix image

### DIFF
--- a/ci/build.yml
+++ b/ci/build.yml
@@ -283,12 +283,13 @@ core unix frozen debug asan build:
     expire_in: 1 week
 
 core unix frozen debug build arm:
-  image: vdovhanych/nixos
+  image: nixos/nix
   stage: build
   <<: *gitlab_caching
   needs: []
   only:
     - master
+    - tags
     - /^release\//
     - /^secfix\//
   variables:
@@ -479,12 +480,13 @@ legacy emu regular debug asan build:
     expire_in: 1 week
 
 legacy emu regular debug build arm:
-  image: vdovhanych/nixos
+  image: nixos/nix
   stage: build
   <<: *gitlab_caching
   needs: []
   only:
     - master
+    - tags
     - /^release\//
     - /^secfix\//
   variables:

--- a/docs/ci/jobs.md
+++ b/docs/ci/jobs.md
@@ -108,34 +108,34 @@ it is just a single binary file that you can execute directly.
 
 ### [core unix frozen debug build arm](https://github.com/trezor/trezor-firmware/blob/master/ci/build.yml#L285)
 
-### [core unix frozen btconly debug t1 build](https://github.com/trezor/trezor-firmware/blob/master/ci/build.yml#L306)
+### [core unix frozen btconly debug t1 build](https://github.com/trezor/trezor-firmware/blob/master/ci/build.yml#L307)
 
-### [core macos frozen regular build](https://github.com/trezor/trezor-firmware/blob/master/ci/build.yml#L321)
+### [core macos frozen regular build](https://github.com/trezor/trezor-firmware/blob/master/ci/build.yml#L322)
 
-### [crypto build](https://github.com/trezor/trezor-firmware/blob/master/ci/build.yml#L346)
+### [crypto build](https://github.com/trezor/trezor-firmware/blob/master/ci/build.yml#L347)
 Build of our cryptographic library, which is then incorporated into the other builds.
 
-### [legacy fw regular build](https://github.com/trezor/trezor-firmware/blob/master/ci/build.yml#L375)
+### [legacy fw regular build](https://github.com/trezor/trezor-firmware/blob/master/ci/build.yml#L376)
 
-### [legacy fw regular debug build](https://github.com/trezor/trezor-firmware/blob/master/ci/build.yml#L391)
+### [legacy fw regular debug build](https://github.com/trezor/trezor-firmware/blob/master/ci/build.yml#L392)
 
-### [legacy fw btconly build](https://github.com/trezor/trezor-firmware/blob/master/ci/build.yml#L408)
+### [legacy fw btconly build](https://github.com/trezor/trezor-firmware/blob/master/ci/build.yml#L409)
 
-### [legacy fw btconly debug build](https://github.com/trezor/trezor-firmware/blob/master/ci/build.yml#L427)
+### [legacy fw btconly debug build](https://github.com/trezor/trezor-firmware/blob/master/ci/build.yml#L428)
 
-### [legacy emu regular debug build](https://github.com/trezor/trezor-firmware/blob/master/ci/build.yml#L448)
+### [legacy emu regular debug build](https://github.com/trezor/trezor-firmware/blob/master/ci/build.yml#L449)
 Regular version (not only Bitcoin) of above.
 **Are you looking for a Trezor One emulator? This is most likely it.**
 
-### [legacy emu regular debug asan build](https://github.com/trezor/trezor-firmware/blob/master/ci/build.yml#L463)
+### [legacy emu regular debug asan build](https://github.com/trezor/trezor-firmware/blob/master/ci/build.yml#L464)
 
-### [legacy emu regular debug build arm](https://github.com/trezor/trezor-firmware/blob/master/ci/build.yml#L481)
+### [legacy emu regular debug build arm](https://github.com/trezor/trezor-firmware/blob/master/ci/build.yml#L482)
 
-### [legacy emu btconly debug build](https://github.com/trezor/trezor-firmware/blob/master/ci/build.yml#L506)
+### [legacy emu btconly debug build](https://github.com/trezor/trezor-firmware/blob/master/ci/build.yml#L508)
 Build of Legacy into UNIX emulator. Use keyboard arrows to emulate button presses.
 Bitcoin-only version.
 
-### [legacy emu btconly debug asan build](https://github.com/trezor/trezor-firmware/blob/master/ci/build.yml#L523)
+### [legacy emu btconly debug asan build](https://github.com/trezor/trezor-firmware/blob/master/ci/build.yml#L525)
 
 ---
 ## TEST stage - [test.yml](../../ci/test.yml)


### PR DESCRIPTION
This fixes the build job of arm emulators to run on tagged branches. Meaning the deployment after release should pass after this. I also changed the image to upstream nixos one as the issues with the old one were fixed.