### PR TITLE
chore(core): add missing parameter to set_brightness function

### DIFF
--- a/core/.changelog.d/4410.fixed
+++ b/core/.changelog.d/4410.fixed
@@ -1,0 +1,1 @@
+Add optional value parameter in brightness setting flow.

--- a/core/embed/rust/src/ui/layout_bolt/component/set_brightness.rs
+++ b/core/embed/rust/src/ui/layout_bolt/component/set_brightness.rs
@@ -19,9 +19,9 @@ pub struct SetBrightnessDialog(NumberInputSliderDialog);
 impl SetBrightnessDialog {
     pub fn new(current: u8) -> Self {
         Self(NumberInputSliderDialog::new(
-            theme::backlight::get_backlight_min() as u16,
-            theme::backlight::get_backlight_max() as u16,
-            current as u16,
+            theme::backlight::get_backlight_min().into(),
+            theme::backlight::get_backlight_max().into(),
+            current.into(),
         ))
     }
 }
@@ -36,15 +36,13 @@ impl Component for SetBrightnessDialog {
     fn event(&mut self, ctx: &mut EventCtx, event: Event) -> Option<Self::Msg> {
         match self.0.event(ctx, event) {
             Some(NumberInputSliderDialogMsg::Changed(value)) => {
-                display::backlight(value as _);
+                display::backlight(value.into());
                 None
             }
             Some(NumberInputSliderDialogMsg::Cancelled) => Some(CancelConfirmMsg::Cancelled),
             Some(NumberInputSliderDialogMsg::Confirmed) => {
-                match storage::set_brightness(self.0.value() as _) {
-                    Ok(_) => Some(CancelConfirmMsg::Confirmed),
-                    Err(_) => Some(CancelConfirmMsg::Cancelled), // TODO: handle error
-                }
+                unwrap!(storage::set_brightness(self.0.value() as _));
+                Some(CancelConfirmMsg::Confirmed)
             }
             None => None,
         }

--- a/core/embed/rust/src/ui/layout_delizia/flow/set_brightness.rs
+++ b/core/embed/rust/src/ui/layout_delizia/flow/set_brightness.rs
@@ -72,14 +72,13 @@ fn footer_update_fn(
     }
 }
 
-pub fn new_set_brightness(brightness: Option<u8>) -> Result<SwipeFlow, Error> {
-    let brightness = brightness.unwrap_or(theme::backlight::get_backlight_normal());
+pub fn new_set_brightness(brightness: u8) -> Result<SwipeFlow, Error> {
     let content_slider = Frame::left_aligned(
         TR::brightness__title.into(),
         NumberInputSliderDialog::new(
-            theme::backlight::get_backlight_min() as u16,
-            theme::backlight::get_backlight_max() as u16,
-            brightness as u16,
+            theme::backlight::get_backlight_min().into(),
+            theme::backlight::get_backlight_max().into(),
+            brightness.into(),
         ),
     )
     .with_subtitle(TR::homescreen__settings_subtitle.into())

--- a/core/embed/rust/src/ui/layout_delizia/ui_firmware.rs
+++ b/core/embed/rust/src/ui/layout_delizia/ui_firmware.rs
@@ -4,6 +4,7 @@ use crate::{
     error::{value_error, Error},
     io::BinaryData,
     micropython::{gc::Gc, iter::IterBuf, list::List, obj::Obj, util},
+    storage,
     strutil::TString,
     translations::TR,
     ui::{
@@ -26,10 +27,6 @@ use crate::{
             obj::{LayoutMaybeTrace, LayoutObj, RootComponent},
             util::{ContentType, PropsList, RecoveryType},
         },
-        layout_delizia::component::{
-            FrameMsg, ScrolledVerticalMenu, TradeScreen, VerticalMenuChoiceMsg, VerticalMenuItem,
-            VerticalMenuItems,
-        },
         ui_firmware::{
             FirmwareUI, ERROR_NOT_IMPLEMENTED, MAX_CHECKLIST_ITEMS, MAX_GROUP_SHARE_LINES,
             MAX_MENU_ITEMS, MAX_WORD_QUIZ_ITEMS,
@@ -40,9 +37,10 @@ use crate::{
 
 use super::{
     component::{
-        check_homescreen_format, Bip39Input, CoinJoinProgress, Frame, Homescreen, Lockscreen,
-        MnemonicKeyboard, PinKeyboard, Progress, SelectWordCount, SelectWordCountLayout,
-        Slip39Input, StatusScreen, SwipeContent, SwipeUpScreen, VerticalMenu,
+        check_homescreen_format, Bip39Input, CoinJoinProgress, Frame, FrameMsg, Homescreen,
+        Lockscreen, MnemonicKeyboard, PinKeyboard, Progress, ScrolledVerticalMenu, SelectWordCount,
+        SelectWordCountLayout, Slip39Input, StatusScreen, SwipeContent, SwipeUpScreen, TradeScreen,
+        VerticalMenu, VerticalMenuChoiceMsg, VerticalMenuItem, VerticalMenuItems,
     },
     flow::{
         self, new_confirm_action_simple, ConfirmActionExtra, ConfirmActionMenuStrings,
@@ -863,7 +861,16 @@ impl FirmwareUI for UIDelizia {
     }
 
     fn set_brightness(current_brightness: Option<u8>) -> Result<impl LayoutMaybeTrace, Error> {
-        let flow = flow::set_brightness::new_set_brightness(current_brightness)?;
+        let brightness = match current_brightness {
+            Some(value) => {
+                // Set the brightness immediately so it is applied in the `_first_paint` UI
+                // layout function
+                unwrap!(storage::set_brightness(value));
+                value
+            }
+            None => theme::backlight::get_backlight_normal(),
+        };
+        let flow = flow::set_brightness::new_set_brightness(brightness)?;
         Ok(flow)
     }
 

--- a/core/src/apps/management/set_brightness.py
+++ b/core/src/apps/management/set_brightness.py
@@ -4,7 +4,7 @@ if TYPE_CHECKING:
     from trezor.messages import SetBrightness, Success
 
 
-async def set_brightness(_msg: SetBrightness) -> Success:
+async def set_brightness(msg: SetBrightness) -> Success:
     import storage.device as storage_device
     from trezor.messages import Success
     from trezor.ui.layouts import set_brightness
@@ -13,5 +13,5 @@ async def set_brightness(_msg: SetBrightness) -> Success:
     if not storage_device.is_initialized():
         raise NotInitialized("Device is not initialized")
 
-    await set_brightness()
+    await set_brightness(msg.value)
     return Success(message="Settings applied")

--- a/core/src/trezor/ui/layouts/delizia/__init__.py
+++ b/core/src/trezor/ui/layouts/delizia/__init__.py
@@ -1700,15 +1700,15 @@ def confirm_firmware_update(description: str, fingerprint: str) -> Awaitable[Non
     )
 
 
-def set_brightness(current: int | None = None) -> Awaitable[None]:
-    from trezor.ui.layouts.menu import Menu, confirm_with_menu
-
-    return confirm_with_menu(
+async def set_brightness(current: int | None = None) -> None:
+    br_name = "set_brightness"
+    await raise_if_cancelled(
         trezorui_api.set_brightness(current=current),
-        Menu.root(cancel=TR.buttons__cancel),
-        "set_brightness",
+        br_name,
         BR_CODE_OTHER,
     )
+
+    show_continue_in_app(TR.brightness__changed_title)
 
 
 def tutorial(br_code: ButtonRequestType = BR_CODE_OTHER) -> Awaitable[None]:

--- a/tests/input_flows.py
+++ b/tests/input_flows.py
@@ -3022,4 +3022,3 @@ class InputFlowCancelBrightness(InputFlowBase):
     def input_flow_delizia(self):
         yield
         self.debug.click(self.debug.screen_buttons.menu())
-        self.debug.click(self.debug.screen_buttons.vertical_menu_items()[0])

--- a/tests/input_flows.py
+++ b/tests/input_flows.py
@@ -3001,6 +3001,19 @@ class InputFlowFidoConfirm(InputFlowBase):
             self.debug.press_yes()
 
 
+class InputFlowSetBrightness(InputFlowBase):
+
+    def input_flow_bolt(self):
+        return self.client.ui.default_input_flow()
+
+    def input_flow_delizia(self):
+        return self.client.ui.default_input_flow()
+
+    def input_flow_eckhart(self):
+        yield
+        self.debug.click(self.debug.screen_buttons.menu())
+
+
 class InputFlowCancelBrightness(InputFlowBase):
     def input_flow_bolt(self) -> BRGeneratorType:
         yield


### PR DESCRIPTION
This PR:
1. adds the missing brightness value parameter in `set_brightness` function
2. If the value has been passed, the brightness is set to this value
3. Parametrizes existing tests to test different scenarios (screenshots do not show the brightness correctly, but locally it works well)
4. [delizia] Fixes inconsistent brightness in `set_brightness` flow by making the flow have 1 screen only.
