### PR TITLE
Firmware combining tweaks

### DIFF
--- a/core/Makefile
+++ b/core/Makefile
@@ -321,10 +321,10 @@ sizecheck: ## check sizes of binary files
 
 combine: ## combine boardloader + bootloader + prodtest into one combined image
 	./tools/combine_firmware \
-		$(BOARDLOADER_START) $(BOARDLOADER_BUILD_DIR)/boardloader.bin \
-		$(BOOTLOADER_START) $(BOOTLOADER_BUILD_DIR)/bootloader.bin \
-		$(PRODTEST_START) $(PRODTEST_BUILD_DIR)/prodtest.bin \
-		> $(PRODTEST_BUILD_DIR)/combined.bin
+		$(BOARDLOADER_BUILD_DIR)/boardloader.bin \
+		$(BOOTLOADER_BUILD_DIR)/bootloader.bin \
+		$(PRODTEST_BUILD_DIR)/prodtest.bin \
+		$(PRODTEST_BUILD_DIR)/combined.bin
 
 upload: ## upload firmware using trezorctl
 	trezorctl firmware_update -f $(FIRMWARE_BUILD_DIR)/firmware.bin

--- a/core/tools/combine_firmware
+++ b/core/tools/combine_firmware
@@ -1,26 +1,73 @@
 #!/usr/bin/env python3
+from __future__ import annotations
+
+import datetime
+import io
 import sys
+from pathlib import Path
+
+import click
 
 
-def pairwise(iterable):
-    a = iter(iterable)
-    return zip(a, a)
+BOARDLOADER_START = 0x08000000
+BOARDLOADER_END = 0x0800C000
+BOOTLOADER_START = 0x08020000
+FIRMWARE_START = 0x08040000
 
 
-files = sys.argv[1:]
-files = list(pairwise(files))
+@click.command()
+@click.argument(
+    "boardloader",
+    type=click.Path(exists=True, dir_okay=False, readable=True, path_type=Path),
+)
+@click.argument(
+    "bootloader",
+    type=click.Path(exists=True, dir_okay=False, readable=True, path_type=Path),
+)
+@click.argument(
+    "firmware",
+    type=click.Path(exists=True, dir_okay=False, readable=True, path_type=Path),
+)
+@click.argument(
+    "outfile",
+    type=click.Path(dir_okay=False, writable=True, path_type=Path),
+    required=False,
+)
+def main(
+    boardloader: Path, bootloader: Path, firmware: Path, outfile: Path | None
+) -> None:
+    if outfile is None:
+        today = datetime.date.today().strftime(r"%Y-%m-%d")
+        outfile = Path(f"combined-{today}.bin")
 
-offset = int(files[0][0], 16)
+    offset = BOARDLOADER_START
+    out_bytes = io.BytesIO()
 
-out = bytearray()
+    # write boardloader
+    offset += out_bytes.write(boardloader.read_bytes())
+    if offset > BOARDLOADER_END:
+        raise Exception("Boardloader too big")
 
-for addr, fn in files:
-    addr = int(addr, 16) - offset
-    data = open(fn, "rb").read()
-    if len(out) < addr:
-        out += b"\x00" * (addr - len(out))
-    if len(out) != addr:
-        raise Exception("Alignment failed")
-    out += data
+    # zero-pad until next section:
+    offset += out_bytes.write(b"\x00" * (BOOTLOADER_START - offset))
+    assert offset == BOOTLOADER_START
 
-sys.stdout.buffer.write(out)
+    # write bootlaoder
+    offset += out_bytes.write(bootloader.read_bytes())
+    if offset > FIRMWARE_START:
+        raise Exception("Bootloader too big")
+
+    # zero-pad until next section:
+    offset += out_bytes.write(b"\x00" * (FIRMWARE_START - offset))
+    assert offset == FIRMWARE_START
+
+    # write firmware
+    offset += out_bytes.write(firmware.read_bytes())
+
+    # write out contents
+    click.echo(f"Writing {outfile} ({offset - BOARDLOADER_START} bytes)")
+    outfile.write_bytes(out_bytes.getvalue())
+
+
+if __name__ == "__main__":
+    main()

--- a/core/tools/snippets/README.md
+++ b/core/tools/snippets/README.md
@@ -1,0 +1,10 @@
+# Core-specific snippets
+
+## [decombine.py](decombine.py)
+
+Take a `combined.bin` file which is the output of `core/tools/combine_firmware`,
+split it back into original parts, and verify that there is no unnaccounted for noise.
+
+## [change_icon_format.py](change_icon_format.py)
+
+Converts all TOIF icons from the old endianity to the new one.

--- a/core/tools/snippets/decombine.py
+++ b/core/tools/snippets/decombine.py
@@ -1,0 +1,60 @@
+import io
+import sys
+from pathlib import Path
+from trezorlib._internal import firmware_headers
+from trezorlib.firmware.core import FirmwareHeader, HeaderType
+
+INFILE = Path(sys.argv[1])
+DATA = INFILE.read_bytes()
+
+READER = io.BytesIO(DATA)
+
+# boardloader is first 3 16kB sectors
+BOARDLOADER = READER.read(3 * 16 * 1024)
+
+# following 16kB is unused
+UNUSED = READER.read(16 * 1024)
+if all(b == 0 for b in UNUSED):
+    print("Unused space is all zero")
+elif all(b == 0xFF for b in UNUSED):
+    print("Unused space is all 0xFF")
+else:
+    print("WARNING: Unused space is noise!!")
+
+# following 64kB is storage area 1, should be empty
+STORAGE1 = READER.read(64 * 1024)
+if all(b == 0 for b in STORAGE1):
+    print("Storage area 1 is all zero")
+elif all(b == 0xFF for b in STORAGE1):
+    print("Storage area 1 is all 0xFF")
+else:
+    print("WARNING: Storage area 1 is noise!!")
+
+# following 128 kB is bootloader
+BOOTLOADER_SECTOR = READER.read(128 * 1024)
+BOOTLOADER_HEADER = FirmwareHeader.parse(BOOTLOADER_SECTOR)
+assert BOOTLOADER_HEADER.magic == HeaderType.BOOTLOADER
+length = BOOTLOADER_HEADER.header_len + BOOTLOADER_HEADER.code_length
+BOOTLOADER = BOOTLOADER_SECTOR[:length]
+BOOTLOADER_AFTER = BOOTLOADER_SECTOR[length:]
+
+BOOTLOADER_PARSED = firmware_headers.parse_image(BOOTLOADER)
+print("Bootloader parses OK:")
+print(BOOTLOADER_PARSED.format())
+if all(b == 0 for b in BOOTLOADER_AFTER):
+    print("Bootloader padding is all zero")
+elif all(b == 0xFF for b in BOOTLOADER_AFTER):
+    print("Bootloader padding is all 0xFF")
+else:
+    print("WARNING: Bootloader padding is noise!!")
+
+# rest of the image is prodtest
+PRODTEST = READER.read()
+PRODTEST_PARSED = firmware_headers.parse_image(PRODTEST)
+print("Prodtest parses OK:")
+print(PRODTEST_PARSED.format())
+
+# save results:
+Path("boardloader.bin").write_bytes(BOARDLOADER)
+Path("bootloader.bin").write_bytes(BOOTLOADER)
+Path("prodtest.bin").write_bytes(PRODTEST)


### PR DESCRIPTION
Improved the `combine_firmware` script to make it easier to manually pass the parts from outside.
Added a "decombine" snippet that can take apart the result, so that, e.g., we can pull out the boardloader from a previous version instead of having to compile it from the current code version.
