### PR TITLE
perf(core): remove more local imports from Bitcoin signing flow

### DIFF
--- a/core/src/apps/bitcoin/common.py
+++ b/core/src/apps/bitcoin/common.py
@@ -6,6 +6,7 @@ from trezor.crypto import bech32
 from trezor.crypto.curve import bip340
 from trezor.enums import InputScriptType, OutputScriptType
 from trezor.messages import MultisigRedeemScriptType
+from trezor.utils import ensure
 
 if TYPE_CHECKING:
     from enum import IntEnum
@@ -120,8 +121,6 @@ def bip340_sign(node: bip32.HDNode, digest: bytes) -> bytes:
 
 
 def ecdsa_hash_pubkey(pubkey: bytes, coin: CoinInfo) -> bytes:
-    from trezor.utils import ensure
-
     ensure(
         coin.curve_name.startswith("secp256k1")
     )  # The following code makes sense only for Weiersrass curves

--- a/core/src/apps/bitcoin/keychain.py
+++ b/core/src/apps/bitcoin/keychain.py
@@ -99,8 +99,6 @@ def validate_path_against_script_type(
     script_type: InputScriptType | None = None,
     multisig: bool = False,
 ) -> bool:
-    from trezor.enums import InputScriptType
-
     patterns = []
     append = patterns.append  # local_cache_attribute
     slip44 = coin.slip44  # local_cache_attribute

--- a/core/src/apps/bitcoin/scripts.py
+++ b/core/src/apps/bitcoin/scripts.py
@@ -1,10 +1,12 @@
 from typing import TYPE_CHECKING
 
 from trezor import utils
+from trezor.crypto import base58, cashaddr
 from trezor.enums import InputScriptType
 from trezor.utils import BufferReader, empty_bytearray
 from trezor.wire import DataError
 
+from apps.common import address_type
 from apps.common.readers import read_compact_size
 from apps.common.writers import write_compact_size
 
@@ -78,10 +80,6 @@ def write_input_script_prefixed(
 
 
 def output_derive_script(address: str, coin: CoinInfo) -> bytes:
-    from trezor.crypto import base58, cashaddr
-
-    from apps.common import address_type
-
     if coin.bech32_prefix and address.startswith(coin.bech32_prefix):
         # p2wpkh or p2wsh or p2tr
         witver, witprog = common.decode_bech32_address(coin.bech32_prefix, address)

--- a/core/src/apps/bitcoin/sign_tx/approvers.py
+++ b/core/src/apps/bitcoin/sign_tx/approvers.py
@@ -1,6 +1,7 @@
 from micropython import const
 from typing import TYPE_CHECKING
 
+from trezor.enums import OutputScriptType
 from trezor.wire import DataError, ProcessError
 
 from apps.common import safety_checks
@@ -190,8 +191,6 @@ class BasicApprover(Approver):
         tx_info: TxInfo | None,
         orig_txo: TxOutput | None = None,
     ) -> None:
-        from trezor.enums import OutputScriptType
-
         await super().add_external_output(txo, script_pubkey, tx_info, orig_txo)
 
         if orig_txo:

--- a/core/src/apps/bitcoin/sign_tx/bitcoin.py
+++ b/core/src/apps/bitcoin/sign_tx/bitcoin.py
@@ -3,8 +3,8 @@ from typing import TYPE_CHECKING
 
 from trezor import workflow
 from trezor.crypto.hashlib import sha256
-from trezor.enums import InputScriptType
-from trezor.utils import HashWriter, empty_bytearray
+from trezor.enums import InputScriptType, OutputScriptType
+from trezor.utils import HashWriter, empty_bytearray, ensure
 from trezor.wire import DataError, ProcessError
 
 from apps.common.writers import write_compact_size
@@ -919,8 +919,6 @@ class Bitcoin:
         self.write_tx_footer(w, tx)
 
     def set_serialized_signature(self, index: int, signature: bytes) -> None:
-        from trezor.utils import ensure
-
         serialized = self.tx_req.serialized  # local_cache_attribute
 
         # Only one signature per TxRequest can be serialized.
