### PR TITLE
feat(rust): update trezor-client crate metadata + run cargo build

### DIFF
--- a/rust/trezor-client/Cargo.lock
+++ b/rust/trezor-client/Cargo.lock
@@ -730,7 +730,7 @@ dependencies = [
 
 [[package]]
 name = "trezor-client"
-version = "0.1.0"
+version = "0.1.1"
 dependencies = [
  "bitcoin",
  "byteorder",

--- a/rust/trezor-client/Cargo.toml
+++ b/rust/trezor-client/Cargo.toml
@@ -2,9 +2,10 @@
 name = "trezor-client"
 version = "0.1.1"
 authors = [
-    "joshie",
+    "Piyush Kumar <piyushkumar2k02@kgpian.iitkgp.ac.in>",
+    "joshieDo <ranriver@protonmail.com>",
     "DaniPopes <57450786+DaniPopes@users.noreply.github.com>",
-    "romanz",
+    "Roman Zeyde <me@romanzey.de>",
     "Steven Roose <steven@stevenroose.org>",
 ]
 license = "CC0-1.0"


### PR DESCRIPTION
Followup to https://github.com/trezor/trezor-firmware/pull/3137

When trying to publish the create I noticed the Cargo.lock file hasn't been updated - run `cargo build` to update the crate version in the lock file.

Also updated the authors section to match reality.

Once this is merged I will tag the commit and publish the trezor-client v0.1.1 crate.