### PR TITLE
chore(core): Fix swipe-back action in tutorial flow menu

### DIFF
--- a/core/.changelog.d/4294.fixed
+++ b/core/.changelog.d/4294.fixed
@@ -1,0 +1,1 @@
+[T3T1] Make swipe back action in tutorial flow menu consistent with menu cancel action.

--- a/core/embed/rust/src/ui/model_mercury/flow/show_tutorial.rs
+++ b/core/embed/rust/src/ui/model_mercury/flow/show_tutorial.rs
@@ -52,7 +52,7 @@ impl FlowController for ShowTutorial {
             (Self::StepMenu, Direction::Down) => Self::StepNavigation.swipe(direction),
             (Self::StepMenu, Direction::Left) => Self::Menu.swipe(direction),
             (Self::Menu, Direction::Left) => Self::DidYouKnow.swipe(direction),
-            (Self::Menu, Direction::Right) => Self::StepBegin.swipe(direction),
+            (Self::Menu, Direction::Right) => Self::StepMenu.swipe(direction),
             (Self::DidYouKnow, Direction::Right) => Self::Menu.swipe(direction),
             (Self::StepDone, Direction::Up) => self.return_msg(FlowMsg::Confirmed),
             _ => self.do_nothing(),


### PR DESCRIPTION
This PR aligns the Swipe Right action in tutorial flow Menu Page with the Cancel Menu action (pressing the cross).

Changes include:

1. Changing Right direction swipe action in the Menu page


