### PR TITLE
Bootloader release 2.1.4

### DIFF
--- a/core/embed/bootloader/.changelog.d/2794.added
+++ b/core/embed/bootloader/.changelog.d/2794.added
@@ -1,1 +1,0 @@
-Minimize risk of losing seed when upgrading firmware

--- a/core/embed/bootloader/.changelog.d/2919.added
+++ b/core/embed/bootloader/.changelog.d/2919.added
@@ -1,1 +1,0 @@
-Support interaction-less upgrade

--- a/core/embed/bootloader/.changelog.d/3205.added
+++ b/core/embed/bootloader/.changelog.d/3205.added
@@ -1,1 +1,0 @@
-Added firmware update without interaction.

--- a/core/embed/bootloader/CHANGELOG.md
+++ b/core/embed/bootloader/CHANGELOG.md
@@ -4,6 +4,13 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
+## 2.1.4 [November 2023]
+
+### Added
+- Minimize risk of losing seed when upgrading firmware.  [#2794]
+- Support interaction-less upgrade.  [#2919]
+
+
 ## 2.1.3 [September 2023]
 
 ### Changed
@@ -98,8 +105,10 @@ Internal only release for Model R prototypes.
 [#2587]: https://github.com/trezor/trezor-firmware/pull/2587
 [#2595]: https://github.com/trezor/trezor-firmware/pull/2595
 [#2623]: https://github.com/trezor/trezor-firmware/pull/2623
+[#2794]: https://github.com/trezor/trezor-firmware/pull/2794
 [#2879]: https://github.com/trezor/trezor-firmware/pull/2879
 [#2896]: https://github.com/trezor/trezor-firmware/pull/2896
+[#2919]: https://github.com/trezor/trezor-firmware/pull/2919
 [#2941]: https://github.com/trezor/trezor-firmware/pull/2941
 [#2955]: https://github.com/trezor/trezor-firmware/pull/2955
 [#2989]: https://github.com/trezor/trezor-firmware/pull/2989

--- a/core/embed/bootloader/version.h
+++ b/core/embed/bootloader/version.h
@@ -1,6 +1,6 @@
 #define VERSION_MAJOR 2
 #define VERSION_MINOR 1
-#define VERSION_PATCH 4
+#define VERSION_PATCH 5
 #define VERSION_BUILD 0
 #define VERSION_UINT32                                            \
   (VERSION_MAJOR | (VERSION_MINOR << 8) | (VERSION_PATCH << 16) | \


### PR DESCRIPTION
Just generate a changelog and bump version. Commit 22e48717a67171b14de0bec0921cf9389bb3247f -- or what it ends up after merging -- will be tagged `core/bl2.1.4` for signing.