### PR TITLE
Iter changes

### DIFF
--- a/core/embed/rust/Cargo.toml
+++ b/core/embed/rust/Cargo.toml
@@ -30,11 +30,11 @@ rgb_led = []
 test = [
     "button",
     "cc",
+    "debug",
     "glob",
     "micropython",
     "protobuf",
     "ui",
-    "ui_debug",
     "dma2d",
     "touch",
 ]

--- a/core/embed/rust/build.rs
+++ b/core/embed/rust/build.rs
@@ -222,6 +222,8 @@ fn generate_micropython_bindings() {
         // module
         .allowlist_type("mp_obj_module_t")
         .allowlist_var("mp_type_module")
+        // qstr
+        .allowlist_function("qstr_data")
         // `ffi::mp_map_t` type is not allowed to be `Clone` or `Copy` because we tie it
         // to the data lifetimes with the `MapRef` type, see `src/micropython/map.rs`.
         // TODO: We should disable `Clone` and `Copy` for all types and only allow-list

--- a/core/embed/rust/src/lib.rs
+++ b/core/embed/rust/src/lib.rs
@@ -33,6 +33,7 @@ pub mod ui;
 pub mod strutil;
 
 #[cfg(feature = "debug")]
+#[cfg(not(test))]
 #[panic_handler]
 /// More detailed panic handling. The difference against
 /// default `panic` below is that this "debug" version

--- a/core/embed/rust/src/micropython/list.rs
+++ b/core/embed/rust/src/micropython/list.rs
@@ -144,10 +144,7 @@ impl TryFrom<Obj> for Gc<List> {
 
 #[cfg(test)]
 mod tests {
-    use crate::micropython::{
-        iter::{Iter, IterBuf},
-        testutil::mpy_init,
-    };
+    use crate::micropython::{iter::IterBuf, testutil::mpy_init};
 
     use super::*;
     use heapless::Vec;
@@ -160,10 +157,10 @@ mod tests {
         let vec: Vec<u8, 10> = (0..5).collect();
         let list: Obj = List::from_iter(vec.iter().copied()).unwrap().into();
 
-        let mut buf = IterBuf::new();
-        let iter = Iter::try_from_obj_with_buf(list, &mut buf).unwrap();
         // collect the elements into a Vec of maximum length 10, through an iterator
-        let retrieved_vec: Vec<u8, 10> = iter
+        let retrieved_vec: Vec<u8, 10> = IterBuf::new()
+            .try_iterate(list)
+            .unwrap()
             .map(TryInto::try_into)
             .collect::<Result<Vec<u8, 10>, Error>>()
             .unwrap();
@@ -199,9 +196,9 @@ mod tests {
             );
         }
 
-        let mut buf = IterBuf::new();
-        let iter = Iter::try_from_obj_with_buf(gc_list.into(), &mut buf).unwrap();
-        let retrieved_vec: Vec<u16, 17> = iter
+        let retrieved_vec: Vec<u16, 17> = IterBuf::new()
+            .try_iterate(gc_list.into())
+            .unwrap()
             .map(TryInto::try_into)
             .collect::<Result<Vec<u16, 17>, Error>>()
             .unwrap();
@@ -240,9 +237,9 @@ mod tests {
             slice[i] = ((i + 10) as u16).into();
         }
 
-        let mut buf = IterBuf::new();
-        let iter = Iter::try_from_obj_with_buf(list.into(), &mut buf).unwrap();
-        let retrieved_vec: Vec<u16, 5> = iter
+        let retrieved_vec: Vec<u16, 5> = IterBuf::new()
+            .try_iterate(list.into())
+            .unwrap()
             .map(TryInto::try_into)
             .collect::<Result<Vec<u16, 5>, Error>>()
             .unwrap();

--- a/core/embed/rust/src/micropython/obj.rs
+++ b/core/embed/rust/src/micropython/obj.rs
@@ -447,11 +447,11 @@ impl Obj {
             // SAFETY:
             // Safe for pointers, for as long as MicroPython behaves sanely.
             // We assume that:
-            // * The pointer is a valid MicroPython object, which has `ObjBase`
-            //   as its first element.
+            // * The pointer is a valid MicroPython object, which has `ObjBase` as its first
+            //   element.
             // * The type pointer points to a valid type object.
-            // * The pointee has a 'static lifetime, i.e., either is
-            //   ROM-based, or GC allocated.
+            // * The pointee has a 'static lifetime, i.e., either is ROM-based, or GC
+            //   allocated.
             let base = self.as_ptr() as *const ObjBase;
             unsafe { (*base).type_.as_ref() }
         } else {

--- a/core/embed/rust/src/micropython/obj.rs
+++ b/core/embed/rust/src/micropython/obj.rs
@@ -441,4 +441,21 @@ impl Obj {
         let is_type_str = unsafe { ffi::mp_type_str.is_type_of(self) };
         is_type_str || self.is_qstr()
     }
+
+    pub fn type_<'a>(self) -> Option<&'a super::typ::Type> {
+        if self.is_ptr() {
+            // SAFETY:
+            // Safe for pointers, for as long as MicroPython behaves sanely.
+            // We assume that:
+            // * The pointer is a valid MicroPython object, which has `ObjBase`
+            //   as its first element.
+            // * The type pointer points to a valid type object.
+            // * The pointee has a 'static lifetime, i.e., either is
+            //   ROM-based, or GC allocated.
+            let base = self.as_ptr() as *const ObjBase;
+            unsafe { (*base).type_.as_ref() }
+        } else {
+            None
+        }
+    }
 }

--- a/core/embed/rust/src/micropython/qstr.rs
+++ b/core/embed/rust/src/micropython/qstr.rs
@@ -2,9 +2,11 @@
 #![allow(non_upper_case_globals)]
 #![allow(dead_code)]
 
-use core::convert::TryFrom;
+use core::{convert::TryFrom, slice, str::from_utf8};
 
-use crate::{error::Error, micropython::obj::Obj};
+use crate::error::Error;
+
+use super::{ffi, obj::Obj};
 
 impl Qstr {
     pub const fn to_obj(self) -> Obj {
@@ -29,6 +31,19 @@ impl Qstr {
     pub const fn from_u16(val: u16) -> Self {
         // TODO: Change the internal representation of Qstr to u16.
         Self(val as _)
+    }
+
+    pub fn as_str(self) -> &'static str {
+        let mut len = 0usize;
+        let slice = unsafe {
+            // SAFETY: qstr_data should always return a valid string, even for unknown ids.
+            let ptr = ffi::qstr_data(self.0 as _, &mut len as *mut _);
+            slice::from_raw_parts(ptr, len)
+        };
+        // SAFETY: Qstr pools are either ROM-based or permanently allocated in the GC
+        // arena. The MicroPython runtime holds the respective head pointers so we don't
+        // need to care.
+        unwrap!(from_utf8(slice))
     }
 }
 

--- a/core/embed/rust/src/micropython/typ.rs
+++ b/core/embed/rust/src/micropython/typ.rs
@@ -7,20 +7,21 @@ pub type Type = ffi::mp_obj_type_t;
 
 impl Type {
     pub fn is_type_of(&'static self, obj: Obj) -> bool {
-        if obj.is_ptr() {
-            // SAFETY: If `obj` is a pointer, it should always point to an object having
-            // `ObjBase` as the first field, making this cast safe.
-            unsafe {
-                let base = obj.as_ptr() as *const ObjBase;
-                (*base).type_ == self
-            }
-        } else {
-            false
+        match obj.type_() {
+            Some(type_) => core::ptr::eq(type_, self),
+            None => false,
         }
     }
 
     pub const fn as_base(&'static self) -> ObjBase {
         ObjBase { type_: self }
+    }
+
+    #[cfg(feature = "debug")]
+    pub fn name(&self) -> &'static str {
+        use super::qstr::Qstr;
+
+        Qstr::from(self.name).as_str()
     }
 }
 

--- a/core/embed/rust/src/ui/component/text/op.rs
+++ b/core/embed/rust/src/ui/component/text/op.rs
@@ -58,7 +58,7 @@ impl<'a, T: StringType + Clone + 'a> OpTextLayout<T> {
         sink: &mut dyn LayoutSink,
     ) -> LayoutFit {
         // TODO: make sure it is called when we have the current font (not sooner)
-        let mut cursor = &mut (self.layout.initial_cursor() + offset);
+        let cursor = &mut (self.layout.initial_cursor() + offset);
         let init_cursor = *cursor;
         let mut total_processed_chars = 0;
 

--- a/core/embed/rust/src/ui/layout/util.rs
+++ b/core/embed/rust/src/ui/layout/util.rs
@@ -3,7 +3,7 @@ use crate::{
     micropython::{
         buffer::{hexlify_bytes, StrBuffer},
         gc::Gc,
-        iter::{Iter, IterBuf},
+        iter::IterBuf,
         list::List,
         obj::Obj,
         util::try_or_raise,
@@ -42,8 +42,7 @@ where
     Error: From<E>,
 {
     let mut vec = Vec::<T, N>::new();
-    let mut iter_buf = IterBuf::new();
-    for item in Iter::try_from_obj_with_buf(iterable, &mut iter_buf)? {
+    for item in IterBuf::new().try_iterate(iterable)? {
         vec.push(item.try_into()?)
             .map_err(|_| value_error!("Invalid iterable length"))?;
     }


### PR DESCRIPTION
Fixes test failure in nightly ASAN jobs by disabling Micropython's built-in stack checking in the Rust test suite (where we don't actually need it for anything).

That is commit 81051d1368855e7cb88453d92e79c8ce9108bc9d, the rest is just gravy.

Namely:

17e25c60cab78b0b11a4e35fdfa4f54d0707fab1 allows easier examination of arbitrary `Obj`s, in particular in debug builds where you can retrieve the name of the type.

3f228c368e61e392830e2d31e7c6d7cef5c72f81 moves the iteration method from `Iter` to `IterBuf`, streamlining from:
```
let mut iter_buf = IterBuf::new();
let iter = Iter::try_from_obj_with_buf(obj, &mut iter_buf)?;
for x in iter { ... }
```
to:
```
for x in IterBuf::new().try_iterate(obj)? { ... }
```

0cc15629e853c3c1646312c27cc9b4a332d9d1b9 fixes an oversight that prevented our print!/println! macros from working in tests

2806b36a90fbdfe7bb17736a56ea4f3cbbab87e1 silences a clippy complaint