### PR TITLE
fix(core): don't ignore `ActionCancelled` exception from menu

### DIFF
--- a/core/embed/rust/src/ui/api/firmware_micropython.rs
+++ b/core/embed/rust/src/ui/api/firmware_micropython.rs
@@ -1887,7 +1887,7 @@ pub static mp_module_trezorui_api: Module = obj_module! {
     ///     *,
     ///     title: str,
     ///     value: list[tuple[str, str]] | str,
-    /// ) -> LayoutObj[int]:
+    /// ) -> LayoutObj[None]:
     ///     """Show a list of key-value pairs, or a chunkified string."""
     Qstr::MP_QSTR_show_properties => obj_fn_kw!(0, new_show_properties).as_obj(),
 

--- a/core/embed/rust/src/ui/layout_caesar/component_msg_obj.rs
+++ b/core/embed/rust/src/ui/layout_caesar/component_msg_obj.rs
@@ -3,7 +3,7 @@ use core::convert::TryInto;
 use super::component::{
     AddressDetails, ButtonPage, CancelConfirmMsg, CancelInfoConfirmMsg, CoinJoinProgress,
     ConfirmHomescreen, Flow, Frame, Homescreen, Lockscreen, NumberInput, Page, PassphraseEntry,
-    PinEntry, Progress, ScrollableContent, ScrollableFrame, ShowMore, SimpleChoice, WordlistEntry,
+    PinEntry, Progress, ScrollableContent, ScrollableFrame, ShowMore, WordlistEntry,
 };
 use crate::{
     error::Error,
@@ -120,22 +120,6 @@ impl ComponentMsgObj for NumberInput {
         match msg {
             Self::Msg::Cancel => (CANCELLED.as_obj(), 0.try_into()?).try_into(),
             Self::Msg::Choice { item, .. } => (CONFIRMED.as_obj(), item.try_into()?).try_into(),
-        }
-    }
-}
-
-impl ComponentMsgObj for SimpleChoice {
-    fn msg_try_into_obj(&self, msg: Self::Msg) -> Result<Obj, Error> {
-        match msg {
-            Self::Msg::Cancel => Ok(CANCELLED.as_obj()),
-            Self::Msg::Choice { item, .. } => {
-                if self.return_index {
-                    item.try_into()
-                } else {
-                    let text = self.result_by_index(item);
-                    text.try_into()
-                }
-            }
         }
     }
 }

--- a/core/embed/rust/src/ui/layout_caesar/ui_firmware.rs
+++ b/core/embed/rust/src/ui/layout_caesar/ui_firmware.rs
@@ -910,7 +910,8 @@ impl FirmwareUI for UICaesar {
             SimpleChoice::new(items, ChoiceControls::Cancellable, TR::buttons__view.into())
                 .with_initial_page_counter(current)
                 .with_show_incomplete()
-                .with_return_index(),
+                .with_return_index()
+                .with_ignore_cancelled(),
         );
         Ok(layout)
     }

