### PR TITLE
Remove bias in ed25519.generate_secret()

### DIFF
--- a/core/embed/extmod/modtrezorcrypto/modtrezorcrypto-ed25519.h
+++ b/core/embed/extmod/modtrezorcrypto/modtrezorcrypto-ed25519.h
@@ -100,16 +100,16 @@ STATIC MP_DEFINE_CONST_FUN_OBJ_VAR_BETWEEN(mod_trezorcrypto_ed25519_sign_obj, 2,
 #if !BITCOIN_ONLY
 
 /// def sign_ext(
-///     secret_key: bytes, secret_extension: bytes, message: bytes
+///     secret_scalar: bytes, secret_extension: bytes, message: bytes
 /// ) -> bytes:
 ///     """
-///     Uses secret key to produce the cardano signature of message.
+///     Uses extended secret key to produce the cardano signature of message.
 ///     """
-STATIC mp_obj_t mod_trezorcrypto_ed25519_sign_ext(mp_obj_t secret_key,
+STATIC mp_obj_t mod_trezorcrypto_ed25519_sign_ext(mp_obj_t secret_scalar,
                                                   mp_obj_t secret_extension,
                                                   mp_obj_t message) {
   mp_buffer_info_t sk = {0}, skext = {0}, msg = {0};
-  mp_get_buffer_raise(secret_key, &sk, MP_BUFFER_READ);
+  mp_get_buffer_raise(secret_scalar, &sk, MP_BUFFER_READ);
   mp_get_buffer_raise(secret_extension, &skext, MP_BUFFER_READ);
   mp_get_buffer_raise(message, &msg, MP_BUFFER_READ);
   if (sk.len != 32) {

--- a/core/embed/extmod/modtrezorcrypto/modtrezorcrypto-ed25519.h
+++ b/core/embed/extmod/modtrezorcrypto/modtrezorcrypto-ed25519.h
@@ -34,10 +34,6 @@ STATIC mp_obj_t mod_trezorcrypto_ed25519_generate_secret() {
   vstr_t sk = {0};
   vstr_init_len(&sk, 32);
   random_buffer((uint8_t *)sk.buf, sk.len);
-  // taken from https://cr.yp.to/ecdh.html
-  sk.buf[0] &= 248;
-  sk.buf[31] &= 127;
-  sk.buf[31] |= 64;
   return mp_obj_new_str_from_vstr(&mp_type_bytes, &sk);
 }
 STATIC MP_DEFINE_CONST_FUN_OBJ_0(mod_trezorcrypto_ed25519_generate_secret_obj,

--- a/core/mocks/generated/trezorcrypto/ed25519.pyi
+++ b/core/mocks/generated/trezorcrypto/ed25519.pyi
@@ -24,10 +24,10 @@ def sign(secret_key: bytes, message: bytes, hasher: str = "") -> bytes:
 
 # extmod/modtrezorcrypto/modtrezorcrypto-ed25519.h
 def sign_ext(
-    secret_key: bytes, secret_extension: bytes, message: bytes
+    secret_scalar: bytes, secret_extension: bytes, message: bytes
 ) -> bytes:
     """
-    Uses secret key to produce the cardano signature of message.
+    Uses extended secret key to produce the cardano signature of message.
     """
 
 

--- a/core/tests/test_trezor.crypto.curve.ed25519.py
+++ b/core/tests/test_trezor.crypto.curve.ed25519.py
@@ -69,12 +69,6 @@ class TestCryptoEd25519(unittest.TestCase):
             )
             pass
 
-    def test_generate_secret(self):
-        for _ in range(100):
-            sk = ed25519.generate_secret()
-            self.assertTrue(len(sk) == 32)
-            self.assertTrue(sk[0] & 7 == 0 and sk[31] & 128 == 0 and sk[31] & 64 == 64)
-
     def test_sign_verify_random(self):
         for l in range(1, 300):
             sk = ed25519.generate_secret()

--- a/crypto/ed25519-donna/ed25519.c
+++ b/crypto/ed25519-donna/ed25519.c
@@ -101,23 +101,17 @@ ED25519_FN(ed25519_cosi_sign) (const unsigned char *m, size_t mlen, const ed2551
 }
 
 void
-ED25519_FN(ed25519_sign_ext) (const unsigned char *m, size_t mlen, const ed25519_secret_key sk, const ed25519_secret_key skext, ed25519_signature RS) {
+ED25519_FN(ed25519_sign_ext) (const unsigned char *m, size_t mlen, const ed25519_secret_key secret_scalar, const ed25519_secret_key skext, ed25519_signature RS) {
 	ed25519_hash_context ctx;
 	bignum256modm r = {0}, S = {0}, a = {0};
 	ge25519 ALIGN(16) R = {0};
 	ge25519 ALIGN(16) A = {0};
 	ed25519_public_key pk = {0};
-	hash_512bits extsk = {0}, hashr = {0}, hram = {0};
-
-	/* we don't stretch the key through hashing first since its already 64 bytes */
-
-	memcpy(extsk, sk, 32);
-	memcpy(extsk+32, skext, 32);
-
+	hash_512bits hashr = {0}, hram = {0};
 
 	/* r = H(aExt[32..64], m) */
 	ed25519_hash_init(&ctx);
-	ed25519_hash_update(&ctx, extsk + 32, 32);
+	ed25519_hash_update(&ctx, skext, 32);
 	ed25519_hash_update(&ctx, m, mlen);
 	ed25519_hash_final(&ctx, hashr);
 	expand256_modm(r, hashr, 64);
@@ -128,8 +122,7 @@ ED25519_FN(ed25519_sign_ext) (const unsigned char *m, size_t mlen, const ed25519
 	ge25519_pack(RS, &R);
 
 	/* a = aExt[0..31] */
-	expand256_modm(a, extsk, 32);
-	memzero(&extsk, sizeof(extsk));
+	expand256_modm(a, secret_scalar, 32);
 
 	/* A = aB */
 	ge25519_scalarmult_base_niels(&A, ge25519_niels_base_multiples, a);

--- a/crypto/ed25519-donna/ed25519.h
+++ b/crypto/ed25519-donna/ed25519.h
@@ -22,7 +22,7 @@ void ed25519_publickey_ext(const ed25519_secret_key extsk, ed25519_public_key pk
 
 int ed25519_sign_open(const unsigned char *m, size_t mlen, const ed25519_public_key pk, const ed25519_signature RS);
 void ed25519_sign(const unsigned char *m, size_t mlen, const ed25519_secret_key sk, ed25519_signature RS);
-void ed25519_sign_ext(const unsigned char *m, size_t mlen, const ed25519_secret_key sk, const ed25519_secret_key skext, ed25519_signature RS);
+void ed25519_sign_ext(const unsigned char *m, size_t mlen, const ed25519_secret_key secret_scalar, const ed25519_secret_key skext, ed25519_signature RS);
 
 int ed25519_scalarmult(ed25519_public_key res, const ed25519_secret_key sk, const ed25519_public_key pk);
 


### PR DESCRIPTION
The function `generate_secret()` from the `ed25519` Python module generates a random 256-bit key and then "clamps" it, i.e. sets the three least significant bits to 0 and the two most significant bits to 0 and 1. I believe that the clamping should not be applied here.

The functions `ed25519_publickey()`, `ed25519_sign()` and `ed25519_cosi_sign()` first hash the secret key and then apply the clamping on the first 256 bits of the hash. In other words, the rest of the module implementation assumes that it is working with an unclamped secret key. This means that clamping does not need to be applied during key generation and it technically violates the rules for generating Ed25519 keys:
> The private key is 32 octets (256 bits, corresponding to b) of cryptographically secure random data.

https://datatracker.ietf.org/doc/html/rfc8032#section-5.1.5

In my opinion it is confusing to apply clamping in `generate_secret()` because it gives the false impression that the module somehow works with the expanded private key. It also introduces a bias into the generated keys, which is, however, cryptographically insignificant.

There is one exception in the module. The function `ed25519_sign_ext()`, which is used only in Cardano, takes as input the expanded secret key as two parameters (`secret_key: bytes` and `secret_extension: bytes`). Since the secret key is already expanded, the function doesn't even clamp it. This might be intentional, because of the way Cardano uses BIP-32 derivation. This might be worth looking into and possibly adding some comment or adding the clamping operation to be on the safe side.

Note that `ed25519.generate_secret()` isn't actually used anywhere, so this PR does not change the firmware behavior. I assume that the function is included for completeness of the module.

History: The function was added in 9c921c073f.