### PR TITLE
chore(python): update cli docs for `reboot-to-bootloader` command

### DIFF
--- a/python/src/trezorlib/cli/device.py
+++ b/python/src/trezorlib/cli/device.py
@@ -310,10 +310,7 @@ def sd_protect(
 @cli.command()
 @click.pass_obj
 def reboot_to_bootloader(obj: "TrezorConnection") -> None:
-    """Reboot device into bootloader mode.
-
-    Currently only supported on Trezor Model One.
-    """
+    """Reboot device into bootloader mode."""
     # avoid using @with_client because it closes the session afterwards,
     # which triggers double prompt on device
     with obj.client_context() as client:


### PR DESCRIPTION
Resolves #4694.

According to [docs](https://docs.trezor.io/trezor-firmware/core/index.html?highlight=safe%205#trezor-core):
```
Trezor Core is the second-gen firmware running on Trezor devices. 
It currently runs on Trezor T, Trezor Safe 3 and Trezor Safe 5.
```

I found [impl](https://github.com/trezor/trezor-firmware/blob/0fb1693ea8cb413cf43177d1bcbb033bb7685990/core/src/apps/management/reboot_to_bootloader.py#L57) for "reboot-to-bootloader"command in core, and therefore it's sufficient to remove the line about support for only Model One to make the documentation up-to-date again.

