### PR TITLE
feat(python): add pretty-printing of protobuf messages in IPython

### DIFF
--- a/python/.changelog.d/4076.added
+++ b/python/.changelog.d/4076.added
@@ -1,0 +1,1 @@
+Added pretty-printing of protobuf messages in IPython (`_repr_pretty_`)


### PR DESCRIPTION
This makes protobuf messages look much nicer in IPython:

Before:
<tt>In[5]: client.features
Out[5]:
<Features: {'vendor': 'trezor.io', 'major_version': 2, 'minor_version': 7, 'patch_version': 2, 'device_id': '[redacted]', 'pin_protection': True, 'language': 'en-US', 'label': '[redacted]', 'initialized': True, 'revision': b'\xdau\xd8\xf4\xb6t\x10\xb4\n\x9c\xfd)T\xd1\x83\xd8\x1d\xd6\xe8\xe8', 'unlocked': False, 'model': 'T', 'fw_vendor': 'SatoshiLabs', 'capabilities': [<Capability.Bitcoin: 1>, <Capability.Bitcoin_like: 2>, <Capability.Binance: 3>, <Capability.Cardano: 4>, <Capability.Crypto: 5>, <Capability.Ethereum: 7>, <Capability.Monero: 9>, <Capability.Ripple: 11>, <Capability.Stellar: 12>, <Capability.Tezos: 13>, <Capability.U2F: 14>, <Capability.Shamir: 15>, <Capability.ShamirGroups: 16>, <Capability.PassphraseEntry: 17>, <Capability.Solana: 18>, <Capability.Translations: 19>, <Capability.NEM: 10>, <Capability.EOS: 6>, <Capability.Brightness: 20>], 'sd_card_present': True, 'busy': False, 'homescreen_format': <HomescreenFormat.Jpeg: 2>, 'internal_model': 'T2T1', 'homescreen_width': 240, 'homescreen_height': 240, 'language_version_matches': True}>
</tt>

After:
```
In[5]: client.features
Out[5]:
<Features: {'vendor': 'trezor.io',
            'major_version': 2,
            'minor_version': 7,
            'patch_version': 2,
            'device_id': '[redacted]',
            'pin_protection': True,
            'language': 'en-US',
            'label': '[redacted]',
            'initialized': True,
            'revision': b'\xdau\xd8\xf4\xb6t\x10\xb4\n\x9c\xfd)T\xd1\x83\xd8\x1d\xd6\xe8\xe8',
            'unlocked': False,
            'model': 'T',
            'fw_vendor': 'SatoshiLabs',
            'capabilities': [<Capability.Bitcoin: 1>,
                             <Capability.Bitcoin_like: 2>,
                             <Capability.Binance: 3>,
                             <Capability.Cardano: 4>,
                             <Capability.Crypto: 5>,
                             <Capability.Ethereum: 7>,
                             <Capability.Monero: 9>,
                             <Capability.Ripple: 11>,
                             <Capability.Stellar: 12>,
                             <Capability.Tezos: 13>,
                             <Capability.U2F: 14>,
                             <Capability.Shamir: 15>,
                             <Capability.ShamirGroups: 16>,
                             <Capability.PassphraseEntry: 17>,
                             <Capability.Solana: 18>,
                             <Capability.Translations: 19>,
                             <Capability.NEM: 10>,
                             <Capability.EOS: 6>,
                             <Capability.Brightness: 20>],
            'sd_card_present': True,
            'busy': False,
            'homescreen_format': <HomescreenFormat.Jpeg: 2>,
            'internal_model': 'T2T1',
            'homescreen_width': 240,
            'homescreen_height': 240,
            'language_version_matches': True}>
```