### PR TITLE
Ensure consistent German translation for 'labeling'

### DIFF
--- a/core/translations/de.json
+++ b/core/translations/de.json
@@ -453,7 +453,7 @@
     "misc__decrypt_value": "Wert entschlüsseln",
     "misc__enable_labeling": "Kennzeichnung aktivieren?",
     "misc__encrypt_value": "Wert verschlüsseln",
-    "misc__title_suite_labeling": "Suite-labeling",
+    "misc__title_suite_labeling": "Suite-Kennzeichnung",
     "modify_amount__decrease_amount": "Betrag reduzieren um:",
     "modify_amount__increase_amount": "Betrag erhöhen um:",
     "modify_amount__new_amount": "Neuer Betrag:",

--- a/core/translations/signatures.json
+++ b/core/translations/signatures.json
@@ -1,8 +1,8 @@
 {
   "current": {
-    "merkle_root": "1b0c558e4f74caa8a5909718214f11924202fcb6b8ccf569a32d70264accb133",
-    "datetime": "2025-06-16T10:21:37.253979+00:00",
-    "commit": "552314fa40f1b8f201fa28805a62c9984493a873"
+    "merkle_root": "c17219dfef87f023e53dd6470f633d38a8f8572466f987e0efe4536652b0d805",
+    "datetime": "2025-06-23T08:18:59.627189+00:00",
+    "commit": "1312054ba96c9037aa99cf48709d9cdafdeb708c"
   },
   "history": [
     {


### PR DESCRIPTION
This PR ensures consistency in German translation of labeling-related translations:
```
    "misc__enable_labeling": "Kennzeichnung aktivieren?",
    "misc__title_suite_labeling": "Suite-Kennzeichnung",
```
Translation correctness was also checked with ChatGPT: 
![image](https://github.com/user-attachments/assets/2232f65e-5a61-47f4-b037-44b1eb07a05e)