### PR TITLE
test(core): reduce pytest timeout for upgrade tests

### DIFF
--- a/.github/workflows/core.yml
+++ b/.github/workflows/core.yml
@@ -376,7 +376,8 @@ jobs:
         asan: ${{ fromJSON(needs.param.outputs.asan) }}
     env:
       TREZOR_UPGRADE_TEST: core
-      PYTEST_TIMEOUT: 400
+      PYTEST_TIMEOUT: 20
+      TESTOPTS: "--durations 50"
     steps:
       - uses: actions/checkout@v4
         with:


### PR DESCRIPTION
Most of the tests complete after a few seconds:
![image](https://github.com/user-attachments/assets/53537495-569b-4df3-b182-7f60bf7b04a7)

Sometimes upgrade tests fail due to flaky debuglink handling on old emulators.
In this case, the test can be terminated earlier.

<!--
For core developers:
- Assign yourself to the PR.
- Set the priority to match the original issue.
- Add the PR to the current sprint.
- If it's a draft PR, mark it as "In Progress."
- If it's a final PR, mark it as "Needs Review."

For external contributors:
- Please open an issue before submitting a PR so we can discuss whether we want to proceed with it.
-->
