### PR TITLE
improved battery precharge 

### DIFF
--- a/core/embed/projects/prodtest/README.md
+++ b/core/embed/projects/prodtest/README.md
@@ -692,18 +692,6 @@ optiga-counter-read
 OK 0E
 ```
 
-### pm-set-soc-limit
-Sets the battery state of charge (SOC) limit. The SOC limit is a percentage value between 10 and 100.
-
-The command returns `OK` if the operation is successful.
-
-```
-pm-set-soc-limit 50
-# Set SOC limit to 50%
-OK
-
-```
-
 ### pm-precharge <soc_target>
 Precharge the battery to the given SoC target.
 During the precharge, command will print out target precharge voltage and battery stats into the console. CTRL+C will terminate the precharge.

--- a/core/embed/projects/prodtest/README.md
+++ b/core/embed/projects/prodtest/README.md
@@ -704,30 +704,19 @@ OK
 
 ```
 
-### pm-precharge
-Enables the battery charging and precharge the battery to the 3.45V. Then it disables charging and terminates.
-During the precharge, command will print out power manager report into the console. CTRL+C will terminate the precharge.
+### pm-precharge <soc_target>
+Precharge the battery to the given SoC target.
+During the precharge, command will print out target precharge voltage and battery stats into the console. CTRL+C will terminate the precharge.
 
 Example:
 ```
 pm-precharge
-# Precharging the device ...
-# Precharging the device to 3.450 V
-# Power manager report:
-# Power state 5
-#   USB connected
-#   WLC disconnected
-#   Battery voltage: 3.435 V
-#   Battery current: -191.700 mA
-#   Battery temperature: 31.541 C
-#   Battery SoC: 68.92
-#   Battery SoC latched: 69.00
-#   PMIC die temperature: 49.096 C
-#   WLC voltage: 0.000 V
-#   WLC current: 0.000 mA
-#   WLC die temperature: 0.000 C
-#   System voltage: 4.449 V
-PROGRESS 5 USB_connected WLC_disconnected 3.435 -191.700 31.541 68.92 69.00 49.096 0.000 0.000 0.000 4.449
+# Target voltage: 3.485V (80 SoC), Battery: 3.431V -190.575mA 23.364 deg
+PROGRESS 3.485 3.431 -190.575 23.364
+# Target voltage: 3.485V (80 SoC), Battery: 3.431V -190.800mA 23.364 deg
+PROGRESS 3.485 3.431 -190.800 23.364
+...
+# Voltage target reached. precharge complete
 OK
 ```
 

--- a/core/embed/projects/prodtest/cmd/prodtest_power_manager.c
+++ b/core/embed/projects/prodtest/cmd/prodtest_power_manager.c
@@ -411,24 +411,6 @@ void prodtest_pm_precharge(cli_t* cli) {
   return;
 }
 
