### PR TITLE
fix default (out of range) color used by gfxmmu

### DIFF
--- a/core/embed/io/display/ltdc_dsi/display_gfxmmu.c
+++ b/core/embed/io/display/ltdc_dsi/display_gfxmmu.c
@@ -40,7 +40,7 @@ bool display_gfxmmu_init(display_driver_t *drv) {
   // GFXMMU peripheral initialization
   drv->hlcd_gfxmmu.Instance = GFXMMU;
   drv->hlcd_gfxmmu.Init.BlocksPerLine = GFXMMU_192BLOCKS;
-  drv->hlcd_gfxmmu.Init.DefaultValue = 0xFFFFFFFFU;
+  drv->hlcd_gfxmmu.Init.DefaultValue = 0;
   drv->hlcd_gfxmmu.Init.Buffers.Buf0Address = (uint32_t)physical_frame_buffer_0;
   drv->hlcd_gfxmmu.Init.Buffers.Buf1Address = (uint32_t)physical_frame_buffer_1;
   drv->hlcd_gfxmmu.Init.Buffers.Buf2Address = 0;


### PR DESCRIPTION
This PR changes the default color used by GFXMMU if pixels out of range are accessed.

Previously white, now black.

Turns out, there are cases that access these pixels, i.e. for blurring, and black makes more sense here. 