### PR TITLE
refactor ui configuration in build scripts

### DIFF
--- a/core/SConscript.bootloader
+++ b/core/SConscript.bootloader
@@ -1,7 +1,7 @@
 # pylint: disable=E0602
 
 import os
-import tools, models
+import tools, models, ui
 
 TREZOR_MODEL = ARGUMENTS.get('TREZOR_MODEL', 'T')
 CMAKELISTS = int(ARGUMENTS.get('CMAKELISTS', 0))
@@ -24,34 +24,7 @@ SOURCE_MOD_CRYPTO = []
 CPPDEFINES_HAL = []
 SOURCE_HAL = []
 PATH_HAL = []
-
-if TREZOR_MODEL in ('R', 'T3B1'):
-    FONT_NORMAL='Font_PixelOperator_Regular_8'
-    FONT_DEMIBOLD='Font_PixelOperator_Regular_8'
-    FONT_BOLD='Font_PixelOperator_Bold_8'
-    FONT_MONO='Font_PixelOperator_Regular_8'
-    FONT_BIG='Font_PixelOperator_Regular_8'
-    FONT_NORMAL_UPPER='Font_PixelOperator_Regular_8_upper'
-    FONT_BOLD_UPPER=None
-    FONT_SUB=None
-elif TREZOR_MODEL in ('T', 'DISC1', 'DISC2'):
-    FONT_NORMAL='Font_TTHoves_Regular_21'
-    FONT_DEMIBOLD='Font_TTHoves_Regular_21'
-    FONT_BOLD='Font_TTHoves_Bold_17_upper'
-    FONT_MONO='Font_TTHoves_Regular_21'
-    FONT_BIG=None
-    FONT_NORMAL_UPPER=None
-    FONT_BOLD_UPPER='Font_TTHoves_Bold_17_upper'
-    FONT_SUB=None
-elif TREZOR_MODEL in ('T3T1',):
-    FONT_NORMAL='Font_TTSatoshi_DemiBold_21'
-    FONT_DEMIBOLD='Font_TTSatoshi_DemiBold_21'
-    FONT_BOLD='Font_TTHoves_Bold_17_upper'
-    FONT_MONO='Font_TTSatoshi_DemiBold_21'
-    FONT_BIG=None
-    FONT_NORMAL_UPPER=None
-    FONT_BOLD_UPPER='Font_TTHoves_Bold_17_upper'
-    FONT_SUB=None
+RUST_UI_FEATURES = []
 
 # modtrezorcrypto
 CCFLAGS_MOD += '-Wno-sequence-point '
@@ -65,7 +38,6 @@ CPPDEFINES_MOD += [
     'AES_192',
     'USE_KECCAK',
     'ED25519_NO_PRECOMP',
-    'TREZOR_UI2',
     'FANCY_FATAL_ERROR',
 ]
 
@@ -132,15 +104,7 @@ SOURCE_NANOPB = [
     'vendor/nanopb/pb_encode.c',
 ]
 
