### PR TITLE
Add BLE support to `Homescreen` events

### DIFF
--- a/core/SConscript.firmware
+++ b/core/SConscript.firmware
@@ -713,6 +713,7 @@ if FROZEN:
         bitcoin_only=BITCOIN_ONLY,
         backlight='backlight' in FEATURES_AVAILABLE,
         optiga='optiga' in FEATURES_AVAILABLE,
+        use_ble='ble' in FEATURES_AVAILABLE,
         use_button='button' in FEATURES_AVAILABLE,
         use_touch='touch' in FEATURES_AVAILABLE,
         ui_layout=ui.get_ui_layout(TREZOR_MODEL),

--- a/core/SConscript.unix
+++ b/core/SConscript.unix
@@ -769,6 +769,7 @@ if FROZEN:
         backlight='backlight' in FEATURES_AVAILABLE,
         optiga='optiga' in FEATURES_AVAILABLE,
         tropic='tropic' in FEATURES_AVAILABLE,
+        use_ble='ble' in FEATURES_AVAILABLE,
         use_button='button' in FEATURES_AVAILABLE,
         use_touch='touch' in FEATURES_AVAILABLE,
         ui_layout=ui.get_ui_layout(TREZOR_MODEL),

--- a/core/embed/rust/src/ui/api/firmware_micropython.rs
+++ b/core/embed/rust/src/ui/api/firmware_micropython.rs
@@ -1068,6 +1068,9 @@ pub static mp_module_trezorui_api: Module = obj_module! {
     ///     def usb_event(self, connected: bool) -> LayoutState | None:
     ///         """Receive a USB connect/disconnect event."""
     ///
+    ///     def ble_event(self, event: tuple[int, bytes]) -> LayoutState | None:
+    ///         """Receive a BLE event."""
+    ///
     ///     def timer(self, token: int) -> LayoutState | None:
     ///         """Callback for the timer set by `attach_timer_fn`.
     ///

--- a/core/embed/upymod/modtrezorio/modtrezorio-poll.h
+++ b/core/embed/upymod/modtrezorio/modtrezorio-poll.h
@@ -207,9 +207,13 @@ STATIC mp_obj_t mod_trezorio_poll(mp_obj_t ifaces, mp_obj_t list_ref,
         ble_event_t event = {0};
         bool read = ble_get_event(&event);
         if (read) {
+          mp_obj_t data = mp_const_empty_bytes;
+          if (event.data_len > 0) {
+            data = mp_obj_new_bytes(event.data, event.data_len);
+          }
           mp_obj_tuple_t *tuple = MP_OBJ_TO_PTR(mp_obj_new_tuple(2, NULL));
           tuple->items[0] = MP_OBJ_NEW_SMALL_INT(event.type);
-          tuple->items[1] = mp_obj_new_bytes(event.data, event.data_len);
+          tuple->items[1] = data;
           ret->items[0] = MP_OBJ_NEW_SMALL_INT(i);
           ret->items[1] = MP_OBJ_FROM_PTR(tuple);
           return mp_const_true;

--- a/core/mocks/generated/trezorui_api.pyi
+++ b/core/mocks/generated/trezorui_api.pyi
@@ -26,6 +26,8 @@ class LayoutObj(Generic[T]):
         """Receive a progress event."""
     def usb_event(self, connected: bool) -> LayoutState | None:
         """Receive a USB connect/disconnect event."""
+    def ble_event(self, event: tuple[int, bytes]) -> LayoutState | None:
+        """Receive a BLE event."""
     def timer(self, token: int) -> LayoutState | None:
         """Callback for the timer set by `attach_timer_fn`.
         This function should be called by the executor after the corresponding

--- a/core/site_scons/site_tools/micropython/__init__.py
+++ b/core/site_scons/site_tools/micropython/__init__.py
@@ -47,6 +47,7 @@ def generate(env):
         tropic = env["tropic"]
         touch = env["use_touch"]
         button = env["use_button"]
+        ble = env["use_ble"]
         layout_bolt = env["ui_layout"] == "UI_LAYOUT_BOLT"
         layout_caesar = env["ui_layout"] == "UI_LAYOUT_CAESAR"
         layout_delizia = env["ui_layout"] == "UI_LAYOUT_DELIZIA"
@@ -60,6 +61,7 @@ def generate(env):
             rf"-e 's/utils\.UI_LAYOUT == \"BOLT\"/{layout_bolt}/g'",
             rf"-e 's/utils\.UI_LAYOUT == \"CAESAR\"/{layout_caesar}/g'",
             rf"-e 's/utils\.UI_LAYOUT == \"DELIZIA\"/{layout_delizia}/g'",
+            rf"-e 's/utils\.USE_BLE/{ble}/g'",
             rf"-e 's/utils\.USE_BUTTON/{button}/g'",
             rf"-e 's/utils\.USE_TOUCH/{touch}/g'",
             rf"-e 's/utils\.USE_THP/{thp}/g'",

--- a/core/src/trezor/ui/layouts/homescreen.py
+++ b/core/src/trezor/ui/layouts/homescreen.py
@@ -3,7 +3,7 @@ from typing import TYPE_CHECKING
 import storage.cache as storage_cache
 import trezorui_api
 from storage.cache_common import APP_COMMON_BUSY_DEADLINE_MS
-from trezor import TR, ui
+from trezor import TR, ui, utils
 
 if TYPE_CHECKING:
     from typing import Any, Callable, Iterator, ParamSpec, TypeVar
@@ -101,9 +101,21 @@ class Homescreen(HomescreenBase):
             event = await usbcheck
             self._event(self.layout.usb_event, event)
 
+    if utils.USE_BLE:
+
+        async def ble_checker_task(self) -> None:
+            from trezor import io, loop
+
+            blecheck = loop.wait(io.BLE_EVENT)
+            while True:
+                event = await blecheck
+                self._event(self.layout.ble_event, event)
+
     def create_tasks(self) -> Iterator[loop.Task]:
         yield from super().create_tasks()
         yield self.usb_checker_task()
+        if utils.USE_BLE:
+            yield self.ble_checker_task()
 
 
 class Lockscreen(HomescreenBase):


### PR DESCRIPTION
This PR adds a [BLE polling task](https://github.com/trezor/trezor-firmware/blob/5158b58b119631c213fd393781ed6f709f782927/core/src/trezor/ui/layouts/homescreen.py#L106) to homescreen layout.
It will fetch BLE events ([using `ble_get_event`](https://github.com/trezor/trezor-firmware/blob/5158b58b119631c213fd393781ed6f709f782927/core/embed/upymod/modtrezorio/modtrezorio-poll.h#L208)) and convert them to [`BLEEvent`](https://github.com/trezor/trezor-firmware/blob/5158b58b119631c213fd393781ed6f709f782927/core/embed/rust/src/ui/layout/obj.rs#L543) in Rust.


<!--
For core developers:
- Assign yourself to the PR.
- Set the priority to match the original issue.
- Add the PR to the current sprint.
- If it's a draft PR, mark it as "In Progress."
- If it's a final PR, mark it as "Needs Review."

For external contributors:
- Please open an issue before submitting a PR so we can discuss whether we want to proceed with it.
-->
