### PR TITLE
Basic animations for Model R

### DIFF
--- a/core/.changelog.d/2307.added
+++ b/core/.changelog.d/2307.added
@@ -1,0 +1,1 @@
+Added basic animations for Model R

--- a/core/embed/extmod/modtrezorui/display-stm32_1.h
+++ b/core/embed/extmod/modtrezorui/display-stm32_1.h
@@ -92,6 +92,8 @@ void display_pixeldata(uint16_t c) {
 #define PIXELDATA(c) display_pixeldata(c)
 
 static void display_reset_state() {}
+void display_trans_start(void) {}
+void display_trans_exec(transition_type_t trans) {}
 
 void PIXELDATA_DIRTY() { pixeldata_dirty = true; }
 

--- a/core/embed/extmod/modtrezorui/display-stm32_R.h
+++ b/core/embed/extmod/modtrezorui/display-stm32_R.h
@@ -105,6 +105,16 @@ static void display_reset_state(void) {
   DISPLAY_STATE.window_y1 = DISPLAY_RESY - 1;
 }
 
+static void display_fast_clear(void) {
+  for (int y = 0; y < DISPLAY_RESY / 8; y++) {
+    display_set_page_and_col(y, 0);
+    for (int x = 0; x < DISPLAY_RESX; x++) {
+      DATA(0x00);
+    }
+  }
+  display_reset_state();
+}
+
 static void __attribute__((unused)) display_sleep(void) {
   CMD(0xAE);  // DISPOFF: Display Off
   HAL_Delay(5);
@@ -246,7 +256,7 @@ void display_init_seq(void) {
 
   send_init_seq_SH1107();
 
-  display_clear();
+  display_fast_clear();
   display_unsleep();
 }
 

--- a/core/embed/extmod/modtrezorui/display-stm32_T.h
+++ b/core/embed/extmod/modtrezorui/display-stm32_T.h
@@ -98,6 +98,8 @@ static uint32_t display_identify(void) {
 }
 
 static void display_reset_state() {}
+void display_trans_start(void) {}
+void display_trans_exec(transition_type_t trans) {}
 
 static void __attribute__((unused)) display_sleep(void) {
   uint32_t id = display_identify();

--- a/core/embed/extmod/modtrezorui/display.h
+++ b/core/embed/extmod/modtrezorui/display.h
@@ -139,6 +139,15 @@ void display_fade(int start, int end, int delay);
 void display_utf8_substr(const char *buf_start, size_t buf_len, int char_off,
                          int char_len, const char **out_start, int *out_len);
 
+typedef enum {
+    TRANSITION_FAST = 0,
+    TRANSITION_SLIDE_RIGHT = 1,
+    TRANSITION_SLIDE_LEFT = 2,
+} transition_type_t;
+
+void display_trans_start(void);
+void display_trans_exec(transition_type_t trans);
+
 // pixeldata accessors
 void display_set_window(uint16_t x0, uint16_t y0, uint16_t x1, uint16_t y1);
 void display_pixeldata(uint16_t c);

--- a/core/embed/rust/build.rs
+++ b/core/embed/rust/build.rs
@@ -261,6 +261,8 @@ fn generate_trezorhal_bindings() {
         .allowlist_function("display_image")
         .allowlist_function("display_toif_info")
         .allowlist_function("display_loader")
+        .allowlist_function("display_trans_start")
+        .allowlist_function("display_trans_exec")
         .allowlist_function("display_pixeldata")
         .allowlist_function("display_pixeldata_dirty")
         .allowlist_function("display_set_window")

--- a/core/embed/rust/src/trezorhal/display.rs
+++ b/core/embed/rust/src/trezorhal/display.rs
@@ -112,6 +112,18 @@ pub fn loader(
     }
 }
 
+pub fn trans_start() {
+    unsafe {
+        ffi::display_trans_start();
+    }
+}
+
+pub fn trans_exec(transition: i32) {
+    unsafe {
+        ffi::display_trans_exec(transition);
+    }
+}
+
 #[inline(always)]
 #[cfg(all(feature = "model_tt", target_arch = "arm"))]
 pub fn pixeldata(c: u16) {

--- a/core/embed/rust/src/ui/display.rs
+++ b/core/embed/rust/src/ui/display.rs
@@ -219,6 +219,21 @@ pub fn text_right(baseline: Point, text: &str, font: Font, fg_color: Color, bg_c
     );
 }
 
+#[repr(i32)]
+pub enum DisplayTransition {
+    Fast = 0,
+    SlideRight = 1,
+    SlideLeft = 2,
+}
+
+pub fn display_trans_start() {
+    display::trans_start();
+}
+
+pub fn display_trans_exec(transition: DisplayTransition) {
+    display::trans_exec(transition as i32);
+}
+
 #[inline(always)]
 pub fn pixeldata(color: Color) {
     display::pixeldata(color.into());


### PR DESCRIPTION
Implements basic animations for Model R using a second framebuffer
- slide left
- slide right
- fast redraw of whole screen (this one would not need the second framebuffer)

Fast redraw enables to get rid of flickering when redrawing large part of the screen (could be useful for #2233 )

Slide effects are meant as replacement of fadeout-in effects which are not perfect on model R.

Also implemented faster initial display clear on model R as i was observing some partial screens after reset.

Noop for model 1 and T.