### PR TITLE
trezorlib: WebUSB resilience

### DIFF
--- a/core/src/apps/debug/__init__.py
+++ b/core/src/apps/debug/__init__.py
@@ -127,10 +127,13 @@ if __debug__:
 
         return content
 
-    async def return_layout_change() -> None:
+    async def return_layout_change() -> None:  # type: ignore [Return type of async generator]
         content_tokens = await get_layout_change_content()
 
-        assert isinstance(DEBUG_CONTEXT, context.Context)
+        # spin for a bit until DEBUG_CONTEXT becomes available
+        while not isinstance(DEBUG_CONTEXT, context.Context):
+            yield  # type: ignore [Return type of async generator]
+
         if storage.layout_watcher is LAYOUT_WATCHER_LAYOUT:
             await DEBUG_CONTEXT.write(DebugLinkLayout(tokens=content_tokens))
         else:

--- a/python/.changelog.d/4089.changed
+++ b/python/.changelog.d/4089.changed
@@ -1,0 +1,1 @@
+Most USB level errors are now converted to `TransportException`.

--- a/python/.changelog.d/4089.fixed
+++ b/python/.changelog.d/4089.fixed
@@ -1,0 +1,1 @@
+It is now possible to interrupt USB communication (via Ctrl+C, or a signal, or any other way).


### PR DESCRIPTION
* converts USB errors to TransportExceptions
* retries USB calls with a short timeout instead of waiting on blocking calls -- this means that Python-level signals (such as KeyboardInterrupt) will successfully stop a USB wait, so you can easily ctrl+c out of a stuck trezorctl
* this also allows pytest-timeout to kill a stuck hardware test

(we should also leverage this to be able to re-sync USB communication after a lost packet. this is not done in this PR however.)

in addition, I noticed and fixed a race condition in debuglink on the device side, which makes hw tests more resilient too

<!--
If you are a core dev:

Don't forget to set up the fields:
- assign yourself
- set priority to same as original issue
- add PR to sprint
- if Draft -> "in progress"
- if final PR -> "needs review"

If you're an external contributor, you can ignore this text.
-->
