### PR TITLE
reduce animation frame requests when swiping

### DIFF
--- a/core/embed/rust/src/ui/model_mercury/component/swipe_content.rs
+++ b/core/embed/rust/src/ui/model_mercury/component/swipe_content.rs
@@ -159,7 +159,6 @@ impl<T: Component> Component for SwipeContent<T> {
                 _ => {}
             }
             ctx.request_paint();
-            ctx.request_anim_frame();
         }
 
         match event {


### PR DESCRIPTION
Attempt to mitigate queue overflow when swiping.

The animation frame requests are useless in first swipe phase - as the animation is driver by touch move (or rather SwipeMove) events. 


<!--
If you are a core dev:

Don't forget to set up the fields:
- assign yourself
- set priority to same as original issue
- add PR to sprint
- if Draft -> "in progress"
- if final PR -> "needs review"

If you're an external contributor, you can ignore this text.
-->
