### PR TITLE
fix boot screen background color 

### DIFF
--- a/core/embed/rust/src/ui/layout_bolt/bootloader/mod.rs
+++ b/core/embed/rust/src/ui/layout_bolt/bootloader/mod.rs
@@ -354,7 +354,11 @@ impl BootloaderUI for UIBolt {
         vendor_img: &'static [u8],
         wait: i32,
     ) {
-        let bg_color = if warning { BLD_WARN_COLOR } else { BLD_BG };
+        let bg_color = if warning {
+            BLD_WARN_COLOR
+        } else {
+            WELCOME_COLOR
+        };
 
         display::sync();
 

--- a/core/embed/rust/src/ui/layout_delizia/bootloader/mod.rs
+++ b/core/embed/rust/src/ui/layout_delizia/bootloader/mod.rs
@@ -394,7 +394,11 @@ impl BootloaderUI for UIDelizia {
         vendor_img: &'static [u8],
         wait: i32,
     ) {
-        let bg_color = if warning { BLD_WARN_COLOR } else { BLD_BG };
+        let bg_color = if warning {
+            BLD_WARN_COLOR
+        } else {
+            WELCOME_COLOR
+        };
 
         display::sync();
 


### PR DESCRIPTION
applies to cases when vendor info is shown but no warning is set.



[no changelog]

<!--
For core developers:
- Assign yourself to the PR.
- Set the priority to match the original issue.
- Add the PR to the current sprint.
- If it's a draft PR, mark it as "In Progress."
- If it's a final PR, mark it as "Needs Review."

For external contributors:
- Please open an issue before submitting a PR so we can discuss whether we want to proceed with it.
-->
