### PR TITLE
fix jump to old bootloader

### DIFF
--- a/core/embed/sys/startup/stm32/bootutils.c
+++ b/core/embed/sys/startup/stm32/bootutils.c
@@ -168,6 +168,10 @@ static void reboot_with_args_phase_2(uint32_t arg1, uint32_t arg2) {
   if (command == BOOT_COMMAND_NONE) {
     NVIC_SystemReset();
   } else {
+#ifndef FIXED_HW_DEINIT
+    SysTick_Config(HAL_RCC_GetSysClockFreq() / 1000U);
+    NVIC_SetPriority(SysTick_IRQn, 0);
+#endif
     jump_to_vectbl(BOOTLOADER_START + IMAGE_HEADER_SIZE, command);
   }
 #else


### PR DESCRIPTION
Initialize systick before jump, as the old bootloaders may not initialize systick on start and rely on systick running from boardloader or firmware. Only relevant for F4, otherwise we are jumping through reset.
