### PR TITLE
fix(core): remove unnecessary non-secure variant of irq_lock/unlock

### DIFF
--- a/core/embed/sys/irq/inc/sys/irq.h
+++ b/core/embed/sys/irq/inc/sys/irq.h
@@ -89,38 +89,6 @@ static inline void irq_unlock(irq_key_t key) {
   );
 }
 
-#if defined(__ARM_FEATURE_CMSE) && (__ARM_FEATURE_CMSE == 3U)
-
-// Disables non-secure interrupts and returns the previous interrupt state.
-//
-// see irq_lock() for more details.
-static inline irq_key_t irq_lock_ns(void) {
-  uint32_t key;
-  const uint32_t tmp = 1;
-  __asm volatile(
-      "MRS %0, PRIMASK_NS\n"
-      "MSR   PRIMASK_NS, %1\n"
-      : "=r"(key)
-      : "r"(tmp)
-      : "memory"  // Clobber memory to ensure correct memory operations
-  );
-  return key;
-}
-
-// Restores the non-secure interrupt state to what it was before `irq_lock`.
-//
-// see irq_unlock() for more details.
-static inline void irq_unlock_ns(irq_key_t key) {
-  __asm volatile(
-      "MSR PRIMASK_NS, %0\n"
-      :
-      : "r"(key)
-      : "memory"  // Clobber memory to ensure correct memory operations
-  );
-}
-
-#endif  // defined(__ARM_FEATURE_CMSE) && (__ARM_FEATURE_CMSE == 3U)
-
 // IRQ priority levels used throughout the system
 
 // Highest priority in the system (only RESET, NMI, and

--- a/core/embed/sys/power_save/stm32u5/power_save.c
+++ b/core/embed/sys/power_save/stm32u5/power_save.c
@@ -71,10 +71,6 @@ void power_save_suspend_cpu(void) {
   // PRIMASK is cleared again. This is necessary to restore the system clock
   // immediately after exiting STOP2 mode.
 
-#ifdef SECMON
-  irq_key_t irq_key_ns = irq_lock_ns();
-#endif
-
   irq_key_t irq_key = irq_lock();
 
   // The PWR clock is disabled after system initialization.
@@ -91,10 +87,6 @@ void power_save_suspend_cpu(void) {
   SystemInit();
 
   irq_unlock(irq_key);
-
-#ifdef SECMON
-  irq_unlock_ns(irq_key_ns);
-#endif
 }
 
 void power_save_suspend_secure_io() {


### PR DESCRIPTION
This PR removes functionality that the secure monitor no longer needs.

Recently added `irq_lock_ns()` and `irq_unlock_ns()`  functions are unnecessary, because the regular `irq_lock()` / `irq_unlock()` calls executed in Secure world already disable Non-Secure interrupts.