### PR TITLE
chore(vendor): replace secp256k1-zkp with secp256k1 (v0.3.0)

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -7,7 +7,7 @@
 	ignore = untracked
 [submodule "vendor/secp256k1-zkp"]
 	path = vendor/secp256k1-zkp
-	url = https://github.com/ElementsProject/secp256k1-zkp.git
+	url = https://github.com/bitcoin-core/secp256k1.git
 [submodule "common/defs/ethereum/tokens"]
 	path = common/defs/ethereum/tokens
 	url = https://github.com/ethereum-lists/tokens.git


### PR DESCRIPTION
We don't use any ZKP features at the moment, so we might as well switch to upstream [secp256k1](https://github.com/bitcoin-core/secp256k1) which does stable releases now.

I am keeping the original submodule name and "zkp" in all integrations, because it seemed kind of pointless to try to rename/refactor everything, especially when we might want to switch back to secp256k1-zkp in the future.

This PR might cause some headaches with local checkouts, so `git submodule sync` might be in order.