### PR TITLE
Add build flag for disabling Optiga

### DIFF
--- a/core/Makefile
+++ b/core/Makefile
@@ -201,7 +201,9 @@ build_firmware: templates build_cross ## build firmware with frozen modules
 	$(SCONS) CFLAGS="$(CFLAGS)" PRODUCTION="$(PRODUCTION)" \
 		TREZOR_MODEL="$(TREZOR_MODEL)" CMAKELISTS="$(CMAKELISTS)" \
 		PYOPT="$(PYOPT)" BITCOIN_ONLY="$(BITCOIN_ONLY)" \
-		BOOTLOADER_QA="$(BOOTLOADER_QA)" BOOTLOADER_DEVEL="$(BOOTLOADER_DEVEL)" $(FIRMWARE_BUILD_DIR)/firmware.bin
+		BOOTLOADER_QA="$(BOOTLOADER_QA)" BOOTLOADER_DEVEL="$(BOOTLOADER_DEVEL)" \
+		DISABLE_OPTIGA="$(DISABLE_OPTIGA)" \
+		$(FIRMWARE_BUILD_DIR)/firmware.bin
 
 build_unix: templates ## build unix port
 	$(SCONS) CFLAGS="$(CFLAGS)" $(UNIX_BUILD_DIR)/trezor-emu-core $(UNIX_PORT_OPTS) \

--- a/core/SConscript.firmware
+++ b/core/SConscript.firmware
@@ -11,6 +11,8 @@ BOOTLOADER_DEVEL = ARGUMENTS.get('BOOTLOADER_DEVEL', '0') == '1'
 EVERYTHING = BITCOIN_ONLY != '1'
 TREZOR_MODEL = ARGUMENTS.get('TREZOR_MODEL', 'T')
 CMAKELISTS = int(ARGUMENTS.get('CMAKELISTS', 0))
+PYOPT = ARGUMENTS.get('PYOPT', '1')
+DISABLE_OPTIGA = ARGUMENTS.get('DISABLE_OPTIGA', '0') == '1'
 
 
 FEATURE_FLAGS = {
@@ -20,6 +22,8 @@ FEATURE_FLAGS = {
 }
 
 FEATURES_WANTED = ["input", "sbu", "sd_card", "rgb_led", "dma2d", "consumption_mask", "usb" ,"optiga"]
+if DISABLE_OPTIGA and PYOPT == '0':
+    FEATURES_WANTED.remove("optiga")
 
 CCFLAGS_MOD = ''
 CPPPATH_MOD = []
@@ -29,7 +33,6 @@ CPPDEFINES_HAL = []
 SOURCE_HAL = []
 PATH_HAL = []
 
-PYOPT = ARGUMENTS.get('PYOPT', '1')
 FROZEN = True
 
 if TREZOR_MODEL in ('1', 'R'):

--- a/core/embed/trezorhal/boards/trezor_r_v10.h
+++ b/core/embed/trezorhal/boards/trezor_r_v10.h
@@ -5,7 +5,6 @@
 #define USE_SBU 1
 #define USE_I2C 1
 #define USE_CONSUMPTION_MASK 1
-#define USE_OPTIGA 1
 
 #include "displays/vg-2864ksweg01.h"
 

--- a/core/site_scons/boards/trezor_r_v10.py
+++ b/core/site_scons/boards/trezor_r_v10.py
@@ -33,7 +33,6 @@ def configure(
     defines += [f'TREZOR_BOARD=\\"boards/{board}\\"']
     defines += [f"HW_MODEL={hw_model}"]
     defines += [f"HW_REVISION={hw_revision}"]
-    defines += ["USE_OPTIGA=1"]
     sources += [
         "embed/models/model_T2B1_layout.c",
     ]
@@ -66,6 +65,7 @@ def configure(
         features_available.append("usb")
 
     if "optiga" in features_wanted:
+        defines += ["USE_OPTIGA=1"]
         sources += ["embed/trezorhal/stm32f4/optiga_hal.c"]
         sources += ["embed/trezorhal/optiga/optiga.c"]
         sources += ["embed/trezorhal/optiga/optiga_commands.c"]


### PR DESCRIPTION
This is needed for hardware tests in CI until we figure out some way how not to trip up the security monitor by running testsuite. Only works with `PYOPT=0`.

<!--
If you are a core dev:

Don't forget to set up the fields:
- assign yourself
- set priority to same as original issue
- add PR to sprint
- if Draft -> "in progress"
- if final PR -> "needs review"

If you're an external contributor, you can ignore this text.
-->
