### PR TITLE
fix display refresh on TS5

### DIFF
--- a/core/embed/io/display/st-7789/display_internal.h
+++ b/core/embed/io/display/st-7789/display_internal.h
@@ -25,6 +25,7 @@ typedef struct {
 
   // Current display orientation (0, 90, 180, 270)
   int orientation_angle;
+  int update_pending;
 
 } display_driver_t;
 


### PR DESCRIPTION
This PR fixes problem with raising backlight before the display driver IC actually copies framebuffer from its internal memory to panel.

Addition display refresh cycle is now waited before raising the backlight to avoid remnants of previous frame being shown.