### PR TITLE
Hold to confirm animation for Model R

### DIFF
--- a/core/.changelog.d/2276.added
+++ b/core/.changelog.d/2276.added
@@ -1,0 +1,1 @@
+Hold to confirm animation on Model R

--- a/core/embed/extmod/modtrezorui/display.c
+++ b/core/embed/extmod/modtrezorui/display.c
@@ -668,7 +668,7 @@ static uint8_t convert_char(const uint8_t c) {
   return 0;
 }
 
-static const uint8_t *get_glyph(int font, uint8_t c) {
+const uint8_t *display_get_glyph(int font, uint8_t c) {
   c = convert_char(c);
   if (!c) return 0;
 
@@ -732,7 +732,7 @@ static void display_text_render(int x, int y, const char *text, int textlen,
 
   // render glyphs
   for (int i = 0; i < textlen; i++) {
-    const uint8_t *g = get_glyph(font, (uint8_t)text[i]);
+    const uint8_t *g = display_get_glyph(font, (uint8_t)text[i]);
     if (!g) continue;
     const uint8_t w = g[0];      // width
     const uint8_t h = g[1];      // height
@@ -801,7 +801,7 @@ int display_text_width(const char *text, int textlen, int font) {
     textlen = strlen(text);
   }
   for (int i = 0; i < textlen; i++) {
-    const uint8_t *g = get_glyph(font, (uint8_t)text[i]);
+    const uint8_t *g = display_get_glyph(font, (uint8_t)text[i]);
     if (!g) continue;
     const uint8_t adv = g[2];  // advance
     width += adv;
@@ -833,7 +833,7 @@ int display_text_split(const char *text, int textlen, int font,
     if (text[i] == ' ') {
       lastspace = i;
     }
-    const uint8_t *g = get_glyph(font, (uint8_t)text[i]);
+    const uint8_t *g = display_get_glyph(font, (uint8_t)text[i]);
     if (!g) continue;
     const uint8_t adv = g[2];  // advance
     width += adv;

--- a/core/embed/extmod/modtrezorui/display.h
+++ b/core/embed/extmod/modtrezorui/display.h
@@ -145,6 +145,8 @@ void display_set_window(uint16_t x0, uint16_t y0, uint16_t x1, uint16_t y1);
 void display_pixeldata(uint16_t c);
 void display_pixeldata_dirty();
 
+const uint8_t *display_get_glyph(int font, uint8_t c);
+
 #if !(defined EMULATOR) && (defined TREZOR_MODEL_T)
 extern volatile uint8_t *const DISPLAY_CMD_ADDRESS;
 extern volatile uint8_t *const DISPLAY_DATA_ADDRESS;

--- a/core/embed/rust/build.rs
+++ b/core/embed/rust/build.rs
@@ -263,6 +263,7 @@ fn generate_trezorhal_bindings() {
         .allowlist_function("display_pixeldata")
         .allowlist_function("display_pixeldata_dirty")
         .allowlist_function("display_set_window")
+        .allowlist_function("display_get_glyph")
         .allowlist_var("DISPLAY_CMD_ADDRESS")
         .allowlist_var("DISPLAY_DATA_ADDRESS")
         // bip39

--- a/core/embed/rust/src/trezorhal/display.rs
+++ b/core/embed/rust/src/trezorhal/display.rs
@@ -35,6 +35,13 @@ pub fn char_width(ch: char, font: i32) -> i32 {
     text_width(encoding, font)
 }
 
+pub fn get_char_glyph(ch: char, font: i32) -> *const u8 {
+    let mut buf = [0u8; 4];
+    let _ = ch.encode_utf8(&mut buf);
+
+    unsafe { ffi::display_get_glyph(font, buf[0]) }
+}
+
 pub fn text_height(font: i32) -> i32 {
     unsafe { ffi::display_text_height(font) }
 }

--- a/core/embed/rust/src/ui/display.rs
+++ b/core/embed/rust/src/ui/display.rs
@@ -204,6 +204,23 @@ pub fn set_window(window: Rect) {
     );
 }
 
+pub fn interpolate_colors(color0: Color, color1: Color, step: u16) -> Color {
+    let cr: u16 = ((color0.r() as u16) * step + (color1.r() as u16) * (15 - step)) / 15;
+    let cg: u16 = ((color0.g() as u16) * step + (color1.g() as u16) * (15 - step)) / 15;
+    let cb: u16 = ((color0.b() as u16) * step + (color1.b() as u16) * (15 - step)) / 15;
+    Color::rgb(cr as u8, cg as u8, cb as u8)
+}
+
+pub fn get_color_table(fg_color: Color, bg_color: Color) -> [Color; 16] {
+    let mut table: [Color; 16] = [Color::from_u16(0); 16];
+
+    for (i, item) in table.iter_mut().enumerate() {
+        *item = interpolate_colors(fg_color, bg_color, i as u16);
+    }
+
+    table
+}
+
 #[derive(Copy, Clone, PartialEq, Eq)]
 pub struct Font(i32);
 

--- a/core/embed/rust/src/ui/model_t1/constant.rs
+++ b/core/embed/rust/src/ui/model_t1/constant.rs
@@ -3,6 +3,7 @@ use crate::ui::geometry::{Offset, Point, Rect};
 pub const WIDTH: i32 = 128;
 pub const HEIGHT: i32 = 64;
 pub const LINE_SPACE: i32 = 1;
+pub const FONT_BPP: i32 = 1;
 
 pub const fn size() -> Offset {
     Offset::new(WIDTH, HEIGHT)

--- a/core/embed/rust/src/ui/model_tr/component/button.rs
+++ b/core/embed/rust/src/ui/model_tr/component/button.rs
@@ -18,7 +18,7 @@ pub enum ButtonPos {
 }
 
 impl ButtonPos {
-    fn hit(&self, b: &PhysicalButton) -> bool {
+    pub fn hit(&self, b: &PhysicalButton) -> bool {
         matches!(
             (self, b),
             (Self::Left, PhysicalButton::Left) | (Self::Right, PhysicalButton::Right)

--- a/core/embed/rust/src/ui/model_tr/component/confirm.rs
+++ b/core/embed/rust/src/ui/model_tr/component/confirm.rs
@@ -1,0 +1,90 @@
+use crate::{
+    time::Instant,
+    ui::{
+        component::{Component, Event, EventCtx},
+        event::ButtonEvent,
+        geometry::{Point, Rect},
+        model_tr::component::{loader::Loader, ButtonPos, LoaderMsg, LoaderStyleSheet},
+    },
+};
+
+pub enum HoldToConfirmMsg {
+    Confirmed,
+    FailedToConfirm,
+}
+
+pub struct HoldToConfirm {
+    area: Rect,
+    pos: ButtonPos,
+    loader: Loader,
+    baseline: Point,
+    text_width: i32,
+}
+
+impl HoldToConfirm {
+    pub fn new(pos: ButtonPos, text: &'static str, styles: LoaderStyleSheet) -> Self {
+        let text_width = styles.normal.font.text_width(text.as_ref());
+        Self {
+            area: Rect::zero(),
+            pos,
+            loader: Loader::new(text, styles),
+            baseline: Point::zero(),
+            text_width,
+        }
+    }
+
+    fn placement(&mut self, area: Rect, pos: ButtonPos) -> Rect {
+        let button_width = self.text_width + 7;
+        match pos {
+            ButtonPos::Left => area.split_left(button_width).0,
+            ButtonPos::Right => area.split_right(button_width).1,
+        }
+    }
+}
+
+impl Component for HoldToConfirm {
+    type Msg = HoldToConfirmMsg;
+
+    fn place(&mut self, bounds: Rect) -> Rect {
+        let loader_area = self.placement(bounds, self.pos);
+        self.loader.place(loader_area)
+    }
+
+    fn event(&mut self, ctx: &mut EventCtx, event: Event) -> Option<Self::Msg> {
+        match event {
+            Event::Button(ButtonEvent::ButtonPressed(which)) if self.pos.hit(&which) => {
+                self.loader.start_growing(ctx, Instant::now());
+            }
+            Event::Button(ButtonEvent::ButtonReleased(which)) if self.pos.hit(&which) => {
+                if self.loader.is_animating() {
+                    self.loader.start_shrinking(ctx, Instant::now());
+                }
+            }
+            _ => {}
+        };
+
+        let msg = self.loader.event(ctx, event);
+
+        if let Some(LoaderMsg::GrownCompletely) = msg {
+            return Some(HoldToConfirmMsg::Confirmed);
+        }
+        if let Some(LoaderMsg::ShrunkCompletely) = msg {
+            return Some(HoldToConfirmMsg::FailedToConfirm);
+        }
+
+        None
+    }
+
+    fn paint(&mut self) {
+        self.loader.paint();
+    }
+}
+
+#[cfg(feature = "ui_debug")]
+impl crate::trace::Trace for HoldToConfirm {
+    fn trace(&self, d: &mut dyn crate::trace::Tracer) {
+        d.open("HoldToConfirm");
+        self.loader.trace(d);
+        d.close();
+    }
+}

--- a/core/embed/rust/src/ui/model_tr/component/loader.rs
+++ b/core/embed/rust/src/ui/model_tr/component/loader.rs
@@ -1,0 +1,206 @@
+use crate::{
+    time::{Duration, Instant},
+    ui::{
+        animation::Animation,
+        component::{Component, Event, EventCtx},
+        display::{self, Color, Font},
+        geometry::{Offset, Rect},
+    },
+};
+
+pub enum LoaderMsg {
+    GrownCompletely,
+    ShrunkCompletely,
+}
+
+enum State {
+    Initial,
+    Growing(Animation<u16>),
+    Shrinking(Animation<u16>),
+    Grown,
+}
+
+pub struct Loader {
+    area: Rect,
+    state: State,
+    growing_duration: Duration,
+    shrinking_duration: Duration,
+    text: display::TextOverlay,
+    styles: LoaderStyleSheet,
+}
+
+impl Loader {
+    pub const SIZE: Offset = Offset::new(120, 120);
+
+    pub fn new(text: &'static str, styles: LoaderStyleSheet) -> Self {
+        let overlay = display::TextOverlay::new(
+            styles.normal.bg_color,
+            styles.normal.fg_color,
+            text,
+            styles.normal.font,
+        );
+
+        Self {
+            area: Rect::zero(),
+            state: State::Initial,
+            growing_duration: Duration::from_millis(1000),
+            shrinking_duration: Duration::from_millis(500),
+            text: overlay,
+            styles,
+        }
+    }
+
+    pub fn start_growing(&mut self, ctx: &mut EventCtx, now: Instant) {
+        let mut anim = Animation::new(
+            display::LOADER_MIN,
+            display::LOADER_MAX,
+            self.growing_duration,
+            now,
+        );
+        if let State::Shrinking(shrinking) = &self.state {
+            anim.seek_to_value(shrinking.value(now));
+        }
+        self.state = State::Growing(anim);
+
+        // The animation is starting, request an animation frame event.
+        ctx.request_anim_frame();
+
+        // We don't have to wait for the animation frame event with the first paint,
+        // let's do that now.
+        ctx.request_paint();
+    }
+
+    pub fn start_shrinking(&mut self, ctx: &mut EventCtx, now: Instant) {
+        let mut anim = Animation::new(
+            display::LOADER_MAX,
+            display::LOADER_MIN,
+            self.shrinking_duration,
+            now,
+        );
+        if let State::Growing(growing) = &self.state {
+            anim.seek_to_value(display::LOADER_MAX - growing.value(now));
+        }
+        self.state = State::Shrinking(anim);
+
+        // The animation should be already progressing at this point, so we don't need
+        // to request another animation frames, but we should request to get painted
+        // after this event pass.
+        ctx.request_paint();
+    }
+
+    pub fn reset(&mut self) {
+        self.state = State::Initial;
+    }
+
+    pub fn animation(&self) -> Option<&Animation<u16>> {
+        match &self.state {
+            State::Initial => None,
+            State::Grown => None,
+            State::Growing(a) | State::Shrinking(a) => Some(a),
+        }
+    }
+
+    pub fn progress(&self, now: Instant) -> Option<u16> {
+        self.animation().map(|a| a.value(now))
+    }
+
+    pub fn is_animating(&self) -> bool {
+        self.animation().is_some()
+    }
+
+    pub fn is_completely_grown(&self, now: Instant) -> bool {
+        //TODO consider fixing overflow in animation?
+        self.progress(now).unwrap() >= display::LOADER_MAX
+    }
+
+    pub fn is_completely_shrunk(&self, now: Instant) -> bool {
+        matches!(self.progress(now), Some(display::LOADER_MIN))
+    }
+
+    pub fn paint_loader(&mut self, style: &LoaderStyle, done: i32) {
+        let invert_from = ((self.area.width() + 1) * done) / (display::LOADER_MAX as i32);
+
+        display::bar_with_text_and_fill(
+            self.area,
+            Some(self.text),
+            style.fg_color,
+            style.bg_color,
+            -1,
+            invert_from,
+        );
+    }
+}
+
+impl Component for Loader {
+    type Msg = LoaderMsg;
+
+    fn place(&mut self, bounds: Rect) -> Rect {
+        self.area = bounds;
+        let baseline = Offset::new(bounds.width() / 2 + 1, bounds.height() - 1);
+        self.text.place(baseline);
+        self.area
+    }
+
+    fn event(&mut self, ctx: &mut EventCtx, event: Event) -> Option<Self::Msg> {
+        let now = Instant::now();
+
+        if let Event::Timer(EventCtx::ANIM_FRAME_TIMER) = event {
+            if self.is_animating() {
+                // We have something to paint, so request to be painted in the next pass.
+                ctx.request_paint();
+
+                if self.is_completely_grown(now) {
+                    self.state = State::Grown;
+                    return Some(LoaderMsg::GrownCompletely);
+                } else if self.is_completely_shrunk(now) {
+                    self.state = State::Initial;
+                    return Some(LoaderMsg::ShrunkCompletely);
+                } else {
+                    // There is further progress in the animation, request an animation frame event.
+                    ctx.request_anim_frame();
+                }
+            }
+        }
+        None
+    }
+
+    fn paint(&mut self) {
+        // TODO: Consider passing the current instant along with the event -- that way,
+        // we could synchronize painting across the component tree. Also could be useful
+        // in automated tests.
+        // In practice, taking the current instant here is more precise in case some
+        // other component in the tree takes a long time to draw.
+        let now = Instant::now();
+
+        if let State::Initial = self.state {
+            self.paint_loader(self.styles.normal, 0);
+        } else if let State::Grown = self.state {
+            self.paint_loader(self.styles.normal, display::LOADER_MAX as i32);
+        } else {
+            let progress = self.progress(now);
+            if let Some(done) = progress {
+                self.paint_loader(self.styles.normal, done as i32);
+            } else {
+                self.paint_loader(self.styles.normal, 0);
+            }
+        }
+    }
+}
+
+pub struct LoaderStyleSheet {
+    pub normal: &'static LoaderStyle,
+}
+
+pub struct LoaderStyle {
+    pub font: Font,
+    pub fg_color: Color,
+    pub bg_color: Color,
+}
+
+#[cfg(feature = "ui_debug")]
+impl crate::trace::Trace for Loader {
+    fn trace(&self, d: &mut dyn crate::trace::Tracer) {
+        d.open("Loader");
+        d.close();
+    }
+}

--- a/core/embed/rust/src/ui/model_tr/component/mod.rs
+++ b/core/embed/rust/src/ui/model_tr/component/mod.rs
@@ -1,11 +1,15 @@
 mod button;
+mod confirm;
 mod dialog;
 mod frame;
+mod loader;
 mod page;
 
 use super::theme;
 
 pub use button::{Button, ButtonContent, ButtonMsg, ButtonPos, ButtonStyle, ButtonStyleSheet};
+pub use confirm::{HoldToConfirm, HoldToConfirmMsg};
 pub use dialog::{Dialog, DialogMsg};
 pub use frame::Frame;
+pub use loader::{Loader, LoaderMsg, LoaderStyle, LoaderStyleSheet};
 pub use page::ButtonPage;

--- a/core/embed/rust/src/ui/model_tr/constant.rs
+++ b/core/embed/rust/src/ui/model_tr/constant.rs
@@ -3,6 +3,7 @@ use crate::ui::geometry::{Offset, Point, Rect};
 pub const WIDTH: i32 = 128;
 pub const HEIGHT: i32 = 128;
 pub const LINE_SPACE: i32 = 1;
+pub const FONT_BPP: i32 = 1;
 
 pub const fn size() -> Offset {
     Offset::new(WIDTH, HEIGHT)

--- a/core/embed/rust/src/ui/model_tr/theme.rs
+++ b/core/embed/rust/src/ui/model_tr/theme.rs
@@ -1,6 +1,7 @@
 use crate::ui::{
     component::text::layout::DefaultTextTheme,
     display::{Color, Font},
+    model_tr::component::{LoaderStyle, LoaderStyleSheet},
 };
 
 use super::component::{ButtonStyle, ButtonStyleSheet};
@@ -44,6 +45,16 @@ pub fn button_cancel() -> ButtonStyleSheet {
             font: FONT_BOLD,
             text_color: BG,
             border_horiz: false,
+        },
+    }
+}
+
+pub fn loader_default() -> LoaderStyleSheet {
+    LoaderStyleSheet {
+        normal: &LoaderStyle {
+            font: FONT_NORMAL,
+            fg_color: FG,
+            bg_color: BG,
         },
     }
 }

--- a/core/embed/rust/src/ui/model_tt/constant.rs
+++ b/core/embed/rust/src/ui/model_tt/constant.rs
@@ -3,6 +3,7 @@ use crate::ui::geometry::{Offset, Point, Rect};
 pub const WIDTH: i32 = 240;
 pub const HEIGHT: i32 = 240;
 pub const LINE_SPACE: i32 = 4;
+pub const FONT_BPP: i32 = 4;
 
 pub const fn size() -> Offset {
     Offset::new(WIDTH, HEIGHT)


### PR DESCRIPTION
Implements hold to confirm animation on Model R. 

Solves #2276 

Builds on #2317 

To enable text rendering over progress bar animation, this includes rewritten text/glyph rendering in rust. Also rust versions of color interpolation and color tables are now available.

This also enables time based functionality in rust for bootloader (i was using bld for development of this PR so i needed it, but its not necessary for this functionality if used only in firmware).