### PR TITLE
feat(core): use OpTextLayout::add_ functions to reduce stack usage

### DIFF
--- a/core/embed/rust/src/ui/component/text/op.rs
+++ b/core/embed/rust/src/ui/component/text/op.rs
@@ -193,60 +193,60 @@ impl<'a> OpTextLayout<'a> {
 
 // Op-adding operations
 impl<'a> OpTextLayout<'a> {
-    pub fn with_new_item(mut self, item: Op<'a>) -> Self {
+    pub fn add_new_item(&mut self, item: Op<'a>) -> &mut Self {
         self.ops
             .push(item)
             .assert_if_debugging_ui("Could not push to self.ops - increase MAX_OPS.");
         self
     }
 
-    pub fn text(self, text: impl Into<TString<'a>>, font: Font) -> Self {
-        self.with_new_item(Op::Text(text.into(), font, false))
+    pub fn add_text(&mut self, text: impl Into<TString<'a>>, font: Font) -> &mut Self {
+        self.add_new_item(Op::Text(text.into(), font, false))
     }
 
-    pub fn color(self, color: Color) -> Self {
-        self.with_new_item(Op::Color(color))
+    pub fn add_color(&mut self, color: Color) -> &mut Self {
+        self.add_new_item(Op::Color(color))
     }
 
-    pub fn newline(self) -> Self {
+    pub fn add_newline(&mut self) -> &mut Self {
         let font = self.layout.style.text_font;
-        self.text("\n", font)
+        self.add_text("\n", font)
     }
 
-    pub fn newline_half(self) -> Self {
+    pub fn add_newline_half(&mut self) -> &mut Self {
         let font = self.layout.style.text_font;
-        self.text("\r", font)
+        self.add_text("\r", font)
     }
 
-    pub fn next_page(self) -> Self {
-        self.with_new_item(Op::NextPage)
+    pub fn add_next_page(&mut self) -> &mut Self {
+        self.add_new_item(Op::NextPage)
     }
 
-    pub fn offset(self, offset: Offset) -> Self {
-        self.with_new_item(Op::CursorOffset(offset))
+    pub fn add_offset(&mut self, offset: Offset) -> &mut Self {
+        self.add_new_item(Op::CursorOffset(offset))
     }
 
-    pub fn alignment(self, alignment: Alignment) -> Self {
-        self.with_new_item(Op::Alignment(alignment))
+    pub fn add_alignment(&mut self, alignment: Alignment) -> &mut Self {
+        self.add_new_item(Op::Alignment(alignment))
     }
 
-    pub fn line_breaking(self, line_breaking: LineBreaking) -> Self {
-        self.with_new_item(Op::LineBreaking(line_breaking))
+    pub fn add_line_breaking(&mut self, line_breaking: LineBreaking) -> &mut Self {
+        self.add_new_item(Op::LineBreaking(line_breaking))
     }
 
-    pub fn chunks(self, chunks: Option<Chunks>) -> Self {
-        self.with_new_item(Op::Chunkify(chunks))
+    pub fn add_chunks(&mut self, chunks: Option<Chunks>) -> &mut Self {
+        self.add_new_item(Op::Chunkify(chunks))
     }
 
-    pub fn line_spacing(self, spacing: i16) -> Self {
-        self.with_new_item(Op::LineSpacing(spacing))
+    pub fn add_line_spacing(&mut self, spacing: i16) -> &mut Self {
+        self.add_new_item(Op::LineSpacing(spacing))
     }
 
-    pub fn chunkify_text(self, chunks: Option<(Chunks, i16)>) -> Self {
-        if let Some(chunks) = chunks {
-            self.chunks(Some(chunks.0)).line_spacing(chunks.1)
+    pub fn add_chunkify_text(&mut self, chunks: Option<(Chunks, i16)>) -> &mut Self {
+        if let Some((c, spacing)) = chunks {
+            self.add_chunks(Some(c)).add_line_spacing(spacing)
         } else {
-            self.chunks(None).line_spacing(0)
+            self.add_chunks(None).add_line_spacing(0)
         }
     }
 }

--- a/core/embed/rust/src/ui/layout_bolt/ui_firmware.rs
+++ b/core/embed/rust/src/ui/layout_bolt/ui_firmware.rs
@@ -190,14 +190,14 @@ impl FirmwareUI for UIBolt {
         let mut ops = OpTextLayout::new(theme::TEXT_NORMAL);
         for item in IterBuf::new().try_iterate(items)? {
             if item.is_str() {
-                ops = ops.text(TString::try_from(item)?, fonts::FONT_NORMAL)
+                ops.add_text(TString::try_from(item)?, fonts::FONT_NORMAL);
             } else {
                 let [emphasis, text]: [Obj; 2] = util::iter_into_array(item)?;
                 let text: TString = text.try_into()?;
                 if emphasis.try_into()? {
-                    ops = ops.text(text, fonts::FONT_DEMIBOLD)
+                    ops.add_text(text, fonts::FONT_DEMIBOLD);
                 } else {
-                    ops = ops.text(text, fonts::FONT_NORMAL);
+                    ops.add_text(text, fonts::FONT_NORMAL);
                 }
             }
         }
@@ -1413,12 +1413,12 @@ mod tests {
             false,
         );
 
-        let ops = OpTextLayout::new(theme::TEXT_NORMAL)
-            .text(
-                "Testing text layout, with some text, and some more text. And ",
-                fonts::FONT_NORMAL,
-            )
-            .text("parameters!", fonts::FONT_BOLD_UPPER);
+        let mut ops = OpTextLayout::new(theme::TEXT_NORMAL);
+        ops.add_text(
+            "Testing text layout, with some text, and some more text. And ",
+            fonts::FONT_NORMAL,
+        )
+        .add_text("parameters!", fonts::FONT_BOLD_UPPER);
         let formatted = FormattedText::new(ops);
         let mut layout = Dialog::new(formatted, buttons);
         layout.place(SCREEN);

--- a/core/embed/rust/src/ui/layout_caesar/ui_firmware.rs
+++ b/core/embed/rust/src/ui/layout_caesar/ui_firmware.rs
@@ -114,15 +114,15 @@ impl FirmwareUI for UICaesar {
                 // address label (for some reason it does not help to turn it off after
                 // rendering the chunks)
                 if chunkify {
-                    ops = ops.chunkify_text(None);
+                    ops.add_chunkify_text(None);
                 }
-                ops = ops.text(label, fonts::FONT_NORMAL).newline();
+                ops.add_text(label, fonts::FONT_NORMAL).add_newline();
             }
             if chunkify {
                 // Chunkifying the address into smaller pieces when requested
-                ops = ops.chunkify_text(Some((theme::MONO_CHUNKS, 2)));
+                ops.add_chunkify_text(Some((theme::MONO_CHUNKS, 2)));
             }
-            ops = ops.text(address, fonts::FONT_MONO);
+            ops.add_text(address, fonts::FONT_MONO);
             let formatted = FormattedText::new(ops).vertically_centered();
             Page::new(btn_layout, btn_actions, formatted).with_title(title)
         };
@@ -269,11 +269,11 @@ impl FirmwareUI for UICaesar {
                 )
             };
 
-            let ops = OpTextLayout::new(theme::TEXT_NORMAL)
-                .newline()
-                .text(app_name, fonts::FONT_NORMAL)
-                .newline()
-                .text(account, fonts::FONT_BOLD);
+            let mut ops = OpTextLayout::new(theme::TEXT_NORMAL);
+            ops.add_newline()
+                .add_text(app_name, fonts::FONT_NORMAL)
+                .add_newline()
+                .add_text(account, fonts::FONT_BOLD);
             let formatted = FormattedText::new(ops);
 
             Page::new(btn_layout, btn_actions, formatted)
@@ -474,12 +474,12 @@ impl FirmwareUI for UICaesar {
                 TR::reset__button_create.into(),
             )
         };
-        let ops = OpTextLayout::new(theme::TEXT_NORMAL)
-            .text(TR::reset__by_continuing, fonts::FONT_NORMAL)
-            .next_page()
-            .text(TR::reset__more_info_at, fonts::FONT_NORMAL)
-            .newline()
-            .text(TR::reset__tos_link, fonts::FONT_BOLD);
+        let mut ops = OpTextLayout::new(theme::TEXT_NORMAL);
+        ops.add_text(TR::reset__by_continuing, fonts::FONT_NORMAL)
+            .add_next_page()
+            .add_text(TR::reset__more_info_at, fonts::FONT_NORMAL)
+            .add_newline()
+            .add_text(TR::reset__tos_link, fonts::FONT_BOLD);
         let formatted = FormattedText::new(ops).vertically_centered();
 
         content_in_button_page(title, formatted, button, Some("".into()), false)
@@ -556,29 +556,27 @@ impl FirmwareUI for UICaesar {
 
                     let mut ops = OpTextLayout::new(theme::TEXT_MONO);
                     if let Some(title) = title {
-                        ops = ops.text(title, fonts::FONT_BOLD_UPPER).newline();
+                        ops.add_text(title, fonts::FONT_BOLD_UPPER).add_newline();
                     }
 
                     let mut has_amount = false;
                     if let Some(amount) = amount {
                         if let Some(amount_label) = amount_label {
                             has_amount = true;
-                            ops = ops
-                                .text(amount_label, fonts::FONT_BOLD)
-                                .newline()
-                                .text(amount, fonts::FONT_MONO);
+                            ops.add_text(amount_label, fonts::FONT_BOLD)
+                                .add_newline()
+                                .add_text(amount, fonts::FONT_MONO);
                         }
                     }
 
                     if !fee_label.is_empty() || !fee.is_empty() {
                         if has_amount {
-                            ops = ops.newline();
+                            ops.add_newline();
                         }
-                        ops = ops
-                            .newline()
-                            .text(fee_label, fonts::FONT_BOLD)
-                            .newline()
-                            .text(fee, fonts::FONT_MONO);
+                        ops.add_newline()
+                            .add_text(fee_label, fonts::FONT_BOLD)
+                            .add_newline()
+                            .add_text(fee, fonts::FONT_MONO);
                     }
 
                     let formatted = FormattedText::new(ops);
@@ -595,12 +593,11 @@ impl FirmwareUI for UICaesar {
                         let [key, value]: [Obj; 2] = unwrap!(util::iter_into_array(item));
                         if !ops.is_empty() {
                             // Each key-value pair is on its own page
-                            ops = ops.next_page();
+                            ops.add_next_page();
                         }
-                        ops = ops
-                            .text(unwrap!(TString::try_from(key)), fonts::FONT_BOLD)
-                            .newline()
-                            .text(unwrap!(TString::try_from(value)), fonts::FONT_MONO);
+                        ops.add_text(unwrap!(TString::try_from(key)), fonts::FONT_BOLD)
+                            .add_newline()
+                            .add_text(unwrap!(TString::try_from(value)), fonts::FONT_MONO);
                     }
 
                     let formatted = FormattedText::new(ops).vertically_centered();
@@ -785,7 +782,8 @@ impl FirmwareUI for UICaesar {
                 )
             };
 
-            let ops = OpTextLayout::new(theme::TEXT_NORMAL).text(text, fonts::FONT_NORMAL);
+            let mut ops = OpTextLayout::new(theme::TEXT_NORMAL);
+            ops.add_text(text, fonts::FONT_NORMAL);
             let formatted = FormattedText::new(ops).vertically_centered();
 
             Page::new(btn_layout, btn_actions, formatted)
@@ -801,10 +799,10 @@ impl FirmwareUI for UICaesar {
             0 => {
                 let btn_layout = ButtonLayout::text_none_arrow_wide(TR::buttons__skip.into());
                 let btn_actions = ButtonActions::cancel_none_next();
-                let ops = OpTextLayout::new(theme::TEXT_NORMAL)
-                    .text(TR::backup__new_wallet_created, fonts::FONT_NORMAL)
-                    .newline()
-                    .text(TR::backup__it_should_be_backed_up_now, fonts::FONT_NORMAL);
+                let mut ops = OpTextLayout::new(theme::TEXT_NORMAL);
+                ops.add_text(TR::backup__new_wallet_created, fonts::FONT_NORMAL)
+                    .add_newline()
+                    .add_text(TR::backup__it_should_be_backed_up_now, fonts::FONT_NORMAL);
                 let formatted = FormattedText::new(ops).vertically_centered();
                 Page::new(btn_layout, btn_actions, formatted)
                     .with_title(TR::words__title_success.into())
@@ -812,8 +810,8 @@ impl FirmwareUI for UICaesar {
             1 => {
                 let btn_layout = ButtonLayout::up_arrow_none_text(TR::buttons__back_up.into());
                 let btn_actions = ButtonActions::prev_none_confirm();
-                let ops = OpTextLayout::new(theme::TEXT_NORMAL)
-                    .text(TR::backup__recover_anytime, fonts::FONT_NORMAL);
+                let mut ops = OpTextLayout::new(theme::TEXT_NORMAL);
+                ops.add_text(TR::backup__recover_anytime, fonts::FONT_NORMAL);
                 let formatted = FormattedText::new(ops).vertically_centered();
                 Page::new(btn_layout, btn_actions, formatted)
                     .with_title(TR::backup__title_backup_wallet.into())
@@ -1013,15 +1011,15 @@ impl FirmwareUI for UICaesar {
             let btn_layout = ButtonLayout::cancel_none_text(TR::buttons__continue.into());
             let btn_actions = ButtonActions::cancel_none_confirm();
             let mut ops = OpTextLayout::new(theme::TEXT_NORMAL);
-            ops = ops.alignment(geometry::Alignment::Center);
+            ops.add_alignment(geometry::Alignment::Center);
             if !title.is_empty() {
-                ops = ops.text(title, fonts::FONT_BOLD_UPPER);
+                ops.add_text(title, fonts::FONT_BOLD_UPPER);
                 if !description.is_empty() {
-                    ops = ops.newline();
+                    ops.add_newline();
                 }
             }
             if !description.is_empty() {
-                ops = ops.text(description, fonts::FONT_NORMAL);
+                ops.add_text(description, fonts::FONT_NORMAL);
             }
             let formatted = FormattedText::new(ops).vertically_centered();
             Page::new(btn_layout, btn_actions, formatted)
@@ -1149,13 +1147,13 @@ impl FirmwareUI for UICaesar {
 
             let btn_layout = ButtonLayout::arrow_none_text(TR::buttons__quit.into());
             let btn_actions = ButtonActions::cancel_none_confirm();
-            let ops = OpTextLayout::new(theme::TEXT_NORMAL)
-                .text(title, fonts::FONT_BOLD_UPPER)
-                .newline()
-                .newline_half()
-                .text(TR::addr_mismatch__contact_support_at, fonts::FONT_NORMAL)
-                .newline()
-                .text(TR::addr_mismatch__support_url, fonts::FONT_BOLD);
+            let mut ops = OpTextLayout::new(theme::TEXT_NORMAL);
+            ops.add_text(title, fonts::FONT_BOLD_UPPER)
+                .add_newline()
+                .add_newline_half()
+                .add_text(TR::addr_mismatch__contact_support_at, fonts::FONT_NORMAL)
+                .add_newline()
+                .add_text(TR::addr_mismatch__support_url, fonts::FONT_BOLD);
             let formatted = FormattedText::new(ops);
             Page::new(btn_layout, btn_actions, formatted)
         };
@@ -1271,15 +1269,15 @@ impl FirmwareUI for UICaesar {
             let btn_layout = ButtonLayout::none_armed_none(button);
             let btn_actions = ButtonActions::none_confirm_none();
             let mut ops = OpTextLayout::new(theme::TEXT_NORMAL);
-            ops = ops.alignment(geometry::Alignment::Center);
+            ops.add_alignment(geometry::Alignment::Center);
             if !value.is_empty() {
-                ops = ops.text(value, fonts::FONT_BOLD_UPPER);
+                ops.add_text(value, fonts::FONT_BOLD_UPPER);
                 if !description.is_empty() {
-                    ops = ops.newline();
+                    ops.add_newline();
                 }
             }
             if !description.is_empty() {
-                ops = ops.text(description, fonts::FONT_NORMAL);
+                ops.add_text(description, fonts::FONT_NORMAL);
             }
             let formatted = FormattedText::new(ops).vertically_centered();
             Page::new(btn_layout, btn_actions, formatted)
@@ -1412,7 +1410,8 @@ fn tutorial_screen(
     btn_layout: ButtonLayout,
     btn_actions: ButtonActions,
 ) -> Page {
-    let ops = OpTextLayout::new(theme::TEXT_NORMAL).text(text, fonts::FONT_NORMAL);
+    let mut ops = OpTextLayout::new(theme::TEXT_NORMAL);
+    ops.add_text(text, fonts::FONT_NORMAL);
     let formatted = FormattedText::new(ops).vertically_centered();
     Page::new(btn_layout, btn_actions, formatted).with_title(title)
 }

--- a/core/embed/rust/src/ui/layout_delizia/ui_firmware.rs
+++ b/core/embed/rust/src/ui/layout_delizia/ui_firmware.rs
@@ -224,12 +224,12 @@ impl FirmwareUI for UIDelizia {
         let mut ops = OpTextLayout::new(theme::TEXT_NORMAL);
         for item in IterBuf::new().try_iterate(items)? {
             if item.is_str() {
-                ops = ops.text(TString::try_from(item)?, fonts::FONT_DEMIBOLD)
+                ops.add_text(TString::try_from(item)?, fonts::FONT_DEMIBOLD);
             } else {
                 let [_emphasis, text]: [Obj; 2] = util::iter_into_array(item)?;
                 let text: TString = text.try_into()?;
                 // emphasis not implemented on Delizia
-                ops = ops.text(text, fonts::FONT_DEMIBOLD);
+                ops.add_text(text, fonts::FONT_DEMIBOLD);
             }
         }
 

--- a/core/embed/rust/src/ui/layout_eckhart/flow/confirm_reset.rs
+++ b/core/embed/rust/src/ui/layout_eckhart/flow/confirm_reset.rs
@@ -61,9 +61,9 @@ pub fn new_confirm_reset(recovery: bool) -> Result<SwipeFlow, error::Error> {
         )
     };
 
-    let op = OpTextLayout::new(theme::TEXT_REGULAR)
-        .text(TR::reset__by_continuing, fonts::FONT_SATOSHI_REGULAR_38)
-        .alignment(Alignment::Start);
+    let mut op = OpTextLayout::new(theme::TEXT_REGULAR);
+    op.add_text(TR::reset__by_continuing, fonts::FONT_SATOSHI_REGULAR_38)
+        .add_alignment(Alignment::Start);
 
     let content_intro = TextScreen::new(FormattedText::new(op))
         .with_header(Header::new(title).with_menu_button())

--- a/core/embed/rust/src/ui/layout_eckhart/ui_firmware.rs
+++ b/core/embed/rust/src/ui/layout_eckhart/ui_firmware.rs
@@ -151,16 +151,16 @@ impl FirmwareUI for UIEckhart {
 
         for item in IterBuf::new().try_iterate(items)? {
             if item.is_str() {
-                ops = ops.text(TString::try_from(item)?, font)
+                ops.add_text(TString::try_from(item)?, font);
             } else {
                 let [emphasis, text]: [Obj; 2] = util::iter_into_array(item)?;
                 let text: TString = text.try_into()?;
                 if emphasis.try_into()? {
-                    ops = ops.color(theme::WHITE);
-                    ops = ops.text(text, font);
-                    ops = ops.color(text_style.text_color);
+                    ops.add_color(theme::WHITE)
+                        .add_text(text, font)
+                        .add_color(text_style.text_color);
                 } else {
-                    ops = ops.text(text, font);
+                    ops.add_text(text, font);
                 }
             }
         }
@@ -1041,11 +1041,11 @@ impl FirmwareUI for UIEckhart {
         let font = fonts::FONT_SATOSHI_REGULAR_38;
         let text_style = theme::firmware::TEXT_REGULAR;
         let mut ops = OpTextLayout::new(text_style);
-        ops = ops.color(theme::GREEN);
-        ops = ops.text(device_name, font);
-        ops = ops.color(text_style.text_color);
         let text: TString = " is your Trezor's name.".into();
-        ops = ops.text(text, font);
+        ops.add_color(theme::GREEN)
+            .add_text(device_name, font)
+            .add_color(text_style.text_color)
+            .add_text(text, font);
         let screen = TextScreen::new(FormattedText::new(ops))
             .with_header(Header::new("Pair with new device".into()).with_close_button())
             .with_action_bar(ActionBar::new_text_only("Continue on host".into()));
@@ -1062,10 +1062,12 @@ impl FirmwareUI for UIEckhart {
         button: bool,
     ) -> Result<impl LayoutMaybeTrace, Error> {
         let mut ops = OpTextLayout::new(theme::firmware::TEXT_REGULAR);
-        ops = ops.text(description, fonts::FONT_SATOSHI_REGULAR_38);
-        ops = ops.newline().newline().newline();
-        ops = ops.alignment(Alignment::Center);
-        ops = ops.text(code, fonts::FONT_SATOSHI_EXTRALIGHT_72);
+        ops.add_text(description, fonts::FONT_SATOSHI_REGULAR_38)
+            .add_newline()
+            .add_newline()
+            .add_newline()
+            .add_alignment(Alignment::Center)
+            .add_text(code, fonts::FONT_SATOSHI_EXTRALIGHT_72);
         let mut screen = TextScreen::new(FormattedText::new(ops)).with_header(Header::new(title));
         if button {
             screen = screen.with_action_bar(ActionBar::new_cancel_confirm());
@@ -1148,12 +1150,11 @@ impl FirmwareUI for UIEckhart {
         let button: TString = TR::buttons__quit.into();
 
         let text_style = theme::TEXT_REGULAR;
-        let ops = OpTextLayout::new(text_style)
-            .text(description, text_style.text_font)
-            .text(url, theme::TEXT_MONO_MEDIUM.text_font);
-        let text = FormattedText::new(ops);
+        let mut ops = OpTextLayout::new(text_style);
+        ops.add_text(description, text_style.text_font)
+            .add_text(url, theme::TEXT_MONO_MEDIUM.text_font);
 
-        let screen = TextScreen::new(text)
+        let screen = TextScreen::new(FormattedText::new(ops))
             .with_header(Header::new(title))
             .with_action_bar(ActionBar::new_double(
                 Button::with_icon(theme::ICON_CROSS),


### PR DESCRIPTION
Change `OpTextLayout` methods to accept `&mut self`. Similar to #4715 
<!--
For core developers:
- Assign yourself to the PR.
- Set the priority to match the original issue.
- Add the PR to the current sprint.
- If it's a draft PR, mark it as "In Progress."
- If it's a final PR, mark it as "Needs Review."

For external contributors:
- Please open an issue before submitting a PR so we can discuss whether we want to proceed with it.
-->
