### PR TITLE
refactor(core): Allow eth & btc signing at m / 45' / coin_type / account / change / address_index

### DIFF
--- a/common/tests/fixtures/ethereum/signmessage.json
+++ b/common/tests/fixtures/ethereum/signmessage.json
@@ -16,6 +16,16 @@
         },
         {
             "parameters": {
+                "msg": "This is an example of a signed message at a different path.",
+                "path": "m/45'/60/2/1/1"
+            },
+            "result": {
+                "address": "0x4C28fB5643a2F9B03736103188845C5B50300242",
+                "sig": "0x10cb53ab88112fa0a915ab3e477843ab534ba1a1caeb70747373a86cba69ca6c5f70367d8f9023e1d7cd9fe34279dd9266dd26d7390acbfdea777c4c436de4df1c"
+            }
+        },
+        {
+            "parameters": {
                 "msg": "VeryLongMessage!VeryLongMessage!VeryLongMessage!VeryLongMessage!VeryLongMessage!VeryLongMessage!VeryLongMessage!VeryLongMessage!VeryLongMessage!VeryLongMessage!VeryLongMessage!VeryLongMessage!VeryLongMessage!VeryLongMessage!VeryLongMessage!VeryLongMessage!VeryLongMessage!VeryLongMessage!VeryLongMessage!VeryLongMessage!VeryLongMessage!VeryLongMessage!VeryLongMessage!VeryLongMessage!VeryLongMessage!VeryLongMessage!VeryLongMessage!VeryLongMessage!VeryLongMessage!VeryLongMessage!VeryLongMessage!VeryLongMessage!VeryLongMessage!VeryLongMessage!VeryLongMessage!VeryLongMessage!VeryLongMessage!VeryLongMessage!VeryLongMessage!VeryLongMessage!VeryLongMessage!VeryLongMessage!VeryLongMessage!VeryLongMessage!VeryLongMessage!VeryLongMessage!VeryLongMessage!VeryLongMessage!VeryLongMessage!VeryLongMessage!VeryLongMessage!VeryLongMessage!VeryLongMessage!VeryLongMessage!VeryLongMessage!VeryLongMessage!VeryLongMessage!VeryLongMessage!VeryLongMessage!VeryLongMessage!VeryLongMessage!VeryLongMessage!VeryLongMessage!VeryLongMessage!",
                 "path": "m/44'/60'/0'/0/0"
             },

--- a/core/src/apps/bitcoin/keychain.py
+++ b/core/src/apps/bitcoin/keychain.py
@@ -3,7 +3,7 @@ from typing import TYPE_CHECKING
 
 from trezor.messages import AuthorizeCoinJoin, SignMessage
 
-from apps.common.paths import PATTERN_BIP44, PathSchema
+from apps.common.paths import PATTERN_BIP44, PATTERN_CASA, PathSchema
 
 from . import authorization
 from .common import BITCOIN_NAMES
@@ -74,7 +74,7 @@ PATTERN_GREENADDRESS_B = "m/3'/[1-100]'/[1,4]/address_index"
 PATTERN_GREENADDRESS_SIGN_A = "m/1195487518"
 PATTERN_GREENADDRESS_SIGN_B = "m/1195487518/6/address_index"
 
-PATTERN_CASA = "m/49/coin_type/account/change/address_index"
+PATTERN_CASA_UNHARDENED = "m/49/coin_type/account/change/address_index"
 
 PATTERN_UNCHAINED_HARDENED = (
     "m/45'/coin_type'/account'/[0-1000000]/change/address_index"
@@ -141,13 +141,14 @@ def validate_path_against_script_type(
 
     elif coin.segwit and script_type == InputScriptType.SPENDP2SHWITNESS:
         append(PATTERN_BIP49)
+        append(PATTERN_CASA)
         if multisig:
             append(PATTERN_BIP48_P2SHSEGWIT)
         if slip44 == _SLIP44_BITCOIN:
             append(PATTERN_GREENADDRESS_A)
             append(PATTERN_GREENADDRESS_B)
         if coin.coin_name in BITCOIN_NAMES:
-            append(PATTERN_CASA)
+            append(PATTERN_CASA_UNHARDENED)
 
     elif coin.segwit and script_type == InputScriptType.SPENDWITNESS:
         append(PATTERN_BIP84)
@@ -178,6 +179,7 @@ def _get_schemas_for_coin(
     patterns = [
         PATTERN_BIP44,
         PATTERN_BIP48_RAW,
+        PATTERN_CASA,
     ]
 
     # patterns without coin_type field must be treated as if coin_type == 0
@@ -201,7 +203,7 @@ def _get_schemas_for_coin(
     if coin.coin_name in BITCOIN_NAMES:
         patterns.extend(
             (
-                PATTERN_CASA,
+                PATTERN_CASA_UNHARDENED,
                 PATTERN_UNCHAINED_HARDENED,
                 PATTERN_UNCHAINED_UNHARDENED,
                 PATTERN_UNCHAINED_DEPRECATED,

--- a/core/src/apps/common/paths.py
+++ b/core/src/apps/common/paths.py
@@ -338,6 +338,8 @@ PATTERN_SEP5 = "m/44'/coin_type'/account'"
 # https://github.com/trezor/trezor-firmware/issues/1749
 PATTERN_SEP5_LEDGER_LIVE_LEGACY = "m/44'/coin_type'/0'/account"
 
+PATTERN_CASA = "m/45'/coin_type/account/change/address_index"
+
 
 async def validate_path(
     ctx: wire.Context,

--- a/core/src/apps/ethereum/keychain.py
+++ b/core/src/apps/ethereum/keychain.py
@@ -44,16 +44,19 @@ PATTERNS_ADDRESS = (
     paths.PATTERN_BIP44,
     paths.PATTERN_SEP5,
     paths.PATTERN_SEP5_LEDGER_LIVE_LEGACY,
+    paths.PATTERN_CASA,
 )
 
 
 def _schemas_from_address_n(
     patterns: Iterable[str], address_n: paths.Bip32Path
 ) -> Iterable[paths.PathSchema]:
-    if len(address_n) < 2:
-        return ()
+    # Casa paths (purpose of 45) do not have hardened coin types
+    if address_n[0] == 45 | paths.HARDENED and not address_n[1] & paths.HARDENED:
+        slip44_hardened = address_n[1] | paths.HARDENED
+    else:
+        slip44_hardened = address_n[1]
 
-    slip44_hardened = address_n[1]
     if slip44_hardened not in networks.all_slip44_ids_hardened():
         return ()
 

--- a/tests/device_tests/bitcoin/test_nonstandard_paths.py
+++ b/tests/device_tests/bitcoin/test_nonstandard_paths.py
@@ -85,6 +85,8 @@ VECTORS_MULTISIG = (  # paths, address_index
     (("m/45h/0/63/1000000", "m/45h/0/62/1000000", "m/45h/0/61/1000000"), [0, 255]),
     # Unchained deprecated m/45'/coin_type'/account'/[0-1000000]/address_index
     (("m/45h/0h/63h/1000000", "m/45h/0h/62h/1000000", "m/45h/0/61/1000000"), [255]),
+    # Casa Paths
+    (("m/45h/0/60/1", "m/45h/1/60/0", "m/45h/2/60/0"), [255]),
 )
 
 


### PR DESCRIPTION
## Toward an Unhardened Multisig Standard

Casa and other multisig providers have learned that the use of extensive key hardening causes usability issues. This is due to additional complexities that arise from having to coordinate the use of multiple geographically distributed keys. The degradation of user experience is not offset by any security improvements because the primary security of a multisignature wallet comes from preventing any given key from being a single point of failure. 

With that said, multisig coordinators should only need to harden up to the purpose path.
Mutlisig coordinators should sign at `m / 45' / coin_type / account / change / address_index`. 