### PR TITLE
Remove unused function

### DIFF
--- a/crypto/bip32.c
+++ b/crypto/bip32.c
@@ -337,31 +337,6 @@ int hdnode_public_ckd(HDNode *inout, uint32_t i) {
   return 1;
 }
 
-void hdnode_public_ckd_address_optimized(const curve_point *pub,
-                                         const uint8_t *chain_code, uint32_t i,
-                                         uint32_t version,
-                                         HasherType hasher_pubkey,
-                                         HasherType hasher_base58, char *addr,
-                                         int addrsize, int addrformat) {
-  uint8_t child_pubkey[33] = {0};
-  curve_point b = {0};
-
-  hdnode_public_ckd_cp(&secp256k1, pub, chain_code, i, &b, NULL);
-  child_pubkey[0] = 0x02 | (b.y.val[0] & 0x01);
-  bn_write_be(&b.x, child_pubkey + 1);
-
-  switch (addrformat) {
-    case 1:  // Segwit-in-P2SH
-      ecdsa_get_address_segwit_p2sh(child_pubkey, version, hasher_pubkey,
-                                    hasher_base58, addr, addrsize);
-      break;
-    default:  // normal address
-      ecdsa_get_address(child_pubkey, version, hasher_pubkey, hasher_base58,
-                        addr, addrsize);
-      break;
-  }
-}
-
 #if USE_BIP32_CACHE
 static bool private_ckd_cache_root_set = false;
 static CONFIDENTIAL HDNode private_ckd_cache_root;

--- a/crypto/bip32.h
+++ b/crypto/bip32.h
@@ -81,13 +81,6 @@ int hdnode_public_ckd_cp(const ecdsa_curve *curve, const curve_point *parent,
 
 int hdnode_public_ckd(HDNode *inout, uint32_t i);
 
-void hdnode_public_ckd_address_optimized(const curve_point *pub,
-                                         const uint8_t *chain_code, uint32_t i,
-                                         uint32_t version,
-                                         HasherType hasher_pubkey,
-                                         HasherType hasher_base58, char *addr,
-                                         int addrsize, int addrformat);
-
 #if USE_BIP32_CACHE
 void bip32_cache_clear(void);
 int hdnode_private_ckd_cached(HDNode *inout, const uint32_t *i, size_t i_count,

--- a/crypto/tests/test_check.c
+++ b/crypto/tests/test_check.c
@@ -2013,34 +2013,6 @@ START_TEST(test_bip32_compare) {
 }
 END_TEST
 
-START_TEST(test_bip32_optimized) {
-  HDNode root;
-  hdnode_from_seed((uint8_t *)"NothingToSeeHere", 16, SECP256K1_NAME, &root);
-  ck_assert_int_eq(hdnode_fill_public_key(&root), 0);
-
-  curve_point pub;
-  ecdsa_read_pubkey(&secp256k1, root.public_key, &pub);
-
-  HDNode node;
-  char addr1[MAX_ADDR_SIZE], addr2[MAX_ADDR_SIZE];
-
-  for (int i = 0; i < 40; i++) {
-    // unoptimized
-    memcpy(&node, &root, sizeof(HDNode));
-    hdnode_public_ckd(&node, i);
-    ck_assert_int_eq(hdnode_fill_public_key(&node), 0);
-    ecdsa_get_address(node.public_key, 0, HASHER_SHA2_RIPEMD, HASHER_SHA2D,
-                      addr1, sizeof(addr1));
-    // optimized
-    hdnode_public_ckd_address_optimized(&pub, root.chain_code, i, 0,
-                                        HASHER_SHA2_RIPEMD, HASHER_SHA2D, addr2,
-                                        sizeof(addr2), 0);
-    // check
-    ck_assert_str_eq(addr1, addr2);
-  }
-}
-END_TEST
-
 START_TEST(test_bip32_cache_1) {
   HDNode node1, node2;
   int i, r;
@@ -10462,7 +10434,6 @@ Suite *test_suite(void) {
   tcase_add_test(tc, test_bip32_vector_3);
   tcase_add_test(tc, test_bip32_vector_4);
   tcase_add_test(tc, test_bip32_compare);
-  tcase_add_test(tc, test_bip32_optimized);
   tcase_add_test(tc, test_bip32_cache_1);
   tcase_add_test(tc, test_bip32_cache_2);
   suite_add_tcase(s, tc);

--- a/crypto/tests/test_speed.c
+++ b/crypto/tests/test_speed.c
@@ -174,26 +174,13 @@ void prepare_node(void) {
   hdnode_fill_public_key(&root);
 }
 
-void bench_ckd_normal(int iterations) {
+void bench_get_address(int iterations) {
   char addr[MAX_ADDR_SIZE];
   HDNode node;
   for (int i = 0; i < iterations; i++) {
     memcpy(&node, &root, sizeof(HDNode));
     hdnode_public_ckd(&node, i);
-    hdnode_fill_public_key(&node);
-    ecdsa_get_address(node.public_key, HASHER_SHA2, HASHER_SHA2D, 0, addr,
-                      sizeof(addr));
-  }
-}
-
-void bench_ckd_optimized(int iterations) {
-  char addr[MAX_ADDR_SIZE];
-  curve_point pub;
-  ecdsa_read_pubkey(&secp256k1, root.public_key, &pub);
-  for (int i = 0; i < iterations; i++) {
-    hdnode_public_ckd_address_optimized(&pub, root.chain_code, i, 0,
-                                        HASHER_SHA2, HASHER_SHA2D, addr,
-                                        sizeof(addr), false);
+    hdnode_get_address(&node, 0, addr, sizeof(addr));
   }
 }
 
@@ -224,8 +211,7 @@ int main(void) {
 
   prepare_node();
 
-  BENCH(bench_ckd_normal, 1000);
-  BENCH(bench_ckd_optimized, 1000);
+  BENCH(bench_get_address, 1000);
 
   return 0;
 }


### PR DESCRIPTION
This pull request removes `hdnode_public_ckd_address_optimized` from `crypto/bip32.c` which has not been used in the last 5 years.