### PR TITLE
refactor(storage): simplify storage api

### DIFF
--- a/core/embed/rust/build.rs
+++ b/core/embed/rust/build.rs
@@ -328,6 +328,7 @@ fn generate_trezorhal_bindings() {
         .allowlist_function("flash_init")
         // storage
         .allowlist_var("EXTERNAL_SALT_SIZE")
+        .allowlist_type("storage_pin_t")
         .allowlist_function("storage_init")
         .allowlist_function("storage_wipe")
         .allowlist_function("storage_is_unlocked")

--- a/core/embed/sys/syscall/stm32/syscall_dispatch.c
+++ b/core/embed/sys/syscall/stm32/syscall_dispatch.c
@@ -541,11 +541,10 @@ __attribute((no_stack_protector)) void syscall_handler(uint32_t *args,
     } break;
 
     case SYSCALL_STORAGE_UNLOCK: {
-      const uint8_t *pin = (const uint8_t *)args[0];
-      size_t pin_len = args[1];
-      const uint8_t *ext_salt = (const uint8_t *)args[2];
+      const storage_pin_t *pin = (const storage_pin_t *)args[0];
+      const uint8_t *ext_salt = (const uint8_t *)args[1];
       mpu_reconfig(MPU_MODE_STORAGE);
-      args[0] = storage_unlock__verified(pin, pin_len, ext_salt);
+      args[0] = storage_unlock__verified(pin, ext_salt);
     } break;
 
     case SYSCALL_STORAGE_HAS_PIN: {
@@ -564,22 +563,19 @@ __attribute((no_stack_protector)) void syscall_handler(uint32_t *args,
     } break;
 
     case SYSCALL_STORAGE_CHANGE_PIN: {
-      const uint8_t *oldpin = (const uint8_t *)args[0];
-      size_t oldpin_len = args[1];
-      const uint8_t *newpin = (const uint8_t *)args[2];
-      size_t newpin_len = args[3];
-      const uint8_t *old_ext_salt = (const uint8_t *)args[4];
-      const uint8_t *new_ext_salt = (const uint8_t *)args[5];
+      const storage_pin_t *oldpin = (const storage_pin_t *)args[0];
+      const storage_pin_t *newpin = (const storage_pin_t *)args[1];
+      const uint8_t *old_ext_salt = (const uint8_t *)args[2];
+      const uint8_t *new_ext_salt = (const uint8_t *)args[3];
       mpu_reconfig(MPU_MODE_STORAGE);
-      args[0] = storage_change_pin__verified(
-          oldpin, oldpin_len, newpin, newpin_len, old_ext_salt, new_ext_salt);
+      args[0] = storage_change_pin__verified(oldpin, newpin, old_ext_salt,
+                                             new_ext_salt);
     } break;
 
     case SYSCALL_STORAGE_ENSURE_NOT_WIPE_CODE: {
-      const uint8_t *pin = (const uint8_t *)args[0];
-      size_t pin_len = args[1];
+      const storage_pin_t *pin = (const storage_pin_t *)args[0];
       mpu_reconfig(MPU_MODE_STORAGE);
-      storage_ensure_not_wipe_code__verified(pin, pin_len);
+      storage_ensure_not_wipe_code__verified(pin);
     } break;
 
     case SYSCALL_STORAGE_HAS_WIPE_CODE: {
@@ -588,14 +584,11 @@ __attribute((no_stack_protector)) void syscall_handler(uint32_t *args,
     } break;
 
     case SYSCALL_STORAGE_CHANGE_WIPE_CODE: {
-      const uint8_t *pin = (const uint8_t *)args[0];
-      size_t pin_len = args[1];
-      const uint8_t *ext_salt = (const uint8_t *)args[2];
-      const uint8_t *wipe_code = (const uint8_t *)args[3];
-      size_t wipe_code_len = args[4];
+      const storage_pin_t *pin = (const storage_pin_t *)args[0];
+      const uint8_t *ext_salt = (const uint8_t *)args[1];
+      const storage_pin_t *wipe_code = (const storage_pin_t *)args[2];
       mpu_reconfig(MPU_MODE_STORAGE);
-      args[0] = storage_change_wipe_code__verified(pin, pin_len, ext_salt,
-                                                   wipe_code, wipe_code_len);
+      args[0] = storage_change_wipe_code__verified(pin, ext_salt, wipe_code);
     } break;
 
     case SYSCALL_STORAGE_HAS: {

--- a/core/embed/sys/syscall/stm32/syscall_stubs.c
+++ b/core/embed/sys/syscall/stm32/syscall_stubs.c
@@ -511,9 +511,8 @@ secbool storage_is_unlocked(void) {
 
 void storage_lock(void) { syscall_invoke0(SYSCALL_STORAGE_LOCK); }
 
-secbool storage_unlock(const uint8_t *pin, size_t pin_len,
-                       const uint8_t *ext_salt) {
-  return (secbool)syscall_invoke3((uint32_t)pin, pin_len, (uint32_t)ext_salt,
+secbool storage_unlock(const storage_pin_t *pin, const uint8_t *ext_salt) {
+  return (secbool)syscall_invoke2((uint32_t)pin, (uint32_t)ext_salt,
                                   SYSCALL_STORAGE_UNLOCK);
 }
 
@@ -528,30 +527,28 @@ uint32_t storage_get_pin_rem(void) {
   return syscall_invoke0(SYSCALL_STORAGE_GET_PIN_REM);
 }
 
-secbool storage_change_pin(const uint8_t *oldpin, size_t oldpin_len,
-                           const uint8_t *newpin, size_t newpin_len,
+secbool storage_change_pin(const storage_pin_t *oldpin,
+                           const storage_pin_t *newpin,
                            const uint8_t *old_ext_salt,
                            const uint8_t *new_ext_salt) {
-  return (secbool)syscall_invoke6(
-      (uint32_t)oldpin, oldpin_len, (uint32_t)newpin, newpin_len,
-      (uint32_t)old_ext_salt, (uint32_t)new_ext_salt,
-      SYSCALL_STORAGE_CHANGE_PIN);
+  return (secbool)syscall_invoke4(
+      (uint32_t)oldpin, (uint32_t)newpin, (uint32_t)old_ext_salt,
+      (uint32_t)new_ext_salt, SYSCALL_STORAGE_CHANGE_PIN);
 }
 
-void storage_ensure_not_wipe_code(const uint8_t *pin, size_t pin_len) {
-  syscall_invoke2((uint32_t)pin, pin_len, SYSCALL_STORAGE_ENSURE_NOT_WIPE_CODE);
+void storage_ensure_not_wipe_code(const storage_pin_t *pin) {
+  syscall_invoke1((uint32_t)pin, SYSCALL_STORAGE_ENSURE_NOT_WIPE_CODE);
 }
 
 secbool storage_has_wipe_code(void) {
   return (secbool)syscall_invoke0(SYSCALL_STORAGE_HAS_WIPE_CODE);
 }
 
-secbool storage_change_wipe_code(const uint8_t *pin, size_t pin_len,
+secbool storage_change_wipe_code(const storage_pin_t *pin,
                                  const uint8_t *ext_salt,
-                                 const uint8_t *wipe_code,
-                                 size_t wipe_code_len) {
-  return (secbool)syscall_invoke5((uint32_t)pin, pin_len, (uint32_t)ext_salt,
-                                  (uint32_t)wipe_code, wipe_code_len,
+                                 const storage_pin_t *wipe_code) {
+  return (secbool)syscall_invoke3((uint32_t)pin, (uint32_t)ext_salt,
+                                  (uint32_t)wipe_code,
                                   SYSCALL_STORAGE_CHANGE_WIPE_CODE);
 }
 

--- a/core/embed/sys/syscall/stm32/syscall_verifiers.h
+++ b/core/embed/sys/syscall/stm32/syscall_verifiers.h
@@ -144,20 +144,19 @@ bool __wur optiga_random_buffer__verified(uint8_t *dest, size_t size);
 void storage_init__verified(PIN_UI_WAIT_CALLBACK callback, const uint8_t *salt,
                             const uint16_t salt_len);
 
-secbool storage_unlock__verified(const uint8_t *pin, size_t pin_len,
+secbool storage_unlock__verified(const storage_pin_t *pin,
                                  const uint8_t *ext_salt);
 
-secbool storage_change_pin__verified(const uint8_t *oldpin, size_t oldpin_len,
-                                     const uint8_t *newpin, size_t newpin_len,
+secbool storage_change_pin__verified(const storage_pin_t *oldpin,
+                                     const storage_pin_t *newpin,
                                      const uint8_t *old_ext_salt,
                                      const uint8_t *new_ext_salt);
 
-void storage_ensure_not_wipe_code__verified(const uint8_t *pin, size_t pin_len);
+void storage_ensure_not_wipe_code__verified(const storage_pin_t *pin);
 
-secbool storage_change_wipe_code__verified(const uint8_t *pin, size_t pin_len,
+secbool storage_change_wipe_code__verified(const storage_pin_t *pin,
                                            const uint8_t *ext_salt,
-                                           const uint8_t *wipe_code,
-                                           size_t wipe_code_len);
+                                           const storage_pin_t *wipe_code);
 
 secbool storage_get__verified(const uint16_t key, void *val,
                               const uint16_t max_len, uint16_t *len);

--- a/core/embed/upymod/modtrezorconfig/modtrezorconfig.c
+++ b/core/embed/upymod/modtrezorconfig/modtrezorconfig.c
@@ -86,8 +86,12 @@ STATIC mp_obj_t mod_trezorconfig_unlock(mp_obj_t pin, mp_obj_t ext_salt) {
     if (ext_salt_b.len != EXTERNAL_SALT_SIZE)
       mp_raise_msg(&mp_type_ValueError, "Invalid length of external salt.");
   }
+  const storage_pin_t _pin = {
+      .text = pin_b.buf,
+      .len = pin_b.len,
+  };
 
-  if (sectrue != storage_unlock(pin_b.buf, pin_b.len, ext_salt_b.buf)) {
+  if (sectrue != storage_unlock(&_pin, ext_salt_b.buf)) {
     return mp_const_false;
   }
   return mp_const_true;
@@ -186,8 +190,17 @@ STATIC mp_obj_t mod_trezorconfig_change_pin(size_t n_args,
     new_ext_salt = ext_salt_b.buf;
   }
 
-  if (sectrue != storage_change_pin(oldpin.buf, oldpin.len, newpin.buf,
-                                    newpin.len, old_ext_salt, new_ext_salt)) {
+  storage_pin_t _oldpin = {
+      .text = oldpin.buf,
+      .len = oldpin.len,
+  };
+  storage_pin_t _newpin = {
+      .text = newpin.buf,
+      .len = newpin.len,
+  };
+
+  if (sectrue !=
+      storage_change_pin(&_oldpin, &_newpin, old_ext_salt, new_ext_salt)) {
     return mp_const_false;
   }
   return mp_const_true;
@@ -202,7 +215,11 @@ STATIC MP_DEFINE_CONST_FUN_OBJ_VAR_BETWEEN(mod_trezorconfig_change_pin_obj, 4,
 STATIC mp_obj_t mod_trezorconfig_ensure_not_wipe_code(mp_obj_t pin) {
   mp_buffer_info_t pin_b = {0};
   mp_get_buffer_raise(pin, &pin_b, MP_BUFFER_READ);
-  storage_ensure_not_wipe_code(pin_b.buf, pin_b.len);
+  const storage_pin_t _pin = {
+      .text = pin_b.buf,
+      .len = pin_b.len,
+  };
+  storage_ensure_not_wipe_code(&_pin);
   return mp_const_none;
 }
 STATIC MP_DEFINE_CONST_FUN_OBJ_1(mod_trezorconfig_ensure_not_wipe_code_obj,
@@ -246,8 +263,17 @@ STATIC mp_obj_t mod_trezorconfig_change_wipe_code(size_t n_args,
     ext_salt = ext_salt_b.buf;
   }
 
-  if (sectrue != storage_change_wipe_code(pin_b.buf, pin_b.len, ext_salt,
-                                          wipe_code_b.buf, wipe_code_b.len)) {
+  storage_pin_t pin = {
+      .text = pin_b.buf,
+      .len = pin_b.len,
+  };
+
+  storage_pin_t wipe_code = {
+      .text = wipe_code_b.buf,
+      .len = wipe_code_b.len,
+  };
+
+  if (sectrue != storage_change_wipe_code(&pin, ext_salt, &wipe_code)) {
     return mp_const_false;
   }
   return mp_const_true;

--- a/storage/storage.h
+++ b/storage/storage.h
@@ -67,6 +67,11 @@ typedef enum {
   STORAGE_PIN_OP_CHANGE,
 } storage_pin_op_t;
 
+typedef struct {
+  const uint8_t *text;
+  size_t len;
+} storage_pin_t;
+
 typedef secbool (*PIN_UI_WAIT_CALLBACK)(uint32_t wait, uint32_t progress,
                                         enum storage_ui_message_t message);
 
@@ -75,21 +80,19 @@ void storage_init(PIN_UI_WAIT_CALLBACK callback, const uint8_t *salt,
 void storage_wipe(void);
 secbool storage_is_unlocked(void);
 void storage_lock(void);
-secbool storage_unlock(const uint8_t *pin, size_t pin_len,
-                       const uint8_t *ext_salt);
+secbool storage_unlock(const storage_pin_t *pin, const uint8_t *ext_salt);
 secbool storage_has_pin(void);
 secbool storage_pin_fails_increase(void);
 uint32_t storage_get_pin_rem(void);
-secbool storage_change_pin(const uint8_t *oldpin, size_t oldpin_len,
-                           const uint8_t *newpin, size_t newpin_len,
+secbool storage_change_pin(const storage_pin_t *oldpin,
+                           const storage_pin_t *newpin,
                            const uint8_t *old_ext_salt,
                            const uint8_t *new_ext_salt);
-void storage_ensure_not_wipe_code(const uint8_t *pin, size_t pin_len);
+void storage_ensure_not_wipe_code(const storage_pin_t *pin);
 secbool storage_has_wipe_code(void);
-secbool storage_change_wipe_code(const uint8_t *pin, size_t pin_len,
+secbool storage_change_wipe_code(const storage_pin_t *pin,
                                  const uint8_t *ext_salt,
-                                 const uint8_t *wipe_code,
-                                 size_t wipe_code_len);
+                                 const storage_pin_t *wipe_code);
 secbool storage_has(const uint16_t key);
 secbool storage_get(const uint16_t key, void *val, const uint16_t max_len,
                     uint16_t *len);

--- a/storage/tests/c3/storage.c
+++ b/storage/tests/c3/storage.c
@@ -1243,15 +1243,14 @@ static secbool unlock(const uint8_t *pin, size_t pin_len,
   return pin_fails_reset();
 }
 
-secbool storage_unlock(const uint8_t *pin, size_t pin_len,
-                       const uint8_t *ext_salt) {
-  if (sectrue != initialized || pin == NULL) {
+secbool storage_unlock(const storage_pin_t *pin, const uint8_t *ext_salt) {
+  if (sectrue != initialized || pin == NULL || pin->text == NULL) {
     return secfalse;
   }
 
   ui_total = PIN_DERIVE_MS;
   ui_rem = ui_total;
-  if (pin_len == 0) {
+  if (pin->len == 0) {
     if (ui_message == NO_MSG) {
       ui_message = STARTING_MSG;
     } else {
@@ -1260,7 +1259,7 @@ secbool storage_unlock(const uint8_t *pin, size_t pin_len,
   } else {
     ui_message = VERIFYING_PIN_MSG;
   }
-  return unlock(pin, pin_len, ext_salt);
+  return unlock(pin->text, pin->len, ext_salt);
 }
 
 /*
@@ -1556,43 +1555,47 @@ uint32_t storage_get_pin_rem(void) {
   return PIN_MAX_TRIES - ctr_mcu;
 }
 
-secbool storage_change_pin(const uint8_t *oldpin, size_t oldpin_len,
-                           const uint8_t *newpin, size_t newpin_len,
+secbool storage_change_pin(const storage_pin_t *oldpin,
+                           const storage_pin_t *newpin,
                            const uint8_t *old_ext_salt,
                            const uint8_t *new_ext_salt) {
-  if (sectrue != initialized || oldpin == NULL || newpin == NULL) {
+  if (sectrue != initialized || oldpin == NULL || newpin == NULL ||
+      oldpin->text == NULL || newpin->text == NULL) {
     return secfalse;
   }
 
   ui_total = 2 * PIN_DERIVE_MS;
   ui_rem = ui_total;
-  ui_message =
-      (oldpin_len != 0 && newpin_len == 0) ? VERIFYING_PIN_MSG : PROCESSING_MSG;
+  ui_message = (oldpin->len != 0 && newpin->len == 0) ? VERIFYING_PIN_MSG
+                                                      : PROCESSING_MSG;
 
-  if (sectrue != unlock(oldpin, oldpin_len, old_ext_salt)) {
+  if (sectrue != unlock(oldpin->text, oldpin->len, old_ext_salt)) {
     return secfalse;
   }
 
   // Fail if the new PIN is the same as the wipe code.
-  if (sectrue != is_not_wipe_code(newpin, newpin_len)) {
+  if (sectrue != is_not_wipe_code(newpin->text, newpin->len)) {
     return secfalse;
   }
 
-  return set_pin(newpin, newpin_len, new_ext_salt);
+  return set_pin(newpin->text, newpin->len, new_ext_salt);
 }
 
-void storage_ensure_not_wipe_code(const uint8_t *pin, size_t pin_len) {
+void storage_ensure_not_wipe_code(const storage_pin_t *pin) {
   // If we are unlocking the storage during upgrade from version 2 or lower,
   // then encode the PIN to the old format.
-  uint32_t legacy_pin = 0;
+  uint32_t legacy_pin_int = 0;
+  storage_pin_t legacy_pin = {
+      .text = (const uint8_t *)&legacy_pin_int,
+      .len = sizeof(legacy_pin_int),
+  };
   if (get_lock_version() <= 2) {
-    legacy_pin = pin_to_int(pin, pin_len);
-    pin = (const uint8_t *)&legacy_pin;
-    pin_len = sizeof(legacy_pin);
+    legacy_pin_int = pin_to_int(pin->text, pin->len);
+    pin = &legacy_pin;
   }
 
-  ensure_not_wipe_code(pin, pin_len);
-  memzero(&legacy_pin, sizeof(legacy_pin));
+  ensure_not_wipe_code(pin->text, pin->len);
+  memzero(&legacy_pin_int, sizeof(legacy_pin_int));
 }
 
 secbool storage_has_wipe_code(void) {
@@ -1603,24 +1606,24 @@ secbool storage_has_wipe_code(void) {
   return is_not_wipe_code(WIPE_CODE_EMPTY, WIPE_CODE_EMPTY_LEN);
 }
 
-secbool storage_change_wipe_code(const uint8_t *pin, size_t pin_len,
+secbool storage_change_wipe_code(const storage_pin_t *pin,
                                  const uint8_t *ext_salt,
-                                 const uint8_t *wipe_code,
-                                 size_t wipe_code_len) {
+                                 const storage_pin_t *wipe_code) {
   if (sectrue != initialized || pin == NULL || wipe_code == NULL ||
-      (pin_len != 0 && pin_len == wipe_code_len &&
-       memcmp(pin, wipe_code, pin_len) == 0)) {
+      pin->text == NULL || wipe_code->text == NULL ||
+      (pin->len != 0 && pin->len == wipe_code->len &&
+       memcmp(pin->text, wipe_code->text, pin->len) == 0)) {
     return secfalse;
   }
 
   ui_total = PIN_DERIVE_MS;
   ui_rem = ui_total;
-  ui_message =
-      (pin_len != 0 && wipe_code_len == 0) ? VERIFYING_PIN_MSG : PROCESSING_MSG;
+  ui_message = (pin->len != 0 && wipe_code->len == 0) ? VERIFYING_PIN_MSG
+                                                      : PROCESSING_MSG;
 
   secbool ret = secfalse;
-  if (sectrue == unlock(pin, pin_len, ext_salt)) {
-    ret = set_wipe_code(wipe_code, wipe_code_len);
+  if (sectrue == unlock(pin->text, pin->len, ext_salt)) {
+    ret = set_wipe_code(wipe_code->text, wipe_code->len);
   }
   return ret;
 }

--- a/storage/tests/c3/storage.h
+++ b/storage/tests/c3/storage.h
@@ -61,6 +61,11 @@ enum storage_ui_message_t {
   WRONG_PIN_MSG,
 };
 
+typedef struct {
+  const uint8_t *text;
+  size_t len;
+} storage_pin_t;
+
 typedef secbool (*PIN_UI_WAIT_CALLBACK)(uint32_t wait, uint32_t progress,
                                         enum storage_ui_message_t message);
 
@@ -69,21 +74,19 @@ void storage_init(PIN_UI_WAIT_CALLBACK callback, const uint8_t *salt,
 void storage_wipe(void);
 secbool storage_is_unlocked(void);
 void storage_lock(void);
-secbool storage_unlock(const uint8_t *pin, size_t pin_len,
-                       const uint8_t *ext_salt);
+secbool storage_unlock(const storage_pin_t *pin, const uint8_t *ext_salt);
 secbool storage_has_pin(void);
 secbool storage_pin_fails_increase(void);
 uint32_t storage_get_pin_rem(void);
-secbool storage_change_pin(const uint8_t *oldpin, size_t oldpin_len,
-                           const uint8_t *newpin, size_t newpin_len,
+secbool storage_change_pin(const storage_pin_t *oldpin,
+                           const storage_pin_t *newpin,
                            const uint8_t *old_ext_salt,
                            const uint8_t *new_ext_salt);
-void storage_ensure_not_wipe_code(const uint8_t *pin, size_t pin_len);
+void storage_ensure_not_wipe_code(const storage_pin_t *pin);
 secbool storage_has_wipe_code(void);
-secbool storage_change_wipe_code(const uint8_t *pin, size_t pin_len,
+secbool storage_change_wipe_code(const storage_pin_t *pin,
                                  const uint8_t *ext_salt,
-                                 const uint8_t *wipe_code,
-                                 size_t wipe_code_len);
+                                 const storage_pin_t *wipe_code);
 secbool storage_has(const uint16_t key);
 secbool storage_get(const uint16_t key, void *val, const uint16_t max_len,
                     uint16_t *len);


### PR DESCRIPTION
**It’s likely that this PR will never be merged. Please disregard it for now.**


This PR reduces the number of arguments in the storage module’s API functions.

This refactoring is a prerequisite for the Secure Monitor API, where the number of arguments is limited (they can only be passed on the stack).

In fact, only two functions really required this refactoring, but for consistency, all places where a pin is passed to the storage module have been updated.
