### PR TITLE
fix(core): unaligned array in protobuf decoder

### DIFF
--- a/common/protob/pb2py
+++ b/common/protob/pb2py
@@ -93,7 +93,7 @@ if not PROTOC:
 PROTOC_PREFIX = Path(PROTOC).resolve().parent.parent
 
 
-ENUM_ENTRY = c.PrefixedArray(c.Byte, c.Int16ul)
+ENUM_ENTRY = c.PrefixedArray(c.Int16ul, c.Int16ul)
 
 FIELD_STRUCT = c.Struct(
     "tag" / c.Byte,

--- a/core/embed/rust/src/protobuf/defs.rs
+++ b/core/embed/rust/src/protobuf/defs.rs
@@ -209,7 +209,7 @@ pub unsafe fn get_msg(msg_offset: u16) -> MsgDef {
 unsafe fn get_enum(enum_offset: u16) -> EnumDef {
     // #[repr(C, packed)]
     // struct EnumDef {
-    //     count: u8,
+    //     count: u16,
     //     vals: [u16],
     // }
 
@@ -217,8 +217,10 @@ unsafe fn get_enum(enum_offset: u16) -> EnumDef {
     // definition inside `ENUM_DEFS`.
     unsafe {
         let ptr = ENUM_DEFS.as_ptr().add(enum_offset as usize);
-        let count = ptr.offset(0).read() as usize;
-        let vals = ptr.offset(1);
+        let count_lo = ptr.offset(0).read();
+        let count_hi = ptr.offset(1).read();
+        let count = u16::from_le_bytes([count_lo, count_hi]) as usize;
+        let vals = ptr.offset(2);
 
         EnumDef {
             values: slice::from_raw_parts(vals.cast(), count),


### PR DESCRIPTION
Protobuf decoder is failing some newly added Rust assertions by creating unaligned slices: https://blog.rust-lang.org/2024/05/02/Rust-1.78.0.html#asserting-unsafe-preconditions

<!--
If you are a core dev:

Don't forget to set up the fields:
- assign yourself
- set priority to same as original issue
- add PR to sprint
- if Draft -> "in progress"
- if final PR -> "needs review"

If you're an external contributor, you can ignore this text.
-->
