### PR TITLE
fix(emu): use same key for screenshots

### DIFF
--- a/core/embed/projects/bootloader/emulator.c
+++ b/core/embed/projects/bootloader/emulator.c
@@ -101,7 +101,7 @@ static int sdl_event_filter(void *userdata, SDL_Event *event) {
         case SDLK_ESCAPE:
           exit(3);
           return 0;
-        case SDLK_p:
+        case SDLK_s:
           display_save("emu");
           return 0;
       }

--- a/core/embed/projects/prodtest/emulator.c
+++ b/core/embed/projects/prodtest/emulator.c
@@ -38,7 +38,7 @@ static int sdl_event_filter(void *userdata, SDL_Event *event) {
         case SDLK_ESCAPE:
           exit(3);
           return 0;
-        case SDLK_p:
+        case SDLK_s:
           display_save("emu");
           return 0;
       }


### PR DESCRIPTION
- firmware emu uses `p` for power button and `s` for screenshot. So use `s` also for bootloader and prodtest emu screenshots.

[no changelog]

<!--
For core developers:
- Assign yourself to the PR.
- Set the priority to match the original issue.
- Add the PR to the current sprint.
- If it's a draft PR, mark it as "In Progress."
- If it's a final PR, mark it as "Needs Review."

For external contributors:
- Please open an issue before submitting a PR so we can discuss whether we want to proceed with it.
-->
