### PR TITLE
ci(core): add a missing `BITCOIN_ONLY` definition to `core-hw.yml`

### DIFF
--- a/.github/workflows/core-hw.yml
+++ b/.github/workflows/core-hw.yml
@@ -32,6 +32,7 @@ jobs:
         coins: [universal, btconly]
     env:
       TREZOR_MODEL: ${{ matrix.model }}
+      BITCOIN_ONLY: ${{ matrix.coins == 'btconly' && '1' || '0' }}
       TREZOR_PYTEST_SKIP_ALTCOINS: ${{ matrix.coins == 'btconly' && '1' || '0' }}
       PYTEST_TIMEOUT: 1200
       PYOPT: 0


### PR DESCRIPTION
Currently, both jobs are testing universal firmware:
![Screenshot from 2025-02-11 10-00-50](https://github.com/user-attachments/assets/400b7827-de13-4974-bcdc-27922881bdfa)

![image](https://github.com/user-attachments/assets/8c697967-5b04-4b62-9554-8314df12e0b7)

<!--
For core developers:
- Assign yourself to the PR.
- Set the priority to match the original issue.
- Add the PR to the current sprint.
- If it's a draft PR, mark it as "In Progress."
- If it's a final PR, mark it as "Needs Review."

For external contributors:
- Please open an issue before submitting a PR so we can discuss whether we want to proceed with it.
-->
