### PR TITLE
fix(core): fix reboot_device function behaviour

### DIFF
--- a/core/embed/sys/startup/stm32/bootutils.c
+++ b/core/embed/sys/startup/stm32/bootutils.c
@@ -162,8 +162,13 @@ static void reboot_with_args_phase_2(uint32_t arg1, uint32_t arg2) {
 #if defined STM32U5
   NVIC_SystemReset();
 #elif defined STM32F4
+  boot_command_t command = arg1;
   clear_otg_hs_memory();
-  jump_to_vectbl(BOOTLOADER_START + IMAGE_HEADER_SIZE, arg1);
+  if (command == BOOT_COMMAND_NONE) {
+    NVIC_SystemReset();
+  } else {
+    jump_to_vectbl(BOOTLOADER_START + IMAGE_HEADER_SIZE, command);
+  }
 #else
 #error Unsupported platform
 #endif


### PR DESCRIPTION
This small PR fixes the `reboot_device()` behavior on the STM32F4 platform.

`reboot_device()` was changed in #4499; instead of resetting the CPU, it now jumps to the bootloader’s `reset_handler`. While this isn’t entirely incorrect, resetting the CPU is preferable. Therefore, this PR reverts that change.
