### PR TITLE
ci: fix data deploy job for release

### DIFF
--- a/ci/deploy.yml
+++ b/ci/deploy.yml
@@ -274,9 +274,6 @@ sync emulators to aws:
     BUCKET: "data.trezor.io"
     GIT_SUBMODULE_STRATEGY: "none"
   before_script: []  # no poetry
-  needs:
-    - release legacy unix debug deploy
-    - release core unix debug deploy
   script:
     - source ${AWS_DEPLOY_DATA}
     - aws s3 sync $DEPLOY_PATH s3://$BUCKET/dev/firmware/releases/emulators/

--- a/docs/ci/jobs.md
+++ b/docs/ci/jobs.md
@@ -300,6 +300,6 @@ Consists of **14 jobs** below:
 
 ### [sync emulators to aws](https://github.com/trezor/trezor-firmware/blob/master/ci/deploy.yml#L270)
 
-### [common sync](https://github.com/trezor/trezor-firmware/blob/master/ci/deploy.yml#L298)
+### [common sync](https://github.com/trezor/trezor-firmware/blob/master/ci/deploy.yml#L295)
 
 ---


### PR DESCRIPTION
Fixes the job deploy emulators to aws which causes jobs on tag to not run, this should solve the error.
