### PR TITLE
fix expected param numbers for TOUCH_IDLE command

### DIFF
--- a/core/embed/prodtest/main.c
+++ b/core/embed/prodtest/main.c
@@ -454,7 +454,7 @@ static void test_touch_custom(const char *args) {
 }
 
 static void test_touch_idle(const char *args) {
-  static const int expected_params = 5;
+  static const int expected_params = 1;
   int num_params = 0;
 
   int params[expected_params];


### PR DESCRIPTION
fix expected param numbers for TOUCH_IDLE command

<!--
If you are a core dev:

Don't forget to set up the fields:
- assign yourself
- set priority to same as original issue
- add PR to sprint
- if Draft -> "in progress"
- if final PR -> "needs review"

If you're an external contributor, you can ignore this text.
-->
