### PR TITLE
chore(core): show the last passphrase character for a while

### DIFF
--- a/core/.changelog.d/3959.added
+++ b/core/.changelog.d/3959.added
@@ -1,0 +1,1 @@
+Show last typed passphrase character for short period of time

--- a/core/embed/rust/src/ui/model_mercury/component/keyboard/common.rs
+++ b/core/embed/rust/src/ui/model_mercury/component/keyboard/common.rs
@@ -168,3 +168,13 @@ pub fn render_pill_shape<'s>(
         .with_thickness(2)
         .render(target);
 }
+
+/// `DisplayStyle` isused to determine whether the text is fully hidden, fully
+/// shown, or partially visible.
+#[derive(PartialEq, Debug, Copy, Clone)]
+#[cfg_attr(feature = "ui_debug", derive(ufmt::derive::uDebug))]
+pub(crate) enum DisplayStyle {
+    Hidden,
+    Shown,
+    LastOnly,
+}

--- a/core/embed/rust/src/ui/model_mercury/component/keyboard/passphrase.rs
+++ b/core/embed/rust/src/ui/model_mercury/component/keyboard/passphrase.rs
@@ -369,12 +369,14 @@ impl Component for PassphraseKeyboard {
                 self.input.multi_tap.clear_pending_state(ctx);
                 self.input.textbox.delete_last(ctx);
                 self.after_edit(ctx);
+                self.input.display_style = DisplayStyle::Hidden;
                 return None;
             }
             Some(ButtonMsg::LongPressed) => {
                 self.input.multi_tap.clear_pending_state(ctx);
                 self.input.textbox.clear(ctx);
                 self.after_edit(ctx);
+                self.input.display_style = DisplayStyle::Hidden;
                 return None;
             }
             _ => {}

