### PR TITLE
return FlowMsg::Choice and Text as plain values instead of a tuple

### DIFF
--- a/core/embed/rust/src/ui/component/base.rs
+++ b/core/embed/rust/src/ui/component/base.rs
@@ -616,8 +616,8 @@ impl TryFrom<FlowMsg> for crate::micropython::obj::Obj {
             FlowMsg::Confirmed => Ok(result::CONFIRMED.as_obj()),
             FlowMsg::Cancelled => Ok(result::CANCELLED.as_obj()),
             FlowMsg::Info => Ok(result::INFO.as_obj()),
-            FlowMsg::Choice(i) => (result::CONFIRMED.as_obj(), i.try_into()?).try_into(),
-            FlowMsg::Text(s) => (result::CONFIRMED.as_obj(), s.as_str().try_into()?).try_into(),
+            FlowMsg::Choice(i) => i.try_into(),
+            FlowMsg::Text(s) => s.as_str().try_into(),
         }
     }
 }

--- a/core/src/trezor/ui/layouts/mercury/__init__.py
+++ b/core/src/trezor/ui/layouts/mercury/__init__.py
@@ -1432,18 +1432,8 @@ async def request_passphrase_on_device(max_len: int) -> str:
     if result is CANCELLED:
         raise ActionCancelled("Passphrase entry cancelled")
 
-    if __debug__:
-        if not isinstance(result, tuple):
-            # TODO: DebugLink problem, better comment or solution?
-            result = (CONFIRMED, str(result))
-
-    status, value = result
-    if status == CONFIRMED:
-        assert isinstance(value, str)
-        return value
-    else:
-        # flow_request_pin returns either CANCELLED or (CONFIRMED, str) so this branch shouldn't be taken
-        raise ActionCancelled("Passphrase entry cancelled")
+    assert isinstance(result, str)
+    return result
 
 
 async def request_pin_on_device(

--- a/core/src/trezor/ui/layouts/mercury/fido.py
+++ b/core/src/trezor/ui/layouts/mercury/fido.py
@@ -70,8 +70,8 @@ async def confirm_fido(
 
     # The Rust side returns either an int or `CANCELLED`. We detect the int situation
     # and assume cancellation otherwise.
-    if isinstance(result, tuple):
-        return result[1]
+    if isinstance(result, int):
+        return result
 
     # Late import won't get executed on the happy path.
     from trezor.wire import ActionCancelled

--- a/core/src/trezor/ui/layouts/mercury/reset.py
+++ b/core/src/trezor/ui/layouts/mercury/reset.py
@@ -176,15 +176,14 @@ async def _prompt_number(
         )
     )
 
-    if __debug__:
-        if not isinstance(result, tuple):
-            # DebugLink currently can't send number of shares and it doesn't
-            # change the counter either so just use the initial value.
-            result = (result, count)
-    status, value = result
-    if status == CONFIRMED:
-        assert isinstance(value, int)
-        return value
+    if __debug__ and result is CONFIRMED:
+        # sent by debuglink. debuglink does not change the number of shares anyway
+        # so use the initial one
+        return count
+
+    if result is not trezorui2.CANCELLED:
+        assert isinstance(result, int)
+        return result
     else:
         raise ActionCancelled  # user cancelled request number prompt
 


### PR DESCRIPTION
<!--
If you are a core dev:

Don't forget to set up the fields:
- assign yourself
- set priority to same as original issue
- add PR to sprint
- if Draft -> "in progress"
- if final PR -> "needs review"

If you're an external contributor, you can ignore this text.
-->
