### PR TITLE
fix(core): workaround for GC-related test issue

### DIFF
--- a/core/prof/prof.py
+++ b/core/prof/prof.py
@@ -43,7 +43,8 @@ class _Prof:
         #     print(event, frame.f_code.co_filename, frame.f_lineno)
 
         if event == "line":
-            self.__coverage.line_tick(frame.f_code.co_filename, frame.f_lineno)
+            filename = str(frame.f_code.co_filename)
+            self.__coverage.line_tick(filename, frame.f_lineno)
 
     def coverage_data(self):
         return self.__coverage.lines_execution()


### PR DESCRIPTION
The underlying issue seems to be caused by the GC not freeing the old `session` since it is reachable from [the C stack](https://github.com/trezor/micropython/blob/6bdefd147256d6a72827ac6225fc5e36bd92a801/shared/runtime/gchelper_generic.c#L180), so the `ImageBuffer` [lock](https://github.com/trezor/trezor-firmware/blob/469f093b8add96d2d2451fe4f6a4ae1dba30309d/core/embed/rust/src/ui/shape/utils/imagebuf.rs#L41) is not dropped.

<!--
For core developers:
- Assign yourself to the PR.
- Set the priority to match the original issue.
- Add the PR to the current sprint.
- If it's a draft PR, mark it as "In Progress."
- If it's a final PR, mark it as "Needs Review."

For external contributors:
- Please open an issue before submitting a PR so we can discuss whether we want to proceed with it.
-->
