### PR TITLE
fix(core): correct loader completion detection

### DIFF
--- a/core/embed/rust/src/ui/layout_bolt/component/loader.rs
+++ b/core/embed/rust/src/ui/layout_bolt/component/loader.rs
@@ -139,11 +139,17 @@ impl Loader {
     }
 
     pub fn is_completely_grown(&self, now: Instant) -> bool {
-        matches!(self.progress(now), Some(display::LOADER_MAX))
+        match &self.state {
+            State::Growing(a) => a.finished(now),
+            _ => false,
+        }
     }
 
     pub fn is_completely_shrunk(&self, now: Instant) -> bool {
-        matches!(self.progress(now), Some(display::LOADER_MIN))
+        match &self.state {
+            State::Shrinking(a) => a.finished(now),
+            _ => false,
+        }
     }
 }
 

--- a/core/embed/rust/src/ui/layout_caesar/component/loader.rs
+++ b/core/embed/rust/src/ui/layout_caesar/component/loader.rs
@@ -154,11 +154,17 @@ impl Loader {
     }
 
     pub fn is_completely_grown(&self, now: Instant) -> bool {
-        matches!(self.progress(now), Some(display::LOADER_MAX))
+        match &self.state {
+            State::Growing(a) => a.finished(now),
+            _ => false,
+        }
     }
 
     pub fn is_completely_shrunk(&self, now: Instant) -> bool {
-        matches!(self.progress(now), Some(display::LOADER_MIN))
+        match &self.state {
+            State::Shrinking(a) => a.finished(now),
+            _ => false,
+        }
     }
 
     pub fn render_loader<'s>(

--- a/core/embed/rust/src/ui/layout_delizia/component/loader.rs
+++ b/core/embed/rust/src/ui/layout_delizia/component/loader.rs
@@ -143,11 +143,17 @@ impl Loader {
     }
 
     pub fn is_completely_grown(&self, now: Instant) -> bool {
-        matches!(self.progress_raw(now), Some(display::LOADER_MAX))
+        match &self.state {
+            State::Growing(a) => a.finished(now),
+            _ => false,
+        }
     }
 
     pub fn is_completely_shrunk(&self, now: Instant) -> bool {
-        matches!(self.progress_raw(now), Some(display::LOADER_MIN))
+        match &self.state {
+            State::Shrinking(a) => a.finished(now),
+            _ => false,
+        }
     }
 }
 


### PR DESCRIPTION
This issue was found while debugging a flaky click test on T3T1 emulator: 
`tests/click_tests/test_lock.py::test_hold_to_lock`

Sample failures:
https://github.com/trezor/trezor-firmware/actions/runs/13209659963/job/36880750418 
https://github.com/trezor/trezor-firmware/actions/runs/13189762414/job/36820368643 
https://github.com/trezor/trezor-firmware/actions/runs/13146713535/job/36686537519 
https://github.com/trezor/trezor-firmware/actions/runs/13124809110/job/36619045092 
https://github.com/trezor/trezor-firmware/actions/runs/13103415015/job/36554567296 
https://github.com/trezor/trezor-firmware/actions/runs/13093382180/job/36532710349

With the following logging added [1], the test failure seems to happen when the loader detects that it is `ShrunkCompletely` (probably due to animation events timing jitter) and stops the animation:

