### PR TITLE
Eckhart: adjust wipe success screen in bootloader

### DIFF
--- a/core/embed/projects/bootloader/bootui.c
+++ b/core/embed/projects/bootloader/bootui.c
@@ -147,7 +147,7 @@ confirm_result_t ui_screen_wipe_confirm(void) { return screen_wipe_confirm(); }
 void ui_screen_wipe(void) { screen_wipe_progress(0, true); }
 
 void ui_screen_wipe_progress(int pos, int len) {
-  screen_wipe_progress(1000 * pos / len, false);
+  screen_wipe_progress((int16_t)(1000 * (int64_t)pos / len), false);
 }
 
 // done UI

--- a/core/embed/projects/bootloader/main.c
+++ b/core/embed/projects/bootloader/main.c
@@ -377,7 +377,7 @@ void real_jump_to_firmware(void) {
       IMAGE_CODE_ALIGN(FIRMWARE_START + vhdr.hdrlen + IMAGE_HEADER_SIZE));
 }
 
-__attribute__((noreturn)) void jump_to_fw_through_reset(void) {
+__attribute__((noreturn)) void reboot_with_fade(void) {
   display_fade(display_get_backlight(), 0, 200);
   reboot_device();
 }
@@ -566,10 +566,12 @@ int bootloader_main(void) {
         ensure(dont_optimize_out_true *
                    (firmware_present == firmware_present_backup),
                NULL);
-        jump_to_fw_through_reset();
+        reboot_with_fade();
         break;
       case WF_OK_DEVICE_WIPED:
       case WF_OK_BOOTLOADER_UNLOCKED:
+        reboot_with_fade();
+        return 0;
       case WF_ERROR:
         reboot_or_halt_after_rsod();
         return 0;

--- a/core/embed/rust/src/ui/layout_bolt/bootloader/mod.rs
+++ b/core/embed/rust/src/ui/layout_bolt/bootloader/mod.rs
@@ -395,7 +395,7 @@ impl BootloaderUI for UIBolt {
                 .vertically_centered(),
             true,
         );
-        show(&mut frame, true);
+        run(&mut frame);
     }
 
     fn screen_wipe_fail() {

--- a/core/embed/rust/src/ui/layout_caesar/bootloader/mod.rs
+++ b/core/embed/rust/src/ui/layout_caesar/bootloader/mod.rs
@@ -267,7 +267,7 @@ impl BootloaderUI for UICaesar {
             .vertically_centered();
 
         let mut frame = ResultScreen::new(BLD_FG, BLD_BG, ICON_SPINNER, title, content, true);
-        show(&mut frame, false);
+        run(&mut frame);
     }
 
     fn screen_intro(bld_version: &str, vendor: &str, version: &str, fw_ok: bool) -> u32 {
@@ -325,7 +325,7 @@ impl BootloaderUI for UICaesar {
             .vertically_centered();
 
         let mut frame = ResultScreen::new(BLD_FG, BLD_BG, ICON_SPINNER, title, content, true);
-        show(&mut frame, false);
+        run(&mut frame);
     }
 
     fn screen_wipe_fail() {

--- a/core/embed/rust/src/ui/layout_delizia/bootloader/mod.rs
+++ b/core/embed/rust/src/ui/layout_delizia/bootloader/mod.rs
@@ -337,7 +337,7 @@ impl BootloaderUI for UIDelizia {
                 .vertically_centered(),
             true,
         );
-        show(&mut frame, true);
+        run(&mut frame);
     }
 
     fn screen_intro(bld_version: &str, vendor: &str, version: &str, fw_ok: bool) -> u32 {
@@ -412,7 +412,7 @@ impl BootloaderUI for UIDelizia {
                 .vertically_centered(),
             true,
         );
-        show(&mut frame, true);
+        run(&mut frame);
     }
 
     fn screen_wipe_fail() {

--- a/core/embed/rust/src/ui/layout_eckhart/bootloader/bld_header.rs
+++ b/core/embed/rust/src/ui/layout_eckhart/bootloader/bld_header.rs
@@ -64,6 +64,10 @@ impl<'a> BldHeader<'a> {
         Self::new("Failure".into()).with_icon(theme::ICON_INFO, theme::RED)
     }
 
+    pub fn new_done() -> Self {
+        Self::new("Done".into()).with_icon(theme::ICON_DONE, theme::GREY)
+    }
+
     pub fn new_pay_attention() -> Self {
         Self::new("Pay attention".into()).with_icon(theme::ICON_WARNING, theme::GREY)
     }

--- a/core/embed/rust/src/ui/layout_eckhart/ui_bootloader.rs
+++ b/core/embed/rust/src/ui/layout_eckhart/ui_bootloader.rs
@@ -286,9 +286,9 @@ impl BootloaderUI for UIEckhart {
     fn screen_unlock_bootloader_confirm() -> u32 {
         let msg1 =
             Label::left_aligned("Unlock bootloader".into(), TEXT_NORMAL).vertically_centered();
-        let msg2 = Label::centered("This action cannot be undone!".into(), TEXT_NORMAL);
+        let msg2 = Label::left_aligned("This action cannot be undone!".into(), TEXT_NORMAL);
 
-        let right = Button::with_text("Unlock".into()).styled(button_confirm());
+        let right = Button::with_text("Unlock".into()).styled(button_wipe_confirm());
         let left = Button::with_icon(theme::ICON_CHEVRON_LEFT).styled(button_cancel());
 
         let mut screen = BldTextScreen::new(msg1)
@@ -306,13 +306,13 @@ impl BootloaderUI for UIEckhart {
             Alignment::Start,
             TEXT_NORMAL,
         ))
-        .with_header(BldHeader::new_pay_attention())
-        .with_footer(
-            Label::centered(WAIT_FOR_RESTART_MESSAGE.into(), TEXT_SMALL_GREY).vertically_centered(),
-        )
-        .with_screen_border(SCREEN_BORDER_BLUE);
+        .with_header(BldHeader::new_done())
+        .with_action_bar(BldActionBar::new_single(
+            Button::with_text("Restart".into()).styled(button_cancel()),
+        ))
+        .with_screen_border(SCREEN_BORDER_RED);
 
-        show(&mut screen, true);
+        run(&mut screen);
     }
 
     fn screen_intro(bld_version: &str, vendor: &str, version: &str, fw_ok: bool) -> u32 {
@@ -368,13 +368,13 @@ impl BootloaderUI for UIEckhart {
             Alignment::Start,
             TEXT_NORMAL,
         ))
-        .with_header(BldHeader::new("Done".into()).with_icon(theme::ICON_DONE, theme::GREY))
-        .with_footer(
-            Label::centered(WAIT_FOR_RESTART_MESSAGE.into(), TEXT_SMALL_GREY).vertically_centered(),
-        )
+        .with_header(BldHeader::new_done())
+        .with_action_bar(BldActionBar::new_single(
+            Button::with_text("Restart".into()).styled(button_default()),
+        ))
         .with_screen_border(SCREEN_BORDER_RED);
 
-        show(&mut screen, true);
+        run(&mut screen);
     }
 
     fn screen_wipe_fail() {


### PR DESCRIPTION
In eckhart UI, after wiping device from bootloader, the success screen now include a restart button, so that user doesn't have to wait until rebooot.

Same applies to unlock bootloader flow. 

Some minor adjustments to unlock bootloader screens were made too.

Also, integer overflow in wipe progress calculation is fixed.

Other models will hang in the success screen until unplugged.

