### PR TITLE
fix(core): correct swapped F4/U5 reset flags

### DIFF
--- a/core/embed/trezorhal/stm32f4/reset_flags.c
+++ b/core/embed/trezorhal/stm32f4/reset_flags.c
@@ -29,8 +29,9 @@ secbool reset_flags_check(void) {
   // for production. check the reset flags to assure that we arrive here due to
   // a regular full power-on event, and not as a result of a lesser reset.
   if ((RCC->CSR & (RCC_CSR_LPWRRSTF | RCC_CSR_WWDGRSTF | RCC_CSR_IWDGRSTF |
-                   RCC_CSR_SFTRSTF | RCC_CSR_PINRSTF | RCC_CSR_BORRSTF |
-                   RCC_CSR_OBLRSTF)) != (RCC_CSR_PINRSTF | RCC_CSR_BORRSTF)) {
+                   RCC_CSR_SFTRSTF | RCC_CSR_PORRSTF | RCC_CSR_PINRSTF |
+                   RCC_CSR_BORRSTF)) !=
+      (RCC_CSR_PORRSTF | RCC_CSR_PINRSTF | RCC_CSR_BORRSTF)) {
     return secfalse;
   }
 #endif

--- a/core/embed/trezorhal/stm32u5/reset_flags.c
+++ b/core/embed/trezorhal/stm32u5/reset_flags.c
@@ -29,9 +29,8 @@ secbool reset_flags_check(void) {
   // for production. check the reset flags to assure that we arrive here due to
   // a regular full power-on event, and not as a result of a lesser reset.
   if ((RCC->CSR & (RCC_CSR_LPWRRSTF | RCC_CSR_WWDGRSTF | RCC_CSR_IWDGRSTF |
-                   RCC_CSR_SFTRSTF | RCC_CSR_PORRSTF | RCC_CSR_PINRSTF |
-                   RCC_CSR_BORRSTF)) !=
-      (RCC_CSR_PORRSTF | RCC_CSR_PINRSTF | RCC_CSR_BORRSTF)) {
+                   RCC_CSR_SFTRSTF | RCC_CSR_PINRSTF | RCC_CSR_BORRSTF |
+                   RCC_CSR_OBLRSTF)) != (RCC_CSR_PINRSTF | RCC_CSR_BORRSTF)) {
     return secfalse;
   }
 #endif


### PR DESCRIPTION
This PR fixes a recently introduced bug in the refactoring of the low-level module that is blocking the production build.

The reset flags for STM32F4 and STM32U5 were mistakenly swapped.

