### PR TITLE
fix(core): fix interaction-less update

### DIFF
--- a/core/embed/trezorhal/stm32f4/syscall_stubs.c
+++ b/core/embed/trezorhal/stm32f4/syscall_stubs.c
@@ -87,7 +87,7 @@ void reboot_to_bootloader(void) {
 }
 
 void reboot_and_upgrade(const uint8_t hash[32]) {
-  syscall_invoke1(SYSCALL_REBOOT_AND_UPGRADE, (uint32_t)hash);
+  syscall_invoke1((uint32_t)hash, SYSCALL_REBOOT_AND_UPGRADE);
   while (1)
     ;
 }


### PR DESCRIPTION
This PR fixes a bug introduced in PR #4188 that causes a deadlock when upgrading to a higher firmware version from the firmware itself (also known as an interaction-less update).

No changelog entry is needed, as this bug is not present in any official release.