### PR TITLE
Run fuzzer in CI

### DIFF
--- a/.clusterfuzzlite/Dockerfile
+++ b/.clusterfuzzlite/Dockerfile
@@ -1,0 +1,6 @@
+FROM gcr.io/oss-fuzz-base/base-builder
+RUN apt-get update && apt-get install -y make autoconf automake libtool \
+  pkg-config
+COPY . $SRC/trezor-firmware
+WORKDIR $SRC/trezor-firmware/crypto
+COPY .clusterfuzzlite/build.sh $SRC/

--- a/.clusterfuzzlite/build.sh
+++ b/.clusterfuzzlite/build.sh
@@ -1,0 +1,5 @@
+# reset sanitizer and optimization flags to avoid interfering with $CFLAGS
+export SANFLAGS=""
+export OPTFLAGS="-O3 -march=native -gline-tables-only"
+FUZZER=1 VALGRIND=0 make -j$(nproc) fuzzer
+mv fuzzer/fuzzer $OUT/

--- a/.clusterfuzzlite/project.yaml
+++ b/.clusterfuzzlite/project.yaml
@@ -1,0 +1,1 @@
+language: c

--- a/.github/workflows/cflite.yml
+++ b/.github/workflows/cflite.yml
@@ -1,0 +1,29 @@
+name: ClusterFuzzLite PR fuzzing
+on:
+  workflow_dispatch:
+  pull_request:
+    paths:
+      - '**'
+permissions: read-all
+jobs:
+  PR:
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        sanitizer: [address]
+    steps:
+      - name: Build Fuzzers (${{ matrix.sanitizer }})
+        id: build
+        uses: google/clusterfuzzlite/actions/build_fuzzers@v1
+        with:
+          sanitizer: ${{ matrix.sanitizer }}
+          language: c
+      - name: Run Fuzzers (${{ matrix.sanitizer }})
+        id: run
+        uses: google/clusterfuzzlite/actions/run_fuzzers@v1
+        with:
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          fuzz-seconds: 400
+          mode: 'code-change'
+          sanitizer: ${{ matrix.sanitizer }}


### PR DESCRIPTION
This PR adds [ClusterfuzzLite](https://google.github.io/clusterfuzzlite/) which runs the crypto fuzzer when PRs are made. 

ClusterfuzzLite  can be extended beyond this PR with code coverage and batch fuzzing: https://google.github.io/clusterfuzzlite/running-clusterfuzzlite/github-actions/

Signed-off-by: AdamKorcz <Adam@adalogics.com>