### PR TITLE
core: handle uncaught exceptions from main.py

### DIFF
--- a/core/embed/firmware/main.c
+++ b/core/embed/firmware/main.c
@@ -219,6 +219,9 @@ int main(void) {
   printf("CORE: Main script finished, cleaning up\n");
   mp_deinit();
 
+  // Python code shouldn't ever exit, avoid black screen if it does
+  error_shutdown("INTERNAL ERROR", "(PE)");
+
   return 0;
 }
 


### PR DESCRIPTION
Currently any exception that is not caught by an `except` block results in the hardware freezing with black screen (tested on Model T). We do define an unhandled exception callback but it doesn't seem to be used as the top-level exceptions are caught by [micropython C code](https://github.com/micropython/micropython/blob/v1.19.1/shared/runtime/pyexec.c#L129) which just does some cleanup and printing.

This PR adds a call to `error_shutdown` after returning from micropython. Other possibility would be to define `MICROPY_BOARD_AFTER_PYTHON_EXEC` micorpython hook.

<!--
If you are a core dev:

Don't forget to set up the fields:
- assign yourself
- set priority to same as original issue
- add PR to sprint
- if Draft -> "in progress"
- if final PR -> "needs review"

If you're an external contributor, you can ignore this text.
-->
