### PR TITLE
ci: warn when Cargo.lock is edited, don't test :it:

### DIFF
--- a/.github/actions/upload-coverage/action.yml
+++ b/.github/actions/upload-coverage/action.yml
@@ -1,0 +1,12 @@
+name: 'Upload coverage data'
+runs:
+  using: "composite"
+  steps:
+    - run: mv core/src/.coverage core/src/.coverage.${{ github.job }}${{ strategy.job-index }} || true
+      shell: sh
+    - uses: actions/upload-artifact@v4
+      with:
+        name: core-coverage-${{ matrix.model }}-${{ github.job }}-${{ strategy.job-index }}
+        path: core/src/.coverage.*
+        retention-days: 7
+        include-hidden-files: true

--- a/.github/workflows/core.yml
+++ b/.github/workflows/core.yml
@@ -284,12 +284,7 @@ jobs:
         continue-on-error: true
       - uses: ./.github/actions/ui-comment
         if: ${{ failure() && env.ACTIONS_DO_UI_TEST == 'true' }}
-      - uses: actions/upload-artifact@v4
-        with:
-          name: core-coverage-${{ matrix.model }}-${{ matrix.lang }}-${{ github.job }}-${{ strategy.job-index }}
-          # there will be more coverage files (one per core)
-          path: core/src/.coverage.*
-          retention-days: 7
+      - uses: ./.github/actions/upload-coverage
 
   # Click tests - UI.
   # See [docs/tests/click-tests](../tests/click-tests.md) for more info.
@@ -338,12 +333,8 @@ jobs:
           status: ${{ job.status }}
         if: always()
         continue-on-error: true
-      - run: mv core/src/.coverage core/.coverage.test_click || true
-      - uses: actions/upload-artifact@v4
-        with:
-          name: core-coverage-${{ matrix.model }}-${{ github.job }}-${{ strategy.job-index }}
-          path: core/.coverage.*
-          retention-days: 7
+      - uses: ./.github/actions/upload-coverage
+
 
   # Upgrade tests.
   # See [docs/tests/upgrade-tests](../tests/upgrade-tests.md) for more info.
@@ -414,12 +405,7 @@ jobs:
           status: ${{ job.status }}
         if: always()
         continue-on-error: true
-      - run: mv core/src/.coverage core/.coverage.test_persistence || true
-      - uses: actions/upload-artifact@v4
-        with:
-          name: core-coverage-${{ matrix.model }}-${{ github.job }}-${{ strategy.job-index }}
-          path: core/.coverage.*
-          retention-days: 7
+      - uses: ./.github/actions/upload-coverage
 
   core_hwi_test:
     name: HWI tests
@@ -567,12 +553,8 @@ jobs:
             core/tests/trezor_monero_tests.log
           retention-days: 7
         if: always()
-      - run: mv core/src/.coverage core/.coverage.test_emu_monero || true
-      - uses: actions/upload-artifact@v4
-        with:
-          name: core-coverage-${{ matrix.model }}-${{ github.job }}-${{ strategy.job-index }}
-          path: core/.coverage.*
-          retention-days: 7
+      - uses: ./.github/actions/upload-coverage
+
 
   # Tests for U2F and HID.
   core_u2f_test:
@@ -607,12 +589,7 @@ jobs:
           path: tests/trezor.log
           retention-days: 7
         if: always()
-      - run: mv core/src/.coverage core/.coverage.test_emu_u2f || true
-      - uses: actions/upload-artifact@v4
-        with:
-          name: core-coverage-${{ matrix.model }}-${{ github.job }}-${{ strategy.job-index }}
-          path: core/.coverage.*
-          retention-days: 7
+      - uses: ./.github/actions/upload-coverage
 
   # FIDO2 device tests.
   core_fido2_test:
@@ -647,12 +624,7 @@ jobs:
             tests/trezor.log
           retention-days: 7
         if: always()
