### PR TITLE
Fix touch driver on dev kits

### DIFF
--- a/core/Makefile
+++ b/core/Makefile
@@ -66,6 +66,7 @@ MODEL_FEATURE = model_mercury
 else ifeq ($(TREZOR_MODEL),$(filter $(TREZOR_MODEL),DISC1))
 MCU = STM32F4
 LAYOUT_FILE = embed/models/D001/model_D001.h
+OPENOCD_TARGET = target/stm32f4x.cfg
 else ifeq ($(TREZOR_MODEL),$(filter $(TREZOR_MODEL),DISC2))
 MCU = STM32U5
 LAYOUT_FILE = embed/models/D002/model_D002.h

--- a/core/embed/trezorhal/stm32f4/touch/stmpe811.c
+++ b/core/embed/trezorhal/stm32f4/touch/stmpe811.c
@@ -633,8 +633,11 @@ uint32_t touch_get_event(void) {
     uint32_t xy = touch_pack_xy(driver->prev_state.X, driver->prev_state.Y);
     event = TOUCH_END | xy;
   } else if (new_state.TouchDetected) {
-    uint32_t xy = touch_pack_xy(new_state.X, new_state.Y);
-    event = TOUCH_MOVE | xy;
+    if ((new_state.X != driver->prev_state.X) ||
+        (new_state.Y != driver->prev_state.Y)) {
+      uint32_t xy = touch_pack_xy(new_state.X, new_state.Y);
+      event = TOUCH_MOVE | xy;
+    }
   }
 
   driver->prev_state = new_state;


### PR DESCRIPTION
This PR fixes the bugs in the touch driver introduced by #3900 on both discovery kits.

1) Fixes duplicated `TOUCH_MOVE` events with the same coordinates
2) Fixes `touch_activity()` detectioin on disc2 kit
3) Fixes `flash_firmware`/`flash_bootloader` make targets for disc1 kit
