### PR TITLE
test(core): deflake passphrase-related tests

### DIFF
--- a/tests/click_tests/test_autolock.py
+++ b/tests/click_tests/test_autolock.py
@@ -218,7 +218,7 @@ def test_autolock_passphrase_keyboard(device_handler: "BackgroundDeviceHandler")
     # get address
     device_handler.run(common.get_test_address)  # type: ignore
 
-    assert "PassphraseKeyboard" in debug.read_layout().all_components()
+    debug.synchronize_at("PassphraseKeyboard")
 
     if debug.layout_type is LayoutType.Caesar:
         # Going into the selected character category
@@ -255,7 +255,7 @@ def test_autolock_interrupts_passphrase(device_handler: "BackgroundDeviceHandler
     # get address
     device_handler.run(common.get_test_address)  # type: ignore
 
-    assert "PassphraseKeyboard" in debug.read_layout().all_components()
+    debug.synchronize_at("PassphraseKeyboard")
 
     if debug.layout_type is LayoutType.Caesar:
         # Going into the selected character category

--- a/tests/click_tests/test_passphrase_bolt_delizia.py
+++ b/tests/click_tests/test_passphrase_bolt_delizia.py
@@ -74,7 +74,7 @@ def prepare_passphrase_dialogue(
 ) -> Generator["DebugLink", None, None]:
     debug = device_handler.debuglink()
     device_handler.run(get_test_address)  # type: ignore
-    assert debug.read_layout().main_component() == "PassphraseKeyboard"
+    debug.synchronize_at("PassphraseKeyboard")
 
     # Resetting the category as it could have been changed by previous tests
     global KEYBOARD_CATEGORY

--- a/tests/click_tests/test_passphrase_caesar.py
+++ b/tests/click_tests/test_passphrase_caesar.py
@@ -92,8 +92,7 @@ def prepare_passphrase_dialogue(
 ) -> Generator["DebugLink", None, None]:
     debug = device_handler.debuglink()
     device_handler.run(get_test_address)  # type: ignore
-    layout = debug.read_layout()
-    assert "PassphraseKeyboard" in layout.all_components()
+    layout = debug.synchronize_at("PassphraseKeyboard")
     assert layout.passphrase() == ""
     assert _current_category(debug) == PassphraseCategory.MENU
 


### PR DESCRIPTION
Currently, `PassphraseKeyboard` is shown after `request_passphrase_on_host()` layout, so in in order to avoid a race condition[^1][^2], an explicit synchronization was added.

[^1]: https://github.com/trezor/trezor-firmware/actions/runs/14999904818/job/42144246518?pr=5037
[^2]: https://github.com/trezor/trezor-firmware/actions/runs/15067093253/job/42354594590?pr=5041

<!--
For core developers:
- Assign yourself to the PR.
- Set the priority to match the original issue.
- Add the PR to the current sprint.
- If it's a draft PR, mark it as "In Progress."
- If it's a final PR, mark it as "Needs Review."

For external contributors:
- Please open an issue before submitting a PR so we can discuss whether we want to proceed with it.
-->
