### PR TITLE
Add busy screen

### DIFF
--- a/common/protob/messages-management.proto
+++ b/common/protob/messages-management.proto
@@ -111,6 +111,7 @@ message Features {
     optional uint32 auto_lock_delay_ms = 38;    // number of milliseconds after which the device locks itself
     optional uint32 display_rotation = 39;      // in degrees from North
     optional bool experimental_features = 40;   // are experimental message types enabled?
+    optional bool busy = 41;                    // is the device busy, showing "Do not disconnect"?
 }
 
 /**
@@ -119,6 +120,15 @@ message Features {
  * @next Success
  */
 message LockDevice {
+}
+
+/**
+ * Request: Show a "Do not disconnect" dialog instead of the standard homescreen.
+ * @start
+ * @next Success
+ */
+message SetBusy {
+    optional uint32 expiry_ms = 1;  // The time in milliseconds after which the dialog will automatically disappear. Overrides any previously set expiry. If not set, then the dialog is hidden.
 }
 
 /**

--- a/common/protob/messages.proto
+++ b/common/protob/messages.proto
@@ -87,6 +87,7 @@ enum MessageType {
     MessageType_Entropy = 10 [(bitcoin_only) = true, (wire_out) = true];
     MessageType_LoadDevice = 13 [(bitcoin_only) = true, (wire_in) = true];
     MessageType_ResetDevice = 14 [(bitcoin_only) = true, (wire_in) = true];
+    MessageType_SetBusy = 16 [(bitcoin_only) = true, (wire_in) = true];
     MessageType_Features = 17 [(bitcoin_only) = true, (wire_out) = true];
     MessageType_PinMatrixRequest = 18 [(bitcoin_only) = true, (wire_out) = true];
     MessageType_PinMatrixAck = 19 [(bitcoin_only) = true, (wire_in) = true, (wire_tiny) = true, (wire_no_fsm) = true];

--- a/core/.changelog.d/2445.added
+++ b/core/.changelog.d/2445.added
@@ -1,0 +1,1 @@
+Support SetBusy message.

--- a/core/src/all_modules.py
+++ b/core/src/all_modules.py
@@ -351,6 +351,8 @@ apps.debug.load_device
 import apps.debug.load_device
 apps.homescreen
 import apps.homescreen
+apps.homescreen.busyscreen
+import apps.homescreen.busyscreen
 apps.homescreen.homescreen
 import apps.homescreen.homescreen
 apps.homescreen.lockscreen

--- a/core/src/apps/homescreen/busyscreen.py
+++ b/core/src/apps/homescreen/busyscreen.py
@@ -1,0 +1,29 @@
+import storage.cache
+from trezor import loop, ui
+from trezor.ui.layouts import draw_simple_text
+
+from apps.base import busy_expiry_ms, set_homescreen
+
+from . import HomescreenBase
+
+
+async def busyscreen() -> None:
+    await Busyscreen()
+
+
+class Busyscreen(HomescreenBase):
+    RENDER_INDICATOR = storage.cache.BUSYSCREEN_ON
+
+    def create_tasks(self) -> tuple[loop.AwaitableTask, ...]:
+        return self.handle_rendering(), self.handle_input(), self.handle_expiry()
+
+    def handle_expiry(self) -> loop.Task:  # type: ignore [awaitable-is-generator]
+        yield loop.sleep(busy_expiry_ms())
+        storage.cache.delete(storage.cache.APP_COMMON_BUSY_DEADLINE_MS)
+        set_homescreen()
+        raise ui.Result(None)
+
+    def do_render(self) -> None:
+        draw_simple_text(
+            "Please wait", "CoinJoin in progress.\n\nDo not disconnect your\nTrezor."
+        )

--- a/core/src/storage/cache.py
+++ b/core/src/storage/cache.py
@@ -30,6 +30,7 @@ APP_COMMON_SEED_WITHOUT_PASSPHRASE = 0 | _SESSIONLESS_FLAG
 APP_COMMON_SAFETY_CHECKS_TEMPORARY = 1 | _SESSIONLESS_FLAG
 STORAGE_DEVICE_EXPERIMENTAL_FEATURES = 2 | _SESSIONLESS_FLAG
 APP_COMMON_REQUEST_PIN_LAST_UNLOCK = 3 | _SESSIONLESS_FLAG
+APP_COMMON_BUSY_DEADLINE_MS = 4 | _SESSIONLESS_FLAG
 
 
 # === Homescreen storage ===
@@ -40,6 +41,7 @@ APP_COMMON_REQUEST_PIN_LAST_UNLOCK = 3 | _SESSIONLESS_FLAG
 # is still on. This way we can avoid unnecessary fadeins/fadeouts when a workflow ends.
 HOMESCREEN_ON = object()
 LOCKSCREEN_ON = object()
+BUSYSCREEN_ON = object()
 homescreen_shown: object | None = None
 
 
@@ -132,6 +134,7 @@ class SessionlessCache(DataCache):
             1,  # APP_COMMON_SAFETY_CHECKS_TEMPORARY
             1,  # STORAGE_DEVICE_EXPERIMENTAL_FEATURES
             4,  # APP_COMMON_REQUEST_PIN_LAST_UNLOCK
+            4,  # APP_COMMON_BUSY_DEADLINE_MS
         )
         super().__init__()
 

--- a/core/src/trezor/enums/MessageType.py
+++ b/core/src/trezor/enums/MessageType.py
@@ -14,6 +14,7 @@ GetEntropy = 9
 Entropy = 10
 LoadDevice = 13
 ResetDevice = 14
+SetBusy = 16
 Features = 17
 PinMatrixRequest = 18
 PinMatrixAck = 19

--- a/core/src/trezor/enums/__init__.py
+++ b/core/src/trezor/enums/__init__.py
@@ -31,6 +31,7 @@ if TYPE_CHECKING:
         Entropy = 10
         LoadDevice = 13
         ResetDevice = 14
+        SetBusy = 16
         Features = 17
         PinMatrixRequest = 18
         PinMatrixAck = 19

--- a/core/src/trezor/messages.py
+++ b/core/src/trezor/messages.py
@@ -2050,6 +2050,7 @@ if TYPE_CHECKING:
         auto_lock_delay_ms: "int | None"
         display_rotation: "int | None"
         experimental_features: "bool | None"
+        busy: "bool | None"
 
         def __init__(
             self,
@@ -2091,6 +2092,7 @@ if TYPE_CHECKING:
             auto_lock_delay_ms: "int | None" = None,
             display_rotation: "int | None" = None,
             experimental_features: "bool | None" = None,
+            busy: "bool | None" = None,
         ) -> None:
             pass
 
@@ -2102,6 +2104,20 @@ if TYPE_CHECKING:
 
         @classmethod
         def is_type_of(cls, msg: protobuf.MessageType) -> TypeGuard["LockDevice"]:
+            return isinstance(msg, cls)
+
+    class SetBusy(protobuf.MessageType):
+        expiry_ms: "int | None"
+
+        def __init__(
+            self,
+            *,
+            expiry_ms: "int | None" = None,
+        ) -> None:
+            pass
+
+        @classmethod
+        def is_type_of(cls, msg: protobuf.MessageType) -> TypeGuard["SetBusy"]:
             return isinstance(msg, cls)
 
     class EndSession(protobuf.MessageType):

--- a/legacy/firmware/protob/Makefile
+++ b/legacy/firmware/protob/Makefile
@@ -5,7 +5,7 @@ endif
 SKIPPED_MESSAGES := Binance Cardano DebugMonero Eos Monero Ontology Ripple SdProtect Tezos WebAuthn \
 	DebugLinkRecordScreen DebugLinkEraseSdCard DebugLinkWatchLayout \
 	GetOwnershipProof OwnershipProof GetOwnershipId OwnershipId AuthorizeCoinJoin DoPreauthorized \
-	CancelAuthorization DebugLinkLayout GetNonce \
+	CancelAuthorization DebugLinkLayout GetNonce SetBusy \
 	TxAckInput TxAckOutput TxAckPrev TxAckPaymentRequest \
 	EthereumSignTypedData EthereumTypedDataStructRequest EthereumTypedDataStructAck \
 	EthereumTypedDataValueRequest EthereumTypedDataValueAck

--- a/python/.changelog.d/2445.added
+++ b/python/.changelog.d/2445.added
@@ -1,0 +1,1 @@
+Add device set-busy command to trezorctl.

--- a/python/src/trezorlib/cli/device.py
+++ b/python/src/trezorlib/cli/device.py
@@ -290,3 +290,30 @@ def reboot_to_bootloader(obj: "TrezorConnection") -> str:
     # which triggers double prompt on device
     with obj.client_context() as client:
         return device.reboot_to_bootloader(client)
+
+
+@cli.command()
+@click.argument("enable", type=ChoiceType({"on": True, "off": False}), required=False)
+@click.option(
+    "-e",
+    "--expiry",
+    type=int,
+    help="Dialog expiry in seconds.",
+)
+@with_client
+def set_busy(
+    client: "TrezorClient", enable: Optional[bool], expiry: Optional[int]
+) -> str:
+    """Show a "Do not disconnect" dialog."""
+    if enable is False:
+        return device.set_busy(client, None)
+
+    if expiry is None:
+        raise click.ClickException("Missing option '-e' / '--expiry'.")
+
+    if expiry <= 0:
+        raise click.ClickException(
+            f"Invalid value for '-e' / '--expiry': '{expiry}' is not a positive integer."
+        )
+
+    return device.set_busy(client, expiry * 1000)

--- a/python/src/trezorlib/device.py
+++ b/python/src/trezorlib/device.py
@@ -224,3 +224,16 @@ def cancel_authorization(client: "TrezorClient") -> "MessageType":
 @expect(messages.Success, field="message", ret_type=str)
 def reboot_to_bootloader(client: "TrezorClient") -> "MessageType":
     return client.call(messages.RebootToBootloader())
+
+
+@expect(messages.Success, field="message", ret_type=str)
+@session
+def set_busy(client: "TrezorClient", expiry_ms: Optional[int]) -> "MessageType":
+    """Sets or clears the busy state of the device.
+
+    In the busy state the device shows a "Do not disconnect" message instead of the homescreen.
+    Setting `expiry_ms=None` clears the busy state.
+    """
+    ret = client.call(messages.SetBusy(expiry_ms=expiry_ms))
+    client.refresh_features()
+    return ret

--- a/python/src/trezorlib/messages.py
+++ b/python/src/trezorlib/messages.py
@@ -39,6 +39,7 @@ class MessageType(IntEnum):
     Entropy = 10
     LoadDevice = 13
     ResetDevice = 14
+    SetBusy = 16
     Features = 17
     PinMatrixRequest = 18
     PinMatrixAck = 19
@@ -3064,6 +3065,7 @@ class Features(protobuf.MessageType):
         38: protobuf.Field("auto_lock_delay_ms", "uint32", repeated=False, required=False),
         39: protobuf.Field("display_rotation", "uint32", repeated=False, required=False),
         40: protobuf.Field("experimental_features", "bool", repeated=False, required=False),
+        41: protobuf.Field("busy", "bool", repeated=False, required=False),
     }
 
     def __init__(
@@ -3107,6 +3109,7 @@ class Features(protobuf.MessageType):
         auto_lock_delay_ms: Optional["int"] = None,
         display_rotation: Optional["int"] = None,
         experimental_features: Optional["bool"] = None,
+        busy: Optional["bool"] = None,
     ) -> None:
         self.capabilities: Sequence["Capability"] = capabilities if capabilities is not None else []
         self.major_version = major_version
@@ -3146,10 +3149,25 @@ class Features(protobuf.MessageType):
         self.auto_lock_delay_ms = auto_lock_delay_ms
         self.display_rotation = display_rotation
         self.experimental_features = experimental_features
+        self.busy = busy
 
 
 class LockDevice(protobuf.MessageType):
     MESSAGE_WIRE_TYPE = 24
+
+
+class SetBusy(protobuf.MessageType):
+    MESSAGE_WIRE_TYPE = 16
+    FIELDS = {
+        1: protobuf.Field("expiry_ms", "uint32", repeated=False, required=False),
+    }
+
+    def __init__(
+        self,
+        *,
+        expiry_ms: Optional["int"] = None,
+    ) -> None:
+        self.expiry_ms = expiry_ms
 
 
 class EndSession(protobuf.MessageType):

--- a/tests/device_tests/test_busy_state.py
+++ b/tests/device_tests/test_busy_state.py
@@ -1,0 +1,68 @@
+# This file is part of the Trezor project.
+#
+# Copyright (C) 2022 SatoshiLabs and contributors
+#
+# This library is free software: you can redistribute it and/or modify
+# it under the terms of the GNU Lesser General Public License version 3
+# as published by the Free Software Foundation.
+#
+# This library is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU Lesser General Public License for more details.
+#
+# You should have received a copy of the License along with this library.
+# If not, see <https://www.gnu.org/licenses/lgpl-3.0.html>.
+
+import time
+
+import pytest
+
+from trezorlib import btc, device
+from trezorlib.debuglink import TrezorClientDebugLink as Client
+from trezorlib.tools import parse_path
+
+PIN = "1234"
+
+pytestmark = pytest.mark.skip_t1
+
+
+@pytest.mark.setup_client(pin=PIN)
+def test_busy_state(client: Client):
+    assert client.features.unlocked is False
+    assert client.features.busy is False
+
+    # Show busy dialog for 1 minute.
+    device.set_busy(client, expiry_ms=60 * 1000)
+    assert client.features.unlocked is False
+    assert client.features.busy is True
+
+    with client:
+        client.use_pin_sequence([PIN])
+        btc.get_address(
+            client, "Bitcoin", parse_path("m/44h/0h/0h/0/0"), show_display=True
+        )
+
+    client.refresh_features()
+    assert client.features.unlocked is True
+    assert client.features.busy is True
+
+    # Hide the busy dialog.
+    device.set_busy(client, None)
+
+    assert client.features.unlocked is True
+    assert client.features.busy is False
+
+
+def test_busy_expiry(client: Client):
+    expiry_ms = 100  # 100 milliseconds
+
+    # Show the busy dialog.
+    device.set_busy(client, expiry_ms=expiry_ms)
+
+    # Wait for it to expire.
+    time.sleep(expiry_ms / 1000)
+
+    # Check that the device is no longer busy.
+    client.refresh_features()
+    assert client.features.busy is False

--- a/tests/ui_tests/fixtures.json
+++ b/tests/ui_tests/fixtures.json
@@ -1535,6 +1535,8 @@
 "TT_test_basic.py::test_device_id_same": "c09de07fbbf1e047442180e2facb5482d06a1a428891b875b7dd93c9e4704ae1",
 "TT_test_basic.py::test_features": "c09de07fbbf1e047442180e2facb5482d06a1a428891b875b7dd93c9e4704ae1",
 "TT_test_basic.py::test_ping": "c09de07fbbf1e047442180e2facb5482d06a1a428891b875b7dd93c9e4704ae1",
+"TT_test_busy_state.py::test_busy_expiry": "84cbf08ffe52f79e63d32ed2298dbdc60c74059bcf59eaa69c01f13acf61c8ae",
+"TT_test_busy_state.py::test_busy_state": "0517aa3301d4f55068766dfc130139e45449d8f90213d4a51c49776e3bbb7c98",
 "TT_test_cancel.py::test_cancel_message_via_cancel[message0]": "b014449cbf1a45739d64a370b30af75df2228f48c090a02227bac8ed20c7b2dc",
 "TT_test_cancel.py::test_cancel_message_via_cancel[message1]": "b014449cbf1a45739d64a370b30af75df2228f48c090a02227bac8ed20c7b2dc",
 "TT_test_cancel.py::test_cancel_message_via_initialize[message0]": "b014449cbf1a45739d64a370b30af75df2228f48c090a02227bac8ed20c7b2dc",


### PR DESCRIPTION
This PR implements a new `SetBusy` message in `core` which causes Trezor T to show a "Do not disconnect" screen instead of the standard homescreen or lockscreen. Suite will need to display this screen at the moment before it commits to participate in a CoinJoin round. The message should appear for about 2 minutes, after which the CoinJoin transaction will be signed. During these two minutes Trezor is just waiting for the signing phase. It is possible for other operations to be called, but UI workflows should be discouraged, because if the UI workflow is running when Suite needs to sign the CoinJoin, then the workflow will be interrupted. Applications should check the `busy` parameter in `Features` and prevent the user from launching a UI workflow if `busy == True`, e.g. by disabling the "Receive" button in Suite. 

The message has an optional parameter `expiry_ms` that sets the time after which the "Do not disconnect" screen will automatically disappear. This is to prevent the message from appearing on the Trezor forever in case the desktop app shuts down in the middle of the CoinJoin workflow. Applications should explicitly hide the busy screen when the workflow is complete by calling `SetBusy` with `expiry_ms=0` or not set.

In the future we can add an `enum` to `SetBusy` which will indicate the reason for the busy state. Right now it only makes sense to show CoinJoin as the reason.

![image](https://user-images.githubusercontent.com/42678794/184121016-7828ebf7-1302-4963-9ec7-0d37446ff326.png)
