### PR TITLE
Fix Rust Trezor-Client Timeouts

### DIFF
--- a/rust/trezor-client/Cargo.lock
+++ b/rust/trezor-client/Cargo.lock
@@ -690,7 +690,7 @@ dependencies = [
 
 [[package]]
 name = "trezor-client"
-version = "0.1.4"
+version = "0.1.5"
 dependencies = [
  "bitcoin",
  "byteorder",

--- a/rust/trezor-client/Cargo.toml
+++ b/rust/trezor-client/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "trezor-client"
-version = "0.1.4"
+version = "0.1.5"
 authors = [
     "Piyush Kumar <piyushkumar2k02@kgpian.iitkgp.ac.in>",
     "joshieDo <ranriver@protonmail.com>",

--- a/rust/trezor-client/src/transport/udp.rs
+++ b/rust/trezor-client/src/transport/udp.rs
@@ -19,8 +19,8 @@ use constants::{DEFAULT_DEBUG_PORT, DEFAULT_HOST, DEFAULT_PORT, LOCAL_LISTENER};
 /// The chunk size for the serial protocol.
 const CHUNK_SIZE: usize = 64;
 
-const READ_TIMEOUT_MS: u64 = 100000;
-const WRITE_TIMEOUT_MS: u64 = 100000;
+const READ_TIMEOUT_MS: u64 = 0;
+const WRITE_TIMEOUT_MS: u64 = 1000;
 
 /// An available transport for connecting with a device.
 #[derive(Debug)]

--- a/rust/trezor-client/src/transport/webusb.rs
+++ b/rust/trezor-client/src/transport/webusb.rs
@@ -26,8 +26,8 @@ mod constants {
 /// The chunk size for the serial protocol.
 const CHUNK_SIZE: usize = 64;
 
-const READ_TIMEOUT_MS: u64 = 100000;
-const WRITE_TIMEOUT_MS: u64 = 100000;
+const READ_TIMEOUT_MS: u64 = 0;
+const WRITE_TIMEOUT_MS: u64 = 1000;
 
 /// An available transport for connecting with a device.
 #[derive(Debug)]


### PR DESCRIPTION
The Rust client will unilaterally timeout after 100 seconds which causes connection errors when interacting with the device between protocol messages. 100 seconds is borderline for some use cases such as complicated transaction verification. This isn't seemingly a problem with the web or Python libraries so without a keep-alive mechanism this fix at least alleviates the problem with no ill effects.

Can we bump the version with this fix also?