### PR TITLE
Remove a submodule subtree of libtropic

### DIFF
--- a/core/SConscript.unix
+++ b/core/SConscript.unix
@@ -254,9 +254,6 @@ SOURCE_MOD += [
     'embed/upymod/modutime.c',
 ]
 
-CPPDEFINES_MOD += ['USE_TREZOR_CRYPTO']
-
-
 SOURCE_MICROPYTHON = [
     'vendor/micropython/extmod/modubinascii.c',
     'vendor/micropython/extmod/moductypes.c',

--- a/core/site_scons/models/T3W1/emulator.py
+++ b/core/site_scons/models/T3W1/emulator.py
@@ -66,7 +66,7 @@ def configure(
             "vendor/libtropic/src/lt_l2_frame_check.c",
             "vendor/libtropic/src/lt_l3.c",
             "vendor/libtropic/src/lt_random.c",
-            "vendor/libtropic/hal/port/unix/lt_port_unix.c",
+            "vendor/libtropic/hal/port/unix/lt_port_unix_tcp.c",
             "vendor/libtropic/hal/crypto/trezor_crypto/lt_crypto_trezor_aesgcm.c",
             "vendor/libtropic/hal/crypto/trezor_crypto/lt_crypto_trezor_ed25519.c",
             "vendor/libtropic/hal/crypto/trezor_crypto/lt_crypto_trezor_sha256.c",
@@ -76,8 +76,9 @@ def configure(
         paths += ["vendor/libtropic/include"]
         paths += ["vendor/libtropic/src"]
         defines += ["USE_TREZOR_CRYPTO"]
+        defines += [("LT_USE_TREZOR_CRYPTO", "1")]
         features_available.append("tropic")
-        defines += ["USE_TROPIC=1"]
+        defines += [("USE_TROPIC", "1")]
 
     if "input" in features_wanted:
         sources += ["embed/io/touch/unix/touch.c"]

--- a/core/site_scons/models/T3W1/trezor_t3w1_revA.py
+++ b/core/site_scons/models/T3W1/trezor_t3w1_revA.py
@@ -164,7 +164,7 @@ def configure(
         paths += ["vendor/libtropic/include"]
         paths += ["vendor/libtropic/src"]
         defines += [("USE_TROPIC", "1")]
-        defines += [("USE_TREZOR_CRYPTO", "1")]
+        defines += [("LT_USE_TREZOR_CRYPTO", "1")]
 
     if "sbu" in features_wanted:
         sources += ["embed/io/sbu/stm32/sbu.c"]

--- a/core/site_scons/models/T3W1/trezor_t3w1_revB.py
+++ b/core/site_scons/models/T3W1/trezor_t3w1_revB.py
@@ -164,7 +164,7 @@ def configure(
         paths += ["vendor/libtropic/include"]
         paths += ["vendor/libtropic/src"]
         defines += [("USE_TROPIC", "1")]
-        defines += [("USE_TREZOR_CRYPTO", "1")]
+        defines += [("LT_USE_TREZOR_CRYPTO", "1")]
 
     if "sbu" in features_wanted:
         sources += ["embed/io/sbu/stm32/sbu.c"]

--- a/core/site_scons/models/T3W1/trezor_t3w1_revC.py
+++ b/core/site_scons/models/T3W1/trezor_t3w1_revC.py
@@ -164,7 +164,7 @@ def configure(
         paths += ["vendor/libtropic/include"]
         paths += ["vendor/libtropic/src"]
         defines += [("USE_TROPIC", "1")]
-        defines += [("USE_TREZOR_CRYPTO", "1")]
+        defines += [("LT_USE_TREZOR_CRYPTO", "1")]
 
     if "sbu" in features_wanted:
         sources += ["embed/io/sbu/stm32/sbu.c"]


### PR DESCRIPTION
The pinned version of libtropic had a `tests/platforms/libtropic-stm32` repostitory as a submodule. This would in turn pull in STM Cube SDK, which pulls in an insane number of per-platform submodules, exploding the total size of the checkout when using recursive submodules (our recommended default).

As of https://github.com/tropicsquare/libtropic/pull/55 this part is, rather sensibly, wholly excluded from the libtropic repo, so updating the submodule resolves the problem.

<!--
For core developers:
- Assign yourself to the PR.
- Set the priority to match the original issue.
- Add the PR to the current sprint.
- If it's a draft PR, mark it as "In Progress."
- If it's a final PR, mark it as "Needs Review."

For external contributors:
- Please open an issue before submitting a PR so we can discuss whether we want to proceed with it.
-->
