### PR TITLE
fix flash_combine makefile command

### DIFF
--- a/core/Makefile
+++ b/core/Makefile
@@ -340,7 +340,7 @@ else
 endif
 
 flash_combine: $(PRODTEST_BUILD_DIR)/combined.bin ## flash combined using OpenOCD
-	$(OPENOCD) -c "init; reset halt; flash write_image erase $< $(FLASH_START); exit"
+	$(OPENOCD) -c "init; reset halt; flash write_image erase $< $(BOARDLOADER_START); exit"
 
 flash_erase: ## erase all sectors in flash bank 0
 	$(OPENOCD) -c "init; reset halt; flash info 0; flash erase_sector 0 0 last; flash erase_check 0; exit"


### PR DESCRIPTION
the combined binary needs flashing on `BOARDLOADER_START` address, as on U5 we dont run boardloader from start of the flash but with some offset to create space for the secret/HDP area

<!--
If you are a core dev:

Don't forget to set up the fields:
- assign yourself
- set priority to same as original issue
- add PR to sprint
- if Draft -> "in progress"
- if final PR -> "needs review"

If you're an external contributor, you can ignore this text.
-->
