### PR TITLE
chore: update actions checkout version

### DIFF
--- a/.github/workflows/fixup_check.yml
+++ b/.github/workflows/fixup_check.yml
@@ -6,6 +6,6 @@ jobs:
   block-fixup:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2.0.0
+      - uses: actions/checkout@v3
       - name: Block Fixup Commit Merge
         uses: 13rac1/block-fixup-merge-action@v2.0.0

--- a/.github/workflows/prebuild.yml
+++ b/.github/workflows/prebuild.yml
@@ -7,7 +7,7 @@ jobs:
     name: Style check
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2.3.4
+      - uses: actions/checkout@v3
       - uses: cachix/install-nix-action@v13
         with:
           nix_path: nixpkgs=channel:nixos-unstable
@@ -19,7 +19,7 @@ jobs:
     name: Defs check
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2.3.4
+      - uses: actions/checkout@v3
         with:
           submodules: "recursive"
           fetch-depth: 0
@@ -34,7 +34,7 @@ jobs:
     name: Gen check
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2.3.4
+      - uses: actions/checkout@v3
         with:
           submodules: "recursive"
           fetch-depth: 0
@@ -49,7 +49,7 @@ jobs:
     name: Changelog check
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2.3.4
+      - uses: actions/checkout@v3
         with:
           fetch-depth: 0
         name: "Run check changelog"


### PR DESCRIPTION
was going trough some repositories and updating some of the actions, this only updates checkout as we do not have that much in here.
