### PR TITLE
minor t3w1/ble related fixes

### DIFF
--- a/core/embed/io/nrf/stm32u5/nrf.c
+++ b/core/embed/io/nrf/stm32u5/nrf.c
@@ -315,6 +315,7 @@ void nrf_deinit(void) {
 
   nrf_stop();
 
+  NVIC_DisableIRQ(GPDMA1_Channel1_IRQn);
   NVIC_DisableIRQ(GPDMA1_Channel2_IRQn);
   NVIC_DisableIRQ(SPI1_IRQn);
 

--- a/core/embed/upymod/modtrezorio/modtrezorio-ble.h
+++ b/core/embed/upymod/modtrezorio/modtrezorio-ble.h
@@ -90,7 +90,7 @@ STATIC mp_obj_t mod_trezorio_BLE_write(mp_obj_t msg) {
 STATIC MP_DEFINE_CONST_FUN_OBJ_1(mod_trezorio_BLE_write_obj,
                                  mod_trezorio_BLE_write);
 
-/// def read(buf: bytes, offset: int = 0) -> int
+/// def read(buf: bytearray, offset: int = 0) -> int:
 ///     """
 ///     Reads message using BLE (device).
 ///     """
@@ -105,6 +105,10 @@ STATIC mp_obj_t mod_trezorio_BLE_read(size_t n_args, const mp_obj_t *args) {
 
   if (offset < 0) {
     mp_raise_ValueError("Negative offset not allowed");
+  }
+
+  if (offset > buf.len) {
+    mp_raise_ValueError("Offset out of bounds");
   }
 
   uint32_t buffer_space = buf.len - offset;
@@ -216,6 +220,12 @@ STATIC mp_obj_t mod_trezorio_BLE_peer_count(void) {
 STATIC MP_DEFINE_CONST_FUN_OBJ_0(mod_trezorio_BLE_peer_count_obj,
                                  mod_trezorio_BLE_peer_count);
 
+/// RX_PACKET_LEN: int
+/// """Length of one BLE RX packet."""
+
+/// TX_PACKET_LEN: int
+/// """Length of one BLE TX packet."""
+
 STATIC const mp_rom_map_elem_t mod_trezorio_BLE_globals_table[] = {
     {MP_ROM_QSTR(MP_QSTR___name__), MP_ROM_QSTR(MP_QSTR_ble)},
     // {MP_ROM_QSTR(MP_QSTR_update_init),
@@ -236,6 +246,8 @@ STATIC const mp_rom_map_elem_t mod_trezorio_BLE_globals_table[] = {
      MP_ROM_PTR(&mod_trezorio_BLE_disconnect_obj)},
     {MP_ROM_QSTR(MP_QSTR_peer_count),
      MP_ROM_PTR(&mod_trezorio_BLE_peer_count_obj)},
+    {MP_ROM_QSTR(MP_QSTR_RX_PACKET_LEN), MP_ROM_INT(BLE_RX_PACKET_SIZE)},
+    {MP_ROM_QSTR(MP_QSTR_TX_PACKET_LEN), MP_ROM_INT(BLE_TX_PACKET_SIZE)},
 };
 STATIC MP_DEFINE_CONST_DICT(mod_trezorio_BLE_globals,
                             mod_trezorio_BLE_globals_table);

--- a/core/embed/upymod/modtrezorio/modtrezorio-hid.h
+++ b/core/embed/upymod/modtrezorio/modtrezorio-hid.h
@@ -198,8 +198,11 @@ STATIC mp_obj_t mod_trezorio_HID_write_blocking(mp_obj_t self, mp_obj_t msg,
 STATIC MP_DEFINE_CONST_FUN_OBJ_3(mod_trezorio_HID_write_blocking_obj,
                                  mod_trezorio_HID_write_blocking);
 
-/// PACKET_LEN: ClassVar[int]
-/// """Length of one USB packet."""
+/// RX_PACKET_LEN: ClassVar[int]
+/// """Length of one USB RX packet."""
+
+/// TX_PACKET_LEN: ClassVar[int]
+/// """Length of one USB TX packet."""
 
 STATIC const mp_rom_map_elem_t mod_trezorio_HID_locals_dict_table[] = {
     {MP_ROM_QSTR(MP_QSTR_iface_num),
@@ -208,7 +211,8 @@ STATIC const mp_rom_map_elem_t mod_trezorio_HID_locals_dict_table[] = {
     {MP_ROM_QSTR(MP_QSTR_read), MP_ROM_PTR(&mod_trezorio_HID_read_obj)},
     {MP_ROM_QSTR(MP_QSTR_write_blocking),
      MP_ROM_PTR(&mod_trezorio_HID_write_blocking_obj)},
-    {MP_ROM_QSTR(MP_QSTR_PACKET_LEN), MP_ROM_INT(USB_PACKET_LEN)},
+    {MP_ROM_QSTR(MP_QSTR_RX_PACKET_LEN), MP_ROM_INT(USB_PACKET_LEN)},
+    {MP_ROM_QSTR(MP_QSTR_TX_PACKET_LEN), MP_ROM_INT(USB_PACKET_LEN)},
 };
 STATIC MP_DEFINE_CONST_DICT(mod_trezorio_HID_locals_dict,
                             mod_trezorio_HID_locals_dict_table);

--- a/core/embed/upymod/modtrezorio/modtrezorio-poll.h
+++ b/core/embed/upymod/modtrezorio/modtrezorio-poll.h
@@ -191,8 +191,7 @@ STATIC mp_obj_t mod_trezorio_poll(mp_obj_t ifaces, mp_obj_t list_ref,
 #ifdef USE_BLE
       else if (iface == BLE_IFACE) {
         if (mode == POLL_READ) {
-          int len = ble_can_read();
-          if (len > 0) {
+          if (ble_can_read()) {
             ret->items[0] = MP_OBJ_NEW_SMALL_INT(i);
             ret->items[1] = MP_OBJ_NEW_SMALL_INT(BLE_RX_PACKET_SIZE);
             return mp_const_true;

--- a/core/embed/upymod/modtrezorio/modtrezorio-webusb.h
+++ b/core/embed/upymod/modtrezorio/modtrezorio-webusb.h
@@ -167,15 +167,19 @@ STATIC mp_obj_t mod_trezorio_WebUSB_read(size_t n_args, const mp_obj_t *args) {
 STATIC MP_DEFINE_CONST_FUN_OBJ_VAR_BETWEEN(mod_trezorio_WebUSB_read_obj, 2, 3,
                                            mod_trezorio_WebUSB_read);
 
-/// PACKET_LEN: ClassVar[int]
-/// """Length of one USB packet."""
+/// RX_PACKET_LEN: ClassVar[int]
+/// """Length of one USB RX packet."""
+
+/// TX_PACKET_LEN: ClassVar[int]
+/// """Length of one USB TX packet."""
 
 STATIC const mp_rom_map_elem_t mod_trezorio_WebUSB_locals_dict_table[] = {
     {MP_ROM_QSTR(MP_QSTR_iface_num),
      MP_ROM_PTR(&mod_trezorio_WebUSB_iface_num_obj)},
     {MP_ROM_QSTR(MP_QSTR_write), MP_ROM_PTR(&mod_trezorio_WebUSB_write_obj)},
     {MP_ROM_QSTR(MP_QSTR_read), MP_ROM_PTR(&mod_trezorio_WebUSB_read_obj)},
-    {MP_ROM_QSTR(MP_QSTR_PACKET_LEN), MP_ROM_INT(USB_PACKET_LEN)},
+    {MP_ROM_QSTR(MP_QSTR_RX_PACKET_LEN), MP_ROM_INT(USB_PACKET_LEN)},
+    {MP_ROM_QSTR(MP_QSTR_TX_PACKET_LEN), MP_ROM_INT(USB_PACKET_LEN)},
 };
 STATIC MP_DEFINE_CONST_DICT(mod_trezorio_WebUSB_locals_dict,
                             mod_trezorio_WebUSB_locals_dict_table);

--- a/core/mocks/generated/trezorio/__init__.pyi
+++ b/core/mocks/generated/trezorio/__init__.pyi
@@ -41,8 +41,10 @@ class HID:
         """
         Sends message using USB HID (device) or UDP (emulator).
         """
-    PACKET_LEN: ClassVar[int]
-    """Length of one USB packet."""
+    RX_PACKET_LEN: ClassVar[int]
+    """Length of one USB RX packet."""
+    TX_PACKET_LEN: ClassVar[int]
+    """Length of one USB TX packet."""
 
 
 # upymod/modtrezorio/modtrezorio-poll.h
@@ -160,8 +162,10 @@ class WebUSB:
         """
         Reads message using USB WebUSB (device) or UDP (emulator).
         """
-    PACKET_LEN: ClassVar[int]
-    """Length of one USB packet."""
+    RX_PACKET_LEN: ClassVar[int]
+    """Length of one USB RX packet."""
+    TX_PACKET_LEN: ClassVar[int]
+    """Length of one USB TX packet."""
 from . import fatfs, haptic, sdcard, ble
 POLL_READ: int  # wait until interface is readable and return read data
 POLL_WRITE: int  # wait until interface is writable

--- a/core/mocks/generated/trezorio/ble.pyi
+++ b/core/mocks/generated/trezorio/ble.pyi
@@ -9,7 +9,7 @@ def write(msg: bytes) -> int:
 
 
 # upymod/modtrezorio/modtrezorio-ble.h
-def read(buf: bytes, offset: int = 0) -> int
+def read(buf: bytearray, offset: int = 0) -> int:
     """
     Reads message using BLE (device).
     """
@@ -55,3 +55,7 @@ def peer_count() -> int:
     """
     Get peer count (number of bonded devices)
     """
+RX_PACKET_LEN: int
+"""Length of one BLE RX packet."""
+TX_PACKET_LEN: int
+"""Length of one BLE TX packet."""


### PR DESCRIPTION
This PR fixes few issues with T3W1 / BLE:

- NRF driver didn't proprely disable one of the interrupts
- wrong code alignment in trezorlib
- adjustments to codec_v1 were made to accommodate the fact that our BLE implementation uses differently sized RX and TX packets