### PR TITLE
Rust UI: zero out memory after using pin/passphrase layout

### DIFF
--- a/core/embed/rust/Cargo.lock
+++ b/core/embed/rust/Cargo.lock
@@ -287,6 +287,7 @@ dependencies = [
  "heapless",
  "num-derive",
  "num-traits",
+ "zeroize",
 ]
 
 [[package]]
@@ -316,3 +317,9 @@ name = "winapi-x86_64-pc-windows-gnu"
 version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "712e227841d057c1ee1cd2fb22fa7e5a5461ae8e48fa2ca79ec42cfc1931183f"
+
+[[package]]
+name = "zeroize"
+version = "1.5.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c394b5bd0c6f669e7275d9c20aa90ae064cb22e75a1cad54e1b34088034b149f"

--- a/core/embed/rust/Cargo.toml
+++ b/core/embed/rust/Cargo.toml
@@ -62,6 +62,10 @@ version = "0.3.3"
 version = "0.2.4"
 default_features = false
 
+[dependencies.zeroize]
+version = "1.5.7"
+default_features = false
+
 # Build dependencies
 
 [build-dependencies.bindgen]

--- a/core/embed/rust/librust_qstr.h
+++ b/core/embed/rust/librust_qstr.h
@@ -16,6 +16,7 @@ static void _librust_qstrs(void) {
   MP_QSTR_CONFIRMED;
   MP_QSTR_CANCELLED;
   MP_QSTR_INFO;
+  MP_QSTR_FORGOTTEN;
   MP_QSTR_confirm_action;
   MP_QSTR_confirm_blob;
   MP_QSTR_confirm_coinjoin;
@@ -55,6 +56,7 @@ static void _librust_qstrs(void) {
   MP_QSTR_trace;
   MP_QSTR_bounds;
   MP_QSTR_page_count;
+  MP_QSTR_forget;
 
   MP_QSTR_title;
   MP_QSTR_subtitle;

--- a/core/embed/rust/src/ui/component/base.rs
+++ b/core/embed/rust/src/ui/component/base.rs
@@ -341,6 +341,9 @@ pub enum Event {
     /// Component has been attached to component tree. This event is sent once
     /// before any other events.
     Attach,
+    /// Component will not be used anymore, zero out all sensitive data like PIN
+    /// and passphrase so that they are not present in memory afterwards.
+    Forget,
     /// Internally-handled event to inform all `Child` wrappers in a sub-tree to
     /// get scheduled for painting.
     RequestPaint,

--- a/core/embed/rust/src/ui/layout/obj.rs
+++ b/core/embed/rust/src/ui/layout/obj.rs
@@ -18,6 +18,7 @@ use crate::{
         component::{Child, Component, Event, EventCtx, Never, TimerToken},
         constant,
         geometry::Rect,
+        layout::result::FORGOTTEN,
     },
 };
 
@@ -283,6 +284,7 @@ impl LayoutObj {
                 Qstr::MP_QSTR_timer => obj_fn_2!(ui_layout_timer).as_obj(),
                 Qstr::MP_QSTR_paint => obj_fn_1!(ui_layout_paint).as_obj(),
                 Qstr::MP_QSTR_request_complete_repaint => obj_fn_1!(ui_layout_request_complete_repaint).as_obj(),
+                Qstr::MP_QSTR_forget => obj_fn_1!(ui_layout_forget).as_obj(),
                 Qstr::MP_QSTR_trace => obj_fn_2!(ui_layout_trace).as_obj(),
                 Qstr::MP_QSTR_bounds => obj_fn_1!(ui_layout_bounds).as_obj(),
                 Qstr::MP_QSTR_page_count => obj_fn_1!(ui_layout_page_count).as_obj(),
@@ -433,6 +435,19 @@ extern "C" fn ui_layout_request_complete_repaint(this: Obj) -> Obj {
             #[cfg(feature = "ui_debug")]
             panic!("cannot raise messages during RequestPaint");
         };
+        Ok(Obj::const_none())
+    };
+    unsafe { util::try_or_raise(block) }
+}
+
+extern "C" fn ui_layout_forget(this: Obj) -> Obj {
+    let block = || {
+        let this: Gc<LayoutObj> = this.try_into()?;
+        let msg = this.obj_event(Event::Forget)?;
+        // Make sure message was delivered.
+        if msg != FORGOTTEN.as_obj() {
+            panic!("failed to clear sensitive data")
+        }
         Ok(Obj::const_none())
     };
     unsafe { util::try_or_raise(block) }

--- a/core/embed/rust/src/ui/layout/result.rs
+++ b/core/embed/rust/src/ui/layout/result.rs
@@ -26,6 +26,7 @@ unsafe impl Sync for ResultObj {}
 static CONFIRMED_TYPE: Type = obj_type! { name: Qstr::MP_QSTR_CONFIRMED, };
 static CANCELLED_TYPE: Type = obj_type! { name: Qstr::MP_QSTR_CANCELLED, };
 static INFO_TYPE: Type = obj_type! { name: Qstr::MP_QSTR_INFO, };
+static FORGOTTEN_TYPE: Type = obj_type! { name: Qstr::MP_QSTR_FORGOTTEN, };
 
 pub static CONFIRMED: ResultObj = ResultObj {
     base: CONFIRMED_TYPE.as_base(),
@@ -35,4 +36,7 @@ pub static CANCELLED: ResultObj = ResultObj {
 };
 pub static INFO: ResultObj = ResultObj {
     base: INFO_TYPE.as_base(),
+};
+pub static FORGOTTEN: ResultObj = ResultObj {
+    base: FORGOTTEN_TYPE.as_base(),
 };

--- a/core/embed/rust/src/ui/model_tt/component/keyboard/bip39.rs
+++ b/core/embed/rust/src/ui/model_tt/component/keyboard/bip39.rs
@@ -68,6 +68,10 @@ impl MnemonicInput for Bip39Input {
     fn mnemonic(&self) -> Option<&'static str> {
         self.suggested_word
     }
+
+    fn forget(&mut self) {
+        self.suggested_word = None;
+    }
 }
 
 impl Component for Bip39Input {

--- a/core/embed/rust/src/ui/model_tt/component/keyboard/common.rs
+++ b/core/embed/rust/src/ui/model_tt/component/keyboard/common.rs
@@ -6,7 +6,7 @@ use crate::{
         component::{Event, EventCtx, TimerToken},
         display::{self, Color, Font},
         geometry::{Offset, Point, Rect},
-        util::ResultExt,
+        util::{zeroize_string, ResultExt},
     },
 };
 
@@ -204,6 +204,10 @@ impl<const L: usize> TextBox<L> {
             TextEdit::ReplaceLast(char) => self.replace_last(ctx, char),
             TextEdit::Append(char) => self.append(ctx, char),
         }
+    }
+
+    pub fn forget(&mut self) {
+        zeroize_string(&mut self.text)
     }
 }
 

