### PR TITLE
Eckhart UI: remove label shadow on default homescreen pattern

### DIFF
--- a/core/embed/rust/src/ui/layout_eckhart/firmware/homescreen.rs
+++ b/core/embed/rust/src/ui/layout_eckhart/firmware/homescreen.rs
@@ -61,6 +61,7 @@ impl Homescreen {
         notification: Option<(TString<'static>, u8)>,
     ) -> Result<Self, Error> {
         let image = get_homescreen_image();
+        let default_hs = image.is_none();
 
         // Notification
         // TODO: better notification handling
@@ -117,7 +118,7 @@ impl Homescreen {
         };
 
         Ok(Self {
-            label: HomeLabel::new(label),
+            label: HomeLabel::new(label, default_hs),
             hint,
             action_bar: ActionBar::new_single(button),
             image,
@@ -227,7 +228,8 @@ impl Component for Homescreen {
 /// Helper component to render a label with a shadow.
 struct HomeLabel {
     label: Label<'static>,
-    label_shadow: Label<'static>,
+    /// Label shadow, only rendered when custom homescreen image is set
+    label_shadow: Option<Label<'static>>,
 }
 
 impl HomeLabel {
@@ -241,9 +243,10 @@ impl HomeLabel {
         theme::BLACK,
     );
 
-    fn new(label: TString<'static>) -> Self {
+    fn new(label: TString<'static>, shadow: bool) -> Self {
         let label_primary = Label::left_aligned(label, Self::LABEL_TEXT_STYLE).top_aligned();
-        let label_shadow = Label::left_aligned(label, Self::LABEL_SHADOW_TEXT_STYLE).top_aligned();
+        let label_shadow = (!shadow)
+            .then_some(Label::left_aligned(label, Self::LABEL_SHADOW_TEXT_STYLE).top_aligned());
         Self {
             label: label_primary,
             label_shadow,


### PR DESCRIPTION
<!--
For core developers:
- Assign yourself to the PR.
- Set the priority to match the original issue.
- Add the PR to the current sprint.
- If it's a draft PR, mark it as "In Progress."
- If it's a final PR, mark it as "Needs Review."

For external contributors:
- Please open an issue before submitting a PR so we can discuss whether we want to proceed with it.
-->
This PR removes the shadow effect from the device name on the homescreen in Eckhart UI. The reason is that it's not needed on the default pattern. However, it will be used when a user sets some custom image, the reason is that it makes the text more readable on light/dark backgrounds.