### PR TITLE
Fix firmware initialization

### DIFF
--- a/core/.changelog.d/2130.changed
+++ b/core/.changelog.d/2130.changed
@@ -1,0 +1,1 @@
+Remove power-down power-up cycle from touch controller initialization in firmware

--- a/core/.changelog.d/2130.removed
+++ b/core/.changelog.d/2130.removed
@@ -1,1 +1,0 @@
-Don't initialize touch controller in firmware

--- a/core/embed/bootloader/main.c
+++ b/core/embed/bootloader/main.c
@@ -250,8 +250,8 @@ int main(void) {
   random_delays_init();
   // display_init_seq();
 #if defined TREZOR_MODEL_T
-  touch_init();
   touch_power_on();
+  touch_init();
 #endif
 
 #if defined TREZOR_MODEL_R

--- a/core/embed/firmware/main.c
+++ b/core/embed/firmware/main.c
@@ -73,7 +73,7 @@ int main(void) {
 #endif
 
   // reinitialize HAL for Trezor One
-#if defined TREZOR_MODEL_1 || defined TREZOR_MODEL_R
+#if defined TREZOR_MODEL_1
   HAL_Init();
 #endif
 
@@ -85,9 +85,7 @@ int main(void) {
 
 #if !defined TREZOR_MODEL_1
   parse_boardloader_capabilities();
-#endif
 
-#if defined TREZOR_MODEL_T
 #if PRODUCTION
   check_and_replace_bootloader();
 #endif
@@ -98,7 +96,7 @@ int main(void) {
   // Init peripherals
   pendsv_init();
 
-#if defined TREZOR_MODEL_1 || defined TREZOR_MODEL_R
+#if defined TREZOR_MODEL_1
   display_init();
   button_init();
 #endif
@@ -113,13 +111,14 @@ int main(void) {
   touch_init();
   // display_init_seq();
   sdcard_init();
+  display_clear();
+#endif
 
+#if !defined TREZOR_MODEL_1
   // jump to unprivileged mode
   // http://infocenter.arm.com/help/topic/com.arm.doc.dui0552a/CHDBIBGJ.html
   __asm__ volatile("msr control, %0" ::"r"(0x1));
   __asm__ volatile("isb");
-
-  display_clear();
 #endif
 
 #ifdef USE_SECP256K1_ZKP

--- a/core/embed/firmware/main.c
+++ b/core/embed/firmware/main.c
@@ -110,6 +110,7 @@ int main(void) {
 #endif
 
 #if defined TREZOR_MODEL_T
+  touch_init();
   // display_init_seq();
   sdcard_init();
 


### PR DESCRIPTION
This PR partially reintroduces touch controller initialization in firmware:
- turns out that if we want to change operation mode of the controller in future, we might have issues when settings from bootloader being incompatible with algorithm used in firmware - this could happen for example if new bootloader is used with intentionally downgraded firmware
- the removal of initialization also caused uninitialized i2c handler being used, which only accidentally didn't cause crashes due to fact that the touch_read function evaluated the uninitialized handler as being BUSY, and thus did I2C reset cycle, which fixed things - but this introduced some unnecessary delays
- this PR also fixes Model R firmware initialization, where some stuff wasn't called and some stuff was called twice or erroneously. A little reorganization of compilation conditions was make the process more clear.


closes #2130 