### PR TITLE
ci: work around rate limit, no comment for legacy

### DIFF
--- a/.github/workflows/core.yml
+++ b/.github/workflows/core.yml
@@ -712,6 +712,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
+      - run: sleep 1m  # try avoiding github api rate limit
       - uses: ./.github/actions/ui-comment
 
   core_upload_emu:

--- a/.github/workflows/legacy.yml
+++ b/.github/workflows/legacy.yml
@@ -139,6 +139,8 @@ jobs:
           status: ${{ job.status }}
         continue-on-error: true
         if: ${{ always() && matrix.coins == 'universal' }}
+      - run: echo "${{ env.PULL_COMMENT }}" >> $GITHUB_STEP_SUMMARY
+        if: ${{ always() && matrix.coins == 'universal' }}
 
   legacy_upgrade_test:
     name: Upgrade test
@@ -216,14 +218,6 @@ jobs:
         run: |
           aws s3 sync --only-show-errors master_diff s3://data.trezor.io/dev/firmware/master_diff/${{ github.run_id }}
         continue-on-error: true
-
-  legacy_ui_comment:
-    name: Post comment with UI diff URLs
-    if: github.event_name == 'pull_request'
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v4
-      - uses: ./.github/actions/ui-comment
 
   legacy_upload_emu:
     name: Upload emulator binaries


### PR DESCRIPTION
Let's see if not posting the comment right after the job starts helps.

Also disable this for legacy firmware since two comments are twice as annoying and the changes are rare anyway. You can still see the table under the artifacts list.

<!--
For core developers:
- Assign yourself to the PR.
- Set the priority to match the original issue.
- Add the PR to the current sprint.
- If it's a draft PR, mark it as "In Progress."
- If it's a final PR, mark it as "Needs Review."

For external contributors:
- Please open an issue before submitting a PR so we can discuss whether we want to proceed with it.
-->
