### PR TITLE
Improve protobuf varint handling

### DIFF
--- a/core/tests/test_trezor.protobuf.py
+++ b/core/tests/test_trezor.protobuf.py
@@ -1,7 +1,12 @@
 from common import *
 
 from trezor import protobuf
-from trezor.messages import WebAuthnCredential, Failure, SignMessage, DebugLinkMemoryRead
+from trezor.messages import (
+    WebAuthnCredential,
+    Failure,
+    SignMessage,
+    DebugLinkMemoryRead,
+)
 
 
 def load_uvarint32(data: bytes) -> int:
@@ -49,7 +54,9 @@ def dump_message(msg: protobuf.MessageType) -> bytearray:
     return buffer
 
 
-def load_message(msg_type: Type[protobuf.MessageType], buffer: bytes) -> protobuf.MessageType:
+def load_message(
+    msg_type: Type[protobuf.MessageType], buffer: bytes
+) -> protobuf.MessageType:
     return protobuf.decode(buffer, msg_type, False)
 
 
@@ -69,6 +76,14 @@ class TestProtobuf(unittest.TestCase):
             self.assertEqual(load_uvarint(b"\x01"), 1)
             self.assertEqual(load_uvarint(b"\xff\x01"), 0xFF)
             self.assertEqual(load_uvarint(b"\xc0\xc4\x07"), 123456)
+
+        self.assertEqual(
+            load_uvarint64(b"\xff\xff\xff\xff\xff\xff\xff\xff\xff\x01"),
+            0xFFFF_FFFF_FFFF_FFFF,
+        )
+        with self.assertRaises(OverflowError):
+            i = load_uvarint64(b"\x80\x80\x80\x80\x80\x80\x80\x80\x80\x02")
+            print(hex(i))
 
     def test_validate_enum(self):
         # ok message:
@@ -108,7 +123,6 @@ class TestProtobuf(unittest.TestCase):
 
         self.assertEqual(nmsg.message, b"hello")
         self.assertEqual(nmsg.coin_name, "Bitcoin")
-
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
an unintentional panic was discovered by a pentest by cure53:

> During testing, it was discovered that the Trezor firmware is vulnerable to DoS attacks due to a flaw in the Rust Protobuf handling. A malicious user could leverage this vulnerability by sending a malformed USB packet to the Trezor firmware, which would result in a crash of the Trezor HSM. The issue was specifically found by a custom fuzzer which leverages the AFL++ framework.
>
> (...)
>
> While using the AFL++ fuzzer for testing, approximately 50 unique crashes emerged out of a total of 2 million executions performed with this test harness. All of the identified crashes had similar stacktraces. The following is an example of the stacktrace observed in these crashes:
>
> ```
> Program received signal SIGABRT, Aborted.
> __GI_raise (sig=sig@entry=6) at ../sysdeps/unix/sysv/linux/raise.c:50
> 50 ../sysdeps/unix/sysv/linux/raise.c: No such file or directory.
> (gdb) bt
> #0 __GI_raise (sig=sig@entry=6) at ../sysdeps/unix/sysv/linux/raise.c:50
> #1 0x00007ffff6777859 in __GI_abort () at abort.c:79
> #2 0x0000555555bdec22 in __fatal_error (expr=<optimized out>, msg=<optimized out>, file=<optimized out>, line=<optimized out>, func=<optimized out>) at embed/unix/common.c:83
> #3 0x000055555604f6d6 in trezor_lib::trezorhal::common::__fatal_error ()
> #4 0x00005555560736cf in rust_begin_unwind ()
> #5 0x0000555555bdec36 in core::panicking::panic_fmt () at library/core/src/panicking.rs:64
> #6 0x0000555555bded2c in core::panicking::panic () at library/core/src/panicking.rs:111
> #7 0x000055555605e68d in trezor_lib::protobuf::decode::InputStream::read_uvarint ()
> #8 0x0000555556054ee8 in trezor_lib::protobuf::decode::Decoder::message_from_stream ()
> #9 0x0000555556053ce1 in protobuf_decode ()
> #10 0x000055555604037b in fuzz (buffer=<optimized out>, len=<optimized out>) at embed/unix/harness.c:49
> #11 0x0000555555be3659 in main (argc=<optimized out>, argv=<optimized out>) at embed/unix/harness.c:103
> ```
>
> The trace indicates that a panic occurred in `trezor_lib::protobuf::decode::InputStream::read_uvarint` because of an overflow error, resulting in a fatal error that would render the device unusable.
>

As a result, a malicious application can cause the Trezor firmware to freeze.

Using Rust helps us here because the overflow triggers a panic (i.e., a shutdown), so an invalid value cannot propagate out.
(with that said, in this particular place, an attacker could not use the overflow for anything useful; the output would be a mis-decoded 64 bit number that the same attacker could instead just encode directly)

---

This PR fixes the panic and adds a testcase. I'm keeping it as a draft because there is space for further improvement here.

Namely:

* we should differentiate between (u/s)int32 and (u/s)int64
* we should have a special 32-bit decoder call
* we might want to try to use the 32-bit call even in 64-bit cases to improve performance (STM32 is a 32bit CPU) and only upgrade to the 64-bit code in case of overflow