### PR TITLE
feat(crypto): add support for Schnorr crypto (eCash variant)

### DIFF
--- a/crypto/Makefile
+++ b/crypto/Makefile
@@ -88,6 +88,7 @@ CFLAGS += -DUSE_MONERO=1
 CFLAGS += -DUSE_NEM=1
 CFLAGS += -DUSE_CARDANO=1
 CFLAGS += -DUSE_INSECURE_PRNG=1
+CFLAGS += -DUSE_ECASH=1
 CFLAGS += -DAES_128
 CFLAGS += -DAES_192
 CFLAGS += -DAES_VAR
@@ -134,6 +135,7 @@ SRCS  += tls_prf.c
 SRCS  += hash_to_curve.c
 SRCS  += buffer.c der.c
 SRCS  += elligator2.c
+SRCS  += ecash/schnorr.c
 
 OBJS   = $(SRCS:.c=.o)
 OBJS  += secp256k1-zkp.o

--- a/crypto/README.md
+++ b/crypto/README.md
@@ -13,6 +13,7 @@ These include:
   uses RFC6979 for deterministic signatures)
 - ECDSA public key derivation
 - BIP340 Schnorr signature signing/verifying
+- eCash Schnorr variant signing/verifying
 - Base32 (RFC4648 and custom alphabets)
 - Base58 address representation
 - Ed25519 signing/verifying (also SHA3 and Keccak variants)

