### PR TITLE
allow T3T1 to start without touch during testing

### DIFF
--- a/core/embed/bootloader/main.c
+++ b/core/embed/bootloader/main.c
@@ -419,16 +419,28 @@ int bootloader_main(void) {
   i2c_init();
 #endif
 
-#ifdef USE_TOUCH
-  touch_power_on();
-  touch_init();
-#endif
+  display_reinit();
 
 #ifdef USE_DMA2D
   dma2d_init();
 #endif
 
-  display_reinit();
+  unit_variant_init();
+
+#ifdef USE_TOUCH
+  touch_power_on();
+#ifdef TREZOR_MODEL_T3T1
+  // on T3T1, tester needs to run without touch, so making an exception
+  // until unit variant is written in OTP
+  if (unit_variant_present()) {
+    ensure(touch_init(), "Touch screen panel was not loaded properly.");
+  } else {
+    touch_init();
+  }
+#else
+  ensure(touch_init(), "Touch screen panel was not loaded properly.");
+#endif
+#endif
 
 #ifdef STM32U5
   ensure(secret_ensure_initialized(), "secret reinitialized");
@@ -507,8 +519,6 @@ int bootloader_main(void) {
 #ifdef USE_RGB_LED
   rgb_led_init();
 #endif
-
-  unit_variant_init();
 
 #if PRODUCTION && !defined STM32U5
   // for STM32U5, this check is moved to boardloader

--- a/core/embed/trezorhal/stm32f4/touch/stmpe811.c
+++ b/core/embed/trezorhal/stm32f4/touch/stmpe811.c
@@ -470,7 +470,7 @@ void stmpe811_Reset() {
   IOE_Delay(2);
 }
 
-void touch_init(void) {
+secbool touch_init(void) {
   GPIO_InitTypeDef GPIO_InitStructure;
 
   __HAL_RCC_GPIOA_CLK_ENABLE();
@@ -486,9 +486,11 @@ void touch_init(void) {
   stmpe811_Reset();
   touch_set_mode();
   touch_sensitivity(0x06);
+
+  return sectrue;
 }
 
-void touch_sensitivity(uint8_t value) {
+secbool touch_sensitivity(uint8_t value) {
   // set panel threshold (TH_GROUP) - default value is 0x12
   //  uint8_t touch_panel_threshold[] = {0x80, value};
   //  ensure(sectrue *
@@ -496,6 +498,7 @@ void touch_sensitivity(uint8_t value) {
   //                         &I2c_handle, TOUCH_ADDRESS, touch_panel_threshold,
   //                         sizeof(touch_panel_threshold), 10)),
   //         NULL);
+  return sectrue;
 }
 
 uint32_t touch_is_detected(void) {

--- a/core/embed/trezorhal/stm32u5/common.c
+++ b/core/embed/trezorhal/stm32u5/common.c
@@ -49,6 +49,8 @@ uint32_t systick_val_copy = 0;
 extern void shutdown_privileged(void);
 
 void __attribute__((noreturn)) trezor_shutdown(void) {
+  display_finish_actions();
+
   __HAL_RCC_SAES_CLK_DISABLE();
   // Erase all secrets
   TAMP->CR2 |= TAMP_CR2_BKERASE;

--- a/core/embed/trezorhal/stm32u5/touch/sitronix.c
+++ b/core/embed/trezorhal/stm32u5/touch/sitronix.c
@@ -1135,7 +1135,7 @@ static int32_t SITRONIX_Probe(uint32_t Instance) {
 #include <string.h>
 #include "touch.h"
 
-void touch_init(void) {
+secbool touch_init(void) {
   TS_Init_t TsInit;
 
   /* Initialize the TouchScreen */
@@ -1145,10 +1145,12 @@ void touch_init(void) {
   TsInit.Accuracy = 10;
 
   BSP_TS_Init(0, &TsInit);
+
+  return sectrue;
 }
 void touch_power_on(void) {}
 void touch_power_off(void) {}
-void touch_sensitivity(uint8_t value) {}
+secbool touch_sensitivity(uint8_t value) { return sectrue; }
 
 uint32_t touch_is_detected(void) { return sitronix_touching != 0; }
 

--- a/core/embed/trezorhal/touch.h
+++ b/core/embed/trezorhal/touch.h
@@ -2,17 +2,18 @@
 #define _TOUCH_H
 
 #include <stdint.h>
+#include "secbool.h"
 
 #define TOUCH_START (1U << 24)
 #define TOUCH_MOVE (1U << 25)
 #define TOUCH_END (1U << 26)
 
-void touch_init(void);
+secbool touch_init(void);
 void touch_power_on(void);
 void touch_power_off(void);
 void touch_wait_until_ready(void);
 
-void touch_sensitivity(uint8_t value);
+secbool touch_sensitivity(uint8_t value);
 uint32_t touch_read(void);
 uint32_t touch_click(void);
 uint32_t touch_is_detected(void);

--- a/core/embed/trezorhal/unix/touch/touch.c
+++ b/core/embed/trezorhal/unix/touch/touch.c
@@ -217,7 +217,7 @@ uint32_t touch_read(void) {
   return ev_type | touch_pack_xy(ev_x, ev_y);
 }
 
-void touch_init(void) {}
+secbool touch_init(void) { return sectrue; }
 void touch_power_on(void) {}
 void touch_wait_until_ready(void) {}
 


### PR DESCRIPTION
Correct touch initialization is not enforced until unit variant is written, which is done later in production when display+touch is already present.

<!--
If you are a core dev:

Don't forget to set up the fields:
- assign yourself
- set priority to same as original issue
- add PR to sprint
- if Draft -> "in progress"
- if final PR -> "needs review"

If you're an external contributor, you can ignore this text.
-->
