### PR TITLE
adjust bootloader (un)locking for tropic-enabled models

### DIFF
--- a/core/embed/projects/bootloader/bootui.c
+++ b/core/embed/projects/bootloader/bootui.c
@@ -160,7 +160,7 @@ void ui_screen_boot_stage_1(bool fading) { screen_boot_stage_1(fading); }
 // error UI
 void ui_screen_fail(void) { screen_install_fail(); }
 
-#ifdef USE_OPTIGA
+#ifdef LOCKABLE_BOOTLOADER
 uint32_t ui_screen_unlock_bootloader_confirm(void) {
   return screen_unlock_bootloader_confirm();
 }

--- a/core/embed/projects/bootloader/bootui.h
+++ b/core/embed/projects/bootloader/bootui.h
@@ -71,7 +71,7 @@ bool ui_get_initial_setup(void);
 
 void ui_screen_boot_stage_1(bool fading);
 
-#ifdef USE_OPTIGA
+#ifdef LOCKABLE_BOOTLOADER
 uint32_t ui_screen_unlock_bootloader_confirm(void);
 #endif
 

--- a/core/embed/projects/bootloader/emulator.c
+++ b/core/embed/projects/bootloader/emulator.c
@@ -12,7 +12,7 @@
 #include <util/flash_otp.h>
 #include "bootui.h"
 
-#ifdef USE_OPTIGA
+#ifdef LOCKABLE_BOOTLOADER
 #include <sec/secret.h>
 #endif
 
@@ -45,7 +45,7 @@ void usage(void) {
   printf("  -b BITCOIN_ONLY  set bitcoin only flag\n");
   printf(
       "  -f FIRMWARE  run interaction-less update for the specified image\n");
-#ifdef USE_OPTIGA
+#ifdef LOCKABLE_BOOTLOADER
   printf("  -l  lock bootloader\n");
 #endif
   printf("  -h  show this help\n");
@@ -153,7 +153,7 @@ int main(int argc, char **argv) {
         }
         bootargs_set(BOOT_COMMAND_INSTALL_UPGRADE, hash, sizeof(hash));
       } break;
-#ifdef USE_OPTIGA
+#ifdef LOCKABLE_BOOTLOADER
       case 'l':
         // write bootloader-lock secret
         secret_write_header();

--- a/core/embed/projects/bootloader/protob/protob.c
+++ b/core/embed/projects/bootloader/protob/protob.c
@@ -26,7 +26,7 @@
 #include <util/image.h>
 #include <util/unit_properties.h>
 
-#if USE_OPTIGA
+#if LOCKABLE_BOOTLOADER
 #include <sec/secret.h>
 #endif
 
@@ -130,7 +130,7 @@ secbool send_msg_features(protob_io_t *iface, const vendor_header *const vhdr,
     MSG_SEND_ASSIGN_VALUE(unit_btconly, unit_properties()->btconly);
   }
 
-#if USE_OPTIGA
+#if LOCKABLE_BOOTLOADER
   MSG_SEND_ASSIGN_VALUE(bootloader_locked,
                         (secret_bootloader_locked() == sectrue));
 #endif

--- a/core/embed/projects/bootloader/workflow/wf_firmware_update.c
+++ b/core/embed/projects/bootloader/workflow/wf_firmware_update.c
@@ -25,7 +25,7 @@
 #include <util/flash.h>
 #include <util/flash_utils.h>
 
-#if USE_OPTIGA || USE_STORAGE_HWKEY
+#if defined(LOCKABLE_BOOTLOADER) || USE_STORAGE_HWKEY
 #include <sec/secret.h>
 #endif
 
@@ -300,8 +300,8 @@ static upload_status_t process_msg_FirmwareUpload(protob_io_t *iface,
         is_ilu = sectrue;
       }
 
