### PR TITLE
chore(rust): decrease icon top margin on welcome screen to 48 px

### DIFF
--- a/core/embed/rust/src/ui/model_tt/component/welcome_screen.rs
+++ b/core/embed/rust/src/ui/model_tt/component/welcome_screen.rs
@@ -6,7 +6,7 @@ use crate::ui::{
 };
 
 const TEXT_BOTTOM_MARGIN: i16 = 24; // matching the homescreen label margin
-const ICON_TOP_MARGIN: i16 = 62;
+const ICON_TOP_MARGIN: i16 = 48;
 const MODEL_NAME: &str = "Trezor Model T";
 const MODEL_NAME_FONT: display::Font = display::Font::DEMIBOLD;
 


### PR DESCRIPTION
Changed from 62 to 48 px. Before vs After

![image](https://user-images.githubusercontent.com/42543243/222453264-51fe869a-2b1b-4705-a6cb-4d91599887c3.png)
![image](https://user-images.githubusercontent.com/42543243/222452971-56febbe2-f3e9-42c3-afe7-fa8df785d48f.png)

