### PR TITLE
Device test features

### DIFF
--- a/core/Makefile
+++ b/core/Makefile
@@ -114,8 +114,12 @@ test_emu_ui_multicore: ## run ui integration tests using multiple cores
 test_emu_ui_record: ## record and hash screens for ui integration tests
 	$(EMU_TEST) $(PYTEST) $(TESTPATH)/device_tests --ui=record --ui-check-missing $(TESTOPTS)
 
-test_emu_ui_record_multicore: ## record and hash screens for ui integration tests using multiple cores
-	$(PYTEST) -n auto $(TESTPATH)/device_tests $(TESTOPTS) --ui=record --ui-check-missing --control-emulators --model=core --random-order-seed=$(shell echo $$RANDOM)
+test_emu_ui_record_multicore: ## quickly record all screens
+	make test_emu_ui_multicore || echo "All errors are recorded in fixtures.json"
+	make test_emu_accept_fixtures
+
+test_emu_accept_fixtures:  # accept UI fixtures from the last run of UI tests
+	../tests/update_fixtures.py
 
 pylint: ## run pylint on application sources and tests
 	pylint -E $(shell find src tests -name *.py)

--- a/core/Makefile
+++ b/core/Makefile
@@ -106,13 +106,17 @@ test_emu_click: ## run click tests
 	$(EMU_TEST) $(PYTEST) $(TESTPATH)/click_tests $(TESTOPTS)
 
 test_emu_ui: ## run ui integration tests
-	$(EMU_TEST) $(PYTEST) $(TESTPATH)/device_tests --ui=test --ui-check-missing $(TESTOPTS)
+	$(EMU_TEST) $(PYTEST) $(TESTPATH)/device_tests $(TESTOPTS) \
+		--ui=test --ui-check-missing --not-generate-report-after-each-test
 
 test_emu_ui_multicore: ## run ui integration tests using multiple cores
-	$(PYTEST) -n auto $(TESTPATH)/device_tests $(TESTOPTS) --ui=test --ui-check-missing --control-emulators --model=core --random-order-seed=$(shell echo $$RANDOM)
+	$(PYTEST) -n auto $(TESTPATH)/device_tests $(TESTOPTS) \
+		--ui=test --ui-check-missing --not-generate-report-after-each-test \
+		--control-emulators --model=core --random-order-seed=$(shell echo $$RANDOM)
 
 test_emu_ui_record: ## record and hash screens for ui integration tests
-	$(EMU_TEST) $(PYTEST) $(TESTPATH)/device_tests --ui=record --ui-check-missing $(TESTOPTS)
+	$(EMU_TEST) $(PYTEST) $(TESTPATH)/device_tests $(TESTOPTS) \
+		--ui=record --ui-check-missing --not-generate-report-after-each-test
 
 test_emu_ui_record_multicore: ## quickly record all screens
 	make test_emu_ui_multicore || echo "All errors are recorded in fixtures.json"

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -351,6 +351,13 @@ def pytest_addoption(parser: "Parser") -> None:
         help="Which emulator to use: 'core' or 'legacy'. "
         "Only valid in connection with `--control-emulators`",
     )
+    parser.addoption(
+        "--not-generate-report-after-each-test",
+        action="store_true",
+        default=False,
+        help="Not generating HTML reports after each test case. "
+        "Useful for CI tests to speed them up.",
+    )
 
 
 def pytest_configure(config: "Config") -> None:
@@ -399,8 +406,11 @@ def pytest_runtest_teardown(item: pytest.Item) -> None:
     # Not calling `testreport.generate_reports()` not to generate
     # the `all_screens` report, as would take a lot of time.
     # That will be generated in `pytest_sessionfinish`.
-    if item.session.config.getoption("ui"):
-        testreport.index()
+
+    # Optionally generating `index.html` report unless turned off by `pytest` flag
+    if not item.session.config.getoption("not_generate_report_after_each_test"):
+        if item.session.config.getoption("ui"):
+            testreport.index()
 
 
 @pytest.hookimpl(tryfirst=True, hookwrapper=True)

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -249,6 +249,8 @@ def pytest_sessionstart(session: pytest.Session) -> None:
     ui_tests.read_fixtures()
     if session.config.getoption("ui") and _is_main_runner(session):
         testreport.clear_dir()
