### PR TITLE
Disallow canceling on uncancelable pages on T3B1

### DIFF
--- a/core/.changelog.d/4500.fixed
+++ b/core/.changelog.d/4500.fixed
@@ -1,0 +1,1 @@
+[T3B1] Fix backup failing if middle button is pressed during confirmation.

--- a/core/embed/rust/src/ui/layout_samson/component/button_controller.rs
+++ b/core/embed/rust/src/ui/layout_samson/component/button_controller.rs
@@ -489,7 +489,11 @@ impl Component for ButtonController {
                             } else {
                                 (
                                     ButtonState::OneReleased(b),
-                                    Some(ButtonControllerMsg::Triggered(b.into(), false)),
+                                    match b {
+                                        PhysicalButton::Left => self.left_btn.maybe_trigger(ctx),
+                                        PhysicalButton::Right => self.right_btn.maybe_trigger(ctx),
+                                        _ => None,
+                                    },
                                 )
                             }
                         }

--- a/core/embed/rust/src/ui/layout_samson/component/page.rs
+++ b/core/embed/rust/src/ui/layout_samson/component/page.rs
@@ -179,9 +179,11 @@ where
                         // Clicked BACK. Scroll up.
                         self.go_to_previous_page();
                         self.change_page(ctx);
-                    } else {
+                    } else if self.cancel_btn_details.is_some() {
                         // Clicked CANCEL. Send result.
                         return Some(PageMsg::Cancelled);
+                    } else {
+                        return None;
                     }
                 }
                 ButtonPos::Right => {


### PR DESCRIPTION
This PR fixes an issue that happens when the "middle" button is pressed on a page that should not handle middle or left button presses. If, when releasing the "middle" button (left + right), the left one is the first one to be released, this triggered a left button press which would cancel an otherwise uncancelable page, like this one:

![image](https://github.com/user-attachments/assets/21523603-52b6-4dce-89d6-5053c91d3ce5)

To reproduce the bug (before the fix):
 * `trezorctl device setup`
 * keep confirming ever page until you arrive at the page shown in the screenshot above
 * press the left button and keep it pressed
 * while the left button is pressed, press the right button and keep both pressed
 * release the left button
 * now the process is canceled even though it should not be possible to cancel it

Note: this fix affects both the `ButtonController` and the `ButtonPage`. Normally one of the two would be enough to fix the issue, but I decided to fix it in both places that have knowledge of the missing cancel button. This duplication indicates that there is some redundancy in the logic that could be perhaps refactored.