### PR TITLE
chore(docs): update SECURITY.md

### DIFF
--- a/SECURITY.md
+++ b/SECURITY.md
@@ -2,15 +2,6 @@
 
 ## Reporting a Vulnerability
 
-To report security issues send an email to security@satoshilabs.com (this is not a support email!).
+Please report suspected security vulnerabilities in private to security@satoshilabs.com. Our guidance on this topic can be found at our [website](https://trezor.io/support/a/how-to-report-a-security-issue) and list of past issues at [GitHub](https://github.com/orgs/trezor/discussions).
 
-The following keys may be used to communicate sensitive information to developers:
-
-| Name            | Fingerprint                                |
-|-----------------|--------------------------------------------|
-| Pavol Rusnak    | `86E6792FC27BFD478860C11091F3B339B9A02A3D` |
-| Marek Palatinus | `71B5A80A63FE12B0D74DABBFE4A883364AAF6E16` |
-
-You can import a key by running the following command with that individual’s fingerprint: `gpg --recv-keys <fingerprint>`.
-
-More info about our Responsible Disclosure program is available from https://trezor.io/security/
+Thank you for your cooperation in making Trezor more secure.


### PR DESCRIPTION
We can also delete the whole thing as it will then default to https://github.com/trezor/.github/blob/master/SECURITY.md. But maybe we want to have a `SECURITY.md` file here.

This is not great, we are working on some better security page on trezor.io with better guidance and past issues to be delivered in Q2/Q3.
