### PR TITLE
Framebuffer access control

### DIFF
--- a/core/embed/trezorhal/mpu.h
+++ b/core/embed/trezorhal/mpu.h
@@ -20,6 +20,8 @@
 #ifndef TREZORHAL_MPU_H
 #define TREZORHAL_MPU_H
 
+#include <stddef.h>
+
 #ifdef KERNEL_MODE
 
 // The MPU driver can be set to on of the following modes.
@@ -65,6 +67,16 @@ mpu_mode_t mpu_reconfig(mpu_mode_t mode);
 //
 // Same as `mpu_reconfig()`, but with a more descriptive name.
 void mpu_restore(mpu_mode_t mode);
+
+// Sets the MPU to allow unprivileged access to the
+// framebuffer at the given address and size.
+//
+// The changes are made effective after the next MPU reconfiguration
+// to the `MPU_MODE_APP` mode.
+//
+// Addr and size must be aligned to the 32-byte boundary.
+// If addr == 0, the framebuffer is not accessible in the unprivileged mode.
+void mpu_set_unpriv_fb(void* addr, size_t size);
 
 #endif  // KERNEL_MODE
 

--- a/core/embed/trezorhal/stm32f4/mpu.c
+++ b/core/embed/trezorhal/stm32f4/mpu.c
@@ -204,6 +204,10 @@ mpu_mode_t mpu_get_mode(void) {
   return drv->mode;
 }
 
+void mpu_set_unpriv_fb(void* addr, size_t size) {
+  // Not implemented on STM32F4
+}
+
 // STM32F4xx memory map
 //
 // 0x08000000  2MB    FLASH

--- a/core/embed/trezorhal/stm32f4/xdisplay/st-7789/display_driver.c
+++ b/core/embed/trezorhal/stm32f4/xdisplay/st-7789/display_driver.c
@@ -21,12 +21,12 @@
 
 #include <xdisplay.h>
 
+#include "backlight_pwm.h"
 #include "display_fb.h"
 #include "display_internal.h"
 #include "display_io.h"
 #include "display_panel.h"
-
-#include "backlight_pwm.h"
+#include "mpu.h"
 
 #ifndef BOARDLOADER
 #include "bg_copy.h"
