### PR TITLE
allow infinite testing of NFC functionalities

### DIFF
--- a/core/embed/projects/prodtest/README.md
+++ b/core/embed/projects/prodtest/README.md
@@ -945,8 +945,8 @@ each 100ms.
 
 Example:
 ```
-nfc-read-card [<timeout_seconds>]
-# NFC activated in reader mode for <timeout_seconds> seconds.
+nfc-read-card [<timeout_ms>]
+# NFC activated in reader mode for <timeout_ms> ms.
 # NFC card detected.
 # NFC Type A: UID: %s
 OK
@@ -958,8 +958,8 @@ Activate NFC in Card Emulator mode for given time, or infinite time if no timeou
 
 Example:
 ```
-nfc-emulate-card [<timeout_seconds>]
-# Emulation started for <timeout_seconds>
+nfc-emulate-card [<timeout_ms>]
+# Emulation started for <timeout_ms>
 # Emulation over
 OK
 ```
@@ -972,8 +972,8 @@ each 100ms.
 
 Example:
 ```
-nfc-write-card [<timeout_seconds>]
-# NFC reader on, put the card on the reader (timeout <timeout_seconds> s)
+nfc-write-card [<timeout_ms>]
+# NFC reader on, put the card on the reader (timeout <timeout_ms> ms)
 # Writting URI to NFC tag 7AF403
 
 ### unit-test-run

--- a/core/embed/projects/prodtest/README.md
+++ b/core/embed/projects/prodtest/README.md
@@ -940,9 +940,12 @@ wpc-update
 ### nfc-read-card
 Activate the NFC in reader mode for a given time. Read general information from firstly discovered NFC tag or exits on timeout.
 
+When used without a timeout, the command will wait indefinitely for a card to be placed on the reader and will repeat the read operation
+each 100ms.
+
 Example:
 ```
-nfc-read-card <timeout_seconds>
+nfc-read-card [<timeout_seconds>]
 # NFC activated in reader mode for <timeout_seconds> seconds.
 # NFC card detected.
 # NFC Type A: UID: %s
@@ -951,11 +954,11 @@ OK
 
 
 ### nfc-emulate-card
-Activate NFC in Card Emulator mode for given time.
+Activate NFC in Card Emulator mode for given time, or infinite time if no timeout is specified.
 
 Example:
 ```
-nfc-emulate-card <timeout_seconds>
+nfc-emulate-card [<timeout_seconds>]
 # Emulation started for <timeout_seconds>
 # Emulation over
 OK
@@ -964,9 +967,12 @@ OK
 ### nfc-write-card
 Activates the NFC reader for given time. Writes the NDEF URI message into the first discovered NFC tag type A or exits on timeout.
 
+When used without a timeout, the command will wait indefinitely for a card to be placed on the reader and will repeat the write operation
+each 100ms.
+
 Example:
 ```
-nfc-write_card <timeout_seconds>
+nfc-write_card [<timeout_seconds>]
 # NFC reader on, put the card on the reader (timeout <timeout_seconds> s)
 # Writting URI to NFC tag 7AF403
 

--- a/core/embed/projects/prodtest/README.md
+++ b/core/embed/projects/prodtest/README.md
@@ -972,7 +972,7 @@ each 100ms.
 
 Example:
 ```
-nfc-write_card [<timeout_seconds>]
+nfc-write-card [<timeout_seconds>]
 # NFC reader on, put the card on the reader (timeout <timeout_seconds> s)
 # Writting URI to NFC tag 7AF403
 

--- a/core/embed/projects/prodtest/README.md
+++ b/core/embed/projects/prodtest/README.md
@@ -16,9 +16,10 @@ To exit from interactive mode type `.+ENTER`.
 
 ### Commands
 These commands begin with the command name and may optionally include parameters separated by spaces.
+Parameters are marked with angle brackets (`<...>`), square brackets (`[<...>]`) indicate optional parameters.
 
 Command Format:
-`command <arg1> <arg2> ...`
+`command <arg1> <arg2> [<optional_arg3>]...`
 
 Example:
 ```

--- a/core/embed/projects/prodtest/cmd/prodtest_nfc.c
+++ b/core/embed/projects/prodtest/cmd/prodtest_nfc.c
@@ -252,7 +252,7 @@ static void prodtest_nfc_write_card(cli_t* cli) {
         goto cleanup;
       }
 
-      cli_trace(cli, "Writting URI to NFC tag %s", dev_info.uid);
+      cli_trace(cli, "Writing URI to NFC tag %s", dev_info.uid);
       nfc_dev_write_ndef_uri();
 
       if (timeout_set) {


### PR DESCRIPTION
For usage during testing, certifications it is needed to be able to have NFC turned on continuously 