### PR TITLE
Introduce new translation blob format to support larger fonts

### DIFF
--- a/core/.changelog.d/4975.added
+++ b/core/.changelog.d/4975.added
@@ -1,0 +1,1 @@
+Added new translation blob format to support larger fonts.

--- a/core/embed/rust/src/translations/blob.rs
+++ b/core/embed/rust/src/translations/blob.rs
@@ -134,8 +134,6 @@ fn read_u16_prefixed_block<'a>(reader: &mut InputStream<'a>) -> Result<InputStre
 }
 
 impl<'a> Translations<'a> {
-    const MAGIC: &'static [u8] = b"TRTR00";
-
     pub fn new(blob: &'a [u8]) -> Result<Self, Error> {
         let mut blob_reader = InputStream::new(blob);
 

--- a/core/translations/signatures.json
+++ b/core/translations/signatures.json
@@ -1,8 +1,8 @@
 {
   "current": {
-    "merkle_root": "cf835159e227117eb1c2cd8a784c259b523c5b9489e408a4cefa169601437af6",
-    "datetime": "2025-04-29T09:29:38.532833",
-    "commit": "af2c36a22ffa4d6326a6161b2ce3037560f5eb7d"
+    "merkle_root": "4c29432094ddfc979ec6b0e2b1e9f2ebe2097f500f8512b2e252d7193887898c",
+    "datetime": "2025-04-29T17:55:49.335120",
+    "commit": "414f5d40bb59c52918b978d864ba27fe9117a690"
   },
   "history": [
     {

--- a/docs/core/misc/translations.md
+++ b/docs/core/misc/translations.md
@@ -18,7 +18,7 @@ To upload blobs with foreign-language translations, use `trezorctl set language 
 
 To switch the language back into `english`, use `trezorctl set language -r`.
 
-# Translations blob format
+# Translations blob format (v1)
 
 | offset | length             | name              | description                                       | hash   |
 |-------:|-------------------:|-------------------|---------------------------------------------------|--------|
@@ -92,3 +92,22 @@ the interpretation of the payload.
 | ?      | ?                                    | sentinel\_offset  | offset past the end of last element                         |
 |        | ?                                    | glyphs            | concatenation of glyph bitmaps                              |
 | ?      | 0-3                                  | padding           | padding (any value) for alignment purposes                  |
+
+# Previous versions
+
+## Translations blob format (v0)
+
+| offset | length             | name              | description                                       | hash   |
+|-------:|-------------------:|-------------------|---------------------------------------------------|--------|
+| 0x0000 |                  6 | magic             | blob magic `TRTR00`                               |        |
+| 0x0006 |                  2 | container\_len    | total length (up to padding)                      |        |
+| 0x0008 |                  2 | header\_len       | header length                                     |        |
+| 0x000A |                  2 | header\_magic     | header magic `TR`                                 |        |
+| 0x000C |                  8 | language\_tag     | BCP 47 language tag (e.g. `cs-CZ`, `en-US`, ...)  | header |
+| 0x0014 |                  4 | version           | 4 bytes of version (major, minor, patch, build)   | header |
+| 0x0018 |                  2 | data\_len         | length of the raw data, i.e. translations + fonts | header |
+| 0x001A |                 32 | data\_hash        | SHA-256 hash of the data                          | header |
+| 0x003A |  `header_len - 48` | ignored           | reserved for forward compatibility                | header |
+|      ? |                  2 | proof\_len        | length of merkle proof and signature in bytes     |        |
+|      ? |                  1 | proof\_count      | number of merkle proof items following            |        |
+|      ? | `proof_count * 20` | proof             | array of SHA-256 hashes                           |        |

--- a/docs/core/misc/translations.md
+++ b/docs/core/misc/translations.md
@@ -22,15 +22,15 @@ To switch the language back into `english`, use `trezorctl set language -r`.
 
 | offset | length             | name              | description                                       | hash   |
 |-------:|-------------------:|-------------------|---------------------------------------------------|--------|
-| 0x0000 |                  6 | magic             | blob magic `TRTR00`                               |        |
-| 0x0006 |                  2 | container\_len    | total length (up to padding)                      |        |
-| 0x0008 |                  2 | header\_len       | header length                                     |        |
-| 0x000A |                  2 | header\_magic     | header magic `TR`                                 |        |
-| 0x000C |                  8 | language\_tag     | BCP 47 language tag (e.g. `cs-CZ`, `en-US`, ...)  | header |
-| 0x0014 |                  4 | version           | 4 bytes of version (major, minor, patch, build)   | header |
-| 0x0018 |                  2 | data\_len         | length of the raw data, i.e. translations + fonts | header |
-| 0x001A |                 32 | data\_hash        | SHA-256 hash of the data                          | header |
-| 0x003A |  `header_len - 48` | ignored           | reserved for forward compatibility                | header |
+| 0x0000 |                  6 | magic             | blob magic `TRTR01`                               |        |
+| 0x0006 |                  4 | container\_len    | total length (up to padding)                      |        |
+| 0x000A |                  2 | header\_len       | header length                                     |        |
+| 0x000C |                  2 | header\_magic     | header magic `TR`                                 |        |
+| 0x000E |                  8 | language\_tag     | BCP 47 language tag (e.g. `cs-CZ`, `en-US`, ...)  | header |
+| 0x0016 |                  4 | version           | 4 bytes of version (major, minor, patch, build)   | header |
+| 0x001A |                  4 | data\_len         | length of the raw data, i.e. translations + fonts | header |
+| 0x001E |                 32 | data\_hash        | SHA-256 hash of the data                          | header |
+| 0x003E |  `header_len - 46` | ignored           | reserved for forward compatibility                | header |
 |      ? |                  2 | proof\_len        | length of merkle proof and signature in bytes     |        |
 |      ? |                  1 | proof\_count      | number of merkle proof items following            |        |
 |      ? | `proof_count * 20` | proof             | array of SHA-256 hashes                           |        |

--- a/python/.changelog.d/4975.added
+++ b/python/.changelog.d/4975.added
@@ -1,0 +1,1 @@
+Added new translation blob format to support larger fonts.

--- a/python/src/trezorlib/_internal/translations.py
+++ b/python/src/trezorlib/_internal/translations.py
@@ -76,7 +76,7 @@ class Header(Struct):
         "language" / c.PaddedString(8, "ascii"),  # BCP47 language tag
         "model" / EnumAdapter(c.Bytes(4), Model),
         "firmware_version" / TupleAdapter(c.Int8ul, c.Int8ul, c.Int8ul, c.Int8ul),
-        "data_len" / c.Int16ul,
+        "data_len" / c.Int32ul,
         "data_hash" / c.Bytes(32),
         ALIGN_SUBCON,
         c.Terminated,
@@ -240,9 +240,9 @@ class TranslationsBlob(Struct):
 
     # fmt: off
     SUBCON = c.Struct(
-        "magic" / c.Const(b"TRTR00"),
+        "magic" / c.Const(b"TRTR01"),
         "total_length" / c.Rebuild(
-            c.Int16ul,
+            c.Int32ul,
             (
                 c.len_(c.this.header_bytes)
                 + c.len_(c.this.proof_bytes)


### PR DESCRIPTION
This PR allows raw data size to be above 64kB:
https://docs.trezor.io/trezor-firmware/core/misc/translations.html?highlight=blob#translations-blob-format

![image](https://github.com/user-attachments/assets/dbf0e3f6-3010-4fd8-9d61-0f220c7b8119)

TODO:

- [ ] Should we also allow an individual blob (translations/fonts) size to be >64kB?

<!--
For core developers:
- Assign yourself to the PR.
- Set the priority to match the original issue.
- Add the PR to the current sprint.
- If it's a draft PR, mark it as "In Progress."
- If it's a final PR, mark it as "Needs Review."

For external contributors:
- Please open an issue before submitting a PR so we can discuss whether we want to proceed with it.
-->
