### PR TITLE
Add explicit `is_data` parameters to props

### DIFF
--- a/core/embed/rust/src/ui/api/firmware_micropython.rs
+++ b/core/embed/rust/src/ui/api/firmware_micropython.rs
@@ -331,7 +331,7 @@ extern "C" fn new_confirm_properties(n_args: usize, args: *const Obj, kwargs: *m
             .unwrap_or(None);
         let hold: bool = kwargs.get_or(Qstr::MP_QSTR_hold, false)?;
 
-        let layout = ModelUI::confirm_properties(title, subtitle, items, hold)?;
+        let layout = ModelUI::confirm_properties(title, items, subtitle, hold)?;
         Ok(LayoutObj::new_root(layout)?.into())
     };
     unsafe { util::try_with_args_and_kwargs(n_args, args, kwargs, block) }
@@ -1404,7 +1404,7 @@ pub static mp_module_trezorui_api: Module = obj_module! {
     /// def confirm_properties(
     ///     *,
     ///     title: str,
-    ///     items: list[tuple[str | None, str | bytes | None, bool]],
+    ///     items: list[tuple[str | None, str | bytes | None, bool | None]],
     ///     subtitle: str | None = None,
     ///     hold: bool = False,
     /// ) -> LayoutObj[UiResult]:

--- a/core/embed/rust/src/ui/layout_bolt/component/address_details.rs
+++ b/core/embed/rust/src/ui/layout_bolt/component/address_details.rs
@@ -43,14 +43,14 @@ impl AddressDetails {
                 &theme::TEXT_NORMAL,
                 TR::words__account_colon,
             ));
