### PR TITLE
refactor(vendor): updated and replaced stm32 libs

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -21,15 +21,12 @@
 [submodule "vendor/fido2-tests"]
 	path = vendor/fido2-tests
 	url = https://github.com/trezor/fido2-tests.git
-[submodule "vendor/stm32f4_cmsis"]
-	path = vendor/stm32f4-cmsis
-	url = https://github.com/STMicroelectronics/cmsis_device_f4.git
-[submodule "vendor/stm32u5_hal"]
-	path = vendor/stm32u5-drivers
+[submodule "vendor/stm32u5-hal"]
+	path = vendor/stm32u5-hal-drivers
 	url = https://github.com/STMicroelectronics/stm32u5xx_hal_driver.git
-[submodule "vendor/stm32f4_hal"]
-	path = vendor/stm32f4-drivers
-	url = https://github.com/STMicroelectronics/stm32f4xx_hal_driver.git
-[submodule "vendor/stm32u5_cmsis"]
-	path = vendor/stm32u5-cmsis
+[submodule "vendor/stm32u5-cmsis"]
+	path = vendor/stm32u5-cmsis-device
 	url = https://github.com/STMicroelectronics/cmsis_device_u5.git
+[submodule "vendor/stm32xx-lib"]
+	path = vendor/stm32xx-lib
+	url = https://github.com/micropython/stm32lib.git

--- a/.gitmodules
+++ b/.gitmodules
@@ -21,3 +21,15 @@
 [submodule "vendor/fido2-tests"]
 	path = vendor/fido2-tests
 	url = https://github.com/trezor/fido2-tests.git
+[submodule "vendor/stm32f4_cmsis"]
+	path = vendor/stm32f4-cmsis
+	url = https://github.com/STMicroelectronics/cmsis_device_f4.git
+[submodule "vendor/stm32u5_hal"]
+	path = vendor/stm32u5-drivers
+	url = https://github.com/STMicroelectronics/stm32u5xx_hal_driver.git
+[submodule "vendor/stm32f4_hal"]
+	path = vendor/stm32f4-drivers
+	url = https://github.com/STMicroelectronics/stm32f4xx_hal_driver.git
+[submodule "vendor/stm32u5_cmsis"]
+	path = vendor/stm32u5-cmsis
+	url = https://github.com/STMicroelectronics/cmsis_device_u5.git

