### PR TITLE
refactor(core): prepare for non mutable paint function

### DIFF
--- a/core/embed/rust/src/ui/component/text/formatted.rs
+++ b/core/embed/rust/src/ui/component/text/formatted.rs
@@ -34,7 +34,7 @@ impl<T: StringType + Clone> FormattedText<T> {
         self
     }
 
-    fn layout_content(&mut self, sink: &mut dyn LayoutSink) -> LayoutFit {
+    pub(crate) fn layout_content(&self, sink: &mut dyn LayoutSink) -> LayoutFit {
         self.op_layout
             .layout_ops(self.char_offset, Offset::y(self.y_offset), sink)
     }
@@ -145,20 +145,6 @@ impl<T: StringType + Clone> Component for FormattedText<T> {
 // DEBUG-ONLY SECTION BELOW
 
 #[cfg(feature = "ui_debug")]
-impl<T: StringType + Clone> FormattedText<T> {
-    /// Is the same as layout_content, but does not use `&mut self`
-    /// to be compatible with `trace`.
-    /// Therefore it has to do the `clone` of `op_layout`.
-    pub fn layout_content_debug(&self, sink: &mut dyn LayoutSink) -> LayoutFit {
-        // TODO: how to solve it "properly", without the `clone`?
-        // (changing `trace` to `&mut self` had some other isses...)
-        self.op_layout
-            .clone()
-            .layout_content(self.char_offset, sink)
-    }
-}
-
-#[cfg(feature = "ui_debug")]
 impl<T: StringType + Clone> crate::trace::Trace for FormattedText<T> {
     fn trace(&self, t: &mut dyn crate::trace::Tracer) {
         use crate::ui::component::text::layout::trace::TraceSink;
@@ -166,7 +152,7 @@ impl<T: StringType + Clone> crate::trace::Trace for FormattedText<T> {
         let fit: Cell<Option<LayoutFit>> = Cell::new(None);
         t.component("FormattedText");
         t.in_list("text", &|l| {
-            let result = self.layout_content_debug(&mut TraceSink(l));
+            let result = self.layout_content(&mut TraceSink(l));
             fit.set(Some(result));
         });
         t.bool("fits", matches!(fit.get(), Some(LayoutFit::Fitting { .. })));

--- a/core/embed/rust/src/ui/model_tr/component/flow_pages.rs
+++ b/core/embed/rust/src/ui/model_tr/component/flow_pages.rs
@@ -97,7 +97,7 @@ where
         btn_actions: ButtonActions,
         formatted: FormattedText<T>,
     ) -> Self {
-        Self {
+        let mut page = Self {
             formatted,
             btn_layout,
             btn_actions,
@@ -105,7 +105,9 @@ where
             page_count: 1,
             title: None,
             slim_arrows: false,
-        }
+        };
+        page.change_page(page.current_page);
+        page
     }
 }
 
@@ -127,7 +129,6 @@ where
     }
 
     pub fn paint(&mut self) {
-        self.change_page(self.current_page);
         self.formatted.paint();
     }
 
@@ -193,10 +194,12 @@ where
 
     pub fn go_to_prev_page(&mut self) {
         self.current_page -= 1;
+        self.change_page(self.current_page);
     }
 
     pub fn go_to_next_page(&mut self) {
         self.current_page += 1;
+        self.change_page(self.current_page);
     }
 
     pub fn get_current_page(&self) -> usize {
@@ -240,7 +243,7 @@ where
         t.int("active_page", self.current_page as i64);
         t.int("page_count", self.page_count as i64);
         t.in_list("text", &|l| {
-            let result = self.formatted.layout_content_debug(&mut TraceSink(l));
+            let result = self.formatted.layout_content(&mut TraceSink(l));
             fit.set(Some(result));
         });
     }

--- a/core/embed/rust/src/ui/model_tr/component/input_methods/choice.rs
+++ b/core/embed/rust/src/ui/model_tr/component/input_methods/choice.rs
@@ -294,11 +294,6 @@ where
     fn show_current_choice(&mut self, area: Rect) {
         self.get_current_item()
             .paint_center(area, self.inverse_selected_item);
-
-        // Color inversion is just one-time thing.
-        if self.inverse_selected_item {
-            self.inverse_selected_item = false;
-        }
     }
 
     /// Display all the choices fitting on the left side.
@@ -491,6 +486,11 @@ where
     }
 
     fn event(&mut self, ctx: &mut EventCtx, event: Event) -> Option<Self::Msg> {
+        // Cancel highlighting of the current choice.
+        // The Highlighting is started by pressing the middle button and
+        // canceled immediately when any other event is processed
+        self.inverse_selected_item = false;
+
         // Possible animation movement when setting (randomizing) the page counter.
         if let Some(animation_direction) = self.animation_event(ctx, event) {
             match animation_direction {

--- a/core/embed/rust/src/ui/model_tt/component/keyboard/passphrase.rs
+++ b/core/embed/rust/src/ui/model_tt/component/keyboard/passphrase.rs
@@ -13,6 +13,8 @@ use crate::ui::{
     util::long_line_content_with_ellipsis,
 };
 
+use core::cell::Cell;
+
 pub enum PassphraseKeyboardMsg {
     Confirmed,
     Cancelled,
@@ -25,7 +27,7 @@ pub struct PassphraseKeyboard {
     confirm: Child<Button<&'static str>>,
     keys: [Child<Button<&'static str>>; KEY_COUNT],
     scrollbar: ScrollBar,
-    fade: bool,
+    fade: Cell<bool>,
 }
 
 const STARTING_PAGE: usize = 1;
@@ -63,7 +65,7 @@ impl PassphraseKeyboard {
                 Child::new(Button::new(Self::key_content(text)).styled(theme::button_pin()))
             }),
             scrollbar: ScrollBar::horizontal(),
-            fade: false,
+            fade: Cell::new(false),
         }
     }
 
@@ -99,7 +101,7 @@ impl PassphraseKeyboard {
         // Update buttons.
         self.replace_button_content(ctx, key_page);
         // Reset backlight to normal level on next paint.
-        self.fade = true;
+        self.fade.set(true);
         // So that swipe does not visually enable the input buttons when max length
         // reached
         self.update_input_btns_state(ctx);
@@ -288,8 +290,7 @@ impl Component for PassphraseKeyboard {
         for btn in &mut self.keys {
             btn.paint();
         }
-        if self.fade {
-            self.fade = false;
+        if self.fade.take() {
             // Note that this is blocking and takes some time.
             display::fade_backlight(theme::BACKLIGHT_NORMAL);
         }

--- a/core/embed/rust/src/ui/model_tt/component/simple_page.rs
+++ b/core/embed/rust/src/ui/model_tt/component/simple_page.rs
@@ -5,6 +5,7 @@ use crate::ui::{
 };
 
 use super::{theme, ScrollBar, Swipe, SwipeDirection};
+use core::cell::Cell;
 
 const SCROLLBAR_HEIGHT: i16 = 18;
 const SCROLLBAR_BORDER: i16 = 4;
@@ -16,7 +17,7 @@ pub struct SimplePage<T> {
     scrollbar: ScrollBar,
     axis: Axis,
     swipe_right_to_go_back: bool,
-    fade: Option<u16>,
+    fade: Cell<Option<u16>>,
 }
 
 impl<T> SimplePage<T>
@@ -32,7 +33,7 @@ where
             scrollbar: ScrollBar::new(axis),
             axis,
             swipe_right_to_go_back: false,
-            fade: None,
+            fade: Cell::new(None),
         }
     }
 
@@ -79,7 +80,7 @@ where
 
         // Swipe has dimmed the screen, so fade back to normal backlight after the next
         // paint.
-        self.fade = Some(theme::BACKLIGHT_NORMAL);
+        self.fade.set(Some(theme::BACKLIGHT_NORMAL));
     }
 
     fn is_horizontal(&self) -> bool {


### PR DESCRIPTION
This PR alters the logic of certain components by eliminating the requirement for `&mut self` in `paint()` functions. The PR serves as preparation for merging a new drawing library that requires it.

Two approaches were used:

1) Interior mutability utilizing `Cell` or `RefCell`.
2) Moving the mutation of component state to event processing.

**The behavior of the device was not affected by this change.** 

