### PR TITLE
tests: tweak wait time for test_autolock_ignores_getaddress

### DIFF
--- a/tests/device_tests/test_autolock.py
+++ b/tests/device_tests/test_autolock.py
@@ -156,13 +156,13 @@ def test_autolock_ignores_getaddress(client: Client):
     assert client.features.unlocked is True
 
     start = time.monotonic()
-    # let's continue for 9 seconds to give a little leeway to the slow CI
-    while time.monotonic() - start < 9:
+    # let's continue for 8 seconds to give a little leeway to the slow CI
+    while time.monotonic() - start < 8:
         get_test_address(client)
         time.sleep(0.1)
 
-    # sleep 2 more seconds to wait for autolock
-    time.sleep(2)
+    # sleep 3 more seconds to wait for autolock
+    time.sleep(3)
 
     # after 11 seconds we are definitely locked
     client.refresh_features()


### PR DESCRIPTION
On _hardware_ this test is often failing, both on CI and my machine. After changing the wait time to 8s the test passes 20+ times in a row on my machine.

<!--
If you are a core dev:

Don't forget to set up the fields:
- assign yourself
- set priority to same as original issue
- add PR to sprint
- if Draft -> "in progress"
- if final PR -> "needs review"

If you're an external contributor, you can ignore this text.
-->
