### PR TITLE
refactor(core): add ufmt, bump heapless from 0.7.6 - 0.8.0

### DIFF
--- a/core/embed/rust/Cargo.lock
+++ b/core/embed/rust/Cargo.lock
@@ -95,22 +95,22 @@ checksum = "9b919933a397b79c37e33b77bb2aa3dc8eb6e165ad809e58ff75bc7db2e34574"
 
 [[package]]
 name = "hash32"
-version = "0.2.1"
+version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b0c35f58762feb77d74ebe43bdbc3210f09be9fe6742234d573bacc26ed92b67"
+checksum = "47d60b12902ba28e2730cd37e95b8c9223af2808df9e902d4df49588d1470606"
 dependencies = [
  "byteorder",
 ]
 
 [[package]]
 name = "heapless"
-version = "0.7.6"
+version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "14db22a3fec113074342010bb85a75ba17789244649af8a3178594e0dc97c381"
+checksum = "0bfb9eb618601c89945a70e254898da93b13be0388091d42117462b265bb3fad"
 dependencies = [
  "hash32",
- "spin",
  "stable_deref_trait",
+ "ufmt-write",
 ]
 
 [[package]]
@@ -145,15 +145,6 @@ checksum = "6f84d96438c15fcd6c3f244c8fce01d1e2b9c6b5623e9c711dc9286d8fc92d6a"
 dependencies = [
  "cfg-if",
  "winapi",
-]
-
-[[package]]
-name = "lock_api"
-version = "0.4.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "712a4d093c9976e24e7dbca41db895dabcbac38eb5f4045393d17a95bdfb1109"
-dependencies = [
- "scopeguard",
 ]
 
 [[package]]
@@ -254,12 +245,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f91339c0467de62360649f8d3e185ca8de4224ff281f66000de5eb2a77a79041"
 
 [[package]]
-name = "scopeguard"
-version = "1.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d29ab0c6d3fc0ee92fe66e2d99f700eab17a8d57d1c1d3b748380fb20baa78cd"
-
-[[package]]
 name = "serde"
 version = "1.0.160"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -287,9 +272,6 @@ name = "spin"
 version = "0.9.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6980e8d7511241f8acf4aebddbb1ff938df5eebe98691418c4468d0b72a96a67"
-dependencies = [
- "lock_api",
-]
 
 [[package]]
 name = "stable_deref_trait"
@@ -328,8 +310,36 @@ dependencies = [
  "serde_json",
  "spin",
  "trezor-tjpgdec",
+ "ufmt",
  "zeroize",
 ]
+
+[[package]]
+name = "ufmt"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1a64846ec02b57e9108d6469d98d1648782ad6bb150a95a9baac26900bbeab9d"
+dependencies = [
+ "ufmt-macros",
+ "ufmt-write",
+]
+
+[[package]]
+name = "ufmt-macros"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d337d3be617449165cb4633c8dece429afd83f84051024079f97ad32a9663716"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "ufmt-write"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e87a2ed6b42ec5e28cc3b94c09982969e9227600b2e3dcbc1db927a84c06bd69"
 
 [[package]]
 name = "unicode-xid"

--- a/core/embed/rust/Cargo.toml
+++ b/core/embed/rust/Cargo.toml
@@ -79,6 +79,7 @@ debug = 2
 qrcodegen = { version = "1.8.0", path = "../../vendor/QR-Code-generator/rust-no-heap" }
 spin = { version = "0.9.8", features = ["rwlock"], default-features = false }
 trezor-tjpgdec = { version = "0.1.0", path = "../../../rust/trezor-tjpgdec" }
+ufmt = "0.2.0"
 zeroize = { version = "1.7.0", default-features = false, optional = true }
 
 # Runtime dependencies
@@ -87,7 +88,8 @@ zeroize = { version = "1.7.0", default-features = false, optional = true }
 version = "0.2.2"
 
 [dependencies.heapless]
-version = "0.7.3"
+version = "0.8.0"
+features = ["ufmt"]
 default_features = false
 
 [dependencies.num-traits]

