### PR TITLE
ci(connect): exclude checkFirmwareAuthenticity test

### DIFF
--- a/tests/connect_tests/connect_tests.sh
+++ b/tests/connect_tests/connect_tests.sh
@@ -30,4 +30,4 @@ fi
 echo "Will be running with ${EMU_VERSION} emulator"
 
 # Using -d flag to disable docker, as tenv is already running on the background
-nix-shell --run "yarn && yarn build:libs && ./docker/docker-connect-test.sh node -p methods -d -c -f ${EMU_VERSION}"
+nix-shell --run "yarn && yarn build:libs && ./docker/docker-connect-test.sh node -p methods -d -c -f ${EMU_VERSION} -e checkFirmwareAuthenticity"


### PR DESCRIPTION
This test expect actual firmware to have been released. At the moment version is set to 2.5.3 but it has not been released yet. So I suggest that we exclude this test from running in firmware repo. 