### PR TITLE
Expose raw pixel access to rust

### DIFF
--- a/core/.changelog.d/2297.added
+++ b/core/.changelog.d/2297.added
@@ -1,0 +1,1 @@
+Expose raw pixel access to Rust

--- a/core/embed/extmod/modtrezorui/display-stm32_1.h
+++ b/core/embed/extmod/modtrezorui/display-stm32_1.h
@@ -68,7 +68,7 @@ static struct {
 
 static bool pixeldata_dirty = true;
 
-void PIXELDATA(uint16_t c) {
+void display_pixeldata(uint16_t c) {
   if (PIXELWINDOW.pos.x <= PIXELWINDOW.end.x &&
       PIXELWINDOW.pos.y <= PIXELWINDOW.end.y) {
     // set to white if highest bits of all R, G, B values are set to 1
@@ -89,12 +89,13 @@ void PIXELDATA(uint16_t c) {
   }
 }
 
+#define PIXELDATA(c) display_pixeldata(c)
+
 static void display_reset_state() {}
 
 void PIXELDATA_DIRTY() { pixeldata_dirty = true; }
 
-static void display_set_window(uint16_t x0, uint16_t y0, uint16_t x1,
-                               uint16_t y1) {
+void display_set_window(uint16_t x0, uint16_t y0, uint16_t x1, uint16_t y1) {
   PIXELWINDOW.start.x = x0;
   PIXELWINDOW.start.y = y0;
   PIXELWINDOW.end.x = x1;

--- a/core/embed/extmod/modtrezorui/display-stm32_R.h
+++ b/core/embed/extmod/modtrezorui/display-stm32_R.h
@@ -57,7 +57,7 @@ static void display_set_page_and_col(uint8_t page, uint8_t col) {
   }
 }
 
-void PIXELDATA(uint16_t c) {
+void display_pixeldata(uint16_t c) {
   uint8_t data = DISPLAY_STATE.RAM[DISPLAY_STATE.row / 8][DISPLAY_STATE.col];
 
   uint8_t bit = 1 << (DISPLAY_STATE.row % 8);
@@ -93,6 +93,8 @@ void PIXELDATA(uint16_t c) {
   }
 }
 
+#define PIXELDATA(c) display_pixeldata(c)
+
 static void display_reset_state(void) {
   memset(DISPLAY_STATE.RAM, 0, sizeof(DISPLAY_STATE.RAM));
   DISPLAY_STATE.row = 0;
@@ -115,8 +117,7 @@ static void display_unsleep(void) {
   CMD(0xAF);                                           // Display ON
 }
 
-static void display_set_window(uint16_t x0, uint16_t y0, uint16_t x1,
-                               uint16_t y1) {
+void display_set_window(uint16_t x0, uint16_t y0, uint16_t x1, uint16_t y1) {
   if (x1 >= DISPLAY_RESX) {
     x1 = DISPLAY_RESX - 1;
   }

--- a/core/embed/extmod/modtrezorui/display-stm32_T.h
+++ b/core/embed/extmod/modtrezorui/display-stm32_T.h
@@ -30,11 +30,14 @@ const volatile uint8_t DISPLAY_ST7789V_INVERT_COLORS = 0;
 #define DISPLAY_MEMORY_BASE 0x60000000
 #define DISPLAY_MEMORY_PIN 16
 
-#define CMD(X) (*((__IO uint8_t *)((uint32_t)(DISPLAY_MEMORY_BASE))) = (X))
-#define ADDR                                           \
-  (*((__IO uint8_t *)((uint32_t)(DISPLAY_MEMORY_BASE | \
-                                 (1 << DISPLAY_MEMORY_PIN)))))
-#define DATA(X) (ADDR) = (X)
+__IO uint8_t *const DISPLAY_CMD_ADDRESS =
+    (__IO uint8_t *const)((uint32_t)DISPLAY_MEMORY_BASE);
+__IO uint8_t *const DISPLAY_DATA_ADDRESS =
+    (__IO uint8_t *const)((uint32_t)DISPLAY_MEMORY_BASE |
+                          (1 << DISPLAY_MEMORY_PIN));
+
+#define CMD(X) (*DISPLAY_CMD_ADDRESS = (X))
+#define DATA(X) (*DISPLAY_DATA_ADDRESS = (X))
 #define PIXELDATA(X) \
   DATA((X) >> 8);    \
   DATA((X)&0xFF)
@@ -62,12 +65,13 @@ static uint32_t read_display_id(uint8_t command) {
   volatile uint8_t c = 0;
   uint32_t id = 0;
   CMD(command);
-  c = ADDR;  // first returned value is a dummy value and should be discarded
-  c = ADDR;
+  c = *DISPLAY_DATA_ADDRESS;  // first returned value is a dummy value and
+                              // should be discarded
+  c = *DISPLAY_DATA_ADDRESS;
   id |= (c << 16);
-  c = ADDR;
+  c = *DISPLAY_DATA_ADDRESS;
   id |= (c << 8);
-  c = ADDR;
+  c = *DISPLAY_DATA_ADDRESS;
   id |= c;
   return id;
 }

--- a/core/embed/extmod/modtrezorui/display-stm32_T.h
+++ b/core/embed/extmod/modtrezorui/display-stm32_T.h
@@ -56,6 +56,8 @@ const volatile uint8_t DISPLAY_ST7789V_INVERT_COLORS = 0;
 // of ILI9341V datasheet
 #define DISPLAY_ID_ILI9341V 0x009341U
 
+void display_pixeldata(uint16_t c) { PIXELDATA(c); }
+
 static uint32_t read_display_id(uint8_t command) {
   volatile uint8_t c = 0;
   uint32_t id = 0;
@@ -117,8 +119,7 @@ static void display_unsleep(void) {
 
 static struct { uint16_t x, y; } BUFFER_OFFSET;
 
-static void display_set_window(uint16_t x0, uint16_t y0, uint16_t x1,
-                               uint16_t y1) {
+void display_set_window(uint16_t x0, uint16_t y0, uint16_t x1, uint16_t y1) {
   x0 += BUFFER_OFFSET.x;
   x1 += BUFFER_OFFSET.x;
   y0 += BUFFER_OFFSET.y;

--- a/core/embed/extmod/modtrezorui/display-unix.h
+++ b/core/embed/extmod/modtrezorui/display-unix.h
@@ -75,7 +75,7 @@ static struct {
 // noop on unix, display is refreshed every loop step
 #define PIXELDATA_DIRTY()
 
-void PIXELDATA(uint16_t c) {
+void display_pixeldata(uint16_t c) {
 #if defined TREZOR_MODEL_1 || defined TREZOR_MODEL_R
   // set to white if highest bits of all R, G, B values are set to 1
   // bin(10000 100000 10000) = hex(0x8410)
@@ -97,6 +97,8 @@ void PIXELDATA(uint16_t c) {
     PIXELWINDOW.pos.y++;
   }
 }
+
+#define PIXELDATA(c) display_pixeldata(c)
 
 static void display_reset_state() {}
 
@@ -208,8 +210,7 @@ void display_init(void) {
 #endif
 }
 
-static void display_set_window(uint16_t x0, uint16_t y0, uint16_t x1,
-                               uint16_t y1) {
+void display_set_window(uint16_t x0, uint16_t y0, uint16_t x1, uint16_t y1) {
   if (!RENDERER) {
     display_init();
   }

--- a/core/embed/extmod/modtrezorui/display.c
+++ b/core/embed/extmod/modtrezorui/display.c
@@ -989,3 +989,5 @@ void display_utf8_substr(const char *buf_start, size_t buf_len, int char_off,
   *out_start = buf_start + i_start;
   *out_len = i - i_start;
 }
+
+void display_pixeldata_dirty(void) { PIXELDATA_DIRTY(); }

--- a/core/embed/extmod/modtrezorui/display.h
+++ b/core/embed/extmod/modtrezorui/display.h
@@ -140,4 +140,14 @@ void display_fade(int start, int end, int delay);
 void display_utf8_substr(const char *buf_start, size_t buf_len, int char_off,
                          int char_len, const char **out_start, int *out_len);
 
+// pixeldata accessors
+void display_set_window(uint16_t x0, uint16_t y0, uint16_t x1, uint16_t y1);
+void display_pixeldata(uint16_t c);
+void display_pixeldata_dirty();
+
+#if !(defined EMULATOR) && (defined TREZOR_MODEL_T)
+extern volatile uint8_t *const DISPLAY_CMD_ADDRESS;
+extern volatile uint8_t *const DISPLAY_DATA_ADDRESS;
+#endif
+
 #endif

--- a/core/embed/rust/src/trezorhal/display.rs
+++ b/core/embed/rust/src/trezorhal/display.rs
@@ -108,6 +108,17 @@ pub fn loader(
     }
 }
 
+#[inline(always)]
+#[cfg(all(feature = "model_tt", target_arch = "arm"))]
+pub fn pixeldata(c: u16) {
+    unsafe {
+        ffi::DISPLAY_DATA_ADDRESS.write_volatile((c >> 8) as u8);
+        ffi::DISPLAY_DATA_ADDRESS.write_volatile((c & 0xff) as u8);
+    }
+}
+
+#[inline(always)]
+#[cfg(not(all(feature = "model_tt", target_arch = "arm")))]
 pub fn pixeldata(c: u16) {
     unsafe {
         ffi::display_pixeldata(c);

--- a/core/embed/rust/src/trezorhal/display.rs
+++ b/core/embed/rust/src/trezorhal/display.rs
@@ -107,3 +107,21 @@ pub fn loader(
         );
     }
 }
+
+pub fn pixeldata(c: u16) {
+    unsafe {
+        ffi::display_pixeldata(c);
+    }
+}
+
+pub fn pixeldata_dirty() {
+    unsafe {
+        ffi::display_pixeldata_dirty();
+    }
+}
+
+pub fn set_window(x0: u16, y0: u16, x1: u16, y1: u16) {
+    unsafe {
+        ffi::display_set_window(x0, y0, x1, y1);
+    }
+}

--- a/core/embed/rust/src/ui/display.rs
+++ b/core/embed/rust/src/ui/display.rs
@@ -183,6 +183,23 @@ pub fn text_right(baseline: Point, text: &str, font: Font, fg_color: Color, bg_c
     );
 }
 
+pub fn pixeldata(color: Color) {
+    display::pixeldata(color.into());
+}
+
+pub fn pixeldata_dirty() {
+    display::pixeldata_dirty();
+}
+
+pub fn set_window(window: Rect) {
+    display::set_window(
+        window.x0 as u16,
+        window.y0 as u16,
+        window.x1 as u16 - 1,
+        window.y1 as u16 - 1,
+    );
+}
+
 #[derive(Copy, Clone, PartialEq, Eq)]
 pub struct Font(i32);
 

--- a/core/embed/rust/src/ui/display.rs
+++ b/core/embed/rust/src/ui/display.rs
@@ -183,6 +183,7 @@ pub fn text_right(baseline: Point, text: &str, font: Font, fg_color: Color, bg_c
     );
 }
 
+#[inline(always)]
 pub fn pixeldata(color: Color) {
     display::pixeldata(color.into());
 }


### PR DESCRIPTION
Exposing to Rust functions needed for raw pixel access: pixeldata, pixeldata_dirty and set_window

Solves #2297 