### PR TITLE
skip signature check for make_upload commands

### DIFF
--- a/core/Makefile
+++ b/core/Makefile
@@ -349,10 +349,10 @@ combine: ## combine boardloader + bootloader + prodtest into one combined image
 		$(PRODTEST_BUILD_DIR)/combined.bin
 
 upload: ## upload firmware using trezorctl
-	trezorctl firmware_update -f $(FIRMWARE_BUILD_DIR)/firmware.bin
+	trezorctl firmware_update -s -f $(FIRMWARE_BUILD_DIR)/firmware.bin
 
 upload_prodtest: ## upload prodtest using trezorctl
-	trezorctl firmware_update -f $(PRODTEST_BUILD_DIR)/prodtest.bin
+	trezorctl firmware_update -s -f $(PRODTEST_BUILD_DIR)/prodtest.bin
 
 coverage:  ## generate coverage report
 	./tools/coverage-report


### PR DESCRIPTION
Since the recent vendor header changes, these commands were not usable with dev bootloader. I think that this is mostly used by devs so the check is not important, and the shortcut is handy.

<!--
If you are a core dev:

Don't forget to set up the fields:
- assign yourself
- set priority to same as original issue
- add PR to sprint
- if Draft -> "in progress"
- if final PR -> "needs review"

If you're an external contributor, you can ignore this text.
-->
