### PR TITLE
unsafe screen design for T2B1

### DIFF
--- a/core/embed/models/model_D001.h
+++ b/core/embed/models/model_D001.h
@@ -1,5 +1,5 @@
-#ifndef MODELS_MODEL_T2T1_H_
-#define MODELS_MODEL_T2T1_H_
+#ifndef MODELS_MODEL_D001_H_
+#define MODELS_MODEL_D001_H_
 
 #define MODEL_NAME "T"
 #define MODEL_INTERNAL_NAME "D001"

--- a/core/embed/rust/rust_ui.h
+++ b/core/embed/rust/rust_ui.h
@@ -28,3 +28,6 @@ void screen_boot_empty(bool fading);
 uint32_t screen_unlock_bootloader_confirm(void);
 void screen_unlock_bootloader_success(void);
 void display_image(int16_t x, int16_t y, const uint8_t* data, uint32_t datalen);
+void display_icon(int16_t x, int16_t y, const uint8_t* data, uint32_t datalen,
+                  uint16_t fg_color, uint16_t bg_color);
+void bld_continue_label(uint16_t bg_color);

--- a/core/embed/rust/src/ui/display/toif.rs
+++ b/core/embed/rust/src/ui/display/toif.rs
@@ -241,6 +241,25 @@ impl<'i> Toif<'i> {
     }
 }
 
