### PR TITLE
test(core): don't wait on `StatusScreen` if animation is disabled

### DIFF
--- a/core/embed/rust/src/ui/layout_delizia/component/status_screen.rs
+++ b/core/embed/rust/src/ui/layout_delizia/component/status_screen.rs
@@ -143,6 +143,12 @@ enum DismissType {
     Timeout(Timeout),
 }
 
+impl DismissType {
+    fn limited_timeout(time_ms: u32) -> Self {
+        Self::Timeout(Timeout::new(if animation_disabled() { 0 } else { time_ms }))
+    }
+}
+
 impl StatusScreen {
     fn new(
         icon: Icon,
@@ -177,7 +183,7 @@ impl StatusScreen {
             theme::ICON_SIMPLE_CHECKMARK30,
             theme::GREEN_LIME,
             theme::GREEN_LIGHT,
-            DismissType::Timeout(Timeout::new(time_ms)),
+            DismissType::limited_timeout(time_ms),
             msg,
         )
     }
@@ -197,7 +203,7 @@ impl StatusScreen {
             theme::ICON_SIMPLE_CHECKMARK30,
             theme::GREY_EXTRA_LIGHT,
             theme::GREY_DARK,
-            DismissType::Timeout(Timeout::new(TIMEOUT_MS)),
+            DismissType::limited_timeout(TIMEOUT_MS),
             msg,
         )
     }


### PR DESCRIPTION
Following https://github.com/trezor/trezor-firmware/pull/5115#discussion_r2115951787.