### PR TITLE
Introduce menu-related layouts for Delizia

### DIFF
--- a/core/embed/rust/src/ui/api/firmware_micropython.rs
+++ b/core/embed/rust/src/ui/api/firmware_micropython.rs
@@ -746,9 +746,13 @@ extern "C" fn new_select_menu(n_args: usize, args: *const Obj, kwargs: *mut Map)
     let block = move |_args: &[Obj], kwargs: &Map| {
         let items_iterable: Obj = kwargs.get(Qstr::MP_QSTR_items)?;
         let items = util::iter_into_vec(items_iterable)?;
-        let page_counter: usize = kwargs.get(Qstr::MP_QSTR_page_counter)?.try_into()?;
+        let current = kwargs.get(Qstr::MP_QSTR_current)?.try_into()?;
+        let cancel = kwargs
+            .get(Qstr::MP_QSTR_cancel)
+            .and_then(Obj::try_into_option)
+            .unwrap_or(None);
 
-        let layout = ModelUI::select_menu(items, page_counter)?;
+        let layout = ModelUI::select_menu(items, current, cancel)?;
         Ok(LayoutObj::new_root(layout)?.into())
     };
     unsafe { util::try_with_args_and_kwargs(n_args, args, kwargs, block) }
@@ -1692,7 +1696,8 @@ pub static mp_module_trezorui_api: Module = obj_module! {
     /// def select_menu(
     ///     *,
     ///     items: Iterable[str],
-    ///     page_counter: int = 0,
+    ///     current: int,
+    ///     cancel: str | None = None
     /// ) -> LayoutObj[int]:
     ///     """Select an item from a menu. Returns index in range `0..len(items)`."""
     Qstr::MP_QSTR_select_menu => obj_fn_kw!(0, new_select_menu).as_obj(),

--- a/core/embed/rust/src/ui/layout_bolt/ui_firmware.rs
+++ b/core/embed/rust/src/ui/layout_bolt/ui_firmware.rs
@@ -714,7 +714,8 @@ impl FirmwareUI for UIBolt {
 
     fn select_menu(
         _items: heapless::Vec<TString<'static>, MAX_MENU_ITEMS>,
-        _page_counter: usize,
+        _current: usize,
+        _cancel: Option<TString<'static>>,
     ) -> Result<impl LayoutMaybeTrace, Error> {
         Err::<RootComponent<Empty, ModelUI>, Error>(ERROR_NOT_IMPLEMENTED)
     }

--- a/core/embed/rust/src/ui/layout_caesar/ui_firmware.rs
+++ b/core/embed/rust/src/ui/layout_caesar/ui_firmware.rs
@@ -902,12 +902,13 @@ impl FirmwareUI for UICaesar {
 
     fn select_menu(
         items: heapless::Vec<TString<'static>, MAX_MENU_ITEMS>,
-        page_counter: usize,
+        current: usize,
+        _cancel: Option<TString<'static>>,
     ) -> Result<impl LayoutMaybeTrace, Error> {
         // Returning the index of the selected menu item
         let layout = RootComponent::new(
             SimpleChoice::new(items, ChoiceControls::Cancellable, TR::buttons__view.into())
-                .with_initial_page_counter(page_counter)
+                .with_initial_page_counter(current)
                 .with_show_incomplete()
                 .with_return_index(),
         );

--- a/core/embed/rust/src/ui/layout_delizia/flow/util.rs
+++ b/core/embed/rust/src/ui/layout_delizia/flow/util.rs
@@ -13,7 +13,10 @@ use crate::{
             },
             Component,
         },
-        flow::{FlowMsg, Swipable, SwipeFlow, SwipePage},
+        flow::{
+            base::{Decision, DecisionBuilder},
+            FlowController, FlowMsg, Swipable, SwipeFlow, SwipePage,
+        },
         geometry::Direction,
         layout::util::{ConfirmValueParams, StrOrBytes},
     },
@@ -484,4 +487,32 @@ pub fn map_to_choice(msg: VerticalMenuChoiceMsg) -> Option<FlowMsg> {
     match msg {
         VerticalMenuChoiceMsg::Selected(i) => Some(FlowMsg::Choice(i)),
     }
+}
+
+enum SinglePage {
+    Show,
+}
+
+impl FlowController for SinglePage {
+    #[inline]
+    fn index(&'static self) -> usize {
+        0
+    }
+
+    fn handle_swipe(&'static self, _direction: Direction) -> Decision {
+        self.do_nothing()
+    }
+
+    fn handle_event(&'static self, msg: FlowMsg) -> Decision {
+        self.return_msg(msg)
+    }
+}
+
+pub fn single_page<T>(layout: T) -> Result<SwipeFlow, Error>
+where
+    T: Component<Msg = FlowMsg> + Swipable + MaybeTrace + 'static,
+{
+    let mut flow = SwipeFlow::new(&SinglePage::Show)?;
+    flow.add_page(&SinglePage::Show, layout)?;
+    Ok(flow)
 }

--- a/core/embed/rust/src/ui/layout_delizia/ui_firmware.rs
+++ b/core/embed/rust/src/ui/layout_delizia/ui_firmware.rs
@@ -782,7 +782,8 @@ impl FirmwareUI for UIDelizia {
 
     fn select_menu(
         _items: heapless::Vec<TString<'static>, MAX_MENU_ITEMS>,
-        _page_counter: usize,
+        _current: usize,
+        _cancel: Option<TString<'static>>,
     ) -> Result<impl LayoutMaybeTrace, Error> {
         Err::<RootComponent<Empty, ModelUI>, Error>(ERROR_NOT_IMPLEMENTED)
     }

--- a/core/embed/rust/src/ui/layout_eckhart/ui_firmware.rs
+++ b/core/embed/rust/src/ui/layout_eckhart/ui_firmware.rs
@@ -902,7 +902,8 @@ impl FirmwareUI for UIEckhart {
 
     fn select_menu(
         _items: heapless::Vec<TString<'static>, MAX_MENU_ITEMS>,
-        _page_counter: usize,
+        _current: usize,
+        _cancel: Option<TString<'static>>,
     ) -> Result<impl LayoutMaybeTrace, Error> {
         Err::<RootComponent<Empty, ModelUI>, Error>(ERROR_NOT_IMPLEMENTED)
     }

--- a/core/embed/rust/src/ui/ui_firmware.rs
+++ b/core/embed/rust/src/ui/ui_firmware.rs
@@ -279,7 +279,8 @@ pub trait FirmwareUI {
 
     fn select_menu(
         items: heapless::Vec<TString<'static>, MAX_MENU_ITEMS>,
-        page_counter: usize,
+        current: usize,
+        cancel: Option<TString<'static>>,
     ) -> Result<impl LayoutMaybeTrace, Error>;
 
     fn select_word(

--- a/core/mocks/generated/trezorui_api.pyi
+++ b/core/mocks/generated/trezorui_api.pyi
@@ -481,7 +481,8 @@ def request_passphrase(
 def select_menu(
     *,
     items: Iterable[str],
-    page_counter: int = 0,
+    current: int,
+    cancel: str | None = None
 ) -> LayoutObj[int]:
     """Select an item from a menu. Returns index in range `0..len(items)`."""
 


### PR DESCRIPTION
Rebased over https://github.com/trezor/trezor-firmware/pull/5295.

Can be tested using the following snippet:
```python
from trezor.ui.layouts.menu import Details, Menu, Properties, show_menu

menu = Menu.root(
    Details("Blockhash", Properties.data("00000000000000000000e8e69d805078afa15947eaf0cc3fe0a9f563da20f93c")),
    Details("Fee info", Properties.paragraphs(fee_details)),
    cancel=TR.send__cancel_sign,
)
await show_menu(menu, br_name=None)
```
[Screencast from 2025-07-03 18-16-03.webm](https://github.com/user-attachments/assets/ac9b15da-9a60-4753-b2bf-ff902ba14554)

Currently supports up to 3 items per menu.

<!--
For core developers:
- Assign yourself to the PR.
- Set the priority to match the original issue.
- Add the PR to the current sprint.
- If it's a draft PR, mark it as "In Progress."
- If it's a final PR, mark it as "Needs Review."

For external contributors:
- Please open an issue before submitting a PR so we can discuss whether we want to proceed with it.
-->
