### PR TITLE
build: build-docker.sh: ignore dubious ownership

### DIFF
--- a/build-docker.sh
+++ b/build-docker.sh
@@ -184,6 +184,8 @@ if [ $INIT -eq 1 ]; then
 
     mkdir -p /reproducible-build
     cd /reproducible-build
+    # ignore ownership of the local repo
+    git config --global --add safe.directory /local/.git
     git clone --branch="$TAG" --depth=1 "$REPOSITORY" trezor-firmware
     cd trezor-firmware
 EOF


### PR DESCRIPTION
Likely caused by #4374. [git docs](https://git-scm.com/docs/git-config#Documentation/git-config.txt-safedirectory)
```
>>> DOCKER REFRESH trezor-firmware-env.nix__main

Cloning into 'trezor-firmware'...
warning: safe.directory 'file:///local/.git' not absolute
fatal: detected dubious ownership in repository at '/local/.git'
To add an exception for this directory, call:

	git config --global --add safe.directory /local/.git
fatal: Could not read from remote repository.

Please make sure you have the correct access rights
and the repository exists.
```

<!--
For core developers:
- Assign yourself to the PR.
- Set the priority to match the original issue.
- Add the PR to the current sprint.
- If it's a draft PR, mark it as "In Progress."
- If it's a final PR, mark it as "Needs Review."

For external contributors:
- Please open an issue before submitting a PR so we can discuss whether we want to proceed with it.
-->
