### PR TITLE
Update blockchain_link.json

### DIFF
--- a/common/defs/blockchain_link.json
+++ b/common/defs/blockchain_link.json
@@ -143,7 +143,7 @@
   "bitcoin:SYS": {
     "type": "blockbook",
     "url": [
-      "https://sys1.bcfn.ca"
+      "https://blockbook.elint.services"
     ]
   },
   "bitcoin:TEST": {


### PR DESCRIPTION
Update the syscoin URL, our previous blockexplorer at sys1.bcfn.ca isn't operational any longer, making the trezor connection to syscoin fail.