### PR TITLE
Remove obsolete font names from lang JSONs

### DIFF
--- a/core/tools/codegen/gen_font.py
+++ b/core/tools/codegen/gen_font.py
@@ -280,10 +280,13 @@ class FaceProcessor:
     def _rs_file_name(self) -> Path:
         return (
             RUST_FONTS_DEST
-            / f"layout_{LAYOUT_NAME}"
+            / f"layout_{LAYOUT_NAME.lower()}"
             / "fonts"
             / f"font_{self.fontname}.rs"
         )
+
+    def _foreign_json_name(self, upper_cased: bool, lang: str) -> str:
+        return f"font_{self.fontname}{'_upper' if upper_cased else ''}_{lang}.json"
 
     def write_files(self) -> None:
         # JSON files:
@@ -310,10 +313,8 @@ class FaceProcessor:
                 glyph = Glyph.from_face(self.face, c, self.shaveX)
                 glyph.print_metrics()
                 fontdata[map_from] = glyph.to_bytes(self.bpp).hex()
-            file = (
-                JSON_FONTS_DEST
-                / f"font_{self.fontname}{'_upper' if upper_cased else ''}_{lang}.json"
-            )
+            file_name = self._foreign_json_name(upper_cased, lang)
+            file = JSON_FONTS_DEST / file_name
             json_content = json.dumps(fontdata, indent=2, ensure_ascii=False)
             file.write_text(json_content + "\n")
 
@@ -473,7 +474,7 @@ class FaceProcessor:
 
 def gen_layout_bolt():
     global LAYOUT_NAME
