### PR TITLE
core: fix stack overflow when displaying passphrase keyboard

### DIFF
--- a/core/embed/rust/build.rs
+++ b/core/embed/rust/build.rs
@@ -289,7 +289,6 @@ fn generate_trezorhal_bindings() {
         .allowlist_function("display_bar_radius")
         .allowlist_function("display_bar_radius_buffer")
         .allowlist_function("display_image")
-        .allowlist_function("display_toif_info")
         .allowlist_function("display_loader")
         .allowlist_function("display_pixeldata")
         .allowlist_function("display_pixeldata_dirty")

--- a/core/embed/rust/src/trezorhal/display.rs
+++ b/core/embed/rust/src/trezorhal/display.rs
@@ -1,7 +1,6 @@
 use super::ffi;
 use core::ptr;
 use cty::c_int;
-use num_traits::FromPrimitive;
 
 use crate::trezorhal::buffers::BufferText;
 
@@ -11,12 +10,6 @@ pub enum ToifFormat {
     GrayScaleOH = ffi::toif_format_t_TOIF_GRAYSCALE_OH as _,
     FullColorLE = ffi::toif_format_t_TOIF_FULL_COLOR_LE as _,
     GrayScaleEH = ffi::toif_format_t_TOIF_GRAYSCALE_EH as _,
-}
-
-pub struct ToifInfo {
-    pub width: u16,
-    pub height: u16,
-    pub format: ToifFormat,
 }
 
 pub fn backlight(val: i32) -> i32 {
@@ -113,31 +106,6 @@ pub fn image(x: i16, y: i16, w: i16, h: i16, data: &[u8]) {
             data.as_ptr() as _,
             data.len() as _,
         )
-    }
-}
-
-pub fn toif_info(data: &[u8]) -> Result<ToifInfo, ()> {
-    let mut width: cty::uint16_t = 0;
-    let mut height: cty::uint16_t = 0;
-    let mut format: ffi::toif_format_t = ffi::toif_format_t_TOIF_FULL_COLOR_BE;
-    if unsafe {
-        ffi::display_toif_info(
-            data.as_ptr() as _,
-            data.len() as _,
-            &mut width,
-            &mut height,
-            &mut format,
-        )
-    } {
-        let format = ToifFormat::from_usize(format as usize).unwrap_or(ToifFormat::FullColorBE);
-
-        Ok(ToifInfo {
-            width,
-            height,
-            format,
-        })
-    } else {
-        Err(())
     }
 }
 

--- a/core/embed/rust/src/ui/component/image.rs
+++ b/core/embed/rust/src/ui/component/image.rs
@@ -3,10 +3,7 @@ use crate::{
     ui::{
         component::{Component, Event, EventCtx, Never},
         display,
-        display::{
-            toif::{NamedToif, Toif},
-            Color, Icon,
-        },
+        display::{toif::Toif, Color, Icon},
         geometry::{Alignment2D, Offset, Point, Rect, CENTER},
     },
 };
