### PR TITLE
fix(core): use stm32f4 implementation of secret.c for unix too

### DIFF
--- a/core/embed/trezorhal/unix/secret.c
+++ b/core/embed/trezorhal/unix/secret.c
@@ -1,9 +1,1 @@
-#include "secret.h"
-
-void secret_write(uint8_t* data, uint32_t offset, uint32_t len) {}
-
-void secret_read(uint8_t* data, uint32_t offset, uint32_t len) {}
-
-secbool secret_wiped(void) { return secfalse; }
-
-void secret_erase(void) {}
+../stm32f4/secret.c


### PR DESCRIPTION
(fixes bootloader_emu build because there was an error in the unix dummy impl)