+#[no_mangle]
+extern "C" fn display_icon(
+    x: cty::int16_t,
+    y: cty::int16_t,
+    data: *const cty::uint8_t,
+    data_len: cty::uint32_t,
+    fg_color: cty::uint16_t,
+    bg_color: cty::uint16_t,
+) {
+    let data_slice = unsafe { core::slice::from_raw_parts(data, data_len as usize) };
+    let icon = Icon::new(data_slice);
+    icon.draw(
+        Point::new(x, y),
+        Alignment2D::TOP_LEFT,
+        Color::from_u16(fg_color),
+        Color::from_u16(bg_color),
+    );
+}
+
 #[derive(PartialEq, Eq, Clone, Copy)]
 pub struct Icon {
     pub toif: Toif<'static>,

--- a/core/embed/rust/src/ui/model_tr/bootloader/mod.rs
+++ b/core/embed/rust/src/ui/model_tr/bootloader/mod.rs
@@ -22,6 +22,12 @@ mod menu;
 mod theme;
 mod welcome;
 
+use crate::ui::{
+    constant,
+    constant::HEIGHT,
+    geometry::Point,
+    model_tr::theme::{ICON_ARM_LEFT, ICON_ARM_RIGHT, WHITE},
+};
 use confirm::Confirm;
 use connect::Connect;
 use intro::Intro;
@@ -365,4 +371,27 @@ extern "C" fn screen_welcome() {
 extern "C" fn screen_welcome_model() {
     let mut frame = WelcomeScreen::new();
     show(&mut frame);
+}
+
+#[no_mangle]
+extern "C" fn bld_continue_label(bg_color: cty::uint16_t) {
+    display::text_center(
+        Point::new(constant::WIDTH / 2, HEIGHT - 2),
+        "CONTINUE",
+        Font::NORMAL,
+        WHITE,
+        Color::from_u16(bg_color),
+    );
+    ICON_ARM_LEFT.draw(
+        Point::new(constant::WIDTH / 2 - 36, HEIGHT - 6),
+        Alignment2D::TOP_LEFT,
+        WHITE,
+        Color::from_u16(bg_color),
+    );
+    ICON_ARM_RIGHT.draw(
+        Point::new(constant::WIDTH / 2 + 25, HEIGHT - 6),
+        Alignment2D::TOP_LEFT,
+        WHITE,
+        Color::from_u16(bg_color),
+    );
 }

--- a/core/embed/rust/src/ui/model_tt/bootloader/mod.rs
+++ b/core/embed/rust/src/ui/model_tt/bootloader/mod.rs
@@ -417,3 +417,14 @@ extern "C" fn screen_welcome() {
     let mut frame = Welcome::new();
     show(&mut frame, true);
 }
+
+#[no_mangle]
+extern "C" fn bld_continue_label(bg_color: cty::uint16_t) {
+    display::text_center(
+        Point::new(constant::WIDTH / 2, HEIGHT - 5),
+        "click to continue ...",
+        Font::NORMAL,
+        WHITE,
+        Color::from_u16(bg_color),
+    );
+}

--- a/core/src/apps/base.py
+++ b/core/src/apps/base.py
@@ -69,7 +69,7 @@ def get_features() -> Features:
         unit_btconly=utils.unit_btconly(),
     )
 
-    if utils.MODEL in ("1", "R"):
+    if utils.INTERNAL_MODEL in ("T1B1", "T2B1"):
         f.homescreen_format = HomescreenFormat.ToiG
     else:
         f.homescreen_format = HomescreenFormat.Jpeg

--- a/core/src/apps/debug/__init__.py
+++ b/core/src/apps/debug/__init__.py
@@ -173,10 +173,10 @@ if __debug__:
         debug_events.last_event += 1
 
         # TT click on specific coordinates, with possible hold
-        if x is not None and y is not None and utils.MODEL in ("T", "DISC1"):
+        if x is not None and y is not None and utils.INTERNAL_MODEL in ("T2T1", "D001"):
             click_chan.publish((debug_events.last_event, x, y, msg.hold_ms))
         # TR press specific button
-        elif msg.physical_button is not None and utils.MODEL in ("R",):
+        elif msg.physical_button is not None and utils.INTERNAL_MODEL in ("T2B1",):
             button_chan.publish(
                 (debug_events.last_event, msg.physical_button, msg.hold_ms)
             )

--- a/core/src/apps/management/apply_settings.py
+++ b/core/src/apps/management/apply_settings.py
@@ -14,7 +14,7 @@ if TYPE_CHECKING:
 
 BRT_PROTECT_CALL = ButtonRequestType.ProtectCall  # CACHE
 
-if utils.MODEL in ("1", "R"):
+if utils.INTERNAL_MODEL in ("T1B1", "T2B1"):
 
     def _validate_homescreen_model_specific(homescreen: bytes) -> None:
         from trezor.ui import WIDTH, HEIGHT

--- a/core/src/apps/management/recovery_device/homescreen.py
+++ b/core/src/apps/management/recovery_device/homescreen.py
@@ -65,7 +65,7 @@ async def _continue_recovery_process() -> Success:
             # If we are starting recovery, ask for word count first...
             # _request_word_count
             # For TT, just continuing straight to word count keyboard
-            if utils.MODEL == "R":
+            if utils.INTERNAL_MODEL == "T2B1":
                 await layout.homescreen_dialog(
                     "Continue", "Select the number of words in your backup."
                 )

--- a/core/src/apps/workflow_handlers.py
+++ b/core/src/apps/workflow_handlers.py
@@ -52,7 +52,7 @@ def _find_message_handler_module(msg_type: int) -> str:
     if msg_type == MessageType.RebootToBootloader:
         return "apps.management.reboot_to_bootloader"
 
-    if utils.MODEL in ("R",) and msg_type == MessageType.ShowDeviceTutorial:
+    if utils.INTERNAL_MODEL in ("T2B1",) and msg_type == MessageType.ShowDeviceTutorial:
         return "apps.management.show_tutorial"
 
     if utils.USE_SD_CARD and msg_type == MessageType.SdProtect:

--- a/core/src/trezor/ui/__init__.py
+++ b/core/src/trezor/ui/__init__.py
@@ -39,7 +39,7 @@ else:
 
 
 # in both debug and production, emulator needs to draw the screen explicitly
-if utils.EMULATOR or utils.MODEL in ("1", "R"):
+if utils.EMULATOR or utils.INTERNAL_MODEL in ("T1B1", "T2B1"):
     loop.after_step_hook = refresh
 
 
@@ -120,7 +120,7 @@ class Component:
     def __init__(self) -> None:
         self.repaint = True
 
-    if utils.MODEL in ("T", "DISC1"):
+    if utils.INTERNAL_MODEL in ("T2T1", "D001"):
 
         def dispatch(self, event: int, x: int, y: int) -> None:
             if event is RENDER:
@@ -143,7 +143,7 @@ class Component:
         def on_touch_end(self, x: int, y: int) -> None:
             pass
 
-    elif utils.MODEL in ("1", "R"):
+    elif utils.INTERNAL_MODEL in ("T1B1", "T2B1"):
 
         def dispatch(self, event: int, x: int, y: int) -> None:
             if event is RENDER:
@@ -255,7 +255,7 @@ class Layout(Component):
         Usually overridden to add another tasks to the list."""
         return self.handle_input(), self.handle_rendering()
 
-    if utils.MODEL in ("T", "DISC1"):
+    if utils.INTERNAL_MODEL in ("T2T1", "D001"):
 
         def handle_input(self) -> Generator:
             """Task that is waiting for the user input."""
@@ -269,7 +269,7 @@ class Layout(Component):
                 # way to get the lowest input-to-render latency.
                 self.dispatch(RENDER, 0, 0)
 
-    elif utils.MODEL in ("1", "R"):
+    elif utils.INTERNAL_MODEL in ("T1B1", "T2B1"):
 
         def handle_input(self) -> Generator:
             """Task that is waiting for the user input."""

--- a/core/src/trezor/ui/layouts/__init__.py
+++ b/core/src/trezor/ui/layouts/__init__.py
@@ -4,9 +4,9 @@ from .common import *  # noqa: F401,F403
 
 # NOTE: using any import magic probably causes mypy not to check equivalence of
 #       layout type signatures across models
-if utils.MODEL in ("1", "R"):
+if utils.INTERNAL_MODEL in ("T1B1", "T2B1"):
     from .tr import *  # noqa: F401,F403
-elif utils.MODEL in ("T", "DISC1"):
+elif utils.INTERNAL_MODEL in ("T2T1", "D001"):
     from .tt_v2 import *  # noqa: F401,F403
 else:
     raise ValueError("Unknown Trezor model")

--- a/core/src/trezor/ui/layouts/fido.py
+++ b/core/src/trezor/ui/layouts/fido.py
@@ -1,6 +1,6 @@
 from trezor import utils
 
-if utils.MODEL in ("T", "DISC1"):
+if utils.INTERNAL_MODEL in ("T2T1", "D001"):
     from .tt_v2.fido import *  # noqa: F401,F403
-elif utils.MODEL in ("R",):
+elif utils.INTERNAL_MODEL in ("T2B1",):
     from .tr.fido import *  # noqa: F401,F403

--- a/core/src/trezor/ui/layouts/homescreen.py
+++ b/core/src/trezor/ui/layouts/homescreen.py
@@ -1,6 +1,6 @@
 from trezor import utils
 
-if utils.MODEL in ("T", "DISC1"):
+if utils.INTERNAL_MODEL in ("T2T1", "D001"):
     from .tt_v2.homescreen import *  # noqa: F401,F403
-elif utils.MODEL in ("R",):
+elif utils.INTERNAL_MODEL in ("T2B1",):
     from .tr.homescreen import *  # noqa: F401,F403

--- a/core/src/trezor/ui/layouts/progress.py
+++ b/core/src/trezor/ui/layouts/progress.py
@@ -1,6 +1,6 @@
 from trezor import utils
 
-if utils.MODEL in ("T", "DISC1"):
+if utils.INTERNAL_MODEL in ("T2T1", "D001"):
     from .tt_v2.progress import *  # noqa: F401,F403
-elif utils.MODEL in ("R",):
+elif utils.INTERNAL_MODEL in ("T2B1",):
     from .tr.progress import *  # noqa: F401,F403

--- a/core/src/trezor/ui/layouts/recovery.py
+++ b/core/src/trezor/ui/layouts/recovery.py
@@ -1,6 +1,6 @@
 from trezor import utils
 
-if utils.MODEL in ("T", "DISC1"):
+if utils.INTERNAL_MODEL in ("T2T1", "D001"):
     from .tt_v2.recovery import *  # noqa: F401,F403
-elif utils.MODEL in ("R",):
+elif utils.INTERNAL_MODEL in ("T2B1",):
     from .tr.recovery import *  # noqa: F401,F403

--- a/core/src/trezor/ui/layouts/reset.py
+++ b/core/src/trezor/ui/layouts/reset.py
@@ -1,6 +1,6 @@
 from trezor import utils
 
-if utils.MODEL in ("T", "DISC1"):
+if utils.INTERNAL_MODEL in ("T2T1", "D001"):
     from .tt_v2.reset import *  # noqa: F401,F403
-elif utils.MODEL in ("R",):
+elif utils.INTERNAL_MODEL in ("T2B1",):
     from .tr.reset import *  # noqa: F401,F403

--- a/python/src/trezorlib/client.py
+++ b/python/src/trezorlib/client.py
@@ -266,7 +266,9 @@ class TrezorClient(Generic[UI]):
 
         if not self.model:
             # Trezor Model One bootloader 1.8.0 or older does not send model name
-            self.model = models.by_name(features.model or "1")
+            self.model = models.by_internal_name(features.internal_model)
+            if self.model is None:
+                self.model = models.by_name(features.model or "1")
             if self.model is None:
                 raise RuntimeError("Unsupported Trezor model")
 

--- a/python/src/trezorlib/models.py
+++ b/python/src/trezorlib/models.py
@@ -27,6 +27,7 @@ VENDORS = ("bitcointrezor.com", "trezor.io")
 @dataclass(eq=True, frozen=True)
 class TrezorModel:
     name: str
+    internal_name: str
     minimum_version: Tuple[int, int, int]
     vendors: Collection[str]
     usb_ids: Collection[UsbId]
@@ -35,6 +36,7 @@ class TrezorModel:
 
 TREZOR_ONE = TrezorModel(
     name="1",
+    internal_name="T1B1",
     minimum_version=(1, 8, 0),
     vendors=VENDORS,
     usb_ids=((0x534C, 0x0001),),
@@ -43,6 +45,7 @@ TREZOR_ONE = TrezorModel(
 
 TREZOR_T = TrezorModel(
     name="T",
+    internal_name="T2T1",
     minimum_version=(2, 1, 0),
     vendors=VENDORS,
     usb_ids=((0x1209, 0x53C1), (0x1209, 0x53C0)),
@@ -51,6 +54,7 @@ TREZOR_T = TrezorModel(
 
 TREZOR_R = TrezorModel(
     name="R",
+    internal_name="T2B1",
     minimum_version=(2, 1, 0),
     vendors=VENDORS,
     usb_ids=((0x1209, 0x53C1), (0x1209, 0x53C0)),
@@ -59,6 +63,7 @@ TREZOR_R = TrezorModel(
 
 TREZOR_DISC1 = TrezorModel(
     name="DISC1",
+    internal_name="D001",
     minimum_version=(2, 1, 0),
     vendors=VENDORS,
     usb_ids=((0x1209, 0x53C1), (0x1209, 0x53C0)),
@@ -73,5 +78,14 @@ def by_name(name: Optional[str]) -> Optional[TrezorModel]:
         return TREZOR_ONE
     for model in TREZORS:
         if model.name == name:
+            return model
+    return None
+
+
+def by_internal_name(name: Optional[str]) -> Optional[TrezorModel]:
+    if name is None:
+        return None
+    for model in TREZORS:
+        if model.internal_name == name:
             return model
     return None


### PR DESCRIPTION
Design for 'unsafe, do not use' screen is updated. Part of the rendering is done in rust. The logic however stays in C. This has a disadvantage that the CONTINUE button is not highlighted in pressed state.

Also: 
- In micropython, the MODEL ifs are replaced with INTERNAL_MODEL
- in trezorctl the model is also derived from INTERNAL_MODEL field in features

<!--
If you are a core dev:

Don't forget to set up the fields:
- assign yourself
- set priority to same as original issue
- add PR to sprint
- if Draft -> "in progress"
- if final PR -> "needs review"

If you're an external contributor, you can ignore this text.
-->
