### PR TITLE
fix(core): ensure proper handling of vendor string

### DIFF
--- a/core/embed/trezorhal/stm32f4/fwutils.c
+++ b/core/embed/trezorhal/stm32f4/fwutils.c
@@ -83,15 +83,17 @@ secbool firmware_get_vendor(char* buff, size_t buff_size) {
 
   vendor_header vhdr = {0};
 
+  memset(buff, 0, buff_size);
+
   if (data == NULL || sectrue != read_vendor_header(data, &vhdr)) {
     return secfalse;
   }
 
-  if (buff == NULL || buff_size < vhdr.vstr_len + 1) {
+  if (buff_size < vhdr.vstr_len + 1) {
     return secfalse;
   }
 
-  strncpy(buff, vhdr.vstr, buff_size);
+  memcpy(buff, vhdr.vstr, vhdr.vstr_len);
 
   return sectrue;
 }


### PR DESCRIPTION
This PR fixes a bug introduced in #4188 that caused an invalid read of the vendor string from the vendor header.

Before the fix, `trezorctl get-features` printed:
```
...

fw_vendor: 'UNSAFE, DO NOT USE!TOIfx',

...
```
No changelog entry is needed since this bug wasn't released yet.


