### PR TITLE
Change T3W1 mcu powerline voltage to 2.9V.

### DIFF
--- a/core/embed/sys/power_manager/npm1300/npm1300.c
+++ b/core/embed/sys/power_manager/npm1300/npm1300.c
@@ -254,9 +254,13 @@ static bool npm1300_initialize(i2c_bus_t* bus, uint16_t i_charge,
       {NPM1300_TASKLDSW1CLR, 0x01},
       {NPM1300_TASKLDSW2CLR, 0x01},
       // BUCK regulators
-      // 2.7V, use sw settigns
-      // {NPM1300_BUCK1NORMVOUT, 17}, // this settings adds 900uA on VBAT
-      // {NPM1300_BUCKSWCTRLSEL, 1},
+
+      // NOTE: NPM1300 ERRATA #27
+      // this settings adds 900uA on VBAT in case the BUCK1NORMVOUT selected
+      // the same voltage as it is selected by external resistor.
+      {NPM1300_BUCK1NORMVOUT, 19},  // 2.9V
+      {NPM1300_BUCKSWCTRLSEL, 1},
+
       // Buck auto mode, Pull downs disabled
       {NPM1300_BUCKCTRL0, 0},  // Auto mode
       //


### PR DESCRIPTION
This PR change the MCU powerline voltage (named 3V3) to 2.9V and overwrite the setting of external resistor. 

This change is needed since the RGB LED was moved to MCU powerline from unregulated VSYS and blue diode require forward voltage of 2.7-2.85V. 

Before we accept this change we need to make several other considerations:

1) Blue LED has the highest forward voltage from all LEDs and its a bottleneck for powerline voltage setting. the forward voltage increases with the LED lighting intensity up almost 3V (for ex 45mcd ~ requires 2.95V of forward voltage). The powerline voltage has to be sufficiently high to cover LED forward voltage + voltage drop on the resistor for current tuning. Smaller the voltage drop on the current resistor, higher the current volatility with the resistor tolerance

2) NPM1300 Buck 1 convertor has a regulation dropout of 100-200mV based on the powerline load. When the device is powered from battery and battery is almost depleted. Battery voltage may drop to 3.0V. According to the measurment we never dropped bellow 2.87V on MCU powerline. If the powerline input drops too low and start to decrease the buck  regulated output due to dropout, Blue LED intensity may start to change => Start to change color.

3) NPM1300 register setting need to respect ERRATA #27 (https://docs.nordicsemi.com/bundle/errata_nPM1300_Rev2/page/ERR/nPM1300/Rev2/latest/anomaly_300_27.html) which cause extra 900uA of quiescent current in case the Software Buck 1 VOUT settings is the same as the VOUT setting of external resistor. Anyway,  maximal VOUT setting by external resistor is 2.7V so setting the VOUT by software to 2.9 should be OK.

3) With all above, we have set the powerline at 2.9V to be sufficiently high to support blue LED at 25mcd + has at least 100mV room for drop out in case the battery will be depleted. (there is an overlap of maybe 30mV, but seems to be acceptable). 
 