### PR TITLE
Fix FIDO issues with Safari browser and CBOR encoding

### DIFF
--- a/core/.changelog.d/2205.changed
+++ b/core/.changelog.d/2205.changed
@@ -1,0 +1,1 @@
+Ignore channel ID in U2F.

--- a/core/src/apps/webauthn/fido2.py
+++ b/core/src/apps/webauthn/fido2.py
@@ -1882,7 +1882,7 @@ def _cbor_get_info(req: Cmd) -> Cmd:
         _GETINFO_RESP_EXTENSIONS: ["hmac-secret"],
         _GETINFO_RESP_AAGUID: _AAGUID,
         _GETINFO_RESP_OPTIONS: {
-            "rk": _ALLOW_RESIDENT_CREDENTIALS,
+            "rk": bool(_ALLOW_RESIDENT_CREDENTIALS),
             "up": True,
             "uv": True,
         },


### PR DESCRIPTION
Fixes https://github.com/trezor/trezor-firmware/issues/2205.
Safari browser changes the channel ID for every single FIDO message. We need to ignore the CID in U2F and keep up the same U2F dialog as long as the dialog corresponds to the same request data.

Fixes https://github.com/trezor/trezor-firmware/issues/2790.
A boolean value was incorrectly being encoded as an integer in CBOR encoding.