### PR TITLE
perf(core/rust/ui): use 16-bit coordinates instead of 32

### DIFF
--- a/core/embed/rust/src/trezorhal/display.rs
+++ b/core/embed/rust/src/trezorhal/display.rs
@@ -12,11 +12,11 @@ pub fn backlight(val: i32) -> i32 {
     unsafe { ffi::display_backlight(val) }
 }
 
-pub fn text(baseline_x: i32, baseline_y: i32, text: &str, font: i32, fgcolor: u16, bgcolor: u16) {
+pub fn text(baseline_x: i16, baseline_y: i16, text: &str, font: i32, fgcolor: u16, bgcolor: u16) {
     unsafe {
         ffi::display_text(
-            baseline_x,
-            baseline_y,
+            baseline_x.into(),
+            baseline_y.into(),
             text.as_ptr() as _,
             text.len() as _,
             font,
@@ -26,11 +26,15 @@ pub fn text(baseline_x: i32, baseline_y: i32, text: &str, font: i32, fgcolor: u1
     }
 }
 
-pub fn text_width(text: &str, font: i32) -> i32 {
-    unsafe { ffi::display_text_width(text.as_ptr() as _, text.len() as _, font) }
+pub fn text_width(text: &str, font: i32) -> i16 {
+    unsafe {
+        ffi::display_text_width(text.as_ptr() as _, text.len() as _, font)
+            .try_into()
+            .unwrap_or(i16::MAX)
+    }
 }
 
-pub fn char_width(ch: char, font: i32) -> i32 {
+pub fn char_width(ch: char, font: i32) -> i16 {
     let mut buf = [0u8; 4];
     let encoding = ch.encode_utf8(&mut buf);
     text_width(encoding, font)
@@ -40,25 +44,39 @@ pub fn get_char_glyph(ch: u8, font: i32) -> *const u8 {
     unsafe { ffi::display_get_glyph(font, ch) }
 }
 
-pub fn text_height(font: i32) -> i32 {
-    unsafe { ffi::display_text_height(font) }
+pub fn text_height(font: i32) -> i16 {
+    unsafe {
+        ffi::display_text_height(font)
+            .try_into()
+            .unwrap_or(i16::MAX)
+    }
 }
 
-pub fn bar(x: i32, y: i32, w: i32, h: i32, fgcolor: u16) {
-    unsafe { ffi::display_bar(x, y, w, h, fgcolor) }
+pub fn bar(x: i16, y: i16, w: i16, h: i16, fgcolor: u16) {
+    unsafe { ffi::display_bar(x.into(), y.into(), w.into(), h.into(), fgcolor) }
 }
 
-pub fn bar_radius(x: i32, y: i32, w: i32, h: i32, fgcolor: u16, bgcolor: u16, radius: u8) {
-    unsafe { ffi::display_bar_radius(x, y, w, h, fgcolor, bgcolor, radius) }
+pub fn bar_radius(x: i16, y: i16, w: i16, h: i16, fgcolor: u16, bgcolor: u16, radius: u8) {
+    unsafe {
+        ffi::display_bar_radius(
+            x.into(),
+            y.into(),
+            w.into(),
+            h.into(),
+            fgcolor,
+            bgcolor,
+            radius,
+        )
+    }
 }
 
-pub fn icon(x: i32, y: i32, w: i32, h: i32, data: &[u8], fgcolor: u16, bgcolor: u16) {
+pub fn icon(x: i16, y: i16, w: i16, h: i16, data: &[u8], fgcolor: u16, bgcolor: u16) {
     unsafe {
         ffi::display_icon(
-            x,
-            y,
-            w,
-            h,
+            x.into(),
+            y.into(),
+            w.into(),
+            h.into(),
             data.as_ptr() as _,
             data.len() as _,
             fgcolor,
@@ -67,8 +85,17 @@ pub fn icon(x: i32, y: i32, w: i32, h: i32, data: &[u8], fgcolor: u16, bgcolor: 
     }
 }
 
-pub fn image(x: i32, y: i32, w: i32, h: i32, data: &[u8]) {
-    unsafe { ffi::display_image(x, y, w, h, data.as_ptr() as _, data.len() as _) }
+pub fn image(x: i16, y: i16, w: i16, h: i16, data: &[u8]) {
+    unsafe {
+        ffi::display_image(
+            x.into(),
+            y.into(),
+            w.into(),
+            h.into(),
+            data.as_ptr() as _,
+            data.len() as _,
+        )
+    }
 }
 
 pub fn toif_info(data: &[u8]) -> Result<ToifInfo, ()> {
@@ -97,7 +124,7 @@ pub fn toif_info(data: &[u8]) -> Result<ToifInfo, ()> {
 pub fn loader(
     progress: u16,
     indeterminate: bool,
-    yoffset: i32,
+    yoffset: i16,
     fgcolor: u16,
     bgcolor: u16,
     icon: Option<&[u8]>,
@@ -107,7 +134,7 @@ pub fn loader(
         ffi::display_loader(
             progress,
             indeterminate,
-            yoffset,
+            yoffset.into(),
             fgcolor,
             bgcolor,
             icon.map(|i| i.as_ptr()).unwrap_or(ptr::null()),
@@ -146,11 +173,11 @@ pub fn set_window(x0: u16, y0: u16, x1: u16, y1: u16) {
     }
 }
 
-pub fn get_offset() -> (i32, i32) {
+pub fn get_offset() -> (i16, i16) {
     unsafe {
         let mut x: c_int = 0;
         let mut y: c_int = 0;
         ffi::display_offset(ptr::null_mut(), &mut x, &mut y);
-        (x as i32, y as i32)
+        (x as i16, y as i16)
     }
 }

--- a/core/embed/rust/src/trezorhal/qr.rs
+++ b/core/embed/rust/src/trezorhal/qr.rs
@@ -33,8 +33,8 @@ fn qr_version_index(data: &str, thresholds: &[usize]) -> Option<usize> {
 }
 
 pub fn render_qrcode(
-    x: i32,
-    y: i32,
+    x: i16,
+    y: i16,
     data: &str,
     max_size: u32,
     case_sensitive: bool,
@@ -69,7 +69,7 @@ pub fn render_qrcode(
         buffer[data_len] = 0u8;
         let cstr = CStr::from_bytes_with_nul_unchecked(&buffer[..data_len + 1]);
 
-        display_qrcode(x, y, cstr.as_ptr() as _, scale as u8);
+        display_qrcode(x.into(), y.into(), cstr.as_ptr() as _, scale as u8);
         Ok(())
     }
 }

--- a/core/embed/rust/src/ui/component/placed.rs
+++ b/core/embed/rust/src/ui/component/placed.rs
@@ -27,7 +27,7 @@ impl<T> GridPlaced<T> {
         self
     }
 
-    pub fn with_spacing(mut self, spacing: i32) -> Self {
+    pub fn with_spacing(mut self, spacing: i16) -> Self {
         self.grid.spacing = spacing;
         self
     }
@@ -80,11 +80,11 @@ where
 
 pub struct FixedHeightBar<T> {
     inner: T,
-    height: i32,
+    height: i16,
 }
 
 impl<T> FixedHeightBar<T> {
-    pub const fn bottom(inner: T, height: i32) -> Self {
+    pub const fn bottom(inner: T, height: i16) -> Self {
         Self { inner, height }
     }
 }

--- a/core/embed/rust/src/ui/component/text/iter.rs
+++ b/core/embed/rust/src/ui/component/text/iter.rs
@@ -6,7 +6,7 @@ struct LineBreak {
     /// Index of character **after** the line-break.
     offset: usize,
     /// Distance from the last line-break of the sequence, in pixels.
-    width: i32,
+    width: i16,
     style: BreakStyle,
 }
 
@@ -19,8 +19,8 @@ enum BreakStyle {
 
 fn limit_line_breaks(
     breaks: impl Iterator<Item = LineBreak>,
-    line_height: i32,
-    available_height: i32,
+    line_height: i16,
+    available_height: i16,
 ) -> impl Iterator<Item = LineBreak> {
     breaks.take(available_height as usize / line_height as usize)
 }
@@ -42,7 +42,7 @@ fn break_text_to_spans(
     text_font: impl GlyphMetrics,
     hyphen_font: impl GlyphMetrics,
     breaking: LineBreaking,
-    available_width: i32,
+    available_width: i16,
 ) -> impl Iterator<Item = Span> {
     let mut finished = false;
     let mut last_break = LineBreak {
@@ -89,7 +89,7 @@ fn select_line_breaks(
     text_font: impl GlyphMetrics,
     hyphen_font: impl GlyphMetrics,
     breaking: LineBreaking,
-    available_width: i32,
+    available_width: i16,
 ) -> impl Iterator<Item = LineBreak> {
     let hyphen_width = hyphen_font.char_width('-');
 
@@ -159,16 +159,16 @@ fn select_line_breaks(
 }
 
 pub trait GlyphMetrics {
-    fn char_width(&self, ch: char) -> i32;
-    fn line_height(&self) -> i32;
+    fn char_width(&self, ch: char) -> i16;
+    fn line_height(&self) -> i16;
 }
 
 impl GlyphMetrics for Font {
-    fn char_width(&self, ch: char) -> i32 {
+    fn char_width(&self, ch: char) -> i16 {
         Font::char_width(*self, ch)
     }
 
-    fn line_height(&self) -> i32 {
+    fn line_height(&self) -> i16 {
         Font::line_height(*self)
     }
 }
@@ -205,21 +205,21 @@ mod tests {
 
     #[derive(Copy, Clone)]
     struct Fixed {
-        width: i32,
-        height: i32,
+        width: i16,
+        height: i16,
     }
 
     impl GlyphMetrics for Fixed {
-        fn char_width(&self, _ch: char) -> i32 {
+        fn char_width(&self, _ch: char) -> i16 {
             self.width
         }
 
-        fn line_height(&self) -> i32 {
+        fn line_height(&self) -> i16 {
             self.height
         }
     }
 
-    fn break_text(s: &str, w: i32) -> Vec<Span> {
+    fn break_text(s: &str, w: i16) -> Vec<Span> {
         break_text_to_spans(
             s,
             Fixed {
@@ -236,7 +236,7 @@ mod tests {
         .collect::<Vec<_>>()
     }
 
-    fn line_breaks(s: &str, w: i32) -> Vec<LineBreak> {
+    fn line_breaks(s: &str, w: i16) -> Vec<LineBreak> {
         select_line_breaks(
             s.char_indices(),
             Fixed {
@@ -253,7 +253,7 @@ mod tests {
         .collect::<Vec<_>>()
     }
 
-    fn hard(offset: usize, width: i32) -> LineBreak {
+    fn hard(offset: usize, width: i16) -> LineBreak {
         LineBreak {
             offset,
             width,
@@ -261,7 +261,7 @@ mod tests {
         }
     }
 
-    fn whitespace(offset: usize, width: i32) -> LineBreak {
+    fn whitespace(offset: usize, width: i16) -> LineBreak {
         LineBreak {
             offset,
             width,
@@ -269,7 +269,7 @@ mod tests {
         }
     }
 
-    fn inside_word(offset: usize, width: i32) -> LineBreak {
+    fn inside_word(offset: usize, width: i16) -> LineBreak {
         LineBreak {
             offset,
             width,

--- a/core/embed/rust/src/ui/component/text/layout.rs
+++ b/core/embed/rust/src/ui/component/text/layout.rs
@@ -32,10 +32,10 @@ pub struct TextLayout {
 
     /// Additional space before beginning of text, can be negative to shift text
     /// upwards.
-    pub padding_top: i32,
+    pub padding_top: i16,
     /// Additional space between end of text and bottom of bounding box, can be
     /// negative.
-    pub padding_bottom: i32,
+    pub padding_bottom: i16,
 
     /// Fonts, colors, line/page breaking behavior.
     pub style: TextStyle,
@@ -252,7 +252,7 @@ impl TextLayout {
         }
     }
 
-    fn layout_height(&self, init_cursor: Point, end_cursor: Point) -> i32 {
+    fn layout_height(&self, init_cursor: Point, end_cursor: Point) -> i16 {
         self.padding_top
             + self.style.text_font.text_height()
             + (end_cursor.y - init_cursor.y)
@@ -262,13 +262,13 @@ impl TextLayout {
 
 pub enum LayoutFit {
     /// Entire content fits. Vertical size is returned in `height`.
-    Fitting { processed_chars: usize, height: i32 },
+    Fitting { processed_chars: usize, height: i16 },
     /// Content fits partially or not at all.
-    OutOfBounds { processed_chars: usize, height: i32 },
+    OutOfBounds { processed_chars: usize, height: i16 },
 }
 
 impl LayoutFit {
-    pub fn height(&self) -> i32 {
+    pub fn height(&self) -> i16 {
         match self {
             LayoutFit::Fitting { height, .. } => *height,
             LayoutFit::OutOfBounds { height, .. } => *height,
@@ -400,7 +400,7 @@ struct Span {
 impl Span {
     fn fit_horizontally(
         text: &str,
-        max_width: i32,
+        max_width: i16,
         text_font: impl GlyphMetrics,
         breaking: LineBreaking,
     ) -> Self {
@@ -489,16 +489,16 @@ mod tests {
     use super::*;
 
     pub struct Fixed {
-        pub width: i32,
-        pub height: i32,
+        pub width: i16,
+        pub height: i16,
     }
 
     impl GlyphMetrics for Fixed {
-        fn char_width(&self, _ch: char) -> i32 {
+        fn char_width(&self, _ch: char) -> i16 {
             self.width
         }
 
-        fn line_height(&self) -> i32 {
+        fn line_height(&self) -> i16 {
             self.height
         }
     }
@@ -555,7 +555,7 @@ mod tests {
         );
     }
 
-    fn spans_from(text: &str, max_width: i32) -> Vec<(&str, bool)> {
+    fn spans_from(text: &str, max_width: i16) -> Vec<(&str, bool)> {
         let mut spans = vec![];
         let mut remaining_text = text;
         loop {

--- a/core/embed/rust/src/ui/component/text/paragraphs.rs
+++ b/core/embed/rust/src/ui/component/text/paragraphs.rs
@@ -11,13 +11,13 @@ use super::layout::{LayoutFit, TextLayout, TextStyle};
 pub const MAX_PARAGRAPHS: usize = 9;
 /// Maximum space between paragraphs. Actual result may be smaller (even 0) if
 /// it would make paragraphs overflow the bounding box.
-pub const DEFAULT_SPACING: i32 = 0;
+pub const DEFAULT_SPACING: i16 = 0;
 /// Offset of paragraph text from the top of the paragraph bounding box. Tweak
 /// these values to get nice alignment of baselines relative to the surrounding
 /// components.
-pub const PARAGRAPH_TOP_SPACE: i32 = -1;
+pub const PARAGRAPH_TOP_SPACE: i16 = -1;
 /// Offset of paragraph bounding box bottom relative to bottom of its text.
-pub const PARAGRAPH_BOTTOM_SPACE: i32 = 5;
+pub const PARAGRAPH_BOTTOM_SPACE: i16 = 5;
 
 pub struct Paragraphs<T> {
     area: Rect,
@@ -48,7 +48,7 @@ where
         self
     }
 
-    pub fn with_spacing(mut self, spacing: i32) -> Self {
+    pub fn with_spacing(mut self, spacing: i16) -> Self {
         self.placement = self.placement.with_spacing(spacing);
         self
     }
@@ -352,7 +352,7 @@ impl<T> Checklist<T>
 where
     T: AsRef<str>,
 {
-    const CHECK_WIDTH: i32 = 16;
+    const CHECK_WIDTH: i16 = 16;
     const DONE_OFFSET: Offset = Offset::new(-2, 6);
     const CURRENT_OFFSET: Offset = Offset::new(2, 3);
 

--- a/core/embed/rust/src/ui/display.rs
+++ b/core/embed/rust/src/ui/display.rs
@@ -526,7 +526,7 @@ pub fn text(baseline: Point, text: &str, font: Font, fg_color: Color, bg_color: 
         baseline.x,
         baseline.y,
         text,
-        font.0,
+        font.into(),
         fg_color.into(),
         bg_color.into(),
     );
@@ -538,7 +538,7 @@ pub fn text_center(baseline: Point, text: &str, font: Font, fg_color: Color, bg_
         baseline.x - w / 2,
         baseline.y,
         text,
-        font.0,
+        font.into(),
         fg_color.into(),
         bg_color.into(),
     );
@@ -550,7 +550,7 @@ pub fn text_right(baseline: Point, text: &str, font: Font, fg_color: Color, bg_c
         baseline.x - w,
         baseline.y,
         text,
-        font.0,
+        font.into(),
         fg_color.into(),
         bg_color.into(),
     );
@@ -687,24 +687,34 @@ impl Glyph {
     }
 }
 
+/// Font constants. Keep in sync with FONT_ definitions in
+/// `extmod/modtrezorui/display.h`.
 #[derive(Copy, Clone, PartialEq, Eq)]
-pub struct Font(i32);
+#[repr(u8)]
+pub enum Font {
+    NORMAL = 1,
+    BOLD = 2,
+    MONO = 3,
+    MEDIUM = 5,
+}
+
+impl From<Font> for i32 {
+    fn from(font: Font) -> i32 {
+        -(font as i32)
+    }
+}
 
 impl Font {
-    pub const fn new(id: i32) -> Self {
-        Self(id)
-    }
-
     pub fn text_width(self, text: &str) -> i16 {
-        display::text_width(text, self.0) as i16
+        display::text_width(text, self.into()) as i16
     }
 
     pub fn char_width(self, ch: char) -> i16 {
-        display::char_width(ch, self.0) as i16
+        display::char_width(ch, self.into()) as i16
     }
 
     pub fn text_height(self) -> i16 {
-        display::text_height(self.0) as i16
+        display::text_height(self.into()) as i16
     }
 
     pub fn line_height(self) -> i16 {
@@ -712,7 +722,7 @@ impl Font {
     }
 
     pub fn get_glyph(self, char_byte: u8) -> Option<Glyph> {
-        let gl_data = display::get_char_glyph(char_byte, self.0);
+        let gl_data = display::get_char_glyph(char_byte, self.into());
 
         if gl_data.is_null() {
             return None;

--- a/core/embed/rust/src/ui/geometry.rs
+++ b/core/embed/rust/src/ui/geometry.rs
@@ -1,7 +1,7 @@
 use crate::ui::lerp::Lerp;
 use core::ops::{Add, Neg, Sub};
 
-const fn min(a: i32, b: i32) -> i32 {
+const fn min(a: i16, b: i16) -> i16 {
     if a < b {
         a
     } else {
@@ -9,7 +9,7 @@ const fn min(a: i32, b: i32) -> i32 {
     }
 }
 
-const fn max(a: i32, b: i32) -> i32 {
+const fn max(a: i16, b: i16) -> i16 {
     if a > b {
         a
     } else {
@@ -17,7 +17,7 @@ const fn max(a: i32, b: i32) -> i32 {
     }
 }
 
-const fn clamp(x: i32, min: i32, max: i32) -> i32 {
+const fn clamp(x: i16, min: i16, max: i16) -> i16 {
     if x < min {
         min
     } else if x > max {
@@ -32,16 +32,16 @@ const fn clamp(x: i32, min: i32, max: i32) -> i32 {
 /// the `Point` type.
 #[derive(Copy, Clone, Debug, PartialEq, Eq)]
 pub struct Offset {
-    pub x: i32,
-    pub y: i32,
+    pub x: i16,
+    pub y: i16,
 }
 
 impl Offset {
-    pub const fn new(x: i32, y: i32) -> Self {
+    pub const fn new(x: i16, y: i16) -> Self {
         Self { x, y }
     }
 
-    pub const fn uniform(a: i32) -> Self {
+    pub const fn uniform(a: i16) -> Self {
         Self::new(a, a)
     }
 
@@ -49,22 +49,22 @@ impl Offset {
         Self::new(0, 0)
     }
 
-    pub const fn x(x: i32) -> Self {
+    pub const fn x(x: i16) -> Self {
         Self::new(x, 0)
     }
 
-    pub const fn y(y: i32) -> Self {
+    pub const fn y(y: i16) -> Self {
         Self::new(0, y)
     }
 
-    pub const fn on_axis(axis: Axis, a: i32) -> Self {
+    pub const fn on_axis(axis: Axis, a: i16) -> Self {
         match axis {
             Axis::Horizontal => Self::new(a, 0),
             Axis::Vertical => Self::new(0, a),
         }
     }
 
-    pub const fn axis(&self, axis: Axis) -> i32 {
+    pub const fn axis(&self, axis: Axis) -> i16 {
         match axis {
             Axis::Horizontal => self.x,
             Axis::Vertical => self.y,
@@ -132,12 +132,12 @@ impl Sub<Offset> for Offset {
 /// coordinates, vectors, and offsets are represented by the `Offset` type.
 #[derive(Copy, Clone, PartialEq, Eq)]
 pub struct Point {
-    pub x: i32,
-    pub y: i32,
+    pub x: i16,
+    pub y: i16,
 }
 
 impl Point {
-    pub const fn new(x: i32, y: i32) -> Self {
+    pub const fn new(x: i16, y: i16) -> Self {
         Self { x, y }
     }
 
@@ -184,7 +184,7 @@ impl Sub<Point> for Point {
 
 impl Lerp for Point {
     fn lerp(a: Self, b: Self, t: f32) -> Self {
-        Point::new(i32::lerp(a.x, b.x, t), i32::lerp(a.y, b.y, t))
+        Point::new(i16::lerp(a.x, b.x, t), i16::lerp(a.y, b.y, t))
     }
 }
 
@@ -192,10 +192,10 @@ impl Lerp for Point {
 /// bottom-right point `x1`,`y1`.
 #[derive(Copy, Clone, PartialEq, Eq)]
 pub struct Rect {
-    pub x0: i32,
-    pub y0: i32,
-    pub x1: i32,
-    pub y1: i32,
+    pub x0: i16,
+    pub y0: i16,
+    pub x1: i16,
+    pub y1: i16,
 }
 
 impl Rect {
@@ -238,19 +238,19 @@ impl Rect {
         Self::from_top_left_and_size(self.top_left(), size)
     }
 
-    pub const fn with_width(self, width: i32) -> Self {
+    pub const fn with_width(self, width: i16) -> Self {
         self.with_size(Offset::new(width, self.height()))
     }
 
-    pub const fn with_height(self, height: i32) -> Self {
+    pub const fn with_height(self, height: i16) -> Self {
         self.with_size(Offset::new(self.width(), height))
     }
 
-    pub const fn width(&self) -> i32 {
+    pub const fn width(&self) -> i16 {
         self.x1 - self.x0
     }
 
-    pub const fn height(&self) -> i32 {
+    pub const fn height(&self) -> i16 {
         self.y1 - self.y0
     }
 
@@ -304,7 +304,7 @@ impl Rect {
         }
     }
 
-    pub const fn cut_from_left(&self, width: i32) -> Self {
+    pub const fn cut_from_left(&self, width: i16) -> Self {
         Self {
             x0: self.x0,
             y0: self.y0,
@@ -313,7 +313,7 @@ impl Rect {
         }
     }
 
-    pub const fn cut_from_right(&self, width: i32) -> Self {
+    pub const fn cut_from_right(&self, width: i16) -> Self {
         Self {
             x0: self.x1 - width,
             y0: self.y0,
@@ -322,7 +322,7 @@ impl Rect {
         }
     }
 
-    pub const fn split_top(self, height: i32) -> (Self, Self) {
+    pub const fn split_top(self, height: i16) -> (Self, Self) {
         let height = clamp(height, 0, self.height());
 
         let top = Self {
@@ -336,11 +336,11 @@ impl Rect {
         (top, bottom)
     }
 
-    pub const fn split_bottom(self, height: i32) -> (Self, Self) {
+    pub const fn split_bottom(self, height: i16) -> (Self, Self) {
         self.split_top(self.height() - height)
     }
 
-    pub const fn split_left(self, width: i32) -> (Self, Self) {
+    pub const fn split_left(self, width: i16) -> (Self, Self) {
         let width = clamp(width, 0, self.width());
 
         let left = Self {
@@ -354,7 +354,7 @@ impl Rect {
         (left, right)
     }
 
-    pub const fn split_right(self, width: i32) -> (Self, Self) {
+    pub const fn split_right(self, width: i16) -> (Self, Self) {
         self.split_left(self.width() - width)
     }
 
@@ -379,14 +379,14 @@ impl Rect {
 
 #[derive(Copy, Clone, PartialEq, Eq)]
 pub struct Insets {
-    pub top: i32,
-    pub right: i32,
-    pub bottom: i32,
-    pub left: i32,
+    pub top: i16,
+    pub right: i16,
+    pub bottom: i16,
+    pub left: i16,
 }
 
 impl Insets {
-    pub const fn new(top: i32, right: i32, bottom: i32, left: i32) -> Self {
+    pub const fn new(top: i16, right: i16, bottom: i16, left: i16) -> Self {
         Self {
             top,
             right,
@@ -395,27 +395,27 @@ impl Insets {
         }
     }
 
-    pub const fn uniform(d: i32) -> Self {
+    pub const fn uniform(d: i16) -> Self {
         Self::new(d, d, d, d)
     }
 
-    pub const fn top(d: i32) -> Self {
+    pub const fn top(d: i16) -> Self {
         Self::new(d, 0, 0, 0)
     }
 
-    pub const fn right(d: i32) -> Self {
+    pub const fn right(d: i16) -> Self {
         Self::new(0, d, 0, 0)
     }
 
-    pub const fn bottom(d: i32) -> Self {
+    pub const fn bottom(d: i16) -> Self {
         Self::new(0, 0, d, 0)
     }
 
-    pub const fn left(d: i32) -> Self {
+    pub const fn left(d: i16) -> Self {
         Self::new(0, 0, 0, d)
     }
 
-    pub const fn sides(d: i32) -> Self {
+    pub const fn sides(d: i16) -> Self {
         Self::new(0, d, 0, d)
     }
 }
@@ -455,7 +455,7 @@ pub struct Grid {
     /// Number of columns (cells on the x-axis) in the grid.
     pub cols: usize,
     /// Padding between cells.
-    pub spacing: i32,
+    pub spacing: i16,
     /// Total area covered by this grid.
     pub area: Rect,
 }
@@ -470,15 +470,15 @@ impl Grid {
         }
     }
 
-    pub const fn with_spacing(self, spacing: i32) -> Self {
+    pub const fn with_spacing(self, spacing: i16) -> Self {
         Self { spacing, ..self }
     }
 
     pub const fn row_col(&self, row: usize, col: usize) -> Rect {
-        let ncols = self.cols as i32;
-        let nrows = self.rows as i32;
-        let col = min(col as i32, ncols - 1);
-        let row = min(row as i32, nrows - 1);
+        let ncols = self.cols as i16;
+        let nrows = self.rows as i16;
+        let col = min(col as i16, ncols - 1);
+        let row = min(row as i16, nrows - 1);
 
         // Total number of horizontal pixels used for spacing.
         let spacing_width = self.spacing * (ncols - 1);
@@ -535,7 +535,7 @@ pub struct GridCellSpan {
 pub struct LinearPlacement {
     pub axis: Axis,
     pub align: Alignment,
-    pub spacing: i32,
+    pub spacing: i16,
 }
 
 impl LinearPlacement {
@@ -576,14 +576,14 @@ impl LinearPlacement {
         }
     }
 
-    pub const fn with_spacing(self, spacing: i32) -> Self {
+    pub const fn with_spacing(self, spacing: i16) -> Self {
         Self { spacing, ..self }
     }
 
     /// Arranges all `items` by parameters configured in `self` into `area`.
     /// Does not change the size of the items (only the position).
     pub fn arrange(&self, area: Rect, items: &mut [impl Dimensions]) {
-        let size_sum: i32 = items
+        let size_sum: i16 = items
             .iter_mut()
             .map(|i| i.area().size().axis(self.axis))
             .sum();
@@ -609,7 +609,7 @@ impl LinearPlacement {
         sink: &mut dyn FnMut(Point),
     ) {
         let item_size = size.axis(self.axis);
-        let (mut cursor, spacing) = self.compute_spacing(area, count, (count as i32) * item_size);
+        let (mut cursor, spacing) = self.compute_spacing(area, count, (count as i16) * item_size);
         let cross_coord =
             area.size().axis(self.axis.cross()) / 2 - size.axis(self.axis.cross()) / 2;
 
@@ -623,15 +623,15 @@ impl LinearPlacement {
         }
     }
 
-    const fn compute_spacing(&self, area: Rect, count: usize, size_sum: i32) -> (i32, i32) {
+    const fn compute_spacing(&self, area: Rect, count: usize, size_sum: i16) -> (i16, i16) {
         let spacing_count = count.saturating_sub(1);
-        let spacing_sum = spacing_count as i32 * self.spacing;
+        let spacing_sum = spacing_count as i16 * self.spacing;
         let naive_size = size_sum + spacing_sum;
         let available_space = area.size().axis(self.axis);
 
         // scale down spacing to fit everything into area
         let (total_size, spacing) = if naive_size > available_space {
-            let scaled_space = (available_space - size_sum) / max(spacing_count as i32, 1);
+            let scaled_space = (available_space - size_sum) / max(spacing_count as i16, 1);
             // forbid negative spacing
             (available_space, max(scaled_space, 0))
         } else {

--- a/core/embed/rust/src/ui/lerp.rs
+++ b/core/embed/rust/src/ui/lerp.rs
@@ -65,6 +65,7 @@ macro_rules! impl_lerp_for_uint {
     };
 }
 
+impl_lerp_for_int!(i16);
 impl_lerp_for_int!(i32);
 impl_lerp_for_uint!(u8);
 impl_lerp_for_uint!(u16);

--- a/core/embed/rust/src/ui/model_t1/component/dialog.rs
+++ b/core/embed/rust/src/ui/model_t1/component/dialog.rs
@@ -1,9 +1,7 @@
-use super::{
-    button::{Button, ButtonMsg::Clicked},
-    theme,
-};
+use super::button::{Button, ButtonMsg::Clicked};
 use crate::ui::{
     component::{Child, Component, Event, EventCtx},
+    display::Font,
     geometry::Rect,
 };
 
@@ -45,7 +43,7 @@ where
     type Msg = DialogMsg<T::Msg>;
 
     fn place(&mut self, bounds: Rect) -> Rect {
-        let button_height = theme::FONT_BOLD.line_height() + 2;
+        let button_height = Font::BOLD.line_height() + 2;
         let (content_area, button_area) = bounds.split_bottom(button_height);
         self.content.place(content_area);
         self.left_btn.as_mut().map(|b| b.place(button_area));

--- a/core/embed/rust/src/ui/model_t1/component/frame.rs
+++ b/core/embed/rust/src/ui/model_t1/component/frame.rs
@@ -1,7 +1,7 @@
 use super::theme;
 use crate::ui::{
     component::{Child, Component, Event, EventCtx},
-    display,
+    display::{self, Font},
     geometry::{Insets, Offset, Rect},
 };
 
@@ -39,7 +39,7 @@ where
     fn place(&mut self, bounds: Rect) -> Rect {
         const TITLE_SPACE: i16 = 4;
 
-        let (title_area, content_area) = bounds.split_top(theme::FONT_BOLD.line_height());
+        let (title_area, content_area) = bounds.split_top(Font::BOLD.line_height());
         let content_area = content_area.inset(Insets::top(TITLE_SPACE));
 
         self.area = title_area;
@@ -55,7 +55,7 @@ where
         display::text(
             self.area.bottom_left() - Offset::y(2),
             self.title.as_ref(),
-            theme::FONT_BOLD,
+            Font::BOLD,
             theme::FG,
             theme::BG,
         );

--- a/core/embed/rust/src/ui/model_t1/component/frame.rs
+++ b/core/embed/rust/src/ui/model_t1/component/frame.rs
@@ -37,7 +37,7 @@ where
     type Msg = T::Msg;
 
     fn place(&mut self, bounds: Rect) -> Rect {
-        const TITLE_SPACE: i32 = 4;
+        const TITLE_SPACE: i16 = 4;
 
         let (title_area, content_area) = bounds.split_top(theme::FONT_BOLD.line_height());
         let content_area = content_area.inset(Insets::top(TITLE_SPACE));

--- a/core/embed/rust/src/ui/model_t1/component/page.rs
+++ b/core/embed/rust/src/ui/model_t1/component/page.rs
@@ -1,6 +1,6 @@
 use crate::ui::{
     component::{Component, ComponentExt, Event, EventCtx, Never, Pad, PageMsg, Paginate},
-    display::{self, Color},
+    display::{self, Color, Font},
     geometry::{Insets, Offset, Point, Rect},
 };
 
@@ -50,7 +50,7 @@ where
     type Msg = PageMsg<T::Msg, bool>;
 
     fn place(&mut self, bounds: Rect) -> Rect {
-        let button_height = theme::FONT_BOLD.line_height() + 2;
+        let button_height = Font::BOLD.line_height() + 2;
         let (content_area, button_area) = bounds.split_bottom(button_height);
         let (content_area, scrollbar_area) = content_area.split_right(ScrollBar::WIDTH);
         let content_area = content_area.inset(Insets::top(1));

--- a/core/embed/rust/src/ui/model_t1/component/page.rs
+++ b/core/embed/rust/src/ui/model_t1/component/page.rs
@@ -134,9 +134,9 @@ pub struct ScrollBar {
 }
 
 impl ScrollBar {
-    pub const WIDTH: i32 = 8;
+    pub const WIDTH: i16 = 8;
     pub const DOT_SIZE: Offset = Offset::new(4, 4);
-    pub const DOT_INTERVAL: i32 = 6;
+    pub const DOT_INTERVAL: i16 = 6;
 
     pub fn vertical() -> Self {
         Self {
@@ -205,7 +205,7 @@ impl Component for ScrollBar {
     }
 
     fn paint(&mut self) {
-        let count = self.page_count as i32;
+        let count = self.page_count as i16;
         let interval = {
             let available_height = self.area.height();
             let naive_height = count * Self::DOT_INTERVAL;

--- a/core/embed/rust/src/ui/model_t1/constant.rs
+++ b/core/embed/rust/src/ui/model_t1/constant.rs
@@ -1,9 +1,9 @@
 use crate::ui::geometry::{Offset, Point, Rect};
 
-pub const WIDTH: i32 = 128;
-pub const HEIGHT: i32 = 64;
-pub const LINE_SPACE: i32 = 1;
-pub const FONT_BPP: i32 = 1;
+pub const WIDTH: i16 = 128;
+pub const HEIGHT: i16 = 64;
+pub const LINE_SPACE: i16 = 1;
+pub const FONT_BPP: i16 = 1;
 
 pub const fn size() -> Offset {
     Offset::new(WIDTH, HEIGHT)

--- a/core/embed/rust/src/ui/model_t1/theme.rs
+++ b/core/embed/rust/src/ui/model_t1/theme.rs
@@ -5,12 +5,6 @@ use crate::ui::{
 
 use super::component::{ButtonStyle, ButtonStyleSheet};
 
-// Font constants.
-pub const FONT_NORMAL: Font = Font::new(-1);
-pub const FONT_MEDIUM: Font = Font::new(-5);
-pub const FONT_BOLD: Font = Font::new(-2);
-pub const FONT_MONO: Font = Font::new(-3);
-
 // Color palette.
 pub const WHITE: Color = Color::rgb(255, 255, 255);
 pub const BLACK: Color = Color::rgb(0, 0, 0);
@@ -21,12 +15,12 @@ pub const BG: Color = BLACK; // Default background color.
 pub fn button_default() -> ButtonStyleSheet {
     ButtonStyleSheet {
         normal: &ButtonStyle {
-            font: FONT_BOLD,
+            font: Font::BOLD,
             text_color: BG,
             border_horiz: true,
         },
         active: &ButtonStyle {
-            font: FONT_BOLD,
+            font: Font::BOLD,
             text_color: FG,
             border_horiz: true,
         },
@@ -36,26 +30,26 @@ pub fn button_default() -> ButtonStyleSheet {
 pub fn button_cancel() -> ButtonStyleSheet {
     ButtonStyleSheet {
         normal: &ButtonStyle {
-            font: FONT_BOLD,
+            font: Font::BOLD,
             text_color: FG,
             border_horiz: false,
         },
         active: &ButtonStyle {
-            font: FONT_BOLD,
+            font: Font::BOLD,
             text_color: BG,
             border_horiz: false,
         },
     }
 }
 
-pub const TEXT_NORMAL: TextStyle = TextStyle::new(FONT_NORMAL, FG, BG, FG, FG);
-pub const TEXT_MEDIUM: TextStyle = TextStyle::new(FONT_MEDIUM, FG, BG, FG, FG);
-pub const TEXT_BOLD: TextStyle = TextStyle::new(FONT_BOLD, FG, BG, FG, FG);
-pub const TEXT_MONO: TextStyle = TextStyle::new(FONT_MONO, FG, BG, FG, FG);
+pub const TEXT_NORMAL: TextStyle = TextStyle::new(Font::NORMAL, FG, BG, FG, FG);
+pub const TEXT_MEDIUM: TextStyle = TextStyle::new(Font::MEDIUM, FG, BG, FG, FG);
+pub const TEXT_BOLD: TextStyle = TextStyle::new(Font::BOLD, FG, BG, FG, FG);
+pub const TEXT_MONO: TextStyle = TextStyle::new(Font::MONO, FG, BG, FG, FG);
 
 pub const FORMATTED: FormattedFonts = FormattedFonts {
-    normal: FONT_NORMAL,
-    medium: FONT_MEDIUM,
-    bold: FONT_BOLD,
-    mono: FONT_MONO,
+    normal: Font::NORMAL,
+    medium: Font::MEDIUM,
+    bold: Font::BOLD,
+    mono: Font::MONO,
 };

--- a/core/embed/rust/src/ui/model_tr/component/confirm.rs
+++ b/core/embed/rust/src/ui/model_tr/component/confirm.rs
@@ -18,7 +18,7 @@ pub struct HoldToConfirm {
     pos: ButtonPos,
     loader: Loader,
     baseline: Point,
-    text_width: i32,
+    text_width: i16,
 }
 
 impl HoldToConfirm {

--- a/core/embed/rust/src/ui/model_tr/component/dialog.rs
+++ b/core/embed/rust/src/ui/model_tr/component/dialog.rs
@@ -1,9 +1,7 @@
-use super::{
-    button::{Button, ButtonMsg::Clicked},
-    theme,
-};
+use super::button::{Button, ButtonMsg::Clicked};
 use crate::ui::{
     component::{Child, Component, Event, EventCtx},
+    display::Font,
     geometry::Rect,
 };
 
@@ -45,7 +43,7 @@ where
     type Msg = DialogMsg<T::Msg>;
 
     fn place(&mut self, bounds: Rect) -> Rect {
-        let button_height = theme::FONT_BOLD.line_height() + 2;
+        let button_height = Font::BOLD.line_height() + 2;
         let (content_area, button_area) = bounds.split_bottom(button_height);
         self.content.place(content_area);
         self.left_btn.as_mut().map(|b| b.place(button_area));

--- a/core/embed/rust/src/ui/model_tr/component/frame.rs
+++ b/core/embed/rust/src/ui/model_tr/component/frame.rs
@@ -1,7 +1,7 @@
 use super::theme;
 use crate::ui::{
     component::{Child, Component, Event, EventCtx},
-    display,
+    display::{self, Font},
     geometry::{Insets, Offset, Rect},
 };
 
@@ -39,7 +39,7 @@ where
     fn place(&mut self, bounds: Rect) -> Rect {
         const TITLE_SPACE: i16 = 4;
 
-        let (title_area, content_area) = bounds.split_top(theme::FONT_BOLD.line_height());
+        let (title_area, content_area) = bounds.split_top(Font::BOLD.line_height());
         let content_area = content_area.inset(Insets::top(TITLE_SPACE));
 
         self.area = title_area;
@@ -55,7 +55,7 @@ where
         display::text(
             self.area.bottom_left() - Offset::y(2),
             self.title.as_ref(),
-            theme::FONT_BOLD,
+            Font::BOLD,
             theme::FG,
             theme::BG,
         );

--- a/core/embed/rust/src/ui/model_tr/component/frame.rs
+++ b/core/embed/rust/src/ui/model_tr/component/frame.rs
@@ -37,7 +37,7 @@ where
     type Msg = T::Msg;
 
     fn place(&mut self, bounds: Rect) -> Rect {
-        const TITLE_SPACE: i32 = 4;
+        const TITLE_SPACE: i16 = 4;
 
         let (title_area, content_area) = bounds.split_top(theme::FONT_BOLD.line_height());
         let content_area = content_area.inset(Insets::top(TITLE_SPACE));

--- a/core/embed/rust/src/ui/model_tr/component/loader.rs
+++ b/core/embed/rust/src/ui/model_tr/component/loader.rs
@@ -111,8 +111,8 @@ impl Loader {
         matches!(self.progress(now), Some(display::LOADER_MIN))
     }
 
-    pub fn paint_loader(&mut self, style: &LoaderStyle, done: i32) {
-        let invert_from = ((self.area.width() + 1) * done) / (display::LOADER_MAX as i32);
+    pub fn paint_loader(&mut self, style: &LoaderStyle, done: i16) {
+        let invert_from = ((self.area.width() + 1) * done) / (display::LOADER_MAX as i16);
 
         display::bar_with_text_and_fill(
             self.area,
@@ -169,11 +169,11 @@ impl Component for Loader {
         if let State::Initial = self.state {
             self.paint_loader(self.styles.normal, 0);
         } else if let State::Grown = self.state {
-            self.paint_loader(self.styles.normal, display::LOADER_MAX as i32);
+            self.paint_loader(self.styles.normal, display::LOADER_MAX as i16);
         } else {
             let progress = self.progress(now);
             if let Some(done) = progress {
-                self.paint_loader(self.styles.normal, done as i32);
+                self.paint_loader(self.styles.normal, done as i16);
             } else {
                 self.paint_loader(self.styles.normal, 0);
             }

--- a/core/embed/rust/src/ui/model_tr/component/page.rs
+++ b/core/embed/rust/src/ui/model_tr/component/page.rs
@@ -1,6 +1,6 @@
 use crate::ui::{
     component::{Component, ComponentExt, Event, EventCtx, Never, Pad, PageMsg, Paginate},
-    display::{self, Color},
+    display::{self, Color, Font},
     geometry::{Insets, Offset, Point, Rect},
 };
 
@@ -50,7 +50,7 @@ where
     type Msg = PageMsg<T::Msg, bool>;
 
     fn place(&mut self, bounds: Rect) -> Rect {
-        let button_height = theme::FONT_BOLD.line_height() + 2;
+        let button_height = Font::BOLD.line_height() + 2;
         let (content_area, button_area) = bounds.split_bottom(button_height);
         let (content_area, scrollbar_area) = content_area.split_right(ScrollBar::WIDTH);
         let content_area = content_area.inset(Insets::top(1));

--- a/core/embed/rust/src/ui/model_tr/component/page.rs
+++ b/core/embed/rust/src/ui/model_tr/component/page.rs
@@ -134,9 +134,9 @@ pub struct ScrollBar {
 }
 
 impl ScrollBar {
-    pub const WIDTH: i32 = 8;
+    pub const WIDTH: i16 = 8;
     pub const DOT_SIZE: Offset = Offset::new(4, 4);
-    pub const DOT_INTERVAL: i32 = 6;
+    pub const DOT_INTERVAL: i16 = 6;
 
     pub fn vertical() -> Self {
         Self {
@@ -205,7 +205,7 @@ impl Component for ScrollBar {
     }
 
     fn paint(&mut self) {
-        let count = self.page_count as i32;
+        let count = self.page_count as i16;
         let interval = {
             let available_height = self.area.height();
             let naive_height = count * Self::DOT_INTERVAL;

--- a/core/embed/rust/src/ui/model_tr/component/result_anim.rs
+++ b/core/embed/rust/src/ui/model_tr/component/result_anim.rs
@@ -78,7 +78,7 @@ impl ResultAnim {
         matches!(self.progress(now), Some(display::LOADER_MAX))
     }
 
-    pub fn paint_anim(&mut self, done: i32) {
+    pub fn paint_anim(&mut self, done: i16) {
         display::rect_rounded2_partial(
             self.area,
             theme::FG,
@@ -128,11 +128,11 @@ impl Component for ResultAnim {
         if let State::Initial = self.state {
             self.paint_anim(0);
         } else if let State::Grown = self.state {
-            self.paint_anim(display::LOADER_MAX as i32);
+            self.paint_anim(display::LOADER_MAX as i16);
         } else {
             let progress = self.progress(now);
             if let Some(done) = progress {
-                self.paint_anim(done as i32);
+                self.paint_anim(done as i16);
             } else {
                 self.paint_anim(0);
             }

--- a/core/embed/rust/src/ui/model_tr/component/result_popup.rs
+++ b/core/embed/rust/src/ui/model_tr/component/result_popup.rs
@@ -6,10 +6,11 @@ use crate::{
             LabelStyle, Pad,
         },
         constant::screen,
+        display::Font,
         geometry::{Alignment, Insets, LinearPlacement, Point, Rect},
         model_tr::{
             component::{Button, ButtonMsg, ButtonPos, ResultAnim, ResultAnimMsg},
-            theme::{self, FONT_BOLD},
+            theme,
         },
     },
 };
@@ -58,7 +59,7 @@ impl ResultPopup {
         let headline_style = LabelStyle {
             background_color: theme::BG,
             text_color: theme::FG,
-            font: FONT_BOLD,
+            font: Font::BOLD,
         };
 
         let mut pad = Pad::with_background(theme::BG);

--- a/core/embed/rust/src/ui/model_tr/component/result_popup.rs
+++ b/core/embed/rust/src/ui/model_tr/component/result_popup.rs
@@ -29,12 +29,12 @@ pub struct ResultPopup {
     autoclose: bool,
 }
 
-const ANIM_SIZE: i32 = 18;
-const BUTTON_HEIGHT: i32 = 13;
-const ANIM_SPACE: i32 = 11;
-const ANIM_POS: i32 = 32;
-const ANIM_POS_ADJ_HEADLINE: i32 = 10;
-const ANIM_POS_ADJ_BUTTON: i32 = 6;
+const ANIM_SIZE: i16 = 18;
+const BUTTON_HEIGHT: i16 = 13;
+const ANIM_SPACE: i16 = 11;
+const ANIM_POS: i16 = 32;
+const ANIM_POS_ADJ_HEADLINE: i16 = 10;
+const ANIM_POS_ADJ_BUTTON: i16 = 6;
 
 impl ResultPopup {
     pub fn new(

--- a/core/embed/rust/src/ui/model_tr/constant.rs
+++ b/core/embed/rust/src/ui/model_tr/constant.rs
@@ -1,9 +1,9 @@
 use crate::ui::geometry::{Offset, Point, Rect};
 
-pub const WIDTH: i32 = 128;
-pub const HEIGHT: i32 = 128;
-pub const LINE_SPACE: i32 = 1;
-pub const FONT_BPP: i32 = 1;
+pub const WIDTH: i16 = 128;
+pub const HEIGHT: i16 = 128;
+pub const LINE_SPACE: i16 = 1;
+pub const FONT_BPP: i16 = 1;
 
 pub const fn size() -> Offset {
     Offset::new(WIDTH, HEIGHT)

--- a/core/embed/rust/src/ui/model_tr/theme.rs
+++ b/core/embed/rust/src/ui/model_tr/theme.rs
@@ -6,12 +6,6 @@ use crate::ui::{
 
 use super::component::{ButtonStyle, ButtonStyleSheet};
 
-// Font constants.
-pub const FONT_NORMAL: Font = Font::new(-1);
-pub const FONT_MEDIUM: Font = Font::new(-5);
-pub const FONT_BOLD: Font = Font::new(-2);
-pub const FONT_MONO: Font = Font::new(-3);
-
 // Color palette.
 pub const WHITE: Color = Color::rgb(255, 255, 255);
 pub const BLACK: Color = Color::rgb(0, 0, 0);
@@ -25,12 +19,12 @@ pub const ICON_FAIL: &[u8] = include_res!("model_tr/res/fail.toif");
 pub fn button_default() -> ButtonStyleSheet {
     ButtonStyleSheet {
         normal: &ButtonStyle {
-            font: FONT_BOLD,
+            font: Font::BOLD,
             text_color: BG,
             border_horiz: true,
         },
         active: &ButtonStyle {
-            font: FONT_BOLD,
+            font: Font::BOLD,
             text_color: FG,
             border_horiz: true,
         },
@@ -40,12 +34,12 @@ pub fn button_default() -> ButtonStyleSheet {
 pub fn button_cancel() -> ButtonStyleSheet {
     ButtonStyleSheet {
         normal: &ButtonStyle {
-            font: FONT_BOLD,
+            font: Font::BOLD,
             text_color: FG,
             border_horiz: false,
         },
         active: &ButtonStyle {
-            font: FONT_BOLD,
+            font: Font::BOLD,
             text_color: BG,
             border_horiz: false,
         },
@@ -55,21 +49,21 @@ pub fn button_cancel() -> ButtonStyleSheet {
 pub fn loader_default() -> LoaderStyleSheet {
     LoaderStyleSheet {
         normal: &LoaderStyle {
-            font: FONT_NORMAL,
+            font: Font::NORMAL,
             fg_color: FG,
             bg_color: BG,
         },
     }
 }
 
-pub const TEXT_NORMAL: TextStyle = TextStyle::new(FONT_NORMAL, FG, BG, FG, FG);
-pub const TEXT_MEDIUM: TextStyle = TextStyle::new(FONT_MEDIUM, FG, BG, FG, FG);
-pub const TEXT_BOLD: TextStyle = TextStyle::new(FONT_BOLD, FG, BG, FG, FG);
-pub const TEXT_MONO: TextStyle = TextStyle::new(FONT_MONO, FG, BG, FG, FG);
+pub const TEXT_NORMAL: TextStyle = TextStyle::new(Font::NORMAL, FG, BG, FG, FG);
+pub const TEXT_MEDIUM: TextStyle = TextStyle::new(Font::MEDIUM, FG, BG, FG, FG);
+pub const TEXT_BOLD: TextStyle = TextStyle::new(Font::BOLD, FG, BG, FG, FG);
+pub const TEXT_MONO: TextStyle = TextStyle::new(Font::MONO, FG, BG, FG, FG);
 
 pub const FORMATTED: FormattedFonts = FormattedFonts {
-    normal: FONT_NORMAL,
-    medium: FONT_MEDIUM,
-    bold: FONT_BOLD,
-    mono: FONT_MONO,
+    normal: Font::NORMAL,
+    medium: Font::MEDIUM,
+    bold: Font::BOLD,
+    mono: Font::MONO,
 };

--- a/core/embed/rust/src/ui/model_tt/component/button.rs
+++ b/core/embed/rust/src/ui/model_tt/component/button.rs
@@ -31,7 +31,7 @@ pub struct Button<T> {
 impl<T> Button<T> {
     /// Offsets the baseline of the button text either up (negative) or down
     /// (positive).
-    pub const BASELINE_OFFSET: i32 = -3;
+    pub const BASELINE_OFFSET: i16 = -3;
 
     pub fn new(content: ButtonContent<T>) -> Self {
         Self {
@@ -335,7 +335,7 @@ pub struct ButtonStyle {
     pub background_color: Color,
     pub border_color: Color,
     pub border_radius: u8,
-    pub border_width: i32,
+    pub border_width: i16,
 }
 
 impl<T> Button<T> {

--- a/core/embed/rust/src/ui/model_tt/component/dialog.rs
+++ b/core/embed/rust/src/ui/model_tt/component/dialog.rs
@@ -135,9 +135,9 @@ where
         }
     }
 
-    pub const ICON_AREA_PADDING: i32 = 2;
-    pub const ICON_AREA_HEIGHT: i32 = 60;
-    pub const VALUE_SPACE: i32 = 5;
+    pub const ICON_AREA_PADDING: i16 = 2;
+    pub const ICON_AREA_HEIGHT: i16 = 60;
+    pub const VALUE_SPACE: i16 = 5;
 }
 
 impl<T, U> Component for IconDialog<T, U>

--- a/core/embed/rust/src/ui/model_tt/component/frame.rs
+++ b/core/embed/rust/src/ui/model_tt/component/frame.rs
@@ -48,7 +48,7 @@ where
 
         let (title_area, content_area) = bounds
             .inset(self.border)
-            .split_top(theme::FONT_BOLD.text_height());
+            .split_top(Font::BOLD.text_height());
         let title_area = title_area.inset(Insets::left(theme::CONTENT_BORDER));
         let content_area = content_area.inset(Insets::top(TITLE_SPACE));
 
@@ -65,7 +65,7 @@ where
         display::text(
             self.area.bottom_left(),
             self.title.as_ref(),
-            theme::FONT_BOLD,
+            Font::BOLD,
             theme::GREY_LIGHT,
             theme::BG,
         );
@@ -107,7 +107,7 @@ where
 {
     const HEIGHT: i16 = 42;
     const COLOR: Color = theme::YELLOW;
-    const FONT: Font = theme::FONT_BOLD;
+    const FONT: Font = Font::BOLD;
     const TEXT_OFFSET: Offset = Offset::new(1, -2);
     const ICON_SPACE: i16 = 8;
 

--- a/core/embed/rust/src/ui/model_tt/component/frame.rs
+++ b/core/embed/rust/src/ui/model_tt/component/frame.rs
@@ -44,7 +44,7 @@ where
     type Msg = T::Msg;
 
     fn place(&mut self, bounds: Rect) -> Rect {
-        const TITLE_SPACE: i32 = theme::BUTTON_SPACING;
+        const TITLE_SPACE: i16 = theme::BUTTON_SPACING;
 
         let (title_area, content_area) = bounds
             .inset(self.border)
@@ -105,11 +105,11 @@ where
     T: Component,
     U: AsRef<str>,
 {
-    const HEIGHT: i32 = 42;
+    const HEIGHT: i16 = 42;
     const COLOR: Color = theme::YELLOW;
     const FONT: Font = theme::FONT_BOLD;
     const TEXT_OFFSET: Offset = Offset::new(1, -2);
-    const ICON_SPACE: i32 = 8;
+    const ICON_SPACE: i16 = 8;
 
     pub fn new(icon: &'static [u8], title: U, content: T) -> Self {
         Self {

--- a/core/embed/rust/src/ui/model_tt/component/keyboard/common.rs
+++ b/core/embed/rust/src/ui/model_tt/component/keyboard/common.rs
@@ -10,9 +10,9 @@ use crate::{
     },
 };
 
-pub const HEADER_HEIGHT: i32 = 25;
-pub const HEADER_PADDING_SIDE: i32 = 5;
-pub const HEADER_PADDING_BOTTOM: i32 = 12;
+pub const HEADER_HEIGHT: i16 = 25;
+pub const HEADER_PADDING_SIDE: i16 = 5;
+pub const HEADER_PADDING_BOTTOM: i16 = 12;
 
 /// Contains state commonly used in implementations multi-tap keyboards.
 pub struct MultiTapKeyboard {

--- a/core/embed/rust/src/ui/model_tt/component/keyboard/pin.rs
+++ b/core/embed/rust/src/ui/model_tt/component/keyboard/pin.rs
@@ -30,9 +30,9 @@ const MAX_VISIBLE_DIGITS: usize = 16;
 const DIGIT_COUNT: usize = 10; // 0..10
 const ERASE_HOLD_DURATION: Duration = Duration::from_secs(2);
 
-const HEADER_HEIGHT: i32 = 25;
-const HEADER_PADDING_SIDE: i32 = 5;
-const HEADER_PADDING_BOTTOM: i32 = 12;
+const HEADER_HEIGHT: i16 = 25;
+const HEADER_PADDING_SIDE: i16 = 5;
+const HEADER_PADDING_BOTTOM: i16 = 12;
 
 const HEADER_PADDING: Insets = Insets::new(
     theme::borders().top,
@@ -269,9 +269,9 @@ struct PinDots {
 }
 
 impl PinDots {
-    const DOT: i32 = 6;
-    const PADDING: i32 = 6;
-    const TWITCH: i32 = 4;
+    const DOT: i16 = 6;
+    const PADDING: i16 = 6;
+    const TWITCH: i16 = 4;
 
     fn new(style: LabelStyle) -> Self {
         Self {
@@ -289,8 +289,8 @@ impl PinDots {
 
     fn size(&self) -> Offset {
         let ndots = self.digits.len().min(MAX_VISIBLE_DOTS);
-        let mut width = Self::DOT * (ndots as i32);
-        width += Self::PADDING * (ndots.saturating_sub(1) as i32);
+        let mut width = Self::DOT * (ndots as i16);
+        width += Self::PADDING * (ndots.saturating_sub(1) as i16);
         Offset::new(width, Self::DOT)
     }
 
@@ -328,7 +328,7 @@ impl PinDots {
     fn paint_digits(&self, area: Rect) {
         let center = area.center() + Offset::y(theme::FONT_MONO.text_height() / 2);
         let right =
-            center + Offset::x(theme::FONT_MONO.text_width("0") * (MAX_VISIBLE_DOTS as i32) / 2);
+            center + Offset::x(theme::FONT_MONO.text_width("0") * (MAX_VISIBLE_DOTS as i16) / 2);
         let digits = self.digits.len();
 
         if digits <= MAX_VISIBLE_DOTS {

--- a/core/embed/rust/src/ui/model_tt/component/keyboard/pin.rs
+++ b/core/embed/rust/src/ui/model_tt/component/keyboard/pin.rs
@@ -9,7 +9,7 @@ use crate::{
             base::ComponentExt, Child, Component, Event, EventCtx, Label, LabelStyle, Maybe, Never,
             Pad, TimerToken,
         },
-        display,
+        display::{self, Font},
         event::TouchEvent,
         geometry::{Alignment, Grid, Insets, Offset, Rect},
         model_tt::component::{
@@ -326,16 +326,15 @@ impl PinDots {
     }
 
     fn paint_digits(&self, area: Rect) {
-        let center = area.center() + Offset::y(theme::FONT_MONO.text_height() / 2);
-        let right =
-            center + Offset::x(theme::FONT_MONO.text_width("0") * (MAX_VISIBLE_DOTS as i16) / 2);
+        let center = area.center() + Offset::y(Font::MONO.text_height() / 2);
+        let right = center + Offset::x(Font::MONO.text_width("0") * (MAX_VISIBLE_DOTS as i16) / 2);
         let digits = self.digits.len();
 
         if digits <= MAX_VISIBLE_DOTS {
             display::text_center(
                 center,
                 &self.digits,
-                theme::FONT_MONO,
+                Font::MONO,
                 self.style.text_color,
                 self.style.background_color,
             );
@@ -344,7 +343,7 @@ impl PinDots {
             display::text_right(
                 right,
                 &self.digits[offset..],
-                theme::FONT_MONO,
+                Font::MONO,
                 self.style.text_color,
                 self.style.background_color,
             );

--- a/core/embed/rust/src/ui/model_tt/component/loader.rs
+++ b/core/embed/rust/src/ui/model_tt/component/loader.rs
@@ -23,7 +23,7 @@ enum State {
 }
 
 pub struct Loader {
-    offset_y: i32,
+    offset_y: i16,
     state: State,
     growing_duration: Duration,
     shrinking_duration: Duration,

--- a/core/embed/rust/src/ui/model_tt/component/number_input.rs
+++ b/core/embed/rust/src/ui/model_tt/component/number_input.rs
@@ -2,7 +2,7 @@ use crate::ui::{
     component::{
         base::ComponentExt, text::paragraphs::Paragraphs, Child, Component, Event, EventCtx, Pad,
     },
-    display,
+    display::{self, Font},
     geometry::{Grid, Insets, Offset, Rect},
     util,
 };
@@ -207,7 +207,7 @@ impl Component for NumberInput {
     fn paint(&mut self) {
         let mut buf = [0u8; 10];
         if let Some(text) = util::u32_to_str(self.value, &mut buf) {
-            let digit_font = theme::FONT_MEDIUM;
+            let digit_font = Font::MEDIUM;
             let y_offset = digit_font.text_height() / 2 + Button::<&str>::BASELINE_OFFSET;
             display::rect_fill(self.area, theme::BG);
             display::text_center(

--- a/core/embed/rust/src/ui/model_tt/component/page.rs
+++ b/core/embed/rust/src/ui/model_tt/component/page.rs
@@ -194,9 +194,9 @@ pub struct PageLayout {
 }
 
 impl PageLayout {
-    const SCROLLBAR_WIDTH: i32 = 10;
-    const SCROLLBAR_SPACE: i32 = 10;
-    const HINT_OFF: i32 = 19;
+    const SCROLLBAR_WIDTH: i16 = 10;
+    const SCROLLBAR_SPACE: i16 = 10;
+    const HINT_OFF: i16 = 19;
 
     pub fn new(area: Rect) -> Self {
         let (_, hint) = area.split_bottom(Self::HINT_OFF);
@@ -339,7 +339,7 @@ mod tests {
         String::from_utf8(t).unwrap()
     }
 
-    fn swipe(component: &mut impl Component, points: &[(i32, i32)]) {
+    fn swipe(component: &mut impl Component, points: &[(i16, i16)]) {
         let last = points.len().saturating_sub(1);
         let mut first = true;
         let mut ctx = EventCtx::new();

--- a/core/embed/rust/src/ui/model_tt/component/scroll.rs
+++ b/core/embed/rust/src/ui/model_tt/component/scroll.rs
@@ -15,11 +15,11 @@ pub struct ScrollBar {
 }
 
 impl ScrollBar {
-    pub const DOT_SIZE: i32 = 6;
+    pub const DOT_SIZE: i16 = 6;
     /// Edge to edge.
-    const DOT_INTERVAL: i32 = 6;
+    const DOT_INTERVAL: i16 = 6;
     /// Edge of last dot to center of arrow icon.
-    const ARROW_SPACE: i32 = 26;
+    const ARROW_SPACE: i16 = 26;
 
     const ICON_UP: &'static [u8] = include_res!("model_tt/res/scroll-up.toif");
     const ICON_DOWN: &'static [u8] = include_res!("model_tt/res/scroll-down.toif");

--- a/core/embed/rust/src/ui/model_tt/component/swipe.rs
+++ b/core/embed/rust/src/ui/model_tt/component/swipe.rs
@@ -74,7 +74,7 @@ impl Swipe {
         self.allow_up || self.allow_down || self.allow_left || self.allow_right
     }
 
-    fn ratio(&self, dist: i32) -> f32 {
+    fn ratio(&self, dist: i16) -> f32 {
         (dist as f32 / Self::DISTANCE as f32).min(1.0)
     }
 

--- a/core/embed/rust/src/ui/model_tt/constant.rs
+++ b/core/embed/rust/src/ui/model_tt/constant.rs
@@ -1,9 +1,9 @@
 use crate::ui::geometry::{Offset, Point, Rect};
 
-pub const WIDTH: i32 = 240;
-pub const HEIGHT: i32 = 240;
-pub const LINE_SPACE: i32 = 4;
-pub const FONT_BPP: i32 = 4;
+pub const WIDTH: i16 = 240;
+pub const HEIGHT: i16 = 240;
+pub const LINE_SPACE: i16 = 4;
+pub const FONT_BPP: i16 = 4;
 
 pub const fn size() -> Offset {
     Offset::new(WIDTH, HEIGHT)

--- a/core/embed/rust/src/ui/model_tt/theme.rs
+++ b/core/embed/rust/src/ui/model_tt/theme.rs
@@ -48,7 +48,7 @@ pub const RADIUS: u8 = 2;
 pub const QR_SIDE_MAX: u32 = 140;
 
 // Size of icons in the UI (i.e. inside buttons).
-pub const ICON_SIZE: i32 = 16;
+pub const ICON_SIZE: i16 = 16;
 
 // UI icons (greyscale).
 pub const ICON_CANCEL: &[u8] = include_res!("model_tt/res/cancel.toif");
@@ -423,16 +423,16 @@ pub const FORMATTED: FormattedFonts = FormattedFonts {
     mono: FONT_MONO,
 };
 
-pub const CONTENT_BORDER: i32 = 5;
-pub const KEYBOARD_SPACING: i32 = 8;
-pub const BUTTON_HEIGHT: i32 = 38;
-pub const BUTTON_SPACING: i32 = 6;
-pub const CHECKLIST_SPACING: i32 = 10;
-pub const RECOVERY_SPACING: i32 = 18;
+pub const CONTENT_BORDER: i16 = 5;
+pub const KEYBOARD_SPACING: i16 = 8;
+pub const BUTTON_HEIGHT: i16 = 38;
+pub const BUTTON_SPACING: i16 = 6;
+pub const CHECKLIST_SPACING: i16 = 10;
+pub const RECOVERY_SPACING: i16 = 18;
 
 /// Standard button height in pixels.
-pub const fn button_rows(count: usize) -> i32 {
-    let count = count as i32;
+pub const fn button_rows(count: usize) -> i16 {
+    let count = count as i16;
     BUTTON_HEIGHT * count + BUTTON_SPACING * count.saturating_sub(1)
 }
 

--- a/core/embed/rust/src/ui/model_tt/theme.rs
+++ b/core/embed/rust/src/ui/model_tt/theme.rs
@@ -10,12 +10,6 @@ use crate::ui::{
 
 use super::component::{ButtonStyle, ButtonStyleSheet, LoaderStyle, LoaderStyleSheet};
 
-// Font constants.
-pub const FONT_NORMAL: Font = Font::new(-1);
-pub const FONT_MEDIUM: Font = Font::new(-5);
-pub const FONT_BOLD: Font = Font::new(-2);
-pub const FONT_MONO: Font = Font::new(-3);
-
 // Typical backlight values.
 pub const BACKLIGHT_NORMAL: i32 = 150;
 pub const BACKLIGHT_LOW: i32 = 45;
@@ -74,7 +68,7 @@ pub const DOT_SMALL: &[u8] = include_res!("model_tt/res/scroll-small.toif");
 
 pub fn label_default() -> LabelStyle {
     LabelStyle {
-        font: FONT_NORMAL,
+        font: Font::NORMAL,
         text_color: FG,
         background_color: BG,
     }
@@ -82,7 +76,7 @@ pub fn label_default() -> LabelStyle {
 
 pub fn label_checklist_default() -> LabelStyle {
     LabelStyle {
-        font: FONT_NORMAL,
+        font: Font::NORMAL,
         text_color: GREY_LIGHT,
         background_color: BG,
     }
@@ -90,7 +84,7 @@ pub fn label_checklist_default() -> LabelStyle {
 
 pub fn label_checklist_selected() -> LabelStyle {
     LabelStyle {
-        font: FONT_NORMAL,
+        font: Font::NORMAL,
         text_color: FG,
         background_color: BG,
     }
@@ -98,7 +92,7 @@ pub fn label_checklist_selected() -> LabelStyle {
 
 pub fn label_checklist_done() -> LabelStyle {
     LabelStyle {
-        font: FONT_NORMAL,
+        font: Font::NORMAL,
         text_color: GREEN_DARK,
         background_color: BG,
     }
@@ -106,7 +100,7 @@ pub fn label_checklist_done() -> LabelStyle {
 
 pub fn label_keyboard() -> LabelStyle {
     LabelStyle {
-        font: FONT_MEDIUM,
+        font: Font::MEDIUM,
         text_color: OFF_WHITE,
         background_color: BG,
     }
@@ -114,7 +108,7 @@ pub fn label_keyboard() -> LabelStyle {
 
 pub fn label_keyboard_warning() -> LabelStyle {
     LabelStyle {
-        font: FONT_MEDIUM,
+        font: Font::MEDIUM,
         text_color: RED,
         background_color: BG,
     }
@@ -122,7 +116,7 @@ pub fn label_keyboard_warning() -> LabelStyle {
 
 pub fn label_keyboard_minor() -> LabelStyle {
     LabelStyle {
-        font: FONT_NORMAL,
+        font: Font::NORMAL,
         text_color: OFF_WHITE,
         background_color: BG,
     }
@@ -130,7 +124,7 @@ pub fn label_keyboard_minor() -> LabelStyle {
 
 pub fn label_page_hint() -> LabelStyle {
     LabelStyle {
-        font: FONT_BOLD,
+        font: Font::BOLD,
         text_color: GREY_LIGHT,
         background_color: BG,
     }
@@ -138,7 +132,7 @@ pub fn label_page_hint() -> LabelStyle {
 
 pub fn label_warning() -> LabelStyle {
     LabelStyle {
-        font: FONT_MEDIUM,
+        font: Font::MEDIUM,
         text_color: FG,
         background_color: BG,
     }
@@ -146,7 +140,7 @@ pub fn label_warning() -> LabelStyle {
 
 pub fn label_warning_value() -> LabelStyle {
     LabelStyle {
-        font: FONT_NORMAL,
+        font: Font::NORMAL,
         text_color: OFF_WHITE,
         background_color: BG,
     }
@@ -154,7 +148,7 @@ pub fn label_warning_value() -> LabelStyle {
 
 pub fn label_recovery_title() -> LabelStyle {
     LabelStyle {
-        font: FONT_BOLD,
+        font: Font::BOLD,
         text_color: FG,
         background_color: BG,
     }
@@ -162,7 +156,7 @@ pub fn label_recovery_title() -> LabelStyle {
 
 pub fn label_recovery_description() -> LabelStyle {
     LabelStyle {
-        font: FONT_NORMAL,
+        font: Font::NORMAL,
         text_color: OFF_WHITE,
         background_color: BG,
     }
@@ -171,7 +165,7 @@ pub fn label_recovery_description() -> LabelStyle {
 pub fn button_default() -> ButtonStyleSheet {
     ButtonStyleSheet {
         normal: &ButtonStyle {
-            font: FONT_BOLD,
+            font: Font::BOLD,
             text_color: FG,
             button_color: GREY_DARK,
             background_color: BG,
@@ -180,7 +174,7 @@ pub fn button_default() -> ButtonStyleSheet {
             border_width: 0,
         },
         active: &ButtonStyle {
-            font: FONT_BOLD,
+            font: Font::BOLD,
             text_color: FG,
             button_color: GREY_MEDIUM,
             background_color: BG,
@@ -189,7 +183,7 @@ pub fn button_default() -> ButtonStyleSheet {
             border_width: 0,
         },
         disabled: &ButtonStyle {
-            font: FONT_BOLD,
+            font: Font::BOLD,
             text_color: GREY_LIGHT,
             button_color: GREY_DARK,
             background_color: BG,
@@ -203,7 +197,7 @@ pub fn button_default() -> ButtonStyleSheet {
 pub fn button_confirm() -> ButtonStyleSheet {
     ButtonStyleSheet {
         normal: &ButtonStyle {
-            font: FONT_BOLD,
+            font: Font::BOLD,
             text_color: FG,
             button_color: GREEN,
             background_color: BG,
@@ -212,7 +206,7 @@ pub fn button_confirm() -> ButtonStyleSheet {
             border_width: 0,
         },
         active: &ButtonStyle {
-            font: FONT_BOLD,
+            font: Font::BOLD,
             text_color: FG,
             button_color: GREEN_DARK,
             background_color: BG,
@@ -221,7 +215,7 @@ pub fn button_confirm() -> ButtonStyleSheet {
             border_width: 0,
         },
         disabled: &ButtonStyle {
-            font: FONT_BOLD,
+            font: Font::BOLD,
             text_color: FG,
             button_color: GREEN,
             background_color: BG,
@@ -235,7 +229,7 @@ pub fn button_confirm() -> ButtonStyleSheet {
 pub fn button_cancel() -> ButtonStyleSheet {
     ButtonStyleSheet {
         normal: &ButtonStyle {
-            font: FONT_BOLD,
+            font: Font::BOLD,
             text_color: FG,
             button_color: RED,
             background_color: BG,
@@ -244,7 +238,7 @@ pub fn button_cancel() -> ButtonStyleSheet {
             border_width: 0,
         },
         active: &ButtonStyle {
-            font: FONT_BOLD,
+            font: Font::BOLD,
             text_color: FG,
             button_color: RED_DARK,
             background_color: BG,
@@ -253,7 +247,7 @@ pub fn button_cancel() -> ButtonStyleSheet {
             border_width: 0,
         },
         disabled: &ButtonStyle {
-            font: FONT_BOLD,
+            font: Font::BOLD,
             text_color: GREY_LIGHT,
             button_color: RED,
             background_color: BG,
@@ -267,7 +261,7 @@ pub fn button_cancel() -> ButtonStyleSheet {
 pub fn button_reset() -> ButtonStyleSheet {
     ButtonStyleSheet {
         normal: &ButtonStyle {
-            font: FONT_BOLD,
+            font: Font::BOLD,
             text_color: FG,
             button_color: YELLOW,
             background_color: BG,
@@ -276,7 +270,7 @@ pub fn button_reset() -> ButtonStyleSheet {
             border_width: 0,
         },
         active: &ButtonStyle {
-            font: FONT_BOLD,
+            font: Font::BOLD,
             text_color: FG,
             button_color: YELLOW_DARK,
             background_color: BG,
@@ -285,7 +279,7 @@ pub fn button_reset() -> ButtonStyleSheet {
             border_width: 0,
         },
         disabled: &ButtonStyle {
-            font: FONT_BOLD,
+            font: Font::BOLD,
             text_color: GREY_LIGHT,
             button_color: YELLOW,
             background_color: BG,
@@ -299,7 +293,7 @@ pub fn button_reset() -> ButtonStyleSheet {
 pub fn button_info() -> ButtonStyleSheet {
     ButtonStyleSheet {
         normal: &ButtonStyle {
-            font: FONT_BOLD,
+            font: Font::BOLD,
             text_color: FG,
             button_color: BLUE,
             background_color: BG,
@@ -308,7 +302,7 @@ pub fn button_info() -> ButtonStyleSheet {
             border_width: 0,
         },
         active: &ButtonStyle {
-            font: FONT_BOLD,
+            font: Font::BOLD,
             text_color: FG,
             button_color: BLUE_DARK,
             background_color: BG,
@@ -317,7 +311,7 @@ pub fn button_info() -> ButtonStyleSheet {
             border_width: 0,
         },
         disabled: &ButtonStyle {
-            font: FONT_BOLD,
+            font: Font::BOLD,
             text_color: GREY_LIGHT,
             button_color: BLUE,
             background_color: BG,
@@ -331,7 +325,7 @@ pub fn button_info() -> ButtonStyleSheet {
 pub fn button_pin() -> ButtonStyleSheet {
     ButtonStyleSheet {
         normal: &ButtonStyle {
-            font: FONT_MONO,
+            font: Font::MONO,
             text_color: FG,
             button_color: GREY_DARK,
             background_color: BG,
@@ -340,7 +334,7 @@ pub fn button_pin() -> ButtonStyleSheet {
             border_width: 0,
         },
         active: &ButtonStyle {
-            font: FONT_MONO,
+            font: Font::MONO,
             text_color: FG,
             button_color: GREY_MEDIUM,
             background_color: BG,
@@ -349,7 +343,7 @@ pub fn button_pin() -> ButtonStyleSheet {
             border_width: 0,
         },
         disabled: &ButtonStyle {
-            font: FONT_MONO,
+            font: Font::MONO,
             text_color: GREY_LIGHT,
             button_color: GREY_DARK,
             background_color: BG,
@@ -363,7 +357,7 @@ pub fn button_pin() -> ButtonStyleSheet {
 pub fn button_counter() -> ButtonStyleSheet {
     ButtonStyleSheet {
         normal: &ButtonStyle {
-            font: FONT_MEDIUM,
+            font: Font::MEDIUM,
             text_color: FG,
             button_color: GREY_DARK,
             background_color: BG,
@@ -372,7 +366,7 @@ pub fn button_counter() -> ButtonStyleSheet {
             border_width: 0,
         },
         active: &ButtonStyle {
-            font: FONT_MEDIUM,
+            font: Font::MEDIUM,
             text_color: FG,
             button_color: GREY_MEDIUM,
             background_color: BG,
@@ -381,7 +375,7 @@ pub fn button_counter() -> ButtonStyleSheet {
             border_width: 0,
         },
         disabled: &ButtonStyle {
-            font: FONT_MEDIUM,
+            font: Font::MEDIUM,
             text_color: GREY_LIGHT,
             button_color: GREY_DARK,
             background_color: BG,
@@ -411,16 +405,16 @@ pub fn loader_default() -> LoaderStyleSheet {
     }
 }
 
-pub const TEXT_NORMAL: TextStyle = TextStyle::new(FONT_NORMAL, FG, BG, GREY_LIGHT, GREY_LIGHT);
-pub const TEXT_MEDIUM: TextStyle = TextStyle::new(FONT_MEDIUM, FG, BG, GREY_LIGHT, GREY_LIGHT);
-pub const TEXT_BOLD: TextStyle = TextStyle::new(FONT_BOLD, FG, BG, GREY_LIGHT, GREY_LIGHT);
-pub const TEXT_MONO: TextStyle = TextStyle::new(FONT_MONO, FG, BG, GREY_LIGHT, GREY_LIGHT);
+pub const TEXT_NORMAL: TextStyle = TextStyle::new(Font::NORMAL, FG, BG, GREY_LIGHT, GREY_LIGHT);
+pub const TEXT_MEDIUM: TextStyle = TextStyle::new(Font::MEDIUM, FG, BG, GREY_LIGHT, GREY_LIGHT);
+pub const TEXT_BOLD: TextStyle = TextStyle::new(Font::BOLD, FG, BG, GREY_LIGHT, GREY_LIGHT);
+pub const TEXT_MONO: TextStyle = TextStyle::new(Font::MONO, FG, BG, GREY_LIGHT, GREY_LIGHT);
 
 pub const FORMATTED: FormattedFonts = FormattedFonts {
-    normal: FONT_NORMAL,
-    medium: FONT_MEDIUM,
-    bold: FONT_BOLD,
-    mono: FONT_MONO,
+    normal: Font::NORMAL,
+    medium: Font::MEDIUM,
+    bold: Font::BOLD,
+    mono: Font::MONO,
 };
 
 pub const CONTENT_BORDER: i16 = 5;


### PR DESCRIPTION
Some layouts store a bunch of rectangles on the heap. This PR makes e.g. PinDialog (~12 buttons) smaller by 150 bytes.

@jpochyla can you see any reason not to do this?