### PR TITLE
fix touch draw test

### DIFF
--- a/core/embed/rust/src/ui/layout_bolt/prodtest/mod.rs
+++ b/core/embed/rust/src/ui/layout_bolt/prodtest/mod.rs
@@ -147,19 +147,16 @@ impl ProdtestUI for UIBolt {
                 match ev {
                     TouchStart(p) => {
                         shape::Bar::new(Rect::from_center_and_size(*p, Offset::new(3, 3)))
-                            .with_fg(Color::rgb(0, 255, 0))
                             .with_bg(Color::rgb(0, 255, 0))
                             .render(target);
                     }
                     TouchMove(p) => {
                         shape::Bar::new(Rect::from_center_and_size(*p, Offset::new(1, 1)))
-                            .with_fg(Color::white())
                             .with_bg(Color::white())
                             .render(target);
                     }
                     TouchEnd(p) => {
                         shape::Bar::new(Rect::from_center_and_size(*p, Offset::new(3, 3)))
-                            .with_fg(Color::rgb(255, 0, 0))
                             .with_bg(Color::rgb(255, 0, 0))
                             .render(target);
                     }


### PR DESCRIPTION
The new touch-draw command stopped working properly after https://github.com/trezor/trezor-firmware/pull/4666 was merged.

The reason is that setting both fg and bg colors caused the square to be drawn as outline+background, but with 1px square the outline didn't draw due to the new algorithm cutting the thickness, and background also didn't render anything. So currently we can't draw 1px squares with bg+fg color set, which is a bug itself (i created https://github.com/trezor/trezor-firmware/issues/4702 for that), but there is no reason to set both fg and bg color in this screen, so i simplified it. 
