### PR TITLE
ci(nix): don't use cached-nix-shell for arm builds and hw tests

### DIFF
--- a/ci/build.yml
+++ b/ci/build.yml
@@ -264,7 +264,7 @@ core unix frozen debug build arm:
   variables:
     PYOPT: "0"
   script:
-    - cached-nix-shell --run "poetry run make -C core build_unix_frozen"
+    - nix-shell --run "poetry run make -C core build_unix_frozen"
     - mv core/build/unix/trezor-emu-core core/build/unix/trezor-emu-core-arm
   artifacts:
     name: "$CI_JOB_NAME-$CI_COMMIT_SHORT_SHA"
@@ -447,7 +447,7 @@ legacy emu regular debug build arm:
     DEBUG_LINK: "1"
     EMULATOR: "1"
   script:
-    - cached-nix-shell --run "poetry run legacy/script/cibuild"
+    - nix-shell --run "poetry run legacy/script/cibuild"
     - mv legacy/firmware/trezor.elf  legacy/firmware/trezor-arm.elf
   artifacts:
     name: "$CI_JOB_NAME-$CI_COMMIT_SHORT_SHA"

--- a/ci/test-hw.yml
+++ b/ci/test-hw.yml
@@ -41,9 +41,9 @@ hardware core regular device test:
     - set -a
     - source hardware.cfg
     - set +a
-    - cached-nix-shell --run "cd ../.. && poetry install"
-    - cached-nix-shell --run "poetry run python bootstrap.py tt ../../firmware-T2*.bin | ts -s"
-    - cached-nix-shell --run "poetry run pytest ../../tests/device_tests | ts -s"
+    - nix-shell --run "cd ../.. && poetry install"
+    - nix-shell --run "poetry run python bootstrap.py tt ../../firmware-T2*.bin | ts -s"
+    - nix-shell --run "poetry run pytest ../../tests/device_tests | ts -s"
   timeout: 6h
   artifacts:
     name: "$CI_JOB_NAME-$CI_COMMIT_SHORT_SHA"
@@ -71,9 +71,9 @@ hardware core btconly device test:
     - set -a
     - source hardware.cfg
     - set +a
-    - cached-nix-shell --run "cd ../.. && poetry install"
-    - cached-nix-shell --run "poetry run python bootstrap.py tt ../../firmware-T2*.bin | ts -s"
-    - cached-nix-shell --run "poetry run pytest ../../tests/device_tests | ts -s"
+    - nix-shell --run "cd ../.. && poetry install"
+    - nix-shell --run "poetry run python bootstrap.py tt ../../firmware-T2*.bin | ts -s"
+    - nix-shell --run "poetry run pytest ../../tests/device_tests | ts -s"
   timeout: 4h
   artifacts:
     name: "$CI_JOB_NAME-$CI_COMMIT_SHORT_SHA"
@@ -98,9 +98,9 @@ hardware core monero test:
     - set -a
     - source hardware.cfg
     - set +a
-    - cached-nix-shell --run "cd ../.. && poetry install"
-    - cached-nix-shell --run "poetry run python bootstrap.py tt ../../firmware-T2*.bin | ts -s"
-    - cached-nix-shell --arg fullDeps true --run "cd ../../core/tests && ./run_tests_device_emu_monero.sh $TESTOPTS | ts -s"
+    - nix-shell --run "cd ../.. && poetry install"
+    - nix-shell --run "poetry run python bootstrap.py tt ../../firmware-T2*.bin | ts -s"
+    - nix-shell --arg fullDeps true --run "cd ../../core/tests && ./run_tests_device_emu_monero.sh $TESTOPTS | ts -s"
   timeout: 1h
   artifacts:
     name: "$CI_JOB_NAME-$CI_COMMIT_SHORT_SHA"
@@ -124,7 +124,7 @@ hardware legacy regular device test:
     - legacy fw regular debug build
   script:
     - cd ci/hardware_tests
-    - cached-nix-shell --run "./t1_hw_test.sh | ts -s"
+    - nix-shell --run "./t1_hw_test.sh | ts -s"
   timeout: 1h10m
   artifacts:
     name: "$CI_JOB_NAME-$CI_COMMIT_SHORT_SHA"
@@ -150,7 +150,7 @@ hardware legacy btconly device test:
     - legacy fw btconly debug build
   script:
     - cd ci/hardware_tests
-    - cached-nix-shell --run "./t1_hw_test.sh | ts -s"
+    - nix-shell --run "./t1_hw_test.sh | ts -s"
   artifacts:
     name: "$CI_JOB_NAME-$CI_COMMIT_SHORT_SHA"
     paths:


### PR DESCRIPTION
HW tests run outside docker so there's no cached-nix-shell and no cache from the env image. I suppose it's the same for ARM builds. Related to #2807 

https://gitlab.com/satoshilabs/trezor/trezor-firmware/-/pipelines/771825942