### PR TITLE
shell.nix: bump arm-embedded-gcc to version 13

### DIFF
--- a/shell.nix
+++ b/shell.nix
@@ -96,7 +96,7 @@ stdenvNoCC.mkDerivation ({
     crowdin-cli  # for translations
     curl  # for connect tests
     editorconfig-checker
-    gcc-arm-embedded
+    gcc-arm-embedded-13
     gcc14
     git
     gitAndTools.git-subrepo


### PR DESCRIPTION
Since #4374 it seems `arm-none-eabi-gdb` v12 is broken. Let's have some moderate progress within the bounds of the law and bump to 13.3.1 which is not broken in this way?

```
$ arm-none-eabi-gdb
Fatal Python error: init_import_size: Failed to import the site module
Python runtime state: initialized
Traceback (most recent call last):
  File "/nix/store/hywjs3gs3fki9v8zpxxas8yra0gxpprm-python3-3.9.20/lib/python3.9/site.py", line 73, in <module>
    import os
  File "/nix/store/hywjs3gs3fki9v8zpxxas8yra0gxpprm-python3-3.9.20/lib/python3.9/os.py", line 29, in <module>
    from _collections_abc import _check_methods
  File "/nix/store/hywjs3gs3fki9v8zpxxas8yra0gxpprm-python3-3.9.20/lib/python3.9/_collections_abc.py", line 12, in <module>
    GenericAlias = type(list[int])
TypeError: 'type' object is not subscriptable
```

<!--
For core developers:
- Assign yourself to the PR.
- Set the priority to match the original issue.
- Add the PR to the current sprint.
- If it's a draft PR, mark it as "In Progress."
- If it's a final PR, mark it as "Needs Review."

For external contributors:
- Please open an issue before submitting a PR so we can discuss whether we want to proceed with it.
-->
