### PR TITLE
feat(core/rust): differentiate between short and long button press

### DIFF
--- a/core/embed/rust/src/ui/model_tr/bootloader/confirm.rs
+++ b/core/embed/rust/src/ui/model_tr/bootloader/confirm.rs
@@ -155,7 +155,7 @@ impl<'a> Component for Confirm<'a> {
         let msg = self.buttons.event(ctx, event);
         if self.showing_info_screen {
             // Showing the info screen currently - going back with the left button
-            if let Some(ButtonControllerMsg::Triggered(ButtonPos::Left)) = msg {
+            if let Some(ButtonControllerMsg::Triggered(ButtonPos::Left, _)) = msg {
                 self.showing_info_screen = false;
                 self.update_everything(ctx);
             };
@@ -163,11 +163,13 @@ impl<'a> Component for Confirm<'a> {
         } else if self.has_info_screen() {
             // Being on the "main" screen but with an info screen available on the right
             match msg {
-                Some(ButtonControllerMsg::Triggered(ButtonPos::Left)) => Some(ConfirmMsg::Cancel),
-                Some(ButtonControllerMsg::Triggered(ButtonPos::Middle)) => {
+                Some(ButtonControllerMsg::Triggered(ButtonPos::Left, _)) => {
+                    Some(ConfirmMsg::Cancel)
+                }
+                Some(ButtonControllerMsg::Triggered(ButtonPos::Middle, _)) => {
                     Some(ConfirmMsg::Confirm)
                 }
-                Some(ButtonControllerMsg::Triggered(ButtonPos::Right)) => {
+                Some(ButtonControllerMsg::Triggered(ButtonPos::Right, _)) => {
                     self.showing_info_screen = true;
                     self.update_everything(ctx);
                     None
@@ -176,8 +178,10 @@ impl<'a> Component for Confirm<'a> {
             }
         } else if self.two_btn_confirm {
             match msg {
-                Some(ButtonControllerMsg::Triggered(ButtonPos::Left)) => Some(ConfirmMsg::Cancel),
-                Some(ButtonControllerMsg::Triggered(ButtonPos::Middle)) => {
+                Some(ButtonControllerMsg::Triggered(ButtonPos::Left, _)) => {
+                    Some(ConfirmMsg::Cancel)
+                }
+                Some(ButtonControllerMsg::Triggered(ButtonPos::Middle, _)) => {
                     Some(ConfirmMsg::Confirm)
                 }
                 _ => None,
@@ -185,8 +189,12 @@ impl<'a> Component for Confirm<'a> {
         } else {
             // There is just one main screen without info screen
             match msg {
-                Some(ButtonControllerMsg::Triggered(ButtonPos::Left)) => Some(ConfirmMsg::Cancel),
-                Some(ButtonControllerMsg::Triggered(ButtonPos::Right)) => Some(ConfirmMsg::Confirm),
+                Some(ButtonControllerMsg::Triggered(ButtonPos::Left, _)) => {
+                    Some(ConfirmMsg::Cancel)
+                }
+                Some(ButtonControllerMsg::Triggered(ButtonPos::Right, _)) => {
+                    Some(ConfirmMsg::Confirm)
+                }
                 _ => None,
             }
         }

--- a/core/embed/rust/src/ui/model_tr/bootloader/intro.rs
+++ b/core/embed/rust/src/ui/model_tr/bootloader/intro.rs
@@ -67,10 +67,10 @@ impl<'a> Component for Intro<'a> {
     fn event(&mut self, ctx: &mut EventCtx, event: Event) -> Option<Self::Msg> {
         let msg = self.buttons.event(ctx, event);
 
-        if let Some(Triggered(ButtonPos::Left)) = msg {
+        if let Some(Triggered(ButtonPos::Left, _)) = msg {
             return Some(Self::Msg::InstallFirmware);
         };
-        if let Some(Triggered(ButtonPos::Right)) = msg {
+        if let Some(Triggered(ButtonPos::Right, _)) = msg {
             return Some(Self::Msg::GoToMenu);
         };
         None

--- a/core/embed/rust/src/ui/model_tr/bootloader/menu.rs
+++ b/core/embed/rust/src/ui/model_tr/bootloader/menu.rs
@@ -141,7 +141,7 @@ impl Component for Menu {
     }
 
     fn event(&mut self, ctx: &mut EventCtx, event: Event) -> Option<Self::Msg> {
-        self.choice_page.event(ctx, event)
+        self.choice_page.event(ctx, event).map(|evt| evt.0)
     }
 
     fn paint(&mut self) {

--- a/core/embed/rust/src/ui/model_tr/component/address_details.rs
+++ b/core/embed/rust/src/ui/model_tr/component/address_details.rs
@@ -204,7 +204,7 @@ where
         };
 
         let button_event = self.buttons.event(ctx, event);
-        if let Some(ButtonControllerMsg::Triggered(button)) = button_event {
+        if let Some(ButtonControllerMsg::Triggered(button, _)) = button_event {
             if self.is_in_subpage() {
                 match button {
                     ButtonPos::Left => {

--- a/core/embed/rust/src/ui/model_tr/component/flow.rs
+++ b/core/embed/rust/src/ui/model_tr/component/flow.rs
@@ -256,7 +256,7 @@ where
 
         // Do something when a button was triggered
         // and we have some action connected with it
-        if let Some(ButtonControllerMsg::Triggered(pos)) = button_event {
+        if let Some(ButtonControllerMsg::Triggered(pos, _)) = button_event {
             // When there is a previous or next screen in the current flow,
             // handle that first and in case it triggers, then do not continue
             if self.event_consumed_by_current_choice(ctx, pos) {

--- a/core/embed/rust/src/ui/model_tr/component/homescreen.rs
+++ b/core/embed/rust/src/ui/model_tr/component/homescreen.rs
@@ -144,7 +144,7 @@ where
     fn event(&mut self, ctx: &mut EventCtx, event: Event) -> Option<Self::Msg> {
         Self::event_usb(self, ctx, event);
         // HTC press of any button will lock the device
-        if let Some(ButtonControllerMsg::Triggered(_)) = self.invisible_buttons.event(ctx, event) {
+        if let Some(ButtonControllerMsg::Triggered(..)) = self.invisible_buttons.event(ctx, event) {
             return Some(());
         }
         None
@@ -202,7 +202,7 @@ where
 
     fn event(&mut self, ctx: &mut EventCtx, event: Event) -> Option<Self::Msg> {
         // Press of any button will unlock the device
-        if let Some(ButtonControllerMsg::Triggered(_)) = self.invisible_buttons.event(ctx, event) {
+        if let Some(ButtonControllerMsg::Triggered(..)) = self.invisible_buttons.event(ctx, event) {
             return Some(());
         }
         None
@@ -261,7 +261,7 @@ where
 
     fn event(&mut self, ctx: &mut EventCtx, event: Event) -> Option<Self::Msg> {
         // Left button cancels, right confirms
-        if let Some(ButtonControllerMsg::Triggered(pos)) = self.buttons.event(ctx, event) {
+        if let Some(ButtonControllerMsg::Triggered(pos, _)) = self.buttons.event(ctx, event) {
             match pos {
                 ButtonPos::Left => return Some(CancelConfirmMsg::Cancelled),
                 ButtonPos::Right => return Some(CancelConfirmMsg::Confirmed),

--- a/core/embed/rust/src/ui/model_tr/component/input_methods/choice.rs
+++ b/core/embed/rust/src/ui/model_tr/component/input_methods/choice.rs
@@ -474,7 +474,7 @@ where
     F: ChoiceFactory<T, Action = A>,
     T: StringType + Clone,
 {
-    type Msg = A;
+    type Msg = (A, bool);
 
     fn place(&mut self, bounds: Rect) -> Rect {
         let (content_area, button_area) = bounds.split_bottom(theme::BUTTON_HEIGHT);
@@ -516,7 +516,7 @@ where
             // Stopping the automatic movement when the released button is the same as the
             // direction we were moving, or when the pressed button is the
             // opposite one (user does middle-click).
-            if matches!(button_event, Some(ButtonControllerMsg::Triggered(pos)) if pos == moving_direction)
+            if matches!(button_event, Some(ButtonControllerMsg::Triggered(pos, _)) if pos == moving_direction)
                 || matches!(button_event, Some(ButtonControllerMsg::Pressed(pos)) if pos != moving_direction)
             {
                 self.holding_mover.stop_moving();
@@ -534,7 +534,7 @@ where
         }
 
         // There was a legitimate button event - doing some action
-        if let Some(ButtonControllerMsg::Triggered(pos)) = button_event {
+        if let Some(ButtonControllerMsg::Triggered(pos, long_press)) = button_event {
             match pos {
                 ButtonPos::Left => {
                     // Clicked BACK. Decrease the page counter.
@@ -547,9 +547,9 @@ where
                     self.move_right(ctx);
                 }
                 ButtonPos::Middle => {
-                    // Clicked SELECT. Send current choice index
+                    // Clicked SELECT. Send current choice index with information about long-press
                     self.clear_and_repaint(ctx);
-                    return Some(self.get_current_choice().1);
+                    return Some((self.get_current_choice().1, long_press));
                 }
             }
         };

--- a/core/embed/rust/src/ui/model_tr/component/input_methods/number_input.rs
+++ b/core/embed/rust/src/ui/model_tr/component/input_methods/number_input.rs
@@ -78,7 +78,7 @@ where
     }
 
     fn event(&mut self, ctx: &mut EventCtx, event: Event) -> Option<Self::Msg> {
-        self.choice_page.event(ctx, event)
+        self.choice_page.event(ctx, event).map(|evt| evt.0)
     }
 
     fn paint(&mut self) {

--- a/core/embed/rust/src/ui/model_tr/component/input_methods/passphrase.rs
+++ b/core/embed/rust/src/ui/model_tr/component/input_methods/passphrase.rs
@@ -291,6 +291,10 @@ where
         self.textbox.delete_last(ctx);
     }
 
+    fn delete_all_digits(&mut self, ctx: &mut EventCtx) {
+        self.textbox.clear(ctx);
+    }
+
     /// Displaying the MENU
     fn show_menu_page(&mut self, ctx: &mut EventCtx) {
         let menu_choices = ChoiceFactoryPassphrase::new(ChoiceCategory::Menu, self.is_empty());
@@ -359,13 +363,18 @@ where
             }
         }
 
-        if let Some(action) = self.choice_page.event(ctx, event) {
+        if let Some((action, long_press)) = self.choice_page.event(ctx, event) {
             match action {
                 PassphraseAction::CancelOrDelete => {
                     if self.is_empty() {
                         return Some(CancelConfirmMsg::Cancelled);
                     } else {
-                        self.delete_last_digit(ctx);
+                        // Deleting all when long-pressed
+                        if long_press {
+                            self.delete_all_digits(ctx);
+                        } else {
+                            self.delete_last_digit(ctx);
+                        }
                         self.update_passphrase_dots(ctx);
                         if self.is_empty() {
                             // Allowing for DELETE/CANCEL change

--- a/core/embed/rust/src/ui/model_tr/component/input_methods/simple_choice.rs
+++ b/core/embed/rust/src/ui/model_tr/component/input_methods/simple_choice.rs
@@ -112,7 +112,7 @@ where
     }
 
     fn event(&mut self, ctx: &mut EventCtx, event: Event) -> Option<Self::Msg> {
-        self.choice_page.event(ctx, event)
+        self.choice_page.event(ctx, event).map(|evt| evt.0)
     }
 
     fn paint(&mut self) {

--- a/core/embed/rust/src/ui/model_tr/component/input_methods/wordlist.rs
+++ b/core/embed/rust/src/ui/model_tr/component/input_methods/wordlist.rs
@@ -201,19 +201,25 @@ where
     }
 
     fn event(&mut self, ctx: &mut EventCtx, event: Event) -> Option<Self::Msg> {
-        match self.choice_page.event(ctx, event) {
-            Some(WordlistAction::Delete) => {
-                self.textbox.delete_last(ctx);
-                self.update(ctx);
+        if let Some((action, long_press)) = self.choice_page.event(ctx, event) {
+            match action {
+                WordlistAction::Delete => {
+                    // Deleting all when long-pressed
+                    if long_press {
+                        self.textbox.clear(ctx);
+                    } else {
+                        self.textbox.delete_last(ctx);
+                    }
+                    self.update(ctx);
+                }
+                WordlistAction::Letter(letter) => {
+                    self.textbox.append(ctx, letter);
+                    self.update(ctx);
+                }
+                WordlistAction::Word(word) => {
+                    return Some(word);
+                }
             }
-            Some(WordlistAction::Letter(letter)) => {
-                self.textbox.append(ctx, letter);
-                self.update(ctx);
-            }
-            Some(WordlistAction::Word(word)) => {
-                return Some(word);
-            }
-            _ => {}
         }
         None
     }

--- a/core/embed/rust/src/ui/model_tr/component/page.rs
+++ b/core/embed/rust/src/ui/model_tr/component/page.rs
@@ -182,7 +182,7 @@ where
 
     fn event(&mut self, ctx: &mut EventCtx, event: Event) -> Option<Self::Msg> {
         ctx.set_page_count(self.page_count());
-        if let Some(ButtonControllerMsg::Triggered(pos)) = self.buttons.event(ctx, event) {
+        if let Some(ButtonControllerMsg::Triggered(pos, _)) = self.buttons.event(ctx, event) {
             match pos {
                 ButtonPos::Left => {
                     if self.has_previous_page() {

--- a/core/embed/rust/src/ui/model_tr/component/result_popup.rs
+++ b/core/embed/rust/src/ui/model_tr/component/result_popup.rs
@@ -134,7 +134,7 @@ where
         self.text.event(ctx, event);
         self.headline.event(ctx, event);
 
-        if let Some(ButtonControllerMsg::Triggered(ButtonPos::Right)) =
+        if let Some(ButtonControllerMsg::Triggered(ButtonPos::Right, _)) =
             self.buttons.event(ctx, event)
         {
             button_confirmed = true;

--- a/core/embed/rust/src/ui/model_tr/component/show_more.rs
+++ b/core/embed/rust/src/ui/model_tr/component/show_more.rs
@@ -58,7 +58,7 @@ where
     fn event(&mut self, ctx: &mut EventCtx, event: Event) -> Option<Self::Msg> {
         let button_event = self.buttons.event(ctx, event);
 
-        if let Some(ButtonControllerMsg::Triggered(pos)) = button_event {
+        if let Some(ButtonControllerMsg::Triggered(pos, _)) = button_event {
             match pos {
                 ButtonPos::Left => {
                     return Some(CancelInfoConfirmMsg::Cancelled);


### PR DESCRIPTION
Fixes https://github.com/trezor/trezor-firmware/issues/3264:
- allows for longer `DELETE` press to delete the whole inputted content, not just one character - in `PIN` or `passphrase` inputs
