### PR TITLE
fix(common): blockbook for testnet 4

### DIFF
--- a/common/defs/bitcoin/bitcoin_testnet.json
+++ b/common/defs/bitcoin/bitcoin_testnet.json
@@ -12,7 +12,7 @@
   "maxfee_kb": 10000000,
   "minfee_kb": 1000,
   "signed_message_header": "Bitcoin Signed Message:\n",
-  "hash_genesis_block": "000000000933ea01ad0ee984209779baaec3ced90fa3f408719526f8d77f4943",
+  "hash_genesis_block": "00000000da84f2bafbbc53dee25a72ae507ff4914b867c565be350b0da8bf043",
   "xprv_magic": 70615956,
   "xpub_magic": 70617039,
   "xpub_magic_segwit_p2sh": 71979618,

--- a/common/defs/blockchain_link.json
+++ b/common/defs/blockchain_link.json
@@ -137,8 +137,7 @@
   "bitcoin:TEST": {
     "type": "blockbook",
     "url": [
-      "https://tbtc1.trezor.io",
-      "https://tbtc2.trezor.io"
+      "https://tbtc4-1.trezor.io"
     ]
   },
   "bitcoin:VIPS": {


### PR DESCRIPTION
<!--
For core developers:
- Assign yourself to the PR.
- Set the priority to match the original issue.
- Add the PR to the current sprint.
- If it's a draft PR, mark it as "In Progress."
- If it's a final PR, mark it as "Needs Review."

For external contributors:
- Please open an issue before submitting a PR so we can discuss whether we want to proceed with it.
-->
As we want to move from Bitcoin Testnet 3 to Bitcoin Testnet 4 we need to change the blockbook default URL.
Related: https://github.com/trezor/trezor-suite/issues/14951
