### PR TITLE
Account for minimum registrable output amount in CoinJoin checks

### DIFF
--- a/core/src/apps/bitcoin/sign_tx/approvers.py
+++ b/core/src/apps/bitcoin/sign_tx/approvers.py
@@ -328,6 +328,12 @@ class BasicApprover(Approver):
 
 
 class CoinJoinApprover(Approver):
+    # Minimum registrable output amount in a CoinJoin.
+    MIN_REGISTRABLE_OUTPUT_AMOUNT = 5000
+
+    # Largest possible weight of an output supported by Trezor (P2TR or P2WSH).
+    MAX_OUTPUT_WEIGHT = 4 * (8 + 1 + 1 + 1 + 32)
+
     def __init__(
         self, tx: SignTx, coin: CoinInfo, authorization: CoinJoinAuthorization
     ) -> None:
@@ -410,7 +416,26 @@ class CoinJoinApprover(Approver):
         # Total fees that the user is paying.
         our_fees = self.total_in - self.external_in - self.change_out
 
-        if our_fees > our_max_coordinator_fee + our_max_mining_fee:
+        # For the next step we need to estimate an upper bound on the mining fee used by the
+        # coordinator. The coordinator does not include the base weight of the transaction when
+        # computing the mining fee, so we take this into account.
+        max_fee_per_weight_unit = mining_fee / (
+            self.weight.get_total() - self.weight.get_base_weight()
+        )
+
+        # Calculate the minimum registrable output amount in a CoinJoin plus the mining fee that it
+        # would cost to register. Amounts below this value are left to the coordinator or miners
+        # and effectively constitute an extra fee for the user.
+        min_allowed_output_amount_plus_fee = (
+            self.MIN_REGISTRABLE_OUTPUT_AMOUNT
+            + max_fee_per_weight_unit * self.MAX_OUTPUT_WEIGHT
+        )
+
+        if our_fees > (
+            our_max_coordinator_fee
+            + our_max_mining_fee
+            + min_allowed_output_amount_plus_fee
+        ):
             raise wire.ProcessError("Total fee over threshold.")
 
         if not self.authorization.approve_sign_tx(tx_info.tx):

--- a/core/src/apps/bitcoin/sign_tx/tx_weight.py
+++ b/core/src/apps/bitcoin/sign_tx/tx_weight.py
@@ -45,7 +45,7 @@ class TxWeightCalculator:
     def __init__(self) -> None:
         self.inputs_count = 0
         self.outputs_count = 0
-        self.counter = 4 * (_TXSIZE_HEADER + _TXSIZE_FOOTER)
+        self.counter = 0
         self.segwit_inputs_count = 0
 
     def add_input(self, i: TxInput) -> None:
@@ -131,12 +131,19 @@ class TxWeightCalculator:
         script_size = self.compact_size_len(len(script)) + len(script)
         self.counter += 4 * (_TXSIZE_OUTPUT + script_size)
 
+    def get_base_weight(self) -> int:
+        base_weight = 4 * (_TXSIZE_HEADER + _TXSIZE_FOOTER)
+        base_weight += 4 * self.compact_size_len(self.inputs_count)
+        base_weight += 4 * self.compact_size_len(self.outputs_count)
+        if self.segwit_inputs_count:
+            base_weight += _TXSIZE_SEGWIT_OVERHEAD
+
+        return base_weight
+
     def get_total(self) -> int:
         total = self.counter
-        total += 4 * self.compact_size_len(self.inputs_count)
-        total += 4 * self.compact_size_len(self.outputs_count)
+        total += self.get_base_weight()
         if self.segwit_inputs_count:
-            total += _TXSIZE_SEGWIT_OVERHEAD
             # add one byte of witness stack item count per non-segwit input
             total += self.inputs_count - self.segwit_inputs_count
 


### PR DESCRIPTION
Implements https://www.notion.so/satoshilabs/Add-dust-upper-bound-to-Trezor-CoinJoin-checks-f1265e781d6847f49b2f0029401339b0.