### PR TITLE
fix flashing usb disconnected error

### DIFF
--- a/core/embed/extmod/modtrezorio/modtrezorio.c
+++ b/core/embed/extmod/modtrezorio/modtrezorio.c
@@ -32,7 +32,7 @@
 #include "usb.h"
 
 // Whether USB data pins were connected on last check (USB configured)
-__attribute__((unused)) static bool usb_connected_previously = false;
+bool usb_connected_previously = true;
 
 #define CHECK_PARAM_RANGE(value, minimum, maximum)  \
   if (value < minimum || value > maximum) {         \

--- a/core/embed/trezorhal/usb.c
+++ b/core/embed/trezorhal/usb.c
@@ -153,8 +153,12 @@ void usb_start(void) { USBD_Start(&usb_dev_handle); }
 void usb_stop(void) { USBD_Stop(&usb_dev_handle); }
 
 secbool usb_configured(void) {
+  static uint32_t usb_configured_last_ok = 0;
+  uint32_t ticks = hal_ticks_ms();
+
   const USBD_HandleTypeDef *pdev = &usb_dev_handle;
   if (pdev->dev_state == USBD_STATE_CONFIGURED) {
+    usb_configured_last_ok = hal_ticks_ms();
     return sectrue;
   }
 
@@ -163,6 +167,20 @@ secbool usb_configured(void) {
   // configured.
   if (pdev->dev_state == USBD_STATE_SUSPENDED &&
       pdev->dev_old_state == USBD_STATE_CONFIGURED) {
+    usb_configured_last_ok = hal_ticks_ms();
+    return sectrue;
+  }
+
+  if (usb_configured_last_ok == 0) {
+    usb_configured_last_ok = ticks;
+    return sectrue;
+  }
+  if (usb_configured_last_ok > ticks) {
+    // probably overflow of 32bit ms counter, ignore as its just once in a long
+    // time
+    return sectrue;
+  }
+  if ((hal_ticks_ms() - usb_configured_last_ok) < 2000) {
     return sectrue;
   }
 

--- a/core/src/apps/homescreen/homescreen.py
+++ b/core/src/apps/homescreen/homescreen.py
@@ -26,7 +26,6 @@ class Homescreen(HomescreenBase):
 
     def __init__(self) -> None:
         super().__init__()
-        self.is_connected = False
         if not storage.device.is_initialized():
             self.label = "Go to trezor.io/start"
 
@@ -44,10 +43,8 @@ class Homescreen(HomescreenBase):
     async def usb_checker_task(self) -> None:
         usbcheck = loop.wait(io.USB_CHECK)
         while True:
-            is_connected = await usbcheck
-            if is_connected != self.is_connected:
-                self.is_connected = is_connected
-                self.set_repaint(True)
+            await usbcheck
+            self.set_repaint(True)
 
     def do_render(self) -> None:
         # warning bar on top
@@ -62,7 +59,7 @@ class Homescreen(HomescreenBase):
         elif storage.device.get_experimental_features():
             ui.header_warning("EXPERIMENTAL MODE!")
         else:
-            ui.display.bar(0, 0, ui.WIDTH, ui.HEIGHT, ui.BG)
+            ui.display.bar(0, 0, ui.WIDTH, ui.get_header_height(), ui.BG)
 
         # homescreen with shifted avatar and text on bottom
         # Differs for each model
@@ -95,6 +92,7 @@ class Homescreen(HomescreenBase):
 
     def on_touch_end(self, _x: int, _y: int) -> None:
         if self.loader.start_ms is not None:
+            ui.display.clear()
             self.set_repaint(True)
         self.loader.stop()
         self.touch_ms = None

--- a/core/src/trezor/ui/__init__.py
+++ b/core/src/trezor/ui/__init__.py
@@ -148,7 +148,7 @@ MODEL_HEADER_HEIGHTS = {"1": 12, "R": 15, "T": 30}
 MODEL_Y_BASELINES = {"1": 10, "R": 11, "T": 22}
 
 
-def header_warning(message: str, clear: bool = True) -> None:
+def header_warning(message: str) -> None:
     height = MODEL_HEADER_HEIGHTS[utils.MODEL]
     y_baseline = MODEL_Y_BASELINES[utils.MODEL]
 
@@ -156,18 +156,18 @@ def header_warning(message: str, clear: bool = True) -> None:
     display.text_center(
         WIDTH // 2, y_baseline, message, BOLD, style.BLACK, style.YELLOW
     )
-    if clear:
-        display.bar(0, height, WIDTH, HEIGHT - height, style.BG)
 
 
-def header_error(message: str, clear: bool = True) -> None:
+def header_error(message: str) -> None:
     height = MODEL_HEADER_HEIGHTS[utils.MODEL]
     y_baseline = MODEL_Y_BASELINES[utils.MODEL]
 
     display.bar(0, 0, WIDTH, height, style.RED)
     display.text_center(WIDTH // 2, y_baseline, message, BOLD, style.WHITE, style.RED)
-    if clear:
-        display.bar(0, height, WIDTH, HEIGHT - height, style.BG)
+
+
+def get_header_height() -> int:
+    return MODEL_HEADER_HEIGHTS[utils.MODEL]
 
 
 def draw_simple(t: "Component") -> None:

--- a/core/src/trezor/ui/components/tt/recovery.py
+++ b/core/src/trezor/ui/components/tt/recovery.py
@@ -16,7 +16,7 @@ class RecoveryHomescreen(ui.Component):
             heading = "SEED CHECK"
         else:
             heading = "RECOVERY MODE"
-        ui.header_warning(heading, clear=False)
+        ui.header_warning(heading)
 
         if not self.subtext:
             ui.display.text_center(ui.WIDTH // 2, 80, self.text, ui.BOLD, ui.FG, ui.BG)


### PR DESCRIPTION
This fixes flashing USB DISCONNECTED ERROR by adding 2s grace period after usb disconnection is detected. 

Change detection logic is removed from homescreen as it this object is rectreated sometimes and than the logic fails, futthermore it was redundant to the polling mechanism.

Also the header warning does not clear entire screen when it get drawn/removed, which eliminates flickering of the avatar.

The grace period is not only on startup but after every disconnection, as i was getting some brief warnings when suite started up - somehow the USB was for a small amount of time in `USBD_STATE_DEFAULT`.