### PR TITLE
feat(ci): upload emulators from all branches to data.trezor.io

### DIFF
--- a/.github/workflows/core.yml
+++ b/.github/workflows/core.yml
@@ -736,5 +736,37 @@ jobs:
           rm unix/trezor-emu-core
           aws s3 sync --no-progress unix s3://data.trezor.io/dev/firmware/emu-nightly
 
+  core_upload_emu_branch:
+    name: Upload emulator binaries for the current branch
+    # Not building it for nightly CI
+    if: github.event_name != 'schedule'
+    runs-on: ubuntu-latest
+    needs:
+      # Do not include ARM, they are only built on nightly
+      - core_emu
+    steps:
+      - uses: actions/download-artifact@v4
+        with:
+          pattern: core-emu*debuglink-noasan
+          merge-multiple: true
+      - name: Configure aws credentials
+        uses: aws-actions/configure-aws-credentials@v4
+        with:
+          role-to-assume: arn:aws:iam::538326561891:role/gh_actions_deploy_dev_firmware_data
+          aws-region: eu-west-1
+        continue-on-error: true
+      - name: Determine branch name
+        run: |
+          if [ "${{ github.event_name }}" == "pull_request" ]; then
+            branch_name=${{ github.head_ref }}
+          else
+            branch_name=${{ github.ref_name }}
+          fi
+          echo "branch_name=$branch_name" >> $GITHUB_ENV
+      - name: Upload artifacts to branch directory
+        run: |
+          rm unix/trezor-emu-core
+          aws s3 sync --no-progress unix s3://data.trezor.io/dev/firmware/emu-branches/$branch_name
+
   # Connect
   # TODO: core_connect_test


### PR DESCRIPTION
For `Connect` end-to-end tests, we have this requirement:
- being able to run tests with an emulator from a specified firmware feature/branch, that is still under development (not merged into `main`)

Currently, emulators are built for all PRs, but not uploaded to data.trezor.io ... the artifacts can be found manually in GHActions logs, but it is not a good and reliable way of finding the URL, e.g. https://github.com/trezor/trezor-firmware/actions/runs/11856555307/artifacts/2193027474

With this change, it will be possible to dynamically get the latest emulators for all the models from a static URL - e.g. `data.trezor.io/dev/firmware/emu-branches/trezor_host_protocol/trezor-emu-core-T2B1-universal`

Notes:
- it will need to be tested how the branches with `/` in the name behave (if they create a nested dir structure) ... maybe we will need to replace all `/` in the branch name with `_`