### PR TITLE
fix(prodtest): remove haptic-test duration limit

### DIFF
--- a/core/embed/projects/prodtest/cmd/prodtest_haptic.c
+++ b/core/embed/projects/prodtest/cmd/prodtest_haptic.c
@@ -27,8 +27,8 @@
 static void prodtest_haptic_test(cli_t* cli) {
   uint32_t duration = 0;  // ms
 
-  if (!cli_arg_uint32(cli, "duration", &duration) || duration > 5000) {
-    cli_error_arg(cli, "Expecting time in milliseconds in range 0-5000.");
+  if (!cli_arg_uint32(cli, "duration", &duration)) {
+    cli_error_arg(cli, "Expecting time in milliseconds.");
     return;
   }
 


### PR DESCRIPTION
This small PR removes the 5000ms limit for the `duration` parameter of `haptic-test`. The production test requires a longer test duration, and any limit seems unnecessary.

The limit was introduced in #4430, so no release note is needed.


