### PR TITLE
Increase Optiga MAX_RETRY_READ_MS to 6 sec

### DIFF
--- a/core/.changelog.d/+optiga.fixed
+++ b/core/.changelog.d/+optiga.fixed
@@ -1,0 +1,1 @@
+Fix Optiga-related RSODs

--- a/core/embed/trezorhal/optiga/optiga_transport.c
+++ b/core/embed/trezorhal/optiga/optiga_transport.c
@@ -66,7 +66,10 @@ static const uint32_t I2C_TIMEOUT_MS = 25;
 static const int I2C_MAX_RETRY_COUNT = 10;
 
 // Maximum time in millisecods to retry reading Optiga's response to a command.
-static const int MAX_RETRY_READ_MS = 300;
+// If the SEC is high, then the throttling down delay can be as high as
+// t_max = 5000 ms. The maximum time to execute a non-RSA operation is 130 ms.
+// We round the total up to the nearest second.
+static const int MAX_RETRY_READ_MS = 6000;
 
 // Maximum number of times to retry reading Optiga's response to a command when
 // it claims it's not busy executing a command.


### PR DESCRIPTION
Changes Optiga's `MAX_RETRY_READ_MS` introduced in https://github.com/trezor/trezor-firmware/pull/3766. I increase it to 6 seconds in order to account for the maximum throttling down delay [1] of 5 seconds when Optiga's security event counter is high.

[1] https://github.com/Infineon/optiga-trust-m-overview/blob/main/docs/OPTIGA%E2%84%A2%20Trust%20M%20Solution%20Reference%20Manual.md#security-monitor-characteristics.