### PR TITLE
reboot immediately in boardloader if BHK is locked

### DIFF
--- a/core/embed/boardloader/main.c
+++ b/core/embed/boardloader/main.c
@@ -34,6 +34,7 @@
 #include "mpu.h"
 #include "rng.h"
 #include "rsod.h"
+#include "secret.h"
 #include "system.h"
 #include "terminal.h"
 
@@ -63,7 +64,6 @@
 #include "memzero.h"
 
 #ifdef STM32U5
-#include "secret.h"
 #include "tamper.h"
 #include "trustzone.h"
 #endif
@@ -253,9 +253,9 @@ int main(void) {
   tamper_init();
 
   trustzone_init_boardloader();
-
-  secret_ensure_initialized();
 #endif
+
+  secret_init();
 
 #ifdef STM32F4
   clear_otg_hs_memory();

--- a/core/embed/trezorhal/secret.h
+++ b/core/embed/trezorhal/secret.h
@@ -30,9 +30,6 @@ secbool secret_wiped(void);
 // Verifies that the secret storage has correct header
 secbool secret_verify_header(void);
 
-// Checks that the secret storage is initialized and initializes it if not
-secbool secret_ensure_initialized(void);
-
 // Erases the entire secret storage
 void secret_erase(void);
 
@@ -69,6 +66,11 @@ void secret_bhk_regenerate(void);
 // Disables access to the secret storage until next reset, if possible
 // This function is called by the bootloader before starting the firmware
 void secret_prepare_fw(secbool allow_run_with_secret, secbool trust_all);
+
+// Prepares the secret storage for running the boardloader and next stages
+// Ensures that secret storage access is enabled
+// This function is called by the boardloader
+void secret_init(void);
 
 #endif  // KERNEL_MODE
 

--- a/core/embed/trezorhal/stm32f4/secret.c
+++ b/core/embed/trezorhal/stm32f4/secret.c
@@ -133,4 +133,6 @@ void secret_prepare_fw(secbool allow_run_with_secret, secbool _trust_all) {
 #endif
 }
 
+void secret_init(void) {}
+
 #endif  // KERNEL_MODE

--- a/core/embed/trezorhal/stm32u5/secret.c
+++ b/core/embed/trezorhal/stm32u5/secret.c
@@ -35,7 +35,7 @@ secbool secret_verify_header(void) {
   return bootloader_locked;
 }
 
-secbool secret_ensure_initialized(void) {
+static secbool secret_ensure_initialized(void) {
   if (sectrue != secret_verify_header()) {
     ensure(erase_storage(NULL), "erase storage failed");
     secret_erase();
@@ -351,6 +351,14 @@ void secret_prepare_fw(secbool allow_run_with_secret, secbool trust_all) {
   if (sectrue != trust_all) {
     secret_disable_access();
   }
+}
+
+void secret_init(void) {
+  if (secret_bhk_locked() == sectrue) {
+    reboot();
+  }
+
+  secret_ensure_initialized();
 }
 
 #endif  // KERNEL_MODE


### PR DESCRIPTION
This PR fixes unwanted behavior, which happens on soft restarts on U5 mcus. 

The BHK is not unlocked during normal reboots, and this was detected in bootloader, which then invoked reboot and unlocked BHK (via TAMP_CR2_BKERASE). 

This is somewhat sub-optimal, as its adds additional boardloader-bootloader cycle, which takes some time and also flickers the display, even more so if display content isn't retained during boardloader-bootloader handoff.

This isn't issue for current models in production, as normally there are either power cycles, or reboots from firmware/bootloader that behave correctly, but one can observe this during development when resetting with debugger, or even pin resets on discovery kits.

To address this, BHK unlock cycle is done immediately in boardloader. In theory, we might not need reboot, but BKERASE also erases SRAM2 where we place stack, so its kinda easier to reboot than to deal with consequences of losing stack.



<!--
If you are a core dev:

Don't forget to set up the fields:
- assign yourself
- set priority to same as original issue
- add PR to sprint
- if Draft -> "in progress"
- if final PR -> "needs review"

If you're an external contributor, you can ignore this text.
-->
