### PR TITLE
fix(xmr): add missing view_tags to hf15

### DIFF
--- a/ci/shell.nix
+++ b/ci/shell.nix
@@ -19,8 +19,8 @@ let
     sha256 = "02s3qkb6kz3ndyx7rfndjbvp4vlwiqc42fxypn3g6jnc0v5jyz95";
   }) { };
   moneroTests = nixpkgs.fetchurl {
-    url = "https://github.com/ph4r05/monero/releases/download/v0.17.3.2-dev-tests-u18.04-02/trezor_tests";
-    sha256 = "f790ad7485cbbad92fbea673a75935028f61d42f64627a7c55f850f6742cf93a";
+    url = "https://github.com/ph4r05/monero/releases/download/v0.17.3.2-dev-tests-u18.04-03/trezor_tests";
+    sha256 = "3280aeef795baf2fc46687c07ac4131e5a18767ecdd3af83cf17823ebb2d1007";
   };
   moneroTestsPatched = nixpkgs.runCommandCC "monero_trezor_tests" {} ''
     cp ${moneroTests} $out

--- a/core/.changelog.d/2232.added
+++ b/core/.changelog.d/2232.added
@@ -1,0 +1,1 @@
+Add support for Monero HF15 features.

--- a/core/tests/run_tests_device_emu_monero.sh
+++ b/core/tests/run_tests_device_emu_monero.sh
@@ -23,8 +23,8 @@ fi
 
 # When updating URL and sha256sum also update the URL in ci/shell.nix.
 error=1
-: "${TREZOR_MONERO_TESTS_URL:=https://github.com/ph4r05/monero/releases/download/v0.17.3.2-dev-tests-u18.04-02/trezor_tests}"
-: "${TREZOR_MONERO_TESTS_SHA256SUM:=f790ad7485cbbad92fbea673a75935028f61d42f64627a7c55f850f6742cf93a}"
+: "${TREZOR_MONERO_TESTS_URL:=https://github.com/ph4r05/monero/releases/download/v0.17.3.2-dev-tests-u18.04-03/trezor_tests}"
+: "${TREZOR_MONERO_TESTS_SHA256SUM:=3280aeef795baf2fc46687c07ac4131e5a18767ecdd3af83cf17823ebb2d1007}"
 : "${TREZOR_MONERO_TESTS_PATH:=$CORE_DIR/tests/trezor_monero_tests}"
 : "${TREZOR_MONERO_TESTS_LOG:=$CORE_DIR/tests/trezor_monero_tests.log}"
 : "${TREZOR_MONERO_TESTS_CHAIN:=$CORE_DIR/tests/trezor_monero_tests.chain}"

--- a/core/tests/test_apps.monero.crypto.py
+++ b/core/tests/test_apps.monero.crypto.py
@@ -236,6 +236,18 @@ class TestMoneroCrypto(unittest.TestCase):
         )
         self.assertEqual(pkey_ex, crypto_helpers.encodepoint(pkey_comp))
 
+    def test_view_tags(self):
+        from apps.monero.signing.step_06_set_output import _derive_view_tags
+
+        test_vectors = [
+            (b'0fc47054f355ced4d67de73bfa12e4c78ff19089548fffa7d07a674741860f97', 0, b'\x76'),
+            (b'fe7770c4b076e95ddb8026affcfab39d31c7c4a2266e0e25e343bc4badc907d0', 15, b'\xeb'),
+            (b'ea9337d0ddf480abdc4fc56a0cb223702729cb230ae7b9de50243ad25ce90e8d', 13, b'\x42'),
+        ]
+
+        for key, idx, exp in test_vectors:
+            self.assertEqual(_derive_view_tags(crypto_helpers.decodepoint(unhexlify(key)), idx), exp)
+
 
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
Adds support for view-tags https://github.com/monero-project/monero/pull/8061, new HF15 feature that was missing in the recent PRs. @selsta pinged me with this missing feature https://github.com/monero-project/monero/pull/8299#issuecomment-1160510870

As wallet is using view_key to derive view tags, tx receiving code on the wallet side does not require changes. 

PR is related to the:
- https://github.com/trezor/trezor-firmware/pull/2232
- https://github.com/trezor/trezor-firmware/pull/2219
- https://github.com/monero-project/monero/pull/8299
- https://github.com/monero-project/monero/pull/8061

