### PR TITLE
chore(python): add ruff linter as a dependency

### DIFF
--- a/ci/shell.nix
+++ b/ci/shell.nix
@@ -98,6 +98,7 @@ stdenvNoCC.mkDerivation ({
     poetry
     protobuf3_19
     pyright
+    ruff
     (mkBinOnlyWrapper rustNightly)
     wget
     zlib

--- a/core/embed/firmware/bootloader_hashes.py
+++ b/core/embed/firmware/bootloader_hashes.py
@@ -29,7 +29,7 @@ def aligned_digest(data: bytes, padding: bytes) -> bytes:
     (unwritten NOR-flash byte) or 0x00 (explicitly cleared byte).
     """
     if len(data) > ALIGNED_SIZE:
-        raise ValueError(fn, "too big")
+        raise ValueError("too big")
 
     assert len(padding) == 1
     digest_data = data + padding * (ALIGNED_SIZE - len(data))
@@ -55,6 +55,7 @@ def bootloader_str(file: Path) -> str:
     data = file.read_bytes()
 
     suffix = file.stem[len("bootloader_") :].upper()
+
     bytes_00 = to_uint_array(aligned_digest(data, b"\x00"))
     bytes_ff = to_uint_array(aligned_digest(data, b"\xff"))
 
@@ -84,7 +85,10 @@ def main():
 
         # write bootloader definitions
         for file in BOOTLOADERS.glob("bootloader*.bin"):
-            bl_check_new.append(bootloader_str(file))
+            try:
+                bl_check_new.append(bootloader_str(file))
+            except ValueError:
+                raise ValueError(f"Data too big in {file}")
 
         # consume up to auto-end
         for line in f:

--- a/core/prof/prof.py
+++ b/core/prof/prof.py
@@ -16,7 +16,7 @@ class Coverage:
         self.__files = {}
 
     def line_tick(self, filename, lineno):
-        if not filename in self.__files:
+        if filename not in self.__files:
             self.__files[filename] = set()
         self.__files[filename].add(lineno)
 
@@ -120,7 +120,7 @@ def atexit():
 sys.atexit(atexit)
 
 global __prof__
-if not "__prof__" in globals():
+if "__prof__" not in globals():
     if getenv("TREZOR_MEMPERF") == "1":
         __prof__ = AllocCounter()
     else:
@@ -131,4 +131,4 @@ sys.settrace(trace_handler)
 if isinstance(__prof__, AllocCounter):
     __prof__.last_alloc_count = micropython.alloc_count()
 
-import main
+import main  # noqa: F401 (imported but unused)

--- a/core/tools/alloc.py
+++ b/core/tools/alloc.py
@@ -10,7 +10,7 @@ from typing_extensions import TypedDict
 
 import click
 from dominate import document
-from dominate.tags import *
+from dominate.tags import meta, style, h3, table, thead, tr, th, tbody, td, a
 from dominate.util import raw
 
 HERE = Path(__file__).resolve().parent

--- a/core/tools/hid-bridge/logger.py
+++ b/core/tools/hid-bridge/logger.py
@@ -9,7 +9,7 @@ def __get_timestamp():
 
 
 def __log_message(message):
-    if log_timestamps == True:
+    if log_timestamps is True:
         print(f"{__get_timestamp()}\t{message}")
     else:
         print(message)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -102,3 +102,11 @@ extra_standard_library = [
 ]
 known_first_party = ["trezorlib", "apps", "coin_info", "marketcap", "ui_tests", "gitlab"]
 known_third_party = ["trezor", "storage"]
+
+[tool.ruff]
+ignore = [
+    "E501", # line too long
+    "E402", # module level import not at top of file
+    "E741", # ambiguous variable name
+]
+exclude = ["tests", "mocks"]


### PR DESCRIPTION
Fixes https://github.com/trezor/trezor-firmware/issues/2820:
- adds `ruff` linter into `shell.nix`, so we can run it on python files
- usage - `ruff .` in `core`

I could not make it a `make` command or adding it into `pystyle` command, it was complaining that `ruff: No such file or directory`