### PR TITLE
build: update `editorconfig-checker` to 2.7.2

### DIFF
--- a/shell.nix
+++ b/shell.nix
@@ -120,7 +120,7 @@ stdenvNoCC.mkDerivation ({
     check
     crowdin-cli  # for translations
     curl  # for connect tests
-    editorconfig-checker
+    newNixpkgs.editorconfig-checker
     (if devTools then gcc-arm-embedded-gdbfix else gcc-arm-embedded)
     git
     gitAndTools.git-subrepo


### PR DESCRIPTION
It should help to resolve spurious `unrecognized charset IBM420_rtl` warnings: https://github.com/editorconfig-checker/editorconfig-checker/issues/252

<!--
For core developers:
- Assign yourself to the PR.
- Set the priority to match the original issue.
- Add the PR to the current sprint.
- If it's a draft PR, mark it as "In Progress."
- If it's a final PR, mark it as "Needs Review."

For external contributors:
- Please open an issue before submitting a PR so we can discuss whether we want to proceed with it.
-->

e.g. in CI:
![image](https://github.com/user-attachments/assets/562ba6e2-26de-4bb0-bb6c-93b21fbf2638)

& during pre-push hook:
![image](https://github.com/user-attachments/assets/d07bde5c-d446-44f3-bd0b-0a5500f2f960)

