### PR TITLE
ci: fix cached-nix-shell failure in hardware tests

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -19,6 +19,11 @@ variables:
 
   # No need for TLS because everything runs on the same machine
   DOCKER_TLS_CERTDIR: ""
+
+  # Hardware tests don't use docker so there's no benefit of prebuilt cache, however they
+  # still run the before_script from this file.
+  NIX_SHELL: "cached-nix-shell"
+
 stages:
   - environment
   - prebuild
@@ -29,10 +34,9 @@ stages:
 
 before_script:
   - . /nix/var/nix/profiles/default/etc/profile.d/nix-daemon.sh || true
-  - which cached-nix-shell > /dev/null || alias cached-nix-shell=nix-shell
-  - cached-nix-shell --run "poetry install --remove-untracked"
-  - export LEGACY_VERSION=$(cached-nix-shell --run "./tools/version.sh legacy/firmware/version.h")
-  - export CORE_VERSION=$(cached-nix-shell --run "./tools/version.sh core/embed/firmware/version.h")
+  - $NIX_SHELL --run "poetry install --remove-untracked"
+  - export LEGACY_VERSION=$($NIX_SHELL --run "./tools/version.sh legacy/firmware/version.h")
+  - export CORE_VERSION=$($NIX_SHELL --run "./tools/version.sh core/embed/firmware/version.h")
 
 include:
   - ci/environment.yml

--- a/ci/build.yml
+++ b/ci/build.yml
@@ -22,12 +22,12 @@ core fw regular build:
   <<: *gitlab_caching
   needs: []
   script:
-    - cached-nix-shell --run "poetry run make -C core build_boardloader"
-    - cached-nix-shell --run "poetry run make -C core build_bootloader"
-    - cached-nix-shell --run "poetry run make -C core build_bootloader_ci"
-    - cached-nix-shell --run "poetry run make -C core build_prodtest"
-    - cached-nix-shell --run "poetry run make -C core build_firmware"
-    - cached-nix-shell --run "poetry run make -C core sizecheck"
+    - $NIX_SHELL --run "poetry run make -C core build_boardloader"
+    - $NIX_SHELL --run "poetry run make -C core build_bootloader"
+    - $NIX_SHELL --run "poetry run make -C core build_bootloader_ci"
+    - $NIX_SHELL --run "poetry run make -C core build_prodtest"
+    - $NIX_SHELL --run "poetry run make -C core build_firmware"
+    - $NIX_SHELL --run "poetry run make -C core sizecheck"
     - cp core/build/firmware/firmware.bin firmware-T2T1-$CORE_VERSION-$CI_COMMIT_SHORT_SHA.bin
   artifacts:
     name: "$CI_JOB_NAME-$CI_COMMIT_SHORT_SHA"
@@ -43,7 +43,7 @@ core fw regular debug build:
   <<: *gitlab_caching
   needs: []
   script:
-    - cached-nix-shell --run "PYOPT=0 poetry run make -C core build_firmware"
+    - $NIX_SHELL --run "PYOPT=0 poetry run make -C core build_firmware"
     - cp core/build/firmware/firmware.bin firmware-T2T1-debug-$CORE_VERSION-$CI_COMMIT_SHORT_SHA.bin
   artifacts:
     name: "$CI_JOB_NAME-$CI_COMMIT_SHORT_SHA"
@@ -60,12 +60,12 @@ core fw regular production build:
   variables:
     PRODUCTION: "1"
   script:
-    - cached-nix-shell --run "poetry run make -C core build_boardloader"
-    - cached-nix-shell --run "poetry run make -C core build_bootloader"
-    - cached-nix-shell --run "poetry run make -C core build_bootloader_ci"
-    - cached-nix-shell --run "poetry run make -C core build_prodtest"
-    - cached-nix-shell --run "poetry run make -C core build_firmware"
-    - cached-nix-shell --run "poetry run make -C core sizecheck"
+    - $NIX_SHELL --run "poetry run make -C core build_boardloader"
+    - $NIX_SHELL --run "poetry run make -C core build_bootloader"
+    - $NIX_SHELL --run "poetry run make -C core build_bootloader_ci"
+    - $NIX_SHELL --run "poetry run make -C core build_prodtest"
+    - $NIX_SHELL --run "poetry run make -C core build_firmware"
+    - $NIX_SHELL --run "poetry run make -C core sizecheck"
     - cp core/build/firmware/firmware.bin firmware-T2T1-production-$CORE_VERSION-$CI_COMMIT_SHORT_SHA.bin
   artifacts:
     name: "$CI_JOB_NAME-$CI_COMMIT_SHORT_SHA"
@@ -81,9 +81,9 @@ core fw btconly build:
   variables:
     BITCOIN_ONLY: "1"
   script:
-    - cached-nix-shell --run "poetry run make -C core build_firmware"
+    - $NIX_SHELL --run "poetry run make -C core build_firmware"
     - mv core/build/firmware/firmware.bin core/build/firmware/firmware-bitcoinonly.bin
-    - cached-nix-shell --run "poetry run ./tools/check-bitcoin-only core/build/firmware/firmware-bitcoinonly.bin"
+    - $NIX_SHELL --run "poetry run ./tools/check-bitcoin-only core/build/firmware/firmware-bitcoinonly.bin"
     - cp core/build/firmware/firmware-bitcoinonly.bin firmware-T2T1-btconly-$CORE_VERSION-$CI_COMMIT_SHORT_SHA.bin
   artifacts:
     name: "$CI_JOB_NAME-$CI_COMMIT_SHORT_SHA"
@@ -99,7 +99,7 @@ core fw btconly debug build:
     BITCOIN_ONLY: "1"
     PYOPT: "0"
   script:
-    - cached-nix-shell --run "poetry run make -C core build_firmware"
+    - $NIX_SHELL --run "poetry run make -C core build_firmware"
     - cp core/build/firmware/firmware.bin firmware-T2T1-btconly-debug-$CORE_VERSION-$CI_COMMIT_SHORT_SHA.bin
   only:  # currently used only for HW tests and deploys
     - schedules  # nightly build
@@ -124,8 +124,8 @@ core fw btconly production build:
     PRODUCTION: "1"
     BITCOIN_ONLY: "1"
   script:
-    - cached-nix-shell --run "poetry run make -C core build_firmware"
-    - cached-nix-shell --run "poetry run ./tools/check-bitcoin-only core/build/firmware/firmware.bin"
+    - $NIX_SHELL --run "poetry run make -C core build_firmware"
+    - $NIX_SHELL --run "poetry run ./tools/check-bitcoin-only core/build/firmware/firmware.bin"
     - cp core/build/firmware/firmware.bin firmware-T2T1-btconly-production-$CORE_VERSION-$CI_COMMIT_SHORT_SHA.bin
   artifacts:
     name: "$CI_JOB_NAME-$CI_COMMIT_SHORT_SHA"
@@ -140,7 +140,7 @@ core unix regular build:
   <<: *gitlab_caching
   needs: []
   script:
-    - cached-nix-shell --run "poetry run make -C core build_unix"
+    - $NIX_SHELL --run "poetry run make -C core build_unix"
   artifacts:
     name: "$CI_JOB_NAME-$CI_COMMIT_SHORT_SHA"
     paths:
