### PR TITLE
Don't access GitHub artifacts from `cflite.yml` job

### DIFF
--- a/.github/actions/run-fuzzers/action.yml
+++ b/.github/actions/run-fuzzers/action.yml
@@ -53,11 +53,11 @@ inputs:
   report-unreproducible-crashes:
     description: 'If True, then unreproducible crashes will be reported.'
     required: false
-    default: False
+    default: false
   minimize-crashes:
     description: 'If True, reportable crashes will be minimized.'
     required: false
-    default: False
+    default: false
   parallel-fuzzing:
     description: "Whether to use all available cores for fuzzing."
     required: false
@@ -91,7 +91,11 @@ runs:
     REPORT_UNREPRODUCIBLE_CRASHES: ${{ inputs.report-unreproducible-crashes }}
     OUTPUT_SARIF: ${{ inputs.output-sarif }}
     MINIMIZE_CRASHES: ${{ inputs.minimize-crashes }}
-    CFL_PLATFORM: 'github'
+    CFL_PLATFORM: 'standalone'  # don't access GitHub artifacts
+    FILESTORE_ROOT_DIR: '/no/such/dir'  # no corpus is available
+    WORKSPACE: '/github/workspace'
+    REPOSITORY: 'trezor-firmware'
+    CIFUZZ_DEBUG: 'True'
     PARALLEL_FUZZING: ${{ inputs.parallel-fuzzing }}
     REPORT_TIMEOUTS: ${{ inputs.report-timeouts }}
     REPORT_OOMS: ${{ inputs.report-ooms}}

