### PR TITLE
style: update cstyle to add new line at EOF if missing

### DIFF
--- a/.clang-format
+++ b/.clang-format
@@ -6,3 +6,5 @@ ColumnLimit: 80
 # This setting differs between clang-format 7 and 9.
 # Let's set it explicitly to v7 value
 IncludeBlocks: Preserve
+# Insert New line at EOF if missing
+InsertNewlineAtEOF: true


### PR DESCRIPTION
Update clang-format style to add new line at EOF if missing
