### PR TITLE
Update GitHub link for Bitcoin Cash

### DIFF
--- a/common/defs/bitcoin/bcash.json
+++ b/common/defs/bitcoin/bcash.json
@@ -3,7 +3,7 @@
   "coin_shortcut": "BCH",
   "coin_label": "Bitcoin Cash",
   "website": "https://www.bitcoincash.org",
-  "github": "https://github.com/Bitcoin-ABC/bitcoin-abc",
+  "github": "https://github.com/bitcoin-cash-node/bitcoin-cash-node",
   "maintainer": "Jochen Hoenicke <hoenicke@gmail.com>",
   "curve_name": "secp256k1",
   "decimals": 8,


### PR DESCRIPTION
Bitcoin Cash (BCH) is not the same as Bitcoin ABC (which is now renamed to eCash). One of the several node implementations for BCH is called BCHN (also known as Bitcoin Cash Node).

Please consider merging my PR.

Regards,
Melroy van den Berg