### PR TITLE
fix(core): ignore context on `early_response()`

### DIFF
--- a/core/src/trezor/wire/__init__.py
+++ b/core/src/trezor/wire/__init__.py
@@ -62,11 +62,13 @@ _EARLY_RESPONSE = EarlyResponse()
 
 
 async def early_response(response: Msg, layout: Awaitable[None]) -> EarlyResponse[Msg]:
-    from .context import get_context
+    from . import context
 
     # first, send the response back to the client
-    await get_context().write(response)
-    # then, show the success layout
+    await context.get_context().write(response)
+    # then, show the success layout without a context, to avoid
+    # `UnexpectedMessageException` during the confirmation layout.
+    context.CURRENT_CONTEXT = None
     await layout
     # return a special marker object
     return _EARLY_RESPONSE


### PR DESCRIPTION
Related to #3666.

<!--
For core developers:
- Assign yourself to the PR.
- Set the priority to match the original issue.
- Add the PR to the current sprint.
- If it's a draft PR, mark it as "In Progress."
- If it's a final PR, mark it as "Needs Review."

For external contributors:
- Please open an issue before submitting a PR so we can discuss whether we want to proceed with it.
-->
