### PR TITLE
Redistribute contents in flash 

### DIFF
--- a/core/embed/firmware/memory_T.ld
+++ b/core/embed/firmware/memory_T.ld
@@ -45,9 +45,11 @@ SECTIONS {
 
   .flash2 : ALIGN(512) {
     build/firmware/frozen_mpy.o(.rodata*);
-    build/firmware/vendor/secp256k1-zkp/src/secp256k1.o(.rodata*);
-    build/firmware/vendor/secp256k1-zkp/src/precomputed_ecmult.o(.rodata*);
-    build/firmware/vendor/secp256k1-zkp/src/precomputed_ecmult_gen.o(.rodata*);
+    build/firmware/vendor/trezor-crypto/aes/aestab.o(.rodata*);
+    . = ALIGN(4);
+    */libtrezor_lib.a:(.text*);
+    . = ALIGN(4);
+    */libtrezor_lib.a:(.rodata*);
     . = ALIGN(512);
   } >FLASH2 AT>FLASH2
 


### PR DESCRIPTION
This PR redistributes content in flash a bit, so that all UI1 and UI2 on TT and TR can be linked. TT with UI2 and PYOPT=0 however does not fit, there just isn't enough space left in both sections to fit that right now. 

With logic that we are moving UI from python to rust, i moved the rust library into same section as python, so that overall size of that section is not changed too much when code is rewritten from py to rs.

closes #2417 