### PR TITLE
add haptic to prodtest

### DIFF
--- a/core/embed/prodtest/README.md
+++ b/core/embed/prodtest/README.md
@@ -160,6 +160,21 @@ SBU 1 0
 OK
 ```
 
+
+### HAPTIC
+The `HAPTIC` command allows you to test the functionality of the device's haptic driver.
+It takes one input parameter, representing the duration of the vibration in milliseconds.
+The device only vibrates if there is motor connected to the haptic driver, otherwise the effect needs to be
+measured by an oscilloscope.
+
+Example:
+```
+// runs the driver for 3000 ms
+
+HAPTIC 3000
+OK
+```
+
 ### OTP READ
 The `OTP READ` command is utilized to retrieve a string parameter from the device's OTP memory.
 This string typically contains information identifying the model and production batch of the device.

--- a/core/embed/prodtest/main.c
+++ b/core/embed/prodtest/main.c
@@ -47,6 +47,10 @@
 #include "optiga_transport.h"
 #endif
 
+#ifdef USE_HAPTIC
+#include "haptic.h"
+#endif
+
 #ifdef USE_HASH_PROCESSOR
 #include "hash_processor.h"
 #endif
@@ -460,6 +464,24 @@ static void test_sbu(const char *args) {
 }
 #endif
 
+#ifdef USE_HAPTIC
+static void test_haptic(const char *args) {
+  int duration_ms = atoi(args);
+
+  if (duration_ms <= 0) {
+    vcp_println("ERROR HAPTIC DURATION");
+    return;
+  }
+
+  if (haptic_test(duration_ms)) {
+    vcp_println("OK");
+
+  } else {
+    vcp_println("ERROR HAPTIC");
+  }
+}
+#endif
+
 static void test_otp_read(void) {
   uint8_t data[32];
   memzero(data, sizeof(data));
@@ -575,6 +597,9 @@ int main(void) {
 #ifdef USE_SBU
   sbu_init();
 #endif
+#ifdef USE_HAPTIC
+  haptic_init();
+#endif
   usb_init_all();
 
   mpu_config_prodtest_initial();
@@ -641,6 +666,10 @@ int main(void) {
 #ifdef USE_SBU
     } else if (startswith(line, "SBU ")) {
       test_sbu(line + 4);
+#endif
+#ifdef USE_HAPTIC
+    } else if (startswith(line, "HAPTIC ")) {
+      test_haptic(line + 7);
 #endif
 #ifdef USE_OPTIGA
     } else if (startswith(line, "OPTIGAID READ")) {

--- a/core/embed/trezorhal/haptic.h
+++ b/core/embed/trezorhal/haptic.h
@@ -2,6 +2,9 @@
 #ifndef TREZORHAL_HAPTIC_H
 #define TREZORHAL_HAPTIC_H
 
+#include <stdbool.h>
+#include <stdint.h>
+
 typedef enum {
   HAPTIC_BUTTON_PRESS = 0,
   HAPTIC_ALERT = 1,
@@ -13,6 +16,9 @@ void haptic_init(void);
 
 // Calibrate haptic driver
 void haptic_calibrate(void);
+
+// Test haptic driver, plays a maximum amplitude for the given duration
+bool haptic_test(uint16_t duration_ms);
 
 // Play haptic effect
 void haptic_play(haptic_effect_t effect);


### PR DESCRIPTION
This PR adds ability to test haptics in prodtest.

Simple `HAPTIC duration_ms` command is added, with a limit to 6500ms. 





<!--
If you are a core dev:

Don't forget to set up the fields:
- assign yourself
- set priority to same as original issue
- add PR to sprint
- if Draft -> "in progress"
- if final PR -> "needs review"

If you're an external contributor, you can ignore this text.
-->
