### PR TITLE
chore: update tokens & networks

### DIFF
--- a/common/defs/coins_details.json
+++ b/common/defs/coins_details.json
@@ -5,7 +5,7 @@
                 "Github": "https://github.com/Actinium-project/Actinium",
                 "Homepage": "https://actinium.org"
             },
-            "marketcap_usd": 184701,
+            "marketcap_usd": 172941,
             "name": "Actinium",
             "shortcut": "ACM",
             "t1_enabled": "yes",
@@ -23,7 +23,7 @@
                 "Github": "https://github.com/axerunners/axe",
                 "Homepage": "https://axerunners.com"
             },
-            "marketcap_usd": 56264,
+            "marketcap_usd": 30507,
             "name": "Axe",
             "shortcut": "AXE",
             "t1_enabled": "yes",
@@ -41,7 +41,7 @@
                 "Github": "https://github.com/Bitcoin-ABC/bitcoin-abc",
                 "Homepage": "https://www.bitcoincash.org"
             },
-            "marketcap_usd": 2496066891,
+            "marketcap_usd": 2214931259,
             "name": "Bitcoin Cash",
             "shortcut": "BCH",
             "t1_enabled": "yes",
@@ -67,7 +67,7 @@
                 "Github": "https://github.com/bitcoin/bitcoin",
                 "Homepage": "https://bitcoin.org"
             },
-            "marketcap_usd": 434848242730,
+            "marketcap_usd": 397443189527,
             "name": "Bitcoin",
             "shortcut": "BTC",
             "t1_enabled": "yes",
@@ -93,7 +93,7 @@
                 "Github": "https://github.com/BTCPrivate/BitcoinPrivate",
                 "Homepage": "https://btcprivate.org"
             },
-            "marketcap_usd": 3886616,
+            "marketcap_usd": 3221199,
             "name": "Bitcoin Private",
             "shortcut": "BTCP",
             "t1_enabled": "yes",
@@ -111,7 +111,7 @@
                 "Github": "https://github.com/BTCGPU/BTCGPU",
                 "Homepage": "https://bitcoingold.org"
             },
-            "marketcap_usd": 481737614,
+            "marketcap_usd": 309410088,
             "name": "Bitcoin Gold",
             "shortcut": "BTG",
             "t1_enabled": "yes",
@@ -137,7 +137,7 @@
                 "Github": "https://github.com/LIMXTEC/BitCore",
                 "Homepage": "https://bitcore.cc"
             },
-            "marketcap_usd": 1458461,
+            "marketcap_usd": 806567,
             "name": "Bitcore",
             "shortcut": "BTX",
             "t1_enabled": "yes",
@@ -173,7 +173,7 @@
                 "Github": "https://github.com/Crowndev/crowncoin",
                 "Homepage": "https://crownplatform.com"
             },
-            "marketcap_usd": 481509,
+            "marketcap_usd": 377382,
             "name": "Crown",
             "shortcut": "CRW",
             "t1_enabled": "yes",
@@ -191,7 +191,7 @@
                 "Github": "https://github.com/dashpay/dash",
                 "Homepage": "https://www.dash.org"
             },
-            "marketcap_usd": 515576993,
+            "marketcap_usd": 472329939,
             "name": "Dash",
             "shortcut": "DASH",
             "t1_enabled": "yes",
@@ -221,7 +221,7 @@
                 "Github": "https://github.com/decred/dcrd",
                 "Homepage": "https://www.decred.org"
             },
-            "marketcap_usd": 371163963,
+            "marketcap_usd": 399928972,
             "name": "Decred",
             "shortcut": "DCR",
             "t1_enabled": "yes",
@@ -239,7 +239,7 @@
                 "Github": "https://github.com/digibyte/digibyte",
                 "Homepage": "https://digibyte.io"
             },
-            "marketcap_usd": 171723512,
+            "marketcap_usd": 141698440,
             "name": "DigiByte",
             "shortcut": "DGB",
             "t1_enabled": "yes",
@@ -261,7 +261,7 @@
                 "Github": "https://github.com/dogecoin/dogecoin",
                 "Homepage": "https://dogecoin.com"
             },
-            "marketcap_usd": 8778128377,
+            "marketcap_usd": 10295057684,
             "name": "Dogecoin",
             "shortcut": "DOGE",
             "t1_enabled": "yes",
@@ -296,7 +296,7 @@
                 "Github": "https://github.com/firoorg/firo",
                 "Homepage": "https://firo.org"
             },
-            "marketcap_usd": 30950896,
+            "marketcap_usd": 26621614,
             "name": "Firo",
             "shortcut": "FIRO",
             "t1_enabled": "yes",
@@ -354,7 +354,7 @@
                 "Github": "https://github.com/FeatherCoin/Feathercoin",
                 "Homepage": "https://feathercoin.com"
             },
-            "marketcap_usd": 1667054,
+            "marketcap_usd": 1568008,
             "name": "Feathercoin",
             "shortcut": "FTC",
             "t1_enabled": "yes",
@@ -372,7 +372,7 @@
                 "Github": "https://github.com/Groestlcoin/groestlcoin",
                 "Homepage": "https://www.groestlcoin.org"
             },
-            "marketcap_usd": 27800688,
+            "marketcap_usd": 27086529,
             "name": "Groestlcoin",
             "shortcut": "GRS",
             "t1_enabled": "yes",
@@ -390,7 +390,7 @@
                 "Github": "https://github.com/komodoplatform/komodo",
                 "Homepage": "https://komodoplatform.com"
             },
-            "marketcap_usd": 39771179,
+            "marketcap_usd": 33951583,
             "name": "Komodo",
             "shortcut": "KMD",
             "t1_enabled": "yes",
@@ -421,7 +421,7 @@
                 "Github": "https://github.com/litecoin-project/litecoin",
                 "Homepage": "https://litecoin.org"
             },
-            "marketcap_usd": 4045640645,
+            "marketcap_usd": 4029105520,
             "name": "Litecoin",
             "shortcut": "LTC",
             "t1_enabled": "yes",
@@ -447,7 +447,7 @@
                 "Github": "https://github.com/monacoinproject/monacoin",
                 "Homepage": "https://monacoin.org"
             },
-            "marketcap_usd": 36577322,
+            "marketcap_usd": 28448057,
             "name": "Monacoin",
             "shortcut": "MONA",
             "t1_enabled": "yes",
@@ -483,7 +483,7 @@
                 "Github": "https://github.com/namecoin/namecoin-core",
                 "Homepage": "https://namecoin.org"
             },
-            "marketcap_usd": 17450523,
+            "marketcap_usd": 16519482,
             "name": "Namecoin",
             "shortcut": "NMC",
             "t1_enabled": "yes",
@@ -505,7 +505,7 @@
                 "Github": "https://github.com/peercoin/peercoin",
                 "Homepage": "https://peercoin.net"
             },
-            "marketcap_usd": 9800439,
+            "marketcap_usd": 14037442,
             "name": "Peercoin",
             "shortcut": "PPC",
             "t1_enabled": "yes",
@@ -518,7 +518,7 @@
                 "Github": "https://github.com/qtumproject/qtum",
                 "Homepage": "https://qtum.org"
             },
-            "marketcap_usd": 404698981,
+            "marketcap_usd": 299918388,
             "name": "Qtum",
             "shortcut": "QTUM",
             "t1_enabled": "yes",
@@ -536,7 +536,7 @@
                 "Github": "https://github.com/RitoProject",
                 "Homepage": "https://ritocoin.org"
             },
-            "marketcap_usd": 38680,
+            "marketcap_usd": 70995,
             "name": "Ritocoin",
             "shortcut": "RITO",
             "t1_enabled": "yes",
@@ -554,7 +554,7 @@
                 "Github": "https://github.com/RavenProject/Ravencoin",
                 "Homepage": "https://ravencoin.org"
             },
-            "marketcap_usd": 368391051,
+            "marketcap_usd": 380378879,
             "name": "Ravencoin",
             "shortcut": "RVN",
             "t1_enabled": "yes",
@@ -576,7 +576,7 @@
                 "Github": "https://github.com/SmartCash/Core-Smart",
                 "Homepage": "https://smartcash.cc"
             },
-            "marketcap_usd": 689180,
+            "marketcap_usd": 645237,
             "name": "SmartCash",
             "shortcut": "SMART",
             "t1_enabled": "yes",
@@ -594,7 +594,7 @@
                 "Github": "https://github.com/syscoin/syscoin",
                 "Homepage": "https://syscoin.org"
             },
-            "marketcap_usd": 113145909,
+            "marketcap_usd": 101192148,
             "name": "Syscoin",
             "shortcut": "SYS",
             "t1_enabled": "yes",
@@ -630,7 +630,7 @@
                 "Github": "https://github.com/viacoin",
                 "Homepage": "https://viacoin.org"
             },
-            "marketcap_usd": 4313627,
+            "marketcap_usd": 4612345,
             "name": "Viacoin",
             "shortcut": "VIA",
             "t1_enabled": "yes",
@@ -666,7 +666,7 @@
                 "Github": "https://github.com/vertcoin-project/vertcoin-core",
                 "Homepage": "https://vertcoin.org"
             },
-            "marketcap_usd": 9923431,
+            "marketcap_usd": 12932358,
             "name": "Vertcoin",
             "shortcut": "VTC",
             "t1_enabled": "yes",
@@ -684,7 +684,7 @@
                 "Github": "https://github.com/primecoin/primecoin",
                 "Homepage": "https://primecoin.io"
             },
-            "marketcap_usd": 1608155,
+            "marketcap_usd": 1605134,
             "name": "Primecoin",
             "shortcut": "XPM",
             "t1_enabled": "yes",
@@ -702,7 +702,7 @@
                 "Github": "https://gitlab.com/bitcoinrh/BRhodiumNode",
                 "Homepage": "https://xrhodium.org"
             },
-            "marketcap_usd": 329364,
+            "marketcap_usd": 278372,
             "name": "xRhodium",
             "shortcut": "XRC",
             "t1_enabled": "yes",
@@ -738,7 +738,7 @@
                 "Github": "https://github.com/vergecurrency/VERGE",
                 "Homepage": "https://vergecurrency.com"
             },
-            "marketcap_usd": 60572022,
+            "marketcap_usd": 52487254,
             "name": "Verge",
             "shortcut": "XVG",
             "t1_enabled": "yes",
@@ -756,7 +756,7 @@
                 "Github": "https://github.com/zcore-coin/zcore-2.0",
                 "Homepage": "https://zcore.cash"
             },
-            "marketcap_usd": 47421,
+            "marketcap_usd": 40144,
             "name": "ZCore",
             "shortcut": "ZCR",
             "t1_enabled": "yes",
@@ -774,7 +774,7 @@
                 "Github": "https://github.com/zcash/zcash",
                 "Homepage": "https://z.cash"
             },
-            "marketcap_usd": 903925624,
+            "marketcap_usd": 858808207,
             "name": "Zcash",
             "shortcut": "ZEC",
             "t1_enabled": "yes",
@@ -788,53 +788,6 @@
                 {
                     "name": "Exodus",
                     "url": "https://www.exodus.io"
-                }
-            ]
-        },
-        "erc20:avax:AVAX": {
-            "address": "0xB31f66AA3C1e785363F0875A1B74E27b85FD66c7",
-            "links": {
-                "Github": "https://github.com/ava-labs",
-                "Homepage": "https://www.avalabs.org"
-            },
-            "marketcap_usd": 0,
-            "name": "Avalanche",
-            "network": "avax",
-            "shortcut": "AVAX",
-            "t1_enabled": "yes",
-            "t2_enabled": "yes",
-            "type": "erc20",
-            "wallet": [
-                {
-                    "name": "MyCrypto",
-                    "url": "https://mycrypto.com"
-                },
-                {
-                    "name": "MyEtherWallet",
-                    "url": "https://www.myetherwallet.com"
-                }
-            ]
-        },
-        "erc20:avax:USDT": {
-            "address": "0xde3A24028580884448a5397872046a019649b084",
-            "links": {
-                "Homepage": "https://tether.to/"
-            },
-            "marketcap_usd": 0,
-            "name": "Tether",
-            "network": "avax",
-            "shortcut": "USDT",
-            "t1_enabled": "yes",
-            "t2_enabled": "yes",
-            "type": "erc20",
-            "wallet": [
-                {
-                    "name": "MyCrypto",
-                    "url": "https://mycrypto.com"
-                },
-                {
-                    "name": "MyEtherWallet",
-                    "url": "https://www.myetherwallet.com"
                 }
             ]
         },
@@ -962,7 +915,7 @@
             "links": {
                 "Homepage": "https://0xbitcoin.org/"
             },
-            "marketcap_usd": 3040703,
+            "marketcap_usd": 1775120,
             "name": "0xBitcoin",
             "network": "eth",
             "shortcut": "0xBTC",
@@ -1020,7 +973,7 @@
             "links": {
                 "Homepage": "https://ico.1worldonline.com"
             },
-            "marketcap_usd": 2921886,
+            "marketcap_usd": 3789412,
             "name": "1World",
             "network": "eth",
             "shortcut": "1WO",
@@ -1098,7 +1051,7 @@
                 "Github": "https://github.com/crypt04dvisor/AlphaWallet",
                 "Homepage": "https://alphaplatform.co/"
             },
-            "marketcap_usd": 289970,
+            "marketcap_usd": 280654,
             "name": "Alpha",
             "network": "eth",
             "shortcut": "A",
@@ -1118,7 +1071,7 @@
                 "Github": "https://github.com/aave",
                 "Homepage": "https://aave.com/ "
             },
-            "marketcap_usd": 1263971663,
+            "marketcap_usd": 1197987039,
             "name": "Aave",
             "network": "eth",
             "shortcut": "AAVE",
@@ -1197,7 +1150,7 @@
             "links": {
                 "Homepage": "https://www.arcblock.io"
             },
-            "marketcap_usd": 9017642,
+            "marketcap_usd": 12225855,
             "name": "ArcBlock Token",
             "network": "eth",
             "shortcut": "ABT",
@@ -1217,7 +1170,7 @@
                 "Github": "https://github.com/theabyssportal",
                 "Homepage": "https://www.theabyss.com"
             },
-            "marketcap_usd": 4225172,
+            "marketcap_usd": 3728120,
             "name": "Abyss Token",
             "network": "eth",
             "shortcut": "ABYSS",
@@ -1274,7 +1227,7 @@
             "links": {
                 "Homepage": "https://adbank.network"
             },
-            "marketcap_usd": 410296,
+            "marketcap_usd": 441475,
             "name": "adbank",
             "network": "eth",
             "shortcut": "ADB",
@@ -1353,7 +1306,7 @@
                 "Github": "https://github.com/aditus",
                 "Homepage": "https://aditus.net"
             },
-            "marketcap_usd": 48681,
+            "marketcap_usd": 49993,
             "name": "Aditus",
             "network": "eth",
             "shortcut": "ADI",
@@ -1432,7 +1385,7 @@
                 "Github": "https://github.com/AdExNetwork",
                 "Homepage": "https://www.adex.network"
             },
-            "marketcap_usd": 25841840,
+            "marketcap_usd": 24887996,
             "name": "AdEx Network",
             "network": "eth",
             "shortcut": "ADX",
@@ -1572,7 +1525,7 @@
                 "Github": "https://github.com/IDNI",
                 "Homepage": "https://tau.net/"
             },
-            "marketcap_usd": 6421395,
+            "marketcap_usd": 3732460,
             "name": "Agoras: Currency of Tau",
             "network": "eth",
             "shortcut": "AGRS",
@@ -1630,7 +1583,7 @@
             "links": {
                 "Homepage": "https://www.aidcoin.co"
             },
-            "marketcap_usd": 80657,
+            "marketcap_usd": 163630,
             "name": "AidCoin",
             "network": "eth",
             "shortcut": "AID",
@@ -1689,7 +1642,7 @@
                 "Github": "https://github.com/AigangNetwork",
                 "Homepage": "https://aigang.network/"
             },
-            "marketcap_usd": 120685,
+            "marketcap_usd": 16229,
             "name": "Aigang",
             "network": "eth",
             "shortcut": "AIX",
@@ -1748,7 +1701,7 @@
                 "Github": "https://github.com/aleph-im/",
                 "Homepage": "https://aleph.im"
             },
-            "marketcap_usd": 63449522,
+            "marketcap_usd": 25025833,
             "name": "Aleph.im",
             "network": "eth",
             "shortcut": "ALEPH",
@@ -1767,7 +1720,7 @@
             "links": {
                 "Homepage": "http://ailink.in"
             },
-            "marketcap_usd": 151862,
+            "marketcap_usd": 0,
             "name": "AiLink Token",
             "network": "eth",
             "shortcut": "ALI",
@@ -1925,7 +1878,7 @@
                 "Github": "https://github.com/amlt-by-coinfirm",
                 "Homepage": "https://amlt.coinfirm.io/"
             },
-            "marketcap_usd": 1252595,
+            "marketcap_usd": 1115162,
             "name": "AMLT",
             "network": "eth",
             "shortcut": "AMLT",
@@ -1945,7 +1898,7 @@
                 "Github": "https://github.com/amontech",
                 "Homepage": "https://amon.tech"
             },
-            "marketcap_usd": 119908,
+            "marketcap_usd": 98793,
             "name": "Amon",
             "network": "eth",
             "shortcut": "AMN",
@@ -1965,7 +1918,7 @@
                 "Github": "https://github.com/AMO-Project/",
                 "Homepage": "https://amo.foundation"
             },
-            "marketcap_usd": 25939045,
+            "marketcap_usd": 19946579,
             "name": "AMO Coin",
             "network": "eth",
             "shortcut": "AMO",
@@ -1984,7 +1937,7 @@
             "links": {
                 "Homepage": "https://ados.foundation/"
             },
-            "marketcap_usd": 673061,
+            "marketcap_usd": 349358,
             "name": "Token AmonD",
             "network": "eth",
             "shortcut": "AMON",
@@ -2004,7 +1957,7 @@
                 "Github": "https://github.com/amptoken",
                 "Homepage": "https://amptoken.org"
             },
-            "marketcap_usd": 348662440,
+            "marketcap_usd": 207935841,
             "name": "Amp",
             "network": "eth",
             "shortcut": "AMP",
@@ -2024,7 +1977,7 @@
                 "Github": "https://github.com/ampleforth",
                 "Homepage": "https://ampleforth.org"
             },
-            "marketcap_usd": 42132846,
+            "marketcap_usd": 51797695,
             "name": "Ampleforth",
             "network": "eth",
             "shortcut": "AMPL",
@@ -2102,7 +2055,7 @@
             "links": {
                 "Homepage": "https://www.aurorachain.io"
             },
-            "marketcap_usd": 3587829,
+            "marketcap_usd": 2183155,
             "name": "Aurora",
             "network": "eth",
             "shortcut": "AOA",
@@ -2122,7 +2075,7 @@
                 "Github": "https://github.com/api3dao",
                 "Homepage": "https://api3.org/"
             },
-            "marketcap_usd": 106625736,
+            "marketcap_usd": 97777429,
             "name": "API3",
             "network": "eth",
             "shortcut": "API3",
@@ -2201,7 +2154,7 @@
                 "Github": "https://github.com/alphaquark/Alpha-Quark",
                 "Homepage": "https://www.alphaquark.io"
             },
-            "marketcap_usd": 37868889,
+            "marketcap_usd": 28972757,
             "name": "AlphaQuarkToken",
             "network": "eth",
             "shortcut": "AQT",
@@ -2240,7 +2193,7 @@
             "links": {
                 "Homepage": "https://www.arbitragect.com"
             },
-            "marketcap_usd": 35721,
+            "marketcap_usd": 21674,
             "name": "ArbitrageCT",
             "network": "eth",
             "shortcut": "ARCT",
@@ -2319,7 +2272,7 @@
                 "Github": "https://github.com/aeronaero/aeron",
                 "Homepage": "https://aeron.aero"
             },
-            "marketcap_usd": 188497,
+            "marketcap_usd": 481,
             "name": "Aeron",
             "network": "eth",
             "shortcut": "ARNX",
@@ -2338,7 +2291,7 @@
             "links": {
                 "Homepage": "http://www.maecenas.co"
             },
-            "marketcap_usd": 228674,
+            "marketcap_usd": 62289,
             "name": "Maecenas",
             "network": "eth",
             "shortcut": "ART",
@@ -2416,7 +2369,7 @@
             "links": {
                 "Homepage": "https://airswap.io"
             },
-            "marketcap_usd": 12756061,
+            "marketcap_usd": 24690535,
             "name": "Airswap",
             "network": "eth",
             "shortcut": "AST",
@@ -2455,7 +2408,7 @@
             "links": {
                 "Homepage": "https://atlant.io"
             },
-            "marketcap_usd": 157448,
+            "marketcap_usd": 607063,
             "name": "ATLANT",
             "network": "eth",
             "shortcut": "ATL",
@@ -2571,7 +2524,7 @@
             "links": {
                 "Homepage": "https://auctus.org"
             },
-            "marketcap_usd": 136763,
+            "marketcap_usd": 99754,
             "name": "Auctus",
             "network": "eth",
             "shortcut": "AUC",
@@ -2591,7 +2544,7 @@
                 "Github": "https://github.com/audiusproject",
                 "Homepage": "https://audius.co"
             },
-            "marketcap_usd": 272001092,
+            "marketcap_usd": 163208812,
             "name": "Audius",
             "network": "eth",
             "shortcut": "AUDIO",
@@ -2688,7 +2641,7 @@
             "links": {
                 "Homepage": "https://aventus.io"
             },
-            "marketcap_usd": 9329258,
+            "marketcap_usd": 9914935,
             "name": "Aventus",
             "network": "eth",
             "shortcut": "AVT",
@@ -2787,7 +2740,7 @@
                 "Github": "https://github.com/axieinfinity",
                 "Homepage": "https://axieinfinity.com/"
             },
-            "marketcap_usd": 1386248511,
+            "marketcap_usd": 889388236,
             "name": "Axie Infinity Shards",
             "network": "eth",
             "shortcut": "AXS",
@@ -2846,7 +2799,7 @@
                 "Github": "https://github.com/balancer-labs",
                 "Homepage": "https://balancer.finance"
             },
-            "marketcap_usd": 248211099,
+            "marketcap_usd": 310309073,
             "name": "Balancer",
             "network": "eth",
             "shortcut": "BAL",
@@ -2905,7 +2858,7 @@
             "links": {
                 "Homepage": "https://www.banca.world"
             },
-            "marketcap_usd": 395270,
+            "marketcap_usd": 201970,
             "name": "Banca",
             "network": "eth",
             "shortcut": "BANCA",
@@ -2963,7 +2916,7 @@
             "links": {
                 "Homepage": "https://basicattentiontoken.org"
             },
-            "marketcap_usd": 586806236,
+            "marketcap_usd": 442552626,
             "name": "Basic Attention Token",
             "network": "eth",
             "shortcut": "BAT",
@@ -3059,7 +3012,7 @@
             "links": {
                 "Homepage": "https://bigbom.com"
             },
-            "marketcap_usd": 80106,
+            "marketcap_usd": 0,
             "name": "Bigbom",
             "network": "eth",
             "shortcut": "BBO",
@@ -3157,7 +3110,7 @@
                 "Github": "https://github.com/VinceBCD/BCDiploma",
                 "Homepage": "https://www.bcdiploma.com"
             },
-            "marketcap_usd": 3360710,
+            "marketcap_usd": 2576751,
             "name": "Blockchain Certified Data Token",
             "network": "eth",
             "shortcut": "BCDT",
@@ -3215,7 +3168,7 @@
                 "Github": "https://github.com/blockmason",
                 "Homepage": "https://blockmason.io"
             },
-            "marketcap_usd": 209143,
+            "marketcap_usd": 268967,
             "name": "BlockMason Credit Protocol Token",
             "network": "eth",
             "shortcut": "BCPT",
@@ -3235,7 +3188,7 @@
                 "Github": "https://github.com/bitcv",
                 "Homepage": "https://bitcv.one/"
             },
-            "marketcap_usd": 138527,
+            "marketcap_usd": 134818,
             "name": "BitCapitalVendor Token",
             "network": "eth",
             "shortcut": "BCV",
@@ -3334,7 +3287,7 @@
                 "Github": "https://github.com/Rentberry",
                 "Homepage": "https://rentberry.com"
             },
-            "marketcap_usd": 144721,
+            "marketcap_usd": 74068,
             "name": "Berry",
             "network": "eth",
             "shortcut": "BERRY",
@@ -3432,7 +3385,7 @@
             "links": {
                 "Homepage": "https://bnktothefuture.com"
             },