-# fonts
-tools.add_font('NORMAL', FONT_NORMAL, CPPDEFINES_MOD, SOURCE_MOD)
-tools.add_font('BOLD', FONT_BOLD, CPPDEFINES_MOD, SOURCE_MOD)
-tools.add_font('DEMIBOLD', FONT_DEMIBOLD, CPPDEFINES_MOD, SOURCE_MOD)
-tools.add_font('MONO', FONT_MONO, CPPDEFINES_MOD, SOURCE_MOD)
-tools.add_font('BIG', FONT_BIG, CPPDEFINES_MOD, SOURCE_MOD)
-tools.add_font('NORMAL_UPPER', FONT_NORMAL_UPPER, CPPDEFINES_MOD, SOURCE_MOD)
-tools.add_font('BOLD_UPPER', FONT_BOLD_UPPER, CPPDEFINES_MOD, SOURCE_MOD)
-tools.add_font('SUB', FONT_SUB, CPPDEFINES_MOD, SOURCE_MOD)
+ui.init_ui(TREZOR_MODEL, "bootloader", CPPDEFINES_MOD, SOURCE_MOD, RUST_UI_FEATURES)
 
 env = Environment(
     ENV=os.environ,
@@ -246,16 +210,9 @@ def cargo_build():
         profile = '--release'
     else:
         profile = ''
-    if TREZOR_MODEL in ("R", "T3B1"):
-        features = ["model_tr"]
-    elif TREZOR_MODEL in ("T3T1",):
-        features = ["model_mercury"]
-    else:
-        features = ["model_tt"]
 
-    if TREZOR_MODEL in ("R",):
-        features.append("ui_empty_lock")
-
+    features = []
+    features.extend(RUST_UI_FEATURES)
     features.append("ui")
     features.append("bootloader")
     features.extend(FEATURES_AVAILABLE)

--- a/core/SConscript.bootloader_ci
+++ b/core/SConscript.bootloader_ci
@@ -1,7 +1,7 @@
 # pylint: disable=E0602
 
 import os
-import tools, models
+import tools, models, ui
 
 TREZOR_MODEL = ARGUMENTS.get('TREZOR_MODEL', 'T')
 CMAKELISTS = int(ARGUMENTS.get('CMAKELISTS', 0))
@@ -22,34 +22,7 @@ SOURCE_MOD_CRYPTO = []
 CPPDEFINES_HAL = []
 SOURCE_HAL = []
 PATH_HAL = []
-
-if TREZOR_MODEL in ('R', 'T3B1'):
-    FONT_NORMAL='Font_PixelOperator_Regular_8'
-    FONT_DEMIBOLD=None
-    FONT_BOLD=None
-    FONT_MONO='Font_PixelOperatorMono_Regular_8'
-    FONT_BIG='Font_PixelOperator_Regular_8'
-    FONT_NORMAL_UPPER='Font_PixelOperator_Regular_8_upper'
-    FONT_BOLD_UPPER=None
-    FONT_SUB=None
-elif TREZOR_MODEL in ('T', 'DISC1', 'DISC2'):
-    FONT_NORMAL='Font_Roboto_Regular_20'
-    FONT_DEMIBOLD=None
-    FONT_BOLD=None
-    FONT_MONO='Font_RobotoMono_Medium_20'
-    FONT_BIG=None
-    FONT_NORMAL_UPPER=None
-    FONT_BOLD_UPPER=None
-    FONT_SUB=None
-elif TREZOR_MODEL in ('T3T1',):
-    FONT_NORMAL='Font_TTSatoshi_DemiBold_21'
-    FONT_DEMIBOLD=None
-    FONT_BOLD=None
-    FONT_MONO='Font_RobotoMono_Medium_21'
-    FONT_BIG=None
-    FONT_NORMAL_UPPER=None
-    FONT_BOLD_UPPER=None
-    FONT_SUB=None
+RUST_UI_FEATURES = []
 
 # modtrezorcrypto
 CCFLAGS_MOD += '-Wno-sequence-point '
@@ -125,15 +98,7 @@ SOURCE_NANOPB = [
     'vendor/nanopb/pb_encode.c',
 ]
 
-# fonts
-tools.add_font('NORMAL', FONT_NORMAL, CPPDEFINES_MOD, SOURCE_MOD)
-tools.add_font('BOLD', FONT_BOLD, CPPDEFINES_MOD, SOURCE_MOD)
-tools.add_font('DEMIBOLD', FONT_DEMIBOLD, CPPDEFINES_MOD, SOURCE_MOD)
-tools.add_font('MONO', FONT_MONO, CPPDEFINES_MOD, SOURCE_MOD)
-tools.add_font('BIG', FONT_BIG, CPPDEFINES_MOD, SOURCE_MOD)
-tools.add_font('NORMAL_UPPER', FONT_NORMAL_UPPER, CPPDEFINES_MOD, SOURCE_MOD)
-tools.add_font('BOLD_UPPER', FONT_BOLD_UPPER, CPPDEFINES_MOD, SOURCE_MOD)
-tools.add_font('SUB', FONT_SUB, CPPDEFINES_MOD, SOURCE_MOD)
+ui.init_ui(TREZOR_MODEL, "bootloader", CPPDEFINES_MOD, SOURCE_MOD, RUST_UI_FEATURES)
 
 env = Environment(
     ENV=os.environ, CFLAGS='%s -DPRODUCTION=%s' % (ARGUMENTS.get('CFLAGS', ''), ARGUMENTS.get('PRODUCTION', '0')),

--- a/core/SConscript.bootloader_emu
+++ b/core/SConscript.bootloader_emu
@@ -1,7 +1,7 @@
 # pylint: disable=E0602
 
 import os
-import tools, models
+import tools, models, ui
 
 TREZOR_MODEL = ARGUMENTS.get('TREZOR_MODEL', 'T')
 CMAKELISTS = int(ARGUMENTS.get('CMAKELISTS', 0))
@@ -32,34 +32,7 @@ PATH_HAL = []
 CPPDEFINES_MOD = []
 SOURCE_MOD = []
 SOURCE_MOD_CRYPTO = []
-
-if TREZOR_MODEL in ('R', 'T3B1'):
-    FONT_NORMAL='Font_PixelOperator_Regular_8'
-    FONT_DEMIBOLD='Font_PixelOperator_Regular_8'
-    FONT_BOLD='Font_PixelOperator_Bold_8'
-    FONT_MONO='Font_PixelOperator_Regular_8'
-    FONT_BIG='Font_PixelOperator_Regular_8'
-    FONT_NORMAL_UPPER='Font_PixelOperator_Regular_8_upper'
-    FONT_BOLD_UPPER=None
-    FONT_SUB=None
-elif TREZOR_MODEL in ('T', 'DISC2'):
-    FONT_NORMAL='Font_TTHoves_Regular_21'
-    FONT_DEMIBOLD=None
-    FONT_BOLD=None
-    FONT_MONO=None
-    FONT_BIG=None
-    FONT_NORMAL_UPPER=None
-    FONT_BOLD_UPPER='Font_TTHoves_Bold_17_upper'
-    FONT_SUB=None
-elif TREZOR_MODEL in ('T3T1',):
-    FONT_NORMAL='Font_TTSatoshi_DemiBold_21'
-    FONT_DEMIBOLD='Font_TTSatoshi_DemiBold_21'
-    FONT_BOLD=None
-    FONT_MONO='Font_TTSatoshi_DemiBold_21'
-    FONT_BIG=None
-    FONT_NORMAL_UPPER=None
-    FONT_BOLD_UPPER='Font_TTHoves_Bold_17_upper'
-    FONT_SUB=None
+RUST_UI_FEATURES = []
 
 # modtrezorcrypto
 CCFLAGS_MOD += '-Wno-sequence-point '
@@ -73,7 +46,6 @@ CPPDEFINES_MOD += [
     'AES_192',
     'USE_KECCAK',
     'ED25519_NO_PRECOMP',
-    'TREZOR_UI2',
     'FANCY_FATAL_ERROR'
 ]
 SOURCE_MOD_CRYPTO += [
@@ -177,17 +149,7 @@ SOURCE_UNIX = [
     'embed/unix/profile.c',
 ]
 
-
-
-# fonts
-tools.add_font('NORMAL', FONT_NORMAL, CPPDEFINES_MOD, SOURCE_MOD)
-tools.add_font('BOLD', FONT_BOLD, CPPDEFINES_MOD, SOURCE_MOD)
-tools.add_font('DEMIBOLD', FONT_DEMIBOLD, CPPDEFINES_MOD, SOURCE_MOD)
-tools.add_font('MONO', FONT_MONO, CPPDEFINES_MOD, SOURCE_MOD)
-tools.add_font('BIG', FONT_BIG, CPPDEFINES_MOD, SOURCE_MOD)
-tools.add_font('NORMAL_UPPER', FONT_NORMAL_UPPER, CPPDEFINES_MOD, SOURCE_MOD)
-tools.add_font('BOLD_UPPER', FONT_BOLD_UPPER, CPPDEFINES_MOD, SOURCE_MOD)
-tools.add_font('SUB', FONT_SUB, CPPDEFINES_MOD, SOURCE_MOD)
+ui.init_ui(TREZOR_MODEL, "bootloader", CPPDEFINES_MOD, SOURCE_MOD, RUST_UI_FEATURES)
 
 env = Environment(ENV=os.environ, CFLAGS='%s -DCONFIDENTIAL= -DPRODUCTION=%s' % (ARGUMENTS.get('CFLAGS', ''), ARGUMENTS.get('PRODUCTION', '0')))
 
@@ -276,19 +238,12 @@ else:
 RUST_LIBPATH = f'{RUST_LIBDIR}/lib{RUST_LIB}.a'
 
 def cargo_build():
-    if TREZOR_MODEL in ("R", "T3B1"):
-        features = ["model_tr"]
-    elif TREZOR_MODEL in ("T3T1",):
-        features = ["model_mercury"]
-    else:
-        features = ["model_tt"]
-
-    if TREZOR_MODEL in ("R",):
-        features.append("ui_empty_lock")
+    features = []
 
     if NEW_RENDERING:
         features.append('new_rendering')
 
+    features.extend(RUST_UI_FEATURES)
     features.append("ui")
     features.append("bootloader")
     features.extend(FEATURES_AVAILABLE)

--- a/core/SConscript.firmware
+++ b/core/SConscript.firmware
@@ -2,7 +2,7 @@
 # fmt: off
 
 import os
-import tools, models
+import tools, models, ui
 
 BITCOIN_ONLY = ARGUMENTS.get('BITCOIN_ONLY', '0')
 PRODUCTION = ARGUMENTS.get('PRODUCTION', '0') == '1'
@@ -38,36 +38,9 @@ SOURCE_MOD_CRYPTO = []
 CPPDEFINES_HAL = []
 SOURCE_HAL = []
 PATH_HAL = []
+RUST_UI_FEATURES = []
 
 FROZEN = True
-
-if TREZOR_MODEL in ('R', 'T3B1'):
-    FONT_NORMAL='Font_PixelOperator_Regular_8'
-    FONT_DEMIBOLD='Font_Unifont_Bold_16'
-    FONT_BOLD='Font_PixelOperator_Bold_8'
-    FONT_MONO='Font_PixelOperatorMono_Regular_8'
-    FONT_BIG='Font_Unifont_Regular_16'
-    FONT_NORMAL_UPPER='Font_PixelOperator_Regular_8_upper'
-    FONT_BOLD_UPPER='Font_PixelOperator_Bold_8_upper'
-    FONT_SUB=None
-elif TREZOR_MODEL in ('T', 'DISC1', 'DISC2'):
-    FONT_NORMAL='Font_TTHoves_Regular_21'
-    FONT_DEMIBOLD='Font_TTHoves_DemiBold_21'
-    FONT_BOLD=None
-    FONT_MONO='Font_RobotoMono_Medium_20'
-    FONT_BIG=None
-    FONT_NORMAL_UPPER=None
-    FONT_BOLD_UPPER='Font_TTHoves_Bold_17_upper'
-    FONT_SUB=None
-elif TREZOR_MODEL in ('T3T1',):
-    FONT_NORMAL='Font_TTSatoshi_DemiBold_21'
-    FONT_DEMIBOLD='Font_TTSatoshi_DemiBold_21'
-    FONT_BOLD='Font_TTSatoshi_DemiBold_21'
-    FONT_MONO='Font_RobotoMono_Medium_21'
-    FONT_BIG='Font_TTSatoshi_DemiBold_42'
-    FONT_NORMAL_UPPER=None
-    FONT_BOLD_UPPER=None
-    FONT_SUB='Font_TTSatoshi_DemiBold_18'
 
 # modtrezorconfig
 CPPPATH_MOD += [
@@ -252,7 +225,6 @@ else:
 
 
 CPPDEFINES_MOD += [
-    'TREZOR_UI2',
     'TRANSLATIONS',
     'FANCY_FATAL_ERROR',
     ]
@@ -404,15 +376,7 @@ if THP:
         'vendor/trezor-crypto/elligator2.c',
     ]
 
-# fonts
-tools.add_font('NORMAL', FONT_NORMAL, CPPDEFINES_MOD, SOURCE_MOD)
-tools.add_font('BOLD', FONT_BOLD, CPPDEFINES_MOD, SOURCE_MOD)
-tools.add_font('DEMIBOLD', FONT_DEMIBOLD, CPPDEFINES_MOD, SOURCE_MOD)
-tools.add_font('MONO', FONT_MONO, CPPDEFINES_MOD, SOURCE_MOD)
-tools.add_font('BIG', FONT_BIG, CPPDEFINES_MOD, SOURCE_MOD)
-tools.add_font('NORMAL_UPPER', FONT_NORMAL_UPPER, CPPDEFINES_MOD, SOURCE_MOD)
-tools.add_font('BOLD_UPPER', FONT_BOLD_UPPER, CPPDEFINES_MOD, SOURCE_MOD)
-tools.add_font('SUB', FONT_SUB, CPPDEFINES_MOD, SOURCE_MOD)
+ui.init_ui(TREZOR_MODEL, "firmware", CPPDEFINES_MOD, SOURCE_MOD, RUST_UI_FEATURES)
 
 SOURCE_QSTR = SOURCE_MOD + SOURCE_MICROPYTHON + SOURCE_MICROPYTHON_SPEED
 
@@ -433,19 +397,6 @@ SOURCE_FIRMWARE = [
     'embed/firmware/nlrthumb.c',
     f'embed/trezorhal/{FILE_SUFFIX}/startup_stage_4.s',
 ]
-
-
-if TREZOR_MODEL in ('T', 'DISC1', 'DISC2'):
-    UI_LAYOUT = 'UI_LAYOUT_TT'
-    ui_layout_feature = 'model_tt'
-elif TREZOR_MODEL in ('R', 'T3B1'):
-    UI_LAYOUT = 'UI_LAYOUT_TR'
-    ui_layout_feature = 'model_tr'
-elif TREZOR_MODEL in ('T3T1',):
-    UI_LAYOUT = 'UI_LAYOUT_MERCURY'
-    ui_layout_feature = 'model_mercury'
-else:
-    raise ValueError('Unknown Trezor model')
 
 if 'sd_card' in FEATURES_AVAILABLE:
     SDCARD = True
@@ -499,7 +450,7 @@ env.Replace(
         'TREZOR_MODEL_'+TREZOR_MODEL,
         'USE_HAL_DRIVER',
         'ARM_USER_MODE',
-        UI_LAYOUT,
+        ui.get_ui_layout(TREZOR_MODEL),
     ] + CPPDEFINES_MOD + CPPDEFINES_HAL,
     ASFLAGS=env.get('ENV')['CPU_ASFLAGS'],
     ASPPFLAGS='$CFLAGS $CCFLAGS',
@@ -601,26 +552,14 @@ if FROZEN:
             SOURCE_PY_DIR + 'trezor/ui/layouts/fido.py',
         ] if not EVERYTHING else []
     ))
