### PR TITLE
chore(core): fix deprecation warning for `input_flow.throw(...)`

### DIFF
--- a/python/src/trezorlib/debuglink.py
+++ b/python/src/trezorlib/debuglink.py
@@ -1151,7 +1151,7 @@ class TrezorClientDebugLink(TrezorClient):
         self.in_with_statement = True
         return self
 
-    def __exit__(self, exc_type: Any, value: Any, traceback: Any) -> None:
+    def __exit__(self, exc_type: Any, value: Any, _traceback: Any) -> None:
         __tracebackhide__ = True  # for pytest # pylint: disable=W0612
 
         # copy expected/actual responses before clearing them
@@ -1174,7 +1174,7 @@ class TrezorClientDebugLink(TrezorClient):
         elif isinstance(input_flow, Generator):
             # Propagate the exception through the input flow, so that we see in
             # traceback where it is stuck.
-            input_flow.throw(exc_type, value, traceback)
+            input_flow.throw(value)
 
     def set_expected_responses(
         self,


### PR DESCRIPTION
https://docs.python.org/3.9/reference/expressions.html#generator.throw

Python 3.8 is no longer maintained: https://peps.python.org/pep-0569/

<!--
For core developers:
- Assign yourself to the PR.
- Set the priority to match the original issue.
- Add the PR to the current sprint.
- If it's a draft PR, mark it as "In Progress."
- If it's a final PR, mark it as "Needs Review."

For external contributors:
- Please open an issue before submitting a PR so we can discuss whether we want to proceed with it.
-->
