### PR TITLE
fix wrong RSOD color on some older Model T devices

### DIFF
--- a/core/.changelog.d/4491.fixed
+++ b/core/.changelog.d/4491.fixed
@@ -1,0 +1,1 @@
+[T2T1] Fix wrong RSOD color on some older Model T devices

--- a/core/embed/io/display/st-7789/display_driver.c
+++ b/core/embed/io/display/st-7789/display_driver.c
@@ -61,6 +61,12 @@ void display_init(display_content_mode_t mode) {
 #endif
 
   if (mode == DISPLAY_RESET_CONTENT) {
+#if defined TREZOR_MODEL_T2T1 && !defined BOARDLOADER
+    // This is required for the model T to work correctly.
+    // Boardloader does this by constant in binary, other stages need to read
+    // this from the display
+    display_panel_preserve_inversion();
+#endif
     display_io_init_gpio();
     display_io_init_fmc();
     display_panel_init();

--- a/core/embed/io/display/st-7789/display_panel.c
+++ b/core/embed/io/display/st-7789/display_panel.c
@@ -47,14 +47,26 @@
 
 #ifdef KERNEL_MODE
 
+#ifdef TREZOR_MODEL_T2T1
+#ifdef BOARDLOADER
 // using const volatile instead of #define results in binaries that change
 // only in 1-byte when the flag changes.
 // using #define leads compiler to over-optimize the code leading to bigger
-// differencies in the resulting binaries.
+// differences in the resulting binaries.
 const volatile uint8_t DISPLAY_ST7789V_INVERT_COLORS2 = 1;
 
+#else
+
+volatile uint8_t DISPLAY_ST7789V_INVERT_COLORS2 = 0;
+
+void display_panel_preserve_inversion(void) {
+  DISPLAY_ST7789V_INVERT_COLORS2 = display_panel_is_inverted();
+}
+#endif
+#endif
+
 // Window padding (correction) when using 90dg or 270dg orientation
-// (internally the display is 240x320 but we use only 240x240)
+// (internally the display is 240x320, but we use only 240x240)
 static display_padding_t g_window_padding;
 
 #ifdef DISPLAY_IDENTIFY
@@ -232,7 +244,7 @@ void display_panel_init(void) {
 }
 
 void display_panel_reinit(void) {
-  // reinitialization is needed due to original sequence is unchangable in
+  // reinitialization is needed due to original sequence is unchangeable in
   // boardloader
 #ifdef TREZOR_MODEL_T2T1
   // model TT has new gamma settings

--- a/core/embed/io/display/st-7789/display_panel.h
+++ b/core/embed/io/display/st-7789/display_panel.h
@@ -55,4 +55,8 @@ void display_panel_set_window(uint16_t x0, uint16_t y0, uint16_t x1,
                               uint16_t y1);
 void display_panel_rotate(int angle);
 
+#if defined TREZOR_MODEL_T2T1 && !defined BOARDLOADER
+void display_panel_preserve_inversion(void);
+#endif
+
 #endif  // TREZORHAL_ST7789_PANEL_H


### PR DESCRIPTION
note to self: dont forget to sync the new ifdefs with https://github.com/trezor/trezor-firmware/pull/4477

<!--
For core developers:
- Assign yourself to the PR.
- Set the priority to match the original issue.
- Add the PR to the current sprint.
- If it's a draft PR, mark it as "In Progress."
- If it's a final PR, mark it as "Needs Review."

For external contributors:
- Please open an issue before submitting a PR so we can discuss whether we want to proceed with it.
-->
