### PR TITLE
USB driver refactoring II

### DIFF
--- a/core/embed/bootloader/main.c
+++ b/core/embed/bootloader/main.c
@@ -122,11 +122,11 @@ static void usb_init_all(secbool usb21_landing) {
       .polling_interval = 1,
   };
 
-  usb_init(&dev_info);
+  ensure(usb_init(&dev_info), NULL);
 
   ensure(usb_webusb_add(&webusb_info), NULL);
 
-  usb_start();
+  ensure(usb_start(), NULL);
 }
 
 static usb_result_t bootloader_usb_loop(const vendor_header *const vhdr,

--- a/core/embed/bootloader/main.c
+++ b/core/embed/bootloader/main.c
@@ -165,7 +165,6 @@ static usb_result_t bootloader_usb_loop(const vendor_header *const vhdr,
         if (INPUT_CANCEL == response) {
           send_user_abort(USB_IFACE_NUM, "Wipe cancelled");
           hal_delay(100);
-          usb_stop();
           usb_deinit();
           return RETURN_TO_MENU;
         }
@@ -174,13 +173,11 @@ static usb_result_t bootloader_usb_loop(const vendor_header *const vhdr,
         if (r < 0) {  // error
           screen_wipe_fail();
           hal_delay(100);
-          usb_stop();
           usb_deinit();
           return SHUTDOWN;
         } else {  // success
           screen_wipe_success();
           hal_delay(100);
-          usb_stop();
           usb_deinit();
           return SHUTDOWN;
         }
@@ -197,12 +194,10 @@ static usb_result_t bootloader_usb_loop(const vendor_header *const vhdr,
           } else {
             ui_screen_fail();
           }
-          usb_stop();
           usb_deinit();
           return SHUTDOWN;
         } else if (r == UPLOAD_ERR_USER_ABORT) {
           hal_delay(100);
-          usb_stop();
           usb_deinit();
           return RETURN_TO_MENU;
         } else if (r == 0) {  // last chunk received
@@ -214,7 +209,6 @@ static usb_result_t bootloader_usb_loop(const vendor_header *const vhdr,
           hal_delay(1000);
           ui_screen_done(1, secfalse);
           hal_delay(1000);
-          usb_stop();
           usb_deinit();
           return CONTINUE_TO_FIRMWARE;
         }
@@ -228,14 +222,12 @@ static usb_result_t bootloader_usb_loop(const vendor_header *const vhdr,
         if (INPUT_CANCEL == response) {
           send_user_abort(USB_IFACE_NUM, "Bootloader unlock cancelled");
           hal_delay(100);
-          usb_stop();
           usb_deinit();
           return RETURN_TO_MENU;
         }
         process_msg_UnlockBootloader(USB_IFACE_NUM, msg_size, buf);
         screen_unlock_bootloader_success();
         hal_delay(100);
-        usb_stop();
         usb_deinit();
         return SHUTDOWN;
         break;

--- a/core/embed/bootloader_ci/main.c
+++ b/core/embed/bootloader_ci/main.c
@@ -117,12 +117,10 @@ static secbool bootloader_usb_loop(const vendor_header *const vhdr,
         r = process_msg_WipeDevice(USB_IFACE_NUM, msg_size, buf);
         if (r < 0) {  // error
           ui_screen_fail();
-          usb_stop();
           usb_deinit();
           return secfalse;  // shutdown
         } else {            // success
           ui_screen_done(0, sectrue);
-          usb_stop();
           usb_deinit();
           return secfalse;  // shutdown
         }
@@ -134,7 +132,6 @@ static secbool bootloader_usb_loop(const vendor_header *const vhdr,
         r = process_msg_FirmwareUpload(USB_IFACE_NUM, msg_size, buf);
         if (r < 0 && r != UPLOAD_ERR_USER_ABORT) {  // error, but not user abort
           ui_screen_fail();
-          usb_stop();
           usb_deinit();
           return secfalse;    // shutdown
         } else if (r == 0) {  // last chunk received
@@ -146,7 +143,6 @@ static secbool bootloader_usb_loop(const vendor_header *const vhdr,
           hal_delay(1000);
           ui_screen_done(1, secfalse);
           hal_delay(1000);
-          usb_stop();
           usb_deinit();
           return sectrue;  // jump to firmware
         }

--- a/core/embed/bootloader_ci/main.c
+++ b/core/embed/bootloader_ci/main.c
@@ -78,11 +78,11 @@ static void usb_init_all(secbool usb21_landing) {
       .polling_interval = 1,
   };
 
-  usb_init(&dev_info);
+  ensure(usb_init(&dev_info), NULL);
 
   ensure(usb_webusb_add(&webusb_info), NULL);
 
-  usb_start();
+  ensure(usb_start(), NULL);
 }
 
 static secbool bootloader_usb_loop(const vendor_header *const vhdr,

--- a/core/embed/extmod/modtrezorio/modtrezorio-usb.h
+++ b/core/embed/extmod/modtrezorio/modtrezorio-usb.h
@@ -190,7 +190,9 @@ STATIC mp_obj_t mod_trezorio_USB_open(mp_obj_t self,
   mp_obj_get_array(MP_OBJ_FROM_PTR(&o->ifaces), &iface_cnt, &iface_objs);
 
   // Initialize the USB stack
-  usb_init(&o->info);
+  if (sectrue != usb_init(&o->info)) {
+    mp_raise_msg(&mp_type_RuntimeError, "failed to initialize usb driver");
+  }
 
   int vcp_iface_num = -1;
 
@@ -224,7 +226,10 @@ STATIC mp_obj_t mod_trezorio_USB_open(mp_obj_t self,
   }
 
   // Start the USB stack
-  usb_start();
+  if (sectrue != usb_start()) {
+    usb_deinit();
+    mp_raise_msg(&mp_type_RuntimeError, "failed to start usb driver");
+  }
   o->state = USB_OPENED;
 
   // If we found any VCP interfaces, use the last one for stdio,

--- a/core/embed/extmod/modtrezorio/modtrezorio-usb.h
+++ b/core/embed/extmod/modtrezorio/modtrezorio-usb.h
@@ -251,7 +251,6 @@ STATIC mp_obj_t mod_trezorio_USB_close(mp_obj_t self) {
   if (o->state != USB_OPENED) {
     mp_raise_msg(&mp_type_RuntimeError, "not initialized");
   }
-  usb_stop();
   usb_deinit();
   mp_obj_list_set_len(MP_OBJ_FROM_PTR(&o->ifaces), 0);
   mp_seq_clear(o->ifaces.items, 0, o->ifaces.alloc, sizeof(*o->ifaces.items));
@@ -271,7 +270,6 @@ STATIC MP_DEFINE_CONST_FUN_OBJ_1(mod_trezorio_USB_close_obj,
 STATIC mp_obj_t mod_trezorio_USB___del__(mp_obj_t self) {
   mp_obj_USB_t *o = MP_OBJ_TO_PTR(self);
   if (o->state != USB_CLOSED) {
-    usb_stop();
     usb_deinit();
     o->state = USB_CLOSED;
   }

--- a/core/embed/prodtest/main.c
+++ b/core/embed/prodtest/main.c
@@ -155,9 +155,9 @@ static void usb_init_all(void) {
       .max_packet_len = VCP_PACKET_LEN,
   };
 
-  usb_init(&dev_info);
+  ensure(usb_init(&dev_info), NULL);
   ensure(usb_vcp_add(&vcp_info), "usb_vcp_add");
-  usb_start();
+  ensure(usb_start(), NULL);
 }
 
 static void draw_border(int width, int padding) {

--- a/core/embed/trezorhal/stm32f4/dma2d_bitblt.c
+++ b/core/embed/trezorhal/stm32f4/dma2d_bitblt.c
@@ -624,7 +624,7 @@ bool dma2d_rgba8888_blend_mono4(const gfx_bitblt_t* params) {
   return true;
 }
 
-bool dma2d_rgb8888_blend_mono8(const gfx_bitblt_t* bb) {
+bool dma2d_rgba8888_blend_mono8(const gfx_bitblt_t* bb) {
   dma2d_wait();
 
   if (!dma2d_accessible(bb->dst_row) || !dma2d_accessible(bb->src_row)) {

--- a/core/embed/trezorhal/stm32f4/usb/usb.c
+++ b/core/embed/trezorhal/stm32f4/usb/usb.c
@@ -324,13 +324,13 @@ void usb_set_iface_class(uint8_t iface_num, const USBD_ClassTypeDef *class) {
 }
 
 USBD_HandleTypeDef *usb_get_dev_handle(void) {
-  usb_driver_t *usb = &g_usb_driver;
+  usb_driver_t *drv = &g_usb_driver;
 
-  return &usb->dev_handle;
+  return &drv->dev_handle;
 }
 
 void *usb_alloc_class_descriptors(size_t desc_len) {
-  usb_driver_t *usb = &g_usb_driver;
+  usb_driver_t *drv = &g_usb_driver;
 
   if (drv->config_desc->wTotalLength + desc_len < USB_MAX_CONFIG_DESC_SIZE) {
     void *retval = &drv->desc_buffer[drv->config_desc->wTotalLength];

--- a/core/embed/trezorhal/stm32f4/usb/usb_class_hid.c
+++ b/core/embed/trezorhal/stm32f4/usb/usb_class_hid.c
@@ -146,7 +146,6 @@ secbool usb_hid_add(const usb_hid_info_t *info) {
   d->ep_out.bInterval = info->polling_interval;
 
   // Interface state
-  state->dev_handle = usb_get_dev_handle();
   state->desc_block = d;
   state->report_desc = info->report_desc;
   state->rx_buffer = info->rx_buffer;
@@ -171,10 +170,12 @@ secbool usb_hid_can_read(uint8_t iface_num) {
   if (state == NULL) {
     return secfalse;  // Invalid interface number
   }
+  if (state->dev_handle == NULL) {
+    return secfalse;  // Class driver not initialized
+  }
   if (state->last_read_len == 0) {
     return secfalse;  // Nothing in the receiving buffer
   }
-
   if (state->dev_handle->dev_state != USBD_STATE_CONFIGURED) {
     return secfalse;  // Device is not configured
   }
@@ -185,6 +186,9 @@ secbool usb_hid_can_write(uint8_t iface_num) {
   usb_hid_state_t *state = usb_get_hid_state(iface_num);
   if (state == NULL) {
     return secfalse;  // Invalid interface number
+  }
+  if (state->dev_handle == NULL) {
+    return secfalse;  // Class driver not initialized
   }
   if (state->ep_in_is_idle == 0) {
     return secfalse;  // Last transmission is not over yet
@@ -200,6 +204,10 @@ int usb_hid_read(uint8_t iface_num, uint8_t *buf, uint32_t len) {
 
   if (state == NULL) {
     return -1;  // Invalid interface number
+  }
+
+  if (state->dev_handle == NULL) {
+    return -1;  // Class driver not initialized
   }
 
   // Copy maximum possible amount of data
@@ -224,6 +232,10 @@ int usb_hid_write(uint8_t iface_num, const uint8_t *buf, uint32_t len) {
 
   if (state == NULL) {
     return -1;  // Invalid interface number
+  }
+
+  if (state->dev_handle == NULL) {
+    return -1;  // Class driver not initialized
   }
 
   if (state->ep_in_is_idle == 0) {
@@ -280,6 +292,8 @@ int usb_hid_write_blocking(uint8_t iface_num, const uint8_t *buf, uint32_t len,
 static uint8_t usb_hid_class_init(USBD_HandleTypeDef *dev, uint8_t cfg_idx) {
   usb_hid_state_t *state = (usb_hid_state_t *)dev->pUserData;
 
+  state->dev_handle = dev;
+
   // Open endpoints
   USBD_LL_OpenEP(dev, state->ep_in, USBD_EP_TYPE_INTR, state->max_packet_len);
   USBD_LL_OpenEP(dev, state->ep_out, USBD_EP_TYPE_INTR, state->max_packet_len);
@@ -307,6 +321,8 @@ static uint8_t usb_hid_class_deinit(USBD_HandleTypeDef *dev, uint8_t cfg_idx) {
   // Close endpoints
   USBD_LL_CloseEP(dev, state->ep_in);
   USBD_LL_CloseEP(dev, state->ep_out);
+
+  state->dev_handle = NULL;
 
   return USBD_OK;
 }

--- a/core/embed/trezorhal/stm32f4/usb/usb_class_vcp.c
+++ b/core/embed/trezorhal/stm32f4/usb/usb_class_vcp.c
@@ -19,9 +19,7 @@
 
 #include "common.h"
 
-#include "usbd_core.h"
-#include "usbd_internal.h"
-
+#include "usb_internal.h"
 #include "usb_vcp.h"
 
 // Communications Device Class Code (bFunctionClass, bInterfaceClass)

--- a/core/embed/trezorhal/stm32f4/usb/usb_class_vcp.c
+++ b/core/embed/trezorhal/stm32f4/usb/usb_class_vcp.c
@@ -297,7 +297,6 @@ secbool usb_vcp_add(const usb_vcp_info_t *info) {
   d->ep_in.bInterval = 0;
 
   // Interface state
-  state->dev_handle = usb_get_dev_handle();
   state->desc_block = d;
 
   state->rx_ring.buf = info->rx_buffer;
@@ -428,6 +427,8 @@ int usb_vcp_write_blocking(uint8_t iface_num, const uint8_t *buf, uint32_t len,
 static uint8_t usb_vcp_class_init(USBD_HandleTypeDef *dev, uint8_t cfg_idx) {
   usb_vcp_state_t *state = (usb_vcp_state_t *)dev->pUserData;
 
+  state->dev_handle = dev;
+
   // Open endpoints
   USBD_LL_OpenEP(dev, state->ep_in, USBD_EP_TYPE_BULK, state->max_packet_len);
   USBD_LL_OpenEP(dev, state->ep_out, USBD_EP_TYPE_BULK, state->max_packet_len);
@@ -459,6 +460,8 @@ static uint8_t usb_vcp_class_deinit(USBD_HandleTypeDef *dev, uint8_t cfg_idx) {
   USBD_LL_CloseEP(dev, state->ep_in);
   USBD_LL_CloseEP(dev, state->ep_out);
   USBD_LL_CloseEP(dev, state->ep_cmd);
+
+  state->dev_handle = NULL;
 
   return USBD_OK;
 }

--- a/core/embed/trezorhal/stm32f4/usb/usb_class_webusb.c
+++ b/core/embed/trezorhal/stm32f4/usb/usb_class_webusb.c
@@ -20,88 +20,60 @@
 #include "common.h"
 #include "random_delays.h"
 
-#include "usbd_core.h"
-#include "usbd_internal.h"
+#include "usb_internal.h"
+#include "usb_webusb.h"
 
-#include "usb_hid.h"
-
-#define USB_CLASS_HID 0x03
-
-#define USB_DESC_TYPE_HID 0x21
-#define USB_DESC_TYPE_REPORT 0x22
-
-#define USB_HID_REQ_SET_PROTOCOL 0x0B
-#define USB_HID_REQ_GET_PROTOCOL 0x03
-#define USB_HID_REQ_SET_IDLE 0x0A
-#define USB_HID_REQ_GET_IDLE 0x02
-
-typedef struct __attribute__((packed)) {
-  uint8_t bLength;
-  uint8_t bDescriptorType;
-  uint16_t bcdHID;
-  uint8_t bCountryCode;
-  uint8_t bNumDescriptors;
-  uint8_t bReportDescriptorType;
-  uint16_t wReportDescriptorLength;
-} usb_hid_descriptor_t;
+#define USB_CLASS_WEBUSB 0xFF
 
 typedef struct __attribute__((packed)) {
   usb_interface_descriptor_t iface;
-  usb_hid_descriptor_t hid;
   usb_endpoint_descriptor_t ep_in;
   usb_endpoint_descriptor_t ep_out;
-} usb_hid_descriptor_block_t;
+} usb_webusb_descriptor_block_t;
 
-/* usb_hid_state_t encapsulates all state used by enabled HID interface.  It
- * needs to be completely initialized in usb_hid_add and reset in
- * usb_hid_class_init.  See usb_hid_info_t for details of the configuration
- * fields. */
-
+/* usb_webusb_state_t encapsulates all state used by enabled WebUSB interface.
+ * It needs to be completely initialized in usb_webusb_add and reset in
+ * usb_webusb_class_init.  See usb_webusb_info_t for details of the
+ * configuration fields. */
 typedef struct {
   USBD_HandleTypeDef *dev_handle;
-  const usb_hid_descriptor_block_t *desc_block;
-  const uint8_t *report_desc;
+  const usb_webusb_descriptor_block_t *desc_block;
   uint8_t *rx_buffer;
   uint8_t ep_in;
   uint8_t ep_out;
   uint8_t max_packet_len;
-  uint8_t report_desc_len;
 
-  uint8_t protocol;       // For SET_PROTOCOL/GET_PROTOCOL setup reqs
-  uint8_t idle_rate;      // For SET_IDLE/GET_IDLE setup reqs
   uint8_t alt_setting;    // For SET_INTERFACE/GET_INTERFACE setup reqs
   uint8_t last_read_len;  // Length of data read into rx_buffer
   uint8_t ep_in_is_idle;  // Set to 1 after IN endpoint gets idle
-} usb_hid_state_t;
+} usb_webusb_state_t;
 
-_Static_assert(sizeof(usb_hid_state_t) <= USBD_CLASS_STATE_MAX_SIZE);
+_Static_assert(sizeof(usb_webusb_state_t) <= USBD_CLASS_STATE_MAX_SIZE);
 
 // interface dispatch functions
-static const USBD_ClassTypeDef usb_hid_class;
+static const USBD_ClassTypeDef usb_webusb_class;
 
-#define usb_get_hid_state(iface_num) \
-  ((usb_hid_state_t *)usb_get_iface_state(iface_num, &usb_hid_class))
+#define usb_get_webusb_state(iface_num) \
+  ((usb_webusb_state_t *)usb_get_iface_state(iface_num, &usb_webusb_class))
 
-/* usb_hid_add adds and configures new USB HID interface according to
+/* usb_webusb_add adds and configures new USB WebUSB interface according to
  * configuration options passed in `info`. */
-secbool usb_hid_add(const usb_hid_info_t *info) {
-  usb_hid_state_t *state = usb_get_iface_state(info->iface_num, NULL);
+secbool usb_webusb_add(const usb_webusb_info_t *info) {
+  usb_webusb_state_t *state =
+      (usb_webusb_state_t *)usb_get_iface_state(info->iface_num, NULL);
 
   if (state == NULL) {
     return secfalse;  // Invalid interface number
   }
 
-  usb_hid_descriptor_block_t *d =
-      usb_alloc_class_descriptors(sizeof(usb_hid_descriptor_block_t));
+  usb_webusb_descriptor_block_t *d =
+      usb_alloc_class_descriptors(sizeof(usb_webusb_descriptor_block_t));
 
   if (d == NULL) {
     return secfalse;  // Not enough space in the configuration descriptor
   }
 
   if (info->rx_buffer == NULL) {
-    return secfalse;
-  }
-  if (info->report_desc == NULL) {
     return secfalse;
   }
   if (info->ep_in >= USBD_MAX_NUM_INTERFACES) {
@@ -117,19 +89,10 @@ secbool usb_hid_add(const usb_hid_info_t *info) {
   d->iface.bInterfaceNumber = info->iface_num;
   d->iface.bAlternateSetting = 0;
   d->iface.bNumEndpoints = 2;
-  d->iface.bInterfaceClass = USB_CLASS_HID;
+  d->iface.bInterfaceClass = USB_CLASS_WEBUSB;
   d->iface.bInterfaceSubClass = info->subclass;
   d->iface.bInterfaceProtocol = info->protocol;
   d->iface.iInterface = USBD_IDX_INTERFACE_STR;
-
-  // HID descriptor
-  d->hid.bLength = sizeof(usb_hid_descriptor_t);
-  d->hid.bDescriptorType = USB_DESC_TYPE_HID;
-  d->hid.bcdHID = 0x0111;      // HID Class Spec release number (1.11)
-  d->hid.bCountryCode = 0;     // Hardware target country
-  d->hid.bNumDescriptors = 1;  // Number of HID class descriptors
-  d->hid.bReportDescriptorType = USB_DESC_TYPE_REPORT;
-  d->hid.wReportDescriptorLength = info->report_desc_len;
 
   // IN endpoint (sending)
   d->ep_in.bLength = sizeof(usb_endpoint_descriptor_t);
@@ -150,41 +113,35 @@ secbool usb_hid_add(const usb_hid_info_t *info) {
   // Interface state
   state->dev_handle = usb_get_dev_handle();
   state->desc_block = d;
-  state->report_desc = info->report_desc;
   state->rx_buffer = info->rx_buffer;
   state->ep_in = info->ep_in | USB_EP_DIR_IN;
   state->ep_out = info->ep_out | USB_EP_DIR_OUT;
   state->max_packet_len = info->max_packet_len;
-  state->report_desc_len = info->report_desc_len;
-  state->protocol = 0;
-  state->idle_rate = 0;
   state->alt_setting = 0;
   state->last_read_len = 0;
   state->ep_in_is_idle = 1;
 
-  usb_set_iface_class(info->iface_num, &usb_hid_class);
+  usb_set_iface_class(info->iface_num, &usb_webusb_class);
 
   return sectrue;
 }
 
-secbool usb_hid_can_read(uint8_t iface_num) {
-  usb_hid_state_t *state = usb_get_hid_state(iface_num);
-
+secbool usb_webusb_can_read(uint8_t iface_num) {
+  usb_webusb_state_t *state = usb_get_webusb_state(iface_num);
   if (state == NULL) {
     return secfalse;  // Invalid interface number
   }
   if (state->last_read_len == 0) {
     return secfalse;  // Nothing in the receiving buffer
   }
-
   if (state->dev_handle->dev_state != USBD_STATE_CONFIGURED) {
     return secfalse;  // Device is not configured
   }
   return sectrue;
 }
 
-secbool usb_hid_can_write(uint8_t iface_num) {
-  usb_hid_state_t *state = usb_get_hid_state(iface_num);
+secbool usb_webusb_can_write(uint8_t iface_num) {
+  usb_webusb_state_t *state = usb_get_webusb_state(iface_num);
   if (state == NULL) {
     return secfalse;  // Invalid interface number
   }
@@ -197,9 +154,8 @@ secbool usb_hid_can_write(uint8_t iface_num) {
   return sectrue;
 }
 
-int usb_hid_read(uint8_t iface_num, uint8_t *buf, uint32_t len) {
-  volatile usb_hid_state_t *state = usb_get_hid_state(iface_num);
-
+int usb_webusb_read(uint8_t iface_num, uint8_t *buf, uint32_t len) {
+  volatile usb_webusb_state_t *state = usb_get_webusb_state(iface_num);
   if (state == NULL) {
     return -1;  // Invalid interface number
   }
@@ -221,15 +177,10 @@ int usb_hid_read(uint8_t iface_num, uint8_t *buf, uint32_t len) {
   return last_read_len;
 }
 
-int usb_hid_write(uint8_t iface_num, const uint8_t *buf, uint32_t len) {
-  volatile usb_hid_state_t *state = usb_get_hid_state(iface_num);
-
+int usb_webusb_write(uint8_t iface_num, const uint8_t *buf, uint32_t len) {
+  volatile usb_webusb_state_t *state = usb_get_webusb_state(iface_num);
   if (state == NULL) {
     return -1;  // Invalid interface number
-  }
-
-  if (state->ep_in_is_idle == 0) {
-    return 0;  // Last transmission is not over yet
   }
 
   state->ep_in_is_idle = 0;
@@ -239,11 +190,11 @@ int usb_hid_write(uint8_t iface_num, const uint8_t *buf, uint32_t len) {
   return len;
 }
 
-int usb_hid_read_select(uint32_t timeout) {
+int usb_webusb_read_select(uint32_t timeout) {
   const uint32_t start = HAL_GetTick();
   for (;;) {
     for (int i = 0; i < USBD_MAX_NUM_INTERFACES; i++) {
-      if (sectrue == usb_hid_can_read(i)) {
+      if (sectrue == usb_webusb_can_read(i)) {
         return i;
       }
     }
@@ -255,40 +206,38 @@ int usb_hid_read_select(uint32_t timeout) {
   return -1;  // Timeout
 }
 
-int usb_hid_read_blocking(uint8_t iface_num, uint8_t *buf, uint32_t len,
-                          int timeout) {
+int usb_webusb_read_blocking(uint8_t iface_num, uint8_t *buf, uint32_t len,
+                             int timeout) {
   const uint32_t start = HAL_GetTick();
-  while (sectrue != usb_hid_can_read(iface_num)) {
+  while (sectrue != usb_webusb_can_read(iface_num)) {
     if (timeout >= 0 && HAL_GetTick() - start >= timeout) {
       return 0;  // Timeout
     }
     __WFI();  // Enter sleep mode, waiting for interrupt
   }
-  return usb_hid_read(iface_num, buf, len);
+  return usb_webusb_read(iface_num, buf, len);
 }
 
-int usb_hid_write_blocking(uint8_t iface_num, const uint8_t *buf, uint32_t len,
-                           int timeout) {
+int usb_webusb_write_blocking(uint8_t iface_num, const uint8_t *buf,
+                              uint32_t len, int timeout) {
   const uint32_t start = HAL_GetTick();
-  while (sectrue != usb_hid_can_write(iface_num)) {
+  while (sectrue != usb_webusb_can_write(iface_num)) {
     if (timeout >= 0 && HAL_GetTick() - start >= timeout) {
       return 0;  // Timeout
     }
     __WFI();  // Enter sleep mode, waiting for interrupt
   }
-  return usb_hid_write(iface_num, buf, len);
+  return usb_webusb_write(iface_num, buf, len);
 }
 
-static uint8_t usb_hid_class_init(USBD_HandleTypeDef *dev, uint8_t cfg_idx) {
-  usb_hid_state_t *state = (usb_hid_state_t *)dev->pUserData;
+static uint8_t usb_webusb_class_init(USBD_HandleTypeDef *dev, uint8_t cfg_idx) {
+  usb_webusb_state_t *state = (usb_webusb_state_t *)dev->pUserData;
 
   // Open endpoints
   USBD_LL_OpenEP(dev, state->ep_in, USBD_EP_TYPE_INTR, state->max_packet_len);
   USBD_LL_OpenEP(dev, state->ep_out, USBD_EP_TYPE_INTR, state->max_packet_len);
 
   // Reset the state
-  state->protocol = 0;
-  state->idle_rate = 0;
   state->alt_setting = 0;
   state->last_read_len = 0;
   state->ep_in_is_idle = 1;
@@ -300,8 +249,9 @@ static uint8_t usb_hid_class_init(USBD_HandleTypeDef *dev, uint8_t cfg_idx) {
   return USBD_OK;
 }
 
-static uint8_t usb_hid_class_deinit(USBD_HandleTypeDef *dev, uint8_t cfg_idx) {
-  usb_hid_state_t *state = (usb_hid_state_t *)dev->pUserData;
+static uint8_t usb_webusb_class_deinit(USBD_HandleTypeDef *dev,
+                                       uint8_t cfg_idx) {
+  usb_webusb_state_t *state = (usb_webusb_state_t *)dev->pUserData;
 
   // Flush endpoints
   USBD_LL_FlushEP(dev, state->ep_in);
@@ -313,84 +263,39 @@ static uint8_t usb_hid_class_deinit(USBD_HandleTypeDef *dev, uint8_t cfg_idx) {
   return USBD_OK;
 }
 
-static uint8_t usb_hid_class_setup(USBD_HandleTypeDef *dev,
-                                   USBD_SetupReqTypedef *req) {
-  usb_hid_state_t *state = (usb_hid_state_t *)dev->pUserData;
+static uint8_t usb_webusb_class_setup(USBD_HandleTypeDef *dev,
+                                      USBD_SetupReqTypedef *req) {
+  usb_webusb_state_t *state = (usb_webusb_state_t *)dev->pUserData;
 
   wait_random();
 
-  switch (req->bmRequest & USB_REQ_TYPE_MASK) {
-    // Class request
-    case USB_REQ_TYPE_CLASS:
-      switch (req->bRequest) {
-        case USB_HID_REQ_SET_PROTOCOL:
-          state->protocol = req->wValue;
-          USBD_CtlSendStatus(dev);
-          return USBD_OK;
+  if ((req->bmRequest & USB_REQ_TYPE_MASK) != USB_REQ_TYPE_STANDARD) {
+    return USBD_OK;
+  }
 
-        case USB_HID_REQ_GET_PROTOCOL:
-          USBD_CtlSendData(dev, &state->protocol, sizeof(state->protocol));
-          return USBD_OK;
+  wait_random();
 
-        case USB_HID_REQ_SET_IDLE:
-          state->idle_rate = req->wValue >> 8;
-          USBD_CtlSendStatus(dev);
-          return USBD_OK;
+  switch (req->bRequest) {
+    case USB_REQ_SET_INTERFACE:
+      state->alt_setting = req->wValue;
+      USBD_CtlSendStatus(dev);
+      return USBD_OK;
 
-        case USB_HID_REQ_GET_IDLE:
-          USBD_CtlSendData(dev, &state->idle_rate, sizeof(state->idle_rate));
-          return USBD_OK;
+    case USB_REQ_GET_INTERFACE:
+      USBD_CtlSendData(dev, &state->alt_setting, sizeof(state->alt_setting));
+      return USBD_OK;
 
-        default:
-          USBD_CtlError(dev, req);
-          return USBD_FAIL;
-      }
-      break;
-
-    // Interface & Endpoint request
-    case USB_REQ_TYPE_STANDARD:
-      switch (req->bRequest) {
-        case USB_REQ_SET_INTERFACE:
-          state->alt_setting = req->wValue;
-          USBD_CtlSendStatus(dev);
-          return USBD_OK;
-
-        case USB_REQ_GET_INTERFACE:
-          USBD_CtlSendData(dev, &state->alt_setting,
-                           sizeof(state->alt_setting));
-          return USBD_OK;
-
-        case USB_REQ_GET_DESCRIPTOR:
-          switch (req->wValue >> 8) {
-            case USB_DESC_TYPE_HID:
-              USBD_CtlSendData(
-                  dev, UNCONST(&state->desc_block->hid),
-                  MIN_8bits(req->wLength, sizeof(state->desc_block->hid)));
-              return USBD_OK;
-
-            case USB_DESC_TYPE_REPORT:
-              USBD_CtlSendData(dev, UNCONST(state->report_desc),
-                               MIN_8bits(req->wLength, state->report_desc_len));
-              return USBD_OK;
-
-            default:
-              USBD_CtlError(dev, req);
-              return USBD_FAIL;
-          }
-          break;
-
-        default:
-          USBD_CtlError(dev, req);
-          return USBD_FAIL;
-      }
-      break;
+    default:
+      USBD_CtlError(dev, req);
+      return USBD_FAIL;
   }
 
   return USBD_OK;
 }
 
-static uint8_t usb_hid_class_data_in(USBD_HandleTypeDef *dev, uint8_t ep_num) {
-  usb_hid_state_t *state = (usb_hid_state_t *)dev->pUserData;
+static uint8_t usb_webusb_class_data_in(USBD_HandleTypeDef *dev,
+                                        uint8_t ep_num) {
+  usb_webusb_state_t *state = (usb_webusb_state_t *)dev->pUserData;
 
   if ((ep_num | USB_EP_DIR_IN) == state->ep_in) {
     wait_random();
@@ -400,8 +305,9 @@ static uint8_t usb_hid_class_data_in(USBD_HandleTypeDef *dev, uint8_t ep_num) {
   return USBD_OK;
 }
 
-static uint8_t usb_hid_class_data_out(USBD_HandleTypeDef *dev, uint8_t ep_num) {
-  usb_hid_state_t *state = (usb_hid_state_t *)dev->pUserData;
+static uint8_t usb_webusb_class_data_out(USBD_HandleTypeDef *dev,
+                                         uint8_t ep_num) {
+  usb_webusb_state_t *state = (usb_webusb_state_t *)dev->pUserData;
 
   if (ep_num == state->ep_out) {
     wait_random();
@@ -413,14 +319,14 @@ static uint8_t usb_hid_class_data_out(USBD_HandleTypeDef *dev, uint8_t ep_num) {
   return USBD_OK;
 }
 
-static const USBD_ClassTypeDef usb_hid_class = {
-    .Init = usb_hid_class_init,
-    .DeInit = usb_hid_class_deinit,
-    .Setup = usb_hid_class_setup,
+static const USBD_ClassTypeDef usb_webusb_class = {
+    .Init = usb_webusb_class_init,
+    .DeInit = usb_webusb_class_deinit,
+    .Setup = usb_webusb_class_setup,
     .EP0_TxSent = NULL,
     .EP0_RxReady = NULL,
-    .DataIn = usb_hid_class_data_in,
-    .DataOut = usb_hid_class_data_out,
+    .DataIn = usb_webusb_class_data_in,
+    .DataOut = usb_webusb_class_data_out,
     .SOF = NULL,
     .IsoINIncomplete = NULL,
     .IsoOUTIncomplete = NULL,

--- a/core/embed/trezorhal/stm32f4/usb/usb_internal.h
+++ b/core/embed/trezorhal/stm32f4/usb/usb_internal.h
@@ -21,6 +21,7 @@
 #define TREZORHAL_USBD_INTERNAL_H
 
 #include <stdint.h>
+#include "usbd_core.h"
 
 #define USB_EP_DIR_MASK 0x80
 #define USB_EP_DIR_OUT 0x00

--- a/core/embed/trezorhal/stm32f4/usb/usb_internal.h
+++ b/core/embed/trezorhal/stm32f4/usb/usb_internal.h
@@ -126,7 +126,4 @@ void usb_set_iface_class(uint8_t iface_num, const USBD_ClassTypeDef *class);
 // returns NULL if not.
 void *usb_alloc_class_descriptors(size_t desc_len);
 
-// Returns the global handle to the USB device.
-USBD_HandleTypeDef *usb_get_dev_handle(void);
-
 #endif  // TREZORHAL_USBD_INTERNAL_H

--- a/core/embed/trezorhal/stm32f4/usb/usbd_def.h
+++ b/core/embed/trezorhal/stm32f4/usb/usbd_def.h
@@ -118,6 +118,7 @@
 #define USB_MAX_EP0_SIZE                                  64
 
 /*  Device Status */
+#define USBD_STATE_UNINITIALIZED                          0
 #define USBD_STATE_DEFAULT                                1
 #define USBD_STATE_ADDRESSED                              2
 #define USBD_STATE_CONFIGURED                             3

--- a/core/embed/trezorhal/unix/usb.c
+++ b/core/embed/trezorhal/unix/usb.c
@@ -53,7 +53,7 @@ static struct {
   socklen_t slen;
 } usb_ifaces[USBD_MAX_NUM_INTERFACES];
 
-void usb_init(const usb_dev_info_t *dev_info) {
+secbool usb_init(const usb_dev_info_t *dev_info) {
   (void)dev_info;
   for (int i = 0; i < USBD_MAX_NUM_INTERFACES; i++) {
     usb_ifaces[i].type = USB_IFACE_TYPE_DISABLED;
@@ -63,11 +63,12 @@ void usb_init(const usb_dev_info_t *dev_info) {
     memzero(&usb_ifaces[i].si_other, sizeof(struct sockaddr_in));
     usb_ifaces[i].slen = 0;
   }
+  return sectrue;
 }
 
 void usb_deinit(void) {}
 
-void usb_start(void) {
+secbool usb_start(void) {
   const char *ip = getenv("TREZOR_UDP_IP");
 
   // iterate interfaces
@@ -96,6 +97,8 @@ void usb_start(void) {
                                 sizeof(struct sockaddr_in))),
            NULL);
   }
+
+  return sectrue;
 }
 
 void usb_stop(void) {

--- a/core/embed/trezorhal/usb.h
+++ b/core/embed/trezorhal/usb.h
@@ -27,6 +27,38 @@
 #include "usb_vcp.h"
 #include "usb_webusb.h"
 
+// clang-format off
+//
+// USB stack high-level state machine
+// ------------------------------------
+//
+//              +---------------+
+//        ----> | Uninitialized |   - Stack is completely uninitialized
+//        |     +---------------+
+//        |            |
+//        |         usb_init()
+//   usb_deinit()      |
+//        |            v
+//        |     +---------------+   - Stack is partially initialized
+//        |-----|  Initialized  |   - Ready for class registration
+//        |     +---------------+
+//        |            |
+//        |       N x usb_xxx_add() - Multiple class drivers can be registered
+//        |            |
+//        |            v
+//        |     +---------------+   - Stack is completely initialized
+//        |-----|    Stopped    |   - USB hardware left uninitialized
+//        |     +---------------+   - Can go low power at this mode
+//        |        |        ^
+//        |    usb_start()  |
+//        |        |     usb_stop()
+//        |        v        |
+//        |     +---------------+   - USB hardware initialized
+//        ------|    Running    |   - Stack is running if the USB host is connected
+//              +---------------+
+//
+// clang-format on
+
 typedef struct {
   uint8_t device_class;
   uint8_t device_subclass;
@@ -42,10 +74,44 @@ typedef struct {
   secbool usb21_landing;
 } usb_dev_info_t;
 
-void usb_init(const usb_dev_info_t *dev_info);
+// Initializes USB stack
+//
+// When the USB driver is initialized, class drivers can be registered.
+// After all class drivers are registered, `usb_start()` can  be called.
+//
+// Returns `sectrue` if the initialization is successful.
+secbool usb_init(const usb_dev_info_t *dev_info);
+
+// Deinitialize USB stack
+//
+// This function completely deinitializes the USB driver and all class drivers.
+// After this function is called, `usb_init()` can be called again.
 void usb_deinit(void);
-void usb_start(void);
+
+// Starts USB driver and its class drivers
+//
+// Initializes the USB stack (and hardware) and starts all registered class
+// drivers.
+//
+// This function can called after all class drivers are registered or after
+// `usb_stop()` is called.
+//
+// Returns `sectrue` if the USB stack is started successfully.
+secbool usb_start(void);
+
+// Stops USB driver and its class drivers
+//
+// Unitializes the USB stack (and hardware) but leaves all configuration intact,
+// so it can be started again with `usb_start()`.
+//
+// When the USB stack is stopped, it does not respond to any USB events and
+// the CPU can go to stop/standby mode.
 void usb_stop(void);
+
+// Returns `sectrue` if the device is connected to the host (or is expected to
+// be)
+//
+// TODO: Review and clarify the logic of this function in the future
 secbool usb_configured(void);
 
 #endif

--- a/core/site_scons/models/D001/discovery.py
+++ b/core/site_scons/models/D001/discovery.py
@@ -76,14 +76,14 @@ def configure(
 
     if "usb" in features_wanted:
         sources += [
-            "embed/trezorhal/stm32f4/usb/usbd_class_hid.c",
-            "embed/trezorhal/stm32f4/usb/usbd_class_vcp.c",
-            "embed/trezorhal/stm32f4/usb/usbd_class_webusb.c",
+            "embed/trezorhal/stm32f4/usb/usb_class_hid.c",
+            "embed/trezorhal/stm32f4/usb/usb_class_vcp.c",
+            "embed/trezorhal/stm32f4/usb/usb_class_webusb.c",
+            "embed/trezorhal/stm32f4/usb/usb.c",
             "embed/trezorhal/stm32f4/usb/usbd_conf.c",
             "embed/trezorhal/stm32f4/usb/usbd_core.c",
             "embed/trezorhal/stm32f4/usb/usbd_ctlreq.c",
             "embed/trezorhal/stm32f4/usb/usbd_ioreq.c",
-            "embed/trezorhal/stm32f4/usb/usbd.c",
             "vendor/micropython/lib/stm32lib/STM32F4xx_HAL_Driver/Src/stm32f4xx_ll_usb.c",
         ]
         features_available.append("usb")

--- a/core/site_scons/models/D002/discovery2.py
+++ b/core/site_scons/models/D002/discovery2.py
@@ -82,14 +82,14 @@ def configure(
 
     if "usb" in features_wanted:
         sources += [
-            "embed/trezorhal/stm32u5/usb/usbd_class_hid.c",
-            "embed/trezorhal/stm32u5/usb/usbd_class_vcp.c",
-            "embed/trezorhal/stm32u5/usb/usbd_class_webusb.c",
+            "embed/trezorhal/stm32u5/usb/usb_class_hid.c",
+            "embed/trezorhal/stm32u5/usb/usb_class_vcp.c",
+            "embed/trezorhal/stm32u5/usb/usb_class_webusb.c",
+            "embed/trezorhal/stm32u5/usb/usb.c",
             "embed/trezorhal/stm32u5/usb/usbd_conf.c",
             "embed/trezorhal/stm32u5/usb/usbd_core.c",
             "embed/trezorhal/stm32u5/usb/usbd_ctlreq.c",
             "embed/trezorhal/stm32u5/usb/usbd_ioreq.c",
-            "embed/trezorhal/stm32u5/usb/usbd.c",
             "vendor/stm32u5xx_hal_driver/Src/stm32u5xx_ll_usb.c",
         ]
         features_available.append("usb")

--- a/core/site_scons/models/T1B1/trezor_1.py
+++ b/core/site_scons/models/T1B1/trezor_1.py
@@ -42,14 +42,14 @@ def configure(
 
     if "usb" in features_wanted:
         sources += [
-            "embed/trezorhal/stm32f4/usb/usbd_class_hid.c",
-            "embed/trezorhal/stm32f4/usb/usbd_class_vcp.c",
-            "embed/trezorhal/stm32f4/usb/usbd_class_webusb.c",
+            "embed/trezorhal/stm32f4/usb/usb_class_hid.c",
+            "embed/trezorhal/stm32f4/usb/usb_class_vcp.c",
+            "embed/trezorhal/stm32f4/usb/usb_class_webusb.c",
+            "embed/trezorhal/stm32f4/usb/usb.c",
             "embed/trezorhal/stm32f4/usb/usbd_conf.c",
             "embed/trezorhal/stm32f4/usb/usbd_core.c",
             "embed/trezorhal/stm32f4/usb/usbd_ctlreq.c",
             "embed/trezorhal/stm32f4/usb/usbd_ioreq.c",
-            "embed/trezorhal/stm32f4/usb/usbd.c",
             "vendor/micropython/lib/stm32lib/STM32F4xx_HAL_Driver/Src/stm32f4xx_ll_usb.c",
         ]
         features_available.append("usb")

--- a/core/site_scons/models/T2B1/trezor_r_v10.py
+++ b/core/site_scons/models/T2B1/trezor_r_v10.py
@@ -65,14 +65,14 @@ def configure(
         ]
     if "usb" in features_wanted:
         sources += [
-            "embed/trezorhal/stm32f4/usb/usbd_class_hid.c",
-            "embed/trezorhal/stm32f4/usb/usbd_class_vcp.c",
-            "embed/trezorhal/stm32f4/usb/usbd_class_webusb.c",
+            "embed/trezorhal/stm32f4/usb/usb_class_hid.c",
+            "embed/trezorhal/stm32f4/usb/usb_class_vcp.c",
+            "embed/trezorhal/stm32f4/usb/usb_class_webusb.c",
+            "embed/trezorhal/stm32f4/usb/usb.c",
             "embed/trezorhal/stm32f4/usb/usbd_conf.c",
             "embed/trezorhal/stm32f4/usb/usbd_core.c",
             "embed/trezorhal/stm32f4/usb/usbd_ctlreq.c",
             "embed/trezorhal/stm32f4/usb/usbd_ioreq.c",
-            "embed/trezorhal/stm32f4/usb/usbd.c",
             "vendor/micropython/lib/stm32lib/STM32F4xx_HAL_Driver/Src/stm32f4xx_ll_usb.c",
         ]
         features_available.append("usb")

--- a/core/site_scons/models/T2B1/trezor_r_v3.py
+++ b/core/site_scons/models/T2B1/trezor_r_v3.py
@@ -62,14 +62,14 @@ def configure(
 
     if "usb" in features_wanted:
         sources += [
-            "embed/trezorhal/stm32f4/usb/usbd_class_hid.c",
-            "embed/trezorhal/stm32f4/usb/usbd_class_vcp.c",
-            "embed/trezorhal/stm32f4/usb/usbd_class_webusb.c",
+            "embed/trezorhal/stm32f4/usb/usb_class_hid.c",
+            "embed/trezorhal/stm32f4/usb/usb_class_vcp.c",
+            "embed/trezorhal/stm32f4/usb/usb_class_webusb.c",
+            "embed/trezorhal/stm32f4/usb/usb.c",
             "embed/trezorhal/stm32f4/usb/usbd_conf.c",
             "embed/trezorhal/stm32f4/usb/usbd_core.c",
             "embed/trezorhal/stm32f4/usb/usbd_ctlreq.c",
             "embed/trezorhal/stm32f4/usb/usbd_ioreq.c",
-            "embed/trezorhal/stm32f4/usb/usbd.c",
             "vendor/micropython/lib/stm32lib/STM32F4xx_HAL_Driver/Src/stm32f4xx_ll_usb.c",
         ]
         features_available.append("usb")

--- a/core/site_scons/models/T2B1/trezor_r_v4.py
+++ b/core/site_scons/models/T2B1/trezor_r_v4.py
@@ -58,14 +58,14 @@ def configure(
 
     if "usb" in features_wanted:
         sources += [
-            "embed/trezorhal/stm32f4/usb/usbd_class_hid.c",
-            "embed/trezorhal/stm32f4/usb/usbd_class_vcp.c",
-            "embed/trezorhal/stm32f4/usb/usbd_class_webusb.c",
+            "embed/trezorhal/stm32f4/usb/usb_class_hid.c",
+            "embed/trezorhal/stm32f4/usb/usb_class_vcp.c",
+            "embed/trezorhal/stm32f4/usb/usb_class_webusb.c",
+            "embed/trezorhal/stm32f4/usb/usb.c",
             "embed/trezorhal/stm32f4/usb/usbd_conf.c",
             "embed/trezorhal/stm32f4/usb/usbd_core.c",
             "embed/trezorhal/stm32f4/usb/usbd_ctlreq.c",
             "embed/trezorhal/stm32f4/usb/usbd_ioreq.c",
-            "embed/trezorhal/stm32f4/usb/usbd.c",
             "vendor/micropython/lib/stm32lib/STM32F4xx_HAL_Driver/Src/stm32f4xx_ll_usb.c",
         ]
         features_available.append("usb")

--- a/core/site_scons/models/T2B1/trezor_r_v6.py
+++ b/core/site_scons/models/T2B1/trezor_r_v6.py
@@ -58,14 +58,14 @@ def configure(
 
     if "usb" in features_wanted:
         sources += [
-            "embed/trezorhal/stm32f4/usb/usbd_class_hid.c",
-            "embed/trezorhal/stm32f4/usb/usbd_class_vcp.c",
-            "embed/trezorhal/stm32f4/usb/usbd_class_webusb.c",
+            "embed/trezorhal/stm32f4/usb/usb_class_hid.c",
+            "embed/trezorhal/stm32f4/usb/usb_class_vcp.c",
+            "embed/trezorhal/stm32f4/usb/usb_class_webusb.c",
+            "embed/trezorhal/stm32f4/usb/usb.c",
             "embed/trezorhal/stm32f4/usb/usbd_conf.c",
             "embed/trezorhal/stm32f4/usb/usbd_core.c",
             "embed/trezorhal/stm32f4/usb/usbd_ctlreq.c",
             "embed/trezorhal/stm32f4/usb/usbd_ioreq.c",
-            "embed/trezorhal/stm32f4/usb/usbd.c",
             "vendor/micropython/lib/stm32lib/STM32F4xx_HAL_Driver/Src/stm32f4xx_ll_usb.c",
         ]
         features_available.append("usb")

--- a/core/site_scons/models/T2T1/trezor_t.py
+++ b/core/site_scons/models/T2T1/trezor_t.py
@@ -100,14 +100,14 @@ def configure(
 
     if "usb" in features_wanted:
         sources += [
-            "embed/trezorhal/stm32f4/usb/usbd_class_hid.c",
-            "embed/trezorhal/stm32f4/usb/usbd_class_vcp.c",
-            "embed/trezorhal/stm32f4/usb/usbd_class_webusb.c",
+            "embed/trezorhal/stm32f4/usb/usb_class_hid.c",
+            "embed/trezorhal/stm32f4/usb/usb_class_vcp.c",
+            "embed/trezorhal/stm32f4/usb/usb_class_webusb.c",
+            "embed/trezorhal/stm32f4/usb/usb.c",
             "embed/trezorhal/stm32f4/usb/usbd_conf.c",
             "embed/trezorhal/stm32f4/usb/usbd_core.c",
             "embed/trezorhal/stm32f4/usb/usbd_ctlreq.c",
             "embed/trezorhal/stm32f4/usb/usbd_ioreq.c",
-            "embed/trezorhal/stm32f4/usb/usbd.c",
             "vendor/micropython/lib/stm32lib/STM32F4xx_HAL_Driver/Src/stm32f4xx_ll_usb.c",
         ]
         features_available.append("usb")

--- a/core/site_scons/models/T3T1/trezor_t3t1_revE.py
+++ b/core/site_scons/models/T3T1/trezor_t3t1_revE.py
@@ -100,14 +100,14 @@ def configure(
 
     if "usb" in features_wanted:
         sources += [
-            "embed/trezorhal/stm32u5/usb/usbd_class_hid.c",
-            "embed/trezorhal/stm32u5/usb/usbd_class_vcp.c",
-            "embed/trezorhal/stm32u5/usb/usbd_class_webusb.c",
+            "embed/trezorhal/stm32u5/usb/usb_class_hid.c",
+            "embed/trezorhal/stm32u5/usb/usb_class_vcp.c",
+            "embed/trezorhal/stm32u5/usb/usb_class_webusb.c",
+            "embed/trezorhal/stm32u5/usb/usb.c",
             "embed/trezorhal/stm32u5/usb/usbd_conf.c",
             "embed/trezorhal/stm32u5/usb/usbd_core.c",
             "embed/trezorhal/stm32u5/usb/usbd_ctlreq.c",
             "embed/trezorhal/stm32u5/usb/usbd_ioreq.c",
-            "embed/trezorhal/stm32u5/usb/usbd.c",
             "vendor/stm32u5xx_hal_driver/Src/stm32u5xx_ll_usb.c",
         ]
         features_available.append("usb")

--- a/core/site_scons/models/T3T1/trezor_t3t1_v4.py
+++ b/core/site_scons/models/T3T1/trezor_t3t1_v4.py
@@ -102,14 +102,14 @@ def configure(
 
     if "usb" in features_wanted:
         sources += [
-            "embed/trezorhal/stm32u5/usb/usbd_class_hid.c",
-            "embed/trezorhal/stm32u5/usb/usbd_class_vcp.c",
-            "embed/trezorhal/stm32u5/usb/usbd_class_webusb.c",
+            "embed/trezorhal/stm32u5/usb/usb_class_hid.c",
+            "embed/trezorhal/stm32u5/usb/usb_class_vcp.c",
+            "embed/trezorhal/stm32u5/usb/usb_class_webusb.c",
+            "embed/trezorhal/stm32u5/usb/usb.c",
             "embed/trezorhal/stm32u5/usb/usbd_conf.c",
             "embed/trezorhal/stm32u5/usb/usbd_core.c",
             "embed/trezorhal/stm32u5/usb/usbd_ctlreq.c",
             "embed/trezorhal/stm32u5/usb/usbd_ioreq.c",
-            "embed/trezorhal/stm32u5/usb/usbd.c",
             "vendor/stm32u5xx_hal_driver/Src/stm32u5xx_ll_usb.c",
         ]
         features_available.append("usb")


### PR DESCRIPTION
This PR continues the refactoring of USB drivers and includes the following changes:

1. **Introduces the `usb_deinit()` routine and clarifies the highest-level API of the driver.** - required by entering/exiting low power modes, not used now.
2. Removes unnecessary calls to `usb_stop()` scattered throughout the codebase, as they always accompany `usb_deinit()`.
3. Removes the dependency of the class driver on the global context of the USB driver.
4. Fixes the build of the disc2 target.

These changes does not affect the device behavior. 


