### PR TITLE
core(rust): format translated strings

### DIFF
--- a/core/embed/rust/src/micropython/buffer.rs
+++ b/core/embed/rust/src/micropython/buffer.rs
@@ -1,4 +1,4 @@
-use core::{convert::TryFrom, ops::Deref, ptr, slice, str};
+use core::{convert::TryFrom, ops::{Deref, Range}, ptr, slice, str};
 
 use crate::{error::Error, micropython::obj::Obj, strutil::hexlify};
 
@@ -102,6 +102,17 @@ impl StrBuffer {
             // given that `off` only advances by as much as `len` decreases, that should not be
             // possible either.
             off: self.off + off,
+        }
+    }
+
+    pub fn get_slice(&self, byte_range: Range<usize>) -> Self {
+        assert!(byte_range.end <= self.len as usize);
+        assert!(self.as_ref().is_char_boundary(byte_range.start));
+        assert!(self.as_ref().is_char_boundary(byte_range.end));
+        Self {
+            ptr: self.ptr,
+            len: (byte_range.end - byte_range.start) as u16,
+            off: byte_range.start as u16 + self.off,
         }
     }
 }

--- a/core/embed/rust/src/ui/component/text/layout.rs
+++ b/core/embed/rust/src/ui/component/text/layout.rs
@@ -453,6 +453,13 @@ impl LayoutFit {
             LayoutFit::OutOfBounds { height, .. } => *height,
         }
     }
+    /// How many characters were processed.
+    pub fn processed_chars(&self) -> usize {
+        match self {
+            LayoutFit::Fitting { processed_chars, .. } => *processed_chars,
+            LayoutFit::OutOfBounds { processed_chars, .. } => *processed_chars,
+        }
+    }
 }
 
 /// Visitor for text segment operations.
@@ -586,7 +593,15 @@ pub mod trace {
             self.0.string(&"\n".into());
         }
     }
+
+    // impl TraceSink<'_> {
+    //     pub fn new(tracer: &mut dyn ListTracer) -> Self {
+    //         Self(&mut <dyn ListTracer>::new(tracer))
+    //     }
+    // }
 }
+
+
 
 /// Carries info about the content that was processed
 /// on the current line.


### PR DESCRIPTION
For Issue: #4338 
These changes add a new `Op` to `OpTextLayout` called `text_formatted` that accepts a template string and a vector of arguments as a function. Related function needed to be added to `StringBuffer` and `TranslatedStrings`. The later now has an `end_at` attribute for slicing.
