### PR TITLE
fix T3T1 reboot to bootloader 

### DIFF
--- a/core/embed/bootloader/main.c
+++ b/core/embed/bootloader/main.c
@@ -353,6 +353,7 @@ void real_jump_to_firmware(void) {
     ui_screen_boot_stage_1(false);
   }
 
+  display_finish_actions();
   ensure_compatible_settings();
 
   // mpu_config_firmware();
@@ -364,6 +365,7 @@ void real_jump_to_firmware(void) {
 
 #ifdef STM32U5
 __attribute__((noreturn)) void jump_to_fw_through_reset(void) {
+  display_finish_actions();
   display_fade(display_backlight(-1), 0, 200);
 
   __disable_irq();

--- a/core/embed/trezorhal/stm32f4/common.c
+++ b/core/embed/trezorhal/stm32f4/common.c
@@ -218,7 +218,6 @@ void collect_hw_entropy(void) {
 // which might be incompatible with the other layers older versions,
 // where this setting might be unknown
 void ensure_compatible_settings(void) {
-  display_finish_actions();
 #ifdef TREZOR_MODEL_T
   display_set_big_endian();
   display_orientation(0);

--- a/core/embed/trezorhal/stm32u5/common.c
+++ b/core/embed/trezorhal/stm32u5/common.c
@@ -200,7 +200,7 @@ void collect_hw_entropy(void) {
 // this function resets settings changed in one layer (bootloader/firmware),
 // which might be incompatible with the other layers older versions,
 // where this setting might be unknown
-void ensure_compatible_settings(void) { display_finish_actions(); }
+void ensure_compatible_settings(void) {}
 
 void show_wipe_code_screen(void) {
   error_uni("WIPE CODE ENTERED", "All data has been erased from the device",


### PR DESCRIPTION
it was occasionally crashing while rebooting, because there was display update in progress and the SVC call blocked other interrupts. 

Moved the `ensure_compatible_settings` from svc handler to initial `svc_reboot_to_bootloader` call, so that inside the handler it is ensured that the display operations have finished.

The removal led to some weird hardfault during the reboot, due to some weirdness in returning from SVC. Basically it seemed that stack pointer, instead of the stack[0] value was changed, and the next stack[6] modification hardfaulted. 

The modification fixed it on U5 at least.. 

@hiviah could you try if this works on F4 also? does this modification makes sense to you?


[no changelog]

<!--
If you are a core dev:

Don't forget to set up the fields:
- assign yourself
- set priority to same as original issue
- add PR to sprint
- if Draft -> "in progress"
- if final PR -> "needs review"

If you're an external contributor, you can ignore this text.
-->
