### PR TITLE
Make button press cancel current hold

### DIFF
--- a/core/.changelog.d/3772.fixed
+++ b/core/.changelog.d/3772.fixed
@@ -1,0 +1,1 @@
+[T3B1] Fix behavior of a button press during "hold to confirm".

--- a/core/embed/rust/src/ui/event/button.rs
+++ b/core/embed/rust/src/ui/event/button.rs
@@ -12,8 +12,10 @@ pub enum ButtonEvent {
     /// Button released up.
     /// ▲ * | * ▲
     ButtonReleased(PhysicalButton),
+
     HoldStarted,
     HoldEnded,
+    HoldCanceled,
 }
 
 impl ButtonEvent {

--- a/core/embed/rust/src/ui/layout_samson/component/hold_to_confirm.rs
+++ b/core/embed/rust/src/ui/layout_samson/component/hold_to_confirm.rs
@@ -105,6 +105,9 @@ impl Component for HoldToConfirm {
                     self.loader.start_shrinking(ctx, Instant::now());
                 }
             }
+            Event::Button(ButtonEvent::HoldCanceled) => {
+                self.loader.shrink_completely(ctx, Instant::now());
+            }
             _ => {}
         };
 

--- a/core/embed/rust/src/ui/layout_samson/component/loader.rs
+++ b/core/embed/rust/src/ui/layout_samson/component/loader.rs
@@ -107,13 +107,13 @@ impl Loader {
         ctx.request_paint();
     }
 
-    pub fn start_shrinking(&mut self, ctx: &mut EventCtx, now: Instant) {
-        let mut anim = Animation::new(
-            display::LOADER_MAX,
-            display::LOADER_MIN,
-            self.shrinking_duration,
-            now,
-        );
+    fn start_shrinking_with_duration(
+        &mut self,
+        ctx: &mut EventCtx,
+        now: Instant,
+        duration: Duration,
+    ) {
+        let mut anim = Animation::new(display::LOADER_MAX, display::LOADER_MIN, duration, now);
         if let State::Growing(growing) = &self.state {
             anim.seek_to_value(display::LOADER_MAX - growing.value(now));
         }
@@ -123,6 +123,14 @@ impl Loader {
         // to request another animation frames, but we should request to get painted
         // after this event pass.
         ctx.request_paint();
+    }
+
+    pub fn start_shrinking(&mut self, ctx: &mut EventCtx, now: Instant) {
+        self.start_shrinking_with_duration(ctx, now, self.shrinking_duration);
+    }
+
+    pub fn shrink_completely(&mut self, ctx: &mut EventCtx, now: Instant) {
+        self.start_shrinking_with_duration(ctx, now, Duration::from_millis(0));
     }
 
     pub fn reset(&mut self) {


### PR DESCRIPTION
On TS3, when holding a button to confirm, pressing the other button now cancels the "hold".

Note: we want to cancel it without an animation rather than with the "shrinking" animation as if the held button was released!