### PR TITLE
ci: only use .venv from gitlab cache if commit matches

### DIFF
--- a/ci/build.yml
+++ b/ci/build.yml
@@ -306,6 +306,7 @@ core unix frozen debug build arm:
 
 core unix frozen btconly debug t1 build:
   stage: build
+  <<: *gitlab_caching
   needs: []
   variables:
     BITCOIN_ONLY: "1"

--- a/ci/shell.nix
+++ b/ci/shell.nix
@@ -70,7 +70,6 @@ stdenvNoCC.mkDerivation ({
   ] ++ [
     SDL2
     SDL2_image
-    autoflake
     bash
     check
     curl  # for connect tests

--- a/docs/ci/jobs.md
+++ b/docs/ci/jobs.md
@@ -110,32 +110,32 @@ it is just a single binary file that you can execute directly.
 
 ### [core unix frozen btconly debug t1 build](https://github.com/trezor/trezor-firmware/blob/master/ci/build.yml#L307)
 
-### [core macos frozen regular build](https://github.com/trezor/trezor-firmware/blob/master/ci/build.yml#L322)
+### [core macos frozen regular build](https://github.com/trezor/trezor-firmware/blob/master/ci/build.yml#L323)
 
-### [crypto build](https://github.com/trezor/trezor-firmware/blob/master/ci/build.yml#L347)
+### [crypto build](https://github.com/trezor/trezor-firmware/blob/master/ci/build.yml#L348)
 Build of our cryptographic library, which is then incorporated into the other builds.
 
-### [legacy fw regular build](https://github.com/trezor/trezor-firmware/blob/master/ci/build.yml#L376)
+### [legacy fw regular build](https://github.com/trezor/trezor-firmware/blob/master/ci/build.yml#L377)
 
-### [legacy fw regular debug build](https://github.com/trezor/trezor-firmware/blob/master/ci/build.yml#L392)
+### [legacy fw regular debug build](https://github.com/trezor/trezor-firmware/blob/master/ci/build.yml#L393)
 
-### [legacy fw btconly build](https://github.com/trezor/trezor-firmware/blob/master/ci/build.yml#L409)
+### [legacy fw btconly build](https://github.com/trezor/trezor-firmware/blob/master/ci/build.yml#L410)
 
-### [legacy fw btconly debug build](https://github.com/trezor/trezor-firmware/blob/master/ci/build.yml#L428)
+### [legacy fw btconly debug build](https://github.com/trezor/trezor-firmware/blob/master/ci/build.yml#L429)
 
-### [legacy emu regular debug build](https://github.com/trezor/trezor-firmware/blob/master/ci/build.yml#L449)
+### [legacy emu regular debug build](https://github.com/trezor/trezor-firmware/blob/master/ci/build.yml#L450)
 Regular version (not only Bitcoin) of above.
 **Are you looking for a Trezor One emulator? This is most likely it.**
 
-### [legacy emu regular debug asan build](https://github.com/trezor/trezor-firmware/blob/master/ci/build.yml#L464)
+### [legacy emu regular debug asan build](https://github.com/trezor/trezor-firmware/blob/master/ci/build.yml#L465)
 
-### [legacy emu regular debug build arm](https://github.com/trezor/trezor-firmware/blob/master/ci/build.yml#L482)
+### [legacy emu regular debug build arm](https://github.com/trezor/trezor-firmware/blob/master/ci/build.yml#L483)
 
-### [legacy emu btconly debug build](https://github.com/trezor/trezor-firmware/blob/master/ci/build.yml#L508)
+### [legacy emu btconly debug build](https://github.com/trezor/trezor-firmware/blob/master/ci/build.yml#L509)
 Build of Legacy into UNIX emulator. Use keyboard arrows to emulate button presses.
 Bitcoin-only version.
 
-### [legacy emu btconly debug asan build](https://github.com/trezor/trezor-firmware/blob/master/ci/build.yml#L525)
+### [legacy emu btconly debug asan build](https://github.com/trezor/trezor-firmware/blob/master/ci/build.yml#L526)
 
 ---
 ## TEST stage - [test.yml](../../ci/test.yml)


### PR DESCRIPTION
Nixpkgs bump #2344 caused poetry to fail when old .venv is present: https://gitlab.com/satoshilabs/trezor/trezor-firmware/-/jobs/2625709443. Currently in GitLab CI we cache .venv across builds on the same branch so master branch keeps failing.

The PR changes the cache key so that the cache is only shared by jobs with the same git commit. This makes the cache less effective but improves isolation of builds on long-lived branches.