### PR TITLE
T3B1: support all coins that should be supported

### DIFF
--- a/common/defs/README.md
+++ b/common/defs/README.md
@@ -80,10 +80,10 @@ added to the dataset.
 
 # Support Information
 
-We keep track of support status of each built-in coin over our devices. That is
-`T1B1` for Trezor One, `T2T1` for Trezor T, `T2B1` for Trezor Safe 3, `T3T1` for Trezor Safe 5, `connect` for [Connect](https://github.com/trezor/connect)
-and `suite` for [Trezor Suite](https://suite.trezor.io/). In further description, the word "device"
-applies to Connect and Suite as well.
+We keep track of support status of each built-in coin over our devices. That is `T1B1`
+for Trezor One, `T2T1` for Trezor T, `T2B1` and `T3B1` for Trezor Safe 3 (both models
+should have identical entries, except for minimum versions which are higher on `T3B1`),
+`T3T1` for Trezor Safe 5.
 
 This information is stored in [`support.json`](support.json).
 External contributors should not touch this file unless asked to.

--- a/common/tools/cointool.py
+++ b/common/tools/cointool.py
@@ -160,6 +160,7 @@ def render_file(
         ROOT=ROOT,
         **coins,
         **MAKO_FILTERS,
+        ALL_MODELS=coin_info.get_models(),
     )
     dst.write_text(str(result))
     src_stat = src.stat()

--- a/core/src/apps/common/coininfo.py
+++ b/core/src/apps/common/coininfo.py
@@ -94,7 +94,7 @@ class CoinInfo:
 
 # fmt: off
 def by_name(name: str) -> CoinInfo:
-    if utils.INTERNAL_MODEL == "T2B1":
+    if utils.INTERNAL_MODEL == "T1B1":
         if name == "Bitcoin":
             return CoinInfo(
                 name,  # coin_name
@@ -299,6 +299,64 @@ def by_name(name: str) -> CoinInfo:
                     False,  # overwintered
                     None,  # confidential_assets
                 )
+            if name == "Bgold":
+                return CoinInfo(
+                    name,  # coin_name
+                    "BTG",  # coin_shortcut
+                    8,  # decimals
+                    38,  # address_type
+                    23,  # address_type_p2sh
+                    380000000,  # maxfee_kb
+                    "Bitcoin Gold Signed Message:\n",  # signed_message_header
+                    0x0488b21e,  # xpub_magic
+                    0x049d7cb2,  # xpub_magic_segwit_p2sh
+                    0x04b24746,  # xpub_magic_segwit_native
+                    0x0488b21e,  # xpub_magic_multisig_segwit_p2sh
+                    0x0488b21e,  # xpub_magic_multisig_segwit_native
+                    "btg",  # bech32_prefix
+                    None,  # cashaddr_prefix
+                    156,  # slip44
+                    True,  # segwit
+                    False,  # taproot
+                    79,  # fork_id
+                    True,  # force_bip143
+                    False,  # decred
+                    False,  # negative_fee
+                    'secp256k1',  # curve_name
+                    False,  # extra_data
+                    False,  # timestamp
+                    False,  # overwintered
+                    None,  # confidential_assets
+                )
+            if name == "Bgold Testnet":
+                return CoinInfo(
+                    name,  # coin_name
+                    "TBTG",  # coin_shortcut
+                    8,  # decimals
+                    111,  # address_type
+                    196,  # address_type_p2sh
+                    500000,  # maxfee_kb
+                    "Bitcoin Gold Signed Message:\n",  # signed_message_header
+                    0x043587cf,  # xpub_magic
+                    0x044a5262,  # xpub_magic_segwit_p2sh
+                    0x045f1cf6,  # xpub_magic_segwit_native
+                    0x043587cf,  # xpub_magic_multisig_segwit_p2sh
+                    0x043587cf,  # xpub_magic_multisig_segwit_native
+                    "tbtg",  # bech32_prefix
+                    None,  # cashaddr_prefix
+                    1,  # slip44
+                    True,  # segwit
+                    False,  # taproot
+                    79,  # fork_id
+                    True,  # force_bip143
+                    False,  # decred
+                    False,  # negative_fee
+                    'secp256k1',  # curve_name
+                    False,  # extra_data
+                    False,  # timestamp
+                    False,  # overwintered
+                    None,  # confidential_assets
+                )
             if name == "Bprivate":
                 return CoinInfo(
                     name,  # coin_name
@@ -404,6 +462,151 @@ def by_name(name: str) -> CoinInfo:
                     None,  # cashaddr_prefix
                     72,  # slip44
                     False,  # segwit
+                    False,  # taproot
+                    None,  # fork_id
+                    False,  # force_bip143
+                    False,  # decred
+                    False,  # negative_fee
+                    'secp256k1',  # curve_name
+                    False,  # extra_data
+                    False,  # timestamp
+                    False,  # overwintered
+                    None,  # confidential_assets
+                )
+            if name == "Dash":
+                return CoinInfo(
+                    name,  # coin_name
+                    "DASH",  # coin_shortcut
+                    8,  # decimals
+                    76,  # address_type
+                    16,  # address_type_p2sh
+                    45000000,  # maxfee_kb
+                    "DarkCoin Signed Message:\n",  # signed_message_header
+                    0x02fe52cc,  # xpub_magic
+                    None,  # xpub_magic_segwit_p2sh
+                    None,  # xpub_magic_segwit_native
+                    None,  # xpub_magic_multisig_segwit_p2sh
+                    None,  # xpub_magic_multisig_segwit_native
+                    None,  # bech32_prefix
+                    None,  # cashaddr_prefix
+                    5,  # slip44
+                    False,  # segwit
+                    False,  # taproot
+                    None,  # fork_id
+                    False,  # force_bip143
+                    False,  # decred
+                    False,  # negative_fee
+                    'secp256k1',  # curve_name
+                    True,  # extra_data
+                    False,  # timestamp
+                    False,  # overwintered
+                    None,  # confidential_assets
+                )
+            if name == "Dash Testnet":
+                return CoinInfo(
+                    name,  # coin_name
+                    "tDASH",  # coin_shortcut
+                    8,  # decimals
+                    140,  # address_type
+                    19,  # address_type_p2sh
+                    100000,  # maxfee_kb
+                    "DarkCoin Signed Message:\n",  # signed_message_header
+                    0x043587cf,  # xpub_magic
+                    None,  # xpub_magic_segwit_p2sh
+                    None,  # xpub_magic_segwit_native
+                    None,  # xpub_magic_multisig_segwit_p2sh
+                    None,  # xpub_magic_multisig_segwit_native
+                    None,  # bech32_prefix
+                    None,  # cashaddr_prefix
+                    1,  # slip44
+                    False,  # segwit
+                    False,  # taproot
+                    None,  # fork_id
+                    False,  # force_bip143
+                    False,  # decred
+                    False,  # negative_fee
+                    'secp256k1',  # curve_name
+                    True,  # extra_data
+                    False,  # timestamp
+                    False,  # overwintered
+                    None,  # confidential_assets
+                )
+            if name == "Decred":
+                return CoinInfo(
+                    name,  # coin_name
+                    "DCR",  # coin_shortcut
+                    8,  # decimals
+                    1855,  # address_type
+                    1818,  # address_type_p2sh
+                    220000000,  # maxfee_kb
+                    "Decred Signed Message:\n",  # signed_message_header
+                    0x02fda926,  # xpub_magic
+                    None,  # xpub_magic_segwit_p2sh
+                    None,  # xpub_magic_segwit_native
+                    None,  # xpub_magic_multisig_segwit_p2sh
+                    None,  # xpub_magic_multisig_segwit_native
+                    None,  # bech32_prefix
+                    None,  # cashaddr_prefix
+                    42,  # slip44
+                    False,  # segwit
+                    False,  # taproot
+                    None,  # fork_id
+                    False,  # force_bip143
+                    True,  # decred
+                    False,  # negative_fee
+                    'secp256k1-decred',  # curve_name
+                    False,  # extra_data
+                    False,  # timestamp
+                    False,  # overwintered
+                    None,  # confidential_assets
+                )
+            if name == "Decred Testnet":
+                return CoinInfo(
+                    name,  # coin_name
+                    "TDCR",  # coin_shortcut
+                    8,  # decimals
+                    3873,  # address_type
+                    3836,  # address_type_p2sh
+                    10000000,  # maxfee_kb
+                    "Decred Signed Message:\n",  # signed_message_header
+                    0x043587d1,  # xpub_magic
+                    None,  # xpub_magic_segwit_p2sh
+                    None,  # xpub_magic_segwit_native
+                    None,  # xpub_magic_multisig_segwit_p2sh
+                    None,  # xpub_magic_multisig_segwit_native
+                    None,  # bech32_prefix
+                    None,  # cashaddr_prefix
+                    1,  # slip44
+                    False,  # segwit
+                    False,  # taproot
+                    None,  # fork_id
+                    False,  # force_bip143
+                    True,  # decred
+                    False,  # negative_fee
+                    'secp256k1-decred',  # curve_name
+                    False,  # extra_data
+                    False,  # timestamp
+                    False,  # overwintered
+                    None,  # confidential_assets
+                )
+            if name == "DigiByte":
+                return CoinInfo(
+                    name,  # coin_name
+                    "DGB",  # coin_shortcut
+                    8,  # decimals
+                    30,  # address_type
+                    63,  # address_type_p2sh
+                    130000000000,  # maxfee_kb
+                    "DigiByte Signed Message:\n",  # signed_message_header
+                    0x0488b21e,  # xpub_magic
+                    0x049d7cb2,  # xpub_magic_segwit_p2sh
+                    0x04b24746,  # xpub_magic_segwit_native
+                    0x0488b21e,  # xpub_magic_multisig_segwit_p2sh
+                    0x0488b21e,  # xpub_magic_multisig_segwit_native
+                    "dgb",  # bech32_prefix
+                    None,  # cashaddr_prefix
+                    20,  # slip44
+                    True,  # segwit
                     False,  # taproot
                     None,  # fork_id
                     False,  # force_bip143
@@ -810,6 +1013,35 @@ def by_name(name: str) -> CoinInfo:
                     None,  # cashaddr_prefix
                     22,  # slip44
                     True,  # segwit
+                    False,  # taproot
+                    None,  # fork_id
+                    False,  # force_bip143
+                    False,  # decred
+                    False,  # negative_fee
+                    'secp256k1',  # curve_name
+                    False,  # extra_data
+                    False,  # timestamp
+                    False,  # overwintered
+                    None,  # confidential_assets
+                )
+            if name == "Namecoin":
+                return CoinInfo(
+                    name,  # coin_name
+                    "NMC",  # coin_shortcut
+                    8,  # decimals
+                    52,  # address_type
+                    5,  # address_type_p2sh
+                    8700000000,  # maxfee_kb
+                    "Namecoin Signed Message:\n",  # signed_message_header
+                    0x0488b21e,  # xpub_magic
+                    None,  # xpub_magic_segwit_p2sh
+                    None,  # xpub_magic_segwit_native
+                    None,  # xpub_magic_multisig_segwit_p2sh
+                    None,  # xpub_magic_multisig_segwit_native
+                    None,  # bech32_prefix
+                    None,  # cashaddr_prefix
+                    7,  # slip44
+                    False,  # segwit
                     False,  # taproot
                     None,  # fork_id
                     False,  # force_bip143
@@ -1256,6 +1488,35 @@ def by_name(name: str) -> CoinInfo:
                     False,  # overwintered
                     None,  # confidential_assets
                 )
+            if name == "Vertcoin":
+                return CoinInfo(
+                    name,  # coin_name
+                    "VTC",  # coin_shortcut
+                    8,  # decimals
+                    71,  # address_type
+                    5,  # address_type_p2sh
+                    13000000000,  # maxfee_kb
+                    "Vertcoin Signed Message:\n",  # signed_message_header
+                    0x0488b21e,  # xpub_magic
+                    0x049d7cb2,  # xpub_magic_segwit_p2sh
+                    0x04b24746,  # xpub_magic_segwit_native
+                    0x0488b21e,  # xpub_magic_multisig_segwit_p2sh
+                    0x0488b21e,  # xpub_magic_multisig_segwit_native
+                    "vtc",  # bech32_prefix
+                    None,  # cashaddr_prefix
+                    28,  # slip44
+                    True,  # segwit
+                    False,  # taproot
+                    None,  # fork_id
+                    False,  # force_bip143
+                    False,  # decred
+                    False,  # negative_fee
+                    'secp256k1',  # curve_name
+                    False,  # extra_data
+                    False,  # timestamp
+                    False,  # overwintered
+                    None,  # confidential_assets
+                )
             if name == "Viacoin":
                 return CoinInfo(
                     name,  # coin_name
@@ -1402,7 +1663,7 @@ def by_name(name: str) -> CoinInfo:
                     None,  # confidential_assets
                 )
         raise ValueError  # Unknown coin name
-    if utils.INTERNAL_MODEL == "T3T1":
+    if utils.INTERNAL_MODEL == "T2B1":
         if name == "Bitcoin":
             return CoinInfo(
                 name,  # coin_name
@@ -4130,6 +4391,2622 @@ def by_name(name: str) -> CoinInfo:
                     'secp256k1',  # curve_name
                     False,  # extra_data
                     False,  # timestamp
+                    False,  # overwintered
+                    None,  # confidential_assets
+                )
+            if name == "Viacoin":
+                return CoinInfo(
+                    name,  # coin_name
+                    "VIA",  # coin_shortcut
+                    8,  # decimals
+                    71,  # address_type
+                    33,  # address_type_p2sh
+                    14000000000,  # maxfee_kb
+                    "Viacoin Signed Message:\n",  # signed_message_header
+                    0x0488b21e,  # xpub_magic
+                    0x049d7cb2,  # xpub_magic_segwit_p2sh
+                    0x04b24746,  # xpub_magic_segwit_native
+                    0x0488b21e,  # xpub_magic_multisig_segwit_p2sh
+                    0x0488b21e,  # xpub_magic_multisig_segwit_native
+                    "via",  # bech32_prefix
+                    None,  # cashaddr_prefix
+                    14,  # slip44
+                    True,  # segwit
+                    False,  # taproot
+                    None,  # fork_id
+                    False,  # force_bip143
+                    False,  # decred
+                    False,  # negative_fee
+                    'secp256k1',  # curve_name
+                    False,  # extra_data
+                    False,  # timestamp
+                    False,  # overwintered
+                    None,  # confidential_assets
+                )
+            if name == "ZCore":
+                return CoinInfo(
+                    name,  # coin_name
+                    "ZCR",  # coin_shortcut
+                    8,  # decimals
+                    142,  # address_type
+                    145,  # address_type_p2sh
+                    170000000000,  # maxfee_kb
+                    "DarkNet Signed Message:\n",  # signed_message_header
+                    0x04b24746,  # xpub_magic
+                    None,  # xpub_magic_segwit_p2sh
+                    None,  # xpub_magic_segwit_native
+                    None,  # xpub_magic_multisig_segwit_p2sh
+                    None,  # xpub_magic_multisig_segwit_native
+                    None,  # bech32_prefix
+                    None,  # cashaddr_prefix
+                    428,  # slip44
+                    False,  # segwit
+                    False,  # taproot
+                    None,  # fork_id
+                    False,  # force_bip143
+                    False,  # decred
+                    False,  # negative_fee
+                    'secp256k1',  # curve_name
+                    False,  # extra_data
+                    False,  # timestamp
+                    False,  # overwintered
+                    None,  # confidential_assets
+                )
+            if name == "Zcash":
+                return CoinInfo(
+                    name,  # coin_name
+                    "ZEC",  # coin_shortcut
+                    8,  # decimals
+                    7352,  # address_type
+                    7357,  # address_type_p2sh
+                    51000000,  # maxfee_kb
+                    "Zcash Signed Message:\n",  # signed_message_header
+                    0x0488b21e,  # xpub_magic
+                    None,  # xpub_magic_segwit_p2sh
+                    None,  # xpub_magic_segwit_native
+                    None,  # xpub_magic_multisig_segwit_p2sh
+                    None,  # xpub_magic_multisig_segwit_native
+                    None,  # bech32_prefix
+                    None,  # cashaddr_prefix
+                    133,  # slip44
+                    False,  # segwit
+                    False,  # taproot
+                    None,  # fork_id
+                    False,  # force_bip143
+                    False,  # decred
+                    False,  # negative_fee
+                    'secp256k1',  # curve_name
+                    True,  # extra_data
+                    False,  # timestamp
+                    True,  # overwintered
+                    None,  # confidential_assets
+                )
+            if name == "Zcash Testnet":
+                return CoinInfo(
+                    name,  # coin_name
+                    "TAZ",  # coin_shortcut
+                    8,  # decimals
+                    7461,  # address_type
+                    7354,  # address_type_p2sh
+                    10000000,  # maxfee_kb
+                    "Zcash Signed Message:\n",  # signed_message_header
+                    0x043587cf,  # xpub_magic
+                    None,  # xpub_magic_segwit_p2sh
+                    None,  # xpub_magic_segwit_native
+                    None,  # xpub_magic_multisig_segwit_p2sh
+                    None,  # xpub_magic_multisig_segwit_native
+                    None,  # bech32_prefix
+                    None,  # cashaddr_prefix
+                    1,  # slip44
+                    False,  # segwit
+                    False,  # taproot
+                    None,  # fork_id
+                    False,  # force_bip143
+                    False,  # decred
+                    False,  # negative_fee
+                    'secp256k1',  # curve_name
+                    True,  # extra_data
+                    False,  # timestamp
+                    True,  # overwintered
+                    None,  # confidential_assets
+                )
+            if name == "Brhodium":
+                return CoinInfo(
+                    name,  # coin_name
+                    "XRC",  # coin_shortcut
+                    8,  # decimals
+                    61,  # address_type
+                    123,  # address_type_p2sh
+                    1000000000,  # maxfee_kb
+                    "BitCoin Rhodium Signed Message:\n",  # signed_message_header
+                    0x0488b21e,  # xpub_magic
+                    None,  # xpub_magic_segwit_p2sh
+                    None,  # xpub_magic_segwit_native
+                    None,  # xpub_magic_multisig_segwit_p2sh
+                    None,  # xpub_magic_multisig_segwit_native
+                    None,  # bech32_prefix
+                    None,  # cashaddr_prefix
+                    10291,  # slip44
+                    False,  # segwit
+                    False,  # taproot
+                    None,  # fork_id
+                    False,  # force_bip143
+                    False,  # decred
+                    False,  # negative_fee
+                    'secp256k1',  # curve_name
+                    False,  # extra_data
+                    False,  # timestamp
+                    False,  # overwintered
+                    None,  # confidential_assets
+                )
+        raise ValueError  # Unknown coin name
+    if utils.INTERNAL_MODEL == "T3B1":
+        if name == "Bitcoin":
+            return CoinInfo(
+                name,  # coin_name
+                "BTC",  # coin_shortcut
+                8,  # decimals
+                0,  # address_type
+                5,  # address_type_p2sh
+                2000000,  # maxfee_kb
+                "Bitcoin Signed Message:\n",  # signed_message_header
+                0x0488b21e,  # xpub_magic
+                0x049d7cb2,  # xpub_magic_segwit_p2sh
+                0x04b24746,  # xpub_magic_segwit_native
+                0x0295b43f,  # xpub_magic_multisig_segwit_p2sh
+                0x02aa7ed3,  # xpub_magic_multisig_segwit_native
+                "bc",  # bech32_prefix
+                None,  # cashaddr_prefix
+                0,  # slip44
+                True,  # segwit
+                True,  # taproot
+                None,  # fork_id
+                False,  # force_bip143
+                False,  # decred
+                False,  # negative_fee
+                'secp256k1',  # curve_name
+                False,  # extra_data
+                False,  # timestamp
+                False,  # overwintered
+                None,  # confidential_assets
+            )
+        if name == "Regtest":
+            return CoinInfo(
+                name,  # coin_name
+                "REGTEST",  # coin_shortcut
+                8,  # decimals
+                111,  # address_type
+                196,  # address_type_p2sh
+                10000000,  # maxfee_kb
+                "Bitcoin Signed Message:\n",  # signed_message_header
+                0x043587cf,  # xpub_magic
+                0x044a5262,  # xpub_magic_segwit_p2sh
+                0x045f1cf6,  # xpub_magic_segwit_native
+                0x024289ef,  # xpub_magic_multisig_segwit_p2sh
+                0x02575483,  # xpub_magic_multisig_segwit_native
+                "bcrt",  # bech32_prefix
+                None,  # cashaddr_prefix
+                1,  # slip44
+                True,  # segwit
+                True,  # taproot
+                None,  # fork_id
+                False,  # force_bip143
+                False,  # decred
+                False,  # negative_fee
+                'secp256k1',  # curve_name
+                False,  # extra_data
+                False,  # timestamp
+                False,  # overwintered
+                None,  # confidential_assets
+            )
+        if name == "Testnet":
+            return CoinInfo(
+                name,  # coin_name
+                "TEST",  # coin_shortcut
+                8,  # decimals
+                111,  # address_type
+                196,  # address_type_p2sh
+                10000000,  # maxfee_kb
+                "Bitcoin Signed Message:\n",  # signed_message_header
+                0x043587cf,  # xpub_magic
+                0x044a5262,  # xpub_magic_segwit_p2sh
+                0x045f1cf6,  # xpub_magic_segwit_native
+                0x024289ef,  # xpub_magic_multisig_segwit_p2sh
+                0x02575483,  # xpub_magic_multisig_segwit_native
+                "tb",  # bech32_prefix
+                None,  # cashaddr_prefix
+                1,  # slip44
+                True,  # segwit
+                True,  # taproot
+                None,  # fork_id
+                False,  # force_bip143
+                False,  # decred
+                False,  # negative_fee
+                'secp256k1',  # curve_name
+                False,  # extra_data
+                False,  # timestamp
+                False,  # overwintered
+                None,  # confidential_assets
+            )
+        if not utils.BITCOIN_ONLY:
+            if name == "Actinium":
+                return CoinInfo(
+                    name,  # coin_name
+                    "ACM",  # coin_shortcut
+                    8,  # decimals
+                    53,  # address_type
+                    55,  # address_type_p2sh
+                    320000000000,  # maxfee_kb
+                    "Actinium Signed Message:\n",  # signed_message_header
+                    0x0488b21e,  # xpub_magic
+                    0x049d7cb2,  # xpub_magic_segwit_p2sh
+                    0x04b24746,  # xpub_magic_segwit_native
+                    0x0488b21e,  # xpub_magic_multisig_segwit_p2sh
+                    0x0488b21e,  # xpub_magic_multisig_segwit_native
+                    "acm",  # bech32_prefix
+                    None,  # cashaddr_prefix
+                    228,  # slip44
+                    True,  # segwit
+                    False,  # taproot
+                    None,  # fork_id
+                    False,  # force_bip143
+                    False,  # decred
+                    False,  # negative_fee
+                    'secp256k1',  # curve_name
+                    False,  # extra_data
+                    False,  # timestamp
+                    False,  # overwintered
+                    None,  # confidential_assets
+                )
+            if name == "Axe":
+                return CoinInfo(
+                    name,  # coin_name
+                    "AXE",  # coin_shortcut
+                    8,  # decimals
+                    55,  # address_type
+                    16,  # address_type_p2sh
+                    21000000000,  # maxfee_kb
+                    "DarkCoin Signed Message:\n",  # signed_message_header
+                    0x02fe52cc,  # xpub_magic
+                    None,  # xpub_magic_segwit_p2sh
+                    None,  # xpub_magic_segwit_native
+                    None,  # xpub_magic_multisig_segwit_p2sh
+                    None,  # xpub_magic_multisig_segwit_native
+                    None,  # bech32_prefix
+                    None,  # cashaddr_prefix
+                    4242,  # slip44
+                    False,  # segwit
+                    False,  # taproot
+                    None,  # fork_id
+                    False,  # force_bip143
+                    False,  # decred
+                    False,  # negative_fee
+                    'secp256k1',  # curve_name
+                    False,  # extra_data
+                    False,  # timestamp
+                    False,  # overwintered
+                    None,  # confidential_assets
+                )
+            if name == "Bcash":
+                return CoinInfo(
+                    name,  # coin_name
+                    "BCH",  # coin_shortcut
+                    8,  # decimals
+                    0,  # address_type
+                    5,  # address_type_p2sh
+                    14000000,  # maxfee_kb
+                    "Bitcoin Signed Message:\n",  # signed_message_header
+                    0x0488b21e,  # xpub_magic
+                    None,  # xpub_magic_segwit_p2sh
+                    None,  # xpub_magic_segwit_native
+                    None,  # xpub_magic_multisig_segwit_p2sh
+                    None,  # xpub_magic_multisig_segwit_native
+                    None,  # bech32_prefix
+                    "bitcoincash",  # cashaddr_prefix
+                    145,  # slip44
+                    False,  # segwit
+                    False,  # taproot
+                    0,  # fork_id
+                    True,  # force_bip143
+                    False,  # decred
+                    False,  # negative_fee
+                    'secp256k1',  # curve_name
+                    False,  # extra_data
+                    False,  # timestamp
+                    False,  # overwintered
+                    None,  # confidential_assets
+                )
+            if name == "Bcash Testnet":
+                return CoinInfo(
+                    name,  # coin_name
+                    "TBCH",  # coin_shortcut
+                    8,  # decimals
+                    111,  # address_type
+                    196,  # address_type_p2sh
+                    10000000,  # maxfee_kb
+                    "Bitcoin Signed Message:\n",  # signed_message_header
+                    0x043587cf,  # xpub_magic
+                    None,  # xpub_magic_segwit_p2sh
+                    None,  # xpub_magic_segwit_native
+                    None,  # xpub_magic_multisig_segwit_p2sh
+                    None,  # xpub_magic_multisig_segwit_native
+                    None,  # bech32_prefix
+                    "bchtest",  # cashaddr_prefix
+                    1,  # slip44
+                    False,  # segwit
+                    False,  # taproot
+                    0,  # fork_id
+                    True,  # force_bip143
+                    False,  # decred
+                    False,  # negative_fee
+                    'secp256k1',  # curve_name
+                    False,  # extra_data
+                    False,  # timestamp
+                    False,  # overwintered
+                    None,  # confidential_assets
+                )
+            if name == "Bprivate":
+                return CoinInfo(
+                    name,  # coin_name
+                    "BTCP",  # coin_shortcut
+                    8,  # decimals
+                    4901,  # address_type
+                    5039,  # address_type_p2sh
+                    32000000000,  # maxfee_kb
+                    "BitcoinPrivate Signed Message:\n",  # signed_message_header
+                    0x0488b21e,  # xpub_magic
+                    None,  # xpub_magic_segwit_p2sh
+                    None,  # xpub_magic_segwit_native
+                    None,  # xpub_magic_multisig_segwit_p2sh
+                    None,  # xpub_magic_multisig_segwit_native
+                    None,  # bech32_prefix
+                    None,  # cashaddr_prefix
+                    183,  # slip44
+                    False,  # segwit
+                    False,  # taproot
+                    42,  # fork_id
+                    False,  # force_bip143
+                    False,  # decred
+                    False,  # negative_fee
+                    'secp256k1',  # curve_name
+                    False,  # extra_data
+                    False,  # timestamp
+                    False,  # overwintered
+                    None,  # confidential_assets
+                )
+            if name == "Bitcore":
+                return CoinInfo(
+                    name,  # coin_name
+                    "BTX",  # coin_shortcut
+                    8,  # decimals
+                    3,  # address_type
+                    125,  # address_type_p2sh
+                    14000000000,  # maxfee_kb
+                    "BitCore Signed Message:\n",  # signed_message_header
+                    0x0488b21e,  # xpub_magic
+                    0x049d7cb2,  # xpub_magic_segwit_p2sh
+                    0x04b24746,  # xpub_magic_segwit_native
+                    0x0488b21e,  # xpub_magic_multisig_segwit_p2sh
+                    0x0488b21e,  # xpub_magic_multisig_segwit_native
+                    "btx",  # bech32_prefix
+                    None,  # cashaddr_prefix
+                    160,  # slip44
+                    True,  # segwit
+                    False,  # taproot
+                    None,  # fork_id
+                    False,  # force_bip143
+                    False,  # decred
+                    False,  # negative_fee
+                    'secp256k1',  # curve_name
+                    False,  # extra_data
+                    False,  # timestamp
+                    False,  # overwintered
+                    None,  # confidential_assets
+                )
+            if name == "CPUchain":
+                return CoinInfo(
+                    name,  # coin_name
+                    "CPU",  # coin_shortcut
+                    8,  # decimals
+                    28,  # address_type
+                    30,  # address_type_p2sh
+                    8700000000000,  # maxfee_kb
+                    "CPUchain Signed Message:\n",  # signed_message_header
+                    0x0488b21e,  # xpub_magic
+                    0x049d7cb2,  # xpub_magic_segwit_p2sh
+                    0x04b24746,  # xpub_magic_segwit_native
+                    0x0488b21e,  # xpub_magic_multisig_segwit_p2sh
+                    0x0488b21e,  # xpub_magic_multisig_segwit_native
+                    "cpu",  # bech32_prefix
+                    None,  # cashaddr_prefix
+                    363,  # slip44
+                    True,  # segwit
+                    False,  # taproot
+                    None,  # fork_id
+                    False,  # force_bip143
+                    False,  # decred
+                    False,  # negative_fee
+                    'secp256k1',  # curve_name
+                    False,  # extra_data
+                    False,  # timestamp
+                    False,  # overwintered
+                    None,  # confidential_assets
+                )
+            if name == "Crown":
+                return CoinInfo(
+                    name,  # coin_name
+                    "CRW",  # coin_shortcut
+                    8,  # decimals
+                    95495,  # address_type
+                    95473,  # address_type_p2sh
+                    52000000000,  # maxfee_kb
+                    "Crown Signed Message:\n",  # signed_message_header
+                    0x0488b21e,  # xpub_magic
+                    None,  # xpub_magic_segwit_p2sh
+                    None,  # xpub_magic_segwit_native
+                    None,  # xpub_magic_multisig_segwit_p2sh
+                    None,  # xpub_magic_multisig_segwit_native
+                    None,  # bech32_prefix
+                    None,  # cashaddr_prefix
+                    72,  # slip44
+                    False,  # segwit
+                    False,  # taproot
+                    None,  # fork_id
+                    False,  # force_bip143
+                    False,  # decred
+                    False,  # negative_fee
+                    'secp256k1',  # curve_name
+                    False,  # extra_data
+                    False,  # timestamp
+                    False,  # overwintered
+                    None,  # confidential_assets
+                )
+            if name == "Dogecoin":
+                return CoinInfo(
+                    name,  # coin_name
+                    "DOGE",  # coin_shortcut
+                    8,  # decimals
+                    30,  # address_type
+                    22,  # address_type_p2sh
+                    1200000000000,  # maxfee_kb
+                    "Dogecoin Signed Message:\n",  # signed_message_header
+                    0x02facafd,  # xpub_magic
+                    None,  # xpub_magic_segwit_p2sh
+                    None,  # xpub_magic_segwit_native
+                    None,  # xpub_magic_multisig_segwit_p2sh
+                    None,  # xpub_magic_multisig_segwit_native
+                    None,  # bech32_prefix
+                    None,  # cashaddr_prefix
+                    3,  # slip44
+                    False,  # segwit
+                    False,  # taproot
+                    None,  # fork_id
+                    False,  # force_bip143
+                    False,  # decred
+                    False,  # negative_fee
+                    'secp256k1',  # curve_name
+                    False,  # extra_data
+                    False,  # timestamp
+                    False,  # overwintered
+                    None,  # confidential_assets
+                )
+            if name == "Elements":
+                return CoinInfo(
+                    name,  # coin_name
+                    "ELEMENTS",  # coin_shortcut
+                    8,  # decimals
+                    235,  # address_type
+                    75,  # address_type_p2sh
+                    10000000,  # maxfee_kb
+                    "Bitcoin Signed Message:\n",  # signed_message_header
+                    0x043587cf,  # xpub_magic
+                    0x044a5262,  # xpub_magic_segwit_p2sh
+                    0x045f1cf6,  # xpub_magic_segwit_native
+                    0x043587cf,  # xpub_magic_multisig_segwit_p2sh
+                    0x043587cf,  # xpub_magic_multisig_segwit_native
+                    "ert",  # bech32_prefix
+                    None,  # cashaddr_prefix
+                    1,  # slip44
+                    True,  # segwit
+                    False,  # taproot
+                    None,  # fork_id
+                    False,  # force_bip143
+                    False,  # decred
+                    False,  # negative_fee
+                    'secp256k1',  # curve_name
+                    False,  # extra_data
+                    False,  # timestamp
+                    False,  # overwintered
+                    {'address_prefix': 4, 'blech32_prefix': 'el'},  # confidential_assets
+                )
+            if name == "Feathercoin":
+                return CoinInfo(
+                    name,  # coin_name
+                    "FTC",  # coin_shortcut
+                    8,  # decimals
+                    14,  # address_type
+                    5,  # address_type_p2sh
+                    390000000000,  # maxfee_kb
+                    "Feathercoin Signed Message:\n",  # signed_message_header
+                    0x0488bc26,  # xpub_magic
+                    0x049d7cb2,  # xpub_magic_segwit_p2sh
+                    0x04b24746,  # xpub_magic_segwit_native
+                    0x0488bc26,  # xpub_magic_multisig_segwit_p2sh
+                    0x0488bc26,  # xpub_magic_multisig_segwit_native
+                    "fc",  # bech32_prefix
+                    None,  # cashaddr_prefix
+                    8,  # slip44
+                    True,  # segwit
+                    False,  # taproot
+                    None,  # fork_id
+                    False,  # force_bip143
+                    False,  # decred
+                    False,  # negative_fee
+                    'secp256k1',  # curve_name
+                    False,  # extra_data
+                    False,  # timestamp
+                    False,  # overwintered
+                    None,  # confidential_assets
+                )
+            if name == "Firo":
+                return CoinInfo(
+                    name,  # coin_name
+                    "FIRO",  # coin_shortcut
+                    8,  # decimals
+                    82,  # address_type
+                    7,  # address_type_p2sh
+                    640000000,  # maxfee_kb
+                    "Zcoin Signed Message:\n",  # signed_message_header
+                    0x0488b21e,  # xpub_magic
+                    None,  # xpub_magic_segwit_p2sh
+                    None,  # xpub_magic_segwit_native
+                    None,  # xpub_magic_multisig_segwit_p2sh
+                    None,  # xpub_magic_multisig_segwit_native
+                    None,  # bech32_prefix
+                    None,  # cashaddr_prefix
+                    136,  # slip44
+                    False,  # segwit
+                    False,  # taproot
+                    None,  # fork_id
+                    False,  # force_bip143
+                    False,  # decred
+                    False,  # negative_fee
+                    'secp256k1',  # curve_name
+                    True,  # extra_data
+                    False,  # timestamp
+                    False,  # overwintered
+                    None,  # confidential_assets
+                )
+            if name == "Firo Testnet":
+                return CoinInfo(
+                    name,  # coin_name
+                    "tFIRO",  # coin_shortcut
+                    8,  # decimals
+                    65,  # address_type
+                    178,  # address_type_p2sh
+                    1000000,  # maxfee_kb
+                    "Zcoin Signed Message:\n",  # signed_message_header
+                    0x043587cf,  # xpub_magic
+                    None,  # xpub_magic_segwit_p2sh
+                    None,  # xpub_magic_segwit_native
+                    None,  # xpub_magic_multisig_segwit_p2sh
+                    None,  # xpub_magic_multisig_segwit_native
+                    None,  # bech32_prefix
+                    None,  # cashaddr_prefix
+                    1,  # slip44
+                    False,  # segwit
+                    False,  # taproot
+                    None,  # fork_id
+                    False,  # force_bip143
+                    False,  # decred
+                    False,  # negative_fee
+                    'secp256k1',  # curve_name
+                    True,  # extra_data
+                    False,  # timestamp
+                    False,  # overwintered
+                    None,  # confidential_assets
+                )
+            if name == "Florincoin":
+                return CoinInfo(
+                    name,  # coin_name
+                    "FLO",  # coin_shortcut
+                    8,  # decimals
+                    35,  # address_type
+                    94,  # address_type_p2sh
+                    78000000000,  # maxfee_kb
+                    "Florincoin Signed Message:\n",  # signed_message_header
+                    0x00174921,  # xpub_magic
+                    0x01b26ef6,  # xpub_magic_segwit_p2sh
+                    0x04b24746,  # xpub_magic_segwit_native
+                    0x00174921,  # xpub_magic_multisig_segwit_p2sh
+                    0x00174921,  # xpub_magic_multisig_segwit_native
+                    "flo",  # bech32_prefix
+                    None,  # cashaddr_prefix
+                    216,  # slip44
+                    True,  # segwit
+                    False,  # taproot
+                    None,  # fork_id
+                    False,  # force_bip143
+                    False,  # decred
+                    False,  # negative_fee
+                    'secp256k1',  # curve_name
+                    True,  # extra_data
+                    False,  # timestamp
+                    False,  # overwintered
+                    None,  # confidential_assets
+                )
+            if name == "Fujicoin":
+                return CoinInfo(
+                    name,  # coin_name
+                    "FJC",  # coin_shortcut
+                    8,  # decimals
+                    36,  # address_type
+                    16,  # address_type_p2sh
+                    35000000000000,  # maxfee_kb
+                    "FujiCoin Signed Message:\n",  # signed_message_header
+                    0x0488b21e,  # xpub_magic
+                    0x049d7cb2,  # xpub_magic_segwit_p2sh
+                    0x04b24746,  # xpub_magic_segwit_native
+                    0x0295b43f,  # xpub_magic_multisig_segwit_p2sh
+                    0x02aa7ed3,  # xpub_magic_multisig_segwit_native
+                    "fc",  # bech32_prefix
+                    None,  # cashaddr_prefix
+                    75,  # slip44
+                    True,  # segwit
+                    True,  # taproot
+                    None,  # fork_id
+                    False,  # force_bip143
+                    False,  # decred
+                    False,  # negative_fee
+                    'secp256k1',  # curve_name
+                    False,  # extra_data
+                    False,  # timestamp
+                    False,  # overwintered
+                    None,  # confidential_assets
+                )
+            if name == "Groestlcoin":
+                return CoinInfo(
+                    name,  # coin_name
+                    "GRS",  # coin_shortcut
+                    8,  # decimals
+                    36,  # address_type
+                    5,  # address_type_p2sh
+                    16000000000,  # maxfee_kb
+                    "GroestlCoin Signed Message:\n",  # signed_message_header
+                    0x0488b21e,  # xpub_magic
+                    0x049d7cb2,  # xpub_magic_segwit_p2sh
+                    0x04b24746,  # xpub_magic_segwit_native
+                    0x0488b21e,  # xpub_magic_multisig_segwit_p2sh
+                    0x0488b21e,  # xpub_magic_multisig_segwit_native
+                    "grs",  # bech32_prefix
+                    None,  # cashaddr_prefix
+                    17,  # slip44
+                    True,  # segwit
+                    True,  # taproot
+                    None,  # fork_id
+                    False,  # force_bip143
+                    False,  # decred
+                    False,  # negative_fee
+                    'secp256k1-groestl',  # curve_name
+                    False,  # extra_data
+                    False,  # timestamp
+                    False,  # overwintered
+                    None,  # confidential_assets
+                )
+            if name == "Groestlcoin Testnet":
+                return CoinInfo(
+                    name,  # coin_name
+                    "tGRS",  # coin_shortcut
+                    8,  # decimals
+                    111,  # address_type
+                    196,  # address_type_p2sh
+                    100000,  # maxfee_kb
+                    "GroestlCoin Signed Message:\n",  # signed_message_header
+                    0x043587cf,  # xpub_magic
+                    0x044a5262,  # xpub_magic_segwit_p2sh
+                    0x045f1cf6,  # xpub_magic_segwit_native
+                    0x043587cf,  # xpub_magic_multisig_segwit_p2sh
+                    0x043587cf,  # xpub_magic_multisig_segwit_native
+                    "tgrs",  # bech32_prefix
+                    None,  # cashaddr_prefix
+                    1,  # slip44
+                    True,  # segwit
+                    True,  # taproot
+                    None,  # fork_id
+                    False,  # force_bip143
+                    False,  # decred
+                    False,  # negative_fee
+                    'secp256k1-groestl',  # curve_name
+                    False,  # extra_data
+                    False,  # timestamp
+                    False,  # overwintered
+                    None,  # confidential_assets
+                )
+            if name == "Komodo":
+                return CoinInfo(
+                    name,  # coin_name
+                    "KMD",  # coin_shortcut
+                    8,  # decimals
+                    60,  # address_type
+                    85,  # address_type_p2sh
+                    4800000000,  # maxfee_kb
+                    "Komodo Signed Message:\n",  # signed_message_header
+                    0x0488b21e,  # xpub_magic
+                    None,  # xpub_magic_segwit_p2sh
+                    None,  # xpub_magic_segwit_native
+                    None,  # xpub_magic_multisig_segwit_p2sh
+                    None,  # xpub_magic_multisig_segwit_native
+                    None,  # bech32_prefix
+                    None,  # cashaddr_prefix
+                    141,  # slip44
+                    False,  # segwit
+                    False,  # taproot
+                    None,  # fork_id
+                    False,  # force_bip143
+                    False,  # decred
+                    True,  # negative_fee
+                    'secp256k1',  # curve_name
+                    True,  # extra_data
+                    False,  # timestamp
+                    True,  # overwintered
+                    None,  # confidential_assets
+                )
+            if name == "Koto":
+                return CoinInfo(
+                    name,  # coin_name
+                    "KOTO",  # coin_shortcut
+                    8,  # decimals
+                    6198,  # address_type
+                    6203,  # address_type_p2sh
+                    1000000,  # maxfee_kb
+                    "Koto Signed Message:\n",  # signed_message_header
+                    0x0488b21e,  # xpub_magic
+                    None,  # xpub_magic_segwit_p2sh
+                    None,  # xpub_magic_segwit_native
+                    None,  # xpub_magic_multisig_segwit_p2sh
+                    None,  # xpub_magic_multisig_segwit_native
+                    None,  # bech32_prefix
+                    None,  # cashaddr_prefix
+                    510,  # slip44
+                    False,  # segwit
+                    False,  # taproot
+                    None,  # fork_id
+                    False,  # force_bip143
+                    False,  # decred
+                    False,  # negative_fee
+                    'secp256k1',  # curve_name
+                    True,  # extra_data
+                    False,  # timestamp
+                    True,  # overwintered
+                    None,  # confidential_assets
+                )
+            if name == "Litecoin":
+                return CoinInfo(
+                    name,  # coin_name
+                    "LTC",  # coin_shortcut
+                    8,  # decimals
+                    48,  # address_type
+                    50,  # address_type_p2sh
+                    67000000,  # maxfee_kb
+                    "Litecoin Signed Message:\n",  # signed_message_header
+                    0x019da462,  # xpub_magic
+                    0x01b26ef6,  # xpub_magic_segwit_p2sh
+                    0x04b24746,  # xpub_magic_segwit_native
+                    0x019da462,  # xpub_magic_multisig_segwit_p2sh
+                    0x019da462,  # xpub_magic_multisig_segwit_native
+                    "ltc",  # bech32_prefix
+                    None,  # cashaddr_prefix
+                    2,  # slip44
+                    True,  # segwit
+                    False,  # taproot
+                    None,  # fork_id
+                    False,  # force_bip143
+                    False,  # decred
+                    False,  # negative_fee
+                    'secp256k1',  # curve_name
+                    False,  # extra_data
+                    False,  # timestamp
+                    False,  # overwintered
+                    None,  # confidential_assets
+                )
+            if name == "Litecoin Testnet":
+                return CoinInfo(
+                    name,  # coin_name
+                    "tLTC",  # coin_shortcut
+                    8,  # decimals
+                    111,  # address_type
+                    58,  # address_type_p2sh
+                    40000000,  # maxfee_kb
+                    "Litecoin Signed Message:\n",  # signed_message_header
+                    0x043587cf,  # xpub_magic
+                    0x044a5262,  # xpub_magic_segwit_p2sh
+                    0x045f1cf6,  # xpub_magic_segwit_native
+                    0x043587cf,  # xpub_magic_multisig_segwit_p2sh
+                    0x043587cf,  # xpub_magic_multisig_segwit_native
+                    "tltc",  # bech32_prefix
+                    None,  # cashaddr_prefix
+                    1,  # slip44
+                    True,  # segwit
+                    False,  # taproot
+                    None,  # fork_id
+                    False,  # force_bip143
+                    False,  # decred
+                    False,  # negative_fee
+                    'secp256k1',  # curve_name
+                    False,  # extra_data
+                    False,  # timestamp
+                    False,  # overwintered
+                    None,  # confidential_assets
+                )
+            if name == "Monacoin":
+                return CoinInfo(
+                    name,  # coin_name
+                    "MONA",  # coin_shortcut
+                    8,  # decimals
+                    50,  # address_type
+                    55,  # address_type_p2sh
+                    2100000000,  # maxfee_kb
+                    "Monacoin Signed Message:\n",  # signed_message_header
+                    0x0488b21e,  # xpub_magic
+                    0x049d7cb2,  # xpub_magic_segwit_p2sh
+                    0x04b24746,  # xpub_magic_segwit_native
+                    0x0488b21e,  # xpub_magic_multisig_segwit_p2sh
+                    0x0488b21e,  # xpub_magic_multisig_segwit_native
+                    "mona",  # bech32_prefix
+                    None,  # cashaddr_prefix
+                    22,  # slip44
+                    True,  # segwit
+                    False,  # taproot
+                    None,  # fork_id
+                    False,  # force_bip143
+                    False,  # decred
+                    False,  # negative_fee
+                    'secp256k1',  # curve_name
+                    False,  # extra_data
+                    False,  # timestamp
+                    False,  # overwintered
+                    None,  # confidential_assets
+                )
+            if name == "Peercoin":
+                return CoinInfo(
+                    name,  # coin_name
+                    "PPC",  # coin_shortcut
+                    6,  # decimals
+                    55,  # address_type
+                    117,  # address_type_p2sh
+                    13000000000,  # maxfee_kb
+                    "Peercoin Signed Message:\n",  # signed_message_header
+                    0x0488b21e,  # xpub_magic
+                    0x049d7cb2,  # xpub_magic_segwit_p2sh
+                    0x04b24746,  # xpub_magic_segwit_native
+                    0x0488b21e,  # xpub_magic_multisig_segwit_p2sh
+                    0x0488b21e,  # xpub_magic_multisig_segwit_native
+                    "pc",  # bech32_prefix
+                    None,  # cashaddr_prefix
+                    6,  # slip44
+                    True,  # segwit
+                    False,  # taproot
+                    None,  # fork_id
+                    False,  # force_bip143
+                    False,  # decred
+                    False,  # negative_fee
+                    'secp256k1',  # curve_name
+                    False,  # extra_data
+                    True,  # timestamp
+                    False,  # overwintered
+                    None,  # confidential_assets
+                )
+            if name == "Peercoin Testnet":
+                return CoinInfo(
+                    name,  # coin_name
+                    "tPPC",  # coin_shortcut
+                    6,  # decimals
+                    111,  # address_type
+                    196,  # address_type_p2sh
+                    2000000,  # maxfee_kb
+                    "Peercoin Signed Message:\n",  # signed_message_header
+                    0x043587cf,  # xpub_magic
+                    0x044a5262,  # xpub_magic_segwit_p2sh
+                    0x045f1cf6,  # xpub_magic_segwit_native
+                    0x043587cf,  # xpub_magic_multisig_segwit_p2sh
+                    0x043587cf,  # xpub_magic_multisig_segwit_native
+                    "tpc",  # bech32_prefix
+                    None,  # cashaddr_prefix
+                    1,  # slip44
+                    True,  # segwit
+                    False,  # taproot
+                    None,  # fork_id
+                    False,  # force_bip143
+                    False,  # decred
+                    False,  # negative_fee
+                    'secp256k1',  # curve_name
+                    False,  # extra_data
+                    True,  # timestamp
+                    False,  # overwintered
+                    None,  # confidential_assets
+                )
+            if name == "Primecoin":
+                return CoinInfo(
+                    name,  # coin_name
+                    "XPM",  # coin_shortcut
+                    8,  # decimals
+                    23,  # address_type
+                    83,  # address_type_p2sh
+                    89000000000,  # maxfee_kb
+                    "Primecoin Signed Message:\n",  # signed_message_header
+                    0x0488b21e,  # xpub_magic
+                    None,  # xpub_magic_segwit_p2sh
+                    None,  # xpub_magic_segwit_native
+                    None,  # xpub_magic_multisig_segwit_p2sh
+                    None,  # xpub_magic_multisig_segwit_native
+                    None,  # bech32_prefix
+                    None,  # cashaddr_prefix
+                    24,  # slip44
+                    False,  # segwit
+                    False,  # taproot
+                    None,  # fork_id
+                    False,  # force_bip143
+                    False,  # decred
+                    False,  # negative_fee
+                    'secp256k1',  # curve_name
+                    False,  # extra_data
+                    False,  # timestamp
+                    False,  # overwintered
+                    None,  # confidential_assets
+                )
+            if name == "Qtum":
+                return CoinInfo(
+                    name,  # coin_name
+                    "QTUM",  # coin_shortcut
+                    8,  # decimals
+                    58,  # address_type
+                    50,  # address_type_p2sh
+                    1000000000,  # maxfee_kb
+                    "Qtum Signed Message:\n",  # signed_message_header
+                    0x0488b21e,  # xpub_magic
+                    0x049d7cb2,  # xpub_magic_segwit_p2sh
+                    0x04b24746,  # xpub_magic_segwit_native
+                    0x0488b21e,  # xpub_magic_multisig_segwit_p2sh
+                    0x0488b21e,  # xpub_magic_multisig_segwit_native
+                    "qc",  # bech32_prefix
+                    None,  # cashaddr_prefix
+                    2301,  # slip44
+                    True,  # segwit
+                    False,  # taproot
+                    None,  # fork_id
+                    False,  # force_bip143
+                    False,  # decred
+                    False,  # negative_fee
+                    'secp256k1',  # curve_name
+                    False,  # extra_data
+                    False,  # timestamp
+                    False,  # overwintered
+                    None,  # confidential_assets
+                )
+            if name == "Qtum Testnet":
+                return CoinInfo(
+                    name,  # coin_name
+                    "tQTUM",  # coin_shortcut
+                    8,  # decimals
+                    120,  # address_type
+                    110,  # address_type_p2sh
+                    40000000,  # maxfee_kb
+                    "Qtum Signed Message:\n",  # signed_message_header
+                    0x043587cf,  # xpub_magic
+                    0x044a5262,  # xpub_magic_segwit_p2sh
+                    0x045f1cf6,  # xpub_magic_segwit_native
+                    0x043587cf,  # xpub_magic_multisig_segwit_p2sh
+                    0x043587cf,  # xpub_magic_multisig_segwit_native
+                    "tq",  # bech32_prefix
+                    None,  # cashaddr_prefix
+                    1,  # slip44
+                    True,  # segwit
+                    False,  # taproot
+                    None,  # fork_id
+                    False,  # force_bip143
+                    False,  # decred
+                    False,  # negative_fee
+                    'secp256k1',  # curve_name
+                    False,  # extra_data
+                    False,  # timestamp
+                    False,  # overwintered
+                    None,  # confidential_assets
+                )
+            if name == "Ravencoin":
+                return CoinInfo(
+                    name,  # coin_name
+                    "RVN",  # coin_shortcut
+                    8,  # decimals
+                    60,  # address_type
+                    122,  # address_type_p2sh
+                    170000000000,  # maxfee_kb
+                    "Raven Signed Message:\n",  # signed_message_header
+                    0x0488b21e,  # xpub_magic
+                    None,  # xpub_magic_segwit_p2sh
+                    None,  # xpub_magic_segwit_native
+                    None,  # xpub_magic_multisig_segwit_p2sh
+                    None,  # xpub_magic_multisig_segwit_native
+                    None,  # bech32_prefix
+                    None,  # cashaddr_prefix
+                    175,  # slip44
+                    False,  # segwit
+                    False,  # taproot
+                    None,  # fork_id
+                    False,  # force_bip143
+                    False,  # decred
+                    False,  # negative_fee
+                    'secp256k1',  # curve_name
+                    False,  # extra_data
+                    False,  # timestamp
+                    False,  # overwintered
+                    None,  # confidential_assets
+                )
+            if name == "Ravencoin Testnet":
+                return CoinInfo(
+                    name,  # coin_name
+                    "tRVN",  # coin_shortcut
+                    8,  # decimals
+                    111,  # address_type
+                    196,  # address_type_p2sh
+                    170000000000,  # maxfee_kb
+                    "Raven Signed Message:\n",  # signed_message_header
+                    0x043587cf,  # xpub_magic
+                    None,  # xpub_magic_segwit_p2sh
+                    None,  # xpub_magic_segwit_native
+                    None,  # xpub_magic_multisig_segwit_p2sh
+                    None,  # xpub_magic_multisig_segwit_native
+                    None,  # bech32_prefix
+                    None,  # cashaddr_prefix
+                    1,  # slip44
+                    False,  # segwit
+                    False,  # taproot
+                    None,  # fork_id
+                    False,  # force_bip143
+                    False,  # decred
+                    False,  # negative_fee
+                    'secp256k1',  # curve_name
+                    False,  # extra_data
+                    False,  # timestamp
+                    False,  # overwintered
+                    None,  # confidential_assets
+                )
+            if name == "Ritocoin":
+                return CoinInfo(
+                    name,  # coin_name
+                    "RITO",  # coin_shortcut
+                    8,  # decimals
+                    25,  # address_type
+                    105,  # address_type_p2sh
+                    39000000000000,  # maxfee_kb
+                    "Rito Signed Message:\n",  # signed_message_header
+                    0x0534e7ca,  # xpub_magic
+                    None,  # xpub_magic_segwit_p2sh
+                    None,  # xpub_magic_segwit_native
+                    None,  # xpub_magic_multisig_segwit_p2sh
+                    None,  # xpub_magic_multisig_segwit_native
+                    None,  # bech32_prefix
+                    None,  # cashaddr_prefix
+                    19169,  # slip44
+                    False,  # segwit
+                    False,  # taproot
+                    None,  # fork_id
+                    False,  # force_bip143
+                    False,  # decred
+                    False,  # negative_fee
+                    'secp256k1',  # curve_name
+                    False,  # extra_data
+                    False,  # timestamp
+                    False,  # overwintered
+                    None,  # confidential_assets
+                )
+            if name == "SmartCash":
+                return CoinInfo(
+                    name,  # coin_name
+                    "SMART",  # coin_shortcut
+                    8,  # decimals
+                    63,  # address_type
+                    18,  # address_type_p2sh
+                    780000000000,  # maxfee_kb
+                    "SmartCash Signed Message:\n",  # signed_message_header
+                    0x0488b21e,  # xpub_magic
+                    None,  # xpub_magic_segwit_p2sh
+                    None,  # xpub_magic_segwit_native
+                    None,  # xpub_magic_multisig_segwit_p2sh
+                    None,  # xpub_magic_multisig_segwit_native
+                    None,  # bech32_prefix
+                    None,  # cashaddr_prefix
+                    224,  # slip44
+                    False,  # segwit
+                    False,  # taproot
+                    None,  # fork_id
+                    False,  # force_bip143
+                    False,  # decred
+                    False,  # negative_fee
+                    'secp256k1-smart',  # curve_name
+                    False,  # extra_data
+                    False,  # timestamp
+                    False,  # overwintered
+                    None,  # confidential_assets
+                )
+            if name == "SmartCash Testnet":
+                return CoinInfo(
+                    name,  # coin_name
+                    "tSMART",  # coin_shortcut
+                    8,  # decimals
+                    65,  # address_type
+                    21,  # address_type_p2sh
+                    1000000,  # maxfee_kb
+                    "SmartCash Signed Message:\n",  # signed_message_header
+                    0x043587cf,  # xpub_magic
+                    None,  # xpub_magic_segwit_p2sh
+                    None,  # xpub_magic_segwit_native
+                    None,  # xpub_magic_multisig_segwit_p2sh
+                    None,  # xpub_magic_multisig_segwit_native
+                    None,  # bech32_prefix
+                    None,  # cashaddr_prefix
+                    1,  # slip44
+                    False,  # segwit
+                    False,  # taproot
+                    None,  # fork_id
+                    False,  # force_bip143
+                    False,  # decred
+                    False,  # negative_fee
+                    'secp256k1-smart',  # curve_name
+                    False,  # extra_data
+                    False,  # timestamp
+                    False,  # overwintered
+                    None,  # confidential_assets
+                )
+            if name == "Stakenet":
+                return CoinInfo(
+                    name,  # coin_name
+                    "XSN",  # coin_shortcut
+                    8,  # decimals
+                    76,  # address_type
+                    16,  # address_type_p2sh
+                    11000000000,  # maxfee_kb
+                    "DarkCoin Signed Message:\n",  # signed_message_header
+                    0x0488b21e,  # xpub_magic
+                    0x049d7cb2,  # xpub_magic_segwit_p2sh
+                    0x04b24746,  # xpub_magic_segwit_native
+                    0x0488b21e,  # xpub_magic_multisig_segwit_p2sh
+                    0x0488b21e,  # xpub_magic_multisig_segwit_native
+                    "xc",  # bech32_prefix
+                    None,  # cashaddr_prefix
+                    199,  # slip44
+                    True,  # segwit
+                    False,  # taproot
+                    None,  # fork_id
+                    False,  # force_bip143
+                    False,  # decred
+                    False,  # negative_fee
+                    'secp256k1',  # curve_name
+                    True,  # extra_data
+                    False,  # timestamp
+                    False,  # overwintered
+                    None,  # confidential_assets
+                )
+            if name == "Syscoin":
+                return CoinInfo(
+                    name,  # coin_name
+                    "SYS",  # coin_shortcut
+                    8,  # decimals
+                    63,  # address_type
+                    5,  # address_type_p2sh
+                    42000000000,  # maxfee_kb
+                    "Syscoin Signed Message:\n",  # signed_message_header
+                    0x0488b21e,  # xpub_magic
+                    0x049d7cb2,  # xpub_magic_segwit_p2sh
+                    0x04b24746,  # xpub_magic_segwit_native
+                    0x0488b21e,  # xpub_magic_multisig_segwit_p2sh
+                    0x0488b21e,  # xpub_magic_multisig_segwit_native
+                    "sys",  # bech32_prefix
+                    None,  # cashaddr_prefix
+                    57,  # slip44
+                    True,  # segwit
+                    False,  # taproot
+                    None,  # fork_id
+                    False,  # force_bip143
+                    False,  # decred
+                    False,  # negative_fee
+                    'secp256k1',  # curve_name
+                    False,  # extra_data
+                    False,  # timestamp
+                    False,  # overwintered
+                    None,  # confidential_assets
+                )
+            if name == "Unobtanium":
+                return CoinInfo(
+                    name,  # coin_name
+                    "UNO",  # coin_shortcut
+                    8,  # decimals
+                    130,  # address_type
+                    30,  # address_type_p2sh
+                    53000000,  # maxfee_kb
+                    "Unobtanium Signed Message:\n",  # signed_message_header
+                    0x0488b21e,  # xpub_magic
+                    None,  # xpub_magic_segwit_p2sh
+                    None,  # xpub_magic_segwit_native
+                    None,  # xpub_magic_multisig_segwit_p2sh
+                    None,  # xpub_magic_multisig_segwit_native
+                    None,  # bech32_prefix
+                    None,  # cashaddr_prefix
+                    92,  # slip44
+                    False,  # segwit
+                    False,  # taproot
+                    None,  # fork_id
+                    False,  # force_bip143
+                    False,  # decred
+                    False,  # negative_fee
+                    'secp256k1',  # curve_name
+                    False,  # extra_data
+                    False,  # timestamp
+                    False,  # overwintered
+                    None,  # confidential_assets
+                )
+            if name == "VIPSTARCOIN":
+                return CoinInfo(
+                    name,  # coin_name
+                    "VIPS",  # coin_shortcut
+                    8,  # decimals
+                    70,  # address_type
+                    50,  # address_type_p2sh
+                    140000000000000,  # maxfee_kb
+                    "VIPSTARCOIN Signed Message:\n",  # signed_message_header
+                    0x0488b21e,  # xpub_magic
+                    0x049d7cb2,  # xpub_magic_segwit_p2sh
+                    0x04b24746,  # xpub_magic_segwit_native
+                    0x0488b21e,  # xpub_magic_multisig_segwit_p2sh
+                    0x0488b21e,  # xpub_magic_multisig_segwit_native
+                    "vips",  # bech32_prefix
+                    None,  # cashaddr_prefix
+                    1919,  # slip44
+                    True,  # segwit
+                    False,  # taproot
+                    None,  # fork_id
+                    False,  # force_bip143
+                    False,  # decred
+                    False,  # negative_fee
+                    'secp256k1',  # curve_name
+                    False,  # extra_data
+                    False,  # timestamp
+                    False,  # overwintered
+                    None,  # confidential_assets
+                )
+            if name == "Verge":
+                return CoinInfo(
+                    name,  # coin_name
+                    "XVG",  # coin_shortcut
+                    6,  # decimals
+                    30,  # address_type
+                    33,  # address_type_p2sh
+                    550000000000,  # maxfee_kb
+                    "Name: Dogecoin Dark\n",  # signed_message_header
+                    0x022d2533,  # xpub_magic
+                    None,  # xpub_magic_segwit_p2sh
+                    None,  # xpub_magic_segwit_native
+                    None,  # xpub_magic_multisig_segwit_p2sh
+                    None,  # xpub_magic_multisig_segwit_native
+                    None,  # bech32_prefix
+                    None,  # cashaddr_prefix
+                    77,  # slip44
+                    False,  # segwit
+                    False,  # taproot
+                    None,  # fork_id
+                    False,  # force_bip143
+                    False,  # decred
+                    False,  # negative_fee
+                    'secp256k1',  # curve_name
+                    False,  # extra_data
+                    True,  # timestamp
+                    False,  # overwintered
+                    None,  # confidential_assets
+                )
+            if name == "Viacoin":
+                return CoinInfo(
+                    name,  # coin_name
+                    "VIA",  # coin_shortcut
+                    8,  # decimals
+                    71,  # address_type
+                    33,  # address_type_p2sh
+                    14000000000,  # maxfee_kb
+                    "Viacoin Signed Message:\n",  # signed_message_header
+                    0x0488b21e,  # xpub_magic
+                    0x049d7cb2,  # xpub_magic_segwit_p2sh
+                    0x04b24746,  # xpub_magic_segwit_native
+                    0x0488b21e,  # xpub_magic_multisig_segwit_p2sh
+                    0x0488b21e,  # xpub_magic_multisig_segwit_native
+                    "via",  # bech32_prefix
+                    None,  # cashaddr_prefix
+                    14,  # slip44
+                    True,  # segwit
+                    False,  # taproot
+                    None,  # fork_id
+                    False,  # force_bip143
+                    False,  # decred
+                    False,  # negative_fee
+                    'secp256k1',  # curve_name
+                    False,  # extra_data
+                    False,  # timestamp
+                    False,  # overwintered
+                    None,  # confidential_assets
+                )
+            if name == "ZCore":
+                return CoinInfo(
+                    name,  # coin_name
+                    "ZCR",  # coin_shortcut
+                    8,  # decimals
+                    142,  # address_type
+                    145,  # address_type_p2sh
+                    170000000000,  # maxfee_kb
+                    "DarkNet Signed Message:\n",  # signed_message_header
+                    0x04b24746,  # xpub_magic
+                    None,  # xpub_magic_segwit_p2sh
+                    None,  # xpub_magic_segwit_native
+                    None,  # xpub_magic_multisig_segwit_p2sh
+                    None,  # xpub_magic_multisig_segwit_native
+                    None,  # bech32_prefix
+                    None,  # cashaddr_prefix
+                    428,  # slip44
+                    False,  # segwit
+                    False,  # taproot
+                    None,  # fork_id
+                    False,  # force_bip143
+                    False,  # decred
+                    False,  # negative_fee
+                    'secp256k1',  # curve_name
+                    False,  # extra_data
+                    False,  # timestamp
+                    False,  # overwintered
+                    None,  # confidential_assets
+                )
+            if name == "Zcash":
+                return CoinInfo(
+                    name,  # coin_name
+                    "ZEC",  # coin_shortcut
+                    8,  # decimals
+                    7352,  # address_type
+                    7357,  # address_type_p2sh
+                    51000000,  # maxfee_kb
+                    "Zcash Signed Message:\n",  # signed_message_header
+                    0x0488b21e,  # xpub_magic
+                    None,  # xpub_magic_segwit_p2sh
+                    None,  # xpub_magic_segwit_native
+                    None,  # xpub_magic_multisig_segwit_p2sh
+                    None,  # xpub_magic_multisig_segwit_native
+                    None,  # bech32_prefix
+                    None,  # cashaddr_prefix
+                    133,  # slip44
+                    False,  # segwit
+                    False,  # taproot
+                    None,  # fork_id
+                    False,  # force_bip143
+                    False,  # decred
+                    False,  # negative_fee
+                    'secp256k1',  # curve_name
+                    True,  # extra_data
+                    False,  # timestamp
+                    True,  # overwintered
+                    None,  # confidential_assets
+                )
+            if name == "Zcash Testnet":
+                return CoinInfo(
+                    name,  # coin_name
+                    "TAZ",  # coin_shortcut
+                    8,  # decimals
+                    7461,  # address_type
+                    7354,  # address_type_p2sh
+                    10000000,  # maxfee_kb
+                    "Zcash Signed Message:\n",  # signed_message_header
+                    0x043587cf,  # xpub_magic
+                    None,  # xpub_magic_segwit_p2sh
+                    None,  # xpub_magic_segwit_native
+                    None,  # xpub_magic_multisig_segwit_p2sh
+                    None,  # xpub_magic_multisig_segwit_native
+                    None,  # bech32_prefix
+                    None,  # cashaddr_prefix
+                    1,  # slip44
+                    False,  # segwit
+                    False,  # taproot
+                    None,  # fork_id
+                    False,  # force_bip143
+                    False,  # decred
+                    False,  # negative_fee
+                    'secp256k1',  # curve_name
+                    True,  # extra_data
+                    False,  # timestamp
+                    True,  # overwintered
+                    None,  # confidential_assets
+                )
+            if name == "Brhodium":
+                return CoinInfo(
+                    name,  # coin_name
+                    "XRC",  # coin_shortcut
+                    8,  # decimals
+                    61,  # address_type
+                    123,  # address_type_p2sh
+                    1000000000,  # maxfee_kb
+                    "BitCoin Rhodium Signed Message:\n",  # signed_message_header
+                    0x0488b21e,  # xpub_magic
+                    None,  # xpub_magic_segwit_p2sh
+                    None,  # xpub_magic_segwit_native
+                    None,  # xpub_magic_multisig_segwit_p2sh
+                    None,  # xpub_magic_multisig_segwit_native
+                    None,  # bech32_prefix
+                    None,  # cashaddr_prefix
+                    10291,  # slip44
+                    False,  # segwit
+                    False,  # taproot
+                    None,  # fork_id
+                    False,  # force_bip143
+                    False,  # decred
+                    False,  # negative_fee
+                    'secp256k1',  # curve_name
+                    False,  # extra_data
+                    False,  # timestamp
+                    False,  # overwintered
+                    None,  # confidential_assets
+                )
+        raise ValueError  # Unknown coin name
+    if utils.INTERNAL_MODEL == "T3T1":
+        if name == "Bitcoin":
+            return CoinInfo(
+                name,  # coin_name
+                "BTC",  # coin_shortcut
+                8,  # decimals
+                0,  # address_type
+                5,  # address_type_p2sh
+                2000000,  # maxfee_kb
+                "Bitcoin Signed Message:\n",  # signed_message_header
+                0x0488b21e,  # xpub_magic
+                0x049d7cb2,  # xpub_magic_segwit_p2sh
+                0x04b24746,  # xpub_magic_segwit_native
+                0x0295b43f,  # xpub_magic_multisig_segwit_p2sh
+                0x02aa7ed3,  # xpub_magic_multisig_segwit_native
+                "bc",  # bech32_prefix
+                None,  # cashaddr_prefix
+                0,  # slip44
+                True,  # segwit
+                True,  # taproot
+                None,  # fork_id
+                False,  # force_bip143
+                False,  # decred
+                False,  # negative_fee
+                'secp256k1',  # curve_name
+                False,  # extra_data
+                False,  # timestamp
+                False,  # overwintered
+                None,  # confidential_assets
+            )
+        if name == "Regtest":
+            return CoinInfo(
+                name,  # coin_name
+                "REGTEST",  # coin_shortcut
+                8,  # decimals
+                111,  # address_type
+                196,  # address_type_p2sh
+                10000000,  # maxfee_kb
+                "Bitcoin Signed Message:\n",  # signed_message_header
+                0x043587cf,  # xpub_magic
+                0x044a5262,  # xpub_magic_segwit_p2sh
+                0x045f1cf6,  # xpub_magic_segwit_native
+                0x024289ef,  # xpub_magic_multisig_segwit_p2sh
+                0x02575483,  # xpub_magic_multisig_segwit_native
+                "bcrt",  # bech32_prefix
+                None,  # cashaddr_prefix
+                1,  # slip44
+                True,  # segwit
+                True,  # taproot
+                None,  # fork_id
+                False,  # force_bip143
+                False,  # decred
+                False,  # negative_fee
+                'secp256k1',  # curve_name
+                False,  # extra_data
+                False,  # timestamp
+                False,  # overwintered
+                None,  # confidential_assets
+            )
+        if name == "Testnet":
+            return CoinInfo(
+                name,  # coin_name
+                "TEST",  # coin_shortcut
+                8,  # decimals
+                111,  # address_type
+                196,  # address_type_p2sh
+                10000000,  # maxfee_kb
+                "Bitcoin Signed Message:\n",  # signed_message_header
+                0x043587cf,  # xpub_magic
+                0x044a5262,  # xpub_magic_segwit_p2sh
+                0x045f1cf6,  # xpub_magic_segwit_native
+                0x024289ef,  # xpub_magic_multisig_segwit_p2sh
+                0x02575483,  # xpub_magic_multisig_segwit_native
+                "tb",  # bech32_prefix
+                None,  # cashaddr_prefix
+                1,  # slip44
+                True,  # segwit
+                True,  # taproot
+                None,  # fork_id
+                False,  # force_bip143
+                False,  # decred
+                False,  # negative_fee
+                'secp256k1',  # curve_name
+                False,  # extra_data
+                False,  # timestamp
+                False,  # overwintered
+                None,  # confidential_assets
+            )
+        if not utils.BITCOIN_ONLY:
+            if name == "Actinium":
+                return CoinInfo(
+                    name,  # coin_name
+                    "ACM",  # coin_shortcut
+                    8,  # decimals
+                    53,  # address_type
+                    55,  # address_type_p2sh
+                    320000000000,  # maxfee_kb
+                    "Actinium Signed Message:\n",  # signed_message_header
+                    0x0488b21e,  # xpub_magic
+                    0x049d7cb2,  # xpub_magic_segwit_p2sh
+                    0x04b24746,  # xpub_magic_segwit_native
+                    0x0488b21e,  # xpub_magic_multisig_segwit_p2sh
+                    0x0488b21e,  # xpub_magic_multisig_segwit_native
+                    "acm",  # bech32_prefix
+                    None,  # cashaddr_prefix
+                    228,  # slip44
+                    True,  # segwit
+                    False,  # taproot
+                    None,  # fork_id
+                    False,  # force_bip143
+                    False,  # decred
+                    False,  # negative_fee
+                    'secp256k1',  # curve_name
+                    False,  # extra_data
+                    False,  # timestamp
+                    False,  # overwintered
+                    None,  # confidential_assets
+                )
+            if name == "Axe":
+                return CoinInfo(
+                    name,  # coin_name
+                    "AXE",  # coin_shortcut
+                    8,  # decimals
+                    55,  # address_type
+                    16,  # address_type_p2sh
+                    21000000000,  # maxfee_kb
+                    "DarkCoin Signed Message:\n",  # signed_message_header
+                    0x02fe52cc,  # xpub_magic
+                    None,  # xpub_magic_segwit_p2sh
+                    None,  # xpub_magic_segwit_native
+                    None,  # xpub_magic_multisig_segwit_p2sh
+                    None,  # xpub_magic_multisig_segwit_native
+                    None,  # bech32_prefix
+                    None,  # cashaddr_prefix
+                    4242,  # slip44
+                    False,  # segwit
+                    False,  # taproot
+                    None,  # fork_id
+                    False,  # force_bip143
+                    False,  # decred
+                    False,  # negative_fee
+                    'secp256k1',  # curve_name
+                    False,  # extra_data
+                    False,  # timestamp
+                    False,  # overwintered
+                    None,  # confidential_assets
+                )
+            if name == "Bcash":
+                return CoinInfo(
+                    name,  # coin_name
+                    "BCH",  # coin_shortcut
+                    8,  # decimals
+                    0,  # address_type
+                    5,  # address_type_p2sh
+                    14000000,  # maxfee_kb
+                    "Bitcoin Signed Message:\n",  # signed_message_header
+                    0x0488b21e,  # xpub_magic
+                    None,  # xpub_magic_segwit_p2sh
+                    None,  # xpub_magic_segwit_native
+                    None,  # xpub_magic_multisig_segwit_p2sh
+                    None,  # xpub_magic_multisig_segwit_native
+                    None,  # bech32_prefix
+                    "bitcoincash",  # cashaddr_prefix
+                    145,  # slip44
+                    False,  # segwit
+                    False,  # taproot
+                    0,  # fork_id
+                    True,  # force_bip143
+                    False,  # decred
+                    False,  # negative_fee
+                    'secp256k1',  # curve_name
+                    False,  # extra_data
+                    False,  # timestamp
+                    False,  # overwintered
+                    None,  # confidential_assets
+                )
+            if name == "Bcash Testnet":
+                return CoinInfo(
+                    name,  # coin_name
+                    "TBCH",  # coin_shortcut
+                    8,  # decimals
+                    111,  # address_type
+                    196,  # address_type_p2sh
+                    10000000,  # maxfee_kb
+                    "Bitcoin Signed Message:\n",  # signed_message_header
+                    0x043587cf,  # xpub_magic
+                    None,  # xpub_magic_segwit_p2sh
+                    None,  # xpub_magic_segwit_native
+                    None,  # xpub_magic_multisig_segwit_p2sh
+                    None,  # xpub_magic_multisig_segwit_native
+                    None,  # bech32_prefix
+                    "bchtest",  # cashaddr_prefix
+                    1,  # slip44
+                    False,  # segwit
+                    False,  # taproot
+                    0,  # fork_id
+                    True,  # force_bip143
+                    False,  # decred
+                    False,  # negative_fee
+                    'secp256k1',  # curve_name
+                    False,  # extra_data
+                    False,  # timestamp
+                    False,  # overwintered
+                    None,  # confidential_assets
+                )
+            if name == "Bprivate":
+                return CoinInfo(
+                    name,  # coin_name
+                    "BTCP",  # coin_shortcut
+                    8,  # decimals
+                    4901,  # address_type
+                    5039,  # address_type_p2sh
+                    32000000000,  # maxfee_kb
+                    "BitcoinPrivate Signed Message:\n",  # signed_message_header
+                    0x0488b21e,  # xpub_magic
+                    None,  # xpub_magic_segwit_p2sh
+                    None,  # xpub_magic_segwit_native
+                    None,  # xpub_magic_multisig_segwit_p2sh
+                    None,  # xpub_magic_multisig_segwit_native
+                    None,  # bech32_prefix
+                    None,  # cashaddr_prefix
+                    183,  # slip44
+                    False,  # segwit
+                    False,  # taproot
+                    42,  # fork_id
+                    False,  # force_bip143
+                    False,  # decred
+                    False,  # negative_fee
+                    'secp256k1',  # curve_name
+                    False,  # extra_data
+                    False,  # timestamp
+                    False,  # overwintered
+                    None,  # confidential_assets
+                )
+            if name == "Bitcore":
+                return CoinInfo(
+                    name,  # coin_name
+                    "BTX",  # coin_shortcut
+                    8,  # decimals
+                    3,  # address_type
+                    125,  # address_type_p2sh
+                    14000000000,  # maxfee_kb
+                    "BitCore Signed Message:\n",  # signed_message_header
+                    0x0488b21e,  # xpub_magic
+                    0x049d7cb2,  # xpub_magic_segwit_p2sh
+                    0x04b24746,  # xpub_magic_segwit_native
+                    0x0488b21e,  # xpub_magic_multisig_segwit_p2sh
+                    0x0488b21e,  # xpub_magic_multisig_segwit_native
+                    "btx",  # bech32_prefix
+                    None,  # cashaddr_prefix
+                    160,  # slip44
+                    True,  # segwit
+                    False,  # taproot
+                    None,  # fork_id
+                    False,  # force_bip143
+                    False,  # decred
+                    False,  # negative_fee
+                    'secp256k1',  # curve_name
+                    False,  # extra_data
+                    False,  # timestamp
+                    False,  # overwintered
+                    None,  # confidential_assets
+                )
+            if name == "CPUchain":
+                return CoinInfo(
+                    name,  # coin_name
+                    "CPU",  # coin_shortcut
+                    8,  # decimals
+                    28,  # address_type
+                    30,  # address_type_p2sh
+                    8700000000000,  # maxfee_kb
+                    "CPUchain Signed Message:\n",  # signed_message_header
+                    0x0488b21e,  # xpub_magic
+                    0x049d7cb2,  # xpub_magic_segwit_p2sh
+                    0x04b24746,  # xpub_magic_segwit_native
+                    0x0488b21e,  # xpub_magic_multisig_segwit_p2sh
+                    0x0488b21e,  # xpub_magic_multisig_segwit_native
+                    "cpu",  # bech32_prefix
+                    None,  # cashaddr_prefix
+                    363,  # slip44
+                    True,  # segwit
+                    False,  # taproot
+                    None,  # fork_id
+                    False,  # force_bip143
+                    False,  # decred
+                    False,  # negative_fee
+                    'secp256k1',  # curve_name
+                    False,  # extra_data
+                    False,  # timestamp
+                    False,  # overwintered
+                    None,  # confidential_assets
+                )
+            if name == "Crown":
+                return CoinInfo(
+                    name,  # coin_name
+                    "CRW",  # coin_shortcut
+                    8,  # decimals
+                    95495,  # address_type
+                    95473,  # address_type_p2sh
+                    52000000000,  # maxfee_kb
+                    "Crown Signed Message:\n",  # signed_message_header
+                    0x0488b21e,  # xpub_magic
+                    None,  # xpub_magic_segwit_p2sh
+                    None,  # xpub_magic_segwit_native
+                    None,  # xpub_magic_multisig_segwit_p2sh
+                    None,  # xpub_magic_multisig_segwit_native
+                    None,  # bech32_prefix
+                    None,  # cashaddr_prefix
+                    72,  # slip44
+                    False,  # segwit
+                    False,  # taproot
+                    None,  # fork_id
+                    False,  # force_bip143
+                    False,  # decred
+                    False,  # negative_fee
+                    'secp256k1',  # curve_name
+                    False,  # extra_data
+                    False,  # timestamp
+                    False,  # overwintered
+                    None,  # confidential_assets
+                )
+            if name == "Dogecoin":
+                return CoinInfo(
+                    name,  # coin_name
+                    "DOGE",  # coin_shortcut
+                    8,  # decimals
+                    30,  # address_type
+                    22,  # address_type_p2sh
+                    1200000000000,  # maxfee_kb
+                    "Dogecoin Signed Message:\n",  # signed_message_header
+                    0x02facafd,  # xpub_magic
+                    None,  # xpub_magic_segwit_p2sh
+                    None,  # xpub_magic_segwit_native
+                    None,  # xpub_magic_multisig_segwit_p2sh
+                    None,  # xpub_magic_multisig_segwit_native
+                    None,  # bech32_prefix
+                    None,  # cashaddr_prefix
+                    3,  # slip44
+                    False,  # segwit
+                    False,  # taproot
+                    None,  # fork_id
+                    False,  # force_bip143
+                    False,  # decred
+                    False,  # negative_fee
+                    'secp256k1',  # curve_name
+                    False,  # extra_data
+                    False,  # timestamp
+                    False,  # overwintered
+                    None,  # confidential_assets
+                )
+            if name == "Elements":
+                return CoinInfo(
+                    name,  # coin_name
+                    "ELEMENTS",  # coin_shortcut
+                    8,  # decimals
+                    235,  # address_type
+                    75,  # address_type_p2sh
+                    10000000,  # maxfee_kb
+                    "Bitcoin Signed Message:\n",  # signed_message_header
+                    0x043587cf,  # xpub_magic
+                    0x044a5262,  # xpub_magic_segwit_p2sh
+                    0x045f1cf6,  # xpub_magic_segwit_native
+                    0x043587cf,  # xpub_magic_multisig_segwit_p2sh
+                    0x043587cf,  # xpub_magic_multisig_segwit_native
+                    "ert",  # bech32_prefix
+                    None,  # cashaddr_prefix
+                    1,  # slip44
+                    True,  # segwit
+                    False,  # taproot
+                    None,  # fork_id
+                    False,  # force_bip143
+                    False,  # decred
+                    False,  # negative_fee
+                    'secp256k1',  # curve_name
+                    False,  # extra_data
+                    False,  # timestamp
+                    False,  # overwintered
+                    {'address_prefix': 4, 'blech32_prefix': 'el'},  # confidential_assets
+                )
+            if name == "Feathercoin":
+                return CoinInfo(
+                    name,  # coin_name
+                    "FTC",  # coin_shortcut
+                    8,  # decimals
+                    14,  # address_type
+                    5,  # address_type_p2sh
+                    390000000000,  # maxfee_kb
+                    "Feathercoin Signed Message:\n",  # signed_message_header
+                    0x0488bc26,  # xpub_magic
+                    0x049d7cb2,  # xpub_magic_segwit_p2sh
+                    0x04b24746,  # xpub_magic_segwit_native
+                    0x0488bc26,  # xpub_magic_multisig_segwit_p2sh
+                    0x0488bc26,  # xpub_magic_multisig_segwit_native
+                    "fc",  # bech32_prefix
+                    None,  # cashaddr_prefix
+                    8,  # slip44
+                    True,  # segwit
+                    False,  # taproot
+                    None,  # fork_id
+                    False,  # force_bip143
+                    False,  # decred
+                    False,  # negative_fee
+                    'secp256k1',  # curve_name
+                    False,  # extra_data
+                    False,  # timestamp
+                    False,  # overwintered
+                    None,  # confidential_assets
+                )
+            if name == "Firo":
+                return CoinInfo(
+                    name,  # coin_name
+                    "FIRO",  # coin_shortcut
+                    8,  # decimals
+                    82,  # address_type
+                    7,  # address_type_p2sh
+                    640000000,  # maxfee_kb
+                    "Zcoin Signed Message:\n",  # signed_message_header
+                    0x0488b21e,  # xpub_magic
+                    None,  # xpub_magic_segwit_p2sh
+                    None,  # xpub_magic_segwit_native
+                    None,  # xpub_magic_multisig_segwit_p2sh
+                    None,  # xpub_magic_multisig_segwit_native
+                    None,  # bech32_prefix
+                    None,  # cashaddr_prefix
+                    136,  # slip44
+                    False,  # segwit
+                    False,  # taproot
+                    None,  # fork_id
+                    False,  # force_bip143
+                    False,  # decred
+                    False,  # negative_fee
+                    'secp256k1',  # curve_name
+                    True,  # extra_data
+                    False,  # timestamp
+                    False,  # overwintered
+                    None,  # confidential_assets
+                )
+            if name == "Firo Testnet":
+                return CoinInfo(
+                    name,  # coin_name
+                    "tFIRO",  # coin_shortcut
+                    8,  # decimals
+                    65,  # address_type
+                    178,  # address_type_p2sh
+                    1000000,  # maxfee_kb
+                    "Zcoin Signed Message:\n",  # signed_message_header
+                    0x043587cf,  # xpub_magic
+                    None,  # xpub_magic_segwit_p2sh
+                    None,  # xpub_magic_segwit_native
+                    None,  # xpub_magic_multisig_segwit_p2sh
+                    None,  # xpub_magic_multisig_segwit_native
+                    None,  # bech32_prefix
+                    None,  # cashaddr_prefix
+                    1,  # slip44
+                    False,  # segwit
+                    False,  # taproot
+                    None,  # fork_id
+                    False,  # force_bip143
+                    False,  # decred
+                    False,  # negative_fee
+                    'secp256k1',  # curve_name
+                    True,  # extra_data
+                    False,  # timestamp
+                    False,  # overwintered
+                    None,  # confidential_assets
+                )
+            if name == "Florincoin":
+                return CoinInfo(
+                    name,  # coin_name
+                    "FLO",  # coin_shortcut
+                    8,  # decimals
+                    35,  # address_type
+                    94,  # address_type_p2sh
+                    78000000000,  # maxfee_kb
+                    "Florincoin Signed Message:\n",  # signed_message_header
+                    0x00174921,  # xpub_magic
+                    0x01b26ef6,  # xpub_magic_segwit_p2sh
+                    0x04b24746,  # xpub_magic_segwit_native
+                    0x00174921,  # xpub_magic_multisig_segwit_p2sh
+                    0x00174921,  # xpub_magic_multisig_segwit_native
+                    "flo",  # bech32_prefix
+                    None,  # cashaddr_prefix
+                    216,  # slip44
+                    True,  # segwit
+                    False,  # taproot
+                    None,  # fork_id
+                    False,  # force_bip143
+                    False,  # decred
+                    False,  # negative_fee
+                    'secp256k1',  # curve_name
+                    True,  # extra_data
+                    False,  # timestamp
+                    False,  # overwintered
+                    None,  # confidential_assets
+                )
+            if name == "Fujicoin":
+                return CoinInfo(
+                    name,  # coin_name
+                    "FJC",  # coin_shortcut
+                    8,  # decimals
+                    36,  # address_type
+                    16,  # address_type_p2sh
+                    35000000000000,  # maxfee_kb
+                    "FujiCoin Signed Message:\n",  # signed_message_header
+                    0x0488b21e,  # xpub_magic
+                    0x049d7cb2,  # xpub_magic_segwit_p2sh
+                    0x04b24746,  # xpub_magic_segwit_native
+                    0x0295b43f,  # xpub_magic_multisig_segwit_p2sh
+                    0x02aa7ed3,  # xpub_magic_multisig_segwit_native
+                    "fc",  # bech32_prefix
+                    None,  # cashaddr_prefix
+                    75,  # slip44
+                    True,  # segwit
+                    True,  # taproot
+                    None,  # fork_id
+                    False,  # force_bip143
+                    False,  # decred
+                    False,  # negative_fee
+                    'secp256k1',  # curve_name
+                    False,  # extra_data
+                    False,  # timestamp
+                    False,  # overwintered
+                    None,  # confidential_assets
+                )
+            if name == "Groestlcoin":
+                return CoinInfo(
+                    name,  # coin_name
+                    "GRS",  # coin_shortcut
+                    8,  # decimals
+                    36,  # address_type
+                    5,  # address_type_p2sh
+                    16000000000,  # maxfee_kb
+                    "GroestlCoin Signed Message:\n",  # signed_message_header
+                    0x0488b21e,  # xpub_magic
+                    0x049d7cb2,  # xpub_magic_segwit_p2sh
+                    0x04b24746,  # xpub_magic_segwit_native
+                    0x0488b21e,  # xpub_magic_multisig_segwit_p2sh
+                    0x0488b21e,  # xpub_magic_multisig_segwit_native
+                    "grs",  # bech32_prefix
+                    None,  # cashaddr_prefix
+                    17,  # slip44
+                    True,  # segwit
+                    True,  # taproot
+                    None,  # fork_id
+                    False,  # force_bip143
+                    False,  # decred
+                    False,  # negative_fee
+                    'secp256k1-groestl',  # curve_name
+                    False,  # extra_data
+                    False,  # timestamp
+                    False,  # overwintered
+                    None,  # confidential_assets
+                )
+            if name == "Groestlcoin Testnet":
+                return CoinInfo(
+                    name,  # coin_name
+                    "tGRS",  # coin_shortcut
+                    8,  # decimals
+                    111,  # address_type
+                    196,  # address_type_p2sh
+                    100000,  # maxfee_kb
+                    "GroestlCoin Signed Message:\n",  # signed_message_header
+                    0x043587cf,  # xpub_magic
+                    0x044a5262,  # xpub_magic_segwit_p2sh
+                    0x045f1cf6,  # xpub_magic_segwit_native
+                    0x043587cf,  # xpub_magic_multisig_segwit_p2sh
+                    0x043587cf,  # xpub_magic_multisig_segwit_native
+                    "tgrs",  # bech32_prefix
+                    None,  # cashaddr_prefix
+                    1,  # slip44
+                    True,  # segwit
+                    True,  # taproot
+                    None,  # fork_id
+                    False,  # force_bip143
+                    False,  # decred
+                    False,  # negative_fee
+                    'secp256k1-groestl',  # curve_name
+                    False,  # extra_data
+                    False,  # timestamp
+                    False,  # overwintered
+                    None,  # confidential_assets
+                )
+            if name == "Komodo":
+                return CoinInfo(
+                    name,  # coin_name
+                    "KMD",  # coin_shortcut
+                    8,  # decimals
+                    60,  # address_type
+                    85,  # address_type_p2sh
+                    4800000000,  # maxfee_kb
+                    "Komodo Signed Message:\n",  # signed_message_header
+                    0x0488b21e,  # xpub_magic
+                    None,  # xpub_magic_segwit_p2sh
+                    None,  # xpub_magic_segwit_native
+                    None,  # xpub_magic_multisig_segwit_p2sh
+                    None,  # xpub_magic_multisig_segwit_native
+                    None,  # bech32_prefix
+                    None,  # cashaddr_prefix
+                    141,  # slip44
+                    False,  # segwit
+                    False,  # taproot
+                    None,  # fork_id
+                    False,  # force_bip143
+                    False,  # decred
+                    True,  # negative_fee
+                    'secp256k1',  # curve_name
+                    True,  # extra_data
+                    False,  # timestamp
+                    True,  # overwintered
+                    None,  # confidential_assets
+                )
+            if name == "Koto":
+                return CoinInfo(
+                    name,  # coin_name
+                    "KOTO",  # coin_shortcut
+                    8,  # decimals
+                    6198,  # address_type
+                    6203,  # address_type_p2sh
+                    1000000,  # maxfee_kb
+                    "Koto Signed Message:\n",  # signed_message_header
+                    0x0488b21e,  # xpub_magic
+                    None,  # xpub_magic_segwit_p2sh
+                    None,  # xpub_magic_segwit_native
+                    None,  # xpub_magic_multisig_segwit_p2sh
+                    None,  # xpub_magic_multisig_segwit_native
+                    None,  # bech32_prefix
+                    None,  # cashaddr_prefix
+                    510,  # slip44
+                    False,  # segwit
+                    False,  # taproot
+                    None,  # fork_id
+                    False,  # force_bip143
+                    False,  # decred
+                    False,  # negative_fee
+                    'secp256k1',  # curve_name
+                    True,  # extra_data
+                    False,  # timestamp
+                    True,  # overwintered
+                    None,  # confidential_assets
+                )
+            if name == "Litecoin":
+                return CoinInfo(
+                    name,  # coin_name
+                    "LTC",  # coin_shortcut
+                    8,  # decimals
+                    48,  # address_type
+                    50,  # address_type_p2sh
+                    67000000,  # maxfee_kb
+                    "Litecoin Signed Message:\n",  # signed_message_header
+                    0x019da462,  # xpub_magic
+                    0x01b26ef6,  # xpub_magic_segwit_p2sh
+                    0x04b24746,  # xpub_magic_segwit_native
+                    0x019da462,  # xpub_magic_multisig_segwit_p2sh
+                    0x019da462,  # xpub_magic_multisig_segwit_native
+                    "ltc",  # bech32_prefix
+                    None,  # cashaddr_prefix
+                    2,  # slip44
+                    True,  # segwit
+                    False,  # taproot
+                    None,  # fork_id
+                    False,  # force_bip143
+                    False,  # decred
+                    False,  # negative_fee
+                    'secp256k1',  # curve_name
+                    False,  # extra_data
+                    False,  # timestamp
+                    False,  # overwintered
+                    None,  # confidential_assets
+                )
+            if name == "Litecoin Testnet":
+                return CoinInfo(
+                    name,  # coin_name
+                    "tLTC",  # coin_shortcut
+                    8,  # decimals
+                    111,  # address_type
+                    58,  # address_type_p2sh
+                    40000000,  # maxfee_kb
+                    "Litecoin Signed Message:\n",  # signed_message_header
+                    0x043587cf,  # xpub_magic
+                    0x044a5262,  # xpub_magic_segwit_p2sh
+                    0x045f1cf6,  # xpub_magic_segwit_native
+                    0x043587cf,  # xpub_magic_multisig_segwit_p2sh
+                    0x043587cf,  # xpub_magic_multisig_segwit_native
+                    "tltc",  # bech32_prefix
+                    None,  # cashaddr_prefix
+                    1,  # slip44
+                    True,  # segwit
+                    False,  # taproot
+                    None,  # fork_id
+                    False,  # force_bip143
+                    False,  # decred
+                    False,  # negative_fee
+                    'secp256k1',  # curve_name
+                    False,  # extra_data
+                    False,  # timestamp
+                    False,  # overwintered
+                    None,  # confidential_assets
+                )
+            if name == "Monacoin":
+                return CoinInfo(
+                    name,  # coin_name
+                    "MONA",  # coin_shortcut
+                    8,  # decimals
+                    50,  # address_type
+                    55,  # address_type_p2sh
+                    2100000000,  # maxfee_kb
+                    "Monacoin Signed Message:\n",  # signed_message_header
+                    0x0488b21e,  # xpub_magic
+                    0x049d7cb2,  # xpub_magic_segwit_p2sh
+                    0x04b24746,  # xpub_magic_segwit_native
+                    0x0488b21e,  # xpub_magic_multisig_segwit_p2sh
+                    0x0488b21e,  # xpub_magic_multisig_segwit_native
+                    "mona",  # bech32_prefix
+                    None,  # cashaddr_prefix
+                    22,  # slip44
+                    True,  # segwit
+                    False,  # taproot
+                    None,  # fork_id
+                    False,  # force_bip143
+                    False,  # decred
+                    False,  # negative_fee
+                    'secp256k1',  # curve_name
+                    False,  # extra_data
+                    False,  # timestamp
+                    False,  # overwintered
+                    None,  # confidential_assets
+                )
+            if name == "Peercoin":
+                return CoinInfo(
+                    name,  # coin_name
+                    "PPC",  # coin_shortcut
+                    6,  # decimals
+                    55,  # address_type
+                    117,  # address_type_p2sh
+                    13000000000,  # maxfee_kb
+                    "Peercoin Signed Message:\n",  # signed_message_header
+                    0x0488b21e,  # xpub_magic
+                    0x049d7cb2,  # xpub_magic_segwit_p2sh
+                    0x04b24746,  # xpub_magic_segwit_native
+                    0x0488b21e,  # xpub_magic_multisig_segwit_p2sh
+                    0x0488b21e,  # xpub_magic_multisig_segwit_native
+                    "pc",  # bech32_prefix
+                    None,  # cashaddr_prefix
+                    6,  # slip44
+                    True,  # segwit
+                    False,  # taproot
+                    None,  # fork_id
+                    False,  # force_bip143
+                    False,  # decred
+                    False,  # negative_fee
+                    'secp256k1',  # curve_name
+                    False,  # extra_data
+                    True,  # timestamp
+                    False,  # overwintered
+                    None,  # confidential_assets
+                )
+            if name == "Peercoin Testnet":
+                return CoinInfo(
+                    name,  # coin_name
+                    "tPPC",  # coin_shortcut
+                    6,  # decimals
+                    111,  # address_type
+                    196,  # address_type_p2sh
+                    2000000,  # maxfee_kb
+                    "Peercoin Signed Message:\n",  # signed_message_header
+                    0x043587cf,  # xpub_magic
+                    0x044a5262,  # xpub_magic_segwit_p2sh
+                    0x045f1cf6,  # xpub_magic_segwit_native
+                    0x043587cf,  # xpub_magic_multisig_segwit_p2sh
+                    0x043587cf,  # xpub_magic_multisig_segwit_native
+                    "tpc",  # bech32_prefix
+                    None,  # cashaddr_prefix
+                    1,  # slip44
+                    True,  # segwit
+                    False,  # taproot
+                    None,  # fork_id
+                    False,  # force_bip143
+                    False,  # decred
+                    False,  # negative_fee
+                    'secp256k1',  # curve_name
+                    False,  # extra_data
+                    True,  # timestamp
+                    False,  # overwintered
+                    None,  # confidential_assets
+                )
+            if name == "Primecoin":
+                return CoinInfo(
+                    name,  # coin_name
+                    "XPM",  # coin_shortcut
+                    8,  # decimals
+                    23,  # address_type
+                    83,  # address_type_p2sh
+                    89000000000,  # maxfee_kb
+                    "Primecoin Signed Message:\n",  # signed_message_header
+                    0x0488b21e,  # xpub_magic
+                    None,  # xpub_magic_segwit_p2sh
+                    None,  # xpub_magic_segwit_native
+                    None,  # xpub_magic_multisig_segwit_p2sh
+                    None,  # xpub_magic_multisig_segwit_native
+                    None,  # bech32_prefix
+                    None,  # cashaddr_prefix
+                    24,  # slip44
+                    False,  # segwit
+                    False,  # taproot
+                    None,  # fork_id
+                    False,  # force_bip143
+                    False,  # decred
+                    False,  # negative_fee
+                    'secp256k1',  # curve_name
+                    False,  # extra_data
+                    False,  # timestamp
+                    False,  # overwintered
+                    None,  # confidential_assets
+                )
+            if name == "Qtum":
+                return CoinInfo(
+                    name,  # coin_name
+                    "QTUM",  # coin_shortcut
+                    8,  # decimals
+                    58,  # address_type
+                    50,  # address_type_p2sh
+                    1000000000,  # maxfee_kb
+                    "Qtum Signed Message:\n",  # signed_message_header
+                    0x0488b21e,  # xpub_magic
+                    0x049d7cb2,  # xpub_magic_segwit_p2sh
+                    0x04b24746,  # xpub_magic_segwit_native
+                    0x0488b21e,  # xpub_magic_multisig_segwit_p2sh
+                    0x0488b21e,  # xpub_magic_multisig_segwit_native
+                    "qc",  # bech32_prefix
+                    None,  # cashaddr_prefix
+                    2301,  # slip44
+                    True,  # segwit
+                    False,  # taproot
+                    None,  # fork_id
+                    False,  # force_bip143
+                    False,  # decred
+                    False,  # negative_fee
+                    'secp256k1',  # curve_name
+                    False,  # extra_data
+                    False,  # timestamp
+                    False,  # overwintered
+                    None,  # confidential_assets
+                )
+            if name == "Qtum Testnet":
+                return CoinInfo(
+                    name,  # coin_name
+                    "tQTUM",  # coin_shortcut
+                    8,  # decimals
+                    120,  # address_type
+                    110,  # address_type_p2sh
+                    40000000,  # maxfee_kb
+                    "Qtum Signed Message:\n",  # signed_message_header
+                    0x043587cf,  # xpub_magic
+                    0x044a5262,  # xpub_magic_segwit_p2sh
+                    0x045f1cf6,  # xpub_magic_segwit_native
+                    0x043587cf,  # xpub_magic_multisig_segwit_p2sh
+                    0x043587cf,  # xpub_magic_multisig_segwit_native
+                    "tq",  # bech32_prefix
+                    None,  # cashaddr_prefix
+                    1,  # slip44
+                    True,  # segwit
+                    False,  # taproot
+                    None,  # fork_id
+                    False,  # force_bip143
+                    False,  # decred
+                    False,  # negative_fee
+                    'secp256k1',  # curve_name
+                    False,  # extra_data
+                    False,  # timestamp
+                    False,  # overwintered
+                    None,  # confidential_assets
+                )
+            if name == "Ravencoin":
+                return CoinInfo(
+                    name,  # coin_name
+                    "RVN",  # coin_shortcut
+                    8,  # decimals
+                    60,  # address_type
+                    122,  # address_type_p2sh
+                    170000000000,  # maxfee_kb
+                    "Raven Signed Message:\n",  # signed_message_header
+                    0x0488b21e,  # xpub_magic
+                    None,  # xpub_magic_segwit_p2sh
+                    None,  # xpub_magic_segwit_native
+                    None,  # xpub_magic_multisig_segwit_p2sh
+                    None,  # xpub_magic_multisig_segwit_native
+                    None,  # bech32_prefix
+                    None,  # cashaddr_prefix
+                    175,  # slip44
+                    False,  # segwit
+                    False,  # taproot
+                    None,  # fork_id
+                    False,  # force_bip143
+                    False,  # decred
+                    False,  # negative_fee
+                    'secp256k1',  # curve_name
+                    False,  # extra_data
+                    False,  # timestamp
+                    False,  # overwintered
+                    None,  # confidential_assets
+                )
+            if name == "Ravencoin Testnet":
+                return CoinInfo(
+                    name,  # coin_name
+                    "tRVN",  # coin_shortcut
+                    8,  # decimals
+                    111,  # address_type
+                    196,  # address_type_p2sh
+                    170000000000,  # maxfee_kb
+                    "Raven Signed Message:\n",  # signed_message_header
+                    0x043587cf,  # xpub_magic
+                    None,  # xpub_magic_segwit_p2sh
+                    None,  # xpub_magic_segwit_native
+                    None,  # xpub_magic_multisig_segwit_p2sh
+                    None,  # xpub_magic_multisig_segwit_native
+                    None,  # bech32_prefix
+                    None,  # cashaddr_prefix
+                    1,  # slip44
+                    False,  # segwit
+                    False,  # taproot
+                    None,  # fork_id
+                    False,  # force_bip143
+                    False,  # decred
+                    False,  # negative_fee
+                    'secp256k1',  # curve_name
+                    False,  # extra_data
+                    False,  # timestamp
+                    False,  # overwintered
+                    None,  # confidential_assets
+                )
+            if name == "Ritocoin":
+                return CoinInfo(
+                    name,  # coin_name
+                    "RITO",  # coin_shortcut
+                    8,  # decimals
+                    25,  # address_type
+                    105,  # address_type_p2sh
+                    39000000000000,  # maxfee_kb
+                    "Rito Signed Message:\n",  # signed_message_header
+                    0x0534e7ca,  # xpub_magic
+                    None,  # xpub_magic_segwit_p2sh
+                    None,  # xpub_magic_segwit_native
+                    None,  # xpub_magic_multisig_segwit_p2sh
+                    None,  # xpub_magic_multisig_segwit_native
+                    None,  # bech32_prefix
+                    None,  # cashaddr_prefix
+                    19169,  # slip44
+                    False,  # segwit
+                    False,  # taproot
+                    None,  # fork_id
+                    False,  # force_bip143
+                    False,  # decred
+                    False,  # negative_fee
+                    'secp256k1',  # curve_name
+                    False,  # extra_data
+                    False,  # timestamp
+                    False,  # overwintered
+                    None,  # confidential_assets
+                )
+            if name == "SmartCash":
+                return CoinInfo(
+                    name,  # coin_name
+                    "SMART",  # coin_shortcut
+                    8,  # decimals
+                    63,  # address_type
+                    18,  # address_type_p2sh
+                    780000000000,  # maxfee_kb
+                    "SmartCash Signed Message:\n",  # signed_message_header
+                    0x0488b21e,  # xpub_magic
+                    None,  # xpub_magic_segwit_p2sh
+                    None,  # xpub_magic_segwit_native
+                    None,  # xpub_magic_multisig_segwit_p2sh
+                    None,  # xpub_magic_multisig_segwit_native
+                    None,  # bech32_prefix
+                    None,  # cashaddr_prefix
+                    224,  # slip44
+                    False,  # segwit
+                    False,  # taproot
+                    None,  # fork_id
+                    False,  # force_bip143
+                    False,  # decred
+                    False,  # negative_fee
+                    'secp256k1-smart',  # curve_name
+                    False,  # extra_data
+                    False,  # timestamp
+                    False,  # overwintered
+                    None,  # confidential_assets
+                )
+            if name == "SmartCash Testnet":
+                return CoinInfo(
+                    name,  # coin_name
+                    "tSMART",  # coin_shortcut
+                    8,  # decimals
+                    65,  # address_type
+                    21,  # address_type_p2sh
+                    1000000,  # maxfee_kb
+                    "SmartCash Signed Message:\n",  # signed_message_header
+                    0x043587cf,  # xpub_magic
+                    None,  # xpub_magic_segwit_p2sh
+                    None,  # xpub_magic_segwit_native
+                    None,  # xpub_magic_multisig_segwit_p2sh
+                    None,  # xpub_magic_multisig_segwit_native
+                    None,  # bech32_prefix
+                    None,  # cashaddr_prefix
+                    1,  # slip44
+                    False,  # segwit
+                    False,  # taproot
+                    None,  # fork_id
+                    False,  # force_bip143
+                    False,  # decred
+                    False,  # negative_fee
+                    'secp256k1-smart',  # curve_name
+                    False,  # extra_data
+                    False,  # timestamp
+                    False,  # overwintered
+                    None,  # confidential_assets
+                )
+            if name == "Stakenet":
+                return CoinInfo(
+                    name,  # coin_name
+                    "XSN",  # coin_shortcut
+                    8,  # decimals
+                    76,  # address_type
+                    16,  # address_type_p2sh
+                    11000000000,  # maxfee_kb
+                    "DarkCoin Signed Message:\n",  # signed_message_header
+                    0x0488b21e,  # xpub_magic
+                    0x049d7cb2,  # xpub_magic_segwit_p2sh
+                    0x04b24746,  # xpub_magic_segwit_native
+                    0x0488b21e,  # xpub_magic_multisig_segwit_p2sh
+                    0x0488b21e,  # xpub_magic_multisig_segwit_native
+                    "xc",  # bech32_prefix
+                    None,  # cashaddr_prefix
+                    199,  # slip44
+                    True,  # segwit
+                    False,  # taproot
+                    None,  # fork_id
+                    False,  # force_bip143
+                    False,  # decred
+                    False,  # negative_fee
+                    'secp256k1',  # curve_name
+                    True,  # extra_data
+                    False,  # timestamp
+                    False,  # overwintered
+                    None,  # confidential_assets
+                )
+            if name == "Syscoin":
+                return CoinInfo(
+                    name,  # coin_name
+                    "SYS",  # coin_shortcut
+                    8,  # decimals
+                    63,  # address_type
+                    5,  # address_type_p2sh
+                    42000000000,  # maxfee_kb
+                    "Syscoin Signed Message:\n",  # signed_message_header
+                    0x0488b21e,  # xpub_magic
+                    0x049d7cb2,  # xpub_magic_segwit_p2sh
+                    0x04b24746,  # xpub_magic_segwit_native
+                    0x0488b21e,  # xpub_magic_multisig_segwit_p2sh
+                    0x0488b21e,  # xpub_magic_multisig_segwit_native
+                    "sys",  # bech32_prefix
+                    None,  # cashaddr_prefix
+                    57,  # slip44
+                    True,  # segwit
+                    False,  # taproot
+                    None,  # fork_id
+                    False,  # force_bip143
+                    False,  # decred
+                    False,  # negative_fee
+                    'secp256k1',  # curve_name
+                    False,  # extra_data
+                    False,  # timestamp
+                    False,  # overwintered
+                    None,  # confidential_assets
+                )
+            if name == "Unobtanium":
+                return CoinInfo(
+                    name,  # coin_name
+                    "UNO",  # coin_shortcut
+                    8,  # decimals
+                    130,  # address_type
+                    30,  # address_type_p2sh
+                    53000000,  # maxfee_kb
+                    "Unobtanium Signed Message:\n",  # signed_message_header
+                    0x0488b21e,  # xpub_magic
+                    None,  # xpub_magic_segwit_p2sh
+                    None,  # xpub_magic_segwit_native
+                    None,  # xpub_magic_multisig_segwit_p2sh
+                    None,  # xpub_magic_multisig_segwit_native
+                    None,  # bech32_prefix
+                    None,  # cashaddr_prefix
+                    92,  # slip44
+                    False,  # segwit
+                    False,  # taproot
+                    None,  # fork_id
+                    False,  # force_bip143
+                    False,  # decred
+                    False,  # negative_fee
+                    'secp256k1',  # curve_name
+                    False,  # extra_data
+                    False,  # timestamp
+                    False,  # overwintered
+                    None,  # confidential_assets
+                )
+            if name == "VIPSTARCOIN":
+                return CoinInfo(
+                    name,  # coin_name
+                    "VIPS",  # coin_shortcut
+                    8,  # decimals
+                    70,  # address_type
+                    50,  # address_type_p2sh
+                    140000000000000,  # maxfee_kb
+                    "VIPSTARCOIN Signed Message:\n",  # signed_message_header
+                    0x0488b21e,  # xpub_magic
+                    0x049d7cb2,  # xpub_magic_segwit_p2sh
+                    0x04b24746,  # xpub_magic_segwit_native
+                    0x0488b21e,  # xpub_magic_multisig_segwit_p2sh
+                    0x0488b21e,  # xpub_magic_multisig_segwit_native
+                    "vips",  # bech32_prefix
+                    None,  # cashaddr_prefix
+                    1919,  # slip44
+                    True,  # segwit
+                    False,  # taproot
+                    None,  # fork_id
+                    False,  # force_bip143
+                    False,  # decred
+                    False,  # negative_fee
+                    'secp256k1',  # curve_name
+                    False,  # extra_data
+                    False,  # timestamp
+                    False,  # overwintered
+                    None,  # confidential_assets
+                )
+            if name == "Verge":
+                return CoinInfo(
+                    name,  # coin_name
+                    "XVG",  # coin_shortcut
+                    6,  # decimals
+                    30,  # address_type
+                    33,  # address_type_p2sh
+                    550000000000,  # maxfee_kb
+                    "Name: Dogecoin Dark\n",  # signed_message_header
+                    0x022d2533,  # xpub_magic
+                    None,  # xpub_magic_segwit_p2sh
+                    None,  # xpub_magic_segwit_native
+                    None,  # xpub_magic_multisig_segwit_p2sh
+                    None,  # xpub_magic_multisig_segwit_native
+                    None,  # bech32_prefix
+                    None,  # cashaddr_prefix
+                    77,  # slip44
+                    False,  # segwit
+                    False,  # taproot
+                    None,  # fork_id
+                    False,  # force_bip143
+                    False,  # decred
+                    False,  # negative_fee
+                    'secp256k1',  # curve_name
+                    False,  # extra_data
+                    True,  # timestamp
                     False,  # overwintered
                     None,  # confidential_assets
                 )

--- a/core/src/apps/common/coininfo.py.mako
+++ b/core/src/apps/common/coininfo.py.mako
@@ -134,17 +134,15 @@ ATTRIBUTES = (
     ("confidential_assets", optional_dict),
 )
 
-models = ["T2B1", "T3T1", "T2T1"]
-
 btc_names = ["Bitcoin", "Testnet", "Regtest"]
 
 coins = {}
-for model in models:
+for model in ALL_MODELS:
     coins.setdefault('btc', {})[model] = [c for c in supported_on(model, bitcoin) if c.name in btc_names]
     coins.setdefault('alt', {})[model] = [c for c in supported_on(model, bitcoin) if c.name not in btc_names]
 %>\
 def by_name(name: str) -> CoinInfo:
-% for model in models:
+% for model in ALL_MODELS:
     if utils.INTERNAL_MODEL == "${model}":
 % for coin in coins['btc'][model]:
         if name == ${black_repr(coin["coin_name"])}:

--- a/core/src/apps/ethereum/networks.py
+++ b/core/src/apps/ethereum/networks.py
@@ -59,6 +59,43 @@ def by_slip44(slip44: int) -> EthereumNetworkInfo:
 
 # fmt: off
 def _networks_iterator() -> Iterator[NetworkInfoTuple]:
+    if utils.INTERNAL_MODEL == "T1B1":
+        yield (
+            1,  # chain_id
+            60,  # slip44
+            "ETH",  # symbol
+            "Ethereum",  # name
+        )
+        yield (
+            56,  # chain_id
+            714,  # slip44
+            "BNB",  # symbol
+            "BNB Smart Chain",  # name
+        )
+        yield (
+            61,  # chain_id
+            61,  # slip44
+            "ETC",  # symbol
+            "Ethereum Classic",  # name
+        )
+        yield (
+            137,  # chain_id
+            966,  # slip44
+            "MATIC",  # symbol
+            "Polygon",  # name
+        )
+        yield (
+            17000,  # chain_id
+            1,  # slip44
+            "tHOL",  # symbol
+            "Holesky",  # name
+        )
+        yield (
+            11155111,  # chain_id
+            1,  # slip44
+            "tSEP",  # symbol
+            "Sepolia",  # name
+        )
     if utils.INTERNAL_MODEL == "T2B1":
         yield (
             1,  # chain_id
@@ -96,7 +133,7 @@ def _networks_iterator() -> Iterator[NetworkInfoTuple]:
             "tSEP",  # symbol
             "Sepolia",  # name
         )
-    if utils.INTERNAL_MODEL == "T3T1":
+    if utils.INTERNAL_MODEL == "T2T1":
         yield (
             1,  # chain_id
             60,  # slip44
@@ -133,7 +170,44 @@ def _networks_iterator() -> Iterator[NetworkInfoTuple]:
             "tSEP",  # symbol
             "Sepolia",  # name
         )
-    if utils.INTERNAL_MODEL == "T2T1":
+    if utils.INTERNAL_MODEL == "T3B1":
+        yield (
+            1,  # chain_id
+            60,  # slip44
+            "ETH",  # symbol
+            "Ethereum",  # name
+        )
+        yield (
+            56,  # chain_id
+            714,  # slip44
+            "BNB",  # symbol
+            "BNB Smart Chain",  # name
+        )
+        yield (
+            61,  # chain_id
+            61,  # slip44
+            "ETC",  # symbol
+            "Ethereum Classic",  # name
+        )
+        yield (
+            137,  # chain_id
+            966,  # slip44
+            "MATIC",  # symbol
+            "Polygon",  # name
+        )
+        yield (
+            17000,  # chain_id
+            1,  # slip44
+            "tHOL",  # symbol
+            "Holesky",  # name
+        )
+        yield (
+            11155111,  # chain_id
+            1,  # slip44
+            "tSEP",  # symbol
+            "Sepolia",  # name
+        )
+    if utils.INTERNAL_MODEL == "T3T1":
         yield (
             1,  # chain_id
             60,  # slip44

--- a/core/src/apps/ethereum/networks.py.mako
+++ b/core/src/apps/ethereum/networks.py.mako
@@ -59,7 +59,7 @@ def by_slip44(slip44: int) -> EthereumNetworkInfo:
 
 # fmt: off
 def _networks_iterator() -> Iterator[NetworkInfoTuple]:
-% for model in ["T2B1", "T3T1", "T2T1"]:
+% for model in ALL_MODELS:
     if utils.INTERNAL_MODEL == "${model}":
 % for n in sorted(supported_on(model, eth), key=lambda network: (int(network.chain_id), network.name)):
         yield (

--- a/core/src/apps/ethereum/tokens.py
+++ b/core/src/apps/ethereum/tokens.py
@@ -42,6 +42,154 @@ def token_by_chain_address(chain_id: int, address: bytes) -> EthereumTokenInfo |
 
 
 def _token_iterator(chain_id: int) -> Iterator[tuple[bytes, str, int, str]]:
+    if utils.INTERNAL_MODEL == "T1B1":
+        if chain_id == 1:  # eth
+            yield (  # address, symbol, decimals, name
+                b"\x7f\xc6\x65\x00\xc8\x4a\x76\xad\x7e\x9c\x93\x43\x7b\xfc\x5a\xc3\x3e\x2d\xda\xe9",
+                "AAVE",
+                18,
+                "Aave",
+            )
+            yield (  # address, symbol, decimals, name
+                b"\x4d\x22\x44\x52\x80\x1a\xce\xd8\xb2\xf0\xae\xbe\x15\x53\x79\xbb\x5d\x59\x43\x81",
+                "APE",
+                18,
+                "ApeCoin",
+            )
+            yield (  # address, symbol, decimals, name
+                b"\xbb\x0e\x17\xef\x65\xf8\x2a\xb0\x18\xd8\xed\xd7\x76\xe8\xdd\x94\x03\x27\xb2\x8b",
+                "AXS",
+                18,
+                "Axie Infinity",
+            )
+            yield (  # address, symbol, decimals, name
+                b"\x4f\xab\xb1\x45\xd6\x46\x52\xa9\x48\xd7\x25\x33\x02\x3f\x6e\x7a\x62\x3c\x7c\x53",
+                "BUSD",
+                18,
+                "Binance USD",
+            )
+            yield (  # address, symbol, decimals, name
+                b"\x35\x06\x42\x4f\x91\xfd\x33\x08\x44\x66\xf4\x02\xd5\xd9\x7f\x05\xf8\xe3\xb4\xaf",
+                "CHZ",
+                18,
+                "Chiliz",
+            )
+            yield (  # address, symbol, decimals, name
+                b"\xa0\xb7\x3e\x1f\xf0\xb8\x09\x14\xab\x6f\xe0\x44\x4e\x65\x84\x8c\x4c\x34\x45\x0b",
+                "CRO",
+                8,
+                "Cronos",
+            )
+            yield (  # address, symbol, decimals, name
+                b"\x6b\x17\x54\x74\xe8\x90\x94\xc4\x4d\xa9\x8b\x95\x4e\xed\xea\xc4\x95\x27\x1d\x0f",
+                "DAI",
+                18,
+                "Dai",
+            )
+            yield (  # address, symbol, decimals, name
+                b"\x85\x3d\x95\x5a\xce\xf8\x22\xdb\x05\x8e\xb8\x50\x59\x11\xed\x77\xf1\x75\xb9\x9e",
+                "FRAX",
+                18,
+                "Frax",
+            )
+            yield (  # address, symbol, decimals, name
+                b"\x2a\xf5\xd2\xad\x76\x74\x11\x91\xd1\x5d\xfe\x7b\xf6\xac\x92\xd4\xbd\x91\x2c\xa3",
+                "LEO",
+                18,
+                "LEO Token",
+            )
+            yield (  # address, symbol, decimals, name
+                b"\x51\x49\x10\x77\x1a\xf9\xca\x65\x6a\xf8\x40\xdf\xf8\x3e\x82\x64\xec\xf9\x86\xca",
+                "LINK",
+                18,
+                "Chainlink",
+            )
+            yield (  # address, symbol, decimals, name
+                b"\x0f\x5d\x2f\xb2\x9f\xb7\xd3\xcf\xee\x44\x4a\x20\x02\x98\xf4\x68\x90\x8c\xc9\x42",
+                "MANA",
+                18,
+                "Decentraland",
+            )
+            yield (  # address, symbol, decimals, name
+                b"\x7d\x1a\xfa\x7b\x71\x8f\xb8\x93\xdb\x30\xa3\xab\xc0\xcf\xc6\x08\xaa\xcf\xeb\xb0",
+                "MATIC",
+                18,
+                "Polygon",
+            )
+            yield (  # address, symbol, decimals, name
+                b"\x75\x23\x1f\x58\xb4\x32\x40\xc9\x71\x8d\xd5\x8b\x49\x67\xc5\x11\x43\x42\xa8\x6c",
+                "OKB",
+                18,
+                "OKB",
+            )
+            yield (  # address, symbol, decimals, name
+                b"\x4a\x22\x0e\x60\x96\xb2\x5e\xad\xb8\x83\x58\xcb\x44\x06\x8a\x32\x48\x25\x46\x75",
+                "QNT",
+                18,
+                "Quant",
+            )
+            yield (  # address, symbol, decimals, name
+                b"\x38\x45\xba\xda\xde\x8e\x6d\xff\x04\x98\x20\x68\x0d\x1f\x14\xbd\x39\x03\xa5\xd0",
+                "SAND",
+                18,
+                "The Sandbox",
+            )
+            yield (  # address, symbol, decimals, name
+                b"\x95\xad\x61\xb0\xa1\x50\xd7\x92\x19\xdc\xf6\x4e\x1e\x6c\xc0\x1f\x0b\x64\xc4\xce",
+                "SHIB",
+                18,
+                "Shiba Inu",
+            )
+            yield (  # address, symbol, decimals, name
+                b"\xae\x7a\xb9\x65\x20\xde\x3a\x18\xe5\xe1\x11\xb5\xea\xab\x09\x53\x12\xd7\xfe\x84",
+                "STETH",
+                18,
+                "Lido Staked Ether",
+            )
+            yield (  # address, symbol, decimals, name
+                b"\x1f\x98\x40\xa8\x5d\x5a\xf5\xbf\x1d\x17\x62\xf9\x25\xbd\xad\xdc\x42\x01\xf9\x84",
+                "UNI",
+                18,
+                "Uniswap",
+            )
+            yield (  # address, symbol, decimals, name
+                b"\xa0\xb8\x69\x91\xc6\x21\x8b\x36\xc1\xd1\x9d\x4a\x2e\x9e\xb0\xce\x36\x06\xeb\x48",
+                "USDC",
+                6,
+                "USD Coin",
+            )
+            yield (  # address, symbol, decimals, name
+                b"\xda\xc1\x7f\x95\x8d\x2e\xe5\x23\xa2\x20\x62\x06\x99\x45\x97\xc1\x3d\x83\x1e\xc7",
+                "USDT",
+                6,
+                "Tether",
+            )
+            yield (  # address, symbol, decimals, name
+                b"\x22\x60\xfa\xc5\xe5\x54\x2a\x77\x3a\xa4\x4f\xbc\xfe\xdf\x7c\x19\x3b\xc2\xc5\x99",
+                "WBTC",
+                8,
+                "Wrapped Bitcoin",
+            )
+            yield (  # address, symbol, decimals, name
+                b"\xa2\xcd\x3d\x43\xc7\x75\x97\x8a\x96\xbd\xbf\x12\xd7\x33\xd5\xa1\xed\x94\xfb\x18",
+                "XCN",
+                18,
+                "Chain",
+            )
+        if chain_id == 56:  # bnb
+            yield (  # address, symbol, decimals, name
+                b"\x0e\xb3\xa7\x05\xfc\x54\x72\x50\x37\xcc\x9e\x00\x8b\xde\xde\x69\x7f\x62\xf3\x35",
+                "ATOM",
+                18,
+                "Cosmos Hub",
+            )
+        if chain_id == 137:  # matic
+            yield (  # address, symbol, decimals, name
+                b"\x2c\x89\xbb\xc9\x2b\xd8\x6f\x80\x75\xd1\xde\xcc\x58\xc7\xf4\xe0\x10\x7f\x28\x6b",
+                "WAVAX",
+                18,
+                "Wrapped AVAX",
+            )
     if utils.INTERNAL_MODEL == "T2B1":
         if chain_id == 1:  # eth
             yield (  # address, symbol, decimals, name
@@ -190,7 +338,7 @@ def _token_iterator(chain_id: int) -> Iterator[tuple[bytes, str, int, str]]:
                 18,
                 "Wrapped AVAX",
             )
-    if utils.INTERNAL_MODEL == "T3T1":
+    if utils.INTERNAL_MODEL == "T2T1":
         if chain_id == 1:  # eth
             yield (  # address, symbol, decimals, name
                 b"\x7f\xc6\x65\x00\xc8\x4a\x76\xad\x7e\x9c\x93\x43\x7b\xfc\x5a\xc3\x3e\x2d\xda\xe9",
@@ -338,7 +486,155 @@ def _token_iterator(chain_id: int) -> Iterator[tuple[bytes, str, int, str]]:
                 18,
                 "Wrapped AVAX",
             )
-    if utils.INTERNAL_MODEL == "T2T1":
+    if utils.INTERNAL_MODEL == "T3B1":
+        if chain_id == 1:  # eth
+            yield (  # address, symbol, decimals, name
+                b"\x7f\xc6\x65\x00\xc8\x4a\x76\xad\x7e\x9c\x93\x43\x7b\xfc\x5a\xc3\x3e\x2d\xda\xe9",
+                "AAVE",
+                18,
+                "Aave",
+            )
+            yield (  # address, symbol, decimals, name
+                b"\x4d\x22\x44\x52\x80\x1a\xce\xd8\xb2\xf0\xae\xbe\x15\x53\x79\xbb\x5d\x59\x43\x81",
+                "APE",
+                18,
+                "ApeCoin",
+            )
+            yield (  # address, symbol, decimals, name
+                b"\xbb\x0e\x17\xef\x65\xf8\x2a\xb0\x18\xd8\xed\xd7\x76\xe8\xdd\x94\x03\x27\xb2\x8b",
+                "AXS",
+                18,
+                "Axie Infinity",
+            )
+            yield (  # address, symbol, decimals, name
+                b"\x4f\xab\xb1\x45\xd6\x46\x52\xa9\x48\xd7\x25\x33\x02\x3f\x6e\x7a\x62\x3c\x7c\x53",
+                "BUSD",
+                18,
+                "Binance USD",
+            )
+            yield (  # address, symbol, decimals, name
+                b"\x35\x06\x42\x4f\x91\xfd\x33\x08\x44\x66\xf4\x02\xd5\xd9\x7f\x05\xf8\xe3\xb4\xaf",
+                "CHZ",
+                18,
+                "Chiliz",
+            )
+            yield (  # address, symbol, decimals, name
+                b"\xa0\xb7\x3e\x1f\xf0\xb8\x09\x14\xab\x6f\xe0\x44\x4e\x65\x84\x8c\x4c\x34\x45\x0b",
+                "CRO",
+                8,
+                "Cronos",
+            )
+            yield (  # address, symbol, decimals, name
+                b"\x6b\x17\x54\x74\xe8\x90\x94\xc4\x4d\xa9\x8b\x95\x4e\xed\xea\xc4\x95\x27\x1d\x0f",
+                "DAI",
+                18,
+                "Dai",
+            )
+            yield (  # address, symbol, decimals, name
+                b"\x85\x3d\x95\x5a\xce\xf8\x22\xdb\x05\x8e\xb8\x50\x59\x11\xed\x77\xf1\x75\xb9\x9e",
+                "FRAX",
+                18,
+                "Frax",
+            )
+            yield (  # address, symbol, decimals, name
+                b"\x2a\xf5\xd2\xad\x76\x74\x11\x91\xd1\x5d\xfe\x7b\xf6\xac\x92\xd4\xbd\x91\x2c\xa3",
+                "LEO",
+                18,
+                "LEO Token",
+            )
+            yield (  # address, symbol, decimals, name
+                b"\x51\x49\x10\x77\x1a\xf9\xca\x65\x6a\xf8\x40\xdf\xf8\x3e\x82\x64\xec\xf9\x86\xca",
+                "LINK",
+                18,
+                "Chainlink",
+            )
+            yield (  # address, symbol, decimals, name
+                b"\x0f\x5d\x2f\xb2\x9f\xb7\xd3\xcf\xee\x44\x4a\x20\x02\x98\xf4\x68\x90\x8c\xc9\x42",
+                "MANA",
+                18,
+                "Decentraland",
+            )
+            yield (  # address, symbol, decimals, name
+                b"\x7d\x1a\xfa\x7b\x71\x8f\xb8\x93\xdb\x30\xa3\xab\xc0\xcf\xc6\x08\xaa\xcf\xeb\xb0",
+                "MATIC",
+                18,
+                "Polygon",
+            )
+            yield (  # address, symbol, decimals, name
+                b"\x75\x23\x1f\x58\xb4\x32\x40\xc9\x71\x8d\xd5\x8b\x49\x67\xc5\x11\x43\x42\xa8\x6c",
+                "OKB",
+                18,
+                "OKB",
+            )
+            yield (  # address, symbol, decimals, name
+                b"\x4a\x22\x0e\x60\x96\xb2\x5e\xad\xb8\x83\x58\xcb\x44\x06\x8a\x32\x48\x25\x46\x75",
+                "QNT",
+                18,
+                "Quant",
+            )
+            yield (  # address, symbol, decimals, name
+                b"\x38\x45\xba\xda\xde\x8e\x6d\xff\x04\x98\x20\x68\x0d\x1f\x14\xbd\x39\x03\xa5\xd0",
+                "SAND",
+                18,
+                "The Sandbox",
+            )
+            yield (  # address, symbol, decimals, name
+                b"\x95\xad\x61\xb0\xa1\x50\xd7\x92\x19\xdc\xf6\x4e\x1e\x6c\xc0\x1f\x0b\x64\xc4\xce",
+                "SHIB",
+                18,
+                "Shiba Inu",
+            )
+            yield (  # address, symbol, decimals, name
+                b"\xae\x7a\xb9\x65\x20\xde\x3a\x18\xe5\xe1\x11\xb5\xea\xab\x09\x53\x12\xd7\xfe\x84",
+                "STETH",
+                18,
+                "Lido Staked Ether",
+            )
+            yield (  # address, symbol, decimals, name
+                b"\x1f\x98\x40\xa8\x5d\x5a\xf5\xbf\x1d\x17\x62\xf9\x25\xbd\xad\xdc\x42\x01\xf9\x84",
+                "UNI",
+                18,
+                "Uniswap",
+            )
+            yield (  # address, symbol, decimals, name
+                b"\xa0\xb8\x69\x91\xc6\x21\x8b\x36\xc1\xd1\x9d\x4a\x2e\x9e\xb0\xce\x36\x06\xeb\x48",
+                "USDC",
+                6,
+                "USD Coin",
+            )
+            yield (  # address, symbol, decimals, name
+                b"\xda\xc1\x7f\x95\x8d\x2e\xe5\x23\xa2\x20\x62\x06\x99\x45\x97\xc1\x3d\x83\x1e\xc7",
+                "USDT",
+                6,
+                "Tether",
+            )
+            yield (  # address, symbol, decimals, name
+                b"\x22\x60\xfa\xc5\xe5\x54\x2a\x77\x3a\xa4\x4f\xbc\xfe\xdf\x7c\x19\x3b\xc2\xc5\x99",
+                "WBTC",
+                8,
+                "Wrapped Bitcoin",
+            )
+            yield (  # address, symbol, decimals, name
+                b"\xa2\xcd\x3d\x43\xc7\x75\x97\x8a\x96\xbd\xbf\x12\xd7\x33\xd5\xa1\xed\x94\xfb\x18",
+                "XCN",
+                18,
+                "Chain",
+            )
+        if chain_id == 56:  # bnb
+            yield (  # address, symbol, decimals, name
+                b"\x0e\xb3\xa7\x05\xfc\x54\x72\x50\x37\xcc\x9e\x00\x8b\xde\xde\x69\x7f\x62\xf3\x35",
+                "ATOM",
+                18,
+                "Cosmos Hub",
+            )
+        if chain_id == 137:  # matic
+            yield (  # address, symbol, decimals, name
+                b"\x2c\x89\xbb\xc9\x2b\xd8\x6f\x80\x75\xd1\xde\xcc\x58\xc7\xf4\xe0\x10\x7f\x28\x6b",
+                "WAVAX",
+                18,
+                "Wrapped AVAX",
+            )
+    if utils.INTERNAL_MODEL == "T3T1":
         if chain_id == 1:  # eth
             yield (  # address, symbol, decimals, name
                 b"\x7f\xc6\x65\x00\xc8\x4a\x76\xad\x7e\x9c\x93\x43\x7b\xfc\x5a\xc3\x3e\x2d\xda\xe9",

--- a/core/src/apps/ethereum/tokens.py.mako
+++ b/core/src/apps/ethereum/tokens.py.mako
@@ -51,7 +51,7 @@ def token_by_chain_address(chain_id: int, address: bytes) -> EthereumTokenInfo |
 
 
 def _token_iterator(chain_id: int) -> Iterator[tuple[bytes, str, int, str]]:
-% for model in ["T2B1", "T3T1", "T2T1"]:
+% for model in ALL_MODELS:
     if utils.INTERNAL_MODEL == "${model}":
 % for token_chain_id, tokens in group_tokens(supported_on(model, erc20)).items():
         if chain_id == ${token_chain_id}:  # ${tokens[0].chain}

--- a/core/translations/cs.json
+++ b/core/translations/cs.json
@@ -1,6 +1,6 @@
 {
   "fonts": {
-    "T2B1": {
+    "##Safe3": {
       "1_FONT_NORMAL": "font_pixeloperator_regular_8_cs.json",
       "2_FONT_BOLD": "font_pixeloperator_bold_8_cs.json",
       "3_FONT_MONO": "font_pixeloperatormono_regular_8_cs.json",

--- a/core/translations/de.json
+++ b/core/translations/de.json
@@ -1,6 +1,6 @@
 {
   "fonts": {
-    "T2B1": {
+    "##Safe3": {
       "1_FONT_NORMAL": "font_pixeloperator_regular_8_de.json",
       "2_FONT_BOLD": "font_pixeloperator_bold_8_de.json",
       "3_FONT_MONO": "font_pixeloperatormono_regular_8_de.json",

--- a/core/translations/es.json
+++ b/core/translations/es.json
@@ -1,6 +1,6 @@
 {
   "fonts": {
-    "T2B1": {
+    "##Safe3": {
       "1_FONT_NORMAL": "font_pixeloperator_regular_8_es.json",
       "2_FONT_BOLD": "font_pixeloperator_bold_8_es.json",
       "3_FONT_MONO": "font_pixeloperatormono_regular_8_es.json",

--- a/core/translations/fr.json
+++ b/core/translations/fr.json
@@ -1,6 +1,6 @@
 {
   "fonts": {
-    "T2B1": {
+    "##Safe3": {
       "1_FONT_NORMAL": "font_pixeloperator_regular_8_fr.json",
       "2_FONT_BOLD": "font_pixeloperator_bold_8_fr.json",
       "3_FONT_MONO": "font_pixeloperatormono_regular_8_fr.json",

--- a/core/translations/signatures.json
+++ b/core/translations/signatures.json
@@ -1,8 +1,8 @@
 {
   "current": {
-    "merkle_root": "0682f8041f5d002800da51d3c3a36351d326b89ddf8fff6c3e70cd1943f3e064",
-    "datetime": "2024-08-29T14:44:39.968325",
-    "commit": "c5e520fd1e34182fb19044baa190dbc81fcf5cad"
+    "merkle_root": "23cd34c69ea6414849d484a7a9cf990f245d4522371fbdad909807d2bd8efe17",
+    "datetime": "2024-09-03T08:33:15.680225",
+    "commit": "4002c934c0dff69ded4247bee4c92bc6642dc0ac"
   },
   "history": [
     {

--- a/tests/translations.py
+++ b/tests/translations.py
@@ -70,7 +70,11 @@ def set_language(client: Client, lang: str):
 
 def get_lang_json(lang: str) -> translations.JsonDef:
     assert lang in LANGUAGES
-    return json.loads((TRANSLATIONS / f"{lang}.json").read_text())
+    lang_json = json.loads((TRANSLATIONS / f"{lang}.json").read_text())
+    if (fonts_safe3 := lang_json.get("fonts", {}).get("##Safe3")) is not None:
+        lang_json["fonts"]["T2B1"] = fonts_safe3
+        lang_json["fonts"]["T3B1"] = fonts_safe3
+    return lang_json
 
 
 def _get_all_language_data() -> list[dict[str, str]]:


### PR DESCRIPTION
Templates for coin data contain a list of models. T3B1 was not on that list.

This PR moves the list out of the templates, and uses `support.json` as an authoritative data source for the list of models.

Additionally, there's a small cleanup of supportinfo tooling -- now that we no longer track `suite` and `connect`, I also removed "missing-means-unsupported" feature.
<!--
If you are a core dev:

Don't forget to set up the fields:
- assign yourself
- set priority to same as original issue
- add PR to sprint
- if Draft -> "in progress"
- if final PR -> "needs review"

If you're an external contributor, you can ignore this text.
-->
