### PR TITLE
fix(core): use the filtered event for subsequent processing

### DIFF
--- a/core/embed/rust/src/ui/flow/swipe.rs
+++ b/core/embed/rust/src/ui/flow/swipe.rs
@@ -216,7 +216,7 @@ impl SwipeFlow {
 
         let mut attach = false;
 
-        let e = if self.allow_swipe {
+        let event = if self.allow_swipe {
             let page = self.current_page();
             let config = page
                 .get_swipe_config()
@@ -251,12 +251,12 @@ impl SwipeFlow {
 
         match decision {
             Decision::Nothing => {
-                decision = self.handle_event_child(ctx, e);
+                decision = self.handle_event_child(ctx, event);
 
                 // when doing internal transition, pass attach event to the child after sending
                 // swipe end.
                 if attach {
-                    if let Event::Swipe(SwipeEvent::End(dir)) = e {
+                    if let Event::Swipe(SwipeEvent::End(dir)) = event {
                         self.current_page_mut()
                             .event(ctx, Event::Attach(AttachType::Swipe(dir)));
                     }


### PR DESCRIPTION
That way we won't pass raw touch events to underlying component if that touch is already part of a swipe.

Fixes a crash when you would swipe right over a Cancel button in menu.

<!--
If you are a core dev:

Don't forget to set up the fields:
- assign yourself
- set priority to same as original issue
- add PR to sprint
- if Draft -> "in progress"
- if final PR -> "needs review"

If you're an external contributor, you can ignore this text.
-->
