### PR TITLE
test(core): decrease single test timeout for HW devices to 10 minutes

### DIFF
--- a/.github/workflows/core-hw.yml
+++ b/.github/workflows/core-hw.yml
@@ -34,12 +34,12 @@ jobs:
       TREZOR_MODEL: ${{ matrix.model }}
       BITCOIN_ONLY: ${{ matrix.coins == 'btconly' && '1' || '0' }}
       TREZOR_PYTEST_SKIP_ALTCOINS: ${{ matrix.coins == 'btconly' && '1' || '0' }}
-      PYTEST_TIMEOUT: 1200  # 20m single test timeout
+      PYTEST_TIMEOUT: 600  # 10m single test timeout
       PYOPT: 0
       DISABLE_OPTIGA: 1
       STORAGE_INSECURE_TESTING_MODE: 1
       BOOTLOADER_DEVEL: ${{ matrix.model == 'T2B1' && '1' || '0' }}
-      TESTOPTS: "-k 'not authenticate and not recovery and not lots' --session-timeout 19800"  # 5.5h pytest global timeout
+      TESTOPTS: "-k 'not authenticate and not recovery and not lots' --durations=50 --session-timeout 19800"  # 5.5h pytest global timeout
       TT_UHUB_PORT: 1
     timeout-minutes: 360  # 6h CI job timeout
     steps:


### PR DESCRIPTION
Also, print [the slowest 50 test durations](https://docs.pytest.org/en/latest/how-to/usage.html#profiling-test-execution-duration).

When analyzing the latest T2B1 CI run, the longest successful test took <5 minutes:
https://github.com/trezor/trezor-firmware/actions/runs/13687527271/job/38274226159

![image](https://github.com/user-attachments/assets/de2e1d57-ca8b-4976-ad01-b46021ebca54)

[tests.ods](https://github.com/user-attachments/files/19113891/tests.ods)
