### PR TITLE
tap to confirm animation for mercury UI

### DIFF
--- a/core/embed/rust/src/ui/model_mercury/component/hold_to_confirm.rs
+++ b/core/embed/rust/src/ui/model_mercury/component/hold_to_confirm.rs
@@ -188,8 +188,8 @@ impl Component for HoldToConfirm {
     fn place(&mut self, bounds: Rect) -> Rect {
         self.area = bounds;
         self.button.place(Rect::snap(
-            self.area.center(),
-            Offset::uniform(120),
+            self.area.center() + Offset::y(CONFIRM_ANIMATION_OFFSET),
+            Offset::uniform(80),
             Alignment2D::CENTER,
         ));
         self.title.place(bounds.split_top(TITLE_HEIGHT).0);

--- a/core/embed/rust/src/ui/model_mercury/component/hold_to_confirm.rs
+++ b/core/embed/rust/src/ui/model_mercury/component/hold_to_confirm.rs
@@ -8,6 +8,7 @@ use crate::{
         lerp::Lerp,
         shape,
         shape::Renderer,
+        util::animation_disabled,
     },
 };
 
@@ -40,6 +41,10 @@ impl HoldToConfirmAnim {
     }
 
     pub fn eval(&self) -> f32 {
+        if animation_disabled() {
+            return 0.0;
+        }
+
         self.timer.elapsed().to_millis() as f32 / 1000.0
     }
 
@@ -210,6 +215,11 @@ impl Component for HoldToConfirm {
                 ctx.request_paint();
             }
             Some(ButtonMsg::Clicked) => {
+                if animation_disabled() {
+                    #[cfg(feature = "haptic")]
+                    haptic::play(HapticEffect::HoldToConfirm);
+                    return Some(());
+                }
                 self.anim.reset();
                 ctx.request_anim_frame();
                 ctx.request_paint();

--- a/core/embed/rust/src/ui/model_mercury/component/mod.rs
+++ b/core/embed/rust/src/ui/model_mercury/component/mod.rs
@@ -26,6 +26,7 @@ pub mod number_input_slider;
 #[cfg(feature = "translations")]
 mod page;
 mod progress;
+#[cfg(feature = "translations")]
 mod prompt_screen;
 mod result;
 mod scroll;
@@ -36,6 +37,8 @@ mod share_words;
 mod simple_page;
 mod status_screen;
 mod swipe_up_screen;
+#[cfg(feature = "translations")]
+mod tap_to_confirm;
 mod welcome_screen;
 
 #[cfg(feature = "translations")]
@@ -72,6 +75,7 @@ pub use number_input_slider::NumberInputSliderDialog;
 #[cfg(feature = "translations")]
 pub use page::ButtonPage;
 pub use progress::Progress;
+#[cfg(feature = "translations")]
 pub use prompt_screen::PromptScreen;
 pub use result::{ResultFooter, ResultScreen, ResultStyle};
 pub use scroll::ScrollBar;
@@ -82,6 +86,8 @@ pub use share_words::ShareWords;
 pub use simple_page::SimplePage;
 pub use status_screen::StatusScreen;
 pub use swipe_up_screen::{SwipeUpScreen, SwipeUpScreenMsg};
+#[cfg(feature = "translations")]
+pub use tap_to_confirm::TapToConfirm;
 pub use vertical_menu::{VerticalMenu, VerticalMenuChoiceMsg};
 pub use welcome_screen::WelcomeScreen;
 

--- a/core/embed/rust/src/ui/model_mercury/component/tap_to_confirm.rs
+++ b/core/embed/rust/src/ui/model_mercury/component/tap_to_confirm.rs
@@ -1,0 +1,255 @@
+use crate::{
+    time::Duration,
+    ui::{
+        component::{Component, Event, EventCtx},
+        display::Color,
+        geometry::{Alignment2D, Offset, Rect},
+        lerp::Lerp,
+        shape,
+        shape::Renderer,
+        util::animation_disabled,
+    },
+};
+
+use super::{theme, Button, ButtonContent, ButtonMsg};
+
+use crate::{time::Stopwatch, ui::model_mercury::theme::CONFIRM_ANIMATION_OFFSET};
+use pareen;
+
+#[derive(Default, Clone)]
+struct TapToConfirmAmin {
+    pub timer: Stopwatch,
+}
+
+impl TapToConfirmAmin {
+    const DURATION_MS: u32 = 600;
+
+    pub fn is_active(&self) -> bool {
+        self.timer
+            .is_running_within(Duration::from_millis(Self::DURATION_MS))
+    }
+
+    pub fn is_finished(&self) -> bool {
+        self.timer.elapsed() >= Duration::from_millis(Self::DURATION_MS)
+    }
+    pub fn eval(&self) -> f32 {
+        if animation_disabled() {
+            return 0.0;
+        }
+        self.timer.elapsed().to_millis() as f32 / 1000.0
+    }
+
+    pub fn get_parent_cover_opacity(&self, t: f32) -> u8 {
+        let parent_cover_opacity = pareen::constant(0.0).seq_ease_in_out(
+            0.0,
+            easer::functions::Cubic,
+            0.2,
+            pareen::constant(1.0),
+        );
+        u8::lerp(0, 255, parent_cover_opacity.eval(t))
+    }
+    pub fn get_circle_scale(&self, t: f32) -> i16 {
+        let circle_scale = pareen::constant(0.0).seq_ease_in_out(
+            0.0,
+            easer::functions::Cubic,
+            0.58,
+            pareen::constant(1.0),
+        );
+        i16::lerp(0, 80, circle_scale.eval(t))
+    }
+    pub fn get_circle_color(&self, t: f32, final_color: Color) -> Color {
+        let circle_color = pareen::constant(0.0).seq_ease_in_out(
+            0.0,
+            easer::functions::Cubic,
+            0.55,
+            pareen::constant(1.0),
+        );
+
+        Color::lerp(Color::black(), final_color, circle_color.eval(t))
+    }
+
+    pub fn get_circle_opacity(&self, t: f32) -> u8 {
+        let circle_opacity = pareen::constant(0.0).seq_ease_in_out(
+            0.2,
+            easer::functions::Cubic,
+            0.8,
+            pareen::constant(1.0),
+        );
+        u8::lerp(255, 0, circle_opacity.eval(t))
+    }
+
+    pub fn get_pad_opacity(&self, t: f32) -> u8 {
+        let pad_opacity = pareen::constant(0.0).seq_ease_in_out(
+            0.2,
+            easer::functions::Cubic,
+            0.4,
+            pareen::constant(1.0),
+        );
+        u8::lerp(255, 0, pad_opacity.eval(t))
+    }
+
+    pub fn get_black_mask_scale(&self, t: f32) -> i16 {
+        let black_mask_scale = pareen::constant(0.0).seq_ease_in_out(
+            0.2,
+            easer::functions::Cubic,
+            0.8,
+            pareen::constant(1.0),
+        );
+        i16::lerp(0, 400, black_mask_scale.eval(t))
+    }
+
+    pub fn start(&mut self) {
+        self.timer.start();
+    }
+
+    pub fn reset(&mut self) {
+        self.timer = Stopwatch::new_stopped();
+    }
+}
+
+/// Component requesting a Tap to confirm action from a user. Most typically
+/// embedded as a content of a Frame.
+#[derive(Clone)]
+pub struct TapToConfirm {
+    area: Rect,
+    button: Button,
+    circle_color: Color,
+    circle_pad_color: Color,
+    circle_inner_color: Color,
+    mask_color: Color,
+    anim: TapToConfirmAmin,
+}
+
+#[derive(Clone)]
+enum DismissType {
+    Tap,
+    Hold,
+}
+
+impl TapToConfirm {
+    pub fn new(
+        circle_color: Color,
+        circle_inner_color: Color,
+        circle_pad_color: Color,
+        mask_color: Color,
+    ) -> Self {
+        let button = Button::new(ButtonContent::Empty).styled(theme::button_default());
+        Self {
+            area: Rect::zero(),
+            circle_color,
+            circle_inner_color,
+            circle_pad_color,
+            mask_color,
+            button,
+            anim: TapToConfirmAmin::default(),
+        }
+    }
+}
+
+impl Component for TapToConfirm {
+    type Msg = ();
+
+    fn place(&mut self, bounds: Rect) -> Rect {
+        self.area = bounds;
+        self.button.place(Rect::snap(
+            self.area.center() + Offset::y(CONFIRM_ANIMATION_OFFSET),
+            Offset::uniform(80),
+            Alignment2D::CENTER,
+        ));
+        bounds
+    }
+
+    fn event(&mut self, ctx: &mut EventCtx, event: Event) -> Option<Self::Msg> {
+        let btn_msg = self.button.event(ctx, event);
+        match btn_msg {
+            Some(ButtonMsg::Pressed) => {
+                self.anim.start();
+                ctx.request_anim_frame();
+                ctx.request_paint();
+            }
+            Some(ButtonMsg::Released) => {
+                self.anim.reset();
+                ctx.request_anim_frame();
+                ctx.request_paint();
+            }
+            Some(ButtonMsg::Clicked) => {
+                if animation_disabled() {
+                    return Some(());
+                }
+            }
+            _ => (),
+        }
+        if self.anim.is_active() {
+            ctx.request_anim_frame();
+            ctx.request_paint();
+        }
+        if self.anim.is_finished() {
+            return Some(());
+        };
+
+        None
+    }
+
+    fn paint(&mut self) {
+        unimplemented!()
+    }
+
+    fn render<'s>(&self, target: &mut impl Renderer<'s>) {
+        const PAD_RADIUS: i16 = 70;
+        const PAD_THICKNESS: i16 = 20;
+        const CIRCLE_RADIUS: i16 = 50;
+        const INNER_CIRCLE_RADIUS: i16 = 40;
+        const CIRCLE_THICKNESS: i16 = 2;
+
+        let t = self.anim.eval();
+
+        let center = self.area.center() + Offset::y(CONFIRM_ANIMATION_OFFSET);
+
+        shape::Bar::new(self.area)
+            .with_fg(theme::BLACK)
+            .with_bg(theme::BLACK)
+            .with_alpha(self.anim.get_parent_cover_opacity(t))
+            .render(target);
+
+        shape::Circle::new(center, PAD_RADIUS)
+            .with_fg(self.circle_pad_color)
+            .with_bg(theme::BLACK)
+            .with_thickness(PAD_THICKNESS)
+            .with_alpha(self.anim.get_pad_opacity(t))
+            .render(target);
+        shape::Circle::new(center, CIRCLE_RADIUS)
+            .with_fg(self.circle_color)
+            .with_bg(theme::BLACK)
+            .with_thickness(CIRCLE_THICKNESS)
+            .render(target);
+        shape::Circle::new(center, CIRCLE_RADIUS - CIRCLE_THICKNESS)
+            .with_fg(self.circle_pad_color)
+            .with_bg(theme::BLACK)
+            .with_thickness(CIRCLE_RADIUS - CIRCLE_THICKNESS - INNER_CIRCLE_RADIUS)
+            .render(target);
+        shape::Circle::new(center, self.anim.get_circle_scale(t))
+            .with_fg(self.anim.get_circle_color(t, self.mask_color))
+            .with_alpha(self.anim.get_circle_opacity(t))
+            .render(target);
+        shape::Circle::new(center, self.anim.get_black_mask_scale(t))
+            .with_fg(theme::BLACK)
+            .render(target);
+
+        shape::ToifImage::new(center, theme::ICON_SIMPLE_CHECKMARK.toif)
+            .with_fg(theme::GREY_LIGHT)
+            .with_alpha(255 - self.anim.get_parent_cover_opacity(t))
+            .with_align(Alignment2D::CENTER)
+            .render(target);
+    }
+}
+
+#[cfg(feature = "micropython")]
+impl crate::ui::flow::Swipable<()> for TapToConfirm {}
+
+#[cfg(feature = "ui_debug")]
+impl crate::trace::Trace for TapToConfirm {
+    fn trace(&self, t: &mut dyn crate::trace::Tracer) {
+        t.component("StatusScreen");
+        t.child("button", &self.button);
+    }
+}

--- a/core/embed/rust/src/ui/model_mercury/flow/confirm_action.rs
+++ b/core/embed/rust/src/ui/model_mercury/flow/confirm_action.rs
@@ -192,8 +192,8 @@ fn new_confirm_action_obj(_args: &[Obj], kwargs: &Map) -> Result<Obj, error::Err
 
     let mut content_confirm = Frame::left_aligned(title, prompt)
         .with_footer(prompt_action, None)
-        .with_menu_button();
-    // .with_overlapping_content();
+        .with_menu_button()
+        .with_overlapping_content();
 
     if let Some(subtitle) = subtitle {
         content_confirm = content_confirm.with_subtitle(subtitle);

--- a/core/embed/rust/src/ui/model_mercury/flow/confirm_reset_recover.rs
+++ b/core/embed/rust/src/ui/model_mercury/flow/confirm_reset_recover.rs
@@ -102,6 +102,7 @@ impl ConfirmResetRecover {
             PromptScreen::new_hold_to_confirm(),
         )
         .with_footer(TR::instructions__hold_to_confirm.into(), None)
+        .with_overlapping_content()
         .map(|msg| match msg {
             FrameMsg::Content(()) => Some(FlowMsg::Confirmed),
             _ => Some(FlowMsg::Cancelled),

--- a/core/embed/rust/src/ui/model_mercury/flow/get_address.rs
+++ b/core/embed/rust/src/ui/model_mercury/flow/get_address.rs
@@ -177,6 +177,7 @@ impl GetAddress {
 
         // Tap
         let content_tap = Frame::left_aligned(title, PromptScreen::new_tap_to_confirm())
+            .with_overlapping_content()
             .with_footer(TR::instructions__tap_to_confirm.into(), None)
             .map(|msg| match msg {
                 FrameMsg::Content(()) => Some(FlowMsg::Confirmed),
@@ -248,6 +249,7 @@ impl GetAddress {
             PromptScreen::new_tap_to_cancel(),
         )
         .with_cancel_button()
+        .with_overlapping_content()
         .with_footer(TR::instructions__tap_to_confirm.into(), None)
         .map(|msg| match msg {
             FrameMsg::Content(()) => Some(FlowMsg::Confirmed),

--- a/core/embed/rust/src/ui/model_mercury/flow/prompt_backup.rs
+++ b/core/embed/rust/src/ui/model_mercury/flow/prompt_backup.rs
@@ -133,6 +133,7 @@ impl PromptBackup {
             PromptScreen::new_tap_to_cancel(),
         )
         .with_footer(TR::instructions__tap_to_confirm.into(), None)
+        .with_overlapping_content()
         .map(|msg| match msg {
             FrameMsg::Content(()) => Some(FlowMsg::Confirmed),
             FrameMsg::Button(CancelInfoConfirmMsg::Cancelled) => Some(FlowMsg::Cancelled),

--- a/core/embed/rust/src/ui/model_mercury/flow/show_share_words.rs
+++ b/core/embed/rust/src/ui/model_mercury/flow/show_share_words.rs
@@ -102,6 +102,7 @@ impl ShowShareWords {
         let content_confirm =
             Frame::left_aligned(text_confirm, PromptScreen::new_hold_to_confirm())
                 .with_footer(TR::instructions__hold_to_confirm.into(), None)
+                .with_overlapping_content()
                 .map(|_| Some(FlowMsg::Confirmed));
 
         let content_check_backup_intro = Frame::left_aligned(


### PR DESCRIPTION
Implements tap-to-confirm animation for mercury UI.

<!--
If you are a core dev:

Don't forget to set up the fields:
- assign yourself
- set priority to same as original issue
- add PR to sprint
- if Draft -> "in progress"
- if final PR -> "needs review"

If you're an external contributor, you can ignore this text.
-->
