### PR TITLE
Type hints fixes for older python versions

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -92,6 +92,9 @@ ruststyle_check:
 	@echo [RUSTFMT]
 	@cd core/embed/rust ; cargo fmt -- --check
 
+python_support_check:
+	./tests/test_python_support.py
+
 ## code generation commands:
 
 mocks: ## generate mock python headers from C modules

--- a/ci/test.yml
+++ b/ci/test.yml
@@ -623,6 +623,13 @@ python test:
     # https://github.com/NixOS/nixpkgs/pull/98915
     - nix-shell --arg fullDeps true --run "unset _PYTHON_SYSCONFIGDATA_NAME && cd python && poetry run tox | ts -s"
 
+python support test:
+  stage: test
+  <<: *gitlab_caching
+  needs: []
+  script:
+    - nix-shell --run "poetry run make python_support_check | ts -s"
+
 
 # Storage
 

--- a/common/tools/coin_info.py
+++ b/common/tools/coin_info.py
@@ -7,7 +7,14 @@ import os
 import re
 from collections import OrderedDict, defaultdict
 from pathlib import Path
-from typing import Any, Callable, Iterable, Iterator, Literal, TypedDict, cast
+from typing import Dict  # for python38 support, must be used in type aliases
+from typing import List  # for python38 support, must be used in type aliases
+from typing import Any, Callable, Iterable, Iterator, cast
+
+from typing_extensions import (  # for python37 support, is not present in typing there
+    Literal,
+    TypedDict,
+)
 
 try:
     import requests
@@ -48,10 +55,10 @@ class SupportInfoItem(TypedDict):
     trezor2: Literal[False] | str
 
 
-SupportInfo = dict[str, SupportInfoItem]
+SupportInfo = Dict[str, SupportInfoItem]
 
-WalletItems = dict[str, str]
-WalletInfo = dict[str, WalletItems]
+WalletItems = Dict[str, str]
+WalletInfo = Dict[str, WalletItems]
 
 
 class Coin(TypedDict):
@@ -126,8 +133,8 @@ class Coin(TypedDict):
     bitcore: list[str]
 
 
-Coins = list[Coin]
-CoinBuckets = dict[str, Coins]
+Coins = List[Coin]
+CoinBuckets = Dict[str, Coins]
 
 
 class FidoApp(TypedDict):
@@ -142,7 +149,7 @@ class FidoApp(TypedDict):
     icon: str
 
 
-FidoApps = list[FidoApp]
+FidoApps = List[FidoApp]
 
 
 def load_json(*path: str | Path) -> Any:
@@ -158,7 +165,7 @@ def load_json(*path: str | Path) -> Any:
 # ====== CoinsInfo ======
 
 
