### PR TITLE
feat(core/prodtest): Allow prodtest to exit from interactive mode 

### DIFF
--- a/core/embed/projects/prodtest/README.md
+++ b/core/embed/projects/prodtest/README.md
@@ -12,6 +12,8 @@ The prodtest includes a simple text-based command-line interface that can be con
 
 Pressing the ENTER key twice switches the interface to interactive mode, enabling basic line editing, autocomplete functionality (using the TAB key), and text coloring.
 
+To exit from interactive mode type `.+ENTER`.
+
 ### Commands
 These commands begin with the command name and may optionally include parameters separated by spaces.
 

--- a/core/embed/rtl/cli.c
+++ b/core/embed/rtl/cli.c
@@ -569,6 +569,15 @@ void cli_run_loop(cli_t* cli) {
     }
     cli->empty_lines = 0;
 
+    // Quit interactive mode on `.+ENTER`
+    if ((strcmp(cli->cmd_name, ".") == 0)) {
+      if (cli->interactive) {
+        cli->interactive = false;
+        cli_trace(cli, "Exiting interactive mode...");
+      }
+      continue;
+    }
+
     // Find the command handler
     cli->current_cmd = cli_find_command(cli, cli->cmd_name);
 


### PR DESCRIPTION
Add an option to exit from prodtest interactive mode with ".+ENTER" command.

If test script or test equipment connects to prodtest serial, it may happen that somebody already switched it to interactive mode before. To make it easier for it, it may switch back to non-interactive mode and don't deal with the colored responses etc. 

Prodtest will confirm the exit command with `OK` in standard mode to be well machine readable.