### PR TITLE
fix bootloader lock check on STM32U5

### DIFF
--- a/core/.changelog.d/3922.fixed
+++ b/core/.changelog.d/3922.fixed
@@ -1,0 +1,1 @@
+[T3T1] Fixed device authenticity check

--- a/core/embed/trezorhal/stm32u5/secret.c
+++ b/core/embed/trezorhal/stm32u5/secret.c
@@ -38,7 +38,7 @@ secbool secret_ensure_initialized(void) {
 
 secbool secret_bootloader_locked(void) {
 #ifdef FIRMWARE
-  return TAMP->BKP8R != 0 * sectrue;
+  return (TAMP->BKP8R != 0) * sectrue;
 #else
   return sectrue;
 #endif


### PR DESCRIPTION
Fixes bootloader lock check, and consequently, device authentication check, which is refused when bootloader is unlocked.

<!--
If you are a core dev:

Don't forget to set up the fields:
- assign yourself
- set priority to same as original issue
- add PR to sprint
- if Draft -> "in progress"
- if final PR -> "needs review"

If you're an external contributor, you can ignore this text.
-->
