### PR TITLE
refactor(core): simplify per-model imports using `cfg-if` macro

### DIFF
--- a/core/embed/rust/Cargo.lock
+++ b/core/embed/rust/Cargo.lock
@@ -330,6 +330,7 @@ version = "0.1.0"
 dependencies = [
  "bindgen",
  "cc",
+ "cfg-if",
  "cty",
  "easer",
  "glob",

--- a/core/embed/rust/Cargo.toml
+++ b/core/embed/rust/Cargo.toml
@@ -95,6 +95,7 @@ split-debuginfo = "off"
 debug = 2
 
 [dependencies]
+cfg-if = { version = "1.0" }
 qrcodegen = { version = "1.8.0", path = "../../vendor/QR-Code-generator/rust-no-heap" }
 spin = { version = "0.9.8", features = ["rwlock"], default-features = false }
 trezor-tjpgdec = { version = "0.1.0", path = "../../../rust/trezor-tjpgdec" }

--- a/core/embed/rust/src/ui/constant.rs
+++ b/core/embed/rust/src/ui/constant.rs
@@ -1,23 +1,14 @@
 //! Reexporting the `constant` module according to the
 //! current feature (Trezor model)
 
-#[cfg(all(
-    feature = "layout_eckhart",
-    not(feature = "layout_bolt"),
-    not(feature = "layout_caesar"),
-    not(feature = "layout_delizia")
-))]
-pub use super::layout_eckhart::constant::*;
-
-#[cfg(all(
-    feature = "layout_delizia",
-    not(feature = "layout_bolt"),
-    not(feature = "layout_caesar")
-))]
-pub use super::layout_delizia::constant::*;
-
-#[cfg(all(feature = "layout_caesar", not(feature = "layout_bolt")))]
-pub use super::layout_caesar::constant::*;
-
-#[cfg(feature = "layout_bolt")]
-pub use super::layout_bolt::constant::*;
+cfg_if::cfg_if! {
+    if #[cfg(feature = "layout_bolt")] {
+        pub use super::layout_bolt::constant::*;
+    } else if #[cfg(feature = "layout_caesar")] {
+        pub use super::layout_caesar::constant::*;
+    } else if #[cfg(feature = "layout_delizia")] {
+        pub use super::layout_delizia::constant::*;
+    } else if #[cfg(feature = "layout_eckhart")] {
+        pub use super::layout_eckhart::constant::*;
+    }
+}

--- a/core/embed/rust/src/ui/mod.rs
+++ b/core/embed/rust/src/ui/mod.rs
@@ -41,20 +41,14 @@ pub use ui_common::CommonUI;
 #[cfg(feature = "ui_debug_overlay")]
 pub use ui_common::DebugOverlay;
 
-#[cfg(all(
-    feature = "layout_eckhart",
-    not(feature = "layout_bolt"),
-    not(feature = "layout_caesar"),
-    not(feature = "layout_delizia")
-))]
-pub type ModelUI = crate::ui::layout_eckhart::UIEckhart;
-#[cfg(all(
-    feature = "layout_delizia",
-    not(feature = "layout_bolt"),
-    not(feature = "layout_caesar")
-))]
-pub type ModelUI = crate::ui::layout_delizia::UIDelizia;
-#[cfg(all(feature = "layout_caesar", not(feature = "layout_bolt")))]
-pub type ModelUI = crate::ui::layout_caesar::UICaesar;
-#[cfg(feature = "layout_bolt")]
-pub type ModelUI = crate::ui::layout_bolt::UIBolt;
+cfg_if::cfg_if! {
+    if #[cfg(feature = "layout_bolt")] {
+        pub type ModelUI = crate::ui::layout_bolt::UIBolt;
+    } else if #[cfg(feature = "layout_caesar")] {
+        pub type ModelUI = crate::ui::layout_caesar::UICaesar;
+    } else if #[cfg(feature = "layout_delizia")] {
+        pub type ModelUI = crate::ui::layout_delizia::UIDelizia;
+    } else if #[cfg(feature = "layout_eckhart")] {
+        pub type ModelUI = crate::ui::layout_eckhart::UIEckhart;
+    }
+}

--- a/tests/device_tests/test_basic.py
+++ b/tests/device_tests/test_basic.py
@@ -48,7 +48,7 @@ def test_device_id_same(client: Client):
     # ID must be at least 12 characters
     assert len(id1) >= 12
 
-    # Every resulf of UUID must be the same
+    # Every result of UUID must be the same
     assert id1 == id2
 
 


### PR DESCRIPTION
IIUC, it should result in similar `#cfg`-based construction:
```rust
macro_rules! cfg_if {
    // match if/else chains with a final `else`
    ($(
        if #[cfg($meta:meta)] { $($tokens:tt)* }
    ) else * else {
        $($tokens2:tt)*
    }) => {
        $crate::cfg_if! {
            @__items
            () ;
            $( ( ($meta) ($($tokens)*) ), )*
            ( () ($($tokens2)*) ),
        }
    };

    // match if/else chains lacking a final `else`
    (
        if #[cfg($i_met:meta)] { $($i_tokens:tt)* }
        $(
            else if #[cfg($e_met:meta)] { $($e_tokens:tt)* }
        )*
    ) => {
        $crate::cfg_if! {
            @__items
            () ;
            ( ($i_met) ($($i_tokens)*) ),
            $( ( ($e_met) ($($e_tokens)*) ), )*
            ( () () ),
        }
    };

    // Internal and recursive macro to emit all the items
    //
    // Collects all the negated cfgs in a list at the beginning and after the
    // semicolon is all the remaining items
    (@__items ($($not:meta,)*) ; ) => {};
    (@__items ($($not:meta,)*) ; ( ($($m:meta),*) ($($tokens:tt)*) ), $($rest:tt)*) => {
        // Emit all items within one block, applying an appropriate #[cfg]. The
        // #[cfg] will require all `$m` matchers specified and must also negate
        // all previous matchers.
        #[cfg(all($($m,)* not(any($($not),*))))] $crate::cfg_if! { @__identity $($tokens)* }

        // Recurse to emit all other items in `$rest`, and when we do so add all
        // our `$m` matchers to the list of `$not` matchers as future emissions
        // will have to negate everything we just matched as well.
        $crate::cfg_if! { @__items ($($not,)* $($m,)*) ; $($rest)* }
    };

    // Internal macro to make __apply work out right for different match types,
    // because of how macros matching/expand stuff.
    (@__identity $($tokens:tt)*) => {
        $($tokens)*
    };
}
```
https://github.com/rust-lang/cfg-if/blob/1.0.0/src/lib.rs