### PR TITLE
fix TS3 bootloader crash when entering menu

### DIFF
--- a/core/SConscript.bootloader
+++ b/core/SConscript.bootloader
@@ -40,7 +40,7 @@ if TREZOR_MODEL in ('R', ):
     FONT_DEMIBOLD='Font_PixelOperator_Regular_8'
     FONT_BOLD='Font_PixelOperator_Bold_8'
     FONT_MONO='Font_PixelOperator_Regular_8'
-    FONT_BIG=None
+    FONT_BIG='Font_PixelOperator_Regular_8'
     FONT_NORMAL_UPPER=None
     FONT_BOLD_UPPER=None
 elif TREZOR_MODEL in ('T', 'DISC1', 'DISC2'):

--- a/core/SConscript.bootloader_ci
+++ b/core/SConscript.bootloader_ci
@@ -35,7 +35,7 @@ if TREZOR_MODEL in ('1', 'R'):
     FONT_DEMIBOLD=None
     FONT_BOLD=None
     FONT_MONO='Font_PixelOperatorMono_Regular_8'
-    FONT_BIG=None
+    FONT_BIG='Font_PixelOperator_Regular_8'
     FONT_NORMAL_UPPER=None
     FONT_BOLD_UPPER=None
 elif TREZOR_MODEL in ('T',):

--- a/core/SConscript.bootloader_emu
+++ b/core/SConscript.bootloader_emu
@@ -37,7 +37,7 @@ if TREZOR_MODEL in ('1', 'R'):
     FONT_DEMIBOLD='Font_PixelOperator_Regular_8'
     FONT_BOLD='Font_PixelOperator_Bold_8'
     FONT_MONO='Font_PixelOperator_Regular_8'
-    FONT_BIG=None
+    FONT_BIG='Font_PixelOperator_Regular_8'
     FONT_NORMAL_UPPER=None
     FONT_BOLD_UPPER=None
 elif TREZOR_MODEL in ('T', 'DISC2'):


### PR DESCRIPTION
Added the missing font to bootooader builds, using regular as that is what it was designed with.

<!--
If you are a core dev:

Don't forget to set up the fields:
- assign yourself
- set priority to same as original issue
- add PR to sprint
- if Draft -> "in progress"
- if final PR -> "needs review"

If you're an external contributor, you can ignore this text.
-->
