### PR TITLE
Use bitcoinlib to parse raw transaction when Blockbook server could not find it.

### DIFF
--- a/python/tools/build_tx.py
+++ b/python/tools/build_tx.py
@@ -69,7 +69,7 @@ def parse_vin(s: str) -> Tuple[bytes, int]:
 
 def _get_inputs_interactive(
     blockbook_url: str,
-) -> Tuple[List[messages.TxInputType], Dict[str, messages.TransactionType]]:
+) -> Tuple[List[messages.TxInputType], Dict[str, Dict[str, Any]]]:
     inputs: List[messages.TxInputType] = []
     txes: Dict[str, messages.TransactionType] = {}
     while True:
@@ -92,7 +92,7 @@ def _get_inputs_interactive(
             raise click.ClickException(f"Transaction not found: {txhash}")
 
         tx = btc.from_json(tx_json)
-        txes[txhash] = tx
+        txes[txhash] = to_dict(tx, hexlify_bytes=True)
         try:
             from_address = tx_json["vout"][prev_index]["scriptPubKey"]["address"]
             echo(f"From address: {from_address}")
@@ -197,10 +197,7 @@ def sign_interactive() -> None:
             "version": version,
             "lock_time": lock_time,
         },
-        "prev_txes": {
-            txhash: to_dict(txdata, hexlify_bytes=True)
-            for txhash, txdata in txes.items()
-        },
+        "prev_txes": txes,
     }
 
     print(json.dumps(result, sort_keys=True, indent=2))

--- a/python/tools/build_tx.py
+++ b/python/tools/build_tx.py
@@ -79,20 +79,20 @@ def _get_inputs_interactive(
         )
         if not prev:
             break
-        prev_hash, prev_index = prev
+        prev_txid, prev_index = prev
 
-        txhash = prev_hash.hex()
-        tx_url = blockbook_url + txhash
+        txid_hex = prev_txid.hex()
+        tx_url = blockbook_url + txid_hex
         r = SESSION.get(tx_url)
         if not r.ok:
             raise click.ClickException(f"Failed to fetch URL: {tx_url}")
 
         tx_json = r.json(parse_float=decimal.Decimal)
         if "error" in tx_json:
-            raise click.ClickException(f"Transaction not found: {txhash}")
+            raise click.ClickException(f"Transaction not found: {txid_hex}")
 
         tx = btc.from_json(tx_json)
-        txes[txhash] = to_dict(tx, hexlify_bytes=True)
+        txes[txid_hex] = to_dict(tx, hexlify_bytes=True)
         try:
             from_address = tx_json["vout"][prev_index]["scriptPubKey"]["address"]
             echo(f"From address: {from_address}")
@@ -124,7 +124,7 @@ def _get_inputs_interactive(
 
         new_input = messages.TxInputType(
             address_n=address_n,
-            prev_hash=prev_hash,
+            prev_hash=prev_txid,
             prev_index=prev_index,
             amount=amount,
             script_type=script_type,


### PR DESCRIPTION
I really like the `build_tx.py` tool, and I patched it to be able to sign a transaction that spends a utxo of a transaction that hasn't been sent to the blockchain yet.

In case the user wants to create two transactions, where the second spends the output of the first, he can do that without broadcasting them. This is useful in scenarios of relative timelocks (using nSequence).

The user can also specify "." as the blockbook host (instead of `btc1.trezor.io`) and then the script will never send http requests and instead will ask the user to provide the previous raw-transaction for every `vin`.

I couldn't find any existing code in this project that parses raw transactions, so I used: https://pypi.org/project/bitcoinlib (if `bitcoinlib` is not installed, the behavior remains the same). 
