### PR TITLE
Get UI fixtures from CI

### DIFF
--- a/ci/test.yml
+++ b/ci/test.yml
@@ -73,6 +73,7 @@ core device test:
       - test_ui_report
       - tests/ui_tests/screens/
       - tests/ui_tests/fixtures.suggestion.json
+      - tests/ui_tests/fixtures.results.json
       - tests/junit.xml
       - tests/trezor.log
       - core/.coverage.*
@@ -104,6 +105,7 @@ core device R test:
       - test_ui_report
       - tests/ui_tests/screens/
       - tests/ui_tests/fixtures.suggestion.json
+      - tests/ui_tests/fixtures.results.json
       - tests/junit.xml
       - tests/trezor.log
       - core/.coverage.*
@@ -316,6 +318,7 @@ core click test:
       - test_ui_report
       - tests/ui_tests/screens/
       - tests/ui_tests/fixtures.suggestion.json
+      - tests/ui_tests/fixtures.results.json
       - tests/trezor.log
       - tests/junit.xml
       - core/.coverage.*
@@ -347,6 +350,7 @@ core click R test:
       - test_ui_report
       - tests/ui_tests/screens/
       - tests/ui_tests/fixtures.suggestion.json
+      - tests/ui_tests/fixtures.results.json
       - tests/trezor.log
       - tests/junit.xml
     reports:
@@ -437,6 +441,7 @@ core persistence test:
       - test_ui_report
       - tests/ui_tests/screens/
       - tests/ui_tests/fixtures.suggestion.json
+      - tests/ui_tests/fixtures.results.json
       - tests/trezor.log
       - tests/junit.xml
       - core/.coverage.*
@@ -534,6 +539,7 @@ legacy device test:
       - test_ui_report
       - tests/ui_tests/screens/
       - tests/ui_tests/fixtures.suggestion.json
+      - tests/ui_tests/fixtures.results.json
       - tests/junit.xml
       - tests/trezor.log
     when: always

--- a/docs/ci/jobs.md
+++ b/docs/ci/jobs.md
@@ -158,81 +158,81 @@ with the expected UI result.
 See artifacts for a comprehensive report of UI.
 See [docs/tests/ui-tests](../tests/ui-tests.md) for more info.
 
-### [core device R test](https://github.com/trezor/trezor-firmware/blob/master/ci/test.yml#L84)
+### [core device R test](https://github.com/trezor/trezor-firmware/blob/master/ci/test.yml#L85)
 
-### [core device asan test](https://github.com/trezor/trezor-firmware/blob/master/ci/test.yml#L115)
+### [core device asan test](https://github.com/trezor/trezor-firmware/blob/master/ci/test.yml#L117)
 
-### [core btconly device test](https://github.com/trezor/trezor-firmware/blob/master/ci/test.yml#L134)
+### [core btconly device test](https://github.com/trezor/trezor-firmware/blob/master/ci/test.yml#L136)
 Device tests excluding altcoins, only for BTC.
 
-### [core btconly device asan test](https://github.com/trezor/trezor-firmware/blob/master/ci/test.yml#L154)
+### [core btconly device asan test](https://github.com/trezor/trezor-firmware/blob/master/ci/test.yml#L156)
 
-### [core monero test](https://github.com/trezor/trezor-firmware/blob/master/ci/test.yml#L175)
+### [core monero test](https://github.com/trezor/trezor-firmware/blob/master/ci/test.yml#L177)
 Monero tests.
 
-### [core monero asan test](https://github.com/trezor/trezor-firmware/blob/master/ci/test.yml#L195)
+### [core monero asan test](https://github.com/trezor/trezor-firmware/blob/master/ci/test.yml#L197)
 
-### [core u2f test](https://github.com/trezor/trezor-firmware/blob/master/ci/test.yml#L218)
+### [core u2f test](https://github.com/trezor/trezor-firmware/blob/master/ci/test.yml#L220)
 Tests for U2F and HID.
 
-### [core u2f asan test](https://github.com/trezor/trezor-firmware/blob/master/ci/test.yml#L237)
+### [core u2f asan test](https://github.com/trezor/trezor-firmware/blob/master/ci/test.yml#L239)
 
-### [core fido2 test](https://github.com/trezor/trezor-firmware/blob/master/ci/test.yml#L255)
+### [core fido2 test](https://github.com/trezor/trezor-firmware/blob/master/ci/test.yml#L257)
 FIDO2 device tests.
 
-### [core fido2 asan test](https://github.com/trezor/trezor-firmware/blob/master/ci/test.yml#L278)
+### [core fido2 asan test](https://github.com/trezor/trezor-firmware/blob/master/ci/test.yml#L280)
 