-void prodtest_pm_set_soc_limit(cli_t* cli) {
-  uint32_t limit = 0;
-  if (!cli_arg_uint32(cli, "limit", &limit) || limit > 100 || limit < 10) {
-    cli_error_arg(cli, "Expecting value in range 10-100");
-    return;
-  }
-
-  if (cli_arg_count(cli) > 1) {
-    cli_error_arg_count(cli);
-    return;
-  }
-
-  pm_set_soc_limit(limit);
-
-  cli_trace(cli, "Set SOC limit to %d%%", limit);
-  cli_ok(cli, "");
-}
-
 // clang-format off
 
 PRODTEST_CLI_CMD(
@@ -485,13 +467,6 @@ PRODTEST_CLI_CMD(
   .func = prodtest_pm_precharge,
   .info = "Precharge the device to specific voltage",
   .args = "<soc_target>",
-);
-
-PRODTEST_CLI_CMD(
-  .name = "pm-set-soc-limit",
-  .func = prodtest_pm_set_soc_limit,
-  .info = "Set limit for the battery SOC",
-  .args = "<limit>"
 );
 
 #endif /* USE POWER_MANAGER */

--- a/core/embed/projects/prodtest/main.c
+++ b/core/embed/projects/prodtest/main.c
@@ -194,7 +194,6 @@ static void drivers_init(void) {
 #endif
 #ifdef USE_POWER_MANAGER
   pm_init(true);
-  pm_set_soc_limit(70);
 #endif
 
   display_init(DISPLAY_RESET_CONTENT);

--- a/core/embed/sys/power_manager/inc/sys/power_manager.h
+++ b/core/embed/sys/power_manager/inc/sys/power_manager.h
@@ -176,6 +176,15 @@ pm_status_t pm_charging_set_max_current(uint16_t current_ma);
 pm_status_t pm_set_soc_limit(uint8_t limit);
 
 /**
+ * @brief This function overrides the fuel gauge State of Charge (SoC) value.
+ * Setting the SoC to the incorrect value may impact the fue gauge performance
+ * for several battery cycles, so this function has to be used with caution.
+ * @param soc SoC percentage (0-100%)
+ * @return pm_status_t Status code indicating success or failure
+ */
+pm_status_t pm_override_soc(uint8_t soc);
+
+/**
  * @brief Store power manager data to backup RAM
  * @return pm_status_t Status code indicating success or failure
  */

--- a/core/embed/sys/power_manager/inc/sys/power_manager.h
+++ b/core/embed/sys/power_manager/inc/sys/power_manager.h
@@ -169,13 +169,6 @@ pm_status_t pm_charging_disable(void);
 pm_status_t pm_charging_set_max_current(uint16_t current_ma);
 
 /**
- * @brief Set the battery State of Charge limit for operations
- * @param limit SoC limit percentage (0-100%)
- * @return pm_status_t Status code indicating success or failure
- */
-pm_status_t pm_set_soc_limit(uint8_t limit);
-
-/**
  * @brief This function overrides the fuel gauge State of Charge (SoC) value.
  * Setting the SoC to the incorrect value may impact the fue gauge performance
  * for several battery cycles, so this function has to be used with caution.

--- a/core/embed/sys/power_manager/stm32u5/power_manager.c
+++ b/core/embed/sys/power_manager/stm32u5/power_manager.c
@@ -131,8 +131,7 @@ pm_status_t pm_init(bool inherit_state) {
   // Enable charging by default to max current
   drv->charging_enabled = true;
 
-  // Set default SOC limit and max charging current limit
-  drv->soc_limit = 100;
+  // Set default max charging current limit
   drv->charging_current_max_limit_ma = PM_BATTERY_CHARGING_CURRENT_MAX;
 
   // Fuel gauge SoC available, set fuel_gauge initialized.
@@ -455,28 +454,6 @@ pm_status_t pm_wakeup_flags_get(pm_wakeup_flags_t* flags) {
   irq_key_t irq_key = irq_lock();
   *flags = drv->wakeup_flags;
   irq_unlock(irq_key);
-  return PM_OK;
-}
-
-pm_status_t pm_set_soc_limit(uint8_t limit) {
-  pm_driver_t* drv = &g_pm;
-
-  if (!drv->initialized) {
-    return PM_NOT_INITIALIZED;
-  }
-
-  if (limit > 100) {
-    return PM_ERROR;
-  }
-
-  if (limit <= PM_SOC_LIMIT_HYSTERESIS) {
-    return PM_ERROR;
-  }
-
-  irq_key_t irq_key = irq_lock();
-  drv->soc_limit = limit;
-  irq_unlock(irq_key);
-
   return PM_OK;
 }
 

--- a/core/embed/sys/power_manager/stm32u5/power_manager.c
+++ b/core/embed/sys/power_manager/stm32u5/power_manager.c
@@ -480,6 +480,24 @@ pm_status_t pm_set_soc_limit(uint8_t limit) {
   return PM_OK;
 }
 
+pm_status_t pm_override_soc(uint8_t soc) {
+  pm_driver_t* drv = &g_pm;
+
+  if (!drv->initialized) {
+    return PM_NOT_INITIALIZED;
+  }
+
+  if (soc > 100) {
+    return PM_ERROR;
+  }
+
+  irq_key_t irq_key = irq_lock();
+  fuel_gauge_set_soc(&drv->fuel_gauge, ((float)soc) / 100, drv->fuel_gauge.P);
+  irq_unlock(irq_key);
+
+  return PM_OK;
+}
+
 // Timer handlers
 static void pm_monitoring_timer_handler(void* context) {
   pm_monitor_power_sources();

--- a/core/embed/sys/power_manager/stm32u5/power_manager_internal.h
+++ b/core/embed/sys/power_manager/stm32u5/power_manager_internal.h
@@ -35,7 +35,6 @@
 #define PM_BATTERY_UNDERVOLT_RECOVERY_THR_V 3.1f
 #define PM_BATTERY_UNDERVOLT_RECOVERY_WPC_THR_V 3.2f
 #define PM_BATTERY_LOW_THRESHOLD_SOC 15
-#define PM_SOC_LIMIT_HYSTERESIS 5
 #define PM_BATTERY_CHARGING_CURRENT_MAX PMIC_CHARGING_LIMIT_MAX
 #define PM_BATTERY_CHARGING_CURRENT_MIN PMIC_CHARGING_LIMIT_MIN
 #define PM_BATTERY_SAMPLING_BUF_SIZE 10
@@ -69,8 +68,6 @@ typedef struct {
   uint8_t bat_sampling_buf_tail_idx;
   uint8_t bat_sampling_buf_head_idx;
   uint8_t soc_ceiled;
-  uint8_t soc_limit;
-  bool soc_limit_reached;
 
   // Battery charging state
   bool charging_enabled;

--- a/core/embed/sys/power_manager/stm32u5/power_monitoring.c
+++ b/core/embed/sys/power_manager/stm32u5/power_monitoring.c
@@ -190,17 +190,6 @@ void pm_charging_controller(pm_driver_t* drv) {
     pmic_set_charging_limit(drv->charging_current_target_ma);
   }
 
-  if (drv->soc_ceiled >= drv->soc_limit) {
-    drv->soc_limit_reached = true;
-  } else if (drv->soc_ceiled < drv->soc_limit - PM_SOC_LIMIT_HYSTERESIS) {
-    drv->soc_limit_reached = false;
-  }
-
-  if (drv->soc_limit_reached) {
-    // Set charging current limit to 0
-    drv->charging_current_target_ma = 0;
-  }
-
   if (drv->charging_current_target_ma == 0) {
     pmic_set_charging(false);
   } else {


### PR DESCRIPTION
This PR improves prodtest pm-precharge command.

Instead of charging to fixed voltage, now you can use and argument to precharge the battery to a specific SoC.
voltage for given SoC is extracted directly from the charging battery model.

When the battery is precharged, charging is disabled so the battery charge will remain.

PR also get rid of the power manager SoC limit which should no longer be needed.
