### PR TITLE
fix(core): add kernel access to assets by default

### DIFF
--- a/core/embed/sys/mpu/stm32f4/mpu.c
+++ b/core/embed/sys/mpu/stm32f4/mpu.c
@@ -353,7 +353,10 @@ mpu_mode_t mpu_reconfig(mpu_mode_t mode) {
 
     default:
       DIS_REGION( 5 );
-      DIS_REGION( 6 );
+      // Assets (Privileged, Read-Only, Non-Executable)
+      // Subregion: 32KB = 64KB except 2/8 at start and 2/8 at end
+      // By default, the kernel needs to have the same access to assets as the app
+      SET_REGION( 6, FLASH_BASE + 0x104000, SIZE_64KB, 0xC3, FLASH_DATA, PRIV_RO );
       break;
   }
   // clang-format on

--- a/core/embed/sys/mpu/stm32u5/mpu.c
+++ b/core/embed/sys/mpu/stm32u5/mpu.c
@@ -193,7 +193,7 @@ static inline void mpu_enable(void) {
 }
 
 static void mpu_init_fixed_regions(void) {
-  // Regions #0 to #5 are fixed for all targets
+  // Regions #0 to #4 are fixed for all targets
 
   // clang-format off
 #if defined(BOARDLOADER)
@@ -240,7 +240,7 @@ static void mpu_init_fixed_regions(void) {
   SET_REGION( 4, AUX1_RAM_START,           AUX1_RAM_SIZE,     SRAM,        YES,    NO );
 #endif
 
-  // Regions #6 and #7 are banked
+  // Regions #5 to #7 are banked
 
   DIS_REGION( 5 );
   DIS_REGION( 6 );
@@ -389,7 +389,8 @@ mpu_mode_t mpu_reconfig(mpu_mode_t mode) {
       SET_REGION( 6, BOOTARGS_START,           BOOTARGS_SIZE,      SRAM,        YES,    NO );
       break;
     default:
-      DIS_REGION( 6 );
+      // By default, the kernel needs to have the same access to assets as the app
+      SET_REGION( 6, ASSETS_START,             ASSETS_MAXSIZE,     FLASH_DATA,   NO,    NO );
       break;
   }
   // clang-format on


### PR DESCRIPTION
This PR fixes the MPU configuration for the assets memory area.

The assets memory area is always accessible in read-only mode for unprivileged applications. However, the kernel must use `mpu_reconfig(MPU_MODE_ASSETS)` to gain access. If the application passes references to assets memory via syscalls and the kernel attempts to read from them, an MM fault occurs. 

This issue has manifested since the introduction of DMA2D syscalls. In non-default languages using custom glyphs, the application passes pointers to glyphs in assets memory to the kernel. When glyphs are drawn to unaligned addresses, DMA2D acceleration cannot be used, and the glyphs are drawn manually by the CPU, leading to an MM fault.

The fix is straightforward: the `MPU_MODE_DEFAULT` now includes read-only access to assets memory, ensuring that the kernel has the same access as an unprivileged application. `MPU_MODE_ASSETS` is still used to switch access to read-write.

No changelog entry is required since the bug has not been released yet.