-    if UI_LAYOUT == 'UI_LAYOUT_TT':
-        SOURCE_PY.extend(Glob(SOURCE_PY_DIR + 'trezor/ui/layouts/tt/*.py',
-            exclude=[
-                SOURCE_PY_DIR + 'trezor/ui/layouts/tt/fido.py',
-            ] if not EVERYTHING else []
-        ))
-    elif UI_LAYOUT == 'UI_LAYOUT_TR':
-        SOURCE_PY.extend(Glob(SOURCE_PY_DIR + 'trezor/ui/layouts/tr/*.py',
-            exclude=[
-                SOURCE_PY_DIR + 'trezor/ui/layouts/tr/fido.py',
-            ] if not EVERYTHING else []
-        ))
-    elif UI_LAYOUT == 'UI_LAYOUT_MERCURY':
-        SOURCE_PY.extend(Glob(SOURCE_PY_DIR + 'trezor/ui/layouts/mercury/*.py',
-            exclude=[
-                SOURCE_PY_DIR + 'trezor/ui/layouts/mercury/fido.py',
-            ] if not EVERYTHING else []
-        ))
-    else:
-        raise ValueError('Unknown layout')
+
+    layout_path = ui.get_ui_layout_path(TREZOR_MODEL)
+
+    SOURCE_PY.extend(Glob(SOURCE_PY_DIR + layout_path + '*.py',
+        exclude=[
+            SOURCE_PY_DIR + layout_path + 'fido.py',
+        ] if not EVERYTHING else []
+    ))
 
     SOURCE_PY.extend(Glob(SOURCE_PY_DIR + 'trezor/wire/*.py'))
 
