### PR TITLE
fix(core): fix firmware hash calculation

### DIFF
--- a/core/embed/projects/kernel/main.c
+++ b/core/embed/projects/kernel/main.c
@@ -213,11 +213,11 @@ static void kernel_loop(applet_t *coreapp) {
 
 // defined in linker script
 extern uint32_t _kernel_flash_end;
-#define KERNEL_END ((uint32_t) & _kernel_flash_end)
+#define KERNEL_END COREAPP_CODE_ALIGN((uint32_t) & _kernel_flash_end)
 
 // Initializes coreapp applet
 static void coreapp_init(applet_t *applet) {
-  const uint32_t CODE1_START = COREAPP_CODE_ALIGN(KERNEL_END);
+  const uint32_t CODE1_START = KERNEL_END;
 
 #ifdef FIRMWARE_P1_START
   const uint32_t CODE1_END = FIRMWARE_P1_START + FIRMWARE_P1_MAXSIZE;

--- a/core/embed/sys/mpu/stm32u5/mpu.c
+++ b/core/embed/sys/mpu/stm32u5/mpu.c
@@ -157,7 +157,7 @@ extern uint32_t _kernel_flash_end;
 #define KERNEL_START FIRMWARE_START
 #endif
 
-#define KERNEL_END ((uint32_t) & _kernel_flash_end)
+#define KERNEL_END COREAPP_CODE_ALIGN((uint32_t) & _kernel_flash_end)
 #define KERNEL_SIZE (KERNEL_END - KERNEL_START)
 #endif  // KERNEL
 


### PR DESCRIPTION
This PR fixes a bug introduced by the secure monitor PR that prevented the firmware hash from being calculated.

The firmware on T3T1 (and possibly T3B1) is crashing when retrieving the firmware hash with `trezorctl fw get-hash`. 

The crash was caused by a small gap between the kernel and the coreapp that the kernel could not access. 


