### PR TITLE
build(core): export Rust functions' stack sizes

### DIFF
--- a/core/SConscript.firmware
+++ b/core/SConscript.firmware
@@ -791,6 +791,12 @@ def cargo_build():
         # see https://nnethercote.github.io/perf-book/type-sizes.html#measuring-type-sizes for more details
         env.Append(ENV={'RUSTFLAGS': '-Z print-type-sizes'})
 
+    # Adds an ELF section with Rust functions' stack sizes. See the following links for more details:
+    # - https://doc.rust-lang.org/nightly/unstable-book/compiler-flags/emit-stack-sizes.html
+    # - https://blog.japaric.io/stack-analysis/
+    # - https://github.com/japaric/stack-sizes/
+    env.Append(ENV={'RUSTFLAGS': '-Z emit-stack-sizes'})
+
     bindgen_macros = tools.get_bindgen_defines(env.get("CPPDEFINES"), ALLPATHS)
     build_dir = str(Dir('.').abspath)
 


### PR DESCRIPTION
It is useful to find the top-most stack consuming functions:

```
$ make build_firmware
$ arm-none-eabi-size -A build/firmware/firmware.elf | grep .stack_sizes
.stack_sizes          7523           0

$ cargo install stack-sizes@0.4.0
$ stack-sizes build/firmware/firmware.elf | grep trezor_lib | sort -k2 -n | tail -n10
0x081c1721	3536	trezor_lib::ui::api::firmware_micropython::new_confirm_properties::h2ab0feebaf154486
0x081c0e7d	3560	trezor_lib::ui::api::firmware_micropython::new_confirm_modify_output::h04465b97d57fafb6
0x081c6161	3688	trezor_lib::ui::api::firmware_micropython::new_show_checklist::he16b109bc4dff398
0x081c4089	4240	trezor_lib::ui::api::firmware_micropython::new_request_pin::h3280c5eff8900a22
0x081be3e1	4960	trezor_lib::ui::api::firmware_micropython::new_confirm_action::h860f874d714ace74
0x081bf545	5096	trezor_lib::ui::api::firmware_micropython::new_confirm_emphasized::h9ade56f5c88001c0
0x081c1ded	5736	trezor_lib::ui::api::firmware_micropython::new_confirm_summary::he2e1274bbc07703e
0x081c7ee9	6760	trezor_lib::ui::api::firmware_micropython::new_show_remaining_shares::h1f67cbfdfeb4c683
0x081c127d	6768	trezor_lib::ui::api::firmware_micropython::new_confirm_more::h107a4be9b5431bb4
0x081c5441	8312	trezor_lib::ui::api::firmware_micropython::new_show_address_details::h352e0b87c58914ce
```

[no changelog]

<!--
For core developers:
- Assign yourself to the PR.
- Set the priority to match the original issue.
- Add the PR to the current sprint.
- If it's a draft PR, mark it as "In Progress."
- If it's a final PR, mark it as "Needs Review."

For external contributors:
- Please open an issue before submitting a PR so we can discuss whether we want to proceed with it.
-->