@@ -18,9 +15,9 @@ pub struct Image {
 }
 
 impl Image {
-    pub fn new(named_toif: NamedToif) -> Self {
-        let toif = Toif::new(named_toif);
-        ensure!(toif.format == ToifFormat::FullColorLE, toif.name);
+    pub fn new(data: &'static [u8]) -> Self {
+        let toif = Toif::new(data);
+        assert!(toif.format == ToifFormat::FullColorLE);
         Self {
             toif,
             area: Rect::zero(),

--- a/core/embed/rust/src/ui/component/image.rs
+++ b/core/embed/rust/src/ui/component/image.rs
@@ -16,8 +16,8 @@ pub struct Image {
 
 impl Image {
     pub fn new(data: &'static [u8]) -> Self {
-        let toif = Toif::new(data);
-        assert!(toif.format == ToifFormat::FullColorLE);
+        let toif = unwrap!(Toif::new(data));
+        assert!(toif.format() == ToifFormat::FullColorLE);
         Self {
             toif,
             area: Rect::zero(),
@@ -27,8 +27,8 @@ impl Image {
     /// Display the icon with baseline Point, aligned according to the
     /// `alignment` argument.
     pub fn draw(&self, baseline: Point, alignment: Alignment2D) {
-        let r = Rect::snap(baseline, self.toif.size, alignment);
-        image(r.x0, r.y0, r.width(), r.height(), self.toif.data);
+        let r = Rect::snap(baseline, self.toif.size(), alignment);
+        image(r.x0, r.y0, r.width(), r.height(), self.toif.zdata());
     }
 }
 
@@ -51,7 +51,7 @@ impl Component for Image {
     fn bounds(&self, sink: &mut dyn FnMut(Rect)) {
         sink(Rect::from_center_and_size(
             self.area.center(),
-            self.toif.size,
+            self.toif.size(),
         ));
     }
 }
@@ -101,12 +101,12 @@ impl Component for BlendedImage {
     type Msg = Never;
 
     fn place(&mut self, bounds: Rect) -> Rect {
-        self.bg_top_left = self.bg.toif.size.snap(bounds.center(), CENTER);
+        self.bg_top_left = self.bg.toif.size().snap(bounds.center(), CENTER);
 
-        let ft_top_left = self.fg.toif.size.snap(bounds.center(), CENTER);
+        let ft_top_left = self.fg.toif.size().snap(bounds.center(), CENTER);
         self.fg_offset = ft_top_left - self.bg_top_left;
 
-        Rect::from_top_left_and_size(self.bg_top_left, self.bg.toif.size)
+        Rect::from_top_left_and_size(self.bg_top_left, self.bg.toif.size())
     }
 
     fn event(&mut self, _ctx: &mut EventCtx, _event: Event) -> Option<Self::Msg> {
@@ -120,7 +120,7 @@ impl Component for BlendedImage {
     fn bounds(&self, sink: &mut dyn FnMut(Rect)) {
         sink(Rect::from_top_left_and_size(
             self.bg_top_left,
-            self.bg.toif.size,
+            self.bg.toif.size(),
         ));
     }
 }

--- a/core/embed/rust/src/ui/display/loader.rs
+++ b/core/embed/rust/src/ui/display/loader.rs
@@ -43,10 +43,11 @@ pub fn loader_uncompress(
     const ICON_MAX_SIZE: i16 = constant::LOADER_ICON_MAX_SIZE;
 
     if let Some((icon, color)) = icon {
-        if icon.toif.width() <= ICON_MAX_SIZE && icon.toif.height() <= ICON_MAX_SIZE {
+        let toif_size = icon.toif.size();
+        if toif_size.x <= ICON_MAX_SIZE && toif_size.y <= ICON_MAX_SIZE {
             let mut icon_data = [0_u8; ((ICON_MAX_SIZE * ICON_MAX_SIZE) / 2) as usize];
             icon.toif.uncompress(&mut icon_data);
-            let i = Some((icon, color, icon.toif.size));
+            let i = Some((icon, color, toif_size));
             loader_rust(y_offset, fg_color, bg_color, progress, indeterminate, i);
         } else {
             loader_rust(y_offset, fg_color, bg_color, progress, indeterminate, None);
@@ -237,7 +238,7 @@ pub fn loader_rust(
                     let x_i = x_c - icon_area.x0;
                     let y_i = y_c - icon_area.y0;
 
-                    let data = unwrap!(icon_data).data()
+                    let data = unwrap!(icon_data).zdata()
                         [(((x_i & 0xFE) + (y_i * icon_width)) / 2) as usize];
                     if (x_i & 0x01) == 0 {
                         underlying_color = icon_colortable[(data & 0xF) as usize];
@@ -337,7 +338,7 @@ pub fn loader_rust(
 
             icon_buffer_used.buffer[icon_offset as usize..(icon_offset + icon_width / 2) as usize]
                 .copy_from_slice(
-                    &unwrap!(icon_data).toif.data[(y_i * (icon_width / 2)) as usize
+                    &unwrap!(icon_data).toif.zdata()[(y_i * (icon_width / 2)) as usize
                         ..((y_i + 1) * (icon_width / 2)) as usize],
                 );
             icon_buffer = icon_buffer_used;

--- a/core/embed/rust/src/ui/display/loader.rs
+++ b/core/embed/rust/src/ui/display/loader.rs
@@ -13,7 +13,7 @@ use crate::trezorhal::{
 
 use crate::ui::{
     constant::{screen, LOADER_OUTER},
-    display::toif::{Icon, NamedToif},
+    display::toif::Icon,
 };
 
 pub const LOADER_MIN: u16 = 0;
@@ -73,7 +73,7 @@ pub extern "C" fn loader_uncompress_r(
 
     let i = if icon_data != 0 {
         let data_slice = unsafe { from_raw_parts(icon_data as _, icon_data_size as _) };
-        Some((Icon::new(NamedToif(data_slice, "loader icon")), ic_color))
+        Some((Icon::new(data_slice), ic_color))
     } else {
         None
     };

--- a/core/embed/rust/src/ui/display/mod.rs
+++ b/core/embed/rust/src/ui/display/mod.rs
@@ -24,11 +24,10 @@ use crate::{
     error::Error,
     time::Duration,
     trezorhal::{display, qr, time, uzlib::UzlibContext},
-    ui::lerp::Lerp,
+    ui::{component::image::Image, lerp::Lerp},
 };
 use core::slice;
 
-use crate::ui::component::image::Image;
 pub use crate::ui::display::toif::Icon;
 #[cfg(any(feature = "model_tt", feature = "model_tr"))]
 pub use loader::{loader, loader_indeterminate, LOADER_MAX, LOADER_MIN};
@@ -228,8 +227,9 @@ pub fn rect_rounded2_partial(
     let mut icon_width = 0;
 
     if let Some((icon, icon_color)) = icon {
-        if icon.toif.width() <= MAX_ICON_SIZE && icon.toif.height() <= MAX_ICON_SIZE {
-            icon_area = Rect::from_center_and_size(center, icon.toif.size);
+        let icon_size = icon.toif.size();
+        if icon_size.x <= MAX_ICON_SIZE && icon_size.y <= MAX_ICON_SIZE {
+            icon_area = Rect::from_center_and_size(center, icon_size);
             icon_area_clamped = icon_area.clamp(constant::screen());
             icon.toif.uncompress(&mut icon_data);
             icon_colortable = get_color_table(icon_color, bg_color);
@@ -461,10 +461,10 @@ pub fn text_over_image(
         empty_img.buffer.copy_from_slice(&img1.buffer);
 
         area = a;
-        r_img = Rect::from_top_left_and_size(a.top_left() + offset_img, image.toif.size);
+        r_img = Rect::from_top_left_and_size(a.top_left() + offset_img, image.toif.size());
         offset_img_final = offset_img;
     } else {
-        area = Rect::from_top_left_and_size(offset_img.into(), image.toif.size);
+        area = Rect::from_top_left_and_size(offset_img.into(), image.toif.size());
         r_img = area;
         offset_img_final = Offset::zero();
     }
@@ -583,26 +583,26 @@ pub fn icon_over_icon(
     let final_offset_bg;
     if let Some(a) = bg_area {
         area = a;
-        r_bg = Rect::from_top_left_and_size(a.top_left() + offset_bg, icon_bg.toif.size);
+        r_bg = Rect::from_top_left_and_size(a.top_left() + offset_bg, icon_bg.toif.size());
         final_offset_bg = offset_bg;
     } else {
         r_bg =
-            Rect::from_top_left_and_size(Point::new(offset_bg.x, offset_bg.y), icon_bg.toif.size);
+            Rect::from_top_left_and_size(Point::new(offset_bg.x, offset_bg.y), icon_bg.toif.size());
         area = r_bg;
         final_offset_bg = Offset::zero();
     }
 
-    let r_fg = Rect::from_top_left_and_size(area.top_left() + offset_fg, icon_fg.toif.size);
+    let r_fg = Rect::from_top_left_and_size(area.top_left() + offset_fg, icon_fg.toif.size());
 
     let clamped = area.clamp(constant::screen()).ensure_even_width();
 
     set_window(clamped);
 
     let mut window_bg = [0; UZLIB_WINDOW_SIZE];
-    let mut ctx_bg = UzlibContext::new(icon_bg.toif.data, Some(&mut window_bg));
+    let mut ctx_bg = UzlibContext::new(icon_bg.toif.zdata(), Some(&mut window_bg));
 
     let mut window_fg = [0; UZLIB_WINDOW_SIZE];
-    let mut ctx_fg = UzlibContext::new(icon_fg.toif.data, Some(&mut window_fg));
+    let mut ctx_fg = UzlibContext::new(icon_fg.toif.zdata(), Some(&mut window_fg));
 
     dma2d_setup_4bpp_over_4bpp(color_icon_bg.into(), bg_color.into(), color_icon_fg.into());
 

--- a/core/embed/rust/src/ui/model_tt/component/fido_icons.rs
+++ b/core/embed/rust/src/ui/model_tt/component/fido_icons.rs
@@ -2,45 +2,43 @@
 //! (by running `make templates` in `core`)
 //! do not edit manually!
 
-use crate::ui::display::toif::NamedToif;
 
-
-const ICON_AWS: NamedToif = NamedToif(include_res!("model_tt/res/fido/icon_aws.toif"), "AWS");
-const ICON_BINANCE: NamedToif = NamedToif(include_res!("model_tt/res/fido/icon_binance.toif"), "BINANCE");
-const ICON_BITBUCKET: NamedToif = NamedToif(include_res!("model_tt/res/fido/icon_bitbucket.toif"), "BITBUCKET");
-const ICON_BITFINEX: NamedToif = NamedToif(include_res!("model_tt/res/fido/icon_bitfinex.toif"), "BITFINEX");
-const ICON_BITWARDEN: NamedToif = NamedToif(include_res!("model_tt/res/fido/icon_bitwarden.toif"), "BITWARDEN");
-const ICON_CLOUDFLARE: NamedToif = NamedToif(include_res!("model_tt/res/fido/icon_cloudflare.toif"), "CLOUDFLARE");
-const ICON_COINBASE: NamedToif = NamedToif(include_res!("model_tt/res/fido/icon_coinbase.toif"), "COINBASE");
-const ICON_DASHLANE: NamedToif = NamedToif(include_res!("model_tt/res/fido/icon_dashlane.toif"), "DASHLANE");
-const ICON_DROPBOX: NamedToif = NamedToif(include_res!("model_tt/res/fido/icon_dropbox.toif"), "DROPBOX");
-const ICON_DUO: NamedToif = NamedToif(include_res!("model_tt/res/fido/icon_duo.toif"), "DUO");
-const ICON_FACEBOOK: NamedToif = NamedToif(include_res!("model_tt/res/fido/icon_facebook.toif"), "FACEBOOK");
-const ICON_FASTMAIL: NamedToif = NamedToif(include_res!("model_tt/res/fido/icon_fastmail.toif"), "FASTMAIL");
-const ICON_FEDORA: NamedToif = NamedToif(include_res!("model_tt/res/fido/icon_fedora.toif"), "FEDORA");
-const ICON_GANDI: NamedToif = NamedToif(include_res!("model_tt/res/fido/icon_gandi.toif"), "GANDI");
-const ICON_GEMINI: NamedToif = NamedToif(include_res!("model_tt/res/fido/icon_gemini.toif"), "GEMINI");
-const ICON_GITHUB: NamedToif = NamedToif(include_res!("model_tt/res/fido/icon_github.toif"), "GITHUB");
-const ICON_GITLAB: NamedToif = NamedToif(include_res!("model_tt/res/fido/icon_gitlab.toif"), "GITLAB");
-const ICON_GOOGLE: NamedToif = NamedToif(include_res!("model_tt/res/fido/icon_google.toif"), "GOOGLE");
-const ICON_INVITY: NamedToif = NamedToif(include_res!("model_tt/res/fido/icon_invity.toif"), "INVITY");
-const ICON_KEEPER: NamedToif = NamedToif(include_res!("model_tt/res/fido/icon_keeper.toif"), "KEEPER");
-const ICON_KRAKEN: NamedToif = NamedToif(include_res!("model_tt/res/fido/icon_kraken.toif"), "KRAKEN");
-const ICON_LOGIN_GOV: NamedToif = NamedToif(include_res!("model_tt/res/fido/icon_login.gov.toif"), "LOGIN_GOV");
-const ICON_MICROSOFT: NamedToif = NamedToif(include_res!("model_tt/res/fido/icon_microsoft.toif"), "MICROSOFT");
-const ICON_MOJEID: NamedToif = NamedToif(include_res!("model_tt/res/fido/icon_mojeid.toif"), "MOJEID");
-const ICON_NAMECHEAP: NamedToif = NamedToif(include_res!("model_tt/res/fido/icon_namecheap.toif"), "NAMECHEAP");
-const ICON_PROTON: NamedToif = NamedToif(include_res!("model_tt/res/fido/icon_proton.toif"), "PROTON");
-const ICON_SLUSHPOOL: NamedToif = NamedToif(include_res!("model_tt/res/fido/icon_slushpool.toif"), "SLUSHPOOL");
-const ICON_STRIPE: NamedToif = NamedToif(include_res!("model_tt/res/fido/icon_stripe.toif"), "STRIPE");
-const ICON_TUTANOTA: NamedToif = NamedToif(include_res!("model_tt/res/fido/icon_tutanota.toif"), "TUTANOTA");
+const ICON_AWS: &[u8] = include_res!("model_tt/res/fido/icon_aws.toif");
+const ICON_BINANCE: &[u8] = include_res!("model_tt/res/fido/icon_binance.toif");
+const ICON_BITBUCKET: &[u8] = include_res!("model_tt/res/fido/icon_bitbucket.toif");
+const ICON_BITFINEX: &[u8] = include_res!("model_tt/res/fido/icon_bitfinex.toif");
+const ICON_BITWARDEN: &[u8] = include_res!("model_tt/res/fido/icon_bitwarden.toif");
+const ICON_CLOUDFLARE: &[u8] = include_res!("model_tt/res/fido/icon_cloudflare.toif");
+const ICON_COINBASE: &[u8] = include_res!("model_tt/res/fido/icon_coinbase.toif");
+const ICON_DASHLANE: &[u8] = include_res!("model_tt/res/fido/icon_dashlane.toif");
+const ICON_DROPBOX: &[u8] = include_res!("model_tt/res/fido/icon_dropbox.toif");
+const ICON_DUO: &[u8] = include_res!("model_tt/res/fido/icon_duo.toif");
+const ICON_FACEBOOK: &[u8] = include_res!("model_tt/res/fido/icon_facebook.toif");
+const ICON_FASTMAIL: &[u8] = include_res!("model_tt/res/fido/icon_fastmail.toif");
+const ICON_FEDORA: &[u8] = include_res!("model_tt/res/fido/icon_fedora.toif");
+const ICON_GANDI: &[u8] = include_res!("model_tt/res/fido/icon_gandi.toif");
+const ICON_GEMINI: &[u8] = include_res!("model_tt/res/fido/icon_gemini.toif");
+const ICON_GITHUB: &[u8] = include_res!("model_tt/res/fido/icon_github.toif");
+const ICON_GITLAB: &[u8] = include_res!("model_tt/res/fido/icon_gitlab.toif");
+const ICON_GOOGLE: &[u8] = include_res!("model_tt/res/fido/icon_google.toif");
+const ICON_INVITY: &[u8] = include_res!("model_tt/res/fido/icon_invity.toif");
+const ICON_KEEPER: &[u8] = include_res!("model_tt/res/fido/icon_keeper.toif");
+const ICON_KRAKEN: &[u8] = include_res!("model_tt/res/fido/icon_kraken.toif");
+const ICON_LOGIN_GOV: &[u8] = include_res!("model_tt/res/fido/icon_login.gov.toif");
+const ICON_MICROSOFT: &[u8] = include_res!("model_tt/res/fido/icon_microsoft.toif");
+const ICON_MOJEID: &[u8] = include_res!("model_tt/res/fido/icon_mojeid.toif");
+const ICON_NAMECHEAP: &[u8] = include_res!("model_tt/res/fido/icon_namecheap.toif");
+const ICON_PROTON: &[u8] = include_res!("model_tt/res/fido/icon_proton.toif");
+const ICON_SLUSHPOOL: &[u8] = include_res!("model_tt/res/fido/icon_slushpool.toif");
+const ICON_STRIPE: &[u8] = include_res!("model_tt/res/fido/icon_stripe.toif");
+const ICON_TUTANOTA: &[u8] = include_res!("model_tt/res/fido/icon_tutanota.toif");
 /// Default icon when app does not have its own
-const ICON_WEBAUTHN: NamedToif = NamedToif(include_res!("model_tt/res/fido/icon_webauthn.toif"), "WEBAUTHN");
+const ICON_WEBAUTHN: &[u8] = include_res!("model_tt/res/fido/icon_webauthn.toif");
 
 /// Translates icon name into its data.
 /// Returns default `ICON_WEBAUTHN` when the icon is not found or name not
 /// supplied.
-pub fn get_fido_icon_data<T: AsRef<str>>(icon_name: Option<T>) -> NamedToif {
+pub fn get_fido_icon_data<T: AsRef<str>>(icon_name: Option<T>) -> &'static [u8] {
     if let Some(icon_name) = icon_name {
         match icon_name.as_ref() {
             "aws" => ICON_AWS,

--- a/core/embed/rust/src/ui/model_tt/component/fido_icons.rs.mako
+++ b/core/embed/rust/src/ui/model_tt/component/fido_icons.rs.mako
@@ -2,8 +2,6 @@
 //! (by running `make templates` in `core`)
 //! do not edit manually!
 
-use crate::ui::display::toif::NamedToif;
-
 <%
 icons: list[tuple[str, str]] = []
 for app in fido:
@@ -15,15 +13,15 @@ for app in fido:
 %>\
 
 % for icon_name, var_name in icons:
-const ICON_${var_name}: NamedToif = NamedToif(include_res!("model_tt/res/fido/icon_${icon_name}.toif"), "${var_name}");
+const ICON_${var_name}: &[u8] = include_res!("model_tt/res/fido/icon_${icon_name}.toif");
 % endfor
 /// Default icon when app does not have its own
-const ICON_WEBAUTHN: NamedToif = NamedToif(include_res!("model_tt/res/fido/icon_webauthn.toif"), "WEBAUTHN");
+const ICON_WEBAUTHN: &[u8] = include_res!("model_tt/res/fido/icon_webauthn.toif");
 
 /// Translates icon name into its data.
 /// Returns default `ICON_WEBAUTHN` when the icon is not found or name not
 /// supplied.
-pub fn get_fido_icon_data<T: AsRef<str>>(icon_name: Option<T>) -> NamedToif {
+pub fn get_fido_icon_data<T: AsRef<str>>(icon_name: Option<T>) -> &'static [u8] {
     if let Some(icon_name) = icon_name {
         match icon_name.as_ref() {
 % for icon_name, var_name in icons:

--- a/core/embed/rust/src/ui/model_tt/component/homescreen/render.rs
+++ b/core/embed/rust/src/ui/model_tt/component/homescreen/render.rs
@@ -131,10 +131,11 @@ fn homescreen_position_text(
     let text_width_clamped = text_width.clamp(0, screen().width());
 
     let icon_size = if let Some(icon) = text.icon {
-        assert!(icon.toif.width() <= HOMESCREEN_MAX_ICON_SIZE);
-        assert!(icon.toif.height() <= HOMESCREEN_MAX_ICON_SIZE);
+        let size = icon.toif.size();
+        assert!(size.x <= HOMESCREEN_MAX_ICON_SIZE);
+        assert!(size.y <= HOMESCREEN_MAX_ICON_SIZE);
         icon.toif.uncompress(icon_buffer);
-        icon.toif.size
+        size
     } else {
         Offset::zero()
     };

--- a/core/embed/rust/src/ui/model_tt/theme.rs
+++ b/core/embed/rust/src/ui/model_tt/theme.rs
@@ -12,7 +12,6 @@ use crate::{
 
 use super::component::{ButtonStyle, ButtonStyleSheet, LoaderStyle, LoaderStyleSheet};
 
-use crate::ui::display::toif::NamedToif;
 use num_traits::FromPrimitive;
 
 pub const ERASE_HOLD_DURATION: Duration = Duration::from_millis(1500);
@@ -53,67 +52,41 @@ pub const QR_SIDE_MAX: u32 = 140;
 pub const ICON_SIZE: i16 = 16;
 
 // UI icons (greyscale).
-pub const ICON_CANCEL: NamedToif = NamedToif(include_res!("model_tt/res/cancel.toif"), "cancel");
-pub const ICON_CONFIRM: NamedToif = NamedToif(include_res!("model_tt/res/confirm.toif"), "confirm");
-pub const ICON_SPACE: NamedToif = NamedToif(include_res!("model_tt/res/space.toif"), "space");
-pub const ICON_BACK: NamedToif = NamedToif(include_res!("model_tt/res/back.toif"), "back");
-pub const ICON_CLICK: NamedToif = NamedToif(include_res!("model_tt/res/click.toif"), "click");
-pub const ICON_NEXT: NamedToif = NamedToif(include_res!("model_tt/res/next.toif"), "next");
-pub const ICON_WARN: NamedToif = NamedToif(include_res!("model_tt/res/warn-icon.toif"), "warn");
-pub const ICON_MAGIC: NamedToif = NamedToif(include_res!("model_tt/res/magic.toif"), "magic");
-pub const ICON_LIST_CURRENT: NamedToif =
-    NamedToif(include_res!("model_tt/res/current.toif"), "current");
-pub const ICON_LIST_CHECK: NamedToif = NamedToif(include_res!("model_tt/res/check.toif"), "check");
-pub const ICON_LOCK: NamedToif = NamedToif(include_res!("model_tt/res/lock.toif"), "lock");
+pub const ICON_CANCEL: &[u8] = include_res!("model_tt/res/cancel.toif");
+pub const ICON_CONFIRM: &[u8] = include_res!("model_tt/res/confirm.toif");
+pub const ICON_SPACE: &[u8] = include_res!("model_tt/res/space.toif");
+pub const ICON_BACK: &[u8] = include_res!("model_tt/res/back.toif");
+pub const ICON_CLICK: &[u8] = include_res!("model_tt/res/click.toif");
+pub const ICON_NEXT: &[u8] = include_res!("model_tt/res/next.toif");
+pub const ICON_WARN: &[u8] = include_res!("model_tt/res/warn-icon.toif");
+pub const ICON_MAGIC: &[u8] = include_res!("model_tt/res/magic.toif");
+pub const ICON_LIST_CURRENT: &[u8] = include_res!("model_tt/res/current.toif");
+pub const ICON_LIST_CHECK: &[u8] = include_res!("model_tt/res/check.toif");
+pub const ICON_LOCK: &[u8] = include_res!("model_tt/res/lock.toif");
 
 // Large, three-color icons.
 pub const WARN_COLOR: Color = YELLOW;
 pub const INFO_COLOR: Color = BLUE;
 pub const SUCCESS_COLOR: Color = GREEN;
 pub const ERROR_COLOR: Color = RED;
-pub const IMAGE_FG_WARN: NamedToif =
-    NamedToif(include_res!("model_tt/res/warn_fg.toif"), "warn_fg");
-pub const IMAGE_FG_SUCCESS: NamedToif =
-    NamedToif(include_res!("model_tt/res/success_fg.toif"), "success_fg");
-pub const IMAGE_FG_ERROR: NamedToif =
-    NamedToif(include_res!("model_tt/res/error_fg.toif"), "error_fg");
-pub const IMAGE_FG_INFO: NamedToif =
-    NamedToif(include_res!("model_tt/res/info_fg.toif"), "info_fg");
-pub const IMAGE_BG_CIRCLE: NamedToif =
-    NamedToif(include_res!("model_tt/res/circle.toif"), "circle");
-pub const IMAGE_BG_TRIANGLE: NamedToif =
-    NamedToif(include_res!("model_tt/res/triangle.toif"), "triangle");
-pub const IMAGE_BG_BACK_BTN: NamedToif =
-    NamedToif(include_res!("model_tt/res/back_btn.toif"), "back_btn");
-pub const IMAGE_BG_BACK_BTN_TALL: NamedToif = NamedToif(
-    include_res!("model_tt/res/back_btn_tall.toif"),
-    "back_btn_tall",
-);
+pub const IMAGE_FG_WARN: &[u8] = include_res!("model_tt/res/warn_fg.toif");
+pub const IMAGE_FG_SUCCESS: &[u8] = include_res!("model_tt/res/success_fg.toif");
+pub const IMAGE_FG_ERROR: &[u8] = include_res!("model_tt/res/error_fg.toif");
+pub const IMAGE_FG_INFO: &[u8] = include_res!("model_tt/res/info_fg.toif");
+pub const IMAGE_BG_CIRCLE: &[u8] = include_res!("model_tt/res/circle.toif");
+pub const IMAGE_BG_TRIANGLE: &[u8] = include_res!("model_tt/res/triangle.toif");
+pub const IMAGE_BG_BACK_BTN: &[u8] = include_res!("model_tt/res/back_btn.toif");
+pub const IMAGE_BG_BACK_BTN_TALL: &[u8] = include_res!("model_tt/res/back_btn_tall.toif");
 
 // Default homescreen
 pub const IMAGE_HOMESCREEN: &[u8] = include_res!("model_tt/res/bg.jpg");
 
 // Scrollbar/PIN dots.
-pub const DOT_ACTIVE: NamedToif = NamedToif(
-    include_res!("model_tt/res/scroll-active.toif"),
-    "scroll-active",
-);
-pub const DOT_INACTIVE: NamedToif = NamedToif(
-    include_res!("model_tt/res/scroll-inactive.toif"),
-    "scroll-inactive",
-);
-pub const DOT_INACTIVE_HALF: NamedToif = NamedToif(
-    include_res!("model_tt/res/scroll-inactive-half.toif"),
-    "scroll-inactive-half",
-);
-pub const DOT_INACTIVE_QUARTER: NamedToif = NamedToif(
-    include_res!("model_tt/res/scroll-inactive-quarter.toif"),
-    "scroll-inactive-quarter",
-);
-pub const DOT_SMALL: NamedToif = NamedToif(
-    include_res!("model_tt/res/scroll-small.toif"),
-    "scroll-small",
-);
+pub const DOT_ACTIVE: &[u8] = include_res!("model_tt/res/scroll-active.toif");
+pub const DOT_INACTIVE: &[u8] = include_res!("model_tt/res/scroll-inactive.toif");
+pub const DOT_INACTIVE_HALF: &[u8] = include_res!("model_tt/res/scroll-inactive-half.toif");
+pub const DOT_INACTIVE_QUARTER: &[u8] = include_res!("model_tt/res/scroll-inactive-quarter.toif");
+pub const DOT_SMALL: &[u8] = include_res!("model_tt/res/scroll-small.toif");
 
 pub const fn label_default() -> TextStyle {
     TEXT_NORMAL


### PR DESCRIPTION
Fixes #2779, related to #2708.

Size of `PassphraseKeyboard`:
* original: 4340 B
* after 24bcb74: 3668 B
* after 3487811: 2996 B
* after 6a4d470: 956 B

Not implemented:
* placement new (=construct object directly on micropython heap): seems tricky at the moment, would probably be feasible with global allocator
* further refactoring of `Button`: it's possible to reduce memory usage even further but the gains are not as big but with more effort