### PR TITLE
Eckhart: remove boot stage 1 screen

### DIFF
--- a/core/embed/io/display/display_utils.c
+++ b/core/embed/io/display/display_utils.c
@@ -24,6 +24,9 @@
 
 void display_fade(int start, int end, int delay) {
 #ifdef USE_BACKLIGHT
+  if (display_get_backlight() == end) {
+    return;
+  }
   for (int i = 0; i < 100; i++) {
     display_set_backlight(start + i * (end - start) / 100);
     hal_delay(delay / 100);

--- a/core/embed/projects/bootloader/workflow/wf_empty_device.c
+++ b/core/embed/projects/bootloader/workflow/wf_empty_device.c
@@ -41,15 +41,6 @@ workflow_result_t workflow_empty_device(void) {
 #endif
   ensure(erase_storage(NULL), NULL);
 
-  // keep the model screen up for a while
-#ifndef USE_BACKLIGHT
-  systick_delay_ms(1500);
-#else
-  // backlight fading takes some time so the explicit delay here is
-  // shorter
-  systick_delay_ms(1000);
-#endif
-
   protob_ios_t ios;
   workflow_ifaces_init(sectrue, &ios);
 

--- a/core/embed/rust/src/ui/layout/simplified.rs
+++ b/core/embed/rust/src/ui/layout/simplified.rs
@@ -124,7 +124,7 @@ pub fn run(frame: &mut impl Component<Msg = impl ReturnToC>) -> u32 {
 pub fn show(frame: &mut impl Component, fading: bool) {
     frame.place(ModelUI::SCREEN);
 
-    if fading {
+    if fading && display::backlight() > 0 {
         ModelUI::fadeout()
     };
 

--- a/core/embed/rust/src/ui/layout_bolt/bootloader/mod.rs
+++ b/core/embed/rust/src/ui/layout_bolt/bootloader/mod.rs
@@ -29,14 +29,18 @@ use super::{
     },
     UIBolt,
 };
-use crate::ui::{
-    component::{Event, Label},
-    display::{self, toif::Toif, Color, Icon, LOADER_MAX},
-    geometry::{Alignment, Alignment2D, Offset, Point, Rect},
-    layout::simplified::{process_frame_event, run, show},
-    shape::{self, render_on_display},
-    ui_bootloader::{BootloaderLayoutType, BootloaderUI},
-    CommonUI,
+use crate::{
+    time::Duration,
+    trezorhal::time,
+    ui::{
+        component::{Event, Label},
+        display::{self, toif::Toif, Color, Icon, LOADER_MAX},
+        geometry::{Alignment, Alignment2D, Offset, Point, Rect},
+        layout::simplified::{process_frame_event, run, show},
+        shape::{self, render_on_display},
+        ui_bootloader::{BootloaderLayoutType, BootloaderUI},
+        CommonUI,
+    },
 };
 use intro::Intro;
 use menu::Menu;
@@ -165,6 +169,8 @@ impl BootloaderLayoutType for BootloaderLayout {
     }
 
     fn init_welcome() -> Self {
+        // let the previous screen on for some time
+        time::sleep(Duration::from_millis(1000));
         Self::Welcome(Welcome::new())
     }
 

--- a/core/embed/rust/src/ui/layout_caesar/bootloader/mod.rs
+++ b/core/embed/rust/src/ui/layout_caesar/bootloader/mod.rs
@@ -32,8 +32,10 @@ mod welcome;
 
 mod connect;
 
-use crate::ui::{
-    component::Event, layout::simplified::process_frame_event, ui_bootloader::BootloaderUI,
+use crate::{
+    time::Duration,
+    trezorhal::time,
+    ui::{component::Event, layout::simplified::process_frame_event, ui_bootloader::BootloaderUI},
 };
 use connect::Connect;
 use intro::Intro;
@@ -115,6 +117,8 @@ impl BootloaderLayoutType for BootloaderLayout {
     }
 
     fn init_welcome() -> Self {
+        // let the previous screen on for some time
+        time::sleep(Duration::from_millis(1500));
         Self::Welcome(Welcome::new())
     }
 

--- a/core/embed/rust/src/ui/layout_delizia/bootloader/mod.rs
+++ b/core/embed/rust/src/ui/layout_delizia/bootloader/mod.rs
@@ -41,7 +41,11 @@ use crate::ui::{
 use ufmt::uwrite;
 
 use super::theme::bootloader::BLD_WARN_COLOR;
-use crate::ui::{component::Event, layout::simplified::process_frame_event};
+use crate::{
+    time::Duration,
+    trezorhal::time,
+    ui::{component::Event, layout::simplified::process_frame_event},
+};
 use connect::Connect;
 use intro::Intro;
 use menu::Menu;
@@ -148,6 +152,8 @@ impl BootloaderLayoutType for BootloaderLayout {
         }
     }
     fn init_welcome() -> Self {
+        // let the previous screen on for some time
+        time::sleep(Duration::from_millis(1500));
         Self::Welcome(Welcome::new())
     }
 

--- a/core/embed/rust/src/ui/layout_eckhart/ui_bootloader.rs
+++ b/core/embed/rust/src/ui/layout_eckhart/ui_bootloader.rs
@@ -19,11 +19,11 @@ use super::{
         BldActionBar, BldHeader, BldHeaderMsg, BldMenuScreen, BldTextScreen, BldWelcomeScreen,
         ConnectScreen,
     },
-    component::{Button, WelcomeScreen},
+    component::Button,
     cshape::{render_loader, ScreenBorder},
     fonts,
     theme::{
-        self, backlight,
+        self,
         bootloader::{
             button_cancel, button_confirm, button_wipe_confirm, BLD_BG, BLD_FG,
             TEXT_FW_FINGERPRINT, TEXT_WARNING, WELCOME_COLOR,
@@ -348,20 +348,7 @@ impl BootloaderUI for UIEckhart {
         run(&mut screen)
     }
 
-    fn screen_boot_stage_1(fading: bool) {
-        if fading {
-            Self::fadeout();
-        }
-
-        let mut frame = WelcomeScreen::new();
-        show(&mut frame, false);
-
-        if fading {
-            Self::fadein();
-        } else {
-            display::set_backlight(backlight::get_backlight_normal());
-        }
-    }
+    fn screen_boot_stage_1(_fading: bool) {}
 
     fn screen_wipe_progress(progress: u16, initialize: bool) {
         Self::screen_progress("Resetting Trezor", progress, initialize, theme::RED, None)


### PR DESCRIPTION
Removed boot stage 1 to optimize UX when booting.  

there is now larger delay between first screen is shown, we can probably optimize a bit more but it will be larger than 1 s anyway i guess. currently at about 1.4 s, which seems bordeline to me. Product confirmation needed.

Some backlight fading was removed to optimize the boot a bit.