--- a/.github/actions/run-fuzzers/action.yml
+++ b/.github/actions/run-fuzzers/action.yml
@@ -1,0 +1,97 @@
+# Vendored from https://github.com/google/clusterfuzzlite/blob/40f9a53e632516d2ec9f738eadd284635529fbad/actions/run_fuzzers/action.yml
+
+# action.yml
+name: 'run-fuzzers'
+description: 'Runs fuzz target binaries.'
+inputs:
+  language:
+    description: 'Programming language project is written in.'
+    required: false
+    default: 'c++'
+  fuzz-seconds:
+    description: 'The total time allotted for fuzzing in seconds.'
+    required: true
+    default: 600
+  dry-run:
+    description: 'If set, run the action without actually reporting a failure.'
+    default: false
+  sanitizer:
+    description: 'The sanitizer to run the fuzzers with.'
+    default: 'address'
+  mode:
+    description: |
+      The mode to run the fuzzers with ("code-change", "batch", "coverage", or "prune").
+      "code-change" is for fuzzing a pull request or commit.
+      "batch" is for non-interactive fuzzing of an entire project.
+      "coverage" is for coverage generation.
+      "prune" is for corpus pruning.
+    required: false
+    default: 'code-change'
+  github-token:
+    description: |
+      Token for GitHub API.
+      You should use "secrets.GITHUB_TOKEN" in your workflow file, do not
+      hardcode the token.
+      TODO(https://github.com/google/oss-fuzz/pull/5841#discussion_r639393361):
+      Document locking this down.
+    required: true
+  storage-repo:
+    description: |
+      The git repo to use for storing certain artifacts from fuzzing.
+    required: false
+  storage-repo-branch:
+    description: |
+      The branch of the git repo to use for storing certain artifacts from
+      fuzzing.
+    default: main
+    required: false
+  storage-repo-branch-coverage:
+    description: |
+      The branch of the git repo to use for storing coverage reports.
+    default: gh-pages
+    required: false
+  report-unreproducible-crashes:
+    description: 'If True, then unreproducible crashes will be reported.'
+    required: false
+    default: False
+  minimize-crashes:
+    description: 'If True, reportable crashes will be minimized.'
+    required: false
+    default: False
+  parallel-fuzzing:
+    description: "Whether to use all available cores for fuzzing."
+    required: false
+    default: false
+  output-sarif:
+    description: "Whether to output fuzzing results to SARIF."
+    required: false
+    default: false
+  report-timeouts:
+    description: "Whether to report fails due to timeout."
+    required: false
+    default: true
+  report-ooms:
+    description: "Whether to report fails due to OOM."
+    required: false
+    default: true
+runs:
+  using: 'docker'
+  image: 'docker://gcr.io/oss-fuzz-base/clusterfuzzlite-run-fuzzers:v1'
+  env:
+    FUZZ_SECONDS: ${{ inputs.fuzz-seconds }}
+    MODE: ${{ inputs.mode }}
+    LANGUAGE: ${{ inputs.language }}
+    DRY_RUN: ${{ inputs.dry-run}}
+    SANITIZER: ${{ inputs.sanitizer }}
+    GITHUB_TOKEN: ${{ inputs.github-token }}
+    LOW_DISK_SPACE: 'True'
+    GIT_STORE_REPO: ${{ inputs.storage-repo }}
+    GIT_STORE_BRANCH: ${{ inputs.storage-repo-branch }}
+    GIT_STORE_BRANCH_COVERAGE: ${{ inputs.storage-repo-branch-coverage }}
+    REPORT_UNREPRODUCIBLE_CRASHES: ${{ inputs.report-unreproducible-crashes }}
+    OUTPUT_SARIF: ${{ inputs.output-sarif }}
+    MINIMIZE_CRASHES: ${{ inputs.minimize-crashes }}
+    CFL_PLATFORM: 'github'
+    PARALLEL_FUZZING: ${{ inputs.parallel-fuzzing }}
+    REPORT_TIMEOUTS: ${{ inputs.report-timeouts }}
+    REPORT_OOMS: ${{ inputs.report-ooms}}

--- a/.github/workflows/cflite.yml
+++ b/.github/workflows/cflite.yml
@@ -21,6 +21,7 @@ jobs:
       matrix:
         sanitizer: [address]
     steps:
+      - uses: actions/checkout@v4  # needed to use the modified `run-fuzzers` action
       - name: Build Fuzzers (${{ matrix.sanitizer }})
         id: build
         uses: google/clusterfuzzlite/actions/build_fuzzers@v1
@@ -29,7 +30,7 @@ jobs:
           language: c
       - name: Run Fuzzers (${{ matrix.sanitizer }})
         id: run
-        uses: google/clusterfuzzlite/actions/run_fuzzers@v1
+        uses: ./.github/actions/run-fuzzers
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}
           fuzz-seconds: 400


### PR DESCRIPTION
Works around https://github.com/trezor/trezor-firmware/issues/4967.

Currently, there is no `cifuzz-corpus-fuzzer` to download, so let's make it fail faster :)
```
2025-04-29 08:13:36,609 - root - INFO - Fuzz targets: ['/github/workspace/build-out/fuzzer']
2025-04-29 08:13:36,609 - root - INFO - Running fuzzer: fuzzer.
2025-04-29 08:13:36,609 - root - INFO - Downloading corpus for fuzzer to /github/workspace/cifuzz-corpus/fuzzer.
2025-04-29 09:40:53,108 - root - WARNING - Could not find artifact: cifuzz-corpus-fuzzer.
2025-04-29 09:40:53,108 - root - WARNING - Could not download artifact: cifuzz-corpus-fuzzer.
2025-04-29 09:40:53,109 - root - INFO - Done downloading corpus. Contains 0 elements.
2025-04-29 09:40:53,109 - root - INFO - Starting fuzzing
```

CC: @AdamKorcz 

<!--
For core developers:
- Assign yourself to the PR.
- Set the priority to match the original issue.
- Add the PR to the current sprint.
- If it's a draft PR, mark it as "In Progress."
- If it's a final PR, mark it as "Needs Review."

For external contributors:
- Please open an issue before submitting a PR so we can discuss whether we want to proceed with it.
-->
