### PR TITLE
perf(core): optimize `AddressDetails::xpubs` layout

### DIFF
--- a/core/embed/rust/src/ui/layout_bolt/component/address_details.rs
+++ b/core/embed/rust/src/ui/layout_bolt/component/address_details.rs
@@ -2,6 +2,7 @@ use heapless::Vec;
 
 use crate::{
     error::Error,
+    micropython::buffer::StrBuffer,
     strutil::TString,
     translations::TR,
     ui::{
@@ -22,7 +23,7 @@ pub struct AddressDetails {
     qr_code: Frame<Qr>,
     details: Frame<Paragraphs<ParagraphVecShort<'static>>>,
     xpub_view: Frame<Paragraphs<Paragraph<'static>>>,
-    xpubs: Vec<(TString<'static>, TString<'static>), MAX_XPUBS>,
+    xpubs: Vec<(StrBuffer, StrBuffer), MAX_XPUBS>,
     xpub_page_count: Vec<u8, MAX_XPUBS>,
     current_page: usize,
 }
@@ -82,11 +83,7 @@ impl AddressDetails {
         Ok(result)
     }
 
-    pub fn add_xpub(
-        &mut self,
-        title: TString<'static>,
-        xpub: TString<'static>,
-    ) -> Result<(), Error> {
+    pub fn add_xpub(&mut self, title: StrBuffer, xpub: StrBuffer) -> Result<(), Error> {
         self.xpubs
             .push((title, xpub))
             .map_err(|_| Error::OutOfRange)
@@ -97,7 +94,8 @@ impl AddressDetails {
         // case the parent component that handles paging always requests complete
         // repaint after page change so we can use a dummy context here.
         let mut dummy_ctx = EventCtx::new();
-        self.xpub_view.update_title(&mut dummy_ctx, self.xpubs[i].0);
+        self.xpub_view
+            .update_title(&mut dummy_ctx, self.xpubs[i].0.into());
         self.xpub_view.update_content(&mut dummy_ctx, |p| {
             p.update(self.xpubs[i].1);
             p.change_page(page);

--- a/core/embed/rust/src/ui/layout_bolt/component/mod.rs
+++ b/core/embed/rust/src/ui/layout_bolt/component/mod.rs
@@ -1,4 +1,4 @@
-#[cfg(feature = "translations")]
+#[cfg(all(feature = "micropython", feature = "translations"))]
 mod address_details;
 pub mod bl_confirm;
 mod button;
@@ -29,7 +29,7 @@ mod simple_page;
 mod swipe;
 mod welcome_screen;
 
-#[cfg(feature = "translations")]
+#[cfg(all(feature = "micropython", feature = "translations"))]
 pub use address_details::AddressDetails;
 pub use button::{
     Button, ButtonContent, ButtonMsg, ButtonStyle, ButtonStyleSheet, CancelConfirmMsg,

--- a/core/embed/rust/src/ui/layout_bolt/ui_firmware.rs
+++ b/core/embed/rust/src/ui/layout_bolt/ui_firmware.rs
@@ -3,7 +3,7 @@ use core::cmp::Ordering;
 use crate::{
     error::{value_error, Error},
     io::BinaryData,
-    micropython::{gc::Gc, iter::IterBuf, list::List, obj::Obj, util},
+    micropython::{buffer::StrBuffer, gc::Gc, iter::IterBuf, list::List, obj::Obj, util},
     strutil::TString,
     translations::TR,
     ui::{
@@ -754,7 +754,7 @@ impl FirmwareUI for UIBolt {
         )?;
 
         for i in IterBuf::new().try_iterate(xpubs)? {
-            let [xtitle, text]: [TString; 2] = util::iter_into_array(i)?;
+            let [xtitle, text]: [StrBuffer; 2] = util::iter_into_array(i)?;
             ad.add_xpub(xtitle, text)?;
         }
 

--- a/core/embed/rust/src/ui/layout_caesar/component/address_details.rs
+++ b/core/embed/rust/src/ui/layout_caesar/component/address_details.rs
@@ -2,6 +2,7 @@ use heapless::Vec;
 
 use crate::{
     error::Error,
+    micropython::buffer::StrBuffer,
     strutil::TString,
     translations::TR,
     ui::{
@@ -25,7 +26,7 @@ pub struct AddressDetails {
     qr_code: Qr,
     details_view: Paragraphs<ParagraphVecShort<'static>>,
     xpub_view: Frame<Paragraphs<Paragraph<'static>>>,
-    xpubs: Vec<(TString<'static>, TString<'static>), MAX_XPUBS>,
+    xpubs: Vec<(StrBuffer, StrBuffer), MAX_XPUBS>,
     current_page: usize,
     current_subpage: usize,
     area: Rect,
@@ -77,11 +78,7 @@ impl AddressDetails {
         Ok(result)
     }
 
-    pub fn add_xpub(
-        &mut self,
-        title: TString<'static>,
-        xpub: TString<'static>,
-    ) -> Result<(), Error> {
+    pub fn add_xpub(&mut self, title: StrBuffer, xpub: StrBuffer) -> Result<(), Error> {
         self.xpubs
             .push((title, xpub))
             .map_err(|_| Error::OutOfRange)
@@ -156,7 +153,7 @@ impl AddressDetails {
 
     fn fill_xpub_page(&mut self, ctx: &mut EventCtx) {
         let i = self.current_page - 2;
-        self.xpub_view.update_title(ctx, self.xpubs[i].0);
+        self.xpub_view.update_title(ctx, self.xpubs[i].0.into());
         self.xpub_view.update_content(ctx, |p| {
             p.update(self.xpubs[i].1);
             p.change_page(0)

--- a/core/embed/rust/src/ui/layout_caesar/component/mod.rs
+++ b/core/embed/rust/src/ui/layout_caesar/component/mod.rs
@@ -25,7 +25,7 @@ pub use loader::{Loader, LoaderMsg, LoaderStyle, LoaderStyleSheet, ProgressLoade
 pub use result::ResultScreen;
 pub use welcome_screen::WelcomeScreen;
 
-#[cfg(feature = "translations")]
+#[cfg(all(feature = "micropython", feature = "translations"))]
 mod address_details;
 mod changing_text;
 #[cfg(feature = "translations")]
@@ -44,7 +44,7 @@ mod share_words;
 mod show_more;
 mod title;
 
-#[cfg(feature = "translations")]
+#[cfg(all(feature = "micropython", feature = "translations"))]
 pub use address_details::AddressDetails;
 
 pub use changing_text::ChangingTextLine;

--- a/core/embed/rust/src/ui/layout_caesar/ui_firmware.rs
+++ b/core/embed/rust/src/ui/layout_caesar/ui_firmware.rs
@@ -4,7 +4,7 @@ use crate::{
     error::Error,
     io::BinaryData,
     maybe_trace::MaybeTrace,
-    micropython::{gc::Gc, iter::IterBuf, list::List, obj::Obj, util},
+    micropython::{buffer::StrBuffer, gc::Gc, iter::IterBuf, list::List, obj::Obj, util},
     strutil::TString,
     translations::TR,
     ui::{
@@ -933,7 +933,7 @@ impl FirmwareUI for UICaesar {
         let mut ad = AddressDetails::new(address, case_sensitive, account, path)?;
 
         for i in IterBuf::new().try_iterate(xpubs)? {
-            let [xtitle, text]: [TString; 2] = util::iter_into_array(i)?;
+            let [xtitle, text]: [StrBuffer; 2] = util::iter_into_array(i)?;
             ad.add_xpub(xtitle, text)?;
         }
 

--- a/core/embed/rust/src/ui/layout_delizia/component/address_details.rs
+++ b/core/embed/rust/src/ui/layout_delizia/component/address_details.rs
@@ -2,6 +2,7 @@ use heapless::Vec;
 
 use crate::{
     error::Error,
+    micropython::buffer::StrBuffer,
     strutil::TString,
     translations::TR,
     ui::{
@@ -25,7 +26,7 @@ const MAX_XPUBS: usize = 16;
 pub struct AddressDetails {
     details: Frame<Paragraphs<ParagraphVecShort<'static>>>,
     xpub_view: Frame<Paragraphs<Paragraph<'static>>>,
-    xpubs: Vec<(TString<'static>, TString<'static>), MAX_XPUBS>,
+    xpubs: Vec<(StrBuffer, StrBuffer), MAX_XPUBS>,
     xpub_page_count: Vec<u8, MAX_XPUBS>,
     current_page: u16,
 }
@@ -75,11 +76,7 @@ impl AddressDetails {
         Ok(result)
     }
 
-    pub fn add_xpub(
-        &mut self,
-        title: TString<'static>,
-        xpub: TString<'static>,
-    ) -> Result<(), Error> {
+    pub fn add_xpub(&mut self, title: StrBuffer, xpub: StrBuffer) -> Result<(), Error> {
         self.xpubs
             .push((title, xpub))
             .map_err(|_| Error::OutOfRange)
@@ -90,7 +87,8 @@ impl AddressDetails {
         // case the parent component that handles paging always requests complete
         // repaint after page change so we can use a dummy context here.
         let mut dummy_ctx = EventCtx::new();
-        self.xpub_view.update_title(&mut dummy_ctx, self.xpubs[i].0);
+        self.xpub_view
+            .update_title(&mut dummy_ctx, self.xpubs[i].0.into());
         self.xpub_view.update_content(&mut dummy_ctx, |_ctx, p| {
             p.update(self.xpubs[i].1);
             p.change_page(page);

--- a/core/embed/rust/src/ui/layout_delizia/component/mod.rs
+++ b/core/embed/rust/src/ui/layout_delizia/component/mod.rs
@@ -1,4 +1,4 @@
-#[cfg(feature = "translations")]
+#[cfg(all(feature = "micropython", feature = "translations"))]
 mod address_details;
 #[cfg(feature = "ui_overlay")]
 mod binary_selection;
@@ -40,7 +40,7 @@ mod tap_to_confirm;
 mod updatable_more_info;
 mod welcome_screen;
 
-#[cfg(feature = "translations")]
+#[cfg(all(feature = "micropython", feature = "translations"))]
 pub use address_details::AddressDetails;
 #[cfg(feature = "ui_overlay")]
 pub use binary_selection::{BinarySelection, BinarySelectionMsg};

--- a/core/embed/rust/src/ui/layout_delizia/flow/get_address.rs
+++ b/core/embed/rust/src/ui/layout_delizia/flow/get_address.rs
@@ -1,6 +1,6 @@
 use crate::{
     error,
-    micropython::{iter::IterBuf, obj::Obj, util},
+    micropython::{buffer::StrBuffer, iter::IterBuf, obj::Obj, util},
     strutil::TString,
     translations::TR,
     ui::{
@@ -168,7 +168,7 @@ pub fn new_get_address(
     // AccountInfo
     let mut ad = AddressDetails::new(TR::address_details__account_info.into(), account, path)?;
     for i in IterBuf::new().try_iterate(xpubs)? {
-        let [xtitle, text]: [TString; 2] = util::iter_into_array(i)?;
+        let [xtitle, text]: [StrBuffer; 2] = util::iter_into_array(i)?;
         ad.add_xpub(xtitle, text)?;
     }
     let content_account = ad.map(|_| Some(FlowMsg::Cancelled));


### PR DESCRIPTION
It reduces `AddressDetails` size by 128 bytes from:
```
`ui::layout_delizia::component::address_details::AddressDetails`: 2080 bytes, alignment: 4 bytes
```
to
```
`ui::layout_delizia::component::address_details::AddressDetails`: 1952 bytes, alignment: 4 bytes
```

Relevant stack sizes are also reduced to:
```
11536	trezor_lib::ui::api::firmware_micropython::new_flow_get_address
16056	trezor_lib::ui::api::firmware_micropython::new_flow_confirm_output
```
(https://github.com/trezor/trezor-firmware/actions/runs/14601983369/job/40962113990?pr=4946)

from:
```
11800	trezor_lib::ui::api::firmware_micropython::new_flow_get_address
16312	trezor_lib::ui::api::firmware_micropython::new_flow_confirm_output
```
(https://github.com/trezor/trezor-firmware/actions/runs/14591197885/job/40926681094?pr=4941)

<!--
For core developers:
- Assign yourself to the PR.
- Set the priority to match the original issue.
- Add the PR to the current sprint.
- If it's a draft PR, mark it as "In Progress."
- If it's a final PR, mark it as "Needs Review."

For external contributors:
- Please open an issue before submitting a PR so we can discuss whether we want to proceed with it.
-->
