### PR TITLE
fix T2B1 display orientation south

### DIFF
--- a/core/.changelog.d/3990.fixed
+++ b/core/.changelog.d/3990.fixed
@@ -1,0 +1,1 @@
+[T2B1] Fix display orientation "south"

--- a/core/embed/trezorhal/stm32f4/displays/vg-2864ksweg01.c
+++ b/core/embed/trezorhal/stm32f4/displays/vg-2864ksweg01.c
@@ -255,8 +255,8 @@ static inline uint8_t reverse_byte(uint8_t b) {
 static void rotate_oled_buffer(void) {
   for (int i = 0; i < OLED_BUFSIZE / 2; i++) {
     uint8_t b = OLED_BUFFER[i];
-    OLED_BUFFER[i] = reverse_byte(OLED_BUFFER[OLED_BUFSIZE - i]);
-    OLED_BUFFER[OLED_BUFSIZE - i] = reverse_byte(b);
+    OLED_BUFFER[i] = reverse_byte(OLED_BUFFER[OLED_BUFSIZE - i - 1]);
+    OLED_BUFFER[OLED_BUFSIZE - i - 1] = reverse_byte(b);
   }
 }
 


### PR DESCRIPTION
Fixes display orientation south on T2B1, fixes #3990 


<!--
If you are a core dev:

Don't forget to set up the fields:
- assign yourself
- set priority to same as original issue
- add PR to sprint
- if Draft -> "in progress"
- if final PR -> "needs review"

If you're an external contributor, you can ignore this text.
-->
