### PR TITLE
T3T1 loaders improvement

### DIFF
--- a/core/embed/rust/src/ui/model_mercury/bootloader/mod.rs
+++ b/core/embed/rust/src/ui/model_mercury/bootloader/mod.rs
@@ -36,8 +36,9 @@ use super::theme::BLACK;
 #[cfg(feature = "new_rendering")]
 use crate::ui::{
     constant,
-    display::toif::Toif,
+    display::{toif::Toif, LOADER_MAX},
     geometry::{Alignment, Alignment2D},
+    model_mercury::shapes::render_loader,
     shape,
     shape::render_on_display,
 };
@@ -122,19 +123,18 @@ impl ModelMercuryFeatures {
             let center_text_offset: i16 = 10;
             let center = SCREEN.center() + Offset::y(loader_offset);
             let inactive_color = bg_color.blend(fg_color, 85);
+            let end = ((progress as i32 * 8 * shape::PI4 as i32) / 1000) as i16;
 
-            shape::Circle::new(center, constant::LOADER_OUTER)
-                .with_bg(inactive_color)
-                .render(target);
-
-            shape::Circle::new(center, constant::LOADER_OUTER)
-                .with_bg(fg_color)
-                .with_end_angle(((progress as i32 * shape::PI4 as i32 * 8) / 1000) as i16)
-                .render(target);
-
-            shape::Circle::new(center, constant::LOADER_INNER + 2)
-                .with_bg(bg_color)
-                .render(target);
+            render_loader(
+                center,
+                inactive_color,
+                fg_color,
+                bg_color,
+                0,
+                end,
+                progress >= LOADER_MAX,
+                target,
+            );
 
             if let Some((icon, color)) = icon {
                 shape::ToifImage::new(center, icon.toif)

--- a/core/embed/rust/src/ui/model_mercury/component/progress.rs
+++ b/core/embed/rust/src/ui/model_mercury/component/progress.rs
@@ -9,9 +9,9 @@ use crate::{
             text::paragraphs::{Paragraph, Paragraphs},
             Child, Component, Event, EventCtx, Label, Never, Pad,
         },
-        display::{self, Font},
+        display::{self, Font, LOADER_MAX},
         geometry::{Insets, Offset, Rect},
-        model_mercury::constant,
+        model_mercury::{constant, shapes::render_loader},
         shape,
         shape::Renderer,
         util::animation_disabled,
@@ -112,9 +112,9 @@ impl Component for Progress {
         self.title.render(target);
 
         let center = constant::screen().center() + Offset::y(self.loader_y_offset);
-        let active_color = theme::FG;
+        let active_color = theme::GREEN_LIGHT;
         let background_color = theme::BG;
-        let inactive_color = background_color.blend(active_color, 85);
+        let inactive_color = theme::GREY_EXTRA_DARK;
 
         let (start, end) = if self.indeterminate {
             let start = (self.value - 100) % 1000;
@@ -127,23 +127,16 @@ impl Component for Progress {
             (0, end)
         };
 
-        shape::Circle::new(center, constant::LOADER_OUTER)
-            .with_bg(inactive_color)
-            .render(target);
-
-        shape::Circle::new(center, constant::LOADER_OUTER)
-            .with_bg(active_color)
-            .with_start_angle(start)
-            .with_end_angle(end)
-            .render(target);
-
-        shape::Circle::new(center, constant::LOADER_INNER + 2)
-            .with_bg(active_color)
-            .render(target);
-
-        shape::Circle::new(center, constant::LOADER_INNER)
-            .with_bg(background_color)
-            .render(target);
+        render_loader(
+            center,
+            inactive_color,
+            active_color,
+            background_color,
+            start,
+            end,
+            !self.indeterminate && self.value >= LOADER_MAX,
+            target,
+        );
 
         self.description_pad.render(target);
         self.description.render(target);

--- a/core/embed/rust/src/ui/model_mercury/mod.rs
+++ b/core/embed/rust/src/ui/model_mercury/mod.rs
@@ -11,6 +11,7 @@ pub mod flow;
 #[cfg(feature = "micropython")]
 pub mod layout;
 pub mod screens;
+pub mod shapes;
 
 pub struct ModelMercuryFeatures;
 

--- a/core/embed/rust/src/ui/model_mercury/shapes.rs
+++ b/core/embed/rust/src/ui/model_mercury/shapes.rs
@@ -1,0 +1,32 @@
+use crate::ui::{display::Color, geometry::Point, model_mercury::constant, shape, shape::Renderer};
+
+pub fn render_loader<'s>(
+    center: Point,
+    inactive_color: Color,
+    active_color: Color,
+    background_color: Color,
+    start: i16,
+    end: i16,
+    full: bool,
+    target: &mut impl Renderer<'s>,
+) {
+    shape::Circle::new(center, constant::LOADER_OUTER)
+        .with_bg(inactive_color)
+        .render(target);
+
+    if full {
+        shape::Circle::new(center, constant::LOADER_OUTER)
+            .with_bg(active_color)
+            .render(target);
+    } else {
+        shape::Circle::new(center, constant::LOADER_OUTER)
+            .with_bg(active_color)
+            .with_start_angle(start)
+            .with_end_angle(end)
+            .render(target);
+    }
+
+    shape::Circle::new(center, constant::LOADER_INNER + 2)
+        .with_bg(background_color)
+        .render(target);
+}

--- a/core/embed/rust/src/ui/model_mercury/theme/mod.rs
+++ b/core/embed/rust/src/ui/model_mercury/theme/mod.rs
@@ -581,14 +581,10 @@ pub const fn button_clear() -> ButtonStyleSheet {
 
 pub const fn loader_default() -> LoaderStyleSheet {
     LoaderStyleSheet {
-        normal: &LoaderStyle {
-            icon: None,
-            loader_color: FG,
-            background_color: BG,
-        },
         active: &LoaderStyle {
             icon: None,
-            loader_color: GREEN,
+            active: GREEN_LIGHT,
+            inactive: GREY_EXTRA_DARK,
             background_color: BG,
         },
     }
@@ -596,14 +592,10 @@ pub const fn loader_default() -> LoaderStyleSheet {
 
 pub const fn loader_lock_icon() -> LoaderStyleSheet {
     LoaderStyleSheet {
-        normal: &LoaderStyle {
-            icon: Some((ICON_LOCK_BIG, FG)),
-            loader_color: FG,
-            background_color: BG,
-        },
         active: &LoaderStyle {
             icon: Some((ICON_LOCK_BIG, FG)),
-            loader_color: GREEN,
+            active: GREEN_LIGHT,
+            inactive: GREY_EXTRA_DARK,
             background_color: BG,
         },
     }


### PR DESCRIPTION
Closer match to figma design.

Round edge of sector is missing as it would be quite difficult to implement.

This is used in bootloader, progress and Loader component, although i expect Loader to be replaced by a hold to confirm animation at some point.


<!--
If you are a core dev:

Don't forget to set up the fields:
- assign yourself
- set priority to same as original issue
- add PR to sprint
- if Draft -> "in progress"
- if final PR -> "needs review"

If you're an external contributor, you can ignore this text.
-->
