### PR TITLE
fix order of loading BHK into SAES key register

### DIFF
--- a/core/embed/trezorhal/stm32u5/secure_aes.c
+++ b/core/embed/trezorhal/stm32u5/secure_aes.c
@@ -40,14 +40,14 @@ secbool secure_aes_init(void) {
 }
 
 static void secure_aes_load_bhk(void) {
-  TAMP->BKP7R;
-  TAMP->BKP6R;
-  TAMP->BKP5R;
-  TAMP->BKP4R;
-  TAMP->BKP3R;
-  TAMP->BKP2R;
-  TAMP->BKP1R;
   TAMP->BKP0R;
+  TAMP->BKP1R;
+  TAMP->BKP2R;
+  TAMP->BKP3R;
+  TAMP->BKP4R;
+  TAMP->BKP5R;
+  TAMP->BKP6R;
+  TAMP->BKP7R;
 }
 
 secbool secure_aes_encrypt(uint32_t* input, size_t size, uint32_t* output) {


### PR DESCRIPTION
According to errata, BHK loading into SAES key register must be done in ascending order.

Though i have verified that encryption and decryption still works (comparing results from SAES using BHK and regular hw AES peripheral using same key), the key is loaded into key reg according to the access order to the backup register thus ends up being different from what one would expect by looking into reference manual.

I don't think this makes any difference in our case, but nevertheless, lets follow the docs.

https://www.st.com/resource/en/errata_sheet/es0499-stm32u575xx-and-stm32u585xx-device-errata-stmicroelectronics.pdf

![saes_errata](https://github.com/trezor/trezor-firmware/assets/37884576/4ffa5826-73dd-4b5a-a754-dd4f910ae39a)

![saes_reference](https://github.com/trezor/trezor-firmware/assets/37884576/4d64367b-eb04-4531-a77d-52fed344dcf7)

<!--
If you are a core dev:

Don't forget to set up the fields:
- assign yourself
- set priority to same as original issue
- add PR to sprint
- if Draft -> "in progress"
- if final PR -> "needs review"

If you're an external contributor, you can ignore this text.
-->
