### PR TITLE
feat(core): double glyphs on t3w1 terminal

### DIFF
--- a/core/site_scons/models/T3W1/trezor_t3w1_revA.py
+++ b/core/site_scons/models/T3W1/trezor_t3w1_revA.py
@@ -37,6 +37,9 @@ def configure(
         ("HSE_VALUE", "32000000"),
         ("USE_HSE", "1"),
         ("FIXED_HW_DEINIT", "1"),
+        ("TERMINAL_FONT_SCALE", "2"),
+        ("TERMINAL_X_PADDING", "4"),
+        ("TERMINAL_Y_PADDING", "12"),
     ]
 
     sources += [

--- a/core/site_scons/models/T3W1/trezor_t3w1_revB.py
+++ b/core/site_scons/models/T3W1/trezor_t3w1_revB.py
@@ -37,6 +37,9 @@ def configure(
         ("HSE_VALUE", "32000000"),
         ("USE_HSE", "1"),
         ("FIXED_HW_DEINIT", "1"),
+        ("TERMINAL_FONT_SCALE", "2"),
+        ("TERMINAL_X_PADDING", "4"),
+        ("TERMINAL_Y_PADDING", "12"),
     ]
 
     sources += [


### PR DESCRIPTION
This PR improves the readability of text on the terminal on T3W1 by doubling the character width and height and adding a small Y offset.

The terminal window size on T3W1 is now 31x31 characters, which seems sufficient for RSOD purposes.

On other models, the terminal screen remains unchanged.