### PR TITLE
fix rust warnings and clippy errors

### DIFF
--- a/core/embed/rust/src/lib.rs
+++ b/core/embed/rust/src/lib.rs
@@ -2,6 +2,7 @@
 #![deny(clippy::all)]
 #![allow(clippy::new_without_default)]
 #![deny(unsafe_op_in_unsafe_fn)]
+#![allow(internal_features)]
 // Allowing dead code not to cause a lot of warnings when building for a specific target
 // (when building for TR, a lot of code only used in TT would get marked as unused).
 #![allow(dead_code)]

--- a/core/embed/rust/src/trezorhal/display.rs
+++ b/core/embed/rust/src/trezorhal/display.rs
@@ -8,8 +8,7 @@ pub use ffi::{DISPLAY_RESX, DISPLAY_RESY};
 
 #[cfg(feature = "framebuffer")]
 pub use ffi::{
-    DISPLAY_FRAMEBUFFER_HEIGHT, DISPLAY_FRAMEBUFFER_OFFSET_X, DISPLAY_FRAMEBUFFER_OFFSET_Y,
-    DISPLAY_FRAMEBUFFER_WIDTH,
+    DISPLAY_FRAMEBUFFER_OFFSET_X, DISPLAY_FRAMEBUFFER_OFFSET_Y, DISPLAY_FRAMEBUFFER_WIDTH,
 };
 
 #[cfg(all(feature = "framebuffer", not(feature = "framebuffer32bit")))]

--- a/core/embed/rust/src/trezorhal/secbool.rs
+++ b/core/embed/rust/src/trezorhal/secbool.rs
@@ -1,3 +1,5 @@
+#![allow(unused_imports)]
+
 use super::ffi;
 
 pub use ffi::{secbool, secfalse, sectrue};

--- a/core/embed/rust/src/ui/component/base.rs
+++ b/core/embed/rust/src/ui/component/base.rs
@@ -235,7 +235,7 @@ where
             self.marked_for_clear = true;
             let mut dummy_ctx = EventCtx::new();
             let paint_msg = self.inner.event(&mut dummy_ctx, Event::RequestPaint);
-            assert!(matches!(paint_msg, None));
+            assert!(paint_msg.is_none());
             assert!(dummy_ctx.timers.is_empty());
         }
         msg

--- a/core/embed/rust/src/ui/display/toif.rs
+++ b/core/embed/rust/src/ui/display/toif.rs
@@ -11,7 +11,6 @@ use crate::{
         geometry::{Alignment2D, Offset, Point, Rect},
     },
 };
