### PR TITLE
refactor(core): remove StringType

### DIFF
--- a/core/embed/rust/src/strutil.rs
+++ b/core/embed/rust/src/strutil.rs
@@ -9,19 +9,6 @@ use crate::micropython::{buffer::StrBuffer, obj::Obj};
 #[cfg(feature = "translations")]
 use crate::translations::TR;
 
-/// Trait for internal representation of strings. This is a legacy crutch before
-/// we fully transition to `TString`. For now, it allows some manner of
-/// compatibility between `&str` and `StrBuffer`. Implies the following
-/// operations:
-/// - dereference into a short-lived `&str` reference (AsRef<str>) (probably not
-///   strictly necessary anymore)
-/// - create a new string from a string literal (From<&'static str>)
-/// - infallibly convert into a `TString` (Into<TString<'static>>), which is
-///   then used for other operations.
-pub trait StringType: AsRef<str> + From<&'static str> + Into<TString<'static>> {}
-
-impl<T> StringType for T where T: AsRef<str> + From<&'static str> + Into<TString<'static>> {}
-
 /// Unified-length String type, long enough for most simple use-cases.
 pub type ShortString = String<50>;
 

--- a/core/embed/rust/src/ui/model_tr/component/share_words.rs
+++ b/core/embed/rust/src/ui/model_tr/component/share_words.rs
@@ -1,5 +1,5 @@
 use crate::{
-    strutil::StringType,
+    strutil::TString,
     translations::TR,
     ui::{
         component::{
@@ -27,21 +27,15 @@ const INFO_TOP_OFFSET: i16 = 20;
 const MAX_WORDS: usize = 33; // super-shamir has 33 words, all other have less
 
 /// Showing the given share words.
-pub struct ShareWords<T>
-where
-    T: StringType,
-{
+pub struct ShareWords<'a> {
     area: Rect,
     scrollbar: Child<ScrollBar>,
-    share_words: Vec<T, MAX_WORDS>,
+    share_words: Vec<TString<'a>, MAX_WORDS>,
     page_index: usize,
 }
 
-impl<T> ShareWords<T>
-where
-    T: StringType + Clone,
-{
-    pub fn new(share_words: Vec<T, MAX_WORDS>) -> Self {
+impl<'a> ShareWords<'a> {
+    pub fn new(share_words: Vec<TString<'a>, MAX_WORDS>) -> Self {
         let mut instance = Self {
             area: Rect::zero(),
             scrollbar: Child::new(ScrollBar::to_be_filled_later()),
@@ -122,11 +116,13 @@ where
             if index >= self.share_words.len() {
                 break;
             }
-            let word = &self.share_words[index];
             let baseline = self.area.top_left() + Offset::y(y_offset);
             let ordinal = build_string!(5, inttostr!(index as u8 + 1), ".");
             display_left(baseline + Offset::x(NUMBER_X_OFFSET), &ordinal, NUMBER_FONT);
-            display_left(baseline + Offset::x(WORD_X_OFFSET), word, WORD_FONT);
+            let word = &self.share_words[index];
+            word.map(|w| {
+                display_left(baseline + Offset::x(WORD_X_OFFSET), w, WORD_FONT);
+            });
         }
     }
 
@@ -149,18 +145,17 @@ where
                 .with_fg(theme::FG)
                 .render(target);
 
-            shape::Text::new(baseline + Offset::x(WORD_X_OFFSET), word.as_ref())
-                .with_font(WORD_FONT)
-                .with_fg(theme::FG)
-                .render(target);
+            word.map(|w| {
+                shape::Text::new(baseline + Offset::x(WORD_X_OFFSET), w)
+                    .with_font(WORD_FONT)
+                    .with_fg(theme::FG)
+                    .render(target);
+            });
         }
     }
 }
 
-impl<T> Component for ShareWords<T>
-where
-    T: StringType + Clone,
-{
+impl<'a> Component for ShareWords<'a> {
     type Msg = Never;
 
     fn place(&mut self, bounds: Rect) -> Rect {
@@ -203,10 +198,7 @@ where
     }
 }
 
-impl<T> Paginate for ShareWords<T>
-where
-    T: StringType + Clone,
-{
+impl<'a> Paginate for ShareWords<'a> {
     fn page_count(&mut self) -> usize {
         // Not defining the logic here, as we do not want it to be `&mut`.
         self.total_page_count()
@@ -221,10 +213,7 @@ where
 // DEBUG-ONLY SECTION BELOW
 
 #[cfg(feature = "ui_debug")]
-impl<T> crate::trace::Trace for ShareWords<T>
-where
-    T: StringType + Clone,
-{
+impl<'a> crate::trace::Trace for ShareWords<'a> {
     fn trace(&self, t: &mut dyn crate::trace::Tracer) {
         t.component("ShareWords");
         let content = if self.is_final_page() {
@@ -238,7 +227,7 @@ where
                 }
                 let word = &self.share_words[index];
                 let current_line =
-                    build_string!(50, inttostr!(index as u8 + 1), ". ", word.as_ref(), "\n");
+                    word.map(|w| build_string!(50, inttostr!(index as u8 + 1), ". ", w, "\n"));
                 unwrap!(content.push_str(&current_line));
             }
             content

--- a/core/embed/rust/src/ui/model_tr/layout.rs
+++ b/core/embed/rust/src/ui/model_tr/layout.rs
@@ -6,8 +6,7 @@ use crate::{
     error::Error,
     maybe_trace::MaybeTrace,
     micropython::{
-        buffer::StrBuffer, gc::Gc, iter::IterBuf, list::List, map::Map, module::Module, obj::Obj,
-        qstr::Qstr, util,
+        gc::Gc, iter::IterBuf, list::List, map::Map, module::Module, obj::Obj, qstr::Qstr, util,
     },
     strutil::TString,
     translations::TR,
@@ -1323,7 +1322,7 @@ extern "C" fn new_select_word(n_args: usize, args: *const Obj, kwargs: *mut Map)
 extern "C" fn new_show_share_words(n_args: usize, args: *const Obj, kwargs: *mut Map) -> Obj {
     let block = |_args: &[Obj], kwargs: &Map| {
         let share_words_obj: Obj = kwargs.get(Qstr::MP_QSTR_share_words)?;
-        let share_words: Vec<StrBuffer, 33> = util::iter_into_vec(share_words_obj)?;
+        let share_words: Vec<TString, 33> = util::iter_into_vec(share_words_obj)?;
 
         let cancel_btn = Some(ButtonDetails::up_arrow_icon());
         let confirm_btn =


### PR DESCRIPTION
Removing the obsolete crutch `StringType` and replacing it with `TString`.

<!--
If you are a core dev:

Don't forget to set up the fields:
- assign yourself
- set priority to same as original issue
- add PR to sprint
- if Draft -> "in progress"
- if final PR -> "needs review"

If you're an external contributor, you can ignore this text.
-->