-#if defined USE_OPTIGA
-      if (secfalse != secret_optiga_present() &&
+#if defined LOCKABLE_BOOTLOADER
+      if (secfalse != secret_bootloader_locked() &&
           ((vhdr.vtrust & VTRUST_SECRET_MASK) != VTRUST_SECRET_ALLOW)) {
         send_msg_failure(iface, FailureType_Failure_ProcessError,
                          "Install restricted");

--- a/core/embed/projects/bootloader/workflow/wf_host_control.c
+++ b/core/embed/projects/bootloader/workflow/wf_host_control.c
@@ -123,7 +123,7 @@ workflow_result_t workflow_host_control(const vendor_header *const vhdr,
         }
         goto exit_host_control;
         break;
-#if defined USE_OPTIGA
+#if defined LOCKABLE_BOOTLOADER
       case MessageType_MessageType_UnlockBootloader:
         result = workflow_unlock_bootloader(active_iface);
         goto exit_host_control;

--- a/core/embed/projects/bootloader/workflow/wf_unlock_bootloader.c
+++ b/core/embed/projects/bootloader/workflow/wf_unlock_bootloader.c
@@ -33,7 +33,7 @@ workflow_result_t workflow_unlock_bootloader(protob_io_t *iface) {
     send_user_abort(iface, "Bootloader unlock cancelled");
     return WF_CANCELLED;
   }
-  secret_optiga_erase();
+  secret_unlock_bootloader();
   send_msg_success(iface, NULL);
 
   screen_unlock_bootloader_success();

--- a/core/embed/projects/bootloader/workflow/workflow.h
+++ b/core/embed/projects/bootloader/workflow/workflow.h
@@ -45,7 +45,7 @@ workflow_result_t workflow_firmware_update(protob_io_t *iface);
 
 workflow_result_t workflow_wipe_device(protob_io_t *iface);
 
-#ifdef USE_OPTIGA
+#ifdef LOCKABLE_BOOTLOADER
 workflow_result_t workflow_unlock_bootloader(protob_io_t *iface);
 #endif
 

--- a/core/embed/sec/secret/inc/sec/secret.h
+++ b/core/embed/sec/secret/inc/sec/secret.h
@@ -117,9 +117,16 @@ void secret_prepare_fw(secbool allow_run_with_secret,
 // This function is called by the boardloader
 void secret_init(void);
 
+#ifdef LOCKABLE_BOOTLOADER
+// Unlocks the bootloader, all neccessary keys are erased
+void secret_unlock_bootloader(void);
+#endif
+
 #endif  // KERNEL_MODE
 
+#ifdef LOCKABLE_BOOTLOADER
 // Checks if bootloader is locked, that is the secret storage contains optiga
 // pairing secret on platforms where access to the secret storage cannot be
 // restricted for unofficial firmware
 secbool secret_bootloader_locked(void);
+#endif

--- a/core/embed/sec/secret/stm32f4/secret.c
+++ b/core/embed/sec/secret/stm32f4/secret.c
@@ -50,6 +50,7 @@ secbool secret_verify_header(void) {
   return bootloader_locked;
 }
 
+#ifdef LOCKABLE_BOOTLOADER
 secbool secret_bootloader_locked(void) {
   if (bootloader_locked_set != sectrue) {
     // Set bootloader_locked.
@@ -58,6 +59,9 @@ secbool secret_bootloader_locked(void) {
 
   return bootloader_locked;
 }
+
+void secret_unlock_bootloader(void) { secret_optiga_erase(); }
+#endif
 
 void secret_write_header(void) {
   uint8_t header[SECRET_HEADER_LEN] = {0};

--- a/core/embed/sec/secret/unix/secret.c
+++ b/core/embed/sec/secret/unix/secret.c
@@ -60,6 +60,7 @@ secbool secret_verify_header(void) {
   return bootloader_locked;
 }
 
+#ifdef LOCKABLE_BOOTLOADER
 secbool secret_bootloader_locked(void) {
   if (bootloader_locked_set != sectrue) {
     // Set bootloader_locked.
@@ -68,6 +69,9 @@ secbool secret_bootloader_locked(void) {
 
   return bootloader_locked;
 }
+
+void secret_unlock_bootloader(void) { secret_erase(); }
+#endif
 
 void secret_write_header(void) {
   uint8_t header[SECRET_HEADER_LEN] = {0};

--- a/core/embed/sys/syscall/stm32/syscall_dispatch.c
+++ b/core/embed/sys/syscall/stm32/syscall_dispatch.c
@@ -421,9 +421,11 @@ __attribute((no_stack_protector)) void syscall_handler(uint32_t *args,
       unit_properties_get__verified(props);
     } break;
 
+#ifdef LOCKABLE_BOOTLOADER
     case SYSCALL_SECRET_BOOTLOADER_LOCKED: {
       args[0] = secret_bootloader_locked();
     } break;
+#endif
 
 #ifdef USE_BUTTON
     case SYSCALL_BUTTON_GET_EVENT: {

--- a/core/embed/sys/syscall/stm32/syscall_stubs.c
+++ b/core/embed/sys/syscall/stm32/syscall_stubs.c
@@ -361,11 +361,13 @@ void unit_properties_get(unit_properties_t *props) {
 // secret.h
 // =============================================================================
 
+#ifdef LOCKABLE_BOOTLOADER
 #include <sec/secret.h>
 
 secbool secret_bootloader_locked(void) {
   return (secbool)syscall_invoke0(SYSCALL_SECRET_BOOTLOADER_LOCKED);
 }
+#endif
 
 // =============================================================================
 // button.h

--- a/core/embed/upymod/modtrezorutils/modtrezorutils.c
+++ b/core/embed/upymod/modtrezorutils/modtrezorutils.c
@@ -493,7 +493,7 @@ STATIC MP_DEFINE_CONST_FUN_OBJ_1(mod_trezorutils_check_firmware_header_obj,
 ///     the feature is not supported.
 ///     """
 STATIC mp_obj_t mod_trezorutils_bootloader_locked() {
-#if USE_OPTIGA
+#if LOCKABLE_BOOTLOADER
 #ifdef TREZOR_EMULATOR
   return mp_const_true;
 #else

--- a/core/site_scons/models/T2B1/emulator.py
+++ b/core/site_scons/models/T2B1/emulator.py
@@ -34,6 +34,7 @@ def configure(
         ("MCU_TYPE", mcu),
         ("FLASH_BIT_ACCESS", "1"),
         ("FLASH_BLOCK_WORDS", "1"),
+        ("LOCKABLE_BOOTLOADER", "1"),
     ]
 
     if "sbu" in features_wanted:

--- a/core/site_scons/models/T2B1/trezor_r_v10.py
+++ b/core/site_scons/models/T2B1/trezor_r_v10.py
@@ -20,6 +20,7 @@ def configure(
         "FRAMEBUFFER",
         ("DISPLAY_RESX", "128"),
         ("DISPLAY_RESY", "64"),
+        ("LOCKABLE_BOOTLOADER", "1"),
     ]
     features_available.append("framebuffer")
     features_available.append("display_mono")

--- a/core/site_scons/models/T3B1/emulator.py
+++ b/core/site_scons/models/T3B1/emulator.py
@@ -22,6 +22,7 @@ def configure(
         "DISPLAY_MONO",
         ("DISPLAY_RESX", "128"),
         ("DISPLAY_RESY", "64"),
+        ("LOCKABLE_BOOTLOADER", "1"),
     ]
     features_available.append("framebuffer")
     features_available.append("display_mono")

--- a/core/site_scons/models/T3B1/trezor_t3b1_revB.py
+++ b/core/site_scons/models/T3B1/trezor_t3b1_revB.py
@@ -20,6 +20,7 @@ def configure(
         "FRAMEBUFFER",
         ("DISPLAY_RESX", "128"),
         ("DISPLAY_RESY", "64"),
+        ("LOCKABLE_BOOTLOADER", "1"),
     ]
     features_available.append("framebuffer")
     features_available.append("display_mono")

--- a/core/site_scons/models/T3T1/emulator.py
+++ b/core/site_scons/models/T3T1/emulator.py
@@ -25,6 +25,7 @@ def configure(
         ("USE_RGB_COLORS", "1"),
         ("DISPLAY_RESX", "240"),
         ("DISPLAY_RESY", "240"),
+        ("LOCKABLE_BOOTLOADER", "1"),
     ]
 
     defines += [

--- a/core/site_scons/models/T3T1/trezor_t3t1_revE.py
+++ b/core/site_scons/models/T3T1/trezor_t3t1_revE.py
@@ -24,6 +24,7 @@ def configure(
         ("USE_RGB_COLORS", "1"),
         ("DISPLAY_RESX", "240"),
         ("DISPLAY_RESY", "240"),
+        ("LOCKABLE_BOOTLOADER", "1"),
     ]
 
     mcu = "STM32U585xx"

--- a/core/site_scons/models/T3W1/emulator.py
+++ b/core/site_scons/models/T3W1/emulator.py
@@ -24,6 +24,7 @@ def configure(
         "UI_COLOR_32BIT",
         ("DISPLAY_RESX", "380"),
         ("DISPLAY_RESY", "520"),
+        ("LOCKABLE_BOOTLOADER", "1"),
     ]
     features_available.append("framebuffer")
     features_available.append("display_rgba8888")

--- a/core/site_scons/models/T3W1/trezor_t3w1_revA.py
+++ b/core/site_scons/models/T3W1/trezor_t3w1_revA.py
@@ -38,6 +38,7 @@ def configure(
         ("USE_HSE", "1"),
         ("USE_LSE", "1"),
         ("FIXED_HW_DEINIT", "1"),
+        ("LOCKABLE_BOOTLOADER", "1"),
         ("TERMINAL_FONT_SCALE", "2"),
         ("TERMINAL_X_PADDING", "4"),
         ("TERMINAL_Y_PADDING", "12"),

--- a/core/site_scons/models/T3W1/trezor_t3w1_revB.py
+++ b/core/site_scons/models/T3W1/trezor_t3w1_revB.py
@@ -38,6 +38,7 @@ def configure(
         ("USE_HSE", "1"),
         ("USE_LSE", "1"),
         ("FIXED_HW_DEINIT", "1"),
+        ("LOCKABLE_BOOTLOADER", "1"),
         ("TERMINAL_FONT_SCALE", "2"),
         ("TERMINAL_X_PADDING", "4"),
         ("TERMINAL_Y_PADDING", "12"),

--- a/core/site_scons/models/T3W1/trezor_t3w1_revC.py
+++ b/core/site_scons/models/T3W1/trezor_t3w1_revC.py
@@ -38,6 +38,7 @@ def configure(
         ("USE_HSE", "1"),
         ("USE_LSE", "1"),
         ("FIXED_HW_DEINIT", "1"),
+        ("LOCKABLE_BOOTLOADER", "1"),
         ("TERMINAL_FONT_SCALE", "2"),
         ("TERMINAL_X_PADDING", "4"),
         ("TERMINAL_Y_PADDING", "12"),


### PR DESCRIPTION
This PR adjust bootloader locking/unlocking mechanism to respect models with tropic.

When unlocking bootloader, secrets for both optiga and tropic should be erased. Therefore, for purpose of bootloader locked status detection, any secret that is not erased means that bootloader is locked and custom firmware should not be allowed to be installed and should not run.

Instead of relying on `USE_OPTIGA` for presence of bootloader lock functionality, new per-model compile flag is introduced: `LOCKABLE_BOOTLOADER`