### PR TITLE
fix translation area access from coreapp applet

### DIFF
--- a/core/embed/projects/kernel/main.c
+++ b/core/embed/projects/kernel/main.c
@@ -235,7 +235,11 @@ static void coreapp_init(applet_t *applet) {
 #endif
   };
 
-  applet_init(applet, coreapp_header, &coreapp_layout);
+  applet_privileges_t coreapp_privileges = {
+      .assets_area_access = true,
+  };
+
+  applet_init(applet, coreapp_header, &coreapp_layout, &coreapp_privileges);
 }
 
 // Shows RSOD (Red Screen of Death)

--- a/core/embed/sys/task/inc/sys/applet.h
+++ b/core/embed/sys/task/inc/sys/applet.h
@@ -55,22 +55,28 @@ typedef struct {
 
 } applet_layout_t;
 
+// Applet privileges
+typedef struct {
+  bool assets_area_access;
+} applet_privileges_t;
+
 typedef struct {
   // Points to the applet header found at the beginning of the applet binary
   applet_header_t* header;
   // Applet memory layout describing the memory areas
   // the applet is allowed to use
   applet_layout_t layout;
+  // Applet privileges
+  applet_privileges_t privileges;
+
   // Applet task
   systask_t task;
-
-  // + privileges
 
 } applet_t;
 
 // Initializes the applet structure
 void applet_init(applet_t* applet, applet_header_t* header,
-                 applet_layout_t* layout);
+                 applet_layout_t* layout, applet_privileges_t* privileges);
 
 // Resets the applet and prepares it for execution from its entry point.
 //

--- a/core/embed/sys/task/stm32/applet.c
+++ b/core/embed/sys/task/stm32/applet.c
@@ -17,6 +17,7 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
+#include <trezor_model.h>
 #include <trezor_rtl.h>
 
 #include <io/display.h>
@@ -32,11 +33,12 @@
 #ifdef SYSCALL_DISPATCH
 
 void applet_init(applet_t* applet, applet_header_t* header,
-                 applet_layout_t* layout) {
+                 applet_layout_t* layout, applet_privileges_t* privileges) {
   memset(applet, 0, sizeof(applet_t));
 
   applet->header = header;
   applet->layout = *layout;
+  applet->privileges = *privileges;
 }
 
 static void applet_clear_memory(applet_t* applet) {
@@ -85,6 +87,10 @@ static void applet_set_unpriv(applet_t* applet, bool unpriv) {
   tz_set_sram_unpriv(layout->data2.start, layout->data2.size, unpriv);
   tz_set_flash_unpriv(layout->code1.start, layout->code1.size, unpriv);
   tz_set_flash_unpriv(layout->code2.start, layout->code2.size, unpriv);
+
+  if (applet->privileges.assets_area_access) {
+    tz_set_flash_unpriv(ASSETS_START, ASSETS_MAXSIZE, unpriv);
+  }
 
   display_set_unpriv_access(unpriv);
 }


### PR DESCRIPTION
trustozone setting changed: assets area as unprivileged.

<!--
For core developers:
- Assign yourself to the PR.
- Set the priority to match the original issue.
- Add the PR to the current sprint.
- If it's a draft PR, mark it as "In Progress."
- If it's a final PR, mark it as "Needs Review."

For external contributors:
- Please open an issue before submitting a PR so we can discuss whether we want to proceed with it.
-->
