### PR TITLE
update wpc-info command to return machine readable data 

### DIFF
--- a/core/embed/projects/prodtest/README.md
+++ b/core/embed/projects/prodtest/README.md
@@ -906,6 +906,8 @@ OK 00000001000000000000000000000000000000000000000000000000000000000000000001000
 ### wpc-info
 Retrieves detailed information from the wireless power receiver, including chip identification, firmware version, configuration settings, and error status.
 
+WARNING: The command will only succeed if the receiver is externally powered (5V present on the VOUT/VRECT test point).
+
 Example:
 ```
 > wpc-info
@@ -928,13 +930,14 @@ Example:
 #   nvm_config_err:    0x0
 #   nvm_patch_err:     0x0
 #   nvm_prod_info_err: 0x0
+PROGRESS 0x38 0x4 0x0 0x161 0x1645 0x1D7C 0xC 0x1 0x52353038385055AA09446D0655AA55AA 0x0
 OK
 ```
 
 ### wpc-update
 Updates the firmware and configuration of the wireless power receiver.
 
-WARNING: The update will only succeed if the receiver is externally powered (5V present on the VOUT test point).
+WARNING: The command will only succeed if the receiver is externally powered (5V present on the VOUT/VRECT test point).
 
 Example:
 ```

--- a/core/embed/projects/prodtest/cmd/prodtest_wpc.c
+++ b/core/embed/projects/prodtest/cmd/prodtest_wpc.c
@@ -63,7 +63,13 @@ static void prodtest_wpc_info(cli_t* cli) {
   cli_trace(cli, "chip_rev   0x%d ", chip_info.chip_rev);
   cli_trace(cli, "cust_id    0x%d ", chip_info.cust_id);
   cli_trace(cli, "rom_id     0x%X ", chip_info.rom_id);
-  cli_trace(cli, "patch_id   0x%X ", chip_info.patch_id);
+
+  if (chip_info.patch_id == 0) {
+    cli_trace(cli, "patch_id   0x%X (This value may be visible after reset)",
+              chip_info.patch_id);
+  } else {
+    cli_trace(cli, "patch_id   0x%X ", chip_info.patch_id);
+  }
   cli_trace(cli, "cfg_id     0x%X ", chip_info.cfg_id);
   cli_trace(cli, "pe_id      0x%X ", chip_info.pe_id);
   cli_trace(cli, "op_mode    0x%X ", chip_info.op_mode);
@@ -77,6 +83,12 @@ static void prodtest_wpc_info(cli_t* cli) {
   cli_trace(cli, "  nvm_config_err:    0x%X ", chip_info.nvm_config_err);
   cli_trace(cli, "  nvm_patch_err:     0x%X ", chip_info.nvm_patch_err);
   cli_trace(cli, "  nvm_prod_info_err: 0x%X ", chip_info.nvm_prod_info_err);
+
+  cli_progress(cli, "0x%d 0x%d 0x%d 0x%X 0x%X 0x%X 0x%X 0x%X 0x%s 0x%X",
+               chip_info.chip_id, chip_info.chip_rev, chip_info.cust_id,
+               chip_info.rom_id, chip_info.patch_id, chip_info.cfg_id,
+               chip_info.pe_id, chip_info.op_mode, device_id,
+               chip_info.sys_err);
 
   stwlc38_deinit();
 


### PR DESCRIPTION
This PR fix `wpc-info` command to return machine readable data (PROGRESS line). 

Example:
```
> wpc-info
# Reading STWLC38 info...
# chip_id    0x38
# chip_rev   0x3
# cust_id    0x0
# rom_id     0x161
# patch_id   0x1299
# cfg_id     0x1026
# pe_id      0x7
# op_mode    0x2
# device_id  005A32344D3555AA021F781855AA55AA
#
# sys_err              0x0
#   core_hard_fault:   0x0
#   nvm_ip_err:        0x0
#   nvm_boot_err:      0x0
#   nvm_pe_error:      0x0
#   nvm_config_err:    0x0
#   nvm_patch_err:     0x0
#   nvm_prod_info_err: 0x0
PROGRESS 0x38 0x4 0x0 0x161 0x1645 0x1D7C 0xC 0x1 0x52353038385055AA09446D0655AA55AA 0x0 <------ NEW
OK
```