### PR TITLE
feat(core): allow more paragraphs in `ShowInfoParams`

### DIFF
--- a/core/embed/rust/src/ui/layout_delizia/flow/util.rs
+++ b/core/embed/rust/src/ui/layout_delizia/flow/util.rs
@@ -9,7 +9,7 @@ use crate::{
             base::ComponentExt,
             swipe_detect::SwipeSettings,
             text::{
-                paragraphs::{Paragraph, ParagraphSource, ParagraphVecShort, VecExt},
+                paragraphs::{Paragraph, ParagraphSource, ParagraphVecLong, VecExt},
                 TextStyle,
             },
             Component,
@@ -386,7 +386,7 @@ impl ShowInfoParams {
     pub fn into_layout(
         self,
     ) -> Result<impl Component<Msg = FlowMsg> + Swipable + MaybeTrace, Error> {
-        let mut paragraphs = ParagraphVecShort::new();
+        let mut paragraphs = ParagraphVecLong::new();
         let mut first: bool = true;
         for item in self.items {
             // FIXME: padding:


### PR DESCRIPTION
Otherwise, it fails when showing 4 items.

Note that each item uses in 2 paragraphs. Also, items are separated by an empty paragraph.

So 3 items use 8 (2\*3+2) paragraphs and 4 items use 11 (2\*4+3) paragraphs.

<!--
For core developers:
- Assign yourself to the PR.
- Set the priority to match the original issue.
- Add the PR to the current sprint.
- If it's a draft PR, mark it as "In Progress."
- If it's a final PR, mark it as "Needs Review."

For external contributors:
- Please open an issue before submitting a PR so we can discuss whether we want to proceed with it.
-->
