### PR TITLE
T2B1 passphrase flow

### DIFF
--- a/core/embed/rust/librust_qstr.h
+++ b/core/embed/rust/librust_qstr.h
@@ -108,6 +108,7 @@ static void _librust_qstrs(void) {
   MP_QSTR_show_info;
   MP_QSTR_show_lockscreen;
   MP_QSTR_show_mismatch;
+  MP_QSTR_show_passphrase;
   MP_QSTR_show_progress;
   MP_QSTR_show_progress_coinjoin;
   MP_QSTR_show_remaining_shares;

--- a/core/embed/rust/src/ui/model_tr/layout.rs
+++ b/core/embed/rust/src/ui/model_tr/layout.rs
@@ -900,6 +900,17 @@ extern "C" fn new_show_info(n_args: usize, args: *const Obj, kwargs: *mut Map) -
     unsafe { util::try_with_args_and_kwargs(n_args, args, kwargs, block) }
 }
 
+extern "C" fn new_show_passphrase() -> Obj {
+    let block = move || {
+        let text: StrBuffer = "Please enter your passphrase.".into();
+        let paragraph = Paragraph::new(&theme::TEXT_NORMAL, text).centered();
+        let content = Paragraphs::new([paragraph]);
+        let obj = LayoutObj::new(content)?;
+        Ok(obj.into())
+    };
+    unsafe { util::try_or_raise(block) }
+}
+
 extern "C" fn new_show_mismatch() -> Obj {
     let block = move || {
         let get_page = move |page_index| {
@@ -1456,6 +1467,10 @@ pub static mp_module_trezorui2: Module = obj_module! {
     /// ) -> object:
     ///     """Info modal."""
     Qstr::MP_QSTR_show_info => obj_fn_kw!(0, new_show_info).as_obj(),
+
+    /// def show_passphrase() -> object:
+    ///     """Show passphrase on host dialog."""
+    Qstr::MP_QSTR_show_passphrase => obj_fn_0!(new_show_passphrase).as_obj(),
 
     /// def show_mismatch() -> object:
     ///     """Warning modal, receiving address mismatch."""

--- a/core/mocks/generated/trezorui2.pyi
+++ b/core/mocks/generated/trezorui2.pyi
@@ -185,6 +185,11 @@ def show_info(
 
 
 # rust/src/ui/model_tr/layout.rs
+def show_passphrase() -> object:
+    """Show passphrase on host dialog."""
+
+
+# rust/src/ui/model_tr/layout.rs
 def show_mismatch() -> object:
     """Warning modal, receiving address mismatch."""
 

--- a/core/src/apps/management/apply_settings.py
+++ b/core/src/apps/management/apply_settings.py
@@ -183,13 +183,15 @@ async def _require_confirm_change_label(ctx: GenericContext, label: str) -> None
 
 
 async def _require_confirm_change_passphrase(ctx: GenericContext, use: bool) -> None:
-    template = "Do you want to {} passphrase protection?"
-    description = template.format("enable" if use else "disable")
+    on_or_off = "on" if use else "off"
+    description = f"Turn {on_or_off} passphrase protection?"
+    verb = f"Turn {on_or_off}"
     await confirm_action(
         ctx,
         "set_passphrase",
-        "Enable passphrase" if use else "Disable passphrase",
+        "Passphrase settings",
         description=description,
+        verb=verb,
         br_code=BRT_PROTECT_CALL,
     )
 

--- a/core/src/trezor/ui/layouts/tr/__init__.py
+++ b/core/src/trezor/ui/layouts/tr/__init__.py
@@ -1157,12 +1157,7 @@ async def show_error_popup(
 
 
 def request_passphrase_on_host() -> None:
-    draw_simple(
-        trezorui2.show_info(
-            title="HIDDEN WALLET",
-            description="Please type your passphrase on the connected host.",
-        )
-    )
+    draw_simple(trezorui2.show_passphrase())
 
 
 async def request_passphrase_on_device(ctx: GenericContext, max_len: int) -> str:

--- a/core/src/trezor/ui/layouts/tt_v2/__init__.py
+++ b/core/src/trezor/ui/layouts/tt_v2/__init__.py
@@ -1197,7 +1197,7 @@ def request_passphrase_on_host() -> None:
     draw_simple(
         trezorui2.show_simple(
             title=None,
-            description="Please type your passphrase on the connected host.",
+            description="Please enter your passphrase.",
         )
     )
 


### PR DESCRIPTION
Fixes https://github.com/trezor/trezor-firmware/issues/3091:
- small design changes on screens around passphrase dialog - e.g. `turn on` button, centering the "input passphrase" text

---

EDIT:
Differing screens:
- [click tests R](https://satoshilabs.gitlab.io/-/trezor/trezor-firmware/-/jobs/4512703306/artifacts/test_ui_report/differing_screens.html)
- [click tests](https://satoshilabs.gitlab.io/-/trezor/trezor-firmware/-/jobs/4512703303/artifacts/test_ui_report/differing_screens.html)
- [device tests](https://satoshilabs.gitlab.io/-/trezor/trezor-firmware/-/jobs/4512703282/artifacts/test_ui_report/differing_screens.html)
- [device tests R](https://satoshilabs.gitlab.io/-/trezor/trezor-firmware/-/jobs/4512703285/artifacts/test_ui_report/differing_screens.html) - there are bugs, to be fixes soon

So that the above-links do not need to be generated manually (and are not outdated after a new commit), a story was created - https://github.com/trezor/trezor-firmware/issues/3099

---

EDIT2:
first try of the auto-generated and auto-updated links: http://grdddj.eu:8002/gitlab/grdddj/tr_passphrase