### PR TITLE
Support new translation blob format

### DIFF
--- a/core/.changelog.d/4975.added
+++ b/core/.changelog.d/4975.added
@@ -1,0 +1,1 @@
+Added new translation blob format to support larger fonts.

--- a/core/embed/rust/src/translations/blob.rs
+++ b/core/embed/rust/src/translations/blob.rs
@@ -125,7 +125,7 @@ impl<'a> Table<'a> {
 }
 
 struct TranslationStringsChunk<'a> {
-    strings: &'a [u8],
+    strings: &'a str,
     offsets: &'a [u16],
 }
 
@@ -139,7 +139,7 @@ impl<'a> TranslationStringsChunk<'a> {
         if !_prefix.is_empty() || !_suffix.is_empty() {
             return Err(INVALID_TRANSLATIONS_BLOB);
         }
-        let strings = reader.rest();
+        let strings = str::from_utf8(reader.rest()).map_err(|_| INVALID_TRANSLATIONS_BLOB)?;
         validate_offset_table(strings.len(), offsets.iter().copied())?;
         Ok(Self { strings, offsets })
     }
@@ -149,7 +149,7 @@ impl<'a> TranslationStringsChunk<'a> {
         self.offsets.len() - 1
     }
 
-    fn get(&self, index: usize) -> Option<&'a [u8]> {
+    fn get(&self, index: usize) -> Option<&'a str> {
         if index >= self.len() {
             return None;
         }
@@ -238,7 +238,7 @@ impl<'a> Translations<'a> {
                         // Fallback to english.
                         return None;
                     }
