### PR TITLE
ci: run `connect test core` manually

### DIFF
--- a/ci/test.yml
+++ b/ci/test.yml
@@ -647,7 +647,7 @@ core unix memory profiler:
 connect test core:
   image: ghcr.io/trezor/trezor-user-env
   stage: test
-  allow_failure: true
+  when: manual
   tags:
     - runner-internal
   needs:


### PR DESCRIPTION
It has been failing for something like a year now? We deserve green pipelines