### PR TITLE
Echart UI - fix hint and gradient buttons

### DIFF
--- a/core/embed/rust/src/ui/layout_eckhart/component/button.rs
+++ b/core/embed/rust/src/ui/layout_eckhart/component/button.rs
@@ -350,7 +350,7 @@ impl Button {
                     .render(target);
             }
             // Gradient bar is rendered only in `normal` state, not `active` or `disabled`
-            (None, true) if self.state == State::Initial || self.state == State::Released => {
+            (None, true) if self.state.is_normal() => {
                 self.render_gradient_bar(target, style);
             }
             _ => {
@@ -607,6 +607,14 @@ enum State {
     Pressed,
     Released,
     Disabled,
+}
+
+impl State {
+    /// Returns true if the button is in a normal state (not pressed or
+    /// disabled).
+    fn is_normal(&self) -> bool {
+        matches!(self, State::Initial | State::Released)
+    }
 }
 
 #[derive(PartialEq, Eq, Clone)]

--- a/core/embed/rust/src/ui/layout_eckhart/firmware/action_bar.rs
+++ b/core/embed/rust/src/ui/layout_eckhart/firmware/action_bar.rs
@@ -71,12 +71,13 @@ impl ActionBar {
     /// component automatically shows navigation up/down buttons for
     /// paginated content.
     pub fn new_single(button: Button) -> Self {
-        Self::new(
-            Mode::Single,
-            None,
-            Some(button.with_expanded_touch_area(Self::BUTTON_EXPAND_TOUCH)),
-            None,
-        )
+        let mut right_button = button
+            .with_expanded_touch_area(Self::BUTTON_EXPAND_TOUCH)
+            .with_gradient();
+        if right_button.stylesheet() == &theme::button_default() {
+            right_button = right_button.styled(theme::firmware::button_default_actionbar_right());
+        };
+        Self::new(Mode::Single, None, Some(right_button), None)
     }
 
     /// Create action bar with single button confirming the layout
@@ -93,17 +94,21 @@ impl ActionBar {
     /// automatically shows navigation up/down buttons for paginated
     /// content.
     pub fn new_double(left: Button, right: Button) -> Self {
+        let left_button = left
+            .with_expanded_touch_area(Self::BUTTON_EXPAND_TOUCH)
+            .with_content_offset(Self::BUTTON_CONTENT_OFFSET);
+        let mut right_button = right
+            .with_expanded_touch_area(Self::BUTTON_EXPAND_TOUCH)
+            .with_content_offset(Self::BUTTON_CONTENT_OFFSET.neg())
+            .with_gradient();
+        if right_button.stylesheet() == &theme::button_default() {
+            right_button = right_button.styled(theme::firmware::button_default_actionbar_right());
+        };
+
         Self::new(
             Mode::Double { left_short: true },
-            Some(
-                left.with_expanded_touch_area(Self::BUTTON_EXPAND_TOUCH)
-                    .with_content_offset(Self::BUTTON_CONTENT_OFFSET),
-            ),
-            Some(
-                right
-                    .with_expanded_touch_area(Self::BUTTON_EXPAND_TOUCH)
-                    .with_content_offset(Self::BUTTON_CONTENT_OFFSET.neg()),
-            ),
+            Some(left_button),
+            Some(right_button),
             None,
         )
     }
@@ -112,7 +117,6 @@ impl ActionBar {
         Self::new_double(
             Button::with_icon(theme::ICON_CROSS),
             Button::with_text(TR::buttons__confirm.into())
-                .with_gradient()
                 .styled(theme::firmware::button_confirm()),
         )
     }

--- a/core/embed/rust/src/ui/layout_eckhart/theme/firmware.rs
+++ b/core/embed/rust/src/ui/layout_eckhart/theme/firmware.rs
@@ -221,6 +221,32 @@ pub const fn button_cancel() -> ButtonStyleSheet {
     }
 }
 
+pub const fn button_default_actionbar_right() -> ButtonStyleSheet {
+    ButtonStyleSheet {
+        normal: &ButtonStyle {
+            font: fonts::FONT_SATOSHI_MEDIUM_26,
+            text_color: GREY_LIGHT,
+            button_color: GREY_EXTRA_DARK,
+            icon_color: GREY_LIGHT,
+            background_color: GREY_EXTRA_DARK,
+        },
+        active: &ButtonStyle {
+            font: fonts::FONT_SATOSHI_MEDIUM_26,
+            text_color: GREY_DARK,
+            button_color: GREY_SUPER_DARK,
+            icon_color: GREY_DARK,
+            background_color: BG,
+        },
+        disabled: &ButtonStyle {
+            font: fonts::FONT_SATOSHI_MEDIUM_26,
+            text_color: GREY_EXTRA_DARK,
+            button_color: BG,
+            icon_color: GREY_EXTRA_DARK,
+            background_color: BG,
+        },
+    }
+}
+
 pub const fn button_warning_high() -> ButtonStyleSheet {
     ButtonStyleSheet {
         normal: &ButtonStyle {

--- a/core/embed/rust/src/ui/layout_eckhart/ui_firmware.rs
+++ b/core/embed/rust/src/ui/layout_eckhart/ui_firmware.rs
@@ -74,9 +74,7 @@ impl FirmwareUI for UIEckhart {
         };
 
         let verb = verb.unwrap_or(TR::buttons__confirm.into());
-        let mut right_button = Button::with_text(verb)
-            .with_gradient()
-            .styled(theme::firmware::button_confirm());
+        let mut right_button = Button::with_text(verb).styled(theme::firmware::button_confirm());
         if hold {
             right_button = right_button.with_long_press(theme::CONFIRM_HOLD_DURATION);
         }


### PR DESCRIPTION
<!--
For core developers:
- Assign yourself to the PR.
- Set the priority to match the original issue.
- Add the PR to the current sprint.
- If it's a draft PR, mark it as "In Progress."
- If it's a final PR, mark it as "Needs Review."

For external contributors:
- Please open an issue before submitting a PR so we can discuss whether we want to proceed with it.
-->
This PR does two things:
1. sets correct padding for `Hint` according to Figma
2. constructs the `right_button` of `ActionBar` with gradient settings which should be the right thing (according to Figma)