### PR TITLE
Implement CoinJoin requests

### DIFF
--- a/common/protob/messages-bitcoin.proto
+++ b/common/protob/messages-bitcoin.proto
@@ -198,6 +198,18 @@ message SignTx {
     optional AmountUnit amount_unit = 11 [default=BITCOIN];    // show amounts in
     optional bool decred_staking_ticket = 12 [default=false];  // only for Decred, this is signing a ticket purchase
     optional bool serialize = 13 [default=true];               // serialize the full transaction, as opposed to only outputting the signatures
+    optional CoinJoinRequest coinjoin_request = 14;            // only for preauthorized CoinJoins
+
+    /**
+     * Signing request for a CoinJoin transaction.
+     */
+    message CoinJoinRequest {
+        required uint32 fee_rate = 1;                // coordination fee rate in units of 10^-8 percent
+        required uint64 no_fee_threshold = 2;        // PlebsDontPayThreshold in Wasabi, the input amount above which the fee rate applies
+        required uint64 min_registrable_amount = 3;  // minimum registrable output amount
+        required bytes mask_public_key = 4;          // ephemeral secp256k1 public key used for masking coinjoin_flags, 33 bytes in compressed form
+        required bytes signature = 5;                // the trusted party's signature of the CoinJoin request digest
+    }
 }
 
 /**
@@ -306,6 +318,7 @@ message TxAck {
             optional uint32 orig_index = 17;                                    // index of the input in the original transaction (used when creating a replacement transaction)
             optional DecredStakingSpendType decred_staking_spend = 18;          // if not None this holds the type of stake spend: revocation or stake generation
             optional bytes script_pubkey = 19;                                  // scriptPubKey of the previous output spent by this input, only set of EXTERNAL inputs
+            optional uint32 coinjoin_flags = 20 [default=0];                    // bit field of CoinJoin-specific flags
         }
         /**
         * Structure representing compiled transaction output
@@ -359,6 +372,7 @@ message TxInput {
     optional uint32 orig_index = 17;                                    // index of the input in the original transaction (used when creating a replacement transaction)
     optional DecredStakingSpendType decred_staking_spend = 18; 	        // if not None this holds the type of stake spend: revocation or stake generation
     optional bytes script_pubkey = 19;                                  // scriptPubKey of the previous output spent by this input, only set of EXTERNAL inputs
+    optional uint32 coinjoin_flags = 20 [default=0];                    // bit field of CoinJoin-specific flags
 }
 
 /** Data type for transaction output to be signed.
@@ -427,7 +441,7 @@ message TxAckPaymentRequest {
     option (unstable) = true;
 
     optional bytes nonce = 1;              // the nonce used in the signature computation
-    required string recipient_name = 2;    // merchant's name or coordinator's name in case of CoinJoin
+    required string recipient_name = 2;    // merchant's name
     repeated PaymentRequestMemo memos = 3; // any memos that were signed as part of the request
     optional uint64 amount = 4;            // the sum of the external output amounts requested, required for non-CoinJoin
     required bytes signature = 5;          // the trusted party's signature of the paymentRequestDigest

--- a/common/protob/messages-bitcoin.proto
+++ b/common/protob/messages-bitcoin.proto
@@ -204,7 +204,7 @@ message SignTx {
      * Signing request for a CoinJoin transaction.
      */
     message CoinJoinRequest {
-        required uint32 fee_rate = 1;                // coordination fee rate in units of 10^-8 percent
+        required uint32 fee_rate = 1;                // coordination fee rate in units of 10^-6 percent
         required uint64 no_fee_threshold = 2;        // PlebsDontPayThreshold in Wasabi, the input amount above which the fee rate applies
         required uint64 min_registrable_amount = 3;  // minimum registrable output amount
         required bytes mask_public_key = 4;          // ephemeral secp256k1 public key used for masking coinjoin_flags, 33 bytes in compressed form
@@ -615,7 +615,7 @@ message AuthorizeCoinJoin {
 
     required string coordinator = 1;                                    // coordinator identifier to approve as a prefix in commitment data (max. 36 ASCII characters)
     required uint64 max_rounds = 2;                                     // maximum number of rounds that Trezor is authorized to take part in
-    required uint32 max_coordinator_fee_rate = 3;                       // maximum coordination fee rate in units of 10^-8 percent
+    required uint32 max_coordinator_fee_rate = 3;                       // maximum coordination fee rate in units of 10^-6 percent
     required uint32 max_fee_per_kvbyte = 4;                             // maximum mining fee rate in units of satoshis per 1000 vbytes
     repeated uint32 address_n = 5;                                      // prefix of the BIP-32 path leading to the account (m / purpose' / coin_type' / account')
     optional string coin_name = 6 [default='Bitcoin'];                  // coin to use

--- a/core/.changelog.d/2577.added
+++ b/core/.changelog.d/2577.added
@@ -1,0 +1,1 @@
+Implement CoinJoin requests.

--- a/core/src/apps/bitcoin/authorization.py
+++ b/core/src/apps/bitcoin/authorization.py
@@ -19,7 +19,7 @@ if TYPE_CHECKING:
 
     from apps.common.coininfo import CoinInfo
 
-FEE_RATE_DECIMALS = const(8)
+FEE_RATE_DECIMALS = const(6)
 
 
 class CoinJoinAuthorization:

--- a/core/src/apps/bitcoin/sign_tx/approvers.py
+++ b/core/src/apps/bitcoin/sign_tx/approvers.py
@@ -481,9 +481,6 @@ class CoinJoinApprover(Approver):
         # The mining fee of the transaction as a whole.
         mining_fee = self.total_in - self.total_out
 
-        if mining_fee > max_fee_per_vbyte * self.weight.get_virtual_size():
-            raise wire.ProcessError("Mining fee over threshold")
-
         # The maximum mining fee that the user should be paying.
         our_max_mining_fee = max_fee_per_vbyte * self.our_weight.get_virtual_size()
 

--- a/core/src/apps/bitcoin/sign_tx/approvers.py
+++ b/core/src/apps/bitcoin/sign_tx/approvers.py
@@ -2,19 +2,26 @@ from micropython import const
 from typing import TYPE_CHECKING
 
 from trezor import wire
+from trezor.crypto.curve import bip340, secp256k1
+from trezor.crypto.hashlib import sha256
 from trezor.enums import OutputScriptType
 from trezor.ui.components.common.confirm import INFO
+from trezor.utils import HashWriter
 
 from apps.common import safety_checks
 
+from .. import writers
 from ..authorization import FEE_RATE_DECIMALS
 from ..common import input_is_external_unverified
 from ..keychain import validate_path_against_script_type
 from . import helpers, tx_weight
 from .payment_request import PaymentRequestVerifier
+from .sig_hasher import BitcoinSigHasher
 from .tx_info import OriginalTxInfo, TxInfo
 
 if TYPE_CHECKING:
+    from trezor.crypto import bip32
+
     from trezor.messages import SignTx
     from trezor.messages import TxInput
     from trezor.messages import TxOutput
@@ -58,20 +65,20 @@ class Approver:
         # the original, so the condition below is equivalent to external_in > orig_external_in.
         return self.external_in != self.orig_external_in
 
-    async def add_internal_input(self, txi: TxInput) -> None:
+    def _add_input(self, txi: TxInput) -> None:
         self.weight.add_input(txi)
         self.total_in += txi.amount
         if txi.orig_hash:
             self.orig_total_in += txi.amount
+
+    async def add_internal_input(self, txi: TxInput, node: bip32.HDNode) -> None:
+        self._add_input(txi)
 
     def check_internal_input(self, txi: TxInput) -> None:
         pass
 
     def add_external_input(self, txi: TxInput) -> None:
-        self.weight.add_input(txi)
-        self.total_in += txi.amount
-        if txi.orig_hash:
-            self.orig_total_in += txi.amount
+        self._add_input(txi)
 
         if input_is_external_unverified(txi):
             self.has_unverified_external_input = True
@@ -139,12 +146,12 @@ class BasicApprover(Approver):
         self.change_count = 0  # the number of change-outputs
         self.foreign_address_confirmed = False
 
-    async def add_internal_input(self, txi: TxInput) -> None:
+    async def add_internal_input(self, txi: TxInput, node: bip32.HDNode) -> None:
         if not validate_path_against_script_type(self.coin, txi):
             await helpers.confirm_foreign_address(txi.address_n)
             self.foreign_address_confirmed = True
 
-        await super().add_internal_input(txi)
+        await super().add_internal_input(txi, node)
 
     def check_internal_input(self, txi: TxInput) -> None:
         # Sanity check not critical for security.
@@ -328,30 +335,84 @@ class BasicApprover(Approver):
 
 
 class CoinJoinApprover(Approver):
-    # Minimum registrable output amount in a CoinJoin.
-    MIN_REGISTRABLE_OUTPUT_AMOUNT = 5000
+    # Minimum registrable output amount accepted by the CoinJoin coordinator.
+    # The CoinJoin request may specify an even lower amount.
+    MIN_REGISTRABLE_OUTPUT_AMOUNT = const(5000)
 
     # Largest possible weight of an output supported by Trezor (P2TR or P2WSH).
-    MAX_OUTPUT_WEIGHT = 4 * (8 + 1 + 1 + 1 + 32)
+    MAX_OUTPUT_WEIGHT = const(4 * (8 + 1 + 1 + 1 + 32))
+
+    # Masks for the signable and no_fee bits in coinjoin_flags.
+    COINJOIN_FLAGS_SIGNABLE = const(0x01)
+    COINJOIN_FLAGS_NO_FEE = const(0x02)
+
+    COINJOIN_REQ_PUBKEY = b""
+    if __debug__:
+        # secp256k1 public key of m/0h for "all all ... all" seed.
+        COINJOIN_REQ_PUBKEY_DEBUG = b"\x03\x0f\xdf^(\x9bZ\xefSb\x90\x95:\xe8\x1c\xe6\x0e\x84\x1f\xf9V\xf3f\xac\x12?\xa6\x9d\xb3\xc7\x9f!\xb0"
 
     def __init__(
-        self, tx: SignTx, coin: CoinInfo, authorization: CoinJoinAuthorization
+        self,
+        tx: SignTx,
+        coin: CoinInfo,
+        authorization: CoinJoinAuthorization,
     ) -> None:
         super().__init__(tx, coin)
-        self.authorization = authorization
 
-        if authorization.params.coin_name != tx.coin_name:
-            raise wire.DataError("Coin name does not match authorization.")
+        if not tx.coinjoin_request:
+            raise wire.DataError("Missing CoinJoin request.")
+
+        self.request = tx.coinjoin_request
+        self.authorization = authorization
+        self.coordination_fee_base = 0
+
+        # Begin hashing the CoinJoin request.
+        self.h_request = HashWriter(sha256(b"CJR1"))  # "CJR1" = CoinJoin Request v1.
+        writers.write_bytes_prefixed(
+            self.h_request, authorization.params.coordinator.encode()
+        )
+        writers.write_uint32(self.h_request, coin.slip44)
+        writers.write_uint32(self.h_request, self.request.fee_rate)
+        writers.write_uint64(self.h_request, self.request.no_fee_threshold)
+        writers.write_uint64(self.h_request, self.request.min_registrable_amount)
+        writers.write_bytes_fixed(self.h_request, self.request.mask_public_key, 33)
+        writers.write_compact_size(self.h_request, tx.inputs_count)
 
         # Upper bound on the user's contribution to the weight of the transaction.
         self.our_weight = tx_weight.TxWeightCalculator()
 
-    async def add_internal_input(self, txi: TxInput) -> None:
+    def _add_input(self, txi: TxInput) -> None:
+        super()._add_input(txi)
+        writers.write_uint8(self.h_request, txi.coinjoin_flags)
+
+    async def add_internal_input(self, txi: TxInput, node: bip32.HDNode) -> None:
         self.our_weight.add_input(txi)
         if not self.authorization.check_sign_tx_input(txi, self.coin):
             raise wire.ProcessError("Unauthorized path")
 
-        await super().add_internal_input(txi)
+        # Compute the masking bit for the signable bit in coinjoin flags.
+        internal_private_key = node.private_key()
+        output_private_key = bip340.tweak_secret_key(internal_private_key)
+        shared_secret = secp256k1.multiply(
+            output_private_key, self.request.mask_public_key
+        )
+        h_mask = HashWriter(sha256())
+        writers.write_bytes_fixed(h_mask, shared_secret[1:33], 32)
+        writers.write_bytes_reversed(h_mask, txi.prev_hash, writers.TX_HASH_SIZE)
+        writers.write_uint32(h_mask, txi.prev_index)
+        mask = h_mask.get_digest()[0] & 1
+
+        # Ensure that the input can be signed.
+        if bool(txi.coinjoin_flags & self.COINJOIN_FLAGS_SIGNABLE) ^ mask != 1:
+            raise wire.ProcessError("Unauthorized input")
+
+        # Add to coordination_fee_base, except for remixes and small inputs which are
+        # not charged a coordination fee.
+        no_fee = bool(txi.coinjoin_flags & self.COINJOIN_FLAGS_NO_FEE)
+        if txi.amount > self.request.no_fee_threshold and not no_fee:
+            self.coordination_fee_base += txi.amount
+
+        await super().add_internal_input(txi, node)
 
     def check_internal_input(self, txi: TxInput) -> None:
         # Sanity check not critical for security.
@@ -374,30 +435,48 @@ class CoinJoinApprover(Approver):
         super().add_change_output(txo, script_pubkey)
         self.our_weight.add_output(script_pubkey)
 
-    async def add_payment_request(
-        self, msg: TxAckPaymentRequest, keychain: Keychain
-    ) -> None:
-        await super().add_payment_request(msg, keychain)
-
-        if msg.recipient_name != self.authorization.params.coordinator:
-            raise wire.DataError("CoinJoin coordinator mismatch in payment request.")
-
-        if msg.memos:
-            raise wire.DataError("Memos not allowed in CoinJoin payment request.")
-
     async def approve_orig_txids(
         self, tx_info: TxInfo, orig_txs: list[OriginalTxInfo]
     ) -> None:
         pass
 
+    def _verify_coinjoin_request(self, tx_info: TxInfo):
+        if not isinstance(tx_info.sig_hasher, BitcoinSigHasher):
+            raise wire.ProcessError("Unexpected signature hasher.")
+
+        # Finish hashing the CoinJoin request.
+        writers.write_bytes_fixed(
+            self.h_request, tx_info.sig_hasher.h_prevouts.get_digest(), 32
+        )
+        writers.write_bytes_fixed(
+            self.h_request, tx_info.sig_hasher.h_outputs.get_digest(), 32
+        )
+
+        # Verify the CoinJoin request signature.
+        if __debug__:
+            if secp256k1.verify(
+                self.COINJOIN_REQ_PUBKEY_DEBUG,
+                self.request.signature,
+                self.h_request.get_digest(),
+            ):
+                return True
+
+        return secp256k1.verify(
+            self.COINJOIN_REQ_PUBKEY,
+            self.request.signature,
+            self.h_request.get_digest(),
+        )
+
     async def approve_tx(self, tx_info: TxInfo, orig_txs: list[OriginalTxInfo]) -> None:
         await super().approve_tx(tx_info, orig_txs)
 
+        if not self._verify_coinjoin_request(tx_info):
+            raise wire.DataError("Invalid signature in CoinJoin request.")
+
         max_fee_per_vbyte = self.authorization.params.max_fee_per_kvbyte / 1000
-        max_coordinator_fee_rate = (
-            self.authorization.params.max_coordinator_fee_rate
-            / pow(10, FEE_RATE_DECIMALS + 2)
-        )
+        coordination_fee_rate = min(
+            self.request.fee_rate, self.authorization.params.max_coordinator_fee_rate
+        ) / pow(10, FEE_RATE_DECIMALS + 2)
 
         # The mining fee of the transaction as a whole.
         mining_fee = self.total_in - self.total_out
@@ -408,10 +487,8 @@ class CoinJoinApprover(Approver):
         # The maximum mining fee that the user should be paying.
         our_max_mining_fee = max_fee_per_vbyte * self.our_weight.get_virtual_size()
 
-        # The maximum coordination fee for the user's inputs.
-        our_max_coordinator_fee = max_coordinator_fee_rate * (
-            self.total_in - self.external_in
-        )
+        # The coordination fee for the user's inputs.
+        our_coordination_fee = coordination_fee_rate * self.coordination_fee_base
 
         # Total fees that the user is paying.
         our_fees = self.total_in - self.external_in - self.change_out
@@ -427,12 +504,12 @@ class CoinJoinApprover(Approver):
         # would cost to register. Amounts below this value are left to the coordinator or miners
         # and effectively constitute an extra fee for the user.
         min_allowed_output_amount_plus_fee = (
-            self.MIN_REGISTRABLE_OUTPUT_AMOUNT
+            min(self.request.min_registrable_amount, self.MIN_REGISTRABLE_OUTPUT_AMOUNT)
             + max_fee_per_weight_unit * self.MAX_OUTPUT_WEIGHT
         )
 
         if our_fees > (
-            our_max_coordinator_fee
+            our_coordination_fee
             + our_max_mining_fee
             + min_allowed_output_amount_plus_fee
         ):
@@ -444,6 +521,5 @@ class CoinJoinApprover(Approver):
     def _add_output(self, txo: TxOutput, script_pubkey: bytes) -> None:
         super()._add_output(txo, script_pubkey)
 
-        # All CoinJoin outputs must be accompanied by a signed payment request.
-        if txo.payment_req_index is None:
-            raise wire.DataError("Missing payment request.")
+        if txo.payment_req_index:
+            raise wire.DataError("Unexpected payment request.")

--- a/core/src/apps/bitcoin/sign_tx/bitcoin.py
+++ b/core/src/apps/bitcoin/sign_tx/bitcoin.py
@@ -175,7 +175,7 @@ class Bitcoin:
                 if txi.witness or txi.script_sig:
                     self.presigned.add(i)
                     writers.write_tx_input_check(h_presigned_inputs_check, txi)
-                await self.process_external_input(txi, script_pubkey)
+                await self.process_external_input(txi)
             else:
                 node = self.keychain.derive(txi.address_n)
                 await self.process_internal_input(txi, node)
@@ -333,13 +333,15 @@ class Bitcoin:
 
         await self.approver.add_internal_input(txi)
 
-    async def process_external_input(self, txi: TxInput, script_pubkey: bytes) -> None:
+    async def process_external_input(self, txi: TxInput) -> None:
+        assert txi.script_pubkey is not None  # checked in sanitize_tx_input
+
         self.approver.add_external_input(txi)
 
         if txi.ownership_proof:
             if not verify_nonownership(
                 txi.ownership_proof,
-                script_pubkey,
+                txi.script_pubkey,
                 txi.commitment_data,
                 self.keychain,
                 self.coin,

--- a/core/src/apps/bitcoin/sign_tx/bitcoin.py
+++ b/core/src/apps/bitcoin/sign_tx/bitcoin.py
@@ -331,7 +331,7 @@ class Bitcoin:
         if txi.script_type not in common.INTERNAL_INPUT_SCRIPT_TYPES:
             raise wire.DataError("Wrong input script type")
 
-        await self.approver.add_internal_input(txi)
+        await self.approver.add_internal_input(txi, node)
 
     async def process_external_input(self, txi: TxInput) -> None:
         assert txi.script_pubkey is not None  # checked in sanitize_tx_input
@@ -499,7 +499,6 @@ class Bitcoin:
     ) -> None:
         if txo.payment_req_index != self.payment_req_index:
             if txo.payment_req_index is None:
-                # TODO not needed
                 self.approver.finish_payment_request()
             else:
                 tx_ack_payment_req = await helpers.request_payment_req(

--- a/core/src/apps/bitcoin/sign_tx/decred.py
+++ b/core/src/apps/bitcoin/sign_tx/decred.py
@@ -28,6 +28,7 @@ OUTPUT_SCRIPT_NULL_SSTXCHANGE = (
 if TYPE_CHECKING:
     from typing import Sequence
 
+    from trezor.crypto import bip32
     from trezor.messages import (
         SignTx,
         TxInput,
@@ -181,8 +182,8 @@ class Decred(Bitcoin):
         if self.serialize:
             self.write_tx_footer(self.serialized_tx, self.tx_info.tx)
 
-    async def process_internal_input(self, txi: TxInput) -> None:
-        await super().process_internal_input(txi)
+    async def process_internal_input(self, txi: TxInput, node: bip32.HDNode) -> None:
+        await super().process_internal_input(txi, node)
 
         # Decred serializes inputs early.
         if self.serialize:

--- a/core/src/apps/zcash/signer.py
+++ b/core/src/apps/zcash/signer.py
@@ -71,10 +71,10 @@ class Zcash(Bitcoinlike):
         await self.sign_nonsegwit_bip143_input(i_sign)
 
     def sign_bip143_input(self, i: int, txi: TxInput) -> tuple[bytes, bytes]:
-        signature_digest = self.tx_info.sig_hasher.hash_zip244(
-            txi, self.input_derive_script(txi)
-        )
         node = self.keychain.derive(txi.address_n)
+        signature_digest = self.tx_info.sig_hasher.hash_zip244(
+            txi, self.input_derive_script(txi, node)
+        )
         signature = ecdsa_sign(node, signature_digest)
         return node.public_key(), signature
 

--- a/core/src/trezor/messages.py
+++ b/core/src/trezor/messages.py
@@ -595,6 +595,7 @@ if TYPE_CHECKING:
         amount_unit: "AmountUnit"
         decred_staking_ticket: "bool"
         serialize: "bool"
+        coinjoin_request: "CoinJoinRequest | None"
 
         def __init__(
             self,
@@ -611,6 +612,7 @@ if TYPE_CHECKING:
             amount_unit: "AmountUnit | None" = None,
             decred_staking_ticket: "bool | None" = None,
             serialize: "bool | None" = None,
+            coinjoin_request: "CoinJoinRequest | None" = None,
         ) -> None:
             pass
 
@@ -653,6 +655,7 @@ if TYPE_CHECKING:
         orig_index: "int | None"
         decred_staking_spend: "DecredStakingSpendType | None"
         script_pubkey: "bytes | None"
+        coinjoin_flags: "int"
 
         def __init__(
             self,
@@ -673,6 +676,7 @@ if TYPE_CHECKING:
             orig_index: "int | None" = None,
             decred_staking_spend: "DecredStakingSpendType | None" = None,
             script_pubkey: "bytes | None" = None,
+            coinjoin_flags: "int | None" = None,
         ) -> None:
             pass
 
@@ -970,6 +974,28 @@ if TYPE_CHECKING:
 
         @classmethod
         def is_type_of(cls, msg: Any) -> TypeGuard["HDNodePathType"]:
+            return isinstance(msg, cls)
+
+    class CoinJoinRequest(protobuf.MessageType):
+        fee_rate: "int"
+        no_fee_threshold: "int"
+        min_registrable_amount: "int"
+        mask_public_key: "bytes"
+        signature: "bytes"
+
+        def __init__(
+            self,
+            *,
+            fee_rate: "int",
+            no_fee_threshold: "int",
+            min_registrable_amount: "int",
+            mask_public_key: "bytes",
+            signature: "bytes",
+        ) -> None:
+            pass
+
+        @classmethod
+        def is_type_of(cls, msg: Any) -> TypeGuard["CoinJoinRequest"]:
             return isinstance(msg, cls)
 
     class TxRequestDetailsType(protobuf.MessageType):

--- a/core/tests/test_apps.bitcoin.approver.py
+++ b/core/tests/test_apps.bitcoin.approver.py
@@ -2,13 +2,14 @@ from common import unittest, await_result, H_
 
 import storage.cache
 from trezor import wire
-from trezor.crypto.curve import secp256k1
+from trezor.crypto import bip32
+from trezor.crypto.curve import bip340, secp256k1
 from trezor.crypto.hashlib import sha256
 from trezor.messages import AuthorizeCoinJoin
 from trezor.messages import TxInput
 from trezor.messages import TxOutput
 from trezor.messages import SignTx
-from trezor.messages import TxAckPaymentRequest
+from trezor.messages import CoinJoinRequest
 from trezor.enums import InputScriptType, OutputScriptType
 from trezor.utils import HashWriter
 
@@ -24,29 +25,82 @@ class TestApprover(unittest.TestCase):
 
     def setUp(self):
         self.coin = coins.by_name('Bitcoin')
-        self.max_fee_rate_percent = 0.3
+        self.fee_rate_percent = 0.3
+        self.no_fee_threshold=1000000
+        self.min_registrable_amount=5000
         self.coordinator_name = "www.example.com"
+
+        # Private key for signing and masking CoinJoin requests.
+        # m/0h for "all all ... all" seed.
+        self.private_key = b'?S\ti\x8b\xc5o{,\xab\x03\x194\xea\xa8[_:\xeb\xdf\xce\xef\xe50\xf17D\x98`\xb9dj'
+
+        self.node = bip32.HDNode(
+            depth=0,
+            fingerprint=0,
+            child_num=0,
+            chain_code=bytearray(32),
+            private_key=b"\x01" * 32,
+            curve_name="secp256k1",
+        )
+        self.tweaked_node_pubkey = b"\x02" + bip340.tweak_public_key(self.node.public_key()[1:])
 
         self.msg_auth = AuthorizeCoinJoin(
             coordinator=self.coordinator_name,
             max_rounds=10,
-            max_coordinator_fee_rate=int(self.max_fee_rate_percent * 10**8),
+            max_coordinator_fee_rate=int(self.fee_rate_percent * 10**8),
             max_fee_per_kvbyte=7000,
-            address_n=[H_(84), H_(0), H_(0)],
+            address_n=[H_(10025), H_(0), H_(0), H_(1)],
             coin_name=self.coin.coin_name,
-            script_type=InputScriptType.SPENDWITNESS,
+            script_type=InputScriptType.SPENDTAPROOT,
         )
         storage.cache.start_session()
 
+    def make_coinjoin_request(self, inputs):
+        mask_public_key = secp256k1.publickey(self.private_key)
+        coinjoin_flags = bytearray()
+        for txi in inputs:
+            shared_secret = secp256k1.multiply(self.private_key, self.tweaked_node_pubkey)[1:33]
+            h_mask = HashWriter(sha256())
+            writers.write_bytes_fixed(h_mask, shared_secret, 32)
+            writers.write_bytes_reversed(h_mask, txi.prev_hash, writers.TX_HASH_SIZE)
+            writers.write_uint32(h_mask, txi.prev_index)
+            mask = h_mask.get_digest()[0] & 1
+            signable = txi.script_type == InputScriptType.SPENDTAPROOT
+            txi.coinjoin_flags = signable ^ mask
+            coinjoin_flags.append(txi.coinjoin_flags)
+
+        # Compute CoinJoin request signature.
+        h_request = HashWriter(sha256(b"CJR1"))
+        writers.write_bytes_prefixed(
+            h_request, self.coordinator_name.encode()
+        )
+        writers.write_uint32(h_request, self.coin.slip44)
+        writers.write_uint32(h_request, int(self.fee_rate_percent * 10**8))
+        writers.write_uint64(h_request, self.no_fee_threshold)
+        writers.write_uint64(h_request, self.min_registrable_amount)
+        writers.write_bytes_fixed(h_request, mask_public_key, 33)
+        writers.write_bytes_prefixed(h_request, coinjoin_flags)
+        writers.write_bytes_fixed(h_request, sha256().digest(), 32)
+        writers.write_bytes_fixed(h_request, sha256().digest(), 32)
+        signature = secp256k1.sign(self.private_key, h_request.get_digest())
+
+        return CoinJoinRequest(
+            fee_rate=int(self.fee_rate_percent * 10**8),
+            no_fee_threshold=self.no_fee_threshold,
+            min_registrable_amount=self.min_registrable_amount,
+            mask_public_key=mask_public_key,
+            signature=signature,
+        )
+
     def test_coinjoin_lots_of_inputs(self):
-        denomination = 10000000
-        coordinator_fee = int(self.max_fee_rate_percent / 100 * denomination)
+        denomination = 10_000_000
+        coordinator_fee = int(self.fee_rate_percent / 100 * denomination)
         fees = coordinator_fee + 500
 
         # Other's inputs.
         inputs = [
             TxInput(
-                prev_hash=b"",
+                prev_hash=bytes(32),
                 prev_index=0,
                 amount=denomination,
                 script_pubkey=bytes(22),
@@ -59,11 +113,11 @@ class TestApprover(unittest.TestCase):
         # Our input.
         inputs.insert(30,
             TxInput(
-                prev_hash=b"",
+                prev_hash=bytes(32),
                 prev_index=0,
-                address_n=[H_(84), H_(0), H_(0), 0, 1],
+                address_n=[H_(10025), H_(0), H_(0), H_(1), 0, 1],
                 amount=denomination,
-                script_type=InputScriptType.SPENDWITNESS,
+                script_type=InputScriptType.SPENDTAPROOT,
                 sequence=0xffffffff,
             )
         )
@@ -83,7 +137,7 @@ class TestApprover(unittest.TestCase):
             40,
             TxOutput(
                 address="",
-                address_n=[H_(84), H_(0), H_(0), 0, 2],
+                address_n=[H_(10025), H_(0), H_(0), H_(1), 0, 2],
                 amount=denomination-fees,
                 script_type=OutputScriptType.PAYTOWITNESS,
                 payment_req_index=0,
@@ -100,39 +154,18 @@ class TestApprover(unittest.TestCase):
             )
         )
 
+        coinjoin_req = self.make_coinjoin_request(inputs)
+        tx = SignTx(outputs_count=len(outputs), inputs_count=len(inputs), coin_name=self.coin.coin_name, lock_time=0, coinjoin_request=coinjoin_req)
         authorization = CoinJoinAuthorization(self.msg_auth)
-        tx = SignTx(outputs_count=len(outputs), inputs_count=len(inputs), coin_name=self.coin.coin_name, lock_time=0)
         approver = CoinJoinApprover(tx, self.coin, authorization)
         signer = Bitcoin(tx, None, self.coin, approver)
-
-        # Compute payment request signature.
-        # Private key of m/0h for "all all ... all" seed.
-        private_key = b'?S\ti\x8b\xc5o{,\xab\x03\x194\xea\xa8[_:\xeb\xdf\xce\xef\xe50\xf17D\x98`\xb9dj'
-        h_pr = HashWriter(sha256())
-        writers.write_bytes_fixed(h_pr, b"SL\x00\x24", 4)
-        writers.write_bytes_prefixed(h_pr, b"")  # Empty nonce.
-        writers.write_bytes_prefixed(h_pr, self.coordinator_name.encode())
-        writers.write_compact_size(h_pr, 0)  # No memos.
-        writers.write_uint32(h_pr, self.coin.slip44)
-        h_outputs = HashWriter(sha256())
-        for txo in outputs:
-            writers.write_uint64(h_outputs, txo.amount)
-            writers.write_bytes_prefixed(h_outputs, txo.address.encode())
-        writers.write_bytes_fixed(h_pr, h_outputs.get_digest(), 32)
-        signature = secp256k1.sign(private_key, h_pr.get_digest())
-
-        tx_ack_payment_req = TxAckPaymentRequest(
-            recipient_name=self.coordinator_name,
-            signature=signature,
-        )
 
         for txi in inputs:
             if txi.script_type == InputScriptType.EXTERNAL:
                 approver.add_external_input(txi)
             else:
-                await_result(approver.add_internal_input(txi))
+                await_result(approver.add_internal_input(txi, self.node))
 
-        await_result(approver.add_payment_request(tx_ack_payment_req, None))
         for txo in outputs:
             if txo.address_n:
                 approver.add_change_output(txo, script_pubkey=bytes(22))
@@ -142,36 +175,38 @@ class TestApprover(unittest.TestCase):
         await_result(approver.approve_tx(TxInfo(signer, tx), []))
 
     def test_coinjoin_input_account_depth_mismatch(self):
-        authorization = CoinJoinAuthorization(self.msg_auth)
-        tx = SignTx(outputs_count=201, inputs_count=100, coin_name=self.coin.coin_name, lock_time=0)
-        approver = CoinJoinApprover(tx, self.coin, authorization)
-
         txi = TxInput(
-            prev_hash=b"",
+            prev_hash=bytes(32),
             prev_index=0,
-            address_n=[H_(49), H_(0), H_(0), 0],
+            address_n=[H_(10025), H_(0), H_(0), H_(1), 0],
             amount=10000000,
-            script_type=InputScriptType.SPENDWITNESS
+            script_type=InputScriptType.SPENDTAPROOT
         )
 
+        coinjoin_req = self.make_coinjoin_request([txi])
+        tx = SignTx(outputs_count=201, inputs_count=100, coin_name=self.coin.coin_name, lock_time=0, coinjoin_request=coinjoin_req)
+        authorization = CoinJoinAuthorization(self.msg_auth)
+        approver = CoinJoinApprover(tx, self.coin, authorization)
+
         with self.assertRaises(wire.ProcessError):
-            await_result(approver.add_internal_input(txi))
+            await_result(approver.add_internal_input(txi, self.node))
 
     def test_coinjoin_input_account_path_mismatch(self):
-        authorization = CoinJoinAuthorization(self.msg_auth)
-        tx = SignTx(outputs_count=201, inputs_count=100, coin_name=self.coin.coin_name, lock_time=0)
-        approver = CoinJoinApprover(tx, self.coin, authorization)
-
         txi = TxInput(
-            prev_hash=b"",
+            prev_hash=bytes(32),
             prev_index=0,
-            address_n=[H_(49), H_(0), H_(0), 0, 2],
+            address_n=[H_(10025), H_(0), H_(1), H_(1), 0, 0],
             amount=10000000,
-            script_type=InputScriptType.SPENDWITNESS
+            script_type=InputScriptType.SPENDTAPROOT
         )
 
+        coinjoin_req = self.make_coinjoin_request([txi])
+        tx = SignTx(outputs_count=201, inputs_count=100, coin_name=self.coin.coin_name, lock_time=0, coinjoin_request=coinjoin_req)
+        authorization = CoinJoinAuthorization(self.msg_auth)
+        approver = CoinJoinApprover(tx, self.coin, authorization)
+
         with self.assertRaises(wire.ProcessError):
-            await_result(approver.add_internal_input(txi))
+            await_result(approver.add_internal_input(txi, self.node))
 
 
 if __name__ == '__main__':

--- a/legacy/firmware/protob/messages-bitcoin.options
+++ b/legacy/firmware/protob/messages-bitcoin.options
@@ -11,6 +11,7 @@ Address.address                                             max_size:130
 Address.mac                                                 type:FT_IGNORE
 
 SignTx.coin_name                                            max_size:21
+SignTx.coinjoin_request                                     type:FT_IGNORE
 
 SignMessage.address_n                                       max_count:8
 SignMessage.message                                         max_size:1024
@@ -86,3 +87,4 @@ GetOwnershipProof                                           skip_message:true
 OwnershipProof                                              skip_message:true
 TxAckPaymentRequest                                         skip_message:true
 PaymentRequestMemo                                          skip_message:true
+CoinJoinRequest                                             skip_message:true

--- a/python/src/trezorlib/messages.py
+++ b/python/src/trezorlib/messages.py
@@ -1173,6 +1173,7 @@ class SignTx(protobuf.MessageType):
         11: protobuf.Field("amount_unit", "AmountUnit", repeated=False, required=False),
         12: protobuf.Field("decred_staking_ticket", "bool", repeated=False, required=False),
         13: protobuf.Field("serialize", "bool", repeated=False, required=False),
+        14: protobuf.Field("coinjoin_request", "CoinJoinRequest", repeated=False, required=False),
     }
 
     def __init__(
@@ -1191,6 +1192,7 @@ class SignTx(protobuf.MessageType):
         amount_unit: Optional["AmountUnit"] = AmountUnit.BITCOIN,
         decred_staking_ticket: Optional["bool"] = False,
         serialize: Optional["bool"] = True,
+        coinjoin_request: Optional["CoinJoinRequest"] = None,
     ) -> None:
         self.outputs_count = outputs_count
         self.inputs_count = inputs_count
@@ -1205,6 +1207,7 @@ class SignTx(protobuf.MessageType):
         self.amount_unit = amount_unit
         self.decred_staking_ticket = decred_staking_ticket
         self.serialize = serialize
+        self.coinjoin_request = coinjoin_request
 
 
 class TxRequest(protobuf.MessageType):
@@ -1260,6 +1263,7 @@ class TxInput(protobuf.MessageType):
         17: protobuf.Field("orig_index", "uint32", repeated=False, required=False),
         18: protobuf.Field("decred_staking_spend", "DecredStakingSpendType", repeated=False, required=False),
         19: protobuf.Field("script_pubkey", "bytes", repeated=False, required=False),
+        20: protobuf.Field("coinjoin_flags", "uint32", repeated=False, required=False),
     }
 
     def __init__(
@@ -1281,6 +1285,7 @@ class TxInput(protobuf.MessageType):
         orig_index: Optional["int"] = None,
         decred_staking_spend: Optional["DecredStakingSpendType"] = None,
         script_pubkey: Optional["bytes"] = None,
+        coinjoin_flags: Optional["int"] = 0,
     ) -> None:
         self.address_n: Sequence["int"] = address_n if address_n is not None else []
         self.prev_hash = prev_hash
@@ -1298,6 +1303,7 @@ class TxInput(protobuf.MessageType):
         self.orig_index = orig_index
         self.decred_staking_spend = decred_staking_spend
         self.script_pubkey = script_pubkey
+        self.coinjoin_flags = coinjoin_flags
 
 
 class TxOutput(protobuf.MessageType):
@@ -1633,6 +1639,32 @@ class HDNodePathType(protobuf.MessageType):
         self.node = node
 
 
+class CoinJoinRequest(protobuf.MessageType):
+    MESSAGE_WIRE_TYPE = None
+    FIELDS = {
+        1: protobuf.Field("fee_rate", "uint32", repeated=False, required=True),
+        2: protobuf.Field("no_fee_threshold", "uint64", repeated=False, required=True),
+        3: protobuf.Field("min_registrable_amount", "uint64", repeated=False, required=True),
+        4: protobuf.Field("mask_public_key", "bytes", repeated=False, required=True),
+        5: protobuf.Field("signature", "bytes", repeated=False, required=True),
+    }
+
+    def __init__(
+        self,
+        *,
+        fee_rate: "int",
+        no_fee_threshold: "int",
+        min_registrable_amount: "int",
+        mask_public_key: "bytes",
+        signature: "bytes",
+    ) -> None:
+        self.fee_rate = fee_rate
+        self.no_fee_threshold = no_fee_threshold
+        self.min_registrable_amount = min_registrable_amount
+        self.mask_public_key = mask_public_key
+        self.signature = signature
+
+
 class TxRequestDetailsType(protobuf.MessageType):
     MESSAGE_WIRE_TYPE = None
     FIELDS = {
@@ -1748,6 +1780,7 @@ class TxInputType(protobuf.MessageType):
         17: protobuf.Field("orig_index", "uint32", repeated=False, required=False),
         18: protobuf.Field("decred_staking_spend", "DecredStakingSpendType", repeated=False, required=False),
         19: protobuf.Field("script_pubkey", "bytes", repeated=False, required=False),
+        20: protobuf.Field("coinjoin_flags", "uint32", repeated=False, required=False),
     }
 
     def __init__(
@@ -1769,6 +1802,7 @@ class TxInputType(protobuf.MessageType):
         orig_index: Optional["int"] = None,
         decred_staking_spend: Optional["DecredStakingSpendType"] = None,
         script_pubkey: Optional["bytes"] = None,
+        coinjoin_flags: Optional["int"] = 0,
     ) -> None:
         self.address_n: Sequence["int"] = address_n if address_n is not None else []
         self.prev_hash = prev_hash
@@ -1786,6 +1820,7 @@ class TxInputType(protobuf.MessageType):
         self.orig_index = orig_index
         self.decred_staking_spend = decred_staking_spend
         self.script_pubkey = script_pubkey
+        self.coinjoin_flags = coinjoin_flags
 
 
 class TxOutputBinType(protobuf.MessageType):

--- a/tests/device_tests/bitcoin/payment_req.py
+++ b/tests/device_tests/bitcoin/payment_req.py
@@ -113,7 +113,7 @@ def make_coinjoin_request(
     outputs,
     output_script_pubkeys,
     no_fee_indices,
-    fee_rate=50_000_000,  # 0.5 %
+    fee_rate=500_000,  # 0.5 %
     no_fee_threshold=1_000_000,
     min_registrable_amount=5_000,
 ):

--- a/tests/device_tests/bitcoin/test_authorize_coinjoin.py
+++ b/tests/device_tests/bitcoin/test_authorize_coinjoin.py
@@ -58,7 +58,7 @@ def test_sign_tx(client: Client):
             client,
             coordinator="www.example.com",
             max_rounds=2,
-            max_coordinator_fee_rate=50_000_000,  # 0.5 %
+            max_coordinator_fee_rate=500_000,  # 0.5 %
             max_fee_per_kvbyte=3500,
             n=parse_path("m/10025h/1h/0h/1h"),
             coin_name="Testnet",
@@ -268,7 +268,7 @@ def test_sign_tx_large(client: Client):
             client,
             coordinator="www.example.com",
             max_rounds=2,
-            max_coordinator_fee_rate=50_000_000,  # 0.5 %
+            max_coordinator_fee_rate=500_000,  # 0.5 %
             max_fee_per_kvbyte=3500,
             n=parse_path("m/10025h/1h/0h/1h"),
             coin_name="Testnet",
@@ -478,7 +478,7 @@ def test_wrong_coordinator(client: Client):
         client,
         coordinator="www.example.com",
         max_rounds=10,
-        max_coordinator_fee_rate=50_000_000,  # 0.5 %
+        max_coordinator_fee_rate=500_000,  # 0.5 %
         max_fee_per_kvbyte=3500,
         n=parse_path("m/10025h/1h/0h/1h"),
         coin_name="Testnet",
@@ -502,7 +502,7 @@ def test_wrong_account_type(client: Client):
         "client": client,
         "coordinator": "www.example.com",
         "max_rounds": 10,
-        "max_coordinator_fee_rate": 50_000_000,  # 0.5 %
+        "max_coordinator_fee_rate": 500_000,  # 0.5 %
         "max_fee_per_kvbyte": 3500,
         "coin_name": "Testnet",
     }
@@ -530,7 +530,7 @@ def test_cancel_authorization(client: Client):
         client,
         coordinator="www.example.com",
         max_rounds=10,
-        max_coordinator_fee_rate=50_000_000,  # 0.5 %
+        max_coordinator_fee_rate=500_000,  # 0.5 %
         max_fee_per_kvbyte=3500,
         n=parse_path("m/10025h/1h/0h/1h"),
         coin_name="Testnet",
@@ -693,7 +693,7 @@ def test_multisession_authorization(client: Client):
         client,
         coordinator="www.example1.com",
         max_rounds=10,
-        max_coordinator_fee_rate=50_000_000,  # 0.5 %
+        max_coordinator_fee_rate=500_000,  # 0.5 %
         max_fee_per_kvbyte=3500,
         n=parse_path("m/10025h/1h/0h/1h"),
         coin_name="Testnet",
@@ -709,7 +709,7 @@ def test_multisession_authorization(client: Client):
         client,
         coordinator="www.example2.com",
         max_rounds=10,
-        max_coordinator_fee_rate=50_000_000,  # 0.5 %
+        max_coordinator_fee_rate=500_000,  # 0.5 %
         max_fee_per_kvbyte=3500,
         n=parse_path("m/10025h/1h/0h/1h"),
         coin_name="Testnet",

--- a/tests/device_tests/test_msg_applysettings.py
+++ b/tests/device_tests/test_msg_applysettings.py
@@ -230,7 +230,7 @@ def test_experimental_features(client: Client):
             client,
             coordinator="www.example.com",
             max_rounds=10,
-            max_coordinator_fee_rate=50_000_000,  # 0.5 %
+            max_coordinator_fee_rate=500_000,  # 0.5 %
             max_fee_per_kvbyte=3500,
             n=parse_path("m/10025h/1h/0h/1h"),
             coin_name="Testnet",


### PR DESCRIPTION
We decided to strengthen the security guarantees that will be provided by the signed affiliate data in CoinJoin. Due to these changes it is becoming a little more complicated to reuse the solution that is based on payment requests, although technically it could still be done if we wanted to. Payment requests are meant for individual outputs or sets of outputs in a transaction, whereas the affiliate data is now working with the entire set of inputs and outputs. I'd call this a "transaction request" and in this particular case a `CoinJoinRequest`. Since there is only one such transaction request per transaction it makes sense to put it into `SignTx`, which is what I did here.

There is an optional commit d54758415ea8fabf995cd8c21db255f33b4797ac that I could add, which adds a fee tolerance of 200 sats on Mainnet. The rationale behind it is to prevent Trezor from declining to sign the transaction in case of some sort of rounding error in the fee computation. That would ruin the CoinJoin for all participants. But I think this shouldn't occur. Opinions?

@onvej-sl please review and feel free to comment on the CoinJoin request digest algorithm and the mask computation. It's implemented in three places actually (core, unit tests and device tests). `make_coinjoin_request()` in `tests/device_tests/bitcoin/payment_req.py` is pretty well legible.

@matejcik you might want to glance at the protobuf changes in 1de8f103cadfab5822593d810b845f9cc89bfc58, but I think it's in line with what we discussed IRL.