### PR TITLE
fix charging to 100%

### DIFF
--- a/core/embed/sys/power_manager/npm1300/npm1300.c
+++ b/core/embed/sys/power_manager/npm1300/npm1300.c
@@ -578,6 +578,7 @@ static void npm1300_calculate_report(npm1300_driver_t* drv,
   report->ibat_meas_status = r->adc_ibat_meas_status;
   report->buck_status = r->buck_status;
   report->usb_status = r->usb_status;
+  report->charge_status = r->charging_status;
 }
 
 // I2C operation for writing constant value to the npm1300 register

--- a/core/embed/sys/power_manager/stm32u5/power_monitoring.c
+++ b/core/embed/sys/power_manager/stm32u5/power_monitoring.c
@@ -98,7 +98,7 @@ void pm_monitor_power_sources(void) {
     fuel_gauge_set_soc(&drv->fuel_gauge, 1.0f, drv->fuel_gauge.P);
   }
 
-  // Ceil the float soc to user friendly integer
+  // Ceil the float soc to user-friendly integer
   uint8_t soc_ceiled_temp = (int)(drv->fuel_gauge.soc_latched * 100 + 0.999f);
   if (soc_ceiled_temp != drv->soc_ceiled) {
     drv->soc_ceiled = soc_ceiled_temp;
@@ -162,7 +162,7 @@ void pm_charging_controller(pm_driver_t* drv) {
 
   } else if (drv->wireless_connected) {
     // Wireless charger is sensitive to large current steps, so we need to
-    // controll the charging current in steps.
+    // control the charging current in steps.
     if (ticks_expired(drv->charging_step_timeout_ms)) {
       if (drv->charging_current_target_ma <
           drv->charging_current_max_limit_ma) {
@@ -190,9 +190,10 @@ void pm_charging_controller(pm_driver_t* drv) {
     pmic_set_charging_limit(drv->charging_current_target_ma);
   }
 
-  if (drv->soc_ceiled >= drv->soc_limit) {
+  if ((drv->soc_ceiled >= drv->soc_limit) && (drv->soc_limit != 100)) {
     drv->soc_limit_reached = true;
-  } else if (drv->soc_ceiled < drv->soc_limit - PM_SOC_LIMIT_HYSTERESIS) {
+  } else if ((drv->soc_limit == 100) ||
+             (drv->soc_ceiled < (drv->soc_limit - PM_SOC_LIMIT_HYSTERESIS))) {
     drv->soc_limit_reached = false;
   }
 

--- a/core/embed/sys/power_manager/stm32u5/power_monitoring.c
+++ b/core/embed/sys/power_manager/stm32u5/power_monitoring.c
@@ -93,7 +93,7 @@ void pm_monitor_power_sources(void) {
                     drv->pmic_data.ntc_temp);
 
   // Charging completed
-  if (drv->pmic_data.charge_status & 0x1) {
+  if (drv->pmic_data.charge_status & 0x2) {
     // Force fuel gauge to 100%, keep the covariance
     fuel_gauge_set_soc(&drv->fuel_gauge, 1.0f, drv->fuel_gauge.P);
   }


### PR DESCRIPTION
This small PR addresses two issues with charging to 100%.

First, we don't want to apply hysteresis when charging to full is enabled - its not expected by end user. Also we want to charge really to full, not 99 % which would be the result before as we comparing ceiled SOC.

Second, full battery detection is fixed - using correct bit and actually setting the value when reading PMIC data.