### PR TITLE
add haptic feedback to TT UI loader

### DIFF
--- a/core/embed/rust/build.rs
+++ b/core/embed/rust/build.rs
@@ -358,7 +358,8 @@ fn generate_trezorhal_bindings() {
         .allowlist_function("button_read")
         // haptic
         .allowlist_type("haptic_effect_t")
-        .allowlist_function("haptic_play");
+        .allowlist_function("haptic_play")
+        .allowlist_function("haptic_play_rtp");
 
     // Write the bindings to a file in the OUR_DIR.
     bindings

--- a/core/embed/rust/build.rs
+++ b/core/embed/rust/build.rs
@@ -359,7 +359,7 @@ fn generate_trezorhal_bindings() {
         // haptic
         .allowlist_type("haptic_effect_t")
         .allowlist_function("haptic_play")
-        .allowlist_function("haptic_play_rtp");
+        .allowlist_function("haptic_play_custom");
 
     // Write the bindings to a file in the OUR_DIR.
     bindings

--- a/core/embed/rust/src/trezorhal/haptic.rs
+++ b/core/embed/rust/src/trezorhal/haptic.rs
@@ -11,3 +11,9 @@ pub fn play(effect: HapticEffect) {
         ffi::haptic_play(effect as _);
     }
 }
+
+pub fn play_rtp(amplitude: i8, duration: u16) {
+    unsafe {
+        ffi::haptic_play_rtp(amplitude, duration);
+    }
+}

--- a/core/embed/rust/src/trezorhal/haptic.rs
+++ b/core/embed/rust/src/trezorhal/haptic.rs
@@ -12,8 +12,8 @@ pub fn play(effect: HapticEffect) {
     }
 }
 
