### PR TITLE
core: prevent USB events from waking autolock timer

### DIFF
--- a/core/.changelog.d/2651.changed
+++ b/core/.changelog.d/2651.changed
@@ -1,0 +1,1 @@
+Auto-lock timer is no longer restarted by USB messages, only touch screen activity.

--- a/core/src/apps/bitcoin/sign_tx/bitcoin.py
+++ b/core/src/apps/bitcoin/sign_tx/bitcoin.py
@@ -1,6 +1,7 @@
 from micropython import const
 from typing import TYPE_CHECKING
 
+from trezor import workflow
 from trezor.crypto.hashlib import sha256
 from trezor.enums import InputScriptType
 from trezor.utils import HashWriter, empty_bytearray
@@ -75,6 +76,10 @@ class Bitcoin:
             self.tx_info.tx,
             self.orig_txs,
         )
+
+        # Following steps can take a long time, make sure autolock doesn't kick in.
+        # This is set to True again after workflow is finished in start_default().
+        workflow.autolock_interrupts_workflow = False
 
         # Verify the transaction input amounts by requesting each previous transaction
         # and checking its output amount. Verify external inputs which have already

--- a/core/src/apps/debug/__init__.py
+++ b/core/src/apps/debug/__init__.py
@@ -132,7 +132,9 @@ if __debug__:
     async def dispatch_DebugLinkDecision(
         ctx: wire.Context, msg: DebugLinkDecision
     ) -> None:
-        from trezor import io
+        from trezor import io, workflow
+
+        workflow.idle_timer.touch()
 
         if debuglink_decision_chan.putters:
             log.warning(__name__, "DebugLinkDecision queue is not empty")

--- a/core/src/storage/cache.py
+++ b/core/src/storage/cache.py
@@ -47,6 +47,10 @@ LOCKSCREEN_ON = object()
 BUSYSCREEN_ON = object()
 homescreen_shown: object | None = None
 
+# Timestamp of last autolock activity.
+# Here to persist across main loop restart between workflows.
+autolock_last_touch: int | None = None
+
 
 class InvalidSessionError(Exception):
     pass
@@ -338,8 +342,11 @@ def stored_async(key: int) -> Callable[[AsyncByteFunc[P]], AsyncByteFunc[P]]:
 
 def clear_all() -> None:
     global _active_session_idx
+    global autolock_last_touch
 
     _active_session_idx = None
     _SESSIONLESS_CACHE.clear()
     for session in _SESSIONS:
         session.clear()
+
+    autolock_last_touch = None

--- a/core/src/trezor/wire/__init__.py
+++ b/core/src/trezor/wire/__init__.py
@@ -194,8 +194,6 @@ class Context:
                 expected_type.MESSAGE_NAME,
             )
 
-        workflow.idle_timer.touch()
-
         # look up the protobuf class and parse the message
         return _wrap_protobuf_load(msg.data, expected_type)
 
@@ -230,8 +228,6 @@ class Context:
                 self.sid,
                 exptype.MESSAGE_NAME,
             )
-
-        workflow.idle_timer.touch()
 
         # parse the message and return it
         return _wrap_protobuf_load(msg.data, exptype)
