### PR TITLE
test(core): increase test timeout for HW devices

### DIFF
--- a/tests/device_tests/bitcoin/test_authorize_coinjoin.py
+++ b/tests/device_tests/bitcoin/test_authorize_coinjoin.py
@@ -276,7 +276,7 @@ def test_sign_tx_large(client: Client):
     own_output_count = 30
     total_output_count = 1200
     output_denom = 10_000  # sats
-    max_expected_delay = 60  # seconds
+    max_expected_delay = 80  # seconds
 
     with client:
         btc.authorize_coinjoin(


### PR DESCRIPTION
Otherwise, the current timeout is exceeded when running the test on the following hardware models:
### T2T1
```
>       assert delay <= max_expected_delay
E       assert 72.02440977096558 <= 60
```
### T2B1
```
>       assert delay <= max_expected_delay
E       assert 77.36052393913269 <= 60
```

<!--
For core developers:
- Assign yourself to the PR.
- Set the priority to match the original issue.
- Add the PR to the current sprint.
- If it's a draft PR, mark it as "In Progress."
- If it's a final PR, mark it as "Needs Review."

For external contributors:
- Please open an issue before submitting a PR so we can discuss whether we want to proceed with it.
-->
