### PR TITLE
build(core): use deterministic git rev-parse

### DIFF
--- a/build-docker.sh
+++ b/build-docker.sh
@@ -285,7 +285,7 @@ for TREZOR_MODEL in ${MODELS[@]}; do
       set -e -o pipefail
       cd /reproducible-build/trezor-firmware/core
       $GIT_CLEAN_REPO
-      poetry run make clean vendor $MAKE_TARGETS
+      poetry run make clean vendor $MAKE_TARGETS QUIET_MODE=1
       for item in bootloader firmware prodtest; do
         if [ -f build/\$item/\$item.bin ]; then
           poetry run ../python/tools/firmware-fingerprint.py \

--- a/build-docker.sh
+++ b/build-docker.sh
@@ -72,7 +72,7 @@ INIT=1
 MODELS=(R T T3T1)
 CORE_TARGETS=(boardloader bootloader firmware)
 
-REPOSITORY="/local"
+REPOSITORY="file:///local"
 
 while true; do
   case "$1" in
@@ -204,7 +204,7 @@ if [ $INIT -eq 1 ]; then
 
     mkdir -p /reproducible-build
     cd /reproducible-build
-    git clone "$REPOSITORY" trezor-firmware
+    git clone --branch="$TAG" --depth=1 "$REPOSITORY" trezor-firmware
     cd trezor-firmware
 EOF
 
@@ -224,8 +224,6 @@ fi  # init
 # append common part to script
 cat <<EOF >> "$SCRIPT_NAME"
   $GIT_CLEAN_REPO
-  git fetch origin "$COMMIT_HASH"
-  git checkout "$COMMIT_HASH"
   git submodule update --init --recursive
   poetry install
   cd core/embed/rust

--- a/core/embed/projects/firmware/mpconfigport.h
+++ b/core/embed/projects/firmware/mpconfigport.h
@@ -177,6 +177,10 @@
 
 #define MP_STATE_PORT MP_STATE_VM
 
+// by default contains nearest git tag, which may not be present in shallow
+// repo, breaking reproducibility
+#define MICROPY_BANNER_NAME_AND_VERSION ""
+
 // ============= this ends common config section ===================
 
 

--- a/core/embed/projects/unix/mpconfigport.h
+++ b/core/embed/projects/unix/mpconfigport.h
@@ -217,6 +217,10 @@ extern const struct _mp_print_t mp_stderr_print;
 
 #define MP_STATE_PORT MP_STATE_VM
 
+// by default contains nearest git tag, which may not be present in shallow
+// repo, breaking reproducibility
+#define MICROPY_BANNER_NAME_AND_VERSION ""
+
 // ============= this ends common config section ===================
 
 // For size_t and ssize_t

--- a/core/site_scons/tools.py
+++ b/core/site_scons/tools.py
@@ -33,9 +33,9 @@ def get_git_revision_hash() -> str:
 
 def get_git_revision_short_hash() -> str:
     return (
-        subprocess.check_output(["git", "rev-parse", "--short", "HEAD"])
+        subprocess.check_output(["git", "rev-parse", "--verify", "HEAD"])
         .decode("ascii")
-        .strip()
+        .strip()[:7]
     )
 
 


### PR DESCRIPTION
`git rev-parse --short`
> shortens the object name to a unique prefix with at least length characters. The minimum length is 4

Means the prefix length depends on the exact contents of your .git database, and shallow git clones get shorter prefix.
<!--
For core developers:
- Assign yourself to the PR.
- Set the priority to match the original issue.
- Add the PR to the current sprint.
- If it's a draft PR, mark it as "In Progress."
- If it's a final PR, mark it as "Needs Review."

For external contributors:
- Please open an issue before submitting a PR so we can discuss whether we want to proceed with it.
-->