-### [core click test](https://github.com/trezor/trezor-firmware/blob/master/ci/test.yml#L298)
+### [core click test](https://github.com/trezor/trezor-firmware/blob/master/ci/test.yml#L300)
 Click tests - UI.
 See [docs/tests/click-tests](../tests/click-tests.md) for more info.
 
-### [core click R test](https://github.com/trezor/trezor-firmware/blob/master/ci/test.yml#L329)
+### [core click R test](https://github.com/trezor/trezor-firmware/blob/master/ci/test.yml#L332)
 Click tests.
 See [docs/tests/click-tests](../tests/click-tests.md) for more info.
 
-### [core click asan test](https://github.com/trezor/trezor-firmware/blob/master/ci/test.yml#L357)
+### [core click asan test](https://github.com/trezor/trezor-firmware/blob/master/ci/test.yml#L361)
 
-### [core upgrade test](https://github.com/trezor/trezor-firmware/blob/master/ci/test.yml#L378)
+### [core upgrade test](https://github.com/trezor/trezor-firmware/blob/master/ci/test.yml#L382)
 Upgrade tests.
 See [docs/tests/upgrade-tests](../tests/upgrade-tests.md) for more info.
 
-### [core upgrade asan test](https://github.com/trezor/trezor-firmware/blob/master/ci/test.yml#L397)
+### [core upgrade asan test](https://github.com/trezor/trezor-firmware/blob/master/ci/test.yml#L401)
 
-### [core persistence test](https://github.com/trezor/trezor-firmware/blob/master/ci/test.yml#L419)
+### [core persistence test](https://github.com/trezor/trezor-firmware/blob/master/ci/test.yml#L423)
 Persistence tests - UI.
 
-### [core persistence asan test](https://github.com/trezor/trezor-firmware/blob/master/ci/test.yml#L448)
+### [core persistence asan test](https://github.com/trezor/trezor-firmware/blob/master/ci/test.yml#L453)
 
-### [core hwi test](https://github.com/trezor/trezor-firmware/blob/master/ci/test.yml#L466)
+### [core hwi test](https://github.com/trezor/trezor-firmware/blob/master/ci/test.yml#L471)
 
-### [crypto test](https://github.com/trezor/trezor-firmware/blob/master/ci/test.yml#L485)
+### [crypto test](https://github.com/trezor/trezor-firmware/blob/master/ci/test.yml#L490)
 
-### [legacy device test](https://github.com/trezor/trezor-firmware/blob/master/ci/test.yml#L517)
+### [legacy device test](https://github.com/trezor/trezor-firmware/blob/master/ci/test.yml#L522)
 Legacy device test - UI.
 
-### [legacy asan test](https://github.com/trezor/trezor-firmware/blob/master/ci/test.yml#L544)
+### [legacy asan test](https://github.com/trezor/trezor-firmware/blob/master/ci/test.yml#L550)
 
-### [legacy btconly test](https://github.com/trezor/trezor-firmware/blob/master/ci/test.yml#L556)
+### [legacy btconly test](https://github.com/trezor/trezor-firmware/blob/master/ci/test.yml#L562)
 
-### [legacy btconly asan test](https://github.com/trezor/trezor-firmware/blob/master/ci/test.yml#L576)
+### [legacy btconly asan test](https://github.com/trezor/trezor-firmware/blob/master/ci/test.yml#L582)
 
-### [legacy upgrade test](https://github.com/trezor/trezor-firmware/blob/master/ci/test.yml#L591)
+### [legacy upgrade test](https://github.com/trezor/trezor-firmware/blob/master/ci/test.yml#L597)
 
-### [legacy upgrade asan test](https://github.com/trezor/trezor-firmware/blob/master/ci/test.yml#L610)
+### [legacy upgrade asan test](https://github.com/trezor/trezor-firmware/blob/master/ci/test.yml#L616)
 
-### [legacy hwi test](https://github.com/trezor/trezor-firmware/blob/master/ci/test.yml#L631)
+### [legacy hwi test](https://github.com/trezor/trezor-firmware/blob/master/ci/test.yml#L637)
 
-### [python test](https://github.com/trezor/trezor-firmware/blob/master/ci/test.yml#L651)
+### [python test](https://github.com/trezor/trezor-firmware/blob/master/ci/test.yml#L657)
 
-### [python support test](https://github.com/trezor/trezor-firmware/blob/master/ci/test.yml#L670)
+### [python support test](https://github.com/trezor/trezor-firmware/blob/master/ci/test.yml#L676)
 
