### PR TITLE
WIP DO NOT MERGE

### DIFF
--- a/tests/click_tests/common.py
+++ b/tests/click_tests/common.py
@@ -82,15 +82,15 @@ def navigate_to_action_and_press(
     """Navigate to the button with certain action and press it"""
     # Orient
     try:
-        _get_action_index(wanted_action, all_actions)
+        _get_action_index(wanted_action, all_actions, debug.layout_type)
     except ValueError:
         raise ValueError(f"Action {wanted_action} is not supported in {all_actions}")
 
     # Navigate
     layout = debug.read_layout()
     current_action = layout.get_middle_choice()
-    current_index = _get_action_index(current_action, all_actions)
-    wanted_index = _get_action_index(wanted_action, all_actions)
+    current_index = _get_action_index(current_action, all_actions, debug.layout_type)
+    wanted_index = _get_action_index(wanted_action, all_actions, debug.layout_type)
 
     if not is_carousel:
         steps = wanted_index - current_index
@@ -126,7 +126,9 @@ def unlock_gesture(debug: "DebugLink") -> LayoutContent:
     return debug.read_layout()
 
 
-def _get_action_index(wanted_action: str, all_actions: AllActionsType) -> int:
+def _get_action_index(
+    wanted_action: str, all_actions: AllActionsType, layout_type: LayoutType
+) -> int:
     """Get index of the action in the list of all actions"""
     if wanted_action in all_actions:
         return all_actions.index(wanted_action)
@@ -135,7 +137,7 @@ def _get_action_index(wanted_action: str, all_actions: AllActionsType) -> int:
             action = (action,)
         for subaction in action:
             try:
-                tr = TR.translate(subaction)
+                tr = TR.translate(subaction, layout_type)
             except KeyError:
                 continue
             if tr == wanted_action:

--- a/tests/click_tests/recovery.py
+++ b/tests/click_tests/recovery.py
@@ -53,7 +53,7 @@ def enter_word(
 
 def confirm_recovery(debug: "DebugLink", title: str = "recovery__title") -> None:
     layout = debug.read_layout()
-    assert TR.translate(title) == layout.title()
+    assert TR.translate(title, debug.layout_type) == layout.title()
     if debug.layout_type is LayoutType.Bolt:
         debug.click(buttons.OK)
     elif debug.layout_type is LayoutType.Delizia:
@@ -68,7 +68,9 @@ def cancel_select_number_of_words(
     unlock_repeated_backup=False,
 ) -> None:
     if debug.layout_type is LayoutType.Bolt:
-        assert debug.read_layout().text_content() == TR.recovery__num_of_words
+        assert debug.read_layout().text_content() == TR.recovery__num_of_words(
+            debug.layout_type
+        )
         # click the button from ValuePad
         if unlock_repeated_backup:
             coords = buttons.grid34(0, 2)
@@ -78,7 +80,7 @@ def cancel_select_number_of_words(
     elif debug.layout_type is LayoutType.Caesar:
         debug.press_right()
         layout = debug.read_layout()
-        assert layout.title() == TR.word_count__title
+        assert layout.title() == TR.word_count__title(debug.layout_type)
         # navigate to the number and confirm it
         debug.press_left()
     elif debug.layout_type is LayoutType.Delizia:
@@ -98,7 +100,7 @@ def select_number_of_words(
     unlock_repeated_backup=False,
 ) -> None:
     layout = debug.read_layout()
-    assert TR.recovery__num_of_words in layout.text_content()
+    assert TR.recovery__num_of_words(debug.layout_type) in layout.text_content()
 
     def select_bolt() -> "LayoutContent":
         # click the button from ValuePad
@@ -150,7 +152,7 @@ def select_number_of_words(
     elif debug.layout_type is LayoutType.Caesar:
         debug.press_right()
         layout = debug.read_layout()
-        assert layout.title() == TR.word_count__title
+        assert layout.title() == TR.word_count__title(debug.layout_type)
         layout = select_caesar()
     elif debug.layout_type is LayoutType.Delizia:
         layout = select_delizia()
@@ -159,24 +161,28 @@ def select_number_of_words(
 
     if unlock_repeated_backup:
         if debug.layout_type is LayoutType.Caesar:
-            assert TR.recovery__enter_backup in layout.text_content()
+            assert TR.recovery__enter_backup(debug.layout_type) in layout.text_content()
         else:
             assert (
-                TR.recovery__only_first_n_letters in layout.text_content()
-                or TR.recovery__enter_each_word in layout.text_content()
+                TR.recovery__only_first_n_letters(debug.layout_type)
+                in layout.text_content()
+                or TR.recovery__enter_each_word(debug.layout_type)
+                in layout.text_content()
             )
     elif num_of_words in (20, 33):
         assert (
-            TR.recovery__enter_backup in layout.text_content()
-            or TR.recovery__enter_any_share in layout.text_content()
-            or TR.recovery__only_first_n_letters in layout.text_content()
-            or TR.recovery__enter_each_word in layout.text_content()
+            TR.recovery__enter_backup(debug.layout_type) in layout.text_content()
+            or TR.recovery__enter_any_share(debug.layout_type) in layout.text_content()
+            or TR.recovery__only_first_n_letters(debug.layout_type)
+            in layout.text_content()
+            or TR.recovery__enter_each_word(debug.layout_type) in layout.text_content()
         )
     else:  # BIP-39
         assert (
-            TR.recovery__enter_backup in layout.text_content()
-            or TR.recovery__only_first_n_letters in layout.text_content()
-            or TR.recovery__enter_each_word in layout.text_content()
+            TR.recovery__enter_backup(debug.layout_type) in layout.text_content()
+            or TR.recovery__only_first_n_letters(debug.layout_type)
+            in layout.text_content()
+            or TR.recovery__enter_each_word(debug.layout_type) in layout.text_content()
         )
 
 
@@ -187,7 +193,9 @@ def enter_share(
     before_title: str = "recovery__title_recover",
 ) -> "LayoutContent":
     if debug.layout_type is LayoutType.Caesar:
-        assert TR.translate(before_title) in debug.read_layout().title()
+        assert (
+            TR.translate(before_title, debug.layout_type) in debug.read_layout().title()
+        )
         layout = debug.read_layout()
         for _ in range(layout.page_count()):
             debug.press_right()
@@ -196,7 +204,9 @@ def enter_share(
         debug.swipe_up()
         layout = debug.read_layout()
     else:
-        assert TR.translate(before_title) in debug.read_layout().title()
+        assert (
+            TR.translate(before_title, debug.layout_type) in debug.read_layout().title()
+        )
         debug.click(buttons.OK)
         layout = debug.read_layout()
 
@@ -216,11 +226,15 @@ def enter_shares(
     after_layout_text: str = "recovery__wallet_recovered",
 ) -> None:
     assert (
-        TR.recovery__enter_backup in debug.read_layout().text_content()
-        or TR.recovery__enter_any_share in debug.read_layout().text_content()
-        or TR.recovery__only_first_n_letters in debug.read_layout().text_content()
-        or TR.recovery__enter_each_word in debug.read_layout().text_content()
-        or TR.translate(text) in debug.read_layout().text_content()
+        TR.recovery__enter_backup(debug.layout_type)
+        in debug.read_layout().text_content()
+        or TR.recovery__enter_any_share(debug.layout_type)
+        in debug.read_layout().text_content()
+        or TR.recovery__only_first_n_letters(debug.layout_type)
+        in debug.read_layout().text_content()
+        or TR.recovery__enter_each_word(debug.layout_type)
+        in debug.read_layout().text_content()
+        or TR.translate(text, debug.layout_type) in debug.read_layout().text_content()
     )
     for index, share in enumerate(shares):
         enter_share(
@@ -228,14 +242,20 @@ def enter_shares(
         )
         if index < len(shares) - 1:
             # FIXME: when ui-t3t1 done for shamir, we want to check the template below
-            assert TR.translate(enter_share_before_title) in debug.read_layout().title()
+            assert (
+                TR.translate(enter_share_before_title, debug.layout_type)
+                in debug.read_layout().title()
+            )
             # TR.assert_in(
             #     debug.read_layout().text_content(),
             #     "recovery__x_of_y_entered_template",
             #     template=(index + 1, len(shares)),
             # )
 
-    assert TR.translate(after_layout_text) in debug.read_layout().text_content()
+    assert (
+        TR.translate(after_layout_text, debug.layout_type)
+        in debug.read_layout().text_content()
+    )
 
 
 def enter_seed(
@@ -250,7 +270,10 @@ def enter_seed(
     for word in seed_words:
         enter_word(debug, word, is_slip39=is_slip39)
 
-    assert TR.translate(after_layout_text) in debug.read_layout().text_content()
+    assert (
+        TR.translate(after_layout_text, debug.layout_type)
+        in debug.read_layout().text_content()
+    )
 
 
 def enter_seed_previous_correct(
@@ -258,7 +281,7 @@ def enter_seed_previous_correct(
 ) -> None:
     prepare_enter_seed(debug)
 
-    DELETE_BTNS = [TR.translate(btn) for btn in DELETE_BTN_TEXTS]
+    DELETE_BTNS = [TR.translate(btn, debug.layout_type) for btn in DELETE_BTN_TEXTS]
 
     i = 0
     go_back = False
@@ -312,10 +335,14 @@ def prepare_enter_seed(
     debug: "DebugLink", layout_text: str = "recovery__enter_backup"
 ) -> None:
     assert (
-        TR.recovery__enter_backup in debug.read_layout().text_content()
-        or TR.recovery__only_first_n_letters in debug.read_layout().text_content()
-        or TR.recovery__enter_each_word in debug.read_layout().text_content()
-        or TR.translate(layout_text) in debug.read_layout().text_content()
+        TR.recovery__enter_backup(debug.layout_type)
+        in debug.read_layout().text_content()
+        or TR.recovery__only_first_n_letters(debug.layout_type)
+        in debug.read_layout().text_content()
+        or TR.recovery__enter_each_word(debug.layout_type)
+        in debug.read_layout().text_content()
+        or TR.translate(layout_text, debug.layout_type)
+        in debug.read_layout().text_content()
     )
     if debug.layout_type is LayoutType.Bolt:
         debug.click(buttons.OK)
@@ -337,8 +364,10 @@ def finalize(debug: "DebugLink") -> None:
 
 
 def cancel_recovery(debug: "DebugLink", recovery_type: str = "dry_run") -> None:
-    title = TR.translate(f"recovery__title_{recovery_type}")
-    cancel_title = TR.translate(f"recovery__title_cancel_{recovery_type}")
+    title = TR.translate(f"recovery__title_{recovery_type}", debug.layout_type)
+    cancel_title = TR.translate(
+        f"recovery__title_cancel_{recovery_type}", debug.layout_type
+    )
 
     layout = debug.read_layout()
     assert title in layout.title()
@@ -359,7 +388,8 @@ def cancel_recovery(debug: "DebugLink", recovery_type: str = "dry_run") -> None:
         debug.click(buttons.CORNER_BUTTON)
         layout = debug.read_layout()
         assert (
-            TR.translate(f"recovery__cancel_{recovery_type}") in layout.text_content()
+            TR.translate(f"recovery__cancel_{recovery_type}", debug.layout_type)
+            in layout.text_content()
         )
         debug.click(buttons.VERTICAL_MENU[0])
     else:

--- a/tests/click_tests/reset.py
+++ b/tests/click_tests/reset.py
@@ -13,7 +13,9 @@ if TYPE_CHECKING:
 
 
 def confirm_new_wallet(debug: "DebugLink") -> None:
-    assert debug.read_layout().title() == TR.reset__title_create_wallet
+    assert debug.read_layout().title() == TR.reset__title_create_wallet(
+        debug.layout_type
+    )
     if debug.layout_type is LayoutType.Bolt:
         debug.click(buttons.OK)
     elif debug.layout_type is LayoutType.Delizia:
@@ -23,8 +25,10 @@ def confirm_new_wallet(debug: "DebugLink") -> None:
         debug.press_right()
         debug.press_right()
     assert (
-        TR.backup__new_wallet_successfully_created in debug.read_layout().text_content()
-        or TR.backup__new_wallet_created in debug.read_layout().text_content()
+        TR.backup__new_wallet_successfully_created(debug.layout_type)
+        in debug.read_layout().text_content()
+        or TR.backup__new_wallet_created(debug.layout_type)
+        in debug.read_layout().text_content()
     )
     if debug.layout_type is LayoutType.Delizia:
         debug.swipe_up()
@@ -74,10 +78,9 @@ def set_selection(debug: "DebugLink", button: tuple[int, int], diff: int) -> Non
             debug.swipe_up()
     elif debug.layout_type is LayoutType.Caesar:
         layout = debug.read_layout()
-        if (
-            layout.title()
-            in TR.reset__title_number_of_shares + TR.words__title_threshold
-        ):
+        if layout.title() in TR.reset__title_number_of_shares(
+            debug.layout_type
+        ) + TR.words__title_threshold(debug.layout_type):
             # Special info screens
             debug.press_right()
             layout = debug.read_layout()
@@ -134,7 +137,7 @@ def confirm_words(debug: "DebugLink", words: list[str]) -> None:
 
     layout = debug.read_layout()
     if debug.layout_type is LayoutType.Bolt:
-        assert TR.regexp("reset__select_word_x_of_y_template").match(
+        assert TR.regexp("reset__select_word_x_of_y_template", debug.layout_type).match(
             layout.text_content()
         )
         for _ in range(3):
@@ -152,7 +155,9 @@ def confirm_words(debug: "DebugLink", words: list[str]) -> None:
             debug.click(buttons.RESET_WORD_CHECK[button_pos])
             layout = debug.read_layout()
     elif debug.layout_type is LayoutType.Delizia:
-        assert TR.regexp("reset__select_word_x_of_y_template").match(layout.subtitle())
+        assert TR.regexp("reset__select_word_x_of_y_template", debug.layout_type).match(
+            layout.subtitle()
+        )
         for _ in range(3):
             # "Select word 3 of 20"
             #              ^
@@ -168,7 +173,7 @@ def confirm_words(debug: "DebugLink", words: list[str]) -> None:
             debug.click(buttons.VERTICAL_MENU[button_pos])
             layout = debug.read_layout()
     elif debug.layout_type is LayoutType.Caesar:
-        assert TR.reset__select_correct_word in layout.text_content()
+        assert TR.reset__select_correct_word(debug.layout_type) in layout.text_content()
         debug.press_right()
         layout = debug.read_layout()
         for _ in range(3):

--- a/tests/click_tests/test_autolock.py
+++ b/tests/click_tests/test_autolock.py
@@ -65,7 +65,7 @@ def set_autolock_delay(device_handler: "BackgroundDeviceHandler", delay_ms: int)
 
     debug.input("1234")
 
-    assert TR.regexp("auto_lock__change_template").match(
+    assert TR.regexp("auto_lock__change_template", debug.layout_type).match(
         debug.read_layout().text_content()
     )
 
@@ -109,19 +109,19 @@ def test_autolock_interrupts_signing(device_handler: "BackgroundDeviceHandler"):
         debug.click(buttons.OK)
         debug.click(buttons.OK)
         layout = debug.read_layout()
-        assert TR.send__total_amount in layout.text_content()
+        assert TR.send__total_amount(debug.layout_type) in layout.text_content()
         assert "0.0039 BTC" in layout.text_content()
     elif debug.layout_type is LayoutType.Delizia:
         debug.swipe_up()
         debug.swipe_up()
         layout = debug.read_layout()
-        assert TR.send__total_amount in layout.text_content()
+        assert TR.send__total_amount(debug.layout_type) in layout.text_content()
         assert "0.0039 BTC" in layout.text_content()
     elif debug.layout_type is LayoutType.Caesar:
         debug.press_right()
         debug.press_right()
         layout = debug.read_layout()
-        assert TR.send__total_amount in layout.text_content()
+        assert TR.send__total_amount(debug.layout_type) in layout.text_content()
         assert "0.0039 BTC" in layout.text_content()
 
     # wait for autolock to kick in
@@ -164,20 +164,20 @@ def test_autolock_does_not_interrupt_signing(device_handler: "BackgroundDeviceHa
         debug.click(buttons.OK)
         debug.click(buttons.OK)
         layout = debug.read_layout()
-        assert TR.send__total_amount in layout.text_content()
+        assert TR.send__total_amount(debug.layout_type) in layout.text_content()
         assert "0.0039 BTC" in layout.text_content()
     elif debug.layout_type is LayoutType.Delizia:
         debug.swipe_up()
         debug.swipe_up()
         layout = debug.read_layout()
-        assert TR.send__total_amount in layout.text_content()
+        assert TR.send__total_amount(debug.layout_type) in layout.text_content()
         assert "0.0039 BTC" in layout.text_content()
         debug.swipe_up()
     elif debug.layout_type is LayoutType.Caesar:
         debug.press_right()
         debug.press_right()
         layout = debug.read_layout()
-        assert TR.send__total_amount in layout.text_content()
+        assert TR.send__total_amount(debug.layout_type) in layout.text_content()
         assert "0.0039 BTC" in layout.text_content()
 
     def sleepy_filter(msg: MessageType) -> MessageType:
@@ -275,7 +275,10 @@ def test_autolock_interrupts_passphrase(device_handler: "BackgroundDeviceHandler
 
 
 def unlock_dry_run(debug: "DebugLink") -> "LayoutContent":
-    assert TR.recovery__check_dry_run in debug.read_layout().text_content()
+    assert (
+        TR.recovery__check_dry_run(debug.layout_type)
+        in debug.read_layout().text_content()
+    )
     layout = go_next(debug)
     assert "PinKeyboard" in layout.all_components()
 
@@ -293,7 +296,10 @@ def test_dryrun_locks_at_number_of_words(device_handler: "BackgroundDeviceHandle
     device_handler.run(device.recover, type=messages.RecoveryType.DryRun)
 
     layout = unlock_dry_run(debug)
-    assert TR.recovery__num_of_words in debug.read_layout().text_content()
+    assert (
+        TR.recovery__num_of_words(debug.layout_type)
+        in debug.read_layout().text_content()
+    )
 
     if debug.layout_type is LayoutType.Caesar:
         debug.press_right()
@@ -315,7 +321,10 @@ def test_dryrun_locks_at_number_of_words(device_handler: "BackgroundDeviceHandle
     assert layout is not None
 
     # we are back at homescreen
-    assert TR.recovery__num_of_words in debug.read_layout().text_content()
+    assert (
+        TR.recovery__num_of_words(debug.layout_type)
+        in debug.read_layout().text_content()
+    )
 
 
 @pytest.mark.setup_client(pin=PIN4)

--- a/tests/click_tests/test_backup_slip39_custom.py
+++ b/tests/click_tests/test_backup_slip39_custom.py
@@ -79,17 +79,20 @@ def test_backup_slip39_custom(
 
     # confirm backup configuration
     if share_count > 1:
-        assert TR.regexp("reset__create_x_of_y_multi_share_backup_template").match(
-            debug.read_layout().text_content()
-        )
+        assert TR.regexp(
+            "reset__create_x_of_y_multi_share_backup_template", debug.layout_type
+        ).match(debug.read_layout().text_content())
     else:
-        assert TR.regexp("backup__info_single_share_backup").match(
+        assert TR.regexp("backup__info_single_share_backup", debug.layout_type).match(
             debug.read_layout().text_content()
         )
     reset.confirm_read(debug)
 
     # confirm backup intro
-    assert TR.reset__never_make_digital_copy in debug.read_layout().text_content()
+    assert (
+        TR.reset__never_make_digital_copy(debug.layout_type)
+        in debug.read_layout().text_content()
+    )
     reset.confirm_read(debug, middle_r=True)
 
     all_words: list[str] = []

--- a/tests/click_tests/test_pin.py
+++ b/tests/click_tests/test_pin.py
@@ -103,8 +103,8 @@ def prepare(
         # Set new PIN
         device_handler.run(device.change_pin)  # type: ignore
         assert (
-            TR.pin__turn_on in debug.read_layout().text_content()
-            or TR.pin__info in debug.read_layout().text_content()
+            TR.pin__turn_on(debug.layout_type) in debug.read_layout().text_content()
+            or TR.pin__info(debug.layout_type) in debug.read_layout().text_content()
         )
         if debug.layout_type in (LayoutType.Bolt, LayoutType.Delizia):
             go_next(debug)
@@ -117,7 +117,7 @@ def prepare(
         # Change PIN
         device_handler.run(device.change_pin)  # type: ignore
         _input_see_confirm(debug, old_pin)
-        assert TR.pin__change in debug.read_layout().text_content()
+        assert TR.pin__change(debug.layout_type) in debug.read_layout().text_content()
         go_next(debug)
         _input_see_confirm(debug, old_pin)
     elif situation == Situation.WIPE_CODE_SETUP:
@@ -125,7 +125,10 @@ def prepare(
         device_handler.run(device.change_wipe_code)  # type: ignore
         if old_pin:
             _input_see_confirm(debug, old_pin)
-        assert TR.wipe_code__turn_on in debug.read_layout().text_content()
+        assert (
+            TR.wipe_code__turn_on(debug.layout_type)
+            in debug.read_layout().text_content()
+        )
         go_next(debug)
         if debug.layout_type is LayoutType.Caesar:
             go_next(debug)

--- a/tests/click_tests/test_reset_bip39.py
+++ b/tests/click_tests/test_reset_bip39.py
@@ -61,7 +61,7 @@ def test_reset_bip39(device_handler: "BackgroundDeviceHandler"):
 
     # confirm backup intro
     # parametrized string
-    assert TR.regexp("backup__info_single_share_backup").match(
+    assert TR.regexp("backup__info_single_share_backup", debug.layout_type).match(
         debug.read_layout().text_content()
     )
     reset.confirm_read(debug)

--- a/tests/click_tests/test_tutorial_caesar.py
+++ b/tests/click_tests/test_tutorial_caesar.py
@@ -58,7 +58,7 @@ def go_through_tutorial_tr(debug: "DebugLink") -> None:
     debug.press_right()
     debug.press_middle()
     layout = debug.read_layout()
-    assert layout.title() == TR.tutorial__title_tutorial_complete
+    assert layout.title() == TR.tutorial__title_tutorial_complete(debug.layout_type)
 
 
 def test_tutorial_finish(device_handler: "BackgroundDeviceHandler"):

--- a/tests/click_tests/test_tutorial_delizia.py
+++ b/tests/click_tests/test_tutorial_delizia.py
@@ -38,17 +38,25 @@ def test_tutorial_ignore_menu(device_handler: "BackgroundDeviceHandler"):
     debug = device_handler.debuglink()
     device_handler.run(device.show_device_tutorial)
 
-    assert debug.read_layout().title() == TR.tutorial__welcome_safe5
+    assert debug.read_layout().title() == TR.tutorial__welcome_safe5(debug.layout_type)
     debug.click(buttons.TAP_TO_CONFIRM)
-    assert debug.read_layout().title() == TR.tutorial__title_lets_begin
+    assert debug.read_layout().title() == TR.tutorial__title_lets_begin(
+        debug.layout_type
+    )
     debug.swipe_up()
-    assert debug.read_layout().title() == TR.tutorial__title_easy_navigation
+    assert debug.read_layout().title() == TR.tutorial__title_easy_navigation(
+        debug.layout_type
+    )
     debug.swipe_up()
-    assert debug.read_layout().title() == TR.tutorial__title_handy_menu
+    assert debug.read_layout().title() == TR.tutorial__title_handy_menu(
+        debug.layout_type
+    )
     debug.swipe_up()
-    assert debug.read_layout().title() == TR.tutorial__title_hold
+    assert debug.read_layout().title() == TR.tutorial__title_hold(debug.layout_type)
     debug.click(buttons.TAP_TO_CONFIRM)
-    assert debug.read_layout().title() == TR.tutorial__title_well_done
+    assert debug.read_layout().title() == TR.tutorial__title_well_done(
+        debug.layout_type
+    )
     debug.swipe_up()
 
     device_handler.result()
@@ -58,23 +66,36 @@ def test_tutorial_menu_open_close(device_handler: "BackgroundDeviceHandler"):
     debug = device_handler.debuglink()
     device_handler.run(device.show_device_tutorial)
 
-    assert debug.read_layout().title() == TR.tutorial__welcome_safe5
+    assert debug.read_layout().title() == TR.tutorial__welcome_safe5(debug.layout_type)
     debug.click(buttons.TAP_TO_CONFIRM)
-    assert debug.read_layout().title() == TR.tutorial__title_lets_begin
+    assert debug.read_layout().title() == TR.tutorial__title_lets_begin(
+        debug.layout_type
+    )
     debug.swipe_up()
-    assert debug.read_layout().title() == TR.tutorial__title_easy_navigation
+    assert debug.read_layout().title() == TR.tutorial__title_easy_navigation(
+        debug.layout_type
+    )
     debug.swipe_up()
-    assert debug.read_layout().title() == TR.tutorial__title_handy_menu
+    assert debug.read_layout().title() == TR.tutorial__title_handy_menu(
+        debug.layout_type
+    )
 
     debug.click(buttons.CORNER_BUTTON)
-    assert TR.tutorial__did_you_know in debug.read_layout().text_content()
+    assert (
+        TR.tutorial__did_you_know(debug.layout_type)
+        in debug.read_layout().text_content()
+    )
     debug.click(buttons.CORNER_BUTTON)
-    assert debug.read_layout().title() == TR.tutorial__title_handy_menu
+    assert debug.read_layout().title() == TR.tutorial__title_handy_menu(
+        debug.layout_type
+    )
 
     debug.swipe_up()
-    assert debug.read_layout().title() == TR.tutorial__title_hold
+    assert debug.read_layout().title() == TR.tutorial__title_hold(debug.layout_type)
     debug.click(buttons.TAP_TO_CONFIRM)
-    assert debug.read_layout().title() == TR.tutorial__title_well_done
+    assert debug.read_layout().title() == TR.tutorial__title_well_done(
+        debug.layout_type
+    )
     debug.swipe_up()
 
     device_handler.result()
@@ -84,20 +105,34 @@ def test_tutorial_menu_exit(device_handler: "BackgroundDeviceHandler"):
     debug = device_handler.debuglink()
     device_handler.run(device.show_device_tutorial)
 
-    assert debug.read_layout().title() == TR.tutorial__welcome_safe5
+    assert debug.read_layout().title() == TR.tutorial__welcome_safe5(debug.layout_type)
     debug.click(buttons.TAP_TO_CONFIRM)
-    assert debug.read_layout().title() == TR.tutorial__title_lets_begin
+    assert debug.read_layout().title() == TR.tutorial__title_lets_begin(
+        debug.layout_type
+    )
     debug.swipe_up()
-    assert debug.read_layout().title() == TR.tutorial__title_easy_navigation
+    assert debug.read_layout().title() == TR.tutorial__title_easy_navigation(
+        debug.layout_type
+    )
     debug.swipe_up()
-    assert debug.read_layout().title() == TR.tutorial__title_handy_menu
+    assert debug.read_layout().title() == TR.tutorial__title_handy_menu(
+        debug.layout_type
+    )
 
     debug.click(buttons.CORNER_BUTTON)
-    assert TR.tutorial__did_you_know in debug.read_layout().text_content()
+    assert (
+        TR.tutorial__did_you_know(debug.layout_type)
+        in debug.read_layout().text_content()
+    )
     debug.click(buttons.VERTICAL_MENU[2])
-    assert TR.instructions__hold_to_exit_tutorial in debug.read_layout().footer()
+    assert (
+        TR.instructions__hold_to_exit_tutorial(debug.layout_type)
+        in debug.read_layout().footer()
+    )
     debug.click(buttons.TAP_TO_CONFIRM)
-    assert debug.read_layout().title() == TR.tutorial__title_well_done
+    assert debug.read_layout().title() == TR.tutorial__title_well_done(
+        debug.layout_type
+    )
     debug.swipe_up()
 
     device_handler.result()
@@ -107,27 +142,44 @@ def test_tutorial_menu_repeat(device_handler: "BackgroundDeviceHandler"):
     debug = device_handler.debuglink()
     device_handler.run(device.show_device_tutorial)
 
-    assert debug.read_layout().title() == TR.tutorial__welcome_safe5
+    assert debug.read_layout().title() == TR.tutorial__welcome_safe5(debug.layout_type)
     debug.click(buttons.TAP_TO_CONFIRM)
-    assert debug.read_layout().title() == TR.tutorial__title_lets_begin
+    assert debug.read_layout().title() == TR.tutorial__title_lets_begin(
+        debug.layout_type
+    )
     debug.swipe_up()
-    assert debug.read_layout().title() == TR.tutorial__title_easy_navigation
+    assert debug.read_layout().title() == TR.tutorial__title_easy_navigation(
+        debug.layout_type
+    )
     debug.swipe_up()
-    assert debug.read_layout().title() == TR.tutorial__title_handy_menu
+    assert debug.read_layout().title() == TR.tutorial__title_handy_menu(
+        debug.layout_type
+    )
 
     debug.click(buttons.CORNER_BUTTON)
-    assert TR.tutorial__did_you_know in debug.read_layout().text_content()
+    assert (
+        TR.tutorial__did_you_know(debug.layout_type)
+        in debug.read_layout().text_content()
+    )
     debug.click(buttons.VERTICAL_MENU[1])
 
-    assert debug.read_layout().title() == TR.tutorial__title_lets_begin
+    assert debug.read_layout().title() == TR.tutorial__title_lets_begin(
+        debug.layout_type
+    )
     debug.swipe_up()
-    assert debug.read_layout().title() == TR.tutorial__title_easy_navigation
+    assert debug.read_layout().title() == TR.tutorial__title_easy_navigation(
+        debug.layout_type
+    )
     debug.swipe_up()
-    assert debug.read_layout().title() == TR.tutorial__title_handy_menu
+    assert debug.read_layout().title() == TR.tutorial__title_handy_menu(
+        debug.layout_type
+    )
     debug.swipe_up()
-    assert debug.read_layout().title() == TR.tutorial__title_hold
+    assert debug.read_layout().title() == TR.tutorial__title_hold(debug.layout_type)
     debug.click(buttons.TAP_TO_CONFIRM)
-    assert debug.read_layout().title() == TR.tutorial__title_well_done
+    assert debug.read_layout().title() == TR.tutorial__title_well_done(
+        debug.layout_type
+    )
     debug.swipe_up()
 
     device_handler.result()
@@ -137,30 +189,46 @@ def test_tutorial_menu_funfact(device_handler: "BackgroundDeviceHandler"):
     debug = device_handler.debuglink()
     device_handler.run(device.show_device_tutorial)
 
-    assert debug.read_layout().title() == TR.tutorial__welcome_safe5
+    assert debug.read_layout().title() == TR.tutorial__welcome_safe5(debug.layout_type)
     debug.click(buttons.TAP_TO_CONFIRM)
-    assert debug.read_layout().title() == TR.tutorial__title_lets_begin
+    assert debug.read_layout().title() == TR.tutorial__title_lets_begin(
+        debug.layout_type
+    )
     debug.swipe_up()
-    assert debug.read_layout().title() == TR.tutorial__title_easy_navigation
+    assert debug.read_layout().title() == TR.tutorial__title_easy_navigation(
+        debug.layout_type
+    )
     debug.swipe_up()
-    assert debug.read_layout().title() == TR.tutorial__title_handy_menu
-
-    debug.click(buttons.CORNER_BUTTON)
-    assert TR.tutorial__did_you_know in debug.read_layout().text_content()
-    debug.click(buttons.VERTICAL_MENU[0])
-    assert debug.read_layout().text_content() in TR.tutorial__first_wallet.replace(
-        "\n", " "
+    assert debug.read_layout().title() == TR.tutorial__title_handy_menu(
+        debug.layout_type
     )
 
     debug.click(buttons.CORNER_BUTTON)
-    assert TR.tutorial__did_you_know in debug.read_layout().text_content()
+    assert (
+        TR.tutorial__did_you_know(debug.layout_type)
+        in debug.read_layout().text_content()
+    )
+    debug.click(buttons.VERTICAL_MENU[0])
+    assert debug.read_layout().text_content() in TR.tutorial__first_wallet(
+        debug.layout_type
+    ).replace("\n", " ")
+
     debug.click(buttons.CORNER_BUTTON)
-    assert debug.read_layout().title() == TR.tutorial__title_handy_menu
+    assert (
+        TR.tutorial__did_you_know(debug.layout_type)
+        in debug.read_layout().text_content()
+    )
+    debug.click(buttons.CORNER_BUTTON)
+    assert debug.read_layout().title() == TR.tutorial__title_handy_menu(
+        debug.layout_type
+    )
 
     debug.swipe_up()
-    assert debug.read_layout().title() == TR.tutorial__title_hold
+    assert debug.read_layout().title() == TR.tutorial__title_hold(debug.layout_type)
     debug.click(buttons.TAP_TO_CONFIRM)
-    assert debug.read_layout().title() == TR.tutorial__title_well_done
+    assert debug.read_layout().title() == TR.tutorial__title_well_done(
+        debug.layout_type
+    )
     debug.swipe_up()
 
     device_handler.result()

--- a/tests/device_tests/misc/test_msg_enablelabeling.py
+++ b/tests/device_tests/misc/test_msg_enablelabeling.py
@@ -28,7 +28,9 @@ from ...common import MNEMONIC12
 def test_encrypt(client: Client):
     def input_flow():
         assert (yield).name == "cipher_key_value"
-        assert client.debug.read_layout().text_content() == TR.misc__enable_labeling
+        assert client.debug.read_layout().text_content() == TR.misc__enable_labeling(
+            client.layout_type
+        )
         client.debug.swipe_up()
         client.debug.press_yes()
 

--- a/tests/device_tests/test_repeated_backup.py
+++ b/tests/device_tests/test_repeated_backup.py
@@ -155,7 +155,10 @@ def test_repeated_backup_cancel(client: Client):
         assert client.features.recovery_status == messages.RecoveryStatus.Backup
 
     layout = client.debug.read_layout()
-    assert TR.recovery__unlock_repeated_backup in layout.text_content()
+    assert (
+        TR.recovery__unlock_repeated_backup(client.debug.layout_type)
+        in layout.text_content()
+    )
 
     # send a Cancel message
 
@@ -209,7 +212,10 @@ def test_repeated_backup_send_disallowed_message(client: Client):
         assert client.features.recovery_status == messages.RecoveryStatus.Backup
 
     layout = client.debug.read_layout()
-    assert TR.recovery__unlock_repeated_backup in layout.text_content()
+    assert (
+        TR.recovery__unlock_repeated_backup(client.debug.layout_type)
+        in layout.text_content()
+    )
 
     # send a GetAddress message
 
@@ -229,5 +235,6 @@ def test_repeated_backup_send_disallowed_message(client: Client):
 
     # we are still on the confirmation screen!
     assert (
-        TR.recovery__unlock_repeated_backup in client.debug.read_layout().text_content()
+        TR.recovery__unlock_repeated_backup(client.debug.layout_type)
+        in client.debug.read_layout().text_content()
     )

--- a/tests/device_tests/test_sdcard.py
+++ b/tests/device_tests/test_sdcard.py
@@ -59,7 +59,7 @@ def test_sd_protect_unlock(client: Client):
         client.debug.input("1234")
 
         yield  # do you really want to enable SD protection
-        assert TR.sd_card__enable in layout().text_content()
+        assert TR.sd_card__enable(client.debug.layout_type) in layout().text_content()
         client.debug.press_yes()
 
         yield  # enter current PIN
@@ -67,7 +67,7 @@ def test_sd_protect_unlock(client: Client):
         client.debug.input("1234")
 
         yield  # you have successfully enabled SD protection
-        assert TR.sd_card__enabled in layout().text_content()
+        assert TR.sd_card__enabled(client.debug.layout_type) in layout().text_content()
         client.debug.press_yes()
 
     with client:
@@ -77,7 +77,7 @@ def test_sd_protect_unlock(client: Client):
 
     def input_flow_change_pin():
         yield  # do you really want to change PIN?
-        assert layout().title() == TR.pin__title_settings
+        assert layout().title() == TR.pin__title_settings(client.debug.layout_type)
         client.debug.press_yes()
 
         yield  # enter current PIN
@@ -93,7 +93,7 @@ def test_sd_protect_unlock(client: Client):
         client.debug.input("1234")
 
         yield  # Pin change successful
-        assert TR.pin__changed in layout().text_content()
+        assert TR.pin__changed(client.debug.layout_type) in layout().text_content()
         client.debug.press_yes()
 
     with client:
@@ -105,7 +105,7 @@ def test_sd_protect_unlock(client: Client):
 
     def input_flow_change_pin_format():
         yield  # do you really want to change PIN?
-        assert layout().title() == TR.pin__title_settings
+        assert layout().title() == TR.pin__title_settings(client.debug.layout_type)
         client.debug.press_yes()
 
         yield  # enter current PIN
@@ -114,8 +114,10 @@ def test_sd_protect_unlock(client: Client):
 
         yield  # SD card problem
         assert (
-            TR.sd_card__unplug_and_insert_correct in layout().text_content()
-            or TR.sd_card__insert_correct_card in layout().text_content()
+            TR.sd_card__unplug_and_insert_correct(client.debug.layout_type)
+            in layout().text_content()
+            or TR.sd_card__insert_correct_card(client.debug.layout_type)
+            in layout().text_content()
         )
         client.debug.press_no()  # close
 

--- a/tests/device_tests/test_session_id_and_passphrase.py
+++ b/tests/device_tests/test_session_id_and_passphrase.py
@@ -398,7 +398,10 @@ def test_hide_passphrase_from_host(client: Client):
         def input_flow():
             yield
             content = client.debug.read_layout().text_content().lower()
-            assert TR.passphrase__from_host_not_shown[:50].lower() in content
+            assert (
+                TR.passphrase__from_host_not_shown(client.layout_type)[:50].lower()
+                in content
+            )
             if client.layout_type in (LayoutType.Bolt, LayoutType.Delizia):
                 client.debug.press_yes()
             elif client.layout_type is LayoutType.Caesar:
@@ -433,13 +436,15 @@ def test_hide_passphrase_from_host(client: Client):
         def input_flow():
             yield
             assert (
-                TR.passphrase__next_screen_will_show_passphrase
+                TR.passphrase__next_screen_will_show_passphrase(client.layout_type)
                 in client.debug.read_layout().text_content()
             )
             client.debug.press_yes()
 
             yield
-            assert client.debug.read_layout().title() == TR.passphrase__title_confirm
+            assert client.debug.read_layout().title() == TR.passphrase__title_confirm(
+                client.layout_type
+            )
             assert passphrase in client.debug.read_layout().text_content()
             client.debug.press_yes()
 

--- a/tests/input_flows.py
+++ b/tests/input_flows.py
@@ -507,9 +507,9 @@ class InputFlowShowMultisigXPUBs(InputFlowBase):
         expected_title = f"MULTISIG XPUB #{xpub_num + 1}"
         assert expected_title in title
         if self.index == xpub_num:
-            assert TR.address__title_yours in title
+            assert TR.address__title_yours(self.client.layout_type) in title
         else:
-            assert TR.address__title_cosigner in title
+            assert TR.address__title_cosigner(self.client.layout_type) in title
 
     def input_flow_bolt(self) -> BRGeneratorType:
         yield  # multisig address warning
@@ -517,7 +517,9 @@ class InputFlowShowMultisigXPUBs(InputFlowBase):
 
         yield  # show address
         layout = self.debug.read_layout()
-        assert TR.address__title_receive_address in layout.title()
+        assert (
+            TR.address__title_receive_address(self.client.layout_type) in layout.title()
+        )
         assert "(MULTISIG)" in layout.title()
         assert layout.text_content().replace(" ", "") == self.address
 
@@ -528,7 +530,10 @@ class InputFlowShowMultisigXPUBs(InputFlowBase):
         layout = self.debug.read_layout()
         # address details
         assert "Multisig 2 of 3" in layout.screen_content()
-        assert TR.address_details__derivation_path in layout.screen_content()
+        assert (
+            TR.address_details__derivation_path(self.client.layout_type)
+            in layout.screen_content()
+        )
 
         # Three xpub pages with the same testing logic
         for xpub_num in range(3):
@@ -552,7 +557,9 @@ class InputFlowShowMultisigXPUBs(InputFlowBase):
 
         yield  # show address
         layout = self.debug.read_layout()
-        assert TR.address__title_receive_address in layout.title()
+        assert (
+            TR.address__title_receive_address(self.client.layout_type) in layout.title()
+        )
         assert "(MULTISIG)" in layout.title()
         assert layout.text_content().replace(" ", "") == self.address
 
@@ -596,7 +603,9 @@ class InputFlowShowMultisigXPUBs(InputFlowBase):
 
         yield  # show address
         layout = self.debug.read_layout()
-        assert TR.address__title_receive_address in layout.title()
+        assert (
+            TR.address__title_receive_address(self.client.layout_type) in layout.title()
+        )
         assert layout.text_content().replace(" ", "") == self.address
 
         self.debug.click(buttons.CORNER_BUTTON)
@@ -613,7 +622,10 @@ class InputFlowShowMultisigXPUBs(InputFlowBase):
         layout = self.debug.synchronize_at("AddressDetails")
         # address details
         assert "Multisig 2 of 3" in layout.screen_content()
-        assert TR.address_details__derivation_path in layout.screen_content()
+        assert (
+            TR.address_details__derivation_path(self.client.layout_type)
+            in layout.screen_content()
+        )
 
         # three xpub pages with the same testing logic
         for _xpub_num in range(3):
@@ -714,7 +726,10 @@ class InputFlowShowXpubQRCode(InputFlowBase):
             br = yield
             layout = self.debug.read_layout()
 
-        assert layout.title() in (TR.address__public_key, "XPUB")
+        assert layout.title() in (
+            TR.address__public_key(self.client.layout_type),
+            "XPUB",
+        )
 
         self.debug.click(buttons.CORNER_BUTTON)
         assert "VerticalMenu" in self.all_components()
@@ -729,7 +744,10 @@ class InputFlowShowXpubQRCode(InputFlowBase):
         self.debug.click(buttons.VERTICAL_MENU[1])
         layout = self.debug.synchronize_at("AddressDetails")
         # address details
-        assert TR.address_details__derivation_path in layout.screen_content()
+        assert (
+            TR.address_details__derivation_path(self.client.layout_type)
+            in layout.screen_content()
+        )
 
         self.debug.click(buttons.CORNER_BUTTON)
         layout = self.debug.synchronize_at("VerticalMenu")
@@ -947,9 +965,9 @@ class InputFlowSignTxInformation(InputFlowBase):
         super().__init__(client)
 
     def assert_content(self, content: str, title_path: str) -> None:
-        assert TR.translate(title_path) in content
+        assert TR.translate(title_path, self.client.layout_type) in content
         assert "Legacy #6" in content
-        assert TR.confirm_total__fee_rate in content
+        assert TR.confirm_total__fee_rate(self.client.layout_type) in content
         assert "71.56 sat" in content
 
     def input_flow_bolt(self) -> BRGeneratorType:
@@ -975,9 +993,9 @@ class InputFlowSignTxInformationMixed(InputFlowBase):
         super().__init__(client)
 
     def assert_content(self, content: str, title_path: str) -> None:
-        assert TR.translate(title_path) in content
-        assert TR.bitcoin__multiple_accounts in content
-        assert TR.confirm_total__fee_rate in content
+        assert TR.translate(title_path, self.client.layout_type) in content
+        assert TR.bitcoin__multiple_accounts(self.client.layout_type) in content
+        assert TR.confirm_total__fee_rate(self.client.layout_type) in content
         assert "18.33 sat" in content
 
     def input_flow_bolt(self) -> BRGeneratorType:
@@ -1137,7 +1155,10 @@ class InputFlowLockTimeBlockHeight(InputFlowBase):
 
     def assert_func(self, debug: DebugLink, br: messages.ButtonRequest) -> None:
         layout_text = get_text_possible_pagination(debug, br)
-        assert TR.bitcoin__locktime_set_to_blockheight in layout_text
+        assert (
+            TR.bitcoin__locktime_set_to_blockheight(self.client.layout_type)
+            in layout_text
+        )
         assert self.block_height in layout_text
 
     def input_flow_bolt(self) -> BRGeneratorType:
@@ -1161,7 +1182,7 @@ class InputFlowLockTimeDatetime(InputFlowBase):
 
     def assert_func(self, debug: DebugLink, br: messages.ButtonRequest) -> None:
         layout_text = get_text_possible_pagination(debug, br)
-        assert TR.bitcoin__locktime_set_to in layout_text
+        assert TR.bitcoin__locktime_set_to(self.client.layout_type) in layout_text
         assert self.lock_time_str.replace(" ", "") in layout_text.replace(" ", "")
 
     def input_flow_bolt(self) -> BRGeneratorType:
@@ -2309,26 +2330,35 @@ class InputFlowResetSkipBackup(InputFlowBase):
     def input_flow_bolt(self) -> BRGeneratorType:
         yield from self.BAK.confirm_new_wallet()
         yield  # Skip Backup
-        assert TR.backup__new_wallet_successfully_created in self.text_content()
+        assert (
+            TR.backup__new_wallet_successfully_created(self.client.layout_type)
+            in self.text_content()
+        )
         self.debug.press_no()
         yield  # Confirm skip backup
-        assert TR.backup__want_to_skip in self.text_content()
+        assert TR.backup__want_to_skip(self.client.layout_type) in self.text_content()
         self.debug.press_no()
 
     def input_flow_caesar(self) -> BRGeneratorType:
         yield from self.BAK.confirm_new_wallet()
         yield  # Skip Backup
-        assert TR.backup__new_wallet_created in self.text_content()
+        assert (
+            TR.backup__new_wallet_created(self.client.layout_type)
+            in self.text_content()
+        )
         self.debug.press_right()
         self.debug.press_no()
         yield  # Confirm skip backup
-        assert TR.backup__want_to_skip in self.text_content()
+        assert TR.backup__want_to_skip(self.client.layout_type) in self.text_content()
         self.debug.press_no()
 
     def input_flow_delizia(self) -> BRGeneratorType:
         yield from self.BAK.confirm_new_wallet()
         yield  # Skip Backup
-        assert TR.backup__new_wallet_created in self.text_content()
+        assert (
+            TR.backup__new_wallet_created(self.client.layout_type)
+            in self.text_content()
+        )
         self.debug.swipe_up()
         yield
         self.debug.click(buttons.CORNER_BUTTON)
@@ -2368,8 +2398,8 @@ class InputFlowConfirmAllWarnings(InputFlowBase):
             text = layout.footer().lower()
             # hi priority warning
             hi_prio = (
-                TR.words__cancel_and_exit,
-                TR.send__cancel_sign,
+                TR.words__cancel_and_exit(self.client.layout_type),
+                TR.send__cancel_sign(self.client.layout_type),
             )
             if any(needle.lower() in text for needle in hi_prio):
                 self.debug.click(buttons.CORNER_BUTTON)

--- a/tests/input_flows_helpers.py
+++ b/tests/input_flows_helpers.py
@@ -29,7 +29,7 @@ class PinFlow:
         if self.client.layout_type is LayoutType.Caesar:
             assert (yield).name == f"reenter_{what}"  # Reenter PIN
             assert (
-                TR.translate(f"{what}__reenter_to_confirm")
+                TR.translate(f"{what}__reenter_to_confirm", self.client.layout_type)
                 in self.debug.read_layout().text_content()
             )
             self.debug.press_yes()
@@ -48,7 +48,10 @@ class BackupFlow:
 
     def confirm_new_wallet(self) -> BRGeneratorType:
         yield
-        assert TR.reset__by_continuing in self.debug.read_layout().text_content()
+        assert (
+            TR.reset__by_continuing(self.debug.layout_type)
+            in self.debug.read_layout().text_content()
+        )
         if self.client.layout_type is LayoutType.Caesar:
             self.debug.press_right()
         self.debug.press_yes()
@@ -65,14 +68,16 @@ class RecoveryFlow:
 
     def confirm_recovery(self) -> BRGeneratorType:
         assert (yield).name == "recover_device"
-        assert TR.reset__by_continuing in self._text_content()
+        assert TR.reset__by_continuing(self.debug.layout_type) in self._text_content()
         if self.client.layout_type is LayoutType.Caesar:
             self.debug.press_right()
         self.debug.press_yes()
 
     def confirm_dry_run(self) -> BRGeneratorType:
         assert (yield).name == "confirm_seedcheck"
-        assert TR.recovery__check_dry_run in self._text_content()
+        assert (
+            TR.recovery__check_dry_run(self.debug.layout_type) in self._text_content()
+        )
         self.debug.press_yes()
 
     def setup_slip39_recovery(self, num_words: int) -> BRGeneratorType:
@@ -95,17 +100,23 @@ class RecoveryFlow:
 
     def recovery_homescreen_caesar(self) -> BRGeneratorType:
         yield
-        assert TR.recovery__num_of_words in self._text_content()
+        assert TR.recovery__num_of_words(self.debug.layout_type) in self._text_content()
         self.debug.press_yes()
 
     def enter_your_backup(self) -> BRGeneratorType:
         assert (yield).name == "recovery"
         if self.debug.layout_type is LayoutType.Delizia:
-            assert TR.recovery__enter_each_word in self._text_content()
+            assert (
+                TR.recovery__enter_each_word(self.debug.layout_type)
+                in self._text_content()
+            )
         else:
-            assert TR.recovery__enter_backup in self._text_content()
+            assert (
+                TR.recovery__enter_backup(self.debug.layout_type)
+                in self._text_content()
+            )
         is_dry_run = (
-            TR.recovery__title_dry_run.lower()
+            TR.recovery__title_dry_run(self.debug.layout_type).lower()
             in self.debug.read_layout().title().lower()
         )
         if self.client.layout_type is LayoutType.Caesar and not is_dry_run:
@@ -117,11 +128,12 @@ class RecoveryFlow:
     def enter_any_share(self) -> BRGeneratorType:
         assert (yield).name == "recovery"
         assert (
-            TR.recovery__enter_any_share in self._text_content()
-            or TR.recovery__enter_each_word in self._text_content()
+            TR.recovery__enter_any_share(self.debug.layout_type) in self._text_content()
+            or TR.recovery__enter_each_word(self.debug.layout_type)
+            in self._text_content()
         )
         is_dry_run = (
-            TR.recovery__title_dry_run.lower()
+            TR.recovery__title_dry_run(self.debug.layout_type).lower()
             in self.debug.read_layout().title().lower()
         )
         if self.client.layout_type is LayoutType.Caesar and not is_dry_run:
@@ -133,17 +145,26 @@ class RecoveryFlow:
     def abort_recovery(self, confirm: bool) -> BRGeneratorType:
         yield
         if self.client.layout_type is LayoutType.Caesar:
-            assert TR.recovery__num_of_words in self._text_content()
+            assert (
+                TR.recovery__num_of_words(self.debug.layout_type)
+                in self._text_content()
+            )
             self.debug.press_no()
             yield
-            assert TR.recovery__wanna_cancel_recovery in self._text_content()
+            assert (
+                TR.recovery__wanna_cancel_recovery(self.debug.layout_type)
+                in self._text_content()
+            )
             self.debug.press_right()
             if confirm:
                 self.debug.press_yes()
             else:
                 self.debug.press_no()
         elif self.client.layout_type is LayoutType.Delizia:
-            assert TR.recovery__enter_each_word in self._text_content()
+            assert (
+                TR.recovery__enter_each_word(self.debug.layout_type)
+                in self._text_content()
+            )
             self.debug.click(buttons.CORNER_BUTTON)
             self.debug.synchronize_at("VerticalMenu")
             if confirm:
@@ -151,10 +172,16 @@ class RecoveryFlow:
             else:
                 self.debug.click(buttons.CORNER_BUTTON)
         else:
-            assert TR.recovery__enter_any_share in self._text_content()
+            assert (
+                TR.recovery__enter_any_share(self.debug.layout_type)
+                in self._text_content()
+            )
             self.debug.press_no()
             yield
-            assert TR.recovery__wanna_cancel_recovery in self._text_content()
+            assert (
+                TR.recovery__wanna_cancel_recovery(self.debug.layout_type)
+                in self._text_content()
+            )
             if confirm:
                 self.debug.press_yes()
             else:
@@ -163,33 +190,41 @@ class RecoveryFlow:
     def abort_recovery_between_shares(self) -> BRGeneratorType:
         yield
         if self.client.layout_type is LayoutType.Caesar:
-            assert TR.regexp("recovery__x_of_y_entered_template").search(
-                self._text_content()
-            )
+            assert TR.regexp(
+                "recovery__x_of_y_entered_template", self.client.layout_type
+            ).search(self._text_content())
             self.debug.press_no()
             assert (yield).name == "abort_recovery"
-            assert TR.recovery__wanna_cancel_recovery in self._text_content()
+            assert (
+                TR.recovery__wanna_cancel_recovery(self.debug.layout_type)
+                in self._text_content()
+            )
             self.debug.press_right()
             self.debug.press_yes()
         elif self.client.layout_type is LayoutType.Delizia:
-            assert TR.regexp("recovery__x_of_y_entered_template").search(
-                self._text_content()
-            )
+            assert TR.regexp(
+                "recovery__x_of_y_entered_template", self.client.layout_type
+            ).search(self._text_content())
             self.debug.click(buttons.CORNER_BUTTON)
             self.debug.synchronize_at("VerticalMenu")
             self.debug.click(buttons.VERTICAL_MENU[0])
             assert (yield).name == "abort_recovery"
             self.debug.swipe_up()
             layout = self.debug.read_layout()
-            assert layout.title() == TR.recovery__title_cancel_recovery
+            assert layout.title() == TR.recovery__title_cancel_recovery(
+                self.debug.layout_type
+            )
             self.debug.click(buttons.TAP_TO_CONFIRM)
         else:
-            assert TR.regexp("recovery__x_of_y_entered_template").search(
-                self._text_content()
-            )
+            assert TR.regexp(
+                "recovery__x_of_y_entered_template", self.client.layout_type
+            ).search(self._text_content())
             self.debug.press_no()
             assert (yield).name == "abort_recovery"
-            assert TR.recovery__wanna_cancel_recovery in self._text_content()
+            assert (
+                TR.recovery__wanna_cancel_recovery(self.debug.layout_type)
+                in self._text_content()
+            )
             self.debug.press_yes()
 
     def input_number_of_words(self, num_words: int | None) -> BRGeneratorType:
@@ -197,9 +232,15 @@ class RecoveryFlow:
         assert br.code == B.MnemonicWordCount
         assert br.name == "recovery_word_count"
         if self.client.layout_type is LayoutType.Caesar:
-            assert TR.word_count__title in self.debug.read_layout().title()
+            assert (
+                TR.word_count__title(self.debug.layout_type)
+                in self.debug.read_layout().title()
+            )
         else:
-            assert TR.recovery__num_of_words in self._text_content()
+            assert (
+                TR.recovery__num_of_words(self.debug.layout_type)
+                in self._text_content()
+            )
 
         if num_words is None:
             self.debug.press_no()
@@ -209,44 +250,63 @@ class RecoveryFlow:
     def warning_invalid_recovery_seed(self) -> BRGeneratorType:
         br = yield
         assert br.code == B.Warning
-        assert TR.recovery__invalid_wallet_backup_entered in self._text_content()
+        assert (
+            TR.recovery__invalid_wallet_backup_entered(self.debug.layout_type)
+            in self._text_content()
+        )
         self.debug.press_yes()
 
     def warning_invalid_recovery_share(self) -> BRGeneratorType:
         br = yield
         assert br.code == B.Warning
-        assert TR.recovery__invalid_share_entered in self._text_content()
+        assert (
+            TR.recovery__invalid_share_entered(self.debug.layout_type)
+            in self._text_content()
+        )
         self.debug.press_yes()
 
     def warning_group_threshold_reached(self) -> BRGeneratorType:
         br = yield
         assert br.code == B.Warning
-        assert TR.recovery__group_threshold_reached in self._text_content()
+        assert (
+            TR.recovery__group_threshold_reached(self.debug.layout_type)
+            in self._text_content()
+        )
         self.debug.press_yes()
 
     def warning_share_already_entered(self) -> BRGeneratorType:
         br = yield
         assert br.code == B.Warning
-        assert TR.recovery__share_already_entered in self._text_content()
+        assert (
+            TR.recovery__share_already_entered(self.debug.layout_type)
+            in self._text_content()
+        )
         self.debug.press_yes()
 
     def warning_share_from_another_shamir(self) -> BRGeneratorType:
         br = yield
         assert br.code == B.Warning
         assert (
-            TR.recovery__share_from_another_multi_share_backup in self._text_content()
+            TR.recovery__share_from_another_multi_share_backup(self.debug.layout_type)
+            in self._text_content()
         )
         self.debug.press_yes()
 
     def success_share_group_entered(self) -> BRGeneratorType:
         assert (yield).name == "share_success"
-        assert TR.recovery__you_have_entered in self._text_content()
+        assert (
+            TR.recovery__you_have_entered(self.debug.layout_type)
+            in self._text_content()
+        )
         self.debug.press_yes()
 
     def success_wallet_recovered(self) -> BRGeneratorType:
         br = yield
         assert br.code == B.Success
-        assert TR.recovery__wallet_recovered in self._text_content()
+        assert (
+            TR.recovery__wallet_recovered(self.debug.layout_type)
+            in self._text_content()
+        )
         self.debug.press_yes()
 
     def success_bip39_dry_run_valid(self) -> BRGeneratorType:
@@ -255,7 +315,9 @@ class RecoveryFlow:
         text = get_text_possible_pagination(self.debug, br)
         # TODO: make sure the translations fit on one page
         if self.client.layout_type not in (LayoutType.Bolt, LayoutType.Delizia):
-            assert TR.recovery__dry_run_bip39_valid_match in text
+            assert (
+                TR.recovery__dry_run_bip39_valid_match(self.debug.layout_type) in text
+            )
         self.debug.press_yes()
 
     def success_slip39_dryrun_valid(self) -> BRGeneratorType:
@@ -264,7 +326,9 @@ class RecoveryFlow:
         text = get_text_possible_pagination(self.debug, br)
         # TODO: make sure the translations fit on one page
         if self.client.layout_type not in (LayoutType.Bolt, LayoutType.Delizia):
-            assert TR.recovery__dry_run_slip39_valid_match in text
+            assert (
+                TR.recovery__dry_run_slip39_valid_match(self.debug.layout_type) in text
+            )
         self.debug.press_yes()
 
     def warning_slip39_dryrun_mismatch(self) -> BRGeneratorType:
@@ -273,7 +337,10 @@ class RecoveryFlow:
         text = get_text_possible_pagination(self.debug, br)
         # TODO: make sure the translations fit on one page on TT
         if self.client.layout_type not in (LayoutType.Bolt, LayoutType.Delizia):
-            assert TR.recovery__dry_run_slip39_valid_mismatch in text
+            assert (
+                TR.recovery__dry_run_slip39_valid_mismatch(self.debug.layout_type)
+                in text
+            )
         self.debug.press_yes()
 
     def warning_bip39_dryrun_mismatch(self) -> BRGeneratorType:
@@ -282,7 +349,10 @@ class RecoveryFlow:
         text = get_text_possible_pagination(self.debug, br)
         # TODO: make sure the translations fit on one page
         if self.client.layout_type not in (LayoutType.Bolt, LayoutType.Delizia):
-            assert TR.recovery__dry_run_bip39_valid_mismatch in text
+            assert (
+                TR.recovery__dry_run_bip39_valid_mismatch(self.debug.layout_type)
+                in text
+            )
         self.debug.press_yes()
 
     def success_more_shares_needed(
@@ -358,7 +428,9 @@ class EthereumFlow:
 
     def confirm_data(self, info: bool = False, cancel: bool = False) -> BRGeneratorType:
         assert (yield).name == "confirm_data"
-        assert self.debug.read_layout().title() == TR.ethereum__title_input_data
+        assert self.debug.read_layout().title() == TR.ethereum__title_input_data(
+            self.debug.layout_type
+        )
         if info:
             self.debug.press_info()
         elif cancel:
@@ -370,7 +442,9 @@ class EthereumFlow:
         br = yield
         assert br.name == "confirm_data"
         assert br.pages is not None
-        assert self.debug.read_layout().title() == TR.ethereum__title_input_data
+        assert self.debug.read_layout().title() == TR.ethereum__title_input_data(
+            self.debug.layout_type
+        )
         for _ in range(br.pages):
             self.debug.read_layout()
             go_next(self.debug)
@@ -381,7 +455,9 @@ class EthereumFlow:
         assert br.name == "confirm_data"
         assert br.pages is not None
         assert br.pages > 2
-        assert self.debug.read_layout().title() == TR.ethereum__title_input_data
+        assert self.debug.read_layout().title() == TR.ethereum__title_input_data(
+            self.debug.layout_type
+        )
         if self.client.layout_type is LayoutType.Caesar:
             self.debug.press_right()
             self.debug.press_right()
@@ -399,23 +475,33 @@ class EthereumFlow:
         self, cancel: bool, info: bool, go_back_from_summary: bool
     ) -> BRGeneratorType:
         assert (yield).name == "confirm_ethereum_tx"
-        assert self.debug.read_layout().title() == TR.words__address
+        assert self.debug.read_layout().title() == TR.words__address(
+            self.debug.layout_type
+        )
         if cancel:
             self.debug.press_no()
             return
         if info:
             self.debug.press_info()
-            assert TR.words__account in self.debug.read_layout().text_content()
             assert (
-                TR.address_details__derivation_path
+                TR.words__account(self.debug.layout_type)
+                in self.debug.read_layout().text_content()
+            )
+            assert (
+                TR.address_details__derivation_path(self.debug.layout_type)
                 in self.debug.read_layout().text_content()
             )
             self.debug.press_no()
 
         self.debug.press_yes()
         assert (yield).name == "confirm_ethereum_tx"
-        assert self.debug.read_layout().title() == TR.words__title_summary
-        assert TR.send__maximum_fee in self.debug.read_layout().text_content()
+        assert self.debug.read_layout().title() == TR.words__title_summary(
+            self.debug.layout_type
+        )
+        assert (
+            TR.send__maximum_fee(self.debug.layout_type)
+            in self.debug.read_layout().text_content()
+        )
         if go_back_from_summary:
             self.debug.press_no()
             assert (yield).name == "confirm_ethereum_tx"
@@ -423,8 +509,14 @@ class EthereumFlow:
             assert (yield).name == "confirm_ethereum_tx"
         if info:
             self.debug.press_info()
-            assert TR.ethereum__gas_limit in self.debug.read_layout().text_content()
-            assert TR.ethereum__gas_price in self.debug.read_layout().text_content()
+            assert (
+                TR.ethereum__gas_limit(self.debug.layout_type)
+                in self.debug.read_layout().text_content()
+            )
+            assert (
+                TR.ethereum__gas_price(self.debug.layout_type)
+                in self.debug.read_layout().text_content()
+            )
             self.debug.press_no()
         self.debug.press_yes()
         assert (yield).name == "confirm_ethereum_tx"
@@ -434,15 +526,20 @@ class EthereumFlow:
     ) -> BRGeneratorType:
         assert (yield).name == "confirm_ethereum_tx"
         assert (
-            TR.ethereum__interaction_contract in self.debug.read_layout().title()
-            or TR.words__recipient in self.debug.read_layout().title()
+            TR.ethereum__interaction_contract(self.debug.layout_type)
+            in self.debug.read_layout().title()
+            or TR.words__recipient(self.debug.layout_type)
+            in self.debug.read_layout().title()
         )
         if cancel:
             self.debug.press_left()
             return
         self.debug.press_right()
         assert (yield).name == "confirm_ethereum_tx"
-        assert TR.send__maximum_fee in self.debug.read_layout().text_content()
+        assert (
+            TR.send__maximum_fee(self.debug.layout_type)
+            in self.debug.read_layout().text_content()
+        )
         if go_back_from_summary:
             self.debug.press_left()
             assert (yield).name == "confirm_ethereum_tx"
@@ -450,9 +547,15 @@ class EthereumFlow:
             assert (yield).name == "confirm_ethereum_tx"
         if info:
             self.debug.press_right()
-            assert TR.ethereum__gas_limit in self.debug.read_layout().text_content()
+            assert (
+                TR.ethereum__gas_limit(self.debug.layout_type)
+                in self.debug.read_layout().text_content()
+            )
             self.debug.press_right()
-            assert TR.ethereum__gas_price in self.debug.read_layout().text_content()
+            assert (
+                TR.ethereum__gas_price(self.debug.layout_type)
+                in self.debug.read_layout().text_content()
+            )
             self.debug.press_left()
             self.debug.press_left()
         self.debug.press_middle()
@@ -463,8 +566,8 @@ class EthereumFlow:
     ) -> BRGeneratorType:
         assert (yield).name == "confirm_output"
         title = self.debug.read_layout().title()
-        assert TR.words__address in title
-        assert TR.words__recipient in title
+        assert TR.words__address(self.debug.layout_type) in title
+        assert TR.words__recipient(self.debug.layout_type) in title
 
         if cancel:
             self.debug.press_no()
@@ -473,8 +576,8 @@ class EthereumFlow:
         self.debug.swipe_up()
         assert (yield).name == "confirm_total"
         layout = self.debug.read_layout()
-        assert layout.title() == TR.words__title_summary
-        assert TR.send__maximum_fee in layout.text_content()
+        assert layout.title() == TR.words__title_summary(self.debug.layout_type)
+        assert TR.send__maximum_fee(self.debug.layout_type) in layout.text_content()
         if go_back_from_summary:
             self.debug.press_no()
             assert (yield).name == "confirm_ethereum_tx"
@@ -485,8 +588,8 @@ class EthereumFlow:
             self.debug.synchronize_at("VerticalMenu")
             self.debug.click(buttons.VERTICAL_MENU[0])
             text = self.debug.read_layout().text_content()
-            assert TR.ethereum__gas_limit in text
-            assert TR.ethereum__gas_price in text
+            assert TR.ethereum__gas_limit(self.debug.layout_type) in text
+            assert TR.ethereum__gas_price(self.debug.layout_type) in text
             self.debug.click(buttons.CORNER_BUTTON)
             self.debug.click(buttons.CORNER_BUTTON)
         self.debug.swipe_up()
@@ -517,14 +620,14 @@ class EthereumFlow:
         assert br.code == B.SignTx
         assert br.name == "confirm_ethereum_staking_tx"
         assert self.debug.read_layout().title() in (
-            TR.ethereum__staking_stake,
-            TR.ethereum__staking_unstake,
-            TR.ethereum__staking_claim,
+            TR.ethereum__staking_stake(self.debug.layout_type),
+            TR.ethereum__staking_unstake(self.debug.layout_type),
+            TR.ethereum__staking_claim(self.debug.layout_type),
         )
         assert self.debug.read_layout().text_content() in (
-            TR.ethereum__staking_stake_intro,
-            TR.ethereum__staking_unstake_intro,
-            TR.ethereum__staking_claim_intro,
+            TR.ethereum__staking_stake_intro(self.debug.layout_type),
+            TR.ethereum__staking_unstake_intro(self.debug.layout_type),
+            TR.ethereum__staking_claim_intro(self.debug.layout_type),
         )
         if self.client.layout_type is LayoutType.Bolt:
             # confirm intro
@@ -533,8 +636,8 @@ class EthereumFlow:
                     buttons.CORNER_BUTTON,
                 )
                 assert self.debug.read_layout().title() in (
-                    TR.ethereum__staking_stake_address,
-                    TR.ethereum__staking_claim_address,
+                    TR.ethereum__staking_stake_address(self.debug.layout_type),
+                    TR.ethereum__staking_claim_address(self.debug.layout_type),
                 )
                 self.debug.press_no()
             self.debug.press_yes()
@@ -543,8 +646,14 @@ class EthereumFlow:
             # confirm summary
             if info:
                 self.debug.press_info()
-                assert TR.ethereum__gas_limit in self.debug.read_layout().text_content()
-                assert TR.ethereum__gas_price in self.debug.read_layout().text_content()
+                assert (
+                    TR.ethereum__gas_limit(self.debug.layout_type)
+                    in self.debug.read_layout().text_content()
+                )
+                assert (
+                    TR.ethereum__gas_price(self.debug.layout_type)
+                    in self.debug.read_layout().text_content()
+                )
                 self.debug.press_no()
             self.debug.press_yes()
             yield
@@ -558,8 +667,8 @@ class EthereumFlow:
                 self.debug.synchronize_at("VerticalMenu")
                 self.debug.click(buttons.VERTICAL_MENU[0])
                 assert self.debug.read_layout().title() in (
-                    TR.ethereum__staking_stake_address,
-                    TR.ethereum__staking_claim_address,
+                    TR.ethereum__staking_stake_address(self.debug.layout_type),
+                    TR.ethereum__staking_claim_address(self.debug.layout_type),
                 )
                 self.debug.click(buttons.CORNER_BUTTON)
                 self.debug.click(buttons.CORNER_BUTTON)
@@ -574,8 +683,14 @@ class EthereumFlow:
                 self.debug.click(buttons.CORNER_BUTTON)
                 self.debug.synchronize_at("VerticalMenu")
                 self.debug.click(buttons.VERTICAL_MENU[0])
-                assert TR.ethereum__gas_limit in self.debug.read_layout().text_content()
-                assert TR.ethereum__gas_price in self.debug.read_layout().text_content()
+                assert (
+                    TR.ethereum__gas_limit(self.debug.layout_type)
+                    in self.debug.read_layout().text_content()
+                )
+                assert (
+                    TR.ethereum__gas_price(self.debug.layout_type)
+                    in self.debug.read_layout().text_content()
+                )
                 self.debug.click(buttons.CORNER_BUTTON)
                 self.debug.click(buttons.CORNER_BUTTON)
             self.debug.swipe_up()
@@ -588,8 +703,8 @@ class EthereumFlow:
             if info:
                 self.debug.press_right()
                 assert self.debug.read_layout().title() in (
-                    TR.ethereum__staking_stake_address,
-                    TR.ethereum__staking_claim_address,
+                    TR.ethereum__staking_stake_address(self.debug.layout_type),
+                    TR.ethereum__staking_claim_address(self.debug.layout_type),
                 )
                 self.debug.press_left()
             self.debug.press_middle()
@@ -598,9 +713,15 @@ class EthereumFlow:
             # confirm summary
             if info:
                 self.debug.press_right()
-                assert TR.ethereum__gas_limit in self.debug.read_layout().text_content()
+                assert (
+                    TR.ethereum__gas_limit(self.debug.layout_type)
+                    in self.debug.read_layout().text_content()
+                )
                 self.debug.press_right()
-                assert TR.ethereum__gas_price in self.debug.read_layout().text_content()
+                assert (
+                    TR.ethereum__gas_price(self.debug.layout_type)
+                    in self.debug.read_layout().text_content()
+                )
                 self.debug.press_left()
                 self.debug.press_left()
             self.debug.press_middle()


### PR DESCRIPTION
This PR enables usage of per-layout translations in the tests
Current translation function returns `str` for simple translations but `dict` for multi-layout translations, which causes errors in the further process. To select a proper layout translation, one parameter `layout_type` is added to all translation functions.
