### PR TITLE
Trezorlib fixes

### DIFF
--- a/python/src/trezorlib/protobuf.py
+++ b/python/src/trezorlib/protobuf.py
@@ -166,7 +166,7 @@ class Field:
         if self._py_type is None:
             self._py_type = self._resolve_type()
         # pyright issue https://github.com/microsoft/pyright/issues/8136
-        return self._py_type  # type: ignore [Type ["Unknown | None"]]
+        return self._py_type  # type: ignore [Type "Unknown | None"]
 
     def _resolve_type(self) -> type:
         # look for a type in the builtins


### PR DESCRIPTION
Trying to solve some new issues with `trezorlib` I found recently when integrating new emulators into `trezor-user-env`.

1. `protobuf.py` had `# type: ignore [Type ["Unknown | None"]]`, which causes `mypy` to flag this as a syntax error in any project that uses `trezorlib` ... example fail in our CI: https://github.com/trezor/trezor-user-env/actions/runs/13370973357/job/37339166006?pr=290
- I found out that it is fine with other `type: ignore`s, and that the issue disappears when removing the inner `[]` ... `mypy` seems to have issues with this

2. Connected with `transport/bridge.py` - `call_bridge` is sending a POST request to bridge URL, but with no timeout. Just last week, with new release emulators, it started happening that the bridge just did not anwer at all. It is strange that it happened just now, with new emulators - we suspect something is different/new in new (2.8.7 and higher) emulators (one other clue is not being able to run Shamir backup flow built for older emulators).