### PR TITLE
fix flashing old display content on model T

### DIFF
--- a/core/embed/io/display/st-7789/display_driver.c
+++ b/core/embed/io/display/st-7789/display_driver.c
@@ -102,11 +102,11 @@ void display_deinit(display_content_mode_t mode) {
     return;
   }
 
-#ifdef FRAMEBUFFER
 #ifndef BOARDLOADER
-  // Ensure that the ready frame buffer is transfered to
+  // Ensure that the ready frame buffer is transferred to
   // the display controller
   display_ensure_refreshed();
+#ifdef FRAMEBUFFER
   // Disable periodical interrupt
   NVIC_DisableIRQ(DISPLAY_TE_INTERRUPT_NUM);
 #endif
@@ -138,13 +138,11 @@ int display_set_backlight(int level) {
     return 0;
   }
 
-#ifdef FRAMEBUFFER
 #ifndef BOARDLOADER
   // if turning on the backlight, wait until the panel is refreshed
   if (backlight_pwm_get() < level && !is_mode_exception()) {
     display_ensure_refreshed();
   }
-#endif
 #endif
 
   return backlight_pwm_set(level);

--- a/core/embed/io/display/st-7789/display_fb.h
+++ b/core/embed/io/display/st-7789/display_fb.h
@@ -29,8 +29,6 @@ void display_fb_init(void);
 // Clears both physical frame buffers
 void display_fb_clear(void);
 
-void display_ensure_refreshed(void);
-
 #endif  // FRAMEBUFFER
 
 #endif  // TREZORHAL_DISPLAY_FB_H

--- a/core/embed/io/display/st-7789/display_internal.h
+++ b/core/embed/io/display/st-7789/display_internal.h
@@ -38,4 +38,6 @@ static inline uint32_t is_mode_exception(void) {
   return (isr_number != 0) && (isr_number != 11);
 }
 
+void display_ensure_refreshed(void);
+
 #endif  // TREZORHAL_DISPLAY_INTERNAL_H


### PR DESCRIPTION
follow up for https://github.com/trezor/trezor-firmware/pull/4492

turns out model T, or rather non-framebuffer models, also need this treatment.