### PR TITLE
prefer vertical swipes over horizontal

### DIFF
--- a/core/.changelog.d/4060.fixed
+++ b/core/.changelog.d/4060.fixed
@@ -1,0 +1,1 @@
+[T3T1] Adjusted detection of swipes: vertical swipes are preferred over horizontal swipes


### PR DESCRIPTION
Adjusting the swipe detection in order to prefer vertical swipes over horizontal, as vertical swipes are more common operation vs. special cases like entering menu. This aims to improve reliability of swipes when swiping somewhat diagonally.



<!--
If you are a core dev:

Don't forget to set up the fields:
- assign yourself
- set priority to same as original issue
- add PR to sprint
- if Draft -> "in progress"
- if final PR -> "needs review"

If you're an external contributor, you can ignore this text.
-->
