### PR TITLE
ci: fix changelog check for github

### DIFF
--- a/.github/workflows/prebuild.yml
+++ b/.github/workflows/prebuild.yml
@@ -59,7 +59,8 @@ jobs:
     steps:
       - uses: actions/checkout@v4
         with:
-          submodules: "recursive"
+          fetch-depth: 0
+          ref: ${{ github.event.pull_request.head.sha }}
       - name: "Run changelog check"
         run: ./ci/check_changelog.sh
 

--- a/ci/check_changelog.sh
+++ b/ci/check_changelog.sh
@@ -1,5 +1,7 @@
 #!/usr/bin/env bash
 
+set -u
+
 base_branch=main
 fail=0
 subdirs="core core/embed/boardloader core/embed/bootloader core/embed/bootloader_ci legacy/bootloader legacy/firmware legacy/intermediate_fw python"
@@ -51,7 +53,11 @@ check_release_branch () {
     fi
 }
 
+# gitlab
 if echo "$CI_COMMIT_BRANCH" | grep -Eq "^(release|secfix)/"; then
+    check_release_branch
+# github, TODO this only makes sense running on branches but not pull requests
+elif $(git branch --show-current) | grep -Eq "^(release|secfix)/"; then
     check_release_branch
 else
     check_feature_branch

--- a/ci/shell.nix
+++ b/ci/shell.nix
@@ -139,6 +139,7 @@ stdenvNoCC.mkDerivation ({
     ffmpeg
     dejavu_fonts
   ] ++ lib.optionals devTools [
+    shellcheck
     gdb
     openocd-stm
   ] ++ lib.optionals (devTools && acceptJlink) [


### PR DESCRIPTION
Changelog check was broken because:
* actions triggered on pull requests run on merge commit of base branch + PR branch by default (on gitlab they run on PR branch),
* we were cloning shallow git repo without history

<!--
If you are a core dev:

Don't forget to set up the fields:
- assign yourself
- set priority to same as original issue
- add PR to sprint
- if Draft -> "in progress"
- if final PR -> "needs review"

If you're an external contributor, you can ignore this text.
-->
