### PR TITLE
ci: pass github token to ClusterFuzzLite jobs

### DIFF
--- a/.github/workflows/cflite.yml
+++ b/.github/workflows/cflite.yml
@@ -25,6 +25,7 @@ jobs:
         id: build
         uses: google/clusterfuzzlite/actions/build_fuzzers@v1
         with:
+          github-token: ${{ secrets.GITHUB_TOKEN }}
           sanitizer: ${{ matrix.sanitizer }}
           language: c
       - name: Run Fuzzers (${{ matrix.sanitizer }})


### PR DESCRIPTION
Trying what's suggested in google/clusterfuzzlite#76. Resolves #4967.

<!--https://github.com/google/clusterfuzzlite/pull/76
For core developers:
- Assign yourself to the PR.
- Set the priority to match the original issue.
- Add the PR to the current sprint.
- If it's a draft PR, mark it as "In Progress."
- If it's a final PR, mark it as "Needs Review."

For external contributors:
- Please open an issue before submitting a PR so we can discuss whether we want to proceed with it.
-->
