### PR TITLE
Add display-text command to prodtest

### DIFF
--- a/core/embed/projects/prodtest/README.md
+++ b/core/embed/projects/prodtest/README.md
@@ -158,6 +158,15 @@ display-border
 OK
 ```
 
+### display-text
+The `display-text` command draws text to the screen
+
+Example:
+```
+display-text hello_world
+OK
+```
+
 ### display-bars
 Draws vertical color bars on the screen according to a specified string of color codes.
 

--- a/core/embed/projects/prodtest/cmd/prodtest_display.c
+++ b/core/embed/projects/prodtest/cmd/prodtest_display.c
@@ -36,6 +36,19 @@ static void prodtest_display_border(cli_t* cli) {
   cli_ok(cli, "");
 }
 
+static void prodtest_display_text(cli_t* cli) {
+  if (cli_arg_count(cli) > 1) {
+    cli_error_arg_count(cli);
+    return;
+  }
+
+  const char* text = cli_arg(cli, "text");
+
+  screen_prodtest_show_text(text, strlen(text));
+
+  cli_ok(cli, "");
+}
+
 static void prodtest_display_bars(cli_t* cli) {
   const char* colors = cli_arg(cli, "colors");
   size_t color_count = strlen(colors);
@@ -93,6 +106,13 @@ PRODTEST_CLI_CMD(
   .func = prodtest_display_border,
   .info = "Display a border around the screen",
   .args = ""
+);
+
+PRODTEST_CLI_CMD(
+  .name = "display-text",
+  .func = prodtest_display_text,
+  .info = "Display text on the screen",
+  .args = "<text>"
 );
 
 PRODTEST_CLI_CMD(


### PR DESCRIPTION
Add simple `display-text` command to prodtest, which prints the text given in argument.

This is quite useful when the external controller needs to logs some data on tested trezor.  
We use this during battery test to log battery voltage, and actual current load.

prodtest excepts arguments splitted with space character and display-text command excepts only single argument, so to print several words use different spacing character such as "_".