### PR TITLE
feat(core): drop support for after-step-hook

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -107,16 +107,16 @@ mocks_check: ## check validity of mock python headers
 	flake8 core/mocks/generated
 
 templates: icons ## rebuild coin lists from definitions in common
-	./core/tools/build_templates
+	make -C core templates
 
 templates_check: ## check that coin lists are up to date
-	./core/tools/build_templates --check
+	make -C core templates_check
 
 solana_templates: ## rebuild Solana instruction template file
-	./core/tools/build_solana_templates
+	make -C core solana_templates
 
 solana_templates_check: ## check that Solana instruction template file is up to date
-	./core/tools/build_solana_templates --check
+	make -C core solana_templates_check
 
 icons: ## generate FIDO service icons
 	python3 core/tools/build_icons.py

--- a/core/Makefile
+++ b/core/Makefile
@@ -211,11 +211,19 @@ clippy:
 
 ## code generation:
 
-templates: ## render Mako templates (for lists of coins, tokens, etc.)
+templates: translations ## render Mako templates (for lists of coins, tokens, etc.)
 	./tools/build_templates
 
-templates_check: ## check that Mako-rendered files match their templates
+templates_check: translations_check ## check that Mako-rendered files match their templates
 	./tools/build_templates --check
+
+translations: ## update translations
+	python ./translations/order.py
+	python ./translations/cli.py gen
+
+translations_check: ## check that translations are up to date
+	# spits out error if the stored merkle root is not up to date
+	python ./translations/cli.py merkle-root > /dev/null
 
 solana_templates: ## rebuild Solana instruction template file
 	./tools/build_solana_templates
@@ -455,3 +463,5 @@ coverage:  ## generate coverage report
 unused:  ## find unused micropython code
 	vulture src src/_vulture_ignore.txt --exclude "messages.py,*/enums/*"
 
+
+.PHONY: templates translations templates_check translations_check

--- a/core/SConscript.firmware
+++ b/core/SConscript.firmware
@@ -367,6 +367,12 @@ if FEATURE_FLAGS["SYSTEM_VIEW"]:
     CPPDEFINES_MOD += ['SYSTEM_VIEW']
     CCFLAGS_MOD += '-DSYSTEM_VIEW '
 
+TRANSLATION_DATA = [
+    "translations/en.json",
+    "translations/order.json",
+]
+
+
 # fonts
 tools.add_font('NORMAL', FONT_NORMAL, CPPDEFINES_MOD, SOURCE_MOD)
 tools.add_font('BOLD', FONT_BOLD, CPPDEFINES_MOD, SOURCE_MOD)
@@ -749,6 +755,7 @@ rust = env.Command(
     source='',
     action=cargo_build(), )
 env.Depends(rust, protobuf_blobs)
+env.Depends(rust, TRANSLATION_DATA)
 
 env.Append(LINKFLAGS=f' -L{RUST_LIBDIR}')
 env.Append(LINKFLAGS=f' -l{RUST_LIB}')

--- a/core/SConscript.unix
+++ b/core/SConscript.unix
@@ -417,6 +417,12 @@ if DMA2D:
     ]
 
 
+TRANSLATION_DATA = [
+    "translations/en.json",
+    "translations/order.json",
+]
+
+
 # fonts
 tools.add_font('NORMAL', FONT_NORMAL, CPPDEFINES_MOD, SOURCE_MOD)
 tools.add_font('BOLD', FONT_BOLD, CPPDEFINES_MOD, SOURCE_MOD)
@@ -833,6 +839,7 @@ rust = env.Command(
     source='',
     action=cargo_build(), )
 env.Depends(rust, protobuf_blobs)
+env.Depends(rust, TRANSLATION_DATA)
 
 
 env.Append(LINKFLAGS=f'-L{RUST_LIBDIR}')

--- a/core/src/apps/debug/__init__.py
+++ b/core/src/apps/debug/__init__.py
@@ -220,6 +220,8 @@ if __debug__:
 
     async def dispatch_DebugLinkRecordScreen(msg: DebugLinkRecordScreen) -> Success:
         if msg.target_directory:
