### PR TITLE
New UI tests reports

### DIFF
--- a/ci/prepare_ui_artifacts.py
+++ b/ci/prepare_ui_artifacts.py
@@ -10,7 +10,7 @@ from tests.ui_tests.common import TestResult, _hash_files, get_fixtures  # isort
 
 FIXTURES = get_fixtures()
 
-for result in TestResult.recent_tests():
+for result in TestResult.recent_results():
     if not result.passed or result.expected_hash != result.actual_hash:
         print("WARNING: skipping failed test", result.test.id)
         continue

--- a/core/Makefile
+++ b/core/Makefile
@@ -111,11 +111,11 @@ test_emu_click_ui: ## run click tests with UI testing
 
 test_emu_ui: ## run ui integration tests
 	$(EMU_TEST) $(PYTEST) $(TESTPATH)/device_tests $(TESTOPTS) \
-		--ui=test --ui-check-missing
+		--ui=test --ui-check-missing --record-text-layout
 
 test_emu_ui_multicore: ## run ui integration tests using multiple cores
 	$(PYTEST) -n auto $(TESTPATH)/device_tests $(TESTOPTS) \
-		--ui=test --ui-check-missing \
+		--ui=test --ui-check-missing --record-text-layout \
 		--control-emulators --model=core --random-order-seed=$(shell echo $$RANDOM)
 
 test_emu_ui_record: ## record and hash screens for ui integration tests

--- a/python/src/trezorlib/debuglink.py
+++ b/python/src/trezorlib/debuglink.py
@@ -197,6 +197,15 @@ class DebugLink:
         self.t1_screenshot_directory: Optional[Path] = None
         self.t1_screenshot_counter = 0
 
+        # Optional file for saving text representation of the screen
+        self.screen_text_file: Optional[Path] = None
+        self.last_screen_content = ""
+
+    def set_screen_text_file(self, file_path: Optional[Path]) -> None:
+        if file_path is not None:
+            file_path.write_bytes(b"")
+        self.screen_text_file = file_path
+
     def open(self) -> None:
         self.transport.begin_session()
 
@@ -292,11 +301,42 @@ class DebugLink:
         decision = messages.DebugLinkDecision(
             button=button, swipe=swipe, input=word, x=x, y=y, wait=wait, hold_ms=hold_ms
         )
+
         ret = self._call(decision, nowait=not wait)
         if ret is not None:
             return LayoutContent(ret.lines)
 
+        # Getting the current screen after the (nowait) decision
+        self.save_current_screen_if_relevant(wait=False)
+
         return None
+
+    def save_current_screen_if_relevant(self, wait: bool = True) -> None:
+        """Optionally saving the textual screen output."""
+        if self.screen_text_file is None:
+            return
+
+        if wait:
+            layout = self.wait_layout()
+        else:
+            layout = self.read_layout()
+        self.save_debug_screen(layout.lines)
+
+    def save_debug_screen(self, lines: List[str]) -> None:
+        if self.screen_text_file is None:
+            return
+
+        content = "\n".join(lines)
+
+        # Not writing the same screen twice
+        if content == self.last_screen_content:
+            return
+
+        self.last_screen_content = content
+
+        with open(self.screen_text_file, "a") as f:
+            f.write(content)
+            f.write("\n" + 80 * "/" + "\n")
 
     # Type overloads make sure that when we supply `wait=True` into `click()`,
     # it will always return `LayoutContent` and we do not need to assert `is not None`.
@@ -449,6 +489,12 @@ class DebugUI:
         self.debuglink.take_t1_screenshot_if_relevant()
 
         if self.input_flow is None:
+            # Only calling screen-saver when not in input-flow
+            # as it collides with wait-layout of input flows.
+            # All input flows call debuglink.input(), so
+            # recording their screens that way (as well as
+            # possible swipes below).
+            self.debuglink.save_current_screen_if_relevant(wait=True)
             if br.code == messages.ButtonRequestType.PinEntry:
                 self.debuglink.input(self.get_pin())
             else:
