### PR TITLE
Swipe tuning

### DIFF
--- a/core/.changelog.d/3965.fixed
+++ b/core/.changelog.d/3965.fixed
@@ -1,0 +1,1 @@
+[T3T1] Improve swipe behavior and animations

--- a/core/embed/rust/librust_qstr.h
+++ b/core/embed/rust/librust_qstr.h
@@ -242,6 +242,7 @@ static void _librust_qstrs(void) {
   MP_QSTR_flow_show_share_words;
   MP_QSTR_flow_warning_hi_prio;
   MP_QSTR_get_language;
+  MP_QSTR_get_transition_out;
   MP_QSTR_haptic_feedback__disable;
   MP_QSTR_haptic_feedback__enable;
   MP_QSTR_haptic_feedback__subtitle;

--- a/core/embed/rust/src/ui/component/base.rs
+++ b/core/embed/rust/src/ui/component/base.rs
@@ -212,6 +212,7 @@ where
 pub struct Root<T> {
     inner: Option<Child<T>>,
     marked_for_clear: bool,
+    transition_out: Option<AttachType>,
 }
 
 impl<T> Root<T> {
@@ -219,6 +220,7 @@ impl<T> Root<T> {
         Self {
             inner: Some(Child::new(component)),
             marked_for_clear: true,
+            transition_out: None,
         }
     }
 
@@ -246,6 +248,10 @@ impl<T> Root<T> {
         self.marked_for_clear = true;
     }
 
+    pub fn get_transition_out(&self) -> Option<AttachType> {
+        self.transition_out
+    }
+
     pub fn delete(&mut self) {
         self.inner = None;
     }
@@ -270,6 +276,11 @@ where
             assert!(paint_msg.is_none());
             assert!(dummy_ctx.timers.is_empty());
         }
+
+        if let Some(t) = ctx.get_transition_out() {
+            self.transition_out = Some(t);
+        }
+
         msg
     }
 
@@ -528,6 +539,7 @@ pub struct EventCtx {
     root_repaint_requested: bool,
     swipe_disable_req: bool,
     swipe_enable_req: bool,
+    transition_out: Option<AttachType>,
 }
 
 impl EventCtx {
@@ -557,6 +569,7 @@ impl EventCtx {
             root_repaint_requested: false,
             swipe_disable_req: false,
             swipe_enable_req: false,
+            transition_out: None,
         }
     }
 
@@ -658,6 +671,7 @@ impl EventCtx {
         self.root_repaint_requested = false;
         self.swipe_disable_req = false;
         self.swipe_enable_req = false;
+        self.transition_out = None;
     }
 
     fn register_timer(&mut self, token: TimerToken, deadline: Duration) {
@@ -679,5 +693,13 @@ impl EventCtx {
             .checked_add(1)
             .unwrap_or(Self::STARTING_TIMER_TOKEN);
         token
+    }
+
+    pub fn set_transition_out(&mut self, attach_type: AttachType) {
+        self.transition_out = Some(attach_type);
+    }
+
+    pub fn get_transition_out(&self) -> Option<AttachType> {
+        self.transition_out
     }
 }

--- a/core/embed/rust/src/ui/component/swipe.rs
+++ b/core/embed/rust/src/ui/component/swipe.rs
@@ -5,7 +5,7 @@ use crate::ui::{
     shape::Renderer,
 };
 