--- a/core/embed/rust/src/ui/model_tt/component/keyboard/mnemonic.rs
+++ b/core/embed/rust/src/ui/model_tt/component/keyboard/mnemonic.rs
@@ -13,6 +13,7 @@ pub const MNEMONIC_KEY_COUNT: usize = 9;
 
 pub enum MnemonicKeyboardMsg {
     Confirmed,
+    Forgotten,
 }
 
 pub struct MnemonicKeyboard<T, U> {
@@ -109,6 +110,10 @@ where
     }
 
     fn event(&mut self, ctx: &mut EventCtx, event: Event) -> Option<Self::Msg> {
+        if let Event::Forget = event {
+            self.input.mutate(ctx, |_ctx, i| i.inner_mut().forget());
+            return Some(MnemonicKeyboardMsg::Forgotten);
+        }
         match self.input.event(ctx, event) {
             Some(MnemonicInputMsg::Confirmed) => {
                 // Confirmed, bubble up.
@@ -162,6 +167,7 @@ pub trait MnemonicInput: Component<Msg = MnemonicInputMsg> {
     fn on_backspace_click(&mut self, ctx: &mut EventCtx);
     fn is_empty(&self) -> bool;
     fn mnemonic(&self) -> Option<&'static str>;
+    fn forget(&mut self);
 }
 
 pub enum MnemonicInputMsg {

--- a/core/embed/rust/src/ui/model_tt/component/keyboard/passphrase.rs
+++ b/core/embed/rust/src/ui/model_tt/component/keyboard/passphrase.rs
@@ -13,6 +13,7 @@ use crate::ui::{
 pub enum PassphraseKeyboardMsg {
     Confirmed,
     Cancelled,
+    Forgotten,
 }
 
 pub struct PassphraseKeyboard {
@@ -147,6 +148,10 @@ impl Component for PassphraseKeyboard {
     }
 
     fn event(&mut self, ctx: &mut EventCtx, event: Event) -> Option<Self::Msg> {
+        if let Event::Forget = event {
+            self.input.mutate(ctx, |_ctx, i| i.textbox.forget());
+            return Some(PassphraseKeyboardMsg::Forgotten);
+        }
         if self.input.inner().multi_tap.is_timeout_event(event) {
             self.input
                 .mutate(ctx, |ctx, i| i.multi_tap.clear_pending_state(ctx));

--- a/core/embed/rust/src/ui/model_tt/component/keyboard/pin.rs
+++ b/core/embed/rust/src/ui/model_tt/component/keyboard/pin.rs
@@ -16,12 +16,14 @@ use crate::{
             button::{Button, ButtonContent, ButtonMsg, ButtonMsg::Clicked},
             theme,
         },
+        util::zeroize_string,
     },
 };
 
 pub enum PinKeyboardMsg {
     Confirmed,
     Cancelled,
+    Forgotten,
 }
 
 const MAX_LENGTH: usize = 50;
@@ -193,6 +195,10 @@ where
                 self.major_warning = None;
                 ctx.request_paint();
             }
+            Event::Forget => {
+                self.textbox.mutate(ctx, |_ctx, t| t.forget());
+                return Some(PinKeyboardMsg::Forgotten);
+            }
             _ => {}
         }
 
@@ -323,6 +329,10 @@ impl PinDots {
 
     fn pin(&self) -> &str {
         &self.digits
+    }
+
+    fn forget(&mut self) {
+        zeroize_string(&mut self.digits)
     }
 
     fn paint_digits(&self, area: Rect) {

--- a/core/embed/rust/src/ui/model_tt/component/keyboard/slip39.rs
+++ b/core/embed/rust/src/ui/model_tt/component/keyboard/slip39.rs
@@ -85,6 +85,10 @@ impl MnemonicInput for Slip39Input {
     fn mnemonic(&self) -> Option<&'static str> {
         self.final_word
     }
+
+    fn forget(&mut self) {
+        self.final_word = None;
+    }
 }
 
 impl Component for Slip39Input {

--- a/core/embed/rust/src/ui/model_tt/layout.rs
+++ b/core/embed/rust/src/ui/model_tt/layout.rs
@@ -22,7 +22,7 @@ use crate::{
         geometry,
         layout::{
             obj::{ComponentMsgObj, LayoutObj},
-            result::{CANCELLED, CONFIRMED, INFO},
+            result::{CANCELLED, CONFIRMED, FORGOTTEN, INFO},
             util::iter_into_array,
         },
     },
@@ -132,6 +132,7 @@ where
         match msg {
             PinKeyboardMsg::Confirmed => self.pin().try_into(),
             PinKeyboardMsg::Cancelled => Ok(CANCELLED.as_obj()),
+            PinKeyboardMsg::Forgotten => Ok(FORGOTTEN.as_obj()),
         }
     }
 }
@@ -141,6 +142,7 @@ impl ComponentMsgObj for PassphraseKeyboard {
         match msg {
             PassphraseKeyboardMsg::Confirmed => self.passphrase().try_into(),
             PassphraseKeyboardMsg::Cancelled => Ok(CANCELLED.as_obj()),
+            PassphraseKeyboardMsg::Forgotten => Ok(FORGOTTEN.as_obj()),
         }
     }
 }
@@ -159,6 +161,7 @@ where
                     panic!("invalid mnemonic")
                 }
             }
+            MnemonicKeyboardMsg::Forgotten => Ok(FORGOTTEN.as_obj()),
         }
     }
 }

