### PR TITLE
Optimize touch controller polling

### DIFF
--- a/core/.changelog.d/262.added
+++ b/core/.changelog.d/262.added
@@ -1,0 +1,1 @@
+Optimize touch controller communication

--- a/core/embed/bootloader/.changelog.d/262.added
+++ b/core/embed/bootloader/.changelog.d/262.added
@@ -1,0 +1,1 @@
+Optimize touch controller communication


### PR DESCRIPTION
This PR optimizes polling the touch controller by only polling when new data are ready, which significantly reduce cpu load when touch is active. 

Also removed the duplicate data detection, with reasoning that previously we filtered this out because we were literally polling the same data multiple times until new data were ready. We might still receive new data with same values though, not sure we would ever find this useful, so maybe the filtering should stay?

This could be also taken a bit further, using interrupts and DMA we could probably offload most of the work to peripherals, but it brings some issues to solve like polling done in the background even when no one wants the data, possibly synchronizing the access to the read buffer, and introducing new interrupt(s) brings some bootloader-firmware compatibility issues.

Builds on #2396 

closes #262 