### PR TITLE
add install restricted screen on installation with locked bootloader

### DIFF
--- a/core/embed/bootloader/bootui.c
+++ b/core/embed/bootloader/bootui.c
@@ -264,6 +264,18 @@ void ui_screen_fail(void) { screen_install_fail(); }
 uint32_t ui_screen_unlock_bootloader_confirm(void) {
   return screen_unlock_bootloader_confirm();
 }
+
+void ui_screen_install_restricted(void) {
+  display_clear();
+  screen_fatal_error_rust(
+      "INSTALL RESTRICTED",
+      "Installation of custom firmware is currently restricted.",
+      "Please visit\ntrezor.io/bootloader");
+
+  display_refresh();
+}
+#else
+void ui_screen_install_restricted(void) { screen_install_fail(); }
 #endif
 
 // general functions

--- a/core/embed/bootloader/bootui.h
+++ b/core/embed/bootloader/bootui.h
@@ -61,6 +61,7 @@ void ui_screen_wipe_progress(int pos, int len);
 void ui_screen_done(uint8_t restart_seconds, secbool full_redraw);
 
 void ui_screen_fail(void);
+void ui_screen_install_restricted(void);
 
 void ui_fadein(void);
 void ui_fadeout(void);

--- a/core/embed/bootloader/messages.c
+++ b/core/embed/bootloader/messages.c
@@ -577,9 +577,9 @@ int process_msg_FirmwareUpload(uint8_t iface_num, uint32_t msg_size,
       if (sectrue != secret_wiped() && ((vhdr.vtrust & VTRUST_SECRET) != 0)) {
         MSG_SEND_INIT(Failure);
         MSG_SEND_ASSIGN_VALUE(code, FailureType_Failure_ProcessError);
-        MSG_SEND_ASSIGN_STRING(message, "Attestation present");
+        MSG_SEND_ASSIGN_STRING(message, "Install restricted");
         MSG_SEND(Failure);
-        return UPLOAD_ERR_ATTESTATION_PRESENT;
+        return UPLOAD_ERR_BOOTLOADER_LOCKED;
       }
 #endif
 
@@ -735,8 +735,8 @@ void process_msg_unknown(uint8_t iface_num, uint32_t msg_size, uint8_t *buf) {
 }
 
 #ifdef USE_OPTIGA
-void process_msg_AttestationDelete(uint8_t iface_num, uint32_t msg_size,
-                                   uint8_t *buf) {
+void process_msg_UnlockBootloader(uint8_t iface_num, uint32_t msg_size,
+                                  uint8_t *buf) {
   secret_erase();
   MSG_SEND_INIT(Success);
   MSG_SEND(Success);

--- a/core/embed/bootloader/messages.h
+++ b/core/embed/bootloader/messages.h
@@ -41,7 +41,7 @@ enum {
   UPLOAD_ERR_USER_ABORT = -7,
   UPLOAD_ERR_FIRMWARE_TOO_BIG = -8,
   UPLOAD_ERR_INVALID_CHUNK_HASH = -9,
-  UPLOAD_ERR_ATTESTATION_PRESENT = -10,
+  UPLOAD_ERR_BOOTLOADER_LOCKED = -10,
 };
 
 enum {
@@ -69,8 +69,8 @@ int process_msg_WipeDevice(uint8_t iface_num, uint32_t msg_size, uint8_t *buf);
 void process_msg_unknown(uint8_t iface_num, uint32_t msg_size, uint8_t *buf);
 
 #ifdef USE_OPTIGA
-void process_msg_AttestationDelete(uint8_t iface_num, uint32_t msg_size,
-                                   uint8_t *buf);
+void process_msg_UnlockBootloader(uint8_t iface_num, uint32_t msg_size,
+                                  uint8_t *buf);
 #endif
 
 secbool bootloader_WipeDevice(void);


### PR DESCRIPTION
Somehow we didn't add it with the last T2B1 bootloader changes. 

Also fixes residual "attestation present" wording. Especially the return message when failing to install might be a reason to add this to earliest production bootloader version, as its something a user see in trezorctl and suite can react to it too, so having two version might be annoying.

<!--
If you are a core dev:

Don't forget to set up the fields:
- assign yourself
- set priority to same as original issue
- add PR to sprint
- if Draft -> "in progress"
- if final PR -> "needs review"

If you're an external contributor, you can ignore this text.
-->
