### PR TITLE
Switch to nightly Rust 

### DIFF
--- a/ci/shell.nix
+++ b/ci/shell.nix
@@ -3,7 +3,7 @@
  }:
 
 let
-  # the last commit from master as of 2022-02-08
+  # the last commit from master as of 2022-08-02
   rustOverlay = import (builtins.fetchTarball {
     url = "https://github.com/oxalica/rust-overlay/archive/b38c1683594aeefa5c3c4dde115401f059146be6.tar.gz";
     sha256 = "0rk4i42cys2v7k2ir57x5qa8dc37nrs432cdpbr4cddskgvyi8ky";
@@ -29,15 +29,15 @@ let
     chmod -w $out
   '';
   # NOTE: don't forget to update Minimum Supported Rust Version in docs/core/build/emulator.md
-  rustProfiles = nixpkgs.rust-bin.stable."1.63.0";
-  rustStable = rustProfiles.minimal.override {
+  rustProfiles = nixpkgs.rust-bin.nightly."2022-08-02";
+  rustNightly = rustProfiles.minimal.override {
     targets = [
       "thumbv7em-none-eabihf" # TT
       "thumbv7m-none-eabi"    # T1
     ];
     # we use rustfmt from nixpkgs because it's built with the nighly flag needed for wrap_comments
     # to use official binary, remove rustfmt from buildInputs and add it to extensions:
-    extensions = [ "clippy" ];
+    extensions = [ "clippy" "rustfmt" ];
   };
   llvmPackages = nixpkgs.llvmPackages_13;
   # see pyright/README.md for update procedure
@@ -88,8 +88,7 @@ stdenvNoCC.mkDerivation ({
     poetry
     protobuf
     pyright
-    rustfmt
-    rustStable
+    rustNightly
     wget
     zlib
     moreutils

--- a/ci/shell.nix
+++ b/ci/shell.nix
@@ -37,7 +37,7 @@ let
     ];
     # we use rustfmt from nixpkgs because it's built with the nighly flag needed for wrap_comments
     # to use official binary, remove rustfmt from buildInputs and add it to extensions:
-    extensions = [ "clippy" "rustfmt" ];
+    extensions = [ "rust-src" "clippy" "rustfmt" ];
   };
   llvmPackages = nixpkgs.llvmPackages_13;
   # see pyright/README.md for update procedure

--- a/core/SConscript.firmware
+++ b/core/SConscript.firmware
@@ -719,7 +719,16 @@ def cargo_build():
         if PYOPT == '0':
             features.append('ui_debug')
 
-    return f'cd embed/rust; cargo build {profile} --target={RUST_TARGET} --target-dir=../../build/firmware/rust --no-default-features --features "{" ".join(features)}"'
+    cargo_opts = [
+        f'--target={RUST_TARGET}',
+        f'--target-dir=../../build/firmware/rust',
+        '--no-default-features',
+        '--features ' + ','.join(features),
+        '-Z build-std=core',
+        '-Z build-std-features=panic_immediate_abort',
+    ]
+
+    return f'cd embed/rust; cargo build {profile} ' + ' '.join(cargo_opts)
 
 rust = env.Command(
     target=RUST_LIBPATH,

--- a/docs/core/build/emulator.md
+++ b/docs/core/build/emulator.md
@@ -54,12 +54,12 @@ brew install scons sdl2 sdl2_image pkg-config llvm
 
 ## Rust
 
-You will require Rust and Cargo. The currently supported version is 1.58 stable.
-The recommended way to install both is with [`rustup`](https://rustup.rs/). If you
-are installing `rustup` for the first time, the stable toolchain will be installed
-for you automatically. Otherwise, make sure you are up to date:
+You will require Rust and Cargo. The currently supported version is 1.64 nightly. The
+recommended way to install both is with [`rustup`](https://rustup.rs/). Make sure you
+are up to date:
 
 ```sh
+rustup default nightly
 rustup update
 ```
 


### PR DESCRIPTION
We require nightly Rust compiler for the panic_immediate_abort feature of core libraries. This feature will compile all panic!s into a single fault instruction, which saves significant amount of space.

For now, we are not using any nightly code features. But now that we need nightly Rust anyway, we can start.

supersedes #2460 , branch rename so that we get HW tests on this