### PR TITLE
Eckhart keyboards screens

### DIFF
--- a/core/embed/rust/src/ui/component/maybe.rs
+++ b/core/embed/rust/src/ui/component/maybe.rs
@@ -66,6 +66,10 @@ where
     pub fn inner_mut(&mut self) -> &mut T {
         &mut self.inner
     }
+
+    pub fn is_visible(&self) -> bool {
+        self.visible
+    }
 }
 
 impl<T> Component for Maybe<T>

--- a/core/embed/rust/src/ui/layout_eckhart/component/button.rs
+++ b/core/embed/rust/src/ui/layout_eckhart/component/button.rs
@@ -159,6 +159,10 @@ impl Button {
         }
     }
 
+    pub fn set_expanded_touch_area(&mut self, expand: Insets) {
+        self.touch_expand = Some(expand);
+    }
+
     pub fn content(&self) -> &ButtonContent {
         &self.content
     }

--- a/core/embed/rust/src/ui/layout_eckhart/component/keyboard/bip39.rs
+++ b/core/embed/rust/src/ui/layout_eckhart/component/keyboard/bip39.rs
@@ -1,0 +1,271 @@
+use crate::{
+    trezorhal::bip39,
+    ui::{
+        component::{text::common::TextBox, Component, Event, EventCtx},
+        geometry::{Alignment, Offset, Point, Rect},
+        shape::{Renderer, Text},
+    },
+};
+
+use super::super::super::{
+    component::{
+        keyboard::{
+            common::{render_pending_marker, MultiTapKeyboard},
+            mnemonic::{MnemonicInput, MnemonicInputMsg, MNEMONIC_KEY_COUNT},
+        },
+        Button, ButtonMsg,
+    },
+    constant::WIDTH,
+    theme,
+};
+
+const MAX_LENGTH: usize = 8;
+
+pub struct Bip39Input {
+    button: Button,
+    // used only to keep track of suggestion text color
+    button_suggestion: Button,
+    textbox: TextBox,
+    multi_tap: MultiTapKeyboard,
+    options_num: Option<usize>,
+    suggested_word: Option<&'static str>,
+}
+
+impl MnemonicInput for Bip39Input {
+    /// Return the key set. Keys are further specified as indices into this
+    /// array.
+    fn keys() -> [&'static str; MNEMONIC_KEY_COUNT] {
+        ["abc", "def", "ghi", "jkl", "mno", "pqr", "stu", "vwx", "yz"]
+    }
+
+    fn can_be_confirmed(&self) -> bool {
+        self.is_choice_unambiguous()
+    }
+
+    /// Returns `true` if given key index can continue towards a valid mnemonic
+    /// word, `false` otherwise.
+    fn can_key_press_lead_to_a_valid_word(&self, key: usize) -> bool {
+        // Currently pending key is always enabled.
+        let key_is_pending = self.multi_tap.pending_key() == Some(key);
+        // Keys that contain letters from the completion mask are enabled as well.
+        let key_matches_mask =
+            bip39::word_completion_mask(self.textbox.content()) & Self::key_mask(key) != 0;
+        key_is_pending || key_matches_mask
+    }
+
+    /// Key button was clicked. If this button is pending, let's cycle the
+    /// pending character in textbox. If not, let's just append the first
+    /// character.
+    fn on_key_click(&mut self, ctx: &mut EventCtx, key: usize) {
+        let edit = self.multi_tap.click_key(ctx, key, Self::keys()[key]);
+        self.textbox.apply(ctx, edit);
+        self.complete_word_from_dictionary(ctx);
+    }
+
+    /// Backspace button was clicked, let's delete the last character of input
+    /// and clear the pending marker.
+    fn on_backspace_click(&mut self, ctx: &mut EventCtx) {
+        self.multi_tap.clear_pending_state(ctx);
+        self.textbox.delete_last(ctx);
+        self.complete_word_from_dictionary(ctx);
+    }
+
+    fn on_confirm_click(&mut self, ctx: &mut EventCtx) -> Option<MnemonicInputMsg> {
+        // same action as clicking on the input
+        self.on_input_click(ctx)
+    }
+
+    /// Backspace button was long pressed, let's delete all characters of input
+    /// and clear the pending marker.
+    fn on_backspace_long_press(&mut self, ctx: &mut EventCtx) {
+        self.multi_tap.clear_pending_state(ctx);
+        self.textbox.clear(ctx);
+        self.complete_word_from_dictionary(ctx);
+    }
+
+    fn is_empty(&self) -> bool {
+        self.textbox.is_empty()
+    }
+
+    fn mnemonic(&self) -> Option<&'static str> {
+        self.suggested_word
+    }
+}
+
+impl Component for Bip39Input {
+    type Msg = MnemonicInputMsg;
+
+    fn place(&mut self, bounds: Rect) -> Rect {
+        self.button.place(bounds);
+        self.button_suggestion.place(bounds)
+    }
+
+    fn event(&mut self, ctx: &mut EventCtx, event: Event) -> Option<Self::Msg> {
+        if let Event::Attach(_) = event {
+            // Catch up with the prefilled word
+            if !self.textbox.is_empty() {
+                self.complete_word_from_dictionary(ctx);
+                return Some(MnemonicInputMsg::Completed);
+            }
+        }
+
+        _ = self.button_suggestion.event(ctx, event);
+
+        if self.multi_tap.timeout_event(event) {
+            self.on_timeout(ctx)
+        } else if let Some(ButtonMsg::Clicked) = self.button.event(ctx, event) {
+            self.on_input_click(ctx)
+        } else {
+            None
+        }
+    }
+
+    fn render<'s>(&'s self, target: &mut impl Renderer<'s>) {
+        let area = self.button.area();
+        let style = self.button.style();
+        let suggestion_style = self.button_suggestion.style();
+
+        // Paint the entered content (the prefix of the suggested word).
+        let text = self.textbox.content();
+        let width = style.font.text_width(text);
+
+        // User input together with suggestion is centered vertically in the input area
+        // and centered horizontally on the screen
+        let text_base_y = area.left_center().y + style.font.allcase_text_height() / 2;
+        let text_base_x = if let Some(word) = self.suggested_word {
+            style.font.horz_center(0, WIDTH, word)
+        } else {
+            style.font.horz_center(0, WIDTH, text)
+        };
+        let text_base = Point::new(text_base_x, text_base_y);
+
+        self.button.render(target);
+
+        // Render text input + suggested completion
+        Text::new(text_base, text, style.font)
+            .with_fg(style.text_color)
+            .with_align(Alignment::Start)
+            .render(target);
+        if let Some(word) = self.suggested_word.and_then(|w| w.get(text.len()..)) {
+            let word_baseline = text_base + Offset::x(width);
+            Text::new(word_baseline, word, style.font)
+                .with_fg(suggestion_style.text_color)
+                .with_align(Alignment::Start)
+                .render(target);
+        }
+
+        // Paint the pending marker.
+        if self.multi_tap.pending_key().is_some() {
+            render_pending_marker(target, text_base, text, style.font, style.text_color);
+        }
+    }
+}
+
+impl Bip39Input {
+    pub fn new() -> Self {
+        Self::prefilled_word("")
+    }
+
+    pub fn prefilled_word(word: &str) -> Self {
+        // Word may be empty string, fallback to normal input
+        let (options_num, suggested_word) = if word.is_empty() {
+            (bip39::options_num(word), bip39::complete_word(word))
+        } else {
+            (None, None)
+        };
+
+        // Styling the input to reflect already filled word
+        Self {
+            button: Button::empty()
+                .styled(theme::input_mnemonic())
+                .with_radius(12),
+            button_suggestion: Button::empty().styled(theme::input_mnemonic_suggestion()),
+            textbox: TextBox::new(word, MAX_LENGTH),
+            multi_tap: MultiTapKeyboard::new(),
+            options_num,
+            suggested_word,
+        }
+    }
+
+    /// Compute a bitmask of all letters contained in given key text. Lowest bit
+    /// is 'a', second lowest 'b', etc.
+    fn key_mask(key: usize) -> u32 {
+        let mut mask = 0;
+        for ch in Self::keys()[key].as_bytes() {
+            // We assume the key text is lower-case alphabetic ASCII, making the subtraction
+            // and the shift panic-free.
+            mask |= 1 << (ch - b'a');
+        }
+        mask
+    }
+
+    fn is_choice_unambiguous(&self) -> bool {
+        if let (Some(word), Some(_num)) = (self.suggested_word, self.options_num) {
+            return word.eq(self.textbox.content());
+        }
+        false
+    }
+
+    /// Input button was clicked.  If the content matches the suggested word,
+    /// let's confirm it, otherwise just auto-complete.
+    fn on_input_click(&mut self, ctx: &mut EventCtx) -> Option<MnemonicInputMsg> {
+        if let (Some(word), Some(_num)) = (self.suggested_word, self.options_num) {
+            return if word.eq(self.textbox.content()) {
+                // Confirm button.
+                self.textbox.clear(ctx);
+                Some(MnemonicInputMsg::Confirmed)
+            } else {
+                // Auto-complete button.
+                self.textbox.replace(ctx, word);
+                self.complete_word_from_dictionary(ctx);
+                ctx.request_paint();
+                Some(MnemonicInputMsg::Completed)
+            };
+        }
+        None
+    }
+
+    /// Timeout occurred.  If we can auto-complete current input, let's just
+    /// reset the pending marker.  If not, input is invalid, let's backspace the
+    /// last character.
+    fn on_timeout(&mut self, ctx: &mut EventCtx) -> Option<MnemonicInputMsg> {
+        self.multi_tap.clear_pending_state(ctx);
+        if self.suggested_word.is_none() {
+            self.textbox.delete_last(ctx);
+            self.complete_word_from_dictionary(ctx);
+        }
+        Some(MnemonicInputMsg::TimedOut)
+    }
+
+    fn complete_word_from_dictionary(&mut self, ctx: &mut EventCtx) {
+        self.options_num = bip39::options_num(self.textbox.content());
+        self.suggested_word = bip39::complete_word(self.textbox.content());
+
+        // Change the style of the button depending on the completed word.
+        if let (Some(word), Some(_num)) = (self.suggested_word, self.options_num) {
+            if word.eq(self.textbox.content()) {
+                // Confirm button.
+                self.button.enable(ctx);
+                self.button.set_stylesheet(theme::input_mnemonic_confirm());
+            } else {
+                // Auto-complete button.
+                self.button.enable(ctx);
+                self.button.set_stylesheet(theme::input_mnemonic());
+            }
+        } else {
+            // Disabled button.
+            self.button.disable(ctx);
+            self.button.set_stylesheet(theme::input_mnemonic());
+        }
+    }
+}
+
+// DEBUG-ONLY SECTION BELOW
+
+#[cfg(feature = "ui_debug")]
+impl crate::trace::Trace for Bip39Input {
+    fn trace(&self, t: &mut dyn crate::trace::Tracer) {
+        t.component("Bip39Input");
+        t.child("textbox", &self.textbox);
+    }
+}

--- a/core/embed/rust/src/ui/layout_eckhart/component/keyboard/common.rs
+++ b/core/embed/rust/src/ui/layout_eckhart/component/keyboard/common.rs
@@ -1,0 +1,168 @@
+use crate::{
+    time::Duration,
+    ui::{
+        component::{text::common::TextEdit, Event, EventCtx, Timer},
+        display::{Color, Font},
+        geometry::{Insets, Offset, Point, Rect},
+        shape::{Bar, Renderer},
+    },
+};
+
+use super::super::theme;
+
+/// Contains state commonly used in implementations multi-tap keyboards.
+pub struct MultiTapKeyboard {
+    /// Configured timeout after which we cancel currently pending key.
+    timeout: Duration,
+    /// The currently pending state.
+    pending: Option<Pending>,
+    /// Timer for clearing the pending state.
+    timer: Timer,
+}
+
+struct Pending {
+    /// Index of the pending key.
+    key: usize,
+    /// Index of the key press (how many times the `key` was pressed, minus
+    /// one).
+    press: usize,
+}
+
+impl MultiTapKeyboard {
+    /// Create a new, empty, multi-tap state.
+    pub fn new() -> Self {
+        Self {
+            timeout: Duration::from_secs(1),
+            pending: None,
+            timer: Timer::new(),
+        }
+    }
+
+    /// Return the index of the currently pending key, if any.
+    pub fn pending_key(&self) -> Option<usize> {
+        self.pending.as_ref().map(|p| p.key)
+    }
+
+    /// Return the index of the pending key press.
+    pub fn pending_press(&self) -> Option<usize> {
+        self.pending.as_ref().map(|p| p.press)
+    }
+
+    /// Returns `true` if `event` is an `Event::Timer` for the currently pending
+    /// timer.
+    pub fn timeout_event(&mut self, event: Event) -> bool {
+        self.timer.expire(event)
+    }
+
+    /// Reset to the empty state. Takes `EventCtx` to request a paint pass (to
+    /// either hide or show any pending marker our caller might want to draw
+    /// later).
+    pub fn clear_pending_state(&mut self, ctx: &mut EventCtx) {
+        self.timer.stop();
+        if self.pending.is_some() {
+            self.pending = None;
+            ctx.request_paint();
+        }
+    }
+
+    /// Register a click to a key. `MultiTapKeyboard` itself does not have any
+    /// concept of the key set, so both the key index and the key content is
+    /// taken here. Returns a text editing operation the caller should apply on
+    /// the output buffer. Takes `EventCtx` to request a timeout for cancelling
+    /// the pending state. Caller is required to handle the timer event and
+    /// call `Self::clear_pending_state` when the timer hits.
+    pub fn click_key(&mut self, ctx: &mut EventCtx, key: usize, key_text: &str) -> TextEdit {
+        let (is_pending, press) = match &self.pending {
+            Some(pending) if pending.key == key => {
+                // This key is pending. Cycle the last inserted character through the
+                // key content.
+                (true, pending.press.wrapping_add(1))
+            }
+            _ => {
+                // This key is not pending. Append the first character in the key.
+                (false, 0)
+            }
+        };
+
+        // If the key has more then one character, we need to set it as pending, so we
+        // can cycle through on the repeated clicks. We also request a timer so we can
+        // reset the pending state after a timeout.
+        //
+        // Note: It might seem that we should make sure to `request_paint` in case we
+        // progress into a pending state (to display the pending marker), but such
+        // transition only happens as a result of an append op, so the painting should
+        // be requested by handling the `TextEdit`.
+        self.pending = if key_text.len() > 1 {
+            self.timer.start(ctx, self.timeout);
+            Some(Pending { key, press })
+        } else {
+            None
+        };
+
+        assert!(!key_text.is_empty());
+        // Now we can be sure that a looped iterator will return a value
+        let ch = unwrap!(key_text.chars().cycle().nth(press));
+        if is_pending {
+            TextEdit::ReplaceLast(ch)
+        } else {
+            TextEdit::Append(ch)
+        }
+    }
+}
+
+/// Create a visible "underscoring" of the last letter of a text.
+pub fn render_pending_marker<'s>(
+    target: &mut impl Renderer<'s>,
+    text_baseline: Point,
+    text: &str,
+    font: Font,
+    color: Color,
+) {
+    // Measure the width of the last character of input.
+    if let Some(last) = text.chars().last() {
+        let width = font.text_width(text);
+        let last_width = font.char_width(last);
+        // Draw the marker 2px under the start of the baseline of the last character.
+        let marker_origin = text_baseline + Offset::new(width - last_width, 2);
+        // Draw the marker 1px longer than the last character, and 3px thick.
+        let marker_rect =
+            Rect::from_top_left_and_size(marker_origin, Offset::new(last_width + 1, 3));
+        Bar::new(marker_rect).with_bg(color).render(target);
+    }
+}
+
+/// `DisplayStyle` isused to determine whether the text is fully hidden, fully
+/// shown, or partially visible.
+#[derive(PartialEq, Debug, Copy, Clone)]
+#[cfg_attr(feature = "ui_debug", derive(ufmt::derive::uDebug))]
+pub(crate) enum DisplayStyle {
+    Hidden,
+    Shown,
+    LastOnly,
+}
+
+/// The number and colors of fading icons to display.
+pub const FADING_ICON_COUNT: usize = 4;
+pub const FADING_ICON_COLORS: [Color; FADING_ICON_COUNT] = [
+    theme::GREY_SUPER_DARK,
+    theme::GREY_EXTRA_DARK,
+    theme::GREY_DARK,
+    theme::GREY,
+];
+
+/// Visible area of the keypad. The touchable area is smaller
+pub const KEYPAD_VISIBLE_HEIGHT: i16 = 440;
+/// Area of the input field that is touchable
+pub const INPUT_TOUCH_HEIGHT: i16 = 96;
+
+const TEXTBOX_HEIGHT: i16 = 72;
+const INPUT_SIDE_PADDING: i16 = 24;
+const INPUT_TOP_PADDING: i16 = 16;
+
+pub const KEYBOARD_INPUT_RADIUS: i16 = 12;
+pub const KEYBOARD_INPUT_INSETS: Insets = Insets::new(
+    INPUT_TOP_PADDING,
+    INPUT_SIDE_PADDING,
+    INPUT_TOUCH_HEIGHT - INPUT_TOP_PADDING - TEXTBOX_HEIGHT,
+    INPUT_SIDE_PADDING,
+);

