### PR TITLE
Configure hardware CI timeouts to collect pytest logs

### DIFF
--- a/.github/workflows/core-hw.yml
+++ b/.github/workflows/core-hw.yml
@@ -34,12 +34,13 @@ jobs:
       TREZOR_MODEL: ${{ matrix.model }}
       BITCOIN_ONLY: ${{ matrix.coins == 'btconly' && '1' || '0' }}
       TREZOR_PYTEST_SKIP_ALTCOINS: ${{ matrix.coins == 'btconly' && '1' || '0' }}
-      PYTEST_TIMEOUT: 1200
+      PYTEST_TIMEOUT: 1200  # 20m single test timeout
       PYOPT: 0
       DISABLE_OPTIGA: 1
       BOOTLOADER_DEVEL: ${{ matrix.model == 'T2B1' && '1' || '0' }}
-      TESTOPTS: "-k 'not authenticate and not recovery and not lots'"
+      TESTOPTS: "-k 'not authenticate and not recovery and not lots' --session-timeout 19800"  # 5.5h pytest global timeout
       TT_UHUB_PORT: 1
+    timeout-minutes: 360  # 6h CI job timeout
     steps:
       - uses: actions/checkout@v4
         with:

--- a/poetry.lock
+++ b/poetry.lock
@@ -1285,17 +1285,17 @@ pytest = ">=3.0.0"
 
 [[package]]
 name = "pytest-timeout"
-version = "2.1.0"
+version = "2.3.1"
 description = "pytest plugin to abort hanging tests"
 optional = false
-python-versions = ">=3.6"
+python-versions = ">=3.7"
 files = [
-    {file = "pytest-timeout-2.1.0.tar.gz", hash = "sha256:c07ca07404c612f8abbe22294b23c368e2e5104b521c1790195561f37e1ac3d9"},
-    {file = "pytest_timeout-2.1.0-py3-none-any.whl", hash = "sha256:f6f50101443ce70ad325ceb4473c4255e9d74e3c7cd0ef827309dfa4c0d975c6"},
+    {file = "pytest-timeout-2.3.1.tar.gz", hash = "sha256:12397729125c6ecbdaca01035b9e5239d4db97352320af155b3f5de1ba5165d9"},
+    {file = "pytest_timeout-2.3.1-py3-none-any.whl", hash = "sha256:68188cb703edfc6a18fad98dc25a3c61e9f24d644b0b70f33af545219fc7813e"},
 ]
 
 [package.dependencies]
-pytest = ">=5.0.0"
+pytest = ">=7.0.0"
 
 [[package]]
 name = "pytest-xdist"


### PR DESCRIPTION
Currently, there are no logs from failed tests in case of a timeout:
https://github.com/trezor/trezor-firmware/actions/runs/13252434089/job/36993028885

![Screenshot from 2025-02-11 16-06-44](https://github.com/user-attachments/assets/c58cf055-698c-41f8-a6d5-51caa0055021)

For example, in the above run, all tests seem to timeout (after 20m) after the first test failure (at `04:31:28`), causing the job to timeout (at `08:11:22`) - and there are no pytest failure logs :(

<!--
For core developers:
- Assign yourself to the PR.
- Set the priority to match the original issue.
- Add the PR to the current sprint.
- If it's a draft PR, mark it as "In Progress."
- If it's a final PR, mark it as "Needs Review."

For external contributors:
- Please open an issue before submitting a PR so we can discuss whether we want to proceed with it.
-->
