### PR TITLE
Hardware JPEG decoder 

### DIFF
--- a/core/embed/gfx/bitblt/dma2d_bitblt.h
+++ b/core/embed/gfx/bitblt/dma2d_bitblt.h
@@ -17,8 +17,7 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-#ifndef TREZORHAL_DMA2D_BITBLT_H
-#define TREZORHAL_DMA2D_BITBLT_H
+#pragma once
 
 #include <gfx/gfx_bitblt.h>
 
@@ -50,4 +49,8 @@ bool dma2d_rgba8888_copy_rgba8888(const gfx_bitblt_t* bb);
 bool dma2d_rgba8888_blend_mono4(const gfx_bitblt_t* bb);
 bool dma2d_rgba8888_blend_mono8(const gfx_bitblt_t* bb);
 
-#endif  // TREZORHAL_DMA2D_BITBLT_H
+#ifdef USE_HW_JPEG_DECODER
+bool dma2d_rgba8888_copy_ycbcr420(const gfx_bitblt_t* bb);
+bool dma2d_rgba8888_copy_ycbcr422(const gfx_bitblt_t* bb);
+bool dma2d_rgba8888_copy_ycbcr444(const gfx_bitblt_t* bb);
+#endif

--- a/core/embed/gfx/bitblt/gfx_bitblt_rgba8888.c
+++ b/core/embed/gfx/bitblt/gfx_bitblt_rgba8888.c
@@ -125,10 +125,10 @@ void gfx_rgba8888_copy_rgba8888(const gfx_bitblt_t* bb) {
 
     while (height-- > 0) {
       for (int x = 0; x < bb->width; x++) {
-        dst_ptr[x] = src_ptr[x];
+        dst_ptr[x] = src_ptr[x << bb->src_downscale];
       }
       dst_ptr += bb->dst_stride / sizeof(*dst_ptr);
-      src_ptr += bb->src_stride / sizeof(*src_ptr);
+      src_ptr += (bb->src_stride / sizeof(*src_ptr)) << bb->src_downscale;
     }
   }
 }

--- a/core/embed/gfx/bitblt/stm32/dma2d_bitblt.c
+++ b/core/embed/gfx/bitblt/stm32/dma2d_bitblt.c
@@ -24,8 +24,27 @@
 
 #include "../dma2d_bitblt.h"
 