-            "marketcap_usd": 3835740,
+            "marketcap_usd": 6291869,
             "name": "BnkToTheFuture",
             "network": "eth",
             "shortcut": "BFT",
@@ -3548,7 +3501,7 @@
                 "Github": "https://github.com/BitScreenerTech",
                 "Homepage": "https://tokensale.bitscreener.com/"
             },
-            "marketcap_usd": 56549,
+            "marketcap_usd": 0,
             "name": "Token BitScreenerToken",
             "network": "eth",
             "shortcut": "BITX",
@@ -3704,7 +3657,7 @@
                 "Github": "https://github.com/hellobloom",
                 "Homepage": "https://hellobloom.io"
             },
-            "marketcap_usd": 267371,
+            "marketcap_usd": 1889666,
             "name": "Bloom",
             "network": "eth",
             "shortcut": "BLT",
@@ -3724,7 +3677,7 @@
                 "Github": "https://github.com/BlueCrypto",
                 "Homepage": "https://blueprotocol.com/"
             },
-            "marketcap_usd": 380317,
+            "marketcap_usd": 203541,
             "name": "Ethereum Blue",
             "network": "eth",
             "shortcut": "BLUE",
@@ -3782,7 +3735,7 @@
             "links": {
                 "Homepage": "https://bluzelle.com"
             },
-            "marketcap_usd": 32920340,
+            "marketcap_usd": 26719149,
             "name": "Bluzelle",
             "network": "eth",
             "shortcut": "BLZ",
@@ -3821,7 +3774,7 @@
             "links": {
                 "Homepage": "https://www.bitmart.com"
             },
-            "marketcap_usd": 35600307,
+            "marketcap_usd": 25174701,
             "name": "BitMart Token",
             "network": "eth",
             "shortcut": "BMX",
@@ -3840,7 +3793,7 @@
             "links": {
                 "Homepage": "https://www.binance.com"
             },
-            "marketcap_usd": 44690398276,
+            "marketcap_usd": 46304453916,
             "name": "Binance Coin",
             "network": "eth",
             "shortcut": "BNB",
@@ -3899,7 +3852,7 @@
                 "Github": "https://github.com/bancorprotocol",
                 "Homepage": "https://www.bancor.network"
             },
-            "marketcap_usd": 110012703,
+            "marketcap_usd": 89351905,
             "name": "Bancor Network Token",
             "network": "eth",
             "shortcut": "BNT",
@@ -3918,7 +3871,7 @@
             "links": {
                 "Homepage": "https://bounty0x.io"
             },
-            "marketcap_usd": 208716,
+            "marketcap_usd": 253555,
             "name": "Bounty0x Token",
             "network": "eth",
             "shortcut": "BNTY",
@@ -3937,7 +3890,7 @@
             "links": {
                 "Homepage": "https://bobsrepair.com"
             },
-            "marketcap_usd": 412870,
+            "marketcap_usd": 330245,
             "name": "Bob's repair",
             "network": "eth",
             "shortcut": "BOB",
@@ -4014,7 +3967,7 @@
             "links": {
                 "Homepage": "https://bonpay.com"
             },
-            "marketcap_usd": 7707,
+            "marketcap_usd": 7014,
             "name": "Bonpay",
             "network": "eth",
             "shortcut": "BON",
@@ -4071,7 +4024,7 @@
             "links": {
                 "Homepage": "https://www.bouts.pro"
             },
-            "marketcap_usd": 30800,
+            "marketcap_usd": 15393,
             "name": "BoutsPro",
             "network": "eth",
             "shortcut": "BOUTS",
@@ -4094,26 +4047,6 @@
             "name": "BOXX Token [Blockparty]",
             "network": "eth",
             "shortcut": "BOXX",
-            "t1_enabled": "yes",
-            "t2_enabled": "yes",
-            "type": "erc20",
-            "wallet": [
-                {
-                    "name": "Trezor Suite",
-                    "url": "https://suite.trezor.io"
-                }
-            ]
-        },
-        "erc20:eth:BPF": {
-            "address": "0x5197FBE1a86679FF1360E27862BF88B0c5119BD8",
-            "links": {
-                "Github": "https://github.com/bitpif",
-                "Homepage": "https://bitpif.com"
-            },
-            "marketcap_usd": 0,
-            "name": "BITPIF",
-            "network": "eth",
-            "shortcut": "BPF",
             "t1_enabled": "yes",
             "t2_enabled": "yes",
             "type": "erc20",
@@ -4188,7 +4121,7 @@
                 "Github": "https://github.com/breadwallet",
                 "Homepage": "https://token.breadapp.com/en"
             },
-            "marketcap_usd": 6943143,
+            "marketcap_usd": 636764,
             "name": "Bread",
             "network": "eth",
             "shortcut": "BRD",
@@ -4520,7 +4453,7 @@
             "links": {
                 "Homepage": "https://www.bottos.org"
             },
-            "marketcap_usd": 310857,
+            "marketcap_usd": 283445,
             "name": "Bottos",
             "network": "eth",
             "shortcut": "BTO",
@@ -4598,7 +4531,7 @@
                 "Github": "https://github.com/btuprotocol",
                 "Homepage": "https://btu-protocol.com"
             },
-            "marketcap_usd": 27884983,
+            "marketcap_usd": 0,
             "name": "BTU Protocol",
             "network": "eth",
             "shortcut": "BTU",
@@ -4657,7 +4590,7 @@
                 "Github": "https://github.com/paxosglobal/busd-contract",
                 "Homepage": "https://www.paxos.com/busd"
             },
-            "marketcap_usd": 17917643708,
+            "marketcap_usd": 21617002662,
             "name": "Binance USD (BUSD)",
             "network": "eth",
             "shortcut": "BUSD",
@@ -4734,7 +4667,7 @@
             "links": {
                 "Homepage": "https://bezant.io"
             },
-            "marketcap_usd": 194653,
+            "marketcap_usd": 310177,
             "name": "Bezant",
             "network": "eth",
             "shortcut": "BZNT",
@@ -4774,7 +4707,7 @@
                 "Github": "https://github.com/cryptotwenty",
                 "Homepage": "https://crypto20.com"
             },
-            "marketcap_usd": 1526658,
+            "marketcap_usd": 1325627,
             "name": "Crypto20's Token",
             "network": "eth",
             "shortcut": "C20",
@@ -4832,7 +4765,7 @@
                 "Github": "https://github.com/Global-Crypto-Alliance/call-token",
                 "Homepage": "https://gcalliance.io"
             },
-            "marketcap_usd": 142187,
+            "marketcap_usd": 97058,
             "name": "CALL token",
             "network": "eth",
             "shortcut": "CALL",
@@ -4946,7 +4879,7 @@
             "links": {
                 "Homepage": "https://coin.cashbet.com"
             },
-            "marketcap_usd": 1528635,
+            "marketcap_usd": 1403855,
             "name": "CashBet Coin",
             "network": "eth",
             "shortcut": "CBC",
@@ -5062,7 +4995,7 @@
             "links": {
                 "Homepage": "https://ccore.io"
             },
-            "marketcap_usd": 10040,
+            "marketcap_usd": 11353,
             "name": "Ccore",
             "network": "eth",
             "shortcut": "CCO",
@@ -5139,7 +5072,7 @@
             "links": {
                 "Homepage": "https://www.ceek.com/"
             },
-            "marketcap_usd": 187145747,
+            "marketcap_usd": 106829396,
             "name": "CEEK VR Token",
             "network": "eth",
             "shortcut": "CEEK",
@@ -5159,7 +5092,7 @@
                 "Github": "https://github.com/celer-network",
                 "Homepage": "https://www.celer.network/"
             },
-            "marketcap_usd": 141526232,
+            "marketcap_usd": 109902013,
             "name": "CelerToken",
             "network": "eth",
             "shortcut": "CELR",
@@ -5198,7 +5131,7 @@
             "links": {
                 "Homepage": "https://www.centrality.ai"
             },
-            "marketcap_usd": 57806547,
+            "marketcap_usd": 29813992,
             "name": "Centrality",
             "network": "eth",
             "shortcut": "CENNZ",
@@ -5296,7 +5229,7 @@
                 "Github": "https://github.com/cache-token/cache-contract",
                 "Homepage": "https://cache.gold"
             },
-            "marketcap_usd": 4448130,
+            "marketcap_usd": 3709739,
             "name": "CACHE Gold",
             "network": "eth",
             "shortcut": "CGT",
@@ -5354,7 +5287,7 @@
             "links": {
                 "Homepage": "https://swissborg.com"
             },
-            "marketcap_usd": 191040193,
+            "marketcap_usd": 205224902,
             "name": "SwissBorg",
             "network": "eth",
             "shortcut": "CHSB",
@@ -5393,7 +5326,7 @@
                 "Github": "https://github.com/CivilizationCIV",
                 "Homepage": "https://civfund.org"
             },
-            "marketcap_usd": 15548799,
+            "marketcap_usd": 7385936,
             "name": "Civilization",
             "network": "eth",
             "shortcut": "CIV",
@@ -5568,7 +5501,7 @@
             "links": {
                 "Homepage": "https://coinloan.io"
             },
-            "marketcap_usd": 35569899,
+            "marketcap_usd": 31252731,
             "name": "CoinLoan",
             "network": "eth",
             "shortcut": "CLT",
@@ -5644,7 +5577,7 @@
             "links": {
                 "Homepage": "https://app.coinmerge.io/"
             },
-            "marketcap_usd": 1941554,
+            "marketcap_usd": 1379434,
             "name": "Coin Merge",
             "network": "eth",
             "shortcut": "CMERGE",
@@ -5682,7 +5615,7 @@
             "links": {
                 "Homepage": "https://cindicator.com"
             },
-            "marketcap_usd": 1343358,
+            "marketcap_usd": 1011122,
             "name": "Cindicator",
             "network": "eth",
             "shortcut": "CND",
@@ -5701,7 +5634,7 @@
             "links": {
                 "Homepage": "https://cnntoken.io"
             },
-            "marketcap_usd": 267360,
+            "marketcap_usd": 194830,
             "name": "Content Neutrality Network",
             "network": "eth",
             "shortcut": "CNN",
@@ -5760,7 +5693,7 @@
                 "Github": "https://github.com/cobinhood",
                 "Homepage": "https://cobinhood.com"
             },
-            "marketcap_usd": 93522,
+            "marketcap_usd": 85118,
             "name": "Cobinhood Token",
             "network": "eth",
             "shortcut": "COB",
@@ -5800,7 +5733,7 @@
                 "Github": "https://github.com/coinfi",
                 "Homepage": "https://www.coinfi.com"
             },
-            "marketcap_usd": 250832,
+            "marketcap_usd": 404071,
             "name": "CoinFi Token",
             "network": "eth",
             "shortcut": "COFI",
@@ -5840,7 +5773,7 @@
                 "Github": "https://github.com/compound-finance",
                 "Homepage": "https://compound.finance"
             },
-            "marketcap_usd": 396375692,
+            "marketcap_usd": 383322397,
             "name": "Compound",
             "network": "eth",
             "shortcut": "COMP",
@@ -5898,7 +5831,7 @@
                 "Github": "https://github.com/coti-io",
                 "Homepage": "https://coti.io"
             },
-            "marketcap_usd": 112294069,
+            "marketcap_usd": 117588195,
             "name": "COTI",
             "network": "eth",
             "shortcut": "COTI",
@@ -5975,7 +5908,7 @@
             "links": {
                 "Homepage": "http://www.cpchain.io"
             },
-            "marketcap_usd": 1418086,
+            "marketcap_usd": 1184483,
             "name": "CPChain",
             "network": "eth",
             "shortcut": "CPC",
@@ -6228,7 +6161,7 @@
             "links": {
                 "Homepage": "https://credits.com/en"
             },
-            "marketcap_usd": 1618637,
+            "marketcap_usd": 896648,
             "name": "Credits",
             "network": "eth",
             "shortcut": "CS",
@@ -6346,7 +6279,7 @@
                 "Github": "https://github.com/cartesi",
                 "Homepage": "https://cartesi.io"
             },
-            "marketcap_usd": 95485176,
+            "marketcap_usd": 84664288,
             "name": "Cartesi Token",
             "network": "eth",
             "shortcut": "CTSI",
@@ -6442,7 +6375,7 @@
             "links": {
                 "Homepage": "https://www.civic.com"
             },
-            "marketcap_usd": 152337117,
+            "marketcap_usd": 127739794,
             "name": "Civic",
             "network": "eth",
             "shortcut": "CVC",
@@ -6481,7 +6414,7 @@
             "links": {
                 "Homepage": "http://www.cybervein.org"
             },
-            "marketcap_usd": 1846634,
+            "marketcap_usd": 1401759,
             "name": "CyberVein",
             "network": "eth",
             "shortcut": "CVT",
@@ -6521,7 +6454,7 @@
                 "Github": "https://github.com/cargoxio",
                 "Homepage": "https://cargox.io"
             },
-            "marketcap_usd": 17189874,
+            "marketcap_usd": 0,
             "name": "CargoX",
             "network": "eth",
             "shortcut": "CXO",
@@ -6579,7 +6512,7 @@
             "links": {
                 "Homepage": "https://cybermusic.io"
             },
-            "marketcap_usd": 14035,
+            "marketcap_usd": 124989,
             "name": "CyberMusic",
             "network": "eth",
             "shortcut": "CYMT",
@@ -6715,7 +6648,7 @@
                 "Github": "https://github.com/makerdao",
                 "Homepage": "https://makerdao.com"
             },
-            "marketcap_usd": 7461820568,
+            "marketcap_usd": 6258537389,
             "name": "Dai Stablecoin v2.0",
             "network": "eth",
             "shortcut": "DAI",
@@ -6812,7 +6745,7 @@
             "links": {
                 "Homepage": "https://www.datx.co"
             },
-            "marketcap_usd": 10979,
+            "marketcap_usd": 0,
             "name": "DATx",
             "network": "eth",
             "shortcut": "DATX",
@@ -6832,7 +6765,7 @@
                 "Github": "https://github.com/DAVFoundation",
                 "Homepage": "https://dav.network/"
             },
-            "marketcap_usd": 521678,
+            "marketcap_usd": 1749227,
             "name": "DAV Token",
             "network": "eth",
             "shortcut": "DAV",
@@ -6851,7 +6784,7 @@
             "links": {
                 "Homepage": "https://www.daex.io"
             },
-            "marketcap_usd": 1573251,
+            "marketcap_usd": 1116264,
             "name": "DAEX",
             "network": "eth",
             "shortcut": "DAX",
@@ -6890,7 +6823,7 @@
                 "Github": "https://github.com/chronologic",
                 "Homepage": "https://chronologic.network"
             },
-            "marketcap_usd": 47374,
+            "marketcap_usd": 28478,
             "name": "ChronoLogic DAY",
             "network": "eth",
             "shortcut": "DAY",
@@ -6909,7 +6842,7 @@
             "links": {
                 "Homepage": "https://www.decent.bet"
             },
-            "marketcap_usd": 51152,
+            "marketcap_usd": 39066,
             "name": "DecentBet",
             "network": "eth",
             "shortcut": "DBET",
@@ -7008,7 +6941,7 @@
                 "Github": "https://github.com/Dentacoin",
                 "Homepage": "https://dentacoin.com"
             },
-            "marketcap_usd": 1574380,
+            "marketcap_usd": 2365371,
             "name": "Dentacoin",
             "network": "eth",
             "shortcut": "DCN",
@@ -7047,7 +6980,7 @@
             "links": {
                 "Homepage": "https://debitum.network/"
             },
-            "marketcap_usd": 349227,
+            "marketcap_usd": 0,
             "name": "DEBITUM",
             "network": "eth",
             "shortcut": "DEB",
@@ -7105,7 +7038,7 @@
             "links": {
                 "Homepage": "https://www.dentwireless.com"
             },
-            "marketcap_usd": 102259438,
+            "marketcap_usd": 87776587,
             "name": "DENT",
             "network": "eth",
             "shortcut": "DENT",
@@ -7163,7 +7096,7 @@
                 "Github": "https://github.com/dforcenetwork",
                 "Homepage": "https://dforce.network"
             },
-            "marketcap_usd": 17977739,
+            "marketcap_usd": 21762220,
             "name": "dForce Platform Token",
             "network": "eth",
             "shortcut": "DF",
@@ -7182,7 +7115,7 @@
             "links": {
                 "Homepage": "https://digix.global/"
             },
-            "marketcap_usd": 9504432,
+            "marketcap_usd": 6640783,
             "name": "Digix DAO",
             "network": "eth",
             "shortcut": "DGD",
@@ -7242,7 +7175,7 @@
                 "Github": "https://github.com/DigixGlobal",
                 "Homepage": "https://digix.global"
             },
-            "marketcap_usd": 839022,
+            "marketcap_usd": 2203372,
             "name": "Digix Gold Token",
             "network": "eth",
             "shortcut": "DGX",
@@ -7320,7 +7253,7 @@
             "links": {
                 "Homepage": "https://inmediate.io"
             },
-            "marketcap_usd": 247665,
+            "marketcap_usd": 335134,
             "name": "Digital Insurance Token",
             "network": "eth",
             "shortcut": "DIT",
@@ -7358,7 +7291,7 @@
             "links": {
                 "Homepage": "https://www.agrello.org"
             },
-            "marketcap_usd": 117479,
+            "marketcap_usd": 106923,
             "name": "Agrello",
             "network": "eth",
             "shortcut": "DLT",
@@ -7378,7 +7311,7 @@
                 "Github": "https://github.com/suntechsoft/dmarket-smartcontract",
                 "Homepage": "https://dmarket.com"
             },
-            "marketcap_usd": 544003,
+            "marketcap_usd": 412600,
             "name": "DMarket Token",
             "network": "eth",
             "shortcut": "DMT",
@@ -7417,7 +7350,7 @@
                 "Github": "https://github.com/district0x",
                 "Homepage": "https://district0x.io"
             },
-            "marketcap_usd": 31686626,
+            "marketcap_usd": 17111493,
             "name": "District0x Network Token",
             "network": "eth",
             "shortcut": "DNT",
@@ -7513,7 +7446,7 @@
             "links": {
                 "Homepage": "https://dovu.io"
             },
-            "marketcap_usd": 5230518,
+            "marketcap_usd": 2685690,
             "name": "Dovu",
             "network": "eth",
             "shortcut": "DOV",
@@ -7572,7 +7505,7 @@
                 "Github": "https://github.com/dragonchain/dragonchain",
                 "Homepage": "https://dragonchain.com"
             },
-            "marketcap_usd": 7778910,
+            "marketcap_usd": 6896396,
             "name": "Dragon",
             "network": "eth",
             "shortcut": "DRGN",
@@ -7610,7 +7543,7 @@
             "links": {
                 "Homepage": "https://token.domraider.com"
             },
-            "marketcap_usd": 141467,
+            "marketcap_usd": 192841,
             "name": "DomRaider",
             "network": "eth",
             "shortcut": "DRT",
@@ -7709,7 +7642,7 @@
                 "Github": "https://github.com/dethertech",
                 "Homepage": "https://dether.io"
             },
-            "marketcap_usd": 188995,
+            "marketcap_usd": 0,
             "name": "dether",
             "network": "eth",
             "shortcut": "DTH",
@@ -7747,7 +7680,7 @@
             "links": {
                 "Homepage": "https://datarius.io"
             },
-            "marketcap_usd": 47699,
+            "marketcap_usd": 39851,
             "name": "Datarius Credit",
             "network": "eth",
             "shortcut": "DTRC",
@@ -7998,7 +7931,7 @@
             "links": {
                 "Homepage": "https://edgeless.io"
             },
-            "marketcap_usd": 2056791,
+            "marketcap_usd": 5577787,
             "name": "Edgeless",
             "network": "eth",
             "shortcut": "EDG",
@@ -8057,7 +7990,7 @@
                 "Github": "https://github.com/EndorCoin",
                 "Homepage": "https://www.endor.com"
             },
-            "marketcap_usd": 217260,
+            "marketcap_usd": 0,
             "name": "Endor Protocol Token",
             "network": "eth",
             "shortcut": "EDR",
@@ -8117,7 +8050,7 @@
                 "Github": "https://github.com/egretia",
                 "Homepage": "https://www.egretia.io"
             },
-            "marketcap_usd": 1594501,
+            "marketcap_usd": 1565852,
             "name": "Egretia Token",
             "network": "eth",
             "shortcut": "EGT",
@@ -8175,7 +8108,7 @@
             "links": {
                 "Homepage": "https://echolink.info"
             },
-            "marketcap_usd": 55123,
+            "marketcap_usd": 35355,
             "name": "EchoLink",
             "network": "eth",
             "shortcut": "EKO",
@@ -8213,7 +8146,7 @@
             "links": {
                 "Homepage": "https://electrify.asia"
             },
-            "marketcap_usd": 395915,
+            "marketcap_usd": 775325,
             "name": "Electrify.Asia",
             "network": "eth",
             "shortcut": "ELEC",
@@ -8233,7 +8166,7 @@
                 "Github": "https://github.com/aelfProject",
                 "Homepage": "https://aelf.io/"
             },
-            "marketcap_usd": 91873409,
+            "marketcap_usd": 70155581,
             "name": "ELF Token",
             "network": "eth",
             "shortcut": "ELF",
@@ -8272,7 +8205,7 @@
                 "Github": "https://github.com/eltcoin",
                 "Homepage": "http://www.eltcoin.tech/"
             },
-            "marketcap_usd": 38197,
+            "marketcap_usd": 31112,
             "name": "ELTCOIN",
             "network": "eth",
             "shortcut": "ELTCOIN",
@@ -8292,7 +8225,7 @@
                 "Github": "https://github.com/Elysian-ELY",
                 "Homepage": "https://elycoin.io"
             },
-            "marketcap_usd": 41659,
+            "marketcap_usd": 37770,
             "name": "ELYCOIN",
             "network": "eth",
             "shortcut": "ELY",
@@ -8430,7 +8363,7 @@
                 "Github": "https://github.com/enigmampc",
                 "Homepage": "https://enigma.co/"
             },
-            "marketcap_usd": 186432,
+            "marketcap_usd": 135855,
             "name": "Enigma",
             "network": "eth",
             "shortcut": "ENG",
@@ -8469,7 +8402,7 @@
                 "Github": "https://github.com/enjin/contracts",
                 "Homepage": "https://enjincoin.io"
             },
-            "marketcap_usd": 540499436,
+            "marketcap_usd": 451271115,
             "name": "ENJIN",
             "network": "eth",
             "shortcut": "ENJ",
@@ -8489,7 +8422,7 @@
                 "Github": "https://github.com/Enecuum",
                 "Homepage": "https://enecuum.com"
             },
-            "marketcap_usd": 896242,
+            "marketcap_usd": 4628910,
             "name": "Enecuum",
             "network": "eth",
             "shortcut": "ENQ",
@@ -8606,7 +8539,7 @@
             "links": {
                 "Homepage": "https://eroscoin.org"
             },
-            "marketcap_usd": 42493,
+            "marketcap_usd": 38674,
             "name": "Eroscoin",
             "network": "eth",
             "shortcut": "ERO",
@@ -8723,7 +8656,7 @@
             "links": {
                 "Homepage": "https://www.etgproject.org"
             },
-            "marketcap_usd": 180816,
+            "marketcap_usd": 0,
             "name": "Ethereum Gold",
             "network": "eth",
             "shortcut": "ETG",
@@ -8860,7 +8793,7 @@
                 "Github": "https://github.com/stasisnet",
                 "Homepage": "https://stasis.net"
             },
-            "marketcap_usd": 126914757,
+            "marketcap_usd": 122712790,
             "name": "STASIS EURS",
             "network": "eth",
             "shortcut": "EURS",
@@ -8898,7 +8831,7 @@
             "links": {
                 "Homepage": "https://eventchain.io"
             },
-            "marketcap_usd": 44616,
+            "marketcap_usd": 32831,
             "name": "EventChain",
             "network": "eth",
             "shortcut": "EVC",
@@ -8937,7 +8870,7 @@
                 "Github": "https://github.com/devery",
                 "Homepage": "https://devery.io"
             },
-            "marketcap_usd": 68606,
+            "marketcap_usd": 0,
             "name": "Devery",
             "network": "eth",
             "shortcut": "EVE",
@@ -8957,7 +8890,7 @@
                 "Github": "https://github.com/evedo-co",
                 "Homepage": "https://www.evedo.co"
             },
-            "marketcap_usd": 520542,
+            "marketcap_usd": 322201,
             "name": "Evedo Token",
             "network": "eth",
             "shortcut": "EVED",
@@ -9016,7 +8949,7 @@
             "links": {
                 "Homepage": "https://everex.io "
             },
