### PR TITLE
Allow Solana AToken Create instruction to contain an optional `rent_sysvar` account

### DIFF
--- a/common/defs/solana/programs.json
+++ b/common/defs/solana/programs.json
@@ -2976,6 +2976,12 @@
               "name": "spl_token",
               "is_authority": false,
               "optional": false
+            },
+            {
+              "//": "Some dApps still include the rent sysvar although it's not officially required anymore.",
+              "name": "rent_sysvar",
+              "is_authority": false,
+              "optional": true
             }
           ],
           "ui_properties": [

--- a/common/tests/fixtures/solana/sign_tx.associated_token_account_program.json
+++ b/common/tests/fixtures/solana/sign_tx.associated_token_account_program.json
@@ -47,6 +47,52 @@
         "expected_signature": "629daa88d10bca2315fe4176c323197a22c821026f7f6019cadbcf2769c5bb38ceef7652b5cba7e246a51f131f14fa8d776df63c50a1c4a09a3cf0bf2d446201"
       }
     },
+
+    {
+      "description": "Create Associated Token Account With Sysvar Rent included",
+      "parameters": {
+        "address": "m/44'/501'/0'/0'",
+        "construct": {
+          "version": null,
+          "header": {
+            "signers": 1,
+            "readonly_signers": 0,
+            "readonly_non_signers": 4
+          },
+          "accounts": [
+            "14CCvQzQzHCVgZM3j9soPnXuJXh1RmCfwLVUcdfbZVBS",
+            "FUqrjRRtF1LiptdFqaFxipE8R3YfCE4k56xwm5n1piqX",
+            "11111111111111111111111111111111",
+            "6YuhWADZyAAxAaVKPm1G5N51RvDBXsnWo4SfsJ47wSoK",
+            "ATokenGPvbdGVxr1b2hvZbsiqW5xWH25efTNsLJA8knL",
+            "TokenkegQfeZyiNwAJbNbGKPFXCWuBvf9Ss623VQ5DA",
+            "SysvarRent111111111111111111111111111111111"
+          ],
+          "blockhash": "2p4rYZAaFfV5Uk5ugdG5KPNty9Uda9B3b4gWB8qnNqak",
+          "instructions": [
+            {
+              "program_index": 4,
+              "accounts": {
+                "funding_account": 0,
+                "associated_token_account": 1,
+                "wallet_address": 0,
+                "token_mint": 3,
+                "system_program": 2,
+                "spl_token": 5,
+                "sysvar_rent": 6
+              },
+              "data": {
+                "instruction_id": null
+              }
+            }
+          ],
+          "luts": []
+        }
+      },
+      "result": {
+        "expected_signature": "098276fc4770c80395e5dd2d3de24f14a6557a0078da95646558ce5dc91aebbdd961bf641dd1ad80ed09391b18f5dcc82157a240c689d86da225a26b9ac2b509"
+      }
+    },
     {
       "description": "Create Associated Token Account Idempotent",
       "parameters": {

--- a/core/src/apps/solana/transaction/instructions.py
+++ b/core/src/apps/solana/transaction/instructions.py
@@ -743,6 +743,7 @@ if TYPE_CHECKING:
         token_mint: Account
         system_program: Account
         spl_token: Account
+        rent_sysvar: Account | None
 
     class AssociatedTokenAccountProgramCreateIdempotentInstruction(Instruction):
 
@@ -5133,6 +5134,11 @@ def get_instruction(
                         "spl_token",
                         False,
                         False,
+                    ),
+                    AccountTemplate(
+                        "rent_sysvar",
+                        False,
+                        True,
                     ),
                 ],
                 [

--- a/tests/device_tests/solana/construct/instructions.py
+++ b/tests/device_tests/solana/construct/instructions.py
@@ -1281,6 +1281,7 @@ AssociatedTokenAccountProgram_Create = Struct(
         "token_mint" / Byte,
         "system_program" / Byte,
         "spl_token" / Byte,
+        "rent_sysvar" / Optional(Byte),
     ),
     "data"
     / CompactStruct(


### PR DESCRIPTION
This is needed because some dApps (https://jup.ag/perps or http://solend.fi/) include the rent_sysvar account although it's not required anymore (it's also not a part of the [official docs](https://docs.rs/spl-associated-token-account/latest/spl_associated_token_account/instruction/enum.AssociatedTokenAccountInstruction.html#variant.Create)). Trezor followed the official docs and didn't support this "legacy" format.

I've tested submitting [a tx](https://explorer.solana.com/tx/3JQLcXPRpER5w1bRmf1HxJeybKAWi4Wq6qoM5PVe6XiS18VraedxofT7i8mNUaiAmUcaqY1JTr8NGQBTsp5eWy5k) via https://jup.ag/perps with the updated Trezor and it went through.

I'm unable to update the ui test fixtures as I am not able to build the FW on the current main branch for some reason (I've developed this on top of a random older commit - `12725d98358f6fcb31a04b9a2b1b443e7f359a09`).

<details><summary>Here's the last line from my build output which produces the error</summary>

```
gcc -o build/unix/embed/lib/mini_printf.o -c -DSCM_REVISION='"\x95\xc2\xcb\x20\x08\xa2\x98\xd4\xac\x78\x97\x7b\xb4\x3b\x43\x7d\x51\x6a\x7a\xbf"' -DCONFIDENTIAL= -DPYOPT=0 -DBITCOIN_ONLY=0 -DSTATIC= -Os -g3 -std=gnu11 -Wall -Werror -Wuninitialized -Wno-missing-braces -fdata-sections -ffunction-sections -fPIE -Wno-sequence-point -DTREZOR_EMULATOR -DTREZOR_MODEL_T -DMP_CONFIGFILE=\"embed/unix/mpconfigport.h\" -DUI_LAYOUT_TT -DAES_128 -DAES_192 -DUSE_INSECURE_PRNG -DUSE_BIP32_CACHE=0 -DUSE_KECCAK=1 -DUSE_ETHEREUM=1 -DUSE_MONERO=1 -DUSE_CARDANO=1 -DUSE_NEM=1 -DUSE_EOS=1 -DUSE_SECP256K1_ZKP -DUSE_SECP256K1_ZKP_ECDSA -DSECP256K1_CONTEXT_SIZE=208 -DUSE_EXTERNAL_DEFAULT_CALLBACKS -DECMULT_GEN_PREC_BITS=2 -DECMULT_WINDOW_SIZE=8 -DENABLE_MODULE_GENERATOR -DENABLE_MODULE_RECOVERY -DENABLE_MODULE_SCHNORRSIG -DENABLE_MODULE_EXTRAKEYS -DUSE_AES_GCM -DAES_VAR -DTREZOR_UI2 -DTRANSLATIONS -DFANCY_FATAL_ERROR -DTREZOR_FONT_NORMAL_ENABLE=Font_TTHoves_Regular_21 -DTREZOR_FONT_NORMAL_INCLUDE=\"font_tthoves_regular_21.h\" -DTREZOR_FONT_DEMIBOLD_ENABLE=Font_TTHoves_DemiBold_21 -DTREZOR_FONT_DEMIBOLD_INCLUDE=\"font_tthoves_demibold_21.h\" -DTREZOR_FONT_MONO_ENABLE=Font_RobotoMono_Medium_20 -DTREZOR_FONT_MONO_INCLUDE=\"font_robotomono_medium_20.h\" -DTREZOR_FONT_BOLD_UPPER_ENABLE=Font_TTHoves_Bold_17_upper -DTREZOR_FONT_BOLD_UPPER_INCLUDE=\"font_tthoves_bold_17.h\" -DSTM32F427xx -DTREZOR_BOARD=\"T2T1/boards/t2t1-unix.h\" -DHW_MODEL=827601492 -DHW_REVISION=0 -DMCU_TYPE=STM32F427xx -DFLASH_BIT_ACCESS=1 -DFLASH_BLOCK_WORDS=1 -DUSE_DMA2D -D_THREAD_SAFE -Ibuild/unix -I. -Ibuild/unix/embed/rust -Iembed/rust -Ibuild/unix/embed/lib -Iembed/lib -Ibuild/unix/embed/models -Iembed/models -Ibuild/unix/embed/unix -Iembed/unix -Ibuild/unix/embed/trezorhal -Iembed/trezorhal -Ibuild/unix/embed/trezorhal/unix -Iembed/trezorhal/unix -Ibuild/unix/embed/extmod/modtrezorui -Iembed/extmod/modtrezorui -Ibuild/unix/vendor/micropython -Ivendor/micropython -Ibuild/unix/vendor/micropython/ports/unix -Ivendor/micropython/ports/unix -Ibuild/unix/vendor/micropython/lib/mp-readline -Ivendor/micropython/lib/mp-readline -Ibuild/unix/embed/extmod/modtrezorconfig -Iembed/extmod/modtrezorconfig -Ibuild/unix/vendor/trezor-storage -Ivendor/trezor-storage -Ibuild/unix/vendor/trezor-crypto -Ivendor/trezor-crypto -Ibuild/unix/vendor/secp256k1-zkp -Ivendor/secp256k1-zkp -Ibuild/unix/vendor/secp256k1-zkp/src -Ivendor/secp256k1-zkp/src -Ibuild/unix/vendor/secp256k1-zkp/include -Ivendor/secp256k1-zkp/include -Ibuild/unix/vendor/micropython/lib/uzlib -Ivendor/micropython/lib/uzlib -I/nix/store/n4ry38iwq6y9wy7fpal3qpw7kzq0f1l1-SDL2-2.26.4-dev/include -I/nix/store/n4ry38iwq6y9wy7fpal3qpw7kzq0f1l1-SDL2-2.26.4-dev/include/SDL2 -I/nix/store/55ymc7rb2imvv0wslf9g8hv1g3h3fnmq-SDL2_image-2.6.3/include/SDL2 embed/lib/mini_printf.c
embed/lib/mini_printf.c:110:2: error: function definition is not allowed here
        {
        ^
embed/lib/mini_printf.c:119:2: error: function definition is not allowed here
        {
        ^
embed/lib/mini_printf.c:137:4: error: call to undeclared function '_putc'; ISO C99 and later do not support implicit function declarations [-Wimplicit-function-declaration]
                        _putc(ch);
                        ^
embed/lib/mini_printf.c:162:6: error: call to undeclared function '_puts'; ISO C99 and later do not support implicit function declarations [-Wimplicit-function-declaration]
                                        _puts(bf, len);
                                        ^
4 errors generated.
scons: *** [build/unix/embed/lib/mini_printf.o] Error 1
```
</details>