### PR TITLE
Increase 'SignIdentity.challenge_hidden' max_size to 512 bytes

### DIFF
--- a/legacy/firmware/.changelog.d/2743.changed
+++ b/legacy/firmware/.changelog.d/2743.changed
@@ -1,0 +1,1 @@
+Increase 'SignIdentity.challenge_hidden' max_size to 512 bytes

--- a/legacy/firmware/protob/messages-crypto.options
+++ b/legacy/firmware/protob/messages-crypto.options
@@ -18,7 +18,7 @@ CosiSign.global_pubkey                  max_size:32
 
 CosiSignature.signature                 max_size:32
 
-SignIdentity.challenge_hidden           max_size:256
+SignIdentity.challenge_hidden           max_size:512
 SignIdentity.challenge_visual           max_size:256
 SignIdentity.ecdsa_curve_name           max_size:32
 


### PR DESCRIPTION
Following https://github.com/romanz/trezor-agent/issues/408.