### PR TITLE
feat(tools): add an optional output argument to `analyze-memory-dump.py`

### DIFF
--- a/core/tools/analyze-memory-dump.py
+++ b/core/tools/analyze-memory-dump.py
@@ -5,7 +5,7 @@ import sys
 
 if len(sys.argv) < 2:
     print("""\
-USAGE: ./analyze-memory-dump.py somefile.json
+USAGE: ./analyze-memory-dump.py somefile.json [memorymap.html]
 
 Where "somefile.json" was produced by using `trezor.utils.mem_dump("somefile.json")`
 somewhere in emulator source code.
@@ -368,6 +368,7 @@ for item in allobjs:
     div.add(dl)
     doc.add(div)
 
-print("Writing to memorymap.html...")
-with open("memorymap.html", "w") as f:
+fname = "memorymap.html" if len(sys.argv) < 3 else sys.argv[2]
+print(f"Writing to {fname}...")
+with open(fname, "w") as f:
     f.write(doc.render(pretty=False))

--- a/docs/core/emulator/valgrind.md
+++ b/docs/core/emulator/valgrind.md
@@ -29,7 +29,7 @@ With `PYOPT=0`, most of the execution time is spent formatting and writing logs,
 
 If you're using Nix, you can use Valgrind and KCachegrind packages from our `shell.nix`:
 ```
-nix-shell --args devTools true --run "poetry shell"
+nix-shell --arg devTools true --run "poetry shell"
 ```
 
 Record profiling data on some device tests:


### PR DESCRIPTION
Also, fix a small typo in `docs/core/emulator/valgrind.md`.

<!--
For core developers:
- Assign yourself to the PR.
- Set the priority to match the original issue.
- Add the PR to the current sprint.
- If it's a draft PR, mark it as "In Progress."
- If it's a final PR, mark it as "Needs Review."

For external contributors:
- Please open an issue before submitting a PR so we can discuss whether we want to proceed with it.
-->