-            para.add(Paragraph::new(&theme::TEXT_MONO, a));
+            para.add(Paragraph::new(&theme::TEXT_MONO_DATA, a));
         }
         if let Some(p) = path {
             para.add(Paragraph::new(
                 &theme::TEXT_NORMAL,
                 TR::address_details__derivation_path_colon,
             ));
-            para.add(Paragraph::new(&theme::TEXT_MONO, p));
+            para.add(Paragraph::new(&theme::TEXT_MONO_DATA, p));
         }
         let result = Self {
             qr_code: Frame::left_aligned(
@@ -72,7 +72,7 @@ impl AddressDetails {
             xpub_view: Frame::left_aligned(
                 theme::label_title(),
                 " \n ".into(),
-                Paragraph::new(&theme::TEXT_MONO, "").into_paragraphs(),
+                Paragraph::new(&theme::TEXT_MONO_DATA, "").into_paragraphs(),
             )
             .with_cancel_button()
             .with_border(theme::borders_horizontal_scroll()),

--- a/core/embed/rust/src/ui/layout_bolt/component/dialog.rs
+++ b/core/embed/rust/src/ui/layout_bolt/component/dialog.rs
@@ -132,7 +132,7 @@ where
     }
 
     pub fn with_value(self, value: impl Into<TString<'static>>) -> Self {
-        self.with_text(&theme::TEXT_MONO, value)
+        self.with_text(&theme::TEXT_MONO_DATA, value)
     }
 
     pub fn new_shares(lines: [impl Into<TString<'static>>; 4], controls: U) -> Self {

--- a/core/embed/rust/src/ui/layout_bolt/component/fido.rs
+++ b/core/embed/rust/src/ui/layout_bolt/component/fido.rs
@@ -71,8 +71,11 @@ where
 
         Self {
             app_name: Label::centered(app_name, theme::TEXT_DEMIBOLD),
-            account_name: Paragraph::new(&theme::TEXT_MONO, get_account(scrollbar.active_page))
-                .into_paragraphs(),
+            account_name: Paragraph::new(
+                &theme::TEXT_MONO_DATA,
+                get_account(scrollbar.active_page),
+            )
+            .into_paragraphs(),
             page_swipe,
             icon: Child::new(Image::new(icon_data)),
             get_account,

--- a/core/embed/rust/src/ui/layout_bolt/component/page.rs
+++ b/core/embed/rust/src/ui/layout_bolt/component/page.rs
@@ -638,7 +638,7 @@ mod tests {
                     "This paragraph is using a bold font. It doesn't need to be all that long.",
                 ),
                 Paragraph::new(
-                    &theme::TEXT_MONO,
+                    &theme::TEXT_MONO_DATA,
                     "And this one is using MONO. Monospace is nice for numbers, they have the same width and can be scanned quickly. Even if they span several pages or something.",
                 ),
                 Paragraph::new(

--- a/core/embed/rust/src/ui/layout_bolt/theme/mod.rs
+++ b/core/embed/rust/src/ui/layout_bolt/theme/mod.rs
@@ -603,10 +603,12 @@ pub const TEXT_DEMIBOLD: TextStyle =
 pub const TEXT_BOLD: TextStyle =
     TextStyle::new(fonts::FONT_BOLD_UPPER, FG, BG, GREY_LIGHT, GREY_LIGHT);
 pub const TEXT_MONO: TextStyle = TextStyle::new(fonts::FONT_MONO, FG, BG, GREY_LIGHT, GREY_LIGHT)
-    .with_line_breaking(LineBreaking::BreakWordsNoHyphen)
+    .with_line_breaking(LineBreaking::BreakAtWhitespace)
     .with_page_breaking(PageBreaking::CutAndInsertEllipsisBoth)
     .with_ellipsis_icon(ICON_PAGE_NEXT, 0)
     .with_prev_page_icon(ICON_PAGE_PREV, 0);
+pub const TEXT_MONO_DATA: TextStyle =
+    TEXT_MONO.with_line_breaking(LineBreaking::BreakWordsNoHyphen);
 pub const TEXT_MONO_WITH_CLASSIC_ELLIPSIS: TextStyle =
     TextStyle::new(fonts::FONT_MONO, FG, BG, GREY_LIGHT, GREY_LIGHT)
         .with_line_breaking(LineBreaking::BreakWordsNoHyphen)
@@ -614,13 +616,13 @@ pub const TEXT_MONO_WITH_CLASSIC_ELLIPSIS: TextStyle =
         .with_prev_page_icon(ICON_PAGE_PREV, 0);
 /// Makes sure that the displayed text (usually address) will get divided into
 /// smaller chunks.
-pub const TEXT_MONO_ADDRESS_CHUNKS: TextStyle = TEXT_MONO
+pub const TEXT_MONO_ADDRESS_CHUNKS: TextStyle = TEXT_MONO_DATA
     .with_chunks(Chunks::new(4, 9))
     .with_line_spacing(5);
 /// Smaller horizontal chunk offset, used e.g. for long Cardano addresses.
 /// Also moving the next page ellipsis to the left (as there is a space on the
 /// left). Last but not least, maximum number of rows is 4 in this case.
-pub const TEXT_MONO_ADDRESS_CHUNKS_SMALLER_X_OFFSET: TextStyle = TEXT_MONO
+pub const TEXT_MONO_ADDRESS_CHUNKS_SMALLER_X_OFFSET: TextStyle = TEXT_MONO_DATA
     .with_chunks(Chunks::new(4, 7).with_max_rows(4))
     .with_line_spacing(5)
     .with_ellipsis_icon(ICON_PAGE_NEXT, -12);

--- a/core/embed/rust/src/ui/layout_bolt/ui_firmware.rs
+++ b/core/embed/rust/src/ui/layout_bolt/ui_firmware.rs
@@ -345,7 +345,7 @@ impl FirmwareUI for UIBolt {
             let [text, is_data]: [Obj; 2] = util::iter_into_array(para)?;
             let is_data = is_data.try_into()?;
             let style: &TextStyle = if is_data {
-                &theme::TEXT_MONO
+                &theme::TEXT_MONO_DATA
             } else {
                 &theme::TEXT_NORMAL
             };
@@ -383,7 +383,7 @@ impl FirmwareUI for UIBolt {
             items,
             &theme::TEXT_NORMAL,
             &theme::TEXT_MONO,
-            &theme::TEXT_MONO,
+            &theme::TEXT_MONO_DATA,
         )?;
         let page = if hold {
             ButtonPage::new(paragraphs.into_paragraphs(), theme::BG).with_hold()?
@@ -962,7 +962,7 @@ impl FirmwareUI for UIBolt {
                     value,
                 ));
             } else {
-                paragraphs.add(Paragraph::new(&theme::TEXT_MONO, value));
+                paragraphs.add(Paragraph::new(&theme::TEXT_MONO_DATA, value));
             }
         }
 
@@ -1350,7 +1350,7 @@ impl ConfirmValue {
                 let value: TString = self.value.try_into()?;
                 theme::get_chunkified_text_style(value.len())
             } else if self.text_mono {
-                &theme::TEXT_MONO
+                &theme::TEXT_MONO_DATA
             } else {
                 &theme::TEXT_NORMAL
             },

--- a/core/embed/rust/src/ui/layout_bolt/ui_firmware.rs
+++ b/core/embed/rust/src/ui/layout_bolt/ui_firmware.rs
@@ -375,8 +375,8 @@ impl FirmwareUI for UIBolt {
 
     fn confirm_properties(
         title: TString<'static>,
-        _subtitle: Option<TString<'static>>,
         items: Obj,
+        _subtitle: Option<TString<'static>>,
         hold: bool,
     ) -> Result<impl LayoutMaybeTrace, Error> {
         let paragraphs = PropsList::new(

--- a/core/embed/rust/src/ui/layout_caesar/ui_firmware.rs
+++ b/core/embed/rust/src/ui/layout_caesar/ui_firmware.rs
@@ -413,8 +413,8 @@ impl FirmwareUI for UICaesar {
 
     fn confirm_properties(
         title: TString<'static>,
-        _subtitle: Option<TString<'static>>,
         items: Obj,
+        _subtitle: Option<TString<'static>>,
         hold: bool,
     ) -> Result<impl LayoutMaybeTrace, Error> {
         let mut paragraphs = ParagraphVecLong::new();

--- a/core/embed/rust/src/ui/layout_delizia/flow/get_address.rs
+++ b/core/embed/rust/src/ui/layout_delizia/flow/get_address.rs
@@ -96,7 +96,7 @@ pub fn new_get_address(
             let address: TString = address.try_into()?;
             theme::get_chunkified_text_style(address.len())
         } else {
-            &theme::TEXT_MONO
+            &theme::TEXT_MONO_DATA
         },
         description_font: &theme::TEXT_NORMAL,
         extra_font: &theme::TEXT_DEMIBOLD,

--- a/core/embed/rust/src/ui/layout_delizia/flow/util.rs
+++ b/core/embed/rust/src/ui/layout_delizia/flow/util.rs
@@ -233,7 +233,7 @@ impl ConfirmValue {
                 if self.classic_ellipsis {
                     &theme::TEXT_MONO_WITH_CLASSIC_ELLIPSIS
                 } else {
-                    &theme::TEXT_MONO
+                    &theme::TEXT_MONO_DATA
                 }
             } else {
                 &theme::TEXT_NORMAL
@@ -287,7 +287,7 @@ impl ConfirmValue {
                 if self.classic_ellipsis {
                     &theme::TEXT_MONO_WITH_CLASSIC_ELLIPSIS
                 } else {
-                    &theme::TEXT_MONO
+                    &theme::TEXT_MONO_DATA
                 }
             } else {
                 &theme::TEXT_NORMAL

--- a/core/embed/rust/src/ui/layout_delizia/theme/mod.rs
+++ b/core/embed/rust/src/ui/layout_delizia/theme/mod.rs
@@ -737,10 +737,13 @@ pub const TEXT_SUB_GREEN_LIME: TextStyle =
 pub const TEXT_WARNING: TextStyle =
     TextStyle::new(fonts::FONT_DEMIBOLD, ORANGE_LIGHT, BG, GREY, GREY);
 pub const TEXT_MONO: TextStyle = TextStyle::new(fonts::FONT_MONO, GREY_EXTRA_LIGHT, BG, GREY, GREY)
-    .with_line_breaking(LineBreaking::BreakWordsNoHyphen)
+    .with_line_breaking(LineBreaking::BreakAtWhitespace)
     .with_page_breaking(PageBreaking::CutAndInsertEllipsisBoth)
     .with_ellipsis_icon(ICON_PAGE_NEXT, 0)
     .with_prev_page_icon(ICON_PAGE_PREV, 0);
+/// Mono data text does not have hyphens
+pub const TEXT_MONO_DATA: TextStyle =
+    TEXT_MONO.with_line_breaking(LineBreaking::BreakWordsNoHyphen);
 pub const TEXT_MONO_WITH_CLASSIC_ELLIPSIS: TextStyle =
     TextStyle::new(fonts::FONT_MONO, GREY_EXTRA_LIGHT, BG, GREY, GREY)
         .with_line_breaking(LineBreaking::BreakWordsNoHyphen)
@@ -748,17 +751,17 @@ pub const TEXT_MONO_WITH_CLASSIC_ELLIPSIS: TextStyle =
         .with_prev_page_icon(ICON_PAGE_PREV, 0);
 pub const TEXT_MONO_GREY_LIGHT: TextStyle = TextStyle {
     text_color: GREY_LIGHT,
-    ..TEXT_MONO
+    ..TEXT_MONO_DATA
 };
 /// Makes sure that the displayed text (usually address) will get divided into
 /// smaller chunks.
-pub const TEXT_MONO_ADDRESS_CHUNKS: TextStyle = TEXT_MONO
+pub const TEXT_MONO_ADDRESS_CHUNKS: TextStyle = TEXT_MONO_DATA
     .with_chunks(Chunks::new(4, 9))
     .with_line_spacing(5);
 /// Smaller horizontal chunk offset, used e.g. for long Cardano addresses.
 /// Also moving the next page ellipsis to the left (as there is a space on the
 /// left). Last but not least, maximum number of rows is 4 in this case.
-pub const TEXT_MONO_ADDRESS_CHUNKS_SMALLER_X_OFFSET: TextStyle = TEXT_MONO
+pub const TEXT_MONO_ADDRESS_CHUNKS_SMALLER_X_OFFSET: TextStyle = TEXT_MONO_DATA
     .with_chunks(Chunks::new(4, 7).with_max_rows(4))
     .with_line_spacing(5)
     .with_ellipsis_icon(ICON_PAGE_NEXT, -12);

--- a/core/embed/rust/src/ui/layout_delizia/ui_firmware.rs
+++ b/core/embed/rust/src/ui/layout_delizia/ui_firmware.rs
@@ -415,8 +415,8 @@ impl FirmwareUI for UIDelizia {
 
     fn confirm_properties(
         title: TString<'static>,
-        subtitle: Option<TString<'static>>,
         items: Obj,
+        subtitle: Option<TString<'static>>,
         hold: bool,
     ) -> Result<impl LayoutMaybeTrace, Error> {
         let paragraphs = PropsList::new(

--- a/core/embed/rust/src/ui/layout_delizia/ui_firmware.rs
+++ b/core/embed/rust/src/ui/layout_delizia/ui_firmware.rs
@@ -423,7 +423,7 @@ impl FirmwareUI for UIDelizia {
             items,
             &theme::TEXT_SUB_GREY_LIGHT,
             &theme::TEXT_MONO,
-            &theme::TEXT_MONO,
+            &theme::TEXT_MONO_DATA,
         )?;
 
         let flow = flow::new_confirm_action_simple(
@@ -959,7 +959,7 @@ impl FirmwareUI for UIDelizia {
                     value,
                 ));
             } else {
-                paragraphs.add(Paragraph::new(&theme::TEXT_MONO, value));
+                paragraphs.add(Paragraph::new(&theme::TEXT_MONO_DATA, value));
             }
         }
 

--- a/core/embed/rust/src/ui/layout_eckhart/theme/firmware.rs
+++ b/core/embed/rust/src/ui/layout_eckhart/theme/firmware.rs
@@ -79,6 +79,9 @@ pub const TEXT_MONO_MEDIUM_LIGHT: TextStyle = TextStyle::new(
 )
 .with_line_breaking(LineBreaking::BreakAtWhitespace);
 
+pub const TEXT_MONO_MEDIUM_LIGHT_DATA: TextStyle =
+    TEXT_MONO_MEDIUM_LIGHT.with_line_breaking(LineBreaking::BreakWordsNoHyphen);
+
 /// Roboto Mono Light - 30 (Address, data)
 pub const TEXT_MONO_LIGHT: TextStyle = TextStyle::new(
     fonts::FONT_MONO_LIGHT_30,

--- a/core/embed/rust/src/ui/layout_eckhart/ui_firmware.rs
+++ b/core/embed/rust/src/ui/layout_eckhart/ui_firmware.rs
@@ -362,8 +362,8 @@ impl FirmwareUI for UIEckhart {
 
     fn confirm_properties(
         title: TString<'static>,
-        _subtitle: Option<TString<'static>>,
         items: Obj,
+        _subtitle: Option<TString<'static>>,
         hold: bool,
     ) -> Result<impl LayoutMaybeTrace, Error> {
         let paragraphs = PropsList::new(

--- a/core/embed/rust/src/ui/layout_eckhart/ui_firmware.rs
+++ b/core/embed/rust/src/ui/layout_eckhart/ui_firmware.rs
@@ -369,8 +369,8 @@ impl FirmwareUI for UIEckhart {
         let paragraphs = PropsList::new(
             items,
             &theme::TEXT_SMALL_LIGHT,
-            &theme::TEXT_MONO_LIGHT,
-            &theme::TEXT_MONO_LIGHT,
+            &theme::TEXT_MONO_MEDIUM_LIGHT,
+            &theme::TEXT_MONO_MEDIUM_LIGHT_DATA,
         )?;
 
         let flow = flow::new_confirm_with_menu(

--- a/core/embed/rust/src/ui/ui_firmware.rs
+++ b/core/embed/rust/src/ui/ui_firmware.rs
@@ -123,8 +123,8 @@ pub trait FirmwareUI {
 
     fn confirm_properties(
         title: TString<'static>,
-        subtitle: Option<TString<'static>>,
         items: Obj, // TODO: replace Obj`
+        subtitle: Option<TString<'static>>,
         hold: bool,
     ) -> Result<impl LayoutMaybeTrace, Error>;
 

--- a/core/mocks/generated/trezorui_api.pyi
+++ b/core/mocks/generated/trezorui_api.pyi
@@ -260,7 +260,7 @@ def confirm_more(
 def confirm_properties(
     *,
     title: str,
-    items: list[tuple[str | None, str | bytes | None, bool]],
+    items: list[tuple[str | None, str | bytes | None, bool | None]],
     subtitle: str | None = None,
     hold: bool = False,
 ) -> LayoutObj[UiResult]:

--- a/core/src/apps/cardano/helpers/credential.py
+++ b/core/src/apps/cardano/helpers/credential.py
@@ -181,21 +181,23 @@ class Credential:
         pointer = self.pointer  # local_cache_attribute
 
         if self.path:
-            return [(None, address_n_to_str(self.path))]
+            return [(None, address_n_to_str(self.path), True)]
         elif self.key_hash:
             hrp = (
                 bech32.HRP_KEY_HASH
                 if self.type_name == CREDENTIAL_TYPE_PAYMENT
                 else bech32.HRP_STAKE_KEY_HASH
             )
-            return [(None, bech32.encode(hrp, self.key_hash))]
+            return [(None, bech32.encode(hrp, self.key_hash), True)]
         elif self.script_hash:
-            return [(None, bech32.encode(bech32.HRP_SCRIPT_HASH, self.script_hash))]
+            return [
+                (None, bech32.encode(bech32.HRP_SCRIPT_HASH, self.script_hash), True)
+            ]
         elif pointer:
             return [
-                (f"{TR.cardano__block}: {pointer.block_index}", None),
-                (f"{TR.cardano__transaction}: {pointer.tx_index}", None),
-                (f"{TR.cardano__certificate}: {pointer.certificate_index}", None),
+                (f"{TR.cardano__block}: {pointer.block_index}", None, None),
+                (f"{TR.cardano__transaction}: {pointer.tx_index}", None, None),
+                (f"{TR.cardano__certificate}: {pointer.certificate_index}", None, None),
             ]
         else:
             return []

--- a/core/src/apps/eos/actions/layout.py
+++ b/core/src/apps/eos/actions/layout.py
@@ -54,9 +54,9 @@ async def confirm_action_buyram(msg: EosActionBuyRam) -> None:
         "confirm_buyram",
         TR.eos__buy_ram,
         (
-            (TR.eos__payer, eos_name_to_string(msg.payer)),
-            (TR.eos__receiver, eos_name_to_string(msg.receiver)),
-            (f"{TR.words__amount}:", eos_asset_to_string(msg.quantity)),
+            (TR.eos__payer, eos_name_to_string(msg.payer), True),
+            (TR.eos__receiver, eos_name_to_string(msg.receiver), True),
+            (f"{TR.words__amount}:", eos_asset_to_string(msg.quantity), True),
         ),
     )
 
@@ -66,26 +66,26 @@ async def confirm_action_buyrambytes(msg: EosActionBuyRamBytes) -> None:
         "confirm_buyrambytes",
         TR.eos__buy_ram,
         (
-            (TR.eos__payer, eos_name_to_string(msg.payer)),
-            (TR.eos__receiver, eos_name_to_string(msg.receiver)),
-            (TR.eos__bytes, str(msg.bytes)),
+            (TR.eos__payer, eos_name_to_string(msg.payer), True),
+            (TR.eos__receiver, eos_name_to_string(msg.receiver), True),
+            (TR.eos__bytes, str(msg.bytes), True),
         ),
     )
 
 
 async def confirm_action_delegate(msg: EosActionDelegate) -> None:
-    props = [
-        (TR.eos__sender, eos_name_to_string(msg.sender)),
-        (TR.eos__receiver, eos_name_to_string(msg.receiver)),
-        (TR.eos__cpu, eos_asset_to_string(msg.cpu_quantity)),
-        (TR.eos__net, eos_asset_to_string(msg.net_quantity)),
+    props: list[PropertyType] = [
+        (TR.eos__sender, eos_name_to_string(msg.sender), True),
+        (TR.eos__receiver, eos_name_to_string(msg.receiver), True),
+        (TR.eos__cpu, eos_asset_to_string(msg.cpu_quantity), True),
+        (TR.eos__net, eos_asset_to_string(msg.net_quantity), True),
     ]
     append = props.append  # local_cache_attribute
     if msg.transfer:
-        append((TR.eos__transfer, TR.words__yes))
-        append((TR.eos__receiver, eos_name_to_string(msg.receiver)))
+        append((TR.eos__transfer, TR.words__yes, False))
+        append((TR.eos__receiver, eos_name_to_string(msg.receiver), True))
     else:
-        append((TR.eos__transfer, TR.words__no))
+        append((TR.eos__transfer, TR.words__no, False))
 
     await _confirm_properties(
         "confirm_delegate",
@@ -99,8 +99,8 @@ async def confirm_action_sellram(msg: EosActionSellRam) -> None:
         "confirm_sellram",
         TR.eos__sell_ram,
         (
-            (TR.eos__receiver, eos_name_to_string(msg.account)),
-            (TR.eos__bytes, str(msg.bytes)),
+            (TR.eos__receiver, eos_name_to_string(msg.account), True),
+            (TR.eos__bytes, str(msg.bytes), True),
         ),
     )
 
@@ -110,10 +110,10 @@ async def confirm_action_undelegate(msg: EosActionUndelegate) -> None:
         "confirm_undelegate",
         TR.eos__undelegate,
         (
-            (TR.eos__sender, eos_name_to_string(msg.sender)),
-            (TR.eos__receiver, eos_name_to_string(msg.receiver)),
-            (TR.eos__cpu, eos_asset_to_string(msg.cpu_quantity)),
-            (TR.eos__net, eos_asset_to_string(msg.net_quantity)),
+            (TR.eos__sender, eos_name_to_string(msg.sender), True),
+            (TR.eos__receiver, eos_name_to_string(msg.receiver), True),
+            (TR.eos__cpu, eos_asset_to_string(msg.cpu_quantity), True),
+            (TR.eos__net, eos_asset_to_string(msg.net_quantity), True),
         ),
     )
 
@@ -122,7 +122,7 @@ async def confirm_action_refund(msg: EosActionRefund) -> None:
     await _confirm_properties(
         "confirm_refund",
         TR.eos__refund,
-        ((TR.eos__owner, eos_name_to_string(msg.owner)),),
+        ((TR.eos__owner, eos_name_to_string(msg.owner), True),),
     )
 
 
@@ -135,8 +135,8 @@ async def confirm_action_voteproducer(msg: EosActionVoteProducer) -> None:
             "confirm_voteproducer",
             TR.eos__vote_for_proxy,
             (
-                (TR.eos__voter, eos_name_to_string(msg.voter)),
-                (TR.eos__proxy, eos_name_to_string(msg.proxy)),
+                (TR.eos__voter, eos_name_to_string(msg.voter), True),
+                (TR.eos__proxy, eos_name_to_string(msg.proxy), True),
             ),
         )
 
@@ -146,7 +146,7 @@ async def confirm_action_voteproducer(msg: EosActionVoteProducer) -> None:
             "confirm_voteproducer",
             TR.eos__vote_for_producers,
             (
-                (f"{wi:2d}. {eos_name_to_string(producer)}", None)
+                (f"{wi:2d}. {eos_name_to_string(producer)}", None, None)
                 for wi, producer in enumerate(producers, 1)
             ),
         )
@@ -156,19 +156,19 @@ async def confirm_action_voteproducer(msg: EosActionVoteProducer) -> None:
         await _confirm_properties(
             "confirm_voteproducer",
             TR.eos__cancel_vote,
-            ((TR.eos__voter, eos_name_to_string(msg.voter)),),
+            ((TR.eos__voter, eos_name_to_string(msg.voter), True),),
         )
 
 
 async def confirm_action_transfer(msg: EosActionTransfer, account: str) -> None:
     props = [
-        (TR.eos__from, eos_name_to_string(msg.sender)),
-        (TR.eos__to, eos_name_to_string(msg.receiver)),
-        (f"{TR.words__amount}:", eos_asset_to_string(msg.quantity)),
-        (TR.eos__contract, account),
+        (TR.eos__from, eos_name_to_string(msg.sender), True),
+        (TR.eos__to, eos_name_to_string(msg.receiver), True),
+        (f"{TR.words__amount}:", eos_asset_to_string(msg.quantity), True),
+        (TR.eos__contract, account, True),
     ]
     if msg.memo is not None:
-        props.append((TR.eos__memo, msg.memo[:512]))
+        props.append((TR.eos__memo, msg.memo[:512], True))
     await _confirm_properties(
         "confirm_transfer",
         TR.eos__transfer.replace(":", ""),
@@ -178,9 +178,9 @@ async def confirm_action_transfer(msg: EosActionTransfer, account: str) -> None:
 
 async def confirm_action_updateauth(msg: EosActionUpdateAuth) -> None:
     props: list[PropertyType] = [
-        (f"{TR.words__account}:", eos_name_to_string(msg.account)),
-        (TR.eos__permission, eos_name_to_string(msg.permission)),
-        (TR.eos__parent, eos_name_to_string(msg.parent)),
+        (f"{TR.words__account}:", eos_name_to_string(msg.account), True),
+        (TR.eos__permission, eos_name_to_string(msg.permission), True),
+        (TR.eos__parent, eos_name_to_string(msg.parent), True),
     ]
     props.extend(authorization_fields(msg.auth))
     await _confirm_properties(
@@ -195,8 +195,8 @@ async def confirm_action_deleteauth(msg: EosActionDeleteAuth) -> None:
         "confirm_deleteauth",
         TR.eos__delete_auth,
         (
-            (f"{TR.words__account}:", eos_name_to_string(msg.account)),
-            (TR.eos__permission, eos_name_to_string(msg.permission)),
+            (f"{TR.words__account}:", eos_name_to_string(msg.account), True),
+            (TR.eos__permission, eos_name_to_string(msg.permission), True),
         ),
     )
 
@@ -206,10 +206,10 @@ async def confirm_action_linkauth(msg: EosActionLinkAuth) -> None:
         "confirm_linkauth",
         TR.eos__link_auth,
         (
-            (f"{TR.words__account}:", eos_name_to_string(msg.account)),
-            (TR.eos__code, eos_name_to_string(msg.code)),
-            (TR.eos__type, eos_name_to_string(msg.type)),
-            (TR.eos__requirement, eos_name_to_string(msg.requirement)),
+            (f"{TR.words__account}:", eos_name_to_string(msg.account), True),
+            (TR.eos__code, eos_name_to_string(msg.code), True),
+            (TR.eos__type, eos_name_to_string(msg.type), True),
+            (TR.eos__requirement, eos_name_to_string(msg.requirement), True),
         ),
     )
 
@@ -219,17 +219,17 @@ async def confirm_action_unlinkauth(msg: EosActionUnlinkAuth) -> None:
         "confirm_unlinkauth",
         TR.eos__unlink_auth,
         (
-            (f"{TR.words__account}:", eos_name_to_string(msg.account)),
-            (TR.eos__code, eos_name_to_string(msg.code)),
-            (TR.eos__type, eos_name_to_string(msg.type)),
+            (f"{TR.words__account}:", eos_name_to_string(msg.account), True),
+            (TR.eos__code, eos_name_to_string(msg.code), True),
+            (TR.eos__type, eos_name_to_string(msg.type), True),
         ),
     )
 
 
 async def confirm_action_newaccount(msg: EosActionNewAccount) -> None:
     props: list[PropertyType] = [
-        (TR.eos__creator, eos_name_to_string(msg.creator)),
-        (TR.eos__name, eos_name_to_string(msg.name)),
+        (TR.eos__creator, eos_name_to_string(msg.creator), True),
+        (TR.eos__name, eos_name_to_string(msg.name), True),
     ]
     props.extend(authorization_fields(msg.owner))
     props.extend(authorization_fields(msg.active))
@@ -245,9 +245,9 @@ async def confirm_action_unknown(action: EosActionCommon, checksum: bytes) -> No
         "confirm_unknown",
         TR.eos__arbitrary_data,
         (
-            (TR.eos__contract, eos_name_to_string(action.account)),
-            (TR.eos__action_name, eos_name_to_string(action.name)),
-            (TR.eos__checksum, checksum),
+            (TR.eos__contract, eos_name_to_string(action.account), False),
+            (TR.eos__action_name, eos_name_to_string(action.name), False),
+            (TR.eos__checksum, checksum, True),
         ),
         hold=is_last,
         br_code=ButtonRequestType.ConfirmOutput,
@@ -262,7 +262,7 @@ def authorization_fields(auth: EosAuthorization) -> list[PropertyType]:
     fields: list[PropertyType] = []
     append = fields.append  # local_cache_attribute
 
-    append((TR.eos__threshold, str(auth.threshold)))
+    append((TR.eos__threshold, str(auth.threshold), False))
 
     # NOTE: getting rid of f-strings saved almost 100 bytes
 
@@ -276,8 +276,8 @@ def authorization_fields(auth: EosAuthorization) -> list[PropertyType]:
         header = f"Key #{i}:"
         w_header = f"Key #{i} Weight:"
 
-        append((header, _key))
-        append((w_header, _weight))
+        append((header, _key, True))
+        append((w_header, _weight, True))
 
     for i, account in enumerate(auth.accounts, 1):
         _account = eos_name_to_string(account.account.actor)
@@ -289,9 +289,9 @@ def authorization_fields(auth: EosAuthorization) -> list[PropertyType]:
         p_header = f"Acc Permission #{i}:"
         w_header = f"Account #{i} weight:"
 
-        append((a_header, _account))
-        append((p_header, _permission))
-        append((w_header, str(account.weight)))
+        append((a_header, _account, True))
+        append((p_header, _permission, True))
+        append((w_header, str(account.weight), True))
 
     for i, wait in enumerate(auth.waits, 1):
         _wait = str(wait.wait_sec)
@@ -299,7 +299,7 @@ def authorization_fields(auth: EosAuthorization) -> list[PropertyType]:
 
         header = f"Delay #{i}"
         w_header = f"{header} weight:"
-        append((f"{header}:", _wait + " sec"))
-        append((w_header, _weight))
+        append((f"{header}:", _wait + " sec", False))
+        append((w_header, _weight, False))
 
     return fields

--- a/core/src/apps/nem/layout.py
+++ b/core/src/apps/nem/layout.py
@@ -1,9 +1,15 @@
+from typing import TYPE_CHECKING
+
 from trezor import TR
 from trezor.enums import ButtonRequestType
 from trezor.strings import format_amount
 from trezor.ui.layouts import confirm_metadata
 
 from .helpers import NEM_MAX_DIVISIBILITY
+
+if TYPE_CHECKING:
+
+    from trezor.ui.layouts import PropertyType
 
 
 async def require_confirm_text(action: str) -> None:
@@ -25,7 +31,7 @@ async def require_confirm_fee(action: str, fee: int) -> None:
     )
 
 
-async def require_confirm_content(headline: str, content: list) -> None:
+async def require_confirm_content(headline: str, content: list[PropertyType]) -> None:
     from trezor.ui.layouts import confirm_properties
 
     await confirm_properties(

--- a/core/src/apps/nem/mosaic/layout.py
+++ b/core/src/apps/nem/mosaic/layout.py
@@ -11,6 +11,7 @@ if TYPE_CHECKING:
         NEMMosaicSupplyChange,
         NEMTransactionCommon,
     )
+    from trezor.ui.layouts import PropertyType
 
 
 async def ask_mosaic_creation(
@@ -18,9 +19,9 @@ async def ask_mosaic_creation(
 ) -> None:
     from ..layout import require_confirm_fee
 
-    creation_message = [
-        (TR.nem__create_mosaic, creation.definition.mosaic),
-        (TR.nem__under_namespace, creation.definition.namespace),
+    creation_message: list[PropertyType] = [
+        (TR.nem__create_mosaic, creation.definition.mosaic, False),
+        (TR.nem__under_namespace, creation.definition.namespace, False),
     ]
     await require_confirm_content(TR.nem__create_mosaic, creation_message)
     await _require_confirm_properties(creation.definition)
@@ -36,9 +37,9 @@ async def ask_supply_change(
 
     from ..layout import require_confirm_text
 
-    supply_message = [
-        (TR.nem__modify_supply_for, change.mosaic),
-        (TR.nem__under_namespace, change.namespace),
+    supply_message: list[PropertyType] = [
+        (TR.nem__modify_supply_for, change.mosaic, False),
+        (TR.nem__under_namespace, change.namespace, False),
     ]
     await require_confirm_content(TR.nem__supply_change, supply_message)
     if change.type == NEMSupplyChangeType.SupplyChange_Decrease:
@@ -58,23 +59,23 @@ async def _require_confirm_properties(definition: NEMMosaicDefinition) -> None:
     from trezor.enums import NEMMosaicLevy
     from trezor.ui.layouts import confirm_properties
 
-    properties = []
+    properties: list[PropertyType] = []
     append = properties.append  # local_cache_attribute
 
     # description
     if definition.description:
-        append((TR.nem__description, definition.description))
+        append((TR.nem__description, definition.description, False))
 
     # transferable
     transferable = TR.words__yes if definition.transferable else TR.words__no
-    append((TR.nem__transferable, transferable))
+    append((TR.nem__transferable, transferable, False))
 
     # mutable_supply
     imm = TR.nem__mutable if definition.mutable_supply else TR.nem__immutable
     if definition.supply:
-        append((TR.nem__initial_supply, str(definition.supply) + "\n" + imm))
+        append((TR.nem__initial_supply, str(definition.supply) + "\n" + imm, False))
     else:
-        append((TR.nem__initial_supply, imm))
+        append((TR.nem__initial_supply, imm, False))
 
     # levy
     if definition.levy:
@@ -83,20 +84,20 @@ async def _require_confirm_properties(definition: NEMMosaicDefinition) -> None:
         assert definition.levy_namespace is not None
         assert definition.levy_mosaic is not None
 
-        append((TR.nem__levy_recipient, definition.levy_address))
+        append((TR.nem__levy_recipient, definition.levy_address, True))
 
-        append((TR.nem__levy_fee, str(definition.fee)))
-        append((TR.nem__levy_divisibility, str(definition.divisibility)))
+        append((TR.nem__levy_fee, str(definition.fee), False))
+        append((TR.nem__levy_divisibility, str(definition.divisibility), False))
 
-        append((TR.nem__levy_namespace, definition.levy_namespace))
-        append((TR.nem__levy_mosaic, definition.levy_mosaic))
+        append((TR.nem__levy_namespace, definition.levy_namespace, True))
+        append((TR.nem__levy_mosaic, definition.levy_mosaic, False))
 
         levy_type = (
             TR.nem__absolute
             if definition.levy == NEMMosaicLevy.MosaicLevy_Absolute
             else TR.nem__percentile
         )
-        append((TR.nem__levy_type, levy_type))
+        append((TR.nem__levy_type, levy_type, False))
 
     await confirm_properties(
         "confirm_properties",

--- a/core/src/apps/nem/namespace/layout.py
+++ b/core/src/apps/nem/namespace/layout.py
@@ -2,6 +2,7 @@ from typing import TYPE_CHECKING
 
 if TYPE_CHECKING:
     from trezor.messages import NEMProvisionNamespace, NEMTransactionCommon
+    from trezor.ui.layouts import PropertyType
 
 
 async def ask_provision_namespace(
@@ -16,13 +17,13 @@ async def ask_provision_namespace(
     )
 
     if namespace.parent:
-        content = [
-            (TR.nem__create_namespace, namespace.namespace),
-            (TR.nem__under_namespace, namespace.parent),
+        content: list[PropertyType] = [
+            (TR.nem__create_namespace, namespace.namespace, False),
+            (TR.nem__under_namespace, namespace.parent, False),
         ]
         await require_confirm_content(TR.nem__confirm_namespace, content)
     else:
-        content = [(TR.nem__create_namespace, namespace.namespace)]
+        content = [(TR.nem__create_namespace, namespace.namespace, False)]
         await require_confirm_content(TR.nem__confirm_namespace, content)
 
     await require_confirm_fee(TR.nem__confirm_rental_fee, namespace.fee)

--- a/core/src/apps/nem/transfer/layout.py
+++ b/core/src/apps/nem/transfer/layout.py
@@ -74,8 +74,9 @@ async def _ask_transfer_mosaic(
                     TR.nem__confirm_transfer_of,
                     format_amount(mosaic_quantity, definition.divisibility)
                     + definition.ticker,
+                    False,
                 ),
-                (TR.nem__of, definition.name),
+                (TR.nem__of, definition.name, False),
             ),
         )
         levy = definition.levy  # local_cache_attribute
@@ -95,7 +96,7 @@ async def _ask_transfer_mosaic(
             await confirm_properties(
                 "confirm_mosaic_levy",
                 TR.nem__confirm_mosaic,
-                ((TR.nem__levy_fee_of, levy_msg),),
+                ((TR.nem__levy_fee_of, levy_msg, False),),
             )
 
     else:
@@ -114,8 +115,9 @@ async def _ask_transfer_mosaic(
                 (
                     TR.nem__confirm_transfer_of,
                     TR.nem__raw_units_template.format(mosaic_quantity),
+                    False,
                 ),
-                (TR.nem__of, f"{mosaic.namespace}.{mosaic.mosaic}"),
+                (TR.nem__of, f"{mosaic.namespace}.{mosaic.mosaic}", False),
             ),
         )
 

--- a/core/src/apps/stellar/layout.py
+++ b/core/src/apps/stellar/layout.py
@@ -58,6 +58,7 @@ async def require_confirm_timebounds(start: int, end: int) -> None:
                     if start > 0
                     else TR.stellar__no_restriction
                 ),
+                False,
             ),
             (
                 TR.stellar__valid_to,
@@ -66,6 +67,7 @@ async def require_confirm_timebounds(start: int, end: int) -> None:
                     if end > 0
                     else TR.stellar__no_restriction
                 ),
+                False,
             ),
         ),
     )

--- a/core/src/apps/tezos/layout.py
+++ b/core/src/apps/tezos/layout.py
@@ -41,8 +41,8 @@ async def require_confirm_origination_fee(balance: int, fee: int) -> None:
         "confirm_origination_final",
         TR.tezos__confirm_origination,
         (
-            (TR.tezos__balance, format_tezos_amount(balance)),
-            (f"{TR.words__fee}:", format_tezos_amount(fee)),
+            (TR.tezos__balance, format_tezos_amount(balance), False),
+            (f"{TR.words__fee}:", format_tezos_amount(fee), False),
         ),
         hold=True,
     )
@@ -74,8 +74,8 @@ async def require_confirm_register_delegate(address: str, fee: int) -> None:
         "confirm_register_delegate",
         TR.tezos__register_delegate,
         (
-            (f"{TR.words__fee}:", format_tezos_amount(fee)),
-            (f"{TR.words__address}:", address),
+            (f"{TR.words__fee}:", format_tezos_amount(fee), True),
+            (f"{TR.words__address}:", address, True),
         ),
         hold=True,
         br_code=BR_SIGN_TX,
@@ -96,8 +96,8 @@ async def require_confirm_ballot(proposal: str, ballot: str) -> None:
         "confirm_ballot",
         TR.tezos__submit_ballot,
         (
-            (TR.tezos__ballot, ballot),
-            (f"{TR.tezos__proposal}:", proposal),
+            (TR.tezos__ballot, ballot, True),
+            (f"{TR.tezos__proposal}:", proposal, True),
         ),
         hold=True,
         br_code=BR_SIGN_TX,
@@ -109,7 +109,7 @@ async def require_confirm_proposals(proposals: list[str]) -> None:
         "confirm_proposals",
         TR.tezos__submit_proposals if len(proposals) > 1 else TR.tezos__submit_proposal,
         [
-            (f"{TR.tezos__proposal} " + str(i), proposal)
+            (f"{TR.tezos__proposal} " + str(i), proposal, True)
             for i, proposal in enumerate(proposals, 1)
         ],
         hold=True,

--- a/core/src/trezor/ui/layouts/common.py
+++ b/core/src/trezor/ui/layouts/common.py
@@ -12,7 +12,7 @@ if __debug__:
 if TYPE_CHECKING:
     from typing import Any, Awaitable, Callable, Coroutine, TypeVar
 
-    PropertyType = tuple[str | None, str | bytes | None]
+    PropertyType = tuple[str | None, str | bytes | None, bool | None]
     ExceptionType = BaseException | type[BaseException]
 
     InfoFunc = Callable[[], Awaitable[None]]

--- a/core/src/trezor/ui/layouts/delizia/__init__.py
+++ b/core/src/trezor/ui/layouts/delizia/__init__.py
@@ -735,14 +735,12 @@ def confirm_properties(
     hold: bool = False,
     br_code: ButtonRequestType = ButtonRequestType.ConfirmOutput,
 ) -> Awaitable[None]:
-    # Monospace flag for values that are bytes.
-    items = [(prop[0], prop[1], isinstance(prop[1], bytes)) for prop in props]
 
     return raise_if_not_confirmed(
         trezorui_api.confirm_properties(
             title=title,
             subtitle=subtitle,
-            items=items,
+            items=list(props),
             hold=hold,
         ),
         br_name,
@@ -941,18 +939,19 @@ if not utils.BITCOIN_ONLY:
                 br_name="confirm_ethereum_approve",
             )
 
-        properties = (
-            [(TR.words__token, token_symbol)]
+        properties: list[PropertyType] = (
+            [(TR.words__token, token_symbol, True)]
             if is_revoke
             else [
                 (
                     TR.ethereum__approve_amount_allowance,
                     total_amount or TR.words__unlimited,
+                    False,
                 )
             ]
         )
         if not is_unknown_network:
-            properties.append((TR.words__chain, network_name))
+            properties.append((TR.words__chain, network_name, True))
         await confirm_properties(
             "confirm_ethereum_approve",
             TR.ethereum__approve_revoke if is_revoke else TR.ethereum__approve,

--- a/core/src/trezor/ui/layouts/eckhart/__init__.py
+++ b/core/src/trezor/ui/layouts/eckhart/__init__.py
@@ -737,8 +737,6 @@ def confirm_properties(
     hold: bool = False,
     br_code: ButtonRequestType = ButtonRequestType.ConfirmOutput,
 ) -> Awaitable[None]:
-    # Monospace flag for values that are bytes.
-    items = [(prop[0], prop[1], isinstance(prop[1], bytes)) for prop in props]
 
     if subtitle:
         title += ": " + subtitle
@@ -746,7 +744,7 @@ def confirm_properties(
     return raise_if_not_confirmed(
         trezorui_api.confirm_properties(
             title=title,
-            items=items,
+            items=list(props),
             hold=hold,
         ),
         br_name,
@@ -961,18 +959,19 @@ if not utils.BITCOIN_ONLY:
                 br_name="confirm_ethereum_approve",
             )
 
-        properties = (
-            [(TR.words__token, token_symbol)]
+        properties: list[PropertyType] = (
+            [(TR.words__token, token_symbol, True)]
             if is_revoke
             else [
                 (
                     TR.ethereum__approve_amount_allowance,
                     total_amount or TR.words__unlimited,
+                    False,
                 )
             ]
         )
         if not is_unknown_network:
-            properties.append((TR.words__chain, network_name))
+            properties.append((TR.words__chain, network_name, True))
         await confirm_properties(
             "confirm_ethereum_approve",
             TR.ethereum__approve_revoke if is_revoke else TR.ethereum__approve,

--- a/core/src/trezor/utils.py
+++ b/core/src/trezor/utils.py
@@ -123,8 +123,6 @@ class unimport:
 
 
 if __debug__:
-    from ubinascii import hexlify
-
     try:
         from trezorutils import enable_oom_dump
 
@@ -146,10 +144,6 @@ if __debug__:
             mem_info()
         else:
             mem_info(True)
-
-    def get_bytes_as_str(a: bytes) -> str:
-        """Converts the provided bytes to a hexadecimal string (decoded as `utf-8`)."""
-        return hexlify(a).decode("utf-8")
 
 
 def ensure(cond: bool, msg: str | None = None) -> None:
@@ -375,6 +369,17 @@ def empty_bytearray(preallocate: int) -> bytearray:
     b = bytearray(preallocate)
     b[:] = bytes()
     return b
+
+
+def hexlify_if_bytes(data: str | bytes | bytearray | memoryview) -> str:
+    if isinstance(data, str):
+        return data
+    elif isinstance(data, (bytes, bytearray, memoryview)):
+        from ubinascii import hexlify
+
+        return hexlify(data).decode()
+    else:
+        raise TypeError("Expected str, bytes, bytearray, or memoryview")
 
 
 if __debug__:

--- a/core/src/trezor/wire/message_handler.py
+++ b/core/src/trezor/wire/message_handler.py
@@ -29,7 +29,7 @@ def wrap_protobuf_load(
             log.debug(
                 __name__,
                 "Buffer to be parsed to a LoadedMessage: %s",
-                utils.get_bytes_as_str(buffer),
+                utils.hexlify_if_bytes(buffer),
             )
         msg = protobuf.decode(buffer, expected_type, EXPERIMENTAL_ENABLED)
         if __debug__ and utils.EMULATOR:


### PR DESCRIPTION
This PR introduces improvements to the `Props` rendering and updates all related usages:

- Makes the **3rd parameter** of the `Props` component **mandatory** — a `bool` indicating whether the value is **data** or not.
- Applies **different monospace fonts** for **data** and **non-data** props.
- Implements distinct line-breaking strategies:
  - **Non-data props**: break at white space; use **hyphens** if a word spans multiple lines.
  - **Data props**: break on a **character basis** with **no hyphens**.
- Added **explicit type-checking** and updated all `confirm_properties` calls across all UIs to include the new 3rd `bool` parameter.
- For the **Eckhart UI**, increased the size of the monospace font for props to match the **[Figma](https://www.figma.com/design/Dkl7W5PLqpr3TnXJ5hbnfd/--Future-Prod---Safe-7?node-id=8499-6247&t=KdxCygULeyByoXnZ-0)** design.


TODO
- [x] update fixtures for all languages
