### PR TITLE
Update translation versions

### DIFF
--- a/core/translations/cs.json
+++ b/core/translations/cs.json
@@ -33,7 +33,7 @@
   },
   "header": {
     "language": "cs-CZ",
-    "version": "2.7.1"
+    "version": "2.7.3"
   },
   "translations": {
     "addr_mismatch__contact_support_at": "Kontaktujte naši podporu na",

--- a/core/translations/de.json
+++ b/core/translations/de.json
@@ -33,7 +33,7 @@
   },
   "header": {
     "language": "de-DE",
-    "version": "2.7.1"
+    "version": "2.7.3"
   },
   "translations": {
     "addr_mismatch__contact_support_at": "Kontaktiere den Trezor Support unter",

--- a/core/translations/en.json
+++ b/core/translations/en.json
@@ -1,7 +1,7 @@
 {
   "header": {
     "language": "en-US",
-    "version": "2.7.1"
+    "version": "2.7.3"
   },
   "translations": {
     "addr_mismatch__contact_support_at": "Please contact Trezor support at",
@@ -389,8 +389,6 @@
     "instructions__swipe_up": "Swipe up",
     "instructions__tap_to_confirm": "Tap to confirm",
     "instructions__tap_to_start": "Tap to start",
-    "instructions__hold_to_confirm": "Hold to confirm",
-    "instructions__continue_holding": "Continue\nholding",
     "joint__title": "Joint transaction",
     "joint__to_the_total_amount": "To the total amount:",
     "joint__you_are_contributing": "You are contributing:",

--- a/core/translations/es.json
+++ b/core/translations/es.json
@@ -33,7 +33,7 @@
   },
   "header": {
     "language": "es-ES",
-    "version": "2.7.1"
+    "version": "2.7.3"
   },
   "translations": {
     "addr_mismatch__contact_support_at": "Contacta con atención al cliente de Trezor en",

--- a/core/translations/fr.json
+++ b/core/translations/fr.json
@@ -33,7 +33,7 @@
   },
   "header": {
     "language": "fr-FR",
-    "version": "2.7.1"
+    "version": "2.7.3"
   },
   "translations": {
     "addr_mismatch__contact_support_at": "Contactez l'assistance Trezor à l'adr.",

--- a/core/translations/signatures.json
+++ b/core/translations/signatures.json
@@ -6,6 +6,20 @@
   },
   "history": [
     {
+      "signature": "03e15faccf60328fee27c3cb2a22597656f22aa8d212537669a067e940e454c8eb90060c0fd8eb0783c9b5bb9e657a1fc40b5fea7f46eeee71d218a885fb68f401",
+      "version": "2.7.2.0",
+      "merkle_root": "47dc6ffabb554cd7f098a2fa87b96b7bfd8de82e94286a20355c5078f8df8d16",
+      "datetime": "2024-06-12T09:32:45.909833",
+      "commit": "905ef05f3aeb327f963785a8126e7f54bdf55b38"
+    },
+    {
+      "signature": "03c2dacdc7800fed2c8bc4052ddbcd260a69d0529bda38d5282f081b4eb9b91b42d1002fa6976d1332815c30e1f38b9b9dc48ae05f040b693d7be906df8c2c6500",
+      "version": "2.7.1.0",
+      "merkle_root": "7fba6f82bbd54d09ca75a1454a0af359fd187dea5b689f4f19552b5ae1d8e2f0",
+      "datetime": "2024-06-12T09:33:19.676243",
+      "commit": "905ef05f3aeb327f963785a8126e7f54bdf55b38"
+    },
+    {
       "signature": "032facfa6224385230e30d6e61179f88c8ddced38759ac778d7f4e412ab70ecaf4f8ac020a25ed4e3c7fd647bdbffc1c66071613d39359ebc834161a0888bcc305",
       "version": "2.7.0.0",
       "merkle_root": "33c7debbc1ee109d5c66835a84191b34696b324d0d0f026a0de7d7df01cab106",


### PR DESCRIPTION
1e03b8afec2f43f82292c3e5a4ee058ec9877679 makes sure that the version number in translation jsons stays up-to-date with  in-tree firmware version.
(also fixes what seemed to be duplicated keys in en.json?)

the rest is updating signatures.json with (a) actual signatures for 2.7.1 and 2.7.2, and (b) the current merkle root for version 2.7.3

<!--
If you are a core dev:

Don't forget to set up the fields:
- assign yourself
- set priority to same as original issue
- add PR to sprint
- if Draft -> "in progress"
- if final PR -> "needs review"

If you're an external contributor, you can ignore this text.
-->
