### PR TITLE
feat(core/rust/ui): support longer passphrases

### DIFF
--- a/core/embed/rust/src/ui/display/mod.rs
+++ b/core/embed/rust/src/ui/display/mod.rs
@@ -1057,6 +1057,22 @@ impl Font {
             }
         }
     }
+
+    /// Get the length of the longest suffix from a given `text`
+    /// that will fit into the area `width` pixels wide.
+    pub fn longest_suffix(self, width: i16, text: &str) -> usize {
+        let mut text_width = 0;
+        for (chars_from_right, c) in text.chars().rev().enumerate() {
+            let c_width = self.char_width(c);
+            if text_width + c_width > width {
+                // Another character cannot be fitted, we're done.
+                return chars_from_right;
+            }
+            text_width += c_width;
+        }
+
+        text.len() // it fits in its entirety
+    }
 }
 
 #[derive(Copy, Clone, PartialEq, Eq)]

--- a/core/embed/rust/src/ui/model_tt/component/keyboard/common.rs
+++ b/core/embed/rust/src/ui/model_tt/component/keyboard/common.rs
@@ -155,6 +155,10 @@ impl<const L: usize> TextBox<L> {
         self.text.is_empty()
     }
 
+    pub fn is_full(&self) -> bool {
+        self.text.len() == self.text.capacity()
+    }
+
     /// Delete the last character of content, if any.
     pub fn delete_last(&mut self, ctx: &mut EventCtx) {
         let changed = self.text.pop().is_some();
@@ -207,6 +211,7 @@ impl<const L: usize> TextBox<L> {
     }
 }
 
+/// Create a visible "underscoring" of the last letter of a text.
 pub fn paint_pending_marker(text_baseline: Point, text: &str, font: Font, color: Color) {
     // Measure the width of the last character of input.
     if let Some(last) = text.chars().last() {


### PR DESCRIPTION
Connected with https://github.com/trezor/trezor-firmware/issues/2499:
- enabling longer passphrases up to 50 characters - the limit was already there, just handling all the edge cases and visuals
- also fixing the change of the character categories - previously the swipes were not changing the buttons, as the new buttons were not placed - there is a need to re-place them on each swipe
  - we could solve it also by reusing the 10 already places buttons, and just changing the content of the buttons via `Button::set_content()` - in that case we would need to place them only once in the beginning and would not have to store the `PassphraseKeyboard::key_grid`, which is necessary for later placement