### PR TITLE
test(core): visit `confirm_action()` menu during tests

### DIFF
--- a/core/embed/rust/src/ui/layout_delizia/component/vertical_menu.rs
+++ b/core/embed/rust/src/ui/layout_delizia/component/vertical_menu.rs
@@ -329,10 +329,12 @@ impl VerticalMenuItem {
     fn button(&self) -> Button {
         match self {
             VerticalMenuItem::Item(text) => {
-                Button::with_text(*text).styled(theme::button_default())
+                let content = IconText::new(*text, theme::ICON_CHEVRON_RIGHT);
+                Button::with_icon_and_text(content).styled(theme::button_default())
             }
             VerticalMenuItem::Cancel(text) => {
-                Button::with_text(*text).styled(theme::button_warning_high())
+                let content = IconText::new(*text, theme::ICON_CANCEL);
+                Button::with_icon_and_text(content).styled(theme::button_warning_high())
             }
         }
     }

--- a/core/embed/rust/src/ui/layout_delizia/flow/confirm_action.rs
+++ b/core/embed/rust/src/ui/layout_delizia/flow/confirm_action.rs
@@ -287,14 +287,11 @@ fn new_confirm_action_uni<T: Component + PaginateFull + MaybeTrace + 'static>(
         .with_swipeup_footer(strings.footer_description)
         .with_vertical_pages();
 
-    match extra {
-        ConfirmActionExtra::Menu { .. } | ConfirmActionExtra::ExternalMenu => {
-            content = content.with_menu_button();
-        }
-        ConfirmActionExtra::Cancel => {
-            content = content.with_cancel_button();
-        }
-    }
+    content = match extra {
+        ConfirmActionExtra::ExternalMenu => content.with_menu_button().with_external_menu(),
+        ConfirmActionExtra::Menu { .. } => content.with_menu_button(),
+        ConfirmActionExtra::Cancel => content.with_cancel_button(),
+    };
 
     if page_counter {
         fn footer_update_fn<T: Component + PaginateFull>(


### PR DESCRIPTION
Rebased over #5333.

Also, refactor `new_confirm_action_uni` a bit.

<!--
For core developers:
- Assign yourself to the PR.
- Set the priority to match the original issue.
- Add the PR to the current sprint.
- If it's a draft PR, mark it as "In Progress."
- If it's a final PR, mark it as "Needs Review."

For external contributors:
- Please open an issue before submitting a PR so we can discuss whether we want to proceed with it.
-->
