### PR TITLE
chore(core): remove duplicated FlowMsg conversion

### DIFF
--- a/core/embed/rust/src/ui/component/base.rs
+++ b/core/embed/rust/src/ui/component/base.rs
@@ -605,7 +605,11 @@ impl TryFrom<FlowMsg> for crate::micropython::obj::Obj {
             FlowMsg::Choice(i) => {
                 Ok((crate::ui::layout::result::CONFIRMED.as_obj(), i.try_into()?).try_into()?)
             }
-            FlowMsg::Text(_s) => panic!(),
+            FlowMsg::Text(s) => Ok((
+                crate::ui::layout::result::CONFIRMED.as_obj(),
+                s.as_str().try_into()?,
+            )
+                .try_into()?),
         }
     }
 }

--- a/core/embed/rust/src/ui/flow/swipe.rs
+++ b/core/embed/rust/src/ui/flow/swipe.rs
@@ -357,17 +357,7 @@ impl ObjComponent for SwipeFlow {
     fn obj_event(&mut self, ctx: &mut EventCtx, event: Event) -> Result<Obj, Error> {
         match self.event(ctx, event) {
             None => Ok(Obj::const_none()),
-            Some(FlowMsg::Confirmed) => Ok(crate::ui::layout::result::CONFIRMED.as_obj()),
-            Some(FlowMsg::Cancelled) => Ok(crate::ui::layout::result::CANCELLED.as_obj()),
-            Some(FlowMsg::Info) => Ok(crate::ui::layout::result::INFO.as_obj()),
-            Some(FlowMsg::Choice(i)) => {
-                Ok((crate::ui::layout::result::CONFIRMED.as_obj(), i.try_into()?).try_into()?)
-            }
-            Some(FlowMsg::Text(s)) => Ok((
-                crate::ui::layout::result::CONFIRMED.as_obj(),
-                s.as_str().try_into()?,
-            )
-                .try_into()?),
+            Some(msg) => msg.try_into(),
         }
     }
 


### PR DESCRIPTION


<!--
If you are a core dev:

Don't forget to set up the fields:
- assign yourself
- set priority to same as original issue
- add PR to sprint
- if Draft -> "in progress"
- if final PR -> "needs review"

If you're an external contributor, you can ignore this text.
-->
