### PR TITLE
fix(core): fix sed script syntax

### DIFF
--- a/core/site_scons/site_tools/micropython/__init__.py
+++ b/core/site_scons/site_tools/micropython/__init__.py
@@ -58,7 +58,7 @@ def generate(env):
                 rf"-e 's/utils\.UI_LAYOUT == \"TR\"/{layout_tr}/g'",
                 r"-e 's/if TYPE_CHECKING/if False/'",
                 r"-e 's/import typing/# \0/'",
-                r"-e '/from typing import (/,/^\s*)/ {s/^/# /}'",
+                r"-e '/from typing import (/,/^\s*)/ {s/^/# /; }'",
                 r"-e 's/from typing import/# \0/'",
             ]
         )


### PR DESCRIPTION
When following the [Emulator Building](https://docs.trezor.io/trezor-firmware/core/build/embedded.html#building) instructions and running the
`make vendor build_boardloader build_bootloader build_firmware` command, this would invoke the `sed -e '/from typing import (/,/^\s*)/ {s/^/# /}` command. 

I would get the following errors as a result:
```
sed: 1: "/from typing import (/, ...": bad flag in substitute command: '}'
scons: *** [build/firmware/src/all_modules.mpy] Error 1
scons: *** [build/firmware/src/boot.mpy] Error 1
sed: 1: "/from typing import (/, ...": bad flag in substitute command: '}'
scons: *** [build/firmware/src/main.mpy] Error 1
make: *** [build_firmware] Error 2
```

Here is the `sed` command that resolved the issue `sed -e '/from typing import (/,/^\s*)/ {s/^/# /; }'`

Note the semicolon `;` before the closing curly brace `}`. This tells `sed` that the substitution command `(s/^/# /)` has ended before closing the range pattern.