### PR TITLE
Bump Nordic Connect SDK to 2.9.0

### DIFF
--- a/nordic/trezor/README.md
+++ b/nordic/trezor/README.md
@@ -31,21 +31,22 @@ Follow these steps to set up the project on your local machine.
 
 Using nrfutil, install the required toolchain for the nRF Connect SDK:
 ```sh
-nrfutil toolchain-manager install --ncs-version v2.6.2
+nrfutil toolchain-manager install --ncs-version v2.9.0
 ```
 
 ### Launch the nRF Shell
 
-First, launch the nRF shell using the `nrfutil` toolchain manager:
+First, launch the nRF shell using the `nrfutil` toolchain manager and set the NCS to chosen version:
 
 ```sh
 nrfutil toolchain-manager launch --shell
+west init -m https://github.com/nrfconnect/sdk-nrf --mr v2.9.0 v2.9.0
 ```
 
 ### Initialize the Workspace
 Initialize your West workspace for the Trezor BLE Gateway project:
 ```sh
-cd west
+cd nordic
 west init -l ./trezor
 ```
 

--- a/nordic/trezor/README.md
+++ b/nordic/trezor/README.md
@@ -40,7 +40,6 @@ First, launch the nRF shell using the `nrfutil` toolchain manager and set the NC
 
 ```sh
 nrfutil toolchain-manager launch --shell
-west init -m https://github.com/nrfconnect/sdk-nrf --mr v2.9.0 v2.9.0
 ```
 
 ### Initialize the Workspace
@@ -63,6 +62,8 @@ west update
 cd trezor
 west build ./trezor-ble -b t3w1_revA_nrf52832 --sysbuild
 ```
+
+When building for first time, add `--pristine=always` so that NCS versions and their cached files don't mix and fubar each other.
 
 Debug builds can be built using the debug overlay configuration:
 Build the application for the t3w1_revA_nrf52832 board:

--- a/nordic/trezor/boards/arm/t3w1_d1_nrf52833/t3w1_d1_nrf52833.dts
+++ b/nordic/trezor/boards/arm/t3w1_d1_nrf52833/t3w1_d1_nrf52833.dts
@@ -23,6 +23,7 @@
 		zephyr,flash = &flash0;
 		zephyr,code-partition = &slot0_partition;
 		zephyr,ieee802154 = &ieee802154;
+                zephyr,bt-hci = &bt_hci_controller;
 	};
 
 	leds {
@@ -65,6 +66,14 @@
 		mcuboot-led0 = &led0;
 		watchdog0 = &wdt0;
 	};
+};
+
+&bt_hci_sdc {
+    status = "disabled";
+};
+
+&bt_hci_controller {
+    status = "okay";
 };
 
 &adc {

--- a/nordic/trezor/boards/arm/t3w1_revA_nrf52832/t3w1_revA_nrf52832.dts
+++ b/nordic/trezor/boards/arm/t3w1_revA_nrf52832/t3w1_revA_nrf52832.dts
@@ -22,6 +22,7 @@
 		zephyr,sram = &sram0;
 		zephyr,flash = &flash0;
 		zephyr,code-partition = &slot0_partition;
+                zephyr,bt-hci = &bt_hci_controller;
 	};
 
 	leds {
@@ -59,6 +60,14 @@
 		mcuboot-button0 = &button0;
 		watchdog0 = &wdt0;
 	};
+};
+
+&bt_hci_sdc {
+    status = "disabled";
+};
+
+&bt_hci_controller {
+    status = "okay";
 };
 
 &adc {

--- a/nordic/trezor/west.yml
+++ b/nordic/trezor/west.yml
@@ -13,5 +13,12 @@ manifest:
     - name: nrf
       remote: ncs
       repo-path: sdk-nrf
-      revision: v2.7.0
+      revision: v2.9.0
       import: true
+
+# Temporarily disable mcuboot fork until it's ready
+#    - name: mcuboot
+#      url: https://github.com/trezor/mcuboot
+#      revision: v2.1.0-ncs3
+#      path: bootloader/mcuboot
+


### PR DESCRIPTION
Bump nRF build to latest Nordic Connect SDK to 2.9.0. Fixes build/linker errors caused by changes in NCS (BLE controller settings).