-            "marketcap_usd": 319228,
+            "marketcap_usd": 268468,
             "name": "Everex",
             "network": "eth",
             "shortcut": "EVX",
@@ -9114,7 +9047,7 @@
             "links": {
                 "Homepage": "https://exrnchain.com"
             },
-            "marketcap_usd": 1158190,
+            "marketcap_usd": 1453500,
             "name": "EXRNchain",
             "network": "eth",
             "shortcut": "EXRN",
@@ -9230,7 +9163,7 @@
             "links": {
                 "Homepage": "https://tokensale.faceter.io"
             },
-            "marketcap_usd": 354513,
+            "marketcap_usd": 210358,
             "name": "Faceter",
             "network": "eth",
             "shortcut": "FACE",
@@ -9328,7 +9261,7 @@
             "links": {
                 "Homepage": "https://friendz.io"
             },
-            "marketcap_usd": 227649,
+            "marketcap_usd": 235206,
             "name": "Friendz",
             "network": "eth",
             "shortcut": "FDZ",
@@ -9466,7 +9399,7 @@
             "links": {
                 "Homepage": "https://www.flixxo.com"
             },
-            "marketcap_usd": 161120,
+            "marketcap_usd": 154032,
             "name": "Flixxo",
             "network": "eth",
             "shortcut": "FLIXX",
@@ -9485,7 +9418,7 @@
             "links": {
                 "Homepage": "https://firelotto.io"
             },
-            "marketcap_usd": 64930,
+            "marketcap_usd": 16310,
             "name": "Fire Lotto",
             "network": "eth",
             "shortcut": "FLOT",
@@ -9505,7 +9438,7 @@
                 "Github": "https://github.com/gameflip",
                 "Homepage": "https://gameflip.com"
             },
-            "marketcap_usd": 320942,
+            "marketcap_usd": 407811,
             "name": "FLIP Token",
             "network": "eth",
             "shortcut": "FLP",
@@ -9583,7 +9516,7 @@
                 "Github": "https://github.com/civitas-fundamenta",
                 "Homepage": "https://fundamenta.network"
             },
-            "marketcap_usd": 57162,
+            "marketcap_usd": 0,
             "name": "Fundamenta",
             "network": "eth",
             "shortcut": "FMTA",
@@ -9661,7 +9594,7 @@
                 "Github": "https://github.com/f-o-a-m",
                 "Homepage": "http://foam.space"
             },
-            "marketcap_usd": 7679395,
+            "marketcap_usd": 10056813,
             "name": "FOAM Token",
             "network": "eth",
             "shortcut": "FOAM",
@@ -9738,7 +9671,7 @@
             "links": {
                 "Homepage": "https://shapeshift.com"
             },
-            "marketcap_usd": 29493352,
+            "marketcap_usd": 15563495,
             "name": "FOX",
             "network": "eth",
             "shortcut": "FOX",
@@ -9874,7 +9807,7 @@
             "links": {
                 "Homepage": "https://fanstime.org"
             },
-            "marketcap_usd": 199104,
+            "marketcap_usd": 168783,
             "name": "FansTime",
             "network": "eth",
             "shortcut": "FTI",
@@ -9894,7 +9827,7 @@
                 "Github": "https://github.com/Fantom-foundation/",
                 "Homepage": "https://fantom.foundation/"
             },
-            "marketcap_usd": 826656185,
+            "marketcap_usd": 569478350,
             "name": "Fantom Token",
             "network": "eth",
             "shortcut": "FTM",
@@ -9952,7 +9885,7 @@
             "links": {
                 "Homepage": "https://www.fintrux.com"
             },
-            "marketcap_usd": 556716,
+            "marketcap_usd": 435665,
             "name": "FintruX Network",
             "network": "eth",
             "shortcut": "FTX",
@@ -9972,7 +9905,7 @@
                 "Github": "https://github.com/futuraxproject",
                 "Homepage": "https://futurax.global"
             },
-            "marketcap_usd": 6974,
+            "marketcap_usd": 53526,
             "name": "FUTURAX",
             "network": "eth",
             "shortcut": "FTXT",
@@ -9992,7 +9925,7 @@
                 "Github": "https://github.com/etherparty",
                 "Homepage": "https://etherparty.io"
             },
-            "marketcap_usd": 265511,
+            "marketcap_usd": 275869,
             "name": "Etherparty FUEL",
             "network": "eth",
             "shortcut": "FUEL",
@@ -10011,7 +9944,7 @@
             "links": {
                 "Homepage": "https://funfair.io"
             },
-            "marketcap_usd": 89998609,
+            "marketcap_usd": 83419422,
             "name": "Funfair",
             "network": "eth",
             "shortcut": "FUN",
@@ -10030,7 +9963,7 @@
             "links": {
                 "Homepage": "https://fuzex.co"
             },
-            "marketcap_usd": 147005,
+            "marketcap_usd": 41060,
             "name": "FuzeX",
             "network": "eth",
             "shortcut": "FXT",
@@ -10088,7 +10021,7 @@
             "links": {
                 "Homepage": "https://flyp.me"
             },
-            "marketcap_usd": 646479,
+            "marketcap_usd": 513574,
             "name": "FlypMe",
             "network": "eth",
             "shortcut": "FYP",
@@ -10107,7 +10040,7 @@
             "links": {
                 "Homepage": "https://www.fyooz.io/"
             },
-            "marketcap_usd": 19899,
+            "marketcap_usd": 0,
             "name": "Fyooz",
             "network": "eth",
             "shortcut": "FYZ",
@@ -10147,7 +10080,7 @@
                 "Github": "https://github.com/gluwa/Creditcoin",
                 "Homepage": "https://creditcoinfoundation.org"
             },
-            "marketcap_usd": 82860717,
+            "marketcap_usd": 82526827,
             "name": "Creditcoin Token",
             "network": "eth",
             "shortcut": "G-CRE",
@@ -10187,7 +10120,7 @@
                 "Github": "https://github.com/gamecredits-project",
                 "Homepage": "https://www.gamecredits.org"
             },
-            "marketcap_usd": 3056175,
+            "marketcap_usd": 2446268,
             "name": "GAME Credits",
             "network": "eth",
             "shortcut": "GAME",
@@ -10226,7 +10159,7 @@
                 "Github": "https://github.com/GateNet-IO/gate-erc20-token",
                 "Homepage": "https://gatetoken.io/"
             },
-            "marketcap_usd": 4392910,
+            "marketcap_usd": 0,
             "name": "GATE Token",
             "network": "eth",
             "shortcut": "GATE",
@@ -10422,7 +10355,7 @@
                 "Github": "https://github.com/Governor-DAO",
                 "Homepage": "https://www.governordao.org"
             },
-            "marketcap_usd": 573375,
+            "marketcap_usd": 510355,
             "name": "Governor DAO",
             "network": "eth",
             "shortcut": "GDAO",
@@ -10500,7 +10433,7 @@
             "links": {
                 "Homepage": "https://gems.org"
             },
-            "marketcap_usd": 120129,
+            "marketcap_usd": 149539,
             "name": "Gems",
             "network": "eth",
             "shortcut": "GEM",
@@ -10520,7 +10453,7 @@
                 "Github": "https://github.com/daostack",
                 "Homepage": "https://daostack.io"
             },
-            "marketcap_usd": 305299,
+            "marketcap_usd": 437109,
             "name": "DAOstack",
             "network": "eth",
             "shortcut": "GEN",
@@ -10559,7 +10492,7 @@
                 "Github": "https://github.com/Getprotocol",
                 "Homepage": "http://www.get-protocol.io"
             },
-            "marketcap_usd": 18653626,
+            "marketcap_usd": 18586854,
             "name": "GET Protocol",
             "network": "eth",
             "shortcut": "GET",
@@ -10617,7 +10550,7 @@
             "links": {
                 "Homepage": "https://gamerhash.io/"
             },
-            "marketcap_usd": 8528648,
+            "marketcap_usd": 7849370,
             "name": "GamerCoin",
             "network": "eth",
             "shortcut": "GHX",
@@ -10729,31 +10662,12 @@
                 }
             ]
         },
-        "erc20:eth:GMB": {
-            "address": "0xA0008F510fE9eE696E7E320C9e5cbf61E27791Ee",
-            "links": {
-                "Homepage": "https://gamb.io"
-            },
-            "marketcap_usd": 1360261,
-            "name": "GAMB",
-            "network": "eth",
-            "shortcut": "GMB",
-            "t1_enabled": "yes",
-            "t2_enabled": "yes",
-            "type": "erc20",
-            "wallet": [
-                {
-                    "name": "Trezor Suite",
-                    "url": "https://suite.trezor.io"
-                }
-            ]
-        },
         "erc20:eth:GNO": {
             "address": "0x6810e776880C02933D47DB1b9fc05908e5386b96",
             "links": {
                 "Homepage": "https://gnosis.pm"
             },
-            "marketcap_usd": 393061882,
+            "marketcap_usd": 330426989,
             "name": "Gnosis",
             "network": "eth",
             "shortcut": "GNO",
@@ -10792,7 +10706,7 @@
             "links": {
                 "Homepage": "https://genaro.network"
             },
-            "marketcap_usd": 1858613,
+            "marketcap_usd": 2208172,
             "name": "Genaro Network",
             "network": "eth",
             "shortcut": "GNX",
@@ -10851,7 +10765,7 @@
             "links": {
                 "Homepage": "https://gonetwork.co/index.html"
             },
-            "marketcap_usd": 63890,
+            "marketcap_usd": 0,
             "name": "GoNetwork",
             "network": "eth",
             "shortcut": "GOT",
@@ -10871,7 +10785,7 @@
                 "Github": "https://github.com/coti-io/cvi-contracts",
                 "Homepage": "https://cvi.finance"
             },
-            "marketcap_usd": 5061991,
+            "marketcap_usd": 4987893,
             "name": "GOVI",
             "network": "eth",
             "shortcut": "GOVI",
@@ -10909,7 +10823,7 @@
             "links": {
                 "Homepage": "http://gridplus.io"
             },
-            "marketcap_usd": 13103130,
+            "marketcap_usd": 7929393,
             "name": "Grid+",
             "network": "eth",
             "shortcut": "GRID",
@@ -10988,7 +10902,7 @@
                 "Github": "https://github.com/graphprotocol",
                 "Homepage": "https://thegraph.com"
             },
-            "marketcap_usd": 794401640,
+            "marketcap_usd": 577329863,
             "name": "Graph Token",
             "network": "eth",
             "shortcut": "GRT",
@@ -11007,7 +10921,7 @@
             "links": {
                 "Homepage": "https://www.gsc.social"
             },
-            "marketcap_usd": 789186,
+            "marketcap_usd": 549233,
             "name": "Global Social Chain",
             "network": "eth",
             "shortcut": "GSC",
@@ -11046,30 +10960,10 @@
                 "Github": "https://github.com/GameLeLe",
                 "Homepage": "https://game.com"
             },
-            "marketcap_usd": 623479,
+            "marketcap_usd": 580922,
             "name": "GTC Token",
             "network": "eth",
             "shortcut": "GTC",
-            "t1_enabled": "yes",
-            "t2_enabled": "yes",
-            "type": "erc20",
-            "wallet": [
-                {
-                    "name": "Trezor Suite",
-                    "url": "https://suite.trezor.io"
-                }
-            ]
-        },
-        "erc20:eth:GTH": {
-            "address": "0xeb986DA994E4a118d5956b02d8b7c3C7CE373674",
-            "links": {
-                "Github": "https://github.com/GatherNetwork",
-                "Homepage": "https://gather.network"
-            },
-            "marketcap_usd": 1369428,
-            "name": "GTH",
-            "network": "eth",
-            "shortcut": "GTH",
             "t1_enabled": "yes",
             "t2_enabled": "yes",
             "type": "erc20",
@@ -11106,7 +11000,7 @@
                 "Github": "https://github.com/GIFTO-io",
                 "Homepage": "https://gifto.io/"
             },
-            "marketcap_usd": 26392102,
+            "marketcap_usd": 19227020,
             "name": "Gifto",
             "network": "eth",
             "shortcut": "GTO",
@@ -11184,7 +11078,7 @@
                 "Github": "https://github.com/GenesisVision",
                 "Homepage": "https://genesis.vision"
             },
-            "marketcap_usd": 846158,
+            "marketcap_usd": 793713,
             "name": "Genesis Vision",
             "network": "eth",
             "shortcut": "GVT",
@@ -11360,7 +11254,7 @@
             "links": {
                 "Homepage": "https://www.showhand.io"
             },
-            "marketcap_usd": 39004,
+            "marketcap_usd": 972862,
             "name": "ShowHand",
             "network": "eth",
             "shortcut": "HAND",
@@ -11436,7 +11330,7 @@
             "links": {
                 "Homepage": "https://heartbout.com"
             },
-            "marketcap_usd": 6507,
+            "marketcap_usd": 5959,
             "name": "HeartBout",
             "network": "eth",
             "shortcut": "HB",
@@ -11572,7 +11466,7 @@
                 "Github": "https://github.com/bitcoinHEX",
                 "Homepage": "https://hex.win"
             },
-            "marketcap_usd": 8203214843,
+            "marketcap_usd": 7781209000,
             "name": "HEX",
             "network": "eth",
             "shortcut": "HEX",
@@ -11766,7 +11660,7 @@
             "links": {
                 "Homepage": "https://humaniq.com"
             },
-            "marketcap_usd": 880646,
+            "marketcap_usd": 953236,
             "name": "Humaniq",
             "network": "eth",
             "shortcut": "HMQ",
@@ -11864,7 +11758,7 @@
                 "Github": "https://github.com/Holo-Host",
                 "Homepage": "https://holo.host/"
             },
-            "marketcap_usd": 387484357,
+            "marketcap_usd": 346822120,
             "name": "Holo Token",
             "network": "eth",
             "shortcut": "HOT (Holo)",
@@ -11883,7 +11777,7 @@
             "links": {
                 "Homepage": "https://thehydrofoundation.com/"
             },
-            "marketcap_usd": 1598618,
+            "marketcap_usd": 1271766,
             "name": "Hydro Protocol",
             "network": "eth",
             "shortcut": "HOT (Hydro)",
@@ -11921,7 +11815,7 @@
             "links": {
                 "Homepage": "https://www.hbg.com"
             },
-            "marketcap_usd": 670891161,
+            "marketcap_usd": 1402568775,
             "name": "Huobi Token",
             "network": "eth",
             "shortcut": "HT",
@@ -12040,7 +11934,7 @@
                 "Github": "https://github.com/HiveProjectLTD",
                 "Homepage": "https://www.hiveterminal.com"
             },
-            "marketcap_usd": 1066273,
+            "marketcap_usd": 627124,
             "name": "Hiveterminal Token",
             "network": "eth",
             "shortcut": "HVN",
@@ -12195,7 +12089,7 @@
             "links": {
                 "Homepage": "https://www.everest.org"
             },
-            "marketcap_usd": 7623489,
+            "marketcap_usd": 7831858,
             "name": "Everest (ID)",
             "network": "eth",
             "shortcut": "ID",
@@ -12253,7 +12147,7 @@
                 "Github": "https://github.com/rupiah-token/",
                 "Homepage": "https://www.rupiahtoken.com"
             },
-            "marketcap_usd": 14466872,
+            "marketcap_usd": 8218508,
             "name": "Rupiah Token",
             "network": "eth",
             "shortcut": "IDRT",
@@ -12272,7 +12166,7 @@
             "links": {
                 "Homepage": "https://investfeed.com"
             },
-            "marketcap_usd": 130645,
+            "marketcap_usd": 118906,
             "name": "InvestFeed",
             "network": "eth",
             "shortcut": "IFT",
@@ -12291,7 +12185,7 @@
             "links": {
                 "Homepage": "http://igtoken.net"
             },
-            "marketcap_usd": 8781,
+            "marketcap_usd": 67395,
             "name": "IGToken",
             "network": "eth",
             "shortcut": "IG",
@@ -12330,7 +12224,7 @@
             "links": {
                 "Homepage": "https://ihtcoin.com"
             },
-            "marketcap_usd": 211728,
+            "marketcap_usd": 211439,
             "name": "I HOUSE TOKEN",
             "network": "eth",
             "shortcut": "IHT",
@@ -12407,7 +12301,7 @@
             "links": {
                 "Homepage": "https://indorse.io"
             },
-            "marketcap_usd": 173228,
+            "marketcap_usd": 129322,
             "name": "Indorse",
             "network": "eth",
             "shortcut": "IND",
@@ -12582,7 +12476,7 @@
                 "Github": "https://github.com/iotexproject/iotex-core",
                 "Homepage": "http://iotex.io/"
             },
-            "marketcap_usd": 300918494,
+            "marketcap_usd": 273034722,
             "name": "IoTeX Network",
             "network": "eth",
             "shortcut": "IOTX",
@@ -12602,7 +12496,7 @@
                 "Github": "https://github.com/InsurePal",
                 "Homepage": "https://insurepal.io/"
             },
-            "marketcap_usd": 106768,
+            "marketcap_usd": 25440,
             "name": "InsurePal token",
             "network": "eth",
             "shortcut": "IPL",
@@ -12641,7 +12535,7 @@
                 "Github": "https://github.com/iqeon",
                 "Homepage": "https://iqeon.io/"
             },
-            "marketcap_usd": 2061614,
+            "marketcap_usd": 1665617,
             "name": "IQeon",
             "network": "eth",
             "shortcut": "IQN",
@@ -12701,7 +12595,7 @@
                 "Github": "https://github.com/IoTChainCode",
                 "Homepage": "https://iotchain.io/"
             },
-            "marketcap_usd": 868882,
+            "marketcap_usd": 12037,
             "name": "IoT Chain",
             "network": "eth",
             "shortcut": "ITC",
@@ -12799,7 +12693,7 @@
             "links": {
                 "Homepage": "https://www.insurex.co"
             },
-            "marketcap_usd": 182079,
+            "marketcap_usd": 182546,
             "name": "InsureX",
             "network": "eth",
             "shortcut": "IXT",
@@ -12858,7 +12752,7 @@
                 "Github": "https://github.com/TokyoToken/JasmyCoin",
                 "Homepage": "https://jasmy.co.jp"
             },
-            "marketcap_usd": 45712197,
+            "marketcap_usd": 23097063,
             "name": "JasmyCoin",
             "network": "eth",
             "shortcut": "JASMY",
@@ -12955,7 +12849,7 @@
                 "Github": "https://github.com/JobchainOfficial",
                 "Homepage": "https://www.jobchain.com"
             },
-            "marketcap_usd": 2691224,
+            "marketcap_usd": 6381610,
             "name": "Jobchain",
             "network": "eth",
             "shortcut": "JOB",
@@ -13032,7 +12926,7 @@
             "links": {
                 "Homepage": "http://www.kan.land"
             },
-            "marketcap_usd": 13160325,
+            "marketcap_usd": 10881693,
             "name": "BitKan",
             "network": "eth",
             "shortcut": "KAN",
@@ -13110,7 +13004,7 @@
             "links": {
                 "Homepage": "https://kindads.io"
             },
-            "marketcap_usd": 10512,
+            "marketcap_usd": 10887,
             "name": "Kind Ads Token",
             "network": "eth",
             "shortcut": "KIND",
@@ -13168,7 +13062,7 @@
             "links": {
                 "Homepage": "https://kanadecoin.com"
             },
-            "marketcap_usd": 86167,
+            "marketcap_usd": 85969,
             "name": "KanadeCoin",
             "network": "eth",
             "shortcut": "KNDC",
@@ -13246,7 +13140,7 @@
                 "Github": "https://github.com/Cryptense/",
                 "Homepage": "https://kryll.io/"
             },
-            "marketcap_usd": 17909542,
+            "marketcap_usd": 14174333,
             "name": "Kryll",
             "network": "eth",
             "shortcut": "KRL",
@@ -13343,7 +13237,7 @@
             "links": {
                 "Homepage": "https://4new.io"
             },
-            "marketcap_usd": 17683,
+            "marketcap_usd": 0,
             "name": "4NEW",
             "network": "eth",
             "shortcut": "KWATT",
@@ -13401,7 +13295,7 @@
                 "Github": "https://github.com/latoken",
                 "Homepage": "https://latoken.com/"
             },
-            "marketcap_usd": 29111840,
+            "marketcap_usd": 22088966,
             "name": "LATOKEN",
             "network": "eth",
             "shortcut": "LA",
@@ -13440,7 +13334,7 @@
                 "Github": "https://github.com/LambdaIM",
                 "Homepage": "https://www.lambda.im/"
             },
-            "marketcap_usd": 0,
+            "marketcap_usd": 2710887,
             "name": "Lambda",
             "network": "eth",
             "shortcut": "LAMB",
@@ -13478,7 +13372,7 @@
             "links": {
                 "Homepage": "https://www.mycred.io"
             },
-            "marketcap_usd": 1205294,
+            "marketcap_usd": 1253046,
             "name": "Cred",
             "network": "eth",
             "shortcut": "LBA",
@@ -13497,7 +13391,7 @@
             "links": {
                 "Homepage": "https://www.localcoinswap.com"
             },
-            "marketcap_usd": 547040,
+            "marketcap_usd": 378219,
             "name": "LocalCoinSwap",
             "network": "eth",
             "shortcut": "LCS",
@@ -13788,7 +13682,7 @@
             "links": {
                 "Homepage": "https://link.smartcontract.com"
             },
-            "marketcap_usd": 3331287196,
+            "marketcap_usd": 3540884016,
             "name": "Chainlink",
             "network": "eth",
             "shortcut": "LINK (Chainlink)",
@@ -13846,7 +13740,7 @@
                 "Github": "https://github.com/GNYIO",
                 "Homepage": "https://www.gny.io/lisk"
             },
-            "marketcap_usd": 264497,
+            "marketcap_usd": 286243,
             "name": "Lisk Machine Learning",
             "network": "eth",
             "shortcut": "LML",
@@ -13866,7 +13760,7 @@
                 "Github": "https://github.com/LunchMoneyToken",
                 "Homepage": "https://www.lunchmoney.io/"
             },
-            "marketcap_usd": 160017,
+            "marketcap_usd": 0,
             "name": "Lunch Money",
             "network": "eth",
             "shortcut": "LMY",
@@ -13886,7 +13780,7 @@
                 "Github": "https://github.com/lendingblock",
                 "Homepage": "https://lendingblock.com"
             },
-            "marketcap_usd": 911743,
+            "marketcap_usd": 0,
             "name": "Lendingblock",
             "network": "eth",
             "shortcut": "LND",
@@ -13944,7 +13838,7 @@
             "links": {
                 "Homepage": "https://www.locuschain.com"
             },
-            "marketcap_usd": 71077061,
+            "marketcap_usd": 64930690,
             "name": "Locus Chain",
             "network": "eth",
             "shortcut": "LOCUS",
@@ -13996,32 +13890,13 @@
                 }
             ]
         },
-        "erc20:eth:LOOKS": {
-            "address": "0xf4d2888d29D722226FafA5d9B24F9164c092421E",
-            "links": {
-                "Homepage": "https://looksrare.org/"
-            },
-            "marketcap_usd": 162286426,
-            "name": "LooksRare",
-            "network": "eth",
-            "shortcut": "LOOKS",
-            "t1_enabled": "yes",
-            "t2_enabled": "yes",
-            "type": "erc20",
-            "wallet": [
-                {
-                    "name": "Trezor Suite",
-                    "url": "https://suite.trezor.io"
-                }
-            ]
-        },
         "erc20:eth:LOOM": {
             "address": "0x42476F744292107e34519F9c357927074Ea3F75D",
             "links": {
                 "Github": "github.com/loomnetwork/",
                 "Homepage": "https://loomx.io"
             },
-            "marketcap_usd": 62877977,
+            "marketcap_usd": 63732527,
             "name": "LOOM",
             "network": "eth",
             "shortcut": "LOOM",
@@ -14041,7 +13916,7 @@
                 "Github": "https://github.com/livepeer",
                 "Homepage": "https://livepeer.org/"
             },
-            "marketcap_usd": 267115919,
+            "marketcap_usd": 233846566,
             "name": "Livepeer Token",
             "network": "eth",
             "shortcut": "LPT",
@@ -14080,7 +13955,7 @@
                 "Github": "https://github.com/loopring",
                 "Homepage": "https://loopring.org"
             },
-            "marketcap_usd": 529224386,
+            "marketcap_usd": 367552993,
             "name": "Loopring",
             "network": "eth",
             "shortcut": "LRC",
@@ -14178,7 +14053,7 @@
                 "Github": "https://github.com/lunyr",
                 "Homepage": "https://lunyr.com"
             },
