### PR TITLE
feat(legacy): use new artifacts naming for legacy builds

### DIFF
--- a/build-docker.sh
+++ b/build-docker.sh
@@ -224,6 +224,7 @@ for BITCOIN_ONLY in ${VARIANTS_legacy[@]}; do
     cp bootloader/bootloader.bin build/bootloader/bootloader.bin
     cp intermediate_fw/trezor.bin build/intermediate_fw/inter.bin
     cp firmware/trezor.bin build/firmware/firmware.bin
+    cp firmware/firmware*.bin build/firmware/ || true  # ignore missing file as it will not be present in old tags
     cp firmware/trezor.elf build/firmware/firmware.elf
     poetry run ../python/tools/firmware-fingerprint.py \
                -o build/firmware/firmware.bin.fingerprint \

--- a/legacy/script/cibuild
+++ b/legacy/script/cibuild
@@ -29,4 +29,23 @@ if [ "$EMULATOR" != 1 ]; then
     make -C firmware sign
     make -C intermediate_fw
     make -C intermediate_fw sign
+
+    # Giving the firmware bin a descriptive name
+    if [ "$BITCOIN_ONLY" = 1 ]; then
+        BTCONLY="-bitcoinonly"
+    else
+        BTCONLY=""
+    fi
+    VERSION_MAJOR=$(grep -P '\bVERSION_MAJOR\b' firmware/version.h | cut -d' ' -f3)
+    VERSION_MINOR=$(grep -P '\bVERSION_MINOR\b' firmware/version.h | cut -d' ' -f3)
+    VERSION_PATCH=$(grep -P '\bVERSION_PATCH\b' firmware/version.h | cut -d' ' -f3)
+    VERSION="${VERSION_MAJOR}.${VERSION_MINOR}.${VERSION_PATCH}"
+    GITHASH=$(git rev-parse --short HEAD)
+    if git status --porcelain | grep -q '.'; then
+        echo "There are changes in the repository."
+        DIRTY="-dirty"
+    else
+        DIRTY=""
+    fi
+    cp firmware/trezor.bin firmware/firmware-T1B1${BTCONLY}-${VERSION}-${GITHASH}${DIRTY}.bin
 fi


### PR DESCRIPTION
Fixes https://github.com/trezor/trezor-firmware/issues/2732:
- exports legacy firmware build under a descriptive name, for example `firmware-T1B1-bitcoinonly-1.12.2-cc5233e57-dirty.bin`
- adds this export also to `build-docker.sh`, where we need to account for older tags/branches not having this, and therefore ignoring the possible error