### PR TITLE
fix(core): don't handle nostr-related messages in BTC-only firmware

### DIFF
--- a/core/src/apps/workflow_handlers.py
+++ b/core/src/apps/workflow_handlers.py
@@ -106,17 +106,17 @@ def _find_message_handler_module(msg_type: int) -> str:
     if msg_type == MessageType.GetFirmwareHash:
         return "apps.misc.get_firmware_hash"
 
-    # When promoting the Nostr app to production-level
-    # and removing the "if" guard don't forget to also remove
-    # the corresponding guards (PYOPT == '0') in Sconscript.*
-    if __debug__:
-        # nostr
-        if msg_type == MessageType.NostrGetPubkey:
-            return "apps.nostr.get_pubkey"
-        if msg_type == MessageType.NostrSignEvent:
-            return "apps.nostr.sign_event"
-
     if not utils.BITCOIN_ONLY:
+        # When promoting the Nostr app to production-level
+        # and removing the "if" guard don't forget to also remove
+        # the corresponding guards (PYOPT == '0') in Sconscript.*
+        if __debug__:
+            # nostr
+            if msg_type == MessageType.NostrGetPubkey:
+                return "apps.nostr.get_pubkey"
+            if msg_type == MessageType.NostrSignEvent:
+                return "apps.nostr.sign_event"
+
         if msg_type == MessageType.SetU2FCounter:
             return "apps.management.set_u2f_counter"
         if msg_type == MessageType.GetNextU2FCounter:


### PR DESCRIPTION
Otherwise, sending non-BTC requests results in the following error:
```
[11:42:37.114] 92750000 trezor.wire.message_handler DEBUG 0 receive: <704 - unknown message type>
[11:42:37.116] 92753000 trezor.wire ERROR exception:
[11:42:37.117] Traceback (most recent call last):
[11:42:37.117]   File "trezor/wire/__init__.py", line 87, in handle_session
[11:42:37.118]   File "trezor/wire/message_handler.py", line 79, in handle_single_message
[11:42:37.119]   File "trezor/wire/message_handler.py", line 197, in find_handler
[11:42:37.120]   File "apps/workflow_handlers.py", line 232, in find_registered_handler
[11:42:37.122]   File "apps/workflow_handlers.py", line 114, in _find_message_handler_module
[11:42:37.123] AttributeError: 'module' object has no attribute 'NostrGetPubkey'
```

<!--
For core developers:
- Assign yourself to the PR.
- Set the priority to match the original issue.
- Add the PR to the current sprint.
- If it's a draft PR, mark it as "In Progress."
- If it's a final PR, mark it as "Needs Review."

For external contributors:
- Please open an issue before submitting a PR so we can discuss whether we want to proceed with it.
-->
