### PR TITLE
Don't support preauthorized operations for get_public_node() and get_address() in trezorlib

### DIFF
--- a/python/.changelog.d/2517.added
+++ b/python/.changelog.d/2517.added
@@ -1,0 +1,1 @@
+Support SLIP-25 accounts in get-public-node and get-address.

--- a/python/src/trezorlib/btc.py
+++ b/python/src/trezorlib/btc.py
@@ -114,7 +114,6 @@ def get_public_node(
     coin_name: Optional[str] = None,
     script_type: messages.InputScriptType = messages.InputScriptType.SPENDADDRESS,
     ignore_xpub_magic: bool = False,
-    preauthorized: bool = False,
     unlock_path: Optional[List[int]] = None,
     unlock_path_mac: Optional[bytes] = None,
 ) -> "MessageType":
@@ -123,10 +122,6 @@ def get_public_node(
             messages.UnlockPath(address_n=unlock_path, mac=unlock_path_mac)
         )
         if not isinstance(res, messages.UnlockedPathRequest):
-            raise exceptions.TrezorException("Unexpected message")
-    elif preauthorized:
-        res = client.call(messages.DoPreauthorized())
-        if not isinstance(res, messages.PreauthorizedRequest):
             raise exceptions.TrezorException("Unexpected message")
 
     return client.call(
@@ -155,7 +150,6 @@ def get_authenticated_address(
     multisig: Optional[messages.MultisigRedeemScriptType] = None,
     script_type: messages.InputScriptType = messages.InputScriptType.SPENDADDRESS,
     ignore_xpub_magic: bool = False,
-    preauthorized: bool = False,
     unlock_path: Optional[List[int]] = None,
     unlock_path_mac: Optional[bytes] = None,
 ) -> "MessageType":
@@ -164,10 +158,6 @@ def get_authenticated_address(
             messages.UnlockPath(address_n=unlock_path, mac=unlock_path_mac)
         )
         if not isinstance(res, messages.UnlockedPathRequest):
-            raise exceptions.TrezorException("Unexpected message")
-    elif preauthorized:
-        res = client.call(messages.DoPreauthorized())
-        if not isinstance(res, messages.PreauthorizedRequest):
             raise exceptions.TrezorException("Unexpected message")
 
     return client.call(

--- a/python/src/trezorlib/cli/btc.py
+++ b/python/src/trezorlib/cli/btc.py
@@ -54,6 +54,7 @@ BIP_PURPOSE_TO_SCRIPT_TYPE = {
     tools.H_(49): messages.InputScriptType.SPENDP2SHWITNESS,
     tools.H_(84): messages.InputScriptType.SPENDWITNESS,
     tools.H_(86): messages.InputScriptType.SPENDTAPROOT,
+    tools.H_(10025): messages.InputScriptType.SPENDTAPROOT,
 }
 
 BIP48_SCRIPT_TYPES = {
@@ -112,6 +113,12 @@ def guess_script_type_from_path(address_n: List[int]) -> messages.InputScriptTyp
             return BIP48_SCRIPT_TYPES[script_type_field]
 
     return messages.InputScriptType.SPENDADDRESS
+
+
+def get_unlock_path(address_n: List[int]) -> Optional[List[int]]:
+    if address_n and address_n[0] == tools.H_(10025):
+        return address_n[:1]
+    return None
 
 
 @click.group(name="btc")
@@ -195,6 +202,7 @@ def get_address(
         show_display,
         script_type=script_type,
         multisig=multisig,
+        unlock_path=get_unlock_path(address_n),
     )
 
 
@@ -224,6 +232,7 @@ def get_public_node(
         show_display=show_display,
         coin_name=coin,
         script_type=script_type,
+        unlock_path=get_unlock_path(address_n),
     )
     return {
         "node": {

--- a/tests/device_tests/bitcoin/test_authorize_coinjoin.py
+++ b/tests/device_tests/bitcoin/test_authorize_coinjoin.py
@@ -392,13 +392,14 @@ def test_cancel_authorization(client: Client):
 
 def test_get_public_key(client: Client):
     ACCOUNT_PATH = parse_path("m/10025h/1h/0h/1h")
-    EXPECTED_XPUB = "xpub6DyhEpXMikKQgH2S1UcRwjYhxHVVLK8ffaABC5E1M1juvdik9t8VsucEnM585ZpiJjiu5uFnpuq21WnkvAH2h8LDMw6jubfX5J2ZggQX1hP"
+    EXPECTED_XPUB = "tpubDEMKm4M3S2Grx5DHTfbX9et5HQb9KhdjDCkUYdH9gvVofvPTE6yb2MH52P9uc4mx6eFohUmfN1f4hhHNK28GaZnWRXr3b8KkfFcySo1SmXU"
 
     # Ensure that user cannot access SLIP-25 path without UnlockPath.
     with pytest.raises(TrezorFailure, match="Forbidden key path"):
         resp = btc.get_public_node(
             client,
             ACCOUNT_PATH,
+            coin_name="Testnet",
             script_type=messages.InputScriptType.SPENDTAPROOT,
         )
 
@@ -419,6 +420,7 @@ def test_get_public_key(client: Client):
         resp = btc.get_public_node(
             client,
             ACCOUNT_PATH,
+            coin_name="Testnet",
             script_type=messages.InputScriptType.SPENDTAPROOT,
             unlock_path=SLIP25_PATH,
             unlock_path_mac=invalid_unlock_path_mac,
@@ -435,6 +437,7 @@ def test_get_public_key(client: Client):
         resp = btc.get_public_node(
             client,
             ACCOUNT_PATH,
+            coin_name="Testnet",
             script_type=messages.InputScriptType.SPENDTAPROOT,
             unlock_path=SLIP25_PATH,
             unlock_path_mac=unlock_path_mac,


### PR DESCRIPTION
Trezorlib shouldn't support preauthorized operations for `get_public_node()` and `get_address()`. I forgot to remove this code during code review of the SLIP-25 implementation. The Trezor function `get_public_key()` doesn't work with `DoPreauthorized`. The Trezor function `get_address()` should work with `DoPreauthorized`, but it's more natural to use `UnlockPath` instead.

No QA needed.