### PR TITLE
fix T2B1 "restarting in" label capitalization

### DIFF
--- a/core/embed/bootloader/bootui.c
+++ b/core/embed/bootloader/bootui.c
@@ -242,17 +242,7 @@ void ui_screen_wipe_progress(int pos, int len) {
 
 // done UI
 void ui_screen_done(uint8_t restart_seconds, secbool full_redraw) {
-  const char *str;
-  char count_str[24];
-  if (restart_seconds >= 1) {
-    mini_snprintf(count_str, sizeof(count_str), "RESTARTING IN %d",
-                  restart_seconds);
-    str = count_str;
-  } else {
-    str = "RECONNECT THE DEVICE";
-  }
-
-  screen_install_success(str, initial_setup, full_redraw);
+  screen_install_success(restart_seconds, initial_setup, full_redraw);
 }
 
 void ui_screen_boot_empty(bool fading) { screen_boot_empty(fading); }

--- a/core/embed/bootloader/emulator.c
+++ b/core/embed/bootloader/emulator.c
@@ -87,7 +87,8 @@ __attribute__((noreturn)) void jump_to(void *addr) {
                             "STORAGE WAS ERASED");
   } else {
     printf("storage was retained\n");
-    screen_install_success("STORAGE WAS RETAINED", true, true);
+    screen_fatal_error_rust("BOOTLOADER EXIT", "Jumped to firmware",
+                            "STORAGE WAS RETAINED");
   }
   display_backlight(180);
   display_refresh();

--- a/core/embed/rust/rust_ui.h
+++ b/core/embed/rust/rust_ui.h
@@ -19,7 +19,7 @@ void screen_fatal_error_rust(const char* title, const char* msg,
                              const char* footer);
 void screen_wipe_success(void);
 void screen_wipe_fail(void);
