### PR TITLE
build(build-docker): use shasum first, then sha256sum

### DIFF
--- a/build-docker.sh
+++ b/build-docker.sh
@@ -156,10 +156,10 @@ else
 fi
 
 # check alpine checksum
-if command -v sha256sum &> /dev/null ; then
-    echo "${ALPINE_CHECKSUM}  ci/${ALPINE_TARBALL}" | sha256sum -c
-else
+if command -v shasum &> /dev/null ; then
     echo "${ALPINE_CHECKSUM}  ci/${ALPINE_TARBALL}" | shasum -a 256 -c
+else
+    echo "${ALPINE_CHECKSUM}  ci/${ALPINE_TARBALL}" | sha256sum -c
 fi
 
 tag_clean="${TAG//[^a-zA-Z0-9]/_}"


### PR DESCRIPTION
macOS recently introduced sha256sum command which can not read from stdin if "-c" option is provided

using shasum first fixes this issue
