### PR TITLE
fixup! fix(eckhart): optimize device menu

### DIFF
--- a/core/embed/rust/src/ui/layout_eckhart/ui_firmware.rs
+++ b/core/embed/rust/src/ui/layout_eckhart/ui_firmware.rs
@@ -794,7 +794,7 @@ impl FirmwareUI for UIEckhart {
             firmware_version,
             device_name,
             paired_devices,
-        ));
+        )?);
         Ok(layout)
     }
 


### PR DESCRIPTION
It significantly reduces `new_show_device_menu` stack usage from:
```
20008	trezor_lib::ui::api::firmware_micropython::new_show_device_menu
```
to:
```
1744	trezor_lib::ui::api::firmware_micropython::new_show_device_menu
```

by moving the largest members `DeviceMenuScreen` to the heap, reducing its size from:
```
 type: `ui::layout_eckhart::firmware::device_menu_screen::DeviceMenuScreen<'_>`: 6260 bytes, alignment: 4 bytes
     field `.menu_screen`: 1260 bytes
     field `.about_screen`: 1580 bytes
     field `.firmware_version`: 12 bytes
     field `.bounds`: 8 bytes
     field `.submenus`: 3244 bytes
     field `.subscreens`: 132 bytes
     field `.active_subscreen`: 4 bytes
     field `.parent_subscreens`: 16 bytes
     field `.battery_percentage`: 1 bytes
     end padding: 3 bytes
```
to
```
 type: `ui::layout_eckhart::firmware::device_menu_screen::DeviceMenuScreen<'_>`: 188 bytes, alignment: 4 bytes
     field `.firmware_version`: 12 bytes
     field `.menu_screen`: 4 bytes
     field `.about_screen`: 4 bytes
     field `.submenus`: 4 bytes
     field `.bounds`: 8 bytes
     field `.subscreens`: 132 bytes
     field `.active_subscreen`: 4 bytes
     field `.parent_subscreens`: 16 bytes
     field `.battery_percentage`: 1 bytes
     end padding: 3 bytes
```
Similar to #4950. 

<!--
For core developers:
- Assign yourself to the PR.
- Set the priority to match the original issue.
- Add the PR to the current sprint.
- If it's a draft PR, mark it as "In Progress."
- If it's a final PR, mark it as "Needs Review."

For external contributors:
- Please open an issue before submitting a PR so we can discuss whether we want to proceed with it.
-->
