### PR TITLE
build(poetry): use new (parallel) installer

### DIFF
--- a/poetry.toml
+++ b/poetry.toml
@@ -1,5 +1,3 @@
 cache-dir = "/tmp/.poetry-cache"
 [virtualenvs]
 in-project = true
-[experimental]
-new-installer = false


### PR DESCRIPTION
We've been sticking to the old poetry installer because of https://github.com/python-poetry/poetry/issues/3199

But it seems the issue is gone now (fixed in poetry 1.1.6) and we can use the new (parallel) installer again.

Change was introduced in https://github.com/trezor/trezor-firmware/pull/1436 and this PR reverts it

<table>
<tr><th>machine</th><th>before</th><th>after</th></tr>
<tr><td>Intel Xeon Desktop</td>
<td>

```
$ time poetry shell
...
real	2m11.478s
user	1m43.056s
sys	0m9.334s
```

</td>
<td>

```
$ time poetry shell
...
real	0m32.622s
user	2m26.914s
sys	0m12.072s
```

</td>
<tr><td>Macbook Air M1</td>
<td>

```
$ time poetry install
...
real	1m13.131s
user	0m52.100s
sys	0m7.698s
```

</td>
<td>

```
$ time poetry install
...
real	0m22.092s
user	1m14.373s
sys	0m12.048s
```

</td>
</table>

Obviously we'd need to test in the CI several times to be sure this works.