### PR TITLE
build: update Rust overlay, switch to Rust stable 1.63

### DIFF
--- a/ci/shell.nix
+++ b/ci/shell.nix
@@ -5,8 +5,8 @@
 let
   # the last commit from master as of 2022-02-08
   rustOverlay = import (builtins.fetchTarball {
-    url = "https://github.com/oxalica/rust-overlay/archive/2eae19e246433530998cbf239d5505b7b87bc854.tar.gz";
-    sha256 = "0panx24sqcvx52wza02zsxmpkhg6xld7hklrv7dybc59akqm2ira";
+    url = "https://github.com/oxalica/rust-overlay/archive/b38c1683594aeefa5c3c4dde115401f059146be6.tar.gz";
+    sha256 = "0rk4i42cys2v7k2ir57x5qa8dc37nrs432cdpbr4cddskgvyi8ky";
   });
   # the last successful build of nixpkgs-unstable as of 2022-06-20
   nixpkgs = import (builtins.fetchTarball {
@@ -29,7 +29,7 @@ let
     chmod -w $out
   '';
   # NOTE: don't forget to update Minimum Supported Rust Version in docs/core/build/emulator.md
-  rustProfiles = nixpkgs.rust-bin.stable."1.58.1";
+  rustProfiles = nixpkgs.rust-bin.stable."1.63.0";
   rustStable = rustProfiles.minimal.override {
     targets = [
       "thumbv7em-none-eabihf" # TT


### PR DESCRIPTION
we accidentally pushed a 1.62 feature into master.
this brings the situation back under control