### PR TITLE
Specify --recurse-submodules as in core doc

### DIFF
--- a/docs/legacy/index.md
+++ b/docs/legacy/index.md
@@ -8,7 +8,7 @@ Ensure that you have Docker installed. You can follow [Docker's installation ins
 
 Clone this repository, then use `build-docker.sh` to build all images:
 ```sh
-git clone https://github.com/trezor/trezor-firmware.git
+git clone --recurse-submodules https://github.com/trezor/trezor-firmware.git
 cd trezor-firmware
 ./build-docker.sh
 ```


### PR DESCRIPTION
This is needed for a successfull build for the legacy firmware as well (at least I had to on my machine)