### PR TITLE
Improved T3T1 framebuffer switching

### DIFF
--- a/core/embed/rust/src/ui/component/base.rs
+++ b/core/embed/rust/src/ui/component/base.rs
@@ -535,7 +535,7 @@ impl EventCtx {
     pub const ANIM_FRAME_TIMER: TimerToken = TimerToken(1);
 
     /// How long into the future we should schedule the animation frame timer.
-    const ANIM_FRAME_DEADLINE: Duration = Duration::from_millis(18);
+    const ANIM_FRAME_DEADLINE: Duration = Duration::from_millis(1);
 
     // 0 == `TimerToken::INVALID`,
     // 1 == `Self::ANIM_FRAME_TIMER`.

--- a/core/embed/trezorhal/bg_copy.h
+++ b/core/embed/trezorhal/bg_copy.h
@@ -7,9 +7,10 @@
 #include <stdint.h>
 
 /**
- * Wait for the data transfer completion
+ * Callback function invoked from the IRQ context
+ * when the transfer is complete
  */
-void bg_copy_wait(void);
+typedef void (*bg_copy_callback_t)(void);
 
 /**
  * Performs data copy from src to dst in the background. The destination is
@@ -19,8 +20,21 @@ void bg_copy_wait(void);
  * @param src source data address
  * @param dst destination data address
  * @param size size of data to be transferred in bytes
+ * @param callback optional callback to be called when the transfer is complete
  */
-void bg_copy_start_const_out_8(const uint8_t *src, uint8_t *dst, size_t size);
+void bg_copy_start_const_out_8(const uint8_t *src, uint8_t *dst, size_t size,
+                               bg_copy_callback_t callback);
+
+/**
+ * Waits for the data transfer completion
+ */
+void bg_copy_wait(void);
+
+/**
+ * Immediately aborts the data transfer
+ *
+ * @note The callback will not be called
+ */
 
 void bg_copy_abort(void);
 

--- a/core/embed/trezorhal/stm32f4/displays/st7789v.c
+++ b/core/embed/trezorhal/stm32f4/displays/st7789v.c
@@ -567,12 +567,12 @@ void DISPLAY_TE_INTERRUPT_HANDLER(void) {
   if (act_frame_buffer == 1) {
     bg_copy_start_const_out_8((uint8_t *)PhysFrameBuffer1,
                               (uint8_t *)DISPLAY_DATA_ADDRESS,
-                              DISPLAY_RESX * DISPLAY_RESY * 2);
+                              DISPLAY_RESX * DISPLAY_RESY * 2, NULL);
 
   } else {
     bg_copy_start_const_out_8((uint8_t *)PhysFrameBuffer0,
                               (uint8_t *)DISPLAY_DATA_ADDRESS,
-                              DISPLAY_RESX * DISPLAY_RESY * 2);
+                              DISPLAY_RESX * DISPLAY_RESY * 2, NULL);
   }
 
   pending_fb_switch = false;

--- a/core/embed/trezorhal/stm32f4/xdisplay/st-7789/display_fb.h
+++ b/core/embed/trezorhal/stm32f4/xdisplay/st-7789/display_fb.h
@@ -29,8 +29,6 @@ void display_physical_fb_clear(void);
 
 void display_ensure_refreshed(void);
 
-void wait_for_fb_switch(void);
-
 #endif  // XFRAMEBUFFER
 
 #endif  // TREZORHAL_DISPLAY_FB_H

--- a/core/embed/trezorhal/stm32f4/xdisplay/st-7789/display_internal.h
+++ b/core/embed/trezorhal/stm32f4/xdisplay/st-7789/display_internal.h
@@ -1,0 +1,59 @@
+#ifndef TREZORHAL_DISPLAY_INTERNAL_H
+#define TREZORHAL_DISPLAY_INTERNAL_H
+
+#include <stdint.h>
+
+#ifdef XFRAMEBUFFER
+
+// Number of frame buffers used (1 or 2)
+// If 1 buffer is selected, some animations may not
+// be so smooth but the memory usage is lower.
+#define FRAME_BUFFER_COUNT 2
+
+// Each frame buffer can be in one of the following states:
+typedef enum {
+  // The frame buffer is empty and can be written to
+  FB_STATE_EMPTY = 0,
+  // The frame buffer pass passed to application
+  FB_STATE_PREPARING = 1,
+  // The frame buffer was written to and is ready
+  // to be copied to the display
+  FB_STATE_READY = 2,
+  // The frame buffer is currently being copied to
+  // the display
+  FB_STATE_COPYING = 3,
+
+} frame_buffer_state_t;
+
+typedef struct {
+  // Queue entries
+  volatile frame_buffer_state_t entry[FRAME_BUFFER_COUNT];
+  // Read index
+  // (accessed & updated in the context of the interrupt handlers
+  uint8_t rix;
+  // Write index
+  // (accessed & updated in context of the main thread)
+  uint8_t wix;
+
+} frame_buffer_queue_t;
+
+#endif  // XFRAMEBUFFER
+
+// Display driver state
+typedef struct {
+#ifdef XFRAMEBUFFER
+  // Framebuffer queue
+  // (accessed & updated in the context of the main thread
+  // and the interrupt context)
+  volatile frame_buffer_queue_t queue;
+#endif
+
+  // Current display orientation (0, 90, 180, 270)
+  int orientation_angle;
+
+} display_driver_t;
+
+// Display driver instance
+extern display_driver_t g_display_driver;
+
+#endif  // TREZORHAL_DISPLAY_INTERNAL_H

