### PR TITLE
chore(python): include the invalid chunk in `RuntimeError` message

### DIFF
--- a/python/src/trezorlib/transport/protocol.py
+++ b/python/src/trezorlib/transport/protocol.py
@@ -149,11 +149,11 @@ class ProtocolV1(Protocol):
     def read_first(self) -> Tuple[int, int, bytes]:
         chunk = self.handle.read_chunk()
         if chunk[:3] != b"?##":
-            raise RuntimeError("Unexpected magic characters")
+            raise RuntimeError(f"Unexpected magic characters: {chunk.hex()}")
         try:
             msg_type, datalen = struct.unpack(">HL", chunk[3 : 3 + self.HEADER_LEN])
         except Exception:
-            raise RuntimeError("Cannot parse header")
+            raise RuntimeError(f"Cannot parse header: {chunk.hex()}")
 
         data = chunk[3 + self.HEADER_LEN :]
         return msg_type, datalen, data
@@ -161,5 +161,5 @@ class ProtocolV1(Protocol):
     def read_next(self) -> bytes:
         chunk = self.handle.read_chunk()
         if chunk[:1] != b"?":
-            raise RuntimeError("Unexpected magic characters")
+            raise RuntimeError(f"Unexpected magic characters: {chunk.hex()}")
         return chunk[1:]


### PR DESCRIPTION
It happened during the last hardware test run on T2T1:
https://github.com/trezor/trezor-firmware/actions/runs/13274453531/job/37061153197#step:9:1149
```

Wed, 12 Feb 2025 05:21:56 GMT tests/device_tests/bitcoin/test_signtx_segwit_native.py:826: 
Wed, 12 Feb 2025 05:21:56 GMT _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ 
Wed, 12 Feb 2025 05:21:56 GMT python/src/trezorlib/btc.py:413: in sign_tx
Wed, 12 Feb 2025 05:21:56 GMT     res = client.call(messages.TxAck(tx=msg), expect=messages.TxRequest)
Wed, 12 Feb 2025 05:21:56 GMT python/src/trezorlib/client.py:260: in call
Wed, 12 Feb 2025 05:21:56 GMT     resp = self.call_raw(msg)
Wed, 12 Feb 2025 05:21:56 GMT python/src/trezorlib/transport/protocol.py:110: in read
Wed, 12 Feb 2025 05:21:56 GMT     return self.protocol.read()
Wed, 12 Feb 2025 05:21:56 GMT python/src/trezorlib/transport/protocol.py:140: in read
Wed, 12 Feb 2025 05:21:56 GMT     msg_type, datalen, first_chunk = self.read_first()
Wed, 12 Feb 2025 05:21:56 GMT _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ 
Wed, 12 Feb 2025 05:21:56 GMT
Wed, 12 Feb 2025 05:21:56 GMT self = <trezorlib.transport.protocol.ProtocolV1 object at 0x7f280fe67f70>
Wed, 12 Feb 2025 05:21:56 GMT
Wed, 12 Feb 2025 05:21:56 GMT     def read_first(self) -> Tuple[int, int, bytes]:
Wed, 12 Feb 2025 05:21:56 GMT         chunk = self.handle.read_chunk()
Wed, 12 Feb 2025 05:21:56 GMT         if chunk[:3] != b"?##":
Wed, 12 Feb 2025 05:21:56 GMT >           raise RuntimeError("Unexpected magic characters")
Wed, 12 Feb 2025 05:21:56 GMT E           RuntimeError: Unexpected magic characters
Wed, 12 Feb 2025 05:21:56 GMT
Wed, 12 Feb 2025 05:21:56 GMT python/src/trezorlib/transport/protocol.py:152: RuntimeError
```

After this failure, all other tests timed out:
![Screenshot from 2025-02-12 15-51-54](https://github.com/user-attachments/assets/908a6f80-0b5c-4b82-9fb5-6bd7c0dfcf55)

<!--
For core developers:
- Assign yourself to the PR.
- Set the priority to match the original issue.
- Add the PR to the current sprint.
- If it's a draft PR, mark it as "In Progress."
- If it's a final PR, mark it as "Needs Review."

For external contributors:
- Please open an issue before submitting a PR so we can discuss whether we want to proceed with it.
-->