-### [rust test](https://github.com/trezor/trezor-firmware/blob/master/ci/test.yml#L679)
+### [rust test](https://github.com/trezor/trezor-firmware/blob/master/ci/test.yml#L685)
 
-### [storage test](https://github.com/trezor/trezor-firmware/blob/master/ci/test.yml#L689)
+### [storage test](https://github.com/trezor/trezor-firmware/blob/master/ci/test.yml#L695)
 
-### [core unix memory profiler](https://github.com/trezor/trezor-firmware/blob/master/ci/test.yml#L713)
+### [core unix memory profiler](https://github.com/trezor/trezor-firmware/blob/master/ci/test.yml#L719)
 
-### [connect test core](https://github.com/trezor/trezor-firmware/blob/master/ci/test.yml#L737)
+### [connect test core](https://github.com/trezor/trezor-firmware/blob/master/ci/test.yml#L743)
 
 ---
 ## TEST-HW stage - [test-hw.yml](https://github.com/trezor/trezor-firmware/blob/master/ci/test-hw.yml)

--- a/tests/gitlab.py
+++ b/tests/gitlab.py
@@ -1,0 +1,136 @@
+"""
+Helper functions for communication with Gitlab.
+
+Allowing for interaction with the test results, e.g. with UI tests.
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from typing import Any, Iterable, Iterator
+
+import requests
+
+AnyDict = dict[Any, Any]
+
+HERE = Path(__file__).parent
+
+BRANCHES_API_TEMPLATE = "https://gitlab.com/satoshilabs/trezor/trezor-firmware/-/pipelines.json?scope=branches&page={}"
+GRAPHQL_API = "https://gitlab.com/api/graphql"
+
+UI_JOB_NAMES = (
+    "core click R test",
+    "core device R test",
+    "core click test",
+    "core device test",
+    "core persistence test",
+    "legacy device test",
+)
+
+SAVE_GRAPHQL_RESULTS = False
+
+
+def _get_gitlab_branches(page: int) -> list[AnyDict]:
+    return requests.get(BRANCHES_API_TEMPLATE.format(page)).json()["pipelines"]
+
+
+def _get_branch_obj(branch_name: str) -> AnyDict:
+    # Trying first 10 pages of branches
+    for page in range(1, 11):
+        branches = _get_gitlab_branches(page)
+        for branch_obj in branches:
+            if branch_obj["ref"]["name"] == branch_name:
+                return branch_obj
+    raise ValueError(f"Branch {branch_name} not found")
+
+
+def _get_pipeline_jobs_info(pipeline_iid: int) -> AnyDict:
+    # Getting just the stuff we need - the job names and IDs
+    graphql_query = """
+query getJobsFromPipeline($projectPath: ID!, $iid: ID!) {
+  project(fullPath: $projectPath) {
+    pipeline(iid: $iid) {
+      stages {
+        nodes {
+          groups {
+            nodes {
+              jobs {
+                nodes {
+                  id
+                  name
+                }
+              }
+            }
+          }
+        }
+      }
+    }
+  }
+}
+    """
+    query = {
+        "query": graphql_query,
+        "variables": {
+            "projectPath": "satoshilabs/trezor/trezor-firmware",
+            "iid": pipeline_iid,
+        },
+    }
+    return requests.post(GRAPHQL_API, json=query).json()
+
+
+def _yield_pipeline_jobs(pipeline_iid: int) -> Iterator[AnyDict]:
+    jobs_info = _get_pipeline_jobs_info(pipeline_iid)
+    if SAVE_GRAPHQL_RESULTS:  # for development purposes
+        with open("jobs_info.json", "w") as f:
+            json.dump(jobs_info, f, indent=2)
+    stages = jobs_info["data"]["project"]["pipeline"]["stages"]["nodes"]
+    for stage in stages:
+        nodes = stage["groups"]["nodes"]
+        for node in nodes:
+            jobs = node["jobs"]["nodes"]
+            for job in jobs:
+                yield job
+
+
+def _get_job_ui_fixtures_results(job: AnyDict) -> AnyDict:
+    print(f"Checking job {job['name']}")
+    job_id = job["id"].split("/")[-1]
+    url = f"https://satoshilabs.gitlab.io/-/trezor/trezor-firmware/-/jobs/{job_id}/artifacts/tests/ui_tests/fixtures.results.json"
+    response = requests.get(url)
+    if response.status_code != 200:
+        print("No UI results found")
+        return {}
+    return response.json()
+
+
+def get_jobs_of_interest(
+    only_jobs: Iterable[str] | None, exclude_jobs: Iterable[str] | None
+) -> Iterable[str]:
+    if only_jobs and exclude_jobs:
+        raise ValueError("Cannot specify both only_jobs and exclude_jobs")
+    if only_jobs:
+        return [job for job in UI_JOB_NAMES if job in only_jobs]
+    if exclude_jobs:
+        return [job for job in UI_JOB_NAMES if job not in exclude_jobs]
+    return UI_JOB_NAMES
+
+
+def get_branch_ui_fixtures_results(
+    branch_name: str, jobs_of_interest: Iterable[str] | None = None
+) -> dict[str, AnyDict]:
+    print(f"Checking branch {branch_name}")
+
+    if jobs_of_interest is None:
+        jobs_of_interest = UI_JOB_NAMES
+
+    branch_obj = _get_branch_obj(branch_name)
+    pipeline_iid = branch_obj["iid"]
+
+    def yield_key_value() -> Iterator[tuple[str, AnyDict]]:
+        for job in _yield_pipeline_jobs(pipeline_iid):
+            for ui_job_name in jobs_of_interest:
+                if job["name"] == ui_job_name:
+                    yield job["name"], _get_job_ui_fixtures_results(job)
+
+    return dict(yield_key_value())

--- a/tests/show_results.py
+++ b/tests/show_results.py
@@ -13,7 +13,7 @@ from urllib.parse import unquote
 
 import click
 
-from ui_tests.common import SCREENS_DIR, TestResult, write_fixtures
+from ui_tests.common import SCREENS_DIR, TestResult, write_fixtures_complete
 from ui_tests.reporting import testreport  # noqa: E402
 
 ROOT = Path(__file__).resolve().parent.parent
@@ -78,7 +78,7 @@ class NoCacheRequestHandler(http.server.SimpleHTTPRequestHandler):
                 test_path = SCREENS_DIR / test_name
                 result = TestResult.load(test_path)
                 assert result.actual_hash == test_hash
-                write_fixtures([result])
+                write_fixtures_complete([result])
 
             self.send_response(200)
             self.send_header("Content-Type", "text/plain")

--- a/tests/ui_tests/.gitignore
+++ b/tests/ui_tests/.gitignore
@@ -3,4 +3,5 @@
 *.zip
 *.txt
 fixtures.suggestion.json
+fixtures.results.json
 reporting/master_cache

--- a/tests/ui_tests/__init__.py
+++ b/tests/ui_tests/__init__.py
@@ -14,6 +14,7 @@ from .common import SCREENS_DIR, UI_TESTS_DIR, TestCase, TestResult
 from .reporting import testreport
 
 FIXTURES_SUGGESTION_FILE = UI_TESTS_DIR / "fixtures.suggestion.json"
+FIXTURES_RESULTS_FILE = UI_TESTS_DIR / "fixtures.results.json"
 
 
 def _process_recorded(result: TestResult) -> None:
@@ -113,7 +114,7 @@ def update_fixtures(remove_missing: bool = False) -> int:
     for result in results:
         result.store_recorded()
 
-    common.write_fixtures(results, remove_missing=remove_missing)
+    common.write_fixtures_complete(results, remove_missing=remove_missing)
     return len(results)
 
 
@@ -174,8 +175,15 @@ def sessionfinish(
         return exitstatus
 
     testreport.generate_reports(record_text_layout, do_master_diff)
+
+    if test_ui == "test":
+        common.write_fixtures_only_new_results(
+            TestResult.recent_results(),
+            dest=FIXTURES_RESULTS_FILE,
+        )
+
     if test_ui == "test" and check_missing and list_missing():
-        common.write_fixtures(
+        common.write_fixtures_complete(
             TestResult.recent_results(),
             remove_missing=True,
             dest=FIXTURES_SUGGESTION_FILE,

--- a/tests/ui_tests/common.py
+++ b/tests/ui_tests/common.py
@@ -77,11 +77,25 @@ def prepare_fixtures(
     return fixtures, missing_tests
 
 
-def write_fixtures(
+def write_fixtures_only_new_results(
+    results: t.Iterable[TestResult],
+    dest: Path,
+) -> None:
+    """Generate new results file with only the tests that were actually run."""
+    content: dict[str, dict[str, dict[str, str]]] = {}
+    for res in results:
+        model = content.setdefault(res.test.model, {})
+        group = model.setdefault(res.test.group, {})
+        group[res.test.fixtures_name] = res.actual_hash
+    dest.write_text(json.dumps(content, indent=0, sort_keys=True) + "\n")
+
+
+def write_fixtures_complete(
     results: t.Iterable[TestResult],
     remove_missing: bool = False,
     dest: Path = FIXTURES_FILE,
 ) -> None:
+    """Generate new fixtures.json file with all the results, updated for the latest run."""
     global FIXTURES
     content, _ = prepare_fixtures(results, remove_missing)
     dest.write_text(json.dumps(content, indent=0, sort_keys=True) + "\n")

--- a/tests/update_fixtures.py
+++ b/tests/update_fixtures.py
@@ -1,16 +1,109 @@
 #!/usr/bin/env python3
+
+from __future__ import annotations
+
+import json
+import subprocess
+from typing import Iterable
+
 import click
 
+from gitlab import UI_JOB_NAMES, get_branch_ui_fixtures_results, get_jobs_of_interest
 from ui_tests import update_fixtures
+from ui_tests.common import FIXTURES_FILE, get_current_fixtures
 
 
-@click.command()
+@click.group()
+def cli():
+    pass
+
+
+@cli.command()
 @click.option("-r", "--remove-missing", is_flag=True, help="Remove missing tests")
-def main(remove_missing: bool) -> None:
-    """Update fixtures file with results from latest test run."""
+def local(remove_missing: bool) -> None:
+    """Update fixtures file with results from latest local test run."""
+    print("Updating from local test run...")
     changes_amount = update_fixtures(remove_missing)
     print(f"Updated fixtures.json with data from {changes_amount} tests.")
 
 
+def _get_current_git_branch() -> str:
+    return (
+        subprocess.check_output(["git", "branch", "--show-current"])
+        .decode("ascii")
+        .strip()
+    )
+
+
+@cli.command()
+@click.option("-b", "--branch", help="Branch name")
+@click.option(
+    "-o",
+    "--only-jobs",
+    type=click.Choice(UI_JOB_NAMES),
+    help="Job names which to process",
+    multiple=True,
+)
+@click.option(
+    "-e",
+    "--exclude-jobs",
+    type=click.Choice(UI_JOB_NAMES),
+    help="Not take these jobs",
+    multiple=True,
+)
+def ci(
+    branch: str | None,
+    only_jobs: Iterable[str] | None,
+    exclude_jobs: Iterable[str] | None,
+) -> None:
+    """Update fixtures file with results from CI."""
+    print("Updating from CI...")
+
+    if only_jobs and exclude_jobs:
+        raise click.UsageError("Cannot use both --only-jobs and --exclude-jobs")
+
+    if branch is None:
+        branch = _get_current_git_branch()
+
+    print(f"Branch: {branch}")
+    if only_jobs:
+        print(f"Only jobs: {only_jobs}")
+    if exclude_jobs:
+        print(f"Exclude jobs: {exclude_jobs}")
+
+    jobs_of_interest = get_jobs_of_interest(only_jobs, exclude_jobs)
+    ui_results = get_branch_ui_fixtures_results(branch, jobs_of_interest)
+
+    current_fixtures = get_current_fixtures()
+
+    differing_total = 0
+    for job_name, ui_res_dict in ui_results.items():
+        print(f"Updating results from {job_name}...")
+        if not ui_res_dict:
+            print("No results found.")
+            continue
+        model = next(iter(ui_res_dict.keys()))
+        group = next(iter(ui_res_dict[model].keys()))
+        current_model = current_fixtures.setdefault(model, {})
+        current_group = current_model.setdefault(group, {})  # type: ignore
+
+        differing = 0
+        for test_name, res in ui_res_dict[model][group].items():
+            if current_group.get(test_name) != res:
+                differing += 1
+            current_group[test_name] = res
+
+        print(f"Updated {differing} tests.")
+        differing_total += differing
+
+    print(80 * "-")
+    print(f"Updated {differing_total} tests in total.")
+
+    FIXTURES_FILE.write_text(
+        json.dumps(current_fixtures, indent=0, sort_keys=True) + "\n"
+    )
+    print("Updated fixtures.json with data from CI.")
+
+
 if __name__ == "__main__":
-    main()
+    cli()


### PR DESCRIPTION
Fixes https://github.com/trezor/trezor-firmware/issues/3052:
- saving `fixtures.results.json` file with the UI hashes of all the tests that were running in a specific test-pipeline
- allowing to download all the CI results and refresh the local `fixtures.json` with a simple script - `python tests/update_fixtures.py ci`

Also found out why the `fixtures.suggestion.json` is not being generated anymore - it requires that some tests are not being run - `if test_ui == "test" and check_missing and list_missing()` ... we might want to change this probably