@@ -947,8 +945,6 @@ class Bitcoin:
         return scripts.output_derive_script(address, self.coin)
 
     def output_derive_script(self, txo: TxOutput) -> bytes:
-        from trezor.enums import OutputScriptType
-
         if txo.script_type == OutputScriptType.PAYTOOPRETURN:
             assert txo.op_return_data is not None  # checked in _sanitize_tx_output
             return scripts.output_script_paytoopreturn(txo.op_return_data)

--- a/core/src/apps/bitcoin/sign_tx/helpers.py
+++ b/core/src/apps/bitcoin/sign_tx/helpers.py
@@ -1,7 +1,16 @@
 from typing import TYPE_CHECKING
 
 from trezor import utils
-from trezor.enums import RequestType
+from trezor.enums import InputScriptType, OutputScriptType, RequestType
+from trezor.messages import (
+    TxAckInput,
+    TxAckOutput,
+    TxAckPaymentRequest,
+    TxAckPrevExtraData,
+    TxAckPrevInput,
+    TxAckPrevMeta,
+    TxAckPrevOutput,
+)
 from trezor.wire import DataError
 
 from .. import common
@@ -17,7 +26,6 @@ if TYPE_CHECKING:
         PrevOutput,
         PrevTx,
         SignTx,
-        TxAckPaymentRequest,
         TxInput,
         TxOutput,
         TxRequest,
@@ -311,8 +319,6 @@ def confirm_multiple_accounts() -> Awaitable[Any]:  # type: ignore [awaitable-re
 
 
 def request_tx_meta(tx_req: TxRequest, coin: CoinInfo, tx_hash: bytes | None = None) -> Awaitable[PrevTx]:  # type: ignore [awaitable-return-type]
-    from trezor.messages import TxAckPrevMeta
-
     assert tx_req.details is not None
     tx_req.request_type = RequestType.TXMETA
     tx_req.details.tx_hash = tx_hash
