### PR TITLE
Add CoinJoin request public key

### DIFF
--- a/core/src/apps/bitcoin/sign_tx/approvers.py
+++ b/core/src/apps/bitcoin/sign_tx/approvers.py
@@ -346,7 +346,7 @@ class CoinJoinApprover(Approver):
     COINJOIN_FLAGS_SIGNABLE = const(0x01)
     COINJOIN_FLAGS_NO_FEE = const(0x02)
 
-    COINJOIN_REQ_PUBKEY = b""
+    COINJOIN_REQ_PUBKEY = b"\x02W\x03\xbb\xe1[\xb0\x8e\x98!\xfed\xaf\xf6\xb2\xef\x1a1`\xe3y\x9d\xd8\xf0\xce\xbf,y\xe8g\xdd\x12]"
     if __debug__:
         # secp256k1 public key of m/0h for "all all ... all" seed.
         COINJOIN_REQ_PUBKEY_DEBUG = b"\x03\x0f\xdf^(\x9bZ\xefSb\x90\x95:\xe8\x1c\xe6\x0e\x84\x1f\xf9V\xf3f\xac\x12?\xa6\x9d\xb3\xc7\x9f!\xb0"

--- a/core/tests/test_apps.bitcoin.approver.py
+++ b/core/tests/test_apps.bitcoin.approver.py
@@ -14,7 +14,7 @@ from trezor.enums import InputScriptType, OutputScriptType
 from trezor.utils import HashWriter
 
 from apps.common import coins
-from apps.bitcoin.authorization import CoinJoinAuthorization
+from apps.bitcoin.authorization import FEE_RATE_DECIMALS, CoinJoinAuthorization
 from apps.bitcoin.sign_tx.approvers import CoinJoinApprover
 from apps.bitcoin.sign_tx.bitcoin import Bitcoin
 from apps.bitcoin.sign_tx.tx_info import TxInfo
@@ -47,7 +47,7 @@ class TestApprover(unittest.TestCase):
         self.msg_auth = AuthorizeCoinJoin(
             coordinator=self.coordinator_name,
             max_rounds=10,
-            max_coordinator_fee_rate=int(self.fee_rate_percent * 10**8),
+            max_coordinator_fee_rate=int(self.fee_rate_percent * 10**FEE_RATE_DECIMALS),
             max_fee_per_kvbyte=7000,
             address_n=[H_(10025), H_(0), H_(0), H_(1)],
             coin_name=self.coin.coin_name,
@@ -75,7 +75,7 @@ class TestApprover(unittest.TestCase):
             h_request, self.coordinator_name.encode()
         )
         writers.write_uint32(h_request, self.coin.slip44)
-        writers.write_uint32(h_request, int(self.fee_rate_percent * 10**8))
+        writers.write_uint32(h_request, int(self.fee_rate_percent * 10**FEE_RATE_DECIMALS))
         writers.write_uint64(h_request, self.no_fee_threshold)
         writers.write_uint64(h_request, self.min_registrable_amount)
         writers.write_bytes_fixed(h_request, mask_public_key, 33)
@@ -85,7 +85,7 @@ class TestApprover(unittest.TestCase):
         signature = secp256k1.sign(self.private_key, h_request.get_digest())
 
         return CoinJoinRequest(
-            fee_rate=int(self.fee_rate_percent * 10**8),
+            fee_rate=int(self.fee_rate_percent * 10**FEE_RATE_DECIMALS),
             no_fee_threshold=self.no_fee_threshold,
             min_registrable_amount=self.min_registrable_amount,
             mask_public_key=mask_public_key,


### PR DESCRIPTION
This adds the CoinJoin request public key for production deployment. @prusnak

I also added a minor fixup of the unit tests related to c7fb9081466b214df93041ec3321b1ba6bc7f9b0.