### PR TITLE
resolve crashes when running without display

### DIFF
--- a/core/embed/rust/src/trezorhal/display.rs
+++ b/core/embed/rust/src/trezorhal/display.rs
@@ -55,13 +55,17 @@ pub fn refresh() {
 }
 
 #[cfg(feature = "framebuffer")]
-pub fn get_frame_buffer() -> (&'static mut [u8], usize) {
+pub fn get_frame_buffer() -> Option<(&'static mut [u8], usize)> {
     let mut fb_info = ffi::display_fb_info_t {
         ptr: ptr::null_mut(),
         stride: 0,
     };
 
     unsafe { ffi::display_get_frame_buffer(&mut fb_info) };
+
+    if fb_info.ptr.is_null() {
+        return None;
+    }
 
     let fb = unsafe {
         core::slice::from_raw_parts_mut(
@@ -70,5 +74,5 @@ pub fn get_frame_buffer() -> (&'static mut [u8], usize) {
         )
     };
 
-    (fb, fb_info.stride)
+    Some((fb, fb_info.stride))
 }

--- a/core/embed/rust/src/ui/shape/display/fb_mono8.rs
+++ b/core/embed/rust/src/ui/shape/display/fb_mono8.rs
@@ -39,7 +39,13 @@ where
 
         let cache = DrawingCache::new(bump, bump);
 
-        let (fb, fb_stride) = display::get_frame_buffer();
+        let fb_info = display::get_frame_buffer();
+
+        if fb_info.is_none() {
+            return;
+        }
+
+        let (fb, fb_stride) = fb_info.unwrap();
 
         let mut canvas = unwrap!(Mono8Canvas::new(
             Offset::new(width, height),

--- a/core/embed/rust/src/ui/shape/display/fb_rgb565.rs
+++ b/core/embed/rust/src/ui/shape/display/fb_rgb565.rs
@@ -32,7 +32,13 @@ where
 
         let cache = DrawingCache::new(bump_a, bump_b);
 
-        let (fb, fb_stride) = display::get_frame_buffer();
+        let fb_info = display::get_frame_buffer();
+
+        if fb_info.is_none() {
+            return;
+        }
+
+        let (fb, fb_stride) = fb_info.unwrap();
 
         let mut canvas = unwrap!(Rgb565Canvas::new(
             Offset::new(width, height),

--- a/core/embed/rust/src/ui/shape/display/fb_rgba8888.rs
+++ b/core/embed/rust/src/ui/shape/display/fb_rgba8888.rs
@@ -32,7 +32,13 @@ where
 
         let cache = DrawingCache::new(bump_a, bump_b);
 
-        let (fb, fb_stride) = display::get_frame_buffer();
+        let fb_info = display::get_frame_buffer();
+
+        if fb_info.is_none() {
+            return;
+        }
+
+        let (fb, fb_stride) = fb_info.unwrap();
 
         let mut canvas = unwrap!(Rgba8888Canvas::new(
             Offset::new(width, height),


### PR DESCRIPTION
This PR resolve crashes when uninitialized display returns null ptr as framebuffer and firmware attempts to render into it.

We will need to run some stages of prodtest of T3W1 running without display and this enables it, but we should probably consider allowing this explicitly via some OTP flag, and implement somewhat more elegant way to shutdown when this is not allowed. however, I consider this out of scope in this PR.

