### PR TITLE
add more thorough touch testing to prodtest

### DIFF
--- a/core/embed/prodtest/.changelog.d/3752.added
+++ b/core/embed/prodtest/.changelog.d/3752.added
@@ -1,0 +1,1 @@
+Added commands to read bootloader and boardloader versions

--- a/core/embed/prodtest/.changelog.d/4064.added
+++ b/core/embed/prodtest/.changelog.d/4064.added
@@ -1,0 +1,1 @@
+Added TOUCH_CUSTOM and TOUCH_IDLE commands

--- a/core/embed/prodtest/README.md
+++ b/core/embed/prodtest/README.md
@@ -282,6 +282,26 @@ FIRMWARE VERSION
 OK 0.2.6
 ```
 
+### BOOTLOADER VERSION
+Returns the version of the bootlaoder.
+The command returns `OK` followed by the version in the format `<major>.<minor>.<patch>`.
+
+Example:
+```
+BOOTLOADER_VERSION
+OK 2.1.7
+```
+
+### BOARDLOADER VERSION
+Returns the version of the boardloader.
+The command returns `OK` followed by the version in the format `<major>.<minor>.<patch>`.
+
+Example:
+```
+FIRMWARE VERSION
+OK 0.2.6
+```
+
 ### WIPE
 This command invalidates the current firmware in the flash memory by erasing its beginning, including metadata.
 After performing this operation, it displays the text "WIPED" on the screen and returns the response OK.

--- a/core/embed/prodtest/README.md
+++ b/core/embed/prodtest/README.md
@@ -88,7 +88,7 @@ OK
 ```
 
 ### TOUCH
-The `TOUCH` command test the functionality of the display's touch screen.
+The `TOUCH` command tests the functionality of the display's touch screen.
 It draws a filled rectangle in one of the four display quadrants and waits for user interaction.
 
 The command requires two input parameters:
@@ -104,6 +104,48 @@ Example (to draw a rectangle in the top-left quadrant and wait for 9 seconds for
 ```
 TOUCH 09
 OK 50 90
+```
+
+
+### TOUCH_CUSTOM
+The `TOUCH_CUSTOM` command tests the functionality of the display's touch screen.
+It draws a filled rectangle on custom coordinates and waits for user interaction.
+
+The command requires five input parameters:
+
+* X position of the top-left corner of the rectangle
+* Y position of the top-left corner of the rectangle
+* Width of the rectangle
+* Height of the rectangle
+* The timeout in seconds
+
+If the display is not touched within the specified timeout, the command will return an `ERROR TIMEOUT`.
+
+The device report touch events, coordinates and timestamps (in ms), correctness of the touch point is not checked and is left to the test equipment.
+
+The test ends with first lift-up event.
+
+Example (to draw a 100x100 rectangle in the top-left (10,10) position and wait for 15 seconds for touch input):
+```
+TOUCH_CUSTOM 10 10 100 100 15
+TOUCH D 69 35 357300
+TOUCH U 69 35 357328
+OK
+```
+
+### TOUCH_IDLE
+The `TOUCH_IDLE` command tests the functionality of the display's touch screen.
+It waits for a specific time period without any touch input.
+
+The command requires one input parameter:
+* The timeout in seconds
+
+If a touch activity is detected within the specified timeout, the command will return an `ERROR TOUCH DETECTED`.
+
+Example - wait ten seconds for no touch input:
+```
+TOUCH_IDLE 10
+OK
 ```
 
 ### SENS

--- a/core/embed/trezorhal/board_capabilities.h
+++ b/core/embed/trezorhal/board_capabilities.h
@@ -45,12 +45,12 @@ enum CapabilityTag {
   TAG_BOARDLOADER_VERSION = 0x03
 };
 
-struct __attribute__((packed)) BoardloaderVersion {
+typedef struct __attribute__((packed)) BoardloaderVersion {
   uint8_t version_major;
   uint8_t version_minor;
   uint8_t version_patch;
   uint8_t version_build;
-};
+} boardloader_version_t;
 
 /*
  * Structure of current boardloader. Older boardloaders can have it missing,
@@ -75,6 +75,6 @@ struct __attribute__((packed)) BoardCapabilities {
 void parse_boardloader_capabilities();
 
 const uint32_t get_board_name();
-const struct BoardloaderVersion* get_boardloader_version();
+const boardloader_version_t* get_boardloader_version();
 
 #endif

--- a/core/embed/trezorhal/stm32f4/board_capabilities.c
+++ b/core/embed/trezorhal/stm32f4/board_capabilities.c
@@ -28,7 +28,7 @@ static struct BoardloaderVersion boardloader_version;
 
 const uint32_t get_board_name() { return board_name; }
 
-const struct BoardloaderVersion *get_boardloader_version() {
+const boardloader_version_t *get_boardloader_version() {
   return &boardloader_version;
 }
 


### PR DESCRIPTION
adding several new commands to prodtest.

TOUCH_CUSTOM - to show arbitrary rectangle and report touches
TOUCH_IDLE - to test that there are no touches
(using underscore to avoid conflicts due to startswith usage)

`BOOTLOADER VERSION` and `BOARDLOADER VERSION` with obvious purpose.


<!--
If you are a core dev:

Don't forget to set up the fields:
- assign yourself
- set priority to same as original issue
- add PR to sprint
- if Draft -> "in progress"
- if final PR -> "needs review"

If you're an external contributor, you can ignore this text.
-->
