### PR TITLE
disable access to secret in flash after boot

### DIFF
--- a/core/embed/firmware/main.c
+++ b/core/embed/firmware/main.c
@@ -116,6 +116,12 @@ int main(void) {
 
   unit_variant_init();
 
+#ifdef USE_OPTIGA
+  uint8_t secret[SECRET_OPTIGA_KEY_LEN] = {0};
+  secbool secret_ok =
+      secret_read(secret, SECRET_OPTIGA_KEY_OFFSET, SECRET_OPTIGA_KEY_LEN);
+#endif
+
 #if PRODUCTION || BOOTLOADER_QA
   check_and_replace_bootloader();
 #endif
@@ -166,10 +172,7 @@ int main(void) {
 #ifdef USE_OPTIGA
   optiga_init();
   optiga_open_application();
-
-  uint8_t secret[SECRET_OPTIGA_KEY_LEN] = {0};
-  if (secret_read(secret, SECRET_OPTIGA_KEY_OFFSET, SECRET_OPTIGA_KEY_LEN) ==
-      sectrue) {
+  if (sectrue == secret_ok) {
     optiga_sec_chan_handshake(secret, sizeof(secret));
   }
   memzero(secret, sizeof(secret));

--- a/core/embed/trezorhal/stm32f4/mpu.c
+++ b/core/embed/trezorhal/stm32f4/mpu.c
@@ -125,13 +125,12 @@ void mpu_config_firmware(void) {
   MPU->RASR = MPU_RASR_ENABLE_Msk | MPU_RASR_ATTR_FLASH |
               LL_MPU_REGION_SIZE_64KB | LL_MPU_REGION_FULL_ACCESS |
               MPU_RASR_XN_Msk;
-  // Secret + Storage#2 (0x08100000 - 0x0811FFFF, 16 Kib + 64 KiB, read-write,
-  // execute never)
+  // Storage#2 (0x08110000 - 0x0811FFFF, 64 KiB, read-write, execute never)
   MPU->RNR = MPU_REGION_NUMBER2;
   MPU->RBAR = FLASH_BASE + 0x110000;
   MPU->RASR = MPU_RASR_ENABLE_Msk | MPU_RASR_ATTR_FLASH |
-              LL_MPU_REGION_SIZE_128KB | LL_MPU_REGION_FULL_ACCESS |
-              MPU_RASR_XN_Msk | MPU_SUBREGION_DISABLE(0x0E);
+              LL_MPU_REGION_SIZE_64KB | LL_MPU_REGION_FULL_ACCESS |
+              MPU_RASR_XN_Msk;
 
   // Firmware (0x08040000 - 0x080FFFFF, 6 * 128 KiB = 1024 KiB except 2/8 at
   // start = 768 KiB, read-only)


### PR DESCRIPTION
disable access to secret in flash after boot.

<!--
If you are a core dev:

Don't forget to set up the fields:
- assign yourself
- set priority to same as original issue
- add PR to sprint
- if Draft -> "in progress"
- if final PR -> "needs review"

If you're an external contributor, you can ignore this text.
-->
