### PR TITLE
Do not show "USB NOT CONNECTED" if device enters USB suspend state

### DIFF
--- a/core/embed/trezorhal/usb.c
+++ b/core/embed/trezorhal/usb.c
@@ -153,8 +153,16 @@ void usb_start(void) { USBD_Start(&usb_dev_handle); }
 void usb_stop(void) { USBD_Stop(&usb_dev_handle); }
 
 secbool usb_configured(void) {
-  USBD_HandleTypeDef *pdev = &usb_dev_handle;
+  const USBD_HandleTypeDef *pdev = &usb_dev_handle;
   if (pdev->dev_state == USBD_STATE_CONFIGURED) {
+    return sectrue;
+  }
+
+  // Linux has autosuspend device after 2 seconds by default.
+  // So a suspended device that was seen as configured is reported as
+  // configured.
+  if (pdev->dev_state == USBD_STATE_SUSPENDED &&
+      pdev->dev_old_state == USBD_STATE_CONFIGURED) {
     return sectrue;
   }
 


### PR DESCRIPTION
Linux has by default 2 seond autosuspend for USB devices. This means on PCs with autosuspend supported, TT showed "USB NOT CONNECTED" when entering suspend.

We now treat switching to USB suspended from configured state as still connected.

This will still work for people plugging TT into charger or using cable without data pins to alert them.