### PR TITLE
Fix bitcoin only pipeline check

### DIFF
--- a/tools/check-bitcoin-only
+++ b/tools/check-bitcoin-only
@@ -1,7 +1,7 @@
 #!/bin/sh
 RETURN=0
 
-EXCEPTIONS="decred|omni|ripple|dash|TEXT_MARGIN_LEFT|dash_width|dashlane|flo|mnemonic|meter|refuse|fused|enemy|cinema|syntaxerror|mix|palm|UdesRsK|kcc|derive_cardano|ntity|gather|bmc"
+EXCEPTIONS="decred|omni|ripple|dash|TEXT_MARGIN_LEFT|dash_width|dashlane|flo|mnemonic|meter|refuse|fused|enemy|cinema|syntaxerror|mix|palm|UdesRsK|kcc|derive_cardano|ntity|gather|bmc|cloudflare"
 
 # dump all coins except the first 3 (Bitcoin, Testnet, Regtest)
 ALTCOINS=$(./common/tools/cointool.py dump -l -p -t | grep '"name"' | cut -d '"' -f 4 | tail -n +4)


### PR DESCRIPTION
#2336 added cloudflare, since there is a coin named 'flare', this causes bitcoin only check to fail. added 'cloudflare' to exceptions.