### PR TITLE
Implement hashing to curve

### DIFF
--- a/crypto/Makefile
+++ b/crypto/Makefile
@@ -124,6 +124,7 @@ SRCS  += zkp_ecdsa.c
 SRCS  += zkp_bip340.c
 SRCS  += cardano.c
 SRCS  += tls_prf.c
+SRCS  += hash_to_curve.c
 
 OBJS   = $(SRCS:.c=.o)
 OBJS  += secp256k1-zkp.o

--- a/crypto/bignum.c
+++ b/crypto/bignum.c
@@ -1591,6 +1591,39 @@ void bn_subtract(const bignum256 *x, const bignum256 *y, bignum256 *res) {
   //     == 1
 }
 
+// Returns 0 if x is zero
+// Returns 1 if x is a square modulo prime
+// Returns -1 if x is not a square modulo prime
+// Assumes x is normalized, x < 2**259
+// Assumes prime is normalized, 2**256 - 2**224 <= prime <= 2**256
+// Assumes prime is a prime
+// The function doesn't have neither constant control flow nor constant memory
+//  access flow with regard to prime
+int bn_legendre(const bignum256 *x, const bignum256 *prime) {
+  // This is a naive implementation
+  // A better implementation would be to use the Euclidean algorithm together with the quadratic reciprocity law
+
+  // e = (prime - 1) / 2
+  bignum256 e = {0};
+  bn_copy(prime, &e);
+  bn_rshift(&e);
+
+  // res = x**e % prime
+  bignum256 res = {0};
+  bn_power_mod(x, &e, prime, &res);
+  bn_mod(&res, prime);
+
+  if (bn_is_one(&res)) {
+    return 1;
+  }
+
+  if (bn_is_zero(&res)) {
+    return 0;
+  }
+
+  return -1;
+}
+
 // q = x // d, r = x % d
 // Assumes x is normalized, 1 <= d <= 61304
 // Guarantees q is normalized

