### PR TITLE
fix(python): missing PIL.Image.ANTIALIAS

### DIFF
--- a/python/requirements-optional.txt
+++ b/python/requirements-optional.txt
@@ -1,5 +1,5 @@
 hidapi>=0.7.99.post20
 web3>=5
-Pillow
+Pillow>=10
 stellar-sdk>=6
 rlp>=1.1.0 ; python_version<'3.7'

--- a/python/src/trezorlib/cli/settings.py
+++ b/python/src/trezorlib/cli/settings.py
@@ -64,7 +64,7 @@ def image_to_t1(filename: Path) -> bytes:
             f"Image is not 128x64, but {image.size}. Do you want to resize it automatically?",
             default=True,
         ):
-            image = image.resize(T1_TR_IMAGE_SIZE, Image.ANTIALIAS)
+            image = image.resize(T1_TR_IMAGE_SIZE, Image.Resampling.LANCZOS)
         else:
             raise click.ClickException("Wrong size of the image - should be 128x64")
 
@@ -99,7 +99,7 @@ def image_to_toif(filename: Path, width: int, height: int, greyscale: bool) -> b
             f"Image is not {width}x{height}, but {image.size[0]}x{image.size[1]}. Do you want to resize it automatically?",
             default=True,
         ):
-            image = image.resize((width, height), Image.ANTIALIAS)
+            image = image.resize((width, height), Image.Resampling.LANCZOS)
         else:
             raise click.ClickException(
                 f"Wrong size of image - should be {width}x{height}"
@@ -137,7 +137,7 @@ def image_to_jpeg(filename: Path, width: int, height: int) -> bytes:
             f"Image is not {width}x{height}, but {image.size[0]}x{image.size[1]}. Do you want to resize it automatically?",
             default=True,
         ):
-            image = image.resize((width, height), Image.ANTIALIAS)
+            image = image.resize((width, height), Image.Resampling.LANCZOS)
         else:
             raise click.ClickException(
                 f"Wrong size of image - should be {width}x{height}"


### PR DESCRIPTION
Image.ANTIALIAS was [removed in 10.0.0](https://pillow.readthedocs.io/en/stable/releasenotes/10.0.0.html#constants). 10.0.0 was released on Jul 1, 2023.

<!--
If you are a core dev:

Don't forget to set up the fields:
- assign yourself
- set priority to same as original issue
- add PR to sprint
- if Draft -> "in progress"
- if final PR -> "needs review"

If you're an external contributor, you can ignore this text.
-->
