### PR TITLE
fix(core): explicitly close `default_task` generator

### DIFF
--- a/core/src/session.py
+++ b/core/src/session.py
@@ -26,5 +26,7 @@ wire.setup(usb.iface_wire)
 # start the event loop
 loop.run()
 
+workflow.close_default()
+
 if __debug__:
     log.debug(__name__, "Restarting main loop")

--- a/core/src/trezor/ui/layouts/homescreen.py
+++ b/core/src/trezor/ui/layouts/homescreen.py
@@ -6,36 +6,9 @@ from storage.cache_common import APP_COMMON_BUSY_DEADLINE_MS
 from trezor import TR, ui, utils
 
 if TYPE_CHECKING:
-    from typing import Any, Callable, Iterator, ParamSpec, TypeVar
+    from typing import Any, Iterator
 
     from trezor import loop
-
-    P = ParamSpec("P")
-    R = TypeVar("R")
-
-
-def _retry_with_gc(layout: Callable[P, R], *args: P.args, **kwargs: P.kwargs) -> R:
-    """Retry creating the layout after garbage collection.
-
-    For reasons unknown, a previous homescreen layout may survive an unimport, and still
-    exists in the GC arena. At the time a new one is instantiated, the old one still
-    holds a lock on the JPEG buffer, and creating a new layout will fail with a
-    MemoryError.
-
-    It seems that the previous layout's survival is a glitch, and at a later time it is
-    still in memory but not held anymore. We assume that triggering a GC cycle will
-    correctly throw it away, and we will be able to create the new layout.
-
-    We only try this once because if it didn't help, the above assumption is wrong, so
-    no point in trying again.
-    """
-    try:
-        return layout(*args, **kwargs)
-    except MemoryError:
-        import gc
-
-        gc.collect()
-        return layout(*args, **kwargs)
 
 
 class HomescreenBase(ui.Layout):
@@ -83,8 +56,7 @@ class Homescreen(HomescreenBase):
                 level = 0
 
         super().__init__(
-            layout=_retry_with_gc(
-                trezorui_api.show_homescreen,
+            layout=trezorui_api.show_homescreen(
                 label=label,
                 notification=notification,
                 notification_level=level,
@@ -136,8 +108,7 @@ class Lockscreen(HomescreenBase):
             not bootscreen and storage_cache.homescreen_shown is self.RENDER_INDICATOR
         )
         super().__init__(
-            layout=_retry_with_gc(
-                trezorui_api.show_lockscreen,
+            layout=trezorui_api.show_lockscreen(
                 label=label,
                 bootscreen=bootscreen,
                 skip_first_paint=skip,
@@ -158,8 +129,7 @@ class Busyscreen(HomescreenBase):
 
     def __init__(self, delay_ms: int) -> None:
         super().__init__(
-            layout=_retry_with_gc(
-                trezorui_api.show_progress_coinjoin,
+            layout=trezorui_api.show_progress_coinjoin(
                 title=TR.coinjoin__waiting_for_others,
                 indeterminate=True,
                 time_ms=delay_ms,

--- a/core/src/trezor/workflow.py
+++ b/core/src/trezor/workflow.py
@@ -108,6 +108,12 @@ def start_default() -> None:
     autolock_interrupts_workflow = True
 
 
+def close_default() -> None:
+    """Close and free all resources used by default task."""
+    if default_task:
+        default_task.close()
+
+
 def set_default(constructor: Callable[[], loop.Task], restart: bool = False) -> None:
     """Configure a default workflow, which will be started next time it is needed."""
     global default_constructor


### PR DESCRIPTION
Otherwise, `homescreen()` generator is not guaranteed to be closed, thus the `await` below may not return):
https://github.com/trezor/trezor-firmware/blob/84393631c883b89e468cfca148a53e234c9c320e/core/src/apps/homescreen/__init__.py#L49-L58

and the statically-allocated `ImageBuffer` won't be dropped:
https://github.com/trezor/trezor-firmware/blob/84393631c883b89e468cfca148a53e234c9c320e/core/embed/rust/src/ui/shape/utils/imagebuf.rs#L33-L44

This issue can be reproduced by running:
```
$ TREZOR_MODEL=T3T1 BITCOIN_ONLY=0 QUIET_MODE=1 PYOPT=0 make -C core build_unix_frozen
$ core/emu.py -ea --profiling -c pytest -x tests/device_tests/test_msg_applysettings.py::test_apply_homescreen_jpeg
```

It should be the fix of #4467's root cause.

<!--
For core developers:
- Assign yourself to the PR.
- Set the priority to match the original issue.
- Add the PR to the current sprint.
- If it's a draft PR, mark it as "In Progress."
- If it's a final PR, mark it as "Needs Review."

For external contributors:
- Please open an issue before submitting a PR so we can discuss whether we want to proceed with it.
-->
