### PR TITLE
Enable bus fault and usage fault handlers in core

### DIFF
--- a/core/embed/firmware/main.c
+++ b/core/embed/firmware/main.c
@@ -96,6 +96,11 @@ int main(void) {
   // Init peripherals
   pendsv_init();
 
+#if !PRODUCTION
+  // enable BUS fault and USAGE fault handlers
+  SCB->SHCSR |= (SCB_SHCSR_USGFAULTENA_Msk | SCB_SHCSR_BUSFAULTENA_Msk);
+#endif
+
 #if defined TREZOR_MODEL_1
   display_init();
   button_init();


### PR DESCRIPTION
The handlers were already there, this just enables them, which helps debugging the faults as you get different error message (hard fault occurs otherwise)