-      - run: mv core/src/.coverage core/.coverage.test_emu_fido2 || true
-      - uses: actions/upload-artifact@v4
-        with:
-          name: core-coverage-${{ matrix.model }}-${{ github.job }}-${{ strategy.job-index }}
-          path: core/.coverage.*
-          retention-days: 7
+      - uses: ./.github/actions/upload-coverage
 
   core_coverage_report:
     name: Coverage report
@@ -690,6 +662,7 @@ jobs:
           name: core-coverage-report-${{ matrix.model }}
           path: core/htmlcov
           retention-days: 7
+          include-hidden-files: true
 
   core_ui_main:
     name: UI diff from main branch

--- a/.github/workflows/core.yml
+++ b/.github/workflows/core.yml
@@ -36,7 +36,7 @@ jobs:
       - id: set_vars
         name: Set variables
         run: |
-          echo test_lang=${{ github.event_name == 'pull_request' && contains(github.event.pull_request.labels.*.name, 'translations') && '[\"en\", \"cs\", \"fr\", \"de\", \"es\", \"it\", \"pt\"]' || '[\"en\"]' }} >> $GITHUB_OUTPUT
+          echo test_lang=${{ github.event_name == 'pull_request' && contains(github.event.pull_request.labels.*.name, 'translations') && '[\"en\", \"cs\", \"fr\", \"de\", \"es\", \"pt\"]' || '[\"en\"]' }} >> $GITHUB_OUTPUT
           echo asan=${{ github.event_name == 'schedule' && '[\"noasan\", \"asan\"]' || '[\"noasan\"]' }} >> $GITHUB_OUTPUT
           cat $GITHUB_OUTPUT
 

--- a/.github/workflows/prebuild.yml
+++ b/.github/workflows/prebuild.yml
@@ -6,6 +6,9 @@ on:
   schedule:
     - cron: '13 23 * * *'  # every day @ 23:13
 
+env:
+  CARGOLOCK_COMMENT: Looks like you changed `Cargo.lock`. Please make sure to review the dependencies and update [internal version list](https://www.notion.so/satoshilabs/Rust-dependencies-a9cc6e8dab934def8eb27896c001e6e2).
+
 jobs:
   block-fixup:
     name: Block fixup
@@ -79,3 +82,38 @@ jobs:
       - uses: ./.github/actions/environment
       - name: "Check release commit message format"
         run: ./ci/check_release_commit_messages.sh
+
+  # Warn if core/embed/rust/Cargo.lock changed
+  cargolock_check:
+    name: Cargo.lock check
+    if: ${{ github.ref != 'main' && github.event_name == 'pull_request' }}
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+          ref: ${{ github.event.pull_request.head.sha }}
+
+      - name: Ask git
+        run: |
+          git diff --exit-code origin/main -- core/embed/rust/Cargo.lock || echo cargo_modified=1 > $GITHUB_ENV
+          cat $GITHUB_OUTPUT
+
+      - name: Find Comment
+        uses: peter-evans/find-comment@v3
+        if: ${{ env.cargo_modified == '1' }}
+        id: fc
+        with:
+          issue-number: ${{ github.event.pull_request.number }}
+          comment-author: 'github-actions[bot]'
+          body-includes: cargolock-comment-${{ github.workflow }}
+
+      - name: Create comment
+        uses: peter-evans/create-or-update-comment@v4
+        if: ${{ env.cargo_modified == '1' && steps.fc.outputs.comment-id == '' }}
+        with:
+          issue-number: ${{ github.event.pull_request.number }}
+          body: |
+            <!-- cargolock-comment-${{ github.workflow }} -->
+            ${{ env.CARGOLOCK_COMMENT }}
+          edit-mode: replace


### PR DESCRIPTION
Example comment below :arrow_down:, wording suggestions appreciated.

Also remove Italian from the language matrix for full CI pipeline (with `translations` PR label) as discussed with @Hannsek 

<!--
If you are a core dev:

Don't forget to set up the fields:
- assign yourself
- set priority to same as original issue
- add PR to sprint
- if Draft -> "in progress"
- if final PR -> "needs review"

If you're an external contributor, you can ignore this text.
-->
