### PR TITLE
fix(docs): make create_monorepo link absolute to work on docs.trezor.io

### DIFF
--- a/docs/misc/monorepo.md
+++ b/docs/misc/monorepo.md
@@ -7,7 +7,7 @@ Generating
 
 Use the [create_monorepo] script to regenerate from current master(s).
 
-[create_monorepo]: ../../create_monorepo.py
+[create_monorepo]: https://github.com/trezor/trezor-firmware/blob/master/create_monorepo.py
 
 
 Structure


### PR DESCRIPTION
As per [Notion discussion](https://www.notion.so/satoshilabs/Broken-Links-5771-66fdc1b727a048648aba5ae0cc3fc325) and [Suite issue](https://github.com/trezor/trezor-suite/issues/5771), there is a broken link on https://docs.trezor.io/trezor-firmware/misc/monorepo.html pointing at https://docs.trezor.io/create_monorepo.py, which does not exist - because it is a relative link.

Making that link to `create_monorepo.py` absolute so it can be accessed even on `docs.trezor.io`