### PR TITLE
SLIP-39 extend_mnemonics()

### DIFF
--- a/core/tests/test_trezor.crypto.slip39.py
+++ b/core/tests/test_trezor.crypto.slip39.py
@@ -37,6 +37,16 @@ class TestCryptoSlip39(unittest.TestCase):
                 slip39.recover_ems(mnemonics[:3]), slip39.recover_ems(mnemonics[2:])
             )
 
+    def test_basic_sharing_extend(self):
+        identifier = slip39.generate_random_identifier()
+        for extendable in (False, True):
+            mnemonics = slip39.split_ems(1, [(2, 3)], identifier, extendable, 1, self.EMS)
+            mnemonics = mnemonics[0]
+            extended_mnemonics = slip39.extend_mnemonics(4, mnemonics[1:])
+            self.assertEqual(mnemonics, extended_mnemonics[:3])
+            for i in range(3):
+                self.assertEqual(slip39.recover_ems([extended_mnemonics[3], mnemonics[i]])[3], self.EMS)
+
     def test_basic_sharing_fixed(self):
         for extendable in (False, True):
             generated_identifier = slip39.generate_random_identifier()


### PR DESCRIPTION
Implements a function which extends a set of SLIP-39 mnemonics by extra shares, while maintaining the threshold.

This, for example, allows extending a 2-of-2 backup to 2-of-3, where the first two shares remain the same. It also allows reconstructing lost shares by providing any threshold number of shares and requesting the original share count.

The implementation is limited to Slip39_Basic, i.e. single group.

Slack thread: https://satoshilabs.slack.com/archives/C016ACNF1BN/p1727975559358469