### PR TITLE
chore(common/defs): remove consensus_branch_id from coin defintions

### DIFF
--- a/common/defs/bitcoin/actinium.json
+++ b/common/defs/bitcoin/actinium.json
@@ -37,7 +37,7 @@
   "max_address_length": 34,
   "negative_fee": false,
   "cooldown": 100,
-  "consensus_branch_id": null,
+  "overwintered": false,
   "extra_data": false,
   "timestamp": false,
   "confidential_assets": null

--- a/common/defs/bitcoin/axe.json
+++ b/common/defs/bitcoin/axe.json
@@ -37,7 +37,7 @@
   "max_address_length": 34,
   "negative_fee": false,
   "cooldown": 100,
-  "consensus_branch_id": null,
+  "overwintered": false,
   "extra_data": false,
   "timestamp": false,
   "confidential_assets": null

--- a/common/defs/bitcoin/bcash.json
+++ b/common/defs/bitcoin/bcash.json
@@ -40,7 +40,7 @@
   "max_address_length": 34,
   "negative_fee": false,
   "cooldown": 100,
-  "consensus_branch_id": null,
+  "overwintered": false,
   "extra_data": false,
   "timestamp": false,
   "confidential_assets": null

--- a/common/defs/bitcoin/bcash_testnet.json
+++ b/common/defs/bitcoin/bcash_testnet.json
@@ -37,7 +37,7 @@
   "max_address_length": 34,
   "negative_fee": false,
   "cooldown": 100,
-  "consensus_branch_id": null,
+  "overwintered": false,
   "extra_data": false,
   "timestamp": false,
   "confidential_assets": null

--- a/common/defs/bitcoin/bgold.json
+++ b/common/defs/bitcoin/bgold.json
@@ -40,7 +40,7 @@
   "max_address_length": 34,
   "negative_fee": false,
   "cooldown": 100,
-  "consensus_branch_id": null,
+  "overwintered": false,
   "extra_data": false,
   "timestamp": false,
   "confidential_assets": null

--- a/common/defs/bitcoin/bgold_testnet.json
+++ b/common/defs/bitcoin/bgold_testnet.json
@@ -40,7 +40,7 @@
   "max_address_length": 34,
   "negative_fee": false,
   "cooldown": 100,
-  "consensus_branch_id": null,
+  "overwintered": false,
   "extra_data": false,
   "timestamp": false,
   "confidential_assets": null

--- a/common/defs/bitcoin/bitcoin.json
+++ b/common/defs/bitcoin/bitcoin.json
@@ -40,7 +40,7 @@
   "max_address_length": 34,
   "negative_fee": false,
   "cooldown": 100,
-  "consensus_branch_id": null,
+  "overwintered": false,
   "extra_data": false,
   "timestamp": false,
   "confidential_assets": null

--- a/common/defs/bitcoin/bitcoin_regtest.json
+++ b/common/defs/bitcoin/bitcoin_regtest.json
@@ -37,7 +37,7 @@
   "max_address_length": 34,
   "negative_fee": false,
   "cooldown": 100,
-  "consensus_branch_id": null,
+  "overwintered": false,
   "extra_data": false,
   "timestamp": false,
   "confidential_assets": null

--- a/common/defs/bitcoin/bitcoin_testnet.json
+++ b/common/defs/bitcoin/bitcoin_testnet.json
@@ -37,7 +37,7 @@
   "max_address_length": 34,
   "negative_fee": false,
   "cooldown": 100,
-  "consensus_branch_id": null,
+  "overwintered": false,
   "extra_data": false,
   "timestamp": false,
   "confidential_assets": null

--- a/common/defs/bitcoin/bitcore.json
+++ b/common/defs/bitcoin/bitcore.json
@@ -37,7 +37,7 @@
   "max_address_length": 34,
   "negative_fee": false,
   "cooldown": 100,
-  "consensus_branch_id": null,
+  "overwintered": false,
   "extra_data": false,
   "timestamp": false,
   "confidential_assets": null

