### PR TITLE
Clean up Optiga error handling

### DIFF
--- a/core/embed/extmod/modtrezorcrypto/modtrezorcrypto-optiga.h
+++ b/core/embed/extmod/modtrezorcrypto/modtrezorcrypto-optiga.h
@@ -90,11 +90,12 @@ STATIC mp_obj_t mod_trezorcrypto_optiga_sign(mp_obj_t key_index,
   vstr_t sig = {0};
   vstr_init_len(&sig, MAX_DER_SIGNATURE_SIZE);
   size_t sig_size = 0;
-  int ret = optiga_sign(idx, (const uint8_t *)dig.buf, dig.len,
-                        ((uint8_t *)sig.buf), sig.alloc, &sig_size);
-  if (ret != 0) {
+  optiga_sign_result ret =
+      optiga_sign(idx, (const uint8_t *)dig.buf, dig.len, ((uint8_t *)sig.buf),
+                  sig.alloc, &sig_size);
+  if (ret != OPTIGA_SIGN_SUCCESS) {
     vstr_clear(&sig);
-    if (ret == OPTIGA_ERR_ACCESS_COND_NOT_SAT) {
+    if (ret == OPTIGA_SIGN_INACCESSIBLE) {
       mp_raise_msg(&mp_type_SigningInaccessible, "Signing inaccessible.");
     } else {
       mp_raise_msg(&mp_type_OptigaError, "Signing failed.");

--- a/core/embed/trezorhal/optiga.h
+++ b/core/embed/trezorhal/optiga.h
@@ -28,16 +28,20 @@
 
 #define OPTIGA_DEVICE_CERT_INDEX 1
 #define OPTIGA_DEVICE_ECC_KEY_INDEX 0
-#define OPTIGA_COMMAND_ERROR_OFFSET 0x100
 
-// Error code 0x07: Access conditions not satisfied
-#define OPTIGA_ERR_ACCESS_COND_NOT_SAT (OPTIGA_COMMAND_ERROR_OFFSET + 0x07)
+typedef enum _optiga_pin_result {
+  OPTIGA_PIN_SUCCESS = 0,       // The operation completed successfully.
+  OPTIGA_PIN_INVALID,           // The PIN is invalid.
+  OPTIGA_PIN_COUNTER_EXCEEDED,  // The PIN try counter limit was exceeded.
+  OPTIGA_PIN_ERROR,             // Optiga processing or communication error.
+} optiga_pin_result;
 
-// Error code 0x0E: Counter threshold limit exceeded
-#define OPTIGA_ERR_COUNTER_EXCEEDED (OPTIGA_COMMAND_ERROR_OFFSET + 0x0E)
-
-// Error code 0x2F: Authorization failure
-#define OPTIGA_ERR_AUTH_FAIL (OPTIGA_COMMAND_ERROR_OFFSET + 0x2F)
+typedef enum _optiga_sign_result {
+  OPTIGA_SIGN_SUCCESS = 0,   // The operation completed successfully.
+  OPTIGA_SIGN_INACCESSIBLE,  // The signing key is inaccessible.
+  OPTIGA_SIGN_ERROR,         // Invalid parameters or Optiga processing or
+                             // communication error.
+} optiga_sign_result;
 
 // Size of secrets used in PIN processing, e.g. salted PIN, master secret etc.
 #define OPTIGA_PIN_SECRET_SIZE 32
@@ -50,9 +54,9 @@
 
 typedef secbool (*OPTIGA_UI_PROGRESS)(uint32_t elapsed_ms);
 
-int __wur optiga_sign(uint8_t index, const uint8_t *digest, size_t digest_size,
-                      uint8_t *signature, size_t max_sig_size,
-                      size_t *sig_size);
+optiga_sign_result __wur optiga_sign(uint8_t index, const uint8_t *digest,
+                                     size_t digest_size, uint8_t *signature,
+                                     size_t max_sig_size, size_t *sig_size);
 
 bool __wur optiga_cert_size(uint8_t index, size_t *cert_size);
 
@@ -63,15 +67,17 @@ bool __wur optiga_read_sec(uint8_t *sec);
 
 bool __wur optiga_random_buffer(uint8_t *dest, size_t size);
 
-int __wur optiga_pin_set(OPTIGA_UI_PROGRESS ui_progress,
-                         uint8_t stretched_pin[OPTIGA_PIN_SECRET_SIZE]);
+bool __wur optiga_pin_set(OPTIGA_UI_PROGRESS ui_progress,
+                          uint8_t stretched_pin[OPTIGA_PIN_SECRET_SIZE]);
 
-int __wur optiga_pin_verify(OPTIGA_UI_PROGRESS ui_progress,
-                            uint8_t stretched_pin[OPTIGA_PIN_SECRET_SIZE]);
+optiga_pin_result __wur
+optiga_pin_verify(OPTIGA_UI_PROGRESS ui_progress,
+                  uint8_t stretched_pin[OPTIGA_PIN_SECRET_SIZE]);
 
-int __wur optiga_pin_verify_v4(OPTIGA_UI_PROGRESS ui_progress,
-                               const uint8_t pin_secret[OPTIGA_PIN_SECRET_SIZE],
-                               uint8_t out_secret[OPTIGA_PIN_SECRET_SIZE]);
+optiga_pin_result __wur
+optiga_pin_verify_v4(OPTIGA_UI_PROGRESS ui_progress,
+                     const uint8_t pin_secret[OPTIGA_PIN_SECRET_SIZE],
+                     uint8_t out_secret[OPTIGA_PIN_SECRET_SIZE]);
 
 int __wur optiga_pin_get_fails_v4(uint32_t *ctr);
 

--- a/core/embed/trezorhal/optiga.h
+++ b/core/embed/trezorhal/optiga.h
@@ -79,12 +79,12 @@ optiga_pin_verify_v4(OPTIGA_UI_PROGRESS ui_progress,
                      const uint8_t pin_secret[OPTIGA_PIN_SECRET_SIZE],
                      uint8_t out_secret[OPTIGA_PIN_SECRET_SIZE]);
 
-int __wur optiga_pin_get_fails_v4(uint32_t *ctr);
+bool __wur optiga_pin_get_rem_v4(uint32_t *ctr);
 
-int __wur optiga_pin_get_fails(uint32_t *ctr);
+bool __wur optiga_pin_get_rem(uint32_t *ctr);
 
-int __wur optiga_pin_fails_increase_v4(uint32_t count);
+bool __wur optiga_pin_decrease_rem_v4(uint32_t count);
 
-int __wur optiga_pin_fails_increase(uint32_t count);
+bool __wur optiga_pin_decrease_rem(uint32_t count);
 
 #endif

--- a/core/embed/trezorhal/optiga/optiga.c
+++ b/core/embed/trezorhal/optiga/optiga.c
@@ -62,6 +62,10 @@
 // Value of the PIN counter when it is reset.
 static const uint8_t COUNTER_RESET[] = {0, 0, 0, 0, 0, 0, 0, PIN_MAX_TRIES};
 
+// Value of the PIN counter with one extra attempt needed in optiga_pin_set().
+static const uint8_t COUNTER_RESET_EXTRA[] = {0, 0, 0, 0,
+                                              0, 0, 0, PIN_MAX_TRIES + 1};
+
 // Initial value of the counter which limits the total number of PIN stretching
 // operations. The limit is 600000 stretching operations, which equates to
 // 300000 / PIN_STRETCH_ITERATIONS unlock operations over the lifetime of the
@@ -578,10 +582,10 @@ bool optiga_pin_set(OPTIGA_UI_PROGRESS ui_progress,
     goto end;
   }
 
-  // Initialize the counter which limits the guesses at OID_STRETCHED_PIN so
-  // that we can authorise using OID_STRETCHED_PIN.
-  if (optiga_set_data_object(OID_STRETCHED_PIN_CTR, false, COUNTER_RESET,
-                             sizeof(COUNTER_RESET)) != OPTIGA_SUCCESS) {
+  // Initialize the counter which limits the guesses at OID_STRETCHED_PIN with
+  // one extra attempt that we will use up in the next step.
+  if (optiga_set_data_object(OID_STRETCHED_PIN_CTR, false, COUNTER_RESET_EXTRA,
+                             sizeof(COUNTER_RESET_EXTRA)) != OPTIGA_SUCCESS) {
     ret = false;
     goto end;
   }
@@ -599,14 +603,6 @@ bool optiga_pin_set(OPTIGA_UI_PROGRESS ui_progress,
   // Initialize the key for HMAC-SHA256 PIN stretching.
   if (optiga_set_data_object(OID_PIN_HMAC, false, pin_hmac, sizeof(pin_hmac)) !=
       OPTIGA_SUCCESS) {
-    ret = false;
-    goto end;
-  }
-
-  // Initialize the counter which limits the guesses at OID_STRETCHED_PIN again,
-  // since we just depleted one attempt.
-  if (optiga_set_data_object(OID_STRETCHED_PIN_CTR, false, COUNTER_RESET,
-                             sizeof(COUNTER_RESET)) != OPTIGA_SUCCESS) {
     ret = false;
     goto end;
   }

--- a/core/embed/trezorhal/optiga_commands.h
+++ b/core/embed/trezorhal/optiga_commands.h
@@ -113,6 +113,40 @@ typedef enum {
   OPTIGA_LCS_TE = 0x0f,  // Termination state.
 } optiga_lcs;
 
+// Error codes returned by optiga_get_error_code().
+typedef enum {
+  OPTIGA_ERR_CODE_NONE = 0x00,             // No Error.
+  OPTIGA_ERR_CODE_INVAL_OID = 0x01,        // Invalid OID.
+  OPTIGA_ERR_CODE_INVAL_CMD_PARAM = 0x03,  // Invalid param field in command.
+  OPTIGA_ERR_CODE_INVAL_CMD_LEN = 0x04,    // Invalid length field in command.
+  OPTIGA_ERR_CODE_INVAL_CMD_DATA = 0x05,   // Invalid parameter in command data.
+  OPTIGA_ERR_CODE_PROCESS = 0x06,          // Internal process error.
+  OPTIGA_ERR_CODE_ACCESS_COND = 0x07,      // Access conditions not satisfied.
+  OPTIGA_ERR_CODE_OBJ_BOUNDARY = 0x08,     // Data object boundary exceeded.
+  OPTIGA_ERR_CODE_META_TRUNC = 0x09,       // Metadata truncation error.
+  OPTIGA_ERR_CODE_INVAL_CMD_FIELD = 0x0A,  // Invalid command field.
+  OPTIGA_ERR_CODE_CMD_SEQ = 0x0B,          // Command out of sequence.
+  OPTIGA_ERR_CODE_CMD_UNAVAIL = 0x0C,      // Command not available.
+  OPTIGA_ERR_CODE_MEMORY = 0x0D,           // Insufficient memory to process the
+                                           // command.
+  OPTIGA_ERR_CODE_CTR_LIMIT = 0x0E,        // Counter threshold limit exceeded.
+  OPTIGA_ERR_CODE_INVAL_MANIFEST = 0x0F,   // Invalid manifest.
+  OPTIGA_ERR_CODE_PAYLOAD_VER = 0x10,      // Wrong payload version.
+  OPTIGA_ERR_CODE_INVAL_OBJ_META = 0x11,   // Invalid data object metadata.
+  OPTIGA_ERR_CODE_UNSUP_EXT_ID = 0x24,     // Unsupported key usage, extension
+                                           // or algorithm identifier.
+  OPTIGA_ERR_CODE_UNSUP_PARAM = 0x25,      // Unsupported parameters in
+                                           // handshake or command APDU InData.
+  OPTIGA_ERR_CODE_INVAL_CERT = 0x29,       // Invalid certificate format or
+                                           // signature.
+  OPTIGA_ERR_CODE_UNSUP_CERT = 0x2A,       // Unsupported certificate.
+  OPTIGA_ERR_CODE_SIG_FAIL = 0x2C,         // Signature verification failure.
+  OPTIGA_ERR_CODE_INT_FAIL = 0x2D,      // Message integrity validation failed
+                                        // (e.g. during CCM decryption).
+  OPTIGA_ERR_CODE_DECRYPT_FAIL = 0x2E,  // Decryption failure
+  OPTIGA_ERR_CODE_AUTH_FAIL = 0x2F,     // Authorization failure
+} optiga_err_code;
+
 typedef struct {
   const uint8_t *ptr;
   uint16_t len;

--- a/core/embed/trezorhal/unix/optiga.c
+++ b/core/embed/trezorhal/unix/optiga.c
@@ -23,6 +23,7 @@
 #include "nist256p1.h"
 #include "optiga_common.h"
 #include "rand.h"
+#include "storage.h"
 
 #if defined(TREZOR_MODEL_R)
 #include "certs/T2B1.h"
@@ -114,16 +115,16 @@ optiga_pin_result optiga_pin_verify(
   return OPTIGA_PIN_SUCCESS;
 }
 
-int optiga_pin_get_fails_v4(uint32_t *ctr) {
-  *ctr = 0;
-  return OPTIGA_SUCCESS;
+bool optiga_pin_get_rem_v4(uint32_t *ctr) {
+  *ctr = PIN_MAX_TRIES;
+  return true;
 }
 
-int optiga_pin_get_fails(uint32_t *ctr) {
-  *ctr = 0;
-  return OPTIGA_SUCCESS;
+bool optiga_pin_get_rem(uint32_t *ctr) {
+  *ctr = PIN_MAX_TRIES;
+  return true;
 }
 
-int optiga_pin_fails_increase_v4(uint32_t count) { return OPTIGA_SUCCESS; }
+bool optiga_pin_decrease_rem_v4(uint32_t count) { return true; }
 
-int optiga_pin_fails_increase(uint32_t count) { return OPTIGA_SUCCESS; }
+bool optiga_pin_decrease_rem(uint32_t count) { return true; }

--- a/core/embed/trezorhal/unix/optiga.c
+++ b/core/embed/trezorhal/unix/optiga.c
@@ -34,27 +34,28 @@
 #error "Cert chain for specified model is not available."
 #endif
 
-int optiga_sign(uint8_t index, const uint8_t *digest, size_t digest_size,
-                uint8_t *signature, size_t max_sig_size, size_t *sig_size) {
+optiga_sign_result optiga_sign(uint8_t index, const uint8_t *digest,
+                               size_t digest_size, uint8_t *signature,
+                               size_t max_sig_size, size_t *sig_size) {
   const uint8_t DEVICE_PRIV_KEY[32] = {1};
 
   if (index != OPTIGA_DEVICE_ECC_KEY_INDEX) {
-    return false;
+    return OPTIGA_SIGN_ERROR;
   }
 
   if (max_sig_size < 72) {
-    return OPTIGA_ERR_SIZE;
+    return OPTIGA_SIGN_ERROR;
   }
 
   uint8_t raw_signature[64] = {0};
   int ret = ecdsa_sign_digest(&nist256p1, DEVICE_PRIV_KEY, digest,
                               raw_signature, NULL, NULL);
   if (ret != 0) {
-    return OPTIGA_ERR_CMD;
+    return OPTIGA_SIGN_ERROR;
   }
 
   *sig_size = ecdsa_sig_to_der(raw_signature, signature);
-  return OPTIGA_SUCCESS;
+  return OPTIGA_SIGN_SUCCESS;
 }
 
 bool optiga_cert_size(uint8_t index, size_t *cert_size) {
@@ -91,24 +92,26 @@ bool optiga_random_buffer(uint8_t *dest, size_t size) {
   return true;
 }
 
-int optiga_pin_set(OPTIGA_UI_PROGRESS ui_progress,
-                   uint8_t stretched_pin[OPTIGA_PIN_SECRET_SIZE]) {
+bool optiga_pin_set(OPTIGA_UI_PROGRESS ui_progress,
+                    uint8_t stretched_pin[OPTIGA_PIN_SECRET_SIZE]) {
   ui_progress(OPTIGA_PIN_SET_MS);
-  return OPTIGA_SUCCESS;
+  return true;
 }
 
-int optiga_pin_verify_v4(OPTIGA_UI_PROGRESS ui_progress,
-                         const uint8_t pin_secret[OPTIGA_PIN_SECRET_SIZE],
-                         uint8_t out_secret[OPTIGA_PIN_SECRET_SIZE]) {
+optiga_pin_result optiga_pin_verify_v4(
+    OPTIGA_UI_PROGRESS ui_progress,
+    const uint8_t pin_secret[OPTIGA_PIN_SECRET_SIZE],
+    uint8_t out_secret[OPTIGA_PIN_SECRET_SIZE]) {
   memcpy(out_secret, pin_secret, OPTIGA_PIN_SECRET_SIZE);
   ui_progress(OPTIGA_PIN_VERIFY_MS);
-  return OPTIGA_SUCCESS;
+  return OPTIGA_PIN_SUCCESS;
 }
 
-int optiga_pin_verify(OPTIGA_UI_PROGRESS ui_progress,
-                      uint8_t stretched_pin[OPTIGA_PIN_SECRET_SIZE]) {
+optiga_pin_result optiga_pin_verify(
+    OPTIGA_UI_PROGRESS ui_progress,
+    uint8_t stretched_pin[OPTIGA_PIN_SECRET_SIZE]) {
   ui_progress(OPTIGA_PIN_VERIFY_MS);
-  return OPTIGA_SUCCESS;
+  return OPTIGA_PIN_SUCCESS;
 }
 
 int optiga_pin_get_fails_v4(uint32_t *ctr) {


### PR DESCRIPTION
- Mainly refactoring to make the Optiga error handling easier to use and read.
- A small optimization in counter initialization.