### PR TITLE
feat(python): show fingerprint before signatures in `trezorctl firmware verify`

### DIFF
--- a/python/.changelog.d/2745.changed
+++ b/python/.changelog.d/2745.changed
@@ -1,0 +1,1 @@
+`trezorctl firmware verify` changed order of checks - fingerprint is validated before signatures.

--- a/python/src/trezorlib/cli/firmware.py
+++ b/python/src/trezorlib/cli/firmware.py
@@ -351,8 +351,8 @@ def validate_firmware(
         sys.exit(2)
 
     print_firmware_version(fw)
-    validate_signatures(fw)
     validate_fingerprint(fw, fingerprint)
+    validate_signatures(fw)
 
     if bootloader_onev2 is not None and trezor_major_version is not None:
         check_device_match(


### PR DESCRIPTION
Fixes https://github.com/trezor/trezor-firmware/issues/2711:
- showing fingerprint even when the signatures are invalid