### PR TITLE
fix booloader reboot

### DIFF
--- a/core/embed/projects/bootloader/workflow/wf_bootloader.c
+++ b/core/embed/projects/bootloader/workflow/wf_bootloader.c
@@ -179,6 +179,7 @@ static screen_t handle_wait_for_host(const vendor_header* vhdr,
                   break;
                 default:
                   *out_result = menu_result;  // final result
+                  next_screen = SCREEN_DONE;
                   break;
               }
             }

--- a/core/embed/rust/rust_types.h
+++ b/core/embed/rust/rust_types.h
@@ -2,5 +2,5 @@
 
 // additional type for C-rust interface
 typedef struct {
-  uint8_t buf[1024];
+  uint8_t buf[2048];
 } c_layout_t;


### PR DESCRIPTION
Menu item reboot was not working when the menu was invoked from waiting for host. (more generally the waiting for host wasn't exited on results other then OK/CANCELLED from menu).

Size of buffer for layouts was increased to 2kB, turns out 1kB was not enough for eckhart UI.