### PR TITLE
adjust T3W1 display refresh rate

### DIFF
--- a/core/embed/io/display/ltdc_dsi/display_driver.c
+++ b/core/embed/io/display/ltdc_dsi/display_driver.c
@@ -58,7 +58,7 @@ static bool display_pll_init(void) {
 #elif HSE_VALUE == 16000000
   PLL3InitPeriph.PLL3.PLL3M = 4;
 #endif
-  PLL3InitPeriph.PLL3.PLL3N = 125;
+  PLL3InitPeriph.PLL3.PLL3N = ((DSI_LANE_BYTE_FREQ_HZ * 8) / 4000000);
   PLL3InitPeriph.PLL3.PLL3P = 8;
   PLL3InitPeriph.PLL3.PLL3Q = 8;
   PLL3InitPeriph.PLL3.PLL3R = 24;
@@ -144,11 +144,7 @@ static bool display_dsi_init(display_driver_t *drv) {
   drv->hlcd_dsi.Init.PHYFrequencyRange = DSI_DPHY_FRANGE_450MHZ_510MHZ;
   drv->hlcd_dsi.Init.PHYLowPowerOffset = 0;
 
-#if HSE_VALUE == 32000000
-  PLLInit.PLLNDIV = 62;
-#elif HSE_VALUE == 16000000
-  PLLInit.PLLNDIV = 125;
-#endif
+  PLLInit.PLLNDIV = ((DSI_LANE_BYTE_FREQ_HZ * 8 * 2 * 4) / (2 * HSE_VALUE));
   PLLInit.PLLIDF = 4;
   PLLInit.PLLODF = 2;
   PLLInit.PLLVCORange = DSI_DPHY_VCO_FRANGE_800MHZ_1GHZ;

--- a/core/embed/io/display/ltdc_dsi/panels/lx200d2406a/lx200d2406a.h
+++ b/core/embed/io/display/ltdc_dsi/panels/lx200d2406a/lx200d2406a.h
@@ -21,6 +21,8 @@
 
 #include <trezor_types.h>
 
+#define DSI_LANE_BYTE_FREQ_HZ 62500000ULL
+
 #define VSYNC 4
 #define VBP 4
 #define VFP 660

--- a/core/embed/io/display/ltdc_dsi/panels/lx250a2401a/lx250a2401a.h
+++ b/core/embed/io/display/ltdc_dsi/panels/lx250a2401a/lx250a2401a.h
@@ -21,13 +21,15 @@
 
 #include <trezor_types.h>
 
+#define DSI_LANE_BYTE_FREQ_HZ 56000000ULL
+
 #define VSYNC 2
 #define VBP 26
 #define VFP 16
 #define VACT 520
-#define HSYNC 6  // 16
-#define HBP 2    // 32
-#define HFP 6    // 26
+#define HSYNC 6
+#define HBP 2
+#define HFP 56
 #define HACT 480
 #define LCD_WIDTH 480
 #define LCD_HEIGHT 520

--- a/core/embed/io/display/ltdc_dsi/panels/stm32u5a9j-dk/stm32u5a9j-dk.h
+++ b/core/embed/io/display/ltdc_dsi/panels/stm32u5a9j-dk/stm32u5a9j-dk.h
@@ -19,6 +19,8 @@
 
 #pragma once
 
+#define DSI_LANE_BYTE_FREQ_HZ 62500000ULL
+
 #define VSYNC 1
 #define VBP 12
 #define VFP 50


### PR DESCRIPTION
This PR adjusts T3W1 display refresh rate to be closer to 60Hz.

This is done by adjusting lane byte frequency, as opposite to adjusting porch setting, after discussing this with display supplier.


<!--
For core developers:
- Assign yourself to the PR.
- Set the priority to match the original issue.
- Add the PR to the current sprint.
- If it's a draft PR, mark it as "In Progress."
- If it's a final PR, mark it as "Needs Review."

For external contributors:
- Please open an issue before submitting a PR so we can discuss whether we want to proceed with it.
-->
