### PR TITLE
ci: less verbose S3 upload

### DIFF
--- a/.github/actions/ui-report/action.yml
+++ b/.github/actions/ui-report/action.yml
@@ -38,12 +38,12 @@ runs:
       shell: sh
     - name: Upload report
       run: |
-        aws s3 sync --no-progress ${{ github.run_id }} s3://data.trezor.io/dev/firmware/ui_report/${{ github.run_id }}
+        aws s3 sync --only-show-errors ${{ github.run_id }} s3://data.trezor.io/dev/firmware/ui_report/${{ github.run_id }}
         echo "[UI test report](https://data.trezor.io/dev/firmware/ui_report/${{ github.run_id }}/${{ inputs.model }}-${{ inputs.lang }}-${{ github.job }}/index.html)" >> $GITHUB_STEP_SUMMARY
       shell: sh
     - name: Upload test screen recording
       run: |
-        aws s3 sync --no-progress ci/ui_test_records s3://data.trezor.io/dev/firmware/ui_tests
+        aws s3 sync --only-show-errors ci/ui_test_records s3://data.trezor.io/dev/firmware/ui_tests
         # TODO: generate directory listing / autoindex
       shell: sh
     - uses: actions/upload-artifact@v4

--- a/.github/workflows/core.yml
+++ b/.github/workflows/core.yml
@@ -703,7 +703,7 @@ jobs:
           fi
       - name: Upload diff from main branch
         run: |
-          aws s3 sync --no-progress master_diff s3://data.trezor.io/dev/firmware/master_diff/${{ github.run_id }}
+          aws s3 sync --only-show-errors master_diff s3://data.trezor.io/dev/firmware/master_diff/${{ github.run_id }}
         continue-on-error: true
 
   core_ui_comment:
@@ -734,7 +734,7 @@ jobs:
         continue-on-error: true
       - run: |
           rm unix/trezor-emu-core
-          aws s3 sync --no-progress unix s3://data.trezor.io/dev/firmware/emu-nightly
+          aws s3 sync --only-show-errors unix s3://data.trezor.io/dev/firmware/emu-nightly
 
   core_upload_emu_branch:
     name: Upload emulator binaries for the current branch
@@ -766,7 +766,7 @@ jobs:
       - name: Upload artifacts to branch directory
         run: |
           rm unix/trezor-emu-core
-          aws s3 sync --no-progress unix s3://data.trezor.io/dev/firmware/emu-branches/$branch_name
+          aws s3 sync --only-show-errors unix s3://data.trezor.io/dev/firmware/emu-branches/$branch_name
 
   # Connect
   # TODO: core_connect_test

--- a/.github/workflows/legacy.yml
+++ b/.github/workflows/legacy.yml
@@ -214,7 +214,7 @@ jobs:
           fi
       - name: Upload main branch diff
         run: |
-          aws s3 sync --no-progress master_diff s3://data.trezor.io/dev/firmware/master_diff/${{ github.run_id }}
+          aws s3 sync --only-show-errors master_diff s3://data.trezor.io/dev/firmware/master_diff/${{ github.run_id }}
         continue-on-error: true
 
   legacy_ui_comment:
@@ -246,4 +246,4 @@ jobs:
       - run: |
           mkdir emulators
           cp trezor-emu-* emulators
-          aws s3 sync --no-progress emulators s3://data.trezor.io/dev/firmware/emu-nightly
+          aws s3 sync --only-show-errors emulators s3://data.trezor.io/dev/firmware/emu-nightly


### PR DESCRIPTION
No significant speedup observed, the longest (T2B1) ui-report action takes 6m30s (previously around 8m?). May still be worth it for not filling the log with useless info.
<!--
If you are a core dev:

Don't forget to set up the fields:
- assign yourself
- set priority to same as original issue
- add PR to sprint
- if Draft -> "in progress"
- if final PR -> "needs review"

If you're an external contributor, you can ignore this text.
-->
