### PR TITLE
fix(core/prodtest): fix vcp jamming when USB unplugged.

### DIFF
--- a/core/embed/projects/prodtest/main.c
+++ b/core/embed/projects/prodtest/main.c
@@ -125,7 +125,7 @@ static size_t console_read(void *context, char *buf, size_t size) {
 }
 
 static size_t console_write(void *context, const char *buf, size_t size) {
-  return usb_vcp_write_blocking(VCP_IFACE, (const uint8_t *)buf, size, -1);
+  return usb_vcp_write_blocking(VCP_IFACE, (const uint8_t *)buf, size, 100);
 }
 
 static void vcp_intr(void) { cli_abort(&g_cli); }


### PR DESCRIPTION
This PR fixes the issue where the prodtest VCP got stuck when the USB is unplugged.

The problem is described in detail here: https://github.com/trezor/trezor-firmware/issues/4980

Ideally, this workaround should be improved by fully disconnecting the VCP whenever no USB cable is detected.