### PR TITLE
Consistent error handling

### DIFF
--- a/core/embed/boardloader/main.c
+++ b/core/embed/boardloader/main.c
@@ -112,7 +112,7 @@ BUFFER_SECTION uint32_t sdcard_buf[BOOTLOADER_IMAGE_MAXSIZE / sizeof(uint32_t)];
 
 #if defined USE_SD_CARD
 static uint32_t check_sdcard(void) {
-  if (sectrue != sdcard_power_on()) {
+  if (ts_error(sdcard_power_on())) {
     return 0;
   }
 
@@ -124,12 +124,12 @@ static uint32_t check_sdcard(void) {
 
   memzero(sdcard_buf, IMAGE_HEADER_SIZE);
 
-  const secbool read_status = sdcard_read_blocks(
+  const ts_t read_status = sdcard_read_blocks(
       sdcard_buf, 0, BOOTLOADER_IMAGE_MAXSIZE / SDCARD_BLOCK_SIZE);
 
   sdcard_power_off();
 
-  if (sectrue == read_status) {
+  if (ts_ok(read_status)) {
     const image_header *hdr =
         read_image_header((const uint8_t *)sdcard_buf, BOOTLOADER_IMAGE_MAGIC,
                           BOOTLOADER_IMAGE_MAXSIZE);

--- a/core/embed/extmod/modtrezorio/modtrezorio-fatfs.h
+++ b/core/embed/extmod/modtrezorio/modtrezorio-fatfs.h
@@ -95,7 +95,7 @@ DSTATUS disk_status(BYTE pdrv) {
 
 DRESULT disk_read(BYTE pdrv, BYTE *buff, LBA_t sector, UINT count) {
   (void)pdrv;
-  if (sectrue == sdcard_read_blocks((uint32_t *)buff, sector, count)) {
+  if (ts_ok(sdcard_read_blocks((uint32_t *)buff, sector, count))) {
     return RES_OK;
   } else {
     return RES_ERROR;
@@ -104,7 +104,7 @@ DRESULT disk_read(BYTE pdrv, BYTE *buff, LBA_t sector, UINT count) {
 
 DRESULT disk_write(BYTE pdrv, const BYTE *buff, LBA_t sector, UINT count) {
   (void)pdrv;
-  if (sectrue == sdcard_write_blocks((const uint32_t *)buff, sector, count)) {
+  if (ts_ok(sdcard_write_blocks((const uint32_t *)buff, sector, count))) {
     return RES_OK;
   } else {
     return RES_ERROR;

--- a/core/embed/extmod/modtrezorio/modtrezorio-sdcard.h
+++ b/core/embed/extmod/modtrezorio/modtrezorio-sdcard.h
@@ -43,7 +43,7 @@ STATIC MP_DEFINE_CONST_FUN_OBJ_0(mod_trezorio_sdcard_is_present_obj,
 ///     is no SD card inserted.
 ///     """
 STATIC mp_obj_t mod_trezorio_sdcard_power_on() {
-  if (sectrue != sdcard_power_on()) {
+  if (ts_error(sdcard_power_on())) {
     mp_raise_OSError(MP_EIO);
   }
   return mp_const_none;
@@ -84,8 +84,8 @@ STATIC mp_obj_t mod_trezorio_sdcard_read(mp_obj_t block_num, mp_obj_t buf) {
   uint32_t block = trezor_obj_get_uint(block_num);
   mp_buffer_info_t bufinfo = {0};
   mp_get_buffer_raise(buf, &bufinfo, MP_BUFFER_WRITE);
-  if (sectrue !=
-      sdcard_read_blocks(bufinfo.buf, block, bufinfo.len / SDCARD_BLOCK_SIZE)) {
+  if (ts_error(sdcard_read_blocks(bufinfo.buf, block,
+                                  bufinfo.len / SDCARD_BLOCK_SIZE))) {
     mp_raise_OSError(MP_EIO);
   }
   return mp_const_none;
@@ -103,8 +103,8 @@ STATIC mp_obj_t mod_trezorio_sdcard_write(mp_obj_t block_num, mp_obj_t buf) {
   uint32_t block = trezor_obj_get_uint(block_num);
   mp_buffer_info_t bufinfo = {0};
   mp_get_buffer_raise(buf, &bufinfo, MP_BUFFER_READ);
-  if (sectrue != sdcard_write_blocks(bufinfo.buf, block,
-                                     bufinfo.len / SDCARD_BLOCK_SIZE)) {
+  if (ts_error(sdcard_write_blocks(bufinfo.buf, block,
+                                   bufinfo.len / SDCARD_BLOCK_SIZE))) {
     mp_raise_OSError(MP_EIO);
   }
   return mp_const_none;

--- a/core/embed/lib/error_handling.c
+++ b/core/embed/lib/error_handling.c
@@ -31,6 +31,26 @@ void __attribute__((noreturn, used)) __stack_chk_fail(void) {
   error_shutdown("(SS)");
 }
 
+const char *ts_string(ts_t status) {
+  if (ts_eq(status, TS_OK)) {
+    return "OK";
+  } else if (ts_eq(status, TS_ERROR)) {
+    return "ERROR";
+  } else if (ts_eq(status, TS_ERROR_BUSY)) {
+    return "ERROR_BUSY";
+  } else if (ts_eq(status, TS_ERROR_TIMEOUT)) {
+    return "ERROR_TIMEOUT";
+  } else if (ts_eq(status, TS_ERROR_NOTINIT)) {
+    return "ERROR_NOTINIT";
+  } else if (ts_eq(status, TS_ERROR_ARG)) {
+    return "ERROR_ARG";
+  } else if (ts_eq(status, TS_ERROR_IO)) {
+    return "ERROR_IO";
+  } else {
+    return "UNKNOWN";
+  }
+}
+
 void __attribute__((noreturn))
 error_shutdown_ex(const char *title, const char *message, const char *footer) {
   system_exit_error(title, message, footer);

--- a/core/embed/lib/error_handling.h
+++ b/core/embed/lib/error_handling.h
@@ -20,6 +20,188 @@
 #ifndef LIB_ERROR_HANDLING_H
 #define LIB_ERROR_HANDLING_H
 
+#include <stdint.h>
+
+// Suppresses the intellisense error in VSCode
+#ifndef __FILE_NAME__
+#define __FILE_NAME__ __FILE__
+#endif
+
+// Status code type
+typedef struct {
+  // Do not access this field directly,
+  // use `ts_ok()` and `ts_error()` macros.
+  uint32_t code;
+} ts_t;
+
+// Build status code from any 16-bit value.
+//
+// Status codes are hardened against fault injections
+// by storing the same value in the upper 16 bits.
+#define TS_BUILD(code) ((const ts_t){(code) | ((code) << 16)})
+
+// OK status code (signalling success or no error)
+#define TS_OK TS_BUILD(0)
+
+// This offset ensures at lest 16bit hamming distance
+// between `TS_OK` and other status codes.
+#define TS_ERROR_OFFSET 0xFF00
+
+// Build error status code from any 8-bit value
+//
+// The code should be in range 0 to 255 to ensure
+// 16-bit hamming distance to `TS_OK`
+#define TS_ERROR_BUILD(code) TS_BUILD(TS_ERROR_OFFSET + (code))
+
+// Error status codes
+#define TS_ERROR TS_ERROR_BUILD(0)
+#define TS_ERROR_BUSY TS_ERROR_BUILD(1)
+#define TS_ERROR_TIMEOUT TS_ERROR_BUILD(2)
+#define TS_ERROR_NOTINIT TS_ERROR_BUILD(3)
+#define TS_ERROR_ARG TS_ERROR_BUILD(4)
+#define TS_ERROR_IO TS_ERROR_BUILD(5)
+
+// Extracts the status code integer value.
+#define ts_code(status) ((status).code)
+
+// Converts status code to 32-bit unsigned integer.
+#define ts_to_u32(status) ((status).code);
+
+// Converts 32-bit unsigned integer to status code.
+#define ts_from_u32(u32) ((const ts_t){u32})
+
+// Check status code consistency and returns its value.
+// If invalid status code is detected, it will call `__fatal_error()`.
+#define _ts_checked(status)                                          \
+  ({                                                                 \
+    ts_t _checked = (status);                                        \
+    if ((ts_code(_checked) & 0xFFFF) != (ts_code(_checked) >> 16)) { \
+      __fatal_error("ts check error", __FILE_NAME__, __LINE__);      \
+    }                                                                \
+    _checked;                                                        \
+  })
+
+// Returns `true` if status code is `TS_OK`
+#define ts_ok(status) (ts_code(_ts_checked(status)) == ts_code(TS_OK))
+
+// Returns `true` if status code is NOT `TS_OK`
+#define ts_error(status) (ts_code(_ts_checked(status)) != ts_code(TS_OK))
+
+// Returns `true` if both status codes are equal
+#define ts_eq(status1, status2) (ts_code(status1) == ts_code(status2))
+
+// Returns a string representation of the status code.
+//
+// TS_OK -> "OK"
+// TS_ERROR -> "ERROR"
+// ...
+const char *ts_string(ts_t status);
+
+// ----------------------------------------------------
+// TS_INIT, TS_RETURN and VERIFY_XXX() macros define
+// a simple error handling mechanism
+//
+// Example:
+//
+// ts_t my_function(int arg) {
+//   // initialize verify mechanism
+//   TS_INIT;
+//
+//   // check arguments
+//   TS_CHECK_ARG(arg > 0);
+//
+//   ts_t status;
+//
+//   // verify success
+//   status = some_function();
+//   TS_CHECK_OK(status);
+//
+//   // verify condition
+//   TS_CHECK(another_function() != 0, TS_ERROR_IO);
+//
+//  cleanup:
+//
+//   // clean up code comes here
+//
+//   TS_RETURN;
+// }
+
+// Declares a status variable and initializes it to `TS_OK`.
+// This variable is used to store the status
+#define TS_INIT __attribute__((unused)) ts_t __status = TS_OK;
+
+// Returns the current status.
+#define TS_RETURN return __status;
+
+// Jumps to `error` label if status is not `TS_OK`.
+#define TS_CHECK_OK(status)  \
+  do {                       \
+    ts_t _status = status;   \
+    if (ts_error(_status)) { \
+      __status = _status;    \
+      goto cleanup;          \
+    }                        \
+  } while (0)
+
+// Jumps to `error` label if the condition is not `true`.
+#define TS_CHECK(cond, status) \
+  do {                         \
+    if (!(cond)) {             \
+      __status = status;       \
+      goto cleanup;            \
+    }                          \
+  } while (0)
+
+// Jumps to `error` label if the condition is not `true`.
+// Sets the status to `TS_ERROR_ARG`.
+#define TS_CHECK_ARG(cond)     \
+  do {                         \
+    if (!(cond)) {             \
+      __status = TS_ERROR_ARG; \
+      goto cleanup;            \
+    }                          \
+  } while (0)
+
+// Jumps to `error` label if the condition is not `sectrue`.
+#define TS_CHECK_SEC(seccond, status) \
+  do {                                \
+    if ((seccond) != sectrue) {       \
+      __status = status;              \
+      goto cleanup;                   \
+    }                                 \
+  } while (0)
+
+// Do not use this function directly, use the `ensure()` macro instead.
+void __attribute__((noreturn))
+__fatal_error(const char *msg, const char *file, int line);
+
+// Ensures that status code is `TS_OK`.
+// If not, it shows an error message and shuts down the device.
+#define ensure_ok(status, msg)                     \
+  do {                                             \
+    if (!ts_ok(status)) {                          \
+      __fatal_error(msg, __FILE_NAME__, __LINE__); \
+    }                                              \
+  } while (0)
+
+// Ensures that condition is evaluated as `true`.
+// If not, it shows an error message and shuts down the device.
+#define ensure_true(cond, msg)                     \
+  do {                                             \
+    if (!(cond)) {                                 \
+      __fatal_error(msg, __FILE_NAME__, __LINE__); \
+    }                                              \
+  } while (0)
+
+// Ensures that condition is evaluated as `sectrue`.
+// If not, it shows an error message and shuts down the device.
+#define ensure(seccond, msg)                       \
+  do {                                             \
+    if ((seccond) != sectrue) {                    \
+      __fatal_error(msg, __FILE_NAME__, __LINE__); \
+    }                                              \
+  } while (0)
+
 // Shows an error message and shuts down the device.
 //
 // If the title is NULL, it will be set to "INTERNAL ERROR".
@@ -32,15 +214,6 @@ error_shutdown_ex(const char *title, const char *message, const char *footer);
 //
 // Same as `error_shutdown_ex()` but with a default header and footer.
 void __attribute__((noreturn)) error_shutdown(const char *message);
-
-// Do not use this function directly, use the `ensure()` macro instead.
-void __attribute__((noreturn))
-__fatal_error(const char *msg, const char *file, int line);
-
-// Checks for an expression and if it is false, shows an error message
-// and shuts down the device.
-#define ensure(expr, msg) \
-  (((expr) == sectrue) ? (void)0 : __fatal_error(msg, __FILE_NAME__, __LINE__))
 
 // Shows WIPE CODE ENTERED screeen and shuts down the device.
 void __attribute__((noreturn)) show_wipe_code_screen(void);

--- a/core/embed/prodtest/main.c
+++ b/core/embed/prodtest/main.c
@@ -653,7 +653,7 @@ static void test_haptic(const char *args) {
     return;
   }
 
-  if (haptic_test(duration_ms)) {
+  if (ts_ok(haptic_test(duration_ms))) {
     vcp_println("OK");
 
   } else {

--- a/core/embed/prodtest/main.c
+++ b/core/embed/prodtest/main.c
@@ -556,11 +556,11 @@ static void test_sd(void) {
   low_speed = true;
 #endif
 
-  if (sectrue != sdcard_power_on_unchecked(low_speed)) {
+  if (ts_error(sdcard_power_on_unchecked(low_speed))) {
     vcp_println("ERROR POWER ON");
     return;
   }
-  if (sectrue != sdcard_read_blocks(buf1, 0, BLOCK_SIZE / SDCARD_BLOCK_SIZE)) {
+  if (ts_error(sdcard_read_blocks(buf1, 0, BLOCK_SIZE / SDCARD_BLOCK_SIZE))) {
     vcp_println("ERROR sdcard_read_blocks (0)");
     goto power_off;
   }
@@ -568,14 +568,13 @@ static void test_sd(void) {
     for (int i = 0; i < BLOCK_SIZE / sizeof(uint32_t); i++) {
       buf1[i] ^= 0xFFFFFFFF;
     }
-    if (sectrue !=
-        sdcard_write_blocks(buf1, 0, BLOCK_SIZE / SDCARD_BLOCK_SIZE)) {
+    if (ts_error(
+            sdcard_write_blocks(buf1, 0, BLOCK_SIZE / SDCARD_BLOCK_SIZE))) {
       vcp_println("ERROR sdcard_write_blocks (%d)", j);
       goto power_off;
     }
     HAL_Delay(1000);
-    if (sectrue !=
-        sdcard_read_blocks(buf2, 0, BLOCK_SIZE / SDCARD_BLOCK_SIZE)) {
+    if (ts_error(sdcard_read_blocks(buf2, 0, BLOCK_SIZE / SDCARD_BLOCK_SIZE))) {
       vcp_println("ERROR sdcard_read_blocks (%d)", j);
       goto power_off;
     }

--- a/core/embed/reflash/main.c
+++ b/core/embed/reflash/main.c
@@ -59,8 +59,8 @@ static void flash_from_sdcard(const flash_area_t *area, uint32_t source,
   for (uint32_t i = 0; i < length / SDCARD_BLOCK_SIZE; i++) {
     term_printf("read %d\n", (unsigned int)(i + source / SDCARD_BLOCK_SIZE));
 
-    ensure(sdcard_read_blocks(buf, i + source / SDCARD_BLOCK_SIZE, 1),
-           "sdcard_read_blocks");
+    ensure_ok(sdcard_read_blocks(buf, i + source / SDCARD_BLOCK_SIZE, 1),
+              "sdcard_read_blocks");
 
     for (uint32_t j = 0; j < SDCARD_BLOCK_SIZE / FLASH_BLOCK_SIZE; j++) {
       ensure(flash_area_write_block(
@@ -99,7 +99,7 @@ int main(void) {
 
   ensure(flash_unlock_write(), NULL);
 
-  ensure(sdcard_power_on(), NULL);
+  ensure_ok(sdcard_power_on(), NULL);
 
 #define BOARDLOADER_CHUNK_SIZE (16 * 1024)
 #define BOARDLOADER_TOTAL_SIZE (3 * BOARDLOADER_CHUNK_SIZE)

--- a/core/embed/trezorhal/haptic.h
+++ b/core/embed/trezorhal/haptic.h
@@ -23,6 +23,8 @@
 #include <stdbool.h>
 #include <stdint.h>
 
+#include "error_handling.h"
+
 typedef enum {
   // Effect at the start of a button press
   HAPTIC_BUTTON_PRESS = 0,
@@ -37,8 +39,8 @@ typedef enum {
 // The function initializes the GPIO pins and the hardware
 // peripherals used by the haptic driver.
 //
-// Returns `true` if the initialization was successful.
-bool haptic_init(void);
+// Returns `TS_OK` if the initialization was successful.
+ts_t haptic_init(void);
 
 // Deinitializes the haptic driver
 //
@@ -54,7 +56,7 @@ void haptic_deinit(void);
 // and potentially can put the controller into a low-power mode.
 //
 // The driver is enabled by default (after initialization).
-void haptic_set_enabled(bool enabled);
+ts_t haptic_set_enabled(bool enabled);
 
 // Returns `true` if haptic driver is enabled
 bool haptic_get_enabled(void);
@@ -64,16 +66,16 @@ bool haptic_get_enabled(void);
 // This function is used during production testing to verify that the haptic
 // motor is working correctly.
 //
-// Returns `true` if the test effect was successfully started.
-bool haptic_test(uint16_t duration_ms);
+// Returns `TS_OK` if the test effect was successfully started.
+ts_t haptic_test(uint16_t duration_ms);
 
 // Plays one of haptic effects
 //
 // The function stops playing any currently running effect and
 // starts playing the specified effect.
 //
-// Returns `true` if the effect was successfully started.
-bool haptic_play(haptic_effect_t effect);
+// Returns `TS_OK` if the effect was successfully started.
+ts_t haptic_play(haptic_effect_t effect);
 
 // Starts the haptic motor with a specified amplitude (in percent) for a
 // specified duration (in milliseconds).
@@ -85,7 +87,7 @@ bool haptic_play(haptic_effect_t effect);
 // (`duration_ms`) to modify the amplitude dynamically, allowing
 // the creation of customized haptic effects.
 //
-// Returns `true` if the effect was successfully started.
-bool haptic_play_custom(int8_t amplitude_pct, uint16_t duration_ms);
+// Returns `TS_OK` if the effect was successfully started.
+ts_t haptic_play_custom(int8_t amplitude_pct, uint16_t duration_ms);
 
 #endif  // TREZORHAL_HAPTIC_H

--- a/core/embed/trezorhal/sdcard.h
+++ b/core/embed/trezorhal/sdcard.h
@@ -43,11 +43,13 @@
  * THE SOFTWARE.
  */
 
-#ifndef __TREZORHAL_SDCARD_H__
-#define __TREZORHAL_SDCARD_H__
+#ifndef TREZORHAL_SDCARD_H
+#define TREZORHAL_SDCARD_H
 
 #include <stdbool.h>
 #include "secbool.h"
+
+#include "error_handling.h"
 
 // this is a fixed size and should not be changed
 #define SDCARD_BLOCK_SIZE (512)
@@ -55,17 +57,17 @@
 #ifdef KERNEL_MODE
 
 void sdcard_init(void);
-secbool __wur sdcard_power_on_unchecked(bool low_speed);
 
-#endif
+#endif  // KERNEL_MODE
 
-secbool __wur sdcard_power_on(void);
+ts_t __wur sdcard_power_on_unchecked(bool low_speed);
+ts_t __wur sdcard_power_on(void);
 void sdcard_power_off(void);
 secbool __wur sdcard_is_present(void);
 uint64_t sdcard_get_capacity_in_bytes(void);
-secbool __wur sdcard_read_blocks(uint32_t *dest, uint32_t block_num,
-                                 uint32_t num_blocks);
-secbool __wur sdcard_write_blocks(const uint32_t *src, uint32_t block_num,
-                                  uint32_t num_blocks);
+ts_t __wur sdcard_read_blocks(uint32_t *dest, uint32_t block_num,
+                              uint32_t num_blocks);
+ts_t __wur sdcard_write_blocks(const uint32_t *src, uint32_t block_num,
+                               uint32_t num_blocks);
 
-#endif
+#endif  // TREZORHAL_SDCARD_H

--- a/core/embed/trezorhal/stm32f4/platform.h
+++ b/core/embed/trezorhal/stm32f4/platform.h
@@ -17,11 +17,13 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-#ifndef TREZORHAL_STM32_H
-#define TREZORHAL_STM32_H
+#ifndef TREZORHAL_PLATFORM_H
+#define TREZORHAL_PLATFORM_H
+
+#include <stdint.h>
 
 #include STM32_HAL_H
-#include <stdint.h>
+#include "error_handling.h"
 
 typedef enum {
   CLOCK_180_MHZ = 0,
@@ -39,4 +41,20 @@ void clear_otg_hs_memory(void);
 
 extern uint32_t __stack_chk_guard;
 
-#endif  // TREZORHAL_STM32_H
+// HAL status code helpers
+static inline ts_t hal_status_to_ts(HAL_StatusTypeDef hal_status) {
+  switch (hal_status) {
+    case HAL_OK:
+      return TS_OK;
+    case HAL_BUSY:
+      return TS_ERROR_BUSY;
+    case HAL_TIMEOUT:
+      return TS_ERROR_TIMEOUT;
+    default:
+      return TS_ERROR;
+  }
+}
+
+#define TS_CHECK_HAL_OK(status) TS_CHECK_OK(hal_status_to_ts(status))
+
+#endif  // TREZORHAL_PLATFORM_H

--- a/core/embed/trezorhal/stm32f4/syscall_dispatch.c
+++ b/core/embed/trezorhal/stm32f4/syscall_dispatch.c
@@ -336,13 +336,13 @@ __attribute((no_stack_protector)) void syscall_handler(uint32_t *args,
       args[0] = haptic_get_enabled();
     } break;
     case SYSCALL_HAPTIC_TEST: {
-      args[0] = haptic_test(args[0]);
+      args[0] = ts_to_u32(haptic_test(args[0]));
     } break;
     case SYSCALL_HAPTIC_PLAY: {
-      args[0] = haptic_play(args[0]);
+      args[0] = ts_to_u32(haptic_play(args[0]));
     } break;
     case SYSCALL_HAPTIC_PLAY_CUSTOM: {
-      args[0] = haptic_play_custom(args[0], args[1]);
+      args[0] = ts_to_u32(haptic_play_custom(args[0], args[1]));
     } break;
 #endif
 

--- a/core/embed/trezorhal/stm32f4/syscall_dispatch.c
+++ b/core/embed/trezorhal/stm32f4/syscall_dispatch.c
@@ -274,7 +274,7 @@ __attribute((no_stack_protector)) void syscall_handler(uint32_t *args,
     } break;
 #ifdef USE_SD_CARD
     case SYSCALL_SDCARD_POWER_ON: {
-      args[0] = sdcard_power_on();
+      args[0] = ts_to_u32(sdcard_power_on());
     } break;
     case SYSCALL_SDCARD_POWER_OFF: {
       sdcard_power_off();
@@ -286,11 +286,12 @@ __attribute((no_stack_protector)) void syscall_handler(uint32_t *args,
       args[0] = sdcard_get_capacity_in_bytes();
     } break;
     case SYSCALL_SDCARD_READ_BLOCKS: {
-      args[0] = sdcard_read_blocks((uint32_t *)args[0], args[1], args[2]);
+      args[0] =
+          ts_to_u32(sdcard_read_blocks((uint32_t *)args[0], args[1], args[2]));
     } break;
     case SYSCALL_SDCARD_WRITE_BLOCKS: {
-      args[0] =
-          sdcard_write_blocks((const uint32_t *)args[0], args[1], args[2]);
+      args[0] = ts_to_u32(
+          sdcard_write_blocks((const uint32_t *)args[0], args[1], args[2]));
     } break;
 #endif
 

--- a/core/embed/trezorhal/stm32f4/syscall_stubs.c
+++ b/core/embed/trezorhal/stm32f4/syscall_stubs.c
@@ -333,8 +333,8 @@ int usb_webusb_write_blocking(uint8_t iface_num, const uint8_t *buf,
 
 #include "sdcard.h"
 
-secbool sdcard_power_on(void) {
-  return (secbool)syscall_invoke0(SYSCALL_SDCARD_POWER_ON);
+ts_t sdcard_power_on(void) {
+  return ts_from_u32(syscall_invoke0(SYSCALL_SDCARD_POWER_ON));
 }
 
 void sdcard_power_off(void) { syscall_invoke0(SYSCALL_SDCARD_POWER_OFF); }
@@ -347,16 +347,16 @@ uint64_t sdcard_get_capacity_in_bytes(void) {
   return syscall_invoke0_ret64(SYSCALL_SDCARD_GET_CAPACITY);
 }
 
-secbool __wur sdcard_read_blocks(uint32_t *dest, uint32_t block_num,
-                                 uint32_t num_blocks) {
-  return (secbool)syscall_invoke3((uint32_t)dest, block_num, num_blocks,
-                                  SYSCALL_SDCARD_READ_BLOCKS);
+ts_t __wur sdcard_read_blocks(uint32_t *dest, uint32_t block_num,
+                              uint32_t num_blocks) {
+  return ts_from_u32(syscall_invoke3((uint32_t)dest, block_num, num_blocks,
+                                     SYSCALL_SDCARD_READ_BLOCKS));
 }
 
-secbool __wur sdcard_write_blocks(const uint32_t *src, uint32_t block_num,
-                                  uint32_t num_blocks) {
-  return (secbool)syscall_invoke3((uint32_t)src, block_num, num_blocks,
-                                  SYSCALL_SDCARD_WRITE_BLOCKS);
+ts_t __wur sdcard_write_blocks(const uint32_t *src, uint32_t block_num,
+                               uint32_t num_blocks) {
+  return ts_from_u32(syscall_invoke3((uint32_t)src, block_num, num_blocks,
+                                     SYSCALL_SDCARD_WRITE_BLOCKS));
 }
 
 // =============================================================================

--- a/core/embed/trezorhal/stm32f4/syscall_stubs.c
+++ b/core/embed/trezorhal/stm32f4/syscall_stubs.c
@@ -421,25 +421,26 @@ uint32_t touch_get_event(void) {
 
 #include "haptic.h"
 
-void haptic_set_enabled(bool enabled) {
-  syscall_invoke1((uint32_t)enabled, SYSCALL_HAPTIC_SET_ENABLED);
+ts_t haptic_set_enabled(bool enabled) {
+  return ts_from_u32(
+      syscall_invoke1((uint32_t)enabled, SYSCALL_HAPTIC_SET_ENABLED));
 }
 
 bool haptic_get_enabled(void) {
   return (bool)syscall_invoke0(SYSCALL_HAPTIC_GET_ENABLED);
 }
 
-bool haptic_test(uint16_t duration_ms) {
-  return (bool)syscall_invoke1(duration_ms, SYSCALL_HAPTIC_TEST);
+ts_t haptic_test(uint16_t duration_ms) {
+  return ts_from_u32(syscall_invoke1(duration_ms, SYSCALL_HAPTIC_TEST));
 }
 
-bool haptic_play(haptic_effect_t effect) {
-  return (bool)syscall_invoke1((uint32_t)effect, SYSCALL_HAPTIC_PLAY);
+ts_t haptic_play(haptic_effect_t effect) {
+  return ts_from_u32(syscall_invoke1((uint32_t)effect, SYSCALL_HAPTIC_PLAY));
 }
 
-bool haptic_play_custom(int8_t amplitude_pct, uint16_t duration_ms) {
-  return (bool)syscall_invoke2((uint32_t)amplitude_pct, duration_ms,
-                               SYSCALL_HAPTIC_PLAY_CUSTOM);
+ts_t haptic_play_custom(int8_t amplitude_pct, uint16_t duration_ms) {
+  return ts_from_u32(syscall_invoke2((uint32_t)amplitude_pct, duration_ms,
+                                     SYSCALL_HAPTIC_PLAY_CUSTOM));
 }
 
 // =============================================================================

--- a/core/embed/trezorhal/stm32u5/platform.h
+++ b/core/embed/trezorhal/stm32u5/platform.h
@@ -17,11 +17,13 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-#ifndef TREZORHAL_STM32_H
-#define TREZORHAL_STM32_H
+#ifndef TREZORHAL_PLATFORM_H
+#define TREZORHAL_PLATFORM_H
+
+#include <stdint.h>
 
 #include STM32_HAL_H
-#include <stdint.h>
+#include "error_handling.h"
 
 #define FLASH_QUADWORD_WORDS (4)
 #define FLASH_QUADWORD_SIZE (FLASH_QUADWORD_WORDS * sizeof(uint32_t))
@@ -44,4 +46,20 @@ extern uint32_t __stack_chk_guard;
 
 void check_oem_keys(void);
 
-#endif  // TREZORHAL_STM32_H
+// HAL status code helpers
+static inline ts_t hal_status_to_ts(HAL_StatusTypeDef hal_status) {
+  switch (hal_status) {
+    case HAL_OK:
+      return TS_OK;
+    case HAL_BUSY:
+      return TS_ERROR_BUSY;
+    case HAL_TIMEOUT:
+      return TS_ERROR_TIMEOUT;
+    default:
+      return TS_ERROR;
+  }
+}
+
+#define TS_CHECK_HAL_OK(status) TS_CHECK_OK(hal_status_to_ts(status))
+
+#endif  // TREZORHAL_PLATFORM_H

--- a/core/embed/trezorhal/stm32u5/sdcard.c
+++ b/core/embed/trezorhal/stm32u5/sdcard.c
@@ -43,13 +43,13 @@
  * THE SOFTWARE.
  */
 
-#include STM32_HAL_H
 #include TREZOR_BOARD
 
 #include <string.h>
 
 #include "irq.h"
 #include "mpu.h"
+#include "platform.h"
 #include "sdcard.h"
 
 #define SDMMC_CLK_ENABLE() __HAL_RCC_SDMMC1_CLK_ENABLE()
@@ -154,10 +154,11 @@ void HAL_SD_MspDeInit(SD_HandleTypeDef *hsd) {
   }
 }
 
-secbool sdcard_power_on_unchecked(bool low_speed) {
-  if (sd_handle.Instance) {
-    return sectrue;
-  }
+ts_t sdcard_power_on_unchecked(bool low_speed) {
+  TS_INIT;
+
+  TS_CHECK(!sd_handle.Instance, TS_ERROR_BUSY);
+
   // turn on SD card circuitry
   sdcard_active_pin_state();
   HAL_Delay(50);
@@ -172,42 +173,45 @@ secbool sdcard_power_on_unchecked(bool low_speed) {
 
   // init the SD interface, with retry if it's not ready yet
   for (int retry = 10; HAL_SD_Init(&sd_handle) != HAL_OK; retry--) {
-    if (retry == 0) {
-      goto error;
-    }
+    TS_CHECK(retry > 0, TS_ERROR_IO);
     HAL_Delay(50);
   }
+
+  uint32_t sdmmc_status;
 
   // disable the card's internal CD/DAT3 card detect pull-up resistor
   // to send ACMD42, we have to send CMD55 (APP_CMD) with the card's RCA as
   // the argument followed by CMD42 (SET_CLR_CARD_DETECT)
-  if (SDMMC_CmdAppCommand(sd_handle.Instance, sd_handle.SdCard.RelCardAdd
-                                                  << 16U) != SDMMC_ERROR_NONE) {
-    goto error;
-  }
-  if (SDMMC_CmdSetClrCardDetect(sd_handle.Instance, 0) != SDMMC_ERROR_NONE) {
-    goto error;
-  }
+  sdmmc_status = SDMMC_CmdAppCommand(sd_handle.Instance,
+                                     sd_handle.SdCard.RelCardAdd << 16U);
+  TS_CHECK(sdmmc_status != SDMMC_ERROR_NONE, TS_ERROR_IO);
+
+  sdmmc_status = SDMMC_CmdSetClrCardDetect(sd_handle.Instance, 0);
+  TS_CHECK(sdmmc_status != SDMMC_ERROR_NONE, TS_ERROR_IO);
+
+  HAL_StatusTypeDef hal_status;
 
   // configure the SD bus width for wide operation
-  if (HAL_SD_ConfigWideBusOperation(&sd_handle, SDMMC_BUS_WIDE_4B) != HAL_OK) {
-    HAL_SD_DeInit(&sd_handle);
-    goto error;
-  }
+  hal_status = HAL_SD_ConfigWideBusOperation(&sd_handle, SDMMC_BUS_WIDE_4B);
+  TS_CHECK_HAL_OK(hal_status);
 
-  return sectrue;
+  TS_RETURN;
 
-error:
+cleanup:
   sdcard_power_off();
-  return secfalse;
+  TS_RETURN;
 }
 
-secbool sdcard_power_on(void) {
-  if (sectrue != sdcard_is_present()) {
-    return secfalse;
-  }
+ts_t sdcard_power_on(void) {
+  TS_INIT;
 
-  return sdcard_power_on_unchecked(false);
+  TS_CHECK_SEC(sdcard_is_present(), TS_ERROR_IO);
+
+  ts_t status = sdcard_power_on_unchecked(false);
+  TS_CHECK_OK(status);
+
+cleanup:
+  TS_RETURN;
 }
 
 void sdcard_power_off(void) {
@@ -255,8 +259,7 @@ static void sdcard_reset_periph(void) {
   SDMMC1->ICR = SDMMC_STATIC_FLAGS;
 }
 
-static HAL_StatusTypeDef sdcard_wait_finished(SD_HandleTypeDef *sd,
-                                              uint32_t timeout) {
+static ts_t sdcard_wait_finished(SD_HandleTypeDef *sd, uint32_t timeout) {
   // Wait for HAL driver to be ready (eg for DMA to finish)
   uint32_t start = HAL_GetTick();
   for (;;) {
@@ -269,7 +272,7 @@ static HAL_StatusTypeDef sdcard_wait_finished(SD_HandleTypeDef *sd,
     __WFI();
     irq_unlock(irq_key);
     if (HAL_GetTick() - start >= timeout) {
-      return HAL_TIMEOUT;
+      return TS_ERROR_TIMEOUT;
     }
   }
 
@@ -277,66 +280,64 @@ static HAL_StatusTypeDef sdcard_wait_finished(SD_HandleTypeDef *sd,
   for (;;) {
     HAL_SD_CardStateTypeDef state = HAL_SD_GetCardState(sd);
     if (state == HAL_SD_CARD_TRANSFER) {
-      return HAL_OK;
+      return TS_OK;
     }
     if (!(state == HAL_SD_CARD_SENDING || state == HAL_SD_CARD_RECEIVING ||
           state == HAL_SD_CARD_PROGRAMMING)) {
-      return HAL_ERROR;
+      return TS_ERROR_IO;
     }
     if (HAL_GetTick() - start >= timeout) {
-      return HAL_TIMEOUT;
+      return TS_ERROR_TIMEOUT;
     }
     __WFI();
   }
-  return HAL_OK;
+  return TS_OK;
 }
 
-secbool sdcard_read_blocks(uint32_t *dest, uint32_t block_num,
-                           uint32_t num_blocks) {
+ts_t sdcard_read_blocks(uint32_t *dest, uint32_t block_num,
+                        uint32_t num_blocks) {
+  TS_INIT;
+
   // check that SD card is initialised
-  if (sd_handle.Instance == NULL) {
-    return secfalse;
-  }
+  TS_CHECK(sd_handle.Instance == NULL, TS_ERROR_BUSY);
 
   // check that dest pointer is aligned on a 4-byte boundary
-  if (((uint32_t)dest & 3) != 0) {
-    return secfalse;
-  }
-
-  HAL_StatusTypeDef err = HAL_OK;
+  TS_CHECK_ARG(((uint32_t)dest & 3) == 0);
 
   sdcard_reset_periph();
-  err =
-      HAL_SD_ReadBlocks_DMA(&sd_handle, (uint8_t *)dest, block_num, num_blocks);
-  if (err == HAL_OK) {
-    err = sdcard_wait_finished(&sd_handle, 5000);
-  }
 
-  return sectrue * (err == HAL_OK);
+  HAL_StatusTypeDef hal_status =
+      HAL_SD_ReadBlocks_DMA(&sd_handle, (uint8_t *)dest, block_num, num_blocks);
+  TS_CHECK_HAL_OK(hal_status);
+
+  ts_t status = sdcard_wait_finished(&sd_handle, 5000);
+  TS_CHECK_OK(status);
+
+cleanup:
+  TS_RETURN;
 }
 
-secbool sdcard_write_blocks(const uint32_t *src, uint32_t block_num,
-                            uint32_t num_blocks) {
+ts_t sdcard_write_blocks(const uint32_t *src, uint32_t block_num,
+                         uint32_t num_blocks) {
+  TS_INIT;
+
   // check that SD card is initialised
-  if (sd_handle.Instance == NULL) {
-    return secfalse;
-  }
+  TS_CHECK(sd_handle.Instance == NULL, TS_ERROR_BUSY);
 
   // check that src pointer is aligned on a 4-byte boundary
-  if (((uint32_t)src & 3) != 0) {
-    return secfalse;
-  }
-
-  HAL_StatusTypeDef err = HAL_OK;
+  TS_CHECK_ARG(((uint32_t)src & 3) == 0);
 
   sdcard_reset_periph();
-  err =
-      HAL_SD_WriteBlocks_DMA(&sd_handle, (uint8_t *)src, block_num, num_blocks);
-  if (err == HAL_OK) {
-    err = sdcard_wait_finished(&sd_handle, 5000);
-  }
 
-  return sectrue * (err == HAL_OK);
+  HAL_StatusTypeDef hal_status =
+      HAL_SD_WriteBlocks_DMA(&sd_handle, (uint8_t *)src, block_num, num_blocks);
+  TS_CHECK_HAL_OK(hal_status);
+
+  ts_t status = sdcard_wait_finished(&sd_handle, 5000);
+  TS_CHECK_OK(status);
+
+cleanup:
+  TS_RETURN;
 }
 
 #endif  // KERNEL_MODE


### PR DESCRIPTION
This PR proposes a consistent approach to error handling in the C codebase. The proposal includes the following:

1. Introduction of system-wide error codes (`ts_t` type) with predefined errors prefixed with `TS_` (Trezor status) and built-in fault injection hardening.
2. A straightforward mechanism/framework for error handling within functions, utilizing `goto` statements to facilitate cleanup at the end of the function.
3. Addition of new `ensure()` macro types to simplify top-level code.
4. Simplification of STM32 HAL error handling with the `hal_status_to_ts()` mapping function and the `TS_CHECK_HAL_OK()` macro.

This PR consists of three commits. Two of them serve as examples: a refactored haptic driver and a refactored SD card driver.

Error handling pattern:

```c
ts_t module_function(int arg1, int arg2) {
  // Initialize the `__status` variable and set it to `TS_OK`.
  // This should be on the first line inside the function (rule 1).
  TS_INIT; 

  // Check arguments to ensure they are greater than 0.
  TS_CHECK_ARG(arg1 > 0);
  TS_CHECK_ARG(arg2 > 0);
  
  // Check the result of another function with a `ts_t` return value.
  // The `status` value is properly propagated.
  // Splitting it into two lines makes debugging easier (rule 2).
  ts_t status = another_function();
  TS_CHECK_OK(status);
  
  // Check the result of an STM32 HAL function returning `HAL_StatusTypeDef`.
  // The HAL_xxx error is properly mapped to TS_xxx and propagated.
  HAL_StatusTypeDef hal_status = HAL_function();
  TS_CHECK_HAL_OK(hal_status);
  
  // Check a generic condition inside the function and propagate the status code
  // if the condition is not fulfilled.
  TS_CHECK(arg1 * arg2 < 1000, TS_ERROR);

  // Alternatively, use the secure variant working with `secbool`.
  secbool ready = usb_ready();
  TS_CHECK_SEC(ready);
  
  // In some cases it's useful to return before the cleanup code, (rule 3: never use `return ...` directly)
  // TS_RETURN;
  
cleanup:
  // Potential cleanup code goes here.
  // ...

  // Return the content of the `__status` variable.
  // In case of no error, it's `TS_OK`.
  TS_RETURN;
}
``` 
We can now use the `ensure_xxx()` set of macros similar to `verify_xxx()` for handling fatal errors. The `ensure_xxx()` macros display an error message on the screen and shut down the device as before. (Note: This feature is not yet complete in this PR.)

```c
  // The generic condition must be `true`
  //  TS_CHECK(condition, ts_t) ->  
  ensure(condition, message);

  // Status must be `TS_OK`
  // TS_CHECK_OK(status) -> 
  ensure_ok(status, message);

  // The generic condition (secbool) must be `sectrue`
  // TS_CHECK_SEC(secbool, status) -> 
  ensure_sec(secbool, message);
 ```
I understand that this is a completely new approach, which is not very common and requires some time to get used to. However, it is very simple and quickly understandable. I will not merge this until we reach a consensus that this is the right approach. Please feel free to provide any comments or suggestions.

