### PR TITLE
use U5 HW keys for additional storage encryption

### DIFF
--- a/core/embed/bootloader/main.c
+++ b/core/embed/bootloader/main.c
@@ -442,10 +442,6 @@ int bootloader_main(void) {
 #endif
 #endif
 
-#ifdef STM32U5
-  ensure(secret_ensure_initialized(), "secret reinitialized");
-#endif
-
   ui_screen_boot_empty(false);
 
   mpu_config_bootloader();

--- a/core/embed/firmware/main.c
+++ b/core/embed/firmware/main.c
@@ -141,9 +141,13 @@ int main(void) {
 
   unit_variant_init();
 
+#ifdef STM32U5
+  secure_aes_init();
+#endif
+
 #ifdef USE_OPTIGA
   uint8_t secret[SECRET_OPTIGA_KEY_LEN] = {0};
-  secbool secret_ok = secret_optiga_extract(secret);
+  secbool secret_ok = secret_optiga_get(secret);
 #endif
 
   mpu_config_firmware_initial();
@@ -164,10 +168,6 @@ int main(void) {
 
 #if defined TREZOR_MODEL_T
   set_core_clock(CLOCK_180_MHZ);
-#endif
-
-#ifdef STM32U5
-  secure_aes_init();
 #endif
 
 #ifdef USE_BUTTON

--- a/core/embed/prodtest/main.c
+++ b/core/embed/prodtest/main.c
@@ -59,6 +59,7 @@
 #include "memzero.h"
 
 #ifdef STM32U5
+#include "secure_aes.h"
 #include "stm32u5xx_ll_utils.h"
 #else
 #include "stm32f4xx_ll_utils.h"
@@ -584,6 +585,9 @@ int main(void) {
   display_reinit();
   display_orientation(0);
   random_delays_init();
+#ifdef STM32U5
+  secure_aes_init();
+#endif
 #ifdef USE_HASH_PROCESSOR
   hash_processor_init();
 #endif

--- a/core/embed/trezorhal/secret.h
+++ b/core/embed/trezorhal/secret.h
@@ -15,7 +15,7 @@
 
 secbool secret_bootloader_locked(void);
 
-void secret_write(uint8_t* data, uint32_t offset, uint32_t len);
+void secret_write(const uint8_t* data, uint32_t offset, uint32_t len);
 
 secbool secret_read(uint8_t* data, uint32_t offset, uint32_t len);
 
@@ -31,11 +31,13 @@ void secret_hide(void);
 
 void secret_write_header(void);
 
+secbool secret_optiga_set(const uint8_t secret[SECRET_OPTIGA_KEY_LEN]);
+
+secbool secret_optiga_get(uint8_t dest[SECRET_OPTIGA_KEY_LEN]);
+
 void secret_optiga_backup(void);
 
 void secret_optiga_hide(void);
-
-secbool secret_optiga_extract(uint8_t* dest);
 
 void secret_bhk_lock(void);
 

--- a/core/embed/trezorhal/secret.h
+++ b/core/embed/trezorhal/secret.h
@@ -13,38 +13,72 @@
 #define SECRET_BHK_OFFSET (1024 * 8)
 #define SECRET_BHK_LEN 32
 
+// Checks if bootloader is locked, that is the secret storage contains optiga
+// pairing secret on platforms where access to the secret storage cannot be
+// restricted for unofficial firmware
 secbool secret_bootloader_locked(void);
 
+// Writes data to the secret storage
 void secret_write(const uint8_t* data, uint32_t offset, uint32_t len);
 
+// Reads data from the secret storage
 secbool secret_read(uint8_t* data, uint32_t offset, uint32_t len);
 
+// Checks if the secret storage has been wiped
 secbool secret_wiped(void);
 
+// Verifies that the secret storage has correct header
 secbool secret_verify_header(void);
 
+// Checks that the secret storage is initialized and initializes it if not
 secbool secret_ensure_initialized(void);
 
+// Erases the entire secret storage
 void secret_erase(void);
 
+// Disables access to the secret storage until next reset
 void secret_hide(void);
 
+// Writes the secret header to the secret storage
 void secret_write_header(void);
 
+// Writes optiga pairing secret to the secret storage
+// Encrypts the secret if encryption is available on the platform
+// Returns true if the secret was written successfully
 secbool secret_optiga_set(const uint8_t secret[SECRET_OPTIGA_KEY_LEN]);
 
+// Reads optiga pairing secret
+// Decrypts the secret if encryption is available on the platform
+// Returns true if the secret was read successfully
+// Reading can fail if optiga is not paired, the pairing secret was not
+// provisioned to the firmware (by calling secret_optiga_backup), or the secret
+// was made unavailable by calling secret_optiga_hide
 secbool secret_optiga_get(uint8_t dest[SECRET_OPTIGA_KEY_LEN]);
 
+// Backs up the optiga pairing secret from the secret storage to the backup
+// register
 void secret_optiga_backup(void);
 
+// Deletes the optiga pairing secret from the register
 void secret_optiga_hide(void);
 
+// Locks the BHK register. Once locked, the BHK register can't be accessed by
+// the software. BHK is made available to the SAES peripheral
 void secret_bhk_lock(void);
 
+// Verifies that access to the register has been disabled
 secbool secret_bhk_locked(void);
 
+// Regenerates the BHK and writes it to the secret storage
 void secret_bhk_regenerate(void);
 
+// Provision the secret BHK from the secret storage to the BHK register
+// which makes the BHK usable for encryption by the firmware, without having
+// read access to it.
 void secret_bhk_provision(void);
 
+// Checks that the optiga pairing secret is present in the secret storage.
+// This functions only works when software has access to the secret storage,
+// i.e. in bootloader. Access to secret storage is restricted by calling
+// secret_hide.
 secbool secret_optiga_present(void);

--- a/core/embed/trezorhal/secure_aes.h
+++ b/core/embed/trezorhal/secure_aes.h
@@ -24,17 +24,25 @@
 #include <stddef.h>
 #include <stdint.h>
 
+typedef enum {
+  SECURE_AES_KEY_DHUK,
+  SECURE_AES_KEY_BHK,
+  SECURE_AES_KEY_XORK,
+} secure_aes_keysel_t;
+
 // Initializes secure AES module
 secbool secure_aes_init(void);
 
-// Encrypts a block of data using AES-256 EBB and (DHUK xor BHK) key
-// Input and output must be aligned to 32 bits, size is in bytes
-secbool secure_aes_encrypt(uint32_t* input, size_t size, uint32_t* output);
+// Encrypts a block of data using AES-256 ECB and HW key (DHUK, BHK or XORK)
+// For optimal speed input and output should be aligned to 32 bits, size is in
+// bytes
+secbool secure_aes_ecb_encrypt_hw(const uint8_t* input, size_t size,
+                                  uint8_t* output, secure_aes_keysel_t key);
 
-// Decrypts a block of data using AES-256 ECB and (DHUK xor BHK) key
-// Input and output must be aligned to 32 bits, size is in bytes
-secbool secure_aes_decrypt(uint32_t* input, size_t size, uint32_t* output);
-
-void secure_aes_test();
+// Decrypts a block of data using AES-256 ECB and HW key (DHUK, BHK or XORK)
+// For optimal speed input and output should be aligned to 32 bits, size is in
+// bytes
+secbool secure_aes_ecb_decrypt_hw(const uint8_t* input, size_t size,
+                                  uint8_t* output, secure_aes_keysel_t key);
 
 #endif  // TREZOR_HAL_SECURE_AES_H

--- a/core/embed/trezorhal/stm32f4/secret.c
+++ b/core/embed/trezorhal/stm32f4/secret.c
@@ -37,7 +37,7 @@ void secret_write_header(void) {
   secret_write(header, 0, SECRET_HEADER_LEN);
 }
 
-void secret_write(uint8_t* data, uint32_t offset, uint32_t len) {
+void secret_write(const uint8_t* data, uint32_t offset, uint32_t len) {
   ensure(flash_unlock_write(), "secret write");
   for (int i = 0; i < len; i++) {
     ensure(flash_area_write_byte(&SECRET_AREA, offset + i, data[i]),
@@ -76,6 +76,13 @@ void secret_erase(void) {
   ensure(flash_area_erase(&SECRET_AREA, NULL), "secret erase");
 }
 
-secbool secret_optiga_extract(uint8_t* dest) {
+secbool secret_optiga_set(const uint8_t secret[SECRET_OPTIGA_KEY_LEN]) {
+  secret_erase();
+  secret_write_header();
+  secret_write(secret, SECRET_OPTIGA_KEY_OFFSET, SECRET_OPTIGA_KEY_LEN);
+  return sectrue;
+}
+
+secbool secret_optiga_get(uint8_t dest[SECRET_OPTIGA_KEY_LEN]) {
   return secret_read(dest, SECRET_OPTIGA_KEY_OFFSET, SECRET_OPTIGA_KEY_LEN);
 }

--- a/core/embed/trezorhal/stm32u5/secure_aes.c
+++ b/core/embed/trezorhal/stm32u5/secure_aes.c
@@ -22,6 +22,10 @@
 
 #include <stdio.h>
 #include <stm32u5xx_hal_cryp.h>
+#include <string.h>
+#include "memzero.h"
+
+#define AES_BLOCK_SIZE 16
 
 secbool secure_aes_init(void) {
   RCC_OscInitTypeDef osc_init_def = {0};
@@ -50,46 +54,33 @@ static void secure_aes_load_bhk(void) {
   TAMP->BKP7R;
 }
 
-secbool secure_aes_encrypt(uint32_t* input, size_t size, uint32_t* output) {
-  CRYP_HandleTypeDef hcryp = {0};
-  uint32_t iv[] = {0, 0, 0, 0};
-
-  hcryp.Instance = SAES;
-  hcryp.Init.DataType = CRYP_NO_SWAP;
-  hcryp.Init.KeySelect = CRYP_KEYSEL_HSW;
-  hcryp.Init.KeySize = CRYP_KEYSIZE_256B;
-  hcryp.Init.pKey = NULL;
-  hcryp.Init.pInitVect = iv;
-  hcryp.Init.Algorithm = CRYP_AES_ECB;
-  hcryp.Init.Header = NULL;
-  hcryp.Init.HeaderSize = 0;
-  hcryp.Init.DataWidthUnit = CRYP_DATAWIDTHUNIT_WORD;
-  hcryp.Init.HeaderWidthUnit = CRYP_HEADERWIDTHUNIT_BYTE;
-  hcryp.Init.KeyIVConfigSkip = CRYP_KEYIVCONFIG_ALWAYS;
-  hcryp.Init.KeyMode = CRYP_KEYMODE_NORMAL;
-
-  if (HAL_CRYP_Init(&hcryp) != HAL_OK) {
-    return secfalse;
+static uint32_t get_keysel(secure_aes_keysel_t key) {
+  switch (key) {
+    case SECURE_AES_KEY_DHUK:
+      return CRYP_KEYSEL_HW;
+    case SECURE_AES_KEY_BHK:
+      return CRYP_KEYSEL_SW;
+    case SECURE_AES_KEY_XORK:
+      return CRYP_KEYSEL_HSW;
+    default:
+      return 0;
   }
-
-  secure_aes_load_bhk();
-
-  if (HAL_CRYP_Encrypt(&hcryp, input, size, output, HAL_MAX_DELAY) != HAL_OK) {
-    return secfalse;
-  }
-
-  HAL_CRYP_DeInit(&hcryp);
-
-  return sectrue;
 }
 
-secbool secure_aes_decrypt(uint32_t* input, size_t size, uint32_t* output) {
+secbool secure_aes_ecb_encrypt_hw(const uint8_t* input, size_t size,
+                                  uint8_t* output, secure_aes_keysel_t key) {
   CRYP_HandleTypeDef hcryp = {0};
   uint32_t iv[] = {0, 0, 0, 0};
 
+  if (size % AES_BLOCK_SIZE != 0) {
+    return secfalse;
+  }
+
+  uint32_t keysel = get_keysel(key);
+
   hcryp.Instance = SAES;
   hcryp.Init.DataType = CRYP_NO_SWAP;
-  hcryp.Init.KeySelect = CRYP_KEYSEL_HSW;
+  hcryp.Init.KeySelect = keysel;
   hcryp.Init.KeySize = CRYP_KEYSIZE_256B;
   hcryp.Init.pKey = NULL;
   hcryp.Init.pInitVect = iv;
@@ -105,10 +96,103 @@ secbool secure_aes_decrypt(uint32_t* input, size_t size, uint32_t* output) {
     return secfalse;
   }
 
-  secure_aes_load_bhk();
+  if (keysel == CRYP_KEYSEL_HSW || keysel == CRYP_KEYSEL_SW) {
+    secure_aes_load_bhk();
+  }
 
-  if (HAL_CRYP_Decrypt(&hcryp, input, size, output, HAL_MAX_DELAY) != HAL_OK) {
+  if ((size_t)input % sizeof(uint32_t) != 0 ||
+      (size_t)output % sizeof(uint32_t) != 0) {
+    size_t tmp_size = size;
+    while (tmp_size >= AES_BLOCK_SIZE) {
+      uint32_t input_buffer[AES_BLOCK_SIZE / sizeof(uint32_t)];
+      uint32_t output_buffer[AES_BLOCK_SIZE / sizeof(uint32_t)];
+      memcpy(input_buffer, input, AES_BLOCK_SIZE);
+      if (HAL_CRYP_Encrypt(&hcryp, input_buffer, AES_BLOCK_SIZE, output_buffer,
+                           HAL_MAX_DELAY) != HAL_OK) {
+        memzero(input_buffer, sizeof(input_buffer));
+        memzero(output_buffer, sizeof(output_buffer));
+        return secfalse;
+      }
+      memcpy(output, output_buffer, AES_BLOCK_SIZE);
+      input += AES_BLOCK_SIZE;
+      output += AES_BLOCK_SIZE;
+      tmp_size -= AES_BLOCK_SIZE;
+
+      memzero(input_buffer, sizeof(input_buffer));
+      memzero(output_buffer, sizeof(output_buffer));
+    }
+
+  } else {
+    if (HAL_CRYP_Encrypt(&hcryp, (uint32_t*)input, size, (uint32_t*)output,
+                         HAL_MAX_DELAY) != HAL_OK) {
+      return secfalse;
+    }
+  }
+
+  HAL_CRYP_DeInit(&hcryp);
+
+  return sectrue;
+}
+
+secbool secure_aes_ecb_decrypt_hw(const uint8_t* input, size_t size,
+                                  uint8_t* output, secure_aes_keysel_t key) {
+  CRYP_HandleTypeDef hcryp = {0};
+  uint32_t iv[] = {0, 0, 0, 0};
+
+  if (size % AES_BLOCK_SIZE != 0) {
     return secfalse;
+  }
+
+  uint32_t keysel = get_keysel(key);
+
+  hcryp.Instance = SAES;
+  hcryp.Init.DataType = CRYP_NO_SWAP;
+  hcryp.Init.KeySelect = keysel;
+  hcryp.Init.KeySize = CRYP_KEYSIZE_256B;
+  hcryp.Init.pKey = NULL;
+  hcryp.Init.pInitVect = iv;
+  hcryp.Init.Algorithm = CRYP_AES_ECB;
+  hcryp.Init.Header = NULL;
+  hcryp.Init.HeaderSize = 0;
+  hcryp.Init.DataWidthUnit = CRYP_DATAWIDTHUNIT_BYTE;
+  hcryp.Init.HeaderWidthUnit = CRYP_HEADERWIDTHUNIT_BYTE;
+  hcryp.Init.KeyIVConfigSkip = CRYP_KEYIVCONFIG_ALWAYS;
+  hcryp.Init.KeyMode = CRYP_KEYMODE_NORMAL;
+
+  if (HAL_CRYP_Init(&hcryp) != HAL_OK) {
+    return secfalse;
+  }
+  if (keysel == CRYP_KEYSEL_HSW || keysel == CRYP_KEYSEL_SW) {
+    secure_aes_load_bhk();
+  }
+
+  if ((size_t)input % sizeof(uint32_t) != 0 ||
+      (size_t)output % sizeof(uint32_t) != 0) {
+    size_t tmp_size = size;
+    while (tmp_size >= AES_BLOCK_SIZE) {
+      uint32_t input_buffer[AES_BLOCK_SIZE / sizeof(uint32_t)];
+      uint32_t output_buffer[AES_BLOCK_SIZE / sizeof(uint32_t)];
+      memcpy(input_buffer, input, AES_BLOCK_SIZE);
+      if (HAL_CRYP_Decrypt(&hcryp, input_buffer, AES_BLOCK_SIZE, output_buffer,
+                           HAL_MAX_DELAY) != HAL_OK) {
+        memzero(input_buffer, sizeof(input_buffer));
+        memzero(output_buffer, sizeof(output_buffer));
+        return secfalse;
+      }
+      memcpy(output, output_buffer, AES_BLOCK_SIZE);
+      input += AES_BLOCK_SIZE;
+      output += AES_BLOCK_SIZE;
+      tmp_size -= AES_BLOCK_SIZE;
+
+      memzero(input_buffer, sizeof(input_buffer));
+      memzero(output_buffer, sizeof(output_buffer));
+    }
+
+  } else {
+    if (HAL_CRYP_Decrypt(&hcryp, (uint32_t*)input, size, (uint32_t*)output,
+                         HAL_MAX_DELAY) != HAL_OK) {
+      return secfalse;
+    }
   }
 
   HAL_CRYP_DeInit(&hcryp);


### PR DESCRIPTION
Improves security of u5 based models by including U5 HW keys (DHUK and BHK) in storage encryption and decryption procedures.


<!--
If you are a core dev:

Don't forget to set up the fields:
- assign yourself
- set priority to same as original issue
- add PR to sprint
- if Draft -> "in progress"
- if final PR -> "needs review"

If you're an external contributor, you can ignore this text.
-->
