### PR TITLE
fix(core):  make mod_trezorio_poll return False only on timeout

### DIFF
--- a/core/embed/projects/kernel/main.c
+++ b/core/embed/projects/kernel/main.c
@@ -186,7 +186,7 @@ static void kernel_loop(applet_t *coreapp) {
     sysevents_t awaited = {0};
     sysevents_t signalled = {0};
 
-    sysevents_poll(&awaited, &signalled, 100);
+    sysevents_poll(&awaited, &signalled, ticks_timeout(100));
 
   } while (applet_is_alive(coreapp));
 }

--- a/core/embed/sys/syscall/stm32/syscall_dispatch.c
+++ b/core/embed/sys/syscall/stm32/syscall_dispatch.c
@@ -157,9 +157,9 @@ __attribute((no_stack_protector)) void syscall_handler(uint32_t *args,
     case SYSCALL_SYSEVENTS_POLL: {
       const sysevents_t *awaited = (sysevents_t *)args[0];
       sysevents_t *signalled = (sysevents_t *)args[1];
-      uint32_t timeout = args[2];
+      uint32_t deadline = args[2];
       if (!g_in_app_callback) {
-        sysevents_poll__verified(awaited, signalled, timeout);
+        sysevents_poll__verified(awaited, signalled, deadline);
       }
     } break;
 

--- a/core/embed/sys/syscall/stm32/syscall_stubs.c
+++ b/core/embed/sys/syscall/stm32/syscall_stubs.c
@@ -77,8 +77,8 @@ uint64_t systick_us_to_cycles(uint64_t us) {
 #include <sys/sysevent.h>
 
 void sysevents_poll(const sysevents_t *awaited, sysevents_t *signalled,
-                    uint32_t timeout) {
-  syscall_invoke3((uint32_t)awaited, (uint32_t)signalled, timeout,
+                    uint32_t deadline) {
+  syscall_invoke3((uint32_t)awaited, (uint32_t)signalled, deadline,
                   SYSCALL_SYSEVENTS_POLL);
 }
 

--- a/core/embed/sys/syscall/stm32/syscall_verifiers.c
+++ b/core/embed/sys/syscall/stm32/syscall_verifiers.c
@@ -46,7 +46,7 @@
 // ---------------------------------------------------------------------
 
 void sysevents_poll__verified(const sysevents_t *awaited,
-                              sysevents_t *signalled, uint32_t timeout) {
+                              sysevents_t *signalled, uint32_t deadline) {
   if (!probe_read_access(awaited, sizeof(*awaited))) {
     goto access_violation;
   }
@@ -55,7 +55,7 @@ void sysevents_poll__verified(const sysevents_t *awaited,
     goto access_violation;
   }
 
-  sysevents_poll(awaited, signalled, timeout);
+  sysevents_poll(awaited, signalled, deadline);
   return;
 
 access_violation:

--- a/core/embed/sys/syscall/stm32/syscall_verifiers.h
+++ b/core/embed/sys/syscall/stm32/syscall_verifiers.h
@@ -25,7 +25,7 @@
 #include <sys/sysevent.h>
 
 void sysevents_poll__verified(const sysevents_t *awaited,
-                              sysevents_t *signalled, uint32_t timeout);
+                              sysevents_t *signalled, uint32_t deadline);
 
 // ---------------------------------------------------------------------
 #include <sys/systask.h>

--- a/core/embed/sys/task/inc/sys/sysevent.h
+++ b/core/embed/sys/task/inc/sys/sysevent.h
@@ -46,11 +46,11 @@ typedef struct {
 } sysevents_t;  // sys_events_t
 
 // Polls for the specified events. The function blocks until at least
-// one event is signaled or the timeout (in milliseconds) expires.
+// one event is signaled or deadline expires.
 //
 // Multiple events may be signaled simultaneously.
 //
 // Returns the events that were signaled. If the timeout expires, both
 // fields in the result are set to 0.
 void sysevents_poll(const sysevents_t* awaited, sysevents_t* signalled,
-                    uint32_t timeout);
+                    uint32_t deadline);

--- a/core/embed/sys/task/sysevent.c
+++ b/core/embed/sys/task/sysevent.c
@@ -157,7 +157,7 @@ static inline void insert_poller(sysevent_dispatcher_t *dispatcher,
 }
 
 void sysevents_poll(const sysevents_t *awaited, sysevents_t *signalled,
-                    uint32_t timeout) {
+                    uint32_t deadline) {
   sysevent_dispatcher_t *dispatcher = &g_sysevent_dispatcher;
 
   memset(signalled, 0, sizeof(*signalled));
@@ -177,7 +177,7 @@ void sysevents_poll(const sysevents_t *awaited, sysevents_t *signalled,
   dispatcher->pollers[prio].task = systask_active();
   dispatcher->pollers[prio].awaited = awaited;
   dispatcher->pollers[prio].signalled = signalled;
-  dispatcher->pollers[prio].deadline = ticks_timeout(timeout);
+  dispatcher->pollers[prio].deadline = deadline;
 
   if (active_task != kernel_task) {
     systask_yield_to(kernel_task);


### PR DESCRIPTION
This PR fixes a bug introduced in #4829.

`modtrezor_io_poll` returned `False` not only in case of a timeout, but also when events were signaled and then discarded due to various reasons - such as false positives or event rate throttling. That broke the task scheduling mechanism in MicroPython, which relies on it.

No changelog needed since the bug was not released yet.