### PR TITLE
fix delay on startup when other than north orientation of the screen is set

### DIFF
--- a/core/.changelog.d/3244.fixed
+++ b/core/.changelog.d/3244.fixed
@@ -1,0 +1,1 @@
+[T2T1] Fixed blank display delay on startup when display orientation is set to other than north

--- a/core/src/apps/base.py
+++ b/core/src/apps/base.py
@@ -412,7 +412,9 @@ def reload_settings_from_storage() -> None:
         storage_device.get_autolock_delay_ms(), lock_device_if_unlocked
     )
     wire.EXPERIMENTAL_ENABLED = storage_device.get_experimental_features()
-    ui.display.orientation(storage_device.get_rotation())
+    if ui.display.orientation() != storage_device.get_rotation():
+        ui.backlight_fade(ui.style.BACKLIGHT_DIM)
+        ui.display.orientation(storage_device.get_rotation())
 
 
 def boot() -> None:

--- a/core/src/boot.py
+++ b/core/src/boot.py
@@ -42,17 +42,30 @@ async def bootscreen() -> None:
     Allowing all of them before returning.
     """
     lockscreen = Lockscreen(label=storage.device.get_label(), bootscreen=True)
-    ui.display.orientation(storage.device.get_rotation())
     while True:
         try:
+
             if can_lock_device():
                 enforce_welcome_screen_duration()
+                ui.backlight_fade(ui.style.BACKLIGHT_DIM)
+                ui.display.orientation(storage.device.get_rotation())
                 await lockscreen
-            await verify_user_pin()
-            storage.init_unlocked()
-            enforce_welcome_screen_duration()
-            allow_all_loader_messages()
-            return
+                await verify_user_pin()
+                storage.init_unlocked()
+                allow_all_loader_messages()
+                return
+            else:
+                await verify_user_pin()
+                storage.init_unlocked()
+                enforce_welcome_screen_duration()
+                rotation = storage.device.get_rotation()
+                if rotation != ui.display.orientation():
+                    # there is a slight delay before next screen is shown,
+                    # so we don't fade unless there is a change of orientation
+                    ui.backlight_fade(ui.style.BACKLIGHT_DIM)
+                    ui.display.orientation(rotation)
+                allow_all_loader_messages()
+                return
         except wire.PinCancelled:
             # verify_user_pin will convert a SdCardUnavailable (in case of sd salt)
             # to PinCancelled exception.


### PR DESCRIPTION
fixes https://github.com/trezor/trezor-firmware/issues/3244

also fixes a fading glitch when changing the device orientation (display was cleared before the fade-out)

<!--
If you are a core dev:

Don't forget to set up the fields:
- assign yourself
- set priority to same as original issue
- add PR to sprint
- if Draft -> "in progress"
- if final PR -> "needs review"

If you're an external contributor, you can ignore this text.
-->
