### PR TITLE
test(core): allow saving verbose log into a file

### DIFF
--- a/.github/workflows/core-hw.yml
+++ b/.github/workflows/core-hw.yml
@@ -55,13 +55,15 @@ jobs:
       - run: |
           # log serial console to file; sleep is used because tio needs stdin that is not /dev/null
           nix-shell --arg hardwareTest true --run "sleep 8h | tio --timestamp --no-autoconnect /dev/ttyTREZOR &> trezor.log" &
-          nix-shell --run "poetry run pytest -v tests/device_tests $TESTOPTS"
+          nix-shell --run "poetry run pytest -v --verbose-log-file pytest.log tests/device_tests $TESTOPTS"
       - run: tail -n50 trezor.log || true
         if: failure()
       - uses: actions/upload-artifact@v4
         with:
           name: core-hardware-${{ matrix.model }}-${{ matrix.coins }}
-          path: trezor.log
+          path: |
+            trezor.log
+            pytest.log
           retention-days: 7
         if: always()
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -16,6 +16,7 @@
 
 from __future__ import annotations
 
+import logging
 import os
 import typing as t
 from enum import IntEnum
@@ -441,6 +442,12 @@ def pytest_addoption(parser: "Parser") -> None:
         choices=translations.LANGUAGES,
         help="Run tests with a specified language: 'en' is the default",
     )
+    parser.addoption(
+        "--verbose-log-file",
+        action="store",
+        default=None,
+        help="File path for verbose logging",
+    )
 
 
 def pytest_configure(config: "Config") -> None:
@@ -468,6 +475,11 @@ def pytest_configure(config: "Config") -> None:
     verbosity = config.getoption("verbose")
     if verbosity:
         log.enable_debug_output(verbosity)
+
+        verbose_log_file = config.getoption("verbose_log_file")
+        if verbose_log_file:
+            handler = logging.FileHandler(verbose_log_file)
+            log.enable_debug_output(verbosity, handler)
 
     idval_orig = IdMaker._idval_from_value
 


### PR DESCRIPTION
It should help debugging stuck tests (e.g. https://github.com/trezor/trezor-firmware/actions/runs/13935367037/job/39002035625) and analyzing full test runs (e.g. [finding how much time does `DebugGetLinkState` request handling take](https://github.com/trezor/trezor-firmware/commit/75cc399e80d600494cc3510cf61fc3123f86a946#commitcomment-153830441)).

<!--
For core developers:
- Assign yourself to the PR.
- Set the priority to match the original issue.
- Add the PR to the current sprint.
- If it's a draft PR, mark it as "In Progress."
- If it's a final PR, mark it as "Needs Review."

For external contributors:
- Please open an issue before submitting a PR so we can discuss whether we want to proceed with it.
-->
