### PR TITLE
Fix broken coverage reporting

### DIFF
--- a/core/embed/bootloader/emulator.c
+++ b/core/embed/bootloader/emulator.c
@@ -22,6 +22,9 @@ uint8_t *FIRMWARE_START = 0;
 
 void set_core_clock(int) {}
 
+// used in fw emulator to raise python exception on exit
+void __attribute__((noreturn)) main_clean_exit() { exit(3); }
+
 int bootloader_main(void);
 
 // assuming storage is single subarea

--- a/core/embed/trezorhal/unix/common.c
+++ b/core/embed/trezorhal/unix/common.c
@@ -28,6 +28,8 @@
 #include "display.h"
 #include "memzero.h"
 
+void __attribute__((noreturn)) main_clean_exit();
+
 void __attribute__((noreturn)) trezor_shutdown(void) {
   printf("SHUTDOWN\n");
 
@@ -49,7 +51,7 @@ uint32_t hal_ticks_ms() {
 static int SDLCALL emulator_event_filter(void *userdata, SDL_Event *event) {
   switch (event->type) {
     case SDL_QUIT:
-      exit(3);
+      main_clean_exit();
       return 0;
     case SDL_KEYUP:
       if (event->key.repeat) {
@@ -57,7 +59,7 @@ static int SDLCALL emulator_event_filter(void *userdata, SDL_Event *event) {
       }
       switch (event->key.keysym.sym) {
         case SDLK_ESCAPE:
-          exit(3);
+          main_clean_exit();
           return 0;
         case SDLK_p:
           display_save("emu");


### PR DESCRIPTION
In 5fc3c6e617619eee14429d44ab6e064ed3f5801e the termination code was modified not to raise micropython SystemExit just before exit(). Unfortunately this is needed for test coverage reports as `prof.py` relies on this exception to write out coverage data.

This has not been caught by CI because the coverage jobs were failing intermittently for long enough time for everyone to learn to ignore them. Hopefully I'll fix this next.

<!--
If you are a core dev:

Don't forget to set up the fields:
- assign yourself
- set priority to same as original issue
- add PR to sprint
- if Draft -> "in progress"
- if final PR -> "needs review"

If you're an external contributor, you can ignore this text.
-->
