### PR TITLE
POC: add user adjustable brightness setting

### DIFF
--- a/common/protob/messages-management.proto
+++ b/common/protob/messages-management.proto
@@ -178,6 +178,7 @@ message ApplySettings {
     optional SafetyCheckLevel safety_checks = 9;  // Safety check level, set to Prompt to limit path namespace enforcement
     optional bool experimental_features = 10;  // enable experimental message types
     optional bool hide_passphrase_from_host = 11;  // do not show passphrase coming from host
+    optional uint32 brightness = 12;  // display brightness, 0 = select on device
 }
 
 /**

--- a/core/.changelog.d/3208.added
+++ b/core/.changelog.d/3208.added
@@ -1,0 +1,1 @@
+[T2T1] Added user adjustable brightness setting.

--- a/core/embed/firmware/main.c
+++ b/core/embed/firmware/main.c
@@ -110,6 +110,10 @@ int main(void) {
   enable_systemview();
 #endif
 
+#if defined TREZOR_MODEL_T
+  set_core_clock(CLOCK_180_MHZ);
+#endif
+
   display_reinit();
 
   screen_boot_full();
@@ -142,10 +146,6 @@ int main(void) {
 #if !PRODUCTION
   // enable BUS fault and USAGE fault handlers
   SCB->SHCSR |= (SCB_SHCSR_USGFAULTENA_Msk | SCB_SHCSR_BUSFAULTENA_Msk);
-#endif
-
-#if defined TREZOR_MODEL_T
-  set_core_clock(CLOCK_180_MHZ);
 #endif
 
 #ifdef USE_BUTTON

--- a/core/embed/rust/librust_qstr.h
+++ b/core/embed/rust/librust_qstr.h
@@ -36,6 +36,7 @@ static void _librust_qstrs(void) {
   MP_QSTR_bounds;
   MP_QSTR_button;
   MP_QSTR_button_event;
+  MP_QSTR_callback;
   MP_QSTR_cancel_arrow;
   MP_QSTR_cancel_cross;
   MP_QSTR_case_sensitive;
@@ -108,6 +109,7 @@ static void _librust_qstrs(void) {
   MP_QSTR_request_bip39;
   MP_QSTR_request_complete_repaint;
   MP_QSTR_request_number;
+  MP_QSTR_request_number_slider;
   MP_QSTR_request_passphrase;
   MP_QSTR_request_pin;
   MP_QSTR_request_slip39;

--- a/core/embed/rust/src/ui/model_tt/component/mod.rs
+++ b/core/embed/rust/src/ui/model_tt/component/mod.rs
@@ -13,6 +13,7 @@ mod homescreen;
 mod keyboard;
 mod loader;
 mod number_input;
+mod number_input_slider;
 mod page;
 mod progress;
 mod result;
@@ -43,6 +44,7 @@ pub use keyboard::{
 };
 pub use loader::{Loader, LoaderMsg, LoaderStyle, LoaderStyleSheet};
 pub use number_input::{NumberInputDialog, NumberInputDialogMsg};
+pub use number_input_slider::{NumberInputSliderDialog, NumberInputSliderDialogMsg};
 pub use page::ButtonPage;
 pub use progress::Progress;
 pub use result::{ResultFooter, ResultScreen, ResultStyle};

--- a/core/embed/rust/src/ui/model_tt/component/number_input_slider.rs
+++ b/core/embed/rust/src/ui/model_tt/component/number_input_slider.rs
@@ -1,0 +1,209 @@
+use crate::ui::{
+    component::{base::ComponentExt, Child, Component, Event, EventCtx},
+    constant::screen,
+    display,
+    event::TouchEvent,
+    geometry::{Grid, Insets, Point, Rect},
+};
+
+use super::{theme, Button, ButtonMsg};
+
+pub enum NumberInputSliderDialogMsg {
+    Confirmed,
+    Cancelled,
+}
+
+pub struct NumberInputSliderDialog<F>
+where
+    F: Fn(u32),
+{
+    area: Rect,
+    callback: F,
+    input: Child<NumberInputSlider>,
+    cancel_button: Child<Button<&'static str>>,
+    confirm_button: Child<Button<&'static str>>,
+}
+
+impl<F> NumberInputSliderDialog<F>
+where
+    F: Fn(u32),
+{
+    pub fn new(min: u32, max: u32, init_value: u32, callback: F) -> Self {
+        Self {
+            area: Rect::zero(),
+            callback,
+            input: NumberInputSlider::new(min, max, init_value).into_child(),
+            cancel_button: Button::with_text("CANCEL")
+                .styled(theme::button_cancel())
+                .into_child(),
+            confirm_button: Button::with_text("CONFIRM")
+                .styled(theme::button_confirm())
+                .into_child(),
+        }
+    }
+
+    pub fn value(&self) -> u32 {
+        self.input.inner().value
+    }
+}
+
+impl<F> Component for NumberInputSliderDialog<F>
+where
+    F: Fn(u32),
+{
+    type Msg = NumberInputSliderDialogMsg;
+
+    fn place(&mut self, bounds: Rect) -> Rect {
+        self.area = bounds;
+        let button_height = theme::BUTTON_HEIGHT;
+        let content_area = self.area.inset(Insets::top(2 * theme::BUTTON_SPACING));
+        let (_, content_area) = content_area.split_top(30);
+        let (input_area, _) = content_area.split_top(15);
+        let (_, button_area) = content_area.split_bottom(button_height);
+        // let (content_area, button_area) = content_area.split_bottom(button_height);
+        // let content_area = content_area.inset(Insets::new(
+        //     theme::BUTTON_SPACING,
+        //     0,
+        //     theme::BUTTON_SPACING,
+        //     theme::CONTENT_BORDER,
+        // ));
+
+        let grid = Grid::new(button_area, 1, 2).with_spacing(theme::KEYBOARD_SPACING);
+        self.input.place(input_area.inset(Insets::sides(20)));
+        self.cancel_button.place(grid.row_col(0, 0));
+        self.confirm_button.place(grid.row_col(0, 1));
+        bounds
+    }
+
+    fn event(&mut self, ctx: &mut EventCtx, event: Event) -> Option<Self::Msg> {
+        if let Some(NumberInputSliderMsg::Changed(i)) = self.input.event(ctx, event) {
+            (self.callback)(i);
+        }
+        if let Some(ButtonMsg::Clicked) = self.cancel_button.event(ctx, event) {
+            return Some(Self::Msg::Cancelled);
+        }
+        if let Some(ButtonMsg::Clicked) = self.confirm_button.event(ctx, event) {
+            return Some(Self::Msg::Confirmed);
+        };
+        None
+    }
+
+    fn paint(&mut self) {
+        self.input.paint();
+        // self.paragraphs_pad.paint();
+        // self.paragraphs.paint();
+        self.cancel_button.paint();
+        self.confirm_button.paint();
+    }
+
+    #[cfg(feature = "ui_bounds")]
+    fn bounds(&self, sink: &mut dyn FnMut(Rect)) {
+        sink(self.area);
+        self.input.bounds(sink);
+        // self.paragraphs.bounds(sink);
+        self.cancel_button.bounds(sink);
+        self.confirm_button.bounds(sink);
+    }
+}
+
+#[cfg(feature = "ui_debug")]
+impl<F> crate::trace::Trace for NumberInputSliderDialog<F>
+where
+    F: Fn(u32),
+{
+    fn trace(&self, t: &mut dyn crate::trace::Tracer) {
+        t.component("NumberInputSliderDialog");
+        t.child("input", &self.input);
+        t.child("cancel_button", &self.cancel_button);
+        t.child("confirm_button", &self.confirm_button);
+    }
+}
+
+pub enum NumberInputSliderMsg {
+    Changed(u32),
+}
+
+pub struct NumberInputSlider {
+    area: Rect,
+    touch_area: Rect,
+    min: u32,
+    max: u32,
+    value: u32,
+}
+
+impl NumberInputSlider {
+    pub fn new(min: u32, max: u32, value: u32) -> Self {
+        let value = value.clamp(min, max);
+        Self {
+            area: Rect::zero(),
+            touch_area: Rect::zero(),
+            min,
+            max,
+            value,
+        }
+    }
+
+    pub fn slider_eval(&mut self, pos: Point, ctx: &mut EventCtx) -> Option<NumberInputSliderMsg> {
+        if self.touch_area.contains(pos) {
+            let filled = pos.x - self.area.x0;
+            let filled = filled.clamp(0, self.area.width());
+            let val_pct = (filled as u32 * 100) / self.area.width() as u32;
+            let val = (val_pct * (self.max - self.min)) / 100 + self.min;
+
+            if val != self.value {
+                self.value = val;
+                ctx.request_paint();
+                return Some(NumberInputSliderMsg::Changed(self.value));
+            }
+        }
+        None
+    }
+}
+
+impl Component for NumberInputSlider {
+    type Msg = NumberInputSliderMsg;
+
+    fn place(&mut self, bounds: Rect) -> Rect {
+        self.area = bounds;
+        self.touch_area = bounds.outset(Insets::new(40, 20, 40, 20)).clamp(screen());
+        bounds
+    }
+
+    fn event(&mut self, ctx: &mut EventCtx, event: Event) -> Option<Self::Msg> {
+        if let Event::Touch(touch_event) = event {
+            return match touch_event {
+                TouchEvent::TouchStart(pos) => self.slider_eval(pos, ctx),
+                TouchEvent::TouchMove(pos) => self.slider_eval(pos, ctx),
+                TouchEvent::TouchEnd(pos) => self.slider_eval(pos, ctx),
+            };
+        }
+        None
+    }
+
+    fn paint(&mut self) {
+        let val_pct = (100 * (self.value - self.min)) / (self.max - self.min);
+        let fill_to = (val_pct as i16 * self.area.width()) / 100;
+
+        display::bar_with_text_and_fill::<&str>(
+            self.area,
+            None,
+            theme::FG,
+            theme::BG,
+            0,
+            fill_to as _,
+        );
+    }
+
+    #[cfg(feature = "ui_bounds")]
+    fn bounds(&self, sink: &mut dyn FnMut(Rect)) {
+        sink(self.area)
+    }
+}
+
+#[cfg(feature = "ui_debug")]
+impl crate::trace::Trace for NumberInputSlider {
+    fn trace(&self, t: &mut dyn crate::trace::Tracer) {
+        t.component("NumberInput");
+        t.int("value", self.value as i64);
+    }
+}

--- a/core/embed/trezorhal/stm32f4/backlight_pwm.c
+++ b/core/embed/trezorhal/stm32f4/backlight_pwm.c
@@ -4,9 +4,11 @@
 #include STM32_HAL_H
 #include TREZOR_BOARD
 
-#define TIM_FREQ 1000000
+#define TIM_FREQ 10000000
 
-#define LED_PWM_PRESCALER (SystemCoreClock / TIM_FREQ - 1)  // 1 MHz
+#define LED_PWM_PRESCALER (SystemCoreClock / TIM_FREQ - 1)
+
+#define LED_PWM_PRESCALER_SLOW (SystemCoreClock / 1000000 - 1)  // 1 MHz
 
 #define LED_PWM_TIM_PERIOD (TIM_FREQ / BACKLIGHT_PWM_FREQ)
 
@@ -16,6 +18,35 @@ static int pwm_period = 0;
 
 int backlight_pwm_set(int val) {
   if (BACKLIGHT != val && val >= 0 && val <= 255) {
+    // TPS61043: min 1% duty cycle
+    if (val < BACKLIGHT_PWM_TIM->ARR / 100) {
+      val = 0;
+    }
+
+    // TPS61043 goes to shutdown when duty cycle is 0 (after 32ms),
+    // so we need to set GPIO to high for at least 500us
+    // to wake it up.
+    if (BACKLIGHT_PWM_TIM->BACKLIGHT_PWM_TIM_CCR == 0) {
+      GPIO_InitTypeDef GPIO_InitStructure = {0};
+
+      HAL_GPIO_WritePin(BACKLIGHT_PWM_PORT, BACKLIGHT_PWM_PIN, GPIO_PIN_SET);
+      // LCD_PWM/PA7 (backlight control)
+      GPIO_InitStructure.Mode = GPIO_MODE_OUTPUT_PP;
+      GPIO_InitStructure.Pull = GPIO_NOPULL;
+      GPIO_InitStructure.Speed = GPIO_SPEED_FREQ_VERY_HIGH;
+      GPIO_InitStructure.Pin = BACKLIGHT_PWM_PIN;
+      HAL_GPIO_Init(BACKLIGHT_PWM_PORT, &GPIO_InitStructure);
+
+      hal_delay_us(500);
+
+      GPIO_InitStructure.Mode = GPIO_MODE_AF_PP;
+      GPIO_InitStructure.Pull = GPIO_NOPULL;
+      GPIO_InitStructure.Speed = GPIO_SPEED_FREQ_VERY_HIGH;
+      GPIO_InitStructure.Alternate = BACKLIGHT_PWM_TIM_AF;
+      GPIO_InitStructure.Pin = BACKLIGHT_PWM_PIN;
+      HAL_GPIO_Init(BACKLIGHT_PWM_PORT, &GPIO_InitStructure);
+    }
+
     BACKLIGHT = val;
     BACKLIGHT_PWM_TIM->CCR1 = pwm_period * val / 255;
   }
@@ -75,6 +106,7 @@ void backlight_pwm_reinit(void) {
   BACKLIGHT = prev_val;
 
   pwm_period = LED_PWM_TIM_PERIOD;
+  BACKLIGHT_PWM_TIM->PSC = LED_PWM_PRESCALER;
   BACKLIGHT_PWM_TIM->CR1 |= TIM_CR1_ARPE;
   BACKLIGHT_PWM_TIM->CR2 |= TIM_CR2_CCPC;
   BACKLIGHT_PWM_TIM->BACKLIGHT_PWM_TIM_CCR = pwm_period * prev_val / 255;
@@ -93,6 +125,7 @@ void backlight_pwm_set_slow(void) {
   uint8_t prev_val = (prev_ccr1 * 255) / prev_arr;
 
   pwm_period = LED_PWM_SLOW_TIM_PERIOD;
+  BACKLIGHT_PWM_TIM->PSC = LED_PWM_PRESCALER_SLOW;
   BACKLIGHT_PWM_TIM->CR1 |= TIM_CR1_ARPE;
   BACKLIGHT_PWM_TIM->CR2 |= TIM_CR2_CCPC;
   BACKLIGHT_PWM_TIM->ARR = LED_PWM_SLOW_TIM_PERIOD - 1;

--- a/core/mocks/generated/trezorui2.pyi
+++ b/core/mocks/generated/trezorui2.pyi
@@ -796,6 +796,18 @@ def request_number(
 
 
 # rust/src/ui/model_tt/layout.rs
+def request_number_slider(
+    *,
+    title: str,
+    count: int,
+    min_count: int,
+    max_count: int,
+    callback: Callable[[int], None] | None = None,
+) -> object:
+    """Number input with slider."""
+
+
+# rust/src/ui/model_tt/layout.rs
 def show_checklist(
     *,
     title: str,

--- a/core/src/apps/management/apply_settings.py
+++ b/core/src/apps/management/apply_settings.py
@@ -1,8 +1,10 @@
 from typing import TYPE_CHECKING
 
 import trezorui2
+from trezor import utils
 from trezor.enums import ButtonRequestType
-from trezor.ui.layouts import confirm_action
+from trezor.ui import display, style
+from trezor.ui.layouts import confirm_action, request_number_slider
 from trezor.wire import DataError
 
 if TYPE_CHECKING:
@@ -48,6 +50,7 @@ async def apply_settings(msg: ApplySettings) -> Success:
     msg_safety_checks = msg.safety_checks  # local_cache_attribute
     experimental_features = msg.experimental_features  # local_cache_attribute
     hide_passphrase_from_host = msg.hide_passphrase_from_host  # local_cache_attribute
+    brightness = msg.brightness
 
     if (
         homescreen is None
@@ -59,6 +62,7 @@ async def apply_settings(msg: ApplySettings) -> Success:
         and msg_safety_checks is None
         and experimental_features is None
         and hide_passphrase_from_host is None
+        and (brightness is None or not utils.USE_BACKLIGHT)
     ):
         raise ProcessError("No setting provided")
 
@@ -111,6 +115,10 @@ async def apply_settings(msg: ApplySettings) -> Success:
             raise ProcessError("Safety checks are strict")
         await _require_confirm_hide_passphrase_from_host(hide_passphrase_from_host)
         storage_device.set_hide_passphrase_from_host(hide_passphrase_from_host)
+
+    if brightness is not None and utils.USE_BACKLIGHT:
+        new_brightness = await _require_set_brightness()
+        storage_device.set_brightness(new_brightness)
 
     reload_settings_from_storage()
 
@@ -249,4 +257,20 @@ async def _require_confirm_hide_passphrase_from_host(enable: bool) -> None:
             "Hide passphrase",
             description="Hide passphrase coming from host?",
             br_code=BRT_PROTECT_CALL,
+        )
+
+
+if utils.USE_BACKLIGHT:
+
+    async def _require_set_brightness() -> int:
+        def callback(val: int) -> None:
+            display.backlight(val)
+
+        return await request_number_slider(
+            "Set brightness",
+            callback,
+            min_count=style.BACKLIGHT_MIN,
+            max_count=style.BACKLIGHT_MAX,
+            count=style.get_backlight_normal(),
+            br_name="set_brightness",
         )

--- a/core/src/storage/common.py
+++ b/core/src/storage/common.py
@@ -49,12 +49,12 @@ def get_bool(app: int, key: int, public: bool = False) -> bool:
     return get(app, key, public) == _TRUE_BYTE
 
 
-def set_uint8(app: int, key: int, val: int) -> None:
-    set(app, key, val.to_bytes(1, "big"))
+def set_uint8(app: int, key: int, val: int, public: bool = False) -> None:
+    set(app, key, val.to_bytes(1, "big"), public)
 
 
-def get_uint8(app: int, key: int) -> int | None:
-    val = get(app, key)
+def get_uint8(app: int, key: int, public: bool = False) -> int | None:
+    val = get(app, key, public)
     if not val:
         return None
     return int.from_bytes(val, "big")

--- a/core/src/storage/device.py
+++ b/core/src/storage/device.py
@@ -35,6 +35,7 @@ INITIALIZED                = const(0x13)  # bool (0x01 or empty)
 _SAFETY_CHECK_LEVEL        = const(0x14)  # int
 _EXPERIMENTAL_FEATURES     = const(0x15)  # bool (0x01 or empty)
 _HIDE_PASSPHRASE_FROM_HOST = const(0x16)  # bool (0x01 or empty)
+_BRIGHTNESS                = const(0x17)  # int
 
 SAFETY_CHECK_LEVEL_STRICT  : Literal[0] = const(0)
 SAFETY_CHECK_LEVEL_PROMPT  : Literal[1] = const(1)
@@ -344,3 +345,17 @@ def get_hide_passphrase_from_host() -> bool:
     Whether we should hide the passphrase from the host.
     """
     return common.get_bool(_NAMESPACE, _HIDE_PASSPHRASE_FROM_HOST)
+
+
+def set_brightness(brightness: int) -> None:
+    """
+    Set the display brightness setting.
+    """
+    common.set_uint8(_NAMESPACE, _BRIGHTNESS, brightness, True)
+
+
+def get_brightness() -> int | None:
+    """
+    Get the display brightness setting.
+    """
+    return common.get_uint8(_NAMESPACE, _BRIGHTNESS, True)

--- a/core/src/trezor/messages.py
+++ b/core/src/trezor/messages.py
@@ -2228,6 +2228,7 @@ if TYPE_CHECKING:
         safety_checks: "SafetyCheckLevel | None"
         experimental_features: "bool | None"
         hide_passphrase_from_host: "bool | None"
+        brightness: "int | None"
 
         def __init__(
             self,
@@ -2242,6 +2243,7 @@ if TYPE_CHECKING:
             safety_checks: "SafetyCheckLevel | None" = None,
             experimental_features: "bool | None" = None,
             hide_passphrase_from_host: "bool | None" = None,
+            brightness: "int | None" = None,
         ) -> None:
             pass
 

--- a/core/src/trezor/ui/__init__.py
+++ b/core/src/trezor/ui/__init__.py
@@ -56,7 +56,7 @@ async def _alert(count: int) -> None:
         else:
             display.backlight(style.BACKLIGHT_DIM)
             await long_sleep
-    display.backlight(style.BACKLIGHT_NORMAL)
+    display.backlight(style.get_backlight_normal())
     global _alert_in_progress
     _alert_in_progress = False
 

--- a/core/src/trezor/ui/layouts/tt/homescreen.py
+++ b/core/src/trezor/ui/layouts/tt/homescreen.py
@@ -86,7 +86,6 @@ class Homescreen(HomescreenBase):
 
 class Lockscreen(HomescreenBase):
     RENDER_INDICATOR = storage_cache.LOCKSCREEN_ON
-    BACKLIGHT_LEVEL = ui.style.BACKLIGHT_LOW
 
     def __init__(
         self,
@@ -95,8 +94,9 @@ class Lockscreen(HomescreenBase):
         coinjoin_authorized: bool = False,
     ) -> None:
         self.bootscreen = bootscreen
+        self.backlight_level = ui.style.get_backlight_low()
         if bootscreen:
-            self.BACKLIGHT_LEVEL = ui.style.BACKLIGHT_NORMAL
+            self.backlight_level = ui.style.get_backlight_normal()
 
         skip = (
             not bootscreen and storage_cache.homescreen_shown is self.RENDER_INDICATOR

--- a/core/src/trezor/ui/layouts/tt/progress.py
+++ b/core/src/trezor/ui/layouts/tt/progress.py
@@ -18,7 +18,7 @@ class RustProgress:
         ui.backlight_fade(ui.style.BACKLIGHT_DIM)
         self.layout.attach_timer_fn(self.set_timer)
         self.layout.paint()
-        ui.backlight_fade(ui.style.BACKLIGHT_NORMAL)
+        ui.backlight_fade(ui.style.get_backlight_normal())
 
     def set_timer(self, token: int, deadline: int) -> None:
         raise RuntimeError  # progress layouts should not set timers

--- a/core/src/trezor/ui/style.py
+++ b/core/src/trezor/ui/style.py
@@ -1,8 +1,25 @@
 from micropython import const
 
+import storage.device
+
 # backlight brightness
 BACKLIGHT_NORMAL = const(150)
 BACKLIGHT_LOW = const(45)
 BACKLIGHT_DIM = const(5)
 BACKLIGHT_NONE = const(0)
+BACKLIGHT_MIN = const(10)
 BACKLIGHT_MAX = const(255)
+
+
+def get_backlight_normal() -> int:
+    val = storage.device.get_brightness()
+    if val is None:
+        return BACKLIGHT_NORMAL
+    return val
+
+
+def get_backlight_low() -> int:
+    val = storage.device.get_brightness()
+    if val is None or val > BACKLIGHT_LOW:
+        return BACKLIGHT_LOW
+    return val

--- a/python/src/trezorlib/cli/settings.py
+++ b/python/src/trezorlib/cli/settings.py
@@ -204,6 +204,13 @@ def label(client: "TrezorClient", label: str) -> str:
 
 
 @cli.command()
+@with_client
+def brightness(client: "TrezorClient") -> str:
+    """Set display brightness."""
+    return device.apply_settings(client, brightness=0)
+
+
+@cli.command()
 @click.argument("rotation", type=ChoiceType(ROTATION))
 @with_client
 def display_rotation(client: "TrezorClient", rotation: int) -> str:

--- a/python/src/trezorlib/device.py
+++ b/python/src/trezorlib/device.py
@@ -44,6 +44,7 @@ def apply_settings(
     safety_checks: Optional[messages.SafetyCheckLevel] = None,
     experimental_features: Optional[bool] = None,
     hide_passphrase_from_host: Optional[bool] = None,
+    brightness: Optional[int] = None,
 ) -> "MessageType":
     settings = messages.ApplySettings(
         label=label,
@@ -56,6 +57,7 @@ def apply_settings(
         safety_checks=safety_checks,
         experimental_features=experimental_features,
         hide_passphrase_from_host=hide_passphrase_from_host,
+        brightness=brightness,
     )
 
     out = client.call(settings)

--- a/python/src/trezorlib/messages.py
+++ b/python/src/trezorlib/messages.py
@@ -3348,6 +3348,7 @@ class ApplySettings(protobuf.MessageType):
         9: protobuf.Field("safety_checks", "SafetyCheckLevel", repeated=False, required=False, default=None),
         10: protobuf.Field("experimental_features", "bool", repeated=False, required=False, default=None),
         11: protobuf.Field("hide_passphrase_from_host", "bool", repeated=False, required=False, default=None),
+        12: protobuf.Field("brightness", "uint32", repeated=False, required=False, default=None),
     }
 
     def __init__(
@@ -3364,6 +3365,7 @@ class ApplySettings(protobuf.MessageType):
         safety_checks: Optional["SafetyCheckLevel"] = None,
         experimental_features: Optional["bool"] = None,
         hide_passphrase_from_host: Optional["bool"] = None,
+        brightness: Optional["int"] = None,
     ) -> None:
         self.language = language
         self.label = label
@@ -3376,6 +3378,7 @@ class ApplySettings(protobuf.MessageType):
         self.safety_checks = safety_checks
         self.experimental_features = experimental_features
         self.hide_passphrase_from_host = hide_passphrase_from_host
+        self.brightness = brightness
 
 
 class ApplyFlags(protobuf.MessageType):

--- a/rust/trezor-client/src/protos/generated/messages_management.rs
+++ b/rust/trezor-client/src/protos/generated/messages_management.rs
@@ -2913,6 +2913,8 @@ pub struct ApplySettings {
     pub experimental_features: ::std::option::Option<bool>,
     // @@protoc_insertion_point(field:hw.trezor.messages.management.ApplySettings.hide_passphrase_from_host)
     pub hide_passphrase_from_host: ::std::option::Option<bool>,
+    // @@protoc_insertion_point(field:hw.trezor.messages.management.ApplySettings.brightness)
+    pub brightness: ::std::option::Option<u32>,
     // special fields
     // @@protoc_insertion_point(special_field:hw.trezor.messages.management.ApplySettings.special_fields)
     pub special_fields: ::protobuf::SpecialFields,
@@ -3192,8 +3194,27 @@ impl ApplySettings {
         self.hide_passphrase_from_host = ::std::option::Option::Some(v);
     }
 
+    // optional uint32 brightness = 12;
+
+    pub fn brightness(&self) -> u32 {
+        self.brightness.unwrap_or(0)
+    }
+
+    pub fn clear_brightness(&mut self) {
+        self.brightness = ::std::option::Option::None;
+    }
+
+    pub fn has_brightness(&self) -> bool {
+        self.brightness.is_some()
+    }
+
+    // Param is passed by value, moved
+    pub fn set_brightness(&mut self, v: u32) {
+        self.brightness = ::std::option::Option::Some(v);
+    }
+
     fn generated_message_descriptor_data() -> ::protobuf::reflect::GeneratedMessageDescriptorData {
-        let mut fields = ::std::vec::Vec::with_capacity(11);
+        let mut fields = ::std::vec::Vec::with_capacity(12);
         let mut oneofs = ::std::vec::Vec::with_capacity(0);
         fields.push(::protobuf::reflect::rt::v2::make_option_accessor::<_, _>(
             "language",
@@ -3250,6 +3271,11 @@ impl ApplySettings {
             |m: &ApplySettings| { &m.hide_passphrase_from_host },
             |m: &mut ApplySettings| { &mut m.hide_passphrase_from_host },
         ));
+        fields.push(::protobuf::reflect::rt::v2::make_option_accessor::<_, _>(
+            "brightness",
+            |m: &ApplySettings| { &m.brightness },
+            |m: &mut ApplySettings| { &mut m.brightness },
+        ));
         ::protobuf::reflect::GeneratedMessageDescriptorData::new_2::<ApplySettings>(
             "ApplySettings",
             fields,
@@ -3301,6 +3327,9 @@ impl ::protobuf::Message for ApplySettings {
                 88 => {
                     self.hide_passphrase_from_host = ::std::option::Option::Some(is.read_bool()?);
                 },
+                96 => {
+                    self.brightness = ::std::option::Option::Some(is.read_uint32()?);
+                },
                 tag => {
                     ::protobuf::rt::read_unknown_or_skip_group(tag, is, self.special_fields.mut_unknown_fields())?;
                 },
@@ -3346,6 +3375,9 @@ impl ::protobuf::Message for ApplySettings {
         if let Some(v) = self.hide_passphrase_from_host {
             my_size += 1 + 1;
         }
+        if let Some(v) = self.brightness {
+            my_size += ::protobuf::rt::uint32_size(12, v);
+        }
         my_size += ::protobuf::rt::unknown_fields_size(self.special_fields.unknown_fields());
         self.special_fields.cached_size().set(my_size as u32);
         my_size
@@ -3385,6 +3417,9 @@ impl ::protobuf::Message for ApplySettings {
         if let Some(v) = self.hide_passphrase_from_host {
             os.write_bool(11, v)?;
         }
+        if let Some(v) = self.brightness {
+            os.write_uint32(12, v)?;
+        }
         os.write_unknown_fields(self.special_fields.unknown_fields())?;
         ::std::result::Result::Ok(())
     }
@@ -3413,6 +3448,7 @@ impl ::protobuf::Message for ApplySettings {
         self.safety_checks = ::std::option::Option::None;
         self.experimental_features = ::std::option::Option::None;
         self.hide_passphrase_from_host = ::std::option::Option::None;
+        self.brightness = ::std::option::Option::None;
         self.special_fields.clear();
     }
 
@@ -3429,6 +3465,7 @@ impl ::protobuf::Message for ApplySettings {
             safety_checks: ::std::option::Option::None,
             experimental_features: ::std::option::Option::None,
             hide_passphrase_from_host: ::std::option::Option::None,
+            brightness: ::std::option::Option::None,
             special_fields: ::protobuf::SpecialFields::new(),
         };
         &instance
@@ -9762,7 +9799,7 @@ static file_descriptor_proto_data: &'static [u8] = b"\
     \x1d\x01\x12$\n\x1aCapability_PassphraseEntry\x10\x11\x1a\x04\x80\xa6\
     \x1d\x01\x12\x15\n\x11Capability_Solana\x10\x12\x1a\x04\xc8\xf3\x18\x01\
     \"\x0c\n\nLockDevice\"&\n\x07SetBusy\x12\x1b\n\texpiry_ms\x18\x01\x20\
-    \x01(\rR\x08expiryMs\"\x0c\n\nEndSession\"\x97\x04\n\rApplySettings\x12\
+    \x01(\rR\x08expiryMs\"\x0c\n\nEndSession\"\xb7\x04\n\rApplySettings\x12\
     \x1a\n\x08language\x18\x01\x20\x01(\tR\x08language\x12\x14\n\x05label\
     \x18\x02\x20\x01(\tR\x05label\x12%\n\x0euse_passphrase\x18\x03\x20\x01(\
     \x08R\rusePassphrase\x12\x1e\n\nhomescreen\x18\x04\x20\x01(\x0cR\nhomesc\
@@ -9774,76 +9811,77 @@ static file_descriptor_proto_data: &'static [u8] = b"\
     r.messages.management.SafetyCheckLevelR\x0csafetyChecks\x123\n\x15experi\
     mental_features\x18\n\x20\x01(\x08R\x14experimentalFeatures\x129\n\x19hi\
     de_passphrase_from_host\x18\x0b\x20\x01(\x08R\x16hidePassphraseFromHost\
-    \"\"\n\nApplyFlags\x12\x14\n\x05flags\x18\x01\x20\x02(\rR\x05flags\"#\n\
-    \tChangePin\x12\x16\n\x06remove\x18\x01\x20\x01(\x08R\x06remove\"(\n\x0e\
-    ChangeWipeCode\x12\x16\n\x06remove\x18\x01\x20\x01(\x08R\x06remove\"\xaa\
-    \x01\n\tSdProtect\x12]\n\toperation\x18\x01\x20\x02(\x0e2?.hw.trezor.mes\
-    sages.management.SdProtect.SdProtectOperationTypeR\toperation\">\n\x16Sd\
-    ProtectOperationType\x12\x0b\n\x07DISABLE\x10\0\x12\n\n\x06ENABLE\x10\
-    \x01\x12\x0b\n\x07REFRESH\x10\x02\"O\n\x04Ping\x12\x1a\n\x07message\x18\
-    \x01\x20\x01(\t:\0R\x07message\x12+\n\x11button_protection\x18\x02\x20\
-    \x01(\x08R\x10buttonProtection\"\x08\n\x06Cancel\"\x20\n\nGetEntropy\x12\
-    \x12\n\x04size\x18\x01\x20\x02(\rR\x04size\"#\n\x07Entropy\x12\x18\n\x07\
-    entropy\x18\x01\x20\x02(\x0cR\x07entropy\"/\n\x0fGetFirmwareHash\x12\x1c\
-    \n\tchallenge\x18\x01\x20\x01(\x0cR\tchallenge\"\"\n\x0cFirmwareHash\x12\
-    \x12\n\x04hash\x18\x01\x20\x02(\x0cR\x04hash\"2\n\x12AuthenticateDevice\
-    \x12\x1c\n\tchallenge\x18\x01\x20\x02(\x0cR\tchallenge\"U\n\x11Authentic\
-    ityProof\x12\"\n\x0ccertificates\x18\x01\x20\x03(\x0cR\x0ccertificates\
-    \x12\x1c\n\tsignature\x18\x02\x20\x02(\x0cR\tsignature\"\x0c\n\nWipeDevi\
-    ce\"\xb0\x02\n\nLoadDevice\x12\x1c\n\tmnemonics\x18\x01\x20\x03(\tR\tmne\
-    monics\x12\x10\n\x03pin\x18\x03\x20\x01(\tR\x03pin\x123\n\x15passphrase_\
-    protection\x18\x04\x20\x01(\x08R\x14passphraseProtection\x12!\n\x08langu\
-    age\x18\x05\x20\x01(\t:\x05en-USR\x08language\x12\x14\n\x05label\x18\x06\
-    \x20\x01(\tR\x05label\x12#\n\rskip_checksum\x18\x07\x20\x01(\x08R\x0cski\
-    pChecksum\x12\x1f\n\x0bu2f_counter\x18\x08\x20\x01(\rR\nu2fCounter\x12!\
-    \n\x0cneeds_backup\x18\t\x20\x01(\x08R\x0bneedsBackup\x12\x1b\n\tno_back\
-    up\x18\n\x20\x01(\x08R\x08noBackup\"\x9c\x03\n\x0bResetDevice\x12%\n\x0e\
-    display_random\x18\x01\x20\x01(\x08R\rdisplayRandom\x12\x1f\n\x08strengt\
-    h\x18\x02\x20\x01(\r:\x03256R\x08strength\x123\n\x15passphrase_protectio\
-    n\x18\x03\x20\x01(\x08R\x14passphraseProtection\x12%\n\x0epin_protection\
-    \x18\x04\x20\x01(\x08R\rpinProtection\x12!\n\x08language\x18\x05\x20\x01\
-    (\t:\x05en-USR\x08language\x12\x14\n\x05label\x18\x06\x20\x01(\tR\x05lab\
-    el\x12\x1f\n\x0bu2f_counter\x18\x07\x20\x01(\rR\nu2fCounter\x12\x1f\n\
-    \x0bskip_backup\x18\x08\x20\x01(\x08R\nskipBackup\x12\x1b\n\tno_backup\
-    \x18\t\x20\x01(\x08R\x08noBackup\x12Q\n\x0bbackup_type\x18\n\x20\x01(\
-    \x0e2).hw.trezor.messages.management.BackupType:\x05Bip39R\nbackupType\"\
-    \x0e\n\x0cBackupDevice\"\x10\n\x0eEntropyRequest\"&\n\nEntropyAck\x12\
-    \x18\n\x07entropy\x18\x01\x20\x02(\x0cR\x07entropy\"\xd4\x03\n\x0eRecove\
-    ryDevice\x12\x1d\n\nword_count\x18\x01\x20\x01(\rR\twordCount\x123\n\x15\
-    passphrase_protection\x18\x02\x20\x01(\x08R\x14passphraseProtection\x12%\
-    \n\x0epin_protection\x18\x03\x20\x01(\x08R\rpinProtection\x12\x1a\n\x08l\
-    anguage\x18\x04\x20\x01(\tR\x08language\x12\x14\n\x05label\x18\x05\x20\
-    \x01(\tR\x05label\x12)\n\x10enforce_wordlist\x18\x06\x20\x01(\x08R\x0fen\
-    forceWordlist\x12T\n\x04type\x18\x08\x20\x01(\x0e2@.hw.trezor.messages.m\
-    anagement.RecoveryDevice.RecoveryDeviceTypeR\x04type\x12\x1f\n\x0bu2f_co\
-    unter\x18\t\x20\x01(\rR\nu2fCounter\x12\x17\n\x07dry_run\x18\n\x20\x01(\
-    \x08R\x06dryRun\"Z\n\x12RecoveryDeviceType\x12%\n!RecoveryDeviceType_Scr\
-    ambledWords\x10\0\x12\x1d\n\x19RecoveryDeviceType_Matrix\x10\x01\"\xc5\
-    \x01\n\x0bWordRequest\x12N\n\x04type\x18\x01\x20\x02(\x0e2:.hw.trezor.me\
-    ssages.management.WordRequest.WordRequestTypeR\x04type\"f\n\x0fWordReque\
-    stType\x12\x19\n\x15WordRequestType_Plain\x10\0\x12\x1b\n\x17WordRequest\
-    Type_Matrix9\x10\x01\x12\x1b\n\x17WordRequestType_Matrix6\x10\x02\"\x1d\
-    \n\x07WordAck\x12\x12\n\x04word\x18\x01\x20\x02(\tR\x04word\"0\n\rSetU2F\
-    Counter\x12\x1f\n\x0bu2f_counter\x18\x01\x20\x02(\rR\nu2fCounter\"\x13\n\
-    \x11GetNextU2FCounter\"1\n\x0eNextU2FCounter\x12\x1f\n\x0bu2f_counter\
-    \x18\x01\x20\x02(\rR\nu2fCounter\"\x11\n\x0fDoPreauthorized\"\x16\n\x14P\
-    reauthorizedRequest\"\x15\n\x13CancelAuthorization\"\xe5\x01\n\x12Reboot\
-    ToBootloader\x12o\n\x0cboot_command\x18\x01\x20\x01(\x0e2=.hw.trezor.mes\
-    sages.management.RebootToBootloader.BootCommand:\rSTOP_AND_WAITR\x0bboot\
-    Command\x12'\n\x0ffirmware_header\x18\x02\x20\x01(\x0cR\x0efirmwareHeade\
-    r\"5\n\x0bBootCommand\x12\x11\n\rSTOP_AND_WAIT\x10\0\x12\x13\n\x0fINSTAL\
-    L_UPGRADE\x10\x01\"\x10\n\x08GetNonce:\x04\x88\xb2\x19\x01\"#\n\x05Nonce\
-    \x12\x14\n\x05nonce\x18\x01\x20\x02(\x0cR\x05nonce:\x04\x88\xb2\x19\x01\
-    \";\n\nUnlockPath\x12\x1b\n\taddress_n\x18\x01\x20\x03(\rR\x08addressN\
-    \x12\x10\n\x03mac\x18\x02\x20\x01(\x0cR\x03mac\"'\n\x13UnlockedPathReque\
-    st\x12\x10\n\x03mac\x18\x01\x20\x01(\x0cR\x03mac\"\x14\n\x12ShowDeviceTu\
-    torial\"\x12\n\x10UnlockBootloader*>\n\nBackupType\x12\t\n\x05Bip39\x10\
-    \0\x12\x10\n\x0cSlip39_Basic\x10\x01\x12\x13\n\x0fSlip39_Advanced\x10\
-    \x02*G\n\x10SafetyCheckLevel\x12\n\n\x06Strict\x10\0\x12\x10\n\x0cPrompt\
-    Always\x10\x01\x12\x15\n\x11PromptTemporarily\x10\x02*0\n\x10HomescreenF\
-    ormat\x12\x08\n\x04Toif\x10\x01\x12\x08\n\x04Jpeg\x10\x02\x12\x08\n\x04T\
-    oiG\x10\x03BB\n#com.satoshilabs.trezor.lib.protobufB\x17TrezorMessageMan\
-    agement\x80\xa6\x1d\x01\
+    \x12\x1e\n\nbrightness\x18\x0c\x20\x01(\rR\nbrightness\"\"\n\nApplyFlags\
+    \x12\x14\n\x05flags\x18\x01\x20\x02(\rR\x05flags\"#\n\tChangePin\x12\x16\
+    \n\x06remove\x18\x01\x20\x01(\x08R\x06remove\"(\n\x0eChangeWipeCode\x12\
+    \x16\n\x06remove\x18\x01\x20\x01(\x08R\x06remove\"\xaa\x01\n\tSdProtect\
+    \x12]\n\toperation\x18\x01\x20\x02(\x0e2?.hw.trezor.messages.management.\
+    SdProtect.SdProtectOperationTypeR\toperation\">\n\x16SdProtectOperationT\
+    ype\x12\x0b\n\x07DISABLE\x10\0\x12\n\n\x06ENABLE\x10\x01\x12\x0b\n\x07RE\
+    FRESH\x10\x02\"O\n\x04Ping\x12\x1a\n\x07message\x18\x01\x20\x01(\t:\0R\
+    \x07message\x12+\n\x11button_protection\x18\x02\x20\x01(\x08R\x10buttonP\
+    rotection\"\x08\n\x06Cancel\"\x20\n\nGetEntropy\x12\x12\n\x04size\x18\
+    \x01\x20\x02(\rR\x04size\"#\n\x07Entropy\x12\x18\n\x07entropy\x18\x01\
+    \x20\x02(\x0cR\x07entropy\"/\n\x0fGetFirmwareHash\x12\x1c\n\tchallenge\
+    \x18\x01\x20\x01(\x0cR\tchallenge\"\"\n\x0cFirmwareHash\x12\x12\n\x04has\
+    h\x18\x01\x20\x02(\x0cR\x04hash\"2\n\x12AuthenticateDevice\x12\x1c\n\tch\
+    allenge\x18\x01\x20\x02(\x0cR\tchallenge\"U\n\x11AuthenticityProof\x12\"\
+    \n\x0ccertificates\x18\x01\x20\x03(\x0cR\x0ccertificates\x12\x1c\n\tsign\
+    ature\x18\x02\x20\x02(\x0cR\tsignature\"\x0c\n\nWipeDevice\"\xb0\x02\n\n\
+    LoadDevice\x12\x1c\n\tmnemonics\x18\x01\x20\x03(\tR\tmnemonics\x12\x10\n\
+    \x03pin\x18\x03\x20\x01(\tR\x03pin\x123\n\x15passphrase_protection\x18\
+    \x04\x20\x01(\x08R\x14passphraseProtection\x12!\n\x08language\x18\x05\
+    \x20\x01(\t:\x05en-USR\x08language\x12\x14\n\x05label\x18\x06\x20\x01(\t\
+    R\x05label\x12#\n\rskip_checksum\x18\x07\x20\x01(\x08R\x0cskipChecksum\
+    \x12\x1f\n\x0bu2f_counter\x18\x08\x20\x01(\rR\nu2fCounter\x12!\n\x0cneed\
+    s_backup\x18\t\x20\x01(\x08R\x0bneedsBackup\x12\x1b\n\tno_backup\x18\n\
+    \x20\x01(\x08R\x08noBackup\"\x9c\x03\n\x0bResetDevice\x12%\n\x0edisplay_\
+    random\x18\x01\x20\x01(\x08R\rdisplayRandom\x12\x1f\n\x08strength\x18\
+    \x02\x20\x01(\r:\x03256R\x08strength\x123\n\x15passphrase_protection\x18\
+    \x03\x20\x01(\x08R\x14passphraseProtection\x12%\n\x0epin_protection\x18\
+    \x04\x20\x01(\x08R\rpinProtection\x12!\n\x08language\x18\x05\x20\x01(\t:\
+    \x05en-USR\x08language\x12\x14\n\x05label\x18\x06\x20\x01(\tR\x05label\
+    \x12\x1f\n\x0bu2f_counter\x18\x07\x20\x01(\rR\nu2fCounter\x12\x1f\n\x0bs\
+    kip_backup\x18\x08\x20\x01(\x08R\nskipBackup\x12\x1b\n\tno_backup\x18\t\
+    \x20\x01(\x08R\x08noBackup\x12Q\n\x0bbackup_type\x18\n\x20\x01(\x0e2).hw\
+    .trezor.messages.management.BackupType:\x05Bip39R\nbackupType\"\x0e\n\
+    \x0cBackupDevice\"\x10\n\x0eEntropyRequest\"&\n\nEntropyAck\x12\x18\n\
+    \x07entropy\x18\x01\x20\x02(\x0cR\x07entropy\"\xd4\x03\n\x0eRecoveryDevi\
+    ce\x12\x1d\n\nword_count\x18\x01\x20\x01(\rR\twordCount\x123\n\x15passph\
+    rase_protection\x18\x02\x20\x01(\x08R\x14passphraseProtection\x12%\n\x0e\
+    pin_protection\x18\x03\x20\x01(\x08R\rpinProtection\x12\x1a\n\x08languag\
+    e\x18\x04\x20\x01(\tR\x08language\x12\x14\n\x05label\x18\x05\x20\x01(\tR\
+    \x05label\x12)\n\x10enforce_wordlist\x18\x06\x20\x01(\x08R\x0fenforceWor\
+    dlist\x12T\n\x04type\x18\x08\x20\x01(\x0e2@.hw.trezor.messages.managemen\
+    t.RecoveryDevice.RecoveryDeviceTypeR\x04type\x12\x1f\n\x0bu2f_counter\
+    \x18\t\x20\x01(\rR\nu2fCounter\x12\x17\n\x07dry_run\x18\n\x20\x01(\x08R\
+    \x06dryRun\"Z\n\x12RecoveryDeviceType\x12%\n!RecoveryDeviceType_Scramble\
+    dWords\x10\0\x12\x1d\n\x19RecoveryDeviceType_Matrix\x10\x01\"\xc5\x01\n\
+    \x0bWordRequest\x12N\n\x04type\x18\x01\x20\x02(\x0e2:.hw.trezor.messages\
+    .management.WordRequest.WordRequestTypeR\x04type\"f\n\x0fWordRequestType\
+    \x12\x19\n\x15WordRequestType_Plain\x10\0\x12\x1b\n\x17WordRequestType_M\
+    atrix9\x10\x01\x12\x1b\n\x17WordRequestType_Matrix6\x10\x02\"\x1d\n\x07W\
+    ordAck\x12\x12\n\x04word\x18\x01\x20\x02(\tR\x04word\"0\n\rSetU2FCounter\
+    \x12\x1f\n\x0bu2f_counter\x18\x01\x20\x02(\rR\nu2fCounter\"\x13\n\x11Get\
+    NextU2FCounter\"1\n\x0eNextU2FCounter\x12\x1f\n\x0bu2f_counter\x18\x01\
+    \x20\x02(\rR\nu2fCounter\"\x11\n\x0fDoPreauthorized\"\x16\n\x14Preauthor\
+    izedRequest\"\x15\n\x13CancelAuthorization\"\xe5\x01\n\x12RebootToBootlo\
+    ader\x12o\n\x0cboot_command\x18\x01\x20\x01(\x0e2=.hw.trezor.messages.ma\
+    nagement.RebootToBootloader.BootCommand:\rSTOP_AND_WAITR\x0bbootCommand\
+    \x12'\n\x0ffirmware_header\x18\x02\x20\x01(\x0cR\x0efirmwareHeader\"5\n\
+    \x0bBootCommand\x12\x11\n\rSTOP_AND_WAIT\x10\0\x12\x13\n\x0fINSTALL_UPGR\
+    ADE\x10\x01\"\x10\n\x08GetNonce:\x04\x88\xb2\x19\x01\"#\n\x05Nonce\x12\
+    \x14\n\x05nonce\x18\x01\x20\x02(\x0cR\x05nonce:\x04\x88\xb2\x19\x01\";\n\
+    \nUnlockPath\x12\x1b\n\taddress_n\x18\x01\x20\x03(\rR\x08addressN\x12\
+    \x10\n\x03mac\x18\x02\x20\x01(\x0cR\x03mac\"'\n\x13UnlockedPathRequest\
+    \x12\x10\n\x03mac\x18\x01\x20\x01(\x0cR\x03mac\"\x14\n\x12ShowDeviceTuto\
+    rial\"\x12\n\x10UnlockBootloader*>\n\nBackupType\x12\t\n\x05Bip39\x10\0\
+    \x12\x10\n\x0cSlip39_Basic\x10\x01\x12\x13\n\x0fSlip39_Advanced\x10\x02*\
+    G\n\x10SafetyCheckLevel\x12\n\n\x06Strict\x10\0\x12\x10\n\x0cPromptAlway\
+    s\x10\x01\x12\x15\n\x11PromptTemporarily\x10\x02*0\n\x10HomescreenFormat\
+    \x12\x08\n\x04Toif\x10\x01\x12\x08\n\x04Jpeg\x10\x02\x12\x08\n\x04ToiG\
+    \x10\x03BB\n#com.satoshilabs.trezor.lib.protobufB\x17TrezorMessageManage\
+    ment\x80\xa6\x1d\x01\
 ";
 
 /// `FileDescriptorProto` object which was a source for this generated file


### PR DESCRIPTION
This PR adds user adjustable brightness setting via trezorctl (`trezorctl set brightness`)


The backlight driver is fixed: when going from zero backlight there needs to be a longer pulse to wake up the IC, with user adjustable this wasn't guaranteed to happen.

POC state:
- needs proper UI design
- backlight for some screens are defined in rust, which currently does not respect the user setting. Needs to be dealt with somehow.
- This brightness is selected with slider on device. Created a new component for that, `NumberInputSliderDialog`, the current `NumberInputDialog` seems a bit too specific with the INFO&CONTINUE buttons which i don't need here, but with some effort these to might be probably merged


<!--
If you are a core dev:

Don't forget to set up the fields:
- assign yourself
- set priority to same as original issue
- add PR to sprint
- if Draft -> "in progress"
- if final PR -> "needs review"

If you're an external contributor, you can ignore this text.
-->
