### PR TITLE
fix(core/rust) Handle touchStop event in brightess dialog

### DIFF
--- a/core/.changelog.d/4261.fixed
+++ b/core/.changelog.d/4261.fixed
@@ -1,0 +1,1 @@
+[T3T1] Add instruction to Swipe up after changing brightness.

--- a/core/embed/rust/src/ui/model_mercury/component/number_input_slider.rs
+++ b/core/embed/rust/src/ui/model_mercury/component/number_input_slider.rs
@@ -76,24 +76,24 @@ impl Component for NumberInputSliderDialog {
     }
 
     fn event(&mut self, ctx: &mut EventCtx, event: Event) -> Option<Self::Msg> {
-        if let Some(value) = self.input.event(ctx, event) {
-            self.val = value;
+        let msg_opt = self.input.event(ctx, event);
 
-            if self.val == self.init_val || self.input.touching {
-                self.footer
-                    .update_instruction(ctx, TR::instructions__swipe_horizontally);
-                self.footer.update_description(ctx, TR::setting__adjust);
-                ctx.request_paint();
-            } else {
-                self.footer
-                    .update_instruction(ctx, TR::instructions__swipe_up);
-                self.footer.update_description(ctx, TR::setting__apply);
-                ctx.request_paint();
-            }
-
-            return Some(Self::Msg::Changed(value));
+        if self.val == self.init_val || self.input.touching {
+            self.footer
+                .update_instruction(ctx, TR::instructions__swipe_horizontally);
+            self.footer.update_description(ctx, TR::setting__adjust);
+            ctx.request_paint();
+        } else {
+            self.footer
+                .update_instruction(ctx, TR::instructions__swipe_up);
+            self.footer.update_description(ctx, TR::setting__apply);
+            ctx.request_paint();
         }
-        None
+
+        msg_opt.map(|value| {
+            self.val = value;
+            Self::Msg::Changed(value)
+        })
     }
 
     fn paint(&mut self) {


### PR DESCRIPTION
This PR adds handling of the `TouchStop` event for `NumberInputSliderDialog` struct on T3T1 (resolves #4261). 

Changes include:

1. In `NumberInputSliderDialog` event function, handling of the `None` value (`TouchEnd` event in `NumberInputSlider` ) is added. It fixes the logic, when the _Adjust_ or _Apply_ strings are shown to the user.
<!--
If you are a core dev:

Don't forget to set up the fields:
- assign yourself
- set priority to same as original issue
- add PR to sprint
- if Draft -> "in progress"
- if final PR -> "needs review"

If you're an external contributor, you can ignore this text.
-->
