### PR TITLE
ci: hardware: wait longer for T1 firmware to install

### DIFF
--- a/ci/hardware_tests/device/t1.py
+++ b/ci/hardware_tests/device/t1.py
@@ -31,7 +31,7 @@ class TrezorOne(Device):
         self.run_trezorctl(trezorctlcmd)
         self.wait(3)
         self.touch("right", "click")
-        self.wait(25)
+        self.wait(30)
         if unofficial:
             self.touch("right", "click")
         self.wait(10)

--- a/ci/test-hw.yml
+++ b/ci/test-hw.yml
@@ -125,7 +125,7 @@ hardware legacy regular device test:
   script:
     - cd ci/hardware_tests
     - $NIX_SHELL --run "./t1_hw_test.sh | ts -s"
-  timeout: 1h10m
+  timeout: 1h20m
   artifacts:
     name: "$CI_JOB_NAME-$CI_COMMIT_SHORT_SHA"
     paths:


### PR DESCRIPTION
The automation currently pushes yes button while the firmware is still being installed, probably because coinjoin and/or ethereum networks made the image larger. Also due to coinjoin we now run more tests so the job timeout needs to be increased.

Tested working in the private repo.