--- a/crypto/ecash/schnorr.c
+++ b/crypto/ecash/schnorr.c
@@ -1,0 +1,217 @@
+/**
+ * Copyright (c) 2021 The Bitcoin ABC developers
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining
+ * a copy of this software and associated documentation files (the "Software"),
+ * to deal in the Software without restriction, including without limitation
+ * the rights to use, copy, modify, merge, publish, distribute, sublicense,
+ * and/or sell copies of the Software, and to permit persons to whom the
+ * Software is furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included
+ * in all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS
+ * OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL
+ * THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES
+ * OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE,
+ * ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
+ * OTHER DEALINGS IN THE SOFTWARE.
+ */
+
+#if USE_ECASH
+
+#include "schnorr.h"
+#include "hmac_drbg.h"
+#include "memzero.h"
+#include "rfc6979.h"
+
+#include <assert.h>
+#include <stdio.h>
+#include <string.h>
+
+static int jacobi(const bignum256 *_n, const bignum256 *_k) {
+  assert(!bn_is_zero(_k) && bn_is_odd(_k));
+
+  bignum256 n_copy = {0};
+  bignum256 *n = &n_copy;
+  bn_copy(_n, n);
+
+  bignum256 k_copy = {0};
+  bignum256 *k = &k_copy;
+  bn_copy(_k, k);
+
+  int t = 0;
+  while (!bn_is_zero(n)) {
+    while (bn_is_even(n)) {
+      // jacobi(2 * n, k) = jacobi(n, k) if k = 1 (mod 8) or k = 7 (mod 8)
+      // jacobi(2 * n, k) = -jacobi(n, k) if k = 3 (mod 8) or k = 5 (mod 8)
+      uint32_t r = k->val[0] & 0x07;
+      t ^= (r == 3 || r == 5);
+      bn_rshift(n);
+    }
+
+    if (bn_is_less(n, k)) {
+      // jacobi(n, k) = jacobi(k, n) if k = n = 1 (mod 4)
+      // jacobi(n, k) = -jacobi(k, n) if k = n = 3 (mod 4)
+      t ^= ((n->val[0] & k->val[0] & 3) == 3);
+      bignum256 *temp = n;
+      n = k;
+      k = temp;
+    }
+
+    // jacobi(n, k) = jacobi(n - k, k)
+    bn_subtract(n, k, n);
+  }
+
+  int k_is_one = bn_is_one(k);
+
+  // Cleanup
+  memzero(&n_copy, sizeof(n_copy));
+  memzero(&k_copy, sizeof(k_copy));
+
+  // Map t: [0] => 1, [1] => -1
+  t = -2 * t + 1;
+
+  return k_is_one * t;
+}
+
+static int is_non_quad_residue(const bignum256 *n, const bignum256 *prime) {
+  return jacobi(n, prime) == -1;
+}
+
+static int generate_k_schnorr(const ecdsa_curve *curve, const uint8_t *priv_key,
+                              const uint8_t *hash, bignum256 *k) {
+  rfc6979_state rng = {0};
+  uint8_t hmac_data[SHA256_DIGEST_LENGTH + 16] = {0};
+
+  /*
+   * Init the HMAC with additional data specific to Schnorr. This prevents from
+   * leaking the private key in the case the same message is signed with both
+   * Schnorr and ECDSA.
+   */
+  memcpy(hmac_data, hash, SHA256_DIGEST_LENGTH);
+  memcpy(hmac_data + SHA256_DIGEST_LENGTH, "Schnorr+SHA256  ", 16);
+  hmac_drbg_init(&rng, priv_key, 32, hmac_data, SHA256_DIGEST_LENGTH + 16);
+
+  for (int i = 0; i < 10000; i++) {
+    generate_k_rfc6979(k, &rng);
+    // If k is too big or too small, we don't like it
+    if (bn_is_zero(k) || !bn_is_less(k, &curve->order)) {
+      continue;
+    }
+
+    memzero(&rng, sizeof(rng));
+    return 0;
+  }
+
+  memzero(&rng, sizeof(rng));
+  return 1;
+}
+
+// e = H(Rx, pub_key, msg_hash)
+static void calc_e(const ecdsa_curve *curve, const bignum256 *Rx,
+                   const uint8_t pub_key[33], const uint8_t *msg_hash,
+                   bignum256 *e) {
+  uint8_t Rxbuf[32] = {0};
+  SHA256_CTX ctx = {0};
+  uint8_t digest[SHA256_DIGEST_LENGTH] = {0};
+
+  bn_write_be(Rx, Rxbuf);
+
+  sha256_Init(&ctx);
+  sha256_Update(&ctx, Rxbuf, sizeof(Rxbuf));
+  sha256_Update(&ctx, pub_key, 33);
+  sha256_Update(&ctx, msg_hash, SHA256_DIGEST_LENGTH);
+  sha256_Final(&ctx, digest);
+
+  bn_read_be(digest, e);
+  bn_fast_mod(e, &curve->order);
+  bn_mod(e, &curve->order);
+}
+
+int schnorr_sign_digest(const ecdsa_curve *curve, const uint8_t *priv_key,
+                        const uint8_t *digest, uint8_t *sign) {
+  uint8_t pub_key[33] = {0};
+  curve_point R = {0};
+  bignum256 e = {0}, s = {0}, k = {0};
+
+  ecdsa_get_public_key33(curve, priv_key, pub_key);
+
+  // Compute k
+  if (generate_k_schnorr(curve, priv_key, digest, &k) != 0) {
+    memzero(&k, sizeof(k));
+    return 1;
+  }
+
+  // Compute R = k * G
+  scalar_multiply(curve, &k, &R);
+
+  // If R.y is not a quadratic residue, negate the nonce
+  bn_cnegate(is_non_quad_residue(&R.y, &curve->prime), &k, &curve->order);
+
+  bn_write_be(&R.x, sign);
+
+  // Compute e = H(Rx, pub_key, msg_hash)
+  calc_e(curve, &R.x, pub_key, digest, &e);
+
+  // Compute s = k + e * priv_key
+  bn_read_be(priv_key, &s);
+  bn_multiply(&e, &s, &curve->order);
+  bn_addmod(&s, &k, &curve->order);
+  memzero(&k, sizeof(k));
+  bn_mod(&s, &curve->order);
+  bn_write_be(&s, sign + 32);
+
+  return 0;
+}
+
+int schnorr_verify_digest(const ecdsa_curve *curve, const uint8_t *pub_key,
+                          const uint8_t *digest, const uint8_t *sign) {
+  curve_point P = {0}, sG = {0}, R = {0};
+  bignum256 r = {0}, s = {0}, e = {0};
+
+  bn_read_be(sign, &r);
+  bn_read_be(sign + 32, &s);
+
+  // Signature is invalid if s >= n or r >= p.
+  if (!bn_is_less(&r, &curve->prime) || !bn_is_less(&s, &curve->order)) {
+    return 1;
+  }
+
+  if (!ecdsa_read_pubkey(curve, pub_key, &P)) {
+    return 2;
+  }
+
+  // Compute e
+  calc_e(curve, &r, pub_key, digest, &e);
+
+  if (bn_is_zero(&e)) {
+    return 3;
+  }
+
+  // Compute R = sG - eP
+  bn_subtract(&curve->order, &e, &e);
+  scalar_multiply(curve, &s, &sG);
+  point_multiply(curve, &e, &P, &R);
+  point_add(curve, &sG, &R);
+
+  if (point_is_infinity(&R)) {
+    return 4;
+  }
+
+  // Check r == Rx
+  if (!bn_is_equal(&r, &R.x)) {
+    return 5;
+  }
+
+  // Check Ry is a quadratic residue
+  if (is_non_quad_residue(&R.y, &curve->prime)) {
+    return 6;
+  }
+
+  return 0;
+}
+
+#endif  // USE_ECASH

