### PR TITLE
add timeout to nrf uart communication

### DIFF
--- a/core/embed/io/nrf/inc/io/nrf.h
+++ b/core/embed/io/nrf/inc/io/nrf.h
@@ -162,8 +162,9 @@ void nrf_reboot(void);
  *
  * @param data  Pointer to the data buffer
  * @param len   Length of the data buffer
+ * @param timeout_ms  Timeout in milliseconds for the operation
  */
-void nrf_send_uart_data(const uint8_t *data, uint32_t len);
+bool nrf_send_uart_data(const uint8_t *data, uint32_t len, uint32_t timeout_ms);
 
 /**
  * @brief Check if an nRF device firmware update is required by comparing SHA256

--- a/core/embed/rust/src/smp/echo.rs
+++ b/core/embed/rust/src/smp/echo.rs
@@ -26,7 +26,11 @@ pub fn send(text: &str) -> bool {
     data[..SMP_HEADER_SIZE].copy_from_slice(&header);
     data[SMP_HEADER_SIZE..SMP_HEADER_SIZE + data_len].copy_from_slice(&cbor_data[..data_len]);
 
-    send_request(&mut data[..SMP_HEADER_SIZE + data_len], &mut buffer);
+    let res = send_request(&mut data[..SMP_HEADER_SIZE + data_len], &mut buffer);
+
+    if res.is_err() {
+        return false;
+    }
 
     let mut resp_buffer = [0u8; 64];
     if wait_for_response(MsgType::Echo, &mut resp_buffer, Duration::from_millis(100)).is_ok() {

--- a/core/embed/rust/src/smp/reset.rs
+++ b/core/embed/rust/src/smp/reset.rs
@@ -23,5 +23,5 @@ pub fn send() {
     data[..SMP_HEADER_SIZE].copy_from_slice(&header);
     data[SMP_HEADER_SIZE..SMP_HEADER_SIZE + data_len].copy_from_slice(&cbor_data[..data_len]);
 
-    send_request(&mut data[..SMP_HEADER_SIZE + data_len], &mut buffer);
+    let _ = send_request(&mut data[..SMP_HEADER_SIZE + data_len], &mut buffer);
 }

--- a/core/embed/rust/src/smp/upload.rs
+++ b/core/embed/rust/src/smp/upload.rs
@@ -44,7 +44,11 @@ pub fn upload_image(image_data: &[u8], image_hash: &[u8]) -> bool {
     data[..SMP_HEADER_SIZE].copy_from_slice(&header);
     data[SMP_HEADER_SIZE..SMP_HEADER_SIZE + data_len].copy_from_slice(&cbor_data[..data_len]);
 
-    send_request(&mut data[..SMP_HEADER_SIZE + data_len], &mut buffer);
+    let res = send_request(&mut data[..SMP_HEADER_SIZE + data_len], &mut buffer);
+
+    if res.is_err() {
+        return false;
+    }
 
     let mut resp_buffer = [0u8; 64];
     if wait_for_response(
@@ -81,7 +85,11 @@ pub fn upload_image(image_data: &[u8], image_hash: &[u8]) -> bool {
         data[..SMP_HEADER_SIZE].copy_from_slice(&header);
         data[SMP_HEADER_SIZE..SMP_HEADER_SIZE + data_len].copy_from_slice(&cbor_data[..data_len]);
 
-        send_request(&mut data[..SMP_HEADER_SIZE + data_len], &mut buffer);
+        let res = send_request(&mut data[..SMP_HEADER_SIZE + data_len], &mut buffer);
+
+        if res.is_err() {
+            return false;
+        }
 
         let mut resp_buffer = [0u8; 64];
         if wait_for_response(

--- a/core/embed/rust/src/trezorhal/nrf.rs
+++ b/core/embed/rust/src/trezorhal/nrf.rs
@@ -1,7 +1,5 @@
 use super::ffi;
 
-pub fn send_data(data: &[u8]) {
-    unsafe {
-        ffi::nrf_send_uart_data(data.as_ptr(), data.len() as _);
-    }
+pub fn send_data(data: &[u8], timeout: u32) -> bool {
+    unsafe { ffi::nrf_send_uart_data(data.as_ptr(), data.len() as _, timeout) }
 }


### PR DESCRIPTION
This PR introduces timeout detection for uart/dfu communication with nRF. This helps in situation where the nrf is not communicating - instead of hanging forever there will be more appropriate timeout failure.