### PR TITLE
build(core): move default values for bindgen macros (back) into build.rs

### DIFF
--- a/core/Makefile
+++ b/core/Makefile
@@ -43,8 +43,6 @@ OPENOCD_INTERFACE ?= stlink
 # OpenOCD transport default. Alternative: jtag
 OPENOCD_TRANSPORT ?= hla_swd
 
-BINDGEN_MACROS_COMMON=-I../unix,-I../trezorhal/unix,-I../../build/unix,-I../../vendor/micropython/ports/unix,-I../../../crypto,-I../../../storage,-I../../vendor/micropython,-I../../vendor/micropython/lib/uzlib,-I../lib,-I../trezorhal,-I../trezorhal/unix,-I../models,-DTREZOR_EMULATOR,-DTREZOR_BOARD="boards/board-unix.h",
-
 ifeq ($(TREZOR_MODEL), 1)
 MCU = STM32F2
 LAYOUT_FILE = embed/models/model_T1B1.h
@@ -53,13 +51,11 @@ else ifeq ($(TREZOR_MODEL),$(filter $(TREZOR_MODEL),T))
 MCU = STM32F4
 LAYOUT_FILE = embed/models/model_T2T1.h
 OPENOCD_TARGET = target/stm32f4x.cfg
-BINDGEN_MACROS_MODEL = -DSTM32F427,-DTREZOR_MODEL_T,-DFLASH_BIT_ACCESS=1,-DFLASH_BLOCK_WORDS=1,
 MODEL_FEATURE = model_tt
 else ifeq ($(TREZOR_MODEL),$(filter $(TREZOR_MODEL),R))
 MCU = STM32F4
 LAYOUT_FILE = embed/models/model_T2B1.h
 OPENOCD_TARGET = target/stm32f4x.cfg
-BINDGEN_MACROS_MODEL =-DSTM32F427,-DTREZOR_MODEL_R,-DFLASH_BIT_ACCESS=1,-DFLASH_BLOCK_WORDS=1,
 MODEL_FEATURE = model_tr
 else ifeq ($(TREZOR_MODEL),$(filter $(TREZOR_MODEL),T3T1))
 MCU = STM32U5
@@ -144,7 +140,6 @@ emu: ## run emulator
 test: ## run unit tests
 	cd tests ; ./run_tests.sh $(TESTOPTS)
 
-test_rust: export BINDGEN_MACROS=$(BINDGEN_MACROS_COMMON)$(BINDGEN_MACROS_MODEL)
 test_rust: ## run rs unit tests
 	cd embed/rust ; cargo test $(TESTOPTS) --target=$(RUST_TARGET) \
 		--no-default-features --features $(MODEL_FEATURE),test \
@@ -214,7 +209,6 @@ typecheck: pyright
 pyright:
 	python ../tools/pyright_tool.py
 
-clippy: export BINDGEN_MACROS:=$(BINDGEN_MACROS_COMMON)$(BINDGEN_MACROS_MODEL)
 clippy:
 	cd embed/rust ; cargo clippy $(TESTOPTS) --all-features --target=$(RUST_TARGET)
 


### PR DESCRIPTION
this way Cargo build can run without the envvar set, e.g. in rust-analyzer
<!--
If you are a core dev:

Don't forget to set up the fields:
- assign yourself
- set priority to same as original issue
- add PR to sprint
- if Draft -> "in progress"
- if final PR -> "needs review"

If you're an external contributor, you can ignore this text.
-->
