### PR TITLE
DO NOT MERGE - Review only - Handling instruction grammar outside of device

### DIFF
--- a/core/embed/rust/src/micropython/buffer.rs
+++ b/core/embed/rust/src/micropython/buffer.rs
@@ -1,4 +1,4 @@
-use core::{convert::TryFrom, ops::Deref, ptr, slice, str};
+use core::{convert::TryFrom, ops::{Deref, Range}, ptr, slice, str};
 
 use crate::{error::Error, micropython::obj::Obj, strutil::hexlify};
 
@@ -102,6 +102,17 @@ impl StrBuffer {
             // given that `off` only advances by as much as `len` decreases, that should not be
             // possible either.
             off: self.off + off,
+        }
+    }
+
+    pub fn get_slice(&self, byte_range: Range<usize>) -> Self {
+        assert!(byte_range.end <= self.len as usize);
+        assert!(self.as_ref().is_char_boundary(byte_range.start));
+        assert!(self.as_ref().is_char_boundary(byte_range.end));
+        Self {
+            ptr: self.ptr,
+            len: (byte_range.end - byte_range.start) as u16,
+            off: byte_range.start as u16 + self.off,
         }
     }
 }

--- a/core/embed/rust/src/ui/component/text/layout.rs
+++ b/core/embed/rust/src/ui/component/text/layout.rs
@@ -453,6 +453,13 @@ impl LayoutFit {
             LayoutFit::OutOfBounds { height, .. } => *height,
         }
     }
+    /// How many characters were processed.
+    pub fn processed_chars(&self) -> usize {
+        match self {
+            LayoutFit::Fitting { processed_chars, .. } => *processed_chars,
+            LayoutFit::OutOfBounds { processed_chars, .. } => *processed_chars,
+        }
+    }
 }
 
 /// Visitor for text segment operations.
@@ -586,7 +593,15 @@ pub mod trace {
             self.0.string(&"\n".into());
         }
     }
+
+    // impl TraceSink<'_> {
+    //     pub fn new(tracer: &mut dyn ListTracer) -> Self {
+    //         Self(&mut <dyn ListTracer>::new(tracer))
+    //     }
+    // }
 }
+
+
 
 /// Carries info about the content that was processed
 /// on the current line.

--- a/core/src/trezor/messages.py
+++ b/core/src/trezor/messages.py
@@ -5511,12 +5511,14 @@ if TYPE_CHECKING:
     class SolanaTxAdditionalInfo(protobuf.MessageType):
         token_accounts_infos: "list[SolanaTxTokenAccountInfo]"
         encoded_token: "bytes | None"
+        instruction: "SolanaInstruction | None"
 
         def __init__(
             self,
             *,
             token_accounts_infos: "list[SolanaTxTokenAccountInfo] | None" = None,
             encoded_token: "bytes | None" = None,
+            instruction: "SolanaInstruction | None" = None,
         ) -> None:
             pass
 
@@ -5554,6 +5556,88 @@ if TYPE_CHECKING:
 
         @classmethod
         def is_type_of(cls, msg: Any) -> TypeGuard["SolanaTxSignature"]:
+            return isinstance(msg, cls)
+
+    class SolanaInstruction(protobuf.MessageType):
+        id: "int"
+        name: "str"
+        is_multisig: "bool | None"
+        is_ui_hidden: "bool | None"
+        is_deprecated_warning: "bool | None"
+        parameters: "list[Parameter]"
+        references: "list[str]"
+        ui_properties: "list[UIProperty]"
+
+        def __init__(
+            self,
+            *,
+            id: "int",
+            name: "str",
+            parameters: "list[Parameter] | None" = None,
+            references: "list[str] | None" = None,
+            ui_properties: "list[UIProperty] | None" = None,
+            is_multisig: "bool | None" = None,
+            is_ui_hidden: "bool | None" = None,
+            is_deprecated_warning: "bool | None" = None,
+        ) -> None:
+            pass
+
+        @classmethod
+        def is_type_of(cls, msg: Any) -> TypeGuard["SolanaInstruction"]:
+            return isinstance(msg, cls)
+
+    class Parameter(protobuf.MessageType):
+        name: "str"
+        type: "str"
+        is_optional: "bool | None"
+
+        def __init__(
+            self,
+            *,
+            name: "str",
+            type: "str",
+            is_optional: "bool | None" = None,
+        ) -> None:
+            pass
+
+        @classmethod
+        def is_type_of(cls, msg: Any) -> TypeGuard["Parameter"]:
+            return isinstance(msg, cls)
+
+    class UIProperty(protobuf.MessageType):
+        account: "str | None"
+        parameter: "str | None"
+        display_name: "str"
+        default_value_to_hide: "str | None"
+
+        def __init__(
+            self,
+            *,
+            display_name: "str",
+            account: "str | None" = None,
+            parameter: "str | None" = None,
+            default_value_to_hide: "str | None" = None,
+        ) -> None:
+            pass
+
+        @classmethod
+        def is_type_of(cls, msg: Any) -> TypeGuard["UIProperty"]:
+            return isinstance(msg, cls)
+
+    class SolanaInstructionAck(protobuf.MessageType):
+        success: "bool"
+        error: "str | None"
+
+        def __init__(
+            self,
+            *,
+            success: "bool",
+            error: "str | None" = None,
+        ) -> None:
+            pass
+
+        @classmethod
+        def is_type_of(cls, msg: Any) -> TypeGuard["SolanaInstructionAck"]:
             return isinstance(msg, cls)
 
     class StellarAsset(protobuf.MessageType):

