### PR TITLE
use the full ethereum rlp package

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,3 +11,5 @@ __pycache__/
 proto.gv*
 .DS_Store
 crypto/tests/libtrezor-crypto.so.dSYM/
+python/venv
+venv

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -55,7 +55,7 @@ ed25519 = "^1.4"
 requests = "^2.31"
 termcolor = "*"
 Pillow = "^9"
-simple-rlp = "^0.1.2"
+pyrlp = "^3.0.0"
 
 # crypto
 ecdsa = "^0.16"

--- a/python/README.md
+++ b/python/README.md
@@ -1,11 +1,15 @@
-# trezorlib
-
-[![repology](https://repology.org/badge/tiny-repos/python:trezor.svg)](https://repology.org/metapackage/python:trezor) [![image](https://badges.gitter.im/trezor/community.svg)](https://gitter.im/trezor/community)
+# eulith-trezorlib
 
 Python library and command-line client for communicating with Trezor
-Hardware Wallet.
+Hardware Wallet, modified to work more closely with Eulith clients & applications.
 
-See <https://trezor.io> for more information.
+See <https://trezor.io> and <https://eulith.com> for more information.
+
+## !! This is a derivative package of Trezor !!
+For the original package, please see https://github.com/trezor/trezor-firmware
+
+This package has been modified primarily to sort out dependency issues that come up when
+trying to use the original trezor package with Ethereum tooling like `web3py`.
 
 ## Install
 
@@ -17,7 +21,7 @@ guide](https://packaging.python.org/tutorials/installing-packages/).
 On a typical system, you already have all you need. Install `trezor` with:
 
 ```sh
-pip3 install trezor
+pip3 install eulith-trezor
 ```
 
 On Windows, you also need to either install [Trezor Bridge](https://suite.trezor.io/web/bridge/), or
@@ -35,122 +39,3 @@ is "upgrade firmware".
 Trezor One with firmware _older than 1.7.0_ and bootloader _older than 1.6.0_
 (including pre-2021 fresh-out-of-the-box units) will not be recognized, unless
 you install HIDAPI support (see below).
-
-### Installation options
-
-* **Ethereum**: To support Ethereum signing from command line, additional packages are
-  needed. Install with:
-
-  ```sh
-  pip3 install trezor[ethereum]
-  ```
-
-* **Stellar**: To support Stellar signing from command line, additional packages are
-  needed. Install with:
-
-  ```sh
-  pip3 install trezor[stellar]
-  ```
-
-* **Firmware-less Trezor One**: If you are setting up a brand new Trezor One
-  manufactured before 2021 (with pre-installed bootloader older than 1.6.0), you will
-  need HIDAPI support. On Linux, you will need the following packages (or their
-  equivalents) as prerequisites: `python3-dev`, `cython3`, `libusb-1.0-0-dev`,
-  `libudev-dev`.
-
-  Install with:
-
-  ```sh
-  pip3 install trezor[hidapi]
-  ```
-
-To install all three, use `pip3 install trezor[hidapi,ethereum,stellar]`.
-
-### Distro packages
-
-Check out [Repology](https://repology.org/metapackage/python:trezor) to see if your
-operating system has an up-to-date python-trezor package.
-
-### Installing latest version from GitHub
-
-```sh
-pip3 install "git+https://github.com/trezor/trezor-firmware#egg=trezor&subdirectory=python"
-```
-
-### Running from source
-
-Install the [Poetry](https://python-poetry.org/) tool, checkout
-`trezor-firmware` from git, and enter the poetry shell:
-
-```sh
-pip3 install poetry
-git clone https://github.com/trezor/trezor-firmware
-cd trezor-firmware
-poetry install
-poetry shell
-```
-
-In this environment, trezorlib and the `trezorctl` tool is running from the live
-sources, so your changes are immediately effective.
-
-## Command line client (trezorctl)
-
-The included `trezorctl` python script can perform various tasks such as
-changing setting in the Trezor, signing transactions, retrieving account
-info and addresses. See the
-[python/docs/](https://github.com/trezor/trezor-firmware/tree/master/python/docs)
-sub folder for detailed examples and options.
-
-NOTE: An older version of the `trezorctl` command is [available for
-Debian Stretch](https://packages.debian.org/en/stretch/python-trezor)
-(and comes pre-installed on [Tails OS](https://tails.boum.org/)).
-
-## Python Library
-
-You can use this python library to interact with a Trezor and use its capabilities in
-your application. See examples here in the
-[tools/](https://github.com/trezor/trezor-firmware/tree/master/python/docs/tools)
-sub folder.
-
-## PIN Entering
-
-When you are asked for PIN, you have to enter scrambled PIN. Follow the
-numbers shown on Trezor display and enter the their positions using the
-numeric keyboard mapping:
-
-|   |   |   |
-|---|---|---|
-| 7 | 8 | 9 |
-| 4 | 5 | 6 |
-| 1 | 2 | 3 |
-
-Example: your PIN is **1234** and Trezor is displaying the following:
-
-|   |   |   |
-|---|---|---|
-| 2 | 8 | 3 |
-| 5 | 4 | 6 |
-| 7 | 9 | 1 |
-
-You have to enter: **3795**
-
-## Contributing
-
-If you want to change protobuf or coin definitions, you will need to regenerate
-definitions in the `python/` subdirectory.
-
-First, make sure your submodules are up-to-date with:
-
-```sh
-git submodule update --init --recursive
-```
-
-Then, rebuild the protobuf messages by running, from the `trezor-firmware` top-level
-directory:
-
-```sh
-make gen
-```
-
-To get support for BTC-like coins, these steps are enough and no further
-changes to the library are necessary.

--- a/python/requirements.txt
+++ b/python/requirements.txt
@@ -6,5 +6,5 @@ libusb1>=1.6.4
 construct>=2.9,!=2.10.55
 typing_extensions>=3.10
 dataclasses ; python_version<'3.7'
-simple-rlp>=0.1.2 ; python_version>='3.7'
+rlp==3.0.0 ; python_version>='3.7'
 construct-classes>=0.1.2

--- a/python/setup.cfg
+++ b/python/setup.cfg
@@ -25,7 +25,7 @@ per-file-ignores =
     helper-scripts/*:I
     tools/*:I
     tests/*:I
-known-modules = libusb1:[usb1],hidapi:[hid],PyQt5:[PyQt5.QtWidgets,PyQt5.QtGui,PyQt5.QtCore],simple-rlp:[rlp]
+known-modules = libusb1:[usb1],hidapi:[hid],PyQt5:[PyQt5.QtWidgets,PyQt5.QtGui,PyQt5.QtCore]
 
 [isort]
 multi_line_output = 3

--- a/python/setup.py
+++ b/python/setup.py
@@ -46,17 +46,17 @@ def find_version():
 
 
 setup(
-    name="trezor",
+    name="eulith-trezor",
     version=find_version(),
-    author="Trezor",
-    author_email="info@trezor.io",
+    author="Trezor & Eulith",
+    author_email="admin@eulith.com",
     license="LGPLv3",
-    description="Python library for communicating with Trezor Hardware Wallet",
+    description="Python library for communicating with Trezor Hardware Wallet (with modifications from Eulith)",
     long_description=(CWD / "README.md").read_text()
     + "\n\n"
     + (CWD / "CHANGELOG.md").read_text(),
     long_description_content_type="text/markdown",
-    url="https://github.com/trezor/trezor-firmware/tree/master/python",
+    url="https://github.com/kristian1108/trezor-firmware",
     package_data={"trezorlib": ["py.typed"]},
     packages=find_packages("src"),
     package_dir={"": "src"},

--- a/python/src/trezorlib/__init__.py
+++ b/python/src/trezorlib/__init__.py
@@ -14,4 +14,4 @@
 # You should have received a copy of the License along with this library.
 # If not, see <https://www.gnu.org/licenses/lgpl-3.0.html>.
 
-__version__ = "0.13.7"
+__version__ = "0.0.2"


### PR DESCRIPTION
I'm not sure why it was decided to use the `simple-rlp` library: https://github.com/SamuelHaidu/simple-rlp

This makes the `trezor` package incompatible with `web3py` if it's installed first due to the fact that the developer of `simple-rlp` chose a conflicting directory name in their release.

We should just be using the full `pyrlp` dependency. It's much better supported & actually compatible with standard ethereum tooling.

<!--
If you are a core dev:

Don't forget to set up the fields:
- assign yourself
- set priority to same as original issue
- add PR to sprint
- if Draft -> "in progress"
- if final PR -> "needs review"

If you're an external contributor, you can ignore this text.
-->
