### PR TITLE
fix dma2d compilation with new rendering

### DIFF
--- a/core/SConscript.bootloader_emu
+++ b/core/SConscript.bootloader_emu
@@ -158,7 +158,6 @@ SOURCE_TREZORHAL = [
 if NEW_RENDERING:
     SOURCE_TREZORHAL += [
         'embed/trezorhal/unix/display_driver.c',
-        'embed/trezorhal/unix/dma2d_bitblt.c',
         'embed/trezorhal/xdisplay_legacy.c',
     ]
 else:

--- a/core/embed/boardloader/main.c
+++ b/core/embed/boardloader/main.c
@@ -44,6 +44,14 @@
 #include "hash_processor.h"
 #endif
 
+#ifdef USE_DMA2D
+#ifdef NEW_RENDERING
+#include "dma2d_bitblt.h"
+#else
+#include "dma2d.h"
+#endif
+#endif
+
 #include "lowlevel.h"
 #include "model.h"
 #include "version.h"
@@ -279,6 +287,10 @@ int main(void) {
 
 #ifdef USE_HASH_PROCESSOR
   hash_processor_init();
+#endif
+
+#ifdef USE_DMA2D
+  dma2d_init();
 #endif
 
   display_init();

--- a/core/embed/bootloader/main.c
+++ b/core/embed/bootloader/main.c
@@ -35,7 +35,11 @@
 #include "secret.h"
 
 #ifdef USE_DMA2D
+#ifdef NEW_RENDERING
+#include "dma2d_bitblt.h"
+#else
 #include "dma2d.h"
+#endif
 #endif
 #ifdef USE_I2C
 #include "i2c.h"

--- a/core/embed/firmware/main.c
+++ b/core/embed/firmware/main.c
@@ -60,8 +60,13 @@
 #include "consumption_mask.h"
 #endif
 #ifdef USE_DMA2D
+#ifdef NEW_RENDERING
+#include "dma2d_bitblt.h"
+#else
 #include "dma2d.h"
 #endif
+#endif
+
 #ifdef USE_BUTTON
 #include "button.h"
 #endif

--- a/core/embed/lib/gfx_draw.c
+++ b/core/embed/lib/gfx_draw.c
@@ -91,8 +91,8 @@ static inline gfx_clip_t gfx_clip(gfx_rect_t dst, const gfx_bitmap_t* bitmap) {
 void gfx_clear(void) {
   gfx_bitblt_t bb = {
       // Destination bitmap
-      .height = DISPLAY_RESX,
-      .width = DISPLAY_RESY,
+      .height = DISPLAY_RESY,
+      .width = DISPLAY_RESX,
       .dst_row = NULL,
       .dst_x = 0,
       .dst_y = 0,

--- a/core/embed/trezorhal/dma2d_bitblt.h
+++ b/core/embed/trezorhal/dma2d_bitblt.h
@@ -22,6 +22,9 @@
 
 #include "gfx_bitblt.h"
 
+// Initializes DMA2D peripheral
+void dma2d_init(void);
+
 // Waits until any pending DMA2D operation is finished
 void dma2d_wait(void);
 

--- a/core/embed/trezorhal/stm32f4/dma2d_bitblt.c
+++ b/core/embed/trezorhal/stm32f4/dma2d_bitblt.c
@@ -40,6 +40,8 @@ static inline bool dma2d_accessible(const void* ptr) {
 #endif
 }
 
+void dma2d_init(void) { __HAL_RCC_DMA2D_CLK_ENABLE(); }
+
 void dma2d_wait(void) {
   while (HAL_DMA2D_PollForTransfer(&dma2d_handle, 10) != HAL_OK)
     ;

--- a/core/embed/trezorhal/unix/dma2d_bitblt.c
+++ b/core/embed/trezorhal/unix/dma2d_bitblt.c
@@ -19,4 +19,6 @@
 
 #include "dma2d_bitblt.h"
 
+void dma2d_init(void) {}
+
 void dma2d_wait(void) {}

--- a/core/site_scons/models/D001/discovery.py
+++ b/core/site_scons/models/D001/discovery.py
@@ -48,8 +48,11 @@ def configure(
         sources += [f"embed/trezorhal/stm32f4/displays/{display}"]
         sources += ["embed/trezorhal/stm32f4/displays/ili9341_spi.c"]
 
-    sources += ["embed/trezorhal/stm32f4/dma2d.c"]
-    sources += ["embed/trezorhal/stm32f4/dma2d_bitblt.c"]
+    if "new_rendering" in features_wanted:
+        sources += ["embed/trezorhal/stm32u5/dma2d_bitblt.c"]
+    else:
+        sources += ["embed/trezorhal/stm32u5/dma2d.c"]
+
     sources += [
         "vendor/micropython/lib/stm32lib/STM32F4xx_HAL_Driver/Src/stm32f4xx_hal_dma2d.c"
     ]

--- a/core/site_scons/models/D002/discovery2.py
+++ b/core/site_scons/models/D002/discovery2.py
@@ -92,10 +92,10 @@ def configure(
         features_available.append("usb")
 
     defines += ["USE_DMA2D", "FRAMEBUFFER", "FRAMEBUFFER32BIT", "UI_COLOR_32BIT"]
-    sources += [
-        "embed/trezorhal/stm32u5/dma2d.c",
-        "embed/trezorhal/stm32u5/dma2d_bitblt.c",
-    ]
+    if "new_rendering" in features_wanted:
+        sources += ["embed/trezorhal/stm32u5/dma2d_bitblt.c"]
+    else:
+        sources += ["embed/trezorhal/stm32u5/dma2d.c"]
     features_available.append("dma2d")
     features_available.append("framebuffer")
     features_available.append("framebuffer32bit")

--- a/core/site_scons/models/T2T1/trezor_t.py
+++ b/core/site_scons/models/T2T1/trezor_t.py
@@ -113,8 +113,10 @@ def configure(
 
     if "dma2d" in features_wanted:
         defines += ["USE_DMA2D"]
-        sources += ["embed/trezorhal/stm32f4/dma2d.c"]
-        sources += ["embed/trezorhal/stm32f4/dma2d_bitblt.c"]
+        if "new_rendering" in features_wanted:
+            sources += ["embed/trezorhal/stm32u5/dma2d_bitblt.c"]
+        else:
+            sources += ["embed/trezorhal/stm32u5/dma2d.c"]
         sources += [
             "vendor/micropython/lib/stm32lib/STM32F4xx_HAL_Driver/Src/stm32f4xx_hal_dma2d.c"
         ]

--- a/core/site_scons/models/T3T1/trezor_t3t1_revE.py
+++ b/core/site_scons/models/T3T1/trezor_t3t1_revE.py
@@ -114,8 +114,10 @@ def configure(
 
     if "dma2d" in features_wanted:
         defines += ["USE_DMA2D"]
-        sources += ["embed/trezorhal/stm32u5/dma2d.c"]
-        sources += ["embed/trezorhal/stm32u5/dma2d_bitblt.c"]
+        if "new_rendering" in features_wanted:
+            sources += ["embed/trezorhal/stm32u5/dma2d_bitblt.c"]
+        else:
+            sources += ["embed/trezorhal/stm32u5/dma2d.c"]
         features_available.append("dma2d")
 
     if "optiga" in features_wanted:

--- a/core/site_scons/models/T3T1/trezor_t3t1_v4.py
+++ b/core/site_scons/models/T3T1/trezor_t3t1_v4.py
@@ -115,8 +115,10 @@ def configure(
 
     if "dma2d" in features_wanted:
         defines += ["USE_DMA2D"]
-        sources += ["embed/trezorhal/stm32u5/dma2d.c"]
-        sources += ["embed/trezorhal/stm32u5/dma2d_bitblt.c"]
+        if "new_rendering" in features_wanted:
+            sources += ["embed/trezorhal/stm32u5/dma2d_bitblt.c"]
+        else:
+            sources += ["embed/trezorhal/stm32u5/dma2d.c"]
         features_available.append("dma2d")
 
     if "optiga" in features_wanted:


### PR DESCRIPTION
This PR fixes minor issues with dma2d including, compiling and initialization with respect to new rendering.

`dma2d_init` function was added to bitblt so that DMA clock can be enabled, this function is now called in boardloader for models that use dma2d always. Only one of the files is compiled based on new rendering selection.

Also i width/height swap was fixed in `gfx_clear`.



<!--
If you are a core dev:

Don't forget to set up the fields:
- assign yourself
- set priority to same as original issue
- add PR to sprint
- if Draft -> "in progress"
- if final PR -> "needs review"

If you're an external contributor, you can ignore this text.
-->
