### PR TITLE
LED for emulator

### DIFF
--- a/core/SConscript.unix
+++ b/core/SConscript.unix
@@ -21,7 +21,7 @@ if BENCHMARK and PYOPT != '0':
   print("BENCHMARK=1 works only with PYOPT=0.")
   exit(1)
 
-FEATURES_WANTED = ["input", "sd_card", "dma2d", "optiga", "ble"]
+FEATURES_WANTED = ["input", "sd_card", "dma2d", "optiga", "ble", "rgb_led"]
 
 if not DISABLE_TROPIC:
     FEATURES_WANTED.append('tropic')

--- a/core/embed/io/display/inc/io/unix/sdl_display.h
+++ b/core/embed/io/display/inc/io/unix/sdl_display.h
@@ -1,0 +1,8 @@
+#pragma once
+
+#include <trezor_types.h>
+
+#ifdef USE_RGB_LED
+// Update the RGB LED color in the emulator
+void display_rgb_led(uint32_t color);
+#endif

--- a/core/embed/io/display/unix/display_driver.c
+++ b/core/embed/io/display/unix/display_driver.c
@@ -24,6 +24,7 @@
 #include <trezor_rtl.h>
 
 #include <io/display.h>
+#include <io/unix/sdl_display.h>
 
 #include <SDL.h>
 #include <SDL_image.h>
@@ -75,6 +76,10 @@ typedef struct {
   uint8_t mono_framebuf[DISPLAY_RESX * DISPLAY_RESY];
 #endif
 
+#ifdef USE_RGB_LED
+  // Color of the RGB LED
+  uint32_t led_color;
+#endif
 } display_driver_t;
 
 static display_driver_t g_display_driver = {
@@ -177,6 +182,9 @@ bool display_init(display_content_mode_t mode) {
   SDL_ShowCursor(SDL_DISABLE);
 #else
   drv->orientation_angle = 0;
+#endif
+#ifdef USE_RGB_LED
+  drv->led_color = 0;
 #endif
 
   gfx_bitblt_init();
@@ -319,6 +327,63 @@ static void copy_mono_framebuf(display_driver_t *drv) {
 }
 #endif
 
+#ifdef USE_RGB_LED
+
+void display_rgb_led(uint32_t color) {
+  display_driver_t *drv = &g_display_driver;
+  if (!drv->initialized) {
+    return;
+  }
+  // Store color for future display refreshes
+  drv->led_color = color;
+  display_refresh();
+}
+
+void draw_rgb_led() {
+  display_driver_t *drv = &g_display_driver;
+
+  if (!drv->initialized) {
+    return;
+  }
+
+  const uint32_t color = drv->led_color;
+
+  if (color == 0) {
+    return;  // No LED color set
+  }
+
+  // Extract RGB components
+  uint32_t r = (color >> 16) & 0xFF;
+  uint32_t g = (color >> 8) & 0xFF;
+  uint32_t b = color & 0xFF;
+
+  // Define LED circle properties
+  const int radius = 5;
+  int center_x = DISPLAY_RESX / 2;
+  int center_y = 0;
+
+  // Position based on background
+  if (drv->background) {
+    center_x += TOUCH_OFFSET_X;
+    center_y = TOUCH_OFFSET_Y / 2;
+  } else {
+    center_x += EMULATOR_BORDER;
+    center_y = EMULATOR_BORDER / 2;
+  }
+
+  // Draw the LED
+  SDL_SetRenderDrawColor(drv->renderer, r, g, b, 255);
+  for (int y = -radius; y <= radius; y++) {
+    for (int x = -radius; x <= radius; x++) {
+      if (x * x + y * y <= radius * radius) {
+        SDL_RenderDrawPoint(drv->renderer, center_x + x, center_y + y);
+      }
+    }
+  }
+  SDL_SetRenderDrawColor(drv->renderer, 0, 0, 0, 255);
+}
+#endif  // USE_RGB_LED
+
 void display_refresh(void) {
   display_driver_t *drv = &g_display_driver;
 
@@ -353,6 +418,10 @@ void display_refresh(void) {
     SDL_RenderCopyEx(drv->renderer, drv->texture, NULL, &r,
                      drv->orientation_angle, NULL, 0);
   }
+#ifdef USE_RGB_LED
+  draw_rgb_led();
+#endif
+
   SDL_RenderPresent(drv->renderer);
 }
 

--- a/core/embed/io/rgb_led/unix/rgb_led.c
+++ b/core/embed/io/rgb_led/unix/rgb_led.c
@@ -1,0 +1,28 @@
+/*
+ * This file is part of the Trezor project, https://trezor.io/
+ *
+ * Copyright (c) SatoshiLabs
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#include <io/rgb_led.h>
+#include <io/unix/sdl_display.h>
+
+#ifdef KERNEL_MODE
+void rgb_led_init(void){};
+void rgb_led_deinit(void){};
+#endif
+
+void rgb_led_set_color(uint32_t color) { display_rgb_led(color); }

--- a/core/site_scons/models/T3W1/emulator.py
+++ b/core/site_scons/models/T3W1/emulator.py
@@ -45,6 +45,12 @@ def configure(
         paths += ["embed/io/sbu/inc"]
         defines += [("USE_SBU", "1")]
 
+    if "rgb_led" in features_wanted:
+        sources += ["embed/io/rgb_led/unix/rgb_led.c"]
+        paths += ["embed/io/rgb_led/inc"]
+        features_available.append("rgb_led")
+        defines += [("USE_RGB_LED", "1")]
+
     if "optiga" in features_wanted:
         sources += ["embed/sec/optiga/unix/optiga_hal.c"]
         sources += ["embed/sec/optiga/unix/optiga.c"]


### PR DESCRIPTION
[no changelog]

<!--
For core developers:
- Assign yourself to the PR.
- Set the priority to match the original issue.
- Add the PR to the current sprint.
- If it's a draft PR, mark it as "In Progress."
- If it's a final PR, mark it as "Needs Review."

For external contributors:
- Please open an issue before submitting a PR so we can discuss whether we want to proceed with it.
-->
This PR adds LED to the emulator. It is done via unix/display_driver.c which draws it right above the display to the padding area.

This is a 2nd PR which follows up from review concerns and changes the target branch to `main` https://github.com/trezor/trezor-firmware/pull/4854#pullrequestreview-2733908768