### PR TITLE
fix drawing of 1pix bar shape 

### DIFF
--- a/core/embed/rust/src/ui/shape/bar.rs
+++ b/core/embed/rust/src/ui/shape/bar.rs
@@ -77,13 +77,22 @@ impl Shape<'_> for Bar {
 
         // TODO: fatal_error! in unsupported scenarious
 
-        let th = match self.fg_color {
-            Some(_) => self.thickness,
-            None => 0,
+        let (fg_color, bg_color, th) = if self.fg_color.is_some() {
+            let th = self.thickness;
+            if th * 2 < self.area.width() && th * 2 < self.area.height() {
+                // Draw a rectangle with a border
+                (self.fg_color, self.bg_color, th)
+            } else {
+                // Too thick border => draw a filled rectangle
+                (None, self.fg_color, 0)
+            }
+        } else {
+            // No foreground color => draw a filled rectangle
+            (None, self.bg_color, 0)
         };
 
         if self.radius == 0 {
-            if let Some(fg_color) = self.fg_color {
+            if let Some(fg_color) = fg_color {
                 // outline
                 if th > 0 {
                     let r = self.area;
@@ -129,13 +138,13 @@ impl Shape<'_> for Bar {
                     );
                 }
             }
-            if let Some(bg_color) = self.bg_color {
+            if let Some(bg_color) = bg_color {
                 // background
                 let bg_r = self.area.shrink(th);
                 canvas.fill_rect(bg_r, bg_color, self.alpha);
             }
         } else {
-            if let Some(fg_color) = self.fg_color {
+            if let Some(fg_color) = fg_color {
                 if th > 0 {
                     if self.bg_color.is_some() {
                         canvas.fill_round_rect(self.area, self.radius, fg_color, self.alpha);
@@ -145,7 +154,7 @@ impl Shape<'_> for Bar {
                     }
                 }
             }
-            if let Some(bg_color) = self.bg_color {
+            if let Some(bg_color) = bg_color {
                 let bg_r = self.area.shrink(th);
                 canvas.fill_round_rect(bg_r, self.radius, bg_color, self.alpha);
             }

--- a/core/site_scons/models/T3W1/trezor_t3w1_revA.py
+++ b/core/site_scons/models/T3W1/trezor_t3w1_revA.py
@@ -84,6 +84,7 @@ def configure(
         features_available.append("ble")
         defines += [("USE_BLE", "1")]
         sources += ["embed/io/nrf/stm32u5/nrf.c"]
+        sources += ["embed/io/nrf/stm32u5/nrf_test.c"]
         sources += ["embed/io/nrf/crc8.c"]
         paths += ["embed/io/nrf/inc"]
         sources += [
@@ -118,7 +119,6 @@ def configure(
         paths += ["embed/io/nfc/rfal/source"]
         paths += ["embed/io/nfc/rfal/source/st25r3916"]
         paths += ["embed/io/nfc/rfal/include/"]
-        features_available.append("nfc")
         defines += [("USE_NFC", "1")]
 
     if "optiga" in features_wanted:


### PR DESCRIPTION
This PR resolves #4702 and fixes the prodtest build for T3W1 rev A.

If the background and foreground colors are the same, the bar thickness is not considered. This fixes the problem with 1-pixel bars and also optimizes drawing, as suggested in #4702.




