### PR TITLE
Haptic driver refactoring

### DIFF
--- a/core/embed/trezorhal/haptic.h
+++ b/core/embed/trezorhal/haptic.h
@@ -1,3 +1,21 @@
+/*
+ * This file is part of the Trezor project, https://trezor.io/
+ *
+ * Copyright (c) SatoshiLabs
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
 
 #ifndef TREZORHAL_HAPTIC_H
 #define TREZORHAL_HAPTIC_H
@@ -6,30 +24,64 @@
 #include <stdint.h>
 
 typedef enum {
+  // Effect at the start of a button press
   HAPTIC_BUTTON_PRESS = 0,
-  HAPTIC_ALERT = 1,
-  HAPTIC_HOLD_TO_CONFIRM = 2,
+  // Effect at the and of hold-to-confirm action
+  HAPTIC_HOLD_TO_CONFIRM = 1,
 } haptic_effect_t;
 
-// Initialize haptic driver
-void haptic_init(void);
+// Initializes the haptic driver
+//
+// The function initializes the GPIO pins and the hardware
+// peripherals used by the haptic driver.
+//
+// Returns `true` if the initialization was successful.
+bool haptic_init(void);
 
-// Calibrate haptic driver
-void haptic_calibrate(void);
+// Deinitializes the haptic driver
+//
+// The function deinitializes the hardware peripherals used by the
+// haptic driver so the device can be eventually put into a low-power mode.
+void haptic_deinit(void);
 
-// Test haptic driver, plays a maximum amplitude for the given duration
+// Enables or disables the haptic driver
+//
+// When the driver is disabled, it does not play any haptic effects
+// and potentially can put the controller into a low-power mode.
+//
+// The driver is enabled by default (after initialization).
+void haptic_set_enabled(bool enabled);
+
+// Returns `true` if haptic driver is enabled
+bool haptic_get_enabled(void);
+
+// Tests the haptic driver, playing at maximum amplitude for the given duration
+//
+// This function is used during production testing to verify that the haptic
+// motor is working correctly.
+//
+// Returns `true` if the test effect was successfully started.
 bool haptic_test(uint16_t duration_ms);
 
-// Play haptic effect
-void haptic_play(haptic_effect_t effect);
+// Plays one of haptic effects
+//
+// The function stops playing any currently running effect and
+// starts playing the specified effect.
+//
+// Returns `true` if the effect was successfully started.
+bool haptic_play(haptic_effect_t effect);
 
-// Starts the haptic motor with a specified amplitude and period
+// Starts the haptic motor with a specified amplitude (in percent) for a
+// specified duration (in milliseconds).
+//
+// The function stops playing any currently running effect and
+// starts playing the specified effect.
 //
 // The function can be invoked repeatedly during the specified duration
 // (`duration_ms`) to modify the amplitude dynamically, allowing
 // the creation of customized haptic effects.
+//
+// Returns `true` if the effect was successfully started.
 bool haptic_play_custom(int8_t amplitude_pct, uint16_t duration_ms);
 
-void haptic_set_enabled(bool enable);
-
-#endif
+#endif  // TREZORHAL_HAPTIC_H

--- a/core/embed/trezorhal/stm32u5/haptic/drv2625/drv2625.h
+++ b/core/embed/trezorhal/stm32u5/haptic/drv2625/drv2625.h
@@ -1,5 +1,63 @@
-#ifndef __DRV_2625_LIB_H__
-#define __DRV_2625_LIB_H__
+#ifndef TREZOR_HAL_DRV_2625_H
+#define TREZOR_HAL_DRV_2625_H
+
+// I2C address of the DRV2625 on the I2C bus.
+// `<< 1` is required because the HAL expects the address to be shifted by 1.
+#define DRV2625_I2C_ADDRESS (0x5A << 1)
+
+// ------------------------------------------------------------
+// DRV2625 registers
+// ------------------------------------------------------------
+
+#define DRV2625_REG_CHIPID 0x00
+#define DRV2625_REG_STATUS 0x01
+#define DRV2625_REG_MODE 0x07
+#define DRV2625_REG_MODE_RTP 0
+#define DRV2625_REG_MODE_WAVEFORM 0x01
+#define DRV2625_REG_MODE_DIAG 0x02
+#define DRV2625_REG_MODE_AUTOCAL 0x03
+#define DRV2625_REG_MODE_TRGFUNC_PULSE 0x00
+#define DRV2625_REG_MODE_TRGFUNC_ENABLE 0x04
+#define DRV2625_REG_MODE_TRGFUNC_INTERRUPT 0x08
+
+#define DRV2625_REG_LRAERM 0x08
+#define DRV2625_REG_LRAERM_LRA 0x80
+#define DRV2625_REG_LRAERM_OPENLOOP 0x40
+#define DRV2625_REG_LRAERM_AUTO_BRK_OL 0x10
+#define DRV2625_REG_LRAERM_AUTO_BRK_STBY 0x08
+
+#define DRV2625_REG_LIBRARY 0x0D  ///< Waveform library selection register
+#define DRV2625_REG_LIBRARY_OPENLOOP 0x40
+#define DRV2625_REG_LIBRARY_GAIN_100 0x00
+#define DRV2625_REG_LIBRARY_GAIN_75 0x01
+#define DRV2625_REG_LIBRARY_GAIN_50 0x02
+#define DRV2625_REG_LIBRARY_GAIN_25 0x03
+
+#define DRV2625_REG_RTP 0x0E  ///< RTP input register
+
+#define DRV2625_REG_WAVESEQ1 0x0F  ///< Waveform sequence register 1
+#define DRV2625_REG_WAVESEQ2 0x10  ///< Waveform sequence register 2
+#define DRV2625_REG_WAVESEQ3 0x11  ///< Waveform sequence register 3
+#define DRV2625_REG_WAVESEQ4 0x12  ///< Waveform sequence register 4
+#define DRV2625_REG_WAVESEQ5 0x13  ///< Waveform sequence register 5
+#define DRV2625_REG_WAVESEQ6 0x14  ///< Waveform sequence register 6
+#define DRV2625_REG_WAVESEQ7 0x15  ///< Waveform sequence register 7
+#define DRV2625_REG_WAVESEQ8 0x16  ///< Waveform sequence register 8
+
+#define DRV2625_REG_GO 0x0C  ///< Go register
+#define DRV2625_REG_GO_GO 0x01
+
+#define DRV2625_REG_OD_CLAMP 0x20
+
+#define DRV2625_REG_LRA_WAVE_SHAPE 0x2C
+#define DRV2625_REG_LRA_WAVE_SHAPE_SINE 0x01
+
+#define DRV2625_REG_OL_LRA_PERIOD_LO 0x2F
+#define DRV2625_REG_OL_LRA_PERIOD_HI 0x2E
+
+// ------------------------------------------------------------
+// DRV2625 effect types
+// ------------------------------------------------------------
 
 typedef enum {
   STRONG_CLICK_100 = 1,
@@ -127,4 +185,4 @@ typedef enum {
   SMOOTH_HUM_5_20 = 123,
 } drv2625_lib_effect_t;
 
-#endif
+#endif  // TREZOR_HAL_DRV_2625_H


### PR DESCRIPTION
This PR focuses on refactoring the haptic controller driver. It does not fix any problems or introduce new features, but includes the following changes:

1. Removed `haptic_calibrate()` since it's unused, and using calibration requires more effort than just having this routine.
2. Removed the `HAPTIC_ALERT` effect since it's unused.
3. Polished the haptic driver API (`haptic.h`). Added the `haptic_deinit()` function, allowing repeated driver initialization and deinitialization, and ensured all functions that can fail return `bool`.
4. Refactored the driver to avoid using many global variables, resulting in the driver state being clear and well-defined in a single location.

The original goal was to prepare the haptic driver for power management features (e.g., suspending before entering low power modes and resuming after returning to full power).
