### PR TITLE
Change build_mocks to include empty lines

### DIFF
--- a/core/embed/extmod/modtrezorcrypto/modtrezorcrypto-monero.h
+++ b/core/embed/extmod/modtrezorcrypto/modtrezorcrypto-monero.h
@@ -140,7 +140,7 @@ STATIC void mp_unpack_scalar(bignum256modm r, const mp_obj_t arg,
 ///     """
 ///     EC point on ED25519
 ///     """
-///
+
 ///     def __init__(self, x: Point | bytes | None = None):
 ///         """
 ///         Constructor
@@ -179,13 +179,12 @@ STATIC MP_DEFINE_CONST_FUN_OBJ_1(mod_trezorcrypto_monero_ge25519___del___obj,
 ///     """
 ///     EC scalar on SC25519
 ///     """
-///
+
 ///     def __init__(self, x: Scalar | bytes | int | None = None):
 ///         """
 ///         Constructor
 ///         """
-///
-///
+
 STATIC mp_obj_t mod_trezorcrypto_monero_bignum256modm_make_new(
     const mp_obj_type_t *type, size_t n_args, size_t n_kw,
     const mp_obj_t *args) {
@@ -223,28 +222,27 @@ STATIC MP_DEFINE_CONST_FUN_OBJ_1(
 ///     """
 ///     XMR hasher
 ///     """
-///
+
 ///     def __init__(self, x: bytes | None = None):
 ///         """
 ///         Constructor
 ///         """
-///
+
 ///     def update(self, buffer: bytes) -> None:
 ///         """
 ///         Update hasher
 ///         """
-///
+
 ///     def digest(self) -> bytes:
 ///         """
 ///         Computes digest
 ///         """
-///
+
 ///     def copy(self) -> Hasher:
 ///         """
 ///         Creates copy of the hasher, preserving the state
 ///         """
-///
-///
+
 STATIC mp_obj_t mod_trezorcrypto_monero_hasher_make_new(
     const mp_obj_type_t *type, size_t n_args, size_t n_kw,
     const mp_obj_t *args) {

--- a/core/embed/extmod/modtrezorio/modtrezorio-poll.h
+++ b/core/embed/extmod/modtrezorio/modtrezorio-poll.h
@@ -37,11 +37,11 @@ extern bool usb_connected_previously;
 /// def poll(ifaces: Iterable[int], list_ref: list, timeout_ms: int) -> bool:
 ///     """
 ///     Wait until one of `ifaces` is ready to read or write (using masks
-//      `io.POLL_READ` and `io.POLL_WRITE`) and assign the result into
+///     `io.POLL_READ` and `io.POLL_WRITE`) and assign the result into
 ///     `list_ref`:
 ///
-///     `list_ref[0]` - the interface number, including the mask
-///     `list_ref[1]` - for touch event, tuple of:
+///     - `list_ref[0]` - the interface number, including the mask
+///     - `list_ref[1]` - for touch event, tuple of:
 ///                     (event_type, x_position, y_position)
 ///                   - for button event (T1), tuple of:
 ///                     (event type, button number)

--- a/core/embed/extmod/modtrezorui/modtrezorui-display.h
+++ b/core/embed/extmod/modtrezorui/modtrezorui-display.h
@@ -25,14 +25,13 @@
 ///     """
 ///     Provide access to device display.
 ///     """
-///
 ///     WIDTH: int  # display width in pixels
 ///     HEIGHT: int  # display height in pixels
 ///     FONT_MONO: int  # id of monospace font
 ///     FONT_NORMAL: int  # id of normal-width font
 ///     FONT_DEMIBOLD: int  # id of demibold font
 ///     FONT_BOLD_UPPER: int # id of bold-width-uppercased font
-///
+
 typedef struct _mp_obj_Display_t {
   mp_obj_base_t base;
 } mp_obj_Display_t;

--- a/core/embed/extmod/modtrezorutils/modtrezorutils.c
+++ b/core/embed/extmod/modtrezorutils/modtrezorutils.c
@@ -320,15 +320,15 @@ STATIC MP_DEFINE_CONST_FUN_OBJ_VAR_BETWEEN(
     mod_trezorutils_reboot_to_bootloader);
 
 /// VersionTuple = Tuple[int, int, int, int]
-///
+
 /// class FirmwareHeaderInfo(NamedTuple):
 ///     version: VersionTuple
 ///     vendor: str
 ///     fingerprint: bytes
 ///     hash: bytes
-///
+
 /// mock:global
-///
+
 /// def check_firmware_header(header : bytes) -> FirmwareHeaderInfo:
 ///     """Parses incoming firmware header and returns information about it."""
 STATIC mp_obj_t mod_trezorutils_check_firmware_header(mp_obj_t header) {

--- a/core/mocks/generated/trezorcrypto/crc.pyi
+++ b/core/mocks/generated/trezorcrypto/crc.pyi
@@ -5,10 +5,12 @@ from typing import *
 def crc32(data: bytes, crc: int = 0) -> int:
    """
    Computes a CRC32 checksum of `data`.
+
    Args:
        `data` (`bytes`): Input data.
        `crc` (`int`, `optional`): Initial CRC value for chaining
        computations over multiple data segments. Defaults to 0.
+
    Returns:
        `int`: Computed CRC32 checksum.
    """

--- a/core/mocks/generated/trezorio/__init__.pyi
+++ b/core/mocks/generated/trezorio/__init__.pyi
@@ -72,13 +72,16 @@ class HID:
 def poll(ifaces: Iterable[int], list_ref: list, timeout_ms: int) -> bool:
     """
     Wait until one of `ifaces` is ready to read or write (using masks
+    `io.POLL_READ` and `io.POLL_WRITE`) and assign the result into
     `list_ref`:
-    `list_ref[0]` - the interface number, including the mask
-    `list_ref[1]` - for touch event, tuple of:
+
+    - `list_ref[0]` - the interface number, including the mask
+    - `list_ref[1]` - for touch event, tuple of:
                     (event_type, x_position, y_position)
                   - for button event (T1), tuple of:
                     (event type, button number)
                   - for USB read event, received bytes
+
     If timeout occurs, False is returned, True otherwise.
     """
 
@@ -193,6 +196,7 @@ class WebUSB:
 from . import fatfs, sdcard
 POLL_READ: int  # wait until interface is readable and return read data
 POLL_WRITE: int  # wait until interface is writable
+
 TOUCH: int  # interface id of the touch events
 TOUCH_START: int  # event id of touch start event
 TOUCH_MOVE: int  # event id of touch move event

--- a/core/tools/build_mocks
+++ b/core/tools/build_mocks
@@ -11,7 +11,8 @@ EXTMOD_PATH = CORE_DIR / "embed" / "extmod"
 RUSTMOD_PATH = CORE_DIR / "embed" / "rust" / "src"
 MOCKS_PATH = CORE_DIR / "mocks" / "generated"
 
-COMMENT_PREFIX = "/// "
+COMMENT_PREFIX_SHORT = "///"
+COMMENT_PREFIX = COMMENT_PREFIX_SHORT + " "
 
 current_indent = 0
 current_class = None
@@ -61,9 +62,11 @@ def split_to_parts(line, mod_desc=None):
             yield (current_package, current_indent * " " + "@overload\n")
             current_method_is_overload = False
 
-    line = current_indent * " " + line
-
-    yield (current_package, line)
+    if not line.strip():
+        yield (current_package, "\n")
+    else:
+        line = current_indent * " " + line
+        yield (current_package, line)
 
 
 def store_to_file(dest, parts):
@@ -105,10 +108,10 @@ def build_module(mod_file, dest):
     mod_desc = str(mod_file.relative_to(CORE_DIR / "embed"))
 
     for l in open(mod_file):
-        if not l.startswith(COMMENT_PREFIX):
+        if not l.startswith(COMMENT_PREFIX_SHORT):
             continue
-
         l = l[len(COMMENT_PREFIX) :]  # .strip()
+
         store_to_file(dest, split_to_parts(l, mod_desc))
 
 


### PR DESCRIPTION
This PR changes the `gen` script to include empty lines when converting comments into documentation.