### PR TITLE
Lower the default fees on Bitcoin Cash

### DIFF
--- a/common/defs/bitcoin/bcash.json
+++ b/common/defs/bitcoin/bcash.json
@@ -28,10 +28,10 @@
   "fork_id": 0,
   "force_bip143": true,
   "default_fee_b": {
-    "Low": 10,
-    "Economy": 70,
-    "Normal": 140,
-    "High": 200
+    "Low": 1,
+    "Economy": 1,
+    "Normal": 1,
+    "High": 100
   },
   "dust_limit": 546,
   "blocktime_seconds": 600,


### PR DESCRIPTION
The default fees defined in `bcash.json` is an one-to-one copy of Bitcoin fees, which is _not_ correct.

As a Trezor user myself I **overpay** BCH fees in Trezor as well as losing some _privacy_ due to the high default fees.  

Thanks.

Best regards,
Melroy van den Berg