### PR TITLE
feat: support Unchained p2wsh path

### DIFF
--- a/core/.changelog.d/4271.added
+++ b/core/.changelog.d/4271.added
@@ -1,0 +1,1 @@
+Add P2WSH support for Unchained BIP32 paths.

--- a/core/src/apps/bitcoin/keychain.py
+++ b/core/src/apps/bitcoin/keychain.py
@@ -158,6 +158,9 @@ def validate_path_against_script_type(
         if slip44 == SLIP44_BITCOIN:
             append(PATTERN_GREENADDRESS_A)
             append(PATTERN_GREENADDRESS_B)
+        if coin.coin_name in BITCOIN_NAMES and multisig:
+            append(PATTERN_UNCHAINED_HARDENED)
+            append(PATTERN_UNCHAINED_UNHARDENED)
 
     elif coin.taproot and script_type == InputScriptType.SPENDTAPROOT:
         append(PATTERN_BIP86)


### PR DESCRIPTION
Unchained plans to support p2wsh using the same `m/45` path we use for p2sh. This change adds the `UNCHAINED_` patterns to bitcoin `InputScriptType.SPENDP2SHWITNESS`.