### PR TITLE
fix(core/rust): fix prompt rendering over warning in pin keyboard

### DIFF
--- a/core/embed/rust/src/ui/model_tt/component/keyboard/pin.rs
+++ b/core/embed/rust/src/ui/model_tt/component/keyboard/pin.rs
@@ -206,6 +206,8 @@ where
             // Hide warning, show major prompt.
             Event::Timer(token) if Some(token) == self.warning_timer => {
                 self.major_warning = None;
+                self.textbox_pad.clear();
+                self.minor_prompt.request_complete_repaint(ctx);
                 ctx.request_paint();
             }
             _ => {}


### PR DESCRIPTION
Fixes a bug introduced in https://github.com/trezor/trezor-firmware/pull/2567 , i missed that textbox needs clearing when warning timer expires