### PR TITLE
replace systick based wait in display SPI with loop

### DIFF
--- a/core/embed/trezorhal/stm32f4/displays/vg-2864ksweg01.c
+++ b/core/embed/trezorhal/stm32f4/displays/vg-2864ksweg01.c
@@ -127,7 +127,10 @@ int display_backlight(int val) {
 SPI_HandleTypeDef spi_handle;
 
 static inline void spi_send(const uint8_t *data, int len) {
-  HAL_Delay(1);
+  volatile int32_t timeout = 1000;
+  for (int i = 0; i < timeout; i++)
+    ;
+
   if (HAL_OK != HAL_SPI_Transmit(&spi_handle, (uint8_t *)data, len, 1000)) {
     // TODO: error
     return;


### PR DESCRIPTION
replace systick based wait in display SPI with loop as systick does not work in fault handlers, hence the rendering gets stuck

<!--
If you are a core dev:

Don't forget to set up the fields:
- assign yourself
- set priority to same as original issue
- add PR to sprint
- if Draft -> "in progress"
- if final PR -> "needs review"

If you're an external contributor, you can ignore this text.
-->
