### PR TITLE
Expose micropython lists as slices

### DIFF
--- a/core/embed/rust/build.rs
+++ b/core/embed/rust/build.rs
@@ -176,6 +176,7 @@ fn generate_micropython_bindings() {
         .allowlist_type("mp_obj_list_t")
         .allowlist_function("mp_obj_new_list")
         .allowlist_function("mp_obj_list_append")
+        .allowlist_function("mp_obj_list_get")
         .allowlist_function("mp_obj_list_set_len")
         .allowlist_var("mp_type_list")
         // map


### PR DESCRIPTION
While working on #2532 it turned out that this would be very useful. My guess is that there are several places in the codebase where it might come in handy.