### PR TITLE
T3T1: fix old frame flickering when rising backlight

### DIFF
--- a/core/embed/trezorhal/stm32f4/xdisplay/st-7789/display_driver.c
+++ b/core/embed/trezorhal/stm32f4/xdisplay/st-7789/display_driver.c
@@ -89,10 +89,9 @@ void display_finish_actions(void) {
 int display_set_backlight(int level) {
 #ifdef XFRAMEBUFFER
 #ifndef BOARDLOADER
-  // wait for DMA transfer to finish before changing backlight
-  // so that we know that panel has current data
-  if (backlight_pwm_get() != level && !is_mode_handler()) {
-    bg_copy_wait();
+  // if turning on the backlight, wait until the panel is refreshed
+  if (backlight_pwm_get() < level && !is_mode_handler()) {
+    display_ensure_refreshed();
   }
 #endif
 #endif

--- a/core/embed/trezorhal/stm32f4/xdisplay/st-7789/display_fb.h
+++ b/core/embed/trezorhal/stm32f4/xdisplay/st-7789/display_fb.h
@@ -27,6 +27,8 @@
 // Clears both physical frame buffers
 void display_physical_fb_clear(void);
 
+void display_ensure_refreshed(void);
+
 #endif  // XFRAMEBUFFER
 
 #endif  // TREZORHAL_DISPLAY_FB_H


### PR DESCRIPTION
the previous protection relied at bg_copy being finished, but after that, it takes some time for the panel to refresh and actually show the new data.

i am switching to time-based protection. We could also consider some more sophisticated approaches like measuring number of TE signals after copying the data, but it seems unnecessarily complicated.

To limit the impact, i am only adding the wait if the backlight value is going up - as this is where the risk is.

<!--
If you are a core dev:

Don't forget to set up the fields:
- assign yourself
- set priority to same as original issue
- add PR to sprint
- if Draft -> "in progress"
- if final PR -> "needs review"

If you're an external contributor, you can ignore this text.
-->
