### PR TITLE
add TOUCH_POWER command to prodtest

### DIFF
--- a/core/embed/prodtest/.changelog.d/4252.added
+++ b/core/embed/prodtest/.changelog.d/4252.added
@@ -1,0 +1,1 @@
+Added TOUCH_POWER command to allow testing touch power supply without connected touch screen

--- a/core/embed/prodtest/README.md
+++ b/core/embed/prodtest/README.md
@@ -148,6 +148,20 @@ TOUCH_IDLE 10
 OK
 ```
 
+### TOUCH_POWER
+The `TOUCH_POWER` command tests the functionality of touch layer power supply
+
+The command requires one input parameter:
+* The timeout in seconds
+
+The powers up the touch layer and waits for a specific time period so that measurement can be done by test equipment.
+
+Example - wait ten seconds for touch power measurement:
+```
+TOUCH_POWER 10
+OK
+```
+
 ### SENS
 The `SENS` command is used to evaluating the touch screen sensitivity.
 It draws a filled box around the touch coordinates.

--- a/core/embed/prodtest/main.c
+++ b/core/embed/prodtest/main.c
@@ -498,6 +498,38 @@ static void test_touch_idle(const char *args) {
   touch_deinit();
 }
 
+static void test_touch_power(const char *args) {
+  static const int expected_params = 1;
+  int num_params = 0;
+
+  int params[expected_params];
+
+  extract_params(args, params, &num_params, expected_params);
+
+  if (num_params != expected_params) {
+    vcp_println("ERROR PARAM");
+    return;
+  }
+
+  int timeout = params[0];
+
+  display_clear();
+  display_text_center(DISPLAY_RESX / 2, DISPLAY_RESY / 2, "MEASURING", -1,
+                      FONT_BOLD, COLOR_WHITE, COLOR_BLACK);
+  display_refresh();
+
+  touch_power_set(true);
+
+  systick_delay_ms(timeout * 1000);
+
+  vcp_println("OK");
+
+  touch_power_set(false);
+
+  display_clear();
+  display_refresh();
+}
+
 static void test_sensitivity(const char *args) {
   int v = atoi(args);
 
@@ -868,6 +900,9 @@ int main(void) {
 
     } else if (startswith(line, "TOUCH_IDLE ")) {
       test_touch_idle(line + 11);
+
+    } else if (startswith(line, "TOUCH_POWER ")) {
+      test_touch_power(line + 12);
 
     } else if (startswith(line, "SENS ")) {
       test_sensitivity(line + 5);

--- a/core/embed/trezorhal/stm32f4/touch/ft6x36.c
+++ b/core/embed/trezorhal/stm32f4/touch/ft6x36.c
@@ -303,6 +303,15 @@ void touch_deinit(void) {
   }
 }
 
+void touch_power_set(bool on) {
+  if (on) {
+    ft6x36_power_up();
+  } else {
+    touch_deinit();
+    ft6x36_power_down();
+  }
+}
+
 secbool touch_ready(void) {
   touch_driver_t* driver = &g_touch_driver;
 

--- a/core/embed/trezorhal/stm32f4/touch/stmpe811.c
+++ b/core/embed/trezorhal/stm32f4/touch/stmpe811.c
@@ -642,6 +642,10 @@ void touch_deinit(void) {
   }
 }
 
+void touch_power_set(bool on) {
+  // Not implemented for the discovery kit
+}
+
 secbool touch_ready(void) {
   touch_driver_t *driver = &g_touch_driver;
   return driver->initialized;

--- a/core/embed/trezorhal/stm32u5/touch/sitronix.c
+++ b/core/embed/trezorhal/stm32u5/touch/sitronix.c
@@ -1253,6 +1253,10 @@ void touch_deinit(void) {
   }
 }
 
+void touch_power_set(bool on) {
+  // Not implemented for the discovery kit
+}
+
 secbool touch_ready(void) {
   touch_driver_t *driver = &g_touch_driver;
   return driver->initialized;

--- a/core/embed/trezorhal/touch.h
+++ b/core/embed/trezorhal/touch.h
@@ -1,6 +1,7 @@
 #ifndef TREZOR_HAL_TOUCH_H
 #define TREZOR_HAL_TOUCH_H
 
+#include <stdbool.h>
 #include <stdint.h>
 #include "secbool.h"
 
@@ -18,6 +19,12 @@ secbool touch_init(void);
 //
 // The function deinitializes touch controller and powers it off.
 void touch_deinit();
+
+// Powers on/off the touch controller
+//
+// The function is used to test touch power supply during production.
+// After forcing power off, the touch controller needs to be re-initialized
+void touch_power_set(bool on);
 
 // Checks if the touch driver is ready to report touches
 //

--- a/core/embed/trezorhal/unix/touch.c
+++ b/core/embed/trezorhal/unix/touch.c
@@ -216,6 +216,10 @@ void touch_deinit(void) {
   }
 }
 
+void touch_power_set(bool on) {
+  // Not implemented on the emulator
+}
+
 secbool touch_ready(void) {
   touch_driver_t* driver = &g_touch_driver;
   return driver->initialized;


### PR DESCRIPTION
Fixes #4252 .

This PR adds TOUCH_POWER command to prodtest, that forces the power supply to turn on for specified time, so that its output can be measured without the need to have touch panel connected.


<!--
If you are a core dev:

Don't forget to set up the fields:
- assign yourself
- set priority to same as original issue
- add PR to sprint
- if Draft -> "in progress"
- if final PR -> "needs review"

If you're an external contributor, you can ignore this text.
-->
