### PR TITLE
T3W1 power optimization

### DIFF
--- a/core/embed/io/display/ltdc_dsi/display_driver.c
+++ b/core/embed/io/display/ltdc_dsi/display_driver.c
@@ -413,19 +413,13 @@ cleanup:
 void display_deinit(display_content_mode_t mode) {
   display_driver_t *drv = &g_display_driver;
 
-  GPIO_InitTypeDef GPIO_InitStructure = {0};
-
   gfx_bitblt_deinit();
 
   NVIC_DisableIRQ(LTDC_IRQn);
   NVIC_DisableIRQ(LTDC_ER_IRQn);
 
 #ifdef BACKLIGHT_PIN_PIN
-  GPIO_InitStructure.Mode = GPIO_MODE_ANALOG;
-  GPIO_InitStructure.Pull = GPIO_NOPULL;
-  GPIO_InitStructure.Speed = GPIO_SPEED_LOW;
-  GPIO_InitStructure.Pin = BACKLIGHT_PIN_PIN;
-  HAL_GPIO_Init(BACKLIGHT_PIN_PORT, &GPIO_InitStructure);
+  HAL_GPIO_DeInit(BACKLIGHT_PIN_PORT, BACKLIGHT_PIN_PIN);
 #endif
 
 #ifdef USE_BACKLIGHT
@@ -439,22 +433,14 @@ void display_deinit(display_content_mode_t mode) {
 #endif
   display_pll_deinit();
 
-#ifdef DISPLAY_PWREN_PIN
-  // Release PWREN pin and switch display power off
-  GPIO_InitStructure.Mode = GPIO_MODE_ANALOG;
-  GPIO_InitStructure.Pull = GPIO_NOPULL;
-  GPIO_InitStructure.Speed = GPIO_SPEED_LOW;
-  GPIO_InitStructure.Pin = DISPLAY_PWREN_PIN;
-  HAL_GPIO_Init(DISPLAY_PWREN_PORT, &GPIO_InitStructure);
-#endif
-
 #ifdef DISPLAY_RESET_PIN
   // Release the RESET pin
-  GPIO_InitStructure.Mode = GPIO_MODE_ANALOG;
-  GPIO_InitStructure.Pull = GPIO_NOPULL;
-  GPIO_InitStructure.Speed = GPIO_SPEED_LOW;
-  GPIO_InitStructure.Pin = DISPLAY_RESET_PIN;
-  HAL_GPIO_Init(DISPLAY_RESET_PORT, &GPIO_InitStructure);
+  HAL_GPIO_DeInit(DISPLAY_RESET_PORT, DISPLAY_RESET_PIN);
+#endif
+
+#ifdef DISPLAY_PWREN_PIN
+  // Release PWREN pin and switch display power off
+  HAL_GPIO_DeInit(DISPLAY_PWREN_PORT, DISPLAY_PWREN_PIN);
 #endif
 
   memset(drv, 0, sizeof(display_driver_t));

--- a/core/embed/io/rgb_led/stm32u5/rgb_led_lp.c
+++ b/core/embed/io/rgb_led/stm32u5/rgb_led_lp.c
@@ -49,19 +49,9 @@ typedef struct {
 static rgb_led_t g_rgb_led = {0};
 
 static void rgb_led_set_default_pin_state(void) {
-  GPIO_InitTypeDef GPIO_InitStructure = {0};
-  GPIO_InitStructure.Mode = GPIO_MODE_ANALOG;
-  GPIO_InitStructure.Pull = GPIO_NOPULL;
-  GPIO_InitStructure.Speed = GPIO_SPEED_FREQ_LOW;
-
-  GPIO_InitStructure.Pin = RGB_LED_RED_PIN;
-  HAL_GPIO_Init(RGB_LED_RED_PORT, &GPIO_InitStructure);
-
-  GPIO_InitStructure.Pin = RGB_LED_GREEN_PIN;
-  HAL_GPIO_Init(RGB_LED_GREEN_PORT, &GPIO_InitStructure);
-
-  GPIO_InitStructure.Pin = RGB_LED_BLUE_PIN;
-  HAL_GPIO_Init(RGB_LED_BLUE_PORT, &GPIO_InitStructure);
+  HAL_GPIO_DeInit(RGB_LED_RED_PORT, RGB_LED_RED_PIN);
+  HAL_GPIO_DeInit(RGB_LED_GREEN_PORT, RGB_LED_GREEN_PIN);
+  HAL_GPIO_DeInit(RGB_LED_BLUE_PORT, RGB_LED_BLUE_PIN);
 }
 
 void rgb_led_init(void) {
@@ -188,6 +178,14 @@ void rgb_led_deinit(void) {
 
   HAL_LPTIM_Counter_Stop(&drv->tim_1);
   HAL_LPTIM_Counter_Stop(&drv->tim_3);
+
+  __HAL_RCC_LPTIM1_CLK_DISABLE();
+  __HAL_RCC_LPTIM1_FORCE_RESET();
+  __HAL_RCC_LPTIM1_RELEASE_RESET();
+
+  __HAL_RCC_LPTIM3_CLK_DISABLE();
+  __HAL_RCC_LPTIM3_FORCE_RESET();
+  __HAL_RCC_LPTIM3_RELEASE_RESET();
 
   memset(drv, 0, sizeof(*drv));
 }

--- a/core/embed/io/touch/ft6x36/ft6x36.c
+++ b/core/embed/io/touch/ft6x36/ft6x36.c
@@ -173,14 +173,13 @@ static void ft6x36_power_down(void) {
                                       // held in reset until released
 #endif
 
-  // set above pins to OUTPUT / NOPULL
-  GPIO_InitTypeDef GPIO_InitStructure = {0};
+  HAL_GPIO_DeInit(TOUCH_INT_PORT, TOUCH_INT_PIN);
 
+#if defined(TOUCH_RST_PIN) || defined(TOUCH_ON_PIN)
+  GPIO_InitTypeDef GPIO_InitStructure = {0};
   GPIO_InitStructure.Mode = GPIO_MODE_OUTPUT_PP;
   GPIO_InitStructure.Pull = GPIO_NOPULL;
   GPIO_InitStructure.Speed = GPIO_SPEED_FREQ_LOW;
-  GPIO_InitStructure.Pin = TOUCH_INT_PIN;
-  HAL_GPIO_Init(TOUCH_INT_PORT, &GPIO_InitStructure);
 
 #ifdef TOUCH_RST_PIN
   GPIO_InitStructure.Pin = TOUCH_RST_PIN;
@@ -195,6 +194,7 @@ static void ft6x36_power_down(void) {
     // 90 ms for circuitry to stabilize (being conservative)
     systick_delay_ms(90);
   }
+#endif
 #endif
 }
 

--- a/core/embed/sec/tropic/stm32/tropic01.c
+++ b/core/embed/sec/tropic/stm32/tropic01.c
@@ -145,7 +145,10 @@ bool tropic_hal_init(void) {
 void tropic_hal_deinit(void) {
   tropic01_hal_driver_t *drv = &g_tropic01_hal_driver;
 
-  HAL_SPI_DeInit(&drv->spi);
+  if (drv->spi.Instance != NULL) {
+    HAL_SPI_DeInit(&drv->spi);
+  }
+
   __HAL_RCC_SPI2_FORCE_RESET();
   __HAL_RCC_SPI2_RELEASE_RESET();
   __HAL_RCC_SPI2_CLK_DISABLE();

--- a/core/embed/sec/tropic/tropic.c
+++ b/core/embed/sec/tropic/tropic.c
@@ -94,7 +94,9 @@ cleanup:
 void tropic_deinit(void) {
   tropic_driver_t *drv = &g_tropic_driver;
 
-  lt_deinit(&drv->handle);
+  if (drv->handle.device != NULL) {
+    lt_deinit(&drv->handle);
+  }
 
   tropic_hal_deinit();
 

--- a/core/embed/sys/powerctl/npm1300/npm1300.c
+++ b/core/embed/sys/powerctl/npm1300/npm1300.c
@@ -227,8 +227,8 @@ static bool npm1300_initialize(i2c_bus_t* bus, uint16_t i_charge,
       {NPM1300_TASKLDSW2CLR, 0x01},
       // BUCK regulators
       // 2.7V, use sw settigns
-      {NPM1300_BUCK1NORMVOUT, 17},
-      {NPM1300_BUCKSWCTRLSEL, 1},
+      // {NPM1300_BUCK1NORMVOUT, 17}, // this settings adds 900uA on VBAT
+      // {NPM1300_BUCKSWCTRLSEL, 1},
       // Buck auto mode, Pull downs disabled
       {NPM1300_BUCKCTRL0, 0},  // Auto mode
       //
@@ -266,8 +266,8 @@ static bool npm1300_initialize(i2c_bus_t* bus, uint16_t i_charge,
       {NPM1300_DIETEMPRESUME, die_temp_resume >> 2},
       {NPM1300_DIETEMPRESUMELSB, die_temp_resume & 0x03},
       // LEDS
-      {NPM1300_LEDDRV0MODESEL, NPM1300_LEDDRVMODESEL_ERROR},
-      {NPM1300_LEDDRV1MODESEL, NPM1300_LEDDRVMODESEL_CHARGING},
+      {NPM1300_LEDDRV0MODESEL, NPM1300_LEDDRVMODESEL_NOTUSED},
+      {NPM1300_LEDDRV1MODESEL, NPM1300_LEDDRVMODESEL_NOTUSED},
       {NPM1300_LEDDRV2MODESEL, NPM1300_LEDDRVMODESEL_NOTUSED},
       // GPIO
       {NPM1300_GPIOMODE0, NPM1300_GPIOMODE_GPIINPUT},

--- a/core/embed/sys/powerctl/stm32u5/powerctl_suspend.c
+++ b/core/embed/sys/powerctl/stm32u5/powerctl_suspend.c
@@ -46,6 +46,10 @@
 #include <io/rgb_led.h>
 #endif
 
+#ifdef USE_TROPIC
+#include <sec/tropic.h>
+#endif
+
 #ifdef KERNEL_MODE
 
 static void background_tasks_suspend(void) {
@@ -69,6 +73,9 @@ void powerctl_suspend(void) {
   // (e.g., USB, display, touch, haptic, etc.).
 #ifdef USE_STORAGE_HWKEY
   secure_aes_deinit();
+#endif
+#ifdef USE_TROPIC
+  tropic_deinit();
 #endif
 #ifdef USE_OPTIGA
   optiga_deinit();
@@ -160,6 +167,9 @@ void powerctl_suspend(void) {
 #endif
 #ifdef USE_OPTIGA
   optiga_init_and_configure();
+#endif
+#ifdef USE_TROPIC
+  tropic_init();
 #endif
 }
 


### PR DESCRIPTION
This PR includes series of commits that optimize power consumption in suspend mode:

- Deinitialization routines were fixed (and in some case only refactored for consistency)
- The Tropic driver is now properly deinitialized before entering suspend mode 
- `tropic_deinit()` was modified to prevent crashes when called without a prior `tropic_init()`
- npm1300 configuration was slightly - the buck 1 output voltage settings is now left unchanged, relying on the bootstrap pin configuration instead

There's still some additional consumption caused by the BLE driver, which will be addressed in a separate PR.
