### PR TITLE
fix(core/embed): fix random delays in usb driver

### DIFF
--- a/core/embed/trezorhal/stm32f4/usb.c
+++ b/core/embed/trezorhal/stm32f4/usb.c
@@ -487,12 +487,10 @@ static uint8_t usb_class_setup(USBD_HandleTypeDef *dev,
     }
     switch (usb_ifaces[req->wIndex].type) {
       case USB_IFACE_TYPE_HID:
-        wait_random();
         return usb_hid_class_setup(dev, &usb_ifaces[req->wIndex].hid, req);
       case USB_IFACE_TYPE_VCP:
         return usb_vcp_class_setup(dev, &usb_ifaces[req->wIndex].vcp, req);
       case USB_IFACE_TYPE_WEBUSB:
-        wait_random();
         return usb_webusb_class_setup(dev, &usb_ifaces[req->wIndex].webusb,
                                       req);
       default:
@@ -511,14 +509,12 @@ static uint8_t usb_class_data_in(USBD_HandleTypeDef *dev, uint8_t ep_num) {
   for (int i = 0; i < USBD_MAX_NUM_INTERFACES; i++) {
     switch (usb_ifaces[i].type) {
       case USB_IFACE_TYPE_HID:
-        wait_random();
         usb_hid_class_data_in(dev, &usb_ifaces[i].hid, ep_num);
         break;
       case USB_IFACE_TYPE_VCP:
         usb_vcp_class_data_in(dev, &usb_ifaces[i].vcp, ep_num);
         break;
       case USB_IFACE_TYPE_WEBUSB:
-        wait_random();
         usb_webusb_class_data_in(dev, &usb_ifaces[i].webusb, ep_num);
         break;
       default:
@@ -535,14 +531,12 @@ static uint8_t usb_class_data_out(USBD_HandleTypeDef *dev, uint8_t ep_num) {
   for (int i = 0; i < USBD_MAX_NUM_INTERFACES; i++) {
     switch (usb_ifaces[i].type) {
       case USB_IFACE_TYPE_HID:
-        wait_random();
         usb_hid_class_data_out(dev, &usb_ifaces[i].hid, ep_num);
         break;
       case USB_IFACE_TYPE_VCP:
         usb_vcp_class_data_out(dev, &usb_ifaces[i].vcp, ep_num);
         break;
       case USB_IFACE_TYPE_WEBUSB:
-        wait_random();
         usb_webusb_class_data_out(dev, &usb_ifaces[i].webusb, ep_num);
         break;
       default:

--- a/core/embed/trezorhal/stm32f4/usb_hid-impl.h
+++ b/core/embed/trezorhal/stm32f4/usb_hid-impl.h
@@ -267,6 +267,8 @@ static void usb_hid_class_deinit(USBD_HandleTypeDef *dev,
 
 static int usb_hid_class_setup(USBD_HandleTypeDef *dev, usb_hid_state_t *state,
                                USBD_SetupReqTypedef *req) {
+  wait_random();
+
   switch (req->bmRequest & USB_REQ_TYPE_MASK) {
     // Class request
     case USB_REQ_TYPE_CLASS:
@@ -340,6 +342,7 @@ static int usb_hid_class_setup(USBD_HandleTypeDef *dev, usb_hid_state_t *state,
 static void usb_hid_class_data_in(USBD_HandleTypeDef *dev,
                                   usb_hid_state_t *state, uint8_t ep_num) {
   if ((ep_num | USB_EP_DIR_IN) == state->ep_in) {
+    wait_random();
     state->ep_in_is_idle = 1;
   }
 }
@@ -347,6 +350,7 @@ static void usb_hid_class_data_in(USBD_HandleTypeDef *dev,
 static void usb_hid_class_data_out(USBD_HandleTypeDef *dev,
                                    usb_hid_state_t *state, uint8_t ep_num) {
   if (ep_num == state->ep_out) {
+    wait_random();
     // Save the report length to indicate we have read something, but don't
     // schedule next reading until user reads this one
     state->last_read_len = USBD_LL_GetRxDataSize(dev, ep_num);

--- a/core/embed/trezorhal/stm32f4/usb_webusb-impl.h
+++ b/core/embed/trezorhal/stm32f4/usb_webusb-impl.h
@@ -243,6 +243,8 @@ static int usb_webusb_class_setup(USBD_HandleTypeDef *dev,
     return USBD_OK;
   }
 
+  wait_random();
+
   switch (req->bRequest) {
     case USB_REQ_SET_INTERFACE:
       state->alt_setting = req->wValue;
@@ -263,6 +265,7 @@ static void usb_webusb_class_data_in(USBD_HandleTypeDef *dev,
                                      usb_webusb_state_t *state,
                                      uint8_t ep_num) {
   if ((ep_num | USB_EP_DIR_IN) == state->ep_in) {
+    wait_random();
     state->ep_in_is_idle = 1;
   }
 }
@@ -271,6 +274,7 @@ static void usb_webusb_class_data_out(USBD_HandleTypeDef *dev,
                                       usb_webusb_state_t *state,
                                       uint8_t ep_num) {
   if (ep_num == state->ep_out) {
+    wait_random();
     // Save the report length to indicate we have read something, but don't
     // schedule next reading until user reads this one
     state->last_read_len = USBD_LL_GetRxDataSize(dev, ep_num);


### PR DESCRIPTION
This small PR fixes random delays in the USB driver while receiving/sending USB data packets for HID and WEBUSB interfaces.

Before this change, `wait_random()` was called multiple times in `usb_class_data_in()` and `usb_class_data_out()` while finding the proper interface to handle a request. Moreover, the fix 62e3a414ad7a20d09fd4ea6709ae4ca5d1335a4f may not succeed at all if the VCP interface was not the first one or the only one.

This change have no effect on device behaviour in production.







