### PR TITLE
feat(legacy): increase EIP1559 access list limits 12/12

### DIFF
--- a/legacy/firmware/ethereum.c
+++ b/legacy/firmware/ethereum.c
@@ -55,7 +55,7 @@ static bool eip1559;
 struct SHA3_CTX keccak_ctx = {0};
 
 static uint32_t signing_access_list_count;
-static EthereumAccessList signing_access_list[8];
+static EthereumAccessList signing_access_list[12];
 _Static_assert(sizeof(signing_access_list) ==
                    sizeof(((EthereumSignTxEIP1559 *)NULL)->access_list),
                "access_list buffer size mismatch");
@@ -212,7 +212,7 @@ static uint32_t rlp_calculate_access_list_keys_length(
 }
 
 static uint32_t rlp_calculate_access_list_length(
-    const EthereumAccessList access_list[8], uint32_t access_list_count) {
+    const EthereumAccessList access_list[12], uint32_t access_list_count) {
   uint32_t length = 0;
   for (size_t i = 0; i < access_list_count; i++) {
     uint32_t address_length = rlp_calculate_length(PUBKEYHASH_LEN, 0xff);

--- a/legacy/firmware/protob/messages-ethereum.options
+++ b/legacy/firmware/protob/messages-ethereum.options
@@ -14,10 +14,10 @@ EthereumSignTxEIP1559.gas_limit          max_size:32
 EthereumSignTxEIP1559.to                 max_size:43
 EthereumSignTxEIP1559.value              max_size:32
 EthereumSignTxEIP1559.data_initial_chunk max_size:1024
-EthereumSignTxEIP1559.access_list        max_count:8
+EthereumSignTxEIP1559.access_list        max_count:12
 
 EthereumAccessList.address              max_size:43
-EthereumAccessList.storage_keys         max_count:8 max_size:32
+EthereumAccessList.storage_keys         max_count:12 max_size:32
 
 EthereumTxRequest.signature_r           max_size:32
 EthereumTxRequest.signature_s           max_size:32


### PR DESCRIPTION
<!--
For core developers:
- Assign yourself to the PR.
- Set the priority to match the original issue.
- Add the PR to the current sprint.
- If it's a draft PR, mark it as "In Progress."
- If it's a final PR, mark it as "Needs Review."

For external contributors:
- Please open an issue before submitting a PR so we can discuss whether we want to proceed with it.
-->
Update legacy firmware to support larger access lists for real-world
contract interactions that require more than 8 items or storage keys.