### PR TITLE
feat(core): make middle-click unlock the device for T2B1

### DIFF
--- a/core/embed/rust/src/ui/model_tr/component/homescreen.rs
+++ b/core/embed/rust/src/ui/model_tr/component/homescreen.rs
@@ -178,7 +178,9 @@ where
     T: StringType + Clone,
 {
     pub fn new(label: T, bootscreen: bool) -> Self {
-        let invisible_btn_layout = ButtonLayout::text_none_text("".into(), "".into());
+        // Buttons will not be visible, we only need all three of them to be present,
+        // so that even middle-click triggers the event.
+        let invisible_btn_layout = ButtonLayout::arrow_armed_arrow("".into());
         let instruction_str = if bootscreen {
             "Click to Connect"
         } else {


### PR DESCRIPTION
Fixes https://github.com/trezor/trezor-firmware/issues/3355:
- middle-click also unlocks the device from lock-screen (in addition to single left or right clicks)