### PR TITLE
ci: fix `JSONDecodeError` when combining `.coverage.gw*` files

### DIFF
--- a/.github/actions/upload-coverage/action.yml
+++ b/.github/actions/upload-coverage/action.yml
@@ -2,7 +2,12 @@ name: 'Upload coverage data'
 runs:
   using: "composite"
   steps:
-    - run: mv core/src/.coverage core/src/.coverage.${{ github.job }}${{ strategy.job-index }} || true
+    # add per-job suffix so the .coverage files won't be overwritten during merge (by `core_coverage_report`)
+    - run: |
+        for F in core/src/.coverage core/src/.coverage.gw*
+        do
+          mv -v $F $F.${{ github.job }}${{ strategy.job-index }} || true
+        done
       shell: sh
     - uses: actions/upload-artifact@v4
       with:


### PR DESCRIPTION
For example: https://github.com/trezor/trezor-firmware/actions/runs/12976369614/job/36188913357

```
Run nix-shell --run "poetry run make -C core coverage"
make: Entering directory '/home/runner/work/trezor-firmware/trezor-firmware/core'
./tools/coverage-report
COVERAGE_THRESHOLD set to 77%
.coverage.core_click_test12
.coverage.core_click_test13
.coverage.core_click_test14
.coverage.core_click_test15
.coverage.core_click_test16
.coverage.core_click_test17
.coverage.core_device_test30
.coverage.core_device_test31
.coverage.core_device_test32
.coverage.core_device_test33
.coverage.core_device_test34
.coverage.core_device_test35
.coverage.core_fido2_test1
.coverage.core_monero_test2
.coverage.core_persistence_test2
.coverage.core_u2f_test2
.coverage.gw0
.coverage.gw1
.coverage.gw2
.coverage.gw3
Creating .coverage.empty file
Combining .coverage.* files
Coverage.py warning: Couldn't read data from '/home/runner/work/trezor-firmware/trezor-firmware/core/.coverage.gw0': JSONDecodeError: Extra data: line 1 column 79752 (char 79751)
Coverage.py warning: Couldn't read data from '/home/runner/work/trezor-firmware/trezor-firmware/core/.coverage.gw1': JSONDecodeError: Extra data: line 1 column 81746 (char 81745)
Coverage.py warning: Couldn't read data from '/home/runner/work/trezor-firmware/trezor-firmware/core/.coverage.gw3': JSONDecodeError: Extra data: line 1 column 78777 (char 78776)
ERROR: Code coverage is less than 77% - 74%
See core/htmlcov/index.html for details.
make: *** [Makefile:481: coverage] Error 1
make: Leaving directory '/home/runner/work/trezor-firmware/trezor-firmware/core'
Error: Process completed with exit code 2.
```

Single `.coverage` files were renamed, but `make test_emu_ui_multicore` generates multiple `.coverage.gw*` files, which may overwrite each other in case there are multiple similar CI jobs (e.g. when translation-related jobs are enabled).

<!--
For core developers:
- Assign yourself to the PR.
- Set the priority to match the original issue.
- Add the PR to the current sprint.
- If it's a draft PR, mark it as "In Progress."
- If it's a final PR, mark it as "Needs Review."

For external contributors:
- Please open an issue before submitting a PR so we can discuss whether we want to proceed with it.
-->