--- a/common/defs/bitcoin/bprivate.json
+++ b/common/defs/bitcoin/bprivate.json
@@ -37,7 +37,7 @@
   "max_address_length": 95,
   "negative_fee": false,
   "cooldown": 100,
-  "consensus_branch_id": null,
+  "overwintered": false,
   "extra_data": false,
   "timestamp": false,
   "confidential_assets": null

--- a/common/defs/bitcoin/cpuchain.json
+++ b/common/defs/bitcoin/cpuchain.json
@@ -37,7 +37,7 @@
   "max_address_length": 34,
   "negative_fee": false,
   "cooldown": 100,
-  "consensus_branch_id": null,
+  "overwintered": false,
   "extra_data": false,
   "timestamp": false,
   "confidential_assets": null

--- a/common/defs/bitcoin/crown.json
+++ b/common/defs/bitcoin/crown.json
@@ -37,7 +37,7 @@
   "max_address_length": 40,
   "negative_fee": false,
   "cooldown": 100,
-  "consensus_branch_id": null,
+  "overwintered": false,
   "extra_data": false,
   "timestamp": false,
   "confidential_assets": null

--- a/common/defs/bitcoin/dash.json
+++ b/common/defs/bitcoin/dash.json
@@ -37,7 +37,7 @@
   "max_address_length": 34,
   "negative_fee": false,
   "cooldown": 100,
-  "consensus_branch_id": null,
+  "overwintered": false,
   "extra_data": true,
   "timestamp": false,
   "confidential_assets": null

--- a/common/defs/bitcoin/dash_testnet.json
+++ b/common/defs/bitcoin/dash_testnet.json
@@ -37,7 +37,7 @@
   "max_address_length": 34,
   "negative_fee": false,
   "cooldown": 100,
-  "consensus_branch_id": null,
+  "overwintered": false,
   "extra_data": true,
   "timestamp": false,
   "confidential_assets": null

--- a/common/defs/bitcoin/decred.json
+++ b/common/defs/bitcoin/decred.json
@@ -37,7 +37,7 @@
   "max_address_length": 35,
   "negative_fee": false,
   "cooldown": 100,
-  "consensus_branch_id": null,
+  "overwintered": false,
   "extra_data": false,
   "timestamp": false,
   "confidential_assets": null

--- a/common/defs/bitcoin/decred_testnet.json
+++ b/common/defs/bitcoin/decred_testnet.json
@@ -37,7 +37,7 @@
   "max_address_length": 35,
   "negative_fee": false,
   "cooldown": 100,
-  "consensus_branch_id": null,
+  "overwintered": false,
   "extra_data": false,
   "timestamp": false,
   "confidential_assets": null

--- a/common/defs/bitcoin/digibyte.json
+++ b/common/defs/bitcoin/digibyte.json
@@ -40,7 +40,7 @@
   "max_address_length": 34,
   "negative_fee": false,
   "cooldown": 100,
-  "consensus_branch_id": null,
+  "overwintered": false,
   "extra_data": false,
   "timestamp": false,
   "confidential_assets": null

--- a/common/defs/bitcoin/dogecoin.json
+++ b/common/defs/bitcoin/dogecoin.json
@@ -37,7 +37,7 @@
   "max_address_length": 34,
   "negative_fee": false,
   "cooldown": 100,
-  "consensus_branch_id": null,
+  "overwintered": false,
   "extra_data": false,
   "timestamp": false,
   "confidential_assets": null

--- a/common/defs/bitcoin/elements.json
+++ b/common/defs/bitcoin/elements.json
@@ -37,7 +37,7 @@
   "max_address_length": 34,
   "negative_fee": false,
   "cooldown": 100,
