### PR TITLE
refactor(core): wrap coverage data map with `spin::RwLock`

### DIFF
--- a/core/embed/rust/src/coverage/mod.rs
+++ b/core/embed/rust/src/coverage/mod.rs
@@ -4,7 +4,6 @@ use heapless::{Entry, FnvIndexMap};
 use crate::{
     error::Error,
     micropython::{
-        buffer::StrBuffer,
         list::List,
         macros::{obj_fn_0, obj_fn_2, obj_module},
         module::Module,
@@ -15,7 +14,7 @@ use crate::{
 };
 
 struct Key {
-    file: StrBuffer,
+    file: Qstr,
     line: u16,
 }
 
@@ -23,9 +22,7 @@ impl TryFrom<&Key> for Obj {
     type Error = Error;
 
     fn try_from(val: &Key) -> Result<Self, Self::Error> {
-        let file: Obj = val.file.as_ref().try_into()?;
-        let line: Obj = val.line.into();
-        (file, line).try_into()
+        (Obj::from(val.file), Obj::from(val.line)).try_into()
     }
 }
 
@@ -38,7 +35,7 @@ impl core::hash::Hash for Key {
 
 impl core::cmp::PartialEq for Key {
     fn eq(&self, other: &Key) -> bool {
-        self.file.as_ref() == other.file.as_ref() && self.line == other.line
+        self.file == other.file && self.line == other.line
     }
 }
 


### PR DESCRIPTION
Following, the upgrade to Rust 2024.

```
warning: creating a mutable reference to mutable static is discouraged
  --> src/coverage/mod.rs:70:19
   |
70 |             match COVERAGE_DATA.entry(key) {
   |                   ^^^^^^^^^^^^^^^^^^^^^^^^ mutable reference to mutable static
   |
   = note: for more information, see <https://doc.rust-lang.org/nightly/edition-guide/rust-2024/static-mut-references.html>
   = note: mutable references to mutable statics are dangerous; it's undefined behavior if any other pointer to the static is used or if any other reference is created for the static while the mutable reference lives
   = note: `#[warn(static_mut_refs)]` on by default

warning: creating a shared reference to mutable static is discouraged
  --> src/coverage/mod.rs:88:45
   |
88 |         let list = unsafe { List::from_iter(COVERAGE_DATA.iter().map(Item))? };
   |                                             ^^^^^^^^^^^^^^^^^^^^ shared reference to mutable static
   |
   = note: for more information, see <https://doc.rust-lang.org/nightly/edition-guide/rust-2024/static-mut-references.html>
   = note: shared references to mutable statics are dangerous; it's undefined behavior if the static is mutated or if a mutable reference is created for it while the shared reference lives
```