-    LAYOUT_NAME = "bolt"
+    LAYOUT_NAME = "Bolt"
     FaceProcessor("TTHoves", "Regular", 21, ext="otf", font_idx=1).write_files()
     FaceProcessor("TTHoves", "DemiBold", 21, ext="otf", font_idx=5).write_files()
     FaceProcessor(
@@ -490,7 +491,7 @@ def gen_layout_bolt():
 
 def gen_layout_caesar():
     global LAYOUT_NAME
-    LAYOUT_NAME = "caesar"
+    LAYOUT_NAME = "Caesar"
     FaceProcessor(
         "PixelOperator",
         "Regular",
@@ -527,7 +528,7 @@ def gen_layout_caesar():
 
 def gen_layout_delizia():
     global LAYOUT_NAME
-    LAYOUT_NAME = "delizia"
+    LAYOUT_NAME = "Delizia"
     # FIXME: BIG font id not needed
     FaceProcessor("TTSatoshi", "DemiBold", 42, ext="otf", font_idx=1).write_files()
     FaceProcessor("TTSatoshi", "DemiBold", 21, ext="otf", font_idx=1).write_files()
@@ -543,10 +544,11 @@ def gen_layout_delizia():
         font_idx_upper=7,
     ).write_files()
 
+
 LAYOUTS = {
-    "bolt": gen_layout_bolt,
-    "caesar": gen_layout_caesar,
-    "delizia": gen_layout_delizia,
+    "Bolt": gen_layout_bolt,
+    "Caesar": gen_layout_caesar,
+    "Delizia": gen_layout_delizia,
 }
 
 

--- a/core/translations/cs.json
+++ b/core/translations/cs.json
@@ -1,44 +1,33 @@
 {
   "fonts": {
     "Bolt": {
-      "1_FONT_NORMAL": "font_tthoves_regular_21_cs.json",
-      "2_FONT_BOLD": null,
-      "3_FONT_MONO": "font_robotomono_medium_20_cs.json",
-      "4_FONT_BIG": null,
-      "5_FONT_DEMIBOLD": "font_tthoves_demibold_21_cs.json",
-      "6_FONT_NORMAL_UPPER": null,
-      "7_FONT_BOLD_UPPER": "font_tthoves_bold_17_upper_cs.json",
-      "8_FONT_SUB": null
+      "1": "font_tthoves_regular_21_cs.json",
+      "3": "font_robotomono_medium_20_cs.json",
+      "5": "font_tthoves_demibold_21_cs.json",
+      "7": "font_tthoves_bold_17_upper_cs.json"
     },
     "Caesar": {
-      "1_FONT_NORMAL": "font_pixeloperator_regular_8_cs.json",
-      "2_FONT_BOLD": "font_pixeloperator_bold_8_cs.json",
-      "3_FONT_MONO": "font_pixeloperatormono_regular_8_cs.json",
-      "4_FONT_BIG": "font_unifont_regular_16_cs.json",
-      "5_FONT_DEMIBOLD": "font_unifont_bold_16_cs.json",
-      "6_FONT_NORMAL_UPPER": "font_pixeloperator_regular_8_upper_cs.json",
-      "7_FONT_BOLD_UPPER": "font_pixeloperator_bold_8_upper_cs.json",
-      "8_FONT_SUB": null
+      "1": "font_pixeloperator_regular_8_cs.json",
+      "2": "font_pixeloperator_bold_8_cs.json",
+      "3": "font_pixeloperatormono_regular_8_cs.json",
+      "4": "font_unifont_regular_16_cs.json",
+      "5": "font_unifont_bold_16_cs.json",
+      "6": "font_pixeloperator_regular_8_upper_cs.json",
+      "7": "font_pixeloperator_bold_8_upper_cs.json"
     },
     "Delizia": {
-      "1_FONT_NORMAL": "font_ttsatoshi_demibold_21_cs.json",
-      "2_FONT_BOLD": "font_ttsatoshi_demibold_21_cs.json",
-      "3_FONT_MONO": "font_robotomono_medium_21_cs.json",
-      "4_FONT_BIG": null,
-      "5_FONT_DEMIBOLD": "font_ttsatoshi_demibold_21_cs.json",
-      "6_FONT_NORMAL_UPPER": null,
-      "7_FONT_BOLD_UPPER": null,
-      "8_FONT_SUB": "font_ttsatoshi_demibold_18_cs.json"
+      "1": "font_ttsatoshi_demibold_21_cs.json",
+      "2": "font_ttsatoshi_demibold_21_cs.json",
+      "3": "font_robotomono_medium_21_cs.json",
+      "5": "font_ttsatoshi_demibold_21_cs.json",
+      "8": "font_ttsatoshi_demibold_18_cs.json"
     },
     "Eckhart": {
-      "1_FONT_NORMAL": "font_ttsatoshi_demibold_21_cs.json",
-      "2_FONT_BOLD": "font_ttsatoshi_demibold_21_cs.json",
-      "3_FONT_MONO": "font_robotomono_medium_21_cs.json",
-      "4_FONT_BIG": null,
-      "5_FONT_DEMIBOLD": "font_ttsatoshi_demibold_21_cs.json",
-      "6_FONT_NORMAL_UPPER": null,
-      "7_FONT_BOLD_UPPER": null,
-      "8_FONT_SUB": "font_ttsatoshi_demibold_18_cs.json"
+      "1": "font_ttsatoshi_demibold_21_cs.json",
+      "2": "font_ttsatoshi_demibold_21_cs.json",
+      "3": "font_robotomono_medium_21_cs.json",
+      "5": "font_ttsatoshi_demibold_21_cs.json",
+      "8": "font_ttsatoshi_demibold_18_cs.json"
     }
   },
   "header": {

--- a/core/translations/de.json
+++ b/core/translations/de.json
@@ -1,44 +1,33 @@
 {
   "fonts": {
     "Bolt": {
-      "1_FONT_NORMAL": "font_tthoves_regular_21_de.json",
-      "2_FONT_BOLD": null,
-      "3_FONT_MONO": "font_robotomono_medium_20_de.json",
-      "4_FONT_BIG": null,
-      "5_FONT_DEMIBOLD": "font_tthoves_demibold_21_de.json",
-      "6_FONT_NORMAL_UPPER": null,
-      "7_FONT_BOLD_UPPER": "font_tthoves_bold_17_upper_de.json",
-      "8_FONT_SUB": null
+      "1": "font_tthoves_regular_21_de.json",
+      "3": "font_robotomono_medium_20_de.json",
+      "5": "font_tthoves_demibold_21_de.json",
+      "7": "font_tthoves_bold_17_upper_de.json"
     },
     "Caesar": {
-      "1_FONT_NORMAL": "font_pixeloperator_regular_8_de.json",
-      "2_FONT_BOLD": "font_pixeloperator_bold_8_de.json",
-      "3_FONT_MONO": "font_pixeloperatormono_regular_8_de.json",
-      "4_FONT_BIG": "font_unifont_regular_16_de.json",
-      "5_FONT_DEMIBOLD": "font_unifont_bold_16_de.json",
-      "6_FONT_NORMAL_UPPER": "font_pixeloperator_regular_8_upper_de.json",
-      "7_FONT_BOLD_UPPER": "font_pixeloperator_bold_8_upper_de.json",
-      "8_FONT_SUB": null
+      "1": "font_pixeloperator_regular_8_de.json",
+      "2": "font_pixeloperator_bold_8_de.json",
+      "3": "font_pixeloperatormono_regular_8_de.json",
+      "4": "font_unifont_regular_16_de.json",
+      "5": "font_unifont_bold_16_de.json",
+      "6": "font_pixeloperator_regular_8_upper_de.json",
+      "7": "font_pixeloperator_bold_8_upper_de.json"
     },
     "Delizia": {
-      "1_FONT_NORMAL": "font_ttsatoshi_demibold_21_de.json",
-      "2_FONT_BOLD": "font_ttsatoshi_demibold_21_de.json",
-      "3_FONT_MONO": "font_robotomono_medium_21_de.json",
-      "4_FONT_BIG": null,
-      "5_FONT_DEMIBOLD": "font_ttsatoshi_demibold_21_de.json",
-      "6_FONT_NORMAL_UPPER": null,
-      "7_FONT_BOLD_UPPER": null,
-      "8_FONT_SUB": "font_ttsatoshi_demibold_18_de.json"
+      "1": "font_ttsatoshi_demibold_21_de.json",
+      "2": "font_ttsatoshi_demibold_21_de.json",
+      "3": "font_robotomono_medium_21_de.json",
+      "5": "font_ttsatoshi_demibold_21_de.json",
+      "8": "font_ttsatoshi_demibold_18_de.json"
     },
     "Eckhart": {
-      "1_FONT_NORMAL": "font_ttsatoshi_demibold_21_de.json",
-      "2_FONT_BOLD": "font_ttsatoshi_demibold_21_de.json",
-      "3_FONT_MONO": "font_robotomono_medium_21_de.json",
-      "4_FONT_BIG": null,
-      "5_FONT_DEMIBOLD": "font_ttsatoshi_demibold_21_de.json",
-      "6_FONT_NORMAL_UPPER": null,
-      "7_FONT_BOLD_UPPER": null,
-      "8_FONT_SUB": "font_ttsatoshi_demibold_18_de.json"
+      "1": "font_ttsatoshi_demibold_21_de.json",
+      "2": "font_ttsatoshi_demibold_21_de.json",
+      "3": "font_robotomono_medium_21_de.json",
+      "5": "font_ttsatoshi_demibold_21_de.json",
+      "8": "font_ttsatoshi_demibold_18_de.json"
     }
   },
   "header": {

--- a/core/translations/es.json
+++ b/core/translations/es.json
@@ -1,44 +1,33 @@
 {
   "fonts": {
     "Bolt": {
-      "1_FONT_NORMAL": "font_tthoves_regular_21_es.json",
-      "2_FONT_BOLD": null,
-      "3_FONT_MONO": "font_robotomono_medium_20_es.json",
-      "4_FONT_BIG": null,
-      "5_FONT_DEMIBOLD": "font_tthoves_demibold_21_es.json",
-      "6_FONT_NORMAL_UPPER": null,
-      "7_FONT_BOLD_UPPER": "font_tthoves_bold_17_upper_es.json",
-      "8_FONT_SUB": null
+      "1": "font_tthoves_regular_21_es.json",
+      "3": "font_robotomono_medium_20_es.json",
+      "5": "font_tthoves_demibold_21_es.json",
+      "7": "font_tthoves_bold_17_upper_es.json"
     },
     "Caesar": {
-      "1_FONT_NORMAL": "font_pixeloperator_regular_8_es.json",
-      "2_FONT_BOLD": "font_pixeloperator_bold_8_es.json",
-      "3_FONT_MONO": "font_pixeloperatormono_regular_8_es.json",
-      "4_FONT_BIG": "font_unifont_regular_16_es.json",
-      "5_FONT_DEMIBOLD": "font_unifont_bold_16_es.json",
-      "6_FONT_NORMAL_UPPER": "font_pixeloperator_regular_8_upper_es.json",
-      "7_FONT_BOLD_UPPER": "font_pixeloperator_bold_8_upper_es.json",
-      "8_FONT_SUB": null
+      "1": "font_pixeloperator_regular_8_es.json",
+      "2": "font_pixeloperator_bold_8_es.json",
+      "3": "font_pixeloperatormono_regular_8_es.json",
+      "4": "font_unifont_regular_16_es.json",
+      "5": "font_unifont_bold_16_es.json",
+      "6": "font_pixeloperator_regular_8_upper_es.json",
+      "7": "font_pixeloperator_bold_8_upper_es.json"
     },
     "Delizia": {
-      "1_FONT_NORMAL": "font_ttsatoshi_demibold_21_es.json",
-      "2_FONT_BOLD": "font_ttsatoshi_demibold_21_es.json",
-      "3_FONT_MONO": "font_robotomono_medium_21_es.json",
-      "4_FONT_BIG": null,
-      "5_FONT_DEMIBOLD": "font_ttsatoshi_demibold_21_es.json",
-      "6_FONT_NORMAL_UPPER": null,
-      "7_FONT_BOLD_UPPER": null,
-      "8_FONT_SUB": "font_ttsatoshi_demibold_18_es.json"
+      "1": "font_ttsatoshi_demibold_21_es.json",
+      "2": "font_ttsatoshi_demibold_21_es.json",
+      "3": "font_robotomono_medium_21_es.json",
+      "5": "font_ttsatoshi_demibold_21_es.json",
+      "8": "font_ttsatoshi_demibold_18_es.json"
     },
     "Eckhart": {
-      "1_FONT_NORMAL": "font_ttsatoshi_demibold_21_es.json",
-      "2_FONT_BOLD": "font_ttsatoshi_demibold_21_es.json",
-      "3_FONT_MONO": "font_robotomono_medium_21_es.json",
-      "4_FONT_BIG": null,
-      "5_FONT_DEMIBOLD": "font_ttsatoshi_demibold_21_es.json",
-      "6_FONT_NORMAL_UPPER": null,
-      "7_FONT_BOLD_UPPER": null,
-      "8_FONT_SUB": "font_ttsatoshi_demibold_18_es.json"
+      "1": "font_ttsatoshi_demibold_21_es.json",
+      "2": "font_ttsatoshi_demibold_21_es.json",
+      "3": "font_robotomono_medium_21_es.json",
+      "5": "font_ttsatoshi_demibold_21_es.json",
+      "8": "font_ttsatoshi_demibold_18_es.json"
     }
   },
   "header": {

--- a/core/translations/fr.json
+++ b/core/translations/fr.json
@@ -1,44 +1,33 @@
 {
   "fonts": {
     "Bolt": {
-      "1_FONT_NORMAL": "font_tthoves_regular_21_fr.json",
-      "2_FONT_BOLD": null,
-      "3_FONT_MONO": "font_robotomono_medium_20_fr.json",
-      "4_FONT_BIG": null,
-      "5_FONT_DEMIBOLD": "font_tthoves_demibold_21_fr.json",
-      "6_FONT_NORMAL_UPPER": null,
-      "7_FONT_BOLD_UPPER": "font_tthoves_bold_17_upper_fr.json",
-      "8_FONT_SUB": null
+      "1": "font_tthoves_regular_21_fr.json",
+      "3": "font_robotomono_medium_20_fr.json",
+      "5": "font_tthoves_demibold_21_fr.json",
+      "7": "font_tthoves_bold_17_upper_fr.json"
     },
     "Caesar": {
-      "1_FONT_NORMAL": "font_pixeloperator_regular_8_fr.json",
-      "2_FONT_BOLD": "font_pixeloperator_bold_8_fr.json",
-      "3_FONT_MONO": "font_pixeloperatormono_regular_8_fr.json",
-      "4_FONT_BIG": "font_unifont_regular_16_fr.json",
-      "5_FONT_DEMIBOLD": "font_unifont_bold_16_fr.json",
-      "6_FONT_NORMAL_UPPER": "font_pixeloperator_regular_8_upper_fr.json",
-      "7_FONT_BOLD_UPPER": "font_pixeloperator_bold_8_upper_fr.json",
-      "8_FONT_SUB": null
+      "1": "font_pixeloperator_regular_8_fr.json",
+      "2": "font_pixeloperator_bold_8_fr.json",
+      "3": "font_pixeloperatormono_regular_8_fr.json",
+      "4": "font_unifont_regular_16_fr.json",
+      "5": "font_unifont_bold_16_fr.json",
+      "6": "font_pixeloperator_regular_8_upper_fr.json",
+      "7": "font_pixeloperator_bold_8_upper_fr.json"
     },
     "Delizia": {
-      "1_FONT_NORMAL": "font_ttsatoshi_demibold_21_fr.json",
-      "2_FONT_BOLD": "font_ttsatoshi_demibold_21_fr.json",
-      "3_FONT_MONO": "font_robotomono_medium_21_fr.json",
-      "4_FONT_BIG": null,
-      "5_FONT_DEMIBOLD": "font_ttsatoshi_demibold_21_fr.json",
-      "6_FONT_NORMAL_UPPER": null,
-      "7_FONT_BOLD_UPPER": null,
-      "8_FONT_SUB": "font_ttsatoshi_demibold_18_fr.json"
+      "1": "font_ttsatoshi_demibold_21_fr.json",
+      "2": "font_ttsatoshi_demibold_21_fr.json",
+      "3": "font_robotomono_medium_21_fr.json",
+      "5": "font_ttsatoshi_demibold_21_fr.json",
+      "8": "font_ttsatoshi_demibold_18_fr.json"
     },
     "Eckhart": {
-      "1_FONT_NORMAL": "font_ttsatoshi_demibold_21_fr.json",
-      "2_FONT_BOLD": "font_ttsatoshi_demibold_21_fr.json",
-      "3_FONT_MONO": "font_robotomono_medium_21_fr.json",
-      "4_FONT_BIG": null,
-      "5_FONT_DEMIBOLD": "font_ttsatoshi_demibold_21_fr.json",
-      "6_FONT_NORMAL_UPPER": null,
-      "7_FONT_BOLD_UPPER": null,
-      "8_FONT_SUB": "font_ttsatoshi_demibold_18_fr.json"
+      "1": "font_ttsatoshi_demibold_21_fr.json",
+      "2": "font_ttsatoshi_demibold_21_fr.json",
+      "3": "font_robotomono_medium_21_fr.json",
+      "5": "font_ttsatoshi_demibold_21_fr.json",
+      "8": "font_ttsatoshi_demibold_18_fr.json"
     }
   },
   "header": {

--- a/core/translations/it.json
+++ b/core/translations/it.json
@@ -1,44 +1,33 @@
 {
   "fonts": {
     "Bolt": {
-      "1_FONT_NORMAL": "font_tthoves_regular_21_it.json",
-      "2_FONT_BOLD": null,
-      "3_FONT_MONO": "font_robotomono_medium_20_it.json",
-      "4_FONT_BIG": null,
-      "5_FONT_DEMIBOLD": "font_tthoves_demibold_21_it.json",
-      "6_FONT_NORMAL_UPPER": null,
-      "7_FONT_BOLD_UPPER": "font_tthoves_bold_17_upper_it.json",
-      "8_FONT_SUB": null
+      "1": "font_tthoves_regular_21_it.json",
+      "3": "font_robotomono_medium_20_it.json",
+      "5": "font_tthoves_demibold_21_it.json",
+      "7": "font_tthoves_bold_17_upper_it.json"
     },
     "Caesar": {
-      "1_FONT_NORMAL": "font_pixeloperator_regular_8_it.json",
-      "2_FONT_BOLD": "font_pixeloperator_bold_8_it.json",
-      "3_FONT_MONO": "font_pixeloperatormono_regular_8_it.json",
-      "4_FONT_BIG": "font_unifont_regular_16_it.json",
-      "5_FONT_DEMIBOLD": "font_unifont_bold_16_it.json",
-      "6_FONT_NORMAL_UPPER": "font_pixeloperator_regular_8_upper_it.json",
-      "7_FONT_BOLD_UPPER": "font_pixeloperator_bold_8_upper_it.json",
-      "8_FONT_SUB": null
+      "1": "font_pixeloperator_regular_8_it.json",
+      "2": "font_pixeloperator_bold_8_it.json",
+      "3": "font_pixeloperatormono_regular_8_it.json",
+      "4": "font_unifont_regular_16_it.json",
+      "5": "font_unifont_bold_16_it.json",
+      "6": "font_pixeloperator_regular_8_upper_it.json",
+      "7": "font_pixeloperator_bold_8_upper_it.json"
     },
     "Delizia": {
-      "1_FONT_NORMAL": "font_ttsatoshi_demibold_21_it.json",
-      "2_FONT_BOLD": "font_ttsatoshi_demibold_21_it.json",
-      "3_FONT_MONO": "font_robotomono_medium_21_it.json",
-      "4_FONT_BIG": null,
-      "5_FONT_DEMIBOLD": "font_ttsatoshi_demibold_21_it.json",
-      "6_FONT_NORMAL_UPPER": null,
-      "7_FONT_BOLD_UPPER": null,
-      "8_FONT_SUB": "font_ttsatoshi_demibold_18_it.json"
+      "1": "font_ttsatoshi_demibold_21_it.json",
+      "2": "font_ttsatoshi_demibold_21_it.json",
+      "3": "font_robotomono_medium_21_it.json",
+      "5": "font_ttsatoshi_demibold_21_it.json",
+      "8": "font_ttsatoshi_demibold_18_it.json"
     },
     "Eckhart": {
-      "1_FONT_NORMAL": "font_ttsatoshi_demibold_21_it.json",
-      "2_FONT_BOLD": "font_ttsatoshi_demibold_21_it.json",
-      "3_FONT_MONO": "font_robotomono_medium_21_it.json",
-      "4_FONT_BIG": null,
-      "5_FONT_DEMIBOLD": "font_ttsatoshi_demibold_21_it.json",
-      "6_FONT_NORMAL_UPPER": null,
-      "7_FONT_BOLD_UPPER": null,
-      "8_FONT_SUB": "font_ttsatoshi_demibold_18_it.json"
+      "1": "font_ttsatoshi_demibold_21_it.json",
+      "2": "font_ttsatoshi_demibold_21_it.json",
+      "3": "font_robotomono_medium_21_it.json",
+      "5": "font_ttsatoshi_demibold_21_it.json",
+      "8": "font_ttsatoshi_demibold_18_it.json"
     }
   },
   "header": {

--- a/core/translations/pt.json
+++ b/core/translations/pt.json
@@ -1,44 +1,33 @@
 {
   "fonts": {
     "Bolt": {
-      "1_FONT_NORMAL": "font_tthoves_regular_21_pt.json",
-      "2_FONT_BOLD": null,
-      "3_FONT_MONO": "font_robotomono_medium_20_pt.json",
-      "4_FONT_BIG": null,
-      "5_FONT_DEMIBOLD": "font_tthoves_demibold_21_pt.json",
-      "6_FONT_NORMAL_UPPER": null,
-      "7_FONT_BOLD_UPPER": "font_tthoves_bold_17_upper_pt.json",
-      "8_FONT_SUB": null
+      "1": "font_tthoves_regular_21_pt.json",
+      "3": "font_robotomono_medium_20_pt.json",
+      "5": "font_tthoves_demibold_21_pt.json",
+      "7": "font_tthoves_bold_17_upper_pt.json"
     },
     "Caesar": {
-      "1_FONT_NORMAL": "font_pixeloperator_regular_8_pt.json",
-      "2_FONT_BOLD": "font_pixeloperator_bold_8_pt.json",
-      "3_FONT_MONO": "font_pixeloperatormono_regular_8_pt.json",
-      "4_FONT_BIG": "font_unifont_regular_16_pt.json",
-      "5_FONT_DEMIBOLD": "font_unifont_bold_16_pt.json",
-      "6_FONT_NORMAL_UPPER": "font_pixeloperator_regular_8_upper_pt.json",
-      "7_FONT_BOLD_UPPER": "font_pixeloperator_bold_8_upper_pt.json",
-      "8_FONT_SUB": null
+      "1": "font_pixeloperator_regular_8_pt.json",
+      "2": "font_pixeloperator_bold_8_pt.json",
+      "3": "font_pixeloperatormono_regular_8_pt.json",
+      "4": "font_unifont_regular_16_pt.json",
+      "5": "font_unifont_bold_16_pt.json",
+      "6": "font_pixeloperator_regular_8_upper_pt.json",
+      "7": "font_pixeloperator_bold_8_upper_pt.json"
     },
     "Delizia": {
-      "1_FONT_NORMAL": "font_ttsatoshi_demibold_21_pt.json",
-      "2_FONT_BOLD": "font_ttsatoshi_demibold_21_pt.json",
-      "3_FONT_MONO": "font_robotomono_medium_21_pt.json",
-      "4_FONT_BIG": null,
-      "5_FONT_DEMIBOLD": "font_ttsatoshi_demibold_21_pt.json",
-      "6_FONT_NORMAL_UPPER": null,
-      "7_FONT_BOLD_UPPER": null,
-      "8_FONT_SUB": "font_ttsatoshi_demibold_18_pt.json"
+      "1": "font_ttsatoshi_demibold_21_pt.json",
+      "2": "font_ttsatoshi_demibold_21_pt.json",
+      "3": "font_robotomono_medium_21_pt.json",
+      "5": "font_ttsatoshi_demibold_21_pt.json",
+      "8": "font_ttsatoshi_demibold_18_pt.json"
     },
     "Eckhart": {
-      "1_FONT_NORMAL": "font_ttsatoshi_demibold_21_pt.json",
-      "2_FONT_BOLD": "font_ttsatoshi_demibold_21_pt.json",
-      "3_FONT_MONO": "font_robotomono_medium_21_pt.json",
-      "4_FONT_BIG": null,
-      "5_FONT_DEMIBOLD": "font_ttsatoshi_demibold_21_pt.json",
-      "6_FONT_NORMAL_UPPER": null,
-      "7_FONT_BOLD_UPPER": null,
-      "8_FONT_SUB": "font_ttsatoshi_demibold_18_pt.json"
+      "1": "font_ttsatoshi_demibold_21_pt.json",
+      "2": "font_ttsatoshi_demibold_21_pt.json",
+      "3": "font_robotomono_medium_21_pt.json",
+      "5": "font_ttsatoshi_demibold_21_pt.json",
+      "8": "font_ttsatoshi_demibold_18_pt.json"
     }
   },
   "header": {

--- a/core/translations/tr.json
+++ b/core/translations/tr.json
@@ -1,44 +1,33 @@
 {
   "fonts": {
     "Bolt": {
-      "1_FONT_NORMAL": "font_tthoves_regular_21_tr.json",
-      "2_FONT_BOLD": null,
-      "3_FONT_MONO": "font_robotomono_medium_20_tr.json",
-      "4_FONT_BIG": null,
-      "5_FONT_DEMIBOLD": "font_tthoves_demibold_21_tr.json",
-      "6_FONT_NORMAL_UPPER": null,
-      "7_FONT_BOLD_UPPER": "font_tthoves_bold_17_upper_tr.json",
-      "8_FONT_SUB": null
+      "1": "font_tthoves_regular_21_tr.json",
+      "3": "font_robotomono_medium_20_tr.json",
+      "5": "font_tthoves_demibold_21_tr.json",
+      "7": "font_tthoves_bold_17_upper_tr.json"
     },
     "Caesar": {
-      "1_FONT_NORMAL": "font_pixeloperator_regular_8_tr.json",
-      "2_FONT_BOLD": "font_pixeloperator_bold_8_tr.json",
-      "3_FONT_MONO": "font_pixeloperatormono_regular_8_tr.json",
-      "4_FONT_BIG": "font_unifont_regular_16_tr.json",
-      "5_FONT_DEMIBOLD": "font_unifont_bold_16_tr.json",
-      "6_FONT_NORMAL_UPPER": "font_pixeloperator_regular_8_upper_tr.json",
-      "7_FONT_BOLD_UPPER": "font_pixeloperator_bold_8_upper_tr.json",
-      "8_FONT_SUB": null
+      "1": "font_pixeloperator_regular_8_tr.json",
+      "2": "font_pixeloperator_bold_8_tr.json",
+      "3": "font_pixeloperatormono_regular_8_tr.json",
+      "4": "font_unifont_regular_16_tr.json",
+      "5": "font_unifont_bold_16_tr.json",
+      "6": "font_pixeloperator_regular_8_upper_tr.json",
+      "7": "font_pixeloperator_bold_8_upper_tr.json"
     },
     "Delizia": {
-      "1_FONT_NORMAL": "font_ttsatoshi_demibold_21_tr.json",
-      "2_FONT_BOLD": "font_ttsatoshi_demibold_21_tr.json",
-      "3_FONT_MONO": "font_robotomono_medium_21_tr.json",
-      "4_FONT_BIG": null,
-      "5_FONT_DEMIBOLD": "font_ttsatoshi_demibold_21_tr.json",
-      "6_FONT_NORMAL_UPPER": null,
-      "7_FONT_BOLD_UPPER": null,
-      "8_FONT_SUB": "font_ttsatoshi_demibold_18_tr.json"
+      "1": "font_ttsatoshi_demibold_21_tr.json",
+      "2": "font_ttsatoshi_demibold_21_tr.json",
+      "3": "font_robotomono_medium_21_tr.json",
+      "5": "font_ttsatoshi_demibold_21_tr.json",
+      "8": "font_ttsatoshi_demibold_18_tr.json"
     },
     "Eckhart": {
-      "1_FONT_NORMAL": "font_ttsatoshi_demibold_21_tr.json",
-      "2_FONT_BOLD": "font_ttsatoshi_demibold_21_tr.json",
-      "3_FONT_MONO": "font_robotomono_medium_21_tr.json",
-      "4_FONT_BIG": null,
-      "5_FONT_DEMIBOLD": "font_ttsatoshi_demibold_21_tr.json",
-      "6_FONT_NORMAL_UPPER": null,
-      "7_FONT_BOLD_UPPER": null,
-      "8_FONT_SUB": "font_ttsatoshi_demibold_18_tr.json"
+      "1": "font_ttsatoshi_demibold_21_tr.json",
+      "2": "font_ttsatoshi_demibold_21_tr.json",
+      "3": "font_robotomono_medium_21_tr.json",
+      "5": "font_ttsatoshi_demibold_21_tr.json",
+      "8": "font_ttsatoshi_demibold_18_tr.json"
     }
   },
   "header": {

--- a/python/src/trezorlib/_internal/translations.py
+++ b/python/src/trezorlib/_internal/translations.py
@@ -189,13 +189,12 @@ class FontsTable(BlobTable):
     @classmethod
     def from_dir(cls, model_fonts: dict[str, str], font_dir: Path) -> Self:
         """Example structure of the font dict:
-        (The beginning number corresponds to the C representation of each font)
+        (The key number corresponds to the index representation of each font set in `gen_font.py`)
         {
-        "1_FONT_NORMAL": "font_tthoves_regular_21_cs.json",
-        "2_FONT_BOLD": "font_tthoves_bold_17_cs.json",
-        "3_FONT_MONO": "font_robotomono_medium_20_cs.json",
-        "4_FONT_BIG": null,
-        "5_FONT_DEMIBOLD": "font_tthoves_demibold_21_cs.json"
+          "1": "font_tthoves_regular_21_cs.json",
+          "3": "font_robotomono_medium_20_cs.json",
+          "5": "font_tthoves_demibold_21_cs.json",
+          "7": "font_tthoves_bold_17_upper_cs.json"
         }
         """
         fonts = {}
@@ -203,7 +202,7 @@ class FontsTable(BlobTable):
             if not file_name:
                 continue
             file_path = font_dir / file_name
-            font_num = int(font_name.split("_")[0])
+            font_num = int(font_name)
             try:
                 fonts[font_num] = Font.from_file(file_path).build()
             except Exception as e:


### PR DESCRIPTION
<!--
For core developers:
- Assign yourself to the PR.
- Set the priority to match the original issue.
- Add the PR to the current sprint.
- If it's a draft PR, mark it as "In Progress."
- If it's a final PR, mark it as "Needs Review."

For external contributors:
- Please open an issue before submitting a PR so we can discuss whether we want to proceed with it.
-->
This PR resolves a small technical debt. As of https://github.com/trezor/trezor-firmware/pull/4536 the C-enum font names are no longer valid and foreign glyphs are mapped to fonts via `translation_blob_idx` in their respective `FontInfo` struct which are written by `gen_font.py`. The changes in the `gen_font.py` in this PR are just cosmetic.

In the future, we might want to specify the mapping in a separate file.