### PR TITLE
fix(tests): don't leave emulator process running

### DIFF
--- a/.github/workflows/core.yml
+++ b/.github/workflows/core.yml
@@ -371,6 +371,7 @@ jobs:
     env:
       TREZOR_UPGRADE_TEST: core
       PYTEST_TIMEOUT: 400
+      TREZOR_PYTEST_LOGS_DIR: ${{ github.workspace }}/tests/
     steps:
       - uses: actions/checkout@v4
         with:
@@ -383,6 +384,13 @@ jobs:
       - uses: ./.github/actions/environment
       - run: nix-shell --run "tests/download_emulators.sh"
       - run: nix-shell --run "poetry run pytest tests/upgrade_tests"
+      - uses: actions/upload-artifact@v4
+        with:
+          name: core-test-upgrade-${{ matrix.model }}-${{ matrix.asan }}
+          path: |
+            tests/trezor.log
+          retention-days: 7
+        if: always()
 
 
   # Persistence tests - UI.
@@ -401,6 +409,7 @@ jobs:
     env:
       TREZOR_PROFILING: ${{ matrix.asan == 'noasan' && '1' || '0' }}
       PYTEST_TIMEOUT: 400
+      TREZOR_PYTEST_LOGS_DIR: ${{ github.workspace }}/tests/
     steps:
       - uses: actions/checkout@v4
         with:
@@ -423,6 +432,13 @@ jobs:
         if: always()
         continue-on-error: true
       - uses: ./.github/actions/upload-coverage
+      - uses: actions/upload-artifact@v4
+        with:
+          name: core-test-persistence-${{ matrix.model }}-${{ matrix.asan }}
+          path: |
+            tests/trezor.log
+          retention-days: 7
+        if: always()
 
   core_hwi_test:
     name: HWI tests

--- a/tests/emulators.py
+++ b/tests/emulators.py
@@ -139,6 +139,7 @@ class EmulatorWrapper:
         if logs_dir is not None:
             src = Path(self.profile_dir.name) / "trezor.log"
             dst = Path(logs_dir) / f"trezor-{self.worker_id}.log"
-            shutil.move(src, dst)
+            with open(src, "rb") as src, open(dst, "ab") as dst:
+                shutil.copyfileobj(src, dst)
 
         self.profile_dir.cleanup()


### PR DESCRIPTION
When an exception is raised in the wrong place, pytest exits but leaves emulator process running in the background. This can result in confusing behavior of further pytest invocations which will connect to this old emulator. The fix attempts to keep track of running emulators in a global variable and then kill them in `atexit()` hook.

Included are two more quality of life improvements.

<!--
For core developers:
- Assign yourself to the PR.
- Set the priority to match the original issue.
- Add the PR to the current sprint.
- If it's a draft PR, mark it as "In Progress."
- If it's a final PR, mark it as "Needs Review."

For external contributors:
- Please open an issue before submitting a PR so we can discuss whether we want to proceed with it.
-->