--- a/python/src/trezorlib/messages.py
+++ b/python/src/trezorlib/messages.py
@@ -7105,6 +7105,7 @@ class SolanaTxAdditionalInfo(protobuf.MessageType):
     FIELDS = {
         1: protobuf.Field("token_accounts_infos", "SolanaTxTokenAccountInfo", repeated=True, required=False, default=None),
         2: protobuf.Field("encoded_token", "bytes", repeated=False, required=False, default=None),
+        3: protobuf.Field("instruction", "SolanaInstruction", repeated=False, required=False, default=None),
     }
 
     def __init__(
@@ -7112,9 +7113,11 @@ class SolanaTxAdditionalInfo(protobuf.MessageType):
         *,
         token_accounts_infos: Optional[Sequence["SolanaTxTokenAccountInfo"]] = None,
         encoded_token: Optional["bytes"] = None,
+        instruction: Optional["SolanaInstruction"] = None,
     ) -> None:
         self.token_accounts_infos: Sequence["SolanaTxTokenAccountInfo"] = token_accounts_infos if token_accounts_infos is not None else []
         self.encoded_token = encoded_token
+        self.instruction = instruction
 
 
 class SolanaSignTx(protobuf.MessageType):
@@ -7149,6 +7152,101 @@ class SolanaTxSignature(protobuf.MessageType):
         signature: "bytes",
     ) -> None:
         self.signature = signature
+
+
+class SolanaInstruction(protobuf.MessageType):
+    MESSAGE_WIRE_TYPE = None
+    FIELDS = {
+        1: protobuf.Field("id", "uint32", repeated=False, required=True),
+        2: protobuf.Field("name", "string", repeated=False, required=True),
+        3: protobuf.Field("is_multisig", "bool", repeated=False, required=False, default=None),
+        4: protobuf.Field("is_ui_hidden", "bool", repeated=False, required=False, default=None),
+        5: protobuf.Field("is_deprecated_warning", "bool", repeated=False, required=False, default=None),
+        6: protobuf.Field("parameters", "Parameter", repeated=True, required=False, default=None),
+        7: protobuf.Field("references", "string", repeated=True, required=False, default=None),
+        8: protobuf.Field("ui_properties", "UIProperty", repeated=True, required=False, default=None),
+    }
+
+    def __init__(
+        self,
+        *,
+        id: "int",
+        name: "str",
+        parameters: Optional[Sequence["Parameter"]] = None,
+        references: Optional[Sequence["str"]] = None,
+        ui_properties: Optional[Sequence["UIProperty"]] = None,
+        is_multisig: Optional["bool"] = None,
+        is_ui_hidden: Optional["bool"] = None,
+        is_deprecated_warning: Optional["bool"] = None,
+    ) -> None:
+        self.parameters: Sequence["Parameter"] = parameters if parameters is not None else []
+        self.references: Sequence["str"] = references if references is not None else []
+        self.ui_properties: Sequence["UIProperty"] = ui_properties if ui_properties is not None else []
+        self.id = id
+        self.name = name
+        self.is_multisig = is_multisig
+        self.is_ui_hidden = is_ui_hidden
+        self.is_deprecated_warning = is_deprecated_warning
+
+
+class Parameter(protobuf.MessageType):
+    MESSAGE_WIRE_TYPE = None
+    FIELDS = {
+        1: protobuf.Field("name", "string", repeated=False, required=True),
+        2: protobuf.Field("type", "string", repeated=False, required=True),
+        3: protobuf.Field("is_optional", "bool", repeated=False, required=False, default=None),
+    }
+
+    def __init__(
+        self,
+        *,
+        name: "str",
+        type: "str",
+        is_optional: Optional["bool"] = None,
+    ) -> None:
+        self.name = name
+        self.type = type
+        self.is_optional = is_optional
+
+
+class UIProperty(protobuf.MessageType):
+    MESSAGE_WIRE_TYPE = None
+    FIELDS = {
+        1: protobuf.Field("account", "string", repeated=False, required=False, default=None),
+        2: protobuf.Field("parameter", "string", repeated=False, required=False, default=None),
+        3: protobuf.Field("display_name", "string", repeated=False, required=True),
+        4: protobuf.Field("default_value_to_hide", "string", repeated=False, required=False, default=None),
+    }
+
+    def __init__(
+        self,
+        *,
+        display_name: "str",
+        account: Optional["str"] = None,
+        parameter: Optional["str"] = None,
+        default_value_to_hide: Optional["str"] = None,
+    ) -> None:
+        self.display_name = display_name
+        self.account = account
+        self.parameter = parameter
+        self.default_value_to_hide = default_value_to_hide
+
+
+class SolanaInstructionAck(protobuf.MessageType):
+    MESSAGE_WIRE_TYPE = None
+    FIELDS = {
+        1: protobuf.Field("success", "bool", repeated=False, required=True),
+        2: protobuf.Field("error", "string", repeated=False, required=False, default=None),
+    }
+
+    def __init__(
+        self,
+        *,
+        success: "bool",
+        error: Optional["str"] = None,
+    ) -> None:
+        self.success = success
+        self.error = error
 
 
 class StellarAsset(protobuf.MessageType):


### PR DESCRIPTION
Raising PR instead of an issue to summarise initial code changes required to handle the Solana instruction parsing outside of the wallet. Currently the instruction schema is a big cost on the flash space. The idea here is to send the instruction schema along with the transaction to save on storage.

We introduce an initial draft of a message definition that will be used to send the instruction. And subsequent code changes that this endeavour might ensue.

TODOs in the relevant files (*.py. *.rs are incorrectly included from another PR) highlight the main changes required.
`sign_tx.py` -> instructions are as an embedded message in the additional info section of the transaction. The `Transaction` class needs to be dated in favour of the message generated SolanaInstruction class. `get_single_instruction()` was just being drafted for demo testing.

`layout.py` -> Needs a PropertyTemplate file for now to start with. 
