### PR TITLE
Support workflow handlers that may or may not have context

### DIFF
--- a/core/src/apps/management/ble/unpair.py
+++ b/core/src/apps/management/ble/unpair.py
@@ -10,16 +10,15 @@ if TYPE_CHECKING:
 async def unpair(msg: BleUnpair) -> None:
     from trezor.messages import Success
     from trezor.ui.layouts import confirm_action
-    from trezor.wire.context import get_context
+    from trezor.wire.context import maybe_get_context
 
     if msg.all:
         await confirm_action("erase bonds", TR.ble__unpair_title, TR.ble__unpair_all)
     else:
         await confirm_action("unpair", TR.ble__unpair_title, TR.ble__unpair_current)
 
-    ctx = get_context()
-
-    await ctx.write(Success(message="Erasing.."))
+    if ctx := maybe_get_context():
+        await ctx.write(Success(message="Erasing..."))
 
     if msg.all:
         ble.erase_bonds()

--- a/core/src/trezor/wire/context.py
+++ b/core/src/trezor/wire/context.py
@@ -107,6 +107,13 @@ def get_context() -> Context:
     return CURRENT_CONTEXT
 
 
+def maybe_get_context() -> Context | None:
+    """Variant of the function above, same limitations apply. Needed in special cases
+    where a handler might be invoked over wire or from a homescreen menu (e.g. wipe).
+    """
+    return CURRENT_CONTEXT
+
+
 def with_context(ctx: Context, workflow: loop.Task) -> Generator:
     """Run a workflow in a particular context.
 


### PR DESCRIPTION
There will be couple of cases where a workflow can be launched either over wire or by user interaction from homescreen. Not sure whether `CURRENT_CONTEXT` should be None like in this PR, or rather some dummy context object, or we should do something different altogether.

<!--
For core developers:
- Assign yourself to the PR.
- Set the priority to match the original issue.
- Add the PR to the current sprint.
- If it's a draft PR, mark it as "In Progress."
- If it's a final PR, mark it as "Needs Review."

For external contributors:
- Please open an issue before submitting a PR so we can discuss whether we want to proceed with it.
-->
