### PR TITLE
fix(core): fix displaying RSOD in bootloader on t3w1

### DIFF
--- a/core/embed/projects/bootloader/main.c
+++ b/core/embed/projects/bootloader/main.c
@@ -406,6 +406,9 @@ int bootloader_main(void) {
 
 #ifdef USE_BOOTARGS_RSOD
   if (bootargs_get_command() == BOOT_COMMAND_SHOW_RSOD) {
+#ifdef LAZY_DISPLAY_INIT
+    display_init(DISPLAY_RESET_CONTENT);
+#endif
     // post mortem info was left in bootargs
     boot_args_t args;
     bootargs_get_args(&args);


### PR DESCRIPTION
This small PR fixes the issue of the RSOD not being shown on T3W1 after introducing lazy display initialization.

The RSOD was not displayed in the bootloader because the display driver was not initialized yet.
