### PR TITLE
nest logger in the proper way

### DIFF
--- a/python/src/trezorlib/log.py
+++ b/python/src/trezorlib/log.py
@@ -70,6 +70,6 @@ def enable_debug_output(
     if verbosity > 2:
         level = DUMP_PACKETS
 
-    logger = logging.getLogger("trezorlib")
+    logger = logging.getLogger(__name__.rsplit(".", 1)[0])
     logger.setLevel(level)
     logger.addHandler(handler)


### PR DESCRIPTION
this way logger is properly nested even when the library is used as submodule (e.g. HWI)

see https://github.com/bitcoin-core/HWI/pull/697
