### PR TITLE
chore(ci): reflect the change of master to main

### DIFF
--- a/ci/build.yml
+++ b/ci/build.yml
@@ -352,7 +352,7 @@ core unix frozen debug build arm:
   <<: *gitlab_caching
   needs: []
   only:
-    - master
+    - main
     - tags
     - /^release\//
     - /^secfix\//
@@ -535,7 +535,7 @@ legacy emu regular debug build arm:
   <<: *gitlab_caching
   needs: []
   only:
-    - master
+    - main
     - tags
     - /^release\//
     - /^secfix\//

--- a/ci/check_changelog.sh
+++ b/ci/check_changelog.sh
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 
-base_branch=master
+base_branch=main
 fail=0
 subdirs="core core/embed/boardloader core/embed/bootloader core/embed/bootloader_ci legacy/bootloader legacy/firmware legacy/intermediate_fw python"
 

--- a/ci/check_release_commit_messages.sh
+++ b/ci/check_release_commit_messages.sh
@@ -2,21 +2,21 @@
 
 fail=0
 
-git fetch origin master
+git fetch origin main
 
-# list all commits between HEAD and master
-for commit in $(git rev-list origin/master..)
+# list all commits between HEAD and main
+for commit in $(git rev-list origin/main..)
 do
     message=$(git log -n1 --format=%B $commit)
     echo "Checking $commit"
 
     # The commit message must contain either
-    # 1. "cherry-picked from [some commit in master]"
+    # 1. "cherry-picked from [some commit in main]"
     if [[ $message =~ "(cherry picked from commit" ]]; then
       # remove last ")" and extract commit hash
-      master_commit=$(echo ${message:0:-1} | tr ' ' '\n' | tail -1)
-      # check if master really contains this commit hash
-      if [[ $(git branch -a --contains $master_commit | grep --only-matching "remotes/origin/master") == "remotes/origin/master" ]]; then
+      main_commit=$(echo ${message:0:-1} | tr ' ' '\n' | tail -1)
+      # check if main really contains this commit hash
+      if [[ $(git branch -a --contains $main_commit | grep --only-matching "remotes/origin/main") == "remotes/origin/main" ]]; then
         continue
       fi
     fi

--- a/ci/posttest.yml
+++ b/ci/posttest.yml
@@ -33,7 +33,7 @@ core unix coverage posttest:
 unix ui changes:
   stage: posttest
   except:
-    - master
+    - main
   <<: *gitlab_caching
   needs:
     - core click test

--- a/ci/prebuild.yml
+++ b/ci/prebuild.yml
@@ -47,7 +47,7 @@ release commit messages prebuild:
   stage: prebuild
   before_script: []  # nothing needed
   variables:
-    # We need to clone the repo properly so we can work with origin/master.
+    # We need to clone the repo properly so we can work with origin/main.
     GIT_STRATEGY: clone
   only:
     refs:
@@ -63,7 +63,7 @@ release commit messages prebuild:
 changelog prebuild:
   stage: prebuild
   except:
-    - master
+    - main
   before_script: []  # nothing needed
   variables:
     GIT_SUBMODULE_STRATEGY: "none"


### PR DESCRIPTION
Just noticed that the CI is running `changelog` check (and failing) even for `main` - and there were more "forgotten" `master` occurrences - replaced by `main`

Example pipeline:
https://gitlab.com/satoshilabs/trezor/trezor-firmware/-/pipelines/1040368818
