### PR TITLE
fix(core): restore filled-lock display time

### DIFF
--- a/core/embed/firmware/main.c
+++ b/core/embed/firmware/main.c
@@ -47,6 +47,7 @@
 #include "model.h"
 #include "mpu.h"
 #include "random_delays.h"
+#include "rust_ui.h"
 
 #include TREZOR_BOARD
 
@@ -110,6 +111,8 @@ int main(void) {
 #endif
 
   display_reinit();
+
+  screen_boot_full();
 
 #if !defined TREZOR_MODEL_1
   parse_boardloader_capabilities();

--- a/core/embed/rust/librust_qstr.h
+++ b/core/embed/rust/librust_qstr.h
@@ -67,7 +67,6 @@ static void _librust_qstrs(void) {
   MP_QSTR_description;
   MP_QSTR_details_title;
   MP_QSTR_disable_animation;
-  MP_QSTR_draw_welcome_screen;
   MP_QSTR_dry_run;
   MP_QSTR_encode;
   MP_QSTR_encoded_length;

--- a/core/embed/rust/rust_ui.h
+++ b/core/embed/rust/rust_ui.h
@@ -23,9 +23,9 @@ void screen_wipe_fail(void);
 uint32_t screen_install_success(uint8_t restart_seconds, bool initial_setup,
                                 bool complete_draw);
 uint32_t screen_install_fail(void);
-void screen_welcome_model(void);
 void screen_welcome(void);
 void screen_boot_empty(bool fading);
+void screen_boot_full(void);
 uint32_t screen_unlock_bootloader_confirm(void);
 void screen_unlock_bootloader_success(void);
 void display_image(int16_t x, int16_t y, const uint8_t* data, uint32_t datalen);

--- a/core/embed/rust/src/ui/model_tr/bootloader/mod.rs
+++ b/core/embed/rust/src/ui/model_tr/bootloader/mod.rs
@@ -378,12 +378,6 @@ extern "C" fn screen_welcome() {
 }
 
 #[no_mangle]
-extern "C" fn screen_welcome_model() {
-    let mut frame = WelcomeScreen::new(false);
-    show(&mut frame);
-}
-
-#[no_mangle]
 extern "C" fn bld_continue_label(bg_color: cty::uint16_t) {
     display::text_center(
         Point::new(constant::WIDTH / 2, HEIGHT - 2),

--- a/core/embed/rust/src/ui/model_tr/layout.rs
+++ b/core/embed/rust/src/ui/model_tr/layout.rs
@@ -1612,15 +1612,6 @@ extern "C" fn new_show_lockscreen(n_args: usize, args: *const Obj, kwargs: *mut 
     unsafe { util::try_with_args_and_kwargs(n_args, args, kwargs, block) }
 }
 
-extern "C" fn draw_welcome_screen() -> Obj {
-    // No need of util::try_or_raise, this does not allocate
-    let mut screen = WelcomeScreen::new(false);
-    screen.place(constant::screen());
-    display::sync();
-    screen.paint();
-    Obj::const_none()
-}
-
 extern "C" fn new_confirm_firmware_update(
     n_args: usize,
     args: *const Obj,
@@ -2068,10 +2059,6 @@ pub static mp_module_trezorui2: Module = obj_module! {
     /// ) -> CANCELLED:
     ///     """Homescreen for locked device."""
     Qstr::MP_QSTR_show_lockscreen => obj_fn_kw!(0, new_show_lockscreen).as_obj(),
-
-    /// def draw_welcome_screen() -> None:
-    ///     """Show logo icon with the model name at the bottom and return."""
-    Qstr::MP_QSTR_draw_welcome_screen => obj_fn_0!(draw_welcome_screen).as_obj(),
 
     /// def confirm_firmware_update(
     ///     *,

--- a/core/embed/rust/src/ui/model_tr/screens.rs
+++ b/core/embed/rust/src/ui/model_tr/screens.rs
@@ -1,6 +1,8 @@
 #[cfg(feature = "micropython")]
 use crate::micropython::buffer::StrBuffer;
-use crate::ui::component::base::Component;
+use crate::ui::{
+    component::base::Component, constant::screen, display, model_tr::component::WelcomeScreen,
+};
 
 use super::{component::ErrorScreen, constant};
 
@@ -26,4 +28,13 @@ pub fn screen_fatal_error(title: &str, msg: &str, footer: &str) {
     let mut frame = ErrorScreen::new(title, msg, footer);
     frame.place(constant::screen());
     frame.paint();
+}
+
+#[no_mangle]
+extern "C" fn screen_boot_full() {
+    let mut frame = WelcomeScreen::new(false);
+    frame.place(screen());
+    display::sync();
+    frame.paint();
+    display::refresh();
 }

--- a/core/embed/rust/src/ui/model_tt/bootloader/mod.rs
+++ b/core/embed/rust/src/ui/model_tt/bootloader/mod.rs
@@ -406,12 +406,6 @@ extern "C" fn screen_install_success(
 }
 
 #[no_mangle]
-extern "C" fn screen_welcome_model() {
-    let mut frame = WelcomeScreen::new(false);
-    show(&mut frame, false);
-}
-
-#[no_mangle]
 extern "C" fn screen_welcome() {
     let mut frame = Welcome::new();
     show(&mut frame, true);

--- a/core/embed/rust/src/ui/model_tt/layout.rs
+++ b/core/embed/rust/src/ui/model_tt/layout.rs
@@ -1579,17 +1579,6 @@ extern "C" fn new_show_lockscreen(n_args: usize, args: *const Obj, kwargs: *mut 
     unsafe { util::try_with_args_and_kwargs(n_args, args, kwargs, block) }
 }
 
-extern "C" fn draw_welcome_screen() -> Obj {
-    // No need of util::try_or_raise, this does not allocate
-    let mut screen = WelcomeScreen::new(false);
-    screen.place(constant::screen());
-    display::sync();
-    screen.paint();
-    display::refresh();
-    display::set_backlight(theme::BACKLIGHT_NORMAL);
-    Obj::const_none()
-}
-
 pub extern "C" fn upy_check_homescreen_format(data: Obj) -> Obj {
     let block = || {
         let buffer = unsafe { get_buffer(data) }?;
@@ -2042,10 +2031,6 @@ pub static mp_module_trezorui2: Module = obj_module! {
     /// ) -> CANCELLED:
     ///     """Homescreen for locked device."""
     Qstr::MP_QSTR_show_lockscreen => obj_fn_kw!(0, new_show_lockscreen).as_obj(),
-
-    /// def draw_welcome_screen() -> None:
-    ///     """Show logo icon with the model name at the bottom and return."""
-    Qstr::MP_QSTR_draw_welcome_screen => obj_fn_0!(draw_welcome_screen).as_obj(),
 
     /// def confirm_firmware_update(
     ///     *,

--- a/core/embed/rust/src/ui/model_tt/screens.rs
+++ b/core/embed/rust/src/ui/model_tt/screens.rs
@@ -2,7 +2,12 @@
 use crate::micropython::buffer::StrBuffer;
 use crate::ui::{
     component::Component,
-    model_tt::{component::ErrorScreen, constant},
+    constant::screen,
+    display,
+    model_tt::{
+        component::{ErrorScreen, WelcomeScreen},
+        constant,
+    },
 };
 
 #[cfg(not(feature = "micropython"))]
@@ -27,4 +32,13 @@ pub fn screen_fatal_error(title: &str, msg: &str, footer: &str) {
     let mut frame = ErrorScreen::new(title, msg, footer);
     frame.place(constant::screen());
     frame.paint();
+}
+
+#[no_mangle]
+extern "C" fn screen_boot_full() {
+    let mut frame = WelcomeScreen::new(false);
+    frame.place(screen());
+    display::sync();
+    frame.paint();
+    display::refresh();
 }

--- a/core/mocks/generated/trezorui2.pyi
+++ b/core/mocks/generated/trezorui2.pyi
@@ -440,11 +440,6 @@ def show_lockscreen(
 
 
 # rust/src/ui/model_tr/layout.rs
-def draw_welcome_screen() -> None:
-    """Show logo icon with the model name at the bottom and return."""
-
-
-# rust/src/ui/model_tr/layout.rs
 def confirm_firmware_update(
     *,
     description: str,
@@ -894,11 +889,6 @@ def show_lockscreen(
     coinjoin_authorized: bool = False,
 ) -> CANCELLED:
     """Homescreen for locked device."""
-
-
-# rust/src/ui/model_tt/layout.rs
-def draw_welcome_screen() -> None:
-    """Show logo icon with the model name at the bottom and return."""
 
 
 # rust/src/ui/model_tt/layout.rs

--- a/core/src/boot.py
+++ b/core/src/boot.py
@@ -1,12 +1,11 @@
 # isort:skip_file
 
-import trezorui2
 import utime
 
-# Showing welcome screen as soon as possible
+# Welcome screen is shown immediately after display init.
+# Then it takes about 120ms to get here.
 # (display is also prepared on that occasion).
 # Remembering time to control how long we show it.
-trezorui2.draw_welcome_screen()
 welcome_screen_start_ms = utime.ticks_ms()
 
 import storage
@@ -21,7 +20,7 @@ from trezor.ui.layouts.homescreen import Lockscreen
 
 from apps.common.request_pin import can_lock_device, verify_user_pin
 
-_WELCOME_SCREEN_MS = 1200  # how long do we want to show welcome screen (minimum)
+_WELCOME_SCREEN_MS = 1000  # how long do we want to show welcome screen (minimum)
 
 
 def enforce_welcome_screen_duration() -> None:


### PR DESCRIPTION
in #3222 the `_WELCOME_SCREEN_MS` code got lost, which means that in 2.6.3 the user is staring at the empty lock for several seconds and on the filled lock for only a fraction of a second. which looks a bit like a bug.

i believe the removal is a result of a bad rebase rather than intention, right @TychoVrahe ?