### PR TITLE
U5: place sensitive variables to confidential section

### DIFF
--- a/core/SConscript.boardloader
+++ b/core/SConscript.boardloader
@@ -168,7 +168,7 @@ program_bin = env.Command(
     target='boardloader.bin',
     source=program_elf,
     action=[
-        '$OBJCOPY -O binary -j .vector_table -j .text -j .data -j .rodata -j .capabilities -j .sensitive $SOURCE $TARGET',
+        '$OBJCOPY -O binary -j .vector_table -j .text -j .data -j .rodata -j .capabilities -j .confidential $SOURCE $TARGET',
         '$CP $TARGET ' + BINARY_NAME,
     ],
 )

--- a/core/SConscript.bootloader
+++ b/core/SConscript.bootloader
@@ -274,7 +274,7 @@ program_bin = env.Command(
     target='bootloader.bin',
     source=program_elf,
     action=[
-        '$OBJCOPY -O binary -j .header -j .flash -j .data -j .sensitive $SOURCE $TARGET',
+        '$OBJCOPY -O binary -j .header -j .flash -j .data -j .confidential $SOURCE $TARGET',
         '$HEADERTOOL $TARGET ' + ('-D' if not PRODUCTION else ''),
         '$CP $TARGET ' + BINARY_NAME,
     ], )

--- a/core/SConscript.bootloader_ci
+++ b/core/SConscript.bootloader_ci
@@ -214,7 +214,7 @@ program_bin = env.Command(
     target='bootloader.bin',
     source=program_elf,
     action=[
-        '$OBJCOPY -O binary -j .header -j .flash -j .data -j .sensitive $SOURCE $TARGET',
+        '$OBJCOPY -O binary -j .header -j .flash -j .data -j .confidential $SOURCE $TARGET',
         '$HEADERTOOL $TARGET ' + ('-D' if ARGUMENTS.get('PRODUCTION', '0') == '0' else ''),
         '$CP $TARGET ' + BINARY_NAME,
     ], )

--- a/core/SConscript.bootloader_emu
+++ b/core/SConscript.bootloader_emu
@@ -158,7 +158,7 @@ tools.add_font('DEMIBOLD', FONT_DEMIBOLD, CPPDEFINES_MOD, SOURCE_MOD)
 tools.add_font('MONO', FONT_MONO, CPPDEFINES_MOD, SOURCE_MOD)
 tools.add_font('BIG', FONT_BIG, CPPDEFINES_MOD, SOURCE_MOD)
 
