### PR TITLE
feat(core): enable hw decoding of grayscale JPEGs

### DIFF
--- a/core/embed/gfx/bitblt/dma2d_bitblt.h
+++ b/core/embed/gfx/bitblt/dma2d_bitblt.h
@@ -44,6 +44,7 @@ bool dma2d_rgb565_blend_mono8(const gfx_bitblt_t* bb);
 
 bool dma2d_rgba8888_fill(const gfx_bitblt_t* bb);
 bool dma2d_rgba8888_copy_mono4(const gfx_bitblt_t* bb);
+bool dma2d_rgba8888_copy_mono8(const gfx_bitblt_t* bb);
 bool dma2d_rgba8888_copy_rgb565(const gfx_bitblt_t* bb);
 bool dma2d_rgba8888_copy_rgba8888(const gfx_bitblt_t* bb);
 bool dma2d_rgba8888_blend_mono4(const gfx_bitblt_t* bb);
@@ -53,4 +54,5 @@ bool dma2d_rgba8888_blend_mono8(const gfx_bitblt_t* bb);
 bool dma2d_rgba8888_copy_ycbcr420(const gfx_bitblt_t* bb);
 bool dma2d_rgba8888_copy_ycbcr422(const gfx_bitblt_t* bb);
 bool dma2d_rgba8888_copy_ycbcr444(const gfx_bitblt_t* bb);
+bool dma2d_rgba8888_copy_y(const gfx_bitblt_t* bb);
 #endif

--- a/core/embed/gfx/jpegdec/stm32u5/jpegdec.c
+++ b/core/embed/gfx/jpegdec/stm32u5/jpegdec.c
@@ -456,7 +456,8 @@ bool jpegdec_get_slice_rgba8888(uint32_t *rgba8888, jpegdec_slice_t *slice) {
       result = dma2d_rgba8888_copy_ycbcr444(&bb);
       break;
     case JPEGDEC_IMAGE_GRAYSCALE:
-      // Conversion from grayscale to RGBA8888 is not supported
+      result = dma2d_rgba8888_copy_y(&bb);
+      break;
     default:
       result = false;
       break;


### PR DESCRIPTION
This PR enhances the HW JPEG decoder to support decoding grayscale images.

Although grayscale images are not accepted by `trezorctl`, we use them internally for the Trezor logo.


 


