### PR TITLE
feat(core/model_r): only refresh screen on display_refresh

### DIFF
--- a/core/embed/extmod/modtrezorui/display-stm32_R.c
+++ b/core/embed/extmod/modtrezorui/display-stm32_R.c
@@ -79,8 +79,6 @@ void display_pixeldata(uint16_t c) {
 
   DISPLAY_STATE.RAM[DISPLAY_STATE.row / 8][DISPLAY_STATE.col] = data;
 
-  DATA(data);
-
   DISPLAY_STATE.col++;
 
   if (DISPLAY_STATE.col > DISPLAY_STATE.window_x1) {
@@ -349,7 +347,14 @@ void display_init(void) {
   display_init_seq();
 }
 
-void display_refresh(void) {}
+void display_refresh(void) {
+  for (int y = 0; y < (DISPLAY_RESY / 8); y++) {
+    display_set_page_and_col(y, 0);
+    for (int x = 0; x < DISPLAY_RESX; x++) {
+      DATA(DISPLAY_STATE.RAM[y][x]);
+    }
+  }
+}
 
 const char *display_save(const char *prefix) { return NULL; }
 


### PR DESCRIPTION
Given that on Model R we have a frame buffer, let's not push out pixels one by one.

Takes code from #2307 to dump the whole frame buffer at once.