### PR TITLE
fix(ci): make Connect tests run properly in CI

### DIFF
--- a/ci/test.yml
+++ b/ci/test.yml
@@ -685,7 +685,7 @@ core unix memory profiler:
 # Connect
 
 connect test core:
-  image: ghcr.io/trezor/trezor-user-env
+  image: ghcr.io/trezor/trezor-user-env:185
   stage: test
   needs:
     - core unix frozen debug build
@@ -693,8 +693,8 @@ connect test core:
     SDL_VIDEODRIVER: "dummy"
   before_script:
     - cp /builds/satoshilabs/trezor/trezor-firmware/core/build/unix/trezor-emu-core /trezor-user-env/src/binaries/firmware/bin/trezor-emu-core-v2.99.99
-    - chmod u+x /trezor-user-env/src/binaries/firmware/bin/trezor-emu-core-v2.99.99
-    - nix-shell -p autoPatchelfHook SDL2 SDL2_image --run "autoPatchelf /trezor-user-env/src/binaries/firmware/bin/trezor-emu-core-v2.99.99"
+    - chmod +x /trezor-user-env/src/binaries/firmware/bin/trezor-emu-core-v2.99.99
+    - nix-shell --run "autoPatchelf /trezor-user-env/src/binaries/firmware/bin/trezor-emu-core-v2.99.99"
   script:
     - /trezor-user-env/run-nix.sh &
     - nix-shell --run "tests/connect_tests/connect_tests.sh 2.99.99"

--- a/tests/connect_tests/connect_tests.sh
+++ b/tests/connect_tests/connect_tests.sh
@@ -17,6 +17,9 @@ else
     cd ${CONNECT_DIR}
 fi
 
+echo "Changing 'localhost' to '127.0.0.1' in websocket client as a workaround for CI servers"
+sed -i 's/localhost/127.0.0.1/g' ./tests/websocket-client.js
+
 # Taking an optional script argument with emulator version
 if [ ! -z "${1}" ]
 then


### PR DESCRIPTION
Allowing the `Connect` tests to run again in `CI`.
- "fixing" the situation on our (CI server) side - changing `localhost` to `127.0.0.1` as a `tenv`'s websocket address - because the CI servers could not resolve `localhost`
  - we could change it in `Connect` code, but I think there is no need - our servers are "broken", not the `Connect` side
- slightly changing the logic of patching the emulators - using `autoPatchelf` directly from the `tenv`'s `nix-shell` - change in `tenv` necessary
  - TODO: remove the `:185` image tag from `tenv` once [this tenv PR](https://github.com/trezor/trezor-user-env/pull/185) gets merged

There are still 24 failing tests - see [last CI](https://gitlab.com/satoshilabs/trezor/trezor-firmware/-/jobs/2661501018) - but these are not `CI` issues, but some inconsistencies between `Connect` and `firmware`.

EDIT: the `Connect` failures are mostly because of `All backends are down`, could be some connectivity thing