### PR TITLE
bld upgrade on U5

### DIFF
--- a/core/embed/bootloader/messages.c
+++ b/core/embed/bootloader/messages.c
@@ -754,8 +754,8 @@ int process_msg_FirmwareUpload(uint8_t iface_num, uint32_t msg_size,
       // write a burst (8 * quadword (16 bytes)) to the flash
       ensure(flash_area_write_burst(&FIRMWARE_AREA, write_offset, quadword_ptr),
              NULL);
-      write_offset += 8 * 4 * sizeof(uint32_t);
-      quadword_ptr += 8 * 4;
+      write_offset += FLASH_BURST_LENGTH * sizeof(uint32_t);
+      quadword_ptr += FLASH_BURST_LENGTH;
     }
     ensure(flash_lock_write(), NULL);
 

--- a/core/embed/firmware/main.c
+++ b/core/embed/firmware/main.c
@@ -120,6 +120,10 @@ int main(void) {
 
   display_reinit();
 
+#ifdef USE_DMA2D
+  dma2d_init();
+#endif
+
 #if !defined TREZOR_MODEL_1
   parse_boardloader_capabilities();
 
@@ -130,6 +134,8 @@ int main(void) {
   secbool secret_ok = secret_optiga_extract(secret);
 #endif
 
+  mpu_config_firmware_initial();
+
 #if PRODUCTION || BOOTLOADER_QA
   check_and_replace_bootloader();
 #endif
@@ -139,10 +145,6 @@ int main(void) {
 
   // Init peripherals
   pendsv_init();
-
-#ifdef USE_DMA2D
-  dma2d_init();
-#endif
 
   fault_handlers_init();
 

--- a/core/embed/trezorhal/flash.h
+++ b/core/embed/trezorhal/flash.h
@@ -28,6 +28,8 @@
 
 #include "flash_ll.h"
 
+#define FLASH_BURST_LENGTH (4 * 8)
+
 void flash_init(void);
 
 #endif  // TREZORHAL_FLASH_H

--- a/core/embed/trezorhal/mpu.h
+++ b/core/embed/trezorhal/mpu.h
@@ -23,6 +23,7 @@
 void mpu_config_off(void);
 void mpu_config_boardloader(void);
 void mpu_config_bootloader(void);
+void mpu_config_firmware_initial(void);
 void mpu_config_firmware(void);
 void mpu_config_prodtest(void);
 

--- a/core/embed/trezorhal/stm32f4/mpu.c
+++ b/core/embed/trezorhal/stm32f4/mpu.c
@@ -104,6 +104,8 @@ void mpu_config_bootloader(void) {
   HAL_MPU_Enable(LL_MPU_CTRL_HARDFAULT_NMI);
 }
 
+void mpu_config_firmware_initial(void) {}
+
 void mpu_config_firmware(void) {
   // Disable MPU
   HAL_MPU_Disable();

--- a/core/embed/trezorhal/stm32u5/mpu.c
+++ b/core/embed/trezorhal/stm32u5/mpu.c
@@ -139,6 +139,8 @@ static void mpu_set_attributes() {
   (FLASH_SIZE - (FIRMWARE_START + BOOTLOADER_SIZE + BOARDLOADER_SIZE + \
                  SECRET_SIZE + STORAGE_SIZE))
 
+#define L3_PREV_SIZE_BLD (STORAGE_SIZE + BOOTLOADER_SIZE)
+
 #ifdef STM32U585xx
 #define GRAPHICS_START FMC_BANK1
 #define GRAPHICS_SIZE SIZE_16M
@@ -177,6 +179,23 @@ void mpu_config_bootloader() {
   SET_REGION( 5, PERIPH_BASE_NS,           SIZE_512M,          PERIPHERAL,  YES,    NO ); // Peripherals
   SET_REGION( 6, FLASH_OTP_BASE,           FLASH_OTP_SIZE,     FLASH_DATA,  YES,    NO ); // OTP
   SET_REGION( 7, SRAM4_BASE,               SIZE_16K,           SRAM,        YES,    NO ); // SRAM4
+  // clang-format on
+  HAL_MPU_Enable(LL_MPU_CTRL_HARDFAULT_NMI);
+}
+
+void mpu_config_firmware_initial() {
+  HAL_MPU_Disable();
+  mpu_set_attributes();
+  // clang-format off
+  //   REGION    ADDRESS                   SIZE                TYPE       WRITE   UNPRIV
+  SET_REGION( 0, BOOTLOADER_START,         L3_PREV_SIZE_BLD,   FLASH_DATA,  YES,   YES ); // Bootloader + Storage
+  SET_REGION( 1, FIRMWARE_START,           FIRMWARE_SIZE,      FLASH_CODE,   NO,   YES ); // Firmware
+  SET_REGION( 2, L3_REST_START,            L3_REST_SIZE,       FLASH_DATA,  YES,   YES ); // Reserve
+  SET_REGION( 3, SRAM1_BASE,               SRAM_SIZE,          SRAM,        YES,   YES ); // SRAM1/2/3/5
+  SET_REGION( 4, GRAPHICS_START,           GRAPHICS_SIZE,      SRAM,        YES,   YES ); // Frame buffer or display interface
+  SET_REGION( 5, PERIPH_BASE_NS,           SIZE_512M,          PERIPHERAL,  YES,   YES ); // Peripherals
+  SET_REGION( 6, FLASH_OTP_BASE,           FLASH_OTP_SIZE,     FLASH_DATA,  YES,   YES ); // OTP
+  DIS_REGION( 7 );
   // clang-format on
   HAL_MPU_Enable(LL_MPU_CTRL_HARDFAULT_NMI);
 }


### PR DESCRIPTION
Adjusts bootloader upgrade mechanism to use bursts to ensure compatibility with U5.


<!--
If you are a core dev:

Don't forget to set up the fields:
- assign yourself
- set priority to same as original issue
- add PR to sprint
- if Draft -> "in progress"
- if final PR -> "needs review"

If you're an external contributor, you can ignore this text.
-->
