### PR TITLE
fix(trezor-client): fix convert_signature invalid s conversion

### DIFF
--- a/rust/trezor-client/src/client/ethereum.rs
+++ b/rust/trezor-client/src/client/ethereum.rs
@@ -162,6 +162,6 @@ fn convert_signature(resp: &EthereumTxRequest, chain_id: Option<u64>) -> Result<
         }
     }
     let r = resp.signature_r().try_into().map_err(|_| Error::MalformedSignature)?;
-    let s = resp.signature_r().try_into().map_err(|_| Error::MalformedSignature)?;
+    let s = resp.signature_s().try_into().map_err(|_| Error::MalformedSignature)?;
     Ok(Signature { r, s, v })
 }


### PR DESCRIPTION
### Description:
- This PR fixes Invalid `convert_signature` function in `trezor-client` Package

### Problem:
The current implementation of the `convert_signature` function in the `trezor-client` package contains a potential error in the way the signature's `s` component is handled. Specifically, the line:

```rust
let s = resp.signature_r().try_into().map_err(|_| Error::MalformedSignature)?;
```

This line incorrectly references `resp.signature_r()` instead of `resp.signature_s()`, leading to a logical error where the `r` component is duplicated as `s`.

Please review the changes and merge them if they meet the project's standards. Thank you for considering this fix.