### PR TITLE
feat(core): use `SwipeFlow::add_page` to reduce stack usage

### DIFF
--- a/core/embed/rust/src/ui/flow/swipe.rs
+++ b/core/embed/rust/src/ui/flow/swipe.rs
@@ -128,18 +128,6 @@ impl SwipeFlow {
     /// Add a page to the flow.
     ///
     /// Pages must be inserted in the order of the flow state index.
-    pub fn with_page(
-        mut self,
-        state: &'static dyn FlowController,
-        page: impl FlowComponentDynTrait + 'static,
-    ) -> Result<Self, error::Error> {
-        self.add_page(state, page)?;
-        Ok(self)
-    }
-
-    /// Add a page to the flow.
-    ///
-    /// Pages must be inserted in the order of the flow state index.
     pub fn add_page(
         &mut self,
         state: &'static dyn FlowController,

--- a/core/embed/rust/src/ui/layout_delizia/flow/confirm_action.rs
+++ b/core/embed/rust/src/ui/layout_delizia/flow/confirm_action.rs
@@ -310,9 +310,10 @@ fn new_confirm_action_uni<T: Component + PaginateFull + MaybeTrace + 'static>(
         .map_to_button_msg()
         .with_pages(move |intro_pages| intro_pages + prompt_pages);
 
-    let flow = flow?.with_page(page, content)?;
-    let flow = create_menu(flow, &extra, prompt_screen)?;
-    let flow = create_confirm(flow, &extra, strings.subtitle, hold, prompt_screen)?;
+    let mut flow = flow?;
+    flow.add_page(page, content)?;
+    create_menu(&mut flow, &extra, prompt_screen)?;
+    create_confirm(&mut flow, &extra, strings.subtitle, hold, prompt_screen)?;
 
     Ok(flow)
 }
@@ -346,10 +347,10 @@ fn create_flow(
 }
 
 fn create_menu(
-    flow: SwipeFlow,
+    flow: &mut SwipeFlow,
     extra: &ConfirmActionExtra,
     prompt_screen: Option<TString<'static>>,
-) -> Result<SwipeFlow, Error> {
+) -> Result<(), Error> {
     if let ConfirmActionExtra::Menu(menu_strings) = extra {
         let mut menu = VerticalMenu::empty();
         let mut menu_items = Vec::<usize, 2>::new();
@@ -374,23 +375,22 @@ fn create_menu(
         });
 
         if prompt_screen.is_some() {
-            flow.with_page(&ConfirmActionWithMenuAndConfirmation::Menu, content_menu)
+            flow.add_page(&ConfirmActionWithMenuAndConfirmation::Menu, content_menu)?;
         } else {
-            flow.with_page(&ConfirmActionWithMenu::Menu, content_menu)
+            flow.add_page(&ConfirmActionWithMenu::Menu, content_menu)?;
         }
-    } else {
-        Ok(flow) // no menu being added
     }
+    Ok(())
 }
 
 // Create the extra confirmation screen (optional).
 fn create_confirm(
-    flow: SwipeFlow,
+    flow: &mut SwipeFlow,
     extra: &ConfirmActionExtra,
     subtitle: Option<TString<'static>>,
     hold: bool,
     prompt_screen: Option<TString<'static>>,
-) -> Result<SwipeFlow, Error> {
+) -> Result<(), Error> {
     if let Some(prompt_title) = prompt_screen {
         let (prompt, prompt_action) = if hold {
             (
@@ -419,13 +419,12 @@ fn create_confirm(
 
         let content_confirm = content_confirm.map(super::util::map_to_confirm);
 
-        flow.with_page(
+        flow.add_page(
             &ConfirmActionWithMenuAndConfirmation::Confirmation,
             content_confirm,
-        )
-    } else {
-        Ok(flow)
+        )?;
     }
+    Ok(())
 }
 
 #[inline(never)]

--- a/core/embed/rust/src/ui/layout_delizia/flow/confirm_fido.rs
+++ b/core/embed/rust/src/ui/layout_delizia/flow/confirm_fido.rs
@@ -191,10 +191,11 @@ pub fn new_confirm_fido(
     } else {
         &ConfirmFido::Intro
     };
-    SwipeFlow::new(initial_page)?
-        .with_page(&ConfirmFido::Intro, content_intro)?
-        .with_page(&ConfirmFido::ChooseCredential, content_choose_credential)?
-        .with_page(&ConfirmFido::Details, content_details)?
-        .with_page(&ConfirmFido::Tap, content_tap)?
-        .with_page(&ConfirmFido::Menu, content_menu)
+    let mut flow = SwipeFlow::new(initial_page)?;
+    flow.add_page(&ConfirmFido::Intro, content_intro)?
+        .add_page(&ConfirmFido::ChooseCredential, content_choose_credential)?
+        .add_page(&ConfirmFido::Details, content_details)?
+        .add_page(&ConfirmFido::Tap, content_tap)?
+        .add_page(&ConfirmFido::Menu, content_menu)?;
+    Ok(flow)
 }

--- a/core/embed/rust/src/ui/layout_delizia/flow/confirm_firmware_update.rs
+++ b/core/embed/rust/src/ui/layout_delizia/flow/confirm_firmware_update.rs
@@ -107,10 +107,10 @@ pub fn new_confirm_firmware_update(
     .with_swipe(Direction::Left, SwipeSettings::default())
     .map(super::util::map_to_confirm);
 
-    let res = SwipeFlow::new(&ConfirmFirmwareUpdate::Intro)?
-        .with_page(&ConfirmFirmwareUpdate::Intro, content_intro)?
-        .with_page(&ConfirmFirmwareUpdate::Menu, content_menu)?
-        .with_page(&ConfirmFirmwareUpdate::Fingerprint, content_fingerprint)?
-        .with_page(&ConfirmFirmwareUpdate::Confirm, content_confirm)?;
+    let mut res = SwipeFlow::new(&ConfirmFirmwareUpdate::Intro)?;
+    res.add_page(&ConfirmFirmwareUpdate::Intro, content_intro)?
+        .add_page(&ConfirmFirmwareUpdate::Menu, content_menu)?
+        .add_page(&ConfirmFirmwareUpdate::Fingerprint, content_fingerprint)?
+        .add_page(&ConfirmFirmwareUpdate::Confirm, content_confirm)?;
     Ok(res)
 }

--- a/core/embed/rust/src/ui/layout_delizia/flow/confirm_homescreen.rs
+++ b/core/embed/rust/src/ui/layout_delizia/flow/confirm_homescreen.rs
@@ -84,9 +84,9 @@ pub fn new_confirm_homescreen(
     .with_swipe(Direction::Left, SwipeSettings::default())
     .map(super::util::map_to_confirm);
 
-    let res = SwipeFlow::new(&ConfirmHomescreen::Homescreen)?
-        .with_page(&ConfirmHomescreen::Homescreen, content_homescreen)?
-        .with_page(&ConfirmHomescreen::Menu, content_menu)?
-        .with_page(&ConfirmHomescreen::Confirm, content_confirm)?;
+    let mut res = SwipeFlow::new(&ConfirmHomescreen::Homescreen)?;
+    res.add_page(&ConfirmHomescreen::Homescreen, content_homescreen)?
+        .add_page(&ConfirmHomescreen::Menu, content_menu)?
+        .add_page(&ConfirmHomescreen::Confirm, content_confirm)?;
     Ok(res)
 }

--- a/core/embed/rust/src/ui/layout_delizia/flow/confirm_reset.rs
+++ b/core/embed/rust/src/ui/layout_delizia/flow/confirm_reset.rs
@@ -127,9 +127,10 @@ pub fn new_confirm_reset(recovery: bool) -> Result<SwipeFlow, error::Error> {
     .map(super::util::map_to_choice);
 
     let res = if recovery {
-        SwipeFlow::new(&ConfirmResetRecover::Intro)?
-            .with_page(&ConfirmResetRecover::Intro, content_intro)?
-            .with_page(&ConfirmResetRecover::Menu, content_menu)?
+        let mut res = SwipeFlow::new(&ConfirmResetRecover::Intro)?;
+        res.add_page(&ConfirmResetRecover::Intro, content_intro)?
+            .add_page(&ConfirmResetRecover::Menu, content_menu)?;
+        res
     } else {
         let content_confirm = Frame::left_aligned(
             TR::reset__title_create_wallet.into(),
@@ -142,10 +143,11 @@ pub fn new_confirm_reset(recovery: bool) -> Result<SwipeFlow, error::Error> {
         .map(super::util::map_to_confirm)
         .one_button_request(ButtonRequestCode::ResetDevice.with_name("confirm_setup_device"));
 
-        SwipeFlow::new(&ConfirmResetCreate::Intro)?
-            .with_page(&ConfirmResetCreate::Intro, content_intro)?
-            .with_page(&ConfirmResetCreate::Menu, content_menu)?
-            .with_page(&ConfirmResetCreate::Confirm, content_confirm)?
+        let mut res = SwipeFlow::new(&ConfirmResetCreate::Intro)?;
+        res.add_page(&ConfirmResetCreate::Intro, content_intro)?
+            .add_page(&ConfirmResetCreate::Menu, content_menu)?
+            .add_page(&ConfirmResetCreate::Confirm, content_confirm)?;
+        res
     };
     Ok(res)
 }

--- a/core/embed/rust/src/ui/layout_delizia/flow/confirm_set_new_pin.rs
+++ b/core/embed/rust/src/ui/layout_delizia/flow/confirm_set_new_pin.rs
@@ -104,10 +104,10 @@ pub fn new_set_new_pin(
     .with_swipe(Direction::Right, SwipeSettings::immediate())
     .map(super::util::map_to_confirm);
 
-    let res = SwipeFlow::new(&SetNewPin::Intro)?
-        .with_page(&SetNewPin::Intro, content_intro)?
-        .with_page(&SetNewPin::Menu, content_menu)?
-        .with_page(&SetNewPin::CancelPinIntro, content_cancel_intro)?
-        .with_page(&SetNewPin::CancelPinConfirm, content_cancel_confirm)?;
+    let mut res = SwipeFlow::new(&SetNewPin::Intro)?;
+    res.add_page(&SetNewPin::Intro, content_intro)?
+        .add_page(&SetNewPin::Menu, content_menu)?
+        .add_page(&SetNewPin::CancelPinIntro, content_cancel_intro)?
+        .add_page(&SetNewPin::CancelPinConfirm, content_cancel_confirm)?;
     Ok(res)
 }

--- a/core/embed/rust/src/ui/layout_delizia/flow/confirm_summary.rs
+++ b/core/embed/rust/src/ui/layout_delizia/flow/confirm_summary.rs
@@ -150,21 +150,21 @@ pub fn new_confirm_summary(
     .with_swipe(Direction::Right, SwipeSettings::immediate())
     .map(super::util::map_to_confirm);
 
-    let mut res = SwipeFlow::new(&ConfirmSummary::Summary)?
-        .with_page(&ConfirmSummary::Summary, content_summary)?
-        .with_page(&ConfirmSummary::Hold, content_hold)?
-        .with_page(&ConfirmSummary::Menu, content_menu)?;
+    let mut res = SwipeFlow::new(&ConfirmSummary::Summary)?;
+    res.add_page(&ConfirmSummary::Summary, content_summary)?
+        .add_page(&ConfirmSummary::Hold, content_hold)?
+        .add_page(&ConfirmSummary::Menu, content_menu)?;
     if let Some(content_extra) = content_extra {
-        res = res.with_page(&ConfirmSummary::ExtraInfo, content_extra)?
+        res.add_page(&ConfirmSummary::ExtraInfo, content_extra)?;
     } else {
-        res = res.with_page(&ConfirmSummary::ExtraInfo, dummy_page())?
+        res.add_page(&ConfirmSummary::ExtraInfo, dummy_page())?;
     };
     if let Some(content_account) = content_account {
-        res = res.with_page(&ConfirmSummary::AccountInfo, content_account)?
+        res.add_page(&ConfirmSummary::AccountInfo, content_account)?;
     } else {
-        res = res.with_page(&ConfirmSummary::AccountInfo, dummy_page())?
+        res.add_page(&ConfirmSummary::AccountInfo, dummy_page())?;
     };
-    res = res.with_page(&ConfirmSummary::CancelTap, content_cancel_tap)?;
+    res.add_page(&ConfirmSummary::CancelTap, content_cancel_tap)?;
 
     Ok(res)
 }

--- a/core/embed/rust/src/ui/layout_delizia/flow/continue_recovery_homepage.rs
+++ b/core/embed/rust/src/ui/layout_delizia/flow/continue_recovery_homepage.rs
@@ -232,9 +232,10 @@ pub fn new_continue_recovery_homepage(
         .with_swipe(Direction::Right, SwipeSettings::immediate())
         .map(super::util::map_to_choice);
 
-        SwipeFlow::new(&ContinueRecoveryBeforeShares::Main)?
-            .with_page(&ContinueRecoveryBeforeShares::Main, content_main)?
-            .with_page(&ContinueRecoveryBeforeShares::Menu, content_menu)?
+        let mut res = SwipeFlow::new(&ContinueRecoveryBeforeShares::Main)?;
+        res.add_page(&ContinueRecoveryBeforeShares::Main, content_main)?
+            .add_page(&ContinueRecoveryBeforeShares::Menu, content_menu)?;
+        res
     } else if pages.is_none() {
         let content_menu = Frame::left_aligned(
             TString::empty(),
@@ -244,17 +245,18 @@ pub fn new_continue_recovery_homepage(
         .with_swipe(Direction::Right, SwipeSettings::immediate())
         .map(super::util::map_to_choice);
 
-        SwipeFlow::new(&ContinueRecoveryBetweenShares::Main)?
-            .with_page(&ContinueRecoveryBetweenShares::Main, content_main)?
-            .with_page(&ContinueRecoveryBetweenShares::Menu, content_menu)?
-            .with_page(
+        let mut res = SwipeFlow::new(&ContinueRecoveryBetweenShares::Main)?;
+        res.add_page(&ContinueRecoveryBetweenShares::Main, content_main)?
+            .add_page(&ContinueRecoveryBetweenShares::Menu, content_menu)?
+            .add_page(
                 &ContinueRecoveryBetweenShares::CancelIntro,
                 content_cancel_intro,
             )?
-            .with_page(
+            .add_page(
                 &ContinueRecoveryBetweenShares::CancelConfirm,
                 content_cancel_confirm,
-            )?
+            )?;
+        res
     } else {
         let content_menu = Frame::left_aligned(
             TString::empty(),
@@ -296,21 +298,22 @@ pub fn new_continue_recovery_homepage(
         ))
         .with_pages(move |_| n_remaining_shares);
 
-        SwipeFlow::new(&ContinueRecoveryBetweenSharesAdvanced::Main)?
-            .with_page(&ContinueRecoveryBetweenSharesAdvanced::Main, content_main)?
-            .with_page(&ContinueRecoveryBetweenSharesAdvanced::Menu, content_menu)?
-            .with_page(
+        let mut res = SwipeFlow::new(&ContinueRecoveryBetweenSharesAdvanced::Main)?;
+        res.add_page(&ContinueRecoveryBetweenSharesAdvanced::Main, content_main)?
+            .add_page(&ContinueRecoveryBetweenSharesAdvanced::Menu, content_menu)?
+            .add_page(
                 &ContinueRecoveryBetweenSharesAdvanced::CancelIntro,
                 content_cancel_intro,
             )?
-            .with_page(
+            .add_page(
                 &ContinueRecoveryBetweenSharesAdvanced::CancelConfirm,
                 content_cancel_confirm,
             )?
-            .with_page(
+            .add_page(
                 &ContinueRecoveryBetweenSharesAdvanced::RemainingShares,
                 content_remaining_shares,
-            )?
+            )?;
+        res
     };
     Ok(res)
 }

--- a/core/embed/rust/src/ui/layout_delizia/flow/get_address.rs
+++ b/core/embed/rust/src/ui/layout_delizia/flow/get_address.rs
@@ -197,14 +197,14 @@ pub fn new_get_address(
     .with_swipe(Direction::Right, SwipeSettings::immediate())
     .map(super::util::map_to_confirm);
 
-    let res = SwipeFlow::new(&GetAddress::Address)?
-        .with_page(&GetAddress::Address, content_address)?
-        .with_page(&GetAddress::Tap, content_tap)?
-        .with_page(&GetAddress::Confirmed, content_confirmed)?
-        .with_page(&GetAddress::Menu, content_menu)?
-        .with_page(&GetAddress::QrCode, content_qr)?
-        .with_page(&GetAddress::AccountInfo, content_account)?
-        .with_page(&GetAddress::Cancel, content_cancel_info)?
-        .with_page(&GetAddress::CancelTap, content_cancel_tap)?;
+    let mut res = SwipeFlow::new(&GetAddress::Address)?;
+    res.add_page(&GetAddress::Address, content_address)?
+        .add_page(&GetAddress::Tap, content_tap)?
+        .add_page(&GetAddress::Confirmed, content_confirmed)?
+        .add_page(&GetAddress::Menu, content_menu)?
+        .add_page(&GetAddress::QrCode, content_qr)?
+        .add_page(&GetAddress::AccountInfo, content_account)?
+        .add_page(&GetAddress::Cancel, content_cancel_info)?
+        .add_page(&GetAddress::CancelTap, content_cancel_tap)?;
     Ok(res)
 }

--- a/core/embed/rust/src/ui/layout_delizia/flow/prompt_backup.rs
+++ b/core/embed/rust/src/ui/layout_delizia/flow/prompt_backup.rs
@@ -107,10 +107,10 @@ pub fn new_prompt_backup() -> Result<SwipeFlow, error::Error> {
     .with_swipe(Direction::Right, SwipeSettings::immediate())
     .map(super::util::map_to_confirm);
 
-    let res = SwipeFlow::new(&PromptBackup::Intro)?
-        .with_page(&PromptBackup::Intro, content_intro)?
-        .with_page(&PromptBackup::Menu, content_menu)?
-        .with_page(&PromptBackup::SkipBackupIntro, content_skip_intro)?
-        .with_page(&PromptBackup::SkipBackupConfirm, content_skip_confirm)?;
+    let mut res = SwipeFlow::new(&PromptBackup::Intro)?;
+    res.add_page(&PromptBackup::Intro, content_intro)?
+        .add_page(&PromptBackup::Menu, content_menu)?
+        .add_page(&PromptBackup::SkipBackupIntro, content_skip_intro)?
+        .add_page(&PromptBackup::SkipBackupConfirm, content_skip_confirm)?;
     Ok(res)
 }

--- a/core/embed/rust/src/ui/layout_delizia/flow/request_number.rs
+++ b/core/embed/rust/src/ui/layout_delizia/flow/request_number.rs
@@ -105,9 +105,9 @@ pub fn new_request_number(
         .with_swipe(Direction::Right, SwipeSettings::immediate())
         .map_to_button_msg();
 
-    let res = SwipeFlow::new(&RequestNumber::Number)?
-        .with_page(&RequestNumber::Number, content_number_input)?
-        .with_page(&RequestNumber::Menu, content_menu)?
-        .with_page(&RequestNumber::Info, content_info)?;
+    let mut res = SwipeFlow::new(&RequestNumber::Number)?;
+    res.add_page(&RequestNumber::Number, content_number_input)?
+        .add_page(&RequestNumber::Menu, content_menu)?
+        .add_page(&RequestNumber::Info, content_info)?;
     Ok(res)
 }

--- a/core/embed/rust/src/ui/layout_delizia/flow/request_passphrase.rs
+++ b/core/embed/rust/src/ui/layout_delizia/flow/request_passphrase.rs
@@ -61,8 +61,8 @@ pub fn new_request_passphrase() -> Result<SwipeFlow, error::Error> {
         PassphraseKeyboardMsg::Cancelled => Some(FlowMsg::Cancelled),
     });
 
-    let res = SwipeFlow::new(&RequestPassphrase::Keypad)?
-        .with_page(&RequestPassphrase::Keypad, content_keypad)?
-        .with_page(&RequestPassphrase::ConfirmEmpty, content_confirm_empty)?;
+    let mut res = SwipeFlow::new(&RequestPassphrase::Keypad)?;
+    res.add_page(&RequestPassphrase::Keypad, content_keypad)?
+        .add_page(&RequestPassphrase::ConfirmEmpty, content_confirm_empty)?;
     Ok(res)
 }

--- a/core/embed/rust/src/ui/layout_delizia/flow/set_brightness.rs
+++ b/core/embed/rust/src/ui/layout_delizia/flow/set_brightness.rs
@@ -119,11 +119,11 @@ pub fn new_set_brightness(brightness: Option<u8>) -> Result<SwipeFlow, Error> {
     .with_result_icon(theme::ICON_BULLET_CHECKMARK, theme::GREEN_LIGHT)
     .map(move |_msg| Some(FlowMsg::Confirmed));
 
-    let res = SwipeFlow::new(&SetBrightness::Slider)?
-        .with_page(&SetBrightness::Slider, content_slider)?
-        .with_page(&SetBrightness::Menu, content_menu)?
-        .with_page(&SetBrightness::Confirm, content_confirm)?
-        .with_page(&SetBrightness::Confirmed, content_confirmed)?;
+    let mut res = SwipeFlow::new(&SetBrightness::Slider)?;
+    res.add_page(&SetBrightness::Slider, content_slider)?
+        .add_page(&SetBrightness::Menu, content_menu)?
+        .add_page(&SetBrightness::Confirm, content_confirm)?
+        .add_page(&SetBrightness::Confirmed, content_confirmed)?;
 
     Ok(res)
 }

--- a/core/embed/rust/src/ui/layout_delizia/flow/show_danger.rs
+++ b/core/embed/rust/src/ui/layout_delizia/flow/show_danger.rs
@@ -101,9 +101,9 @@ pub fn new_show_danger(
     .with_result_icon(theme::ICON_BULLET_CHECKMARK, theme::GREY_DARK)
     .map(|_| Some(FlowMsg::Cancelled));
 
-    let res = SwipeFlow::new(&ShowDanger::Message)?
-        .with_page(&ShowDanger::Message, content_message)?
-        .with_page(&ShowDanger::Menu, content_menu)?
-        .with_page(&ShowDanger::Cancelled, content_cancelled)?;
+    let mut res = SwipeFlow::new(&ShowDanger::Message)?;
+    res.add_page(&ShowDanger::Message, content_message)?
+        .add_page(&ShowDanger::Menu, content_menu)?
+        .add_page(&ShowDanger::Cancelled, content_cancelled)?;
     Ok(res)
 }

--- a/core/embed/rust/src/ui/layout_delizia/flow/show_share_words.rs
+++ b/core/embed/rust/src/ui/layout_delizia/flow/show_share_words.rs
@@ -132,11 +132,11 @@ pub fn new_show_share_words(
     .with_swipeup_footer(None)
     .map(|_| Some(FlowMsg::Confirmed));
 
-    let res = SwipeFlow::new(&ShowShareWords::Instruction)?
-        .with_page(&ShowShareWords::Instruction, content_instruction)?
-        .with_page(&ShowShareWords::Words, content_words)?
-        .with_page(&ShowShareWords::Confirm, content_confirm)?
-        .with_page(
+    let mut res = SwipeFlow::new(&ShowShareWords::Instruction)?;
+    res.add_page(&ShowShareWords::Instruction, content_instruction)?
+        .add_page(&ShowShareWords::Words, content_words)?
+        .add_page(&ShowShareWords::Confirm, content_confirm)?
+        .add_page(
             &ShowShareWords::CheckBackupIntro,
             content_check_backup_intro,
         )?;

--- a/core/embed/rust/src/ui/layout_delizia/flow/show_tutorial.rs
+++ b/core/embed/rust/src/ui/layout_delizia/flow/show_tutorial.rs
@@ -163,15 +163,15 @@ pub fn new_show_tutorial() -> Result<SwipeFlow, error::Error> {
     .with_swipe(Direction::Down, SwipeSettings::default())
     .map(super::util::map_to_confirm);
 
-    let res = SwipeFlow::new(&ShowTutorial::StepWelcome)?
-        .with_page(&ShowTutorial::StepWelcome, content_step_welcome)?
-        .with_page(&ShowTutorial::StepBegin, content_step_begin)?
-        .with_page(&ShowTutorial::StepNavigation, content_step_navigation)?
-        .with_page(&ShowTutorial::StepMenu, content_step_menu)?
-        .with_page(&ShowTutorial::StepHold, content_step_hold)?
-        .with_page(&ShowTutorial::StepDone, content_step_done)?
-        .with_page(&ShowTutorial::Menu, content_menu)?
-        .with_page(&ShowTutorial::DidYouKnow, content_did_you_know)?
-        .with_page(&ShowTutorial::HoldToExit, content_hold_to_exit)?;
+    let mut res = SwipeFlow::new(&ShowTutorial::StepWelcome)?;
+    res.add_page(&ShowTutorial::StepWelcome, content_step_welcome)?
+        .add_page(&ShowTutorial::StepBegin, content_step_begin)?
+        .add_page(&ShowTutorial::StepNavigation, content_step_navigation)?
+        .add_page(&ShowTutorial::StepMenu, content_step_menu)?
+        .add_page(&ShowTutorial::StepHold, content_step_hold)?
+        .add_page(&ShowTutorial::StepDone, content_step_done)?
+        .add_page(&ShowTutorial::Menu, content_menu)?
+        .add_page(&ShowTutorial::DidYouKnow, content_did_you_know)?
+        .add_page(&ShowTutorial::HoldToExit, content_hold_to_exit)?;
     Ok(res)
 }


### PR DESCRIPTION
Following https://github.com/trezor/trezor-firmware/pull/4696 (used to reduce `new_flow_confirm_output` stack size):

## Before
```
$ git lg -1
* 587b5e8eb tychovrahe:  (HEAD -> main, origin/main, origin/HEAD) fix(core): fix jump to old bootloader (3 days ago)

$ TREZOR_MODEL=T3T1 make -C core build_firmware; python ~/tmp/stack_sizes.py | sort -k1 -n | tail
...
7256	trezor_lib::ui::api::firmware_micropython::new_show_checklist
7440	trezor_lib::ui::api::firmware_micropython::new_flow_confirm_set_new_pin
7440	trezor_lib::ui::api::firmware_micropython::new_prompt_backup
7512	trezor_lib::ui::api::firmware_micropython::new_show_share_words_delizia
9224	trezor_lib::ui::api::firmware_micropython::new_confirm_fido
13176	trezor_lib::ui::api::firmware_micropython::new_tutorial
14096	trezor_lib::ui::api::firmware_micropython::new_continue_recovery_homepage
14144	trezor_lib::ui::api::firmware_micropython::new_flow_get_address
15792	trezor_lib::ui::api::firmware_micropython::new_confirm_summary
18096	trezor_lib::ui::api::firmware_micropython::new_flow_confirm_output
```

## After
```
$ git lg -1
* 7a0008064 Roman Zeyde:  (HEAD -> romanz/page-builder) feat(core): use `SwipeFlow::add_page` to reduce stack usage (13 minutes ago)

$ TREZOR_MODEL=T3T1 make -C core build_firmware; python ~/tmp/stack_sizes.py | sort -k1 -n | tail
...
5768	trezor_lib::ui::api::firmware_micropython::new_flow_confirm_set_new_pin
5768	trezor_lib::ui::api::firmware_micropython::new_prompt_backup
6696	trezor_lib::ui::api::firmware_micropython::new_show_share_words_delizia
7256	trezor_lib::ui::api::firmware_micropython::new_show_checklist
7616	trezor_lib::ui::api::firmware_micropython::new_confirm_fido
9112	trezor_lib::ui::api::firmware_micropython::new_tutorial
10704	trezor_lib::ui::api::firmware_micropython::new_continue_recovery_homepage
11800	trezor_lib::ui::api::firmware_micropython::new_flow_get_address
14744	trezor_lib::ui::api::firmware_micropython::new_confirm_summary
18096	trezor_lib::ui::api::firmware_micropython::new_flow_confirm_output
```

<!--
For core developers:
- Assign yourself to the PR.
- Set the priority to match the original issue.
- Add the PR to the current sprint.
- If it's a draft PR, mark it as "In Progress."
- If it's a final PR, mark it as "Needs Review."

For external contributors:
- Please open an issue before submitting a PR so we can discuss whether we want to proceed with it.
-->
