### PR TITLE
ci: fix crypto test, storage test

### DIFF
--- a/ci/build.yml
+++ b/ci/build.yml
@@ -304,6 +304,7 @@ crypto build:
   needs: []
   variables:
     ADDRESS_SANITIZER: "1"
+    CC: gcc
   only:
     changes:
       - .gitlab-ci.yml

--- a/docs/ci/jobs.md
+++ b/docs/ci/jobs.md
@@ -106,27 +106,27 @@ it is just a single binary file that you can execute directly.
 ### [crypto build](https://github.com/trezor/trezor-firmware/blob/master/ci/build.yml#L301)
 Build of our cryptographic library, which is then incorporated into the other builds.
 
-### [legacy fw regular build](https://github.com/trezor/trezor-firmware/blob/master/ci/build.yml#L330)
+### [legacy fw regular build](https://github.com/trezor/trezor-firmware/blob/master/ci/build.yml#L331)
 
-### [legacy fw regular debug build](https://github.com/trezor/trezor-firmware/blob/master/ci/build.yml#L346)
+### [legacy fw regular debug build](https://github.com/trezor/trezor-firmware/blob/master/ci/build.yml#L347)
 
-### [legacy fw btconly build](https://github.com/trezor/trezor-firmware/blob/master/ci/build.yml#L363)
+### [legacy fw btconly build](https://github.com/trezor/trezor-firmware/blob/master/ci/build.yml#L364)
 
-### [legacy fw btconly debug build](https://github.com/trezor/trezor-firmware/blob/master/ci/build.yml#L382)
+### [legacy fw btconly debug build](https://github.com/trezor/trezor-firmware/blob/master/ci/build.yml#L383)
 
-### [legacy emu regular debug build](https://github.com/trezor/trezor-firmware/blob/master/ci/build.yml#L403)
+### [legacy emu regular debug build](https://github.com/trezor/trezor-firmware/blob/master/ci/build.yml#L404)
 Regular version (not only Bitcoin) of above.
 **Are you looking for a Trezor One emulator? This is most likely it.**
 
-### [legacy emu regular debug asan build](https://github.com/trezor/trezor-firmware/blob/master/ci/build.yml#L418)
+### [legacy emu regular debug asan build](https://github.com/trezor/trezor-firmware/blob/master/ci/build.yml#L419)
 
-### [legacy emu regular debug build arm](https://github.com/trezor/trezor-firmware/blob/master/ci/build.yml#L436)
+### [legacy emu regular debug build arm](https://github.com/trezor/trezor-firmware/blob/master/ci/build.yml#L437)
 
-### [legacy emu btconly debug build](https://github.com/trezor/trezor-firmware/blob/master/ci/build.yml#L462)
+### [legacy emu btconly debug build](https://github.com/trezor/trezor-firmware/blob/master/ci/build.yml#L463)
 Build of Legacy into UNIX emulator. Use keyboard arrows to emulate button presses.
 Bitcoin-only version.
 
-### [legacy emu btconly debug asan build](https://github.com/trezor/trezor-firmware/blob/master/ci/build.yml#L479)
+### [legacy emu btconly debug asan build](https://github.com/trezor/trezor-firmware/blob/master/ci/build.yml#L480)
 
 ---
 ## TEST stage - [test.yml](https://github.com/trezor/trezor-firmware/blob/master/ci/test.yml)

--- a/storage/tests/c/flash.c
+++ b/storage/tests/c/flash.c
@@ -24,8 +24,10 @@
 #include "common.h"
 #include "flash.h"
 
+static const uint32_t FLASH_START = 0x08000000;
+static const uint32_t FLASH_END = 0x08200000;
 static const uint32_t FLASH_SECTOR_TABLE[FLASH_SECTOR_COUNT + 1] = {
-    [0] = 0x08000000,   // - 0x08003FFF |  16 KiB
+    [0] = FLASH_START,  // - 0x08003FFF |  16 KiB
     [1] = 0x08004000,   // - 0x08007FFF |  16 KiB
     [2] = 0x08008000,   // - 0x0800BFFF |  16 KiB
     [3] = 0x0800C000,   // - 0x0800FFFF |  16 KiB
@@ -49,10 +51,9 @@ static const uint32_t FLASH_SECTOR_TABLE[FLASH_SECTOR_COUNT + 1] = {
     [21] = 0x081A0000,  // - 0x081BFFFF | 128 KiB
     [22] = 0x081C0000,  // - 0x081DFFFF | 128 KiB
     [23] = 0x081E0000,  // - 0x081FFFFF | 128 KiB
-    [24] = 0x08200000,  // last element - not a valid sector
+    [24] = FLASH_END,   // last element - not a valid sector
 };
-const uint32_t FLASH_SIZE =
-    FLASH_SECTOR_TABLE[FLASH_SECTOR_COUNT] - FLASH_SECTOR_TABLE[0];
+const uint32_t FLASH_SIZE = FLASH_END - FLASH_START;
 uint8_t *FLASH_BUFFER = NULL;
 
 secbool flash_unlock_write(void) { return sectrue; }

--- a/storage/tests/c0/flash.c
+++ b/storage/tests/c0/flash.c
@@ -24,8 +24,10 @@
 #include "common.h"
 #include "flash.h"
 
+static const uint32_t FLASH_START = 0x08000000;
+static const uint32_t FLASH_END = 0x08200000;
 static const uint32_t FLASH_SECTOR_TABLE[FLASH_SECTOR_COUNT + 1] = {
-    [0] = 0x08000000,   // - 0x08003FFF |  16 KiB
+    [0] = FLASH_START,  // - 0x08003FFF |  16 KiB
     [1] = 0x08004000,   // - 0x08007FFF |  16 KiB
     [2] = 0x08008000,   // - 0x0800BFFF |  16 KiB
     [3] = 0x0800C000,   // - 0x0800FFFF |  16 KiB
@@ -49,11 +51,10 @@ static const uint32_t FLASH_SECTOR_TABLE[FLASH_SECTOR_COUNT + 1] = {
     [21] = 0x081A0000,  // - 0x081BFFFF | 128 KiB
     [22] = 0x081C0000,  // - 0x081DFFFF | 128 KiB
     [23] = 0x081E0000,  // - 0x081FFFFF | 128 KiB
-    [24] = 0x08200000,  // last element - not a valid sector
+    [24] = FLASH_END,   // last element - not a valid sector
 };
 
-const uint32_t FLASH_SIZE =
-    FLASH_SECTOR_TABLE[FLASH_SECTOR_COUNT] - FLASH_SECTOR_TABLE[0];
+const uint32_t FLASH_SIZE = FLASH_END - FLASH_START;
 uint8_t *FLASH_BUFFER = NULL;
 
 secbool flash_unlock(void) { return sectrue; }


### PR DESCRIPTION
#3005 caused clang to be used instead of gcc in some CI jobs. I modified the storage test to also work with clang and forced the use of gcc in the crypto test - it could work with clang but needs to be run as `LD_PRELOAD=/path/to/libclang_rt.asan-x86_64.so ITERS=10 pytest tests`.

Passing jobs:
* https://gitlab.com/satoshilabs/trezor/trezor-firmware/-/jobs/4295068658
* https://gitlab.com/satoshilabs/trezor/trezor-firmware/-/jobs/4295068687