### PR TITLE
remove MPU_MODE_KERNEL_SRAM

### DIFF
--- a/core/embed/trezorhal/mpu.h
+++ b/core/embed/trezorhal/mpu.h
@@ -43,7 +43,6 @@ typedef enum {
   MPU_MODE_STORAGE,       // + both storage areas (privileged RW)
   MPU_MODE_ASSETS,        // + assets (privileged RW)
   MPU_MODE_SAES,          // + unprivileged SAES code
-  MPU_MODE_KERNEL_SRAM,   // + extra kernel SRAM (STM32F4 Only) (privileged RW)
   MPU_MODE_UNUSED_FLASH,  // + unused flash areas (privileged RW)
   MPU_MODE_APP,           // + unprivileged DMA2D (RW) & Assets (RO)
 } mpu_mode_t;

--- a/core/embed/trezorhal/stm32f4/consumption_mask.c
+++ b/core/embed/trezorhal/stm32f4/consumption_mask.c
@@ -35,13 +35,9 @@
 __attribute__((section(".buf"))) uint32_t pwm_data[SAMPLES] = {0};
 
 void consumption_mask_randomize() {
-  mpu_mode_t mpu_mode = mpu_reconfig(MPU_MODE_KERNEL_SRAM);
-
   for (int i = 0; i < SAMPLES; i++) {
     pwm_data[i] = rng_get() % TIMER_PERIOD;
   }
-
-  mpu_restore(mpu_mode);
 }
 
 void consumption_mask_init(void) {

--- a/core/embed/trezorhal/stm32f4/mpu.c
+++ b/core/embed/trezorhal/stm32f4/mpu.c
@@ -281,13 +281,6 @@ mpu_mode_t mpu_reconfig(mpu_mode_t mode) {
       SET_REGION( 6, FLASH_BASE + 0x110000, SIZE_64KB, 0x00, FLASH_DATA, PRIV_RW );
       break;
 
-    case MPU_MODE_KERNEL_SRAM:
-      DIS_REGION( 5 );
-      // Kernel data in DMA accessible SRAM (Privileged, Read-Write, Non-Executable)
-      // (overlaps with unprivileged SRAM region)
-      SET_REGION( 6, SRAM_BASE,             SIZE_1KB,  0x00, SRAM, PRIV_RW );
-      break;
-
     case MPU_MODE_UNUSED_FLASH:
       // Unused Flash Area #1 (Privileged, Read-Write, Non-Executable)
       SET_REGION( 5, FLASH_BASE + 0x00C000, SIZE_16KB, 0x00, FLASH_DATA, PRIV_RW );


### PR DESCRIPTION
MPU_MODE_KERNEL_SRAM is removed as it doesn't have any effect.

The SRAM is always accessible by kernel, and blocked in APP mode. Making it explicitly available again doesn't provide any value.

Only placed it was used was consumption mask on F4. This still works after removal on T2B1.

<!--
If you are a core dev:

Don't forget to set up the fields:
- assign yourself
- set priority to same as original issue
- add PR to sprint
- if Draft -> "in progress"
- if final PR -> "needs review"

If you're an external contributor, you can ignore this text.
-->
