### PR TITLE
fix TT bootloader emulator backlight, fix rust warning

### DIFF
--- a/core/SConscript.bootloader_emu
+++ b/core/SConscript.bootloader_emu
@@ -230,6 +230,7 @@ def cargo_build():
 
     if TREZOR_MODEL in ('T',):
         features.append('touch')
+        features.append('backlight')
     if TREZOR_MODEL in ('R', '1'):
         features.append('button')
 

--- a/core/embed/rust/src/ui/display/mod.rs
+++ b/core/embed/rust/src/ui/display/mod.rs
@@ -23,9 +23,11 @@ use crate::ui::component::image::Image;
 #[cfg(not(feature = "dma2d"))]
 use crate::ui::geometry::Alignment2D;
 
+#[cfg(feature = "backlight")]
+use crate::{time::Duration, trezorhal::time};
+
 use crate::{
-    time::Duration,
-    trezorhal::{buffers, display, time, uzlib::UzlibContext},
+    trezorhal::{buffers, display, uzlib::UzlibContext},
     ui::lerp::Lerp,
 };
 


### PR DESCRIPTION
broken by the recent backlight refactoring

<!--
If you are a core dev:

Don't forget to set up the fields:
- assign yourself
- set priority to same as original issue
- add PR to sprint
- if Draft -> "in progress"
- if final PR -> "needs review"

If you're an external contributor, you can ignore this text.
-->
