### PR TITLE
Migrate connect tests

### DIFF
--- a/ci/test.yml
+++ b/ci/test.yml
@@ -685,7 +685,7 @@ core unix memory profiler:
 # Connect
 
 connect test core:
-  image: ghcr.io/trezor/trezor-user-env:185
+  image: ghcr.io/trezor/trezor-user-env
   stage: test
   tags:
     - runner-internal

--- a/ci/test.yml
+++ b/ci/test.yml
@@ -687,6 +687,8 @@ core unix memory profiler:
 connect test core:
   image: ghcr.io/trezor/trezor-user-env:185
   stage: test
+  tags:
+    - runner-internal
   needs:
     - core unix frozen debug build
   variables:

--- a/tests/.gitignore
+++ b/tests/.gitignore
@@ -1,3 +1,3 @@
 junit.xml
 trezor.log
-connect_tests/connect
+connect_tests/trezor-suite

--- a/tests/connect_tests/connect_tests.sh
+++ b/tests/connect_tests/connect_tests.sh
@@ -1,24 +1,24 @@
 #!/usr/bin/env bash
 
-# Cloning connect repository and running the tests from there
+# Cloning trezor-suite repository and running connect tests from there
 
 FILE_DIR="$(dirname "${0}")"
 cd ${FILE_DIR}
 
-CONNECT_DIR="connect"
+TREZOR_SUITE_DIR="trezor-suite"
 
 # For quicker local usage, do not cloning connect repo if it already exists
-if [[ ! -d "${CONNECT_DIR}" ]]
+if [[ ! -d "${TREZOR_SUITE_DIR}" ]]
 then
-    git clone https://github.com/trezor/connect.git
-    cd ${CONNECT_DIR}
+    git clone https://github.com/trezor/trezor-suite.git
+    cd ${TREZOR_SUITE_DIR}
     git submodule update --init --recursive
 else
-    cd ${CONNECT_DIR}
+    cd ${TREZOR_SUITE_DIR}
 fi
 
 echo "Changing 'localhost' to '127.0.0.1' in websocket client as a workaround for CI servers"
-sed -i 's/localhost/127.0.0.1/g' ./tests/websocket-client.js
+sed -i 's/localhost/127.0.0.1/g' ./packages/integration-tests/websocket-client.js
 
 # Taking an optional script argument with emulator version
 if [ ! -z "${1}" ]
@@ -30,4 +30,4 @@ fi
 echo "Will be running with ${EMU_VERSION} emulator"
 
 # Using -d flag to disable docker, as tenv is already running on the background
-nix-shell --run "yarn && tests/run.sh -d -f ${EMU_VERSION} -s 'yarn test:integration methods'"
+nix-shell --run "yarn && yarn build:libs && ./docker/docker-connect-test.sh node -p methods -d -f ${EMU_VERSION}"

--- a/tests/connect_tests/connect_tests.sh
+++ b/tests/connect_tests/connect_tests.sh
@@ -30,4 +30,4 @@ fi
 echo "Will be running with ${EMU_VERSION} emulator"
 
 # Using -d flag to disable docker, as tenv is already running on the background
-nix-shell --run "yarn && yarn build:libs && ./docker/docker-connect-test.sh node -p methods -d -f ${EMU_VERSION}"
+nix-shell --run "yarn && yarn build:libs && ./docker/docker-connect-test.sh node -p methods -d -c -f ${EMU_VERSION}"


### PR DESCRIPTION
Connected with https://github.com/trezor/trezor-firmware/issues/2295:
- updating `connect` tests to account for their move into `Suite` monorepo