### PR TITLE
Fix emulators on MacOS

### DIFF
--- a/core/SConscript.bootloader_emu
+++ b/core/SConscript.bootloader_emu
@@ -187,7 +187,7 @@ env.Replace(
     '-g3 '
     '-nostdlib '
     '-std=gnu11 -Wall -Werror -Wpointer-arith -Wno-missing-braces -fno-common '
-    '-fsingle-precision-constant -fdata-sections -ffunction-sections '
+    '-fdata-sections -ffunction-sections '
     '-ffreestanding '
     '-fstack-protector-all '
     + CCFLAGS_MOD,

--- a/core/embed/bootloader/emulator.c
+++ b/core/embed/bootloader/emulator.c
@@ -146,13 +146,13 @@ __attribute__((noreturn)) int main(int argc, char **argv) {
         set_variant = 1;
         bitcoin_only = atoi(optarg);
         break;
-      case 'f':
+      case 'f': {
         uint8_t hash[BLAKE2S_DIGEST_LENGTH];
         if (!load_firmware(optarg, hash)) {
           exit(1);
         }
         bootargs_set(BOOT_COMMAND_INSTALL_UPGRADE, hash, sizeof(hash));
-        break;
+      } break;
 #ifdef USE_OPTIGA
       case 'l':
         // write bootloader-lock secret

--- a/core/embed/bootloader/main.c
+++ b/core/embed/bootloader/main.c
@@ -99,7 +99,7 @@ typedef enum {
 void failed_jump_to_firmware(void);
 
 CONFIDENTIAL volatile secbool dont_optimize_out_true = sectrue;
-CONFIDENTIAL volatile void (*firmware_jump_fn)(void) = failed_jump_to_firmware;
+CONFIDENTIAL void (*volatile firmware_jump_fn)(void) = failed_jump_to_firmware;
 
 static void usb_init_all(secbool usb21_landing) {
   usb_dev_info_t dev_info = {

--- a/core/embed/bootloader/messages.c
+++ b/core/embed/bootloader/messages.c
@@ -395,7 +395,10 @@ void process_msg_FirmwareErase(uint8_t iface_num, uint32_t msg_size,
 
 static uint32_t chunk_size = 0;
 
-__attribute__((section(".buf"))) uint32_t chunk_buffer[IMAGE_CHUNK_SIZE / 4];
+#ifndef TREZOR_EMULATOR
+__attribute__((section(".buf")))
+#endif
+uint32_t chunk_buffer[IMAGE_CHUNK_SIZE / 4];
 
 #define CHUNK_BUFFER_PTR ((const uint8_t *const)&chunk_buffer)
 

--- a/core/embed/lib/error_handling.c
+++ b/core/embed/lib/error_handling.c
@@ -23,7 +23,11 @@
 #include "error_handling.h"
 #include "system.h"
 
+#ifndef TREZOR_EMULATOR
+// Stack check guard value set in startup code.
+// This is used if stack protection is enabled.
 uint32_t __stack_chk_guard = 0;
+#endif
 
 // Calls to this function are inserted by the compiler
 // when stack protection is enabled.


### PR DESCRIPTION
This PR fixes the Trezor firmware build and runtime on macOS.

- Fixes a crash caused by the stack protector during display initialization in the firmware emulator.
- Resolves several issues with building bootloader_emu using Apple Clang.

This also solved the problem with 64-bit arm builds mentioned in #4259.