### PR TITLE
fix(core): fix FMC initialization

### DIFF
--- a/core/embed/trezorhal/displays/st7789v.c
+++ b/core/embed/trezorhal/displays/st7789v.c
@@ -520,8 +520,9 @@ void display_init_seq(void) {
 void display_setup_fmc(void) {
   // Reference UM1725 "Description of STM32F4 HAL and LL drivers",
   // section 64.2.1 "How to use this driver"
-  SRAM_HandleTypeDef external_display_data_sram;
+  SRAM_HandleTypeDef external_display_data_sram = {0};
   external_display_data_sram.Instance = FMC_NORSRAM_DEVICE;
+  external_display_data_sram.Extended = FMC_NORSRAM_EXTENDED_DEVICE;
   external_display_data_sram.Init.NSBank = FMC_NORSRAM_BANK1;
   external_display_data_sram.Init.DataAddressMux = FMC_DATA_ADDRESS_MUX_DISABLE;
   external_display_data_sram.Init.MemoryType = FMC_MEMORY_TYPE_SRAM;
@@ -543,7 +544,7 @@ void display_setup_fmc(void) {
   external_display_data_sram.Init.PageSize = FMC_PAGE_SIZE_NONE;
 
   // reference RM0090 section 37.5 Table 259, 37.5.4, Mode 1 SRAM, and 37.5.6
-  FMC_NORSRAM_TimingTypeDef normal_mode_timing;
+  FMC_NORSRAM_TimingTypeDef normal_mode_timing = {0};
   normal_mode_timing.AddressSetupTime = 5;
   normal_mode_timing.AddressHoldTime = 1;  // don't care
   normal_mode_timing.DataSetupTime = 6;

--- a/core/embed/trezorhal/displays/ug-2828tswig01.c
+++ b/core/embed/trezorhal/displays/ug-2828tswig01.c
@@ -317,8 +317,9 @@ void display_init(void) {
 
   // Reference UM1725 "Description of STM32F4 HAL and LL drivers",
   // section 64.2.1 "How to use this driver"
-  SRAM_HandleTypeDef external_display_data_sram;
+  SRAM_HandleTypeDef external_display_data_sram = {0};
   external_display_data_sram.Instance = FMC_NORSRAM_DEVICE;
+  external_display_data_sram.Extended = FMC_NORSRAM_EXTENDED_DEVICE;
   external_display_data_sram.Init.NSBank = FMC_NORSRAM_BANK1;
   external_display_data_sram.Init.DataAddressMux = FMC_DATA_ADDRESS_MUX_DISABLE;
   external_display_data_sram.Init.MemoryType = FMC_MEMORY_TYPE_SRAM;
@@ -340,7 +341,7 @@ void display_init(void) {
   external_display_data_sram.Init.PageSize = FMC_PAGE_SIZE_NONE;
 
   // reference RM0090 section 37.5 Table 259, 37.5.4, Mode 1 SRAM, and 37.5.6
-  FMC_NORSRAM_TimingTypeDef normal_mode_timing;
+  FMC_NORSRAM_TimingTypeDef normal_mode_timing = {0};
   normal_mode_timing.AddressSetupTime = 10;
   normal_mode_timing.AddressHoldTime = 10;
   normal_mode_timing.DataSetupTime = 10;


### PR DESCRIPTION
Fixes initialization of FMC, where unitialized pointer could cause a write to invalid memory.

<!--
If you are a core dev:

Don't forget to set up the fields:
- assign yourself
- set priority to same as original issue
- add PR to sprint
- if Draft -> "in progress"
- if final PR -> "needs review"

If you're an external contributor, you can ignore this text.
-->