@@ -97,6 +97,8 @@ void display_deinit(display_content_mode_t mode) {
   NVIC_DisableIRQ(DISPLAY_TE_INTERRUPT_NUM);
 #endif
 #endif
+
+  mpu_set_unpriv_fb(NULL, 0);
 
   backlight_pwm_deinit(mode == DISPLAY_RESET_CONTENT ? BACKLIGHT_RESET
                                                      : BACKLIGHT_RETAIN);

--- a/core/embed/trezorhal/stm32f4/xdisplay/st-7789/display_fb.c
+++ b/core/embed/trezorhal/stm32f4/xdisplay/st-7789/display_fb.c
@@ -177,6 +177,8 @@ bool display_get_frame_buffer(display_fb_info_t *fb) {
 
   fb->ptr = get_fb_ptr(drv->queue.wix);
   fb->stride = DISPLAY_RESX * sizeof(uint16_t);
+  // Enable access to the frame buffer from the unprivileged code
+  mpu_set_unpriv_fb(fb->ptr, PHYSICAL_FRAME_BUFFER_SIZE);
 
   return true;
 }
@@ -214,6 +216,9 @@ void display_refresh(void) {
     // the state to be copied to the display
     return;
   }
+
+  // Disable access to the frame buffer from the unprivileged code
+  mpu_set_unpriv_fb(NULL, 0);
 
 #ifndef BOARDLOADER
   if (is_mode_exception()) {

--- a/core/embed/trezorhal/stm32f4/xdisplay/stm32f429i-disc1/display_driver.c
+++ b/core/embed/trezorhal/stm32f4/xdisplay/stm32f429i-disc1/display_driver.c
@@ -27,6 +27,7 @@
 
 #include "display_internal.h"
 #include "ili9341_spi.h"
+#include "mpu.h"
 #include "xdisplay.h"
 
 #if (DISPLAY_RESX != 240) || (DISPLAY_RESY != 320)
@@ -72,6 +73,8 @@ void display_init(display_content_mode_t mode) {
 
 void display_deinit(display_content_mode_t mode) {
   display_driver_t *drv = &g_display_driver;
+
+  mpu_set_unpriv_fb(NULL, 0);
 
   drv->initialized = false;
 }
@@ -133,12 +136,17 @@ bool display_get_frame_buffer(display_fb_info_t *fb) {
   } else {
     fb->ptr = (void *)drv->framebuf;
     fb->stride = DISPLAY_RESX * sizeof(uint16_t);
+    // Enable access to the frame buffer from the unprivileged code
+    mpu_set_unpriv_fb(fb->ptr, FRAME_BUFFER_SIZE);
     return true;
   }
 }
 
 void display_refresh(void) {
   // Do nothing as using just a single frame buffer
+
+  // Disable access to the frame buffer from the unprivileged code
+  mpu_set_unpriv_fb(NULL, 0);
 }
 
 void display_fill(const gfx_bitblt_t *bb) {

--- a/core/embed/trezorhal/stm32u5/xdisplay/stm32u5a9j-dk/display_driver.c
+++ b/core/embed/trezorhal/stm32u5/xdisplay/stm32u5a9j-dk/display_driver.c
@@ -24,6 +24,7 @@
 #include STM32_HAL_H
 
 #include "display_internal.h"
+#include "mpu.h"
 #include "xdisplay.h"
 
 #if (DISPLAY_RESX != 240) || (DISPLAY_RESY != 240)
@@ -109,6 +110,8 @@ void display_deinit(display_content_mode_t mode) {
     BSP_LCD_SetBrightness(0, 0);
     BSP_LCD_DeInit(0);
   }
+
+  mpu_set_unpriv_fb(NULL, 0);
 
   drv->initialized = false;
 }

--- a/core/embed/trezorhal/stm32u5/xdisplay/stm32u5a9j-dk/display_fb.c
+++ b/core/embed/trezorhal/stm32u5/xdisplay/stm32u5a9j-dk/display_fb.c
@@ -25,6 +25,7 @@
 
 #include <xdisplay.h>
 #include "display_internal.h"
+#include "mpu.h"
 
 #ifdef KERNEL_MODE
 
@@ -67,6 +68,9 @@ bool display_get_frame_buffer(display_fb_info_t *fb) {
   fb->ptr = (void *)addr;
   fb->stride = fb_stride;
 
+  // Enable access to the frame buffer from the unprivileged code
+  mpu_set_unpriv_fb(fb->ptr, VIRTUAL_FRAME_BUFFER_SIZE);
+
   return true;
 }
 
@@ -76,6 +80,9 @@ void display_refresh(void) {
   if (!drv->initialized) {
     return;
   }
+
+  // Disable access to the frame buffer from the unprivileged code
+  mpu_set_unpriv_fb(NULL, 0);
 
   if (current_frame_buffer == 0) {
     current_frame_buffer = 1;

--- a/core/embed/trezorhal/stm32u5/xdisplay/stm32u5a9j-dk/display_internal.h
+++ b/core/embed/trezorhal/stm32u5/xdisplay/stm32u5a9j-dk/display_internal.h
@@ -45,6 +45,10 @@ extern display_driver_t g_display_driver;
 // Pitch (in pixels) of the virtual frame buffer
 #define FRAME_BUFFER_PIXELS_PER_LINE 768
 
+// Size of the virtual frame buffer in bytes
+#define VIRTUAL_FRAME_BUFFER_SIZE \
+  (FRAME_BUFFER_PIXELS_PER_LINE * DISPLAY_RESY * 4)
+
 // Physical frame buffers in internal SRAM memory
 //
 // Both frame buffers layes in the fixed addresses that


### PR DESCRIPTION
This small PR adds precise access control for the framebuffer (and resolves #4207).

This change is primarily aimed at devices using two framebuffers (T3T1) but also affects devices using a single framebuffer (T2B1, T3B1).

Before this change, the unprivileged app had access to both framebuffers at any time. Now, an unprivileged application has access only to the framebuffer acquired by `display_get_frame_buffer()` until it releases it by calling the `display_refresh()` function.