### PR TITLE
 fix rendering of outlined Bars

### DIFF
--- a/core/embed/rust/src/ui/shape/bar.rs
+++ b/core/embed/rust/src/ui/shape/bar.rs
@@ -87,10 +87,46 @@ impl Shape<'_> for Bar {
                 // outline
                 if th > 0 {
                     let r = self.area;
-                    canvas.fill_rect(Rect { y1: r.y0 + th, ..r }, fg_color, self.alpha);
-                    canvas.fill_rect(Rect { x1: r.x0 + th, ..r }, fg_color, self.alpha);
-                    canvas.fill_rect(Rect { x0: r.x1 - th, ..r }, fg_color, self.alpha);
-                    canvas.fill_rect(Rect { y0: r.y1 - th, ..r }, fg_color, self.alpha);
+                    // top
+                    canvas.fill_rect(
+                        Rect {
+                            y1: r.y0 + th,
+                            x1: r.x1 - th,
+                            ..r
+                        },
+                        fg_color,
+                        self.alpha,
+                    );
+                    // left
+                    canvas.fill_rect(
+                        Rect {
+                            x1: r.x0 + th,
+                            y0: r.y0 + th,
+                            ..r
+                        },
+                        fg_color,
+                        self.alpha,
+                    );
+                    // right
+                    canvas.fill_rect(
+                        Rect {
+                            x0: r.x1 - th,
+                            y1: r.y1 - th,
+                            ..r
+                        },
+                        fg_color,
+                        self.alpha,
+                    );
+                    // bottom
+                    canvas.fill_rect(
+                        Rect {
+                            y0: r.y1 - th,
+                            x0: r.x0 + th,
+                            ..r
+                        },
+                        fg_color,
+                        self.alpha,
+                    );
                 }
             }
             if let Some(bg_color) = self.bg_color {


### PR DESCRIPTION
This PR fixes a problem with rendering outlines of Bar. Previous implementation drawn sides of the rectangle one over another, which, in combination with `with_alpha` usage, cause different color then the rest of the rect.

<!--
For core developers:
- Assign yourself to the PR.
- Set the priority to match the original issue.
- Add the PR to the current sprint.
- If it's a draft PR, mark it as "In Progress."
- If it's a final PR, mark it as "Needs Review."

For external contributors:
- Please open an issue before submitting a PR so we can discuss whether we want to proceed with it.
-->
