### PR TITLE
fix(core): don't invoke `dump_meminfo_json` on emulator

### DIFF
--- a/core/embed/upymod/modtrezorutils/modtrezorutils.c
+++ b/core/embed/upymod/modtrezorutils/modtrezorutils.c
@@ -284,7 +284,7 @@ STATIC MP_DEFINE_CONST_FUN_OBJ_0(mod_trezorutils_estimate_unused_stack_obj,
 #if MICROPY_OOM_CALLBACK
 static void gc_oom_callback(void) {
   gc_dump_info();
-#if BLOCK_ON_VCP || TREZOR_EMULATOR
+#if BLOCK_ON_VCP
   dump_meminfo_json(NULL);  // dump to stdout
 #endif
 }


### PR DESCRIPTION
Otherwise, the unit-tests emit a lot of output:
![image](https://github.com/user-attachments/assets/587d5583-3de0-45e4-85f1-139d7c264ae0)
https://github.com/trezor/trezor-firmware/actions/runs/13949157258/job/39043798020?pr=4798

<!--
For core developers:
- Assign yourself to the PR.
- Set the priority to match the original issue.
- Add the PR to the current sprint.
- If it's a draft PR, mark it as "In Progress."
- If it's a final PR, mark it as "Needs Review."

For external contributors:
- Please open an issue before submitting a PR so we can discuss whether we want to proceed with it.
-->
