### PR TITLE
set proper VDD level for T3T1 boards

### DIFF
--- a/core/embed/trezorhal/boards/trezor_t3t1_revE.h
+++ b/core/embed/trezorhal/boards/trezor_t3t1_revE.h
@@ -4,7 +4,7 @@
 #define DISPLAY_RESX 240
 #define DISPLAY_RESY 240
 
-#define VDD_1V8 1
+#define VDD_3V3 1
 
 #define USE_SD_CARD 1
 #define USE_I2C 1

--- a/core/embed/trezorhal/boards/trezor_t3t1_v4.h
+++ b/core/embed/trezorhal/boards/trezor_t3t1_v4.h
@@ -4,7 +4,7 @@
 #define DISPLAY_RESX 240
 #define DISPLAY_RESY 240
 
-#define VDD_1V8 1
+#define VDD_3V3 1
 #define HSE_16MHZ 1
 
 #define USE_SD_CARD 1


### PR DESCRIPTION
The boards use 3.3V voltage.
 
This modification sets BOR level to cca 2.8V and enables PVD, also at about 2.8V.

The supervisor IC is set to 2.9V, this does not entirely matter, but i think its preferable to have it set this way, so it is apparent what the board voltage is.

The original 1.8V setting came from U5 discovery kit.

<!--
If you are a core dev:

Don't forget to set up the fields:
- assign yourself
- set priority to same as original issue
- add PR to sprint
- if Draft -> "in progress"
- if final PR -> "needs review"

If you're an external contributor, you can ignore this text.
-->
