### PR TITLE
fix(core): use `bool` for `trezor.pin._ignore_loader_messages`

### DIFF
--- a/core/src/trezor/pin.py
+++ b/core/src/trezor/pin.py
@@ -3,7 +3,7 @@ from typing import TYPE_CHECKING
 from . import config
 
 if TYPE_CHECKING:
-    from typing import Any, Container
+    from typing import Any
 
     from trezor.ui import ProgressLayout
 
@@ -13,20 +13,17 @@ _progress_layout: ProgressLayout | None = None
 _started_with_empty_loader = False
 keepalive_callback: Any = None
 
-_ignore_loader_messages: Container[config.StorageMessage] = ()
+_ignore_loader_messages: bool = False
 
 
 def ignore_nonpin_loader_messages() -> None:
     global _ignore_loader_messages
-    _ignore_loader_messages = (
-        config.StorageMessage.PROCESSING_MSG,
-        config.StorageMessage.STARTING_MSG,
-    )
+    _ignore_loader_messages = True
 
 
 def allow_all_loader_messages() -> None:
     global _ignore_loader_messages
-    _ignore_loader_messages = ()
+    _ignore_loader_messages = False
 
 
 def render_empty_loader(message: config.StorageMessage, description: str = "") -> None:
@@ -49,7 +46,10 @@ def show_pin_timeout(
     from trezor.ui.layouts.progress import pin_progress
 
     # Possibility to ignore certain messages - not showing loader for them
-    if message in _ignore_loader_messages:
+    if _ignore_loader_messages and message in (
+        config.StorageMessage.PROCESSING_MSG,
+        config.StorageMessage.STARTING_MSG,
+    ):
         return False
 
     global _previous_seconds


### PR DESCRIPTION
Since `trezor.pin` is persisted across sessions, it should use constant-size globals.

Related to https://github.com/trezor/trezor-firmware/pull/4821.

<!--
For core developers:
- Assign yourself to the PR.
- Set the priority to match the original issue.
- Add the PR to the current sprint.
- If it's a draft PR, mark it as "In Progress."
- If it's a final PR, mark it as "Needs Review."

For external contributors:
- Please open an issue before submitting a PR so we can discuss whether we want to proceed with it.
-->