+            from trezor import ui
+
             # In case emulator is restarted but we still want to record screenshots
             # into the same directory as before, we need to increment the refresh index,
             # so that the screenshots are not overwritten.
@@ -227,6 +229,7 @@ if __debug__:
             REFRESH_INDEX = msg.refresh_index
             storage.save_screen_directory = msg.target_directory
             storage.save_screen = True
+            ui.refresh()
         else:
             storage.save_screen = False
             display.clear_save()  # clear C buffers

--- a/core/src/trezor/loop.py
+++ b/core/src/trezor/loop.py
@@ -20,9 +20,6 @@ if TYPE_CHECKING:
     AwaitableTask = Task | Awaitable
     Finalizer = Callable[[Task, Any], None]
 
-# function to call after every task step
-after_step_hook: Callable[[], None] | None = None
-
 # tasks scheduled for execution in the future
 _queue = utimeq.utimeq(64)
 
@@ -176,8 +173,6 @@ def _step(task: Task, value: Any) -> None:
         else:
             if __debug__:
                 log.error(__name__, "unknown syscall: %s", result)
-        if after_step_hook:
-            after_step_hook()
 
 
 class Syscall:

--- a/core/src/trezor/loop.py
+++ b/core/src/trezor/loop.py
@@ -90,6 +90,9 @@ def close(task: Task) -> None:
     """
     for iface in _paused:  # pylint: disable=consider-using-dict-items
         _paused[iface].discard(task)
+    for iface in _paused:  # pylint: disable=consider-using-dict-items
+        if not _paused[iface]:
+            del _paused[iface]
     _queue.discard(task)
     task.close()
     finalize(task, GeneratorExit())

--- a/core/src/trezor/ui/__init__.py
+++ b/core/src/trezor/ui/__init__.py
@@ -47,12 +47,6 @@ if __debug__:
 else:
     refresh = display.refresh  # type: ignore [obscured-by-same-name]
 
-
-# in both debug and production, emulator needs to draw the screen explicitly
-if utils.EMULATOR or utils.INTERNAL_MODEL in ("T1B1", "T2B1"):
-    loop.after_step_hook = refresh
-
-
 # import style later to avoid circular dep
 from trezor.ui import style  # isort:skip
 

--- a/core/translations/order.py
+++ b/core/translations/order.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 import json
+import os
 
 from pathlib import Path
 
@@ -29,6 +30,8 @@ def generate_new_order() -> None:
             old_order[new_index] = item
 
         output_file.write_text(json.dumps(old_order, indent=2) + "\n")
+        stat = language_file.stat()
+        os.utime(output_file, ns=(stat.st_atime_ns, stat.st_mtime_ns))
     else:
         print("No new items found.")
 

--- a/core/translations/signatures.json
+++ b/core/translations/signatures.json
@@ -1,9 +1,9 @@
 {
   "current": {
-    "merkle_root": "8eb1e04215ee1e9c083b6abef4eae47a2f6c9ad3d8e8b8e0542505b7e0078b58",
-    "signature": null,
-    "datetime": "2024-03-08T20:33:12.745274",
-    "commit": "1005d857f8d4ee2ccee70fa8407052df7b7d1c13"
+    "merkle_root": "7393c46812b1bdf8789adcfde4feea951c7036c7524d9b38f64641620504898e",
+    "signature": "03ca77980a972b9ff9825a67d5be437f2588f095104fefc9d0415702f065fc063f9f30ce69768bf1b3c8ae7e93220c61f1e3a6d0d1cc52b8ddae6bd1766bd4f202",
+    "datetime": "2024-03-07T11:26:08.409760",
+    "commit": "45e8a842a31e62a6d43d7f6ccac62a45e1198ef0"
   },
   "history": []
 }

--- a/core/translations/signatures.json
+++ b/core/translations/signatures.json
@@ -1,7 +1,6 @@
 {
   "current": {
     "merkle_root": "d349550e9ad7be0b63b06fc43c6b764d008bf4497a8e1d0374cb92119b242160",
-    "signature": null,
     "datetime": "2024-03-25T14:23:51.859562",
     "commit": "ef11039a818bb0941191af49e0c9a0f7aae9324a"
   },

--- a/core/translations/signatures.json
+++ b/core/translations/signatures.json
@@ -9,7 +9,8 @@
       "merkle_root": "7393c46812b1bdf8789adcfde4feea951c7036c7524d9b38f64641620504898e",
       "signature": "03ca77980a972b9ff9825a67d5be437f2588f095104fefc9d0415702f065fc063f9f30ce69768bf1b3c8ae7e93220c61f1e3a6d0d1cc52b8ddae6bd1766bd4f202",
       "datetime": "2024-03-07T11:26:08.409760",
-      "commit": "45e8a842a31e62a6d43d7f6ccac62a45e1198ef0"
+      "commit": "45e8a842a31e62a6d43d7f6ccac62a45e1198ef0",
+      "version": "2.7.0.0"
     }
   ]
 }

--- a/core/translations/signatures.json
+++ b/core/translations/signatures.json
@@ -1,9 +1,16 @@
 {
   "current": {
-    "merkle_root": "7393c46812b1bdf8789adcfde4feea951c7036c7524d9b38f64641620504898e",
-    "signature": "03ca77980a972b9ff9825a67d5be437f2588f095104fefc9d0415702f065fc063f9f30ce69768bf1b3c8ae7e93220c61f1e3a6d0d1cc52b8ddae6bd1766bd4f202",
-    "datetime": "2024-03-07T11:26:08.409760",
-    "commit": "45e8a842a31e62a6d43d7f6ccac62a45e1198ef0"
+    "merkle_root": "d349550e9ad7be0b63b06fc43c6b764d008bf4497a8e1d0374cb92119b242160",
+    "signature": null,
+    "datetime": "2024-03-25T14:23:51.859562",
+    "commit": "ef11039a818bb0941191af49e0c9a0f7aae9324a"
   },
-  "history": []
+  "history": [
+    {
+      "merkle_root": "7393c46812b1bdf8789adcfde4feea951c7036c7524d9b38f64641620504898e",
+      "signature": "03ca77980a972b9ff9825a67d5be437f2588f095104fefc9d0415702f065fc063f9f30ce69768bf1b3c8ae7e93220c61f1e3a6d0d1cc52b8ddae6bd1766bd4f202",
+      "datetime": "2024-03-07T11:26:08.409760",
+      "commit": "45e8a842a31e62a6d43d7f6ccac62a45e1198ef0"
+    }
+  ]
 }


### PR DESCRIPTION
### Chipmakers hate her!
### Local granny discovers One Weird Trick for saving up to 50 % clock cycles

(less on actual hardware)

so it turns out that in `loop.py::run()` the hottest of our hot paths, there's this code:
```
if after_step_hook:
   after_step_hook()
```
what's `after_step_hook`, you ask?
well, on Trezor T, it's `None`. so that's one useless code branch
(and no, this isn't optimized out, we're in Python here)

In emulator, and on T2B1, `after_step_hook = display.refresh()`
I don't exactly recall why this was there. My suspicion is that with the previous UI toolkit, we relied on immediate mode painting on the TT but it didn't work on the emulator (nor when we later added TS3 that paints into an internal buffer even on real hardware).

Then UI2 came along and we're sticking explicit `ui.refresh()` calls liberally on all painting paths, presumably because the implicit refresh was failing in some weird cases? Maybe Rust is drawing something without hitting the loop? Maybe the screenshotting thing had a problem? I don't know, hence why this is just a draft for now.

...annnnyway. By completely random chance I was profiling the emulator and noticed that `display_refresh()` gets called billions of times.

Removing the whole `after_step_hook` mechanism doesn't seem to have any adverse effects in my (limited) testing so far, and it speeds up device-tests in frozen build by a whooping 50 % (that's in headless mode so no actual screen drawing, mind you. but under the hood the texture updates were happening anyway).

<!--
If you are a core dev:

Don't forget to set up the fields:
- assign yourself
- set priority to same as original issue
- add PR to sprint
- if Draft -> "in progress"
- if final PR -> "needs review"

If you're an external contributor, you can ignore this text.
-->
