### PR TITLE
chore(ci): temporary allow_failure for connect tests

### DIFF
--- a/ci/test.yml
+++ b/ci/test.yml
@@ -647,6 +647,7 @@ core unix memory profiler:
 connect test core:
   image: ghcr.io/trezor/trezor-user-env
   stage: test
+  allow_failure: true
   tags:
     - runner-internal
   needs:


### PR DESCRIPTION
Lets allow it to fail for now until i figure it out. We are missing latest master builds in tenv due to this.