### PR TITLE
fix(core): fix USB VCP freeze on T3W1 in prodtest

### DIFF
--- a/core/embed/io/usb/inc/io/usb_vcp.h
+++ b/core/embed/io/usb/inc/io/usb_vcp.h
@@ -50,8 +50,8 @@ typedef struct {
   uint8_t ep_out;  // Address of OUT endpoint
 #endif
   uint8_t polling_interval;  // In units of 1ms
-  uint8_t max_packet_len;  // Length of the biggest packet, and of tx_packet and
-                           // rx_packet
+  uint16_t max_packet_len;   // Length of the biggest packet, and of tx_packet
+                             // and rx_packet
 } usb_vcp_info_t;
 
 secbool __wur usb_vcp_add(const usb_vcp_info_t *vcp_info);

--- a/core/embed/io/usb/stm32/usb_class_vcp.c
+++ b/core/embed/io/usb/stm32/usb_class_vcp.c
@@ -152,7 +152,7 @@ typedef struct {
   uint8_t ep_cmd;
   uint8_t ep_in;
   uint8_t ep_out;
-  uint8_t max_packet_len;
+  uint16_t max_packet_len;
   uint8_t ep_in_is_idle;  // Set to 1 after IN endpoint gets idle
   uint8_t cmd_buffer[USB_CDC_MAX_CMD_PACKET_LEN];
 } usb_vcp_state_t;

--- a/core/embed/projects/prodtest/main.c
+++ b/core/embed/projects/prodtest/main.c
@@ -17,6 +17,7 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
+#include <trezor_bsp.h>
 #include <trezor_model.h>
 #include <trezor_rtl.h>
 
@@ -116,12 +117,17 @@ static size_t console_write(void *context, const char *buf, size_t size) {
 
 static void vcp_intr(void) { cli_abort(&g_cli); }
 
-static void usb_init_all(void) {
-  enum {
-    VCP_PACKET_LEN = 64,
-    VCP_BUFFER_LEN = 1024,
-  };
+#if defined(USE_USB_HS)
+#define VCP_PACKET_LEN 512
+#elif defined(USE_USB_FS)
+#define VCP_PACKET_LEN 64
+#else
+#error "USB type not defined"
+#endif
 
+#define VCP_BUFFER_LEN 1024
+
+static void usb_init_all(void) {
   static const usb_dev_info_t dev_info = {
       .device_class = 0xEF,     // Composite Device Class
       .device_subclass = 0x02,  // Common Class


### PR DESCRIPTION
This PR fixes a freeze in the USB driver on T3W1 when receiving packets longer than 64 bytes.

On T3W1, we use USB High Speed, whereas other products use USB Full Speed. USB HS allows packets up to 512 bytes, which we weren’t prepared for. This PR provides a hotfix for the issue in prodtest, but we need to investigate further to determine if this difference should be accounted for elsewhere.