### PR TITLE
fix(core): make `'.'` part of `ethereum__unknown_contract_address`

### DIFF
--- a/core/embed/rust/src/translations/generated/translated_string.rs
+++ b/core/embed/rust/src/translations/generated/translated_string.rs
@@ -1336,7 +1336,7 @@ pub enum TranslatedString {
     address__public_key_confirmed = 966,  // "Public key confirmed"
     words__continue_anyway = 967,  // "Continue anyway"
     #[cfg(feature = "universal_fw")]
-    ethereum__unknown_contract_address = 968,  // "Unknown contract address"
+    ethereum__unknown_contract_address = 968,  // "Unknown contract address."
     #[cfg(feature = "universal_fw")]
     ethereum__token_contract = 969,  // "Token contract"
     buttons__view_all_data = 970,  // "View all data"
@@ -2747,7 +2747,7 @@ impl TranslatedString {
             (Self::address__public_key_confirmed, "Public key confirmed"),
             (Self::words__continue_anyway, "Continue anyway"),
             #[cfg(feature = "universal_fw")]
-            (Self::ethereum__unknown_contract_address, "Unknown contract address"),
+            (Self::ethereum__unknown_contract_address, "Unknown contract address."),
             #[cfg(feature = "universal_fw")]
             (Self::ethereum__token_contract, "Token contract"),
             (Self::buttons__view_all_data, "View all data"),

--- a/core/mocks/trezortranslate_keys.pyi
+++ b/core/mocks/trezortranslate_keys.pyi
@@ -328,7 +328,7 @@ class TR:
     ethereum__title_signing_address: str = "Signing address"
     ethereum__token_contract: str = "Token contract"
     ethereum__units_template: str = "{0} units"
-    ethereum__unknown_contract_address: str = "Unknown contract address"
+    ethereum__unknown_contract_address: str = "Unknown contract address."
     ethereum__unknown_token: str = "Unknown token"
     ethereum__valid_signature: str = "The signature is valid."
     experimental_mode__enable: str = "Enable experimental features?"

--- a/core/src/trezor/ui/layouts/delizia/__init__.py
+++ b/core/src/trezor/ui/layouts/delizia/__init__.py
@@ -748,7 +748,7 @@ if not utils.BITCOIN_ONLY:
     def confirm_ethereum_unknown_contract_warning() -> Awaitable[None]:
         return show_danger(
             "unknown_contract_warning",
-            content=f"{TR.ethereum__unknown_contract_address}. {TR.words__know_what_your_doing}",
+            content=f"{TR.ethereum__unknown_contract_address} {TR.words__know_what_your_doing}",
             verb_cancel=TR.send__cancel_sign,
         )
 

--- a/core/translations/cs.json
+++ b/core/translations/cs.json
@@ -358,7 +358,7 @@
     "ethereum__title_signing_address": "Podepisování adresy",
     "ethereum__token_contract": "Kontrakt tokenu",
     "ethereum__units_template": "Jednotky: {0}",
-    "ethereum__unknown_contract_address": "Neznámá adresa kontraktu",
+    "ethereum__unknown_contract_address": "Neznámá adresa kontraktu.",
     "ethereum__unknown_token": "Neznámý token",
     "ethereum__valid_signature": "Podpis je platný.",
     "experimental_mode__enable": "Povolit experimentální funkce?",

--- a/core/translations/de.json
+++ b/core/translations/de.json
@@ -358,7 +358,7 @@
     "ethereum__title_signing_address": "Signieradresse",
     "ethereum__token_contract": "Tokenvertrag",
     "ethereum__units_template": "{0} Einheiten",
-    "ethereum__unknown_contract_address": "Unbekannte Vertragsadresse",
+    "ethereum__unknown_contract_address": "Unbekannte Vertragsadresse.",
     "ethereum__unknown_token": "Ungültiger Token",
     "ethereum__valid_signature": "Die Signatur ist gültig.",
     "experimental_mode__enable": "Experimentelle Funktionen aktivieren?",

--- a/core/translations/en.json
+++ b/core/translations/en.json
@@ -330,7 +330,7 @@
     "ethereum__title_signing_address": "Signing address",
     "ethereum__token_contract": "Token contract",
     "ethereum__units_template": "{0} units",
-    "ethereum__unknown_contract_address": "Unknown contract address",
+    "ethereum__unknown_contract_address": "Unknown contract address.",
     "ethereum__unknown_token": "Unknown token",
     "ethereum__valid_signature": "The signature is valid.",
     "experimental_mode__enable": "Enable experimental features?",

--- a/core/translations/es.json
+++ b/core/translations/es.json
@@ -358,7 +358,7 @@
     "ethereum__title_signing_address": "Dirección firma",
     "ethereum__token_contract": "Contrato de token",
     "ethereum__units_template": "{0} unidades",
-    "ethereum__unknown_contract_address": "Dirección de contrato desconocida",
+    "ethereum__unknown_contract_address": "Dirección de contrato desconocida.",
     "ethereum__unknown_token": "Token desconocido",
     "ethereum__valid_signature": "La firma es válida.",
     "experimental_mode__enable": "¿Activar funciones experimentales?",

--- a/core/translations/fr.json
+++ b/core/translations/fr.json
@@ -358,7 +358,7 @@
     "ethereum__title_signing_address": "Adr. de signature",
     "ethereum__token_contract": "Contrat de jeton",
     "ethereum__units_template": "{0} unités",
-    "ethereum__unknown_contract_address": "Adresse de contrat inconnue",
+    "ethereum__unknown_contract_address": "Adresse de contrat inconnue.",
     "ethereum__unknown_token": "Jeton inconnu",
     "ethereum__valid_signature": "Signature valide.",
     "experimental_mode__enable": "Activer les fonct. expérimentales ?",

--- a/core/translations/it.json
+++ b/core/translations/it.json
@@ -358,7 +358,7 @@
     "ethereum__title_signing_address": "Indirizzo di firma",
     "ethereum__token_contract": "Contratto token",
     "ethereum__units_template": "{0} unità",
-    "ethereum__unknown_contract_address": "Indirizzo del contratto sconosciuto",
+    "ethereum__unknown_contract_address": "Indirizzo del contratto sconosciuto.",
     "ethereum__unknown_token": "Token sconosciuto",
     "ethereum__valid_signature": "La firma è valida.",
     "experimental_mode__enable": "Abilitare funzion. sperimentali?",

--- a/core/translations/pt.json
+++ b/core/translations/pt.json
@@ -358,7 +358,7 @@
     "ethereum__title_signing_address": "End. assinatura",
     "ethereum__token_contract": "Contrato Token",
     "ethereum__units_template": "{0} unidades",
-    "ethereum__unknown_contract_address": "Endereço de contrato desconhecido",
+    "ethereum__unknown_contract_address": "Endereço de contrato desconhecido.",
     "ethereum__unknown_token": "Token desconhecido",
     "ethereum__valid_signature": "A assinatura é válida.",
     "experimental_mode__enable": "Ativar recursos experimentais?",

--- a/core/translations/signatures.json
+++ b/core/translations/signatures.json
@@ -1,8 +1,8 @@
 {
   "current": {
-    "merkle_root": "237c8b9cc7a9473b8c84b6b8a874e75272669a57994a36877361280fefca0748",
-    "datetime": "2025-05-28T08:30:30.276442",
-    "commit": "e67526c12f7972ba056347194313d080a6703f74"
+    "merkle_root": "ffc15d97b4b6ea18590fb7a3c51d8b1bae707d65169191d2f8c7726efc663ff7",
+    "datetime": "2025-05-28T09:41:28.075905",
+    "commit": "aca41ac5ce9d30f583e87aea0b0c00a2476c6354"
   },
   "history": [
     {


### PR DESCRIPTION
Following https://github.com/trezor/trezor-firmware/pull/5086#discussion_r2111306385.

<!--
For core developers:
- Assign yourself to the PR.
- Set the priority to match the original issue.
- Add the PR to the current sprint.
- If it's a draft PR, mark it as "In Progress."
- If it's a final PR, mark it as "Needs Review."

For external contributors:
- Please open an issue before submitting a PR so we can discuss whether we want to proceed with it.
-->
