### PR TITLE
fix(core/delizia): incorrect shares number input

### DIFF
--- a/core/.changelog.d/5099.fixed
+++ b/core/.changelog.d/5099.fixed
@@ -1,0 +1,1 @@
+[T3T1] Incorrect number of shares input.


### PR DESCRIPTION
<!--
For core developers:
- Assign yourself to the PR.
- Set the priority to match the original issue.
- Add the PR to the current sprint.
- If it's a draft PR, mark it as "In Progress."
- If it's a final PR, mark it as "Needs Review."

For external contributors:
- Please open an issue before submitting a PR so we can discuss whether we want to proceed with it.
-->

The bug was introduced in this PR https://github.com/trezor/trezor-firmware/pull/4763 which was released for `25.05`, i.e. Firmware version 2.8.10

Due to the bug, a user may have incorrect number of shares or threshold in multi-share backup. The incorrect value was always off by 1. It happened if the user incremented or decremented the value and then dirrectly tapped to the footer to confirm. If the user tapped somewhere else between inc/dec, the value was correct.
