### PR TITLE
Support per-layout translations entries

### DIFF
--- a/core/embed/rust/src/translations/generated/translated_string.rs
+++ b/core/embed/rust/src/translations/generated/translated_string.rs
@@ -1385,6 +1385,8 @@ pub enum TranslatedString {
 }
 
 impl TranslatedString {
+    // Allow building with `--all-features` (enabling all layouts results in duplicate match keys) for clippy
+    #[allow(unreachable_patterns)]
     pub fn untranslated(self) -> &'static str {
         match self {
             Self::addr_mismatch__contact_support_at => "Please contact Trezor support at",

--- a/core/embed/rust/src/translations/generated/translated_string.rs.mako
+++ b/core/embed/rust/src/translations/generated/translated_string.rs.mako
@@ -32,6 +32,9 @@ order = {int(k): v for k, v in order_index_name.items()}
 en_file = TR_DIR / "en.json"
 en_data = json.loads(en_file.read_text())["translations"]
 
+def encode_str(s):
+    return re.sub(r'\\u([0-9a-f]{4})', r'\\u{\g<1>}', json.dumps(s))
+
 %>\
 #[cfg(feature = "micropython")]
 use crate::micropython::qstr::Qstr;
@@ -50,13 +53,30 @@ pub enum TranslatedString {
 }
 
 impl TranslatedString {
+    // Allow building with `--all-features` (enabling all layouts results in duplicate match keys) for clippy
+    #[allow(unreachable_patterns)]
     pub fn untranslated(self) -> &'static str {
         match self {
 % for name in order.values():
-            %if any(name.startswith(prefix + "__") for prefix in ALTCOIN_PREFIXES):
+<%
+            value = en_data.get(name, '""')
+            layouts_dict = value if isinstance(value, dict) else None
+            universal_fw = any(name.startswith(prefix + "__") for prefix in ALTCOIN_PREFIXES)
+%>\
+%if layouts_dict is not None:
+    % for layout_name, layout_value in layouts_dict.items():
+        %if universal_fw:
             #[cfg(feature = "universal_fw")]
-            %endif
-            Self::${name} => ${re.sub(r'\\u([0-9a-f]{4})', r'\\u{\g<1>}', json.dumps(en_data.get(name, '""')))},
+        %endif
+            #[cfg(feature = "${f"layout_{layout_name.lower()}"}")]
+            Self::${name} => ${encode_str(layout_value)},
+    % endfor
+%else:
+    %if universal_fw:
+            #[cfg(feature = "universal_fw")]
+    %endif
+            Self::${name} => ${encode_str(value)},
+%endif
 % endfor
         }
     }

--- a/core/mocks/trezortranslate_keys.pyi.mako
+++ b/core/mocks/trezortranslate_keys.pyi.mako
@@ -9,7 +9,12 @@ en_data = json.loads(en_file.read_text())["translations"]
 
 %>\
 class TR:
-% for name, text in sorted(en_data.items()):
-    ${name}: str = ${json.dumps(text)}
+% for name, value in sorted(en_data.items()):
+<%
+    if isinstance(value, dict):
+        # For simplicity, use the first model's text for the stubs.
+        value, *_ = value.values()
+%>\
+    ${name}: str = ${json.dumps(value)}
 % endfor
 

--- a/core/translations/cli.py
+++ b/core/translations/cli.py
@@ -124,14 +124,8 @@ class TranslationsDir:
     def _lang_path(self, lang: str) -> Path:
         return self.path / f"{lang}.json"
 
-    def load_lang(self, lang: str, model_groups: bool = True) -> translations.JsonDef:
-        json_def = json.loads(self._lang_path(lang).read_text())
-        # special-case for T2B1 and T3B1, so that we keep the info in one place instead
-        # of duplicating it in two entries, risking a desync
-        if model_groups and (fonts_safe3 := json_def.get("fonts", {}).get("##Safe3")) is not None:
-            json_def["fonts"]["T2B1"] = fonts_safe3
-            json_def["fonts"]["T3B1"] = fonts_safe3
-        return json_def
+    def load_lang(self, lang: str) -> translations.JsonDef:
+        return json.loads(self._lang_path(lang).read_text())
 
     def save_lang(self, lang: str, data: translations.JsonDef) -> None:
         self._lang_path(lang).write_text(
@@ -150,7 +144,7 @@ class TranslationsDir:
     def update_version_from_h(self, check: bool = False) -> VersionTuple:
         version = _version_from_version_h()
         for lang in self.all_languages():
-            blob_json = self.load_lang(lang, model_groups=False)
+            blob_json = self.load_lang(lang)
             blob_version = translations.version_from_json(
                 blob_json["header"]["version"]
             )

--- a/core/translations/cs.json
+++ b/core/translations/cs.json
@@ -1,6 +1,6 @@
 {
   "fonts": {
-    "##Safe3": {
+    "Caesar": {
       "1_FONT_NORMAL": "font_pixeloperator_regular_8_cs.json",
       "2_FONT_BOLD": "font_pixeloperator_bold_8_cs.json",
       "3_FONT_MONO": "font_pixeloperatormono_regular_8_cs.json",
@@ -10,7 +10,7 @@
       "7_FONT_BOLD_UPPER": "font_pixeloperator_bold_8_upper_cs.json",
       "8_FONT_SUB": null
     },
-    "T2T1": {
+    "Bolt": {
       "1_FONT_NORMAL": "font_tthoves_regular_21_cs.json",
       "2_FONT_BOLD": null,
       "3_FONT_MONO": "font_robotomono_medium_20_cs.json",
@@ -20,7 +20,7 @@
       "7_FONT_BOLD_UPPER": "font_tthoves_bold_17_upper_cs.json",
       "8_FONT_SUB": null
     },
-    "T3T1": {
+    "Delizia": {
       "1_FONT_NORMAL": "font_ttsatoshi_demibold_21_cs.json",
       "2_FONT_BOLD": "font_ttsatoshi_demibold_21_cs.json",
       "3_FONT_MONO": "font_robotomono_medium_21_cs.json",
@@ -30,7 +30,7 @@
       "7_FONT_BOLD_UPPER": null,
       "8_FONT_SUB": "font_ttsatoshi_demibold_18_cs.json"
     },
-    "T3W1": {
+    "Eckhart": {
       "1_FONT_NORMAL": "font_ttsatoshi_demibold_21_cs.json",
       "2_FONT_BOLD": "font_ttsatoshi_demibold_21_cs.json",
       "3_FONT_MONO": "font_robotomono_medium_21_cs.json",

--- a/core/translations/cs.json
+++ b/core/translations/cs.json
@@ -1,15 +1,5 @@
 {
   "fonts": {
-    "Caesar": {
-      "1_FONT_NORMAL": "font_pixeloperator_regular_8_cs.json",
-      "2_FONT_BOLD": "font_pixeloperator_bold_8_cs.json",
-      "3_FONT_MONO": "font_pixeloperatormono_regular_8_cs.json",
-      "4_FONT_BIG": "font_unifont_regular_16_cs.json",
-      "5_FONT_DEMIBOLD": "font_unifont_bold_16_cs.json",
-      "6_FONT_NORMAL_UPPER": "font_pixeloperator_regular_8_upper_cs.json",
-      "7_FONT_BOLD_UPPER": "font_pixeloperator_bold_8_upper_cs.json",
-      "8_FONT_SUB": null
-    },
     "Bolt": {
       "1_FONT_NORMAL": "font_tthoves_regular_21_cs.json",
       "2_FONT_BOLD": null,
@@ -18,6 +8,16 @@
       "5_FONT_DEMIBOLD": "font_tthoves_demibold_21_cs.json",
       "6_FONT_NORMAL_UPPER": null,
       "7_FONT_BOLD_UPPER": "font_tthoves_bold_17_upper_cs.json",
+      "8_FONT_SUB": null
+    },
+    "Caesar": {
+      "1_FONT_NORMAL": "font_pixeloperator_regular_8_cs.json",
+      "2_FONT_BOLD": "font_pixeloperator_bold_8_cs.json",
+      "3_FONT_MONO": "font_pixeloperatormono_regular_8_cs.json",
+      "4_FONT_BIG": "font_unifont_regular_16_cs.json",
+      "5_FONT_DEMIBOLD": "font_unifont_bold_16_cs.json",
+      "6_FONT_NORMAL_UPPER": "font_pixeloperator_regular_8_upper_cs.json",
+      "7_FONT_BOLD_UPPER": "font_pixeloperator_bold_8_upper_cs.json",
       "8_FONT_SUB": null
     },
     "Delizia": {

--- a/core/translations/de.json
+++ b/core/translations/de.json
@@ -1,15 +1,5 @@
 {
   "fonts": {
-    "Caesar": {
-      "1_FONT_NORMAL": "font_pixeloperator_regular_8_de.json",
-      "2_FONT_BOLD": "font_pixeloperator_bold_8_de.json",
-      "3_FONT_MONO": "font_pixeloperatormono_regular_8_de.json",
-      "4_FONT_BIG": "font_unifont_regular_16_de.json",
-      "5_FONT_DEMIBOLD": "font_unifont_bold_16_de.json",
-      "6_FONT_NORMAL_UPPER": "font_pixeloperator_regular_8_upper_de.json",
-      "7_FONT_BOLD_UPPER": "font_pixeloperator_bold_8_upper_de.json",
-      "8_FONT_SUB": null
-    },
     "Bolt": {
       "1_FONT_NORMAL": "font_tthoves_regular_21_de.json",
       "2_FONT_BOLD": null,
@@ -18,6 +8,16 @@
       "5_FONT_DEMIBOLD": "font_tthoves_demibold_21_de.json",
       "6_FONT_NORMAL_UPPER": null,
       "7_FONT_BOLD_UPPER": "font_tthoves_bold_17_upper_de.json",
+      "8_FONT_SUB": null
+    },
+    "Caesar": {
+      "1_FONT_NORMAL": "font_pixeloperator_regular_8_de.json",
+      "2_FONT_BOLD": "font_pixeloperator_bold_8_de.json",
+      "3_FONT_MONO": "font_pixeloperatormono_regular_8_de.json",
+      "4_FONT_BIG": "font_unifont_regular_16_de.json",
+      "5_FONT_DEMIBOLD": "font_unifont_bold_16_de.json",
+      "6_FONT_NORMAL_UPPER": "font_pixeloperator_regular_8_upper_de.json",
+      "7_FONT_BOLD_UPPER": "font_pixeloperator_bold_8_upper_de.json",
       "8_FONT_SUB": null
     },
     "Delizia": {

--- a/core/translations/de.json
+++ b/core/translations/de.json
@@ -1,6 +1,6 @@
 {
   "fonts": {
-    "##Safe3": {
+    "Caesar": {
       "1_FONT_NORMAL": "font_pixeloperator_regular_8_de.json",
       "2_FONT_BOLD": "font_pixeloperator_bold_8_de.json",
       "3_FONT_MONO": "font_pixeloperatormono_regular_8_de.json",
@@ -10,7 +10,7 @@
       "7_FONT_BOLD_UPPER": "font_pixeloperator_bold_8_upper_de.json",
       "8_FONT_SUB": null
     },
-    "T2T1": {
+    "Bolt": {
       "1_FONT_NORMAL": "font_tthoves_regular_21_de.json",
       "2_FONT_BOLD": null,
       "3_FONT_MONO": "font_robotomono_medium_20_de.json",
@@ -20,7 +20,7 @@
       "7_FONT_BOLD_UPPER": "font_tthoves_bold_17_upper_de.json",
       "8_FONT_SUB": null
     },
-    "T3T1": {
+    "Delizia": {
       "1_FONT_NORMAL": "font_ttsatoshi_demibold_21_de.json",
       "2_FONT_BOLD": "font_ttsatoshi_demibold_21_de.json",
       "3_FONT_MONO": "font_robotomono_medium_21_de.json",
@@ -30,7 +30,7 @@
       "7_FONT_BOLD_UPPER": null,
       "8_FONT_SUB": "font_ttsatoshi_demibold_18_de.json"
     },
-    "T3W1": {
+    "Eckhart": {
       "1_FONT_NORMAL": "font_ttsatoshi_demibold_21_de.json",
       "2_FONT_BOLD": "font_ttsatoshi_demibold_21_de.json",
       "3_FONT_MONO": "font_robotomono_medium_21_de.json",

--- a/core/translations/es.json
+++ b/core/translations/es.json
@@ -1,6 +1,6 @@
 {
   "fonts": {
-    "##Safe3": {
+    "Caesar": {
       "1_FONT_NORMAL": "font_pixeloperator_regular_8_es.json",
       "2_FONT_BOLD": "font_pixeloperator_bold_8_es.json",
       "3_FONT_MONO": "font_pixeloperatormono_regular_8_es.json",
@@ -10,7 +10,7 @@
       "7_FONT_BOLD_UPPER": "font_pixeloperator_bold_8_upper_es.json",
       "8_FONT_SUB": null
     },
-    "T2T1": {
+    "Bolt": {
       "1_FONT_NORMAL": "font_tthoves_regular_21_es.json",
       "2_FONT_BOLD": null,
       "3_FONT_MONO": "font_robotomono_medium_20_es.json",
@@ -20,7 +20,7 @@
       "7_FONT_BOLD_UPPER": "font_tthoves_bold_17_upper_es.json",
       "8_FONT_SUB": null
     },
-    "T3T1": {
+    "Delizia": {
       "1_FONT_NORMAL": "font_ttsatoshi_demibold_21_es.json",
       "2_FONT_BOLD": "font_ttsatoshi_demibold_21_es.json",
       "3_FONT_MONO": "font_robotomono_medium_21_es.json",
@@ -30,7 +30,7 @@
       "7_FONT_BOLD_UPPER": null,
       "8_FONT_SUB": "font_ttsatoshi_demibold_18_es.json"
     },
-    "T3W1": {
+    "Eckhart": {
       "1_FONT_NORMAL": "font_ttsatoshi_demibold_21_es.json",
       "2_FONT_BOLD": "font_ttsatoshi_demibold_21_es.json",
       "3_FONT_MONO": "font_robotomono_medium_21_es.json",

--- a/core/translations/es.json
+++ b/core/translations/es.json
@@ -1,15 +1,5 @@
 {
   "fonts": {
-    "Caesar": {
-      "1_FONT_NORMAL": "font_pixeloperator_regular_8_es.json",
-      "2_FONT_BOLD": "font_pixeloperator_bold_8_es.json",
-      "3_FONT_MONO": "font_pixeloperatormono_regular_8_es.json",
-      "4_FONT_BIG": "font_unifont_regular_16_es.json",
-      "5_FONT_DEMIBOLD": "font_unifont_bold_16_es.json",
-      "6_FONT_NORMAL_UPPER": "font_pixeloperator_regular_8_upper_es.json",
-      "7_FONT_BOLD_UPPER": "font_pixeloperator_bold_8_upper_es.json",
-      "8_FONT_SUB": null
-    },
     "Bolt": {
       "1_FONT_NORMAL": "font_tthoves_regular_21_es.json",
       "2_FONT_BOLD": null,
@@ -18,6 +8,16 @@
       "5_FONT_DEMIBOLD": "font_tthoves_demibold_21_es.json",
       "6_FONT_NORMAL_UPPER": null,
       "7_FONT_BOLD_UPPER": "font_tthoves_bold_17_upper_es.json",
+      "8_FONT_SUB": null
+    },
+    "Caesar": {
+      "1_FONT_NORMAL": "font_pixeloperator_regular_8_es.json",
+      "2_FONT_BOLD": "font_pixeloperator_bold_8_es.json",
+      "3_FONT_MONO": "font_pixeloperatormono_regular_8_es.json",
+      "4_FONT_BIG": "font_unifont_regular_16_es.json",
+      "5_FONT_DEMIBOLD": "font_unifont_bold_16_es.json",
+      "6_FONT_NORMAL_UPPER": "font_pixeloperator_regular_8_upper_es.json",
+      "7_FONT_BOLD_UPPER": "font_pixeloperator_bold_8_upper_es.json",
       "8_FONT_SUB": null
     },
     "Delizia": {

--- a/core/translations/fr.json
+++ b/core/translations/fr.json
@@ -1,15 +1,5 @@
 {
   "fonts": {
-    "Caesar": {
-      "1_FONT_NORMAL": "font_pixeloperator_regular_8_fr.json",
-      "2_FONT_BOLD": "font_pixeloperator_bold_8_fr.json",
-      "3_FONT_MONO": "font_pixeloperatormono_regular_8_fr.json",
-      "4_FONT_BIG": "font_unifont_regular_16_fr.json",
-      "5_FONT_DEMIBOLD": "font_unifont_bold_16_fr.json",
-      "6_FONT_NORMAL_UPPER": "font_pixeloperator_regular_8_upper_fr.json",
-      "7_FONT_BOLD_UPPER": "font_pixeloperator_bold_8_upper_fr.json",
-      "8_FONT_SUB": null
-    },
     "Bolt": {
       "1_FONT_NORMAL": "font_tthoves_regular_21_fr.json",
       "2_FONT_BOLD": null,
@@ -18,6 +8,16 @@
       "5_FONT_DEMIBOLD": "font_tthoves_demibold_21_fr.json",
       "6_FONT_NORMAL_UPPER": null,
       "7_FONT_BOLD_UPPER": "font_tthoves_bold_17_upper_fr.json",
+      "8_FONT_SUB": null
+    },
+    "Caesar": {
+      "1_FONT_NORMAL": "font_pixeloperator_regular_8_fr.json",
+      "2_FONT_BOLD": "font_pixeloperator_bold_8_fr.json",
+      "3_FONT_MONO": "font_pixeloperatormono_regular_8_fr.json",
+      "4_FONT_BIG": "font_unifont_regular_16_fr.json",
+      "5_FONT_DEMIBOLD": "font_unifont_bold_16_fr.json",
+      "6_FONT_NORMAL_UPPER": "font_pixeloperator_regular_8_upper_fr.json",
+      "7_FONT_BOLD_UPPER": "font_pixeloperator_bold_8_upper_fr.json",
       "8_FONT_SUB": null
     },
     "Delizia": {

--- a/core/translations/fr.json
+++ b/core/translations/fr.json
@@ -1,6 +1,6 @@
 {
   "fonts": {
-    "##Safe3": {
+    "Caesar": {
       "1_FONT_NORMAL": "font_pixeloperator_regular_8_fr.json",
       "2_FONT_BOLD": "font_pixeloperator_bold_8_fr.json",
       "3_FONT_MONO": "font_pixeloperatormono_regular_8_fr.json",
@@ -10,7 +10,7 @@
       "7_FONT_BOLD_UPPER": "font_pixeloperator_bold_8_upper_fr.json",
       "8_FONT_SUB": null
     },
-    "T2T1": {
+    "Bolt": {
       "1_FONT_NORMAL": "font_tthoves_regular_21_fr.json",
       "2_FONT_BOLD": null,
       "3_FONT_MONO": "font_robotomono_medium_20_fr.json",
@@ -20,7 +20,7 @@
       "7_FONT_BOLD_UPPER": "font_tthoves_bold_17_upper_fr.json",
       "8_FONT_SUB": null
     },
-    "T3T1": {
+    "Delizia": {
       "1_FONT_NORMAL": "font_ttsatoshi_demibold_21_fr.json",
       "2_FONT_BOLD": "font_ttsatoshi_demibold_21_fr.json",
       "3_FONT_MONO": "font_robotomono_medium_21_fr.json",
@@ -30,7 +30,7 @@
       "7_FONT_BOLD_UPPER": null,
       "8_FONT_SUB": "font_ttsatoshi_demibold_18_fr.json"
     },
-    "T3W1": {
+    "Eckhart": {
       "1_FONT_NORMAL": "font_ttsatoshi_demibold_21_fr.json",
       "2_FONT_BOLD": "font_ttsatoshi_demibold_21_fr.json",
       "3_FONT_MONO": "font_robotomono_medium_21_fr.json",

--- a/core/translations/it.json
+++ b/core/translations/it.json
@@ -1,15 +1,5 @@
 {
   "fonts": {
-    "Caesar": {
-      "1_FONT_NORMAL": "font_pixeloperator_regular_8_it.json",
-      "2_FONT_BOLD": "font_pixeloperator_bold_8_it.json",
-      "3_FONT_MONO": "font_pixeloperatormono_regular_8_it.json",
-      "4_FONT_BIG": "font_unifont_regular_16_it.json",
-      "5_FONT_DEMIBOLD": "font_unifont_bold_16_it.json",
-      "6_FONT_NORMAL_UPPER": "font_pixeloperator_regular_8_upper_it.json",
-      "7_FONT_BOLD_UPPER": "font_pixeloperator_bold_8_upper_it.json",
-      "8_FONT_SUB": null
-    },
     "Bolt": {
       "1_FONT_NORMAL": "font_tthoves_regular_21_it.json",
       "2_FONT_BOLD": null,
@@ -18,6 +8,16 @@
       "5_FONT_DEMIBOLD": "font_tthoves_demibold_21_it.json",
       "6_FONT_NORMAL_UPPER": null,
       "7_FONT_BOLD_UPPER": "font_tthoves_bold_17_upper_it.json",
+      "8_FONT_SUB": null
+    },
+    "Caesar": {
+      "1_FONT_NORMAL": "font_pixeloperator_regular_8_it.json",
+      "2_FONT_BOLD": "font_pixeloperator_bold_8_it.json",
+      "3_FONT_MONO": "font_pixeloperatormono_regular_8_it.json",
+      "4_FONT_BIG": "font_unifont_regular_16_it.json",
+      "5_FONT_DEMIBOLD": "font_unifont_bold_16_it.json",
+      "6_FONT_NORMAL_UPPER": "font_pixeloperator_regular_8_upper_it.json",
+      "7_FONT_BOLD_UPPER": "font_pixeloperator_bold_8_upper_it.json",
       "8_FONT_SUB": null
     },
     "Delizia": {

--- a/core/translations/it.json
+++ b/core/translations/it.json
@@ -1,6 +1,6 @@
 {
   "fonts": {
-    "##Safe3": {
+    "Caesar": {
       "1_FONT_NORMAL": "font_pixeloperator_regular_8_it.json",
       "2_FONT_BOLD": "font_pixeloperator_bold_8_it.json",
       "3_FONT_MONO": "font_pixeloperatormono_regular_8_it.json",
@@ -10,7 +10,7 @@
       "7_FONT_BOLD_UPPER": "font_pixeloperator_bold_8_upper_it.json",
       "8_FONT_SUB": null
     },
-    "T2T1": {
+    "Bolt": {
       "1_FONT_NORMAL": "font_tthoves_regular_21_it.json",
       "2_FONT_BOLD": null,
       "3_FONT_MONO": "font_robotomono_medium_20_it.json",
@@ -20,7 +20,7 @@
       "7_FONT_BOLD_UPPER": "font_tthoves_bold_17_upper_it.json",
       "8_FONT_SUB": null
     },
-    "T3T1": {
+    "Delizia": {
       "1_FONT_NORMAL": "font_ttsatoshi_demibold_21_it.json",
       "2_FONT_BOLD": "font_ttsatoshi_demibold_21_it.json",
       "3_FONT_MONO": "font_robotomono_medium_21_it.json",
@@ -30,7 +30,7 @@
       "7_FONT_BOLD_UPPER": null,
       "8_FONT_SUB": "font_ttsatoshi_demibold_18_it.json"
     },
-    "T3W1": {
+    "Eckhart": {
       "1_FONT_NORMAL": "font_ttsatoshi_demibold_21_it.json",
       "2_FONT_BOLD": "font_ttsatoshi_demibold_21_it.json",
       "3_FONT_MONO": "font_robotomono_medium_21_it.json",

--- a/core/translations/pt.json
+++ b/core/translations/pt.json
@@ -1,15 +1,5 @@
 {
   "fonts": {
-    "Caesar": {
-      "1_FONT_NORMAL": "font_pixeloperator_regular_8_pt.json",
-      "2_FONT_BOLD": "font_pixeloperator_bold_8_pt.json",
-      "3_FONT_MONO": "font_pixeloperatormono_regular_8_pt.json",
-      "4_FONT_BIG": "font_unifont_regular_16_pt.json",
-      "5_FONT_DEMIBOLD": "font_unifont_bold_16_pt.json",
-      "6_FONT_NORMAL_UPPER": "font_pixeloperator_regular_8_upper_pt.json",
-      "7_FONT_BOLD_UPPER": "font_pixeloperator_bold_8_upper_pt.json",
-      "8_FONT_SUB": null
-    },
     "Bolt": {
       "1_FONT_NORMAL": "font_tthoves_regular_21_pt.json",
       "2_FONT_BOLD": null,
@@ -18,6 +8,16 @@
       "5_FONT_DEMIBOLD": "font_tthoves_demibold_21_pt.json",
       "6_FONT_NORMAL_UPPER": null,
       "7_FONT_BOLD_UPPER": "font_tthoves_bold_17_upper_pt.json",
+      "8_FONT_SUB": null
+    },
+    "Caesar": {
+      "1_FONT_NORMAL": "font_pixeloperator_regular_8_pt.json",
+      "2_FONT_BOLD": "font_pixeloperator_bold_8_pt.json",
+      "3_FONT_MONO": "font_pixeloperatormono_regular_8_pt.json",
+      "4_FONT_BIG": "font_unifont_regular_16_pt.json",
+      "5_FONT_DEMIBOLD": "font_unifont_bold_16_pt.json",
+      "6_FONT_NORMAL_UPPER": "font_pixeloperator_regular_8_upper_pt.json",
+      "7_FONT_BOLD_UPPER": "font_pixeloperator_bold_8_upper_pt.json",
       "8_FONT_SUB": null
     },
     "Delizia": {

--- a/core/translations/pt.json
+++ b/core/translations/pt.json
@@ -1,6 +1,6 @@
 {
   "fonts": {
-    "##Safe3": {
+    "Caesar": {
       "1_FONT_NORMAL": "font_pixeloperator_regular_8_pt.json",
       "2_FONT_BOLD": "font_pixeloperator_bold_8_pt.json",
       "3_FONT_MONO": "font_pixeloperatormono_regular_8_pt.json",
@@ -10,7 +10,7 @@
       "7_FONT_BOLD_UPPER": "font_pixeloperator_bold_8_upper_pt.json",
       "8_FONT_SUB": null
     },
-    "T2T1": {
+    "Bolt": {
       "1_FONT_NORMAL": "font_tthoves_regular_21_pt.json",
       "2_FONT_BOLD": null,
       "3_FONT_MONO": "font_robotomono_medium_20_pt.json",
@@ -20,7 +20,7 @@
       "7_FONT_BOLD_UPPER": "font_tthoves_bold_17_upper_pt.json",
       "8_FONT_SUB": null
     },
-    "T3T1": {
+    "Delizia": {
       "1_FONT_NORMAL": "font_ttsatoshi_demibold_21_pt.json",
       "2_FONT_BOLD": "font_ttsatoshi_demibold_21_pt.json",
       "3_FONT_MONO": "font_robotomono_medium_21_pt.json",
@@ -30,7 +30,7 @@
       "7_FONT_BOLD_UPPER": null,
       "8_FONT_SUB": "font_ttsatoshi_demibold_18_pt.json"
     },
-    "T3W1": {
+    "Eckhart": {
       "1_FONT_NORMAL": "font_ttsatoshi_demibold_21_pt.json",
       "2_FONT_BOLD": "font_ttsatoshi_demibold_21_pt.json",
       "3_FONT_MONO": "font_robotomono_medium_21_pt.json",

--- a/core/translations/tr.json
+++ b/core/translations/tr.json
@@ -1,15 +1,5 @@
 {
   "fonts": {
-    "Caesar": {
-      "1_FONT_NORMAL": "font_pixeloperator_regular_8_tr.json",
-      "2_FONT_BOLD": "font_pixeloperator_bold_8_tr.json",
-      "3_FONT_MONO": "font_pixeloperatormono_regular_8_tr.json",
-      "4_FONT_BIG": "font_unifont_regular_16_tr.json",
-      "5_FONT_DEMIBOLD": "font_unifont_bold_16_tr.json",
-      "6_FONT_NORMAL_UPPER": "font_pixeloperator_regular_8_upper_tr.json",
-      "7_FONT_BOLD_UPPER": "font_pixeloperator_bold_8_upper_tr.json",
-      "8_FONT_SUB": null
-    },
     "Bolt": {
       "1_FONT_NORMAL": "font_tthoves_regular_21_tr.json",
       "2_FONT_BOLD": null,
@@ -18,6 +8,16 @@
       "5_FONT_DEMIBOLD": "font_tthoves_demibold_21_tr.json",
       "6_FONT_NORMAL_UPPER": null,
       "7_FONT_BOLD_UPPER": "font_tthoves_bold_17_upper_tr.json",
+      "8_FONT_SUB": null
+    },
+    "Caesar": {
+      "1_FONT_NORMAL": "font_pixeloperator_regular_8_tr.json",
+      "2_FONT_BOLD": "font_pixeloperator_bold_8_tr.json",
+      "3_FONT_MONO": "font_pixeloperatormono_regular_8_tr.json",
+      "4_FONT_BIG": "font_unifont_regular_16_tr.json",
+      "5_FONT_DEMIBOLD": "font_unifont_bold_16_tr.json",
+      "6_FONT_NORMAL_UPPER": "font_pixeloperator_regular_8_upper_tr.json",
+      "7_FONT_BOLD_UPPER": "font_pixeloperator_bold_8_upper_tr.json",
       "8_FONT_SUB": null
     },
     "Delizia": {

--- a/core/translations/tr.json
+++ b/core/translations/tr.json
@@ -1,6 +1,6 @@
 {
   "fonts": {
-    "##Safe3": {
+    "Caesar": {
       "1_FONT_NORMAL": "font_pixeloperator_regular_8_tr.json",
       "2_FONT_BOLD": "font_pixeloperator_bold_8_tr.json",
       "3_FONT_MONO": "font_pixeloperatormono_regular_8_tr.json",
@@ -10,7 +10,7 @@
       "7_FONT_BOLD_UPPER": "font_pixeloperator_bold_8_upper_tr.json",
       "8_FONT_SUB": null
     },
-    "T2T1": {
+    "Bolt": {
       "1_FONT_NORMAL": "font_tthoves_regular_21_tr.json",
       "2_FONT_BOLD": null,
       "3_FONT_MONO": "font_robotomono_medium_20_tr.json",
@@ -20,7 +20,7 @@
       "7_FONT_BOLD_UPPER": "font_tthoves_bold_17_upper_tr.json",
       "8_FONT_SUB": null
     },
-    "T3T1": {
+    "Delizia": {
       "1_FONT_NORMAL": "font_ttsatoshi_demibold_21_tr.json",
       "2_FONT_BOLD": "font_ttsatoshi_demibold_21_tr.json",
       "3_FONT_MONO": "font_robotomono_medium_21_tr.json",
@@ -30,7 +30,7 @@
       "7_FONT_BOLD_UPPER": null,
       "8_FONT_SUB": "font_ttsatoshi_demibold_18_tr.json"
     },
-    "T3W1": {
+    "Eckhart": {
       "1_FONT_NORMAL": "font_ttsatoshi_demibold_21_tr.json",
       "2_FONT_BOLD": "font_ttsatoshi_demibold_21_tr.json",
       "3_FONT_MONO": "font_robotomono_medium_21_tr.json",

--- a/python/src/trezorlib/_internal/translations.py
+++ b/python/src/trezorlib/_internal/translations.py
@@ -313,12 +313,12 @@ def blob_from_defs(
 
     translations = TranslatedStrings.from_items(translations_ordered)
 
-    if model.internal_name not in lang_data["fonts"]:
+    if layout_type.name not in lang_data["fonts"]:
         raise ValueError(
-            f"Model {model.internal_name} not found in header for {json_header['language']} v{json_header['version']}"
+            f"Layout {layout_type.name} not found in header for {json_header['language']} v{json_header['version']}"
         )
 
-    model_fonts = lang_data["fonts"][model.internal_name]
+    model_fonts = lang_data["fonts"][layout_type.name]
     fonts = FontsTable.from_dir(model_fonts, fonts_dir)
 
     translations_bytes = translations.build()

--- a/python/src/trezorlib/debuglink.py
+++ b/python/src/trezorlib/debuglink.py
@@ -80,6 +80,7 @@ class LayoutType(Enum):
     Bolt = auto()
     Caesar = auto()
     Delizia = auto()
+    Eckhart = auto()
 
     @classmethod
     def from_model(cls, model: models.TrezorModel) -> "LayoutType":
@@ -89,6 +90,8 @@ class LayoutType(Enum):
             return cls.Caesar
         if model in (models.T3T1,):
             return cls.Delizia
+        if model in (models.T3W1,):
+            return cls.Eckhart
         if model in (models.T1B1,):
             return cls.T1
         raise ValueError(f"Unknown model: {model}")


### PR DESCRIPTION
Following #4489.

Also, use layout names for translation font keys.
