### PR TITLE
Fix serialization of signatures and witnesses in multisig

### DIFF
--- a/core/src/apps/bitcoin/get_address.py
+++ b/core/src/apps/bitcoin/get_address.py
@@ -52,7 +52,7 @@ async def get_address(msg: GetAddress, keychain: Keychain, coin: CoinInfo) -> Ad
         address_n_to_name_or_unknown,
         validate_path_against_script_type,
     )
-    from .multisig import multisig_pubkey_index
+    from .multisig import multisig_xpub_index
 
     multisig = msg.multisig  # local_cache_attribute
     address_n = msg.address_n  # local_cache_attribute
@@ -110,7 +110,7 @@ async def get_address(msg: GetAddress, keychain: Keychain, coin: CoinInfo) -> Ad
                 pubnodes = multisig.nodes
             else:
                 pubnodes = [hd.node for hd in multisig.pubkeys]
-            multisig_index = multisig_pubkey_index(multisig, node.public_key())
+            multisig_index = multisig_xpub_index(multisig, node.public_key())
 
             await confirm_multisig_warning()
 

--- a/core/src/apps/bitcoin/multisig.py
+++ b/core/src/apps/bitcoin/multisig.py
@@ -59,6 +59,15 @@ def validate_multisig(multisig: MultisigRedeemScriptType) -> None:
 
 def multisig_pubkey_index(multisig: MultisigRedeemScriptType, pubkey: bytes) -> int:
     validate_multisig(multisig)
+    pubkeys = multisig_get_pubkeys(multisig)
+    try:
+        return pubkeys.index(pubkey)
+    except ValueError:
+        raise DataError("Pubkey not found in multisig script")
+
+
+def multisig_xpub_index(multisig: MultisigRedeemScriptType, pubkey: bytes) -> int:
+    validate_multisig(multisig)
     if multisig.nodes:
         for i, hd_node in enumerate(multisig.nodes):
             if multisig_get_pubkey(hd_node, multisig.address_n) == pubkey:
@@ -67,7 +76,7 @@ def multisig_pubkey_index(multisig: MultisigRedeemScriptType, pubkey: bytes) -> 
         for i, hd in enumerate(multisig.pubkeys):
             if multisig_get_pubkey(hd.node, hd.address_n) == pubkey:
                 return i
-    raise DataError("Pubkey not found in multisig script")
+    raise DataError("XPUB not found in multisig script")
 
 
 def multisig_get_pubkey(n: HDNodeType, p: paths.Bip32Path) -> bytes:


### PR DESCRIPTION
This pull request aims to fix an issue introduced in https://github.com/trezor/trezor-firmware/pull/4351 and [discovered](https://github.com/trezor/trezor-firmware/pull/4351#issuecomment-2533092420) by @andrewtoth: The signatures and witnesses for multisig scripts were serialized without regard to the order specified by `MultisigPubkeys`.