-class CoinsInfo(dict[str, Coins]):
+class CoinsInfo(Dict[str, Coins]):
     """Collection of information about all known kinds of coins.
 
     It contains the following lists:

--- a/docs/ci/jobs.md
+++ b/docs/ci/jobs.md
@@ -141,7 +141,7 @@ Bitcoin-only version.
 ## TEST stage - [test.yml](../../ci/test.yml)
 All the tests run test cases on the freshly built emulators from the previous `BUILD` stage.
 
-Consists of **34 jobs** below:
+Consists of **35 jobs** below:
 
 ### [core unit test](https://github.com/trezor/trezor-firmware/blob/master/ci/test.yml#L15)
 Python and rust unit tests, checking TT functionality.
@@ -219,11 +219,13 @@ Persistence tests.
 
 ### [python test](https://github.com/trezor/trezor-firmware/blob/master/ci/test.yml#L600)
 
-### [storage test](https://github.com/trezor/trezor-firmware/blob/master/ci/test.yml#L629)
+### [python support test](https://github.com/trezor/trezor-firmware/blob/master/ci/test.yml#L626)
 
-### [core unix memory profiler](https://github.com/trezor/trezor-firmware/blob/master/ci/test.yml#L653)
+### [storage test](https://github.com/trezor/trezor-firmware/blob/master/ci/test.yml#L636)
 
-### [connect test core](https://github.com/trezor/trezor-firmware/blob/master/ci/test.yml#L677)
+### [core unix memory profiler](https://github.com/trezor/trezor-firmware/blob/master/ci/test.yml#L660)
+
+### [connect test core](https://github.com/trezor/trezor-firmware/blob/master/ci/test.yml#L684)
 
 ---
 ## TEST-HW stage - [test-hw.yml](../../ci/test-hw.yml)

--- a/tests/test_python_support.py
+++ b/tests/test_python_support.py
@@ -1,0 +1,60 @@
+#!/usr/bin/env python3
+"""
+Verifying that all the tools can be run even by older python versions.
+
+Uses `pyright --pythonversion 3.X <path>` output to check for substrings that
+indicate the type-hints in the code are not compatible with this version.
+"""
+
+import os
+import subprocess
+import sys
+from pathlib import Path
+
+HERE = Path(__file__).resolve().parent
+ROOT_DIR = HERE.parent
+
+EXIT_CODE = 0
+
+os.chdir(ROOT_DIR)
+
+versions_to_check = [
+    "3.7",
+    "3.8",
+    "3.9",
+]
+
+dirs_to_check = [
+    "tools",
+    "common",
+    "core/tools",
+]
+
+signs_of_issues = [
+    "is unknown import symbol",  # we need to import some stuff from typing_extensions instead of typing
+    "will generate runtime exception",  # happens when using `dict` or `list` as a type alias
+]
+
+
+def check_directory(path: str, python_version: str) -> None:
+    global EXIT_CODE
+    cmd = (
+        "pyright",
+        "--pythonversion",
+        python_version,
+        path,
+    )
+
+    result = subprocess.run(cmd, stdout=subprocess.PIPE, text=True)
+    for line in result.stdout.splitlines():
+        if any(sign in line for sign in signs_of_issues):
+            print(line)
+            EXIT_CODE = 1
+
+
+for version in versions_to_check:
+    print(f"Checking python version {version}")
+    for dir_to_check in dirs_to_check:
+        check_directory(dir_to_check, version)
+
+sys.exit(EXIT_CODE)

--- a/tools/generate_ci_docs.py
+++ b/tools/generate_ci_docs.py
@@ -16,6 +16,8 @@ Running the script:
 - `python generate_ci_docs.py --check` to check if documentation is up-to-date
 """
 
+from __future__ import annotations
+
 import argparse
 import filecmp
 import os

--- a/tools/pyright_tool.py
+++ b/tools/pyright_tool.py
@@ -46,18 +46,24 @@ import sys
 import tempfile
 from dataclasses import dataclass
 from pathlib import Path
-from typing import TYPE_CHECKING, Any, Final, Iterator, TypedDict
+from typing import Dict  # for python38 support, must be used in type aliases
+from typing import List  # for python38 support, must be used in type aliases
+from typing import TYPE_CHECKING, Any, Iterator
+from typing_extensions import (  # for python37 support, is not present in typing there
+    Final,
+    TypedDict,
+)
 
 import click
 
 if TYPE_CHECKING:
-    LineIgnores = list["LineIgnore"]
+    LineIgnores = List["LineIgnore"]
 
-    FileIgnores = dict[str, LineIgnores]
-    FileSpecificIgnores = dict[str, list["FileSpecificIgnore"]]
+    FileIgnores = Dict[str, LineIgnores]
+    FileSpecificIgnores = Dict[str, List["FileSpecificIgnore"]]
 
-    PyrightOffIgnores = list["PyrightOffIgnore"]
-    FilePyrightOffIgnores = dict[str, PyrightOffIgnores]
+    PyrightOffIgnores = List["PyrightOffIgnore"]
+    FilePyrightOffIgnores = Dict[str, PyrightOffIgnores]
 
 
 class RangeDetail(TypedDict):


### PR DESCRIPTION
Fixes #2305:
- modifying type hints so that even older (`3.7` and `3.8`) python versions understand it
- also the test for this was created and added into `CI`
  - it is currently in the `Test` stage, but could be probably moved to `Prebuild` thanks to its nature (it is not dependent on `Build` and it is very similar to `style prebuild`)

In [this CI](https://gitlab.com/satoshilabs/trezor/trezor-firmware/-/pipelines/549800707) the tests should fail, as it only has the first commit with tests - it is "fixed" in [subsequent CI](https://gitlab.com/satoshilabs/trezor/trezor-firmware/-/pipelines/549805580), so the difference can be seen.