-pub fn play_rtp(amplitude: i8, duration: u16) {
+pub fn play_custom(amplitude_pct: i8, duration_ms: u16) {
     unsafe {
-        ffi::haptic_play_rtp(amplitude, duration);
+        ffi::haptic_play_custom(amplitude_pct, duration_ms);
     }
 }

--- a/core/embed/rust/src/ui/model_tt/component/loader.rs
+++ b/core/embed/rust/src/ui/model_tt/component/loader.rs
@@ -1,5 +1,5 @@
 #[cfg(feature = "haptic")]
-use crate::trezorhal::haptic::{play, HapticEffect};
+use crate::trezorhal::haptic::{self, play, HapticEffect};
 use crate::{
     time::{Duration, Instant},
     ui::{
@@ -7,6 +7,7 @@ use crate::{
         component::{Component, Event, EventCtx, Pad},
         display::{self, toif::Icon, Color},
         geometry::{Offset, Rect},
+        lerp::Lerp,
         model_tt::constant,
         util::animation_disabled,
     },
@@ -173,6 +174,10 @@ impl Component for Loader {
                 } else if self.is_completely_shrunk(now) {
                     return Some(LoaderMsg::ShrunkCompletely);
                 } else {
+                    let progress = self.progress(now).unwrap() as f32 / 1000.0;
+                    let ampl = i16::lerp(0, 76, progress);
+                    haptic::play_rtp(ampl as i8, 100);
+
                     // There is further progress in the animation, request an animation frame event.
                     ctx.request_anim_frame();
                 }

--- a/core/embed/rust/src/ui/model_tt/component/loader.rs
+++ b/core/embed/rust/src/ui/model_tt/component/loader.rs
@@ -1,5 +1,5 @@
 #[cfg(feature = "haptic")]
-use crate::trezorhal::haptic::{self, play, HapticEffect};
+use crate::trezorhal::haptic::{self, HapticEffect};
 use crate::{
     time::{Duration, Instant},
     ui::{
@@ -17,6 +17,9 @@ use super::theme;
 
 const GROWING_DURATION_MS: u32 = 1000;
 const SHRINKING_DURATION_MS: u32 = 500;
+
+const HAPTIC_AMPLITUDE_MAX_PCT: i16 = 16;
+const HAPTIC_AMPLITUDE_DURATION_MS: u16 = 100;
 
 pub enum LoaderMsg {
     GrownCompletely,
@@ -169,14 +172,20 @@ impl Component for Loader {
 
                 if self.is_completely_grown(now) {
                     #[cfg(feature = "haptic")]
-                    play(HapticEffect::HoldToConfirm);
+                    haptic::play(HapticEffect::HoldToConfirm);
                     return Some(LoaderMsg::GrownCompletely);
                 } else if self.is_completely_shrunk(now) {
                     return Some(LoaderMsg::ShrunkCompletely);
                 } else {
-                    let progress = self.progress(now).unwrap() as f32 / 1000.0;
-                    let ampl = i16::lerp(0, 76, progress);
-                    haptic::play_rtp(ampl as i8, 100);
+                    #[cfg(feature = "haptic")]
+                    {
+                        if matches!(self.state, State::Growing(_)) {
+                            let progress =
+                                self.progress(now).unwrap() as f32 / display::LOADER_MAX as f32;
+                            let ampl = i16::lerp(0, HAPTIC_AMPLITUDE_MAX_PCT, progress);
+                            haptic::play_custom(ampl as i8, HAPTIC_AMPLITUDE_DURATION_MS);
+                        }
+                    }
 
                     // There is further progress in the animation, request an animation frame event.
                     ctx.request_anim_frame();

--- a/core/embed/rust/src/ui/model_tt/component/page.rs
+++ b/core/embed/rust/src/ui/model_tt/component/page.rs
@@ -49,8 +49,9 @@ where
     T: Component,
 {
     pub fn with_hold(mut self) -> Result<Self, Error> {
-        self.button_confirm =
-            Button::with_text(TR::buttons__hold_to_confirm.into()).styled(theme::button_confirm());
+        self.button_confirm = Button::with_text(TR::buttons__hold_to_confirm.into())
+            .styled(theme::button_confirm())
+            .without_haptics();
         self.loader = Some(Loader::new());
         Ok(self)
     }

--- a/core/embed/trezorhal/haptic.h
+++ b/core/embed/trezorhal/haptic.h
@@ -23,4 +23,11 @@ bool haptic_test(uint16_t duration_ms);
 // Play haptic effect
 void haptic_play(haptic_effect_t effect);
 
+// Starts the haptic motor with a specified amplitude and period
+//
+// The function can be invoked repeatedly during the specified duration
+// (`duration_ms`) to modify the amplitude dynamically, allowing
+// the creation of customized haptic effects.
+bool haptic_play_rtp(int8_t amplitude, uint16_t duration_ms);
+
 #endif

--- a/core/embed/trezorhal/haptic.h
+++ b/core/embed/trezorhal/haptic.h
@@ -28,6 +28,6 @@ void haptic_play(haptic_effect_t effect);
 // The function can be invoked repeatedly during the specified duration
 // (`duration_ms`) to modify the amplitude dynamically, allowing
 // the creation of customized haptic effects.
-bool haptic_play_rtp(int8_t amplitude, uint16_t duration_ms);
+bool haptic_play_custom(int8_t amplitude_pct, uint16_t duration_ms);
 
 #endif

--- a/core/embed/trezorhal/stm32u5/haptic/drv2625/drv2625.c
+++ b/core/embed/trezorhal/stm32u5/haptic/drv2625/drv2625.c
@@ -78,6 +78,7 @@
 #define PRESS_EFFECT_AMPLITUDE 25
 #define PRESS_EFFECT_DURATION 10
 
+#define MAX_AMPLITUDE 127
 #define PRODTEST_EFFECT_AMPLITUDE 127
 
 static bool set_reg(uint8_t addr, uint8_t value) {
@@ -144,7 +145,7 @@ void haptic_init(void) {
   TIM16->BDTR |= TIM_BDTR_MOE;
 }
 
-bool haptic_play_rtp(int8_t amplitude, uint16_t duration_ms) {
+static bool haptic_play_rtp(int8_t amplitude, uint16_t duration_ms) {
   if (!playing_rtp) {
     if (!set_reg(DRV2625_REG_MODE,
                  DRV2625_REG_MODE_RTP | DRV2625_REG_MODE_TRGFUNC_ENABLE)) {
@@ -196,6 +197,17 @@ void haptic_play(haptic_effect_t effect) {
     default:
       break;
   }
+}
+
+bool haptic_play_custom(int8_t amplitude_pct, uint16_t duration_ms) {
+  if (amplitude_pct < 0) {
+    amplitude_pct = 0;
+  } else if (amplitude_pct > 100) {
+    amplitude_pct = 100;
+  }
+
+  return haptic_play_rtp((int8_t)((amplitude_pct * MAX_AMPLITUDE) / 100),
+                         duration_ms);
 }
 
 bool haptic_test(uint16_t duration_ms) {


### PR DESCRIPTION
add the loader feedback to tt ui (as fallback for mercury for T3T1)

still needs to be added to mercury too, but thats a separate PR 


<!--
If you are a core dev:

Don't forget to set up the fields:
- assign yourself
- set priority to same as original issue
- add PR to sprint
- if Draft -> "in progress"
- if final PR -> "needs review"

If you're an external contributor, you can ignore this text.
-->
