### PR TITLE
Remove unused function mnemonic_generate()

### DIFF
--- a/core/embed/upymod/modtrezorcrypto/modtrezorcrypto-bip39.h
+++ b/core/embed/upymod/modtrezorcrypto/modtrezorcrypto-bip39.h
@@ -25,26 +25,6 @@
 
 /// package: trezorcrypto.bip39
 
-/// def generate(strength: int) -> str:
-///     """
-///     Generate a mnemonic of given strength (128, 160, 192, 224 and 256 bits).
-///     """
-STATIC mp_obj_t mod_trezorcrypto_bip39_generate(mp_obj_t strength) {
-  int bits = mp_obj_get_int(strength);
-  if (bits % 32 || bits < 128 || bits > 256) {
-    mp_raise_ValueError(
-        "Invalid bit strength (only 128, 160, 192, 224 and 256 values are "
-        "allowed)");
-  }
-  const char *mnemo = mnemonic_generate(bits);
-  mp_obj_t res =
-      mp_obj_new_str_copy(&mp_type_str, (const uint8_t *)mnemo, strlen(mnemo));
-  mnemonic_clear();
-  return res;
-}
-STATIC MP_DEFINE_CONST_FUN_OBJ_1(mod_trezorcrypto_bip39_generate_obj,
-                                 mod_trezorcrypto_bip39_generate);
-
 /// def from_data(data: bytes) -> str:
 ///     """
 ///     Generate a mnemonic from given data (of 16, 20, 24, 28 and 32 bytes).
@@ -113,8 +93,6 @@ STATIC MP_DEFINE_CONST_FUN_OBJ_VAR_BETWEEN(mod_trezorcrypto_bip39_seed_obj, 2,
 
 STATIC const mp_rom_map_elem_t mod_trezorcrypto_bip39_globals_table[] = {
     {MP_ROM_QSTR(MP_QSTR___name__), MP_ROM_QSTR(MP_QSTR_bip39)},
-    {MP_ROM_QSTR(MP_QSTR_generate),
-     MP_ROM_PTR(&mod_trezorcrypto_bip39_generate_obj)},
     {MP_ROM_QSTR(MP_QSTR_from_data),
      MP_ROM_PTR(&mod_trezorcrypto_bip39_from_data_obj)},
     {MP_ROM_QSTR(MP_QSTR_check), MP_ROM_PTR(&mod_trezorcrypto_bip39_check_obj)},

--- a/core/mocks/generated/trezorcrypto/bip39.pyi
+++ b/core/mocks/generated/trezorcrypto/bip39.pyi
@@ -2,13 +2,6 @@ from typing import *
 
 
 # upymod/modtrezorcrypto/modtrezorcrypto-bip39.h
-def generate(strength: int) -> str:
-    """
-    Generate a mnemonic of given strength (128, 160, 192, 224 and 256 bits).
-    """
-
-
-# upymod/modtrezorcrypto/modtrezorcrypto-bip39.h
 def from_data(data: bytes) -> str:
     """
     Generate a mnemonic from given data (of 16, 20, 24, 28 and 32 bytes).

--- a/crypto/bip39.c
+++ b/crypto/bip39.c
@@ -50,17 +50,6 @@ void bip39_cache_clear(void) {
 
 #endif
 
-const char *mnemonic_generate(int strength) {
-  if (strength % 32 || strength < 128 || strength > 256) {
-    return 0;
-  }
-  uint8_t data[32] = {0};
-  random_buffer(data, 32);
-  const char *r = mnemonic_from_data(data, strength / 8);
-  memzero(data, sizeof(data));
-  return r;
-}
-
 static CONFIDENTIAL char mnemo[24 * 10];
 
 const char *mnemonic_from_data(const uint8_t *data, int len) {

--- a/crypto/bip39.h
+++ b/crypto/bip39.h
@@ -38,7 +38,6 @@ void bip39_cache_clear(void);
 
 extern const char *const BIP39_WORDLIST_ENGLISH[BIP39_WORD_COUNT];
 
-const char *mnemonic_generate(int strength);  // strength in bits
 const char *mnemonic_from_data(const uint8_t *data, int len);
 void mnemonic_clear(void);
 


### PR DESCRIPTION
Removes the unused function `mnemonic_generate()` from the trezor-crypto bip39.c module and the corresponding unused function `bip39.generate()` in python. The problem with this function is that it directly calls `random_buffer()`, but Trezor generates seeds using different entropy sources `random_buffer()`, Optiga's RNG and the host's RNG. Both legacy and core then use `mnemonic_from_data()` to convert the randomness to a BIP39 mnemonic.

Thanks to @invd for proposing this change.