--- a/core/embed/rust/src/ui/layout_eckhart/component/keyboard/keypad.rs
+++ b/core/embed/rust/src/ui/layout_eckhart/component/keyboard/keypad.rs
@@ -1,0 +1,571 @@
+use crate::{
+    trezorhal::random,
+    ui::{
+        component::{Component, Event, EventCtx, Maybe},
+        geometry::{Alignment, Insets, Offset, Rect},
+        shape::Renderer,
+    },
+};
+
+use super::{
+    super::super::{
+        component::button::{Button, ButtonContent, ButtonMsg, ButtonStyleSheet},
+        constant::SCREEN,
+        theme,
+    },
+    common::KEYPAD_VISIBLE_HEIGHT,
+};
+
+#[derive(PartialEq)]
+pub enum KeypadButton {
+    Key(usize),
+    Erase,   // Represents an erase button.
+    Cancel,  // Represents a cancel button.
+    Confirm, // Represents a confirm button.
+    Back,    // Represents a back(previous) button.
+}
+
+pub enum ButtonState {
+    Enabled,
+    Disabled,
+    Hidden,
+}
+
+const KEYPAD_MAX_KEYS: usize = 10;
+type KeypadKeys = [Maybe<Button>; KEYPAD_MAX_KEYS];
+
+pub struct KeypadState {
+    pub back: ButtonState,
+    pub erase: ButtonState,
+    pub cancel: ButtonState,
+    pub confirm: ButtonState,
+    pub keys: ButtonState,
+}
+
+pub struct Keypad {
+    back: Maybe<Button>,
+    erase: Maybe<Button>,
+    cancel: Maybe<Button>,
+    confirm: Maybe<Button>,
+    keys: KeypadKeys,
+    pressed: Option<KeypadButton>,
+}
+
+#[derive(PartialEq, Debug, Copy, Clone)]
+#[cfg_attr(feature = "ui_debug", derive(ufmt::derive::uDebug))]
+pub enum KeypadMsg {
+    Back,
+    Confirm,
+    EraseShort,
+    EraseLong,
+    Cancel,
+    Key(usize),
+}
+
+impl Keypad {
+    pub const MAX_KEYS: usize = KEYPAD_MAX_KEYS;
+    const KEYBOARD_BUTTON_HEIGHT: i16 = 70;
+    const KEYBOARD_BUTTON_RADIUS: u8 = 11;
+
+    const ERASE_BUTTON_INDEX: usize = 9;
+    const CONFIRM_BUTTON_INDEX: usize = 11;
+
+    /// Create a new keypad with numeric keys. The keys are shown and active and
+    /// are shuffled if `shuffle` is true. The special buttons are hidden.
+    pub fn new_numeric(shuffle: bool) -> Self {
+        let mut digits = ["1", "2", "3", "4", "5", "6", "7", "8", "9", "0"];
+        // Shuffle if requested
+        if shuffle {
+            random::shuffle(&mut digits);
+        }
+        let keypad_content: [_; KEYPAD_MAX_KEYS] =
+            core::array::from_fn(|i| ButtonContent::Text(digits[i].into()));
+
+        Self::new_inner(true, true, theme::button_keyboard_numeric())
+            .with_keys_content(&keypad_content)
+    }
+
+    /// Create a new keypad with empty keys. The keys and special buttons are
+    /// hidden.
+    pub fn new_hidden() -> Self {
+        Self::new_inner(false, false, theme::button_keyboard())
+    }
+
+    /// Create a new keypad with empty keys. The keys are shown and the special
+    /// buttons are hidden.
+    pub fn new_shown() -> Self {
+        Self::new_inner(true, true, theme::button_keyboard())
+    }
+
+    fn new_inner(enabled: bool, visible: bool, styles: ButtonStyleSheet) -> Self {
+        Self {
+            // Special buttons are hidden by default.
+            back: Maybe::hidden(
+                theme::BG,
+                Button::with_icon(theme::ICON_CHEVRON_LEFT)
+                    .styled(theme::button_keyboard_numeric())
+                    .with_radius(Self::KEYBOARD_BUTTON_RADIUS)
+                    .initially_enabled(false),
+            ),
+            cancel: Maybe::hidden(
+                theme::BG,
+                Button::with_icon(theme::ICON_CROSS)
+                    .styled(theme::button_cancel())
+                    .with_radius(Self::KEYBOARD_BUTTON_RADIUS)
+                    .initially_enabled(false),
+            ),
+            confirm: Maybe::hidden(
+                theme::BG,
+                Button::with_icon(theme::ICON_CHECKMARK)
+                    .styled(theme::button_keyboard_confirm())
+                    .with_radius(Self::KEYBOARD_BUTTON_RADIUS)
+                    .initially_enabled(false),
+            ),
+            erase: Maybe::hidden(
+                theme::BG,
+                Button::with_icon(theme::ICON_DELETE)
+                    .styled(theme::button_keyboard())
+                    .with_long_press(theme::ERASE_HOLD_DURATION)
+                    .with_radius(Self::KEYBOARD_BUTTON_RADIUS)
+                    .initially_enabled(false),
+            ),
+            // Initialize all keys with empty content
+            keys: core::array::from_fn(|_idx| {
+                let inner = Button::empty()
+                    .with_radius(Self::KEYBOARD_BUTTON_RADIUS)
+                    .styled(styles)
+                    .with_text_align(Alignment::Center)
+                    .initially_enabled(enabled);
+                Maybe::new(theme::BG, inner, visible)
+            }),
+            pressed: None,
+        }
+    }
+
+    /// Set the content of all keyboard keys.
+    pub fn with_keys_content(mut self, keypad_content: &[ButtonContent]) -> Self {
+        // Make sure the content fits the keypad.
+        debug_assert!(keypad_content.len() <= Self::MAX_KEYS);
+
+        for (i, key_content) in keypad_content.into_iter().enumerate() {
+            self.keys[i].inner_mut().set_content(key_content.clone());
+        }
+        self
+    }
+
+    /// Get the content of a key at the specified index.
+    pub fn get_key_content(&self, idx: usize) -> &ButtonContent {
+        // Make sure the index is within bounds.
+        debug_assert!(idx < Self::MAX_KEYS);
+
+        &self.keys[idx].inner().content()
+    }
+
+    /// Set the state of the keypad.
+    pub fn set_state(&mut self, state: KeypadState, ctx: &mut EventCtx) {
+        Self::apply_button_state(&mut self.back, &state.back, ctx);
+        Self::apply_button_state(&mut self.erase, &state.erase, ctx);
+        Self::apply_button_state(&mut self.cancel, &state.cancel, ctx);
+        Self::apply_button_state(&mut self.confirm, &state.confirm, ctx);
+        self.set_keys_state(ctx, &state.keys);
+    }
+
+    /// Set the content of a key at the specified index.
+    pub fn set_key_content(&mut self, idx: usize, content: ButtonContent) {
+        // Make sure the index is within bounds.
+        debug_assert!(idx < Self::MAX_KEYS);
+
+        self.keys[idx].inner_mut().set_content(content);
+    }
+
+    fn get_button_mut(&mut self, button: &KeypadButton) -> &mut Maybe<Button> {
+        match button {
+            KeypadButton::Key(idx) => &mut self.keys[*idx],
+            KeypadButton::Erase => &mut self.erase,
+            KeypadButton::Cancel => &mut self.cancel,
+            KeypadButton::Confirm => &mut self.confirm,
+            KeypadButton::Back => &mut self.back,
+        }
+    }
+
+    fn get_button(&self, button: &KeypadButton) -> &Maybe<Button> {
+        match button {
+            KeypadButton::Key(idx) => &self.keys[*idx],
+            KeypadButton::Erase => &self.erase,
+            KeypadButton::Cancel => &self.cancel,
+            KeypadButton::Confirm => &self.confirm,
+            KeypadButton::Back => &self.back,
+        }
+    }
+
+    /// Set the stylesheet of one keypad button.
+    pub fn set_button_stylesheet(&mut self, button: KeypadButton, styles: ButtonStyleSheet) {
+        self.get_button_mut(&button)
+            .inner_mut()
+            .set_stylesheet(styles);
+    }
+
+    fn apply_button_state(btn: &mut Maybe<Button>, state: &ButtonState, ctx: &mut EventCtx) {
+        match state {
+            ButtonState::Enabled => {
+                btn.show(ctx);
+                btn.inner_mut().enable(ctx);
+            }
+            ButtonState::Disabled => {
+                btn.show(ctx);
+                btn.inner_mut().disable(ctx);
+            }
+            ButtonState::Hidden => {
+                btn.hide(ctx);
+            }
+        }
+    }
+
+    /// Set the state of all key buttons
+    pub fn set_keys_state(&mut self, ctx: &mut EventCtx, state: &ButtonState) {
+        for btn in self.keys.iter_mut() {
+            Self::apply_button_state(btn, state, ctx);
+        }
+    }
+
+    /// Set the state of one keypad button.
+    pub fn set_button_state(
+        &mut self,
+        ctx: &mut EventCtx,
+        button: KeypadButton,
+        state: &ButtonState,
+    ) {
+        Self::apply_button_state(self.get_button_mut(&button), state, ctx);
+    }
+
+    /// Check if any button is currently pressed.
+    pub fn pressed(&self) -> bool {
+        self.pressed.is_some()
+    }
+
+    fn render_button<'s>(btn: &'s Maybe<Button>, target: &mut impl Renderer<'s>) {
+        if btn.is_visible() {
+            btn.render(target);
+        }
+    }
+
+    /// Render pressed button.
+    fn render_pressed_button<'s>(&'s self, target: &mut impl Renderer<'s>) {
+        // TODO: Render special shape for the edge buttons.
+        if let Some(button) = &self.pressed {
+            Self::render_button(self.get_button(button), target);
+        }
+    }
+
+    /// Convert key index to grid cell index.
+    fn key_2_grid_cell(key: usize) -> usize {
+        // Make sure the key is within bounds.
+        debug_assert!(key < Self::MAX_KEYS);
+        // Key with index 9 must be mapped after the cancel button.
+        if key < 9 {
+            key
+        } else {
+            key + 1
+        }
+    }
+}
+
+impl Component for Keypad {
+    type Msg = KeypadMsg;
+
+    fn place(&mut self, bounds: Rect) -> Rect {
+        // assert precise size and position of the keypad
+        debug_assert_eq!(bounds.width(), SCREEN.width());
+        debug_assert_eq!(bounds.height(), KEYPAD_VISIBLE_HEIGHT);
+        debug_assert!(bounds.bottom_right() == SCREEN.bottom_right());
+
+        // Decrease touch area for buttons.
+        let erase_touch_inset = KeypadGrid::insets_of_cell(Self::ERASE_BUTTON_INDEX);
+        let confirm_touch_inset = KeypadGrid::insets_of_cell(Self::CONFIRM_BUTTON_INDEX);
+
+        self.erase
+            .inner_mut()
+            .set_expanded_touch_area(erase_touch_inset);
+        self.cancel
+            .inner_mut()
+            .set_expanded_touch_area(erase_touch_inset);
+        self.back
+            .inner_mut()
+            .set_expanded_touch_area(erase_touch_inset);
+        self.confirm
+            .inner_mut()
+            .set_expanded_touch_area(confirm_touch_inset);
+
+        for (i, btn) in self.keys.iter_mut().enumerate() {
+            btn.inner_mut()
+                .set_expanded_touch_area(KeypadGrid::insets_of_cell(Self::key_2_grid_cell(i)));
+        }
+
+        // Place buttons
+        let erase_area = KeypadGrid::border_of_cell(Self::ERASE_BUTTON_INDEX);
+        let confirm_area = KeypadGrid::border_of_cell(Self::CONFIRM_BUTTON_INDEX);
+
+        self.erase.place(erase_area);
+        self.cancel.place(erase_area);
+        self.back.place(erase_area);
+        self.confirm.place(confirm_area);
+        for (i, btn) in self.keys.iter_mut().enumerate() {
+            btn.place(KeypadGrid::border_of_cell(Self::key_2_grid_cell(i)));
+        }
+        bounds
+    }
+    fn event(&mut self, ctx: &mut EventCtx, event: Event) -> Option<Self::Msg> {
+        let click_mapping = [
+            (KeypadButton::Confirm, KeypadMsg::Confirm),
+            (KeypadButton::Erase, KeypadMsg::EraseShort),
+            (KeypadButton::Cancel, KeypadMsg::Cancel),
+            (KeypadButton::Back, KeypadMsg::Back),
+        ];
+
+        for (button, msg) in click_mapping {
+            match self.get_button_mut(&button).event(ctx, event) {
+                // Detect click of all special buttons
+                Some(ButtonMsg::Clicked) => {
+                    self.pressed = None;
+                    return Some(msg);
+                }
+                // Detect long press of the erase button
+                Some(ButtonMsg::LongPressed) if button == KeypadButton::Erase => {
+                    self.pressed = None;
+                    return Some(KeypadMsg::EraseLong);
+                }
+                // Detect press of all special buttons for rendering purposes
+                Some(ButtonMsg::Pressed) => {
+                    self.pressed = Some(button);
+                }
+                _ => {}
+            }
+        }
+
+        for (idx, btn) in self.keys.iter_mut().enumerate() {
+            match btn.event(ctx, event) {
+                // Detect click of all key buttons
+                Some(ButtonMsg::Clicked) => {
+                    self.pressed = None;
+                    return Some(KeypadMsg::Key(idx));
+                }
+                // Detect press of all key buttons for rendering purposes
+                Some(ButtonMsg::Pressed) => {
+                    self.pressed = Some(KeypadButton::Key(idx));
+                }
+                _ => {}
+            }
+        }
+
+        None
+    }
+
+    fn render<'s>(&'s self, target: &mut impl Renderer<'s>) {
+        // render key buttons
+        for btn in self.keys.iter() {
+            Self::render_button(btn, target);
+        }
+
+        // render special buttons
+        Self::render_button(&self.cancel, target);
+        Self::render_button(&self.erase, target);
+        Self::render_button(&self.back, target);
+        Self::render_button(&self.confirm, target);
+
+        // render currently pressed button once again because of possible overlap
+        self.render_pressed_button(target);
+    }
+}
+
+// Dimensions of the grid.
+const ROWS: usize = 4;
+const COLS: usize = 3;
+
+/// Represents a grid of buttons with fixed dimensions of 4x3.
+/// Borders of buttons overlap each other and the input component because in
+/// pressed state, they are rendered larger. To avoid touch interference between
+/// buttons, negative insets are used to reduce the touch area of each button
+/// not to overlap.
+pub struct KeypadGrid;
+
+impl KeypadGrid {
+    /// The visible area of the keypad.
+    const VISIBLE_AREA: Rect = Self::visible_area();
+
+    // Button dimensions.
+    const BUTTON_WIDTH: i16 = 136;
+    const BUTTON_HEIGHT: i16 = 134;
+
+    // Overlap parameters.
+    const VERTICAL_BUTTON_SPACING: i16 = 32;
+    const HORIZONTAL_BUTTON_PADDING: i16 = 7;
+
+    // Precomputed border rects and touch insets for each grid entry.
+    const BORDER_RECTS: [[Rect; COLS]; ROWS] = KeypadGrid::compute_border_rects();
+    const TOUCH_INSETS: [[Insets; COLS]; ROWS] = KeypadGrid::compute_touch_insets();
+
+    // Keypad touch area is smaller than the visible area.
+    // Sum input and keypad gives the
+    const KEYPAD_TOUCH_HEIGHT: i16 = KEYPAD_VISIBLE_HEIGHT - Self::VERTICAL_BUTTON_SPACING / 2;
+
+    const fn visible_area() -> Rect {
+        let (_, visible_area) = SCREEN.split_bottom(KEYPAD_VISIBLE_HEIGHT);
+        visible_area
+    }
+
+    /// Computes the border rects for each grid entry.
+    const fn compute_border_rects() -> [[Rect; COLS]; ROWS] {
+        let mut rects = [[Rect::zero(); COLS]; ROWS];
+        let mut row = 0;
+        while row < ROWS {
+            let mut col = 0;
+            while col < COLS {
+                rects[row][col] = Rect::from_top_left_and_size(
+                    Self::VISIBLE_AREA.top_left().ofs(Offset::new(
+                        col as i16 * (Self::BUTTON_WIDTH - 2 * Self::HORIZONTAL_BUTTON_PADDING),
+                        row as i16 * (Self::BUTTON_HEIGHT - Self::VERTICAL_BUTTON_SPACING),
+                    )),
+                    Offset::new(Self::BUTTON_WIDTH, Self::BUTTON_HEIGHT),
+                );
+                col += 1;
+            }
+            row += 1;
+        }
+        rects
+    }
+
+    /// Computes negative touch insets for each grid entry for
+    /// `set_expanded_touch_area` Buttonfunction
+    const fn compute_touch_insets() -> [[Insets; COLS]; ROWS] {
+        let mut insets = [[Insets::uniform(0); COLS]; ROWS];
+        let mut row = 0;
+        while row < ROWS {
+            let mut col = 0;
+            while col < COLS {
+                insets[row][col] = Insets::new(
+                    -Self::VERTICAL_BUTTON_SPACING / 2,
+                    -Self::HORIZONTAL_BUTTON_PADDING,
+                    -Self::VERTICAL_BUTTON_SPACING / 2,
+                    -Self::HORIZONTAL_BUTTON_PADDING,
+                );
+                // No bottom inset for the last row
+                if row == ROWS - 1 {
+                    insets[row][col].bottom = 0;
+                }
+                // no left inset for the first column
+                if col == 0 {
+                    insets[row][col].left = 0;
+                // no right inset for the last column
+                } else if col == COLS - 1 {
+                    insets[row][col].right = 0;
+                }
+                col += 1;
+            }
+            row += 1;
+        }
+        insets
+    }
+
+    /// Retrieves the button border `Rect` at the specified index.
+    pub const fn border_of_cell(index: usize) -> Rect {
+        let (row, col) = Self::cell2row_col(index);
+        Self::border_of_row_col(row, col)
+    }
+
+    // Converts a cell index to a (row, col) tuple.
+    const fn cell2row_col(index: usize) -> (usize, usize) {
+        (index / COLS, index % COLS)
+    }
+
+    /// Retrieves the button border `Rect` for the given row and column.
+    pub const fn border_of_row_col(row: usize, col: usize) -> Rect {
+        debug_assert!(row < ROWS);
+        debug_assert!(col < COLS);
+        Self::BORDER_RECTS[row][col]
+    }
+
+    /// Retrieves the button touch `Insets` at the specified index.
+    pub const fn insets_of_cell(index: usize) -> Insets {
+        let (row, col) = Self::cell2row_col(index);
+        Self::insets_of_row_col(row, col)
+    }
+
+    /// Retrieves the button touch `Insets` for the given row and column.
+    pub const fn insets_of_row_col(row: usize, col: usize) -> Insets {
+        debug_assert!(row < ROWS);
+        debug_assert!(col < COLS);
+        Self::TOUCH_INSETS[row][col]
+    }
+}
+
+#[cfg(test)]
+mod tests {
+
+    use super::{
+        super::{super::constant::SCREEN, common::INPUT_TOUCH_HEIGHT},
+        *,
+    };
+
+    #[test]
+    fn test_layout_constraints() {
+        debug_assert_eq!(
+            KeypadGrid::KEYPAD_TOUCH_HEIGHT + INPUT_TOUCH_HEIGHT,
+            SCREEN.height(),
+            "Keypad and input touch areas do not sum into the screen height"
+        );
+
+        assert_eq!(
+            (ROWS as i16) * KeypadGrid::BUTTON_HEIGHT,
+            KeypadGrid::KEYPAD_TOUCH_HEIGHT
+                + (ROWS as i16 - 1) * KeypadGrid::VERTICAL_BUTTON_SPACING,
+            "Keypad height does not match expected layout constraints"
+        );
+
+        assert_eq!(
+            (COLS as i16) * KeypadGrid::BUTTON_WIDTH,
+            KeypadGrid::VISIBLE_AREA.width()
+                + (COLS as i16 - 1) * 2 * KeypadGrid::HORIZONTAL_BUTTON_PADDING,
+            "Keypad width does not match expected layout constraints"
+        );
+    }
+
+    #[test]
+    fn test_borders_within_visible_area_by_cell() {
+        for index in 0..(ROWS * COLS) {
+            let border = KeypadGrid::border_of_cell(index);
+            // The border is within the visible area if the intersection is equal to the
+            // border.
+            let intersection = border.clamp(KeypadGrid::VISIBLE_AREA);
+            assert!(
+                border.width() == intersection.width() && border.height() == intersection.height(),
+                "Border at index {} is out of keypad visible bounds",
+                index
+            );
+        }
+    }
+
+    #[test]
+    fn test_no_touch_overlap() {
+        for idx1 in 0..(ROWS * COLS) {
+            let touch_border_1 =
+                KeypadGrid::border_of_cell(idx1).outset(KeypadGrid::insets_of_cell(idx1));
+
+            for idx2 in 0..(ROWS * COLS) {
+                if idx1 == idx2 {
+                    continue; // Skip comparing the same cell
+                }
+
+                let touch_border_2 =
+                    KeypadGrid::border_of_cell(idx2).outset(KeypadGrid::insets_of_cell(idx2));
+
+                assert!(
+                    touch_border_1.clamp(touch_border_2).is_empty(),
+                    "Touch border of cell {} overlaps the touch border of
+                cell {}",
+                    idx1,
+                    idx2,
+                );
+            }
+        }
+    }
+}

