### PR TITLE
Add debugging tool for hashing operations

### DIFF
--- a/core/src/trezor/utils.py
+++ b/core/src/trezor/utils.py
@@ -169,6 +169,42 @@ if TYPE_CHECKING:
             ...
 
 
+if False:
+
+    class DebugHashContextWrapper:
+        """
+        Use this wrapper to debug hashing operations. When digest() is called,
+        it will log all of the data that was provided to update().
+
+        Example usage:
+        self.h_prevouts = HashWriter(DebugHashContextWrapper(sha256()))
+        """
+
+        def __init__(self, ctx: HashContext) -> None:
+            self.ctx = ctx
+            self.data = ""
+
+        def update(self, data: bytes) -> None:
+            from ubinascii import hexlify
+
+            self.ctx.update(data)
+            self.data += hexlify(data).decode() + " "
+
+        def digest(self) -> bytes:
+            from trezor import log
+            from ubinascii import hexlify
+
+            digest = self.ctx.digest()
+            log.debug(
+                __name__,
+                "%s hash: %s, data: %s",
+                self.ctx.__class__.__name__,
+                hexlify(digest).decode(),
+                self.data,
+            )
+            return digest
+
+
 class HashWriter:
     def __init__(self, ctx: HashContext) -> None:
         self.ctx = ctx


### PR DESCRIPTION
This PR adds a simple tool to help debugging issues which involve incorrect digests being computed. The wrapper allows the developer to log what data the Trezor is hashing when computing the digest.

I don't know whether `utils.py` is the best place for this. I put it there, because `HashContext` and `HashWriter` are defined there. Possible alternatives:
1. Split off these hashing-related classes, including the new wrapper, into a separate file.
2. Introduce a file with debugging tools. There is `apps/debug/__init__.py`, but I think that's for handling debuglink messages.