### PR TITLE
Fix fuel gauge soc limit during initial estimation

### DIFF
--- a/core/embed/projects/prodtest/README.md
+++ b/core/embed/projects/prodtest/README.md
@@ -712,6 +712,16 @@ optiga-counter-read
 OK 0E
 ```
 
+### pm-new-soc-estimate
+Erase power manager recovery data from the backup RAM and immediately reboot the device to run new battery SoC estimate.
+
+Example:
+```
+pm-new-soc-estimate
+# Erasing backup RAM and rebooting...
+OK
+```
+
 ### pm-set-soc-limit
 Sets the battery state of charge (SOC) limit. The SOC limit is a percentage value between 10 and 100.
 

--- a/core/embed/sys/backup_ram/inc/sys/backup_ram.h
+++ b/core/embed/sys/backup_ram/inc/sys/backup_ram.h
@@ -54,6 +54,17 @@ void backup_ram_deinit(void);
 
 bool backup_ram_erase(void);
 
+/**
+ * @brief Erases a single item in backup RAM by its key.
+ *
+ * If the item with the given key does not exist, the function does nothing.
+ *
+ * @param key Key of the item to erase
+ *
+ * @return true if the operation was successful, false otherwise.
+ */
+bool backup_ram_erase_item(uint16_t key);
+
 #define BACKUP_RAM_INVALID_KEY 0xFFFF
 
 /**

--- a/core/embed/sys/backup_ram/stm32u5/backup_ram.c
+++ b/core/embed/sys/backup_ram/stm32u5/backup_ram.c
@@ -354,6 +354,21 @@ uint16_t backup_ram_search(uint16_t min_key) {
   return key;
 }
 
+bool backup_ram_erase_item(uint16_t key) {
+  backup_ram_driver_t* drv = &g_backup_ram_driver;
+
+  if (!drv->initialized) {
+    return false;
+  }
+
+  // Writing NULL data will just remove the item with the given key
+  irq_key_t irq_key = irq_lock();
+  bool status = backup_ram_write(key, NULL, 0);
+  irq_unlock(irq_key);
+
+  return status;
+}
+
 bool backup_ram_read(uint16_t key, void* buffer, size_t buffer_size,
                      size_t* data_size) {
   bool success = false;

--- a/core/embed/sys/power_manager/fuel_gauge/fuel_gauge.c
+++ b/core/embed/sys/power_manager/fuel_gauge/fuel_gauge.c
@@ -41,6 +41,8 @@ void fuel_gauge_reset(fuel_gauge_state_t* state) {
 }
 
 void fuel_gauge_set_soc(fuel_gauge_state_t* state, float soc, float P) {
+  soc = fmaxf(0.0f, fminf(soc, 1.0f));  // Clamp SOC to [0, 1]
+
   // Set SOC directly
   state->soc = soc;
   state->soc_latched = soc;
@@ -55,8 +57,9 @@ void fuel_gauge_initial_guess(fuel_gauge_state_t* state, float voltage_V,
   // Calculate OCV from terminal voltage and current
   float ocv = battery_meas_to_ocv(voltage_V, current_mA, temperature);
 
-  // Get SOC from OCV using lookup
+  // Extract SoC from battery model
   state->soc = battery_soc(ocv, temperature, discharging_mode);
+  state->soc = fmaxf(0.0f, fminf(state->soc, 1.0f));  // Clamp SOC to [0, 1]
   state->soc_latched = state->soc;
 }
 

--- a/core/embed/sys/power_manager/stm32u5/power_monitoring.c
+++ b/core/embed/sys/power_manager/stm32u5/power_monitoring.c
@@ -99,10 +99,7 @@ void pm_monitor_power_sources(void) {
   }
 
   // Ceil the float soc to user-friendly integer
-  uint8_t soc_ceiled_temp = (int)(drv->fuel_gauge.soc_latched * 100 + 0.999f);
-  if (soc_ceiled_temp != drv->soc_ceiled) {
-    drv->soc_ceiled = soc_ceiled_temp;
-  }
+  drv->soc_ceiled = (uint8_t)(drv->fuel_gauge.soc_latched * 100 + 0.999f);
 
   // Check battery voltage for low threshold
   if (drv->soc_ceiled <= PM_BATTERY_LOW_THRESHOLD_SOC && !drv->battery_low) {


### PR DESCRIPTION
This tiny PR fix an issue with out-of-bound SoC estimation during battery initialization.

The initial estimate was not bounded, so time to time it returned crazy estimates when battery was not connected and then showing SoC 255% in the core app.

This PR also add simple prodtest command `pm-new-soc-estimate` which is helpful when a user need to test battery initialization several times. Command disable the power manager, erase recovery data from backup ram an reboot the device to get a new estimate. 

Before, this was usually done by simply erasing the backup ram and manually rebooting the device, but after backup ram refactor this is no longer possible, since now it could recover from data loss.

 