--- a/core/embed/rust/src/ui/layout_eckhart/component/keyboard/mnemonic.rs
+++ b/core/embed/rust/src/ui/layout_eckhart/component/keyboard/mnemonic.rs
@@ -1,0 +1,283 @@
+use crate::{
+    strutil::TString,
+    ui::{
+        component::{Component, Event, EventCtx, Label, Maybe},
+        geometry::Rect,
+        shape::Renderer,
+    },
+};
+
+use super::super::super::{
+    component::{
+        button::ButtonContent,
+        keyboard::{
+            common::{INPUT_TOUCH_HEIGHT, KEYBOARD_INPUT_INSETS, KEYPAD_VISIBLE_HEIGHT},
+            keypad::{ButtonState, Keypad, KeypadButton, KeypadMsg},
+        },
+    },
+    constant::SCREEN,
+    theme,
+};
+
+pub const MNEMONIC_KEY_COUNT: usize = 9;
+
+pub enum MnemonicKeyboardMsg {
+    Confirmed,
+    Previous,
+}
+
+pub struct MnemonicKeyboard<T> {
+    /// Initial prompt, displayed on empty input.
+    prompt: Maybe<Label<'static>>,
+    /// Input area, acting as the auto-complete.
+    input: Maybe<T>,
+    /// Key buttons.
+    keypad: Keypad,
+    /// Whether going back is allowed (is not on the very first word).
+    can_go_back: bool,
+}
+
+impl<T> MnemonicKeyboard<T>
+where
+    T: MnemonicInput,
+{
+    pub const KEY_COUNT: usize = 9;
+    pub fn new(input: T, prompt: TString<'static>, can_go_back: bool) -> Self {
+        // Input might be already pre-filled
+        let prompt_visible = input.is_empty();
+
+        let keypad_content: [_; MNEMONIC_KEY_COUNT] =
+            core::array::from_fn(|idx| ButtonContent::Text(T::keys()[idx].into()));
+
+        Self {
+            prompt: Maybe::new(
+                theme::BG,
+                Label::centered(prompt, theme::TEXT_SMALL).vertically_centered(),
+                prompt_visible,
+            ),
+            keypad: Keypad::new_hidden().with_keys_content(&keypad_content),
+            can_go_back,
+            input: Maybe::new(theme::BG, input, !prompt_visible),
+        }
+    }
+
+    fn on_input_change(&mut self, ctx: &mut EventCtx) {
+        self.toggle_buttons(ctx);
+        self.toggle_prompt_or_input(ctx);
+    }
+
+    /// Either enable or disable the key buttons, depending on the dictionary
+    /// completion mask and the pending key.
+    fn toggle_buttons(&mut self, ctx: &mut EventCtx) {
+        let input = self.input.inner();
+        // Enable/disable the key buttons based on the ability to form a valid word.
+        for idx in 0..Self::KEY_COUNT {
+            let state = if input.can_key_press_lead_to_a_valid_word(idx) {
+                ButtonState::Enabled
+            } else {
+                ButtonState::Disabled
+            };
+            self.keypad
+                .set_button_state(ctx, KeypadButton::Key(idx), &state);
+        }
+
+        // Determine states for erase and back buttons
+        let (erase_state, back_state) = if input.is_empty() {
+            (
+                ButtonState::Hidden,
+                if self.can_go_back {
+                    ButtonState::Enabled
+                } else {
+                    ButtonState::Hidden
+                },
+            )
+        } else {
+            (ButtonState::Enabled, ButtonState::Hidden)
+        };
+
+        // Determine state and style for the confirm button based on input state
+        let confirm_state = if input.is_empty() || input.mnemonic().is_none() {
+            ButtonState::Hidden
+        } else {
+            ButtonState::Enabled
+        };
+        let confirm_style = if input.mnemonic().is_some() {
+            let any_press_can_lead_to_valid_word = || {
+                (0..Self::KEY_COUNT)
+                    .any(|idx| self.input.inner().can_key_press_lead_to_a_valid_word(idx))
+            };
+            if any_press_can_lead_to_valid_word() {
+                theme::button_keyboard()
+            } else {
+                theme::button_keyboard_confirm()
+            }
+        } else {
+            theme::button_keyboard()
+        };
+
+        // Apply all button states
+        self.keypad
+            .set_button_state(ctx, KeypadButton::Erase, &erase_state);
+        self.keypad
+            .set_button_state(ctx, KeypadButton::Back, &back_state);
+        self.keypad
+            .set_button_state(ctx, KeypadButton::Confirm, &confirm_state);
+
+        // Apply the stylesheet for the confirm button
+        self.keypad
+            .set_button_stylesheet(KeypadButton::Confirm, confirm_style);
+    }
+
+    /// After edit operations, we need to either show or hide the prompt, the
+    /// input, the erase button and the back button.
+    fn toggle_prompt_or_input(&mut self, ctx: &mut EventCtx) {
+        let input_empty = self.input.inner().is_empty();
+        // Prompt is shown if the input is empty.
+        self.prompt.show_if(ctx, input_empty);
+        self.input.show_if(ctx, !input_empty);
+    }
+
+    pub fn mnemonic(&self) -> Option<&'static str> {
+        self.input.inner().mnemonic()
+    }
+}
+
+impl<T> Component for MnemonicKeyboard<T>
+where
+    T: MnemonicInput,
+{
+    type Msg = MnemonicKeyboardMsg;
+
+    fn place(&mut self, bounds: Rect) -> Rect {
+        // assert full screen
+        debug_assert_eq!(bounds.height(), SCREEN.height());
+        debug_assert_eq!(bounds.width(), SCREEN.width());
+
+        // Keypad and input areas are overlapped
+        let (_, keypad_area) = bounds.split_bottom(KEYPAD_VISIBLE_HEIGHT);
+        let (input_area, _) = bounds.split_top(INPUT_TOUCH_HEIGHT);
+
+        let prompt_area = input_area.inset(KEYBOARD_INPUT_INSETS);
+        let input_area = input_area.inset(KEYBOARD_INPUT_INSETS);
+
+        // Prompt/input placement
+        self.prompt.place(prompt_area);
+        self.input.place(input_area);
+
+        // Keypad placement
+        self.keypad.place(keypad_area);
+
+        bounds
+    }
+
+    fn event(&mut self, ctx: &mut EventCtx, event: Event) -> Option<Self::Msg> {
+        match event {
+            Event::Attach(_) => {
+                self.on_input_change(ctx);
+            }
+            _ => {}
+        }
+
+        match self.input.event(ctx, event) {
+            Some(MnemonicInputMsg::Confirmed) => {
+                // Confirmed, bubble up.
+                return Some(MnemonicKeyboardMsg::Confirmed);
+            }
+            Some(_) => {
+                // Either a timeout or a completion.
+                self.on_input_change(ctx);
+                return None;
+            }
+            _ => {}
+        }
+
+        match self.keypad.event(ctx, event) {
+            Some(KeypadMsg::Key(idx)) => {
+                self.input.inner_mut().on_key_click(ctx, idx);
+                self.on_input_change(ctx);
+                return None;
+            }
+            Some(KeypadMsg::Back) => {
+                // Back button will cause going back to the previous word when allowed.
+                if self.can_go_back {
+                    return Some(MnemonicKeyboardMsg::Previous);
+                }
+            }
+            Some(KeypadMsg::EraseShort) => {
+                self.input.inner_mut().on_backspace_click(ctx);
+                self.on_input_change(ctx);
+                return None;
+            }
+            Some(KeypadMsg::EraseLong) => {
+                self.input.inner_mut().on_backspace_long_press(ctx);
+                self.on_input_change(ctx);
+                return None;
+            }
+            Some(KeypadMsg::Confirm) => {
+                match self.input.inner_mut().on_confirm_click(ctx) {
+                    Some(MnemonicInputMsg::Confirmed) => {
+                        // Confirmed, bubble up.
+                        return Some(MnemonicKeyboardMsg::Confirmed);
+                    }
+                    Some(_) => {
+                        // Either a timeout or a completion.
+                        self.on_input_change(ctx);
+                        return None;
+                    }
+                    _ => {}
+                }
+            }
+            _ => {}
+        }
+
+        None
+    }
+
+    fn render<'s>(&'s self, target: &mut impl Renderer<'s>) {
+        let render_prompt_or_input = |target| {
+            if self.input.inner().is_empty() {
+                self.prompt.render(target);
+            } else {
+                self.input.render(target);
+            }
+        };
+
+        if self.keypad.pressed() {
+            render_prompt_or_input(target);
+            self.keypad.render(target);
+        } else {
+            self.keypad.render(target);
+            render_prompt_or_input(target);
+        }
+    }
+}
+
+pub trait MnemonicInput: Component<Msg = MnemonicInputMsg> {
+    fn keys() -> [&'static str; MNEMONIC_KEY_COUNT];
+    fn can_key_press_lead_to_a_valid_word(&self, key: usize) -> bool;
+    fn can_be_confirmed(&self) -> bool;
+    fn on_key_click(&mut self, ctx: &mut EventCtx, key: usize);
+    fn on_backspace_click(&mut self, ctx: &mut EventCtx);
+    fn on_confirm_click(&mut self, ctx: &mut EventCtx) -> Option<MnemonicInputMsg>;
+    fn on_backspace_long_press(&mut self, ctx: &mut EventCtx);
+    fn is_empty(&self) -> bool;
+    fn mnemonic(&self) -> Option<&'static str>;
+}
+
+pub enum MnemonicInputMsg {
+    Confirmed,
+    Completed,
+    TimedOut,
+}
+
+#[cfg(feature = "ui_debug")]
+impl<T> crate::trace::Trace for MnemonicKeyboard<T>
+where
+    T: MnemonicInput + crate::trace::Trace,
+{
+    fn trace(&self, t: &mut dyn crate::trace::Tracer) {
+        t.component("MnemonicKeyboard");
+        t.child("prompt", &self.prompt);
+        t.child("input", &self.input);
+    }
+}

--- a/core/embed/rust/src/ui/layout_eckhart/component/keyboard/mod.rs
+++ b/core/embed/rust/src/ui/layout_eckhart/component/keyboard/mod.rs
@@ -1,0 +1,1 @@
+mod common;

--- a/core/embed/rust/src/ui/layout_eckhart/component/keyboard/mod.rs
+++ b/core/embed/rust/src/ui/layout_eckhart/component/keyboard/mod.rs
@@ -1,3 +1,4 @@
+pub mod bip39;
 pub mod mnemonic;
 pub mod passphrase;
 pub mod pin;

--- a/core/embed/rust/src/ui/layout_eckhart/component/keyboard/mod.rs
+++ b/core/embed/rust/src/ui/layout_eckhart/component/keyboard/mod.rs
@@ -1,1 +1,2 @@
 mod common;
+mod keypad;

--- a/core/embed/rust/src/ui/layout_eckhart/component/keyboard/mod.rs
+++ b/core/embed/rust/src/ui/layout_eckhart/component/keyboard/mod.rs
@@ -2,6 +2,7 @@ pub mod bip39;
 pub mod mnemonic;
 pub mod passphrase;
 pub mod pin;
+pub mod slip39;
 
 mod common;
 mod keypad;

--- a/core/embed/rust/src/ui/layout_eckhart/component/keyboard/mod.rs
+++ b/core/embed/rust/src/ui/layout_eckhart/component/keyboard/mod.rs
@@ -1,3 +1,4 @@
+pub mod mnemonic;
 pub mod passphrase;
 pub mod pin;
 

--- a/core/embed/rust/src/ui/layout_eckhart/component/keyboard/mod.rs
+++ b/core/embed/rust/src/ui/layout_eckhart/component/keyboard/mod.rs
@@ -1,3 +1,4 @@
+pub mod passphrase;
 pub mod pin;
 
 mod common;

--- a/core/embed/rust/src/ui/layout_eckhart/component/keyboard/mod.rs
+++ b/core/embed/rust/src/ui/layout_eckhart/component/keyboard/mod.rs
@@ -1,2 +1,4 @@
+pub mod pin;
+
 mod common;
 mod keypad;

--- a/core/embed/rust/src/ui/layout_eckhart/component/keyboard/passphrase.rs
+++ b/core/embed/rust/src/ui/layout_eckhart/component/keyboard/passphrase.rs
@@ -1,0 +1,632 @@
+use crate::{
+    strutil::{ShortString, TString},
+    time::Duration,
+    translations::TR,
+    ui::{
+        component::{
+            swipe_detect::SwipeConfig,
+            text::{
+                common::TextBox,
+                layout::{LayoutFit, LineBreaking},
+                TextStyle,
+            },
+            Component, Event, EventCtx, Label, Swipe, TextLayout, Timer,
+        },
+        display::Icon,
+        event::TouchEvent,
+        flow::Swipable,
+        geometry::{Alignment, Alignment2D, Direction, Insets, Offset, Rect},
+        shape::{Bar, Renderer, Text, ToifImage},
+        util::Pager,
+    },
+};
+
+use super::super::{
+    button::{Button, ButtonContent, ButtonMsg, ButtonStyleSheet},
+    constant::SCREEN,
+    keyboard::{
+        common::{
+            render_pending_marker, DisplayStyle, MultiTapKeyboard, FADING_ICON_COLORS,
+            FADING_ICON_COUNT, INPUT_TOUCH_HEIGHT, KEYBOARD_INPUT_INSETS, KEYBOARD_INPUT_RADIUS,
+            KEYPAD_VISIBLE_HEIGHT,
+        },
+        keypad::{ButtonState, Keypad, KeypadButton, KeypadMsg, KeypadState},
+    },
+    theme,
+};
+
+pub enum PassphraseKeyboardMsg {
+    Confirmed(ShortString),
+    Cancelled,
+}
+
+/// Enum keeping track of which keyboard is shown and which comes next. Keep the
+/// number of values and the constant PAGE_COUNT in synch.
+#[repr(u32)]
+#[derive(Copy, Clone, PartialEq)]
+enum KeyboardLayout {
+    LettersLower = 0,
+    LettersUpper = 1,
+    Numeric = 2,
+    Special = 3,
+}
+
+impl KeyboardLayout {
+    fn next(self) -> Self {
+        match self {
+            Self::LettersLower => Self::LettersUpper,
+            Self::LettersUpper => Self::Numeric,
+            Self::Numeric => Self::Special,
+            Self::Special => Self::LettersLower,
+        }
+    }
+
+    fn prev(self) -> Self {
+        match self {
+            Self::LettersLower => Self::Special,
+            Self::LettersUpper => Self::LettersLower,
+            Self::Numeric => Self::LettersUpper,
+            Self::Special => Self::Numeric,
+        }
+    }
+}
+
+impl From<KeyboardLayout> for ButtonContent {
+    /// Used to get content for the "next keyboard" button
+    fn from(kl: KeyboardLayout) -> Self {
+        match kl {
+            KeyboardLayout::LettersLower => ButtonContent::Text("abc".into()),
+            KeyboardLayout::LettersUpper => ButtonContent::Text("ABC".into()),
+            KeyboardLayout::Numeric => ButtonContent::Text("123".into()),
+            KeyboardLayout::Special => ButtonContent::Icon(theme::ICON_ASTERISK),
+        }
+    }
+}
+
+pub struct PassphraseKeyboard {
+    page_swipe: Swipe,
+    input: PassphraseInput,
+    input_prompt: Label<'static>,
+    keypad: Keypad,
+    next_btn: Button,
+    active_layout: KeyboardLayout,
+    swipe_config: SwipeConfig,
+    multi_tap: MultiTapKeyboard,
+}
+
+const PAGE_COUNT: usize = 4;
+const KEY_COUNT: usize = 10;
+#[rustfmt::skip]
+const KEYBOARD: [[&str; KEY_COUNT]; PAGE_COUNT] = [
+    ["abc", "def", "ghi", "jkl", "mno", "pq", "rst", "uvw", "xyz", " *#"],
+    ["ABC", "DEF", "GHI", "JKL", "MNO", "PQ", "RST", "UVW", "XYZ", " *#"],
+    ["1", "2", "3", "4", "5", "6", "7", "8", "9", "0"],
+    ["_<>", ".:@", "/|\\", "!()", "+%&", "-[]", "?{}", ",'`", ";\"~", "$^="],
+    ];
+
+const MAX_LENGTH: usize = 50; // max length of the passphrase
+const MAX_SHOWN_LEN: usize = 14; // max number of icons per line
+const LAST_DIGIT_TIMEOUT_S: u32 = 1;
+
+const NEXT_BTN_WIDTH: i16 = 103;
+const NEXT_BTN_PADDING: i16 = 14;
+const NEXT_BTN_INSETS: Insets =
+    Insets::new(NEXT_BTN_PADDING, NEXT_BTN_PADDING, 0, NEXT_BTN_PADDING);
+
+impl PassphraseKeyboard {
+    pub fn new() -> Self {
+        let active_layout = KeyboardLayout::LettersLower;
+        let layout: &[&str; KEY_COUNT] = &KEYBOARD[active_layout as usize];
+        let keypad_content: [ButtonContent; KEY_COUNT] =
+            core::array::from_fn(|idx| Self::key_content(layout[idx]));
+
+        let next_btn = Button::new(active_layout.next().into())
+            .styled(theme::button_keyboard_next())
+            .with_radius(12)
+            .with_text_align(Alignment::Center)
+            .with_expanded_touch_area(NEXT_BTN_INSETS);
+
+        Self {
+            page_swipe: Swipe::horizontal(),
+            input: PassphraseInput::new(),
+            input_prompt: Label::left_aligned(
+                TString::from_translation(TR::passphrase__title_enter),
+                theme::TEXT_SMALL,
+            )
+            .vertically_centered(),
+            next_btn,
+            keypad: Keypad::new_shown().with_keys_content(&keypad_content),
+            active_layout,
+            swipe_config: SwipeConfig::new(),
+            multi_tap: MultiTapKeyboard::new(),
+        }
+    }
+
+    fn key_text(content: &ButtonContent) -> TString<'static> {
+        match content {
+            ButtonContent::Text(text) => *text,
+            ButtonContent::TextAndSubtext(_, _) => "".into(),
+            ButtonContent::Icon(theme::ICON_SPECIAL_CHARS) => " *#".into(),
+            ButtonContent::Icon(_) => " ".into(),
+            ButtonContent::IconAndText(_) => " ".into(),
+            ButtonContent::Empty => "".into(),
+        }
+    }
+
+    fn key_content(text: &'static str) -> ButtonContent {
+        match text {
+            " *#" => ButtonContent::Icon(theme::ICON_SPECIAL_CHARS),
+            t => ButtonContent::Text(t.into()),
+        }
+    }
+
+    fn key_style(layout: KeyboardLayout) -> ButtonStyleSheet {
+        if layout == KeyboardLayout::Numeric {
+            theme::button_keyboard_numeric()
+        } else {
+            theme::button_keyboard()
+        }
+    }
+
+    fn on_page_change(&mut self, ctx: &mut EventCtx, swipe: Direction) {
+        // Change the keyboard layout.
+        self.active_layout = match swipe {
+            Direction::Left => self.active_layout.next(),
+            Direction::Right => self.active_layout.prev(),
+            _ => self.active_layout,
+        };
+        if self.multi_tap.pending_key().is_some() {
+            // Clear the pending state.
+            self.multi_tap.clear_pending_state(ctx);
+            self.input.marker = false;
+            // the character has been added, show it for a bit and then hide it
+            self.input
+                .last_char_timer
+                .start(ctx, Duration::from_secs(LAST_DIGIT_TIMEOUT_S));
+        }
+        // Update keys.
+        self.replace_keys_contents();
+    }
+
+    fn replace_keys_contents(&mut self) {
+        self.next_btn.set_content(self.active_layout.next().into());
+        let layout = self.active_layout as usize;
+        let styles = Self::key_style(self.active_layout);
+
+        for idx in 0..KEY_COUNT {
+            let text = KEYBOARD[layout][idx];
+            let content = Self::key_content(text);
+            self.keypad.set_key_content(idx, content);
+            self.keypad
+                .set_button_stylesheet(KeypadButton::Key(idx), styles);
+        }
+    }
+
+    fn update_keypad_state(&mut self, ctx: &mut EventCtx) {
+        let keypad_state = match self.input.display_style {
+            DisplayStyle::Shown => {
+                // Disable the entire active keypad
+                KeypadState {
+                    back: ButtonState::Hidden,
+                    erase: ButtonState::Disabled,
+                    cancel: ButtonState::Hidden,
+                    confirm: ButtonState::Disabled,
+                    keys: ButtonState::Disabled,
+                }
+            }
+            _ => {
+                if self.passphrase().len() == MAX_LENGTH {
+                    // Disable all except of confirm and erase buttons
+                    KeypadState {
+                        back: ButtonState::Hidden,
+                        erase: ButtonState::Enabled,
+                        cancel: ButtonState::Hidden,
+                        confirm: ButtonState::Enabled,
+                        keys: ButtonState::Disabled,
+                    }
+                } else if self.input.textbox.is_empty() {
+                    // Disable all except of confirm and erase buttons
+                    KeypadState {
+                        back: ButtonState::Hidden,
+                        erase: ButtonState::Hidden,
+                        cancel: ButtonState::Hidden,
+                        confirm: ButtonState::Enabled,
+                        keys: ButtonState::Enabled,
+                    }
+                } else {
+                    KeypadState {
+                        back: ButtonState::Hidden,
+                        erase: ButtonState::Enabled,
+                        cancel: ButtonState::Hidden,
+                        confirm: ButtonState::Enabled,
+                        keys: ButtonState::Enabled,
+                    }
+                }
+            }
+        };
+
+        self.keypad.set_state(keypad_state, ctx);
+    }
+
+    pub fn passphrase(&self) -> &str {
+        self.input.textbox.content()
+    }
+}
+
+impl Component for PassphraseKeyboard {
+    type Msg = PassphraseKeyboardMsg;
+
+    fn place(&mut self, bounds: Rect) -> Rect {
+        // assert full screen
+        debug_assert_eq!(bounds.height(), SCREEN.height());
+        debug_assert_eq!(bounds.width(), SCREEN.width());
+
+        // Enable swiping over the entire screen.
+        self.page_swipe.place(bounds);
+
+        // Keypad and input areas are overlapped
+        let (_, keypad_area) = bounds.split_bottom(KEYPAD_VISIBLE_HEIGHT);
+        let (top_area, _) = bounds.split_top(INPUT_TOUCH_HEIGHT);
+
+        let (input_area, next_btn_area) =
+            top_area.split_right(NEXT_BTN_WIDTH + 2 * NEXT_BTN_PADDING);
+
+        let next_btn_area = next_btn_area.inset(NEXT_BTN_INSETS);
+
+        self.input.place(input_area);
+        self.input_prompt
+            .place(top_area.inset(KEYBOARD_INPUT_INSETS));
+        self.keypad.place(keypad_area);
+        self.next_btn.place(next_btn_area);
+
+        bounds
+    }
+
+    fn event(&mut self, ctx: &mut EventCtx, event: Event) -> Option<Self::Msg> {
+        match event {
+            Event::Attach(_) => {
+                // Update the keypad state in the first event
+                self.update_keypad_state(ctx);
+            }
+            Event::Timer(_) if self.multi_tap.timeout_event(event) => {
+                self.multi_tap.clear_pending_state(ctx);
+                self.input
+                    .last_char_timer
+                    .start(ctx, Duration::from_secs(LAST_DIGIT_TIMEOUT_S));
+                self.input.marker = false;
+                return None;
+            }
+
+            _ => {}
+        }
+
+        if let Some(swipe) = self.page_swipe.event(ctx, event) {
+            // We have detected a horizontal swipe. Change the keyboard page.
+            self.on_page_change(ctx, swipe);
+            return None;
+        }
+
+        if let Some(ButtonMsg::Clicked) = self.next_btn.event(ctx, event) {
+            self.on_page_change(ctx, Direction::Left);
+        }
+
+        match self.keypad.event(ctx, event) {
+            Some(KeypadMsg::Key(idx)) => {
+                let text = Self::key_text(self.keypad.get_key_content(idx));
+                let edit = text.map(|c| self.multi_tap.click_key(ctx, idx, c));
+                self.input.textbox.apply(ctx, edit);
+                if text.len() == 1 {
+                    // If the key has just one character, it is immediately applied and the last
+                    // digit timer should be started
+                    self.input.marker = false;
+                    self.input
+                        .last_char_timer
+                        .start(ctx, Duration::from_secs(LAST_DIGIT_TIMEOUT_S));
+                } else {
+                    // multi tap timer is runnig, the last digit timer should be stopped
+                    self.input.last_char_timer.stop();
+                    self.input.marker = true;
+                }
+                self.input.display_style = DisplayStyle::LastOnly;
+                self.update_keypad_state(ctx);
+                return None;
+            }
+            Some(KeypadMsg::EraseShort) => {
+                self.multi_tap.clear_pending_state(ctx);
+                self.input.textbox.delete_last(ctx);
+                self.input.display_style = DisplayStyle::Hidden;
+                self.update_keypad_state(ctx);
+                return None;
+            }
+            Some(KeypadMsg::EraseLong) => {
+                self.multi_tap.clear_pending_state(ctx);
+                self.input.textbox.clear(ctx);
+                self.input.display_style = DisplayStyle::Hidden;
+                self.update_keypad_state(ctx);
+                return None;
+            }
+            Some(KeypadMsg::Cancel) => {
+                return Some(PassphraseKeyboardMsg::Cancelled);
+            }
+            Some(KeypadMsg::Confirm) => {
+                return Some(PassphraseKeyboardMsg::Confirmed(unwrap!(
+                    ShortString::try_from(self.passphrase())
+                )));
+            }
+            _ => {}
+        }
+
+        match self.input.event(ctx, event) {
+            Some(PassphraseInputMsg::TouchStart) => {
+                self.multi_tap.clear_pending_state(ctx);
+                // Disable keypad.
+                self.update_keypad_state(ctx);
+                return None;
+            }
+            Some(PassphraseInputMsg::TouchEnd) => {
+                // Enable keypad.
+                self.update_keypad_state(ctx);
+                return None;
+            }
+            _ => {}
+        }
+
+        None
+    }
+
+    fn render<'s>(&'s self, target: &mut impl Renderer<'s>) {
+        let empty = self.passphrase().is_empty();
+
+        // Render prompt when the pin is empty
+        if empty {
+            self.input_prompt.render(target);
+        }
+
+        // When the entire passphrase is shown, the input area might overlap the keypad
+        // so it has to be render later
+        match self.input.display_style {
+            DisplayStyle::Shown => {
+                self.keypad.render(target);
+                self.input.render(target);
+            }
+            _ => {
+                // When the next button is shown, the input area might overlap the keypad so it
+                // has to be render later
+                self.input.render(target);
+
+                if self.next_btn.is_pressed() {
+                    self.keypad.render(target);
+                    self.next_btn.render(target);
+                } else {
+                    self.next_btn.render(target);
+                    self.keypad.render(target);
+                }
+            }
+        }
+    }
+}
+
+#[derive(PartialEq, Debug, Copy, Clone)]
+#[cfg_attr(feature = "ui_debug", derive(ufmt::derive::uDebug))]
+pub enum PassphraseInputMsg {
+    TouchStart,
+    TouchEnd,
+}
+
+struct PassphraseInput {
+    area: Rect,
+    textbox: TextBox,
+    display_style: DisplayStyle,
+    marker: bool,
+    last_char_timer: Timer,
+    shown_area: Rect,
+}
+
+impl PassphraseInput {
+    const TWITCH: i16 = 4;
+    const SHOWN_PADDING: i16 = 24;
+    const SHOWN_STYLE: TextStyle =
+        theme::TEXT_MEDIUM.with_line_breaking(LineBreaking::BreakWordsNoHyphen);
+    const ICON: Icon = theme::ICON_DASH_VERTICAL;
+    const ICON_WIDTH: i16 = Self::ICON.toif.width();
+    const ICON_SPACE: i16 = 12;
+
+    fn new() -> Self {
+        Self {
+            area: Rect::zero(),
+            textbox: TextBox::empty(MAX_LENGTH),
+            display_style: DisplayStyle::LastOnly,
+            marker: false,
+            last_char_timer: Timer::new(),
+            shown_area: Rect::zero(),
+        }
+    }
+
+    fn passphrase(&self) -> &str {
+        &self.textbox.content()
+    }
+
+    fn update_shown_area(&mut self) {
+        // The area where the passphrase is shown
+        let mut shown_area = Rect::from_top_left_and_size(
+            self.area.top_left(),
+            Offset::new(SCREEN.width(), self.area.height()),
+        )
+        .inset(KEYBOARD_INPUT_INSETS);
+
+        // Extend the shown area until the text fits
+        while let LayoutFit::OutOfBounds { .. } = TextLayout::new(Self::SHOWN_STYLE)
+            .with_align(Alignment::Start)
+            .with_bounds(shown_area.inset(Insets::uniform(Self::SHOWN_PADDING)))
+            .fit_text(self.passphrase())
+        {
+            shown_area = shown_area.outset(Insets::bottom(32));
+        }
+
+        self.shown_area = shown_area;
+    }
+
+    fn render_shown<'s>(&self, target: &mut impl Renderer<'s>) {
+        // Make sure the pin should be shown
+        debug_assert_eq!(self.display_style, DisplayStyle::Shown);
+
+        Bar::new(self.shown_area)
+            .with_bg(theme::GREY_SUPER_DARK)
+            .with_radius(KEYBOARD_INPUT_RADIUS)
+            .render(target);
+
+        TextLayout::new(Self::SHOWN_STYLE)
+            .with_bounds(self.shown_area.inset(Insets::uniform(Self::SHOWN_PADDING)))
+            .with_align(Alignment::Start)
+            .render_text(self.passphrase(), target);
+    }
+
+    fn render_hidden<'s>(&self, target: &mut impl Renderer<'s>) {
+        debug_assert_ne!(self.display_style, DisplayStyle::Shown);
+
+        let hidden_area: Rect = self.area.inset(KEYBOARD_INPUT_INSETS);
+        let style = theme::TEXT_MEDIUM;
+        let pp_len = self.passphrase().len();
+        let last_char = self.display_style == DisplayStyle::LastOnly;
+
+        let mut cursor = hidden_area.left_center().ofs(Offset::x(12));
+
+        // Render only when there are characters
+        if pp_len > 0 {
+            // Number of visible icons + characters
+            let visible_len = pp_len.min(MAX_SHOWN_LEN);
+            // Number of visible icons
+            let visible_icons = visible_len - last_char as usize;
+
+            // Jiggle when overflowed.
+            if pp_len > visible_len && pp_len % 2 == 0 && self.display_style != DisplayStyle::Shown
+            {
+                cursor.x += Self::TWITCH;
+            }
+
+            let mut char_idx = 0;
+
+            // Greyed out overflowing icons
+            for (i, &fg_color) in FADING_ICON_COLORS.iter().enumerate() {
+                if pp_len > visible_len + (FADING_ICON_COUNT - 1 - i) {
+                    ToifImage::new(cursor, Self::ICON.toif)
+                        .with_align(Alignment2D::TOP_LEFT)
+                        .with_fg(fg_color)
+                        .render(target);
+                    cursor.x += Self::ICON_SPACE + Self::ICON_WIDTH;
+                    char_idx += 1;
+                }
+            }
+
+            if visible_icons > 0 {
+                // Classical dot(s)
+                for _ in char_idx..visible_icons {
+                    ToifImage::new(cursor, Self::ICON.toif)
+                        .with_align(Alignment2D::TOP_LEFT)
+                        .with_fg(style.text_color)
+                        .render(target);
+                    cursor.x += Self::ICON_SPACE + Self::ICON_WIDTH;
+                }
+            }
+
+            if last_char {
+                // This should not fail because pp_len > 0
+                let last = &self.passphrase()[(pp_len - 1)..pp_len];
+
+                // Adapt a and y positions for the character
+                cursor.y = hidden_area.left_center().y + style.text_font.text_max_height() / 2;
+                cursor.x -= Self::ICON_WIDTH;
+
+                // Paint the last character
+                Text::new(cursor, last, style.text_font)
+                    .with_align(Alignment::Start)
+                    .with_fg(style.text_color)
+                    .render(target);
+
+                // Paint the pending marker.
+                if self.marker {
+                    render_pending_marker(target, cursor, last, style.text_font, style.text_color);
+                }
+            }
+        }
+    }
+}
+
+impl Component for PassphraseInput {
+    type Msg = PassphraseInputMsg;
+
+    fn place(&mut self, bounds: Rect) -> Rect {
+        self.area = bounds;
+        bounds
+    }
+
+    fn event(&mut self, ctx: &mut EventCtx, event: Event) -> Option<Self::Msg> {
+        // No touch events are handled when the textbox is empty
+        if self.textbox.is_empty() {
+            return None;
+        }
+
+        match event {
+            // Return touch start if the touch is detected inside the touchable area
+            Event::Touch(TouchEvent::TouchStart(pos)) if self.area.contains(pos) => {
+                // Stop the last char timer
+                self.last_char_timer.stop();
+                // Show the entire passphrase on the touch start
+                self.display_style = DisplayStyle::Shown;
+                self.update_shown_area();
+                return Some(PassphraseInputMsg::TouchStart);
+            }
+            // Return touch end if the touch end is detected inside the visible area
+            Event::Touch(TouchEvent::TouchEnd(pos))
+                if self.shown_area.contains(pos) && self.display_style == DisplayStyle::Shown =>
+            {
+                self.display_style = DisplayStyle::Hidden;
+                return Some(PassphraseInputMsg::TouchEnd);
+            }
+            // Return touch end if the touch moves out of the visible area
+            Event::Touch(TouchEvent::TouchMove(pos))
+                if !self.shown_area.contains(pos) && self.display_style == DisplayStyle::Shown =>
+            {
+                self.display_style = DisplayStyle::Hidden;
+                return Some(PassphraseInputMsg::TouchEnd);
+            }
+            // Timeout for showing the last char.
+            Event::Timer(_) if self.last_char_timer.expire(event) => {
+                self.display_style = DisplayStyle::Hidden;
+                ctx.request_paint();
+            }
+            _ => {}
+        };
+        None
+    }
+
+    fn render<'s>(&'s self, target: &mut impl Renderer<'s>) {
+        if !self.passphrase().is_empty() {
+            match self.display_style {
+                DisplayStyle::Shown => self.render_shown(target),
+                _ => self.render_hidden(target),
+            }
+        }
+    }
+}
+
+#[cfg(feature = "micropython")]
+impl Swipable for PassphraseKeyboard {
+    fn get_swipe_config(&self) -> SwipeConfig {
+        self.swipe_config
+    }
+
+    fn get_pager(&self) -> Pager {
+        Pager::single_page()
+    }
+}
+
+#[cfg(feature = "ui_debug")]
+impl crate::trace::Trace for PassphraseKeyboard {
+    fn trace(&self, t: &mut dyn crate::trace::Tracer) {
+        let display_style = uformat!("{:?}", self.input.display_style);
+        t.component("PassphraseKeyboard");
+        t.string("passphrase", self.passphrase().into());
+        t.string("display_style", display_style.as_str().into());
+    }
+}

