### PR TITLE
fix: remove wpc gradual charging

### DIFF
--- a/core/embed/sys/power_manager/stm32u5/power_manager_internal.h
+++ b/core/embed/sys/power_manager/stm32u5/power_manager_internal.h
@@ -39,8 +39,6 @@
 #define PM_BATTERY_CHARGING_CURRENT_MAX PMIC_CHARGING_LIMIT_MAX
 #define PM_BATTERY_CHARGING_CURRENT_MIN PMIC_CHARGING_LIMIT_MIN
 #define PM_BATTERY_SAMPLING_BUF_SIZE 10
-#define PM_WPC_CHARGE_CURR_STEP_MA 20
-#define PM_WPC_CHARGE_CURR_STEP_TIMEOUT_MS 1000
 
 // Fuel gauge extended kalman filter parameters
 #define PM_FUEL_GAUGE_R 2000.0f
@@ -76,7 +74,6 @@ typedef struct {
   bool charging_enabled;
   uint16_t charging_current_target_ma;
   uint16_t charging_current_max_limit_ma;
-  uint32_t charging_step_timeout_ms;
 
   // Power source hardware state
   pmic_report_t pmic_data;

--- a/core/embed/sys/power_manager/stm32u5/power_monitoring.c
+++ b/core/embed/sys/power_manager/stm32u5/power_monitoring.c
@@ -157,22 +157,10 @@ void pm_charging_controller(pm_driver_t* drv) {
       return;
     }
   } else if (drv->usb_connected) {
-    // USB connected, set maximum charging current right away
-    drv->charging_current_target_ma = drv->charging_current_max_limit_ma;
+    drv->charging_current_target_ma = PM_BATTERY_CHARGING_CURRENT_MAX;
 
   } else if (drv->wireless_connected) {
-    // Wireless charger is sensitive to large current steps, so we need to
-    // control the charging current in steps.
-    if (ticks_expired(drv->charging_step_timeout_ms)) {
-      if (drv->charging_current_target_ma <
-          drv->charging_current_max_limit_ma) {
-        drv->charging_current_target_ma += PM_WPC_CHARGE_CURR_STEP_MA;
-      }
-
-      // Reset charging step timeout
-      drv->charging_step_timeout_ms =
-          ticks_timeout(PM_WPC_CHARGE_CURR_STEP_TIMEOUT_MS);
-    }
+    drv->charging_current_target_ma = PM_BATTERY_CHARGING_CURRENT_MAX;
 
   } else {
     // Charging enabled but no external power source, clear charging target


### PR DESCRIPTION
This PR removes WPC gradual charging from the power manager. 

unfortunately, NPM1300 has to stop the charging between every change of the charging current setting, which means that gradual charge makes no sense. 

WPC charging changed to start right at maximal charging current, and we may update the charging current to suitable value after thermal tests. 

Charging was tested with current WPC FW and config and all available coils and shows no anomaly.
