### PR TITLE
Add max backlight limit to backlight driver

### DIFF
--- a/core/embed/io/backlight/inc/io/backlight.h
+++ b/core/embed/io/backlight/inc/io/backlight.h
@@ -19,6 +19,9 @@
 
 #pragma once
 
+#define BACKLIGHT_MAX_LEVEL 255
+#define BACKLIGHT_MIN_LEVEL 0
+
 // Action to be taken when initializing or
 // deinitializing the backlight driver
 typedef enum {
@@ -41,7 +44,8 @@ void backlight_init(backlight_action_t action);
 // is kept on.
 void backlight_deinit(backlight_action_t action);
 
-// Sets the backlight level in range 0-255 and returns the actual level set.
+// Request the backlight level in range 0-255 and returns the actual level set.
+// The requested level may be limited if its above the max_level limit.
 //
 // If the level is outside the range, the function has no effect
 // and just returns the actual level set. If the backlight driver
@@ -52,3 +56,8 @@ int backlight_set(int val);
 //
 // Returns 0 if the backlight driver is not initialized.
 int backlight_get(void);
+
+// Set maximal backlight limit, limits the requested level to max_level value.
+//
+// Returns 0 if the backlight driver is not initialized.
+int backlight_set_max_level(int max_level);


### PR DESCRIPTION
Introduce max backlight limit in the T3W1 backlight driver. 

If user will request the backlight which is above the maximal set level, backlight will be automatically adjusted to maximal limit. if the user will increase the max backlight limit later, the backlight will be updated to originally requested level.

This feature is needed in power manager to decrease the backlight regardless to app in power save mode. 

This feature is intentionally not added in prodtest, since the API should be strictly used by kernel -> hence, should not be part of the general display driver.

