### PR TITLE
Fix TX summary back button

### DIFF
--- a/core/src/trezor/ui/layouts/caesar/__init__.py
+++ b/core/src/trezor/ui/layouts/caesar/__init__.py
@@ -967,7 +967,7 @@ if not utils.BITCOIN_ONLY:
             fee_label=f"{TR.send__maximum_fee}:",
             extra_items=[(f"{k}:", v) for (k, v) in fee_info_items],
             extra_title=TR.confirm_total__title_fee,
-            verb_cancel="<",
+            verb_cancel="^",
         )
 
         if not is_contract_interaction:


### PR DESCRIPTION
#4471 attempted to fix the back button on the TX summary on TS3, but I later learned that it should be "^" rather than "<". So here is the proper fix.