### PR TITLE
fix(core): fixed blurring algo panic in debug mode

### DIFF
--- a/core/embed/rust/src/ui/model_tt/component/homescreen/render.rs
+++ b/core/embed/rust/src/ui/model_tt/component/homescreen/render.rs
@@ -500,12 +500,12 @@ impl BlurringContext {
     fn vertical_avg(&mut self) {
         let lines = &mut self.mem.buffer[0..DECOMP_LINES];
         for i in 0..HOMESCREEN_IMAGE_WIDTH as usize {
-            self.totals.buffer[RED_IDX][i] +=
-                lines[self.add_idx][RED_IDX][i] - lines[self.rem_idx][RED_IDX][i];
-            self.totals.buffer[GREEN_IDX][i] +=
-                lines[self.add_idx][GREEN_IDX][i] - lines[self.rem_idx][GREEN_IDX][i];
-            self.totals.buffer[BLUE_IDX][i] +=
-                lines[self.add_idx][BLUE_IDX][i] - lines[self.rem_idx][BLUE_IDX][i];
+            self.totals.buffer[RED_IDX][i] += lines[self.add_idx][RED_IDX][i];
+            self.totals.buffer[GREEN_IDX][i] += lines[self.add_idx][GREEN_IDX][i];
+            self.totals.buffer[BLUE_IDX][i] += lines[self.add_idx][BLUE_IDX][i];
+            self.totals.buffer[RED_IDX][i] -= lines[self.rem_idx][RED_IDX][i];
+            self.totals.buffer[GREEN_IDX][i] -= lines[self.rem_idx][GREEN_IDX][i];
+            self.totals.buffer[BLUE_IDX][i] -= lines[self.rem_idx][BLUE_IDX][i];
         }
     }
 


### PR DESCRIPTION
This PR addresses crashes in the simulator caused by overflow in the blur algorithm.

On the right side of `+=` or `-=` operations, the value may become negative, resulting in a `u16` overflow for `RUST_PROFILE == 'dev'`.

This bug does not affect any hardware or simulators running with `RUST_PROFILE=='release'`.