### PR TITLE
fix jpeg blurring and dimming area

### DIFF
--- a/core/embed/rust/src/ui/shape/jpeg.rs
+++ b/core/embed/rust/src/ui/shape/jpeg.rs
@@ -134,12 +134,12 @@ impl<'a> Shape<'a> for JpegImage<'a> {
             // Draw dimmed overlay.
             // This solution is suboptimal and might be replaced by
             // using faster alpha blending in the hardware.
-            canvas.fill_rect(clip, Color::black(), 255 - self.dim);
+            canvas.fill_rect(bounds, Color::black(), 255 - self.dim);
         }
 
         if self.blur_radius > 0 {
             // Blur the image
-            canvas.blur_rect(clip, self.blur_radius, cache);
+            canvas.blur_rect(bounds, self.blur_radius, cache);
         }
     }
 


### PR DESCRIPTION
clip was used instead of bounds

<!--
For core developers:
- Assign yourself to the PR.
- Set the priority to match the original issue.
- Add the PR to the current sprint.
- If it's a draft PR, mark it as "In Progress."
- If it's a final PR, mark it as "Needs Review."

For external contributors:
- Please open an issue before submitting a PR so we can discuss whether we want to proceed with it.
-->
