### PR TITLE
fix(core): correct `dump_qstr_pool()`

### DIFF
--- a/core/embed/upymod/modtrezorutils/modtrezorutils-meminfo.h
+++ b/core/embed/upymod/modtrezorutils/modtrezorutils-meminfo.h
@@ -702,7 +702,7 @@ void dump_qstr_pool(FILE *out, const qstr_pool_t *pool) {
   for (const char *const *q = pool->qstrs, *const *q_top =
                                                pool->qstrs + pool->len;
        q < q_top; q++) {
-    escape_and_dump_string(out, Q_GET_DATA(*q));
+    escape_and_dump_string(out, *q);
     if (q < (q_top - 1))
       fprintf(out, ",\n");
     else


### PR DESCRIPTION
Tested on T2T1 (comparing with the output of MicroPython's `qstr_dump_data()` function):
```
[20:15:20.419] Q(___PRESIZE_MODULE_20)
[20:15:20.419] Q(___PRESIZE_MODULE_21)
[20:15:20.420] Q(___PRESIZE_MODULE_22)
[20:15:20.420] Q(___PRESIZE_MODULE_23)
[20:15:20.421] Q(___PRESIZE_MODULE_24)
[20:15:20.421] Q(___PRESIZE_MODULE_25)
[20:15:20.421] Q(___PRESIZE_MODULE_26)
[20:15:20.422] Q(___PRESIZE_MODULE_27)
[20:15:20.422] Q(___PRESIZE_MODULE_28)
[20:15:20.423] Q(___PRESIZE_MODULE_29)
[20:15:20.423] Q(___PRESIZE_MODULE_0)
[20:15:20.423] Q(___PRESIZE_MODULE_1)
[20:15:20.424] Q(___PRESIZE_MODULE_2)
[20:15:20.424] Q(___PRESIZE_MODULE_3)
[20:15:20.425] Q(___PRESIZE_MODULE_4)
[20:15:20.425] Q(___PRESIZE_MODULE_5)
[20:15:20.425] Q(___PRESIZE_MODULE_6)
[20:15:20.426] Q(___PRESIZE_MODULE_7)
[20:15:20.426] Q(___PRESIZE_MODULE_8)
[20:15:20.426] Q(___PRESIZE_MODULE_9)
[20:15:20.427] Q(___PRESIZE_MODULE_10)
[20:15:20.427] Q(___PRESIZE_MODULE_11)
[20:15:20.428] Q(___PRESIZE_MODULE_12)
[20:15:20.428] Q(___PRESIZE_MODULE_13)
[20:15:20.428] Q(___PRESIZE_MODULE_14)
[20:15:20.429] Q(___PRESIZE_MODULE_15)
[20:15:20.429] Q(___PRESIZE_MODULE_16)
[20:15:20.430] Q(___PRESIZE_MODULE_17)
[20:15:20.430] Q(___PRESIZE_MODULE_18)
[20:15:20.431] Q(___PRESIZE_MODULE_19)
...
[20:15:20.431] "qstr_pools",
[20:15:20.432] {"type": "qstrpool", "alloc": 19, "ptr": "0x2000b8e0", "shortval": null, "qstrs": [
[20:15:20.433] "___PRESIZE_MODULE_20",
[20:15:20.433] "___PRESIZE_MODULE_21",
[20:15:20.434] "___PRESIZE_MODULE_22",
[20:15:20.435] "___PRESIZE_MODULE_23",
[20:15:20.435] "___PRESIZE_MODULE_24",
[20:15:20.435] "___PRESIZE_MODULE_25",
[20:15:20.435] "___PRESIZE_MODULE_26",
[20:15:20.436] "___PRESIZE_MODULE_27",
[20:15:20.436] "___PRESIZE_MODULE_28",
[20:15:20.436] "___PRESIZE_MODULE_29"]
[20:15:20.437] },
[20:15:20.437] {"type": "qstrdata", "alloc": 0, "ptr": "0x2000b7da", "shortval": null, "pool": "0x2000b8e0"},
[20:15:20.439] {"type": "qstrdata", "alloc": 0, "ptr": "0x2000b7ef", "shortval": null, "pool": "0x2000b8e0"},
[20:15:20.440] {"type": "qstrdata", "alloc": 0, "ptr": "0x2000b804", "shortval": null, "pool": "0x2000b8e0"},
[20:15:20.442] {"type": "qstrdata", "alloc": 0, "ptr": "0x2000b819", "shortval": null, "pool": "0x2000b8e0"},
[20:15:20.443] {"type": "qstrdata", "alloc": 8, "ptr": "0x2000bb90", "shortval": null, "pool": "0x2000b8e0"},
[20:15:20.445] {"type": "qstrdata", "alloc": 0, "ptr": "0x2000bba5", "shortval": null, "pool": "0x2000b8e0"},
[20:15:20.446] {"type": "qstrdata", "alloc": 0, "ptr": "0x2000bbba", "shortval": null, "pool": "0x2000b8e0"},
[20:15:20.448] {"type": "qstrdata", "alloc": 0, "ptr": "0x2000bbcf", "shortval": null, "pool": "0x2000b8e0"},
[20:15:20.449] {"type": "qstrdata", "alloc": 0, "ptr": "0x2000bbe4", "shortval": null, "pool": "0x2000b8e0"},
[20:15:20.451] {"type": "qstrdata", "alloc": 0, "ptr": "0x2000bbf9", "shortval": null, "pool": "0x2000b8e0"},
[20:15:20.452] {"type": "qstrpool", "alloc": 11, "ptr": "0x2000afd0", "shortval": null, "qstrs": [
[20:15:20.454] "___PRESIZE_MODULE_0",
[20:15:20.454] "___PRESIZE_MODULE_1",
[20:15:20.454] "___PRESIZE_MODULE_2",
[20:15:20.455] "___PRESIZE_MODULE_3",
[20:15:20.455] "___PRESIZE_MODULE_4",
[20:15:20.455] "___PRESIZE_MODULE_5",
[20:15:20.456] "___PRESIZE_MODULE_6",
[20:15:20.456] "___PRESIZE_MODULE_7",
[20:15:20.457] "___PRESIZE_MODULE_8",
[20:15:20.458] "___PRESIZE_MODULE_9",
[20:15:20.458] "___PRESIZE_MODULE_10",
[20:15:20.458] "___PRESIZE_MODULE_11",
[20:15:20.459] "___PRESIZE_MODULE_12",
[20:15:20.459] "___PRESIZE_MODULE_13",
[20:15:20.460] "___PRESIZE_MODULE_14",
[20:15:20.460] "___PRESIZE_MODULE_15",
[20:15:20.460] "___PRESIZE_MODULE_16",
[20:15:20.461] "___PRESIZE_MODULE_17",
[20:15:20.461] "___PRESIZE_MODULE_18",
[20:15:20.461] "___PRESIZE_MODULE_19"]
[20:15:20.462] },
[20:15:20.462] {"type": "qstrdata", "alloc": 8, "ptr": "0x2000af50", "shortval": null, "pool": "0x2000afd0"},
[20:15:20.463] {"type": "qstrdata", "alloc": 0, "ptr": "0x2000af64", "shortval": null, "pool": "0x2000afd0"},
[20:15:20.464] {"type": "qstrdata", "alloc": 0, "ptr": "0x2000af78", "shortval": null, "pool": "0x2000afd0"},
[20:15:20.466] {"type": "qstrdata", "alloc": 0, "ptr": "0x2000af8c", "shortval": null, "pool": "0x2000afd0"},
[20:15:20.467] {"type": "qstrdata", "alloc": 0, "ptr": "0x2000afa0", "shortval": null, "pool": "0x2000afd0"},
[20:15:20.469] {"type": "qstrdata", "alloc": 0, "ptr": "0x2000afb4", "shortval": null, "pool": "0x2000afd0"},
[20:15:20.470] {"type": "qstrdata", "alloc": 8, "ptr": "0x2000b2a0", "shortval": null, "pool": "0x2000afd0"},
[20:15:20.472] {"type": "qstrdata", "alloc": 0, "ptr": "0x2000b2b4", "shortval": null, "pool": "0x2000afd0"},
[20:15:20.474] {"type": "qstrdata", "alloc": 0, "ptr": "0x2000b2c8", "shortval": null, "pool": "0x2000afd0"},
[20:15:20.475] {"type": "qstrdata", "alloc": 0, "ptr": "0x2000b2dc", "shortval": null, "pool": "0x2000afd0"},
[20:15:20.477] {"type": "qstrdata", "alloc": 0, "ptr": "0x2000b2f0", "shortval": null, "pool": "0x2000afd0"},
[20:15:20.478] {"type": "qstrdata", "alloc": 0, "ptr": "0x2000b305", "shortval": null, "pool": "0x2000afd0"},
[20:15:20.480] {"type": "qstrdata", "alloc": 8, "ptr": "0x2000b530", "shortval": null, "pool": "0x2000afd0"},
[20:15:20.482] {"type": "qstrdata", "alloc": 0, "ptr": "0x2000b545", "shortval": null, "pool": "0x2000afd0"},
[20:15:20.483] {"type": "qstrdata", "alloc": 0, "ptr": "0x2000b55a", "shortval": null, "pool": "0x2000afd0"},
[20:15:20.484] {"type": "qstrdata", "alloc": 0, "ptr": "0x2000b56f", "shortval": null, "pool": "0x2000afd0"},
[20:15:20.486] {"type": "qstrdata", "alloc": 0, "ptr": "0x2000b584", "shortval": null, "pool": "0x2000afd0"},
[20:15:20.487] {"type": "qstrdata", "alloc": 0, "ptr": "0x2000b599", "shortval": null, "pool": "0x2000afd0"},
[20:15:20.489] {"type": "qstrdata", "alloc": 8, "ptr": "0x2000b7b0", "shortval": null, "pool": "0x2000afd0"},
[20:15:20.490] {"type": "qstrdata", "alloc": 0, "ptr": "0x2000b7c5", "shortval": null, "pool": "0x2000afd0"},
[20:15:20.492] null
[20:15:20.492] ]
```

<!--
For core developers:
- Assign yourself to the PR.
- Set the priority to match the original issue.
- Add the PR to the current sprint.
- If it's a draft PR, mark it as "In Progress."
- If it's a final PR, mark it as "Needs Review."

For external contributors:
- Please open an issue before submitting a PR so we can discuss whether we want to proceed with it.
-->
