### PR TITLE
ci(core): update hardware CI tests

### DIFF
--- a/.github/workflows/core-hw.yml
+++ b/.github/workflows/core-hw.yml
@@ -38,7 +38,8 @@ jobs:
       DISABLE_OPTIGA: 1
       STORAGE_INSECURE_TESTING_MODE: 1
       BOOTLOADER_DEVEL: ${{ matrix.model == 'T2B1' && '1' || '0' }}
-      TESTOPTS: "-k 'not authenticate and not recovery and not lots' --durations=50 --session-timeout 19800"  # 5.5h pytest global timeout
+      # TODO: enable SD-related tests after fixing #4924
+      TESTOPTS: "-m 'not sd_card' -k 'not authenticate' --durations=50 --session-timeout 19800"  # 5.5h pytest global timeout
       TT_UHUB_PORT: 1
     timeout-minutes: 360  # 6h CI job timeout
     steps:


### PR DESCRIPTION
Tested on T2T1:

```
$ pytest -v tests/device_tests/ -k lots --durations 0
...
==================================================================== slowest durations ====================================================================
309.73s call     tests/device_tests/bitcoin/test_signtx.py::test_lots_of_inputs
61.37s call     tests/device_tests/bitcoin/test_signtx.py::test_lots_of_outputs
5.73s setup    tests/device_tests/bitcoin/test_signtx.py::test_lots_of_change
5.03s call     tests/device_tests/bitcoin/test_signtx.py::test_lots_of_change
4.10s setup    tests/device_tests/bitcoin/test_signtx.py::test_lots_of_outputs
4.09s setup    tests/device_tests/bitcoin/test_signtx.py::test_lots_of_inputs
...
===================================================== 3 passed, 1588 deselected in 390.63s (0:06:30) ======================================================
```

```
$ pytest -v tests/device_tests/ -k recovery --durations 0
...
==================================================================== slowest durations ====================================================================
191.90s call     tests/device_tests/reset_recovery/test_reset_recovery_slip39_advanced.py::test_reset_recovery
116.65s call     tests/device_tests/reset_recovery/test_reset_recovery_slip39_basic.py::test_reset_recovery
24.95s call     tests/device_tests/reset_recovery/test_reset_backup.py::test_skip_backup_manual[BackupType.Slip39_Advanced_Extendable-backup_flow_slip39_advanced]
24.74s call     tests/device_tests/reset_recovery/test_reset_backup.py::test_skip_backup_msg[BackupType.Slip39_Advanced_Extendable-backup_flow_slip39_advanced]
23.49s call     tests/device_tests/reset_recovery/test_reset_slip39_advanced.py::test_reset_device_slip39_advanced
18.58s call     tests/device_tests/reset_recovery/test_recovery_slip39_advanced_dryrun.py::test_2of3_dryrun
17.13s call     tests/device_tests/reset_recovery/test_recovery_slip39_advanced.py::test_noabort
16.74s call     tests/device_tests/reset_recovery/test_recovery_slip39_advanced.py::test_extra_share_entered
14.05s call     tests/device_tests/reset_recovery/test_recovery_slip39_advanced.py::test_secret_click_info_button[shares0-c2d2e26ad06023c60145f150abe2dd2b]
13.84s call     tests/device_tests/reset_recovery/test_reset_slip39_basic.py::test_reset_entropy_check
13.13s call     tests/device_tests/reset_recovery/test_recovery_slip39_advanced.py::test_secret[shares0-c2d2e26ad06023c60145f150abe2dd2b]
12.74s call     tests/device_tests/reset_recovery/test_recovery_slip39_advanced_dryrun.py::test_2of3_invalid_seed_dryrun
9.42s call     tests/device_tests/reset_recovery/test_recovery_slip39_advanced.py::test_secret_click_info_button[shares1-c41d5cf80fed71a008a3a0ae0458ff0c6d621b1a5522bccbfedbcfad87005c06]
9.13s call     tests/device_tests/reset_recovery/test_recovery_slip39_advanced.py::test_secret[shares1-c41d5cf80fed71a008a3a0ae0458ff0c6d621b1a5522bccbfedbcfad87005c06]
8.48s call     tests/device_tests/reset_recovery/test_reset_slip39_basic.py::test_reset_device_slip39_basic_256
7.91s call     tests/device_tests/reset_recovery/test_reset_recovery_bip39.py::test_reset_recovery
7.68s call     tests/device_tests/reset_recovery/test_recovery_slip39_basic.py::test_noabort
...
========================================= 61 passed, 15 skipped, 1515 deselected, 1 warning in 885.84s (0:14:45) ==========================================
```


<!--
For core developers:
- Assign yourself to the PR.
- Set the priority to match the original issue.
- Add the PR to the current sprint.
- If it's a draft PR, mark it as "In Progress."
- If it's a final PR, mark it as "Needs Review."

For external contributors:
- Please open an issue before submitting a PR so we can discuss whether we want to proceed with it.
-->
