### PR TITLE
Include pb2py for python style linting

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -5,7 +5,7 @@ help: ## show this help
 
 ## style commands:
 
-PY_FILES = $(shell find . -type f -name '*.py'   | sed 'sO^\./OO' | grep -f ./tools/style.py.include | grep -v -f ./tools/style.py.exclude )
+PY_FILES = $(shell find . -type f -name '*.py'   | sed 'sO^\./OO' | grep -f ./tools/style.py.include | grep -v -f ./tools/style.py.exclude ) common/protob/pb2py
 C_FILES =  $(shell find . -type f -name '*.[ch]' | grep -f ./tools/style.c.include  | grep -v -f ./tools/style.c.exclude )
 
 

--- a/common/protob/pb2py
+++ b/common/protob/pb2py
@@ -133,9 +133,7 @@ WIRETYPE_ENTRY = c.Sequence(
 )
 
 # QDEF(MP_QSTR_copysign, 5171, 8, "copysign")
-QDEF_RE = re.compile(
-    r'^QDEF\(MP_QSTR(\S+), ([0-9]+), ([0-9])+, "(.*)"\)$'
-)
+QDEF_RE = re.compile(r'^QDEF\(MP_QSTR(\S+), ([0-9]+), ([0-9])+, "(.*)"\)$')
 
 
 @dataclass


### PR DESCRIPTION
Add `pb2py` for python style linting, i.e. running `make style` now includes `pb2py`.