### PR TITLE
chore(core): keep `-ffreestanding` only for `SOURCE_MOD_CRYPTO`

### DIFF
--- a/core/SConscript.firmware
+++ b/core/SConscript.firmware
@@ -466,7 +466,6 @@ env.Replace(
     '-nostdlib '
     '-std=gnu11 -Wall -Werror -Wdouble-promotion -Wpointer-arith -Wno-missing-braces -fno-common '
     '-fsingle-precision-constant -fdata-sections -ffunction-sections '
-    '-ffreestanding '
     '-fstack-protector-all '
     +  env.get('ENV')["CPU_CCFLAGS"] + CCFLAGS_MOD,
     CCFLAGS_QSTR='-DNO_QSTR -DN_X64 -DN_X86 -DN_THUMB',
@@ -754,9 +753,9 @@ if FROZEN:
 source_files = SOURCE_MOD + SOURCE_MOD_CRYPTO + SOURCE_FIRMWARE + SOURCE_MICROPYTHON + SOURCE_MICROPYTHON_SPEED + SOURCE_HAL
 obj_program = []
 obj_program.extend(env.Object(source=SOURCE_MOD))
-obj_program.extend(env.Object(source=SOURCE_MOD_CRYPTO, CCFLAGS='$CCFLAGS -ftrivial-auto-var-init=zero'))
+obj_program.extend(env.Object(source=SOURCE_MOD_CRYPTO, CCFLAGS='$CCFLAGS -ftrivial-auto-var-init=zero -ffreestanding'))
 if FEATURE_FLAGS["SECP256K1_ZKP"]:
-    obj_program.extend(env.Object(source=SOURCE_MOD_SECP256K1_ZKP, CCFLAGS='$CCFLAGS -Wno-unused-function'))
+    obj_program.extend(env.Object(source=SOURCE_MOD_SECP256K1_ZKP, CCFLAGS='$CCFLAGS -Wno-unused-function -ffreestanding'))
     source_files.extend(SOURCE_MOD_SECP256K1_ZKP)
 obj_program.extend(env.Object(source=SOURCE_FIRMWARE))
 obj_program.extend(env.Object(source=SOURCE_MICROPYTHON))

--- a/core/embed/projects/firmware/main.c
+++ b/core/embed/projects/firmware/main.c
@@ -44,7 +44,7 @@
 #include "zkp_context.h"
 #endif
 
-int main(uint32_t cmd, void *arg) {
+int main_func(uint32_t cmd, void *arg) {
   if (cmd == 1) {
     systask_postmortem_t *info = (systask_postmortem_t *)arg;
     rsod_gui(info);
@@ -125,7 +125,7 @@ __attribute((no_stack_protector)) void reset_handler(uint32_t cmd, void *arg,
   // Now everything is perfectly initialized and we can do anything
   // in C code
 
-  int main_result = main(cmd, arg);
+  int main_result = main_func(cmd, arg);
 
   system_exit(main_result);
 }


### PR DESCRIPTION
If it is removed from `SOURCE_MOD_CRYPTO`, code size increases by ~0.5 kB on T3B1:

## `-ffreestanding` enabled for `SOURCE_MOD_CRYPTO`:
```
Memory region         Used Size  Region Size  %age Used
           FLASH:     1383936 B      1664 KB     81.22%
        AUX1_RAM:       10272 B     196096 B      5.24%
        AUX2_RAM:        544 KB       544 KB    100.00%
...
    code_length: 1382400        
```
## without `-ffreestanding`:
```
Memory region         Used Size  Region Size  %age Used
           FLASH:       1352 KB      1664 KB     81.25%
        AUX1_RAM:       10268 B     196096 B      5.24%
        AUX2_RAM:        544 KB       544 KB    100.00%
...
    code_length: 1382912
        
```

We need to compile MicroPython without `-ffreestanding` to enable `strcmp` compile-time optimization which is required for https://github.com/trezor/trezor-firmware/pull/4961 (following https://github.com/micropython/micropython/pull/17196#issuecomment-2833593366).

<!--
For core developers:
- Assign yourself to the PR.
- Set the priority to match the original issue.
- Add the PR to the current sprint.
- If it's a draft PR, mark it as "In Progress."
- If it's a final PR, mark it as "Needs Review."

For external contributors:
- Please open an issue before submitting a PR so we can discuss whether we want to proceed with it.
-->
