### PR TITLE
build(core): fix T2B1 build

### DIFF
--- a/core/embed/sec/secret/stm32f4/secret.c
+++ b/core/embed/sec/secret/stm32f4/secret.c
@@ -61,6 +61,12 @@ secbool secret_verify_header(void) {
   return bootloader_locked;
 }
 
+static void secret_erase(void) {
+  mpu_mode_t mpu_mode = mpu_reconfig(MPU_MODE_SECRET);
+  ensure(flash_area_erase(&SECRET_AREA, NULL), "secret erase");
+  mpu_restore(mpu_mode);
+}
+
 #ifdef LOCKABLE_BOOTLOADER
 secbool secret_bootloader_locked(void) {
   if (bootloader_locked_set != sectrue) {
@@ -132,12 +138,6 @@ static secbool secret_wiped(void) {
   return wiped;
 }
 
-void secret_erase(void) {
-  mpu_mode_t mpu_mode = mpu_reconfig(MPU_MODE_SECRET);
-  ensure(flash_area_erase(&SECRET_AREA, NULL), "secret erase");
-  mpu_restore(mpu_mode);
-}
-
 secbool secret_key_set(uint8_t slot, const uint8_t* key, size_t len) {
   if (slot >= SECRET_NUM_KEY_SLOTS) {
     return secfalse;
@@ -167,14 +167,6 @@ secbool secret_key_get(uint8_t slot, uint8_t* dest, size_t len) {
   uint32_t offset = SECRET_KEY_SLOT_0_OFFSET;
 
   return secret_read(dest, offset, len);
-}
-
-static secbool secret_key_present(uint8_t slot) {
-  if (slot >= SECRET_NUM_KEY_SLOTS) {
-    return secfalse;
-  }
-
-  return (sectrue != secret_wiped()) * sectrue;
 }
 
 secbool secret_key_writable(uint8_t slot) {


### PR DESCRIPTION
Otherwise, it fails with:
```
$ TREZOR_MODEL=T2B1 BITCOIN_ONLY=0 PYOPT=0 QUIET_MODE=1 make -C core build_firmware
...
embed/sec/secret/stm32f4/secret.c: In function 'secret_unlock_bootloader':
embed/sec/secret/stm32f4/secret.c:74:39: error: implicit declaration of function 'secret_erase'; did you mean 'secret_read'? [-Werror=implicit-function-declaration]
   74 | void secret_unlock_bootloader(void) { secret_erase(); }
      |                                       ^~~~~~~~~~~~
      |                                       secret_read
embed/sec/secret/stm32f4/secret.c: At top level:
embed/sec/secret/stm32f4/secret.c:135:6: error: conflicting types for 'secret_erase'; have 'void(void)' [-Werror]
  135 | void secret_erase(void) {
      |      ^~~~~~~~~~~~
embed/sec/secret/stm32f4/secret.c:74:39: note: previous implicit declaration of 'secret_erase' with type 'void(void)'
   74 | void secret_unlock_bootloader(void) { secret_erase(); }
      |                                       ^~~~~~~~~~~~
embed/sec/secret/stm32f4/secret.c:172:16: error: 'secret_key_present' defined but not used [-Werror=unused-function]
  172 | static secbool secret_key_present(uint8_t slot) {
      |                ^~~~~~~~~~~~~~~~~~
```
https://github.com/trezor/trezor-firmware/actions/runs/15863538391/job/44725887234