### PR TITLE
Fix bug in SetBusy when running CI tests

### DIFF
--- a/core/src/apps/base.py
+++ b/core/src/apps/base.py
@@ -29,13 +29,12 @@ def busy_expiry_ms() -> int:
     Returns the time left until the busy state expires or 0 if the device is not in the busy state.
     """
 
-    busy_deadline_bytes = storage.cache.get(storage.cache.APP_COMMON_BUSY_DEADLINE_MS)
-    if busy_deadline_bytes is None:
+    busy_deadline_ms = storage.cache.get_int(storage.cache.APP_COMMON_BUSY_DEADLINE_MS)
+    if busy_deadline_ms is None:
         return 0
 
     import utime
 
-    busy_deadline_ms = int.from_bytes(busy_deadline_bytes, "big")
     expiry_ms = utime.ticks_diff(busy_deadline_ms, utime.ticks_ms())
     return expiry_ms if expiry_ms > 0 else 0
 
@@ -171,9 +170,7 @@ async def handle_SetBusy(ctx: wire.Context, msg: SetBusy) -> Success:
         import utime
 
         deadline = utime.ticks_add(utime.ticks_ms(), msg.expiry_ms)
-        storage.cache.set(
-            storage.cache.APP_COMMON_BUSY_DEADLINE_MS, deadline.to_bytes(4, "big")
-        )
+        storage.cache.set_int(storage.cache.APP_COMMON_BUSY_DEADLINE_MS, deadline)
     else:
         storage.cache.delete(storage.cache.APP_COMMON_BUSY_DEADLINE_MS)
     set_homescreen()

--- a/core/src/apps/common/request_pin.py
+++ b/core/src/apps/common/request_pin.py
@@ -58,15 +58,11 @@ async def request_pin_and_sd_salt(
 
 def _set_last_unlock_time() -> None:
     now = utime.ticks_ms()
-    storage.cache.set(
-        storage.cache.APP_COMMON_REQUEST_PIN_LAST_UNLOCK, now.to_bytes(4, "big")
-    )
+    storage.cache.set_int(storage.cache.APP_COMMON_REQUEST_PIN_LAST_UNLOCK, now)
 
 
 def _get_last_unlock_time() -> int:
-    return int.from_bytes(
-        storage.cache.get(storage.cache.APP_COMMON_REQUEST_PIN_LAST_UNLOCK, b""), "big"
-    )
+    return storage.cache.get_int(storage.cache.APP_COMMON_REQUEST_PIN_LAST_UNLOCK) or 0
 
 
 async def verify_user_pin(

--- a/core/src/storage/cache.py
+++ b/core/src/storage/cache.py
@@ -133,8 +133,8 @@ class SessionlessCache(DataCache):
             64,  # APP_COMMON_SEED_WITHOUT_PASSPHRASE
             1,  # APP_COMMON_SAFETY_CHECKS_TEMPORARY
             1,  # STORAGE_DEVICE_EXPERIMENTAL_FEATURES
-            4,  # APP_COMMON_REQUEST_PIN_LAST_UNLOCK
-            4,  # APP_COMMON_BUSY_DEADLINE_MS
+            8,  # APP_COMMON_REQUEST_PIN_LAST_UNLOCK
+            8,  # APP_COMMON_BUSY_DEADLINE_MS
         )
         super().__init__()
 

--- a/core/tests/test_storage.cache.py
+++ b/core/tests/test_storage.cache.py
@@ -83,6 +83,24 @@ class TestStorageCache(unittest.TestCase):
         with self.assertRaises(cache.InvalidSessionError):
             cache.get(KEY)
 
+    def test_get_set_int(self):
+        session_id1 = cache.start_session()
+        cache.set_int(KEY, 1234)
+        self.assertEqual(cache.get_int(KEY), 1234)
+
+        session_id2 = cache.start_session()
+        cache.set_int(KEY, 5678)
+        self.assertEqual(cache.get_int(KEY), 5678)
+
+        cache.start_session(session_id2)
+        self.assertEqual(cache.get_int(KEY), 5678)
+        cache.start_session(session_id1)
+        self.assertEqual(cache.get_int(KEY), 1234)
+
+        cache.clear_all()
+        with self.assertRaises(cache.InvalidSessionError):
+            cache.get_int(KEY)
+
     def test_delete(self):
         session_id1 = cache.start_session()
         self.assertIsNone(cache.get(KEY))


### PR DESCRIPTION
The resolution of the `ticks_ms()` is 62 bits in unix builds. On the CI machines which run continuously for days the value can overflow the 4 bytes that are available for it in the storage cache. This could cause `test_busy_state` to fail randomly.

- I increased the size of `APP_COMMON_REQUEST_PIN_LAST_UNLOCK` and `APP_COMMON_BUSY_DEADLINE_MS` to 8 bytes.
- I also introduced `set_int()` and `get_int()` which automatically deal with the encoding/decoding of integers in the storage cache. One of the reasons why this was so hard to debug is that in micropython `int.to_bytes()` does not fail when the value cannot be encoded into the specified number of bytes.