### PR TITLE
chore(python): use `pytest-rerunfailures` instead of `flaky`

### DIFF
--- a/poetry.lock
+++ b/poetry.lock
@@ -550,17 +550,6 @@ tomli = {version = ">=1.2.1", markers = "python_version < \"3.11\""}
 pyproject = ["Flake8-pyproject"]
 
 [[package]]
-name = "flaky"
-version = "3.8.1"
-description = "Plugin for pytest that automatically reruns flaky tests."
-optional = false
-python-versions = ">=3.5"
-files = [
-    {file = "flaky-3.8.1-py2.py3-none-any.whl", hash = "sha256:194ccf4f0d3a22b2de7130f4b62e45e977ac1b5ccad74d4d48f3005dcc38815e"},
-    {file = "flaky-3.8.1.tar.gz", hash = "sha256:47204a81ec905f3d5acfbd61daeabcada8f9d4031616d9bcb0618461729699f5"},
-]
-
-[[package]]
 name = "graphviz"
 version = "0.19.1"
 description = "Simple Python interface for Graphviz"
@@ -1295,6 +1284,21 @@ files = [
 pytest = ">=3.0.0"
 
 [[package]]
+name = "pytest-rerunfailures"
+version = "15.0"
+description = "pytest plugin to re-run tests to eliminate flaky failures"
+optional = false
+python-versions = ">=3.9"
+files = [
+    {file = "pytest-rerunfailures-15.0.tar.gz", hash = "sha256:2d9ac7baf59f4c13ac730b47f6fa80e755d1ba0581da45ce30b72fb3542b4474"},
+    {file = "pytest_rerunfailures-15.0-py3-none-any.whl", hash = "sha256:dd150c4795c229ef44320adc9a0c0532c51b78bb7a6843a8c53556b9a611df1a"},
+]
+
+[package.dependencies]
+packaging = ">=17.1"
+pytest = ">=7.4,<8.2.2 || >8.2.2"
+
+[[package]]
 name = "pytest-timeout"
 version = "2.3.1"
 description = "pytest plugin to abort hanging tests"
@@ -1916,4 +1920,4 @@ test = ["big-O", "jaraco.functools", "jaraco.itertools", "jaraco.test", "more-it
 [metadata]
 lock-version = "2.0"
 python-versions = "^3.9"
-content-hash = "1257cb4cd905c3a00c46535ffa5767cf7bc5af0ac33b80f0adbd5776a8c49d31"
+content-hash = "c1e9b094e97f629a43034cf7d81051443b2345af342db123b0e5038845dc9c03"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -15,7 +15,6 @@ nanopb = "^0.4.3"
 ## test tools
 pytest = "^8"
 coverage = "<5"  # coverage 5+ uses binary sqlite format
-flaky = ">3.6.1"  # https://github.com/box/flaky/issues/156
 pytest-ordering = "*"
 pytest-random-order = "*"
 pytest-timeout = "*"
@@ -77,6 +76,7 @@ trezor-pylint-plugin = {path = "./tools/trezor-pylint-plugin", develop = true}
 trezor-core-tools = {path = "./core/tools", develop = true}
 flake8-annotations = "^3.1.1"
 pyelftools = "^0.32"
+pytest-rerunfailures = "^15.0"
 
 [tool.poetry.dev-dependencies]
 scan-build = "*"

--- a/python/tox.ini
+++ b/python/tox.ini
@@ -26,7 +26,7 @@ commands =
     # Smoke-test trezorctl
     trezorctl --help
     # Run test suite
-    !minimal: pytest --random-order tests
+    !minimal: pytest -c setup.cfg --random-order tests
 
 [testenv:py{38,39,310,311}-click{7,80,81}]
 deps =

--- a/setup.cfg
+++ b/setup.cfg
@@ -36,7 +36,7 @@ per-file-ignores =
     tests/*:ANN
 
 [tool:pytest]
-addopts = -rfE --strict-markers --random-order
+addopts = -rfER --strict-markers --random-order --only-rerun='RuntimeError: Unexpected magic characters: 3f' --reruns=5
 testpaths = tests crypto storage python/tests
 xfail_strict = true
 junit_family = xunit2

--- a/tests/device_tests/test_bip32_speed.py
+++ b/tests/device_tests/test_bip32_speed.py
@@ -25,7 +25,7 @@ from trezorlib.tools import H_
 
 pytestmark = [
     pytest.mark.models("legacy"),
-    pytest.mark.flaky(max_runs=5),
+    pytest.mark.flaky(reruns=5),
 ]
 
 

--- a/tests/device_tests/test_busy_state.py
+++ b/tests/device_tests/test_busy_state.py
@@ -88,7 +88,7 @@ def test_busy_expiry_core(client: Client):
     _assert_busy(client, False)
 
 
-@pytest.mark.flaky(max_runs=5)
+@pytest.mark.flaky(reruns=5)
 @pytest.mark.models("legacy")
 def test_busy_expiry_legacy(client: Client):
     _assert_busy(client, False)


### PR DESCRIPTION
Since it supports re-running all failures that match certain expressions:
https://github.com/pytest-dev/pytest-rerunfailures?tab=readme-ov-file#re-run-all-failures-matching-certain-expressions


<!--
For core developers:
- Assign yourself to the PR.
- Set the priority to match the original issue.
- Add the PR to the current sprint.
- If it's a draft PR, mark it as "In Progress."
- If it's a final PR, mark it as "Needs Review."

For external contributors:
- Please open an issue before submitting a PR so we can discuss whether we want to proceed with it.
-->