@@ -729,7 +668,7 @@ if FROZEN:
         bitcoin_only=BITCOIN_ONLY,
         backlight='backlight' in FEATURES_AVAILABLE,
         optiga='optiga' in FEATURES_AVAILABLE,
-        ui_layout=UI_LAYOUT,
+        ui_layout=ui.get_ui_layout(TREZOR_MODEL),
         thp=THP,
         )
 
@@ -796,11 +735,13 @@ def cargo_build():
     else:
         profile = ''
 
-    features = ['micropython', 'protobuf', ui_layout_feature]
+    features = ['micropython', 'protobuf']
     if EVERYTHING:
         features.append('universal_fw')
+    features.extend(RUST_UI_FEATURES)
     features.append('ui')
     features.append('translations')
+
 
     if NEW_RENDERING:
         features.append('new_rendering')
@@ -808,13 +749,6 @@ def cargo_build():
     if PYOPT == '0':
         features.append('debug')
         features.append('ui_debug')
-    if TREZOR_MODEL in ('T', 'T3T1', 'DISC1', 'DISC2'):
-        features.append('ui_blurring')
-        features.append('ui_jpeg_decoder')
-
-    if NEW_RENDERING and TREZOR_MODEL in ('T3T1', 'DISC2'):
-        features.append('ui_image_buffer')
-        features.append('ui_overlay')
 
     features.extend(FEATURES_AVAILABLE)
 

--- a/core/SConscript.prodtest
+++ b/core/SConscript.prodtest
@@ -1,7 +1,7 @@
 # pylint: disable=E0602
 
 import os
-import tools, models
+import tools, models, ui
 
 TREZOR_MODEL = ARGUMENTS.get('TREZOR_MODEL', 'T')
 CMAKELISTS = int(ARGUMENTS.get('CMAKELISTS', 0))
@@ -27,34 +27,7 @@ SOURCE_MOD_CRYPTO = []
 CPPDEFINES_HAL = []
 SOURCE_HAL = []
 PATH_HAL = []
-
-if TREZOR_MODEL in ('R', 'T3B1'):
-    FONT_NORMAL=None
-    FONT_DEMIBOLD=None
-    FONT_BOLD='Font_PixelOperator_Bold_8'
-    FONT_MONO=None
-    FONT_BIG=None
-    FONT_NORMAL_UPPER=None
-    FONT_BOLD_UPPER=None
-    FONT_SUB=None
-elif TREZOR_MODEL in ('T', 'DISC1', 'DISC2'):
-    FONT_NORMAL=None
-    FONT_DEMIBOLD=None
-    FONT_BOLD='Font_Roboto_Bold_20'
-    FONT_MONO=None
-    FONT_BIG=None
-    FONT_NORMAL_UPPER=None
-    FONT_BOLD_UPPER=None
-    FONT_SUB=None
-elif TREZOR_MODEL in ('T3T1',):
-    FONT_NORMAL='Font_TTSatoshi_DemiBold_21'
-    FONT_DEMIBOLD=None
-    FONT_BOLD='Font_TTSatoshi_DemiBold_21'
-    FONT_MONO='Font_RobotoMono_Medium_21'
-    FONT_BIG=None
-    FONT_NORMAL_UPPER=None
-    FONT_BOLD_UPPER=None
-    FONT_SUB=None
+RUST_UI_FEATURES = []
 
 # modtrezorcrypto
 CPPPATH_MOD += [
@@ -123,16 +96,7 @@ else:
         'embed/lib/display_draw.c',
     ]
 
