### PR TITLE
move OEM key check after display initialization so that error message can be displayed

### DIFF
--- a/core/embed/firmware/main.c
+++ b/core/embed/firmware/main.c
@@ -111,10 +111,6 @@ int main(void) {
   rdi_start();
 #endif
 
-#ifdef STM32U5
-  check_oem_keys();
-#endif
-
   // reinitialize HAL for Trezor One
 #if defined TREZOR_MODEL_1
   HAL_Init();
@@ -133,6 +129,10 @@ int main(void) {
 #endif
 
   display_reinit();
+
+#ifdef STM32U5
+  check_oem_keys();
+#endif
 
   screen_boot_stage_2();
 


### PR DESCRIPTION
just that we can see if that happens.

<!--
If you are a core dev:

Don't forget to set up the fields:
- assign yourself
- set priority to same as original issue
- add PR to sprint
- if Draft -> "in progress"
- if final PR -> "needs review"

If you're an external contributor, you can ignore this text.
-->