@@ -156,7 +156,7 @@ core unix regular asan build:
   variables:
     ADDRESS_SANITIZER: "1"
   script:
-    - cached-nix-shell --run "poetry run make -C core build_unix"
+    - $NIX_SHELL --run "poetry run make -C core build_unix"
   artifacts:
     name: "$CI_JOB_NAME-$CI_COMMIT_SHORT_SHA"
     paths:
@@ -171,7 +171,7 @@ core unix frozen regular build:
   <<: *gitlab_caching
   needs: []
   script:
-    - cached-nix-shell --run "poetry run make -C core build_unix_frozen"
+    - $NIX_SHELL --run "poetry run make -C core build_unix_frozen"
   artifacts:
     name: "$CI_JOB_NAME-$CI_COMMIT_SHORT_SHA"
     paths:
@@ -191,7 +191,7 @@ core unix frozen btconly debug build:
     PYOPT: "0"
     BITCOIN_ONLY: "1"
   script:
-    - cached-nix-shell --run "poetry run make -C core build_unix_frozen"
+    - $NIX_SHELL --run "poetry run make -C core build_unix_frozen"
     - mv core/build/unix/trezor-emu-core core/build/unix/trezor-emu-core-bitcoinonly
   artifacts:
     name: "$CI_JOB_NAME-$CI_COMMIT_SHORT_SHA"
@@ -210,7 +210,7 @@ core unix frozen btconly debug asan build:
     BITCOIN_ONLY: "1"
     ADDRESS_SANITIZER: "1"
   script:
-    - cached-nix-shell --run "poetry run make -C core build_unix_frozen"
+    - $NIX_SHELL --run "poetry run make -C core build_unix_frozen"
     - mv core/build/unix/trezor-emu-core core/build/unix/trezor-emu-core-bitcoinonly
   artifacts:
     name: "$CI_JOB_NAME-$CI_COMMIT_SHORT_SHA"
@@ -229,7 +229,7 @@ core unix frozen debug build:
   variables:
     PYOPT: "0"
   script:
-    - cached-nix-shell --run "poetry run make -C core build_unix_frozen"
+    - $NIX_SHELL --run "poetry run make -C core build_unix_frozen"
   artifacts:
     name: "$CI_JOB_NAME-$CI_COMMIT_SHORT_SHA"
     untracked: true
@@ -245,7 +245,7 @@ core unix frozen debug asan build:
     PYOPT: "0"
     ADDRESS_SANITIZER: "1"
   script:
-    - cached-nix-shell --run "poetry run make -C core build_unix_frozen"
+    - $NIX_SHELL --run "poetry run make -C core build_unix_frozen"
   artifacts:
     name: "$CI_JOB_NAME-$CI_COMMIT_SHORT_SHA"
     untracked: true
@@ -263,8 +263,9 @@ core unix frozen debug build arm:
     - /^secfix\//
   variables:
     PYOPT: "0"
+    NIX_SHELL: "nix-shell"
   script:
-    - nix-shell --run "poetry run make -C core build_unix_frozen"
+    - $NIX_SHELL --run "poetry run make -C core build_unix_frozen"
     - mv core/build/unix/trezor-emu-core core/build/unix/trezor-emu-core-arm
   artifacts:
     name: "$CI_JOB_NAME-$CI_COMMIT_SHORT_SHA"
@@ -281,7 +282,7 @@ core macos frozen regular build:
   tags:
     - darwin_arm
   script:
-    - cached-nix-shell --option system x86_64-darwin --run "poetry run make -C core build_unix_frozen"
+    - $NIX_SHELL --option system x86_64-darwin --run "poetry run make -C core build_unix_frozen"
     - export NAME="trezor-emu-core.darwin"
     - cp -v core/build/unix/trezor-emu-core ./$NAME
     - chmod +x $NAME
