### PR TITLE
style(core): fix a few Rust lints

### DIFF
--- a/core/embed/rust/Cargo.toml
+++ b/core/embed/rust/Cargo.toml
@@ -115,11 +115,11 @@ version = "0.2.2"
 [dependencies.heapless]
 version = "0.8.0"
 features = ["ufmt"]
-default_features = false
+default-features = false
 
 [dependencies.num-traits]
 version = "0.2.19"
-default_features = false
+default-features = false
 features = ["libm"]
 
 [dependencies.num-derive]
@@ -154,7 +154,7 @@ default-features = false
 
 [build-dependencies.bindgen]
 version = "0.62.0"
-default_features = false
+default-features = false
 features = ["runtime"]
 
 # Build dependencies used for linking the test binary

--- a/core/embed/rust/src/ui/layout_caesar/cshape/loader_circular.rs
+++ b/core/embed/rust/src/ui/layout_caesar/cshape/loader_circular.rs
@@ -106,7 +106,7 @@ impl<'s> Shape<'s> for LoaderCircular {
 }
 
 impl<'s> ShapeClone<'s> for LoaderCircular {
-    fn clone_at_bump<T>(self, bump: &'s T) -> Option<&'s mut dyn Shape>
+    fn clone_at_bump<T>(self, bump: &'s T) -> Option<&'s mut dyn Shape<'s>>
     where
         T: LocalAllocLeakExt<'s>,
     {

--- a/core/embed/rust/src/ui/layout_caesar/cshape/loader_small.rs
+++ b/core/embed/rust/src/ui/layout_caesar/cshape/loader_small.rs
@@ -78,7 +78,7 @@ impl Shape<'_> for LoaderSmall {
 }
 
 impl<'s> ShapeClone<'s> for LoaderSmall {
-    fn clone_at_bump<T>(self, bump: &'s T) -> Option<&'s mut dyn Shape>
+    fn clone_at_bump<T>(self, bump: &'s T) -> Option<&'s mut dyn Shape<'s>>
     where
         T: LocalAllocLeakExt<'s>,
     {

--- a/core/embed/rust/src/ui/layout_caesar/cshape/loader_starry.rs
+++ b/core/embed/rust/src/ui/layout_caesar/cshape/loader_starry.rs
@@ -95,7 +95,7 @@ impl Shape<'_> for LoaderStarry {
 }
 
 impl<'s> ShapeClone<'s> for LoaderStarry {
-    fn clone_at_bump<T>(self, bump: &'s T) -> Option<&'s mut dyn Shape>
+    fn clone_at_bump<T>(self, bump: &'s T) -> Option<&'s mut dyn Shape<'s>>
     where
         T: LocalAllocLeakExt<'s>,
     {


### PR DESCRIPTION
Following #5090, we are using Rust `1.88.0-nightly`.

Fixes the following comments:
```
warning: `default_features` is deprecated in favor of `default-features` and will not work in the 2024 edition
(in the `heapless` dependency)
warning: `default_features` is deprecated in favor of `default-features` and will not work in the 2024 edition
(in the `num-traits` dependency)
warning: `default_features` is deprecated in favor of `default-features` and will not work in the 2024 edition
(in the `bindgen` dependency)

   --> src/ui/layout_caesar/cshape/loader_circular.rs:109:66
    |
108 | impl<'s> ShapeClone<'s> for LoaderCircular {
    |      -- lifetime `'s` declared here
109 |     fn clone_at_bump<T>(self, bump: &'s T) -> Option<&'s mut dyn Shape>
    |                                                                  ^^^^^ this elided lifetime gets resolved as `'s`
    |
    = note: `#[warn(elided_named_lifetimes)]` on by default

warning: elided lifetime has a name
  --> src/ui/layout_caesar/cshape/loader_small.rs:81:66
   |
80 | impl<'s> ShapeClone<'s> for LoaderSmall {
   |      -- lifetime `'s` declared here
81 |     fn clone_at_bump<T>(self, bump: &'s T) -> Option<&'s mut dyn Shape>
   |                                                                  ^^^^^ this elided lifetime gets resolved as `'s`

warning: elided lifetime has a name
  --> src/ui/layout_caesar/cshape/loader_starry.rs:98:66
   |
97 | impl<'s> ShapeClone<'s> for LoaderStarry {
   |      -- lifetime `'s` declared here
98 |     fn clone_at_bump<T>(self, bump: &'s T) -> Option<&'s mut dyn Shape>
   |              
```   

<!--
For core developers:
- Assign yourself to the PR.
- Set the priority to match the original issue.
- Add the PR to the current sprint.
- If it's a draft PR, mark it as "In Progress."
- If it's a final PR, mark it as "Needs Review."

For external contributors:
- Please open an issue before submitting a PR so we can discuss whether we want to proceed with it.
-->