--- a/core/embed/rust/src/ui/layout_eckhart/component/keyboard/pin.rs
+++ b/core/embed/rust/src/ui/layout_eckhart/component/keyboard/pin.rs
@@ -1,0 +1,509 @@
+use crate::{
+    strutil::{ShortString, TString},
+    time::Duration,
+    ui::{
+        component::{
+            text::{
+                layout::{Chunks, LayoutFit, LineBreaking},
+                TextStyle,
+            },
+            Component, Event, EventCtx, Label, TextLayout, Timer,
+        },
+        display::Icon,
+        event::TouchEvent,
+        geometry::{Alignment, Alignment2D, Insets, Offset, Rect},
+        shape::{Bar, Renderer, Text, ToifImage},
+    },
+};
+
+use super::super::super::{
+    component::{
+        button::ButtonContent,
+        constant::SCREEN,
+        keyboard::{
+            common::{
+                DisplayStyle, FADING_ICON_COLORS, FADING_ICON_COUNT, INPUT_TOUCH_HEIGHT,
+                KEYBOARD_INPUT_INSETS, KEYBOARD_INPUT_RADIUS, KEYPAD_VISIBLE_HEIGHT,
+            },
+            keypad::{ButtonState, Keypad, KeypadMsg, KeypadState},
+        },
+    },
+    theme,
+};
+
+pub enum PinKeyboardMsg {
+    Confirmed,
+    Cancelled,
+}
+
+pub struct PinKeyboard<'a> {
+    allow_cancel: bool,
+    major_prompt: Label<'a>,
+    minor_prompt: Label<'a>,
+    major_warning: Option<Label<'a>>,
+    keypad: Keypad,
+    input: PinInput,
+    warning_timer: Timer,
+}
+
+impl<'a> PinKeyboard<'a> {
+    const LAST_DIGIT_TIMEOUT_S: u32 = 1;
+
+    pub fn new(
+        major_prompt: TString<'a>,
+        minor_prompt: TString<'a>,
+        major_warning: Option<TString<'a>>,
+        allow_cancel: bool,
+    ) -> Self {
+        Self {
+            allow_cancel,
+            major_prompt: Label::left_aligned(major_prompt, theme::TEXT_SMALL)
+                .vertically_centered(),
+            minor_prompt: Label::right_aligned(minor_prompt, theme::TEXT_SMALL)
+                .vertically_centered(),
+            major_warning: major_warning
+                .map(|text| Label::left_aligned(text, theme::TEXT_SMALL).vertically_centered()),
+            input: PinInput::new(theme::TEXT_MONO_LIGHT),
+            keypad: Keypad::new_numeric(true),
+            warning_timer: Timer::new(),
+        }
+    }
+
+    fn update_keypad_state(&mut self, ctx: &mut EventCtx) {
+        let keypad_state = match self.input.display_style {
+            DisplayStyle::Shown => {
+                // Disable the entire active keypad
+                KeypadState {
+                    back: ButtonState::Hidden,
+                    erase: ButtonState::Disabled,
+                    cancel: ButtonState::Hidden,
+                    confirm: ButtonState::Disabled,
+                    keys: ButtonState::Disabled,
+                }
+            }
+            _ => {
+                if self.input.is_full() {
+                    // Disable all except of confirm and erase buttons
+                    KeypadState {
+                        back: ButtonState::Hidden,
+                        erase: ButtonState::Enabled,
+                        cancel: ButtonState::Hidden,
+                        confirm: ButtonState::Enabled,
+                        keys: ButtonState::Disabled,
+                    }
+                } else if self.input.is_empty() {
+                    KeypadState {
+                        back: ButtonState::Hidden,
+                        erase: ButtonState::Hidden,
+                        cancel: if self.allow_cancel {
+                            ButtonState::Enabled
+                        } else {
+                            ButtonState::Hidden
+                        },
+                        confirm: ButtonState::Hidden,
+                        keys: ButtonState::Enabled,
+                    }
+                } else {
+                    KeypadState {
+                        back: ButtonState::Hidden,
+                        erase: ButtonState::Enabled,
+                        cancel: ButtonState::Hidden,
+                        confirm: ButtonState::Enabled,
+                        keys: ButtonState::Enabled,
+                    }
+                }
+            }
+        };
+        // Apply all button states
+        self.keypad.set_state(keypad_state, ctx);
+    }
+
+    pub fn pin(&self) -> &str {
+        self.input.pin()
+    }
+}
+
+impl Component for PinKeyboard<'_> {
+    type Msg = PinKeyboardMsg;
+
+    fn place(&mut self, bounds: Rect) -> Rect {
+        // assert full screen
+        debug_assert_eq!(bounds.height(), SCREEN.height());
+        debug_assert_eq!(bounds.width(), SCREEN.width());
+
+        // Keypad and input areas are overlapped
+        let (_, keypad_area) = bounds.split_bottom(KEYPAD_VISIBLE_HEIGHT);
+        let (input_touch_area, _) = bounds.split_top(INPUT_TOUCH_HEIGHT);
+
+        // Prompts and PIN dots placement.
+        self.input.place(input_touch_area);
+        self.major_prompt
+            .place(input_touch_area.inset(KEYBOARD_INPUT_INSETS));
+        self.minor_prompt
+            .place(input_touch_area.inset(KEYBOARD_INPUT_INSETS));
+        self.major_warning
+            .as_mut()
+            .map(|c| c.place(input_touch_area));
+
+        // Keypad placement
+        self.keypad.place(keypad_area);
+
+        bounds
+    }
+
+    fn event(&mut self, ctx: &mut EventCtx, event: Event) -> Option<Self::Msg> {
+        match event {
+            // Set up timer to switch off warning prompt.
+            Event::Attach(_) => {
+                if self.major_warning.is_some() {
+                    self.warning_timer.start(ctx, Duration::from_secs(2));
+                }
+                // Update the keypad state in the first event
+                self.update_keypad_state(ctx);
+            }
+            // Hide warning, show major prompt.
+            Event::Timer(_) if self.warning_timer.expire(event) => {
+                self.major_warning = None;
+            }
+
+            _ => {}
+        }
+
+        match self.keypad.event(ctx, event) {
+            Some(KeypadMsg::Key(idx)) => {
+                // Add new pin digit
+                if let ButtonContent::Text(text) = self.keypad.get_key_content(idx) {
+                    text.map(|text| {
+                        self.input.push(text);
+                    });
+                    // Start the timer to show the last digit.
+                    self.input
+                        .last_digit_timer
+                        .start(ctx, Duration::from_secs(Self::LAST_DIGIT_TIMEOUT_S));
+                    self.input.display_style = DisplayStyle::LastOnly;
+                    // Update the keypad state.
+                    self.update_keypad_state(ctx);
+                    return None;
+                }
+            }
+            Some(KeypadMsg::EraseShort) => {
+                // Erase pin digit
+                self.input.pop();
+                self.update_keypad_state(ctx);
+                return None;
+            }
+            Some(KeypadMsg::EraseLong) => {
+                // Clear the entire pin
+                self.input.clear();
+                self.update_keypad_state(ctx);
+                return None;
+            }
+            Some(KeypadMsg::Cancel) => {
+                return Some(PinKeyboardMsg::Cancelled);
+            }
+            Some(KeypadMsg::Confirm) => {
+                return Some(PinKeyboardMsg::Confirmed);
+            }
+            _ => {}
+        }
+
+        match self.input.event(ctx, event) {
+            Some(PinInputMsg::TouchStart) => {
+                // Disable keypad.
+                self.update_keypad_state(ctx);
+                return None;
+            }
+            Some(PinInputMsg::TouchEnd) => {
+                // Enable keypad.
+                self.update_keypad_state(ctx);
+                return None;
+            }
+            _ => {}
+        }
+
+        None
+    }
+
+    fn render<'s>(&'s self, target: &mut impl Renderer<'s>) {
+        let empty = self.input.is_empty();
+
+        // Render prompt when the pin is empty
+        if empty {
+            if let Some(ref w) = self.major_warning {
+                w.render(target);
+            } else {
+                self.major_prompt.render(target);
+            }
+            self.minor_prompt.render(target);
+        }
+
+        // When the entire pin is shown, the input area might overlap the keypad so it
+        // has to be rendered later
+        match self.input.display_style {
+            DisplayStyle::Shown if !empty => {
+                self.keypad.render(target);
+                self.input.render(target);
+            }
+            _ if !empty => {
+                self.input.render(target);
+                self.keypad.render(target);
+            }
+            _ => {
+                self.keypad.render(target);
+            }
+        }
+    }
+}
+
+#[derive(PartialEq, Debug, Copy, Clone)]
+#[cfg_attr(feature = "ui_debug", derive(ufmt::derive::uDebug))]
+pub enum PinInputMsg {
+    TouchStart,
+    TouchEnd,
+}
+
+struct PinInput {
+    area: Rect,
+    style: TextStyle,
+    digits: ShortString,
+    display_style: DisplayStyle,
+    last_digit_timer: Timer,
+    shown_area: Rect,
+}
+
+impl PinInput {
+    const MAX_LENGTH: usize = 50; // max length of the pin
+    const MAX_SHOWN_LEN: usize = 19; // max number of icons per line
+
+    const TWITCH: i16 = 4;
+    const SHOWN_PADDING: i16 = 24;
+    const SHOWN_STYLE: TextStyle = theme::TEXT_MEDIUM
+        .with_line_breaking(LineBreaking::BreakWordsNoHyphen)
+        .with_chunks(Chunks::new(1, 8));
+    const PIN_ICON: Icon = theme::ICON_DASH_VERTICAL;
+    const ICON_WIDTH: i16 = Self::PIN_ICON.toif.width();
+    const ICON_SPACE: i16 = 12;
+
+    fn new(style: TextStyle) -> Self {
+        Self {
+            area: Rect::zero(),
+            style,
+            digits: ShortString::new(),
+            display_style: DisplayStyle::Hidden,
+            last_digit_timer: Timer::new(),
+            shown_area: Rect::zero(),
+        }
+    }
+
+    fn size(&self) -> Offset {
+        let ndots = self.pin().len().min(Self::MAX_SHOWN_LEN);
+        let mut width = Self::ICON_WIDTH * (ndots as i16);
+        width += Self::ICON_SPACE * (ndots.saturating_sub(1) as i16);
+        Offset::new(width, 6)
+    }
+
+    fn is_empty(&self) -> bool {
+        self.digits.is_empty()
+    }
+
+    fn is_full(&self) -> bool {
+        self.digits.len() >= Self::MAX_LENGTH
+    }
+
+    fn clear(&mut self) {
+        self.digits.clear();
+    }
+
+    fn push(&mut self, text: &str) {
+        // This could happen only when `self.pin` is full and wasn't able to accept all
+        // of `text`
+        unwrap!(self.digits.push_str(text));
+    }
+
+    fn pop(&mut self) {
+        self.digits.pop();
+    }
+
+    fn pin(&self) -> &str {
+        &self.digits
+    }
+
+    fn update_shown_area(&mut self) {
+        // The area where the pin is shown
+        let mut shown_area = self.area.inset(KEYBOARD_INPUT_INSETS);
+
+        // Extend the shown area until the text fits
+        while let LayoutFit::OutOfBounds { .. } = TextLayout::new(Self::SHOWN_STYLE)
+            .with_align(Alignment::Start)
+            .with_bounds(shown_area.inset(Insets::uniform(Self::SHOWN_PADDING)))
+            .fit_text(self.pin())
+        {
+            shown_area = shown_area.outset(Insets::bottom(32));
+        }
+
+        self.shown_area = shown_area;
+    }
+
+    fn render_shown<'s>(&self, target: &mut impl Renderer<'s>) {
+        // Make sure the pin should be shown
+        debug_assert_eq!(self.display_style, DisplayStyle::Shown);
+
+        Bar::new(self.shown_area)
+            .with_bg(theme::GREY_SUPER_DARK)
+            .with_radius(KEYBOARD_INPUT_RADIUS)
+            .render(target);
+
+        TextLayout::new(Self::SHOWN_STYLE)
+            .with_bounds(self.shown_area.inset(Insets::uniform(Self::SHOWN_PADDING)))
+            .with_align(Alignment::Start)
+            .render_text(self.pin(), target);
+    }
+
+    fn render_hidden<'s>(&self, target: &mut impl Renderer<'s>) {
+        debug_assert_ne!(self.display_style, DisplayStyle::Shown);
+
+        let hidden_area: Rect = self.area.inset(KEYBOARD_INPUT_INSETS);
+        let style = theme::TEXT_MEDIUM;
+        let pin_len = self.pin().len();
+        let last_digit = self.display_style == DisplayStyle::LastOnly;
+
+        let mut cursor = self.size().snap(hidden_area.center(), Alignment2D::CENTER);
+
+        // Render only when there are characters
+        if pin_len > 0 {
+            // Number of visible icons + characters
+            let visible_len = pin_len.min(Self::MAX_SHOWN_LEN);
+            // Number of visible icons
+            let visible_icons = visible_len - last_digit as usize;
+
+            // Jiggle when overflowed.
+            if pin_len > visible_len
+                && pin_len % 2 == 0
+                && self.display_style != DisplayStyle::Shown
+            {
+                cursor.x += Self::TWITCH;
+            }
+
+            let mut char_idx = 0;
+
+            // Greyed out overflowing icons
+            for (i, &fg_color) in FADING_ICON_COLORS.iter().enumerate() {
+                if pin_len > visible_len + (FADING_ICON_COUNT - 1 - i) {
+                    ToifImage::new(cursor, Self::PIN_ICON.toif)
+                        .with_align(Alignment2D::TOP_LEFT)
+                        .with_fg(fg_color)
+                        .render(target);
+                    cursor.x += Self::ICON_SPACE + Self::ICON_WIDTH;
+                    char_idx += 1;
+                }
+            }
+
+            if visible_icons > 0 {
+                // Classical icons
+                for _ in char_idx..visible_icons {
+                    ToifImage::new(cursor, Self::PIN_ICON.toif)
+                        .with_align(Alignment2D::TOP_LEFT)
+                        .with_fg(style.text_color)
+                        .render(target);
+                    cursor.x += Self::ICON_SPACE + Self::ICON_WIDTH;
+                }
+            }
+
+            if last_digit {
+                // This should not fail because all_chars > 0
+                let last = &self.digits.as_str()[(pin_len - 1)..pin_len];
+
+                // Adapt a and y positions for the character
+                cursor.y = hidden_area.left_center().y + style.text_font.allcase_text_height() / 2;
+                cursor.x -= style.text_font.text_width(last) / 2 - Self::ICON_WIDTH / 2;
+
+                // Paint the last character
+                Text::new(cursor, last, style.text_font)
+                    .with_align(Alignment::Start)
+                    .with_fg(style.text_color)
+                    .render(target);
+            }
+        }
+    }
+}
+
+impl Component for PinInput {
+    type Msg = PinInputMsg;
+
+    fn place(&mut self, bounds: Rect) -> Rect {
+        self.area = bounds;
+        bounds
+    }
+
+    fn event(&mut self, ctx: &mut EventCtx, event: Event) -> Option<Self::Msg> {
+        // No touch events are handled when the input is empty
+        if self.is_empty() {
+            return None;
+        }
+
+        match event {
+            // Return touch start if the touch is detected inside the touchable area
+            Event::Touch(TouchEvent::TouchStart(pos)) if self.area.contains(pos) => {
+                // Stop the last char timer
+                self.last_digit_timer.stop();
+                // Show the entire pin on the touch start
+                self.display_style = DisplayStyle::Shown;
+                self.update_shown_area();
+                return Some(PinInputMsg::TouchStart);
+            }
+            // Return touch end if the touch end is detected inside the visible area
+            Event::Touch(TouchEvent::TouchEnd(pos))
+                if self.shown_area.contains(pos) && self.display_style == DisplayStyle::Shown =>
+            {
+                self.display_style = DisplayStyle::Hidden;
+                return Some(PinInputMsg::TouchEnd);
+            }
+            // Return touch end if the touch moves out of the visible area
+            Event::Touch(TouchEvent::TouchMove(pos))
+                if !self.shown_area.contains(pos) && self.display_style == DisplayStyle::Shown =>
+            {
+                self.display_style = DisplayStyle::Hidden;
+                return Some(PinInputMsg::TouchEnd);
+            }
+            // Timeout for showing the last digit.
+            Event::Timer(_) if self.last_digit_timer.expire(event) => {
+                // Hide the PIN
+                self.display_style = DisplayStyle::Hidden;
+                ctx.request_paint();
+            }
+            _ => {}
+        };
+        None
+    }
+
+    fn render<'s>(&'s self, target: &mut impl Renderer<'s>) {
+        if !self.digits.is_empty() {
+            match self.display_style {
+                DisplayStyle::Shown => self.render_shown(target),
+                _ => self.render_hidden(target),
+            }
+        }
+    }
+}
+
+#[cfg(feature = "ui_debug")]
+impl crate::trace::Trace for PinKeyboard<'_> {
+    fn trace(&self, t: &mut dyn crate::trace::Tracer) {
+        t.component("PinKeyboard");
+        // So that debuglink knows the locations of the buttons
+        let mut digits_order = ShortString::new();
+
+        for idx in 0..10 {
+            let btn_content = self.keypad.get_key_content(idx);
+            if let ButtonContent::Text(text) = btn_content {
+                text.map(|text| {
+                    unwrap!(digits_order.push_str(text));
+                });
+            }
+        }
+        let display_style = uformat!("{:?}", self.input.display_style);
+        t.string("digits_order", digits_order.as_str().into());
+        t.string("pin", self.input.pin().into());
+        t.string("display_style", display_style.as_str().into());
+    }
+}

