### PR TITLE
introduce ui_overlay feature

### DIFF
--- a/core/SConscript.firmware
+++ b/core/SConscript.firmware
@@ -845,6 +845,7 @@ def cargo_build():
 
     if NEW_RENDERING and TREZOR_MODEL in ('T3T1', 'DISC2'):
         features.append('ui_image_buffer')
+        features.append('ui_overlay')
 
     features.extend(FEATURES_AVAILABLE)
 

--- a/core/SConscript.unix
+++ b/core/SConscript.unix
@@ -888,6 +888,7 @@ def cargo_build():
 
     if NEW_RENDERING and TREZOR_MODEL in ('T3T1', ):
         features.append('ui_image_buffer')
+        features.append('ui_overlay')
 
     if NEW_RENDERING:
         features.append('new_rendering')

--- a/core/embed/rust/Cargo.toml
+++ b/core/embed/rust/Cargo.toml
@@ -27,6 +27,7 @@ ui_blurring = []
 ui_jpeg_decoder = ["jpeg"]
 ui_image_buffer = []
 ui_color_32bit = []
+ui_overlay = []
 new_rendering = []
 bootloader = []
 button = []
@@ -62,6 +63,7 @@ test = [
     "ui_jpeg_decoder",
     "ui_blurring",
     "ui_image_buffer",
+    "ui_overlay",
     "universal_fw",
 ]
 universal_fw = []

--- a/core/embed/rust/src/ui/model_mercury/cshape/mod.rs
+++ b/core/embed/rust/src/ui/model_mercury/cshape/mod.rs
@@ -1,11 +1,15 @@
 mod loader;
 
+#[cfg(feature = "ui_overlay")]
 mod unlock_overlay;
 
+#[cfg(feature = "ui_overlay")]
 mod keyboard_overlay;
 
+#[cfg(feature = "ui_overlay")]
 pub use unlock_overlay::UnlockOverlay;
 
+#[cfg(feature = "ui_overlay")]
 pub use keyboard_overlay::KeyboardOverlay;
 
 pub use loader::{render_loader, LoaderRange};

--- a/core/embed/rust/src/ui/shape/cache/drawing_cache.rs
+++ b/core/embed/rust/src/ui/shape/cache/drawing_cache.rs
@@ -16,17 +16,22 @@ const ZLIB_CACHE_SLOTS: usize = 1;
 #[cfg(not(feature = "xframebuffer"))]
 const ZLIB_CACHE_SLOTS: usize = 3;
 
+#[cfg(not(feature = "xframebuffer"))]
 const RENDER_BUFF_SIZE: usize = (240 * 2 * 16) + ALIGN_PAD;
 
-#[cfg(feature = "model_mercury")]
+#[cfg(feature = "ui_overlay")]
 const IMAGE_BUFF_SIZE: usize = 240 * 240 + ALIGN_PAD;
-#[cfg(not(feature = "model_mercury"))]
+#[cfg(not(feature = "ui_overlay"))]
 const IMAGE_BUFF_SIZE: usize = 2048 + ALIGN_PAD;
 
 pub type ImageBuff = [u8; IMAGE_BUFF_SIZE];
+
+#[cfg(not(feature = "xframebuffer"))]
 pub type RenderBuff = [u8; RENDER_BUFF_SIZE];
 
 pub type ImageBuffRef<'a> = RefMut<'a, ImageBuff>;
+
+#[cfg(not(feature = "xframebuffer"))]
 pub type RenderBuffRef<'a> = RefMut<'a, RenderBuff>;
 
 pub struct DrawingCache<'a> {


### PR DESCRIPTION
this fixes compilation of T3T1 bootloader with new rendering, which was overflowing RAM.

<!--
If you are a core dev:

Don't forget to set up the fields:
- assign yourself
- set priority to same as original issue
- add PR to sprint
- if Draft -> "in progress"
- if final PR -> "needs review"

If you're an external contributor, you can ignore this text.
-->
