### PR TITLE
Fix Safe3 fonts for pt/br/it

### DIFF
--- a/core/translations/it.json
+++ b/core/translations/it.json
@@ -1,6 +1,6 @@
 {
   "fonts": {
-    "T2B1": {
+    "##Safe3": {
       "1_FONT_NORMAL": "font_pixeloperator_regular_8_it.json",
       "2_FONT_BOLD": "font_pixeloperator_bold_8_it.json",
       "3_FONT_MONO": "font_pixeloperatormono_regular_8_it.json",

--- a/core/translations/pt.json
+++ b/core/translations/pt.json
@@ -1,6 +1,6 @@
 {
   "fonts": {
-    "T2B1": {
+    "##Safe3": {
       "1_FONT_NORMAL": "font_pixeloperator_regular_8_pt.json",
       "2_FONT_BOLD": "font_pixeloperator_bold_8_pt.json",
       "3_FONT_MONO": "font_pixeloperatormono_regular_8_pt.json",

--- a/core/translations/signatures.json
+++ b/core/translations/signatures.json
@@ -1,8 +1,8 @@
 {
   "current": {
-    "merkle_root": "4553280c7d6f5a19fd2bd47ced62fbf70606394781d473355aa61ac0e1e42338",
-    "datetime": "2024-09-03T16:11:12.734773",
-    "commit": "423f1597941d5354b2f941e04ad5e27003431067"
+    "merkle_root": "8be4e819a1acbb7f131a0fd4e2573a977f94a41fe8a02ea4d3f47fd21f565a41",
+    "datetime": "2024-09-06T08:59:57.672431",
+    "commit": "d2a2ac21787c80a2e1d9414e663e04e2e4a90ef2"
   },
   "history": [
     {

--- a/core/translations/tr.json
+++ b/core/translations/tr.json
@@ -1,6 +1,6 @@
 {
   "fonts": {
-    "T2B1": {
+    "##Safe3": {
       "1_FONT_NORMAL": "font_pixeloperator_regular_8_tr.json",
       "2_FONT_BOLD": "font_pixeloperator_bold_8_tr.json",
       "3_FONT_MONO": "font_pixeloperatormono_regular_8_tr.json",


### PR DESCRIPTION
fixes `translations/cli.py gen` after #4047

<!--
If you are a core dev:

Don't forget to set up the fields:
- assign yourself
- set priority to same as original issue
- add PR to sprint
- if Draft -> "in progress"
- if final PR -> "needs review"

If you're an external contributor, you can ignore this text.
-->
