### PR TITLE
re-balance distribution in flash on F4 models

### DIFF
--- a/core/embed/sys/linker/stm32f4/firmware.ld
+++ b/core/embed/sys/linker/stm32f4/firmware.ld
@@ -37,10 +37,6 @@ SECTIONS {
 
   .flash2 : ALIGN(CODE_ALIGNMENT) {
     build/firmware/frozen_mpy.o(.rodata*);
-    build/firmware/vendor/secp256k1-zkp/src/secp256k1.o(.rodata*);
-    build/firmware/vendor/secp256k1-zkp/src/precomputed_ecmult.o(.rodata*);
-    build/firmware/vendor/secp256k1-zkp/src/precomputed_ecmult_gen.o(.rodata*);
-    build/firmware/vendor/trezor-crypto/aes/aestab.o(.rodata*);
     . = ALIGN(4);
     */libtrezor_lib.a:(.text*);
     . = ALIGN(4);


### PR DESCRIPTION
moved the crypto data to flash 1.
