### PR TITLE
ci(nix): bump ffmpeg

### DIFF
--- a/shell.nix
+++ b/shell.nix
@@ -136,7 +136,7 @@ stdenvNoCC.mkDerivation ({
   ] ++ lib.optionals hardwareTest [
     uhubctl
     tio
-    ffmpeg_5-full
+    ffmpeg_7-headless
     dejavu_fonts
   ] ++ lib.optionals devTools [
     shellcheck


### PR DESCRIPTION
Should fix nightly hardware tests. Only tested that the shell starts.

<!--
For core developers:
- Assign yourself to the PR.
- Set the priority to match the original issue.
- Add the PR to the current sprint.
- If it's a draft PR, mark it as "In Progress."
- If it's a final PR, mark it as "Needs Review."

For external contributors:
- Please open an issue before submitting a PR so we can discuss whether we want to proceed with it.
-->