-  "consensus_branch_id": null,
+  "overwintered": false,
   "extra_data": false,
   "timestamp": false,
   "confidential_assets": {

--- a/common/defs/bitcoin/feathercoin.json
+++ b/common/defs/bitcoin/feathercoin.json
@@ -37,7 +37,7 @@
   "max_address_length": 34,
   "negative_fee": false,
   "cooldown": 100,
-  "consensus_branch_id": null,
+  "overwintered": false,
   "extra_data": false,
   "timestamp": false,
   "confidential_assets": null

--- a/common/defs/bitcoin/firo.json
+++ b/common/defs/bitcoin/firo.json
@@ -40,7 +40,7 @@
   "max_address_length": 34,
   "negative_fee": false,
   "cooldown": 100,
-  "consensus_branch_id": null,
+  "overwintered": false,
   "extra_data": true,
   "timestamp": false,
   "confidential_assets": null

--- a/common/defs/bitcoin/firo_testnet.json
+++ b/common/defs/bitcoin/firo_testnet.json
@@ -40,7 +40,7 @@
   "max_address_length": 35,
   "negative_fee": false,
   "cooldown": 100,
-  "consensus_branch_id": null,
+  "overwintered": false,
   "extra_data": true,
   "timestamp": false,
   "confidential_assets": null

--- a/common/defs/bitcoin/florincoin.json
+++ b/common/defs/bitcoin/florincoin.json
@@ -37,7 +37,7 @@
   "max_address_length": 34,
   "negative_fee": false,
   "cooldown": 100,
-  "consensus_branch_id": null,
+  "overwintered": false,
   "extra_data": true,
   "timestamp": false,
   "confidential_assets": null

--- a/common/defs/bitcoin/fujicoin.json
+++ b/common/defs/bitcoin/fujicoin.json
@@ -40,7 +40,7 @@
   "max_address_length": 34,
   "negative_fee": false,
   "cooldown": 100,
-  "consensus_branch_id": null,
+  "overwintered": false,
   "extra_data": false,
   "timestamp": false,
   "confidential_assets": null

--- a/common/defs/bitcoin/groestlcoin.json
+++ b/common/defs/bitcoin/groestlcoin.json
@@ -37,7 +37,7 @@
   "max_address_length": 34,
   "negative_fee": false,
   "cooldown": 100,
-  "consensus_branch_id": null,
+  "overwintered": false,
   "extra_data": false,
   "timestamp": false,
   "confidential_assets": null

--- a/common/defs/bitcoin/groestlcoin_testnet.json
+++ b/common/defs/bitcoin/groestlcoin_testnet.json
@@ -37,7 +37,7 @@
   "max_address_length": 34,
   "negative_fee": false,
   "cooldown": 100,
-  "consensus_branch_id": null,
+  "overwintered": false,
   "extra_data": false,
   "timestamp": false,
   "confidential_assets": null

--- a/common/defs/bitcoin/komodo.json
+++ b/common/defs/bitcoin/komodo.json
@@ -37,12 +37,7 @@
   "max_address_length": 34,
   "negative_fee": true,
   "cooldown": 100,
-  "consensus_branch_id": {
-    "1": 0,
-    "2": 0,
-    "3": 1537743641,
-    "4": 1991772603
-  },
+  "overwintered": true,
   "extra_data": true,
   "timestamp": false,
   "confidential_assets": null

--- a/common/defs/bitcoin/koto.json
+++ b/common/defs/bitcoin/koto.json
@@ -37,12 +37,7 @@
   "max_address_length": 95,
   "negative_fee": false,
   "cooldown": 100,
-  "consensus_branch_id": {
-    "1": 0,
-    "2": 0,
-    "3": 1537743641,
-    "4": 733220448
-  },
+  "overwintered": true,
   "extra_data": true,
   "timestamp": false,
   "confidential_assets": null

--- a/common/defs/bitcoin/litecoin.json
+++ b/common/defs/bitcoin/litecoin.json
@@ -37,7 +37,7 @@
   "max_address_length": 34,
   "negative_fee": false,
   "cooldown": 100,
-  "consensus_branch_id": null,
+  "overwintered": false,
   "extra_data": false,
   "timestamp": false,
   "confidential_assets": null

--- a/common/defs/bitcoin/litecoin_testnet.json
+++ b/common/defs/bitcoin/litecoin_testnet.json
@@ -37,7 +37,7 @@
   "max_address_length": 34,
   "negative_fee": false,
   "cooldown": 100,
-  "consensus_branch_id": null,
+  "overwintered": false,
   "extra_data": false,
   "timestamp": false,
   "confidential_assets": null

--- a/common/defs/bitcoin/monacoin.json
+++ b/common/defs/bitcoin/monacoin.json
@@ -37,7 +37,7 @@
   "max_address_length": 34,
   "negative_fee": false,
   "cooldown": 100,
-  "consensus_branch_id": null,
+  "overwintered": false,
   "extra_data": false,
   "timestamp": false,
   "confidential_assets": null

--- a/common/defs/bitcoin/monetaryunit.json
+++ b/common/defs/bitcoin/monetaryunit.json
@@ -37,7 +37,7 @@
   "max_address_length": 34,
   "negative_fee": false,
   "cooldown": 100,
-  "consensus_branch_id": null,
+  "overwintered": false,
   "extra_data": false,
   "timestamp": false,
   "confidential_assets": null

--- a/common/defs/bitcoin/namecoin.json
+++ b/common/defs/bitcoin/namecoin.json
@@ -37,7 +37,7 @@
   "max_address_length": 34,
   "negative_fee": false,
   "cooldown": 100,
-  "consensus_branch_id": null,
+  "overwintered": false,
   "extra_data": false,
   "timestamp": false,
   "confidential_assets": null

--- a/common/defs/bitcoin/particl.json
+++ b/common/defs/bitcoin/particl.json
@@ -40,7 +40,7 @@
   "max_address_length": 34,
   "negative_fee": false,
   "cooldown": 100,
-  "consensus_branch_id": null,
+  "overwintered": false,
   "extra_data": false,
   "timestamp": false,
   "confidential_assets": null

--- a/common/defs/bitcoin/particl_testnet.json
+++ b/common/defs/bitcoin/particl_testnet.json
@@ -37,7 +37,7 @@
   "max_address_length": 34,
   "negative_fee": false,
   "cooldown": 100,
-  "consensus_branch_id": null,
+  "overwintered": false,
   "extra_data": false,
   "timestamp": false,
   "confidential_assets": null

--- a/common/defs/bitcoin/peercoin.json
+++ b/common/defs/bitcoin/peercoin.json
@@ -37,7 +37,7 @@
   "max_address_length": 34,
   "negative_fee": false,
   "cooldown": 100,
-  "consensus_branch_id": null,
+  "overwintered": false,
   "extra_data": false,
   "timestamp": true,
   "confidential_assets": null

--- a/common/defs/bitcoin/peercoin_testnet.json
+++ b/common/defs/bitcoin/peercoin_testnet.json
@@ -37,7 +37,7 @@
   "max_address_length": 34,
   "negative_fee": false,
   "cooldown": 100,
-  "consensus_branch_id": null,
+  "overwintered": false,
   "extra_data": false,
   "timestamp": true,
   "confidential_assets": null

--- a/common/defs/bitcoin/primecoin.json
+++ b/common/defs/bitcoin/primecoin.json
@@ -37,7 +37,7 @@
   "max_address_length": 35,
   "negative_fee": false,
   "cooldown": 100,
-  "consensus_branch_id": null,
+  "overwintered": false,
   "extra_data": false,
   "timestamp": false,
   "confidential_assets": null

--- a/common/defs/bitcoin/qtum.json
+++ b/common/defs/bitcoin/qtum.json
@@ -40,7 +40,7 @@
   "max_address_length": 34,
   "negative_fee": false,
   "cooldown": 100,
-  "consensus_branch_id": null,
+  "overwintered": false,
   "extra_data": false,
   "timestamp": false,
   "confidential_assets": null

--- a/common/defs/bitcoin/qtum_testnet.json
+++ b/common/defs/bitcoin/qtum_testnet.json
@@ -40,7 +40,7 @@
   "max_address_length": 34,
   "negative_fee": false,
   "cooldown": 100,
-  "consensus_branch_id": null,
+  "overwintered": false,
   "extra_data": false,
   "timestamp": false,
   "confidential_assets": null

--- a/common/defs/bitcoin/ravencoin.json
+++ b/common/defs/bitcoin/ravencoin.json
@@ -37,7 +37,7 @@
   "max_address_length": 34,
   "negative_fee": false,
   "cooldown": 100,
-  "consensus_branch_id": null,
+  "overwintered": false,
   "extra_data": false,
   "timestamp": false,
   "confidential_assets": null

--- a/common/defs/bitcoin/ravencoin_testnet.json
+++ b/common/defs/bitcoin/ravencoin_testnet.json
@@ -37,7 +37,7 @@
   "max_address_length": 34,
   "negative_fee": false,
   "cooldown": 100,
-  "consensus_branch_id": null,
+  "overwintered": false,
   "extra_data": false,
   "timestamp": false,
   "confidential_assets": null

--- a/common/defs/bitcoin/ritocoin.json
+++ b/common/defs/bitcoin/ritocoin.json
@@ -37,7 +37,7 @@
   "max_address_length": 34,
   "negative_fee": false,
   "cooldown": 100,
-  "consensus_branch_id": null,
+  "overwintered": false,
   "extra_data": false,
   "timestamp": false,
   "confidential_assets": null

--- a/common/defs/bitcoin/smartcash.json
+++ b/common/defs/bitcoin/smartcash.json
@@ -40,7 +40,7 @@
   "max_address_length": 34,
   "negative_fee": false,
   "cooldown": 100,
-  "consensus_branch_id": null,
+  "overwintered": false,
   "extra_data": false,
   "timestamp": false,
   "confidential_assets": null

--- a/common/defs/bitcoin/smartcash_testnet.json
+++ b/common/defs/bitcoin/smartcash_testnet.json
@@ -40,7 +40,7 @@
   "max_address_length": 35,
   "negative_fee": false,
   "cooldown": 100,
-  "consensus_branch_id": null,
+  "overwintered": false,
   "extra_data": false,
   "timestamp": false,
   "confidential_assets": null

--- a/common/defs/bitcoin/stakenet.json
+++ b/common/defs/bitcoin/stakenet.json
@@ -40,7 +40,7 @@
   "max_address_length": 47,
   "negative_fee": false,
   "cooldown": 100,
-  "consensus_branch_id": null,
+  "overwintered": false,
   "extra_data": true,
   "timestamp": false,
   "confidential_assets": null

--- a/common/defs/bitcoin/syscoin.json
+++ b/common/defs/bitcoin/syscoin.json
@@ -40,7 +40,7 @@
   "max_address_length": 34,
   "negative_fee": false,
   "cooldown": 100,
-  "consensus_branch_id": null,
+  "overwintered": false,
   "extra_data": false,
   "timestamp": false,
   "confidential_assets": null

--- a/common/defs/bitcoin/terracoin.json
+++ b/common/defs/bitcoin/terracoin.json
@@ -37,7 +37,7 @@
   "max_address_length": 34,
   "negative_fee": false,
   "cooldown": 100,
-  "consensus_branch_id": null,
+  "overwintered": false,
   "extra_data": false,
   "timestamp": false,
   "confidential_assets": null

--- a/common/defs/bitcoin/unobtanium.json
+++ b/common/defs/bitcoin/unobtanium.json
@@ -40,7 +40,7 @@
   "max_address_length": 34,
   "negative_fee": false,
   "cooldown": 100,
-  "consensus_branch_id": null,
+  "overwintered": false,
   "extra_data": false,
   "timestamp": false,
   "confidential_assets": null

--- a/common/defs/bitcoin/verge.json
+++ b/common/defs/bitcoin/verge.json
@@ -37,7 +37,7 @@
   "max_address_length": 34,
   "negative_fee": false,
   "cooldown": 100,
-  "consensus_branch_id": null,
+  "overwintered": false,
   "confidential_assets": null,
   "timestamp": true,
   "extra_data": false

--- a/common/defs/bitcoin/vertcoin.json
+++ b/common/defs/bitcoin/vertcoin.json
@@ -37,7 +37,7 @@
   "max_address_length": 34,
   "negative_fee": false,
   "cooldown": 100,
-  "consensus_branch_id": null,
+  "overwintered": false,
   "extra_data": false,
   "timestamp": false,
   "confidential_assets": null

--- a/common/defs/bitcoin/viacoin.json
+++ b/common/defs/bitcoin/viacoin.json
@@ -40,7 +40,7 @@
   "max_address_length": 34,
   "negative_fee": false,
   "cooldown": 100,
-  "consensus_branch_id": null,
+  "overwintered": false,
   "extra_data": false,
   "timestamp": false,
   "confidential_assets": null

--- a/common/defs/bitcoin/vipstarcoin.json
+++ b/common/defs/bitcoin/vipstarcoin.json
@@ -40,7 +40,7 @@
   "max_address_length": 36,
   "negative_fee": false,
   "cooldown": 100,
-  "consensus_branch_id": null,
+  "overwintered": false,
   "extra_data": false,
   "timestamp": false,
   "confidential_assets": null

--- a/common/defs/bitcoin/xrhodium.json
+++ b/common/defs/bitcoin/xrhodium.json
@@ -40,7 +40,7 @@
   "max_address_length": 34,
   "negative_fee": false,
   "cooldown": 100,
-  "consensus_branch_id": null,
+  "overwintered": false,
   "extra_data": false,
   "timestamp": false,
   "confidential_assets": null

--- a/common/defs/bitcoin/zcash.json
+++ b/common/defs/bitcoin/zcash.json
@@ -37,13 +37,7 @@
   "max_address_length": 95,
   "negative_fee": false,
   "cooldown": 100,
-  "consensus_branch_id": {
-    "1": 0,
-    "2": 0,
-    "3": 1537743641,
-    "4": 4122551051,
-    "5": 3268858036
-  },
+  "overwintered": true,
   "extra_data": true,
   "timestamp": false,
   "confidential_assets": null

--- a/common/defs/bitcoin/zcash_testnet.json
+++ b/common/defs/bitcoin/zcash_testnet.json
@@ -37,13 +37,7 @@
   "max_address_length": 95,
   "negative_fee": false,
   "cooldown": 100,
-  "consensus_branch_id": {
-    "1": 0,
-    "2": 0,
-    "3": 1537743641,
-    "4": 4122551051,
-    "5": 3268858036
-  },
+  "overwintered": true,
   "extra_data": true,
   "timestamp": false,
   "confidential_assets": null

--- a/common/defs/bitcoin/zcore.json
+++ b/common/defs/bitcoin/zcore.json
@@ -37,7 +37,7 @@
   "max_address_length": 95,
   "negative_fee": false,
   "cooldown": 100,
-  "consensus_branch_id": null,
+  "overwintered": false,
   "extra_data": false,
   "timestamp": false,
   "confidential_assets": null

--- a/core/src/apps/common/coininfo.py.mako
+++ b/core/src/apps/common/coininfo.py.mako
@@ -136,9 +136,6 @@ btc_names = ["Bitcoin", "Testnet", "Regtest"]
 coins_btc = [c for c in supported_on("trezor2", bitcoin) if c.name in btc_names]
 coins_alt = [c for c in supported_on("trezor2", bitcoin) if c.name not in btc_names]
 
-for c in coins_btc + coins_alt:
-    c.overwintered = bool(c.consensus_branch_id)
-
 %>\
 def by_name(name: str) -> CoinInfo:
 % for coin in coins_btc:

--- a/legacy/firmware/coin_info.c.mako
+++ b/legacy/firmware/coin_info.c.mako
@@ -51,7 +51,7 @@ const CoinInfo coins[COINS_COUNT] = {
 	.curve = &${c.curve_name}_info,
 	.extra_data = ${c_bool(c.extra_data)},
 	.timestamp = ${c_bool(c.timestamp)},
-	.overwintered = ${c_bool(c.consensus_branch_id)},
+	.overwintered = ${c_bool(c.overwintered)},
 },
 % endfor
 };


### PR DESCRIPTION
Related to https://github.com/trezor/trezor-suite/pull/5554 - it's no longer required to maintain these constants in coin definitions