### PR TITLE
Add Nostr to misc.json

### DIFF
--- a/common/defs/misc/misc.json
+++ b/common/defs/misc/misc.json
@@ -175,5 +175,16 @@
             "Homepage": "https://tether.to"
         },
         "wallet": {}
+    },
+    {
+        "name": "Nostr",
+        "shortcut": "NOSTR",
+        "slip44": 1237,
+        "curve": "secp256k1",
+        "decimals": 0,
+        "links": {
+            "Github": "https://github.com/nostr-protocol/nostr"
+        },
+        "wallet": {}
     }
 ]


### PR DESCRIPTION
This will enable Trezor users to sign Nostr events: https://github.com/nostr-protocol/nips/blob/master/06.md