### PR TITLE
Update VerticalMenu swiping behavior for Eckhart

### DIFF
--- a/core/embed/rust/src/ui/layout_eckhart/firmware/device_menu_screen.rs
+++ b/core/embed/rust/src/ui/layout_eckhart/firmware/device_menu_screen.rs
@@ -416,10 +416,13 @@ impl<'a> DeviceMenuScreen<'a> {
             Subscreen::Submenu(ref mut submenu_index) => {
                 match self.submenus[*submenu_index].items[idx].action {
                     Some(Action::GoTo(menu)) => {
-                        self.menu_screen.as_mut().unwrap().update_menu(ctx);
                         unwrap!(self.parent_subscreens.push(self.active_subscreen));
                         self.set_active_subscreen(menu);
                         self.place(self.bounds);
+                        if let Some(screen) = self.menu_screen.as_mut() {
+                            screen.initialize_screen(ctx);
+                        }
+                        return None;
                     }
                     Some(Action::Return(msg)) => return Some(msg),
                     None => {}
@@ -433,10 +436,13 @@ impl<'a> DeviceMenuScreen<'a> {
         None
     }
 
-    fn go_back(&mut self) -> Option<DeviceMenuMsg> {
+    fn go_back(&mut self, ctx: &mut EventCtx) -> Option<DeviceMenuMsg> {
         if let Some(parent) = self.parent_subscreens.pop() {
             self.set_active_subscreen(parent);
             self.place(self.bounds);
+            if let Some(screen) = self.menu_screen.as_mut() {
+                screen.initialize_screen(ctx);
+            }
             None
         } else {
             Some(DeviceMenuMsg::Close)
@@ -478,7 +484,7 @@ impl<'a> Component for DeviceMenuScreen<'a> {
                         }
                     }
                     Some(VerticalMenuScreenMsg::Back) => {
-                        return self.go_back();
+                        return self.go_back(ctx);
                     }
                     Some(VerticalMenuScreenMsg::Close) => {
                         return Some(DeviceMenuMsg::Close);
@@ -488,7 +494,7 @@ impl<'a> Component for DeviceMenuScreen<'a> {
             }
             Subscreen::AboutScreen => {
                 if let Some(TextScreenMsg::Cancelled) = self.about_screen.event(ctx, event) {
-                    return self.go_back();
+                    return self.go_back(ctx);
                 }
             }
         }

--- a/core/embed/rust/src/ui/layout_eckhart/firmware/select_word_screen.rs
+++ b/core/embed/rust/src/ui/layout_eckhart/firmware/select_word_screen.rs
@@ -1,24 +1,27 @@
+use heapless::Vec;
+
 use crate::{
     strutil::TString,
     ui::{
         component::{Component, Event, EventCtx, Label},
-        geometry::{Alignment, Insets, Rect},
+        geometry::{Alignment, Insets, Offset, Rect},
+        shape,
         shape::Renderer,
         ui_firmware::MAX_WORD_QUIZ_ITEMS,
     },
 };
 
 use super::super::{
-    component::Button,
+    component::{Button, ButtonMsg},
     constant::SCREEN,
-    firmware::{Header, HeaderMsg, VerticalMenu, VerticalMenuMsg},
+    firmware::{Header, HeaderMsg},
     theme,
 };
 
 pub struct SelectWordScreen {
     header: Header,
     description: Label<'static>,
-    menu: VerticalMenu,
+    menu: SelectWordButtons,
 }
 
 pub enum SelectWordMsg {
@@ -36,21 +39,11 @@ impl SelectWordScreen {
         share_words_vec: [TString<'static>; MAX_WORD_QUIZ_ITEMS],
         description: TString<'static>,
     ) -> Self {
-        let mut menu = VerticalMenu::empty().with_separators().with_content_fit();
-
-        for word in share_words_vec {
-            menu = menu.item(
-                Button::with_text(word)
-                    .styled(theme::button_select_word())
-                    .with_radius(12),
-            );
-        }
-
         Self {
             header: Header::new(TString::empty()),
             description: Label::new(description, Alignment::Start, theme::TEXT_MEDIUM)
                 .top_aligned(),
-            menu,
+            menu: SelectWordButtons::new(share_words_vec),
         }
     }
 
@@ -87,7 +80,7 @@ impl Component for SelectWordScreen {
             return Some(SelectWordMsg::Cancelled);
         }
 
-        if let Some(VerticalMenuMsg::Selected(i)) = self.menu.event(ctx, event) {
+        if let Some(i) = self.menu.event(ctx, event) {
             return Some(SelectWordMsg::Selected(i));
         }
 
@@ -101,13 +94,90 @@ impl Component for SelectWordScreen {
     }
 }
 
+struct SelectWordButtons {
+    buttons: Vec<Button, MAX_WORD_QUIZ_ITEMS>,
+}
+
+impl SelectWordButtons {
+    const SEPARATOR_PADDING: i16 = 12;
+    fn new(share_words_vec: [TString<'static>; MAX_WORD_QUIZ_ITEMS]) -> Self {
+        let mut buttons = Vec::new();
+        for word in share_words_vec {
+            unwrap!(buttons.push(
+                Button::with_text(word)
+                    .styled(theme::button_select_word())
+                    .with_radius(12)
+                    .with_text_align(Alignment::Center),
+            ));
+        }
+        Self { buttons }
+    }
+
+    fn render_separators<'s>(&'s self, target: &mut impl Renderer<'s>) {
+        for i in 1..self.buttons.len() {
+            let button = &self.buttons[i];
+            let button_prev = &self.buttons[i - 1];
+
+            if !button.is_pressed() && !button_prev.is_pressed() {
+                let separator = Rect::from_top_left_and_size(
+                    button
+                        .area()
+                        .top_left()
+                        .ofs(Offset::x(Self::SEPARATOR_PADDING)),
+                    Offset::new(button.area().width() - 2 * Self::SEPARATOR_PADDING, 1),
+                );
+                shape::Bar::new(separator)
+                    .with_fg(theme::GREY_EXTRA_DARK)
+                    .render(target);
+            }
+        }
+    }
+}
+
+impl Component for SelectWordButtons {
+    type Msg = usize;
+
+    fn place(&mut self, bounds: Rect) -> Rect {
+        let button_height = bounds.height() / self.buttons.len() as i16;
+        for (i, button) in self.buttons.iter_mut().enumerate() {
+            let top_left = bounds.top_left().ofs(Offset::y(i as i16 * button_height));
+            let button_bounds =
+                Rect::from_top_left_and_size(top_left, Offset::new(bounds.width(), button_height));
+            button.place(button_bounds);
+        }
+
+        bounds
+    }
+
+    fn event(&mut self, ctx: &mut EventCtx, event: Event) -> Option<Self::Msg> {
+        for (i, button) in self.buttons.iter_mut().enumerate() {
+            if let Some(ButtonMsg::Clicked) = button.event(ctx, event) {
+                return Some(i);
+            }
+        }
+
+        None
+    }
+
+    fn render<'s>(&'s self, target: &mut impl Renderer<'s>) {
+        for button in &self.buttons {
+            button.render(target);
+        }
+        self.render_separators(target);
+    }
+}
+
 #[cfg(feature = "ui_debug")]
 impl crate::trace::Trace for SelectWordScreen {
     fn trace(&self, t: &mut dyn crate::trace::Tracer) {
         t.component("SelectWordScreen");
         t.child("Header", &self.header);
         t.child("subtitle", &self.description);
-        t.child("Content", &self.menu);
+        t.in_list("buttons", &|button_list| {
+            for button in &self.menu.buttons {
+                button_list.child(button);
+            }
+        });
     }
 }
 

--- a/core/embed/rust/src/ui/layout_eckhart/firmware/select_word_screen.rs
+++ b/core/embed/rust/src/ui/layout_eckhart/firmware/select_word_screen.rs
@@ -36,7 +36,7 @@ impl SelectWordScreen {
         share_words_vec: [TString<'static>; MAX_WORD_QUIZ_ITEMS],
         description: TString<'static>,
     ) -> Self {
-        let mut menu = VerticalMenu::empty().with_separators().with_fit_area();
+        let mut menu = VerticalMenu::empty().with_separators().with_content_fit();
 
         for word in share_words_vec {
             menu = menu.item(

--- a/core/embed/rust/src/ui/layout_eckhart/firmware/vertical_menu.rs
+++ b/core/embed/rust/src/ui/layout_eckhart/firmware/vertical_menu.rs
@@ -28,9 +28,6 @@ pub struct VerticalMenu {
     offset_y: i16,
     /// Maximum vertical offset.
     offset_y_max: i16,
-    /// Adapt padding to fit entire area. If the area is too small, the padding
-    /// will be reduced to min value.
-    content_fit: bool,
     /// Whether to show separators between buttons.
     separators: bool,
 }
@@ -52,7 +49,6 @@ impl VerticalMenu {
             offset_y: 0,
             offset_y_max: 0,
             separators: false,
-            content_fit: false,
         }
     }
 
@@ -62,11 +58,6 @@ impl VerticalMenu {
 
     pub fn with_separators(mut self) -> Self {
         self.separators = true;
-        self
-    }
-
-    pub fn with_content_fit(mut self) -> Self {
-        self.content_fit = true;
         self
     }
 
@@ -177,24 +168,12 @@ impl Component for VerticalMenu {
         // Crop the menu area
         self.bounds = bounds.inset(Self::SIDE_INSETS);
 
-        // Determine padding dynamically if `content_fit` is enabled
-        let padding = if self.content_fit {
-            let mut content_height = 0;
-            for button in self.buttons.iter_mut() {
-                content_height += button.content_height();
-            }
-            let padding = (self.bounds.height() - content_height) / (self.buttons.len() as i16) / 2;
-            padding.max(Self::MIN_PADDING)
-        } else {
-            Self::DEFAULT_PADDING
-        };
-
         let button_width = self.bounds.width();
         let mut top_left = self.bounds.top_left();
 
         // Place each button (might overflow the menu bounds)
         for button in self.buttons.iter_mut() {
-            let button_height = button.content_height() + 2 * padding;
+            let button_height = button.content_height() + 2 * Self::DEFAULT_PADDING;
             let button_bounds =
                 Rect::from_top_left_and_size(top_left, Offset::new(button_width, button_height));
 

--- a/core/embed/rust/src/ui/layout_eckhart/firmware/vertical_menu_screen.rs
+++ b/core/embed/rust/src/ui/layout_eckhart/firmware/vertical_menu_screen.rs
@@ -2,13 +2,12 @@ use crate::{
     strutil::TString,
     ui::{
         component::{
-            base::AttachType,
             swipe_detect::{SwipeConfig, SwipeSettings},
             Component, Event, EventCtx, SwipeDetect,
         },
-        event::{SwipeEvent, TouchEvent},
+        event::SwipeEvent,
         flow::Swipable,
-        geometry::{Alignment2D, Direction, Offset, Rect},
+        geometry::{Alignment2D, Direction, Rect},
         shape::{Renderer, ToifImage},
         util::Pager,
     },
@@ -22,6 +21,8 @@ pub struct VerticalMenuScreen {
     menu: VerticalMenu,
     /// Base position of the menu sliding window to scroll around
     offset_base: i16,
+    /// Used to enable swipe detection only when the menu does not fit its area
+    swipe_enabled: bool,
     /// Swipe detector
     swipe: SwipeDetect,
     /// Swipe configuration
@@ -37,11 +38,13 @@ pub enum VerticalMenuScreenMsg {
 }
 
 impl VerticalMenuScreen {
+    const TOUCH_SENSITIVITY_DIVIDER: i16 = 15;
     pub fn new(menu: VerticalMenu) -> Self {
         Self {
             header: Header::new(TString::empty()),
             menu,
             offset_base: 0,
+            swipe_enabled: false,
             swipe: SwipeDetect::new(),
             swipe_config: SwipeConfig::new()
                 .with_swipe(Direction::Up, SwipeSettings::default())
@@ -54,32 +57,23 @@ impl VerticalMenuScreen {
         self
     }
 
-    // Shift position of touch events in the menu area by an offset of the current
-    // sliding window position
-    fn shift_touch_event(&self, event: Event) -> Option<Event> {
-        match event {
-            Event::Touch(touch_event) => {
-                let shifted_event = match touch_event {
-                    TouchEvent::TouchStart(point) if self.menu.area().contains(point) => Some(
-                        TouchEvent::TouchStart(point.ofs(Offset::y(self.menu.get_offset()))),
-                    ),
-                    TouchEvent::TouchMove(point) if self.menu.area().contains(point) => Some(
-                        TouchEvent::TouchMove(point.ofs(Offset::y(self.menu.get_offset()))),
-                    ),
-                    TouchEvent::TouchEnd(point) if self.menu.area().contains(point) => Some(
-                        TouchEvent::TouchEnd(point.ofs(Offset::y(self.menu.get_offset()))),
-                    ),
-                    _ => None, // Ignore touch events outside the bounds
-                };
-                shifted_event.map(Event::Touch)
-            }
-            _ => None, // Ignore other events
-        }
-    }
+    /// Update swipe detection and buttons state based on menu size
+    pub fn initialize_screen(&mut self, ctx: &mut EventCtx) {
+        if !self.menu.fits_area() {
+            // Enable swipe
+            self.swipe_enabled = true;
+            self.swipe_config = SwipeConfig::new()
+                .with_swipe(Direction::Up, SwipeSettings::default())
+                .with_swipe(Direction::Down, SwipeSettings::default());
+            ctx.enable_swipe();
 
-    /// Update menu buttons based on the current offset.
-    pub fn update_menu(&mut self, ctx: &mut EventCtx) {
-        self.menu.update_menu(ctx);
+            // Update the menu buttons state
+            self.menu.update_menu(ctx);
+        } else {
+            // Disable swipe
+            self.swipe_enabled = false;
+            ctx.disable_swipe();
+        }
     }
 }
 
@@ -93,49 +87,58 @@ impl Component for VerticalMenuScreen {
 
         let (header_area, menu_area) = bounds.split_top(Header::HEADER_HEIGHT);
 
-        self.menu.place(menu_area);
         self.header.place(header_area);
+        self.menu.place(menu_area);
 
         bounds
     }
 
     fn event(&mut self, ctx: &mut EventCtx, event: Event) -> Option<Self::Msg> {
-        // Update the menu when the screen is attached
-        if let Event::Attach(AttachType::Initial) = event {
-            self.update_menu(ctx);
+        // Update the screen after the menu fit is calculated
+        // This is needed to enable swipe detection only when the menu does not fit
+        if let Event::Attach(_) = event {
+            self.initialize_screen(ctx);
         }
 
-        match self.swipe.event(ctx, event, self.swipe_config) {
-            Some(SwipeEvent::Start(_)) => {
-                // Lock the base position to scroll around
-                self.offset_base = self.menu.get_offset();
-            }
+        // Handle swipe events if swipe is enabled (menu does not fit)
+        if self.swipe_enabled {
+            // Handle swipe events from the standalone swipe detector or ones coming from
+            // the flow. These two are mutually exclusive and should not be triggered at the
+            // same time.
+            let swipe_event = self
+                .swipe
+                .event(ctx, event, self.swipe_config)
+                .or(match event {
+                    Event::Swipe(e) => Some(e),
+                    _ => None,
+                });
 
-            Some(SwipeEvent::End(_)) => {
-                // Lock the base position to scroll around
-                self.offset_base = self.menu.get_offset();
-            }
-
-            Some(SwipeEvent::Move(dir, delta)) => {
-                // Decrease the sensitivity of the swipe
-                let delta = delta / 10;
-                // Scroll the menu based on the swipe direction
-                match dir {
-                    Direction::Up => {
-                        self.menu.set_offset(self.offset_base + delta);
-                        self.menu.update_menu(ctx);
-                        return None;
-                    }
-                    Direction::Down => {
-                        self.menu.set_offset(self.offset_base - delta);
-                        self.menu.update_menu(ctx);
-                        return None;
-                    }
-                    _ => {}
+            match swipe_event {
+                Some(SwipeEvent::Start(_) | SwipeEvent::End(_)) => {
+                    // Lock the base position to scroll around
+                    self.offset_base = self.menu.get_offset();
                 }
+                Some(SwipeEvent::Move(dir, delta)) => {
+                    // Decrease the sensitivity of the swipe
+                    let delta = delta / Self::TOUCH_SENSITIVITY_DIVIDER;
+                    // Scroll the menu based on the swipe direction
+                    match dir {
+                        Direction::Up => {
+                            self.menu.set_offset(self.offset_base + delta);
+                            self.menu.update_menu(ctx);
+                            return None;
+                        }
+                        Direction::Down => {
+                            self.menu.set_offset(self.offset_base - delta);
+                            self.menu.update_menu(ctx);
+                            return None;
+                        }
+                        _ => {}
+                    }
+                }
+                _ => {}
             }
-            _ => {}
-        };
+        }
 
         if let Some(msg) = self.header.event(ctx, event) {
             match msg {
@@ -145,11 +148,8 @@ impl Component for VerticalMenuScreen {
             }
         }
 
-        // Shift touch events in the menu area by the current sliding window position
-        if let Some(shifted) = self.shift_touch_event(event) {
-            if let Some(VerticalMenuMsg::Selected(i)) = self.menu.event(ctx, shifted) {
-                return Some(VerticalMenuScreenMsg::Selected(i));
-            }
+        if let Some(VerticalMenuMsg::Selected(i)) = self.menu.event(ctx, event) {
+            return Some(VerticalMenuScreenMsg::Selected(i));
         }
 
         None
@@ -159,15 +159,12 @@ impl Component for VerticalMenuScreen {
         self.header.render(target);
         self.menu.render(target);
 
-        // Render the down arrow if the menu  can be scrolled down
-        if !self.menu.is_max_offset() {
-            ToifImage::new(
-                self.menu.area().bottom_center(),
-                theme::ICON_CHEVRON_DOWN_MINI.toif,
-            )
-            .with_align(Alignment2D::BOTTOM_CENTER)
-            .with_fg(theme::GREY_LIGHT)
-            .render(target);
+        // Render the down arrow if the menu overflows and can be scrolled further down
+        if !self.menu.fits_area() && !self.menu.is_max_offset() {
+            ToifImage::new(SCREEN.bottom_center(), theme::ICON_CHEVRON_DOWN_MINI.toif)
+                .with_align(Alignment2D::BOTTOM_CENTER)
+                .with_fg(theme::GREY_LIGHT)
+                .render(target);
         }
     }
 }

--- a/core/embed/rust/src/ui/layout_eckhart/firmware/vertical_menu_screen.rs
+++ b/core/embed/rust/src/ui/layout_eckhart/firmware/vertical_menu_screen.rs
@@ -9,7 +9,7 @@ use crate::{
         flow::Swipable,
         geometry::{Alignment2D, Direction, Rect},
         shape::{Renderer, ToifImage},
-        util::Pager,
+        util::{animation_disabled, Pager},
     },
 };
 
@@ -21,10 +21,8 @@ pub struct VerticalMenuScreen {
     menu: VerticalMenu,
     /// Base position of the menu sliding window to scroll around
     offset_base: i16,
-    /// Used to enable swipe detection only when the menu does not fit its area
-    swipe_enabled: bool,
     /// Swipe detector
-    swipe: SwipeDetect,
+    swipe: Option<SwipeDetect>,
     /// Swipe configuration
     swipe_config: SwipeConfig,
 }
@@ -44,8 +42,7 @@ impl VerticalMenuScreen {
             header: Header::new(TString::empty()),
             menu,
             offset_base: 0,
-            swipe_enabled: false,
-            swipe: SwipeDetect::new(),
+            swipe: None,
             swipe_config: SwipeConfig::new()
                 .with_swipe(Direction::Up, SwipeSettings::default())
                 .with_swipe(Direction::Down, SwipeSettings::default()),
@@ -59,20 +56,108 @@ impl VerticalMenuScreen {
 
     /// Update swipe detection and buttons state based on menu size
     pub fn initialize_screen(&mut self, ctx: &mut EventCtx) {
-        if !self.menu.fits_area() {
-            // Enable swipe
-            self.swipe_enabled = true;
-            self.swipe_config = SwipeConfig::new()
-                .with_swipe(Direction::Up, SwipeSettings::default())
-                .with_swipe(Direction::Down, SwipeSettings::default());
+        #[cfg(feature = "ui_debug")]
+        if animation_disabled() {
+            self.swipe = Some(SwipeDetect::new());
             ctx.enable_swipe();
-
+            // Set default position for the sliding window
+            self.menu.set_offset(0);
             // Update the menu buttons state
-            self.menu.update_menu(ctx);
+            self.menu.update_button_states(ctx);
+            return;
+        }
+
+        // Switch swiping on/off based on the menu fit
+        self.swipe = if !self.menu.fits_area() {
+            ctx.enable_swipe();
+            Some(SwipeDetect::new())
         } else {
-            // Disable swipe
-            self.swipe_enabled = false;
             ctx.disable_swipe();
+            None
+        };
+
+        // Set default position for the sliding window
+        self.menu.set_offset(0);
+        // Update button states
+        self.menu.update_button_states(ctx);
+    }
+
+    fn handle_swipe_event(&mut self, ctx: &mut EventCtx, event: Event) {
+        // Relevant only for testing when the animations are disabled
+        // The menu is scrollable until the last button is visible
+        #[cfg(feature = "ui_debug")]
+        if animation_disabled() {
+            // Handle swipes from the standalone swipe detector or ones coming from
+            // the flow. These two are mutually exclusive and should not be triggered at the
+            // same time.
+            let direction = self
+                .swipe
+                .as_mut()
+                .and_then(|swipe| swipe.event(ctx, event, self.swipe_config))
+                .and_then(|e| match e {
+                    SwipeEvent::End(dir @ (Direction::Up | Direction::Down)) => Some(dir),
+                    _ => None,
+                })
+                .or(match event {
+                    Event::Swipe(SwipeEvent::End(dir @ (Direction::Up | Direction::Down))) => {
+                        Some(dir)
+                    }
+                    _ => None,
+                });
+
+            if let Some(dir) = direction {
+                self.menu.scroll_item(dir);
+                self.menu.update_button_states(ctx);
+                ctx.request_paint();
+            }
+            return;
+        }
+
+        if let Some(swipe) = &mut self.swipe {
+            // Handle swipe events from the standalone swipe detector or ones coming from
+            // the flow. These two are mutually exclusive and should not be triggered at the
+            // same time.
+            let swipe_event = swipe.event(ctx, event, self.swipe_config).or(match event {
+                Event::Swipe(e) => Some(e),
+                _ => None,
+            });
+
+            match swipe_event {
+                Some(SwipeEvent::Start(_) | SwipeEvent::End(_)) => {
+                    // Lock the base position to scroll around
+                    self.offset_base = self.menu.get_offset();
+                }
+                Some(SwipeEvent::Move(dir @ (Direction::Up | Direction::Down), delta)) => {
+                    // Reduce swipe sensitivity
+                    let delta = delta / Self::TOUCH_SENSITIVITY_DIVIDER;
+
+                    let offset = match dir {
+                        Direction::Up => self.offset_base + delta,
+                        Direction::Down => self.offset_base - delta,
+                        _ => unreachable!(), // Already matched Up or Down
+                    };
+
+                    self.menu.set_offset(offset);
+                    self.menu.update_button_states(ctx);
+                }
+                _ => {}
+            }
+        }
+    }
+
+    fn render_overflow_arrow<'s>(&'s self, target: &mut impl Renderer<'s>) {
+        // Do not render the arrow if animations are disabled
+        #[cfg(feature = "ui_debug")]
+        if animation_disabled() {
+            return;
+        }
+
+        // Render the down arrow if the menu overflows and can be scrolled further down
+        if self.swipe.is_some() && !self.menu.is_max_offset() {
+            ToifImage::new(SCREEN.bottom_center(), theme::ICON_CHEVRON_DOWN_MINI.toif)
+                .with_align(Alignment2D::BOTTOM_CENTER)
+                .with_fg(theme::GREY_LIGHT)
+                .render(target);
         }
     }
 }
@@ -100,46 +185,6 @@ impl Component for VerticalMenuScreen {
             self.initialize_screen(ctx);
         }
 
-        // Handle swipe events if swipe is enabled (menu does not fit)
-        if self.swipe_enabled {
-            // Handle swipe events from the standalone swipe detector or ones coming from
-            // the flow. These two are mutually exclusive and should not be triggered at the
-            // same time.
-            let swipe_event = self
-                .swipe
-                .event(ctx, event, self.swipe_config)
-                .or(match event {
-                    Event::Swipe(e) => Some(e),
-                    _ => None,
-                });
-
-            match swipe_event {
-                Some(SwipeEvent::Start(_) | SwipeEvent::End(_)) => {
-                    // Lock the base position to scroll around
-                    self.offset_base = self.menu.get_offset();
-                }
-                Some(SwipeEvent::Move(dir, delta)) => {
-                    // Decrease the sensitivity of the swipe
-                    let delta = delta / Self::TOUCH_SENSITIVITY_DIVIDER;
-                    // Scroll the menu based on the swipe direction
-                    match dir {
-                        Direction::Up => {
-                            self.menu.set_offset(self.offset_base + delta);
-                            self.menu.update_menu(ctx);
-                            return None;
-                        }
-                        Direction::Down => {
-                            self.menu.set_offset(self.offset_base - delta);
-                            self.menu.update_menu(ctx);
-                            return None;
-                        }
-                        _ => {}
-                    }
-                }
-                _ => {}
-            }
-        }
-
         if let Some(msg) = self.header.event(ctx, event) {
             match msg {
                 HeaderMsg::Cancelled => return Some(VerticalMenuScreenMsg::Close),
@@ -152,20 +197,14 @@ impl Component for VerticalMenuScreen {
             return Some(VerticalMenuScreenMsg::Selected(i));
         }
 
+        self.handle_swipe_event(ctx, event);
         None
     }
 
     fn render<'s>(&'s self, target: &mut impl Renderer<'s>) {
         self.header.render(target);
         self.menu.render(target);
-
-        // Render the down arrow if the menu overflows and can be scrolled further down
-        if !self.menu.fits_area() && !self.menu.is_max_offset() {
-            ToifImage::new(SCREEN.bottom_center(), theme::ICON_CHEVRON_DOWN_MINI.toif)
-                .with_align(Alignment2D::BOTTOM_CENTER)
-                .with_fg(theme::GREY_LIGHT)
-                .render(target);
-        }
+        self.render_overflow_arrow(target);
     }
 }
 


### PR DESCRIPTION
This PR:
- Improves event processing for the `VerticalMenu` component
- Switches swiping on/off based on the `VerticalMenu` fitting/not fitting its bounds
- Implements function `update_screen` for `VerticalMenuScreen`. It has to be called in the `DeviceMenuScreen` whenever the screen is switched.
- Adds swiping functionality for testing purposes when animations are disabled:
  - The menu is swipable until the the last item is visible on top of the menu area (even if an entire menu fits the screen).
  - This way the device tests can select `n-th` item by swiping up `n-1` times and then clicking on the 1st item area no matter what the menu item height is. The behavior can be tested by spawning the emulator with disabled animations:`./emu.py -a`
