### PR TITLE
test(core): fix waiting for recovery

### DIFF
--- a/tests/click_tests/recovery.py
+++ b/tests/click_tests/recovery.py
@@ -55,8 +55,10 @@ def enter_word(
 
 
 def confirm_recovery(debug: "DebugLink", title: str = "recovery__title") -> None:
-    layout = debug.read_layout()
-    assert TR.translate(title) == layout.title()
+    expected_title = TR.translate(title)
+    # exlicitly wait, in case the recovery was started asynchronously (e.g. using BackgroundDeviceHandler)
+    layout = debug.synchronize_at(expected_title)
+    assert expected_title == layout.title()
     if debug.layout_type in (LayoutType.Bolt, LayoutType.Eckhart):
         debug.click(debug.screen_buttons.ok())
     elif debug.layout_type is LayoutType.Delizia:


### PR DESCRIPTION
It seems that there is a race between starting the recovery flow and verifying its layout, causing [test failures when running persistence_tests on THP](https://github.com/trezor/trezor-firmware/actions/runs/16174356159/job/45656150594#step:6:235).

https://github.com/trezor/trezor-firmware/blob/953b0e23d1ae4ba433f512df95530154d13ace5d/tests/persistence_tests/test_shamir_persistence.py#L47-L49

