### PR TITLE
fix(core): fix optiga pairing issue

### DIFF
--- a/core/embed/sys/startup/inc/sys/sysutils.h
+++ b/core/embed/sys/startup/inc/sys/sysutils.h
@@ -28,9 +28,13 @@ typedef void (*new_stack_callback_t)(uint32_t arg1, uint32_t arg2);
 // Disables interrupts, disables the MPU, clears
 // all registers, sets up a new stack and calls the given callback.
 //
+// If `clear_bkregs` is set, the function also clears the BKP registers
+// and SRAM2 on STM32U5. It has no effect on STM32F4.
+//
 // The function is intended to be used in special cases, like
 // emergency situations, where the current stack may be corrupted.
 __attribute((noreturn)) void call_with_new_stack(uint32_t arg1, uint32_t arg2,
+                                                 bool clear_bkpregs,
                                                  new_stack_callback_t callback);
 
 // Ensure that we are running in privileged thread mode.

--- a/core/embed/sys/startup/stm32/bootutils.c
+++ b/core/embed/sys/startup/stm32/bootutils.c
@@ -136,7 +136,7 @@ __attribute__((noreturn)) static void halt_device(void) {
 
   // Disable interrupts, MPU, clear all registers and set up a new stack
   // (on STM32U5 it also clear all CPU secrets and SRAM2).
-  call_with_new_stack(0, 0, halt_device_phase_2);
+  call_with_new_stack(0, 0, true, halt_device_phase_2);
 }
 #endif  // RSOD_INFINITE_LOOP
 
@@ -188,7 +188,7 @@ __attribute__((noreturn)) static void reboot_with_args(boot_command_t command,
 
   // Disable interrupts, MPU, clear all registers and set up a new stack
   // (on STM32U5 it also clear all CPU secrets and SRAM2).
-  call_with_new_stack(command, 0, reboot_with_args_phase_2);
+  call_with_new_stack(command, 0, true, reboot_with_args_phase_2);
 }
 
 __attribute__((noreturn)) void reboot_to_bootloader(void) {
@@ -247,7 +247,7 @@ void __attribute__((noreturn)) jump_to_next_stage(uint32_t vectbl_address) {
 
   // Disable interrupts, MPU, clear all registers and set up a new stack
   // (on STM32U5 it also clear all CPU secrets and SRAM2).
-  call_with_new_stack(vectbl_address, 0, jump_to_next_stage_phase_2);
+  call_with_new_stack(vectbl_address, 0, false, jump_to_next_stage_phase_2);
 }
 
 #endif  // KERNEL_MODE

--- a/core/embed/sys/task/stm32/system.c
+++ b/core/embed/sys/task/stm32/system.c
@@ -131,7 +131,7 @@ __attribute((naked, noreturn, no_stack_protector)) void system_emergency_rescue(
   // Save `pminfo` to bootargs so it isn't overwritten by succesive call
   bootargs_set(BOOT_COMMAND_SHOW_RSOD, pminfo, sizeof(*pminfo));
 
-  call_with_new_stack((uint32_t)error_handler, 0,
+  call_with_new_stack((uint32_t)error_handler, 0, true,
                       system_emergency_rescue_phase_2);
 }
 


### PR DESCRIPTION
This small PR fixes a problem introduced in #4499.

The Optiga secret stored in backup registers was unintentionally cleared during the transition from the bootloader to the firmware.

This fix prevents it from being cleared during all forward transitions from the boardloader → bootloader → kernel.

The bug was not present in any released version.