@@ -321,6 +317,9 @@ async def _handle_single_message(
         # respond with failure.
         await ctx.write(unexpected_message())
         return None
+
+    if msg.type in workflow.ALLOW_WHILE_LOCKED:
+        workflow.autolock_interrupts_workflow = False
 
     # Here we make sure we always respond with a Failure response
     # in case of any errors.

--- a/python/src/trezorlib/debuglink.py
+++ b/python/src/trezorlib/debuglink.py
@@ -690,7 +690,7 @@ class TrezorClientDebugLink(TrezorClient):
         self.actual_responses: Optional[List[protobuf.MessageType]] = None
         self.filters: Dict[
             Type[protobuf.MessageType],
-            Callable[[protobuf.MessageType], protobuf.MessageType],
+            Optional[Callable[[protobuf.MessageType], protobuf.MessageType]],
         ] = {}
 
     def ensure_open(self) -> None:
@@ -711,7 +711,7 @@ class TrezorClientDebugLink(TrezorClient):
     def set_filter(
         self,
         message_type: Type[protobuf.MessageType],
-        callback: Callable[[protobuf.MessageType], protobuf.MessageType],
+        callback: Optional[Callable[[protobuf.MessageType], protobuf.MessageType]],
     ) -> None:
         """Configure a filter function for a specified message type.
 

--- a/tests/click_tests/test_autolock.py
+++ b/tests/click_tests/test_autolock.py
@@ -21,17 +21,26 @@ from typing import TYPE_CHECKING
 import pytest
 
 from trezorlib import btc, device, exceptions, messages
+from trezorlib.protobuf import MessageType
 from trezorlib.tools import parse_path
 
 from .. import buttons, common
+from ..device_tests.bitcoin.payment_req import make_coinjoin_request
 from ..tx_cache import TxCache
 from . import recovery
 
 if TYPE_CHECKING:
     from ..device_handler import BackgroundDeviceHandler
 
-TX_CACHE = TxCache("Bitcoin")
+TX_CACHE_MAINNET = TxCache("Bitcoin")
+TX_CACHE_TESTNET = TxCache("Testnet")
 
+FAKE_TXHASH_e5b7e2 = bytes.fromhex(
+    "e5b7e21b5ba720e81efd6bfa9f854ababdcddc75a43bfa60bf0fe069cfd1bb8a"
+)
+FAKE_TXHASH_f982c0 = bytes.fromhex(
+    "f982c0a283bd65a59aa89eded9e48f2a3319cb80361dfab4cf6192a03badb60a"
+)
 TXHASH_d5f65e = bytes.fromhex(
     "d5f65ee80147b4bcc70b75e4bbf2d7382021b871bd8867ef8fa525ef50864882"
 )
@@ -64,6 +73,8 @@ def set_autolock_delay(device_handler: "BackgroundDeviceHandler", delay_ms: int)
 
 @pytest.mark.setup_client(pin=PIN4)
 def test_autolock_interrupts_signing(device_handler: "BackgroundDeviceHandler"):
+    """Autolock will lock the device that is waiting for the user
+    to confirm transaction."""
     set_autolock_delay(device_handler, 10_000)
 
     debug = device_handler.debuglink()
@@ -81,7 +92,9 @@ def test_autolock_interrupts_signing(device_handler: "BackgroundDeviceHandler"):
         script_type=messages.OutputScriptType.PAYTOADDRESS,
     )
 
-    device_handler.run(btc.sign_tx, "Bitcoin", [inp1], [out1], prev_txes=TX_CACHE)
+    device_handler.run(
+        btc.sign_tx, "Bitcoin", [inp1], [out1], prev_txes=TX_CACHE_MAINNET
+    )
 
     layout = debug.wait_layout()
     assert "1MJ2tj2ThBE62zXbBYA5ZaN3fdve5CPAz1" in layout.get_content().replace(" ", "")
@@ -95,6 +108,56 @@ def test_autolock_interrupts_signing(device_handler: "BackgroundDeviceHandler"):
     time.sleep(10.1)
     with pytest.raises(exceptions.Cancelled):
         device_handler.result()
+
+
+@pytest.mark.setup_client(pin=PIN4)
+def test_autolock_does_not_interrupt_signing(device_handler: "BackgroundDeviceHandler"):
+    """Autolock will NOT lock the device once transaction is confirmed."""
+    set_autolock_delay(device_handler, 10_000)
+
+    debug = device_handler.debuglink()
+    # try to sign a transaction
+    inp1 = messages.TxInputType(
+        address_n=parse_path("86h/0h/0h/0/0"),
+        amount=390000,
+        script_type=messages.InputScriptType.SPENDTAPROOT,
+        prev_hash=TXHASH_d5f65e,
+        prev_index=0,
+    )
+
+    out1 = messages.TxOutputType(
+        address="1MJ2tj2ThBE62zXbBYA5ZaN3fdve5CPAz1",
+        amount=390000 - 10000,
+        script_type=messages.OutputScriptType.PAYTOADDRESS,
+    )
+
+    device_handler.run(
+        btc.sign_tx, "Bitcoin", [inp1], [out1], prev_txes=TX_CACHE_MAINNET
+    )
+
+    layout = debug.wait_layout()
+    assert "1MJ2tj2ThBE62zXbBYA5ZaN3fdve5CPAz1" in layout.get_content().replace(" ", "")
+
+    debug.click(buttons.OK, wait=True)
+
+    layout = debug.click(buttons.OK, wait=True)
+    assert "Total amount: 0.0039 BTC" in layout.get_content()
+
+    def sleepy_filter(msg: MessageType) -> MessageType:
+        time.sleep(10.1)
+        device_handler.client.set_filter(messages.TxAck, None)
+        return msg
+
+    with device_handler.client:
+        device_handler.client.set_filter(messages.TxAck, sleepy_filter)
+        # confirm transaction
+        debug.click(buttons.OK)
+
+        signatures, tx = device_handler.result()
+        assert len(signatures) == 1
+        assert tx
+
+    assert device_handler.features().unlocked is False
 
 
 @pytest.mark.setup_client(pin=PIN4, passphrase=True)
@@ -230,3 +293,155 @@ def test_dryrun_enter_word_slowly(device_handler: "BackgroundDeviceHandler"):
     # should not have locked, even though we took 9 seconds to type each letter
     assert layout.text == "< MnemonicKeyboard >"
     device_handler.kill_task()
+
+
+@pytest.mark.setup_client(pin=PIN4)
+def test_autolock_does_not_interrupt_preauthorized(
+    device_handler: "BackgroundDeviceHandler",
+):
+    # NOTE: FAKE input tx
+    # NOTE: mostly copy-pasted from test_authorize_coinjoin.py::test_sign_tx
+    set_autolock_delay(device_handler, 10_000)
+
+    debug = device_handler.debuglink()
+
+    device_handler.run(
+        btc.authorize_coinjoin,
+        coordinator="www.example.com",
+        max_rounds=2,
+        max_coordinator_fee_rate=500_000,  # 0.5 %
+        max_fee_per_kvbyte=3500,
+        n=parse_path("m/10025h/1h/0h/1h"),
+        coin_name="Testnet",
+        script_type=messages.InputScriptType.SPENDTAPROOT,
+    )
+    debug.press_yes(wait=True)
+    device_handler.result()
+
+    inputs = [
+        messages.TxInputType(
+            # seed "alcohol woman abuse must during monitor noble actual mixed trade anger aisle"
+            # m/10025h/1h/0h/1h/0/0
+            # tb1pkw382r3plt8vx6e22mtkejnqrxl4z7jugh3w4rjmfmgezzg0xqpsdaww8z
+            amount=100_000,
+            prev_hash=FAKE_TXHASH_e5b7e2,
+            prev_index=0,
+            script_type=messages.InputScriptType.EXTERNAL,
+            script_pubkey=bytes.fromhex(
+                "5120b3a2750e21facec36b2a56d76cca6019bf517a5c45e2ea8e5b4ed191090f3003"
+            ),
+            ownership_proof=bytearray.fromhex(
+                "534c001901019cf1b0ad730100bd7a69e987d55348bb798e2b2096a6a5713e9517655bd2021300014052d479f48d34f1ca6872d4571413660040c3e98841ab23a2c5c1f37399b71bfa6f56364b79717ee90552076a872da68129694e1b4fb0e0651373dcf56db123c5"
+            ),
+            commitment_data=b"\x0fwww.example.com" + (1).to_bytes(32, "big"),
+        ),
+        messages.TxInputType(
+            address_n=parse_path("m/10025h/1h/0h/1h/1/0"),
+            amount=7_289_000,
+            prev_hash=FAKE_TXHASH_f982c0,
+            prev_index=1,
+            script_type=messages.InputScriptType.SPENDTAPROOT,
+        ),
+    ]
+
+    input_script_pubkeys = [
+        bytes.fromhex(
+            "5120b3a2750e21facec36b2a56d76cca6019bf517a5c45e2ea8e5b4ed191090f3003"
+        ),
+        bytes.fromhex(
+            "51202f436892d90fb2665519efa3d9f0f5182859124f179486862c2cd7a78ea9ac19"
+        ),
+    ]
+
+    outputs = [
+        # Other's coinjoined output.
+        messages.TxOutputType(
+            # seed "alcohol woman abuse must during monitor noble actual mixed trade anger aisle"
+            # m/10025h/1h/0h/1h/1/0
+            address="tb1pupzczx9cpgyqgtvycncr2mvxscl790luqd8g88qkdt2w3kn7ymhsrdueu2",
+            amount=50_000,
+            script_type=messages.OutputScriptType.PAYTOADDRESS,
+        ),
+        # Our coinjoined output.
+        messages.TxOutputType(
+            # tb1phkcspf88hge86djxgtwx2wu7ddghsw77d6sd7txtcxncu0xpx22shcydyf
+            address_n=parse_path("m/10025h/1h/0h/1h/1/1"),
+            amount=50_000,
+            script_type=messages.OutputScriptType.PAYTOTAPROOT,
+        ),
+        # Our change output.
+        messages.TxOutputType(
+            # tb1pchruvduckkwuzm5hmytqz85emften5dnmkqu9uhfxwfywaqhuu0qjggqyp
+            address_n=parse_path("m/10025h/1h/0h/1h/1/2"),
+            amount=7_289_000 - 50_000 - 36_445 - 490,
+            script_type=messages.OutputScriptType.PAYTOTAPROOT,
+        ),
+        # Other's change output.
+        messages.TxOutputType(
+            # seed "alcohol woman abuse must during monitor noble actual mixed trade anger aisle"
+            # m/10025h/1h/0h/1h/1/1
+            address="tb1pvt7lzserh8xd5m6mq0zu9s5wxkpe5wgf5ts56v44jhrr6578hz8saxup5m",
+            amount=100_000 - 50_000 - 500 - 490,
+            script_type=messages.OutputScriptType.PAYTOADDRESS,
+        ),
+        # Coordinator's output.
+        messages.TxOutputType(
+            address="mvbu1Gdy8SUjTenqerxUaZyYjmveZvt33q",
+            amount=36_945,
+            script_type=messages.OutputScriptType.PAYTOADDRESS,
+        ),
+    ]
+
+    output_script_pubkeys = [
+        bytes.fromhex(
+            "5120e0458118b80a08042d84c4f0356d86863fe2bffc034e839c166ad4e8da7e26ef"
+        ),
+        bytes.fromhex(
+            "5120bdb100a4e7ba327d364642dc653b9e6b51783bde6ea0df2ccbc1a78e3cc13295"
+        ),
+        bytes.fromhex(
+            "5120c5c7c63798b59dc16e97d916011e99da5799d1b3dd81c2f2e93392477417e71e"
+        ),
+        bytes.fromhex(
+            "512062fdf14323b9ccda6f5b03c5c2c28e35839a3909a2e14d32b595c63d53c7b88f"
+        ),
+        bytes.fromhex("76a914a579388225827d9f2fe9014add644487808c695d88ac"),
+    ]
+
+    coinjoin_req = make_coinjoin_request(
+        "www.example.com",
+        inputs,
+        input_script_pubkeys,
+        outputs,
+        output_script_pubkeys,
+        no_fee_indices=[],
+    )
+
+    def sleepy_filter(msg: MessageType) -> MessageType:
+        time.sleep(10.1)
+        device_handler.client.set_filter(messages.SignTx, None)
+        return msg
+
+    with device_handler.client:
+        # Start DoPreauthorized flow when device is unlocked. Wait 10s before
+        # delivering SignTx, by that time autolock timer should have fired.
+        device_handler.client.set_filter(messages.SignTx, sleepy_filter)
+        device_handler.run(
+            btc.sign_tx,
+            "Testnet",
+            inputs,
+            outputs,
+            prev_txes=TX_CACHE_TESTNET,
+            coinjoin_request=coinjoin_req,
+            preauthorized=True,
+            serialize=False,
+        )
+        signatures, _ = device_handler.result()
+
+    assert len(signatures) == 2
+    assert signatures[0] is None
+    assert (
+        signatures[1].hex()
+        == "c017fce789fa8db54a2ae032012d2dd6d7c76cc1c1a6f00e29b86acbf93022da8aa559009a574792c7b09b2535d288d6e03c6ed169902ed8c4c97626a83fbc11"
+    )
+    assert device_handler.features().unlocked is False

--- a/tests/ui_tests/fixtures.json
+++ b/tests/ui_tests/fixtures.json
@@ -599,6 +599,8 @@
 "T1_test_autolock.py::test_apply_auto_lock_delay_valid[60]": "186dc5f99a14566f8c8985d157e90721f186e6edc4b743a910590b008794164b",
 "T1_test_autolock.py::test_apply_auto_lock_delay_valid[7227]": "811357fd9acb0de12cb31acf96bee107cd0de53b78326fee5b962bbc1bc17662",
 "T1_test_autolock.py::test_autolock_default_value": "cde0dd7c453463cbfbb6bb35289fca350efd43511f2701b634c0fbb81f7d9dec",
+"T1_test_autolock.py::test_autolock_ignores_getaddress": "4f24424b5a55618ecc6d3e57a96071a222892dcef874428c3914ab86eca98c77",
+"T1_test_autolock.py::test_autolock_ignores_initialize": "4f24424b5a55618ecc6d3e57a96071a222892dcef874428c3914ab86eca98c77",
 "T1_test_basic.py::test_device_id_different": "aac15a6d12d21966c77572aeebd56ebc2a47ecba3a508f5a421af2a5da2919e7",
 "T1_test_basic.py::test_device_id_same": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
 "T1_test_basic.py::test_features": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
@@ -695,6 +697,8 @@
 },
 "TT": {
 "click_tests": {
+"TT_test_autolock.py::test_autolock_does_not_interrupt_preauthorized": "03e156da82e7acd3509f831d1fc2e635fcebc673f3c14d61d141273e608fc7a4",
+"TT_test_autolock.py::test_autolock_does_not_interrupt_signing": "6711f75420f88f7500a6adfa8d9d25007871f698e08f048a80450085d9452133",
 "TT_test_autolock.py::test_autolock_interrupts_passphrase": "d1f797544d62708739c340dd4aa4ee28cfc65e9b643f595a55706de5917ee82f",
 "TT_test_autolock.py::test_autolock_interrupts_signing": "ae4d3cc00fd5482b4499eff1c73aec75f4153e34950db910d4f787cc5f9b4208",
 "TT_test_autolock.py::test_autolock_passphrase_keyboard": "d1be209e13144850fc8b2cca8fded027cd53d2a9990af3c5be1db489995dc821",
@@ -1732,6 +1736,8 @@
 "TT_test_autolock.py::test_apply_auto_lock_delay_valid[7227]": "0e00ab4c70dd9fec3511712ebbcdfa2556487efa1e53830248240627c5f1417f",
 "TT_test_autolock.py::test_autolock_cancels_ui": "41bce102e56bcb761e7480690b4f2ded2739522c9642c7233eceafece9641a1e",
 "TT_test_autolock.py::test_autolock_default_value": "0126aab250a451219f64248cb9ff5a34e36e9c8caf85b175f16fbaa90a38e654",
+"TT_test_autolock.py::test_autolock_ignores_getaddress": "21605135cfbb4914cd525d6b76f260a17fe6552fdadcf9a89b2ec6e3572606f5",
+"TT_test_autolock.py::test_autolock_ignores_initialize": "21605135cfbb4914cd525d6b76f260a17fe6552fdadcf9a89b2ec6e3572606f5",
 "TT_test_basic.py::test_device_id_different": "4c7862bedbc9de710152f7b7ab15256ac9885f3c9f8082e6d04125acca6a71d7",
 "TT_test_basic.py::test_device_id_same": "80a6e289138a604cf351a29511cf6f85e2243591317894703152787e1351a1a3",
 "TT_test_basic.py::test_features": "80a6e289138a604cf351a29511cf6f85e2243591317894703152787e1351a1a3",


### PR DESCRIPTION
~~Given the timeline and complexity I did not feel confident implementing the proposed solution of #2651. This PR introduces different solution which avoids touching the idle timer when processing message listed as allowed to be processed when device is locked.~~

~~The disadvantage is that with unfortunate timing the autolock interrupts coinjoin signing if there's one in progress.~~

Fixes #2651.