### PR TITLE
CLI: force bitcoin only fw on bitcoin only units

### DIFF
--- a/python/src/trezorlib/cli/firmware.py
+++ b/python/src/trezorlib/cli/firmware.py
@@ -251,6 +251,9 @@ def find_best_firmware_version(
 
     f = client.features
 
+    if f.unit_btconly:
+        bitcoin_only = True
+
     releases = get_all_firmware_releases(bitcoin_only, beta, f.major_version)
     highest_version = releases[0]["version"]
 


### PR DESCRIPTION
installation of universal fw is still possible via custom url.

<!--
If you are a core dev:

Don't forget to set up the fields:
- assign yourself
- set priority to same as original issue
- add PR to sprint
- if Draft -> "in progress"
- if final PR -> "needs review"

If you're an external contributor, you can ignore this text.
-->
