### PR TITLE
fix(core): Fix success color and icon in set_brightness flow

### DIFF
--- a/core/.changelog.d/4295.fixed
+++ b/core/.changelog.d/4295.fixed
@@ -1,0 +1,1 @@
+[T3T1] Fix color and icon for 'Success' string in set_brightness flow.

--- a/core/embed/rust/src/ui/model_mercury/flow/set_brightness.rs
+++ b/core/embed/rust/src/ui/model_mercury/flow/set_brightness.rs
@@ -131,6 +131,7 @@ impl SetBrightness {
         )
         .with_footer(TR::instructions__swipe_up.into(), None)
         .with_swipe(Direction::Up, SwipeSettings::default())
+        .with_result_icon(theme::ICON_BULLET_CHECKMARK, theme::GREEN_LIGHT)
         .map(move |_msg| Some(FlowMsg::Confirmed));
 
         let res = SwipeFlow::new(&SetBrightness::Slider)?


### PR DESCRIPTION
This PR aligns the color and icon of 'Success' string in `SetBrightness` flow to match one in `GetAddress` flow.

![brightness](https://github.com/user-attachments/assets/170f5b1f-3763-45da-8757-bb3889869ec1)

Changes include:

1. Changing font color to green and adding icon to `Success` string in `SetBrightness` flow.


