### PR TITLE
feat(python): more compact debuglink logging

### DIFF
--- a/python/src/trezorlib/debuglink.py
+++ b/python/src/trezorlib/debuglink.py
@@ -424,9 +424,16 @@ class DebugLink:
             f"received type {msg_type} ({len(msg_bytes)} bytes): {msg_bytes.hex()}",
         )
         msg = self.mapping.decode(ret_type, ret_bytes)
+
+        # Collapse tokens to make log use less lines.
+        msg_for_log = msg
+        if isinstance(msg, (messages.DebugLinkState, messages.DebugLinkLayout)):
+            msg_for_log = deepcopy(msg)
+            msg_for_log.tokens = ["".join(msg_for_log.tokens)]
+
         LOG.debug(
-            f"received message: {msg.__class__.__name__}",
-            extra={"protobuf": msg},
+            f"received message: {msg_for_log.__class__.__name__}",
+            extra={"protobuf": msg_for_log},
         )
         return msg
 


### PR DESCRIPTION
Currently the tokens take up most of the lines in test output. I usually die of old age before I scroll up to the stack trace (if it's in the terminal buffer at all).

<!--
If you are a core dev:

Don't forget to set up the fields:
- assign yourself
- set priority to same as original issue
- add PR to sprint
- if Draft -> "in progress"
- if final PR -> "needs review"

If you're an external contributor, you can ignore this text.
-->
