### PR TITLE
Fix error output in emulator

### DIFF
--- a/core/Makefile
+++ b/core/Makefile
@@ -306,7 +306,7 @@ build_firmware: templates build_cross build_kernel ## build firmware with frozen
 	$(SCONS) $(FIRMWARE_BUILD_DIR)/firmware.bin
 
 build_unix: templates ## build unix port
-	$(SCONS) $(UNIX_BUILD_DIR)/trezor-emu-core $(UNIX_PORT_OPTS)
+	$(SCONS) PYOPT=0 $(UNIX_BUILD_DIR)/trezor-emu-core $(UNIX_PORT_OPTS)
 
 build_unix_frozen: templates build_cross ## build unix port with frozen modules
 	$(SCONS) $(UNIX_BUILD_DIR)/trezor-emu-core $(UNIX_PORT_OPTS) TREZOR_EMULATOR_FROZEN=1

--- a/core/embed/sys/task/unix/system.c
+++ b/core/embed/sys/task/unix/system.c
@@ -52,7 +52,7 @@ void system_exit(int exitcode) {
 void system_exit_error_ex(const char* title, size_t title_len,
                           const char* message, size_t message_len,
                           const char* footer, size_t footer_len) {
-  fprintf(stderr, "ERROR: %s\n", message);
+  fprintf(stderr, "ERROR: %.*s\n", (int)message_len, message);
   fflush(stderr);
 
   if (g_error_handler != NULL) {


### PR DESCRIPTION
also ~set default~ force-set PYOPT=0 for `make build_unix` which is the previous behavior before #4234 removed it