-
-# fonts
-tools.add_font('NORMAL', FONT_NORMAL, CPPDEFINES_MOD, SOURCE_MOD)
-tools.add_font('BOLD', FONT_BOLD, CPPDEFINES_MOD, SOURCE_MOD)
-tools.add_font('DEMIBOLD', FONT_DEMIBOLD, CPPDEFINES_MOD, SOURCE_MOD)
-tools.add_font('MONO', FONT_MONO, CPPDEFINES_MOD, SOURCE_MOD)
-tools.add_font('BIG', FONT_BIG, CPPDEFINES_MOD, SOURCE_MOD)
-tools.add_font('NORMAL_UPPER', FONT_NORMAL_UPPER, CPPDEFINES_MOD, SOURCE_MOD)
-tools.add_font('BOLD_UPPER', FONT_BOLD_UPPER, CPPDEFINES_MOD, SOURCE_MOD)
-tools.add_font('SUB', FONT_SUB, CPPDEFINES_MOD, SOURCE_MOD)
+ui.init_ui(TREZOR_MODEL, "prodtest", CPPDEFINES_MOD, SOURCE_MOD, RUST_UI_FEATURES)
 
 env = Environment(
     ENV=os.environ,

--- a/core/SConscript.reflash
+++ b/core/SConscript.reflash
@@ -1,7 +1,7 @@
 # pylint: disable=E0602
 
 import os
-import tools, models
+import tools, models, ui
 
 TREZOR_MODEL = ARGUMENTS.get('TREZOR_MODEL', 'T')
 CMAKELISTS = int(ARGUMENTS.get('CMAKELISTS', 0))
@@ -32,34 +32,7 @@ SOURCE_MOD_CRYPTO = []
 CPPDEFINES_HAL = []
 SOURCE_HAL = []
 PATH_HAL = []
-
-if TREZOR_MODEL in ('R', 'T3B1'):
-    FONT_NORMAL=None
-    FONT_DEMIBOLD=None
-    FONT_BOLD='Font_PixelOperator_Bold_8'
-    FONT_MONO=None
-    FONT_BIG=None
-    FONT_NORMAL_UPPER=None
-    FONT_BOLD_UPPER=None
-    FONT_SUB=None
-elif TREZOR_MODEL in ('T',):
-    FONT_NORMAL=None
-    FONT_DEMIBOLD=None
-    FONT_BOLD='Font_Roboto_Bold_20'
-    FONT_MONO=None
-    FONT_BIG=None
-    FONT_NORMAL_UPPER=None
-    FONT_BOLD_UPPER=None
-    FONT_SUB=None
-elif TREZOR_MODEL in ('T3T1',):
-    FONT_NORMAL=None
-    FONT_DEMIBOLD=None
-    FONT_BOLD='Font_TTSatoshi_DemiBold_21'
-    FONT_MONO=None
-    FONT_BIG=None
-    FONT_NORMAL_UPPER=None
-    FONT_BOLD_UPPER=None
-    FONT_SUB=None
+RUST_UI_FEATURES = []
 
 CPPDEFINES_MOD += [
     'KERNEL_MODE',
@@ -109,15 +82,7 @@ else:
     ]
 
 
-# fonts
-tools.add_font('NORMAL', FONT_NORMAL, CPPDEFINES_MOD, SOURCE_MOD)
-tools.add_font('BOLD', FONT_BOLD, CPPDEFINES_MOD, SOURCE_MOD)
-tools.add_font('DEMIBOLD', FONT_DEMIBOLD, CPPDEFINES_MOD, SOURCE_MOD)
-tools.add_font('MONO', FONT_MONO, CPPDEFINES_MOD, SOURCE_MOD)
-tools.add_font('BIG', FONT_BIG, CPPDEFINES_MOD, SOURCE_MOD)
-tools.add_font('NORMAL_UPPER', FONT_NORMAL_UPPER, CPPDEFINES_MOD, SOURCE_MOD)
-tools.add_font('BOLD_UPPER', FONT_BOLD_UPPER, CPPDEFINES_MOD, SOURCE_MOD)
-tools.add_font('SUB', FONT_SUB, CPPDEFINES_MOD, SOURCE_MOD)
+ui.init_ui(TREZOR_MODEL, "prodtest", CPPDEFINES_MOD, SOURCE_MOD, RUST_UI_FEATURES)
 
 env = Environment(
     ENV=os.environ,

--- a/core/SConscript.unix
+++ b/core/SConscript.unix
@@ -2,7 +2,7 @@
 # fmt: off
 
 import os
-import tools, models
+import tools, models, ui
 
 BITCOIN_ONLY = ARGUMENTS.get('BITCOIN_ONLY', '0')
 EVERYTHING = BITCOIN_ONLY != '1'
@@ -42,38 +42,11 @@ SOURCE_MOD = [
     'vendor/micropython/extmod/vfs_posix_file.c',
 ]
 SOURCE_MOD_CRYPTO = []
+RUST_UI_FEATURES = []
 
 PYOPT = ARGUMENTS.get('PYOPT', '1')
 FROZEN = ARGUMENTS.get('TREZOR_EMULATOR_FROZEN', 0)
 RASPI = os.getenv('TREZOR_EMULATOR_RASPI') == '1'
-
-if TREZOR_MODEL in ('R', 'T3B1'):
-    FONT_NORMAL='Font_PixelOperator_Regular_8'
-    FONT_DEMIBOLD='Font_Unifont_Bold_16'
-    FONT_BOLD='Font_PixelOperator_Bold_8'
-    FONT_MONO='Font_PixelOperatorMono_Regular_8'
-    FONT_BIG='Font_Unifont_Regular_16'
-    FONT_NORMAL_UPPER='Font_PixelOperator_Regular_8_upper'
-    FONT_BOLD_UPPER='Font_PixelOperator_Bold_8_upper'
-    FONT_SUB=None
-elif TREZOR_MODEL in ('T',):
-    FONT_NORMAL='Font_TTHoves_Regular_21'
-    FONT_DEMIBOLD='Font_TTHoves_DemiBold_21'
-    FONT_BOLD=None
-    FONT_MONO='Font_RobotoMono_Medium_20'
-    FONT_BIG=None
-    FONT_NORMAL_UPPER=None
-    FONT_BOLD_UPPER='Font_TTHoves_Bold_17_upper'
-    FONT_SUB=None
-elif TREZOR_MODEL in ('T3T1',):
-    FONT_NORMAL='Font_TTSatoshi_DemiBold_21'
-    FONT_DEMIBOLD='Font_TTSatoshi_DemiBold_21'
-    FONT_BOLD='Font_TTSatoshi_DemiBold_21'
-    FONT_MONO='Font_RobotoMono_Medium_21'
-    FONT_BIG='Font_TTSatoshi_DemiBold_42'
-    FONT_NORMAL_UPPER=None
-    FONT_BOLD_UPPER=None
-    FONT_SUB='Font_TTSatoshi_DemiBold_18'
 
 # modtrezorconfig
 CPPPATH_MOD += [
@@ -262,7 +235,6 @@ else:
     ]
 
 CPPDEFINES_MOD += [
-    'TREZOR_UI2',
     'TRANSLATIONS',
     'FANCY_FATAL_ERROR',
     ]
@@ -456,17 +428,7 @@ TRANSLATION_DATA = [
     "translations/order.json",
 ]
 
-
-# fonts
-tools.add_font('NORMAL', FONT_NORMAL, CPPDEFINES_MOD, SOURCE_MOD)
-tools.add_font('BOLD', FONT_BOLD, CPPDEFINES_MOD, SOURCE_MOD)
-tools.add_font('DEMIBOLD', FONT_DEMIBOLD, CPPDEFINES_MOD, SOURCE_MOD)
-tools.add_font('MONO', FONT_MONO, CPPDEFINES_MOD, SOURCE_MOD)
-tools.add_font('BIG', FONT_BIG, CPPDEFINES_MOD, SOURCE_MOD)
-tools.add_font('NORMAL_UPPER', FONT_NORMAL_UPPER, CPPDEFINES_MOD, SOURCE_MOD)
-tools.add_font('BOLD_UPPER', FONT_BOLD_UPPER, CPPDEFINES_MOD, SOURCE_MOD)
-tools.add_font('SUB', FONT_SUB, CPPDEFINES_MOD, SOURCE_MOD)
-
+ui.init_ui(TREZOR_MODEL, "firmware", CPPDEFINES_MOD, SOURCE_MOD, RUST_UI_FEATURES)
 
 SOURCE_QSTR = SOURCE_MOD + SOURCE_MICROPYTHON + SOURCE_UNIX
 
@@ -478,18 +440,6 @@ else:
 env = Environment(ENV=os.environ, CFLAGS='%s -DCONFIDENTIAL= -DPYOPT=%s -DBITCOIN_ONLY=%s %s' % (ARGUMENTS.get('CFLAGS', ''), PYOPT, BITCOIN_ONLY, STATIC))
 
 FEATURES_AVAILABLE = models.configure_board(TREZOR_MODEL, HW_REVISION, FEATURES_WANTED, env, CPPDEFINES_HAL, SOURCE_UNIX, PATH_HAL)
-
-if TREZOR_MODEL in ('T',):
-    UI_LAYOUT = 'UI_LAYOUT_TT'
-    ui_layout_feature = 'model_tt'
-elif TREZOR_MODEL in ('R', 'T3B1'):
-    UI_LAYOUT = 'UI_LAYOUT_TR'
-    ui_layout_feature = 'model_tr'
-elif TREZOR_MODEL in ('T3T1',):
-    UI_LAYOUT = 'UI_LAYOUT_MERCURY'
-    ui_layout_feature = 'model_mercury'
-else:
-    raise ValueError('Unknown Trezor model')
 
 
 if 'sd_card' in FEATURES_AVAILABLE:
@@ -576,7 +526,7 @@ env.Replace(
         'TREZOR_EMULATOR',
         'TREZOR_MODEL_'+TREZOR_MODEL,
         ('MP_CONFIGFILE', '\\"embed/unix/mpconfigport.h\\"'),
-        UI_LAYOUT,
+        ui.get_ui_layout(TREZOR_MODEL),
     ] + CPPDEFINES_MOD + CPPDEFINES_HAL,
     ASPPFLAGS='$CFLAGS $CCFLAGS', )
 
@@ -681,26 +631,14 @@ if FROZEN:
             SOURCE_PY_DIR + 'trezor/ui/layouts/fido.py',
         ] if not EVERYTHING else []
     ))