--- a/core/embed/rust/src/ui/layout_eckhart/component/keyboard/slip39.rs
+++ b/core/embed/rust/src/ui/layout_eckhart/component/keyboard/slip39.rs
@@ -1,0 +1,338 @@
+use crate::{
+    strutil::ShortString,
+    trezorhal::slip39,
+    ui::{
+        component::{
+            text::common::{TextBox, TextEdit},
+            Component, Event, EventCtx,
+        },
+        display::Icon,
+        geometry::{Alignment, Alignment2D, Offset, Rect},
+        shape::{Renderer, Text, ToifImage},
+        util::ResultExt,
+    },
+};
+
+use super::super::super::{
+    component::{
+        keyboard::{
+            common::{render_pending_marker, MultiTapKeyboard},
+            mnemonic::{MnemonicInput, MnemonicInputMsg, MNEMONIC_KEY_COUNT},
+        },
+        Button, ButtonMsg,
+    },
+    theme,
+};
+
+const MAX_LENGTH: usize = 8;
+
+pub struct Slip39Input {
+    button: Button,
+    textbox: TextBox,
+    multi_tap: MultiTapKeyboard,
+    final_word: Option<&'static str>,
+    input_mask: Slip39Mask,
+}
+
+impl MnemonicInput for Slip39Input {
+    /// Return the key set. Keys are further specified as indices into this
+    /// array.
+    fn keys() -> [&'static str; MNEMONIC_KEY_COUNT] {
+        ["ab", "cd", "ef", "ghij", "klm", "nopq", "rs", "tuv", "wxyz"]
+    }
+
+    fn can_be_confirmed(&self) -> bool {
+        self.final_word.is_some()
+    }
+
+    /// Returns `true` if given key index can continue towards a valid mnemonic
+    /// word, `false` otherwise.
+    fn can_key_press_lead_to_a_valid_word(&self, key: usize) -> bool {
+        if self.input_mask.is_final() {
+            false
+        } else {
+            // Currently pending key is always enabled.
+            // Keys that mach the completion mask are enabled as well.
+            self.multi_tap.pending_key() == Some(key) || self.input_mask.contains_key(key)
+        }
+    }
+
+    /// Key button was clicked. If this button is pending, let's cycle the
+    /// pending character in textbox. If not, let's just append the first
+    /// character.
+    fn on_key_click(&mut self, ctx: &mut EventCtx, key: usize) {
+        let edit = self.multi_tap.click_key(ctx, key, Self::keys()[key]);
+        if let TextEdit::Append(_) = edit {
+            // This key press wasn't just a pending key rotation, so let's push the key
+            // digit to the buffer.
+            self.textbox.append(ctx, Self::key_digit(key));
+        } else {
+            // Ignore the pending char rotation. We use the pending key to paint
+            // the last character, but the mnemonic word computation depends
+            // only on the pressed key, not on the specific character inside it.
+            // Request paint of pending char.
+            ctx.request_paint();
+        }
+        self.complete_word_from_dictionary(ctx);
+    }
+
+    /// Backspace button was clicked, let's delete the last character of input
+    /// and clear the pending marker.
+    fn on_backspace_click(&mut self, ctx: &mut EventCtx) {
+        self.multi_tap.clear_pending_state(ctx);
+        self.textbox.delete_last(ctx);
+        self.complete_word_from_dictionary(ctx);
+    }
+
+    fn on_confirm_click(&mut self, ctx: &mut EventCtx) -> Option<MnemonicInputMsg> {
+        self.on_input_click(ctx)
+    }
+
+    /// Backspace button was long pressed, let's delete all characters of input
+    /// and clear the pending marker.
+    fn on_backspace_long_press(&mut self, ctx: &mut EventCtx) {
+        self.multi_tap.clear_pending_state(ctx);
+        self.textbox.clear(ctx);
+        self.complete_word_from_dictionary(ctx);
+    }
+
+    fn is_empty(&self) -> bool {
+        self.textbox.is_empty()
+    }
+
+    fn mnemonic(&self) -> Option<&'static str> {
+        self.final_word
+    }
+}
+
+impl Component for Slip39Input {
+    type Msg = MnemonicInputMsg;
+
+    fn place(&mut self, bounds: Rect) -> Rect {
+        self.button.place(bounds)
+    }
+
+    fn event(&mut self, ctx: &mut EventCtx, event: Event) -> Option<Self::Msg> {
+        if self.multi_tap.timeout_event(event) {
+            // Timeout occurred. Reset the pending key.
+            self.multi_tap.clear_pending_state(ctx);
+            return Some(MnemonicInputMsg::TimedOut);
+        }
+        if let Some(ButtonMsg::Clicked) = self.button.event(ctx, event) {
+            // Input button was clicked.  If the whole word is totally identified, let's
+            // confirm it, otherwise don't do anything.
+            return self.on_input_click(ctx);
+        }
+        None
+    }
+
+    fn render<'s>(&'s self, target: &mut impl Renderer<'s>) {
+        let area = self.button.area();
+        let style = self.button.style();
+
+        if let Some(word) = self.final_word {
+            // print the final mnemonic
+            Text::new(
+                area.center() + Offset::y(style.font.allcase_text_height() / 2),
+                word,
+                style.font,
+            )
+            .with_fg(style.text_color)
+            .with_align(Alignment::Center)
+            .render(target);
+        } else {
+            let input_len = self.textbox.content().len();
+
+            // Get last pending character, if any.
+            let last = if let (Some(key), Some(press)) =
+                (self.multi_tap.pending_key(), self.multi_tap.pending_press())
+            {
+                Some(&Self::keys()[key][press..(press + 1)])
+            } else {
+                None
+            };
+
+            // Initial position for drawing the icons
+            let mut cursor = area.center().ofs(Offset::x(-self.size() / 2));
+            let visible_icons = input_len.saturating_sub(last.is_some() as usize);
+
+            if input_len > 0 {
+                for _ in 0..visible_icons {
+                    ToifImage::new(cursor, Self::ICON.toif)
+                        .with_align(Alignment2D::TOP_LEFT)
+                        .with_fg(style.text_color)
+                        .render(target);
+                    cursor.x += Self::ICON_SPACE + Self::ICON_WIDTH;
+                }
+
+                if let Some(last) = last {
+                    // Adapt a and y positions for the character
+                    cursor.y += style.font.allcase_text_height() / 2;
+                    cursor.x -= Self::ICON_WIDTH;
+
+                    // Paint the last character
+                    Text::new(cursor, last, style.font)
+                        .with_align(Alignment::Start)
+                        .with_fg(style.text_color)
+                        .render(target);
+
+                    render_pending_marker(target, cursor, last, style.font, style.text_color);
+                }
+            }
+        }
+    }
+}
+
+impl Slip39Input {
+    const ICON: Icon = theme::ICON_DASH_VERTICAL;
+    const ICON_WIDTH: i16 = Self::ICON.toif.width();
+    const ICON_SPACE: i16 = 12;
+
+    pub fn new() -> Self {
+        Self {
+            button: Button::empty().styled(theme::input_mnemonic()),
+            textbox: TextBox::empty(MAX_LENGTH),
+            multi_tap: MultiTapKeyboard::new(),
+            final_word: None,
+            input_mask: Slip39Mask::full(),
+        }
+    }
+
+    pub fn prefilled_word(word: &str) -> Self {
+        // Word may be empty string, fallback to normal input
+        if word.is_empty() {
+            return Self::new();
+        }
+
+        let (buff, input_mask, final_word) = Self::setup_from_prefilled_word(word);
+
+        Self {
+            button: Button::empty().styled(theme::input_mnemonic()),
+            textbox: TextBox::new(&buff, MAX_LENGTH),
+            multi_tap: MultiTapKeyboard::new(),
+            final_word,
+            input_mask,
+        }
+    }
+
+    fn on_input_click(&mut self, _ctx: &mut EventCtx) -> Option<MnemonicInputMsg> {
+        if self.final_word.is_some() {
+            return Some(MnemonicInputMsg::Confirmed);
+        }
+        None
+    }
+
+    fn setup_from_prefilled_word(word: &str) -> (ShortString, Slip39Mask, Option<&'static str>) {
+        let mut buff = ShortString::new();
+
+        // Gradually appending encoded key digits to the buffer and checking if
+        // have not already formed a final word.
+        for ch in word.chars() {
+            let mut index = 0;
+            for (i, key) in Self::keys().iter().enumerate() {
+                if key.contains(ch) {
+                    index = i;
+                    break;
+                }
+            }
+            buff.push(Self::key_digit(index))
+                .assert_if_debugging_ui("Text buffer is too small");
+
+            let sequence: Option<u16> = buff.parse().ok();
+            let input_mask = sequence
+                .and_then(slip39::word_completion_mask)
+                .map(Slip39Mask)
+                .unwrap_or_else(Slip39Mask::full);
+            let final_word = if input_mask.is_final() {
+                sequence.and_then(slip39::button_sequence_to_word)
+            } else {
+                None
+            };
+
+            // As soon as we have a final word, we can stop.
+            if final_word.is_some() {
+                return (buff, input_mask, final_word);
+            }
+        }
+        (buff, Slip39Mask::full(), None)
+    }
+
+    /// Convert a key index into the key digit. This is what we push into the
+    /// input buffer.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// Self::key_digit(0) == '1';
+    /// Self::key_digit(1) == '2';
+    /// ```
+    fn key_digit(key: usize) -> char {
+        let index = key + 1;
+        unwrap!(char::from_digit(index as u32, 10))
+    }
+
+    fn complete_word_from_dictionary(&mut self, ctx: &mut EventCtx) {
+        let sequence = self.input_sequence();
+        self.input_mask = sequence
+            .and_then(slip39::word_completion_mask)
+            .map(Slip39Mask)
+            .unwrap_or_else(Slip39Mask::full);
+        self.final_word = if self.input_mask.is_final() {
+            sequence.and_then(slip39::button_sequence_to_word)
+        } else {
+            None
+        };
+
+        // Change the style of the button depending on the input.
+        if self.final_word.is_some() {
+            // Confirm button.
+            self.button.enable(ctx);
+            self.button.set_stylesheet(theme::input_mnemonic_confirm());
+        } else {
+            // Disabled button.
+            self.button.disable(ctx);
+            self.button.set_stylesheet(theme::input_mnemonic());
+        }
+        ctx.request_paint();
+    }
+
+    fn input_sequence(&self) -> Option<u16> {
+        self.textbox.content().parse().ok()
+    }
+
+    fn size(&self) -> i16 {
+        let ndots = self.textbox.content().len();
+        let mut width = Self::ICON_WIDTH * (ndots as i16);
+        width += Self::ICON_SPACE * (ndots.saturating_sub(1) as i16);
+        width
+    }
+}
+
+struct Slip39Mask(u16);
+
+impl Slip39Mask {
+    /// Return a mask with all keys allowed.
+    fn full() -> Self {
+        Self(0x1FF) // All buttons are allowed. 9-bit bitmap all set to 1.
+    }
+
+    /// Returns `true` if `key` can lead to a valid SLIP39 word with this mask.
+    fn contains_key(&self, key: usize) -> bool {
+        self.0 & (1 << key) != 0
+    }
+
+    /// Returns `true` if mask has exactly one bit set to 1, or is equal to 0.
+    fn is_final(&self) -> bool {
+        self.0.count_ones() <= 1
+    }
+}
+
+// DEBUG-ONLY SECTION BELOW
+
+#[cfg(feature = "ui_debug")]
+impl crate::trace::Trace for Slip39Input {
+    fn trace(&self, t: &mut dyn crate::trace::Tracer) {
+        t.component("Slip39Input");
+        t.child("textbox", &self.textbox);
+    }
+}

