### PR TITLE
TS5 framerate fix

### DIFF
--- a/core/embed/trezorhal/stm32f4/xdisplay/st-7789/display_fb.c
+++ b/core/embed/trezorhal/stm32f4/xdisplay/st-7789/display_fb.c
@@ -166,10 +166,12 @@ display_fb_info_t display_get_frame_buffer(void) {
   if (state == FB_STATE_EMPTY) {
     // First use of this buffer, copy the previous buffer into it
 #if (FRAME_BUFFER_COUNT > 1)
+#ifndef NEW_RENDERING
     uint8_t *src = get_fb_ptr((FRAME_BUFFER_COUNT + drv->queue.wix - 1) %
                               FRAME_BUFFER_COUNT);
     uint8_t *dst = get_fb_ptr(drv->queue.wix);
     memcpy(dst, src, PHYSICAL_FRAME_BUFFER_SIZE);
+#endif
 #endif
   };
 

--- a/core/embed/trezorhal/stm32f4/xdisplay/st-7789/display_internal.h
+++ b/core/embed/trezorhal/stm32f4/xdisplay/st-7789/display_internal.h
@@ -61,7 +61,8 @@ extern display_driver_t g_display_driver;
 
 static inline uint32_t is_mode_exception(void) {
   uint32_t isr_number = __get_IPSR() & IPSR_ISR_Msk;
-  return (isr_number > 0) && (isr_number << 11);
+  // Check if the ISR number is not 0 (thread mode) or 11 (SVCall)
+  return (isr_number != 0) && (isr_number != 11);
 }
 
 #endif  // TREZORHAL_DISPLAY_INTERNAL_H


### PR DESCRIPTION
This PR fixes the problem of decreased display framerate on TS5.

Two issues were addressed:

1. Incorrect detection of exception/handler mode inside `display_refresh()`, which caused unnecessary waiting for the TE signal.
2. Removed unnecessary framebuffer copying in `display_get_frame_buffer` (this is not actually a bug fix, but an optimization).

The bug 1) was introduced in #4188, so no changelog entry is needed.
