### PR TITLE
add missing swipe right to address QR screen - mercury ui

### DIFF
--- a/core/.changelog.d/3919.fixed
+++ b/core/.changelog.d/3919.fixed
@@ -1,0 +1,1 @@
+[T3T1] fixed swipe back from address QR code screen

--- a/core/embed/rust/src/ui/model_mercury/flow/get_address.rs
+++ b/core/embed/rust/src/ui/model_mercury/flow/get_address.rs
@@ -231,6 +231,7 @@ impl GetAddress {
                 .with_border(QR_BORDER),
         )
         .with_cancel_button()
+        .with_swipe(SwipeDirection::Right, SwipeSettings::immediate())
         .map(|msg| matches!(msg, FrameMsg::Button(_)).then_some(FlowMsg::Cancelled));
 
         // AccountInfo


### PR DESCRIPTION
adds missing swipe right to address QR screen.

<!--
If you are a core dev:

Don't forget to set up the fields:
- assign yourself
- set priority to same as original issue
- add PR to sprint
- if Draft -> "in progress"
- if final PR -> "needs review"

If you're an external contributor, you can ignore this text.
-->
