### PR TITLE
add boundaries checks for icon rendering (framebuffer variant)

### DIFF
--- a/core/embed/rust/src/ui/model_tt/bootloader/mod.rs
+++ b/core/embed/rust/src/ui/model_tt/bootloader/mod.rs
@@ -80,6 +80,7 @@ where
     fadeout();
     display::sync();
     frame.paint();
+    display::refresh();
     fadein();
 
     loop {
@@ -264,6 +265,8 @@ fn screen_progress(
     if initialize {
         fadein();
     }
+
+    display::refresh();
 }
 
 #[no_mangle]
@@ -340,6 +343,7 @@ extern "C" fn screen_boot_empty(fading: bool) {
     } else {
         display::set_backlight(BACKLIGHT_NORMAL);
     }
+    display::refresh();
 }
 
 #[no_mangle]

--- a/core/embed/rust/src/ui/model_tt/layout.rs
+++ b/core/embed/rust/src/ui/model_tt/layout.rs
@@ -1588,6 +1588,7 @@ extern "C" fn draw_welcome_screen() -> Obj {
     screen.place(constant::screen());
     display::sync();
     screen.paint();
+    display::refresh();
     display::set_backlight(theme::BACKLIGHT_NORMAL);
     Obj::const_none()
 }


### PR DESCRIPTION
So that it correctly renders on the edge of display and such.

Also display_refresh calls are added in TT UI, as a preparations for models with displays that actually needs this. Shouldn't affect TT. 

<!--
If you are a core dev:

Don't forget to set up the fields:
- assign yourself
- set priority to same as original issue
- add PR to sprint
- if Draft -> "in progress"
- if final PR -> "needs review"

If you're an external contributor, you can ignore this text.
-->
