### PR TITLE
Add thread monitor and BLE debug monitor for nRF,  JLink flashing

### DIFF
--- a/core/Makefile
+++ b/core/Makefile
@@ -1,4 +1,3 @@
-
 .PHONY: vendor
 
 # get the number of CPU cores in a "portable" manner
@@ -401,12 +400,20 @@ flash_bootloader_ci_jlink: $(BOOTLOADER_CI_BUILD_DIR)/bootloader.bin ## flash CI
 	JLinkExe -nogui 1 -commanderscript embed/projects/bootloader_ci/bootloader_flash.jlink
 
 flash_firmware_jlink: $(FIRMWARE_BUILD_DIR)/firmware.bin ## flash firmware using JLink. file names must end in .bin for JLink
+ifeq ($(MCU),$(filter $(MCU),STM32F4))
 	cp -f $<.p1 $<.p1.bin
 	cp -f $<.p2 $<.p2.bin
 	## pad 2nd part so that FW integrity works after flash
 	## read&compare in flashing will avoid erasing unmodified sectors
 	truncate -s $(FIRMWARE_P2_MAXSIZE) $<.p2.bin
-	JLinkExe -nogui 1 -commanderscript embed/projects/firmware/firmware_flash.jlink
+	JLinkExe -nogui 1 -commanderscript embed/models/T2T1/firmware_flash.jlink
+else
+	# unfortunately JLink commander cannot be parameterized without buying SDK and rebuilding with changes
+	cp -f $< $<.padded.bin
+	echo firmware size is $(FIRMWARE_MAXSIZE)
+	dd if=/dev/zero bs=1 count=$$(($(FIRMWARE_MAXSIZE) - $$(stat -c %s $<))) | tr '\000' '\377' >> $<.padded.bin
+	JLinkExe -nogui 1 -commanderscript embed/models/T3W1/firmware_flash.jlink
+endif
 
 ## openocd debug commands:
 

--- a/core/embed/models/T2T1/firmware_flash.jlink
+++ b/core/embed/models/T2T1/firmware_flash.jlink
@@ -1,0 +1,8 @@
+device stm32f427vi
+if swd
+speed 50000
+loadbin build/firmware/firmware.bin.p1.bin 0x08040000
+loadbin build/firmware/firmware.bin.p2.bin 0x08120000
+r
+g
+exit

--- a/core/embed/models/T3W1/firmware_flash.jlink
+++ b/core/embed/models/T3W1/firmware_flash.jlink
@@ -1,0 +1,7 @@
+device STM32U5G9ZJ
+if swd
+speed 20000
+loadbin build/firmware/firmware.bin.padded.bin 0x0C044000
+r
+g
+exit

--- a/nordic/trezor/trezor-ble/debug.conf
+++ b/nordic/trezor/trezor-ble/debug.conf
@@ -15,3 +15,13 @@ CONFIG_LOG_BACKEND_RTT=y
 
 
 CONFIG_ASSERT=y
+
+
+# Thread monitor and debug moninot exception to be able to debug BLE when running
+# Applies only to application, not mcuboot.
+# VTOR is currently at 0xC200 (mcuboot size + mcuboot_pad size)
+CONFIG_THREAD_NAME=y
+CONFIG_THREAD_MONITOR=y
+CONFIG_CORTEX_M_DEBUG_MONITOR_HOOK=y
+CONFIG_SEGGER_DEBUGMON=y
+


### PR DESCRIPTION
When using NCS debug.conf overlay, build with thread monitor so you can debug threads separately (supported in Ozone, CLion, VSCode).
JLink flashing of STM32 added.