### PR TITLE
fix bootloader unlocking issues

### DIFF
--- a/core/embed/bootloader/.changelog.d/3709.changed
+++ b/core/embed/bootloader/.changelog.d/3709.changed
@@ -1,1 +1,0 @@
-Require confirmation when installing non-full trust firmware image on empty device

--- a/core/embed/bootloader/.changelog.d/4081.changed
+++ b/core/embed/bootloader/.changelog.d/4081.changed
@@ -1,1 +1,0 @@
-Fix incorrect error message when installing firmware for different model.

--- a/core/embed/bootloader/.changelog.d/4133.added
+++ b/core/embed/bootloader/.changelog.d/4133.added
@@ -1,1 +1,0 @@
-Added firmware downgrade protection

--- a/core/embed/bootloader/.changelog.d/4133.changed
+++ b/core/embed/bootloader/.changelog.d/4133.changed
@@ -1,1 +1,0 @@
-[T3B1, T3T1] Added bootloader unlock mechanism to U5 models

--- a/core/embed/bootloader/.changelog.d/4140.fixed
+++ b/core/embed/bootloader/.changelog.d/4140.fixed
@@ -1,1 +1,0 @@
-[T3B1] UI adjustments: fix icon on warning screen, replace empty logo with full during boot

--- a/core/embed/bootloader/CHANGELOG.md
+++ b/core/embed/bootloader/CHANGELOG.md
@@ -4,6 +4,19 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
+## 2.1.8 [September 2024]
+
+### Added
+- Added firmware downgrade protection  [#4133]
+
+### Changed
+- Require confirmation when installing non-full trust firmware image on empty device  [#3709]
+- Fix incorrect error message when installing firmware for different model.  [#4081]
+- [T3B1, T3T1] Added bootloader unlock mechanism to U5 models  [#4133]
+
+### Fixed
+- [T3B1] UI adjustments: fix icon on warning screen, replace empty logo with full during boot  [#4140]
+
 ## 2.1.7 [July 2024]
 
 ### Added
@@ -144,5 +157,9 @@ Internal only release for Model R prototypes.
 [#3303]: https://github.com/trezor/trezor-firmware/pull/3303
 [#3370]: https://github.com/trezor/trezor-firmware/pull/3370
 [#3429]: https://github.com/trezor/trezor-firmware/pull/3429
+[#3709]: https://github.com/trezor/trezor-firmware/pull/3709
 [#3711]: https://github.com/trezor/trezor-firmware/pull/3711
 [#3770]: https://github.com/trezor/trezor-firmware/pull/3770
+[#4081]: https://github.com/trezor/trezor-firmware/pull/4081
+[#4133]: https://github.com/trezor/trezor-firmware/pull/4133
+[#4140]: https://github.com/trezor/trezor-firmware/pull/4140

--- a/core/embed/bootloader/main.c
+++ b/core/embed/bootloader/main.c
@@ -289,9 +289,9 @@ void real_jump_to_firmware(void) {
   ensure(check_image_header_sig(hdr, vhdr.vsig_m, vhdr.vsig_n, vhdr.vpub),
          "Firmware is corrupted");
 
-  ensure(check_firmware_min_version(hdr->version),
+  ensure(check_firmware_min_version(hdr->monotonic),
          "Firmware downgrade protection");
-  ensure_firmware_min_version(hdr->version);
+  ensure_firmware_min_version(hdr->monotonic);
 
   ensure(check_image_contents(hdr, IMAGE_HEADER_SIZE + vhdr.hdrlen,
                               &FIRMWARE_AREA),

--- a/core/embed/prodtest/.changelog.d/3752.added
+++ b/core/embed/prodtest/.changelog.d/3752.added
@@ -1,1 +1,0 @@
-Added commands to read bootloader and boardloader versions

--- a/core/embed/prodtest/.changelog.d/4064.added
+++ b/core/embed/prodtest/.changelog.d/4064.added
@@ -1,1 +1,0 @@
-Added TOUCH_CUSTOM and TOUCH_IDLE commands

--- a/core/embed/prodtest/.changelog.d/4140.changed
+++ b/core/embed/prodtest/.changelog.d/4140.changed
@@ -1,1 +1,0 @@
-[T3B1] Changed welcome screen to show full white display

--- a/core/embed/prodtest/CHANGELOG.md
+++ b/core/embed/prodtest/CHANGELOG.md
@@ -1,4 +1,13 @@
 
+## 0.2.9 [7th September 2024]
+
+### Added
+- Added commands to read bootloader and boardloader versions  [#3752]
+- Added TOUCH_CUSTOM and TOUCH_IDLE commands  [#4064]
+
+### Changed
+- [T3B1] Changed welcome screen to show full white display  [#4140]
+
 ## 0.2.8 [19th July 2024]
 
 ### Added
@@ -61,7 +70,10 @@
 
 [#3325]: https://github.com/trezor/trezor-firmware/pull/3325
 [#3370]: https://github.com/trezor/trezor-firmware/pull/3370
+[#3752]: https://github.com/trezor/trezor-firmware/pull/3752
 [#3769]: https://github.com/trezor/trezor-firmware/pull/3769
 [#3770]: https://github.com/trezor/trezor-firmware/pull/3770
 [#3900]: https://github.com/trezor/trezor-firmware/pull/3900
 [#3932]: https://github.com/trezor/trezor-firmware/pull/3932
+[#4064]: https://github.com/trezor/trezor-firmware/pull/4064
+[#4140]: https://github.com/trezor/trezor-firmware/pull/4140

--- a/core/embed/prodtest/optiga_prodtest.c
+++ b/core/embed/prodtest/optiga_prodtest.c
@@ -143,6 +143,12 @@ void pair_optiga(void) {
   uint8_t secret[SECRET_OPTIGA_KEY_LEN] = {0};
 
   if (secret_optiga_get(secret) != sectrue) {
+    if (secret_optiga_writable() != sectrue) {
+      // optiga pairing secret is unwritable, so fail
+      optiga_pairing_state = OPTIGA_PAIRING_ERR_WRITE_FLASH;
+      return;
+    }
+
     // Generate the pairing secret.
     if (OPTIGA_SUCCESS != optiga_get_random(secret, sizeof(secret))) {
       optiga_pairing_state = OPTIGA_PAIRING_ERR_RNG;

--- a/core/embed/trezorhal/secret.h
+++ b/core/embed/trezorhal/secret.h
@@ -56,6 +56,9 @@ secbool secret_optiga_get(uint8_t dest[SECRET_OPTIGA_KEY_LEN]);
 // Checks if the optiga pairing secret is present in the secret storage
 secbool secret_optiga_present(void);
 
+// Checks if the optiga pairing secret can be written to the secret storage
+secbool secret_optiga_writable(void);
+
 // Erases optiga pairing secret from the secret storage
 void secret_optiga_erase(void);
 

--- a/core/embed/trezorhal/stm32f4/secret.c
+++ b/core/embed/trezorhal/stm32f4/secret.c
@@ -102,6 +102,8 @@ secbool secret_optiga_present(void) {
   return (sectrue != secret_wiped()) * sectrue;
 }
 
+secbool secret_optiga_writable(void) { return secret_wiped(); }
+
 void secret_optiga_erase(void) { secret_erase(); }
 
 void secret_prepare_fw(secbool allow_run_with_secret, secbool _trust_all) {

--- a/core/embed/trezorhal/stm32u5/secret.c
+++ b/core/embed/trezorhal/stm32u5/secret.c
@@ -176,6 +176,29 @@ secbool secret_optiga_present(void) {
   return secret_present(SECRET_OPTIGA_KEY_OFFSET, SECRET_OPTIGA_KEY_LEN);
 }
 
+secbool secret_optiga_writable(void) {
+  const uint32_t offset = SECRET_OPTIGA_KEY_OFFSET;
+  const uint32_t len = SECRET_OPTIGA_KEY_LEN;
+
+  const uint8_t *const secret =
+      (uint8_t *)flash_area_get_address(&SECRET_AREA, offset, len);
+
+  if (secret == NULL) {
+    return secfalse;
+  }
+
+  int secret_empty_bytes = 0;
+
+  for (int i = 0; i < len; i++) {
+    // 0xFF being the default value of the flash memory (before any write)
+    // 0x00 being the value of the flash memory after manual erase
+    if (secret[i] == 0xFF) {
+      secret_empty_bytes++;
+    }
+  }
+  return sectrue * (secret_empty_bytes == len);
+}
+
 // Backs up the optiga pairing secret from the secret storage to the backup
 // register
 static void secret_optiga_cache(void) {
@@ -270,16 +293,25 @@ void secret_prepare_fw(secbool allow_run_with_secret, secbool trust_all) {
   secret_bhk_lock();
 #ifdef USE_OPTIGA
   secret_optiga_uncache();
-  if (sectrue == allow_run_with_secret) {
-    if (secfalse != secret_optiga_present()) {
-      secret_optiga_cache();
-      secret_disable_access();
-    }
-  } else {
-    if (secfalse != secret_optiga_present()) {
-      show_install_restricted_screen();
-    }
-    secret_disable_access();
+  secbool optiga_secret_present = secret_optiga_present();
+  secbool optiga_secret_writable = secret_optiga_writable();
+  if (sectrue == trust_all && sectrue == allow_run_with_secret &&
+      sectrue == optiga_secret_writable && secfalse == optiga_secret_present) {
+    // Secret is not present and the secret sector is writable.
+    // This means the U5 chip is unprovisioned.
+    // Allow trusted firmware (prodtest presumably) to access the secret sector,
+    // early return here.
+    return;
+  }
+  if (sectrue == allow_run_with_secret && sectrue == optiga_secret_present) {
+    // Firmware is trusted and the Optiga secret is present, make it available.
+    secret_optiga_cache();
+  }
+  // Disable access unconditionally.
+  secret_disable_access();
+  if (sectrue != trust_all && sectrue == optiga_secret_present) {
+    // Untrusted firmware, locked bootloader. Show the restricted screen.
+    show_install_restricted_screen();
   }
 #else
   secret_disable_access();

--- a/core/embed/trezorhal/stm32u5/secret.c
+++ b/core/embed/trezorhal/stm32u5/secret.c
@@ -37,10 +37,16 @@ secbool secret_ensure_initialized(void) {
 }
 
 secbool secret_bootloader_locked(void) {
-#ifdef FIRMWARE
-  return (TAMP->BKP8R != 0) * sectrue;
+#if defined BOOTLOADER || defined BOARDLOADER
+  return secret_optiga_present();
 #else
-  return sectrue;
+  const volatile uint32_t *reg1 = &TAMP->BKP8R;
+  for (int i = 0; i < 8; i++) {
+    if (reg1[i] != 0) {
+      return sectrue;
+    }
+  }
+  return secfalse;
 #endif
 }
 


### PR DESCRIPTION
This PR fixes several unreleased bootloader issues, recently introduced:
- reporting bootloader unlock state via features
- firmware downgrade protection was using incorrect version in one place
- unlocking bootloader on U5 was granting HDP access to firmware, which is unwanted as it contains other stuff than optiga pairing secret
- and finally, fixes prodtest issue when running prodtest on unlocked bootloader. Note that there are differences between F4 and U5. Unlocking bootloader on F4 will result in prodtest being able to pair optiga again (unless optiga is locked of course). On U5 this is not allowed (as HDP contains other stuff so we can't make it accessible again).


<!--
If you are a core dev:

Don't forget to set up the fields:
- assign yourself
- set priority to same as original issue
- add PR to sprint
- if Draft -> "in progress"
- if final PR -> "needs review"

If you're an external contributor, you can ignore this text.
-->
