### PR TITLE
fix(core): fix D002 model build

### DIFF
--- a/core/embed/sys/smcall/stm32/smcall_verifiers.h
+++ b/core/embed/sys/smcall/stm32/smcall_verifiers.h
@@ -132,6 +132,8 @@ bool tropic_ecc_sign__verified(uint16_t key_slot_index, const uint8_t *dig,
 
 // ---------------------------------------------------------------------
 
+#ifdef USE_BACKUP_RAM
+
 #include <sys/backup_ram.h>
 
 bool backup_ram_read__verified(uint16_t key, void *buffer, size_t buffer_size,
@@ -139,5 +141,7 @@ bool backup_ram_read__verified(uint16_t key, void *buffer, size_t buffer_size,
 
 bool backup_ram_write__verified(uint16_t key, const void *data,
                                 size_t data_size);
+
+#endif  // USE_BACKUP_RAM
 
 #endif  // SECMON

--- a/core/site_scons/models/D002/discovery2.py
+++ b/core/site_scons/models/D002/discovery2.py
@@ -46,6 +46,7 @@ def configure(
         ("HSE_VALUE", "16000000"),
         ("USE_HSE", "1"),
         ("USE_BOOTARGS_RSOD", "1"),
+        ("LOCKABLE_BOOTLOADER", "1"),
     ]
 
     if "display" in features_wanted:


### PR DESCRIPTION
This small PR fixes the firmware build for the D002 model.

- It enables `LOCKABLE_BOOTLOADER` for discovery kit as well.
- Fixes conditional compilation of backup ram smcalls