--- a/core/embed/trezorhal/stm32f4/xdisplay/st-7789/display_io.c
+++ b/core/embed/trezorhal/stm32f4/xdisplay/st-7789/display_io.c
@@ -22,6 +22,7 @@
 
 #include "display_io.h"
 #include "irq.h"
+#include "supervise.h"
 
 __IO DISP_MEM_TYPE *const DISPLAY_CMD_ADDRESS =
     (__IO DISP_MEM_TYPE *const)((uint32_t)DISPLAY_MEMORY_BASE);
@@ -35,7 +36,6 @@ void display_io_init_gpio(void) {
   __HAL_RCC_GPIOA_CLK_ENABLE();
   __HAL_RCC_GPIOC_CLK_ENABLE();
   __HAL_RCC_GPIOD_CLK_ENABLE();
-  __HAL_RCC_FMC_CLK_ENABLE();
 
   GPIO_InitTypeDef GPIO_InitStructure;
 
@@ -87,6 +87,8 @@ void display_io_init_gpio(void) {
 }
 
 void display_io_init_fmc(void) {
+  __HAL_RCC_FMC_CLK_ENABLE();
+
   // Reference UM1725 "Description of STM32F4 HAL and LL drivers",
   // section 64.2.1 "How to use this driver"
   SRAM_HandleTypeDef external_display_data_sram = {0};
@@ -141,5 +143,6 @@ void display_io_init_te_interrupt(void) {
 
   // setup interrupt for tearing effect pin
   HAL_NVIC_SetPriority(DISPLAY_TE_INTERRUPT_NUM, IRQ_PRI_DMA, 0);
+  svc_enableIRQ(DISPLAY_TE_INTERRUPT_NUM);
 }
 #endif

--- a/core/embed/trezorhal/stm32f4/xdisplay/st-7789/display_nofb.c
+++ b/core/embed/trezorhal/stm32f4/xdisplay/st-7789/display_nofb.c
@@ -25,7 +25,23 @@
 #include "display_panel.h"
 
 void display_refresh(void) {
-  // if the framebuffer is not used the implementation is empty
+  // If the framebuffer is not used the, we do not need
+  // to refresh the display explicitly as we write the data
+  // directly to the display internal RAM.
+}
+
+void display_wait_for_sync(void) {
+#ifdef DISPLAY_TE_PIN
+  uint32_t id = display_panel_identify();
+  if (id && (id != DISPLAY_ID_GC9307)) {
+    // synchronize with the panel synchronization signal
+    // in order to avoid visual tearing effects
+    while (GPIO_PIN_SET == HAL_GPIO_ReadPin(DISPLAY_TE_PORT, DISPLAY_TE_PIN))
+      ;
+    while (GPIO_PIN_RESET == HAL_GPIO_ReadPin(DISPLAY_TE_PORT, DISPLAY_TE_PIN))
+      ;
+  }
+#endif
 }
 
 static inline void set_window(const gfx_bitblt_t* bb) {

--- a/core/embed/trezorhal/xdisplay_legacy.c
+++ b/core/embed/trezorhal/xdisplay_legacy.c
@@ -40,4 +40,8 @@ int display_backlight(int level) {
   }
 }
 
-void display_sync(void) {}
+void display_sync(void) {
+#ifndef XFRAMEBUFFER
+  display_wait_for_sync();
+#endif
+}


### PR DESCRIPTION
This PR improves the display refreshing algorithm for the T3T1 model with the following enhancements:

1. Simplified the framebuffer switching algorithm, enabling full framerate, especially for simpler animations.
2. Modified the semantics of `display_get_frame_buffer()` and `display_refresh()`. Details are provided below.
3. Fixed the issue of waiting for the TE signal on the T2T1 model (with `NEW_RENDERING`=1).
4. Shorten `ANIM_FRAME_TIMER` deadline from 18ms to 1ms

The functions `display_get_frame_buffer()` and `display_refresh()` should now be used as a pair:

On the T3T1 model, all framebuffer switching (except when running in handler mode) is done in the background.

- `display_get_frame_buffer()`: Retrieves a new framebuffer for writing. This function may block for a while if the buffer is not ready. If called twice consecutively without an intervening call to `display_refresh()`, it returns the same buffer.
- `display_refresh()`: Enqueues the last retrieved buffer. This function is always non-blocking. Calling `display_refresh()` twice consecutively without an intervening call to `display_get_frame_buffer()` has no effect.



