### PR TITLE
fix(core): fix RSOD handling in secmon

### DIFF
--- a/core/embed/sys/startup/inc/sys/sysutils.h
+++ b/core/embed/sys/startup/inc/sys/sysutils.h
@@ -39,9 +39,13 @@ __attribute((noreturn)) void call_with_new_stack(uint32_t arg1, uint32_t arg2,
 
 // Ensure that we are running in privileged thread mode.
 //
-// This function is used only on STM32F4, where a direct jump to the
-// bootloader is performed. It checks if we are in handler mode, and
-// if so, it switches to privileged thread mode.
+// The function checks if we are in handler mode, and if so, it switches to
+// privileged thread mode.
+//
+// It is used in two specific cases:
+// 1. When a direct jump to the bootloader is performed (STM32F4 only)
+// 2. When the system recovers from an error state and needs to call
+//    error_handler callback that draws an RSOD screen.
 void ensure_thread_mode(void);
 
 // Ensure compatible hardware settings before jumping to

--- a/core/embed/sys/task/stm32/system.c
+++ b/core/embed/sys/task/stm32/system.c
@@ -123,8 +123,14 @@ system_emergency_rescue_phase_2(uint32_t arg1, uint32_t arg2) {
   // Now we can safely enable interrupts again
   __enable_fault_irq();
 
-  // Ensure we are in thread mode
+#ifndef SECMON
+  // Ensure we are in thread mode.
+  //
+  // In the secure monitor, we are not able to ensure a transition to
+  // thread mode under all circumstances. And because the error_handler is
+  // always NULL in the secure monitor, it's not even necessary.
   ensure_thread_mode();
+#endif
 
   // Now everything is perfectly initialized and we can do anything
   // in C code


### PR DESCRIPTION
This small PR fixes an issue with RSOD in the secure monitor.

The fix removes the transition from handler mode to thread mode inside the `system_emergency_rescue()` function, which is responsible for cleaning up memory and resources before the RSOD is displayed.

It appears that transitioning from handler mode to thread mode cannot be reliably performed in all circumstances when running in the secure monitor. Since we don't need to invoke `error_handler` (because we use `USE_BOOTARGS_RSOD` in the secure monitor), we can safely skip this automatic transition.





