### PR TITLE
Recovery shuffle letters in T2B1

### DIFF
--- a/core/embed/rust/src/ui/model_tr/component/input_methods/wordlist.rs
+++ b/core/embed/rust/src/ui/model_tr/component/input_methods/wordlist.rs
@@ -157,19 +157,49 @@ where
         ChoiceFactoryWordlist::new(self.wordlist_type, self.textbox.content())
     }
 
+    fn get_last_textbox_letter(&self) -> Option<char> {
+        self.textbox.content().chars().last()
+    }
+
+    fn get_new_page_counter(&self, new_choices: &ChoiceFactoryWordlist) -> usize {
+        // Starting at the random position in case of letters and at the beginning in
+        // case of words.
+        if self.offer_words {
+            INITIAL_PAGE_COUNTER
+        } else {
+            let choices_count = <ChoiceFactoryWordlist as ChoiceFactory<T>>::count(new_choices);
+            // There should be always DELETE and at least one letter
+            assert!(choices_count > 1);
+            if choices_count == 2 {
+                // In case there is only DELETE and one letter, starting on that letter
+                // (regardless of the last letter in the textbox)
+                return INITIAL_PAGE_COUNTER;
+            }
+            // We do not want to end up at the same letter as the last one in the textbox
+            loop {
+                let random_position = get_random_position(choices_count);
+                let current_action =
+                    <ChoiceFactoryWordlist as ChoiceFactory<T>>::get(new_choices, random_position)
+                        .1;
+                if let WordlistAction::Letter(current_letter) = current_action {
+                    if let Some(last_letter) = self.get_last_textbox_letter() {
+                        if current_letter == last_letter {
+                            // Randomly trying again when the last and current letter match
+                            continue;
+                        }
+                    }
+                }
+                break random_position;
+            }
+        }
+    }
+
     /// Updates the whole page.
     fn update(&mut self, ctx: &mut EventCtx) {
         self.update_chosen_letters(ctx);
         let new_choices = self.get_current_choices();
         self.offer_words = new_choices.offer_words;
-        // Starting at the random position in case of letters and at the beginning in
-        // case of words
-        let new_page_counter = if self.offer_words {
-            INITIAL_PAGE_COUNTER
-        } else {
-            let choices_count = <ChoiceFactoryWordlist as ChoiceFactory<T>>::count(&new_choices);
-            get_random_position(choices_count)
-        };
+        let new_page_counter = self.get_new_page_counter(&new_choices);
         // Not using carousel in case of words, as that looks weird in case
         // there is only one word to choose from.
         self.choice_page

--- a/tests/ui_tests/fixtures.json
+++ b/tests/ui_tests/fixtures.json
@@ -783,7 +783,7 @@
 "TR_test_pin.py::test_pin_short": "20acadc34173f58ce9eb9d712e47732f1c8b03868f0f197be4213b314832ee4c",
 "TR_test_pin.py::test_wipe_code_same_as_pin": "17bb952006f42c3948370d1257618be76cf39d2892fd5c491488d9544cdc205d",
 "TR_test_pin.py::test_wipe_code_setup": "2f1d097810aa38ff87acef79133ccc735a9523118a1d83420efb84db21a05d97",
-"TR_test_recovery.py::test_recovery_bip39": "ec9e8ef343bba729d4fe5cab796ddb6408f54ccd7f3f4f3569ec07e8db66105c",
+"TR_test_recovery.py::test_recovery_bip39": "92c26b0e97c8e950c568bc8c7f71177a6e9338c950d6d6abb129dc217dc57c3a",
 "TR_test_recovery.py::test_recovery_slip39_basic": "ccfd227ca8dcd1abf0dc7b5827167279461b7151c810c2a587893d7016d38f01",
 "TR_test_reset_bip39.py::test_reset_bip39": "7dee2da63f3d220b4a1466b59da6c89a623d1a55c3d5300efe37761d064435db",
 "TR_test_reset_slip39_advanced.py::test_reset_slip39_advanced[16of16]": "0442794f3b952b6362d6569eaf15af002e7af5ccd3fedcf5339a9e75a61cb6e7",


### PR DESCRIPTION
Fixes https://github.com/trezor/trezor-firmware/issues/3291:
- makes sure the letter always changes after selection in recovery flow