### PR TITLE
fix(python): add default value to protobuf.Field

### DIFF
--- a/common/protob/messages-nem.proto
+++ b/common/protob/messages-nem.proto
@@ -58,7 +58,7 @@ message NEMSignTx {
     message NEMTransfer {
         required string recipient = 1;              // Address of the recipient
         required uint64 amount = 2;                 // Amount of micro NEM that is transferred
-        optional bytes payload = 3 [default=""];    // Actual message data (unencrypted)
+        optional bytes payload = 3;                 // Actual message data (unencrypted)
         optional bytes public_key = 4;              // Public key of the recipient (for encrypted payloads)
         repeated NEMMosaic mosaics = 5;             // Attached mosaics
         /**

--- a/core/src/apps/nem/transfer/serialize.py
+++ b/core/src/apps/nem/transfer/serialize.py
@@ -93,7 +93,7 @@ def get_transfer_payload(
         encrypted_payload = _encrypt(node, transfer.public_key, transfer.payload)
         return encrypted_payload, True
     else:
-        return transfer.payload, False
+        return transfer.payload or b"", False
 
 
 def _encrypt(node: bip32.HDNode, public_key: bytes, payload: bytes) -> bytes:

--- a/core/src/trezor/messages.py
+++ b/core/src/trezor/messages.py
@@ -4722,7 +4722,7 @@ if TYPE_CHECKING:
     class NEMTransfer(protobuf.MessageType):
         recipient: "str"
         amount: "int"
-        payload: "bytes"
+        payload: "bytes | None"
         public_key: "bytes | None"
         mosaics: "list[NEMMosaic]"
 

--- a/python/src/trezorlib/_proto_messages.mako
+++ b/python/src/trezorlib/_proto_messages.mako
@@ -27,7 +27,11 @@ class ${message.name}(protobuf.MessageType):
 % if message.fields:
     FIELDS = {
 % for field in message.fields:
+% if not field.required:
+        ${field.number}: protobuf.Field("${field.name}", "${field.type_name}", repeated=${field.repeated}, required=${field.required}, default=${field.default_value_repr}),
+% else:
         ${field.number}: protobuf.Field("${field.name}", "${field.type_name}", repeated=${field.repeated}, required=${field.required}),
+% endif
 % endfor
     }
 

--- a/python/src/trezorlib/messages.py
+++ b/python/src/trezorlib/messages.py
@@ -559,8 +559,8 @@ class TezosBallotType(IntEnum):
 class BinanceGetAddress(protobuf.MessageType):
     MESSAGE_WIRE_TYPE = 700
     FIELDS = {
-        1: protobuf.Field("address_n", "uint32", repeated=True, required=False),
-        2: protobuf.Field("show_display", "bool", repeated=False, required=False),
+        1: protobuf.Field("address_n", "uint32", repeated=True, required=False, default=None),
+        2: protobuf.Field("show_display", "bool", repeated=False, required=False, default=None),
     }
 
     def __init__(
@@ -590,8 +590,8 @@ class BinanceAddress(protobuf.MessageType):
 class BinanceGetPublicKey(protobuf.MessageType):
     MESSAGE_WIRE_TYPE = 702
     FIELDS = {
-        1: protobuf.Field("address_n", "uint32", repeated=True, required=False),
-        2: protobuf.Field("show_display", "bool", repeated=False, required=False),
+        1: protobuf.Field("address_n", "uint32", repeated=True, required=False, default=None),
+        2: protobuf.Field("show_display", "bool", repeated=False, required=False, default=None),
     }
 
     def __init__(
@@ -621,11 +621,11 @@ class BinancePublicKey(protobuf.MessageType):
 class BinanceSignTx(protobuf.MessageType):
     MESSAGE_WIRE_TYPE = 704
     FIELDS = {
-        1: protobuf.Field("address_n", "uint32", repeated=True, required=False),
+        1: protobuf.Field("address_n", "uint32", repeated=True, required=False, default=None),
         2: protobuf.Field("msg_count", "uint32", repeated=False, required=True),
         3: protobuf.Field("account_number", "sint64", repeated=False, required=True),
-        4: protobuf.Field("chain_id", "string", repeated=False, required=False),
-        5: protobuf.Field("memo", "string", repeated=False, required=False),
+        4: protobuf.Field("chain_id", "string", repeated=False, required=False, default=None),
+        5: protobuf.Field("memo", "string", repeated=False, required=False, default=None),
         6: protobuf.Field("sequence", "sint64", repeated=False, required=True),
         7: protobuf.Field("source", "sint64", repeated=False, required=True),
     }
@@ -657,8 +657,8 @@ class BinanceTxRequest(protobuf.MessageType):
 class BinanceTransferMsg(protobuf.MessageType):
     MESSAGE_WIRE_TYPE = 706
     FIELDS = {
-        1: protobuf.Field("inputs", "BinanceInputOutput", repeated=True, required=False),
-        2: protobuf.Field("outputs", "BinanceInputOutput", repeated=True, required=False),
+        1: protobuf.Field("inputs", "BinanceInputOutput", repeated=True, required=False, default=None),
+        2: protobuf.Field("outputs", "BinanceInputOutput", repeated=True, required=False, default=None),
     }
 
     def __init__(
@@ -674,13 +674,13 @@ class BinanceTransferMsg(protobuf.MessageType):
 class BinanceOrderMsg(protobuf.MessageType):
     MESSAGE_WIRE_TYPE = 707
     FIELDS = {
-        1: protobuf.Field("id", "string", repeated=False, required=False),
+        1: protobuf.Field("id", "string", repeated=False, required=False, default=None),
         2: protobuf.Field("ordertype", "BinanceOrderType", repeated=False, required=True),
         3: protobuf.Field("price", "sint64", repeated=False, required=True),
         4: protobuf.Field("quantity", "sint64", repeated=False, required=True),
-        5: protobuf.Field("sender", "string", repeated=False, required=False),
+        5: protobuf.Field("sender", "string", repeated=False, required=False, default=None),
         6: protobuf.Field("side", "BinanceOrderSide", repeated=False, required=True),
-        7: protobuf.Field("symbol", "string", repeated=False, required=False),
+        7: protobuf.Field("symbol", "string", repeated=False, required=False, default=None),
         8: protobuf.Field("timeinforce", "BinanceTimeInForce", repeated=False, required=True),
     }
 
@@ -709,9 +709,9 @@ class BinanceOrderMsg(protobuf.MessageType):
 class BinanceCancelMsg(protobuf.MessageType):
     MESSAGE_WIRE_TYPE = 708
     FIELDS = {
-        1: protobuf.Field("refid", "string", repeated=False, required=False),
-        2: protobuf.Field("sender", "string", repeated=False, required=False),
-        3: protobuf.Field("symbol", "string", repeated=False, required=False),
+        1: protobuf.Field("refid", "string", repeated=False, required=False, default=None),
+        2: protobuf.Field("sender", "string", repeated=False, required=False, default=None),
+        3: protobuf.Field("symbol", "string", repeated=False, required=False, default=None),
     }
 
     def __init__(
@@ -747,7 +747,7 @@ class BinanceInputOutput(protobuf.MessageType):
     MESSAGE_WIRE_TYPE = None
     FIELDS = {
         1: protobuf.Field("address", "string", repeated=False, required=True),
-        2: protobuf.Field("coins", "BinanceCoin", repeated=True, required=False),
+        2: protobuf.Field("coins", "BinanceCoin", repeated=True, required=False, default=None),
     }
 
     def __init__(
@@ -780,7 +780,7 @@ class BinanceCoin(protobuf.MessageType):
 class Success(protobuf.MessageType):
     MESSAGE_WIRE_TYPE = 2
     FIELDS = {
-        1: protobuf.Field("message", "string", repeated=False, required=False),
+        1: protobuf.Field("message", "string", repeated=False, required=False, default=''),
     }
 
     def __init__(
@@ -794,8 +794,8 @@ class Success(protobuf.MessageType):
 class Failure(protobuf.MessageType):
     MESSAGE_WIRE_TYPE = 3
     FIELDS = {
-        1: protobuf.Field("code", "FailureType", repeated=False, required=False),
-        2: protobuf.Field("message", "string", repeated=False, required=False),
+        1: protobuf.Field("code", "FailureType", repeated=False, required=False, default=None),
+        2: protobuf.Field("message", "string", repeated=False, required=False, default=None),
     }
 
     def __init__(
@@ -811,8 +811,8 @@ class Failure(protobuf.MessageType):
 class ButtonRequest(protobuf.MessageType):
     MESSAGE_WIRE_TYPE = 26
     FIELDS = {
-        1: protobuf.Field("code", "ButtonRequestType", repeated=False, required=False),
-        2: protobuf.Field("pages", "uint32", repeated=False, required=False),
+        1: protobuf.Field("code", "ButtonRequestType", repeated=False, required=False, default=None),
+        2: protobuf.Field("pages", "uint32", repeated=False, required=False, default=None),
     }
 
     def __init__(
@@ -832,7 +832,7 @@ class ButtonAck(protobuf.MessageType):
 class PinMatrixRequest(protobuf.MessageType):
     MESSAGE_WIRE_TYPE = 18
     FIELDS = {
-        1: protobuf.Field("type", "PinMatrixRequestType", repeated=False, required=False),
+        1: protobuf.Field("type", "PinMatrixRequestType", repeated=False, required=False, default=None),
     }
 
     def __init__(
@@ -860,7 +860,7 @@ class PinMatrixAck(protobuf.MessageType):
 class PassphraseRequest(protobuf.MessageType):
     MESSAGE_WIRE_TYPE = 41
     FIELDS = {
-        1: protobuf.Field("_on_device", "bool", repeated=False, required=False),
+        1: protobuf.Field("_on_device", "bool", repeated=False, required=False, default=None),
     }
 
     def __init__(
@@ -874,9 +874,9 @@ class PassphraseRequest(protobuf.MessageType):
 class PassphraseAck(protobuf.MessageType):
     MESSAGE_WIRE_TYPE = 42
     FIELDS = {
-        1: protobuf.Field("passphrase", "string", repeated=False, required=False),
-        2: protobuf.Field("_state", "bytes", repeated=False, required=False),
-        3: protobuf.Field("on_device", "bool", repeated=False, required=False),
+        1: protobuf.Field("passphrase", "string", repeated=False, required=False, default=None),
+        2: protobuf.Field("_state", "bytes", repeated=False, required=False, default=None),
+        3: protobuf.Field("on_device", "bool", repeated=False, required=False, default=None),
     }
 
     def __init__(
@@ -894,7 +894,7 @@ class PassphraseAck(protobuf.MessageType):
 class Deprecated_PassphraseStateRequest(protobuf.MessageType):
     MESSAGE_WIRE_TYPE = 77
     FIELDS = {
-        1: protobuf.Field("state", "bytes", repeated=False, required=False),
+        1: protobuf.Field("state", "bytes", repeated=False, required=False, default=None),
     }
 
     def __init__(
@@ -916,7 +916,7 @@ class HDNodeType(protobuf.MessageType):
         2: protobuf.Field("fingerprint", "uint32", repeated=False, required=True),
         3: protobuf.Field("child_num", "uint32", repeated=False, required=True),
         4: protobuf.Field("chain_code", "bytes", repeated=False, required=True),
-        5: protobuf.Field("private_key", "bytes", repeated=False, required=False),
+        5: protobuf.Field("private_key", "bytes", repeated=False, required=False, default=None),
         6: protobuf.Field("public_key", "bytes", repeated=False, required=True),
     }
 
@@ -941,11 +941,11 @@ class HDNodeType(protobuf.MessageType):
 class MultisigRedeemScriptType(protobuf.MessageType):
     MESSAGE_WIRE_TYPE = None
     FIELDS = {
-        1: protobuf.Field("pubkeys", "HDNodePathType", repeated=True, required=False),
-        2: protobuf.Field("signatures", "bytes", repeated=True, required=False),
+        1: protobuf.Field("pubkeys", "HDNodePathType", repeated=True, required=False, default=None),
+        2: protobuf.Field("signatures", "bytes", repeated=True, required=False, default=None),
         3: protobuf.Field("m", "uint32", repeated=False, required=True),
-        4: protobuf.Field("nodes", "HDNodeType", repeated=True, required=False),
-        5: protobuf.Field("address_n", "uint32", repeated=True, required=False),
+        4: protobuf.Field("nodes", "HDNodeType", repeated=True, required=False, default=None),
+        5: protobuf.Field("address_n", "uint32", repeated=True, required=False, default=None),
     }
 
     def __init__(
@@ -967,12 +967,12 @@ class MultisigRedeemScriptType(protobuf.MessageType):
 class GetPublicKey(protobuf.MessageType):
     MESSAGE_WIRE_TYPE = 11
     FIELDS = {
-        1: protobuf.Field("address_n", "uint32", repeated=True, required=False),
-        2: protobuf.Field("ecdsa_curve_name", "string", repeated=False, required=False),
-        3: protobuf.Field("show_display", "bool", repeated=False, required=False),
-        4: protobuf.Field("coin_name", "string", repeated=False, required=False),
-        5: protobuf.Field("script_type", "InputScriptType", repeated=False, required=False),
-        6: protobuf.Field("ignore_xpub_magic", "bool", repeated=False, required=False),
+        1: protobuf.Field("address_n", "uint32", repeated=True, required=False, default=None),
+        2: protobuf.Field("ecdsa_curve_name", "string", repeated=False, required=False, default=None),
+        3: protobuf.Field("show_display", "bool", repeated=False, required=False, default=None),
+        4: protobuf.Field("coin_name", "string", repeated=False, required=False, default='Bitcoin'),
+        5: protobuf.Field("script_type", "InputScriptType", repeated=False, required=False, default=InputScriptType.SPENDADDRESS),
+        6: protobuf.Field("ignore_xpub_magic", "bool", repeated=False, required=False, default=None),
     }
 
     def __init__(
@@ -998,7 +998,7 @@ class PublicKey(protobuf.MessageType):
     FIELDS = {
         1: protobuf.Field("node", "HDNodeType", repeated=False, required=True),
         2: protobuf.Field("xpub", "string", repeated=False, required=True),
-        3: protobuf.Field("root_fingerprint", "uint32", repeated=False, required=False),
+        3: protobuf.Field("root_fingerprint", "uint32", repeated=False, required=False, default=None),
     }
 
     def __init__(
@@ -1016,12 +1016,12 @@ class PublicKey(protobuf.MessageType):
 class GetAddress(protobuf.MessageType):
     MESSAGE_WIRE_TYPE = 29
     FIELDS = {
-        1: protobuf.Field("address_n", "uint32", repeated=True, required=False),
-        2: protobuf.Field("coin_name", "string", repeated=False, required=False),
-        3: protobuf.Field("show_display", "bool", repeated=False, required=False),
-        4: protobuf.Field("multisig", "MultisigRedeemScriptType", repeated=False, required=False),
-        5: protobuf.Field("script_type", "InputScriptType", repeated=False, required=False),
-        6: protobuf.Field("ignore_xpub_magic", "bool", repeated=False, required=False),
+        1: protobuf.Field("address_n", "uint32", repeated=True, required=False, default=None),
+        2: protobuf.Field("coin_name", "string", repeated=False, required=False, default='Bitcoin'),
+        3: protobuf.Field("show_display", "bool", repeated=False, required=False, default=None),
+        4: protobuf.Field("multisig", "MultisigRedeemScriptType", repeated=False, required=False, default=None),
+        5: protobuf.Field("script_type", "InputScriptType", repeated=False, required=False, default=InputScriptType.SPENDADDRESS),
+        6: protobuf.Field("ignore_xpub_magic", "bool", repeated=False, required=False, default=None),
     }
 
     def __init__(
@@ -1046,7 +1046,7 @@ class Address(protobuf.MessageType):
     MESSAGE_WIRE_TYPE = 30
     FIELDS = {
         1: protobuf.Field("address", "string", repeated=False, required=True),
-        2: protobuf.Field("mac", "bytes", repeated=False, required=False),
+        2: protobuf.Field("mac", "bytes", repeated=False, required=False, default=None),
     }
 
     def __init__(
@@ -1062,10 +1062,10 @@ class Address(protobuf.MessageType):
 class GetOwnershipId(protobuf.MessageType):
     MESSAGE_WIRE_TYPE = 43
     FIELDS = {
-        1: protobuf.Field("address_n", "uint32", repeated=True, required=False),
-        2: protobuf.Field("coin_name", "string", repeated=False, required=False),
-        3: protobuf.Field("multisig", "MultisigRedeemScriptType", repeated=False, required=False),
-        4: protobuf.Field("script_type", "InputScriptType", repeated=False, required=False),
+        1: protobuf.Field("address_n", "uint32", repeated=True, required=False, default=None),
+        2: protobuf.Field("coin_name", "string", repeated=False, required=False, default='Bitcoin'),
+        3: protobuf.Field("multisig", "MultisigRedeemScriptType", repeated=False, required=False, default=None),
+        4: protobuf.Field("script_type", "InputScriptType", repeated=False, required=False, default=InputScriptType.SPENDADDRESS),
     }
 
     def __init__(
@@ -1099,11 +1099,11 @@ class OwnershipId(protobuf.MessageType):
 class SignMessage(protobuf.MessageType):
     MESSAGE_WIRE_TYPE = 38
     FIELDS = {
-        1: protobuf.Field("address_n", "uint32", repeated=True, required=False),
+        1: protobuf.Field("address_n", "uint32", repeated=True, required=False, default=None),
         2: protobuf.Field("message", "bytes", repeated=False, required=True),
-        3: protobuf.Field("coin_name", "string", repeated=False, required=False),
-        4: protobuf.Field("script_type", "InputScriptType", repeated=False, required=False),
-        5: protobuf.Field("no_script_type", "bool", repeated=False, required=False),
+        3: protobuf.Field("coin_name", "string", repeated=False, required=False, default='Bitcoin'),
+        4: protobuf.Field("script_type", "InputScriptType", repeated=False, required=False, default=InputScriptType.SPENDADDRESS),
+        5: protobuf.Field("no_script_type", "bool", repeated=False, required=False, default=None),
     }
 
     def __init__(
@@ -1145,7 +1145,7 @@ class VerifyMessage(protobuf.MessageType):
         1: protobuf.Field("address", "string", repeated=False, required=True),
         2: protobuf.Field("signature", "bytes", repeated=False, required=True),
         3: protobuf.Field("message", "bytes", repeated=False, required=True),
-        4: protobuf.Field("coin_name", "string", repeated=False, required=False),
+        4: protobuf.Field("coin_name", "string", repeated=False, required=False, default='Bitcoin'),
     }
 
     def __init__(
@@ -1167,18 +1167,18 @@ class SignTx(protobuf.MessageType):
     FIELDS = {
         1: protobuf.Field("outputs_count", "uint32", repeated=False, required=True),
         2: protobuf.Field("inputs_count", "uint32", repeated=False, required=True),
-        3: protobuf.Field("coin_name", "string", repeated=False, required=False),
-        4: protobuf.Field("version", "uint32", repeated=False, required=False),
-        5: protobuf.Field("lock_time", "uint32", repeated=False, required=False),
-        6: protobuf.Field("expiry", "uint32", repeated=False, required=False),
-        7: protobuf.Field("overwintered", "bool", repeated=False, required=False),
-        8: protobuf.Field("version_group_id", "uint32", repeated=False, required=False),
-        9: protobuf.Field("timestamp", "uint32", repeated=False, required=False),
-        10: protobuf.Field("branch_id", "uint32", repeated=False, required=False),
-        11: protobuf.Field("amount_unit", "AmountUnit", repeated=False, required=False),
-        12: protobuf.Field("decred_staking_ticket", "bool", repeated=False, required=False),
-        13: protobuf.Field("serialize", "bool", repeated=False, required=False),
-        14: protobuf.Field("coinjoin_request", "CoinJoinRequest", repeated=False, required=False),
+        3: protobuf.Field("coin_name", "string", repeated=False, required=False, default='Bitcoin'),
+        4: protobuf.Field("version", "uint32", repeated=False, required=False, default=1),
+        5: protobuf.Field("lock_time", "uint32", repeated=False, required=False, default=0),
+        6: protobuf.Field("expiry", "uint32", repeated=False, required=False, default=None),
+        7: protobuf.Field("overwintered", "bool", repeated=False, required=False, default=None),
+        8: protobuf.Field("version_group_id", "uint32", repeated=False, required=False, default=None),
+        9: protobuf.Field("timestamp", "uint32", repeated=False, required=False, default=None),
+        10: protobuf.Field("branch_id", "uint32", repeated=False, required=False, default=None),
+        11: protobuf.Field("amount_unit", "AmountUnit", repeated=False, required=False, default=AmountUnit.BITCOIN),
+        12: protobuf.Field("decred_staking_ticket", "bool", repeated=False, required=False, default=False),
+        13: protobuf.Field("serialize", "bool", repeated=False, required=False, default=True),
+        14: protobuf.Field("coinjoin_request", "CoinJoinRequest", repeated=False, required=False, default=None),
     }
 
     def __init__(
@@ -1218,9 +1218,9 @@ class SignTx(protobuf.MessageType):
 class TxRequest(protobuf.MessageType):
     MESSAGE_WIRE_TYPE = 21
     FIELDS = {
-        1: protobuf.Field("request_type", "RequestType", repeated=False, required=False),
-        2: protobuf.Field("details", "TxRequestDetailsType", repeated=False, required=False),
-        3: protobuf.Field("serialized", "TxRequestSerializedType", repeated=False, required=False),
+        1: protobuf.Field("request_type", "RequestType", repeated=False, required=False, default=None),
+        2: protobuf.Field("details", "TxRequestDetailsType", repeated=False, required=False, default=None),
+        3: protobuf.Field("serialized", "TxRequestSerializedType", repeated=False, required=False, default=None),
     }
 
     def __init__(
@@ -1238,7 +1238,7 @@ class TxRequest(protobuf.MessageType):
 class TxAck(protobuf.MessageType):
     MESSAGE_WIRE_TYPE = 22
     FIELDS = {
-        1: protobuf.Field("tx", "TransactionType", repeated=False, required=False),
+        1: protobuf.Field("tx", "TransactionType", repeated=False, required=False, default=None),
     }
 
     def __init__(
@@ -1252,23 +1252,23 @@ class TxAck(protobuf.MessageType):
 class TxInput(protobuf.MessageType):
     MESSAGE_WIRE_TYPE = None
     FIELDS = {
-        1: protobuf.Field("address_n", "uint32", repeated=True, required=False),
+        1: protobuf.Field("address_n", "uint32", repeated=True, required=False, default=None),
         2: protobuf.Field("prev_hash", "bytes", repeated=False, required=True),
         3: protobuf.Field("prev_index", "uint32", repeated=False, required=True),
-        4: protobuf.Field("script_sig", "bytes", repeated=False, required=False),
-        5: protobuf.Field("sequence", "uint32", repeated=False, required=False),
-        6: protobuf.Field("script_type", "InputScriptType", repeated=False, required=False),
-        7: protobuf.Field("multisig", "MultisigRedeemScriptType", repeated=False, required=False),
+        4: protobuf.Field("script_sig", "bytes", repeated=False, required=False, default=None),
+        5: protobuf.Field("sequence", "uint32", repeated=False, required=False, default=4294967295),
+        6: protobuf.Field("script_type", "InputScriptType", repeated=False, required=False, default=InputScriptType.SPENDADDRESS),
+        7: protobuf.Field("multisig", "MultisigRedeemScriptType", repeated=False, required=False, default=None),
         8: protobuf.Field("amount", "uint64", repeated=False, required=True),
-        9: protobuf.Field("decred_tree", "uint32", repeated=False, required=False),
-        13: protobuf.Field("witness", "bytes", repeated=False, required=False),
-        14: protobuf.Field("ownership_proof", "bytes", repeated=False, required=False),
-        15: protobuf.Field("commitment_data", "bytes", repeated=False, required=False),
-        16: protobuf.Field("orig_hash", "bytes", repeated=False, required=False),
-        17: protobuf.Field("orig_index", "uint32", repeated=False, required=False),
-        18: protobuf.Field("decred_staking_spend", "DecredStakingSpendType", repeated=False, required=False),
-        19: protobuf.Field("script_pubkey", "bytes", repeated=False, required=False),
-        20: protobuf.Field("coinjoin_flags", "uint32", repeated=False, required=False),
+        9: protobuf.Field("decred_tree", "uint32", repeated=False, required=False, default=None),
+        13: protobuf.Field("witness", "bytes", repeated=False, required=False, default=None),
+        14: protobuf.Field("ownership_proof", "bytes", repeated=False, required=False, default=None),
+        15: protobuf.Field("commitment_data", "bytes", repeated=False, required=False, default=None),
+        16: protobuf.Field("orig_hash", "bytes", repeated=False, required=False, default=None),
+        17: protobuf.Field("orig_index", "uint32", repeated=False, required=False, default=None),
+        18: protobuf.Field("decred_staking_spend", "DecredStakingSpendType", repeated=False, required=False, default=None),
+        19: protobuf.Field("script_pubkey", "bytes", repeated=False, required=False, default=None),
+        20: protobuf.Field("coinjoin_flags", "uint32", repeated=False, required=False, default=0),
     }
 
     def __init__(
@@ -1314,15 +1314,15 @@ class TxInput(protobuf.MessageType):
 class TxOutput(protobuf.MessageType):
     MESSAGE_WIRE_TYPE = None
     FIELDS = {
-        1: protobuf.Field("address", "string", repeated=False, required=False),
-        2: protobuf.Field("address_n", "uint32", repeated=True, required=False),
+        1: protobuf.Field("address", "string", repeated=False, required=False, default=None),
+        2: protobuf.Field("address_n", "uint32", repeated=True, required=False, default=None),
         3: protobuf.Field("amount", "uint64", repeated=False, required=True),
-        4: protobuf.Field("script_type", "OutputScriptType", repeated=False, required=False),
-        5: protobuf.Field("multisig", "MultisigRedeemScriptType", repeated=False, required=False),
-        6: protobuf.Field("op_return_data", "bytes", repeated=False, required=False),
-        10: protobuf.Field("orig_hash", "bytes", repeated=False, required=False),
-        11: protobuf.Field("orig_index", "uint32", repeated=False, required=False),
-        12: protobuf.Field("payment_req_index", "uint32", repeated=False, required=False),
+        4: protobuf.Field("script_type", "OutputScriptType", repeated=False, required=False, default=OutputScriptType.PAYTOADDRESS),
+        5: protobuf.Field("multisig", "MultisigRedeemScriptType", repeated=False, required=False, default=None),
+        6: protobuf.Field("op_return_data", "bytes", repeated=False, required=False, default=None),
+        10: protobuf.Field("orig_hash", "bytes", repeated=False, required=False, default=None),
+        11: protobuf.Field("orig_index", "uint32", repeated=False, required=False, default=None),
+        12: protobuf.Field("payment_req_index", "uint32", repeated=False, required=False, default=None),
     }
 
     def __init__(
@@ -1356,11 +1356,11 @@ class PrevTx(protobuf.MessageType):
         4: protobuf.Field("lock_time", "uint32", repeated=False, required=True),
         6: protobuf.Field("inputs_count", "uint32", repeated=False, required=True),
         7: protobuf.Field("outputs_count", "uint32", repeated=False, required=True),
-        9: protobuf.Field("extra_data_len", "uint32", repeated=False, required=False),
-        10: protobuf.Field("expiry", "uint32", repeated=False, required=False),
-        12: protobuf.Field("version_group_id", "uint32", repeated=False, required=False),
-        13: protobuf.Field("timestamp", "uint32", repeated=False, required=False),
-        14: protobuf.Field("branch_id", "uint32", repeated=False, required=False),
+        9: protobuf.Field("extra_data_len", "uint32", repeated=False, required=False, default=0),
+        10: protobuf.Field("expiry", "uint32", repeated=False, required=False, default=None),
+        12: protobuf.Field("version_group_id", "uint32", repeated=False, required=False, default=None),
+        13: protobuf.Field("timestamp", "uint32", repeated=False, required=False, default=None),
+        14: protobuf.Field("branch_id", "uint32", repeated=False, required=False, default=None),
     }
 
     def __init__(
@@ -1394,7 +1394,7 @@ class PrevInput(protobuf.MessageType):
         3: protobuf.Field("prev_index", "uint32", repeated=False, required=True),
         4: protobuf.Field("script_sig", "bytes", repeated=False, required=True),
         5: protobuf.Field("sequence", "uint32", repeated=False, required=True),
-        9: protobuf.Field("decred_tree", "uint32", repeated=False, required=False),
+        9: protobuf.Field("decred_tree", "uint32", repeated=False, required=False, default=None),
     }
 
     def __init__(
@@ -1418,7 +1418,7 @@ class PrevOutput(protobuf.MessageType):
     FIELDS = {
         1: protobuf.Field("amount", "uint64", repeated=False, required=True),
         2: protobuf.Field("script_pubkey", "bytes", repeated=False, required=True),
-        3: protobuf.Field("decred_script_version", "uint32", repeated=False, required=False),
+        3: protobuf.Field("decred_script_version", "uint32", repeated=False, required=False, default=None),
     }
 
     def __init__(
@@ -1436,10 +1436,10 @@ class PrevOutput(protobuf.MessageType):
 class TxAckPaymentRequest(protobuf.MessageType):
     MESSAGE_WIRE_TYPE = 37
     FIELDS = {
-        1: protobuf.Field("nonce", "bytes", repeated=False, required=False),
+        1: protobuf.Field("nonce", "bytes", repeated=False, required=False, default=None),
         2: protobuf.Field("recipient_name", "string", repeated=False, required=True),
-        3: protobuf.Field("memos", "PaymentRequestMemo", repeated=True, required=False),
-        4: protobuf.Field("amount", "uint64", repeated=False, required=False),
+        3: protobuf.Field("memos", "PaymentRequestMemo", repeated=True, required=False, default=None),
+        4: protobuf.Field("amount", "uint64", repeated=False, required=False, default=None),
         5: protobuf.Field("signature", "bytes", repeated=False, required=True),
     }
 
@@ -1546,13 +1546,13 @@ class TxAckPrevExtraData(protobuf.MessageType):
 class GetOwnershipProof(protobuf.MessageType):
     MESSAGE_WIRE_TYPE = 49
     FIELDS = {
-        1: protobuf.Field("address_n", "uint32", repeated=True, required=False),
-        2: protobuf.Field("coin_name", "string", repeated=False, required=False),
-        3: protobuf.Field("script_type", "InputScriptType", repeated=False, required=False),
-        4: protobuf.Field("multisig", "MultisigRedeemScriptType", repeated=False, required=False),
-        5: protobuf.Field("user_confirmation", "bool", repeated=False, required=False),
-        6: protobuf.Field("ownership_ids", "bytes", repeated=True, required=False),
-        7: protobuf.Field("commitment_data", "bytes", repeated=False, required=False),
+        1: protobuf.Field("address_n", "uint32", repeated=True, required=False, default=None),
+        2: protobuf.Field("coin_name", "string", repeated=False, required=False, default='Bitcoin'),
+        3: protobuf.Field("script_type", "InputScriptType", repeated=False, required=False, default=InputScriptType.SPENDWITNESS),
+        4: protobuf.Field("multisig", "MultisigRedeemScriptType", repeated=False, required=False, default=None),
+        5: protobuf.Field("user_confirmation", "bool", repeated=False, required=False, default=False),
+        6: protobuf.Field("ownership_ids", "bytes", repeated=True, required=False, default=None),
+        7: protobuf.Field("commitment_data", "bytes", repeated=False, required=False, default=b''),
     }
 
     def __init__(
@@ -1599,10 +1599,10 @@ class AuthorizeCoinJoin(protobuf.MessageType):
         2: protobuf.Field("max_rounds", "uint64", repeated=False, required=True),
         3: protobuf.Field("max_coordinator_fee_rate", "uint32", repeated=False, required=True),
         4: protobuf.Field("max_fee_per_kvbyte", "uint32", repeated=False, required=True),
-        5: protobuf.Field("address_n", "uint32", repeated=True, required=False),
-        6: protobuf.Field("coin_name", "string", repeated=False, required=False),
-        7: protobuf.Field("script_type", "InputScriptType", repeated=False, required=False),
-        8: protobuf.Field("amount_unit", "AmountUnit", repeated=False, required=False),
+        5: protobuf.Field("address_n", "uint32", repeated=True, required=False, default=None),
+        6: protobuf.Field("coin_name", "string", repeated=False, required=False, default='Bitcoin'),
+        7: protobuf.Field("script_type", "InputScriptType", repeated=False, required=False, default=InputScriptType.SPENDADDRESS),
+        8: protobuf.Field("amount_unit", "AmountUnit", repeated=False, required=False, default=AmountUnit.BITCOIN),
     }
 
     def __init__(
@@ -1631,7 +1631,7 @@ class HDNodePathType(protobuf.MessageType):
     MESSAGE_WIRE_TYPE = None
     FIELDS = {
         1: protobuf.Field("node", "HDNodeType", repeated=False, required=True),
-        2: protobuf.Field("address_n", "uint32", repeated=True, required=False),
+        2: protobuf.Field("address_n", "uint32", repeated=True, required=False, default=None),
     }
 
     def __init__(
@@ -1673,10 +1673,10 @@ class CoinJoinRequest(protobuf.MessageType):
 class TxRequestDetailsType(protobuf.MessageType):
     MESSAGE_WIRE_TYPE = None
     FIELDS = {
-        1: protobuf.Field("request_index", "uint32", repeated=False, required=False),
-        2: protobuf.Field("tx_hash", "bytes", repeated=False, required=False),
-        3: protobuf.Field("extra_data_len", "uint32", repeated=False, required=False),
-        4: protobuf.Field("extra_data_offset", "uint32", repeated=False, required=False),
+        1: protobuf.Field("request_index", "uint32", repeated=False, required=False, default=None),
+        2: protobuf.Field("tx_hash", "bytes", repeated=False, required=False, default=None),
+        3: protobuf.Field("extra_data_len", "uint32", repeated=False, required=False, default=None),
+        4: protobuf.Field("extra_data_offset", "uint32", repeated=False, required=False, default=None),
     }
 
     def __init__(
@@ -1696,9 +1696,9 @@ class TxRequestDetailsType(protobuf.MessageType):
 class TxRequestSerializedType(protobuf.MessageType):
     MESSAGE_WIRE_TYPE = None
     FIELDS = {
-        1: protobuf.Field("signature_index", "uint32", repeated=False, required=False),
-        2: protobuf.Field("signature", "bytes", repeated=False, required=False),
-        3: protobuf.Field("serialized_tx", "bytes", repeated=False, required=False),
+        1: protobuf.Field("signature_index", "uint32", repeated=False, required=False, default=None),
+        2: protobuf.Field("signature", "bytes", repeated=False, required=False, default=None),
+        3: protobuf.Field("serialized_tx", "bytes", repeated=False, required=False, default=None),
     }
 
     def __init__(
@@ -1716,20 +1716,20 @@ class TxRequestSerializedType(protobuf.MessageType):
 class TransactionType(protobuf.MessageType):
     MESSAGE_WIRE_TYPE = None
     FIELDS = {
-        1: protobuf.Field("version", "uint32", repeated=False, required=False),
-        2: protobuf.Field("inputs", "TxInputType", repeated=True, required=False),
-        3: protobuf.Field("bin_outputs", "TxOutputBinType", repeated=True, required=False),
-        4: protobuf.Field("lock_time", "uint32", repeated=False, required=False),
-        5: protobuf.Field("outputs", "TxOutputType", repeated=True, required=False),
-        6: protobuf.Field("inputs_cnt", "uint32", repeated=False, required=False),
-        7: protobuf.Field("outputs_cnt", "uint32", repeated=False, required=False),
-        8: protobuf.Field("extra_data", "bytes", repeated=False, required=False),
-        9: protobuf.Field("extra_data_len", "uint32", repeated=False, required=False),
-        10: protobuf.Field("expiry", "uint32", repeated=False, required=False),
-        11: protobuf.Field("overwintered", "bool", repeated=False, required=False),
-        12: protobuf.Field("version_group_id", "uint32", repeated=False, required=False),
-        13: protobuf.Field("timestamp", "uint32", repeated=False, required=False),
-        14: protobuf.Field("branch_id", "uint32", repeated=False, required=False),
+        1: protobuf.Field("version", "uint32", repeated=False, required=False, default=None),
+        2: protobuf.Field("inputs", "TxInputType", repeated=True, required=False, default=None),
+        3: protobuf.Field("bin_outputs", "TxOutputBinType", repeated=True, required=False, default=None),
+        4: protobuf.Field("lock_time", "uint32", repeated=False, required=False, default=None),
+        5: protobuf.Field("outputs", "TxOutputType", repeated=True, required=False, default=None),
+        6: protobuf.Field("inputs_cnt", "uint32", repeated=False, required=False, default=None),
+        7: protobuf.Field("outputs_cnt", "uint32", repeated=False, required=False, default=None),
+        8: protobuf.Field("extra_data", "bytes", repeated=False, required=False, default=None),
+        9: protobuf.Field("extra_data_len", "uint32", repeated=False, required=False, default=None),
+        10: protobuf.Field("expiry", "uint32", repeated=False, required=False, default=None),
+        11: protobuf.Field("overwintered", "bool", repeated=False, required=False, default=None),
+        12: protobuf.Field("version_group_id", "uint32", repeated=False, required=False, default=None),
+        13: protobuf.Field("timestamp", "uint32", repeated=False, required=False, default=None),
+        14: protobuf.Field("branch_id", "uint32", repeated=False, required=False, default=None),
     }
 
     def __init__(
@@ -1769,23 +1769,23 @@ class TransactionType(protobuf.MessageType):
 class TxInputType(protobuf.MessageType):
     MESSAGE_WIRE_TYPE = None
     FIELDS = {
-        1: protobuf.Field("address_n", "uint32", repeated=True, required=False),
+        1: protobuf.Field("address_n", "uint32", repeated=True, required=False, default=None),
         2: protobuf.Field("prev_hash", "bytes", repeated=False, required=True),
         3: protobuf.Field("prev_index", "uint32", repeated=False, required=True),
-        4: protobuf.Field("script_sig", "bytes", repeated=False, required=False),
-        5: protobuf.Field("sequence", "uint32", repeated=False, required=False),
-        6: protobuf.Field("script_type", "InputScriptType", repeated=False, required=False),
-        7: protobuf.Field("multisig", "MultisigRedeemScriptType", repeated=False, required=False),
-        8: protobuf.Field("amount", "uint64", repeated=False, required=False),
-        9: protobuf.Field("decred_tree", "uint32", repeated=False, required=False),
-        13: protobuf.Field("witness", "bytes", repeated=False, required=False),
-        14: protobuf.Field("ownership_proof", "bytes", repeated=False, required=False),
-        15: protobuf.Field("commitment_data", "bytes", repeated=False, required=False),
-        16: protobuf.Field("orig_hash", "bytes", repeated=False, required=False),
-        17: protobuf.Field("orig_index", "uint32", repeated=False, required=False),
-        18: protobuf.Field("decred_staking_spend", "DecredStakingSpendType", repeated=False, required=False),
-        19: protobuf.Field("script_pubkey", "bytes", repeated=False, required=False),
-        20: protobuf.Field("coinjoin_flags", "uint32", repeated=False, required=False),
+        4: protobuf.Field("script_sig", "bytes", repeated=False, required=False, default=None),
+        5: protobuf.Field("sequence", "uint32", repeated=False, required=False, default=4294967295),
+        6: protobuf.Field("script_type", "InputScriptType", repeated=False, required=False, default=InputScriptType.SPENDADDRESS),
+        7: protobuf.Field("multisig", "MultisigRedeemScriptType", repeated=False, required=False, default=None),
+        8: protobuf.Field("amount", "uint64", repeated=False, required=False, default=None),
+        9: protobuf.Field("decred_tree", "uint32", repeated=False, required=False, default=None),
+        13: protobuf.Field("witness", "bytes", repeated=False, required=False, default=None),
+        14: protobuf.Field("ownership_proof", "bytes", repeated=False, required=False, default=None),
+        15: protobuf.Field("commitment_data", "bytes", repeated=False, required=False, default=None),
+        16: protobuf.Field("orig_hash", "bytes", repeated=False, required=False, default=None),
+        17: protobuf.Field("orig_index", "uint32", repeated=False, required=False, default=None),
+        18: protobuf.Field("decred_staking_spend", "DecredStakingSpendType", repeated=False, required=False, default=None),
+        19: protobuf.Field("script_pubkey", "bytes", repeated=False, required=False, default=None),
+        20: protobuf.Field("coinjoin_flags", "uint32", repeated=False, required=False, default=0),
     }
 
     def __init__(
@@ -1833,7 +1833,7 @@ class TxOutputBinType(protobuf.MessageType):
     FIELDS = {
         1: protobuf.Field("amount", "uint64", repeated=False, required=True),
         2: protobuf.Field("script_pubkey", "bytes", repeated=False, required=True),
-        3: protobuf.Field("decred_script_version", "uint32", repeated=False, required=False),
+        3: protobuf.Field("decred_script_version", "uint32", repeated=False, required=False, default=None),
     }
 
     def __init__(
@@ -1851,15 +1851,15 @@ class TxOutputBinType(protobuf.MessageType):
 class TxOutputType(protobuf.MessageType):
     MESSAGE_WIRE_TYPE = None
     FIELDS = {
-        1: protobuf.Field("address", "string", repeated=False, required=False),
-        2: protobuf.Field("address_n", "uint32", repeated=True, required=False),
+        1: protobuf.Field("address", "string", repeated=False, required=False, default=None),
+        2: protobuf.Field("address_n", "uint32", repeated=True, required=False, default=None),
         3: protobuf.Field("amount", "uint64", repeated=False, required=True),
-        4: protobuf.Field("script_type", "OutputScriptType", repeated=False, required=False),
-        5: protobuf.Field("multisig", "MultisigRedeemScriptType", repeated=False, required=False),
-        6: protobuf.Field("op_return_data", "bytes", repeated=False, required=False),
-        10: protobuf.Field("orig_hash", "bytes", repeated=False, required=False),
-        11: protobuf.Field("orig_index", "uint32", repeated=False, required=False),
-        12: protobuf.Field("payment_req_index", "uint32", repeated=False, required=False),
+        4: protobuf.Field("script_type", "OutputScriptType", repeated=False, required=False, default=OutputScriptType.PAYTOADDRESS),
+        5: protobuf.Field("multisig", "MultisigRedeemScriptType", repeated=False, required=False, default=None),
+        6: protobuf.Field("op_return_data", "bytes", repeated=False, required=False, default=None),
+        10: protobuf.Field("orig_hash", "bytes", repeated=False, required=False, default=None),
+        11: protobuf.Field("orig_index", "uint32", repeated=False, required=False, default=None),
+        12: protobuf.Field("payment_req_index", "uint32", repeated=False, required=False, default=None),
     }
 
     def __init__(
@@ -1889,9 +1889,9 @@ class TxOutputType(protobuf.MessageType):
 class PaymentRequestMemo(protobuf.MessageType):
     MESSAGE_WIRE_TYPE = None
     FIELDS = {
-        1: protobuf.Field("text_memo", "TextMemo", repeated=False, required=False),
-        2: protobuf.Field("refund_memo", "RefundMemo", repeated=False, required=False),
-        3: protobuf.Field("coin_purchase_memo", "CoinPurchaseMemo", repeated=False, required=False),
+        1: protobuf.Field("text_memo", "TextMemo", repeated=False, required=False, default=None),
+        2: protobuf.Field("refund_memo", "RefundMemo", repeated=False, required=False, default=None),
+        3: protobuf.Field("coin_purchase_memo", "CoinPurchaseMemo", repeated=False, required=False, default=None),
     }
 
     def __init__(
@@ -2033,7 +2033,7 @@ class TxAckPrevExtraDataWrapper(protobuf.MessageType):
 class FirmwareErase(protobuf.MessageType):
     MESSAGE_WIRE_TYPE = 6
     FIELDS = {
-        1: protobuf.Field("length", "uint32", repeated=False, required=False),
+        1: protobuf.Field("length", "uint32", repeated=False, required=False, default=None),
     }
 
     def __init__(
@@ -2047,8 +2047,8 @@ class FirmwareErase(protobuf.MessageType):
 class FirmwareRequest(protobuf.MessageType):
     MESSAGE_WIRE_TYPE = 8
     FIELDS = {
-        1: protobuf.Field("offset", "uint32", repeated=False, required=False),
-        2: protobuf.Field("length", "uint32", repeated=False, required=False),
+        1: protobuf.Field("offset", "uint32", repeated=False, required=False, default=None),
+        2: protobuf.Field("length", "uint32", repeated=False, required=False, default=None),
     }
 
     def __init__(
@@ -2065,7 +2065,7 @@ class FirmwareUpload(protobuf.MessageType):
     MESSAGE_WIRE_TYPE = 7
     FIELDS = {
         1: protobuf.Field("payload", "bytes", repeated=False, required=True),
-        2: protobuf.Field("hash", "bytes", repeated=False, required=False),
+        2: protobuf.Field("hash", "bytes", repeated=False, required=False, default=None),
     }
 
     def __init__(
@@ -2081,7 +2081,7 @@ class FirmwareUpload(protobuf.MessageType):
 class SelfTest(protobuf.MessageType):
     MESSAGE_WIRE_TYPE = 32
     FIELDS = {
-        1: protobuf.Field("payload", "bytes", repeated=False, required=False),
+        1: protobuf.Field("payload", "bytes", repeated=False, required=False, default=None),
     }
 
     def __init__(
@@ -2116,12 +2116,12 @@ class CardanoNativeScript(protobuf.MessageType):
     MESSAGE_WIRE_TYPE = None
     FIELDS = {
         1: protobuf.Field("type", "CardanoNativeScriptType", repeated=False, required=True),
-        2: protobuf.Field("scripts", "CardanoNativeScript", repeated=True, required=False),
-        3: protobuf.Field("key_hash", "bytes", repeated=False, required=False),
-        4: protobuf.Field("key_path", "uint32", repeated=True, required=False),
-        5: protobuf.Field("required_signatures_count", "uint32", repeated=False, required=False),
-        6: protobuf.Field("invalid_before", "uint64", repeated=False, required=False),
-        7: protobuf.Field("invalid_hereafter", "uint64", repeated=False, required=False),
+        2: protobuf.Field("scripts", "CardanoNativeScript", repeated=True, required=False, default=None),
+        3: protobuf.Field("key_hash", "bytes", repeated=False, required=False, default=None),
+        4: protobuf.Field("key_path", "uint32", repeated=True, required=False, default=None),
+        5: protobuf.Field("required_signatures_count", "uint32", repeated=False, required=False, default=None),
+        6: protobuf.Field("invalid_before", "uint64", repeated=False, required=False, default=None),
+        7: protobuf.Field("invalid_hereafter", "uint64", repeated=False, required=False, default=None),
     }
 
     def __init__(
@@ -2182,12 +2182,12 @@ class CardanoAddressParametersType(protobuf.MessageType):
     MESSAGE_WIRE_TYPE = None
     FIELDS = {
         1: protobuf.Field("address_type", "CardanoAddressType", repeated=False, required=True),
-        2: protobuf.Field("address_n", "uint32", repeated=True, required=False),
-        3: protobuf.Field("address_n_staking", "uint32", repeated=True, required=False),
-        4: protobuf.Field("staking_key_hash", "bytes", repeated=False, required=False),
-        5: protobuf.Field("certificate_pointer", "CardanoBlockchainPointerType", repeated=False, required=False),
-        6: protobuf.Field("script_payment_hash", "bytes", repeated=False, required=False),
-        7: protobuf.Field("script_staking_hash", "bytes", repeated=False, required=False),
+        2: protobuf.Field("address_n", "uint32", repeated=True, required=False, default=None),
+        3: protobuf.Field("address_n_staking", "uint32", repeated=True, required=False, default=None),
+        4: protobuf.Field("staking_key_hash", "bytes", repeated=False, required=False, default=None),
+        5: protobuf.Field("certificate_pointer", "CardanoBlockchainPointerType", repeated=False, required=False, default=None),
+        6: protobuf.Field("script_payment_hash", "bytes", repeated=False, required=False, default=None),
+        7: protobuf.Field("script_staking_hash", "bytes", repeated=False, required=False, default=None),
     }
 
     def __init__(
@@ -2213,7 +2213,7 @@ class CardanoAddressParametersType(protobuf.MessageType):
 class CardanoGetAddress(protobuf.MessageType):
     MESSAGE_WIRE_TYPE = 307
     FIELDS = {
-        2: protobuf.Field("show_display", "bool", repeated=False, required=False),
+        2: protobuf.Field("show_display", "bool", repeated=False, required=False, default=False),
         3: protobuf.Field("protocol_magic", "uint32", repeated=False, required=True),
         4: protobuf.Field("network_id", "uint32", repeated=False, required=True),
         5: protobuf.Field("address_parameters", "CardanoAddressParametersType", repeated=False, required=True),
@@ -2253,8 +2253,8 @@ class CardanoAddress(protobuf.MessageType):
 class CardanoGetPublicKey(protobuf.MessageType):
     MESSAGE_WIRE_TYPE = 305
     FIELDS = {
-        1: protobuf.Field("address_n", "uint32", repeated=True, required=False),
-        2: protobuf.Field("show_display", "bool", repeated=False, required=False),
+        1: protobuf.Field("address_n", "uint32", repeated=True, required=False, default=None),
+        2: protobuf.Field("show_display", "bool", repeated=False, required=False, default=None),
         3: protobuf.Field("derivation_type", "CardanoDerivationType", repeated=False, required=True),
     }
 
@@ -2296,21 +2296,21 @@ class CardanoSignTxInit(protobuf.MessageType):
         4: protobuf.Field("inputs_count", "uint32", repeated=False, required=True),
         5: protobuf.Field("outputs_count", "uint32", repeated=False, required=True),
         6: protobuf.Field("fee", "uint64", repeated=False, required=True),
-        7: protobuf.Field("ttl", "uint64", repeated=False, required=False),
+        7: protobuf.Field("ttl", "uint64", repeated=False, required=False, default=None),
         8: protobuf.Field("certificates_count", "uint32", repeated=False, required=True),
         9: protobuf.Field("withdrawals_count", "uint32", repeated=False, required=True),
         10: protobuf.Field("has_auxiliary_data", "bool", repeated=False, required=True),
-        11: protobuf.Field("validity_interval_start", "uint64", repeated=False, required=False),
+        11: protobuf.Field("validity_interval_start", "uint64", repeated=False, required=False, default=None),
         12: protobuf.Field("witness_requests_count", "uint32", repeated=False, required=True),
         13: protobuf.Field("minting_asset_groups_count", "uint32", repeated=False, required=True),
         14: protobuf.Field("derivation_type", "CardanoDerivationType", repeated=False, required=True),
-        15: protobuf.Field("include_network_id", "bool", repeated=False, required=False),
-        16: protobuf.Field("script_data_hash", "bytes", repeated=False, required=False),
+        15: protobuf.Field("include_network_id", "bool", repeated=False, required=False, default=False),
+        16: protobuf.Field("script_data_hash", "bytes", repeated=False, required=False, default=None),
         17: protobuf.Field("collateral_inputs_count", "uint32", repeated=False, required=True),
         18: protobuf.Field("required_signers_count", "uint32", repeated=False, required=True),
-        19: protobuf.Field("has_collateral_return", "bool", repeated=False, required=False),
-        20: protobuf.Field("total_collateral", "uint64", repeated=False, required=False),
-        21: protobuf.Field("reference_inputs_count", "uint32", repeated=False, required=False),
+        19: protobuf.Field("has_collateral_return", "bool", repeated=False, required=False, default=False),
+        20: protobuf.Field("total_collateral", "uint64", repeated=False, required=False, default=None),
+        21: protobuf.Field("reference_inputs_count", "uint32", repeated=False, required=False, default=0),
     }
 
     def __init__(
@@ -2381,14 +2381,14 @@ class CardanoTxInput(protobuf.MessageType):
 class CardanoTxOutput(protobuf.MessageType):
     MESSAGE_WIRE_TYPE = 322
     FIELDS = {
-        1: protobuf.Field("address", "string", repeated=False, required=False),
-        2: protobuf.Field("address_parameters", "CardanoAddressParametersType", repeated=False, required=False),
+        1: protobuf.Field("address", "string", repeated=False, required=False, default=None),
+        2: protobuf.Field("address_parameters", "CardanoAddressParametersType", repeated=False, required=False, default=None),
         3: protobuf.Field("amount", "uint64", repeated=False, required=True),
         4: protobuf.Field("asset_groups_count", "uint32", repeated=False, required=True),
-        5: protobuf.Field("datum_hash", "bytes", repeated=False, required=False),
-        6: protobuf.Field("format", "CardanoTxOutputSerializationFormat", repeated=False, required=False),
-        7: protobuf.Field("inline_datum_size", "uint32", repeated=False, required=False),
-        8: protobuf.Field("reference_script_size", "uint32", repeated=False, required=False),
+        5: protobuf.Field("datum_hash", "bytes", repeated=False, required=False, default=None),
+        6: protobuf.Field("format", "CardanoTxOutputSerializationFormat", repeated=False, required=False, default=CardanoTxOutputSerializationFormat.ARRAY_LEGACY),
+        7: protobuf.Field("inline_datum_size", "uint32", repeated=False, required=False, default=0),
+        8: protobuf.Field("reference_script_size", "uint32", repeated=False, required=False, default=0),
     }
 
     def __init__(
@@ -2434,8 +2434,8 @@ class CardanoToken(protobuf.MessageType):
     MESSAGE_WIRE_TYPE = 324
     FIELDS = {
         1: protobuf.Field("asset_name_bytes", "bytes", repeated=False, required=True),
-        2: protobuf.Field("amount", "uint64", repeated=False, required=False),
-        3: protobuf.Field("mint_amount", "sint64", repeated=False, required=False),
+        2: protobuf.Field("amount", "uint64", repeated=False, required=False, default=None),
+        3: protobuf.Field("mint_amount", "sint64", repeated=False, required=False, default=None),
     }
 
     def __init__(
@@ -2481,8 +2481,8 @@ class CardanoTxReferenceScriptChunk(protobuf.MessageType):
 class CardanoPoolOwner(protobuf.MessageType):
     MESSAGE_WIRE_TYPE = 328
     FIELDS = {
-        1: protobuf.Field("staking_key_path", "uint32", repeated=True, required=False),
-        2: protobuf.Field("staking_key_hash", "bytes", repeated=False, required=False),
+        1: protobuf.Field("staking_key_path", "uint32", repeated=True, required=False, default=None),
+        2: protobuf.Field("staking_key_hash", "bytes", repeated=False, required=False, default=None),
     }
 
     def __init__(
@@ -2499,10 +2499,10 @@ class CardanoPoolRelayParameters(protobuf.MessageType):
     MESSAGE_WIRE_TYPE = 329
     FIELDS = {
         1: protobuf.Field("type", "CardanoPoolRelayType", repeated=False, required=True),
-        2: protobuf.Field("ipv4_address", "bytes", repeated=False, required=False),
-        3: protobuf.Field("ipv6_address", "bytes", repeated=False, required=False),
-        4: protobuf.Field("host_name", "string", repeated=False, required=False),
-        5: protobuf.Field("port", "uint32", repeated=False, required=False),
+        2: protobuf.Field("ipv4_address", "bytes", repeated=False, required=False, default=None),
+        3: protobuf.Field("ipv6_address", "bytes", repeated=False, required=False, default=None),
+        4: protobuf.Field("host_name", "string", repeated=False, required=False, default=None),
+        5: protobuf.Field("port", "uint32", repeated=False, required=False, default=None),
     }
 
     def __init__(
@@ -2548,7 +2548,7 @@ class CardanoPoolParametersType(protobuf.MessageType):
         5: protobuf.Field("margin_numerator", "uint64", repeated=False, required=True),
         6: protobuf.Field("margin_denominator", "uint64", repeated=False, required=True),
         7: protobuf.Field("reward_account", "string", repeated=False, required=True),
-        10: protobuf.Field("metadata", "CardanoPoolMetadataType", repeated=False, required=False),
+        10: protobuf.Field("metadata", "CardanoPoolMetadataType", repeated=False, required=False, default=None),
         11: protobuf.Field("owners_count", "uint32", repeated=False, required=True),
         12: protobuf.Field("relays_count", "uint32", repeated=False, required=True),
     }
@@ -2583,11 +2583,11 @@ class CardanoTxCertificate(protobuf.MessageType):
     MESSAGE_WIRE_TYPE = 325
     FIELDS = {
         1: protobuf.Field("type", "CardanoCertificateType", repeated=False, required=True),
-        2: protobuf.Field("path", "uint32", repeated=True, required=False),
-        3: protobuf.Field("pool", "bytes", repeated=False, required=False),
-        4: protobuf.Field("pool_parameters", "CardanoPoolParametersType", repeated=False, required=False),
-        5: protobuf.Field("script_hash", "bytes", repeated=False, required=False),
-        6: protobuf.Field("key_hash", "bytes", repeated=False, required=False),
+        2: protobuf.Field("path", "uint32", repeated=True, required=False, default=None),
+        3: protobuf.Field("pool", "bytes", repeated=False, required=False, default=None),
+        4: protobuf.Field("pool_parameters", "CardanoPoolParametersType", repeated=False, required=False, default=None),
+        5: protobuf.Field("script_hash", "bytes", repeated=False, required=False, default=None),
+        6: protobuf.Field("key_hash", "bytes", repeated=False, required=False, default=None),
     }
 
     def __init__(
@@ -2611,10 +2611,10 @@ class CardanoTxCertificate(protobuf.MessageType):
 class CardanoTxWithdrawal(protobuf.MessageType):
     MESSAGE_WIRE_TYPE = 326
     FIELDS = {
-        1: protobuf.Field("path", "uint32", repeated=True, required=False),
+        1: protobuf.Field("path", "uint32", repeated=True, required=False, default=None),
         2: protobuf.Field("amount", "uint64", repeated=False, required=True),
-        3: protobuf.Field("script_hash", "bytes", repeated=False, required=False),
-        4: protobuf.Field("key_hash", "bytes", repeated=False, required=False),
+        3: protobuf.Field("script_hash", "bytes", repeated=False, required=False, default=None),
+        4: protobuf.Field("key_hash", "bytes", repeated=False, required=False, default=None),
     }
 
     def __init__(
@@ -2651,13 +2651,13 @@ class CardanoGovernanceRegistrationDelegation(protobuf.MessageType):
 class CardanoGovernanceRegistrationParametersType(protobuf.MessageType):
     MESSAGE_WIRE_TYPE = None
     FIELDS = {
-        1: protobuf.Field("voting_public_key", "bytes", repeated=False, required=False),
-        2: protobuf.Field("staking_path", "uint32", repeated=True, required=False),
+        1: protobuf.Field("voting_public_key", "bytes", repeated=False, required=False, default=None),
+        2: protobuf.Field("staking_path", "uint32", repeated=True, required=False, default=None),
         3: protobuf.Field("reward_address_parameters", "CardanoAddressParametersType", repeated=False, required=True),
         4: protobuf.Field("nonce", "uint64", repeated=False, required=True),
-        5: protobuf.Field("format", "CardanoGovernanceRegistrationFormat", repeated=False, required=False),
-        6: protobuf.Field("delegations", "CardanoGovernanceRegistrationDelegation", repeated=True, required=False),
-        7: protobuf.Field("voting_purpose", "uint64", repeated=False, required=False),
+        5: protobuf.Field("format", "CardanoGovernanceRegistrationFormat", repeated=False, required=False, default=CardanoGovernanceRegistrationFormat.CIP15),
+        6: protobuf.Field("delegations", "CardanoGovernanceRegistrationDelegation", repeated=True, required=False, default=None),
+        7: protobuf.Field("voting_purpose", "uint64", repeated=False, required=False, default=None),
     }
 
     def __init__(
@@ -2683,8 +2683,8 @@ class CardanoGovernanceRegistrationParametersType(protobuf.MessageType):
 class CardanoTxAuxiliaryData(protobuf.MessageType):
     MESSAGE_WIRE_TYPE = 327
     FIELDS = {
-        1: protobuf.Field("governance_registration_parameters", "CardanoGovernanceRegistrationParametersType", repeated=False, required=False),
-        2: protobuf.Field("hash", "bytes", repeated=False, required=False),
+        1: protobuf.Field("governance_registration_parameters", "CardanoGovernanceRegistrationParametersType", repeated=False, required=False, default=None),
+        2: protobuf.Field("hash", "bytes", repeated=False, required=False, default=None),
     }
 
     def __init__(
@@ -2731,8 +2731,8 @@ class CardanoTxCollateralInput(protobuf.MessageType):
 class CardanoTxRequiredSigner(protobuf.MessageType):
     MESSAGE_WIRE_TYPE = 334
     FIELDS = {
-        1: protobuf.Field("key_hash", "bytes", repeated=False, required=False),
-        2: protobuf.Field("key_path", "uint32", repeated=True, required=False),
+        1: protobuf.Field("key_hash", "bytes", repeated=False, required=False, default=None),
+        2: protobuf.Field("key_path", "uint32", repeated=True, required=False, default=None),
     }
 
     def __init__(
@@ -2770,8 +2770,8 @@ class CardanoTxAuxiliaryDataSupplement(protobuf.MessageType):
     MESSAGE_WIRE_TYPE = 314
     FIELDS = {
         1: protobuf.Field("type", "CardanoTxAuxiliaryDataSupplementType", repeated=False, required=True),
-        2: protobuf.Field("auxiliary_data_hash", "bytes", repeated=False, required=False),
-        3: protobuf.Field("governance_signature", "bytes", repeated=False, required=False),
+        2: protobuf.Field("auxiliary_data_hash", "bytes", repeated=False, required=False, default=None),
+        3: protobuf.Field("governance_signature", "bytes", repeated=False, required=False, default=None),
     }
 
     def __init__(
@@ -2789,7 +2789,7 @@ class CardanoTxAuxiliaryDataSupplement(protobuf.MessageType):
 class CardanoTxWitnessRequest(protobuf.MessageType):
     MESSAGE_WIRE_TYPE = 315
     FIELDS = {
-        1: protobuf.Field("path", "uint32", repeated=True, required=False),
+        1: protobuf.Field("path", "uint32", repeated=True, required=False, default=None),
     }
 
     def __init__(
@@ -2806,7 +2806,7 @@ class CardanoTxWitnessResponse(protobuf.MessageType):
         1: protobuf.Field("type", "CardanoTxWitnessType", repeated=False, required=True),
         2: protobuf.Field("pub_key", "bytes", repeated=False, required=True),
         3: protobuf.Field("signature", "bytes", repeated=False, required=True),
-        4: protobuf.Field("chain_code", "bytes", repeated=False, required=False),
+        4: protobuf.Field("chain_code", "bytes", repeated=False, required=False, default=None),
     }
 
     def __init__(
@@ -2848,13 +2848,13 @@ class CardanoSignTxFinished(protobuf.MessageType):
 class CipherKeyValue(protobuf.MessageType):
     MESSAGE_WIRE_TYPE = 23
     FIELDS = {
-        1: protobuf.Field("address_n", "uint32", repeated=True, required=False),
+        1: protobuf.Field("address_n", "uint32", repeated=True, required=False, default=None),
         2: protobuf.Field("key", "string", repeated=False, required=True),
         3: protobuf.Field("value", "bytes", repeated=False, required=True),
-        4: protobuf.Field("encrypt", "bool", repeated=False, required=False),
-        5: protobuf.Field("ask_on_encrypt", "bool", repeated=False, required=False),
-        6: protobuf.Field("ask_on_decrypt", "bool", repeated=False, required=False),
-        7: protobuf.Field("iv", "bytes", repeated=False, required=False),
+        4: protobuf.Field("encrypt", "bool", repeated=False, required=False, default=None),
+        5: protobuf.Field("ask_on_encrypt", "bool", repeated=False, required=False, default=None),
+        6: protobuf.Field("ask_on_decrypt", "bool", repeated=False, required=False, default=None),
+        7: protobuf.Field("iv", "bytes", repeated=False, required=False, default=None),
     }
 
     def __init__(
@@ -2894,12 +2894,12 @@ class CipheredKeyValue(protobuf.MessageType):
 class IdentityType(protobuf.MessageType):
     MESSAGE_WIRE_TYPE = None
     FIELDS = {
-        1: protobuf.Field("proto", "string", repeated=False, required=False),
-        2: protobuf.Field("user", "string", repeated=False, required=False),
-        3: protobuf.Field("host", "string", repeated=False, required=False),
-        4: protobuf.Field("port", "string", repeated=False, required=False),
-        5: protobuf.Field("path", "string", repeated=False, required=False),
-        6: protobuf.Field("index", "uint32", repeated=False, required=False),
+        1: protobuf.Field("proto", "string", repeated=False, required=False, default=None),
+        2: protobuf.Field("user", "string", repeated=False, required=False, default=None),
+        3: protobuf.Field("host", "string", repeated=False, required=False, default=None),
+        4: protobuf.Field("port", "string", repeated=False, required=False, default=None),
+        5: protobuf.Field("path", "string", repeated=False, required=False, default=None),
+        6: protobuf.Field("index", "uint32", repeated=False, required=False, default=0),
     }
 
     def __init__(
@@ -2924,9 +2924,9 @@ class SignIdentity(protobuf.MessageType):
     MESSAGE_WIRE_TYPE = 53
     FIELDS = {
         1: protobuf.Field("identity", "IdentityType", repeated=False, required=True),
-        2: protobuf.Field("challenge_hidden", "bytes", repeated=False, required=False),
-        3: protobuf.Field("challenge_visual", "string", repeated=False, required=False),
-        4: protobuf.Field("ecdsa_curve_name", "string", repeated=False, required=False),
+        2: protobuf.Field("challenge_hidden", "bytes", repeated=False, required=False, default=b''),
+        3: protobuf.Field("challenge_visual", "string", repeated=False, required=False, default=''),
+        4: protobuf.Field("ecdsa_curve_name", "string", repeated=False, required=False, default=None),
     }
 
     def __init__(
@@ -2946,7 +2946,7 @@ class SignIdentity(protobuf.MessageType):
 class SignedIdentity(protobuf.MessageType):
     MESSAGE_WIRE_TYPE = 54
     FIELDS = {
-        1: protobuf.Field("address", "string", repeated=False, required=False),
+        1: protobuf.Field("address", "string", repeated=False, required=False, default=None),
         2: protobuf.Field("public_key", "bytes", repeated=False, required=True),
         3: protobuf.Field("signature", "bytes", repeated=False, required=True),
     }
@@ -2968,7 +2968,7 @@ class GetECDHSessionKey(protobuf.MessageType):
     FIELDS = {
         1: protobuf.Field("identity", "IdentityType", repeated=False, required=True),
         2: protobuf.Field("peer_public_key", "bytes", repeated=False, required=True),
-        3: protobuf.Field("ecdsa_curve_name", "string", repeated=False, required=False),
+        3: protobuf.Field("ecdsa_curve_name", "string", repeated=False, required=False, default=None),
     }
 
     def __init__(
@@ -2987,7 +2987,7 @@ class ECDHSessionKey(protobuf.MessageType):
     MESSAGE_WIRE_TYPE = 62
     FIELDS = {
         1: protobuf.Field("session_key", "bytes", repeated=False, required=True),
-        2: protobuf.Field("public_key", "bytes", repeated=False, required=False),
+        2: protobuf.Field("public_key", "bytes", repeated=False, required=False, default=None),
     }
 
     def __init__(
@@ -3003,8 +3003,8 @@ class ECDHSessionKey(protobuf.MessageType):
 class CosiCommit(protobuf.MessageType):
     MESSAGE_WIRE_TYPE = 71
     FIELDS = {
-        1: protobuf.Field("address_n", "uint32", repeated=True, required=False),
-        2: protobuf.Field("data", "bytes", repeated=False, required=False),
+        1: protobuf.Field("address_n", "uint32", repeated=True, required=False, default=None),
+        2: protobuf.Field("data", "bytes", repeated=False, required=False, default=None),
     }
 
     def __init__(
@@ -3020,8 +3020,8 @@ class CosiCommit(protobuf.MessageType):
 class CosiCommitment(protobuf.MessageType):
     MESSAGE_WIRE_TYPE = 72
     FIELDS = {
-        1: protobuf.Field("commitment", "bytes", repeated=False, required=False),
-        2: protobuf.Field("pubkey", "bytes", repeated=False, required=False),
+        1: protobuf.Field("commitment", "bytes", repeated=False, required=False, default=None),
+        2: protobuf.Field("pubkey", "bytes", repeated=False, required=False, default=None),
     }
 
     def __init__(
@@ -3037,10 +3037,10 @@ class CosiCommitment(protobuf.MessageType):
 class CosiSign(protobuf.MessageType):
     MESSAGE_WIRE_TYPE = 73
     FIELDS = {
-        1: protobuf.Field("address_n", "uint32", repeated=True, required=False),
-        2: protobuf.Field("data", "bytes", repeated=False, required=False),
-        3: protobuf.Field("global_commitment", "bytes", repeated=False, required=False),
-        4: protobuf.Field("global_pubkey", "bytes", repeated=False, required=False),
+        1: protobuf.Field("address_n", "uint32", repeated=True, required=False, default=None),
+        2: protobuf.Field("data", "bytes", repeated=False, required=False, default=None),
+        3: protobuf.Field("global_commitment", "bytes", repeated=False, required=False, default=None),
+        4: protobuf.Field("global_pubkey", "bytes", repeated=False, required=False, default=None),
     }
 
     def __init__(
@@ -3074,9 +3074,9 @@ class CosiSignature(protobuf.MessageType):
 class Initialize(protobuf.MessageType):
     MESSAGE_WIRE_TYPE = 0
     FIELDS = {
-        1: protobuf.Field("session_id", "bytes", repeated=False, required=False),
-        2: protobuf.Field("_skip_passphrase", "bool", repeated=False, required=False),
-        3: protobuf.Field("derive_cardano", "bool", repeated=False, required=False),
+        1: protobuf.Field("session_id", "bytes", repeated=False, required=False, default=None),
+        2: protobuf.Field("_skip_passphrase", "bool", repeated=False, required=False, default=None),
+        3: protobuf.Field("derive_cardano", "bool", repeated=False, required=False, default=None),
     }
 
     def __init__(
@@ -3098,45 +3098,45 @@ class GetFeatures(protobuf.MessageType):
 class Features(protobuf.MessageType):
     MESSAGE_WIRE_TYPE = 17
     FIELDS = {
-        1: protobuf.Field("vendor", "string", repeated=False, required=False),
+        1: protobuf.Field("vendor", "string", repeated=False, required=False, default=None),
         2: protobuf.Field("major_version", "uint32", repeated=False, required=True),
         3: protobuf.Field("minor_version", "uint32", repeated=False, required=True),
         4: protobuf.Field("patch_version", "uint32", repeated=False, required=True),
-        5: protobuf.Field("bootloader_mode", "bool", repeated=False, required=False),
-        6: protobuf.Field("device_id", "string", repeated=False, required=False),
-        7: protobuf.Field("pin_protection", "bool", repeated=False, required=False),
-        8: protobuf.Field("passphrase_protection", "bool", repeated=False, required=False),
-        9: protobuf.Field("language", "string", repeated=False, required=False),
-        10: protobuf.Field("label", "string", repeated=False, required=False),
-        12: protobuf.Field("initialized", "bool", repeated=False, required=False),
-        13: protobuf.Field("revision", "bytes", repeated=False, required=False),
-        14: protobuf.Field("bootloader_hash", "bytes", repeated=False, required=False),
-        15: protobuf.Field("imported", "bool", repeated=False, required=False),
-        16: protobuf.Field("unlocked", "bool", repeated=False, required=False),
-        17: protobuf.Field("_passphrase_cached", "bool", repeated=False, required=False),
-        18: protobuf.Field("firmware_present", "bool", repeated=False, required=False),
-        19: protobuf.Field("needs_backup", "bool", repeated=False, required=False),
-        20: protobuf.Field("flags", "uint32", repeated=False, required=False),
-        21: protobuf.Field("model", "string", repeated=False, required=False),
-        22: protobuf.Field("fw_major", "uint32", repeated=False, required=False),
-        23: protobuf.Field("fw_minor", "uint32", repeated=False, required=False),
-        24: protobuf.Field("fw_patch", "uint32", repeated=False, required=False),
-        25: protobuf.Field("fw_vendor", "string", repeated=False, required=False),
-        27: protobuf.Field("unfinished_backup", "bool", repeated=False, required=False),
-        28: protobuf.Field("no_backup", "bool", repeated=False, required=False),
-        29: protobuf.Field("recovery_mode", "bool", repeated=False, required=False),
-        30: protobuf.Field("capabilities", "Capability", repeated=True, required=False),
-        31: protobuf.Field("backup_type", "BackupType", repeated=False, required=False),
-        32: protobuf.Field("sd_card_present", "bool", repeated=False, required=False),
-        33: protobuf.Field("sd_protection", "bool", repeated=False, required=False),
-        34: protobuf.Field("wipe_code_protection", "bool", repeated=False, required=False),
-        35: protobuf.Field("session_id", "bytes", repeated=False, required=False),
-        36: protobuf.Field("passphrase_always_on_device", "bool", repeated=False, required=False),
-        37: protobuf.Field("safety_checks", "SafetyCheckLevel", repeated=False, required=False),
-        38: protobuf.Field("auto_lock_delay_ms", "uint32", repeated=False, required=False),
-        39: protobuf.Field("display_rotation", "uint32", repeated=False, required=False),
-        40: protobuf.Field("experimental_features", "bool", repeated=False, required=False),
-        41: protobuf.Field("busy", "bool", repeated=False, required=False),
+        5: protobuf.Field("bootloader_mode", "bool", repeated=False, required=False, default=None),
+        6: protobuf.Field("device_id", "string", repeated=False, required=False, default=None),
+        7: protobuf.Field("pin_protection", "bool", repeated=False, required=False, default=None),
+        8: protobuf.Field("passphrase_protection", "bool", repeated=False, required=False, default=None),
+        9: protobuf.Field("language", "string", repeated=False, required=False, default=None),
+        10: protobuf.Field("label", "string", repeated=False, required=False, default=None),
+        12: protobuf.Field("initialized", "bool", repeated=False, required=False, default=None),
+        13: protobuf.Field("revision", "bytes", repeated=False, required=False, default=None),
+        14: protobuf.Field("bootloader_hash", "bytes", repeated=False, required=False, default=None),
+        15: protobuf.Field("imported", "bool", repeated=False, required=False, default=None),
+        16: protobuf.Field("unlocked", "bool", repeated=False, required=False, default=None),
+        17: protobuf.Field("_passphrase_cached", "bool", repeated=False, required=False, default=None),
+        18: protobuf.Field("firmware_present", "bool", repeated=False, required=False, default=None),
+        19: protobuf.Field("needs_backup", "bool", repeated=False, required=False, default=None),
+        20: protobuf.Field("flags", "uint32", repeated=False, required=False, default=None),
+        21: protobuf.Field("model", "string", repeated=False, required=False, default=None),
+        22: protobuf.Field("fw_major", "uint32", repeated=False, required=False, default=None),
+        23: protobuf.Field("fw_minor", "uint32", repeated=False, required=False, default=None),
+        24: protobuf.Field("fw_patch", "uint32", repeated=False, required=False, default=None),
+        25: protobuf.Field("fw_vendor", "string", repeated=False, required=False, default=None),
+        27: protobuf.Field("unfinished_backup", "bool", repeated=False, required=False, default=None),
+        28: protobuf.Field("no_backup", "bool", repeated=False, required=False, default=None),
+        29: protobuf.Field("recovery_mode", "bool", repeated=False, required=False, default=None),
+        30: protobuf.Field("capabilities", "Capability", repeated=True, required=False, default=None),
+        31: protobuf.Field("backup_type", "BackupType", repeated=False, required=False, default=None),
+        32: protobuf.Field("sd_card_present", "bool", repeated=False, required=False, default=None),
+        33: protobuf.Field("sd_protection", "bool", repeated=False, required=False, default=None),
+        34: protobuf.Field("wipe_code_protection", "bool", repeated=False, required=False, default=None),
+        35: protobuf.Field("session_id", "bytes", repeated=False, required=False, default=None),
+        36: protobuf.Field("passphrase_always_on_device", "bool", repeated=False, required=False, default=None),
+        37: protobuf.Field("safety_checks", "SafetyCheckLevel", repeated=False, required=False, default=None),
+        38: protobuf.Field("auto_lock_delay_ms", "uint32", repeated=False, required=False, default=None),
+        39: protobuf.Field("display_rotation", "uint32", repeated=False, required=False, default=None),
+        40: protobuf.Field("experimental_features", "bool", repeated=False, required=False, default=None),
+        41: protobuf.Field("busy", "bool", repeated=False, required=False, default=None),
     }
 
     def __init__(
@@ -3230,7 +3230,7 @@ class LockDevice(protobuf.MessageType):
 class SetBusy(protobuf.MessageType):
     MESSAGE_WIRE_TYPE = 16
     FIELDS = {
-        1: protobuf.Field("expiry_ms", "uint32", repeated=False, required=False),
+        1: protobuf.Field("expiry_ms", "uint32", repeated=False, required=False, default=None),
     }
 
     def __init__(
@@ -3248,16 +3248,16 @@ class EndSession(protobuf.MessageType):
 class ApplySettings(protobuf.MessageType):
     MESSAGE_WIRE_TYPE = 25
     FIELDS = {
-        1: protobuf.Field("language", "string", repeated=False, required=False),
-        2: protobuf.Field("label", "string", repeated=False, required=False),
-        3: protobuf.Field("use_passphrase", "bool", repeated=False, required=False),
-        4: protobuf.Field("homescreen", "bytes", repeated=False, required=False),
-        5: protobuf.Field("_passphrase_source", "uint32", repeated=False, required=False),
-        6: protobuf.Field("auto_lock_delay_ms", "uint32", repeated=False, required=False),
-        7: protobuf.Field("display_rotation", "uint32", repeated=False, required=False),
-        8: protobuf.Field("passphrase_always_on_device", "bool", repeated=False, required=False),
-        9: protobuf.Field("safety_checks", "SafetyCheckLevel", repeated=False, required=False),
-        10: protobuf.Field("experimental_features", "bool", repeated=False, required=False),
+        1: protobuf.Field("language", "string", repeated=False, required=False, default=None),
+        2: protobuf.Field("label", "string", repeated=False, required=False, default=None),
+        3: protobuf.Field("use_passphrase", "bool", repeated=False, required=False, default=None),
+        4: protobuf.Field("homescreen", "bytes", repeated=False, required=False, default=None),
+        5: protobuf.Field("_passphrase_source", "uint32", repeated=False, required=False, default=None),
+        6: protobuf.Field("auto_lock_delay_ms", "uint32", repeated=False, required=False, default=None),
+        7: protobuf.Field("display_rotation", "uint32", repeated=False, required=False, default=None),
+        8: protobuf.Field("passphrase_always_on_device", "bool", repeated=False, required=False, default=None),
+        9: protobuf.Field("safety_checks", "SafetyCheckLevel", repeated=False, required=False, default=None),
+        10: protobuf.Field("experimental_features", "bool", repeated=False, required=False, default=None),
     }
 
     def __init__(
@@ -3303,7 +3303,7 @@ class ApplyFlags(protobuf.MessageType):
 class ChangePin(protobuf.MessageType):
     MESSAGE_WIRE_TYPE = 4
     FIELDS = {
-        1: protobuf.Field("remove", "bool", repeated=False, required=False),
+        1: protobuf.Field("remove", "bool", repeated=False, required=False, default=None),
     }
 
     def __init__(
@@ -3317,7 +3317,7 @@ class ChangePin(protobuf.MessageType):
 class ChangeWipeCode(protobuf.MessageType):
     MESSAGE_WIRE_TYPE = 82
     FIELDS = {
-        1: protobuf.Field("remove", "bool", repeated=False, required=False),
+        1: protobuf.Field("remove", "bool", repeated=False, required=False, default=None),
     }
 
     def __init__(
@@ -3345,8 +3345,8 @@ class SdProtect(protobuf.MessageType):
 class Ping(protobuf.MessageType):
     MESSAGE_WIRE_TYPE = 1
     FIELDS = {
-        1: protobuf.Field("message", "string", repeated=False, required=False),
-        2: protobuf.Field("button_protection", "bool", repeated=False, required=False),
+        1: protobuf.Field("message", "string", repeated=False, required=False, default=''),
+        2: protobuf.Field("button_protection", "bool", repeated=False, required=False, default=None),
     }
 
     def __init__(
@@ -3394,7 +3394,7 @@ class Entropy(protobuf.MessageType):
 class GetFirmwareHash(protobuf.MessageType):
     MESSAGE_WIRE_TYPE = 88
     FIELDS = {
-        1: protobuf.Field("challenge", "bytes", repeated=False, required=False),
+        1: protobuf.Field("challenge", "bytes", repeated=False, required=False, default=None),
     }
 
     def __init__(
@@ -3426,15 +3426,15 @@ class WipeDevice(protobuf.MessageType):
 class LoadDevice(protobuf.MessageType):
     MESSAGE_WIRE_TYPE = 13
     FIELDS = {
-        1: protobuf.Field("mnemonics", "string", repeated=True, required=False),
-        3: protobuf.Field("pin", "string", repeated=False, required=False),
-        4: protobuf.Field("passphrase_protection", "bool", repeated=False, required=False),
-        5: protobuf.Field("language", "string", repeated=False, required=False),
-        6: protobuf.Field("label", "string", repeated=False, required=False),
-        7: protobuf.Field("skip_checksum", "bool", repeated=False, required=False),
-        8: protobuf.Field("u2f_counter", "uint32", repeated=False, required=False),
-        9: protobuf.Field("needs_backup", "bool", repeated=False, required=False),
-        10: protobuf.Field("no_backup", "bool", repeated=False, required=False),
+        1: protobuf.Field("mnemonics", "string", repeated=True, required=False, default=None),
+        3: protobuf.Field("pin", "string", repeated=False, required=False, default=None),
+        4: protobuf.Field("passphrase_protection", "bool", repeated=False, required=False, default=None),
+        5: protobuf.Field("language", "string", repeated=False, required=False, default='en-US'),
+        6: protobuf.Field("label", "string", repeated=False, required=False, default=None),
+        7: protobuf.Field("skip_checksum", "bool", repeated=False, required=False, default=None),
+        8: protobuf.Field("u2f_counter", "uint32", repeated=False, required=False, default=None),
+        9: protobuf.Field("needs_backup", "bool", repeated=False, required=False, default=None),
+        10: protobuf.Field("no_backup", "bool", repeated=False, required=False, default=None),
     }
 
     def __init__(
@@ -3464,16 +3464,16 @@ class LoadDevice(protobuf.MessageType):
 class ResetDevice(protobuf.MessageType):
     MESSAGE_WIRE_TYPE = 14
     FIELDS = {
-        1: protobuf.Field("display_random", "bool", repeated=False, required=False),
-        2: protobuf.Field("strength", "uint32", repeated=False, required=False),
-        3: protobuf.Field("passphrase_protection", "bool", repeated=False, required=False),
-        4: protobuf.Field("pin_protection", "bool", repeated=False, required=False),
-        5: protobuf.Field("language", "string", repeated=False, required=False),
-        6: protobuf.Field("label", "string", repeated=False, required=False),
-        7: protobuf.Field("u2f_counter", "uint32", repeated=False, required=False),
-        8: protobuf.Field("skip_backup", "bool", repeated=False, required=False),
-        9: protobuf.Field("no_backup", "bool", repeated=False, required=False),
-        10: protobuf.Field("backup_type", "BackupType", repeated=False, required=False),
+        1: protobuf.Field("display_random", "bool", repeated=False, required=False, default=None),
+        2: protobuf.Field("strength", "uint32", repeated=False, required=False, default=256),
+        3: protobuf.Field("passphrase_protection", "bool", repeated=False, required=False, default=None),
+        4: protobuf.Field("pin_protection", "bool", repeated=False, required=False, default=None),
+        5: protobuf.Field("language", "string", repeated=False, required=False, default='en-US'),
+        6: protobuf.Field("label", "string", repeated=False, required=False, default=None),
+        7: protobuf.Field("u2f_counter", "uint32", repeated=False, required=False, default=None),
+        8: protobuf.Field("skip_backup", "bool", repeated=False, required=False, default=None),
+        9: protobuf.Field("no_backup", "bool", repeated=False, required=False, default=None),
+        10: protobuf.Field("backup_type", "BackupType", repeated=False, required=False, default=BackupType.Bip39),
     }
 
     def __init__(
@@ -3527,15 +3527,15 @@ class EntropyAck(protobuf.MessageType):
 class RecoveryDevice(protobuf.MessageType):
     MESSAGE_WIRE_TYPE = 45
     FIELDS = {
-        1: protobuf.Field("word_count", "uint32", repeated=False, required=False),
-        2: protobuf.Field("passphrase_protection", "bool", repeated=False, required=False),
-        3: protobuf.Field("pin_protection", "bool", repeated=False, required=False),
-        4: protobuf.Field("language", "string", repeated=False, required=False),
-        5: protobuf.Field("label", "string", repeated=False, required=False),
-        6: protobuf.Field("enforce_wordlist", "bool", repeated=False, required=False),
-        8: protobuf.Field("type", "RecoveryDeviceType", repeated=False, required=False),
-        9: protobuf.Field("u2f_counter", "uint32", repeated=False, required=False),
-        10: protobuf.Field("dry_run", "bool", repeated=False, required=False),
+        1: protobuf.Field("word_count", "uint32", repeated=False, required=False, default=None),
+        2: protobuf.Field("passphrase_protection", "bool", repeated=False, required=False, default=None),
+        3: protobuf.Field("pin_protection", "bool", repeated=False, required=False, default=None),
+        4: protobuf.Field("language", "string", repeated=False, required=False, default=None),
+        5: protobuf.Field("label", "string", repeated=False, required=False, default=None),
+        6: protobuf.Field("enforce_wordlist", "bool", repeated=False, required=False, default=None),
+        8: protobuf.Field("type", "RecoveryDeviceType", repeated=False, required=False, default=None),
+        9: protobuf.Field("u2f_counter", "uint32", repeated=False, required=False, default=None),
+        10: protobuf.Field("dry_run", "bool", repeated=False, required=False, default=None),
     }
 
     def __init__(
@@ -3659,8 +3659,8 @@ class Nonce(protobuf.MessageType):
 class UnlockPath(protobuf.MessageType):
     MESSAGE_WIRE_TYPE = 93
     FIELDS = {
-        1: protobuf.Field("address_n", "uint32", repeated=True, required=False),
-        2: protobuf.Field("mac", "bytes", repeated=False, required=False),
+        1: protobuf.Field("address_n", "uint32", repeated=True, required=False, default=None),
+        2: protobuf.Field("mac", "bytes", repeated=False, required=False, default=None),
     }
 
     def __init__(
@@ -3676,7 +3676,7 @@ class UnlockPath(protobuf.MessageType):
 class UnlockedPathRequest(protobuf.MessageType):
     MESSAGE_WIRE_TYPE = 94
     FIELDS = {
-        1: protobuf.Field("mac", "bytes", repeated=False, required=False),
+        1: protobuf.Field("mac", "bytes", repeated=False, required=False, default=None),
     }
 
     def __init__(
@@ -3690,13 +3690,13 @@ class UnlockedPathRequest(protobuf.MessageType):
 class DebugLinkDecision(protobuf.MessageType):
     MESSAGE_WIRE_TYPE = 100
     FIELDS = {
-        1: protobuf.Field("button", "DebugButton", repeated=False, required=False),
-        2: protobuf.Field("swipe", "DebugSwipeDirection", repeated=False, required=False),
-        3: protobuf.Field("input", "string", repeated=False, required=False),
-        4: protobuf.Field("x", "uint32", repeated=False, required=False),
-        5: protobuf.Field("y", "uint32", repeated=False, required=False),
-        6: protobuf.Field("wait", "bool", repeated=False, required=False),
-        7: protobuf.Field("hold_ms", "uint32", repeated=False, required=False),
+        1: protobuf.Field("button", "DebugButton", repeated=False, required=False, default=None),
+        2: protobuf.Field("swipe", "DebugSwipeDirection", repeated=False, required=False, default=None),
+        3: protobuf.Field("input", "string", repeated=False, required=False, default=None),
+        4: protobuf.Field("x", "uint32", repeated=False, required=False, default=None),
+        5: protobuf.Field("y", "uint32", repeated=False, required=False, default=None),
+        6: protobuf.Field("wait", "bool", repeated=False, required=False, default=None),
+        7: protobuf.Field("hold_ms", "uint32", repeated=False, required=False, default=None),
     }
 
     def __init__(
@@ -3722,7 +3722,7 @@ class DebugLinkDecision(protobuf.MessageType):
 class DebugLinkLayout(protobuf.MessageType):
     MESSAGE_WIRE_TYPE = 9001
     FIELDS = {
-        1: protobuf.Field("lines", "string", repeated=True, required=False),
+        1: protobuf.Field("lines", "string", repeated=True, required=False, default=None),
     }
 
     def __init__(
@@ -3736,7 +3736,7 @@ class DebugLinkLayout(protobuf.MessageType):
 class DebugLinkReseedRandom(protobuf.MessageType):
     MESSAGE_WIRE_TYPE = 9002
     FIELDS = {
-        1: protobuf.Field("value", "uint32", repeated=False, required=False),
+        1: protobuf.Field("value", "uint32", repeated=False, required=False, default=None),
     }
 
     def __init__(
@@ -3750,7 +3750,7 @@ class DebugLinkReseedRandom(protobuf.MessageType):
 class DebugLinkRecordScreen(protobuf.MessageType):
     MESSAGE_WIRE_TYPE = 9003
     FIELDS = {
-        1: protobuf.Field("target_directory", "string", repeated=False, required=False),
+        1: protobuf.Field("target_directory", "string", repeated=False, required=False, default=None),
     }
 
     def __init__(
@@ -3764,9 +3764,9 @@ class DebugLinkRecordScreen(protobuf.MessageType):
 class DebugLinkGetState(protobuf.MessageType):
     MESSAGE_WIRE_TYPE = 101
     FIELDS = {
-        1: protobuf.Field("wait_word_list", "bool", repeated=False, required=False),
-        2: protobuf.Field("wait_word_pos", "bool", repeated=False, required=False),
-        3: protobuf.Field("wait_layout", "bool", repeated=False, required=False),
+        1: protobuf.Field("wait_word_list", "bool", repeated=False, required=False, default=None),
+        2: protobuf.Field("wait_word_pos", "bool", repeated=False, required=False, default=None),
+        3: protobuf.Field("wait_layout", "bool", repeated=False, required=False, default=None),
     }
 
     def __init__(
@@ -3784,19 +3784,19 @@ class DebugLinkGetState(protobuf.MessageType):
 class DebugLinkState(protobuf.MessageType):
     MESSAGE_WIRE_TYPE = 102
     FIELDS = {
-        1: protobuf.Field("layout", "bytes", repeated=False, required=False),
-        2: protobuf.Field("pin", "string", repeated=False, required=False),
-        3: protobuf.Field("matrix", "string", repeated=False, required=False),
-        4: protobuf.Field("mnemonic_secret", "bytes", repeated=False, required=False),
-        5: protobuf.Field("node", "HDNodeType", repeated=False, required=False),
-        6: protobuf.Field("passphrase_protection", "bool", repeated=False, required=False),
-        7: protobuf.Field("reset_word", "string", repeated=False, required=False),
-        8: protobuf.Field("reset_entropy", "bytes", repeated=False, required=False),
-        9: protobuf.Field("recovery_fake_word", "string", repeated=False, required=False),
-        10: protobuf.Field("recovery_word_pos", "uint32", repeated=False, required=False),
-        11: protobuf.Field("reset_word_pos", "uint32", repeated=False, required=False),
-        12: protobuf.Field("mnemonic_type", "BackupType", repeated=False, required=False),
-        13: protobuf.Field("layout_lines", "string", repeated=True, required=False),
+        1: protobuf.Field("layout", "bytes", repeated=False, required=False, default=None),
+        2: protobuf.Field("pin", "string", repeated=False, required=False, default=None),
+        3: protobuf.Field("matrix", "string", repeated=False, required=False, default=None),
+        4: protobuf.Field("mnemonic_secret", "bytes", repeated=False, required=False, default=None),
+        5: protobuf.Field("node", "HDNodeType", repeated=False, required=False, default=None),
+        6: protobuf.Field("passphrase_protection", "bool", repeated=False, required=False, default=None),
+        7: protobuf.Field("reset_word", "string", repeated=False, required=False, default=None),
+        8: protobuf.Field("reset_entropy", "bytes", repeated=False, required=False, default=None),
+        9: protobuf.Field("recovery_fake_word", "string", repeated=False, required=False, default=None),
+        10: protobuf.Field("recovery_word_pos", "uint32", repeated=False, required=False, default=None),
+        11: protobuf.Field("reset_word_pos", "uint32", repeated=False, required=False, default=None),
+        12: protobuf.Field("mnemonic_type", "BackupType", repeated=False, required=False, default=None),
+        13: protobuf.Field("layout_lines", "string", repeated=True, required=False, default=None),
     }
 
     def __init__(
@@ -3838,9 +3838,9 @@ class DebugLinkStop(protobuf.MessageType):
 class DebugLinkLog(protobuf.MessageType):
     MESSAGE_WIRE_TYPE = 104
     FIELDS = {
-        1: protobuf.Field("level", "uint32", repeated=False, required=False),
-        2: protobuf.Field("bucket", "string", repeated=False, required=False),
-        3: protobuf.Field("text", "string", repeated=False, required=False),
+        1: protobuf.Field("level", "uint32", repeated=False, required=False, default=None),
+        2: protobuf.Field("bucket", "string", repeated=False, required=False, default=None),
+        3: protobuf.Field("text", "string", repeated=False, required=False, default=None),
     }
 
     def __init__(
@@ -3858,8 +3858,8 @@ class DebugLinkLog(protobuf.MessageType):
 class DebugLinkMemoryRead(protobuf.MessageType):
     MESSAGE_WIRE_TYPE = 110
     FIELDS = {
-        1: protobuf.Field("address", "uint32", repeated=False, required=False),
-        2: protobuf.Field("length", "uint32", repeated=False, required=False),
+        1: protobuf.Field("address", "uint32", repeated=False, required=False, default=None),
+        2: protobuf.Field("length", "uint32", repeated=False, required=False, default=None),
     }
 
     def __init__(
@@ -3875,7 +3875,7 @@ class DebugLinkMemoryRead(protobuf.MessageType):
 class DebugLinkMemory(protobuf.MessageType):
     MESSAGE_WIRE_TYPE = 111
     FIELDS = {
-        1: protobuf.Field("memory", "bytes", repeated=False, required=False),
+        1: protobuf.Field("memory", "bytes", repeated=False, required=False, default=None),
     }
 
     def __init__(
@@ -3889,9 +3889,9 @@ class DebugLinkMemory(protobuf.MessageType):
 class DebugLinkMemoryWrite(protobuf.MessageType):
     MESSAGE_WIRE_TYPE = 112
     FIELDS = {
-        1: protobuf.Field("address", "uint32", repeated=False, required=False),
-        2: protobuf.Field("memory", "bytes", repeated=False, required=False),
-        3: protobuf.Field("flash", "bool", repeated=False, required=False),
+        1: protobuf.Field("address", "uint32", repeated=False, required=False, default=None),
+        2: protobuf.Field("memory", "bytes", repeated=False, required=False, default=None),
+        3: protobuf.Field("flash", "bool", repeated=False, required=False, default=None),
     }
 
     def __init__(
@@ -3909,7 +3909,7 @@ class DebugLinkMemoryWrite(protobuf.MessageType):
 class DebugLinkFlashErase(protobuf.MessageType):
     MESSAGE_WIRE_TYPE = 113
     FIELDS = {
-        1: protobuf.Field("sector", "uint32", repeated=False, required=False),
+        1: protobuf.Field("sector", "uint32", repeated=False, required=False, default=None),
     }
 
     def __init__(
@@ -3923,7 +3923,7 @@ class DebugLinkFlashErase(protobuf.MessageType):
 class DebugLinkEraseSdCard(protobuf.MessageType):
     MESSAGE_WIRE_TYPE = 9005
     FIELDS = {
-        1: protobuf.Field("format", "bool", repeated=False, required=False),
+        1: protobuf.Field("format", "bool", repeated=False, required=False, default=None),
     }
 
     def __init__(
@@ -3937,7 +3937,7 @@ class DebugLinkEraseSdCard(protobuf.MessageType):
 class DebugLinkWatchLayout(protobuf.MessageType):
     MESSAGE_WIRE_TYPE = 9006
     FIELDS = {
-        1: protobuf.Field("watch", "bool", repeated=False, required=False),
+        1: protobuf.Field("watch", "bool", repeated=False, required=False, default=None),
     }
 
     def __init__(
@@ -3951,8 +3951,8 @@ class DebugLinkWatchLayout(protobuf.MessageType):
 class EosGetPublicKey(protobuf.MessageType):
     MESSAGE_WIRE_TYPE = 600
     FIELDS = {
-        1: protobuf.Field("address_n", "uint32", repeated=True, required=False),
-        2: protobuf.Field("show_display", "bool", repeated=False, required=False),
+        1: protobuf.Field("address_n", "uint32", repeated=True, required=False, default=None),
+        2: protobuf.Field("show_display", "bool", repeated=False, required=False, default=None),
     }
 
     def __init__(
@@ -3985,7 +3985,7 @@ class EosPublicKey(protobuf.MessageType):
 class EosSignTx(protobuf.MessageType):
     MESSAGE_WIRE_TYPE = 602
     FIELDS = {
-        1: protobuf.Field("address_n", "uint32", repeated=True, required=False),
+        1: protobuf.Field("address_n", "uint32", repeated=True, required=False, default=None),
         2: protobuf.Field("chain_id", "bytes", repeated=False, required=True),
         3: protobuf.Field("header", "EosTxHeader", repeated=False, required=True),
         4: protobuf.Field("num_actions", "uint32", repeated=False, required=True),
@@ -4008,7 +4008,7 @@ class EosSignTx(protobuf.MessageType):
 class EosTxActionRequest(protobuf.MessageType):
     MESSAGE_WIRE_TYPE = 603
     FIELDS = {
-        1: protobuf.Field("data_size", "uint32", repeated=False, required=False),
+        1: protobuf.Field("data_size", "uint32", repeated=False, required=False, default=None),
     }
 
     def __init__(
@@ -4023,20 +4023,20 @@ class EosTxActionAck(protobuf.MessageType):
     MESSAGE_WIRE_TYPE = 604
     FIELDS = {
         1: protobuf.Field("common", "EosActionCommon", repeated=False, required=True),
-        2: protobuf.Field("transfer", "EosActionTransfer", repeated=False, required=False),
-        3: protobuf.Field("delegate", "EosActionDelegate", repeated=False, required=False),
-        4: protobuf.Field("undelegate", "EosActionUndelegate", repeated=False, required=False),
-        5: protobuf.Field("refund", "EosActionRefund", repeated=False, required=False),
-        6: protobuf.Field("buy_ram", "EosActionBuyRam", repeated=False, required=False),
-        7: protobuf.Field("buy_ram_bytes", "EosActionBuyRamBytes", repeated=False, required=False),
-        8: protobuf.Field("sell_ram", "EosActionSellRam", repeated=False, required=False),
-        9: protobuf.Field("vote_producer", "EosActionVoteProducer", repeated=False, required=False),
-        10: protobuf.Field("update_auth", "EosActionUpdateAuth", repeated=False, required=False),
-        11: protobuf.Field("delete_auth", "EosActionDeleteAuth", repeated=False, required=False),
-        12: protobuf.Field("link_auth", "EosActionLinkAuth", repeated=False, required=False),
-        13: protobuf.Field("unlink_auth", "EosActionUnlinkAuth", repeated=False, required=False),
-        14: protobuf.Field("new_account", "EosActionNewAccount", repeated=False, required=False),
-        15: protobuf.Field("unknown", "EosActionUnknown", repeated=False, required=False),
+        2: protobuf.Field("transfer", "EosActionTransfer", repeated=False, required=False, default=None),
+        3: protobuf.Field("delegate", "EosActionDelegate", repeated=False, required=False, default=None),
+        4: protobuf.Field("undelegate", "EosActionUndelegate", repeated=False, required=False, default=None),
+        5: protobuf.Field("refund", "EosActionRefund", repeated=False, required=False, default=None),
+        6: protobuf.Field("buy_ram", "EosActionBuyRam", repeated=False, required=False, default=None),
+        7: protobuf.Field("buy_ram_bytes", "EosActionBuyRamBytes", repeated=False, required=False, default=None),
+        8: protobuf.Field("sell_ram", "EosActionSellRam", repeated=False, required=False, default=None),
+        9: protobuf.Field("vote_producer", "EosActionVoteProducer", repeated=False, required=False, default=None),
+        10: protobuf.Field("update_auth", "EosActionUpdateAuth", repeated=False, required=False, default=None),
+        11: protobuf.Field("delete_auth", "EosActionDeleteAuth", repeated=False, required=False, default=None),
+        12: protobuf.Field("link_auth", "EosActionLinkAuth", repeated=False, required=False, default=None),
+        13: protobuf.Field("unlink_auth", "EosActionUnlinkAuth", repeated=False, required=False, default=None),
+        14: protobuf.Field("new_account", "EosActionNewAccount", repeated=False, required=False, default=None),
+        15: protobuf.Field("unknown", "EosActionUnknown", repeated=False, required=False, default=None),
     }
 
     def __init__(
@@ -4156,8 +4156,8 @@ class EosAuthorizationKey(protobuf.MessageType):
     MESSAGE_WIRE_TYPE = None
     FIELDS = {
         1: protobuf.Field("type", "uint32", repeated=False, required=True),
-        2: protobuf.Field("key", "bytes", repeated=False, required=False),
-        3: protobuf.Field("address_n", "uint32", repeated=True, required=False),
+        2: protobuf.Field("key", "bytes", repeated=False, required=False, default=None),
+        3: protobuf.Field("address_n", "uint32", repeated=True, required=False, default=None),
         4: protobuf.Field("weight", "uint32", repeated=False, required=True),
     }
 
@@ -4213,9 +4213,9 @@ class EosAuthorization(protobuf.MessageType):
     MESSAGE_WIRE_TYPE = None
     FIELDS = {
         1: protobuf.Field("threshold", "uint32", repeated=False, required=True),
-        2: protobuf.Field("keys", "EosAuthorizationKey", repeated=True, required=False),
-        3: protobuf.Field("accounts", "EosAuthorizationAccount", repeated=True, required=False),
-        4: protobuf.Field("waits", "EosAuthorizationWait", repeated=True, required=False),
+        2: protobuf.Field("keys", "EosAuthorizationKey", repeated=True, required=False, default=None),
+        3: protobuf.Field("accounts", "EosAuthorizationAccount", repeated=True, required=False, default=None),
+        4: protobuf.Field("waits", "EosAuthorizationWait", repeated=True, required=False, default=None),
     }
 
     def __init__(
@@ -4237,7 +4237,7 @@ class EosActionCommon(protobuf.MessageType):
     FIELDS = {
         1: protobuf.Field("account", "uint64", repeated=False, required=True),
         2: protobuf.Field("name", "uint64", repeated=False, required=True),
-        3: protobuf.Field("authorization", "EosPermissionLevel", repeated=True, required=False),
+        3: protobuf.Field("authorization", "EosPermissionLevel", repeated=True, required=False, default=None),
     }
 
     def __init__(
@@ -4400,7 +4400,7 @@ class EosActionVoteProducer(protobuf.MessageType):
     FIELDS = {
         1: protobuf.Field("voter", "uint64", repeated=False, required=True),
         2: protobuf.Field("proxy", "uint64", repeated=False, required=True),
-        3: protobuf.Field("producers", "uint64", repeated=True, required=False),
+        3: protobuf.Field("producers", "uint64", repeated=True, required=False, default=None),
     }
 
     def __init__(
@@ -4541,9 +4541,9 @@ class EosActionUnknown(protobuf.MessageType):
 class EthereumSignTypedData(protobuf.MessageType):
     MESSAGE_WIRE_TYPE = 464
     FIELDS = {
-        1: protobuf.Field("address_n", "uint32", repeated=True, required=False),
+        1: protobuf.Field("address_n", "uint32", repeated=True, required=False, default=None),
         2: protobuf.Field("primary_type", "string", repeated=False, required=True),
-        3: protobuf.Field("metamask_v4_compat", "bool", repeated=False, required=False),
+        3: protobuf.Field("metamask_v4_compat", "bool", repeated=False, required=False, default=True),
     }
 
     def __init__(
@@ -4575,7 +4575,7 @@ class EthereumTypedDataStructRequest(protobuf.MessageType):
 class EthereumTypedDataStructAck(protobuf.MessageType):
     MESSAGE_WIRE_TYPE = 466
     FIELDS = {
-        1: protobuf.Field("members", "EthereumStructMember", repeated=True, required=False),
+        1: protobuf.Field("members", "EthereumStructMember", repeated=True, required=False, default=None),
     }
 
     def __init__(
@@ -4589,7 +4589,7 @@ class EthereumTypedDataStructAck(protobuf.MessageType):
 class EthereumTypedDataValueRequest(protobuf.MessageType):
     MESSAGE_WIRE_TYPE = 467
     FIELDS = {
-        1: protobuf.Field("member_path", "uint32", repeated=True, required=False),
+        1: protobuf.Field("member_path", "uint32", repeated=True, required=False, default=None),
     }
 
     def __init__(
@@ -4635,9 +4635,9 @@ class EthereumFieldType(protobuf.MessageType):
     MESSAGE_WIRE_TYPE = None
     FIELDS = {
         1: protobuf.Field("data_type", "EthereumDataType", repeated=False, required=True),
-        2: protobuf.Field("size", "uint32", repeated=False, required=False),
-        3: protobuf.Field("entry_type", "EthereumFieldType", repeated=False, required=False),
-        4: protobuf.Field("struct_name", "string", repeated=False, required=False),
+        2: protobuf.Field("size", "uint32", repeated=False, required=False, default=None),
+        3: protobuf.Field("entry_type", "EthereumFieldType", repeated=False, required=False, default=None),
+        4: protobuf.Field("struct_name", "string", repeated=False, required=False, default=None),
     }
 
     def __init__(
@@ -4657,8 +4657,8 @@ class EthereumFieldType(protobuf.MessageType):
 class EthereumGetPublicKey(protobuf.MessageType):
     MESSAGE_WIRE_TYPE = 450
     FIELDS = {
-        1: protobuf.Field("address_n", "uint32", repeated=True, required=False),
-        2: protobuf.Field("show_display", "bool", repeated=False, required=False),
+        1: protobuf.Field("address_n", "uint32", repeated=True, required=False, default=None),
+        2: protobuf.Field("show_display", "bool", repeated=False, required=False, default=None),
     }
 
     def __init__(
@@ -4691,8 +4691,8 @@ class EthereumPublicKey(protobuf.MessageType):
 class EthereumGetAddress(protobuf.MessageType):
     MESSAGE_WIRE_TYPE = 56
     FIELDS = {
-        1: protobuf.Field("address_n", "uint32", repeated=True, required=False),
-        2: protobuf.Field("show_display", "bool", repeated=False, required=False),
+        1: protobuf.Field("address_n", "uint32", repeated=True, required=False, default=None),
+        2: protobuf.Field("show_display", "bool", repeated=False, required=False, default=None),
     }
 
     def __init__(
@@ -4708,8 +4708,8 @@ class EthereumGetAddress(protobuf.MessageType):
 class EthereumAddress(protobuf.MessageType):
     MESSAGE_WIRE_TYPE = 57
     FIELDS = {
-        1: protobuf.Field("_old_address", "bytes", repeated=False, required=False),
-        2: protobuf.Field("address", "string", repeated=False, required=False),
+        1: protobuf.Field("_old_address", "bytes", repeated=False, required=False, default=None),
+        2: protobuf.Field("address", "string", repeated=False, required=False, default=None),
     }
 
     def __init__(
@@ -4725,16 +4725,16 @@ class EthereumAddress(protobuf.MessageType):
 class EthereumSignTx(protobuf.MessageType):
     MESSAGE_WIRE_TYPE = 58
     FIELDS = {
-        1: protobuf.Field("address_n", "uint32", repeated=True, required=False),
-        2: protobuf.Field("nonce", "bytes", repeated=False, required=False),
+        1: protobuf.Field("address_n", "uint32", repeated=True, required=False, default=None),
+        2: protobuf.Field("nonce", "bytes", repeated=False, required=False, default=b''),
         3: protobuf.Field("gas_price", "bytes", repeated=False, required=True),
         4: protobuf.Field("gas_limit", "bytes", repeated=False, required=True),
-        11: protobuf.Field("to", "string", repeated=False, required=False),
-        6: protobuf.Field("value", "bytes", repeated=False, required=False),
-        7: protobuf.Field("data_initial_chunk", "bytes", repeated=False, required=False),
-        8: protobuf.Field("data_length", "uint32", repeated=False, required=False),
+        11: protobuf.Field("to", "string", repeated=False, required=False, default=''),
+        6: protobuf.Field("value", "bytes", repeated=False, required=False, default=b''),
+        7: protobuf.Field("data_initial_chunk", "bytes", repeated=False, required=False, default=b''),
+        8: protobuf.Field("data_length", "uint32", repeated=False, required=False, default=0),
         9: protobuf.Field("chain_id", "uint64", repeated=False, required=True),
-        10: protobuf.Field("tx_type", "uint32", repeated=False, required=False),
+        10: protobuf.Field("tx_type", "uint32", repeated=False, required=False, default=None),
     }
 
     def __init__(
@@ -4766,17 +4766,17 @@ class EthereumSignTx(protobuf.MessageType):
 class EthereumSignTxEIP1559(protobuf.MessageType):
     MESSAGE_WIRE_TYPE = 452
     FIELDS = {
-        1: protobuf.Field("address_n", "uint32", repeated=True, required=False),
+        1: protobuf.Field("address_n", "uint32", repeated=True, required=False, default=None),
         2: protobuf.Field("nonce", "bytes", repeated=False, required=True),
         3: protobuf.Field("max_gas_fee", "bytes", repeated=False, required=True),
         4: protobuf.Field("max_priority_fee", "bytes", repeated=False, required=True),
         5: protobuf.Field("gas_limit", "bytes", repeated=False, required=True),
-        6: protobuf.Field("to", "string", repeated=False, required=False),
+        6: protobuf.Field("to", "string", repeated=False, required=False, default=''),
         7: protobuf.Field("value", "bytes", repeated=False, required=True),
-        8: protobuf.Field("data_initial_chunk", "bytes", repeated=False, required=False),
+        8: protobuf.Field("data_initial_chunk", "bytes", repeated=False, required=False, default=b''),
         9: protobuf.Field("data_length", "uint32", repeated=False, required=True),
         10: protobuf.Field("chain_id", "uint64", repeated=False, required=True),
-        11: protobuf.Field("access_list", "EthereumAccessList", repeated=True, required=False),
+        11: protobuf.Field("access_list", "EthereumAccessList", repeated=True, required=False, default=None),
     }
 
     def __init__(
@@ -4810,10 +4810,10 @@ class EthereumSignTxEIP1559(protobuf.MessageType):
 class EthereumTxRequest(protobuf.MessageType):
     MESSAGE_WIRE_TYPE = 59
     FIELDS = {
-        1: protobuf.Field("data_length", "uint32", repeated=False, required=False),
-        2: protobuf.Field("signature_v", "uint32", repeated=False, required=False),
-        3: protobuf.Field("signature_r", "bytes", repeated=False, required=False),
-        4: protobuf.Field("signature_s", "bytes", repeated=False, required=False),
+        1: protobuf.Field("data_length", "uint32", repeated=False, required=False, default=None),
+        2: protobuf.Field("signature_v", "uint32", repeated=False, required=False, default=None),
+        3: protobuf.Field("signature_r", "bytes", repeated=False, required=False, default=None),
+        4: protobuf.Field("signature_s", "bytes", repeated=False, required=False, default=None),
     }
 
     def __init__(
@@ -4847,7 +4847,7 @@ class EthereumTxAck(protobuf.MessageType):
 class EthereumSignMessage(protobuf.MessageType):
     MESSAGE_WIRE_TYPE = 64
     FIELDS = {
-        1: protobuf.Field("address_n", "uint32", repeated=True, required=False),
+        1: protobuf.Field("address_n", "uint32", repeated=True, required=False, default=None),
         2: protobuf.Field("message", "bytes", repeated=False, required=True),
     }
 
@@ -4901,9 +4901,9 @@ class EthereumVerifyMessage(protobuf.MessageType):
 class EthereumSignTypedHash(protobuf.MessageType):
     MESSAGE_WIRE_TYPE = 470
     FIELDS = {
-        1: protobuf.Field("address_n", "uint32", repeated=True, required=False),
+        1: protobuf.Field("address_n", "uint32", repeated=True, required=False, default=None),
         2: protobuf.Field("domain_separator_hash", "bytes", repeated=False, required=True),
-        3: protobuf.Field("message_hash", "bytes", repeated=False, required=False),
+        3: protobuf.Field("message_hash", "bytes", repeated=False, required=False, default=None),
     }
 
     def __init__(
@@ -4939,7 +4939,7 @@ class EthereumAccessList(protobuf.MessageType):
     MESSAGE_WIRE_TYPE = None
     FIELDS = {
         1: protobuf.Field("address", "string", repeated=False, required=True),
-        2: protobuf.Field("storage_keys", "bytes", repeated=True, required=False),
+        2: protobuf.Field("storage_keys", "bytes", repeated=True, required=False, default=None),
     }
 
     def __init__(
@@ -4955,16 +4955,16 @@ class EthereumAccessList(protobuf.MessageType):
 class MoneroTransactionSourceEntry(protobuf.MessageType):
     MESSAGE_WIRE_TYPE = None
     FIELDS = {
-        1: protobuf.Field("outputs", "MoneroOutputEntry", repeated=True, required=False),
-        2: protobuf.Field("real_output", "uint64", repeated=False, required=False),
-        3: protobuf.Field("real_out_tx_key", "bytes", repeated=False, required=False),
-        4: protobuf.Field("real_out_additional_tx_keys", "bytes", repeated=True, required=False),
-        5: protobuf.Field("real_output_in_tx_index", "uint64", repeated=False, required=False),
-        6: protobuf.Field("amount", "uint64", repeated=False, required=False),
-        7: protobuf.Field("rct", "bool", repeated=False, required=False),
-        8: protobuf.Field("mask", "bytes", repeated=False, required=False),
-        9: protobuf.Field("multisig_kLRki", "MoneroMultisigKLRki", repeated=False, required=False),
-        10: protobuf.Field("subaddr_minor", "uint32", repeated=False, required=False),
+        1: protobuf.Field("outputs", "MoneroOutputEntry", repeated=True, required=False, default=None),
+        2: protobuf.Field("real_output", "uint64", repeated=False, required=False, default=None),
+        3: protobuf.Field("real_out_tx_key", "bytes", repeated=False, required=False, default=None),
+        4: protobuf.Field("real_out_additional_tx_keys", "bytes", repeated=True, required=False, default=None),
+        5: protobuf.Field("real_output_in_tx_index", "uint64", repeated=False, required=False, default=None),
+        6: protobuf.Field("amount", "uint64", repeated=False, required=False, default=None),
+        7: protobuf.Field("rct", "bool", repeated=False, required=False, default=None),
+        8: protobuf.Field("mask", "bytes", repeated=False, required=False, default=None),
+        9: protobuf.Field("multisig_kLRki", "MoneroMultisigKLRki", repeated=False, required=False, default=None),
+        10: protobuf.Field("subaddr_minor", "uint32", repeated=False, required=False, default=None),
     }
 
     def __init__(
@@ -4996,11 +4996,11 @@ class MoneroTransactionSourceEntry(protobuf.MessageType):
 class MoneroTransactionDestinationEntry(protobuf.MessageType):
     MESSAGE_WIRE_TYPE = None
     FIELDS = {
-        1: protobuf.Field("amount", "uint64", repeated=False, required=False),
-        2: protobuf.Field("addr", "MoneroAccountPublicAddress", repeated=False, required=False),
-        3: protobuf.Field("is_subaddress", "bool", repeated=False, required=False),
-        4: protobuf.Field("original", "bytes", repeated=False, required=False),
-        5: protobuf.Field("is_integrated", "bool", repeated=False, required=False),
+        1: protobuf.Field("amount", "uint64", repeated=False, required=False, default=None),
+        2: protobuf.Field("addr", "MoneroAccountPublicAddress", repeated=False, required=False, default=None),
+        3: protobuf.Field("is_subaddress", "bool", repeated=False, required=False, default=None),
+        4: protobuf.Field("original", "bytes", repeated=False, required=False, default=None),
+        5: protobuf.Field("is_integrated", "bool", repeated=False, required=False, default=None),
     }
 
     def __init__(
@@ -5022,13 +5022,13 @@ class MoneroTransactionDestinationEntry(protobuf.MessageType):
 class MoneroTransactionRsigData(protobuf.MessageType):
     MESSAGE_WIRE_TYPE = None
     FIELDS = {
-        1: protobuf.Field("rsig_type", "uint32", repeated=False, required=False),
-        2: protobuf.Field("offload_type", "uint32", repeated=False, required=False),
-        3: protobuf.Field("grouping", "uint64", repeated=True, required=False),
-        4: protobuf.Field("mask", "bytes", repeated=False, required=False),
-        5: protobuf.Field("rsig", "bytes", repeated=False, required=False),
-        6: protobuf.Field("rsig_parts", "bytes", repeated=True, required=False),
-        7: protobuf.Field("bp_version", "uint32", repeated=False, required=False),
+        1: protobuf.Field("rsig_type", "uint32", repeated=False, required=False, default=None),
+        2: protobuf.Field("offload_type", "uint32", repeated=False, required=False, default=None),
+        3: protobuf.Field("grouping", "uint64", repeated=True, required=False, default=None),
+        4: protobuf.Field("mask", "bytes", repeated=False, required=False, default=None),
+        5: protobuf.Field("rsig", "bytes", repeated=False, required=False, default=None),
+        6: protobuf.Field("rsig_parts", "bytes", repeated=True, required=False, default=None),
+        7: protobuf.Field("bp_version", "uint32", repeated=False, required=False, default=None),
     }
 
     def __init__(
@@ -5054,12 +5054,12 @@ class MoneroTransactionRsigData(protobuf.MessageType):
 class MoneroGetAddress(protobuf.MessageType):
     MESSAGE_WIRE_TYPE = 540
     FIELDS = {
-        1: protobuf.Field("address_n", "uint32", repeated=True, required=False),
-        2: protobuf.Field("show_display", "bool", repeated=False, required=False),
-        3: protobuf.Field("network_type", "MoneroNetworkType", repeated=False, required=False),
-        4: protobuf.Field("account", "uint32", repeated=False, required=False),
-        5: protobuf.Field("minor", "uint32", repeated=False, required=False),
-        6: protobuf.Field("payment_id", "bytes", repeated=False, required=False),
+        1: protobuf.Field("address_n", "uint32", repeated=True, required=False, default=None),
+        2: protobuf.Field("show_display", "bool", repeated=False, required=False, default=None),
+        3: protobuf.Field("network_type", "MoneroNetworkType", repeated=False, required=False, default=MoneroNetworkType.MAINNET),
+        4: protobuf.Field("account", "uint32", repeated=False, required=False, default=None),
+        5: protobuf.Field("minor", "uint32", repeated=False, required=False, default=None),
+        6: protobuf.Field("payment_id", "bytes", repeated=False, required=False, default=None),
     }
 
     def __init__(
@@ -5083,7 +5083,7 @@ class MoneroGetAddress(protobuf.MessageType):
 class MoneroAddress(protobuf.MessageType):
     MESSAGE_WIRE_TYPE = 541
     FIELDS = {
-        1: protobuf.Field("address", "bytes", repeated=False, required=False),
+        1: protobuf.Field("address", "bytes", repeated=False, required=False, default=None),
     }
 
     def __init__(
@@ -5097,8 +5097,8 @@ class MoneroAddress(protobuf.MessageType):
 class MoneroGetWatchKey(protobuf.MessageType):
     MESSAGE_WIRE_TYPE = 542
     FIELDS = {
-        1: protobuf.Field("address_n", "uint32", repeated=True, required=False),
-        2: protobuf.Field("network_type", "MoneroNetworkType", repeated=False, required=False),
+        1: protobuf.Field("address_n", "uint32", repeated=True, required=False, default=None),
+        2: protobuf.Field("network_type", "MoneroNetworkType", repeated=False, required=False, default=MoneroNetworkType.MAINNET),
     }
 
     def __init__(
@@ -5114,8 +5114,8 @@ class MoneroGetWatchKey(protobuf.MessageType):
 class MoneroWatchKey(protobuf.MessageType):
     MESSAGE_WIRE_TYPE = 543
     FIELDS = {
-        1: protobuf.Field("watch_key", "bytes", repeated=False, required=False),
-        2: protobuf.Field("address", "bytes", repeated=False, required=False),
+        1: protobuf.Field("watch_key", "bytes", repeated=False, required=False, default=None),
+        2: protobuf.Field("address", "bytes", repeated=False, required=False, default=None),
     }
 
     def __init__(
@@ -5131,10 +5131,10 @@ class MoneroWatchKey(protobuf.MessageType):
 class MoneroTransactionInitRequest(protobuf.MessageType):
     MESSAGE_WIRE_TYPE = 501
     FIELDS = {
-        1: protobuf.Field("version", "uint32", repeated=False, required=False),
-        2: protobuf.Field("address_n", "uint32", repeated=True, required=False),
-        3: protobuf.Field("network_type", "MoneroNetworkType", repeated=False, required=False),
-        4: protobuf.Field("tsx_data", "MoneroTransactionData", repeated=False, required=False),
+        1: protobuf.Field("version", "uint32", repeated=False, required=False, default=None),
+        2: protobuf.Field("address_n", "uint32", repeated=True, required=False, default=None),
+        3: protobuf.Field("network_type", "MoneroNetworkType", repeated=False, required=False, default=MoneroNetworkType.MAINNET),
+        4: protobuf.Field("tsx_data", "MoneroTransactionData", repeated=False, required=False, default=None),
     }
 
     def __init__(
@@ -5154,8 +5154,8 @@ class MoneroTransactionInitRequest(protobuf.MessageType):
 class MoneroTransactionInitAck(protobuf.MessageType):
     MESSAGE_WIRE_TYPE = 502
     FIELDS = {
-        1: protobuf.Field("hmacs", "bytes", repeated=True, required=False),
-        2: protobuf.Field("rsig_data", "MoneroTransactionRsigData", repeated=False, required=False),
+        1: protobuf.Field("hmacs", "bytes", repeated=True, required=False, default=None),
+        2: protobuf.Field("rsig_data", "MoneroTransactionRsigData", repeated=False, required=False, default=None),
     }
 
     def __init__(
@@ -5171,7 +5171,7 @@ class MoneroTransactionInitAck(protobuf.MessageType):
 class MoneroTransactionSetInputRequest(protobuf.MessageType):
     MESSAGE_WIRE_TYPE = 503
     FIELDS = {
-        1: protobuf.Field("src_entr", "MoneroTransactionSourceEntry", repeated=False, required=False),
+        1: protobuf.Field("src_entr", "MoneroTransactionSourceEntry", repeated=False, required=False, default=None),
     }
 
     def __init__(
@@ -5185,12 +5185,12 @@ class MoneroTransactionSetInputRequest(protobuf.MessageType):
 class MoneroTransactionSetInputAck(protobuf.MessageType):
     MESSAGE_WIRE_TYPE = 504
     FIELDS = {
-        1: protobuf.Field("vini", "bytes", repeated=False, required=False),
-        2: protobuf.Field("vini_hmac", "bytes", repeated=False, required=False),
-        3: protobuf.Field("pseudo_out", "bytes", repeated=False, required=False),
-        4: protobuf.Field("pseudo_out_hmac", "bytes", repeated=False, required=False),
-        5: protobuf.Field("pseudo_out_alpha", "bytes", repeated=False, required=False),
-        6: protobuf.Field("spend_key", "bytes", repeated=False, required=False),
+        1: protobuf.Field("vini", "bytes", repeated=False, required=False, default=None),
+        2: protobuf.Field("vini_hmac", "bytes", repeated=False, required=False, default=None),
+        3: protobuf.Field("pseudo_out", "bytes", repeated=False, required=False, default=None),
+        4: protobuf.Field("pseudo_out_hmac", "bytes", repeated=False, required=False, default=None),
+        5: protobuf.Field("pseudo_out_alpha", "bytes", repeated=False, required=False, default=None),
+        6: protobuf.Field("spend_key", "bytes", repeated=False, required=False, default=None),
     }
 
     def __init__(
@@ -5214,12 +5214,12 @@ class MoneroTransactionSetInputAck(protobuf.MessageType):
 class MoneroTransactionInputViniRequest(protobuf.MessageType):
     MESSAGE_WIRE_TYPE = 507
     FIELDS = {
-        1: protobuf.Field("src_entr", "MoneroTransactionSourceEntry", repeated=False, required=False),
-        2: protobuf.Field("vini", "bytes", repeated=False, required=False),
-        3: protobuf.Field("vini_hmac", "bytes", repeated=False, required=False),
-        4: protobuf.Field("pseudo_out", "bytes", repeated=False, required=False),
-        5: protobuf.Field("pseudo_out_hmac", "bytes", repeated=False, required=False),
-        6: protobuf.Field("orig_idx", "uint32", repeated=False, required=False),
+        1: protobuf.Field("src_entr", "MoneroTransactionSourceEntry", repeated=False, required=False, default=None),
+        2: protobuf.Field("vini", "bytes", repeated=False, required=False, default=None),
+        3: protobuf.Field("vini_hmac", "bytes", repeated=False, required=False, default=None),
+        4: protobuf.Field("pseudo_out", "bytes", repeated=False, required=False, default=None),
+        5: protobuf.Field("pseudo_out_hmac", "bytes", repeated=False, required=False, default=None),
+        6: protobuf.Field("orig_idx", "uint32", repeated=False, required=False, default=None),
     }
 
     def __init__(
@@ -5251,7 +5251,7 @@ class MoneroTransactionAllInputsSetRequest(protobuf.MessageType):
 class MoneroTransactionAllInputsSetAck(protobuf.MessageType):
     MESSAGE_WIRE_TYPE = 510
     FIELDS = {
-        1: protobuf.Field("rsig_data", "MoneroTransactionRsigData", repeated=False, required=False),
+        1: protobuf.Field("rsig_data", "MoneroTransactionRsigData", repeated=False, required=False, default=None),
     }
 
     def __init__(
@@ -5265,10 +5265,10 @@ class MoneroTransactionAllInputsSetAck(protobuf.MessageType):
 class MoneroTransactionSetOutputRequest(protobuf.MessageType):
     MESSAGE_WIRE_TYPE = 511
     FIELDS = {
-        1: protobuf.Field("dst_entr", "MoneroTransactionDestinationEntry", repeated=False, required=False),
-        2: protobuf.Field("dst_entr_hmac", "bytes", repeated=False, required=False),
-        3: protobuf.Field("rsig_data", "MoneroTransactionRsigData", repeated=False, required=False),
-        4: protobuf.Field("is_offloaded_bp", "bool", repeated=False, required=False),
+        1: protobuf.Field("dst_entr", "MoneroTransactionDestinationEntry", repeated=False, required=False, default=None),
+        2: protobuf.Field("dst_entr_hmac", "bytes", repeated=False, required=False, default=None),
+        3: protobuf.Field("rsig_data", "MoneroTransactionRsigData", repeated=False, required=False, default=None),
+        4: protobuf.Field("is_offloaded_bp", "bool", repeated=False, required=False, default=None),
     }
 
     def __init__(
@@ -5288,11 +5288,11 @@ class MoneroTransactionSetOutputRequest(protobuf.MessageType):
 class MoneroTransactionSetOutputAck(protobuf.MessageType):
     MESSAGE_WIRE_TYPE = 512
     FIELDS = {
-        1: protobuf.Field("tx_out", "bytes", repeated=False, required=False),
-        2: protobuf.Field("vouti_hmac", "bytes", repeated=False, required=False),
-        3: protobuf.Field("rsig_data", "MoneroTransactionRsigData", repeated=False, required=False),
-        4: protobuf.Field("out_pk", "bytes", repeated=False, required=False),
-        5: protobuf.Field("ecdh_info", "bytes", repeated=False, required=False),
+        1: protobuf.Field("tx_out", "bytes", repeated=False, required=False, default=None),
+        2: protobuf.Field("vouti_hmac", "bytes", repeated=False, required=False, default=None),
+        3: protobuf.Field("rsig_data", "MoneroTransactionRsigData", repeated=False, required=False, default=None),
+        4: protobuf.Field("out_pk", "bytes", repeated=False, required=False, default=None),
+        5: protobuf.Field("ecdh_info", "bytes", repeated=False, required=False, default=None),
     }
 
     def __init__(
@@ -5314,7 +5314,7 @@ class MoneroTransactionSetOutputAck(protobuf.MessageType):
 class MoneroTransactionAllOutSetRequest(protobuf.MessageType):
     MESSAGE_WIRE_TYPE = 513
     FIELDS = {
-        1: protobuf.Field("rsig_data", "MoneroTransactionRsigData", repeated=False, required=False),
+        1: protobuf.Field("rsig_data", "MoneroTransactionRsigData", repeated=False, required=False, default=None),
     }
 
     def __init__(
@@ -5328,10 +5328,10 @@ class MoneroTransactionAllOutSetRequest(protobuf.MessageType):
 class MoneroTransactionAllOutSetAck(protobuf.MessageType):
     MESSAGE_WIRE_TYPE = 514
     FIELDS = {
-        1: protobuf.Field("extra", "bytes", repeated=False, required=False),
-        2: protobuf.Field("tx_prefix_hash", "bytes", repeated=False, required=False),
-        4: protobuf.Field("rv", "MoneroRingCtSig", repeated=False, required=False),
-        5: protobuf.Field("full_message_hash", "bytes", repeated=False, required=False),
+        1: protobuf.Field("extra", "bytes", repeated=False, required=False, default=None),
+        2: protobuf.Field("tx_prefix_hash", "bytes", repeated=False, required=False, default=None),
+        4: protobuf.Field("rv", "MoneroRingCtSig", repeated=False, required=False, default=None),
+        5: protobuf.Field("full_message_hash", "bytes", repeated=False, required=False, default=None),
     }
 
     def __init__(
@@ -5351,14 +5351,14 @@ class MoneroTransactionAllOutSetAck(protobuf.MessageType):
 class MoneroTransactionSignInputRequest(protobuf.MessageType):
     MESSAGE_WIRE_TYPE = 515
     FIELDS = {
-        1: protobuf.Field("src_entr", "MoneroTransactionSourceEntry", repeated=False, required=False),
-        2: protobuf.Field("vini", "bytes", repeated=False, required=False),
-        3: protobuf.Field("vini_hmac", "bytes", repeated=False, required=False),
-        4: protobuf.Field("pseudo_out", "bytes", repeated=False, required=False),
-        5: protobuf.Field("pseudo_out_hmac", "bytes", repeated=False, required=False),
-        6: protobuf.Field("pseudo_out_alpha", "bytes", repeated=False, required=False),
-        7: protobuf.Field("spend_key", "bytes", repeated=False, required=False),
-        8: protobuf.Field("orig_idx", "uint32", repeated=False, required=False),
+        1: protobuf.Field("src_entr", "MoneroTransactionSourceEntry", repeated=False, required=False, default=None),
+        2: protobuf.Field("vini", "bytes", repeated=False, required=False, default=None),
+        3: protobuf.Field("vini_hmac", "bytes", repeated=False, required=False, default=None),
+        4: protobuf.Field("pseudo_out", "bytes", repeated=False, required=False, default=None),
+        5: protobuf.Field("pseudo_out_hmac", "bytes", repeated=False, required=False, default=None),
+        6: protobuf.Field("pseudo_out_alpha", "bytes", repeated=False, required=False, default=None),
+        7: protobuf.Field("spend_key", "bytes", repeated=False, required=False, default=None),
+        8: protobuf.Field("orig_idx", "uint32", repeated=False, required=False, default=None),
     }
 
     def __init__(
@@ -5386,8 +5386,8 @@ class MoneroTransactionSignInputRequest(protobuf.MessageType):
 class MoneroTransactionSignInputAck(protobuf.MessageType):
     MESSAGE_WIRE_TYPE = 516
     FIELDS = {
-        1: protobuf.Field("signature", "bytes", repeated=False, required=False),
-        2: protobuf.Field("pseudo_out", "bytes", repeated=False, required=False),
+        1: protobuf.Field("signature", "bytes", repeated=False, required=False, default=None),
+        2: protobuf.Field("pseudo_out", "bytes", repeated=False, required=False, default=None),
     }
 
     def __init__(
@@ -5407,11 +5407,11 @@ class MoneroTransactionFinalRequest(protobuf.MessageType):
 class MoneroTransactionFinalAck(protobuf.MessageType):
     MESSAGE_WIRE_TYPE = 518
     FIELDS = {
-        1: protobuf.Field("cout_key", "bytes", repeated=False, required=False),
-        2: protobuf.Field("salt", "bytes", repeated=False, required=False),
-        3: protobuf.Field("rand_mult", "bytes", repeated=False, required=False),
-        4: protobuf.Field("tx_enc_keys", "bytes", repeated=False, required=False),
-        5: protobuf.Field("opening_key", "bytes", repeated=False, required=False),
+        1: protobuf.Field("cout_key", "bytes", repeated=False, required=False, default=None),
+        2: protobuf.Field("salt", "bytes", repeated=False, required=False, default=None),
+        3: protobuf.Field("rand_mult", "bytes", repeated=False, required=False, default=None),
+        4: protobuf.Field("tx_enc_keys", "bytes", repeated=False, required=False, default=None),
+        5: protobuf.Field("opening_key", "bytes", repeated=False, required=False, default=None),
     }
 
     def __init__(
@@ -5435,9 +5435,9 @@ class MoneroKeyImageExportInitRequest(protobuf.MessageType):
     FIELDS = {
         1: protobuf.Field("num", "uint64", repeated=False, required=True),
         2: protobuf.Field("hash", "bytes", repeated=False, required=True),
-        3: protobuf.Field("address_n", "uint32", repeated=True, required=False),
-        4: protobuf.Field("network_type", "MoneroNetworkType", repeated=False, required=False),
-        5: protobuf.Field("subs", "MoneroSubAddressIndicesList", repeated=True, required=False),
+        3: protobuf.Field("address_n", "uint32", repeated=True, required=False, default=None),
+        4: protobuf.Field("network_type", "MoneroNetworkType", repeated=False, required=False, default=MoneroNetworkType.MAINNET),
+        5: protobuf.Field("subs", "MoneroSubAddressIndicesList", repeated=True, required=False, default=None),
     }
 
     def __init__(
@@ -5463,7 +5463,7 @@ class MoneroKeyImageExportInitAck(protobuf.MessageType):
 class MoneroKeyImageSyncStepRequest(protobuf.MessageType):
     MESSAGE_WIRE_TYPE = 532
     FIELDS = {
-        1: protobuf.Field("tdis", "MoneroTransferDetails", repeated=True, required=False),
+        1: protobuf.Field("tdis", "MoneroTransferDetails", repeated=True, required=False, default=None),
     }
 
     def __init__(
@@ -5477,7 +5477,7 @@ class MoneroKeyImageSyncStepRequest(protobuf.MessageType):
 class MoneroKeyImageSyncStepAck(protobuf.MessageType):
     MESSAGE_WIRE_TYPE = 533
     FIELDS = {
-        1: protobuf.Field("kis", "MoneroExportedKeyImage", repeated=True, required=False),
+        1: protobuf.Field("kis", "MoneroExportedKeyImage", repeated=True, required=False, default=None),
     }
 
     def __init__(
@@ -5495,7 +5495,7 @@ class MoneroKeyImageSyncFinalRequest(protobuf.MessageType):
 class MoneroKeyImageSyncFinalAck(protobuf.MessageType):
     MESSAGE_WIRE_TYPE = 535
     FIELDS = {
-        1: protobuf.Field("enc_key", "bytes", repeated=False, required=False),
+        1: protobuf.Field("enc_key", "bytes", repeated=False, required=False, default=None),
     }
 
     def __init__(
@@ -5509,14 +5509,14 @@ class MoneroKeyImageSyncFinalAck(protobuf.MessageType):
 class MoneroGetTxKeyRequest(protobuf.MessageType):
     MESSAGE_WIRE_TYPE = 550
     FIELDS = {
-        1: protobuf.Field("address_n", "uint32", repeated=True, required=False),
-        2: protobuf.Field("network_type", "MoneroNetworkType", repeated=False, required=False),
+        1: protobuf.Field("address_n", "uint32", repeated=True, required=False, default=None),
+        2: protobuf.Field("network_type", "MoneroNetworkType", repeated=False, required=False, default=MoneroNetworkType.MAINNET),
         3: protobuf.Field("salt1", "bytes", repeated=False, required=True),
         4: protobuf.Field("salt2", "bytes", repeated=False, required=True),
         5: protobuf.Field("tx_enc_keys", "bytes", repeated=False, required=True),
         6: protobuf.Field("tx_prefix_hash", "bytes", repeated=False, required=True),
-        7: protobuf.Field("reason", "uint32", repeated=False, required=False),
-        8: protobuf.Field("view_public_key", "bytes", repeated=False, required=False),
+        7: protobuf.Field("reason", "uint32", repeated=False, required=False, default=None),
+        8: protobuf.Field("view_public_key", "bytes", repeated=False, required=False, default=None),
     }
 
     def __init__(
@@ -5544,9 +5544,9 @@ class MoneroGetTxKeyRequest(protobuf.MessageType):
 class MoneroGetTxKeyAck(protobuf.MessageType):
     MESSAGE_WIRE_TYPE = 551
     FIELDS = {
-        1: protobuf.Field("salt", "bytes", repeated=False, required=False),
-        2: protobuf.Field("tx_keys", "bytes", repeated=False, required=False),
-        3: protobuf.Field("tx_derivations", "bytes", repeated=False, required=False),
+        1: protobuf.Field("salt", "bytes", repeated=False, required=False, default=None),
+        2: protobuf.Field("tx_keys", "bytes", repeated=False, required=False, default=None),
+        3: protobuf.Field("tx_derivations", "bytes", repeated=False, required=False, default=None),
     }
 
     def __init__(
@@ -5564,8 +5564,8 @@ class MoneroGetTxKeyAck(protobuf.MessageType):
 class MoneroLiveRefreshStartRequest(protobuf.MessageType):
     MESSAGE_WIRE_TYPE = 552
     FIELDS = {
-        1: protobuf.Field("address_n", "uint32", repeated=True, required=False),
-        2: protobuf.Field("network_type", "MoneroNetworkType", repeated=False, required=False),
+        1: protobuf.Field("address_n", "uint32", repeated=True, required=False, default=None),
+        2: protobuf.Field("network_type", "MoneroNetworkType", repeated=False, required=False, default=MoneroNetworkType.MAINNET),
     }
 
     def __init__(
@@ -5611,8 +5611,8 @@ class MoneroLiveRefreshStepRequest(protobuf.MessageType):
 class MoneroLiveRefreshStepAck(protobuf.MessageType):
     MESSAGE_WIRE_TYPE = 555
     FIELDS = {
-        1: protobuf.Field("salt", "bytes", repeated=False, required=False),
-        2: protobuf.Field("key_image", "bytes", repeated=False, required=False),
+        1: protobuf.Field("salt", "bytes", repeated=False, required=False, default=None),
+        2: protobuf.Field("key_image", "bytes", repeated=False, required=False, default=None),
     }
 
     def __init__(
@@ -5636,12 +5636,12 @@ class MoneroLiveRefreshFinalAck(protobuf.MessageType):
 class DebugMoneroDiagRequest(protobuf.MessageType):
     MESSAGE_WIRE_TYPE = 546
     FIELDS = {
-        1: protobuf.Field("ins", "uint64", repeated=False, required=False),
-        2: protobuf.Field("p1", "uint64", repeated=False, required=False),
-        3: protobuf.Field("p2", "uint64", repeated=False, required=False),
-        4: protobuf.Field("pd", "uint64", repeated=True, required=False),
-        5: protobuf.Field("data1", "bytes", repeated=False, required=False),
-        6: protobuf.Field("data2", "bytes", repeated=False, required=False),
+        1: protobuf.Field("ins", "uint64", repeated=False, required=False, default=None),
+        2: protobuf.Field("p1", "uint64", repeated=False, required=False, default=None),
+        3: protobuf.Field("p2", "uint64", repeated=False, required=False, default=None),
+        4: protobuf.Field("pd", "uint64", repeated=True, required=False, default=None),
+        5: protobuf.Field("data1", "bytes", repeated=False, required=False, default=None),
+        6: protobuf.Field("data2", "bytes", repeated=False, required=False, default=None),
     }
 
     def __init__(
@@ -5665,12 +5665,12 @@ class DebugMoneroDiagRequest(protobuf.MessageType):
 class DebugMoneroDiagAck(protobuf.MessageType):
     MESSAGE_WIRE_TYPE = 547
     FIELDS = {
-        1: protobuf.Field("ins", "uint64", repeated=False, required=False),
-        2: protobuf.Field("p1", "uint64", repeated=False, required=False),
-        3: protobuf.Field("p2", "uint64", repeated=False, required=False),
-        4: protobuf.Field("pd", "uint64", repeated=True, required=False),
-        5: protobuf.Field("data1", "bytes", repeated=False, required=False),
-        6: protobuf.Field("data2", "bytes", repeated=False, required=False),
+        1: protobuf.Field("ins", "uint64", repeated=False, required=False, default=None),
+        2: protobuf.Field("p1", "uint64", repeated=False, required=False, default=None),
+        3: protobuf.Field("p2", "uint64", repeated=False, required=False, default=None),
+        4: protobuf.Field("pd", "uint64", repeated=True, required=False, default=None),
+        5: protobuf.Field("data1", "bytes", repeated=False, required=False, default=None),
+        6: protobuf.Field("data2", "bytes", repeated=False, required=False, default=None),
     }
 
     def __init__(
@@ -5694,8 +5694,8 @@ class DebugMoneroDiagAck(protobuf.MessageType):
 class MoneroOutputEntry(protobuf.MessageType):
     MESSAGE_WIRE_TYPE = None
     FIELDS = {
-        1: protobuf.Field("idx", "uint64", repeated=False, required=False),
-        2: protobuf.Field("key", "MoneroRctKeyPublic", repeated=False, required=False),
+        1: protobuf.Field("idx", "uint64", repeated=False, required=False, default=None),
+        2: protobuf.Field("key", "MoneroRctKeyPublic", repeated=False, required=False, default=None),
     }
 
     def __init__(
@@ -5711,10 +5711,10 @@ class MoneroOutputEntry(protobuf.MessageType):
 class MoneroMultisigKLRki(protobuf.MessageType):
     MESSAGE_WIRE_TYPE = None
     FIELDS = {
-        1: protobuf.Field("K", "bytes", repeated=False, required=False),
-        2: protobuf.Field("L", "bytes", repeated=False, required=False),
-        3: protobuf.Field("R", "bytes", repeated=False, required=False),
-        4: protobuf.Field("ki", "bytes", repeated=False, required=False),
+        1: protobuf.Field("K", "bytes", repeated=False, required=False, default=None),
+        2: protobuf.Field("L", "bytes", repeated=False, required=False, default=None),
+        3: protobuf.Field("R", "bytes", repeated=False, required=False, default=None),
+        4: protobuf.Field("ki", "bytes", repeated=False, required=False, default=None),
     }
 
     def __init__(
@@ -5751,8 +5751,8 @@ class MoneroRctKeyPublic(protobuf.MessageType):
 class MoneroAccountPublicAddress(protobuf.MessageType):
     MESSAGE_WIRE_TYPE = None
     FIELDS = {
-        1: protobuf.Field("spend_public_key", "bytes", repeated=False, required=False),
-        2: protobuf.Field("view_public_key", "bytes", repeated=False, required=False),
+        1: protobuf.Field("spend_public_key", "bytes", repeated=False, required=False, default=None),
+        2: protobuf.Field("view_public_key", "bytes", repeated=False, required=False, default=None),
     }
 
     def __init__(
@@ -5768,21 +5768,21 @@ class MoneroAccountPublicAddress(protobuf.MessageType):
 class MoneroTransactionData(protobuf.MessageType):
     MESSAGE_WIRE_TYPE = None
     FIELDS = {
-        1: protobuf.Field("version", "uint32", repeated=False, required=False),
-        2: protobuf.Field("payment_id", "bytes", repeated=False, required=False),
-        3: protobuf.Field("unlock_time", "uint64", repeated=False, required=False),
-        4: protobuf.Field("outputs", "MoneroTransactionDestinationEntry", repeated=True, required=False),
-        5: protobuf.Field("change_dts", "MoneroTransactionDestinationEntry", repeated=False, required=False),
-        6: protobuf.Field("num_inputs", "uint32", repeated=False, required=False),
-        7: protobuf.Field("mixin", "uint32", repeated=False, required=False),
-        8: protobuf.Field("fee", "uint64", repeated=False, required=False),
-        9: protobuf.Field("account", "uint32", repeated=False, required=False),
-        10: protobuf.Field("minor_indices", "uint32", repeated=True, required=False),
-        11: protobuf.Field("rsig_data", "MoneroTransactionRsigData", repeated=False, required=False),
-        12: protobuf.Field("integrated_indices", "uint32", repeated=True, required=False),
-        13: protobuf.Field("client_version", "uint32", repeated=False, required=False),
-        14: protobuf.Field("hard_fork", "uint32", repeated=False, required=False),
-        15: protobuf.Field("monero_version", "bytes", repeated=False, required=False),
+        1: protobuf.Field("version", "uint32", repeated=False, required=False, default=None),
+        2: protobuf.Field("payment_id", "bytes", repeated=False, required=False, default=None),
+        3: protobuf.Field("unlock_time", "uint64", repeated=False, required=False, default=None),
+        4: protobuf.Field("outputs", "MoneroTransactionDestinationEntry", repeated=True, required=False, default=None),
+        5: protobuf.Field("change_dts", "MoneroTransactionDestinationEntry", repeated=False, required=False, default=None),
+        6: protobuf.Field("num_inputs", "uint32", repeated=False, required=False, default=None),
+        7: protobuf.Field("mixin", "uint32", repeated=False, required=False, default=None),
+        8: protobuf.Field("fee", "uint64", repeated=False, required=False, default=None),
+        9: protobuf.Field("account", "uint32", repeated=False, required=False, default=None),
+        10: protobuf.Field("minor_indices", "uint32", repeated=True, required=False, default=None),
+        11: protobuf.Field("rsig_data", "MoneroTransactionRsigData", repeated=False, required=False, default=None),
+        12: protobuf.Field("integrated_indices", "uint32", repeated=True, required=False, default=None),
+        13: protobuf.Field("client_version", "uint32", repeated=False, required=False, default=None),
+        14: protobuf.Field("hard_fork", "uint32", repeated=False, required=False, default=None),
+        15: protobuf.Field("monero_version", "bytes", repeated=False, required=False, default=None),
     }
 
     def __init__(
@@ -5824,9 +5824,9 @@ class MoneroTransactionData(protobuf.MessageType):
 class MoneroRingCtSig(protobuf.MessageType):
     MESSAGE_WIRE_TYPE = None
     FIELDS = {
-        1: protobuf.Field("txn_fee", "uint64", repeated=False, required=False),
-        2: protobuf.Field("message", "bytes", repeated=False, required=False),
-        3: protobuf.Field("rv_type", "uint32", repeated=False, required=False),
+        1: protobuf.Field("txn_fee", "uint64", repeated=False, required=False, default=None),
+        2: protobuf.Field("message", "bytes", repeated=False, required=False, default=None),
+        3: protobuf.Field("rv_type", "uint32", repeated=False, required=False, default=None),
     }
 
     def __init__(
@@ -5845,7 +5845,7 @@ class MoneroSubAddressIndicesList(protobuf.MessageType):
     MESSAGE_WIRE_TYPE = None
     FIELDS = {
         1: protobuf.Field("account", "uint32", repeated=False, required=True),
-        2: protobuf.Field("minor_indices", "uint32", repeated=True, required=False),
+        2: protobuf.Field("minor_indices", "uint32", repeated=True, required=False, default=None),
     }
 
     def __init__(
@@ -5863,10 +5863,10 @@ class MoneroTransferDetails(protobuf.MessageType):
     FIELDS = {
         1: protobuf.Field("out_key", "bytes", repeated=False, required=True),
         2: protobuf.Field("tx_pub_key", "bytes", repeated=False, required=True),
-        3: protobuf.Field("additional_tx_pub_keys", "bytes", repeated=True, required=False),
+        3: protobuf.Field("additional_tx_pub_keys", "bytes", repeated=True, required=False, default=None),
         4: protobuf.Field("internal_output_index", "uint64", repeated=False, required=True),
-        5: protobuf.Field("sub_addr_major", "uint32", repeated=False, required=False),
-        6: protobuf.Field("sub_addr_minor", "uint32", repeated=False, required=False),
+        5: protobuf.Field("sub_addr_major", "uint32", repeated=False, required=False, default=None),
+        6: protobuf.Field("sub_addr_minor", "uint32", repeated=False, required=False, default=None),
     }
 
     def __init__(
@@ -5890,8 +5890,8 @@ class MoneroTransferDetails(protobuf.MessageType):
 class MoneroExportedKeyImage(protobuf.MessageType):
     MESSAGE_WIRE_TYPE = None
     FIELDS = {
-        1: protobuf.Field("iv", "bytes", repeated=False, required=False),
-        3: protobuf.Field("blob", "bytes", repeated=False, required=False),
+        1: protobuf.Field("iv", "bytes", repeated=False, required=False, default=None),
+        3: protobuf.Field("blob", "bytes", repeated=False, required=False, default=None),
     }
 
     def __init__(
@@ -5907,9 +5907,9 @@ class MoneroExportedKeyImage(protobuf.MessageType):
 class NEMGetAddress(protobuf.MessageType):
     MESSAGE_WIRE_TYPE = 67
     FIELDS = {
-        1: protobuf.Field("address_n", "uint32", repeated=True, required=False),
-        2: protobuf.Field("network", "uint32", repeated=False, required=False),
-        3: protobuf.Field("show_display", "bool", repeated=False, required=False),
+        1: protobuf.Field("address_n", "uint32", repeated=True, required=False, default=None),
+        2: protobuf.Field("network", "uint32", repeated=False, required=False, default=104),
+        3: protobuf.Field("show_display", "bool", repeated=False, required=False, default=None),
     }
 
     def __init__(
@@ -5942,14 +5942,14 @@ class NEMSignTx(protobuf.MessageType):
     MESSAGE_WIRE_TYPE = 69
     FIELDS = {
         1: protobuf.Field("transaction", "NEMTransactionCommon", repeated=False, required=True),
-        2: protobuf.Field("multisig", "NEMTransactionCommon", repeated=False, required=False),
-        3: protobuf.Field("transfer", "NEMTransfer", repeated=False, required=False),
-        4: protobuf.Field("cosigning", "bool", repeated=False, required=False),
-        5: protobuf.Field("provision_namespace", "NEMProvisionNamespace", repeated=False, required=False),
-        6: protobuf.Field("mosaic_creation", "NEMMosaicCreation", repeated=False, required=False),
-        7: protobuf.Field("supply_change", "NEMMosaicSupplyChange", repeated=False, required=False),
-        8: protobuf.Field("aggregate_modification", "NEMAggregateModification", repeated=False, required=False),
-        9: protobuf.Field("importance_transfer", "NEMImportanceTransfer", repeated=False, required=False),
+        2: protobuf.Field("multisig", "NEMTransactionCommon", repeated=False, required=False, default=None),
+        3: protobuf.Field("transfer", "NEMTransfer", repeated=False, required=False, default=None),
+        4: protobuf.Field("cosigning", "bool", repeated=False, required=False, default=None),
+        5: protobuf.Field("provision_namespace", "NEMProvisionNamespace", repeated=False, required=False, default=None),
+        6: protobuf.Field("mosaic_creation", "NEMMosaicCreation", repeated=False, required=False, default=None),
+        7: protobuf.Field("supply_change", "NEMMosaicSupplyChange", repeated=False, required=False, default=None),
+        8: protobuf.Field("aggregate_modification", "NEMAggregateModification", repeated=False, required=False, default=None),
+        9: protobuf.Field("importance_transfer", "NEMImportanceTransfer", repeated=False, required=False, default=None),
     }
 
     def __init__(
@@ -5996,10 +5996,10 @@ class NEMSignedTx(protobuf.MessageType):
 class NEMDecryptMessage(protobuf.MessageType):
     MESSAGE_WIRE_TYPE = 75
     FIELDS = {
-        1: protobuf.Field("address_n", "uint32", repeated=True, required=False),
-        2: protobuf.Field("network", "uint32", repeated=False, required=False),
-        3: protobuf.Field("public_key", "bytes", repeated=False, required=False),
-        4: protobuf.Field("payload", "bytes", repeated=False, required=False),
+        1: protobuf.Field("address_n", "uint32", repeated=True, required=False, default=None),
+        2: protobuf.Field("network", "uint32", repeated=False, required=False, default=None),
+        3: protobuf.Field("public_key", "bytes", repeated=False, required=False, default=None),
+        4: protobuf.Field("payload", "bytes", repeated=False, required=False, default=None),
     }
 
     def __init__(
@@ -6033,12 +6033,12 @@ class NEMDecryptedMessage(protobuf.MessageType):
 class NEMTransactionCommon(protobuf.MessageType):
     MESSAGE_WIRE_TYPE = None
     FIELDS = {
-        1: protobuf.Field("address_n", "uint32", repeated=True, required=False),
-        2: protobuf.Field("network", "uint32", repeated=False, required=False),
+        1: protobuf.Field("address_n", "uint32", repeated=True, required=False, default=None),
+        2: protobuf.Field("network", "uint32", repeated=False, required=False, default=104),
         3: protobuf.Field("timestamp", "uint32", repeated=False, required=True),
         4: protobuf.Field("fee", "uint64", repeated=False, required=True),
         5: protobuf.Field("deadline", "uint32", repeated=False, required=True),
-        6: protobuf.Field("signer", "bytes", repeated=False, required=False),
+        6: protobuf.Field("signer", "bytes", repeated=False, required=False, default=None),
     }
 
     def __init__(
@@ -6064,9 +6064,9 @@ class NEMTransfer(protobuf.MessageType):
     FIELDS = {
         1: protobuf.Field("recipient", "string", repeated=False, required=True),
         2: protobuf.Field("amount", "uint64", repeated=False, required=True),
-        3: protobuf.Field("payload", "bytes", repeated=False, required=False),
-        4: protobuf.Field("public_key", "bytes", repeated=False, required=False),
-        5: protobuf.Field("mosaics", "NEMMosaic", repeated=True, required=False),
+        3: protobuf.Field("payload", "bytes", repeated=False, required=False, default=b''),
+        4: protobuf.Field("public_key", "bytes", repeated=False, required=False, default=None),
+        5: protobuf.Field("mosaics", "NEMMosaic", repeated=True, required=False, default=None),
     }
 
     def __init__(
@@ -6089,7 +6089,7 @@ class NEMProvisionNamespace(protobuf.MessageType):
     MESSAGE_WIRE_TYPE = None
     FIELDS = {
         1: protobuf.Field("namespace", "string", repeated=False, required=True),
-        2: protobuf.Field("parent", "string", repeated=False, required=False),
+        2: protobuf.Field("parent", "string", repeated=False, required=False, default=None),
         3: protobuf.Field("sink", "string", repeated=False, required=True),
         4: protobuf.Field("fee", "uint64", repeated=False, required=True),
     }
@@ -6154,8 +6154,8 @@ class NEMMosaicSupplyChange(protobuf.MessageType):
 class NEMAggregateModification(protobuf.MessageType):
     MESSAGE_WIRE_TYPE = None
     FIELDS = {
-        1: protobuf.Field("modifications", "NEMCosignatoryModification", repeated=True, required=False),
-        2: protobuf.Field("relative_change", "sint32", repeated=False, required=False),
+        1: protobuf.Field("modifications", "NEMCosignatoryModification", repeated=True, required=False, default=None),
+        2: protobuf.Field("relative_change", "sint32", repeated=False, required=False, default=None),
     }
 
     def __init__(
@@ -6208,21 +6208,21 @@ class NEMMosaic(protobuf.MessageType):
 class NEMMosaicDefinition(protobuf.MessageType):
     MESSAGE_WIRE_TYPE = None
     FIELDS = {
-        1: protobuf.Field("name", "string", repeated=False, required=False),
-        2: protobuf.Field("ticker", "string", repeated=False, required=False),
+        1: protobuf.Field("name", "string", repeated=False, required=False, default=None),
+        2: protobuf.Field("ticker", "string", repeated=False, required=False, default=None),
         3: protobuf.Field("namespace", "string", repeated=False, required=True),
         4: protobuf.Field("mosaic", "string", repeated=False, required=True),
-        5: protobuf.Field("divisibility", "uint32", repeated=False, required=False),
-        6: protobuf.Field("levy", "NEMMosaicLevy", repeated=False, required=False),
-        7: protobuf.Field("fee", "uint64", repeated=False, required=False),
-        8: protobuf.Field("levy_address", "string", repeated=False, required=False),
-        9: protobuf.Field("levy_namespace", "string", repeated=False, required=False),
-        10: protobuf.Field("levy_mosaic", "string", repeated=False, required=False),
-        11: protobuf.Field("supply", "uint64", repeated=False, required=False),
-        12: protobuf.Field("mutable_supply", "bool", repeated=False, required=False),
-        13: protobuf.Field("transferable", "bool", repeated=False, required=False),
+        5: protobuf.Field("divisibility", "uint32", repeated=False, required=False, default=None),
+        6: protobuf.Field("levy", "NEMMosaicLevy", repeated=False, required=False, default=None),
+        7: protobuf.Field("fee", "uint64", repeated=False, required=False, default=None),
+        8: protobuf.Field("levy_address", "string", repeated=False, required=False, default=None),
+        9: protobuf.Field("levy_namespace", "string", repeated=False, required=False, default=None),
+        10: protobuf.Field("levy_mosaic", "string", repeated=False, required=False, default=None),
+        11: protobuf.Field("supply", "uint64", repeated=False, required=False, default=None),
+        12: protobuf.Field("mutable_supply", "bool", repeated=False, required=False, default=None),
+        13: protobuf.Field("transferable", "bool", repeated=False, required=False, default=None),
         14: protobuf.Field("description", "string", repeated=False, required=True),
-        15: protobuf.Field("networks", "uint32", repeated=True, required=False),
+        15: protobuf.Field("networks", "uint32", repeated=True, required=False, default=None),
     }
 
     def __init__(
@@ -6281,8 +6281,8 @@ class NEMCosignatoryModification(protobuf.MessageType):
 class RippleGetAddress(protobuf.MessageType):
     MESSAGE_WIRE_TYPE = 400
     FIELDS = {
-        1: protobuf.Field("address_n", "uint32", repeated=True, required=False),
-        2: protobuf.Field("show_display", "bool", repeated=False, required=False),
+        1: protobuf.Field("address_n", "uint32", repeated=True, required=False, default=None),
+        2: protobuf.Field("show_display", "bool", repeated=False, required=False, default=None),
     }
 
     def __init__(
@@ -6312,11 +6312,11 @@ class RippleAddress(protobuf.MessageType):
 class RippleSignTx(protobuf.MessageType):
     MESSAGE_WIRE_TYPE = 402
     FIELDS = {
-        1: protobuf.Field("address_n", "uint32", repeated=True, required=False),
+        1: protobuf.Field("address_n", "uint32", repeated=True, required=False, default=None),
         2: protobuf.Field("fee", "uint64", repeated=False, required=True),
-        3: protobuf.Field("flags", "uint32", repeated=False, required=False),
+        3: protobuf.Field("flags", "uint32", repeated=False, required=False, default=0),
         4: protobuf.Field("sequence", "uint32", repeated=False, required=True),
-        5: protobuf.Field("last_ledger_sequence", "uint32", repeated=False, required=False),
+        5: protobuf.Field("last_ledger_sequence", "uint32", repeated=False, required=False, default=None),
         6: protobuf.Field("payment", "RipplePayment", repeated=False, required=True),
     }
 
@@ -6360,7 +6360,7 @@ class RipplePayment(protobuf.MessageType):
     FIELDS = {
         1: protobuf.Field("amount", "uint64", repeated=False, required=True),
         2: protobuf.Field("destination", "string", repeated=False, required=True),
-        3: protobuf.Field("destination_tag", "uint32", repeated=False, required=False),
+        3: protobuf.Field("destination_tag", "uint32", repeated=False, required=False, default=None),
     }
 
     def __init__(
@@ -6379,8 +6379,8 @@ class StellarAsset(protobuf.MessageType):
     MESSAGE_WIRE_TYPE = None
     FIELDS = {
         1: protobuf.Field("type", "StellarAssetType", repeated=False, required=True),
-        2: protobuf.Field("code", "string", repeated=False, required=False),
-        3: protobuf.Field("issuer", "string", repeated=False, required=False),
+        2: protobuf.Field("code", "string", repeated=False, required=False, default=None),
+        3: protobuf.Field("issuer", "string", repeated=False, required=False, default=None),
     }
 
     def __init__(
@@ -6398,8 +6398,8 @@ class StellarAsset(protobuf.MessageType):
 class StellarGetAddress(protobuf.MessageType):
     MESSAGE_WIRE_TYPE = 207
     FIELDS = {
-        1: protobuf.Field("address_n", "uint32", repeated=True, required=False),
-        2: protobuf.Field("show_display", "bool", repeated=False, required=False),
+        1: protobuf.Field("address_n", "uint32", repeated=True, required=False, default=None),
+        2: protobuf.Field("show_display", "bool", repeated=False, required=False, default=None),
     }
 
     def __init__(
@@ -6429,7 +6429,7 @@ class StellarAddress(protobuf.MessageType):
 class StellarSignTx(protobuf.MessageType):
     MESSAGE_WIRE_TYPE = 202
     FIELDS = {
-        2: protobuf.Field("address_n", "uint32", repeated=True, required=False),
+        2: protobuf.Field("address_n", "uint32", repeated=True, required=False, default=None),
         3: protobuf.Field("network_passphrase", "string", repeated=False, required=True),
         4: protobuf.Field("source_account", "string", repeated=False, required=True),
         5: protobuf.Field("fee", "uint32", repeated=False, required=True),
@@ -6437,9 +6437,9 @@ class StellarSignTx(protobuf.MessageType):
         8: protobuf.Field("timebounds_start", "uint32", repeated=False, required=True),
         9: protobuf.Field("timebounds_end", "uint32", repeated=False, required=True),
         10: protobuf.Field("memo_type", "StellarMemoType", repeated=False, required=True),
-        11: protobuf.Field("memo_text", "string", repeated=False, required=False),
-        12: protobuf.Field("memo_id", "uint64", repeated=False, required=False),
-        13: protobuf.Field("memo_hash", "bytes", repeated=False, required=False),
+        11: protobuf.Field("memo_text", "string", repeated=False, required=False, default=None),
+        12: protobuf.Field("memo_id", "uint64", repeated=False, required=False, default=None),
+        13: protobuf.Field("memo_hash", "bytes", repeated=False, required=False, default=None),
         14: protobuf.Field("num_operations", "uint32", repeated=False, required=True),
     }
 
@@ -6480,7 +6480,7 @@ class StellarTxOpRequest(protobuf.MessageType):
 class StellarPaymentOp(protobuf.MessageType):
     MESSAGE_WIRE_TYPE = 211
     FIELDS = {
-        1: protobuf.Field("source_account", "string", repeated=False, required=False),
+        1: protobuf.Field("source_account", "string", repeated=False, required=False, default=None),
         2: protobuf.Field("destination_account", "string", repeated=False, required=True),
         3: protobuf.Field("asset", "StellarAsset", repeated=False, required=True),
         4: protobuf.Field("amount", "sint64", repeated=False, required=True),
@@ -6503,7 +6503,7 @@ class StellarPaymentOp(protobuf.MessageType):
 class StellarCreateAccountOp(protobuf.MessageType):
     MESSAGE_WIRE_TYPE = 210
     FIELDS = {
-        1: protobuf.Field("source_account", "string", repeated=False, required=False),
+        1: protobuf.Field("source_account", "string", repeated=False, required=False, default=None),
         2: protobuf.Field("new_account", "string", repeated=False, required=True),
         3: protobuf.Field("starting_balance", "sint64", repeated=False, required=True),
     }
@@ -6523,13 +6523,13 @@ class StellarCreateAccountOp(protobuf.MessageType):
 class StellarPathPaymentStrictReceiveOp(protobuf.MessageType):
     MESSAGE_WIRE_TYPE = 212
     FIELDS = {
-        1: protobuf.Field("source_account", "string", repeated=False, required=False),
+        1: protobuf.Field("source_account", "string", repeated=False, required=False, default=None),
         2: protobuf.Field("send_asset", "StellarAsset", repeated=False, required=True),
         3: protobuf.Field("send_max", "sint64", repeated=False, required=True),
         4: protobuf.Field("destination_account", "string", repeated=False, required=True),
         5: protobuf.Field("destination_asset", "StellarAsset", repeated=False, required=True),
         6: protobuf.Field("destination_amount", "sint64", repeated=False, required=True),
-        7: protobuf.Field("paths", "StellarAsset", repeated=True, required=False),
+        7: protobuf.Field("paths", "StellarAsset", repeated=True, required=False, default=None),
     }
 
     def __init__(
@@ -6555,13 +6555,13 @@ class StellarPathPaymentStrictReceiveOp(protobuf.MessageType):
 class StellarPathPaymentStrictSendOp(protobuf.MessageType):
     MESSAGE_WIRE_TYPE = 223
     FIELDS = {
-        1: protobuf.Field("source_account", "string", repeated=False, required=False),
+        1: protobuf.Field("source_account", "string", repeated=False, required=False, default=None),
         2: protobuf.Field("send_asset", "StellarAsset", repeated=False, required=True),
         3: protobuf.Field("send_amount", "sint64", repeated=False, required=True),
         4: protobuf.Field("destination_account", "string", repeated=False, required=True),
         5: protobuf.Field("destination_asset", "StellarAsset", repeated=False, required=True),
         6: protobuf.Field("destination_min", "sint64", repeated=False, required=True),
-        7: protobuf.Field("paths", "StellarAsset", repeated=True, required=False),
+        7: protobuf.Field("paths", "StellarAsset", repeated=True, required=False, default=None),
     }
 
     def __init__(
@@ -6587,7 +6587,7 @@ class StellarPathPaymentStrictSendOp(protobuf.MessageType):
 class StellarManageSellOfferOp(protobuf.MessageType):
     MESSAGE_WIRE_TYPE = 213
     FIELDS = {
-        1: protobuf.Field("source_account", "string", repeated=False, required=False),
+        1: protobuf.Field("source_account", "string", repeated=False, required=False, default=None),
         2: protobuf.Field("selling_asset", "StellarAsset", repeated=False, required=True),
         3: protobuf.Field("buying_asset", "StellarAsset", repeated=False, required=True),
         4: protobuf.Field("amount", "sint64", repeated=False, required=True),
@@ -6619,7 +6619,7 @@ class StellarManageSellOfferOp(protobuf.MessageType):
 class StellarManageBuyOfferOp(protobuf.MessageType):
     MESSAGE_WIRE_TYPE = 222
     FIELDS = {
-        1: protobuf.Field("source_account", "string", repeated=False, required=False),
+        1: protobuf.Field("source_account", "string", repeated=False, required=False, default=None),
         2: protobuf.Field("selling_asset", "StellarAsset", repeated=False, required=True),
         3: protobuf.Field("buying_asset", "StellarAsset", repeated=False, required=True),
         4: protobuf.Field("amount", "sint64", repeated=False, required=True),
@@ -6651,7 +6651,7 @@ class StellarManageBuyOfferOp(protobuf.MessageType):
 class StellarCreatePassiveSellOfferOp(protobuf.MessageType):
     MESSAGE_WIRE_TYPE = 214
     FIELDS = {
-        1: protobuf.Field("source_account", "string", repeated=False, required=False),
+        1: protobuf.Field("source_account", "string", repeated=False, required=False, default=None),
         2: protobuf.Field("selling_asset", "StellarAsset", repeated=False, required=True),
         3: protobuf.Field("buying_asset", "StellarAsset", repeated=False, required=True),
         4: protobuf.Field("amount", "sint64", repeated=False, required=True),
@@ -6680,18 +6680,18 @@ class StellarCreatePassiveSellOfferOp(protobuf.MessageType):
 class StellarSetOptionsOp(protobuf.MessageType):
     MESSAGE_WIRE_TYPE = 215
     FIELDS = {
-        1: protobuf.Field("source_account", "string", repeated=False, required=False),
-        2: protobuf.Field("inflation_destination_account", "string", repeated=False, required=False),
-        3: protobuf.Field("clear_flags", "uint32", repeated=False, required=False),
-        4: protobuf.Field("set_flags", "uint32", repeated=False, required=False),
-        5: protobuf.Field("master_weight", "uint32", repeated=False, required=False),
-        6: protobuf.Field("low_threshold", "uint32", repeated=False, required=False),
-        7: protobuf.Field("medium_threshold", "uint32", repeated=False, required=False),
-        8: protobuf.Field("high_threshold", "uint32", repeated=False, required=False),
-        9: protobuf.Field("home_domain", "string", repeated=False, required=False),
-        10: protobuf.Field("signer_type", "StellarSignerType", repeated=False, required=False),
-        11: protobuf.Field("signer_key", "bytes", repeated=False, required=False),
-        12: protobuf.Field("signer_weight", "uint32", repeated=False, required=False),
+        1: protobuf.Field("source_account", "string", repeated=False, required=False, default=None),
+        2: protobuf.Field("inflation_destination_account", "string", repeated=False, required=False, default=None),
+        3: protobuf.Field("clear_flags", "uint32", repeated=False, required=False, default=None),
+        4: protobuf.Field("set_flags", "uint32", repeated=False, required=False, default=None),
+        5: protobuf.Field("master_weight", "uint32", repeated=False, required=False, default=None),
+        6: protobuf.Field("low_threshold", "uint32", repeated=False, required=False, default=None),
+        7: protobuf.Field("medium_threshold", "uint32", repeated=False, required=False, default=None),
+        8: protobuf.Field("high_threshold", "uint32", repeated=False, required=False, default=None),
+        9: protobuf.Field("home_domain", "string", repeated=False, required=False, default=None),
+        10: protobuf.Field("signer_type", "StellarSignerType", repeated=False, required=False, default=None),
+        11: protobuf.Field("signer_key", "bytes", repeated=False, required=False, default=None),
+        12: protobuf.Field("signer_weight", "uint32", repeated=False, required=False, default=None),
     }
 
     def __init__(
@@ -6727,7 +6727,7 @@ class StellarSetOptionsOp(protobuf.MessageType):
 class StellarChangeTrustOp(protobuf.MessageType):
     MESSAGE_WIRE_TYPE = 216
     FIELDS = {
-        1: protobuf.Field("source_account", "string", repeated=False, required=False),
+        1: protobuf.Field("source_account", "string", repeated=False, required=False, default=None),
         2: protobuf.Field("asset", "StellarAsset", repeated=False, required=True),
         3: protobuf.Field("limit", "uint64", repeated=False, required=True),
     }
@@ -6747,10 +6747,10 @@ class StellarChangeTrustOp(protobuf.MessageType):
 class StellarAllowTrustOp(protobuf.MessageType):
     MESSAGE_WIRE_TYPE = 217
     FIELDS = {
-        1: protobuf.Field("source_account", "string", repeated=False, required=False),
+        1: protobuf.Field("source_account", "string", repeated=False, required=False, default=None),
         2: protobuf.Field("trusted_account", "string", repeated=False, required=True),
         3: protobuf.Field("asset_type", "StellarAssetType", repeated=False, required=True),
-        4: protobuf.Field("asset_code", "string", repeated=False, required=False),
+        4: protobuf.Field("asset_code", "string", repeated=False, required=False, default=None),
         5: protobuf.Field("is_authorized", "bool", repeated=False, required=True),
     }
 
@@ -6773,7 +6773,7 @@ class StellarAllowTrustOp(protobuf.MessageType):
 class StellarAccountMergeOp(protobuf.MessageType):
     MESSAGE_WIRE_TYPE = 218
     FIELDS = {
-        1: protobuf.Field("source_account", "string", repeated=False, required=False),
+        1: protobuf.Field("source_account", "string", repeated=False, required=False, default=None),
         2: protobuf.Field("destination_account", "string", repeated=False, required=True),
     }
 
@@ -6790,9 +6790,9 @@ class StellarAccountMergeOp(protobuf.MessageType):
 class StellarManageDataOp(protobuf.MessageType):
     MESSAGE_WIRE_TYPE = 220
     FIELDS = {
-        1: protobuf.Field("source_account", "string", repeated=False, required=False),
+        1: protobuf.Field("source_account", "string", repeated=False, required=False, default=None),
         2: protobuf.Field("key", "string", repeated=False, required=True),
-        3: protobuf.Field("value", "bytes", repeated=False, required=False),
+        3: protobuf.Field("value", "bytes", repeated=False, required=False, default=None),
     }
 
     def __init__(
@@ -6810,7 +6810,7 @@ class StellarManageDataOp(protobuf.MessageType):
 class StellarBumpSequenceOp(protobuf.MessageType):
     MESSAGE_WIRE_TYPE = 221
     FIELDS = {
-        1: protobuf.Field("source_account", "string", repeated=False, required=False),
+        1: protobuf.Field("source_account", "string", repeated=False, required=False, default=None),
         2: protobuf.Field("bump_to", "uint64", repeated=False, required=True),
     }
 
@@ -6844,8 +6844,8 @@ class StellarSignedTx(protobuf.MessageType):
 class TezosGetAddress(protobuf.MessageType):
     MESSAGE_WIRE_TYPE = 150
     FIELDS = {
-        1: protobuf.Field("address_n", "uint32", repeated=True, required=False),
-        2: protobuf.Field("show_display", "bool", repeated=False, required=False),
+        1: protobuf.Field("address_n", "uint32", repeated=True, required=False, default=None),
+        2: protobuf.Field("show_display", "bool", repeated=False, required=False, default=None),
     }
 
     def __init__(
@@ -6875,8 +6875,8 @@ class TezosAddress(protobuf.MessageType):
 class TezosGetPublicKey(protobuf.MessageType):
     MESSAGE_WIRE_TYPE = 154
     FIELDS = {
-        1: protobuf.Field("address_n", "uint32", repeated=True, required=False),
-        2: protobuf.Field("show_display", "bool", repeated=False, required=False),
+        1: protobuf.Field("address_n", "uint32", repeated=True, required=False, default=None),
+        2: protobuf.Field("show_display", "bool", repeated=False, required=False, default=None),
     }
 
     def __init__(
@@ -6906,14 +6906,14 @@ class TezosPublicKey(protobuf.MessageType):
 class TezosSignTx(protobuf.MessageType):
     MESSAGE_WIRE_TYPE = 152
     FIELDS = {
-        1: protobuf.Field("address_n", "uint32", repeated=True, required=False),
+        1: protobuf.Field("address_n", "uint32", repeated=True, required=False, default=None),
         2: protobuf.Field("branch", "bytes", repeated=False, required=True),
-        3: protobuf.Field("reveal", "TezosRevealOp", repeated=False, required=False),
-        4: protobuf.Field("transaction", "TezosTransactionOp", repeated=False, required=False),
-        5: protobuf.Field("origination", "TezosOriginationOp", repeated=False, required=False),
-        6: protobuf.Field("delegation", "TezosDelegationOp", repeated=False, required=False),
-        7: protobuf.Field("proposal", "TezosProposalOp", repeated=False, required=False),
-        8: protobuf.Field("ballot", "TezosBallotOp", repeated=False, required=False),
+        3: protobuf.Field("reveal", "TezosRevealOp", repeated=False, required=False, default=None),
+        4: protobuf.Field("transaction", "TezosTransactionOp", repeated=False, required=False, default=None),
+        5: protobuf.Field("origination", "TezosOriginationOp", repeated=False, required=False, default=None),
+        6: protobuf.Field("delegation", "TezosDelegationOp", repeated=False, required=False, default=None),
+        7: protobuf.Field("proposal", "TezosProposalOp", repeated=False, required=False, default=None),
+        8: protobuf.Field("ballot", "TezosBallotOp", repeated=False, required=False, default=None),
     }
 
     def __init__(
@@ -7014,8 +7014,8 @@ class TezosTransactionOp(protobuf.MessageType):
         5: protobuf.Field("storage_limit", "uint64", repeated=False, required=True),
         6: protobuf.Field("amount", "uint64", repeated=False, required=True),
         7: protobuf.Field("destination", "TezosContractID", repeated=False, required=True),
-        8: protobuf.Field("parameters", "bytes", repeated=False, required=False),
-        10: protobuf.Field("parameters_manager", "TezosParametersManager", repeated=False, required=False),
+        8: protobuf.Field("parameters", "bytes", repeated=False, required=False, default=None),
+        10: protobuf.Field("parameters_manager", "TezosParametersManager", repeated=False, required=False, default=None),
     }
 
     def __init__(
@@ -7050,11 +7050,11 @@ class TezosOriginationOp(protobuf.MessageType):
         3: protobuf.Field("counter", "uint64", repeated=False, required=True),
         4: protobuf.Field("gas_limit", "uint64", repeated=False, required=True),
         5: protobuf.Field("storage_limit", "uint64", repeated=False, required=True),
-        6: protobuf.Field("manager_pubkey", "bytes", repeated=False, required=False),
+        6: protobuf.Field("manager_pubkey", "bytes", repeated=False, required=False, default=None),
         7: protobuf.Field("balance", "uint64", repeated=False, required=True),
-        8: protobuf.Field("spendable", "bool", repeated=False, required=False),
-        9: protobuf.Field("delegatable", "bool", repeated=False, required=False),
-        10: protobuf.Field("delegate", "bytes", repeated=False, required=False),
+        8: protobuf.Field("spendable", "bool", repeated=False, required=False, default=None),
+        9: protobuf.Field("delegatable", "bool", repeated=False, required=False, default=None),
+        10: protobuf.Field("delegate", "bytes", repeated=False, required=False, default=None),
         11: protobuf.Field("script", "bytes", repeated=False, required=True),
     }
 
@@ -7120,7 +7120,7 @@ class TezosProposalOp(protobuf.MessageType):
     FIELDS = {
         1: protobuf.Field("source", "bytes", repeated=False, required=True),
         2: protobuf.Field("period", "uint64", repeated=False, required=True),
-        4: protobuf.Field("proposals", "bytes", repeated=True, required=False),
+        4: protobuf.Field("proposals", "bytes", repeated=True, required=False, default=None),
     }
 
     def __init__(
@@ -7161,9 +7161,9 @@ class TezosBallotOp(protobuf.MessageType):
 class TezosParametersManager(protobuf.MessageType):
     MESSAGE_WIRE_TYPE = None
     FIELDS = {
-        1: protobuf.Field("set_delegate", "bytes", repeated=False, required=False),
-        2: protobuf.Field("cancel_delegate", "bool", repeated=False, required=False),
-        3: protobuf.Field("transfer", "TezosManagerTransfer", repeated=False, required=False),
+        1: protobuf.Field("set_delegate", "bytes", repeated=False, required=False, default=None),
+        2: protobuf.Field("cancel_delegate", "bool", repeated=False, required=False, default=None),
+        3: protobuf.Field("transfer", "TezosManagerTransfer", repeated=False, required=False, default=None),
     }
 
     def __init__(
@@ -7202,7 +7202,7 @@ class WebAuthnListResidentCredentials(protobuf.MessageType):
 class WebAuthnAddResidentCredential(protobuf.MessageType):
     MESSAGE_WIRE_TYPE = 802
     FIELDS = {
-        1: protobuf.Field("credential_id", "bytes", repeated=False, required=False),
+        1: protobuf.Field("credential_id", "bytes", repeated=False, required=False, default=None),
     }
 
     def __init__(
@@ -7216,7 +7216,7 @@ class WebAuthnAddResidentCredential(protobuf.MessageType):
 class WebAuthnRemoveResidentCredential(protobuf.MessageType):
     MESSAGE_WIRE_TYPE = 803
     FIELDS = {
-        1: protobuf.Field("index", "uint32", repeated=False, required=False),
+        1: protobuf.Field("index", "uint32", repeated=False, required=False, default=None),
     }
 
     def __init__(
@@ -7230,7 +7230,7 @@ class WebAuthnRemoveResidentCredential(protobuf.MessageType):
 class WebAuthnCredentials(protobuf.MessageType):
     MESSAGE_WIRE_TYPE = 801
     FIELDS = {
-        1: protobuf.Field("credentials", "WebAuthnCredential", repeated=True, required=False),
+        1: protobuf.Field("credentials", "WebAuthnCredential", repeated=True, required=False, default=None),
     }
 
     def __init__(
@@ -7244,18 +7244,18 @@ class WebAuthnCredentials(protobuf.MessageType):
 class WebAuthnCredential(protobuf.MessageType):
     MESSAGE_WIRE_TYPE = None
     FIELDS = {
-        1: protobuf.Field("index", "uint32", repeated=False, required=False),
-        2: protobuf.Field("id", "bytes", repeated=False, required=False),
-        3: protobuf.Field("rp_id", "string", repeated=False, required=False),
-        4: protobuf.Field("rp_name", "string", repeated=False, required=False),
-        5: protobuf.Field("user_id", "bytes", repeated=False, required=False),
-        6: protobuf.Field("user_name", "string", repeated=False, required=False),
-        7: protobuf.Field("user_display_name", "string", repeated=False, required=False),
-        8: protobuf.Field("creation_time", "uint32", repeated=False, required=False),
-        9: protobuf.Field("hmac_secret", "bool", repeated=False, required=False),
-        10: protobuf.Field("use_sign_count", "bool", repeated=False, required=False),
-        11: protobuf.Field("algorithm", "sint32", repeated=False, required=False),
-        12: protobuf.Field("curve", "sint32", repeated=False, required=False),
+        1: protobuf.Field("index", "uint32", repeated=False, required=False, default=None),
+        2: protobuf.Field("id", "bytes", repeated=False, required=False, default=None),
+        3: protobuf.Field("rp_id", "string", repeated=False, required=False, default=None),
+        4: protobuf.Field("rp_name", "string", repeated=False, required=False, default=None),
+        5: protobuf.Field("user_id", "bytes", repeated=False, required=False, default=None),
+        6: protobuf.Field("user_name", "string", repeated=False, required=False, default=None),
+        7: protobuf.Field("user_display_name", "string", repeated=False, required=False, default=None),
+        8: protobuf.Field("creation_time", "uint32", repeated=False, required=False, default=None),
+        9: protobuf.Field("hmac_secret", "bool", repeated=False, required=False, default=None),
+        10: protobuf.Field("use_sign_count", "bool", repeated=False, required=False, default=None),
+        11: protobuf.Field("algorithm", "sint32", repeated=False, required=False, default=None),
+        12: protobuf.Field("curve", "sint32", repeated=False, required=False, default=None),
     }
 
     def __init__(

--- a/python/src/trezorlib/messages.py
+++ b/python/src/trezorlib/messages.py
@@ -6064,7 +6064,7 @@ class NEMTransfer(protobuf.MessageType):
     FIELDS = {
         1: protobuf.Field("recipient", "string", repeated=False, required=True),
         2: protobuf.Field("amount", "uint64", repeated=False, required=True),
-        3: protobuf.Field("payload", "bytes", repeated=False, required=False, default=b''),
+        3: protobuf.Field("payload", "bytes", repeated=False, required=False, default=None),
         4: protobuf.Field("public_key", "bytes", repeated=False, required=False, default=None),
         5: protobuf.Field("mosaics", "NEMMosaic", repeated=True, required=False, default=None),
     }
@@ -6075,7 +6075,7 @@ class NEMTransfer(protobuf.MessageType):
         recipient: "str",
         amount: "int",
         mosaics: Optional[Sequence["NEMMosaic"]] = None,
-        payload: Optional["bytes"] = b'',
+        payload: Optional["bytes"] = None,
         public_key: Optional["bytes"] = None,
     ) -> None:
         self.mosaics: Sequence["NEMMosaic"] = mosaics if mosaics is not None else []


### PR DESCRIPTION
Connected with https://github.com/trezor/trezor-firmware/issues/2527:
- add missing default value into creation of `protobuf.Field` in `python/src/trezorlib/messages.py`

There were two possible ways how to include the `default` kwarg :
1. when `field.default_value is not None`, as `None` is the "default-default" value
2. when `not field.required` - for all fields that do not enforce a value to be set

In the end, I chose `#2`, so seeing `default=...` is another sign that the field is not required.


> (Somewhat related, the Rust protobuf descriptors [wrongly decode](https://github.com/trezor/trezor-firmware/blob/master/common/protob/pb2py#L641) default=true as false)

I did not look into this, how can I replicate the issue? 