### PR TITLE
fix bootloader emulator compilation

### DIFF
--- a/core/SConscript.bootloader_emu
+++ b/core/SConscript.bootloader_emu
@@ -76,6 +76,7 @@ CPPPATH_MOD += [
 ]
 
 SOURCE_MOD += [
+    'embed/lib/unit_variant.c',
     'embed/lib/buffers.c',
     'embed/lib/colors.c',
     'embed/lib/display.c',


### PR DESCRIPTION
added missing file.

<!--
If you are a core dev:

Don't forget to set up the fields:
- assign yourself
- set priority to same as original issue
- add PR to sprint
- if Draft -> "in progress"
- if final PR -> "needs review"

If you're an external contributor, you can ignore this text.
-->
