### PR TITLE
build: also deploy click-test fixtures

### DIFF
--- a/ci/deploy.yml
+++ b/ci/deploy.yml
@@ -234,6 +234,7 @@ ui tests fixtures deploy:
     GIT_SUBMODULE_STRATEGY: "none"
   before_script: []  # no poetry
   needs:
+    - core click test
     - core device test
     - legacy device test
   script:

--- a/docs/ci/jobs.md
+++ b/docs/ci/jobs.md
@@ -287,8 +287,8 @@ Consists of **13 jobs** below:
 
 ### [ui tests fixtures deploy](https://github.com/trezor/trezor-firmware/blob/master/ci/deploy.yml#L229)
 
-### [sync emulators to aws](https://github.com/trezor/trezor-firmware/blob/master/ci/deploy.yml#L251)
+### [sync emulators to aws](https://github.com/trezor/trezor-firmware/blob/master/ci/deploy.yml#L252)
 
-### [common sync](https://github.com/trezor/trezor-firmware/blob/master/ci/deploy.yml#L276)
+### [common sync](https://github.com/trezor/trezor-firmware/blob/master/ci/deploy.yml#L277)
 
 ---


### PR DESCRIPTION
the master diff was failing in #2799 because of missing fixtures on the server.

those are in fact not actually deployed because the deploy job was not requesting results from the clicktest job