### PR TITLE
Fix overflow in bip39.rs tests

### DIFF
--- a/ci/test.yml
+++ b/ci/test.yml
@@ -131,6 +131,8 @@ core device asan test:
     - core unix frozen debug asan build
   only:
     - schedules  # nightly build
+  variables:
+    PYTEST_TIMEOUT: "600"
   script:
     - nix-shell --run "poetry run make -C core test_emu | ts -s"
   artifacts:
@@ -171,6 +173,7 @@ core btconly device asan test:
   variables:
     MICROPYTHON: "build/unix/trezor-emu-core-bitcoinonly"
     TREZOR_PYTEST_SKIP_ALTCOINS: 1
+    PYTEST_TIMEOUT: "600"
   script:
     - nix-shell --run "poetry run make -C core test_emu | ts -s"
   artifacts:

--- a/core/embed/rust/src/trezorhal/bip39.rs
+++ b/core/embed/rust/src/trezorhal/bip39.rs
@@ -96,33 +96,40 @@ impl Wordlist {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use cstr_core::cstr;
 
     const BIP39_WORD_COUNT: usize = ffi::BIP39_WORD_COUNT as usize;
 
     #[test]
     fn test_prefix_cmp() {
-        assert_eq!(unsafe { prefix_cmp("", "".as_ptr() as _) }, Ordering::Equal);
-
-        assert_eq!(unsafe { prefix_cmp("b", "".as_ptr() as _) }, Ordering::Less);
         assert_eq!(
-            unsafe { prefix_cmp("b", "a".as_ptr() as _) },
+            unsafe { prefix_cmp("", cstr!("").as_ptr()) },
+            Ordering::Equal
+        );
+
+        assert_eq!(
+            unsafe { prefix_cmp("b", cstr!("").as_ptr()) },
             Ordering::Less
         );
         assert_eq!(
-            unsafe { prefix_cmp("b", "b".as_ptr() as _) },
+            unsafe { prefix_cmp("b", cstr!("a").as_ptr()) },
+            Ordering::Less
+        );
+        assert_eq!(
+            unsafe { prefix_cmp("b", cstr!("b").as_ptr()) },
             Ordering::Equal
         );
         assert_eq!(
-            unsafe { prefix_cmp("b", "below".as_ptr() as _) },
+            unsafe { prefix_cmp("b", cstr!("below").as_ptr()) },
             Ordering::Equal
         );
         assert_eq!(
-            unsafe { prefix_cmp("b", "c".as_ptr() as _) },
+            unsafe { prefix_cmp("b", cstr!("c").as_ptr()) },
             Ordering::Greater
         );
 
         assert_eq!(
-            unsafe { prefix_cmp("bartender", "bar".as_ptr() as _) },
+            unsafe { prefix_cmp("bartender", cstr!("bar").as_ptr()) },
             Ordering::Less
         );
     }

--- a/docs/ci/jobs.md
+++ b/docs/ci/jobs.md
@@ -162,70 +162,70 @@ See [docs/tests/ui-tests](../docs/tests/ui-tests.md) for more info.
 
 ### [core device asan test](https://github.com/trezor/trezor-firmware/blob/master/ci/test.yml#L127)
 
-### [core btconly device test](https://github.com/trezor/trezor-firmware/blob/master/ci/test.yml#L144)
+### [core btconly device test](https://github.com/trezor/trezor-firmware/blob/master/ci/test.yml#L146)
 Device tests excluding altcoins, only for BTC.
 
-### [core btconly device asan test](https://github.com/trezor/trezor-firmware/blob/master/ci/test.yml#L164)
+### [core btconly device asan test](https://github.com/trezor/trezor-firmware/blob/master/ci/test.yml#L166)
 
-### [core monero test](https://github.com/trezor/trezor-firmware/blob/master/ci/test.yml#L184)
+### [core monero test](https://github.com/trezor/trezor-firmware/blob/master/ci/test.yml#L187)
 Monero tests.
 
-### [core monero asan test](https://github.com/trezor/trezor-firmware/blob/master/ci/test.yml#L203)
+### [core monero asan test](https://github.com/trezor/trezor-firmware/blob/master/ci/test.yml#L206)
 
-### [core u2f test](https://github.com/trezor/trezor-firmware/blob/master/ci/test.yml#L225)
+### [core u2f test](https://github.com/trezor/trezor-firmware/blob/master/ci/test.yml#L228)
 Tests for U2F and HID.
 
-### [core u2f asan test](https://github.com/trezor/trezor-firmware/blob/master/ci/test.yml#L244)
+### [core u2f asan test](https://github.com/trezor/trezor-firmware/blob/master/ci/test.yml#L247)
 
-### [core fido2 test](https://github.com/trezor/trezor-firmware/blob/master/ci/test.yml#L262)
+### [core fido2 test](https://github.com/trezor/trezor-firmware/blob/master/ci/test.yml#L265)
 FIDO2 device tests.
 
-### [core fido2 asan test](https://github.com/trezor/trezor-firmware/blob/master/ci/test.yml#L285)
+### [core fido2 asan test](https://github.com/trezor/trezor-firmware/blob/master/ci/test.yml#L288)
 
-### [core click test](https://github.com/trezor/trezor-firmware/blob/master/ci/test.yml#L305)
+### [core click test](https://github.com/trezor/trezor-firmware/blob/master/ci/test.yml#L308)
 Click tests.
 See [docs/tests/click-tests](../docs/tests/click-tests.md) for more info.
 
-### [core click asan test](https://github.com/trezor/trezor-firmware/blob/master/ci/test.yml#L322)
+### [core click asan test](https://github.com/trezor/trezor-firmware/blob/master/ci/test.yml#L325)
 
-### [core upgrade test](https://github.com/trezor/trezor-firmware/blob/master/ci/test.yml#L343)
+### [core upgrade test](https://github.com/trezor/trezor-firmware/blob/master/ci/test.yml#L346)
 Upgrade tests.
 See [docs/tests/upgrade-tests](../docs/tests/upgrade-tests.md) for more info.
 
-### [core upgrade asan test](https://github.com/trezor/trezor-firmware/blob/master/ci/test.yml#L362)
+### [core upgrade asan test](https://github.com/trezor/trezor-firmware/blob/master/ci/test.yml#L365)
 
-### [core persistence test](https://github.com/trezor/trezor-firmware/blob/master/ci/test.yml#L384)
+### [core persistence test](https://github.com/trezor/trezor-firmware/blob/master/ci/test.yml#L387)
 Persistence tests.
 
-### [core persistence asan test](https://github.com/trezor/trezor-firmware/blob/master/ci/test.yml#L400)
+### [core persistence asan test](https://github.com/trezor/trezor-firmware/blob/master/ci/test.yml#L403)
 
-### [core hwi test](https://github.com/trezor/trezor-firmware/blob/master/ci/test.yml#L418)
+### [core hwi test](https://github.com/trezor/trezor-firmware/blob/master/ci/test.yml#L421)
 
-### [crypto test](https://github.com/trezor/trezor-firmware/blob/master/ci/test.yml#L436)
+### [crypto test](https://github.com/trezor/trezor-firmware/blob/master/ci/test.yml#L439)
 
-### [legacy device test](https://github.com/trezor/trezor-firmware/blob/master/ci/test.yml#L467)
+### [legacy device test](https://github.com/trezor/trezor-firmware/blob/master/ci/test.yml#L470)
 
-### [legacy asan test](https://github.com/trezor/trezor-firmware/blob/master/ci/test.yml#L494)
+### [legacy asan test](https://github.com/trezor/trezor-firmware/blob/master/ci/test.yml#L497)
 
-### [legacy btconly test](https://github.com/trezor/trezor-firmware/blob/master/ci/test.yml#L506)
+### [legacy btconly test](https://github.com/trezor/trezor-firmware/blob/master/ci/test.yml#L509)
 
-### [legacy btconly asan test](https://github.com/trezor/trezor-firmware/blob/master/ci/test.yml#L526)
+### [legacy btconly asan test](https://github.com/trezor/trezor-firmware/blob/master/ci/test.yml#L529)
 
-### [legacy upgrade test](https://github.com/trezor/trezor-firmware/blob/master/ci/test.yml#L541)
+### [legacy upgrade test](https://github.com/trezor/trezor-firmware/blob/master/ci/test.yml#L544)
 
-### [legacy upgrade asan test](https://github.com/trezor/trezor-firmware/blob/master/ci/test.yml#L560)
+### [legacy upgrade asan test](https://github.com/trezor/trezor-firmware/blob/master/ci/test.yml#L563)
 
-### [legacy hwi test](https://github.com/trezor/trezor-firmware/blob/master/ci/test.yml#L581)
+### [legacy hwi test](https://github.com/trezor/trezor-firmware/blob/master/ci/test.yml#L584)
 
-### [python test](https://github.com/trezor/trezor-firmware/blob/master/ci/test.yml#L600)
+### [python test](https://github.com/trezor/trezor-firmware/blob/master/ci/test.yml#L603)
 
-### [python support test](https://github.com/trezor/trezor-firmware/blob/master/ci/test.yml#L626)
+### [python support test](https://github.com/trezor/trezor-firmware/blob/master/ci/test.yml#L629)
 
-### [storage test](https://github.com/trezor/trezor-firmware/blob/master/ci/test.yml#L636)
+### [storage test](https://github.com/trezor/trezor-firmware/blob/master/ci/test.yml#L639)
 
-### [core unix memory profiler](https://github.com/trezor/trezor-firmware/blob/master/ci/test.yml#L660)
+### [core unix memory profiler](https://github.com/trezor/trezor-firmware/blob/master/ci/test.yml#L663)
 
-### [connect test core](https://github.com/trezor/trezor-firmware/blob/master/ci/test.yml#L684)
+### [connect test core](https://github.com/trezor/trezor-firmware/blob/master/ci/test.yml#L687)
 
 ---
 ## TEST-HW stage - [test-hw.yml](../../ci/test-hw.yml)


### PR DESCRIPTION
by using `cstr!` to generate 0-terminated strings