--- a/crypto/bignum.c
+++ b/crypto/bignum.c
@@ -886,7 +886,7 @@ void bn_sqrt(bignum256 *x, const bignum256 *prime) {
   // http://en.wikipedia.org/wiki/Quadratic_residue#Prime_or_prime_power_modulus
   // If prime % 4 == 3, then sqrt(x) % prime == x**((prime+1)//4) % prime
 
-  assert(prime->val[BN_LIMBS - 1] % 4 == 3);
+  assert(prime->val[0] % 4 == 3);
 
   // e = (prime + 1) // 4
   bignum256 e = {0};

--- a/crypto/bignum.h
+++ b/crypto/bignum.h
@@ -74,6 +74,7 @@ static inline void write_le(uint8_t *data, uint32_t x) {
 
 void bn_copy_lower(const bignum512 *x, bignum256 *y);
 void bn_read_be(const uint8_t *in_number, bignum256 *out_number);
+void bn_read_be_512(const uint8_t *in_number, bignum512 *out_number);
 void bn_write_be(const bignum256 *in_number, uint8_t *out_number);
 void bn_read_le(const uint8_t *in_number, bignum256 *out_number);
 void bn_write_le(const bignum256 *in_number, uint8_t *out_number);

--- a/crypto/bignum.h
+++ b/crypto/bignum.h
@@ -43,6 +43,11 @@ typedef struct {
   uint32_t val[BN_LIMBS];
 } bignum256;
 
+// Represents the number sum([val[i] * 2**(29*i) for i in range(18))
+typedef struct {
+  uint32_t val[2 * BN_LIMBS];
+} bignum512;
+
 static inline uint32_t read_be(const uint8_t *data) {
   return (((uint32_t)data[0]) << 24) | (((uint32_t)data[1]) << 16) |
          (((uint32_t)data[2]) << 8) | (((uint32_t)data[3]));

--- a/crypto/bignum.h
+++ b/crypto/bignum.h
@@ -108,6 +108,7 @@ void bn_subi(bignum256 *x, uint32_t y, const bignum256 *prime);
 void bn_subtractmod(const bignum256 *x, const bignum256 *y, bignum256 *res,
                     const bignum256 *prime);
 void bn_subtract(const bignum256 *x, const bignum256 *y, bignum256 *res);
+int bn_legendre(const bignum256 *x, const bignum256 *prime);
 void bn_long_division(bignum256 *x, uint32_t d, bignum256 *q, uint32_t *r);
 void bn_divmod58(bignum256 *x, uint32_t *r);
 void bn_divmod1000(bignum256 *x, uint32_t *r);

--- a/crypto/bignum.h
+++ b/crypto/bignum.h
@@ -72,6 +72,7 @@ static inline void write_le(uint8_t *data, uint32_t x) {
   data[0] = x;
 }
 
+void bn_copy_lower(const bignum512 *x, bignum256 *y);
 void bn_read_be(const uint8_t *in_number, bignum256 *out_number);
 void bn_write_be(const bignum256 *in_number, uint8_t *out_number);
 void bn_read_le(const uint8_t *in_number, bignum256 *out_number);
@@ -99,6 +100,7 @@ void bn_mult_half(bignum256 *x, const bignum256 *prime);
 void bn_mult_k(bignum256 *x, uint8_t k, const bignum256 *prime);
 void bn_mod(bignum256 *x, const bignum256 *prime);
 void bn_multiply(const bignum256 *k, bignum256 *x, const bignum256 *prime);
+void bn_reduce(bignum512 *x, const bignum256 *prime);
 void bn_fast_mod(bignum256 *x, const bignum256 *prime);
 void bn_power_mod(const bignum256 *x, const bignum256 *e,
                   const bignum256 *prime, bignum256 *res);

--- a/crypto/hash_to_curve.c
+++ b/crypto/hash_to_curve.c
@@ -1,0 +1,413 @@
+/**
+ * Permission is hereby granted, free of charge, to any person obtaining
+ * a copy of this software and associated documentation files (the "Software"),
+ * to deal in the Software without restriction, including without limitation
+ * the rights to use, copy, modify, merge, publish, distribute, sublicense,
+ * and/or sell copies of the Software, and to permit persons to whom the
+ * Software is furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included
+ * in all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS
+ * OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL
+ * THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES
+ * OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE,
+ * ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
+ * OTHER DEALINGS IN THE SOFTWARE.
+ */
+#include <assert.h>
+#include <stdint.h>
+#include <string.h>
+
+#include "bignum.h"
+#include "ecdsa.h"
+#include "memzero.h"
+#include "nist256p1.h"
+#include "sha2.h"
+
+#include "hash_to_curve.h"
+
+// https://www.rfc-editor.org/rfc/rfc9380.html#name-hash_to_field-implementatio
+static bool hash_to_field(const uint8_t *msg, size_t msg_len,
+                          const uint8_t *dst,  // domain separation tag
+                          const size_t dst_len, size_t expansion_len,
+                          const bignum256 *prime,
+                          bool expand(const uint8_t *, size_t, const uint8_t *,
+                                      size_t, uint8_t *, size_t),
+                          bignum256 *out, size_t out_len) {
+  const size_t max_expansion_len = 64;
+  if (expansion_len > max_expansion_len) {
+    // Not supported by this implementation
+    return false;
+  }
+
+  const size_t expanded_msg_length = out_len * expansion_len;
+  uint8_t expanded_msg[expanded_msg_length];
+  memzero(expanded_msg, sizeof(expanded_msg));
+
+  if (!expand(msg, msg_len, dst, dst_len, expanded_msg, expanded_msg_length)) {
+    return false;
+  }
+
+  uint8_t raw_number[max_expansion_len];
+  memzero(raw_number, sizeof(raw_number));
+  bignum512 bn_number = {0};
+
+  for (size_t i = 0; i < out_len; i++) {
+    memcpy(raw_number + (max_expansion_len - expansion_len),
+           expanded_msg + i * expansion_len, expansion_len);
+
+    bn_read_be_512(raw_number, &bn_number);
+    bn_reduce(&bn_number, prime);
+    bn_copy_lower(&bn_number, &out[i]);
+    bn_mod(&out[i], prime);
+  }
+
+  memzero(expanded_msg, sizeof(expanded_msg));
+  memzero(raw_number, sizeof(raw_number));
+  memzero(&bn_number, sizeof(bn_number));
+
+  return true;
+}
+
+// Simplified Shallue-van de Woestijne-Ulas Method
+// https://www.rfc-editor.org/rfc/rfc9380.html#name-simplified-shallue-van-de-w
+// Algorithm assumptions:
+//   * z is a non-square modulo p
+//   * z != -1 modulo p
+//   * x^2 + a * x + b - z is an irreducible polynomial modulo p
+//   * (b/(z*a))^2 + a * (b/(z*a)) + b is a square modulo p
+//   * z is not zero
+//   * a is not zero
+//   * b is not zero
+//   * p is at least 6
+//  Implementation assumptions:
+//   * p is a prime
+//   * 2**256 - 2**224 <= prime <= 2**256
+//   * p % 4 == 3
+static bool simple_swu(const bignum256 *u, const bignum256 *a,
+                       const bignum256 *b, const bignum256 *p,
+                       const bignum256 *z, int sign_function(const bignum256 *),
+                       curve_point *point) {
+  if (bn_is_zero(a) || bn_is_zero(b) || (p->val[0] % 4 != 3)) {
+    return false;
+  }
+
+  // c1 = -b / a
+  bignum256 c1 = {0};
+  bn_copy(a, &c1);
+  bn_subtract(p, &c1, &c1);
+  bn_inverse(&c1, p);
+  bn_multiply(b, &c1, p);
+  bn_mod(&c1, p);
+
+  // c2 = -1 / z
+  bignum256 c2 = {0};
+  bn_copy(z, &c2);
+  bn_subtract(p, &c2, &c2);
+  bn_inverse(&c2, p);
+  bn_mod(&c2, p);
+
+  // t1 = z * u^2
+  bignum256 t1 = {0};
+  bn_copy(u, &t1);
+  bn_multiply(&t1, &t1, p);
+  bn_mod(&t1, p);
+  bn_multiply(z, &t1, p);
+  bn_mod(&t1, p);
+
+  // t2 = t1^2
+  bignum256 t2 = {0};
+  bn_copy(&t1, &t2);
+  bn_multiply(&t2, &t2, p);
+  bn_mod(&t2, p);
+
+  // x1 = t1 + t2
+  bignum256 x1 = {0};
+  bn_copy(&t1, &x1);
+  bn_add(&x1, &t2);
+  bn_mod(&x1, p);
+
+  // x1 = inv0(1)
+  bn_inverse(&x1, p);
+
+  // e1 = x1 == 0
+  int e1 = bn_is_zero(&x1);
+
+  // x1 = x1 + 1
+  bn_addi(&x1, 1);
+  bn_mod(&x1, p);
+
+  // x1 = CMOV(x1, c2, e1)
+  bn_cmov(&x1, e1, &c2, &x1);
+  memzero(&c2, sizeof(c2));
+
+  // x1 = x1 * c1
+  bn_multiply(&c1, &x1, p);
+  memzero(&c1, sizeof(c1));
+  bn_mod(&x1, p);
+
+  // gx1 = x1^2
+  bignum256 gx1 = {0};
+  bn_copy(&x1, &gx1);
+  bn_multiply(&x1, &gx1, p);
+  bn_mod(&gx1, p);
+
+  // gx1 = gx1 + A
+  bn_add(&gx1, a);
+  bn_mod(&gx1, p);
+
+  // gx1 = gx1 * x1
+  bn_multiply(&x1, &gx1, p);
+  bn_mod(&gx1, p);
+
+  // gx1 = gx1 + B
+  bn_add(&gx1, b);
+  bn_mod(&gx1, p);
+
+  // x2 = t1 * x1
+  bignum256 x2 = {0};
+  bn_copy(&t1, &x2);
+  bn_multiply(&x1, &x2, p);
+  bn_mod(&x2, p);
+
+  // t2 = t1 * t2
+  bn_multiply(&t1, &t2, p);
+  memzero(&t1, sizeof(t1));
+  bn_mod(&t2, p);
+
+  // gx2 = gx1 * t2
+  bignum256 gx2 = {0};
+  bn_copy(&gx1, &gx2);
+  bn_multiply(&t2, &gx2, p);
+  memzero(&t2, sizeof(t2));
+  bn_mod(&gx2, p);
+
+  // e2 = is_square(gx1)
+  int e2 = bn_legendre(&gx1, p) >= 0;
+
+  // x = CMOV(x2, x1, e2)
+  bignum256 x = {0};
+  bn_cmov(&x, e2, &x1, &x2);
+  memzero(&x1, sizeof(x1));
+  memzero(&x2, sizeof(x2));
+
+  // y2 = CMOV(gx2, gx1, e2)
+  bignum256 y2 = {0};
+  bn_cmov(&y2, e2, &gx1, &gx2);
+  memzero(&gx1, sizeof(gx1));
+  memzero(&gx2, sizeof(gx2));
+
+  // y = sqrt(y2)
+  bignum256 y = {0};
+  bn_copy(&y2, &y);
+  memzero(&y2, sizeof(y2));
+  bn_sqrt(&y, p);  // This is the slowest operation
+
+  // e3 = sgn0(u) == sgn0(y)
+  int e3 = sign_function(u) == sign_function(&y);
+
+  bignum256 minus_y = {0};
+  bn_subtract(p, &y, &minus_y);
+
+  // y = CMOV(-y, y, e3)
+  bn_cmov(&y, e3, &y, &minus_y);
+  memzero(&minus_y, sizeof(minus_y));
+
+  bn_copy(&x, &point->x);
+  bn_copy(&y, &point->y);
+  memzero(&x, sizeof(x));
+  memzero(&y, sizeof(y));
+
+  return true;
+}
+
+static void bn_read_int32(int32_t in_number, const bignum256 *prime,
+                          bignum256 *out_number) {
+  if (in_number < 0) {
+    bn_read_uint32(-in_number, out_number);
+    bn_subtract(prime, out_number, out_number);
+  } else {
+    bn_read_uint32(in_number, out_number);
+  }
+}
+
+// https://www.rfc-editor.org/rfc/rfc9380.html#name-encoding-byte-strings-to-el
+static bool hash_to_curve(const uint8_t *msg, size_t msg_len,
+                          const ecdsa_curve *curve, const uint8_t *suite_id,
+                          const uint8_t suite_id_len, int z, int cofactor,
+                          bool expand_function(const uint8_t *, size_t,
+                                               const uint8_t *, size_t,
+                                               uint8_t *, size_t),
+                          int sign_function(const bignum256 *),
+                          curve_point *point) {
+  if (cofactor != 1) {
+    // Not supported by this implementation
+    return false;
+  }
+
+  bignum256 bn_z = {0};
+  bn_read_int32(z, &curve->prime, &bn_z);
+
+  bignum256 bn_a = {0};
+  bn_read_int32(curve->a, &curve->prime, &bn_a);
+
+  bignum256 u[2] = {0};
+
+  if (!hash_to_field(msg, msg_len, suite_id, suite_id_len, 48, &curve->prime,
+                     expand_function, u, 2)) {
+    return false;
+  }
+
+  curve_point point1 = {0}, point2 = {0};
+
+  if (!simple_swu(&u[0], &bn_a, &curve->b, &curve->prime, &bn_z, sign_function,
+                  &point1)) {
+    memzero(&u[0], sizeof(u[0]));
+    return false;
+  }
+  memzero(&u[0], sizeof(u[0]));
+
+  if (!simple_swu(&u[1], &bn_a, &curve->b, &curve->prime, &bn_z, sign_function,
+                  &point2)) {
+    memzero(&u[1], sizeof(u[1]));
+    return false;
+  }
+  memzero(&u[1], sizeof(u[1]));
+
+  point_add(curve, &point1, &point2);
+
+  point->x = point2.x;
+  point->y = point2.y;
+
+  memzero(&point1, sizeof(point1));
+  memzero(&point2, sizeof(point2));
+
+  return true;
+}
+
+static int sgn0(const bignum256 *a) {
+  // https://datatracker.ietf.org/doc/html/draft-irtf-cfrg-hash-to-curve-05#section-4.1.2
+  if (bn_is_even(a)) {
+    return 1;
+  }
+
+  return -1;
+}
+
+// https://www.rfc-editor.org/rfc/rfc9380.html#hashtofield-expand-xmd
+bool expand_message_xmd_sha256(const uint8_t *msg, size_t msg_len,
+                               const uint8_t *dst,  // domain separation tag
+                               size_t dst_len, uint8_t *output,
+                               size_t output_len) {
+  if (dst_len > 255) {
+    return false;
+  }
+
+  if ((output_len > 65535) || (output_len > 255 * SHA256_DIGEST_LENGTH)) {
+    return false;
+  }
+
+  const uint8_t zero_block[SHA256_BLOCK_LENGTH] = {0};
+  const uint8_t output_len_bytes[2] = {(output_len >> 8) & 255,
+                                       output_len & 255};
+  const uint8_t dst_len_bytes[1] = {dst_len & 255};
+  const uint8_t zero[1] = {0};
+
+  SHA256_CTX ctx = {0};
+  sha256_Init(&ctx);
+
+  // Z_pad = I2OSP(0, s_in_bytes)
+  sha256_Update(&ctx, zero_block, sizeof(zero_block));
+
+  // msg
+  sha256_Update(&ctx, msg, msg_len);
+
+  // l_i_b_str = I2OSP(len_in_bytes, 2)
+  sha256_Update(&ctx, output_len_bytes, sizeof(output_len_bytes));
+
+  // I2OSP(0, 1)
+  sha256_Update(&ctx, zero, sizeof(zero));
+
+  // DST_prime = DST || I2OSP(len(DST), 1)
+  sha256_Update(&ctx, dst, dst_len);
+  sha256_Update(&ctx, dst_len_bytes, sizeof(dst_len_bytes));
+
+  uint8_t first_digest[SHA256_DIGEST_LENGTH] = {0};  // b_0
+  sha256_Final(&ctx, first_digest);
+
+  uint8_t current_digest[SHA256_DIGEST_LENGTH] = {0};  // b_i
+
+  size_t output_position = 0;
+  size_t remaining_output_length = output_len;
+  int i = 1;
+
+  while (remaining_output_length > 0) {
+    const uint8_t i_bytes[1] = {i & 255};
+
+    // strxor(b_0, b_(i - 1))
+    for (size_t j = 0; j < sizeof(current_digest); j++) {
+      current_digest[j] ^= first_digest[j];
+    }
+
+    sha256_Init(&ctx);
+
+    // strxor(b_0, b_(i - 1))
+    sha256_Update(&ctx, current_digest, sizeof(current_digest));
+
+    // I2OSP(i, 1)
+    sha256_Update(&ctx, i_bytes, sizeof(i_bytes));
+
+    // DST_prime = DST || I2OSP(len(DST), 1)
+    sha256_Update(&ctx, dst, dst_len);
+    sha256_Update(&ctx, dst_len_bytes, sizeof(dst_len_bytes));
+
+    sha256_Final(&ctx, current_digest);
+
+    const size_t copy_length = remaining_output_length > SHA256_DIGEST_LENGTH
+                                   ? SHA256_DIGEST_LENGTH
+                                   : remaining_output_length;
+    memcpy(output + output_position, current_digest, copy_length);
+
+    output_position += copy_length;
+    remaining_output_length -= copy_length;
+    i++;
+  }
+
+  memzero(&ctx, sizeof(ctx));
+  memzero(first_digest, sizeof(first_digest));
+  memzero(current_digest, sizeof(current_digest));
+
+  return true;
+}
+
+bool hash_to_curve_p256(const uint8_t *msg, size_t msg_len, const uint8_t *dst,
+                        size_t dst_len, curve_point *point) {
+  // https://www.rfc-editor.org/rfc/rfc9380.html#suites-p256
+  // P256_XMD:SHA-256_SSWU_RO_
+  if (!hash_to_curve(msg, msg_len, &nist256p1, dst, dst_len, -10, 1,
+                     expand_message_xmd_sha256, sgn0, point)) {
+    return false;
+  }
+
+  return true;
+}
+
+bool hash_to_curve_optiga(const uint8_t input[32], uint8_t public_key[65]) {
+  char dst[] = "OPTIGA-SECRET-V0-P256_XMD:SHA-256_SSWU_RO_";
+  curve_point point = {0};
+
+  if (!hash_to_curve_p256(input, 32, (uint8_t *)dst, sizeof(dst) - 1, &point)) {
+    return false;
+  }
+
+  public_key[0] = 0x04;
+  bn_write_be(&point.x, public_key + 1);
+  bn_write_be(&point.y, public_key + 33);
+
+  memzero(&point, sizeof(point));
+
+  return true;
+}

--- a/crypto/hash_to_curve.h
+++ b/crypto/hash_to_curve.h
@@ -1,0 +1,32 @@
+/**
+ * Permission is hereby granted, free of charge, to any person obtaining
+ * a copy of this software and associated documentation files (the "Software"),
+ * to deal in the Software without restriction, including without limitation
+ * the rights to use, copy, modify, merge, publish, distribute, sublicense,
+ * and/or sell copies of the Software, and to permit persons to whom the
+ * Software is furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included
+ * in all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS
+ * OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL
+ * THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES
+ * OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE,
+ * ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
+ * OTHER DEALINGS IN THE SOFTWARE.
+ */
+
+#ifndef __HASH_TO_CURVE_H__
+#define __HASH_TO_CURVE_H__
+
+#include "ecdsa.h"
+
+bool expand_message_xmd_sha256(const uint8_t *msg, size_t msg_len,
+                               const uint8_t *dst, size_t dst_len,
+                               uint8_t *output, size_t output_len);
+bool hash_to_curve_p256(const uint8_t *msg, size_t msg_len, const uint8_t *dst,
+                        size_t dst_len, curve_point *point);
+bool hash_to_curve_optiga(const uint8_t input[32], uint8_t public_key[65]);
+#endif

--- a/crypto/tests/test_bignum.py
+++ b/crypto/tests/test_bignum.py
@@ -551,6 +551,21 @@ def assert_bn_subtractmod(x, y, prime):
     assert res % prime == (x - y) % prime
 
 
+def legendre(x, prime):
+    res = pow(x, (prime - 1) // 2, prime)
+    if res == prime - 1:
+        return -1
+    return res
+
+
+def assert_bn_legendre(x, prime):
+    bn_x = int_to_bignum(x)
+    bn_prime = int_to_bignum(prime)
+    return_value = lib.bn_legendre(bn_x, bn_prime)
+
+    assert return_value == legendre(x, prime)
+
+
 def assert_bn_subtract(x, y):
     bn_x = int_to_bignum(x)
     bn_y = int_to_bignum(y)
@@ -1003,6 +1018,11 @@ def test_bn_subtract_2(r):
     if a < b:
         a, b = b, a
     assert_bn_subtract(a, b)
+
+
+def test_bn_legendre(r, prime):
+    x = r.rand_int_bitsize(259)
+    assert_bn_legendre(x, prime)
 
 
 def test_bn_long_division(r):

--- a/crypto/tests/test_bignum.py
+++ b/crypto/tests/test_bignum.py
@@ -24,10 +24,13 @@ lib = ctypes.cdll.LoadLibrary(os.path.join(dir, "libtrezor-crypto.so"))
 limbs_number = 9
 bits_per_limb = 29
 
+secp256k1_prime = 0xFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFEFFFFFC2F
+p256_prime = 0xFFFFFFFF00000001000000000000000000000000FFFFFFFFFFFFFFFFFFFFFFFF
 
-@pytest.fixture()
+
+@pytest.fixture(params=[secp256k1_prime, p256_prime])
 def prime(request):
-    return 0xFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFEFFFFFC2F
+    return request.param
 
 
 @pytest.fixture(params=range(limbs_number * bits_per_limb))
@@ -400,7 +403,7 @@ def assert_bn_multiply(k, x_old, prime):
 
     assert bignum_is_normalised(bn_x)
     assert number_is_partly_reduced(x_new, prime)
-    assert x_new == (k * x_old) % prime
+    assert x_new % prime == (k * x_old) % prime
 
 
 def assert_bn_fast_mod(x_old, prime):

--- a/crypto/tests/test_bignum.py
+++ b/crypto/tests/test_bignum.py
@@ -197,6 +197,16 @@ class Random(random.Random):
         return self.rand_bignum(2 * limbs_number)
 
 
+def assert_bn_copy_lower(x):
+    x_number = int_to_bignum512(x)
+    y_number = bignum256()
+    lib.bn_copy_lower(x_number, y_number)
+    y = bignum256_to_int(y_number)
+
+    assert bignum_is_normalised(y_number)
+    assert y == x
+
+
 def assert_bn_read_be(in_number):
     raw_in_number = integer_to_raw_number256(in_number, "big")
     bn_out_number = bignum256()
@@ -456,6 +466,17 @@ def assert_bn_multiply(k, x_old, prime):
     assert bignum_is_normalised(bn_x)
     assert number_is_partly_reduced(x_new, prime)
     assert x_new % prime == (k * x_old) % prime
+
+
+def assert_bn_reduce(x_old, prime):
+    bn_x = int_to_bignum512(x_old)
+    bn_prime = int_to_bignum256(prime)
+    lib.bn_reduce(bn_x, bn_prime)
+    x_new = bignum256_to_int(bn_x)
+
+    assert bignum_is_normalised(bn_x)
+    assert number_is_partly_reduced(x_new, prime)
+    assert x_new % prime == x_old % prime
 
 
 def assert_bn_fast_mod(x_old, prime):
@@ -731,6 +752,10 @@ def assert_bn_format(x, prefix, suffix, decimals, exponent, trailing, thousands)
     assert return_value == correct_return_value
 
 
+def test_bn_copy_lower(r):
+    assert_bn_copy_lower(r.rand_int_bitsize(261))
+
+
 def test_bn_read_be(r):
     assert_bn_read_be(r.rand_int_256())
 
@@ -914,6 +939,11 @@ def test_bn_multiply_reduce_step(r, prime):
     k = r.randrange(0, limbs_number)
     res = r.randrange(2 ** (256 + 29 * k + 31))
     assert_bn_multiply_reduce_step(res, prime, k)
+
+
+def test_bn_reduce(r, prime):
+    x = r.rand_int_bitsize(519)
+    assert_bn_reduce(x, prime)
 
 
 def test_bn_multiply(r, prime):

--- a/crypto/tests/test_bignum.py
+++ b/crypto/tests/test_bignum.py
@@ -216,6 +216,13 @@ def assert_bn_read_be(in_number):
     assert bignum_is_normalised(bn_out_number)
     assert out_number == in_number
 
+
+def assert_bn_read_be_512(in_number):
+    raw_in_number = integer_to_raw_number512(in_number, "big")
+    bn_out_number = bignum512()
+    lib.bn_read_be_512(raw_in_number, bn_out_number)
+    out_number = bignum512_to_int(bn_out_number)
+
     assert bignum_is_normalised(bn_out_number)
     assert out_number == in_number
 
@@ -758,6 +765,10 @@ def test_bn_copy_lower(r):
 
 def test_bn_read_be(r):
     assert_bn_read_be(r.rand_int_256())
+
+
+def test_bn_read_be_512(r):
+    assert_bn_read_be_512(r.rand_int_512())
 
 
 def test_bn_read_le(r):

--- a/crypto/tests/test_bignum.py
+++ b/crypto/tests/test_bignum.py
@@ -69,15 +69,23 @@ def uint32_p():
 limb_type = c_uint32
 
 
-def bignum(limbs_number=limbs_number):
+def bignum(limbs_number):
     return (limbs_number * limb_type)()
+
+
+def bignum256():
+    return bignum(limbs_number)
+
+
+def bignum512():
+    return bignum(2 * limbs_number)
 
 
 def limbs_to_bignum(limbs):
     return (limbs_number * limb_type)(*limbs)
 
 
-def int_to_bignum(number, limbs_number=limbs_number):
+def int_to_bignum(number, limbs_number):
     assert number >= 0
     assert number.bit_length() <= limbs_number * bits_per_limb
 
@@ -89,7 +97,15 @@ def int_to_bignum(number, limbs_number=limbs_number):
     return bn
 
 
-def bignum_to_int(bignum, limbs_number=limbs_number):
+def int_to_bignum256(number):
+    return int_to_bignum(number, limbs_number)
+
+
+def int_to_bignum512(number):
+    return int_to_bignum(number, 2 * limbs_number)
+
+
+def bignum_to_int(bignum, limbs_number):
     number = 0
 
     for i in reversed(range(limbs_number)):
@@ -99,16 +115,40 @@ def bignum_to_int(bignum, limbs_number=limbs_number):
     return number
 
 
-def raw_number():
-    return (32 * c_uint8)()
+def bignum256_to_int(bignum):
+    return bignum_to_int(bignum, limbs_number)
+
+
+def bignum512_to_int(bignum):
+    return bignum_to_int(bignum, 2 * limbs_number)
+
+
+def raw_number(byte_size):
+    return (byte_size * c_uint8)()
+
+
+def raw_number256():
+    return raw_number(32)
+
+
+def raw_number512():
+    return raw_number(64)
 
 
 def raw_number_to_integer(raw_number, endianess):
     return int.from_bytes(raw_number, endianess)
 
 
-def integer_to_raw_number(number, endianess):
-    return (32 * c_uint8)(*number.to_bytes(32, endianess))
+def integer_to_raw_number(number, endianess, byte_size):
+    return (byte_size * c_uint8)(*number.to_bytes(byte_size, endianess))
+
+
+def integer_to_raw_number256(number, endianess):
+    return integer_to_raw_number(number, endianess, 32)
+
+
+def integer_to_raw_number512(number, endianess):
+    return integer_to_raw_number(number, endianess, 64)
 
 
 def bignum_is_normalised(bignum):
@@ -133,6 +173,9 @@ class Random(random.Random):
     def rand_int_256(self):
         return self.randrange(0, 2**256)
 
+    def rand_int_512(self):
+        return self.randrange(0, 2**512)
+
     def rand_int_reduced(self, p):
         return self.randrange(0, 2 * p)
 
@@ -142,35 +185,44 @@ class Random(random.Random):
     def rand_bit_index(self):
         return self.randrange(0, limbs_number * bits_per_limb)
 
-    def rand_bignum(self, limbs_number=limbs_number):
+    def rand_bignum(self, limbs_number):
         return (limb_type * limbs_number)(
             *[self.randrange(0, 256**4) for _ in range(limbs_number)]
         )
 
+    def rand_bignum256(self):
+        return self.rand_bignum(limbs_number)
+
+    def rand_bignum512(self):
+        return self.rand_bignum(2 * limbs_number)
+
 
 def assert_bn_read_be(in_number):
-    raw_in_number = integer_to_raw_number(in_number, "big")
-    bn_out_number = bignum()
+    raw_in_number = integer_to_raw_number256(in_number, "big")
+    bn_out_number = bignum256()
     lib.bn_read_be(raw_in_number, bn_out_number)
-    out_number = bignum_to_int(bn_out_number)
+    out_number = bignum256_to_int(bn_out_number)
+
+    assert bignum_is_normalised(bn_out_number)
+    assert out_number == in_number
 
     assert bignum_is_normalised(bn_out_number)
     assert out_number == in_number
 
 
 def assert_bn_read_le(in_number):
-    raw_in_number = integer_to_raw_number(in_number, "little")
-    bn_out_number = bignum()
+    raw_in_number = integer_to_raw_number256(in_number, "little")
+    bn_out_number = bignum256()
     lib.bn_read_le(raw_in_number, bn_out_number)
-    out_number = bignum_to_int(bn_out_number)
+    out_number = bignum256_to_int(bn_out_number)
 
     assert bignum_is_normalised(bn_out_number)
     assert out_number == in_number
 
 
 def assert_bn_write_be(in_number):
-    bn_in_number = int_to_bignum(in_number)
-    raw_out_number = raw_number()
+    bn_in_number = int_to_bignum256(in_number)
+    raw_out_number = raw_number256()
     lib.bn_write_be(bn_in_number, raw_out_number)
     out_number = raw_number_to_integer(raw_out_number, "big")
 
@@ -178,8 +230,8 @@ def assert_bn_write_be(in_number):
 
 
 def assert_bn_write_le(in_number):
-    bn_in_number = int_to_bignum(in_number)
-    raw_out_number = raw_number()
+    bn_in_number = int_to_bignum256(in_number)
+    raw_out_number = raw_number256()
     lib.bn_write_le(bn_in_number, raw_out_number)
     out_number = raw_number_to_integer(raw_out_number, "little")
 
@@ -187,100 +239,100 @@ def assert_bn_write_le(in_number):
 
 
 def assert_bn_read_uint32(x):
-    bn_out_number = bignum()
+    bn_out_number = bignum256()
     lib.bn_read_uint32(c_uint32(x), bn_out_number)
-    out_number = bignum_to_int(bn_out_number)
+    out_number = bignum256_to_int(bn_out_number)
 
     assert bignum_is_normalised(bn_out_number)
     assert out_number == x
 
 
 def assert_bn_read_uint64(x):
-    bn_out_number = bignum()
+    bn_out_number = bignum256()
     lib.bn_read_uint64(c_uint64(x), bn_out_number)
-    out_number = bignum_to_int(bn_out_number)
+    out_number = bignum256_to_int(bn_out_number)
 
     assert bignum_is_normalised(bn_out_number)
     assert out_number == x
 
 
 def assert_bn_bitcount(x):
-    bn_x = int_to_bignum(x)
+    bn_x = int_to_bignum256(x)
     return_value = lib.bn_bitcount(bn_x)
 
     assert return_value == x.bit_length()
 
 
 def assert_bn_digitcount(x):
-    bn_x = int_to_bignum(x)
+    bn_x = int_to_bignum256(x)
     return_value = lib.bn_digitcount(bn_x)
 
     assert return_value == len(str(x))
 
 
 def assert_bn_zero():
-    bn_x = bignum()
+    bn_x = bignum256()
     lib.bn_zero(bn_x)
-    x = bignum_to_int(bn_x)
+    x = bignum256_to_int(bn_x)
 
     assert bignum_is_normalised(bn_x)
     assert x == 0
 
 
 def assert_bn_one():
-    bn_x = bignum()
+    bn_x = bignum256()
     lib.bn_one(bn_x)
-    x = bignum_to_int(bn_x)
+    x = bignum256_to_int(bn_x)
 
     assert bignum_is_normalised(bn_x)
     assert x == 1
 
 
 def assert_bn_is_zero(x):
-    bn_x = int_to_bignum(x)
+    bn_x = int_to_bignum256(x)
     return_value = lib.bn_is_zero(bn_x)
 
     assert return_value == (x == 0)
 
 
 def assert_bn_is_one(x):
-    bn_x = int_to_bignum(x)
+    bn_x = int_to_bignum256(x)
     return_value = lib.bn_is_one(bn_x)
 
     assert return_value == (x == 1)
 
 
 def assert_bn_is_less(x, y):
-    bn_x = int_to_bignum(x)
-    bn_y = int_to_bignum(y)
+    bn_x = int_to_bignum256(x)
+    bn_y = int_to_bignum256(y)
     return_value = lib.bn_is_less(bn_x, bn_y)
 
     assert return_value == (x < y)
 
 
 def assert_bn_is_equal(x, y):
-    bn_x = int_to_bignum(x)
-    bn_y = int_to_bignum(y)
+    bn_x = int_to_bignum256(x)
+    bn_y = int_to_bignum256(y)
     return_value = lib.bn_is_equal(bn_x, bn_y)
 
     assert return_value == (x == y)
 
 
 def assert_bn_cmov(cond, truecase, falsecase):
-    bn_res = bignum()
-    bn_truecase = int_to_bignum(truecase)
-    bn_falsecase = int_to_bignum(falsecase)
+    bn_res = bignum256()
+    bn_truecase = int_to_bignum256(truecase)
+    bn_falsecase = int_to_bignum256(falsecase)
     lib.bn_cmov(bn_res, c_uint32(cond), bn_truecase, bn_falsecase)
-    res = bignum_to_int(bn_res)
+    res = bignum256_to_int(bn_res)
 
     assert res == truecase if cond else falsecase
 
 
 def assert_bn_cnegate(cond, x_old, prime):
-    bn_x = int_to_bignum(x_old)
-    bn_prime = int_to_bignum(prime)
+    bn_x = int_to_bignum256(x_old)
+    bn_prime = int_to_bignum256(prime)
     lib.bn_cnegate(c_uint32(cond), bn_x, bn_prime)
-    x_new = bignum_to_int(bn_x)
+    x_new = bignum256_to_int(bn_x)
 
     assert bignum_is_normalised(bn_x)
     assert number_is_partly_reduced(x_new, prime)
@@ -288,63 +340,63 @@ def assert_bn_cnegate(cond, x_old, prime):
 
 
 def assert_bn_lshift(x_old):
-    bn_x = int_to_bignum(x_old)
+    bn_x = int_to_bignum256(x_old)
     lib.bn_lshift(bn_x)
-    x_new = bignum_to_int(bn_x)
+    x_new = bignum256_to_int(bn_x)
 
     assert bignum_is_normalised(bn_x)
     assert x_new == (x_old << 1)
 
 
 def assert_bn_rshift(x_old):
-    bn_x = int_to_bignum(x_old)
+    bn_x = int_to_bignum256(x_old)
     lib.bn_rshift(bn_x)
-    x_new = bignum_to_int(bn_x)
+    x_new = bignum256_to_int(bn_x)
 
     assert bignum_is_normalised(bn_x)
     assert x_new == (x_old >> 1)
 
 
 def assert_bn_setbit(x_old, i):
-    bn_x = int_to_bignum(x_old)
+    bn_x = int_to_bignum256(x_old)
     lib.bn_setbit(bn_x, c_uint16(i))
-    x_new = bignum_to_int(bn_x)
+    x_new = bignum256_to_int(bn_x)
 
     assert bignum_is_normalised(bn_x)
     assert x_new == x_old | (1 << i)
 
 
 def assert_bn_clearbit(x_old, i):
-    bn_x = int_to_bignum(x_old)
+    bn_x = int_to_bignum256(x_old)
     lib.bn_clearbit(bn_x, c_uint16(i))
-    x_new = bignum_to_int(bn_x)
+    x_new = bignum256_to_int(bn_x)
 
     assert bignum_is_normalised(bn_x)
     assert x_new == x_old & ~(1 << i)
 
 
 def assert_bn_testbit(x_old, i):
-    bn_x = int_to_bignum(x_old)
+    bn_x = int_to_bignum256(x_old)
     return_value = lib.bn_testbit(bn_x, c_uint16(i))
 
     assert return_value == x_old >> i & 1
 
 
 def assert_bn_xor(x, y):
-    bn_res = bignum()
-    bn_x = int_to_bignum(x)
-    bn_y = int_to_bignum(y)
+    bn_res = bignum256()
+    bn_x = int_to_bignum256(x)
+    bn_y = int_to_bignum256(y)
     lib.bn_xor(bn_res, bn_x, bn_y)
-    res = bignum_to_int(bn_res)
+    res = bignum256_to_int(bn_res)
 
     assert res == x ^ y
 
 
 def assert_bn_mult_half(x_old, prime):
-    bn_x = int_to_bignum(x_old)
-    bn_prime = int_to_bignum(prime)
+    bn_x = int_to_bignum256(x_old)
+    bn_prime = int_to_bignum256(prime)
     lib.bn_mult_half(bn_x, bn_prime)
-    x_new = bignum_to_int(bn_x)
+    x_new = bignum256_to_int(bn_x)
 
     assert implication(
         number_is_partly_reduced(x_old, prime), number_is_partly_reduced(x_new, prime)
@@ -353,10 +405,10 @@ def assert_bn_mult_half(x_old, prime):
 
 
 def assert_bn_mult_k(x_old, k, prime):
-    bn_x = int_to_bignum(x_old)
-    bn_prime = int_to_bignum(prime)
+    bn_x = int_to_bignum256(x_old)
+    bn_prime = int_to_bignum256(prime)
     lib.bn_mult_k(bn_x, c_uint8(k), bn_prime)
-    x_new = bignum_to_int(bn_x)
+    x_new = bignum256_to_int(bn_x)
 
     assert bignum_is_normalised(bn_x)
     assert number_is_partly_reduced(x_new, prime)
@@ -364,10 +416,10 @@ def assert_bn_mult_k(x_old, k, prime):
 
 
 def assert_bn_mod(x_old, prime):
-    bn_x = int_to_bignum(x_old)
-    bn_prime = int_to_bignum(prime)
+    bn_x = int_to_bignum256(x_old)
+    bn_prime = int_to_bignum256(prime)
     lib.bn_mod(bn_x, bn_prime)
-    x_new = bignum_to_int(bn_x)
+    x_new = bignum256_to_int(bn_x)
 
     assert bignum_is_normalised(bn_x)
     assert number_is_fully_reduced(x_new, prime)
@@ -375,31 +427,31 @@ def assert_bn_mod(x_old, prime):
 
 
 def assert_bn_multiply_long(k_old, x_old):
-    bn_k = int_to_bignum(k_old)
-    bn_x = int_to_bignum(x_old)
-    bn_res = bignum(2 * limbs_number)
+    bn_k = int_to_bignum256(k_old)
+    bn_x = int_to_bignum256(x_old)
+    bn_res = bignum512()
     lib.bn_multiply_long(bn_k, bn_x, bn_res)
-    res = bignum_to_int(bn_res, 2 * limbs_number)
+    res = bignum512_to_int(bn_res)
 
     assert res == k_old * x_old
 
 
 def assert_bn_multiply_reduce_step(res_old, prime, d):
-    bn_res = int_to_bignum(res_old, 2 * limbs_number)
-    bn_prime = int_to_bignum(prime)
+    bn_res = int_to_bignum512(res_old)
+    bn_prime = int_to_bignum256(prime)
     lib.bn_multiply_reduce_step(bn_res, bn_prime, d)
-    res_new = bignum_to_int(bn_res, 2 * limbs_number)
+    res_new = bignum512_to_int(bn_res)
 
     assert bignum_is_normalised(bn_res)
     assert res_new < 2 * prime * 2 ** (d * bits_per_limb)
 
 
 def assert_bn_multiply(k, x_old, prime):
-    bn_k = int_to_bignum(k)
-    bn_x = int_to_bignum(x_old)
-    bn_prime = int_to_bignum(prime)
+    bn_k = int_to_bignum256(k)
+    bn_x = int_to_bignum256(x_old)
+    bn_prime = int_to_bignum256(prime)
     lib.bn_multiply(bn_k, bn_x, bn_prime)
-    x_new = bignum_to_int(bn_x)
+    x_new = bignum256_to_int(bn_x)
 
     assert bignum_is_normalised(bn_x)
     assert number_is_partly_reduced(x_new, prime)
@@ -407,10 +459,10 @@ def assert_bn_multiply(k, x_old, prime):
 
 
 def assert_bn_fast_mod(x_old, prime):
-    bn_x = int_to_bignum(x_old)
-    bn_prime = int_to_bignum(prime)
+    bn_x = int_to_bignum256(x_old)
+    bn_prime = int_to_bignum256(prime)
     lib.bn_fast_mod(bn_x, bn_prime)
-    x_new = bignum_to_int(bn_x)
+    x_new = bignum256_to_int(bn_x)
 
     assert bignum_is_normalised(bn_x)
     assert number_is_partly_reduced(x_new, prime)
@@ -419,10 +471,10 @@ def assert_bn_fast_mod(x_old, prime):
 
 def assert_bn_fast_mod_bn(bn_x, prime):
     bn_x
-    x_old = bignum_to_int(bn_x)
-    bn_prime = int_to_bignum(prime)
+    x_old = bignum256_to_int(bn_x)
+    bn_prime = int_to_bignum256(prime)
     lib.bn_fast_mod(bn_x, bn_prime)
-    x_new = bignum_to_int(bn_x)
+    x_new = bignum256_to_int(bn_x)
 
     assert bignum_is_normalised(bn_x)
     assert number_is_partly_reduced(x_new, prime)
@@ -430,12 +482,12 @@ def assert_bn_fast_mod_bn(bn_x, prime):
 
 
 def assert_bn_power_mod(x, e, prime):
-    bn_x = int_to_bignum(x)
-    bn_e = int_to_bignum(e)
-    bn_prime = int_to_bignum(prime)
-    bn_res_new = bignum()
+    bn_x = int_to_bignum256(x)
+    bn_e = int_to_bignum256(e)
+    bn_prime = int_to_bignum256(prime)
+    bn_res_new = bignum256()
     lib.bn_power_mod(bn_x, bn_e, bn_prime, bn_res_new)
-    res_new = bignum_to_int(bn_res_new)
+    res_new = bignum256_to_int(bn_res_new)
 
     assert bignum_is_normalised(bn_res_new)
     assert number_is_partly_reduced(res_new, prime)
@@ -443,10 +495,10 @@ def assert_bn_power_mod(x, e, prime):
 
 
 def assert_bn_sqrt(x_old, prime):
-    bn_x = int_to_bignum(x_old)
-    bn_prime = int_to_bignum(prime)
+    bn_x = int_to_bignum256(x_old)
+    bn_prime = int_to_bignum256(prime)
     lib.bn_sqrt(bn_x, bn_prime)
-    x_new = bignum_to_int(bn_x)
+    x_new = bignum256_to_int(bn_x)
 
     assert bignum_is_normalised(bn_x)
     assert number_is_fully_reduced(x_new, prime)
@@ -460,10 +512,10 @@ def assert_inverse_mod_power_two(x, m):
 
 
 def assert_bn_divide_base(x_old, prime):
-    bn_x = int_to_bignum(x_old)
-    bn_prime = int_to_bignum(prime)
+    bn_x = int_to_bignum256(x_old)
+    bn_prime = int_to_bignum256(prime)
     lib.bn_divide_base(bn_x, bn_prime)
-    x_new = bignum_to_int(bn_x)
+    x_new = bignum256_to_int(bn_x)
 
     assert implication(
         number_is_fully_reduced(x_old, prime), number_is_fully_reduced(x_new, prime)
@@ -475,10 +527,10 @@ def assert_bn_divide_base(x_old, prime):
 
 
 def assert_bn_inverse(x_old, prime):
-    bn_x = int_to_bignum(x_old)
-    bn_prime = int_to_bignum(prime)
+    bn_x = int_to_bignum256(x_old)
+    bn_prime = int_to_bignum256(prime)
     lib.bn_inverse(bn_x, bn_prime)
-    x_new = bignum_to_int(bn_x)
+    x_new = bignum256_to_int(bn_x)
 
     assert bignum_is_normalised(bn_x)
     assert number_is_fully_reduced(x_new, prime)
@@ -486,31 +538,31 @@ def assert_bn_inverse(x_old, prime):
 
 
 def assert_bn_normalize(bn_x):
-    x_old = bignum_to_int(bn_x)
+    x_old = bignum256_to_int(bn_x)
     lib.bn_normalize(bn_x)
-    x_new = bignum_to_int(bn_x)
+    x_new = bignum256_to_int(bn_x)
 
     assert x_new == x_old % 2 ** (bits_per_limb * limbs_number)
     assert bignum_is_normalised(bn_x)
 
 
 def assert_bn_add(x_old, y):
-    bn_x = int_to_bignum(x_old)
-    bn_y = int_to_bignum(y)
+    bn_x = int_to_bignum256(x_old)
+    bn_y = int_to_bignum256(y)
     lib.bn_add(bn_x, bn_y)
-    x_new = bignum_to_int(bn_x)
-    y = bignum_to_int(bn_y)
+    x_new = bignum256_to_int(bn_x)
+    y = bignum256_to_int(bn_y)
 
     assert bignum_is_normalised(bn_x)
     assert x_new == x_old + y
 
 
 def assert_bn_addmod(x_old, y, prime):
-    bn_x = int_to_bignum(x_old)
-    bn_y = int_to_bignum(y)
-    bn_prime = int_to_bignum(prime)
+    bn_x = int_to_bignum256(x_old)
+    bn_y = int_to_bignum256(y)
+    bn_prime = int_to_bignum256(prime)
     lib.bn_addmod(bn_x, bn_y, bn_prime)
-    x_new = bignum_to_int(bn_x)
+    x_new = bignum256_to_int(bn_x)
 
     assert bignum_is_normalised(bn_x)
     assert number_is_partly_reduced(x_new, prime)
@@ -518,19 +570,19 @@ def assert_bn_addmod(x_old, y, prime):
 
 
 def assert_bn_addi(x_old, y):
-    bn_x = int_to_bignum(x_old)
+    bn_x = int_to_bignum256(x_old)
     lib.bn_addi(bn_x, c_uint32(y))
-    x_new = bignum_to_int(bn_x)
+    x_new = bignum256_to_int(bn_x)
 
     assert bignum_is_normalised(bn_x)
     assert x_new == x_old + y
 
 
 def assert_bn_subi(x_old, y, prime):
-    bn_x = int_to_bignum(x_old)
-    bn_prime = int_to_bignum(prime)
+    bn_x = int_to_bignum256(x_old)
+    bn_prime = int_to_bignum256(prime)
     lib.bn_subi(bn_x, c_uint32(y), bn_prime)
-    x_new = bignum_to_int(bn_x)
+    x_new = bignum256_to_int(bn_x)
 
     assert bignum_is_normalised(bn_x)
     assert implication(
@@ -540,12 +592,12 @@ def assert_bn_subi(x_old, y, prime):
 
 
 def assert_bn_subtractmod(x, y, prime):
-    bn_x = int_to_bignum(x)
-    bn_y = int_to_bignum(y)
-    bn_prime = int_to_bignum(prime)
-    bn_res = bignum()
+    bn_x = int_to_bignum256(x)
+    bn_y = int_to_bignum256(y)
+    bn_prime = int_to_bignum256(prime)
+    bn_res = bignum256()
     lib.bn_subtractmod(bn_x, bn_y, bn_res, bn_prime)
-    res = bignum_to_int(bn_res)
+    res = bignum256_to_int(bn_res)
 
     assert bignum_is_normalised(bn_x)
     assert res % prime == (x - y) % prime
@@ -559,31 +611,31 @@ def legendre(x, prime):
 
 
 def assert_bn_legendre(x, prime):
-    bn_x = int_to_bignum(x)
-    bn_prime = int_to_bignum(prime)
+    bn_x = int_to_bignum256(x)
+    bn_prime = int_to_bignum256(prime)
     return_value = lib.bn_legendre(bn_x, bn_prime)
 
     assert return_value == legendre(x, prime)
 
 
 def assert_bn_subtract(x, y):
-    bn_x = int_to_bignum(x)
-    bn_y = int_to_bignum(y)
-    bn_res = bignum()
+    bn_x = int_to_bignum256(x)
+    bn_y = int_to_bignum256(y)
+    bn_res = bignum256()
     lib.bn_subtract(bn_x, bn_y, bn_res)
-    res = bignum_to_int(bn_res)
+    res = bignum256_to_int(bn_res)
 
     assert bignum_is_normalised(bn_x)
     assert res == x - y
 
 
 def assert_bn_long_division(x, d):
-    bn_x = int_to_bignum(x)
-    bn_q = bignum()
+    bn_x = int_to_bignum256(x)
+    bn_q = bignum256()
     uint32_p_r = uint32_p()
     lib.bn_long_division(bn_x, d, bn_q, uint32_p_r)
     r = uint32_p_to_int(uint32_p_r)
-    q = bignum_to_int(bn_q)
+    q = bignum256_to_int(bn_q)
 
     assert bignum_is_normalised(bn_q)
     assert q == x // d
@@ -591,10 +643,10 @@ def assert_bn_long_division(x, d):
 
 
 def assert_bn_divmod58(x_old):
-    bn_x = int_to_bignum(x_old)
+    bn_x = int_to_bignum256(x_old)
     uint32_p_r = uint32_p()
     lib.bn_divmod58(bn_x, uint32_p_r)
-    x_new = bignum_to_int(bn_x)
+    x_new = bignum256_to_int(bn_x)
     r = uint32_p_to_int(uint32_p_r)
 
     assert bignum_is_normalised(bn_x)
@@ -603,10 +655,10 @@ def assert_bn_divmod58(x_old):
 
 
 def assert_bn_divmod1000(x_old):
-    bn_x = int_to_bignum(x_old)
+    bn_x = int_to_bignum256(x_old)
     uint32_p_r = uint32_p()
     lib.bn_divmod1000(bn_x, uint32_p_r)
-    x_new = bignum_to_int(bn_x)
+    x_new = bignum256_to_int(bn_x)
     r = uint32_p_to_int(uint32_p_r)
 
     assert bignum_is_normalised(bn_x)
@@ -615,10 +667,10 @@ def assert_bn_divmod1000(x_old):
 
 
 def assert_bn_divmod10(x_old):
-    bn_x = int_to_bignum(x_old)
+    bn_x = int_to_bignum256(x_old)
     uint32_p_r = uint32_p()
     lib.bn_divmod10(bn_x, uint32_p_r)
-    x_new = bignum_to_int(bn_x)
+    x_new = bignum256_to_int(bn_x)
     r = uint32_p_to_int(uint32_p_r)
 
     assert bignum_is_normalised(bn_x)
@@ -654,7 +706,7 @@ def assert_bn_format(x, prefix, suffix, decimals, exponent, trailing, thousands)
     def char_p_to_string(pointer):
         return str(pointer.value, "ascii")
 
-    bn_x = int_to_bignum(x)
+    bn_x = int_to_bignum256(x)
     output_length = 100
     output = string_to_char_p("?" * output_length)
     return_value = lib.bn_format(
@@ -875,7 +927,7 @@ def test_bn_fast_mod_1(r, prime):
 
 
 def test_bn_fast_mod_2(r, prime):
-    bn_x = r.rand_bignum()
+    bn_x = r.rand_bignum256()
     assert_bn_fast_mod_bn(bn_x, prime)
 
 
@@ -929,7 +981,7 @@ def test_bn_inverse_2(r, prime):
 
 
 def test_bn_normalize(r):
-    assert_bn_normalize(r.rand_bignum())
+    assert_bn_normalize(r.rand_bignum256())
 
 
 def test_bn_add_1(r):


### PR DESCRIPTION
This pull requests implements hashing to a curve that is compatible with the suite [`P256_XMD:SHA-256_SSWU_RO_`](https://www.rfc-editor.org/rfc/rfc9380.html#name-suites-for-nist-p-256) from RFC9380.