--- a/core/site_scons/boards/discovery.py
+++ b/core/site_scons/boards/discovery.py
@@ -40,9 +40,7 @@ def configure(
     sources += ["embed/trezorhal/stm32f4/displays/ili9341_spi.c"]
     sources += ["embed/trezorhal/stm32f4/dma.c"]
     sources += ["embed/trezorhal/stm32f4/sdram.c"]
-    sources += [
-        "vendor/stm32f4-drivers/Src/stm32f4xx_hal_dma.c"
-    ]
+    sources += ["vendor/stm32xx-lib/STM32F4xx_HAL_Driver/Src/stm32f4xx_hal_dma.c"]
 
     if "input" in features_wanted:
         sources += ["embed/trezorhal/stm32f4/i2c.c"]
@@ -62,7 +60,7 @@ def configure(
             "embed/trezorhal/stm32f4/usbd_core.c",
             "embed/trezorhal/stm32f4/usbd_ctlreq.c",
             "embed/trezorhal/stm32f4/usbd_ioreq.c",
-            "vendor/stm32f4-drivers/Src/stm32f4xx_ll_usb.c",
+            "vendor/stm32xx-lib/STM32F4xx_HAL_Driver/Src/stm32f4xx_ll_usb.c",
         ]
         features_available.append("usb")
 

--- a/core/site_scons/boards/discovery.py
+++ b/core/site_scons/boards/discovery.py
@@ -41,7 +41,7 @@ def configure(
     sources += ["embed/trezorhal/stm32f4/dma.c"]
     sources += ["embed/trezorhal/stm32f4/sdram.c"]
     sources += [
-        "vendor/micropython/lib/stm32lib/STM32F4xx_HAL_Driver/Src/stm32f4xx_hal_dma.c"
+        "vendor/stm32f4-drivers/Src/stm32f4xx_hal_dma.c"
     ]
 
     if "input" in features_wanted:
@@ -62,7 +62,7 @@ def configure(
             "embed/trezorhal/stm32f4/usbd_core.c",
             "embed/trezorhal/stm32f4/usbd_ctlreq.c",
             "embed/trezorhal/stm32f4/usbd_ioreq.c",
-            "vendor/micropython/lib/stm32lib/STM32F4xx_HAL_Driver/Src/stm32f4xx_ll_usb.c",
+            "vendor/stm32f4-drivers/Src/stm32f4xx_ll_usb.c",
         ]
         features_available.append("usb")
 

--- a/core/site_scons/boards/stm32f4_common.py
+++ b/core/site_scons/boards/stm32f4_common.py
@@ -8,31 +8,31 @@ def stm32f4_common_files(env, defines, sources, paths):
 
     paths += [
         "embed/trezorhal/stm32f4",
-        "vendor/micropython/lib/stm32lib/STM32F4xx_HAL_Driver/Inc",
-        "vendor/micropython/lib/stm32lib/CMSIS/STM32F4xx/Include",
+        "vendor/stm32f4-drivers/Inc",
+        "vendor/stm32f4-cmsis/Include",
     ]
 
     sources += [
-        "vendor/micropython/lib/stm32lib/STM32F4xx_HAL_Driver/Src/stm32f4xx_hal.c",
-        "vendor/micropython/lib/stm32lib/STM32F4xx_HAL_Driver/Src/stm32f4xx_hal_cortex.c",
-        "vendor/micropython/lib/stm32lib/STM32F4xx_HAL_Driver/Src/stm32f4xx_hal_flash.c",
-        "vendor/micropython/lib/stm32lib/STM32F4xx_HAL_Driver/Src/stm32f4xx_hal_flash_ex.c",
-        "vendor/micropython/lib/stm32lib/STM32F4xx_HAL_Driver/Src/stm32f4xx_hal_gpio.c",
-        "vendor/micropython/lib/stm32lib/STM32F4xx_HAL_Driver/Src/stm32f4xx_hal_i2c.c",
-        "vendor/micropython/lib/stm32lib/STM32F4xx_HAL_Driver/Src/stm32f4xx_hal_ltdc.c",
-        "vendor/micropython/lib/stm32lib/STM32F4xx_HAL_Driver/Src/stm32f4xx_hal_pcd.c",
-        "vendor/micropython/lib/stm32lib/STM32F4xx_HAL_Driver/Src/stm32f4xx_hal_pcd_ex.c",
-        "vendor/micropython/lib/stm32lib/STM32F4xx_HAL_Driver/Src/stm32f4xx_hal_pwr.c",
-        "vendor/micropython/lib/stm32lib/STM32F4xx_HAL_Driver/Src/stm32f4xx_hal_rcc.c",
-        "vendor/micropython/lib/stm32lib/STM32F4xx_HAL_Driver/Src/stm32f4xx_hal_rcc_ex.c",
-        "vendor/micropython/lib/stm32lib/STM32F4xx_HAL_Driver/Src/stm32f4xx_hal_sd.c",
-        "vendor/micropython/lib/stm32lib/STM32F4xx_HAL_Driver/Src/stm32f4xx_hal_spi.c",
-        "vendor/micropython/lib/stm32lib/STM32F4xx_HAL_Driver/Src/stm32f4xx_hal_sram.c",
-        "vendor/micropython/lib/stm32lib/STM32F4xx_HAL_Driver/Src/stm32f4xx_hal_sdram.c",
-        "vendor/micropython/lib/stm32lib/STM32F4xx_HAL_Driver/Src/stm32f4xx_hal_tim.c",
-        "vendor/micropython/lib/stm32lib/STM32F4xx_HAL_Driver/Src/stm32f4xx_hal_tim_ex.c",
-        "vendor/micropython/lib/stm32lib/STM32F4xx_HAL_Driver/Src/stm32f4xx_ll_fmc.c",
-        "vendor/micropython/lib/stm32lib/STM32F4xx_HAL_Driver/Src/stm32f4xx_ll_sdmmc.c",
+        "vendor/stm32f4-drivers/Src/stm32f4xx_hal.c",
+        "vendor/stm32f4-drivers/Src/stm32f4xx_hal_cortex.c",
+        "vendor/stm32f4-drivers/Src/stm32f4xx_hal_flash.c",
+        "vendor/stm32f4-drivers/Src/stm32f4xx_hal_flash_ex.c",
+        "vendor/stm32f4-drivers/Src/stm32f4xx_hal_gpio.c",
+        "vendor/stm32f4-drivers/Src/stm32f4xx_hal_i2c.c",
+        "vendor/stm32f4-drivers/Src/stm32f4xx_hal_ltdc.c",
+        "vendor/stm32f4-drivers/Src/stm32f4xx_hal_pcd.c",
+        "vendor/stm32f4-drivers/Src/stm32f4xx_hal_pcd_ex.c",
+        "vendor/stm32f4-drivers/Src/stm32f4xx_hal_pwr.c",
+        "vendor/stm32f4-drivers/Src/stm32f4xx_hal_rcc.c",
+        "vendor/stm32f4-drivers/Src/stm32f4xx_hal_rcc_ex.c",
+        "vendor/stm32f4-drivers/Src/stm32f4xx_hal_sd.c",
+        "vendor/stm32f4-drivers/Src/stm32f4xx_hal_spi.c",
+        "vendor/stm32f4-drivers/Src/stm32f4xx_hal_sram.c",
+        "vendor/stm32f4-drivers/Src/stm32f4xx_hal_sdram.c",
+        "vendor/stm32f4-drivers/Src/stm32f4xx_hal_tim.c",
+        "vendor/stm32f4-drivers/Src/stm32f4xx_hal_tim_ex.c",
+        "vendor/stm32f4-drivers/Src/stm32f4xx_ll_fmc.c",
+        "vendor/stm32f4-drivers/Src/stm32f4xx_ll_sdmmc.c",
     ]
 
     sources += [
@@ -62,7 +62,7 @@ def stm32f4_common_files(env, defines, sources, paths):
 
     env.get("ENV")["RUST_INCLUDES"] = (
         "-I../trezorhal/stm32f4;"
-        "-I../../vendor/micropython/lib/stm32lib/STM32F4xx_HAL_Driver/Inc;"
-        "-I../../vendor/micropython/lib/stm32lib/CMSIS/STM32F4xx/Include;"
+        "-I../../vendor/stm32f4-drivers/Inc;"
+        "-I../../vendor/stm32f4-cmsis/Include;"
         "-DSTM32_HAL_H=<stm32f4xx.h>"
     )

--- a/core/site_scons/boards/stm32f4_common.py
+++ b/core/site_scons/boards/stm32f4_common.py
@@ -9,8 +9,8 @@ def stm32f4_common_files(env, defines, sources, paths):
     paths += [
         "embed/trezorhal/stm32f4",
         "vendor/stm32xx-lib/STM32F4xx_HAL_Driver/Inc",
-        "vendor/stm32xx-lib/CMSIS/STM32F4xx/Include"
-    ] 
+        "vendor/stm32xx-lib/CMSIS/STM32F4xx/Include",
+    ]
     sources += [
         "vendor/stm32xx-lib/STM32F4xx_HAL_Driver/Src/stm32f4xx_hal.c",
         "vendor/stm32xx-lib/STM32F4xx_HAL_Driver/Src/stm32f4xx_hal_cortex.c",

--- a/core/site_scons/boards/stm32f4_common.py
+++ b/core/site_scons/boards/stm32f4_common.py
@@ -8,31 +8,30 @@ def stm32f4_common_files(env, defines, sources, paths):
 
     paths += [
         "embed/trezorhal/stm32f4",
-        "vendor/stm32f4-drivers/Inc",
-        "vendor/stm32f4-cmsis/Include",
-    ]
-
+        "vendor/stm32xx-lib/STM32F4xx_HAL_Driver/Inc",
+        "vendor/stm32xx-lib/CMSIS/STM32F4xx/Include"
+    ] 
     sources += [
-        "vendor/stm32f4-drivers/Src/stm32f4xx_hal.c",
-        "vendor/stm32f4-drivers/Src/stm32f4xx_hal_cortex.c",
-        "vendor/stm32f4-drivers/Src/stm32f4xx_hal_flash.c",
-        "vendor/stm32f4-drivers/Src/stm32f4xx_hal_flash_ex.c",
-        "vendor/stm32f4-drivers/Src/stm32f4xx_hal_gpio.c",
-        "vendor/stm32f4-drivers/Src/stm32f4xx_hal_i2c.c",
-        "vendor/stm32f4-drivers/Src/stm32f4xx_hal_ltdc.c",
-        "vendor/stm32f4-drivers/Src/stm32f4xx_hal_pcd.c",
-        "vendor/stm32f4-drivers/Src/stm32f4xx_hal_pcd_ex.c",
-        "vendor/stm32f4-drivers/Src/stm32f4xx_hal_pwr.c",
-        "vendor/stm32f4-drivers/Src/stm32f4xx_hal_rcc.c",
-        "vendor/stm32f4-drivers/Src/stm32f4xx_hal_rcc_ex.c",
-        "vendor/stm32f4-drivers/Src/stm32f4xx_hal_sd.c",
-        "vendor/stm32f4-drivers/Src/stm32f4xx_hal_spi.c",
-        "vendor/stm32f4-drivers/Src/stm32f4xx_hal_sram.c",
-        "vendor/stm32f4-drivers/Src/stm32f4xx_hal_sdram.c",
-        "vendor/stm32f4-drivers/Src/stm32f4xx_hal_tim.c",
-        "vendor/stm32f4-drivers/Src/stm32f4xx_hal_tim_ex.c",
-        "vendor/stm32f4-drivers/Src/stm32f4xx_ll_fmc.c",
-        "vendor/stm32f4-drivers/Src/stm32f4xx_ll_sdmmc.c",
+        "vendor/stm32xx-lib/STM32F4xx_HAL_Driver/Src/stm32f4xx_hal.c",
+        "vendor/stm32xx-lib/STM32F4xx_HAL_Driver/Src/stm32f4xx_hal_cortex.c",
+        "vendor/stm32xx-lib/STM32F4xx_HAL_Driver/Src/stm32f4xx_hal_flash.c",
+        "vendor/stm32xx-lib/STM32F4xx_HAL_Driver/Src/stm32f4xx_hal_flash_ex.c",
+        "vendor/stm32xx-lib/STM32F4xx_HAL_Driver/Src/stm32f4xx_hal_gpio.c",
+        "vendor/stm32xx-lib/STM32F4xx_HAL_Driver/Src/stm32f4xx_hal_i2c.c",
+        "vendor/stm32xx-lib/STM32F4xx_HAL_Driver/Src/stm32f4xx_hal_ltdc.c",
+        "vendor/stm32xx-lib/STM32F4xx_HAL_Driver/Src/stm32f4xx_hal_pcd.c",
+        "vendor/stm32xx-lib/STM32F4xx_HAL_Driver/Src/stm32f4xx_hal_pcd_ex.c",
+        "vendor/stm32xx-lib/STM32F4xx_HAL_Driver/Src/stm32f4xx_hal_pwr.c",
+        "vendor/stm32xx-lib/STM32F4xx_HAL_Driver/Src/stm32f4xx_hal_rcc.c",
+        "vendor/stm32xx-lib/STM32F4xx_HAL_Driver/Src/stm32f4xx_hal_rcc_ex.c",
+        "vendor/stm32xx-lib/STM32F4xx_HAL_Driver/Src/stm32f4xx_hal_sd.c",
+        "vendor/stm32xx-lib/STM32F4xx_HAL_Driver/Src/stm32f4xx_hal_spi.c",
+        "vendor/stm32xx-lib/STM32F4xx_HAL_Driver/Src/stm32f4xx_hal_sram.c",
+        "vendor/stm32xx-lib/STM32F4xx_HAL_Driver/Src/stm32f4xx_hal_sdram.c",
+        "vendor/stm32xx-lib/STM32F4xx_HAL_Driver/Src/stm32f4xx_hal_tim.c",
+        "vendor/stm32xx-lib/STM32F4xx_HAL_Driver/Src/stm32f4xx_hal_tim_ex.c",
+        "vendor/stm32xx-lib/STM32F4xx_HAL_Driver/Src/stm32f4xx_ll_fmc.c",
+        "vendor/stm32xx-lib/STM32F4xx_HAL_Driver/Src/stm32f4xx_ll_sdmmc.c",
     ]
 
     sources += [
@@ -62,7 +61,7 @@ def stm32f4_common_files(env, defines, sources, paths):
 
     env.get("ENV")["RUST_INCLUDES"] = (
         "-I../trezorhal/stm32f4;"
-        "-I../../vendor/stm32f4-drivers/Inc;"
-        "-I../../vendor/stm32f4-cmsis/Include;"
+        "-I../../vendor/stm32xx-lib/STM32F4xx_HAL_Driver/Inc;"
+        "-I../../vendor/stm32xx-lib/CMSIS/STM32F4xx/Include;"
         "-DSTM32_HAL_H=<stm32f4xx.h>"
     )

--- a/core/site_scons/boards/trezor_1.py
+++ b/core/site_scons/boards/trezor_1.py
@@ -47,7 +47,7 @@ def configure(
             "embed/trezorhal/stm32f4/usbd_core.c",
             "embed/trezorhal/stm32f4/usbd_ctlreq.c",
             "embed/trezorhal/stm32f4/usbd_ioreq.c",
-            "vendor/stm32f4-drivers/Src/stm32f4xx_ll_usb.c",
+            "vendor/stm32xx-lib/STM32F4xx_HAL_Driver/Src/stm32f4xx_ll_usb.c",
         ]
         features_available.append("usb")
 

--- a/core/site_scons/boards/trezor_1.py
+++ b/core/site_scons/boards/trezor_1.py
@@ -47,7 +47,7 @@ def configure(
             "embed/trezorhal/stm32f4/usbd_core.c",
             "embed/trezorhal/stm32f4/usbd_ctlreq.c",
             "embed/trezorhal/stm32f4/usbd_ioreq.c",
-            "vendor/micropython/lib/stm32lib/STM32F4xx_HAL_Driver/Src/stm32f4xx_ll_usb.c",
+            "vendor/stm32f4-drivers/Src/stm32f4xx_ll_usb.c",
         ]
         features_available.append("usb")
 

--- a/core/site_scons/boards/trezor_r_v10.py
+++ b/core/site_scons/boards/trezor_r_v10.py
@@ -52,7 +52,7 @@ def configure(
     if "consumption_mask" in features_wanted:
         sources += ["embed/trezorhal/stm32f4/consumption_mask.c"]
         sources += [
-            "vendor/micropython/lib/stm32lib/STM32F4xx_HAL_Driver/Src/stm32f4xx_hal_dma.c"
+            "vendor/stm32f4-drivers/Src/stm32f4xx_hal_dma.c"
         ]
     if "usb" in features_wanted:
         sources += [
@@ -61,7 +61,7 @@ def configure(
             "embed/trezorhal/stm32f4/usbd_core.c",
             "embed/trezorhal/stm32f4/usbd_ctlreq.c",
             "embed/trezorhal/stm32f4/usbd_ioreq.c",
-            "vendor/micropython/lib/stm32lib/STM32F4xx_HAL_Driver/Src/stm32f4xx_ll_usb.c",
+            "vendor/stm32f4-drivers/Src/stm32f4xx_ll_usb.c",
         ]
         features_available.append("usb")
 

--- a/core/site_scons/boards/trezor_r_v10.py
+++ b/core/site_scons/boards/trezor_r_v10.py
@@ -51,9 +51,7 @@ def configure(
 
     if "consumption_mask" in features_wanted:
         sources += ["embed/trezorhal/stm32f4/consumption_mask.c"]
-        sources += [
-            "vendor/stm32f4-drivers/Src/stm32f4xx_hal_dma.c"
-        ]
+        sources += ["vendor/stm32xx-lib/STM32F4xx_HAL_Driver/Src/stm32f4xx_hal_dma.c"]
     if "usb" in features_wanted:
         sources += [
             "embed/trezorhal/stm32f4/usb.c",
@@ -61,7 +59,7 @@ def configure(
             "embed/trezorhal/stm32f4/usbd_core.c",
             "embed/trezorhal/stm32f4/usbd_ctlreq.c",
             "embed/trezorhal/stm32f4/usbd_ioreq.c",
-            "vendor/stm32f4-drivers/Src/stm32f4xx_ll_usb.c",
+            "vendor/stm32xx-lib/STM32F4xx_HAL_Driver/Src/stm32f4xx_ll_usb.c",
         ]
         features_available.append("usb")
 

--- a/core/site_scons/boards/trezor_r_v3.py
+++ b/core/site_scons/boards/trezor_r_v3.py
@@ -57,7 +57,7 @@ def configure(
             "embed/trezorhal/stm32f4/usbd_core.c",
             "embed/trezorhal/stm32f4/usbd_ctlreq.c",
             "embed/trezorhal/stm32f4/usbd_ioreq.c",
-            "vendor/micropython/lib/stm32lib/STM32F4xx_HAL_Driver/Src/stm32f4xx_ll_usb.c",
+            "vendor/stm32f4-drivers/Src/stm32f4xx_ll_usb.c",
         ]
         features_available.append("usb")
 

--- a/core/site_scons/boards/trezor_r_v3.py
+++ b/core/site_scons/boards/trezor_r_v3.py
@@ -57,7 +57,7 @@ def configure(
             "embed/trezorhal/stm32f4/usbd_core.c",
             "embed/trezorhal/stm32f4/usbd_ctlreq.c",
             "embed/trezorhal/stm32f4/usbd_ioreq.c",
-            "vendor/stm32f4-drivers/Src/stm32f4xx_ll_usb.c",
+            "vendor/stm32xx-lib/STM32F4xx_HAL_Driver/Src/stm32f4xx_ll_usb.c",
         ]
         features_available.append("usb")
 

--- a/core/site_scons/boards/trezor_r_v4.py
+++ b/core/site_scons/boards/trezor_r_v4.py
@@ -53,7 +53,7 @@ def configure(
             "embed/trezorhal/stm32f4/usbd_core.c",
             "embed/trezorhal/stm32f4/usbd_ctlreq.c",
             "embed/trezorhal/stm32f4/usbd_ioreq.c",
-            "vendor/stm32f4-drivers/Src/stm32f4xx_ll_usb.c",
+            "vendor/stm32xx-lib/STM32F4xx_HAL_Driver/Src/stm32f4xx_ll_usb.c",
         ]
         features_available.append("usb")
 

--- a/core/site_scons/boards/trezor_r_v4.py
+++ b/core/site_scons/boards/trezor_r_v4.py
@@ -53,7 +53,7 @@ def configure(
             "embed/trezorhal/stm32f4/usbd_core.c",
             "embed/trezorhal/stm32f4/usbd_ctlreq.c",
             "embed/trezorhal/stm32f4/usbd_ioreq.c",
-            "vendor/micropython/lib/stm32lib/STM32F4xx_HAL_Driver/Src/stm32f4xx_ll_usb.c",
+            "vendor/stm32f4-drivers/Src/stm32f4xx_ll_usb.c",
         ]
         features_available.append("usb")
 

--- a/core/site_scons/boards/trezor_r_v6.py
+++ b/core/site_scons/boards/trezor_r_v6.py
@@ -53,7 +53,7 @@ def configure(
             "embed/trezorhal/stm32f4/usbd_core.c",
             "embed/trezorhal/stm32f4/usbd_ctlreq.c",
             "embed/trezorhal/stm32f4/usbd_ioreq.c",
-            "vendor/stm32f4-drivers/Src/stm32f4xx_ll_usb.c",
+            "vendor/stm32xx-lib/STM32F4xx_HAL_Driver/Src/stm32f4xx_ll_usb.c",
         ]
         features_available.append("usb")
 

--- a/core/site_scons/boards/trezor_r_v6.py
+++ b/core/site_scons/boards/trezor_r_v6.py
@@ -53,7 +53,7 @@ def configure(
             "embed/trezorhal/stm32f4/usbd_core.c",
             "embed/trezorhal/stm32f4/usbd_ctlreq.c",
             "embed/trezorhal/stm32f4/usbd_ioreq.c",
-            "vendor/micropython/lib/stm32lib/STM32F4xx_HAL_Driver/Src/stm32f4xx_ll_usb.c",
+            "vendor/stm32f4-drivers/Src/stm32f4xx_ll_usb.c",
         ]
         features_available.append("usb")
 

--- a/core/site_scons/boards/trezor_t.py
+++ b/core/site_scons/boards/trezor_t.py
@@ -64,9 +64,7 @@ def configure(
         sources += ["embed/trezorhal/stm32f4/sdcard.c"]
         sources += ["embed/extmod/modtrezorio/ff.c"]
         sources += ["embed/extmod/modtrezorio/ffunicode.c"]
-        sources += [
-            "vendor/stm32f4-drivers/Src/stm32f4xx_hal_dma.c"
-        ]
+        sources += ["vendor/stm32xx-lib/STM32F4xx_HAL_Driver/Src/stm32f4xx_hal_dma.c"]
         features_available.append("sd_card")
 
     if "sbu" in features_wanted:
@@ -80,16 +78,14 @@ def configure(
             "embed/trezorhal/stm32f4/usbd_core.c",
             "embed/trezorhal/stm32f4/usbd_ctlreq.c",
             "embed/trezorhal/stm32f4/usbd_ioreq.c",
-            "vendor/stm32f4-drivers/Src/stm32f4xx_ll_usb.c",
+            "vendor/stm32xx-lib/STM32F4xx_HAL_Driver/Src/stm32f4xx_ll_usb.c",
         ]
         features_available.append("usb")
 
     if "dma2d" in features_wanted:
         defines += ["USE_DMA2D"]
         sources += ["embed/trezorhal/stm32f4/dma2d.c"]
-        sources += [
-            "vendor/stm32f4-drivers/Src/stm32f4xx_hal_dma2d.c"
-        ]
+        sources += ["vendor/stm32xx-lib/STM32F4xx_HAL_Driver/Src/stm32f4xx_hal_dma2d.c"]
         features_available.append("dma2d")
 
     env.get("ENV")["TREZOR_BOARD"] = board

--- a/core/site_scons/boards/trezor_t.py
+++ b/core/site_scons/boards/trezor_t.py
@@ -65,7 +65,7 @@ def configure(
         sources += ["embed/extmod/modtrezorio/ff.c"]
         sources += ["embed/extmod/modtrezorio/ffunicode.c"]
         sources += [
-            "vendor/micropython/lib/stm32lib/STM32F4xx_HAL_Driver/Src/stm32f4xx_hal_dma.c"
+            "vendor/stm32f4-drivers/Src/stm32f4xx_hal_dma.c"
         ]
         features_available.append("sd_card")
 
@@ -80,7 +80,7 @@ def configure(
             "embed/trezorhal/stm32f4/usbd_core.c",
             "embed/trezorhal/stm32f4/usbd_ctlreq.c",
             "embed/trezorhal/stm32f4/usbd_ioreq.c",
-            "vendor/micropython/lib/stm32lib/STM32F4xx_HAL_Driver/Src/stm32f4xx_ll_usb.c",
+            "vendor/stm32f4-drivers/Src/stm32f4xx_ll_usb.c",
         ]
         features_available.append("usb")
 
@@ -88,7 +88,7 @@ def configure(
         defines += ["USE_DMA2D"]
         sources += ["embed/trezorhal/stm32f4/dma2d.c"]
         sources += [
-            "vendor/micropython/lib/stm32lib/STM32F4xx_HAL_Driver/Src/stm32f4xx_hal_dma2d.c"
+            "vendor/stm32f4-drivers/Src/stm32f4xx_hal_dma2d.c"
         ]
         features_available.append("dma2d")
 

--- a/core/vendor/stm32f4-cmsis
+++ b/core/vendor/stm32f4-cmsis
@@ -1,0 +1,1 @@
+../../vendor/stm32f4-cmsis

--- a/core/vendor/stm32f4-cmsis
+++ b/core/vendor/stm32f4-cmsis
@@ -1,1 +1,0 @@
-../../vendor/stm32f4-cmsis

--- a/core/vendor/stm32f4-drivers
+++ b/core/vendor/stm32f4-drivers
@@ -1,1 +1,0 @@
-../../vendor/stm32f4-drivers

--- a/core/vendor/stm32f4-drivers
+++ b/core/vendor/stm32f4-drivers
@@ -1,0 +1,1 @@
+../../vendor/stm32f4-drivers

--- a/core/vendor/stm32u5-cmsis
+++ b/core/vendor/stm32u5-cmsis
@@ -1,1 +1,0 @@
-../../vendor/stm32u5-cmsis

--- a/core/vendor/stm32u5-cmsis
+++ b/core/vendor/stm32u5-cmsis
@@ -1,0 +1,1 @@
+../../vendor/stm32u5-cmsis

--- a/core/vendor/stm32u5-cmsis-device
+++ b/core/vendor/stm32u5-cmsis-device
@@ -1,0 +1,1 @@
+../../vendor/stm32u5-cmsis-device/

--- a/core/vendor/stm32u5-drivers
+++ b/core/vendor/stm32u5-drivers
@@ -1,1 +1,0 @@
-../../vendor/stm32u5-drivers

--- a/core/vendor/stm32u5-drivers
+++ b/core/vendor/stm32u5-drivers
@@ -1,0 +1,1 @@
+../../vendor/stm32u5-drivers

--- a/core/vendor/stm32u5-hal-drivers
+++ b/core/vendor/stm32u5-hal-drivers
@@ -1,0 +1,1 @@
+../../vendor/stm32u5-hal-drivers/

--- a/core/vendor/stm32xx-lib
+++ b/core/vendor/stm32xx-lib
@@ -1,0 +1,1 @@
+../../vendor/stm32xx-lib

--- a/vendor/readme.md
+++ b/vendor/readme.md
@@ -19,11 +19,11 @@ This repository houses a QR Code generator library.
 secp256k1-zkp is an optimized C library tailored for ECDSA signatures and secret/public key operations on the secp256k1 curve.
 
 ## stm32u5-cmsis-device
-The STM32U5 CMSIS device module for the STM32U5 family of microcontrollers. 
-    
+The STM32U5 CMSIS device module for the STM32U5 family of microcontrollers.
+
 ## stm32u5-hal-drivers
 This repository contains STM32U5 HAL/LL (Hardware Abstraction Layer/Low-Level) drivers developed for the STM32U5 family.
 
-## stm32xx-lib 
+## stm32xx-lib
 This repository holds a portion of STMicroelectronics' STM32 Cube firmware library.
-It's maintaned by MicroPython team and it is quite outdated. We use this library for products based on STM32F4xx devices, currently limited to the T model. 
+It's maintaned by MicroPython team and it is quite outdated. We use this library for products based on STM32F4xx devices, currently limited to the T model.

--- a/vendor/readme.md
+++ b/vendor/readme.md
@@ -1,0 +1,29 @@
+# External repositories
+
+## fido2-tests
+This repository contains a test suite for FIDO2, U2F, and other security key functions.
+
+## libopencm3
+An open-source firmware library designed for various ARM Cortex-M microcontrollers. We utilize this library specifically for products based on STM32F2 devices, with the current application limited to the T1 model.
+
+## micropython
+Micropython is a project aimed at implementing Python 3.x on microcontrollers and small embedded systems.
+
+## nanopb
+This is a compact Protocol Buffers implementation written in ANSI C. It is particularly suitable for microcontrollers but can be used in any memory-constrained system.
+
+## QR-Code-generator
+This repository houses a QR Code generator library.
+
+## secp256k1-zkp
+secp256k1-zkp is an optimized C library tailored for ECDSA signatures and secret/public key operations on the secp256k1 curve.
+
+## stm32u5-cmsis-device
+The STM32U5 CMSIS device module for the STM32U5 family of microcontrollers. 
+    
+## stm32u5-hal-drivers
+This repository contains STM32U5 HAL/LL (Hardware Abstraction Layer/Low-Level) drivers developed for the STM32U5 family.
+
+## stm32xx-lib 
+This repository holds a portion of STMicroelectronics' STM32 Cube firmware library.
+It's maintaned by MicroPython team and it is quite outdated. We use this library for products based on STM32F4xx devices, currently limited to the T model. 


### PR DESCRIPTION
With this pull request, we are discontinuing the use of the micropython/stm32lib submodule and relocating all related components into the vendor directory.

*Motivation: Currently, we are utilizing STM32 HAL/CMSIS libraries from the micropython repository as a submodule called stm32lib. This submodule includes a copy of the STM32CubeXX firmware libraries. However, the repository occasionally receives updates and is somewhat outdated. Additionally, it lacks STM32U5 firmware libraries.*

We have introduced four new submodules containing CMSIS and HAL drivers for STM32F4 and STM32U5. These submodules can be updated individually as needed.

The STM32U5 CMSIS/HAL drivers are up to date, while the STM32F4 CMSIS/HAL drivers have been aligned as closely as possible with the original stm32lib versions. Further updates for STM32F4 are possible but require additional testing.