### PR TITLE
fix enabling/disabling haptics before the driver is initialized

### DIFF
--- a/core/embed/io/haptic/drv2625/drv2625.c
+++ b/core/embed/io/haptic/drv2625/drv2625.c
@@ -217,6 +217,10 @@ void haptic_deinit(void) {
 void haptic_set_enabled(bool enabled) {
   haptic_driver_t *driver = &g_haptic_driver;
 
+  if (!driver->initialized) {
+    return;
+  }
+
   driver->enabled = enabled;
 }
 


### PR DESCRIPTION
added the missing check.

<!--
If you are a core dev:

Don't forget to set up the fields:
- assign yourself
- set priority to same as original issue
- add PR to sprint
- if Draft -> "in progress"
- if final PR -> "needs review"

If you're an external contributor, you can ignore this text.
-->
