### PR TITLE
fix(core): fix gfx_bitblt initialization

### DIFF
--- a/core/embed/io/display/ltdc_dsi/display_driver.c
+++ b/core/embed/io/display/ltdc_dsi/display_driver.c
@@ -412,6 +412,8 @@ bool display_init(display_content_mode_t mode) {
 
   __HAL_LTDC_ENABLE_IT(&drv->hlcd_ltdc, LTDC_IT_LI | LTDC_IT_FU | LTDC_IT_TE);
 
+  gfx_bitblt_init();
+
   drv->initialized = true;
   return true;
 
@@ -435,6 +437,8 @@ void display_deinit(display_content_mode_t mode) {
   }
 
   GPIO_InitTypeDef GPIO_InitStructure = {0};
+
+  gfx_bitblt_deinit();
 
   NVIC_DisableIRQ(LTDC_IRQn);
   NVIC_DisableIRQ(LTDC_ER_IRQn);

--- a/core/embed/io/display/st-7789/display_driver.c
+++ b/core/embed/io/display/st-7789/display_driver.c
@@ -89,6 +89,8 @@ bool display_init(display_content_mode_t mode) {
 #endif
 #endif
 
+  gfx_bitblt_init();
+
   drv->initialized = true;
   return true;
 }
@@ -109,6 +111,8 @@ void display_deinit(display_content_mode_t mode) {
   NVIC_DisableIRQ(DISPLAY_TE_INTERRUPT_NUM);
 #endif
 #endif
+
+  gfx_bitblt_deinit();
 
   mpu_set_active_fb(NULL, 0);
 

--- a/core/embed/io/display/stm32f429i-disc1/display_driver.c
+++ b/core/embed/io/display/stm32f429i-disc1/display_driver.c
@@ -67,12 +67,16 @@ bool display_init(display_content_mode_t mode) {
     ili9341_init();
   }
 
+  gfx_bitblt_init();
+
   drv->initialized = true;
   return true;
 }
 
 void display_deinit(display_content_mode_t mode) {
   display_driver_t *drv = &g_display_driver;
+
+  gfx_bitblt_deinit();
 
   mpu_set_active_fb(NULL, 0);
 

--- a/core/embed/io/display/unix/display_driver.c
+++ b/core/embed/io/display/unix/display_driver.c
@@ -178,6 +178,9 @@ bool display_init(display_content_mode_t mode) {
 #else
   drv->orientation_angle = 0;
 #endif
+
+  gfx_bitblt_init();
+
   drv->initialized = true;
   return true;
 }
@@ -188,6 +191,8 @@ void display_deinit(display_content_mode_t mode) {
   if (!drv->initialized) {
     return;
   }
+
+  gfx_bitblt_deinit();
 
   SDL_FreeSurface(drv->prev_saved);
   SDL_FreeSurface(drv->buffer);

--- a/core/embed/io/display/vg-2864/display_driver.c
+++ b/core/embed/io/display/vg-2864/display_driver.c
@@ -318,6 +318,8 @@ bool display_init(display_content_mode_t mode) {
     display_init_spi(drv);
   }
 
+  gfx_bitblt_init();
+
   drv->initialized = true;
   return true;
 }
@@ -326,6 +328,8 @@ void display_deinit(display_content_mode_t mode) {
   display_driver_t *drv = &g_display_driver;
 
   mpu_set_active_fb(NULL, 0);
+
+  gfx_bitblt_deinit();
 
   drv->initialized = false;
 }

--- a/core/embed/projects/boardloader/main.c
+++ b/core/embed/projects/boardloader/main.c
@@ -92,7 +92,6 @@ static void drivers_init(void) {
 #ifdef USE_HASH_PROCESSOR
   hash_processor_init();
 #endif
-  gfx_bitblt_init();
   display_init(DISPLAY_RESET_CONTENT);
 #ifdef USE_SD_CARD
   sdcard_init();
@@ -103,7 +102,6 @@ static void drivers_deinit(void) {
 #ifdef FIXED_HW_DEINIT
   // TODO
 #endif
-  gfx_bitblt_deinit();
   display_deinit(DISPLAY_JUMP_BEHAVIOR);
 #ifdef USE_POWERCTL
   powerctl_deinit();

--- a/core/embed/projects/bootloader/main.c
+++ b/core/embed/projects/bootloader/main.c
@@ -98,7 +98,6 @@ static void drivers_init(secbool *touch_initialized) {
 #ifdef USE_HASH_PROCESSOR
   hash_processor_init();
 #endif
-  gfx_bitblt_init();
   display_init(DISPLAY_JUMP_BEHAVIOR);
   unit_properties_init();
 
@@ -138,7 +137,6 @@ static void drivers_deinit(void) {
   button_deinit();
 #endif
 #endif
-  gfx_bitblt_deinit();
   display_deinit(DISPLAY_JUMP_BEHAVIOR);
   ensure_compatible_settings();
 }

--- a/core/embed/projects/kernel/main.c
+++ b/core/embed/projects/kernel/main.c
@@ -116,8 +116,6 @@ void drivers_init() {
   hash_processor_init();
 #endif
 
-  gfx_bitblt_init();
-
   display_init(DISPLAY_JUMP_BEHAVIOR);
 
 #ifdef USE_OEM_KEYS_CHECK


### PR DESCRIPTION
This PR simplifies the initialization of the `gfx_bitblt` module (DMA2D). The `gfx_bitblt` module no longer requires explicit initialization, as it is now automatically initialized along with the display driver.

Additionally, this PR fixes a bug introduced in commit d4cd1a3ac5d2e93751e009741a73d6368c36077b. In rescue mode, DMA2D was deinitialized but not reinitialized before displaying the RSOD screen.