### PR TITLE
Fix bootloader using predictable PRNG. Fix build logic to make predictable PRNG opt-in, not opt-out

### DIFF
--- a/core/.changelog.d/2899.fixed
+++ b/core/.changelog.d/2899.fixed
@@ -1,0 +1,1 @@
+Fix RNG for bootloader and make insecure PRNG opt-in, not opt-out.

--- a/core/SConscript.bootloader
+++ b/core/SConscript.bootloader
@@ -49,8 +49,9 @@ CPPDEFINES_MOD += [
     'ED25519_NO_PRECOMP',
     'TREZOR_UI2',
     'USE_RUST_LOADER',
-    'FANCY_FATAL_ERROR'
+    'FANCY_FATAL_ERROR',
 ]
+
 SOURCE_MOD += [
     'vendor/trezor-crypto/blake2s.c',
     'vendor/trezor-crypto/chacha_drbg.c',
@@ -77,6 +78,7 @@ SOURCE_MOD += [
     'embed/extmod/modtrezorui/display.c',
     'embed/extmod/modtrezorui/fonts/fonts.c',
     'embed/extmod/modtrezorui/fonts/font_bitmap.c',
+    'embed/extmod/modtrezorcrypto/rand.c',
     'vendor/micropython/lib/uzlib/adler32.c',
     'vendor/micropython/lib/uzlib/crc32.c',
     'vendor/micropython/lib/uzlib/tinflate.c',

--- a/core/SConscript.bootloader_ci
+++ b/core/SConscript.bootloader_ci
@@ -71,6 +71,7 @@ SOURCE_MOD += [
     'embed/extmod/modtrezorui/colors.c',
     'embed/extmod/modtrezorui/fonts/fonts.c',
     'embed/extmod/modtrezorui/fonts/font_bitmap.c',
+    'embed/extmod/modtrezorcrypto/rand.c',
     'vendor/micropython/lib/uzlib/adler32.c',
     'vendor/micropython/lib/uzlib/crc32.c',
     'vendor/micropython/lib/uzlib/tinflate.c',

--- a/core/SConscript.firmware
+++ b/core/SConscript.firmware
@@ -61,7 +61,6 @@ CPPPATH_MOD += [
 CPPDEFINES_MOD += [
     'AES_128',
     'AES_192',
-    'RAND_PLATFORM_INDEPENDENT',
     ('USE_BIP32_CACHE', '0'),
     ('USE_KECCAK', '1'),
     ('USE_ETHEREUM', '1' if EVERYTHING else '0'),

--- a/core/SConscript.prodtest
+++ b/core/SConscript.prodtest
@@ -10,7 +10,9 @@ FEATURES_WANTED = ["input", "sbu", "sdcard", "rdb_led"]
 
 CCFLAGS_MOD = ''
 CPPPATH_MOD = []
-CPPDEFINES_MOD = []
+CPPDEFINES_MOD = [
+    'USE_INSECURE_PRNG',
+]
 SOURCE_MOD = []
 
 if TREZOR_MODEL in ('1', 'R'):

--- a/core/SConscript.unix
+++ b/core/SConscript.unix
@@ -55,6 +55,7 @@ CPPPATH_MOD += [
 CPPDEFINES_MOD += [
     'AES_128',
     'AES_192',
+    'USE_INSECURE_PRNG',
     ('USE_BIP32_CACHE', '0'),
     ('USE_KECCAK', '1'),
     ('USE_ETHEREUM', '1' if EVERYTHING else '0'),

--- a/crypto/Makefile
+++ b/crypto/Makefile
@@ -82,6 +82,7 @@ CFLAGS += -DUSE_KECCAK=1
 CFLAGS += -DUSE_MONERO=1
 CFLAGS += -DUSE_NEM=1
 CFLAGS += -DUSE_CARDANO=1
+CFLAGS += -DUSE_INSECURE_PRNG=1
 CFLAGS += $(shell pkg-config --cflags openssl)
 
 # disable certain optimizations and features when small footprint is required

--- a/crypto/rand.c
+++ b/crypto/rand.c
@@ -23,7 +23,7 @@
 
 #include "rand.h"
 
-#ifndef RAND_PLATFORM_INDEPENDENT
+#ifdef USE_INSECURE_PRNG
 
 #pragma message( \
     "NOT SUITABLE FOR PRODUCTION USE! Replace random32() function with your own secure code.")
@@ -48,7 +48,7 @@ uint32_t random32(void) {
   return seed;
 }
 
-#endif /* RAND_PLATFORM_INDEPENDENT */
+#endif /* USE_INSECURE_PRNG */
 
 //
 // The following code is platform independent

--- a/legacy/Makefile.include
+++ b/legacy/Makefile.include
@@ -104,6 +104,7 @@ CFLAGS   += -DHW_REVISION=0
 
 ifeq ($(EMULATOR),1)
 CFLAGS   += -DEMULATOR=1
+CFLAGS   += -DUSE_INSECURE_PRNG=1
 
 CFLAGS   += -include $(TOP_DIR)emulator/emulator.h
 CFLAGS   += -include stdio.h
@@ -125,7 +126,6 @@ LDSCRIPT  = $(TOP_DIR)/memory.ld
 endif
 
 CFLAGS   += -DEMULATOR=0
-CFLAGS   += -DRAND_PLATFORM_INDEPENDENT=1
 
 LDFLAGS  += --static \
             -Wl,--start-group \


### PR DESCRIPTION
Fixes #2828 .

Bootloader now uses TRNG for `random32()`. The old opt-out misnomer definition `RAND_PLATFORM_INDEPENDENT` was changed opt-in `USE_INSECURE_PRNG` which needs to be specified explicitly to use predictable PRNG (for non-production code such as emulators).

