### PR TITLE
fix(core): raise ActionCancelled when cancelling tutorial flow for TR

### DIFF
--- a/core/src/trezor/ui/layouts/tr/__init__.py
+++ b/core/src/trezor/ui/layouts/tr/__init__.py
@@ -684,10 +684,12 @@ async def tutorial(
     br_code: ButtonRequestType = BR_TYPE_OTHER,
 ) -> None:
     """Showing users how to interact with the device."""
-    await interact(
-        RustLayout(trezorui2.tutorial()),
-        "tutorial",
-        br_code,
+    await raise_if_not_confirmed(
+        interact(
+            RustLayout(trezorui2.tutorial()),
+            "tutorial",
+            br_code,
+        )
     )
 
 


### PR DESCRIPTION
Fixes https://github.com/trezor/trezor-firmware/issues/3187:
- differentiates the case when the user cancels the tutorial, in comparison to successfully finishing it