--- a/core/embed/rust/src/ui/layout_eckhart/component/mod.rs
+++ b/core/embed/rust/src/ui/layout_eckhart/component/mod.rs
@@ -26,6 +26,7 @@ pub use keyboard::{
     mnemonic::{MnemonicInput, MnemonicKeyboard, MnemonicKeyboardMsg},
     passphrase::{PassphraseKeyboard, PassphraseKeyboardMsg},
     pin::{PinKeyboard, PinKeyboardMsg},
+    slip39::Slip39Input,
 };
 pub use result::{ResultFooter, ResultScreen, ResultStyle};
 pub use select_word_screen::{SelectWordMsg, SelectWordScreen};

--- a/core/embed/rust/src/ui/layout_eckhart/component/mod.rs
+++ b/core/embed/rust/src/ui/layout_eckhart/component/mod.rs
@@ -5,6 +5,7 @@ mod error;
 mod header;
 mod hint;
 mod hold_to_confirm;
+mod keyboard;
 mod result;
 mod select_word_screen;
 mod share_words;

--- a/core/embed/rust/src/ui/layout_eckhart/component/mod.rs
+++ b/core/embed/rust/src/ui/layout_eckhart/component/mod.rs
@@ -22,6 +22,7 @@ pub use hint::Hint;
 pub use hold_to_confirm::HoldToConfirmAnim;
 #[cfg(feature = "translations")]
 pub use keyboard::{
+    mnemonic::{MnemonicInput, MnemonicKeyboard, MnemonicKeyboardMsg},
     passphrase::{PassphraseKeyboard, PassphraseKeyboardMsg},
     pin::{PinKeyboard, PinKeyboardMsg},
 };

