### PR TITLE
fix cmakelists generation

### DIFF
--- a/core/site_scons/tools.py
+++ b/core/site_scons/tools.py
@@ -52,7 +52,8 @@ def get_defs_for_cmake(defs: list[str | tuple[str, str]]) -> list[str]:
     result: list[str] = []
     for d in defs:
         if type(d) is tuple:
-            result.append(d[0] + "=" + d[1])
+            val = d[1].replace('"', '\\"').replace("(", "\\(").replace(")", "\\)")
+            result.append(f'{d[0]}="{val}"')
         else:
             result.append(d)
     return result


### PR DESCRIPTION
Latest changes from https://github.com/trezor/trezor-firmware/pull/4234 broke compilation with `CMAKELISTS=1`, so this adds some needed escaping.


<!--
If you are a core dev:

Don't forget to set up the fields:
- assign yourself
- set priority to same as original issue
- add PR to sprint
- if Draft -> "in progress"
- if final PR -> "needs review"

If you're an external contributor, you can ignore this text.
-->
