### PR TITLE
Eckhart UI: low hanging bootloader updates

### DIFF
--- a/core/embed/rust/src/ui/layout_eckhart/bootloader/bld_menu.rs
+++ b/core/embed/rust/src/ui/layout_eckhart/bootloader/bld_menu.rs
@@ -21,6 +21,8 @@ pub enum BldMenuSelectionMsg {
 }
 
 impl BldMenu {
+    const MENU_ITEM_CONTENT_PADDING: i16 = 24;
+
     pub fn new(buttons: VerticalMenuButtons) -> Self {
         Self {
             bounds: Rect::zero(),
@@ -71,12 +73,10 @@ impl Component for BldMenu {
 
         let button_width = self.bounds.width();
         let mut top_left = self.bounds.top_left();
-        let padding = 28;
 
         for button in self.buttons.iter_mut() {
-            let button_height = button
-                .content_height(button_width - 2 * Button::MENU_ITEM_CONTENT_OFFSET.x)
-                + 2 * padding;
+            let button_height =
+                button.content_height(button_width) + 2 * Self::MENU_ITEM_CONTENT_PADDING;
             let button_bounds =
                 Rect::from_top_left_and_size(top_left, Offset::new(button_width, button_height));
 

--- a/core/embed/rust/src/ui/layout_eckhart/bootloader/bld_menu_screen.rs
+++ b/core/embed/rust/src/ui/layout_eckhart/bootloader/bld_menu_screen.rs
@@ -32,24 +32,24 @@ pub struct BldMenuScreen {
 
 impl BldMenuScreen {
     pub fn new() -> Self {
-        let bluetooth = Button::with_text("Bluetooth".into())
+        let bluetooth = Button::with_text("Pair new device".into())
             .styled(theme::bootloader::button_bld_menu())
             .with_text_align(Alignment::Start);
-        let reboot = Button::with_text("Reboot Trezor".into())
+        let reboot = Button::with_text("Reboot".into())
+            .styled(theme::bootloader::button_bld_menu())
+            .with_text_align(Alignment::Start);
+        let turnoff = Button::with_text("Power off".into())
             .styled(theme::bootloader::button_bld_menu())
             .with_text_align(Alignment::Start);
         let reset = Button::with_text("Factory reset".into())
-            .styled(theme::bootloader::button_bld_menu())
-            .with_text_align(Alignment::Start);
-        let turnoff = Button::with_text("Turn off Trezor".into())
-            .styled(theme::bootloader::button_bld_menu())
+            .styled(theme::bootloader::button_bld_menu_danger())
             .with_text_align(Alignment::Start);
 
         let menu = BldMenu::empty()
             .item(bluetooth)
             .item(reboot)
-            .item(reset)
-            .item(turnoff);
+            .item(turnoff)
+            .item(reset);
         Self {
             header: BldHeader::new("Bootloader".into()).with_close_button(),
             menu,
@@ -78,8 +78,8 @@ impl Component for BldMenuScreen {
             match n {
                 0 => return Some(Self::Msg::Bluetooth),
                 1 => return Some(Self::Msg::Reboot),
-                2 => return Some(Self::Msg::FactoryReset),
-                3 => return Some(Self::Msg::PowerOff),
+                2 => return Some(Self::Msg::PowerOff),
+                3 => return Some(Self::Msg::FactoryReset),
                 _ => {}
             }
         }

--- a/core/embed/rust/src/ui/layout_eckhart/component/button.rs
+++ b/core/embed/rust/src/ui/layout_eckhart/component/button.rs
@@ -288,6 +288,7 @@ impl Button {
     }
 
     pub fn content_height(&self, width: i16) -> i16 {
+        let width = width - 2 * Self::MENU_ITEM_CONTENT_OFFSET.x;
         match &self.content {
             ButtonContent::Empty => 0,
             ButtonContent::Text { text, single_line } => {

--- a/core/embed/rust/src/ui/layout_eckhart/component/error.rs
+++ b/core/embed/rust/src/ui/layout_eckhart/component/error.rs
@@ -11,9 +11,10 @@ use crate::{
 use super::super::{
     cshape::ScreenBorder,
     theme::{
-        ACTION_BAR_HEIGHT, HEADER_HEIGHT, RED, SIDE_INSETS, TEXT_NORMAL, TEXT_SMALL,
-        TEXT_SMALL_GREY, TEXT_SMALL_RED, TEXT_VERTICAL_SPACING,
+        ACTION_BAR_HEIGHT, HEADER_HEIGHT, PADDING, RED, SIDE_INSETS, TEXT_NORMAL, TEXT_SMALL,
+        TEXT_SMALL_GREY, TEXT_SMALL_GREY_EXTRA_LIGHT, TEXT_SMALL_RED, TEXT_VERTICAL_SPACING,
     },
+    WAIT_FOR_RESTART_MESSAGE,
 };
 
 /// Full-screen component showing Eckhart RSOD. To keep it minimal, this screen
@@ -23,22 +24,23 @@ pub struct ErrorScreen<'a> {
     title: Label<'a>,
     message: Label<'a>,
     footer: Label<'a>,
+    wait_for_restart: Label<'a>,
     screen_border: ScreenBorder,
 }
 
 impl<'a> ErrorScreen<'a> {
     pub fn new(title: TString<'a>, message: TString<'a>, footer: TString<'a>) -> Self {
-        let header = Label::left_aligned("Failure".into(), TEXT_SMALL_RED).vertically_centered();
         let title = Label::left_aligned(title, TEXT_NORMAL);
         let message = Label::left_aligned(message, TEXT_SMALL);
-        let footer = Label::centered(footer, TEXT_SMALL_GREY).vertically_centered();
-
+        let footer = Label::left_aligned(footer, TEXT_SMALL_GREY_EXTRA_LIGHT);
         Self {
-            header,
+            header: Label::left_aligned("Failure".into(), TEXT_SMALL_RED).vertically_centered(),
             title,
             message,
             footer,
             screen_border: ScreenBorder::new(RED),
+            wait_for_restart: Label::centered(WAIT_FOR_RESTART_MESSAGE.into(), TEXT_SMALL_GREY)
+                .vertically_centered(),
         }
     }
 }
@@ -47,10 +49,13 @@ impl<'a> Component for ErrorScreen<'a> {
     type Msg = Never;
 
     fn place(&mut self, _bounds: Rect) -> Rect {
-        let area = SCREEN.inset(SIDE_INSETS);
+        const FOOTER_AREA_HEIGHT: i16 = 52;
+        const AREA: Rect = SCREEN.inset(SIDE_INSETS);
 
-        let (header_area, area) = area.split_top(HEADER_HEIGHT);
-        let (area, footer_area) = area.split_bottom(ACTION_BAR_HEIGHT);
+        let (header_area, area) = AREA.split_top(HEADER_HEIGHT);
+        let (area, actionbar_area) = area.split_bottom(ACTION_BAR_HEIGHT);
+        let area = area.inset(Insets::bottom(PADDING));
+        let (area, footer_area) = area.split_bottom(FOOTER_AREA_HEIGHT);
 
         let title_height = self.title.text_height(area.width());
         let message_height = self.message.text_height(area.width());
@@ -63,6 +68,7 @@ impl<'a> Component for ErrorScreen<'a> {
         self.title.place(title_area);
         self.message.place(message_area);
         self.footer.place(footer_area);
+        self.wait_for_restart.place(actionbar_area);
         SCREEN
     }
 
@@ -75,6 +81,7 @@ impl<'a> Component for ErrorScreen<'a> {
         self.title.render(target);
         self.message.render(target);
         self.footer.render(target);
+        self.wait_for_restart.render(target);
         self.screen_border.render(u8::MAX, target);
     }
 }

--- a/core/embed/rust/src/ui/layout_eckhart/component/mod.rs
+++ b/core/embed/rust/src/ui/layout_eckhart/component/mod.rs
@@ -1,7 +1,9 @@
 mod button;
 mod error;
+mod update_screen;
 mod welcome_screen;
 
 pub use button::{Button, ButtonContent, ButtonMsg, ButtonStyle, ButtonStyleSheet, IconText};
 pub use error::ErrorScreen;
+pub use update_screen::UpdateScreen;
 pub use welcome_screen::WelcomeScreen;

--- a/core/embed/rust/src/ui/layout_eckhart/component/update_screen.rs
+++ b/core/embed/rust/src/ui/layout_eckhart/component/update_screen.rs
@@ -1,0 +1,67 @@
+use crate::ui::{
+    component::{Component, Event, EventCtx, Label, Never},
+    geometry::{Alignment2D, Rect},
+    shape::{self, Renderer},
+};
+
+use super::super::{constant::SCREEN, theme};
+
+pub struct UpdateScreen {
+    text_header: Label<'static>,
+    text_message: Label<'static>,
+    text_footer: Label<'static>,
+    icon_area: Rect,
+}
+
+impl UpdateScreen {
+    const UPDATE_HEADER: &'static str = "Update done";
+    const UPDATE_MESSAGE: &'static str = "Completing final steps...";
+    const UPDATE_FOOTER: &'static str = "Wait";
+
+    pub fn new() -> Self {
+        Self {
+            text_header: Label::left_aligned(Self::UPDATE_HEADER.into(), theme::TEXT_SMALL_GREY)
+                .vertically_centered(),
+            text_message: Label::left_aligned(Self::UPDATE_MESSAGE.into(), theme::TEXT_NORMAL),
+            text_footer: Label::centered(Self::UPDATE_FOOTER.into(), theme::TEXT_SMALL_GREY)
+                .vertically_centered(),
+            icon_area: Rect::zero(),
+        }
+    }
+}
+
+impl Component for UpdateScreen {
+    type Msg = Never;
+
+    fn place(&mut self, _bounds: Rect) -> Rect {
+        const ICON_RIGHT_MARGIN: i16 = 16;
+
+        let rest = SCREEN.inset(theme::SIDE_INSETS);
+        let (header_area, rest) = rest.split_top(theme::HEADER_HEIGHT);
+        let (message_area, footer_area) = rest.split_bottom(theme::ACTION_BAR_HEIGHT);
+        let icon_width_with_margin = theme::ICON_DONE.toif.width() + ICON_RIGHT_MARGIN;
+        let (icon_area, title_area) = header_area.split_left(icon_width_with_margin);
+
+        self.icon_area = icon_area;
+
+        self.text_header.place(title_area);
+        self.text_message.place(message_area);
+        self.text_footer.place(footer_area);
+
+        SCREEN
+    }
+
+    fn event(&mut self, _ctx: &mut EventCtx, _event: Event) -> Option<Self::Msg> {
+        None
+    }
+
+    fn render<'s>(&'s self, target: &mut impl Renderer<'s>) {
+        shape::ToifImage::new(self.icon_area.left_center(), theme::ICON_DONE.toif)
+            .with_fg(theme::GREY)
+            .with_align(Alignment2D::CENTER_LEFT)
+            .render(target);
+        self.text_header.render(target);
+        self.text_message.render(target);
+        self.text_footer.render(target);
+    }
+}

--- a/core/embed/rust/src/ui/layout_eckhart/firmware/share_words.rs
+++ b/core/embed/rust/src/ui/layout_eckhart/firmware/share_words.rs
@@ -296,7 +296,7 @@ impl<'a> Component for ShareWords<'a> {
             self.area.top_right(),
             Offset::new(
                 self.area.width()
-                    - theme::TEXT_NORMAL.text_font.text_width(&ordinal)
+                    - theme::TEXT_REGULAR.text_font.text_width(&ordinal)
                     - Self::ORDINAL_PADDING,
                 1,
             ),

--- a/core/embed/rust/src/ui/layout_eckhart/firmware/vertical_menu.rs
+++ b/core/embed/rust/src/ui/layout_eckhart/firmware/vertical_menu.rs
@@ -300,9 +300,8 @@ impl<T: MenuItems> Component for VerticalMenu<T> {
 
         // Place each button (might overflow the menu bounds)
         for button in self.buttons.iter_mut() {
-            let button_height = button
-                .content_height(button_width - 2 * Button::MENU_ITEM_CONTENT_OFFSET.x)
-                + 2 * Self::MENU_ITEM_CONTENT_PADDING;
+            let button_height =
+                button.content_height(button_width) + 2 * Self::MENU_ITEM_CONTENT_PADDING;
             let button_bounds =
                 Rect::from_top_left_and_size(top_left, Offset::new(button_width, button_height));
 

--- a/core/embed/rust/src/ui/layout_eckhart/flow/request_passphrase.rs
+++ b/core/embed/rust/src/ui/layout_eckhart/flow/request_passphrase.rs
@@ -61,7 +61,7 @@ impl FlowController for RequestPassphrase {
 pub fn new_request_passphrase() -> Result<SwipeFlow, error::Error> {
     let content_confirm_empty = TextScreen::new(
         Paragraph::new(
-            &theme::TEXT_NORMAL,
+            &theme::TEXT_REGULAR,
             TR::passphrase__continue_with_empty_passphrase,
         )
         .into_paragraphs()

--- a/core/embed/rust/src/ui/layout_eckhart/mod.rs
+++ b/core/embed/rust/src/ui/layout_eckhart/mod.rs
@@ -35,7 +35,9 @@ pub mod ui_firmware;
 mod prodtest;
 
 use crate::ui::layout::simplified::show;
-use component::{ErrorScreen, WelcomeScreen};
+use component::{ErrorScreen, UpdateScreen, WelcomeScreen};
+
+pub const WAIT_FOR_RESTART_MESSAGE: &str = "Wait for device restart";
 
 pub struct UIEckhart;
 
@@ -93,12 +95,8 @@ impl CommonUI for UIEckhart {
     }
 
     fn screen_update() {
-        let mut frame = ErrorScreen::new(
-            "Update".into(),
-            "Finishing firmware update".into(),
-            "Do not turn off your Trezor".into(),
-        );
-        show(&mut frame, true);
+        let mut screen = UpdateScreen::new();
+        show(&mut screen, true);
     }
 
     #[cfg(feature = "ui_debug_overlay")]

--- a/core/embed/rust/src/ui/layout_eckhart/theme/bootloader.rs
+++ b/core/embed/rust/src/ui/layout_eckhart/theme/bootloader.rs
@@ -8,7 +8,8 @@ use super::{
         component::{ButtonStyle, ButtonStyleSheet},
         fonts,
     },
-    BLACK, BLUE, GREY, GREY_DARK, GREY_EXTRA_LIGHT, GREY_LIGHT, GREY_SUPER_DARK, RED, WHITE,
+    BLACK, BLUE, GREY, GREY_DARK, GREY_EXTRA_LIGHT, GREY_LIGHT, GREY_SUPER_DARK, ORANGE, RED,
+    WHITE,
 };
 
 pub const BLD_BG: Color = BLACK;
@@ -127,6 +128,32 @@ pub fn button_bld_menu() -> ButtonStyleSheet {
             text_color: GREY_EXTRA_LIGHT,
             button_color: BLD_BG,
             icon_color: GREY_EXTRA_LIGHT,
+            background_color: BLD_BG,
+        },
+        active: &ButtonStyle {
+            font: fonts::FONT_SATOSHI_REGULAR_38,
+            text_color: GREY_DARK,
+            button_color: GREY_SUPER_DARK,
+            icon_color: GREY_DARK,
+            background_color: GREY_SUPER_DARK,
+        },
+        disabled: &ButtonStyle {
+            font: fonts::FONT_SATOSHI_REGULAR_38,
+            text_color: GREY_DARK,
+            button_color: BLD_BG,
+            icon_color: GREY_DARK,
+            background_color: BLD_BG,
+        },
+    }
+}
+
+pub fn button_bld_menu_danger() -> ButtonStyleSheet {
+    ButtonStyleSheet {
+        normal: &ButtonStyle {
+            font: fonts::FONT_SATOSHI_REGULAR_38,
+            text_color: ORANGE,
+            button_color: BLD_BG,
+            icon_color: ORANGE,
             background_color: BLD_BG,
         },
         active: &ButtonStyle {

--- a/core/embed/rust/src/ui/layout_eckhart/theme/firmware.rs
+++ b/core/embed/rust/src/ui/layout_eckhart/theme/firmware.rs
@@ -20,8 +20,6 @@ pub const ERASE_HOLD_DURATION: ShortDuration = ShortDuration::from_millis(1500);
 pub const FUEL_GAUGE_DURATION: ShortDuration = ShortDuration::from_millis(2000);
 
 // Text styles
-/// Alias for use with copied code, might be deleted later
-pub const TEXT_NORMAL: TextStyle = TEXT_MEDIUM;
 /// TT Satoshi Extra Light - 72 (PIN keyboard, Wallet backup / word)
 pub const TEXT_SUPER_BIG: TextStyle = TextStyle::new(
     fonts::FONT_SATOSHI_EXTRALIGHT_72,
@@ -547,9 +545,9 @@ pub const fn button_keyboard_next() -> ButtonStyleSheet {
 pub const fn button_always_disabled() -> ButtonStyleSheet {
     let style = &ButtonStyle {
         font: fonts::FONT_SATOSHI_MEDIUM_26,
-        text_color: GREY_LIGHT,
+        text_color: GREY,
         button_color: BG,
-        icon_color: GREY_LIGHT,
+        icon_color: GREY,
         background_color: BG,
     };
     ButtonStyleSheet {

--- a/core/embed/rust/src/ui/layout_eckhart/theme/mod.rs
+++ b/core/embed/rust/src/ui/layout_eckhart/theme/mod.rs
@@ -147,15 +147,19 @@ include_icon!(
 // bootloader and firmware
 
 pub const TEXT_NORMAL: TextStyle =
-    TextStyle::new(fonts::FONT_SATOSHI_REGULAR_38, GREY_EXTRA_LIGHT, BG, FG, FG);
+    TextStyle::new(fonts::FONT_SATOSHI_REGULAR_38, GREY_LIGHT, BG, FG, FG);
 pub const TEXT_SMALL: TextStyle =
-    TextStyle::new(fonts::FONT_SATOSHI_MEDIUM_26, GREY_EXTRA_LIGHT, BG, FG, FG);
+    TextStyle::new(fonts::FONT_SATOSHI_MEDIUM_26, GREY_LIGHT, BG, FG, FG);
 pub const TEXT_SMALL_RED: TextStyle = TextStyle {
     text_color: RED,
     ..TEXT_SMALL
 };
 pub const TEXT_SMALL_GREY: TextStyle = TextStyle {
     text_color: GREY,
+    ..TEXT_SMALL
+};
+pub const TEXT_SMALL_GREY_EXTRA_LIGHT: TextStyle = TextStyle {
+    text_color: GREY_EXTRA_LIGHT,
     ..TEXT_SMALL
 };
 

--- a/core/embed/rust/src/ui/layout_eckhart/ui_bootloader.rs
+++ b/core/embed/rust/src/ui/layout_eckhart/ui_bootloader.rs
@@ -31,15 +31,13 @@ use super::{
         button_default, BLUE, GREY, ICON_CHECKMARK, ICON_CLOSE, ICON_CROSS, RED, TEXT_NORMAL,
         TEXT_SMALL_GREY,
     },
-    UIEckhart,
+    UIEckhart, WAIT_FOR_RESTART_MESSAGE,
 };
 
 #[cfg(feature = "ble")]
 use super::bootloader::{ConfirmPairingScreen, PairingFinalizationScreen, PairingModeScreen};
 
 pub type BootloaderString = String<128>;
-
-const RECONNECT_MESSAGE: &str = "Please reconnect\nthe device";
 
 const SCREEN: Rect = UIEckhart::SCREEN;
 const PROGRESS_TEXT_ORIGIN: Point = SCREEN
@@ -188,7 +186,7 @@ impl BootloaderUI for UIEckhart {
         ))
         .with_header(BldHeader::new_pay_attention())
         .with_footer(
-            Label::centered(RECONNECT_MESSAGE.into(), TEXT_SMALL_GREY).vertically_centered(),
+            Label::centered(WAIT_FOR_RESTART_MESSAGE.into(), TEXT_SMALL_GREY).vertically_centered(),
         )
         .with_screen_border(SCREEN_BORDER_RED);
 
@@ -310,7 +308,7 @@ impl BootloaderUI for UIEckhart {
         ))
         .with_header(BldHeader::new_pay_attention())
         .with_footer(
-            Label::centered(RECONNECT_MESSAGE.into(), TEXT_SMALL_GREY).vertically_centered(),
+            Label::centered(WAIT_FOR_RESTART_MESSAGE.into(), TEXT_SMALL_GREY).vertically_centered(),
         )
         .with_screen_border(SCREEN_BORDER_BLUE);
 
@@ -385,7 +383,7 @@ impl BootloaderUI for UIEckhart {
         ))
         .with_header(BldHeader::new("Done".into()).with_icon(theme::ICON_DONE, theme::GREY))
         .with_footer(
-            Label::centered(RECONNECT_MESSAGE.into(), TEXT_SMALL_GREY).vertically_centered(),
+            Label::centered(WAIT_FOR_RESTART_MESSAGE.into(), TEXT_SMALL_GREY).vertically_centered(),
         )
         .with_screen_border(SCREEN_BORDER_RED);
 
@@ -400,7 +398,7 @@ impl BootloaderUI for UIEckhart {
         ))
         .with_header(BldHeader::new_pay_attention())
         .with_footer(
-            Label::centered(RECONNECT_MESSAGE.into(), TEXT_SMALL_GREY).vertically_centered(),
+            Label::centered(WAIT_FOR_RESTART_MESSAGE.into(), TEXT_SMALL_GREY).vertically_centered(),
         )
         .with_screen_border(SCREEN_BORDER_RED);
         show(&mut screen, true);

--- a/core/embed/rust/src/ui/layout_eckhart/ui_firmware.rs
+++ b/core/embed/rust/src/ui/layout_eckhart/ui_firmware.rs
@@ -596,7 +596,7 @@ impl FirmwareUI for UIEckhart {
     ) -> Result<impl LayoutMaybeTrace, Error> {
         let mut main_paragraphs = ParagraphVecShort::new();
         if let Some(description) = description {
-            main_paragraphs.add(Paragraph::new(&theme::TEXT_NORMAL, description));
+            main_paragraphs.add(Paragraph::new(&theme::TEXT_REGULAR, description));
         }
         if let Some(extra) = extra {
             main_paragraphs.add(Paragraph::new(&theme::TEXT_SMALL, extra));


### PR DESCRIPTION
<!--
For core developers:
- Assign yourself to the PR.
- Set the priority to match the original issue.
- Add the PR to the current sprint.
- If it's a draft PR, mark it as "In Progress."
- If it's a final PR, mark it as "Needs Review."

For external contributors:
- Please open an issue before submitting a PR so we can discuss whether we want to proceed with it.
-->
This PR:
- improves the bootloader menu (reorgs buttons, improves styling, removes "Trezor")
- improves `ErrorScreen` by showing "Wait for device restart" and also moves the "trezor.io" label above that
- implements "UpdateScreen" by delegating to a `TextScreen`/`BldTextScreen` based on `cfg(feature = "..")`