### PR TITLE
fix(xmr): Remove inv8 optimization as in xmr master

### DIFF
--- a/ci/shell.nix
+++ b/ci/shell.nix
@@ -19,8 +19,8 @@ let
     sha256 = "02s3qkb6kz3ndyx7rfndjbvp4vlwiqc42fxypn3g6jnc0v5jyz95";
   }) { };
   moneroTests = nixpkgs.fetchurl {
-    url = "https://github.com/ph4r05/monero/releases/download/v0.17.3.2-dev-tests-u18.04-01/trezor_tests";
-    sha256 = "a9f5ac4f0ea908a132d1b1d2a49917ac35ca2a7166fb5178498f3342329d0a5c";
+    url = "https://github.com/ph4r05/monero/releases/download/v0.17.3.2-dev-tests-u18.04-02/trezor_tests";
+    sha256 = "f790ad7485cbbad92fbea673a75935028f61d42f64627a7c55f850f6742cf93a";
   };
   moneroTestsPatched = nixpkgs.runCommandCC "monero_trezor_tests" {} ''
     cp ${moneroTests} $out

--- a/core/src/apps/monero/signing/step_06_set_output.py
+++ b/core/src/apps/monero/signing/step_06_set_output.py
@@ -460,16 +460,7 @@ def _get_ecdh_info_and_out_pk(
     so the recipient is able to reconstruct the commitment.
     """
     out_pk_dest = crypto_helpers.encodepoint(tx_out_key)
-    if state.rsig_is_bp_plus:
-        # HF15+ stores commitment multiplied by 8**-1
-        inv8 = crypto.decodeint_into_noreduce(None, crypto_helpers.INV_EIGHT)
-        mask8 = crypto.sc_mul_into(None, mask, inv8)
-        amnt8 = crypto.Scalar(amount)
-        amnt8 = crypto.sc_mul_into(amnt8, amnt8, inv8)
-        out_pk_commitment = crypto.add_keys2_into(None, mask8, amnt8, crypto.xmr_H())
-        del (inv8, mask8, amnt8)
-    else:
-        out_pk_commitment = crypto.gen_commitment_into(None, mask, amount)
+    out_pk_commitment = crypto.gen_commitment_into(None, mask, amount)
 
     out_pk_commitment = crypto_helpers.encodepoint(out_pk_commitment)
     crypto.sc_add_into(state.sumout, state.sumout, mask)

--- a/core/tests/run_tests_device_emu_monero.sh
+++ b/core/tests/run_tests_device_emu_monero.sh
@@ -23,8 +23,8 @@ fi
 
 # When updating URL and sha256sum also update the URL in ci/shell.nix.
 error=1
-: "${TREZOR_MONERO_TESTS_URL:=https://github.com/ph4r05/monero/releases/download/v0.17.3.0-dev-tests/trezor_tests}"
-: "${TREZOR_MONERO_TESTS_SHA256SUM:=b534137bf624ea8511abb183384a2d27b6365290a0cae539a1d8c41cd4ccae61}"
+: "${TREZOR_MONERO_TESTS_URL:=https://github.com/ph4r05/monero/releases/download/v0.17.3.2-dev-tests-u18.04-02/trezor_tests}"
+: "${TREZOR_MONERO_TESTS_SHA256SUM:=f790ad7485cbbad92fbea673a75935028f61d42f64627a7c55f850f6742cf93a}"
 : "${TREZOR_MONERO_TESTS_PATH:=$CORE_DIR/tests/trezor_monero_tests}"
 : "${TREZOR_MONERO_TESTS_LOG:=$CORE_DIR/tests/trezor_monero_tests.log}"
 : "${TREZOR_MONERO_TESTS_CHAIN:=$CORE_DIR/tests/trezor_monero_tests.chain}"


### PR DESCRIPTION
I was notified that Monero changed a BP+ result format in this PR: https://github.com/monero-project/monero/pull/8277

As it affects XMR transaction signing, we have to adapt to the change. Corresponding changes in the Trezor-client code in the XMR wallet are already incorporated in the https://github.com/monero-project/monero/pull/8299

I will send a testing binary once I manage to build it (should be soon).

PR is related to the:
- https://github.com/trezor/trezor-firmware/pull/2232
- https://github.com/trezor/trezor-firmware/pull/2219
- https://github.com/monero-project/monero/pull/8299
- https://github.com/monero-project/monero/pull/8277