### PR TITLE
Handle layout-specific translations in tests

### DIFF
--- a/python/src/trezorlib/debuglink.py
+++ b/python/src/trezorlib/debuglink.py
@@ -97,6 +97,12 @@ class LayoutType(Enum):
             return cls.T1
         raise ValueError(f"Unknown model: {model}")
 
+    def __str__(self) -> str:
+        return self.name
+
+    def __repr__(self) -> str:
+        return f"LayoutType.{self.name}"
+
 
 class UnstructuredJSONReader:
     """Contains data-parsing helpers for JSON data that have unknown structure."""

--- a/tests/translations.py
+++ b/tests/translations.py
@@ -8,6 +8,7 @@ from pathlib import Path
 
 from trezorlib import cosi, device, models
 from trezorlib._internal import translations
+from trezorlib.debuglink import LayoutType
 from trezorlib.debuglink import TrezorClientDebugLink as Client
 
 from . import common
@@ -72,7 +73,12 @@ def set_language(client: Client, lang: str, *, force: bool = True):
     with client:
         if not client.features.language.startswith(lang) or force:
             device.change_language(client, language_data)  # type: ignore
+    set_layout(client)
     _CURRENT_TRANSLATION.TR = TRANSLATIONS[lang]
+
+
+def set_layout(client: Client):
+    _CURRENT_TRANSLATION.LAYOUT = client.layout_type
 
 
 def get_lang_json(lang: str) -> translations.JsonDef:
@@ -92,13 +98,24 @@ class Translation:
         self.lang_json = get_lang_json(lang)
 
     @property
-    def translations(self) -> dict[str, str]:
+    def translations(self) -> dict[str, str | dict[str, str]]:
         return self.lang_json["translations"]
 
     def _translate_raw(self, key: str, _stacklevel: int = 0) -> str:
         tr = self.translations.get(key)
         if tr is not None:
-            return tr
+            # Handle layout-specific translations
+            if isinstance(tr, dict) and hasattr(_CURRENT_TRANSLATION, "LAYOUT"):
+                # Try to get translation for current layout
+                layout_name = _CURRENT_TRANSLATION.LAYOUT.name
+                if layout_name in tr:
+                    return tr[layout_name]
+                # Fall back to any available translation if no match for current layout
+                return next(iter(tr.values()))
+            elif isinstance(tr, str):
+                return tr
+            else:
+                raise ValueError(f"Invalid translation value for key '{key}'")
         if self.lang != "en":
             # check if the key exists in English first
             retval = TRANSLATIONS["en"]._translate_raw(key)
@@ -123,6 +140,7 @@ class Translation:
 
 TRANSLATIONS = {lang: Translation(lang) for lang in LANGUAGES}
 _CURRENT_TRANSLATION.TR = TRANSLATIONS["en"]
+_CURRENT_TRANSLATION.LAYOUT = LayoutType.Bolt
 
 
 def translate(key: str, _stacklevel: int = 0) -> str:


### PR DESCRIPTION
<!--
For core developers:
- Assign yourself to the PR.
- Set the priority to match the original issue.
- Add the PR to the current sprint.
- If it's a draft PR, mark it as "In Progress."
- If it's a final PR, mark it as "Needs Review."

For external contributors:
- Please open an issue before submitting a PR so we can discuss whether we want to proceed with it.
-->
The PR adds the current Layout (`Bolt`/`Caesar`/`Delizia`/`Eckhart`) to the thread-local context `_CURRENT_TRANSLATIONS` for test runner. This is to handle layout-specific translation assertions in test introduced in https://github.com/trezor/trezor-firmware/pull/4495.

This is `cherry-pick`ed from `ui-eckhart` branch where we encountered the issue and there it works. I thought it would be a good idea to merge separatedly.