-    if UI_LAYOUT == 'UI_LAYOUT_TT':
-        SOURCE_PY.extend(Glob(SOURCE_PY_DIR + 'trezor/ui/layouts/tt/*.py',
-            exclude=[
-                SOURCE_PY_DIR + 'trezor/ui/layouts/tt/fido.py',
-            ] if not EVERYTHING else []
-        ))
-    elif UI_LAYOUT == 'UI_LAYOUT_TR':
-        SOURCE_PY.extend(Glob(SOURCE_PY_DIR + 'trezor/ui/layouts/tr/*.py',
-            exclude=[
-                SOURCE_PY_DIR + 'trezor/ui/layouts/tr/fido.py',
-            ] if not EVERYTHING else []
-        ))
-    elif UI_LAYOUT == 'UI_LAYOUT_MERCURY':
-        SOURCE_PY.extend(Glob(SOURCE_PY_DIR + 'trezor/ui/layouts/mercury/*.py',
-            exclude=[
-                SOURCE_PY_DIR + 'trezor/ui/layouts/mercury/fido.py',
-            ] if not EVERYTHING else []
-        ))
-    else:
-        raise ValueError('Unknown layout')
+
+    layout_path = ui.get_ui_layout_path(TREZOR_MODEL)
+
+    SOURCE_PY.extend(Glob(SOURCE_PY_DIR + layout_path + '*.py',
+        exclude=[
+            SOURCE_PY_DIR + layout_path + 'fido.py',
+        ] if not EVERYTHING else []
+    ))
 
     SOURCE_PY.extend(Glob(SOURCE_PY_DIR + 'trezor/wire/*.py'))
 
@@ -811,7 +749,7 @@ if FROZEN:
         bitcoin_only=BITCOIN_ONLY,
         backlight='backlight' in FEATURES_AVAILABLE,
         optiga=OPTIGA,
-        ui_layout=UI_LAYOUT,
+        ui_layout=ui.get_ui_layout(TREZOR_MODEL),
         thp=THP,
         )
 
@@ -877,9 +815,10 @@ RUST_LIB = 'trezor_lib'
 RUST_LIBPATH = f'{RUST_LIBDIR}/lib{RUST_LIB}.a'
 
 def cargo_build():
-    features = ['micropython', 'protobuf', ui_layout_feature]
+    features = ['micropython', 'protobuf']
     if EVERYTHING:
         features.append('universal_fw')
+    features.extend(RUST_UI_FEATURES)
     features.append('ui')
     features.append('translations')
 
@@ -887,14 +826,6 @@ def cargo_build():
         features.append('debug')
 
     features.extend(FEATURES_AVAILABLE)
-
-    if TREZOR_MODEL in ('T', 'T3T1'):
-        features.append('ui_blurring')
-        features.append('ui_jpeg_decoder')
-
-    if NEW_RENDERING and TREZOR_MODEL in ('T3T1', ):
-        features.append('ui_image_buffer')
-        features.append('ui_overlay')
 
     if NEW_RENDERING:
         features.append('new_rendering')

--- a/core/embed/extmod/modtrezorutils/modtrezorutils-meminfo.h
+++ b/core/embed/extmod/modtrezorutils/modtrezorutils-meminfo.h
@@ -659,11 +659,9 @@ void dump_value_opt(FILE *out, mp_const_obj_t value, bool eval_short) {
     dump_protodef(out, value);
   }
 
-#ifdef TREZOR_UI2
   else if (mp_obj_is_type(value, ui_debug_layout_type())) {
     dump_uilayout(out, value);
   }
