### PR TITLE
Fix Delizia request number dialog

### DIFF
--- a/core/.changelog.d/4751.fixed
+++ b/core/.changelog.d/4751.fixed
@@ -1,0 +1,1 @@
+[T3T1] Not being able to tap to continue in request number dialog.

--- a/core/embed/rust/src/ui/layout_delizia/component/number_input.rs
+++ b/core/embed/rust/src/ui/layout_delizia/component/number_input.rs
@@ -5,10 +5,10 @@ use crate::{
         component::{
             paginated::SinglePage,
             text::paragraphs::{Paragraph, Paragraphs},
-            Component, Event, EventCtx, Pad,
+            Component, Event, EventCtx, Never, Pad,
         },
-        event::SwipeEvent,
-        geometry::{Alignment, Direction, Grid, Insets, Offset, Rect},
+        event::TouchEvent,
+        geometry::{Alignment, Grid, Insets, Offset, Rect},
         shape::{self, Renderer},
     },
 };
@@ -16,8 +16,7 @@ use crate::{
 use super::{super::fonts::FONT_DEMIBOLD, theme, Button, ButtonMsg};
 
 pub enum NumberInputDialogMsg {
-    Confirmed(u32),
-    Changed(u32),
+    Changed(u16),
 }
 
 pub struct NumberInputDialog {
@@ -28,7 +27,7 @@ pub struct NumberInputDialog {
 }
 
 impl NumberInputDialog {
-    pub fn new(min: u32, max: u32, init_value: u32, text: TString<'static>) -> Result<Self, Error> {
+    pub fn new(min: u16, max: u16, init_value: u16, text: TString<'static>) -> Result<Self, Error> {
         Ok(Self {
             area: Rect::zero(),
             input: NumberInput::new(min, max, init_value),
@@ -37,7 +36,7 @@ impl NumberInputDialog {
         })
     }
 
-    pub fn value(&self) -> u32 {
+    pub fn value(&self) -> u16 {
         self.input.value
     }
 }
@@ -62,14 +61,16 @@ impl Component for NumberInputDialog {
     }
 
     fn event(&mut self, ctx: &mut EventCtx, event: Event) -> Option<Self::Msg> {
-        if let Some(NumberInputMsg::Changed(i)) = self.input.event(ctx, event) {
-            return Some(NumberInputDialogMsg::Changed(i));
-        }
-
-        if let Event::Swipe(SwipeEvent::End(Direction::Up)) = event {
-            return Some(NumberInputDialogMsg::Confirmed(self.input.value));
-        }
+        self.input.event(ctx, event);
         self.paragraphs.event(ctx, event);
+
+        // Consume all touch events to prevent dialog confirmation if not clicking
+        // directly on the Footer
+        if let Event::Touch(TouchEvent::TouchStart(point)) = event {
+            if self.area.contains(point) {
+                return Some(NumberInputDialogMsg::Changed(self.value()));
+            }
+        }
         None
     }
 
@@ -91,21 +92,17 @@ impl crate::trace::Trace for NumberInputDialog {
     }
 }
 
-pub enum NumberInputMsg {
-    Changed(u32),
-}
-
 pub struct NumberInput {
     area: Rect,
     dec: Button,
     inc: Button,
-    min: u32,
-    max: u32,
-    value: u32,
+    min: u16,
+    max: u16,
+    value: u16,
 }
 
 impl NumberInput {
-    pub fn new(min: u32, max: u32, value: u32) -> Self {
+    pub fn new(min: u16, max: u16, value: u16) -> Self {
         let dec = Button::with_icon(theme::ICON_MINUS).styled(theme::button_counter());
         let inc = Button::with_icon(theme::ICON_PLUS).styled(theme::button_counter());
         let value = value.clamp(min, max);
@@ -118,10 +115,16 @@ impl NumberInput {
             value,
         }
     }
+
+    fn update_button_states(&mut self, ctx: &mut EventCtx) {
+        self.dec.enable_if(ctx, self.value > self.min);
+        self.inc.enable_if(ctx, self.value < self.max);
+        ctx.request_paint();
+    }
 }
 
 impl Component for NumberInput {
-    type Msg = NumberInputMsg;
+    type Msg = Never;
 
     fn place(&mut self, bounds: Rect) -> Rect {
         let grid = Grid::new(bounds, 1, 3).with_spacing(theme::KEYBOARD_SPACING);
@@ -132,21 +135,15 @@ impl Component for NumberInput {
     }
 
     fn event(&mut self, ctx: &mut EventCtx, event: Event) -> Option<Self::Msg> {
-        let mut changed = false;
         if let Some(ButtonMsg::Clicked) = self.dec.event(ctx, event) {
             self.value = self.min.max(self.value.saturating_sub(1));
-            changed = true;
+            self.update_button_states(ctx);
         };
         if let Some(ButtonMsg::Clicked) = self.inc.event(ctx, event) {
             self.value = self.max.min(self.value.saturating_add(1));
-            changed = true;
+            self.update_button_states(ctx);
         };
-        if changed {
-            self.dec.enable_if(ctx, self.value > self.min);
-            self.inc.enable_if(ctx, self.value < self.max);
-            ctx.request_paint();
-            return Some(NumberInputMsg::Changed(self.value));
-        }
+
         None
     }
 

--- a/core/embed/rust/src/ui/layout_delizia/component/number_input_slider.rs
+++ b/core/embed/rust/src/ui/layout_delizia/component/number_input_slider.rs
@@ -17,9 +17,6 @@ pub enum NumberInputSliderDialogMsg {
 pub struct NumberInputSliderDialog {
     area: Rect,
     input: NumberInputSlider,
-    min: u16,
-    max: u16,
-    val: u16,
     init_val: u16,
 }
 
@@ -28,9 +25,6 @@ impl NumberInputSliderDialog {
         Self {
             area: Rect::zero(),
             input: NumberInputSlider::new(min, max, init_value),
-            min,
-            max,
-            val: init_value,
             init_val: init_value,
         }
     }
@@ -73,11 +67,7 @@ impl Component for NumberInputSliderDialog {
 
     fn event(&mut self, ctx: &mut EventCtx, event: Event) -> Option<Self::Msg> {
         let msg_opt = self.input.event(ctx, event);
-
-        msg_opt.map(|value| {
-            self.val = value;
-            Self::Msg::Changed(value)
-        })
+        msg_opt.map(Self::Msg::Changed)
     }
 
     fn render<'s>(&'s self, target: &mut impl Renderer<'s>) {

--- a/core/embed/rust/src/ui/layout_delizia/flow/request_number.rs
+++ b/core/embed/rust/src/ui/layout_delizia/flow/request_number.rs
@@ -38,6 +38,9 @@ impl FlowController for RequestNumber {
     fn handle_swipe(&'static self, direction: Direction) -> Decision {
         match (self, direction) {
             (Self::Number, Direction::Left) => Self::Menu.swipe(direction),
+            (Self::Number, Direction::Up) => self.return_msg(FlowMsg::Choice(
+                NUM_DISPLAYED.load(Ordering::Relaxed).into(),
+            )),
             (Self::Menu, Direction::Right) => Self::Number.swipe(direction),
             (Self::Info, Direction::Right) => Self::Menu.swipe(direction),
             _ => self.do_nothing(),
@@ -50,7 +53,6 @@ impl FlowController for RequestNumber {
             (Self::Menu, FlowMsg::Choice(0)) => Self::Info.swipe_left(),
             (Self::Menu, FlowMsg::Cancelled) => Self::Number.swipe_right(),
             (Self::Info, FlowMsg::Cancelled) => Self::Menu.goto(),
-            (Self::Number, FlowMsg::Choice(n)) => self.return_msg(FlowMsg::Choice(n)),
             _ => self.do_nothing(),
         }
     }
@@ -75,19 +77,20 @@ pub fn new_request_number(
         info_closure(curr_number as u32)
     };
 
-    let number_input_dialog = NumberInputDialog::new(min_count, max_count, count, description)?;
+    let number_input_dialog = NumberInputDialog::new(
+        min_count as u16,
+        max_count as u16,
+        count as u16,
+        description,
+    )?;
     let content_number_input = Frame::left_aligned(title, SwipeContent::new(number_input_dialog))
         .with_menu_button()
         .with_swipeup_footer(None)
         .with_swipe(Direction::Left, SwipeSettings::default())
         .map(|msg| match msg {
             NumberInputDialogMsg::Changed(n) => {
-                NUM_DISPLAYED.store(n as u16, Ordering::Relaxed);
+                NUM_DISPLAYED.store(n, Ordering::Relaxed);
                 None
-            }
-            NumberInputDialogMsg::Confirmed(n) => {
-                NUM_DISPLAYED.store(n as u16, Ordering::Relaxed);
-                Some(FlowMsg::Choice(n as usize))
             }
         });
 

--- a/core/embed/rust/src/ui/layout_delizia/flow/set_brightness.rs
+++ b/core/embed/rust/src/ui/layout_delizia/flow/set_brightness.rs
@@ -12,14 +12,13 @@ use crate::{
             FlowController, SwipeFlow,
         },
         geometry::Direction,
-        layout_delizia::component::Footer,
     },
 };
 
 use super::super::{
     component::{
         number_input_slider::{NumberInputSliderDialog, NumberInputSliderDialogMsg},
-        Frame, PromptMsg, PromptScreen, StatusScreen, SwipeContent, VerticalMenu,
+        Footer, Frame, PromptMsg, PromptScreen, StatusScreen, SwipeContent, VerticalMenu,
     },
     theme,
 };

--- a/tests/click_tests/test_reset_slip39_basic.py
+++ b/tests/click_tests/test_reset_slip39_basic.py
@@ -91,7 +91,8 @@ def test_reset_slip39_basic(
     if num_of_shares == 1 and threshold == 1:
         reset.set_selection(debug, 0)
     elif num_of_shares == 16 and threshold == 16:
-        reset.set_selection(debug, 11)
+        # set threshold - dialog starts at 9
+        reset.set_selection(debug, 7)
     else:
         raise RuntimeError("not a supported combination")
 


### PR DESCRIPTION
- NumberInputDialog now reacts to tap to continue
- change the types there to u16 to be consistent with NumberInputSlider

<!--
For core developers:
- Assign yourself to the PR.
- Set the priority to match the original issue.
- Add the PR to the current sprint.
- If it's a draft PR, mark it as "In Progress."
- If it's a final PR, mark it as "Needs Review."

For external contributors:
- Please open an issue before submitting a PR so we can discuss whether we want to proceed with it.
-->
