### PR TITLE
ci: add build-docker.sh jobs

### DIFF
--- a/.github/workflows/common.yml
+++ b/.github/workflows/common.yml
@@ -5,6 +5,10 @@ on:
   workflow_dispatch:
   schedule:
     - cron: '14 23 * * *'  # every day @ 23:14
+  push:
+    branches:
+      - 'release/**'
+
 
 # cancel any previous runs on the same PR
 concurrency:
@@ -123,8 +127,8 @@ jobs:
 
   docker_build:
     name: Firmware docker build
-    # scheduled, manual runs, PRs for release branches
-    if: github.event_name != 'pull_request' || startsWith(github.head_ref, 'release/')
+    # scheduled, manual runs, push to release branches
+    if: github.event_name != 'pull_request'
     runs-on: ubuntu-latest
     strategy:
       fail-fast: false

--- a/.github/workflows/common.yml
+++ b/.github/workflows/common.yml
@@ -120,3 +120,36 @@ jobs:
       - run: unset PYTEST_TIMEOUT
       - run: nix-shell --run "poetry run make -C storage/tests build"
       - run: nix-shell --run "poetry run make -C storage/tests tests_all"
+
+  docker_build:
+    name: Firmware docker build
+    # scheduled, manual runs, PRs for release branches
+    if: github.event_name != 'pull_request' || startsWith(github.head_ref, 'release/')
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        # model: [T1B1, T2T1, T2B1, T3B1, T3T1]  # TODO update exprs below
+        model: ["1", "T", "R", T3B1, T3T1]
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+      - run: git checkout ${{ github.head_ref || github.ref_name }}
+      - run: ./build-docker.sh ${{ matrix.model == '1' && '--skip-core' || '--skip-legacy' }} --models ${{ matrix.model }} ${{ github.head_ref || github.ref_name }}
+      - name: Show fingerprints
+        run: |
+          for file in build/*/*/*.fingerprint; do
+            if [ -f "$file" ]; then
+              origfile="${file%.fingerprint}"
+              fingerprint=$(tr -d '\n' < $file)
+              echo "\`$fingerprint\` $origfile" >> $GITHUB_STEP_SUMMARY
+            fi
+          done
+          cat $GITHUB_STEP_SUMMARY
+      - uses: actions/upload-artifact@v4
+        with:
+          name: reproducible-${{ matrix.model }}
+          path: |
+            build/*/*/*.bin
+          retention-days: 7

--- a/.github/workflows/core.yml
+++ b/.github/workflows/core.yml
@@ -10,6 +10,9 @@ on:
   workflow_dispatch:
   schedule:
     - cron: '15 23 * * *'  # every day @ 23:15
+  push:
+    branches:
+      - 'release/**'
 
 # cancel any previous runs on the same PR
 concurrency:

--- a/.github/workflows/legacy.yml
+++ b/.github/workflows/legacy.yml
@@ -5,6 +5,9 @@ on:
   workflow_dispatch:
   schedule:
     - cron: '35 22 * * *'  # every day @ 22:35
+  push:
+    branches:
+      - 'release/**'
 
 # cancel any previous runs on the same PR
 concurrency:

--- a/.github/workflows/prebuild.yml
+++ b/.github/workflows/prebuild.yml
@@ -5,6 +5,9 @@ on:
   workflow_dispatch:
   schedule:
     - cron: '13 23 * * *'  # every day @ 23:13
+  push:
+    branches:
+      - 'release/**'
 
 # cancel any previous runs on the same PR
 concurrency:

--- a/build-docker.sh
+++ b/build-docker.sh
@@ -225,7 +225,7 @@ fi  # init
 cat <<EOF >> "$SCRIPT_NAME"
   $GIT_CLEAN_REPO
   git submodule update --init --recursive
-  poetry install
+  poetry install -v --no-ansi --no-interaction
   cd core/embed/rust
   cargo fetch
 
@@ -305,7 +305,6 @@ EOF
 
     $DOCKER run \
       --network=host \
-      -it \
       --rm \
       -v "$DIR:/local" \
       -v "$DIR/build/core$DIRSUFFIX":/build:z \
@@ -354,7 +353,6 @@ EOF
 
   $DOCKER run \
     --network=host \
-    -it \
     --rm \
     -v "$DIR:/local" \
     -v "$DIR/build/legacy$DIRSUFFIX":/build:z \


### PR DESCRIPTION
Only for scheduled and manual pipelines so as not to slow down regular PRs.

I tried all models in a single build but ran into `No space left on device`. Job per model is faster but eats more compute time because every job builds its own docker image.

You can see all fingerprints in [workflow summary](https://github.com/trezor/trezor-firmware/actions/runs/12148645944?pr=4420#summary-33877558860).

Based on #4418.

<!--
For core developers:
- Assign yourself to the PR.
- Set the priority to match the original issue.
- Add the PR to the current sprint.
- If it's a draft PR, mark it as "In Progress."
- If it's a final PR, mark it as "Needs Review."

For external contributors:
- Please open an issue before submitting a PR so we can discuss whether we want to proceed with it.
-->
