### PR TITLE
fix(core): fix TREZOR_MEMPERF flag

### DIFF
--- a/core/SConscript.unix
+++ b/core/SConscript.unix
@@ -461,7 +461,7 @@ if ARGUMENTS.get('TREZOR_EMULATOR_DEBUGGABLE', '0') == '1':
 
 if ARGUMENTS.get('TREZOR_MEMPERF', '0') == '1':
     CPPDEFINES_MOD += [
-        ('MICROPY_TREZOR_MEMPERF', '\(1\)')
+        ('MICROPY_TREZOR_MEMPERF', '1')
     ]
 
 env.Replace(


### PR DESCRIPTION
With this change, the command `PYOPT=0 TREZOR_MEMPERF=1 make build_unix_frozen` successfully creates a local build with `micropython.alloc_count()` included.