### PR TITLE
configure option bytes on STM32U5

### DIFF
--- a/core/embed/boardloader/main.c
+++ b/core/embed/boardloader/main.c
@@ -106,7 +106,7 @@ void write_bootloader_min_version(uint8_t version) {
 }
 #endif
 
-struct BoardCapabilities capablities
+struct BoardCapabilities capabilities
     __attribute__((section(".capabilities_section"))) = {
         .header = CAPABILITIES_HEADER,
         .model_tag = TAG_MODEL_NAME,

--- a/core/embed/boardloader/main.c
+++ b/core/embed/boardloader/main.c
@@ -122,7 +122,7 @@ struct BoardCapabilities capablities
         .terminator_length = 0};
 
 // we use SRAM as SD card read buffer (because DMA can't access the CCMRAM)
-BUFFER_SECTION uint32_t sdcard_buf[IMAGE_HEADER_SIZE / sizeof(uint32_t)];
+BUFFER_SECTION uint32_t sdcard_buf[BOOTLOADER_IMAGE_MAXSIZE / sizeof(uint32_t)];
 
 #if defined USE_SD_CARD
 static uint32_t check_sdcard(void) {
@@ -138,8 +138,8 @@ static uint32_t check_sdcard(void) {
 
   memzero(sdcard_buf, IMAGE_HEADER_SIZE);
 
-  const secbool read_status =
-      sdcard_read_blocks(sdcard_buf, 0, IMAGE_HEADER_SIZE / SDCARD_BLOCK_SIZE);
+  const secbool read_status = sdcard_read_blocks(
+      sdcard_buf, 0, BOOTLOADER_IMAGE_MAXSIZE / SDCARD_BLOCK_SIZE);
 
   sdcard_power_off();
 
@@ -160,6 +160,21 @@ static uint32_t check_sdcard(void) {
                                           BOARDLOADER_KEY_N,
                                           BOARDLOADER_KEYS)) {
       return 0;
+    }
+
+    _Static_assert(IMAGE_CHUNK_SIZE >= BOOTLOADER_IMAGE_MAXSIZE,
+                   "BOOTLOADER IMAGE MAXSIZE too large for IMAGE_CHUNK_SIZE");
+
+    if (sectrue != (check_single_hash(
+                       hdr->hashes, ((const uint8_t *)sdcard_buf) + hdr->hdrlen,
+                       hdr->codelen))) {
+      return 0;
+    }
+
+    for (int i = IMAGE_HASH_DIGEST_LENGTH; i < sizeof(hdr->hashes); i++) {
+      if (hdr->hashes[i] != 0) {
+        return 0;
+      }
     }
 
 #ifdef STM32U5
@@ -212,24 +227,15 @@ static secbool copy_sdcard(void) {
   // copy bootloader from SD card to Flash
   term_printf("copying new bootloader from SD card\n\n");
 
-  ensure(sdcard_power_on(), NULL);
-
-  memzero(sdcard_buf, SDCARD_BLOCK_SIZE);
-
-  for (int i = 0; i < (IMAGE_HEADER_SIZE + codelen) / SDCARD_BLOCK_SIZE; i++) {
-    ensure(sdcard_read_blocks(sdcard_buf, i, 1), NULL);
-    for (int j = 0;
-         j < SDCARD_BLOCK_SIZE / (FLASH_BURST_LENGTH * sizeof(uint32_t)); j++) {
-      ensure(
-          flash_area_write_burst(
-              &BOOTLOADER_AREA,
-              i * SDCARD_BLOCK_SIZE + j * FLASH_BURST_LENGTH * sizeof(uint32_t),
-              &sdcard_buf[j * FLASH_BURST_LENGTH]),
-          NULL);
-    }
+  for (int j = 0; j < (IMAGE_HEADER_SIZE + codelen) /
+                          (FLASH_BURST_LENGTH * sizeof(uint32_t));
+       j++) {
+    ensure(flash_area_write_burst(&BOOTLOADER_AREA,
+                                  j * FLASH_BURST_LENGTH * sizeof(uint32_t),
+                                  &sdcard_buf[j * FLASH_BURST_LENGTH]),
+           NULL);
   }
 
-  sdcard_power_off();
   ensure(flash_lock_write(), NULL);
 
   term_printf("\ndone\n\n");

--- a/core/embed/boardloader/memory_stm32f4.ld
+++ b/core/embed/boardloader/memory_stm32f4.ld
@@ -48,6 +48,11 @@ SECTIONS {
     . = ALIGN(4); /* make the section size a multiple of the word size */
   } >CCMRAM
 
+  .buf : ALIGN(4) {
+    *(.buf*);
+    . = ALIGN(4);
+  } >SRAM
+
   /* Hard-coded address for capabilities structure */
   .capabilities 0x0800BF00 : {KEEP(*(.capabilities_section))}
 

--- a/core/embed/bootloader/main.c
+++ b/core/embed/bootloader/main.c
@@ -430,6 +430,10 @@ int bootloader_main(void) {
 
   display_reinit();
 
+#ifdef STM32U5
+  ensure(secret_ensure_initialized(), "secret reinitialized");
+#endif
+
   ui_screen_boot_empty(false);
 
   mpu_config_bootloader();

--- a/core/embed/bootloader/main.c
+++ b/core/embed/bootloader/main.c
@@ -411,20 +411,6 @@ int bootloader_main(void) {
   set_core_clock(CLOCK_180_MHZ);
 #endif
 
-#ifdef STM32U5
-  if (sectrue != flash_configure_sec_area_ob()) {
-#ifdef STM32U5
-    secret_bhk_regenerate();
-#endif
-
-    const secbool r =
-        flash_area_erase_bulk(STORAGE_AREAS, STORAGE_AREAS_COUNT, NULL);
-    (void)r;
-    __disable_irq();
-    HAL_NVIC_SystemReset();
-  }
-#endif
-
 #ifdef USE_HASH_PROCESSOR
   hash_processor_init();
 #endif

--- a/core/embed/lib/buffers.h
+++ b/core/embed/lib/buffers.h
@@ -45,7 +45,7 @@
 // sometimes
 #define JPEG_WORK_SIZE (3100 + 256 + (6 << 10) + 1000)
 
-#if defined BOOTLOADER
+#if defined BOOTLOADER || defined BOARDLOADER
 #define BUFFER_SECTION __attribute__((section(".buf")))
 #else
 #define BUFFER_SECTION

--- a/core/embed/trezorhal/lowlevel.h
+++ b/core/embed/trezorhal/lowlevel.h
@@ -27,7 +27,6 @@ void flash_lock_option_bytes(void);
 void flash_unlock_option_bytes(void);
 uint32_t flash_set_option_bytes(void);
 secbool flash_configure_option_bytes(void);
-secbool flash_configure_sec_area_ob(void);
 void periph_init(void);
 secbool reset_flags_check(void);
 void reset_flags_reset(void);

--- a/core/embed/trezorhal/secret.h
+++ b/core/embed/trezorhal/secret.h
@@ -21,6 +21,10 @@ secbool secret_read(uint8_t* data, uint32_t offset, uint32_t len);
 
 secbool secret_wiped(void);
 
+secbool secret_verify_header(void);
+
+secbool secret_ensure_initialized(void);
+
 void secret_erase(void);
 
 void secret_hide(void);

--- a/core/embed/trezorhal/stm32f4/secret.c
+++ b/core/embed/trezorhal/stm32f4/secret.c
@@ -7,14 +7,17 @@
 static secbool bootloader_locked_set = secfalse;
 static secbool bootloader_locked = secfalse;
 
-static secbool verify_header(void) {
-  uint8_t header[SECRET_HEADER_LEN] = {0};
+secbool secret_verify_header(void) {
+  uint8_t header[sizeof(SECRET_HEADER_MAGIC)] = {0};
 
-  memcpy(header, flash_area_get_address(&SECRET_AREA, 0, SECRET_HEADER_LEN),
-         SECRET_HEADER_LEN);
+  memcpy(header,
+         flash_area_get_address(&SECRET_AREA, 0, sizeof(SECRET_HEADER_MAGIC)),
+         sizeof(SECRET_HEADER_MAGIC));
 
   bootloader_locked =
-      memcmp(header, SECRET_HEADER_MAGIC, 4) == 0 ? sectrue : secfalse;
+      memcmp(header, SECRET_HEADER_MAGIC, sizeof(SECRET_HEADER_MAGIC)) == 0
+          ? sectrue
+          : secfalse;
   bootloader_locked_set = sectrue;
   return bootloader_locked;
 }
@@ -22,7 +25,7 @@ static secbool verify_header(void) {
 secbool secret_bootloader_locked(void) {
   if (bootloader_locked_set != sectrue) {
     // Set bootloader_locked.
-    verify_header();
+    secret_verify_header();
   }
 
   return bootloader_locked;
@@ -44,7 +47,7 @@ void secret_write(uint8_t* data, uint32_t offset, uint32_t len) {
 }
 
 secbool secret_read(uint8_t* data, uint32_t offset, uint32_t len) {
-  if (sectrue != verify_header()) {
+  if (sectrue != secret_verify_header()) {
     return secfalse;
   }
 

--- a/core/vendor/cmsis_5
+++ b/core/vendor/cmsis_5
@@ -1,0 +1,1 @@
+../../vendor/cmsis_5

--- a/core/vendor/cmsis_device_u5
+++ b/core/vendor/cmsis_device_u5
@@ -1,0 +1,1 @@
+../../vendor/cmsis_device_u5/


### PR DESCRIPTION
-fixes option bytes configuration on STM32U5
- improves robustness of BHK handling on STM32U5
- fixes missing symlinks


<!--
If you are a core dev:

Don't forget to set up the fields:
- assign yourself
- set priority to same as original issue
- add PR to sprint
- if Draft -> "in progress"
- if final PR -> "needs review"

If you're an external contributor, you can ignore this text.
-->
