### PR TITLE
Clean up T1 state in config_wipe()

### DIFF
--- a/legacy/firmware/config.c
+++ b/legacy/firmware/config.c
@@ -976,6 +976,8 @@ void config_wipe(void) {
   storage_set(KEY_UUID, config_uuid, sizeof(config_uuid));
   storage_set(KEY_VERSION, &CONFIG_VERSION, sizeof(CONFIG_VERSION));
   session_clear(false);
+  fsm_abortWorkflows();
+  fsm_clearCosiNonce();
 
 #if USE_BIP32_CACHE
   bip32_cache_clear();

--- a/legacy/firmware/fsm.h
+++ b/legacy/firmware/fsm.h
@@ -87,6 +87,7 @@ void fsm_msgSignIdentity(const SignIdentity *msg);
 void fsm_msgGetECDHSessionKey(const GetECDHSessionKey *msg);
 void fsm_msgCosiCommit(const CosiCommit *msg);
 void fsm_msgCosiSign(const CosiSign *msg);
+void fsm_clearCosiNonce(void);
 
 // debug
 #if DEBUG_LINK

--- a/legacy/firmware/fsm_msg_crypto.h
+++ b/legacy/firmware/fsm_msg_crypto.h
@@ -334,6 +334,11 @@ void fsm_msgCosiSign(const CosiSign *msg) {
   } else {
     fsm_sendFailure(FailureType_Failure_FirmwareError, NULL);
   }
-  memzero(cosi_nonce, sizeof(cosi_nonce));
+  fsm_clearCosiNonce();
   layoutHome();
+}
+
+void fsm_clearCosiNonce(void) {
+  cosi_nonce_is_set = false;
+  memzero(cosi_nonce, sizeof(cosi_nonce));
 }


### PR DESCRIPTION
Added `fsm_clearCosiNonce()` to `config_wipe()` to fix CI issues with `test_cosi_nonce`. To reproduce the failing test run:
```
pytest -k test_cosi_pubkey -s --ui=test
pytest -k test_cosi_nonce -s --ui=test
```
i.e. `test_cosi_pubkey` needs to run immediately before `test_cosi_nonce` and UI tests need to be active in order for reseeding to be taking place. The reason why the test fails is https://github.com/trezor/trezor-firmware/blob/77cdf4b43c8630878b8fb8ad4c362ba2a7ed5a47/legacy/firmware/fsm_msg_crypto.h#L274
which allows the nonce to persist between tests if it is not depleted by a `cosi.sign()` call, which it's not in `test_cosi_pubkey`. There was some rate-limiting rationale for not generating the nonce every time: https://github.com/satoshilabs/trezor-firmware/pull/154/files#r907239928.

Also added `fsm_abortWorkflows()` to `config_wipe()` to avoid state inconsistencies between test cases in the future.
