### PR TITLE
autodim & autosuspend bootloader on inactivity

### DIFF
--- a/core/embed/rust/build.rs
+++ b/core/embed/rust/build.rs
@@ -455,6 +455,7 @@ fn generate_trezorhal_bindings() {
         .allowlist_type("pm_event_t")
         .allowlist_function("pm_get_events")
         .allowlist_function("pm_get_state")
+        .allowlist_function("pm_suspend")
         // irq
         .allowlist_function("irq_lock_fn")
         .allowlist_function("irq_unlock_fn")

--- a/core/embed/rust/src/trezorhal/power_manager.rs
+++ b/core/embed/rust/src/trezorhal/power_manager.rs
@@ -1,4 +1,5 @@
 use super::ffi;
+use core::ptr::null_mut;
 
 #[cfg(feature = "ui")]
 use crate::ui::event::PMEvent;
@@ -39,4 +40,14 @@ pub fn charging_state() -> ChargingState {
         ffi::pm_charging_status_t_PM_BATTERY_IDLE => ChargingState::Idle,
         _ => panic!("Unknown charging status"),
     }
+}
+
+pub fn is_usb_connected() -> bool {
+    let mut state: ffi::pm_state_t = unsafe { core::mem::zeroed() };
+    unsafe { ffi::pm_get_state(&mut state as _) };
+    state.usb_connected
+}
+
+pub fn suspend() {
+    unsafe { ffi::pm_suspend(null_mut()) };
 }

--- a/core/embed/rust/src/trezorhal/sysevent.rs
+++ b/core/embed/rust/src/trezorhal/sysevent.rs
@@ -34,6 +34,7 @@ pub enum Syshandle {
     Button = ffi::syshandle_t_SYSHANDLE_BUTTON as _,
     Touch = ffi::syshandle_t_SYSHANDLE_TOUCH as _,
     Ble = ffi::syshandle_t_SYSHANDLE_BLE as _,
+    PowerManager = ffi::syshandle_t_SYSHANDLE_POWER_MANAGER as _,
 }
 
 impl Syshandle {

--- a/core/embed/sys/power_manager/unix/power_manager.c
+++ b/core/embed/sys/power_manager/unix/power_manager.c
@@ -31,6 +31,9 @@ pm_status_t pm_hibernate(void) {
   exit(1);
   return PM_OK;
 }
+
+pm_status_t pm_suspend(wakeup_flags_t* wakeup_reason) { exit(1); }
+
 pm_status_t pm_turn_on(void) { return PM_OK; }
 pm_status_t pm_charging_enable(void) { return PM_OK; }
 pm_status_t pm_charging_disable(void) { return PM_OK; }


### PR DESCRIPTION
This PR introduces auto dimming and auto suspending of bootloader on inactivity.

After suspending and resuming, the flow continues where it ended.

Timing is subject to further tuning.
