### PR TITLE
Add Makefile commands to be able to flash T1 legacy bootloader and firmware via JLink

### DIFF
--- a/legacy/Makefile
+++ b/legacy/Makefile
@@ -30,7 +30,8 @@ libtrezor.a:
 	@printf "  AR      $@\n"
 	$(Q)$(AR) rcs $@ $^
 
-.PHONY: vendor build_unix test_emu test_emu_ui test_emu_ui_record
+.PHONY: vendor build_unix test_emu test_emu_ui test_emu_ui_record \
+        flash_firmware_jlink flash_bootloader_jlink
 
 vendor:
 	git submodule update --init --recursive
@@ -47,3 +48,10 @@ test_emu_ui: ## run ui integration tests
 
 test_emu_ui_record: ## record and hash screens for ui integration tests
 	./script/test --ui=record --ui-check-missing $(TESTOPTS)
+
+flash_firmware_jlink:
+	JLinkExe -nogui 1 -commanderscript firmware/firmware_flash.jlink
+
+flash_bootloader_jlink:
+	JLinkExe -nogui 1 -commanderscript bootloader/bootloader_flash.jlink
+

--- a/legacy/bootloader/bootloader_flash.jlink
+++ b/legacy/bootloader/bootloader_flash.jlink
@@ -1,0 +1,7 @@
+device stm32f205rg
+if swd
+speed auto
+loadbin bootloader/bootloader.bin 0x8000000
+r
+g
+exit

--- a/legacy/firmware/firmware_flash.jlink
+++ b/legacy/firmware/firmware_flash.jlink
@@ -1,0 +1,7 @@
+device stm32f205rg
+if swd
+speed auto
+loadbin firmware/trezor.bin 0x08010000
+r
+g
+exit


### PR DESCRIPTION
Add two commands for commandline flashing of T1 legacy bootloader and firmware with JLink.

Both commands are marked `.PHONY` so that it won't trigger rebuild, since (re)build needs to be done with `cibuild` script.