### PR TITLE
test(core): also rerun in case of a packet loss

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -36,7 +36,13 @@ per-file-ignores =
     tests/*:ANN
 
 [tool:pytest]
-addopts = -rfER --strict-markers --random-order --only-rerun='RuntimeError: Unexpected magic characters: 3f' --reruns=5
+addopts =
+    -rfER
+    --strict-markers
+    --random-order
+    --only-rerun='RuntimeError: Unexpected magic characters: 3f'
+    --only-rerun='Timeout: Timeout reading [A-Za-z]+ packet'
+    --reruns=5
 testpaths = tests crypto storage python/tests
 xfail_strict = true
 junit_family = xunit2


### PR DESCRIPTION
Tested locally with the patch below:
```diff
diff --git a/core/src/trezor/wire/codec/codec_v1.py b/core/src/trezor/wire/codec/codec_v1.py
index c1c3b39e7..cd23eab25 100644
--- a/core/src/trezor/wire/codec/codec_v1.py
+++ b/core/src/trezor/wire/codec/codec_v1.py
@@ -82,6 +82,13 @@ async def write_message(iface: WireInterface, mtype: int, mdata: bytes) -> None:
         _REP_INIT, report, 0, _REP_MARKER, _REP_MAGIC, _REP_MAGIC, mtype, msize
     )
 
+    from trezor.crypto import random
+
+    # HACK: drop BinanceSignTx response
+    drop = msize == 101 and random.uniform(10) < 5
+    if drop:
+        return
+
     nwritten = 0
     while True:
         # copy as much as possible to the report buffer
```



<!--
For core developers:
- Assign yourself to the PR.
- Set the priority to match the original issue.
- Add the PR to the current sprint.
- If it's a draft PR, mark it as "In Progress."
- If it's a final PR, mark it as "Needs Review."

For external contributors:
- Please open an issue before submitting a PR so we can discuss whether we want to proceed with it.
-->