--- a/core/embed/rust/src/ui/util.rs
+++ b/core/embed/rust/src/ui/util.rs
@@ -1,3 +1,6 @@
+use heapless::{String, Vec};
+use zeroize::{DefaultIsZeroes, Zeroize};
+
 pub trait ResultExt {
     fn assert_if_debugging_ui(self, message: &str);
 }
@@ -29,6 +32,20 @@ pub fn u32_to_str(num: u32, buffer: &mut [u8]) -> Option<&str> {
             Some(core::str::from_utf8(result).unwrap())
         }
     }
+}
+
+pub fn zeroize_vec<T, const N: usize>(val: &mut Vec<T, N>)
+where
+    T: DefaultIsZeroes,
+{
+    let slice: &mut [T] = val.as_mut();
+    slice.zeroize();
+    val.clear();
+}
+
+pub fn zeroize_string<const N: usize>(val: &mut String<N>) {
+    // SAFETY: afterwards the underlying vec will be empty, which is valid UTF-8.
+    zeroize_vec(unsafe { val.as_mut_vec() })
 }
 
 #[cfg(test)]

--- a/core/embed/rust/src/ui/util.rs
+++ b/core/embed/rust/src/ui/util.rs
@@ -38,6 +38,8 @@ pub fn zeroize_vec<T, const N: usize>(val: &mut Vec<T, N>)
 where
     T: DefaultIsZeroes,
 {
+    // Fill vector to capacity to avoid leftovers.
+    while val.push(T::default()).is_ok() {}
     let slice: &mut [T] = val.as_mut();
     slice.zeroize();
     val.clear();

--- a/core/src/trezor/ui/layouts/tt_v2/recovery.py
+++ b/core/src/trezor/ui/layouts/tt_v2/recovery.py
@@ -53,7 +53,11 @@ async def request_word(
             )
         )
 
-    word: str = await ctx.wait(keyboard)
+    try:
+        word: str = await ctx.wait(keyboard)
+    finally:
+        keyboard.forget()
+
     return word
 
 


### PR DESCRIPTION
Fixes #2530. Originally I wanted to handle this in `msg_try_into_obj` but it would require making mutable a lot of references that previously weren't, and would make it easy to use the `Child` abstraction in a wrong way. Adding an event seems much less intrusive.