### PR TITLE
fix storage compilation for U5 models without optiga

### DIFF
--- a/storage/storage.c
+++ b/storage/storage.c
@@ -572,9 +572,9 @@ static void stretch_pin(const uint8_t *pin, size_t pin_len,
     ui_progress(PIN_PBKDF2_MS / 10);
   }
 #ifdef STM32U5
-  uint8_t stretched_pin_tmp[OPTIGA_PIN_SECRET_SIZE] = {0};
+  uint8_t stretched_pin_tmp[SHA256_DIGEST_LENGTH] = {0};
   pbkdf2_hmac_sha256_Final(&ctx, stretched_pin_tmp);
-  ensure(secure_aes_ecb_encrypt_hw(stretched_pin_tmp, OPTIGA_PIN_SECRET_SIZE,
+  ensure(secure_aes_ecb_encrypt_hw(stretched_pin_tmp, SHA256_DIGEST_LENGTH,
                                    stretched_pin, SECURE_AES_KEY_XORK),
          "secure_aes pin stretch failed");
   memzero(stretched_pin_tmp, sizeof(stretched_pin_tmp));


### PR DESCRIPTION
`OPTIGA_PIN_SECRET_SIZE` is not available when optiga is not used and its usage here seems incorrect.

(this configuration is used on DISC2 devkit)

<!--
If you are a core dev:

Don't forget to set up the fields:
- assign yourself
- set priority to same as original issue
- add PR to sprint
- if Draft -> "in progress"
- if final PR -> "needs review"

If you're an external contributor, you can ignore this text.
-->
