### PR TITLE
fix bindgen macros generation

### DIFF
--- a/core/SConscript.bootloader
+++ b/core/SConscript.bootloader
@@ -230,8 +230,6 @@ def cargo_build():
     features.append("bootloader")
     features.extend(FEATURES_AVAILABLE)
 
-    env.get("ENV")["BINDGEN_MACROS"] = tools.get_bindgen_defines(env.get("ALLDEFS"), ALLPATHS)
-
     cargo_opts = [
         f'--target={env.get("ENV")["RUST_TARGET"]}',
         f'--target-dir=../../build/bootloader/rust',
@@ -241,7 +239,9 @@ def cargo_build():
         '-Z build-std-features=panic_immediate_abort',
     ]
 
-    return f'cd embed/rust; cargo build {profile} ' + ' '.join(cargo_opts)
+    bindgen_macros = tools.get_bindgen_defines(env.get("CPPDEFINES"), ALLPATHS)
+
+    return f'export BINDGEN_MACROS=\'{bindgen_macros}\'; cd embed/rust; cargo build {profile} ' + ' '.join(cargo_opts)
 
 rust = env.Command(
     target=RUST_LIBPATH,

--- a/core/SConscript.bootloader_emu
+++ b/core/SConscript.bootloader_emu
@@ -209,7 +209,7 @@ ALLPATHS = ['embed/rust',
            'embed/unix',
            'embed/extmod/modtrezorui',
            'vendor/nanopb',
-       ] + CPPPATH_MOD,
+       ] + CPPPATH_MOD
 
 env.Replace(
     COPT=env.get('ENV').get('OPTIMIZE', '-Os'),
@@ -291,7 +291,6 @@ def cargo_build():
     features.append("ui")
     features.append("bootloader")
 
-    env.get("ENV")["BINDGEN_MACROS"] = tools.get_bindgen_defines(env.get("ALLDEFS"), ALLPATHS)
 
     cargo_opts = [
         f'--target={RUST_TARGET}',
@@ -302,7 +301,9 @@ def cargo_build():
         '-Z build-std-features=panic_immediate_abort',
     ]
 
-    return f'cd embed/rust; cargo build {profile} ' + ' '.join(cargo_opts)
+    bindgen_macros = tools.get_bindgen_defines(env.get("CPPDEFINES"), ALLPATHS)
+
+    return f'export BINDGEN_MACROS=\'{bindgen_macros}\'; cd embed/rust; cargo build {profile} ' + ' '.join(cargo_opts)
 
 rust = env.Command(
     target=RUST_LIBPATH,

--- a/core/SConscript.firmware
+++ b/core/SConscript.firmware
@@ -780,8 +780,6 @@ def cargo_build():
 
     features.extend(FEATURES_AVAILABLE)
 
-    env.get("ENV")["BINDGEN_MACROS"] = tools.get_bindgen_defines(env.get("ALLDEFS"), ALLPATHS)
-
     cargo_opts = [
         f'--target={env.get("ENV")["RUST_TARGET"]}',
         f'--target-dir=../../build/firmware/rust',
@@ -793,7 +791,9 @@ def cargo_build():
 
     env.get('ENV')['TREZOR_MODEL'] = TREZOR_MODEL
 
-    return f'cd embed/rust; cargo build {profile} ' + ' '.join(cargo_opts)
+    bindgen_macros = tools.get_bindgen_defines(env.get("CPPDEFINES"), ALLPATHS)
+
+    return f'export BINDGEN_MACROS=\'{bindgen_macros}\'; cd embed/rust; cargo build {profile} ' + ' '.join(cargo_opts)
 
 rust = env.Command(
     target=RUST_LIBPATH,

--- a/core/SConscript.unix
+++ b/core/SConscript.unix
@@ -871,9 +871,9 @@ def cargo_build():
     if TREZOR_MODEL in ('R', '1'):
         features.append('button')
 
-    env.get("ENV")["BINDGEN_MACROS"] = tools.get_bindgen_defines(env.get("ALLDEFS"), ALLPATHS)
+    bindgen_macros = tools.get_bindgen_defines(env.get("CPPDEFINES"), ALLPATHS)
 
-    return f'cd embed/rust; cargo build --profile {RUST_PROFILE} --target-dir=../../build/unix/rust --no-default-features --features "{" ".join(features)}"  --target {TARGET}'
+    return f'export BINDGEN_MACROS=\'{bindgen_macros}\'; cd embed/rust; cargo build --profile {RUST_PROFILE} --target-dir=../../build/unix/rust --no-default-features --features "{" ".join(features)}"  --target {TARGET}'
 
 rust = env.Command(
     target=RUST_LIBPATH,

--- a/core/site_scons/tools.py
+++ b/core/site_scons/tools.py
@@ -153,9 +153,17 @@ def get_bindgen_defines(
 ) -> tuple(str, str):
     rest_defs = []
     for d in defines:
-        rest_defs.append(
-            f"-D{d}".replace('"<', "<").replace('>"', ">").replace('\\"', '"')
+        if type(d) is tuple:
+            d = f"-D{d[0]}={d[1]}"
+        else:
+            d = f"-D{d}"
+        d = (
+            d.replace('\\"', '"')
+            .replace("'", "'\"'\"'")
+            .replace('"<', "<")
+            .replace('>"', ">")
         )
+        rest_defs.append(d)
     for d in paths:
         rest_defs.append(f"-I../../{d}")
 


### PR DESCRIPTION
the previous version actually did not work well because the later sconscript files were overriding the environment variable, resulting in unix macros always being used. 

<!--
If you are a core dev:

Don't forget to set up the fields:
- assign yourself
- set priority to same as original issue
- add PR to sprint
- if Draft -> "in progress"
- if final PR -> "needs review"

If you're an external contributor, you can ignore this text.
-->
