### PR TITLE
Add error message to check-bitcoin-only

### DIFF
--- a/tools/check-bitcoin-only
+++ b/tools/check-bitcoin-only
@@ -17,4 +17,7 @@ for altcoin in $ALTCOINS; do
 done
 IFS=$OLDIFS
 
+if [ $RETURN -ne 0 ]; then
+    echo "ERROR: Altcoin strings found in Bitcoin-only firmware."
+fi
 exit $RETURN


### PR DESCRIPTION
Show an error string like in the example below on line 323. Otherwise it's not clear why the build failed.

![image](https://user-images.githubusercontent.com/42678794/181002970-f60521ec-820b-4870-b12c-927552dbe79e.png)
