### PR TITLE
Unify SLIP-21 paths used in FW

### DIFF
--- a/core/src/apps/thp/credential_manager.py
+++ b/core/src/apps/thp/credential_manager.py
@@ -12,22 +12,23 @@ from trezor.wire.message_handler import wrap_protobuf_load
 if TYPE_CHECKING:
     from apps.common.paths import Slip21Path
 
+_THP_CREDENTIAL_KEY_PATH_PREFIX = [b"TREZOR", b"THP credential authentication key"]
+
 
 def derive_cred_auth_key() -> bytes:
     """
-    Derive current credential authentication mac-ing key from device secret.
+    Derive the current THP credential authentication mac-ing key from the device secret.
     """
     from storage.device import get_cred_auth_key_counter, get_device_secret
 
     from apps.common.seed import Slip21Node
 
     # Derive the key using SLIP-21 https://github.com/satoshilabs/slips/blob/master/slip-0021.md,
-    # the derivation path is m/"Credential authentication key"/(counter 4-byte BE)
+    # the derivation path is m/"TREZOR"/"THP credential authentication key"/(counter 4-byte BE)
 
     thp_secret = get_device_secret()
-    label = b"Credential authentication key"
     counter = get_cred_auth_key_counter()
-    path: Slip21Path = [label, counter]
+    path: Slip21Path = _THP_CREDENTIAL_KEY_PATH_PREFIX + [counter]
 
     symmetric_key_node: Slip21Node = Slip21Node(thp_secret)
     symmetric_key_node.derive_path(path)


### PR DESCRIPTION
All `SLIP-21` paths in FW start either with the `"SLIP-XXXX"` prefix if they are used for a purpose defined in some SLIP, or with `"TREZOR"` prefix when the purpose is not part of any SLIP.

This PR adds the `"TREZOR"` prefix to the THP credential key derivation path. The path is also modified to reflect that the credential key is used for THP and not other type of Trezor-specific credentials.
