### PR TITLE
fix(legacy): always use Gwei for ETH fee rates

### DIFF
--- a/legacy/firmware/ethereum.c
+++ b/legacy/firmware/ethereum.c
@@ -322,22 +322,18 @@ static void ethereumFormatAmount(const bignum256 *amnt,
   bignum256 bn1e9 = {0};
   bn_read_uint32(1000000000, &bn1e9);
 
-  bignum256 bn1e3 = {0};
-  bn_read_uint32(1000, &bn1e3);
-
   char suffix[50] = {' ', 0};
   int decimals = 18;
   if (token) {
     strlcpy(suffix + 1, token->symbol, sizeof(suffix) - 1);
     decimals = token->decimals;
+  } else if (use_gwei) {
+    // "per gas" fees should always use Gwei
+    strlcpy(suffix + 1, "Gwei", sizeof(suffix) - 1);
+    decimals = 9;
   } else if (bn_is_less(amnt, &bn1e9)) {
-    if (use_gwei && !bn_is_less(amnt, &bn1e3)) {
-      strlcpy(suffix + 1, "Gwei", sizeof(suffix) - 1);
-      decimals = 9;
-    } else {
-      strlcpy(suffix + 1, "Wei", sizeof(suffix) - 1);
-      decimals = 0;
-    }
+    strlcpy(suffix + 1, "Wei", sizeof(suffix) - 1);
+    decimals = 0;
   } else {
     strlcpy(suffix + 1, chain_suffix, sizeof(suffix) - 1);
   }
@@ -448,7 +444,7 @@ static void layoutEthereumFee(const uint8_t *value, uint32_t value_len,
   bn_multiply(&val, &gas, &secp256k1.prime);
 
   ethereumFormatAmount(&gas, NULL, gas_value, sizeof(gas_value),
-                       /*use_gwei=*/true);
+                       /*use_gwei=*/false);
 
   parse_bignum256(value, value_len, &val);
 
@@ -468,7 +464,7 @@ static void layoutEthereumFeeEIP1559(const char *description,
                                      const uint8_t *amount_bytes,
                                      uint32_t amount_len,
                                      const uint8_t *multiplier_bytes,
-                                     uint32_t multiplier_len) {
+                                     uint32_t multiplier_len, bool use_gwei) {
   bignum256 amount_val = {0};
   char amount_str[32] = {0};
 
@@ -482,7 +478,7 @@ static void layoutEthereumFeeEIP1559(const char *description,
   }
 
   ethereumFormatAmount(&amount_val, NULL, amount_str, sizeof(amount_str),
-                       /*use_gwei=*/true);
+                       use_gwei);
 
   layoutDialogSwipeWrapping(&bmp_icon_question, _("Cancel"), _("Confirm"),
                             _("Confirm fee"), description, amount_str);
@@ -891,7 +887,8 @@ void ethereum_signing_init_eip1559(const EthereumSignTxEIP1559 *msg,
   }
 
   layoutEthereumFeeEIP1559(_("Maximum fee per gas"), msg->max_gas_fee.bytes,
-                           msg->max_gas_fee.size, NULL, 0);
+                           msg->max_gas_fee.size, NULL, 0,
+                           /*use_gwei=*/true);
   if (!protectButton(ButtonRequestType_ButtonRequest_SignTx, false)) {
     fsm_sendFailure(FailureType_Failure_ActionCancelled, NULL);
     ethereum_signing_abort();
@@ -900,7 +897,8 @@ void ethereum_signing_init_eip1559(const EthereumSignTxEIP1559 *msg,
 
   layoutEthereumFeeEIP1559(_("Priority fee per gas"),
                            msg->max_priority_fee.bytes,
-                           msg->max_priority_fee.size, NULL, 0);
+                           msg->max_priority_fee.size, NULL, 0,
+                           /*use_gwei=*/true);
   if (!protectButton(ButtonRequestType_ButtonRequest_SignTx, false)) {
     fsm_sendFailure(FailureType_Failure_ActionCancelled, NULL);
     ethereum_signing_abort();
@@ -909,7 +907,7 @@ void ethereum_signing_init_eip1559(const EthereumSignTxEIP1559 *msg,
 
   layoutEthereumFeeEIP1559(_("Maximum fee"), msg->gas_limit.bytes,
                            msg->gas_limit.size, msg->max_gas_fee.bytes,
-                           msg->max_gas_fee.size);
+                           msg->max_gas_fee.size, /*use_gwei=*/false);
   if (!protectButton(ButtonRequestType_ButtonRequest_SignTx, false)) {
     fsm_sendFailure(FailureType_Failure_ActionCancelled, NULL);
     ethereum_signing_abort();


### PR DESCRIPTION
Similar to how it's done in core.

Following https://github.com/trezor/trezor-firmware/issues/4932#issuecomment-2820458343, we should use Gwei for "per gas" fee rates:

<img width="1410" height="457" alt="image" src="https://github.com/user-attachments/assets/7af47d66-b773-4425-920f-aed5222ca3ab" />

After this PR:

<img src="https://github.com/user-attachments/assets/be3bdcf1-dc67-4174-8506-5272974b1376" width=400>


## Recent UI diff
https://data.trezor.io/dev/firmware/ui_report/16425051463/T1B1-en-legacy_device_test-index.html

<!--
For core developers:
- Assign yourself to the PR.
- Set the priority to match the original issue.
- Add the PR to the current sprint.
- If it's a draft PR, mark it as "In Progress."
- If it's a final PR, mark it as "Needs Review."

For external contributors:
- Please open an issue before submitting a PR so we can discuss whether we want to proceed with it.
-->
