### PR TITLE
test(core): allow replacing GC leak error by warning via CLI flag

### DIFF
--- a/docs/tests/device-tests.md
+++ b/docs/tests/device-tests.md
@@ -164,3 +164,11 @@ Run the tests with coverage output.
 ```sh
 make build_unix && make coverage
 ```
+
+### GC leak check (both Emulator and Hardware)
+
+DebugLink interface supports polling the device for its current [GC-related information](https://github.com/trezor/trezor-firmware/pull/5091).
+
+On every test setup/teardown, we check for whether the free memory has decreased (indicating that the GC didn't free all allocated heap memory).
+
+By default, the test will fail if a leak is detected. In order to issue a warning instead, use `--ignore-gc-leak` CLI flag.

--- a/python/src/trezorlib/debuglink.py
+++ b/python/src/trezorlib/debuglink.py
@@ -21,6 +21,7 @@ import logging
 import re
 import textwrap
 import time
+import warnings
 from contextlib import contextmanager
 from copy import deepcopy
 from datetime import datetime
@@ -851,7 +852,7 @@ class DebugLink:
         im.save(img_location)
         self.t1_screenshot_counter += 1
 
-    def check_gc_info(self):
+    def check_gc_info(self, fail_on_gc_leak: bool = True):
         """Fetch GC heap information and check for leaks."""
         if not self.has_gc_info:
             return
@@ -876,7 +877,10 @@ class DebugLink:
         # Free heap memory should not decrease
         if info["free"] < prev_info["free"]:
             msg = f"GC leak found: {prev_info} -> {info}"
-            raise AssertionError(msg)
+            if fail_on_gc_leak:
+                raise AssertionError(msg)
+            else:
+                warnings.warn(msg)
 
 
 del _make_input_func

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -304,6 +304,7 @@ def client(
         )
 
     test_ui = request.config.getoption("ui")
+    fail_on_gc_leak = not request.config.getoption("ignore_gc_leak")
 
     _raw_client.reset_debug_features()
     _raw_client.open()
@@ -314,7 +315,7 @@ def client(
         _raw_client.debug.reset_debug_events()
 
         # Make sure there are no GC leaks from previous tests
-        _raw_client.debug.check_gc_info()
+        _raw_client.debug.check_gc_info(fail_on_gc_leak)
 
         if test_ui:
             # we need to reseed before the wipe
@@ -374,7 +375,7 @@ def client(
             yield _raw_client
     finally:
         # Make sure there are no GC leaks from this test
-        _raw_client.debug.check_gc_info()
+        _raw_client.debug.check_gc_info(fail_on_gc_leak)
 
         _raw_client.close()
 
@@ -474,6 +475,12 @@ def pytest_addoption(parser: "Parser") -> None:
         action="store",
         default=None,
         help="File path for verbose logging",
+    )
+    parser.addoption(
+        "--ignore-gc-leak",
+        action="store_true",
+        default=False,
+        help="Issue a warning when GC leak detected (otherwise, fail the test)",
     )
 
 


### PR DESCRIPTION
This PR:
- doesn't fail next tests in case of a GC leak.
- adds more details to the assertion failure message.
- allows disabling GC leak error via `--ignore-gc-leak` flag (will issue [a warning](https://docs.pytest.org/en/stable/how-to/capture-warnings.html) instead).

<!--
For core developers:
- Assign yourself to the PR.
- Set the priority to match the original issue.
- Add the PR to the current sprint.
- If it's a draft PR, mark it as "In Progress."
- If it's a final PR, mark it as "Needs Review."

For external contributors:
- Please open an issue before submitting a PR so we can discuss whether we want to proceed with it.
-->
