### PR TITLE
fix(rust/trezor-client): update `sign_message` example

### DIFF
--- a/rust/trezor-client/examples/sign_message.rs
+++ b/rust/trezor-client/examples/sign_message.rs
@@ -1,32 +1,7 @@
-use std::io;
+use std::str::FromStr;
 
-use bitcoin::{bip32, network::Network, Address};
-use trezor_client::{InputScriptType, TrezorMessage, TrezorResponse};
-
-fn handle_interaction<T, R: TrezorMessage>(resp: TrezorResponse<T, R>) -> T {
-    match resp {
-        TrezorResponse::Ok(res) => res,
-        // assering ok() returns the failure error
-        TrezorResponse::Failure(_) => resp.ok().unwrap(),
-        TrezorResponse::ButtonRequest(req) => handle_interaction(req.ack().unwrap()),
-        TrezorResponse::PinMatrixRequest(req) => {
-            println!("Enter PIN");
-            let mut pin = String::new();
-            if io::stdin().read_line(&mut pin).unwrap() != 5 {
-                println!("must enter pin, received: {}", pin);
-            }
-            // trim newline
-            handle_interaction(req.ack_pin(pin[..4].to_owned()).unwrap())
-        }
-        TrezorResponse::PassphraseRequest(req) => {
-            println!("Enter passphrase");
-            let mut pass = String::new();
-            io::stdin().read_line(&mut pass).unwrap();
-            // trim newline
-            handle_interaction(req.ack_passphrase(pass[..pass.len() - 1].to_owned()).unwrap())
-        }
-    }
-}
+use bitcoin::{bip32::DerivationPath, network::Network, Address};
+use trezor_client::{client::common::handle_interaction, InputScriptType};
 
 fn main() {
     tracing_subscriber::fmt().with_max_level(tracing::Level::TRACE).init();
@@ -38,18 +13,14 @@ fn main() {
     let pubkey = handle_interaction(
         trezor
             .get_public_key(
-                &vec![
-                    bip32::ChildNumber::from_hardened_idx(0).unwrap(),
-                    bip32::ChildNumber::from_hardened_idx(0).unwrap(),
-                    bip32::ChildNumber::from_hardened_idx(1).unwrap(),
-                ]
-                .into(),
+                &DerivationPath::from_str("m/44h/1h/0h/0/0").unwrap(),
                 trezor_client::protos::InputScriptType::SPENDADDRESS,
                 Network::Testnet,
                 true,
             )
             .unwrap(),
-    );
+    )
+    .unwrap();
     let addr = Address::p2pkh(&pubkey.to_pub(), Network::Testnet);
     println!("address: {}", addr);
 
@@ -57,17 +28,13 @@ fn main() {
         trezor
             .sign_message(
                 "regel het".to_owned(),
-                &vec![
-                    bip32::ChildNumber::from_hardened_idx(0).unwrap(),
-                    bip32::ChildNumber::from_hardened_idx(0).unwrap(),
-                    bip32::ChildNumber::from_hardened_idx(1).unwrap(),
-                ]
-                .into(),
+                &DerivationPath::from_str("m/44h/1h/0h/0/0").unwrap(),
                 InputScriptType::SPENDADDRESS,
                 Network::Testnet,
             )
             .unwrap(),
-    );
+    )
+    .unwrap();
     println!("Addr from device: {}", addr);
     println!("Signature: {:?}", signature);
 }


### PR DESCRIPTION
The existing code fails (tested on Model T 2.6.0):

```
2023-11-25T15:52:06.035004Z TRACE trezor_client::client: Sending MessageType_SignMessage msg: SignMessage { address_n: [2147483648, 2147483648, 2147483649], message: Some([114, 101, 103, 101, 108, 32, 104, 101, 116]), coin_name: Some("Testnet"), script_type: Some(SPENDADDRESS), no_script_type: None, chunkify: None, special_fields: SpecialFields { unknown_fields: UnknownFields { fields: None }, cached_size: CachedSize { size: 0 } } }
2023-11-25T15:52:06.413333Z DEBUG trezor_client::client: Received failure: Failure { code: Some(Failure_DataError), message: Some("Forbidden key path"), special_fields: SpecialFields { unknown_fields: UnknownFields { fields: None }, cached_size: CachedSize { size: 0 } } }
thread 'main' panicked at examples/sign_message.rs:10:49:
called `Result::unwrap()` on an `Err` value: FailureResponse(Failure { code: Some(Failure_DataError), message: Some("Forbidden key path"), special_fields: SpecialFields { unknown_fields: UnknownFields { fields: None }, cached_size: CachedSize { size: 0 } } })
```

Also, use `handle_interaction` from `trezor_client::client::common` to simplify the example.
