### PR TITLE
chore(core): change `Go to bootloader` screen text

### DIFF
--- a/core/src/apps/management/reboot_to_bootloader.py
+++ b/core/src/apps/management/reboot_to_bootloader.py
@@ -59,7 +59,7 @@ async def reboot_to_bootloader(msg: RebootToBootloader) -> NoReturn:
         await confirm_action(
             "reboot",
             "Go to bootloader",
-            "Do you want to restart Trezor in bootloader mode?",
+            "Trezor will restart in bootloader mode.",
             verb="Restart",
         )
         boot_command = BootCommand.STOP_AND_WAIT


### PR DESCRIPTION
Fixes https://github.com/trezor/trezor-firmware/issues/3416:
- change the text before going to bootloader