### PR TITLE
remove final wait from report commands

### DIFF
--- a/core/embed/projects/prodtest/cmd/prodtest_pmic.c
+++ b/core/embed/projects/prodtest/cmd/prodtest_pmic.c
@@ -187,13 +187,14 @@ static void prodtest_pmic_report(cli_t* cli) {
         (int)report.die_temp, (int)abs(report.die_temp * 1000) % 1000,
         report.ibat_meas_status, report.buck_status, state);
 
-    do {
-      if (cli_aborted(cli)) {
-        return;
-      }
-    } while (!ticks_expired(ticks + period));
-
-    ticks += period;
+    if (count > 0) {
+      do {
+        if (cli_aborted(cli)) {
+          return;
+        }
+      } while (!ticks_expired(ticks + period));
+      ticks += period;
+    }
   }
 
   cli_ok(cli, "");

--- a/core/embed/projects/prodtest/cmd/prodtest_wpc.c
+++ b/core/embed/projects/prodtest/cmd/prodtest_wpc.c
@@ -151,13 +151,14 @@ static void prodtest_wpc_report(cli_t* cli) {
                  report.opfreq, (int)report.ntc,
                  (int)abs(report.ntc * 1000) % 1000);
 
-    do {
-      if (cli_aborted(cli)) {
-        return;
-      }
-    } while (!ticks_expired(ticks + period));
-
-    ticks += period;
+    if (count > 0) {
+      do {
+        if (cli_aborted(cli)) {
+          return;
+        }
+      } while (!ticks_expired(ticks + period));
+      ticks += period;
+    }
   }
 
   cli_ok(cli, "");


### PR DESCRIPTION
This PR removes an unnecessary wait after last report in prodtests pmic-report and wpc-report commands