### PR TITLE
feat(python): add trezorctl possibility to record screen changes

### DIFF
--- a/core/emu.py
+++ b/core/emu.py
@@ -9,7 +9,7 @@ import subprocess
 import sys
 import tempfile
 from pathlib import Path
-from typing import TextIO
+from typing import Optional, TextIO
 
 import click
 
@@ -108,6 +108,7 @@ def _from_env(name: str) -> bool:
 @click.option("-p", "--profile", metavar="NAME", help="Profile name or path")
 @click.option("-P", "--port", metavar="PORT", type=int, default=int(os.environ.get("TREZOR_UDP_PORT", 0)) or None, help="UDP port number")
 @click.option("-q", "--quiet", is_flag=True, help="Silence emulator output")
+@click.option("-r", "--record-dir", help="Directory where to record screen changes")
 @click.option("-s", "--slip0014", is_flag=True, help="Initialize device with SLIP-14 seed (all all all...)")
 @click.option("-t", "--temporary-profile", is_flag=True, help="Create an empty temporary profile")
 @click.option("-w", "--watch", is_flag=True, help="Restart emulator if sources change")
@@ -132,6 +133,7 @@ def cli(
     port: int,
     output: TextIO | None,
     quiet: bool,
+    record_dir: Optional[str],
     slip0014: bool,
     temporary_profile: bool,
     watch: bool,
@@ -272,6 +274,12 @@ def cli(
             pin=None,
             passphrase_protection=False,
             label=label,
+        )
+
+    if record_dir:
+        assert emulator.client is not None
+        trezorlib.debuglink.record_screen(
+            emulator.client, record_dir, report_func=print
         )
 
     if run_command:

--- a/python/.changelog.d/2547.added
+++ b/python/.changelog.d/2547.added
@@ -1,0 +1,1 @@
+Add possibility to save emulator screenshots.


### PR DESCRIPTION
Connected with https://github.com/trezor/trezor-firmware/issues/2547:
- allowing for `trezorctl` specifying the directory where all the screen changes from emulator will be saved

There are two possibilities how to do that, each with a little different use-case:

1. Via `-r / --record` option directly in `trezorctl` command, so it can be used together with any other action - e.g. `trezorctl -r screenshots ping "Hello world" -b`. This allows for recording separate `trezorctl` actions.
2. Via separate `record` command - `trezorctl record screenshots`, it also allows for stopping the recording with `trezorctl record -s/--stop`. This will save all the screens from the current "session" - until the emulator does not die.

Both will do basically the same - create `screenshots` directory in current `pwd`, if it does not exist, generate a unique subdirectory based on datetime (like `screenshots/2022-10-07_13-09-48`) and will start saving new screen refresh pictures into it. 

The reason of creating subdirectories for every call/every `emulator` session is that `emulator` names the screens `refresh-00000000.png`, `refresh-00000001.png` etc., resetting the counter at every emulator restart. When it would always save into the same directory, new screens would overwrite older ones.

Option number 1 currently does not stop recording after that `trezorctl` returns, so it will be recording further screens from emulator into the same dir (unless the next command specified their own `-r / --record`). It should be possible to stop recording at the end when recording started this way - probably with `@cli.set_result_callback()`?. 

I was not sure where to put the `record_screen` "helper" function (that gets called in two places), so I left it in `cli/trezorctl.py`. It might be moved outside of `cli`, maybe into `device.py` or `debuglink.py`. (It might be useful as a function to be called from scripts using `trezorlib`.)