### PR TITLE
feat(core/ethereum): remove EIP-712 field size limitation of 1024 bytes

### DIFF
--- a/core/.changelog.d/2746.changed
+++ b/core/.changelog.d/2746.changed
@@ -1,0 +1,1 @@
+Ethereum's EIP-712 signing no longer restricts the maximum field size to 1024 bytes.

--- a/core/src/apps/ethereum/sign_typed_data.py
+++ b/core/src/apps/ethereum/sign_typed_data.py
@@ -1,4 +1,3 @@
-from micropython import const
 from typing import TYPE_CHECKING
 
 from trezor.enums import EthereumDataType
@@ -19,10 +18,6 @@ if TYPE_CHECKING:
         EthereumTypedDataSignature,
         EthereumTypedDataStructAck,
     )
-
-
-# Maximum data size we support
-_MAX_VALUE_BYTE_SIZE = const(1024)
 
 
 @with_keychain_from_path(*PATTERNS_ADDRESS)
@@ -426,14 +421,12 @@ def _validate_value(field: EthereumFieldType, value: bytes) -> None:
 
     Raise DataError if encountering a problem, so clients are notified.
     """
-    # Checking if the size corresponds to what is defined in types,
-    # and also setting our maximum supported size in bytes
-    if field.size is not None:
-        if len(value) != field.size:
-            raise DataError("Invalid length")
-    else:
-        if len(value) > _MAX_VALUE_BYTE_SIZE:
-            raise DataError(f"Invalid length, bigger than {_MAX_VALUE_BYTE_SIZE}")
+    # Checking if the size corresponds to what is defined in types.
+    # Not having any maximum field size - it is a responsibility of the client
+    # (and message creator) to make sure the data is not too large to cause problems
+    # on the Trezor side.
+    if field.size is not None and len(value) != field.size:
+        raise DataError("Invalid length")
 
     # Specific tests for some data types
     if field.data_type == EthereumDataType.BOOL:

--- a/core/tests/test_apps.ethereum.sign_typed_data.py
+++ b/core/tests/test_apps.ethereum.sign_typed_data.py
@@ -582,8 +582,8 @@ class TestEthereumSignTypedData(unittest.TestCase):
             ),
             (
                 EFT(data_type=EDT.STRING, size=None),
-                [b"\x7f", b"a" * 1024],
-                [b"\x80", b"a" * 1025],
+                [b"\x7f"],
+                [b"\x80"],
             ),
             (
                 EFT(data_type=EDT.ADDRESS, size=None),


### PR DESCRIPTION
Fixes https://github.com/trezor/trezor-firmware/issues/1909:
- removing the limitation of `EIP-712` message's fields to be smaller than 1024 bytes