### PR TITLE
refactor(core): improve safety of translation blobs

### DIFF
--- a/core/embed/rust/Cargo.lock
+++ b/core/embed/rust/Cargo.lock
@@ -284,9 +284,9 @@ checksum = "0fda2ff0d084019ba4d7c6f371c95d8fd75ce3524c3cb8fb653a3023f6323e64"
 
 [[package]]
 name = "spin"
-version = "0.9.2"
+version = "0.9.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "511254be0c5bcf062b019a6c89c01a664aa359ded62f78aa72c6fc137c0590e5"
+checksum = "6980e8d7511241f8acf4aebddbb1ff938df5eebe98691418c4468d0b72a96a67"
 dependencies = [
  "lock_api",
 ]
@@ -326,6 +326,7 @@ dependencies = [
  "num-traits",
  "qrcodegen",
  "serde_json",
+ "spin",
  "trezor-tjpgdec",
  "zeroize",
 ]

--- a/core/embed/rust/Cargo.toml
+++ b/core/embed/rust/Cargo.toml
@@ -77,6 +77,7 @@ debug = 2
 
 [dependencies]
 qrcodegen = { version = "1.8.0", path = "../../vendor/QR-Code-generator/rust-no-heap" }
+spin = { version = "0.9.8", features = ["rwlock"], default-features = false }
 trezor-tjpgdec = { version = "0.1.0", path = "../../../rust/trezor-tjpgdec" }
 zeroize = { version = "1.7.0", default-features = false, optional = true }
 

--- a/core/embed/rust/src/strutil.rs
+++ b/core/embed/rust/src/strutil.rs
@@ -102,10 +102,17 @@ impl TString<'_> {
         self.map(|s| s.is_empty())
     }
 
+    /// Maps the string to a value using a closure.
+    ///
+    /// # Safety
+    ///
+    /// The properties of this function are bounded by the properties of
+    /// `TranslatedString::map_translated`. The reference to the string is
+    /// guaranteed to be valid throughout the closure, but must not escape
+    /// it. The `for<'a>` bound on the closure's argument ensures this.
     pub fn map<F, T>(&self, fun: F) -> T
     where
         F: for<'a> FnOnce(&'a str) -> T,
-        T: 'static,
     {
         match self {
             #[cfg(feature = "micropython")]

--- a/core/embed/rust/src/translations/blob.rs
+++ b/core/embed/rust/src/translations/blob.rs
@@ -122,7 +122,7 @@ impl<'a> Table<'a> {
 }
 
 pub struct Translations<'a> {
-    pub header: TranslationsHeader<'a>,
+    header: TranslationsHeader<'a>,
     translations: &'a [u8],
     translations_offsets: &'a [u16],
     fonts: Table<'a>,
@@ -196,7 +196,15 @@ impl<'a> Translations<'a> {
     }
 
     /// Returns the translation at the given index.
-    pub fn translation(&self, index: usize) -> Option<&str> {
+    ///
+    /// SAFETY: Do not mess with the lifetimes in this signature.
+    ///
+    /// The lifetimes are a useful lie that bind the lifetime of the returned
+    /// string not to the underlying data, but to the _reference_ to the
+    /// translations object. This is to facilitate safe interface to
+    /// flash-based translations. See docs for `flash::get` for details.
+    #[allow(clippy::needless_lifetimes)]
+    pub fn translation<'b>(&'b self, index: usize) -> Option<&'b str> {
         if index + 1 >= self.translations_offsets.len() {
             // The index is out of bounds.
             // (The last entry is a sentinel, so the last valid index is len - 2)
@@ -223,10 +231,32 @@ impl<'a> Translations<'a> {
         str::from_utf8(string).ok()
     }
 
-    pub fn font(&'a self, index: u16) -> Option<Table<'a>> {
+    /// Returns the font table at the given index.
+    ///
+    /// SAFETY: Do not mess with the lifetimes in this signature.
+    ///
+    /// The lifetimes are a useful lie that bind the lifetime of the returned
+    /// string not to the underlying data, but to the _reference_ to the
+    /// translations object. This is to facilitate safe interface to
+    /// flash-based translations. See docs for `flash::get` for details.
+    #[allow(clippy::needless_lifetimes)]
+    pub fn font<'b>(&'b self, index: u16) -> Option<Table<'b>> {
         self.fonts
             .get(index)
             .and_then(|data| Table::new(InputStream::new(data)).ok())
+    }
+
+    /// Returns the header of the translations blob.
+    ///
+    /// SAFETY: Do not mess with the lifetimes in this signature.
+    ///
+    /// The lifetimes are a useful lie that bind the lifetime of the returned
+    /// string not to the underlying data, but to the _reference_ to the
+    /// translations object. This is to facilitate safe interface to
+    /// flash-based translations. See docs for `flash::get` for details.
+    #[allow(clippy::needless_lifetimes)]
+    pub fn header<'b>(&'b self) -> &'b TranslationsHeader<'b> {
+        &self.header
     }
 }
 

--- a/core/embed/rust/src/translations/mod.rs
+++ b/core/embed/rust/src/translations/mod.rs
@@ -22,7 +22,10 @@ pub unsafe extern "C" fn get_utf8_glyph(codepoint: cty::uint16_t, font: cty::c_i
     // SAFETY: Reference is discarded at the end of the function.
     // We do return a _pointer_ to the same memory location, but the pointer is
     // always valid.
-    let Some(tr) = (unsafe { flash::get() }) else {
+    let Ok(translations) = flash::get() else {
+        return core::ptr::null();
+    };
+    let Some(tr) = translations.as_ref() else {
         return core::ptr::null();
     };
     if let Some(glyph) = tr.font(font_abs).and_then(|t| t.get(codepoint)) {

--- a/core/embed/rust/src/translations/translated_string.rs
+++ b/core/embed/rust/src/translations/translated_string.rs
@@ -10,16 +10,25 @@ impl TranslatedString {
             .unwrap_or(self.untranslated())
     }
 
+    /// Maps the translated string to a value using a closure.
+    ///
+    /// # Safety
+    ///
+    /// This is the only safe way to access a reference to the flash data. This
+    /// function guarantees that the reference is valid throughout the
+    /// closure, but as soon as the closure returns, the lock held on flash
+    /// data is released. This means that translations could get deinited
+    /// and rewritten, invalidating the reference.
+    ///
+    /// To guarantee that the reference does not escape the closure, we use a
+    /// HRTB of the closure's argument, which ensures that the lifetime of
+    /// the reference is too short to store it outside in any form.
     pub fn map_translated<F, T>(self, fun: F) -> T
     where
         F: for<'a> FnOnce(&'a str) -> T,
-        T: 'static,
     {
-        // SAFETY: The bound on F _somehow_ ensures that the reference cannot escape
-        // the closure. (I don't understand how, but it does), see soundness test below.
-        // For good measure, we limit the return value to 'static.
-        let translations = unsafe { super::flash::get() };
-        fun(self.translate(translations))
+        let translations = unwrap!(super::flash::get());
+        fun(self.translate(translations.as_ref()))
     }
 
     pub const fn as_tstring(self) -> TString<'static> {


### PR DESCRIPTION
* the public interface to Translations is now completely safe
* it is more obvious that `map_translated` needs to work the way it does
* documentation is improved

<!--
If you are a core dev:

Don't forget to set up the fields:
- assign yourself
- set priority to same as original issue
- add PR to sprint
- if Draft -> "in progress"
- if final PR -> "needs review"

If you're an external contributor, you can ignore this text.
-->
