### PR TITLE
fix(core): fix slow jpeg decoding

### DIFF
--- a/core/embed/rust/src/io.rs
+++ b/core/embed/rust/src/io.rs
@@ -166,6 +166,10 @@ impl<'a> PartialEq for BinaryData<'a> {
             #[cfg(feature = "micropython")]
             (Self::Object(a), Self::Object(b)) => a == b,
             #[cfg(feature = "micropython")]
+            (Self::AllocatedSlice(a), Self::AllocatedSlice(b)) => {
+                a.as_ptr() == b.as_ptr() && a.len() == b.len()
+            }
+            #[cfg(feature = "micropython")]
             _ => false,
         }
     }


### PR DESCRIPTION
This PR resolves issue #4217, which caused slow decoding of user JPEG images.

The bug appeared after the permanent switch to `NEW_RENDERING` and only affects the T model. Since the bug is not present in any official release, no update to the release notes is required.
