### PR TITLE
ci(core): enable retries only for HW tests

### DIFF
--- a/.github/workflows/core-hw.yml
+++ b/.github/workflows/core-hw.yml
@@ -39,7 +39,13 @@ jobs:
       STORAGE_INSECURE_TESTING_MODE: 1
       BOOTLOADER_DEVEL: ${{ matrix.model == 'T2B1' && '1' || '0' }}
       # TODO: enable SD-related tests after fixing #4924
-      TESTOPTS: "-m 'not sd_card' -k 'not authenticate' --durations=50 --session-timeout 19800"  # 5.5h pytest global timeout
+      # 5.5h pytest global timeout
+      TESTOPTS: >-
+        -m 'not sd_card' -k 'not authenticate'
+        --durations=50
+        --session-timeout 19800
+        --retries=5
+        --retry-delay=1
       TT_UHUB_PORT: 1
     timeout-minutes: 360  # 6h CI job timeout
     steps:

--- a/setup.cfg
+++ b/setup.cfg
@@ -40,8 +40,6 @@ addopts =
     -rfER
     --strict-markers
     --random-order
-    --retries=5
-    --retry-delay=1
 testpaths = tests crypto storage python/tests
 xfail_strict = true
 junit_family = xunit2


### PR DESCRIPTION
Following https://yaml-multiline.info, `>-` is used to split `TESTOPTS` in `core-hw.yml`.

<!--
For core developers:
- Assign yourself to the PR.
- Set the priority to match the original issue.
- Add the PR to the current sprint.
- If it's a draft PR, mark it as "In Progress."
- If it's a final PR, mark it as "Needs Review."

For external contributors:
- Please open an issue before submitting a PR so we can discuss whether we want to proceed with it.
-->
