### PR TITLE
Enable BKRAM retention in vbat mode

### DIFF
--- a/core/embed/sys/power_manager/stm32u5/power_control.c
+++ b/core/embed/sys/power_manager/stm32u5/power_control.c
@@ -31,19 +31,6 @@ static bool pm_background_tasks_suspended(void);
 static void pm_background_tasks_resume(void);
 
 pm_status_t pm_control_hibernate() {
-  // TEMPORARY FIX:
-  // Enable Backup domain retention in VBAT mode before entering the
-  // hibernation. BREN bit can be accessed only in LDO mode.
-  __HAL_RCC_PWR_CLK_ENABLE();
-
-  // Switch to LDO regulator
-  CLEAR_BIT(PWR->CR3, PWR_CR3_REGSEL);
-  // Wait until system switch on new regulator
-  while (HAL_IS_BIT_SET(PWR->SVMSR, PWR_SVMSR_REGS))
-    ;
-  // Enable backup domain retention
-  PWR->BDCR1 |= PWR_BDCR1_BREN;
-
   if (!pmic_enter_shipmode()) {
     return PM_ERROR;
   }

--- a/core/embed/sys/startup/stm32u5/startup_init.c
+++ b/core/embed/sys/startup/stm32u5/startup_init.c
@@ -241,6 +241,13 @@ void SystemInit(void) {
   // Disable the internal Pull-Up in Dead Battery pins of UCPD peripheral
   HAL_PWREx_DisableUCPDDeadBattery();
 
+#ifdef USE_BACKUP_RAM
+  // Enable backup domain retention
+  // This bit can be written only when the regulator is LDO,
+  // which must be configured before switching to SMPS.
+  PWR->BDCR1 |= PWR_BDCR1_BREN;
+#endif
+
 #ifdef USE_SMPS
   // Switch to SMPS regulator instead of LDO
   SET_BIT(PWR->CR3, PWR_CR3_REGSEL);


### PR DESCRIPTION
This small PR correctly enables the BKRAM retention bit during the early stages of boot - before the SMPS is turned on.

This fixes the retention problem when holding power button for more than 10s.

![image (1)](https://github.com/user-attachments/assets/3b143374-169d-44ab-b7a7-0c7f08e55aeb)

This setting applies only in the boardloader, because the SMPS is already enabled in later boot stages. It seems the power- and clock-initialization code in `startup_init.c` still needs a few tweaks to be completely correct.

