### PR TITLE
fix(legacy): show complete taproot QR code

### DIFF
--- a/legacy/firmware/layout2.c
+++ b/legacy/firmware/layout2.c
@@ -790,12 +790,8 @@ void layoutAddress(const char *address, const char *desc, bool qrcode,
     }
 
     oledInvert(0, 0, 63, 63);
-    if (side > 0 && side <= 33) {
-      // For QR code V4 (33x33), still maintaining two pixels per module
-      // so that it is nicely readable. Not showing the bottom row,
-      // which is not a problem thanks to the QR code's error correction.
-      // It is a use-case for BTC taproot addresses.
-      int offset = side <= 29 ? 32 - side : 0;
+    if (side > 0 && side <= 29) {
+      int offset = 32 - side;
       for (int i = 0; i < side; i++) {
         for (int j = 0; j < side; j++) {
           if (qrcodegen_getModule(codedata, i, j)) {

--- a/tests/ui_tests/fixtures.json
+++ b/tests/ui_tests/fixtures.json
@@ -97,7 +97,7 @@
 "T1_bitcoin-test_getaddress_show.py::test_show[m-44h-0h-12h-0-0-InputScriptType.SPENDADDRESS-1F-1e4f2f74": "9e7c7d751f82daaab09cdc499a41988d8519ffbc1efb6ef23a58e48fc4960787",
 "T1_bitcoin-test_getaddress_show.py::test_show[m-49h-0h-12h-0-0-InputScriptType.SPENDP2SHWITNES-a986211d": "49058bad1db26efc3c7cdafcee64b0b0975ea7eab8de41994217d901c7e4f44c",
 "T1_bitcoin-test_getaddress_show.py::test_show[m-84h-0h-12h-0-0-InputScriptType.SPENDWITNESS-bc-a5f08dfb": "e2fa133ac77b590f7686e2af19483a67dd8354a59bcef78159ca6193eb9c6580",
-"T1_bitcoin-test_getaddress_show.py::test_show[m-86h-0h-12h-0-0-InputScriptType.SPENDTAPROOT-bc-f94d8b44": "ab2f29604a1dc2fcd9f22ba0897ad344f527f82ff4c5d873ee7102eb662e1ab5",
+"T1_bitcoin-test_getaddress_show.py::test_show[m-86h-0h-12h-0-0-InputScriptType.SPENDTAPROOT-bc-f94d8b44": "9cd4081c30d19a596436ec730c6a79483aa1064244d12aa4ec51f4f608c10f49",
 "T1_bitcoin-test_getaddress_show.py::test_show_multisig_15": "40f652d0e899d528605f472f47ec6cb727ced8fe90588a8904b46ed39c2088e8",
 "T1_bitcoin-test_getaddress_show.py::test_show_multisig_3": "05e4e5cd014bf96373788e4563a48f5cdb4c54d358a88e8a29247c2825c5669e",
 "T1_bitcoin-test_getaddress_show.py::test_show_unrecognized_path": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",


### PR DESCRIPTION
Fixes https://github.com/trezor/trezor-firmware/issues/2638:
- show the taproot QR code smaller, but complete

![image](https://user-images.githubusercontent.com/42543243/220609908-0dc1813c-f37a-4a02-8ad2-ec2d1fa0d1fc.png)
