### PR TITLE
Include pairing code in BLE_ALLOW_PAIRING command

### DIFF
--- a/core/embed/rust/src/trezorhal/ble.rs
+++ b/core/embed/rust/src/trezorhal/ble.rs
@@ -35,13 +35,19 @@ pub fn pairing_mode(name: &str) {
     }
 }
 
-pub fn allow_pairing() {
+pub fn allow_pairing(mut code: u32) {
+    const CODE_LEN: u8 = 6;
+    let mut cmd = ffi::ble_command_t {
+        cmd_type: ffi::ble_command_type_t_BLE_ALLOW_PAIRING,
+        data_len: CODE_LEN,
+        data: ffi::ble_command_data_t { raw: [0; 32] },
+    };
     unsafe {
-        let mut cmd = ffi::ble_command_t {
-            cmd_type: ffi::ble_command_type_t_BLE_ALLOW_PAIRING,
-            data_len: 0,
-            data: ffi::ble_command_data_t { raw: [0; 32] },
-        };
+        for i in (0..CODE_LEN).rev() {
+            let digit = b'0' + ((code % 10) as u8);
+            code /= 10;
+            cmd.data.raw[i as usize] = digit;
+        }
         ffi::ble_issue_command(&mut cmd as _);
     }
 }

--- a/core/embed/upymod/modtrezorio/modtrezorio-ble.h
+++ b/core/embed/upymod/modtrezorio/modtrezorio-ble.h
@@ -169,6 +169,28 @@ STATIC mp_obj_t mod_trezorio_BLE_peer_count(void) {
 STATIC MP_DEFINE_CONST_FUN_OBJ_0(mod_trezorio_BLE_peer_count_obj,
                                  mod_trezorio_BLE_peer_count);
 
+/// def allow_pairing() -> bool:
+///     """
+///     Accept BLE pairing request
+///     """
+STATIC mp_obj_t mod_trezorio_BLE_allow_pairing() {
+  ble_command_t cmd = {.cmd_type = BLE_ALLOW_PAIRING, .data_len = 0};
+  return mp_obj_new_bool(ble_issue_command(&cmd));
+}
+STATIC MP_DEFINE_CONST_FUN_OBJ_0(mod_trezorio_BLE_allow_pairing_obj,
+                                 mod_trezorio_BLE_allow_pairing);
+
+/// def reject_pairing() -> bool:
+///     """
+///     Reject BLE pairing request
+///     """
+STATIC mp_obj_t mod_trezorio_BLE_reject_pairing(void) {
+  ble_command_t cmd = {.cmd_type = BLE_REJECT_PAIRING, .data_len = 0};
+  return mp_obj_new_bool(ble_issue_command(&cmd));
+}
+STATIC MP_DEFINE_CONST_FUN_OBJ_0(mod_trezorio_BLE_reject_pairing_obj,
+                                 mod_trezorio_BLE_reject_pairing);
+
 /// class BleInterface:
 ///     """
 ///     BLE interface wrapper.
@@ -302,6 +324,10 @@ STATIC const mp_rom_map_elem_t mod_trezorio_BLE_globals_table[] = {
      MP_ROM_PTR(&mod_trezorio_BLE_disconnect_obj)},
     {MP_ROM_QSTR(MP_QSTR_peer_count),
      MP_ROM_PTR(&mod_trezorio_BLE_peer_count_obj)},
+    {MP_ROM_QSTR(MP_QSTR_allow_pairing),
+     MP_ROM_PTR(&mod_trezorio_BLE_allow_pairing_obj)},
+    {MP_ROM_QSTR(MP_QSTR_reject_pairing),
+     MP_ROM_PTR(&mod_trezorio_BLE_reject_pairing_obj)},
     {MP_ROM_QSTR(MP_QSTR_BleInterface),
      MP_ROM_PTR(&mod_trezorio_BleInterface_type)},
 };

--- a/core/mocks/generated/trezorio/ble.pyi
+++ b/core/mocks/generated/trezorio/ble.pyi
@@ -45,9 +45,10 @@ def peer_count() -> int:
 
 
 # upymod/modtrezorio/modtrezorio-ble.h
-def allow_pairing() -> bool:
+def allow_pairing(code: int) -> bool:
     """
-    Accept BLE pairing request
+    Accept BLE pairing request. Code must match the one received with
+    BLE_PAIRING_REQUEST event.
     """
 
 

--- a/core/mocks/generated/trezorio/ble.pyi
+++ b/core/mocks/generated/trezorio/ble.pyi
@@ -45,6 +45,20 @@ def peer_count() -> int:
 
 
 # upymod/modtrezorio/modtrezorio-ble.h
+def allow_pairing() -> bool:
+    """
+    Accept BLE pairing request
+    """
+
+
+# upymod/modtrezorio/modtrezorio-ble.h
+def reject_pairing() -> bool:
+    """
+    Reject BLE pairing request
+    """
+
+
+# upymod/modtrezorio/modtrezorio-ble.h
 class BleInterface:
     """
     BLE interface wrapper.


### PR DESCRIPTION
Should make it possible to prevent responding to mismatched pairing request. Needs corresponding change to the nRF code - should be quite straightforward but I don't have means to test it.

The PR also exposes the `allow_pairing`/`reject_pairing` functions to python as I'd prefer not to call them directly from UI when possible.
<!--
For core developers:
- Assign yourself to the PR.
- Set the priority to match the original issue.
- Add the PR to the current sprint.
- If it's a draft PR, mark it as "In Progress."
- If it's a final PR, mark it as "Needs Review."

For external contributors:
- Please open an issue before submitting a PR so we can discuss whether we want to proceed with it.
-->
