### PR TITLE
Fuel gauge compensation in low power mode

### DIFF
--- a/core/SConscript.prodtest
+++ b/core/SConscript.prodtest
@@ -169,6 +169,7 @@ SOURCE_PRODTEST = [
     'embed/projects/prodtest/cmd/prodtest_help.c',
     'embed/projects/prodtest/cmd/prodtest_hw_revision.c',
     'embed/projects/prodtest/cmd/prodtest_nfc.c',
+    'embed/projects/prodtest/cmd/prodtest_rtc.c',
     'embed/projects/prodtest/cmd/prodtest_nrf.c',
     'embed/projects/prodtest/cmd/prodtest_optiga.c',
     'embed/projects/prodtest/cmd/prodtest_otp_batch.c',

--- a/core/embed/projects/bootloader/main.c
+++ b/core/embed/projects/bootloader/main.c
@@ -129,6 +129,10 @@ static secbool boot_sequence(secbool manufacturing_mode) {
   haptic_init();
 #endif
 
+#ifdef USE_RTC
+  rtc_init();
+#endif
+
 #ifdef USE_POWER_MANAGER
   pm_init(false);
 
@@ -231,10 +235,6 @@ static void drivers_init(secbool manufacturing_mode,
 
 #ifdef USE_TAMPER
   tamper_init();
-#endif
-
-#ifdef USE_RTC
-  rtc_init();
 #endif
 
   display_init(DISPLAY_RESET_CONTENT);

--- a/core/embed/projects/prodtest/README.md
+++ b/core/embed/projects/prodtest/README.md
@@ -1009,6 +1009,8 @@ Example:
 nfc-write-card [<timeout_ms>]
 # NFC reader on, put the card on the reader (timeout <timeout_ms> ms)
 # Writting URI to NFC tag 7AF403
+OK
+```
 
 ### unit-test-run
 Prodtest have capability to verify the overall firmware functionality by running built-in unit tests which should excercise the basic
@@ -1033,18 +1035,14 @@ Example:
 OK
 ```
 
-### fuel-gauge
-Activates fuel gauge which monitors battery state of charge and reports it on
-display and command line, exit the fuel gauge monitor with CTRL+C
+### rtc-timestamp
+Retrieves the current RTC timestamp as a number of seconds since the device got powered up for the first time.
 
 Example:
-fuel-gauge
-# Initialize Fuel gauge.
-PROGRESS 3.123 122.13 0.281
-PROGRESS 3.125 122.18 0.281
-PROGRESS 3.123 122.13 0.280
 ```
-
+rtc-timestamp
+OK 1886533
+```
 
 
 

--- a/core/embed/projects/prodtest/cmd/prodtest_rtc.c
+++ b/core/embed/projects/prodtest/cmd/prodtest_rtc.c
@@ -1,0 +1,46 @@
+/*
+ * This file is part of the Trezor project, https://trezor.io/
+ *
+ * Copyright (c) SatoshiLabs
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#include <trezor_bsp.h>
+
+#include <rtl/cli.h>
+#include <sys/rtc.h>
+
+static void prodtest_rtc_timestamp(cli_t* cli) {
+  if (cli_arg_count(cli) > 0) {
+    cli_error_arg_count(cli);
+    return;
+  }
+
+  uint32_t timestamp;
+  if (!rtc_get_timestamp(&timestamp)) {
+    cli_error(cli, CLI_ERROR, "Failed to get RTC timestamp");
+    return;
+  }
+  cli_ok(cli, "%u", timestamp);
+}
+
+// clang-format off
+PRODTEST_CLI_CMD(
+  .name = "rtc-timestamp",
+  .func = prodtest_rtc_timestamp,
+  .info = "Read the RTC timestamp",
+  .args = ""
+);
+

--- a/core/embed/sys/power_manager/inc/sys/power_manager.h
+++ b/core/embed/sys/power_manager/inc/sys/power_manager.h
@@ -28,6 +28,7 @@ typedef enum {
   PM_OK = 0,
   PM_NOT_INITIALIZED,
   PM_REQUEST_REJECTED,
+  PM_TIMEOUT,
   PM_ERROR,
 } pm_status_t;
 

--- a/core/embed/sys/power_manager/inc/sys/power_manager.h
+++ b/core/embed/sys/power_manager/inc/sys/power_manager.h
@@ -203,3 +203,28 @@ pm_status_t pm_set_soc_limit(uint8_t limit);
  * @return pm_status_t Status code indicating success or failure
  */
 pm_status_t pm_store_data_to_backup_ram();
+
+/**
+ * @brief Suspends driver activity so the CPU can enter low-power mode.
+ *
+ * Suspending may take some time if the driver is currently
+ * performing an operation. Caller may check the status by
+ * pm_is_suspended().
+ *
+ * @return true if the power manager was successfully suspended, false otherwise
+ */
+bool pm_driver_suspend(void);
+
+/**
+ * @brief Resume the power manager after it has been suspended
+ *
+ * @return true if the power manager was successfully resumed, false otherwise
+ *  */
+bool pm_driver_resume(void);
+
+/**
+ * @brief Check if the power manager is suspended
+ *
+ * @return true if the power manager is suspended, false otherwise
+ */
+bool pm_driver_is_suspended(void);

--- a/core/embed/sys/power_manager/stm32u5/power_manager.c
+++ b/core/embed/sys/power_manager/stm32u5/power_manager.c
@@ -31,6 +31,7 @@
 #include <sys/rtc.h>
 #endif
 
+#include "../fuel_gauge/battery_model.h"
 #include "../power_manager_poll.h"
 #include "../stwlc38/stwlc38.h"
 #include "power_manager_internal.h"
@@ -44,6 +45,7 @@ pm_driver_t g_pm = {
 static void pm_monitoring_timer_handler(void* context);
 static void pm_shutdown_timer_handler(void* context);
 static bool pm_load_recovery_data(pm_recovery_data_t* recovery);
+static pm_status_t pm_wait_to_stabilize(pm_driver_t* drv, uint32_t timeout_ms);
 
 pm_status_t pm_init(bool inherit_state) {
   pm_driver_t* drv = &g_pm;
@@ -142,14 +144,12 @@ pm_status_t pm_init(bool inherit_state) {
 
   irq_unlock(irq_key);
 
-  // Poll until fuel_gauge is initialized and first PMIC & WLC measurements
-  // propagates into power_monitor.
-  bool state_machine_stabilized;
-  do {
-    irq_key_t irq_key = irq_lock();
-    state_machine_stabilized = drv->state_machine_stabilized;
-    irq_unlock(irq_key);
-  } while (!state_machine_stabilized);
+  // Wait to stabilize the state machine
+  pm_status_t status = pm_wait_to_stabilize(drv, PM_STABILIZATION_TIMEOUT_MS);
+  if (status != PM_OK) {
+    pm_deinit();
+    return status;
+  }
 
   drv->initialized = true;
 
@@ -210,22 +210,15 @@ pm_status_t pm_get_state(pm_state_t* state) {
 }
 
 // This callback is called from inside the system_suspend() function
-// when the rtc wake-up timer expires. The callback can perform
-// measurements and update the fuel gauge state.
+// when the rtc wake-up timer expires.
 // - The callback can schedule the next wake-up by calling
 // rtc_wakeup_timer_start().
 // - If the callback return with wakeup_flags set, system_suspend() returns.
 #ifdef USE_RTC
 void pm_rtc_wakeup_callback(void* context) {
-  // TODO: update fuel gauge state
-  // TODO: decide whether to reschedule the next wake-up or wake up the coreapp
-  if (true) {
-    // Reschedule the next wake-up
-    rtc_wakeup_timer_start(10, pm_rtc_wakeup_callback, NULL);
-  } else {
-    // Wake up the coreapp
-    wakeup_flags_set(WAKEUP_FLAG_RTC);
-  }
+  // No need to do anything here, but left as a placeholder for potential
+  // future use. This is an optimal place where to set a wakeup flag from RTC
+  // wakeup_flags_set(WAKEUP_FLAG_RTC);
 }
 #endif
 
@@ -247,6 +240,7 @@ pm_status_t pm_suspend(wakeup_flags_t* wakeup_reason) {
 
   // Something went wrong, suspend request was not accepted
   if (drv->request_suspend == true || drv->state != PM_STATE_SUSPEND) {
+    drv->request_suspend = false;
     irq_unlock(irq_key);
     return PM_REQUEST_REJECTED;
   }
@@ -254,15 +248,13 @@ pm_status_t pm_suspend(wakeup_flags_t* wakeup_reason) {
   irq_unlock(irq_key);
 
 #ifdef USE_RTC
-  // Automatically wakes up after specified time and call pm_rtc_wakeup_callback
-  rtc_wakeup_timer_start(10, pm_rtc_wakeup_callback, NULL);
+  // Read the current timestamp before entering suspend mode
+  if (!rtc_get_timestamp(&drv->suspend_timestamp)) {
+    return PM_ERROR;
+  }
 #endif
 
   wakeup_flags_t wakeup_flags = system_suspend();
-
-#ifdef USE_RTC
-  rtc_wakeup_timer_stop();
-#endif
 
   // TODO: Handle wake-up flags
   // UNUSED(wakeup_flags);
@@ -539,6 +531,40 @@ bool pm_driver_suspend(void) {
     return false;
   }
 
+#ifdef USE_RTC
+
+  // Capture the timestamp when device was active for the last time.
+  if (!rtc_get_timestamp(&drv->last_active_timestamp)) {
+    return false;
+  }
+
+  if (drv->usb_connected || drv->wireless_connected) {
+    drv->suspended_charging = true;
+
+    // External power source is connected, wake up early to update the fuel
+    // gauge
+    rtc_wakeup_timer_start(PM_SUSPENDED_CHARGING_TIMEOUT_S,
+                           pm_rtc_wakeup_callback, NULL);
+
+  } else {
+    if ((drv->last_active_timestamp - drv->suspend_timestamp) >=
+        PM_AUTO_HIBERNATE_TIMEOUT_S) {
+      // Device is very long time in suspend mode without external power source,
+      // hibernate it to save power.
+      pm_hibernate();
+    }
+
+    uint32_t time_to_hibernate =
+        PM_AUTO_HIBERNATE_TIMEOUT_S -
+        (drv->last_active_timestamp - drv->suspend_timestamp);
+
+    drv->suspended_charging = false;
+
+    rtc_wakeup_timer_start(time_to_hibernate, pm_rtc_wakeup_callback, NULL);
+  }
+
+#endif
+
   irq_key_t irq_key = irq_lock();
   systimer_delete(drv->monitoring_timer);
   irq_unlock(irq_key);
@@ -553,6 +579,17 @@ bool pm_driver_resume(void) {
     return false;
   }
 
+  drv->woke_up_from_suspend = true;
+
+#ifdef USE_RTC
+  rtc_wakeup_timer_stop();
+
+  uint32_t rtc_timestamp;
+  rtc_get_timestamp(&rtc_timestamp);
+  drv->time_in_suspend_s = (rtc_timestamp - drv->last_active_timestamp);
+
+#endif
+
   // Recreate the monitoring timer
   drv->monitoring_timer = systimer_create(pm_monitoring_timer_handler, NULL);
   if (drv->monitoring_timer == NULL) {
@@ -565,12 +602,46 @@ bool pm_driver_resume(void) {
   // Set the periodic sampling period
   systimer_set_periodic(drv->monitoring_timer, PM_BATTERY_SAMPLING_PERIOD_MS);
 
+  // Wait for pmic measurements to stabilize the fuel gauge estimation.
+  pm_status_t status = pm_wait_to_stabilize(drv, PM_STABILIZATION_TIMEOUT_MS);
+  if (status != PM_OK) {
+    // timeout during state machine stabilization
+    return false;
+  }
   return true;
 }
 
 bool pm_driver_is_suspended(void) {
   // No specific pending tasks, just return true
   return true;
+}
+
+void pm_compensate_fuel_gauge(float* soc, uint32_t elapsed_s,
+                              float battery_current_ma, float bat_temp_c) {
+  float compensation_mah = ((battery_current_ma)*elapsed_s) / 3600.0f;
+  bool discharging_mode = battery_current_ma >= 0.0f;
+  *soc -=
+      (compensation_mah / battery_total_capacity(bat_temp_c, discharging_mode));
+  return;
+}
+
+static pm_status_t pm_wait_to_stabilize(pm_driver_t* drv, uint32_t timeout_ms) {
+  uint32_t expire_time = ticks_timeout(timeout_ms);
+
+  // Poll until fuel_gauge is initialized and first PMIC & WLC measurements
+  // propagates into power_monitor.
+  bool state_machine_stabilized;
+  do {
+    if (ticks_expired(expire_time)) {
+      return PM_TIMEOUT;
+    }
+
+    irq_key_t irq_key = irq_lock();
+    state_machine_stabilized = drv->state_machine_stabilized;
+    irq_unlock(irq_key);
+  } while (!state_machine_stabilized);
+
+  return PM_OK;
 }
 
 #endif

--- a/core/embed/sys/power_manager/stm32u5/power_manager.c
+++ b/core/embed/sys/power_manager/stm32u5/power_manager.c
@@ -78,14 +78,14 @@ pm_status_t pm_init(bool inherit_state) {
     return PM_ERROR;
   }
 
-  systimer_set_periodic(drv->monitoring_timer, PM_BATTERY_SAMPLING_PERIOD_MS);
-
   // Create shutdown timer
   drv->shutdown_timer = systimer_create(pm_shutdown_timer_handler, NULL);
   if (drv->shutdown_timer == NULL) {
     pm_deinit();
     return PM_ERROR;
   }
+
+  systimer_set_periodic(drv->monitoring_timer, PM_BATTERY_SAMPLING_PERIOD_MS);
 
   // Initial power source measurement
   pmic_measure(pm_pmic_data_ready, NULL);
@@ -530,6 +530,47 @@ static void pm_shutdown_timer_handler(void* context) {
   pm_driver_t* drv = &g_pm;
   drv->shutdown_timer_elapsed = true;
   pm_process_state_machine();
+}
+
+bool pm_driver_suspend(void) {
+  pm_driver_t* drv = &g_pm;
+
+  if (!drv->initialized) {
+    return false;
+  }
+
+  irq_key_t irq_key = irq_lock();
+  systimer_delete(drv->monitoring_timer);
+  irq_unlock(irq_key);
+
+  return true;
+}
+
+bool pm_driver_resume(void) {
+  pm_driver_t* drv = &g_pm;
+
+  if (!drv->initialized) {
+    return false;
+  }
+
+  // Recreate the monitoring timer
+  drv->monitoring_timer = systimer_create(pm_monitoring_timer_handler, NULL);
+  if (drv->monitoring_timer == NULL) {
+    return false;
+  }
+
+  // Request new pmic measurement
+  pmic_measure(pm_pmic_data_ready, NULL);
+
+  // Set the periodic sampling period
+  systimer_set_periodic(drv->monitoring_timer, PM_BATTERY_SAMPLING_PERIOD_MS);
+
+  return true;
+}
+
+bool pm_driver_is_suspended(void) {
+  // No specific pending tasks, just return true
+  return true;
 }
 
 #endif

--- a/core/embed/sys/power_manager/stm32u5/power_manager_internal.h
+++ b/core/embed/sys/power_manager/stm32u5/power_manager_internal.h
@@ -40,12 +40,22 @@
 #define PM_BATTERY_CHARGING_CURRENT_MIN PMIC_CHARGING_LIMIT_MIN
 #define PM_BATTERY_SAMPLING_BUF_SIZE 10
 
+#define PM_SELF_DISG_RATE_HIBERATION_MAH 0.004f
+#define PM_SELF_DISG_RATE_SUSPEND_MAH 0.032f
+
 // Fuel gauge extended kalman filter parameters
 #define PM_FUEL_GAUGE_R 2000.0f
 #define PM_FUEL_GAUGE_Q 0.001f
 #define PM_FUEL_GAUGE_R_AGGRESSIVE 1000.0f
 #define PM_FUEL_GAUGE_Q_AGGRESSIVE 0.001f
 #define PM_FUEL_GAUGE_P_INIT 0.1f
+
+// Timeout after which the device automatically transit from suspend to
+// hibernation
+#define PM_AUTO_HIBERNATE_TIMEOUT_S (24 * 60 * 60)  // 24 hours
+
+#define PM_SUSPENDED_CHARGING_TIMEOUT_S 60
+#define PM_STABILIZATION_TIMEOUT_MS 2000
 
 // Power manager battery sampling data structure
 typedef struct {
@@ -81,6 +91,8 @@ typedef struct {
   uint32_t pmic_last_update_ms;
   uint32_t pmic_sampling_period_ms;
   bool pmic_measurement_ready;
+  bool woke_up_from_suspend;
+  bool suspended_charging;
 
   // Power source logical state
   bool usb_connected;
@@ -95,9 +107,12 @@ typedef struct {
   bool request_turn_on;
   bool shutdown_timer_elapsed;
 
-  // Timers
+  // Timers and timestamps
   systimer_t* monitoring_timer;
   systimer_t* shutdown_timer;
+  uint32_t suspend_timestamp;
+  uint32_t last_active_timestamp;
+  uint32_t time_in_suspend_s;
 
 } pm_driver_t;
 
@@ -130,3 +145,10 @@ void pm_charging_controller(pm_driver_t* drv);
 // Battery initial state of charge guess function. This function use the sampled
 // battery data to guess the initial state of charge in case its unknown.
 void pm_battery_initial_soc_guess(void);
+
+// Direct coulomb counter compensation of the SoC based on the battery current,
+// temp and elapsed time, this function is used to compensate the fuel gauge
+// estimation during the periods where the EKF could not be used, such as
+// suspend or hibernation.
+void pm_compensate_fuel_gauge(float* soc, uint32_t elapsed_s,
+                              float battery_current_mah, float bat_temp_c);

--- a/core/embed/sys/power_manager/stm32u5/power_states.c
+++ b/core/embed/sys/power_manager/stm32u5/power_states.c
@@ -164,6 +164,11 @@ static pm_power_status_t pm_handle_state_charging(pm_driver_t* drv) {
 }
 
 static pm_power_status_t pm_handle_state_suspend(pm_driver_t* drv) {
+  if (drv->request_hibernate) {
+    drv->request_hibernate = false;
+    return PM_STATE_HIBERNATE;
+  }
+
   if (drv->request_exit_suspend) {
     drv->request_exit_suspend = false;
     return PM_STATE_POWER_SAVE;

--- a/core/embed/sys/suspend/stm32u5/suspend.c
+++ b/core/embed/sys/suspend/stm32u5/suspend.c
@@ -27,6 +27,7 @@
 
 #include <../../power_manager/stwlc38/stwlc38.h>
 #include <sys/pmic.h>
+#include <sys/power_manager.h>
 
 static wakeup_flags_t g_wakeup_flags = 0;
 
@@ -110,17 +111,20 @@ wakeup_flags_t system_suspend(void) {
 }
 
 static void background_tasks_suspend(void) {
+  pm_driver_suspend();
   pmic_suspend();
   stwlc38_suspend();
 }
 
 static bool background_tasks_suspended(void) {
-  return pmic_is_suspended() && stwlc38_is_suspended();
+  return pmic_is_suspended() && stwlc38_is_suspended() &&
+         pm_driver_is_suspended();
 }
 
 static void background_tasks_resume(void) {
   stwlc38_resume();
   pmic_resume();
+  pm_driver_resume();
 }
 
 #endif  // defined(KERNEL_MODE) && !defined(SECMON)

--- a/core/embed/sys/time/inc/sys/rtc.h
+++ b/core/embed/sys/time/inc/sys/rtc.h
@@ -19,6 +19,8 @@
 
 #pragma once
 
+#include <trezor_bsp.h>
+
 /**
  * @brief Initialize the RTC driver
  *
@@ -28,6 +30,18 @@
  * @return true if initialization was successful, false otherwise
  */
 bool rtc_init(void);
+
+/**
+ * @brief Get the current timestamp from the RTC
+ *
+ * Retrieves the current timestamp as a number of seconds since the device got
+ * powered up for the first time. The timestamp is calculated based on the
+ * current date and time stored in the RTC.
+ *
+ * @param timestamp Pointer to a variable where the timestamp will be stored.
+ * @return true if the timestamp was successfully retrieved, false otherwise
+ */
+bool rtc_get_timestamp(uint32_t* timestamp);
 
 /**
  * @brief Callback invoked when the RTC wakeup event occurs

--- a/core/embed/sys/time/stm32u5/rtc.c
+++ b/core/embed/sys/time/stm32u5/rtc.c
@@ -72,6 +72,34 @@ bool rtc_init(void) {
   return true;
 }
 
+bool rtc_get_timestamp(uint32_t* timestamp) {
+  rtc_driver_t* drv = &g_rtc_driver;
+
+  if (!drv->initialized || timestamp == NULL) {
+    return false;
+  }
+
+  RTC_DateTypeDef date;
+  RTC_TimeTypeDef time;
+
+  // Get current time and date, date has to be read first.
+  if (HAL_OK != HAL_RTC_GetTime(&drv->hrtc, &time, RTC_FORMAT_BIN)) {
+    return false;
+  }
+
+  // Get the current date
+  if (HAL_OK != HAL_RTC_GetDate(&drv->hrtc, &date, RTC_FORMAT_BIN)) {
+    return false;
+  }
+
+  *timestamp =
+      ((date.Year * 365 * 24 * 3600) + ((date.Month - 1) * 30 * 24 * 3600) +
+       ((date.Date - 1) * 24 * 3600) + (time.Hours * 3600) +
+       (time.Minutes * 60) + time.Seconds);
+
+  return true;
+}
+
 bool rtc_wakeup_timer_start(uint32_t seconds, rtc_wakeup_callback_t callback,
                             void* context) {
   rtc_driver_t* drv = &g_rtc_driver;


### PR DESCRIPTION
This PR introduces fuel gauge compensation in low power modes, as well as fuel gauge updates during charging in suspend mode. It builds upon the enhanced suspend logic implemented in PR https://github.com/trezor/trezor-firmware/pull/5235

The first two commits add an `rtc_get_timestamp()` function to the RTC library, which returns a timestamp representing the number of seconds since the device was powered on. Additionally, a prodtest command is introduced to retrieve and display the current timestamp in the console.

The power manager has been restructured to allow it to operate as a background task within the suspend module. As part of this, the functions `pm_driver_suspend()`, `pm_driver_is_suspended()`, and `pm_driver_resume()` were added. The power monitoring logic was also improved: instead of using the systimer to both wait for and process PMIC data, the systimer now only triggers PMIC data acquisition, and the PMIC callback handles data processing.

Finally, fuel gauge compensation was implemented to improve state-of-charge (SoC) estimation while the device is in low power mode and the typical fuel gauge estimation loop is not running.

Fuel gauge compensation has three scenarios:

1) Hibernation mode:
The RTC timestamp is now included in the power manager's recovery data stored in backup RAM. This allows the device to track how long it remained in hibernation. Upon initialization in the bootloader, the power manager compensates the state of charge (SoC) using the known hibernation current consumption and the elapsed time. Since the device temperature during hibernation is unknown, battery curves for 25 °C are used for this calculation.

2) Suspend mode (not charging):
When entering suspend mode, the RTC timestamp is recorded. Upon wake-up, the power manager compensates the SoC based on the known current consumption during suspend. Additionally, an auto-hibernation feature has been added: if there is no activity for 24 hours, the device will automatically enter hibernation to conserve power.

3) Suspend mode (charging):
In this mode, the device enters suspend but wakes up every 60 seconds to measure the charging current and update the SoC. If external power is disconnected, the device automatically transitions to the non-charging suspend scenario (2) without waking up.




 


