### PR TITLE
docs(core): update Optiga-related changelogs

### DIFF
--- a/core/.changelog.d/+optiga.added
+++ b/core/.changelog.d/+optiga.added
@@ -1,0 +1,1 @@
+Expose value of the Optiga SEC counter in `Features` message.

--- a/core/.changelog.d/+optiga.fixed
+++ b/core/.changelog.d/+optiga.fixed
@@ -1,1 +1,1 @@
-Fix Optiga-related RSODs
+Increase Optiga read timeout to avoid spurious RSODs.


### PR DESCRIPTION
* It seems overly self-assured to call the RSODs "fixed" :)
* the exposed `optiga_sec` should have its own changelog
<!--
If you are a core dev:

Don't forget to set up the fields:
- assign yourself
- set priority to same as original issue
- add PR to sprint
- if Draft -> "in progress"
- if final PR -> "needs review"

If you're an external contributor, you can ignore this text.
-->
