### PR TITLE
adjust T2B1 display refresh rate and contrast when displaying qr code

### DIFF
--- a/core/embed/extmod/modtrezorui/modtrezorui-display.h
+++ b/core/embed/extmod/modtrezorui/modtrezorui-display.h
@@ -160,6 +160,28 @@ STATIC mp_obj_t mod_trezorui_Display_clear_save(mp_obj_t self) {
 STATIC MP_DEFINE_CONST_FUN_OBJ_1(mod_trezorui_Display_clear_save_obj,
                                  mod_trezorui_Display_clear_save);
 
+/// def enter_qr_mode(self) -> None:
+///     """
+///     Enters display QR mode
+///     """
+STATIC mp_obj_t mod_trezorui_Display_enter_qr_mode(mp_obj_t self) {
+  display_enter_qr_mode();
+  return mp_const_none;
+}
+STATIC MP_DEFINE_CONST_FUN_OBJ_1(mod_trezorui_Display_enter_qr_mode_obj,
+                                 mod_trezorui_Display_enter_qr_mode);
+
+/// def exit_qr_mode(self) -> None:
+///     """
+///     Exits display QR mode
+///     """
+STATIC mp_obj_t mod_trezorui_Display_exit_qr_mode(mp_obj_t self) {
+  display_exit_qr_mode();
+  return mp_const_none;
+}
+STATIC MP_DEFINE_CONST_FUN_OBJ_1(mod_trezorui_Display_exit_qr_mode_obj,
+                                 mod_trezorui_Display_exit_qr_mode);
+
 STATIC const mp_rom_map_elem_t mod_trezorui_Display_locals_dict_table[] = {
     {MP_ROM_QSTR(MP_QSTR_clear), MP_ROM_PTR(&mod_trezorui_Display_clear_obj)},
     {MP_ROM_QSTR(MP_QSTR_refresh),
@@ -172,6 +194,10 @@ STATIC const mp_rom_map_elem_t mod_trezorui_Display_locals_dict_table[] = {
     {MP_ROM_QSTR(MP_QSTR_save), MP_ROM_PTR(&mod_trezorui_Display_save_obj)},
     {MP_ROM_QSTR(MP_QSTR_clear_save),
      MP_ROM_PTR(&mod_trezorui_Display_clear_save_obj)},
+    {MP_ROM_QSTR(MP_QSTR_enter_qr_mode),
+     MP_ROM_PTR(&mod_trezorui_Display_enter_qr_mode_obj)},
+    {MP_ROM_QSTR(MP_QSTR_exit_qr_mode),
+     MP_ROM_PTR(&mod_trezorui_Display_exit_qr_mode_obj)},
     {MP_ROM_QSTR(MP_QSTR_WIDTH), MP_ROM_INT(DISPLAY_RESX)},
     {MP_ROM_QSTR(MP_QSTR_HEIGHT), MP_ROM_INT(DISPLAY_RESY)},
     {MP_ROM_QSTR(MP_QSTR_FONT_NORMAL), MP_ROM_INT(FONT_NORMAL)},

--- a/core/embed/lib/display_interface.h
+++ b/core/embed/lib/display_interface.h
@@ -47,5 +47,7 @@ void display_sync(void);
 void display_refresh(void);
 const char *display_save(const char *prefix);
 void display_clear_save(void);
+void display_enter_qr_mode(void);
+void display_exit_qr_mode(void);
 
 #endif  //_DISPLAY_INTERFACE_H

--- a/core/embed/trezorhal/stm32f4/displays/ltdc.c
+++ b/core/embed/trezorhal/stm32f4/displays/ltdc.c
@@ -371,3 +371,5 @@ void display_sync(void) {}
 const char *display_save(const char *prefix) { return NULL; }
 
 void display_clear_save(void) {}
+void display_enter_qr_mode(void) {}
+void display_exit_qr_mode(void) {}

--- a/core/embed/trezorhal/stm32f4/displays/st7789v.c
+++ b/core/embed/trezorhal/stm32f4/displays/st7789v.c
@@ -470,3 +470,6 @@ void display_set_big_endian(void) {
 const char *display_save(const char *prefix) { return NULL; }
 
 void display_clear_save(void) {}
+
+void display_enter_qr_mode(void) {}
+void display_exit_qr_mode(void) {}

--- a/core/embed/trezorhal/stm32f4/displays/ug-2828tswig01.c
+++ b/core/embed/trezorhal/stm32f4/displays/ug-2828tswig01.c
@@ -371,3 +371,5 @@ void display_reinit(void) {}
 const char *display_save(const char *prefix) { return NULL; }
 
 void display_clear_save(void) {}
+void display_enter_qr_mode(void) {}
+void display_exit_qr_mode(void) {}

--- a/core/embed/trezorhal/unix/display-unix.c
+++ b/core/embed/trezorhal/unix/display-unix.c
@@ -332,3 +332,6 @@ void display_clear_save(void) {
   SDL_FreeSurface(PREV_SAVED);
   PREV_SAVED = NULL;
 }
+
+void display_enter_qr_mode(void) {}
+void display_exit_qr_mode(void) {}

--- a/core/mocks/generated/trezorui.pyi
+++ b/core/mocks/generated/trezorui.pyi
@@ -57,3 +57,13 @@ class Display:
         """
         Clears buffers in display saving.
         """
+
+    def enter_qr_mode(self) -> None:
+        """
+        Enters display QR mode
+        """
+
+    def exit_qr_mode(self) -> None:
+        """
+        Exits display QR mode
+        """

--- a/core/src/trezor/ui/layouts/tr/__init__.py
+++ b/core/src/trezor/ui/layouts/tr/__init__.py
@@ -513,6 +513,8 @@ async def show_address(
                 result += " (YOURS)" if i == multisig_index else " (COSIGNER)"
                 return result
 
+            ui.display.enter_qr_mode()
+
             result = await ctx_wait(
                 RustLayout(
                     trezorui2.show_address_details(
@@ -526,6 +528,9 @@ async def show_address(
                     )
                 ),
             )
+
+            ui.display.exit_qr_mode()
+
             # Can only go back from the address details.
             assert result is CANCELLED
 


### PR DESCRIPTION
adjust T2B1 display refresh rate and contrast when displaying qr code.

also SPI baudrate is adjusted - was slightly outside of tolerance.

Not very sure about the API of the functionality, its a bit single purpose but i also didnt want to get into exposing the contrast and frequency settings of the display.

[no changelog]

<!--
If you are a core dev:

Don't forget to set up the fields:
- assign yourself
- set priority to same as original issue
- add PR to sprint
- if Draft -> "in progress"
- if final PR -> "needs review"

If you're an external contributor, you can ignore this text.
-->