--- a/core/embed/rust/src/ui/layout_eckhart/component/mod.rs
+++ b/core/embed/rust/src/ui/layout_eckhart/component/mod.rs
@@ -21,7 +21,10 @@ pub use header::{Header, HeaderMsg};
 pub use hint::Hint;
 pub use hold_to_confirm::HoldToConfirmAnim;
 #[cfg(feature = "translations")]
-pub use keyboard::pin::{PinKeyboard, PinKeyboardMsg};
+pub use keyboard::{
+    passphrase::{PassphraseKeyboard, PassphraseKeyboardMsg},
+    pin::{PinKeyboard, PinKeyboardMsg},
+};
 pub use result::{ResultFooter, ResultScreen, ResultStyle};
 pub use select_word_screen::{SelectWordMsg, SelectWordScreen};
 #[cfg(feature = "translations")]

--- a/core/embed/rust/src/ui/layout_eckhart/component/mod.rs
+++ b/core/embed/rust/src/ui/layout_eckhart/component/mod.rs
@@ -20,6 +20,8 @@ pub use error::ErrorScreen;
 pub use header::{Header, HeaderMsg};
 pub use hint::Hint;
 pub use hold_to_confirm::HoldToConfirmAnim;
+#[cfg(feature = "translations")]
+pub use keyboard::pin::{PinKeyboard, PinKeyboardMsg};
 pub use result::{ResultFooter, ResultScreen, ResultStyle};
 pub use select_word_screen::{SelectWordMsg, SelectWordScreen};
 #[cfg(feature = "translations")]

--- a/core/embed/rust/src/ui/layout_eckhart/component/mod.rs
+++ b/core/embed/rust/src/ui/layout_eckhart/component/mod.rs
@@ -22,6 +22,7 @@ pub use hint::Hint;
 pub use hold_to_confirm::HoldToConfirmAnim;
 #[cfg(feature = "translations")]
 pub use keyboard::{
+    bip39::Bip39Input,
     mnemonic::{MnemonicInput, MnemonicKeyboard, MnemonicKeyboardMsg},
     passphrase::{PassphraseKeyboard, PassphraseKeyboardMsg},
     pin::{PinKeyboard, PinKeyboardMsg},

--- a/core/embed/rust/src/ui/layout_eckhart/component_msg_obj.rs
+++ b/core/embed/rust/src/ui/layout_eckhart/component_msg_obj.rs
@@ -14,8 +14,18 @@ use crate::{
 };
 
 use super::component::{
-    AllowedTextContent, SelectWordMsg, SelectWordScreen, TextScreen, TextScreenMsg,
+    AllowedTextContent, PinKeyboard, PinKeyboardMsg, SelectWordMsg, SelectWordScreen, TextScreen,
+    TextScreenMsg,
 };
+
+impl ComponentMsgObj for PinKeyboard<'_> {
+    fn msg_try_into_obj(&self, msg: Self::Msg) -> Result<Obj, Error> {
+        match msg {
+            PinKeyboardMsg::Confirmed => self.pin().try_into(),
+            PinKeyboardMsg::Cancelled => Ok(CANCELLED.as_obj()),
+        }
+    }
+}
 
 // Clippy/compiler complains about conflicting implementations
 // TODO move the common impls to a common module

--- a/core/embed/rust/src/ui/layout_eckhart/component_msg_obj.rs
+++ b/core/embed/rust/src/ui/layout_eckhart/component_msg_obj.rs
@@ -14,8 +14,8 @@ use crate::{
 };
 
 use super::component::{
-    AllowedTextContent, PinKeyboard, PinKeyboardMsg, SelectWordMsg, SelectWordScreen, TextScreen,
-    TextScreenMsg,
+    AllowedTextContent, MnemonicInput, MnemonicKeyboard, MnemonicKeyboardMsg, PinKeyboard,
+    PinKeyboardMsg, SelectWordMsg, SelectWordScreen, TextScreen, TextScreenMsg,
 };
 
 impl ComponentMsgObj for PinKeyboard<'_> {
@@ -23,6 +23,24 @@ impl ComponentMsgObj for PinKeyboard<'_> {
         match msg {
             PinKeyboardMsg::Confirmed => self.pin().try_into(),
             PinKeyboardMsg::Cancelled => Ok(CANCELLED.as_obj()),
+        }
+    }
+}
+
+impl<T> ComponentMsgObj for MnemonicKeyboard<T>
+where
+    T: MnemonicInput,
+{
+    fn msg_try_into_obj(&self, msg: Self::Msg) -> Result<Obj, Error> {
+        match msg {
+            MnemonicKeyboardMsg::Confirmed => {
+                if let Some(word) = self.mnemonic() {
+                    word.try_into()
+                } else {
+                    fatal_error!("Invalid mnemonic")
+                }
+            }
+            MnemonicKeyboardMsg::Previous => "".try_into(),
         }
     }
 }

--- a/core/embed/rust/src/ui/layout_eckhart/flow/mod.rs
+++ b/core/embed/rust/src/ui/layout_eckhart/flow/mod.rs
@@ -1,5 +1,7 @@
 pub mod eckhart_swipe_flow_test;
 pub mod show_share_words;
+pub mod request_passphrase;
 
 pub use eckhart_swipe_flow_test::new_eckhart_swipe_flow;
+pub use request_passphrase::RequestPassphrase;
 pub use show_share_words::new_show_share_words_flow;

