### PR TITLE
UI2: support StrBuffer slicing

### DIFF
--- a/core/embed/rust/src/ui/model_tr/component/result_popup.rs
+++ b/core/embed/rust/src/ui/model_tr/component/result_popup.rs
@@ -2,7 +2,7 @@ use crate::{
     time::Instant,
     ui::{
         component::{
-            text::paragraphs::{Paragraph, Paragraphs},
+            text::paragraphs::{Paragraph, ParagraphStrType, Paragraphs},
             Child, Component, ComponentExt, Event, EventCtx, Label, Pad,
         },
         constant::screen,
@@ -18,13 +18,13 @@ pub enum ResultPopupMsg {
     Confirmed,
 }
 
-pub struct ResultPopup {
+pub struct ResultPopup<S> {
     area: Rect,
     pad: Pad,
     result_anim: Child<ResultAnim>,
     headline_baseline: Point,
     headline: Option<Label<&'static str>>,
-    text: Child<Paragraphs<Paragraph<&'static str>>>,
+    text: Child<Paragraphs<Paragraph<S>>>,
     button: Option<Child<Button<&'static str>>>,
     autoclose: bool,
 }
@@ -36,10 +36,10 @@ const ANIM_POS: i16 = 32;
 const ANIM_POS_ADJ_HEADLINE: i16 = 10;
 const ANIM_POS_ADJ_BUTTON: i16 = 6;
 
-impl ResultPopup {
+impl<S: ParagraphStrType> ResultPopup<S> {
     pub fn new(
         icon: &'static [u8],
-        text: &'static str,
+        text: S,
         headline: Option<&'static str>,
         button_text: Option<&'static str>,
     ) -> Self {
@@ -86,7 +86,7 @@ impl ResultPopup {
     }
 }
 
-impl Component for ResultPopup {
+impl<S: ParagraphStrType> Component for ResultPopup<S> {
     type Msg = ResultPopupMsg;
 
     fn place(&mut self, bounds: Rect) -> Rect {
@@ -155,7 +155,7 @@ impl Component for ResultPopup {
 }
 
 #[cfg(feature = "ui_debug")]
-impl crate::trace::Trace for ResultPopup {
+impl<S: ParagraphStrType> crate::trace::Trace for ResultPopup<S> {
     fn trace(&self, d: &mut dyn crate::trace::Tracer) {
         d.open("ResultPopup");
         self.text.trace(d);

--- a/core/embed/rust/src/ui/model_tt/component/dialog.rs
+++ b/core/embed/rust/src/ui/model_tt/component/dialog.rs
@@ -1,7 +1,9 @@
 use crate::ui::{
     component::{
         image::BlendedImage,
-        text::paragraphs::{Paragraph, ParagraphSource, ParagraphVecShort, Paragraphs, VecExt},
+        text::paragraphs::{
+            Paragraph, ParagraphSource, ParagraphStrType, ParagraphVecShort, Paragraphs, VecExt,
+        },
         Child, Component, Event, EventCtx, Never,
     },
     geometry::{Insets, LinearPlacement, Rect},
@@ -93,18 +95,17 @@ pub struct IconDialog<T, U> {
 
 impl<T, U> IconDialog<T, U>
 where
-    T: AsRef<str>,
+    T: ParagraphStrType,
     U: Component,
 {
     pub fn new(icon: BlendedImage, title: T, controls: U) -> Self {
         Self {
             image: Child::new(icon),
-            paragraphs: ParagraphVecShort::from_iter([Paragraph::new(
+            paragraphs: Paragraphs::new(ParagraphVecShort::from_iter([Paragraph::new(
                 &theme::TEXT_DEMIBOLD,
                 title,
             )
-            .centered()])
-            .into_paragraphs()
+            .centered()]))
             .with_placement(
                 LinearPlacement::vertical()
                     .align_at_center()
@@ -152,7 +153,7 @@ where
 
 impl<T, U> Component for IconDialog<T, U>
 where
-    T: AsRef<str>,
+    T: ParagraphStrType,
     U: Component,
 {
     type Msg = DialogMsg<Never, U::Msg>;
@@ -193,7 +194,7 @@ where
 #[cfg(feature = "ui_debug")]
 impl<T, U> crate::trace::Trace for IconDialog<T, U>
 where
-    T: AsRef<str>,
+    T: ParagraphStrType,
     U: crate::trace::Trace,
 {
     fn trace(&self, t: &mut dyn crate::trace::Tracer) {

--- a/core/embed/rust/src/ui/model_tt/component/number_input.rs
+++ b/core/embed/rust/src/ui/model_tt/component/number_input.rs
@@ -2,7 +2,7 @@ use crate::ui::{
     component::{
         base::ComponentExt,
         paginated::Paginate,
-        text::paragraphs::{Paragraph, Paragraphs},
+        text::paragraphs::{Paragraph, ParagraphStrType, Paragraphs},
         Child, Component, Event, EventCtx, Pad,
     },
     display::{self, Font},
@@ -33,7 +33,7 @@ where
 impl<T, F> NumberInputDialog<T, F>
 where
     F: Fn(u32) -> T,
-    T: AsRef<str>,
+    T: ParagraphStrType,
 {
     pub fn new(min: u32, max: u32, init_value: u32, description_func: F) -> Self {
         let text = description_func(init_value);
@@ -69,7 +69,7 @@ where
 
 impl<T, F> Component for NumberInputDialog<T, F>
 where
-    T: AsRef<str>,
+    T: ParagraphStrType,
     F: Fn(u32) -> T,
 {
     type Msg = NumberInputDialogMsg;
@@ -131,7 +131,7 @@ where
 #[cfg(feature = "ui_debug")]
 impl<T, F> crate::trace::Trace for NumberInputDialog<T, F>
 where
-    T: AsRef<str>,
+    T: ParagraphStrType,
     F: Fn(u32) -> T,
 {
     fn trace(&self, t: &mut dyn crate::trace::Tracer) {

--- a/core/embed/rust/src/ui/model_tt/component/page.rs
+++ b/core/embed/rust/src/ui/model_tt/component/page.rs
@@ -385,7 +385,7 @@ mod tests {
         trace::Trace,
         ui::{
             component::{
-                text::paragraphs::{Paragraph, Paragraphs},
+                text::paragraphs::{Paragraph, ParagraphStrType, Paragraphs},
                 Empty,
             },
             event::TouchEvent,
@@ -397,6 +397,12 @@ mod tests {
     use super::*;
 
     const SCREEN: Rect = constant::screen().inset(theme::borders());
+
+    impl ParagraphStrType for &'static str {
+        fn skip_prefix(&self, chars: usize) -> Self {
+            &self[chars..]
+        }
+    }
 
     fn trace(val: &impl Trace) -> String {
         let mut t = Vec::new();

--- a/core/embed/rust/src/ui/model_tt/layout.rs
+++ b/core/embed/rust/src/ui/model_tt/layout.rs
@@ -21,8 +21,8 @@ use crate::{
             painter,
             text::{
                 paragraphs::{
-                    Checklist, Paragraph, ParagraphSource, ParagraphVecLong, ParagraphVecShort,
-                    Paragraphs, VecExt,
+                    Checklist, Paragraph, ParagraphSource, ParagraphStrType, ParagraphVecLong,
+                    ParagraphVecShort, Paragraphs, VecExt,
                 },
                 TextStyle,
             },
@@ -122,7 +122,7 @@ where
 
 impl<T, U> ComponentMsgObj for IconDialog<T, U>
 where
-    T: AsRef<str>,
+    T: ParagraphStrType,
     U: Component,
     <U as Component>::Msg: TryInto<Obj, Error = Error>,
 {
@@ -263,7 +263,7 @@ where
 
 impl<T, F> ComponentMsgObj for NumberInputDialog<T, F>
 where
-    T: AsRef<str>,
+    T: ParagraphStrType,
     F: Fn(u32) -> T,
 {
     fn msg_try_into_obj(&self, msg: Self::Msg) -> Result<Obj, Error> {
@@ -1061,8 +1061,9 @@ extern "C" fn new_select_word_count(n_args: usize, args: *const Obj, kwargs: *mu
             "RECOVERY MODE"
         };
 
-        let paragraphs =
-            Paragraphs::new([Paragraph::new(&theme::TEXT_BOLD, "Number of words?").centered()]);
+        let paragraphs = Paragraphs::new(
+            Paragraph::new(&theme::TEXT_BOLD, StrBuffer::from("Number of words?")).centered(),
+        );
 
         let obj = LayoutObj::new(
             Frame::new(title, Dialog::new(paragraphs, SelectWordCount::new()))


### PR DESCRIPTION
Fixes #2665. It seems to me we actually can't implement indexing by ranges as the type signature is `fn index(&self, index: Idx) -> &Self::Output` but we need to return new StrBuffer value, not a reference.

We can't create new `StrBuffer` from stack data so I had to drop the scratch buffer handling (introduced in #2575), the hexadecimal representation is now written to GC-allocated buffer. We can't do hexadecimal conversion without StrBuffer but I guess that shouldn't be a problem.