### PR TITLE
ci(core): build and upload arm emus also on workflow_dispatch event

### DIFF
--- a/.github/workflows/core.yml
+++ b/.github/workflows/core.yml
@@ -5,14 +5,14 @@ on:
     types:
       - opened
       - reopened
-      - synchronize  # branch head update
+      - synchronize # branch head update
       - labeled
   workflow_dispatch:
   schedule:
-    - cron: '15 23 * * *'  # every day @ 23:15
+    - cron: "15 23 * * *" # every day @ 23:15
   push:
     branches:
-      - 'release/**'
+      - "release/**"
 
 # cancel any previous runs on the same PR
 concurrency:
@@ -20,9 +20,9 @@ concurrency:
   cancel-in-progress: true
 
 permissions:
-  id-token: write       # for fetching the OIDC token
-  contents: read        # for actions/checkout
-  pull-requests: write  # For dflook comments on PR
+  id-token: write # for fetching the OIDC token
+  contents: read # for actions/checkout
+  pull-requests: write # For dflook comments on PR
 
 env:
   # See https://yaml-multiline.info/
@@ -204,7 +204,7 @@ jobs:
           retention-days: 7
 
   core_emu_arm:
-    if: github.event_name == 'schedule'
+    if: (github.event_name == 'schedule' || github.event_name == 'workflow_dispatch')
     name: Build emu arm
     runs-on: ubuntu-latest-arm64
     needs: param
@@ -263,7 +263,7 @@ jobs:
       - run: nix-shell --run "poetry run make -C core build_unix"
       - run: nix-shell --run "cd vendor/ts-tvl/tvl/server/model_config && poetry install && poetry run model_server tcp -c model_config.yml &"
       - run: nix-shell --run "poetry run make -C core test"
-      - run: nix-shell --run "poetry run core/emu.py -c true"  # sanity check non-frozen emulator
+      - run: nix-shell --run "poetry run core/emu.py -c true" # sanity check non-frozen emulator
 
   core_unit_rust_test:
     name: Rust unit tests
@@ -340,7 +340,7 @@ jobs:
       PYTEST_TIMEOUT: ${{ matrix.asan == 'asan' && 600 || 400 }}
       ACTIONS_DO_UI_TEST: ${{ matrix.coins == 'universal' && matrix.asan == 'noasan' }}
       TEST_LANG: ${{ matrix.lang }}
-      TESTOPTS: "--durations 50 --session-timeout 1800"  # 30m pytest global timeout
+      TESTOPTS: "--durations 50 --session-timeout 1800" # 30m pytest global timeout
     timeout-minutes: 40
     steps:
       - uses: actions/checkout@v4
@@ -419,7 +419,6 @@ jobs:
         continue-on-error: true
       - uses: ./.github/actions/upload-coverage
 
-
   # Upgrade tests.
   # See [docs/tests/upgrade-tests](../tests/upgrade-tests.md) for more info.
   core_upgrade_test:
@@ -458,7 +457,6 @@ jobs:
             tests/trezor*.log
           retention-days: 7
         if: always()
-
 
   # Persistence tests - UI.
   core_persistence_test:
@@ -508,7 +506,7 @@ jobs:
 
   core_hwi_test:
     name: HWI tests
-    if: false  # XXX currently failing
+    if: false # XXX currently failing
     continue-on-error: true
     runs-on: ubuntu-latest
     needs: core_emu
@@ -525,7 +523,7 @@ jobs:
           name: core-emu-${{ matrix.model }}-universal-debuglink-noasan
           path: core/build
       - run: chmod +x core/build/unix/trezor-emu-core*
-      - uses: ./.github/actions/environment  # XXX poetry maybe not needed
+      - uses: ./.github/actions/environment # XXX poetry maybe not needed
       - run: nix-shell --run "git clone --depth=1 https://github.com/bitcoin-core/HWI.git"
       - run: nix-shell --arg fullDeps true --run "cd HWI && poetry install && poetry run ./test/test_trezor.py --model_t ../core/build/unix/trezor-emu-core bitcoind"
       - uses: actions/upload-artifact@v4
@@ -536,7 +534,7 @@ jobs:
 
   core_memory_profile:
     name: Memory allocation report
-    if: false  # NOTE manual job, comment out to run
+    if: false # NOTE manual job, comment out to run
     runs-on: ubuntu-latest
     env:
       TREZOR_MODEL: T2T1
@@ -572,14 +570,14 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        model: [T2T1]  # FIXME: checker.py lacks awareness of U5 flash layout
+        model: [T2T1] # FIXME: checker.py lacks awareness of U5 flash layout
     steps:
       - uses: actions/checkout@v4
         with:
           submodules: recursive
       - uses: actions/download-artifact@v4
         with:
-          name: core-firmware-${{ matrix.model }}-universal-normal  # FIXME: s/normal/debuglink/
+          name: core-firmware-${{ matrix.model }}-universal-normal # FIXME: s/normal/debuglink/
           path: core/build
       - uses: ./.github/actions/environment
       - run: nix-shell --run "poetry run core/tools/size/checker.py core/build/firmware/firmware.elf"
@@ -595,7 +593,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        model: [T2T1]  # FIXME: T2T1 url is hardcoded in compare_master.py
+        model: [T2T1] # FIXME: T2T1 url is hardcoded in compare_master.py
     steps:
       - uses: actions/checkout@v4
         with:
@@ -652,7 +650,6 @@ jobs:
         if: always()
       - uses: ./.github/actions/upload-coverage
 
-
   # Tests for U2F and HID.
   core_u2f_test:
     name: U2F test
@@ -698,7 +695,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        model: [T2T1, T3T1, T3W1]  # XXX T3B1 https://github.com/trezor/trezor-firmware/issues/2724
+        model: [T2T1, T3T1, T3W1] # XXX T3B1 https://github.com/trezor/trezor-firmware/issues/2724
         asan: ${{ fromJSON(needs.param.outputs.asan) }}
     env:
       TREZOR_PROFILING: ${{ matrix.asan == 'noasan' && '1' || '0' }}
@@ -763,7 +760,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
-      - run: sleep 1m  # try avoiding github api rate limit
+      - run: sleep 1m # try avoiding github api rate limit
       - uses: ./.github/actions/ui-comment
 
       - name: Configure aws credentials
@@ -780,7 +777,7 @@ jobs:
 
   core_upload_emu:
     name: Upload emulator binaries
-    if: github.event_name == 'schedule'
+    if: (github.event_name == 'schedule' || github.event_name == 'workflow_dispatch')
     runs-on: ubuntu-latest
     needs:
       - core_emu


### PR DESCRIPTION
We have a nice feature in trezor-user-env that allows us to run emulators from CI builds. 

<img width="1046" alt="image" src="https://github.com/user-attachments/assets/3557e43a-7ed9-451a-99cf-296017fba7be" />

The problem is that for arm users these builds are not available until a fw branch is merged since these buids run only in nightly runs and on top of the main branch. 

This change would allow us to force arm builds in CI

