### PR TITLE
chore(core): use `systick_us` for `mp_hal_ticks_us`

### DIFF
--- a/core/embed/projects/firmware/mphalport.c
+++ b/core/embed/projects/firmware/mphalport.c
@@ -56,4 +56,4 @@ void mp_hal_delay_us(mp_uint_t usec) { systick_delay_us(usec); }
 
 mp_uint_t mp_hal_ticks_ms(void) { return systick_ms(); }
 
-mp_uint_t mp_hal_ticks_us(void) { return systick_ms() * 1000; }
+mp_uint_t mp_hal_ticks_us(void) { return systick_us(); }


### PR DESCRIPTION
This PR enables microsecond resolution for `mp_hal_ticks_us`.

<!--
For core developers:
- Assign yourself to the PR.
- Set the priority to match the original issue.
- Add the PR to the current sprint.
- If it's a draft PR, mark it as "In Progress."
- If it's a final PR, mark it as "Needs Review."

For external contributors:
- Please open an issue before submitting a PR so we can discuss whether we want to proceed with it.
-->
