### PR TITLE
Eckhart UI - button gradient

### DIFF
--- a/core/embed/rust/src/ui/layout_eckhart/firmware/action_bar.rs
+++ b/core/embed/rust/src/ui/layout_eckhart/firmware/action_bar.rs
@@ -111,7 +111,9 @@ impl ActionBar {
     pub fn new_cancel_confirm() -> Self {
         Self::new_double(
             Button::with_icon(theme::ICON_CROSS),
-            Button::with_text(TR::buttons__confirm.into()),
+            Button::with_text(TR::buttons__confirm.into())
+                .with_gradient()
+                .styled(theme::firmware::button_confirm()),
         )
     }
 

--- a/core/embed/rust/src/ui/layout_eckhart/theme/firmware.rs
+++ b/core/embed/rust/src/ui/layout_eckhart/theme/firmware.rs
@@ -170,14 +170,14 @@ pub const fn button_confirm() -> ButtonStyleSheet {
         normal: &ButtonStyle {
             font: fonts::FONT_SATOSHI_MEDIUM_26,
             text_color: GREEN_LIGHT,
-            button_color: BG,
+            button_color: GREEN_DARK,
             icon_color: GREEN_LIGHT,
-            background_color: BG,
+            background_color: GREEN_DARK,
         },
         active: &ButtonStyle {
             font: fonts::FONT_SATOSHI_MEDIUM_26,
             text_color: GREEN,
-            button_color: GREY_SUPER_DARK,
+            button_color: GREEN_EXTRA_DARK,
             icon_color: GREEN,
             background_color: BG,
         },

--- a/core/embed/rust/src/ui/layout_eckhart/ui_firmware.rs
+++ b/core/embed/rust/src/ui/layout_eckhart/ui_firmware.rs
@@ -72,11 +72,12 @@ impl FirmwareUI for UIEckhart {
         };
 
         let verb = verb.unwrap_or(TR::buttons__confirm.into());
-        let right_button = if hold {
-            Button::with_text(verb).with_long_press(theme::CONFIRM_HOLD_DURATION)
-        } else {
-            Button::with_text(verb)
-        };
+        let mut right_button = Button::with_text(verb)
+            .with_gradient()
+            .styled(theme::firmware::button_confirm());
+        if hold {
+            right_button = right_button.with_long_press(theme::CONFIRM_HOLD_DURATION);
+        }
 
         let mut screen = TextScreen::new(paragraphs)
             .with_header(Header::new(title))


### PR DESCRIPTION
<!--
For core developers:
- Assign yourself to the PR.
- Set the priority to match the original issue.
- Add the PR to the current sprint.
- If it's a draft PR, mark it as "In Progress."
- If it's a final PR, mark it as "Needs Review."

For external contributors:
- Please open an issue before submitting a PR so we can discuss whether we want to proceed with it.
-->
This PR allows to construct buttons `.with_gradient()`. The button is then rendered with 3 layers
- vertical gradient of the `button_color` 
- horizontal gradient of black color factored by the distance from the middle
- overlay black overlay with 20% intensity
Stops and the intensities are specified in Figma.

Gradients are incompatible with radius.