### PR TITLE
Show app icon in Fido2ConfirmNoCredentials

### DIFF
--- a/core/src/apps/webauthn/fido2.py
+++ b/core/src/apps/webauthn/fido2.py
@@ -930,6 +930,7 @@ class Fido2ConfirmNoCredentials(Fido2ConfirmGetAssertion):
     def __init__(self, cid: int, iface: HID, rp_id: str) -> None:
         cred = Fido2Credential()
         cred.rp_id = rp_id
+        cred.rp_id_hash = hashlib.sha256(rp_id).digest()
         super().__init__(
             cid, iface, b"", [cred], {}, resident=False, user_verification=False
         )


### PR DESCRIPTION
This should fix the missing logo reported in https://github.com/trezor/trezor-firmware/pull/2844#issuecomment-1443747492
> first FIDO2 screen does not display Google logo

For reasons stated in https://github.com/trezor/trezor-firmware/pull/2844#issuecomment-1443823464, it does not fix:
> you have to confirm login twice FIDO2 and then U2F