### PR TITLE
Fix marquee in T2B1

### DIFF
--- a/core/embed/rust/src/ui/component/marquee.rs
+++ b/core/embed/rust/src/ui/component/marquee.rs
@@ -10,7 +10,6 @@ use crate::{
     },
 };
 
-const MILLIS_PER_LETTER_M: u32 = 300;
 const ANIMATION_DURATION_MS: u32 = 2000;
 const PAUSE_DURATION_MS: u32 = 1000;
 
@@ -141,22 +140,6 @@ where
     type Msg = Never;
 
     fn place(&mut self, bounds: Rect) -> Rect {
-        let base_width = self.font.text_width("M");
-        let text_width = self.font.text_width(self.text.as_ref());
-        let area_width = bounds.width();
-
-        let shift_width = if area_width > text_width {
-            area_width - text_width
-        } else {
-            text_width - area_width
-        };
-
-        let mut duration = (MILLIS_PER_LETTER_M * shift_width as u32) / base_width as u32;
-        if duration < MILLIS_PER_LETTER_M {
-            duration = MILLIS_PER_LETTER_M;
-        }
-
-        self.duration = Duration::from_millis(duration);
         self.area = bounds;
         self.area
     }


### PR DESCRIPTION
Fixes https://github.com/trezor/trezor-firmware/issues/3204:
- makes marquee to always take 2 seconds to animate from end to end (pause of 1 second persists)
- @Hannsek not sure what are the exact requirements for "behaving consistently" - but this way it works fine with the multisig xpubs titles
- It might now work so well with much shorter or much longer texts, but we should not use these extensively
