### PR TITLE
feat(tests): number the screens in UI test reports, give unique IDs to images

### DIFF
--- a/tests/ui_tests/reporting/html.py
+++ b/tests/ui_tests/reporting/html.py
@@ -47,11 +47,11 @@ def write(fixture_test_path: Path, doc: document, filename: str) -> Path:
     return fixture_test_path / filename
 
 
-def image_column(hash: str | None, cur_dir: Path) -> None:
+def image_column(hash: str | None, cur_dir: Path, img_id: str | None = None) -> None:
     """Put image into table as one cell."""
     with td():
         if hash:
-            image_link(hash, cur_dir)
+            image_link(hash, cur_dir, img_id=img_id)
         else:
             i("missing")
 
@@ -72,10 +72,13 @@ def _relative_path(cur_dir: Path, path_to: Path) -> str:
     return "/".join(components)
 
 
-def image_link(hash: str, cur_dir: Path, title: str = "") -> None:
+def image_link(
+    hash: str, cur_dir: Path, title: str = "", img_id: str | None = None
+) -> None:
     """Put image into table as one cell."""
     path = _IMAGE_DIR / f"{hash}.png"
     img(
+        id=img_id,
         src=_relative_path(cur_dir, path),
         title=title,
         loading="lazy",

--- a/tests/ui_tests/reporting/testreport.py
+++ b/tests/ui_tests/reporting/testreport.py
@@ -384,10 +384,12 @@ def recorded(result: TestResult, header: str = "Recorded", dir: str = "passed") 
 
         with table(border=1):
             with tr():
+                th("id")
                 th(header)
 
-            for screen in result.images:
+            for index, screen in enumerate(result.images):
                 with tr():
-                    html.image_column(screen, TESTREPORT_PATH / dir)
+                    td(index)
+                    html.image_column(screen, TESTREPORT_PATH / dir, img_id=str(index))
 
     return html.write(TESTREPORT_PATH / dir, doc, result.test.id + ".html")


### PR DESCRIPTION
Fixes https://github.com/trezor/trezor-firmware/issues/3118:
- prepares the UI tests for automatic retrieval of specific images and allows for linking to a given screen

The mapping itself and the application/dashboard code are currently stored at https://github.com/grdddj/figma_ui repository

The app itself is running under https://figma.grdddj.eu