### PR TITLE
fix(core/prodtest): fix CPUID READ command

### DIFF
--- a/core/embed/prodtest/.changelog.d/4310.fixed
+++ b/core/embed/prodtest/.changelog.d/4310.fixed
@@ -1,0 +1,1 @@
+Fixed a device crash in the CPUID READ command.

--- a/core/embed/prodtest/main.c
+++ b/core/embed/prodtest/main.c
@@ -807,10 +807,14 @@ static void test_otp_write_device_variant(const char *args) {
 static void test_reboot(void) { reboot_device(); }
 
 void cpuid_read(void) {
+  mpu_mode_t mpu_mode = mpu_reconfig(MPU_MODE_OTP);
+
   uint32_t cpuid[3];
   cpuid[0] = LL_GetUID_Word0();
   cpuid[1] = LL_GetUID_Word1();
   cpuid[2] = LL_GetUID_Word2();
+
+  mpu_restore(mpu_mode);
 
   vcp_print("OK ");
   vcp_println_hex((uint8_t *)cpuid, sizeof(cpuid));


### PR DESCRIPTION
This PR fixes #4310,  the bug of CPUID READ command in protest.


