### PR TITLE
Improve VTRUST bits documentation and naming.

### DIFF
--- a/core/embed/bootloader/bootui.c
+++ b/core/embed/bootloader/bootui.c
@@ -83,11 +83,11 @@ void ui_set_initial_setup(bool initial) { initial_setup = initial; }
 #ifndef NEW_RENDERING
 static void ui_screen_boot_old(const vendor_header *const vhdr,
                                const image_header *const hdr) {
-  const int show_string = ((vhdr->vtrust & VTRUST_STRING) == 0);
-  if ((vhdr->vtrust & VTRUST_RED) == 0) {
-    boot_background = COLOR_BL_FAIL;
-  } else {
+  const int show_string = ((vhdr->vtrust & VTRUST_NO_STRING) == 0);
+  if ((vhdr->vtrust & VTRUST_NO_RED) != 0) {
     boot_background = COLOR_BLACK;
+  } else {
+    boot_background = COLOR_BL_FAIL;
   }
 
   const uint8_t *vimg = vhdr->vimg;

--- a/core/embed/bootloader/main.c
+++ b/core/embed/bootloader/main.c
@@ -325,16 +325,17 @@ void real_jump_to_firmware(void) {
          "Firmware is corrupted");
 
   secret_prepare_fw(
-      ((vhdr.vtrust & VTRUST_SECRET) == VTRUST_SECRET_ALLOW) * sectrue,
-      ((vhdr.vtrust & VTRUST_ALL) == VTRUST_ALL) * sectrue);
+      ((vhdr.vtrust & VTRUST_SECRET_MASK) == VTRUST_SECRET_ALLOW) * sectrue,
+      ((vhdr.vtrust & VTRUST_NO_WARNING) == VTRUST_NO_WARNING) * sectrue);
 
-  // if all VTRUST flags are unset = ultimate trust => skip the procedure
-  if ((vhdr.vtrust & VTRUST_ALL) != VTRUST_ALL) {
+  // if all warnings are disabled in VTRUST flags then skip the procedure
+  if ((vhdr.vtrust & VTRUST_NO_WARNING) != VTRUST_NO_WARNING) {
     ui_fadeout();
     ui_screen_boot(&vhdr, hdr, 0);
     ui_fadein();
 
-    int delay = (vhdr.vtrust & VTRUST_WAIT) ^ VTRUST_WAIT;
+    // The delay is encoded in bitwise complement form.
+    int delay = (vhdr.vtrust & VTRUST_WAIT_MASK) ^ VTRUST_WAIT_MASK;
     if (delay > 1) {
       while (delay > 0) {
         ui_screen_boot(&vhdr, hdr, delay);
@@ -345,7 +346,7 @@ void real_jump_to_firmware(void) {
       hal_delay(1000);
     }
 
-    if ((vhdr.vtrust & VTRUST_CLICK) == 0) {
+    if ((vhdr.vtrust & VTRUST_NO_CLICK) == 0) {
       ui_screen_boot(&vhdr, hdr, -1);
       ui_click();
     }

--- a/core/embed/bootloader/messages.c
+++ b/core/embed/bootloader/messages.c
@@ -626,7 +626,7 @@ int process_msg_FirmwareUpload(uint8_t iface_num, uint32_t msg_size,
           return UPLOAD_ERR_NOT_FIRMWARE_UPGRADE;
         }
 
-        if ((vhdr.vtrust & VTRUST_ALL) != VTRUST_ALL) {
+        if ((vhdr.vtrust & VTRUST_NO_WARNING) != VTRUST_NO_WARNING) {
           MSG_SEND_INIT(Failure);
           MSG_SEND_ASSIGN_VALUE(code, FailureType_Failure_ProcessError);
           MSG_SEND_ASSIGN_STRING(message, "Not a full-trust image");
@@ -640,7 +640,7 @@ int process_msg_FirmwareUpload(uint8_t iface_num, uint32_t msg_size,
 
 #if defined USE_OPTIGA && !defined STM32U5
       if (sectrue != secret_wiped() &&
-          ((vhdr.vtrust & VTRUST_SECRET) != VTRUST_SECRET_ALLOW)) {
+          ((vhdr.vtrust & VTRUST_SECRET_MASK) != VTRUST_SECRET_ALLOW)) {
         MSG_SEND_INIT(Failure);
         MSG_SEND_ASSIGN_VALUE(code, FailureType_Failure_ProcessError);
         MSG_SEND_ASSIGN_STRING(message, "Install restricted");

--- a/core/embed/lib/image.h
+++ b/core/embed/lib/image.h
@@ -54,19 +54,28 @@ typedef struct {
 
 #define MAX_VENDOR_PUBLIC_KEYS 8
 
-#define VTRUST_WAIT 0x000F
-#define VTRUST_RED 0x0010
-#define VTRUST_CLICK 0x0020
-#define VTRUST_STRING 0x0040
+// The mask of the vendor screen wait time in seconds, encoded in bitwise
+// complement form.
+#define VTRUST_WAIT_MASK 0x000F
+
+// Use black background instead of red one in the vendor screen.
+#define VTRUST_NO_RED 0x0010
+
+// Do not require user click to leave the vendor screen.
+#define VTRUST_NO_CLICK 0x0020
+
+// Do not show vendor string in the vendor screen.
+#define VTRUST_NO_STRING 0x0040
 
 // Two bits for historical reasons. On T2B1, only the lower bit was used with
 // inverted logic (due to late inclusion of the secret handling during
 // development process). On T3T1, we decided to remedy the situation by
 // including the upper bit as well.
-#define VTRUST_SECRET 0x0180
+#define VTRUST_SECRET_MASK 0x0180
 #define VTRUST_SECRET_ALLOW 0x0100
 
-#define VTRUST_ALL (VTRUST_WAIT | VTRUST_RED | VTRUST_CLICK | VTRUST_STRING)
+#define VTRUST_NO_WARNING \
+  (VTRUST_WAIT_MASK | VTRUST_NO_RED | VTRUST_NO_CLICK | VTRUST_NO_STRING)
 
 typedef struct {
   uint32_t magic;

--- a/docs/core/misc/boot.md
+++ b/docs/core/misc/boot.md
@@ -139,8 +139,16 @@ Vendor trust is stored as bitmap where unset bit means the feature is active.
 |  2  | 0x0004 | wait 4 seconds                          |
 |  3  | 0x0008 | wait 8 seconds                          |
 |  4  | 0x0010 | use red background instead of black one |
-|  5  | 0x0020 | require user click                      |
+|  5  | 0x0020 | require user click to continue          |
 |  6  | 0x0040 | show vendor string (not just the logo)  |
+|  7  | 0x0080 | allow access to pairing secret          |
+|  8  | 0x0100 | disable access to pairing secret        |
+
+Bits 0 to 6 represent vendor screen settings. The wait times are additive.
+
+Two bits are used for access to the pairing secret for historical reasons.
+On T2B1 only bit 7 is evaluated.
+On newer models, both bits 7 and 8 are evaluated.
 
 ### Firmware Header
 


### PR DESCRIPTION
During a recent code review I was getting lost in the bitwise complement logic that is used for vtrust flags. This PR should improve legibility by renaming the code constants to what I believe to be more intuitive names and by adding more documentation.

`VTRUST_ALL` -> `VTRUST_NO_WARNING`
`VTRUST_ALL` no longer represents "ultimate trust". It represents the absence of any vendor screen warnings.

`VTRUST_RED` - > `VTRUST_NO_RED` etc.
When the corresponding bit is set, it represents that no red screen should be shown, etc.