### PR TITLE
fix(core): use correct size in `workflow_ifaces_init()`

### DIFF
--- a/core/embed/io/touch/stmpe811/touch.c
+++ b/core/embed/io/touch/stmpe811/touch.c
@@ -49,7 +49,7 @@ secbool touch_init(void) {
     return sectrue;
   }
 
-  memset(drv, 0, sizeof(drv));
+  memset(drv, 0, sizeof(*drv));
 
   drv->i2c_bus = i2c_bus_open(TOUCH_I2C_INSTANCE);
 

--- a/core/embed/projects/bootloader/workflow/wf_host_control.c
+++ b/core/embed/projects/bootloader/workflow/wf_host_control.c
@@ -141,7 +141,7 @@ exit_host_control:
 
 void workflow_ifaces_init(secbool usb21_landing, protob_ios_t *ios) {
   size_t cnt = 1;
-  memset(ios, 0, sizeof(ios));
+  memset(ios, 0, sizeof(*ios));
 
   wire_iface_t *usb_iface = usb_iface_init(usb21_landing);
 


### PR DESCRIPTION
No changelog, since https://github.com/trezor/trezor-firmware/commit/c319e5fa208365c8c79efeea364903505d6de848 hasn't been released yet.

- [x] Rebased over https://github.com/trezor/trezor-firmware/pull/5180.