### PR TITLE
build(core/rust): provide a default value for BUILD_DIR

### DIFF
--- a/core/embed/rust/build.rs
+++ b/core/embed/rust/build.rs
@@ -3,6 +3,7 @@ use std::ffi::OsStr;
 use std::{env, path::PathBuf, process::Command};
 
 fn main() {
+    println!("cargo:rustc-env=BUILD_DIR={}", build_dir());
     #[cfg(feature = "micropython")]
     generate_qstr_bindings();
     #[cfg(feature = "micropython")]
@@ -15,7 +16,13 @@ fn main() {
 }
 
 fn build_dir() -> String {
-    env::var("BUILD_DIR").expect("BUILD_DIR not defined")
+    let build_dir_str = env::var("BUILD_DIR").unwrap_or(String::from("../../build/unix"));
+    PathBuf::from(build_dir_str)
+        .canonicalize()
+        .unwrap()
+        .to_str()
+        .unwrap()
+        .to_string()
 }
 
 const DEFAULT_BINDGEN_MACROS_COMMON: &[&str] = &[


### PR DESCRIPTION
to make it easier to run cargo separately, and support rust-analyzer without tweaking its config

<!--
If you are a core dev:

Don't forget to set up the fields:
- assign yourself
- set priority to same as original issue
- add PR to sprint
- if Draft -> "in progress"
- if final PR -> "needs review"

If you're an external contributor, you can ignore this text.
-->
