### PR TITLE
chore(build): use host network instead of the default (bridge)

### DIFF
--- a/build-docker.sh
+++ b/build-docker.sh
@@ -32,6 +32,7 @@ if [ -z "$ALPINE_CHECKSUM" ]; then
  fi
 
 
+DOCKER=${DOCKER:-docker}
 CONTAINER_NAME=${CONTAINER_NAME:-trezor-firmware-env.nix}
 ALPINE_CDN=${ALPINE_CDN:-https://dl-cdn.alpinelinux.org/alpine}
 ALPINE_RELEASE=${ALPINE_RELEASE:-3.15}
@@ -83,7 +84,7 @@ echo
 echo ">>> DOCKER BUILD ALPINE_VERSION=$ALPINE_VERSION ALPINE_ARCH=$ALPINE_ARCH NIX_VERSION=$NIX_VERSION -t $CONTAINER_NAME"
 echo
 
-docker build \
+$DOCKER build \
   --network=host \
   --build-arg ALPINE_VERSION="$ALPINE_VERSION" \
   --build-arg ALPINE_ARCH="$ALPINE_ARCH" \
@@ -131,7 +132,7 @@ EOF
   echo ">>> DOCKER RUN core BITCOIN_ONLY=$BITCOIN_ONLY PRODUCTION=$PRODUCTION"
   echo
 
-  docker run \
+  $DOCKER run \
     --network=host \
     -it \
     --rm \
@@ -180,7 +181,7 @@ EOF
   echo ">>> DOCKER RUN legacy BITCOIN_ONLY=$BITCOIN_ONLY PRODUCTION=$PRODUCTION"
   echo
 
-  docker run \
+  $DOCKER run \
     --network=host \
     -it \
     --rm \

--- a/build-docker.sh
+++ b/build-docker.sh
@@ -83,7 +83,13 @@ echo
 echo ">>> DOCKER BUILD ALPINE_VERSION=$ALPINE_VERSION ALPINE_ARCH=$ALPINE_ARCH NIX_VERSION=$NIX_VERSION -t $CONTAINER_NAME"
 echo
 
-docker build --build-arg ALPINE_VERSION="$ALPINE_VERSION" --build-arg ALPINE_ARCH="$ALPINE_ARCH" --build-arg NIX_VERSION="$NIX_VERSION" -t "$CONTAINER_NAME" ci/
+docker build \
+  --network=host \
+  --build-arg ALPINE_VERSION="$ALPINE_VERSION" \
+  --build-arg ALPINE_ARCH="$ALPINE_ARCH" \
+  --build-arg NIX_VERSION="$NIX_VERSION" \
+  -t "$CONTAINER_NAME" \
+  ci/
 
 # stat under macOS has slightly different cli interface
 USER=$(stat -c "%u" . 2>/dev/null || stat -f "%u" .)
@@ -125,7 +131,10 @@ EOF
   echo ">>> DOCKER RUN core BITCOIN_ONLY=$BITCOIN_ONLY PRODUCTION=$PRODUCTION"
   echo
 
-  docker run -it --rm \
+  docker run \
+    --network=host \
+    -it \
+    --rm \
     -v "$DIR:/local" \
     -v "$DIR/build/core$DIRSUFFIX":/build:z \
     --env BITCOIN_ONLY="$BITCOIN_ONLY" \
@@ -171,7 +180,10 @@ EOF
   echo ">>> DOCKER RUN legacy BITCOIN_ONLY=$BITCOIN_ONLY PRODUCTION=$PRODUCTION"
   echo
 
-  docker run -it --rm \
+  docker run \
+    --network=host \
+    -it \
+    --rm \
     -v "$DIR:/local" \
     -v "$DIR/build/legacy$DIRSUFFIX":/build:z \
     --env BITCOIN_ONLY="$BITCOIN_ONLY" \
@@ -179,7 +191,6 @@ EOF
     --init \
     "$CONTAINER_NAME" \
     /nix/var/nix/profiles/default/bin/nix-shell --run "bash /local/build/$SCRIPT_NAME"
-
 done
 
 # all built, show fingerprints


### PR DESCRIPTION
It seems that bridge is not a good default because it does not always work out of the box.

see https://docs.docker.com/network/ for more info

edit: also [podman](https://podman.io) is a thing, so make it possible to override the docker command