### PR TITLE
ci: actions: add T3T1 firmware build

### DIFF
--- a/.github/workflows/core.yml
+++ b/.github/workflows/core.yml
@@ -46,7 +46,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        model: [T2T1, T2B1]  # FIXME: add T3T1 after https://github.com/trezor/trezor-firmware/pull/3553 is fixed
+        model: [T2T1, T2B1, T3T1]
         coins: [universal, btconly]
         type: ${{ fromJSON(github.event_name == 'schedule' && '["normal", "debuglink", "production"]' || '["normal", "debuglink"]') }}
         include:
@@ -58,6 +58,7 @@ jobs:
       BITCOIN_ONLY: ${{ matrix.coins == 'universal' && '0' || '1' }}
       PYOPT: ${{ matrix.type == 'debuglink' && '0' || '1' }}
       PRODUCTION: ${{ matrix.type == 'production' && '1' || '0' }}
+      BOOTLOADER_DEVEL: ${{ matrix.model == 'T3T1' && '1' || '0' }}
     steps:
       - uses: actions/checkout@v4
         with:
@@ -453,7 +454,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        model: [T2T1, T2B1]
+        model: [T2T1, T2B1]  # FIXME: checker.py lacks awareness of T3T1 flash layout
     steps:
       - uses: actions/checkout@v4
         with:
@@ -476,7 +477,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        model: [T2T1, T2B1]
+        model: [T2T1]  # FIXME: T2T1 url is hardcoded in compare_master.py
     steps:
       - uses: actions/checkout@v4
         with:


### PR DESCRIPTION
Skipping `build_prodtest` as it's failing with
```
scons: *** [build/prodtest/embed/prodtest/vendorheader.o] Source `embed/vendorheader/T3T1/vendorheader_unsafe_signed_prod.bin' not found, needed by target `build/prodtest/embed/prodtest/vendorheader.o'.
```

<!--
If you are a core dev:

Don't forget to set up the fields:
- assign yourself
- set priority to same as original issue
- add PR to sprint
- if Draft -> "in progress"
- if final PR -> "needs review"

If you're an external contributor, you can ignore this text.
-->