-#endif
 
   else {
     print_type(out, "unknown", NULL, value, true);

--- a/core/site_scons/models/D001/__init__.py
+++ b/core/site_scons/models/D001/__init__.py
@@ -14,3 +14,11 @@ def configure_board(
     paths: list[str],
 ):
     return configure(env, features_wanted, defines, sources, paths)
+
+
+def get_model_ui() -> str:
+    return "tt"
+
+
+def get_model_ui_conf() -> list[str]:
+    return []

--- a/core/site_scons/models/D002/__init__.py
+++ b/core/site_scons/models/D002/__init__.py
@@ -14,3 +14,11 @@ def configure_board(
     paths: list[str],
 ):
     return configure(env, features_wanted, defines, sources, paths)
+
+
+def get_model_ui() -> str:
+    return "tt"
+
+
+def get_model_ui_conf() -> list[str]:
+    return []

--- a/core/site_scons/models/T2B1/__init__.py
+++ b/core/site_scons/models/T2B1/__init__.py
@@ -31,3 +31,11 @@ def configure_board(
         return module.configure(env, features_wanted, defines, sources, paths)
 
     raise Exception("Unknown model_r_version")
+
+
+def get_model_ui() -> str:
+    return "tr"
+
+
+def get_model_ui_conf() -> list[str]:
+    return ["bootloader_empty_lock"]

--- a/core/site_scons/models/T2T1/__init__.py
+++ b/core/site_scons/models/T2T1/__init__.py
@@ -18,3 +18,11 @@ def configure_board(
         return emul(env, features_wanted, defines, sources, paths)
     else:
         return configure(env, features_wanted, defines, sources, paths)
+
+
+def get_model_ui() -> str:
+    return "tt"
+
+
+def get_model_ui_conf() -> list[str]:
+    return []

--- a/core/site_scons/models/T3B1/__init__.py
+++ b/core/site_scons/models/T3B1/__init__.py
@@ -28,3 +28,11 @@ def configure_board(
         return module.configure(env, features_wanted, defines, sources, paths)
 
     raise Exception("Unknown T3B1 revision")
+
+
+def get_model_ui() -> str:
+    return "tr"
+
+
+def get_model_ui_conf() -> list[str]:
+    return []

--- a/core/site_scons/models/T3T1/__init__.py
+++ b/core/site_scons/models/T3T1/__init__.py
@@ -29,3 +29,11 @@ def configure_board(
         return module.configure(env, features_wanted, defines, sources, paths)
 
     raise Exception("Unknown model_r_version")
+
+
+def get_model_ui() -> str:
+    return "mercury"
+
+
+def get_model_ui_conf() -> list[str]:
+    return []

--- a/core/site_scons/models/__init__.py
+++ b/core/site_scons/models/__init__.py
@@ -43,3 +43,13 @@ def get_model_identifier(model: str) -> str:
 def has_emulator(model: str) -> bool:
     imported_module = importlib.import_module("models." + get_model_identifier(model))
     return hasattr(imported_module, "emulator")
+
+
+def get_model_ui(model: str) -> str:
+    imported_module = importlib.import_module("models." + get_model_identifier(model))
+    return imported_module.get_model_ui()
+
+
+def get_model_ui_conf(model: str) -> str:
+    imported_module = importlib.import_module("models." + get_model_identifier(model))
+    return imported_module.get_model_ui_conf()

--- a/core/site_scons/tools.py
+++ b/core/site_scons/tools.py
@@ -10,20 +10,6 @@ HERE = Path(__file__).parent.resolve()
 PROJECT_ROOT = HERE.parent.resolve()
 
 
-def add_font(
-    font_name: str, font: str | None, defines: list[str], sources: list[str]
-) -> None:
-    if font is not None:
-        font_filename = font.replace("_upper", "").lower()
-        defines += [
-            "TREZOR_FONT_" + font_name + "_ENABLE=" + font,
-            "TREZOR_FONT_" + font_name + '_INCLUDE=\\"' + font_filename + '.h\\"',
-        ]
-        sourcefile = "embed/lib/fonts/" + font_filename + ".c"
-        if sourcefile not in sources:
-            sources.append(sourcefile)
-
-
 def get_version(file: str) -> str:
     major = 0
     minor = 0

--- a/core/site_scons/ui/__init__.py
+++ b/core/site_scons/ui/__init__.py
@@ -1,0 +1,34 @@
+from __future__ import annotations
+
+from site_scons import models
+
+from . import mercury, tr, tt
+
+
+def get_ui_module(model: str):
+    ui_modules = {
+        "mercury": mercury,
+        "tr": tr,
+        "tt": tt,
+    }
+
+    return ui_modules[models.get_model_ui(model)]
+
+
+def init_ui(
+    model: str,
+    stage: int,
+    defines: list[str | tuple[str, str]],
+    sources: list[str],
+    rust_features: list[str],
+):
+    conf = models.get_model_ui_conf(model)
+    get_ui_module(model).init_ui(stage, conf, defines, sources, rust_features)
+
+
+def get_ui_layout(model: str):
+    return get_ui_module(model).get_ui_layout()
+
+
+def get_ui_layout_path(model: str):
+    return get_ui_module(model).get_ui_layout_path()

--- a/core/site_scons/ui/common.py
+++ b/core/site_scons/ui/common.py
@@ -1,0 +1,15 @@
+from __future__ import annotations
+
+
+def add_font(
+    font_name: str, font: str | None, defines: list[str], sources: list[str]
+) -> None:
+    if font is not None:
+        font_filename = font.replace("_upper", "").lower()
+        defines += [
+            "TREZOR_FONT_" + font_name + "_ENABLE=" + font,
+            "TREZOR_FONT_" + font_name + '_INCLUDE=\\"' + font_filename + '.h\\"',
+        ]
+        sourcefile = "embed/lib/fonts/" + font_filename + ".c"
+        if sourcefile not in sources:
+            sources.append(sourcefile)

--- a/core/site_scons/ui/mercury.py
+++ b/core/site_scons/ui/mercury.py
@@ -1,0 +1,63 @@
+from __future__ import annotations
+
+from .common import add_font
+
+
+def init_ui(
+    stage: str,
+    config: list[str],
+    defines: list[str | tuple[str, str]],
+    sources: list[str],
+    rust_features: list[str],
+):
+
+    rust_features.append("model_mercury")
+
+    font_normal = None
+    font_demibold = None
+    font_bold = None
+    font_mono = None
+    font_big = None
+    font_normal_upper = None
+    font_bold_upper = None
+    font_sub = None
+
+    if stage == "bootloader":
+        font_normal = "Font_TTSatoshi_DemiBold_21"
+        font_demibold = "Font_TTSatoshi_DemiBold_21"
+        font_bold = "Font_TTHoves_Bold_17_upper"
+        font_mono = "Font_TTSatoshi_DemiBold_21"
+        font_bold_upper = "Font_TTHoves_Bold_17_upper"
+    if stage == "prodtest":
+        font_normal = "Font_TTSatoshi_DemiBold_21"
+        font_bold = "Font_TTSatoshi_DemiBold_21"
+        font_mono = "Font_RobotoMono_Medium_21"
+    if stage == "firmware":
+        font_normal = "Font_TTSatoshi_DemiBold_21"
+        font_demibold = "Font_TTSatoshi_DemiBold_21"
+        font_bold = "Font_TTSatoshi_DemiBold_21"
+        font_mono = "Font_RobotoMono_Medium_21"
+        font_big = "Font_TTSatoshi_DemiBold_42"
+        font_sub = "Font_TTSatoshi_DemiBold_18"
+        rust_features.append("ui_blurring")
+        rust_features.append("ui_jpeg_decoder")
+        rust_features.append("ui_image_buffer")
+        rust_features.append("ui_overlay")
+
+    # fonts
+    add_font("NORMAL", font_normal, defines, sources)
+    add_font("BOLD", font_bold, defines, sources)
+    add_font("DEMIBOLD", font_demibold, defines, sources)
+    add_font("MONO", font_mono, defines, sources)
+    add_font("BIG", font_big, defines, sources)
+    add_font("NORMAL_UPPER", font_normal_upper, defines, sources)
+    add_font("BOLD_UPPER", font_bold_upper, defines, sources)
+    add_font("SUB", font_sub, defines, sources)
+
+
+def get_ui_layout() -> str:
+    return "UI_LAYOUT_MERCURY"
+
+
+def get_ui_layout_path() -> str:
+    return "trezor/ui/layouts/mercury/"

--- a/core/site_scons/ui/tr.py
+++ b/core/site_scons/ui/tr.py
@@ -1,0 +1,61 @@
+from __future__ import annotations
+
+from .common import add_font
+
+
+def init_ui(
+    stage: str,
+    config: list[str],
+    defines: list[str | tuple[str, str]],
+    sources: list[str],
+    rust_features: list[str],
+):
+
+    rust_features.append("model_tr")
+
+    font_normal = None
+    font_demibold = None
+    font_bold = None
+    font_mono = None
+    font_big = None
+    font_normal_upper = None
+    font_bold_upper = None
+    font_sub = None
+
+    if stage == "bootloader":
+        font_normal = "Font_PixelOperator_Regular_8"
+        font_demibold = "Font_PixelOperator_Regular_8"
+        font_bold = "Font_PixelOperator_Bold_8"
+        font_mono = "Font_PixelOperator_Regular_8"
+        font_big = "Font_PixelOperator_Regular_8"
+        font_normal_upper = "Font_PixelOperator_Regular_8_upper"
+        if "bootloader_empty_lock" in config:
+            rust_features.append("ui_empty_lock")
+    if stage == "prodtest":
+        font_bold = "Font_PixelOperator_Bold_8"
+    if stage == "firmware":
+        font_normal = "Font_PixelOperator_Regular_8"
+        font_demibold = "Font_Unifont_Bold_16"
+        font_bold = "Font_PixelOperator_Bold_8"
+        font_mono = "Font_PixelOperatorMono_Regular_8"
+        font_big = "Font_Unifont_Regular_16"
+        font_normal_upper = "Font_PixelOperator_Regular_8_upper"
+        font_bold_upper = "Font_PixelOperator_Bold_8_upper"
+
+    # fonts
+    add_font("NORMAL", font_normal, defines, sources)
+    add_font("BOLD", font_bold, defines, sources)
+    add_font("DEMIBOLD", font_demibold, defines, sources)
+    add_font("MONO", font_mono, defines, sources)
+    add_font("BIG", font_big, defines, sources)
+    add_font("NORMAL_UPPER", font_normal_upper, defines, sources)
+    add_font("BOLD_UPPER", font_bold_upper, defines, sources)
+    add_font("SUB", font_sub, defines, sources)
+
+
+def get_ui_layout() -> str:
+    return "UI_LAYOUT_TR"
+
+
+def get_ui_layout_path() -> str:
+    return "trezor/ui/layouts/tr/"

--- a/core/site_scons/ui/tt.py
+++ b/core/site_scons/ui/tt.py
@@ -1,0 +1,57 @@
+from __future__ import annotations
+
+from .common import add_font
+
+
+def init_ui(
+    stage: str,
+    config: list[str],
+    defines: list[str | tuple[str, str]],
+    sources: list[str],
+    rust_features: list[str],
+):
+
+    rust_features.append("model_tt")
+
+    font_normal = None
+    font_demibold = None
+    font_bold = None
+    font_mono = None
+    font_big = None
+    font_normal_upper = None
+    font_bold_upper = None
+    font_sub = None
+
+    if stage == "bootloader":
+        font_normal = "Font_TTHoves_Regular_21"
+        font_demibold = "Font_TTHoves_Regular_21"
+        font_bold = "Font_TTHoves_Bold_17_upper"
+        font_mono = "Font_TTHoves_Regular_21"
+        font_bold_upper = "Font_TTHoves_Bold_17_upper"
+    if stage == "prodtest":
+        font_bold = "Font_Roboto_Bold_20"
+    if stage == "firmware":
+        font_normal = "Font_TTHoves_Regular_21"
+        font_demibold = "Font_TTHoves_DemiBold_21"
+        font_mono = "Font_RobotoMono_Medium_20"
+        font_bold_upper = "Font_TTHoves_Bold_17_upper"
+        rust_features.append("ui_blurring")
+        rust_features.append("ui_jpeg_decoder")
+
+    # fonts
+    add_font("NORMAL", font_normal, defines, sources)
+    add_font("BOLD", font_bold, defines, sources)
+    add_font("DEMIBOLD", font_demibold, defines, sources)
+    add_font("MONO", font_mono, defines, sources)
+    add_font("BIG", font_big, defines, sources)
+    add_font("NORMAL_UPPER", font_normal_upper, defines, sources)
+    add_font("BOLD_UPPER", font_bold_upper, defines, sources)
+    add_font("SUB", font_sub, defines, sources)
+
+
+def get_ui_layout() -> str:
+    return "UI_LAYOUT_TT"
+
+
+def get_ui_layout_path() -> str:
+    return "trezor/ui/layouts/tt/"


### PR DESCRIPTION
This PR refactors how UI configuration is done in sconscripts.

A single configuration file per given UI type is introduced. This file defines what fonts, build constants etc should be used in build, depending on concrete target.

Each model carries information what UI type its using.

<!--
If you are a core dev:

Don't forget to set up the fields:
- assign yourself
- set priority to same as original issue
- add PR to sprint
- if Draft -> "in progress"
- if final PR -> "needs review"

If you're an external contributor, you can ignore this text.
-->
