### PR TITLE
fix(core): fix `DeprecationWarning` for `datetime.datetime.utcnow()`

### DIFF
--- a/core/translations/cli.py
+++ b/core/translations/cli.py
@@ -76,7 +76,7 @@ def _version_str(version: tuple[int, ...]) -> str:
 
 
 def make_tree_info(merkle_root: bytes) -> UnsignedInfo:
-    now = datetime.datetime.utcnow()
+    now = datetime.datetime.now(datetime.UTC)
     commit = (
         subprocess.check_output(["git", "rev-parse", "HEAD"], cwd=HERE)
         .decode("ascii")


### PR DESCRIPTION
```
>>> datetime.datetime.utcnow()
DeprecationWarning: datetime.datetime.utcnow() is deprecated and scheduled for removal in a future version. Use timezone-aware objects to represent datetimes in UTC: datetime.datetime.now(datetime.UTC).
  datetime.datetime.utcnow()
datetime.datetime(2025, 5, 27, 10, 59, 12, 672487)

>>> datetime.datetime.now(datetime.UTC)
datetime.datetime(2025, 5, 27, 10, 59, 18, 590023, tzinfo=datetime.timezone.utc)
```

<!--
For core developers:
- Assign yourself to the PR.
- Set the priority to match the original issue.
- Add the PR to the current sprint.
- If it's a draft PR, mark it as "In Progress."
- If it's a final PR, mark it as "Needs Review."

For external contributors:
- Please open an issue before submitting a PR so we can discuss whether we want to proceed with it.
-->
