### PR TITLE
Workaround failing build_unix_debug

### DIFF
--- a/core/embed/rust/src/lib.rs
+++ b/core/embed/rust/src/lib.rs
@@ -3,6 +3,7 @@
 #![allow(clippy::new_without_default)]
 #![deny(unsafe_op_in_unsafe_fn)]
 #![allow(dead_code)]
+#![feature(lang_items)]
 
 mod error;
 // use trezorhal for its macros early
@@ -52,3 +53,10 @@ fn panic(_info: &core::panic::PanicInfo) -> ! {
     // Otherwise, use `unwrap!` macro from trezorhal.
     trezorhal::common::__fatal_error("", "rs", "", 0, "");
 }
+
+#[cfg(not(target_arch = "arm"))]
+#[cfg(not(test))]
+#[cfg(any(not(feature = "test"), feature = "clippy"))]
+#[lang = "eh_personality"]
+/// Needed by full debuginfo `opt-level = 0` builds for some reason.
+extern "C" fn eh_personality() {}


### PR DESCRIPTION
Something needs the symbol even though we don't do unwinding (I think):
```
/bin/ld: build/unix/rust/debug/libtrezor_lib.a(core-05898138a596088a.core.4cbccd39-cgu.0.rcgu.o):(.data.DW.ref.rust_eh_personality[DW.ref.rust_eh_personality]+0x0): undefined reference to `rust_eh_personality'
```
Defining one that does nothing seems to avoid the problem, not sure what happens when it actually gets called. Needs nightly rustc. Possibly related: https://github.com/rust-lang/rust/issues/56152, https://docs.rust-embedded.org/embedonomicon/smallest-no-std.html#eh_personality