--- a/crypto/ecash/schnorr.h
+++ b/crypto/ecash/schnorr.h
@@ -1,0 +1,40 @@
+/**
+ * Copyright (c) 2021 The Bitcoin ABC developers
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining
+ * a copy of this software and associated documentation files (the "Software"),
+ * to deal in the Software without restriction, including without limitation
+ * the rights to use, copy, modify, merge, publish, distribute, sublicense,
+ * and/or sell copies of the Software, and to permit persons to whom the
+ * Software is furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included
+ * in all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS
+ * OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL
+ * THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES
+ * OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE,
+ * ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
+ * OTHER DEALINGS IN THE SOFTWARE.
+ */
+
+#ifndef TREZOR_CRYPTO_ECASH_SCHNORR_H
+#define TREZOR_CRYPTO_ECASH_SCHNORR_H
+
+#if !USE_ECASH
+#error "Compile with -DUSE_ECASH=1"
+#endif
+
+#include "ecdsa.h"
+
+/* A Schnorr signature is always 64 bytes */
+#define SCHNORR_SIG_LENGTH 64
+
+// sign/verify returns 0 if operation succeeded
+int schnorr_sign_digest(const ecdsa_curve *curve, const uint8_t *priv_key,
+                        const uint8_t *digest, uint8_t *result);
+int schnorr_verify_digest(const ecdsa_curve *curve, const uint8_t *pub_key,
+                          const uint8_t *msg_hash, const uint8_t *sign);
+#endif

--- a/crypto/options.h
+++ b/crypto/options.h
@@ -102,6 +102,11 @@
 #define USE_KECCAK 1
 #endif
 
+// support eCash operations
+#ifndef USE_ECASH
+#define USE_ECASH 0
+#endif
+
 // add way how to mark confidential data
 #ifndef CONFIDENTIAL
 #define CONFIDENTIAL

