### PR TITLE
Reduce heap fragmentation

### DIFF
--- a/core/embed/upymod/modtrezorutils/modtrezorutils.c
+++ b/core/embed/upymod/modtrezorutils/modtrezorutils.c
@@ -580,7 +580,6 @@ STATIC const mp_rom_map_elem_t mp_module_trezorutils_globals_table[] = {
      MP_ROM_INT(MODEL_HOMESCREEN_MAXSIZE)},
 #ifdef TREZOR_EMULATOR
     {MP_ROM_QSTR(MP_QSTR_EMULATOR), mp_const_true},
-    MEMINFO_DICT_ENTRIES
 #else
     {MP_ROM_QSTR(MP_QSTR_EMULATOR), mp_const_false},
 #endif
@@ -604,6 +603,7 @@ STATIC const mp_rom_map_elem_t mp_module_trezorutils_globals_table[] = {
 #error Unknown layout
 #endif
 #if !PYOPT
+    MEMINFO_DICT_ENTRIES
 #if DISABLE_ANIMATION
     {MP_ROM_QSTR(MP_QSTR_DISABLE_ANIMATION), mp_const_true},
 #else

--- a/core/src/apps/management/reset_device/__init__.py
+++ b/core/src/apps/management/reset_device/__init__.py
@@ -84,7 +84,7 @@ async def reset_device(msg: ResetDevice) -> Success:
         # generate internal entropy
         int_entropy = random.bytes(32, True)
         if __debug__:
-            storage.debug.reset_internal_entropy = int_entropy
+            storage.debug.reset_internal_entropy[:] = int_entropy
 
         entropy_commitment = (
             hmac(hmac.SHA256, int_entropy, b"").digest() if msg.entropy_check else None

--- a/core/src/storage/debug.py
+++ b/core/src/storage/debug.py
@@ -9,4 +9,5 @@ if __debug__:
 
     layout_watcher = False
 
-    reset_internal_entropy: bytes = b""
+    reset_internal_entropy = bytearray(32)
+    reset_internal_entropy[:] = bytes()

--- a/core/src/trezor/pin.py
+++ b/core/src/trezor/pin.py
@@ -91,5 +91,6 @@ def show_pin_timeout(
     # drop the layout when done so trezor.ui doesn't have to remain in memory
     if progress >= 1000:
         _progress_layout = None
+        _previous_remaining = None
 
     return False


### PR DESCRIPTION
We have found that there are some objects left "in the middle" of the heap after the session is over, using the following patch:
```diff
diff --git a/core/src/trezor/utils.py b/core/src/trezor/utils.py
index ebb005756..5f368721b 100644
--- a/core/src/trezor/utils.py
+++ b/core/src/trezor/utils.py
@@ -99,6 +99,10 @@ class unimport:
 
     def __enter__(self) -> None:
         self.mods = unimport_begin()
+        from micropython import mem_info
+        from trezorutils import meminfo
+        mem_info(True)
+        meminfo(None)
```

<!--
For core developers:
- Assign yourself to the PR.
- Set the priority to match the original issue.
- Add the PR to the current sprint.
- If it's a draft PR, mark it as "In Progress."
- If it's a final PR, mark it as "Needs Review."

For external contributors:
- Please open an issue before submitting a PR so we can discuss whether we want to proceed with it.
-->
