### PR TITLE
Better typestub generation from C / Rust sources

### DIFF
--- a/core/embed/rust/src/ui/layout/obj.rs
+++ b/core/embed/rust/src/ui/layout/obj.rs
@@ -317,6 +317,21 @@ impl TryFrom<Never> for Obj {
     }
 }
 
+//# package: trezorui2
+//#
+//# from trezor import utils
+//# class LayoutObj:
+//#     """Representation of a Rust-based layout object.
+//#     see `trezor::ui::layout::obj::LayoutObj`.
+//#     """
+
+//# def attach_timer_fn(self, fn: Callable[[int, int], None]) -> None:
+//#     """Attach a timer setter function.
+//#
+//#     The layout object can call the timer setter with two arguments,
+//#     `token` and `deadline`. When `deadline` is reached, the layout object
+//#     expects a callback to `self.timer(token)`.
+//#     """
 extern "C" fn ui_layout_attach_timer_fn(this: Obj, timer_fn: Obj) -> Obj {
     let block = || {
         let this: Gc<LayoutObj> = this.try_into()?;
@@ -328,6 +343,10 @@ extern "C" fn ui_layout_attach_timer_fn(this: Obj, timer_fn: Obj) -> Obj {
     unsafe { util::try_or_raise(block) }
 }
 
+
+//# if utils.USE_TOUCH:
+//#     def touch_event(self, event: int, x: int, y: int) -> None:
+//#         """Receive a touch event `event` at coordinates `x`, `y`."""
 #[cfg(feature = "touch")]
 extern "C" fn ui_layout_touch_event(n_args: usize, args: *const Obj) -> Obj {
     let block = |args: &[Obj], _kwargs: &Map| {
@@ -351,6 +370,9 @@ extern "C" fn ui_layout_touch_event(_n_args: usize, _args: *const Obj) -> Obj {
     Obj::const_none()
 }
 
+//# if utils.USE_BUTTON:
+//#     def button_event(self, event: int, button: int) -> None:
+//#         """Receive a button event `event` for button `button`."""
 #[cfg(feature = "button")]
 extern "C" fn ui_layout_button_event(n_args: usize, args: *const Obj) -> Obj {
     let block = |args: &[Obj], _kwargs: &Map| {
@@ -370,6 +392,8 @@ extern "C" fn ui_layout_button_event(_n_args: usize, _args: *const Obj) -> Obj {
     Obj::const_none()
 }
 
+//# def progress_event(self, value: int, description: str) -> None:
+//#     """Receive a progress event."""
 extern "C" fn ui_layout_progress_event(n_args: usize, args: *const Obj) -> Obj {
     let block = |args: &[Obj], _kwargs: &Map| {
         if args.len() != 3 {
@@ -384,6 +408,8 @@ extern "C" fn ui_layout_progress_event(n_args: usize, args: *const Obj) -> Obj {
     unsafe { util::try_with_args_and_kwargs(n_args, args, &Map::EMPTY, block) }
 }
 
+//# def usb_event(self, connected: bool) -> None:
+//#     """Receive a USB connect/disconnect event."""
 extern "C" fn ui_layout_usb_event(n_args: usize, args: *const Obj) -> Obj {
     let block = |args: &[Obj], _kwargs: &Map| {
         if args.len() != 2 {
@@ -397,6 +423,12 @@ extern "C" fn ui_layout_usb_event(n_args: usize, args: *const Obj) -> Obj {
     unsafe { util::try_with_args_and_kwargs(n_args, args, &Map::EMPTY, block) }
 }
 
+//# def timer(self, token: int) -> None:
+//#     """Callback for the timer set by `attach_timer_fn`.
+//#
+//#     This function should be called by the executor after the corresponding
+//#     deadline is reached.
+//#     """
 extern "C" fn ui_layout_timer(this: Obj, token: Obj) -> Obj {
     let block = || {
         let this: Gc<LayoutObj> = this.try_into()?;
@@ -407,6 +439,11 @@ extern "C" fn ui_layout_timer(this: Obj, token: Obj) -> Obj {
     unsafe { util::try_or_raise(block) }
 }
 
+//# def paint(self) -> None:
+//#     """Paint the layout object on screen.
+//#
+//#     Will only paint updated parts of the layout as required.
+//#     """
 extern "C" fn ui_layout_paint(this: Obj) -> Obj {
     let block = || {
         let this: Gc<LayoutObj> = this.try_into()?;
@@ -416,6 +453,11 @@ extern "C" fn ui_layout_paint(this: Obj) -> Obj {
     unsafe { util::try_or_raise(block) }
 }
 
+//# def request_complete_repaint(self) -> None:
+//#     """Request a complete repaint of the screen.
+//#
+//#     Does not repaint the screen, a subsequent call to `paint()` is required.
+//#     """
 extern "C" fn ui_layout_request_complete_repaint(this: Obj) -> Obj {
     let block = || {
         let this: Gc<LayoutObj> = this.try_into()?;
@@ -432,6 +474,8 @@ extern "C" fn ui_layout_request_complete_repaint(this: Obj) -> Obj {
     unsafe { util::try_or_raise(block) }
 }
 
+//# def page_count(self) -> int:
+//#     """Return the number of pages in the layout object."""
 extern "C" fn ui_layout_page_count(this: Obj) -> Obj {
     let block = || {
         let this: Gc<LayoutObj> = this.try_into()?;
@@ -446,6 +490,14 @@ pub extern "C" fn ui_debug_layout_type() -> &'static Type {
     LayoutObj::obj_type()
 }
 
+//# if __debug__:
+//#     def trace(self, tracer: Callable[[str], None]) -> None:
+//#         """Generate a JSON trace of the layout object.
+//#
+//#         The JSON can be emitted as a sequence of calls to `tracer`, each of
+//#         which is not necessarily a valid JSON chunk. The caller must
+//#         reassemble the chunks to get a sensible result.
+//#         """
 #[cfg(feature = "ui_debug")]
 extern "C" fn ui_layout_trace(this: Obj, callback: Obj) -> Obj {
     let block = || {
@@ -461,6 +513,9 @@ extern "C" fn ui_layout_trace(_this: Obj, _callback: Obj) -> Obj {
     Obj::const_none()
 }
 
+//# if __debug__:
+//#     def bounds(self) -> None:
+//#         """Paint bounds of individual components on screen."""
 #[cfg(feature = "ui_bounds")]
 extern "C" fn ui_layout_bounds(this: Obj) -> Obj {
     let block = || {

--- a/core/embed/rust/src/ui/model_tt/layout.rs
+++ b/core/embed/rust/src/ui/model_tt/layout.rs
@@ -1594,415 +1594,416 @@ extern "C" fn draw_welcome_screen() -> Obj {
 
 #[no_mangle]
 pub static mp_module_trezorui2: Module = obj_module! {
+    //# package: trezorui2
     Qstr::MP_QSTR___name__ => Qstr::MP_QSTR_trezorui2.to_obj(),
 
-    /// CONFIRMED: object
+    //# CONFIRMED: object
     Qstr::MP_QSTR_CONFIRMED => CONFIRMED.as_obj(),
 
-    /// CANCELLED: object
+    //# CANCELLED: object
     Qstr::MP_QSTR_CANCELLED => CANCELLED.as_obj(),
 
-    /// INFO: object
+    //# INFO: object
     Qstr::MP_QSTR_INFO => INFO.as_obj(),
 
-    /// def disable_animation(disable: bool) -> None:
-    ///     """Disable animations, debug builds only."""
+    //# def disable_animation(disable: bool) -> None:
+    //#     """Disable animations, debug builds only."""
     Qstr::MP_QSTR_disable_animation => obj_fn_1!(upy_disable_animation).as_obj(),
 
-    /// def jpeg_info(data: bytes) -> tuple[int, int, int]:
-    ///     """Get JPEG image dimensions (width: int, height: int, mcu_height: int)."""
+    //# def jpeg_info(data: bytes) -> tuple[int, int, int]:
+    //#     """Get JPEG image dimensions (width: int, height: int, mcu_height: int)."""
     Qstr::MP_QSTR_jpeg_info => obj_fn_1!(upy_jpeg_info).as_obj(),
 
-    /// def jpeg_test(data: bytes) -> bool:
-    ///     """Test JPEG image."""
+    //# def jpeg_test(data: bytes) -> bool:
+    //#     """Test JPEG image."""
     Qstr::MP_QSTR_jpeg_test => obj_fn_1!(upy_jpeg_test).as_obj(),
 
-    /// def confirm_action(
-    ///     *,
-    ///     title: str,
-    ///     action: str | None,
-    ///     description: str | None,
-    ///     verb: str | None = None,
-    ///     verb_cancel: str | None = None,
-    ///     hold: bool = False,
-    ///     hold_danger: bool = False,
-    ///     reverse: bool = False,
-    /// ) -> object:
-    ///     """Confirm action."""
+    //# def confirm_action(
+    //#     *,
+    //#     title: str,
+    //#     action: str | None,
+    //#     description: str | None,
+    //#     verb: str | None = None,
+    //#     verb_cancel: str | None = None,
+    //#     hold: bool = False,
+    //#     hold_danger: bool = False,
+    //#     reverse: bool = False,
+    //# ) -> LayoutObj:
+    //#     """Confirm action."""
     Qstr::MP_QSTR_confirm_action => obj_fn_kw!(0, new_confirm_action).as_obj(),
 
-    /// def confirm_emphasized(
-    ///     *,
-    ///     title: str,
-    ///     items: Iterable[str | tuple[bool, str]],
-    ///     verb: str | None = None,
-    /// ) -> object:
-    ///     """Confirm formatted text that has been pre-split in python. For tuples
-    ///     the first component is a bool indicating whether this part is emphasized."""
+    //# def confirm_emphasized(
+    //#     *,
+    //#     title: str,
+    //#     items: Iterable[str | tuple[bool, str]],
+    //#     verb: str | None = None,
+    //# ) -> LayoutObj:
+    //#     """Confirm formatted text that has been pre-split in python. For tuples
+    //#     the first component is a bool indicating whether this part is emphasized."""
     Qstr::MP_QSTR_confirm_emphasized => obj_fn_kw!(0, new_confirm_emphasized).as_obj(),
 
-    /// def confirm_homescreen(
-    ///     *,
-    ///     title: str,
-    ///     image: bytes,
-    /// ) -> object:
-    ///     """Confirm homescreen."""
+    //# def confirm_homescreen(
+    //#     *,
+    //#     title: str,
+    //#     image: bytes,
+    //# ) -> LayoutObj:
+    //#     """Confirm homescreen."""
     Qstr::MP_QSTR_confirm_homescreen => obj_fn_kw!(0, new_confirm_homescreen).as_obj(),
 
-    /// def confirm_blob(
-    ///     *,
-    ///     title: str,
-    ///     data: str | bytes,
-    ///     description: str | None,
-    ///     extra: str | None,
-    ///     verb: str | None = None,
-    ///     verb_cancel: str | None = None,
-    ///     hold: bool = False,
-    /// ) -> object:
-    ///     """Confirm byte sequence data."""
+    //# def confirm_blob(
+    //#     *,
+    //#     title: str,
+    //#     data: str | bytes,
+    //#     description: str | None,
+    //#     extra: str | None,
+    //#     verb: str | None = None,
+    //#     verb_cancel: str | None = None,
+    //#     hold: bool = False,
+    //# ) -> LayoutObj:
+    //#     """Confirm byte sequence data."""
     Qstr::MP_QSTR_confirm_blob => obj_fn_kw!(0, new_confirm_blob).as_obj(),
 
-    /// def confirm_address(
-    ///     *,
-    ///     title: str,
-    ///     data: str | bytes,
-    ///     description: str | None,
-    ///     extra: str | None,
-    /// ) -> object:
-    ///     """Confirm address. Similar to `confirm_blob` but has corner info button
-    ///     and allows left swipe which does the same thing as the button."""
+    //# def confirm_address(
+    //#     *,
+    //#     title: str,
+    //#     data: str | bytes,
+    //#     description: str | None,
+    //#     extra: str | None,
+    //# ) -> LayoutObj:
+    //#     """Confirm address. Similar to `confirm_blob` but has corner info button
+    //#     and allows left swipe which does the same thing as the button."""
     Qstr::MP_QSTR_confirm_address => obj_fn_kw!(0, new_confirm_address).as_obj(),
 
-    /// def confirm_properties(
-    ///     *,
-    ///     title: str,
-    ///     items: list[tuple[str | None, str | bytes | None, bool]],
-    ///     hold: bool = False,
-    /// ) -> object:
-    ///     """Confirm list of key-value pairs. The third component in the tuple should be True if
-    ///     the value is to be rendered as binary with monospace font, False otherwise."""
+    //# def confirm_properties(
+    //#     *,
+    //#     title: str,
+    //#     items: list[tuple[str | None, str | bytes | None, bool]],
+    //#     hold: bool = False,
+    //# ) -> LayoutObj:
+    //#     """Confirm list of key-value pairs. The third component in the tuple should be True if
+    //#     the value is to be rendered as binary with monospace font, False otherwise."""
     Qstr::MP_QSTR_confirm_properties => obj_fn_kw!(0, new_confirm_properties).as_obj(),
 
-    /// def confirm_reset_device(
-    ///     *,
-    ///     title: str,
-    ///     button: str,
-    /// ) -> object:
-    ///     """Confirm TOS before device setup."""
+    //# def confirm_reset_device(
+    //#     *,
+    //#     title: str,
+    //#     button: str,
+    //# ) -> LayoutObj:
+    //#     """Confirm TOS before device setup."""
     Qstr::MP_QSTR_confirm_reset_device => obj_fn_kw!(0, new_confirm_reset_device).as_obj(),
 
-    /// def show_address_details(
-    ///     *,
-    ///     address: str,
-    ///     case_sensitive: bool,
-    ///     account: str | None,
-    ///     path: str | None,
-    ///     xpubs: list[tuple[str, str]],
-    /// ) -> object:
-    ///     """Show address details - QR code, account, path, cosigner xpubs."""
+    //# def show_address_details(
+    //#     *,
+    //#     address: str,
+    //#     case_sensitive: bool,
+    //#     account: str | None,
+    //#     path: str | None,
+    //#     xpubs: list[tuple[str, str]],
+    //# ) -> LayoutObj:
+    //#     """Show address details - QR code, account, path, cosigner xpubs."""
     Qstr::MP_QSTR_show_address_details => obj_fn_kw!(0, new_show_address_details).as_obj(),
 
-    /// def show_spending_details(
-    ///     *,
-    ///     title: str = "INFORMATION",
-    ///     account: str | None,
-    ///     fee_rate: str | None,
-    ///     fee_rate_title: str = "Fee rate:",
-    /// ) -> object:
-    ///     """Show metadata when for outgoing transaction."""
+    //# def show_spending_details(
+    //#     *,
+    //#     title: str = "INFORMATION",
+    //#     account: str | None,
+    //#     fee_rate: str | None,
+    //#     fee_rate_title: str = "Fee rate:",
+    //# ) -> LayoutObj:
+    //#     """Show metadata when for outgoing transaction."""
     Qstr::MP_QSTR_show_spending_details => obj_fn_kw!(0, new_show_spending_details).as_obj(),
 
-    /// def confirm_value(
-    ///     *,
-    ///     title: str,
-    ///     value: str,
-    ///     description: str | None,
-    ///     subtitle: str | None,
-    ///     verb: str | None = None,
-    ///     verb_cancel: str | None = None,
-    ///     info_button: bool = False,
-    ///     hold: bool = False,
-    /// ) -> object:
-    ///     """Confirm value. Merge of confirm_total and confirm_output."""
+    //# def confirm_value(
+    //#     *,
+    //#     title: str,
+    //#     value: str,
+    //#     description: str | None,
+    //#     subtitle: str | None,
+    //#     verb: str | None = None,
+    //#     verb_cancel: str | None = None,
+    //#     info_button: bool = False,
+    //#     hold: bool = False,
+    //# ) -> LayoutObj:
+    //#     """Confirm value. Merge of confirm_total and confirm_output."""
     Qstr::MP_QSTR_confirm_value => obj_fn_kw!(0, new_confirm_value).as_obj(),
 
-    /// def confirm_total(
-    ///     *,
-    ///     title: str,
-    ///     items: list[tuple[str, str]],
-    ///     info_button: bool = False,
-    /// ) -> object:
-    ///     """Transaction summary. Always hold to confirm."""
+    //# def confirm_total(
+    //#     *,
+    //#     title: str,
+    //#     items: list[tuple[str, str]],
+    //#     info_button: bool = False,
+    //# ) -> LayoutObj:
+    //#     """Transaction summary. Always hold to confirm."""
     Qstr::MP_QSTR_confirm_total => obj_fn_kw!(0, new_confirm_total).as_obj(),
 
-    /// def confirm_modify_output(
-    ///     *,
-    ///     address: str,  # ignored
-    ///     sign: int,
-    ///     amount_change: str,
-    ///     amount_new: str,
-    /// ) -> object:
-    ///     """Decrease or increase amount for given address."""
+    //# def confirm_modify_output(
+    //#     *,
+    //#     address: str,  # ignored
+    //#     sign: int,
+    //#     amount_change: str,
+    //#     amount_new: str,
+    //# ) -> LayoutObj:
+    //#     """Decrease or increase amount for given address."""
     Qstr::MP_QSTR_confirm_modify_output => obj_fn_kw!(0, new_confirm_modify_output).as_obj(),
 
-    /// def confirm_modify_fee(
-    ///     *,
-    ///     title: str,
-    ///     sign: int,
-    ///     user_fee_change: str,
-    ///     total_fee_new: str,
-    ///     fee_rate_amount: str | None,  # ignored
-    /// ) -> object:
-    ///     """Decrease or increase transaction fee."""
+    //# def confirm_modify_fee(
+    //#     *,
+    //#     title: str,
+    //#     sign: int,
+    //#     user_fee_change: str,
+    //#     total_fee_new: str,
+    //#     fee_rate_amount: str | None,  # ignored
+    //# ) -> LayoutObj:
+    //#     """Decrease or increase transaction fee."""
     Qstr::MP_QSTR_confirm_modify_fee => obj_fn_kw!(0, new_confirm_modify_fee).as_obj(),
 
-    /// def confirm_fido(
-    ///     *,
-    ///     title: str,
-    ///     app_name: str,
-    ///     icon_name: str | None,
-    ///     accounts: list[str | None],
-    /// ) -> int | object:
-    ///     """FIDO confirmation.
-    ///
-    ///     Returns page index in case of confirmation and CANCELLED otherwise.
-    ///     """
+    //# def confirm_fido(
+    //#     *,
+    //#     title: str,
+    //#     app_name: str,
+    //#     icon_name: str | None,
+    //#     accounts: list[str | None],
+    //# ) -> int | object:
+    //#     """FIDO confirmation.
+    //#
+    //#     Returns page index in case of confirmation and CANCELLED otherwise.
+    //#     """
     Qstr::MP_QSTR_confirm_fido => obj_fn_kw!(0, new_confirm_fido).as_obj(),
 
-    /// def show_error(
-    ///     *,
-    ///     title: str,
-    ///     button: str = "CONTINUE",
-    ///     description: str = "",
-    ///     allow_cancel: bool = False,
-    ///     time_ms: int = 0,
-    /// ) -> object:
-    ///     """Error modal. No buttons shown when `button` is empty string."""
+    //# def show_error(
+    //#     *,
+    //#     title: str,
+    //#     button: str = "CONTINUE",
+    //#     description: str = "",
+    //#     allow_cancel: bool = False,
+    //#     time_ms: int = 0,
+    //# ) -> LayoutObj:
+    //#     """Error modal. No buttons shown when `button` is empty string."""
     Qstr::MP_QSTR_show_error => obj_fn_kw!(0, new_show_error).as_obj(),
 
-    /// def show_warning(
-    ///     *,
-    ///     title: str,
-    ///     button: str = "CONTINUE",
-    ///     description: str = "",
-    ///     allow_cancel: bool = False,
-    ///     time_ms: int = 0,
-    /// ) -> object:
-    ///     """Warning modal. No buttons shown when `button` is empty string."""
+    //# def show_warning(
+    //#     *,
+    //#     title: str,
+    //#     button: str = "CONTINUE",
+    //#     description: str = "",
+    //#     allow_cancel: bool = False,
+    //#     time_ms: int = 0,
+    //# ) -> LayoutObj:
+    //#     """Warning modal. No buttons shown when `button` is empty string."""
     Qstr::MP_QSTR_show_warning => obj_fn_kw!(0, new_show_warning).as_obj(),
 
-    /// def show_success(
-    ///     *,
-    ///     title: str,
-    ///     button: str = "CONTINUE",
-    ///     description: str = "",
-    ///     allow_cancel: bool = False,
-    ///     time_ms: int = 0,
-    /// ) -> object:
-    ///     """Success modal. No buttons shown when `button` is empty string."""
+    //# def show_success(
+    //#     *,
+    //#     title: str,
+    //#     button: str = "CONTINUE",
+    //#     description: str = "",
+    //#     allow_cancel: bool = False,
+    //#     time_ms: int = 0,
+    //# ) -> LayoutObj:
+    //#     """Success modal. No buttons shown when `button` is empty string."""
     Qstr::MP_QSTR_show_success => obj_fn_kw!(0, new_show_success).as_obj(),
 
-    /// def show_info(
-    ///     *,
-    ///     title: str,
-    ///     button: str = "CONTINUE",
-    ///     description: str = "",
-    ///     allow_cancel: bool = False,
-    ///     time_ms: int = 0,
-    /// ) -> object:
-    ///     """Info modal. No buttons shown when `button` is empty string."""
+    //# def show_info(
+    //#     *,
+    //#     title: str,
+    //#     button: str = "CONTINUE",
+    //#     description: str = "",
+    //#     allow_cancel: bool = False,
+    //#     time_ms: int = 0,
+    //# ) -> LayoutObj:
+    //#     """Info modal. No buttons shown when `button` is empty string."""
     Qstr::MP_QSTR_show_info => obj_fn_kw!(0, new_show_info).as_obj(),
 
-    /// def show_mismatch() -> object:
-    ///     """Warning modal, receiving address mismatch."""
+    //# def show_mismatch() -> LayoutObj:
+    //#     """Warning modal, receiving address mismatch."""
     Qstr::MP_QSTR_show_mismatch => obj_fn_0!(new_show_mismatch).as_obj(),
 
-    /// def show_simple(
-    ///     *,
-    ///     title: str | None,
-    ///     description: str = "",
-    ///     button: str = "",
-    /// ) -> object:
-    ///     """Simple dialog with text and one button."""
+    //# def show_simple(
+    //#     *,
+    //#     title: str | None,
+    //#     description: str = "",
+    //#     button: str = "",
+    //# ) -> LayoutObj:
+    //#     """Simple dialog with text and one button."""
     Qstr::MP_QSTR_show_simple => obj_fn_kw!(0, new_show_simple).as_obj(),
 
-    /// def confirm_with_info(
-    ///     *,
-    ///     title: str,
-    ///     button: str,
-    ///     info_button: str,
-    ///     items: Iterable[tuple[int, str]],
-    /// ) -> object:
-    ///     """Confirm given items but with third button. Always single page
-    ///     without scrolling."""
+    //# def confirm_with_info(
+    //#     *,
+    //#     title: str,
+    //#     button: str,
+    //#     info_button: str,
+    //#     items: Iterable[tuple[int, str]],
+    //# ) -> LayoutObj:
+    //#     """Confirm given items but with third button. Always single page
+    //#     without scrolling."""
     Qstr::MP_QSTR_confirm_with_info => obj_fn_kw!(0, new_confirm_with_info).as_obj(),
 
-    /// def confirm_more(
-    ///     *,
-    ///     title: str,
-    ///     button: str,
-    ///     items: Iterable[tuple[int, str]],
-    /// ) -> object:
-    ///     """Confirm long content with the possibility to go back from any page.
-    ///     Meant to be used with confirm_with_info."""
+    //# def confirm_more(
+    //#     *,
+    //#     title: str,
+    //#     button: str,
+    //#     items: Iterable[tuple[int, str]],
+    //# ) -> LayoutObj:
+    //#     """Confirm long content with the possibility to go back from any page.
+    //#     Meant to be used with confirm_with_info."""
     Qstr::MP_QSTR_confirm_more => obj_fn_kw!(0, new_confirm_more).as_obj(),
 
-    /// def confirm_coinjoin(
-    ///     *,
-    ///     max_rounds: str,
-    ///     max_feerate: str,
-    /// ) -> object:
-    ///     """Confirm coinjoin authorization."""
+    //# def confirm_coinjoin(
+    //#     *,
+    //#     max_rounds: str,
+    //#     max_feerate: str,
+    //# ) -> LayoutObj:
+    //#     """Confirm coinjoin authorization."""
     Qstr::MP_QSTR_confirm_coinjoin => obj_fn_kw!(0, new_confirm_coinjoin).as_obj(),
 
-    /// def request_pin(
-    ///     *,
-    ///     prompt: str,
-    ///     subprompt: str,
-    ///     allow_cancel: bool = True,
-    ///     wrong_pin: bool = False,
-    /// ) -> str | object:
-    ///     """Request pin on device."""
+    //# def request_pin(
+    //#     *,
+    //#     prompt: str,
+    //#     subprompt: str,
+    //#     allow_cancel: bool = True,
+    //#     wrong_pin: bool = False,
+    //# ) -> str | object:
+    //#     """Request pin on device."""
     Qstr::MP_QSTR_request_pin => obj_fn_kw!(0, new_request_pin).as_obj(),
 
-    /// def request_passphrase(
-    ///     *,
-    ///     prompt: str,
-    ///     max_len: int,
-    /// ) -> str | object:
-    ///     """Passphrase input keyboard."""
+    //# def request_passphrase(
+    //#     *,
+    //#     prompt: str,
+    //#     max_len: int,
+    //# ) -> str | object:
+    //#     """Passphrase input keyboard."""
     Qstr::MP_QSTR_request_passphrase => obj_fn_kw!(0, new_request_passphrase).as_obj(),
 
-    /// def request_bip39(
-    ///     *,
-    ///     prompt: str,
-    /// ) -> str:
-    ///     """BIP39 word input keyboard."""
+    //# def request_bip39(
+    //#     *,
+    //#     prompt: str,
+    //# ) -> str:
+    //#     """BIP39 word input keyboard."""
     Qstr::MP_QSTR_request_bip39 => obj_fn_kw!(0, new_request_bip39).as_obj(),
 
-    /// def request_slip39(
-    ///     *,
-    ///     prompt: str,
-    /// ) -> str:
-    ///     """SLIP39 word input keyboard."""
+    //# def request_slip39(
+    //#     *,
+    //#     prompt: str,
+    //# ) -> str:
+    //#     """SLIP39 word input keyboard."""
     Qstr::MP_QSTR_request_slip39 => obj_fn_kw!(0, new_request_slip39).as_obj(),
 
-    /// def select_word(
-    ///     *,
-    ///     title: str,
-    ///     description: str,
-    ///     words: Iterable[str],
-    /// ) -> int:
-    ///     """Select mnemonic word from three possibilities - seed check after backup. The
-    ///    iterable must be of exact size. Returns index in range `0..3`."""
+    //# def select_word(
+    //#     *,
+    //#     title: str,
+    //#     description: str,
+    //#     words: Iterable[str],
+    //# ) -> int:
+    //#     """Select mnemonic word from three possibilities - seed check after backup. The
+    //#    iterable must be of exact size. Returns index in range `0..3`."""
     Qstr::MP_QSTR_select_word => obj_fn_kw!(0, new_select_word).as_obj(),
 
-    /// def show_share_words(
-    ///     *,
-    ///     title: str,
-    ///     pages: Iterable[str],
-    /// ) -> object:
-    ///     """Show mnemonic for backup. Expects the words pre-divided into individual pages."""
+    //# def show_share_words(
+    //#     *,
+    //#     title: str,
+    //#     pages: Iterable[str],
+    //# ) -> LayoutObj:
+    //#     """Show mnemonic for backup. Expects the words pre-divided into individual pages."""
     Qstr::MP_QSTR_show_share_words => obj_fn_kw!(0, new_show_share_words).as_obj(),
 
-    /// def request_number(
-    ///     *,
-    ///     title: str,
-    ///     count: int,
-    ///     min_count: int,
-    ///     max_count: int,
-    ///     description: Callable[[int], str] | None = None,
-    /// ) -> object:
-    ///     """Number input with + and - buttons, description, and info button."""
+    //# def request_number(
+    //#     *,
+    //#     title: str,
+    //#     count: int,
+    //#     min_count: int,
+    //#     max_count: int,
+    //#     description: Callable[[int], str] | None = None,
+    //# ) -> LayoutObj:
+    //#     """Number input with + and - buttons, description, and info button."""
     Qstr::MP_QSTR_request_number => obj_fn_kw!(0, new_request_number).as_obj(),
 
-    /// def show_checklist(
-    ///     *,
-    ///     title: str,
-    ///     items: Iterable[str],
-    ///     active: int,
-    ///     button: str,
-    /// ) -> object:
-    ///     """Checklist of backup steps. Active index is highlighted, previous items have check
-    ///    mark next to them."""
+    //# def show_checklist(
+    //#     *,
+    //#     title: str,
+    //#     items: Iterable[str],
+    //#     active: int,
+    //#     button: str,
+    //# ) -> LayoutObj:
+    //#     """Checklist of backup steps. Active index is highlighted, previous items have check
+    //#    mark next to them."""
     Qstr::MP_QSTR_show_checklist => obj_fn_kw!(0, new_show_checklist).as_obj(),
 
-    /// def confirm_recovery(
-    ///     *,
-    ///     title: str,
-    ///     description: str,
-    ///     button: str,
-    ///     dry_run: bool,
-    ///     info_button: bool = False,
-    /// ) -> object:
-    ///     """Device recovery homescreen."""
+    //# def confirm_recovery(
+    //#     *,
+    //#     title: str,
+    //#     description: str,
+    //#     button: str,
+    //#     dry_run: bool,
+    //#     info_button: bool = False,
+    //# ) -> LayoutObj:
+    //#     """Device recovery homescreen."""
     Qstr::MP_QSTR_confirm_recovery => obj_fn_kw!(0, new_confirm_recovery).as_obj(),
 
-    /// def select_word_count(
-    ///     *,
-    ///     dry_run: bool,
-    /// ) -> int | str:  # TT returns int
-    ///     """Select mnemonic word count from (12, 18, 20, 24, 33)."""
+    //# def select_word_count(
+    //#     *,
+    //#     dry_run: bool,
+    //# ) -> int | str:  # TT returns int
+    //#     """Select mnemonic word count from (12, 18, 20, 24, 33)."""
     Qstr::MP_QSTR_select_word_count => obj_fn_kw!(0, new_select_word_count).as_obj(),
 
-    /// def show_group_share_success(
-    ///     *,
-    ///     lines: Iterable[str]
-    /// ) -> int:
-    ///     """Shown after successfully finishing a group."""
+    //# def show_group_share_success(
+    //#     *,
+    //#     lines: Iterable[str]
+    //# ) -> int:
+    //#     """Shown after successfully finishing a group."""
     Qstr::MP_QSTR_show_group_share_success => obj_fn_kw!(0, new_show_group_share_success).as_obj(),
 
-    /// def show_remaining_shares(
-    ///     *,
-    ///     pages: Iterable[tuple[str, str]],
-    /// ) -> int:
-    ///     """Shows SLIP39 state after info button is pressed on `confirm_recovery`."""
+    //# def show_remaining_shares(
+    //#     *,
+    //#     pages: Iterable[tuple[str, str]],
+    //# ) -> int:
+    //#     """Shows SLIP39 state after info button is pressed on `confirm_recovery`."""
     Qstr::MP_QSTR_show_remaining_shares => obj_fn_kw!(0, new_show_remaining_shares).as_obj(),
 
-    /// def show_progress(
-    ///     *,
-    ///     title: str,
-    ///     indeterminate: bool = False,
-    ///     description: str = "",
-    /// ) -> object:
-    ///     """Show progress loader. Please note that the number of lines reserved on screen for
-    ///    description is determined at construction time. If you want multiline descriptions
-    ///    make sure the initial description has at least that amount of lines."""
+    //# def show_progress(
+    //#     *,
+    //#     title: str,
+    //#     indeterminate: bool = False,
+    //#     description: str = "",
+    //# ) -> LayoutObj:
+    //#     """Show progress loader. Please note that the number of lines reserved on screen for
+    //#    description is determined at construction time. If you want multiline descriptions
+    //#    make sure the initial description has at least that amount of lines."""
     Qstr::MP_QSTR_show_progress => obj_fn_kw!(0, new_show_progress).as_obj(),
 
-    /// def show_progress_coinjoin(
-    ///     *,
-    ///     title: str,
-    ///     indeterminate: bool = False,
-    ///     time_ms: int = 0,
-    ///     skip_first_paint: bool = False,
-    /// ) -> object:
-    ///     """Show progress loader for coinjoin. Returns CANCELLED after a specified time when
-    ///    time_ms timeout is passed."""
+    //# def show_progress_coinjoin(
+    //#     *,
+    //#     title: str,
+    //#     indeterminate: bool = False,
+    //#     time_ms: int = 0,
+    //#     skip_first_paint: bool = False,
+    //# ) -> LayoutObj:
+    //#     """Show progress loader for coinjoin. Returns CANCELLED after a specified time when
+    //#    time_ms timeout is passed."""
     Qstr::MP_QSTR_show_progress_coinjoin => obj_fn_kw!(0, new_show_progress_coinjoin).as_obj(),
 
-    /// def show_homescreen(
-    ///     *,
-    ///     label: str | None,
-    ///     hold: bool,
-    ///     notification: str | None,
-    ///     notification_level: int = 0,
-    ///     skip_first_paint: bool,
-    /// ) -> CANCELLED:
-    ///     """Idle homescreen."""
+    //# def show_homescreen(
+    //#     *,
+    //#     label: str | None,
+    //#     hold: bool,
+    //#     notification: str | None,
+    //#     notification_level: int = 0,
+    //#     skip_first_paint: bool,
+    //# ) -> CANCELLED:
+    //#     """Idle homescreen."""
     Qstr::MP_QSTR_show_homescreen => obj_fn_kw!(0, new_show_homescreen).as_obj(),
 
-    /// def show_lockscreen(
-    ///     *,
-    ///     label: str | None,
-    ///     bootscreen: bool,
-    ///     skip_first_paint: bool,
-    /// ) -> CANCELLED:
-    ///     """Homescreen for locked device."""
+    //# def show_lockscreen(
+    //#     *,
+    //#     label: str | None,
+    //#     bootscreen: bool,
+    //#     skip_first_paint: bool,
+    //# ) -> CANCELLED:
+    //#     """Homescreen for locked device."""
     Qstr::MP_QSTR_show_lockscreen => obj_fn_kw!(0, new_show_lockscreen).as_obj(),
 
-    /// def draw_welcome_screen() -> None:
-    ///     """Show logo icon with the model name at the bottom and return."""
+    //# def draw_welcome_screen() -> None:
+    //#     """Show logo icon with the model name at the bottom and return."""
     Qstr::MP_QSTR_draw_welcome_screen => obj_fn_0!(draw_welcome_screen).as_obj(),
 };
 

--- a/core/mocks/generated/trezorconfig.pyi
+++ b/core/mocks/generated/trezorconfig.pyi
@@ -1,7 +1,4 @@
 from typing import *
-
-
-# extmod/modtrezorconfig/modtrezorconfig.c
 def init(
    ui_wait_callback: Callable[[int, int, str], bool] | None = None
 ) -> None:
@@ -9,53 +6,32 @@ def init(
     Initializes the storage.  Must be called before any other method is
     called from this module!
     """
-
-
-# extmod/modtrezorconfig/modtrezorconfig.c
 def unlock(pin: str, ext_salt: bytes | None) -> bool:
     """
     Attempts to unlock the storage with the given PIN and external salt.
     Returns True on success, False on failure.
     """
-
-
-# extmod/modtrezorconfig/modtrezorconfig.c
 def check_pin(pin: str, ext_salt: bytes | None) -> bool:
     """
     Check the given PIN with the given external salt.
     Returns True on success, False on failure.
     """
-
-
-# extmod/modtrezorconfig/modtrezorconfig.c
 def lock() -> None:
     """
     Locks the storage.
     """
-
-
-# extmod/modtrezorconfig/modtrezorconfig.c
 def is_unlocked() -> bool:
     """
     Returns True if storage is unlocked, False otherwise.
     """
-
-
-# extmod/modtrezorconfig/modtrezorconfig.c
 def has_pin() -> bool:
     """
     Returns True if storage has a configured PIN, False otherwise.
     """
-
-
-# extmod/modtrezorconfig/modtrezorconfig.c
 def get_pin_rem() -> int:
     """
     Returns the number of remaining PIN entry attempts.
     """
-
-
-# extmod/modtrezorconfig/modtrezorconfig.c
 def change_pin(
     oldpin: str,
     newpin: str,
@@ -65,23 +41,14 @@ def change_pin(
     """
     Change PIN and external salt. Returns True on success, False on failure.
     """
-
-
-# extmod/modtrezorconfig/modtrezorconfig.c
 def ensure_not_wipe_code(pin: str) -> None:
     """
     Wipes the device if the entered PIN is the wipe code.
     """
-
-
-# extmod/modtrezorconfig/modtrezorconfig.c
 def has_wipe_code() -> bool:
     """
     Returns True if storage has a configured wipe code, False otherwise.
     """
-
-
-# extmod/modtrezorconfig/modtrezorconfig.c
 def change_wipe_code(
     pin: str,
     ext_salt: bytes | None,
@@ -90,43 +57,28 @@ def change_wipe_code(
     """
     Change wipe code. Returns True on success, False on failure.
     """
-
-
-# extmod/modtrezorconfig/modtrezorconfig.c
 def get(app: int, key: int, public: bool = False) -> bytes | None:
     """
     Gets the value of the given key for the given app (or None if not set).
     Raises a RuntimeError if decryption or authentication of the stored
     value fails.
     """
-
-
-# extmod/modtrezorconfig/modtrezorconfig.c
 def set(app: int, key: int, value: bytes, public: bool = False) -> None:
     """
     Sets a value of given key for given app.
     """
-
-
-# extmod/modtrezorconfig/modtrezorconfig.c
 def delete(
     app: int, key: int, public: bool = False, writable_locked: bool = False
 ) -> bool:
     """
     Deletes the given key of the given app.
     """
-
-
-# extmod/modtrezorconfig/modtrezorconfig.c
 def set_counter(
     app: int, key: int, count: int, writable_locked: bool = False
 ) -> None:
     """
     Sets the given key of the given app as a counter with the given value.
     """
-
-
-# extmod/modtrezorconfig/modtrezorconfig.c
 def next_counter(
    app: int, key: int, writable_locked: bool = False,
 ) -> int:
@@ -134,9 +86,6 @@ def next_counter(
     Increments the counter stored under the given key of the given app and
     returns the new value.
     """
-
-
-# extmod/modtrezorconfig/modtrezorconfig.c
 def wipe() -> None:
     """
     Erases the whole config. Use with caution!

--- a/core/mocks/generated/trezorcrypto/__init__.pyi
+++ b/core/mocks/generated/trezorcrypto/__init__.pyi
@@ -1,17 +1,13 @@
 from typing import *
-
-
-# extmod/modtrezorcrypto/modtrezorcrypto-aes.h
 class aes:
-    """
-    AES context.
-    """
-    ECB: int
-    CBC: int
-    CFB: int
-    OFB: int
-    CTR: int
-
+        """
+        AES context.
+        """
+        ECB: int
+        CBC: int
+        CFB: int
+        OFB: int
+        CTR: int
     def __init__(
         self,
         mode: int,
@@ -21,50 +17,38 @@ class aes:
         """
         Initialize AES context.
         """
-
     def encrypt(self, data: bytes) -> bytes:
         """
         Encrypt data and update AES context.
         """
-
     def decrypt(self, data: bytes) -> bytes:
         """
         Decrypt data and update AES context.
         """
-
-
-# extmod/modtrezorcrypto/modtrezorcrypto-blake256.h
 class blake256:
-    """
-    Blake256 context.
-    """
-    block_size: int
-    digest_size: int
-
+        """
+        Blake256 context.
+        """
+        block_size: int
+        digest_size: int
     def __init__(self, __data: AnyStr | None = None) -> None:
         """
         Creates a hash context object.
         """
-
     def update(self, __data: AnyStr) -> None:
         """
         Update the hash context with hashed data.
         """
-
     def digest(self) -> bytes:
         """
         Returns the digest of hashed data.
         """
-
-
-# extmod/modtrezorcrypto/modtrezorcrypto-blake2b.h
 class blake2b:
-    """
-    Blake2b context.
-    """
-    block_size: int
-    digest_size: int
-
+        """
+        Blake2b context.
+        """
+        block_size: int
+        digest_size: int
     def __init__(
         self,
         data: bytes | None = None,
@@ -75,26 +59,20 @@ class blake2b:
         """
         Creates a hash context object.
         """
-
     def update(self, __data: AnyStr) -> None:
         """
         Update the hash context with hashed data.
         """
-
     def digest(self) -> bytes:
         """
         Returns the digest of hashed data.
         """
-
-
-# extmod/modtrezorcrypto/modtrezorcrypto-blake2s.h
 class blake2s:
-    """
-    Blake2s context.
-    """
-    block_size: int
-    digest_size: int
-
+        """
+        Blake2s context.
+        """
+        block_size: int
+        digest_size: int
     def __init__(
         self,
         data: bytes | None = None,
@@ -105,87 +83,67 @@ class blake2s:
         """
         Creates a hash context object.
         """
-
     def update(self, __data: AnyStr) -> None:
         """
         Update the hash context with hashed data.
         """
-
     def digest(self) -> bytes:
         """
         Returns the digest of hashed data.
         """
-
-
-# extmod/modtrezorcrypto/modtrezorcrypto-chacha20poly1305.h
 class chacha20poly1305:
-    """
-    ChaCha20Poly1305 context.
-    """
-
+        """
+        ChaCha20Poly1305 context.
+        """
     def __init__(self, key: bytes, nonce: bytes) -> None:
         """
         Initialize the ChaCha20 + Poly1305 context for encryption or decryption
         using a 32 byte key and 12 byte nonce as in the RFC 7539 style.
         """
-
     def encrypt(self, data: bytes) -> bytes:
         """
         Encrypt data (length of data must be divisible by 64 except for the
         final value).
         """
-
     def decrypt(self, data: bytes) -> bytes:
         """
         Decrypt data (length of data must be divisible by 64 except for the
         final value).
         """
-
     def auth(self, data: bytes) -> None:
         """
         Include authenticated data in the Poly1305 MAC using the RFC 7539
         style with 16 byte padding. This must only be called once and prior
         to encryption or decryption.
         """
-
     def finish(self) -> bytes:
         """
         Compute RFC 7539-style Poly1305 MAC.
         """
-
-
-# extmod/modtrezorcrypto/modtrezorcrypto-groestl.h
 class groestl512:
-    """
-    GROESTL512 context.
-    """
-    block_size: int
-    digest_size: int
-
+        """
+        GROESTL512 context.
+        """
+        block_size: int
+        digest_size: int
     def __init__(self, __data: AnyStr | None = None) -> None:
         """
         Creates a hash context object.
         """
-
     def update(self, __data: AnyStr) -> None:
         """
         Update the hash context with hashed data.
         """
-
     def digest(self) -> bytes:
         """
         Returns the digest of hashed data.
         """
-
-
-# extmod/modtrezorcrypto/modtrezorcrypto-hmac.h
 class hmac:
-    """
-    HMAC context.
-    """
-    SHA256: int
-    SHA512: int
-
+        """
+        HMAC context.
+        """
+        SHA256: int
+        SHA512: int
     def __init__(
         self,
         hashtype: int,
@@ -195,26 +153,20 @@ class hmac:
         """
         Create a HMAC context.
         """
-
     def update(self, message: bytes) -> None:
         """
         Update a HMAC context.
         """
-
     def digest(self) -> bytes:
         """
         Return the digest of processed data so far.
         """
-
-
-# extmod/modtrezorcrypto/modtrezorcrypto-pbkdf2.h
 class pbkdf2:
-    """
-    PBKDF2 context.
-    """
-    HMAC_SHA256: int
-    HMAC_SHA512: int
-
+        """
+        PBKDF2 context.
+        """
+        HMAC_SHA256: int
+        HMAC_SHA512: int
     def __init__(
         self,
         prf: int,
@@ -226,98 +178,74 @@ class pbkdf2:
         """
         Create a PBKDF2 context.
         """
-
     def update(self, iterations: int) -> None:
         """
         Update a PBKDF2 context.
         """
-
     def key(self) -> bytes:
         """
         Retrieve derived key.
         """
-
-
-# extmod/modtrezorcrypto/modtrezorcrypto-ripemd160.h
 class ripemd160:
-    """
-    RIPEMD160 context.
-    """
-    block_size: int
-    digest_size: int
-
+        """
+        RIPEMD160 context.
+        """
+        block_size: int
+        digest_size: int
     def __init__(self, __data: AnyStr | None = None) -> None:
         """
         Creates a hash context object.
         """
-
     def update(self, __data: AnyStr) -> None:
         """
         Update the hash context with hashed data.
         """
-
     def digest(self) -> bytes:
         """
         Returns the digest of hashed data.
         """
-
-
-# extmod/modtrezorcrypto/modtrezorcrypto-sha1.h
 class sha1:
-    """
-    SHA1 context.
-    """
-    block_size: int
-    digest_size: int
-
+        """
+        SHA1 context.
+        """
+        block_size: int
+        digest_size: int
     def __init__(self, __data: AnyStr | None = None) -> None:
         """
         Creates a hash context object.
         """
-
     def update(self, __data: AnyStr) -> None:
         """
         Update the hash context with hashed data.
         """
-
     def digest(self) -> bytes:
         """
         Returns the digest of hashed data.
         """
-
-
-# extmod/modtrezorcrypto/modtrezorcrypto-sha256.h
 class sha256:
-    """
-    SHA256 context.
-    """
-    block_size: int
-    digest_size: int
-
+        """
+        SHA256 context.
+        """
+        block_size: int
+        digest_size: int
     def __init__(self, __data: AnyStr | None = None) -> None:
         """
         Creates a hash context object.
         """
-
     def update(self, __data: AnyStr) -> None:
         """
         Update the hash context with hashed data.
         """
-
     def digest(self) -> bytes:
         """
         Returns the digest of hashed data.
         """
-
-
-# extmod/modtrezorcrypto/modtrezorcrypto-sha3-256.h
 class sha3_256:
-    """
-    SHA3_256 context.
-    """
-    block_size: int
-    digest_size: int
-
+        """
+        SHA3_256 context.
+        """
+        block_size: int
+        digest_size: int
     def __init__(
         self,
         data: bytes | None = None,
@@ -326,31 +254,24 @@ class sha3_256:
         """
         Creates a hash context object.
         """
-
     def update(self, __data: AnyStr) -> None:
         """
         Update the hash context with hashed data.
         """
-
     def digest(self) -> bytes:
         """
         Returns the digest of hashed data.
         """
-
     def copy(self) -> sha3_256:
         """
         Returns the copy of the digest object with the current state
         """
-
-
-# extmod/modtrezorcrypto/modtrezorcrypto-sha3-512.h
 class sha3_512:
-    """
-    SHA3_512 context.
-    """
-    block_size: int
-    digest_size: int
-
+        """
+        SHA3_512 context.
+        """
+        block_size: int
+        digest_size: int
     def __init__(
         self,
         data: bytes | None = None,
@@ -359,41 +280,32 @@ class sha3_512:
         """
         Creates a hash context object.
         """
-
     def update(self, __data: AnyStr) -> None:
         """
         Update the hash context with hashed data.
         """
-
     def digest(self) -> bytes:
         """
         Returns the digest of hashed data.
         """
-
     def copy(self) -> sha3_512:
         """
         Returns the copy of the digest object with the current state
         """
-
-
-# extmod/modtrezorcrypto/modtrezorcrypto-sha512.h
 class sha512:
-    """
-    SHA512 context.
-    """
-    block_size: int
-    digest_size: int
-
+        """
+        SHA512 context.
+        """
+        block_size: int
+        digest_size: int
     def __init__(self, __data: AnyStr | None = None) -> None:
         """
         Creates a hash context object.
         """
-
     def update(self, __data: AnyStr) -> None:
         """
         Update the hash context with hashed data.
         """
-
     def digest(self) -> bytes:
         """
         Returns the digest of hashed data.

--- a/core/mocks/generated/trezorcrypto/bech32.pyi
+++ b/core/mocks/generated/trezorcrypto/bech32.pyi
@@ -1,7 +1,4 @@
 from typing import *
-
-
-# extmod/modtrezorcrypto/modtrezorcrypto-bech32.h
 def decode(
     bech: str,
     max_bech_len: int = 90,

--- a/core/mocks/generated/trezorcrypto/bip32.pyi
+++ b/core/mocks/generated/trezorcrypto/bip32.pyi
@@ -1,12 +1,8 @@
 from typing import *
-
-
-# extmod/modtrezorcrypto/modtrezorcrypto-bip32.h
 class HDNode:
-    """
-    BIP0032 HD node structure.
-    """
-
+        """
+        BIP0032 HD node structure.
+        """
     def __init__(
         self,
         depth: int,
@@ -19,92 +15,73 @@ class HDNode:
     ) -> None:
         """
         """
-
     def derive(self, index: int, public: bool = False) -> None:
         """
         Derive a BIP0032 child node in place.
         """
-
     def derive_path(self, path: Sequence[int]) -> None:
         """
         Go through a list of indexes and iteratively derive a child node in
         place.
         """
-
     def serialize_public(self, version: int) -> str:
         """
         Serialize the public info from HD node to base58 string.
         """
-
     def clone(self) -> HDNode:
         """
         Returns a copy of the HD node.
         """
-
     def depth(self) -> int:
         """
         Returns a depth of the HD node.
         """
-
     def fingerprint(self) -> int:
         """
         Returns a fingerprint of the HD node (hash of the parent public key).
         """
-
     def child_num(self) -> int:
         """
         Returns a child index of the HD node.
         """
-
     def chain_code(self) -> bytes:
         """
         Returns a chain code of the HD node.
         """
-
     def private_key(self) -> bytes:
         """
         Returns a private key of the HD node.
         """
-
     def private_key_ext(self) -> bytes:
         """
         Returns a private key extension of the HD node.
         """
-
     def public_key(self) -> bytes:
         """
         Returns a public key of the HD node.
         """
-
     def address(self, version: int) -> str:
         """
         Compute a base58-encoded address string from the HD node.
         """
-
     def nem_address(self, network: int) -> str:
         """
         Compute a NEM address string from the HD node.
         """
-
     def nem_encrypt(
         self, transfer_public_key: bytes, iv: bytes, salt: bytes, payload: bytes
     ) -> bytes:
         """
         Encrypts payload using the transfer's public key
         """
-
     def ethereum_pubkeyhash(self) -> bytes:
         """
         Compute an Ethereum pubkeyhash (aka address) from the HD node.
         """
-
     def __del__(self) -> None:
         """
         Cleans up sensitive memory.
         """
-
-
-# extmod/modtrezorcrypto/modtrezorcrypto-bip32.h
 def from_seed(seed: bytes, curve_name: str) -> HDNode:
     """
     Construct a BIP0032 HD node from a BIP0039 seed value.

--- a/core/mocks/generated/trezorcrypto/bip340.pyi
+++ b/core/mocks/generated/trezorcrypto/bip340.pyi
@@ -1,21 +1,12 @@
 from typing import *
-
-
-# extmod/modtrezorcrypto/modtrezorcrypto-bip340.h
 def generate_secret() -> bytes:
     """
     Generate secret key.
     """
-
-
-# extmod/modtrezorcrypto/modtrezorcrypto-bip340.h
 def publickey(secret_key: bytes) -> bytes:
     """
     Computes public key from secret key.
     """
-
-
-# extmod/modtrezorcrypto/modtrezorcrypto-bip340.h
 def sign(
     secret_key: bytes,
     digest: bytes,
@@ -23,25 +14,16 @@ def sign(
     """
     Uses secret key to produce the signature of the digest.
     """
-
-
-# extmod/modtrezorcrypto/modtrezorcrypto-bip340.h
 def verify_publickey(public_key: bytes) -> bool:
     """
     Verifies whether the public key is valid.
     Returns True on success.
     """
-
-
-# extmod/modtrezorcrypto/modtrezorcrypto-bip340.h
 def verify(public_key: bytes, signature: bytes, digest: bytes) -> bool:
     """
     Uses public key to verify the signature of the digest.
     Returns True on success.
     """
-
-
-# extmod/modtrezorcrypto/modtrezorcrypto-bip340.h
 def tweak_public_key(
     public_key: bytes,
     root_hash: bytes | None = None,
@@ -49,9 +31,6 @@ def tweak_public_key(
     """
     Tweaks the public key with the specified root_hash.
     """
-
-
-# extmod/modtrezorcrypto/modtrezorcrypto-bip340.h
 def tweak_secret_key(
     secret_key: bytes,
     root_hash: bytes | None = None,

--- a/core/mocks/generated/trezorcrypto/bip39.pyi
+++ b/core/mocks/generated/trezorcrypto/bip39.pyi
@@ -1,28 +1,16 @@
 from typing import *
-
-
-# extmod/modtrezorcrypto/modtrezorcrypto-bip39.h
 def generate(strength: int) -> str:
     """
     Generate a mnemonic of given strength (128, 160, 192, 224 and 256 bits).
     """
-
-
-# extmod/modtrezorcrypto/modtrezorcrypto-bip39.h
 def from_data(data: bytes) -> str:
     """
     Generate a mnemonic from given data (of 16, 20, 24, 28 and 32 bytes).
     """
-
-
-# extmod/modtrezorcrypto/modtrezorcrypto-bip39.h
 def check(mnemonic: str) -> bool:
     """
     Check whether given mnemonic is valid.
     """
-
-
-# extmod/modtrezorcrypto/modtrezorcrypto-bip39.h
 def seed(
     mnemonic: str,
     passphrase: str,

--- a/core/mocks/generated/trezorcrypto/cardano.pyi
+++ b/core/mocks/generated/trezorcrypto/cardano.pyi
@@ -1,8 +1,5 @@
 from typing import *
 from trezorcrypto.bip32 import HDNode
-
-
-# extmod/modtrezorcrypto/modtrezorcrypto-cardano.h
 def derive_icarus(
     mnemonic: str,
     passphrase: str,
@@ -15,23 +12,14 @@ def derive_icarus(
     If `trezor_derivation` is True, the Icarus-Trezor variant is used (see
     CIP-3).
     """
-
-
-# extmod/modtrezorcrypto/modtrezorcrypto-cardano.h
 def from_secret(secret: bytes) -> HDNode:
     """
     Creates a Cardano HD node from a master secret.
     """
-
-
-# extmod/modtrezorcrypto/modtrezorcrypto-cardano.h
 def from_seed_slip23(seed: bytes) -> HDNode:
    """
    Creates a Cardano HD node from a seed via SLIP-23 derivation.
    """
-
-
-# extmod/modtrezorcrypto/modtrezorcrypto-cardano.h
 def from_seed_ledger(seed: bytes) -> HDNode:
     """
     Creates a Cardano HD node from a seed via Ledger derivation.

--- a/core/mocks/generated/trezorcrypto/crc.pyi
+++ b/core/mocks/generated/trezorcrypto/crc.pyi
@@ -1,7 +1,4 @@
 from typing import *
-
-
-# extmod/modtrezorcrypto/modtrezorcrypto-crc.h
 def crc32(data: bytes, crc: int = 0) -> int:
     """
     Computes a CRC32 checksum of `data`.

--- a/core/mocks/generated/trezorcrypto/curve25519.pyi
+++ b/core/mocks/generated/trezorcrypto/curve25519.pyi
@@ -1,21 +1,12 @@
 from typing import *
-
-
-# extmod/modtrezorcrypto/modtrezorcrypto-curve25519.h
 def generate_secret() -> bytes:
     """
     Generate secret key.
     """
-
-
-# extmod/modtrezorcrypto/modtrezorcrypto-curve25519.h
 def publickey(secret_key: bytes) -> bytes:
     """
     Computes public key from secret key.
     """
-
-
-# extmod/modtrezorcrypto/modtrezorcrypto-curve25519.h
 def multiply(secret_key: bytes, public_key: bytes) -> bytes:
     """
     Multiplies point defined by public_key with scalar defined by

--- a/core/mocks/generated/trezorcrypto/ed25519.pyi
+++ b/core/mocks/generated/trezorcrypto/ed25519.pyi
@@ -1,66 +1,39 @@
 from typing import *
-
-
-# extmod/modtrezorcrypto/modtrezorcrypto-ed25519.h
 def generate_secret() -> bytes:
     """
     Generate secret key.
     """
-
-
-# extmod/modtrezorcrypto/modtrezorcrypto-ed25519.h
 def publickey(secret_key: bytes) -> bytes:
     """
     Computes public key from secret key.
     """
-
-
-# extmod/modtrezorcrypto/modtrezorcrypto-ed25519.h
 def sign(secret_key: bytes, message: bytes, hasher: str = "") -> bytes:
     """
     Uses secret key to produce the signature of message.
     """
-
-
-# extmod/modtrezorcrypto/modtrezorcrypto-ed25519.h
 def sign_ext(
     secret_key: bytes, secret_extension: bytes, message: bytes
 ) -> bytes:
     """
     Uses secret key to produce the cardano signature of message.
     """
-
-
-# extmod/modtrezorcrypto/modtrezorcrypto-ed25519.h
 def verify(public_key: bytes, signature: bytes, message: bytes) -> bool:
     """
     Uses public key to verify the signature of the message.
     Returns True on success.
     """
-
-
-# extmod/modtrezorcrypto/modtrezorcrypto-ed25519.h
 def cosi_combine_publickeys(public_keys: list[bytes]) -> bytes:
     """
     Combines a list of public keys used in COSI cosigning scheme.
     """
-
-
-# extmod/modtrezorcrypto/modtrezorcrypto-ed25519.h
 def cosi_combine_signatures(R: bytes, signatures: list[bytes]) -> bytes:
     """
     Combines a list of signatures used in COSI cosigning scheme.
     """
-
-
-# extmod/modtrezorcrypto/modtrezorcrypto-ed25519.h
 def cosi_commit() -> tuple[bytes, bytes]:
     """
     Generate a nonce and commitment for the CoSi cosigning scheme.
     """
-
-
-# extmod/modtrezorcrypto/modtrezorcrypto-ed25519.h
 def cosi_sign(
     secret_key: bytes,
     message: bytes,

--- a/core/mocks/generated/trezorcrypto/monero.pyi
+++ b/core/mocks/generated/trezorcrypto/monero.pyi
@@ -1,269 +1,183 @@
 from typing import *
-
-
-# extmod/modtrezorcrypto/modtrezorcrypto-monero.h
 class Point:
-    """
-    EC point on ED25519
-    """
-    def __init__(self, x: Point | bytes | None = None):
         """
-        Constructor
+        EC point on ED25519
         """
 
-
-# extmod/modtrezorcrypto/modtrezorcrypto-monero.h
+        def __init__(self, x: Point | bytes | None = None):
+            """
+            Constructor
+            """
 class Scalar:
-    """
-    EC scalar on SC25519
-    """
-    def __init__(self, x: Scalar | bytes | int | None = None):
         """
-        Constructor
+        EC scalar on SC25519
         """
 
+        def __init__(self, x: Scalar | bytes | int | None = None):
+            """
+            Constructor
+            """
 
-# extmod/modtrezorcrypto/modtrezorcrypto-monero.h
+
 class Hasher:
-    """
-    XMR hasher
-    """
-    def __init__(self, x: bytes | None = None):
         """
-        Constructor
-        """
-    def update(self, buffer: bytes) -> None:
-        """
-        Update hasher
-        """
-    def digest(self) -> bytes:
-        """
-        Computes digest
-        """
-    def copy(self) -> Hasher:
-        """
-        Creates copy of the hasher, preserving the state
+        XMR hasher
         """
 
+        def __init__(self, x: bytes | None = None):
+            """
+            Constructor
+            """
 
-# extmod/modtrezorcrypto/modtrezorcrypto-monero.h
+        def update(self, buffer: bytes) -> None:
+            """
+            Update hasher
+            """
+
+        def digest(self) -> bytes:
+            """
+            Computes digest
+            """
+
+        def copy(self) -> Hasher:
+            """
+            Creates copy of the hasher, preserving the state
+            """
+
+
 def sc_copy(
     dst: Scalar | None, val: int | bytes | Scalar
 ) -> Scalar:
     """
     Initializes a scalar
     """
-
-
-# extmod/modtrezorcrypto/modtrezorcrypto-monero.h
 def sc_check(val: Scalar) -> None:
     """
     Throws exception if scalar is invalid
     """
-
-
-# extmod/modtrezorcrypto/modtrezorcrypto-monero.h
 def sc_iszero(val: Scalar) -> bool:
     """
     Returns False if the scalar is zero
     """
-
-
-# extmod/modtrezorcrypto/modtrezorcrypto-monero.h
 def sc_eq(a: Scalar, b: Scalar) -> int:
     """
     Compares scalars, returns 1 on the same value
     """
-
-
-# extmod/modtrezorcrypto/modtrezorcrypto-monero.h
 def sc_add_into(r: Scalar | None, a: Scalar, b: Scalar) -> Scalar:
     """
     Scalar addition
     """
-
-
-# extmod/modtrezorcrypto/modtrezorcrypto-monero.h
 def sc_sub_into(r: Scalar | None, a: Scalar, b: Scalar) -> Scalar:
     """
     Scalar subtraction
     """
-
-
-# extmod/modtrezorcrypto/modtrezorcrypto-monero.h
 def sc_mul_into(r: Scalar | None, a: Scalar, b: Scalar) -> Scalar:
     """
     Scalar multiplication
     """
-
-
-# extmod/modtrezorcrypto/modtrezorcrypto-monero.h
 def sc_mulsub_into(
     r: Scalar | None, a: Scalar, b: Scalar, c: Scalar
 ) -> Scalar:
     """
     c - a*b
     """
-
-
-# extmod/modtrezorcrypto/modtrezorcrypto-monero.h
 def sc_muladd_into(
     r: Scalar | None, a: Scalar, b: Scalar, c: Scalar
 ) -> Scalar:
     """
     c + a*b
     """
-
-
-# extmod/modtrezorcrypto/modtrezorcrypto-monero.h
 def sc_inv_into(r: Scalar | None, a: Scalar) -> Scalar:
     """
     Scalar modular inversion
     """
-
-
-# extmod/modtrezorcrypto/modtrezorcrypto-monero.h
 def encodeint_into(
     r: bytes | None, a: Scalar, offset: int | None = 0
 ) -> bytes:
     """
     Scalar compression
     """
-
-
-# extmod/modtrezorcrypto/modtrezorcrypto-monero.h
 def decodeint_into(
     r: Scalar | None, a: bytes, offset: int = 0
 ) -> Scalar:
     """
     Scalar decompression
     """
-
-
-# extmod/modtrezorcrypto/modtrezorcrypto-monero.h
 def decodeint_into_noreduce(
     r: Scalar | None, a: bytes, offset: int = 0
 ) -> Scalar:
     """
     Scalar decompression, raw, without modular reduction
     """
-
-
-# extmod/modtrezorcrypto/modtrezorcrypto-monero.h
 def identity_into(r: Point | None = None) -> Point:
     """
     Sets neutral point
     """
-
-
-# extmod/modtrezorcrypto/modtrezorcrypto-monero.h
 def xmr_H(r: Point | None = None) -> Point:
     """
     Sets H point
     """
-
-
-# extmod/modtrezorcrypto/modtrezorcrypto-monero.h
 def ge25519_check(r: Point) -> None:
     """
     Checks point, throws if not on curve
     """
-
-
-# extmod/modtrezorcrypto/modtrezorcrypto-monero.h
 def point_eq(a: Point, b: Point) -> bool:
     """
     Compares EC points
     """
-
-
-# extmod/modtrezorcrypto/modtrezorcrypto-monero.h
 def point_add_into(r: Point | None, a: Point, b: Point) -> Point:
     """
     Adds EC points
     """
-
-
-# extmod/modtrezorcrypto/modtrezorcrypto-monero.h
 def point_sub_into(r: Point | None, a: Point, b: Point) -> Point:
     """
     Subtracts EC points
     """
-
-
-# extmod/modtrezorcrypto/modtrezorcrypto-monero.h
 def ge25519_mul8(r: Point | None, p: Point) -> Point:
     """
     EC point * 8
     """
-
-
-# extmod/modtrezorcrypto/modtrezorcrypto-monero.h
 def ge25519_double_scalarmult_vartime_into(
     r: Point | None, p1: Point, s1: Scalar, s2: Scalar
 ) -> Point:
     """
     s1 * G + s2 * p1
     """
-
-
-# extmod/modtrezorcrypto/modtrezorcrypto-monero.h
 def scalarmult_base_into(
     r: Point | None, s: Scalar | int
 ) -> Point:
     """
     s * G
     """
-
-
-# extmod/modtrezorcrypto/modtrezorcrypto-monero.h
 def scalarmult_into(
     r: Point | None, p: Point, s: Scalar | int
 ) -> Point:
     """
     s * p
     """
-
-
-# extmod/modtrezorcrypto/modtrezorcrypto-monero.h
 def encodepoint_into(r: bytes | None, p: Point, offset: int = 0) -> bytes:
     """
     Point compression
     """
-
-
-# extmod/modtrezorcrypto/modtrezorcrypto-monero.h
 def decodepoint_into(
     r: Point | None, buff: bytes, offset: int = 0
 ) -> Point:
     """
     Point decompression
     """
-
-
-# extmod/modtrezorcrypto/modtrezorcrypto-monero.h
 def xmr_base58_addr_encode_check(tag: int, buff: bytes) -> str:
     """
     Monero block base 58 encoding
     """
-
-
-# extmod/modtrezorcrypto/modtrezorcrypto-monero.h
 def xmr_base58_addr_decode_check(buff: bytes) -> tuple[bytes, int]:
     """
     Monero block base 58 decoding, returning (decoded, tag) or raising on
     error.
     """
-
-
-# extmod/modtrezorcrypto/modtrezorcrypto-monero.h
 def random_scalar(r: Scalar | None = None) -> Scalar:
     """
     Generates a random scalar
     """
-
-
-# extmod/modtrezorcrypto/modtrezorcrypto-monero.h
 def fast_hash_into(
    r: bytes | None,
    buff: bytes,
@@ -273,9 +187,6 @@ def fast_hash_into(
     """
     XMR fast hash
     """
-
-
-# extmod/modtrezorcrypto/modtrezorcrypto-monero.h
 def hash_to_point_into(
     r: Point | None,
     buff: bytes,
@@ -285,9 +196,6 @@ def hash_to_point_into(
     """
     XMR hashing to EC point
     """
-
-
-# extmod/modtrezorcrypto/modtrezorcrypto-monero.h
 def hash_to_scalar_into(
    r: Scalar | None,
    buff: bytes,
@@ -297,79 +205,52 @@ def hash_to_scalar_into(
     """
     XMR hashing to EC scalar
     """
-
-
-# extmod/modtrezorcrypto/modtrezorcrypto-monero.h
 def xmr_derivation_to_scalar(
     r: Scalar | None, p: Point, output_index: int
 ) -> Scalar:
     """
     H_s(derivation || varint(output_index))
     """
-
-
-# extmod/modtrezorcrypto/modtrezorcrypto-monero.h
 def xmr_generate_key_derivation(
     r: Point | None, A: Point, b: Scalar
 ) -> Point:
     """
     8*(key2*key1)
     """
-
-
-# extmod/modtrezorcrypto/modtrezorcrypto-monero.h
 def xmr_derive_private_key(
     r: Scalar | None, deriv: Point, idx: int, base: Scalar
 ) -> Scalar:
     """
     base + H_s(derivation || varint(output_index))
     """
-
-
-# extmod/modtrezorcrypto/modtrezorcrypto-monero.h
 def xmr_derive_public_key(
     r: Point | None, deriv: Point, idx: int, base: Point
 ) -> Point:
     """
     H_s(derivation || varint(output_index))G + base
     """
-
-
-# extmod/modtrezorcrypto/modtrezorcrypto-monero.h
 def add_keys2_into(
     r: Point | None, a: Scalar, b: Scalar, B: Point
 ) -> Point:
     """
     aG + bB, G is basepoint
     """
-
-
-# extmod/modtrezorcrypto/modtrezorcrypto-monero.h
 def add_keys3_into(
     r: Point | None, a: Scalar, A: Point, b: Scalar, B: Point
 ) -> Point:
     """
     aA + bB
     """
-
-
-# extmod/modtrezorcrypto/modtrezorcrypto-monero.h
 def xmr_get_subaddress_secret_key(
     r: Scalar | None, major: int, minor: int, m: Scalar
 ) -> Scalar:
     """
     Hs(SubAddr || a || index_major || index_minor)
     """
-
-
-# extmod/modtrezorcrypto/modtrezorcrypto-monero.h
 def gen_commitment_into(r: Point | None, a: Scalar, amount: int) -> Point:
     """
     aG + amount * H
     """
-
-
-# extmod/modtrezorcrypto/modtrezorcrypto-monero.h
 def ct_equals(a: bytes, b: bytes) -> bool:
     """
     Constant time buffer comparison

--- a/core/mocks/generated/trezorcrypto/nem.pyi
+++ b/core/mocks/generated/trezorcrypto/nem.pyi
@@ -1,14 +1,8 @@
 from typing import *
-
-
-# extmod/modtrezorcrypto/modtrezorcrypto-nem.h
 def validate_address(address: str, network: int) -> bool:
     """
     Validate a NEM address
     """
-
-
-# extmod/modtrezorcrypto/modtrezorcrypto-nem.h
 def compute_address(public_key: bytes, network: int) -> str:
     """
     Compute a NEM address from a public key

--- a/core/mocks/generated/trezorcrypto/nist256p1.pyi
+++ b/core/mocks/generated/trezorcrypto/nist256p1.pyi
@@ -1,46 +1,28 @@
 from typing import *
-
-
-# extmod/modtrezorcrypto/modtrezorcrypto-nist256p1.h
 def generate_secret() -> bytes:
     """
     Generate secret key.
     """
-
-
-# extmod/modtrezorcrypto/modtrezorcrypto-nist256p1.h
 def publickey(secret_key: bytes, compressed: bool = True) -> bytes:
     """
     Computes public key from secret key.
     """
-
-
-# extmod/modtrezorcrypto/modtrezorcrypto-nist256p1.h
 def sign(
     secret_key: bytes, digest: bytes, compressed: bool = True
 ) -> bytes:
     """
     Uses secret key to produce the signature of the digest.
     """
-
-
-# extmod/modtrezorcrypto/modtrezorcrypto-nist256p1.h
 def verify(public_key: bytes, signature: bytes, digest: bytes) -> bool:
     """
     Uses public key to verify the signature of the digest.
     Returns True on success.
     """
-
-
-# extmod/modtrezorcrypto/modtrezorcrypto-nist256p1.h
 def verify_recover(signature: bytes, digest: bytes) -> bytes:
     """
     Uses signature of the digest to verify the digest and recover the public
     key. Returns public key on success, None if the signature is invalid.
     """
-
-
-# extmod/modtrezorcrypto/modtrezorcrypto-nist256p1.h
 def multiply(secret_key: bytes, public_key: bytes) -> bytes:
     """
     Multiplies point defined by public_key with scalar defined by

--- a/core/mocks/generated/trezorcrypto/random.pyi
+++ b/core/mocks/generated/trezorcrypto/random.pyi
@@ -1,29 +1,17 @@
 from typing import *
-
-
-# extmod/modtrezorcrypto/modtrezorcrypto-random.h
 def uniform(n: int) -> int:
     """
     Compute uniform random number from interval 0 ... n - 1.
     """
 import builtins
-
-
-# extmod/modtrezorcrypto/modtrezorcrypto-random.h
 def bytes(len: int) -> builtins.bytes:
     """
     Generate random bytes sequence of length len.
     """
-
-
-# extmod/modtrezorcrypto/modtrezorcrypto-random.h
 def shuffle(data: list) -> None:
     """
     Shuffles items of given list (in-place).
     """
-
-
-# extmod/modtrezorcrypto/modtrezorcrypto-random.h
 def reseed(value: int) -> None:
     """
     Re-seed the RNG with given value.

--- a/core/mocks/generated/trezorcrypto/secp256k1.pyi
+++ b/core/mocks/generated/trezorcrypto/secp256k1.pyi
@@ -1,23 +1,14 @@
 from typing import *
-
-
-# extmod/modtrezorcrypto/modtrezorcrypto-secp256k1.h
 def generate_secret() -> bytes:
     """
     Generate secret key.
     """
-
-
-# extmod/modtrezorcrypto/modtrezorcrypto-secp256k1.h
 def publickey(secret_key: bytes, compressed: bool = True) -> bytes:
     """
     Computes public key from secret key.
     """
 CANONICAL_SIG_ETHEREUM: int = 1
 CANONICAL_SIG_EOS: int = 2
-
-
-# extmod/modtrezorcrypto/modtrezorcrypto-secp256k1.h
 def sign(
     secret_key: bytes,
     digest: bytes,
@@ -27,25 +18,16 @@ def sign(
     """
     Uses secret key to produce the signature of the digest.
     """
-
-
-# extmod/modtrezorcrypto/modtrezorcrypto-secp256k1.h
 def verify(public_key: bytes, signature: bytes, digest: bytes) -> bool:
     """
     Uses public key to verify the signature of the digest.
     Returns True on success.
     """
-
-
-# extmod/modtrezorcrypto/modtrezorcrypto-secp256k1.h
 def verify_recover(signature: bytes, digest: bytes) -> bytes:
     """
     Uses signature of the digest to verify the digest and recover the public
     key. Returns public key on success, None if the signature is invalid.
     """
-
-
-# extmod/modtrezorcrypto/modtrezorcrypto-secp256k1.h
 def multiply(secret_key: bytes, public_key: bytes) -> bytes:
     """
     Multiplies point defined by public_key with scalar defined by

--- a/core/mocks/generated/trezorcrypto/shamir.pyi
+++ b/core/mocks/generated/trezorcrypto/shamir.pyi
@@ -1,7 +1,4 @@
 from typing import *
-
-
-# extmod/modtrezorcrypto/modtrezorcrypto-shamir.h
 def interpolate(shares: list[tuple[int, bytes]], x: int) -> bytes:
     """
     Returns f(x) given the Shamir shares (x_1, f(x_1)), ... , (x_k, f(x_k)).

--- a/core/mocks/generated/trezorcrypto/slip39.pyi
+++ b/core/mocks/generated/trezorcrypto/slip39.pyi
@@ -1,15 +1,9 @@
 from typing import *
-
-
-# extmod/modtrezorcrypto/modtrezorcrypto-slip39.h
 def word_index(word: str) -> int:
     """
     Finds index of given word.
     Raises ValueError if not found.
     """
-
-
-# extmod/modtrezorcrypto/modtrezorcrypto-slip39.h
 def get_word(index: int) -> str:
     """
     Returns word on position 'index'.

--- a/core/mocks/generated/trezorio/__init__.pyi
+++ b/core/mocks/generated/trezorio/__init__.pyi
@@ -1,42 +1,30 @@
 from typing import *
-
-
-# extmod/modtrezorio/modtrezorio-flash.h
 class FlashOTP:
-    """
-    """
-
+        """
+        """
     def __init__(self) -> None:
         """
         """
-
     def write(self, block: int, offset: int, data: bytes) -> None:
         """
         Writes data to OTP flash
         """
-
     def read(self, block: int, offset: int, data: bytearray) -> None:
         """
         Reads data from OTP flash
         """
-
     def lock(self, block: int) -> None:
         """
         Lock OTP flash block
         """
-
     def is_locked(self, block: int) -> bool:
         """
         Is OTP flash block locked?
         """
-
-
-# extmod/modtrezorio/modtrezorio-hid.h
 class HID:
-    """
-    USB HID interface configuration.
-    """
-
+        """
+        USB HID interface configuration.
+        """
     def __init__(
         self,
         iface_num: int,
@@ -51,59 +39,46 @@ class HID:
     ) -> None:
         """
         """
-
     def iface_num(self) -> int:
         """
         Returns the configured number of this interface.
         """
-
     def write(self, msg: bytes) -> int:
         """
         Sends message using USB HID (device) or UDP (emulator).
         """
-
     def write_blocking(self, msg: bytes, timeout_ms: int) -> int:
         """
         Sends message using USB HID (device) or UDP (emulator).
         """
-
-
-# extmod/modtrezorio/modtrezorio-poll.h
 def poll(ifaces: Iterable[int], list_ref: list, timeout_ms: int) -> bool:
     """
     Wait until one of `ifaces` is ready to read or write (using masks
     `list_ref`:
+
     `list_ref[0]` - the interface number, including the mask
     `list_ref[1]` - for touch event, tuple of:
                     (event_type, x_position, y_position)
                   - for button event (T1), tuple of:
                     (event type, button number)
                   - for USB read event, received bytes
+
     If timeout occurs, False is returned, True otherwise.
     """
-
-
-# extmod/modtrezorio/modtrezorio-sbu.h
 class SBU:
-    """
-    """
-
+        """
+        """
     def __init__(self) -> None:
         """
         """
-
     def set(self, sbu1: bool, sbu2: bool) -> None:
         """
         Sets SBU wires to sbu1 and sbu2 values respectively
         """
-
-
-# extmod/modtrezorio/modtrezorio-usb.h
 class USB:
-    """
-    USB device configuration.
-    """
-
+        """
+        USB device configuration.
+        """
     def __init__(
         self,
         vendor_id: int,
@@ -120,29 +95,22 @@ class USB:
     ) -> None:
         """
         """
-
     def add(self, iface: HID | VCP | WebUSB) -> None:
         """
         Registers passed interface into the USB stack.
         """
-
     def open(self, serial_number: str) -> None:
         """
         Initializes the USB stack.
         """
-
     def close(self) -> None:
         """
         Cleans up the USB stack.
         """
-
-
-# extmod/modtrezorio/modtrezorio-vcp.h
 class VCP:
-    """
-    USB VCP interface configuration.
-    """
-
+        """
+        USB VCP interface configuration.
+        """
     def __init__(
         self,
         iface_num: int,
@@ -154,19 +122,14 @@ class VCP:
     ) -> None:
         """
         """
-
     def iface_num(self) -> int:
         """
         Returns the configured number of this interface.
         """
-
-
-# extmod/modtrezorio/modtrezorio-webusb.h
 class WebUSB:
-    """
-    USB WebUSB interface configuration.
-    """
-
+        """
+        USB WebUSB interface configuration.
+        """
     def __init__(
         self,
         iface_num: int,
@@ -180,12 +143,10 @@ class WebUSB:
     ) -> None:
         """
         """
-
     def iface_num(self) -> int:
         """
         Returns the configured number of this interface.
         """
-
     def write(self, msg: bytes) -> int:
         """
         Sends message using USB WebUSB (device) or UDP (emulator).
@@ -193,6 +154,7 @@ class WebUSB:
 from . import fatfs, sdcard
 POLL_READ: int  # wait until interface is readable and return read data
 POLL_WRITE: int  # wait until interface is writable
+
 TOUCH: int  # interface id of the touch events
 TOUCH_START: int  # event id of touch start event
 TOUCH_MOVE: int  # event id of touch move event

--- a/core/mocks/generated/trezorio/fatfs.pyi
+++ b/core/mocks/generated/trezorio/fatfs.pyi
@@ -21,35 +21,21 @@ FR_TOO_MANY_OPEN_FILES: int  # (18) Number of open files > FF_FS_LOCK
 FR_INVALID_PARAMETER: int    # (19) Given parameter is invalid
 # nonstandard value:
 FR_NO_SPACE: int             # (64) No space left on device
-
-
-# extmod/modtrezorio/modtrezorio-fatfs.h
 class FatFSError(OSError):
-    pass
-
-
-# extmod/modtrezorio/modtrezorio-fatfs.h
+        pass
 class NotMounted(FatFSError):
-    pass
-
-
-# extmod/modtrezorio/modtrezorio-fatfs.h
+        pass
 class NoFilesystem(FatFSError):
-    pass
-
-
-# extmod/modtrezorio/modtrezorio-fatfs.h
+        pass
 class FatFSFile:
-    """
-    Class encapsulating file
-    """
-
+        """
+        Class encapsulating file
+        """
     def __enter__(self) -> FatFSFile:
         """
         Return an open file object
         """
     from types import TracebackType
-
     def __exit__(
         self, type: type[BaseException] | None,
         value: BaseException | None,
@@ -58,121 +44,78 @@ class FatFSFile:
         """
         Close an open file object
         """
-
     def close(self) -> None:
         """
         Close an open file object
         """
-
     def read(self, data: bytearray) -> int:
         """
         Read data from the file
         """
-
     def write(self, data: bytes | bytearray) -> int:
         """
         Write data to the file
         """
-
     def seek(self, offset: int) -> None:
         """
         Move file pointer of the file object
         """
-
     def truncate(self) -> None:
         """
         Truncate the file
         """
-
     def sync(self) -> None:
         """
         Flush cached data of the writing file
         """
-
-
-# extmod/modtrezorio/modtrezorio-fatfs.h
 class FatFSDir(Iterator[tuple[int, str, str]]):
-    """
-    Class encapsulating directory
-    """
-
+        """
+        Class encapsulating directory
+        """
     def __next__(self) -> tuple[int, str, str]:
         """
         Read an entry in the directory
         """
-
-
-# extmod/modtrezorio/modtrezorio-fatfs.h
 def open(path: str, flags: str) -> FatFSFile:
     """
     Open or create a file
     """
-
-
-# extmod/modtrezorio/modtrezorio-fatfs.h
 def listdir(path: str) -> FatFSDir:
     """
     List a directory (return generator)
     """
-
-
-# extmod/modtrezorio/modtrezorio-fatfs.h
 def mkdir(path: str, exist_ok: bool=False) -> None:
     """
     Create a sub directory
     """
-
-
-# extmod/modtrezorio/modtrezorio-fatfs.h
 def unlink(path: str) -> None:
     """
     Delete an existing file or directory
     """
-
-
-# extmod/modtrezorio/modtrezorio-fatfs.h
 def stat(path: str) -> tuple[int, str, str]:
     """
     Get file status
     """
-
-
-# extmod/modtrezorio/modtrezorio-fatfs.h
 def rename(oldpath: str, newpath: str) -> None:
     """
     Rename/Move a file or directory
     """
-
-
-# extmod/modtrezorio/modtrezorio-fatfs.h
 def mount() -> None:
     """
     Mount the SD card filesystem.
     """
-
-
-# extmod/modtrezorio/modtrezorio-fatfs.h
 def unmount() -> None:
     """
     Unmount the SD card filesystem.
     """
-
-
-# extmod/modtrezorio/modtrezorio-fatfs.h
 def is_mounted() -> bool:
    """
    Check if the filesystem is mounted.
    """
-
-
-# extmod/modtrezorio/modtrezorio-fatfs.h
 def mkfs() -> None:
     """
     Create a FAT volume on the SD card,
     """
-
-
-# extmod/modtrezorio/modtrezorio-fatfs.h
 def setlabel(label: str) -> None:
     """
     Set volume label

--- a/core/mocks/generated/trezorio/sdcard.pyi
+++ b/core/mocks/generated/trezorio/sdcard.pyi
@@ -1,47 +1,29 @@
 from typing import *
 BLOCK_SIZE: int  # size of SD card block
-
-
-# extmod/modtrezorio/modtrezorio-sdcard.h
 def is_present() -> bool:
     """
     Returns True if SD card is detected, False otherwise.
     """
-
-
-# extmod/modtrezorio/modtrezorio-sdcard.h
 def power_on() -> None:
     """
     Power on the SD card interface.
     Raises OSError if the SD card cannot be powered on, e.g., when there
     is no SD card inserted.
     """
-
-
-# extmod/modtrezorio/modtrezorio-sdcard.h
 def power_off() -> None:
     """
     Power off the SD card interface.
     """
-
-
-# extmod/modtrezorio/modtrezorio-sdcard.h
 def capacity() -> int:
     """
     Returns capacity of the SD card in bytes, or zero if not present.
     """
-
-
-# extmod/modtrezorio/modtrezorio-sdcard.h
 def read(block_num: int, buf: bytearray) -> None:
     """
     Reads blocks starting with block_num from the SD card into buf.
     Number of bytes read is length of buf rounded down to multiply of
     SDCARD_BLOCK_SIZE. Returns True if in case of success, False otherwise.
     """
-
-
-# extmod/modtrezorio/modtrezorio-sdcard.h
 def write(block_num: int, buf: bytes) -> None:
     """
     Writes blocks starting with block_num from buf to the SD card.

--- a/core/mocks/generated/trezorui.pyi
+++ b/core/mocks/generated/trezorui.pyi
@@ -1,39 +1,33 @@
 from typing import *
-
-
-# extmod/modtrezorui/modtrezorui-display.h
 class Display:
-    """
-    Provide access to device display.
-    """
-    WIDTH: int  # display width in pixels
-    HEIGHT: int  # display height in pixels
-    FONT_MONO: int  # id of monospace font
-    FONT_NORMAL: int  # id of normal-width font
-    FONT_BOLD: int  # id of bold-width font
-    FONT_DEMIBOLD: int  # id of demibold font
+        """
+        Provide access to device display.
+        """
+
+        WIDTH: int  # display width in pixels
+        HEIGHT: int  # display height in pixels
+        FONT_MONO: int  # id of monospace font
+        FONT_NORMAL: int  # id of normal-width font
+        FONT_BOLD: int  # id of bold-width font
+        FONT_DEMIBOLD: int  # id of demibold font
 
     def __init__(self) -> None:
         """
         Initialize the display.
         """
-
     def clear(self) -> None:
         """
         Clear display with black color.
         """
-
     def refresh(self) -> None:
         """
         Refresh display (update screen).
         """
-
     def bar(self, x: int, y: int, w: int, h: int, color: int) -> None:
         """
         Renders a bar at position (x,y = upper left corner) with width w and
         height h of color color.
         """
-
     def orientation(self, degrees: int | None = None) -> int:
         """
         Sets display orientation to 0, 90, 180 or 270 degrees.
@@ -41,18 +35,15 @@ class Display:
         Call without the degrees parameter to just perform the read of the
         value.
         """
-
     def backlight(self, val: int | None = None) -> int:
         """
         Sets backlight intensity to the value specified in val.
         Call without the val parameter to just perform the read of the value.
         """
-
     def save(self, prefix: str) -> None:
         """
         Saves current display contents to PNG file with given prefix.
         """
-
     def clear_save(self) -> None:
         """
         Clears buffers in display saving.

--- a/core/mocks/generated/trezorui2.pyi
+++ b/core/mocks/generated/trezorui2.pyi
@@ -1,122 +1,4 @@
 from typing import *
-CONFIRMED: object
-CANCELLED: object
-INFO: object
-
-
-# rust/src/ui/model_tr/layout.rs
-def disable_animation(disable: bool) -> None:
-    """Disable animations, debug builds only."""
-
-
-# rust/src/ui/model_tr/layout.rs
-def toif_info(data: bytes) -> tuple[int, int, bool]:
-    """Get TOIF image dimensions and format (width: int, height: int, is_grayscale: bool)."""
-
-
-# rust/src/ui/model_tr/layout.rs
-def confirm_action(
-    *,
-    title: str,
-    action: str | None,
-    description: str | None,
-    verb: str = "CONFIRM",
-    verb_cancel: str | None = None,
-    hold: bool = False,
-    hold_danger: bool = False,  # unused on TR
-    reverse: bool = False,
-) -> object:
-    """Confirm action."""
-
-
-# rust/src/ui/model_tr/layout.rs
-def confirm_blob(
-    *,
-    title: str,
-    data: str | bytes,
-    description: str | None,
-    extra: str | None,
-    verb: str = "CONFIRM",
-    verb_cancel: str | None = None,
-    hold: bool = False,
-) -> object:
-    """Confirm byte sequence data."""
-
-
-# rust/src/ui/model_tr/layout.rs
-def confirm_address(
-    *,
-    title: str,
-    data: str,
-    description: str | None,  # unused on TR
-    extra: str | None,  # unused on TR
-) -> object:
-    """Confirm address."""
-
-
-# rust/src/ui/model_tr/layout.rs
-def confirm_properties(
-    *,
-    title: str,
-    items: list[tuple[str | None, str | bytes | None, bool]],
-    hold: bool = False,
-) -> object:
-    """Confirm list of key-value pairs. The third component in the tuple should be True if
-    the value is to be rendered as binary with monospace font, False otherwise.
-    This only concerns the text style, you need to decode the value to UTF-8 in python."""
-
-
-# rust/src/ui/model_tr/layout.rs
-def confirm_reset_device(
-    *,
-    title: str,
-    button: str,
-) -> object:
-    """Confirm TOS before device setup."""
-
-
-# rust/src/ui/model_tr/layout.rs
-def show_address_details(
-    *,
-    address: str,
-    case_sensitive: bool,
-    account: str | None,
-    path: str | None,
-    xpubs: list[tuple[str, str]],
-) -> object:
-    """Show address details - QR code, account, path, cosigner xpubs."""
-
-
-# rust/src/ui/model_tr/layout.rs
-def confirm_value(
-    *,
-    title: str,
-    description: str,
-    value: str,
-    verb: str | None = None,
-    hold: bool = False,
-) -> object:
-    """Confirm value."""
-
-
-# rust/src/ui/model_tr/layout.rs
-def confirm_joint_total(
-    *,
-    spending_amount: str,
-    total_amount: str,
-) -> object:
-    """Confirm total if there are external inputs."""
-
-
-# rust/src/ui/model_tr/layout.rs
-def confirm_modify_output(
-    *,
-    address: str,
-    sign: int,
-    amount_change: str,
-    amount_new: str,
-) -> object:
-    """Decrease or increase amount for given address."""
 
 
 # rust/src/ui/model_tr/layout.rs
@@ -368,24 +250,24 @@ def show_lockscreen(
 def draw_welcome_screen() -> None:
     """Show logo icon with the model name at the bottom and return."""
 CONFIRMED: object
-CANCELLED: object
-INFO: object
 
+# rust/src/ui/model_tt/layout.rs
+CANCELLED: object
+
+# rust/src/ui/model_tt/layout.rs
+INFO: object
 
 # rust/src/ui/model_tt/layout.rs
 def disable_animation(disable: bool) -> None:
     """Disable animations, debug builds only."""
 
-
 # rust/src/ui/model_tt/layout.rs
 def jpeg_info(data: bytes) -> tuple[int, int, int]:
     """Get JPEG image dimensions (width: int, height: int, mcu_height: int)."""
 
-
 # rust/src/ui/model_tt/layout.rs
 def jpeg_test(data: bytes) -> bool:
     """Test JPEG image."""
-
 
 # rust/src/ui/model_tt/layout.rs
 def confirm_action(
@@ -401,7 +283,6 @@ def confirm_action(
 ) -> object:
     """Confirm action."""
 
-
 # rust/src/ui/model_tt/layout.rs
 def confirm_emphasized(
     *,
@@ -412,7 +293,6 @@ def confirm_emphasized(
     """Confirm formatted text that has been pre-split in python. For tuples
     the first component is a bool indicating whether this part is emphasized."""
 
-
 # rust/src/ui/model_tt/layout.rs
 def confirm_homescreen(
     *,
@@ -420,7 +300,6 @@ def confirm_homescreen(
     image: bytes,
 ) -> object:
     """Confirm homescreen."""
-
 
 # rust/src/ui/model_tt/layout.rs
 def confirm_blob(
@@ -435,7 +314,6 @@ def confirm_blob(
 ) -> object:
     """Confirm byte sequence data."""
 
-
 # rust/src/ui/model_tt/layout.rs
 def confirm_address(
     *,
@@ -447,7 +325,6 @@ def confirm_address(
     """Confirm address. Similar to `confirm_blob` but has corner info button
     and allows left swipe which does the same thing as the button."""
 
-
 # rust/src/ui/model_tt/layout.rs
 def confirm_properties(
     *,
@@ -458,7 +335,6 @@ def confirm_properties(
     """Confirm list of key-value pairs. The third component in the tuple should be True if
     the value is to be rendered as binary with monospace font, False otherwise."""
 
-
 # rust/src/ui/model_tt/layout.rs
 def confirm_reset_device(
     *,
@@ -466,7 +342,6 @@ def confirm_reset_device(
     button: str,
 ) -> object:
     """Confirm TOS before device setup."""
-
 
 # rust/src/ui/model_tt/layout.rs
 def show_address_details(
@@ -479,7 +354,6 @@ def show_address_details(
 ) -> object:
     """Show address details - QR code, account, path, cosigner xpubs."""
 
-
 # rust/src/ui/model_tt/layout.rs
 def show_spending_details(
     *,
@@ -489,7 +363,6 @@ def show_spending_details(
     fee_rate_title: str = "Fee rate:",
 ) -> object:
     """Show metadata when for outgoing transaction."""
-
 
 # rust/src/ui/model_tt/layout.rs
 def confirm_value(
@@ -505,7 +378,6 @@ def confirm_value(
 ) -> object:
     """Confirm value. Merge of confirm_total and confirm_output."""
 
-
 # rust/src/ui/model_tt/layout.rs
 def confirm_total(
     *,
@@ -514,7 +386,6 @@ def confirm_total(
     info_button: bool = False,
 ) -> object:
     """Transaction summary. Always hold to confirm."""
-
 
 # rust/src/ui/model_tt/layout.rs
 def confirm_modify_output(
@@ -525,7 +396,6 @@ def confirm_modify_output(
     amount_new: str,
 ) -> object:
     """Decrease or increase amount for given address."""
-
 
 # rust/src/ui/model_tt/layout.rs
 def confirm_modify_fee(
@@ -538,7 +408,6 @@ def confirm_modify_fee(
 ) -> object:
     """Decrease or increase transaction fee."""
 
-
 # rust/src/ui/model_tt/layout.rs
 def confirm_fido(
     *,
@@ -548,9 +417,9 @@ def confirm_fido(
     accounts: list[str | None],
 ) -> int | object:
     """FIDO confirmation.
+
     Returns page index in case of confirmation and CANCELLED otherwise.
     """
-
 
 # rust/src/ui/model_tt/layout.rs
 def show_error(
@@ -563,7 +432,6 @@ def show_error(
 ) -> object:
     """Error modal. No buttons shown when `button` is empty string."""
 
-
 # rust/src/ui/model_tt/layout.rs
 def show_warning(
     *,
@@ -574,7 +442,6 @@ def show_warning(
     time_ms: int = 0,
 ) -> object:
     """Warning modal. No buttons shown when `button` is empty string."""
-
 
 # rust/src/ui/model_tt/layout.rs
 def show_success(
@@ -587,7 +454,6 @@ def show_success(
 ) -> object:
     """Success modal. No buttons shown when `button` is empty string."""
 
-
 # rust/src/ui/model_tt/layout.rs
 def show_info(
     *,
@@ -599,11 +465,9 @@ def show_info(
 ) -> object:
     """Info modal. No buttons shown when `button` is empty string."""
 
-
 # rust/src/ui/model_tt/layout.rs
 def show_mismatch() -> object:
     """Warning modal, receiving address mismatch."""
-
 
 # rust/src/ui/model_tt/layout.rs
 def show_simple(
@@ -613,7 +477,6 @@ def show_simple(
     button: str = "",
 ) -> object:
     """Simple dialog with text and one button."""
-
 
 # rust/src/ui/model_tt/layout.rs
 def confirm_with_info(
@@ -626,7 +489,6 @@ def confirm_with_info(
     """Confirm given items but with third button. Always single page
     without scrolling."""
 
-
 # rust/src/ui/model_tt/layout.rs
 def confirm_more(
     *,
@@ -637,7 +499,6 @@ def confirm_more(
     """Confirm long content with the possibility to go back from any page.
     Meant to be used with confirm_with_info."""
 
-
 # rust/src/ui/model_tt/layout.rs
 def confirm_coinjoin(
     *,
@@ -645,7 +506,6 @@ def confirm_coinjoin(
     max_feerate: str,
 ) -> object:
     """Confirm coinjoin authorization."""
-
 
 # rust/src/ui/model_tt/layout.rs
 def request_pin(
@@ -657,7 +517,6 @@ def request_pin(
 ) -> str | object:
     """Request pin on device."""
 
-
 # rust/src/ui/model_tt/layout.rs
 def request_passphrase(
     *,
@@ -666,7 +525,6 @@ def request_passphrase(
 ) -> str | object:
     """Passphrase input keyboard."""
 
-
 # rust/src/ui/model_tt/layout.rs
 def request_bip39(
     *,
@@ -674,14 +532,12 @@ def request_bip39(
 ) -> str:
     """BIP39 word input keyboard."""
 
-
 # rust/src/ui/model_tt/layout.rs
 def request_slip39(
     *,
     prompt: str,
 ) -> str:
     """SLIP39 word input keyboard."""
-
 
 # rust/src/ui/model_tt/layout.rs
 def select_word(
@@ -693,7 +549,6 @@ def select_word(
     """Select mnemonic word from three possibilities - seed check after backup. The
    iterable must be of exact size. Returns index in range `0..3`."""
 
-
 # rust/src/ui/model_tt/layout.rs
 def show_share_words(
     *,
@@ -701,7 +556,6 @@ def show_share_words(
     pages: Iterable[str],
 ) -> object:
     """Show mnemonic for backup. Expects the words pre-divided into individual pages."""
-
 
 # rust/src/ui/model_tt/layout.rs
 def request_number(
@@ -714,7 +568,6 @@ def request_number(
 ) -> object:
     """Number input with + and - buttons, description, and info button."""
 
-
 # rust/src/ui/model_tt/layout.rs
 def show_checklist(
     *,
@@ -725,7 +578,6 @@ def show_checklist(
 ) -> object:
     """Checklist of backup steps. Active index is highlighted, previous items have check
    mark next to them."""
-
 
 # rust/src/ui/model_tt/layout.rs
 def confirm_recovery(
@@ -738,14 +590,12 @@ def confirm_recovery(
 ) -> object:
     """Device recovery homescreen."""
 
-
 # rust/src/ui/model_tt/layout.rs
 def select_word_count(
     *,
     dry_run: bool,
 ) -> int | str:  # TT returns int
     """Select mnemonic word count from (12, 18, 20, 24, 33)."""
-
 
 # rust/src/ui/model_tt/layout.rs
 def show_group_share_success(
@@ -754,14 +604,12 @@ def show_group_share_success(
 ) -> int:
     """Shown after successfully finishing a group."""
 
-
 # rust/src/ui/model_tt/layout.rs
 def show_remaining_shares(
     *,
     pages: Iterable[tuple[str, str]],
 ) -> int:
     """Shows SLIP39 state after info button is pressed on `confirm_recovery`."""
-
 
 # rust/src/ui/model_tt/layout.rs
 def show_progress(
@@ -774,7 +622,6 @@ def show_progress(
    description is determined at construction time. If you want multiline descriptions
    make sure the initial description has at least that amount of lines."""
 
-
 # rust/src/ui/model_tt/layout.rs
 def show_progress_coinjoin(
     *,
@@ -785,7 +632,6 @@ def show_progress_coinjoin(
 ) -> object:
     """Show progress loader for coinjoin. Returns CANCELLED after a specified time when
    time_ms timeout is passed."""
-
 
 # rust/src/ui/model_tt/layout.rs
 def show_homescreen(
@@ -798,7 +644,6 @@ def show_homescreen(
 ) -> CANCELLED:
     """Idle homescreen."""
 
-
 # rust/src/ui/model_tt/layout.rs
 def show_lockscreen(
     *,
@@ -808,7 +653,8 @@ def show_lockscreen(
 ) -> CANCELLED:
     """Homescreen for locked device."""
 
-
 # rust/src/ui/model_tt/layout.rs
 def draw_welcome_screen() -> None:
     """Show logo icon with the model name at the bottom and return."""
+
+# rust/src/ui/model_tt/layout.rs

--- a/core/mocks/generated/trezorutils.pyi
+++ b/core/mocks/generated/trezorutils.pyi
@@ -1,15 +1,9 @@
 from typing import *
-
-
-# extmod/modtrezorutils/modtrezorutils-meminfo.h
 def meminfo(filename: str) -> None:
     """Dumps map of micropython GC arena to a file.
     The JSON file can be decoded by analyze.py
     Only available in the emulator.
      """
-
-
-# extmod/modtrezorutils/modtrezorutils.c
 def consteq(sec: bytes, pub: bytes) -> bool:
     """
     Compares the private information in `sec` with public, user-provided
@@ -17,9 +11,6 @@ def consteq(sec: bytes, pub: bytes) -> bool:
     of `pub`.  Can access memory behind valid length of `sec`, caller is
     expected to avoid any invalid memory access.
     """
-
-
-# extmod/modtrezorutils/modtrezorutils.c
 def memcpy(
     dst: bytearray | memoryview,
     dst_ofs: int,
@@ -33,16 +24,10 @@ def memcpy(
     copied bytes. If `n` is not specified, tries to copy
     as much as possible.
     """
-
-
-# extmod/modtrezorutils/modtrezorutils.c
 def halt(msg: str | None = None) -> None:
     """
     Halts execution.
     """
-
-
-# extmod/modtrezorutils/modtrezorutils.c
 def firmware_hash(
     challenge: bytes | None = None,
     callback: Callable[[int, int], None] | None = None,
@@ -51,30 +36,18 @@ def firmware_hash(
     Computes the Blake2s hash of the firmware with an optional challenge as
     the key.
     """
-
-
-# extmod/modtrezorutils/modtrezorutils.c
 def firmware_vendor() -> str:
     """
     Returns the firmware vendor string from the vendor header.
     """
-
-
-# extmod/modtrezorutils/modtrezorutils.c
 def unit_color() -> int | None:
     """
     Returns the color of the unit.
     """
-
-
-# extmod/modtrezorutils/modtrezorutils.c
 def unit_btconly() -> bool | None:
     """
     Returns True if the unit is BTConly.
     """
-
-
-# extmod/modtrezorutils/modtrezorutils.c
 def reboot_to_bootloader() -> None:
     """
     Reboots to bootloader.

--- a/core/tools/build_mocks
+++ b/core/tools/build_mocks
@@ -1,4 +1,6 @@
 #!/usr/bin/env python3
+from __future__ import annotations
+
 import os
 import shutil
 import subprocess
@@ -6,64 +8,74 @@ import sys
 import tempfile
 from pathlib import Path
 
+import typing as t
+
 CORE_DIR = Path(__file__).resolve().parent.parent
 EXTMOD_PATH = CORE_DIR / "embed" / "extmod"
 RUSTMOD_PATH = CORE_DIR / "embed" / "rust" / "src"
 MOCKS_PATH = CORE_DIR / "mocks" / "generated"
 
-COMMENT_PREFIX = "/// "
+COMMENT_PREFIX = "///"
+COMMENT_PREFIX_RS = "//#"
 
-current_indent = 0
-current_class = None
-current_method = None
+in_class = False
 current_package = None
 current_method_is_overload = False
 
+def process_file(lines_iter: t.Iterator[str], block_prefix: str) -> t.Iterator[tuple[str, str]]:
+    in_class = False
+    package = None
 
-def split_to_parts(line, mod_desc=None):
-    global current_indent
-    global current_class
-    global current_method
+    def process_block() -> t.Iterator[tuple[str, str]]:
+        """Process a single block of comment-prefixed lines."""
+        block_indent = "" if not in_class else " " * 4
+        nonlocal package
+        nonlocal in_class
+        for line in lines_iter:
+            line = line.strip()
+            if not line.startswith(block_prefix):
+                return
+            
+            line = line[len(block_prefix) + 1 :].rstrip()
+            
+            if line.startswith("package: "):
+                package = line[len("package: ") :].strip()
+                continue
+
+            if package is None:
+                raise ValueError("No package set (use 'package: <name>')")
+
+        if not in_class:
+            yield package, f"\n# {mod_desc}"
+
+        for line in block:
+            if not line.strip():
+                continue
+
+            yield package, line
+
+
+def split_to_parts(line):
+    global in_class
     global current_package
     global current_method_is_overload
 
     if line.startswith("package: "):
-        current_package = line[9:].strip()
+        current_package = line[len("package: ") :].strip()
         return
+
+    if current_package is None:
+        raise ValueError("No package set (use 'package: <name>')")
 
     if line.startswith("mock:global"):
-        current_indent = 0
-        current_class = None
+        in_class = False
         return
 
-    if line == "@overload\n":
-        current_method_is_overload = True
-        return
+    indent = "" if not in_class else " " * 4
+    yield (current_package, (indent + line).rstrip())
 
     if line.startswith("class "):
-        current_class = line[6:].split("(")[0].strip(":")
-        current_indent = 0
-
-        yield (current_package, "\n\n")
-        yield (current_package, "# " + mod_desc + "\n")
-
-    elif line.startswith("def "):
-        current_method = line[4:].split("(")[0]
-
-        if current_class is None:
-            yield (current_package, "\n\n")
-            yield (current_package, "# " + mod_desc + "\n")
-        else:
-            yield (current_package, "\n")
-            current_indent = 4
-
-        if current_method_is_overload:
-            yield (current_package, current_indent * " " + "@overload\n")
-            current_method_is_overload = False
-
-    line = current_indent * " " + line
-
-    yield (current_package, line)
+        in_class = True
 
 
 def store_to_file(dest, parts):
@@ -76,8 +88,8 @@ def store_to_file(dest, parts):
         dirpath.mkdir(parents=True, exist_ok=True)
 
         if (dest / package).is_dir():
-            if not line.strip():
-                continue
+            # if not line.strip():
+            #     continue
             print(f"Package exists: {package}")
             print(f"You should set 'package:' in {line.strip()}")
             sys.exit(1)
@@ -86,12 +98,12 @@ def store_to_file(dest, parts):
             filepath.write_text("from typing import *\n")
 
         with open(filepath, "a") as f:
-            f.write(line)
+            f.write(line + "\n")
 
 
 def build_module(mod_file, dest):
     global current_indent
-    global current_class
+    global in_class
     global current_package
 
     assert mod_file.name.startswith("mod")
@@ -100,47 +112,51 @@ def build_module(mod_file, dest):
     name = mod_file.name[3:-2]
 
     current_indent = 0
-    current_class = None
+    in_class = None
     current_package = name.split("-")[0]
     mod_desc = str(mod_file.relative_to(CORE_DIR / "embed"))
 
     for l in open(mod_file):
+        l = l.strip()
         if not l.startswith(COMMENT_PREFIX):
             continue
 
-        l = l[len(COMMENT_PREFIX) :]  # .strip()
+        l = l[len(COMMENT_PREFIX) + 1 :]  # account for space after ///
         store_to_file(dest, split_to_parts(l, mod_desc))
 
 
-def build_rsmodule(mod_file, dest):
+def build_rsmodule(mod_file):
     global current_indent
-    global current_class
+    global in_class
     global current_package
 
     assert mod_file.suffix == ".rs"
 
-    start_prefix = "pub static mp_module_"
-    comment_prefix = f"    {COMMENT_PREFIX}"
-    in_module = False
     current_indent = 0
-    current_class = None
+    in_class = False
+    current_package = None
     mod_desc = str(mod_file.relative_to(CORE_DIR / "embed"))
 
+    yield_sep = False
     for l in open(mod_file):
-        if l.startswith(start_prefix):
-            in_module = True
-            current_package = l[len(start_prefix) : ].split(":")[0]
-        elif l.startswith("}"):
-            in_module = False
-
-        if not in_module:
+        l = l.strip()
+        if not l.startswith(COMMENT_PREFIX_RS):
+            if yield_sep:
+                if in_class:
+                    yield current_package, ""
+                else:
+                    yield current_package, f"\n# {mod_desc}"
+                yield_sep = False
             continue
 
-        if not l.startswith(comment_prefix):
-            continue
-
-        l = l[len(comment_prefix) :]
-        store_to_file(dest, split_to_parts(l, mod_desc))
+        l = l[len(COMMENT_PREFIX_RS) + 1 :]  # account for space after //#
+        try:
+            yield from split_to_parts(l, mod_desc)
+            yield_sep = True
+        except ValueError as e:
+            print(f"Error in {mod_file}: {e}")
+            print(f"Line: {l}")
+            sys.exit(1)
 
 
 def place_symlinks(dest):
@@ -154,7 +170,7 @@ def build_directory(dest):
     for modfile in sorted(EXTMOD_PATH.glob("**/mod*.[ch]")):
         build_module(modfile, dest)
     for modfile in sorted(RUSTMOD_PATH.glob("**/*.rs")):
-        build_rsmodule(modfile, dest)
+        store_to_file(dest, build_rsmodule(modfile))
     place_symlinks(dest)
 
 


### PR DESCRIPTION
two issues with the current process:

(a) empty newlines get stripped out, squishing the content together
(b) in Rust, we can't place typestubs outside obj_module declarations.

this is a very unfinished draft of a fix

it changes Rust comment prefix from `///` to `//#` for easier detection.
The next idea is to treat every unbroken chunk of typestub comment lines as a single "block" and keep all newlines found inside the block intact, as well as indentation. Only detect if we're supposed to be inside a class, and if yes, pre-indent next blocks by exactly one indent step.

(that allows "if __debug__" and "if utils.BITCOIN_ONLY" at class level)