### PR TITLE
fix bootloader entry on T3W1

### DIFF
--- a/core/embed/io/haptic/drv2625/drv2625.c
+++ b/core/embed/io/haptic/drv2625/drv2625.c
@@ -37,6 +37,10 @@
 #define PRESS_EFFECT_AMPLITUDE 25
 // Duration of the button press effect
 #define PRESS_EFFECT_DURATION 10
+// Amplitude of the bootloader entry effect
+#define BOOTLOADER_ENTRY_EFFECT_AMPLITUDE 100
+// Duration of the bootloader entry effect
+#define BOOTLOADER_ENTRY_EFFECT_DURATION 300
 
 // Actuator configuration
 #include HAPTIC_ACTUATOR
@@ -345,6 +349,10 @@ bool haptic_play(haptic_effect_t effect) {
       break;
     case HAPTIC_HOLD_TO_CONFIRM:
       return haptic_play_lib(DOUBLE_CLICK_60);
+      break;
+    case HAPTIC_BOOTLOADER_ENTRY:
+      return haptic_play_rtp(BOOTLOADER_ENTRY_EFFECT_AMPLITUDE,
+                             BOOTLOADER_ENTRY_EFFECT_DURATION);
       break;
     default:
       break;

--- a/core/embed/io/haptic/inc/io/haptic.h
+++ b/core/embed/io/haptic/inc/io/haptic.h
@@ -26,6 +26,8 @@ typedef enum {
   HAPTIC_BUTTON_PRESS = 0,
   // Effect at the end of hold-to-confirm action
   HAPTIC_HOLD_TO_CONFIRM = 1,
+  // Bootloader entry
+  HAPTIC_BOOTLOADER_ENTRY = 2,
 } haptic_effect_t;
 
 #ifdef KERNEL_MODE

--- a/core/embed/projects/bootloader/main.c
+++ b/core/embed/projects/bootloader/main.c
@@ -159,7 +159,7 @@ static secbool boot_sequence(secbool manufacturing_mode) {
       uint32_t elapsed = systick_ms() - press_start;
       if (elapsed >= 3000 && !bld_locked) {
 #ifdef USE_HAPTIC
-        haptic_play(HAPTIC_BUTTON_PRESS);
+        haptic_play(HAPTIC_BOOTLOADER_ENTRY);
 #endif
         bld_locked = true;
       } else if ((elapsed >= 1000 || manufacturing_mode == sectrue) &&


### PR DESCRIPTION
This PR fixes an issue with entering bootloader on T3W1, and changes the haptic effect on success.