--- a/core/embed/rust/src/ui/macros.rs
+++ b/core/embed/rust/src/ui/macros.rs
@@ -20,6 +20,6 @@ macro_rules! build_string {
 #[allow(unused_macros)] // not used in TT UI
 macro_rules! inttostr {
     ($int:expr) => {{
-        heapless::String::<10>::from($int).as_str()
+        unwrap!(heapless::String::<10>::try_from($int)).as_str()
     }};
 }

--- a/core/embed/rust/src/ui/model_tr/component/input_methods/choice_item.rs
+++ b/core/embed/rust/src/ui/model_tr/component/input_methods/choice_item.rs
@@ -25,7 +25,7 @@ pub struct ChoiceItem {
 impl ChoiceItem {
     pub fn new<U: AsRef<str>>(text: U, btn_layout: ButtonLayout) -> Self {
         Self {
-            text: String::from(text.as_ref()),
+            text: unwrap!(String::try_from(text.as_ref())),
             icon: None,
             btn_layout,
             font: theme::FONT_CHOICE_ITEMS,

--- a/core/embed/rust/src/ui/model_tr/component/input_methods/number_input.rs
+++ b/core/embed/rust/src/ui/model_tr/component/input_methods/number_input.rs
@@ -30,7 +30,7 @@ impl ChoiceFactory for ChoiceFactoryNumberInput {
 
     fn get(&self, choice_index: usize) -> (Self::Item, Self::Action) {
         let num = self.min + choice_index as u32;
-        let text: String<10> = String::from(num);
+        let text: String<10> = unwrap!(String::try_from(num));
         let mut choice_item = ChoiceItem::new(
             text,
             ButtonLayout::arrow_armed_arrow(TR::buttons__select.into()),

--- a/core/embed/rust/src/ui/model_tr/component/input_methods/passphrase.rs
+++ b/core/embed/rust/src/ui/model_tr/component/input_methods/passphrase.rs
@@ -292,9 +292,9 @@ impl PassphraseEntry {
 
     fn update_passphrase_dots(&mut self, ctx: &mut EventCtx) {
         let text_to_show = if self.show_plain_passphrase {
-            String::from(self.passphrase())
+            unwrap!(String::try_from(self.passphrase()))
         } else if self.is_empty() {
-            String::from("")
+            unwrap!(String::try_from(""))
         } else {
             // Showing asterisks and possibly the last digit.
             let mut dots: String<MAX_PASSPHRASE_LENGTH> = String::new();

--- a/core/embed/rust/src/ui/model_tr/component/input_methods/pin.rs
+++ b/core/embed/rust/src/ui/model_tr/component/input_methods/pin.rs
@@ -155,14 +155,14 @@ where
         let (showing_real_prompt, header_line_content, pin_line_content) = if show_subprompt {
             (
                 false,
-                TR::pin__title_wrong_pin.map_translated(|t| String::from(t)),
-                String::from(subprompt.as_ref()),
+                TR::pin__title_wrong_pin.map_translated(|t| unwrap!(String::try_from(t))),
+                unwrap!(String::try_from(subprompt.as_ref())),
             )
         } else {
             (
                 true,
-                String::from(prompt.as_ref()),
-                String::from(EMPTY_PIN_STR),
+                unwrap!(String::try_from(prompt.as_ref())),
+                unwrap!(String::try_from(EMPTY_PIN_STR)),
             )
         };
 
@@ -204,11 +204,11 @@ where
         let pin_line_text = if self.is_empty() && !self.subprompt.as_ref().is_empty() {
             // Showing the subprompt in NORMAL font
             used_font = Font::NORMAL;
-            String::from(self.subprompt.as_ref())
+            unwrap!(String::try_from(self.subprompt.as_ref()))
         } else if self.is_empty() {
-            String::from(EMPTY_PIN_STR)
+            unwrap!(String::try_from(EMPTY_PIN_STR))
         } else if self.show_real_pin {
-            String::from(self.pin())
+            unwrap!(String::try_from(self.pin()))
         } else {
             // Showing asterisks and possibly the last digit.
             let mut dots: String<MAX_PIN_LENGTH> = String::new();
@@ -234,7 +234,7 @@ where
     /// Showing the real prompt instead of WRONG PIN
     fn show_prompt(&mut self, ctx: &mut EventCtx) {
         self.header_line.mutate(ctx, |ctx, header_line| {
-            header_line.update_text(String::from(self.prompt.as_ref()));
+            header_line.update_text(unwrap!(String::try_from(self.prompt.as_ref())));
             header_line.request_complete_repaint(ctx);
         });
     }

--- a/core/embed/rust/src/ui/model_tr/component/input_methods/wordlist.rs
+++ b/core/embed/rust/src/ui/model_tr/component/input_methods/wordlist.rs
@@ -173,7 +173,9 @@ impl WordlistEntry {
                 .with_incomplete(true)
                 .with_carousel(true)
                 .with_initial_page_counter(get_random_position(choices_count)),
-            chosen_letters: Child::new(ChangingTextLine::center_mono(String::from(PROMPT))),
+            chosen_letters: Child::new(ChangingTextLine::center_mono(unwrap!(String::try_from(
+                PROMPT
+            )))),
             textbox: TextBox::empty(),
             offer_words: false,
             wordlist_type,
@@ -193,8 +195,10 @@ impl WordlistEntry {
             choice_page: ChoicePage::new(choices)
                 .with_incomplete(true)
                 .with_initial_page_counter(1),
-            chosen_letters: Child::new(ChangingTextLine::center_mono(String::from(word))),
-            textbox: TextBox::new(String::from(word)),
+            chosen_letters: Child::new(ChangingTextLine::center_mono(unwrap!(String::try_from(
+                word
+            )))),
+            textbox: TextBox::new(unwrap!(String::try_from(word))),
             offer_words: false,
             wordlist_type,
             can_go_back,

--- a/core/embed/rust/src/ui/model_tt/component/keyboard/bip39.rs
+++ b/core/embed/rust/src/ui/model_tt/component/keyboard/bip39.rs
@@ -181,7 +181,7 @@ impl Bip39Input {
         // Styling the input to reflect already filled word
         Self {
             button: Button::with_icon(theme::ICON_LIST_CHECK).styled(theme::button_pin_confirm()),
-            textbox: TextBox::new(String::from(word)),
+            textbox: TextBox::new(unwrap!(String::try_from(word))),
             multi_tap: MultiTapKeyboard::new(),
             options_num: bip39::options_num(word),
             suggested_word: bip39::complete_word(word),

--- a/core/embed/rust/src/ui/util.rs
+++ b/core/embed/rust/src/ui/util.rs
@@ -148,7 +148,7 @@ pub fn long_line_content_with_ellipsis(
     available_width: i16,
 ) -> ShortString {
     if text_font.text_width(text) <= available_width {
-        String::from(text) // whole text can fit
+        unwrap!(String::try_from(text)) // whole text can fit
     } else {
         // Text is longer, showing its right end with ellipsis at the beginning.
         // Finding out how many additional text characters will fit in,


### PR DESCRIPTION
This small PR adds the [ufmt](https://docs.rs/ufmt/latest/ufmt/) crate for string formatting.

Additionally, the `heapless` crate needed to be upgraded. However, there are some breaking changes: the `String<N>` type no longer implements the `From` trait; it has been replaced by the `TryFrom` trait. Consequently, all occurrences of `from` calls have been replaced by `try_from`, and `unwrap!` has been added where necessary.

**Note: Previous version of heapless used `unwrap()` internally in `from` implementation. So the final behavior remains the same.**

Changes Made:
- Added ufmt crate for string formatting.
- Upgraded heapless crate.
- Replaced occurrences of `from` with `try_from`.
- Added `unwrap!` where necessary.

**This PR does not alter the behavior of the device from the user's perspective.**

FYI: @mmilata, @grdddj, @obrusvit 