### PR TITLE
fix USB configuration for STM32U585

### DIFF
--- a/core/embed/trezorhal/stm32f4/usb_vcp-impl.h
+++ b/core/embed/trezorhal/stm32f4/usb_vcp-impl.h
@@ -263,7 +263,7 @@ int usb_vcp_read(uint8_t iface_num, uint8_t *buf, uint32_t len) {
     return -1;  // Invalid interface number
   }
   if (iface->type != USB_IFACE_TYPE_VCP) {
-    return -2;  // Interface interface type
+    return -2;  // Invalid interface type
   }
   usb_vcp_state_t *state = &iface->vcp;
 
@@ -284,7 +284,7 @@ int usb_vcp_write(uint8_t iface_num, const uint8_t *buf, uint32_t len) {
     return -1;  // Invalid interface number
   }
   if (iface->type != USB_IFACE_TYPE_VCP) {
-    return -2;  // Interface interface type
+    return -2;  // Invalid interface type
   }
   usb_vcp_state_t *state = &iface->vcp;
 

--- a/core/embed/trezorhal/stm32f4/usbd_conf.c
+++ b/core/embed/trezorhal/stm32f4/usbd_conf.c
@@ -488,7 +488,7 @@ USBD_StatusTypeDef  USBD_LL_Init (USBD_HandleTypeDef *pdev)
   if (pdev->id == USB_PHY_FS_ID) {
     /*Set LL Driver parameters */
     pcd_fs_handle.Instance = USB_OTG_FS;
-    pcd_fs_handle.Init.dev_endpoints = 4;
+    pcd_fs_handle.Init.dev_endpoints = 6;
     pcd_fs_handle.Init.use_dedicated_ep1 = 0;
     pcd_fs_handle.Init.ep0_mps = 0x40;
     pcd_fs_handle.Init.dma_enable = 0;
@@ -508,10 +508,10 @@ USBD_StatusTypeDef  USBD_LL_Init (USBD_HandleTypeDef *pdev)
     // in this dedicated 1.25KiB data RAM to use. see section 6.3.8 in UM1021 and 29.13 in RM0033.
     // USB packets that we deal with are 64 bytes in size which equates to 16 32-bit words.
     // we size the transmit FIFO's equally and give the rest of the space to the receive FIFO.
-    const uint16_t transmit_fifo_size = 48; // 48 = 16 * 3 meaning that we give 3 packets of space for each transmit fifo
-    const uint16_t receive_fifo_zie = 128; // 128 = 320 - 4 * 48
+    const uint16_t transmit_fifo_size = 32; // 32 = 16 * 2 meaning that we give 2 packets of space for each transmit fifo
+    const uint16_t receive_fifo_zie = 128; // 128 = 320 - 6 * 32
     HAL_PCDEx_SetRxFiFo(&pcd_fs_handle, receive_fifo_zie);
-    for (uint16_t i = 0; i < 4; i++) {
+    for (uint16_t i = 0; i < 6; i++) {
       HAL_PCDEx_SetTxFiFo(&pcd_fs_handle, i, transmit_fifo_size);
     }
   }

--- a/core/embed/trezorhal/stm32f4/usbd_conf.c
+++ b/core/embed/trezorhal/stm32f4/usbd_conf.c
@@ -509,8 +509,8 @@ USBD_StatusTypeDef  USBD_LL_Init (USBD_HandleTypeDef *pdev)
     // USB packets that we deal with are 64 bytes in size which equates to 16 32-bit words.
     // we size the transmit FIFO's equally and give the rest of the space to the receive FIFO.
     const uint16_t transmit_fifo_size = 32; // 32 = 16 * 2 meaning that we give 2 packets of space for each transmit fifo
-    const uint16_t receive_fifo_zie = 128; // 128 = 320 - 6 * 32
-    HAL_PCDEx_SetRxFiFo(&pcd_fs_handle, receive_fifo_zie);
+    const uint16_t receive_fifo_size = 128; // 128 = 320 - 6 * 32
+    HAL_PCDEx_SetRxFiFo(&pcd_fs_handle, receive_fifo_size);
     for (uint16_t i = 0; i < 6; i++) {
       HAL_PCDEx_SetTxFiFo(&pcd_fs_handle, i, transmit_fifo_size);
     }
@@ -547,8 +547,8 @@ USBD_StatusTypeDef  USBD_LL_Init (USBD_HandleTypeDef *pdev)
     // USB packets that we deal with are 64 bytes in size which equates to 16 32-bit words.
     // we size the transmit FIFO's equally and give the rest of the space to the receive FIFO.
     const uint16_t transmit_fifo_size = 144; // 144 = 16 * 9 meaning that we give 9 packets of space for each transmit fifo
-    const uint16_t receive_fifo_zie = 160; // 160 = 1024 - 6 * 144 section 35.10.1 details what some of this is used for besides storing packets
-    HAL_PCDEx_SetRxFiFo(&pcd_hs_handle, receive_fifo_zie);
+    const uint16_t receive_fifo_size = 160; // 160 = 1024 - 6 * 144 section 35.10.1 details what some of this is used for besides storing packets
+    HAL_PCDEx_SetRxFiFo(&pcd_hs_handle, receive_fifo_size);
     for (uint16_t i = 0; i < 6; i++) {
       HAL_PCDEx_SetTxFiFo(&pcd_hs_handle, i, transmit_fifo_size);
     }
@@ -585,8 +585,8 @@ USBD_StatusTypeDef  USBD_LL_Init (USBD_HandleTypeDef *pdev)
     // USB packets that we deal with are 64 bytes in size which equates to 16 32-bit words.
     // we size the transmit FIFO's equally and give the rest of the space to the receive FIFO.
     const uint16_t transmit_fifo_size = 144; // 144 = 16 * 9 meaning that we give 9 packets of space for each transmit fifo
-    const uint16_t receive_fifo_zie = 160; // 160 = 1024 - 6 * 144 section 35.10.1 details what some of this is used for besides storing packets
-    HAL_PCDEx_SetRxFiFo(&pcd_hs_handle, receive_fifo_zie);
+    const uint16_t receive_fifo_size = 160; // 160 = 1024 - 6 * 144 section 35.10.1 details what some of this is used for besides storing packets
+    HAL_PCDEx_SetRxFiFo(&pcd_hs_handle, receive_fifo_size);
     for (uint16_t i = 0; i < 6; i++) {
       HAL_PCDEx_SetTxFiFo(&pcd_hs_handle, i, transmit_fifo_size);
     }


### PR DESCRIPTION
Configures USB FS to use 6 endpoints - we need that when we use VCP and FIDO together.

<!--
If you are a core dev:

Don't forget to set up the fields:
- assign yourself
- set priority to same as original issue
- add PR to sprint
- if Draft -> "in progress"
- if final PR -> "needs review"

If you're an external contributor, you can ignore this text.
-->
