### PR TITLE
Fix memory clearing in boardloader

### DIFF
--- a/core/embed/bootloader/main.c
+++ b/core/embed/bootloader/main.c
@@ -348,9 +348,6 @@ void real_jump_to_firmware(void) {
   display_finish_actions();
   ensure_compatible_settings();
 
-  // mpu_config_firmware();
-  // jump_to_unprivileged(FIRMWARE_START + vhdr.hdrlen + IMAGE_HEADER_SIZE);
-
   mpu_config_off();
   jump_to(FIRMWARE_START + vhdr.hdrlen + IMAGE_HEADER_SIZE);
 }

--- a/core/embed/bootloader_ci/main.c
+++ b/core/embed/bootloader_ci/main.c
@@ -293,9 +293,6 @@ int main(void) {
 
   // do not check any trust flags on header, proceed
 
-  // mpu_config_firmware();
-  // jump_to_unprivileged(FIRMWARE_START + vhdr.hdrlen + IMAGE_HEADER_SIZE);
-
   mpu_config_off();
   jump_to(FIRMWARE_START + vhdr.hdrlen + IMAGE_HEADER_SIZE);
 

--- a/core/embed/trezorhal/stm32f4/platform.h
+++ b/core/embed/trezorhal/stm32f4/platform.h
@@ -34,7 +34,6 @@ void set_core_clock(clock_settings_t settings);
 
 void memset_reg(volatile void *start, volatile void *stop, uint32_t val);
 void jump_to(uint32_t address);
-void jump_to_unprivileged(uint32_t address);
 void jump_to_with_flag(uint32_t address, uint32_t register_flag);
 void ensure_compatible_settings(void);
 void clear_otg_hs_memory(void);

--- a/core/embed/trezorhal/stm32f4/util.s
+++ b/core/embed/trezorhal/stm32f4/util.s
@@ -77,61 +77,6 @@ jump_to_with_flag:
   ldr lr, [lr, 4]       // set lr to the next stage's reset_handler
   bx lr
 
-  .global jump_to_unprivileged
-  .type jump_to_unprivileged, STT_FUNC
-jump_to_unprivileged:
-  mov r4, r0            // save input argument r0 (the address of the next stage's vector table) (r4 is callee save)
-  // this subroutine re-points the exception handlers before the C code
-  // that comprises them has been given a good environment to run.
-  // therefore, this code needs to disable interrupts before the VTOR
-  // update. then, the reset_handler of the next stage needs to re-enable interrupts.
-  // the following prevents activation of all exceptions except Non-Maskable Interrupt (NMI).
-  // according to "ARM Cortex-M Programming Guide to Memory Barrier Instructions" Application Note 321, section 4.8:
-  // "there is no requirement to insert memory barrier instructions after CPSID".
-  cpsid f
-  // wipe memory at the end of the current stage of code
-  bl clear_otg_hs_memory
-  ldr r0, =ccmram_start // r0 - point to beginning of CCMRAM
-  ldr r1, =ccmram_end   // r1 - point to byte after the end of CCMRAM
-  ldr r2, =0            // r2 - the word-sized value to be written
-  bl memset_reg
-  ldr r0, =sram_start   // r0 - point to beginning of SRAM
-  ldr r1, =sram_end     // r1 - point to byte after the end of SRAM
-  ldr r2, =0            // r2 - the word-sized value to be written
-  bl memset_reg
-  mov lr, r4
-  // clear out the general purpose registers before the next stage's code can run (even the NMI exception handler)
-  ldr r0, =0
-  mov r1, r0
-  mov r2, r0
-  mov r3, r0
-  mov r4, r0
-  mov r5, r0
-  mov r6, r0
-  mov r7, r0
-  mov r8, r0
-  mov r9, r0
-  mov r10, r0
-  mov r11, r0
-  mov r12, r0
-  // give the next stage a fresh main stack pointer
-  ldr r0, [lr]          // set r0 to the main stack pointer in the next stage's vector table
-  msr msp, r0           // give the next stage its main stack pointer
-  // point to the next stage's exception handlers
-  // AN321, section 4.11: "a memory barrier is not required after a VTOR update"
-  .set SCB_VTOR, 0xE000ED08 // reference "Cortex-M4 Devices Generic User Guide" section 4.3
-  ldr r0, =SCB_VTOR
-  str lr, [r0]
-  mov r0, r1            // zero out r0
-  // go on to the next stage
-  ldr lr, [lr, 4]       // set lr to the next stage's reset_handler
-  // switch to unprivileged mode
-  ldr r0, =1
-  msr control, r0
-  isb
-  // jump
-  bx lr
-
   .global shutdown_privileged
   .type shutdown_privileged, STT_FUNC
   // The function must be called from the privileged mode

--- a/core/embed/trezorhal/stm32u5/limited_util.s
+++ b/core/embed/trezorhal/stm32u5/limited_util.s
@@ -34,6 +34,7 @@ jump_to:
   // "there is no requirement to insert memory barrier instructions after CPSID".
   cpsid f
   // wipe memory at the end of the current stage of code
+  ldr r2, =0             // r2 - the word-sized value to be written
   ldr r0, =sram1_start   // r0 - point to beginning of SRAM
   ldr r1, =sram1_end     // r1 - point to byte after the end of SRAM
   bl memset_reg

--- a/core/embed/trezorhal/stm32u5/limited_util.s
+++ b/core/embed/trezorhal/stm32u5/limited_util.s
@@ -53,8 +53,9 @@ jump_to:
   ldr r0, =__fb_end      // r0 - point to end of framebuffer
   ldr r1, =sram5_end     // r1 - point to byte after the end of SRAM
   bl memset_reg
+
   mov lr, r4
-  // clear out the general purpose registers before the next stage's code can run (even the NMI exception handler)
+  // clear out the general purpose registers before the next stage's code can run
   ldr r0, =0
   mov r1, r0
   mov r2, r0
@@ -80,7 +81,6 @@ jump_to:
   // go on to the next stage
   ldr lr, [lr, 4]       // set lr to the next stage's reset_handler
   bx lr
-
 
   .global shutdown_privileged
   .type shutdown_privileged, STT_FUNC

--- a/core/embed/trezorhal/stm32u5/platform.h
+++ b/core/embed/trezorhal/stm32u5/platform.h
@@ -40,7 +40,6 @@ void drop_privileges(void);
 // the following functions are defined in util.s
 void memset_reg(volatile void *start, volatile void *stop, uint32_t val);
 void jump_to(uint32_t address);
-void jump_to_unprivileged(uint32_t address);
 void jump_to_with_flag(uint32_t address, uint32_t register_flag);
 
 extern uint32_t __stack_chk_guard;


### PR DESCRIPTION
This PR fixed memory clearing during the transition from the boardloader to the bootloader.

Prior to this change, the memory was filled with potentially uninitialized values. After this change, the memory is correctly set to zero as expected. This bug did not pose any security issues since the memory was always overwritten.

Additionally, the unused `jump_to_unprivileged` function has been removed in this PR.