### PR TITLE
perf(core): simplify Button struct to save RAM

### DIFF
--- a/core/embed/rust/src/ui/layout_bolt/component/button.rs
+++ b/core/embed/rust/src/ui/layout_bolt/component/button.rs
@@ -30,7 +30,7 @@ pub struct Button {
     content: ButtonContent,
     styles: ButtonStyleSheet,
     state: State,
-    long_press: Option<Duration>,
+    long_press: Duration,
     long_timer: Timer,
     haptics: bool,
 }
@@ -47,7 +47,7 @@ impl Button {
             touch_expand: None,
             styles: theme::button_default(),
             state: State::Initial,
-            long_press: None,
+            long_press: Duration::ZERO,
             long_timer: Timer::new(),
             haptics: true,
         }
@@ -84,7 +84,7 @@ impl Button {
     }
 
     pub fn with_long_press(mut self, duration: Duration) -> Self {
-        self.long_press = Some(duration);
+        self.long_press = duration;
         self
     }
 
@@ -244,8 +244,8 @@ impl Component for Button {
                                 haptic::play(HapticEffect::ButtonPress);
                             }
                             self.set(ctx, State::Pressed);
-                            if let Some(duration) = self.long_press {
-                                self.long_timer.start(ctx, duration)
+                            if self.long_press != Duration::ZERO {
+                                self.long_timer.start(ctx, self.long_press)
                             }
                             return Some(ButtonMsg::Pressed);
                         }


### PR DESCRIPTION
## This branch:
```
`MnemonicKeyboard<Slip39Input>`: 1236 bytes, alignment: 4 bytes
print-type-size     field `.prompt`: 124 bytes
print-type-size     field `.swipe`: 20 bytes
print-type-size     field `.keys`: 792 bytes
print-type-size     field `.back`: 104 bytes
print-type-size     field `.input`: 192 bytes
print-type-size     field `.can_go_back`: 1 bytes
print-type-size     end padding: 3 bytes
```

## `main` branch:
```
`MnemonicKeyboard<Slip39Input>`: 1280 bytes, alignment: 4 bytes
print-type-size     field `.back`: 108 bytes
print-type-size     field `.input`: 196 bytes
print-type-size     field `.keys`: 828 bytes
print-type-size     field `.prompt`: 124 bytes
print-type-size     field `.swipe`: 20 bytes
print-type-size     field `.can_go_back`: 1 bytes
print-type-size     end padding: 3 bytes
```

<!--
For core developers:
- Assign yourself to the PR.
- Set the priority to match the original issue.
- Add the PR to the current sprint.
- If it's a draft PR, mark it as "In Progress."
- If it's a final PR, mark it as "Needs Review."

For external contributors:
- Please open an issue before submitting a PR so we can discuss whether we want to proceed with it.
-->
