### PR TITLE
Fix cstyle and editor_check inconsistency

### DIFF
--- a/.clang-format
+++ b/.clang-format
@@ -8,3 +8,5 @@ ColumnLimit: 80
 IncludeBlocks: Preserve
 # Insert New line at EOF if missing
 InsertNewlineAtEOF: true
+#Set EOL to LF unconditionally
+LineEnding: LF


### PR DESCRIPTION
If you create a .c or .h file with CRLF EOL sequence `make cstyle_check` wont recognize any issue nor fix anything with `make cstyle` command. 

On the other hand `make editor_check` will fails with error:
```
Wrong line endings or no final newline
Not all lines have the correct end of line character
```

this PR fix the clang-format to enforce LF EOL sequence, so `make cstyle` command will deal with this automatically. 