### PR TITLE
ci(core): collect debug logs also from `multicore` tests

### DIFF
--- a/.github/actions/ui-report/action.yml
+++ b/.github/actions/ui-report/action.yml
@@ -26,7 +26,7 @@ runs:
         nix-shell --run "poetry run python ci/prepare_ui_artifacts.py || true"
         mv tests/ui_tests/reports/test/* $OUTDIR || true
         mv tests/ui_tests/fixtures.*.json $OUTDIR || true
-        mv tests/trezor.log $OUTDIR || true
+        mv tests/trezor*.log $OUTDIR || true
         diff -u tests/ui_tests/fixtures.json tests/ui_tests/fixtures.suggestion.json || true
         tar -cf screens_$MODELJOB.tar tests/ui_tests/screens || true
 

--- a/.github/workflows/core.yml
+++ b/.github/workflows/core.yml
@@ -264,6 +264,7 @@ jobs:
       TREZOR_PROFILING: ${{ matrix.asan == 'noasan' && '1' || '0' }}
       TREZOR_MODEL: ${{ matrix.model }}
       TREZOR_PYTEST_SKIP_ALTCOINS: ${{ matrix.coins == 'btconly' && '1' || '0' }}
+      TREZOR_PYTEST_LOGS_DIR: ${{ github.workspace }}/tests/
       ADDRESS_SANITIZER: ${{ matrix.asan == 'asan' && '1' || '0' }}
       PYTEST_TIMEOUT: ${{ matrix.asan == 'asan' && 600 || 400 }}
       ACTIONS_DO_UI_TEST: ${{ matrix.coins == 'universal' && matrix.asan == 'noasan' }}
@@ -279,12 +280,12 @@ jobs:
       - run: chmod +x core/build/unix/trezor-emu-core*
       - uses: ./.github/actions/environment
       - run: nix-shell --run "poetry run make -C core ${{ env.ACTIONS_DO_UI_TEST == 'true' && 'test_emu_ui_multicore' || 'test_emu' }}"
-      - run: tail -n50 tests/trezor.log || true
+      - run: tail -v -n50 tests/trezor*.log || true
         if: failure()
       - uses: actions/upload-artifact@v4
         with:
           name: core-test-device-${{ matrix.model }}-${{ matrix.coins }}-${{ matrix.lang }}-${{ matrix.asan }}
-          path: tests/trezor.log
+          path: tests/trezor*.log
           retention-days: 7
         if: always()
       - uses: ./.github/actions/ui-report

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -111,21 +111,13 @@ def emulator(request: pytest.FixtureRequest) -> t.Generator["Emulator", None, No
             "Legacy emulator is not supported until it can be run on arbitrary ports."
         )
 
-    def _get_port() -> int:
-        """Get a unique port for this worker process on which it can run.
-
-        Guarantees to be unique because each worker has a different name.
-        gw0=>20000, gw1=>20003, gw2=>20006, etc.
-        """
-        worker_id = xdist.get_xdist_worker_id(request)
-        assert worker_id.startswith("gw")
-        # One emulator instance occupies 3 consecutive ports:
-        # 1. normal link, 2. debug link and 3. webauthn fake interface
-        return 20000 + int(worker_id[2:]) * 3
+    worker_id = xdist.get_xdist_worker_id(request)
+    assert worker_id.startswith("gw")
+    worker_id = int(worker_id[2:])
 
     with EmulatorWrapper(
         model,
-        port=_get_port(),
+        worker_id=worker_id,
         headless=True,
         auto_interact=not interact,
         main_args=_emulator_wrapper_main_args(),


### PR DESCRIPTION
Otherwise, tailing and uploading when running `make test_emu_ui_multicore` fail: 
https://github.com/trezor/trezor-firmware/actions/runs/13049022289/job/36405211984?pr=4558

![image](https://github.com/user-attachments/assets/5f7f7da8-b780-4e65-9619-145c06c7f9a1)


<!--
For core developers:
- Assign yourself to the PR.
- Set the priority to match the original issue.
- Add the PR to the current sprint.
- If it's a draft PR, mark it as "In Progress."
- If it's a final PR, mark it as "Needs Review."

For external contributors:
- Please open an issue before submitting a PR so we can discuss whether we want to proceed with it.
-->