-            "marketcap_usd": 51764,
+            "marketcap_usd": 50444,
             "name": "Lunyr",
             "network": "eth",
             "shortcut": "LUN",
@@ -14270,26 +14145,6 @@
                 }
             ]
         },
-        "erc20:eth:MAGIC": {
-            "address": "0xB0c7a3Ba49C7a6EaBa6cD4a96C55a1391070Ac9A",
-            "links": {
-                "Github": "https://github.com/TreasureProject",
-                "Homepage": "https://treasure.lol/"
-            },
-            "marketcap_usd": 0,
-            "name": "MAGIC",
-            "network": "eth",
-            "shortcut": "MAGIC",
-            "t1_enabled": "yes",
-            "t2_enabled": "yes",
-            "type": "erc20",
-            "wallet": [
-                {
-                    "name": "Trezor Suite",
-                    "url": "https://suite.trezor.io"
-                }
-            ]
-        },
         "erc20:eth:MAN": {
             "address": "0xe25bCec5D3801cE3a794079BF94adF1B8cCD802D",
             "links": {
@@ -14316,7 +14171,7 @@
                 "Github": "https://github.com/decentraland",
                 "Homepage": "https://decentraland.org"
             },
-            "marketcap_usd": 1751483367,
+            "marketcap_usd": 1203256763,
             "name": "Decentraland MANA",
             "network": "eth",
             "shortcut": "MANA",
@@ -14354,7 +14209,7 @@
             "links": {
                 "Homepage": "https://midasprotocol.io/"
             },
-            "marketcap_usd": 68061,
+            "marketcap_usd": 79376,
             "name": "MIDAS PROTOCOL",
             "network": "eth",
             "shortcut": "MAS",
@@ -14373,7 +14228,7 @@
             "links": {
                 "Homepage": "https://polygon.technology/"
             },
-            "marketcap_usd": 6871256644,
+            "marketcap_usd": 8228741645,
             "name": "Matic Token",
             "network": "eth",
             "shortcut": "MATIC",
@@ -14470,7 +14325,7 @@
             "links": {
                 "Homepage": "https://moedaseeds.com"
             },
-            "marketcap_usd": 3103244,
+            "marketcap_usd": 941369,
             "name": "Moeda Loyalty Points",
             "network": "eth",
             "shortcut": "MDA",
@@ -14489,7 +14344,7 @@
             "links": {
                 "Homepage": "https://www.mdt.co"
             },
-            "marketcap_usd": 23270367,
+            "marketcap_usd": 20302065,
             "name": "Measurable Data Token",
             "network": "eth",
             "shortcut": "MDT",
@@ -14565,7 +14420,7 @@
             "links": {
                 "Homepage": "https://dontbuymeme.com"
             },
-            "marketcap_usd": 18,
+            "marketcap_usd": 2296621,
             "name": "Meme",
             "network": "eth",
             "shortcut": "MEME",
@@ -14624,7 +14479,7 @@
             "links": {
                 "Homepage": "https://www.metronome.io"
             },
-            "marketcap_usd": 14603708,
+            "marketcap_usd": 0,
             "name": "Metronome",
             "network": "eth",
             "shortcut": "MET",
@@ -14663,7 +14518,7 @@
                 "Github": "https://github.com/syncfab",
                 "Homepage": "https://syncfab.com/"
             },
-            "marketcap_usd": 2597882,
+            "marketcap_usd": 2485177,
             "name": "SyncFab Smart Manufacturing Blockchain",
             "network": "eth",
             "shortcut": "MFG",
@@ -14683,7 +14538,7 @@
                 "Github": "https://github.com/MainframeHQ",
                 "Homepage": "https://mainframe.com"
             },
-            "marketcap_usd": 45471512,
+            "marketcap_usd": 50882000,
             "name": "Mainframe Token",
             "network": "eth",
             "shortcut": "MFT",
@@ -14817,7 +14672,7 @@
             "links": {
                 "Homepage": "https://token.morpheuslabs.io"
             },
-            "marketcap_usd": 3583191,
+            "marketcap_usd": 3240236,
             "name": "Morpheus Infrastructure Token",
             "network": "eth",
             "shortcut": "MITX",
@@ -14837,7 +14692,7 @@
                 "Github": "https://github.com/makerdao",
                 "Homepage": "https://makerdao.com"
             },
-            "marketcap_usd": 1000598238,
+            "marketcap_usd": 921451437,
             "name": "MakerDAO",
             "network": "eth",
             "shortcut": "MKR",
@@ -14876,7 +14731,7 @@
             "links": {
                 "Homepage": "https://melonport.com"
             },
-            "marketcap_usd": 55177593,
+            "marketcap_usd": 55465595,
             "name": "Melonport",
             "network": "eth",
             "shortcut": "MLN (new)",
@@ -14973,7 +14828,7 @@
                 "Github": "https://github.com/Goldmint",
                 "Homepage": "https://goldmint.io"
             },
-            "marketcap_usd": 244522,
+            "marketcap_usd": 167035,
             "name": "Goldmint MNT Prelaunch Token",
             "network": "eth",
             "shortcut": "MNTP",
@@ -15166,7 +15021,7 @@
                 "Github": "https://github.com/mstable",
                 "Homepage": "http://mstable.org"
             },
-            "marketcap_usd": 7745724,
+            "marketcap_usd": 4221527,
             "name": "mStable Meta",
             "network": "eth",
             "shortcut": "MTA",
@@ -15185,7 +15040,7 @@
             "links": {
                 "Homepage": "http://www.monetha.io"
             },
-            "marketcap_usd": 2913406,
+            "marketcap_usd": 4954321,
             "name": "Monetha",
             "network": "eth",
             "shortcut": "MTH",
@@ -15204,7 +15059,7 @@
             "links": {
                 "Homepage": "https://www.metalpay.com"
             },
-            "marketcap_usd": 89716429,
+            "marketcap_usd": 68562834,
             "name": "Metal",
             "network": "eth",
             "shortcut": "MTL",
@@ -15223,7 +15078,7 @@
             "links": {
                 "Homepage": "https://medicalchain.com"
             },
-            "marketcap_usd": 676611,
+            "marketcap_usd": 699954,
             "name": "MedToken",
             "network": "eth",
             "shortcut": "MTN",
@@ -15280,7 +15135,7 @@
             "links": {
                 "Homepage": "https://www.matryx.ai"
             },
-            "marketcap_usd": 104534,
+            "marketcap_usd": 0,
             "name": "Matryx",
             "network": "eth",
             "shortcut": "MTX",
@@ -15357,7 +15212,7 @@
             "links": {
                 "Homepage": "http://mvlchain.io"
             },
-            "marketcap_usd": 113988507,
+            "marketcap_usd": 98360336,
             "name": "Mass Vehicle Ledger Token",
             "network": "eth",
             "shortcut": "MVL",
@@ -15377,7 +15232,7 @@
                 "Github": "https://github.com/Merculet",
                 "Homepage": "https://www.merculet.io"
             },
-            "marketcap_usd": 277985,
+            "marketcap_usd": 399201,
             "name": "Merculet",
             "network": "eth",
             "shortcut": "MVP",
@@ -15415,7 +15270,7 @@
             "links": {
                 "Homepage": "https://mysterium.network/"
             },
-            "marketcap_usd": 7454003,
+            "marketcap_usd": 5609808,
             "name": "Mysterium",
             "network": "eth",
             "shortcut": "MYST",
@@ -15454,7 +15309,7 @@
                 "Github": "https://github.com/NANJ-COIN",
                 "Homepage": "https://nanjcoin.com/"
             },
-            "marketcap_usd": 304943,
+            "marketcap_usd": 304243,
             "name": "NANJCOIN",
             "network": "eth",
             "shortcut": "NANJ",
@@ -15551,7 +15406,7 @@
             "links": {
                 "Homepage": "https://niobiumcoin.io"
             },
-            "marketcap_usd": 125735,
+            "marketcap_usd": 110699,
             "name": "Niobium Coin",
             "network": "eth",
             "shortcut": "NBC",
@@ -15610,7 +15465,7 @@
                 "Github": "https://github.com/polyswarm",
                 "Homepage": "https://polyswarm.io"
             },
-            "marketcap_usd": 27218993,
+            "marketcap_usd": 14383154,
             "name": "Nectar",
             "network": "eth",
             "shortcut": "NCT",
@@ -15746,29 +15601,10 @@
             "links": {
                 "Homepage": "http://nexo.io"
             },
-            "marketcap_usd": 389141824,
+            "marketcap_usd": 559205200,
             "name": "Nexo",
             "network": "eth",
             "shortcut": "NEXO",
-            "t1_enabled": "yes",
-            "t2_enabled": "yes",
-            "type": "erc20",
-            "wallet": [
-                {
-                    "name": "Trezor Suite",
-                    "url": "https://suite.trezor.io"
-                }
-            ]
-        },
-        "erc20:eth:NFTL": {
-            "address": "0x3c8D2FCE49906e11e71cB16Fa0fFeB2B16C29638",
-            "links": {
-                "Homepage": "https://niftyleague.com/"
-            },
-            "marketcap_usd": 0,
-            "name": "Nifty League",
-            "network": "eth",
-            "shortcut": "NFTL",
             "t1_enabled": "yes",
             "t2_enabled": "yes",
             "type": "erc20",
@@ -15824,7 +15660,7 @@
                 "Github": "https://github.com/nknorg",
                 "Homepage": "https://nkn.org"
             },
-            "marketcap_usd": 71928965,
+            "marketcap_usd": 62602488,
             "name": "NKN",
             "network": "eth",
             "shortcut": "NKN",
@@ -15864,7 +15700,7 @@
                 "Github": "https://github.com/numerai",
                 "Homepage": "https://numer.ai"
             },
-            "marketcap_usd": 137072291,
+            "marketcap_usd": 89464816,
             "name": "Numerai",
             "network": "eth",
             "shortcut": "NMR",
@@ -15982,7 +15818,7 @@
                 "Github": "https://github.com/pundix",
                 "Homepage": "https://pundix.com"
             },
-            "marketcap_usd": 169403527,
+            "marketcap_usd": 130176292,
             "name": "Pundi X Token",
             "network": "eth",
             "shortcut": "NPXS",
@@ -16041,7 +15877,7 @@
                 "Github": "https://github.com/nucypher",
                 "Homepage": "https://nucypher.com"
             },
-            "marketcap_usd": 134773752,
+            "marketcap_usd": 104081601,
             "name": "NuCypher Network",
             "network": "eth",
             "shortcut": "NU",
@@ -16214,7 +16050,7 @@
             "links": {
                 "Homepage": "https://www.openanx.org/en"
             },
-            "marketcap_usd": 4148821,
+            "marketcap_usd": 12507318,
             "name": "OAX",
             "network": "eth",
             "shortcut": "OAX",
@@ -16274,7 +16110,7 @@
                 "Github": "https://github.com/oceanprotocol",
                 "Homepage": "https://oceanprotocol.com"
             },
-            "marketcap_usd": 113980902,
+            "marketcap_usd": 104198869,
             "name": "Ocean Token",
             "network": "eth",
             "shortcut": "OCEAN",
@@ -16293,7 +16129,7 @@
             "links": {
                 "Homepage": "http://www.ocnex.net"
             },
-            "marketcap_usd": 693366,
+            "marketcap_usd": 687250,
             "name": "Odyssey",
             "network": "eth",
             "shortcut": "OCN",
@@ -16313,7 +16149,7 @@
                 "Github": "https://github.com/octofi",
                 "Homepage": "https://octo.fi"
             },
-            "marketcap_usd": 1415542,
+            "marketcap_usd": 1228111,
             "name": "OctoFi",
             "network": "eth",
             "shortcut": "OCTO",
@@ -16373,7 +16209,7 @@
                 "Github": "https://github.com/originprotocol",
                 "Homepage": "https://www.originprotocol.com"
             },
-            "marketcap_usd": 81273723,
+            "marketcap_usd": 73821122,
             "name": "OriginToken",
             "network": "eth",
             "shortcut": "OGN",
@@ -16433,7 +16269,7 @@
                 "Github": "https://github.com/okex/okberc20token",
                 "Homepage": "https://www.okex.com/"
             },
-            "marketcap_usd": 1048340141,
+            "marketcap_usd": 964698283,
             "name": "OKB",
             "network": "eth",
             "shortcut": "OKB",
@@ -16512,7 +16348,7 @@
                 "Github": "https://github.com/omisego",
                 "Homepage": "https://omg.omise.co"
             },
-            "marketcap_usd": 295651643,
+            "marketcap_usd": 237217527,
             "name": "OmiseGO",
             "network": "eth",
             "shortcut": "OMG",
@@ -16590,7 +16426,7 @@
                 "Github": "https://github.com/onGsocial",
                 "Homepage": "https://somee.social"
             },
-            "marketcap_usd": 336410,
+            "marketcap_usd": 151731,
             "name": "SoMee.Social",
             "network": "eth",
             "shortcut": "ONG",
@@ -16667,7 +16503,7 @@
             "links": {
                 "Homepage": "https://opus-foundation.org"
             },
-            "marketcap_usd": 15937,
+            "marketcap_usd": 0,
             "name": "Opus Foundation",
             "network": "eth",
             "shortcut": "OPT",
@@ -16725,7 +16561,7 @@
                 "Github": "https://github.com/orbs-network",
                 "Homepage": "https://orbs.com"
             },
-            "marketcap_usd": 127021639,
+            "marketcap_usd": 95024759,
             "name": "Orbs",
             "network": "eth",
             "shortcut": "ORBS",
@@ -16803,7 +16639,7 @@
             "links": {
                 "Homepage": "https://www.originsport.io"
             },
-            "marketcap_usd": 1440340,
+            "marketcap_usd": 2610379,
             "name": "Origin Sport",
             "network": "eth",
             "shortcut": "ORS",
@@ -16862,7 +16698,7 @@
                 "Github": "https://github.com/OpenSTFoundation",
                 "Homepage": "https://simpletoken.org"
             },
-            "marketcap_usd": 398079,
+            "marketcap_usd": 373885,
             "name": "Simple Token 'OST'",
             "network": "eth",
             "shortcut": "OST",
@@ -16921,7 +16757,7 @@
                 "Github": "https://github.com/originprotocol",
                 "Homepage": "https://ousd.com"
             },
-            "marketcap_usd": 49547527,
+            "marketcap_usd": 40851015,
             "name": "Origin Dollar",
             "network": "eth",
             "shortcut": "OUSD",
@@ -16941,7 +16777,7 @@
                 "Github": "https://github.com/owndata",
                 "Homepage": "https://owndata.network"
             },
-            "marketcap_usd": 73902,
+            "marketcap_usd": 0,
             "name": "OWNDATA",
             "network": "eth",
             "shortcut": "OWN",
@@ -16981,7 +16817,7 @@
                 "Github": "https://github.com/orchidtechnologies/orchid",
                 "Homepage": "https://www.orchid.com"
             },
-            "marketcap_usd": 80362252,
+            "marketcap_usd": 65471958,
             "name": "Orchid",
             "network": "eth",
             "shortcut": "OXT",
@@ -17099,7 +16935,7 @@
             "links": {
                 "Homepage": "https://patron-influencers.com"
             },
-            "marketcap_usd": 1211806,
+            "marketcap_usd": 0,
             "name": "Patron",
             "network": "eth",
             "shortcut": "PAT",
@@ -17178,7 +17014,7 @@
                 "Github": "https://github.com/paxosglobal",
                 "Homepage": "https://www.paxos.com/standard"
             },
-            "marketcap_usd": 945057992,
+            "marketcap_usd": 942158374,
             "name": "Paxos Standard (PAX)",
             "network": "eth",
             "shortcut": "PAX",
@@ -17198,7 +17034,7 @@
                 "Github": "https://github.com/paxosglobal/paxos-gold-contract",
                 "Homepage": "https://www.paxos.com/paxgold"
             },
-            "marketcap_usd": 601750745,
+            "marketcap_usd": 538116442,
             "name": "Paxos Gold",
             "network": "eth",
             "shortcut": "PAXG",
@@ -17217,7 +17053,7 @@
             "links": {
                 "Homepage": "http://www.tenx.tech"
             },
-            "marketcap_usd": 3663052,
+            "marketcap_usd": 3448505,
             "name": "TenX",
             "network": "eth",
             "shortcut": "PAY",
@@ -17470,7 +17306,7 @@
             "links": {
                 "Homepage": "https://www.phitoken.io"
             },
-            "marketcap_usd": 416865,
+            "marketcap_usd": 396707,
             "name": "PHI Token",
             "network": "eth",
             "shortcut": "PHI",
@@ -17489,7 +17325,7 @@
             "links": {
                 "Homepage": "https://pickle.finance/"
             },
-            "marketcap_usd": 2454553,
+            "marketcap_usd": 2711743,
             "name": "Pickle Finance",
             "network": "eth",
             "shortcut": "PICKLE",
@@ -17508,7 +17344,7 @@
             "links": {
                 "Homepage": "https://piplcoin.com"
             },
-            "marketcap_usd": 39260,
+            "marketcap_usd": 71466,
             "name": "PIPL Coin",
             "network": "eth",
             "shortcut": "PIPL",
@@ -17584,7 +17420,7 @@
             "links": {
                 "Homepage": "http://pkgtoken.io"
             },
-            "marketcap_usd": 49441,
+            "marketcap_usd": 76365,
             "name": "PKG Token",
             "network": "eth",
             "shortcut": "PKG",
@@ -17603,7 +17439,7 @@
             "links": {
                 "Homepage": "https://playkey.io"
             },
-            "marketcap_usd": 78992,
+            "marketcap_usd": 77884,
             "name": "Playkey",
             "network": "eth",
             "shortcut": "PKT",
@@ -17661,7 +17497,7 @@
                 "Github": "https://github.com/twentythirty/PillarToken",
                 "Homepage": "https://www.pillarproject.io"
             },
-            "marketcap_usd": 1381819,
+            "marketcap_usd": 1337992,
             "name": "Pillar Project",
             "network": "eth",
             "shortcut": "PLR",
@@ -17700,7 +17536,7 @@
             "links": {
                 "Homepage": "https://plutus.it"
             },
-            "marketcap_usd": 13783375,
+            "marketcap_usd": 18135931,
             "name": "Pluton",
             "network": "eth",
             "shortcut": "PLU",
@@ -17719,7 +17555,7 @@
             "links": {
                 "Homepage": "https://pumapay.io"
             },
-            "marketcap_usd": 909804,
+            "marketcap_usd": 579891,
             "name": "PumaPay",
             "network": "eth",
             "shortcut": "PMA",
@@ -17758,7 +17594,7 @@
                 "Github": "https://github.com/kleros",
                 "Homepage": "https://kleros.io"
             },
-            "marketcap_usd": 20322698,
+            "marketcap_usd": 19873042,
             "name": "Pinakion",
             "network": "eth",
             "shortcut": "PNK",
@@ -17777,7 +17613,7 @@
             "links": {
                 "Homepage": "https://po.et"
             },
-            "marketcap_usd": 78635,
+            "marketcap_usd": 84581,
             "name": "Po.et Tokens",
             "network": "eth",
             "shortcut": "POE",
@@ -17834,7 +17670,7 @@
             "links": {
                 "Homepage": "https://polymath.network"
             },
-            "marketcap_usd": 200761358,
+            "marketcap_usd": 243576154,
             "name": "Polymath Network",
             "network": "eth",
             "shortcut": "POLY",
@@ -17912,7 +17748,7 @@
             "links": {
                 "Homepage": "https://powerledger.io"
             },
-            "marketcap_usd": 119016732,
+            "marketcap_usd": 100273298,
             "name": "PowerLedger",
             "network": "eth",
             "shortcut": "POWR",
@@ -17931,7 +17767,7 @@
             "links": {
                 "Homepage": "https://www.paypie.com"
             },
-            "marketcap_usd": 563182,
+            "marketcap_usd": 0,
             "name": "PayPie",
             "network": "eth",
             "shortcut": "PPP",
@@ -17951,7 +17787,7 @@
                 "Github": "https://github.com/Bitpopulous",
                 "Homepage": "https://populous.co"
             },
-            "marketcap_usd": 6142426,
+            "marketcap_usd": 3901585,
             "name": "Populous",
             "network": "eth",
             "shortcut": "PPT",
@@ -18009,7 +17845,7 @@
             "links": {
                 "Homepage": "https://privatix.io"
             },
-            "marketcap_usd": 44944,
+            "marketcap_usd": 38225,
             "name": "Privatix",
             "network": "eth",
             "shortcut": "PRIX",
@@ -18068,7 +17904,7 @@
                 "Github": "https://github.com/propsproject",
                 "Homepage": "https://propsproject.com"
             },
-            "marketcap_usd": 699809,
+            "marketcap_usd": 607844,
             "name": "Props",
             "network": "eth",
             "shortcut": "PROPS",
@@ -18165,7 +18001,7 @@
             "links": {
                 "Homepage": "https://primas.io"
             },
-            "marketcap_usd": 524000,
+            "marketcap_usd": 520383,
             "name": "Primas",
             "network": "eth",
             "shortcut": "PST",
@@ -18224,7 +18060,7 @@
             "links": {
                 "Homepage": "https://patientory.com"
             },
-            "marketcap_usd": 0,
+            "marketcap_usd": 183333,
             "name": "Patientory",
             "network": "eth",
             "shortcut": "PTOY",
@@ -18343,7 +18179,7 @@
                 "Github": "https://github.com/playgame-global",
                 "Homepage": "https://its.playgame.com"
             },
-            "marketcap_usd": 287032,
+            "marketcap_usd": 235004,
             "name": "PlayGame",
             "network": "eth",
             "shortcut": "PXG",
@@ -18420,7 +18256,7 @@
             "links": {
                 "Homepage": "https://liquid.plus"
             },
-            "marketcap_usd": 15562824,
+            "marketcap_usd": 7876201,
             "name": "QASH",
             "network": "eth",
             "shortcut": "QASH",
@@ -18473,32 +18309,12 @@
                 }
             ]
         },
-        "erc20:eth:QDT": {
-            "address": "0x9Adc7710E9d1b29d8a78c04d52D32532297C2Ef3",
-            "links": {
-                "Github": "https://github.com/quadrans",
-                "Homepage": "https://quadrans.io"
-            },
-            "marketcap_usd": 0,
-            "name": "Quadrans Token",
-            "network": "eth",
-            "shortcut": "QDT",
-            "t1_enabled": "yes",
-            "t2_enabled": "yes",
-            "type": "erc20",
-            "wallet": [
-                {
-                    "name": "Trezor Suite",
-                    "url": "https://suite.trezor.io"
-                }
-            ]
-        },
         "erc20:eth:QKC": {
             "address": "0xEA26c4aC16D4a5A106820BC8AEE85fd0b7b2b664",
             "links": {
                 "Homepage": "https://quarkchain.io"
             },
-            "marketcap_usd": 72187447,
+            "marketcap_usd": 93261183,
             "name": "QuarkChain",
             "network": "eth",
             "shortcut": "QKC",
@@ -18518,7 +18334,7 @@
                 "Github": "https://github.com/quantnetwork",
                 "Homepage": "https://www.quant.network/"
             },
-            "marketcap_usd": 1201311181,
+            "marketcap_usd": 2099519462,
             "name": "Quant",
             "network": "eth",
             "shortcut": "QNT",
@@ -18577,7 +18393,7 @@
                 "Github": "https://github.com/quantstamp",
                 "Homepage": "https://quantstamp.com/"
             },
-            "marketcap_usd": 18133673,
+            "marketcap_usd": 11812098,
             "name": "Quantstamp Token",
             "network": "eth",
             "shortcut": "QSP",
@@ -18675,7 +18491,7 @@
                 "Github": "https://github.com/rokfin/eth-contracts",
                 "Homepage": "https://www.raetoken.org"
             },
-            "marketcap_usd": 6611706,
+            "marketcap_usd": 7199497,
             "name": "RAE Token",
             "network": "eth",
             "shortcut": "RAE",
@@ -18695,7 +18511,7 @@
                 "Github": "https://github.com/reflexer-labs/",
                 "Homepage": "https://reflexer.finance/"
             },
-            "marketcap_usd": 13631806,
+            "marketcap_usd": 13393008,
             "name": "Rai Reflex Index",
             "network": "eth",
             "shortcut": "RAI",
@@ -18734,7 +18550,7 @@
             "links": {
                 "Homepage": "http://token.dprating.com"
             },
-            "marketcap_usd": 327240,
+            "marketcap_usd": 304865,
             "name": "DPRating",
             "network": "eth",
             "shortcut": "RATING",
@@ -18754,7 +18570,7 @@
                 "Github": "https://github.com/rublixdev",
                 "Homepage": "https://rublix.io/"
             },
