### PR TITLE
fix(prodtest): increase vcp ring buffer size

### DIFF
--- a/core/embed/projects/prodtest/main.c
+++ b/core/embed/projects/prodtest/main.c
@@ -125,7 +125,7 @@ static void vcp_intr(void) { cli_abort(&g_cli); }
 #error "USB type not defined"
 #endif
 
-#define VCP_BUFFER_LEN 1024
+#define VCP_BUFFER_LEN 2048
 
 static void usb_init_all(void) {
   static const usb_dev_info_t dev_info = {


### PR DESCRIPTION
This PR fixes an issue with a small RX ring buffer for USB VCP.

Issue: In non-interactive CLI mode, when a large amount of data is received (e.g., a certificate larger than 1024 bytes), the data may be discarded if the RX ring buffer overflows. This issue was observed on the T3W1, where USB HS is used.

The fix increases both TX and RX buffer sizes.
