### PR TITLE
test(core): don't force changing language if not needed

### DIFF
--- a/tests/translations.py
+++ b/tests/translations.py
@@ -64,7 +64,7 @@ def build_and_sign_blob(
     return sign_blob(blob)
 
 
-def set_language(client: Client, lang: str, *, force: bool = True):
+def set_language(client: Client, lang: str, *, force: bool = False):
     if lang.startswith("en"):
         language_data = b""
     else:


### PR DESCRIPTION
An incorrect default value was used in https://github.com/trezor/trezor-firmware/commit/abcbb5c2ab5f5dcabf42bfffacca374d79cac712.

Currently, it takes at least ~0.2s (for every test case):
```
[2025-04-24 21:22:13,270] trezorlib.client DEBUG: sending message: ChangeLanguage
ChangeLanguage (2 bytes) {
    data_length: 0,
}
[2025-04-24 21:22:13,270] trezorlib.client BYTES: encoded as type 990 (2 bytes): 0800
[2025-04-24 21:22:13,458] trezorlib.client BYTES: received type 2 (18 bytes): 0a104c616e6775616765206368616e676564
[2025-04-24 21:22:13,459] trezorlib.client DEBUG: received message: Success
Success (18 bytes) {
    message: 'Language changed',
}
```