-use core::cmp::max;
 
 #[cfg(feature = "dma2d")]
 use crate::{
@@ -27,6 +26,8 @@ use crate::ui::display::{get_color_table, pixeldata};
 
 #[cfg(feature = "framebuffer")]
 use crate::trezorhal::{buffers::BufferLine4bpp, dma2d::dma2d_setup_4bpp};
+#[cfg(feature = "framebuffer")]
+use core::cmp::max;
 
 use super::Color;
 

--- a/core/embed/rust/src/ui/model_tr/bootloader/mod.rs
+++ b/core/embed/rust/src/ui/model_tr/bootloader/mod.rs
@@ -132,7 +132,7 @@ extern "C" fn screen_install_confirm(
 
     let mut fingerprint_buffer: [u8; 64] = [0; 64];
     let fingerprint_str = unsafe {
-        let fingerprint_slice = core::slice::from_raw_parts(fingerprint as *const u8, 32);
+        let fingerprint_slice = core::slice::from_raw_parts(fingerprint, 32);
         hexlify(fingerprint_slice, &mut fingerprint_buffer);
         core::str::from_utf8_unchecked(fingerprint_buffer.as_ref())
     };

--- a/core/embed/rust/src/ui/model_tr/layout.rs
+++ b/core/embed/rust/src/ui/model_tr/layout.rs
@@ -47,8 +47,8 @@ use super::{
         AddressDetails, ButtonActions, ButtonDetails, ButtonLayout, ButtonPage, CancelConfirmMsg,
         CancelInfoConfirmMsg, CoinJoinProgress, ConfirmHomescreen, Flow, FlowPages, Frame,
         Homescreen, Lockscreen, NumberInput, Page, PassphraseEntry, PinEntry, Progress,
-        ScrollableContent, ScrollableFrame, ShareWords, ShowMore, SimpleChoice, WelcomeScreen,
-        WordlistEntry, WordlistType,
+        ScrollableContent, ScrollableFrame, ShareWords, ShowMore, SimpleChoice, WordlistEntry,
+        WordlistType,
     },
     constant, theme,
 };

--- a/core/embed/rust/src/ui/model_tt/bootloader/mod.rs
+++ b/core/embed/rust/src/ui/model_tt/bootloader/mod.rs
@@ -142,7 +142,7 @@ extern "C" fn screen_install_confirm(
 
     let mut fingerprint_buffer: [u8; 64] = [0; 64];
     let fingerprint_str = unsafe {
-        let fingerprint_slice = core::slice::from_raw_parts(fingerprint as *const u8, 32);
+        let fingerprint_slice = core::slice::from_raw_parts(fingerprint, 32);
         hexlify(fingerprint_slice, &mut fingerprint_buffer);
         core::str::from_utf8_unchecked(fingerprint_buffer.as_ref())
     };

--- a/core/embed/rust/src/ui/model_tt/component/homescreen/render.rs
+++ b/core/embed/rust/src/ui/model_tt/component/homescreen/render.rs
@@ -541,7 +541,7 @@ pub fn homescreen_blurred(data: &mut dyn HomescreenDecompressor, texts: &[Homesc
 
     let mut next_text_idx = 1;
     let mut text_info =
-        homescreen_position_text(unwrap!(texts.get(0)), &mut text_buffer, &mut icon_data);
+        homescreen_position_text(unwrap!(texts.first()), &mut text_buffer, &mut icon_data);
 
     let mcu_height = data.get_height();
     data.decompress();
@@ -671,7 +671,7 @@ pub fn homescreen(
         }
     } else {
         next_text_idx += 1;
-        homescreen_position_text(unwrap!(texts.get(0)), &mut text_buffer, &mut icon_data)
+        homescreen_position_text(unwrap!(texts.first()), &mut text_buffer, &mut icon_data)
     };
 
     set_window(screen());

--- a/core/embed/rust/src/ui/model_tt/layout.rs
+++ b/core/embed/rust/src/ui/model_tt/layout.rs
@@ -32,7 +32,7 @@ use crate::{
             },
             Border, Component, Empty, FormattedText, Label, Never, Qr, Timeout,
         },
-        display::{self, tjpgd::jpeg_info},
+        display::tjpgd::jpeg_info,
         geometry,
         layout::{
             obj::{ComponentMsgObj, LayoutObj},
@@ -50,9 +50,9 @@ use super::{
         FidoMsg, Frame, FrameMsg, Homescreen, HomescreenMsg, IconDialog, Lockscreen, MnemonicInput,
         MnemonicKeyboard, MnemonicKeyboardMsg, NumberInputDialog, NumberInputDialogMsg,
         PassphraseKeyboard, PassphraseKeyboardMsg, PinKeyboard, PinKeyboardMsg, Progress,
-        SelectWordCount, SelectWordCountMsg, SelectWordMsg, SimplePage, Slip39Input, WelcomeScreen,
+        SelectWordCount, SelectWordCountMsg, SelectWordMsg, SimplePage, Slip39Input,
     },
-    constant, theme,
+    theme,
 };
 
 impl TryFrom<CancelConfirmMsg> for Obj {


### PR DESCRIPTION
just to have clean slate. 

Not entirely sure about the `#![allow(internal_features)]` which is needed to suppress warning about `#![feature(lang_items)]`

<!--
If you are a core dev:

Don't forget to set up the fields:
- assign yourself
- set priority to same as original issue
- add PR to sprint
- if Draft -> "in progress"
- if final PR -> "needs review"

If you're an external contributor, you can ignore this text.
-->
