### PR TITLE
fix(core): fix build on disc2 model

### DIFF
--- a/core/embed/models/model_D002.h
+++ b/core/embed/models/model_D002.h
@@ -1,6 +1,8 @@
 #ifndef MODELS_MODEL_DISC2_H_
 #define MODELS_MODEL_DISC2_H_
 
+#include "sizedefs.h"
+
 #define MODEL_NAME "T"
 #define MODEL_FULL_NAME "Trezor Model T"
 #define MODEL_INTERNAL_NAME "D002"

--- a/core/embed/models/model_D002_layout.c
+++ b/core/embed/models/model_D002_layout.c
@@ -45,8 +45,8 @@ const flash_area_t FIRMWARE_AREA = {
     .num_subareas = 1,
     .subarea[0] =
         {
-            .first_sector = FIRMWARE_SECTOR_START.num_sectors =
-                FIRMWARE_SECTOR_END - FIRMWARE_SECTOR_START + 1,
+            .first_sector = FIRMWARE_SECTOR_START,
+            .num_sectors = FIRMWARE_SECTOR_END - FIRMWARE_SECTOR_START + 1,
         },
 };
 


### PR DESCRIPTION
This tiny PR fixes the broken build on **disc2** platform:

```
make build_firmware TREZOR_MODEL=DISC2 BOOTLOADER_DEVEL=1
```

It doesn't affect any other platform.


