### PR TITLE
tearing effect prevention improvement

### DIFF
--- a/core/embed/extmod/modtrezorui/display_interface.h
+++ b/core/embed/extmod/modtrezorui/display_interface.h
@@ -43,6 +43,7 @@ int display_backlight(int val);
 
 void display_init(void);
 void display_reinit(void);
+void display_sync(void);
 void display_refresh(void);
 const char *display_save(const char *prefix);
 void display_clear_save(void);

--- a/core/embed/rust/build.rs
+++ b/core/embed/rust/build.rs
@@ -293,6 +293,7 @@ fn generate_trezorhal_bindings() {
         .allowlist_function("display_pixeldata")
         .allowlist_function("display_pixeldata_dirty")
         .allowlist_function("display_set_window")
+        .allowlist_function("display_sync")
         .allowlist_var("DISPLAY_CMD_ADDRESS")
         .allowlist_var("DISPLAY_DATA_ADDRESS")
         .allowlist_type("toif_format_t")

--- a/core/embed/rust/src/trezorhal/display.rs
+++ b/core/embed/rust/src/trezorhal/display.rs
@@ -169,3 +169,9 @@ pub fn get_offset() -> (i16, i16) {
         (x as i16, y as i16)
     }
 }
+
+pub fn sync() {
+    unsafe {
+        ffi::display_sync();
+    }
+}

--- a/core/embed/rust/src/ui/display/mod.rs
+++ b/core/embed/rust/src/ui/display/mod.rs
@@ -826,6 +826,10 @@ pub fn set_window(window: Rect) {
     );
 }
 
+pub fn sync() {
+    display::sync();
+}
+
 pub fn get_color_table(fg_color: Color, bg_color: Color) -> [Color; 16] {
     let mut table: [Color; 16] = [Color::from_u16(0); 16];
 

--- a/core/embed/rust/src/ui/layout/obj.rs
+++ b/core/embed/rust/src/ui/layout/obj.rs
@@ -18,6 +18,7 @@ use crate::{
     ui::{
         component::{Child, Component, Event, EventCtx, Never, TimerToken},
         constant,
+        display::sync,
         geometry::Rect,
     },
 };
@@ -199,6 +200,8 @@ impl LayoutObj {
             // SAFETY: `inner.root` is unique because of the `inner.borrow_mut()`.
             unsafe { Gc::as_mut(&mut inner.root) }.obj_place(constant::screen());
         }
+
+        sync();
 
         // SAFETY: `inner.root` is unique because of the `inner.borrow_mut()`.
         unsafe { Gc::as_mut(&mut inner.root) }.obj_paint()

--- a/core/embed/trezorhal/common.c
+++ b/core/embed/trezorhal/common.c
@@ -192,6 +192,7 @@ void collect_hw_entropy(void) {
 void ensure_compatible_settings(void) {
 #ifdef TREZOR_MODEL_T
   display_set_big_endian();
+  display_orientation(0);
   set_core_clock(CLOCK_168_MHZ);
   display_set_slow_pwm();
 #endif

--- a/core/embed/trezorhal/displays/ug-2828tswig01.c
+++ b/core/embed/trezorhal/displays/ug-2828tswig01.c
@@ -347,6 +347,8 @@ void display_init(void) {
   display_init_seq();
 }
 
+void display_sync(void) {}
+
 void display_refresh(void) {
   for (int y = 0; y < (DISPLAY_RESY / 8); y++) {
     display_set_page_and_col(y, 0);

--- a/core/embed/trezorhal/displays/vg-2864ksweg01.c
+++ b/core/embed/trezorhal/displays/vg-2864ksweg01.c
@@ -247,6 +247,8 @@ static void rotate_oled_buffer(void) {
   }
 }
 
+void display_sync(void) {}
+
 void display_refresh(void) {
   static const uint8_t s[3] = {OLED_SETLOWCOLUMN | 0x00,
                                OLED_SETHIGHCOLUMN | 0x00,

--- a/core/embed/unix/display-unix.c
+++ b/core/embed/unix/display-unix.c
@@ -234,6 +234,8 @@ void display_set_window(uint16_t x0, uint16_t y0, uint16_t x1, uint16_t y1) {
   PIXELWINDOW.pos.y = y0;
 }
 
+void display_sync(void) {}
+
 void display_refresh(void) {
   if (!RENDERER) {
     display_init();


### PR DESCRIPTION
Introduces `display_sync` function that synchronizes writing to display RAM with panel refresh. This is called before every relevant paint so that optimally the paint is done before the corresponding panel part is refreshed.

`display_orientation` function is modified so that the panel refresh direction respects the orientation. This is only possible for north and south orientation with current display driver. 

For west and east orientation, the display refresh direction is perpendicular to the orientation so the tearing effect prevention is not working and the effect is actually diagonal, but at least the display is synchronized so the UI should behave less randomly in this regard.

closes #2546 , builds on #2714 

