### PR TITLE
slow down SDIO communication in T3T1 prodtest

### DIFF
--- a/core/embed/prodtest/main.c
+++ b/core/embed/prodtest/main.c
@@ -403,14 +403,17 @@ static void test_sd(void) {
   static uint32_t buf1[BLOCK_SIZE / sizeof(uint32_t)];
   static uint32_t buf2[BLOCK_SIZE / sizeof(uint32_t)];
 
+  bool low_speed = false;
 #ifndef TREZOR_MODEL_T3T1
   if (sectrue != sdcard_is_present()) {
     vcp_println("ERROR NOCARD");
     return;
   }
+#else
+  low_speed = true;
 #endif
 
-  if (sectrue != sdcard_power_on_unchecked()) {
+  if (sectrue != sdcard_power_on_unchecked(low_speed)) {
     vcp_println("ERROR POWER ON");
     return;
   }

--- a/core/embed/trezorhal/sdcard.h
+++ b/core/embed/trezorhal/sdcard.h
@@ -46,13 +46,14 @@
 #ifndef __TREZORHAL_SDCARD_H__
 #define __TREZORHAL_SDCARD_H__
 
+#include <stdbool.h>
 #include "secbool.h"
 
 // this is a fixed size and should not be changed
 #define SDCARD_BLOCK_SIZE (512)
 
 void sdcard_init(void);
-secbool __wur sdcard_power_on_unchecked(void);
+secbool __wur sdcard_power_on_unchecked(bool low_speed);
 secbool __wur sdcard_power_on(void);
 void sdcard_power_off(void);
 secbool __wur sdcard_is_present(void);

--- a/core/embed/trezorhal/stm32f4/sdcard.c
+++ b/core/embed/trezorhal/stm32f4/sdcard.c
@@ -148,7 +148,7 @@ void HAL_SD_MspDeInit(SD_HandleTypeDef *hsd) {
   }
 }
 
-secbool sdcard_power_on_unchecked(void) {
+secbool sdcard_power_on_unchecked(bool low_speed) {
   if (sd_handle.Instance) {
     return sectrue;
   }
@@ -163,7 +163,7 @@ secbool sdcard_power_on_unchecked(void) {
   sd_handle.Init.ClockPowerSave = SDIO_CLOCK_POWER_SAVE_ENABLE;
   sd_handle.Init.BusWide = SDIO_BUS_WIDE_1B;
   sd_handle.Init.HardwareFlowControl = SDIO_HARDWARE_FLOW_CONTROL_DISABLE;
-  sd_handle.Init.ClockDiv = SDIO_TRANSFER_CLK_DIV;
+  sd_handle.Init.ClockDiv = low_speed ? 1 : SDIO_TRANSFER_CLK_DIV;
 
   // init the SD interface, with retry if it's not ready yet
   for (int retry = 10; HAL_SD_Init(&sd_handle) != HAL_OK; retry--) {
@@ -202,7 +202,7 @@ secbool sdcard_power_on(void) {
     return secfalse;
   }
 
-  return sdcard_power_on_unchecked();
+  return sdcard_power_on_unchecked(false);
 }
 
 void sdcard_power_off(void) {

--- a/core/embed/trezorhal/stm32u5/sdcard.c
+++ b/core/embed/trezorhal/stm32u5/sdcard.c
@@ -152,7 +152,7 @@ void HAL_SD_MspDeInit(SD_HandleTypeDef *hsd) {
   }
 }
 
-secbool sdcard_power_on_unchecked(void) {
+secbool sdcard_power_on_unchecked(bool low_speed) {
   if (sd_handle.Instance) {
     return sectrue;
   }
@@ -166,7 +166,7 @@ secbool sdcard_power_on_unchecked(void) {
   sd_handle.Init.ClockPowerSave = SDMMC_CLOCK_POWER_SAVE_ENABLE;
   sd_handle.Init.BusWide = SDMMC_BUS_WIDE_1B;
   sd_handle.Init.HardwareFlowControl = SDMMC_HARDWARE_FLOW_CONTROL_DISABLE;
-  sd_handle.Init.ClockDiv = 0;
+  sd_handle.Init.ClockDiv = low_speed ? 1 : 0;
 
   // init the SD interface, with retry if it's not ready yet
   for (int retry = 10; HAL_SD_Init(&sd_handle) != HAL_OK; retry--) {
@@ -205,7 +205,7 @@ secbool sdcard_power_on(void) {
     return secfalse;
   }
 
-  return sdcard_power_on_unchecked();
+  return sdcard_power_on_unchecked(false);
 }
 
 void sdcard_power_off(void) {

--- a/core/embed/trezorhal/unix/sdcard.c
+++ b/core/embed/trezorhal/unix/sdcard.c
@@ -87,13 +87,13 @@ void sdcard_init(void) {
 
 secbool sdcard_is_present(void) { return sectrue; }
 
-secbool sdcard_power_on_unchecked(void) {
+secbool sdcard_power_on_unchecked(bool _low_speed) {
   sdcard_init();
   sdcard_powered = sectrue;
   return sectrue;
 }
 
-secbool sdcard_power_on(void) { return sdcard_power_on_unchecked(); }
+secbool sdcard_power_on(void) { return sdcard_power_on_unchecked(false); }
 
 void sdcard_power_off(void) { sdcard_powered = secfalse; }
 


### PR DESCRIPTION
Use half the speed to make it easier to work with tester in production.

Added a `clk_div` param `sdcard_power_on_unchecked` to achieve this, which is not very nice solution due to bad portability, but simple enough given the time pressure. The `sdcard_power_on_unchecked` is only used in prodtest so the impact is limited.


<!--
If you are a core dev:

Don't forget to set up the fields:
- assign yourself
- set priority to same as original issue
- add PR to sprint
- if Draft -> "in progress"
- if final PR -> "needs review"

If you're an external contributor, you can ignore this text.
-->
