### PR TITLE
Forbid multisig to singlesig change outputs

### DIFF
--- a/core/.changelog.d/4285.feat
+++ b/core/.changelog.d/4285.feat
@@ -1,0 +1,1 @@
+Forbidden multisig to singlesig change outputs.

--- a/core/src/apps/bitcoin/sign_tx/matchcheck.py
+++ b/core/src/apps/bitcoin/sign_tx/matchcheck.py
@@ -107,6 +107,11 @@ class MultisigFingerprintChecker(MatchChecker):
         return multisig.multisig_fingerprint(txio.multisig)
 
 
+class MultisigChecker(MatchChecker):
+    def attribute_from_tx(self, txio: TxInput | TxOutput) -> Any:
+        return txio.multisig is not None
+
+
 class ScriptTypeChecker(MatchChecker):
     def attribute_from_tx(self, txio: TxInput | TxOutput) -> Any:
         from trezor.enums import InputScriptType

--- a/core/src/apps/bitcoin/sign_tx/tx_info.py
+++ b/core/src/apps/bitcoin/sign_tx/tx_info.py
@@ -53,10 +53,14 @@ class TxInfoBase:
         from trezor.utils import HashWriter
 
         from .matchcheck import (
+            MultisigChecker,
             MultisigFingerprintChecker,
             ScriptTypeChecker,
             WalletPathChecker,
         )
+
+        # Whether all inputs are multisig or all inputs are singlesig, used to validate change-output.
+        self.multisig = MultisigChecker()
 
         # Checksum of multisig inputs, used to validate change-output.
         self.multisig_fingerprint = MultisigFingerprintChecker()
@@ -90,6 +94,7 @@ class TxInfoBase:
         self.min_sequence = min(self.min_sequence, txi.sequence)
 
         if not common.input_is_external(txi):
+            self.multisig.add_input(txi)
             self.wallet_path.add_input(txi)
             self.script_type.add_input(txi)
             self.multisig_fingerprint.add_input(txi)
@@ -107,17 +112,12 @@ class TxInfoBase:
         if txo.script_type not in common.CHANGE_OUTPUT_SCRIPT_TYPES:
             return False
 
-        # Check the multisig fingerprint only for multisig outputs. This means
-        # that a transfer from a multisig account to a singlesig account is
-        # treated as a change-output as long as all other change-output
-        # conditions are satisfied. This goes a bit against the concept of a
-        # multisig account but the other cosigners will notice that they are
-        # relinquishing control of the funds, so there is no security risk.
         if txo.multisig and not self.multisig_fingerprint.output_matches(txo):
             return False
 
         return (
-            self.wallet_path.output_matches(txo)
+            self.multisig.output_matches(txo)
+            and self.wallet_path.output_matches(txo)
             and self.script_type.output_matches(txo)
             and len(txo.address_n) >= common.BIP32_WALLET_DEPTH
             and txo.address_n[-2] <= _BIP32_CHANGE_CHAIN

--- a/legacy/firmware/.changelog.d/4285.feat
+++ b/legacy/firmware/.changelog.d/4285.feat
@@ -1,0 +1,1 @@
+Forbidden multisig to singlesig change outputs.


### PR DESCRIPTION
In the main branch, the multisig fingerprint is checked only for multisig outputs. This means that a transfer from a multisig account to a singlesig account is treated as a change-output as long as all other change-output conditions are satisfied.

In this pull request, an output is treated as a change output only if
  * the output is a multisig and all the inputs are multisig or
  * the output is a singlesig and all the inputs are singlesig.

This allows users to have greater control over where their funds are sent because since https://github.com/trezor/trezor-firmware/pull/2925, we also display the path for internal outputs.
