### PR TITLE
Fix status screen for UI tests

### DIFF
--- a/core/embed/rust/src/ui/model_mercury/component/status_screen.rs
+++ b/core/embed/rust/src/ui/model_mercury/component/status_screen.rs
@@ -149,7 +149,7 @@ impl StatusScreen {
         icon: Icon,
         icon_color: Color,
         circle_color: Color,
-        dismiss_style: DismissType,
+        dismiss_type: DismissType,
         msg: TString<'static>,
     ) -> Self {
         Self {
@@ -157,7 +157,7 @@ impl StatusScreen {
             icon,
             icon_color,
             circle_color,
-            dismiss_type: dismiss_style,
+            dismiss_type,
             anim: StatusAnimation::default(),
             msg: Label::new(msg, Alignment::Start, theme::TEXT_NORMAL).vertically_centered(),
         }
@@ -174,11 +174,12 @@ impl StatusScreen {
     }
 
     pub fn new_success_timeout(msg: TString<'static>) -> Self {
+        let timeout_ms = if !animation_disabled() { TIMEOUT_MS } else { 0 };
         Self::new(
             theme::ICON_SIMPLE_CHECKMARK30,
             theme::GREEN_LIME,
             theme::GREEN_LIGHT,
-            DismissType::Timeout(Timeout::new(TIMEOUT_MS)),
+            DismissType::Timeout(Timeout::new(timeout_ms)),
             msg,
         )
     }
@@ -194,11 +195,12 @@ impl StatusScreen {
     }
 
     pub fn new_neutral_timeout(msg: TString<'static>) -> Self {
+        let timeout_ms = if !animation_disabled() { TIMEOUT_MS } else { 0 };
         Self::new(
             theme::ICON_SIMPLE_CHECKMARK30,
             theme::GREY_EXTRA_LIGHT,
             theme::GREY_DARK,
-            DismissType::Timeout(Timeout::new(TIMEOUT_MS)),
+            DismissType::Timeout(Timeout::new(timeout_ms)),
             msg,
         )
     }

--- a/tests/input_flows.py
+++ b/tests/input_flows.py
@@ -655,7 +655,7 @@ class InputFlowShowXpubQRCode(InputFlowBase):
             layout = self.debug.swipe_up()
         self.debug.synchronize_at("PromptScreen")
         # tap to confirm
-        self.debug.press_yes()
+        self.debug.click(buttons.TAP_TO_CONFIRM)
 
 
 class InputFlowPaymentRequestDetails(InputFlowBase):


### PR DESCRIPTION
Show Success screens with timeout in UI diff for `mercury`.

Setting the timeout to 0 if `animations_disabled` is not necessary but speeds up the tests.
![image](https://github.com/user-attachments/assets/47f43bfd-49fb-4e7a-951f-6502a35b6dd5)

<!--
If you are a core dev:

Don't forget to set up the fields:
- assign yourself
- set priority to same as original issue
- add PR to sprint
- if Draft -> "in progress"
- if final PR -> "needs review"

If you're an external contributor, you can ignore this text.
-->
