### PR TITLE
fix(core): use smaller button for upgrade cancellation

### DIFF
--- a/core/.changelog.d/4771.fixed
+++ b/core/.changelog.d/4771.fixed
@@ -1,0 +1,1 @@
+[T2T1] Fixed upgrade confirmation text overflow.

--- a/core/src/trezor/ui/layouts/bolt/__init__.py
+++ b/core/src/trezor/ui/layouts/bolt/__init__.py
@@ -1415,22 +1415,16 @@ async def confirm_firmware_update(description: str, fingerprint: str) -> None:
         verb=TR.buttons__install,
         info=True,
     )
-    info = trezorui_api.confirm_value(
+    info = trezorui_api.show_info_with_cancel(
         title=TR.firmware_update__title_fingerprint,
-        value=fingerprint,
-        description=None,
+        items=(("", fingerprint),),
         chunkify=True,
-        verb=TR.buttons__install,
-        verb_cancel="<",
-        info=False,
-        cancel=True,
     )
     await with_info(
         main,
         info,
         br_name="firmware_update",
         br_code=BR_CODE_OTHER,
-        info_layout_can_confirm=True,
     )
 
 

--- a/core/src/trezor/ui/layouts/bolt/__init__.py
+++ b/core/src/trezor/ui/layouts/bolt/__init__.py
@@ -1420,10 +1420,18 @@ async def confirm_firmware_update(description: str, fingerprint: str) -> None:
         value=fingerprint,
         description=None,
         chunkify=True,
+        verb=TR.buttons__install,
+        verb_cancel="<",
         info=False,
         cancel=True,
     )
-    await with_info(main, info, "firmware_update", BR_CODE_OTHER)
+    await with_info(
+        main,
+        info,
+        br_name="firmware_update",
+        br_code=BR_CODE_OTHER,
+        info_layout_can_confirm=True,
+    )
 
 
 async def set_brightness(current: int | None = None) -> None:

--- a/core/src/trezor/ui/layouts/bolt/__init__.py
+++ b/core/src/trezor/ui/layouts/bolt/__init__.py
@@ -1407,14 +1407,23 @@ def confirm_set_new_pin(
     )
 
 
-def confirm_firmware_update(description: str, fingerprint: str) -> Awaitable[None]:
-    return raise_if_not_confirmed(
-        trezorui_api.confirm_firmware_update(
-            description=description, fingerprint=fingerprint
-        ),
-        "firmware_update",
-        BR_CODE_OTHER,
+async def confirm_firmware_update(description: str, fingerprint: str) -> None:
+    main = trezorui_api.confirm_value(
+        title=TR.firmware_update__title,
+        description=description,
+        value="",
+        verb=TR.buttons__install,
+        info=True,
     )
+    info = trezorui_api.confirm_value(
+        title=TR.firmware_update__title_fingerprint,
+        value=fingerprint,
+        description=None,
+        chunkify=True,
+        info=False,
+        cancel=True,
+    )
+    await with_info(main, info, "firmware_update", BR_CODE_OTHER)
 
 
 async def set_brightness(current: int | None = None) -> None:


### PR DESCRIPTION
Otherwise, the translated `Install` text may overflow.

<img src=https://github.com/user-attachments/assets/7b994678-35cf-4b46-9125-765dd5e130ac width=300>

<img src=https://github.com/user-attachments/assets/91ad7327-06ef-4f8a-b1d6-e3c79b8f78e4 width=300>

Also, changed the `Confirm` methods signature to minimize copies and reduce stack usage.

<!--
For core developers:
- Assign yourself to the PR.
- Set the priority to match the original issue.
- Add the PR to the current sprint.
- If it's a draft PR, mark it as "In Progress."
- If it's a final PR, mark it as "Needs Review."

For external contributors:
- Please open an issue before submitting a PR so we can discuss whether we want to proceed with it.
-->