+        # Preparing a new empty file for UI diff
+        ui_tests.FIXTURES_DIFF.write_bytes(b"")
 
 
 def _should_write_ui_report(exitstatus: pytest.ExitCode) -> bool:
@@ -314,6 +316,10 @@ def pytest_terminal_summary(
     if _should_write_ui_report(exitstatus):
         println("-------- UI tests summary: --------")
         println("Run ./tests/show_results.py to open test summary")
+        println("")
+
+        println("-------- Accepting all recent UI changes: --------")
+        println("Run ./tests/update_fixtures.py to apply all changes")
         println("")
 
 

--- a/tests/ui_tests/.gitignore
+++ b/tests/ui_tests/.gitignore
@@ -2,3 +2,4 @@
 *.html
 *.zip
 fixtures.suggestion.json
+fixtures.json.diff

--- a/tests/ui_tests/__init__.py
+++ b/tests/ui_tests/__init__.py
@@ -18,6 +18,7 @@ UI_TESTS_DIR = Path(__file__).resolve().parent
 SCREENS_DIR = UI_TESTS_DIR / "screens"
 HASH_FILE = UI_TESTS_DIR / "fixtures.json"
 SUGGESTION_FILE = UI_TESTS_DIR / "fixtures.suggestion.json"
+FIXTURES_DIFF = UI_TESTS_DIR / "fixtures.json.diff"
 FILE_HASHES: Dict[str, str] = {}
 ACTUAL_HASHES: Dict[str, str] = {}
 PROCESSED: Set[str] = set()
@@ -91,6 +92,16 @@ def _process_tested(fixture_test_path: Path, test_name: str) -> None:
         file_path = testreport.failed(
             fixture_test_path, test_name, actual_hash, expected_hash
         )
+
+        # Writing the diff to a file, so that we can process it later
+        # Appending a new JSON object, not having to regenerate the
+        # whole file (which could cause issues with multiple processes/threads)
+        with open(FIXTURES_DIFF, "a") as f:
+            diff = {
+                "test_name": test_name,
+                "actual_hash": actual_hash,
+            }
+            f.write(json.dumps(diff) + "\n")
 
         pytest.fail(
             f"Hash of {test_name} differs.\n"
@@ -184,6 +195,31 @@ def write_fixtures_suggestion(
     SUGGESTION_FILE.write_text(
         _get_fixtures_content(ACTUAL_HASHES, remove_missing, only_passed_tests)
     )
+
+
+def update_fixtures_with_diff() -> int:
+    """Update the fixtures.json file with the actual hashes from the diff file.
+
+    Use-case is that the UI test run will generate the differing hashes,
+    and with this function we can simply update the fixtures.json file
+    without having to call the UI tests again in recording mode.
+    """
+    if not FIXTURES_DIFF.exists():
+        raise ValueError(f"File {FIXTURES_DIFF} not found.")
+
+    read_fixtures()
+
+    changes_amount = 0
+    with open(FIXTURES_DIFF) as f:
+        for line in f:
+            changes_amount += 1
+            diff = json.loads(line)
+            FILE_HASHES[diff["test_name"]] = diff["actual_hash"]
+
+    write_fixtures(remove_missing=False)
+
+    # Returning the amount of updated hashes
+    return changes_amount
 
 
 def _get_fixtures_content(

--- a/tests/update_fixtures.py
+++ b/tests/update_fixtures.py
@@ -1,0 +1,7 @@
+#!/usr/bin/env python3
+
+from ui_tests import update_fixtures_with_diff
+
+changes_amount = update_fixtures_with_diff()
+
+print(f"{changes_amount} hashes updated in fixtures.json file.")


### PR DESCRIPTION
Some device tests usability improvements done in `model R` branch, but wanting to move them to `master`, as `model R` branch will not be there any time soon.

1. Possibility to accept the UI diff (change hashes in `fixtures.json`) after running tests with `--ui=test`, without having to call them again with `--ui=record`
- by `make test_emu_accept_fixtures`
- the quickest workflow is then `make test_emu_ui_multicore` to generate the UI diff as quickly as possible, and immediately update those changes by abovementioned command

2. Quickening the tests in CI by not generating `index.html` after each test case
- by the usage of `--not-generate-report-after-each-test` `pytest` flag