@@ -720,7 +766,6 @@ class TrezorClientDebugLink(TrezorClient):
     def __exit__(self, exc_type: Any, value: Any, traceback: Any) -> None:
         __tracebackhide__ = True  # for pytest # pylint: disable=W0612
 
-        self.watch_layout(False)
         # copy expected/actual responses before clearing them
         expected_responses = self.expected_responses
         actual_responses = self.actual_responses

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -253,6 +253,7 @@ def pytest_sessionfinish(session: pytest.Session, exitstatus: pytest.ExitCode) -
             exitstatus,
             test_ui,  # type: ignore
             bool(session.config.getoption("ui_check_missing")),
+            bool(session.config.getoption("record_text_layout")),
         )
 
 
@@ -299,6 +300,13 @@ def pytest_addoption(parser: "Parser") -> None:
         choices=["core", "legacy"],
         help="Which emulator to use: 'core' or 'legacy'. "
         "Only valid in connection with `--control-emulators`",
+    )
+    parser.addoption(
+        "--record-text-layout",
+        action="store_true",
+        default=False,
+        help="Saving debugging traces for each screen change. "
+        "Will generate a report with text from all test-cases. ",
     )
 
 

--- a/tests/ui_tests/.gitignore
+++ b/tests/ui_tests/.gitignore
@@ -1,4 +1,5 @@
 *.png
 *.html
 *.zip
+*.txt
 fixtures.suggestion.json

--- a/tests/ui_tests/.gitignore
+++ b/tests/ui_tests/.gitignore
@@ -2,4 +2,3 @@
 *.html
 *.zip
 fixtures.suggestion.json
-fixtures.json.diff

--- a/tests/ui_tests/__init__.py
+++ b/tests/ui_tests/__init__.py
@@ -90,7 +90,9 @@ def setup(main_runner: bool) -> None:
 
 def list_missing() -> set[str]:
     # Only listing the ones for the current model
-    _, missing = common.prepare_fixtures(TestResult.recent_tests(), remove_missing=True)
+    _, missing = common.prepare_fixtures(
+        TestResult.recent_results(), remove_missing=True
+    )
     return {test.id for test in missing}
 
 
@@ -99,7 +101,7 @@ def update_fixtures(remove_missing: bool = False) -> int:
 
     Used in --ui=record and in update_fixtures.py
     """
-    results = list(TestResult.recent_tests())
+    results = list(TestResult.recent_results())
     for result in results:
         result.store_recorded()
 
@@ -162,7 +164,7 @@ def sessionfinish(
     testreport.generate_reports()
     if test_ui == "test" and check_missing and list_missing():
         common.write_fixtures(
-            TestResult.recent_tests(),
+            TestResult.recent_results(),
             remove_missing=True,
             dest=FIXTURES_SUGGESTION_FILE,
         )
@@ -175,7 +177,7 @@ def sessionfinish(
 
 
 def main() -> None:
-    for result in TestResult.recent_tests():
+    for result in TestResult.recent_results():
         try:
             _process_tested(result)
             print("PASSED:", result.test.id)

--- a/tests/ui_tests/common.py
+++ b/tests/ui_tests/common.py
@@ -270,6 +270,9 @@ class TestResult:
             json.dumps(metadata, indent=2, sort_keys=True) + "\n"
         )
 
+    def succeeded_in_ui_comparison(self) -> bool:
+        return self.actual_hash == self.expected_hash
+
     @classmethod
     def load(cls, testdir: Path) -> Self:
         metadata = json.loads((testdir / "metadata.json").read_text())
@@ -293,6 +296,13 @@ class TestResult:
             if not meta.exists():
                 continue
             yield cls.load(testdir)
+
+    @classmethod
+    def recent_ui_failures(cls) -> t.Iterator[Self]:
+        """Returning just the results that resulted in UI failure."""
+        for result in cls.recent_results():
+            if not result.succeeded_in_ui_comparison():
+                yield result
 
     def store_recorded(self) -> None:
         self.expected_hash = self.actual_hash

--- a/tests/ui_tests/common.py
+++ b/tests/ui_tests/common.py
@@ -215,6 +215,10 @@ class TestCase:
         return SCREENS_DIR / self.id
 
     @property
+    def screen_text_file(self) -> Path:
+        return self.dir / "screens.txt"
+
+    @property
     def actual_dir(self) -> Path:
         return self.dir / "actual"
 

--- a/tests/ui_tests/reporting/testreport.py
+++ b/tests/ui_tests/reporting/testreport.py
@@ -94,7 +94,7 @@ def index() -> Path:
     new_tests = list((TESTREPORT_PATH / "new").iterdir())
 
     actual_hashes = {
-        result.test.id: result.actual_hash for result in TestResult.recent_tests()
+        result.test.id: result.actual_hash for result in TestResult.recent_results()
     }
 
     title = "UI Test report " + datetime.now().strftime("%Y-%m-%d %H:%M:%S")
@@ -143,8 +143,8 @@ def all_screens() -> Path:
 
     Shows all test-cases at one place.
     """
