### PR TITLE
test(core): don't call `clear_gc_info()` when PYOPT=1

### DIFF
--- a/core/src/trezor/utils.py
+++ b/core/src/trezor/utils.py
@@ -101,7 +101,8 @@ def unimport_end(mods: set[str], collect: bool = True) -> None:
 class unimport:
     def __init__(self) -> None:
         self.mods: set[str] | None = None
-        clear_gc_info()
+        if __debug__:
+            clear_gc_info()
 
     def __enter__(self) -> None:
         self.mods = unimport_begin()


### PR DESCRIPTION
Fixes a `(PE)` error introduced by #5091 on non-debug builds.

<!--
For core developers:
- Assign yourself to the PR.
- Set the priority to match the original issue.
- Add the PR to the current sprint.
- If it's a draft PR, mark it as "In Progress."
- If it's a final PR, mark it as "Needs Review."

For external contributors:
- Please open an issue before submitting a PR so we can discuss whether we want to proceed with it.
-->