@@ -324,8 +330,6 @@ def request_tx_meta(tx_req: TxRequest, coin: CoinInfo, tx_hash: bytes | None = N
 def request_tx_extra_data(
     tx_req: TxRequest, offset: int, size: int, tx_hash: bytes | None = None
 ) -> Awaitable[bytearray]:  # type: ignore [awaitable-return-type]
-    from trezor.messages import TxAckPrevExtraData
-
     details = tx_req.details  # local_cache_attribute
 
     assert details is not None
@@ -339,8 +343,6 @@ def request_tx_extra_data(
 
 
 def request_tx_input(tx_req: TxRequest, i: int, coin: CoinInfo, tx_hash: bytes | None = None) -> Awaitable[TxInput]:  # type: ignore [awaitable-return-type]
-    from trezor.messages import TxAckInput
-
     assert tx_req.details is not None
     if tx_hash:
         tx_req.request_type = RequestType.TXORIGINPUT
@@ -354,8 +356,6 @@ def request_tx_input(tx_req: TxRequest, i: int, coin: CoinInfo, tx_hash: bytes |
 
 
 def request_tx_prev_input(tx_req: TxRequest, i: int, coin: CoinInfo, tx_hash: bytes | None = None) -> Awaitable[PrevInput]:  # type: ignore [awaitable-return-type]
-    from trezor.messages import TxAckPrevInput
-
     assert tx_req.details is not None
     tx_req.request_type = RequestType.TXINPUT
     tx_req.details.request_index = i
@@ -366,8 +366,6 @@ def request_tx_prev_input(tx_req: TxRequest, i: int, coin: CoinInfo, tx_hash: by
 
 
 def request_tx_output(tx_req: TxRequest, i: int, coin: CoinInfo, tx_hash: bytes | None = None) -> Awaitable[TxOutput]:  # type: ignore [awaitable-return-type]
-    from trezor.messages import TxAckOutput
-
     assert tx_req.details is not None
     if tx_hash:
         tx_req.request_type = RequestType.TXORIGOUTPUT
@@ -381,8 +379,6 @@ def request_tx_output(tx_req: TxRequest, i: int, coin: CoinInfo, tx_hash: bytes 
 
 
 def request_tx_prev_output(tx_req: TxRequest, i: int, coin: CoinInfo, tx_hash: bytes | None = None) -> Awaitable[PrevOutput]:  # type: ignore [awaitable-return-type]
-    from trezor.messages import TxAckPrevOutput
-
     assert tx_req.details is not None
     tx_req.request_type = RequestType.TXOUTPUT
     tx_req.details.request_index = i
@@ -394,8 +390,6 @@ def request_tx_prev_output(tx_req: TxRequest, i: int, coin: CoinInfo, tx_hash: b
 
 
 def request_payment_req(tx_req: TxRequest, i: int) -> Awaitable[TxAckPaymentRequest]:  # type: ignore [awaitable-return-type]
-    from trezor.messages import TxAckPaymentRequest
-
     assert tx_req.details is not None
     tx_req.request_type = RequestType.TXPAYMENTREQ
     tx_req.details.request_index = i
@@ -481,9 +475,6 @@ def _sanitize_tx_meta(tx: PrevTx, coin: CoinInfo) -> PrevTx:
 
 
 def _sanitize_tx_input(txi: TxInput, coin: CoinInfo) -> TxInput:
-    from trezor.enums import InputScriptType
-    from trezor.wire import DataError  # local_cache_global
-
     script_type = txi.script_type  # local_cache_attribute
 
     if len(txi.prev_hash) != TX_HASH_SIZE:
@@ -538,9 +529,6 @@ def _sanitize_tx_prev_input(txi: PrevInput, coin: CoinInfo) -> PrevInput:
 
 
 def _sanitize_tx_output(txo: TxOutput, coin: CoinInfo) -> TxOutput:
-    from trezor.enums import OutputScriptType
-    from trezor.wire import DataError  # local_cache_global
-
     script_type = txo.script_type  # local_cache_attribute
     address_n = txo.address_n  # local_cache_attribute
 

--- a/core/src/apps/bitcoin/sign_tx/matchcheck.py
+++ b/core/src/apps/bitcoin/sign_tx/matchcheck.py
@@ -2,6 +2,7 @@ from typing import TYPE_CHECKING
 
 from trezor.enums import InputScriptType
 from trezor.messages import TxOutput
+from trezor.utils import ensure
 
 from ..common import BIP32_WALLET_DEPTH, CHANGE_OUTPUT_TO_INPUT_SCRIPT_TYPES
 
@@ -54,8 +55,6 @@ class MatchChecker(Generic[T]):
         raise NotImplementedError
 
     def add_input(self, txi: TxInput) -> None:
-        from trezor.utils import ensure
-
         ensure(not self.read_only)
 
         if self.attribute is self.MISMATCH:


### PR DESCRIPTION
Tested with the following MicroPython patch:
```diff
diff --git a/py/builtinimport.c b/py/builtinimport.c
index cd9636ccd..8cf93376e 100644
--- a/py/builtinimport.c
+++ b/py/builtinimport.c
@@ -468,14 +468,12 @@ STATIC mp_obj_t process_import_at_level(qstr full_mod_name, qstr level_mod_name,
 }
 
 mp_obj_t mp_builtin___import__(size_t n_args, const mp_obj_t *args) {
-    #if DEBUG_PRINT
-    DEBUG_printf("__import__:\n");
+    mp_printf(MICROPY_DEBUG_PRINTER, "__import__");
     for (size_t i = 0; i < n_args; i++) {
-        DEBUG_printf("  ");
+        mp_printf(MICROPY_DEBUG_PRINTER, i == 0 ? "(" : ", ");
         mp_obj_print_helper(MICROPY_DEBUG_PRINTER, args[i], PRINT_REPR);
-        DEBUG_printf("\n");
     }
-    #endif
+    mp_printf(MICROPY_DEBUG_PRINTER, ")\n");
 
     // This is the import path, with any leading dots stripped.
     // "import foo.bar" --> module_name="foo.bar"
```

```python
In [1]: import collections, heapq

### after the fix
In [2]: c = collections.Counter(l for l in open('/tmp/trezor1.log') if l.startswith('__import'))

In [3]: for k, v in heapq.nlargest(20, c.items(), lambda kv: kv[1]): print(v, k.strip())
2268 __import__('hashlib', None, None, ('sha256',), 1)
1102 __import__('apps.debug', None, None, ('notify_layout_change',), 0)
827 __import__('apps.debug', None, None, ('screenshot',), 0)
670 __import__('storage.cache', None, None, None, 0)
577 __import__('trezor', None, None, ('ui', 'workflow'), 0)
539 __import__('micropython', None, None, ('const',), 0)
536 __import__('trezor.messages', None, None, ('DebugLinkState',), 0)
524 __import__('trezor.enums', None, None, ('DebugButton',), 0)
481 __import__('', None, None, ('multisig',), 2)
460 __import__('trezor', None, None, ('wire',), 0)
332 __import__('trezor', None, None, ('utils',), 0)
321 __import__('trezor.crypto.hashlib', None, None, ('sha256',), 0)
302 __import__('storage.device', None, None, None, 0)
264 __import__('trezor', None, None, ('TR', 'workflow'), 0)
264 __import__('trezor.ui.layouts.progress', None, None, ('bitcoin_progress', 'coinjoin_progress'), 0)
263 __import__('trezor.enums', None, None, ('AmountUnit',), 0)
260 __import__('trezor.enums', None, None, ('OutputScriptType',), 0)
259 __import__('trezor.wire', None, None, ('context',), 0)
257 __import__('', None, None, ('omni',), 1)
249 __import__('utime', None, None, None, 0)

### before the fix
In [4]: c = collections.Counter(l for l in open('/tmp/trezor0.log') if l.startswith('__import'))

In [5]: for k, v in heapq.nlargest(20, c.items(), lambda kv: kv[1]): print(v, k.strip())
11197 __import__('trezor.wire', None, None, ('DataError',), 0)
10346 __import__('trezor.enums', None, None, ('InputScriptType',), 0)
10206 __import__('trezor.messages', None, None, ('TxAckInput',), 0)
10003 __import__('trezor.messages', None, None, ('TxAckPrevOutput',), 0)
2374 __import__('trezor.enums', None, None, ('OutputScriptType',), 0)
2268 __import__('hashlib', None, None, ('sha256',), 1)
1137 __import__('apps.common', None, None, ('address_type',), 0)
1134 __import__('trezor.crypto', None, None, ('base58', 'cashaddr'), 0)
1102 __import__('apps.debug', None, None, ('notify_layout_change',), 0)
930 __import__('trezor.messages', None, None, ('TxAckOutput',), 0)
827 __import__('apps.debug', None, None, ('screenshot',), 0)
670 __import__('storage.cache', None, None, None, 0)
577 __import__('trezor', None, None, ('ui', 'workflow'), 0)
539 __import__('micropython', None, None, ('const',), 0)
536 __import__('trezor.messages', None, None, ('DebugLinkState',), 0)
524 __import__('trezor.enums', None, None, ('DebugButton',), 0)
516 __import__('trezor.utils', None, None, ('ensure',), 0)
481 __import__('', None, None, ('multisig',), 2)
460 __import__('trezor', None, None, ('wire',), 0)
332 __import__('trezor', None, None, ('utils',), 0)
```
Flash usage is the same (compared f5f230cf7 and 6da49a0ac with `TREZOR_MODEL=T2T1 BITCOIN_ONLY=0 PYOPT=1`):
```
Memory region         Used Size  Region Size  %age Used
           FLASH:      655388 B       768 KB     83.34%
          FLASH2:      803328 B       896 KB     87.56%
```
https://github.com/trezor/trezor-firmware/actions/runs/14443114817/job/40497545435?pr=4914#step:8:1235
<!--
For core developers:
- Assign yourself to the PR.
- Set the priority to match the original issue.
- Add the PR to the current sprint.
- If it's a draft PR, mark it as "In Progress."
- If it's a final PR, mark it as "Needs Review."

For external contributors:
- Please open an issue before submitting a PR so we can discuss whether we want to proceed with it.
-->