-            "marketcap_usd": 574907,
+            "marketcap_usd": 472673,
             "name": "Rublix",
             "network": "eth",
             "shortcut": "RBLX",
@@ -18793,7 +18609,7 @@
                 "Github": "https://github.com/ripio/rcn-token",
                 "Homepage": "https://ripiocredit.network"
             },
-            "marketcap_usd": 1956711,
+            "marketcap_usd": 1924356,
             "name": "Ripio Credit Network",
             "network": "eth",
             "shortcut": "RCN",
@@ -18813,7 +18629,7 @@
                 "Github": "https://github.com/raiden-network/raiden/",
                 "Homepage": "https://raiden.network"
             },
-            "marketcap_usd": 4407004,
+            "marketcap_usd": 4095284,
             "name": "Raiden Network",
             "network": "eth",
             "shortcut": "RDN",
@@ -18910,7 +18726,7 @@
                 "Github": "https://github.com/red",
                 "Homepage": "https://ico.red-lang.org"
             },
-            "marketcap_usd": 267445,
+            "marketcap_usd": 311030,
             "name": "Red Community Token",
             "network": "eth",
             "shortcut": "RED",
@@ -18950,7 +18766,7 @@
                 "Github": "http://github.com/reef-defi",
                 "Homepage": "http://reef.finance"
             },
-            "marketcap_usd": 79192470,
+            "marketcap_usd": 115926650,
             "name": "Reef Finance",
             "network": "eth",
             "shortcut": "REEF",
@@ -18988,7 +18804,7 @@
             "links": {
                 "Homepage": "https://remme.io"
             },
-            "marketcap_usd": 257764,
+            "marketcap_usd": 238965,
             "name": "Remme",
             "network": "eth",
             "shortcut": "REM",
@@ -19028,7 +18844,7 @@
                 "Github": "https://github.com/renproject",
                 "Homepage": "https://renproject.io/"
             },
-            "marketcap_usd": 134908215,
+            "marketcap_usd": 125305482,
             "name": "Republic Token",
             "network": "eth",
             "shortcut": "REN",
@@ -19047,7 +18863,7 @@
             "links": {
                 "Homepage": "https://augur.net"
             },
-            "marketcap_usd": 92697544,
+            "marketcap_usd": 80369495,
             "name": "Augur",
             "network": "eth",
             "shortcut": "REP",
@@ -19085,7 +18901,7 @@
             "links": {
                 "Homepage": "https://request.network"
             },
-            "marketcap_usd": 129387761,
+            "marketcap_usd": 113142253,
             "name": "Request Network",
             "network": "eth",
             "shortcut": "REQ",
@@ -19105,7 +18921,7 @@
                 "Github": "https://github.com/Revain",
                 "Homepage": "https://revain.org"
             },
-            "marketcap_usd": 95183974,
+            "marketcap_usd": 65369070,
             "name": "Revain",
             "network": "eth",
             "shortcut": "REV",
@@ -19144,7 +18960,7 @@
             "links": {
                 "Homepage": "https://refereum.com"
             },
-            "marketcap_usd": 32611515,
+            "marketcap_usd": 29917190,
             "name": "Refereum",
             "network": "eth",
             "shortcut": "RFR",
@@ -19221,7 +19037,7 @@
             "links": {
                 "Homepage": "http://iex.ec/"
             },
-            "marketcap_usd": 79004770,
+            "marketcap_usd": 95624333,
             "name": "IEx.ec",
             "network": "eth",
             "shortcut": "RLC",
@@ -19337,7 +19153,7 @@
             "links": {
                 "Homepage": "https://www.oneroot.io/en"
             },
-            "marketcap_usd": 446953,
+            "marketcap_usd": 476745,
             "name": "OneRoot Network",
             "network": "eth",
             "shortcut": "RNT",
@@ -19395,7 +19211,7 @@
             "links": {
                 "Homepage": "https://icerockmining.io"
             },
-            "marketcap_usd": 47796,
+            "marketcap_usd": 0,
             "name": "ICE ROCK MINING",
             "network": "eth",
             "shortcut": "ROCK2",
@@ -19452,7 +19268,7 @@
             "links": {
                 "Homepage": "https://roobee.io/"
             },
-            "marketcap_usd": 3165816,
+            "marketcap_usd": 3022846,
             "name": "ROOBEE",
             "network": "eth",
             "shortcut": "ROOBEE",
@@ -19511,7 +19327,7 @@
                 "Github": "https://github.com/reserve-protocol/rsr-mainnet",
                 "Homepage": "https://reserve.org"
             },
-            "marketcap_usd": 120649413,
+            "marketcap_usd": 268733435,
             "name": "Reserve Rights",
             "network": "eth",
             "shortcut": "RSR",
@@ -19569,7 +19385,7 @@
             "links": {
                 "Homepage": "https://www.rotharium.io"
             },
-            "marketcap_usd": 2328072,
+            "marketcap_usd": 2857488,
             "name": "Rotharium",
             "network": "eth",
             "shortcut": "RTH",
@@ -19608,7 +19424,7 @@
             "links": {
                 "Homepage": "http://ruffchain.com"
             },
-            "marketcap_usd": 1188164,
+            "marketcap_usd": 485004,
             "name": "Ruff",
             "network": "eth",
             "shortcut": "RUFF",
@@ -19666,7 +19482,7 @@
             "links": {
                 "Homepage": "https://rivetzintl.com"
             },
-            "marketcap_usd": 17680,
+            "marketcap_usd": 14770,
             "name": "Rivetz",
             "network": "eth",
             "shortcut": "RVT",
@@ -19782,7 +19598,7 @@
             "links": {
                 "Homepage": "https://saltlending.com"
             },
-            "marketcap_usd": 2984416,
+            "marketcap_usd": 4135738,
             "name": "Salt Lending Token",
             "network": "eth",
             "shortcut": "SALT",
@@ -19801,7 +19617,7 @@
             "links": {
                 "Homepage": "https://santiment.net"
             },
-            "marketcap_usd": 9687158,
+            "marketcap_usd": 5226733,
             "name": "Santiment",
             "network": "eth",
             "shortcut": "SAN",
@@ -19839,7 +19655,7 @@
             "links": {
                 "Homepage": "https://ico.nexus.social"
             },
-            "marketcap_usd": 37652,
+            "marketcap_usd": 41537,
             "name": "SocialCoin",
             "network": "eth",
             "shortcut": "SCL",
@@ -19916,7 +19732,7 @@
             "links": {
                 "Homepage": "https://www.sentinel-chain.org"
             },
-            "marketcap_usd": 94004,
+            "marketcap_usd": 95679,
             "name": "Sentinel Chain",
             "network": "eth",
             "shortcut": "SENC",
@@ -20128,7 +19944,7 @@
             "links": {
                 "Homepage": "https://shibatoken.com"
             },
-            "marketcap_usd": 6407433195,
+            "marketcap_usd": 6097381910,
             "name": "SHIBA INU",
             "network": "eth",
             "shortcut": "SHIB",
@@ -20147,7 +19963,7 @@
             "links": {
                 "Homepage": "https://www.shipchain.io"
             },
-            "marketcap_usd": 197116,
+            "marketcap_usd": 0,
             "name": "ShipChain",
             "network": "eth",
             "shortcut": "SHIP",
@@ -20302,7 +20118,7 @@
             "links": {
                 "Homepage": "https://www.skb-coin.jp/en"
             },
-            "marketcap_usd": 334555,
+            "marketcap_usd": 308055,
             "name": "Sakura Bloom",
             "network": "eth",
             "shortcut": "SKB",
@@ -20341,7 +20157,7 @@
                 "Github": "https://github.com/Steamtradenet/smart-contract",
                 "Homepage": "https://skincoin.org"
             },
-            "marketcap_usd": 55554,
+            "marketcap_usd": 44341,
             "name": "SKIN",
             "network": "eth",
             "shortcut": "SKIN",
@@ -20437,7 +20253,7 @@
             "links": {
                 "Homepage": "https://youengine.io"
             },
-            "marketcap_usd": 181167294,
+            "marketcap_usd": 143700742,
             "name": "Smooth Love Potion",
             "network": "eth",
             "shortcut": "SLP",
@@ -20514,7 +20330,7 @@
             "links": {
                 "Homepage": "https://suncontract.org"
             },
-            "marketcap_usd": 2806206,
+            "marketcap_usd": 3392800,
             "name": "SunContract",
             "network": "eth",
             "shortcut": "SNC",
@@ -20650,7 +20466,7 @@
                 "Github": "https://github.com/status-im",
                 "Homepage": "https://status.im"
             },
-            "marketcap_usd": 109393410,
+            "marketcap_usd": 99015159,
             "name": "Status Network Token",
             "network": "eth",
             "shortcut": "SNT",
@@ -20689,7 +20505,7 @@
                 "Github": "https://github.com/havven/havven",
                 "Homepage": "https://synthetix.io"
             },
-            "marketcap_usd": 391548448,
+            "marketcap_usd": 756764695,
             "name": "Synthetix Network Token",
             "network": "eth",
             "shortcut": "SNX",
@@ -20727,7 +20543,7 @@
             "links": {
                 "Homepage": "https://www.allsportschain.com"
             },
-            "marketcap_usd": 11488514,
+            "marketcap_usd": 2270253,
             "name": "All Sports",
             "network": "eth",
             "shortcut": "SOC",
@@ -20785,7 +20601,7 @@
                 "Github": "https://github.com/cryptosoulgame",
                 "Homepage": "https://cryptosoul.io/"
             },
-            "marketcap_usd": 453252,
+            "marketcap_usd": 181882,
             "name": "CryptoSoul",
             "network": "eth",
             "shortcut": "SOUL",
@@ -20921,7 +20737,7 @@
             "links": {
                 "Homepage": "https://spindle.zone"
             },
-            "marketcap_usd": 115224,
+            "marketcap_usd": 309029,
             "name": "SPINDLE",
             "network": "eth",
             "shortcut": "SPD",
@@ -21018,7 +20834,7 @@
                 "Github": "https://github.com/sirin-labs/crowdsale-smart-contract",
                 "Homepage": "https://sirinlabs.com"
             },
-            "marketcap_usd": 1947090,
+            "marketcap_usd": 1281011,
             "name": "Sirin Labs",
             "network": "eth",
             "shortcut": "SRN",
@@ -21076,7 +20892,7 @@
             "links": {
                 "Homepage": "https://smartshare.vip/#"
             },
-            "marketcap_usd": 120666,
+            "marketcap_usd": 69608,
             "name": "Smartshare",
             "network": "eth",
             "shortcut": "SSP",
@@ -21114,7 +20930,7 @@
             "links": {
                 "Homepage": "https://coinstarter.com"
             },
-            "marketcap_usd": 10171,
+            "marketcap_usd": 9649,
             "name": "Starter Coin",
             "network": "eth",
             "shortcut": "STAC",
@@ -21152,7 +20968,7 @@
             "links": {
                 "Homepage": "http://starbase.co"
             },
-            "marketcap_usd": 271189,
+            "marketcap_usd": 127706,
             "name": "Star Token",
             "network": "eth",
             "shortcut": "STAR",
@@ -21308,7 +21124,7 @@
                 "Github": "https://github.com/Storj",
                 "Homepage": "https://storj.io"
             },
-            "marketcap_usd": 244726302,
+            "marketcap_usd": 180837370,
             "name": "STORJ",
             "network": "eth",
             "shortcut": "STORJ",
@@ -21386,7 +21202,7 @@
             "links": {
                 "Homepage": "https://staker.network"
             },
-            "marketcap_usd": 386,
+            "marketcap_usd": 351,
             "name": "Staker",
             "network": "eth",
             "shortcut": "STR",
@@ -21445,7 +21261,7 @@
                 "Github": "https://github.com/stx-technologies/stox-token",
                 "Homepage": "https://www.stox.com"
             },
-            "marketcap_usd": 144820,
+            "marketcap_usd": 204187,
             "name": "StoxToken",
             "network": "eth",
             "shortcut": "STX",
@@ -21465,7 +21281,7 @@
                 "Github": "https://github.com/SubstratumNetwork",
                 "Homepage": "https://substratum.net"
             },
-            "marketcap_usd": 389669,
+            "marketcap_usd": 325700,
             "name": "Substratum",
             "network": "eth",
             "shortcut": "SUB",
@@ -21504,7 +21320,7 @@
                 "Github": "https://github.com/sushiswap",
                 "Homepage": "https://sushiswapclassic.org/"
             },
-            "marketcap_usd": 170487114,
+            "marketcap_usd": 212921325,
             "name": "SushiToken",
             "network": "eth",
             "shortcut": "SUSHI",
@@ -21563,7 +21379,7 @@
                 "Github": "https://github.com/swashapp/",
                 "Homepage": "https://swashapp.io/"
             },
-            "marketcap_usd": 5119665,
+            "marketcap_usd": 6277746,
             "name": "Swash Token",
             "network": "eth",
             "shortcut": "SWASH",
@@ -21582,7 +21398,7 @@
             "links": {
                 "Homepage": "http://www.swftcoin.com"
             },
-            "marketcap_usd": 9310615,
+            "marketcap_usd": 5414486,
             "name": "SwftCoin",
             "network": "eth",
             "shortcut": "SWFTC",
@@ -21621,7 +21437,7 @@
             "links": {
                 "Homepage": "http://swarm.city"
             },
-            "marketcap_usd": 606019,
+            "marketcap_usd": 305966,
             "name": "Swarm City Token",
             "network": "eth",
             "shortcut": "SWT",
@@ -21679,7 +21495,7 @@
             "links": {
                 "Homepage": "http://www.spectre.ai"
             },
-            "marketcap_usd": 44653,
+            "marketcap_usd": 35560,
             "name": "Spectre.ai U-Token",
             "network": "eth",
             "shortcut": "SXUT",
@@ -21794,7 +21610,7 @@
             "links": {
                 "Homepage": "https://taklimakan.io"
             },
-            "marketcap_usd": 28961,
+            "marketcap_usd": 19920,
             "name": "Taklimakan Network",
             "network": "eth",
             "shortcut": "TAN",
@@ -21952,7 +21768,7 @@
             "links": {
                 "Homepage": "https://tokenbox.io"
             },
-            "marketcap_usd": 56762,
+            "marketcap_usd": 19476,
             "name": "Tokenbox",
             "network": "eth",
             "shortcut": "TBX",
@@ -22011,7 +21827,7 @@
             "links": {
                 "Homepage": "https://www.thorecash.com"
             },
-            "marketcap_usd": 8431,
+            "marketcap_usd": 7431,
             "name": "Thore Cash",
             "network": "eth",
             "shortcut": "TCH",
@@ -22145,7 +21961,7 @@
             "links": {
                 "Homepage": "https://www.tokenomy.com"
             },
-            "marketcap_usd": 5605312,
+            "marketcap_usd": 4547615,
             "name": "Tokenomy",
             "network": "eth",
             "shortcut": "TEN",
@@ -22204,7 +22020,7 @@
                 "Github": "https://github.com/TrueFlip",
                 "Homepage": "https://trueflip.io"
             },
-            "marketcap_usd": 1087281,
+            "marketcap_usd": 0,
             "name": "TrueFlip",
             "network": "eth",
             "shortcut": "TFL",
@@ -22223,7 +22039,7 @@
             "links": {
                 "Homepage": "https://ico.truegame.io"
             },
-            "marketcap_usd": 21068,
+            "marketcap_usd": 0,
             "name": "Truegame",
             "network": "eth",
             "shortcut": "TGAME",
@@ -22378,7 +22194,7 @@
             "links": {
                 "Homepage": "https://chronobase.eu/"
             },
-            "marketcap_usd": 218587,
+            "marketcap_usd": 154552,
             "name": "ChronoBase",
             "network": "eth",
             "shortcut": "TIK",
@@ -22435,7 +22251,7 @@
             "links": {
                 "Homepage": "https://www.blocktix.io"
             },
-            "marketcap_usd": 27305,
+            "marketcap_usd": 8284,
             "name": "Blocktix",
             "network": "eth",
             "shortcut": "TIX",
@@ -22492,7 +22308,7 @@
             "links": {
                 "Homepage": "https://etherscan.io/token/TokenCard"
             },
-            "marketcap_usd": 2869975,
+            "marketcap_usd": 2939052,
             "name": "TokenCard",
             "network": "eth",
             "shortcut": "TKN",
@@ -22512,7 +22328,7 @@
                 "Github": "https://github.com/Tokpie/tokpie-contract",
                 "Homepage": "https://tokpie.io/"
             },
-            "marketcap_usd": 3549737,
+            "marketcap_usd": 4928767,
             "name": "TOKPIE",
             "network": "eth",
             "shortcut": "TKP",
@@ -22609,7 +22425,7 @@
             "links": {
                 "Homepage": "https://transcodium.com"
             },
-            "marketcap_usd": 34689,
+            "marketcap_usd": 30385,
             "name": "Transcodium",
             "network": "eth",
             "shortcut": "TNS",
@@ -22687,7 +22503,7 @@
             "links": {
                 "Homepage": "https://origintrail.io"
             },
-            "marketcap_usd": 83149796,
+            "marketcap_usd": 73576910,
             "name": "OriginTrail",
             "network": "eth",
             "shortcut": "TRAC",
@@ -22783,7 +22599,7 @@
                 "Github": "https://github.com/WeTrustPlatform",
                 "Homepage": "https://www.wetrust.io"
             },
-            "marketcap_usd": 209480,
+            "marketcap_usd": 175011,
             "name": "WeTrust",
             "network": "eth",
             "shortcut": "TRST",
@@ -22900,7 +22716,7 @@
                 "Github": "https://github.com/trusttoken",
                 "Homepage": "https://www.trusttoken.com"
             },
-            "marketcap_usd": 1190204542,
+            "marketcap_usd": 819806104,
             "name": "TrueUSD",
             "network": "eth",
             "shortcut": "TUSD",
@@ -22997,7 +22813,7 @@
                 "Github": "https://github.com/ubex-ai",
                 "Homepage": "https://www.ubex.com/"
             },
-            "marketcap_usd": 220144,
+            "marketcap_usd": 279110,
             "name": "UBEX Token",
             "network": "eth",
             "shortcut": "UBEX",
@@ -23016,7 +22832,7 @@
             "links": {
                 "Homepage": "https://unibright.io"
             },
-            "marketcap_usd": 32860304,
+            "marketcap_usd": 34651900,
             "name": "Unibright",
             "network": "eth",
             "shortcut": "UBT",
@@ -23074,7 +22890,7 @@
             "links": {
                 "Homepage": "https://uchain.world"
             },
-            "marketcap_usd": 13994,
+            "marketcap_usd": 0,
             "name": "UChain",
             "network": "eth",
             "shortcut": "UCN",
@@ -23093,7 +22909,7 @@
             "links": {
                 "Homepage": "https://www.upfiring.com"
             },
-            "marketcap_usd": 786408,
+            "marketcap_usd": 780358,
             "name": "Upfiring",
             "network": "eth",
             "shortcut": "UFR",
@@ -23133,7 +22949,7 @@
                 "Github": "https://github.com/umbrella-network",
                 "Homepage": "https://umb.network/"
             },
-            "marketcap_usd": 1159844,
+            "marketcap_usd": 697103,
             "name": "Umbrella",
             "network": "eth",
             "shortcut": "UMB",
@@ -23152,7 +22968,7 @@
             "links": {
                 "Homepage": "https://uniswap.org/"
             },
-            "marketcap_usd": 5872723054,
+            "marketcap_usd": 5412075849,
             "name": "Uniswap",
             "network": "eth",
             "shortcut": "UNI",
@@ -23171,7 +22987,7 @@
             "links": {
                 "Homepage": "https://uptoken.org"
             },
-            "marketcap_usd": 41681,
+            "marketcap_usd": 38486,
             "name": "UpToken",
             "network": "eth",
             "shortcut": "UP",
@@ -23190,7 +23006,7 @@
             "links": {
                 "Homepage": "https://sentinelprotocol.io"
             },
-            "marketcap_usd": 34568530,
+            "marketcap_usd": 28427386,
             "name": "Sentinel Protocol",
             "network": "eth",
             "shortcut": "UPP",
@@ -23289,7 +23105,7 @@
                 "Github": "https://github.com/centrehq/centre-tokens",
                 "Homepage": "https://www.centre.io"
             },
-            "marketcap_usd": 54488264711,
+            "marketcap_usd": 43884573326,
             "name": "USD//Coin",
             "network": "eth",
             "shortcut": "USDC",
@@ -23308,7 +23124,7 @@
             "links": {
                 "Homepage": "https://stably.io"
             },
-            "marketcap_usd": 463142,
+            "marketcap_usd": 462556,
             "name": "StableUSD",
             "network": "eth",
             "shortcut": "USDS",
@@ -23327,7 +23143,7 @@
             "links": {
                 "Homepage": "https://tether.to"
             },
-            "marketcap_usd": 66323337069,
+            "marketcap_usd": 68523909342,
             "name": "USD Tether (erc20)",
             "network": "eth",
             "shortcut": "USDT",
@@ -23367,7 +23183,7 @@
                 "Github": "https://github.com/utrustdev/",
                 "Homepage": "https://utrust.com"
             },
-            "marketcap_usd": 64132578,
+            "marketcap_usd": 65308673,
             "name": "Utrust",
             "network": "eth",
             "shortcut": "UTK",
@@ -23425,7 +23241,7 @@
             "links": {
                 "Homepage": "https://u.network/"
             },
-            "marketcap_usd": 412174,
+            "marketcap_usd": 321373,
             "name": "U Networks",
             "network": "eth",
             "shortcut": "UUU",
@@ -23445,7 +23261,7 @@
                 "Github": "https://github.com/smartvalor/ValorToken",
                 "Homepage": "https://smartvalor.com"
             },
-            "marketcap_usd": 6149044,
+            "marketcap_usd": 4600772,
             "name": "ValorToken",
             "network": "eth",
             "shortcut": "VALOR",
@@ -23485,7 +23301,7 @@
                 "Github": "https://github.com/VeriDocGlobal",
                 "Homepage": "https://www.veridocglobal.com/"
             },
-            "marketcap_usd": 2247641,
+            "marketcap_usd": 2287594,
             "name": "VeriDocGlobal",
             "network": "eth",
             "shortcut": "VDG",
@@ -23525,7 +23341,7 @@
                 "Github": "https://github.com/blockv",
                 "Homepage": "https://blockv.io"
             },
-            "marketcap_usd": 5900690,
+            "marketcap_usd": 10640423,
             "name": "BLOCKv",
             "network": "eth",
             "shortcut": "VEE",
@@ -23545,7 +23361,7 @@
                 "Github": "https://github.com/vegaprotocol",
                 "Homepage": "https://vega.xyz"
             },
-            "marketcap_usd": 41779940,
+            "marketcap_usd": 42758233,
             "name": "Vega",
             "network": "eth",
             "shortcut": "VEGA",
@@ -23602,7 +23418,7 @@
             "links": {
                 "Homepage": "https://veritas.veritaseum.com"
             },
-            "marketcap_usd": 62598013,
+            "marketcap_usd": 104861372,
             "name": "Veritaseum",
             "network": "eth",
             "shortcut": "VERI",
@@ -23621,7 +23437,7 @@
             "links": {
                 "Homepage": "https://www.viberate.com"
             },
-            "marketcap_usd": 3016756,
+            "marketcap_usd": 14921611,
             "name": "Viberate",
             "network": "eth",
             "shortcut": "VIB",
@@ -23640,7 +23456,7 @@
             "links": {
                 "Homepage": "https://www.vibehub.io"
             },
-            "marketcap_usd": 1016546,
+            "marketcap_usd": 656718,
             "name": "VIBE Coin",
             "network": "eth",
             "shortcut": "VIBE",
@@ -23680,7 +23496,7 @@
                 "Github": "https://github.com/videocoin",
                 "Homepage": "https://www.videocoin.io"
             },
-            "marketcap_usd": 9396123,
+            "marketcap_usd": 8449225,
             "name": "VideoCoin",
             "network": "eth",
             "shortcut": "VID",
@@ -23739,7 +23555,7 @@
             "links": {
                 "Homepage": "https://ico.vikky.io"
             },
-            "marketcap_usd": 58700,
+            "marketcap_usd": 58565,
             "name": "VikkyToken",
             "network": "eth",
             "shortcut": "VIKKY",
@@ -23818,7 +23634,7 @@
                 "Github": "https://github.com/vetri-global/",
                 "Homepage": "https://vetri.global/"
             },
-            "marketcap_usd": 3358892,
+            "marketcap_usd": 0,
             "name": "VETRI",
             "network": "eth",
             "shortcut": "VLD",
