### PR TITLE
TStringify Paragraphs

### DIFF
--- a/core/embed/rust/src/micropython/buffer.rs
+++ b/core/embed/rust/src/micropython/buffer.rs
@@ -1,10 +1,6 @@
 use core::{convert::TryFrom, ops::Deref, ptr, slice, str};
 
-use crate::{
-    error::Error,
-    micropython::obj::Obj,
-    strutil::{hexlify, SkipPrefix},
-};
+use crate::{error::Error, micropython::obj::Obj, strutil::hexlify};
 
 use super::ffi;
 
@@ -93,10 +89,8 @@ impl StrBuffer {
             unsafe { slice::from_raw_parts(self.ptr.add(self.off.into()), self.len.into()) }
         }
     }
-}
 
-impl SkipPrefix for StrBuffer {
-    fn skip_prefix(&self, skip_bytes: usize) -> Self {
+    pub fn skip_prefix(&self, skip_bytes: usize) -> Self {
         let off: u16 = unwrap!(skip_bytes.try_into());
         assert!(off <= self.len);
         assert!(self.as_ref().is_char_boundary(skip_bytes));

--- a/core/embed/rust/src/translations/generated/translated_string.rs
+++ b/core/embed/rust/src/translations/generated/translated_string.rs
@@ -6,7 +6,7 @@
 #[cfg(feature = "micropython")]
 use crate::micropython::qstr::Qstr;
 
-#[derive(Debug, Copy, Clone, FromPrimitive)]
+#[derive(Debug, Copy, Clone, FromPrimitive, PartialEq, Eq)]
 #[repr(u16)]
 #[allow(non_camel_case_types)]
 pub enum TranslatedString {

--- a/core/embed/rust/src/translations/generated/translated_string.rs.mako
+++ b/core/embed/rust/src/translations/generated/translated_string.rs.mako
@@ -35,7 +35,7 @@ en_data = json.loads(en_file.read_text())["translations"]
 #[cfg(feature = "micropython")]
 use crate::micropython::qstr::Qstr;
 
-#[derive(Debug, Copy, Clone, FromPrimitive)]
+#[derive(Debug, Copy, Clone, FromPrimitive, PartialEq, Eq)]
 #[repr(u16)]
 #[allow(non_camel_case_types)]
 pub enum TranslatedString {

--- a/core/embed/rust/src/translations/translated_string.rs
+++ b/core/embed/rust/src/translations/translated_string.rs
@@ -23,7 +23,7 @@ impl TranslatedString {
     }
 
     pub const fn as_tstring(self) -> TString<'static> {
-        TString::Translation(self)
+        TString::from_translation(self)
     }
 }
 

--- a/core/embed/rust/src/ui/component/base.rs
+++ b/core/embed/rust/src/ui/component/base.rs
@@ -3,6 +3,7 @@ use core::mem;
 use heapless::Vec;
 
 use crate::{
+    strutil::TString,
     time::Duration,
     ui::{
         component::{maybe::PaintOverlapping, MsgMap},
@@ -415,7 +416,7 @@ where
 }
 
 #[derive(Copy, Clone, PartialEq, Eq)]
-pub enum Event<'a> {
+pub enum Event {
     #[cfg(feature = "button")]
     Button(ButtonEvent),
     #[cfg(feature = "touch")]
@@ -425,7 +426,7 @@ pub enum Event<'a> {
     /// token (another timer has to be requested).
     Timer(TimerToken),
     /// Advance progress bar. Progress screens only.
-    Progress(u16, &'a str),
+    Progress(u16, TString<'static>),
     /// Component has been attached to component tree. This event is sent once
     /// before any other events.
     Attach,

--- a/core/embed/rust/src/ui/component/text/formatted.rs
+++ b/core/embed/rust/src/ui/component/text/formatted.rs
@@ -1,9 +1,6 @@
-use crate::{
-    strutil::StringType,
-    ui::{
-        component::{Component, Event, EventCtx, Never, Paginate},
-        geometry::{Alignment, Offset, Rect},
-    },
+use crate::ui::{
+    component::{Component, Event, EventCtx, Never, Paginate},
+    geometry::{Alignment, Offset, Rect},
 };
 
 use super::{
@@ -12,15 +9,15 @@ use super::{
 };
 
 #[derive(Clone)]
-pub struct FormattedText<T: StringType + Clone> {
-    op_layout: OpTextLayout<T>,
+pub struct FormattedText {
+    op_layout: OpTextLayout<'static>,
     vertical: Alignment,
     char_offset: usize,
     y_offset: i16,
 }
 
-impl<T: StringType + Clone> FormattedText<T> {
-    pub fn new(op_layout: OpTextLayout<T>) -> Self {
+impl FormattedText {
+    pub fn new(op_layout: OpTextLayout<'static>) -> Self {
         Self {
             op_layout,
             vertical: Alignment::Start,
@@ -54,7 +51,7 @@ impl<T: StringType + Clone> FormattedText<T> {
 }
 
 // Pagination
-impl<T: StringType + Clone> Paginate for FormattedText<T> {
+impl Paginate for FormattedText {
     fn page_count(&mut self) -> usize {
         let mut page_count = 1; // There's always at least one page.
 
@@ -118,7 +115,7 @@ impl<T: StringType + Clone> Paginate for FormattedText<T> {
     }
 }
 
-impl<T: StringType + Clone> Component for FormattedText<T> {
+impl Component for FormattedText {
     type Msg = Never;
 
     fn place(&mut self, bounds: Rect) -> Rect {
@@ -145,7 +142,7 @@ impl<T: StringType + Clone> Component for FormattedText<T> {
 // DEBUG-ONLY SECTION BELOW
 
 #[cfg(feature = "ui_debug")]
-impl<T: StringType + Clone> crate::trace::Trace for FormattedText<T> {
+impl crate::trace::Trace for FormattedText {
     fn trace(&self, t: &mut dyn crate::trace::Tracer) {
         use crate::ui::component::text::layout::trace::TraceSink;
         use core::cell::Cell;

--- a/core/embed/rust/src/ui/layout/obj.rs
+++ b/core/embed/rust/src/ui/layout/obj.rs
@@ -389,7 +389,7 @@ extern "C" fn ui_layout_progress_event(n_args: usize, args: *const Obj) -> Obj {
         let this: Gc<LayoutObj> = args[0].try_into()?;
         let value: u16 = args[1].try_into()?;
         let description: StrBuffer = args[2].try_into()?;
-        let msg = this.obj_event(Event::Progress(value, description.as_ref()))?;
+        let msg = this.obj_event(Event::Progress(value, description.into()))?;
         Ok(msg)
     };
     unsafe { util::try_with_args_and_kwargs(n_args, args, &Map::EMPTY, block) }

--- a/core/embed/rust/src/ui/layout/util.rs
+++ b/core/embed/rust/src/ui/layout/util.rs
@@ -8,7 +8,6 @@ use crate::{
         util::{iter_into_array, try_or_raise},
     },
     storage::{get_avatar_len, load_avatar},
-    strutil::SkipPrefix,
     ui::{
         component::text::{
             paragraphs::{Paragraph, ParagraphSource},
@@ -62,10 +61,8 @@ pub struct ConfirmBlob {
     pub data_font: &'static TextStyle,
 }
 
-impl ParagraphSource for ConfirmBlob {
-    type StrType = StrBuffer;
-
-    fn at(&self, index: usize, offset: usize) -> Paragraph<Self::StrType> {
+impl ParagraphSource<'static> for ConfirmBlob {
+    fn at(&self, index: usize, offset: usize) -> Paragraph<'static> {
         match index {
             0 => Paragraph::new(self.description_font, self.description.skip_prefix(offset)),
             1 => Paragraph::new(self.extra_font, self.extra.skip_prefix(offset)),
@@ -102,10 +99,8 @@ impl PropsList {
     }
 }
 
-impl ParagraphSource for PropsList {
-    type StrType = StrBuffer;
-
-    fn at(&self, index: usize, offset: usize) -> Paragraph<Self::StrType> {
+impl ParagraphSource<'static> for PropsList {
+    fn at(&self, index: usize, offset: usize) -> Paragraph<'static> {
         let block = move || {
             let entry = self.items.get(index / 2)?;
             let [key, value, value_is_mono]: [Obj; 3] = iter_into_array(entry)?;

--- a/core/embed/rust/src/ui/model_tr/component/address_details.rs
+++ b/core/embed/rust/src/ui/model_tr/component/address_details.rs
@@ -22,8 +22,8 @@ const QR_BORDER: i16 = 3;
 
 pub struct AddressDetails {
     qr_code: Qr,
-    details_view: Paragraphs<ParagraphVecShort<StrBuffer>>,
-    xpub_view: Frame<Paragraphs<Paragraph<StrBuffer>>, StrBuffer>,
+    details_view: Paragraphs<ParagraphVecShort<'static>>,
+    xpub_view: Frame<Paragraphs<Paragraph<'static>>, StrBuffer>,
     xpubs: Vec<(StrBuffer, StrBuffer), MAX_XPUBS>,
     current_page: usize,
     current_subpage: usize,
@@ -43,16 +43,13 @@ impl AddressDetails {
         let details_view = {
             let mut para = ParagraphVecShort::new();
             if let Some(account) = account {
-                para.add(Paragraph::new(
-                    &theme::TEXT_BOLD,
-                    TR::words__account_colon.try_into()?,
-                ));
+                para.add(Paragraph::new(&theme::TEXT_BOLD, TR::words__account_colon));
                 para.add(Paragraph::new(&theme::TEXT_MONO, account));
             }
             if let Some(path) = path {
                 para.add(Paragraph::new(
                     &theme::TEXT_BOLD,
-                    TR::address_details__derivation_path.try_into()?,
+                    TR::address_details__derivation_path,
                 ));
                 para.add(Paragraph::new(&theme::TEXT_MONO, path));
             }
@@ -60,7 +57,7 @@ impl AddressDetails {
         };
         let xpub_view = Frame::new(
             "".into(),
-            Paragraph::new(&theme::TEXT_MONO_DATA, "".into()).into_paragraphs(),
+            Paragraph::new(&theme::TEXT_MONO_DATA, "").into_paragraphs(),
         );
 
         let result = Self {

--- a/core/embed/rust/src/ui/model_tr/component/flow_pages.rs
+++ b/core/embed/rust/src/ui/model_tr/component/flow_pages.rs
@@ -78,7 +78,7 @@ pub struct Page<T>
 where
     T: StringType + Clone,
 {
-    formatted: FormattedText<T>,
+    formatted: FormattedText,
     btn_layout: ButtonLayout,
     btn_actions: ButtonActions,
     current_page: usize,
@@ -95,7 +95,7 @@ where
     pub fn new(
         btn_layout: ButtonLayout,
         btn_actions: ButtonActions,
-        formatted: FormattedText<T>,
+        formatted: FormattedText,
     ) -> Self {
         let mut page = Self {
             formatted,

--- a/core/embed/rust/src/ui/model_tr/component/loader.rs
+++ b/core/embed/rust/src/ui/model_tr/component/loader.rs
@@ -274,7 +274,7 @@ where
 
     pub fn start(&mut self, ctx: &mut EventCtx) {
         self.start_time = Some(Instant::now());
-        self.loader.event(ctx, Event::Progress(0, ""));
+        self.loader.event(ctx, Event::Progress(0, "".into()));
         self.loader.mutate(ctx, |ctx, loader| {
             loader.request_paint(ctx);
         });
@@ -318,7 +318,7 @@ where
                 let percentage = self.percentage(now);
                 let new_loader_value = (percentage * LOADER_MAX as u32) / 100;
                 self.loader
-                    .event(ctx, Event::Progress(new_loader_value as u16, ""));
+                    .event(ctx, Event::Progress(new_loader_value as u16, "".into()));
                 // Returning only after the loader was fully painted
                 if percentage >= 100 {
                     return Some(LoaderMsg::GrownCompletely);

--- a/core/embed/rust/src/ui/model_tr/layout.rs
+++ b/core/embed/rust/src/ui/model_tr/layout.rs
@@ -77,9 +77,9 @@ where
     }
 }
 
-impl<T> ComponentMsgObj for Paragraphs<T>
+impl<'a, T> ComponentMsgObj for Paragraphs<T>
 where
-    T: ParagraphSource,
+    T: ParagraphSource<'a>,
 {
     fn msg_try_into_obj(&self, _msg: Self::Msg) -> Result<Obj, Error> {
         unreachable!()
@@ -442,12 +442,12 @@ extern "C" fn new_confirm_reset_device(n_args: usize, args: *const Obj, kwargs: 
         let title: StrBuffer = kwargs.get(Qstr::MP_QSTR_title)?.try_into()?;
         let button: TString<'static> = kwargs.get(Qstr::MP_QSTR_button)?.try_into()?;
 
-        let ops = OpTextLayout::<StrBuffer>::new(theme::TEXT_NORMAL)
-            .text_normal(TR::reset__by_continuing.try_into()?)
+        let ops = OpTextLayout::new(theme::TEXT_NORMAL)
+            .text_normal(TR::reset__by_continuing)
             .next_page()
-            .text_normal(TR::reset__more_info_at.try_into()?)
+            .text_normal(TR::reset__more_info_at)
             .newline()
-            .text_bold(TR::reset__tos_link.try_into()?);
+            .text_bold(TR::reset__tos_link);
         let formatted = FormattedText::new(ops).vertically_centered();
 
         content_in_button_page(title, formatted, button, Some("".into()), false)
@@ -459,27 +459,24 @@ extern "C" fn new_confirm_backup(n_args: usize, args: *const Obj, kwargs: *mut M
     let block = move |_args: &[Obj], _kwargs: &Map| {
         // cached allocated translations that get_page can reuse
         let tr_title_success: StrBuffer = TR::words__title_success.try_into()?;
-        let tr_new_wallet_created: StrBuffer = TR::backup__new_wallet_created.try_into()?;
-        let tr_it_should_be_backed_up_now: StrBuffer =
-            TR::backup__it_should_be_backed_up_now.try_into()?;
         let tr_title_backup_wallet: StrBuffer = TR::backup__title_backup_wallet.try_into()?;
-        let tr_recover_anytime: StrBuffer = TR::backup__recover_anytime.try_into()?;
 
         let get_page = move |page_index| match page_index {
             0 => {
                 let btn_layout = ButtonLayout::text_none_arrow_wide(TR::buttons__skip.into());
                 let btn_actions = ButtonActions::cancel_none_next();
                 let ops = OpTextLayout::new(theme::TEXT_NORMAL)
-                    .text_normal(tr_new_wallet_created)
+                    .text_normal(TR::backup__new_wallet_created)
                     .newline()
-                    .text_normal(tr_it_should_be_backed_up_now);
+                    .text_normal(TR::backup__it_should_be_backed_up_now);
                 let formatted = FormattedText::new(ops).vertically_centered();
                 Page::new(btn_layout, btn_actions, formatted).with_title(tr_title_success)
             }
             1 => {
                 let btn_layout = ButtonLayout::up_arrow_none_text(TR::buttons__back_up.into());
                 let btn_actions = ButtonActions::prev_none_confirm();
-                let ops = OpTextLayout::new(theme::TEXT_NORMAL).text_normal(tr_recover_anytime);
+                let ops =
+                    OpTextLayout::new(theme::TEXT_NORMAL).text_normal(TR::backup__recover_anytime);
                 let formatted = FormattedText::new(ops).vertically_centered();
                 Page::<StrBuffer>::new(btn_layout, btn_actions, formatted)
                     .with_title(tr_title_backup_wallet)
@@ -550,15 +547,9 @@ extern "C" fn new_confirm_joint_total(n_args: usize, args: *const Obj, kwargs: *
         let total_amount: StrBuffer = kwargs.get(Qstr::MP_QSTR_total_amount)?.try_into()?;
 
         let paragraphs = Paragraphs::new([
-            Paragraph::new(
-                &theme::TEXT_BOLD,
-                TR::joint__you_are_contributing.try_into()?,
-            ),
+            Paragraph::new(&theme::TEXT_BOLD, TR::joint__you_are_contributing),
             Paragraph::new(&theme::TEXT_MONO, spending_amount),
-            Paragraph::new(
-                &theme::TEXT_BOLD,
-                TR::joint__to_the_total_amount.try_into()?,
-            ),
+            Paragraph::new(&theme::TEXT_BOLD, TR::joint__to_the_total_amount),
             Paragraph::new(&theme::TEXT_MONO, total_amount),
         ]);
 
@@ -586,9 +577,9 @@ extern "C" fn new_confirm_modify_output(n_args: usize, args: *const Obj, kwargs:
         };
 
         let paragraphs = Paragraphs::new([
-            Paragraph::new(&theme::TEXT_NORMAL, description.try_into()?),
+            Paragraph::new(&theme::TEXT_NORMAL, description),
             Paragraph::new(&theme::TEXT_MONO, amount_change).break_after(),
-            Paragraph::new(&theme::TEXT_BOLD, TR::modify_amount__new_amount.try_into()?),
+            Paragraph::new(&theme::TEXT_BOLD, TR::modify_amount__new_amount),
             Paragraph::new(&theme::TEXT_MONO, amount_new),
         ]);
 
@@ -677,12 +668,6 @@ extern "C" fn new_confirm_total(n_args: usize, args: *const Obj, kwargs: *mut Ma
         let total_label: StrBuffer = kwargs.get(Qstr::MP_QSTR_total_label)?.try_into()?;
         let fee_label: StrBuffer = kwargs.get(Qstr::MP_QSTR_fee_label)?.try_into()?;
 
-        // cached allocated translated strings that get_page can reuse
-        let tr_title_fee = TR::confirm_total__title_fee.try_into()?;
-        let tr_fee_rate = TR::confirm_total__fee_rate.try_into()?;
-        let tr_title_sending_from = TR::confirm_total__title_sending_from.try_into()?;
-        let tr_account = TR::words__account_colon.try_into()?;
-
         let get_page = move |page_index| {
             match page_index {
                 0 => {
@@ -701,7 +686,7 @@ extern "C" fn new_confirm_total(n_args: usize, args: *const Obj, kwargs: *mut Ma
                         .text_mono(fee_amount);
 
                     let formatted = FormattedText::new(ops);
-                    Page::new(btn_layout, btn_actions, formatted)
+                    Page::<StrBuffer>::new(btn_layout, btn_actions, formatted)
                 }
                 1 => {
                     // Fee rate info
@@ -711,11 +696,11 @@ extern "C" fn new_confirm_total(n_args: usize, args: *const Obj, kwargs: *mut Ma
                     let fee_rate_amount = fee_rate_amount.unwrap_or_default();
 
                     let ops = OpTextLayout::new(theme::TEXT_MONO)
-                        .text_bold(tr_title_fee)
+                        .text_bold(TR::confirm_total__title_fee)
                         .newline()
                         .newline()
                         .newline_half()
-                        .text_bold(tr_fee_rate)
+                        .text_bold(TR::confirm_total__fee_rate)
                         .newline()
                         .text_mono(fee_rate_amount);
 
@@ -732,11 +717,11 @@ extern "C" fn new_confirm_total(n_args: usize, args: *const Obj, kwargs: *mut Ma
                     // TODO: include wallet info when available
 
                     let ops = OpTextLayout::new(theme::TEXT_MONO)
-                        .text_bold(tr_title_sending_from)
+                        .text_bold(TR::confirm_total__title_sending_from)
                         .newline()
                         .newline()
                         .newline_half()
-                        .text_bold(tr_account)
+                        .text_bold(TR::words__account_colon)
                         .newline()
                         .text_mono(account_label);
 
@@ -802,9 +787,9 @@ extern "C" fn new_altcoin_tx_summary(n_args: usize, args: *const Obj, kwargs: *m
                             ops = ops.next_page();
                         }
                         ops = ops
-                            .text_bold(unwrap!(key.try_into()))
+                            .text_bold(unwrap!(TString::try_from(key)))
                             .newline()
-                            .text_mono(unwrap!(value.try_into()));
+                            .text_mono(unwrap!(TString::try_from(value)));
                     }
 
                     let formatted = FormattedText::new(ops).vertically_centered();
@@ -858,11 +843,11 @@ extern "C" fn new_confirm_address(n_args: usize, args: *const Obj, kwargs: *mut 
 /// (title, text, btn_layout, btn_actions, text_y_offset)
 fn tutorial_screen(
     title: StrBuffer,
-    text: StrBuffer,
+    text: TR,
     btn_layout: ButtonLayout,
     btn_actions: ButtonActions,
 ) -> Page<StrBuffer> {
-    let ops = OpTextLayout::<StrBuffer>::new(theme::TEXT_NORMAL).text_normal(text);
+    let ops = OpTextLayout::new(theme::TEXT_NORMAL).text_normal(text);
     let formatted = FormattedText::new(ops).vertically_centered();
     Page::new(btn_layout, btn_actions, formatted).with_title(title)
 }
@@ -873,19 +858,12 @@ extern "C" fn tutorial(n_args: usize, args: *const Obj, kwargs: *mut Map) -> Obj
 
         // cached allocated translated strings that get_page can reuse
         let tr_title_hello: StrBuffer = TR::tutorial__title_hello.try_into()?;
-        let tr_welcome_press_right: StrBuffer = TR::tutorial__welcome_press_right.try_into()?;
-        let tr_use_trezor: StrBuffer = TR::tutorial__use_trezor.try_into()?;
         let tr_hold_to_confirm: StrBuffer = TR::buttons__hold_to_confirm.try_into()?;
-        let tr_press_and_hold: StrBuffer = TR::tutorial__press_and_hold.try_into()?;
         let tr_title_screen_scroll: StrBuffer = TR::tutorial__title_screen_scroll.try_into()?;
-        let tr_scroll_down: StrBuffer = TR::tutorial__scroll_down.try_into()?;
         let tr_confirm: StrBuffer = TR::buttons__confirm.try_into()?;
-        let tr_middle_click: StrBuffer = TR::tutorial__middle_click.try_into()?;
         let tr_title_tutorial_complete: StrBuffer =
             TR::tutorial__title_tutorial_complete.try_into()?;
-        let tr_ready_to_use: StrBuffer = TR::tutorial__ready_to_use.try_into()?;
         let tr_title_skip: StrBuffer = TR::tutorial__title_skip.try_into()?;
-        let tr_sure_you_want_skip: StrBuffer = TR::tutorial__sure_you_want_skip.try_into()?;
 
         let get_page = move |page_index| {
             // Lazy-loaded list of screens to show, with custom content,
@@ -897,37 +875,37 @@ extern "C" fn tutorial(n_args: usize, args: *const Obj, kwargs: *mut Map) -> Obj
                 // title, text, btn_layout, btn_actions
                 0 => tutorial_screen(
                     tr_title_hello,
-                    tr_welcome_press_right,
+                    TR::tutorial__welcome_press_right,
                     ButtonLayout::cancel_none_arrow(),
                     ButtonActions::last_none_next(),
                 ),
                 1 => tutorial_screen(
                     "".into(),
-                    tr_use_trezor,
+                    TR::tutorial__use_trezor,
                     ButtonLayout::arrow_none_arrow(),
                     ButtonActions::prev_none_next(),
                 ),
                 2 => tutorial_screen(
                     tr_hold_to_confirm,
-                    tr_press_and_hold,
+                    TR::tutorial__press_and_hold,
                     ButtonLayout::arrow_none_htc(TR::buttons__hold_to_confirm.into()),
                     ButtonActions::prev_none_next(),
                 ),
                 3 => tutorial_screen(
                     tr_title_screen_scroll,
-                    tr_scroll_down,
+                    TR::tutorial__scroll_down,
                     ButtonLayout::arrow_none_text(TR::buttons__continue.into()),
                     ButtonActions::prev_none_next(),
                 ),
                 4 => tutorial_screen(
                     tr_confirm,
-                    tr_middle_click,
+                    TR::tutorial__middle_click,
                     ButtonLayout::none_armed_none(TR::buttons__confirm.into()),
                     ButtonActions::none_next_none(),
                 ),
                 5 => tutorial_screen(
                     tr_title_tutorial_complete,
-                    tr_ready_to_use,
+                    TR::tutorial__ready_to_use,
                     ButtonLayout::text_none_text(
                         TR::buttons__again.into(),
                         TR::buttons__continue.into(),
@@ -936,7 +914,7 @@ extern "C" fn tutorial(n_args: usize, args: *const Obj, kwargs: *mut Map) -> Obj
                 ),
                 6 => tutorial_screen(
                     tr_title_skip,
-                    tr_sure_you_want_skip,
+                    TR::tutorial__sure_you_want_skip,
                     ButtonLayout::arrow_none_text(TR::buttons__skip.into()),
                     ButtonActions::beginning_none_cancel(),
                 ),
@@ -976,23 +954,14 @@ extern "C" fn new_confirm_modify_fee(n_args: usize, args: *const Obj, kwargs: *m
 
         let mut paragraphs_vec = ParagraphVecShort::new();
         paragraphs_vec
-            .add(Paragraph::new(&theme::TEXT_BOLD, description.try_into()?))
+            .add(Paragraph::new(&theme::TEXT_BOLD, description))
             .add(Paragraph::new(&theme::TEXT_MONO, change))
-            .add(
-                Paragraph::new(
-                    &theme::TEXT_BOLD,
-                    TR::modify_fee__transaction_fee.try_into()?,
-                )
-                .no_break(),
-            )
+            .add(Paragraph::new(&theme::TEXT_BOLD, TR::modify_fee__transaction_fee).no_break())
             .add(Paragraph::new(&theme::TEXT_MONO, total_fee_new));
 
         if let Some(fee_rate_amount) = fee_rate_amount {
             paragraphs_vec
-                .add(
-                    Paragraph::new(&theme::TEXT_BOLD, TR::modify_fee__fee_rate.try_into()?)
-                        .no_break(),
-                )
+                .add(Paragraph::new(&theme::TEXT_BOLD, TR::modify_fee__fee_rate).no_break())
                 .add(Paragraph::new(&theme::TEXT_MONO, fee_rate_amount));
         }
 
@@ -1010,7 +979,7 @@ extern "C" fn new_confirm_modify_fee(n_args: usize, args: *const Obj, kwargs: *m
 extern "C" fn new_multiple_pages_texts(n_args: usize, args: *const Obj, kwargs: *mut Map) -> Obj {
     let block = move |_args: &[Obj], kwargs: &Map| {
         let title: StrBuffer = kwargs.get(Qstr::MP_QSTR_title)?.try_into()?;
-        let verb: TString<'static> = kwargs.get(Qstr::MP_QSTR_verb)?.try_into()?;
+        let verb: TString = kwargs.get(Qstr::MP_QSTR_verb)?.try_into()?;
         let items: Gc<List> = kwargs.get(Qstr::MP_QSTR_items)?.try_into()?;
 
         // Cache the page count so that we can move `items` into the closure.
@@ -1021,7 +990,7 @@ extern "C" fn new_multiple_pages_texts(n_args: usize, args: *const Obj, kwargs: 
         // the need of any allocation here in Rust.
         let get_page = move |page_index| {
             let item_obj = unwrap!(items.get(page_index));
-            let text = unwrap!(item_obj.try_into());
+            let text = unwrap!(TString::try_from(item_obj));
 
             let (btn_layout, btn_actions) = if page_count == 1 {
                 // There is only one page
@@ -1052,7 +1021,7 @@ extern "C" fn new_multiple_pages_texts(n_args: usize, args: *const Obj, kwargs: 
             let ops = OpTextLayout::new(theme::TEXT_NORMAL).text_normal(text);
             let formatted = FormattedText::new(ops).vertically_centered();
 
-            Page::new(btn_layout, btn_actions, formatted)
+            Page::<StrBuffer>::new(btn_layout, btn_actions, formatted)
         };
 
         let pages = FlowPages::new(get_page, page_count);
@@ -1076,7 +1045,7 @@ extern "C" fn new_confirm_fido(n_args: usize, args: *const Obj, kwargs: *mut Map
         // the need of any allocation here in Rust.
         let get_page = move |page_index| {
             let account_obj = unwrap!(accounts.get(page_index));
-            let account = account_obj.try_into().unwrap_or_else(|_| "".into());
+            let account = TString::try_from(account_obj).unwrap_or_else(|_| TString::empty());
 
             let (btn_layout, btn_actions) = if page_count == 1 {
                 // There is only one page
@@ -1111,7 +1080,7 @@ extern "C" fn new_confirm_fido(n_args: usize, args: *const Obj, kwargs: *mut Map
                 .text_bold(account);
             let formatted = FormattedText::new(ops);
 
-            Page::new(btn_layout, btn_actions, formatted)
+            Page::<StrBuffer>::new(btn_layout, btn_actions, formatted)
         };
 
         let pages = FlowPages::new(get_page, page_count);
@@ -1137,7 +1106,7 @@ extern "C" fn new_show_warning(n_args: usize, args: *const Obj, kwargs: *mut Map
 
             let btn_layout = ButtonLayout::none_armed_none(button);
             let btn_actions = ButtonActions::none_confirm_none();
-            let mut ops = OpTextLayout::<StrBuffer>::new(theme::TEXT_NORMAL);
+            let mut ops = OpTextLayout::new(theme::TEXT_NORMAL);
             ops = ops.alignment(geometry::Alignment::Center);
             if !warning.is_empty() {
                 ops = ops.text_bold(warning).newline();
@@ -1146,7 +1115,7 @@ extern "C" fn new_show_warning(n_args: usize, args: *const Obj, kwargs: *mut Map
                 ops = ops.text_normal(description);
             }
             let formatted = FormattedText::new(ops).vertically_centered();
-            Page::new(btn_layout, btn_actions, formatted)
+            Page::<StrBuffer>::new(btn_layout, btn_actions, formatted)
         };
         let pages = FlowPages::new(get_page, 1);
         let obj = LayoutObj::new(Flow::new(pages))?;
@@ -1207,24 +1176,20 @@ extern "C" fn new_show_mismatch(n_args: usize, args: *const Obj, kwargs: *mut Ma
     let block = move |_args: &[Obj], kwargs: &Map| {
         let title: StrBuffer = kwargs.get(Qstr::MP_QSTR_title)?.try_into()?;
 
-        // cached allocated translated strings that get_page can reuse
-        let tr_contact_support_at = TR::addr_mismatch__contact_support_at.try_into()?;
-        let tr_support_url = TR::addr_mismatch__support_url.try_into()?;
-
         let get_page = move |page_index| {
             assert!(page_index == 0);
 
             let btn_layout = ButtonLayout::arrow_none_text(TR::buttons__quit.into());
             let btn_actions = ButtonActions::cancel_none_confirm();
-            let ops = OpTextLayout::<StrBuffer>::new(theme::TEXT_NORMAL)
+            let ops = OpTextLayout::new(theme::TEXT_NORMAL)
                 .text_bold(title)
                 .newline()
                 .newline_half()
-                .text_normal(tr_contact_support_at)
+                .text_normal(TR::addr_mismatch__contact_support_at)
                 .newline()
-                .text_bold(tr_support_url);
+                .text_bold(TR::addr_mismatch__support_url);
             let formatted = FormattedText::new(ops);
-            Page::new(btn_layout, btn_actions, formatted)
+            Page::<StrBuffer>::new(btn_layout, btn_actions, formatted)
         };
         let pages = FlowPages::new(get_page, 1);
 
@@ -1258,7 +1223,7 @@ extern "C" fn new_confirm_with_info(n_args: usize, args: *const Obj, kwargs: *mu
 
         let obj = LayoutObj::new(Frame::new(
             title,
-            ShowMore::<Paragraphs<ParagraphVecShort<StrBuffer>>>::new(
+            ShowMore::<Paragraphs<ParagraphVecShort>>::new(
                 paragraphs.into_paragraphs(),
                 verb_cancel,
                 button,
@@ -1302,10 +1267,9 @@ extern "C" fn new_confirm_coinjoin(n_args: usize, args: *const Obj, kwargs: *mut
 
         // Decreasing bottom padding between paragraphs to fit one screen
         let paragraphs = Paragraphs::new([
-            Paragraph::new(&theme::TEXT_BOLD, TR::coinjoin__max_rounds.try_into()?)
-                .with_bottom_padding(2),
+            Paragraph::new(&theme::TEXT_BOLD, TR::coinjoin__max_rounds).with_bottom_padding(2),
             Paragraph::new(&theme::TEXT_MONO, max_rounds),
-            Paragraph::new(&theme::TEXT_BOLD, TR::coinjoin__max_mining_fee.try_into()?)
+            Paragraph::new(&theme::TEXT_BOLD, TR::coinjoin__max_mining_fee)
                 .with_bottom_padding(2)
                 .no_break(),
             Paragraph::new(&theme::TEXT_MONO, max_feerate).with_bottom_padding(2),
@@ -1498,11 +1462,11 @@ extern "C" fn new_confirm_recovery(n_args: usize, args: *const Obj, kwargs: *mut
             paragraphs
                 .add(Paragraph::new(
                     &theme::TEXT_NORMAL,
-                    TR::recovery__only_first_n_letters.try_into()?,
+                    TR::recovery__only_first_n_letters,
                 ))
                 .add(Paragraph::new(
                     &theme::TEXT_NORMAL,
-                    TR::recovery__cursor_will_change.try_into()?,
+                    TR::recovery__cursor_will_change,
                 ));
         }
 
@@ -1578,8 +1542,7 @@ extern "C" fn new_show_progress(n_args: usize, args: *const Obj, kwargs: *mut Ma
             .and_then(Obj::try_into_option)
             .unwrap_or(None);
 
-        let mut progress =
-            Progress::new(indeterminate, description).with_update_description(StrBuffer::alloc);
+        let mut progress = Progress::new(indeterminate, description);
         if let Some(title) = title {
             progress = progress.with_title(title);
         };

--- a/core/embed/rust/src/ui/model_tt/component/address_details.rs
+++ b/core/embed/rust/src/ui/model_tt/component/address_details.rs
@@ -20,8 +20,8 @@ const MAX_XPUBS: usize = 16;
 
 pub struct AddressDetails<T> {
     qr_code: Frame<Qr, T>,
-    details: Frame<Paragraphs<ParagraphVecShort<StrBuffer>>, T>,
-    xpub_view: Frame<Paragraphs<Paragraph<T>>, T>,
+    details: Frame<Paragraphs<ParagraphVecShort<'static>>, T>,
+    xpub_view: Frame<Paragraphs<Paragraph<'static>>, T>,
     xpubs: Vec<(T, T), MAX_XPUBS>,
     xpub_page_count: Vec<u8, MAX_XPUBS>,
     current_page: usize,
@@ -46,14 +46,14 @@ where
         if let Some(a) = account {
             para.add(Paragraph::new(
                 &theme::TEXT_NORMAL,
-                TR::words__account_colon.try_into()?,
+                TR::words__account_colon,
             ));
             para.add(Paragraph::new(&theme::TEXT_MONO, a));
         }
         if let Some(p) = path {
             para.add(Paragraph::new(
                 &theme::TEXT_NORMAL,
-                TR::address_details__derivation_path.try_into()?,
+                TR::address_details__derivation_path,
             ));
             para.add(Paragraph::new(&theme::TEXT_MONO, p));
         }
@@ -75,7 +75,7 @@ where
             xpub_view: Frame::left_aligned(
                 theme::label_title(),
                 " \n ".into(),
-                Paragraph::new(&theme::TEXT_MONO, "".into()).into_paragraphs(),
+                Paragraph::new(&theme::TEXT_MONO, "").into_paragraphs(),
             )
             .with_cancel_button()
             .with_border(theme::borders_horizontal_scroll()),

--- a/core/embed/rust/src/ui/model_tt/component/dialog.rs
+++ b/core/embed/rust/src/ui/model_tt/component/dialog.rs
@@ -1,5 +1,5 @@
 use crate::{
-    strutil::StringType,
+    strutil::TString,
     ui::{
         component::{
             image::BlendedImage,
@@ -91,18 +91,17 @@ where
     }
 }
 
-pub struct IconDialog<T, U> {
+pub struct IconDialog<U> {
     image: Child<BlendedImage>,
-    paragraphs: Paragraphs<ParagraphVecShort<T>>,
+    paragraphs: Paragraphs<ParagraphVecShort<'static>>,
     controls: Child<U>,
 }
 
-impl<T, U> IconDialog<T, U>
+impl<U> IconDialog<U>
 where
-    T: StringType,
     U: Component,
 {
-    pub fn new(icon: BlendedImage, title: T, controls: U) -> Self {
+    pub fn new(icon: BlendedImage, title: impl Into<TString<'static>>, controls: U) -> Self {
         Self {
             image: Child::new(icon),
             paragraphs: Paragraphs::new(ParagraphVecShort::from_iter([Paragraph::new(
@@ -119,26 +118,26 @@ where
         }
     }
 
-    pub fn with_paragraph(mut self, para: Paragraph<T>) -> Self {
-        if !para.content().as_ref().is_empty() {
+    pub fn with_paragraph(mut self, para: Paragraph<'static>) -> Self {
+        if !para.content().is_empty() {
             self.paragraphs.inner_mut().add(para);
         }
         self
     }
 
-    pub fn with_text(self, style: &'static TextStyle, text: T) -> Self {
+    pub fn with_text(self, style: &'static TextStyle, text: impl Into<TString<'static>>) -> Self {
         self.with_paragraph(Paragraph::new(style, text).centered())
     }
 
-    pub fn with_description(self, description: T) -> Self {
+    pub fn with_description(self, description: impl Into<TString<'static>>) -> Self {
         self.with_text(&theme::TEXT_NORMAL_OFF_WHITE, description)
     }
 
-    pub fn with_value(self, value: T) -> Self {
+    pub fn with_value(self, value: impl Into<TString<'static>>) -> Self {
         self.with_text(&theme::TEXT_MONO, value)
     }
 
-    pub fn new_shares(lines: [T; 4], controls: U) -> Self {
+    pub fn new_shares(lines: [impl Into<TString<'static>>; 4], controls: U) -> Self {
         let [l0, l1, l2, l3] = lines;
         Self {
             image: Child::new(BlendedImage::new(
@@ -165,9 +164,8 @@ where
     pub const VALUE_SPACE: i16 = 5;
 }
 
-impl<T, U> Component for IconDialog<T, U>
+impl<U> Component for IconDialog<U>
 where
-    T: StringType,
     U: Component,
 {
     type Msg = DialogMsg<Never, U::Msg>;
@@ -207,9 +205,8 @@ where
 }
 
 #[cfg(feature = "ui_debug")]
-impl<T, U> crate::trace::Trace for IconDialog<T, U>
+impl<U> crate::trace::Trace for IconDialog<U>
 where
-    T: StringType,
     U: crate::trace::Trace,
 {
     fn trace(&self, t: &mut dyn crate::trace::Tracer) {

--- a/core/embed/rust/src/ui/model_tt/component/number_input.rs
+++ b/core/embed/rust/src/ui/model_tt/component/number_input.rs
@@ -29,7 +29,7 @@ where
     area: Rect,
     description_func: F,
     input: Child<NumberInput>,
-    paragraphs: Child<Paragraphs<Paragraph<T>>>,
+    paragraphs: Child<Paragraphs<Paragraph<'static>>>,
     paragraphs_pad: Pad,
     info_button: Child<Button<StrBuffer>>,
     confirm_button: Child<Button<StrBuffer>>,

--- a/core/embed/rust/src/ui/model_tt/component/page.rs
+++ b/core/embed/rust/src/ui/model_tt/component/page.rs
@@ -485,28 +485,19 @@ impl PageLayout {
 
 #[cfg(test)]
 mod tests {
-    use serde_json;
-
     use crate::{
-        strutil::SkipPrefix,
         trace::tests::trace,
         ui::{
             component::text::paragraphs::{Paragraph, Paragraphs},
             event::TouchEvent,
             geometry::Point,
-            model_tt::{constant, theme},
+            model_tt::constant,
         },
     };
 
     use super::*;
 
     const SCREEN: Rect = constant::screen().inset(theme::borders());
-
-    impl SkipPrefix for &str {
-        fn skip_prefix(&self, chars: usize) -> Self {
-            &self[chars..]
-        }
-    }
 
     fn swipe(component: &mut impl Component, points: &[(i16, i16)]) {
         let last = points.len().saturating_sub(1);
@@ -538,7 +529,7 @@ mod tests {
     #[test]
     fn paragraphs_empty() {
         let mut page = ButtonPage::<_, &'static str>::new(
-            Paragraphs::<[Paragraph<&'static str>; 0]>::new([]),
+            Paragraphs::<[Paragraph<'static>; 0]>::new([]),
             theme::BG,
         );
         page.place(SCREEN);


### PR DESCRIPTION
This is a minimally-invasive change that uses TString as the internal storage for `Paragraph`, modifies `Paragraphs` and `ParagraphSource` accordingly. (in code, this looks mostly like replacing the `T: StringType` argument with a lifetime `'a` instead).
The invasiveness of the change is limited by using `Paragraphs<'static>` in most downstream usages. Even so, this generated a fair amount of churn as type parameters went away.

Going forward we can apply a similar conversion to components where we need it - `Label` is an obvious candidate, correct @TychoVrahe ?

I haven't tested the effect of this change on bootloader code. It _does_ apply to bootloader. In theory, in bootloader only one variant `TString::Str` should exist, and as such, the enum _should_ be completely optimized out. In practice, :woman_shrugging: 
<!--
If you are a core dev:

Don't forget to set up the fields:
- assign yourself
- set priority to same as original issue
- add PR to sprint
- if Draft -> "in progress"
- if final PR -> "needs review"

If you're an external contributor, you can ignore this text.
-->