-#[derive(Copy, Clone, Eq, PartialEq)]
+#[derive(Copy, Clone, Eq, PartialEq, ToPrimitive, FromPrimitive)]
 #[cfg_attr(feature = "debug", derive(ufmt::derive::uDebug))]
 pub enum SwipeDirection {
     Up,

--- a/core/embed/rust/src/ui/component/swipe_detect.rs
+++ b/core/embed/rust/src/ui/component/swipe_detect.rs
@@ -290,7 +290,7 @@ impl SwipeDetect {
 
                     if !animation_disabled() {
                         let done = self.moved as f32 / Self::PROGRESS_MAX as f32;
-                        let ratio = 1.0 - done;
+                        let ratio = if final_value == 0 { done } else { 1.0 - done };
 
                         let duration = config
                             .duration(locked)

--- a/core/embed/rust/src/ui/component/swipe_detect.rs
+++ b/core/embed/rust/src/ui/component/swipe_detect.rs
@@ -181,6 +181,21 @@ impl SwipeDetect {
         Self::MIN_TRIGGER
     }
 
+    fn is_lockable(&self, dir: SwipeDirection) -> bool {
+        let Some(origin) = self.origin else {
+            return false;
+        };
+
+        let min_distance = self.min_trigger() as i16;
+
+        match dir {
+            SwipeDirection::Up => origin.y > min_distance,
+            SwipeDirection::Down => origin.y < (screen().height() - min_distance),
+            SwipeDirection::Left => origin.x > min_distance,
+            SwipeDirection::Right => origin.x < (screen().width() - min_distance),
+        }
+    }
+
     fn progress(&self, val: u16) -> u16 {
         ((val as f32 / Self::DISTANCE as f32) * Self::PROGRESS_MAX as f32) as u16
     }
@@ -236,7 +251,7 @@ impl SwipeDetect {
                             let mut res = None;
                             for dir in SwipeDirection::iter() {
                                 let progress = config.progress(dir, ofs, self.min_lock());
-                                if progress > 0 {
+                                if progress > 0 && self.is_lockable(dir) {
                                     self.locked = Some(dir);
                                     res = Some(SwipeDetectMsg::Start(dir));
                                     break;

--- a/core/embed/rust/src/ui/component/swipe_detect.rs
+++ b/core/embed/rust/src/ui/component/swipe_detect.rs
@@ -277,18 +277,7 @@ impl SwipeDetect {
                         // advance in direction other than locked trigger animation towards starting
                         // position
                         Some(_) => 0,
-                        None => {
-                            let mut res = 0;
-                            for dir in SwipeDirection::iter() {
-                                // insta-lock if the movement went at least the trigger distance
-                                if config.progress(dir, ofs, self.min_trigger()) > 0 {
-                                    self.locked = Some(dir);
-                                    res = Self::PROGRESS_MAX;
-                                }
-                            }
-
-                            res
-                        }
+                        None => return None,
                     };
 
                     let Some(locked) = self.locked else {

--- a/core/embed/rust/src/ui/component/swipe_detect.rs
+++ b/core/embed/rust/src/ui/component/swipe_detect.rs
@@ -141,6 +141,7 @@ impl core::ops::IndexMut<SwipeDirection> for SwipeConfig {
 
 #[derive(Copy, Clone, Eq, PartialEq)]
 pub enum SwipeDetectMsg {
+    Start(SwipeDirection),
     Move(SwipeDirection, u16),
     Trigger(SwipeDirection),
 }
@@ -237,7 +238,7 @@ impl SwipeDetect {
                                 let progress = config.progress(dir, ofs, self.min_lock());
                                 if progress > 0 {
                                     self.locked = Some(dir);
-                                    res = Some(SwipeDetectMsg::Move(dir, self.progress(progress)));
+                                    res = Some(SwipeDetectMsg::Start(dir));
                                     break;
                                 }
                             }

--- a/core/embed/rust/src/ui/event.rs
+++ b/core/embed/rust/src/ui/event.rs
@@ -51,6 +51,8 @@ pub enum TouchEvent {
     TouchMove(Point),
     /// Touch has ended at a point on the screen.
     TouchEnd(Point),
+    /// Touch event has been suppressed by more important event - i.e. Swipe.
+    TouchAbort,
 }
 
 impl TouchEvent {

--- a/core/embed/rust/src/ui/flow/swipe.rs
+++ b/core/embed/rust/src/ui/flow/swipe.rs
@@ -175,6 +175,7 @@ impl<Q: FlowState, S: FlowStore> Component for SwipeFlow<Q, S> {
                 Some(SwipeDetectMsg::Move(dir, progress)) => {
                     Some(Event::Swipe(SwipeEvent::Move(dir, progress as i16)))
                 }
+                Some(SwipeDetectMsg::Start(_)) => Some(Event::Touch(TouchEvent::TouchAbort)),
                 _ => Some(event),
             }
         } else {

--- a/core/embed/rust/src/ui/flow/swipe.rs
+++ b/core/embed/rust/src/ui/flow/swipe.rs
@@ -5,7 +5,7 @@ use crate::{
             base::AttachType, swipe_detect::SwipeSettings, Component, Event, EventCtx, SwipeDetect,
             SwipeDetectMsg, SwipeDirection,
         },
-        event::SwipeEvent,
+        event::{SwipeEvent, TouchEvent},
         flow::{base::Decision, FlowMsg, FlowState, FlowStore},
         geometry::Rect,
         shape::Renderer,
@@ -107,6 +107,7 @@ impl<Q: FlowState, S: FlowStore> Component for SwipeFlow<Q, S> {
 
     fn event(&mut self, ctx: &mut EventCtx, event: Event) -> Option<Self::Msg> {
         let mut decision: Decision<Q> = Decision::Nothing;
+        let mut return_transition: AttachType = AttachType::Initial;
 
         let mut attach = false;
 
@@ -138,6 +139,8 @@ impl<Q: FlowState, S: FlowStore> Component for SwipeFlow<Q, S> {
                     } else {
                         decision = self.handle_swipe_child(ctx, dir);
                     }
+
+                    return_transition = AttachType::Swipe(dir);
 
                     let states_num = self.internal_pages;
                     if states_num > 0 {
@@ -230,6 +233,7 @@ impl<Q: FlowState, S: FlowStore> Component for SwipeFlow<Q, S> {
                 None
             }
             Decision::Return(msg) => {
+                ctx.set_transition_out(return_transition);
                 self.swipe.reset();
                 self.allow_swipe = true;
                 Some(msg)

--- a/core/embed/rust/src/ui/model_mercury/component/footer.rs
+++ b/core/embed/rust/src/ui/model_mercury/component/footer.rs
@@ -12,8 +12,6 @@ use crate::{
     },
 };
 
-use heapless::String;
-
 /// Component showing a task instruction, e.g. "Swipe up", and an optional
 /// content consisting of one of these:
 ///     - a task description e.g. "Confirm transaction", or
@@ -94,6 +92,8 @@ impl<'a> Footer<'a> {
         if let Some(ref mut content) = self.content {
             if let Some(counter) = content.as_page_counter_mut() {
                 counter.update_current_page(n);
+                self.swipe_allow_down = counter.is_first_page();
+                self.swipe_allow_up = counter.is_last_page();
                 ctx.request_paint();
             } else {
                 #[cfg(feature = "ui_debug")]
@@ -284,9 +284,9 @@ impl<'a> FooterContent<'a> {
 #[derive(Clone)]
 struct PageCounter {
     area: Rect,
+    font: Font,
     page_curr: u8,
     page_max: u8,
-    font: Font,
 }
 
 impl PageCounter {
@@ -300,7 +300,15 @@ impl PageCounter {
     }
 
     fn update_current_page(&mut self, new_value: u8) {
-        self.page_curr = new_value;
+        self.page_curr = new_value.clamp(1, self.page_max);
+    }
+
+    fn is_first_page(&self) -> bool {
+        self.page_curr == 1
+    }
+
+    fn is_last_page(&self) -> bool {
+        self.page_curr == self.page_max
     }
 }
 

--- a/core/embed/rust/src/ui/model_mercury/component/hold_to_confirm.rs
+++ b/core/embed/rust/src/ui/model_mercury/component/hold_to_confirm.rs
@@ -227,6 +227,7 @@ impl Component for HoldToConfirm {
                     self.anim.start();
                     ctx.request_anim_frame();
                     ctx.request_paint();
+                    ctx.disable_swipe();
                     self.finalizing = false;
                 }
             }
@@ -235,6 +236,7 @@ impl Component for HoldToConfirm {
                     self.anim.reset();
                     ctx.request_anim_frame();
                     ctx.request_paint();
+                    ctx.enable_swipe();
                     self.finalizing = false;
                 }
             }
@@ -249,6 +251,7 @@ impl Component for HoldToConfirm {
                     self.anim.reset();
                     ctx.request_anim_frame();
                     ctx.request_paint();
+                    ctx.enable_swipe();
                 }
             }
             Some(ButtonMsg::LongPressed) => {

--- a/core/embed/rust/src/ui/model_mercury/component/mod.rs
+++ b/core/embed/rust/src/ui/model_mercury/component/mod.rs
@@ -78,7 +78,7 @@ pub use set_brightness::SetBrightnessDialog;
 #[cfg(feature = "translations")]
 pub use share_words::ShareWords;
 pub use status_screen::StatusScreen;
-pub use swipe_content::SwipeContent;
+pub use swipe_content::{InternallySwipable, InternallySwipableContent, SwipeContent};
 #[cfg(feature = "translations")]
 pub use swipe_up_screen::{SwipeUpScreen, SwipeUpScreenMsg};
 #[cfg(feature = "translations")]

--- a/core/embed/rust/src/ui/model_mercury/component/number_input_slider.rs
+++ b/core/embed/rust/src/ui/model_mercury/component/number_input_slider.rs
@@ -181,6 +181,7 @@ impl Component for NumberInputSlider {
                 TouchEvent::TouchStart(pos) => self.slider_eval(pos, ctx),
                 TouchEvent::TouchMove(pos) => self.slider_eval(pos, ctx),
                 TouchEvent::TouchEnd(pos) => self.slider_eval(pos, ctx),
+                TouchEvent::TouchAbort => None,
             };
         }
         None

--- a/core/embed/rust/src/ui/model_mercury/component/swipe_content.rs
+++ b/core/embed/rust/src/ui/model_mercury/component/swipe_content.rs
@@ -119,21 +119,14 @@ impl<T: Component> SwipeContent<T> {
     pub fn inner(&self) -> &T {
         &self.inner
     }
-}
 
-impl<T: Component> Component for SwipeContent<T> {
-    type Msg = T::Msg;
-
-    fn place(&mut self, bounds: Rect) -> Rect {
-        self.bounds = self.inner.place(bounds);
-        self.bounds
-    }
-
-    fn event(&mut self, ctx: &mut EventCtx, event: Event) -> Option<Self::Msg> {
+    fn process_event(&mut self, ctx: &mut EventCtx, event: Event, animate: bool) -> Option<T::Msg> {
         if let Event::Attach(attach_type) = event {
             self.progress = 0;
-            if self.show_attach_anim {
+            if self.show_attach_anim && animate {
                 self.attach_type = Some(attach_type);
+            } else {
+                self.attach_type = None;
             }
             self.attach_animation.reset();
             ctx.request_anim_frame();
@@ -153,8 +146,10 @@ impl<T: Component> Component for SwipeContent<T> {
         if let Event::Swipe(SwipeEvent::Move(dir, progress)) = event {
             match dir {
                 SwipeDirection::Up | SwipeDirection::Down => {
-                    self.dir = dir;
-                    self.progress = progress;
+                    if animate {
+                        self.dir = dir;
+                        self.progress = progress;
+                    }
                 }
                 _ => {}
             }
@@ -171,6 +166,19 @@ impl<T: Component> Component for SwipeContent<T> {
             }
             _ => self.inner.event(ctx, event),
         }
+    }
+}
+
+impl<T: Component> Component for SwipeContent<T> {
+    type Msg = T::Msg;
+
+    fn place(&mut self, bounds: Rect) -> Rect {
+        self.bounds = self.inner.place(bounds);
+        self.bounds
+    }
+
+    fn event(&mut self, ctx: &mut EventCtx, event: Event) -> Option<Self::Msg> {
+        self.process_event(ctx, event, true)
     }
 
     fn paint(&mut self) {
@@ -257,5 +265,120 @@ where
     fn trace(&self, t: &mut dyn crate::trace::Tracer) {
         t.component("SwipeContent");
         t.child("content", &self.inner);
+    }
+}
+
+pub trait InternallySwipable {
+    fn current_page(&self) -> usize;
+
+    fn num_pages(&self) -> usize;
+}
+
+pub struct InternallySwipableContent<T>
+where
+    T: Component + InternallySwipable,
+{
+    content: SwipeContent<T>,
+    animate: bool,
+}
+
+impl<T> InternallySwipableContent<T>
+where
+    T: Component + InternallySwipable,
+{
+    pub fn new(content: T) -> Self {
+        Self {
+            content: SwipeContent::new(content),
+            animate: true,
+        }
+    }
+
+    pub fn inner(&self) -> &T {
+        self.content.inner()
+    }
+
+    fn should_animate_attach(&self, attach_type: AttachType) -> bool {
+        let is_first_page = self.content.inner.current_page() == 0;
+        let is_last_page =
+            self.content.inner.current_page() == (self.content.inner.num_pages() - 1);
+
+        let is_swipe_up = matches!(attach_type, AttachType::Swipe(SwipeDirection::Up));
+        let is_swipe_down = matches!(attach_type, AttachType::Swipe(SwipeDirection::Down));
+
+        if !self.content.show_attach_anim {
+            return false;
+        }
+
+        if is_first_page && is_swipe_up {
+            return true;
+        }
+
+        if is_last_page && is_swipe_down {
+            return true;
+        }
+
+        false
+    }
+
+    fn should_animate_swipe(&self, swipe_direction: SwipeDirection) -> bool {
+        let is_first_page = self.content.inner.current_page() == 0;
+        let is_last_page =
+            self.content.inner.current_page() == (self.content.inner.num_pages() - 1);
+
+        let is_swipe_up = matches!(swipe_direction, SwipeDirection::Up);
+        let is_swipe_down = matches!(swipe_direction, SwipeDirection::Down);
+
+        if is_last_page && is_swipe_up {
+            return true;
+        }
+
+        if is_first_page && is_swipe_down {
+            return true;
+        }
+
+        false
+    }
+}
+
+impl<T> Component for InternallySwipableContent<T>
+where
+    T: Component + InternallySwipable,
+{
+    type Msg = T::Msg;
+
+    fn place(&mut self, bounds: Rect) -> Rect {
+        self.content.place(bounds)
+    }
+
+    fn event(&mut self, ctx: &mut EventCtx, event: Event) -> Option<Self::Msg> {
+        let animate = match event {
+            Event::Attach(attach_type) => self.should_animate_attach(attach_type),
+            Event::Swipe(SwipeEvent::Move(dir, _)) => self.should_animate_swipe(dir),
+            Event::Swipe(SwipeEvent::End(dir)) => self.should_animate_swipe(dir),
+            _ => self.animate,
+        };
+
+        self.animate = animate;
+
+        self.content.process_event(ctx, event, animate)
+    }
+
+    fn paint(&mut self) {
+        self.content.paint()
+    }
+
+    fn render<'s>(&'s self, target: &mut impl Renderer<'s>) {
+        self.content.render(target)
+    }
+}
+
+#[cfg(feature = "ui_debug")]
+impl<T> crate::trace::Trace for InternallySwipableContent<T>
+where
+    T: crate::trace::Trace + Component + InternallySwipable,
+{
+    fn trace(&self, t: &mut dyn crate::trace::Tracer) {
+        t.component("InternallySwipableContent");
+        t.child("content", &self.content);
     }
 }

--- a/core/embed/rust/src/ui/model_mercury/component/swipe_up_screen.rs
+++ b/core/embed/rust/src/ui/model_mercury/component/swipe_up_screen.rs
@@ -1,6 +1,6 @@
 use crate::ui::{
     component::{base::AttachType, Component, Event, EventCtx, SwipeDetect, SwipeDetectMsg},
-    event::{SwipeEvent},
+    event::{SwipeEvent, TouchEvent},
     flow::Swipable,
     geometry::Rect,
     shape::Renderer,
@@ -56,6 +56,7 @@ impl<T: Swipable + Component> Component for SwipeUpScreen<T> {
             Some(SwipeDetectMsg::Move(dir, progress)) => {
                 Event::Swipe(SwipeEvent::Move(dir, progress as i16))
             }
+            Some(SwipeDetectMsg::Start(_)) => Event::Touch(TouchEvent::TouchAbort),
             _ => event,
         };
 

--- a/core/embed/rust/src/ui/model_mercury/component/swipe_up_screen.rs
+++ b/core/embed/rust/src/ui/model_mercury/component/swipe_up_screen.rs
@@ -1,6 +1,6 @@
 use crate::ui::{
-    component::{Component, Event, EventCtx, SwipeDetect, SwipeDetectMsg},
-    event::SwipeEvent,
+    component::{base::AttachType, Component, Event, EventCtx, SwipeDetect, SwipeDetectMsg},
+    event::{SwipeEvent},
     flow::Swipable,
     geometry::Rect,
     shape::Renderer,
@@ -49,7 +49,8 @@ impl<T: Swipable + Component> Component for SwipeUpScreen<T> {
             .swipe
             .event(ctx, event, self.content.get_swipe_config())
         {
-            Some(SwipeDetectMsg::Trigger(_)) => {
+            Some(SwipeDetectMsg::Trigger(dir)) => {
+                ctx.set_transition_out(AttachType::Swipe(dir));
                 return Some(SwipeUpScreenMsg::Swiped);
             }
             Some(SwipeDetectMsg::Move(dir, progress)) => {

--- a/core/embed/rust/src/ui/model_mercury/flow/show_share_words.rs
+++ b/core/embed/rust/src/ui/model_mercury/flow/show_share_words.rs
@@ -112,11 +112,13 @@ impl ShowShareWords {
         let content_words =
             ShareWords::new(title, subtitle, share_words_vec, highlight_repeated).map(|_| None);
 
-        let content_confirm =
-            Frame::left_aligned(text_confirm, PromptScreen::new_hold_to_confirm())
-                .with_footer(TR::instructions__hold_to_confirm.into(), None)
-                .with_swipe(SwipeDirection::Down, SwipeSettings::default())
-                .map(|_| Some(FlowMsg::Confirmed));
+        let content_confirm = Frame::left_aligned(
+            text_confirm,
+            SwipeContent::new(PromptScreen::new_hold_to_confirm()),
+        )
+        .with_footer(TR::instructions__hold_to_confirm.into(), None)
+        .with_swipe(SwipeDirection::Down, SwipeSettings::default())
+        .map(|_| Some(FlowMsg::Confirmed));
 
         let content_check_backup_intro = Frame::left_aligned(
             TR::reset__check_wallet_backup_title.into(),

--- a/core/embed/rust/src/ui/model_mercury/layout.rs
+++ b/core/embed/rust/src/ui/model_mercury/layout.rs
@@ -20,7 +20,7 @@ use crate::{
     ui::{
         backlight::BACKLIGHT_LEVELS_OBJ,
         component::{
-            base::{AttachType, ComponentExt},
+            base::ComponentExt,
             connect::Connect,
             swipe_detect::SwipeSettings,
             text::{
@@ -811,7 +811,7 @@ extern "C" fn new_show_success(n_args: usize, args: *const Obj, kwargs: *mut Map
 
         let content = StatusScreen::new_success();
         let obj = LayoutObj::new(SwipeUpScreen::new(
-            Frame::left_aligned(title, SwipeContent::new(content).with_normal_attach(None))
+            Frame::left_aligned(title, SwipeContent::new(content).with_no_attach_anim())
                 .with_footer(TR::instructions__swipe_up.into(), description)
                 .with_swipe(SwipeDirection::Up, SwipeSettings::default()),
         ))?;
@@ -1070,13 +1070,9 @@ extern "C" fn new_show_checklist(n_args: usize, args: *const Obj, kwargs: *mut M
         .with_done_offset(theme::CHECKLIST_DONE_OFFSET);
 
         let obj = LayoutObj::new(SwipeUpScreen::new(
-            Frame::left_aligned(
-                title,
-                SwipeContent::new(checklist_content)
-                    .with_normal_attach(Some(AttachType::Swipe(SwipeDirection::Up))),
-            )
-            .with_footer(TR::instructions__swipe_up.into(), None)
-            .with_swipe(SwipeDirection::Up, SwipeSettings::default()),
+            Frame::left_aligned(title, SwipeContent::new(checklist_content))
+                .with_footer(TR::instructions__swipe_up.into(), None)
+                .with_swipe(SwipeDirection::Up, SwipeSettings::default()),
         ))?;
         Ok(obj.into())
     };
@@ -1317,12 +1313,15 @@ pub static mp_module_trezorui2: Module = obj_module! {
     ///
     /// T = TypeVar("T")
     ///
+    /// class AttachType:
+    ///     ...
+    ///
     /// class LayoutObj(Generic[T]):
     ///     """Representation of a Rust-based layout object.
     ///     see `trezor::ui::layout::obj::LayoutObj`.
     ///     """
     ///
-    ///     def attach_timer_fn(self, fn: Callable[[int, int], None]) -> None:
+    ///     def attach_timer_fn(self, fn: Callable[[int, int], None], attach_type: AttachType | None) -> None:
     ///         """Attach a timer setter function.
     ///
     ///         The layout object can call the timer setter with two arguments,
@@ -1378,6 +1377,9 @@ pub static mp_module_trezorui2: Module = obj_module! {
     ///
     ///     def page_count(self) -> int:
     ///         """Return the number of pages in the layout object."""
+    ///
+    ///     def get_transition_out(self) -> AttachType:
+    ///         """Return the transition type."""
     ///
     ///     def __del__(self) -> None:
     ///         """Calls drop on contents of the root component."""

--- a/core/embed/rust/src/ui/model_tt/component/number_input_slider.rs
+++ b/core/embed/rust/src/ui/model_tt/component/number_input_slider.rs
@@ -155,6 +155,7 @@ impl Component for NumberInputSlider {
                 TouchEvent::TouchStart(pos) => self.slider_eval(pos, ctx),
                 TouchEvent::TouchMove(pos) => self.slider_eval(pos, ctx),
                 TouchEvent::TouchEnd(pos) => self.slider_eval(pos, ctx),
+                TouchEvent::TouchAbort => None,
             };
         }
         None

--- a/core/embed/rust/src/ui/model_tt/layout.rs
+++ b/core/embed/rust/src/ui/model_tt/layout.rs
@@ -1625,12 +1625,15 @@ pub static mp_module_trezorui2: Module = obj_module! {
     ///
     /// T = TypeVar("T")
     ///
+    /// class AttachType:
+    ///     ...
+    ///
     /// class LayoutObj(Generic[T]):
     ///     """Representation of a Rust-based layout object.
     ///     see `trezor::ui::layout::obj::LayoutObj`.
     ///     """
     ///
-    ///     def attach_timer_fn(self, fn: Callable[[int, int], None]) -> None:
+    ///     def attach_timer_fn(self, fn: Callable[[int, int], None], attach_type: AttachType | None) -> None:
     ///         """Attach a timer setter function.
     ///
     ///         The layout object can call the timer setter with two arguments,
@@ -1689,6 +1692,9 @@ pub static mp_module_trezorui2: Module = obj_module! {
     ///
     ///     def button_request(self) -> tuple[int, str] | None:
     ///         """Return (code, type) of button request made during the last event or timer pass."""
+    ///
+    ///     def get_transition_out(self) -> AttachType:
+    ///         """Return the transition type."""
     ///
     ///     def __del__(self) -> None:
     ///         """Calls drop on contents of the root component."""

--- a/core/embed/trezorhal/stm32f4/touch/ft6x36.c
+++ b/core/embed/trezorhal/stm32f4/touch/ft6x36.c
@@ -388,9 +388,15 @@ uint32_t touch_get_event(void) {
       // Finger was just pressed down
       event = TOUCH_START | xy;
     } else {
-      // It looks like we have missed the lift up event
-      // We should send the TOUCH_END event here with old coordinates
-      event = TOUCH_END | touch_pack_xy(driver->last_x, driver->last_y);
+      if ((x != driver->last_x) || (y != driver->last_y)) {
+        // It looks like we have missed the lift up event
+        // We should send the TOUCH_END event here with old coordinates
+        event = TOUCH_END | touch_pack_xy(driver->last_x, driver->last_y);
+      } else {
+        // We have received the same coordinates as before,
+        // probably this is the same start event, or a quick bounce,
+        // we should ignore it.
+      }
     }
   } else if ((nb_touches == 1) && (flags == FT6X63_EVENT_CONTACT)) {
     if (driver->pressed) {

--- a/core/mocks/generated/trezorui2.pyi
+++ b/core/mocks/generated/trezorui2.pyi
@@ -4,11 +4,16 @@ T = TypeVar("T")
 
 
 # rust/src/ui/model_mercury/layout.rs
+class AttachType:
+    ...
+
+
+# rust/src/ui/model_mercury/layout.rs
 class LayoutObj(Generic[T]):
     """Representation of a Rust-based layout object.
     see `trezor::ui::layout::obj::LayoutObj`.
     """
-    def attach_timer_fn(self, fn: Callable[[int, int], None]) -> None:
+    def attach_timer_fn(self, fn: Callable[[int, int], None], attach_type: AttachType | None) -> None:
         """Attach a timer setter function.
         The layout object can call the timer setter with two arguments,
         `token` and `deadline`. When `deadline` is reached, the layout object
@@ -49,6 +54,8 @@ class LayoutObj(Generic[T]):
             """Paint bounds of individual components on screen."""
     def page_count(self) -> int:
         """Return the number of pages in the layout object."""
+    def get_transition_out(self) -> AttachType:
+        """Return the transition type."""
     def __del__(self) -> None:
         """Calls drop on contents of the root component."""
 
@@ -1084,11 +1091,16 @@ T = TypeVar("T")
 
 
 # rust/src/ui/model_tt/layout.rs
+class AttachType:
+    ...
+
+
+# rust/src/ui/model_tt/layout.rs
 class LayoutObj(Generic[T]):
     """Representation of a Rust-based layout object.
     see `trezor::ui::layout::obj::LayoutObj`.
     """
-    def attach_timer_fn(self, fn: Callable[[int, int], None]) -> None:
+    def attach_timer_fn(self, fn: Callable[[int, int], None], attach_type: AttachType | None) -> None:
         """Attach a timer setter function.
         The layout object can call the timer setter with two arguments,
         `token` and `deadline`. When `deadline` is reached, the layout object
@@ -1131,6 +1143,8 @@ class LayoutObj(Generic[T]):
         """Return the number of pages in the layout object."""
     def button_request(self) -> tuple[int, str] | None:
         """Return (code, type) of button request made during the last event or timer pass."""
+    def get_transition_out(self) -> AttachType:
+        """Return the transition type."""
     def __del__(self) -> None:
         """Calls drop on contents of the root component."""
 

--- a/core/src/trezor/ui/layouts/mercury/__init__.py
+++ b/core/src/trezor/ui/layouts/mercury/__init__.py
@@ -65,8 +65,8 @@ class RustLayout(ui.Layout):
         def create_tasks(self) -> tuple[loop.AwaitableTask, ...]:
             if context.CURRENT_CONTEXT:
                 return (
-                    self.handle_timers(),
                     self.handle_input_and_rendering(),
+                    self.handle_timers(),
                     self.handle_swipe(),
                     self.handle_click_signal(),
                     self.handle_result_signal(),
@@ -74,8 +74,8 @@ class RustLayout(ui.Layout):
                 )
             else:
                 return (
-                    self.handle_timers(),
                     self.handle_input_and_rendering(),
+                    self.handle_timers(),
                     self.handle_swipe(),
                     self.handle_click_signal(),
                     self.handle_result_signal(),
@@ -180,14 +180,14 @@ class RustLayout(ui.Layout):
         def create_tasks(self) -> tuple[loop.AwaitableTask, ...]:
             if context.CURRENT_CONTEXT:
                 return (
-                    self.handle_timers(),
                     self.handle_input_and_rendering(),
+                    self.handle_timers(),
                     self.handle_usb(context.get_context()),
                 )
             else:
                 return (
-                    self.handle_timers(),
                     self.handle_input_and_rendering(),
+                    self.handle_timers(),
                 )
 
     def _first_paint(self) -> None:

--- a/core/src/trezor/ui/layouts/mercury/__init__.py
+++ b/core/src/trezor/ui/layouts/mercury/__init__.py
@@ -36,7 +36,7 @@ class RustLayout(ui.Layout):
         self.br_chan = loop.chan()
         self.layout = layout
         self.timer = loop.Timer()
-        self.layout.attach_timer_fn(self.set_timer)
+        self.layout.attach_timer_fn(self.set_timer, ui.LAST_TRANSITION_OUT)
         self._send_button_request()
         self.backlight_level = ui.BacklightLevels.NORMAL
 
@@ -191,6 +191,7 @@ class RustLayout(ui.Layout):
                 )
 
     def _first_paint(self) -> None:
+
         ui.backlight_fade(ui.BacklightLevels.NONE)
         self._paint()
 
@@ -213,7 +214,7 @@ class RustLayout(ui.Layout):
 
             notify_layout_change(self, event_id)
 
-        # Turn the brightness on again.
+        # Fade brightness to desired level
         ui.backlight_fade(self.backlight_level)
 
     def handle_input_and_rendering(self) -> loop.Task:
@@ -260,13 +261,16 @@ class RustLayout(ui.Layout):
             br_code, br_type = res
             self.br_chan.publish((br_code, br_type, self.layout.page_count()))
 
+    def finalize(self):
+        ui.LAST_TRANSITION_OUT = self.layout.get_transition_out()
+
 
 def draw_simple(layout: Any) -> None:
     # Simple drawing not supported for layouts that set timers.
     def dummy_set_timer(token: int, deadline: int) -> None:
         raise RuntimeError
 
-    layout.attach_timer_fn(dummy_set_timer)
+    layout.attach_timer_fn(dummy_set_timer, None)
     ui.backlight_fade(ui.BacklightLevels.DIM)
     layout.paint()
     ui.refresh()

--- a/core/src/trezor/ui/layouts/mercury/fido.py
+++ b/core/src/trezor/ui/layouts/mercury/fido.py
@@ -18,8 +18,8 @@ if __debug__:
     class _RustFidoLayoutImpl(RustLayout):
         def create_tasks(self) -> tuple[AwaitableTask, ...]:
             return (
-                self.handle_timers(),
                 self.handle_input_and_rendering(),
+                self.handle_timers(),
                 self.handle_swipe(),
                 self.handle_debug_confirm(),
             )

--- a/core/src/trezor/ui/layouts/mercury/homescreen.py
+++ b/core/src/trezor/ui/layouts/mercury/homescreen.py
@@ -33,8 +33,8 @@ class HomescreenBase(RustLayout):
         # In __debug__ mode, ignore {confirm,swipe,input}_signal.
         def create_tasks(self) -> tuple[loop.AwaitableTask, ...]:
             return (
-                self.handle_timers(),
                 self.handle_input_and_rendering(),
+                self.handle_timers(),
                 self.handle_click_signal(),  # so we can receive debug events
             )
 

--- a/core/src/trezor/ui/layouts/progress.py
+++ b/core/src/trezor/ui/layouts/progress.py
@@ -35,7 +35,7 @@ class RustProgress:
     ):
         self.layout = layout
         ui.backlight_fade(ui.BacklightLevels.DIM)
-        self.layout.attach_timer_fn(self.set_timer)
+        self.layout.attach_timer_fn(self.set_timer, None)
         if self.layout.paint():
             ui.refresh()
         ui.backlight_fade(ui.BacklightLevels.NORMAL)

--- a/core/src/trezor/ui/layouts/tr/__init__.py
+++ b/core/src/trezor/ui/layouts/tr/__init__.py
@@ -41,7 +41,7 @@ class RustLayout(LayoutParentType[T]):
         self.br_chan = loop.chan()
         self.layout = layout
         self.timer = loop.Timer()
-        self.layout.attach_timer_fn(self.set_timer)
+        self.layout.attach_timer_fn(self.set_timer, None)
         self._send_button_request()
 
     def __del__(self):
@@ -309,7 +309,7 @@ def draw_simple(layout: trezorui2.LayoutObj[Any]) -> None:
     def dummy_set_timer(token: int, deadline: int) -> None:
         raise RuntimeError
 
-    layout.attach_timer_fn(dummy_set_timer)
+    layout.attach_timer_fn(dummy_set_timer, None)
     layout.paint()
     ui.refresh()
 

--- a/core/src/trezor/ui/layouts/tr/__init__.py
+++ b/core/src/trezor/ui/layouts/tr/__init__.py
@@ -226,14 +226,14 @@ class RustLayout(LayoutParentType[T]):
         def create_tasks(self) -> tuple[loop.AwaitableTask, ...]:
             if context.CURRENT_CONTEXT:
                 return (
-                    self.handle_timers(),
                     self.handle_input_and_rendering(),
+                    self.handle_timers(),
                     self.handle_usb(context.get_context()),
                 )
             else:
                 return (
-                    self.handle_timers(),
                     self.handle_input_and_rendering(),
+                    self.handle_timers(),
                 )
 
     def _first_paint(self) -> None:

--- a/core/src/trezor/ui/layouts/tt/__init__.py
+++ b/core/src/trezor/ui/layouts/tt/__init__.py
@@ -71,8 +71,8 @@ class RustLayout(LayoutParentType[T]):
         def create_tasks(self) -> tuple[loop.AwaitableTask, ...]:
             if context.CURRENT_CONTEXT:
                 return (
-                    self.handle_timers(),
                     self.handle_input_and_rendering(),
+                    self.handle_timers(),
                     self.handle_swipe(),
                     self.handle_click_signal(),
                     self.handle_result_signal(),
@@ -80,8 +80,8 @@ class RustLayout(LayoutParentType[T]):
                 )
             else:
                 return (
-                    self.handle_timers(),
                     self.handle_input_and_rendering(),
+                    self.handle_timers(),
                     self.handle_swipe(),
                     self.handle_click_signal(),
                     self.handle_result_signal(),
@@ -186,14 +186,14 @@ class RustLayout(LayoutParentType[T]):
         def create_tasks(self) -> tuple[loop.AwaitableTask, ...]:
             if context.CURRENT_CONTEXT:
                 return (
-                    self.handle_timers(),
                     self.handle_input_and_rendering(),
+                    self.handle_timers(),
                     self.handle_usb(context.get_context()),
                 )
             else:
                 return (
-                    self.handle_timers(),
                     self.handle_input_and_rendering(),
+                    self.handle_timers(),
                 )
 
     def _first_paint(self) -> None:

--- a/core/src/trezor/ui/layouts/tt/__init__.py
+++ b/core/src/trezor/ui/layouts/tt/__init__.py
@@ -42,7 +42,7 @@ class RustLayout(LayoutParentType[T]):
         self.br_chan = loop.chan()
         self.layout = layout
         self.timer = loop.Timer()
-        self.layout.attach_timer_fn(self.set_timer)
+        self.layout.attach_timer_fn(self.set_timer, None)
         self._send_button_request()
         self.backlight_level = ui.BacklightLevels.NORMAL
 
@@ -272,7 +272,7 @@ def draw_simple(layout: trezorui2.LayoutObj[Any]) -> None:
     def dummy_set_timer(token: int, deadline: int) -> None:
         raise RuntimeError
 
-    layout.attach_timer_fn(dummy_set_timer)
+    layout.attach_timer_fn(dummy_set_timer, None)
     ui.backlight_fade(ui.BacklightLevels.DIM)
     layout.paint()
     ui.refresh()

--- a/core/src/trezor/ui/layouts/tt/fido.py
+++ b/core/src/trezor/ui/layouts/tt/fido.py
@@ -18,8 +18,8 @@ if __debug__:
     class _RustFidoLayoutImpl(RustLayout):
         def create_tasks(self) -> tuple[AwaitableTask, ...]:
             return (
-                self.handle_timers(),
                 self.handle_input_and_rendering(),
+                self.handle_timers(),
                 self.handle_swipe(),
                 self.handle_debug_confirm(),
             )

--- a/core/src/trezor/ui/layouts/tt/homescreen.py
+++ b/core/src/trezor/ui/layouts/tt/homescreen.py
@@ -33,8 +33,8 @@ class HomescreenBase(RustLayout):
         # In __debug__ mode, ignore {confirm,swipe,input}_signal.
         def create_tasks(self) -> tuple[loop.AwaitableTask, ...]:
             return (
-                self.handle_timers(),
                 self.handle_input_and_rendering(),
+                self.handle_timers(),
                 self.handle_click_signal(),  # so we can receive debug events
             )
 


### PR DESCRIPTION
This PR addresses several problems/UX issues with swiping on T3T1.

- when changing layout (with going through python), swipe direction is remembered and therefore the second part of the animation has right effect
- no longer blocking swipes when button is pressed, rather we selectively block swipes on hold to confirm press only. When the swipe is locked-in while, new TouchAbort event is sent so any pressed buttons are deactivated.
- swipes beginning too close to an edge (that in direction of the swipe) are ignored, as they would fail anyway
- handling of repeated touches when swiping is improved
- instant lock-trigger of swipe without TouchMove event in between Start and End is removed- this would cause some complications with the new TouchAbort mechanism and these situations are not real swipes anyway..
- hold to confirm screen when showing share words is animated
- internal swipes handling is improved - when entering/exiting screen with internal swipes, normal swipe animation is played. This mainly affects show share words flow.
- duration of canceled swipe animation is fixed


Also in this PR, a fix of two other bugs:
- touch driver sometimes issued second TouchStart/End event pair, causing double button clicks for example
- backlight handling on first paint is fixed to address now quicker timers when playing attach animation



<!--
If you are a core dev:

Don't forget to set up the fields:
- assign yourself
- set priority to same as original issue
- add PR to sprint
- if Draft -> "in progress"
- if final PR -> "needs review"

If you're an external contributor, you can ignore this text.
-->
