### PR TITLE
Optimize `Button` memory layout

### DIFF
--- a/core/embed/rust/src/time.rs
+++ b/core/embed/rust/src/time.rs
@@ -10,6 +10,19 @@ const MILLIS_PER_MINUTE: u32 = MILLIS_PER_SEC * 60;
 const MILLIS_PER_HOUR: u32 = MILLIS_PER_MINUTE * 60;
 const MILLIS_PER_DAY: u32 = MILLIS_PER_HOUR * 24;
 
+#[derive(Copy, Clone, Debug, PartialEq, Eq)]
+pub struct ShortDuration {
+    millis: u16,
+}
+
+impl ShortDuration {
+    pub const ZERO: Self = Self::from_millis(0);
+
+    pub const fn from_millis(millis: u16) -> Self {
+        Self { millis }
+    }
+}
+
 #[derive(Copy, Clone, Debug, PartialEq, Eq, PartialOrd, Ord, Default)]
 pub struct Duration {
     millis: u32,
@@ -165,6 +178,12 @@ impl Div<Duration> for Duration {
 
     fn div(self, rhs: Self) -> Self::Output {
         self.to_millis() as f32 / rhs.to_millis() as f32
+    }
+}
+
+impl From<ShortDuration> for Duration {
+    fn from(value: ShortDuration) -> Self {
+        Self::from_millis(value.millis.into())
     }
 }
 

--- a/core/embed/rust/src/ui/geometry.rs
+++ b/core/embed/rust/src/ui/geometry.rs
@@ -539,6 +539,10 @@ impl Insets {
         }
     }
 
+    pub const fn zero() -> Self {
+        Self::new(0, 0, 0, 0)
+    }
+
     pub const fn uniform(d: i16) -> Self {
         Self::new(d, d, d, d)
     }