--- a/core/embed/rust/src/ui/layout_delizia/flow/set_brightness.rs
+++ b/core/embed/rust/src/ui/layout_delizia/flow/set_brightness.rs
@@ -18,7 +18,7 @@ use crate::{
 use super::super::{
     component::{
         number_input_slider::{NumberInputSliderDialog, NumberInputSliderDialogMsg},
-        Footer, Frame, PromptMsg, PromptScreen, StatusScreen, SwipeContent, VerticalMenu,
+        Footer, Frame, PromptMsg, PromptScreen, StatusScreen, SwipeContent,
     },
     theme,
 };
@@ -26,7 +26,6 @@ use super::super::{
 #[derive(Copy, Clone, PartialEq, Eq, ToPrimitive)]
 pub enum SetBrightness {
     Slider,
-    Menu,
     Confirm,
     Confirmed,
 }
@@ -48,11 +47,9 @@ impl FlowController for SetBrightness {
 
     fn handle_event(&'static self, msg: FlowMsg) -> Decision {
         match (self, msg) {
-            (Self::Slider, FlowMsg::Info) => Self::Menu.swipe_left(),
-            (Self::Menu, FlowMsg::Cancelled) => Self::Slider.swipe_right(),
-            (Self::Menu, FlowMsg::Choice(0)) => self.return_msg(FlowMsg::Cancelled),
+            (Self::Slider, FlowMsg::Info) => self.return_msg(FlowMsg::Info),
             (Self::Confirm, FlowMsg::Confirmed) => Self::Confirmed.swipe_up(),
-            (Self::Confirm, FlowMsg::Info) => Self::Menu.swipe_left(),
+            (Self::Confirm, FlowMsg::Info) => self.return_msg(FlowMsg::Info),
             (Self::Confirmed, FlowMsg::Confirmed) => self.return_msg(FlowMsg::Confirmed),
             _ => self.do_nothing(),
         }
@@ -101,13 +98,6 @@ pub fn new_set_brightness(brightness: Option<u8>) -> Result<SwipeFlow, Error> {
         }
     });
 
-    let content_menu = Frame::left_aligned(
-        "".into(),
-        VerticalMenu::empty().danger(theme::ICON_CANCEL, TR::buttons__cancel.into()),
-    )
-    .with_cancel_button()
-    .map(super::util::map_to_choice);
-
     let content_confirm = Frame::left_aligned(
         TR::brightness__change_title.into(),
         SwipeContent::new(PromptScreen::new_tap_to_confirm()),
@@ -136,7 +126,6 @@ pub fn new_set_brightness(brightness: Option<u8>) -> Result<SwipeFlow, Error> {
 
     let mut res = SwipeFlow::new(&SetBrightness::Slider)?;
     res.add_page(&SetBrightness::Slider, content_slider)?
-        .add_page(&SetBrightness::Menu, content_menu)?
         .add_page(&SetBrightness::Confirm, content_confirm)?
         .add_page(&SetBrightness::Confirmed, content_confirmed)?;
 

--- a/core/mocks/generated/trezorui_api.pyi
+++ b/core/mocks/generated/trezorui_api.pyi
@@ -692,7 +692,7 @@ def show_properties(
     *,
     title: str,
     value: list[tuple[str, str]] | str,
-) -> LayoutObj[int]:
+) -> LayoutObj[None]:
     """Show a list of key-value pairs, or a chunkified string."""
 
 

--- a/core/src/trezor/ui/layouts/delizia/__init__.py
+++ b/core/src/trezor/ui/layouts/delizia/__init__.py
@@ -1563,8 +1563,11 @@ def confirm_firmware_update(description: str, fingerprint: str) -> Awaitable[Non
 
 
 def set_brightness(current: int | None = None) -> Awaitable[None]:
-    return raise_if_not_confirmed(
+    from trezor.ui.layouts.menu import Menu, confirm_with_menu
+
+    return confirm_with_menu(
         trezorui_api.set_brightness(current=current),
+        Menu.root(cancel=TR.buttons__cancel),
         "set_brightness",
         BR_CODE_OTHER,
     )

--- a/core/src/trezor/ui/layouts/menu.py
+++ b/core/src/trezor/ui/layouts/menu.py
@@ -62,18 +62,20 @@ async def show_menu(
                 current=current_item,
                 cancel=menu.cancel,
             )
+            choice = await interact(layout, br_name, br_code)
+            if isinstance(choice, int):
+                # go one level down
+                menu_path.append(choice)
+                current_item = 0
+                continue
         else:
             layout = trezorui_api.show_properties(
                 title=menu.name,
                 value=menu.value,
             )
+            await interact(layout, br_name, br_code, raise_on_cancel=None)
 
-        choice = await interact(layout, br_name, br_code, raise_on_cancel=None)
-        if isinstance(choice, int):
-            menu_path.append(choice)
-            current_item = 0
-            continue
-
+        # go one level up, or exit the menu
         if menu_path:
             current_item = menu_path.pop()
         else:

--- a/python/src/trezorlib/debuglink.py
+++ b/python/src/trezorlib/debuglink.py
@@ -954,8 +954,8 @@ class DebugUI:
             # paginate to next menu item
             self.debuglink.press_right()
 
-        # cancel info menu layout
-        self.debuglink.press_no()
+        # confirm info menu layout
+        self.debuglink.press_yes()
 
     def _paginate_and_confirm(self, pages: int | None) -> None:
         if pages is None:

--- a/tests/device_tests/test_msg_applysettings.py
+++ b/tests/device_tests/test_msg_applysettings.py
@@ -23,7 +23,7 @@ from trezorlib.debuglink import LayoutType
 from trezorlib.debuglink import TrezorClientDebugLink as Client
 from trezorlib.tools import parse_path
 
-from ..input_flows import InputFlowConfirmAllWarnings
+from ..input_flows import InputFlowCancelBrightness, InputFlowConfirmAllWarnings
 
 HERE = Path(__file__).parent.resolve()
 
@@ -478,3 +478,8 @@ def test_label_too_long(client: Client):
 @pytest.mark.setup_client(pin=None)
 def test_set_brightness(client: Client):
     device.set_brightness(client, None)
+
+    with pytest.raises(exceptions.Cancelled), client:
+        IF = InputFlowCancelBrightness(client)
+        client.set_input_flow(IF.get())
+        device.set_brightness(client, None)

--- a/tests/input_flows.py
+++ b/tests/input_flows.py
@@ -2999,3 +2999,14 @@ class InputFlowFidoConfirm(InputFlowBase):
         while True:
             yield
             self.debug.press_yes()
+
+
+class InputFlowCancelBrightness(InputFlowBase):
+    def input_flow_bolt(self) -> BRGeneratorType:
+        yield
+        self.debug.click(self.debug.screen_buttons.cancel())
+
+    def input_flow_delizia(self):
+        yield
+        self.debug.click(self.debug.screen_buttons.menu())
+        self.debug.click(self.debug.screen_buttons.vertical_menu_items()[0])


### PR DESCRIPTION
~Rebased over #5296.~

In Delizia, it should be possible to cancel the flow using the menu.

In Caesar, the menu doesn't support cancellation - so it should return `CONFIRMED` instead.

Also, allow menu details (the leaves of the menu hierarchy) to be generic awaitables.
It should be useful for [payment requests confirmation UI](https://github.com/trezor/trezor-firmware/pull/5253).

Tested by replacing `set_brightness` menu in Delizia.