-    recent_tests = list(TestResult.recent_tests())
-    model = recent_tests[0].test.model if recent_tests else None
+    recent_results = list(TestResult.recent_results())
+    model = recent_results[0].test.model if recent_results else None
 
     title = "All test cases"
     doc = document(title=title, model=model)
@@ -154,7 +154,7 @@ def all_screens() -> Path:
 
         count = 0
         result_count = 0
-        for result in recent_tests:
+        for result in recent_results:
             result_count += 1
             h2(result.test.id, id=result.test.id)
             for image in result.images:
@@ -170,11 +170,11 @@ def all_screens() -> Path:
 
 def all_unique_screens() -> Path:
     """Generate an HTML file with all the unique screens from the current test run."""
-    results = TestResult.recent_tests()
+    recent_results = TestResult.recent_results()
     result_count = 0
     model = None
-    test_cases = defaultdict(list)
-    for result in results:
+    test_cases: dict[str, list[str]] = defaultdict(list)
+    for result in recent_results:
         result_count += 1
         model = result.test.model
         for image in result.images:


### PR DESCRIPTION
Fixes https://github.com/trezor/trezor-firmware/issues/2727

Introduces two new reports and one fix connected with UI tests:
- when accepting UI diff manually with `make test_emu_accept_fixtures`, also copying the content of `actual` dir into `recorded` to mimic what would happen in `--ui=record`
- possibility to save text layout as sent from `Rust` (debugging trace) with each `Debuglink` decision (corresponding to each screenshot) - saving as downloadable artifact under `screen_text.txt`
  - allowing for a text search when looking for a test-case(s) where a certain string is appearing
  - example output for `TT` below:

```

TT_eos-test_signtx.py::test_eos_signtx_buyram
	< Homescreen label :  test >
	////////////////////////////////////////////////////////////////////////////////
	< Frame title :  SIGN TRANSACTION content :  < SwipePage active_page :  0 page_count :  1 content :  < Paragraphs You are about to sign 1 
	 action. 
	 > buttons :  < FixedHeightBar inner :  < Tuple 0 :  < GridPlaced inner :  < Button < icon > > > 1 :  < GridPlaced inner :  < Button text :  CONFIRM > > > > > >
	////////////////////////////////////////////////////////////////////////////////

TT_eos-test_signtx.py::test_eos_signtx_buyrambytes
	< Homescreen label :  test >
	////////////////////////////////////////////////////////////////////////////////
	< Frame title :  SIGN TRANSACTION content :  < SwipePage active_page :  0 page_count :  1 content :  < Paragraphs You are about to sign 1 
	 action. 
	 > buttons :  < FixedHeightBar inner :  < Tuple 0 :  < GridPlaced inner :  < Button < icon > > > 1 :  < GridPlaced inner :  < Button text :  CONFIRM > > > > > >
	////////////////////////////////////////////////////////////////////////////////

TT_eos-test_signtx.py::test_eos_signtx_delegate
...
```

- showing all unique screens that got changed in comparison to recorded screenshots
 
![image](https://user-images.githubusercontent.com/42543243/213194897-d4697ef9-e2bb-45d2-bda4-13faa739f06e.png)