-uint32_t screen_install_success(const char* reboot_msg, bool initial_setup,
+uint32_t screen_install_success(uint8_t restart_seconds, bool initial_setup,
                                 bool complete_draw);
 uint32_t screen_install_fail(void);
 void screen_welcome_model(void);

--- a/core/embed/rust/src/ui/model_tr/bootloader/mod.rs
+++ b/core/embed/rust/src/ui/model_tr/bootloader/mod.rs
@@ -301,7 +301,7 @@ extern "C" fn screen_wipe_success() {
     let title = Label::centered("Trezor Reset", theme::TEXT_BOLD).vertically_centered();
 
     let content =
-        Label::centered("Reconnect\nthe device", theme::TEXT_NORMAL).vertically_centered();
+        Label::centered("Please reconnect\nthe device", theme::TEXT_NORMAL).vertically_centered();
 
     let mut frame = ResultScreen::new(BLD_FG, BLD_BG, ICON_SPINNER, title, content, true);
     show(&mut frame);
@@ -339,15 +339,24 @@ extern "C" fn screen_install_fail() {
 
 #[no_mangle]
 extern "C" fn screen_install_success(
-    reboot_msg: *const cty::c_char,
+    restart_seconds: u8,
     _initial_setup: bool,
     complete_draw: bool,
 ) {
-    let msg = unwrap!(unsafe { from_c_str(reboot_msg) });
+    let mut reboot_msg = BootloaderString::new();
+
+    if restart_seconds >= 1 {
+        unwrap!(reboot_msg.push_str("Restarting in "));
+        // in practice, restart_seconds is 5 or less so this is fine
+        let seconds_char = b'0' + restart_seconds % 10;
+        unwrap!(reboot_msg.push(seconds_char as char));
+    } else {
+        unwrap!(reboot_msg.push_str("Reconnect the device"));
+    }
 
     let title = Label::centered("Firmware installed", theme::TEXT_BOLD).vertically_centered();
 
-    let content = Label::centered(msg, theme::TEXT_NORMAL).vertically_centered();
+    let content = Label::centered(reboot_msg.as_str(), theme::TEXT_NORMAL).vertically_centered();
 
     let mut frame = ResultScreen::new(BLD_FG, BLD_BG, ICON_SPINNER, title, content, complete_draw);
     show(&mut frame);

--- a/core/embed/rust/src/ui/model_tr/component/result.rs
+++ b/core/embed/rust/src/ui/model_tr/component/result.rs
@@ -5,8 +5,10 @@ use crate::ui::{
     geometry::{Alignment2D, Offset, Point, Rect},
 };
 
-const MESSAGE_AREA_START: i16 = 26;
-const FOOTER_AREA_START: i16 = 40;
+const MESSAGE_AREA_START: i16 = 24 + 11;
+const MESSAGE_AREA_START_2L: i16 = 24 + 7;
+const FOOTER_AREA_START: i16 = MESSAGE_AREA_START + 10;
+const FOOTER_AREA_START_2L: i16 = MESSAGE_AREA_START_2L + 10;
 const ICON_TOP: i16 = 12;
 
 pub struct ResultScreen<'a> {
@@ -53,15 +55,36 @@ impl<'a> Component for ResultScreen<'a> {
     fn place(&mut self, bounds: Rect) -> Rect {
         self.bg.place(bounds);
 
-        self.message_top.place(Rect::new(
-            Point::new(0, MESSAGE_AREA_START),
-            Point::new(WIDTH, FOOTER_AREA_START),
-        ));
-
         let bottom_area = Rect::new(Point::new(0, FOOTER_AREA_START), Point::new(WIDTH, HEIGHT));
 
-        self.small_pad.place(bottom_area);
         self.message_bottom.place(bottom_area);
+        let h = self.message_bottom.inner().text_height(WIDTH);
+
+        if h > 8 {
+            self.message_top.place(Rect::new(
+                Point::new(0, MESSAGE_AREA_START_2L),
+                Point::new(WIDTH, FOOTER_AREA_START_2L),
+            ));
+
+            let bottom_area = Rect::new(
+                Point::new(0, FOOTER_AREA_START_2L),
+                Point::new(WIDTH, FOOTER_AREA_START_2L + h),
+            );
+            self.message_bottom.place(bottom_area);
+        } else {
+            self.message_top.place(Rect::new(
+                Point::new(0, MESSAGE_AREA_START),
+                Point::new(WIDTH, FOOTER_AREA_START),
+            ));
+
+            let bottom_area = Rect::new(
+                Point::new(0, FOOTER_AREA_START),
+                Point::new(WIDTH, FOOTER_AREA_START + h),
+            );
+            self.message_bottom.place(bottom_area);
+        }
+
+        self.small_pad.place(bottom_area);
 
         bounds
     }

--- a/core/embed/rust/src/ui/model_tt/component/error.rs
+++ b/core/embed/rust/src/ui/model_tt/component/error.rs
@@ -30,7 +30,10 @@ impl<T: AsRef<str>> ErrorScreen<'_, T> {
     pub fn new(title: T, message: T, footer: T) -> Self {
         let title = Label::centered(title, STYLE.title_style());
         let message = Label::centered(message, STYLE.message_style());
-        let footer = ResultFooter::new(footer, STYLE);
+        let footer = ResultFooter::new(
+            Label::centered(footer, STYLE.title_style()).vertically_centered(),
+            STYLE,
+        );
 
         Self {
             bg: Pad::with_background(FATAL_ERROR_COLOR).with_clear(),

--- a/core/embed/rust/src/ui/model_tt/component/result.rs
+++ b/core/embed/rust/src/ui/model_tt/component/result.rs
@@ -48,10 +48,10 @@ pub struct ResultFooter<'a, T> {
 }
 
 impl<'a, T: AsRef<str>> ResultFooter<'a, T> {
-    pub fn new(text: T, style: &'a ResultStyle) -> Self {
+    pub fn new(text: Label<T>, style: &'a ResultStyle) -> Self {
         Self {
             style,
-            text: Label::centered(text, style.title_style()).vertically_centered(),
+            text,
             area: Rect::zero(),
         }
     }
@@ -101,7 +101,7 @@ pub struct ResultScreen<'a, T> {
     style: &'a ResultStyle,
     icon: Icon,
     message: Child<Label<T>>,
-    footer: Child<ResultFooter<'a, T>>,
+    footer: Child<ResultFooter<'a, &'a str>>,
 }
 
 impl<'a, T: StringType> ResultScreen<'a, T> {
@@ -109,7 +109,7 @@ impl<'a, T: StringType> ResultScreen<'a, T> {
         style: &'a ResultStyle,
         icon: Icon,
         message: T,
-        footer: T,
+        footer: Label<&'a str>,
         complete_draw: bool,
     ) -> Self {
         let mut instance = Self {
@@ -130,13 +130,13 @@ impl<'a, T: StringType> ResultScreen<'a, T> {
     }
 }
 
-impl<T: StringType> Component for ResultScreen<'_, T> {
+impl<'a, T: StringType> Component for ResultScreen<'a, T> {
     type Msg = Never;
 
     fn place(&mut self, _bounds: Rect) -> Rect {
         self.bg.place(screen());
 
-        let (main_area, footer_area) = ResultFooter::<T>::split_bounds();
+        let (main_area, footer_area) = ResultFooter::<&'a str>::split_bounds();
 
         self.footer_pad.place(footer_area);
         self.footer.place(footer_area);


### PR DESCRIPTION
- moved the message composition to rust, had to adjust few things to satisfy lifetimes etc.
- positioning of the message is also fixed to better match the design
- one reconnect message is also fixed

<!--
If you are a core dev:

Don't forget to set up the fields:
- assign yourself
- set priority to same as original issue
- add PR to sprint
- if Draft -> "in progress"
- if final PR -> "needs review"

If you're an external contributor, you can ignore this text.
-->
