### PR TITLE
fix(core): explicitly delete keyboard layout

### DIFF
--- a/core/.changelog.d/4537.fixed
+++ b/core/.changelog.d/4537.fixed
@@ -1,0 +1,1 @@
+[T2T1] Fixed a bug resulting in restarting the recovery flow when inputting 33-word mnemonic.

--- a/core/src/trezor/ui/layouts/bolt/recovery.py
+++ b/core/src/trezor/ui/layouts/bolt/recovery.py
@@ -32,21 +32,24 @@ async def request_word(
 ) -> str:
     prompt = TR.recovery__type_word_x_of_y_template.format(word_index + 1, word_count)
     can_go_back = word_index > 0
+
     if is_slip39:
         keyboard = trezorui_api.request_slip39(
             prompt=prompt, prefill_word=prefill_word, can_go_back=can_go_back
         )
-
     else:
         keyboard = trezorui_api.request_bip39(
             prompt=prompt, prefill_word=prefill_word, can_go_back=can_go_back
         )
 
-    word: str = await interact(
-        keyboard,
-        "mnemonic" if send_button_request else None,
-        ButtonRequestType.MnemonicInput,
-    )
+    try:
+        word: str = await interact(
+            keyboard,
+            "mnemonic" if send_button_request else None,
+            ButtonRequestType.MnemonicInput,
+        )
+    finally:
+        keyboard.__del__()
     return word
 
 

--- a/core/src/trezor/ui/layouts/caesar/recovery.py
+++ b/core/src/trezor/ui/layouts/caesar/recovery.py
@@ -31,24 +31,25 @@ async def request_word(
     prefill_word: str = "",
 ) -> str:
     prompt = TR.recovery__word_x_of_y_template.format(word_index + 1, word_count)
-
     can_go_back = word_index > 0
 
     if is_slip39:
         keyboard = trezorui_api.request_slip39(
             prompt=prompt, prefill_word=prefill_word, can_go_back=can_go_back
         )
-
     else:
         keyboard = trezorui_api.request_bip39(
             prompt=prompt, prefill_word=prefill_word, can_go_back=can_go_back
         )
 
-    word: str = await interact(
-        keyboard,
-        "mnemonic" if send_button_request else None,
-        ButtonRequestType.MnemonicInput,
-    )
+    try:
+        word: str = await interact(
+            keyboard,
+            "mnemonic" if send_button_request else None,
+            ButtonRequestType.MnemonicInput,
+        )
+    finally:
+        keyboard.__del__()
     return word
 
 

--- a/core/src/trezor/ui/layouts/delizia/recovery.py
+++ b/core/src/trezor/ui/layouts/delizia/recovery.py
@@ -33,6 +33,7 @@ async def request_word(
 ) -> str:
     prompt = TR.recovery__word_x_of_y_template.format(word_index + 1, word_count)
     can_go_back = word_index > 0
+
     if is_slip39:
         keyboard = trezorui_api.request_slip39(
             prompt=prompt, prefill_word=prefill_word, can_go_back=can_go_back
@@ -42,11 +43,14 @@ async def request_word(
             prompt=prompt, prefill_word=prefill_word, can_go_back=can_go_back
         )
 
-    word: str = await interact(
-        keyboard,
-        "mnemonic" if send_button_request else None,
-        ButtonRequestType.MnemonicInput,
-    )
+    try:
+        word: str = await interact(
+            keyboard,
+            "mnemonic" if send_button_request else None,
+            ButtonRequestType.MnemonicInput,
+        )
+    finally:
+        keyboard.__del__()
     return word
 
 


### PR DESCRIPTION
- seems that keyboard LayoutObj was not properly deallocated resulting in MemoryError. Fix by calling the dunder `del` method explicitly fixes the issue
- the problem was on Model T (Bolt), but applying it for all layouts to prevent similar problem

<!--
For core developers:
- Assign yourself to the PR.
- Set the priority to match the original issue.
- Add the PR to the current sprint.
- If it's a draft PR, mark it as "In Progress."
- If it's a final PR, mark it as "Needs Review."

For external contributors:
- Please open an issue before submitting a PR so we can discuss whether we want to proceed with it.
-->
