### PR TITLE
T3T1: expand menu btn

### DIFF
--- a/core/embed/rust/src/ui/model_mercury/component/frame.rs
+++ b/core/embed/rust/src/ui/model_mercury/component/frame.rs
@@ -13,7 +13,7 @@ use crate::{
 use super::{theme, Button, ButtonMsg, ButtonStyleSheet, CancelInfoConfirmMsg, Footer};
 
 const TITLE_HEIGHT: i16 = 42;
-const BUTTON_EXPAND_BORDER: i16 = 16;
+const BUTTON_EXPAND_BORDER: i16 = 32;
 
 #[derive(Clone)]
 pub struct Frame<T> {
@@ -83,11 +83,7 @@ where
     }
 
     fn with_button(mut self, icon: Icon, msg: CancelInfoConfirmMsg, enabled: bool) -> Self {
-        let touch_area = Insets {
-            left: BUTTON_EXPAND_BORDER,
-            bottom: BUTTON_EXPAND_BORDER,
-            ..self.border
-        };
+        let touch_area = Insets::uniform(BUTTON_EXPAND_BORDER);
         self.button = Some(Child::new(
             Button::with_icon(icon)
                 .with_expanded_touch_area(touch_area)


### PR DESCRIPTION
32 pixels instead of 16 in mercury UI. (tt has 44px button + 6*4px expansion, here we have 42px + 32 expansion)

<!--
If you are a core dev:

Don't forget to set up the fields:
- assign yourself
- set priority to same as original issue
- add PR to sprint
- if Draft -> "in progress"
- if final PR -> "needs review"

If you're an external contributor, you can ignore this text.
-->
