### PR TITLE
simplify wireless setup flow

### DIFF
--- a/core/embed/projects/bootloader/workflow/wf_ble_pairing_request.c
+++ b/core/embed/projects/bootloader/workflow/wf_ble_pairing_request.c
@@ -197,17 +197,7 @@ workflow_result_t workflow_wireless_setup(const vendor_header *const vhdr,
     }
   }
 
-  memset(&layout, 0, sizeof(layout));
-  screen_wireless_setup_final(&layout);
-
-  uint32_t ui_result = 0;
-  res = workflow_host_control(vhdr, hdr, &layout, &ui_result, ios);
-
-  if (ui_result == WIRELESS_SETUP_FINAL_CANCEL) {
-    return WF_OK_PAIRING_COMPLETED;
-  }
-
-  return res;
+  return WF_OK_PAIRING_COMPLETED;
 }
 
 #endif

--- a/core/embed/rust/rust_ui_bootloader.h
+++ b/core/embed/rust/rust_ui_bootloader.h
@@ -97,8 +97,3 @@ typedef enum {
 } wireless_setup_result_t;
 void screen_wireless_setup(const char* name, size_t name_len,
                            c_layout_t* layout);
-
-typedef enum {
-  WIRELESS_SETUP_FINAL_CANCEL = 1,
-} wireless_setup_final_result_t;
-void screen_wireless_setup_final(c_layout_t* layout);

--- a/core/embed/rust/src/ui/api/bootloader_c.rs
+++ b/core/embed/rust/src/ui/api/bootloader_c.rs
@@ -212,16 +212,6 @@ extern "C" fn screen_wireless_setup(
 
 #[cfg(feature = "ble")]
 #[no_mangle]
-extern "C" fn screen_wireless_setup_final(layout: *mut c_layout_t) {
-    let mut screen = <ModelUI as BootloaderUI>::CLayoutType::init_wireless_setup_final();
-    screen.show();
-    // SAFETY: calling code is supposed to give us exclusive access to the layout
-    let mut layout = unsafe { LayoutBuffer::new(layout) };
-    layout.store(screen);
-}
-
-#[cfg(feature = "ble")]
-#[no_mangle]
 extern "C" fn screen_pairing_mode_finalizing(initial_setup: bool) -> u32 {
     ModelUI::screen_pairing_mode_finalizing(initial_setup)
 }

--- a/core/embed/rust/src/ui/layout_bolt/bootloader/mod.rs
+++ b/core/embed/rust/src/ui/layout_bolt/bootloader/mod.rs
@@ -213,11 +213,6 @@ impl BootloaderLayoutType for BootloaderLayout {
     fn init_wireless_setup(_name: &'static str) -> Self {
         unimplemented!()
     }
-
-    #[cfg(feature = "ble")]
-    fn init_wireless_setup_final() -> Self {
-        unimplemented!()
-    }
 }
 
 impl BootloaderUI for UIBolt {

--- a/core/embed/rust/src/ui/layout_caesar/bootloader/mod.rs
+++ b/core/embed/rust/src/ui/layout_caesar/bootloader/mod.rs
@@ -144,11 +144,6 @@ impl BootloaderLayoutType for BootloaderLayout {
     fn init_wireless_setup(_name: &'static str) -> Self {
         unimplemented!()
     }
-
-    #[cfg(feature = "ble")]
-    fn init_wireless_setup_final() -> Self {
-        unimplemented!()
-    }
 }
 
 impl BootloaderUI for UICaesar {

--- a/core/embed/rust/src/ui/layout_delizia/bootloader/mod.rs
+++ b/core/embed/rust/src/ui/layout_delizia/bootloader/mod.rs
@@ -179,11 +179,6 @@ impl BootloaderLayoutType for BootloaderLayout {
     fn init_wireless_setup(_name: &'static str) -> Self {
         unimplemented!()
     }
-
-    #[cfg(feature = "ble")]
-    fn init_wireless_setup_final() -> Self {
-        unimplemented!()
-    }
 }
 impl BootloaderUI for UIDelizia {
     type CLayoutType = BootloaderLayout;

--- a/core/embed/rust/src/ui/layout_eckhart/ui_bootloader.rs
+++ b/core/embed/rust/src/ui/layout_eckhart/ui_bootloader.rs
@@ -173,15 +173,6 @@ impl BootloaderLayoutType for BootloaderLayout {
             .with_action_bar(BldActionBar::new_single(btn));
         Self::WirelessSetup(screen)
     }
-
-    #[cfg(feature = "ble")]
-    fn init_wireless_setup_final() -> Self {
-        // todo implement correct UI
-        let btn = Button::with_text("Cancel".into()).styled(button_default());
-        let screen =
-            ConnectScreen::new("WAIT".into()).with_action_bar(BldActionBar::new_single(btn));
-        Self::WirelessSetupFinal(screen)
-    }
 }
 
 impl BootloaderUI for UIEckhart {

--- a/core/embed/rust/src/ui/ui_bootloader.rs
+++ b/core/embed/rust/src/ui/ui_bootloader.rs
@@ -10,9 +10,6 @@ pub trait BootloaderLayoutType {
     fn init_pairing_mode(initial_setup: bool, name: &'static str) -> Self;
     #[cfg(feature = "ble")]
     fn init_wireless_setup(name: &'static str) -> Self;
-
-    #[cfg(feature = "ble")]
-    fn init_wireless_setup_final() -> Self;
 }
 
 pub trait BootloaderUI {


### PR DESCRIPTION
removing final screen, as we now returning to the welcome screen after pairing is done