-env = Environment(ENV=os.environ, CFLAGS='%s -DPRODUCTION=%s' % (ARGUMENTS.get('CFLAGS', ''), ARGUMENTS.get('PRODUCTION', '0')))
+env = Environment(ENV=os.environ, CFLAGS='%s -DCONFIDENTIAL= -DPRODUCTION=%s' % (ARGUMENTS.get('CFLAGS', ''), ARGUMENTS.get('PRODUCTION', '0')))
 
 env.Replace(
     CP='cp',

--- a/core/SConscript.firmware
+++ b/core/SConscript.firmware
@@ -865,14 +865,14 @@ BINARY_NAME += ".bin"
 
 if TREZOR_MODEL in ('1'):
     action_bin=[
-        '$OBJCOPY -O binary -j .header -j .flash -j .data -j .sensitive $SOURCE $TARGET',
+        '$OBJCOPY -O binary -j .header -j .flash -j .data -j .confidential $SOURCE $TARGET',
         '../legacy/bootloader/firmware_sign.py -f $TARGET',
         '$CP $TARGET ' + BINARY_NAME,
     ]
 else:
     if 'STM32F427xx' in CPPDEFINES_HAL or 'STM32F429xx' in CPPDEFINES_HAL:
         action_bin=[
-            '$OBJCOPY -O binary -j .vendorheader -j .header -j .flash -j .data -j .sensitive --pad-to 0x08100000 $SOURCE ${TARGET}.p1',
+            '$OBJCOPY -O binary -j .vendorheader -j .header -j .flash -j .data -j .confidential --pad-to 0x08100000 $SOURCE ${TARGET}.p1',
             '$OBJCOPY -O binary -j .flash2 $SOURCE ${TARGET}.p2',
             '$CAT ${TARGET}.p1 ${TARGET}.p2 > $TARGET',
             '$HEADERTOOL -h $TARGET ' + ('-D' if not PRODUCTION else ''),
@@ -881,7 +881,7 @@ else:
         ]
     elif 'STM32U5A9xx' in CPPDEFINES_HAL or 'STM32U585xx' in CPPDEFINES_HAL:
         action_bin=[
-            '$OBJCOPY -O binary -j .vendorheader -j .header -j .flash -j .data -j .sensitive $SOURCE ${TARGET}',
+            '$OBJCOPY -O binary -j .vendorheader -j .header -j .flash -j .data -j .confidential $SOURCE ${TARGET}',
             '$HEADERTOOL -h $TARGET ' + ('-D' if not PRODUCTION else ''),
             '$CP $TARGET ' + BINARY_NAME,
             ]

--- a/core/SConscript.prodtest
+++ b/core/SConscript.prodtest
@@ -232,7 +232,7 @@ program_bin = env.Command(
     target='prodtest.bin',
     source=program_elf,
     action=[
-        '$OBJCOPY -O binary -j .vendorheader -j .header -j .flash -j .data -j .sensitive $SOURCE $TARGET',
+        '$OBJCOPY -O binary -j .vendorheader -j .header -j .flash -j .data -j .confidential $SOURCE $TARGET',
         '$HEADERTOOL $TARGET ' + ('-D' if ARGUMENTS.get('PRODUCTION', '0') == '0' else ''),
         '$CP $TARGET ' + BINARY_NAME,
     ], )

--- a/core/SConscript.reflash
+++ b/core/SConscript.reflash
@@ -190,7 +190,7 @@ program_bin = env.Command(
     target='reflash.bin',
     source=program_elf,
     action=[
-        '$OBJCOPY -O binary -j .vendorheader -j .header -j .flash -j .data -j .sensitive $SOURCE $TARGET',
+        '$OBJCOPY -O binary -j .vendorheader -j .header -j .flash -j .data -j .confidential $SOURCE $TARGET',
         '$HEADERTOOL $TARGET ' + ('-D' if ARGUMENTS.get('PRODUCTION', '0') == '0' else ''),
         '$CP $TARGET ' + BINARY_NAME,
     ], )

--- a/core/SConscript.unix
+++ b/core/SConscript.unix
@@ -450,7 +450,7 @@ if PYOPT == '0' or not FROZEN:
 else:
     STATIC=""
 
-env = Environment(ENV=os.environ, CFLAGS='%s -DPYOPT=%s -DBITCOIN_ONLY=%s %s' % (ARGUMENTS.get('CFLAGS', ''), PYOPT, BITCOIN_ONLY, STATIC))
+env = Environment(ENV=os.environ, CFLAGS='%s -DCONFIDENTIAL= -DPYOPT=%s -DBITCOIN_ONLY=%s %s' % (ARGUMENTS.get('CFLAGS', ''), PYOPT, BITCOIN_ONLY, STATIC))
 
 
 if TREZOR_MODEL in ('T', 'T3T1'):

--- a/core/embed/boardloader/memory_stm32u58.ld
+++ b/core/embed/boardloader/memory_stm32u58.ld
@@ -23,9 +23,9 @@ data_vma = ADDR(.data);
 data_size = SIZEOF(.data);
 
 /* used by the startup code to populate variables used by the C code */
-sensitive_lma = LOADADDR(.sensitive);
-sensitive_vma = ADDR(.sensitive);
-sensitive_size = SIZEOF(.sensitive);
+confidential_lma = LOADADDR(.confidential);
+confidential_vma = ADDR(.confidential);
+confidential_size = SIZEOF(.confidential);
 
 /* used by the startup code to wipe memory */
 sram1_start = ORIGIN(SRAM1);
@@ -83,8 +83,8 @@ SECTIONS {
     . = 16K; /* Overflow causes UsageFault */
   } >SRAM2
 
-  .sensitive : ALIGN(8) {
-    *(.sensitive*);
+  .confidential : ALIGN(8) {
+    *(.confidential*);
     . = ALIGN(4);
   } >SRAM2 AT>FLASH
 

--- a/core/embed/boardloader/memory_stm32u5a.ld
+++ b/core/embed/boardloader/memory_stm32u5a.ld
@@ -23,9 +23,9 @@ data_vma = ADDR(.data);
 data_size = SIZEOF(.data);
 
 /* used by the startup code to populate variables used by the C code */
-sensitive_lma = LOADADDR(.sensitive);
-sensitive_vma = ADDR(.sensitive);
-sensitive_size = SIZEOF(.sensitive);
+confidential_lma = LOADADDR(.confidential);
+confidential_vma = ADDR(.confidential);
+confidential_size = SIZEOF(.confidential);
 
 /* used by the startup code to wipe memory */
 sram1_start = ORIGIN(SRAM1);
@@ -83,8 +83,8 @@ SECTIONS {
     . = 16K; /* Overflow causes UsageFault */
   } >SRAM2
 
-  .sensitive : ALIGN(8) {
-    *(.sensitive*);
+  .confidential : ALIGN(8) {
+    *(.confidential*);
     . = ALIGN(4);
   } >SRAM2 AT>FLASH
 

--- a/core/embed/boardloader/startup_stm32u5.s
+++ b/core/embed/boardloader/startup_stm32u5.s
@@ -23,7 +23,7 @@ reset_handler:
   bl rng_read
   mov r4, r0            // save TRNG output in r4
 
-  // wipe memory to remove any possible vestiges of sensitive data
+  // wipe memory to remove any possible vestiges of confidential data
 
 
 fill_ram:
@@ -88,10 +88,10 @@ clear_ram:
   ldr r2, =data_size    // size in bytes
   bl memcpy
 
-  // copy sensitive data in from flash
-  ldr r0, =sensitive_vma     // dst addr
-  ldr r1, =sensitive_lma     // src addr
-  ldr r2, =sensitive_size    // size in bytes
+  // copy confidential data in from flash
+  ldr r0, =confidential_vma     // dst addr
+  ldr r1, =confidential_lma     // src addr
+  ldr r2, =confidential_size    // size in bytes
   bl memcpy
 
   // setup the stack protector (see build script "-fstack-protector-all") with an unpredictable value

--- a/core/embed/bootloader/main.c
+++ b/core/embed/bootloader/main.c
@@ -87,8 +87,8 @@ typedef enum {
 
 void failed_jump_to_firmware(void);
 
-SENSITIVE volatile secbool dont_optimize_out_true = sectrue;
-SENSITIVE volatile void (*firmware_jump_fn)(void) = failed_jump_to_firmware;
+CONFIDENTIAL volatile secbool dont_optimize_out_true = sectrue;
+CONFIDENTIAL volatile void (*firmware_jump_fn)(void) = failed_jump_to_firmware;
 
 static void usb_init_all(secbool usb21_landing) {
   usb_dev_info_t dev_info = {

--- a/core/embed/bootloader/memory_stm32u58.ld
+++ b/core/embed/bootloader/memory_stm32u58.ld
@@ -23,9 +23,9 @@ data_vma = ADDR(.data);
 data_size = SIZEOF(.data);
 
 /* used by the startup code to populate variables used by the C code */
-sensitive_lma = LOADADDR(.sensitive);
-sensitive_vma = ADDR(.sensitive);
-sensitive_size = SIZEOF(.sensitive);
+confidential_lma = LOADADDR(.confidential);
+confidential_vma = ADDR(.confidential);
+confidential_size = SIZEOF(.confidential);
 
 /* used by the startup code to wipe memory */
 sram1_start = ORIGIN(SRAM1);
@@ -45,7 +45,7 @@ sram6_end = ORIGIN(SRAM6) + LENGTH(SRAM6);
 boot_args_start = ORIGIN(BOOT_ARGS);
 boot_args_end = ORIGIN(BOOT_ARGS) + LENGTH(BOOT_ARGS);
 
-_codelen = SIZEOF(.flash) + SIZEOF(.data) + SIZEOF(.sensitive);
+_codelen = SIZEOF(.flash) + SIZEOF(.data) + SIZEOF(.confidential);
 
 SECTIONS {
   .header : ALIGN(4) {
@@ -84,8 +84,8 @@ SECTIONS {
     . = 16K; /* Overflow causes UsageFault */
   } >SRAM2
 
-  .sensitive : ALIGN(512) {
-    *(.sensitive*);
+  .confidential : ALIGN(512) {
+    *(.confidential*);
     . = ALIGN(512);
   } >SRAM2 AT>FLASH
 

--- a/core/embed/bootloader/memory_stm32u5a.ld
+++ b/core/embed/bootloader/memory_stm32u5a.ld
@@ -23,9 +23,9 @@ data_vma = ADDR(.data);
 data_size = SIZEOF(.data);
 
 /* used by the startup code to populate variables used by the C code */
-sensitive_lma = LOADADDR(.sensitive);
-sensitive_vma = ADDR(.sensitive);
-sensitive_size = SIZEOF(.sensitive);
+confidential_lma = LOADADDR(.confidential);
+confidential_vma = ADDR(.confidential);
+confidential_size = SIZEOF(.confidential);
 
 /* used by the startup code to wipe memory */
 sram1_start = ORIGIN(SRAM1);
@@ -45,7 +45,7 @@ sram6_end = ORIGIN(SRAM6) + LENGTH(SRAM6);
 boot_args_start = ORIGIN(BOOT_ARGS);
 boot_args_end = ORIGIN(BOOT_ARGS) + LENGTH(BOOT_ARGS);
 
-_codelen = SIZEOF(.flash) + SIZEOF(.data) + SIZEOF(.sensitive);
+_codelen = SIZEOF(.flash) + SIZEOF(.data) + SIZEOF(.confidential);
 
 SECTIONS {
   .header : ALIGN(4) {
@@ -84,8 +84,8 @@ SECTIONS {
     . = 16K; /* Overflow causes UsageFault */
   } >SRAM2
 
-  .sensitive : ALIGN(512) {
-    *(.sensitive*);
+  .confidential : ALIGN(512) {
+    *(.confidential*);
     . = ALIGN(512);
   } >SRAM2 AT>FLASH
 

--- a/core/embed/bootloader/startup_stm32u5.s
+++ b/core/embed/bootloader/startup_stm32u5.s
@@ -43,10 +43,10 @@ reset_handler:
   ldr r2, =data_size    // size in bytes
   bl memcpy
 
-  // copy sensitive data in from flash
-  ldr r0, =sensitive_vma     // dst addr
-  ldr r1, =sensitive_lma     // src addr
-  ldr r2, =sensitive_size    // size in bytes
+  // copy confidential data in from flash
+  ldr r0, =confidential_vma     // dst addr
+  ldr r1, =confidential_lma     // src addr
+  ldr r2, =confidential_size    // size in bytes
   bl memcpy
 
   // setup the stack protector (see build script "-fstack-protector-all") with an unpredictable value

--- a/core/embed/bootloader_ci/memory_stm32u58.ld
+++ b/core/embed/bootloader_ci/memory_stm32u58.ld
@@ -23,9 +23,9 @@ data_vma = ADDR(.data);
 data_size = SIZEOF(.data);
 
 /* used by the startup code to populate variables used by the C code */
-sensitive_lma = LOADADDR(.sensitive);
-sensitive_vma = ADDR(.sensitive);
-sensitive_size = SIZEOF(.sensitive);
+confidential_lma = LOADADDR(.confidential);
+confidential_vma = ADDR(.confidential);
+confidential_size = SIZEOF(.confidential);
 
 /* used by the startup code to wipe memory */
 sram1_start = ORIGIN(SRAM1);
@@ -45,7 +45,7 @@ sram6_end = ORIGIN(SRAM6) + LENGTH(SRAM6);
 boot_args_start = ORIGIN(BOOT_ARGS);
 boot_args_end = ORIGIN(BOOT_ARGS) + LENGTH(BOOT_ARGS);
 
-_codelen = SIZEOF(.flash) + SIZEOF(.data) + SIZEOF(.sensitive);
+_codelen = SIZEOF(.flash) + SIZEOF(.data) + SIZEOF(.confidential);
 
 SECTIONS {
   .header : ALIGN(4) {
@@ -84,8 +84,8 @@ SECTIONS {
     . = 16K; /* Exactly 16K allocated for stack. Overflow causes Usage fault. */
   } >SRAM2
 
-  .sensitive : ALIGN(512) {
-    *(.sensitive*);
+  .confidential : ALIGN(512) {
+    *(.confidential*);
     . = ALIGN(512);
   } >SRAM2 AT>FLASH
 

--- a/core/embed/bootloader_ci/memory_stm32u5a.ld
+++ b/core/embed/bootloader_ci/memory_stm32u5a.ld
@@ -23,9 +23,9 @@ data_vma = ADDR(.data);
 data_size = SIZEOF(.data);
 
 /* used by the startup code to populate variables used by the C code */
-sensitive_lma = LOADADDR(.sensitive);
-sensitive_vma = ADDR(.sensitive);
-sensitive_size = SIZEOF(.sensitive);
+confidential_lma = LOADADDR(.confidential);
+confidential_vma = ADDR(.confidential);
+confidential_size = SIZEOF(.confidential);
 
 /* used by the startup code to wipe memory */
 sram1_start = ORIGIN(SRAM1);
@@ -45,7 +45,7 @@ sram6_end = ORIGIN(SRAM6) + LENGTH(SRAM6);
 boot_args_start = ORIGIN(BOOT_ARGS);
 boot_args_end = ORIGIN(BOOT_ARGS) + LENGTH(BOOT_ARGS);
 
-_codelen = SIZEOF(.flash) + SIZEOF(.data) + SIZEOF(.sensitive);
+_codelen = SIZEOF(.flash) + SIZEOF(.data) + SIZEOF(.confidential);
 
 SECTIONS {
   .header : ALIGN(4) {
@@ -84,8 +84,8 @@ SECTIONS {
     . = 16K; /* Overflow causes UsageFault */
   } >SRAM2
 
-  .sensitive : ALIGN(512) {
-    *(.sensitive*);
+  .confidential : ALIGN(512) {
+    *(.confidential*);
     . = ALIGN(512);
   } >SRAM2 AT>FLASH
 

--- a/core/embed/bootloader_ci/startup_stm32u5.s
+++ b/core/embed/bootloader_ci/startup_stm32u5.s
@@ -43,10 +43,10 @@ reset_handler:
   ldr r2, =data_size    // size in bytes
   bl memcpy
 
-  // copy sensitive data in from flash
-  ldr r0, =sensitive_vma     // dst addr
-  ldr r1, =sensitive_lma     // src addr
-  ldr r2, =sensitive_size    // size in bytes
+  // copy confidential data in from flash
+  ldr r0, =confidential_vma     // dst addr
+  ldr r1, =confidential_lma     // src addr
+  ldr r2, =confidential_size    // size in bytes
   bl memcpy
 
   // setup the stack protector (see build script "-fstack-protector-all") with an unpredictable value

--- a/core/embed/firmware/memory_DISC2.ld
+++ b/core/embed/firmware/memory_DISC2.ld
@@ -23,9 +23,9 @@ data_vma = ADDR(.data);
 data_size = SIZEOF(.data);
 
 /* used by the startup code to populate variables used by the C code */
-sensitive_lma = LOADADDR(.sensitive);
-sensitive_vma = ADDR(.sensitive);
-sensitive_size = SIZEOF(.sensitive);
+confidential_lma = LOADADDR(.confidential);
+confidential_vma = ADDR(.confidential);
+confidential_size = SIZEOF(.confidential);
 
 /* used by the startup code to wipe memory */
 sram1_start = ORIGIN(SRAM1);
@@ -45,7 +45,7 @@ sram6_end = ORIGIN(SRAM6) + LENGTH(SRAM6);
 boot_args_start = ORIGIN(BOOT_ARGS);
 boot_args_end = ORIGIN(BOOT_ARGS) + LENGTH(BOOT_ARGS);
 
-_codelen = SIZEOF(.flash) + SIZEOF(.data) + SIZEOF(.sensitive);
+_codelen = SIZEOF(.flash) + SIZEOF(.data) + SIZEOF(.confidential);
 _flash_start = ORIGIN(FLASH);
 _flash_end = ORIGIN(FLASH) + LENGTH(FLASH);
 _heap_start = ADDR(.heap);
@@ -100,8 +100,8 @@ SECTIONS {
     . = 16K; /* Overflow causes UsageFault */
   } >SRAM2
 
-  .sensitive : ALIGN(512) {
-    *(.sensitive*);
+  .confidential : ALIGN(512) {
+    *(.confidential*);
     . = ALIGN(512);
   } >SRAM2 AT>FLASH
 

--- a/core/embed/firmware/memory_T3T1.ld
+++ b/core/embed/firmware/memory_T3T1.ld
@@ -23,9 +23,9 @@ data_vma = ADDR(.data);
 data_size = SIZEOF(.data);
 
 /* used by the startup code to populate variables used by the C code */
-sensitive_lma = LOADADDR(.sensitive);
-sensitive_vma = ADDR(.sensitive);
-sensitive_size = SIZEOF(.sensitive);
+confidential_lma = LOADADDR(.confidential);
+confidential_vma = ADDR(.confidential);
+confidential_size = SIZEOF(.confidential);
 
 /* used by the startup code to wipe memory */
 sram1_start = ORIGIN(SRAM1);
@@ -45,7 +45,7 @@ sram6_end = ORIGIN(SRAM6) + LENGTH(SRAM6);
 boot_args_start = ORIGIN(BOOT_ARGS);
 boot_args_end = ORIGIN(BOOT_ARGS) + LENGTH(BOOT_ARGS);
 
-_codelen = SIZEOF(.flash) + SIZEOF(.data) + SIZEOF(.sensitive);
+_codelen = SIZEOF(.flash) + SIZEOF(.data) + SIZEOF(.confidential);
 _flash_start = ORIGIN(FLASH);
 _flash_end = ORIGIN(FLASH) + LENGTH(FLASH);
 _heap_start = ADDR(.heap);
@@ -82,6 +82,7 @@ SECTIONS {
   }
 
   .bss : ALIGN(4) {
+    *(.no_dma_buffers*);
     *(.bss*);
     . = ALIGN(4);
   } >SRAM1
@@ -95,8 +96,8 @@ SECTIONS {
     . = 16K; /* Overflow causes UsageFault */
   } >SRAM2
 
-  .sensitive : ALIGN(512) {
-    *(.sensitive*);
+  .confidential : ALIGN(512) {
+    *(.confidential*);
     . = ALIGN(512);
   } >SRAM2 AT>FLASH
 

--- a/core/embed/firmware/startup_stm32u5.S
+++ b/core/embed/firmware/startup_stm32u5.S
@@ -47,10 +47,10 @@ reset_handler:
   ldr r2, =data_size    // size in bytes
   bl memcpy
 
-  // copy sensitive data in from flash
-  ldr r0, =sensitive_vma     // dst addr
-  ldr r1, =sensitive_lma     // src addr
-  ldr r2, =sensitive_size    // size in bytes
+  // copy confidential data in from flash
+  ldr r0, =confidential_vma     // dst addr
+  ldr r1, =confidential_lma     // src addr
+  ldr r2, =confidential_size    // size in bytes
   bl memcpy
 
   // setup the stack protector (see build script "-fstack-protector-all") with an unpredictable value

--- a/core/embed/prodtest/memory_stm32u58.ld
+++ b/core/embed/prodtest/memory_stm32u58.ld
@@ -3,7 +3,7 @@
 ENTRY(reset_handler)
 
 MEMORY {
-  FLASH  (rx)  : ORIGIN = 0x0C050000, LENGTH = 3648K
+  FLASH  (rx)  : ORIGIN = 0x0C050000, LENGTH = 1664K
   SRAM1  (wal) : ORIGIN = 0x30000000, LENGTH =  192K - 0x100
   BOOT_ARGS  (wal) : ORIGIN = 0x3002FF00, LENGTH =  0x100
   SRAM2  (wal) : ORIGIN = 0x30030000, LENGTH =  64K
@@ -23,9 +23,9 @@ data_vma = ADDR(.data);
 data_size = SIZEOF(.data);
 
 /* used by the startup code to populate variables used by the C code */
-sensitive_lma = LOADADDR(.sensitive);
-sensitive_vma = ADDR(.sensitive);
-sensitive_size = SIZEOF(.sensitive);
+confidential_lma = LOADADDR(.confidential);
+confidential_vma = ADDR(.confidential);
+confidential_size = SIZEOF(.confidential);
 
 /* used by the startup code to wipe memory */
 sram1_start = ORIGIN(SRAM1);
@@ -44,7 +44,8 @@ sram6_end = ORIGIN(SRAM6) + LENGTH(SRAM6);
 /* reserve 256 bytes for bootloader arguments */
 boot_args_start = ORIGIN(BOOT_ARGS);
 boot_args_end = ORIGIN(BOOT_ARGS) + LENGTH(BOOT_ARGS);
-_codelen = SIZEOF(.flash) + SIZEOF(.data) + SIZEOF(.sensitive);
+
+_codelen = SIZEOF(.flash) + SIZEOF(.data) + SIZEOF(.confidential);
 _flash_start = ORIGIN(FLASH);
 _flash_end = ORIGIN(FLASH) + LENGTH(FLASH);
 _heap_start = ADDR(.heap);
@@ -99,8 +100,8 @@ SECTIONS {
     . = 16K; /* Overflow causes UsageFault */
   } >SRAM2
 
-  .sensitive : ALIGN(512) {
-    *(.sensitive*);
+  .confidential : ALIGN(512) {
+    *(.confidential*);
     . = ALIGN(512);
   } >SRAM2 AT>FLASH
 

--- a/core/embed/prodtest/memory_stm32u5a.ld
+++ b/core/embed/prodtest/memory_stm32u5a.ld
@@ -23,9 +23,9 @@ data_vma = ADDR(.data);
 data_size = SIZEOF(.data);
 
 /* used by the startup code to populate variables used by the C code */
-sensitive_lma = LOADADDR(.sensitive);
-sensitive_vma = ADDR(.sensitive);
-sensitive_size = SIZEOF(.sensitive);
+confidential_lma = LOADADDR(.confidential);
+confidential_vma = ADDR(.confidential);
+confidential_size = SIZEOF(.confidential);
 
 /* used by the startup code to wipe memory */
 sram1_start = ORIGIN(SRAM1);
@@ -44,7 +44,7 @@ sram6_end = ORIGIN(SRAM6) + LENGTH(SRAM6);
 /* reserve 256 bytes for bootloader arguments */
 boot_args_start = ORIGIN(BOOT_ARGS);
 boot_args_end = ORIGIN(BOOT_ARGS) + LENGTH(BOOT_ARGS);
-_codelen = SIZEOF(.flash) + SIZEOF(.data) + SIZEOF(.sensitive);
+_codelen = SIZEOF(.flash) + SIZEOF(.data) + SIZEOF(.confidential);
 _flash_start = ORIGIN(FLASH);
 _flash_end = ORIGIN(FLASH) + LENGTH(FLASH);
 _heap_start = ADDR(.heap);
@@ -99,8 +99,8 @@ SECTIONS {
     . = 16K; /* Overflow causes UsageFault */
   } >SRAM2
 
-  .sensitive : ALIGN(512) {
-    *(.sensitive*);
+  .confidential : ALIGN(512) {
+    *(.confidential*);
     . = ALIGN(512);
   } >SRAM2 AT>FLASH
 

--- a/core/embed/prodtest/startup_stm32u5.s
+++ b/core/embed/prodtest/startup_stm32u5.s
@@ -47,10 +47,10 @@ reset_handler:
   ldr r2, =data_size    // size in bytes
   bl memcpy
 
-  // copy sensitive data in from flash
-  ldr r0, =sensitive_vma     // dst addr
-  ldr r1, =sensitive_lma     // src addr
-  ldr r2, =sensitive_size    // size in bytes
+  // copy confidential data in from flash
+  ldr r0, =confidential_vma     // dst addr
+  ldr r1, =confidential_lma     // src addr
+  ldr r2, =confidential_size    // size in bytes
   bl memcpy
 
   // setup the stack protector (see build script "-fstack-protector-all") with an unpredictable value

--- a/core/embed/reflash/memory_stm32u58.ld
+++ b/core/embed/reflash/memory_stm32u58.ld
@@ -23,9 +23,9 @@ data_vma = ADDR(.data);
 data_size = SIZEOF(.data);
 
 /* used by the startup code to populate variables used by the C code */
-sensitive_lma = LOADADDR(.sensitive);
-sensitive_vma = ADDR(.sensitive);
-sensitive_size = SIZEOF(.sensitive);
+confidential_lma = LOADADDR(.confidential);
+confidential_vma = ADDR(.confidential);
+confidential_size = SIZEOF(.confidential);
 
 /* used by the startup code to wipe memory */
 sram1_start = ORIGIN(SRAM1);
@@ -45,7 +45,7 @@ sram6_end = ORIGIN(SRAM6) + LENGTH(SRAM6);
 boot_args_start = ORIGIN(BOOT_ARGS);
 boot_args_end = ORIGIN(BOOT_ARGS) + LENGTH(BOOT_ARGS);
 
-_codelen = SIZEOF(.flash) + SIZEOF(.data) + SIZEOF(.sensitive);
+_codelen = SIZEOF(.flash) + SIZEOF(.data) + SIZEOF(.confidential);
 _flash_start = ORIGIN(FLASH);
 _flash_end = ORIGIN(FLASH) + LENGTH(FLASH);
 _heap_start = ADDR(.heap);
@@ -100,8 +100,8 @@ SECTIONS {
     . = 16K + 0x100; /* Overflow causes UsageFault */
   } >SRAM2
 
-  .sensitive : ALIGN(512) {
-    *(.sensitive*);
+  .confidential : ALIGN(512) {
+    *(.confidential*);
     . = ALIGN(512);
   } >SRAM2 AT>FLASH
 

--- a/core/embed/reflash/memory_stm32u5a.ld
+++ b/core/embed/reflash/memory_stm32u5a.ld
@@ -23,9 +23,9 @@ data_vma = ADDR(.data);
 data_size = SIZEOF(.data);
 
 /* used by the startup code to populate variables used by the C code */
-sensitive_lma = LOADADDR(.sensitive);
-sensitive_vma = ADDR(.sensitive);
-sensitive_size = SIZEOF(.sensitive);
+confidential_lma = LOADADDR(.confidential);
+confidential_vma = ADDR(.confidential);
+confidential_size = SIZEOF(.confidential);
 
 /* used by the startup code to wipe memory */
 sram1_start = ORIGIN(SRAM1);
@@ -45,7 +45,7 @@ sram6_end = ORIGIN(SRAM6) + LENGTH(SRAM6);
 boot_args_start = ORIGIN(BOOT_ARGS);
 boot_args_end = ORIGIN(BOOT_ARGS) + LENGTH(BOOT_ARGS);
 
-_codelen = SIZEOF(.flash) + SIZEOF(.data) + SIZEOF(.sensitive);
+_codelen = SIZEOF(.flash) + SIZEOF(.data) + SIZEOF(.confidential);
 _flash_start = ORIGIN(FLASH);
 _flash_end = ORIGIN(FLASH) + LENGTH(FLASH);
 _heap_start = ADDR(.heap);
@@ -100,8 +100,8 @@ SECTIONS {
     . = 16K + 0x100; /* Overflow causes UsageFault */
   } >SRAM2
 
-  .sensitive : ALIGN(512) {
-    *(.sensitive*);
+  .confidential : ALIGN(512) {
+    *(.confidential*);
     . = ALIGN(512);
   } >SRAM2 AT>FLASH
 

--- a/core/embed/reflash/startup_stm32u5.s
+++ b/core/embed/reflash/startup_stm32u5.s
@@ -47,10 +47,10 @@ reset_handler:
   ldr r2, =data_size    // size in bytes
   bl memcpy
 
-  // copy sensitive data in from flash
-  ldr r0, =sensitive_vma     // dst addr
-  ldr r1, =sensitive_lma     // src addr
-  ldr r2, =sensitive_size    // size in bytes
+  // copy confidential data in from flash
+  ldr r0, =confidential_vma     // dst addr
+  ldr r1, =confidential_lma     // src addr
+  ldr r2, =confidential_size    // size in bytes
   bl memcpy
 
   // setup the stack protector (see build script "-fstack-protector-all") with an unpredictable value

--- a/core/embed/trezorhal/stm32f4/platform.h
+++ b/core/embed/trezorhal/stm32f4/platform.h
@@ -23,8 +23,6 @@
 #include STM32_HAL_H
 #include <stdint.h>
 
-#define SENSITIVE
-
 typedef enum {
   CLOCK_180_MHZ = 0,
   CLOCK_168_MHZ = 1,

--- a/core/embed/trezorhal/stm32u5/platform.h
+++ b/core/embed/trezorhal/stm32u5/platform.h
@@ -23,8 +23,6 @@
 #include STM32_HAL_H
 #include <stdint.h>
 
-#define SENSITIVE __attribute__((section(".sensitive")))
-
 #define FLASH_QUADWORD_WORDS (4)
 #define FLASH_QUADWORD_SIZE (FLASH_QUADWORD_WORDS * sizeof(uint32_t))
 

--- a/core/embed/trezorhal/unix/platform.h
+++ b/core/embed/trezorhal/unix/platform.h
@@ -1,4 +1,2 @@
 
-#define SENSITIVE
-
 void emulator_poll_events(void);

--- a/core/site_scons/boards/stm32f4_common.py
+++ b/core/site_scons/boards/stm32f4_common.py
@@ -6,6 +6,7 @@ def stm32f4_common_files(env, defines, sources, paths):
         ("STM32_HAL_H", '"<stm32f4xx.h>"'),
         ("FLASH_BLOCK_WORDS", "1"),
         ("FLASH_BIT_ACCESS", "1"),
+        ("CONFIDENTIAL", ""),
     ]
 
     paths += [
@@ -76,6 +77,7 @@ def stm32f4_common_files(env, defines, sources, paths):
         "-DSTM32F4;"
         "-DFLASH_BLOCK_WORDS=1;"
         "-DFLASH_BIT_ACCESS=1;"
+        "-DCONFIDENTIAL;"
     )
 
     env.get("ENV")["SUFFIX"] = "stm32f4"

--- a/core/site_scons/boards/stm32u5_common.py
+++ b/core/site_scons/boards/stm32u5_common.py
@@ -5,6 +5,7 @@ def stm32u5_common_files(env, defines, sources, paths):
     defines += [
         ("STM32_HAL_H", '"<stm32u5xx.h>"'),
         ("FLASH_BLOCK_WORDS", "4"),
+        ("CONFIDENTIAL", "'__attribute__((section(\".confidential\")))'"),
     ]
 
     paths += [
@@ -89,6 +90,7 @@ def stm32u5_common_files(env, defines, sources, paths):
         "-DSTM32_HAL_H=<stm32u5xx.h>;"
         "-DSTM32U5;"
         "-DFLASH_BLOCK_WORDS=4;"
+        "-DCONFIDENTIAL;"
     )
 
     env.get("ENV")["SUFFIX"] = "stm32u5"

--- a/storage/norcow_blockwise.h
+++ b/storage/norcow_blockwise.h
@@ -52,11 +52,11 @@
  */
 
 // Buffer for update bytes function, used to avoid writing partial blocks
-static flash_block_t norcow_write_buffer = {0};
+CONFIDENTIAL static flash_block_t norcow_write_buffer = {0};
 // Tracks how much data is in the buffer, not yet flashed
-static uint16_t norcow_write_buffer_filled = 0;
+CONFIDENTIAL static uint16_t norcow_write_buffer_filled = 0;
 // Key of the item being updated, -1 if no update is in progress
-static int32_t norcow_write_buffer_key = -1;
+CONFIDENTIAL static int32_t norcow_write_buffer_key = -1;
 
 /*
  * Writes data to given sector, starting from offset

--- a/storage/storage.c
+++ b/storage/storage.c
@@ -137,18 +137,18 @@ const uint8_t WIPE_CODE_EMPTY[] = {0, 0, 0, 0};
 // The uint32 representation of an empty wipe code used in storage version 2.
 #define V2_WIPE_CODE_EMPTY 0
 
-static secbool initialized = secfalse;
-static secbool unlocked = secfalse;
+CONFIDENTIAL static secbool initialized = secfalse;
+CONFIDENTIAL static secbool unlocked = secfalse;
 static PIN_UI_WAIT_CALLBACK ui_callback = NULL;
 static uint32_t ui_total = 0;
 static uint32_t ui_rem = 0;
 static enum storage_ui_message_t ui_message = NO_MSG;
-static uint8_t cached_keys[KEYS_SIZE] = {0};
-static uint8_t *const cached_dek = cached_keys;
-static uint8_t *const cached_sak = cached_keys + DEK_SIZE;
-static uint8_t authentication_sum[SHA256_DIGEST_LENGTH] = {0};
-static uint8_t hardware_salt[HARDWARE_SALT_SIZE] = {0};
-static uint32_t norcow_active_version = 0;
+CONFIDENTIAL static uint8_t cached_keys[KEYS_SIZE] = {0};
+CONFIDENTIAL static uint8_t *const cached_dek = cached_keys;
+CONFIDENTIAL static uint8_t *const cached_sak = cached_keys + DEK_SIZE;
+CONFIDENTIAL uint8_t authentication_sum[SHA256_DIGEST_LENGTH] = {0};
+CONFIDENTIAL static uint8_t hardware_salt[HARDWARE_SALT_SIZE] = {0};
+CONFIDENTIAL static uint32_t norcow_active_version = 0;
 static const uint8_t TRUE_BYTE = 0x01;
 static const uint8_t FALSE_BYTE = 0x00;
 static const uint32_t TRUE_WORD = 0xC35A69A5;
@@ -1336,7 +1336,7 @@ void storage_wipe(void) {
 
 static void __handle_fault(const char *msg, const char *file, int line,
                            const char *func) {
-  static secbool in_progress = secfalse;
+  CONFIDENTIAL static secbool in_progress = secfalse;
 
   // If fault handling is already in progress, then we are probably facing a
   // fault injection attack, so wipe.
@@ -1420,7 +1420,7 @@ static uint32_t pin_to_int(const uint8_t *pin, size_t pin_len) {
 // Legacy conversion of wipe code from the uint32 scheme that was used prior to
 // storage version 3.
 static char *int_to_wipe_code(uint32_t val) {
-  static char wipe_code[V0_MAX_PIN_LEN + 1] = {0};
+  CONFIDENTIAL static char wipe_code[V0_MAX_PIN_LEN + 1] = {0};
   size_t pos = sizeof(wipe_code) - 1;
   wipe_code[pos] = '\0';
 

--- a/storage/tests/c/Makefile
+++ b/storage/tests/c/Makefile
@@ -5,6 +5,7 @@ CFLAGS += -fPIC
 CFALGS += -fsanitize=address,undefined
 CFLAGS += -DTREZOR_MODEL_T
 CFLAGS += -DUSE_INSECURE_PRNG
+CFLAGS += -DCONFIDENTIAL=""
 
 LIBS =
 INC = -I ../../../crypto -I ../.. -I .


### PR DESCRIPTION
The variables are placed into SRAM2, which is tamper and ECC protected.

Done regardless on initialization, uninitialized variables and zero initialized variables for take additional flash space. This can be mitigated in future by introducing something like `confidential_noinit` section and use that for such variales.

<!--
If you are a core dev:

Don't forget to set up the fields:
- assign yourself
- set priority to same as original issue
- add PR to sprint
- if Draft -> "in progress"
- if final PR -> "needs review"

If you're an external contributor, you can ignore this text.
-->
