### PR TITLE
fix(core): fix invalid symbol for deflated bootloader

### DIFF
--- a/core/SConscript.kernel
+++ b/core/SConscript.kernel
@@ -374,7 +374,8 @@ tools.embed_compressed_binary(
         'bootloader',
         'embed/projects/bootloaders/bootloader.o',
         f'embed/models/{MODEL_IDENTIFIER}/bootloaders/bootloader_{BOOTLOADER_SUFFIX}.bin',
-        'kernel'
+        'kernel',
+        'bootloader',
         )
 
 linkerscript_gen = env.Command(

--- a/core/embed/rust/src/trezorhal/display.rs
+++ b/core/embed/rust/src/trezorhal/display.rs
@@ -40,7 +40,9 @@ pub fn text_baseline(font: i32) -> i16 {
 }
 
 pub fn sync() {
-    #[cfg(not(feature = "framebuffer"))]
+    // NOTE: The sync operation is not called for tests because the linker
+    // would otherwise report missing symbols if the tests are built with ASAN.
+    #[cfg(not(any(feature = "framebuffer", feature = "test")))]
     unsafe {
         ffi::display_wait_for_sync();
     }

--- a/core/embed/util/bl_check/bl_check.c
+++ b/core/embed/util/bl_check/bl_check.c
@@ -29,8 +29,8 @@
 #include "uzlib.h"
 
 // symbols from bootloader.bin => bootloader.o
-extern const void _binary_embed_bootloaders_bootloader_bin_deflated_start;
-extern const void _binary_embed_bootloaders_bootloader_bin_deflated_size;
+extern const void _deflated_bootloader_start;
+extern const void _deflated_bootloader_size;
 
 #define CONCAT_NAME_HELPER(prefix, name, suffix) prefix##name##suffix
 #define CONCAT_NAME(name, var) CONCAT_NAME_HELPER(BOOTLOADER_, name, var)
@@ -99,11 +99,8 @@ void check_and_replace_bootloader(void) {
   }
 
   // replace bootloader with the latest one
-  const uint32_t *data =
-      (const uint32_t
-           *)&_binary_embed_bootloaders_bootloader_bin_deflated_start;
-  const uint32_t len =
-      (const uint32_t)&_binary_embed_bootloaders_bootloader_bin_deflated_size;
+  const uint32_t *data = (const uint32_t *)&_deflated_bootloader_start;
+  const uint32_t len = (const uint32_t)&_deflated_bootloader_size;
 
   struct uzlib_uncomp decomp = {0};
   uint8_t decomp_window[UZLIB_WINDOW_SIZE] = {0};

--- a/core/site_scons/tools.py
+++ b/core/site_scons/tools.py
@@ -85,22 +85,17 @@ def get_bindgen_defines(
     return ",".join(rest_defs)
 
 
-def embed_compressed_binary(obj_program, env, section, target_, file, build):
+def embed_compressed_binary(obj_program, env, section, target_, file, build, symbol):
     _in = f"embedded_{section}.bin.deflated"
 
-    def redefine_sym(name):
+    def redefine_sym(suffix):
         src = (
             f"_binary_build_{build}_"
             + _in.replace("/", "_").replace(".", "_")
             + "_"
-            + name
+            + suffix
         )
-        dest = (
-            "_binary_"
-            + target_.replace("/", "_").replace(".o", "_bin_deflated")
-            + "_"
-            + name
-        )
+        dest = f"_deflated_{symbol}_{suffix}"
         return f" --redefine-sym {src}={dest}"
 
     def compress_action(target, source, env):


### PR DESCRIPTION
This PR fixes an invalid symbol for the deflated bootloader used in the kernel and the problem with rust unit test build.

1. The structure of the symbol for deflated has been changed, so it no longer contains the path of the original file.
2. Fixed the problem with linking unused symbol `display_wait_for_sync`.