--- a/core/embed/rust/src/ui/layout_bolt/component/button.rs
+++ b/core/embed/rust/src/ui/layout_bolt/component/button.rs
@@ -2,7 +2,7 @@
 use crate::trezorhal::haptic::{self, HapticEffect};
 use crate::{
     strutil::TString,
-    time::Duration,
+    time::ShortDuration,
     ui::{
         component::{
             Component, ComponentExt, Event, EventCtx, FixedHeightBar, MsgMap, Split, Timer,
@@ -41,7 +41,7 @@ pub struct Button {
     content: ButtonContent,
     styles: ButtonStyleSheet,
     state: State,
-    long_press: Duration,
+    long_press: ShortDuration, // long press requires non-zero duration
     long_timer: Timer,
     haptics: bool,
 }
@@ -58,7 +58,7 @@ impl Button {
             touch_expand: Insets::zero(),
             styles: theme::button_default(),
             state: State::Initial,
-            long_press: Duration::ZERO,
+            long_press: ShortDuration::ZERO,
             long_timer: Timer::new(),
             haptics: true,
         }
@@ -94,7 +94,8 @@ impl Button {
         self
     }
 
-    pub fn with_long_press(mut self, duration: Duration) -> Self {
+    pub fn with_long_press(mut self, duration: ShortDuration) -> Self {
+        debug_assert_ne!(duration, ShortDuration::ZERO);
         self.long_press = duration;
         self
     }
@@ -251,8 +252,8 @@ impl Component for Button {
                                 haptic::play(HapticEffect::ButtonPress);
                             }
                             self.set(ctx, State::Pressed);
-                            if self.long_press != Duration::ZERO {
-                                self.long_timer.start(ctx, self.long_press)
+                            if self.long_press != ShortDuration::ZERO {
+                                self.long_timer.start(ctx, self.long_press.into())
                             }
                             return Some(ButtonMsg::Pressed);
                         }

--- a/core/embed/rust/src/ui/layout_bolt/component/button.rs
+++ b/core/embed/rust/src/ui/layout_bolt/component/button.rs
@@ -37,7 +37,7 @@ pub trait SelectHandler = Fn(ButtonMsg) -> Option<SelectWordMsg>;
 
 pub struct Button {
     area: Rect,
-    touch_expand: Option<Insets>,
+    touch_expand: Insets,
     content: ButtonContent,
     styles: ButtonStyleSheet,
     state: State,
@@ -55,7 +55,7 @@ impl Button {
         Self {
             content,
             area: Rect::zero(),
-            touch_expand: None,
+            touch_expand: Insets::zero(),
             styles: theme::button_default(),
             state: State::Initial,
             long_press: Duration::ZERO,
@@ -90,7 +90,7 @@ impl Button {
     }
 
     pub const fn with_expanded_touch_area(mut self, expand: Insets) -> Self {
-        self.touch_expand = Some(expand);
+        self.touch_expand = expand;
         self
     }
 
@@ -235,11 +235,7 @@ impl Component for Button {
     }
 
     fn event(&mut self, ctx: &mut EventCtx, event: Event) -> Option<Self::Msg> {
-        let touch_area = if let Some(expand) = self.touch_expand {
-            self.area.outset(expand)
-        } else {
-            self.area
-        };
+        let touch_area = self.area.outset(self.touch_expand);
 
         match event {
             Event::Touch(TouchEvent::TouchStart(pos)) => {

--- a/core/embed/rust/src/ui/layout_bolt/theme/mod.rs
+++ b/core/embed/rust/src/ui/layout_bolt/theme/mod.rs
@@ -2,7 +2,7 @@ pub mod backlight;
 pub mod bootloader;
 
 use crate::{
-    time::Duration,
+    time::ShortDuration,
     ui::{
         component::{
             text::{layout::Chunks, LineBreaking, PageBreaking, TextStyle},
@@ -19,7 +19,7 @@ use super::{
     fonts,
 };
 
-pub const ERASE_HOLD_DURATION: Duration = Duration::from_millis(1500);
+pub const ERASE_HOLD_DURATION: ShortDuration = ShortDuration::from_millis(1500);
 
 // Color palette.
 pub const WHITE: Color = Color::rgb(0xFF, 0xFF, 0xFF);

--- a/core/embed/rust/src/ui/layout_delizia/component/button.rs
+++ b/core/embed/rust/src/ui/layout_delizia/component/button.rs
@@ -24,7 +24,7 @@ pub enum ButtonMsg {
 
 pub struct Button {
     area: Rect,
-    touch_expand: Option<Insets>,
+    touch_expand: Insets,
     content: ButtonContent,
     styles: ButtonStyleSheet,
     text_align: Alignment,
@@ -45,7 +45,7 @@ impl Button {
         Self {
             content,
             area: Rect::zero(),
-            touch_expand: None,
+            touch_expand: Insets::zero(),
             styles: theme::button_default(),
             text_align: Alignment::Start,
             radius: None,
@@ -83,7 +83,7 @@ impl Button {
     }
 
     pub const fn with_expanded_touch_area(mut self, expand: Insets) -> Self {
-        self.touch_expand = Some(expand);
+        self.touch_expand = expand;
         self
     }
 
@@ -255,11 +255,7 @@ impl Component for Button {
     }
 
     fn event(&mut self, ctx: &mut EventCtx, event: Event) -> Option<Self::Msg> {
-        let touch_area = if let Some(expand) = self.touch_expand {
-            self.area.outset(expand)
-        } else {
-            self.area
-        };
+        let touch_area = self.area.outset(self.touch_expand);
 
         match event {
             Event::Touch(TouchEvent::TouchStart(pos)) => {

--- a/core/embed/rust/src/ui/layout_delizia/component/button.rs
+++ b/core/embed/rust/src/ui/layout_delizia/component/button.rs
@@ -2,7 +2,7 @@
 use crate::trezorhal::haptic::{play, HapticEffect};
 use crate::{
     strutil::TString,
-    time::Duration,
+    time::ShortDuration,
     ui::{
         component::{Component, Event, EventCtx, Timer},
         display::{toif::Icon, Color, Font},
@@ -30,7 +30,7 @@ pub struct Button {
     text_align: Alignment,
     radius: Option<u8>,
     state: State,
-    long_press: Option<Duration>,
+    long_press: ShortDuration, // long press requires non-zero duration
     long_timer: Timer,
     haptic: bool,
 }
@@ -50,7 +50,7 @@ impl Button {
             text_align: Alignment::Start,
             radius: None,
             state: State::Initial,
-            long_press: None,
+            long_press: ShortDuration::ZERO,
             long_timer: Timer::new(),
             haptic: true,
         }
@@ -87,8 +87,9 @@ impl Button {
         self
     }
 
-    pub fn with_long_press(mut self, duration: Duration) -> Self {
-        self.long_press = Some(duration);
+    pub fn with_long_press(mut self, duration: ShortDuration) -> Self {
+        debug_assert_ne!(duration, ShortDuration::ZERO);
+        self.long_press = duration;
         self
     }
 
@@ -271,8 +272,8 @@ impl Component for Button {
                                 play(HapticEffect::ButtonPress);
                             }
                             self.set(ctx, State::Pressed);
-                            if let Some(duration) = self.long_press {
-                                self.long_timer.start(ctx, duration);
+                            if self.long_press != ShortDuration::ZERO {
+                                self.long_timer.start(ctx, self.long_press.into());
                             }
                             return Some(ButtonMsg::Pressed);
                         }

--- a/core/embed/rust/src/ui/layout_delizia/component/hold_to_confirm.rs
+++ b/core/embed/rust/src/ui/layout_delizia/component/hold_to_confirm.rs
@@ -1,5 +1,5 @@
 use crate::{
-    time::Duration,
+    time::{Duration, ShortDuration},
     translations::TR,
     ui::{
         component::{Component, Event, EventCtx},
@@ -180,7 +180,7 @@ impl HoldToConfirm {
     pub fn new(circle_color: Color, circle_inner_color: Color) -> Self {
         let button = Button::new(ButtonContent::Empty)
             .styled(theme::button_default())
-            .with_long_press(Duration::from_millis(2200))
+            .with_long_press(ShortDuration::from_millis(2200))
             .without_haptics();
         Self {
             title: Label::new(

--- a/core/embed/rust/src/ui/layout_delizia/theme/mod.rs
+++ b/core/embed/rust/src/ui/layout_delizia/theme/mod.rs
@@ -3,7 +3,7 @@ pub mod bootloader;
 pub mod backlight;
 
 use crate::{
-    time::Duration,
+    time::ShortDuration,
     ui::{
         component::{
             text::{layout::Chunks, LineBreaking, PageBreaking, TextStyle},
@@ -20,7 +20,7 @@ use super::{
     fonts,
 };
 
-pub const ERASE_HOLD_DURATION: Duration = Duration::from_millis(1500);
+pub const ERASE_HOLD_DURATION: ShortDuration = ShortDuration::from_millis(1500);
 
 // Color palette.
 pub const WHITE: Color = Color::rgb(0xFF, 0xFF, 0xFF);

--- a/core/embed/rust/src/ui/layout_eckhart/component/button.rs
+++ b/core/embed/rust/src/ui/layout_eckhart/component/button.rs
@@ -29,7 +29,7 @@ pub enum ButtonMsg {
 
 pub struct Button {
     area: Rect,
-    touch_expand: Option<Insets>,
+    touch_expand: Insets,
     content: ButtonContent,
     content_offset: Offset,
     stylesheet: ButtonStyleSheet,
@@ -66,7 +66,7 @@ impl Button {
             content,
             content_offset: Offset::zero(),
             area: Rect::zero(),
-            touch_expand: None,
+            touch_expand: Insets::zero(),
             stylesheet: theme::button_default(),
             text_align: Alignment::Center,
             radius: None,
@@ -160,7 +160,7 @@ impl Button {
     }
 
     pub const fn with_expanded_touch_area(mut self, expand: Insets) -> Self {
-        self.touch_expand = Some(expand);
+        self.touch_expand = expand;
         self
     }
 
@@ -237,7 +237,7 @@ impl Button {
     }
 
     pub fn set_expanded_touch_area(&mut self, expand: Insets) {
-        self.touch_expand = Some(expand);
+        self.touch_expand = expand;
     }
 
     pub fn set_content_offset(&mut self, offset: Offset) {
@@ -323,8 +323,7 @@ impl Button {
     }
 
     pub fn touch_area(&self) -> Rect {
-        self.touch_expand
-            .map_or(self.area, |expand| self.area.outset(expand))
+        self.area.outset(self.touch_expand)
     }
 
     fn set(&mut self, ctx: &mut EventCtx, state: State) {

--- a/core/embed/rust/src/ui/layout_eckhart/component/button.rs
+++ b/core/embed/rust/src/ui/layout_eckhart/component/button.rs
@@ -98,7 +98,7 @@ impl Button {
         text: TString<'static>,
         stylesheet: ButtonStyleSheet,
         subtext: TString<'static>,
-        subtext_style: Option<TextStyle>,
+        subtext_style: Option<&'static TextStyle>,
     ) -> Self {
         Self::with_text_and_subtext(text, subtext, subtext_style)
             .with_text_align(Self::MENU_ITEM_ALIGNMENT)
@@ -118,12 +118,12 @@ impl Button {
     pub fn with_text_and_subtext(
         text: TString<'static>,
         subtext: TString<'static>,
-        subtext_style: Option<TextStyle>,
+        subtext_style: Option<&'static TextStyle>,
     ) -> Self {
         Self::new(ButtonContent::TextAndSubtext {
             text,
             subtext,
-            subtext_style: subtext_style.unwrap_or(Self::DEFAULT_SUBTEXT_STYLE),
+            subtext_style: subtext_style.unwrap_or(&Self::DEFAULT_SUBTEXT_STYLE),
         })
     }
 
@@ -717,7 +717,7 @@ pub enum ButtonContent {
     TextAndSubtext {
         text: TString<'static>,
         subtext: TString<'static>,
-        subtext_style: TextStyle,
+        subtext_style: &'static TextStyle,
     },
     Icon(Icon),
     IconAndText(IconText),

--- a/core/embed/rust/src/ui/layout_eckhart/firmware/device_menu_screen.rs
+++ b/core/embed/rust/src/ui/layout_eckhart/firmware/device_menu_screen.rs
@@ -69,7 +69,7 @@ pub enum DeviceMenuMsg {
 
 struct MenuItem {
     text: TString<'static>,
-    subtext: Option<(TString<'static>, Option<TextStyle>)>,
+    subtext: Option<(TString<'static>, Option<&'static TextStyle>)>,
     stylesheet: &'static ButtonStyleSheet,
     action: Option<Action>,
 }
@@ -87,7 +87,7 @@ impl MenuItem {
 
     pub fn with_subtext(
         &mut self,
-        subtext: Option<(TString<'static>, Option<TextStyle>)>,
+        subtext: Option<(TString<'static>, Option<&'static TextStyle>)>,
     ) -> &mut Self {
         self.subtext = subtext;
         self
@@ -234,7 +234,7 @@ impl<'a> DeviceMenuScreen<'a> {
             // TODO: this should be a boolean feature of the device
             item_device.with_subtext(Some((
                 "Connected".into(),
-                Some(Button::SUBTEXT_STYLE_GREEN),
+                Some(&Button::SUBTEXT_STYLE_GREEN),
             )));
             unwrap!(items.push(item_device));
         }
@@ -254,7 +254,7 @@ impl<'a> DeviceMenuScreen<'a> {
             Some(Action::GoTo(manage_devices_index)),
         );
         manage_paired_item
-            .with_subtext(connected_subtext.map(|t| (t, Some(Button::SUBTEXT_STYLE_GREEN))));
+            .with_subtext(connected_subtext.map(|t| (t, Some(&Button::SUBTEXT_STYLE_GREEN))));
         unwrap!(items.push(manage_paired_item));
         unwrap!(items.push(MenuItem::new(
             "Pair new device".into(),
@@ -350,7 +350,7 @@ impl<'a> DeviceMenuScreen<'a> {
             Some(Action::GoTo(pair_and_connect_index)),
         );
         item_pair_and_connect
-            .with_subtext(connected_subtext.map(|t| (t, Some(Button::SUBTEXT_STYLE_GREEN))));
+            .with_subtext(connected_subtext.map(|t| (t, Some(&Button::SUBTEXT_STYLE_GREEN))));
         unwrap!(items.push(item_pair_and_connect));
         unwrap!(items.push(MenuItem::new(
             "Settings".into(),

--- a/core/embed/rust/src/ui/layout_eckhart/firmware/hold_to_confirm.rs
+++ b/core/embed/rust/src/ui/layout_eckhart/firmware/hold_to_confirm.rs
@@ -57,7 +57,7 @@ impl HoldToConfirmAnim {
     pub fn new() -> Self {
         let default_color = theme::GREEN_LIME;
         Self {
-            total_duration: theme::CONFIRM_HOLD_DURATION,
+            total_duration: theme::CONFIRM_HOLD_DURATION.into(),
             color: default_color,
             border: ScreenBorder::new(default_color),
             timer: Stopwatch::default(),

--- a/core/embed/rust/src/ui/layout_eckhart/firmware/homescreen.rs
+++ b/core/embed/rust/src/ui/layout_eckhart/firmware/homescreen.rs
@@ -2,7 +2,7 @@ use crate::{
     error::Error,
     io::BinaryData,
     strutil::TString,
-    time::Duration,
+    time::ShortDuration,
     translations::TR,
     ui::{
         component::{text::TextStyle, Component, Event, EventCtx, Label, Never},
@@ -24,7 +24,7 @@ use super::{
     ActionBar, ActionBarMsg, Hint,
 };
 
-const LOCK_HOLD_DURATION: Duration = Duration::from_millis(3000);
+const LOCK_HOLD_DURATION: ShortDuration = ShortDuration::from_millis(3000);
 
 /// Full-screen component for the homescreen and lockscreen.
 pub struct Homescreen {

--- a/core/embed/rust/src/ui/layout_eckhart/theme/firmware.rs
+++ b/core/embed/rust/src/ui/layout_eckhart/theme/firmware.rs
@@ -1,5 +1,5 @@
 use crate::{
-    time::Duration,
+    time::ShortDuration,
     ui::component::text::{
         layout::{Chunks, LineBreaking, PageBreaking},
         TextStyle,
@@ -14,8 +14,8 @@ use super::{
     *,
 };
 
-pub const CONFIRM_HOLD_DURATION: Duration = Duration::from_millis(1500);
-pub const ERASE_HOLD_DURATION: Duration = Duration::from_millis(1500);
+pub const CONFIRM_HOLD_DURATION: ShortDuration = ShortDuration::from_millis(1500);
+pub const ERASE_HOLD_DURATION: ShortDuration = ShortDuration::from_millis(1500);
 
 // Text styles
 /// Alias for use with copied code, might be deleted later


### PR DESCRIPTION
It should reduce stack and heap utilization for layouts using `Vec<Button>` (e.g. `LongMenuGc` containing 100 buttons).

# Before
```
print-type-size type: `ui::layout_eckhart::component::button::Button`: 136 bytes, alignment: 4 bytes
print-type-size     field `.long_press`: 8 bytes
print-type-size     field `.content`: 84 bytes
print-type-size     field `.stylesheet`: 12 bytes
print-type-size     field `.area`: 8 bytes
print-type-size     field `.content_offset`: 4 bytes
print-type-size     field `.long_timer`: 4 bytes
print-type-size     field `.touch_expand`: 10 bytes
print-type-size     field `.radius`: 2 bytes
print-type-size     field `.haptic`: 1 bytes
print-type-size     field `.gradient`: 1 bytes
print-type-size     field `.text_align`: 1 bytes
print-type-size     field `.state`: 1 bytes

print-type-size type: `ui::layout_eckhart::component::button::ButtonContent`: 84 bytes, alignment: 4 bytes
print-type-size     variant `TextAndSubtext`: 84 bytes
print-type-size         field `.subtext_style`: 60 bytes
print-type-size         field `.text`: 12 bytes
print-type-size         field `.subtext`: 12 bytes
print-type-size     variant `IconAndText`: 24 bytes
print-type-size         padding: 4 bytes
print-type-size         field `.0`: 20 bytes, alignment: 4 bytes
print-type-size     variant `Text`: 17 bytes
print-type-size         padding: 4 bytes
print-type-size         field `.text`: 12 bytes, alignment: 4 bytes
print-type-size         field `.single_line`: 1 bytes
print-type-size     variant `HomeBar`: 16 bytes
print-type-size         padding: 4 bytes
print-type-size         field `.0`: 12 bytes, alignment: 4 bytes
print-type-size     variant `Icon`: 12 bytes
print-type-size         padding: 4 bytes
print-type-size         field `.0`: 8 bytes, alignment: 4 bytes
print-type-size     variant `Empty`: 0 bytes
```

# After
```
print-type-size type: `ui::layout_eckhart::component::button::Button`: 76 bytes, alignment: 4 bytes
print-type-size     field `.content`: 32 bytes
print-type-size     field `.area`: 8 bytes
print-type-size     field `.touch_expand`: 8 bytes
print-type-size     field `.content_offset`: 4 bytes
print-type-size     field `.long_timer`: 4 bytes
print-type-size     field `.stylesheet`: 12 bytes
print-type-size     field `.long_press`: 2 bytes
print-type-size     field `.radius_or_gradient`: 2 bytes
print-type-size     field `.state`: 1 bytes
print-type-size     field `.text_align`: 1 bytes
print-type-size     field `.haptic`: 1 bytes
print-type-size     end padding: 1 bytes

print-type-size type: `ui::layout_eckhart::component::button::ButtonContent`: 32 bytes, alignment: 4 bytes
print-type-size     discriminant: 1 bytes
print-type-size     variant `TextAndSubtext`: 31 bytes
print-type-size         padding: 3 bytes
print-type-size         field `.subtext_style`: 4 bytes, alignment: 4 bytes
print-type-size         field `.text`: 12 bytes
print-type-size         field `.subtext`: 12 bytes
print-type-size     variant `IconAndText`: 23 bytes
print-type-size         padding: 3 bytes
print-type-size         field `.0`: 20 bytes, alignment: 4 bytes
print-type-size     variant `Text`: 15 bytes
print-type-size         field `.single_line`: 1 bytes
print-type-size         padding: 2 bytes
print-type-size         field `.text`: 12 bytes, alignment: 4 bytes
print-type-size     variant `HomeBar`: 15 bytes
print-type-size         padding: 3 bytes
print-type-size         field `.0`: 12 bytes, alignment: 4 bytes
print-type-size     variant `Icon`: 11 bytes
print-type-size         padding: 3 bytes
print-type-size         field `.0`: 8 bytes, alignment: 4 bytes
print-type-size     variant `Empty`: 0 bytes

```
