### PR TITLE
eckhart: add close button to THP pairing dialog

### DIFF
--- a/core/embed/rust/src/ui/layout_eckhart/ui_firmware.rs
+++ b/core/embed/rust/src/ui/layout_eckhart/ui_firmware.rs
@@ -1085,9 +1085,13 @@ impl FirmwareUI for UIEckhart {
             .add_newline()
             .add_alignment(Alignment::Center)
             .add_text(code, fonts::FONT_SATOSHI_EXTRALIGHT_72);
-        let mut screen = TextScreen::new(FormattedText::new(ops)).with_header(Header::new(title));
+        let mut screen = TextScreen::new(FormattedText::new(ops));
         if button {
-            screen = screen.with_action_bar(ActionBar::new_cancel_confirm());
+            screen = screen
+                .with_header(Header::new(title))
+                .with_action_bar(ActionBar::new_cancel_confirm());
+        } else {
+            screen = screen.with_header(Header::new(title).with_close_button());
         }
         #[cfg(feature = "ble")]
         let screen = crate::ui::component::BLEHandler::new(screen, false);


### PR DESCRIPTION
Figma has "cancel from menu", which will be implemented in #TBD.

Meanwhile this adds simple close button so that we can test cancelling the pairing.

<!--
For core developers:
- Assign yourself to the PR.
- Set the priority to match the original issue.
- Add the PR to the current sprint.
- If it's a draft PR, mark it as "In Progress."
- If it's a final PR, mark it as "Needs Review."

For external contributors:
- Please open an issue before submitting a PR so we can discuss whether we want to proceed with it.
-->
