### PR TITLE
Remove redundant display initialization in the intermediate firmware on T1

### DIFF
--- a/legacy/intermediate_fw/trezor.c
+++ b/legacy/intermediate_fw/trezor.c
@@ -107,7 +107,7 @@ int main(void) {
   setupApp();
   __stack_chk_guard = random32();  // this supports compiler provided
                                    // unpredictable stack protection checks
-  oledInit();
+
   if (is_mode_unprivileged()) {
     layoutDialog(&bmp_icon_warning, NULL, NULL, NULL, "Cannot update", NULL,
                  NULL, "Unprivileged mode", "Unsigned firmware", NULL);


### PR DESCRIPTION
I have removed redundant display initialization in the intermediate firmware on T1. This change should reduce the probability of display glitches described in issue #3308. However, please note that this is just a workaround, as the root cause of the problem is still unknown.

fixes #3308
