### PR TITLE
Faster device/UI tests

### DIFF
--- a/ci/test.yml
+++ b/ci/test.yml
@@ -57,12 +57,12 @@ core device test:
   needs:
     - core unix frozen debug build
   variables:
-    TREZOR_PROFILING: 1
+    TREZOR_PROFILING: 1  # so that we get coverage data
     MULTICORE: 4  # more could interfere with other jobs
   script:
     - $NIX_SHELL --run "poetry run make -C core test_emu_ui_multicore | ts -s"
   after_script:
-    - mv core/src/.coverage core/.coverage.test_emu
+    - mv core/src/.coverage.* core  # there will be more coverage files (one per core)
     - mv tests/ui_tests/reports/test/ test_ui_report
     - $NIX_SHELL --run "poetry run python ci/prepare_ui_artifacts.py | ts -s"
     - diff -u tests/ui_tests/fixtures.json tests/ui_tests/fixtures.suggestion.json

--- a/ci/test.yml
+++ b/ci/test.yml
@@ -285,6 +285,7 @@ core click test:
       - tests/ui_tests/fixtures.suggestion.json
       - tests/trezor.log
       - tests/junit.xml
+      - core/.coverage.*
     reports:
       junit: tests/junit.xml
     expire_in: 1 week

--- a/ci/test.yml
+++ b/ci/test.yml
@@ -58,8 +58,9 @@ core device test:
     - core unix frozen debug build
   variables:
     TREZOR_PROFILING: 1
+    MULTICORE: 4  # more could interfere with other jobs
   script:
-    - $NIX_SHELL --run "poetry run make -C core test_emu_ui | ts -s"
+    - $NIX_SHELL --run "poetry run make -C core test_emu_ui_multicore | ts -s"
   after_script:
     - mv core/src/.coverage core/.coverage.test_emu
     - mv tests/ui_tests/reports/test/ test_ui_report

