### PR TITLE
ci(core): increase S3 upload concurrency for `ui-report` action

### DIFF
--- a/.github/actions/ui-report/action.yml
+++ b/.github/actions/ui-report/action.yml
@@ -19,6 +19,9 @@ runs:
       with:
         role-to-assume: arn:aws:iam::538326561891:role/gh_actions_deploy_dev_firmware_data
         aws-region: eu-west-1
+    - name: Increase AWS S3 max concurrency for faster uploads
+      run: aws configure set default.s3.max_concurrent_requests 30
+      shell: sh
     - run: |
         MODELJOB=${{ inputs.model }}-${{ inputs.lang }}-${{ github.job }}
         OUTDIR=${{ github.run_id }}/$MODELJOB


### PR DESCRIPTION
Before this PR, it takes ~7m to upload click UI tests' results:
![image](https://github.com/user-attachments/assets/ab070c31-649b-441b-a67b-b2a6a5570ef1)


<!--
For core developers:
- Assign yourself to the PR.
- Set the priority to match the original issue.
- Add the PR to the current sprint.
- If it's a draft PR, mark it as "In Progress."
- If it's a final PR, mark it as "Needs Review."

For external contributors:
- Please open an issue before submitting a PR so we can discuss whether we want to proceed with it.
-->