--- a/crypto/tests/test_check.c
+++ b/crypto/tests/test_check.c
@@ -11426,6 +11426,10 @@ static int my_strncasecmp(const char *s1, const char *s2, size_t n) {
 #include "test_check_monero.h"
 #endif
 
+#if USE_ECASH
+#include "test_check_ecash.h"
+#endif
+
 // define test suite and cases
 Suite *test_suite(void) {
   Suite *s = suite_create("trezor-crypto");
@@ -11754,6 +11758,13 @@ Suite *test_suite(void) {
   tc = tcase_create("elligator2");
   tcase_add_test(tc, test_elligator2);
   suite_add_tcase(s, tc);
+
+#if USE_ECASH
+  tc = tcase_create("ecash_schnorr");
+  tcase_add_test(tc, test_ecash_schnorr_sign_verify_digest);
+  tcase_add_test(tc, test_ecash_schnorr_verify_digest);
+  suite_add_tcase(s, tc);
+#endif
 
 #if USE_CARDANO
   tc = tcase_create("bip32-cardano");

--- a/crypto/tests/test_check_ecash.h
+++ b/crypto/tests/test_check_ecash.h
@@ -1,0 +1,248 @@
+/**
+ * Copyright (c) 2025 The Bitcoin ABC developers
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining
+ * a copy of this software and associated documentation files (the "Software"),
+ * to deal in the Software without restriction, including without limitation
+ * the rights to use, copy, modify, merge, publish, distribute, sublicense,
+ * and/or sell copies of the Software, and to permit persons to whom the
+ * Software is furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included
+ * in all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS
+ * OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL
+ * THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES
+ * OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE,
+ * ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
+ * OTHER DEALINGS IN THE SOFTWARE.
+ */
+
+#include "ecash/schnorr.h"
+
+START_TEST(test_ecash_schnorr_sign_verify_digest) {
+  static struct {
+    const char *digest;
+    const char *priv_key;
+    const char *sig;
+  } tests[] = {
+      {
+          /* Very deterministic message */
+          "5255683DA567900BFD3E786ED8836A4E7763C221BF1AC20ECE2A5171B9199E8A",
+          "12B004FFF7F4B69EF8650E767F18F11EDE158148B425660723B9F9A66E61F747",
+          "2C56731AC2F7A7E7F11518FC7722A166B02438924CA9D8B4D111347B81D07175"
+          "71846DE67AD3D913A8FDF9D8F3F73161A4C48AE81CB183B214765FEB86E255CE",
+      },
+  };
+
+  const ecdsa_curve *curve = &secp256k1;
+  uint8_t digest[SHA256_DIGEST_LENGTH] = {0};
+  uint8_t priv_key[32] = {0};
+  uint8_t pub_key[33] = {0};
+  uint8_t result[SCHNORR_SIG_LENGTH] = {0};
+  uint8_t expected[SCHNORR_SIG_LENGTH] = {0};
+  int res = 0;
+
+  for (size_t i = 0; i < sizeof(tests) / sizeof(*tests); i++) {
+    memcpy(digest, fromhex(tests[i].digest), SHA256_DIGEST_LENGTH);
+    memcpy(priv_key, fromhex(tests[i].priv_key), 32);
+    memcpy(expected, fromhex(tests[i].sig), SCHNORR_SIG_LENGTH);
+
+    ecdsa_get_public_key33(curve, priv_key, pub_key);
+
+    schnorr_sign_digest(curve, priv_key, digest, result);
+
+    ck_assert_mem_eq(expected, result, SCHNORR_SIG_LENGTH);
+
+    res = schnorr_verify_digest(curve, pub_key, digest, result);
+    ck_assert_int_eq(res, 0);
+  }
+}
+END_TEST
+
+START_TEST(test_ecash_schnorr_verify_digest) {
+  static struct {
+    const char *digest;
+    const char *pub_key;
+    const char *sig;
+    const int res;
+  } tests[] = {
+      {
+          /* Very deterministic message */
+          "5255683DA567900BFD3E786ED8836A4E7763C221BF1AC20ECE2A5171B9199E8A",
+          "030B4C866585DD868A9D62348A9CD008D6A312937048FFF31670E7E920CFC7A744",
+          "2C56731AC2F7A7E7F11518FC7722A166B02438924CA9D8B4D111347B81D07175"
+          "71846DE67AD3D913A8FDF9D8F3F73161A4C48AE81CB183B214765FEB86E255CE",
+          0, /* Success */
+      },
+      {
+          /*
+           * From Bitcoin ABC libsecp256k1, test vector 1.
+           * https://github.com/Bitcoin-ABC/secp256k1/blob/master/src/modules/schnorr/tests_impl.h
+           */
+          "0000000000000000000000000000000000000000000000000000000000000000",
+          "0279BE667EF9DCBBAC55A06295CE870B07029BFCDB2DCE28D959F2815B16F81798",
+          "787A848E71043D280C50470E8E1532B2DD5D20EE912A45DBDD2BD1DFBF187EF6"
+          "7031A98831859DC34DFFEEDDA86831842CCD0079E1F92AF177F7F22CC1DCED05",
+          0, /* Success */
+      },
+      {
+          /*
+           * From Bitcoin ABC libsecp256k1, test vector 2.
+           * https://github.com/Bitcoin-ABC/secp256k1/blob/master/src/modules/schnorr/tests_impl.h
+           */
+          "243F6A8885A308D313198A2E03707344A4093822299F31D0082EFA98EC4E6C89",
+          "02DFF1D77F2A671C5F36183726DB2341BE58FEAE1DA2DECED843240F7B502BA659",
+          "2A298DACAE57395A15D0795DDBFD1DCB564DA82B0F269BC70A74F8220429BA1D"
+          "1E51A22CCEC35599B8F266912281F8365FFC2D035A230434A1A64DC59F7013FD",
+          0, /* Success */
+      },
+      {
+          /*
+           * From Bitcoin ABC libsecp256k1, test vector 3.
+           * https://github.com/Bitcoin-ABC/secp256k1/blob/master/src/modules/schnorr/tests_impl.h
+           */
+          "5E2D58D8B3BCDF1ABADEC7829054F90DDA9805AAB56C77333024B9D0A508B75C",
+          "03FAC2114C2FBB091527EB7C64ECB11F8021CB45E8E7809D3C0938E4B8C0E5F84B",
+          "00DA9B08172A9B6F0466A2DEFD817F2D7AB437E0D253CB5395A963866B3574BE"
+          "00880371D01766935B92D2AB4CD5C8A2A5837EC57FED7660773A05F0DE142380",
+          0, /* Success */
+      },
+      {
+          /*
+           * From Bitcoin ABC libsecp256k1, test vector 4.
+           * https://github.com/Bitcoin-ABC/secp256k1/blob/master/src/modules/schnorr/tests_impl.h
+           */
+          "4DF3C3F68FCC83B27E9D42C90431A72499F17875C81A599B566C9889B9696703",
+          "03DEFDEA4CDB677750A420FEE807EACF21EB9898AE79B9768766E4FAA04A2D4A34",
+          "00000000000000000000003B78CE563F89A0ED9414F5AA28AD0D96D6795F9C63"
+          "02A8DC32E64E86A333F20EF56EAC9BA30B7246D6D25E22ADB8C6BE1AEB08D49D",
+          0, /* Success */
+      },
+      {
+          /*
+           * From Bitcoin ABC libsecp256k1, test vector 4b.
+           * https://github.com/Bitcoin-ABC/secp256k1/blob/master/src/modules/schnorr/tests_impl.h
+           */
+          "0000000000000000000000000000000000000000000000000000000000000000",
+          "031B84C5567B126440995D3ED5AABA0565D71E1834604819FF9C17F5E9D5DD078F",
+          "52818579ACA59767E3291D91B76B637BEF062083284992F2D95F564CA6CB4E35"
+          "30B1DA849C8E8304ADC0CFE870660334B3CFC18E825EF1DB34CFAE3DFC5D8187",
+          0, /* Success */
+      },
+      {
+          /*
+           * From Bitcoin ABC libsecp256k1, test vector 6.
+           * https://github.com/Bitcoin-ABC/secp256k1/blob/master/src/modules/schnorr/tests_impl.h
+           */
+          "243F6A8885A308D313198A2E03707344A4093822299F31D0082EFA98EC4E6C89",
+          "02DFF1D77F2A671C5F36183726DB2341BE58FEAE1DA2DECED843240F7B502BA659",
+          "2A298DACAE57395A15D0795DDBFD1DCB564DA82B0F269BC70A74F8220429BA1D"
+          "FA16AEE06609280A19B67A24E1977E4697712B5FD2943914ECD5F730901B4AB7",
+          6, /* R.y is not a quadratic residue */
+      },
+      {
+          /*
+           * From Bitcoin ABC libsecp256k1, test vector 7.
+           * https://github.com/Bitcoin-ABC/secp256k1/blob/master/src/modules/schnorr/tests_impl.h
+           */
+          "5E2D58D8B3BCDF1ABADEC7829054F90DDA9805AAB56C77333024B9D0A508B75C",
+          "03FAC2114C2FBB091527EB7C64ECB11F8021CB45E8E7809D3C0938E4B8C0E5F84B",
+          "00DA9B08172A9B6F0466A2DEFD817F2D7AB437E0D253CB5395A963866B3574BE"
+          "D092F9D860F1776A1F7412AD8A1EB50DACCC222BC8C0E26B2056DF2F273EFDEC",
+          5, /* Negated message hash, R.x mismatch */
+      },
+      {
+          /*
+           * From Bitcoin ABC libsecp256k1, test vector 8.
+           * https://github.com/Bitcoin-ABC/secp256k1/blob/master/src/modules/schnorr/tests_impl.h
+           */
+          "0000000000000000000000000000000000000000000000000000000000000000",
+          "0279BE667EF9DCBBAC55A06295CE870B07029BFCDB2DCE28D959F2815B16F81798",
+          "787A848E71043D280C50470E8E1532B2DD5D20EE912A45DBDD2BD1DFBF187EF6"
+          "8FCE5677CE7A623CB20011225797CE7A8DE1DC6CCD4F754A47DA6C600E59543C",
+          5, /* Negated s, R.x mismatch */
+      },
+      {
+          /*
+           * From Bitcoin ABC libsecp256k1, test vector 9.
+           * https://github.com/Bitcoin-ABC/secp256k1/blob/master/src/modules/schnorr/tests_impl.h
+           */
+          "243F6A8885A308D313198A2E03707344A4093822299F31D0082EFA98EC4E6C89",
+          "03DFF1D77F2A671C5F36183726DB2341BE58FEAE1DA2DECED843240F7B502BA659",
+          "2A298DACAE57395A15D0795DDBFD1DCB564DA82B0F269BC70A74F8220429BA1D"
+          "1E51A22CCEC35599B8F266912281F8365FFC2D035A230434A1A64DC59F7013FD",
+          5, /* Negated P, R.x mismatch */
+      },
+      {
+          /*
+           * From Bitcoin ABC libsecp256k1, test vector 10.
+           * https://github.com/Bitcoin-ABC/secp256k1/blob/master/src/modules/schnorr/tests_impl.h
+           */
+          "243F6A8885A308D313198A2E03707344A4093822299F31D0082EFA98EC4E6C89",
+          "02DFF1D77F2A671C5F36183726DB2341BE58FEAE1DA2DECED843240F7B502BA659",
+          "2A298DACAE57395A15D0795DDBFD1DCB564DA82B0F269BC70A74F8220429BA1D"
+          "8C3428869A663ED1E954705B020CBB3E7BB6AC31965B9EA4C73E227B17C5AF5A",
+          4, /* s * G = e * P, R = 0 */
+      },
+      {
+          /*
+           * From Bitcoin ABC libsecp256k1, test vector 11.
+           * https://github.com/Bitcoin-ABC/secp256k1/blob/master/src/modules/schnorr/tests_impl.h
+           */
+          "243F6A8885A308D313198A2E03707344A4093822299F31D0082EFA98EC4E6C89",
+          "02DFF1D77F2A671C5F36183726DB2341BE58FEAE1DA2DECED843240F7B502BA659",
+          "4A298DACAE57395A15D0795DDBFD1DCB564DA82B0F269BC70A74F8220429BA1D"
+          "1E51A22CCEC35599B8F266912281F8365FFC2D035A230434A1A64DC59F7013FD",
+          5, /* R.x not on the curve, R.x mismatch */
+      },
+      {
+          /*
+           * From Bitcoin ABC libsecp256k1, test vector 12.
+           * https://github.com/Bitcoin-ABC/secp256k1/blob/master/src/modules/schnorr/tests_impl.h
+           */
+          "243F6A8885A308D313198A2E03707344A4093822299F31D0082EFA98EC4E6C89",
+          "02DFF1D77F2A671C5F36183726DB2341BE58FEAE1DA2DECED843240F7B502BA659",
+          "FFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFC2F"
+          "1E51A22CCEC35599B8F266912281F8365FFC2D035A230434A1A64DC59F7013FD",
+          1, /* r = p */
+      },
+      {
+          /*
+           * From Bitcoin ABC libsecp256k1, test vector 13.
+           * https://github.com/Bitcoin-ABC/secp256k1/blob/master/src/modules/schnorr/tests_impl.h
+           */
+          "243F6A8885A308D313198A2E03707344A4093822299F31D0082EFA98EC4E6C89",
+          "02DFF1D77F2A671C5F36183726DB2341BE58FEAE1DA2DECED843240F7B502BA659",
+          "2A298DACAE57395A15D0795DDBFD1DCB564DA82B0F269BC70A74F8220429BA1D"
+          "FFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFEBAAEDCE6AF48A03BBFD25E8CD0364141",
+          1, /* s = n */
+      },
+      {
+          /* Very deterministic message */
+          "5255683DA567900BFD3E786ED8836A4E7763C221BF1AC20ECE2A5171B9199E8A",
+          "010B4C866585DD868A9D62348A9CD008D6A312937048FFF31670E7E920CFC7A744",
+          "2C56731AC2F7A7E7F11518FC7722A166B02438924CA9D8B4D111347B81D07175"
+          "71846DE67AD3D913A8FDF9D8F3F73161A4C48AE81CB183B214765FEB86E255CE",
+          2, /* Invalid public key */
+      },
+  };
+
+  const ecdsa_curve *curve = &secp256k1;
+  uint8_t digest[SHA256_DIGEST_LENGTH] = {0};
+  uint8_t pub_key[33] = {0};
+  uint8_t signature[SCHNORR_SIG_LENGTH] = {0};
+  int res = 0;
+
+  for (size_t i = 0; i < sizeof(tests) / sizeof(*tests); i++) {
+    memcpy(digest, fromhex(tests[i].digest), SHA256_DIGEST_LENGTH);
+    memcpy(pub_key, fromhex(tests[i].pub_key), 33);
+    memcpy(signature, fromhex(tests[i].sig), SCHNORR_SIG_LENGTH);
+
+    res = schnorr_verify_digest(curve, pub_key, digest, signature);
+    ck_assert_int_eq(res, tests[i].res);
+  }
+}
+END_TEST


### PR DESCRIPTION
Support Schnorr signature and verification defined in https://github.com/Bitcoin-ABC/bitcoin-abc/tree/master/doc/standards/schnorr.md.

The implementation is based on https://github.com/Bitcoin-ABC/secp256k1 as well as the test vectors.

This is a revival of https://github.com/trezor/trezor-firmware/pull/1509 that was reverted due to not being used after https://github.com/trezor/trezor-firmware/pull/1591 was rejected. The only difference is that the source files are now located in a ecash/ folder to avoid confusion with BIP340 Schnorr signatures, and a USE_ECASH flag makes it possible to disable the feature to save space.

Now that eCash is supported on Trezor, supporting this signature scheme would be very useful for eCash users.
It can be leveraged to add avalanche stake signature using the Trezor devices.