@@ -23895,7 +23711,7 @@
             "links": {
                 "Homepage": "https://vnx.io/"
             },
-            "marketcap_usd": 729051,
+            "marketcap_usd": 0,
             "name": "VNX Exchange",
             "network": "eth",
             "shortcut": "VNXLU",
@@ -23938,25 +23754,6 @@
             "name": "Voise",
             "network": "eth",
             "shortcut": "VOISE",
-            "t1_enabled": "yes",
-            "t2_enabled": "yes",
-            "type": "erc20",
-            "wallet": [
-                {
-                    "name": "Trezor Suite",
-                    "url": "https://suite.trezor.io"
-                }
-            ]
-        },
-        "erc20:eth:VR": {
-            "address": "0x7d5121505149065b562C789A0145eD750e6E8cdD",
-            "links": {
-                "Homepage": "https://victoriavr.com/"
-            },
-            "marketcap_usd": 17332994,
-            "name": "Victoria VR",
-            "network": "eth",
-            "shortcut": "VR",
             "t1_enabled": "yes",
             "t2_enabled": "yes",
             "type": "erc20",
@@ -24088,7 +23885,7 @@
             "links": {
                 "Homepage": "https://wab.network"
             },
-            "marketcap_usd": 153164,
+            "marketcap_usd": 267044,
             "name": "WABnetwork",
             "network": "eth",
             "shortcut": "WAB",
@@ -24107,7 +23904,7 @@
             "links": {
                 "Homepage": "https://taelpay.com"
             },
-            "marketcap_usd": 4524619,
+            "marketcap_usd": 11082695,
             "name": "Tael",
             "network": "eth",
             "shortcut": "WABI",
@@ -24226,7 +24023,7 @@
                 "Github": "https://github.com/WrappedBTC",
                 "Homepage": "https://wbtc.network"
             },
-            "marketcap_usd": 5382346911,
+            "marketcap_usd": 5073961138,
             "name": "Wrapped Bitcoin",
             "network": "eth",
             "shortcut": "WBTC",
@@ -24421,7 +24218,7 @@
             "links": {
                 "Homepage": "https://wings.ai"
             },
-            "marketcap_usd": 415712,
+            "marketcap_usd": 363151,
             "name": "WINGS",
             "network": "eth",
             "shortcut": "WINGS",
@@ -24577,7 +24374,7 @@
             "links": {
                 "Homepage": "https://wepower.network"
             },
-            "marketcap_usd": 613438,
+            "marketcap_usd": 418376,
             "name": "WePower Token",
             "network": "eth",
             "shortcut": "WPR",
@@ -24596,7 +24393,7 @@
             "links": {
                 "Homepage": "https://worldcore.eu"
             },
-            "marketcap_usd": 45509,
+            "marketcap_usd": 28237,
             "name": "Worldcore",
             "network": "eth",
             "shortcut": "WRC",
@@ -24715,7 +24512,7 @@
             "links": {
                 "Homepage": "https://x8currency.com"
             },
-            "marketcap_usd": 655264,
+            "marketcap_usd": 545972,
             "name": "X8X",
             "network": "eth",
             "shortcut": "X8X",
@@ -24734,7 +24531,7 @@
             "links": {
                 "Homepage": "https://www.antiample.org/"
             },
-            "marketcap_usd": 687085,
+            "marketcap_usd": 0,
             "name": "Antiample",
             "network": "eth",
             "shortcut": "XAMP",
@@ -24753,7 +24550,7 @@
             "links": {
                 "Homepage": "http://www.xaurum.org"
             },
-            "marketcap_usd": 1312062,
+            "marketcap_usd": 1223647,
             "name": "Xaurum",
             "network": "eth",
             "shortcut": "XAUR",
@@ -24792,7 +24589,7 @@
                 "Github": "https://github.com/blitzpredict",
                 "Homepage": "https://www.blitzpredict.io"
             },
-            "marketcap_usd": 93743,
+            "marketcap_usd": 86819,
             "name": "BlitzPredict",
             "network": "eth",
             "shortcut": "XBP",
@@ -24831,7 +24628,7 @@
             "links": {
                 "Homepage": "https://www.swisscryptotokens.ch/"
             },
-            "marketcap_usd": 3072576,
+            "marketcap_usd": 3100429,
             "name": "CryptoFranc",
             "network": "eth",
             "shortcut": "XCHF",
@@ -25063,7 +24860,7 @@
             "links": {
                 "Homepage": "https://xio.network/"
             },
-            "marketcap_usd": 880117,
+            "marketcap_usd": 472767,
             "name": "XIO Network",
             "network": "eth",
             "shortcut": "XIO",
@@ -25122,7 +24919,7 @@
                 "Github": "https://github.com/XMaxPlatform",
                 "Homepage": "https://www.xmx.com"
             },
-            "marketcap_usd": 661817,
+            "marketcap_usd": 568067,
             "name": "XMax",
             "network": "eth",
             "shortcut": "XMX",
@@ -25199,7 +24996,7 @@
             "links": {
                 "Homepage": "http://www.xov.io"
             },
-            "marketcap_usd": 6697,
+            "marketcap_usd": 4454,
             "name": "XOVBank",
             "network": "eth",
             "shortcut": "XOV",
@@ -25218,7 +25015,7 @@
             "links": {
                 "Homepage": "https://xpa.io"
             },
-            "marketcap_usd": 31518,
+            "marketcap_usd": 31446,
             "name": "XPA",
             "network": "eth",
             "shortcut": "XPA",
@@ -25278,7 +25075,7 @@
                 "Github": "https://github.com/ProtonProtocol",
                 "Homepage": "https://www.protonchain.com/"
             },
-            "marketcap_usd": 43908891,
+            "marketcap_usd": 32097665,
             "name": "Proton",
             "network": "eth",
             "shortcut": "XPR",
@@ -25297,7 +25094,7 @@
             "links": {
                 "Homepage": "https://cryptobuyer.io"
             },
-            "marketcap_usd": 21056,
+            "marketcap_usd": 13582,
             "name": "Cryptobuyer Token",
             "network": "eth",
             "shortcut": "XPT",
@@ -25355,7 +25152,7 @@
                 "Github": "https://github.com/Xfers/StraitsX-tokens",
                 "Homepage": "https://xfers.com/sg/stablecoin"
             },
-            "marketcap_usd": 63409101,
+            "marketcap_usd": 48922678,
             "name": "Singapore-Dollar Backed Stablecoin",
             "network": "eth",
             "shortcut": "XSGD",
@@ -25374,7 +25171,7 @@
             "links": {
                 "Homepage": "https://xyo.network"
             },
-            "marketcap_usd": 113534904,
+            "marketcap_usd": 79662882,
             "name": "XYO",
             "network": "eth",
             "shortcut": "XYO",
@@ -25433,7 +25230,7 @@
             "links": {
                 "Homepage": "http://www.yeefoundation.com"
             },
-            "marketcap_usd": 182076,
+            "marketcap_usd": 117425,
             "name": "Yee Token",
             "network": "eth",
             "shortcut": "YEE",
@@ -25453,7 +25250,7 @@
                 "Github": "https://github.com/iearn-finance",
                 "Homepage": "https://yearn.finance/"
             },
-            "marketcap_usd": 402844034,
+            "marketcap_usd": 307596970,
             "name": "yearn.finance",
             "network": "eth",
             "shortcut": "YFI",
@@ -25473,7 +25270,7 @@
                 "Github": "https://github.com/yfii/vault",
                 "Homepage": "https://dfi.money/"
             },
-            "marketcap_usd": 70199110,
+            "marketcap_usd": 47704415,
             "name": "YFII.finance",
             "network": "eth",
             "shortcut": "YFII",
@@ -25513,7 +25310,7 @@
                 "Github": "https://github.com/YOUengine",
                 "Homepage": "https://youengine.io"
             },
-            "marketcap_usd": 4406429895,
+            "marketcap_usd": 0,
             "name": "yOUcash",
             "network": "eth",
             "shortcut": "YOUC",
@@ -25553,7 +25350,7 @@
                 "Github": "https://github.com/zapproject",
                 "Homepage": "https://zap.store"
             },
-            "marketcap_usd": 935365,
+            "marketcap_usd": 738835,
             "name": "ZAP",
             "network": "eth",
             "shortcut": "ZAP",
@@ -25572,7 +25369,7 @@
             "links": {
                 "Homepage": "https://0chain.net"
             },
-            "marketcap_usd": 7910084,
+            "marketcap_usd": 10193368,
             "name": "0chain",
             "network": "eth",
             "shortcut": "ZCN",
@@ -25610,7 +25407,7 @@
             "links": {
                 "Homepage": "https://zsc.io/"
             },
-            "marketcap_usd": 130868,
+            "marketcap_usd": 135457,
             "name": "Zeusshield",
             "network": "eth",
             "shortcut": "ZCS",
@@ -25633,25 +25430,6 @@
             "name": "Zodcoin",
             "network": "eth",
             "shortcut": "ZDC",
-            "t1_enabled": "yes",
-            "t2_enabled": "yes",
-            "type": "erc20",
-            "wallet": [
-                {
-                    "name": "Trezor Suite",
-                    "url": "https://suite.trezor.io"
-                }
-            ]
-        },
-        "erc20:eth:ZENI": {
-            "address": "0x2E59D147962E2bB3fBdc52dc18CfBa2653C06Ccc",
-            "links": {
-                "Homepage": "https://thesevensofficial.com/"
-            },
-            "marketcap_usd": 0,
-            "name": "Zeni Token",
-            "network": "eth",
-            "shortcut": "ZENI",
             "t1_enabled": "yes",
             "t2_enabled": "yes",
             "type": "erc20",
@@ -25688,7 +25466,7 @@
                 "Github": "https://github.com/ZEUS-coin",
                 "Homepage": "https://zeusfundme.com/"
             },
-            "marketcap_usd": 15928,
+            "marketcap_usd": 14497,
             "name": "ZeusNetwork",
             "network": "eth",
             "shortcut": "ZEUS",
@@ -25707,7 +25485,7 @@
             "links": {
                 "Homepage": "https://zinc.work"
             },
-            "marketcap_usd": 3372,
+            "marketcap_usd": 4817,
             "name": "ZINC",
             "network": "eth",
             "shortcut": "ZINC",
@@ -25842,7 +25620,7 @@
             "links": {
                 "Homepage": "https://zper.io"
             },
-            "marketcap_usd": 23384,
+            "marketcap_usd": 21946,
             "name": "ZPER",
             "network": "eth",
             "shortcut": "ZPR",
@@ -25862,7 +25640,7 @@
                 "Github": "https://github.com/0xProject",
                 "Homepage": "https://0xproject.com"
             },
-            "marketcap_usd": 283896539,
+            "marketcap_usd": 224207054,
             "name": "0x Project",
             "network": "eth",
             "shortcut": "ZRX",
@@ -25900,7 +25678,7 @@
             "links": {
                 "Homepage": "https://0xcert.org"
             },
-            "marketcap_usd": 71736,
+            "marketcap_usd": 0,
             "name": "0xcert Protocol Token",
             "network": "eth",
             "shortcut": "ZXC",
@@ -26978,7 +26756,7 @@
                 "Github": "https://github.com/eosdac",
                 "Homepage": "https://eosdac.io/"
             },
-            "marketcap_usd": 330882,
+            "marketcap_usd": 344186,
             "name": "eosDAC",
             "network": "eth",
             "shortcut": "eosDAC",
@@ -33618,97 +33396,13 @@
                 }
             ]
         },
-        "eth:AIOZ": {
-            "links": {
-                "Homepage": "https://aioz.network"
-            },
-            "marketcap_usd": 41085232,
-            "name": "AIOZ Network",
-            "shortcut": "AIOZ",
-            "t1_enabled": "yes",
-            "t2_enabled": "yes",
-            "type": "coin",
-            "wallet": [
-                {
-                    "name": "MyCrypto",
-                    "url": "https://mycrypto.com"
-                },
-                {
-                    "name": "MyEtherWallet",
-                    "url": "https://www.myetherwallet.com"
-                }
-            ]
-        },
-        "eth:AITD": {
-            "links": {
-                "Homepage": "https://www.aitd.io/"
-            },
-            "marketcap_usd": 0,
-            "name": "Aitd",
-            "shortcut": "AITD",
-            "t1_enabled": "yes",
-            "t2_enabled": "yes",
-            "type": "coin",
-            "wallet": [
-                {
-                    "name": "MyCrypto",
-                    "url": "https://mycrypto.com"
-                },
-                {
-                    "name": "MyEtherWallet",
-                    "url": "https://www.myetherwallet.com"
-                }
-            ]
-        },
         "eth:AKA": {
             "links": {
                 "Homepage": "https://akroma.io"
             },
-            "marketcap_usd": 4363,
+            "marketcap_usd": 15886,
             "name": "Akroma",
             "shortcut": "AKA",
-            "t1_enabled": "yes",
-            "t2_enabled": "yes",
-            "type": "coin",
-            "wallet": [
-                {
-                    "name": "MyCrypto",
-                    "url": "https://mycrypto.com"
-                },
-                {
-                    "name": "MyEtherWallet",
-                    "url": "https://www.myetherwallet.com"
-                }
-            ]
-        },
-        "eth:AMBROS": {
-            "links": {
-                "Homepage": "https://ambros.network"
-            },
-            "marketcap_usd": 0,
-            "name": "Ambros Chain",
-            "shortcut": "AMBROS",
-            "t1_enabled": "yes",
-            "t2_enabled": "yes",
-            "type": "coin",
-            "wallet": [
-                {
-                    "name": "MyCrypto",
-                    "url": "https://mycrypto.com"
-                },
-                {
-                    "name": "MyEtherWallet",
-                    "url": "https://www.myetherwallet.com"
-                }
-            ]
-        },
-        "eth:AME": {
-            "links": {
-                "Homepage": "https://amechain.io/"
-            },
-            "marketcap_usd": 0,
-            "name": "AME Chain",
-            "shortcut": "AME",
             "t1_enabled": "yes",
             "t2_enabled": "yes",
             "type": "coin",
@@ -33751,27 +33445,6 @@
             "marketcap_usd": 0,
             "name": "Permission",
             "shortcut": "ASK",
-            "t1_enabled": "yes",
-            "t2_enabled": "yes",
-            "type": "coin",
-            "wallet": [
-                {
-                    "name": "MyCrypto",
-                    "url": "https://mycrypto.com"
-                },
-                {
-                    "name": "MyEtherWallet",
-                    "url": "https://www.myetherwallet.com"
-                }
-            ]
-        },
-        "eth:ASTR": {
-            "links": {
-                "Homepage": "https://astar.network/"
-            },
-            "marketcap_usd": 167986159,
-            "name": "Astar",
-            "shortcut": "ASTR",
             "t1_enabled": "yes",
             "t2_enabled": "yes",
             "type": "coin",
@@ -33867,55 +33540,13 @@
                 }
             ]
         },
-        "eth:BELLY": {
-            "links": {
-                "Homepage": "https://cryptopiece.online"
-            },
-            "marketcap_usd": 0,
-            "name": "Openpiece",
-            "shortcut": "BELLY",
-            "t1_enabled": "yes",
-            "t2_enabled": "yes",
-            "type": "coin",
-            "wallet": [
-                {
-                    "name": "MyCrypto",
-                    "url": "https://mycrypto.com"
-                },
-                {
-                    "name": "MyEtherWallet",
-                    "url": "https://www.myetherwallet.com"
-                }
-            ]
-        },
         "eth:BNB": {
             "links": {
                 "Homepage": "https://www.binance.org"
             },
-            "marketcap_usd": 44690398276,
+            "marketcap_usd": 46304453916,
             "name": "Binance Smart Chain",
             "shortcut": "BNB",
-            "t1_enabled": "yes",
-            "t2_enabled": "yes",
-            "type": "coin",
-            "wallet": [
-                {
-                    "name": "MyCrypto",
-                    "url": "https://mycrypto.com"
-                },
-                {
-                    "name": "MyEtherWallet",
-                    "url": "https://www.myetherwallet.com"
-                }
-            ]
-        },
-        "eth:BOBA": {
-            "links": {
-                "Homepage": "https://boba.network"
-            },
-            "marketcap_usd": 0,
-            "name": "Boba Network Bobabase",
-            "shortcut": "BOBA",
             "t1_enabled": "yes",
             "t2_enabled": "yes",
             "type": "coin",
@@ -33937,27 +33568,6 @@
             "marketcap_usd": 0,
             "name": "BON Network",
             "shortcut": "BOY",
-            "t1_enabled": "yes",
-            "t2_enabled": "yes",
-            "type": "coin",
-            "wallet": [
-                {
-                    "name": "MyCrypto",
-                    "url": "https://mycrypto.com"
-                },
-                {
-                    "name": "MyEtherWallet",
-                    "url": "https://www.myetherwallet.com"
-                }
-            ]
-        },
-        "eth:BRB": {
-            "links": {
-                "Homepage": "https://www.beryl-bit.com"
-            },
-            "marketcap_usd": 0,
-            "name": "BerylBit",
-            "shortcut": "BRB",
             "t1_enabled": "yes",
             "t2_enabled": "yes",
             "type": "coin",
@@ -34077,27 +33687,6 @@
                 }
             ]
         },
-        "eth:Brise": {
-            "links": {
-                "Homepage": "https://bitgert.com/"
-            },
-            "marketcap_usd": 0,
-            "name": "Bitgert",
-            "shortcut": "Brise",
-            "t1_enabled": "yes",
-            "t2_enabled": "yes",
-            "type": "coin",
-            "wallet": [
-                {
-                    "name": "MyCrypto",
-                    "url": "https://mycrypto.com"
-                },
-                {
-                    "name": "MyEtherWallet",
-                    "url": "https://www.myetherwallet.com"
-                }
-            ]
-        },
         "eth:CATE": {
             "links": {
                 "Homepage": "https://catechain.com"
@@ -34144,30 +33733,9 @@
             "links": {
                 "Homepage": "https://docs.celo.org/"
             },
-            "marketcap_usd": 453103476,
+            "marketcap_usd": 340743000,
             "name": "Celo",
             "shortcut": "CELO",
-            "t1_enabled": "yes",
-            "t2_enabled": "yes",
-            "type": "coin",
-            "wallet": [
-                {
-                    "name": "MyCrypto",
-                    "url": "https://mycrypto.com"
-                },
-                {
-                    "name": "MyEtherWallet",
-                    "url": "https://www.myetherwallet.com"
-                }
-            ]
-        },
-        "eth:CEM": {
-            "links": {
-                "Homepage": "https://cemblockchain.com/"
-            },
-            "marketcap_usd": 0,
-            "name": "Crypto Emergency",
-            "shortcut": "CEM",
             "t1_enabled": "yes",
             "t2_enabled": "yes",
             "type": "coin",
@@ -34229,7 +33797,7 @@
             "links": {
                 "Homepage": "https://callisto.network"
             },
-            "marketcap_usd": 7915500,
+            "marketcap_usd": 23162008,
             "name": "Callisto",
             "shortcut": "CLO",
             "t1_enabled": "yes",
@@ -34248,95 +33816,11 @@
         },
         "eth:CLV": {
             "links": {
-                "Homepage": "https://clv.org"
+                "Homepage": "https://clover.finance"
             },
-            "marketcap_usd": 0,
-            "name": "CLV Parachain",
+            "marketcap_usd": 37947081,
+            "name": "Clover",
             "shortcut": "CLV",
-            "t1_enabled": "yes",
-            "t2_enabled": "yes",
-            "type": "coin",
-            "wallet": [
-                {
-                    "name": "MyCrypto",
-                    "url": "https://mycrypto.com"
-                },
-                {
-                    "name": "MyEtherWallet",
-                    "url": "https://www.myetherwallet.com"
-                }
-            ]
-        },
-        "eth:CNDL": {
-            "links": {
-                "Homepage": "https://candlelabs.org/"
-            },
-            "marketcap_usd": 0,
-            "name": "Candle",
-            "shortcut": "CNDL",
-            "t1_enabled": "yes",
-            "t2_enabled": "yes",
-            "type": "coin",
-            "wallet": [
-                {
-                    "name": "MyCrypto",
-                    "url": "https://mycrypto.com"
-                },
-                {
-                    "name": "MyEtherWallet",
-                    "url": "https://www.myetherwallet.com"
-                }
-            ]
-        },
-        "eth:CPAY:21337": {
-            "links": {
-                "Homepage": "https://cennz.net"
-            },
-            "marketcap_usd": 0,
-            "name": "CENNZnet Azalea",
-            "shortcut": "CPAY",
-            "t1_enabled": "yes",
-            "t2_enabled": "yes",
-            "type": "coin",
-            "wallet": [
-                {
-                    "name": "MyCrypto",
-                    "url": "https://mycrypto.com"
-                },
-                {
-                    "name": "MyEtherWallet",
-                    "url": "https://www.myetherwallet.com"
-                }
-            ]
-        },
-        "eth:CPAY:3000": {
-            "links": {
-                "Homepage": "https://cennz.net"
-            },
-            "marketcap_usd": 0,
-            "name": "CENNZnet Rata",
-            "shortcut": "CPAY",
-            "t1_enabled": "yes",
-            "t2_enabled": "yes",
-            "type": "coin",
-            "wallet": [
-                {
-                    "name": "MyCrypto",
-                    "url": "https://mycrypto.com"
-                },
-                {
-                    "name": "MyEtherWallet",
-                    "url": "https://www.myetherwallet.com"
-                }
-            ]
-        },
-        "eth:CPAY:3001": {
-            "links": {
-                "Homepage": "https://cennz.net"
-            },
-            "marketcap_usd": 0,
-            "name": "CENNZnet Nikau",
-            "shortcut": "CPAY",
             "t1_enabled": "yes",
             "t2_enabled": "yes",
             "type": "coin",
@@ -34376,72 +33860,9 @@
             "links": {
                 "Homepage": "https://cronos.org/"
             },
-            "marketcap_usd": 3699264619,
+            "marketcap_usd": 2861924175,
             "name": "Cronos",
             "shortcut": "CRO",
-            "t1_enabled": "yes",
-            "t2_enabled": "yes",
-            "type": "coin",
-            "wallet": [
-                {
-                    "name": "MyCrypto",
-                    "url": "https://mycrypto.com"
-                },
-                {
-                    "name": "MyEtherWallet",
-                    "url": "https://www.myetherwallet.com"
-                }
-            ]
-        },
-        "eth:CSB": {
-            "links": {
-                "Homepage": "https://crossbell.io"
-            },
-            "marketcap_usd": 0,
-            "name": "Crossbell",
-            "shortcut": "CSB",
-            "t1_enabled": "yes",
-            "t2_enabled": "yes",
-            "type": "coin",
-            "wallet": [
-                {
-                    "name": "MyCrypto",
-                    "url": "https://mycrypto.com"
-                },
-                {
-                    "name": "MyEtherWallet",
-                    "url": "https://www.myetherwallet.com"
-                }
-            ]
-        },
-        "eth:CUBE": {
-            "links": {
-                "Homepage": "https://www.cube.network"
-            },
-            "marketcap_usd": 0,
-            "name": "Cube Chain",
-            "shortcut": "CUBE",
-            "t1_enabled": "yes",
-            "t2_enabled": "yes",
-            "type": "coin",
-            "wallet": [
-                {
-                    "name": "MyCrypto",
-                    "url": "https://mycrypto.com"
-                },
-                {
-                    "name": "MyEtherWallet",
-                    "url": "https://www.myetherwallet.com"
-                }
-            ]
-        },
-        "eth:CWN": {
-            "links": {
-                "Homepage": "https://cloudwalk.io"
-            },
-            "marketcap_usd": 0,
-            "name": "CloudWalk",
-            "shortcut": "CWN",
             "t1_enabled": "yes",
             "t2_enabled": "yes",
             "type": "coin",
@@ -34484,27 +33905,6 @@
             "marketcap_usd": 0,
             "name": "Moonbase Alpha",
             "shortcut": "DEV",
-            "t1_enabled": "yes",
-            "t2_enabled": "yes",
-            "type": "coin",
-            "wallet": [
-                {
-                    "name": "MyCrypto",
-                    "url": "https://mycrypto.com"
-                },
-                {
-                    "name": "MyEtherWallet",
-                    "url": "https://www.myetherwallet.com"
-                }
-            ]
-        },
-        "eth:DGCC": {
-            "links": {
-                "Homepage": "https://digestgroup.ltd"
-            },
-            "marketcap_usd": 0,
-            "name": "Digest Swarm Chain",
-            "shortcut": "DGCC",
             "t1_enabled": "yes",
             "t2_enabled": "yes",
             "type": "coin",
@@ -34568,27 +33968,6 @@
             "marketcap_usd": 0,
             "name": "Decentralized Web",
             "shortcut": "DWU",
-            "t1_enabled": "yes",
-            "t2_enabled": "yes",
-            "type": "coin",
-            "wallet": [
-                {
-                    "name": "MyCrypto",
-                    "url": "https://mycrypto.com"
-                },
-                {
-                    "name": "MyEtherWallet",
-                    "url": "https://www.myetherwallet.com"
-                }
-            ]
-        },
-        "eth:DX": {
-            "links": {
-                "Homepage": "https://www.dxchain.com/"
-            },
-            "marketcap_usd": 0,
-            "name": "Dxchain",
-            "shortcut": "DX",
             "t1_enabled": "yes",
             "t2_enabled": "yes",
             "type": "coin",
@@ -34670,7 +34049,7 @@
             "links": {
                 "Homepage": "http://edgewa.re"
             },
-            "marketcap_usd": 9311411,
+            "marketcap_usd": 5599557,
             "name": "Edgeware",
             "shortcut": "EDG",
             "t1_enabled": "yes",
@@ -34691,7 +34070,7 @@
             "links": {
                 "Homepage": "https://egem.io"
             },
-            "marketcap_usd": 84946,
+            "marketcap_usd": 89711,
             "name": "EtherGem",
             "shortcut": "EGEM",
             "t1_enabled": "yes",
@@ -34839,7 +34218,7 @@
             "links": {
                 "Homepage": "https://ethereumclassic.org"
             },
-            "marketcap_usd": 4593639300,
+            "marketcap_usd": 3496867946,
             "name": "Ethereum Classic",
             "shortcut": "ETC",
             "t1_enabled": "yes",
@@ -34856,7 +34235,7 @@
             "links": {
                 "Homepage": "https://ethereum.org"
             },
-            "marketcap_usd": 191826182799,
+            "marketcap_usd": 192292400539,
             "name": "Ethereum",
             "shortcut": "ETH",
             "t1_enabled": "yes",
@@ -34873,7 +34252,7 @@
             "links": {
                 "Homepage": "https://ethoprotocol.com"
             },
-            "marketcap_usd": 161490,
+            "marketcap_usd": 0,
             "name": "Etho Protocol",
             "shortcut": "ETHO",
             "t1_enabled": "yes",
@@ -34918,48 +34297,6 @@
             "marketcap_usd": 0,
             "name": "EtherLite Chain",
             "shortcut": "ETL",
-            "t1_enabled": "yes",
-            "t2_enabled": "yes",
-            "type": "coin",
-            "wallet": [
-                {
-                    "name": "MyCrypto",
-                    "url": "https://mycrypto.com"
-                },
-                {
-                    "name": "MyEtherWallet",
-                    "url": "https://www.myetherwallet.com"
-                }
-            ]
-        },
-        "eth:ETND": {
-            "links": {
-                "Homepage": "https://www.etnd.pro"
-            },
-            "marketcap_usd": 0,
-            "name": "ETND Chain",
-            "shortcut": "ETND",
-            "t1_enabled": "yes",
-            "t2_enabled": "yes",
-            "type": "coin",
-            "wallet": [
-                {
-                    "name": "MyCrypto",
-                    "url": "https://mycrypto.com"
-                },
-                {
-                    "name": "MyEtherWallet",
-                    "url": "https://www.myetherwallet.com"
-                }
-            ]
-        },
-        "eth:EUN": {
-            "links": {
-                "Homepage": "https://eurus.network"
-            },
-            "marketcap_usd": 0,
-            "name": "Eurus",
-            "shortcut": "EUN",
             "t1_enabled": "yes",
             "t2_enabled": "yes",
             "type": "coin",
@@ -35079,27 +34416,6 @@
                 }
             ]
         },
