### PR TITLE
chore(core): export Rust-related uPy types on debug firmware

### DIFF
--- a/core/embed/rust/librust.h
+++ b/core/embed/rust/librust.h
@@ -2,7 +2,7 @@
 
 #include "librust_qstr.h"
 
-#ifdef TREZOR_EMULATOR
+#if !PYOPT
 mp_obj_t protobuf_debug_msg_type();
 mp_obj_t protobuf_debug_msg_def_type();
 #endif
@@ -11,6 +11,6 @@ extern mp_obj_module_t mp_module_trezorproto;
 extern mp_obj_module_t mp_module_trezorui_api;
 extern mp_obj_module_t mp_module_trezortranslate;
 
-#ifdef TREZOR_EMULATOR
+#if !PYOPT
 mp_obj_t ui_debug_layout_type();
 #endif


### PR DESCRIPTION
It would allow running `mod_trezorutils_meminfo()` also on debug firmware (currently it can run only on the emulator).

https://github.com/trezor/trezor-firmware/blob/45adcd963a4f992b6545f6d52ad4a9412674db57/core/embed/upymod/modtrezorutils/modtrezorutils-meminfo.h#L653-L663

<!--
For core developers:
- Assign yourself to the PR.
- Set the priority to match the original issue.
- Add the PR to the current sprint.
- If it's a draft PR, mark it as "In Progress."
- If it's a final PR, mark it as "Needs Review."

For external contributors:
- Please open an issue before submitting a PR so we can discuss whether we want to proceed with it.
-->
