### PR TITLE
build(core): fix `RUST_PRINT_TYPES_SIZES` passing to `SConscript.firmware`

### DIFF
--- a/core/SConscript.bootloader
+++ b/core/SConscript.bootloader
@@ -192,12 +192,13 @@ if UI_DEBUG_OVERLAY:
     features.append('ui_debug_overlay')
 
 rust = tools.add_rust_lib(
-    env,
-    'bootloader',
-    'release',
-    features,
-    ALLPATHS,
-    str(Dir('.').abspath))
+    env=env,
+    build='bootloader',
+    profile='release',
+    features=features,
+    all_paths=ALLPATHS,
+    build_dir=str(Dir('.').abspath),
+)
 
 
 #

--- a/core/SConscript.bootloader_emu
+++ b/core/SConscript.bootloader_emu
@@ -232,12 +232,14 @@ else:
     profile = 'release'
 
 rust = tools.add_rust_lib(
-    env,
-    'bootloader_emu',
-    profile,
-    features,
-    ALLPATHS,
-    str(Dir('.').abspath))
+    env=env,
+    build='bootloader_emu',
+    profile=profile,
+    features=features,
+    all_paths=ALLPATHS,
+    build_dir=str(Dir('.').abspath),
+)
+
 
 env.Append(LINKFLAGS='-lm')
 env.Append(LINKFLAGS='-Wl,' + ('-dead_strip' if env['PLATFORM'] == 'darwin' else '--gc-sections'))

--- a/core/SConscript.firmware
+++ b/core/SConscript.firmware
@@ -22,6 +22,7 @@ BENCHMARK = ARGUMENTS.get('BENCHMARK', '0') == '1'
 LOG_STACK_USAGE=ARGUMENTS.get('LOG_STACK_USAGE', '0') == '1'
 DISABLE_ANIMATION = ARGUMENTS.get('TREZOR_DISABLE_ANIMATION', '0') == '1'
 UI_DEBUG_OVERLAY = ARGUMENTS.get('UI_DEBUG_OVERLAY', '0') == '1'
+RUST_PRINT_TYPES_SIZES = ARGUMENTS.get('RUST_PRINT_TYPES_SIZES', '0') == '1'
 
 STORAGE_INSECURE_TESTING_MODE = ARGUMENTS.get('STORAGE_INSECURE_TESTING_MODE', '0') == '1'
 if STORAGE_INSECURE_TESTING_MODE and PRODUCTION:
@@ -775,12 +776,14 @@ if UI_DEBUG_OVERLAY:
     features.append('ui_debug_overlay')
 
 rust = tools.add_rust_lib(
-    env,
-    'firmware',
-    'release',
-    features,
-    ALLPATHS,
-    str(Dir('.').abspath))
+    env=env,
+    build='firmware',
+    profile='release',
+    features=features,
+    all_paths=ALLPATHS,
+    build_dir=str(Dir('.').abspath),
+    print_types_sizes=RUST_PRINT_TYPES_SIZES,
+)
 
 
 env.Depends(rust, protobuf_blobs)

--- a/core/SConscript.prodtest
+++ b/core/SConscript.prodtest
@@ -221,12 +221,13 @@ if UI_DEBUG_OVERLAY:
 
 
 rust = tools.add_rust_lib(
-    env,
-    'prodtest',
-    'release',
-    features,
-    ALLPATHS,
-    str(Dir('.').abspath))
+    env=env,
+    build='prodtest',
+    profile='release',
+    features=features,
+    all_paths=ALLPATHS,
+    build_dir=str(Dir('.').abspath),
+)
 
 
 if (vh := ARGUMENTS.get("VENDOR_HEADER", None)):

--- a/core/SConscript.unix
+++ b/core/SConscript.unix
@@ -833,12 +833,13 @@ if EVERYTHING:
     features.append('universal_fw')
 
 rust = tools.add_rust_lib(
-    env,
-    'firmware',
-    profile,
-    features,
-    ALLPATHS,
-    str(Dir('.').abspath))
+    env=env,
+    build='unix',
+    profile=profile,
+    features=features,
+    all_paths=ALLPATHS,
+    build_dir=str(Dir('.').abspath),
+)
 
 
 env.Depends(rust, protobuf_blobs)

--- a/core/site_scons/tools.py
+++ b/core/site_scons/tools.py
@@ -129,7 +129,7 @@ def embed_raw_binary(obj_program, env, section, target_, file):
 
 
 def add_rust_lib(
-    env, build, profile, features, all_paths, build_dir, print_types_sizes=False
+    *, env, build, profile, features, all_paths, build_dir, print_types_sizes=False
 ):
     RUST_LIB = "trezor_lib"
     RUST_TARGET = env.get("ENV")["RUST_TARGET"]
@@ -157,21 +157,26 @@ def add_rust_lib(
             "-Z build-std-features=panic_immediate_abort",
         ]
 
+        rustc_flags = []
+
         if print_types_sizes:
             # see https://nnethercote.github.io/perf-book/type-sizes.html#measuring-type-sizes for more details
-            env.Append(ENV={"RUSTFLAGS": "-Z print-type-sizes"})
+            rustc_flags.append("print-type-sizes")
 
         # Adds an ELF section with Rust functions' stack sizes. See the following links for more details:
         # - https://doc.rust-lang.org/nightly/unstable-book/compiler-flags/emit-stack-sizes.html
         # - https://blog.japaric.io/stack-analysis/
         # - https://github.com/japaric/stack-sizes/
-        env.Append(ENV={"RUSTFLAGS": "-Z emit-stack-sizes"})
+        rustc_flags.append("emit-stack-sizes")
+
+        env.Append(ENV={"RUSTFLAGS": " ".join(f"-Z {f}" for f in rustc_flags)})
 
         bindgen_macros = get_bindgen_defines(env.get("CPPDEFINES"), all_paths)
 
         return (
-            f"export BINDGEN_MACROS={shlex.quote(bindgen_macros)}; export BUILD_DIR='{build_dir}'; cd embed/rust; cargo build {profile} "
-            + " ".join(cargo_opts)
+            f"export BINDGEN_MACROS={shlex.quote(bindgen_macros)}; "
+            f"export BUILD_DIR='{build_dir}'; "
+            f"cd embed/rust; cargo build {profile} " + " ".join(cargo_opts)
         )
 
     rust = env.Command(


### PR DESCRIPTION
Use a list to collect RUSTFLAGS, to prevent overwriting them.

Also:
- fix a typo in `SConscript.unix` (it was using `firmware` build directory)
- use keyword arguments for better readability
- reformat Rust library build command string

<!--
For core developers:
- Assign yourself to the PR.
- Set the priority to match the original issue.
- Add the PR to the current sprint.
- If it's a draft PR, mark it as "In Progress."
- If it's a final PR, mark it as "Needs Review."

For external contributors:
- Please open an issue before submitting a PR so we can discuss whether we want to proceed with it.
-->
