### PR TITLE
Fix TT display blinking by increasing backlight PWM frequency

### DIFF
--- a/core/.changelog.d/2595.changed
+++ b/core/.changelog.d/2595.changed
@@ -1,0 +1,1 @@
+Fixed display blinking by increasing backlight PWM frequency

--- a/core/embed/boardloader/.changelog.d/2595.changed
+++ b/core/embed/boardloader/.changelog.d/2595.changed
@@ -1,0 +1,1 @@
+Fixed display blinking by increasing backlight PWM frequency

--- a/core/embed/bootloader/.changelog.d/2595.changed
+++ b/core/embed/bootloader/.changelog.d/2595.changed
@@ -1,0 +1,1 @@
+Fixed display blinking by increasing backlight PWM frequency

--- a/core/embed/trezorhal/common.c
+++ b/core/embed/trezorhal/common.c
@@ -193,5 +193,6 @@ void ensure_compatible_settings(void) {
 #ifdef TREZOR_MODEL_T
   display_set_big_endian();
   set_core_clock(CLOCK_168_MHZ);
+  display_set_slow_pwm();
 #endif
 }

--- a/core/embed/trezorhal/displays/st7789v.h
+++ b/core/embed/trezorhal/displays/st7789v.h
@@ -21,5 +21,6 @@ extern __IO uint8_t *const DISPLAY_DATA_ADDRESS;
 
 void display_set_little_endian(void);
 void display_set_big_endian(void);
+void display_set_slow_pwm(void);
 
 #endif  //_ST7789V_H


### PR DESCRIPTION
Increased PWM freq from 100Hz to about 4kHz. The TPS61043 driver has 100Hz to 50kHz range, the 100Hz minimum causes visible(sometimes, depends on what is shown on the display) and annoying blinking effect.

4kHz produces much better result. 

For compatibility purposes the setting is reset when switching layers. 

Builds on refactoring done in #2565 