### PR TITLE
tests: tweak wait time for test_busy_expiry

### DIFF
--- a/tests/device_tests/test_busy_state.py
+++ b/tests/device_tests/test_busy_state.py
@@ -69,11 +69,11 @@ def test_busy_expiry(client: Client):
     _assert_busy(client, True)
 
     # Hasn't expired yet.
-    time.sleep(1.4)
+    time.sleep(0.1)
     _assert_busy(client, True)
 
-    # Wait for it to expire. Add 400ms tolerance to account for CI slowness.
-    time.sleep(0.5)
+    # Wait for it to expire. Add some tolerance to account for CI/hardware slowness.
+    time.sleep(4.0)
 
     # Check that the device is no longer busy.
     # Also needs to come back to Homescreen (for UI tests).


### PR DESCRIPTION
Durations seems to work on T2B1 hardware. See also #3158.