--- a/core/.coveragerc
+++ b/core/.coveragerc
@@ -1,0 +1,13 @@
+[report]
+# Regexes for lines to exclude from consideration
+exclude_lines =
+    from typing import
+    if TYPE_CHECKING:
+    # local const variables, e.g. _FIELD_TYPE_VL = const(7)
+    ^_.*const\(\d+
+    assert False
+    pass
+    raise RuntimeError
+    raise NotImplementedError
+    def mem_dump
+    def __repr__(self)

--- a/core/Makefile
+++ b/core/Makefile
@@ -60,6 +60,8 @@ PYTEST = pytest --junitxml=$(JUNIT_XML)
 TREZOR_FIDO2_UDP_PORT = 21326
 RUST_TARGET=$(shell rustc -vV | sed -n 's/host: //p')
 
+MULTICORE ?= "auto"
+
 ## help commands:
 
 help: ## show this help
@@ -90,7 +92,7 @@ test_emu: ## run selected device tests from python-trezor
 	$(EMU_TEST) $(PYTEST) $(TESTPATH)/device_tests $(TESTOPTS)
 
 test_emu_multicore: ## run device tests using multiple cores
-	$(PYTEST) -n auto $(TESTPATH)/device_tests $(TESTOPTS) --control-emulators --model=core --random-order-seed=$(shell echo $$RANDOM)
+	$(PYTEST) -n $(MULTICORE) $(TESTPATH)/device_tests $(TESTOPTS) --control-emulators --model=core --random-order-seed=$(shell echo $$RANDOM)
 
 test_emu_monero: ## run selected monero device tests from monero-agent
 	cd tests ; $(EMU_TEST) ./run_tests_device_emu_monero.sh $(TESTOPTS)
@@ -114,7 +116,7 @@ test_emu_ui: ## run ui integration tests
 		--ui=test --ui-check-missing --record-text-layout
 
 test_emu_ui_multicore: ## run ui integration tests using multiple cores
-	$(PYTEST) -n auto $(TESTPATH)/device_tests $(TESTOPTS) \
+	$(PYTEST) -n $(MULTICORE) $(TESTPATH)/device_tests $(TESTOPTS) \
 		--ui=test --ui-check-missing --record-text-layout \
 		--control-emulators --model=core --random-order-seed=$(shell echo $$RANDOM)
 

--- a/core/prof/prof.py
+++ b/core/prof/prof.py
@@ -50,7 +50,14 @@ class _Prof:
 
     def write_data(self):
         print("Total traces executed: ", __prof__.trace_count)
-        with open(".coverage", "w") as f:
+        # In case of multithreaded tests, we might be called multiple times.
+        # Making sure the threads do not overwrite each other's data.
+        worker_id = getenv("PYTEST_XDIST_WORKER")
+        if worker_id:
+            file_name = f".coverage.{worker_id}"
+        else:
+            file_name = ".coverage"
+        with open(file_name, "w") as f:
             # wtf so private much beautiful wow
             f.write("!coverage.py: This is a private format, don't read it directly!")
             # poormans json
@@ -67,10 +74,13 @@ class AllocCounter:
         if self.last_line is None:
             return
 
-        entry = self.data.setdefault(self.last_line, {
-            "total_allocs": 0,
-            "calls": 0,
-        })
+        entry = self.data.setdefault(
+            self.last_line,
+            {
+                "total_allocs": 0,
+                "calls": 0,
+            },
+        )
         entry["total_allocs"] += allocs
         entry["calls"] += 1
 

--- a/core/tools/coverage-report
+++ b/core/tools/coverage-report
@@ -28,10 +28,14 @@ fi
 
 EXCLUDES="\
 src/all_modules.py,\
+src/typing.py,\
 src/apps/ethereum/tokens.py,\
+src/apps/webauthn/knownapps.py,\
+src/apps/common/coininfo.py,\
 src/trezor/messages.py,\
 src/trezor/enums/__init__.py"
 
+# Uses core/.coveragerc configuration file
 coverage html \
   --omit="$EXCLUDES" \
   --fail-under=${COVERAGE_THRESHOLD}

--- a/core/tools/coverage-report
+++ b/core/tools/coverage-report
@@ -1,10 +1,30 @@
 #!/bin/sh
 
-COVERAGE_THRESHOLD=${COVERAGE_THRESHOLD:-0}
+readonly COVERAGE_THRESHOLD=${COVERAGE_THRESHOLD:-0}
 
-coverage run --source=./src /dev/null 2>/dev/null
-mv .coverage .coverage.empty
-coverage combine .coverage.*
+if [ ${COVERAGE_THRESHOLD} -ne 0 ]; then
+  echo "COVERAGE_THRESHOLD set to ${COVERAGE_THRESHOLD}%"
+fi
+
+# Moving coverage files from src (tests usually save it there).
+mv -v src/.coverage* . 2>/dev/null
+
+# When there are some .coverage.* files, it is a sign
+# we need to combine them into one .coverage file.
+if ls .coverage.* 2>/dev/null; then
+  # Need to create an empty coverage file containing
+  # all existing code files, to get coverage over whole src.
+  echo "Creating .coverage.empty file"
+  coverage run --source=./src /dev/null 2>/dev/null
+  mv .coverage .coverage.empty
+  echo "Combining .coverage.* files"
+  coverage combine .coverage.*
+elif [ ! -f .coverage ]; then
+  echo "ERROR: .coverage file not found"
+  exit 1
+else
+  echo "Using already existing .coverage file"
+fi
 
 EXCLUDES="\
 src/all_modules.py,\
@@ -16,10 +36,23 @@ coverage html \
   --omit="$EXCLUDES" \
   --fail-under=${COVERAGE_THRESHOLD}
 
-if [ $? -eq 2 ]; then
-  echo "Code coverage is less than ${COVERAGE_THRESHOLD}%"
+EXIT_CODE=$?
+
+RESULT=$(grep pc_cov htmlcov/index.html | egrep -o '[0-9]{1,3}%')
+
+# Catching the case when coverage is less than threshold
+if [ ${EXIT_CODE} -eq 2 ]; then
+  echo "ERROR: Code coverage is less than ${COVERAGE_THRESHOLD}% - ${RESULT}"
+  echo "See core/htmlcov/index.html for details."
   exit 1
 fi
 
-RESULT=$(grep pc_cov htmlcov/index.html | egrep -o '[0-9]{1,3}%')
-echo "COVERAGE: ${RESULT}"
+# Catching all other errors
+if [ ${EXIT_CODE} -ne 0 ]; then
+  echo "ERROR: Coverage generation failed with exit code ${EXIT_CODE} - see output above"
+  exit ${EXIT_CODE}
+fi
+
+# Happy path
+echo "SUCCESS: COVERAGE: ${RESULT}"
+echo "See core/htmlcov/index.html for details."

--- a/docs/ci/jobs.md
+++ b/docs/ci/jobs.md
@@ -148,72 +148,72 @@ with the expected UI result.
 See artifacts for a comprehensive report of UI.
 See [docs/tests/ui-tests](../tests/ui-tests.md) for more info.
 
-### [core device asan test](https://github.com/trezor/trezor-firmware/blob/master/ci/test.yml#L83)
+### [core device asan test](https://github.com/trezor/trezor-firmware/blob/master/ci/test.yml#L84)
 
-### [core btconly device test](https://github.com/trezor/trezor-firmware/blob/master/ci/test.yml#L102)
+### [core btconly device test](https://github.com/trezor/trezor-firmware/blob/master/ci/test.yml#L103)
 Device tests excluding altcoins, only for BTC.
 
-### [core btconly device asan test](https://github.com/trezor/trezor-firmware/blob/master/ci/test.yml#L122)
+### [core btconly device asan test](https://github.com/trezor/trezor-firmware/blob/master/ci/test.yml#L123)
 
-### [core monero test](https://github.com/trezor/trezor-firmware/blob/master/ci/test.yml#L143)
+### [core monero test](https://github.com/trezor/trezor-firmware/blob/master/ci/test.yml#L144)
 Monero tests.
 
-### [core monero asan test](https://github.com/trezor/trezor-firmware/blob/master/ci/test.yml#L162)
+### [core monero asan test](https://github.com/trezor/trezor-firmware/blob/master/ci/test.yml#L163)
 
-### [core u2f test](https://github.com/trezor/trezor-firmware/blob/master/ci/test.yml#L184)
+### [core u2f test](https://github.com/trezor/trezor-firmware/blob/master/ci/test.yml#L185)
 Tests for U2F and HID.
 
-### [core u2f asan test](https://github.com/trezor/trezor-firmware/blob/master/ci/test.yml#L203)
+### [core u2f asan test](https://github.com/trezor/trezor-firmware/blob/master/ci/test.yml#L204)
 
-### [core fido2 test](https://github.com/trezor/trezor-firmware/blob/master/ci/test.yml#L221)
+### [core fido2 test](https://github.com/trezor/trezor-firmware/blob/master/ci/test.yml#L222)
 FIDO2 device tests.
 
-### [core fido2 asan test](https://github.com/trezor/trezor-firmware/blob/master/ci/test.yml#L244)
+### [core fido2 asan test](https://github.com/trezor/trezor-firmware/blob/master/ci/test.yml#L245)
 
-### [core click test](https://github.com/trezor/trezor-firmware/blob/master/ci/test.yml#L264)
+### [core click test](https://github.com/trezor/trezor-firmware/blob/master/ci/test.yml#L265)
 Click tests.
 See [docs/tests/click-tests](../tests/click-tests.md) for more info.
 
-### [core click asan test](https://github.com/trezor/trezor-firmware/blob/master/ci/test.yml#L292)
+### [core click asan test](https://github.com/trezor/trezor-firmware/blob/master/ci/test.yml#L294)
 
-### [core upgrade test](https://github.com/trezor/trezor-firmware/blob/master/ci/test.yml#L313)
+### [core upgrade test](https://github.com/trezor/trezor-firmware/blob/master/ci/test.yml#L315)
 Upgrade tests.
 See [docs/tests/upgrade-tests](../tests/upgrade-tests.md) for more info.
 
-### [core upgrade asan test](https://github.com/trezor/trezor-firmware/blob/master/ci/test.yml#L332)
+### [core upgrade asan test](https://github.com/trezor/trezor-firmware/blob/master/ci/test.yml#L334)
 
-### [core persistence test](https://github.com/trezor/trezor-firmware/blob/master/ci/test.yml#L354)
+### [core persistence test](https://github.com/trezor/trezor-firmware/blob/master/ci/test.yml#L356)
 Persistence tests.
 
-### [core persistence asan test](https://github.com/trezor/trezor-firmware/blob/master/ci/test.yml#L370)
+### [core persistence asan test](https://github.com/trezor/trezor-firmware/blob/master/ci/test.yml#L372)
 
-### [core hwi test](https://github.com/trezor/trezor-firmware/blob/master/ci/test.yml#L388)
+### [core hwi test](https://github.com/trezor/trezor-firmware/blob/master/ci/test.yml#L390)
 
-### [crypto test](https://github.com/trezor/trezor-firmware/blob/master/ci/test.yml#L406)
+### [crypto test](https://github.com/trezor/trezor-firmware/blob/master/ci/test.yml#L408)
 
-### [legacy device test](https://github.com/trezor/trezor-firmware/blob/master/ci/test.yml#L437)
+### [legacy device test](https://github.com/trezor/trezor-firmware/blob/master/ci/test.yml#L439)
 
-### [legacy asan test](https://github.com/trezor/trezor-firmware/blob/master/ci/test.yml#L464)
+### [legacy asan test](https://github.com/trezor/trezor-firmware/blob/master/ci/test.yml#L466)
 
-### [legacy btconly test](https://github.com/trezor/trezor-firmware/blob/master/ci/test.yml#L476)
+### [legacy btconly test](https://github.com/trezor/trezor-firmware/blob/master/ci/test.yml#L478)
 
-### [legacy btconly asan test](https://github.com/trezor/trezor-firmware/blob/master/ci/test.yml#L496)
+### [legacy btconly asan test](https://github.com/trezor/trezor-firmware/blob/master/ci/test.yml#L498)
 
-### [legacy upgrade test](https://github.com/trezor/trezor-firmware/blob/master/ci/test.yml#L511)
+### [legacy upgrade test](https://github.com/trezor/trezor-firmware/blob/master/ci/test.yml#L513)
 
-### [legacy upgrade asan test](https://github.com/trezor/trezor-firmware/blob/master/ci/test.yml#L530)
+### [legacy upgrade asan test](https://github.com/trezor/trezor-firmware/blob/master/ci/test.yml#L532)
 
-### [legacy hwi test](https://github.com/trezor/trezor-firmware/blob/master/ci/test.yml#L551)
+### [legacy hwi test](https://github.com/trezor/trezor-firmware/blob/master/ci/test.yml#L553)
 
-### [python test](https://github.com/trezor/trezor-firmware/blob/master/ci/test.yml#L570)
+### [python test](https://github.com/trezor/trezor-firmware/blob/master/ci/test.yml#L572)
 
-### [python support test](https://github.com/trezor/trezor-firmware/blob/master/ci/test.yml#L589)
+### [python support test](https://github.com/trezor/trezor-firmware/blob/master/ci/test.yml#L591)
 
-### [storage test](https://github.com/trezor/trezor-firmware/blob/master/ci/test.yml#L599)
+### [storage test](https://github.com/trezor/trezor-firmware/blob/master/ci/test.yml#L601)
 
-### [core unix memory profiler](https://github.com/trezor/trezor-firmware/blob/master/ci/test.yml#L623)
+### [core unix memory profiler](https://github.com/trezor/trezor-firmware/blob/master/ci/test.yml#L625)
 
-### [connect test core](https://github.com/trezor/trezor-firmware/blob/master/ci/test.yml#L647)
+### [connect test core](https://github.com/trezor/trezor-firmware/blob/master/ci/test.yml#L649)
 
 ---
 ## TEST-HW stage - [test-hw.yml](https://github.com/trezor/trezor-firmware/blob/master/ci/test-hw.yml)

--- a/docs/tests/ui-tests.md
+++ b/docs/tests/ui-tests.md
@@ -73,12 +73,12 @@ pytest tests/device_tests --ui=record --ui-check-missing
 ### Tests
 
 Each `--ui=test` creates a clear report which tests passed and which failed.
-The index file is stored in `tests/ui_tests/reporting/reports/test/index.html`.
+The index file is stored in `tests/ui_tests/reports/test/index.html`.
 The script `tests/show_results.py` starts a local HTTP server that serves this page --
 this is necessary for access to browser local storage, which enables a simple reviewer
 UI.
 
-On CI this report is published as an artifact. You can see the latest master report [here](https://gitlab.com/satoshilabs/trezor/trezor-firmware/-/jobs/artifacts/master/file/test_ui_report/index.html?job=core%20device%20ui%20test). The reviewer features work directly here.
+On CI this report is published as an artifact. You can see the latest master report [here](https://gitlab.com/satoshilabs/trezor/trezor-firmware/-/jobs/artifacts/master/file/test_ui_report/index.html?job=core%20device%20test). The reviewer features work directly here.
 
 If needed, you can use `python3 -m tests.ui_tests` to regenerate the report from local
 recorded screens.

--- a/tests/emulators.py
+++ b/tests/emulators.py
@@ -17,7 +17,7 @@
 import tempfile
 from collections import defaultdict
 from pathlib import Path
-from typing import Dict, List, Optional, Tuple
+from typing import Dict, List, Optional, Sequence, Tuple
 
 from trezorlib._internal.emulator import CoreEmulator, Emulator, LegacyEmulator
 
@@ -75,6 +75,7 @@ class EmulatorWrapper:
         port: Optional[int] = None,
         headless: bool = True,
         auto_interact: bool = True,
+        main_args: Sequence[str] = ("-m", "main"),
     ) -> None:
         if tag is not None:
             executable = filename_from_tag(gen, tag)
@@ -107,6 +108,7 @@ class EmulatorWrapper:
                 port=port,
                 headless=headless,
                 auto_interact=auto_interact,
+                main_args=main_args,
             )
         else:
             raise ValueError(


### PR DESCRIPTION
Creating a draft from the experiments I tried.

The time-saving of all these changes _could_ be around 2-3 minutes per test, when nothing breaks.

WRT to `danger_no_wipe_device` marker, it is a really extreme measure, saves `0.1-0.2` seconds from each saved wipe-initialize cycle, but it takes some development time to try where it works and where not. 

Currently, the `skip_ui` option is not being used, as it made some UI tests break - but with some effort, it should be compatible.