-        "eth:EZC": {
-            "links": {
-                "Homepage": "https://ezchain.com"
-            },
-            "marketcap_usd": 0,
-            "name": "EZChain C-Chain",
-            "shortcut": "EZC",
-            "t1_enabled": "yes",
-            "t2_enabled": "yes",
-            "type": "coin",
-            "wallet": [
-                {
-                    "name": "MyCrypto",
-                    "url": "https://mycrypto.com"
-                },
-                {
-                    "name": "MyEtherWallet",
-                    "url": "https://www.myetherwallet.com"
-                }
-            ]
-        },
         "eth:FETH": {
             "links": {
                 "Homepage": "https://www.factory127.com"
@@ -35163,32 +34479,11 @@
                 }
             ]
         },
-        "eth:FRA": {
-            "links": {
-                "Homepage": "https://findora.org/"
-            },
-            "marketcap_usd": 0,
-            "name": "Findora",
-            "shortcut": "FRA",
-            "t1_enabled": "yes",
-            "t2_enabled": "yes",
-            "type": "coin",
-            "wallet": [
-                {
-                    "name": "MyCrypto",
-                    "url": "https://mycrypto.com"
-                },
-                {
-                    "name": "MyEtherWallet",
-                    "url": "https://www.myetherwallet.com"
-                }
-            ]
-        },
         "eth:FSN": {
             "links": {
                 "Homepage": "https://www.fusion.org/"
             },
-            "marketcap_usd": 17449663,
+            "marketcap_usd": 16622757,
             "name": "Fusion",
             "shortcut": "FSN",
             "t1_enabled": "yes",
@@ -35247,27 +34542,6 @@
                 }
             ]
         },
-        "eth:FX": {
-            "links": {
-                "Homepage": "https://functionx.io/"
-            },
-            "marketcap_usd": 0,
-            "name": "F(x)Core",
-            "shortcut": "FX",
-            "t1_enabled": "yes",
-            "t2_enabled": "yes",
-            "type": "coin",
-            "wallet": [
-                {
-                    "name": "MyCrypto",
-                    "url": "https://mycrypto.com"
-                },
-                {
-                    "name": "MyEtherWallet",
-                    "url": "https://www.myetherwallet.com"
-                }
-            ]
-        },
         "eth:GAR:90": {
             "links": {
                 "Homepage": "https://garizon.com"
@@ -35275,27 +34549,6 @@
             "marketcap_usd": 0,
             "name": "Garizon Stage0",
             "shortcut": "GAR",
-            "t1_enabled": "yes",
-            "t2_enabled": "yes",
-            "type": "coin",
-            "wallet": [
-                {
-                    "name": "MyCrypto",
-                    "url": "https://mycrypto.com"
-                },
-                {
-                    "name": "MyEtherWallet",
-                    "url": "https://www.myetherwallet.com"
-                }
-            ]
-        },
-        "eth:GCD": {
-            "links": {
-                "Homepage": "https://gton.capital"
-            },
-            "marketcap_usd": 0,
-            "name": "GTON",
-            "shortcut": "GCD",
             "t1_enabled": "yes",
             "t2_enabled": "yes",
             "type": "coin",
@@ -35335,7 +34588,7 @@
             "links": {
                 "Homepage": "https://moonbeam.network/networks/moonbeam/"
             },
-            "marketcap_usd": 222514714,
+            "marketcap_usd": 206213971,
             "name": "Moonbeam",
             "shortcut": "GLMR",
             "t1_enabled": "yes",
@@ -35377,7 +34630,7 @@
             "links": {
                 "Homepage": "https://gochain.io"
             },
-            "marketcap_usd": 11358330,
+            "marketcap_usd": 9195250,
             "name": "GoChain",
             "shortcut": "GO",
             "t1_enabled": "yes",
@@ -35478,27 +34731,6 @@
                 }
             ]
         },
-        "eth:HOO": {
-            "links": {
-                "Homepage": "https://www.hoosmartchain.com"
-            },
-            "marketcap_usd": 0,
-            "name": "Hoo Smart Chain",
-            "shortcut": "HOO",
-            "t1_enabled": "yes",
-            "t2_enabled": "yes",
-            "type": "coin",
-            "wallet": [
-                {
-                    "name": "MyCrypto",
-                    "url": "https://mycrypto.com"
-                },
-                {
-                    "name": "MyEtherWallet",
-                    "url": "https://www.myetherwallet.com"
-                }
-            ]
-        },
         "eth:HOP": {
             "links": {
                 "Homepage": "https://www.DataHopper.com"
@@ -35524,7 +34756,7 @@
             "links": {
                 "Homepage": "https://hpb.io"
             },
-            "marketcap_usd": 1400795,
+            "marketcap_usd": 1011760,
             "name": "High Performance Blockchain",
             "shortcut": "HPB",
             "t1_enabled": "yes",
@@ -35646,27 +34878,6 @@
                 }
             ]
         },
-        "eth:IVAR": {
-            "links": {
-                "Homepage": "https://ivarex.com"
-            },
-            "marketcap_usd": 0,
-            "name": "IVAR Chain",
-            "shortcut": "IVAR",
-            "t1_enabled": "yes",
-            "t2_enabled": "yes",
-            "type": "coin",
-            "wallet": [
-                {
-                    "name": "MyCrypto",
-                    "url": "https://mycrypto.com"
-                },
-                {
-                    "name": "MyEtherWallet",
-                    "url": "https://www.myetherwallet.com"
-                }
-            ]
-        },
         "eth:JEWEL:53935": {
             "links": {
                 "Homepage": "https://defikingdoms.com"
@@ -35730,27 +34941,6 @@
                 }
             ]
         },
-        "eth:KAVA": {
-            "links": {
-                "Homepage": "https://www.kava.io"
-            },
-            "marketcap_usd": 486846769,
-            "name": "Kava EVM",
-            "shortcut": "KAVA",
-            "t1_enabled": "yes",
-            "t2_enabled": "yes",
-            "type": "coin",
-            "wallet": [
-                {
-                    "name": "MyCrypto",
-                    "url": "https://mycrypto.com"
-                },
-                {
-                    "name": "MyEtherWallet",
-                    "url": "https://www.myetherwallet.com"
-                }
-            ]
-        },
         "eth:KCS": {
             "links": {
                 "Homepage": "https://kcc.io"
@@ -35776,30 +34966,9 @@
             "links": {
                 "Homepage": "https://www.klaytn.com/"
             },
-            "marketcap_usd": 862049881,
+            "marketcap_usd": 755790383,
             "name": "Klaytn",
             "shortcut": "KLAY",
-            "t1_enabled": "yes",
-            "t2_enabled": "yes",
-            "type": "coin",
-            "wallet": [
-                {
-                    "name": "MyCrypto",
-                    "url": "https://mycrypto.com"
-                },
-                {
-                    "name": "MyEtherWallet",
-                    "url": "https://www.myetherwallet.com"
-                }
-            ]
-        },
-        "eth:KSX": {
-            "links": {
-                "Homepage": "https://sherpax.io/"
-            },
-            "marketcap_usd": 0,
-            "name": "Sherpax",
-            "shortcut": "KSX",
             "t1_enabled": "yes",
             "t2_enabled": "yes",
             "type": "coin",
@@ -35898,53 +35067,11 @@
                 }
             ]
         },
-        "eth:LISINS": {
-            "links": {
-                "Homepage": "https://lisinski.online"
-            },
-            "marketcap_usd": 0,
-            "name": "Lisinski",
-            "shortcut": "LISINS",
-            "t1_enabled": "yes",
-            "t2_enabled": "yes",
-            "type": "coin",
-            "wallet": [
-                {
-                    "name": "MyCrypto",
-                    "url": "https://mycrypto.com"
-                },
-                {
-                    "name": "MyEtherWallet",
-                    "url": "https://www.myetherwallet.com"
-                }
-            ]
-        },
-        "eth:LUDAN": {
-            "links": {
-                "Homepage": "https://www.ludan.org/"
-            },
-            "marketcap_usd": 0,
-            "name": "LUDAN",
-            "shortcut": "LUDAN",
-            "t1_enabled": "yes",
-            "t2_enabled": "yes",
-            "type": "coin",
-            "wallet": [
-                {
-                    "name": "MyCrypto",
-                    "url": "https://mycrypto.com"
-                },
-                {
-                    "name": "MyEtherWallet",
-                    "url": "https://www.myetherwallet.com"
-                }
-            ]
-        },
         "eth:MATH": {
             "links": {
                 "Homepage": "https://mathchain.org"
             },
-            "marketcap_usd": 20217903,
+            "marketcap_usd": 10444592,
             "name": "MathChain",
             "shortcut": "MATH",
             "t1_enabled": "yes",
@@ -35965,7 +35092,7 @@
             "links": {
                 "Homepage": "https://polygon.technology/"
             },
-            "marketcap_usd": 6871256644,
+            "marketcap_usd": 8228741645,
             "name": "Polygon",
             "shortcut": "MATIC",
             "t1_enabled": "yes",
@@ -35986,7 +35113,7 @@
             "links": {
                 "Homepage": "https://metadium.com"
             },
-            "marketcap_usd": 71228929,
+            "marketcap_usd": 50995327,
             "name": "Metadium",
             "shortcut": "META",
             "t1_enabled": "yes",
@@ -36066,27 +35193,6 @@
                 }
             ]
         },
-        "eth:MMT": {
-            "links": {
-                "Homepage": "https://mmtchain.io/"
-            },
-            "marketcap_usd": 0,
-            "name": "Mammoth",
-            "shortcut": "MMT",
-            "t1_enabled": "yes",
-            "t2_enabled": "yes",
-            "type": "coin",
-            "wallet": [
-                {
-                    "name": "MyCrypto",
-                    "url": "https://mycrypto.com"
-                },
-                {
-                    "name": "MyEtherWallet",
-                    "url": "https://www.myetherwallet.com"
-                }
-            ]
-        },
         "eth:MOLE": {
             "links": {
                 "Homepage": "https://github.com/Jdubedition/molereum"
@@ -36112,7 +35218,7 @@
             "links": {
                 "Homepage": "https://moonbeam.network/networks/moonriver/"
             },
-            "marketcap_usd": 71197718,
+            "marketcap_usd": 62749326,
             "name": "Moonriver",
             "shortcut": "MOVR",
             "t1_enabled": "yes",
@@ -36171,27 +35277,6 @@
                 }
             ]
         },
-        "eth:MTV": {
-            "links": {
-                "Homepage": "https://mtv.ac"
-            },
-            "marketcap_usd": 4401735,
-            "name": "MultiVAC",
-            "shortcut": "MTV",
-            "t1_enabled": "yes",
-            "t2_enabled": "yes",
-            "type": "coin",
-            "wallet": [
-                {
-                    "name": "MyCrypto",
-                    "url": "https://mycrypto.com"
-                },
-                {
-                    "name": "MyEtherWallet",
-                    "url": "https://www.myetherwallet.com"
-                }
-            ]
-        },
         "eth:MUSIC": {
             "links": {
                 "Homepage": "https://musicoin.tw"
@@ -36215,7 +35300,7 @@
         },
         "eth:NEON:245022934": {
             "links": {
-                "Homepage": "https://neon-labs.org"
+                "Homepage": "https://neon-labs.org/"
             },
             "marketcap_usd": 0,
             "name": "Neon EVM",
@@ -36238,7 +35323,7 @@
             "links": {
                 "Homepage": "https://www.newtonproject.org/"
             },
-            "marketcap_usd": 5973693,
+            "marketcap_usd": 4632493,
             "name": "Newton",
             "shortcut": "NEW",
             "t1_enabled": "yes",
@@ -36280,7 +35365,7 @@
             "links": {
                 "Homepage": "https://www.energi.world/"
             },
-            "marketcap_usd": 24570145,
+            "marketcap_usd": 9495758,
             "name": "Energi",
             "shortcut": "NRG",
             "t1_enabled": "yes",
@@ -36318,30 +35403,9 @@
                 }
             ]
         },
-        "eth:OAC": {
-            "links": {
-                "Homepage": "https://scan.oasischain.io"
-            },
-            "marketcap_usd": 0,
-            "name": "OasisChain",
-            "shortcut": "OAC",
-            "t1_enabled": "yes",
-            "t2_enabled": "yes",
-            "type": "coin",
-            "wallet": [
-                {
-                    "name": "MyCrypto",
-                    "url": "https://mycrypto.com"
-                },
-                {
-                    "name": "MyEtherWallet",
-                    "url": "https://www.myetherwallet.com"
-                }
-            ]
-        },
         "eth:OKT": {
             "links": {
-                "Homepage": "https://www.okex.com/okc"
+                "Homepage": "https://www.okex.com/okexchain"
             },
             "marketcap_usd": 0,
             "name": "OKXChain",
@@ -36385,51 +35449,9 @@
             "links": {
                 "Homepage": "https://oneledger.io"
             },
-            "marketcap_usd": 3759517,
+            "marketcap_usd": 2935786,
             "name": "OneLedger",
             "shortcut": "OLT",
-            "t1_enabled": "yes",
-            "t2_enabled": "yes",
-            "type": "coin",
-            "wallet": [
-                {
-                    "name": "MyCrypto",
-                    "url": "https://mycrypto.com"
-                },
-                {
-                    "name": "MyEtherWallet",
-                    "url": "https://www.myetherwallet.com"
-                }
-            ]
-        },
-        "eth:OM": {
-            "links": {
-                "Homepage": "https://omplatform.com/"
-            },
-            "marketcap_usd": 0,
-            "name": "OM Chain",
-            "shortcut": "OM",
-            "t1_enabled": "yes",
-            "t2_enabled": "yes",
-            "type": "coin",
-            "wallet": [
-                {
-                    "name": "MyCrypto",
-                    "url": "https://mycrypto.com"
-                },
-                {
-                    "name": "MyEtherWallet",
-                    "url": "https://www.myetherwallet.com"
-                }
-            ]
-        },
-        "eth:OMC": {
-            "links": {
-                "Homepage": "https://omchain.io"
-            },
-            "marketcap_usd": 0,
-            "name": "omChain",
-            "shortcut": "OMC",
             "t1_enabled": "yes",
             "t2_enabled": "yes",
             "type": "coin",
@@ -36448,7 +35470,7 @@
             "links": {
                 "Homepage": "https://www.harmony.one/"
             },
-            "marketcap_usd": 268076721,
+            "marketcap_usd": 233127060,
             "name": "Harmony",
             "shortcut": "ONE",
             "t1_enabled": "yes",
@@ -36469,7 +35491,7 @@
             "links": {
                 "Homepage": "https://www.harmony.one/"
             },
-            "marketcap_usd": 268076721,
+            "marketcap_usd": 233127060,
             "name": "Harmony",
             "shortcut": "ONE",
             "t1_enabled": "yes",
@@ -36490,7 +35512,7 @@
             "links": {
                 "Homepage": "https://www.harmony.one/"
             },
-            "marketcap_usd": 268076721,
+            "marketcap_usd": 233127060,
             "name": "Harmony",
             "shortcut": "ONE",
             "t1_enabled": "yes",
@@ -36511,7 +35533,7 @@
             "links": {
                 "Homepage": "https://www.harmony.one/"
             },
-            "marketcap_usd": 268076721,
+            "marketcap_usd": 233127060,
             "name": "Harmony",
             "shortcut": "ONE",
             "t1_enabled": "yes",
@@ -36532,30 +35554,9 @@
             "links": {
                 "Homepage": "https://ont.io/"
             },
-            "marketcap_usd": 230463857,
+            "marketcap_usd": 197803257,
             "name": "Ontology",
             "shortcut": "ONG",
-            "t1_enabled": "yes",
-            "t2_enabled": "yes",
-            "type": "coin",
-            "wallet": [
-                {
-                    "name": "MyCrypto",
-                    "url": "https://mycrypto.com"
-                },
-                {
-                    "name": "MyEtherWallet",
-                    "url": "https://www.myetherwallet.com"
-                }
-            ]
-        },
-        "eth:OPC": {
-            "links": {
-                "Homepage": "https://www.openchain.live"
-            },
-            "marketcap_usd": 0,
-            "name": "OpenChain",
-            "shortcut": "OPC",
             "t1_enabled": "yes",
             "t2_enabled": "yes",
             "type": "coin",
@@ -36633,32 +35634,11 @@
                 }
             ]
         },
-        "eth:PFT:909": {
-            "links": {
-                "Homepage": "https://portalfantasy.io"
-            },
-            "marketcap_usd": 0,
-            "name": "Portal Fantasy Chain",
-            "shortcut": "PFT",
-            "t1_enabled": "yes",
-            "t2_enabled": "yes",
-            "type": "coin",
-            "wallet": [
-                {
-                    "name": "MyCrypto",
-                    "url": "https://mycrypto.com"
-                },
-                {
-                    "name": "MyEtherWallet",
-                    "url": "https://www.myetherwallet.com"
-                }
-            ]
-        },
         "eth:PHT": {
             "links": {
                 "Homepage": "https://explorer.lightstreams.io"
             },
-            "marketcap_usd": 206692,
+            "marketcap_usd": 129249,
             "name": "Lightstreams",
             "shortcut": "PHT",
             "t1_enabled": "yes",
@@ -36763,7 +35743,7 @@
             "links": {
                 "Homepage": "https://poa.network"
             },
-            "marketcap_usd": 6008406,
+            "marketcap_usd": 5019756,
             "name": "POA Network Core",
             "shortcut": "POA",
             "t1_enabled": "yes",
@@ -36784,7 +35764,7 @@
             "links": {
                 "Homepage": "https://polis.tech"
             },
-            "marketcap_usd": 359044,
+            "marketcap_usd": 144501,
             "name": "Polis",
             "shortcut": "POLIS",
             "t1_enabled": "yes",
@@ -36843,32 +35823,11 @@
                 }
             ]
         },
-        "eth:QDC": {
-            "links": {
-                "Homepage": "https://quadrans.io"
-            },
-            "marketcap_usd": 0,
-            "name": "Quadrans Blockchain",
-            "shortcut": "QDC",
-            "t1_enabled": "yes",
-            "t2_enabled": "yes",
-            "type": "coin",
-            "wallet": [
-                {
-                    "name": "MyCrypto",
-                    "url": "https://mycrypto.com"
-                },
-                {
-                    "name": "MyEtherWallet",
-                    "url": "https://www.myetherwallet.com"
-                }
-            ]
-        },
         "eth:QKC:100000": {
             "links": {
-                "Homepage": "https://www.quarkchain.io"
+                "Homepage": "https://www.quarkchain.io/"
             },
-            "marketcap_usd": 72187447,
+            "marketcap_usd": 93261183,
             "name": "QuarkChain",
             "shortcut": "QKC",
             "t1_enabled": "yes",
@@ -36887,9 +35846,9 @@
         },
         "eth:QKC:100001": {
             "links": {
-                "Homepage": "https://www.quarkchain.io"
+                "Homepage": "https://www.quarkchain.io/"
             },
-            "marketcap_usd": 72187447,
+            "marketcap_usd": 93261183,
             "name": "QuarkChain",
             "shortcut": "QKC",
             "t1_enabled": "yes",
@@ -36908,9 +35867,9 @@
         },
         "eth:QKC:100002": {
             "links": {
-                "Homepage": "https://www.quarkchain.io"
+                "Homepage": "https://www.quarkchain.io/"
             },
-            "marketcap_usd": 72187447,
+            "marketcap_usd": 93261183,
             "name": "QuarkChain",
             "shortcut": "QKC",
             "t1_enabled": "yes",
@@ -36929,9 +35888,9 @@
         },
         "eth:QKC:100003": {
             "links": {
-                "Homepage": "https://www.quarkchain.io"
+                "Homepage": "https://www.quarkchain.io/"
             },
-            "marketcap_usd": 72187447,
+            "marketcap_usd": 93261183,
             "name": "QuarkChain",
             "shortcut": "QKC",
             "t1_enabled": "yes",
@@ -36950,9 +35909,9 @@
         },
         "eth:QKC:100004": {
             "links": {
-                "Homepage": "https://www.quarkchain.io"
+                "Homepage": "https://www.quarkchain.io/"
             },
-            "marketcap_usd": 72187447,
+            "marketcap_usd": 93261183,
             "name": "QuarkChain",
             "shortcut": "QKC",
             "t1_enabled": "yes",
@@ -36971,9 +35930,9 @@
         },
         "eth:QKC:100005": {
             "links": {
-                "Homepage": "https://www.quarkchain.io"
+                "Homepage": "https://www.quarkchain.io/"
             },
-            "marketcap_usd": 72187447,
+            "marketcap_usd": 93261183,
             "name": "QuarkChain",
             "shortcut": "QKC",
             "t1_enabled": "yes",
@@ -36992,9 +35951,9 @@
         },
         "eth:QKC:100006": {
             "links": {
-                "Homepage": "https://www.quarkchain.io"
+                "Homepage": "https://www.quarkchain.io/"
             },
-            "marketcap_usd": 72187447,
+            "marketcap_usd": 93261183,
             "name": "QuarkChain",
             "shortcut": "QKC",
             "t1_enabled": "yes",
@@ -37013,9 +35972,9 @@
         },
         "eth:QKC:100007": {
             "links": {
-                "Homepage": "https://www.quarkchain.io"
+                "Homepage": "https://www.quarkchain.io/"
             },
-            "marketcap_usd": 72187447,
+            "marketcap_usd": 93261183,
             "name": "QuarkChain",
             "shortcut": "QKC",
             "t1_enabled": "yes",
@@ -37034,9 +35993,9 @@
         },
         "eth:QKC:100008": {
             "links": {
-                "Homepage": "https://www.quarkchain.io"
+                "Homepage": "https://www.quarkchain.io/"
             },
-            "marketcap_usd": 72187447,
+            "marketcap_usd": 93261183,
             "name": "QuarkChain",
             "shortcut": "QKC",
             "t1_enabled": "yes",
@@ -37120,30 +36079,9 @@
             "links": {
                 "Homepage": "https://rei.network/"
             },
-            "marketcap_usd": 40315608,
+            "marketcap_usd": 30177894,
             "name": "REI Network",
             "shortcut": "REI",
-            "t1_enabled": "yes",
-            "t2_enabled": "yes",
-            "type": "coin",
-            "wallet": [
-                {
-                    "name": "MyCrypto",
-                    "url": "https://mycrypto.com"
-                },
-                {
-                    "name": "MyEtherWallet",
-                    "url": "https://www.myetherwallet.com"
-                }
-            ]
-        },
-        "eth:RING": {
-            "links": {
-                "Homepage": "https://darwinia.network/"
-            },
-            "marketcap_usd": 4488462,
-            "name": "Darwinia Network",
-            "shortcut": "RING",
             "t1_enabled": "yes",
             "t2_enabled": "yes",
             "type": "coin",
@@ -37165,27 +36103,6 @@
             "marketcap_usd": 0,
             "name": "GeneChain",
             "shortcut": "RNA",
-            "t1_enabled": "yes",
-            "t2_enabled": "yes",
-            "type": "coin",
-            "wallet": [
-                {
-                    "name": "MyCrypto",
-                    "url": "https://mycrypto.com"
-                },
-                {
-                    "name": "MyEtherWallet",
-                    "url": "https://www.myetherwallet.com"
-                }
-            ]
-        },
-        "eth:ROC:1288": {
-            "links": {
-                "Homepage": "https://docs.moonbeam.network/learn/platform/networks/overview/"
-            },
-            "marketcap_usd": 0,
-            "name": "Moonrock",
-            "shortcut": "ROC",
             "t1_enabled": "yes",
             "t2_enabled": "yes",
             "type": "coin",
@@ -37225,7 +36142,7 @@
             "links": {
                 "Homepage": "https://rangersprotocol.com"
             },
-            "marketcap_usd": 1824951,
+            "marketcap_usd": 1442598,
             "name": "Rangers Protocol",
             "shortcut": "RPG",
             "t1_enabled": "yes",
@@ -37305,27 +36222,6 @@
                 }
             ]
         },
