### PR TITLE
fix UI test report generation

### DIFF
--- a/tests/ui_tests/reporting/html.py
+++ b/tests/ui_tests/reporting/html.py
@@ -8,11 +8,7 @@ from dominate import document
 from dominate.tags import a, i, img, table, td, th, tr
 
 
-def report_links(
-    tests: List[Path], reports_path: Path, actual_hashes: Dict[str, str] = None
-) -> None:
-    if actual_hashes is None:
-        actual_hashes = {}
+def report_links(tests: List[Path], reports_path: Path) -> None:
 
     if not tests:
         i("None!")
@@ -21,8 +17,13 @@ def report_links(
         with tr():
             th("Link to report")
         for test in sorted(tests):
-            with tr(data_actual_hash=actual_hashes.get(test.stem, "")):
-                path = test.relative_to(reports_path)
+            actual_hash = ""
+            path = test.relative_to(reports_path)
+            if path.is_relative_to("failed"):
+                with open(test, "r") as report:
+                    data = report.read()
+                    actual_hash = data.split("<p>Actual: ")[1].split("</p>")[0].strip()
+            with tr(data_actual_hash=actual_hash):
                 td(a(test.name, href=path))
 
 

--- a/tests/ui_tests/reporting/html.py
+++ b/tests/ui_tests/reporting/html.py
@@ -2,7 +2,7 @@ import base64
 import filecmp
 from itertools import zip_longest
 from pathlib import Path
-from typing import Dict, List, Optional
+from typing import List, Optional
 
 from dominate import document
 from dominate.tags import a, i, img, table, td, th, tr

--- a/tests/ui_tests/reporting/testreport.js
+++ b/tests/ui_tests/reporting/testreport.js
@@ -24,11 +24,11 @@ function itemKeyFromIndexEntry(entry) {
 }
 
 
-function markState(state) {
+async function markState(state) {
     if (state === 'update') {
         let lastIndex = decodeURIComponent(window.location.href).split("/").reverse()[0].lastIndexOf(".")
         let stem = decodeURIComponent(window.location.href).split("/").reverse()[0].slice(0, lastIndex)
-        fetch('http://localhost:8000/fixtures.json', {
+        await fetch('http://localhost:8000/fixtures.json', {
             method: 'POST',
             headers: {
                 'Accept': 'application/json',
@@ -38,7 +38,7 @@ function markState(state) {
                 "test": stem,
                 "hash": document.body.dataset.actualHash
             })
-         }).then(() => {})
+         })
         window.localStorage.setItem(itemKeyFromOneTest(), 'ok')
     } else {
         window.localStorage.setItem(itemKeyFromOneTest(), state)

--- a/tests/ui_tests/reporting/testreport.py
+++ b/tests/ui_tests/reporting/testreport.py
@@ -29,8 +29,6 @@ SCREENSHOTS_WIDTH_PX_TO_DISPLAY = {
 ALL_SCREENS = "all_screens.html"
 ALL_UNIQUE_SCREENS = "all_unique_screens.html"
 
-ACTUAL_HASHES: Dict[str, str] = {}
-
 
 def _image_width(test_name: str) -> int:
     """Return the width of the image to display for the given test name.
@@ -120,7 +118,7 @@ def index() -> Path:
                     t.span("marked BAD", style="color: darkred")
                     t.button("clear", onclick="resetState('bad')")
 
-        html.report_links(failed_tests, REPORTS_PATH, ACTUAL_HASHES)
+        html.report_links(failed_tests, REPORTS_PATH)
 
         h2("Passed", style="color: green;")
         html.report_links(passed_tests, REPORTS_PATH)
@@ -246,7 +244,6 @@ def failed(
 
     Compares the actual screenshots to the expected ones.
     """
-    ACTUAL_HASHES[test_name] = actual_hash
 
     doc = document(title=test_name, actual_hash=actual_hash)
     recorded_path = fixture_test_path / "recorded"


### PR DESCRIPTION
Fixes a problem with report generation, where `data-actual-hash` was not filled in when generation was invoked via `make test_emu_ui`, which causes that links to next test are not properly generated. Generation via `python -m tests.ui_tests` worked fine.

Also fixes a bug where last failed tests failed to update fixture from report, as the window was closed before the promise was resolved and fixtures updated.
