### PR TITLE
fix(core): propagate exceptions via `unimport.__exit__`

### DIFF
--- a/core/src/trezor/utils.py
+++ b/core/src/trezor/utils.py
@@ -107,7 +107,10 @@ class unimport:
         self.mods = None
         gc.collect()
 
-        if __debug__ and exc_type is not SystemExit:
+        # If an exception is being handled here, `check_free_heap()` will fail
+        # (since the exception survives `gc.collect()` call above).
+        # So we prefer to skip the check, in order to preserve the exception.
+        if __debug__ and exc_type is None:
             self.free_heap = check_free_heap(self.free_heap)
 
 


### PR DESCRIPTION
If an exception is being handled here by `unimport.__exit__()`, `check_free_heap()` will probably fail (since the exception type, value and traceback objects survive `gc.collect()` call).

Thus, we should prefer to skip the check, in order to preserve the "original" exception.

<!--
For core developers:
- Assign yourself to the PR.
- Set the priority to match the original issue.
- Add the PR to the current sprint.
- If it's a draft PR, mark it as "In Progress."
- If it's a final PR, mark it as "Needs Review."

For external contributors:
- Please open an issue before submitting a PR so we can discuss whether we want to proceed with it.
-->
