### PR TITLE
support 32 bit colors in emulator

### DIFF
--- a/core/embed/lib/gfx_draw.c
+++ b/core/embed/lib/gfx_draw.c
@@ -294,15 +294,15 @@ void gfx_draw_qrcode(int x, int y, uint8_t scale, const char* data) {
 void display_clear(void) { gfx_clear(); }
 
 void display_bar(int x, int y, int w, int h, uint16_t c) {
-  gfx_draw_bar(gfx_rect_wh(x, y, w, h), c);
+  gfx_draw_bar(gfx_rect_wh(x, y, w, h), gfx_color16_to_color(c));
 }
 
 void display_text(int x, int y, const char* text, int textlen, int font,
                   uint16_t fg_color, uint16_t bg_color) {
   gfx_text_attr_t attr = {
       .font = font,
-      .fg_color = fg_color,
-      .bg_color = bg_color,
+      .fg_color = gfx_color16_to_color(fg_color),
+      .bg_color = gfx_color16_to_color(bg_color),
   };
 
   size_t maxlen = textlen < 0 ? UINT32_MAX : textlen;
@@ -313,8 +313,8 @@ void display_text_center(int x, int y, const char* text, int textlen, int font,
                          uint16_t fg_color, uint16_t bg_color) {
   gfx_text_attr_t attr = {
       .font = font,
-      .fg_color = fg_color,
-      .bg_color = bg_color,
+      .fg_color = gfx_color16_to_color(fg_color),
+      .bg_color = gfx_color16_to_color(bg_color),
   };
 
   size_t maxlen = textlen < 0 ? UINT32_MAX : textlen;

--- a/core/site_scons/models/T3W1/emulator.py
+++ b/core/site_scons/models/T3W1/emulator.py
@@ -17,9 +17,10 @@ def configure(
     hw_revision = 0
     mcu = "STM32F427xx"
 
-    defines += ["XFRAMEBUFFER", "DISPLAY_RGB585"]
+    defines += ["XFRAMEBUFFER", "DISPLAY_RGBA8888", "UI_COLOR_32BIT"]
     features_available.append("xframebuffer")
-    features_available.append("display_rgb565")
+    features_available.append("display_rgba8888")
+    features_available.append("ui_color_32bit")
 
     defines += [mcu]
     defines += [f'TREZOR_BOARD=\\"{board}\\"']


### PR DESCRIPTION
This PR introduces support for 32bit colors in emulator.

T3W1 emulator is switched to use these colors.


<!--
If you are a core dev:

Don't forget to set up the fields:
- assign yourself
- set priority to same as original issue
- add PR to sprint
- if Draft -> "in progress"
- if final PR -> "needs review"

If you're an external contributor, you can ignore this text.
-->
