### PR TITLE
Expose BIP-39 wordlist array from trezor-crypto to Rust code

### DIFF
--- a/core/SConscript.firmware
+++ b/core/SConscript.firmware
@@ -65,6 +65,7 @@ SOURCE_MOD += [
     'vendor/trezor-crypto/bignum.c',
     'vendor/trezor-crypto/bip32.c',
     'vendor/trezor-crypto/bip39.c',
+    'vendor/trezor-crypto/bip39_english.c',
     'vendor/trezor-crypto/blake256.c',
     'vendor/trezor-crypto/blake2b.c',
     'vendor/trezor-crypto/blake2s.c',

--- a/core/SConscript.unix
+++ b/core/SConscript.unix
@@ -64,6 +64,7 @@ SOURCE_MOD += [
     'vendor/trezor-crypto/bignum.c',
     'vendor/trezor-crypto/bip32.c',
     'vendor/trezor-crypto/bip39.c',
+    'vendor/trezor-crypto/bip39_english.c',
     'vendor/trezor-crypto/blake256.c',
     'vendor/trezor-crypto/blake2b.c',
     'vendor/trezor-crypto/blake2s.c',

--- a/core/embed/rust/Cargo.lock
+++ b/core/embed/rust/Cargo.lock
@@ -89,9 +89,9 @@ dependencies = [
 
 [[package]]
 name = "cty"
-version = "0.2.1"
+version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7313c0d620d0cb4dbd9d019e461a4beb501071ff46ec0ab933efb4daa76d73e3"
+checksum = "b365fabc795046672053e29c954733ec3b05e4be654ab130fe8f1f94d7051f35"
 
 [[package]]
 name = "funty"

--- a/core/embed/rust/Cargo.toml
+++ b/core/embed/rust/Cargo.toml
@@ -37,7 +37,7 @@ split-debuginfo = "unpacked"
 # Runtime dependencies
 
 [dependencies.cty]
-version = "0.2.1"
+version = "0.2.2"
 
 [dependencies.heapless]
 version = "0.7.3"

--- a/core/embed/rust/src/trezorhal/bip39.rs
+++ b/core/embed/rust/src/trezorhal/bip39.rs
@@ -2,12 +2,12 @@ use core::cmp::Ordering;
 use cstr_core::CStr;
 
 // TODO: expose from trezor-crypto via build.rs
-const BIP39_WORDS: usize = 2048;
+const BIP39_WORD_COUNT: usize = 2048;
 
 extern "C" {
     // trezor-crypto/bip39.h
     fn mnemonic_word_completion_mask(prefix: *const cty::c_char, len: cty::c_int) -> u32;
-    pub static BIP39_WORDLIST_ENGLISH: [*const cty::c_char; BIP39_WORDS];
+    pub static BIP39_WORDLIST_ENGLISH: [*const cty::c_char; BIP39_WORD_COUNT];
 }
 
 unsafe fn from_utf8_unchecked<'a>(word: *const cty::c_char) -> &'a str {
@@ -136,9 +136,9 @@ mod tests {
     #[test]
     fn test_filter_prefix_empty() {
         let words = Wordlist::all().filter_prefix("");
-        assert_eq!(words.len(), BIP39_WORDS);
+        assert_eq!(words.len(), BIP39_WORD_COUNT);
         let iter = words.iter();
-        assert_eq!(iter.size_hint(), (BIP39_WORDS, Some(BIP39_WORDS)));
+        assert_eq!(iter.size_hint(), (BIP39_WORD_COUNT, Some(BIP39_WORD_COUNT)));
     }
 
     #[test]
@@ -171,9 +171,9 @@ mod tests {
     fn test_wordlist_get() {
         let words = Wordlist::all();
         assert_eq!(words.get(0), Some("abandon"));
-        assert_eq!(words.get(BIP39_WORDS - 1), Some("zoo"));
-        assert_eq!(words.get(BIP39_WORDS), None);
-        assert_eq!(words.get(BIP39_WORDS + 1), None);
+        assert_eq!(words.get(BIP39_WORD_COUNT - 1), Some("zoo"));
+        assert_eq!(words.get(BIP39_WORD_COUNT), None);
+        assert_eq!(words.get(BIP39_WORD_COUNT + 1), None);
 
         let filtered = words.filter_prefix("str");
         assert_eq!(filtered.get(0), Some("strategy"));

--- a/core/embed/rust/src/trezorhal/bip39.rs
+++ b/core/embed/rust/src/trezorhal/bip39.rs
@@ -1,25 +1,48 @@
+use core::cmp::Ordering;
 use cstr_core::CStr;
+
+// TODO: expose from trezor-crypto via build.rs
+const BIP39_WORDS: usize = 2048;
 
 extern "C" {
     // trezor-crypto/bip39.h
-    fn mnemonic_complete_word(prefix: *const cty::c_char, len: cty::c_int) -> *const cty::c_char;
     fn mnemonic_word_completion_mask(prefix: *const cty::c_char, len: cty::c_int) -> u32;
+    pub static BIP39_WORDLIST_ENGLISH: [*const cty::c_char; BIP39_WORDS];
+}
+
+unsafe fn from_utf8_unchecked<'a>(word: *const cty::c_char) -> &'a str {
+    // SAFETY: caller must pass a valid 0-terminated UTF-8 string.
+    // This assumption holds for usage on words of the BIP-39 wordlist.
+    unsafe {
+        let word = CStr::from_ptr(word);
+        core::str::from_utf8_unchecked(word.to_bytes())
+    }
+}
+
+/// Compare word from wordlist to a prefix.
+///
+/// The comparison returns Less if the word comes lexicographically before all
+/// possible words starting with `prefix`, and Greater if it comes after.
+/// Equal is returned if the word starts with `prefix`.
+unsafe fn prefix_cmp(prefix: &str, word: *const cty::c_char) -> Ordering {
+    // SAFETY: we assume `word` is a pointer to a 0-terminated string.
+    for (i, prefix_char) in prefix.as_bytes().iter().enumerate() {
+        let word_char = unsafe { *(word.add(i)) } as u8;
+        if word_char == 0 {
+            // Prefix is longer than word.
+            return Ordering::Less;
+        } else if *prefix_char != word_char {
+            return word_char.cmp(prefix_char);
+        }
+    }
+    Ordering::Equal
 }
 
 pub fn complete_word(prefix: &str) -> Option<&'static str> {
     if prefix.is_empty() {
         None
     } else {
-        // SAFETY: `mnemonic_complete_word` shouldn't retain nor modify the passed byte
-        // string, making the call safe.
-        let word = unsafe { mnemonic_complete_word(prefix.as_ptr() as _, prefix.len() as _) };
-        if word.is_null() {
-            None
-        } else {
-            // SAFETY: On success, `mnemonic_complete_word` should return a 0-terminated
-            // UTF-8 string with static lifetime.
-            Some(unsafe { CStr::from_ptr(word).to_str().unwrap_unchecked() })
-        }
+        Wordlist::all().filter_prefix(prefix).iter().next()
     }
 }
 
@@ -27,4 +50,143 @@ pub fn word_completion_mask(prefix: &str) -> u32 {
     // SAFETY: `mnemonic_word_completion_mask` shouldn't retain nor modify the
     // passed byte string, making the call safe.
     unsafe { mnemonic_word_completion_mask(prefix.as_ptr() as _, prefix.len() as _) }
+}
+
+pub struct Wordlist(&'static [*const cty::c_char]);
+
+impl Wordlist {
+    pub fn all() -> Self {
+        Self(unsafe { &BIP39_WORDLIST_ENGLISH })
+    }
+
+    pub const fn empty() -> Self {
+        Self(&[])
+    }
+
+    pub fn filter_prefix(&self, prefix: &str) -> Self {
+        let mut start = 0usize;
+        let mut end = self.0.len();
+        for (i, word) in self.0.iter().enumerate() {
+            // SAFETY: We assume our slice is an array of 0-terminated strings.
+            match unsafe { prefix_cmp(prefix, *word) } {
+                Ordering::Less => {
+                    start = i + 1;
+                }
+                Ordering::Greater => {
+                    end = i;
+                    break;
+                }
+                _ => {}
+            }
+        }
+        Self(&self.0[start..end])
+    }
+
+    pub fn get(&self, index: usize) -> Option<&'static str> {
+        // SAFETY: we assume every word in the wordlist is a valid 0-terminated UTF-8
+        // string.
+        self.0
+            .get(index)
+            .map(|word| unsafe { from_utf8_unchecked(*word) })
+    }
+
+    pub const fn len(&self) -> usize {
+        self.0.len()
+    }
+
+    pub fn iter(&self) -> impl Iterator<Item = &'static str> {
+        self.0
+            .iter()
+            .map(|word| unsafe { from_utf8_unchecked(*word) })
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_prefix_cmp() {
+        assert_eq!(unsafe { prefix_cmp("", "".as_ptr() as _) }, Ordering::Equal);
+
+        assert_eq!(unsafe { prefix_cmp("b", "".as_ptr() as _) }, Ordering::Less);
+        assert_eq!(
+            unsafe { prefix_cmp("b", "a".as_ptr() as _) },
+            Ordering::Less
+        );
+        assert_eq!(
+            unsafe { prefix_cmp("b", "b".as_ptr() as _) },
+            Ordering::Equal
+        );
+        assert_eq!(
+            unsafe { prefix_cmp("b", "below".as_ptr() as _) },
+            Ordering::Equal
+        );
+        assert_eq!(
+            unsafe { prefix_cmp("b", "c".as_ptr() as _) },
+            Ordering::Greater
+        );
+
+        assert_eq!(
+            unsafe { prefix_cmp("bartender", "bar".as_ptr() as _) },
+            Ordering::Less
+        );
+    }
+
+    #[test]
+    fn test_filter_prefix_empty() {
+        let words = Wordlist::all().filter_prefix("");
+        assert_eq!(words.len(), BIP39_WORDS);
+        let iter = words.iter();
+        assert_eq!(iter.size_hint(), (BIP39_WORDS, Some(BIP39_WORDS)));
+    }
+
+    #[test]
+    fn test_filter_prefix() {
+        let expected_result = vec!["strategy", "street", "strike", "strong", "struggle"];
+        let result = Wordlist::all()
+            .filter_prefix("str")
+            .iter()
+            .collect::<Vec<_>>();
+        assert_eq!(result, expected_result);
+    }
+
+    #[test]
+    fn test_filter_prefix_refine() {
+        let expected_result = vec!["strategy", "street", "strike", "strong", "struggle"];
+        let words = Wordlist::all().filter_prefix("st");
+        let result_a = words.filter_prefix("str").iter().collect::<Vec<_>>();
+        let result_b = Wordlist::all()
+            .filter_prefix("str")
+            .iter()
+            .collect::<Vec<_>>();
+        assert_eq!(result_a, expected_result);
+        assert_eq!(result_b, expected_result);
+
+        let empty = words.filter_prefix("c");
+        assert_eq!(empty.len(), 0);
+    }
+
+    #[test]
+    fn test_wordlist_get() {
+        let words = Wordlist::all();
+        assert_eq!(words.get(0), Some("abandon"));
+        assert_eq!(words.get(BIP39_WORDS - 1), Some("zoo"));
+        assert_eq!(words.get(BIP39_WORDS), None);
+        assert_eq!(words.get(BIP39_WORDS + 1), None);
+
+        let filtered = words.filter_prefix("str");
+        assert_eq!(filtered.get(0), Some("strategy"));
+        assert_eq!(filtered.get(filtered.len()), None);
+    }
+
+    #[test]
+    fn test_filter_prefix_just_one() {
+        let expected_result = vec!["stick"];
+        let result = Wordlist::all()
+            .filter_prefix("stick")
+            .iter()
+            .collect::<Vec<_>>();
+        assert_eq!(result, expected_result);
+    }
 }

--- a/crypto/Makefile
+++ b/crypto/Makefile
@@ -1,5 +1,5 @@
 # CLANG_VERSION is empty if the compiler is not clang-based
-CLANG_VERSION = $(shell $(CC) --version | grep -Po "clang version \K[\d\.]+")
+CLANG_VERSION = $(shell $(CC) --version | sed -nr 's/^.*clang version ([0-9.]+).*$$/\1/p')
 CLANG_VERSION_MAJOR = $(shell echo $(CLANG_VERSION) | cut -f1 -d.)
 
 # determine specific version ranges

--- a/crypto/Makefile
+++ b/crypto/Makefile
@@ -98,7 +98,7 @@ ifdef SMALL
 CFLAGS += -DUSE_PRECOMPUTED_CP=0
 endif
 
-SRCS   = bignum.c ecdsa.c curves.c secp256k1.c nist256p1.c rand.c hmac.c bip32.c bip39.c pbkdf2.c base58.c base32.c
+SRCS   = bignum.c ecdsa.c curves.c secp256k1.c nist256p1.c rand.c hmac.c bip32.c bip39.c bip39_english.c pbkdf2.c base58.c base32.c
 SRCS  += address.c
 SRCS  += script.c
 SRCS  += ripemd160.c

--- a/crypto/bip39.c
+++ b/crypto/bip39.c
@@ -242,7 +242,7 @@ void mnemonic_to_seed(const char *mnemonic, const char *passphrase,
 
 // binary search for finding the word in the wordlist
 int mnemonic_find_word(const char *word) {
-  int lo = 0, hi = BIP39_WORDS - 1;
+  int lo = 0, hi = BIP39_WORD_COUNT - 1;
   while (lo <= hi) {
     int mid = lo + (hi - lo) / 2;
     int cmp = strcmp(word, BIP39_WORDLIST_ENGLISH[mid]);
@@ -261,7 +261,7 @@ int mnemonic_find_word(const char *word) {
 const char *mnemonic_complete_word(const char *prefix, int len) {
   // we need to perform linear search,
   // because we want to return the first match
-  for (int i = 0; i < BIP39_WORDS; i++) {
+  for (int i = 0; i < BIP39_WORD_COUNT; i++) {
     if (strncmp(BIP39_WORDLIST_ENGLISH[i], prefix, len) == 0) {
       return BIP39_WORDLIST_ENGLISH[i];
     }
@@ -270,7 +270,7 @@ const char *mnemonic_complete_word(const char *prefix, int len) {
 }
 
 const char *mnemonic_get_word(int index) {
-  if (index >= 0 && index < BIP39_WORDS) {
+  if (index >= 0 && index < BIP39_WORD_COUNT) {
     return BIP39_WORDLIST_ENGLISH[index];
   } else {
     return NULL;
@@ -282,7 +282,7 @@ uint32_t mnemonic_word_completion_mask(const char *prefix, int len) {
     return 0x3ffffff;  // all letters (bits 1-26 set)
   }
   uint32_t res = 0;
-  for (int i = 0; i < BIP39_WORDS; i++) {
+  for (int i = 0; i < BIP39_WORD_COUNT; i++) {
     const char *word = BIP39_WORDLIST_ENGLISH[i];
     if (strncmp(word, prefix, len) == 0 && word[len] >= 'a' &&
         word[len] <= 'z') {

--- a/crypto/bip39.c
+++ b/crypto/bip39.c
@@ -25,7 +25,6 @@
 #include <string.h>
 
 #include "bip39.h"
-#include "bip39_english.h"
 #include "hmac.h"
 #include "memzero.h"
 #include "options.h"
@@ -87,8 +86,8 @@ const char *mnemonic_from_data(const uint8_t *data, int len) {
       idx <<= 1;
       idx += (bits[(i * 11 + j) / 8] & (1 << (7 - ((i * 11 + j) % 8)))) > 0;
     }
-    strcpy(p, wordlist[idx]);
-    p += strlen(wordlist[idx]);
+    strcpy(p, BIP39_WORDLIST_ENGLISH[idx]);
+    p += strlen(BIP39_WORDLIST_ENGLISH[idx]);
     *p = (i < mlen - 1) ? ' ' : 0;
     p++;
   }
@@ -144,10 +143,11 @@ int mnemonic_to_bits(const char *mnemonic, uint8_t *bits) {
     }
     k = 0;
     for (;;) {
-      if (!wordlist[k]) {  // word not found
+      if (!BIP39_WORDLIST_ENGLISH[k]) {  // word not found
         return 0;
       }
-      if (strcmp(current_word, wordlist[k]) == 0) {  // word found on index k
+      if (strcmp(current_word, BIP39_WORDLIST_ENGLISH[k]) ==
+          0) {  // word found on index k
         for (ki = 0; ki < 11; ki++) {
           if (k & (1 << (10 - ki))) {
             result[bi / 8] |= 1 << (7 - (bi % 8));
@@ -245,7 +245,7 @@ int mnemonic_find_word(const char *word) {
   int lo = 0, hi = BIP39_WORDS - 1;
   while (lo <= hi) {
     int mid = lo + (hi - lo) / 2;
-    int cmp = strcmp(word, wordlist[mid]);
+    int cmp = strcmp(word, BIP39_WORDLIST_ENGLISH[mid]);
     if (cmp == 0) {
       return mid;
     }
@@ -261,9 +261,9 @@ int mnemonic_find_word(const char *word) {
 const char *mnemonic_complete_word(const char *prefix, int len) {
   // we need to perform linear search,
   // because we want to return the first match
-  for (const char *const *w = wordlist; *w != 0; w++) {
-    if (strncmp(*w, prefix, len) == 0) {
-      return *w;
+  for (int i = 0; i < BIP39_WORDS; i++) {
+    if (strncmp(BIP39_WORDLIST_ENGLISH[i], prefix, len) == 0) {
+      return BIP39_WORDLIST_ENGLISH[i];
     }
   }
   return NULL;
@@ -271,7 +271,7 @@ const char *mnemonic_complete_word(const char *prefix, int len) {
 
 const char *mnemonic_get_word(int index) {
   if (index >= 0 && index < BIP39_WORDS) {
-    return wordlist[index];
+    return BIP39_WORDLIST_ENGLISH[index];
   } else {
     return NULL;
   }
@@ -282,8 +282,8 @@ uint32_t mnemonic_word_completion_mask(const char *prefix, int len) {
     return 0x3ffffff;  // all letters (bits 1-26 set)
   }
   uint32_t res = 0;
-  for (const char *const *w = wordlist; *w != 0; w++) {
-    const char *word = *w;
+  for (int i = 0; i < BIP39_WORDS; i++) {
+    const char *word = BIP39_WORDLIST_ENGLISH[i];
     if (strncmp(word, prefix, len) == 0 && word[len] >= 'a' &&
         word[len] <= 'z') {
       res |= 1 << (word[len] - 'a');

--- a/crypto/bip39.h
+++ b/crypto/bip39.h
@@ -36,6 +36,8 @@
 void bip39_cache_clear(void);
 #endif
 
+extern const char *const BIP39_WORDLIST_ENGLISH[BIP39_WORDS];
+
 const char *mnemonic_generate(int strength);  // strength in bits
 const char *mnemonic_from_data(const uint8_t *data, int len);
 void mnemonic_clear(void);

--- a/crypto/bip39.h
+++ b/crypto/bip39.h
@@ -29,14 +29,14 @@
 
 #include "options.h"
 
-#define BIP39_WORDS 2048
+#define BIP39_WORD_COUNT 2048
 #define BIP39_PBKDF2_ROUNDS 2048
 
 #if USE_BIP39_CACHE
 void bip39_cache_clear(void);
 #endif
 
-extern const char *const BIP39_WORDLIST_ENGLISH[BIP39_WORDS];
+extern const char *const BIP39_WORDLIST_ENGLISH[BIP39_WORD_COUNT];
 
 const char *mnemonic_generate(int strength);  // strength in bits
 const char *mnemonic_from_data(const uint8_t *data, int len);

--- a/crypto/bip39_english.c
+++ b/crypto/bip39_english.c
@@ -21,7 +21,9 @@
  * OTHER DEALINGS IN THE SOFTWARE.
  */
 
-static const char* const wordlist[] = {
+#include "bip39.h"
+
+const char* const BIP39_WORDLIST_ENGLISH[BIP39_WORDS] = {
     "abandon",  "ability",  "able",     "about",    "above",    "absent",
     "absorb",   "abstract", "absurd",   "abuse",    "access",   "accident",
     "account",  "accuse",   "achieve",  "acid",     "acoustic", "acquire",
@@ -363,5 +365,5 @@ static const char* const wordlist[] = {
     "work",     "world",    "worry",    "worth",    "wrap",     "wreck",
     "wrestle",  "wrist",    "write",    "wrong",    "yard",     "year",
     "yellow",   "you",      "young",    "youth",    "zebra",    "zero",
-    "zone",     "zoo",      0,
+    "zone",     "zoo",
 };

--- a/crypto/bip39_english.c
+++ b/crypto/bip39_english.c
@@ -23,7 +23,7 @@
 
 #include "bip39.h"
 
-const char* const BIP39_WORDLIST_ENGLISH[BIP39_WORDS] = {
+const char* const BIP39_WORDLIST_ENGLISH[BIP39_WORD_COUNT] = {
     "abandon",  "ability",  "able",     "about",    "above",    "absent",
     "absorb",   "abstract", "absurd",   "abuse",    "access",   "accident",
     "account",  "accuse",   "achieve",  "acid",     "acoustic", "acquire",

--- a/crypto/gui/gui.pro
+++ b/crypto/gui/gui.pro
@@ -7,6 +7,7 @@ TEMPLATE = app
 SOURCES += ../address.c
 SOURCES += ../bip32.c
 SOURCES += ../bip39.c
+SOURCES += ../bip39_english.c
 SOURCES += ../sha2.c
 SOURCES += ../pbkdf2.c
 SOURCES += ../hmac.c

--- a/crypto/tests/test_check.c
+++ b/crypto/tests/test_check.c
@@ -5603,7 +5603,7 @@ END_TEST
 START_TEST(test_mnemonic_find_word) {
   ck_assert_int_eq(-1, mnemonic_find_word("aaaa"));
   ck_assert_int_eq(-1, mnemonic_find_word("zzzz"));
-  for (int i = 0; i < BIP39_WORDS; i++) {
+  for (int i = 0; i < BIP39_WORD_COUNT; i++) {
     const char *word = mnemonic_get_word(i);
     int index = mnemonic_find_word(word);
     ck_assert_int_eq(i, index);

--- a/legacy/demo/Makefile
+++ b/legacy/demo/Makefile
@@ -14,6 +14,7 @@ OBJS += ../vendor/trezor-crypto/ripemd160.o
 OBJS += ../vendor/trezor-crypto/secp256k1.o
 OBJS += ../vendor/trezor-crypto/sha2.o
 OBJS += ../vendor/trezor-crypto/bip39.o
+OBJS += ../vendor/trezor-crypto/bip39_english.o
 OBJS += ../vendor/trezor-crypto/pbkdf2.o
 OBJS += ../vendor/trezor-crypto/memzero.o
 

--- a/legacy/firmware/Makefile
+++ b/legacy/firmware/Makefile
@@ -93,6 +93,7 @@ OBJS += ../vendor/trezor-crypto/ed25519-donna/ed25519-keccak.o
 OBJS += ../vendor/trezor-crypto/hmac.o
 OBJS += ../vendor/trezor-crypto/bip32.o
 OBJS += ../vendor/trezor-crypto/bip39.o
+OBJS += ../vendor/trezor-crypto/bip39_english.o
 OBJS += ../vendor/trezor-crypto/pbkdf2.o
 OBJS += ../vendor/trezor-crypto/base32.o
 OBJS += ../vendor/trezor-crypto/base58.o

--- a/legacy/firmware/recovery.c
+++ b/legacy/firmware/recovery.c
@@ -451,7 +451,7 @@ void next_word(void) {
   oledDrawStringCenter(OLED_WIDTH / 2, 8, _("Please enter"), FONT_STANDARD);
   word_pos = word_order[word_index];
   if (word_pos == 0) {
-    strlcpy(fake_word, mnemonic_get_word(random_uniform(BIP39_WORDS)),
+    strlcpy(fake_word, mnemonic_get_word(random_uniform(BIP39_WORD_COUNT)),
             sizeof(fake_word));
     oledDrawStringCenter(OLED_WIDTH / 2, 24, fake_word,
                          FONT_FIXED | FONT_DOUBLE);


### PR DESCRIPTION
For Trezor R, we need to be able to refine subsets of the wordlist, which is difficult to do without having the wordlist. We _could_ repeatedly call `mnemonic_get_word(i)` but that seems pointless.

Is there any particular reason the wordlist was not exposed in the original code?

tagging @andrewkozlik or @onvej-sl for review of the crypto-side changes
@mmilata and @grdddj for review of the Rust part