### PR TITLE
ci(core): disable authenticity tests on HW CI

### DIFF
--- a/.github/workflows/core-hw.yml
+++ b/.github/workflows/core-hw.yml
@@ -39,9 +39,11 @@ jobs:
       STORAGE_INSECURE_TESTING_MODE: 1
       BOOTLOADER_DEVEL: ${{ matrix.model == 'T2B1' && '1' || '0' }}
       # TODO: enable SD-related tests after fixing #4924
+      # Disable authenticity test since it requires DISABLE_OPTIGA=0
       # 5.5h pytest global timeout
       TESTOPTS: >-
         -m 'not sd_card'
+        -k 'not test_authenticate_device'
         --durations=50
         --session-timeout 19800
         --retries=5


### PR DESCRIPTION
T2B1 device seems to have a locked bootloader so #5087 is not enough.
https://github.com/trezor/trezor-firmware/actions/runs/15368486126/job/43244403997#step:8:19


<!--
For core developers:
- Assign yourself to the PR.
- Set the priority to match the original issue.
- Add the PR to the current sprint.
- If it's a draft PR, mark it as "In Progress."
- If it's a final PR, mark it as "Needs Review."

For external contributors:
- Please open an issue before submitting a PR so we can discuss whether we want to proceed with it.
-->
