### PR TITLE
do not require sd detect pin for running SD card test on T3T1

### DIFF
--- a/core/embed/prodtest/main.c
+++ b/core/embed/prodtest/main.c
@@ -402,12 +402,17 @@ static void test_sd(void) {
   static uint32_t buf1[BLOCK_SIZE / sizeof(uint32_t)];
   static uint32_t buf2[BLOCK_SIZE / sizeof(uint32_t)];
 
+#ifndef TREZOR_MODEL_T3T1
   if (sectrue != sdcard_is_present()) {
     vcp_println("ERROR NOCARD");
     return;
   }
+#endif
 
-  ensure(sdcard_power_on(), NULL);
+  if (sectrue != sdcard_power_on_unchecked()) {
+    vcp_println("ERROR POWER ON");
+    return;
+  }
   if (sectrue != sdcard_read_blocks(buf1, 0, BLOCK_SIZE / SDCARD_BLOCK_SIZE)) {
     vcp_println("ERROR sdcard_read_blocks (0)");
     goto power_off;

--- a/core/embed/trezorhal/sdcard.h
+++ b/core/embed/trezorhal/sdcard.h
@@ -52,6 +52,7 @@
 #define SDCARD_BLOCK_SIZE (512)
 
 void sdcard_init(void);
+secbool __wur sdcard_power_on_unchecked(void);
 secbool __wur sdcard_power_on(void);
 void sdcard_power_off(void);
 secbool __wur sdcard_is_present(void);

--- a/core/embed/trezorhal/stm32f4/sdcard.c
+++ b/core/embed/trezorhal/stm32f4/sdcard.c
@@ -148,10 +148,7 @@ void HAL_SD_MspDeInit(SD_HandleTypeDef *hsd) {
   }
 }
 
-secbool sdcard_power_on(void) {
-  if (sectrue != sdcard_is_present()) {
-    return secfalse;
-  }
+secbool sdcard_power_on_unchecked(void) {
   if (sd_handle.Instance) {
     return sectrue;
   }
@@ -198,6 +195,14 @@ secbool sdcard_power_on(void) {
 error:
   sdcard_power_off();
   return secfalse;
+}
+
+secbool sdcard_power_on(void) {
+  if (sectrue != sdcard_is_present()) {
+    return secfalse;
+  }
+
+  return sdcard_power_on_unchecked();
 }
 
 void sdcard_power_off(void) {

--- a/core/embed/trezorhal/stm32u5/sdcard.c
+++ b/core/embed/trezorhal/stm32u5/sdcard.c
@@ -152,10 +152,7 @@ void HAL_SD_MspDeInit(SD_HandleTypeDef *hsd) {
   }
 }
 
-secbool sdcard_power_on(void) {
-  if (sectrue != sdcard_is_present()) {
-    return secfalse;
-  }
+secbool sdcard_power_on_unchecked(void) {
   if (sd_handle.Instance) {
     return sectrue;
   }
@@ -201,6 +198,14 @@ secbool sdcard_power_on(void) {
 error:
   sdcard_power_off();
   return secfalse;
+}
+
+secbool sdcard_power_on(void) {
+  if (sectrue != sdcard_is_present()) {
+    return secfalse;
+  }
+
+  return sdcard_power_on_unchecked();
 }
 
 void sdcard_power_off(void) {

--- a/core/embed/trezorhal/unix/sdcard.c
+++ b/core/embed/trezorhal/unix/sdcard.c
@@ -87,11 +87,13 @@ void sdcard_init(void) {
 
 secbool sdcard_is_present(void) { return sectrue; }
 
-secbool sdcard_power_on(void) {
+secbool sdcard_power_on_unchecked(void) {
   sdcard_init();
   sdcard_powered = sectrue;
   return sectrue;
 }
+
+secbool sdcard_power_on(void) { return sdcard_power_on_unchecked(); }
 
 void sdcard_power_off(void) { sdcard_powered = secfalse; }
 


### PR DESCRIPTION
Due to the HW limitation and tester concept it is not possible to set the SD detect signal when testing the SD card on T3T1.


[no changelog]

<!--
If you are a core dev:

Don't forget to set up the fields:
- assign yourself
- set priority to same as original issue
- add PR to sprint
- if Draft -> "in progress"
- if final PR -> "needs review"

If you're an external contributor, you can ignore this text.
-->
