### PR TITLE
Fix hardware build

### DIFF
--- a/core/SConscript.firmware
+++ b/core/SConscript.firmware
@@ -720,7 +720,7 @@ def cargo_build():
     features.append('ui')
     features.append('translations')
     if PYOPT == '0':
-        features.append('ui_debug')
+        features.append('debug')
 
     features.extend(FEATURES_AVAILABLE)
 


### PR DESCRIPTION
Adding missing `debug` feature, which was missing and causing development keys not being included for translations