--- a/core/embed/rust/src/ui/layout_eckhart/flow/request_passphrase.rs
+++ b/core/embed/rust/src/ui/layout_eckhart/flow/request_passphrase.rs
@@ -1,0 +1,84 @@
+use crate::{
+    error,
+    strutil::ShortString,
+    translations::TR,
+    ui::{
+        component::{text::op::OpTextLayout, ComponentExt, FormattedText},
+        flow::{
+            base::{Decision, DecisionBuilder as _},
+            FlowController, FlowMsg, SwipeFlow,
+        },
+        geometry::Direction,
+        layout_eckhart::{
+            component::{
+                ActionBar, Button, Header, PassphraseKeyboard, PassphraseKeyboardMsg, TextScreen,
+                TextScreenMsg,
+            },
+            fonts, theme,
+        },
+    },
+};
+
+#[derive(Copy, Clone, PartialEq, Eq)]
+pub enum RequestPassphrase {
+    Keypad,
+    ConfirmEmpty,
+}
+
+impl FlowController for RequestPassphrase {
+    #[inline]
+    fn index(&'static self) -> usize {
+        *self as usize
+    }
+
+    fn handle_swipe(&'static self, _direction: Direction) -> Decision {
+        self.do_nothing()
+    }
+
+    fn handle_event(&'static self, msg: FlowMsg) -> Decision {
+        match (self, msg) {
+            (Self::Keypad, FlowMsg::Text(s)) => {
+                if s.is_empty() {
+                    Self::ConfirmEmpty.goto()
+                } else {
+                    self.return_msg(FlowMsg::Text(s))
+                }
+            }
+            (Self::Keypad, FlowMsg::Cancelled) => self.return_msg(FlowMsg::Cancelled),
+            (Self::ConfirmEmpty, FlowMsg::Cancelled) => Self::Keypad.goto(),
+            (Self::ConfirmEmpty, FlowMsg::Confirmed) => {
+                self.return_msg(FlowMsg::Text(ShortString::new()))
+            }
+            _ => self.do_nothing(),
+        }
+    }
+}
+
+pub fn new_request_passphrase() -> Result<SwipeFlow, error::Error> {
+    let op_confirm = OpTextLayout::new(theme::TEXT_NORMAL).text(
+        TR::passphrase__continue_with_empty_passphrase,
+        fonts::FONT_SATOSHI_REGULAR_38,
+    );
+
+    let content_confirm_empty = TextScreen::new(FormattedText::new(op_confirm))
+        .with_header(Header::new("".into()))
+        .with_action_bar(ActionBar::new_double(
+            Button::with_icon(theme::ICON_CROSS).styled(theme::button_cancel()),
+            Button::with_icon(theme::ICON_CHECKMARK).styled(theme::button_confirm()),
+        ))
+        .map(|msg| match msg {
+            TextScreenMsg::Cancelled => Some(FlowMsg::Cancelled),
+            TextScreenMsg::Confirmed => Some(FlowMsg::Confirmed),
+            _ => Some(FlowMsg::Cancelled),
+        });
+
+    let content_keypad = PassphraseKeyboard::new().map(|msg| match msg {
+        PassphraseKeyboardMsg::Confirmed(s) => Some(FlowMsg::Text(s)),
+        PassphraseKeyboardMsg::Cancelled => Some(FlowMsg::Cancelled),
+    });
+
+    let res = SwipeFlow::new(&RequestPassphrase::Keypad)?
+        .with_page(&RequestPassphrase::Keypad, content_keypad)?
+        .with_page(&RequestPassphrase::ConfirmEmpty, content_confirm_empty)?;
+    Ok(res)
+}

--- a/core/embed/rust/src/ui/layout_eckhart/theme/mod.rs
+++ b/core/embed/rust/src/ui/layout_eckhart/theme/mod.rs
@@ -215,6 +215,32 @@ pub const fn button_confirm() -> ButtonStyleSheet {
     }
 }
 
+pub const fn button_cancel() -> ButtonStyleSheet {
+    ButtonStyleSheet {
+        normal: &ButtonStyle {
+            font: fonts::FONT_SATOSHI_REGULAR_22, // unused
+            text_color: ORANGE,                   // unused
+            button_color: BG,
+            icon_color: ORANGE,
+            background_color: BG,
+        },
+        active: &ButtonStyle {
+            font: fonts::FONT_SATOSHI_REGULAR_22, // unused
+            text_color: ORANGE_DIMMED,            //unused
+            button_color: ORANGE_EXTRA_DARK,
+            icon_color: ORANGE_DIMMED,
+            background_color: ORANGE_EXTRA_DARK,
+        },
+        disabled: &ButtonStyle {
+            font: fonts::FONT_SATOSHI_REGULAR_22, // unused
+            text_color: GREY_EXTRA_DARK,          // unused
+            button_color: BG,
+            icon_color: GREY_EXTRA_DARK,
+            background_color: BG,
+        },
+    }
+}
+
 pub const fn button_warning_high() -> ButtonStyleSheet {
     ButtonStyleSheet {
         normal: &ButtonStyle {
@@ -326,6 +352,190 @@ pub const fn button_select_word() -> ButtonStyleSheet {
         // unused
         disabled: &ButtonStyle {
             font: fonts::FONT_SATOSHI_EXTRALIGHT_46,
+            text_color: BG,
+            button_color: BG,
+            icon_color: BG,
+            background_color: BG,
+        },
+    }
+}
+
+pub const fn button_keyboard() -> ButtonStyleSheet {
+    ButtonStyleSheet {
+        normal: &ButtonStyle {
+            font: fonts::FONT_SATOSHI_EXTRALIGHT_46,
+            text_color: GREY_EXTRA_LIGHT,
+            button_color: BG,
+            icon_color: GREY_LIGHT,
+            background_color: BG,
+        },
+        active: &ButtonStyle {
+            font: fonts::FONT_SATOSHI_EXTRALIGHT_46,
+            text_color: GREY_DARK,
+            button_color: GREY_SUPER_DARK,
+            icon_color: GREY_DARK,
+            background_color: GREY_SUPER_DARK,
+        },
+        disabled: &ButtonStyle {
+            font: fonts::FONT_SATOSHI_EXTRALIGHT_46,
+            text_color: GREY_EXTRA_DARK,
+            button_color: BG,
+            icon_color: GREY_EXTRA_DARK,
+            background_color: BG,
+        },
+    }
+}
+
+pub const fn button_keyboard_numeric() -> ButtonStyleSheet {
+    ButtonStyleSheet {
+        normal: &ButtonStyle {
+            font: fonts::FONT_SATOSHI_EXTRALIGHT_72,
+            text_color: GREY_EXTRA_LIGHT,
+            button_color: BG,
+            icon_color: GREY_LIGHT,
+            background_color: BG,
+        },
+        active: &ButtonStyle {
+            font: fonts::FONT_SATOSHI_EXTRALIGHT_72,
+            text_color: GREY_DARK,
+            button_color: GREY_SUPER_DARK,
+            icon_color: GREY_DARK,
+            background_color: GREY_SUPER_DARK,
+        },
+        disabled: &ButtonStyle {
+            font: fonts::FONT_SATOSHI_EXTRALIGHT_72,
+            text_color: GREY_EXTRA_DARK,
+            button_color: BG,
+            icon_color: GREY_EXTRA_DARK,
+            background_color: BG,
+        },
+    }
+}
+
+pub const fn button_keyboard_confirm() -> ButtonStyleSheet {
+    ButtonStyleSheet {
+        normal: &ButtonStyle {
+            font: fonts::FONT_SATOSHI_REGULAR_22, // unused
+            text_color: GREEN_LIGHT,              // unused
+            button_color: BG,
+            icon_color: GREEN_LIGHT,
+            background_color: BG,
+        },
+        active: &ButtonStyle {
+            font: fonts::FONT_SATOSHI_REGULAR_22, // unused
+            text_color: GREEN,                    // unused
+            button_color: GREEN_EXTRA_DARK,
+            icon_color: GREEN,
+            background_color: GREEN_EXTRA_DARK,
+        },
+        disabled: &ButtonStyle {
+            font: fonts::FONT_SATOSHI_REGULAR_22, // unused
+            text_color: GREY_EXTRA_DARK,          // unused
+            button_color: BG,
+            icon_color: GREY_EXTRA_DARK,
+            background_color: BG,
+        },
+    }
+}
+
+pub const fn button_keyboard_next() -> ButtonStyleSheet {
+    ButtonStyleSheet {
+        normal: &ButtonStyle {
+            font: fonts::FONT_SATOSHI_MEDIUM_26,
+            text_color: GREY_EXTRA_LIGHT,
+            button_color: BG,
+            icon_color: GREY_EXTRA_LIGHT,
+            background_color: BG,
+        },
+        active: &ButtonStyle {
+            font: fonts::FONT_SATOSHI_MEDIUM_26,
+            text_color: GREY_DARK,
+            button_color: GREY_SUPER_DARK,
+            icon_color: GREY_DARK,
+            background_color: GREY_SUPER_DARK,
+        },
+        // not used
+        disabled: &ButtonStyle {
+            font: fonts::FONT_SATOSHI_MEDIUM_26,
+            text_color: BG,
+            button_color: BG,
+            icon_color: BG,
+            background_color: BG,
+        },
+    }
+}
+
+pub const fn input_mnemonic() -> ButtonStyleSheet {
+    ButtonStyleSheet {
+        normal: &ButtonStyle {
+            font: fonts::FONT_SATOSHI_MEDIUM_26,
+            text_color: GREY_LIGHT,
+            button_color: BG,
+            icon_color: GREY_LIGHT,
+            background_color: BG,
+        },
+        active: &ButtonStyle {
+            font: fonts::FONT_SATOSHI_MEDIUM_26,
+            text_color: GREY_LIGHT,
+            button_color: GREY_SUPER_DARK,
+            icon_color: GREY_LIGHT,
+            background_color: GREY_SUPER_DARK,
+        },
+        disabled: &ButtonStyle {
+            font: fonts::FONT_SATOSHI_MEDIUM_26,
+            text_color: GREY_LIGHT,
+            button_color: BG,
+            icon_color: GREY_LIGHT,
+            background_color: BG,
+        },
+    }
+}
+
+pub const fn input_mnemonic_suggestion() -> ButtonStyleSheet {
+    ButtonStyleSheet {
+        normal: &ButtonStyle {
+            font: fonts::FONT_SATOSHI_MEDIUM_26,
+            text_color: GREY_DARK,
+            button_color: BG,
+            icon_color: GREY_DARK,
+            background_color: BG,
+        },
+        active: &ButtonStyle {
+            font: fonts::FONT_SATOSHI_MEDIUM_26,
+            text_color: GREY_LIGHT,
+            button_color: BG,
+            icon_color: GREY_LIGHT,
+            background_color: BG,
+        },
+        disabled: &ButtonStyle {
+            font: fonts::FONT_SATOSHI_MEDIUM_26,
+            text_color: BG,
+            button_color: BG,
+            icon_color: BG,
+            background_color: BG,
+        },
+    }
+}
+
+pub const fn input_mnemonic_confirm() -> ButtonStyleSheet {
+    ButtonStyleSheet {
+        normal: &ButtonStyle {
+            font: fonts::FONT_SATOSHI_MEDIUM_26,
+            text_color: GREEN_LIGHT,
+            button_color: BG,
+            icon_color: GREEN_LIGHT,
+            background_color: BG,
+        },
+        active: &ButtonStyle {
+            font: fonts::FONT_SATOSHI_MEDIUM_26,
+            text_color: GREEN_LIGHT,
+            button_color: GREEN_EXTRA_DARK,
+            icon_color: GREEN_LIGHT,
+            background_color: GREEN_EXTRA_DARK,
+        },
+        disabled: &ButtonStyle {
+            // unused
+            font: fonts::FONT_SATOSHI_MEDIUM_26,
             text_color: BG,
             button_color: BG,
             icon_color: BG,

--- a/core/embed/rust/src/ui/layout_eckhart/ui_firmware.rs
+++ b/core/embed/rust/src/ui/layout_eckhart/ui_firmware.rs
@@ -25,7 +25,8 @@ use crate::{
 
 use super::{
     component::{
-        ActionBar, Button, Header, HeaderMsg, Hint, PinKeyboard, SelectWordScreen, TextScreen,
+        ActionBar, Button, Header, HeaderMsg, Hint, MnemonicKeyboard, PinKeyboard,
+        SelectWordScreen, TextScreen,
     },
     flow, fonts, theme, UIEckhart,
 };

--- a/core/embed/rust/src/ui/layout_eckhart/ui_firmware.rs
+++ b/core/embed/rust/src/ui/layout_eckhart/ui_firmware.rs
@@ -25,7 +25,7 @@ use crate::{
 
 use super::{
     component::{
-        ActionBar, Button, Header, HeaderMsg, Hint, MnemonicKeyboard, PinKeyboard,
+        ActionBar, Bip39Input, Button, Header, HeaderMsg, Hint, MnemonicKeyboard, PinKeyboard,
         SelectWordScreen, TextScreen,
     },
     flow, fonts, theme, UIEckhart,
@@ -349,11 +349,16 @@ impl FirmwareUI for UIEckhart {
     }
 
     fn request_bip39(
-        _prompt: TString<'static>,
-        _prefill_word: TString<'static>,
-        _can_go_back: bool,
+        prompt: TString<'static>,
+        prefill_word: TString<'static>,
+        can_go_back: bool,
     ) -> Result<impl LayoutMaybeTrace, Error> {
-        Err::<RootComponent<Empty, ModelUI>, Error>(Error::ValueError(c"not implemented"))
+        let layout = RootComponent::new(MnemonicKeyboard::new(
+            prefill_word.map(Bip39Input::prefilled_word),
+            prompt,
+            can_go_back,
+        ));
+        Ok(layout)
     }
 
     fn request_slip39(

--- a/core/embed/rust/src/ui/layout_eckhart/ui_firmware.rs
+++ b/core/embed/rust/src/ui/layout_eckhart/ui_firmware.rs
@@ -394,7 +394,8 @@ impl FirmwareUI for UIEckhart {
         _prompt: TString<'static>,
         _max_len: u32,
     ) -> Result<impl LayoutMaybeTrace, Error> {
-        Err::<RootComponent<Empty, ModelUI>, Error>(Error::ValueError(c"not implemented"))
+        let flow = flow::request_passphrase::new_request_passphrase()?;
+        Ok(flow)
     }
 
     fn select_word(

--- a/core/embed/rust/src/ui/layout_eckhart/ui_firmware.rs
+++ b/core/embed/rust/src/ui/layout_eckhart/ui_firmware.rs
@@ -26,7 +26,7 @@ use crate::{
 use super::{
     component::{
         ActionBar, Bip39Input, Button, Header, HeaderMsg, Hint, MnemonicKeyboard, PinKeyboard,
-        SelectWordScreen, TextScreen,
+        SelectWordScreen, Slip39Input, TextScreen,
     },
     flow, fonts, theme, UIEckhart,
 };
@@ -362,11 +362,17 @@ impl FirmwareUI for UIEckhart {
     }
 
     fn request_slip39(
-        _prompt: TString<'static>,
-        _prefill_word: TString<'static>,
-        _can_go_back: bool,
+        prompt: TString<'static>,
+        prefill_word: TString<'static>,
+        can_go_back: bool,
     ) -> Result<impl LayoutMaybeTrace, Error> {
-        Err::<RootComponent<Empty, ModelUI>, Error>(Error::ValueError(c"not implemented"))
+        let layout = RootComponent::new(MnemonicKeyboard::new(
+            prefill_word.map(Slip39Input::prefilled_word),
+            prompt,
+            can_go_back,
+        ));
+
+        Ok(layout)
     }
 
     fn request_number(

--- a/core/embed/rust/src/ui/layout_eckhart/ui_firmware.rs
+++ b/core/embed/rust/src/ui/layout_eckhart/ui_firmware.rs
@@ -24,7 +24,9 @@ use crate::{
 };
 
 use super::{
-    component::{ActionBar, Button, Header, HeaderMsg, Hint, SelectWordScreen, TextScreen},
+    component::{
+        ActionBar, Button, Header, HeaderMsg, Hint, PinKeyboard, SelectWordScreen, TextScreen,
+    },
     flow, fonts, theme, UIEckhart,
 };
 
@@ -373,12 +375,19 @@ impl FirmwareUI for UIEckhart {
     }
 
     fn request_pin(
-        _prompt: TString<'static>,
-        _subprompt: TString<'static>,
-        _allow_cancel: bool,
-        _warning: bool,
+        prompt: TString<'static>,
+        subprompt: TString<'static>,
+        allow_cancel: bool,
+        warning: bool,
     ) -> Result<impl LayoutMaybeTrace, Error> {
-        Err::<RootComponent<Empty, ModelUI>, Error>(Error::ValueError(c"not implemented"))
+        let warning = if warning {
+            Some(TR::pin__wrong_pin.into())
+        } else {
+            None
+        };
+
+        let layout = RootComponent::new(PinKeyboard::new(prompt, subprompt, warning, allow_cancel));
+        Ok(layout)
     }
 
     fn request_passphrase(


### PR DESCRIPTION
- button styles for keyboards
- module with common keyboard stuff, i.e. _MultiTapKeyboard_
- keypad grid with dims of 4x3 with buttons overlaying each other when in pressed state
- Full-screen _Pin Keyboard_ component
- Full-screen _Passphrase Keyboard_ component
- first prototype of a _request passphrase_ flow
- Full-screen _Mnemonic Keyboard_ component + _MnemonicInput_ trait
- BIP39 input component
- SLIP39 input component