### PR TITLE
suspend/hibernate on button in bootloader

### DIFF
--- a/core/embed/projects/bootloader/bootui.c
+++ b/core/embed/projects/bootloader/bootui.c
@@ -27,8 +27,6 @@
 #include "rust_ui_bootloader.h"
 #include "version.h"
 
-#define BACKLIGHT_NORMAL 150
-
 #define TOIF_LENGTH(ptr) ((*(uint32_t *)((ptr) + 8)) + 12)
 
 // common shared functions

--- a/core/embed/projects/bootloader/bootui.h
+++ b/core/embed/projects/bootloader/bootui.h
@@ -25,6 +25,8 @@
 
 #include "rust_ui_bootloader.h"
 
+#define BACKLIGHT_NORMAL 150
+
 // Displays a warning screen before jumping to the untrusted firmware
 //
 // Shows vendor image, vendor string and firmware version

--- a/core/embed/rust/build.rs
+++ b/core/embed/rust/build.rs
@@ -456,6 +456,7 @@ fn generate_trezorhal_bindings() {
         .allowlist_function("pm_get_events")
         .allowlist_function("pm_get_state")
         .allowlist_function("pm_suspend")
+        .allowlist_function("pm_hibernate")
         // irq
         .allowlist_function("irq_lock_fn")
         .allowlist_function("irq_unlock_fn")

--- a/core/embed/rust/rust_ui_bootloader.h
+++ b/core/embed/rust/rust_ui_bootloader.h
@@ -11,6 +11,9 @@
 // common event function for screens that need UI + communication
 uint32_t screen_event(c_layout_t* layout, sysevents_t* signalled);
 
+// common render event
+void screen_render(c_layout_t* layout);
+
 // result screens
 void screen_wipe_success(void);
 void screen_wipe_fail(void);

--- a/core/embed/rust/src/trezorhal/haptic.rs
+++ b/core/embed/rust/src/trezorhal/haptic.rs
@@ -4,6 +4,7 @@ use super::ffi;
 pub enum HapticEffect {
     ButtonPress = ffi::haptic_effect_t_HAPTIC_BUTTON_PRESS as _,
     HoldToConfirm = ffi::haptic_effect_t_HAPTIC_HOLD_TO_CONFIRM as _,
+    BootloaderEntry = ffi::haptic_effect_t_HAPTIC_BOOTLOADER_ENTRY as _,
 }
 
 pub fn play(effect: HapticEffect) {

--- a/core/embed/rust/src/trezorhal/power_manager.rs
+++ b/core/embed/rust/src/trezorhal/power_manager.rs
@@ -51,3 +51,7 @@ pub fn is_usb_connected() -> bool {
 pub fn suspend() {
     unsafe { ffi::pm_suspend(null_mut()) };
 }
+
+pub fn hibernate() {
+    unsafe { ffi::pm_hibernate() };
+}

--- a/core/embed/rust/src/ui/api/bootloader_c.rs
+++ b/core/embed/rust/src/ui/api/bootloader_c.rs
@@ -24,6 +24,15 @@ extern "C" fn screen_event(layout: *mut c_layout_t, signalled: &sysevents_t) -> 
 }
 
 #[no_mangle]
+extern "C" fn screen_render(layout: *mut c_layout_t) {
+    unsafe {
+        let mut layout = LayoutBuffer::<<ModelUI as BootloaderUI>::CLayoutType>::new(layout);
+        let layout = layout.get_mut();
+        layout.render()
+    }
+}
+
+#[no_mangle]
 extern "C" fn screen_welcome(layout: *mut c_layout_t) {
     let mut screen = <ModelUI as BootloaderUI>::CLayoutType::init_welcome();
     screen.show();

--- a/core/embed/rust/src/ui/layout_eckhart/ui_bootloader.rs
+++ b/core/embed/rust/src/ui/layout_eckhart/ui_bootloader.rs
@@ -2,7 +2,7 @@ use crate::ui::{
     component::{Event, Label},
     display::{self, toif::Toif, Color},
     geometry::{Alignment, Alignment2D, Offset, Point, Rect},
-    layout::simplified::{process_frame_event, run, show},
+    layout::simplified::{process_frame_event, render, run, show},
     shape::{self, render_on_display},
     ui_bootloader::{BootloaderLayoutType, BootloaderUI},
     CommonUI,
@@ -106,6 +106,18 @@ impl BootloaderLayoutType for BootloaderLayout {
             BootloaderLayout::WirelessSetup(f) => {
                 process_frame_event::<WirelessSetupScreen>(f, event)
             }
+        }
+    }
+
+    fn render(&mut self) {
+        match self {
+            BootloaderLayout::Welcome(f) => render(f),
+            BootloaderLayout::Menu(f) => render(f),
+            BootloaderLayout::Connect(f) => render(f),
+            #[cfg(feature = "ble")]
+            BootloaderLayout::PairingMode(f) => render(f),
+            #[cfg(feature = "ble")]
+            BootloaderLayout::WirelessSetup(f) => render(f),
         }
     }
 

--- a/core/embed/rust/src/ui/ui_bootloader.rs
+++ b/core/embed/rust/src/ui/ui_bootloader.rs
@@ -2,6 +2,11 @@ use crate::ui::component::Event;
 
 pub trait BootloaderLayoutType {
     fn event(&mut self, event: Option<Event>) -> u32;
+
+    fn render(&mut self) {
+        unimplemented!();
+    }
+
     fn show(&mut self);
     fn init_welcome() -> Self;
     fn init_menu(initial_setup: bool) -> Self;


### PR DESCRIPTION
This PR introduces suspension/hibernation on button press in bootloader.

Short press leads to suspend, long press to hibernation with haptic effect.

<!--
For core developers:
- Assign yourself to the PR.
- Set the priority to match the original issue.
- Add the PR to the current sprint.
- If it's a draft PR, mark it as "In Progress."
- If it's a final PR, mark it as "Needs Review."

For external contributors:
- Please open an issue before submitting a PR so we can discuss whether we want to proceed with it.
-->
