### PR TITLE
fix(python): remove duplicated 0x prefix for publish sign-tx

### DIFF
--- a/python/src/trezorlib/cli/ethereum.py
+++ b/python/src/trezorlib/cli/ethereum.py
@@ -517,7 +517,7 @@ def sign_tx(
 
     if publish:
         tx_hash = _get_web3().eth.send_raw_transaction(tx_bytes).hex()
-        return f"Transaction published with ID: 0x{tx_hash}"
+        return f"Transaction published with ID: {tx_hash}"
     else:
         return f"Signed raw transaction:\n0x{tx_bytes.hex()}"
 


### PR DESCRIPTION
This tiny pull request removes hardcoded `0x` prefix for sign-tx ethereum cli command with a publish flag. web3 lib adds it upfront.

<!--
If you are a core dev:

Don't forget to set up the fields:
- assign yourself
- set priority to same as original issue
- add PR to sprint
- if Draft -> "in progress"
- if final PR -> "needs review"

If you're an external contributor, you can ignore this text.
-->
