### PR TITLE
ci(common): run `ClusterFuzzLite PR fuzzing` job daily

### DIFF
--- a/.github/workflows/cflite.yml
+++ b/.github/workflows/cflite.yml
@@ -2,9 +2,8 @@ name: ClusterFuzzLite PR fuzzing
 
 on:
   workflow_dispatch:
-  pull_request:
-    paths:
-      - '**'
+  schedule:
+    - cron: '55 23 * * *'  # every day @ 23:55
 
 # cancel any previous runs on the same PR
 concurrency:


### PR DESCRIPTION
It seems that this job takes >1h:

![image](https://github.com/user-attachments/assets/cae4026d-2a8c-45bd-ab5b-67a31db14f9a)

Most of the time is spent waiting:

![image](https://github.com/user-attachments/assets/82071975-fb76-4fab-b2d3-f055b142039d)


<!--
For core developers:
- Assign yourself to the PR.
- Set the priority to match the original issue.
- Add the PR to the current sprint.
- If it's a draft PR, mark it as "In Progress."
- If it's a final PR, mark it as "Needs Review."

For external contributors:
- Please open an issue before submitting a PR so we can discuss whether we want to proceed with it.
-->
