### PR TITLE
prodtest backlight control fix

### DIFF
--- a/core/embed/projects/prodtest/cmd/prodtest_display.c
+++ b/core/embed/projects/prodtest/cmd/prodtest_display.c
@@ -23,6 +23,8 @@
 #include <io/display.h>
 #include <rtl/cli.h>
 
+#include "prodtest.h"
+
 static void prodtest_display_border(cli_t* cli) {
   if (cli_arg_count(cli) > 0) {
     cli_error_arg_count(cli);
@@ -95,6 +97,7 @@ static void prodtest_display_set_backlight(cli_t* cli) {
 
   cli_trace(cli, "Updating display backlight level to %d...", level);
   display_set_backlight(level);
+  prodtest_show_homescreen();
 
   cli_ok(cli, "");
 }

--- a/core/embed/projects/prodtest/main.c
+++ b/core/embed/projects/prodtest/main.c
@@ -252,8 +252,6 @@ void prodtest_show_homescreen(void) {
   } else {
     screen_prodtest_welcome(&g_layout.layout, NULL, 0);
   }
-
-  display_set_backlight(150);
 }
 
 int main(void) {
@@ -287,6 +285,7 @@ int main(void) {
   rgb_led_set_color(RGBLED_GREEN);
 #endif
 
+  display_set_backlight(150);
   prodtest_show_homescreen();
 
   while (true) {

--- a/core/embed/rust/src/ui/layout_bolt/prodtest/mod.rs
+++ b/core/embed/rust/src/ui/layout_bolt/prodtest/mod.rs
@@ -11,7 +11,7 @@ use crate::ui::{
     },
     geometry::{Alignment, Offset, Rect},
     layout::simplified::{process_frame_event, show},
-    layout_bolt::{fonts, prodtest::welcome::Welcome, theme, UIBolt},
+    layout_bolt::{fonts, prodtest::welcome::Welcome, UIBolt},
     shape,
     shape::render_on_display,
     ui_prodtest::{ProdtestLayoutType, ProdtestUI},
@@ -54,7 +54,6 @@ impl ProdtestUI for UIBolt {
         });
 
         display::refresh();
-        display::fade_backlight_duration(theme::backlight::get_backlight_normal(), 150);
     }
 
     fn screen_prodtest_border() {
@@ -68,7 +67,6 @@ impl ProdtestUI for UIBolt {
         });
 
         display::refresh();
-        display::fade_backlight_duration(theme::backlight::get_backlight_normal(), 150);
     }
 
     fn screen_prodtest_bars(colors: &str) {
@@ -105,7 +103,6 @@ impl ProdtestUI for UIBolt {
         });
 
         display::refresh();
-        display::fade_backlight_duration(theme::backlight::get_backlight_normal(), 150);
     }
 
     fn screen_prodtest_touch(area: Rect) {
@@ -118,7 +115,6 @@ impl ProdtestUI for UIBolt {
         });
 
         display::refresh();
-        display::set_backlight(theme::backlight::get_backlight_normal());
     }
 
     fn screen_prodtest_draw(events: Vec<TouchEvent, 256>) {


### PR DESCRIPTION
This PR fixes and issue with setting backlight in prodtest. while backlight could be set, it also causes screen to go blank and was reset after any other command (showing something on display), so not very useful.

Now prodtest homescreen will be shown after the backlight command, and other commands will not override the setting.