### PR TITLE
Cointool improvements, wallet data

### DIFF
--- a/common/defs/wallets.json
+++ b/common/defs/wallets.json
@@ -123,5 +123,13 @@
     },
     "eth:WAN": {
         "Wanchain Wallet": "https://www.wanchain.org/getstarted/"
+    },
+    "eth:AUX": {
+        "MyEtherWallet": null
+    },
+    "eth:XDC": {
+        "MyCrypto": null,
+        "MyEtherWallet": null,
+        "XDC Wallet": "https://wallet.xinfin.network"
     }
 }

--- a/common/tools/cointool.py
+++ b/common/tools/cointool.py
@@ -711,6 +711,7 @@ device_choice = click.Choice(["connect", "suite", "trezor1", "trezor2"])
 # fmt: off
 @click.option("-o", "--outfile", type=click.File(mode="w"), default="-")
 @click.option("-s/-S", "--support/--no-support", default=True, help="Include support data for each coin")
+@click.option("-w/-W", "--wallet/--no-wallet", default=True, help="Include wallet data for each coin")
 @click.option("-p", "--pretty", is_flag=True, help="Generate nicely formatted JSON")
 @click.option("-l", "--list", "flat_list", is_flag=True, help="Output a flat list of coins")
 @click.option("-i", "--include", metavar="FIELD", multiple=True, help="Include only these fields (-i shortcut -i name)")
@@ -726,6 +727,7 @@ device_choice = click.Choice(["connect", "suite", "trezor1", "trezor2"])
 def dump(
     outfile: TextIO,
     support: bool,
+    wallet: bool,
     pretty: bool,
     flat_list: bool,
     include: tuple[str, ...],
@@ -770,6 +772,9 @@ def dump(
     Also devices can be used as filters. For example to find out which coins are
     supported in Suite and connect but not on Trezor 1, it is possible to say
     '-d suite -d connect -D trezor1'.
+
+    Includes even the wallet data, unless turned off by '-W'.
+    These can be filtered by using '-f', for example `-f 'wallet=*exodus*'` (* are necessary)
     """
     if exclude_tokens:
         exclude_type += ("erc20",)
@@ -786,12 +791,19 @@ def dump(
     # getting initial info
     coins = coin_info.coin_info()
     support_info = coin_info.support_info(coins.as_list())
+    wallet_info = coin_info.wallet_info(coins)
 
     # optionally adding support info
     if support:
         for category in coins.values():
             for coin in category:
                 coin["support"] = support_info[coin["key"]]
+
+    # optionally adding wallet info
+    if wallet:
+        for category in coins.values():
+            for coin in category:
+                coin["wallet"] = wallet_info[coin["key"]]
 
     # filter types
     if include_type:


### PR DESCRIPTION
Connected with https://github.com/trezor/trezor-firmware/issues/2278:
- add wallet support for `common/tools/cointools.py dump` command

The goal was for `cointool.py dump` to generate the same wallet data as in `coins_details.json`. To test it, I created a small [snippet](https://gist.github.com/grdddj/c253bd9346081bf40c8ea9afbefc2582) for comparing these two ( `python cointool.py dump -o new.json -p --list` must be run beforehand to generate the new report). It passes fine, except for `eth:AUX` and `eth:XDC`, which however have exceptions in `coins_details.override.json`. (should we also look at `coins_details.override.json`?)

Also, the actual `dump` command itself got (hopefully) a little improved and documented.  

Before doing the actual new feature, I wanted to add type-hints to both `coin_info.py` and `cointool.py` to understand the data more and to have more trust in the code. It is still not completely clean, both `mypy` and `pyright` sometimes complain, but the majority of those are bugs in `TypedDict` support. A lot more time could be spent with this, but it is not crucial, as it is just internal script.


