### PR TITLE
ci(core): run click UI tests in parallel

### DIFF
--- a/.github/actions/ui-report/action.yml
+++ b/.github/actions/ui-report/action.yml
@@ -20,7 +20,7 @@ runs:
         role-to-assume: arn:aws:iam::538326561891:role/gh_actions_deploy_dev_firmware_data
         aws-region: eu-west-1
     - name: Increase AWS S3 max concurrency for faster uploads
-      run: aws configure set default.s3.max_concurrent_requests 30
+      run: aws configure set default.s3.max_concurrent_requests 50
       shell: sh
     - run: |
         MODELJOB=${{ inputs.model }}-${{ inputs.lang }}-${{ github.job }}
@@ -39,15 +39,22 @@ runs:
           cp .github/actions/ui-report/failure.png $OUTDIR/status.png
         fi
       shell: sh
-    - name: Upload report
+    - name: Upload test results
       run: |
-        aws s3 sync --only-show-errors ${{ github.run_id }} s3://data.trezor.io/dev/firmware/ui_report/${{ github.run_id }}
-        echo "[UI test report](https://data.trezor.io/dev/firmware/ui_report/${{ github.run_id }}/${{ inputs.model }}-${{ inputs.lang }}-${{ github.job }}/index.html)" >> $GITHUB_STEP_SUMMARY
-      shell: sh
-    - name: Upload test screen recording
-      run: |
-        aws s3 sync --only-show-errors ci/ui_test_records s3://data.trezor.io/dev/firmware/ui_tests
+        # Upload report
+        aws s3 cp --recursive --only-show-errors ${{ github.run_id }} s3://data.trezor.io/dev/firmware/ui_report/${{ github.run_id }} &
+        PID1=$!
+
+        # Upload test screen recording
+        aws s3 sync --only-show-errors ci/ui_test_records s3://data.trezor.io/dev/firmware/ui_tests &
+        PID2=$!
         # TODO: generate directory listing / autoindex
+
+        # Wait for the above sync jobs to finish (fail if one of them fails)
+        wait $PID1
+        wait $PID2
+
+        echo "[UI test report](https://data.trezor.io/dev/firmware/ui_report/${{ github.run_id }}/${{ inputs.model }}-${{ inputs.lang }}-${{ github.job }}/index.html)" >> $GITHUB_STEP_SUMMARY
       shell: sh
     - uses: actions/upload-artifact@v4
       with:

--- a/.github/actions/ui-report/action.yml
+++ b/.github/actions/ui-report/action.yml
@@ -19,6 +19,9 @@ runs:
       with:
         role-to-assume: arn:aws:iam::538326561891:role/gh_actions_deploy_dev_firmware_data
         aws-region: eu-west-1
+    - name: Increase AWS S3 max concurrency for faster uploads
+      run: aws configure set default.s3.max_concurrent_requests 30
+      shell: sh
     - run: |
         MODELJOB=${{ inputs.model }}-${{ inputs.lang }}-${{ github.job }}
         OUTDIR=${{ github.run_id }}/$MODELJOB

--- a/.github/workflows/core.yml
+++ b/.github/workflows/core.yml
@@ -339,7 +339,7 @@ jobs:
           path: core/build
       - run: chmod +x core/build/unix/trezor-emu-core*
       - uses: ./.github/actions/environment
-      - run: nix-shell --run "poetry run make -C core test_emu_click_ui"
+      - run: nix-shell --run "poetry run make -C core test_emu_click_ui_multicore"
         if: ${{ matrix.asan == 'noasan' }}
       - run: nix-shell --run "poetry run make -C core test_emu_click"
         if: ${{ matrix.asan == 'asan' }}

--- a/core/Makefile
+++ b/core/Makefile
@@ -205,6 +205,11 @@ test_emu_click_ui: ## run click tests with UI testing
 	$(EMU_TEST) $(PYTEST) $(TESTPATH)/click_tests $(TESTOPTS) \
 		--ui=test --ui-check-missing --do-master-diff --lang=$(TEST_LANG)
 
+test_emu_click_ui_multicore: ## run click tests with UI testing using multiple cores
+	$(PYTEST) -n $(MULTICORE) $(TESTPATH)/click_tests $(TESTOPTS) --timeout $(PYTEST_TIMEOUT) \
+		--ui=test --ui-check-missing --do-master-diff --lang=$(TEST_LANG) \
+		--control-emulators --model=core --random-order-seed=$(RANDOM)
+
 test_emu_persistence: ## run persistence tests
 	$(PYTEST) $(TESTPATH)/persistence_tests $(TESTOPTS) --lang=$(TEST_LANG)
 


### PR DESCRIPTION
Currently, running T3B1 click tests using a single worker take ~6.5 minutes:

![image](https://github.com/user-attachments/assets/a5745661-e7d1-4926-ade0-e319f06f894d)

Also, increase UI results' uploading concurrency, reducing upload results' duration by ~2x ([before](https://github.com/trezor/trezor-firmware/actions/runs/14954453993/job/42008339784), [after](https://github.com/trezor/trezor-firmware/actions/runs/14974386229/job/42063337230?pr=5028))

<!--
For core developers:
- Assign yourself to the PR.
- Set the priority to match the original issue.
- Add the PR to the current sprint.
- If it's a draft PR, mark it as "In Progress."
- If it's a final PR, mark it as "Needs Review."

For external contributors:
- Please open an issue before submitting a PR so we can discuss whether we want to proceed with it.
-->
