### PR TITLE
send pairing code back to nrf for verification

### DIFF
--- a/core/embed/io/ble/inc/io/ble.h
+++ b/core/embed/io/ble/inc/io/ble.h
@@ -17,8 +17,7 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-#ifndef TREZORHAL_BLE_H
-#define TREZORHAL_BLE_H
+#pragma once
 
 // This module provides interface to BLE (Bluetooth Low Energy) functionality.
 // It allows the device to advertise itself, connect to other devices, and
@@ -30,6 +29,7 @@
 #define BLE_TX_PACKET_SIZE 64
 
 #define BLE_ADV_NAME_LEN 20
+#define BLE_PAIRING_CODE_LEN 6
 
 typedef enum {
   BLE_SWITCH_OFF = 0,      // Turn off BLE advertising, disconnect
@@ -150,5 +150,3 @@ uint32_t ble_read(uint8_t *data, uint16_t max_len);
 // When not using static address, the address is random and may not correspond
 // to what is actually used for advertising
 bool ble_get_mac(uint8_t *mac, size_t max_len);
-
-#endif

--- a/core/embed/io/ble/stm32/ble_comm_defs.h
+++ b/core/embed/io/ble/stm32/ble_comm_defs.h
@@ -43,13 +43,15 @@ typedef struct {
 
 typedef enum {
   INTERNAL_EVENT_STATUS = 0x01,
+  INTERNAL_EVENT_SUCCESS = 0x02,
+  INTERNAL_EVENT_FAILURE = 0x03,
   INTERNAL_EVENT_PAIRING_REQUEST = 0x04,
   INTERNAL_EVENT_PAIRING_CANCELLED = 0x05,
   INTERNAL_EVENT_MAC = 0x06,
 } internal_event_t;
 
 typedef enum {
-  INTERNAL_CMD_PING = 0x00,
+  INTERNAL_CMD_SEND_STATE = 0x00,
   INTERNAL_CMD_ADVERTISING_ON = 0x01,
   INTERNAL_CMD_ADVERTISING_OFF = 0x02,
   INTERNAL_CMD_ERASE_BONDS = 0x03,
@@ -58,7 +60,7 @@ typedef enum {
   INTERNAL_CMD_ALLOW_PAIRING = 0x06,
   INTERNAL_CMD_REJECT_PAIRING = 0x07,
   INTERNAL_CMD_UNPAIR = 0x08,
-  INTERNAL_CMD_MAC_REQUEST = 0x09,
+  INTERNAL_CMD_GET_MAC = 0x09,
 } internal_cmd_t;
 
 typedef struct {
@@ -69,3 +71,8 @@ typedef struct {
   uint32_t device_code;
   uint8_t name[BLE_ADV_NAME_LEN];
 } cmd_advertising_on_t;
+
+typedef struct {
+  uint8_t cmd_id;
+  uint8_t code[BLE_PAIRING_CODE_LEN];
+} cmd_allow_pairing_t;

--- a/core/embed/projects/prodtest/cmd/prodtest_ble.c
+++ b/core/embed/projects/prodtest/cmd/prodtest_ble.c
@@ -36,6 +36,8 @@ void ble_timer_cb(void* context) {
     switch (e.type) {
       case BLE_PAIRING_REQUEST:
         cmd.cmd_type = BLE_ALLOW_PAIRING;
+        memcpy(cmd.data.raw, e.data, BLE_PAIRING_CODE_LEN);
+        cmd.data_len = BLE_PAIRING_CODE_LEN;
         ble_issue_command(&cmd);
       default:
         break;

--- a/nordic/trezor/trezor-ble/src/ble/advertising.c
+++ b/nordic/trezor/trezor-ble/src/ble/advertising.c
@@ -92,7 +92,7 @@ void advertising_start(bool wl, uint8_t color, uint32_t device_code,
   advertising_data[1].data_len = name_len;
   advertising_data[1].data = (const uint8_t *)name;
 
-  char gap_name[21] = {0};
+  char gap_name[BLE_ADV_NAME_LEN + 1] = {0};
   memcpy(gap_name, name, name_len);
 
   bt_set_name(gap_name);

--- a/nordic/trezor/trezor-ble/src/ble/ble_internal.h
+++ b/nordic/trezor/trezor-ble/src/ble/ble_internal.h
@@ -46,6 +46,9 @@
 #define BT_UUID_TRZ_RX BT_UUID_DECLARE_128(BT_UUID_TRZ_RX_VAL)
 #define BT_UUID_TRZ_TX BT_UUID_DECLARE_128(BT_UUID_TRZ_TX_VAL)
 
+#define BLE_PAIRING_CODE_LEN 6
+#define BLE_ADV_NAME_LEN 20
+
 typedef struct {
   uint8_t msg_id;
   uint8_t connected;
@@ -85,6 +88,20 @@ typedef enum {
   INTERNAL_CMD_UNPAIR = 0x08,
   INTERNAL_CMD_GET_MAC = 0x09,
 } internal_cmd_t;
+
+typedef struct {
+  uint8_t cmd_id;
+  uint8_t whitelist;
+  uint8_t color;
+  uint8_t static_addr;
+  uint32_t device_code;
+  uint8_t name[BLE_ADV_NAME_LEN];
+} cmd_advertising_on_t;
+
+typedef struct {
+  uint8_t cmd_id;
+  uint8_t code[BLE_PAIRING_CODE_LEN];
+} cmd_allow_pairing_t;
 
 // BLE management functions
 // Initialization
@@ -135,7 +152,7 @@ bool pairing_init(void);
 // Reset pairing process
 void pairing_reset(void);
 // Respond to pairing request
-void pairing_num_comp_reply(bool accept);
+void pairing_num_comp_reply(bool accept, uint8_t *code);
 
 // Service functions
 // Callback definition for received data

--- a/nordic/trezor/trezor-ble/src/ble/ble_management.c
+++ b/nordic/trezor/trezor-ble/src/ble/ble_management.c
@@ -113,15 +113,11 @@ static void process_command(uint8_t *data, uint16_t len) {
       ble_management_send_status_event();
       break;
     case INTERNAL_CMD_ADVERTISING_ON: {
-      uint8_t color = data[2];
-      bool static_addr = data[3];
-      uint32_t device_code =
-          (data[4] << 24) | (data[5] << 16) | (data[6] << 8) | data[7];
-      char *name = &data[8];
+      cmd_advertising_on_t *cmd = (cmd_advertising_on_t *)data;
 
-      int name_len = strnlen(name, 20);
-      advertising_start(data[1] != 0, color, device_code, static_addr, name,
-                        name_len);
+      int name_len = strnlen(cmd->name, BLE_ADV_NAME_LEN);
+      advertising_start(cmd->whitelist != 0, cmd->color, cmd->device_code,
+                        cmd->static_addr, (char *)cmd->name, name_len);
     } break;
     case INTERNAL_CMD_ADVERTISING_OFF:
       advertising_stop();
@@ -135,10 +131,12 @@ static void process_command(uint8_t *data, uint16_t len) {
       // pb_msg_ack();
       break;
     case INTERNAL_CMD_ALLOW_PAIRING:
-      pairing_num_comp_reply(true);
+      cmd_allow_pairing_t *cmd = (cmd_allow_pairing_t *)data;
+
+      pairing_num_comp_reply(true, cmd->code);
       break;
     case INTERNAL_CMD_REJECT_PAIRING:
-      pairing_num_comp_reply(false);
+      pairing_num_comp_reply(false, NULL);
       break;
     case INTERNAL_CMD_UNPAIR:
       success = bonds_erase_current();


### PR DESCRIPTION
This PR addresses a potential problem with reconnecting when pairing. NRF now compares the pairing code received from UI with the one that is currently expected before confirming.