### PR TITLE
fix model T display reinitialization crash

### DIFF
--- a/core/embed/firmware/main.c
+++ b/core/embed/firmware/main.c
@@ -87,6 +87,8 @@ int main(void) {
   enable_systemview();
 #endif
 
+  display_reinit();
+
 #if !defined TREZOR_MODEL_1
   parse_boardloader_capabilities();
 
@@ -108,8 +110,6 @@ int main(void) {
   // enable BUS fault and USAGE fault handlers
   SCB->SHCSR |= (SCB_SHCSR_USGFAULTENA_Msk | SCB_SHCSR_BUSFAULTENA_Msk);
 #endif
-
-  display_reinit();
 
 #if defined TREZOR_MODEL_1
   button_init();


### PR DESCRIPTION
Unfortunately the FMC timing fix #2698  introduced a bug that crashes firmware startup, because the FMC initialization accesses area of memory that is under MPU protection at that point.