### PR TITLE
unify size of enums between rust and C

### DIFF
--- a/core/embed/rust/build.rs
+++ b/core/embed/rust/build.rs
@@ -137,6 +137,7 @@ fn prepare_bindings() -> bindgen::Builder {
     // Pass in correct include paths and defines.
     if is_firmware() {
         clang_args.push("-nostdinc");
+        clang_args.push("-fshort-enums"); // Make sure enums use the same size as in C
 
         // Append gcc-arm-none-eabi's include paths.
         let cc_output = Command::new("arm-none-eabi-gcc")
@@ -158,6 +159,8 @@ fn prepare_bindings() -> bindgen::Builder {
             .map(|s| format!("-I{}", s.trim()));
 
         bindings = bindings.clang_args(include_args);
+    } else {
+        clang_args.push("-fno-short-enums");
     }
 
     bindings = bindings.clang_args(&clang_args);

--- a/core/embed/rust/src/micropython/gc.rs
+++ b/core/embed/rust/src/micropython/gc.rs
@@ -76,7 +76,7 @@ impl<T> Gc<T> {
     /// Can only be used with Python objects that have a base as their
     /// first element
     pub unsafe fn new_with_custom_finaliser(v: T) -> Result<Self, Error> {
-        unsafe { Self::alloc(v, ffi::GC_ALLOC_FLAG_HAS_FINALISER) }
+        unsafe { Self::alloc(v, ffi::GC_ALLOC_FLAG_HAS_FINALISER as _) }
     }
 }
 

--- a/core/embed/rust/src/trezorhal/display.rs
+++ b/core/embed/rust/src/trezorhal/display.rs
@@ -22,7 +22,7 @@ pub fn get_font_info(font: i32) -> Option<FontInfo> {
     // - The font_info_t contains pointers to static glyph data arrays also in ROM
     // - All font data is generated at compile time and included in the binary
     unsafe {
-        let font = ffi::get_font_info(font);
+        let font = ffi::get_font_info(font as _);
         Some(*font.as_ref()?)
     }
 }

--- a/core/embed/rust/src/trezorhal/storage.rs
+++ b/core/embed/rust/src/trezorhal/storage.rs
@@ -50,7 +50,7 @@ unsafe extern "C" fn callback_wrapper(
                 c(
                     wait,
                     progress,
-                    PinCallbackMessage::from_u32(message).unwrap_or(PinCallbackMessage::None),
+                    PinCallbackMessage::from_u32(message as _).unwrap_or(PinCallbackMessage::None),
                 )
             })
             .unwrap_or(PinCallbackResult::Continue)


### PR DESCRIPTION
By default, ARM eabi has `-fshort-enums` switched on, so we need to pass this flag to clang when building bindings for rust to account for this behavior.

For contrast, unix builds don't use this. SDL also enforces building without this flags via static asserts, so we can't use `-fshort-enums` for the whole of unix, so i opted for using different settings for unix and embedded targets. 


<!--
For core developers:
- Assign yourself to the PR.
- Set the priority to match the original issue.
- Add the PR to the current sprint.
- If it's a draft PR, mark it as "In Progress."
- If it's a final PR, mark it as "Needs Review."

For external contributors:
- Please open an issue before submitting a PR so we can discuss whether we want to proceed with it.
-->
