### PR TITLE
T2B1 Coinjoin design

### DIFF
--- a/core/embed/rust/src/ui/component/text/util.rs
+++ b/core/embed/rust/src/ui/component/text/util.rs
@@ -15,7 +15,7 @@ use super::{
 ///
 /// If it fits, returns the rest of the area.
 /// If it does not fit, returns `None`.
-pub fn text_multiline_split_words(
+pub fn text_multiline(
     area: Rect,
     text: &str,
     font: Font,
@@ -31,5 +31,35 @@ pub fn text_multiline_split_words(
     match layout_fit {
         LayoutFit::Fitting { height, .. } => Some(area.split_top(height).1),
         LayoutFit::OutOfBounds { .. } => None,
+    }
+}
+
+/// Same as `text_multiline` above, but aligns the text to the bottom of the
+/// area.
+pub fn text_multiline_bottom(
+    area: Rect,
+    text: &str,
+    font: Font,
+    fg_color: Color,
+    bg_color: Color,
+    alignment: Alignment,
+) -> Option<Rect> {
+    let text_style = TextStyle::new(font, fg_color, bg_color, fg_color, fg_color);
+    let mut text_layout = TextLayout::new(text_style)
+        .with_bounds(area)
+        .with_align(alignment);
+    // When text fits the area, displaying it in the bottom part.
+    // When not, render it "normally".
+    match text_layout.fit_text(text) {
+        LayoutFit::Fitting { height, .. } => {
+            let (top, bottom) = area.split_bottom(height);
+            text_layout = text_layout.with_bounds(bottom);
+            text_layout.render_text(text);
+            Some(top)
+        }
+        LayoutFit::OutOfBounds { .. } => {
+            text_layout.render_text(text);
+            None
+        }
     }
 }

--- a/core/embed/rust/src/ui/display/loader/mod.rs
+++ b/core/embed/rust/src/ui/display/loader/mod.rs
@@ -1,5 +1,6 @@
 mod circular;
 mod rectangular;
+mod small;
 mod starry;
 
 use crate::ui::display::{Color, Icon};
@@ -15,6 +16,8 @@ pub use crate::ui::display::loader::circular::{loader_circular_uncompress, Loade
 use crate::ui::display::loader::rectangular::loader_rectangular as determinate;
 #[cfg(not(feature = "model_tt"))]
 use crate::ui::display::loader::starry::loader_starry_indeterminate as indeterminate;
+
+pub use small::loader_small_indeterminate;
 
 pub const LOADER_MIN: u16 = 0;
 pub const LOADER_MAX: u16 = 1000;

--- a/core/embed/rust/src/ui/display/loader/small.rs
+++ b/core/embed/rust/src/ui/display/loader/small.rs
@@ -1,0 +1,53 @@
+use crate::ui::{
+    constant::screen,
+    display::{rect_fill, Color},
+    geometry::{Offset, Point, Rect},
+};
+use core::f32::consts::SQRT_2;
+
+const STAR_COUNT: usize = 8;
+const RADIUS: i16 = 3;
+const DIAGONAL: i16 = ((RADIUS as f32 * SQRT_2) / 2_f32) as i16;
+const LOADER_SIZE: Offset = Offset::uniform(2 * RADIUS + 3);
+
+fn fill_point(point: Point, color: Color) {
+    let area = Rect::from_center_and_size(point, Offset::uniform(1));
+    rect_fill(area, color);
+}
+
+pub fn loader_small_indeterminate(progress: u16, y_offset: i16, fg_color: Color, bg_color: Color) {
+    let area =
+        Rect::from_center_and_size(screen().center(), LOADER_SIZE).translate(Offset::y(y_offset));
+
+    rect_fill(area, bg_color);
+
+    // Offset of the normal point and then the extra offset for the main point
+    let offsets: [(Offset, Offset); STAR_COUNT] = [
+        (Offset::y(-RADIUS), Offset::y(-1)),
+        (Offset::new(DIAGONAL, -DIAGONAL), Offset::new(1, -1)),
+        (Offset::x(RADIUS), Offset::x(1)),
+        (Offset::new(DIAGONAL, DIAGONAL), Offset::new(1, 1)),
+        (Offset::y(RADIUS), Offset::y(1)),
+        (Offset::new(-DIAGONAL, DIAGONAL), Offset::new(-1, 1)),
+        (Offset::x(-RADIUS), Offset::x(-1)),
+        (Offset::new(-DIAGONAL, -DIAGONAL), Offset::new(-1, -1)),
+    ];
+
+    let main_idx = (STAR_COUNT * progress as usize / 1000) % STAR_COUNT;
+
+    for (i, (point_offset, main_offset)) in offsets.iter().enumerate() {
+        // Skip it when it is behind the main one (clockwise)
+        if (main_idx + 1) % STAR_COUNT == i {
+            continue;
+        }
+
+        // Draw the normal point
+        let point = area.center() + *point_offset;
+        fill_point(point, fg_color);
+
+        // Draw the main point
+        if main_idx == i {
+            fill_point(point + *main_offset, fg_color);
+        }
+    }
+}

--- a/core/embed/rust/src/ui/display/mod.rs
+++ b/core/embed/rust/src/ui/display/mod.rs
@@ -35,7 +35,9 @@ use crate::{
 pub use crate::ui::display::toif::Icon;
 pub use color::Color;
 pub use font::{Font, Glyph, GlyphMetrics};
-pub use loader::{loader, loader_indeterminate, LOADER_MAX, LOADER_MIN};
+pub use loader::{
+    loader, loader_indeterminate, loader_small_indeterminate, LOADER_MAX, LOADER_MIN,
+};
 
 pub fn backlight() -> u16 {
     display::backlight(-1) as u16

--- a/core/embed/rust/src/ui/model_tr/component/coinjoin_progress.rs
+++ b/core/embed/rust/src/ui/model_tr/component/coinjoin_progress.rs
@@ -2,31 +2,36 @@ use crate::{
     strutil::StringType,
     ui::{
         component::{
-            base::Never, text::util::text_multiline_split_words, Component, Event, EventCtx,
+            base::Never,
+            text::util::{text_multiline, text_multiline_bottom},
+            Component, Event, EventCtx,
         },
         display::Font,
-        geometry::{Alignment, Rect},
+        geometry::{Alignment, Insets, Rect},
     },
 };
 
 use super::theme;
 
 const HEADER: &str = "COINJOIN IN PROGRESS";
-const FOOTER: &str = "Don't disconnect your Trezor";
+const FOOTER: &str = "Do not disconnect your Trezor!";
+const FOOTER_TEXT_MARGIN: i16 = 8;
 
 pub struct CoinJoinProgress<T> {
     text: T,
     area: Rect,
+    indeterminate: bool,
 }
 
 impl<T> CoinJoinProgress<T>
 where
     T: StringType,
 {
-    pub fn new(text: T, _indeterminate: bool) -> Self {
+    pub fn new(text: T, indeterminate: bool) -> Self {
         Self {
             text,
             area: Rect::zero(),
+            indeterminate,
         }
     }
 }
@@ -47,33 +52,34 @@ where
     }
 
     fn paint(&mut self) {
-        // Trying to paint all three parts into the area, stopping if any of them
-        // doesn't fit.
-        let mut possible_rest = text_multiline_split_words(
+        // TOP
+        if self.indeterminate {
+            text_multiline(
+                self.area,
+                HEADER,
+                Font::BOLD,
+                theme::FG,
+                theme::BG,
+                Alignment::Center,
+            );
+        }
+
+        // CENTER
+
+        // BOTTOM
+        let top_rest = text_multiline_bottom(
             self.area,
-            HEADER,
+            FOOTER,
             Font::BOLD,
             theme::FG,
             theme::BG,
             Alignment::Center,
         );
-        if let Some(rest) = possible_rest {
-            possible_rest = text_multiline_split_words(
-                rest,
+        if let Some(rest) = top_rest {
+            text_multiline_bottom(
+                rest.inset(Insets::bottom(FOOTER_TEXT_MARGIN)),
                 self.text.as_ref(),
-                Font::MONO,
-                theme::FG,
-                theme::BG,
-                Alignment::Center,
-            );
-        } else {
-            return;
-        }
-        if let Some(rest) = possible_rest {
-            text_multiline_split_words(
-                rest,
-                FOOTER,
-                Font::BOLD,
+                Font::NORMAL,
                 theme::FG,
                 theme::BG,
                 Alignment::Center,

--- a/core/embed/rust/src/ui/model_tr/component/homescreen.rs
+++ b/core/embed/rust/src/ui/model_tr/component/homescreen.rs
@@ -3,7 +3,7 @@ use crate::{
     trezorhal::usb::usb_configured,
     ui::{
         component::{Child, Component, Event, EventCtx, Label},
-        display::{rect_fill, toif::Toif, Font},
+        display::{rect_fill, toif::Toif, Font, Icon},
         event::USBEvent,
         geometry::{Alignment2D, Insets, Offset, Point, Rect},
         layout::util::get_user_custom_image,
@@ -25,6 +25,8 @@ const LOGO_ICON_TOP_MARGIN: i16 = 12;
 const LOCK_ICON_TOP_MARGIN: i16 = 12;
 const NOTIFICATION_HEIGHT: i16 = 12;
 const LABEL_OUTSET: i16 = 3;
+const NOTIFICATION_FONT: Font = Font::NORMAL;
+const NOTIFICATION_ICON: Icon = theme::ICON_WARNING;
 
 pub struct Homescreen<T>
 where
@@ -66,16 +68,32 @@ where
     }
 
     fn paint_notification(&self) {
-        let baseline = TOP_CENTER + Offset::y(Font::MONO.line_height());
+        let baseline = TOP_CENTER + Offset::y(NOTIFICATION_FONT.line_height());
         if !usb_configured() {
             self.fill_notification_background();
             // TODO: fill warning icons here as well?
-            display_center(baseline, &"NO USB CONNECTION", Font::MONO);
+            display_center(baseline, &"NO USB CONNECTION", NOTIFICATION_FONT);
         } else if let Some((notification, _level)) = &self.notification {
             self.fill_notification_background();
-            // TODO: what if the notification text is so long it collides with icons?
-            self.paint_warning_icons_in_top_corners();
-            display_center(baseline, &notification.as_ref(), Font::MONO);
+            display_center(baseline, &notification.as_ref(), NOTIFICATION_FONT);
+            // Painting warning icons in top corners when the text is short enough not to
+            // collide with them
+            let icon_width = NOTIFICATION_ICON.toif.width();
+            let text_width = NOTIFICATION_FONT.text_width(notification.as_ref());
+            if AREA.width() >= text_width + (icon_width + 1) * 2 {
+                NOTIFICATION_ICON.draw(
+                    AREA.top_left(),
+                    Alignment2D::TOP_LEFT,
+                    theme::FG,
+                    theme::BG,
+                );
+                NOTIFICATION_ICON.draw(
+                    AREA.top_right(),
+                    Alignment2D::TOP_RIGHT,
+                    theme::FG,
+                    theme::BG,
+                );
+            }
         }
     }
 

--- a/core/embed/rust/src/ui/model_tr/component/share_words.rs
+++ b/core/embed/rust/src/ui/model_tr/component/share_words.rs
@@ -2,8 +2,7 @@ use crate::{
     strutil::StringType,
     ui::{
         component::{
-            text::util::text_multiline_split_words, Child, Component, Event, EventCtx, Never,
-            Paginate,
+            text::util::text_multiline, Child, Component, Event, EventCtx, Never, Paginate,
         },
         display::Font,
         geometry::{Alignment, Offset, Rect},
@@ -118,7 +117,7 @@ where
 
     /// Shows text in the main screen area.
     fn render_text_on_screen(&self, text: &str, font: Font) {
-        text_multiline_split_words(
+        text_multiline(
             self.area.split_top(INFO_TOP_OFFSET).1,
             text,
             font,

--- a/core/embed/rust/src/ui/model_tr/layout.rs
+++ b/core/embed/rust/src/ui/model_tr/layout.rs
@@ -368,7 +368,13 @@ extern "C" fn new_confirm_properties(n_args: usize, args: *const Obj, kwargs: *m
 
             if let Some(key) = key {
                 if value.is_some() {
-                    paragraphs.add(Paragraph::new(&theme::TEXT_BOLD, key).no_break());
+                    // Decreasing the margin between key and value (default is 5 px, we use 2 px)
+                    // (this enables 4 lines - 2 key:value pairs - on the same screen)
+                    paragraphs.add(
+                        Paragraph::new(&theme::TEXT_BOLD, key)
+                            .no_break()
+                            .with_bottom_padding(2),
+                    );
                 } else {
                     paragraphs.add(Paragraph::new(&theme::TEXT_BOLD, key));
                 }

--- a/core/embed/rust/src/ui/model_tr/layout.rs
+++ b/core/embed/rust/src/ui/model_tr/layout.rs
@@ -958,11 +958,14 @@ extern "C" fn new_confirm_coinjoin(n_args: usize, args: *const Obj, kwargs: *mut
         let max_rounds: StrBuffer = kwargs.get(Qstr::MP_QSTR_max_rounds)?.try_into()?;
         let max_feerate: StrBuffer = kwargs.get(Qstr::MP_QSTR_max_feerate)?.try_into()?;
 
+        // Decreasing bottom padding between paragraphs to fit one screen
         let paragraphs = Paragraphs::new([
-            Paragraph::new(&theme::TEXT_BOLD, "Max rounds".into()),
+            Paragraph::new(&theme::TEXT_BOLD, "Max rounds".into()).with_bottom_padding(2),
             Paragraph::new(&theme::TEXT_MONO, max_rounds),
-            Paragraph::new(&theme::TEXT_BOLD, "Max mining fee".into()).no_break(),
-            Paragraph::new(&theme::TEXT_MONO, max_feerate),
+            Paragraph::new(&theme::TEXT_BOLD, "Max mining fee".into())
+                .with_bottom_padding(2)
+                .no_break(),
+            Paragraph::new(&theme::TEXT_MONO, max_feerate).with_bottom_padding(2),
         ]);
 
         content_in_button_page(

--- a/core/src/apps/base.py
+++ b/core/src/apps/base.py
@@ -273,7 +273,7 @@ async def handle_UnlockPath(ctx: wire.Context, msg: UnlockPath) -> protobuf.Mess
             "confirm_coinjoin_access",
             title="Coinjoin",
             description="Access your coinjoin account?",
-            verb="ALLOW",
+            verb="ACCESS",
         )
 
     wire_types = (MessageType.GetAddress, MessageType.GetPublicKey, MessageType.SignTx)

--- a/core/src/apps/homescreen/__init__.py
+++ b/core/src/apps/homescreen/__init__.py
@@ -24,7 +24,6 @@ async def homescreen() -> None:
     notification = None
     notification_is_error = False
     if is_set_any_session(MessageType.AuthorizeCoinJoin):
-        # TODO: is too long for TR
         notification = "COINJOIN AUTHORIZED"
     elif storage.device.is_initialized() and storage.device.no_backup():
         notification = "SEEDLESS"
@@ -37,7 +36,6 @@ async def homescreen() -> None:
     elif storage.device.is_initialized() and not config.has_pin():
         notification = "PIN NOT SET"
     elif storage.device.get_experimental_features():
-        # TODO: is too long for TR
         notification = "EXPERIMENTAL MODE"
 
     await Homescreen(

--- a/core/src/trezor/ui/layouts/tr/progress.py
+++ b/core/src/trezor/ui/layouts/tr/progress.py
@@ -49,11 +49,9 @@ def bitcoin_progress(description: str) -> ProgressLayout:
 
 
 def coinjoin_progress(message: str) -> ProgressLayout:
-    # TODO: create show_progress_coinjoin for TR
-    return progress("Coinjoin", message)
-    # return RustProgress(
-    #     layout=trezorui2.show_progress_coinjoin(title=message, indeterminate=False)
-    # )
+    return RustProgress(
+        layout=trezorui2.show_progress_coinjoin(title=message, indeterminate=False)
+    )
 
 
 def pin_progress(message: str, description: str) -> ProgressLayout:


### PR DESCRIPTION
Fixes https://github.com/trezor/trezor-firmware/issues/2957:
- design of coinjoin screens with loaders

The small loader looks a little different than in `Figma`, I went for 2x2 big square and two missing slots clock-wise, as with the 2x1 rectangle, it would be tedious to change its angle when rotating around the circle. Up to discussion (could be tried with `trezorctl device set-busy -e 100`)

![image](https://github.com/trezor/trezor-firmware/assets/42543243/3a15a887-5669-4005-bcf0-d79513db2e22)

The determinate loaders are not visible in tests

![image](https://github.com/trezor/trezor-firmware/assets/42543243/0b70aa67-a90e-40a0-b8fc-957c748b855c)

Here are the recordings with animations turned-on ... compared to `Figma` it is missing the "check" in the middle after finish - what are the requirements for it - how much time should we be showing that (some of these operations are very quick)?

![image](https://github.com/trezor/trezor-firmware/assets/42543243/3cb57614-940c-4d95-969d-e642189d05dd)


