### PR TITLE
docs(core): add protoc installation instructions

### DIFF
--- a/docs/core/build/embedded.md
+++ b/docs/core/build/embedded.md
@@ -34,6 +34,10 @@ For other users:
 3. To install OpenOCD, run `brew install open-ocd`
 4. Run `make vendor build_boardloader build_bootloader build_firmware`
 
+## Protobuf Compiler
+
+The protocol buffer compiler `protoc` is needed to (unsurprisingly) compile protocol buffer files. [Follow the installation instructions for your system](https://grpc.io/docs/protoc-installation/).
+
 ## Rust
 
 Install the appropriate target with [`rustup`](https://rustup.rs/):

--- a/docs/core/build/emulator.md
+++ b/docs/core/build/emulator.md
@@ -52,6 +52,10 @@ brew install scons sdl2 sdl2_image pkg-config llvm
 
 * __Windows__: not supported yet, sorry.
 
+## Protobuf Compiler
+
+The protocol buffer compiler `protoc` is needed to (unsurprisingly) compile protocol buffer files. [Follow the installation instructions for your system](https://grpc.io/docs/protoc-installation/).
+
 ## Rust
 
 You will require Rust and Cargo. The currently supported version is 1.64 nightly. The


### PR DESCRIPTION
Seems like `protoc` (the protobuf compiler binary) is now a required dependency to build the firmware and emulator. Following the instructions in `docs/core/embed.md`:

```
make vendor build_boardloader build_bootloader build_firmware
```

```
scons -Q -j 4 CFLAGS="-DSCM_REVISION='\"\x77\xf1\x37\x9d\xc8\x3c\xde\x21\xa8\x70\x37\x3c\x31\xd5\xe1\xca\xa6\xe6\x98\x62\"'" PRODUCTION="0" \
	TREZOR_MODEL="T" CMAKELISTS="0" \
	PYOPT="1" BITCOIN_ONLY="0" \
	BOOTLOADER_QA="0" BOOTLOADER_DEVEL="0" build/firmware/firmware.bin
python ../common/protob/pb2py /home/user/src/conduition/trezor-firmware/common/protob/messages-binance.proto /home/user/src/conduition/trezor-firmware/common/protob/messages-bitcoin.proto /home/user/src/conduition/trezor-firmware/common/protob/messages-cardano.proto /home/user/src/conduition/trezor-firmware/common/protob/messages-common.proto /home/user/src/conduition/trezor-firmware/common/protob/messages-crypto.proto /home/user/src/conduition/trezor-firmware/common/protob/messages-debug.proto /home/user/src/conduition/trezor-firmware/common/protob/messages-eos.proto /home/user/src/conduition/trezor-firmware/common/protob/messages-ethereum-definitions.proto /home/user/src/conduition/trezor-firmware/common/protob/messages-ethereum-eip712.proto /home/user/src/conduition/trezor-firmware/common/protob/messages-ethereum.proto /home/user/src/conduition/trezor-firmware/common/protob/messages-management.proto /home/user/src/conduition/trezor-firmware/common/protob/messages-monero.proto /home/user/src/conduition/trezor-firmware/common/protob/messages-nem.proto /home/user/src/conduition/trezor-firmware/common/protob/messages-ripple.proto /home/user/src/conduition/trezor-firmware/common/protob/messages-stellar.proto /home/user/src/conduition/trezor-firmware/common/protob/messages-tezos.proto /home/user/src/conduition/trezor-firmware/common/protob/messages-webauthn.proto /home/user/src/conduition/trezor-firmware/common/protob/messages.proto --qstr-out build/firmware/genhdr/qstrdefs.protobuf.h --bitcoin-only=0
python vendor/micropython/py/makeversionhdr.py build/firmware/genhdr/mpversion.h
protoc command not found
GEN build/firmware/genhdr/mpversion.h
sed -e 's/utils\.BITCOIN_ONLY/False/g' -e 's/utils\.USE_BACKLIGHT/True/g' -e 's/if TYPE_CHECKING/if False/' -e 's/import typing/# \0/' -e '/from typing import (/,/^\s*)/ {s/^/# /}' -e 's/from typing import/# \0/' src/all_modules.py > build/firmware/src/all_modules.i && vendor/micropython/mpy-cross/mpy-cross -O1 -o build/firmware/src/all_modules.mpy -s all_modules.py build/firmware/src/all_modules.i
sed -e 's/utils\.BITCOIN_ONLY/False/g' -e 's/utils\.USE_BACKLIGHT/True/g' -e 's/if TYPE_CHECKING/if False/' -e 's/import typing/# \0/' -e '/from typing import (/,/^\s*)/ {s/^/# /}' -e 's/from typing import/# \0/' src/boot.py > build/firmware/src/boot.i && vendor/micropython/mpy-cross/mpy-cross -O1 -o build/firmware/src/boot.mpy -s boot.py build/firmware/src/boot.i
scons: *** [build/firmware/genhdr/qstrdefs.protobuf.h] Error 1
make: *** [Makefile:201: build_firmware] Error 2
```

Might be related to https://github.com/trezor/trezor-firmware/issues/3153.


I fixed this on my system by installing `protoc` with `apt install protobuf-compiler`. I would have added `protobuf-compiler` to the `Requirements` section of the documents, but I wasn't sure which packages applied to other distros like OpenSUSE, Arch, etc.