@@ -311,8 +312,8 @@ crypto build:
       - crypto/**
   script:
     - cp -r crypto crypto_noasan
-    - cached-nix-shell --run "poetry run make -C crypto"
-    - cached-nix-shell --run "export ADDRESS_SANITIZER=0; poetry run make -C crypto_noasan"
+    - $NIX_SHELL --run "poetry run make -C crypto"
+    - $NIX_SHELL --run "export ADDRESS_SANITIZER=0; poetry run make -C crypto_noasan"
     - mv crypto_noasan/tests/test_check crypto/tests/test_check_noasan
   artifacts:
     name: "$CI_JOB_NAME-$CI_COMMIT_SHORT_SHA"
@@ -332,10 +333,10 @@ legacy fw regular build:
   <<: *gitlab_caching
   needs: []
   script:
-    - cached-nix-shell --run "export PRODUCTION=1 && poetry run legacy/script/cibuild"
-    - cached-nix-shell --run "poetry run legacy/script/setup"
-    - cached-nix-shell --run "export PRODUCTION=0 && poetry run legacy/script/cibuild"
-    - cached-nix-shell --run "poetry run make -C legacy/demo"
+    - $NIX_SHELL --run "export PRODUCTION=1 && poetry run legacy/script/cibuild"
+    - $NIX_SHELL --run "poetry run legacy/script/setup"
+    - $NIX_SHELL --run "export PRODUCTION=0 && poetry run legacy/script/cibuild"
+    - $NIX_SHELL --run "poetry run make -C legacy/demo"
     - mv legacy/firmware/trezor.bin firmware-T1B1-$LEGACY_VERSION-$CI_COMMIT_SHORT_SHA.bin
   artifacts:
     name: "$CI_JOB_NAME-$CI_COMMIT_SHORT_SHA"
@@ -350,9 +351,9 @@ legacy fw regular debug build:
   variables:
     DEBUG_LINK: "1"
   script:
-    - cached-nix-shell --run "export PRODUCTION=1 && poetry run legacy/script/cibuild"
-    - cached-nix-shell --run "poetry run legacy/script/setup"
-    - cached-nix-shell --run "export PRODUCTION=0 && poetry run legacy/script/cibuild"
+    - $NIX_SHELL --run "export PRODUCTION=1 && poetry run legacy/script/cibuild"
+    - $NIX_SHELL --run "poetry run legacy/script/setup"
+    - $NIX_SHELL --run "export PRODUCTION=0 && poetry run legacy/script/cibuild"
     - mv legacy/firmware/trezor.bin firmware-T1B1-debug-$LEGACY_VERSION-$CI_COMMIT_SHORT_SHA.bin
   artifacts:
     name: "$CI_JOB_NAME-$CI_COMMIT_SHORT_SHA"
@@ -367,11 +368,11 @@ legacy fw btconly build:
   variables:
     BITCOIN_ONLY: "1"
   script:
-    - cached-nix-shell --run "export PRODUCTION=1 && poetry run legacy/script/cibuild"
-    - cached-nix-shell --run "poetry run legacy/script/setup"
-    - cached-nix-shell --run "export PRODUCTION=0 && poetry run legacy/script/cibuild"
+    - $NIX_SHELL --run "export PRODUCTION=1 && poetry run legacy/script/cibuild"
+    - $NIX_SHELL --run "poetry run legacy/script/setup"
+    - $NIX_SHELL --run "export PRODUCTION=0 && poetry run legacy/script/cibuild"
     - mv legacy/firmware/trezor.bin legacy/firmware/trezor-bitcoinonly.bin
-    - cached-nix-shell --run "poetry run ./tools/check-bitcoin-only legacy/firmware/trezor-bitcoinonly.bin"
+    - $NIX_SHELL --run "poetry run ./tools/check-bitcoin-only legacy/firmware/trezor-bitcoinonly.bin"
     - mv legacy/firmware/trezor-bitcoinonly.bin firmware-T1B1-btconly-$LEGACY_VERSION-$CI_COMMIT_SHORT_SHA.bin
   artifacts:
     name: "$CI_JOB_NAME-$CI_COMMIT_SHORT_SHA"
@@ -387,10 +388,10 @@ legacy fw btconly debug build:
     BITCOIN_ONLY: "1"
     DEBUG_LINK: "1"
   script:
-    - cached-nix-shell --run "export PRODUCTION=1 && poetry run legacy/script/cibuild"
-    - cached-nix-shell --run "poetry run legacy/script/setup"
-    - cached-nix-shell --run "export PRODUCTION=0 && poetry run legacy/script/cibuild"
-    - cached-nix-shell --run "poetry run ./tools/check-bitcoin-only legacy/firmware/trezor.bin"
+    - $NIX_SHELL --run "export PRODUCTION=1 && poetry run legacy/script/cibuild"
+    - $NIX_SHELL --run "poetry run legacy/script/setup"
+    - $NIX_SHELL --run "export PRODUCTION=0 && poetry run legacy/script/cibuild"
+    - $NIX_SHELL --run "poetry run ./tools/check-bitcoin-only legacy/firmware/trezor.bin"
     - mv legacy/firmware/trezor.bin firmware-T1B1-btconly-debug-$LEGACY_VERSION-$CI_COMMIT_SHORT_SHA.bin
   artifacts:
     name: "$CI_JOB_NAME-$CI_COMMIT_SHORT_SHA"
@@ -408,7 +409,7 @@ legacy emu regular debug build:
     DEBUG_LINK: "1"
     EMULATOR: "1"
   script:
-    - cached-nix-shell --run "poetry run legacy/script/cibuild"
+    - $NIX_SHELL --run "poetry run legacy/script/cibuild"
   artifacts:
     name: "$CI_JOB_NAME-$CI_COMMIT_SHORT_SHA"
     paths:
@@ -426,7 +427,7 @@ legacy emu regular debug asan build:
     EMULATOR: "1"
     ADDRESS_SANITIZER: "1"
   script:
-    - cached-nix-shell --run "poetry run legacy/script/cibuild"
+    - $NIX_SHELL --run "poetry run legacy/script/cibuild"
   artifacts:
     name: "$CI_JOB_NAME-$CI_COMMIT_SHORT_SHA"
     paths:
@@ -446,8 +447,9 @@ legacy emu regular debug build arm:
   variables:
     DEBUG_LINK: "1"
     EMULATOR: "1"
+    NIX_SHELL: "nix-shell"
   script:
-    - nix-shell --run "poetry run legacy/script/cibuild"
+    - $NIX_SHELL --run "poetry run legacy/script/cibuild"
     - mv legacy/firmware/trezor.elf  legacy/firmware/trezor-arm.elf
   artifacts:
     name: "$CI_JOB_NAME-$CI_COMMIT_SHORT_SHA"
@@ -468,7 +470,7 @@ legacy emu btconly debug build:
     DEBUG_LINK: "1"
     EMULATOR: "1"
   script:
-    - cached-nix-shell --run "poetry run legacy/script/cibuild"
+    - $NIX_SHELL --run "poetry run legacy/script/cibuild"
     - mv legacy/firmware/trezor.elf legacy/firmware/trezor-bitcoinonly.elf
   artifacts:
     name: "$CI_JOB_NAME-$CI_COMMIT_SHORT_SHA"
@@ -488,7 +490,7 @@ legacy emu btconly debug asan build:
     EMULATOR: "1"
     ADDRESS_SANITIZER: "1"
   script:
-    - cached-nix-shell --run "poetry run legacy/script/cibuild"
+    - $NIX_SHELL --run "poetry run legacy/script/cibuild"
     - mv legacy/firmware/trezor.elf legacy/firmware/trezor-bitcoinonly.elf
   artifacts:
     name: "$CI_JOB_NAME-$CI_COMMIT_SHORT_SHA"

--- a/ci/deploy.yml
+++ b/ci/deploy.yml
@@ -188,8 +188,8 @@ release core unix debug deploy:
     - DEST="$DEPLOY_PATH/trezor-emu-core-v$VERSION"
     - DEST_ARM="$DEPLOY_PATH/arm/trezor-emu-core-v$VERSION-arm"
     - echo "Deploying to $DEST and $DEST_ARM"
-    - cached-nix-shell -p patchelf --run "patchelf --set-interpreter /lib64/ld-linux-x86-64.so.2 core/build/unix/trezor-emu-core"
-    - cached-nix-shell -p patchelf --run "patchelf --set-interpreter /lib/ld-linux-aarch64.so.1 core/build/unix/trezor-emu-core-arm"
+    - $NIX_SHELL -p patchelf --run "patchelf --set-interpreter /lib64/ld-linux-x86-64.so.2 core/build/unix/trezor-emu-core"
+    - $NIX_SHELL -p patchelf --run "patchelf --set-interpreter /lib/ld-linux-aarch64.so.1 core/build/unix/trezor-emu-core-arm"
     - rsync --delete -va core/build/unix/trezor-emu-core "$DEST"
     - rsync --delete -va core/build/unix/trezor-emu-core-arm "$DEST_ARM"
   only:
@@ -213,8 +213,8 @@ release legacy unix debug deploy:
     - DEST="$DEPLOY_PATH/trezor-emu-legacy-v$VERSION"
     - DEST_ARM="$DEPLOY_PATH/arm/trezor-emu-legacy-v$VERSION-arm"
     - echo "Deploying to $DEST and $DEST_ARM"
-    - cached-nix-shell -p patchelf --run "patchelf --set-interpreter /lib64/ld-linux-x86-64.so.2 legacy/firmware/trezor.elf"
-    - cached-nix-shell -p patchelf --run "patchelf --set-interpreter /lib/ld-linux-aarch64.so.1 legacy/firmware/trezor-arm.elf"
+    - $NIX_SHELL -p patchelf --run "patchelf --set-interpreter /lib64/ld-linux-x86-64.so.2 legacy/firmware/trezor.elf"
+    - $NIX_SHELL -p patchelf --run "patchelf --set-interpreter /lib/ld-linux-aarch64.so.1 legacy/firmware/trezor-arm.elf"
     - rsync --delete -va legacy/firmware/trezor.elf "$DEST"
     - rsync --delete -va legacy/firmware/trezor-arm.elf "$DEST_ARM"
   only:

--- a/ci/posttest.yml
+++ b/ci/posttest.yml
@@ -19,7 +19,7 @@ core unix coverage posttest:
     - core u2f test
     - core fido2 test
   script:
-    - cached-nix-shell --run "poetry run make -C core coverage"
+    - $NIX_SHELL --run "poetry run make -C core coverage"
   coverage: '/COVERAGE: \d+%/'
   artifacts:
     name: core-unix-coverage-posttest
@@ -39,7 +39,7 @@ unix ui changes:
     - core device test
     - legacy device test
   script:
-    - cached-nix-shell --run "poetry run python -m tests.ui_tests.reporting master-diff"
+    - $NIX_SHELL --run "poetry run python -m tests.ui_tests.reporting master-diff"
     - mv tests/ui_tests/reports/master_diff .
   artifacts:
     name: core-unix-ui-changes

--- a/ci/prebuild.yml
+++ b/ci/prebuild.yml
@@ -42,13 +42,6 @@ editor prebuild:
   script:
     - $NIX_SHELL --run "make editor_check"
 
-# All .yml/.yaml files are checked for syntax validity and other correctness.
-yaml prebuild:
-  stage: prebuild
-  <<: *gitlab_caching
-  script:
-    - $NIX_SHELL --run "poetry run make yaml_check"
-
 # Checking the format of release commit messages.
 release commit messages prebuild:
   stage: prebuild

--- a/ci/prebuild.yml
+++ b/ci/prebuild.yml
@@ -19,35 +19,35 @@ style prebuild:
     GIT_SUBMODULE_STRATEGY: "none"
   <<: *gitlab_caching
   script:
-    - cached-nix-shell --run "poetry run make -j1 style_check"
+    - $NIX_SHELL --run "poetry run make -j1 style_check"
 
 # Check validity of coin definitions and protobuf files.
 common prebuild:
   stage: prebuild
   <<: *gitlab_caching
   script:
-    - cached-nix-shell --run "poetry run make defs_check"
+    - $NIX_SHELL --run "poetry run make defs_check"
 
 # Check validity of auto-generated files.
 gen prebuild:
   stage: prebuild
   <<: *gitlab_caching
   script:
-    - cached-nix-shell --run "poetry run make -j1 gen_check"
+    - $NIX_SHELL --run "poetry run make -j1 gen_check"
 
 # Checking format of .editorconfig files.
 editor prebuild:
   stage: prebuild
   <<: *gitlab_caching
   script:
-    - cached-nix-shell --run "make editor_check"
+    - $NIX_SHELL --run "make editor_check"
 
 # All .yml/.yaml files are checked for syntax validity and other correctness.
 yaml prebuild:
   stage: prebuild
   <<: *gitlab_caching
   script:
-    - cached-nix-shell --run "poetry run make yaml_check"
+    - $NIX_SHELL --run "poetry run make yaml_check"
 
 # Checking the format of release commit messages.
 release commit messages prebuild:
@@ -63,7 +63,7 @@ release commit messages prebuild:
       # We want this to run on gitlab.com/satoshilabs/trezor/trezor-firmware only.
       - $CI_PROJECT_PATH_SLUG == 'satoshilabs-trezor-trezor-firmware'
   script:
-    - cached-nix-shell --run "ci/check_release_commit_messages.sh"
+    - $NIX_SHELL --run "ci/check_release_commit_messages.sh"
 
 # Verifying that all commits changing some functionality have a changelog entry
 # or contain `[no changelog]` in the commit message.
@@ -76,4 +76,4 @@ changelog prebuild:
     GIT_SUBMODULE_STRATEGY: "none"
     GIT_STRATEGY: clone
   script:
-    - cached-nix-shell --run "ci/check_changelog.sh"
+    - $NIX_SHELL --run "ci/check_changelog.sh"

--- a/ci/test-hw.yml
+++ b/ci/test-hw.yml
@@ -36,14 +36,15 @@ hardware core regular device test:
     - core fw regular debug build
   variables:
     PYTEST_TIMEOUT: "1200"
+    NIX_SHELL: "nix-shell"
   script:
     - cd ci/hardware_tests
     - set -a
     - source hardware.cfg
     - set +a
-    - nix-shell --run "cd ../.. && poetry install"
-    - nix-shell --run "poetry run python bootstrap.py tt ../../firmware-T2*.bin | ts -s"
-    - nix-shell --run "poetry run pytest ../../tests/device_tests | ts -s"
+    - $NIX_SHELL --run "cd ../.. && poetry install"
+    - $NIX_SHELL --run "poetry run python bootstrap.py tt ../../firmware-T2*.bin | ts -s"
+    - $NIX_SHELL --run "poetry run pytest ../../tests/device_tests | ts -s"
   timeout: 6h
   artifacts:
     name: "$CI_JOB_NAME-$CI_COMMIT_SHORT_SHA"
@@ -66,14 +67,15 @@ hardware core btconly device test:
   variables:
     TREZOR_PYTEST_SKIP_ALTCOINS: 1
     PYTEST_TIMEOUT: "1200"
+    NIX_SHELL: "nix-shell"
   script:
     - cd ci/hardware_tests
     - set -a
     - source hardware.cfg
     - set +a
-    - nix-shell --run "cd ../.. && poetry install"
-    - nix-shell --run "poetry run python bootstrap.py tt ../../firmware-T2*.bin | ts -s"
-    - nix-shell --run "poetry run pytest ../../tests/device_tests | ts -s"
+    - $NIX_SHELL --run "cd ../.. && poetry install"
+    - $NIX_SHELL --run "poetry run python bootstrap.py tt ../../firmware-T2*.bin | ts -s"
+    - $NIX_SHELL --run "poetry run pytest ../../tests/device_tests | ts -s"
   timeout: 4h
   artifacts:
     name: "$CI_JOB_NAME-$CI_COMMIT_SHORT_SHA"
@@ -93,14 +95,15 @@ hardware core monero test:
     - core fw regular debug build
   variables:
     TESTOPTS: --trezor_path webusb
+    NIX_SHELL: "nix-shell"
   script:
     - cd ci/hardware_tests
     - set -a
     - source hardware.cfg
     - set +a
-    - nix-shell --run "cd ../.. && poetry install"
-    - nix-shell --run "poetry run python bootstrap.py tt ../../firmware-T2*.bin | ts -s"
-    - nix-shell --arg fullDeps true --run "cd ../../core/tests && ./run_tests_device_emu_monero.sh $TESTOPTS | ts -s"
+    - $NIX_SHELL --run "cd ../.. && poetry install"
+    - $NIX_SHELL --run "poetry run python bootstrap.py tt ../../firmware-T2*.bin | ts -s"
+    - $NIX_SHELL --arg fullDeps true --run "cd ../../core/tests && ./run_tests_device_emu_monero.sh $TESTOPTS | ts -s"
   timeout: 1h
   artifacts:
     name: "$CI_JOB_NAME-$CI_COMMIT_SHORT_SHA"
@@ -122,9 +125,11 @@ hardware legacy regular device test:
     - tpmb
   needs:
     - legacy fw regular debug build
+  variables:
+    NIX_SHELL: "nix-shell"
   script:
     - cd ci/hardware_tests
-    - nix-shell --run "./t1_hw_test.sh | ts -s"
+    - $NIX_SHELL --run "./t1_hw_test.sh | ts -s"
   timeout: 1h10m
   artifacts:
     name: "$CI_JOB_NAME-$CI_COMMIT_SHORT_SHA"
@@ -138,6 +143,7 @@ hardware legacy btconly device test:
   stage: test
   variables:
     TREZOR_PYTEST_SKIP_ALTCOINS: 1
+    NIX_SHELL: "nix-shell"
   only:
     - schedules  # nightly build
     - /^legacy\//
@@ -150,7 +156,7 @@ hardware legacy btconly device test:
     - legacy fw btconly debug build
   script:
     - cd ci/hardware_tests
-    - nix-shell --run "./t1_hw_test.sh | ts -s"
+    - $NIX_SHELL --run "./t1_hw_test.sh | ts -s"
   artifacts:
     name: "$CI_JOB_NAME-$CI_COMMIT_SHORT_SHA"
     paths:

--- a/ci/test.yml
+++ b/ci/test.yml
@@ -18,7 +18,7 @@ core unit python test:
   needs:
     - core unix regular build
   script:
-    - cached-nix-shell --run "poetry run make -C core test | ts -s"
+    - $NIX_SHELL --run "poetry run make -C core test | ts -s"
 
 # Rust unit tests.
 core unit rust test:
@@ -27,8 +27,8 @@ core unit rust test:
   needs:
     - core unix frozen debug build
   script:
-    - cached-nix-shell --run "poetry run make -C core clippy | ts -s"
-    - cached-nix-shell --run "poetry run make -C core test_rust | ts -s"
+    - $NIX_SHELL --run "poetry run make -C core clippy | ts -s"
+    - $NIX_SHELL --run "poetry run make -C core test_rust | ts -s"
 
 core unit asan test:
   stage: test
@@ -43,9 +43,9 @@ core unit asan test:
     ADDRESS_SANITIZER: "1"
     LSAN_OPTIONS: "suppressions=../../asan_suppressions.txt"
   script:
-    - cached-nix-shell --run "poetry run make -C core test | ts -s"
-    - cached-nix-shell --run "poetry run make -C core clean build_unix | ts -s"
-    - cached-nix-shell --run "poetry run make -C core test_rust | ts -s"
+    - $NIX_SHELL --run "poetry run make -C core test | ts -s"
+    - $NIX_SHELL --run "poetry run make -C core clean build_unix | ts -s"
+    - $NIX_SHELL --run "poetry run make -C core test_rust | ts -s"
 
 # Device tests for Core. Running device tests and also comparing screens
 # with the expected UI result.
@@ -59,11 +59,11 @@ core device test:
   variables:
     TREZOR_PROFILING: 1
   script:
-    - cached-nix-shell --run "poetry run make -C core test_emu_ui | ts -s"
+    - $NIX_SHELL --run "poetry run make -C core test_emu_ui | ts -s"
   after_script:
     - mv core/src/.coverage core/.coverage.test_emu
     - mv tests/ui_tests/reports/test/ test_ui_report
-    - cached-nix-shell --run "poetry run python ci/prepare_ui_artifacts.py | ts -s"
+    - $NIX_SHELL --run "poetry run python ci/prepare_ui_artifacts.py | ts -s"
     - diff -u tests/ui_tests/fixtures.json tests/ui_tests/fixtures.suggestion.json
   artifacts:
     name: "$CI_JOB_NAME-$CI_COMMIT_SHORT_SHA"
@@ -90,7 +90,7 @@ core device asan test:
   variables:
     PYTEST_TIMEOUT: "600"
   script:
-    - cached-nix-shell --run "poetry run make -C core test_emu | ts -s"
+    - $NIX_SHELL --run "poetry run make -C core test_emu | ts -s"
   artifacts:
     name: "$CI_JOB_NAME-$CI_COMMIT_SHORT_SHA"
     paths:
@@ -108,7 +108,7 @@ core btconly device test:
     MICROPYTHON: "build/unix/trezor-emu-core-bitcoinonly"
     TREZOR_PYTEST_SKIP_ALTCOINS: 1
   script:
-    - cached-nix-shell --run "poetry run make -C core test_emu | ts -s"
+    - $NIX_SHELL --run "poetry run make -C core test_emu | ts -s"
   artifacts:
     name: "$CI_JOB_NAME-$CI_COMMIT_SHORT_SHA"
     paths:
@@ -131,7 +131,7 @@ core btconly device asan test:
     TREZOR_PYTEST_SKIP_ALTCOINS: 1
     PYTEST_TIMEOUT: "600"
   script:
-    - cached-nix-shell --run "poetry run make -C core test_emu | ts -s"
+    - $NIX_SHELL --run "poetry run make -C core test_emu | ts -s"
   artifacts:
     name: "$CI_JOB_NAME-$CI_COMMIT_SHORT_SHA"
     paths:
@@ -148,7 +148,7 @@ core monero test:
   variables:
     TREZOR_PROFILING: 1
   script:
-    - cached-nix-shell --arg fullDeps true --run "poetry run make -C core test_emu_monero | ts -s"
+    - $NIX_SHELL --arg fullDeps true --run "poetry run make -C core test_emu_monero | ts -s"
     - mv core/src/.coverage core/.coverage.test_emu_monero
   artifacts:
     name: "$CI_JOB_NAME-$CI_COMMIT_SHORT_SHA"
@@ -169,7 +169,7 @@ core monero asan test:
   variables:
     TREZOR_PROFILING: 1
   script:
-    - cached-nix-shell --arg fullDeps true --run "poetry run make -C core test_emu_monero | ts -s"
+    - $NIX_SHELL --arg fullDeps true --run "poetry run make -C core test_emu_monero | ts -s"
     - mv core/src/.coverage core/.coverage.test_emu_monero
   artifacts:
     name: "$CI_JOB_NAME-$CI_COMMIT_SHORT_SHA"
@@ -189,8 +189,8 @@ core u2f test:
   variables:
     TREZOR_PROFILING: 1
   script:
-    - cached-nix-shell --run "poetry run make -C tests/fido_tests/u2f-tests-hid | ts -s"
-    - cached-nix-shell --run "poetry run make -C core test_emu_u2f | ts -s"
+    - $NIX_SHELL --run "poetry run make -C tests/fido_tests/u2f-tests-hid | ts -s"
+    - $NIX_SHELL --run "poetry run make -C core test_emu_u2f | ts -s"
     - mv core/src/.coverage core/.coverage.test_emu_u2f
   artifacts:
     name: "$CI_JOB_NAME-$CI_COMMIT_SHORT_SHA"
@@ -208,8 +208,8 @@ core u2f asan test:
   only:
     - schedules  # nightly build
   script:
-    - cached-nix-shell --run "poetry run make -C tests/fido_tests/u2f-tests-hid | ts -s"
-    - cached-nix-shell --run "poetry run make -C core test_emu_u2f | ts -s"
+    - $NIX_SHELL --run "poetry run make -C tests/fido_tests/u2f-tests-hid | ts -s"
+    - $NIX_SHELL --run "poetry run make -C core test_emu_u2f | ts -s"
   artifacts:
     name: "$CI_JOB_NAME-$CI_COMMIT_SHORT_SHA"
     paths:
@@ -227,7 +227,7 @@ core fido2 test:
     TREZOR_PROFILING: 1
   script:
     - pgrep trezor-emu-core || true
-    - cached-nix-shell --run "poetry run make -C core test_emu_fido2 | ts -s"
+    - $NIX_SHELL --run "poetry run make -C core test_emu_fido2 | ts -s"
     - pgrep trezor-emu-core || true
     - mv core/src/.coverage core/.coverage.test_emu_fido2
   artifacts:
@@ -250,7 +250,7 @@ core fido2 asan test:
     - schedules  # nightly build
   script:
     - pgrep trezor-emu-core || true
-    - cached-nix-shell --run "poetry run make -C core test_emu_fido2 | ts -s"
+    - $NIX_SHELL --run "poetry run make -C core test_emu_fido2 | ts -s"
     - pgrep trezor-emu-core || true
   artifacts:
     name: "$CI_JOB_NAME-$CI_COMMIT_SHORT_SHA"
@@ -269,11 +269,11 @@ core click test:
   variables:
     TREZOR_PROFILING: 1
   script:
-    - cached-nix-shell --run "poetry run make -C core test_emu_click_ui | ts -s"
+    - $NIX_SHELL --run "poetry run make -C core test_emu_click_ui | ts -s"
   after_script:
     - mv core/src/.coverage core/.coverage.test_click
     - mv tests/ui_tests/reports/test/ test_ui_report
-    - cached-nix-shell --run "poetry run python ci/prepare_ui_artifacts.py | ts -s"
+    - $NIX_SHELL --run "poetry run python ci/prepare_ui_artifacts.py | ts -s"
     - diff -u tests/ui_tests/fixtures.json tests/ui_tests/fixtures.suggestion.json
   artifacts:
     name: "$CI_JOB_NAME-$CI_COMMIT_SHORT_SHA"
@@ -297,7 +297,7 @@ core click asan test:
   only:
     - schedules  # nightly build
   script:
-    - cached-nix-shell --run "poetry run make -C core test_emu_click | ts -s"
+    - $NIX_SHELL --run "poetry run make -C core test_emu_click | ts -s"
   artifacts:
     name: "$CI_JOB_NAME-$CI_COMMIT_SHORT_SHA"
     paths:
@@ -318,8 +318,8 @@ core upgrade test:
   variables:
     TREZOR_UPGRADE_TEST: "core"
   script:
-    - cached-nix-shell --run "tests/download_emulators.sh"
-    - cached-nix-shell --run "poetry run pytest --junitxml=tests/junit.xml tests/upgrade_tests | ts -s"
+    - $NIX_SHELL --run "tests/download_emulators.sh"
+    - $NIX_SHELL --run "poetry run pytest --junitxml=tests/junit.xml tests/upgrade_tests | ts -s"
   artifacts:
     name: "$CI_JOB_NAME-$CI_COMMIT_SHORT_SHA"
     paths:
@@ -339,8 +339,8 @@ core upgrade asan test:
   variables:
     TREZOR_UPGRADE_TEST: "core"
   script:
-    - cached-nix-shell --run "tests/download_emulators.sh"
-    - cached-nix-shell --run "poetry run pytest --junitxml=tests/junit.xml tests/upgrade_tests | ts -s"
+    - $NIX_SHELL --run "tests/download_emulators.sh"
+    - $NIX_SHELL --run "poetry run pytest --junitxml=tests/junit.xml tests/upgrade_tests | ts -s"
   artifacts:
     name: "$CI_JOB_NAME-$CI_COMMIT_SHORT_SHA"
     paths:
@@ -357,7 +357,7 @@ core persistence test:
   needs:
     - core unix frozen debug build
   script:
-    - cached-nix-shell --run "poetry run pytest --junitxml=tests/junit.xml tests/persistence_tests | ts -s"
+    - $NIX_SHELL --run "poetry run pytest --junitxml=tests/junit.xml tests/persistence_tests | ts -s"
   artifacts:
     name: "$CI_JOB_NAME-$CI_COMMIT_SHORT_SHA"
     paths:
@@ -375,7 +375,7 @@ core persistence asan test:
   only:
     - schedules  # nightly build
   script:
-    - cached-nix-shell --run "poetry run pytest --junitxml=tests/junit.xml tests/persistence_tests | ts -s"
+    - $NIX_SHELL --run "poetry run pytest --junitxml=tests/junit.xml tests/persistence_tests | ts -s"
   artifacts:
     name: "$CI_JOB_NAME-$CI_COMMIT_SHORT_SHA"
     paths:
@@ -392,8 +392,8 @@ core hwi test:
     - core unix frozen debug build
   allow_failure: true
   script:
-    - cached-nix-shell --run "git clone https://github.com/bitcoin-core/HWI.git"
-    - cached-nix-shell --arg fullDeps true --run "cd HWI && poetry install && poetry run ./test/test_trezor.py --model_t ../core/build/unix/trezor-emu-core bitcoind"
+    - $NIX_SHELL --run "git clone https://github.com/bitcoin-core/HWI.git"
+    - $NIX_SHELL --arg fullDeps true --run "cd HWI && poetry install && poetry run ./test/test_trezor.py --model_t ../core/build/unix/trezor-emu-core bitcoind"
   artifacts:
     name: "$CI_JOB_NAME-$CI_COMMIT_SHORT_SHA"
     paths:
@@ -420,8 +420,8 @@ crypto test:
     - ./crypto/tests/aestst
     - ./crypto/tests/test_check
     - ./crypto/tests/test_openssl 1000
-    - cached-nix-shell --run "cd crypto && ITERS=10 poetry run pytest --junitxml=tests/junit.xml tests | ts -s"
-    - cached-nix-shell --run "CK_TIMEOUT_MULTIPLIER=20 valgrind -q --error-exitcode=1 ./crypto/tests/test_check_noasan | ts -s"
+    - $NIX_SHELL --run "cd crypto && ITERS=10 poetry run pytest --junitxml=tests/junit.xml tests | ts -s"
+    - $NIX_SHELL --run "CK_TIMEOUT_MULTIPLIER=20 valgrind -q --error-exitcode=1 ./crypto/tests/test_check_noasan | ts -s"
   artifacts:
     name: "$CI_JOB_NAME-$CI_COMMIT_SHORT_SHA"
     paths:
@@ -442,10 +442,10 @@ legacy device test:
   variables:
     EMULATOR: "1"
   script:
-    - cached-nix-shell --run "poetry run make -C legacy test_emu_ui | ts -s"
+    - $NIX_SHELL --run "poetry run make -C legacy test_emu_ui | ts -s"
   after_script:
     - mv tests/ui_tests/reports/test/ test_ui_report
-    - cached-nix-shell --run "poetry run python ci/prepare_ui_artifacts.py | ts -s"
+    - $NIX_SHELL --run "poetry run python ci/prepare_ui_artifacts.py | ts -s"
     - diff -u tests/ui_tests/fixtures.json tests/ui_tests/fixtures.suggestion.json
   artifacts:
     name: "$CI_JOB_NAME-$CI_COMMIT_SHORT_SHA"
@@ -471,7 +471,7 @@ legacy asan test:
   variables:
     EMULATOR: "1"
   script:
-    - cached-nix-shell --run "poetry run make -C legacy test_emu | ts -s"
+    - $NIX_SHELL --run "poetry run make -C legacy test_emu | ts -s"
 
 legacy btconly test:
   stage: test
@@ -483,7 +483,7 @@ legacy btconly test:
     EMULATOR_BINARY: "firmware/trezor-bitcoinonly.elf"
     TREZOR_PYTEST_SKIP_ALTCOINS: 1
   script:
-    - cached-nix-shell --run "poetry run make -C legacy test_emu | ts -s"
+    - $NIX_SHELL --run "poetry run make -C legacy test_emu | ts -s"
   artifacts:
     name: "$CI_JOB_NAME-$CI_COMMIT_SHORT_SHA"
     paths:
@@ -505,7 +505,7 @@ legacy btconly asan test:
     EMULATOR_BINARY: "firmware/trezor-bitcoinonly.elf"
     TREZOR_PYTEST_SKIP_ALTCOINS: 1
   script:
-    - cached-nix-shell --run "poetry run make -C legacy test_emu | ts -s"
+    - $NIX_SHELL --run "poetry run make -C legacy test_emu | ts -s"
 
 
 legacy upgrade test:
@@ -516,8 +516,8 @@ legacy upgrade test:
   variables:
     TREZOR_UPGRADE_TEST: "legacy"
   script:
-    - cached-nix-shell --run "tests/download_emulators.sh"
-    - cached-nix-shell --run "poetry run pytest --junitxml=tests/junit.xml tests/upgrade_tests | ts -s"
+    - $NIX_SHELL --run "tests/download_emulators.sh"
+    - $NIX_SHELL --run "poetry run pytest --junitxml=tests/junit.xml tests/upgrade_tests | ts -s"
   artifacts:
     name: "$CI_JOB_NAME-$CI_COMMIT_SHORT_SHA"
     paths:
@@ -537,8 +537,8 @@ legacy upgrade asan test:
   variables:
     TREZOR_UPGRADE_TEST: "legacy"
   script:
-    - cached-nix-shell --run "tests/download_emulators.sh"
-    - cached-nix-shell --run "poetry run pytest --junitxml=tests/junit.xml tests/upgrade_tests | ts -s"
+    - $NIX_SHELL --run "tests/download_emulators.sh"
+    - $NIX_SHELL --run "poetry run pytest --junitxml=tests/junit.xml tests/upgrade_tests | ts -s"
   artifacts:
     name: "$CI_JOB_NAME-$CI_COMMIT_SHORT_SHA"
     paths:
@@ -557,8 +557,8 @@ legacy hwi test:
     EMULATOR: "1"
   allow_failure: true
   script:
-    - cached-nix-shell --run "git clone https://github.com/bitcoin-core/HWI.git"
-    - cached-nix-shell --arg fullDeps true --run "cd HWI && poetry install && poetry run ./test/test_trezor.py --model_1 ../legacy/firmware/trezor.elf bitcoind"
+    - $NIX_SHELL --run "git clone https://github.com/bitcoin-core/HWI.git"
+    - $NIX_SHELL --arg fullDeps true --run "cd HWI && poetry install && poetry run ./test/test_trezor.py --model_1 ../legacy/firmware/trezor.elf bitcoind"
   artifacts:
     name: "$CI_JOB_NAME-$CI_COMMIT_SHORT_SHA"
     paths:
@@ -584,14 +584,14 @@ python test:
     # See also:
     # https://github.com/NixOS/nixpkgs/blob/b00c7c2d1d905eb63c81a0917f1a94b763a7843b/pkgs/development/interpreters/python/cpython/default.nix#L103
     # https://github.com/NixOS/nixpkgs/pull/98915
-    - cached-nix-shell --arg fullDeps true --run "unset _PYTHON_SYSCONFIGDATA_NAME && cd python && poetry run tox | ts -s"
+    - $NIX_SHELL --arg fullDeps true --run "unset _PYTHON_SYSCONFIGDATA_NAME && cd python && poetry run tox | ts -s"
 
 python support test:
   stage: test
   <<: *gitlab_caching
   needs: []
   script:
-    - cached-nix-shell --run "poetry run make python_support_check | ts -s"
+    - $NIX_SHELL --run "poetry run make python_support_check | ts -s"
 
 
 # Storage
@@ -607,8 +607,8 @@ storage test:
   needs: []
   script:
     - unset PYTEST_TIMEOUT
-    - cached-nix-shell --run "poetry run make -C storage/tests build | ts -s"
-    - cached-nix-shell --run "poetry run make -C storage/tests tests_all | ts -s"
+    - $NIX_SHELL --run "poetry run make -C storage/tests build | ts -s"
+    - $NIX_SHELL --run "poetry run make -C storage/tests tests_all | ts -s"
   artifacts:
     name: "$CI_JOB_NAME-$CI_COMMIT_SHORT_SHA"
     paths:
@@ -630,10 +630,10 @@ core unix memory profiler:
     TREZOR_MEMPERF: "1"
     PYTEST_TIMEOUT: "900"
   script:
-    - cached-nix-shell --run "poetry run make -C core build_unix_frozen | ts -s"
-    - cached-nix-shell --run "poetry run make -C core test_emu | ts -s"
-    - cached-nix-shell --run "mkdir core/prof/memperf-html"
-    - cached-nix-shell --run "poetry run core/tools/alloc.py --alloc-data=core/src/alloc_data.txt html core/prof/memperf-html"
+    - $NIX_SHELL --run "poetry run make -C core build_unix_frozen | ts -s"
+    - $NIX_SHELL --run "poetry run make -C core test_emu | ts -s"
+    - $NIX_SHELL --run "mkdir core/prof/memperf-html"
+    - $NIX_SHELL --run "poetry run core/tools/alloc.py --alloc-data=core/src/alloc_data.txt html core/prof/memperf-html"
   artifacts:
     name: "$CI_JOB_NAME-$CI_COMMIT_SHORT_SHA"
     paths:
@@ -657,10 +657,10 @@ connect test core:
   before_script:
     - cp /builds/satoshilabs/trezor/trezor-firmware/core/build/unix/trezor-emu-core /trezor-user-env/src/binaries/firmware/bin/trezor-emu-core-v2.99.99
     - chmod +x /trezor-user-env/src/binaries/firmware/bin/trezor-emu-core-v2.99.99
-    - cached-nix-shell --run "autoPatchelf /trezor-user-env/src/binaries/firmware/bin/trezor-emu-core-v2.99.99"
+    - $NIX_SHELL --run "autoPatchelf /trezor-user-env/src/binaries/firmware/bin/trezor-emu-core-v2.99.99"
   script:
     - /trezor-user-env/run-nix.sh &
-    - cached-nix-shell --run "tests/connect_tests/connect_tests.sh 2.99.99"
+    - $NIX_SHELL --run "tests/connect_tests/connect_tests.sh 2.99.99"
   after_script:
     - cp /trezor-user-env/logs/debugging.log trezor-user-env-debugging.log
     - cp /trezor-user-env/logs/emulator_bridge.log tenv-emulator-bridge-debugging.log

--- a/docs/ci/jobs.md
+++ b/docs/ci/jobs.md
@@ -23,7 +23,7 @@ Almost all CI jobs run inside this docker image.
 ## PREBUILD stage - [prebuild.yml](https://github.com/trezor/trezor-firmware/blob/master/ci/prebuild.yml)
 Static checks on the code.
 
-Consists of **7 jobs** below:
+Consists of **6 jobs** below:
 
 ### [style prebuild](https://github.com/trezor/trezor-firmware/blob/master/ci/prebuild.yml#L16)
 Check the code for style correctness and perform some static code analysis.
@@ -40,13 +40,10 @@ Check validity of auto-generated files.
 ### [editor prebuild](https://github.com/trezor/trezor-firmware/blob/master/ci/prebuild.yml#L39)
 Checking format of .editorconfig files.
 
-### [yaml prebuild](https://github.com/trezor/trezor-firmware/blob/master/ci/prebuild.yml#L46)
-All .yml/.yaml files are checked for syntax validity and other correctness.
-
-### [release commit messages prebuild](https://github.com/trezor/trezor-firmware/blob/master/ci/prebuild.yml#L53)
+### [release commit messages prebuild](https://github.com/trezor/trezor-firmware/blob/master/ci/prebuild.yml#L46)
 Checking the format of release commit messages.
 
-### [changelog prebuild](https://github.com/trezor/trezor-firmware/blob/master/ci/prebuild.yml#L70)
+### [changelog prebuild](https://github.com/trezor/trezor-firmware/blob/master/ci/prebuild.yml#L63)
 Verifying that all commits changing some functionality have a changelog entry
 or contain `[no changelog]` in the commit message.
 
@@ -104,32 +101,32 @@ it is just a single binary file that you can execute directly.
 
 ### [core unix frozen debug build arm](https://github.com/trezor/trezor-firmware/blob/master/ci/build.yml#L254)
 
-### [core macos frozen regular build](https://github.com/trezor/trezor-firmware/blob/master/ci/build.yml#L276)
+### [core macos frozen regular build](https://github.com/trezor/trezor-firmware/blob/master/ci/build.yml#L277)
 
-### [crypto build](https://github.com/trezor/trezor-firmware/blob/master/ci/build.yml#L301)
+### [crypto build](https://github.com/trezor/trezor-firmware/blob/master/ci/build.yml#L302)
 Build of our cryptographic library, which is then incorporated into the other builds.
 
-### [legacy fw regular build](https://github.com/trezor/trezor-firmware/blob/master/ci/build.yml#L330)
+### [legacy fw regular build](https://github.com/trezor/trezor-firmware/blob/master/ci/build.yml#L331)
 
-### [legacy fw regular debug build](https://github.com/trezor/trezor-firmware/blob/master/ci/build.yml#L346)
+### [legacy fw regular debug build](https://github.com/trezor/trezor-firmware/blob/master/ci/build.yml#L347)
 
-### [legacy fw btconly build](https://github.com/trezor/trezor-firmware/blob/master/ci/build.yml#L363)
+### [legacy fw btconly build](https://github.com/trezor/trezor-firmware/blob/master/ci/build.yml#L364)
 
-### [legacy fw btconly debug build](https://github.com/trezor/trezor-firmware/blob/master/ci/build.yml#L382)
+### [legacy fw btconly debug build](https://github.com/trezor/trezor-firmware/blob/master/ci/build.yml#L383)
 
-### [legacy emu regular debug build](https://github.com/trezor/trezor-firmware/blob/master/ci/build.yml#L403)
+### [legacy emu regular debug build](https://github.com/trezor/trezor-firmware/blob/master/ci/build.yml#L404)
 Regular version (not only Bitcoin) of above.
 **Are you looking for a Trezor One emulator? This is most likely it.**
 
-### [legacy emu regular debug asan build](https://github.com/trezor/trezor-firmware/blob/master/ci/build.yml#L418)
+### [legacy emu regular debug asan build](https://github.com/trezor/trezor-firmware/blob/master/ci/build.yml#L419)
 
-### [legacy emu regular debug build arm](https://github.com/trezor/trezor-firmware/blob/master/ci/build.yml#L436)
+### [legacy emu regular debug build arm](https://github.com/trezor/trezor-firmware/blob/master/ci/build.yml#L437)
 
-### [legacy emu btconly debug build](https://github.com/trezor/trezor-firmware/blob/master/ci/build.yml#L462)
+### [legacy emu btconly debug build](https://github.com/trezor/trezor-firmware/blob/master/ci/build.yml#L464)
 Build of Legacy into UNIX emulator. Use keyboard arrows to emulate button presses.
 Bitcoin-only version.
 
-### [legacy emu btconly debug asan build](https://github.com/trezor/trezor-firmware/blob/master/ci/build.yml#L479)
+### [legacy emu btconly debug asan build](https://github.com/trezor/trezor-firmware/blob/master/ci/build.yml#L481)
 
 ---
 ## TEST stage - [test.yml](https://github.com/trezor/trezor-firmware/blob/master/ci/test.yml)
@@ -238,17 +235,17 @@ a state where the micropython heap is too fragmented and allocations fail
 skipped.
 See also: https://github.com/trezor/trezor-firmware/issues/1371
 
-### [hardware core btconly device test](https://github.com/trezor/trezor-firmware/blob/master/ci/test-hw.yml#L54)
+### [hardware core btconly device test](https://github.com/trezor/trezor-firmware/blob/master/ci/test-hw.yml#L55)
 Also device tests on physical Trezor T but with Bitcoin-only firmware.
 
-### [hardware core monero test](https://github.com/trezor/trezor-firmware/blob/master/ci/test-hw.yml#L83)
+### [hardware core monero test](https://github.com/trezor/trezor-firmware/blob/master/ci/test-hw.yml#L85)
 
-### [hardware legacy regular device test](https://github.com/trezor/trezor-firmware/blob/master/ci/test-hw.yml#L113)
+### [hardware legacy regular device test](https://github.com/trezor/trezor-firmware/blob/master/ci/test-hw.yml#L116)
 [Device tests](../tests/device-tests.md) executed on physical Trezor 1.
 This works thanks to [tpmb](https://github.com/mmahut/tpmb), which is a small arduino
 device capable of pushing an actual buttons on the device.
 
-### [hardware legacy btconly device test](https://github.com/trezor/trezor-firmware/blob/master/ci/test-hw.yml#L137)
+### [hardware legacy btconly device test](https://github.com/trezor/trezor-firmware/blob/master/ci/test-hw.yml#L142)
 Also device tests on physical Trezor 1 but with Bitcoin-only firmware.
 
 ---


### PR DESCRIPTION
Followup of #2816. Also remove `yaml prebuild` because it's a strict subset of `style prebuild`.