### PR TITLE
chore(core): enable reboot-to-bootloader without experimental features

### DIFF
--- a/core/.changelog.d/2841.added
+++ b/core/.changelog.d/2841.added
@@ -1,0 +1,1 @@
+Add the possibility of rebooting the device into bootloader mode

--- a/core/src/apps/management/reboot_to_bootloader.py
+++ b/core/src/apps/management/reboot_to_bootloader.py
@@ -7,13 +7,9 @@ if TYPE_CHECKING:
 
 
 async def reboot_to_bootloader(ctx: Context, msg: RebootToBootloader) -> NoReturn:
-    import storage.device
-    from trezor import io, loop, utils, wire
+    from trezor import io, loop, utils
     from trezor.messages import Success
     from trezor.ui.layouts import confirm_action
-
-    if not storage.device.get_experimental_features():
-        raise wire.UnexpectedMessage("Experimental features are not enabled")
 
     await confirm_action(
         ctx,


### PR DESCRIPTION
Fixes https://github.com/trezor/trezor-firmware/issues/2316:
- not needing experimental features to trigger reboot-to-bootloader functionality