### PR TITLE
ci: always post UI report comment to PR

### DIFF
--- a/.github/workflows/core.yml
+++ b/.github/workflows/core.yml
@@ -286,8 +286,6 @@ jobs:
           status: ${{ job.status }}
         if: ${{ always() && env.ACTIONS_DO_UI_TEST == 'true' }}
         continue-on-error: true
-      - uses: ./.github/actions/ui-comment
-        if: ${{ failure() && env.ACTIONS_DO_UI_TEST == 'true' }}
       - uses: ./.github/actions/upload-coverage
 
   # Click tests - UI.
@@ -705,19 +703,11 @@ jobs:
 
   core_ui_comment:
     name: Post comment with UI diff URLs
+    if: github.event_name == 'pull_request'
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
-        with:
-          fetch-depth: 0
-          ref: ${{ github.event.pull_request.head.sha }}
-      - run: |
-          git fetch origin main
-          git diff --quiet origin/main...HEAD -- tests/ui_tests/fixtures.json || echo "FIXTURES_CHANGED=$?" >> $GITHUB_OUTPUT
-        id: check-fixtures-changed
       - uses: ./.github/actions/ui-comment
-        # TODO: always run if comment already exists
-        if: ${{ steps.check-fixtures-changed.outputs.FIXTURES_CHANGED == '1' }}
 
   core_upload_emu:
     name: Upload emulator binaries

--- a/.github/workflows/legacy.yml
+++ b/.github/workflows/legacy.yml
@@ -134,8 +134,6 @@ jobs:
           status: ${{ job.status }}
         continue-on-error: true
         if: ${{ always() && matrix.coins == 'universal' }}
-      - uses: ./.github/actions/ui-comment
-        if: ${{ failure() && matrix.coins == 'universal' }}
 
   legacy_upgrade_test:
     name: Upgrade test
@@ -216,19 +214,11 @@ jobs:
 
   legacy_ui_comment:
     name: Post comment with UI diff URLs
+    if: github.event_name == 'pull_request'
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
-        with:
-          fetch-depth: 0
-          ref: ${{ github.event.pull_request.head.sha }}
-      - run: |
-          git fetch origin main
-          git diff --quiet origin/main...HEAD -- tests/ui_tests/fixtures.json || echo "FIXTURES_CHANGED=$?" >> $GITHUB_OUTPUT
-        id: check-fixtures-changed
       - uses: ./.github/actions/ui-comment
-        # TODO: always run if comment already exists
-        if: ${{ steps.check-fixtures-changed.outputs.FIXTURES_CHANGED == '1' }}
 
   legacy_upload_emu:
     name: Upload emulator binaries


### PR DESCRIPTION
Currently the comment with links to UI reports is posted when at least one of the following is satisfied:
1. there are changes in `fixtures.json` compared to `main`,
2. at least one _Device tests_ job fails.

Unfortunately there are cases when the comment would be useful but isn't posted:
* only a _Click tests_ job fails,
* in the current run everything passes, there are no changes in `fixtures.json`, comment isn't posted but in some previous run this was not the case so PR now contains outdated comment.

The first issue can be solved by extending `2.` to click tests and persistence tests, however this creates too many GitHub API requests and gets us 429 rate limited.

So until we figure out something better let's just post the comments always and hope that people who never touch the UI code don't get too annoyed ...
<!--
If you are a core dev:

Don't forget to set up the fields:
- assign yourself
- set priority to same as original issue
- add PR to sprint
- if Draft -> "in progress"
- if final PR -> "needs review"

If you're an external contributor, you can ignore this text.
-->