-                    return str::from_utf8(string).ok();
+                    return Some(string);
                 }
                 None => {
                     index -= chunk.len();

--- a/core/embed/rust/src/translations/blob.rs
+++ b/core/embed/rust/src/translations/blob.rs
@@ -134,8 +134,6 @@ fn read_u16_prefixed_block<'a>(reader: &mut InputStream<'a>) -> Result<InputStre
 }
 
 impl<'a> Translations<'a> {
-    const MAGIC: &'static [u8] = b"TRTR00";
-
     pub fn new(blob: &'a [u8]) -> Result<Self, Error> {
         let mut blob_reader = InputStream::new(blob);
 

--- a/core/translations/signatures.json
+++ b/core/translations/signatures.json
@@ -1,8 +1,8 @@
 {
   "current": {
-    "merkle_root": "8fe9d116fc763842a5335bfb96f5b71e3714d03bbbf5df84bec533c248cc7e16",
-    "datetime": "2025-06-03T15:04:06.020399+00:00",
-    "commit": "ba1a93c90ac785cc49c0fcec47c0da50a7376a38"
+    "merkle_root": "f0d64bdeeba6745eea985af63a6f3696c5c54863937776b5c65daa97397eac50",
+    "datetime": "2025-06-04T05:25:47.081188+00:00",
+    "commit": "dfaf0a411eca91a63edc26f0ba30e7c08be24ca8"
   },
   "history": [
     {

--- a/docs/core/misc/translations.md
+++ b/docs/core/misc/translations.md
@@ -18,29 +18,35 @@ To upload blobs with foreign-language translations, use `trezorctl set language 
 
 To switch the language back into `english`, use `trezorctl set language -r`.
 
-# Translations blob format
+# Translations blob format (v1)
 
-| offset | length             | name              | description                                       | hash   |
-|-------:|-------------------:|-------------------|---------------------------------------------------|--------|
-| 0x0000 |                  6 | magic             | blob magic `TRTR00`                               |        |
-| 0x0006 |                  2 | container\_len    | total length (up to padding)                      |        |
-| 0x0008 |                  2 | header\_len       | header length                                     |        |
-| 0x000A |                  2 | header\_magic     | header magic `TR`                                 |        |
-| 0x000C |                  8 | language\_tag     | BCP 47 language tag (e.g. `cs-CZ`, `en-US`, ...)  | header |
-| 0x0014 |                  4 | version           | 4 bytes of version (major, minor, patch, build)   | header |
-| 0x0018 |                  2 | data\_len         | length of the raw data, i.e. translations + fonts | header |
-| 0x001A |                 32 | data\_hash        | SHA-256 hash of the data                          | header |
-| 0x003A |  `header_len - 48` | ignored           | reserved for forward compatibility                | header |
-|      ? |                  2 | proof\_len        | length of merkle proof and signature in bytes     |        |
-|      ? |                  1 | proof\_count      | number of merkle proof items following            |        |
-|      ? | `proof_count * 20` | proof             | array of SHA-256 hashes                           |        |
-|      ? |                  1 | sig\_mask         | CoSi signature mask                               |        |
-|      ? |                 64 | sig               | ed25519 CoSi signature of merkle root             |        |
-|      ? |                  2 | translations\_len | length of the translated strings                  | data   |
-|      ? | `translations_len` | translations      | translated string data                            | data   |
-|      ? |                  2 | fonts\_len        | length of the font data                           | data   |
-|      ? |        `fonts_len` | fonts             | font data                                         | data   |
-|      ? |                  ? | padding           | `0xff` bytes padding to flash sector boundary     |        |
+| offset | length                           | name                           | description                                       | hash   |
+|-------:|---------------------------------:|--------------------------------|---------------------------------------------------|--------|
+| 0x0000 |                                6 | magic                          | blob magic `TRTR01`                               |        |
+| 0x0006 |                                4 | container\_len                 | total length (up to padding)                      |        |
+| 0x000A |                                2 | header\_len                    | header length                                     |        |
+| 0x000C |                                2 | header\_magic                  | header magic `TR`                                 |        |
+| 0x000E |                                8 | language\_tag                  | BCP 47 language tag (e.g. `cs-CZ`, `en-US`, ...)  | header |
+| 0x0016 |                                4 | version                        | 4 bytes of version (major, minor, patch, build)   | header |
+| 0x001A |                                4 | data\_len                      | length of the raw data, i.e. translations + fonts | header |
+| 0x001E |                               32 | data\_hash                     | SHA-256 hash of the data                          | header |
+| 0x003E |                `header_len - 46` | ignored                        | reserved for forward compatibility                | header |
+|      ? |                                2 | proof\_len                     | length of merkle proof and signature in bytes     |        |
+|      ? |                                1 | proof\_count                   | number of merkle proof items following            |        |
+|      ? |               `proof_count * 20` | proof                          | array of SHA-256 hashes                           |        |
+|      ? |                                1 | sig\_mask                      | CoSi signature mask                               |        |
+|      ? |                               64 | sig                            | ed25519 CoSi signature of merkle root             |        |
+|      ? |                                2 | translations\_chunks\_count    | number of translated strings chunks               | data   |
+|      ? |                                2 | 1st\_translations\_chunk\_len  | length of the 1st translated strings chunk        | data   |
+|      ? |    1st\_translations\_chunk\_len | 1st\_translations\_chunk       | 1st translated string chunk data                  | data   |
+|      ? |                                2 | 2nd\_translations\_chunk\_len  | length of the 2nd translated strings chunk        | data   |
+|      ? |    2nd\_translations\_chunk\_len | 2nd\_translations\_chunk       | 2nd translated string chunk data                  | data   |
+|      ? |                              ... | ...                            | ...                                               | data   |
+|      ? |                                2 | last\_translations\_chunk\_len | last translated string chunk data                 | data   |
+|      ? |   last\_translations\_chunk\_len | last\_translations\_chunk      | length of the last translated strings chunk       | data   |
+|      ? |                                2 | fonts\_len                     | length of the font data                           | data   |
+|      ? |                       fonts\_len | fonts                          | font data                                         | data   |
+|      ? |                                ? | padding                        | `0xff` bytes padding to flash sector boundary     |        |
 
 ## Translation data
 
@@ -92,3 +98,22 @@ the interpretation of the payload.
 | ?      | ?                                    | sentinel\_offset  | offset past the end of last element                         |
 |        | ?                                    | glyphs            | concatenation of glyph bitmaps                              |
 | ?      | 0-3                                  | padding           | padding (any value) for alignment purposes                  |
+
+# Previous versions
+
+## Translations blob format (v0)
+
+| offset | length             | name              | description                                       | hash   |
+|-------:|-------------------:|-------------------|---------------------------------------------------|--------|
+| 0x0000 |                  6 | magic             | blob magic `TRTR00`                               |        |
+| 0x0006 |                  2 | container\_len    | total length (up to padding)                      |        |
+| 0x0008 |                  2 | header\_len       | header length                                     |        |
+| 0x000A |                  2 | header\_magic     | header magic `TR`                                 |        |
+| 0x000C |                  8 | language\_tag     | BCP 47 language tag (e.g. `cs-CZ`, `en-US`, ...)  | header |
+| 0x0014 |                  4 | version           | 4 bytes of version (major, minor, patch, build)   | header |
+| 0x0018 |                  2 | data\_len         | length of the raw data, i.e. translations + fonts | header |
+| 0x001A |                 32 | data\_hash        | SHA-256 hash of the data                          | header |
+| 0x003A |  `header_len - 48` | ignored           | reserved for forward compatibility                | header |
+|      ? |                  2 | proof\_len        | length of merkle proof and signature in bytes     |        |
+|      ? |                  1 | proof\_count      | number of merkle proof items following            |        |
+|      ? | `proof_count * 20` | proof             | array of SHA-256 hashes                           |        |

--- a/python/.changelog.d/4975.added
+++ b/python/.changelog.d/4975.added
@@ -1,0 +1,1 @@
+Added new translation blob format to support larger fonts.


### PR DESCRIPTION
It supports multiple translations strings chunks and allows total container size to be above 64kB.

![Screenshot from 2025-05-01 21-21-58](https://github.com/user-attachments/assets/ea69af58-ba11-49d4-913a-febe349dcfac)

Previous format is also supported by firmware.

## Translation sizes comparison

Model | Language | Size [B] d579d87948 | Size [B] aafdfd20c8 | Delta [B] | Delta [%] | Capacity [B] | Utilization aafdfd20c8
-- | -- | -- | -- | -- | -- | -- | --
T2B1 | cs-CZ | 29258 | 29264 | 6 | 0.02% | 32768 | 89.31%
T2B1 | de-DE | 26920 | 26926 | 6 | 0.02% | 32768 | 82.17%
T2B1 | es-ES | 28568 | 28670 | 102 | 0.36% | 32768 | 87.49%
T2B1 | fr-FR | 30342 | 30348 | 6 | 0.02% | 32768 | 92.61%
T2B1 | it-IT | 25218 | 25224 | 6 | 0.02% | 32768 | 76.98%
T2B1 | pt-BR | 28092 | 28098 | 6 | 0.02% | 32768 | 85.75%
T2B1 | tr-TR | 24798 | 24804 | 6 | 0.02% | 32768 | 75.70%
T2T1 | cs-CZ | 39394 | 39272 | -122 | -0.31% | 49152 | 79.90%
T2T1 | de-DE | 29344 | 29350 | 6 | 0.02% | 49152 | 59.71%
T2T1 | es-ES | 33524 | 33530 | 6 | 0.02% | 49152 | 68.22%
T2T1 | fr-FR | 41124 | 41130 | 6 | 0.01% | 49152 | 83.68%
T2T1 | it-IT | 27274 | 27280 | 6 | 0.02% | 49152 | 55.50%
T2T1 | pt-BR | 34292 | 34298 | 6 | 0.02% | 49152 | 69.78%
T2T1 | tr-TR | 28680 | 28686 | 6 | 0.02% | 49152 | 58.36%
T3B1 | cs-CZ | 29258 | 29264 | 6 | 0.02% | 65536 | 44.65%
T3B1 | de-DE | 26920 | 26926 | 6 | 0.02% | 65536 | 41.09%
T3B1 | es-ES | 28664 | 28670 | 6 | 0.02% | 65536 | 43.75%
T3B1 | fr-FR | 30342 | 30348 | 6 | 0.02% | 65536 | 46.31%
T3B1 | it-IT | 25218 | 25224 | 6 | 0.02% | 65536 | 38.49%
T3B1 | pt-BR | 28092 | 28098 | 6 | 0.02% | 65536 | 42.87%
T3B1 | tr-TR | 24798 | 24804 | 6 | 0.02% | 65536 | 37.85%
T3T1 | cs-CZ | 43436 | 43442 | 6 | 0.01% | 65536 | 66.29%
T3T1 | de-DE | 30354 | 30360 | 6 | 0.02% | 65536 | 46.33%
T3T1 | es-ES | 35620 | 35626 | 6 | 0.02% | 65536 | 54.36%
T3T1 | fr-FR | 45714 | 45720 | 6 | 0.01% | 65536 | 69.76%
T3T1 | it-IT | 28108 | 28018 | -90 | -0.32% | 65536 | 42.75%
T3T1 | pt-BR | 36704 | 36710 | 6 | 0.02% | 65536 | 56.02%
T3T1 | tr-TR | 30272 | 30278 | 6 | 0.02% | 65536 | 46.20%
T3W1 | cs-CZ | 43340 | 43442 | 102 | 0.24% | 131072 | 33.14%
T3W1 | de-DE | 30354 | 30360 | 6 | 0.02% | 131072 | 23.16%
T3W1 | es-ES | 35634 | 35640 | 6 | 0.02% | 131072 | 27.19%
T3W1 | fr-FR | 45714 | 45720 | 6 | 0.01% | 131072 | 34.88%
T3W1 | it-IT | 27980 | 28114 | 134 | 0.48% | 131072 | 21.45%
T3W1 | pt-BR | 36704 | 36710 | 6 | 0.02% | 131072 | 28.01%
T3W1 | tr-TR | 30272 | 30182 | -90 | -0.30% | 131072 | 23.03%

