### PR TITLE
T3T1 keyboards

### DIFF
--- a/core/embed/rust/src/ui/model_mercury/component/button.rs
+++ b/core/embed/rust/src/ui/model_mercury/component/button.rs
@@ -31,6 +31,7 @@ pub struct Button {
     content: ButtonContent,
     styles: ButtonStyleSheet,
     text_align: Alignment,
+    radius: Option<u8>,
     state: State,
     long_press: Option<Duration>,
     long_timer: Option<TimerToken>,
@@ -49,6 +50,7 @@ impl Button {
             touch_expand: None,
             styles: theme::button_default(),
             text_align: Alignment::Start,
+            radius: None,
             state: State::Initial,
             long_press: None,
             long_timer: None,
@@ -92,6 +94,11 @@ impl Button {
 
     pub fn with_long_press(mut self, duration: Duration) -> Self {
         self.long_press = Some(duration);
+        self
+    }
+
+    pub fn with_radius(mut self, radius: u8) -> Self {
+        self.radius = Some(radius);
         self
     }
 
@@ -178,10 +185,21 @@ impl Button {
     pub fn render_background<'s>(&self, target: &mut impl Renderer<'s>, style: &ButtonStyle) {
         match &self.content {
             ButtonContent::IconBlend(_, _, _) => {}
-            _ => shape::Bar::new(self.area)
-                .with_bg(style.button_color)
-                .with_fg(style.button_color)
-                .render(target),
+            _ => {
+                if self.radius.is_some() {
+                    shape::Bar::new(self.area)
+                        .with_bg(style.background_color)
+                        .with_radius(self.radius.unwrap() as i16)
+                        .with_thickness(2)
+                        .with_fg(style.button_color)
+                        .render(target);
+                } else {
+                    shape::Bar::new(self.area)
+                        .with_bg(style.button_color)
+                        .with_fg(style.button_color)
+                        .render(target);
+                }
+            }
         }
     }
 

--- a/core/embed/rust/src/ui/model_mercury/component/keyboard/pin.rs
+++ b/core/embed/rust/src/ui/model_mercury/component/keyboard/pin.rs
@@ -66,12 +66,13 @@ impl<'a> PinKeyboard<'a> {
     ) -> Self {
         // Control buttons.
         let erase_btn = Button::with_icon(theme::ICON_DELETE)
-            .styled(theme::button_pin_erase())
+            .styled(theme::button_keyboard_erase())
             .with_long_press(theme::ERASE_HOLD_DURATION)
             .initially_enabled(false);
         let erase_btn = Maybe::hidden(theme::BG, erase_btn).into_child();
 
-        let cancel_btn = Button::with_icon(theme::ICON_CLOSE).styled(theme::button_pin_cancel());
+        let cancel_btn =
+            Button::with_icon(theme::ICON_CLOSE).styled(theme::button_keyboard_cancel());
         let cancel_btn = Maybe::new(theme::BG, cancel_btn, allow_cancel).into_child();
 
         Self {

--- a/core/embed/rust/src/ui/model_mercury/component/keyboard/pin.rs
+++ b/core/embed/rust/src/ui/model_mercury/component/keyboard/pin.rs
@@ -363,24 +363,14 @@ impl PinDots {
         let step = Self::DOT + Self::PADDING;
 
         // Jiggle when overflowed.
-        if digits >= MAX_VISIBLE_DOTS + 2 && (digits + 1) % 2 == 0 {
+        if digits > MAX_VISIBLE_DOTS + 1 && (digits + 1) % 2 == 0 {
             cursor.x += Self::TWITCH
         }
 
         let mut digit_idx = 0;
         // Small leftmost dot.
-        if digits >= MAX_VISIBLE_DOTS + 2 {
+        if digits > MAX_VISIBLE_DOTS + 1 {
             shape::ToifImage::new(cursor, theme::DOT_SMALL.toif)
-                .with_align(Alignment2D::CENTER_LEFT)
-                .with_fg(theme::GREY_DARK)
-                .render(target);
-            cursor.x += step;
-            digit_idx += 1;
-        }
-
-        // Greyed out dot.
-        if digits > MAX_VISIBLE_DOTS {
-            shape::ToifImage::new(cursor, theme::DOT_ACTIVE.toif)
                 .with_align(Alignment2D::CENTER_LEFT)
                 .with_fg(theme::GREY)
                 .render(target);
@@ -388,9 +378,19 @@ impl PinDots {
             digit_idx += 1;
         }
 
+        // Greyed out dot.
+        if digits > MAX_VISIBLE_DOTS {
+            shape::ToifImage::new(cursor, theme::DOT_SMALL.toif)
+                .with_align(Alignment2D::CENTER_LEFT)
+                .with_fg(self.style.text_color)
+                .render(target);
+            cursor.x += step;
+            digit_idx += 1;
+        }
+
         // Draw a dot for each PIN digit.
         for _ in digit_idx..dots_visible {
-            shape::ToifImage::new(cursor, theme::DOT_ACTIVE.toif)
+            shape::ToifImage::new(cursor, theme::ICON_PIN_BULLET.toif)
                 .with_align(Alignment2D::CENTER_LEFT)
                 .with_fg(self.style.text_color)
                 .render(target);

--- a/core/embed/rust/src/ui/model_mercury/component/mod.rs
+++ b/core/embed/rust/src/ui/model_mercury/component/mod.rs
@@ -14,6 +14,7 @@ mod error;
 mod frame;
 #[cfg(feature = "micropython")]
 mod homescreen;
+#[cfg(feature = "translations")]
 mod keyboard;
 mod loader;
 #[cfg(feature = "translations")]
@@ -47,6 +48,7 @@ pub use footer::Footer;
 pub use frame::{Frame, FrameMsg};
 #[cfg(feature = "micropython")]
 pub use homescreen::{check_homescreen_format, Homescreen, HomescreenMsg, Lockscreen};
+#[cfg(feature = "translations")]
 pub use keyboard::{
     bip39::Bip39Input,
     mnemonic::{MnemonicInput, MnemonicKeyboard, MnemonicKeyboardMsg},

--- a/core/embed/rust/src/ui/model_mercury/component/share_words.rs
+++ b/core/embed/rust/src/ui/model_mercury/component/share_words.rs
@@ -3,10 +3,10 @@ use crate::{
     strutil::TString,
     translations::TR,
     ui::{
-        component::{Component, Event, EventCtx, Paginate, Swipe},
+        component::{Component, Event, EventCtx, Paginate, Swipe, SwipeDirection},
         flow::Swipable,
         geometry::{Alignment, Alignment2D, Insets, Offset, Rect},
-        model_mercury::component::{Footer, SwipeDirection},
+        model_mercury::component::Footer,
         shape,
         shape::Renderer,
     },

--- a/core/embed/rust/src/ui/model_mercury/layout.rs
+++ b/core/embed/rust/src/ui/model_mercury/layout.rs
@@ -959,7 +959,7 @@ extern "C" fn new_show_mismatch(n_args: usize, args: *const Obj, kwargs: *mut Ma
                 title,
                 Button::cancel_confirm(
                     Button::with_icon(theme::ICON_BACK),
-                    Button::with_text(button).styled(theme::button_reset()),
+                    Button::with_text(button).styled(theme::button_default()),
                     true,
                 ),
             )

--- a/core/embed/rust/src/ui/model_mercury/theme/mod.rs
+++ b/core/embed/rust/src/ui/model_mercury/theme/mod.rs
@@ -122,6 +122,7 @@ include_icon!(
     "model_mercury/res/scroll-inactive-quarter.toif"
 );
 include_icon!(DOT_SMALL, "model_mercury/res/scroll-small.toif");
+include_icon!(ICON_PIN_BULLET, "model_mercury/res/pin_bullet6.toif");
 
 // Text arrows.
 include_icon!(ICON_PAGE_NEXT, "model_mercury/res/page-next.toif");

--- a/core/embed/rust/src/ui/model_mercury/theme/mod.rs
+++ b/core/embed/rust/src/ui/model_mercury/theme/mod.rs
@@ -126,6 +126,14 @@ include_icon!(DOT_SMALL, "model_mercury/res/scroll-small.toif");
 include_icon!(ICON_PAGE_NEXT, "model_mercury/res/page-next.toif");
 include_icon!(ICON_PAGE_PREV, "model_mercury/res/page-prev.toif");
 
+// Icon for "<space>*#" key on the passphrase keyboard.
+include_icon!(
+    ICON_SPECIAL_CHARS_GROUP,
+    "model_mercury/res/special_chars_group.toif"
+);
+// Icon for "next keyboard layout" for special characters
+include_icon!(ICON_ASTERISK, "model_mercury/res/asterisk16.toif");
+
 // Large, three-color icons.
 pub const WARN_COLOR: Color = ORANGE_LIGHT;
 pub const INFO_COLOR: Color = GREY_LIGHT;
@@ -404,33 +412,6 @@ pub const fn button_danger() -> ButtonStyleSheet {
     }
 }
 
-// TODO: delete
-pub const fn button_reset() -> ButtonStyleSheet {
-    ButtonStyleSheet {
-        normal: &ButtonStyle {
-            font: Font::BOLD,
-            text_color: FG,
-            button_color: YELLOW,
-            icon_color: GREY_LIGHT,
-            background_color: BG,
-        },
-        active: &ButtonStyle {
-            font: Font::BOLD,
-            text_color: FG,
-            button_color: YELLOW_DARK,
-            icon_color: GREY_LIGHT,
-            background_color: BG,
-        },
-        disabled: &ButtonStyle {
-            font: Font::BOLD,
-            text_color: FG,
-            button_color: YELLOW,
-            icon_color: GREY_LIGHT,
-            background_color: BG,
-        },
-    }
-}
-
 // used for PIN digit keys and passphrase/recovery letter keys
 pub const fn button_keyboard() -> ButtonStyleSheet {
     ButtonStyleSheet {
@@ -458,33 +439,7 @@ pub const fn button_keyboard() -> ButtonStyleSheet {
     }
 }
 
-pub const fn button_pin_confirm() -> ButtonStyleSheet {
-    ButtonStyleSheet {
-        normal: &ButtonStyle {
-            font: Font::MONO,
-            text_color: FG,
-            button_color: GREEN_DARK,
-            icon_color: GREEN_LIME,
-            background_color: BG,
-        },
-        active: &ButtonStyle {
-            font: Font::MONO,
-            text_color: FG,
-            button_color: GREEN_LIGHT,
-            icon_color: GREEN_DARK,
-            background_color: BG,
-        },
-        disabled: &ButtonStyle {
-            font: Font::MONO,
-            text_color: GREY_DARK,
-            button_color: BG,
-            icon_color: GREY_DARK,
-            background_color: BG,
-        },
-    }
-}
-
-pub const fn button_pin_cancel() -> ButtonStyleSheet {
+pub const fn button_keyboard_cancel() -> ButtonStyleSheet {
     ButtonStyleSheet {
         normal: &ButtonStyle {
             font: Font::MONO,
@@ -511,7 +466,7 @@ pub const fn button_pin_cancel() -> ButtonStyleSheet {
     }
 }
 
-pub const fn button_pin_erase() -> ButtonStyleSheet {
+pub const fn button_keyboard_erase() -> ButtonStyleSheet {
     ButtonStyleSheet {
         normal: &ButtonStyle {
             font: Font::MONO,
@@ -533,6 +488,88 @@ pub const fn button_pin_erase() -> ButtonStyleSheet {
             text_color: FG,
             button_color: BG,
             icon_color: GREEN_LIGHT,
+            background_color: BG,
+        },
+    }
+}
+
+// TODO: merge `button_pin_confirm` and `_passphrase_confirm`. Need to render
+// button `.with_radius` correctly
+pub const fn button_pin_confirm() -> ButtonStyleSheet {
+    ButtonStyleSheet {
+        normal: &ButtonStyle {
+            font: Font::MONO,
+            text_color: FG,
+            button_color: GREEN_DARK,
+            icon_color: GREEN_LIME,
+            background_color: BG,
+        },
+        active: &ButtonStyle {
+            font: Font::MONO,
+            text_color: FG,
+            button_color: GREEN_LIGHT,
+            icon_color: GREEN_DARK,
+            background_color: BG,
+        },
+        disabled: &ButtonStyle {
+            font: Font::MONO,
+            text_color: GREY_DARK,
+            button_color: BG,
+            icon_color: GREY_DARK,
+            background_color: BG,
+        },
+    }
+}
+
+pub const fn button_passphrase_confirm() -> ButtonStyleSheet {
+    ButtonStyleSheet {
+        normal: &ButtonStyle {
+            font: Font::DEMIBOLD,
+            text_color: GREEN_LIME,
+            button_color: GREEN_LIGHT,
+            icon_color: GREEN_LIME,
+            background_color: GREEN_DARK,
+        },
+        active: &ButtonStyle {
+            font: Font::DEMIBOLD,
+            text_color: GREEN_LIME,
+            button_color: GREEN_LIGHT,
+            icon_color: GREEN_DARK,
+            background_color: GREEN_LIGHT,
+        },
+        // not used
+        disabled: &ButtonStyle {
+            font: Font::DEMIBOLD,
+            text_color: BG,
+            button_color: BG,
+            icon_color: BG,
+            background_color: BG,
+        },
+    }
+}
+
+pub const fn button_passphrase_next() -> ButtonStyleSheet {
+    ButtonStyleSheet {
+        normal: &ButtonStyle {
+            font: Font::DEMIBOLD,
+            text_color: GREY_LIGHT,
+            button_color: BG, // TODO: gradient
+            icon_color: GREY_LIGHT,
+            background_color: BG,
+        },
+        active: &ButtonStyle {
+            font: Font::DEMIBOLD,
+            text_color: GREY_LIGHT,
+            button_color: BG, // TODO: gradient
+            icon_color: GREY_LIGHT,
+            background_color: BG,
+        },
+        // not used
+        disabled: &ButtonStyle {
+            font: Font::DEMIBOLD,
+            text_color: GREY_LIGHT,
+            button_color: BG,
+            icon_color: GREY_LIGHT,
             background_color: BG,
         },
     }
@@ -751,7 +788,8 @@ pub const CORNER_BUTTON_SIDE: i16 = 44;
 pub const CORNER_BUTTON_SPACING: i16 = BUTTON_SPACING;
 pub const INFO_BUTTON_HEIGHT: i16 = 44;
 pub const PIN_BUTTON_HEIGHT: i16 = 52;
-pub const MNEMONIC_BUTTON_HEIGHT: i16 = 52;
+pub const MNEMONIC_BUTTON_HEIGHT: i16 = 62;
+pub const PASSPHRASE_BUTTON_HEIGHT: i16 = 48;
 pub const RESULT_PADDING: i16 = 6;
 pub const RESULT_FOOTER_START: i16 = 171;
 pub const RESULT_FOOTER_HEIGHT: i16 = 62;

--- a/core/embed/rust/src/ui/model_mercury/theme/mod.rs
+++ b/core/embed/rust/src/ui/model_mercury/theme/mod.rs
@@ -75,6 +75,7 @@ include_icon!(ICON_PAGE_UP, "model_mercury/res/page_up20.toif");
 
 // 24x24
 include_icon!(ICON_CANCEL, "model_mercury/res/cancel24.toif");
+include_icon!(ICON_CHEVRON_LEFT, "model_mercury/res/chevron_left24.toif");
 include_icon!(ICON_CHEVRON_RIGHT, "model_mercury/res/chevron_right24.toif");
 include_icon!(ICON_DOWNLOAD, "model_mercury/res/download24.toif");
 include_icon!(ICON_KEY, "model_mercury/res/key20.toif");
@@ -575,27 +576,28 @@ pub const fn button_passphrase_next() -> ButtonStyleSheet {
     }
 }
 
-pub const fn button_bip39_autocomplete() -> ButtonStyleSheet {
+pub const fn button_recovery_confirm() -> ButtonStyleSheet {
     ButtonStyleSheet {
         normal: &ButtonStyle {
-            font: Font::MONO,
-            text_color: FG,
-            button_color: BG,
-            icon_color: GREY_LIGHT,
-            background_color: BG,
+            font: Font::DEMIBOLD,
+            text_color: GREEN_LIME,
+            button_color: GREEN_LIGHT,
+            icon_color: GREEN_LIME,
+            background_color: GREEN_DARK,
         },
         active: &ButtonStyle {
-            font: Font::MONO,
-            text_color: FG,
-            button_color: BG,
-            icon_color: GREY_LIGHT,
-            background_color: BG,
+            font: Font::DEMIBOLD,
+            text_color: GREEN_DARK,
+            button_color: GREEN_LIGHT,
+            icon_color: GREEN_DARK,
+            background_color: GREEN_LIGHT,
         },
+        // used in SLIP-39 recovery for "*"
         disabled: &ButtonStyle {
-            font: Font::MONO,
-            text_color: FG,
+            font: Font::DEMIBOLD,
+            text_color: GREY_LIGHT,
             button_color: BG,
-            icon_color: GREY_LIGHT,
+            icon_color: BG,
             background_color: BG,
         },
     }
@@ -604,24 +606,52 @@ pub const fn button_bip39_autocomplete() -> ButtonStyleSheet {
 pub const fn button_suggestion_confirm() -> ButtonStyleSheet {
     ButtonStyleSheet {
         normal: &ButtonStyle {
-            font: Font::MONO,
+            font: Font::DEMIBOLD,
+            text_color: GREY_LIGHT, // difference
+            button_color: GREEN_LIGHT,
+            icon_color: GREEN_LIME,
+            background_color: GREEN_DARK,
+        },
+        active: &ButtonStyle {
+            font: Font::DEMIBOLD,
+            text_color: GREEN_LIME,
+            button_color: GREEN_LIGHT,
+            icon_color: GREEN_DARK,
+            background_color: GREEN_LIGHT,
+        },
+        // not used
+        disabled: &ButtonStyle {
+            font: Font::DEMIBOLD,
+            text_color: BG,
+            button_color: BG,
+            icon_color: BG,
+            background_color: BG,
+        },
+    }
+}
+
+pub const fn button_recovery_autocomplete() -> ButtonStyleSheet {
+    ButtonStyleSheet {
+        normal: &ButtonStyle {
+            font: Font::DEMIBOLD,
             text_color: GREY_LIGHT,
-            button_color: GREEN,
+            button_color: GREY_EXTRA_DARK,
             icon_color: GREY_LIGHT,
             background_color: BG,
         },
         active: &ButtonStyle {
-            font: Font::MONO,
-            text_color: FG,
-            button_color: GREEN_DARK,
-            icon_color: GREY_LIGHT,
-            background_color: BG,
+            font: Font::DEMIBOLD,
+            text_color: BG,
+            button_color: FG,
+            icon_color: BG,
+            background_color: FG,
         },
+        // not used
         disabled: &ButtonStyle {
-            font: Font::MONO,
-            text_color: GREY_LIGHT,
-            button_color: GREY_DARK,
-            icon_color: GREY_LIGHT,
+            font: Font::DEMIBOLD,
+            text_color: BG,
+            button_color: BG,
+            icon_color: BG,
             background_color: BG,
         },
     }
@@ -630,24 +660,25 @@ pub const fn button_suggestion_confirm() -> ButtonStyleSheet {
 pub const fn button_suggestion_autocomplete() -> ButtonStyleSheet {
     ButtonStyleSheet {
         normal: &ButtonStyle {
-            font: Font::MONO,
-            text_color: GREY_LIGHT,
-            button_color: GREY_DARK, // same as PIN buttons
-            icon_color: GREY_LIGHT,
+            font: Font::DEMIBOLD,
+            text_color: GREY,
+            button_color: BG,
+            icon_color: BG,
             background_color: BG,
         },
         active: &ButtonStyle {
             font: Font::MONO,
-            text_color: FG,
-            button_color: GREEN_DARK,
-            icon_color: GREY_LIGHT,
-            background_color: BG,
+            text_color: BG,
+            button_color: FG,
+            icon_color: BG,
+            background_color: FG,
         },
+        // not used
         disabled: &ButtonStyle {
             font: Font::MONO,
-            text_color: GREY_LIGHT,
+            text_color: BG,
             button_color: BG,
-            icon_color: GREY_LIGHT,
+            icon_color: BG,
             background_color: BG,
         },
     }

--- a/core/src/trezor/ui/layouts/mercury/recovery.py
+++ b/core/src/trezor/ui/layouts/mercury/recovery.py
@@ -34,7 +34,7 @@ async def request_word_count(dry_run: bool) -> int:
 async def request_word(
     word_index: int, word_count: int, is_slip39: bool, prefill_word: str = ""
 ) -> str:
-    prompt = TR.recovery__type_word_x_of_y_template.format(word_index + 1, word_count)
+    prompt = TR.recovery__word_x_of_y_template.format(word_index + 1, word_count)
     can_go_back = word_index > 0
     if is_slip39:
         keyboard = RustLayout(


### PR DESCRIPTION
<!--
If you are a core dev:

Don't forget to set up the fields:
- assign yourself
- set priority to same as original issue
- add PR to sprint
- if Draft -> "in progress"
- if final PR -> "needs review"

If you're an external contributor, you can ignore this text.
-->
Hopefully final PR for keyboards

Passphrase keyboard
- redesign

Recovery keyboard
- both BIP39 and SLIP39 redesign
- pill-shaped button used for auto-complete and confirm

PIN keyboard:
- minor change - bullets shown are a little bit smaller