![image](https://github.com/user-attachments/assets/9a0cb2b9-7f6d-43fc-a2cf-cbae777b022c)

<details>

<summary> [1] Debug patch </summary>

```diff
diff --git a/core/embed/rust/src/ui/component/base.rs b/core/embed/rust/src/ui/component/base.rs
index 9b24c44fd..efe88e78b 100644
--- a/core/embed/rust/src/ui/component/base.rs
+++ b/core/embed/rust/src/ui/component/base.rs
@@ -575,6 +575,7 @@ impl EventCtx {
     }
 
     fn register_timer(&mut self, token: TimerToken, duration: Duration) {
+        dbg_println!("register_timer: {:?} {}ms", token, duration.to_millis());
         if self.timers.push((token, duration)).is_err() {
             // The timer queue is full, this would be a development error in the layout
             // layer. Let's panic in the debug env.
diff --git a/core/embed/rust/src/ui/layout/obj.rs b/core/embed/rust/src/ui/layout/obj.rs
index 4ec68214a..f546e9fce 100644
--- a/core/embed/rust/src/ui/layout/obj.rs
+++ b/core/embed/rust/src/ui/layout/obj.rs
@@ -285,6 +285,7 @@ impl LayoutObjInner {
 
         // Drain any pending timers into the callback.
         while let Some((token, duration)) = self.event_ctx.pop_timer() {
+            dbg_println!("timer_fn: {:?} {}ms", token, duration.to_millis());
             let token = token.try_into();
             let duration = duration.try_into();
             if let (Ok(token), Ok(duration)) = (token, duration) {
diff --git a/core/embed/rust/src/ui/layout_delizia/component/homescreen.rs b/core/embed/rust/src/ui/layout_delizia/component/homescreen.rs
index fe68b28a5..e80452b19 100644
--- a/core/embed/rust/src/ui/layout_delizia/component/homescreen.rs
+++ b/core/embed/rust/src/ui/layout_delizia/component/homescreen.rs
@@ -507,6 +507,7 @@ impl Homescreen {
     }
 
     fn event_hold(&mut self, ctx: &mut EventCtx, event: Event) -> bool {
+        dbg_println!("event_hold: {:?} animating={}", event, self.loader.is_animating());
         match event {
             Event::Touch(TouchEvent::TouchStart(_)) => {
                 if self.loader.is_animating() {
diff --git a/core/embed/rust/src/ui/layout_delizia/component/loader.rs b/core/embed/rust/src/ui/layout_delizia/component/loader.rs
index 158a0bc83..a67a160ce 100644
--- a/core/embed/rust/src/ui/layout_delizia/component/loader.rs
+++ b/core/embed/rust/src/ui/layout_delizia/component/loader.rs
@@ -180,15 +180,19 @@ impl Component for Loader {
                 if self.is_completely_grown(now) {
                     #[cfg(feature = "haptic")]
                     play(HapticEffect::HoldToConfirm);
+                    dbg_println!("Loader::event {:?} -> GrownCompletely", event);
                     return Some(LoaderMsg::GrownCompletely);
                 } else if self.is_completely_shrunk(now) {
+                    dbg_println!("Loader::event {:?} -> ShrunkCompletely", event);
                     return Some(LoaderMsg::ShrunkCompletely);
                 } else {
                     // There is further progress in the animation, request an animation frame event.
                     ctx.request_anim_frame();
+                    return None;
                 }
             }
         }
+        dbg_println!("Loader::event {:?} -> None", event);
         None
     }
 
diff --git a/tests/click_tests/test_lock.py b/tests/click_tests/test_lock.py
index 9a0340910..0f270d343 100644
--- a/tests/click_tests/test_lock.py
+++ b/tests/click_tests/test_lock.py
@@ -14,6 +14,7 @@
 # You should have received a copy of the License along with this library.
 # If not, see <https://www.gnu.org/licenses/lgpl-3.0.html>.
 
+import logging
 import time
 from typing import TYPE_CHECKING
 
@@ -28,6 +29,7 @@ if TYPE_CHECKING:
     from ..device_handler import BackgroundDeviceHandler
 
 
+LOG = logging.getLogger()
 PIN4 = "1234"
 
 
@@ -77,17 +79,20 @@ def test_hold_to_lock(device_handler: "BackgroundDeviceHandler"):
     hold(lock_duration)
     assert device_handler.features().unlocked is False
 
-    # unlock by touching
-    if debug.layout_type is LayoutType.Caesar:
-        debug.press_right()
-    else:
-        debug.click(buttons.INFO)
-    layout = debug.read_layout()
-    assert "PinKeyboard" in layout.all_components()
-    debug.input("1234")
-
-    assert device_handler.features().unlocked is True
-
-    # lock
-    hold(lock_duration)
-    assert device_handler.features().unlocked is False
+    for i in range(1000):
+        # unlock by touching
+        if debug.layout_type is LayoutType.Caesar:
+            debug.press_right()
+        else:
+            debug.click(buttons.INFO)
+        layout = debug.read_layout()
+        assert "PinKeyboard" in layout.all_components()
+        debug.input("1234")
+
+        assert device_handler.features().unlocked is True
+
+        # lock
+        LOG.info("LOCK: #%d", i)
+        hold(lock_duration)
+        LOG.info("STAT: #%d", i)
+        assert device_handler.features().unlocked is False
```

</details>

<!--
For core developers:
- Assign yourself to the PR.
- Set the priority to match the original issue.
- Add the PR to the current sprint.
- If it's a draft PR, mark it as "In Progress."
- If it's a final PR, mark it as "Needs Review."

For external contributors:
- Please open an issue before submitting a PR so we can discuss whether we want to proceed with it.
-->
