### PR TITLE
Promote `confirm_multiple_accounts_warning` to danger

### DIFF
--- a/core/.changelog.d/5218.changed
+++ b/core/.changelog.d/5218.changed
@@ -1,0 +1,1 @@
+[T3T1] Change multiple accounts warning to danger.

--- a/core/embed/rust/librust_qstr.h
+++ b/core/embed/rust/librust_qstr.h
@@ -683,6 +683,7 @@ static void _librust_qstrs(void) {
   MP_QSTR_send__incl_transaction_fee;
   MP_QSTR_send__including_fee;
   MP_QSTR_send__maximum_fee;
+  MP_QSTR_send__multisig_different_paths;
   MP_QSTR_send__receiving_to_multisig;
   MP_QSTR_send__send_from;
   MP_QSTR_send__send_in_the_app;

--- a/core/embed/rust/librust_qstr.h
+++ b/core/embed/rust/librust_qstr.h
@@ -677,6 +677,7 @@ static void _librust_qstrs(void) {
   MP_QSTR_select_word;
   MP_QSTR_select_word_count;
   MP_QSTR_send__cancel_sign;
+  MP_QSTR_send__cancel_transaction;
   MP_QSTR_send__confirm_sending;
   MP_QSTR_send__from_multiple_accounts;
   MP_QSTR_send__incl_transaction_fee;

--- a/core/embed/rust/src/translations/generated/translated_string.rs
+++ b/core/embed/rust/src/translations/generated/translated_string.rs
@@ -1447,6 +1447,7 @@ pub enum TranslatedString {
     reset__select_word_from_share_template = 1043,  // "Select word #{0} from\nShare #{1}"
     recovery__share_from_group_entered_template = 1044,  // "Share #{0} from Group #{1} entered."
     send__cancel_transaction = 1045,  // "Cancel transaction"
+    send__multisig_different_paths = 1046,  // "Using different paths for different XPUBs."
 }
 
 impl TranslatedString {
@@ -3199,6 +3200,7 @@ impl TranslatedString {
             (Self::reset__select_word_from_share_template, "Select word #{0} from\nShare #{1}"),
             (Self::recovery__share_from_group_entered_template, "Share #{0} from Group #{1} entered."),
             (Self::send__cancel_transaction, "Cancel transaction"),
+            (Self::send__multisig_different_paths, "Using different paths for different XPUBs."),
     ];
 
     #[cfg(feature = "micropython")]
@@ -4269,6 +4271,7 @@ impl TranslatedString {
         (Qstr::MP_QSTR_send__incl_transaction_fee, Self::send__incl_transaction_fee),
         (Qstr::MP_QSTR_send__including_fee, Self::send__including_fee),
         (Qstr::MP_QSTR_send__maximum_fee, Self::send__maximum_fee),
+        (Qstr::MP_QSTR_send__multisig_different_paths, Self::send__multisig_different_paths),
         (Qstr::MP_QSTR_send__receiving_to_multisig, Self::send__receiving_to_multisig),
         (Qstr::MP_QSTR_send__send_from, Self::send__send_from),
         (Qstr::MP_QSTR_send__send_in_the_app, Self::send__send_in_the_app),

--- a/core/embed/rust/src/translations/generated/translated_string.rs
+++ b/core/embed/rust/src/translations/generated/translated_string.rs
@@ -1446,6 +1446,7 @@ pub enum TranslatedString {
     reset__check_share_backup_template = 1042,  // "Let's do a quick check of Share #{0}."
     reset__select_word_from_share_template = 1043,  // "Select word #{0} from\nShare #{1}"
     recovery__share_from_group_entered_template = 1044,  // "Share #{0} from Group #{1} entered."
+    send__cancel_transaction = 1045,  // "Cancel transaction"
 }
 
 impl TranslatedString {
@@ -3197,6 +3198,7 @@ impl TranslatedString {
             (Self::reset__check_share_backup_template, "Let's do a quick check of Share #{0}."),
             (Self::reset__select_word_from_share_template, "Select word #{0} from\nShare #{1}"),
             (Self::recovery__share_from_group_entered_template, "Share #{0} from Group #{1} entered."),
+            (Self::send__cancel_transaction, "Cancel transaction"),
     ];
 
     #[cfg(feature = "micropython")]
@@ -4261,6 +4263,7 @@ impl TranslatedString {
         (Qstr::MP_QSTR_sd_card__wanna_format, Self::sd_card__wanna_format),
         (Qstr::MP_QSTR_sd_card__wrong_sd_card, Self::sd_card__wrong_sd_card),
         (Qstr::MP_QSTR_send__cancel_sign, Self::send__cancel_sign),
+        (Qstr::MP_QSTR_send__cancel_transaction, Self::send__cancel_transaction),
         (Qstr::MP_QSTR_send__confirm_sending, Self::send__confirm_sending),
         (Qstr::MP_QSTR_send__from_multiple_accounts, Self::send__from_multiple_accounts),
         (Qstr::MP_QSTR_send__incl_transaction_fee, Self::send__incl_transaction_fee),

--- a/core/embed/rust/src/ui/layout_eckhart/flow/confirm_output.rs
+++ b/core/embed/rust/src/ui/layout_eckhart/flow/confirm_output.rs
@@ -345,7 +345,7 @@ pub fn new_confirm_output(
                 .into_paragraphs()
                 .with_placement(LinearPlacement::vertical()),
         )
-        .with_header(Header::new(TR::words__amount.into()).with_menu_button())
+        .with_header(Header::new(TR::words__send.into()).with_menu_button())
         .with_action_bar(ActionBar::new_double(
             Button::with_icon(theme::ICON_CHEVRON_UP),
             Button::with_text(TR::buttons__confirm.into()).styled(theme::button_confirm()),

--- a/core/embed/rust/src/ui/layout_eckhart/ui_firmware.rs
+++ b/core/embed/rust/src/ui/layout_eckhart/ui_firmware.rs
@@ -1350,11 +1350,12 @@ impl FirmwareUI for UIEckhart {
         danger: bool,
     ) -> Result<Gc<LayoutObj>, Error> {
         let paragraphs = ParagraphVecShort::from_iter([
-            Paragraph::new(&theme::TEXT_SMALL, description),
+            Paragraph::new(&theme::TEXT_REGULAR, description),
             Paragraph::new(&theme::TEXT_REGULAR, value),
         ])
         .into_paragraphs()
-        .with_placement(LinearPlacement::vertical());
+        .with_placement(LinearPlacement::vertical())
+        .with_spacing(theme::TEXT_VERTICAL_SPACING);
 
         let (color, style) = if danger {
             (theme::ORANGE, theme::label_title_danger())
@@ -1367,7 +1368,7 @@ impl FirmwareUI for UIEckhart {
             .with_text_style(style);
         let action_bar = if allow_cancel {
             ActionBar::new_double(
-                Button::with_icon(theme::ICON_CROSS).styled(theme::button_cancel()),
+                Button::with_icon(theme::ICON_CROSS),
                 Button::with_single_line_text(button),
             )
         } else {

--- a/core/mocks/trezortranslate_keys.pyi
+++ b/core/mocks/trezortranslate_keys.pyi
@@ -767,6 +767,7 @@ class TR:
     send__incl_transaction_fee: str = "incl. Transaction fee"
     send__including_fee: str = "Including fee:"
     send__maximum_fee: str = "Maximum fee"
+    send__multisig_different_paths: str = "Using different paths for different XPUBs."
     send__receiving_to_multisig: str = "Receiving to a multisig address."
     send__send_from: str = "Send from"
     send__send_in_the_app: str = "After signing, send the transaction in the app."

--- a/core/mocks/trezortranslate_keys.pyi
+++ b/core/mocks/trezortranslate_keys.pyi
@@ -761,6 +761,7 @@ class TR:
     sd_card__wanna_format: str = "Do you really want to format the SD card?"
     sd_card__wrong_sd_card: str = "Wrong SD card."
     send__cancel_sign: str = "Cancel sign"
+    send__cancel_transaction: str = "Cancel transaction"
     send__confirm_sending: str = "Sending amount"
     send__from_multiple_accounts: str = "Sending from multiple accounts."
     send__incl_transaction_fee: str = "incl. Transaction fee"

--- a/core/src/apps/bitcoin/sign_tx/layout.py
+++ b/core/src/apps/bitcoin/sign_tx/layout.py
@@ -290,13 +290,7 @@ async def confirm_nondefault_locktime(lock_time: int, lock_time_disabled: bool) 
     from trezor.strings import format_timestamp
 
     if lock_time_disabled:
-        await layouts.show_warning(
-            "nondefault_locktime",
-            TR.bitcoin__locktime_no_effect,
-            TR.words__continue_anyway_question,
-            button=TR.buttons__continue,
-            br_code=ButtonRequestType.SignTx,
-        )
+        await layouts.lock_time_disabled_warning()
     else:
         if lock_time < _LOCKTIME_TIMESTAMP_MIN_VALUE:
             text = TR.bitcoin__locktime_set_to_blockheight

--- a/core/src/apps/bitcoin/sign_tx/layout.py
+++ b/core/src/apps/bitcoin/sign_tx/layout.py
@@ -283,13 +283,7 @@ async def confirm_unverified_external_input() -> None:
 
 
 async def confirm_multiple_accounts() -> None:
-    await layouts.show_warning(
-        "sending_from_multiple_accounts",
-        TR.send__from_multiple_accounts,
-        TR.words__continue_anyway_question,
-        button=TR.buttons__continue,
-        br_code=ButtonRequestType.SignTx,
-    )
+    await layouts.confirm_multiple_accounts_warning()
 
 
 async def confirm_nondefault_locktime(lock_time: int, lock_time_disabled: bool) -> None:

--- a/core/src/trezor/ui/layouts/bolt/__init__.py
+++ b/core/src/trezor/ui/layouts/bolt/__init__.py
@@ -180,6 +180,16 @@ def confirm_multisig_different_paths_warning() -> Awaitable[None]:
     )
 
 
+def confirm_multiple_accounts_warning() -> Awaitable[None]:
+    return show_warning(
+        "sending_from_multiple_accounts",
+        TR.send__from_multiple_accounts,
+        TR.words__continue_anyway_question,
+        button=TR.buttons__continue,
+        br_code=ButtonRequestType.SignTx,
+    )
+
+
 def confirm_homescreen(image: bytes) -> Awaitable[None]:
     return raise_if_not_confirmed(
         trezorui_api.confirm_homescreen(

--- a/core/src/trezor/ui/layouts/bolt/__init__.py
+++ b/core/src/trezor/ui/layouts/bolt/__init__.py
@@ -175,7 +175,7 @@ def confirm_multisig_warning() -> Awaitable[None]:
 def confirm_multisig_different_paths_warning() -> Awaitable[None]:
     return show_warning(
         "warning_multisig_different_paths",
-        "Using different paths for different XPUBs.",
+        TR.send__multisig_different_paths,
         TR.words__continue_anyway_question,
     )
 
@@ -184,6 +184,16 @@ def confirm_multiple_accounts_warning() -> Awaitable[None]:
     return show_warning(
         "sending_from_multiple_accounts",
         TR.send__from_multiple_accounts,
+        TR.words__continue_anyway_question,
+        button=TR.buttons__continue,
+        br_code=ButtonRequestType.SignTx,
+    )
+
+
+def lock_time_disabled_warning() -> Awaitable[None]:
+    return show_warning(
+        "nondefault_locktime",
+        TR.bitcoin__locktime_no_effect,
         TR.words__continue_anyway_question,
         button=TR.buttons__continue,
         br_code=ButtonRequestType.SignTx,

--- a/core/src/trezor/ui/layouts/caesar/__init__.py
+++ b/core/src/trezor/ui/layouts/caesar/__init__.py
@@ -192,7 +192,7 @@ def confirm_multisig_warning() -> Awaitable[ui.UiResult]:
 def confirm_multisig_different_paths_warning() -> Awaitable[ui.UiResult]:
     return show_warning(
         "warning_multisig_different_paths",
-        "Using different paths for different XPUBs.",
+        TR.send__multisig_different_paths,
         TR.words__continue_anyway_question,
     )
 
@@ -201,6 +201,16 @@ def confirm_multiple_accounts_warning() -> Awaitable[ui.UiResult]:
     return show_warning(
         "sending_from_multiple_accounts",
         TR.send__from_multiple_accounts,
+        TR.words__continue_anyway_question,
+        button=TR.buttons__continue,
+        br_code=ButtonRequestType.SignTx,
+    )
+
+
+def lock_time_disabled_warning() -> Awaitable[ui.UiResult]:
+    return show_warning(
+        "nondefault_locktime",
+        TR.bitcoin__locktime_no_effect,
         TR.words__continue_anyway_question,
         button=TR.buttons__continue,
         br_code=ButtonRequestType.SignTx,

--- a/core/src/trezor/ui/layouts/caesar/__init__.py
+++ b/core/src/trezor/ui/layouts/caesar/__init__.py
@@ -197,6 +197,16 @@ def confirm_multisig_different_paths_warning() -> Awaitable[ui.UiResult]:
     )
 
 
+def confirm_multiple_accounts_warning() -> Awaitable[ui.UiResult]:
+    return show_warning(
+        "sending_from_multiple_accounts",
+        TR.send__from_multiple_accounts,
+        TR.words__continue_anyway_question,
+        button=TR.buttons__continue,
+        br_code=ButtonRequestType.SignTx,
+    )
+
+
 def confirm_homescreen(image: bytes) -> Awaitable[None]:
     return raise_if_not_confirmed(
         trezorui_api.confirm_homescreen(

--- a/core/src/trezor/ui/layouts/delizia/__init__.py
+++ b/core/src/trezor/ui/layouts/delizia/__init__.py
@@ -158,7 +158,7 @@ def confirm_multisig_different_paths_warning() -> Awaitable[None]:
     return raise_if_not_confirmed(
         trezorui_api.show_danger(
             title=f"{TR.words__important}!",
-            description="Using different paths for different XPUBs.",
+            description=TR.send__multisig_different_paths,
         ),
         "warning_multisig_different_paths",
         br_code=ButtonRequestType.Warning,
@@ -170,6 +170,16 @@ def confirm_multiple_accounts_warning() -> Awaitable[None]:
         "sending_from_multiple_accounts",
         TR.send__from_multiple_accounts,
         verb_cancel=TR.send__cancel_transaction,
+        br_code=ButtonRequestType.SignTx,
+    )
+
+
+def lock_time_disabled_warning() -> Awaitable[None]:
+    return show_warning(
+        "nondefault_locktime",
+        TR.bitcoin__locktime_no_effect,
+        TR.words__continue_anyway_question,
+        button=TR.buttons__continue,
         br_code=ButtonRequestType.SignTx,
     )
 

--- a/core/src/trezor/ui/layouts/delizia/__init__.py
+++ b/core/src/trezor/ui/layouts/delizia/__init__.py
@@ -165,6 +165,15 @@ def confirm_multisig_different_paths_warning() -> Awaitable[None]:
     )
 
 
+def confirm_multiple_accounts_warning() -> Awaitable[None]:
+    return show_danger(
+        "sending_from_multiple_accounts",
+        TR.send__from_multiple_accounts,
+        verb_cancel=TR.send__cancel_transaction,
+        br_code=ButtonRequestType.SignTx,
+    )
+
+
 def confirm_homescreen(
     image: bytes,
 ) -> Awaitable[None]:

--- a/core/src/trezor/ui/layouts/eckhart/__init__.py
+++ b/core/src/trezor/ui/layouts/eckhart/__init__.py
@@ -449,7 +449,7 @@ async def confirm_output(
 
     await raise_if_not_confirmed(
         trezorui_api.flow_confirm_output(
-            title=TR.words__address,
+            title=TR.words__send,
             subtitle=title,
             message=address,
             extra=None,
@@ -654,7 +654,7 @@ def confirm_amount(
     br_name: str = "confirm_amount",
     br_code: ButtonRequestType = BR_CODE_OTHER,
 ) -> Awaitable[None]:
-    description = description or f"{TR.words__amount}:"  # def_arg
+    description = description or f"{TR.words__send}:"  # def_arg
     return confirm_value(
         title,
         amount,

--- a/core/src/trezor/ui/layouts/eckhart/__init__.py
+++ b/core/src/trezor/ui/layouts/eckhart/__init__.py
@@ -174,6 +174,16 @@ def confirm_multisig_different_paths_warning() -> Awaitable[None]:
     )
 
 
+def confirm_multiple_accounts_warning() -> Awaitable[None]:
+    return show_danger(
+        "sending_from_multiple_accounts",
+        TR.send__from_multiple_accounts,
+        title=TR.words__important,
+        verb_cancel=TR.send__cancel_transaction,
+        br_code=ButtonRequestType.SignTx,
+    )
+
+
 def confirm_homescreen(
     image: bytes,
 ) -> Awaitable[None]:

--- a/core/src/trezor/ui/layouts/eckhart/__init__.py
+++ b/core/src/trezor/ui/layouts/eckhart/__init__.py
@@ -163,14 +163,13 @@ def confirm_multisig_warning() -> Awaitable[None]:
 
 
 def confirm_multisig_different_paths_warning() -> Awaitable[None]:
-    return raise_if_not_confirmed(
-        trezorui_api.show_danger(
-            title=TR.words__pay_attention,
-            description="Using different paths for different XPUBs.",
-            menu_title=TR.words__receive,
-        ),
+    return show_danger(
         "warning_multisig_different_paths",
+        content=TR.send__multisig_different_paths,
+        title=TR.words__important,
+        menu_title=TR.words__receive,
         br_code=ButtonRequestType.Warning,
+        verb_cancel=TR.words__cancel_and_exit,
     )
 
 
@@ -180,6 +179,14 @@ def confirm_multiple_accounts_warning() -> Awaitable[None]:
         TR.send__from_multiple_accounts,
         title=TR.words__important,
         verb_cancel=TR.send__cancel_transaction,
+        br_code=ButtonRequestType.SignTx,
+    )
+
+
+def lock_time_disabled_warning() -> Awaitable[None]:
+    return show_warning(
+        "nondefault_locktime",
+        TR.bitcoin__locktime_no_effect,
         br_code=ButtonRequestType.SignTx,
     )
 
@@ -366,12 +373,13 @@ def show_warning(
     button: str | None = None,
     br_code: ButtonRequestType = ButtonRequestType.Warning,
 ) -> Awaitable[None]:
-    button = button or TR.buttons__continue  # def_arg
+    button = button or TR.words__continue_anyway  # def_arg
     return raise_if_not_confirmed(
         trezorui_api.show_warning(
             title=TR.words__important,
-            value=content,
-            button=subheader or TR.words__continue_anyway_question,
+            button=button,
+            description=content,
+            value=subheader or "",
             danger=True,
         ),
         br_name,

--- a/core/translations/en.json
+++ b/core/translations/en.json
@@ -976,6 +976,7 @@
     "send__maximum_fee": "Maximum fee",
     "send__receiving_to_multisig": "Receiving to a multisig address.",
     "send__send_from": "Send from",
+    "send__cancel_transaction": "Cancel transaction",
     "send__sign_transaction": "Sign transaction",
     "send__send_in_the_app": "After signing, send the transaction in the app.",
     "send__title_confirm_sending": "Confirm sending",

--- a/core/translations/en.json
+++ b/core/translations/en.json
@@ -975,6 +975,7 @@
     "send__including_fee": "Including fee:",
     "send__maximum_fee": "Maximum fee",
     "send__receiving_to_multisig": "Receiving to a multisig address.",
+    "send__multisig_different_paths": "Using different paths for different XPUBs.",
     "send__send_from": "Send from",
     "send__cancel_transaction": "Cancel transaction",
     "send__sign_transaction": "Sign transaction",

--- a/core/translations/order.json
+++ b/core/translations/order.json
@@ -1044,5 +1044,6 @@
   "1042": "reset__check_share_backup_template",
   "1043": "reset__select_word_from_share_template",
   "1044": "recovery__share_from_group_entered_template",
-  "1045": "send__cancel_transaction"
+  "1045": "send__cancel_transaction",
+  "1046": "send__multisig_different_paths"
 }

--- a/core/translations/order.json
+++ b/core/translations/order.json
@@ -1043,5 +1043,6 @@
   "1041": "instructions__shares_start_with_x_template",
   "1042": "reset__check_share_backup_template",
   "1043": "reset__select_word_from_share_template",
-  "1044": "recovery__share_from_group_entered_template"
+  "1044": "recovery__share_from_group_entered_template",
+  "1045": "send__cancel_transaction"
 }

--- a/core/translations/signatures.json
+++ b/core/translations/signatures.json
@@ -1,8 +1,8 @@
 {
   "current": {
-    "merkle_root": "4a06e39dde3af691ccef119898d3124fb596e384b777a55044f29d27a7ebbd8e",
-    "datetime": "2025-06-23T10:46:39.805001+00:00",
-    "commit": "f8327ed2c85209eafbe0c73eeea8861bf1cb57d7"
+    "merkle_root": "9bf21982ee758961ef15e5436ea363d19b02d5d6760f4916e4090ac44c3140f4",
+    "datetime": "2025-06-23T10:48:03.422303+00:00",
+    "commit": "5bc936133a6ed97c2cd7c448facffc86847ae25c"
   },
   "history": [
     {

--- a/core/translations/signatures.json
+++ b/core/translations/signatures.json
@@ -1,8 +1,8 @@
 {
   "current": {
-    "merkle_root": "c17219dfef87f023e53dd6470f633d38a8f8572466f987e0efe4536652b0d805",
-    "datetime": "2025-06-23T08:18:59.627189+00:00",
-    "commit": "1312054ba96c9037aa99cf48709d9cdafdeb708c"
+    "merkle_root": "4a06e39dde3af691ccef119898d3124fb596e384b777a55044f29d27a7ebbd8e",
+    "datetime": "2025-06-23T10:46:39.805001+00:00",
+    "commit": "f8327ed2c85209eafbe0c73eeea8861bf1cb57d7"
   },
   "history": [
     {

--- a/tests/device_tests/bitcoin/test_signtx_invalid_path.py
+++ b/tests/device_tests/bitcoin/test_signtx_invalid_path.py
@@ -179,8 +179,9 @@ def test_attack_path_segwit(client: Client):
         return msg
 
     with client:
-        IF = InputFlowConfirmAllWarnings(client)
-        client.set_input_flow(IF.get())
+        if is_core(client):
+            IF = InputFlowConfirmAllWarnings(client)
+            client.set_input_flow(IF.get())
         client.set_filter(messages.TxAck, attack_processor)
         with pytest.raises(TrezorFailure):
             btc.sign_tx(

--- a/tests/device_tests/bitcoin/test_signtx_invalid_path.py
+++ b/tests/device_tests/bitcoin/test_signtx_invalid_path.py
@@ -179,6 +179,8 @@ def test_attack_path_segwit(client: Client):
         return msg
 
     with client:
+        IF = InputFlowConfirmAllWarnings(client)
+        client.set_input_flow(IF.get())
         client.set_filter(messages.TxAck, attack_processor)
         with pytest.raises(TrezorFailure):
             btc.sign_tx(

--- a/tests/device_tests/bitcoin/test_signtx_mixed_inputs.py
+++ b/tests/device_tests/bitcoin/test_signtx_mixed_inputs.py
@@ -18,6 +18,7 @@ from trezorlib import btc, messages
 from trezorlib.debuglink import TrezorClientDebugLink as Client
 from trezorlib.tools import parse_path
 
+from ...common import is_core
 from ...input_flows import InputFlowConfirmAllWarnings
 from ...tx_cache import TxCache
 from .signtx import assert_tx_matches
@@ -60,8 +61,9 @@ def test_non_segwit_segwit_inputs(client: Client):
     )
 
     with client:
-        IF = InputFlowConfirmAllWarnings(client)
-        client.set_input_flow(IF.get())
+        if is_core(client):
+            IF = InputFlowConfirmAllWarnings(client)
+            client.set_input_flow(IF.get())
         signatures, serialized_tx = btc.sign_tx(
             client, "Testnet", [inp1, inp2], [out1], prev_txes=TX_API
         )
@@ -98,8 +100,9 @@ def test_segwit_non_segwit_inputs(client: Client):
     )
 
     with client:
-        IF = InputFlowConfirmAllWarnings(client)
-        client.set_input_flow(IF.get())
+        if is_core(client):
+            IF = InputFlowConfirmAllWarnings(client)
+            client.set_input_flow(IF.get())
         signatures, serialized_tx = btc.sign_tx(
             client, "Testnet", [inp1, inp2], [out1], prev_txes=TX_API
         )
@@ -144,8 +147,9 @@ def test_segwit_non_segwit_segwit_inputs(client: Client):
     )
 
     with client:
-        IF = InputFlowConfirmAllWarnings(client)
-        client.set_input_flow(IF.get())
+        if is_core(client):
+            IF = InputFlowConfirmAllWarnings(client)
+            client.set_input_flow(IF.get())
         signatures, serialized_tx = btc.sign_tx(
             client, "Testnet", [inp1, inp2, inp3], [out1], prev_txes=TX_API
         )
@@ -188,8 +192,9 @@ def test_non_segwit_segwit_non_segwit_inputs(client: Client):
     )
 
     with client:
-        IF = InputFlowConfirmAllWarnings(client)
-        client.set_input_flow(IF.get())
+        if is_core(client):
+            IF = InputFlowConfirmAllWarnings(client)
+            client.set_input_flow(IF.get())
         signatures, serialized_tx = btc.sign_tx(
             client, "Testnet", [inp1, inp2, inp3], [out1], prev_txes=TX_API
         )

--- a/tests/device_tests/bitcoin/test_signtx_mixed_inputs.py
+++ b/tests/device_tests/bitcoin/test_signtx_mixed_inputs.py
@@ -18,6 +18,7 @@ from trezorlib import btc, messages
 from trezorlib.debuglink import TrezorClientDebugLink as Client
 from trezorlib.tools import parse_path
 
+from ...input_flows import InputFlowConfirmAllWarnings
 from ...tx_cache import TxCache
 from .signtx import assert_tx_matches
 
@@ -59,6 +60,8 @@ def test_non_segwit_segwit_inputs(client: Client):
     )
 
     with client:
+        IF = InputFlowConfirmAllWarnings(client)
+        client.set_input_flow(IF.get())
         signatures, serialized_tx = btc.sign_tx(
             client, "Testnet", [inp1, inp2], [out1], prev_txes=TX_API
         )
@@ -95,6 +98,8 @@ def test_segwit_non_segwit_inputs(client: Client):
     )
 
     with client:
+        IF = InputFlowConfirmAllWarnings(client)
+        client.set_input_flow(IF.get())
         signatures, serialized_tx = btc.sign_tx(
             client, "Testnet", [inp1, inp2], [out1], prev_txes=TX_API
         )
@@ -139,6 +144,8 @@ def test_segwit_non_segwit_segwit_inputs(client: Client):
     )
 
     with client:
+        IF = InputFlowConfirmAllWarnings(client)
+        client.set_input_flow(IF.get())
         signatures, serialized_tx = btc.sign_tx(
             client, "Testnet", [inp1, inp2, inp3], [out1], prev_txes=TX_API
         )
@@ -181,6 +188,8 @@ def test_non_segwit_segwit_non_segwit_inputs(client: Client):
     )
 
     with client:
+        IF = InputFlowConfirmAllWarnings(client)
+        client.set_input_flow(IF.get())
         signatures, serialized_tx = btc.sign_tx(
             client, "Testnet", [inp1, inp2, inp3], [out1], prev_txes=TX_API
         )

--- a/tests/device_tests/bitcoin/test_signtx_segwit.py
+++ b/tests/device_tests/bitcoin/test_signtx_segwit.py
@@ -22,6 +22,7 @@ from trezorlib.exceptions import TrezorFailure
 from trezorlib.tools import H_, parse_path
 
 from ...common import is_core
+from ...input_flows import InputFlowConfirmAllWarnings
 from ...tx_cache import TxCache
 from .signtx import (
     assert_tx_matches,
@@ -422,6 +423,8 @@ def test_attack_mixed_inputs(client: Client):
         expected_responses.insert(-2, request_input(0))
 
     with client:
+        IF = InputFlowConfirmAllWarnings(client)
+        client.set_input_flow(IF.get())
         # Sign unmodified transaction.
         # "Fee over threshold" warning is displayed - fee is the whole TRUE_AMOUNT
         client.set_expected_responses(expected_responses)
@@ -447,6 +450,8 @@ def test_attack_mixed_inputs(client: Client):
         )
 
     with pytest.raises(TrezorFailure) as e, client:
+        IF = InputFlowConfirmAllWarnings(client)
+        client.set_input_flow(IF.get())
         client.set_expected_responses(expected_responses)
         btc.sign_tx(
             client,

--- a/tests/device_tests/bitcoin/test_signtx_segwit.py
+++ b/tests/device_tests/bitcoin/test_signtx_segwit.py
@@ -423,8 +423,9 @@ def test_attack_mixed_inputs(client: Client):
         expected_responses.insert(-2, request_input(0))
 
     with client:
-        IF = InputFlowConfirmAllWarnings(client)
-        client.set_input_flow(IF.get())
+        if is_core(client):
+            IF = InputFlowConfirmAllWarnings(client)
+            client.set_input_flow(IF.get())
         # Sign unmodified transaction.
         # "Fee over threshold" warning is displayed - fee is the whole TRUE_AMOUNT
         client.set_expected_responses(expected_responses)
@@ -450,8 +451,9 @@ def test_attack_mixed_inputs(client: Client):
         )
 
     with pytest.raises(TrezorFailure) as e, client:
-        IF = InputFlowConfirmAllWarnings(client)
-        client.set_input_flow(IF.get())
+        if is_core(client):
+            IF = InputFlowConfirmAllWarnings(client)
+            client.set_input_flow(IF.get())
         client.set_expected_responses(expected_responses)
         btc.sign_tx(
             client,

--- a/tests/device_tests/bitcoin/test_signtx_segwit_native.py
+++ b/tests/device_tests/bitcoin/test_signtx_segwit_native.py
@@ -345,6 +345,8 @@ def test_send_both(client: Client):
     )
 
     with client:
+        IF = InputFlowConfirmAllWarnings(client)
+        client.set_input_flow(IF.get())
         client.set_expected_responses(
             [
                 request_input(0),

--- a/tests/device_tests/bitcoin/test_signtx_segwit_native.py
+++ b/tests/device_tests/bitcoin/test_signtx_segwit_native.py
@@ -345,8 +345,9 @@ def test_send_both(client: Client):
     )
 
     with client:
-        IF = InputFlowConfirmAllWarnings(client)
-        client.set_input_flow(IF.get())
+        if is_core(client):
+            IF = InputFlowConfirmAllWarnings(client)
+            client.set_input_flow(IF.get())
         client.set_expected_responses(
             [
                 request_input(0),

--- a/tests/device_tests/bitcoin/test_signtx_taproot.py
+++ b/tests/device_tests/bitcoin/test_signtx_taproot.py
@@ -224,8 +224,9 @@ def test_send_mixed(client: Client):
     )
 
     with client:
-        IF = InputFlowConfirmAllWarnings(client)
-        client.set_input_flow(IF.get())
+        if is_core(client):
+            IF = InputFlowConfirmAllWarnings(client)
+            client.set_input_flow(IF.get())
         client.set_expected_responses(
             [
                 # process inputs
@@ -358,8 +359,9 @@ def test_attack_script_type(client: Client):
         return msg
 
     with client:
-        IF = InputFlowConfirmAllWarnings(client)
-        client.set_input_flow(IF.get())
+        if is_core(client):
+            IF = InputFlowConfirmAllWarnings(client)
+            client.set_input_flow(IF.get())
         client.set_filter(messages.TxAck, attack_processor)
         client.set_expected_responses(
             [

--- a/tests/device_tests/bitcoin/test_signtx_taproot.py
+++ b/tests/device_tests/bitcoin/test_signtx_taproot.py
@@ -22,6 +22,7 @@ from trezorlib.exceptions import TrezorFailure
 from trezorlib.tools import H_, parse_path
 
 from ...common import is_core
+from ...input_flows import InputFlowConfirmAllWarnings
 from ...tx_cache import TxCache
 from .signtx import (
     assert_tx_matches,
@@ -223,6 +224,8 @@ def test_send_mixed(client: Client):
     )
 
     with client:
+        IF = InputFlowConfirmAllWarnings(client)
+        client.set_input_flow(IF.get())
         client.set_expected_responses(
             [
                 # process inputs
@@ -355,6 +358,8 @@ def test_attack_script_type(client: Client):
         return msg
 
     with client:
+        IF = InputFlowConfirmAllWarnings(client)
+        client.set_input_flow(IF.get())
         client.set_filter(messages.TxAck, attack_processor)
         client.set_expected_responses(
             [

--- a/tests/input_flows.py
+++ b/tests/input_flows.py
@@ -1171,20 +1171,20 @@ def sign_tx_go_to_info_eckhart(
         yield
         client.debug.read_layout()
         client.debug.click(client.debug.screen_buttons.menu())
-        client.debug.synchronize_at("VerticalMenuScreen")
+        client.debug.synchronize_at("VerticalMenu")
         client.debug.click(client.debug.screen_buttons.vertical_menu_items()[1])
 
     yield  # confirm transaction
     client.debug.read_layout()
     client.debug.click(client.debug.screen_buttons.menu())
-    client.debug.synchronize_at("VerticalMenuScreen")
+    client.debug.synchronize_at("VerticalMenu")
     client.debug.click(client.debug.screen_buttons.vertical_menu_items()[0])
 
     layout = client.debug.read_layout()
     content = layout.text_content()
 
     client.debug.click(client.debug.screen_buttons.menu())
-    client.debug.synchronize_at("VerticalMenuScreen")
+    client.debug.synchronize_at("VerticalMenu")
     client.debug.click(client.debug.screen_buttons.vertical_menu_items()[1])
 
     layout = client.debug.read_layout()

--- a/tests/input_flows.py
+++ b/tests/input_flows.py
@@ -1130,7 +1130,9 @@ def sign_tx_go_to_info_delizia(
     if multi_account:
         yield
         client.debug.read_layout()
-        client.debug.swipe_up()
+        client.debug.click(client.debug.screen_buttons.menu())
+        client.debug.synchronize_at("VerticalMenu")
+        client.debug.click(client.debug.screen_buttons.vertical_menu_items()[1])
 
     yield  # confirm transaction
     client.debug.read_layout()
@@ -1168,7 +1170,9 @@ def sign_tx_go_to_info_eckhart(
     if multi_account:
         yield
         client.debug.read_layout()
-        client.debug.press_yes()
+        client.debug.click(client.debug.screen_buttons.menu())
+        client.debug.synchronize_at("VerticalMenuScreen")
+        client.debug.click(client.debug.screen_buttons.vertical_menu_items()[1])
 
     yield  # confirm transaction
     client.debug.read_layout()
@@ -2939,6 +2943,7 @@ class InputFlowConfirmAllWarnings(InputFlowBase):
             hi_prio = (
                 TR.words__cancel_and_exit,
                 TR.send__cancel_sign,
+                TR.send__cancel_transaction,
             )
             if any(needle.lower() in text for needle in hi_prio):
                 self.debug.click(self.debug.screen_buttons.menu())
@@ -2967,6 +2972,7 @@ class InputFlowConfirmAllWarnings(InputFlowBase):
             hi_prio = (
                 TR.words__cancel_and_exit,
                 TR.send__cancel_sign,
+                TR.send__cancel_transaction,
             )
             if any(needle.lower() in text for needle in hi_prio):
                 self.debug.click(self.debug.screen_buttons.menu())


### PR DESCRIPTION
## Summary

This PR includes the following changes:

- Promotes the **multiple accounts warning** to a **cancel-type** warning for **Delizia** and **Eckhart** UIs.
- Fixes the **design** of the **Eckhart** `warning` `FirmwareUI` function.
- Fixes the **title** in the **Eckhart**  `confirm_output` `FirmwareUI` function.

---

## Technical Details

- Changed `confirm_output` titles from **"Amount"** and **"Address"** to **"Send"**, per [Figma](https://www.figma.com/design/Dkl7W5PLqpr3TnXJ5hbnfd/--Future-Prod---Safe-7?node-id=6374-1612&t=yfEc0J1asekmLh0U-0) design.
- Introduced new per-layout `confirm_multiple_accounts_warning` function:
  - For **[Delizia](https://www.figma.com/design/n43caWJFGJlT167AQcxruu/--Prod---Safe-5?node-id=2033-935&t=xcsxOxPmj95GqOyf-0)** and **[Eckhart](https://www.figma.com/design/Dkl7W5PLqpr3TnXJ5hbnfd/--Future-Prod---Safe-7?node-id=6374-4957&t=yfEc0J1asekmLh0U-0)**, this warning is now treated as **danger** instead of a generic warning in `FirmwareUI`.
- Updated Delizia and Eckhart tests that include the above warning to use `InputFlowConfirmAllWarnings` instead of the default flow.
- Added a new translation string for `confirm_multisig_different_paths_warning`.
- Updated **Eckhart** `FirmwareUI` `warning` to use the `subheader` parameter directly instead of placing it in the button (as done in Delizia).
  - Updated related warning functions to reflect this change.
- Created a new per-layout `lock_time_disabled_warning` function:
  - Eckhart's [Figma](https://www.figma.com/design/Dkl7W5PLqpr3TnXJ5hbnfd/--Future-Prod---Safe-7?node-id=6374-5278&t=vtwwEE1iwSnZfe2a-0) design differed significantly and required its own implementation.
