### PR TITLE
fix(core): enable shsi clock after resuming from suspend mode

### DIFF
--- a/core/embed/sec/secure_aes/inc/sec/secure_aes.h
+++ b/core/embed/sec/secure_aes/inc/sec/secure_aes.h
@@ -17,8 +17,7 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-#ifndef TREZOR_HAL_SECURE_AES_H
-#define TREZOR_HAL_SECURE_AES_H
+#pragma once
 
 #include <trezor_types.h>
 
@@ -33,6 +32,9 @@ typedef enum {
 // Initializes secure AES module
 secbool secure_aes_init(void);
 
+// Deinitializes secure AES module
+void secure_aes_deinit(void);
+
 // Encrypts a block of data using AES-256 ECB and HW key (DHUK, BHK or XORK)
 // For optimal speed input and output should be aligned to 32 bits, size is in
 // bytes
@@ -44,5 +46,3 @@ secbool secure_aes_ecb_encrypt_hw(const uint8_t* input, size_t size,
 // bytes
 secbool secure_aes_ecb_decrypt_hw(const uint8_t* input, size_t size,
                                   uint8_t* output, secure_aes_keysel_t key);
-
-#endif  // TREZOR_HAL_SECURE_AES_H

--- a/core/embed/sec/secure_aes/stm32u5/secure_aes.c
+++ b/core/embed/sec/secure_aes/stm32u5/secure_aes.c
@@ -375,13 +375,32 @@ secbool secure_aes_init(void) {
 
   // Enable SHSI clock
   if (HAL_RCC_OscConfig(&osc_init_def) != HAL_OK) {
-    return secfalse;
+    goto cleanup;
   }
 
   // Enable SAES peripheral clock
+  __HAL_RCC_SAES_FORCE_RESET();
+  __HAL_RCC_SAES_RELEASE_RESET();
   __HAL_RCC_SAES_CLK_ENABLE();
 
   return sectrue;
+
+cleanup:
+  secure_aes_deinit();
+  return secfalse;
+}
+
+void secure_aes_deinit(void) {
+  __HAL_RCC_SAES_CLK_DISABLE();
+  __HAL_RCC_SAES_FORCE_RESET();
+  __HAL_RCC_SAES_RELEASE_RESET();
+
+  RCC_OscInitTypeDef osc_init_def = {0};
+  osc_init_def.OscillatorType = RCC_OSCILLATORTYPE_SHSI;
+  osc_init_def.SHSIState = RCC_SHSI_OFF;
+
+  // Disable SHSI clock
+  HAL_RCC_OscConfig(&osc_init_def);
 }
 
 #endif

--- a/core/embed/sys/powerctl/stm32u5/powerctl_suspend.c
+++ b/core/embed/sys/powerctl/stm32u5/powerctl_suspend.c
@@ -30,6 +30,10 @@
 #include <sec/optiga_transport.h>
 #endif
 
+#ifdef USE_STORAGE_HWKEY
+#include <sec/secure_aes.h>
+#endif
+
 #ifdef USE_TOUCH
 #include <io/touch.h>
 #endif
@@ -63,6 +67,9 @@ void powerctl_suspend(void) {
 
   // Deinitialize all drivers that are not required in low-power mode
   // (e.g., USB, display, touch, haptic, etc.).
+#ifdef USE_STORAGE_HWKEY
+  secure_aes_deinit();
+#endif
 #ifdef USE_OPTIGA
   optiga_deinit();
 #endif
@@ -147,6 +154,9 @@ void powerctl_suspend(void) {
 #endif
 #ifdef USE_USB
   usb_start();
+#endif
+#ifdef USE_STORAGE_HWKEY
+  secure_aes_init();
 #endif
 #ifdef USE_OPTIGA
   optiga_init_and_configure();


### PR DESCRIPTION
This PR addresses an issue causing the SAES peripheral to become non-functional after returning from suspend mode, and also introduces minor improvements to the SAES driver:

- Enables SHSI clock after returning from suspend mode
- Completely resets the SAES peripheral in `secure_aes_init()`
- Add `secure_aes_deinit()`