### PR TITLE
fix(core): correct `__main__` dict size retrieval in firmware

### DIFF
--- a/core/embed/upymod/modtrezorutils/modtrezorutils.c
+++ b/core/embed/upymod/modtrezorutils/modtrezorutils.c
@@ -313,8 +313,14 @@ STATIC mp_obj_t mod_trezorutils_check_reallocs(void) {
   if (modules->map.alloc > MICROPY_LOADED_MODULES_DICT_SIZE) {
     mp_raise_msg(&mp_type_AssertionError, "sys.modules dict is reallocated");
   }
+#ifdef TREZOR_EMULATOR
+  // when profiling, __main__ module is `prof.py`, not `main.py`
   mp_obj_t main = mp_obj_dict_get(modules, MP_OBJ_NEW_QSTR(MP_QSTR_main));
   size_t main_map_alloc = mp_obj_module_get_globals(main)->map.alloc;
+#else
+  // `main.py` is executed (not imported), so there is no `main` module
+  size_t main_map_alloc = MP_STATE_VM(dict_main).map.alloc;
+#endif
   if (main_map_alloc > MICROPY_MAIN_DICT_SIZE) {
     mp_raise_msg(&mp_type_AssertionError, "main globals dict is reallocated");
   }


### PR DESCRIPTION
Otherwise, it fails to boot (following e6f96974d).

<!--
For core developers:
- Assign yourself to the PR.
- Set the priority to match the original issue.
- Add the PR to the current sprint.
- If it's a draft PR, mark it as "In Progress."
- If it's a final PR, mark it as "Needs Review."

For external contributors:
- Please open an issue before submitting a PR so we can discuss whether we want to proceed with it.
-->
