### PR TITLE
fix bootloader build for D002

### DIFF
--- a/core/embed/projects/bootloader/workflow/wf_firmware_update.c
+++ b/core/embed/projects/bootloader/workflow/wf_firmware_update.c
@@ -25,7 +25,7 @@
 #include <util/flash.h>
 #include <util/flash_utils.h>
 
-#if USE_OPTIGA
+#if USE_OPTIGA || USE_STORAGE_HWKEY
 #include <sec/secret.h>
 #endif
 


### PR DESCRIPTION
fix bootloader build for D002 (more generally for models with HW keys but without optiga)