### PR TITLE
increase work buffer size for jpeg decompression

### DIFF
--- a/core/embed/extmod/modtrezorui/buffers.h
+++ b/core/embed/extmod/modtrezorui/buffers.h
@@ -41,7 +41,9 @@
 // 3100 is needed according to tjpgd docs,
 // 256 because we need non overlapping memory in rust
 // 6 << 10 is for huffman decoding table
-#define JPEG_WORK_SIZE (3100 + 256 + (6 << 10))
+// 1000 bytes reserve, as we discovered that we are running out of memory
+// sometimes
+#define JPEG_WORK_SIZE (3100 + 256 + (6 << 10) + 1000)
 
 #if defined BOOTLOADER
 #define BUFFER_SECTION __attribute__((section(".buf")))


### PR DESCRIPTION
Increasing the work buffer size a bit to make it more reliable. 

<!--
If you are a core dev:

Don't forget to set up the fields:
- assign yourself
- set priority to same as original issue
- add PR to sprint
- if Draft -> "in progress"
- if final PR -> "needs review"

If you're an external contributor, you can ignore this text.
-->