--- a/core/embed/rust/src/ui/model_mercury/component/keyboard/passphrase.rs
+++ b/core/embed/rust/src/ui/model_mercury/component/keyboard/passphrase.rs
@@ -295,7 +295,6 @@ impl Component for PassphraseKeyboard {
             .1;
 
         let top_area = top_area.inset(INPUT_INSETS);
-        // let input_area = input_area.inset(INPUT_INSETS);
         let confirm_btn_area = confirm_btn_area.inset(CONFIRM_BTN_INSETS);
         let confirm_empty_btn_area = confirm_empty_btn_area.inset(CONFIRM_EMPTY_BTN_INSETS);
 

--- a/core/embed/rust/src/ui/model_mercury/component/keyboard/passphrase.rs
+++ b/core/embed/rust/src/ui/model_mercury/component/keyboard/passphrase.rs
@@ -9,7 +9,7 @@ use crate::{
         },
         display,
         event::TouchEvent,
-        geometry::{Alignment, Direction, Grid, Insets, Offset, Rect},
+        geometry::{Alignment, Alignment2D, Direction, Grid, Insets, Offset, Rect},
         model_mercury::{
             component::{
                 button::{Button, ButtonContent, ButtonMsg},
@@ -449,6 +449,7 @@ struct Input {
 
 impl Input {
     const TWITCH: i16 = 4;
+    const X_STEP: i16 = 13;
 
     fn new() -> Self {
         Self {
@@ -460,28 +461,125 @@ impl Input {
         }
     }
 
-    fn apply_display_style(&self, passphrase: &ShortString) -> ShortString {
-        if passphrase.len() == 0 {
-            ShortString::new()
-        } else {
-            match self.display_style {
-                DisplayStyle::Dots => {
-                    let mut dots = ShortString::new();
-                    for _ in 0..(passphrase.len()) {
-                        dots.push('*').unwrap();
-                    }
-                    dots
+    fn render_chars<'s>(&self, area: Rect, target: &mut impl Renderer<'s>) {
+        let style = theme::label_keyboard_mono();
+        let mut text_baseline = area.top_left() + Offset::y(style.text_font.text_height());
+        let chars = self.textbox.content().len();
+
+        if chars > 0 {
+            // Find out how much text can fit into the textbox.
+            // Accounting for the pending marker, which draws itself one extra pixel
+            let available_area_width = area.width() - 1;
+            let truncated = long_line_content_with_ellipsis(
+                self.textbox.content(),
+                "",
+                style.text_font,
+                available_area_width,
+            );
+
+            // Jiggle hidden passphrase when overflowed.
+            if chars > truncated.len()
+                && chars % 2 == 0
+                && (self.display_style == DisplayStyle::Dots
+                    || self.display_style == DisplayStyle::LastChar)
+            {
+                text_baseline.x += Self::TWITCH;
+            }
+
+            // Paint the visible passphrase.
+            shape::Text::new(text_baseline, &truncated)
+                .with_font(style.text_font)
+                .with_fg(style.text_color)
+                .render(target);
+
+            // Paint the pending marker.
+            if self.multi_tap.pending_key().is_some() {
+                render_pending_marker(
+                    target,
+                    text_baseline,
+                    &truncated,
+                    style.text_font,
+                    style.text_color,
+                );
+            }
+        }
+    }
+
+    fn render_dots<'s>(&self, last_char: bool, area: Rect, target: &mut impl Renderer<'s>) {
+        let style = theme::label_keyboard_mono();
+        let bullet = theme::ICON_PIN_BULLET;
+        let mut cursor = area.left_center();
+        let all_chars = self.textbox.content().len();
+
+        if all_chars > 0 {
+            // Find out how much text can fit into the textbox.
+            // Accounting for the pending marker, which draws itself one extra pixel
+            let truncated = long_line_content_with_ellipsis(
+                self.textbox.content(),
+                "",
+                style.text_font,
+                area.width() - 1,
+            );
+            let visible_chars = truncated.len();
+
+            // Jiggle when overflowed.
+            if all_chars > visible_chars
+                && all_chars % 2 == 0
+                && (self.display_style == DisplayStyle::Dots
+                    || self.display_style == DisplayStyle::LastChar)
+            {
+                cursor.x += Self::TWITCH;
+            }
+
+            let mut char_idx = 0;
+            // Small leftmost dot.
+            if all_chars > visible_chars + 1 {
+                shape::ToifImage::new(cursor, theme::DOT_SMALL.toif)
+                    .with_align(Alignment2D::TOP_LEFT)
+                    .with_fg(theme::GREY)
+                    .render(target);
+                cursor.x += Self::X_STEP;
+                char_idx += 1;
+            }
+            // Greyed out dot.
+            if all_chars > visible_chars {
+                shape::ToifImage::new(cursor, theme::DOT_SMALL.toif)
+                    .with_align(Alignment2D::TOP_LEFT)
+                    .with_fg(style.text_color)
+                    .render(target);
+                cursor.x += Self::X_STEP;
+                char_idx += 1;
+            }
+            // Classical dot(s)
+            for _ in char_idx..(visible_chars - 1) {
+                shape::ToifImage::new(cursor, bullet)
+                    .with_align(Alignment2D::TOP_LEFT)
+                    .with_fg(style.text_color)
+                    .render(target);
+                cursor.x += Self::X_STEP;
+            }
+
+            if last_char {
+                // Adapt y position for the character
+                cursor.y = area.top_left().y + style.text_font.text_height();
+                // This should not fail because all_chars > 0
+                let last = &self.textbox.content()[(all_chars - 1)..all_chars];
+                // Paint the last character
+                shape::Text::new(cursor, last)
+                    .with_align(Alignment::Start)
+                    .with_font(style.text_font)
+                    .with_fg(style.text_color)
+                    .render(target);
+                // Paint the pending marker.
+                if self.multi_tap.pending_key().is_some() {
+                    render_pending_marker(target, cursor, last, style.text_font, style.text_color);
                 }
-                DisplayStyle::Chars => passphrase.clone(),
-                DisplayStyle::LastChar => {
-                    let mut dots = ShortString::new();
-                    for _ in 0..(passphrase.len() - 1) {
-                        dots.push('*').unwrap();
-                    }
-                    // This should not fail because the passphrase is not empty.
-                    dots.push(passphrase.chars().last().unwrap()).unwrap();
-                    dots
-                }
+            } else {
+                // Last classical dot
+                shape::ToifImage::new(cursor, bullet)
+                    .with_align(Alignment2D::TOP_LEFT)
+                    .with_fg(style.text_color)
+                    .render(target);
             }
         }
     }
@@ -517,48 +615,18 @@ impl Component for Input {
     }
 
     fn render<'s>(&'s self, target: &mut impl Renderer<'s>) {
-        let style = theme::label_keyboard_mono();
         let text_area = self.area.inset(INPUT_INSETS);
 
-        let mut text_baseline = text_area.top_left() + Offset::y(style.text_font.text_height())
-            - Offset::y(style.text_font.text_baseline());
-
-        let text = self.textbox.content();
-
+        // Paint the background
         shape::Bar::new(text_area).with_bg(theme::BG).render(target);
 
-        // Find out how much text can fit into the textbox.
-        // Accounting for the pending marker, which draws itself one pixel longer than
-        // the last character
-        let available_area_width = text_area.width() - 1;
-        let truncated =
-            long_line_content_with_ellipsis(text, "", style.text_font, available_area_width);
-
-        // Jiggle hidden passphrase when overflowed.
-        if text.len() > truncated.len()
-            && text.len() % 2 == 0
-            && (self.display_style == DisplayStyle::Dots
-                || self.display_style == DisplayStyle::LastChar)
-        {
-            text_baseline.x += Self::TWITCH;
-        }
-
-        let text_to_display = self.apply_display_style(&truncated);
-
-        shape::Text::new(text_baseline, &text_to_display)
-            .with_font(style.text_font)
-            .with_fg(style.text_color)
-            .render(target);
-
-        // Paint the pending marker.
-        if self.multi_tap.pending_key().is_some() {
-            render_pending_marker(
-                target,
-                text_baseline,
-                &text_to_display,
-                style.text_font,
-                style.text_color,
-            );
+        // Paint the passphrase
+        if !self.textbox.content().is_empty() {
+            match self.display_style {
+                DisplayStyle::Chars => self.render_chars(text_area, target),
+                DisplayStyle::Dots => self.render_dots(false, text_area, target),
+                DisplayStyle::LastChar => self.render_dots(true, text_area, target),
+            }
         }
     }
 }

--- a/core/embed/rust/src/ui/model_mercury/component/keyboard/pin.rs
+++ b/core/embed/rust/src/ui/model_mercury/component/keyboard/pin.rs
@@ -19,6 +19,7 @@ use crate::{
                     Button, ButtonContent,
                     ButtonMsg::{self, Clicked},
                 },
+                keyboard::common::DisplayStyle,
                 theme,
             },
             cshape,
@@ -431,7 +432,7 @@ impl Component for PinKeyboard<'_> {
             }
             // Timeout for showing the last digit.
             Event::Timer(_) if self.timeout_timer.expire(event) => {
-                self.textbox.display_style = DisplayStyle::Dots;
+                self.textbox.display_style = DisplayStyle::Hidden;
                 self.textbox.request_complete_repaint(ctx);
                 ctx.request_paint();
             }
@@ -482,7 +483,7 @@ impl Component for PinKeyboard<'_> {
                     self.pin_modified(ctx);
                     self.timeout_timer
                         .start(ctx, Duration::from_secs(LAST_DIGIT_TIMEOUT_S));
-                    self.textbox.display_style = DisplayStyle::LastDigit;
+                    self.textbox.display_style = DisplayStyle::LastOnly;
                     self.textbox.request_complete_repaint(ctx);
                     ctx.request_paint();
                     return None;
@@ -542,14 +543,6 @@ struct PinDots {
     display_style: DisplayStyle,
 }
 
-#[derive(PartialEq, Debug, Copy, Clone)]
-#[cfg_attr(feature = "ui_debug", derive(ufmt::derive::uDebug))]
-enum DisplayStyle {
-    Dots,
-    Digits,
-    LastDigit,
-}
-
 impl PinDots {
     const DOT: i16 = 6;
     const PADDING: i16 = 7;
@@ -561,7 +554,7 @@ impl PinDots {
             pad: Pad::with_background(style.background_color),
             style,
             digits: ShortString::new(),
-            display_style: DisplayStyle::Dots,
+            display_style: DisplayStyle::Hidden,
         }
     }
 
@@ -695,14 +688,15 @@ impl Component for PinDots {
         match event {
             Event::Touch(TouchEvent::TouchStart(pos)) => {
                 if self.area.contains(pos) {
-                    self.display_style = DisplayStyle::Digits;
+                    self.display_style = DisplayStyle::Shown;
                     self.pad.clear();
                     ctx.request_paint();
                 };
                 None
             }
             Event::Touch(TouchEvent::TouchEnd(_)) => {
-                if mem::replace(&mut self.display_style, DisplayStyle::Dots) == DisplayStyle::Digits
+                if mem::replace(&mut self.display_style, DisplayStyle::Hidden)
+                    == DisplayStyle::Shown
                 {
                     self.pad.clear();
                     ctx.request_paint();
@@ -717,9 +711,9 @@ impl Component for PinDots {
         let dot_area = self.area.inset(HEADER_PADDING);
         self.pad.render(target);
         match self.display_style {
-            DisplayStyle::Digits => self.render_digits(dot_area, target),
-            DisplayStyle::Dots => self.render_dots(false, dot_area, target),
-            DisplayStyle::LastDigit => self.render_dots(true, dot_area, target),
+            DisplayStyle::Shown => self.render_digits(dot_area, target),
+            DisplayStyle::Hidden => self.render_dots(false, dot_area, target),
+            DisplayStyle::LastOnly => self.render_dots(true, dot_area, target),
         }
     }
 }

--- a/core/embed/rust/src/ui/model_mercury/theme/mod.rs
+++ b/core/embed/rust/src/ui/model_mercury/theme/mod.rs
@@ -136,6 +136,10 @@ pub const fn label_keyboard() -> TextStyle {
     TextStyle::new(Font::DEMIBOLD, GREY_EXTRA_LIGHT, BG, GREY_LIGHT, GREY_LIGHT)
 }
 
+pub const fn label_keyboard_mono() -> TextStyle {
+    TextStyle::new(Font::MONO, GREY_EXTRA_LIGHT, BG, GREY_LIGHT, GREY_LIGHT)
+}
+
 pub const fn label_keyboard_prompt() -> TextStyle {
     TextStyle::new(Font::DEMIBOLD, GREY_LIGHT, BG, GREY_LIGHT, GREY_LIGHT)
 }

--- a/core/embed/rust/src/ui/model_tr/component/input_methods/passphrase.rs
+++ b/core/embed/rust/src/ui/model_tr/component/input_methods/passphrase.rs
@@ -1,9 +1,12 @@
 use crate::{
     strutil::{ShortString, TString},
+    time::Duration,
     translations::TR,
     trezorhal::random,
     ui::{
-        component::{text::common::TextBox, Child, Component, ComponentExt, Event, EventCtx},
+        component::{
+            text::common::TextBox, Child, Component, ComponentExt, Event, EventCtx, Timer,
+        },
         display::Icon,
         geometry::Rect,
         shape::Renderer,
@@ -42,6 +45,8 @@ const UPPERCASE_INDEX: usize = 4;
 const DIGITS_INDEX: usize = 5;
 const SPECIAL_INDEX: usize = 6;
 const SPACE_INDEX: usize = 7;
+
+const LAST_DIGIT_TIMEOUT_S: u32 = 1;
 
 #[derive(Clone)]
 struct MenuItem {
@@ -273,6 +278,7 @@ pub struct PassphraseEntry {
     show_last_digit: bool,
     textbox: TextBox,
     current_category: ChoiceCategory,
+    last_char_timer: Timer,
 }
 
 impl PassphraseEntry {
@@ -286,6 +292,7 @@ impl PassphraseEntry {
             show_last_digit: false,
             textbox: TextBox::empty(MAX_PASSPHRASE_LENGTH),
             current_category: ChoiceCategory::Menu,
+            last_char_timer: Timer::new(),
         }
     }
 
@@ -383,17 +390,22 @@ impl Component for PassphraseEntry {
     }
 
     fn event(&mut self, ctx: &mut EventCtx, event: Event) -> Option<Self::Msg> {
-        // Any non-timer event when showing real passphrase should hide it
-        // Same with showing last digit
-        if !matches!(event, Event::Timer(_)) {
-            if self.show_plain_passphrase {
+        match event {
+            // Timeout for showing the last digit.
+            Event::Timer(_) if self.last_char_timer.expire(event) => {
+                if self.show_last_digit {
+                    self.show_last_digit = false;
+                    self.update_passphrase_dots(ctx);
+                }
+            }
+            // Other timers are ignored.
+            Event::Timer(_) => {}
+            // Any non-timer event when showing plain passphrase should hide it
+            _ if self.show_plain_passphrase => {
                 self.show_plain_passphrase = false;
                 self.update_passphrase_dots(ctx);
             }
-            if self.show_last_digit {
-                self.show_last_digit = false;
-                self.update_passphrase_dots(ctx);
-            }
+            _ => {}
         }
 
         if let Some((action, long_press)) = self.choice_page.event(ctx, event) {
@@ -437,6 +449,8 @@ impl Component for PassphraseEntry {
                 PassphraseAction::Character(ch) if !self.is_full() => {
                     self.append_char(ctx, ch);
                     self.show_last_digit = true;
+                    self.last_char_timer
+                        .start(ctx, Duration::from_secs(LAST_DIGIT_TIMEOUT_S));
                     self.update_passphrase_dots(ctx);
                     self.randomize_category_position(ctx);
                     ctx.request_paint();

--- a/core/embed/rust/src/ui/model_tr/component/input_methods/passphrase.rs
+++ b/core/embed/rust/src/ui/model_tr/component/input_methods/passphrase.rs
@@ -287,7 +287,9 @@ impl PassphraseEntry {
             choice_page: ChoicePage::new(ChoiceFactoryPassphrase::new(ChoiceCategory::Menu, true))
                 .with_carousel(true)
                 .with_initial_page_counter(random_menu_position()),
-            passphrase_dots: Child::new(ChangingTextLine::center_mono("", MAX_PASSPHRASE_LENGTH)),
+            passphrase_dots: Child::new(
+                ChangingTextLine::center_mono("", MAX_PASSPHRASE_LENGTH).without_ellipsis(),
+            ),
             show_plain_passphrase: false,
             show_last_digit: false,
             textbox: TextBox::empty(MAX_PASSPHRASE_LENGTH),

--- a/core/embed/rust/src/ui/model_tt/component/keyboard/common.rs
+++ b/core/embed/rust/src/ui/model_tt/component/keyboard/common.rs
@@ -137,3 +137,13 @@ pub fn render_pending_marker<'s>(
         shape::Bar::new(marker_rect).with_bg(color).render(target);
     }
 }
+
+/// `DisplayStyle` isused to determine whether the text is fully hidden, fully
+/// shown, or partially visible.
+#[derive(PartialEq, Debug, Copy, Clone)]
+#[cfg_attr(feature = "ui_debug", derive(ufmt::derive::uDebug))]
+pub(crate) enum DisplayStyle {
+    Hidden,
+    Shown,
+    LastOnly,
+}

--- a/core/embed/rust/src/ui/model_tt/component/keyboard/passphrase.rs
+++ b/core/embed/rust/src/ui/model_tt/component/keyboard/passphrase.rs
@@ -273,6 +273,8 @@ impl Component for PassphraseKeyboard {
                         i.textbox.delete_last(ctx);
                     });
                     self.after_edit(ctx);
+                    self.input
+                        .mutate(ctx, |_ctx, t| t.set_display_style(DisplayStyle::Hidden));
                     None
                 };
             }
@@ -282,6 +284,8 @@ impl Component for PassphraseKeyboard {
                     i.textbox.clear(ctx);
                 });
                 self.after_edit(ctx);
+                self.input
+                    .mutate(ctx, |_ctx, t| t.set_display_style(DisplayStyle::Hidden));
                 return None;
             }
             _ => {}

--- a/core/embed/rust/src/ui/model_tt/theme/mod.rs
+++ b/core/embed/rust/src/ui/model_tt/theme/mod.rs
@@ -120,6 +120,10 @@ pub const fn label_keyboard() -> TextStyle {
     TextStyle::new(Font::DEMIBOLD, OFF_WHITE, BG, GREY_LIGHT, GREY_LIGHT)
 }
 
+pub const fn label_keyboard_mono() -> TextStyle {
+    TextStyle::new(Font::MONO, OFF_WHITE, BG, GREY_LIGHT, GREY_LIGHT)
+}
+
 pub const fn label_keyboard_prompt() -> TextStyle {
     TextStyle::new(Font::DEMIBOLD, GREY_LIGHT, BG, GREY_LIGHT, GREY_LIGHT)
 }

--- a/tests/click_tests/common.py
+++ b/tests/click_tests/common.py
@@ -27,6 +27,8 @@ class CommonPass:
 
     EMPTY_ADDRESS = "mvbu1Gdy8SUjTenqerxUaZyYjmveZvt33q"
 
+    MULTI_CATEGORY = "as12 *&_N"
+
 
 class PassphraseCategory(Enum):
     MENU = "MENU"

--- a/tests/click_tests/test_passphrase_mercury.py
+++ b/tests/click_tests/test_passphrase_mercury.py
@@ -343,10 +343,10 @@ def test_cycle_through_last_character(
 def test_last_char_timeout(device_handler: "BackgroundDeviceHandler"):
     with prepare_passphrase_dialogue(device_handler) as debug:
         for character in CommonPass.MULTI_CATEGORY:
-            # insert a digit
+            # insert a character
             input_passphrase(debug, character)
-            # wait until the last digit is hidden
+            # wait until the last character is hidden
             time.sleep(DELAY_S)
-            # show the entire PIN
+            # show the entire passphrase
             show_passphrase(debug)
         enter_passphrase(debug)

--- a/tests/click_tests/test_passphrase_mercury.py
+++ b/tests/click_tests/test_passphrase_mercury.py
@@ -70,6 +70,9 @@ DA_51_ADDRESS = DA_50_ADDRESS
 assert len(DA_51) == 51
 assert DA_51_ADDRESS == DA_50_ADDRESS
 
+# pending + entered character is shown for 1 + 1 seconds, so the delay must be grater
+DELAY_S = 2.1
+
 
 def get_passphrase_choices(char: str) -> tuple[str, ...]:
     if char in " *#":
@@ -174,6 +177,11 @@ def enter_passphrase(debug: "DebugLink") -> None:
     debug.click(coords)
     if is_empty:
         debug.click(buttons.MERCURY_YES)
+
+
+def show_passphrase(debug: "DebugLink") -> None:
+    """See the passphrase"""
+    debug.click(buttons.TOP_ROW)
 
 
 def delete_char(debug: "DebugLink") -> None:
@@ -328,4 +336,17 @@ def test_cycle_through_last_character(
     with prepare_passphrase_dialogue(device_handler) as debug:
         passphrase = DA_49 + "i"  # for i we need to cycle through "ghi" three times
         input_passphrase(debug, passphrase)
+        enter_passphrase(debug)
+
+
+@pytest.mark.setup_client(passphrase=True)
+def test_last_char_timeout(device_handler: "BackgroundDeviceHandler"):
+    with prepare_passphrase_dialogue(device_handler) as debug:
+        for character in CommonPass.MULTI_CATEGORY:
+            # insert a digit
+            input_passphrase(debug, character)
+            # wait until the last digit is hidden
+            time.sleep(DELAY_S)
+            # show the entire PIN
+            show_passphrase(debug)
         enter_passphrase(debug)

--- a/tests/click_tests/test_passphrase_mercury.py
+++ b/tests/click_tests/test_passphrase_mercury.py
@@ -347,6 +347,6 @@ def test_last_char_timeout(device_handler: "BackgroundDeviceHandler"):
             input_passphrase(debug, character)
             # wait until the last character is hidden
             time.sleep(DELAY_S)
-            # show the entire passphrase
-            show_passphrase(debug)
+        # show the entire passphrase
+        show_passphrase(debug)
         enter_passphrase(debug)

--- a/tests/click_tests/test_passphrase_tr.py
+++ b/tests/click_tests/test_passphrase_tr.py
@@ -14,6 +14,7 @@
 # You should have received a copy of the License along with this library.
 # If not, see <https://www.gnu.org/licenses/lgpl-3.0.html>.
 
+import time
 from contextlib import contextmanager
 from typing import TYPE_CHECKING, Generator, Optional
 
@@ -53,6 +54,9 @@ AAA_51 = AAA_50 + "a"
 AAA_51_ADDRESS = "miPeCUxf1Ufh5DtV3AuBopNM8YEDvnQZMh"
 assert len(AAA_51) == 51
 assert AAA_51_ADDRESS == AAA_50_ADDRESS
+
+# entered character is shown for 1 second, so the delay must be grater
+DELAY_S = 1.1
 
 
 BACK = "inputs__back"
@@ -263,4 +267,17 @@ def test_passphrase_loop_all_characters(device_handler: "BackgroundDeviceHandler
             # use_carousel=False because we want to reach BACK at the end of the list
             go_to_category(debug, PassphraseCategory.MENU, use_carousel=False)
 
+        enter_passphrase(debug)
+
+
+@pytest.mark.setup_client(passphrase=True)
+def test_last_char_timeout(device_handler: "BackgroundDeviceHandler"):
+    with prepare_passphrase_dialogue(device_handler) as debug:
+        for character in CommonPass.MULTI_CATEGORY:
+            # insert a digit
+            input_passphrase(debug, character)
+            # wait until the last digit is hidden
+            time.sleep(DELAY_S)
+            # show the entire PIN
+            show_passphrase(debug)
         enter_passphrase(debug)

--- a/tests/click_tests/test_passphrase_tr.py
+++ b/tests/click_tests/test_passphrase_tr.py
@@ -278,6 +278,6 @@ def test_last_char_timeout(device_handler: "BackgroundDeviceHandler"):
             input_passphrase(debug, character)
             # wait until the last character is hidden
             time.sleep(DELAY_S)
-            # show the entire passphrase
-            show_passphrase(debug)
+        # show the entire passphrase
+        show_passphrase(debug)
         enter_passphrase(debug)

--- a/tests/click_tests/test_passphrase_tr.py
+++ b/tests/click_tests/test_passphrase_tr.py
@@ -274,10 +274,10 @@ def test_passphrase_loop_all_characters(device_handler: "BackgroundDeviceHandler
 def test_last_char_timeout(device_handler: "BackgroundDeviceHandler"):
     with prepare_passphrase_dialogue(device_handler) as debug:
         for character in CommonPass.MULTI_CATEGORY:
-            # insert a digit
+            # insert a character
             input_passphrase(debug, character)
-            # wait until the last digit is hidden
+            # wait until the last character is hidden
             time.sleep(DELAY_S)
-            # show the entire PIN
+            # show the entire passphrase
             show_passphrase(debug)
         enter_passphrase(debug)

--- a/tests/click_tests/test_passphrase_tt.py
+++ b/tests/click_tests/test_passphrase_tt.py
@@ -314,6 +314,6 @@ def test_last_char_timeout(device_handler: "BackgroundDeviceHandler"):
             input_passphrase(debug, character)
             # wait until the last character is hidden
             time.sleep(DELAY_S)
-            # show the entire passphrase
-            show_passphrase(debug)
+        # show the entire passphrase
+        show_passphrase(debug)
         enter_passphrase(debug)

--- a/tests/click_tests/test_passphrase_tt.py
+++ b/tests/click_tests/test_passphrase_tt.py
@@ -63,6 +63,9 @@ DA_51_ADDRESS = DA_50_ADDRESS
 assert len(DA_51) == 51
 assert DA_51_ADDRESS == DA_50_ADDRESS
 
+# pending + entered character is shown for 1 + 1 seconds, so the delay must be grater
+DELAY_S = 2.1
+
 
 @contextmanager
 def prepare_passphrase_dialogue(
@@ -143,6 +146,11 @@ def enter_passphrase(debug: "DebugLink") -> None:
     """Enter a passphrase"""
     coords = buttons.pin_passphrase_grid(11)
     debug.click(coords)
+
+
+def show_passphrase(debug: "DebugLink") -> None:
+    """See the passphrase"""
+    debug.click(buttons.TOP_ROW)
 
 
 def delete_char(debug: "DebugLink") -> None:
@@ -295,4 +303,17 @@ def test_cycle_through_last_character(
     with prepare_passphrase_dialogue(device_handler) as debug:
         passphrase = DA_49 + "i"  # for i we need to cycle through "ghi" three times
         input_passphrase(debug, passphrase)
+        enter_passphrase(debug)
+
+
+@pytest.mark.setup_client(passphrase=True)
+def test_last_char_timeout(device_handler: "BackgroundDeviceHandler"):
+    with prepare_passphrase_dialogue(device_handler) as debug:
+        for character in CommonPass.MULTI_CATEGORY:
+            # insert a digit
+            input_passphrase(debug, character)
+            # wait until the last digit is hidden
+            time.sleep(DELAY_S)
+            # show the entire PIN
+            show_passphrase(debug)
         enter_passphrase(debug)

--- a/tests/click_tests/test_passphrase_tt.py
+++ b/tests/click_tests/test_passphrase_tt.py
@@ -310,10 +310,10 @@ def test_cycle_through_last_character(
 def test_last_char_timeout(device_handler: "BackgroundDeviceHandler"):
     with prepare_passphrase_dialogue(device_handler) as debug:
         for character in CommonPass.MULTI_CATEGORY:
-            # insert a digit
+            # insert a character
             input_passphrase(debug, character)
-            # wait until the last digit is hidden
+            # wait until the last character is hidden
             time.sleep(DELAY_S)
-            # show the entire PIN
+            # show the entire passphrase
             show_passphrase(debug)
         enter_passphrase(debug)


### PR DESCRIPTION
This PR solves #3959 :

- [`mercury`] Introduces a feature, that shows the last typed PIN number for short period of time (1 second) before changing it to back to a bullet icon
- [`tt`] Introduces a feature, that shows the last typed PIN number for short period of time (1 second) before changing it to back to a `*` character with faded color
- [`tr`] Changes the feature, where the last PIN digit is shown until non-timer (button) event to use aforementioned timeout.

Changes include:

- `tt`, `mercury`
   - Adding `Timer` and 3-state enum objects to the _Input_ struct and utilizing them to change the passphrase rendering style (stars, last character, all characters)
   - Adding new `label_keyboard_mono` font
   - Changing ellipse `...` to twitching when passphrase overflows
   - Utilizing `TouchStart` and `TouchStop` events to show/hide entire passphrase and maximizing the touch area
   - Implementing `apply_display_style` function to render the passphrase according to required rendering style 
- `tr`
  - Adding `Timer` to the _PassphraseEntry_ struct and utilizing it to change the passphrase rendering style (stars, last character, all characters)
  - Changing any non-timer event handling with the introduced timer token event.
  - Removing ellipse `...`, and keep only twitching when passphrase overflows


![t_pp](https://github.com/user-attachments/assets/3fc75a95-7d80-4fc1-b513-f77d366f8494)
![mercury_pp](https://github.com/user-attachments/assets/3d75bca1-f1b4-4368-a5bc-1eab4f1ce18a)

<!--
If you are a core dev:

Don't forget to set up the fields:
- assign yourself
- set priority to same as original issue
- add PR to sprint
- if Draft -> "in progress"
- if final PR -> "needs review"

If you're an external contributor, you can ignore this text.
-->
