### PR TITLE
remove residual usage of old flash api

### DIFF
--- a/core/embed/bootloader/emulator.c
+++ b/core/embed/bootloader/emulator.c
@@ -28,9 +28,9 @@ void set_core_clock(int) {}
 
 int bootloader_main(void);
 
-bool sector_is_empty(uint16_t sector) {
-  const uint8_t *storage = flash_get_address(sector, 0, 0);
-  size_t storage_size = flash_sector_size(sector);
+bool sector_is_empty(const flash_area_t *area) {
+  const uint8_t *storage = flash_area_get_address(area, 0, 0);
+  size_t storage_size = flash_area_get_size(area);
   for (size_t i = 0; i < storage_size; i++) {
     if (storage[i] != 0xFF) {
       return false;
@@ -117,7 +117,7 @@ __attribute__((noreturn)) int main(int argc, char **argv) {
   FIRMWARE_START = (uint8_t *)flash_area_get_address(&FIRMWARE_AREA, 0, 0);
 
   // simulate non-empty storage so that we know whether it was erased or not
-  if (sector_is_empty(STORAGE_AREAS[0].subarea[0].first_sector)) {
+  if (sector_is_empty(&STORAGE_AREAS[0])) {
     secbool ret = flash_area_write_word(&STORAGE_AREAS[0], 16, 0x12345678);
     (void)ret;
   }
@@ -197,8 +197,7 @@ void mpu_config_off(void) {}
 
 __attribute__((noreturn)) void jump_to(void *addr) {
   bool storage_is_erased =
-      sector_is_empty(STORAGE_AREAS[0].subarea[0].first_sector) &&
-      sector_is_empty(STORAGE_AREAS[1].subarea[0].first_sector);
+      sector_is_empty(&STORAGE_AREAS[0]) && sector_is_empty(&STORAGE_AREAS[1]);
 
   if (storage_is_erased) {
     printf("STORAGE WAS ERASED\n");

--- a/core/embed/trezorhal/flash.h
+++ b/core/embed/trezorhal/flash.h
@@ -51,10 +51,6 @@
 
 void flash_init(void);
 
-secbool flash_write_byte(uint16_t sector, uint32_t offset, uint8_t data);
-
-secbool flash_write_word(uint16_t sector, uint32_t offset, uint32_t data);
-
 uint32_t flash_wait_and_clear_status_flags(void);
 
 // Erases the single sector in the designated flash area

--- a/legacy/flash.c
+++ b/legacy/flash.c
@@ -95,7 +95,7 @@ uint32_t flash_sector_size(uint16_t sector) {
   return FLASH_SECTOR_TABLE[sector + 1] - FLASH_SECTOR_TABLE[sector];
 }
 
-secbool flash_write_byte(uint8_t sector, uint32_t offset, uint8_t data) {
+secbool flash_write_byte(uint16_t sector, uint32_t offset, uint8_t data) {
   uint8_t *address = (uint8_t *)flash_get_address(sector, offset, 1);
   if (address == NULL) {
     return secfalse;
@@ -115,7 +115,7 @@ secbool flash_write_byte(uint8_t sector, uint32_t offset, uint8_t data) {
   return sectrue;
 }
 
-secbool flash_write_word(uint8_t sector, uint32_t offset, uint32_t data) {
+secbool flash_write_word(uint16_t sector, uint32_t offset, uint32_t data) {
   uint32_t *address = (uint32_t *)flash_get_address(sector, offset, 4);
   if (address == NULL) {
     return secfalse;

--- a/legacy/flash.h
+++ b/legacy/flash.h
@@ -39,7 +39,4 @@
   (FLASH_SR_RDERR | FLASH_SR_PGSERR | FLASH_SR_PGPERR | FLASH_SR_PGAERR | \
    FLASH_SR_WRPERR | FLASH_SR_SOP | FLASH_SR_EOP)
 
-secbool __wur flash_write_byte(uint8_t sector, uint32_t offset, uint8_t data);
-secbool __wur flash_write_word(uint8_t sector, uint32_t offset, uint32_t data);
-
 #endif  // FLASH_H

--- a/legacy/intermediate_fw/trezor.c
+++ b/legacy/intermediate_fw/trezor.c
@@ -35,6 +35,8 @@
 #include "timer.h"
 #include "util.h"
 
+const void *flash_get_address(uint16_t sector, uint32_t offset, uint32_t size);
+
 // legacy storage magic
 #define LEGACY_STORAGE_SECTOR 2
 static const uint32_t META_MAGIC_V10 = 0x525a5254;  // 'TRZR'

--- a/legacy/memory.c
+++ b/legacy/memory.c
@@ -28,6 +28,8 @@
 #define FLASH_OPTION_BYTES_1 (*(const uint64_t *)0x1FFFC000)
 #define FLASH_OPTION_BYTES_2 (*(const uint64_t *)0x1FFFC008)
 
+const void *flash_get_address(uint16_t sector, uint32_t offset, uint32_t size);
+
 void memory_protect(void) {
 #if PRODUCTION
 #if BOOTLOADER_QA

--- a/storage/flash_common.c
+++ b/storage/flash_common.c
@@ -1,5 +1,11 @@
 #include "flash.h"
 
+secbool flash_write_byte(uint16_t sector, uint32_t offset, uint8_t data);
+
+secbool flash_write_word(uint16_t sector, uint32_t offset, uint32_t data);
+
+const void *flash_get_address(uint16_t sector, uint32_t offset, uint32_t size);
+
 static uint32_t flash_subarea_get_size(const flash_subarea_t *subarea) {
   uint32_t size = 0;
   for (int s = 0; s < subarea->num_sectors; s++) {

--- a/storage/flash_common.h
+++ b/storage/flash_common.h
@@ -19,7 +19,6 @@ void flash_init(void);
 secbool __wur flash_unlock_write(void);
 secbool __wur flash_lock_write(void);
 
-const void *flash_get_address(uint16_t sector, uint32_t offset, uint32_t size);
 uint32_t flash_sector_size(uint16_t sector);
 uint16_t flash_total_sectors(const flash_area_t *area);
 int32_t flash_get_sector_num(const flash_area_t *area,


### PR DESCRIPTION
should only be using `flash_area_xx` functions now - at least in core

<!--
If you are a core dev:

Don't forget to set up the fields:
- assign yourself
- set priority to same as original issue
- add PR to sprint
- if Draft -> "in progress"
- if final PR -> "needs review"

If you're an external contributor, you can ignore this text.
-->
