### PR TITLE
WIP: RBF update for Eckhart UI

### DIFF
--- a/core/embed/rust/src/translations/generated/translated_string.rs
+++ b/core/embed/rust/src/translations/generated/translated_string.rs
@@ -52,7 +52,7 @@ pub enum TranslatedString {
     bitcoin__title_confirm_details = 50,  // "Confirm details"
     bitcoin__title_finalize_transaction = 51,  // "Finalize transaction"
     bitcoin__title_high_mining_fee = 52,  // "High mining fee"
-    bitcoin__title_meld_transaction = 53,  // "Meld transactions"
+    bitcoin__title_meld_transaction = 53,  // "Meld transaction"
     bitcoin__title_modify_amount = 54,  // "Modify amount"
     bitcoin__title_payjoin = 55,  // "Payjoin"
     bitcoin__title_proof_of_ownership = 56,  // "Proof of ownership"
@@ -543,17 +543,17 @@ pub enum TranslatedString {
     misc__decrypt_value = 349,  // "Decrypt value"
     misc__encrypt_value = 350,  // "Encrypt value"
     misc__title_suite_labeling = 351,  // "Suite labeling"
-    modify_amount__decrease_amount = 352,  // "Decrease amount by:"
-    modify_amount__increase_amount = 353,  // "Increase amount by:"
-    modify_amount__new_amount = 354,  // "New amount:"
+    modify_amount__decrease_amount = 352,  // {"Bolt": "Decrease amount by:", "Caesar": "Decrease amount by:", "Delizia": "Decrease amount by:", "Eckhart": "Decrease amount by"}
+    modify_amount__increase_amount = 353,  // {"Bolt": "Increase amount by:", "Caesar": "Increase amount by:", "Delizia": "Increase amount by:", "Eckhart": "Increase amount by"}
+    modify_amount__new_amount = 354,  // {"Bolt": "New amount:", "Caesar": "New amount:", "Delizia": "New amount:", "Eckhart": "New amount"}
     modify_amount__title = 355,  // "Modify amount"
-    modify_fee__decrease_fee = 356,  // "Decrease fee by:"
+    modify_fee__decrease_fee = 356,  // {"Bolt": "Decrease fee by:", "Caesar": "Decrease fee by:", "Delizia": "Decrease fee by:", "Eckhart": "Decrease fee by"}
     modify_fee__fee_rate = 357,  // "Fee rate:"
-    modify_fee__increase_fee = 358,  // "Increase fee by:"
-    modify_fee__new_transaction_fee = 359,  // "New transaction fee:"
-    modify_fee__no_change = 360,  // "Fee did not change.\n"
+    modify_fee__increase_fee = 358,  // {"Bolt": "Increase fee by:", "Caesar": "Increase fee by:", "Delizia": "Increase fee by:", "Eckhart": "Increase fee by"}
+    modify_fee__new_transaction_fee = 359,  // {"Bolt": "New transaction fee:", "Caesar": "New transaction fee:", "Delizia": "New transaction fee:", "Eckhart": "New transaction fee"}
+    modify_fee__no_change = 360,  // {"Bolt": "Fee did not change.\n", "Caesar": "Fee did not change.\n", "Delizia": "Fee did not change.\n", "Eckhart": "Fee did not change"}
     modify_fee__title = 361,  // "Modify fee"
-    modify_fee__transaction_fee = 362,  // "Transaction fee:"
+    modify_fee__transaction_fee = 362,  // {"Bolt": "Transaction fee:", "Caesar": "Transaction fee:", "Delizia": "Transaction fee:", "Eckhart": "Transaction fee"}
     #[cfg(feature = "universal_fw")]
     monero__confirm_export = 363,  // "Confirm export"
     #[cfg(feature = "universal_fw")]
@@ -1499,7 +1499,7 @@ impl TranslatedString {
             (Self::bitcoin__title_confirm_details, "Confirm details"),
             (Self::bitcoin__title_finalize_transaction, "Finalize transaction"),
             (Self::bitcoin__title_high_mining_fee, "High mining fee"),
-            (Self::bitcoin__title_meld_transaction, "Meld transactions"),
+            (Self::bitcoin__title_meld_transaction, "Meld transaction"),
             (Self::bitcoin__title_modify_amount, "Modify amount"),
             (Self::bitcoin__title_payjoin, "Payjoin"),
             (Self::bitcoin__title_proof_of_ownership, "Proof of ownership"),
@@ -2020,17 +2020,73 @@ impl TranslatedString {
             (Self::misc__decrypt_value, "Decrypt value"),
             (Self::misc__encrypt_value, "Encrypt value"),
             (Self::misc__title_suite_labeling, "Suite labeling"),
+            #[cfg(feature = "layout_bolt")]
             (Self::modify_amount__decrease_amount, "Decrease amount by:"),
+            #[cfg(feature = "layout_caesar")]
+            (Self::modify_amount__decrease_amount, "Decrease amount by:"),
+            #[cfg(feature = "layout_delizia")]
+            (Self::modify_amount__decrease_amount, "Decrease amount by:"),
+            #[cfg(feature = "layout_eckhart")]
+            (Self::modify_amount__decrease_amount, "Decrease amount by"),
+            #[cfg(feature = "layout_bolt")]
             (Self::modify_amount__increase_amount, "Increase amount by:"),
+            #[cfg(feature = "layout_caesar")]
+            (Self::modify_amount__increase_amount, "Increase amount by:"),
+            #[cfg(feature = "layout_delizia")]
+            (Self::modify_amount__increase_amount, "Increase amount by:"),
+            #[cfg(feature = "layout_eckhart")]
+            (Self::modify_amount__increase_amount, "Increase amount by"),
+            #[cfg(feature = "layout_bolt")]
             (Self::modify_amount__new_amount, "New amount:"),
+            #[cfg(feature = "layout_caesar")]
+            (Self::modify_amount__new_amount, "New amount:"),
+            #[cfg(feature = "layout_delizia")]
+            (Self::modify_amount__new_amount, "New amount:"),
+            #[cfg(feature = "layout_eckhart")]
+            (Self::modify_amount__new_amount, "New amount"),
             (Self::modify_amount__title, "Modify amount"),
+            #[cfg(feature = "layout_bolt")]
             (Self::modify_fee__decrease_fee, "Decrease fee by:"),
+            #[cfg(feature = "layout_caesar")]
+            (Self::modify_fee__decrease_fee, "Decrease fee by:"),
+            #[cfg(feature = "layout_delizia")]
+            (Self::modify_fee__decrease_fee, "Decrease fee by:"),
+            #[cfg(feature = "layout_eckhart")]
+            (Self::modify_fee__decrease_fee, "Decrease fee by"),
             (Self::modify_fee__fee_rate, "Fee rate:"),
+            #[cfg(feature = "layout_bolt")]
             (Self::modify_fee__increase_fee, "Increase fee by:"),
+            #[cfg(feature = "layout_caesar")]
+            (Self::modify_fee__increase_fee, "Increase fee by:"),
+            #[cfg(feature = "layout_delizia")]
+            (Self::modify_fee__increase_fee, "Increase fee by:"),
+            #[cfg(feature = "layout_eckhart")]
+            (Self::modify_fee__increase_fee, "Increase fee by"),
+            #[cfg(feature = "layout_bolt")]
             (Self::modify_fee__new_transaction_fee, "New transaction fee:"),
+            #[cfg(feature = "layout_caesar")]
+            (Self::modify_fee__new_transaction_fee, "New transaction fee:"),
+            #[cfg(feature = "layout_delizia")]
+            (Self::modify_fee__new_transaction_fee, "New transaction fee:"),
+            #[cfg(feature = "layout_eckhart")]
+            (Self::modify_fee__new_transaction_fee, "New transaction fee"),
+            #[cfg(feature = "layout_bolt")]
             (Self::modify_fee__no_change, "Fee did not change.\n"),
+            #[cfg(feature = "layout_caesar")]
+            (Self::modify_fee__no_change, "Fee did not change.\n"),
+            #[cfg(feature = "layout_delizia")]
+            (Self::modify_fee__no_change, "Fee did not change.\n"),
+            #[cfg(feature = "layout_eckhart")]
+            (Self::modify_fee__no_change, "Fee did not change"),
             (Self::modify_fee__title, "Modify fee"),
+            #[cfg(feature = "layout_bolt")]
             (Self::modify_fee__transaction_fee, "Transaction fee:"),
+            #[cfg(feature = "layout_caesar")]
+            (Self::modify_fee__transaction_fee, "Transaction fee:"),
+            #[cfg(feature = "layout_delizia")]
+            (Self::modify_fee__transaction_fee, "Transaction fee:"),
+            #[cfg(feature = "layout_eckhart")]
+            (Self::modify_fee__transaction_fee, "Transaction fee"),
             #[cfg(feature = "universal_fw")]
             (Self::monero__confirm_export, "Confirm export"),
             #[cfg(feature = "universal_fw")]

--- a/core/embed/rust/src/ui/layout_eckhart/component_msg_obj.rs
+++ b/core/embed/rust/src/ui/layout_eckhart/component_msg_obj.rs
@@ -1,16 +1,15 @@
+#[cfg(not(feature = "clippy"))]
+use crate::ui::component::{
+    text::paragraphs::{ParagraphSource, Paragraphs},
+    Component, Timeout,
+};
 use crate::{
     error::Error,
     micropython::{obj::Obj, util::new_tuple},
-    ui::{
-        component::{
-            text::paragraphs::{ParagraphSource, Paragraphs},
-            Component, Timeout,
-        },
-        layout::{
-            device_menu_result::*,
-            obj::ComponentMsgObj,
-            result::{CANCELLED, CONFIRMED, INFO},
-        },
+    ui::layout::{
+        device_menu_result::*,
+        obj::ComponentMsgObj,
+        result::{CANCELLED, CONFIRMED, INFO},
     },
 };
 

--- a/core/embed/rust/src/ui/layout_eckhart/flow/confirm_summary.rs
+++ b/core/embed/rust/src/ui/layout_eckhart/flow/confirm_summary.rs
@@ -6,7 +6,7 @@ use crate::{
     translations::TR,
     ui::{
         component::{
-            text::paragraphs::{Paragraph, ParagraphSource, ParagraphVecShort, Paragraphs},
+            text::paragraphs::{Paragraph, ParagraphSource, ParagraphVecShort, Paragraphs, VecExt},
             ComponentExt, MsgMap,
         },
         flow::{
@@ -103,13 +103,14 @@ pub fn new_confirm_summary(
     // Summary
     let mut summary_paragraphs = ParagraphVecShort::new();
     if let Some(amount_label) = amount_label {
-        unwrap!(summary_paragraphs.push(Paragraph::new(&theme::TEXT_SMALL_LIGHT, amount_label)));
+        summary_paragraphs.add(Paragraph::new(&theme::TEXT_SMALL_LIGHT, amount_label));
     }
     if let Some(amount) = amount {
-        unwrap!(summary_paragraphs.push(Paragraph::new(&theme::TEXT_MONO_MEDIUM_LIGHT, amount)));
+        summary_paragraphs.add(Paragraph::new(&theme::TEXT_MONO_MEDIUM_LIGHT, amount));
     }
-    unwrap!(summary_paragraphs.push(Paragraph::new(&theme::TEXT_SMALL_LIGHT, fee_label)));
-    unwrap!(summary_paragraphs.push(Paragraph::new(&theme::TEXT_MONO_MEDIUM_LIGHT, fee)));
+    summary_paragraphs
+        .add(Paragraph::new(&theme::TEXT_SMALL_LIGHT, fee_label))
+        .add(Paragraph::new(&theme::TEXT_MONO_MEDIUM_LIGHT, fee));
 
     let content_summary = TextScreen::new(
         summary_paragraphs

--- a/core/embed/rust/src/ui/layout_eckhart/ui_firmware.rs
+++ b/core/embed/rust/src/ui/layout_eckhart/ui_firmware.rs
@@ -229,18 +229,19 @@ impl FirmwareUI for UIEckhart {
 
         let mut paragraphs = ParagraphVecShort::new();
         if let Some(description) = description {
-            paragraphs.add(
-                Paragraph::new(&theme::TEXT_SMALL_LIGHT, description)
-                    .with_bottom_padding(theme::PARAGRAPHS_SPACING),
-            );
             paragraphs
+                .add(
+                    Paragraph::new(&theme::TEXT_SMALL_LIGHT, description)
+                        .with_bottom_padding(theme::PARAGRAPHS_SPACING),
+                )
                 .add(Paragraph::new(&theme::TEXT_MONO_EXTRA_LIGHT, change).with_bottom_padding(16));
         }
-        paragraphs.add(
-            Paragraph::new(&theme::TEXT_SMALL_LIGHT, total_label)
-                .with_bottom_padding(theme::PARAGRAPHS_SPACING),
-        );
-        paragraphs.add(Paragraph::new(&theme::TEXT_MONO_EXTRA_LIGHT, total_fee_new));
+        paragraphs
+            .add(
+                Paragraph::new(&theme::TEXT_SMALL_LIGHT, total_label)
+                    .with_bottom_padding(theme::PARAGRAPHS_SPACING),
+            )
+            .add(Paragraph::new(&theme::TEXT_MONO_EXTRA_LIGHT, total_fee_new));
 
         let flow = flow::new_confirm_with_menu(
             title,
@@ -317,8 +318,9 @@ impl FirmwareUI for UIEckhart {
             let mut paragraphs = ParagraphVecShort::new();
             for pair in IterBuf::new().try_iterate(items)? {
                 let [label, value]: [TString; 2] = util::iter_into_array(pair)?;
-                unwrap!(paragraphs.push(Paragraph::new(&theme::TEXT_SMALL_LIGHT, label).no_break()));
-                unwrap!(paragraphs.push(Paragraph::new(&theme::TEXT_MONO_LIGHT, value)));
+                paragraphs
+                    .add(Paragraph::new(&theme::TEXT_SMALL_LIGHT, label).no_break())
+                    .add(Paragraph::new(&theme::TEXT_MONO_LIGHT, value));
             }
             Some(paragraphs)
         } else {
@@ -328,8 +330,9 @@ impl FirmwareUI for UIEckhart {
             let mut paragraphs = ParagraphVecShort::new();
             for pair in IterBuf::new().try_iterate(items)? {
                 let [label, value]: [TString; 2] = util::iter_into_array(pair)?;
-                unwrap!(paragraphs.push(Paragraph::new(&theme::TEXT_SMALL_LIGHT, label).no_break()));
-                unwrap!(paragraphs.push(Paragraph::new(&theme::TEXT_MONO_LIGHT, value)));
+                paragraphs
+                    .add(Paragraph::new(&theme::TEXT_SMALL_LIGHT, label).no_break())
+                    .add(Paragraph::new(&theme::TEXT_MONO_LIGHT, value));
             }
             Some(paragraphs)
         } else {
@@ -579,10 +582,10 @@ impl FirmwareUI for UIEckhart {
     ) -> Result<impl LayoutMaybeTrace, Error> {
         let mut main_paragraphs = ParagraphVecShort::new();
         if let Some(description) = description {
-            unwrap!(main_paragraphs.push(Paragraph::new(&theme::TEXT_NORMAL, description)));
+            main_paragraphs.add(Paragraph::new(&theme::TEXT_NORMAL, description));
         }
         if let Some(extra) = extra {
-            unwrap!(main_paragraphs.push(Paragraph::new(&theme::TEXT_SMALL, extra)));
+            main_paragraphs.add(Paragraph::new(&theme::TEXT_SMALL, extra));
         }
         let font = if chunkify {
             &theme::TEXT_MONO_ADDRESS_CHUNKS
@@ -591,10 +594,10 @@ impl FirmwareUI for UIEckhart {
         } else {
             &theme::TEXT_REGULAR
         };
-        unwrap!(main_paragraphs.push(Paragraph::new(
+        main_paragraphs.add(Paragraph::new(
             font,
             message.try_into().unwrap_or(TString::empty()),
-        )));
+        ));
 
         let (address_title, address_paragraph) = if let Some((title, item)) = address_item {
             let paragraph = Paragraph::new(
@@ -610,24 +613,26 @@ impl FirmwareUI for UIEckhart {
         let account_paragraphs = {
             let mut paragraphs = ParagraphVecShort::new();
             if let Some(account) = account {
-                unwrap!(paragraphs.push(
-                    Paragraph::new(
-                        &theme::TEXT_SMALL_LIGHT,
-                        TString::from_translation(TR::words__wallet)
+                paragraphs
+                    .add(
+                        Paragraph::new(
+                            &theme::TEXT_SMALL_LIGHT,
+                            TString::from_translation(TR::words__wallet),
+                        )
+                        .no_break(),
                     )
-                    .no_break()
-                ));
-                unwrap!(paragraphs.push(Paragraph::new(&theme::TEXT_MONO_LIGHT, account)));
+                    .add(Paragraph::new(&theme::TEXT_MONO_LIGHT, account));
             }
             if let Some(path) = account_path {
-                unwrap!(paragraphs.push(
-                    Paragraph::new(
-                        &theme::TEXT_SMALL_LIGHT,
-                        TString::from_translation(TR::address_details__derivation_path)
+                paragraphs
+                    .add(
+                        Paragraph::new(
+                            &theme::TEXT_SMALL_LIGHT,
+                            TString::from_translation(TR::address_details__derivation_path),
+                        )
+                        .no_break(),
                     )
-                    .no_break()
-                ));
-                unwrap!(paragraphs.push(Paragraph::new(&theme::TEXT_MONO_LIGHT, path)));
+                    .add(Paragraph::new(&theme::TEXT_MONO_LIGHT, path));
             }
             if paragraphs.is_empty() {
                 None
@@ -640,8 +645,9 @@ impl FirmwareUI for UIEckhart {
             let mut paragraphs = ParagraphVecShort::new();
             for pair in IterBuf::new().try_iterate(items)? {
                 let [label, value]: [TString; 2] = util::iter_into_array(pair)?;
-                unwrap!(paragraphs.push(Paragraph::new(&theme::TEXT_SMALL_LIGHT, label).no_break()));
-                unwrap!(paragraphs.push(Paragraph::new(&theme::TEXT_MONO_MEDIUM_LIGHT, value)));
+                paragraphs
+                    .add(Paragraph::new(&theme::TEXT_SMALL_LIGHT, label).no_break())
+                    .add(Paragraph::new(&theme::TEXT_MONO_MEDIUM_LIGHT, value));
             }
             Some(paragraphs)
         } else {
@@ -652,8 +658,9 @@ impl FirmwareUI for UIEckhart {
             let mut paragraphs = ParagraphVecShort::new();
             for pair in IterBuf::new().try_iterate(items)? {
                 let [label, value]: [TString; 2] = util::iter_into_array(pair)?;
-                unwrap!(paragraphs.push(Paragraph::new(&theme::TEXT_SMALL_LIGHT, label).no_break()));
-                unwrap!(paragraphs.push(Paragraph::new(&theme::TEXT_MONO_MEDIUM_LIGHT, value)));
+                paragraphs
+                    .add(Paragraph::new(&theme::TEXT_SMALL_LIGHT, label).no_break())
+                    .add(Paragraph::new(&theme::TEXT_MONO_MEDIUM_LIGHT, value));
             }
             Some(paragraphs)
         } else {

--- a/core/mocks/trezortranslate_keys.pyi
+++ b/core/mocks/trezortranslate_keys.pyi
@@ -59,7 +59,7 @@ class TR:
     bitcoin__title_confirm_details: str = "Confirm details"
     bitcoin__title_finalize_transaction: str = "Finalize transaction"
     bitcoin__title_high_mining_fee: str = "High mining fee"
-    bitcoin__title_meld_transaction: str = "Meld transactions"
+    bitcoin__title_meld_transaction: str = "Meld transaction"
     bitcoin__title_modify_amount: str = "Modify amount"
     bitcoin__title_payjoin: str = "Payjoin"
     bitcoin__title_proof_of_ownership: str = "Proof of ownership"

--- a/core/src/trezor/ui/layouts/eckhart/__init__.py
+++ b/core/src/trezor/ui/layouts/eckhart/__init__.py
@@ -1143,7 +1143,7 @@ def confirm_replacement(title: str, txid: str) -> Awaitable[None]:
         "confirm_replacement",
         title,
         txid,
-        TR.send__transaction_id,
+        subtitle=TR.send__transaction_id,
         verb=TR.buttons__continue,
         info=False,
         br_code=ButtonRequestType.SignTx,
@@ -1158,10 +1158,12 @@ async def confirm_modify_output(
 ) -> None:
     address_layout = trezorui_api.confirm_value(
         title=TR.modify_amount__title,
+        subtitle=TR.words__address,
         value=address,
         verb=TR.buttons__continue,
-        description=f"{TR.words__address}:",
         cancel=True,
+        is_data=True,
+        description=None,
     )
     modify_layout = trezorui_api.confirm_modify_output(
         sign=sign,
@@ -1257,7 +1259,7 @@ async def confirm_signverify(
     address_layout = trezorui_api.confirm_value(
         title=address_title,
         value=address,
-        description="",
+        description=None,
         is_data=True,
         verb=TR.buttons__continue,
         info=True,

--- a/core/translations/en.json
+++ b/core/translations/en.json
@@ -86,7 +86,7 @@
     "bitcoin__title_confirm_details": "Confirm details",
     "bitcoin__title_finalize_transaction": "Finalize transaction",
     "bitcoin__title_high_mining_fee": "High mining fee",
-    "bitcoin__title_meld_transaction": "Meld transactions",
+    "bitcoin__title_meld_transaction": "Meld transaction",
     "bitcoin__title_modify_amount": "Modify amount",
     "bitcoin__title_payjoin": "Payjoin",
     "bitcoin__title_proof_of_ownership": "Proof of ownership",
@@ -487,17 +487,57 @@
     "misc__enable_labeling": "Enable labeling?",
     "misc__encrypt_value": "Encrypt value",
     "misc__title_suite_labeling": "Suite labeling",
-    "modify_amount__decrease_amount": "Decrease amount by:",
-    "modify_amount__increase_amount": "Increase amount by:",
-    "modify_amount__new_amount": "New amount:",
+    "modify_amount__decrease_amount": {
+      "Bolt": "Decrease amount by:",
+      "Caesar": "Decrease amount by:",
+      "Delizia": "Decrease amount by:",
+      "Eckhart": "Decrease amount by"
+    },
+    "modify_amount__increase_amount": {
+      "Bolt": "Increase amount by:",
+      "Caesar": "Increase amount by:",
+      "Delizia": "Increase amount by:",
+      "Eckhart": "Increase amount by"
+    },
+    "modify_amount__new_amount": {
+      "Bolt": "New amount:",
+      "Caesar": "New amount:",
+      "Delizia": "New amount:",
+      "Eckhart": "New amount"
+    },
     "modify_amount__title": "Modify amount",
-    "modify_fee__decrease_fee": "Decrease fee by:",
+    "modify_fee__decrease_fee": {
+      "Bolt": "Decrease fee by:",
+      "Caesar": "Decrease fee by:",
+      "Delizia": "Decrease fee by:",
+      "Eckhart": "Decrease fee by"
+    },
     "modify_fee__fee_rate": "Fee rate:",
-    "modify_fee__increase_fee": "Increase fee by:",
-    "modify_fee__new_transaction_fee": "New transaction fee:",
-    "modify_fee__no_change": "Fee did not change.\n",
+    "modify_fee__increase_fee": {
+      "Bolt": "Increase fee by:",
+      "Caesar": "Increase fee by:",
+      "Delizia": "Increase fee by:",
+      "Eckhart": "Increase fee by"
+    },
+    "modify_fee__new_transaction_fee": {
+      "Bolt": "New transaction fee:",
+      "Caesar": "New transaction fee:",
+      "Delizia": "New transaction fee:",
+      "Eckhart": "New transaction fee"
+    },
+    "modify_fee__no_change": {
+      "Bolt": "Fee did not change.\n",
+      "Caesar": "Fee did not change.\n",
+      "Delizia": "Fee did not change.\n",
+      "Eckhart": "Fee did not change"
+    },
     "modify_fee__title": "Modify fee",
-    "modify_fee__transaction_fee": "Transaction fee:",
+    "modify_fee__transaction_fee": {
+      "Bolt": "Transaction fee:",
+      "Caesar": "Transaction fee:",
+      "Delizia": "Transaction fee:",
+      "Eckhart": "Transaction fee"
+    },
     "monero__confirm_export": "Confirm export",
     "monero__confirm_ki_sync": "Confirm ki sync",
     "monero__confirm_refresh": "Confirm refresh",


### PR DESCRIPTION
This PR:
- updates `confirm_modify_output`, `new_confirm_with_menu`, `confirm_replacement` and `confirm_modify_fee` according to latest [Figma](https://www.figma.com/design/Dkl7W5PLqpr3TnXJ5hbnfd/--Future-Prod---Safe-7?node-id=6374-5404) design 
- adapts rules for the right action bar button in `new_confirm_with_menu` flow:
    - hold is true -> green style
    - empty verb param -> "Confirm" with green style
    - otherwise -> verb with default style
- updates dependency importing  in `component_msg_obj.rs` to suppress clippy warning

TODO:
- [x] update fixtures for other languages
- [x] add "no changelog" flag to the commits to avoid changelog check error