### PR TITLE
Implement CoinJoin requests

### DIFF
--- a/common/protob/messages-bitcoin.proto
+++ b/common/protob/messages-bitcoin.proto
@@ -208,9 +208,7 @@ message SignTx {
         required uint64 plebs_dont_pay_threshold = 2;  // input amount above which the fee rate applies
         required uint64 min_registrable_amount = 3;    // minimum registrable output amount
         required bytes mask_public_key = 4;            // ephemeral secp256k1 public key used for masking signable_inputs, 33 bytes in compressed form
-        required bytes signable_inputs = 5;            // masked bit field indicating which transaction inputs can be signed.
-        required bytes remixed_inputs = 6;             // bit field indicating which transaction inputs are remixes
-        required bytes signature = 7;                  // the trusted party's signature of the request digest
+        required bytes signature = 5;                  // the trusted party's signature of the request digest
     }
 }
 
@@ -373,6 +371,7 @@ message TxInput {
     optional uint32 orig_index = 17;                                    // index of the input in the original transaction (used when creating a replacement transaction)
     optional DecredStakingSpendType decred_staking_spend = 18; 	        // if not None this holds the type of stake spend: revocation or stake generation
     optional bytes script_pubkey = 19;                                  // scriptPubKey of the previous output spent by this input, only set of EXTERNAL inputs
+    optional uint32 coinjoin_flags = 20;                                // bit field of CoinJoin-specific flags
 }
 
 /** Data type for transaction output to be signed.

--- a/common/protob/messages-bitcoin.proto
+++ b/common/protob/messages-bitcoin.proto
@@ -197,6 +197,21 @@ message SignTx {
     optional uint32 branch_id = 10;                            // only for Zcash, BRANCH_ID
     optional AmountUnit amount_unit = 11 [default=BITCOIN];    // show amounts in
     optional bool decred_staking_ticket = 12 [default=false];  // only for Decred, this is signing a ticket purchase
+    optional CoinJoinRequest coinjoin_request = 13;            // only for preauthorized CoinJoins
+
+    /**
+     * Signing request for a CoinJoin transaction.
+     */
+    message CoinJoinRequest {
+        option (unstable) = true;
+        required uint32 fee_rate = 1;                  // coordination fee rate in units of 10^-8 percent
+        required uint64 plebs_dont_pay_threshold = 2;  // input amount above which the fee rate applies
+        required uint64 min_registrable_amount = 3;    // minimum registrable output amount
+        required bytes mask_public_key = 4;            // ephemeral secp256k1 public key used for masking signable_inputs, 33 bytes in compressed form
+        required bytes signable_inputs = 5;            // masked bit field indicating which transaction inputs can be signed.
+        required bytes remixed_inputs = 6;             // bit field indicating which transaction inputs are remixes
+        required bytes signature = 7;                  // the trusted party's signature of the request digest
+    }
 }
 
 /**
@@ -426,7 +441,7 @@ message TxAckPaymentRequest {
     option (unstable) = true;
 
     optional bytes nonce = 1;              // the nonce used in the signature computation
-    required string recipient_name = 2;    // merchant's name or coordinator's name in case of CoinJoin
+    required string recipient_name = 2;    // merchant's name
     repeated PaymentRequestMemo memos = 3; // any memos that were signed as part of the request
     optional uint64 amount = 4;            // the sum of the external output amounts requested, required for non-CoinJoin
     required bytes signature = 5;          // the trusted party's signature of the paymentRequestDigest

--- a/core/.changelog.d/noissue.added
+++ b/core/.changelog.d/noissue.added
@@ -1,0 +1,1 @@
+Implement CoinJoin requests.

--- a/core/src/apps/bitcoin/sign_tx/__init__.py
+++ b/core/src/apps/bitcoin/sign_tx/__init__.py
@@ -63,7 +63,11 @@ async def sign_tx(
 ) -> TxRequest:
     approver: approvers.Approver | None = None
     if authorization:
-        approver = approvers.CoinJoinApprover(msg, coin, authorization)
+        if not msg.coinjoin_request:
+            raise wire.DataError("Missing CoinJoin request.")
+        approver = approvers.CoinJoinApprover(
+            msg, coin, authorization, msg.coinjoin_request
+        )
 
     if utils.BITCOIN_ONLY or coin.coin_name in BITCOIN_NAMES:
         signer_class: type[SignerClass] = bitcoin.Bitcoin

--- a/core/src/apps/bitcoin/sign_tx/approvers.py
+++ b/core/src/apps/bitcoin/sign_tx/approvers.py
@@ -331,6 +331,10 @@ class CoinJoinApprover(Approver):
     # Minimum registrable output amount in a CoinJoin.
     MIN_REGISTRABLE_OUTPUT_AMOUNT = 5000
 
+    # Trezor will tolerate a slightly larger fee to account for rounding errors.
+    # Does not apply to Testnet, so that we don't overlook bugs.
+    FEE_TOLERANCE = 200
+
     # Largest possible weight of an output supported by Trezor (P2TR or P2WSH).
     MAX_OUTPUT_WEIGHT = 4 * (8 + 1 + 1 + 1 + 32)
 
@@ -431,10 +435,14 @@ class CoinJoinApprover(Approver):
             + max_fee_per_weight_unit * self.MAX_OUTPUT_WEIGHT
         )
 
+        # Tolerate a small fee difference on Mainnet.
+        tolerance = self.FEE_TOLERANCE if self.coin.slip44 != SLIP44_TESTNET else 0
+
         if our_fees > (
             our_max_coordinator_fee
             + our_max_mining_fee
             + min_allowed_output_amount_plus_fee
+            + tolerance
         ):
             raise wire.ProcessError("Total fee over threshold.")
 

--- a/core/src/apps/bitcoin/sign_tx/bitcoin.py
+++ b/core/src/apps/bitcoin/sign_tx/bitcoin.py
@@ -144,8 +144,6 @@ class Bitcoin:
         for i in range(self.tx_info.tx.inputs_count):
             # STAGE_REQUEST_1_INPUT in legacy
             txi = await helpers.request_tx_input(self.tx_req, i, self.coin)
-            script_pubkey = self.input_derive_script(txi)
-            self.tx_info.add_input(txi, script_pubkey)
             if txi.script_type not in (
                 InputScriptType.SPENDTAPROOT,
                 InputScriptType.EXTERNAL,
@@ -156,11 +154,16 @@ class Bitcoin:
                 self.segwit.add(i)
 
             if input_is_external(txi):
+                node = None
                 self.external.add(i)
                 writers.write_tx_input_check(h_external_inputs_check, txi)
                 await self.process_external_input(txi)
             else:
-                await self.process_internal_input(txi)
+                node = self.keychain.derive(txi.address_n)
+                await self.process_internal_input(txi, node)
+
+            script_pubkey = self.input_derive_script(txi, node)
+            self.tx_info.add_input(txi, script_pubkey)
 
             if txi.orig_hash:
                 await self.process_original_input(txi, script_pubkey)
@@ -285,7 +288,7 @@ class Bitcoin:
         self.write_tx_footer(self.serialized_tx, self.tx_info.tx)
         await helpers.request_tx_finish(self.tx_req)
 
-    async def process_internal_input(self, txi: TxInput) -> None:
+    async def process_internal_input(self, txi: TxInput, node: bip32.HDNode) -> None:
         if txi.script_type not in common.INTERNAL_INPUT_SCRIPT_TYPES:
             raise wire.DataError("Wrong input script type")
 
@@ -856,12 +859,16 @@ class Bitcoin:
     # scriptPubKey derivation
     # ===
 
-    def input_derive_script(self, txi: TxInput) -> bytes:
+    def input_derive_script(
+        self, txi: TxInput, node: bip32.HDNode | None = None
+    ) -> bytes:
         if input_is_external(txi):
             assert txi.script_pubkey is not None  # checked in sanitize_tx_input
             return txi.script_pubkey
 
-        node = self.keychain.derive(txi.address_n)
+        if node is None:
+            node = self.keychain.derive(txi.address_n)
+
         address = addresses.get_address(txi.script_type, self.coin, node, txi.multisig)
         return scripts.output_derive_script(address, self.coin)
 

--- a/core/src/apps/bitcoin/sign_tx/bitcoin.py
+++ b/core/src/apps/bitcoin/sign_tx/bitcoin.py
@@ -292,7 +292,7 @@ class Bitcoin:
         if txi.script_type not in common.INTERNAL_INPUT_SCRIPT_TYPES:
             raise wire.DataError("Wrong input script type")
 
-        await self.approver.add_internal_input(txi)
+        await self.approver.add_internal_input(txi, node)
 
     async def process_external_input(self, txi: TxInput) -> None:
         self.approver.add_external_input(txi)
@@ -447,7 +447,6 @@ class Bitcoin:
     ) -> None:
         if txo.payment_req_index != self.payment_req_index:
             if txo.payment_req_index is None:
-                # TODO not needed
                 self.approver.finish_payment_request()
             else:
                 tx_ack_payment_req = await helpers.request_payment_req(

--- a/core/src/apps/bitcoin/sign_tx/decred.py
+++ b/core/src/apps/bitcoin/sign_tx/decred.py
@@ -27,6 +27,7 @@ OUTPUT_SCRIPT_NULL_SSTXCHANGE = (
 if TYPE_CHECKING:
     from typing import Sequence
 
+    from trezor.crypto import bip32
     from trezor.messages import (
         SignTx,
         TxInput,
@@ -175,8 +176,8 @@ class Decred(Bitcoin):
         self.write_tx_footer(self.serialized_tx, self.tx_info.tx)
         self.write_tx_footer(self.h_prefix, self.tx_info.tx)
 
-    async def process_internal_input(self, txi: TxInput) -> None:
-        await super().process_internal_input(txi)
+    async def process_internal_input(self, txi: TxInput, node: bip32.HDNode) -> None:
+        await super().process_internal_input(txi, node)
 
         # Decred serializes inputs early.
         self.write_tx_input(self.serialized_tx, txi, bytes())

--- a/core/src/apps/zcash/signer.py
+++ b/core/src/apps/zcash/signer.py
@@ -71,10 +71,10 @@ class Zcash(Bitcoinlike):
         await self.sign_nonsegwit_bip143_input(i_sign)
 
     def sign_bip143_input(self, i: int, txi: TxInput) -> tuple[bytes, bytes]:
-        signature_digest = self.tx_info.sig_hasher.hash_zip244(
-            txi, self.input_derive_script(txi)
-        )
         node = self.keychain.derive(txi.address_n)
+        signature_digest = self.tx_info.sig_hasher.hash_zip244(
+            txi, self.input_derive_script(txi, node)
+        )
         signature = ecdsa_sign(node, signature_digest)
         return node.public_key(), signature
 

--- a/core/src/trezor/messages.py
+++ b/core/src/trezor/messages.py
@@ -653,6 +653,7 @@ if TYPE_CHECKING:
         orig_index: "int | None"
         decred_staking_spend: "DecredStakingSpendType | None"
         script_pubkey: "bytes | None"
+        coinjoin_flags: "int | None"
 
         def __init__(
             self,
@@ -673,6 +674,7 @@ if TYPE_CHECKING:
             orig_index: "int | None" = None,
             decred_staking_spend: "DecredStakingSpendType | None" = None,
             script_pubkey: "bytes | None" = None,
+            coinjoin_flags: "int | None" = None,
         ) -> None:
             pass
 
@@ -977,8 +979,6 @@ if TYPE_CHECKING:
         plebs_dont_pay_threshold: "int"
         min_registrable_amount: "int"
         mask_public_key: "bytes"
-        signable_inputs: "bytes"
-        remixed_inputs: "bytes"
         signature: "bytes"
 
         def __init__(
@@ -988,8 +988,6 @@ if TYPE_CHECKING:
             plebs_dont_pay_threshold: "int",
             min_registrable_amount: "int",
             mask_public_key: "bytes",
-            signable_inputs: "bytes",
-            remixed_inputs: "bytes",
             signature: "bytes",
         ) -> None:
             pass

--- a/core/src/trezor/messages.py
+++ b/core/src/trezor/messages.py
@@ -594,6 +594,7 @@ if TYPE_CHECKING:
         branch_id: "int | None"
         amount_unit: "AmountUnit"
         decred_staking_ticket: "bool"
+        coinjoin_request: "CoinJoinRequest | None"
 
         def __init__(
             self,
@@ -609,6 +610,7 @@ if TYPE_CHECKING:
             branch_id: "int | None" = None,
             amount_unit: "AmountUnit | None" = None,
             decred_staking_ticket: "bool | None" = None,
+            coinjoin_request: "CoinJoinRequest | None" = None,
         ) -> None:
             pass
 
@@ -968,6 +970,32 @@ if TYPE_CHECKING:
 
         @classmethod
         def is_type_of(cls, msg: Any) -> TypeGuard["HDNodePathType"]:
+            return isinstance(msg, cls)
+
+    class CoinJoinRequest(protobuf.MessageType):
+        fee_rate: "int"
+        plebs_dont_pay_threshold: "int"
+        min_registrable_amount: "int"
+        mask_public_key: "bytes"
+        signable_inputs: "bytes"
+        remixed_inputs: "bytes"
+        signature: "bytes"
+
+        def __init__(
+            self,
+            *,
+            fee_rate: "int",
+            plebs_dont_pay_threshold: "int",
+            min_registrable_amount: "int",
+            mask_public_key: "bytes",
+            signable_inputs: "bytes",
+            remixed_inputs: "bytes",
+            signature: "bytes",
+        ) -> None:
+            pass
+
+        @classmethod
+        def is_type_of(cls, msg: Any) -> TypeGuard["CoinJoinRequest"]:
             return isinstance(msg, cls)
 
     class TxRequestDetailsType(protobuf.MessageType):

--- a/core/tests/test_apps.bitcoin.approver.py
+++ b/core/tests/test_apps.bitcoin.approver.py
@@ -2,13 +2,14 @@ from common import unittest, await_result, H_
 
 import storage.cache
 from trezor import wire
-from trezor.crypto.curve import secp256k1
+from trezor.crypto import bip32
+from trezor.crypto.curve import bip340, secp256k1
 from trezor.crypto.hashlib import sha256
 from trezor.messages import AuthorizeCoinJoin
 from trezor.messages import TxInput
 from trezor.messages import TxOutput
 from trezor.messages import SignTx
-from trezor.messages import TxAckPaymentRequest
+from trezor.messages import CoinJoinRequest
 from trezor.enums import InputScriptType, OutputScriptType
 from trezor.utils import HashWriter
 
@@ -24,29 +25,88 @@ class TestApprover(unittest.TestCase):
 
     def setUp(self):
         self.coin = coins.by_name('Bitcoin')
-        self.max_fee_rate_percent = 0.3
+        self.fee_rate_percent = 0.3
+        self.plebs_dont_pay_threshold=1000000
+        self.min_registrable_amount=5000
         self.coordinator_name = "www.example.com"
+
+        # Private key for signing and masking CoinJoin requests.
+        # m/0h for "all all ... all" seed.
+        self.private_key = b'?S\ti\x8b\xc5o{,\xab\x03\x194\xea\xa8[_:\xeb\xdf\xce\xef\xe50\xf17D\x98`\xb9dj'
+
+        self.node = bip32.HDNode(
+            depth=0,
+            fingerprint=0,
+            child_num=0,
+            chain_code=bytearray(32),
+            private_key=b"\x01" * 32,
+            curve_name="secp256k1",
+        )
+        self.tweaked_node_pubkey = b"\x02" + bip340.tweak_public_key(self.node.public_key()[1:])
 
         self.msg_auth = AuthorizeCoinJoin(
             coordinator=self.coordinator_name,
             max_rounds=10,
-            max_coordinator_fee_rate=int(self.max_fee_rate_percent * 10**8),
+            max_coordinator_fee_rate=int(self.fee_rate_percent * 10**8),
             max_fee_per_kvbyte=7000,
-            address_n=[H_(84), H_(0), H_(0)],
+            address_n=[H_(10025), H_(0), H_(0), H_(1)],
             coin_name=self.coin.coin_name,
-            script_type=InputScriptType.SPENDWITNESS,
+            script_type=InputScriptType.SPENDTAPROOT,
         )
         storage.cache.start_session()
 
+    def make_coinjon_request(self, inputs):
+        mask_public_key = secp256k1.publickey(self.private_key)
+        signable_inputs_int = 0
+        for i, txi in enumerate(inputs):
+            if txi.script_type == InputScriptType.SPENDTAPROOT:
+                shared_secret = secp256k1.multiply(self.private_key, self.tweaked_node_pubkey)[1:33]
+                h_mask = HashWriter(sha256())
+                writers.write_bytes_fixed(h_mask, shared_secret, 32)
+                writers.write_bytes_reversed(h_mask, txi.prev_hash, writers.TX_HASH_SIZE)
+                writers.write_uint32(h_mask, txi.prev_index)
+                mask = h_mask.get_digest()[0] & 1
+                signable_inputs_int |= (1 ^ mask) << i
+
+        # Convert bitfields from int to bytes.
+        bitfield_len = (len(inputs) + 7) // 8
+        signable_inputs = signable_inputs_int.to_bytes(bitfield_len, "little")
+        remixed_inputs = bytes(bitfield_len)
+
+        # Compute CoinJoin request signature.
+        h_request = HashWriter(sha256(b"CJR1"))
+        writers.write_bytes_prefixed(
+            h_request, self.coordinator_name.encode()
+        )
+        writers.write_uint32(h_request, int(self.fee_rate_percent * 10**8))
+        writers.write_uint64(h_request, self.plebs_dont_pay_threshold)
+        writers.write_uint64(h_request, self.min_registrable_amount)
+        writers.write_bytes_fixed(h_request, mask_public_key, 33)
+        writers.write_bytes_prefixed(h_request, signable_inputs)
+        writers.write_bytes_prefixed(h_request, remixed_inputs)
+        writers.write_bytes_fixed(h_request, sha256().digest(), 32)
+        writers.write_bytes_fixed(h_request, sha256().digest(), 32)
+        signature = secp256k1.sign(self.private_key, h_request.get_digest())
+
+        return CoinJoinRequest(
+            fee_rate=int(self.fee_rate_percent * 10**8),
+            plebs_dont_pay_threshold=self.plebs_dont_pay_threshold,
+            min_registrable_amount=self.min_registrable_amount,
+            mask_public_key=mask_public_key,
+            signable_inputs=signable_inputs,
+            remixed_inputs=remixed_inputs,
+            signature=signature,
+        )
+
     def test_coinjoin_lots_of_inputs(self):
-        denomination = 10000000
-        coordinator_fee = int(self.max_fee_rate_percent / 100 * denomination)
+        denomination = 10_000_000
+        coordinator_fee = int(self.fee_rate_percent / 100 * denomination)
         fees = coordinator_fee + 500
 
         # Other's inputs.
         inputs = [
             TxInput(
-                prev_hash=b"",
+                prev_hash=bytes(32),
                 prev_index=0,
                 amount=denomination,
                 script_pubkey=bytes(22),
@@ -59,11 +119,11 @@ class TestApprover(unittest.TestCase):
         # Our input.
         inputs.insert(30,
             TxInput(
-                prev_hash=b"",
+                prev_hash=bytes(32),
                 prev_index=0,
-                address_n=[H_(84), H_(0), H_(0), 0, 1],
+                address_n=[H_(10025), H_(0), H_(0), H_(1), 0, 1],
                 amount=denomination,
-                script_type=InputScriptType.SPENDWITNESS,
+                script_type=InputScriptType.SPENDTAPROOT,
                 sequence=0xffffffff,
             )
         )
@@ -83,7 +143,7 @@ class TestApprover(unittest.TestCase):
             40,
             TxOutput(
                 address="",
-                address_n=[H_(84), H_(0), H_(0), 0, 2],
+                address_n=[H_(10025), H_(0), H_(0), H_(1), 0, 2],
                 amount=denomination-fees,
                 script_type=OutputScriptType.PAYTOWITNESS,
                 payment_req_index=0,
@@ -100,39 +160,18 @@ class TestApprover(unittest.TestCase):
             )
         )
 
-        authorization = CoinJoinAuthorization(self.msg_auth)
         tx = SignTx(outputs_count=len(outputs), inputs_count=len(inputs), coin_name=self.coin.coin_name, lock_time=0)
-        approver = CoinJoinApprover(tx, self.coin, authorization)
+        authorization = CoinJoinAuthorization(self.msg_auth)
+        coinjoin_req = self.make_coinjon_request(inputs)
+        approver = CoinJoinApprover(tx, self.coin, authorization, coinjoin_req)
         signer = Bitcoin(tx, None, self.coin, approver)
-
-        # Compute payment request signature.
-        # Private key of m/0h for "all all ... all" seed.
-        private_key = b'?S\ti\x8b\xc5o{,\xab\x03\x194\xea\xa8[_:\xeb\xdf\xce\xef\xe50\xf17D\x98`\xb9dj'
-        h_pr = HashWriter(sha256())
-        writers.write_bytes_fixed(h_pr, b"SL\x00\x24", 4)
-        writers.write_bytes_prefixed(h_pr, b"")  # Empty nonce.
-        writers.write_bytes_prefixed(h_pr, self.coordinator_name.encode())
-        writers.write_compact_size(h_pr, 0)  # No memos.
-        writers.write_uint32(h_pr, self.coin.slip44)
-        h_outputs = HashWriter(sha256())
-        for txo in outputs:
-            writers.write_uint64(h_outputs, txo.amount)
-            writers.write_bytes_prefixed(h_outputs, txo.address.encode())
-        writers.write_bytes_fixed(h_pr, h_outputs.get_digest(), 32)
-        signature = secp256k1.sign(private_key, h_pr.get_digest())
-
-        tx_ack_payment_req = TxAckPaymentRequest(
-            recipient_name=self.coordinator_name,
-            signature=signature,
-        )
 
         for txi in inputs:
             if txi.script_type == InputScriptType.EXTERNAL:
                 approver.add_external_input(txi)
             else:
-                await_result(approver.add_internal_input(txi))
+                await_result(approver.add_internal_input(txi, self.node))
 
-        await_result(approver.add_payment_request(tx_ack_payment_req, None))
         for txo in outputs:
             if txo.address_n:
                 approver.add_change_output(txo, script_pubkey=bytes(22))
@@ -142,36 +181,38 @@ class TestApprover(unittest.TestCase):
         await_result(approver.approve_tx(TxInfo(signer, tx), []))
 
     def test_coinjoin_input_account_depth_mismatch(self):
-        authorization = CoinJoinAuthorization(self.msg_auth)
-        tx = SignTx(outputs_count=201, inputs_count=100, coin_name=self.coin.coin_name, lock_time=0)
-        approver = CoinJoinApprover(tx, self.coin, authorization)
-
         txi = TxInput(
-            prev_hash=b"",
+            prev_hash=bytes(32),
             prev_index=0,
-            address_n=[H_(49), H_(0), H_(0), 0],
+            address_n=[H_(10025), H_(0), H_(0), H_(1), 0],
             amount=10000000,
-            script_type=InputScriptType.SPENDWITNESS
+            script_type=InputScriptType.SPENDTAPROOT
         )
 
+        tx = SignTx(outputs_count=201, inputs_count=100, coin_name=self.coin.coin_name, lock_time=0)
+        authorization = CoinJoinAuthorization(self.msg_auth)
+        coinjoin_req = self.make_coinjon_request([txi])
+        approver = CoinJoinApprover(tx, self.coin, authorization, coinjoin_req)
+
         with self.assertRaises(wire.ProcessError):
-            await_result(approver.add_internal_input(txi))
+            await_result(approver.add_internal_input(txi, self.node))
 
     def test_coinjoin_input_account_path_mismatch(self):
-        authorization = CoinJoinAuthorization(self.msg_auth)
-        tx = SignTx(outputs_count=201, inputs_count=100, coin_name=self.coin.coin_name, lock_time=0)
-        approver = CoinJoinApprover(tx, self.coin, authorization)
-
         txi = TxInput(
-            prev_hash=b"",
+            prev_hash=bytes(32),
             prev_index=0,
-            address_n=[H_(49), H_(0), H_(0), 0, 2],
+            address_n=[H_(10025), H_(0), H_(1), H_(1), 0, 0],
             amount=10000000,
-            script_type=InputScriptType.SPENDWITNESS
+            script_type=InputScriptType.SPENDTAPROOT
         )
 
+        tx = SignTx(outputs_count=201, inputs_count=100, coin_name=self.coin.coin_name, lock_time=0)
+        authorization = CoinJoinAuthorization(self.msg_auth)
+        coinjoin_req = self.make_coinjon_request([txi])
+        approver = CoinJoinApprover(tx, self.coin, authorization, coinjoin_req)
+
         with self.assertRaises(wire.ProcessError):
-            await_result(approver.add_internal_input(txi))
+            await_result(approver.add_internal_input(txi, self.node))
 
 
 if __name__ == '__main__':

--- a/legacy/firmware/protob/messages-bitcoin.options
+++ b/legacy/firmware/protob/messages-bitcoin.options
@@ -11,6 +11,7 @@ Address.address                                             max_size:130
 Address.mac                                                 type:FT_IGNORE
 
 SignTx.coin_name                                            max_size:21
+SignTx.coinjoin_request                                     type:FT_IGNORE
 
 SignMessage.address_n                                       max_count:8
 SignMessage.message                                         max_size:1024
@@ -86,3 +87,4 @@ GetOwnershipProof                                           skip_message:true
 OwnershipProof                                              skip_message:true
 TxAckPaymentRequest                                         skip_message:true
 PaymentRequestMemo                                          skip_message:true
+CoinJoinRequest                                             skip_message:true

--- a/python/src/trezorlib/messages.py
+++ b/python/src/trezorlib/messages.py
@@ -1172,6 +1172,7 @@ class SignTx(protobuf.MessageType):
         10: protobuf.Field("branch_id", "uint32", repeated=False, required=False),
         11: protobuf.Field("amount_unit", "AmountUnit", repeated=False, required=False),
         12: protobuf.Field("decred_staking_ticket", "bool", repeated=False, required=False),
+        13: protobuf.Field("coinjoin_request", "CoinJoinRequest", repeated=False, required=False),
     }
 
     def __init__(
@@ -1189,6 +1190,7 @@ class SignTx(protobuf.MessageType):
         branch_id: Optional["int"] = None,
         amount_unit: Optional["AmountUnit"] = AmountUnit.BITCOIN,
         decred_staking_ticket: Optional["bool"] = False,
+        coinjoin_request: Optional["CoinJoinRequest"] = None,
     ) -> None:
         self.outputs_count = outputs_count
         self.inputs_count = inputs_count
@@ -1202,6 +1204,7 @@ class SignTx(protobuf.MessageType):
         self.branch_id = branch_id
         self.amount_unit = amount_unit
         self.decred_staking_ticket = decred_staking_ticket
+        self.coinjoin_request = coinjoin_request
 
 
 class TxRequest(protobuf.MessageType):
@@ -1628,6 +1631,38 @@ class HDNodePathType(protobuf.MessageType):
     ) -> None:
         self.address_n: Sequence["int"] = address_n if address_n is not None else []
         self.node = node
+
+
+class CoinJoinRequest(protobuf.MessageType):
+    MESSAGE_WIRE_TYPE = None
+    FIELDS = {
+        1: protobuf.Field("fee_rate", "uint32", repeated=False, required=True),
+        2: protobuf.Field("plebs_dont_pay_threshold", "uint64", repeated=False, required=True),
+        3: protobuf.Field("min_registrable_amount", "uint64", repeated=False, required=True),
+        4: protobuf.Field("mask_public_key", "bytes", repeated=False, required=True),
+        5: protobuf.Field("signable_inputs", "bytes", repeated=False, required=True),
+        6: protobuf.Field("remixed_inputs", "bytes", repeated=False, required=True),
+        7: protobuf.Field("signature", "bytes", repeated=False, required=True),
+    }
+
+    def __init__(
+        self,
+        *,
+        fee_rate: "int",
+        plebs_dont_pay_threshold: "int",
+        min_registrable_amount: "int",
+        mask_public_key: "bytes",
+        signable_inputs: "bytes",
+        remixed_inputs: "bytes",
+        signature: "bytes",
+    ) -> None:
+        self.fee_rate = fee_rate
+        self.plebs_dont_pay_threshold = plebs_dont_pay_threshold
+        self.min_registrable_amount = min_registrable_amount
+        self.mask_public_key = mask_public_key
+        self.signable_inputs = signable_inputs
+        self.remixed_inputs = remixed_inputs
+        self.signature = signature
 
 
 class TxRequestDetailsType(protobuf.MessageType):

--- a/python/src/trezorlib/messages.py
+++ b/python/src/trezorlib/messages.py
@@ -1260,6 +1260,7 @@ class TxInput(protobuf.MessageType):
         17: protobuf.Field("orig_index", "uint32", repeated=False, required=False),
         18: protobuf.Field("decred_staking_spend", "DecredStakingSpendType", repeated=False, required=False),
         19: protobuf.Field("script_pubkey", "bytes", repeated=False, required=False),
+        20: protobuf.Field("coinjoin_flags", "uint32", repeated=False, required=False),
     }
 
     def __init__(
@@ -1281,6 +1282,7 @@ class TxInput(protobuf.MessageType):
         orig_index: Optional["int"] = None,
         decred_staking_spend: Optional["DecredStakingSpendType"] = None,
         script_pubkey: Optional["bytes"] = None,
+        coinjoin_flags: Optional["int"] = None,
     ) -> None:
         self.address_n: Sequence["int"] = address_n if address_n is not None else []
         self.prev_hash = prev_hash
@@ -1298,6 +1300,7 @@ class TxInput(protobuf.MessageType):
         self.orig_index = orig_index
         self.decred_staking_spend = decred_staking_spend
         self.script_pubkey = script_pubkey
+        self.coinjoin_flags = coinjoin_flags
 
 
 class TxOutput(protobuf.MessageType):
@@ -1640,9 +1643,7 @@ class CoinJoinRequest(protobuf.MessageType):
         2: protobuf.Field("plebs_dont_pay_threshold", "uint64", repeated=False, required=True),
         3: protobuf.Field("min_registrable_amount", "uint64", repeated=False, required=True),
         4: protobuf.Field("mask_public_key", "bytes", repeated=False, required=True),
-        5: protobuf.Field("signable_inputs", "bytes", repeated=False, required=True),
-        6: protobuf.Field("remixed_inputs", "bytes", repeated=False, required=True),
-        7: protobuf.Field("signature", "bytes", repeated=False, required=True),
+        5: protobuf.Field("signature", "bytes", repeated=False, required=True),
     }
 
     def __init__(
@@ -1652,16 +1653,12 @@ class CoinJoinRequest(protobuf.MessageType):
         plebs_dont_pay_threshold: "int",
         min_registrable_amount: "int",
         mask_public_key: "bytes",
-        signable_inputs: "bytes",
-        remixed_inputs: "bytes",
         signature: "bytes",
     ) -> None:
         self.fee_rate = fee_rate
         self.plebs_dont_pay_threshold = plebs_dont_pay_threshold
         self.min_registrable_amount = min_registrable_amount
         self.mask_public_key = mask_public_key
-        self.signable_inputs = signable_inputs
-        self.remixed_inputs = remixed_inputs
         self.signature = signature
 
 


### PR DESCRIPTION
We decided to strengthen the security guarantees that will be provided by the signed affiliate data in CoinJoin. Due to these changes it is becoming a little more complicated to reuse the solution that is based on payment requests, although I think it could still be done if we wanted to. Payment requests are meant for individual outputs or sets of outputs in a transaction, whereas the affiliate data is now working with the entire set of inputs and outputs. I'd call this a "transaction request" and in this particular case a `CoinJoinRequest`. Since there is only one such transaction request per transaction it makes sense to put it into `SignTx`, which is what I did here.

In the future we might want to add other types of transaction requests. In that case we should be able to change
```
optional CoinJoinRequest coinjoin_request = 13;
```
to
```
oneof TransactionRequest {
    CoinJoinRequest coinjoin_request = 13;
    AbcRequest abc_request = 14;
}
```
and maintain binary compatibility, see https://developers.google.com/protocol-buffers/docs/proto3#oneof.

The `CoinJoinRequest` contains two bitfields `required bytes remixed_inputs` and `required bytes signable_inputs`. The size of each of these fields is proportional to the number of inputs, e.g. 300 inputs implies ceil(300/8) = 38 bytes. In terms of scalability it seems more correct to put this information into `TxInput` as two fields `optional bool coinjoin_remix` and `optional bool coinjoin_signable` or merged into a single field `optional int coinjoin_flags` with possible values 0, 1, 2, 3. These fields should then be present if and only if a `CoinJoinRequest` is present in `SignTx`. The current solution on the other hand puts all the information in one place.

I'd like to hear opinions about the protobuf design mainly from @matejcik:
1. Are we bloating the `SignTx` with too much information by adding this? We could devise a way to send the information in a separate message.
2. Which of these options is most preferable?
    - `CoinJoinRequest.remixed_inputs` and `CoinJoinRequest.signable_inputs`
    - `TxInput.coinjoin_remix` and `TxInput.coinjoin_signable`
    - `TxInput.coinjoin_flags`

I am still considering implementing this via the existing payment request mechanism, in which case we'd need to use one of the two latter options in Question 2 above and either hard-code `plebs_dont_pay_threshold` or send it in `SignTx`. Any opinions on the dedicated CoinJoinRequest mechanism proposed here vs. reusing the payment request mechanism?