### PR TITLE
make secret api more versatile

### DIFF
--- a/core/embed/models/D002/model_D002.h
+++ b/core/embed/models/D002/model_D002.h
@@ -21,6 +21,7 @@
 
 #include <rtl/sizedefs.h>
 #include "bootloaders/bootloader_hashes.h"
+#include "secret_layout.h"
 
 #define MODEL_NAME "D002"
 #define MODEL_FULL_NAME "Trezor DIY 2"

--- a/core/embed/models/D002/secret_layout.h
+++ b/core/embed/models/D002/secret_layout.h
@@ -1,0 +1,36 @@
+/*
+ * This file is part of the Trezor project, https://trezor.io/
+ *
+ * Copyright (c) SatoshiLabs
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#pragma once
+
+#define SECRET_NUM_KEY_SLOTS 0
+
+// first page: static
+#define SECRET_HEADER_OFFSET 0x00
+#define SECRET_HEADER_LEN 0x10
+
+#define SECRET_MONOTONIC_COUNTER_0_OFFSET 0x10
+#define SECRET_MONOTONIC_COUNTER_0_LEN 0x400
+
+#define SECRET_MONOTONIC_COUNTER_1_OFFSET (0x410)
+#define SECRET_MONOTONIC_COUNTER_1_LEN 0x400
+
+// second page: refreshed on wallet wipe
+#define SECRET_BHK_OFFSET 0x2000
+#define SECRET_BHK_LEN 0x20

--- a/core/embed/models/T2B1/model_T2B1.h
+++ b/core/embed/models/T2B1/model_T2B1.h
@@ -20,6 +20,7 @@
 #pragma once
 
 #include "bootloaders/bootloader_hashes.h"
+#include "secret_layout.h"
 
 #define MODEL_NAME "Safe 3"
 #define MODEL_FULL_NAME "Trezor Safe 3"

--- a/core/embed/models/T2B1/secret_layout.h
+++ b/core/embed/models/T2B1/secret_layout.h
@@ -1,0 +1,31 @@
+/*
+ * This file is part of the Trezor project, https://trezor.io/
+ *
+ * Copyright (c) SatoshiLabs
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#pragma once
+
+#define SECRET_NUM_KEY_SLOTS 1
+
+// first page: static
+#define SECRET_HEADER_OFFSET 0x00
+#define SECRET_HEADER_LEN 0x10
+
+#define SECRET_KEY_SLOT_0_OFFSET 0x10
+#define SECRET_KEY_SLOT_0_LEN 0x20
+
+#define SECRET_OPTIGA_SLOT 0

--- a/core/embed/models/T3B1/model_T3B1.h
+++ b/core/embed/models/T3B1/model_T3B1.h
@@ -20,6 +20,7 @@
 #pragma once
 
 #include "bootloaders/bootloader_hashes.h"
+#include "secret_layout.h"
 
 #include <rtl/sizedefs.h>
 

--- a/core/embed/models/T3B1/secret_layout.h
+++ b/core/embed/models/T3B1/secret_layout.h
@@ -1,0 +1,41 @@
+/*
+ * This file is part of the Trezor project, https://trezor.io/
+ *
+ * Copyright (c) SatoshiLabs
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#pragma once
+
+#define SECRET_NUM_KEY_SLOTS 1
+
+// first page: static
+#define SECRET_HEADER_OFFSET 0x00
+#define SECRET_HEADER_LEN 0x10
+
+#define SECRET_KEY_SLOT_0_OFFSET 0x10
+#define SECRET_KEY_SLOT_0_LEN 0x20
+
+#define SECRET_MONOTONIC_COUNTER_0_OFFSET 0x30
+#define SECRET_MONOTONIC_COUNTER_0_LEN 0x400
+
+#define SECRET_MONOTONIC_COUNTER_1_OFFSET (0x430)
+#define SECRET_MONOTONIC_COUNTER_1_LEN 0x400
+
+// second page: refreshed on wallet wipe
+#define SECRET_BHK_OFFSET 0x2000
+#define SECRET_BHK_LEN 0x20
+
+#define SECRET_OPTIGA_SLOT 0

--- a/core/embed/models/T3T1/model_T3T1.h
+++ b/core/embed/models/T3T1/model_T3T1.h
@@ -20,6 +20,7 @@
 #pragma once
 
 #include "bootloaders/bootloader_hashes.h"
+#include "secret_layout.h"
 
 #include <rtl/sizedefs.h>
 

--- a/core/embed/models/T3T1/secret_layout.h
+++ b/core/embed/models/T3T1/secret_layout.h
@@ -1,0 +1,41 @@
+/*
+ * This file is part of the Trezor project, https://trezor.io/
+ *
+ * Copyright (c) SatoshiLabs
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#pragma once
+
+#define SECRET_NUM_KEY_SLOTS 1
+
+// first page: static
+#define SECRET_HEADER_OFFSET 0x00
+#define SECRET_HEADER_LEN 0x10
+
+#define SECRET_KEY_SLOT_0_OFFSET 0x10
+#define SECRET_KEY_SLOT_0_LEN 0x20
+
+#define SECRET_MONOTONIC_COUNTER_0_OFFSET 0x30
+#define SECRET_MONOTONIC_COUNTER_0_LEN 0x400
+
+#define SECRET_MONOTONIC_COUNTER_1_OFFSET (0x430)
+#define SECRET_MONOTONIC_COUNTER_1_LEN 0x400
+
+// second page: refreshed on wallet wipe
+#define SECRET_BHK_OFFSET 0x2000
+#define SECRET_BHK_LEN 0x20
+
+#define SECRET_OPTIGA_SLOT 0

--- a/core/embed/models/T3W1/model_T3W1.h
+++ b/core/embed/models/T3W1/model_T3W1.h
@@ -21,6 +21,7 @@
 #pragma once
 
 #include <rtl/sizedefs.h>
+#include "secret_layout.h"
 
 #include "bootloaders/bootloader_hashes.h"
 

--- a/core/embed/models/T3W1/secret_layout.h
+++ b/core/embed/models/T3W1/secret_layout.h
@@ -1,0 +1,51 @@
+/*
+ * This file is part of the Trezor project, https://trezor.io/
+ *
+ * Copyright (c) SatoshiLabs
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#pragma once
+
+#define SECRET_NUM_KEY_SLOTS 3
+
+// first page: static
+#define SECRET_HEADER_OFFSET 0x00
+#define SECRET_HEADER_LEN 0x10
+
+#define SECRET_KEY_SLOT_0_OFFSET 0x10
+#define SECRET_KEY_SLOT_0_LEN 0x20
+
+#define SECRET_MONOTONIC_COUNTER_0_OFFSET 0x30
+#define SECRET_MONOTONIC_COUNTER_0_LEN 0x400
+
+#define SECRET_MONOTONIC_COUNTER_1_OFFSET (0x430)
+#define SECRET_MONOTONIC_COUNTER_1_LEN 0x400
+
+#define SECRET_KEY_SLOT_1_OFFSET 0x830
+#define SECRET_KEY_SLOT_1_LEN 0x20
+
+#define SECRET_KEY_SLOT_2_OFFSET 0x850
+#define SECRET_KEY_SLOT_2_LEN 0x20
+#define SECRET_KEY_SLOT_2_PUBLIC 1
+
+// second page: refreshed on wallet wipe
+#define SECRET_BHK_OFFSET 0x2000
+#define SECRET_BHK_LEN 0x20
+
+// slot assignments
+#define SECRET_OPTIGA_SLOT 0
+#define SECRET_TROPIC_TREZOR_PRIVKEY_SLOT 1
+#define SECRET_TROPIC_TROPIC_PUBKEY_SLOT 2

--- a/core/embed/projects/bootloader/emulator.c
+++ b/core/embed/projects/bootloader/emulator.c
@@ -155,8 +155,7 @@ int main(int argc, char **argv) {
       } break;
 #ifdef LOCKABLE_BOOTLOADER
       case 'l':
-        // write bootloader-lock secret
-        secret_write_header();
+        secret_lock_bootloader();
         break;
 #endif
       default:

--- a/core/embed/projects/prodtest/cmd/prodtest_optiga.c
+++ b/core/embed/projects/prodtest/cmd/prodtest_optiga.c
@@ -19,6 +19,7 @@
 
 #ifdef USE_OPTIGA
 
+#include <trezor_model.h>
 #include <trezor_rtl.h>
 
 #include <rtl/cli.h>
@@ -164,10 +165,10 @@ static bool set_metadata(cli_t* cli, uint16_t oid,
 }
 
 void pair_optiga(cli_t* cli) {
-  uint8_t secret[SECRET_KEY_LEN] = {0};
+  uint8_t secret[32] = {0};
 
-  if (secret_optiga_get(secret) != sectrue) {
-    if (secret_optiga_writable() != sectrue) {
+  if (secret_key_get(SECRET_OPTIGA_SLOT, secret, sizeof(secret)) != sectrue) {
+    if (secret_key_writable(SECRET_OPTIGA_SLOT) != sectrue) {
       // optiga pairing secret is unwritable, so fail
       optiga_pairing_state = OPTIGA_PAIRING_ERR_WRITE_FLASH;
       return;
@@ -203,14 +204,14 @@ void pair_optiga(cli_t* cli) {
     }
 
     // Store the pairing secret in the flash memory.
-    if (sectrue != secret_optiga_set(secret)) {
+    if (sectrue != secret_key_set(SECRET_OPTIGA_SLOT, secret, sizeof(secret))) {
       optiga_pairing_state = OPTIGA_PAIRING_ERR_WRITE_FLASH;
       return;
     }
 
     // Reload the pairing secret from the flash memory.
     memzero(secret, sizeof(secret));
-    if (sectrue != secret_optiga_get(secret)) {
+    if (sectrue != secret_key_get(SECRET_OPTIGA_SLOT, secret, sizeof(secret))) {
       optiga_pairing_state = OPTIGA_PAIRING_ERR_READ_FLASH;
       return;
     }

--- a/core/embed/projects/prodtest/emulator.c
+++ b/core/embed/projects/prodtest/emulator.c
@@ -1,15 +1,15 @@
 #include <trezor_model.h>
 #include <trezor_rtl.h>
 
+#include <stdlib.h>
 #include <unistd.h>
 
 #include <SDL.h>
 
 #include <io/display.h>
+#include <sec/secret.h>
 #include <util/flash.h>
 #include <util/flash_otp.h>
-
-#include <stdlib.h>
 
 int prodtest_main(void);
 
@@ -53,6 +53,10 @@ int main(int argc, char **argv) {
   display_init(DISPLAY_RESET_CONTENT);
   flash_init();
   flash_otp_init();
+
+#ifdef LOCKABLE_BOOTLOADER
+  secret_lock_bootloader();
+#endif
 
   int opt;
   while ((opt = getopt(argc, argv, "h")) != -1) {

--- a/core/embed/projects/unix/main.c
+++ b/core/embed/projects/unix/main.c
@@ -37,6 +37,7 @@
 #include <unistd.h>
 
 #include <io/display.h>
+#include <sec/secret.h>
 #include <sys/system.h>
 #include <sys/systimer.h>
 #include <util/flash.h>
@@ -57,7 +58,6 @@
 #endif
 
 #ifdef USE_TROPIC
-#include <sec/secret.h>
 #include <sec/tropic.h>
 #endif
 
@@ -527,6 +527,10 @@ MP_NOINLINE int main_(int argc, char **argv) {
   mp_stack_set_limit(600000 * (sizeof(void *) / 4));
 
   pre_process_options(argc, argv);
+
+#ifdef LOCKABLE_BOOTLOADER
+  secret_lock_bootloader();
+#endif
 
   system_init(&rsod_panic_handler);
 

--- a/core/embed/sec/optiga/optiga_config.c
+++ b/core/embed/sec/optiga/optiga_config.c
@@ -24,7 +24,7 @@
 #include <sec/optiga.h>
 #include <sec/optiga_commands.h>
 #include <sec/optiga_transport.h>
-#include <sec/secret.h>
+#include <sec/secret_keys.h>
 #include <sys/systick.h>
 
 #include "memzero.h"
@@ -57,8 +57,8 @@ void optiga_init_and_configure(void) {
 
   optiga_init();
 
-  uint8_t secret[SECRET_KEY_LEN] = {0};
-  secbool secret_ok = secret_optiga_get(secret);
+  uint8_t secret[OPTIGA_PAIRING_SECRET_SIZE] = {0};
+  secbool secret_ok = secret_key_optiga_pairing(secret);
 
   if (sectrue == secret_ok) {
     // If the shielded connection cannot be established, reset Optiga and

--- a/core/embed/sec/secret/inc/sec/secret_keys.h
+++ b/core/embed/sec/secret/inc/sec/secret_keys.h
@@ -1,0 +1,42 @@
+/*
+ * This file is part of the Trezor project, https://trezor.io/
+ *
+ * Copyright (c) SatoshiLabs
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#pragma once
+
+#include <trezor_types.h>
+
+#ifdef SECURE_MODE
+
+#ifdef USE_OPTIGA
+
+#define OPTIGA_PAIRING_SECRET_SIZE 32
+secbool secret_key_optiga_pairing(uint8_t dest[OPTIGA_PAIRING_SECRET_SIZE]);
+
+#endif
+
+#ifdef USE_TROPIC
+
+#include <ed25519-donna/ed25519.h>
+
+secbool secret_key_tropic_public(curve25519_key dest);
+
+secbool secret_key_tropic_pairing(curve25519_key dest);
+#endif
+
+#endif

--- a/core/embed/sec/secret/stm32f4/secret_keys.c
+++ b/core/embed/sec/secret/stm32f4/secret_keys.c
@@ -1,0 +1,35 @@
+/*
+ * This file is part of the Trezor project, https://trezor.io/
+ *
+ * Copyright (c) SatoshiLabs
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#ifdef SECURE_MODE
+
+#include <trezor_bsp.h>
+#include <trezor_model.h>
+#include <trezor_rtl.h>
+
+#include <sec/secret.h>
+#include <sec/secret_keys.h>
+
+#ifdef USE_OPTIGA
+secbool secret_key_optiga_pairing(uint8_t dest[OPTIGA_PAIRING_SECRET_SIZE]) {
+  return secret_key_get(SECRET_OPTIGA_SLOT, dest, OPTIGA_PAIRING_SECRET_SIZE);
+}
+#endif
+
+#endif

--- a/core/embed/sec/secret/stm32u5/secret_keys.c
+++ b/core/embed/sec/secret/stm32u5/secret_keys.c
@@ -1,0 +1,47 @@
+/*
+ * This file is part of the Trezor project, https://trezor.io/
+ *
+ * Copyright (c) SatoshiLabs
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#ifdef SECURE_MODE
+
+#include <trezor_bsp.h>
+#include <trezor_model.h>
+#include <trezor_rtl.h>
+
+#include <sec/secret.h>
+#include <sec/secret_keys.h>
+
+#ifdef USE_OPTIGA
+secbool secret_key_optiga_pairing(uint8_t dest[OPTIGA_PAIRING_SECRET_SIZE]) {
+  return secret_key_get(SECRET_OPTIGA_SLOT, dest, OPTIGA_PAIRING_SECRET_SIZE);
+}
+#endif
+
+#ifdef USE_TROPIC
+secbool secret_key_tropic_public(curve25519_key dest) {
+  return secret_key_get(SECRET_TROPIC_TROPIC_PUBKEY_SLOT, dest,
+                        sizeof(curve25519_key));
+}
+
+secbool secret_key_tropic_pairing(curve25519_key dest) {
+  return secret_key_get(SECRET_TROPIC_TREZOR_PRIVKEY_SLOT, dest,
+                        sizeof(curve25519_key));
+}
+#endif
+
+#endif

--- a/core/embed/sec/secret/unix/secret_keys.c
+++ b/core/embed/sec/secret/unix/secret_keys.c
@@ -1,0 +1,58 @@
+/*
+ * This file is part of the Trezor project, https://trezor.io/
+ *
+ * Copyright (c) SatoshiLabs
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#ifdef SECURE_MODE
+
+#include <trezor_bsp.h>
+#include <trezor_model.h>
+#include <trezor_rtl.h>
+
+#include <sec/secret.h>
+#include <sec/secret_keys.h>
+
+#ifdef USE_TROPIC
+
+static uint8_t SECRET_TROPIC_PAIRING_BYTES[] = {
+    0xf0, 0xc4, 0xaa, 0x04, 0x8f, 0x00, 0x13, 0xa0, 0x96, 0x84, 0xdf,
+    0x05, 0xe8, 0xa2, 0x2e, 0xf7, 0x21, 0x38, 0x98, 0x28, 0x2b, 0xa9,
+    0x43, 0x12, 0xf3, 0x13, 0xdf, 0x2d, 0xce, 0x8d, 0x41, 0x64};
+
+static uint8_t SECRET_TROPIC_PUBKEY_BYTES[] = {
+    0x31, 0xE9, 0x0A, 0xF1, 0x50, 0x45, 0x10, 0xEE, 0x4E, 0xFD, 0x79,
+    0x13, 0x33, 0x41, 0x48, 0x15, 0x89, 0xA2, 0x89, 0x5C, 0xC5, 0xFB,
+    0xB1, 0x3E, 0xD5, 0x71, 0x1C, 0x1E, 0x9B, 0x81, 0x98, 0x72};
+
+_Static_assert(sizeof(SECRET_TROPIC_PAIRING_BYTES) == sizeof(curve25519_key),
+               "Invalid size of Tropic pairing key");
+
+_Static_assert(sizeof(SECRET_TROPIC_PUBKEY_BYTES) == sizeof(curve25519_key),
+               "Invalid size of Tropic public key");
+
+secbool secret_key_tropic_public(curve25519_key dest) {
+  memcpy(dest, SECRET_TROPIC_PUBKEY_BYTES, sizeof(curve25519_key));
+  return sectrue;
+}
+
+secbool secret_key_tropic_pairing(curve25519_key dest) {
+  memcpy(dest, SECRET_TROPIC_PAIRING_BYTES, sizeof(curve25519_key));
+  return sectrue;
+}
+#endif
+
+#endif

--- a/core/embed/sec/tropic/tropic.c
+++ b/core/embed/sec/tropic/tropic.c
@@ -22,7 +22,7 @@
 #include <trezor_rtl.h>
 #include <trezor_types.h>
 
-#include <sec/secret.h>
+#include <sec/secret_keys.h>
 #include <sec/tropic.h>
 
 #include <libtropic.h>
@@ -48,8 +48,8 @@ bool tropic_init(void) {
     return true;
   }
 
-  uint8_t tropic_secret_tropic_pubkey[SECRET_KEY_LEN] = {0};
-  uint8_t tropic_secret_trezor_privkey[SECRET_KEY_LEN] = {0};
+  curve25519_key tropic_secret_tropic_pubkey = {0};
+  curve25519_key tropic_secret_trezor_privkey = {0};
 
   if (!tropic_hal_init()) {
     goto cleanup;
@@ -60,13 +60,11 @@ bool tropic_init(void) {
     goto cleanup;
   }
 
-  secbool pubkey_ok =
-      secret_tropic_get_tropic_pubkey(tropic_secret_tropic_pubkey);
-  secbool privkey_ok =
-      secret_tropic_get_trezor_privkey(tropic_secret_trezor_privkey);
+  secbool pubkey_ok = secret_key_tropic_public(tropic_secret_tropic_pubkey);
+  secbool privkey_ok = secret_key_tropic_pairing(tropic_secret_trezor_privkey);
 
   if (pubkey_ok == sectrue && privkey_ok == sectrue) {
-    uint8_t trezor_pubkey[SECRET_KEY_LEN] = {0};
+    uint8_t trezor_pubkey[32] = {0};
     curve25519_scalarmult_basepoint(trezor_pubkey,
                                     tropic_secret_trezor_privkey);
 

--- a/core/site_scons/models/stm32f4_common.py
+++ b/core/site_scons/models/stm32f4_common.py
@@ -69,6 +69,7 @@ def stm32f4_common_files(env, defines, sources, paths):
         "embed/sec/random_delays/stm32/random_delays.c",
         "embed/sec/rng/stm32/rng.c",
         "embed/sec/secret/stm32f4/secret.c",
+        "embed/sec/secret/stm32f4/secret_keys.c",
         "embed/sec/time_estimate/stm32/time_estimate.c",
         "embed/sys/dbg/stm32/dbg_printf.c",
         "embed/sys/irq/stm32/irq.c",

--- a/core/site_scons/models/stm32u5_common.py
+++ b/core/site_scons/models/stm32u5_common.py
@@ -88,6 +88,7 @@ def stm32u5_common_files(env, features_wanted, defines, sources, paths):
         "embed/sec/random_delays/stm32/random_delays.c",
         "embed/sec/rng/stm32/rng.c",
         "embed/sec/secret/stm32u5/secret.c",
+        "embed/sec/secret/stm32u5/secret_keys.c",
         "embed/sec/secure_aes/stm32u5/secure_aes.c",
         "embed/sec/secure_aes/stm32u5/secure_aes_unpriv.c",
         "embed/sec/time_estimate/stm32/time_estimate.c",

--- a/core/site_scons/models/unix_common.py
+++ b/core/site_scons/models/unix_common.py
@@ -36,6 +36,7 @@ def unix_common_files(env, defines, sources, paths):
         "embed/sec/entropy/unix/entropy.c",
         "embed/sec/random_delays/unix/random_delays.c",
         "embed/sec/secret/unix/secret.c",
+        "embed/sec/secret/unix/secret_keys.c",
         "embed/sec/monoctr/unix/monoctr.c",
         "embed/sec/rng/unix/rng.c",
         "embed/sec/time_estimate/unix/time_estimate.c",


### PR DESCRIPTION
This PR refactors secret API to accommodate needs for more complex keys handling.

Secret API is unified to be independent on optiga/tropic presence, and a specific secret_keys extension is introduced to handle these specific keys. 

Secret storage layout is now model dependent.

On U5, new key variant, public, is introduced: such keys are always provided to FW and are not erased on bootloader unlock. 

On T3W1 we still use original secret layout with three keys stored, change to 'root key' and derivations are left to next work. 

Ad review: @andrewkozlik and @onvej-sl as you will be working on the derivations, please look over the API to see if it can work. No need to go trough implementation details if you dont want to.
