### PR TITLE
ci: fix bootloader_emu trying to link with ASAN

### DIFF
--- a/.github/workflows/core.yml
+++ b/.github/workflows/core.yml
@@ -124,7 +124,7 @@ jobs:
           submodules: recursive
       - uses: ./.github/actions/environment
       - run: nix-shell --run "poetry run make -C core build_bootloader_emu"
-        if: matrix.coins == 'universal'
+        if: matrix.coins == 'universal' && matrix.asan == 'noasan'
       - run: nix-shell --run "poetry run make -C core build_unix_frozen"
       - run: cp core/build/unix/trezor-emu-core core/build/unix/trezor-emu-core-${{ matrix.model }}-${{ matrix.coins }}
       - uses: actions/upload-artifact@v4


### PR DESCRIPTION
In the AddressSanitizer-enabled emulator build job, when building bootloader emulator, the Rust standard library tries to link with ASAN runtime even though we do not support it at all. I don't understand what causes it, possibly rustc/cargo notices that `ADDRESS_SANITIZER=1` is set and does this? May or may not be related to #4234.

https://github.com/trezor/trezor-firmware/actions/runs/12020560773/job/33509404323

This patch disables bootloader emulator in the job since there's not point in it anyway.
<!--
For core developers:
- Assign yourself to the PR.
- Set the priority to match the original issue.
- Add the PR to the current sprint.
- If it's a draft PR, mark it as "In Progress."
- If it's a final PR, mark it as "Needs Review."

For external contributors:
- Please open an issue before submitting a PR so we can discuss whether we want to proceed with it.
-->
