### PR TITLE
Fix CI bootloader build for T2B1

### DIFF
--- a/core/SConscript.bootloader_ci
+++ b/core/SConscript.bootloader_ci
@@ -18,7 +18,7 @@ if TREZOR_MODEL in ('1', 'DISC1'):
              )
     Return()
 
-FEATURES_WANTED = ["input", "usb"]
+FEATURES_WANTED = ["input", "rgb_led", "consumption_mask", "usb", "optiga"]
 
 CCFLAGS_MOD = ''
 CPPPATH_MOD = []
@@ -152,6 +152,7 @@ env.Replace(
         'vendor/nanopb',
     ] + CPPPATH_MOD + PATH_HAL,
     CPPDEFINES=[
+        'BOOTLOADER',
         'TREZOR_MODEL_'+TREZOR_MODEL,
         'USE_HAL_DRIVER',
         'PB_FIELD_16BIT',

--- a/core/embed/bootloader_ci/messages.c
+++ b/core/embed/bootloader_ci/messages.c
@@ -501,7 +501,7 @@ int process_msg_FirmwareUpload(uint8_t iface_num, uint32_t msg_size,
           read_image_header(chunk_buffer + vhdr.hdrlen, FIRMWARE_IMAGE_MAGIC,
                             FIRMWARE_IMAGE_MAXSIZE);
 
-      if (received_hdr != (const image_header *)chunk_buffer + vhdr.hdrlen) {
+      if (received_hdr != (const image_header *)(chunk_buffer + vhdr.hdrlen)) {
         MSG_SEND_INIT(Failure);
         MSG_SEND_ASSIGN_VALUE(code, FailureType_Failure_ProcessError);
         MSG_SEND_ASSIGN_STRING(message, "Invalid firmware header");


### PR DESCRIPTION
It builds now but I'm not able to test it. I'd be very grateful if somebody with a devkit can confirm that it always waits for firmware update after reboot and installs it without any user interaction.


<!--
If you are a core dev:

Don't forget to set up the fields:
- assign yourself
- set priority to same as original issue
- add PR to sprint
- if Draft -> "in progress"
- if final PR -> "needs review"

If you're an external contributor, you can ignore this text.
-->
