### PR TITLE
bump T3W1 revB revision

### DIFF
--- a/core/site_scons/models/T3W1/trezor_t3w1_revB.py
+++ b/core/site_scons/models/T3W1/trezor_t3w1_revB.py
@@ -14,7 +14,7 @@ def configure(
     features_available: list[str] = []
     board = "T3W1/boards/trezor_t3w1_revB.h"
     hw_model = get_hw_model_as_number("T3W1")
-    hw_revision = 0
+    hw_revision = 1
 
     mcu = "STM32U5G9xx"
     linker_script = """embed/sys/linker/stm32u5g/{target}.ld"""


### PR DESCRIPTION
this PR increments T3W1 revB revision, making the builds incompatible with revA build. Prevents accidental uploading/running fw on boards with incompatible bootloader.

<!--
For core developers:
- Assign yourself to the PR.
- Set the priority to match the original issue.
- Add the PR to the current sprint.
- If it's a draft PR, mark it as "In Progress."
- If it's a final PR, mark it as "Needs Review."

For external contributors:
- Please open an issue before submitting a PR so we can discuss whether we want to proceed with it.
-->
