### PR TITLE
fix stwlc38 deinitialization

### DIFF
--- a/core/embed/sys/powerctl/stwlc38/stwlc38.h
+++ b/core/embed/sys/powerctl/stwlc38/stwlc38.h
@@ -17,8 +17,7 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-#ifndef TREZORHAL_STWLC38_H
-#define TREZORHAL_STWLC38_H
+#pragma once
 
 #include <trezor_types.h>
 
@@ -89,7 +88,7 @@ void stwlc38_deinit(void);
 // wireless charging functionality.
 //
 // If the STWLC38 is disabled, it's not self-powered and is unable to
-// communicate over I2C. STWLC38 is disabled by default after initialization.
+// communicate over I2C. STWLC38 is enabled by default after initialization.
 //
 // Returns true if the STWLC38 was successfully enabled or disabled.
 bool stwlc38_enable(bool enable);
@@ -120,5 +119,3 @@ bool stwlc38_patch_and_config();
 
 // Gets the current report from the STWLC38
 bool stwlc38_get_report(stwlc38_report_t* status);
-
-#endif  // TREZORHAL_STWLC38_H

--- a/core/embed/sys/powerctl/stwlc38/stwlc38_defs.h
+++ b/core/embed/sys/powerctl/stwlc38/stwlc38_defs.h
@@ -17,8 +17,7 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-#ifndef TREZORHAL_STWLC38_DEFS_H
-#define TREZORHAL_STWLC38_DEFS_H
+#pragma once
 
 // I2C address of the STWLC38 on the I2C bus.
 #define STWLC38_I2C_ADDRESS 0x61
@@ -95,5 +94,3 @@
 #define STWLC38_ERR_INVALID_CHIP_ID 0x80000006U
 #define STWLC38_ERR_NVM_ID_MISMATCH 0x80000007U
 #define STWLC38_ERR_NVM_DATA_CORRUPTED 0x80000008U
-
-#endif  // TREZORHAL_STWLC38_DEFS_H

--- a/core/embed/sys/powerctl/stwlc38/stwlc38_internal.h
+++ b/core/embed/sys/powerctl/stwlc38/stwlc38_internal.h
@@ -18,8 +18,7 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-#ifndef TREZORHAL_STWLC38_INTERNAL_H
-#define TREZORHAL_STWLC38_INTERNAL_H
+#pragma once
 
 #include <io/i2c_bus.h>
 #include <trezor_types.h>
@@ -35,7 +34,7 @@
 #define STWLC38_EXTI_INTERRUPT_NUM EXTI15_IRQn
 #define STWLC38_EXTI_INTERRUPT_HANDLER EXTI15_IRQHandler
 #define STWLC38_ENB_PIN GPIO_PIN_3
-#define STWLC37_ENB_PORT GPIOD
+#define STWLC38_ENB_PORT GPIOD
 #define STWLC38_ENB_PIN_CLK_ENA __HAL_RCC_GPIOD_CLK_ENABLE
 
 // Period of the report readout [ms]
@@ -73,6 +72,9 @@ typedef struct {
   // Set if the driver is initialized
   bool initialized;
 
+  // EXTI handle
+  EXTI_HandleTypeDef EXTI_Handle;
+
   // I2C bus where the STWLC38 is connected
   i2c_bus_t *i2c_bus;
   // Storage for the pending I2C packet
@@ -99,5 +101,3 @@ typedef struct {
 extern stwlc38_driver_t g_stwlc38_driver;
 
 #endif  // KERNEL_MODE
-
-#endif  // TREZORHAL_STWLC38_INTERNAL_H


### PR DESCRIPTION
This PR fixes deinitialzation of STWLC38 driver: 
- interrupt is disabled
- ~~wlc itself is disabled~~
