### PR TITLE
Update to clang-14 to fix nix-shell on darwin

### DIFF
--- a/ci/shell.nix
+++ b/ci/shell.nix
@@ -50,7 +50,7 @@ let
     # to use official binary, remove rustfmt from buildInputs and add it to extensions:
     extensions = [ "rust-src" "clippy" "rustfmt" ];
   };
-  llvmPackages = nixpkgs.llvmPackages_13;
+  llvmPackages = nixpkgs.llvmPackages_14;
   # see pyright/README.md for update procedure
   pyright = nixpkgs.callPackage ./pyright {};
 in


### PR DESCRIPTION
This makes it possible to start the shell however build still fails: https://gitlab.com/satoshilabs/trezor/trezor-firmware/-/jobs/4182963058