-static DMA2D_HandleTypeDef dma2d_handle = {
-    .Instance = (DMA2D_TypeDef*)DMA2D_BASE,
+// Number of DMA2D layers - background (0) and foreground (1)
+#define DMA2D_LAYER_COUNT 2
+
+typedef struct {
+  // Set if the driver is initialized
+  bool initialized;
+  // ST DMA2D driver handle
+  DMA2D_HandleTypeDef handle;
+  // CLUT cache
+  struct {
+    gfx_color32_t c_fg;
+    gfx_color32_t c_bg;
+  } cache[DMA2D_LAYER_COUNT];
+
+  // CLUT is configured according to the cache
+  bool clut_valid;
+
+} dma2d_driver_t;
+
+static dma2d_driver_t g_dma2d_driver = {
+    .initialized = false,
 };
 
 // Returns `true` if the specified address is accessible by DMA2D
@@ -41,25 +60,50 @@ static inline bool dma2d_accessible(const void* ptr) {
 }
 
 void dma2d_init(void) {
+  dma2d_driver_t* drv = &g_dma2d_driver;
+  if (drv->initialized) {
+    return;
+  }
+  memset(drv, 0, sizeof(dma2d_driver_t));
+  drv->handle.Instance = DMA2D;
+
+#ifdef KERNEL_MODE
   __HAL_RCC_DMA2D_FORCE_RESET();
   __HAL_RCC_DMA2D_RELEASE_RESET();
-
   __HAL_RCC_DMA2D_CLK_ENABLE();
+#endif
+  drv->initialized = true;
 }
 
 void dma2d_deinit(void) {
-  __HAL_RCC_DMA2D_CLK_DISABLE();
+  dma2d_driver_t* drv = &g_dma2d_driver;
 
+#ifdef KERNEL_MODE
+  __HAL_RCC_DMA2D_CLK_DISABLE();
   __HAL_RCC_DMA2D_FORCE_RESET();
   __HAL_RCC_DMA2D_RELEASE_RESET();
+#endif
+  memset(drv, 0, sizeof(dma2d_driver_t));
 }
 
 void dma2d_wait(void) {
-  while (HAL_DMA2D_PollForTransfer(&dma2d_handle, 10) != HAL_OK)
+  dma2d_driver_t* drv = &g_dma2d_driver;
+
+  if (!drv->initialized) {
+    return;
+  }
+
+  while (HAL_DMA2D_PollForTransfer(&drv->handle, 10) != HAL_OK)
     ;
 }
 
 bool dma2d_rgb565_fill(const gfx_bitblt_t* bb) {
+  dma2d_driver_t* drv = &g_dma2d_driver;
+
+  if (!drv->initialized) {
+    return false;
+  }
+
   dma2d_wait();
 
   if (!dma2d_accessible(bb->dst_row)) {
@@ -67,38 +111,38 @@ bool dma2d_rgb565_fill(const gfx_bitblt_t* bb) {
   }
 
   if (bb->src_alpha == 255) {
-    dma2d_handle.Init.ColorMode = DMA2D_OUTPUT_RGB565;
-    dma2d_handle.Init.Mode = DMA2D_R2M;
-    dma2d_handle.Init.OutputOffset =
+    drv->handle.Init.ColorMode = DMA2D_OUTPUT_RGB565;
+    drv->handle.Init.Mode = DMA2D_R2M;
+    drv->handle.Init.OutputOffset =
         bb->dst_stride / sizeof(uint16_t) - bb->width;
-    HAL_DMA2D_Init(&dma2d_handle);
+    HAL_DMA2D_Init(&drv->handle);
 
-    HAL_DMA2D_Start(&dma2d_handle, gfx_color_to_color32(bb->src_fg),
+    HAL_DMA2D_Start(&drv->handle, gfx_color_to_color32(bb->src_fg),
                     (uint32_t)bb->dst_row + bb->dst_x * sizeof(uint16_t),
                     bb->width, bb->height);
   } else {
 #ifdef STM32U5
-    dma2d_handle.Init.ColorMode = DMA2D_OUTPUT_RGB565;
-    dma2d_handle.Init.Mode = DMA2D_M2M_BLEND_FG;
-    dma2d_handle.Init.OutputOffset =
+    drv->handle.Init.ColorMode = DMA2D_OUTPUT_RGB565;
+    drv->handle.Init.Mode = DMA2D_M2M_BLEND_FG;
+    drv->handle.Init.OutputOffset =
         bb->dst_stride / sizeof(uint16_t) - bb->width;
-    HAL_DMA2D_Init(&dma2d_handle);
+    HAL_DMA2D_Init(&drv->handle);
 
-    dma2d_handle.LayerCfg[1].InputColorMode = DMA2D_INPUT_RGB565;
-    dma2d_handle.LayerCfg[1].InputOffset = 0;
-    dma2d_handle.LayerCfg[1].AlphaMode = DMA2D_REPLACE_ALPHA;
-    dma2d_handle.LayerCfg[1].InputAlpha = bb->src_alpha;
-    HAL_DMA2D_ConfigLayer(&dma2d_handle, 1);
+    drv->handle.LayerCfg[1].InputColorMode = DMA2D_INPUT_RGB565;
+    drv->handle.LayerCfg[1].InputOffset = 0;
+    drv->handle.LayerCfg[1].AlphaMode = DMA2D_REPLACE_ALPHA;
+    drv->handle.LayerCfg[1].InputAlpha = bb->src_alpha;
+    HAL_DMA2D_ConfigLayer(&drv->handle, 1);
 
-    dma2d_handle.LayerCfg[0].InputColorMode = DMA2D_INPUT_RGB565;
-    dma2d_handle.LayerCfg[0].InputOffset =
+    drv->handle.LayerCfg[0].InputColorMode = DMA2D_INPUT_RGB565;
+    drv->handle.LayerCfg[0].InputOffset =
         bb->dst_stride / sizeof(uint16_t) - bb->width;
-    dma2d_handle.LayerCfg[0].AlphaMode = 0;
-    dma2d_handle.LayerCfg[0].InputAlpha = 0;
-    HAL_DMA2D_ConfigLayer(&dma2d_handle, 0);
+    drv->handle.LayerCfg[0].AlphaMode = 0;
+    drv->handle.LayerCfg[0].InputAlpha = 0;
+    HAL_DMA2D_ConfigLayer(&drv->handle, 0);
 
     HAL_DMA2D_BlendingStart(
-        &dma2d_handle, gfx_color_to_color32(bb->src_fg),
+        &drv->handle, gfx_color_to_color32(bb->src_fg),
         (uint32_t)bb->dst_row + bb->dst_x * sizeof(uint16_t),
         (uint32_t)bb->dst_row + bb->dst_x * sizeof(uint16_t), bb->width,
         bb->height);
@@ -113,24 +157,22 @@ bool dma2d_rgb565_fill(const gfx_bitblt_t* bb) {
 
 static void dma2d_config_clut(uint32_t layer, gfx_color32_t fg,
                               gfx_color32_t bg) {
-#define LAYER_COUNT 2
+  dma2d_driver_t* drv = &g_dma2d_driver;
+
 #define GRADIENT_STEPS 16
 
-  static struct {
-    gfx_color32_t c_fg;
-    gfx_color32_t c_bg;
-  } cache[LAYER_COUNT] = {0};
-
-  if (layer >= LAYER_COUNT) {
+  if (layer >= ARRAY_LENGTH(drv->cache)) {
     return;
   }
 
   volatile uint32_t* clut =
-      layer ? dma2d_handle.Instance->FGCLUT : dma2d_handle.Instance->BGCLUT;
+      layer ? drv->handle.Instance->FGCLUT : drv->handle.Instance->BGCLUT;
 
-  if (fg != cache[layer].c_fg || bg != cache[layer].c_bg) {
-    cache[layer].c_fg = fg;
-    cache[layer].c_bg = bg;
+  if (fg != drv->cache[layer].c_fg || bg != drv->cache[layer].c_bg ||
+      !drv->clut_valid) {
+    drv->cache[layer].c_fg = fg;
+    drv->cache[layer].c_bg = bg;
+    drv->clut_valid = true;
 
     for (int step = 0; step < GRADIENT_STEPS; step++) {
       clut[step] = gfx_color32_rgba(
@@ -145,7 +187,7 @@ static void dma2d_config_clut(uint32_t layer, gfx_color32_t fg,
     clut_def.Size = GRADIENT_STEPS - 1;
     clut_def.pCLUT = 0;  // ???
 
-    HAL_DMA2D_ConfigCLUT(&dma2d_handle, clut_def, layer);
+    HAL_DMA2D_ConfigCLUT(&drv->handle, clut_def, layer);
   }
 }
 
@@ -180,6 +222,12 @@ static void dma2d_rgb565_copy_mono4_last_col(gfx_bitblt_t* bb,
 }
 
 bool dma2d_rgb565_copy_mono4(const gfx_bitblt_t* params) {
+  dma2d_driver_t* drv = &g_dma2d_driver;
+
+  if (!drv->initialized) {
+    return false;
+  }
+
   const gfx_color16_t* src_gradient = NULL;
 
   gfx_bitblt_t bb_copy = *params;
@@ -211,48 +259,52 @@ bool dma2d_rgb565_copy_mono4(const gfx_bitblt_t* params) {
     bb->width -= 1;
   }
 
-  dma2d_handle.Init.ColorMode = DMA2D_OUTPUT_RGB565;
-  dma2d_handle.Init.Mode = DMA2D_M2M_PFC;
-  dma2d_handle.Init.OutputOffset =
-      bb->dst_stride / sizeof(uint16_t) - bb->width;
-  HAL_DMA2D_Init(&dma2d_handle);
+  drv->handle.Init.ColorMode = DMA2D_OUTPUT_RGB565;
+  drv->handle.Init.Mode = DMA2D_M2M_PFC;
+  drv->handle.Init.OutputOffset = bb->dst_stride / sizeof(uint16_t) - bb->width;
+  HAL_DMA2D_Init(&drv->handle);
 
-  dma2d_handle.LayerCfg[1].InputColorMode = DMA2D_INPUT_L4;
-  dma2d_handle.LayerCfg[1].InputOffset = bb->src_stride * 2 - bb->width;
-  dma2d_handle.LayerCfg[1].AlphaMode = 0;
-  dma2d_handle.LayerCfg[1].InputAlpha = 0;
-  HAL_DMA2D_ConfigLayer(&dma2d_handle, 1);
+  drv->handle.LayerCfg[1].InputColorMode = DMA2D_INPUT_L4;
+  drv->handle.LayerCfg[1].InputOffset = bb->src_stride * 2 - bb->width;
+  drv->handle.LayerCfg[1].AlphaMode = 0;
+  drv->handle.LayerCfg[1].InputAlpha = 0;
+  HAL_DMA2D_ConfigLayer(&drv->handle, 1);
 
   dma2d_config_clut(1, gfx_color_to_color32(bb->src_fg),
                     gfx_color_to_color32(bb->src_bg));
 
-  HAL_DMA2D_Start(&dma2d_handle, (uint32_t)bb->src_row + bb->src_x / 2,
+  HAL_DMA2D_Start(&drv->handle, (uint32_t)bb->src_row + bb->src_x / 2,
                   (uint32_t)bb->dst_row + bb->dst_x * sizeof(uint16_t),
                   bb->width, bb->height);
   return true;
 }
 
 bool dma2d_rgb565_copy_rgb565(const gfx_bitblt_t* bb) {
+  dma2d_driver_t* drv = &g_dma2d_driver;
+
+  if (!drv->initialized) {
+    return false;
+  }
+
   dma2d_wait();
 
   if (!dma2d_accessible(bb->dst_row) || !dma2d_accessible(bb->src_row)) {
     return false;
   }
 
-  dma2d_handle.Init.ColorMode = DMA2D_OUTPUT_RGB565;
-  dma2d_handle.Init.Mode = DMA2D_M2M_PFC;
-  dma2d_handle.Init.OutputOffset =
-      bb->dst_stride / sizeof(uint16_t) - bb->width;
-  HAL_DMA2D_Init(&dma2d_handle);
+  drv->handle.Init.ColorMode = DMA2D_OUTPUT_RGB565;
+  drv->handle.Init.Mode = DMA2D_M2M_PFC;
+  drv->handle.Init.OutputOffset = bb->dst_stride / sizeof(uint16_t) - bb->width;
+  HAL_DMA2D_Init(&drv->handle);
 
-  dma2d_handle.LayerCfg[1].InputColorMode = DMA2D_INPUT_RGB565;
-  dma2d_handle.LayerCfg[1].InputOffset =
+  drv->handle.LayerCfg[1].InputColorMode = DMA2D_INPUT_RGB565;
+  drv->handle.LayerCfg[1].InputOffset =
       bb->src_stride / sizeof(uint16_t) - bb->width;
-  dma2d_handle.LayerCfg[1].AlphaMode = 0;
-  dma2d_handle.LayerCfg[1].InputAlpha = 0;
-  HAL_DMA2D_ConfigLayer(&dma2d_handle, 1);
+  drv->handle.LayerCfg[1].AlphaMode = 0;
+  drv->handle.LayerCfg[1].InputAlpha = 0;
+  HAL_DMA2D_ConfigLayer(&drv->handle, 1);
 
-  HAL_DMA2D_Start(&dma2d_handle,
+  HAL_DMA2D_Start(&drv->handle,
                   (uint32_t)bb->src_row + bb->src_x * sizeof(uint16_t),
                   (uint32_t)bb->dst_row + bb->dst_x * sizeof(uint16_t),
                   bb->width, bb->height);
@@ -292,6 +344,12 @@ static void dma2d_rgb565_blend_mono4_last_col(const gfx_bitblt_t* bb) {
 }
 
 bool dma2d_rgb565_blend_mono4(const gfx_bitblt_t* params) {
+  dma2d_driver_t* drv = &g_dma2d_driver;
+
+  if (!drv->initialized) {
+    return false;
+  }
+
   dma2d_wait();
 
   gfx_bitblt_t bb_copy = *params;
@@ -318,31 +376,31 @@ bool dma2d_rgb565_blend_mono4(const gfx_bitblt_t* params) {
   }
 
   if (bb->width > 0) {
-    dma2d_handle.Init.ColorMode = DMA2D_OUTPUT_RGB565;
-    dma2d_handle.Init.Mode = DMA2D_M2M_BLEND;
-    dma2d_handle.Init.OutputOffset =
+    drv->handle.Init.ColorMode = DMA2D_OUTPUT_RGB565;
+    drv->handle.Init.Mode = DMA2D_M2M_BLEND;
+    drv->handle.Init.OutputOffset =
         bb->dst_stride / sizeof(uint16_t) - bb->width;
-    HAL_DMA2D_Init(&dma2d_handle);
+    HAL_DMA2D_Init(&drv->handle);
 
-    dma2d_handle.LayerCfg[1].InputColorMode = DMA2D_INPUT_L4;
-    dma2d_handle.LayerCfg[1].InputOffset = bb->src_stride * 2 - bb->width;
-    dma2d_handle.LayerCfg[1].AlphaMode = DMA2D_COMBINE_ALPHA;
-    dma2d_handle.LayerCfg[1].InputAlpha = bb->src_alpha;
-    HAL_DMA2D_ConfigLayer(&dma2d_handle, 1);
+    drv->handle.LayerCfg[1].InputColorMode = DMA2D_INPUT_L4;
+    drv->handle.LayerCfg[1].InputOffset = bb->src_stride * 2 - bb->width;
+    drv->handle.LayerCfg[1].AlphaMode = DMA2D_COMBINE_ALPHA;
+    drv->handle.LayerCfg[1].InputAlpha = bb->src_alpha;
+    HAL_DMA2D_ConfigLayer(&drv->handle, 1);
 
     dma2d_config_clut(
         1, gfx_color_to_color32(bb->src_fg),
         gfx_color32_set_alpha(gfx_color_to_color32(bb->src_fg), 0));
 
-    dma2d_handle.LayerCfg[0].InputColorMode = DMA2D_INPUT_RGB565;
-    dma2d_handle.LayerCfg[0].InputOffset =
+    drv->handle.LayerCfg[0].InputColorMode = DMA2D_INPUT_RGB565;
+    drv->handle.LayerCfg[0].InputOffset =
         bb->dst_stride / sizeof(uint16_t) - bb->width;
-    dma2d_handle.LayerCfg[0].AlphaMode = 0;
-    dma2d_handle.LayerCfg[0].InputAlpha = 0;
-    HAL_DMA2D_ConfigLayer(&dma2d_handle, 0);
+    drv->handle.LayerCfg[0].AlphaMode = 0;
+    drv->handle.LayerCfg[0].InputAlpha = 0;
+    HAL_DMA2D_ConfigLayer(&drv->handle, 0);
 
     HAL_DMA2D_BlendingStart(
-        &dma2d_handle, (uint32_t)bb->src_row + bb->src_x / 2,
+        &drv->handle, (uint32_t)bb->src_row + bb->src_x / 2,
         (uint32_t)bb->dst_row + bb->dst_x * sizeof(uint16_t),
         (uint32_t)bb->dst_row + bb->dst_x * sizeof(uint16_t), bb->width,
         bb->height);
@@ -352,32 +410,37 @@ bool dma2d_rgb565_blend_mono4(const gfx_bitblt_t* params) {
 }
 
 bool dma2d_rgb565_blend_mono8(const gfx_bitblt_t* bb) {
+  dma2d_driver_t* drv = &g_dma2d_driver;
+
+  if (!drv->initialized) {
+    return false;
+  }
+
   dma2d_wait();
 
   if (!dma2d_accessible(bb->dst_row) || !dma2d_accessible(bb->src_row)) {
     return false;
   }
 
-  dma2d_handle.Init.ColorMode = DMA2D_OUTPUT_RGB565;
-  dma2d_handle.Init.Mode = DMA2D_M2M_BLEND;
-  dma2d_handle.Init.OutputOffset =
+  drv->handle.Init.ColorMode = DMA2D_OUTPUT_RGB565;
+  drv->handle.Init.Mode = DMA2D_M2M_BLEND;
+  drv->handle.Init.OutputOffset = bb->dst_stride / sizeof(uint16_t) - bb->width;
+  HAL_DMA2D_Init(&drv->handle);
+
+  drv->handle.LayerCfg[1].InputColorMode = DMA2D_INPUT_A8;
+  drv->handle.LayerCfg[1].InputOffset = bb->src_stride - bb->width;
+  drv->handle.LayerCfg[1].AlphaMode = 0;
+  drv->handle.LayerCfg[1].InputAlpha = gfx_color_to_color32(bb->src_fg);
+  HAL_DMA2D_ConfigLayer(&drv->handle, 1);
+
+  drv->handle.LayerCfg[0].InputColorMode = DMA2D_INPUT_RGB565;
+  drv->handle.LayerCfg[0].InputOffset =
       bb->dst_stride / sizeof(uint16_t) - bb->width;
-  HAL_DMA2D_Init(&dma2d_handle);
+  drv->handle.LayerCfg[0].AlphaMode = 0;
+  drv->handle.LayerCfg[0].InputAlpha = 0;
+  HAL_DMA2D_ConfigLayer(&drv->handle, 0);
 
-  dma2d_handle.LayerCfg[1].InputColorMode = DMA2D_INPUT_A8;
-  dma2d_handle.LayerCfg[1].InputOffset = bb->src_stride - bb->width;
-  dma2d_handle.LayerCfg[1].AlphaMode = 0;
-  dma2d_handle.LayerCfg[1].InputAlpha = gfx_color_to_color32(bb->src_fg);
-  HAL_DMA2D_ConfigLayer(&dma2d_handle, 1);
-
-  dma2d_handle.LayerCfg[0].InputColorMode = DMA2D_INPUT_RGB565;
-  dma2d_handle.LayerCfg[0].InputOffset =
-      bb->dst_stride / sizeof(uint16_t) - bb->width;
-  dma2d_handle.LayerCfg[0].AlphaMode = 0;
-  dma2d_handle.LayerCfg[0].InputAlpha = 0;
-  HAL_DMA2D_ConfigLayer(&dma2d_handle, 0);
-
-  HAL_DMA2D_BlendingStart(&dma2d_handle, (uint32_t)bb->src_row + bb->src_x,
+  HAL_DMA2D_BlendingStart(&drv->handle, (uint32_t)bb->src_row + bb->src_x,
                           (uint32_t)bb->dst_row + bb->dst_x * sizeof(uint16_t),
                           (uint32_t)bb->dst_row + bb->dst_x * sizeof(uint16_t),
                           bb->width, bb->height);
@@ -386,6 +449,12 @@ bool dma2d_rgb565_blend_mono8(const gfx_bitblt_t* bb) {
 }
 
 bool dma2d_rgba8888_fill(const gfx_bitblt_t* bb) {
+  dma2d_driver_t* drv = &g_dma2d_driver;
+
+  if (!drv->initialized) {
+    return false;
+  }
+
   dma2d_wait();
 
   if (!dma2d_accessible(bb->dst_row)) {
@@ -393,38 +462,38 @@ bool dma2d_rgba8888_fill(const gfx_bitblt_t* bb) {
   }
 
   if (bb->src_alpha == 255) {
-    dma2d_handle.Init.ColorMode = DMA2D_OUTPUT_ARGB8888;
-    dma2d_handle.Init.Mode = DMA2D_R2M;
-    dma2d_handle.Init.OutputOffset =
+    drv->handle.Init.ColorMode = DMA2D_OUTPUT_ARGB8888;
+    drv->handle.Init.Mode = DMA2D_R2M;
+    drv->handle.Init.OutputOffset =
         bb->dst_stride / sizeof(uint32_t) - bb->width;
-    HAL_DMA2D_Init(&dma2d_handle);
+    HAL_DMA2D_Init(&drv->handle);
 
-    HAL_DMA2D_Start(&dma2d_handle, gfx_color_to_color32(bb->src_fg),
+    HAL_DMA2D_Start(&drv->handle, gfx_color_to_color32(bb->src_fg),
                     (uint32_t)bb->dst_row + bb->dst_x * sizeof(uint32_t),
                     bb->width, bb->height);
   } else {
 #ifdef STM32U5
-    dma2d_handle.Init.ColorMode = DMA2D_OUTPUT_ARGB8888;
-    dma2d_handle.Init.Mode = DMA2D_M2M_BLEND_FG;
-    dma2d_handle.Init.OutputOffset =
+    drv->handle.Init.ColorMode = DMA2D_OUTPUT_ARGB8888;
+    drv->handle.Init.Mode = DMA2D_M2M_BLEND_FG;
+    drv->handle.Init.OutputOffset =
         bb->dst_stride / sizeof(uint32_t) - bb->width;
-    HAL_DMA2D_Init(&dma2d_handle);
+    HAL_DMA2D_Init(&drv->handle);
 
-    dma2d_handle.LayerCfg[1].InputColorMode = DMA2D_INPUT_ARGB8888;
-    dma2d_handle.LayerCfg[1].InputOffset = 0;
-    dma2d_handle.LayerCfg[1].AlphaMode = DMA2D_REPLACE_ALPHA;
-    dma2d_handle.LayerCfg[1].InputAlpha = bb->src_alpha;
-    HAL_DMA2D_ConfigLayer(&dma2d_handle, 1);
+    drv->handle.LayerCfg[1].InputColorMode = DMA2D_INPUT_ARGB8888;
+    drv->handle.LayerCfg[1].InputOffset = 0;
+    drv->handle.LayerCfg[1].AlphaMode = DMA2D_REPLACE_ALPHA;
+    drv->handle.LayerCfg[1].InputAlpha = bb->src_alpha;
+    HAL_DMA2D_ConfigLayer(&drv->handle, 1);
 
-    dma2d_handle.LayerCfg[0].InputColorMode = DMA2D_INPUT_ARGB8888;
-    dma2d_handle.LayerCfg[0].InputOffset =
+    drv->handle.LayerCfg[0].InputColorMode = DMA2D_INPUT_ARGB8888;
+    drv->handle.LayerCfg[0].InputOffset =
         bb->dst_stride / sizeof(uint32_t) - bb->width;
-    dma2d_handle.LayerCfg[0].AlphaMode = 0;
-    dma2d_handle.LayerCfg[0].InputAlpha = 0;
-    HAL_DMA2D_ConfigLayer(&dma2d_handle, 0);
+    drv->handle.LayerCfg[0].AlphaMode = 0;
+    drv->handle.LayerCfg[0].InputAlpha = 0;
+    HAL_DMA2D_ConfigLayer(&drv->handle, 0);
 
     HAL_DMA2D_BlendingStart(
-        &dma2d_handle, gfx_color_to_color32(bb->src_fg),
+        &drv->handle, gfx_color_to_color32(bb->src_fg),
         (uint32_t)bb->dst_row + bb->dst_x * sizeof(uint32_t),
         (uint32_t)bb->dst_row + bb->dst_x * sizeof(uint32_t), bb->width,
         bb->height);
@@ -467,8 +536,15 @@ static void dma2d_rgba8888_copy_mono4_last_col(gfx_bitblt_t* bb,
 }
 
 bool dma2d_rgba8888_copy_mono4(const gfx_bitblt_t* params) {
-  const gfx_color32_t* src_gradient = NULL;
+  dma2d_driver_t* drv = &g_dma2d_driver;
 
+  if (!drv->initialized) {
+    return false;
+  }
+
+  dma2d_wait();
+
+  const gfx_color32_t* src_gradient = NULL;
   gfx_bitblt_t bb_copy = *params;
   gfx_bitblt_t* bb = &bb_copy;
 
@@ -498,48 +574,52 @@ bool dma2d_rgba8888_copy_mono4(const gfx_bitblt_t* params) {
     bb->width -= 1;
   }
 
-  dma2d_handle.Init.ColorMode = DMA2D_OUTPUT_ARGB8888;
-  dma2d_handle.Init.Mode = DMA2D_M2M_PFC;
-  dma2d_handle.Init.OutputOffset =
-      bb->dst_stride / sizeof(uint32_t) - bb->width;
-  HAL_DMA2D_Init(&dma2d_handle);
+  drv->handle.Init.ColorMode = DMA2D_OUTPUT_ARGB8888;
+  drv->handle.Init.Mode = DMA2D_M2M_PFC;
+  drv->handle.Init.OutputOffset = bb->dst_stride / sizeof(uint32_t) - bb->width;
+  HAL_DMA2D_Init(&drv->handle);
 
-  dma2d_handle.LayerCfg[1].InputColorMode = DMA2D_INPUT_L4;
-  dma2d_handle.LayerCfg[1].InputOffset = bb->src_stride * 2 - bb->width;
-  dma2d_handle.LayerCfg[1].AlphaMode = 0;
-  dma2d_handle.LayerCfg[1].InputAlpha = 0;
-  HAL_DMA2D_ConfigLayer(&dma2d_handle, 1);
+  drv->handle.LayerCfg[1].InputColorMode = DMA2D_INPUT_L4;
+  drv->handle.LayerCfg[1].InputOffset = bb->src_stride * 2 - bb->width;
+  drv->handle.LayerCfg[1].AlphaMode = 0;
+  drv->handle.LayerCfg[1].InputAlpha = 0;
+  HAL_DMA2D_ConfigLayer(&drv->handle, 1);
 
   dma2d_config_clut(1, gfx_color_to_color32(bb->src_fg),
                     gfx_color_to_color32(bb->src_bg));
 
-  HAL_DMA2D_Start(&dma2d_handle, (uint32_t)bb->src_row + bb->src_x / 2,
+  HAL_DMA2D_Start(&drv->handle, (uint32_t)bb->src_row + bb->src_x / 2,
                   (uint32_t)bb->dst_row + bb->dst_x * sizeof(uint32_t),
                   bb->width, bb->height);
   return true;
 }
 
 bool dma2d_rgba8888_copy_rgb565(const gfx_bitblt_t* bb) {
+  dma2d_driver_t* drv = &g_dma2d_driver;
+
+  if (!drv->initialized) {
+    return false;
+  }
+
   dma2d_wait();
 
   if (!dma2d_accessible(bb->dst_row) || !dma2d_accessible(bb->src_row)) {
     return false;
   }
 
-  dma2d_handle.Init.ColorMode = DMA2D_OUTPUT_ARGB8888;
-  dma2d_handle.Init.Mode = DMA2D_M2M_PFC;
-  dma2d_handle.Init.OutputOffset =
-      bb->dst_stride / sizeof(uint32_t) - bb->width;
-  HAL_DMA2D_Init(&dma2d_handle);
+  drv->handle.Init.ColorMode = DMA2D_OUTPUT_ARGB8888;
+  drv->handle.Init.Mode = DMA2D_M2M_PFC;
+  drv->handle.Init.OutputOffset = bb->dst_stride / sizeof(uint32_t) - bb->width;
+  HAL_DMA2D_Init(&drv->handle);
 
-  dma2d_handle.LayerCfg[1].InputColorMode = DMA2D_INPUT_RGB565;
-  dma2d_handle.LayerCfg[1].InputOffset =
+  drv->handle.LayerCfg[1].InputColorMode = DMA2D_INPUT_RGB565;
+  drv->handle.LayerCfg[1].InputOffset =
       bb->src_stride / sizeof(uint16_t) - bb->width;
-  dma2d_handle.LayerCfg[1].AlphaMode = 0;
-  dma2d_handle.LayerCfg[1].InputAlpha = 0;
-  HAL_DMA2D_ConfigLayer(&dma2d_handle, 1);
+  drv->handle.LayerCfg[1].AlphaMode = 0;
+  drv->handle.LayerCfg[1].InputAlpha = 0;
+  HAL_DMA2D_ConfigLayer(&drv->handle, 1);
 
-  HAL_DMA2D_Start(&dma2d_handle,
+  HAL_DMA2D_Start(&drv->handle,
                   (uint32_t)bb->src_row + bb->src_x * sizeof(uint16_t),
                   (uint32_t)bb->dst_row + bb->dst_x * sizeof(uint32_t),
                   bb->width, bb->height);
@@ -579,6 +659,12 @@ static void dma2d_rgba8888_blend_mono4_last_col(const gfx_bitblt_t* bb) {
 }
 
 bool dma2d_rgba8888_blend_mono4(const gfx_bitblt_t* params) {
+  dma2d_driver_t* drv = &g_dma2d_driver;
+
+  if (!drv->initialized) {
+    return false;
+  }
+
   dma2d_wait();
 
   gfx_bitblt_t bb_copy = *params;
@@ -605,31 +691,31 @@ bool dma2d_rgba8888_blend_mono4(const gfx_bitblt_t* params) {
   }
 
   if (bb->width > 0) {
-    dma2d_handle.Init.ColorMode = DMA2D_OUTPUT_ARGB8888;
-    dma2d_handle.Init.Mode = DMA2D_M2M_BLEND;
-    dma2d_handle.Init.OutputOffset =
+    drv->handle.Init.ColorMode = DMA2D_OUTPUT_ARGB8888;
+    drv->handle.Init.Mode = DMA2D_M2M_BLEND;
+    drv->handle.Init.OutputOffset =
         bb->dst_stride / sizeof(uint32_t) - bb->width;
-    HAL_DMA2D_Init(&dma2d_handle);
+    HAL_DMA2D_Init(&drv->handle);
 
-    dma2d_handle.LayerCfg[1].InputColorMode = DMA2D_INPUT_L4;
-    dma2d_handle.LayerCfg[1].InputOffset = bb->src_stride * 2 - bb->width;
-    dma2d_handle.LayerCfg[1].AlphaMode = DMA2D_COMBINE_ALPHA;
-    dma2d_handle.LayerCfg[1].InputAlpha = bb->src_alpha;
-    HAL_DMA2D_ConfigLayer(&dma2d_handle, 1);
+    drv->handle.LayerCfg[1].InputColorMode = DMA2D_INPUT_L4;
+    drv->handle.LayerCfg[1].InputOffset = bb->src_stride * 2 - bb->width;
+    drv->handle.LayerCfg[1].AlphaMode = DMA2D_COMBINE_ALPHA;
+    drv->handle.LayerCfg[1].InputAlpha = bb->src_alpha;
+    HAL_DMA2D_ConfigLayer(&drv->handle, 1);
 
     dma2d_config_clut(
         1, gfx_color_to_color32(bb->src_fg),
         gfx_color32_set_alpha(gfx_color_to_color32(bb->src_fg), 0));
 
-    dma2d_handle.LayerCfg[0].InputColorMode = DMA2D_INPUT_ARGB8888;
-    dma2d_handle.LayerCfg[0].InputOffset =
+    drv->handle.LayerCfg[0].InputColorMode = DMA2D_INPUT_ARGB8888;
+    drv->handle.LayerCfg[0].InputOffset =
         bb->dst_stride / sizeof(uint32_t) - bb->width;
-    dma2d_handle.LayerCfg[0].AlphaMode = 0;
-    dma2d_handle.LayerCfg[0].InputAlpha = 0;
-    HAL_DMA2D_ConfigLayer(&dma2d_handle, 0);
+    drv->handle.LayerCfg[0].AlphaMode = 0;
+    drv->handle.LayerCfg[0].InputAlpha = 0;
+    HAL_DMA2D_ConfigLayer(&drv->handle, 0);
 
     HAL_DMA2D_BlendingStart(
-        &dma2d_handle, (uint32_t)bb->src_row + bb->src_x / 2,
+        &drv->handle, (uint32_t)bb->src_row + bb->src_x / 2,
         (uint32_t)bb->dst_row + bb->dst_x * sizeof(uint32_t),
         (uint32_t)bb->dst_row + bb->dst_x * sizeof(uint32_t), bb->width,
         bb->height);
@@ -639,32 +725,37 @@ bool dma2d_rgba8888_blend_mono4(const gfx_bitblt_t* params) {
 }
 
 bool dma2d_rgba8888_blend_mono8(const gfx_bitblt_t* bb) {
+  dma2d_driver_t* drv = &g_dma2d_driver;
+
+  if (!drv->initialized) {
+    return false;
+  }
+
   dma2d_wait();
 
   if (!dma2d_accessible(bb->dst_row) || !dma2d_accessible(bb->src_row)) {
     return false;
   }
 
-  dma2d_handle.Init.ColorMode = DMA2D_OUTPUT_ARGB8888;
-  dma2d_handle.Init.Mode = DMA2D_M2M_BLEND;
-  dma2d_handle.Init.OutputOffset =
+  drv->handle.Init.ColorMode = DMA2D_OUTPUT_ARGB8888;
+  drv->handle.Init.Mode = DMA2D_M2M_BLEND;
+  drv->handle.Init.OutputOffset = bb->dst_stride / sizeof(uint32_t) - bb->width;
+  HAL_DMA2D_Init(&drv->handle);
+
+  drv->handle.LayerCfg[1].InputColorMode = DMA2D_INPUT_A8;
+  drv->handle.LayerCfg[1].InputOffset = bb->src_stride - bb->width;
+  drv->handle.LayerCfg[1].AlphaMode = 0;
+  drv->handle.LayerCfg[1].InputAlpha = gfx_color_to_color32(bb->src_fg);
+  HAL_DMA2D_ConfigLayer(&drv->handle, 1);
+
+  drv->handle.LayerCfg[0].InputColorMode = DMA2D_INPUT_ARGB8888;
+  drv->handle.LayerCfg[0].InputOffset =
       bb->dst_stride / sizeof(uint32_t) - bb->width;
-  HAL_DMA2D_Init(&dma2d_handle);
+  drv->handle.LayerCfg[0].AlphaMode = 0;
+  drv->handle.LayerCfg[0].InputAlpha = 0;
+  HAL_DMA2D_ConfigLayer(&drv->handle, 0);
 
-  dma2d_handle.LayerCfg[1].InputColorMode = DMA2D_INPUT_A8;
-  dma2d_handle.LayerCfg[1].InputOffset = bb->src_stride - bb->width;
-  dma2d_handle.LayerCfg[1].AlphaMode = 0;
-  dma2d_handle.LayerCfg[1].InputAlpha = gfx_color_to_color32(bb->src_fg);
-  HAL_DMA2D_ConfigLayer(&dma2d_handle, 1);
-
-  dma2d_handle.LayerCfg[0].InputColorMode = DMA2D_INPUT_ARGB8888;
-  dma2d_handle.LayerCfg[0].InputOffset =
-      bb->dst_stride / sizeof(uint32_t) - bb->width;
-  dma2d_handle.LayerCfg[0].AlphaMode = 0;
-  dma2d_handle.LayerCfg[0].InputAlpha = 0;
-  HAL_DMA2D_ConfigLayer(&dma2d_handle, 0);
-
-  HAL_DMA2D_BlendingStart(&dma2d_handle, (uint32_t)bb->src_row + bb->src_x,
+  HAL_DMA2D_BlendingStart(&drv->handle, (uint32_t)bb->src_row + bb->src_x,
                           (uint32_t)bb->dst_row + bb->dst_x * sizeof(uint32_t),
                           (uint32_t)bb->dst_row + bb->dst_x * sizeof(uint32_t),
                           bb->width, bb->height);
@@ -673,26 +764,31 @@ bool dma2d_rgba8888_blend_mono8(const gfx_bitblt_t* bb) {
 }
 
 bool dma2d_rgba8888_copy_rgba8888(const gfx_bitblt_t* bb) {
+  dma2d_driver_t* drv = &g_dma2d_driver;
+
+  if (!drv->initialized) {
+    return false;
+  }
+
   dma2d_wait();
 
   if (!dma2d_accessible(bb->dst_row) || !dma2d_accessible(bb->src_row)) {
     return false;
   }
 
-  dma2d_handle.Init.ColorMode = DMA2D_OUTPUT_ARGB8888;
-  dma2d_handle.Init.Mode = DMA2D_M2M_PFC;
-  dma2d_handle.Init.OutputOffset =
-      bb->dst_stride / sizeof(uint32_t) - bb->width;
-  HAL_DMA2D_Init(&dma2d_handle);
+  drv->handle.Init.ColorMode = DMA2D_OUTPUT_ARGB8888;
+  drv->handle.Init.Mode = DMA2D_M2M_PFC;
+  drv->handle.Init.OutputOffset = bb->dst_stride / sizeof(uint32_t) - bb->width;
+  HAL_DMA2D_Init(&drv->handle);
 
-  dma2d_handle.LayerCfg[1].InputColorMode = DMA2D_INPUT_ARGB8888;
-  dma2d_handle.LayerCfg[1].InputOffset =
+  drv->handle.LayerCfg[1].InputColorMode = DMA2D_INPUT_ARGB8888;
+  drv->handle.LayerCfg[1].InputOffset =
       bb->src_stride / sizeof(uint32_t) - bb->width;
-  dma2d_handle.LayerCfg[1].AlphaMode = 0;
-  dma2d_handle.LayerCfg[1].InputAlpha = 0;
-  HAL_DMA2D_ConfigLayer(&dma2d_handle, 1);
+  drv->handle.LayerCfg[1].AlphaMode = 0;
+  drv->handle.LayerCfg[1].InputAlpha = 0;
+  HAL_DMA2D_ConfigLayer(&drv->handle, 1);
 
-  HAL_DMA2D_Start(&dma2d_handle,
+  HAL_DMA2D_Start(&drv->handle,
                   (uint32_t)bb->src_row + bb->src_x * sizeof(uint32_t),
                   (uint32_t)bb->dst_row + bb->dst_x * sizeof(uint32_t),
                   bb->width, bb->height);

--- a/core/embed/gfx/bitblt/stm32/dma2d_bitblt.c
+++ b/core/embed/gfx/bitblt/stm32/dma2d_bitblt.c
@@ -776,6 +776,10 @@ bool dma2d_rgba8888_copy_rgba8888(const gfx_bitblt_t* bb) {
     return false;
   }
 
+  if (bb->src_downscale > 0) {
+    return false;
+  }
+
   drv->handle.Init.ColorMode = DMA2D_OUTPUT_ARGB8888;
   drv->handle.Init.Mode = DMA2D_M2M_PFC;
   drv->handle.Init.OutputOffset = bb->dst_stride / sizeof(uint32_t) - bb->width;

--- a/core/embed/gfx/inc/gfx/gfx_bitblt.h
+++ b/core/embed/gfx/inc/gfx/gfx_bitblt.h
@@ -72,6 +72,9 @@ typedef struct {
   gfx_color_t src_bg;
   // Alpha value for fill operation (255 => normal fill, 0 => noop)
   uint8_t src_alpha;
+  // Downscaling for the source bitmap
+  // (0 => no downscaling, 1 => 1/2, 2 => 1/4, 3 => 1/8)
+  uint8_t src_downscale;
 
 } gfx_bitblt_t;
 

--- a/core/embed/gfx/inc/gfx/jpegdec.h
+++ b/core/embed/gfx/inc/gfx/jpegdec.h
@@ -1,0 +1,127 @@
+/*
+ * This file is part of the Trezor project, https://trezor.io/
+ *
+ * Copyright (c) SatoshiLabs
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#pragma once
+
+#include <trezor_types.h>
+
+// Maximum number of blocks (8x8) in a slice.
+// The more blocks we use, the decodeer is faster.
+// Minimum value is 4 to support 4:2:0 subsampling (MCU is 16x16).
+#define JPEGDEC_MAX_SLICE_BLOCKS 16
+
+// Size of Y/YCbCr data buffer
+// The worst case is 192 bytes per block (8x8 pixels) for 4:4:4 subsampling
+#define JPEGDEC_YCBCR_BUFFER_SIZE (JPEGDEC_MAX_SLICE_BLOCKS * 8 * 8 * 3)
+
+// Maximum size of the RGBA8888 buffer for a slice.
+#define JPEGDEC_RGBA8888_BUFFER_SIZE (JPEGDEC_MAX_SLICE_BLOCKS * 8 * 8 * 4)
+
+typedef struct jpegdec jpegdec_t;
+
+typedef enum {
+  // Decoder needs more data
+  // (jpegdec_process should be called with more data)
+  JPEGDEC_STATE_NEED_DATA,
+  // Image info is ready
+  // (jpegdec_get_info can be called to get the image info)
+  JPEGDEC_STATE_INFO_READY,
+  // Decoded slice is ready
+  // (jpegdec_get_slice_rgba8888 can be called to get the slice data)
+  JPEGDEC_STATE_SLICE_READY,
+  // Decoding is finished
+  JPEGDEC_STATE_FINISHED,
+  // Error occurred, decoding is stopped
+  JPEGDEC_STATE_ERROR,
+} jpegdec_state_t;
+
+typedef enum {
+  JPEGDEC_IMAGE_GRAYSCALE,  // Gray scale image
+  JPEGDEC_IMAGE_YCBCR420,   // Color image with 4:2:0 subsampling
+  JPEGDEC_IMAGE_YCBCR422,   // Color image with 4:2:2 subsampling
+  JPEGDEC_IMAGE_YCBCR444,   // Color image with 4:4:4 subsampling
+} jpegdec_image_format_t;
+
+typedef struct {
+  // Pointer to the data
+  const uint8_t* data;
+  // Size of the data in bytes
+  size_t size;
+  // Current offset in the data
+  size_t offset;
+  // Set to true when no more data is available
+  bool last_chunk;
+} jpegdec_input_t;
+
+typedef struct {
+  // Image format
+  jpegdec_image_format_t format;
+  // Image width in pixels
+  int16_t width;
+  // Image height in pixels
+  int16_t height;
+} jpegdec_image_t;
+
+typedef struct {
+  // Slice x-coordinate
+  int16_t x;
+  // Slice y-coordinate
+  int16_t y;
+  // Slice width
+  int16_t width;
+  // Slice height
+  int16_t height;
+} jpegdec_slice_t;
+
+// Initialize and reset the decoder internal state
+bool jpegdec_open(void);
+
+// Release the decoder and free resources
+void jpegdec_close(void);
+
+// Process all or part of the input buffer and advances the `input->offset`
+//
+// `input->offset` must be aligned to 4 bytes.
+// `input->size` must be aligned to 4 bytes except for the last chunk.
+// `input->last_chunk` must be set to true when no more data is available.
+//
+// Returns the current state of the decoder:
+// - `JPEGDEC_STATE_NEED_DATA` - more data is needed
+// - `JPEGDEC_STATE_INFO_READY` - the image info is ready
+// - `JPEGDEC_STATE_SLICE_READY` - a decoded slice is ready
+// - `JPEGDEC_STATE_FINISHED` - the decoding is finished
+// - `JPEGDEC_STATE_ERROR` - an error occurred
+jpegdec_state_t jpegdec_process(jpegdec_input_t* input);
+
+// Get the decoded image info
+//
+// Can be called anytimer if the decoder went through the
+// `JPEGDEC_STATE_INFO_READY` state.
+//
+// Returns true if the info is available
+bool jpegdec_get_info(jpegdec_image_t* info);
+
+// Copy the last decoded slice to the buffer
+//
+// `rgba8888` must be a buffer of at least `JPEGDEC_RGBA8888_BUFFER_SIZE`
+// bytes and must be aligned to 4 bytes.
+//
+// Can be called immediately after `jpegdec_process` returns
+// `JPEGDEC_STATE_SLICE_READY`.
+bool jpegdec_get_slice_rgba8888(uint32_t* rgba8888, jpegdec_slice_t* slice);

--- a/core/embed/gfx/jpegdec/stm32u5/jpegdec.c
+++ b/core/embed/gfx/jpegdec/stm32u5/jpegdec.c
@@ -1,0 +1,474 @@
+/*
+ * This file is part of the Trezor project, https://trezor.io/
+ *
+ * Copyright (c) SatoshiLabs
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#ifdef KERNEL_MODE
+
+#include <trezor_bsp.h>
+#include <trezor_rtl.h>
+
+#include <gfx/jpegdec.h>
+#include <rtl/sizedefs.h>
+#include <sys/systick.h>
+
+#include <../bitblt/dma2d_bitblt.h>
+
+#include <sys/trustzone.h>
+
+// Fixes of STMicro bugs in cmsis-device-u5
+#undef JPEG_BASE_S
+#define JPEG_BASE_S (AHB1PERIPH_BASE_S + 0x0A000UL)
+#undef JPEG_CFR_CEOCF_Pos
+#define JPEG_CFR_CEOCF_Pos (5U)
+#undef JPEG_CFR_CHPDF_Pos
+#define JPEG_CFR_CHPDF_Pos (6U)
+
+// JPEG decoder processing timeout in microseconds.
+// The timeout must be selected to be long enough to process a single slice.
+// 100us @ 160MHZ CPU clock speed => 8000 CPU cycles
+// JPEG decoder issues 1pixel/1cycles => 125 8x8 blocks
+#define JPEGDEC_PROCESSING_TIMEOUT_US 100
+
+// JPEG decoder state
+struct jpegdec {
+  // Set if the decoder is in use
+  bool inuse;
+
+  // DMA channel for JPEG data output
+  DMA_HandleTypeDef hdma;
+
+  // Current state of the FSM
+  jpegdec_state_t state;
+  // Decoded image parameters
+  jpegdec_image_t image;
+
+  // Decoded image MCU width
+  int16_t mcu_width;
+  // Decoded image MCU height
+  int16_t mcu_height;
+  // Decoded image MCU size in bytes
+  size_t mcu_size;
+
+  // Decoded YCbCr data for the current slice
+  uint32_t ycbcr_buffer[JPEGDEC_YCBCR_BUFFER_SIZE / sizeof(uint32_t)];
+
+  // Current slice x-coordinate
+  int16_t slice_x;
+  // Current slice y-coordinate
+  int16_t slice_y;
+  // Current slice width
+  int16_t slice_width;
+  // Current slice height
+  int16_t slice_height;
+};
+
+// JPEG decoder instance
+jpegdec_t g_jpegdec = {
+    .inuse = false,
+};
+
+bool jpegdec_open(void) {
+  jpegdec_t *dec = &g_jpegdec;
+
+  if (dec->inuse) {
+    return false;
+  }
+
+  memset(dec, 0, sizeof(jpegdec_t));
+  dec->inuse = true;
+
+  __HAL_RCC_JPEG_FORCE_RESET();
+  __HAL_RCC_JPEG_RELEASE_RESET();
+  __HAL_RCC_JPEG_CLK_ENABLE();
+
+  // Configure JPEG codec for decoding and header parsing
+  JPEG->CR |= JPEG_CR_JCEN;
+  JPEG->CONFR1 |= JPEG_CONFR1_DE;
+  JPEG->CONFR1 |= JPEG_CONFR1_HDR;
+  JPEG->CONFR0 |= JPEG_CONFR0_START;
+  JPEG->CR |= JPEG_CR_OFF | JPEG_CR_IFF;
+
+  // Configure DMA channel for JPEG data output
+  __HAL_RCC_GPDMA1_CLK_ENABLE();
+  dec->hdma.Instance = GPDMA1_Channel4;
+  dec->hdma.Init.Request = GPDMA1_REQUEST_JPEG_TX;
+  dec->hdma.Init.BlkHWRequest = DMA_BREQ_SINGLE_BURST;
+  dec->hdma.Init.Direction = DMA_PERIPH_TO_MEMORY;
+  dec->hdma.Init.SrcInc = DMA_SINC_FIXED;
+  dec->hdma.Init.DestInc = DMA_DINC_INCREMENTED;
+  dec->hdma.Init.SrcDataWidth = DMA_SRC_DATAWIDTH_WORD;
+  dec->hdma.Init.DestDataWidth = DMA_DEST_DATAWIDTH_WORD;
+  dec->hdma.Init.Priority = DMA_LOW_PRIORITY_LOW_WEIGHT;
+  dec->hdma.Init.SrcBurstLength = 8;
+  dec->hdma.Init.DestBurstLength = 8;
+  dec->hdma.Init.TransferAllocatedPort =
+      DMA_SRC_ALLOCATED_PORT1 | DMA_DEST_ALLOCATED_PORT0;
+  dec->hdma.Init.TransferEventMode = DMA_TCEM_BLOCK_TRANSFER;
+  dec->hdma.Init.Mode = DMA_NORMAL;
+
+  if (HAL_DMA_Init(&dec->hdma) != HAL_OK) {
+    dec->hdma.Instance = NULL;
+    goto cleanup;
+  }
+
+  if (HAL_DMA_ConfigChannelAttributes(
+          &dec->hdma, DMA_CHANNEL_PRIV | DMA_CHANNEL_SEC | DMA_CHANNEL_SRC_SEC |
+                          DMA_CHANNEL_DEST_SEC) != HAL_OK) {
+    goto cleanup;
+  }
+
+  return true;
+
+cleanup:
+  jpegdec_close();
+  return false;
+}
+
+void jpegdec_close(void) {
+  jpegdec_t *dec = &g_jpegdec;
+
+  if (dec->hdma.Instance != NULL) {
+    HAL_DMA_Abort(&dec->hdma);
+    HAL_DMA_DeInit(&dec->hdma);
+  }
+
+  __HAL_RCC_JPEG_CLK_DISABLE();
+  __HAL_RCC_JPEG_FORCE_RESET();
+  __HAL_RCC_JPEG_RELEASE_RESET();
+
+  memset(dec, 0, sizeof(jpegdec_t));
+}
+
+#define READ_REG_FIELD(reg, field) (((reg) & field##_Msk) >> field##_Pos)
+
+// Extracts image parameters from the JPEG codec registers
+// and set `dec->image` and `dec->mcu_xxx` fields
+static bool jpegdec_extract_header_info(jpegdec_t *dec) {
+  jpegdec_image_t image = {0};
+  size_t mcu_size = 64;  // Grayscale, 8x8 blocks
+  int16_t mcu_width = 8;
+  int16_t mcu_height = 8;
+
+  image.height = READ_REG_FIELD(JPEG->CONFR1, JPEG_CONFR1_YSIZE);
+  image.width = READ_REG_FIELD(JPEG->CONFR3, JPEG_CONFR3_XSIZE);
+
+  if (image.height == 0 || image.width == 0) {
+    // Image size is zero, invalid header
+    return false;
+  }
+
+  if (image.height > 32767 || image.width > 32767) {
+    // Image is too large
+    return false;
+  }
+
+  // Number of quantization tables
+  int n_qt = 1 + READ_REG_FIELD(JPEG->CONFR1, JPEG_CONFR1_NF);
+
+  if (n_qt == 1) {
+    // 1 quantization table => Grayscale
+    image.format = JPEGDEC_IMAGE_GRAYSCALE;
+  } else if (n_qt == 3) {
+    // 3 quantization table => YCbCr
+    int y_blocks = 1 + READ_REG_FIELD(JPEG->CONFR4, JPEG_CONFR4_NB);
+    int cb_blocks = 1 + READ_REG_FIELD(JPEG->CONFR5, JPEG_CONFR5_NB);
+    int cr_blocks = 1 + READ_REG_FIELD(JPEG->CONFR6, JPEG_CONFR6_NB);
+
+    mcu_size = (y_blocks + cb_blocks + cr_blocks) * 64;
+    mcu_width = (y_blocks == 1) ? 8 : 16;
+    mcu_height = (y_blocks == 4) ? 16 : 8;
+
+    if (y_blocks == 2 && cb_blocks == 1 && cr_blocks == 1) {
+      // 4:2:2 subsampling
+      image.format = JPEGDEC_IMAGE_YCBCR422;
+    } else if (y_blocks == 4 && cb_blocks == 1 && cr_blocks == 1) {
+      // 4:2:0 subsampling
+      image.format = JPEGDEC_IMAGE_YCBCR420;
+    } else if (y_blocks == 1 && cb_blocks == 1 && cr_blocks == 1) {
+      // 4:4:4 subsampling
+      image.format = JPEGDEC_IMAGE_YCBCR444;
+    } else {
+      // Unsupported subsampling
+      return false;
+    }
+  } else {
+    // 2 or 4 quantization tables are not supported
+    return false;
+  }
+
+  dec->image = image;
+  dec->mcu_size = mcu_size;
+  dec->mcu_width = mcu_width;
+  dec->mcu_height = mcu_height;
+  return true;
+}
+
+// Starts DMA transfer of the decoded YCbCr data for the current slice
+static bool jpegdec_start_dma_transfer(jpegdec_t *dec) {
+  // Number ofs MCU that fit into the YCbCr buffer
+  int n_ycbcr = sizeof(dec->ycbcr_buffer) / dec->mcu_size;
+  // Number ofs MCUs that fit into the RGB buffer
+  int n_rgb =
+      JPEGDEC_MAX_SLICE_BLOCKS / ((dec->mcu_width * dec->mcu_height) / 64);
+  // Number of remaining MCUs in the current row
+  int n_row =
+      (dec->image.width - dec->slice_x + dec->mcu_width - 1) / dec->mcu_width;
+  // Number of MCUs to decode in the current slice
+  int mcu_count = MIN(MIN(n_ycbcr, n_rgb), n_row);
+
+  dec->slice_width = dec->mcu_width * mcu_count;
+  dec->slice_height = dec->mcu_height;
+
+  if (HAL_DMA_Start(&dec->hdma, (uint32_t)&JPEG->DOR,
+                    (uint32_t)dec->ycbcr_buffer,
+                    dec->mcu_size * mcu_count) != HAL_OK) {
+    return false;
+  }
+
+  JPEG->CR |= JPEG_CR_ODMAEN;
+  return true;
+}
+
+// Feeds the input FIFO with the data from the input buffer.
+// Returns `true` if at least one word was written to the FIFO.
+static inline bool jpegdec_feed_fifo(jpegdec_t *dec, jpegdec_input_t *inp) {
+  // Input FIFO needs data
+  uint32_t *ptr = (uint32_t *)&inp->data[inp->offset];
+  if (inp->offset + 16 <= inp->size) {
+    // Feed the FIFO with 16 bytes
+    JPEG->DIR = ptr[0];
+    JPEG->DIR = ptr[1];
+    JPEG->DIR = ptr[2];
+    JPEG->DIR = ptr[3];
+    inp->offset += 16;
+    return true;
+  } else if (inp->offset < inp->size) {
+    // Feed the FIFO with the remaining data
+    while (inp->offset + 4 < inp->size) {
+      JPEG->DIR = *ptr++;
+      inp->offset += 4;
+    }
+    if (inp->offset < inp->size) {
+      size_t bits = (inp->size - inp->offset) * 8;
+      JPEG->DIR = *ptr & (0xFFFFFFFF >> (32 - bits));
+      inp->offset = inp->size;
+    }
+    return true;
+  }
+
+  return false;
+}
+
+// Advances the slice coordinates to the next slice.
+// Returns `true` if the decoding is complete.
+static inline bool jpegdec_advance_slice_coordinates(jpegdec_t *dec) {
+  dec->slice_x += dec->slice_width;
+  if (dec->slice_x >= dec->image.width) {
+    dec->slice_x = 0;
+    dec->slice_y += dec->slice_height;
+  }
+  return dec->slice_y >= dec->image.height;
+}
+
+jpegdec_state_t jpegdec_process(jpegdec_input_t *inp) {
+  jpegdec_t *dec = &g_jpegdec;
+
+  if (!dec->inuse) {
+    return JPEGDEC_STATE_ERROR;
+  }
+
+  // Check input buffer alignment
+  if (inp->offset < inp->size) {
+    if (!IS_ALIGNED(inp->offset, 4) ||
+        (!IS_ALIGNED(inp->size, 4) && !inp->last_chunk)) {
+      return JPEGDEC_STATE_ERROR;
+    }
+  }
+
+  switch (dec->state) {
+    case JPEGDEC_STATE_ERROR:
+    case JPEGDEC_STATE_FINISHED:
+      return dec->state;
+
+    case JPEGDEC_STATE_SLICE_READY:
+      if (jpegdec_advance_slice_coordinates(dec)) {
+        dec->state = JPEGDEC_STATE_FINISHED;
+        return dec->state;
+      }
+      // pass through
+    case JPEGDEC_STATE_INFO_READY:
+      if (!jpegdec_start_dma_transfer(dec)) {
+        dec->state = JPEGDEC_STATE_ERROR;
+        return dec->state;
+      }
+      break;
+
+    default:
+      break;
+  }
+
+  uint64_t expire_time = 0;  // = 0 => not active
+  bool timed_out = false;
+  uint8_t poll_counter = 0;
+
+  for (;;) {
+    uint32_t sr = JPEG->SR;
+
+    if ((sr & JPEG_SR_IFTF) != 0) {
+      if (jpegdec_feed_fifo(dec, inp)) {
+        expire_time = 0;
+        continue;  // Feed the FIFO as fast as possible
+      } else if (!inp->last_chunk) {
+        dec->state = JPEGDEC_STATE_NEED_DATA;
+        break;
+      }
+    }
+
+    if (__HAL_DMA_GET_FLAG(&dec->hdma, DMA_FLAG_TC)) {
+      // Clear status flags and prepare for the next transfer
+      HAL_DMA_PollForTransfer(&dec->hdma, HAL_DMA_FULL_TRANSFER, 0);
+      dec->state = JPEGDEC_STATE_SLICE_READY;
+      break;
+    }
+
+    if ((sr & JPEG_SR_HPDF) != 0) {
+      // Header parsing is complete
+      // Clear the HPDF flag
+      JPEG->CFR |= JPEG_CFR_CHPDF;
+      bool unexpected_header = dec->image.width > 0;
+      if (unexpected_header || !jpegdec_extract_header_info(dec)) {
+        dec->state = JPEGDEC_STATE_ERROR;
+      } else {
+        dec->state = JPEGDEC_STATE_INFO_READY;
+      }
+      break;
+    }
+
+    // Timeout processing (especially `systick_us()`) is quite expensive
+    // and therefore it is done only every 16 passes.
+    if (poll_counter-- == 0) {
+      poll_counter = 16;
+      if (expire_time == 0) {
+        // The timeout handles two situations:
+        // 1) Invalid input data that causes the JPEG codec not produce
+        //    any output and the processing is stuck.
+        // 2) Unexpected JPEG codec stuck in the processing state.
+        expire_time = systick_us() + JPEGDEC_PROCESSING_TIMEOUT_US;
+      } else if (timed_out) {
+        dec->state = JPEGDEC_STATE_ERROR;
+        break;
+      } else {
+        // `timed_out` flag is checked in the next pass
+        timed_out = systick_us() > expire_time;
+      }
+    }
+  }
+
+  if (dec->state == JPEGDEC_STATE_ERROR ||
+      dec->state == JPEGDEC_STATE_FINISHED) {
+    JPEG->CR &= ~JPEG_CR_JCEN;
+    HAL_DMA_Abort(&dec->hdma);
+  }
+
+  return dec->state;
+}
+
+bool jpegdec_get_info(jpegdec_image_t *image) {
+  jpegdec_t *dec = &g_jpegdec;
+
+  if (!dec->inuse) {
+    return false;
+  }
+
+  if (dec->image.width == 0 || dec->image.height == 0) {
+    return false;
+  }
+
+  *image = dec->image;
+  return true;
+}
+
+bool jpegdec_get_slice_rgba8888(uint32_t *rgba8888, jpegdec_slice_t *slice) {
+  jpegdec_t *dec = &g_jpegdec;
+
+  if (!dec->inuse) {
+    return false;
+  }
+
+  if (dec->state != JPEGDEC_STATE_SLICE_READY) {
+    return false;
+  }
+
+  if (!IS_ALIGNED((uint32_t)rgba8888, 4)) {
+    return false;
+  }
+
+  slice->width = dec->slice_width;
+  slice->height = dec->slice_height;
+  slice->x = dec->slice_x;
+  slice->y = dec->slice_y;
+
+  gfx_bitblt_t bb = {
+      .height = dec->slice_height,
+      .width = dec->slice_width,
+      .dst_row = rgba8888,
+      .dst_stride = dec->slice_width * 4,
+      .dst_x = 0,
+      .dst_y = 0,
+      .src_row = dec->ycbcr_buffer,
+      .src_stride = 0,
+      .src_x = 0,
+      .src_y = 0,
+      .src_fg = 0,
+      .src_bg = 0,
+      .src_alpha = 255,
+  };
+
+#ifdef KERNEL
+  tz_set_dma2d_unpriv(false);
+#endif
+
+  switch (dec->image.format) {
+    case JPEGDEC_IMAGE_YCBCR420:
+      dma2d_rgba8888_copy_ycbcr420(&bb);
+      break;
+    case JPEGDEC_IMAGE_YCBCR422:
+      dma2d_rgba8888_copy_ycbcr422(&bb);
+      break;
+    case JPEGDEC_IMAGE_YCBCR444:
+      dma2d_rgba8888_copy_ycbcr444(&bb);
+      break;
+    case JPEGDEC_IMAGE_GRAYSCALE:
+      // Conversion from grayscale to RGBA8888 is not supported
+      return false;
+    default:
+      return false;
+  }
+
+  // Wait until the DMA transfer is complete so that the caller can use
+  // data in the `rgba8888` buffer immediately.
+  dma2d_wait();
+
+#ifdef KERNEL
+  tz_set_dma2d_unpriv(true);
+#endif
+
+  return true;
+}
+
+#endif  // KERNEL_MODE

--- a/core/embed/gfx/terminal.c
+++ b/core/embed/gfx/terminal.c
@@ -80,6 +80,7 @@ static void term_redraw_rows(int start_row, int row_count) {
       .src_stride = 8,
       .src_fg = terminal_fgcolor,
       .src_bg = terminal_bgcolor,
+      .src_alpha = 255,
   };
 
   for (int y = start_row; y < start_row + row_count; y++) {

--- a/core/embed/projects/firmware/main.c
+++ b/core/embed/projects/firmware/main.c
@@ -45,6 +45,9 @@
 #endif
 
 int main(uint32_t cmd, void *arg) {
+  // This call will be removed in the future with DMA2D syscalls.
+  gfx_bitblt_init();
+
   if (cmd == 1) {
     systask_postmortem_t *info = (systask_postmortem_t *)arg;
     rsod_gui(info);

--- a/core/embed/rust/Cargo.toml
+++ b/core/embed/rust/Cargo.toml
@@ -8,9 +8,9 @@ build = "build.rs"
 [features]
 default = ["layout_bolt"]
 crypto = ["zeroize"]
-layout_bolt = ["jpeg"]
+layout_bolt = []
 layout_caesar = []
-layout_delizia = ["jpeg", "dma2d"]
+layout_delizia = []
 micropython = []
 protobuf = ["micropython"]
 ui = []
@@ -22,16 +22,16 @@ display_rgba8888 = ["ui_antialiasing"]
 ui_debug = []
 ui_antialiasing = []
 ui_blurring = []
-ui_jpeg_decoder = ["jpeg"]
 ui_image_buffer = []
 ui_color_32bit = []
 ui_overlay = []
 ui_empty_lock = []
+ui_jpeg = []
+hw_jpeg_decoder = []
 bootloader = []
 button = []
 touch = []
 clippy = []
-jpeg = []
 debug = ["ui_debug"]
 sbu = []
 haptic = []
@@ -56,7 +56,7 @@ test = [
     "touch",
     "translations",
     "ui",
-    "ui_jpeg_decoder",
+    "ui_jpeg",
     "ui_blurring",
     "ui_image_buffer",
     "ui_overlay",

--- a/core/embed/rust/build.rs
+++ b/core/embed/rust/build.rs
@@ -53,6 +53,7 @@ const DEFAULT_BINDGEN_MACROS_COMMON: &[&str] = &[
     "-DUSE_HAPTIC",
     "-DUSE_RGB_LED",
     "-DUSE_BLE",
+    "-DUSE_HW_JPEG_DECODER",
 ];
 
 fn add_bindgen_macros<'a>(
@@ -395,7 +396,18 @@ fn generate_trezorhal_bindings() {
         // haptic
         .allowlist_type("haptic_effect_t")
         .allowlist_function("haptic_play")
-        .allowlist_function("haptic_play_custom");
+        .allowlist_function("haptic_play_custom")
+        // jpegdec
+        .allowlist_var("JPEGDEC_RGBA8888_BUFFER_SIZE")
+        .allowlist_type("jpegdec_state_t")
+        .allowlist_type("jpegdec_image_t")
+        .allowlist_type("jpegdec_image_format_t")
+        .allowlist_type("jpegdec_slice_t")
+        .allowlist_function("jpegdec_open")
+        .allowlist_function("jpegdec_close")
+        .allowlist_function("jpegdec_process")
+        .allowlist_function("jpegdec_get_info")
+        .allowlist_function("jpegdec_get_slice_rgba8888");
 
     // Write the bindings to a file in the OUR_DIR.
     bindings

--- a/core/embed/rust/src/io.rs
+++ b/core/embed/rust/src/io.rs
@@ -88,30 +88,6 @@ impl<'a> BinaryData<'a> {
         self.len() == 0
     }
 
-    /// Returns a reference to the binary data.
-    ///
-    /// This function is used just in the `paint()` functions in
-    /// UI components, that are going to be deleted after adopting new
-    /// drawing library for models T and TS3. Do not use this function in new
-    /// code.
-    ///
-    /// # Safety
-    /// The caller must ensure that the returned slice is not modified by
-    /// MicroPython. This means (a) discarding the slice before returning
-    /// to Python, and (b) being careful about calling into Python while
-    /// the slice is held.
-    pub unsafe fn data(&self) -> &[u8] {
-        match self {
-            Self::Slice(data) => data,
-            // SAFETY: We expect no existing mutable reference. See safety
-            // note above.
-            #[cfg(feature = "micropython")]
-            Self::Object(obj) => unsafe { unwrap!(get_buffer(*obj)) },
-            #[cfg(feature = "micropython")]
-            Self::AllocatedSlice(data) => data,
-        }
-    }
-
     /// Returns the length of the binary data in bytes.
     pub fn len(&self) -> usize {
         match self {

--- a/core/embed/rust/src/trezorhal/jpegdec.rs
+++ b/core/embed/rust/src/trezorhal/jpegdec.rs
@@ -1,0 +1,204 @@
+use super::ffi;
+
+use crate::ui::{
+    geometry::{Offset, Point, Rect},
+    shape::{Bitmap, BitmapFormat, BitmapView},
+};
+
+use crate::io::BinaryData;
+use num_traits::FromPrimitive;
+
+pub const RGBA8888_BUFFER_SIZE: usize = ffi::JPEGDEC_RGBA8888_BUFFER_SIZE as _;
+
+#[derive(PartialEq, Debug, Eq, FromPrimitive, Clone, Copy)]
+enum JpegDecState {
+    NeedData = ffi::jpegdec_state_t_JPEGDEC_STATE_NEED_DATA as _,
+    InfoReady = ffi::jpegdec_state_t_JPEGDEC_STATE_INFO_READY as _,
+    SliceReady = ffi::jpegdec_state_t_JPEGDEC_STATE_SLICE_READY as _,
+    Finished = ffi::jpegdec_state_t_JPEGDEC_STATE_FINISHED as _,
+    Error = ffi::jpegdec_state_t_JPEGDEC_STATE_ERROR as _,
+}
+
+#[derive(PartialEq, Debug, Eq, FromPrimitive, Clone, Copy)]
+pub enum JpegDecImageFormat {
+    GrayScale = ffi::jpegdec_image_format_t_JPEGDEC_IMAGE_GRAYSCALE as _,
+    YCBCR420 = ffi::jpegdec_image_format_t_JPEGDEC_IMAGE_YCBCR420 as _,
+    YCBCR422 = ffi::jpegdec_image_format_t_JPEGDEC_IMAGE_YCBCR422 as _,
+    YCBCR444 = ffi::jpegdec_image_format_t_JPEGDEC_IMAGE_YCBCR444 as _,
+}
+
+pub struct JpegDecImage {
+    pub width: i16,
+    pub height: i16,
+    pub format: JpegDecImageFormat,
+}
+
+pub struct JpegDecoder<'a> {
+    jpeg: BinaryData<'a>,
+    jpeg_pos: usize,
+    buff: [u8; 1024],
+    buff_pos: usize,
+    buff_len: usize,
+}
+
+impl Drop for JpegDecoder<'_> {
+    fn drop(&mut self) {
+        // SAFETY:
+        // We cannot have more than one instance of JpegDecoder at a time.
+        // The `jpegdec_close` is called in pair with `jpegdec_open`.
+        unsafe {
+            ffi::jpegdec_close();
+        }
+    }
+}
+
+impl<'a> JpegDecoder<'a> {
+    /// Creates a new JPEG decoder instance from the given JPEG data.
+    ///
+    /// The function reads the JPEG header and returns.
+    pub fn new(jpeg: BinaryData<'a>) -> Result<Self, ()> {
+        // SAFETY:
+        // `jpegdec_open()` is always called in pair with `jpegdec_close()`.
+        if !unsafe { ffi::jpegdec_open() } {
+            // Already open
+            return Err(());
+        }
+
+        let mut dec = Self {
+            jpeg,
+            jpeg_pos: 0,
+            buff: [0; 1024],
+            buff_pos: 0,
+            buff_len: 0,
+        };
+
+        loop {
+            match dec.read_input() {
+                JpegDecState::InfoReady => break,
+                JpegDecState::NeedData => {}
+                _ => return Err(()),
+            };
+        }
+
+        Ok(dec)
+    }
+
+    // Returns the image format and dimensions.
+    pub fn image(&self) -> Result<JpegDecImage, ()> {
+        let mut info = ffi::jpegdec_image_t {
+            width: 0,
+            height: 0,
+            format: 0,
+        };
+
+        // SAFETY:
+        // - `info` is a valid pointer to a mutable `jpegdec_image_t` struct.
+        if unsafe { ffi::jpegdec_get_info(&mut info) } {
+            Ok(JpegDecImage {
+                width: info.width,
+                height: info.height,
+                format: unwrap!(JpegDecImageFormat::from_u8(info.format as _)),
+            })
+        } else {
+            Err(())
+        }
+    }
+
+    /// Decodes the JPEG image and calls the output function for each slice.
+    /// Requires a temporary buffer of size `RGBA8888_BUFFER_SIZE`.
+    /// The output function should return `true` to continue decoding or `false`
+    /// to stop. Returns `Ok(())` if the decoding was successful or
+    /// `Err(())` if an error occurred.
+    pub fn decode(
+        &mut self,
+        buff: &mut [u8],
+        output: &mut dyn FnMut(Rect, BitmapView) -> bool,
+    ) -> Result<(), ()> {
+        loop {
+            match self.read_input() {
+                JpegDecState::SliceReady => {
+                    if !self.write_output(buff, output) {
+                        break;
+                    };
+                }
+                JpegDecState::Finished => break,
+                JpegDecState::NeedData => {}
+                _ => return Err(()),
+            };
+        }
+        Ok(())
+    }
+
+    fn read_input(&mut self) -> JpegDecState {
+        if self.buff_pos == self.buff_len {
+            self.buff_len = self.jpeg.read(self.jpeg_pos, &mut self.buff);
+            self.buff_pos = 0;
+            self.jpeg_pos += self.buff_len;
+        }
+
+        let mut inp = ffi::jpegdec_input_t {
+            data: self.buff.as_ptr(),
+            size: self.buff_len,
+            offset: self.buff_pos,
+            last_chunk: self.buff_len < self.buff.len(),
+        };
+
+        // SAFETY:
+        // - `inp.data` points to the mutable buffer we own
+        // - `inp.size` is valid buffer size
+        // - `inp.offset` is a valid offset in the buffer
+        // - jpegdec_process() doesn't retain the pointers to the data for later use
+        let state_u8 = unsafe { ffi::jpegdec_process(&mut inp) };
+        self.buff_pos = inp.offset;
+
+        unwrap!(JpegDecState::from_u8(state_u8 as _))
+    }
+
+    fn write_output(
+        &self,
+        buff: &mut [u8],
+        output: &mut dyn FnMut(Rect, BitmapView) -> bool,
+    ) -> bool {
+        // SAFETY:
+        // - after aligning the buffer to u32, the we check the
+        //  length of the buffer to be at least `RGBA8888_BUFFER_SIZE`
+        let rgba_u32 = unsafe { buff.align_to_mut::<u32>().1 };
+        assert!(rgba_u32.len() * 4 >= RGBA8888_BUFFER_SIZE);
+
+        let mut slice = ffi::jpegdec_slice_t {
+            x: 0,
+            y: 0,
+            width: 0,
+            height: 0,
+        };
+
+        // SAFETY:
+        //  - `rgba_u32` is a valid pointer to a mutable buffer of u32 of length at
+        //    least `RGBA8888_BUFFER_SIZE`
+        //  - `slice` is a valid pointer to a mutable `jpegdec_slice_t`
+        //  - `jpegdec_get_slice_rgba8888` doesn't retain the pointers to the data for
+        //    later use
+        unsafe { ffi::jpegdec_get_slice_rgba8888(rgba_u32.as_mut_ptr(), &mut slice) };
+
+        let r = Rect::from_top_left_and_size(
+            Point::new(slice.x, slice.y),
+            Offset::new(slice.width, slice.height),
+        );
+
+        // SAFETY:
+        // - reinterpreting &[u32] to &[u8] is safe
+        let rgba_u8 = unsafe { buff.align_to::<u8>().1 };
+
+        let bitmap = unwrap!(Bitmap::new(
+            BitmapFormat::RGBA8888,
+            None,
+            r.size(),
+            None,
+            rgba_u8
+        ));
+
+        let view = BitmapView::new(&bitmap);
+
+        output(r, view)
+    }
+}

--- a/core/embed/rust/src/trezorhal/mod.rs
+++ b/core/embed/rust/src/trezorhal/mod.rs
@@ -13,6 +13,9 @@ mod ffi;
 pub mod haptic;
 
 pub mod io;
+
+#[cfg(feature = "hw_jpeg_decoder")]
+pub mod jpegdec;
 pub mod model;
 pub mod random;
 #[cfg(feature = "rgb_led")]

--- a/core/embed/rust/src/ui/component/mod.rs
+++ b/core/embed/rust/src/ui/component/mod.rs
@@ -4,12 +4,16 @@ pub mod bar;
 pub mod base;
 pub mod border;
 pub mod button_request;
-#[cfg(all(feature = "jpeg", feature = "ui_image_buffer", feature = "micropython"))]
+#[cfg(all(
+    feature = "ui_jpeg",
+    feature = "ui_image_buffer",
+    feature = "micropython"
+))]
 pub mod cached_jpeg;
 pub mod connect;
 pub mod empty;
 pub mod image;
-#[cfg(all(feature = "jpeg", feature = "micropython"))]
+#[cfg(all(feature = "ui_jpeg", feature = "micropython"))]
 pub mod jpeg;
 pub mod label;
 pub mod map;
@@ -30,10 +34,14 @@ pub use bar::Bar;
 pub use base::{Child, Component, ComponentExt, Event, EventCtx, FlowMsg, Never, Timer};
 pub use border::Border;
 pub use button_request::{ButtonRequestExt, SendButtonRequest};
-#[cfg(all(feature = "jpeg", feature = "ui_image_buffer", feature = "micropython"))]
+#[cfg(all(
+    feature = "ui_jpeg",
+    feature = "ui_image_buffer",
+    feature = "micropython"
+))]
 pub use cached_jpeg::CachedJpeg;
 pub use empty::Empty;
-#[cfg(all(feature = "jpeg", feature = "micropython"))]
+#[cfg(all(feature = "ui_jpeg", feature = "micropython"))]
 pub use jpeg::Jpeg;
 pub use label::Label;
 pub use map::{MsgMap, PageMap};

--- a/core/embed/rust/src/ui/shape/bitmap.rs
+++ b/core/embed/rust/src/ui/shape/bitmap.rs
@@ -300,6 +300,7 @@ pub struct BitmapView<'a> {
     pub fg_color: Color,
     pub bg_color: Color,
     pub alpha: u8,
+    pub downscale: u8,
 }
 
 impl<'a> BitmapView<'a> {
@@ -311,6 +312,7 @@ impl<'a> BitmapView<'a> {
             fg_color: Color::black(),
             bg_color: Color::black(),
             alpha: 255,
+            downscale: 0,
         }
     }
 
@@ -335,6 +337,12 @@ impl<'a> BitmapView<'a> {
     /// Builds a new structure with alpha set to the specified value
     pub fn with_alpha(self, alpha: u8) -> Self {
         Self { alpha, ..self }
+    }
+
+    /// Builds a new structure with downscale set to the specified value
+    /// (0 means no downscale, 1 means 1/2, 2 means 1/4, etc.)
+    pub fn with_downscale(self, downscale: u8) -> Self {
+        Self { downscale, ..self }
     }
 
     /// Returns the bitmap width and height in pixels

--- a/core/embed/rust/src/ui/shape/cache/jpeg_cache.rs
+++ b/core/embed/rust/src/ui/shape/cache/jpeg_cache.rs
@@ -196,7 +196,7 @@ impl<'a> JpegCache<'a> {
                 offset_y += row_canvas.height() - offset_y % row_canvas.height();
             }
         } else {
-            // Create a new row for cahing decoded JPEG data
+            // Create a new row for caching decoded JPEG data
             // Now there's nobody else holding any reference to canvas_buff so
             // we can get a mutable reference and pass it to a new instance
             // of Rgb565Canvas

--- a/core/embed/rust/src/ui/shape/cache/mod.rs
+++ b/core/embed/rust/src/ui/shape/cache/mod.rs
@@ -1,7 +1,7 @@
 pub mod blur_cache;
 pub mod drawing_cache;
 
-#[cfg(feature = "ui_jpeg_decoder")]
+#[cfg(all(feature = "ui_jpeg", not(feature = "hw_jpeg_decoder")))]
 pub mod jpeg_cache;
 
 pub mod zlib_cache;

--- a/core/embed/rust/src/ui/shape/canvas/rgba8888.rs
+++ b/core/embed/rust/src/ui/shape/canvas/rgba8888.rs
@@ -135,7 +135,31 @@ impl<'a> Canvas for Rgba8888Canvas<'a> {
     }
 
     #[cfg(feature = "ui_blurring")]
-    fn blur_rect(&mut self, _r: Rect, _radius: usize, _cache: &DrawingCache) {
-        // TODO
+    fn blur_rect(&mut self, r: Rect, radius: usize, cache: &DrawingCache) {
+        let clip = r.translate(self.viewport.origin).clamp(self.viewport.clip);
+
+        let ofs = radius as i16;
+
+        if clip.width() > 2 * ofs - 1 && clip.height() > 2 * ofs - 1 {
+            let mut blur_cache = cache.blur();
+            let (blur, _) = unwrap!(
+                blur_cache.get(clip.size(), radius, None),
+                "Too small blur buffer"
+            );
+
+            loop {
+                if let Some(y) = blur.push_ready() {
+                    let row = unwrap!(self.row_mut(y + clip.y0)); // can't panic
+                    blur.push(&row[clip.x0 as usize..clip.x1 as usize]);
+                }
+                if let Some(y) = blur.pop_ready() {
+                    let row = unwrap!(self.row_mut(y + clip.y0)); // can't panic
+                    blur.pop(&mut row[clip.x0 as usize..clip.x1 as usize], None);
+                    if y + 1 >= clip.height() {
+                        break;
+                    }
+                }
+            }
+        }
     }
 }

--- a/core/embed/rust/src/ui/shape/jpeg.rs
+++ b/core/embed/rust/src/ui/shape/jpeg.rs
@@ -197,14 +197,14 @@ impl<'a> Shape<'a> for JpegImage<'a> {
                         if let Some(y) = blur.push_ready() {
                             if y < row_r.y1 {
                                 // should never fail
-                                blur.push(unwrap!(jpeg_slice.row(y - row_r.y0)));
+                                blur.push(unwrap!(jpeg_slice.row::<u16>(y - row_r.y0)));
                             } else {
                                 return true; // need more data
                             }
                         }
 
                         if let Some(y) = blur.pop_ready() {
-                            blur.pop(unwrap!(slice.row_mut(0)), Some(self.dim)); // should never fail
+                            blur.pop(unwrap!(slice.row_mut::<u16>(0)), Some(self.dim)); // should never fail
                             let dst_r = Rect::from_top_left_and_size(bounds.top_left(), jpeg_size)
                                 .translate(Offset::new(0, y));
                             canvas.draw_bitmap(dst_r, slice.view());

--- a/core/embed/rust/src/ui/shape/mod.rs
+++ b/core/embed/rust/src/ui/shape/mod.rs
@@ -8,7 +8,7 @@ mod canvas;
 mod circle;
 mod corner_highlight;
 mod display;
-#[cfg(feature = "ui_jpeg_decoder")]
+#[cfg(feature = "ui_jpeg")]
 mod jpeg;
 #[cfg(not(feature = "framebuffer"))]
 mod progressive_render;
@@ -31,7 +31,7 @@ pub use canvas::{
 pub use circle::Circle;
 pub use corner_highlight::CornerHighlight;
 pub use display::{render_on_canvas, render_on_display, unlock_bumps_on_failure, ConcreteRenderer};
-#[cfg(feature = "ui_jpeg_decoder")]
+#[cfg(feature = "ui_jpeg")]
 pub use jpeg::JpegImage;
 #[cfg(not(feature = "framebuffer"))]
 pub use progressive_render::ProgressiveRenderer;

--- a/core/embed/rust/trezorhal.h
+++ b/core/embed/rust/trezorhal.h
@@ -13,6 +13,10 @@
 #include <util/translations.h>
 #include "storage.h"
 
+#ifdef USE_HW_JPEG_DECODER
+#include <gfx/jpegdec.h>
+#endif
+
 #ifdef USE_BLE
 #include <io/ble.h>
 #endif

--- a/core/embed/sys/syscall/stm32/syscall_dispatch.c
+++ b/core/embed/sys/syscall/stm32/syscall_dispatch.c
@@ -51,6 +51,10 @@
 #include <io/haptic.h>
 #endif
 
+#ifdef USE_HW_JPEG_DECODER
+#include <gfx/jpegdec.h>
+#endif
+
 #ifdef USE_OPTIGA
 #include <sec/optiga.h>
 #endif
@@ -723,6 +727,31 @@ __attribute((no_stack_protector)) void syscall_handler(uint32_t *args,
       powerctl_suspend();
     } break;
 #endif
+
+#ifdef USE_HW_JPEG_DECODER
+    case SYSCALL_JPEGDEC_OPEN: {
+      args[0] = jpegdec_open();
+    } break;
+
+    case SYSCALL_JPEGDEC_CLOSE: {
+      jpegdec_close();
+    } break;
+
+    case SYSCALL_JPEGDEC_PROCESS: {
+      args[0] = jpegdec_process__verified((jpegdec_input_t *)args[0]);
+    } break;
+
+    case SYSCALL_JPEGDEC_GET_INFO: {
+      args[0] = jpegdec_get_info__verified((jpegdec_image_t *)args[0]);
+      break;
+    }
+
+    case SYSCALL_JPEGDEC_GET_SLICE_RGBA8888: {
+      args[0] = jpegdec_get_slice_rgba8888__verified(
+          (void *)args[0], (jpegdec_slice_t *)args[1]);
+      break;
+    }
+#endif  // USE_HW_JPEG_DECODER
 
     default:
       system_exit_fatal("Invalid syscall", __FILE__, __LINE__);

--- a/core/embed/sys/syscall/stm32/syscall_numbers.h
+++ b/core/embed/sys/syscall/stm32/syscall_numbers.h
@@ -17,8 +17,7 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-#ifndef SYSCALL_NUMBERS_H
-#define SYSCALL_NUMBERS_H
+#pragma once
 
 // Syscall identifiers
 typedef enum {
@@ -149,6 +148,10 @@ typedef enum {
 
   SYSCALL_POWERCTL_SUSPEND,
 
-} syscall_number_t;
+  SYSCALL_JPEGDEC_OPEN,
+  SYSCALL_JPEGDEC_CLOSE,
+  SYSCALL_JPEGDEC_PROCESS,
+  SYSCALL_JPEGDEC_GET_INFO,
+  SYSCALL_JPEGDEC_GET_SLICE_RGBA8888,
 
-#endif  // SYSCALL_NUMBERS_H
+} syscall_number_t;

--- a/core/embed/sys/syscall/stm32/syscall_stubs.c
+++ b/core/embed/sys/syscall/stm32/syscall_stubs.c
@@ -687,4 +687,40 @@ void powerctl_suspend(void) { syscall_invoke0(SYSCALL_POWERCTL_SUSPEND); }
 
 #endif  // USE_POWERCTL
 
+// =============================================================================
+// jpegdec.h
+// =============================================================================
+
+#ifdef USE_HW_JPEG_DECODER
+
+#include <gfx/jpegdec.h>
+
+bool jpegdec_open(void) { return (bool)syscall_invoke0(SYSCALL_JPEGDEC_OPEN); }
+
+void jpegdec_close(void) {
+  {
+    // Temporary hack to fix the problem with dual DMA2D driver in
+    // user/kernel space - will be removed in the future with DMA2D syscalls
+    extern void dma2d_invalidate_clut();
+    dma2d_invalidate_clut();
+  }
+  syscall_invoke0(SYSCALL_JPEGDEC_CLOSE);
+}
+
+jpegdec_state_t jpegdec_process(jpegdec_input_t *input) {
+  return (jpegdec_state_t)syscall_invoke1((uint32_t)input,
+                                          SYSCALL_JPEGDEC_PROCESS);
+}
+
+bool jpegdec_get_info(jpegdec_image_t *info) {
+  return (bool)syscall_invoke1((uint32_t)info, SYSCALL_JPEGDEC_GET_INFO);
+}
+
+bool jpegdec_get_slice_rgba8888(uint32_t *rgba8888, jpegdec_slice_t *slice) {
+  return (bool)syscall_invoke2((uint32_t)rgba8888, (uint32_t)slice,
+                               SYSCALL_JPEGDEC_GET_SLICE_RGBA8888);
+}
+
+#endif  // USE_HW_JPEG_DECODER
+
 #endif  // KERNEL_MODE

--- a/core/embed/sys/syscall/stm32/syscall_verifiers.c
+++ b/core/embed/sys/syscall/stm32/syscall_verifiers.c
@@ -781,4 +781,48 @@ access_violation:
 }
 #endif
 
+// ---------------------------------------------------------------------
+
+#ifdef USE_HW_JPEG_DECODER
+
+jpegdec_state_t jpegdec_process__verified(jpegdec_input_t *input) {
+  if (!probe_write_access(input, sizeof(*input))) {
+    goto access_violation;
+  }
+
+  return jpegdec_process(input);
+
+access_violation:
+  return JPEGDEC_STATE_ERROR;
+}
+
+bool jpegdec_get_info__verified(jpegdec_image_t *image) {
+  if (!probe_write_access(image, sizeof(*image))) {
+    goto access_violation;
+  }
+
+  return jpegdec_get_info(image);
+
+access_violation:
+  return false;
+}
+
+bool jpegdec_get_slice_rgba8888__verified(void *rgba8888,
+                                          jpegdec_slice_t *slice) {
+  if (!probe_write_access(rgba8888, JPEGDEC_RGBA8888_BUFFER_SIZE)) {
+    goto access_violation;
+  }
+
+  if (!probe_write_access(slice, sizeof(*slice))) {
+    goto access_violation;
+  }
+
+  return jpegdec_get_slice_rgba8888(rgba8888, slice);
+
+access_violation:
+  return false;
+}
+
+#endif  // USE_HW_JPEG_DECODER
+
 #endif  // SYSCALL_DISPATCH

--- a/core/embed/sys/syscall/stm32/syscall_verifiers.h
+++ b/core/embed/sys/syscall/stm32/syscall_verifiers.h
@@ -17,8 +17,7 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-#ifndef TREZORHAL_SYSCALL_VERIFIERS_H
-#define TREZORHAL_SYSCALL_VERIFIERS_H
+#pragma once
 
 #ifdef SYSCALL_DISPATCH
 
@@ -203,6 +202,18 @@ secbool ble_read__verified(uint8_t *data, size_t len);
 
 #endif
 
-#endif  // SYSCALL_DISPATCH
+// ---------------------------------------------------------------------
+#ifdef USE_HW_JPEG_DECODER
 
-#endif  // TREZORHAL_SYSCALL_VERIFIERS_H
+#include <gfx/jpegdec.h>
+
+jpegdec_state_t jpegdec_process__verified(jpegdec_input_t *input);
+
+bool jpegdec_get_info__verified(jpegdec_image_t *image);
+
+bool jpegdec_get_slice_rgba8888__verified(void *rgba8888,
+                                          jpegdec_slice_t *slice);
+
+#endif  // USE_HW_JPEG_DECODER
+
+#endif  // SYSCALL_DISPATCH

--- a/core/site_scons/models/T3W1/trezor_t3w1_revA.py
+++ b/core/site_scons/models/T3W1/trezor_t3w1_revA.py
@@ -148,6 +148,12 @@ def configure(
     features_available.append("dma2d")
     sources += ["embed/gfx/bitblt/stm32/dma2d_bitblt.c"]
 
+    defines += ["USE_HW_JPEG_DECODER"]
+    features_available.append("hw_jpeg_decoder")
+    sources += [
+        "embed/gfx/jpegdec/stm32u5/jpegdec.c",
+    ]
+
     defines += [
         ("USE_HASH_PROCESSOR", "1"),
         ("USE_STORAGE_HWKEY", "1"),

--- a/core/site_scons/models/T3W1/trezor_t3w1_revA0.py
+++ b/core/site_scons/models/T3W1/trezor_t3w1_revA0.py
@@ -139,11 +139,15 @@ def configure(
     features_available.append("framebuffer")
     features_available.append("display_rgb565")
 
-    defines += [
-        "USE_DMA2D",
-    ]
+    defines += ["USE_DMA2D"]
     features_available.append("dma2d")
     sources += ["embed/gfx/bitblt/stm32/dma2d_bitblt.c"]
+
+    defines += ["USE_HW_JPEG_DECODER"]
+    features_available.append("hw_jpeg_decoder")
+    sources += [
+        "embed/gfx/jpegdec/stm32u5/jpegdec.c",
+    ]
 
     defines += [
         ("USE_HASH_PROCESSOR", "1"),

--- a/core/site_scons/models/T3W1/trezor_t3w1_revB.py
+++ b/core/site_scons/models/T3W1/trezor_t3w1_revB.py
@@ -148,6 +148,12 @@ def configure(
     features_available.append("dma2d")
     sources += ["embed/gfx/bitblt/stm32/dma2d_bitblt.c"]
 
+    defines += ["USE_HW_JPEG_DECODER"]
+    features_available.append("hw_jpeg_decoder")
+    sources += [
+        "embed/gfx/jpegdec/stm32u5/jpegdec.c",
+    ]
+
     defines += [
         ("USE_HASH_PROCESSOR", "1"),
         ("USE_STORAGE_HWKEY", "1"),

--- a/core/site_scons/ui/ui_bolt.py
+++ b/core/site_scons/ui/ui_bolt.py
@@ -22,7 +22,7 @@ def init_ui(
         add_font("BOLD", "Font_Roboto_Bold_20", defines, sources)
     if stage == "firmware":
         rust_features.append("ui_blurring")
-        rust_features.append("ui_jpeg_decoder")
+        rust_features.append("ui_jpeg")
 
 
 def get_ui_layout() -> str:

--- a/core/site_scons/ui/ui_delizia.py
+++ b/core/site_scons/ui/ui_delizia.py
@@ -22,7 +22,7 @@ def init_ui(
         add_font("BOLD", "Font_TTSatoshi_DemiBold_21", defines, sources)
     if stage == "firmware":
         rust_features.append("ui_blurring")
-        rust_features.append("ui_jpeg_decoder")
+        rust_features.append("ui_jpeg")
         rust_features.append("ui_image_buffer")
         rust_features.append("ui_overlay")
 


### PR DESCRIPTION
This PR implements a hardware JPEG decoder for T3W1.

- Implemented a new `gfx/jpegdec` module that wraps the STM32 hardware JPEG decoder.
- Implemented a new `trezorhal/jpegdec.rs` module that provides the JpegDecoder API for Rust.
- Modified `shape::JpegImage` to support the hardware jpeg decoder.
- Additionally, two new features have been introduced - `hw_jpeg_decoder` and `ui_jpeg` - which replace `jpeg` and `ui_jpeg_decoder`.
- Implemented missing blurring for Rgba8888 canvas
- Implemented simple downscaling for Rgba8888->Rgba8888 bitblt copy operation

The simulator is still using the original JPEG decoder implemented in Rust. 
All other models (except T3W1) should not be affected by this PR.