### PR TITLE
Hide passphrase from host

### DIFF
--- a/common/protob/messages-management.proto
+++ b/common/protob/messages-management.proto
@@ -122,6 +122,7 @@ message Features {
     optional bool experimental_features = 40;   // are experimental message types enabled?
     optional bool busy = 41;                    // is the device busy, showing "Do not disconnect"?
     optional HomescreenFormat homescreen_format = 42;   // format of the homescreen, 1 = TOIf 144x144, 2 = jpg 240x240
+    optional bool hide_passphrase_from_host = 43;   // should we hide the passphrase when it comes from host?
 }
 
 /**
@@ -168,6 +169,7 @@ message ApplySettings {
     optional bool passphrase_always_on_device = 8;  // do not prompt for passphrase, enforce device entry
     optional SafetyCheckLevel safety_checks = 9;  // Safety check level, set to Prompt to limit path namespace enforcement
     optional bool experimental_features = 10;  // enable experimental message types
+    optional bool hide_passphrase_from_host = 11;  // do not show passphrase coming from host
 }
 
 /**

--- a/core/src/apps/base.py
+++ b/core/src/apps/base.py
@@ -128,6 +128,7 @@ def get_features() -> Features:
         f.auto_lock_delay_ms = storage_device.get_autolock_delay_ms()
         f.display_rotation = storage_device.get_rotation()
         f.experimental_features = storage_device.get_experimental_features()
+        f.hide_passphrase_from_host = storage_device.get_hide_passphrase_from_host()
 
     return f
 

--- a/core/src/apps/common/passphrase.py
+++ b/core/src/apps/common/passphrase.py
@@ -59,19 +59,29 @@ async def _request_on_host(ctx: Context) -> str:
     if passphrase:
         from trezor.ui.layouts import confirm_action, confirm_blob
 
-        await confirm_action(
-            ctx,
-            "passphrase_host1",
-            "Hidden wallet",
-            description="Access hidden wallet?\n\nNext screen will show the passphrase!",
-        )
+        # We want to hide the passphrase, or show it, according to settings.
+        if storage_device.get_hide_passphrase_from_host():
+            explanation = "Passphrase provided by host will be used but will not be displayed due to the device settings."
+            await confirm_action(
+                ctx,
+                "passphrase_host1_hidden",
+                "Hidden wallet",
+                description=f"Access hidden wallet?\n\n{explanation}",
+            )
+        else:
+            await confirm_action(
+                ctx,
+                "passphrase_host1",
+                "Hidden wallet",
+                description="Access hidden wallet?\n\nNext screen will show the passphrase!",
+            )
 
-        await confirm_blob(
-            ctx,
-            "passphrase_host2",
-            "Hidden wallet",
-            passphrase,
-            "Use this passphrase?\n",
-        )
+            await confirm_blob(
+                ctx,
+                "passphrase_host2",
+                "Hidden wallet",
+                passphrase,
+                "Use this passphrase?\n",
+            )
 
     return passphrase

--- a/core/src/storage/device.py
+++ b/core/src/storage/device.py
@@ -34,6 +34,7 @@ _SD_SALT_AUTH_KEY          = const(0x12)  # bytes
 INITIALIZED                = const(0x13)  # bool (0x01 or empty)
 _SAFETY_CHECK_LEVEL        = const(0x14)  # int
 _EXPERIMENTAL_FEATURES     = const(0x15)  # bool (0x01 or empty)
+_HIDE_PASSPHRASE_FROM_HOST = const(0x16)  # bool (0x01 or empty)
 
 SAFETY_CHECK_LEVEL_STRICT  : Literal[0] = const(0)
 SAFETY_CHECK_LEVEL_PROMPT  : Literal[1] = const(1)
@@ -334,3 +335,17 @@ def set_experimental_features(enabled: bool) -> None:
     cached_bytes = b"\x01" if enabled else b""
     storage_cache.set(storage_cache.STORAGE_DEVICE_EXPERIMENTAL_FEATURES, cached_bytes)
     common.set_true_or_delete(_NAMESPACE, _EXPERIMENTAL_FEATURES, enabled)
+
+
+def set_hide_passphrase_from_host(hide: bool) -> None:
+    """
+    Whether we should hide the passphrase from the host.
+    """
+    common.set_bool(_NAMESPACE, _HIDE_PASSPHRASE_FROM_HOST, hide)
+
+
+def get_hide_passphrase_from_host() -> bool:
+    """
+    Whether we should hide the passphrase from the host.
+    """
+    return common.get_bool(_NAMESPACE, _HIDE_PASSPHRASE_FROM_HOST)

--- a/core/src/trezor/messages.py
+++ b/core/src/trezor/messages.py
@@ -2104,6 +2104,7 @@ if TYPE_CHECKING:
         experimental_features: "bool | None"
         busy: "bool | None"
         homescreen_format: "HomescreenFormat | None"
+        hide_passphrase_from_host: "bool | None"
 
         def __init__(
             self,
@@ -2147,6 +2148,7 @@ if TYPE_CHECKING:
             experimental_features: "bool | None" = None,
             busy: "bool | None" = None,
             homescreen_format: "HomescreenFormat | None" = None,
+            hide_passphrase_from_host: "bool | None" = None,
         ) -> None:
             pass
 
@@ -2190,6 +2192,7 @@ if TYPE_CHECKING:
         passphrase_always_on_device: "bool | None"
         safety_checks: "SafetyCheckLevel | None"
         experimental_features: "bool | None"
+        hide_passphrase_from_host: "bool | None"
 
         def __init__(
             self,
@@ -2203,6 +2206,7 @@ if TYPE_CHECKING:
             passphrase_always_on_device: "bool | None" = None,
             safety_checks: "SafetyCheckLevel | None" = None,
             experimental_features: "bool | None" = None,
+            hide_passphrase_from_host: "bool | None" = None,
         ) -> None:
             pass
 

--- a/python/src/trezorlib/cli/settings.py
+++ b/python/src/trezorlib/cli/settings.py
@@ -337,3 +337,14 @@ passphrase.aliases = {
     "enabled": passphrase_on,
     "disabled": passphrase_off,
 }
+
+
+@passphrase.command(name="hide")
+@click.argument("hide", type=ChoiceType({"on": True, "off": False}))
+@with_client
+def hide_passphrase_from_host(client: "TrezorClient", hide: bool) -> str:
+    """Enable or disable hiding passphrase coming from host.
+
+    This is a developer feature. Use with caution.
+    """
+    return device.apply_settings(client, hide_passphrase_from_host=hide)

--- a/python/src/trezorlib/device.py
+++ b/python/src/trezorlib/device.py
@@ -43,6 +43,7 @@ def apply_settings(
     display_rotation: Optional[int] = None,
     safety_checks: Optional[messages.SafetyCheckLevel] = None,
     experimental_features: Optional[bool] = None,
+    hide_passphrase_from_host: Optional[bool] = None,
 ) -> "MessageType":
     settings = messages.ApplySettings(
         label=label,
@@ -54,6 +55,7 @@ def apply_settings(
         display_rotation=display_rotation,
         safety_checks=safety_checks,
         experimental_features=experimental_features,
+        hide_passphrase_from_host=hide_passphrase_from_host,
     )
 
     out = client.call(settings)

--- a/python/src/trezorlib/messages.py
+++ b/python/src/trezorlib/messages.py
@@ -3143,6 +3143,7 @@ class Features(protobuf.MessageType):
         40: protobuf.Field("experimental_features", "bool", repeated=False, required=False, default=None),
         41: protobuf.Field("busy", "bool", repeated=False, required=False, default=None),
         42: protobuf.Field("homescreen_format", "HomescreenFormat", repeated=False, required=False, default=None),
+        43: protobuf.Field("hide_passphrase_from_host", "bool", repeated=False, required=False, default=None),
     }
 
     def __init__(
@@ -3188,6 +3189,7 @@ class Features(protobuf.MessageType):
         experimental_features: Optional["bool"] = None,
         busy: Optional["bool"] = None,
         homescreen_format: Optional["HomescreenFormat"] = None,
+        hide_passphrase_from_host: Optional["bool"] = None,
     ) -> None:
         self.capabilities: Sequence["Capability"] = capabilities if capabilities is not None else []
         self.major_version = major_version
@@ -3229,6 +3231,7 @@ class Features(protobuf.MessageType):
         self.experimental_features = experimental_features
         self.busy = busy
         self.homescreen_format = homescreen_format
+        self.hide_passphrase_from_host = hide_passphrase_from_host
 
 
 class LockDevice(protobuf.MessageType):
@@ -3266,6 +3269,7 @@ class ApplySettings(protobuf.MessageType):
         8: protobuf.Field("passphrase_always_on_device", "bool", repeated=False, required=False, default=None),
         9: protobuf.Field("safety_checks", "SafetyCheckLevel", repeated=False, required=False, default=None),
         10: protobuf.Field("experimental_features", "bool", repeated=False, required=False, default=None),
+        11: protobuf.Field("hide_passphrase_from_host", "bool", repeated=False, required=False, default=None),
     }
 
     def __init__(
@@ -3281,6 +3285,7 @@ class ApplySettings(protobuf.MessageType):
         passphrase_always_on_device: Optional["bool"] = None,
         safety_checks: Optional["SafetyCheckLevel"] = None,
         experimental_features: Optional["bool"] = None,
+        hide_passphrase_from_host: Optional["bool"] = None,
     ) -> None:
         self.language = language
         self.label = label
@@ -3292,6 +3297,7 @@ class ApplySettings(protobuf.MessageType):
         self.passphrase_always_on_device = passphrase_always_on_device
         self.safety_checks = safety_checks
         self.experimental_features = experimental_features
+        self.hide_passphrase_from_host = hide_passphrase_from_host
 
 
 class ApplyFlags(protobuf.MessageType):

--- a/tests/ui_tests/fixtures.json
+++ b/tests/ui_tests/fixtures.json
@@ -1705,6 +1705,7 @@
 "TT_test_session.py::test_end_session_only_current": "bd83a31d0fc4c23953dfd0d138e4441984e34698ace96aad5308a4ae51b712ae",
 "TT_test_session.py::test_session_recycling": "07f265234a3269c8c99172e2f67abf626e17a542e6f4c00b45c5b685d0e4c240",
 "TT_test_session_id_and_passphrase.py::test_cardano_passphrase": "26e3b8bc6b1ba85fc89d5b237096685309a95f73350d2fca646720fb750d0e8f",
+"TT_test_session_id_and_passphrase.py::test_hide_passphrase_from_host": "ccdb34cba3b759d91500b3c2b2ee5d427167d21b6aefa709b659aed298760605",
 "TT_test_session_id_and_passphrase.py::test_max_sessions_with_passphrases": "5c85cb246fe4bb07076ed88f426e6133368f3417472cf2dfbef2daac32a088aa",
 "TT_test_session_id_and_passphrase.py::test_multiple_passphrases": "12231bae2ea96b600c96ade946e5dda29d6625d128906cf14728869c1e697987",
 "TT_test_session_id_and_passphrase.py::test_multiple_sessions": "bd83a31d0fc4c23953dfd0d138e4441984e34698ace96aad5308a4ae51b712ae",


### PR DESCRIPTION
Fixes https://github.com/trezor/trezor-firmware/issues/2598:
- adds the optional possibility of hiding the passphrase coming from host

Allows for changing this behavior by `trezorctl set passphrase hide {on,off}`.
It is currently hidden behind `safety checks`.
It is being shown in `Features` as `hide_passphrase_from_host: {True,False}`.

Trezorlib step-by-step flow I used when testing this:
- $ `trezorctl device wipe && trezorctl device load -s && trezorctl set pin`
- $ `trezorctl get-features | grep passphrase_protection` 
  - `passphrase_protection: False`
- $ `trezorctl set passphrase on` 
- $ `trezorctl get-features | grep passphrase_protection` 
  - `passphrase_protection: True`
- $ `PASSPHRASE=abc trezorctl -P btc get-address -n "84'/0'/0'/1/0"`
  - shows `Next screen will show the passphrase`
- $ `trezorctl get-features | grep hide_passphrase` 
  - `hide_passphrase_from_host: False`
- $ `trezorctl set passphrase hide on` 
  - `Error: ProcessError: Safety checks are strict` 
- $ `trezorctl set safety-checks prompt` 
  - `Settings applied`   
- $ `trezorctl set passphrase hide on` 
  - `Settings applied`
- $ `trezorctl get-features | grep hide_passphrase` 
  - `hide_passphrase_from_host: True`
- $ `PASSPHRASE=abc trezorctl -P btc get-address -n "84'/0'/0'/1/0"`
  - shows `Passphrase provided by host will be used but will not be displayed due to the device settings.`

There are currently no changelog entries (and `[no changelog]` in both commits), as I understand it we do not want to reveal it to the public if not necessary.