### PR TITLE
core/translations: check order.json for holes

### DIFF
--- a/core/Makefile
+++ b/core/Makefile
@@ -239,6 +239,7 @@ translations: ## update translations
 	python ./translations/cli.py gen
 
 translations_check: ## check that translations are up to date
+	python ./translations/order.py --check
 	python ./translations/cli.py gen --check
 	# spits out error if the stored merkle root is not up to date
 	python ./translations/cli.py merkle-root > /dev/null

--- a/core/translations/order.py
+++ b/core/translations/order.py
@@ -1,8 +1,10 @@
 from __future__ import annotations
 import json
 import os
-
+import sys
 from pathlib import Path
+
+import click
 
 HERE = Path(__file__).parent
 
@@ -36,5 +38,22 @@ def generate_new_order() -> None:
         print("No new items found.")
 
 
-if __name__ == "__main__":
+def check_order() -> None:
+    old_order: dict[str, str] = json.loads(output_file.read_text())
+    keys = { int(k) for k in old_order.keys() }
+    for i in range(len(old_order)):
+        if i not in keys:
+            raise ValueError(f"order.json is missing index {i}")
+
+
+@click.command()
+@click.option("--check", is_flag=True, help="Do not modify order.json, only check if it's valid.")
+def main(check: bool | None) -> None:
+    check_order()
+    if check:
+        sys.exit(0)
     generate_new_order()
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
One more check in addition to #4327 that aims to prevent the situation where the indices in `order.json` are not contiguous, which can easily happen during merge conflict resolution (see fix in: #4299).

<!--
If you are a core dev:

Don't forget to set up the fields:
- assign yourself
- set priority to same as original issue
- add PR to sprint
- if Draft -> "in progress"
- if final PR -> "needs review"

If you're an external contributor, you can ignore this text.
-->