-        "eth:SFL": {
-            "links": {
-                "Homepage": "https://hupayx.io"
-            },
-            "marketcap_usd": 0,
-            "name": "Taycan",
-            "shortcut": "SFL",
-            "t1_enabled": "yes",
-            "t2_enabled": "yes",
-            "type": "coin",
-            "wallet": [
-                {
-                    "name": "MyCrypto",
-                    "url": "https://mycrypto.com"
-                },
-                {
-                    "name": "MyEtherWallet",
-                    "url": "https://www.myetherwallet.com"
-                }
-            ]
-        },
         "eth:SGB": {
             "links": {
                 "Homepage": "https://flare.xyz"
@@ -37372,30 +36268,9 @@
             "links": {
                 "Homepage": "https://clover.finance/sakura"
             },
-            "marketcap_usd": 1307156,
+            "marketcap_usd": 1023560,
             "name": "Sakura",
             "shortcut": "SKU",
-            "t1_enabled": "yes",
-            "t2_enabled": "yes",
-            "type": "coin",
-            "wallet": [
-                {
-                    "name": "MyCrypto",
-                    "url": "https://mycrypto.com"
-                },
-                {
-                    "name": "MyEtherWallet",
-                    "url": "https://www.myetherwallet.com"
-                }
-            ]
-        },
-        "eth:SMT": {
-            "links": {
-                "Homepage": "https://smartmesh.io"
-            },
-            "marketcap_usd": 2556470,
-            "name": "SmartMesh",
-            "shortcut": "SMT",
             "t1_enabled": "yes",
             "t2_enabled": "yes",
             "type": "coin",
@@ -37417,27 +36292,6 @@
             "marketcap_usd": 0,
             "name": "Nova Network",
             "shortcut": "SNT",
-            "t1_enabled": "yes",
-            "t2_enabled": "yes",
-            "type": "coin",
-            "wallet": [
-                {
-                    "name": "MyCrypto",
-                    "url": "https://mycrypto.com"
-                },
-                {
-                    "name": "MyEtherWallet",
-                    "url": "https://www.myetherwallet.com"
-                }
-            ]
-        },
-        "eth:SOTER:68": {
-            "links": {
-                "Homepage": "https://www.soterone.com"
-            },
-            "marketcap_usd": 0,
-            "name": "SoterOne",
-            "shortcut": "SOTER",
             "t1_enabled": "yes",
             "t2_enabled": "yes",
             "type": "coin",
@@ -37515,32 +36369,11 @@
                 }
             ]
         },
-        "eth:SX": {
-            "links": {
-                "Homepage": "https://www.sx.technology"
-            },
-            "marketcap_usd": 0,
-            "name": "SX Network",
-            "shortcut": "SX",
-            "t1_enabled": "yes",
-            "t2_enabled": "yes",
-            "type": "coin",
-            "wallet": [
-                {
-                    "name": "MyCrypto",
-                    "url": "https://mycrypto.com"
-                },
-                {
-                    "name": "MyEtherWallet",
-                    "url": "https://www.myetherwallet.com"
-                }
-            ]
-        },
         "eth:Seele": {
             "links": {
                 "Homepage": "https://seelen.pro/"
             },
-            "marketcap_usd": 6284505,
+            "marketcap_usd": 3221306,
             "name": "Seele",
             "shortcut": "Seele",
             "t1_enabled": "yes",
@@ -37662,27 +36495,6 @@
                 }
             ]
         },
-        "eth:TLC": {
-            "links": {
-                "Homepage": "https://tlchain.network/"
-            },
-            "marketcap_usd": 0,
-            "name": "TLChain Network",
-            "shortcut": "TLC",
-            "t1_enabled": "yes",
-            "t2_enabled": "yes",
-            "type": "coin",
-            "wallet": [
-                {
-                    "name": "MyCrypto",
-                    "url": "https://mycrypto.com"
-                },
-                {
-                    "name": "MyEtherWallet",
-                    "url": "https://www.myetherwallet.com"
-                }
-            ]
-        },
         "eth:TLOS:40": {
             "links": {
                 "Homepage": "https://telos.net"
@@ -37704,32 +36516,11 @@
                 }
             ]
         },
-        "eth:TOMB": {
-            "links": {
-                "Homepage": "https://tombchain.com/"
-            },
-            "marketcap_usd": 0,
-            "name": "Tomb Chain",
-            "shortcut": "TOMB",
-            "t1_enabled": "yes",
-            "t2_enabled": "yes",
-            "type": "coin",
-            "wallet": [
-                {
-                    "name": "MyCrypto",
-                    "url": "https://mycrypto.com"
-                },
-                {
-                    "name": "MyEtherWallet",
-                    "url": "https://www.myetherwallet.com"
-                }
-            ]
-        },
         "eth:TOMO:88": {
             "links": {
                 "Homepage": "https://tomochain.com"
             },
-            "marketcap_usd": 52151865,
+            "marketcap_usd": 40252619,
             "name": "TomoChain",
             "shortcut": "TOMO",
             "t1_enabled": "yes",
@@ -37753,27 +36544,6 @@
             "marketcap_usd": 0,
             "name": "Joys Digital TestNet",
             "shortcut": "TOYS",
-            "t1_enabled": "yes",
-            "t2_enabled": "yes",
-            "type": "coin",
-            "wallet": [
-                {
-                    "name": "MyCrypto",
-                    "url": "https://mycrypto.com"
-                },
-                {
-                    "name": "MyEtherWallet",
-                    "url": "https://www.myetherwallet.com"
-                }
-            ]
-        },
-        "eth:TPC": {
-            "links": {
-                "Homepage": "https://techpay.io/"
-            },
-            "marketcap_usd": 0,
-            "name": "TechPay",
-            "shortcut": "TPC",
             "t1_enabled": "yes",
             "t2_enabled": "yes",
             "type": "coin",
@@ -37834,30 +36604,9 @@
             "links": {
                 "Homepage": "https://thundercore.com"
             },
-            "marketcap_usd": 54386509,
+            "marketcap_usd": 46116376,
             "name": "ThunderCore",
             "shortcut": "TT",
-            "t1_enabled": "yes",
-            "t2_enabled": "yes",
-            "type": "coin",
-            "wallet": [
-                {
-                    "name": "MyCrypto",
-                    "url": "https://mycrypto.com"
-                },
-                {
-                    "name": "MyEtherWallet",
-                    "url": "https://www.myetherwallet.com"
-                }
-            ]
-        },
-        "eth:TXL": {
-            "links": {
-                "Homepage": "https://autobahn.network"
-            },
-            "marketcap_usd": 0,
-            "name": "Autobahn Network",
-            "shortcut": "TXL",
             "t1_enabled": "yes",
             "t2_enabled": "yes",
             "type": "coin",
@@ -37918,7 +36667,7 @@
             "links": {
                 "Homepage": "https://ubiqsmart.com"
             },
-            "marketcap_usd": 1636533,
+            "marketcap_usd": 1816802,
             "name": "Ubiq",
             "shortcut": "UBQ",
             "t1_enabled": "yes",
@@ -37984,27 +36733,6 @@
             "marketcap_usd": 0,
             "name": "Velas EVM",
             "shortcut": "VLX",
-            "t1_enabled": "yes",
-            "t2_enabled": "yes",
-            "type": "coin",
-            "wallet": [
-                {
-                    "name": "MyCrypto",
-                    "url": "https://mycrypto.com"
-                },
-                {
-                    "name": "MyEtherWallet",
-                    "url": "https://www.myetherwallet.com"
-                }
-            ]
-        },
-        "eth:VNDT": {
-            "links": {
-                "Homepage": "https://bo.vcex.xyz/"
-            },
-            "marketcap_usd": 0,
-            "name": "VChain",
-            "shortcut": "VNDT",
             "t1_enabled": "yes",
             "t2_enabled": "yes",
             "type": "coin",
@@ -38086,7 +36814,7 @@
             "links": {
                 "Homepage": "https://www.wanscan.org"
             },
-            "marketcap_usd": 45365590,
+            "marketcap_usd": 36051075,
             "name": "Wanchain",
             "shortcut": "WAN",
             "t1_enabled": "yes",
@@ -38208,90 +36936,6 @@
                 }
             ]
         },
-        "eth:XIN": {
-            "links": {
-                "Homepage": "https://mvm.dev"
-            },
-            "marketcap_usd": 0,
-            "name": "Mixin Virtual Machine",
-            "shortcut": "XIN",
-            "t1_enabled": "yes",
-            "t2_enabled": "yes",
-            "type": "coin",
-            "wallet": [
-                {
-                    "name": "MyCrypto",
-                    "url": "https://mycrypto.com"
-                },
-                {
-                    "name": "MyEtherWallet",
-                    "url": "https://www.myetherwallet.com"
-                }
-            ]
-        },
-        "eth:XT": {
-            "links": {
-                "Homepage": "https://xsc.pub/"
-            },
-            "marketcap_usd": 0,
-            "name": "XT Smart Chain",
-            "shortcut": "XT",
-            "t1_enabled": "yes",
-            "t2_enabled": "yes",
-            "type": "coin",
-            "wallet": [
-                {
-                    "name": "MyCrypto",
-                    "url": "https://mycrypto.com"
-                },
-                {
-                    "name": "MyEtherWallet",
-                    "url": "https://www.myetherwallet.com"
-                }
-            ]
-        },
-        "eth:XVM": {
-            "links": {
-                "Homepage": "https://venidium.io"
-            },
-            "marketcap_usd": 0,
-            "name": "Venidium",
-            "shortcut": "XVM",
-            "t1_enabled": "yes",
-            "t2_enabled": "yes",
-            "type": "coin",
-            "wallet": [
-                {
-                    "name": "MyCrypto",
-                    "url": "https://mycrypto.com"
-                },
-                {
-                    "name": "MyEtherWallet",
-                    "url": "https://www.myetherwallet.com"
-                }
-            ]
-        },
-        "eth:YCC": {
-            "links": {
-                "Homepage": "https://www.yuan.org"
-            },
-            "marketcap_usd": 0,
-            "name": "YuanChain",
-            "shortcut": "YCC",
-            "t1_enabled": "yes",
-            "t2_enabled": "yes",
-            "type": "coin",
-            "wallet": [
-                {
-                    "name": "MyCrypto",
-                    "url": "https://mycrypto.com"
-                },
-                {
-                    "name": "MyEtherWallet",
-                    "url": "https://www.myetherwallet.com"
-                }
-            ]
-        },
         "eth:YETI": {
             "links": {
                 "Homepage": "https://nepalblockchain.network"
@@ -38313,32 +36957,11 @@
                 }
             ]
         },
-        "eth:ZENITH": {
-            "links": {
-                "Homepage": "https://www.zenithchain.co/"
-            },
-            "marketcap_usd": 0,
-            "name": "Zenith",
-            "shortcut": "ZENITH",
-            "t1_enabled": "yes",
-            "t2_enabled": "yes",
-            "type": "coin",
-            "wallet": [
-                {
-                    "name": "MyCrypto",
-                    "url": "https://mycrypto.com"
-                },
-                {
-                    "name": "MyEtherWallet",
-                    "url": "https://www.myetherwallet.com"
-                }
-            ]
-        },
         "eth:ZERO": {
             "links": {
                 "Homepage": "https://www.singularity.gold"
             },
-            "marketcap_usd": 85348,
+            "marketcap_usd": 107383,
             "name": "Singularity ZERO",
             "shortcut": "ZERO",
             "t1_enabled": "yes",
@@ -38439,76 +37062,13 @@
                 }
             ]
         },
-        "eth:jfin": {
-            "links": {
-                "Homepage": "https://jfinchain.com"
-            },
-            "marketcap_usd": 0,
-            "name": "JFIN Chain",
-            "shortcut": "jfin",
-            "t1_enabled": "yes",
-            "t2_enabled": "yes",
-            "type": "coin",
-            "wallet": [
-                {
-                    "name": "MyCrypto",
-                    "url": "https://mycrypto.com"
-                },
-                {
-                    "name": "MyEtherWallet",
-                    "url": "https://www.myetherwallet.com"
-                }
-            ]
-        },
         "eth:lat": {
             "links": {
                 "Homepage": "https://www.platon.network"
             },
-            "marketcap_usd": 37149107,
+            "marketcap_usd": 20947381,
             "name": "PlatON",
             "shortcut": "lat",
-            "t1_enabled": "yes",
-            "t2_enabled": "yes",
-            "type": "coin",
-            "wallet": [
-                {
-                    "name": "MyCrypto",
-                    "url": "https://mycrypto.com"
-                },
-                {
-                    "name": "MyEtherWallet",
-                    "url": "https://www.myetherwallet.com"
-                }
-            ]
-        },
-        "eth:mADA": {
-            "links": {
-                "Homepage": "https://milkomeda.com"
-            },
-            "marketcap_usd": 0,
-            "name": "Milkomeda C1",
-            "shortcut": "mADA",
-            "t1_enabled": "yes",
-            "t2_enabled": "yes",
-            "type": "coin",
-            "wallet": [
-                {
-                    "name": "MyCrypto",
-                    "url": "https://mycrypto.com"
-                },
-                {
-                    "name": "MyEtherWallet",
-                    "url": "https://www.myetherwallet.com"
-                }
-            ]
-        },
-        "eth:pCKB": {
-            "links": {
-                "Homepage": "https://www.nervos.org"
-            },
-            "marketcap_usd": 0,
-            "name": "Godwoken",
-            "shortcut": "pCKB",
             "t1_enabled": "yes",
             "t2_enabled": "yes",
             "type": "coin",
@@ -38530,27 +37090,6 @@
             "marketcap_usd": 0,
             "name": "pegglecoin",
             "shortcut": "peggle",
-            "t1_enabled": "yes",
-            "t2_enabled": "yes",
-            "type": "coin",
-            "wallet": [
-                {
-                    "name": "MyCrypto",
-                    "url": "https://mycrypto.com"
-                },
-                {
-                    "name": "MyEtherWallet",
-                    "url": "https://www.myetherwallet.com"
-                }
-            ]
-        },
-        "eth:tGOR": {
-            "links": {
-                "Homepage": "https://goerli.net/#about"
-            },
-            "marketcap_usd": 0,
-            "name": "G\u00f6rli",
-            "shortcut": "tGOR",
             "t1_enabled": "yes",
             "t2_enabled": "yes",
             "type": "coin",
@@ -38689,74 +37228,11 @@
         },
         "eth:xDAI:100": {
             "links": {
-                "Homepage": "https://developers.gnosischain.com"
+                "Homepage": "https://www.xdaichain.com/"
             },
-            "marketcap_usd": 34301274,
-            "name": "Gnosis Chain",
+            "marketcap_usd": 11516082,
+            "name": "Gnosis Chain (formerly xDai)",
             "shortcut": "xDAI",
-            "t1_enabled": "yes",
-            "t2_enabled": "yes",
-            "type": "coin",
-            "wallet": [
-                {
-                    "name": "MyCrypto",
-                    "url": "https://mycrypto.com"
-                },
-                {
-                    "name": "MyEtherWallet",
-                    "url": "https://www.myetherwallet.com"
-                }
-            ]
-        },
-        "eth:xDAI:300": {
-            "links": {
-                "Homepage": "https://www.xdaichain.com/for-developers/optimism-optimistic-rollups-on-gc"
-            },
-            "marketcap_usd": 34301274,
-            "name": "Optimism on Gnosis Chain",
-            "shortcut": "xDAI",
-            "t1_enabled": "yes",
-            "t2_enabled": "yes",
-            "type": "coin",
-            "wallet": [
-                {
-                    "name": "MyCrypto",
-                    "url": "https://mycrypto.com"
-                },
-                {
-                    "name": "MyEtherWallet",
-                    "url": "https://www.myetherwallet.com"
-                }
-            ]
-        },
-        "eth:\u03a6": {
-            "links": {
-                "Homepage": "https://phi.network"
-            },
-            "marketcap_usd": 0,
-            "name": "PHI Network",
-            "shortcut": "\u03a6",
-            "t1_enabled": "yes",
-            "t2_enabled": "yes",
-            "type": "coin",
-            "wallet": [
-                {
-                    "name": "MyCrypto",
-                    "url": "https://mycrypto.com"
-                },
-                {
-                    "name": "MyEtherWallet",
-                    "url": "https://www.myetherwallet.com"
-                }
-            ]
-        },
-        "eth:\u25c8": {
-            "links": {
-                "Homepage": "https://crystaleum.org"
-            },
-            "marketcap_usd": 0,
-            "name": "Crystaleum",
-            "shortcut": "\u25c8",
             "t1_enabled": "yes",
             "t2_enabled": "yes",
             "type": "coin",
@@ -38776,7 +37252,7 @@
                 "Github": "https://github.com/input-output-hk/cardano-node",
                 "Homepage": "https://www.cardano.org"
             },
-            "marketcap_usd": 16691439800,
+            "marketcap_usd": 13979853593,
             "name": "Cardano",
             "shortcut": "ADA",
             "t1_enabled": "no",
@@ -38793,7 +37269,7 @@
             "links": {
                 "Homepage": "https://binance.org"
             },
-            "marketcap_usd": 44690398276,
+            "marketcap_usd": 46304453916,
             "name": "Binance Chain",
             "shortcut": "BNB",
             "t1_enabled": "no",
@@ -38811,7 +37287,7 @@
                 "Github": "https://github.com/EOSIO/eos",
                 "Homepage": "https://eos.io"
             },
-            "marketcap_usd": 1164397047,
+            "marketcap_usd": 1141746296,
             "name": "EOS",
             "shortcut": "EOS",
             "t1_enabled": "no",
@@ -38829,7 +37305,7 @@
                 "Github": "https://github.com/maidsafe",
                 "Homepage": "https://maidsafe.net"
             },
-            "marketcap_usd": 135295506,
+            "marketcap_usd": 61692086,
             "name": "MaidSafeCoin",
             "shortcut": "MAID",
             "t1_enabled": "yes",
@@ -38842,7 +37318,7 @@
                 "Github": "https://github.com/OmniLayer",
                 "Homepage": "https://www.omnilayer.org"
             },
-            "marketcap_usd": 1126092,
+            "marketcap_usd": 1015710,
             "name": "Omni",
             "shortcut": "OMNI",
             "t1_enabled": "yes",
@@ -38854,7 +37330,7 @@
             "links": {
                 "Homepage": "https://tether.to"
             },
-            "marketcap_usd": 66323337069,
+            "marketcap_usd": 68523909342,
             "name": "Tether",
             "shortcut": "USDT",
             "t1_enabled": "yes",
@@ -38867,7 +37343,7 @@
                 "Github": "https://github.com/stellar/stellar-core",
                 "Homepage": "https://www.stellar.org"
             },
-            "marketcap_usd": 2872329195,
+            "marketcap_usd": 2915219544,
             "name": "Stellar",
             "shortcut": "XLM",
             "t1_enabled": "yes",
@@ -38893,7 +37369,7 @@
                 "Github": "https://github.com/monero-project/monero",
                 "Homepage": "https://getmonero.org"
             },
-            "marketcap_usd": 2867147174,
+            "marketcap_usd": 2687324744,
             "name": "Monero",
             "shortcut": "XMR",
             "t1_enabled": "no",
@@ -38911,7 +37387,7 @@
                 "Github": "https://github.com/ripple/rippled",
                 "Homepage": "https://ripple.com"
             },
-            "marketcap_usd": 17840748825,
+            "marketcap_usd": 23735131456,
             "name": "Ripple",
             "shortcut": "XRP",
             "t1_enabled": "no",
@@ -38933,7 +37409,7 @@
                 "Github": "https://github.com/tezos/tezos",
                 "Homepage": "https://tezos.com"
             },
-            "marketcap_usd": 1529816930,
+            "marketcap_usd": 1336765477,
             "name": "Tezos",
             "shortcut": "XTZ",
             "t1_enabled": "no",
@@ -38941,8 +37417,8 @@
             "type": "coin",
             "wallet": [
                 {
-                    "name": "SimpleStaking",
-                    "url": "https://simplestaking.com"
+                    "name": "Briskett",
+                    "url": "https://briskett.app"
                 }
             ]
         },
@@ -39036,7 +37512,7 @@
             "links": {
                 "Homepage": "https://nemplatform.com"
             },
-            "marketcap_usd": 434936910,
+            "marketcap_usd": 358702032,
             "name": "NEM",
             "shortcut": "XEM",
             "t1_enabled": "yes",
@@ -39051,12 +37527,12 @@
         }
     },
     "info": {
-        "marketcap_supported": "107.08 %",
-        "marketcap_usd": 1121654537156,
-        "t1_coins": 1967,
-        "t2_coins": 1973,
-        "total_marketcap_usd": 1047500554957,
-        "updated_at": 1659434933,
-        "updated_at_readable": "Tue Aug  2 12:08:53 2022"
+        "marketcap_supported": "107.62 %",
+        "marketcap_usd": 1081571024599,
+        "t1_coins": 1894,
+        "t2_coins": 1900,
+        "total_marketcap_usd": 1004956748685,
+        "updated_at": 1666876726,
+        "updated_at_readable": "Thu Oct 27 15:18:46 2022"
     }
 }

--- a/common/defs/misc/misc.json
+++ b/common/defs/misc/misc.json
@@ -111,7 +111,7 @@
             "Github": "https://github.com/tezos/tezos"
         },
         "wallet": {
-            "SimpleStaking": "https://simplestaking.com"
+            "Briskett": "https://briskett.app"
         }
     },
     {


### PR DESCRIPTION
SimpleStaking is no longer the recommended Wallet for Tezos, Briskett is.

Update `misc.json` with the above, and re-generated `coin_details.json`