### PR TITLE
chore(core): use smaller vectors for `ShowInfoParams`

### DIFF
--- a/core/embed/rust/src/ui/layout_delizia/flow/util.rs
+++ b/core/embed/rust/src/ui/layout_delizia/flow/util.rs
@@ -8,7 +8,7 @@ use crate::{
         component::{
             swipe_detect::SwipeSettings,
             text::{
-                paragraphs::{Paragraph, ParagraphSource, ParagraphVecLong, VecExt},
+                paragraphs::{Paragraph, ParagraphSource, ParagraphVecShort, VecExt},
                 TextStyle,
             },
             Component,
@@ -330,7 +330,7 @@ pub struct ShowInfoParams {
     chunkify: bool,
     swipe_up: bool,
     swipe_down: bool,
-    items: Vec<(TString<'static>, TString<'static>), 4>,
+    items: Vec<(TString<'static>, TString<'static>), 3>,
 }
 
 impl ShowInfoParams {
@@ -412,7 +412,7 @@ impl ShowInfoParams {
     pub fn into_layout(
         self,
     ) -> Result<impl Component<Msg = FlowMsg> + Swipable + MaybeTrace, Error> {
-        let mut paragraphs = ParagraphVecLong::new();
+        let mut paragraphs = ParagraphVecShort::new();
         let mut first: bool = true;
         for item in self.items {
             // FIXME: padding:


### PR DESCRIPTION
It was increased by #4644 but eventually it wasn't used in #4639.

<!--
For core developers:
- Assign yourself to the PR.
- Set the priority to match the original issue.
- Add the PR to the current sprint.
- If it's a draft PR, mark it as "In Progress."
- If it's a final PR, mark it as "Needs Review."

For external contributors:
- Please open an issue before submitting a PR so we can discuss whether we want to proceed with it.
-->
