### PR TITLE
fix(prodtest): fix haptic test

### DIFF
--- a/core/embed/projects/prodtest/cmd/prodtest_haptic.c
+++ b/core/embed/projects/prodtest/cmd/prodtest_haptic.c
@@ -42,16 +42,15 @@ static void prodtest_haptic_test(cli_t* cli) {
     return;
   }
 
+  haptic_play(HAPTIC_BUTTON_PRESS);
+
   cli_trace(cli, "Running haptic feedback test for %d ms...", duration);
   if (!haptic_test(duration)) {
     cli_error(cli, CLI_ERROR, "Haptic feedback test failed.");
-    goto cleanup;
+    return;
   }
 
   cli_ok(cli, "");
-
-cleanup:
-  haptic_deinit();
 }
 
 // clang-format off

--- a/core/embed/projects/prodtest/cmd/prodtest_touch.c
+++ b/core/embed/projects/prodtest/cmd/prodtest_touch.c
@@ -57,8 +57,6 @@ static void prodtest_touch_version(cli_t* cli) {
   uint8_t version = touch_get_version();
 
   cli_ok(cli, "%d", version);
-
-  touch_deinit();
 }
 
 static bool touch_click_timeout(cli_t* cli, uint32_t* event, uint32_t timeout) {
@@ -141,8 +139,6 @@ static void prodtest_touch_test(cli_t* cli) {
       cli_error(cli, CLI_ERROR_TIMEOUT, "");
     }
   }
-
-  touch_deinit();
 
   gfx_clear();
   display_refresh();
@@ -230,8 +226,6 @@ static void prodtest_touch_test_custom(cli_t* cli) {
     }
   }
 
-  touch_deinit();
-
   gfx_clear();
   display_refresh();
 }
@@ -279,7 +273,6 @@ static void prodtest_touch_test_idle(cli_t* cli) {
   cli_ok(cli, "");
 
 cleanup:
-  touch_deinit();
   gfx_clear();
   display_refresh();
 }
@@ -364,8 +357,6 @@ static void prodtest_touch_test_sensitivity(cli_t* cli) {
       break;
     }
   }
-
-  touch_deinit();
 
   gfx_clear();
   display_refresh();


### PR DESCRIPTION
This PR fixes the haptic test in prodtest. The bug was introduced in #4430 but is not present in any official release.

The logic for driver initialization and deinitialization has been refined:

1) All drivers are initialized in `drivers_init()` when prodtest starts.
2) Each test calls `{driver}_init()` and checks the result.
3) No test should call `{driver}_deinit()`, ensuring that all drivers remain active throughout.