### PR TITLE
Integrate OPTIGA Trust M

### DIFF
--- a/core/SConscript.firmware
+++ b/core/SConscript.firmware
@@ -18,7 +18,7 @@ FEATURE_FLAGS = {
     "SYSTEM_VIEW": False,
 }
 
-FEATURES_WANTED = ["input", "sbu", "sd_card", "rgb_led", "dma2d", "consumption_mask", "usb"]
+FEATURES_WANTED = ["input", "sbu", "sd_card", "rgb_led", "dma2d", "consumption_mask", "usb" ,"optiga"]
 
 CCFLAGS_MOD = ''
 CPPPATH_MOD = []

--- a/core/embed/firmware/main.c
+++ b/core/embed/firmware/main.c
@@ -47,6 +47,8 @@
 #include "mpu.h"
 #include "random_delays.h"
 
+#include TREZOR_BOARD
+
 #ifdef USE_RGB_LED
 #include "rgb_led.h"
 #endif
@@ -67,6 +69,9 @@
 #endif
 #ifdef USE_SD_CARD
 #include "sdcard.h"
+#endif
+#ifdef USE_OPTIGA
+#include "optiga_transport.h"
 #endif
 #include "unit_variant.h"
 
@@ -153,6 +158,10 @@ int main(void) {
 
 #ifdef USE_SD_CARD
   sdcard_init();
+#endif
+
+#ifdef USE_OPTIGA
+  optiga_init();
 #endif
 
 #if !defined TREZOR_MODEL_1

--- a/core/embed/trezorhal/boards/trezor_r_v10.h
+++ b/core/embed/trezorhal/boards/trezor_r_v10.h
@@ -5,6 +5,7 @@
 #define USE_SBU 1
 #define USE_I2C 1
 #define USE_CONSUMPTION_MASK 1
+#define USE_OPTIGA 1
 
 #include "displays/vg-2864ksweg01.h"
 
@@ -47,5 +48,7 @@
 #define I2C_INSTANCE_1_SCL_PIN GPIO_PIN_10
 #define I2C_INSTANCE_1_SCL_CLK_EN __HAL_RCC_GPIOB_CLK_ENABLE
 #define I2C_INSTANCE_1_RESET_FLG RCC_APB1RSTR_I2C2RST
+
+#define OPTIGA_I2C_INSTANCE 0
 
 #endif  //_TREZOR_R_V10_H

--- a/core/embed/trezorhal/optiga/optiga_commands.c
+++ b/core/embed/trezorhal/optiga/optiga_commands.c
@@ -1,0 +1,750 @@
+/*
+ * This file is part of the Trezor project, https://trezor.io/
+ *
+ * Copyright (c) SatoshiLabs
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+/*
+ * Reference manuals:
+ * https://github.com/Infineon/optiga-trust-m/blob/develop/documents/OPTIGA%E2%84%A2%20Trust%20M%20Solution%20Reference%20Manual.md
+ * https://github.com/Infineon/optiga-trust-m/blob/develop/documents/Infineon_I2C_Protocol_v2.03.pdf
+ */
+
+#include "optiga_commands.h"
+#include <string.h>
+#include "ecdsa.h"
+#include "hmac.h"
+#include "memzero.h"
+#include "nist256p1.h"
+#include "optiga_transport.h"
+#include "sha2.h"
+
+// Static buffer for commands and responses.
+static uint8_t tx_buffer[1750] = {0};
+static size_t tx_size = 0;
+
+static optiga_result process_output_fixedlen(uint8_t *data, size_t data_size) {
+  // Expecting data_size bytes of output data in the response.
+  if (tx_size != 4 + data_size ||
+      (tx_buffer[2] << 8) + tx_buffer[3] != tx_size - 4) {
+    return OPTIGA_ERR_UNEXPECTED;
+  }
+
+  if (tx_buffer[0] != 0) {
+    return OPTIGA_ERR_CMD;
+  }
+
+  if (data_size != 0) {
+    memcpy(data, tx_buffer + 4, data_size);
+    memzero(tx_buffer, tx_size);
+  }
+
+  return OPTIGA_SUCCESS;
+}
+
+static optiga_result process_output_varlen(uint8_t *data, size_t max_data_size,
+                                           size_t *data_size) {
+  // Check that there is no trailing output data in the response.
+  if (tx_size < 4 || (tx_buffer[2] << 8) + tx_buffer[3] != tx_size - 4) {
+    return OPTIGA_ERR_UNEXPECTED;
+  }
+
+  // Check response status code.
+  if (tx_buffer[0] != 0) {
+    return OPTIGA_ERR_CMD;
+  }
+
+  // Return result.
+  if (tx_size - 4 > max_data_size) {
+    return OPTIGA_ERR_SIZE;
+  }
+  *data_size = tx_size - 4;
+  memcpy(data, tx_buffer + 4, tx_size - 4);
+  memzero(tx_buffer, tx_size);
+
+  return OPTIGA_SUCCESS;
+}
+
+/*
+ * For metadata description see:
+ * https://github.com/Infineon/optiga-trust-m/blob/develop/documents/OPTIGA%E2%84%A2%20Trust%20M%20Solution%20Reference%20Manual.md#metadata-expression
+ */
+
+static const struct {
+  size_t offset;
+  uint8_t tag;
+} METADATA_OFFSET_TAG_MAP[] = {
+    {offsetof(optiga_metadata, lcso), 0xC0},
+    {offsetof(optiga_metadata, version), 0xC1},
+    {offsetof(optiga_metadata, max_size), 0xC4},
+    {offsetof(optiga_metadata, used_size), 0xC5},
+    {offsetof(optiga_metadata, change), 0xD0},
+    {offsetof(optiga_metadata, read), 0xD1},
+    {offsetof(optiga_metadata, execute), 0xD3},
+    {offsetof(optiga_metadata, meta_update), 0xD8},
+    {offsetof(optiga_metadata, algorithm), 0xE0},
+    {offsetof(optiga_metadata, key_usage), 0xE1},
+    {offsetof(optiga_metadata, data_type), 0xE8},
+    {offsetof(optiga_metadata, reset_type), 0xF0},
+};
+
+static const size_t METADATA_TAG_COUNT =
+    sizeof(METADATA_OFFSET_TAG_MAP) / sizeof(METADATA_OFFSET_TAG_MAP[0]);
+
+optiga_result optiga_parse_metadata(const uint8_t *serialized,
+                                    size_t serialized_size,
+                                    optiga_metadata *metadata) {
+  memzero(metadata, sizeof(*metadata));
+
+  if (serialized_size < 2 || serialized[0] != 0x20 ||
+      serialized[1] + 2 != serialized_size) {
+    return OPTIGA_ERR_PARAM;
+  }
+
+  size_t pos = 2;
+  while (pos < serialized_size) {
+    if (pos + 2 >= serialized_size) {
+      return OPTIGA_ERR_PARAM;
+    }
+
+    // Determine metadata type from tag.
+    optiga_metadata_item *item = NULL;
+    for (int i = 0; i < METADATA_TAG_COUNT; ++i) {
+      if (METADATA_OFFSET_TAG_MAP[i].tag == serialized[pos]) {
+        item = (void *)((char *)metadata + METADATA_OFFSET_TAG_MAP[i].offset);
+        break;
+      }
+    }
+
+    if (item == NULL || item->ptr != NULL) {
+      // Invalid tag or multiply defined tag.
+      return OPTIGA_ERR_PARAM;
+    }
+
+    item->ptr = &serialized[pos + 2];
+    item->len = serialized[pos + 1];
+    pos += 2 + serialized[pos + 1];
+  }
+
+  if (pos != serialized_size) {
+    return OPTIGA_ERR_PARAM;
+  }
+
+  return OPTIGA_SUCCESS;
+}
+
+optiga_result optiga_serialize_metadata(const optiga_metadata *metadata,
+                                        uint8_t *serialized,
+                                        size_t max_serialized,
+                                        size_t *serialized_size) {
+  *serialized_size = 0;
+  if (max_serialized < 2) {
+    return OPTIGA_ERR_SIZE;
+  }
+
+  serialized[0] = 0x20;  // Metadata constructed TLV-Object tag.
+  size_t pos = 2;        // Leave room for length byte.
+
+  for (int i = 0; i < METADATA_TAG_COUNT; ++i) {
+    optiga_metadata_item *item =
+        (void *)((char *)metadata + METADATA_OFFSET_TAG_MAP[i].offset);
+    if (item->ptr == NULL) {
+      continue;
+    }
+
+    if (max_serialized < pos + 2 + item->len) {
+      return OPTIGA_ERR_SIZE;
+    }
+
+    serialized[pos++] = METADATA_OFFSET_TAG_MAP[i].tag;
+    serialized[pos++] = item->len;
+    memcpy(&serialized[pos], item->ptr, item->len);
+    pos += item->len;
+  }
+
+  // Set length byte.
+  if (pos - 2 > 256) {
+    return OPTIGA_ERR_SIZE;
+  }
+  serialized[1] = pos - 2;
+
+  *serialized_size = pos;
+  return OPTIGA_SUCCESS;
+}
+
+/*
+ * https://github.com/Infineon/optiga-trust-m/blob/develop/documents/OPTIGA%E2%84%A2%20Trust%20M%20Solution%20Reference%20Manual.md#openapplication
+ */
+optiga_result optiga_open_application(void) {
+  static const uint8_t OPEN_APP[] = {
+      0x70, 0x00, 0x00, 0x10, 0xD2, 0x76, 0x00, 0x00, 0x04, 0x47,
+      0x65, 0x6E, 0x41, 0x75, 0x74, 0x68, 0x41, 0x70, 0x70, 0x6C,
+  };
+
+  optiga_result ret =
+      optiga_execute_command(false, OPEN_APP, sizeof(OPEN_APP), tx_buffer,
+                             sizeof(tx_buffer), &tx_size);
+  if (ret != OPTIGA_SUCCESS) {
+    return ret;
+  }
+
+  return process_output_fixedlen(NULL, 0);
+}
+
+optiga_result optiga_get_error_code(uint8_t *error_code) {
+  size_t data_size = 0;
+  optiga_result ret =
+      optiga_get_data_object(0xf1c2, false, error_code, 1, &data_size);
+  if (ret != OPTIGA_SUCCESS) {
+    return ret;
+  }
+
+  if (data_size != 1) {
+    return OPTIGA_ERR_SIZE;
+  }
+
+  return OPTIGA_SUCCESS;
+}
+
+/*
+ * https://github.com/Infineon/optiga-trust-m/blob/develop/documents/OPTIGA%E2%84%A2%20Trust%20M%20Solution%20Reference%20Manual.md#getdataobject
+ */
+optiga_result optiga_get_data_object(uint16_t oid, bool get_metadata,
+                                     uint8_t *data, size_t max_data_size,
+                                     size_t *data_size) {
+  uint8_t get_data[6] = {0x01, 0x00, 0x00, 0x02};
+  if (get_metadata) {
+    get_data[1] = 0x01;
+  }
+  get_data[4] = oid >> 8;
+  get_data[5] = oid & 0xff;
+
+  optiga_result ret =
+      optiga_execute_command(false, get_data, sizeof(get_data), tx_buffer,
+                             sizeof(tx_buffer), &tx_size);
+  if (ret != OPTIGA_SUCCESS) {
+    return ret;
+  }
+
+  return process_output_varlen(data, max_data_size, data_size);
+}
+
+/*
+ * https://github.com/Infineon/optiga-trust-m/blob/develop/documents/OPTIGA%E2%84%A2%20Trust%20M%20Solution%20Reference%20Manual.md#setdataobject
+ */
+optiga_result optiga_set_data_object(uint16_t oid, bool set_metadata,
+                                     const uint8_t *data, size_t data_size) {
+  if (data_size + 8 > sizeof(tx_buffer)) {
+    return OPTIGA_ERR_PARAM;
+  }
+
+  tx_size = data_size + 8;
+  tx_buffer[0] = 0x02;
+  tx_buffer[1] = set_metadata ? 0x01 : 0x40;
+  tx_buffer[2] = (tx_size - 4) >> 8;
+  tx_buffer[3] = (tx_size - 4) & 0xff;
+  tx_buffer[4] = oid >> 8;
+  tx_buffer[5] = oid & 0xff;
+  tx_buffer[6] = 0;
+  tx_buffer[7] = 0;
+
+  if (data_size != 0) {
+    memcpy(tx_buffer + 8, data, data_size);
+  }
+
+  optiga_result ret = optiga_execute_command(
+      false, tx_buffer, data_size + 8, tx_buffer, sizeof(tx_buffer), &tx_size);
+  if (ret != OPTIGA_SUCCESS) {
+    memzero(tx_buffer + 8, data_size);
+    return ret;
+  }
+
+  ret = process_output_fixedlen(NULL, 0);
+  memzero(tx_buffer + 8, data_size);
+  return ret;
+}
+
+/*
+ * https://github.com/Infineon/optiga-trust-m/blob/develop/documents/OPTIGA%E2%84%A2%20Trust%20M%20Solution%20Reference%20Manual.md#getrandom
+ */
+optiga_result optiga_get_random(uint8_t *random, size_t random_size) {
+  if (random_size < 8 || random_size > 256) {
+    return OPTIGA_ERR_SIZE;
+  }
+
+  uint8_t get_random[6] = {0x0C, 0x00, 0x00, 0x02};
+  get_random[4] = random_size >> 8;
+  get_random[5] = random_size & 0xff;
+
+  optiga_result ret =
+      optiga_execute_command(false, get_random, sizeof(get_random), tx_buffer,
+                             sizeof(tx_buffer), &tx_size);
+  if (ret != OPTIGA_SUCCESS) {
+    return ret;
+  }
+
+  return process_output_fixedlen(random, random_size);
+}
+
+/*
+ * https://github.com/Infineon/optiga-trust-m/blob/develop/documents/OPTIGA%E2%84%A2%20Trust%20M%20Solution%20Reference%20Manual.md#encryptsym
+ */
+optiga_result optiga_encrypt_sym(optiga_sym_mode mode, uint16_t oid,
+                                 const uint8_t *input, size_t input_size,
+                                 uint8_t *output, size_t max_output_size,
+                                 size_t *output_size) {
+  if (input_size < 1 || input_size > 640) {
+    return OPTIGA_ERR_PARAM;
+  }
+
+  tx_size = 9 + input_size;
+  tx_buffer[0] = 0x14;
+  tx_buffer[1] = mode;
+  tx_buffer[2] = (tx_size - 4) >> 8;
+  tx_buffer[3] = (tx_size - 4) & 0xff;
+  tx_buffer[4] = oid >> 8;
+  tx_buffer[5] = oid & 0xff;
+  tx_buffer[6] = 0x01;
+  tx_buffer[7] = input_size >> 8;
+  tx_buffer[8] = input_size & 0xff;
+  memcpy(tx_buffer + 9, input, input_size);
+
+  optiga_result ret = optiga_execute_command(
+      false, tx_buffer, tx_size, tx_buffer, sizeof(tx_buffer), &tx_size);
+  if (ret == OPTIGA_SUCCESS) {
+    ret = process_output_varlen(output, max_output_size, output_size);
+  }
+
+  memzero(tx_buffer + 7, input_size);
+  return ret;
+}
+
+/*
+ * https://github.com/Infineon/optiga-trust-m/blob/develop/documents/OPTIGA%E2%84%A2%20Trust%20M%20Solution%20Reference%20Manual.md#decryptsym
+ */
+optiga_result optiga_set_auto_state(uint16_t nonce_oid, uint16_t key_oid,
+                                    const uint8_t key[32]) {
+  uint8_t nonce[16] = {0};
+  uint8_t get_random[] = {
+      0x0C, 0x00, 0x00, 0x07, 0x00, sizeof(nonce), 0x00, 0x00, 0x41, 0x00, 0x00,
+  };
+  get_random[6] = nonce_oid >> 8;
+  get_random[7] = nonce_oid & 0xff;
+
+  optiga_result ret =
+      optiga_execute_command(false, get_random, sizeof(get_random), tx_buffer,
+                             sizeof(tx_buffer), &tx_size);
+
+  ret = process_output_fixedlen(nonce, sizeof(nonce));
+  if (ret != OPTIGA_SUCCESS) {
+    return ret;
+  }
+
+  tx_size = 11 + sizeof(nonce) + 3 + 32;
+  tx_buffer[0] = 0x15;
+  tx_buffer[1] = 0x20;
+  tx_buffer[2] = 0x00;
+  tx_buffer[3] = tx_size - 4;
+  tx_buffer[4] = key_oid >> 8;
+  tx_buffer[5] = key_oid & 0xff;
+  tx_buffer[6] = 0x01;
+  tx_buffer[7] = 0x00;
+  tx_buffer[8] = 2 + sizeof(nonce);
+  tx_buffer[9] = nonce_oid >> 8;
+  tx_buffer[10] = nonce_oid & 0xff;
+  memcpy(&tx_buffer[11], nonce, sizeof(nonce));
+  tx_buffer[11 + sizeof(nonce)] = 0x43;
+  tx_buffer[12 + sizeof(nonce)] = 0x00;
+  tx_buffer[13 + sizeof(nonce)] = 0x20;
+  hmac_sha256(key, 32, nonce, sizeof(nonce), &tx_buffer[14 + sizeof(nonce)]);
+
+  ret = optiga_execute_command(false, tx_buffer, tx_size, tx_buffer,
+                               sizeof(tx_buffer), &tx_size);
+  if (ret != OPTIGA_SUCCESS) {
+    return ret;
+  }
+
+  return process_output_fixedlen(NULL, 0);
+}
+
+optiga_result optiga_clear_auto_state(uint16_t key_oid) {
+  uint8_t decrypt_sym[] = {
+      0x15, 0x20, 0x00, 0x08, 0x00, 0x00, 0x01, 0x00, 0x00, 0x43, 0x00, 0x00,
+  };
+  decrypt_sym[4] = key_oid >> 8;
+  decrypt_sym[5] = key_oid & 0xff;
+
+  optiga_result ret =
+      optiga_execute_command(false, decrypt_sym, sizeof(decrypt_sym), tx_buffer,
+                             sizeof(tx_buffer), &tx_size);
+  if (ret != OPTIGA_SUCCESS) {
+    return ret;
+  }
+
+  // Expecting no output data. Response status code should indicate failure.
+  if (tx_size != 4 || tx_buffer[0] != 0xff || tx_buffer[2] != 0 ||
+      tx_buffer[3] != 0) {
+    return OPTIGA_ERR_UNEXPECTED;
+  }
+
+  return OPTIGA_SUCCESS;
+}
+
+/*
+ * https://github.com/Infineon/optiga-trust-m/blob/develop/documents/OPTIGA%E2%84%A2%20Trust%20M%20Solution%20Reference%20Manual.md#calcsign
+ */
+optiga_result optiga_calc_sign(uint16_t oid, const uint8_t *digest,
+                               size_t digest_size, uint8_t *signature,
+                               size_t max_sig_size, size_t *sig_size) {
+  if (digest_size + 12 > sizeof(tx_buffer)) {
+    return OPTIGA_ERR_PARAM;
+  }
+
+  tx_size = digest_size + 12;
+  tx_buffer[0] = 0x31;
+  tx_buffer[1] = 0x11;
+  tx_buffer[2] = (tx_size - 4) >> 8;
+  tx_buffer[3] = (tx_size - 4) & 0xff;
+  tx_buffer[4] = 0x01;
+  tx_buffer[5] = digest_size >> 8;
+  tx_buffer[6] = digest_size & 0xff;
+  memcpy(tx_buffer + 7, digest, digest_size);
+  tx_buffer[7 + digest_size] = 0x03;
+  tx_buffer[8 + digest_size] = 0x00;
+  tx_buffer[9 + digest_size] = 0x02;
+  tx_buffer[10 + digest_size] = oid >> 8;
+  tx_buffer[11 + digest_size] = oid & 0xff;
+
+  optiga_result ret = optiga_execute_command(
+      false, tx_buffer, tx_size, tx_buffer, sizeof(tx_buffer), &tx_size);
+  if (ret != OPTIGA_SUCCESS) {
+    return ret;
+  }
+
+  return process_output_varlen(signature, max_sig_size, sig_size);
+}
+
+/*
+ * https://github.com/Infineon/optiga-trust-m/blob/develop/documents/OPTIGA%E2%84%A2%20Trust%20M%20Solution%20Reference%20Manual.md#genkeypair
+ */
+optiga_result optiga_gen_key_pair(optiga_curve curve, optiga_key_usage usage,
+                                  uint16_t oid, uint8_t *public_key,
+                                  size_t max_public_key_size,
+                                  size_t *public_key_size) {
+  tx_size = 13;
+  tx_buffer[0] = 0x38;
+  tx_buffer[1] = curve;
+  tx_buffer[2] = 0x00;
+  tx_buffer[3] = 0x09;
+  tx_buffer[4] = 0x01;
+  tx_buffer[5] = 0x00;
+  tx_buffer[6] = 0x02;
+  tx_buffer[7] = oid >> 8;
+  tx_buffer[8] = oid & 0xff;
+  tx_buffer[9] = 0x02;
+  tx_buffer[10] = 0x00;
+  tx_buffer[11] = 0x01;
+  tx_buffer[12] = usage;
+
+  optiga_result ret = optiga_execute_command(
+      false, tx_buffer, tx_size, tx_buffer, sizeof(tx_buffer), &tx_size);
+  if (ret != OPTIGA_SUCCESS) {
+    return ret;
+  }
+
+  return process_output_varlen(public_key, max_public_key_size,
+                               public_key_size);
+}
+
+/*
+ * https://github.com/Infineon/optiga-trust-m/blob/develop/documents/OPTIGA%E2%84%A2%20Trust%20M%20Solution%20Reference%20Manual.md#gensymkey
+ */
+optiga_result optiga_gen_sym_key(optiga_aes algorithm, optiga_key_usage usage,
+                                 uint16_t oid) {
+  tx_size = 13;
+  tx_buffer[0] = 0x39;
+  tx_buffer[1] = algorithm;
+  tx_buffer[2] = 0x00;
+  tx_buffer[3] = 0x09;
+  tx_buffer[4] = 0x01;
+  tx_buffer[5] = 0x00;
+  tx_buffer[6] = 0x02;
+  tx_buffer[7] = oid >> 8;
+  tx_buffer[8] = oid & 0xff;
+  tx_buffer[9] = 0x02;
+  tx_buffer[10] = 0x00;
+  tx_buffer[11] = 0x01;
+  tx_buffer[12] = usage;
+
+  optiga_result ret = optiga_execute_command(
+      false, tx_buffer, tx_size, tx_buffer, sizeof(tx_buffer), &tx_size);
+  if (ret != OPTIGA_SUCCESS) {
+    return ret;
+  }
+
+  return process_output_fixedlen(NULL, 0);
+}
+
+/*
+ * https://github.com/Infineon/optiga-trust-m/blob/develop/documents/OPTIGA%E2%84%A2%20Trust%20M%20Solution%20Reference%20Manual.md#calcssec
+ */
+optiga_result optiga_calc_ssec(optiga_curve curve, uint16_t oid,
+                               const uint8_t *public_key,
+                               size_t public_key_size, uint8_t *secret,
+                               size_t max_secret_size, size_t *secret_size) {
+  // Size of a P521 public key encode as a DER BIT STRING.
+  static const size_t MAX_PUBKEY_SIZE = 5 + 2 * 66;
+
+  if (public_key_size > MAX_PUBKEY_SIZE) {
+    return OPTIGA_ERR_PARAM;
+  }
+
+  tx_size = 16 + public_key_size + 3;
+  tx_buffer[0] = 0x33;
+  tx_buffer[1] = 0x01;
+  tx_buffer[2] = 0x00;
+  tx_buffer[3] = tx_size - 4;
+  tx_buffer[4] = 0x01;
+  tx_buffer[5] = 0x00;
+  tx_buffer[6] = 0x02;
+  tx_buffer[7] = oid >> 8;
+  tx_buffer[8] = oid & 0xff;
+  tx_buffer[9] = 0x05;
+  tx_buffer[10] = 0x00;
+  tx_buffer[11] = 0x01;
+  tx_buffer[12] = curve;
+  tx_buffer[13] = 0x06;
+  tx_buffer[14] = 0x00;
+  tx_buffer[15] = public_key_size;
+  memcpy(&tx_buffer[16], public_key, public_key_size);
+  tx_buffer[16 + public_key_size] = 0x07;
+  tx_buffer[17 + public_key_size] = 0x00;
+  tx_buffer[18 + public_key_size] = 0x00;
+
+  optiga_result ret = optiga_execute_command(
+      false, tx_buffer, tx_size, tx_buffer, sizeof(tx_buffer), &tx_size);
+  if (ret != OPTIGA_SUCCESS) {
+    return ret;
+  }
+
+  return process_output_varlen(secret, max_secret_size, secret_size);
+}
+
+/*
+ * https://github.com/Infineon/optiga-trust-m/blob/develop/documents/OPTIGA%E2%84%A2%20Trust%20M%20Solution%20Reference%20Manual.md#derivekey
+ */
+optiga_result optiga_derive_key(optiga_key_derivation deriv, uint16_t oid,
+                                const uint8_t *salt, size_t salt_size,
+                                uint8_t *info, size_t info_size, uint8_t *key,
+                                size_t key_size) {
+  const bool is_hkdf =
+      (deriv == OPTIGA_DERIV_HKDF_SHA256 || deriv == OPTIGA_DERIV_HKDF_SHA384 ||
+       deriv == OPTIGA_DERIV_HKDF_SHA512);
+
+  if (salt_size > 1024 || (!is_hkdf && salt_size < 8)) {
+    return OPTIGA_ERR_PARAM;
+  }
+
+  if (info_size > 256 || (!is_hkdf && info_size != 0)) {
+    return OPTIGA_ERR_PARAM;
+  }
+
+  tx_size = is_hkdf ? 23 + salt_size + info_size : 20 + salt_size;
+  tx_buffer[0] = 0x34;
+  tx_buffer[1] = deriv;
+  tx_buffer[2] = (tx_size - 4) >> 8;
+  tx_buffer[3] = (tx_size - 4) & 0xff;
+  tx_buffer[4] = 0x01;
+  tx_buffer[5] = 0x00;
+  tx_buffer[6] = 0x02;
+  tx_buffer[7] = oid >> 8;
+  tx_buffer[8] = oid & 0xff;
+  tx_buffer[9] = 0x02;
+  tx_buffer[10] = salt_size >> 8;
+  tx_buffer[11] = salt_size & 0xff;
+  if (salt_size != 0) {
+    memcpy(&tx_buffer[12], salt, salt_size);
+  }
+  tx_buffer[12 + salt_size] = 0x03;
+  tx_buffer[13 + salt_size] = 0x00;
+  tx_buffer[14 + salt_size] = 0x02;
+  tx_buffer[15 + salt_size] = key_size >> 8;
+  tx_buffer[16 + salt_size] = key_size & 0xff;
+
+  if (is_hkdf) {
+    tx_buffer[17 + salt_size] = 0x04;
+    tx_buffer[18 + salt_size] = info_size >> 8;
+    tx_buffer[19 + salt_size] = info_size & 0xff;
+    if (info_size != 0) {
+      memcpy(&tx_buffer[20 + salt_size], info, info_size);
+    }
+    tx_buffer[20 + salt_size + info_size] = 0x07;
+    tx_buffer[21 + salt_size + info_size] = 0x00;
+    tx_buffer[22 + salt_size + info_size] = 0x00;
+  } else {
+    tx_buffer[17 + salt_size] = 0x07;
+    tx_buffer[18 + salt_size] = 0x00;
+    tx_buffer[19 + salt_size] = 0x00;
+  }
+
+  optiga_result ret = optiga_execute_command(
+      false, tx_buffer, tx_size, tx_buffer, sizeof(tx_buffer), &tx_size);
+  if (ret == OPTIGA_SUCCESS) {
+    ret = process_output_fixedlen(key, key_size);
+  }
+
+  memzero(&tx_buffer[12], salt_size);
+  memzero(&tx_buffer[20 + salt_size], info_size);
+  return ret;
+}
+
+optiga_result optiga_set_trust_anchor(void) {
+  // Trust anchor certificate.
+  const uint8_t TA_CERT[] = {
+      0x30, 0x82, 0x01, 0x49, 0x30, 0x81, 0xf0, 0xa0, 0x03, 0x02, 0x01, 0x02,
+      0x02, 0x01, 0x01, 0x30, 0x0a, 0x06, 0x08, 0x2a, 0x86, 0x48, 0xce, 0x3d,
+      0x04, 0x03, 0x02, 0x30, 0x0d, 0x31, 0x0b, 0x30, 0x09, 0x06, 0x03, 0x55,
+      0x04, 0x03, 0x0c, 0x02, 0x54, 0x41, 0x30, 0x20, 0x17, 0x0d, 0x32, 0x33,
+      0x30, 0x37, 0x32, 0x34, 0x31, 0x35, 0x31, 0x31, 0x34, 0x37, 0x5a, 0x18,
+      0x0f, 0x32, 0x30, 0x35, 0x33, 0x30, 0x37, 0x32, 0x33, 0x31, 0x35, 0x31,
+      0x31, 0x34, 0x37, 0x5a, 0x30, 0x0d, 0x31, 0x0b, 0x30, 0x09, 0x06, 0x03,
+      0x55, 0x04, 0x03, 0x0c, 0x02, 0x54, 0x41, 0x30, 0x59, 0x30, 0x13, 0x06,
+      0x07, 0x2a, 0x86, 0x48, 0xce, 0x3d, 0x02, 0x01, 0x06, 0x08, 0x2a, 0x86,
+      0x48, 0xce, 0x3d, 0x03, 0x01, 0x07, 0x03, 0x42, 0x00, 0x04, 0x9b, 0xbf,
+      0x06, 0xda, 0xd9, 0xab, 0x59, 0x05, 0xe0, 0x54, 0x71, 0xce, 0x16, 0xd5,
+      0x22, 0x2c, 0x89, 0xc2, 0xca, 0xa3, 0x9f, 0x26, 0x26, 0x7a, 0xc0, 0x74,
+      0x71, 0x29, 0x88, 0x5f, 0xbd, 0x44, 0x1b, 0xcc, 0x7f, 0xa8, 0x4d, 0xe1,
+      0x20, 0xa3, 0x67, 0x55, 0xda, 0xf3, 0x0a, 0x6f, 0x47, 0xe8, 0xc0, 0xd4,
+      0xbd, 0xdc, 0x15, 0x03, 0x6e, 0xd2, 0xa3, 0x44, 0x7d, 0xfa, 0x7a, 0x1d,
+      0x3e, 0x88, 0xa3, 0x3f, 0x30, 0x3d, 0x30, 0x0c, 0x06, 0x03, 0x55, 0x1d,
+      0x13, 0x01, 0x01, 0xff, 0x04, 0x02, 0x30, 0x00, 0x30, 0x0e, 0x06, 0x03,
+      0x55, 0x1d, 0x0f, 0x01, 0x01, 0xff, 0x04, 0x04, 0x03, 0x02, 0x07, 0x80,
+      0x30, 0x1d, 0x06, 0x03, 0x55, 0x1d, 0x0e, 0x04, 0x16, 0x04, 0x14, 0x68,
+      0x36, 0xfc, 0x5d, 0x40, 0xb5, 0xbe, 0x47, 0xd4, 0xb0, 0xe2, 0x46, 0x7a,
+      0xfe, 0x54, 0x3d, 0x8a, 0xd7, 0x0e, 0x26, 0x30, 0x0a, 0x06, 0x08, 0x2a,
+      0x86, 0x48, 0xce, 0x3d, 0x04, 0x03, 0x02, 0x03, 0x48, 0x00, 0x30, 0x45,
+      0x02, 0x21, 0x00, 0xff, 0x39, 0x3d, 0x00, 0x1d, 0x9f, 0x88, 0xdc, 0xc1,
+      0x58, 0x12, 0x68, 0xa5, 0x7f, 0x06, 0x18, 0x1e, 0x65, 0x77, 0x88, 0x12,
+      0xcb, 0xa5, 0x9d, 0x47, 0xd0, 0x17, 0x85, 0xcd, 0xb8, 0xdc, 0xaa, 0x02,
+      0x20, 0x08, 0xb8, 0xbe, 0x65, 0xd4, 0xbe, 0x31, 0xe7, 0x74, 0x64, 0x46,
+      0xfb, 0xe7, 0x70, 0x48, 0x02, 0xd1, 0x08, 0x64, 0xf8, 0xe8, 0x4e, 0xfc,
+      0xb0, 0xa5, 0x21, 0x2c, 0x54, 0x3a, 0x6c, 0x04, 0x72,
+  };
+
+  return optiga_set_data_object(0xe0e8, false, TA_CERT, sizeof(TA_CERT));
+}
+
+/*
+ * https://github.com/Infineon/optiga-trust-m/blob/develop/documents/OPTIGA%E2%84%A2%20Trust%20M%20Solution%20Reference%20Manual.md#setobjectprotected
+ */
+optiga_result optiga_set_priv_key(uint16_t oid, const uint8_t priv_key[32]) {
+  uint8_t metadata_buffer[256] = {0};
+  size_t metadata_size = 0;
+  optiga_result ret = optiga_get_data_object(
+      oid, true, metadata_buffer, sizeof(metadata_buffer), &metadata_size);
+  if (ret != OPTIGA_SUCCESS) {
+    return ret;
+  }
+
+  optiga_metadata metadata = {0};
+  ret = optiga_parse_metadata(metadata_buffer, metadata_size, &metadata);
+  if (ret != OPTIGA_SUCCESS) {
+    return ret;
+  }
+
+  uint16_t payload_version = 0;
+  if (metadata.version.ptr != NULL) {
+    if (metadata.version.len != 2) {
+      return OPTIGA_ERR_UNEXPECTED;
+    }
+    payload_version = (metadata.version.ptr[0] << 8) + metadata.version.ptr[1];
+  }
+  payload_version += 1;
+
+  if (payload_version > 23) {
+    // CBOR integer encoding not implemented.
+    return OPTIGA_ERR_PARAM;
+  }
+
+  // Trust anchor private key.
+  const uint8_t TA_PRIV_KEY[32] = {1};
+
+  // First part of the SetObjectProtected command containing the manifest.
+  uint8_t sop_cmd1[145] = {
+      0x03, 0x01, 0x00, 0x8d, 0x30, 0x00, 0x8a, 0x84, 0x43, 0xA1, 0x01, 0x26,
+      0xA1, 0x04, 0x42, 0xE0, 0xE8, 0x58, 0x3C, 0x86, 0x01, 0xF6, 0xF6, 0x84,
+      0x22, 0x18, 0x23, 0x03, 0x82, 0x03, 0x10, 0x82, 0x82, 0x20, 0x58, 0x25,
+      0x82, 0x18, 0x29, 0x58, 0x20, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
+      0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
+      0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
+      0x00, 0xF6, 0x82, 0x40, 0x42, 0xE0, 0xF2, 0x58, 0x40,
+  };
+
+  // Second part of the SetObjectProtected command containing the fragment
+  // with the private key.
+  uint8_t sop_cmd2[42] = {
+      0x03, 0x01, 0x00, 0x26, 0x31, 0x00, 0x23, 0x01, 0x00, 0x20,
+  };
+
+  memcpy(&sop_cmd2[10], &priv_key[0], 32);
+
+  sha256_Raw(&sop_cmd2[7], 35, &sop_cmd1[41]);
+
+  sop_cmd1[27] = payload_version;
+  sop_cmd1[77] = oid >> 8;
+  sop_cmd1[78] = oid & 0xff;
+  // NOTE sop_cmd1[26] = fragment length (1 + 2 + 32)
+  // NOTE sop_cmd1[30] = key usage
+
+  const uint8_t signature_header[] = {
+      0x84, 0x4A, 0x53, 0x69, 0x67, 0x6E, 0x61, 0x74, 0x75,
+      0x72, 0x65, 0x31, 0x43, 0xA1, 0x01, 0x26, 0x40,
+  };
+  uint8_t digest[SHA256_DIGEST_LENGTH] = {0};
+  SHA256_CTX context = {0};
+  sha256_Init(&context);
+  sha256_Update(&context, signature_header, sizeof(signature_header));
+  sha256_Update(&context, &sop_cmd1[17], 62);
+  sha256_Final(&context, digest);
+
+  if (0 != ecdsa_sign_digest(&nist256p1, TA_PRIV_KEY, digest, &sop_cmd1[81],
+                             NULL, NULL)) {
+    memzero(sop_cmd2, sizeof(sop_cmd2));
+    return OPTIGA_ERR_PROCESS;
+  }
+
+  ret = optiga_execute_command(false, sop_cmd1, sizeof(sop_cmd1), tx_buffer,
+                               sizeof(tx_buffer), &tx_size);
+  if (ret != OPTIGA_SUCCESS) {
+    memzero(sop_cmd2, sizeof(sop_cmd2));
+    return ret;
+  }
+
+  ret = process_output_fixedlen(NULL, 0);
+  if (ret != OPTIGA_SUCCESS) {
+    memzero(sop_cmd2, sizeof(sop_cmd2));
+    return ret;
+  }
+
+  ret = optiga_execute_command(false, sop_cmd2, sizeof(sop_cmd2), tx_buffer,
+                               sizeof(tx_buffer), &tx_size);
+  memzero(sop_cmd2, sizeof(sop_cmd2));
+  if (ret != OPTIGA_SUCCESS) {
+    return ret;
+  }
+
+  return process_output_fixedlen(NULL, 0);
+}

--- a/core/embed/trezorhal/optiga/optiga_transport.c
+++ b/core/embed/trezorhal/optiga/optiga_transport.c
@@ -1,0 +1,506 @@
+/*
+ * This file is part of the Trezor project, https://trezor.io/
+ *
+ * Copyright (c) SatoshiLabs
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+/*
+ * Reference manual:
+ * https://github.com/Infineon/optiga-trust-m/blob/develop/documents/Infineon_I2C_Protocol_v2.03.pdf
+ */
+
+#include "optiga_transport.h"
+#include <string.h>
+#include "common.h"
+#include "i2c.h"
+#include "optiga_hal.h"
+#include TREZOR_BOARD
+
+// Maximum possible packet size that can be transmitted.
+#define OPTIGA_MAX_PACKET_SIZE (OPTIGA_DATA_REG_LEN - 5)
+
+// Register address of the data register.
+static const uint8_t REG_DATA = 0x80;
+
+// Register address of the register holding the maximum data register length (2
+// bytes).
+static const uint8_t REG_DATA_LEN = 0x81;
+
+// Register address of the I2C state register (4 bytes).
+static const uint8_t REG_I2C_STATE = 0x82;
+
+// Register address of the register that triggers a warm device reset.
+static const uint8_t REG_SOFT_RESET = 0x88;
+
+// I2C state register - Device is busy executing a command.
+static const uint8_t I2C_STATE_BYTE1_BUSY = 0x80;
+
+// I2C state register - Device is ready to return a response.
+static const uint8_t I2C_STATE_BYTE1_RESP_RDY = 0x40;
+
+// I2C base address of Optiga.
+static const uint8_t BASE_ADDR = 0x30;
+
+// Address of Optiga use by our HAL which requires it to be shifted by one bit.
+static const uint16_t OPTIGA_ADDRESS = (BASE_ADDR << 1);
+
+// Constants for our I2C HAL.
+static const uint32_t I2C_TIMEOUT = 15;
+static const int I2C_MAX_RETRY_COUNT = 10;
+
+// Maximum number of times to retry reading Optiga's response to a command.
+static const int MAX_RETRY_READ = 10000;
+
+// Maximum number of packets per response. Used for flushing old reponses.
+static const int MAX_RESPONSE_PACKET_COUNT = 15;
+
+// Frame control byte - Type.
+static const uint8_t FTYPE_MASK = 0x80;
+static const uint8_t FTYPE_DATA = 0x00;
+static const uint8_t FTYPE_CONTROL = 0x80;
+
+// Frame control byte - Sequence.
+static const uint8_t SEQCTR_ACK = 0x00;    // Acknowledge received frame ACKNR.
+static const uint8_t SEQCTR_RESET = 0x40;  // Reset frame counter for sync.
+static const uint8_t SEQCTR_MASK = 0x60;   // Mask of SEQCTR bits.
+
+// Frame control byte - Frame number.
+static const uint8_t FRNR_MASK = 0x0C;
+static const uint8_t FRNR_SHIFT = 2;
+static const uint8_t ACKNR_MASK = 0x03;
+
+// Packet control byte.
+enum {
+  PCTR_PRESENTATION_LAYER = 0x08,  // Presentation layer present.
+  PCTR_CHAIN_NONE = 0x00,          // No chaining. Single frame.
+  PCTR_CHAIN_FIRST = 0x01,         // First packet of a chain.
+  PCTR_CHAIN_MIDDLE = 0x02,        // Intermediate packet(s) of a chain.
+  PCTR_CHAIN_LAST = 0x04,          // Last packet of a chain.
+  PCTR_CHAIN_MASK = 0x07,          // Mask of chain field.
+};
+
+static uint8_t frame_num_out = 0xff;
+static uint8_t frame_num_in = 0xff;
+static uint8_t frame_buffer[1 + OPTIGA_DATA_REG_LEN];
+static size_t frame_size = 0;  // Set by optiga_read().
+
+#ifdef NDEBUG
+#define OPTIGA_LOG(prefix, data, data_size)
+#else
+static optiga_log_hex_t log_hex = NULL;
+void optiga_set_log_hex(optiga_log_hex_t f) { log_hex = f; }
+#define OPTIGA_LOG(prefix, data, data_size) \
+  if (log_hex != NULL) {                    \
+    log_hex(prefix, data, data_size);       \
+  }
+#endif
+
+static uint16_t calc_crc_byte(uint16_t seed, uint8_t c) {
+  uint16_t h1 = (seed ^ c) & 0xFF;
+  uint16_t h2 = h1 & 0x0F;
+  uint16_t h3 = (h2 << 4) ^ h1;
+  uint16_t h4 = h3 >> 4;
+  return (((((h3 << 1) ^ h4) << 4) ^ h2) << 3) ^ h4 ^ (seed >> 8);
+}
+
+static uint16_t calc_crc(uint8_t *data, size_t data_size) {
+  uint16_t crc = 0;
+  for (size_t i = 0; i < data_size; ++i) {
+    crc = calc_crc_byte(crc, data[i]);
+  }
+  return crc;
+}
+
+optiga_result optiga_init(void) {
+  optiga_hal_init();
+  return optiga_set_data_reg_len(OPTIGA_DATA_REG_LEN);
+}
+
+static optiga_result optiga_i2c_write(const uint8_t *data, uint16_t data_size) {
+  OPTIGA_LOG(">>> ", data, data_size)
+
+  for (int try_count = 0; try_count <= I2C_MAX_RETRY_COUNT; ++try_count) {
+    if (try_count != 0) {
+      hal_delay(1);
+    }
+    if (HAL_OK == i2c_transmit(OPTIGA_I2C_INSTANCE, OPTIGA_ADDRESS,
+                               (uint8_t *)data, data_size, I2C_TIMEOUT)) {
+      return OPTIGA_SUCCESS;
+    }
+  }
+  return OPTIGA_ERR_I2C_WRITE;
+}
+
+static optiga_result optiga_i2c_read(uint8_t *buffer, uint16_t buffer_size) {
+  for (int try_count = 0; try_count <= I2C_MAX_RETRY_COUNT; ++try_count) {
+    HAL_Delay(1);
+    if (HAL_OK == i2c_receive(OPTIGA_I2C_INSTANCE, OPTIGA_ADDRESS, buffer,
+                              buffer_size, I2C_TIMEOUT)) {
+      OPTIGA_LOG("<<< ", buffer, buffer_size)
+      return OPTIGA_SUCCESS;
+    }
+  }
+  return OPTIGA_ERR_I2C_READ;
+}
+
+optiga_result optiga_resync(void) {
+  frame_num_out = 0xff;
+  frame_num_in = 0xff;
+  uint8_t data[6] = {REG_DATA, FTYPE_CONTROL | SEQCTR_RESET, 0, 0};
+  uint16_t crc = calc_crc(&data[1], 3);
+  data[4] = crc >> 8;
+  data[5] = crc & 0xff;
+  return optiga_i2c_write(data, sizeof(data));
+}
+
+optiga_result optiga_soft_reset(void) {
+  uint8_t data[3] = {REG_SOFT_RESET, 0xff, 0xff};
+  optiga_result ret = optiga_i2c_write(data, sizeof(data));
+  if (ret != OPTIGA_SUCCESS) {
+    return ret;
+  }
+
+  frame_num_out = 0xff;
+  frame_num_in = 0xff;
+
+  return OPTIGA_SUCCESS;
+}
+
+static optiga_result optiga_send_ack(void) {
+  // Set up frame control information.
+  uint8_t fctr = FTYPE_CONTROL | SEQCTR_ACK;
+  fctr |= (frame_num_in & ACKNR_MASK);
+
+  // Compile frame.
+  frame_buffer[0] = REG_DATA;
+  frame_buffer[1] = fctr;
+  frame_buffer[2] = 0;
+  frame_buffer[3] = 0;
+  uint16_t crc = calc_crc(&frame_buffer[1], 3);
+  frame_buffer[4] = crc >> 8;
+  frame_buffer[5] = crc & 0xff;
+
+  return optiga_i2c_write(frame_buffer, 6);
+}
+
+static optiga_result optiga_check_ack(void) {
+  // Expected frame control information byte.
+  uint8_t fctr = FTYPE_CONTROL | SEQCTR_ACK;
+  fctr |= (frame_num_out & ACKNR_MASK);
+
+  optiga_result ret = OPTIGA_SUCCESS;
+  if (frame_size != 3 || frame_buffer[0] != fctr || frame_buffer[1] != 0 ||
+      frame_buffer[2] != 0) {
+    ret = OPTIGA_ERR_UNEXPECTED;
+  }
+
+  frame_size = 0;
+  return ret;
+}
+
+static optiga_result optiga_ensure_ready(void) {
+  optiga_result ret = OPTIGA_SUCCESS;
+  for (int i = 0; i < MAX_RESPONSE_PACKET_COUNT; ++i) {
+    for (int j = 0; j < MAX_RETRY_READ; ++j) {
+      ret = optiga_i2c_write(&REG_I2C_STATE, 1);
+      if (OPTIGA_SUCCESS != ret) {
+        return ret;
+      }
+
+      ret = optiga_i2c_read(frame_buffer, 4);
+      if (OPTIGA_SUCCESS != ret) {
+        return ret;
+      }
+
+      if ((frame_buffer[0] & I2C_STATE_BYTE1_BUSY) == 0) {
+        break;
+      }
+      ret = OPTIGA_ERR_BUSY;
+    }
+
+    if (ret != OPTIGA_SUCCESS) {
+      return ret;
+    }
+
+    if ((frame_buffer[0] & I2C_STATE_BYTE1_RESP_RDY) == 0) {
+      return OPTIGA_SUCCESS;
+    }
+
+    // Flush out the previous response.
+
+    uint16_t size = (frame_buffer[2] << 8) + frame_buffer[3];
+    if (size > sizeof(frame_buffer)) {
+      return OPTIGA_ERR_SIZE;
+    }
+
+    ret = optiga_i2c_write(&REG_DATA, 1);
+    if (OPTIGA_SUCCESS != ret) {
+      return ret;
+    }
+
+    ret = optiga_i2c_read(frame_buffer, size);
+    if (OPTIGA_SUCCESS != ret) {
+      return ret;
+    }
+
+    if (size < 3) {
+      return OPTIGA_ERR_UNEXPECTED;
+    }
+
+    // Ignore CRC.
+    frame_size = size - 2;
+
+    if ((frame_buffer[0] & FTYPE_MASK) == FTYPE_DATA) {
+      // Sync frame numbers with Optiga.
+      frame_num_in = (frame_buffer[0] & FRNR_MASK) >> FRNR_SHIFT;
+      frame_num_out = frame_buffer[0] & ACKNR_MASK;
+      ret = optiga_send_ack();
+      if (OPTIGA_SUCCESS != ret) {
+        return ret;
+      }
+    } else {
+      if ((frame_buffer[0] & SEQCTR_MASK) == SEQCTR_RESET) {
+        frame_num_out = 0xff;
+        frame_num_in = 0xff;
+      }
+    }
+  }
+
+  return OPTIGA_ERR_TIMEOUT;
+}
+
+optiga_result optiga_set_data_reg_len(size_t size) {
+  if (size > 0xffff) {
+    return OPTIGA_ERR_SIZE;
+  }
+
+  // Set the new data register length.
+  uint8_t data[3] = {REG_DATA_LEN, size >> 8, size & 0xff};
+  optiga_result ret = optiga_i2c_write(data, sizeof(data));
+  if (ret != OPTIGA_SUCCESS) {
+    return ret;
+  }
+
+  // Check that the length was set correctly.
+  ret = optiga_i2c_write(&REG_DATA_LEN, 1);
+  if (OPTIGA_SUCCESS != ret) {
+    return ret;
+  }
+
+  ret = optiga_i2c_read(frame_buffer, 2);
+  if (OPTIGA_SUCCESS != ret) {
+    return ret;
+  }
+
+  if ((frame_buffer[0] << 8) + frame_buffer[1] != size) {
+    return OPTIGA_ERR_SIZE;
+  }
+  return OPTIGA_SUCCESS;
+}
+
+static optiga_result optiga_read(void) {
+  for (int i = 0; i < MAX_RETRY_READ; ++i) {
+    optiga_result ret = optiga_i2c_write(&REG_I2C_STATE, 1);
+    if (OPTIGA_SUCCESS != ret) {
+      return ret;
+    }
+
+    ret = optiga_i2c_read(frame_buffer, 4);
+    if (OPTIGA_SUCCESS != ret) {
+      return ret;
+    }
+
+    if (frame_buffer[0] & I2C_STATE_BYTE1_RESP_RDY) {
+      uint16_t size = (frame_buffer[2] << 8) + frame_buffer[3];
+      if (size > sizeof(frame_buffer)) {
+        return OPTIGA_ERR_SIZE;
+      }
+
+      ret = optiga_i2c_write(&REG_DATA, 1);
+      if (OPTIGA_SUCCESS != ret) {
+        return ret;
+      }
+
+      ret = optiga_i2c_read(frame_buffer, size);
+      if (OPTIGA_SUCCESS != ret) {
+        return ret;
+      }
+
+      if (calc_crc(frame_buffer, size - 2) !=
+          (frame_buffer[size - 2] << 8) + frame_buffer[size - 1]) {
+        return OPTIGA_ERR_CRC;
+      }
+
+      frame_size = size - 2;
+
+      return OPTIGA_SUCCESS;
+    }
+  }
+
+  return OPTIGA_ERR_TIMEOUT;
+}
+
+static optiga_result optiga_send_packet(uint8_t packet_control_byte,
+                                        const uint8_t *packet_data,
+                                        size_t packet_data_size) {
+  _Static_assert(sizeof(frame_buffer) - 7 >= OPTIGA_MAX_PACKET_SIZE - 1);
+
+  if (packet_data_size > sizeof(frame_buffer) - 7) {
+    return OPTIGA_ERR_SIZE;
+  }
+
+  // Set up frame control information.
+  uint8_t fctr = FTYPE_DATA | SEQCTR_ACK;
+  fctr |= (frame_num_out << FRNR_SHIFT) & FRNR_MASK;
+  fctr |= (frame_num_in & ACKNR_MASK);
+
+  // Compile frame.
+  frame_buffer[0] = REG_DATA;
+  frame_buffer[1] = fctr;
+  frame_buffer[2] = (packet_data_size + 1) >> 8;
+  frame_buffer[3] = (packet_data_size + 1) & 0xff;
+  frame_buffer[4] = packet_control_byte;
+  memcpy(&frame_buffer[5], packet_data, packet_data_size);
+  uint16_t crc = calc_crc(&frame_buffer[1], packet_data_size + 4);
+  frame_buffer[packet_data_size + 5] = crc >> 8;
+  frame_buffer[packet_data_size + 6] = crc & 0xff;
+
+  return optiga_i2c_write(frame_buffer, packet_data_size + 7);
+}
+
+static optiga_result optiga_receive_packet(uint8_t *packet_control_byte,
+                                           uint8_t *packet_data,
+                                           size_t max_packet_data_size,
+                                           size_t *packet_data_size) {
+  // Expected frame control information byte.
+  uint8_t fctr = FTYPE_DATA | SEQCTR_ACK;
+  fctr |= (frame_num_in << FRNR_SHIFT) & FRNR_MASK;
+  fctr |= (frame_num_out & ACKNR_MASK);
+  *packet_data_size = (frame_buffer[1] << 8) + frame_buffer[2] - 1;
+  if (frame_size < 3 || frame_buffer[0] != fctr ||
+      *packet_data_size + 4 != frame_size) {
+    frame_size = 0;
+    return OPTIGA_ERR_UNEXPECTED;
+  }
+  frame_size = 0;
+
+  if (*packet_data_size > max_packet_data_size) {
+    return OPTIGA_ERR_SIZE;
+  }
+
+  *packet_control_byte = frame_buffer[3];
+  memcpy(packet_data, &frame_buffer[4], *packet_data_size);
+  return OPTIGA_SUCCESS;
+}
+
+optiga_result optiga_execute_command(
+    bool presentation_layer, const uint8_t *command_data, size_t command_size,
+    uint8_t *response_data, size_t max_response_size, size_t *response_size) {
+  *response_size = 0;
+  optiga_result ret = optiga_ensure_ready();
+  if (ret != OPTIGA_SUCCESS) {
+    return ret;
+  }
+
+  uint8_t pctr = 0;
+  if (presentation_layer) {
+    pctr |= PCTR_PRESENTATION_LAYER;
+  }
+
+  // Transmit command packets to OPTIGA.
+  uint8_t chain = PCTR_CHAIN_NONE;
+  do {
+    size_t packet_data_size = 0;
+    // The first byte of each packet is the packet control byte pctr, so each
+    // packet contains at most OPTIGA_MAX_PACKET_SIZE - 1 bytes of data.
+    if (command_size > OPTIGA_MAX_PACKET_SIZE - 1) {
+      packet_data_size = OPTIGA_MAX_PACKET_SIZE - 1;
+      if (chain == PCTR_CHAIN_NONE) {
+        chain = PCTR_CHAIN_FIRST;
+      } else {
+        chain = PCTR_CHAIN_MIDDLE;
+      }
+    } else {
+      packet_data_size = command_size;
+      if (chain != PCTR_CHAIN_NONE) {
+        chain = PCTR_CHAIN_LAST;
+      }
+    }
+
+    frame_num_out += 1;
+
+    ret = optiga_send_packet(pctr | chain, command_data, packet_data_size);
+    if (ret != OPTIGA_SUCCESS) {
+      return ret;
+    }
+
+    command_data += packet_data_size;
+    command_size -= packet_data_size;
+
+    ret = optiga_read();
+    if (ret != OPTIGA_SUCCESS) {
+      return ret;
+    }
+
+    if ((frame_buffer[0] & FTYPE_MASK) == FTYPE_DATA) {
+      // OPTIGA sometimes doesn't send a separate control frame to ACK receipt,
+      // but responds directly with data. It may also respond with data instead
+      // of an ACK if there is an error in a multi-packet transmission.
+      break;
+    }
+
+    ret = optiga_check_ack();
+    if (ret != OPTIGA_SUCCESS) {
+      return ret;
+    }
+  } while (command_size != 0);
+
+  // Receive response packets from OPTIGA.
+  do {
+    frame_num_in += 1;
+
+    // Read only if there is no pending data in the frame buffer. (There will
+    // already be data if OPTIGA didn't send a separate control frame in the
+    // previous loop.)
+    if (frame_size == 0) {
+      ret = optiga_read();
+      if (ret != OPTIGA_SUCCESS) {
+        return ret;
+      }
+    }
+
+    size_t packet_data_size = 0;
+    ret = optiga_receive_packet(&pctr, response_data, max_response_size,
+                                &packet_data_size);
+    if (ret != OPTIGA_SUCCESS) {
+      *response_size = 0;
+      return ret;
+    }
+    *response_size += packet_data_size;
+    response_data += packet_data_size;
+    max_response_size -= packet_data_size;
+
+    ret = optiga_send_ack();
+    if (ret != OPTIGA_SUCCESS) {
+      *response_size = 0;
+      return ret;
+    }
+
+    pctr &= PCTR_CHAIN_MASK;
+  } while (pctr == PCTR_CHAIN_FIRST || pctr == PCTR_CHAIN_MIDDLE);
+
+  return command_size == 0 ? OPTIGA_SUCCESS : OPTIGA_ERR_CMD;
+}

--- a/core/embed/trezorhal/optiga_commands.h
+++ b/core/embed/trezorhal/optiga_commands.h
@@ -1,0 +1,144 @@
+/*
+ * This file is part of the Trezor project, https://trezor.io/
+ *
+ * Copyright (c) SatoshiLabs
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#ifndef TREZORHAL_OPTIGA_COMMANDS_H
+#define TREZORHAL_OPTIGA_COMMANDS_H
+
+#include <stdbool.h>
+#include <stddef.h>
+#include <stdint.h>
+#include "optiga_common.h"
+
+// ECC curve identifiers.
+typedef enum {
+  OPTIGA_CURVE_P256 = 0x03,  // NIST P256 ECC key.
+  OPTIGA_CURVE_P384 = 0x04,  // NIST P384 ECC key.
+  OPTIGA_CURVE_P521 = 0x05,  // NIST P521 ECC key.
+} optiga_curve;
+
+// AES algorithm identifiers.
+typedef enum {
+  OPTIGA_AES_128 = 0x81,  // AES-128 key.
+  OPTIGA_AES_192 = 0x82,  // AES-192 key.
+  OPTIGA_AES_256 = 0x83,  // AES-256 key.
+} optiga_aes;
+
+// Key usage identifiers.
+typedef enum {
+  OPTIGA_KEY_USAGE_AUTH = 0x01,      // Authentication.
+  OPTIGA_KEY_USAGE_ENC = 0x02,       // Encryption, decryption, key transport.
+  OPTIGA_KEY_USAGE_SIGN = 0x10,      // Signature calculation and verification.
+  OPTIGA_KEY_USAGE_KEYAGREE = 0x20,  // Key agreement.
+} optiga_key_usage;
+
+// Key derivation methods.
+typedef enum {
+  OPTIGA_DERIV_TLS_PRF_SHA256 = 0x01,
+  OPTIGA_DERIV_TLS_PRF_SHA384 = 0x02,
+  OPTIGA_DERIV_TLS_PRF_SHA512 = 0x03,
+  OPTIGA_DERIV_HKDF_SHA256 = 0x08,
+  OPTIGA_DERIV_HKDF_SHA384 = 0x09,
+  OPTIGA_DERIV_HKDF_SHA512 = 0x0a,
+} optiga_key_derivation;
+
+// Symmetric modes of operation.
+typedef enum {
+  OPTIGA_SYM_MODE_ECB = 0x08,      // Input must be padded.
+  OPTIGA_SYM_MODE_CBC_MAC = 0x0A,  // Input must be padded.
+  OPTIGA_SYM_MODE_CMAC = 0x0B,
+  OPTIGA_SYM_MODE_HMAC_SHA256 = 0x20,
+  OPTIGA_SYM_MODE_HMAC_SHA384 = 0x21,
+  OPTIGA_SYM_MODE_HMAC_SHA512 = 0x22,
+} optiga_sym_mode;
+
+// Data object types.
+typedef enum {
+  OPTIGA_DATA_TYPE_BSTR = 0x00,      // Byte string.
+  OPTIGA_DATA_TYPE_UPCTR = 0x01,     // Monotonic up-counter.
+  OPTIGA_DATA_TYPE_TA = 0x11,        // Trust anchor.
+  OPTIGA_DATA_TYPE_DEVCERT = 0x12,   // Device identity certificate.
+  OPTIGA_DATA_TYPE_PRESSEC = 0x21,   // Secret for HMAC computation.
+  OPTIGA_DATA_TYPE_PTFBIND = 0x22,   // Secret for platform binding.
+  OPTIGA_DATA_TYPE_UPDATSEC = 0x23,  // Secret for confidential object update.
+  OPTIGA_DATA_TYPE_AUTOREF = 0x31,   // Secret for verifying external entity.
+} optiga_data_type;
+
+typedef struct {
+  const uint8_t *ptr;
+  uint16_t len;
+} optiga_metadata_item;
+
+typedef struct {
+  optiga_metadata_item lcso;         // C0 - Life cycle state of data object.
+  optiga_metadata_item version;      // C1 - Version information of data object.
+  optiga_metadata_item max_size;     // C4 - Maximum size of the data object.
+  optiga_metadata_item used_size;    // C5 - Used size of the data object.
+  optiga_metadata_item change;       // D0 - Change access conditions.
+  optiga_metadata_item read;         // D1 - Read access conditions.
+  optiga_metadata_item execute;      // D3 - Execute access conditions.
+  optiga_metadata_item meta_update;  // D8 - Metadata update descriptor.
+  optiga_metadata_item algorithm;    // E0 - Algorithm associated with the key.
+  optiga_metadata_item key_usage;    // E1 - Key usage associated with the key.
+  optiga_metadata_item data_type;    // E8 - Data object type.
+  optiga_metadata_item reset_type;   // F0 - Factory reset type.
+} optiga_metadata;
+
+optiga_result optiga_parse_metadata(const uint8_t *serialized,
+                                    size_t serialized_size,
+                                    optiga_metadata *metadata);
+optiga_result optiga_serialize_metadata(const optiga_metadata *metadata,
+                                        uint8_t *serialized,
+                                        size_t max_serialized,
+                                        size_t *serialized_size);
+
+optiga_result optiga_open_application(void);
+optiga_result optiga_get_error_code(uint8_t *error_code);
+optiga_result optiga_get_data_object(uint16_t oid, bool get_metadata,
+                                     uint8_t *data, size_t max_data_size,
+                                     size_t *data_size);
+optiga_result optiga_set_data_object(uint16_t oid, bool set_metadata,
+                                     const uint8_t *data, size_t data_size);
+optiga_result optiga_get_random(uint8_t *random, size_t random_size);
+optiga_result optiga_encrypt_sym(optiga_sym_mode mode, uint16_t oid,
+                                 const uint8_t *input, size_t input_size,
+                                 uint8_t *output, size_t max_output_size,
+                                 size_t *output_size);
+optiga_result optiga_set_auto_state(uint16_t nonce_oid, uint16_t key_oid,
+                                    const uint8_t key[32]);
+optiga_result optiga_clear_auto_state(uint16_t key_oid);
+optiga_result optiga_calc_sign(uint16_t oid, const uint8_t *digest,
+                               size_t digest_size, uint8_t *signature,
+                               size_t max_sig_size, size_t *sig_size);
+optiga_result optiga_gen_key_pair(optiga_curve curve, optiga_key_usage usage,
+                                  uint16_t oid, uint8_t *public_key,
+                                  size_t max_public_key_size,
+                                  size_t *public_key_size);
+optiga_result optiga_gen_sym_key(optiga_aes algorithm, optiga_key_usage usage,
+                                 uint16_t oid);
+optiga_result optiga_calc_ssec(optiga_curve curve, uint16_t oid,
+                               const uint8_t *public_key,
+                               size_t public_key_size, uint8_t *secret,
+                               size_t max_secret_size, size_t *secret_size);
+optiga_result optiga_derive_key(optiga_key_derivation deriv, uint16_t oid,
+                                const uint8_t *salt, size_t salt_size,
+                                uint8_t *info, size_t info_size, uint8_t *key,
+                                size_t key_size);
+optiga_result optiga_set_trust_anchor(void);
+optiga_result optiga_set_priv_key(uint16_t oid, const uint8_t priv_key[32]);
+#endif

--- a/core/embed/trezorhal/optiga_common.h
+++ b/core/embed/trezorhal/optiga_common.h
@@ -1,0 +1,37 @@
+/*
+ * This file is part of the Trezor project, https://trezor.io/
+ *
+ * Copyright (c) SatoshiLabs
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#ifndef TREZORHAL_OPTIGA_COMMON_H
+#define TREZORHAL_OPTIGA_COMMON_H
+
+typedef enum _optiga_result {
+  OPTIGA_SUCCESS = 0,     // Operation completed successfully.
+  OPTIGA_ERR_I2C_WRITE,   // HAL failed on I2C write.
+  OPTIGA_ERR_I2C_READ,    // HAL failed on I2C read.
+  OPTIGA_ERR_BUSY,        // Optiga is busy processing another command.
+  OPTIGA_ERR_TIMEOUT,     // Optiga did not return data within the time limit.
+  OPTIGA_ERR_SIZE,        // Input or output exceeds buffer size.
+  OPTIGA_ERR_CRC,         // Invalid CRC.
+  OPTIGA_ERR_UNEXPECTED,  // Optiga returned unexpected data.
+  OPTIGA_ERR_PROCESS,     // Processing error.
+  OPTIGA_ERR_PARAM,       // Invalid command parameters.
+  OPTIGA_ERR_CMD,         // Command error. See error code data object 0xF1C2.
+} optiga_result;
+
+#endif

--- a/core/embed/trezorhal/optiga_hal.h
+++ b/core/embed/trezorhal/optiga_hal.h
@@ -1,0 +1,12 @@
+
+#ifndef CORE_OPTIGA_HAL_H
+#define CORE_OPTIGA_HAL_H
+
+#include <stdint.h>
+#include "secbool.h"
+
+void optiga_hal_init(void);
+
+void optiga_reset(void);
+
+#endif  // CORE_OPTIGA_HAL_H

--- a/core/embed/trezorhal/optiga_transport.h
+++ b/core/embed/trezorhal/optiga_transport.h
@@ -1,0 +1,46 @@
+/*
+ * This file is part of the Trezor project, https://trezor.io/
+ *
+ * Copyright (c) SatoshiLabs
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#ifndef TREZORHAL_OPTIGA_TRANSPORT_H
+#define TREZORHAL_OPTIGA_TRANSPORT_H
+
+#include <stdbool.h>
+#include <stddef.h>
+#include <stdint.h>
+#include "optiga_common.h"
+
+// Maximum data register length supported by OPTIGA.
+#define OPTIGA_DATA_REG_LEN 277
+
+optiga_result optiga_init(void);
+optiga_result optiga_execute_command(
+    bool presentation_layer, const uint8_t *command_data, size_t command_size,
+    uint8_t *response_data, size_t max_response_size, size_t *response_size);
+
+optiga_result optiga_resync(void);
+optiga_result optiga_soft_reset(void);
+optiga_result optiga_set_data_reg_len(size_t size);
+
+#ifndef NDEBUG
+typedef void (*optiga_log_hex_t)(const char *prefix, const uint8_t *data,
+                                 size_t data_size);
+void optiga_set_log_hex(optiga_log_hex_t f);
+#endif
+
+#endif

--- a/core/embed/trezorhal/stm32f4/optiga_hal.c
+++ b/core/embed/trezorhal/stm32f4/optiga_hal.c
@@ -1,0 +1,22 @@
+#include "optiga_hal.h"
+#include "common.h"
+#include TREZOR_BOARD
+
+void optiga_hal_init(void) {
+  // init reset pin
+  GPIO_InitTypeDef GPIO_InitStructure;
+  GPIO_InitStructure.Mode = GPIO_MODE_OUTPUT_PP;
+  GPIO_InitStructure.Pull = GPIO_NOPULL;
+  GPIO_InitStructure.Speed = GPIO_SPEED_FREQ_LOW;
+  GPIO_InitStructure.Alternate = 0;
+  GPIO_InitStructure.Pin = GPIO_PIN_9;
+  HAL_GPIO_Init(GPIOD, &GPIO_InitStructure);
+  HAL_GPIO_WritePin(GPIOD, GPIO_PIN_9, GPIO_PIN_SET);
+  hal_delay(1);
+}
+
+void optiga_reset(void) {
+  HAL_GPIO_WritePin(GPIOD, GPIO_PIN_9, GPIO_PIN_RESET);
+  hal_delay(10);
+  HAL_GPIO_WritePin(GPIOD, GPIO_PIN_9, GPIO_PIN_SET);
+}

--- a/core/site_scons/boards/trezor_r_v10.py
+++ b/core/site_scons/boards/trezor_r_v10.py
@@ -66,6 +66,11 @@ def configure(
         ]
         features_available.append("usb")
 
+    if "optiga" in features_wanted:
+        sources += ["embed/trezorhal/stm32f4/optiga_hal.c"]
+        sources += ["embed/trezorhal/optiga/optiga_commands.c"]
+        sources += ["embed/trezorhal/optiga/optiga_transport.c"]
+
     env.get("ENV")["TREZOR_BOARD"] = board
     env.get("ENV")["MCU_TYPE"] = mcu
 


### PR DESCRIPTION
Further work in this PR:
- <s>I am probably doing the initialization of the I2C interface wrong. There has been some refactoring recently around I2C, so that's not reflected in this PR. @TychoVrahe </s> (_Edit: Done_)
- <s>Maybe move the code to a subdirectory in `core/embed/trezorhal` such as `se` or `optiga`.</s> (_Edit: Done_)

Further work, that can be split into separate issues/PRs:
- <s>Not sure why I can't use the full capacity of the data register. See `OPTIGA_DATA_REG_LEN` in `transport.h`.  @TychoVrahe </s> (_Edit: Solved_)
- We will need to agree on how to integrate this with the emulator. My plan is to add a new file `optiga.h`, which will implement some higher level operations, such as `optiga_get_device_cert()` or `optiga_check_pin()`. Only these would be used by the firmware directly and only they would need to be implemented for the emulator.
- Improve management of timeouts. Right now there is just a for-loop with some arbitrary maximum retry count.
- Improve error handling in general, e.g. retransmission in case of CRC failures.
- <s>Add the files to the build process only for the right firmwares. How will we determine that? Using `TREZOR_MODEL`, or something else?</s> (_Edit: Solved_)