### PR TITLE
erase backup ram in bootloader when erasing storage

### DIFF
--- a/core/embed/projects/bootloader/main.c
+++ b/core/embed/projects/bootloader/main.c
@@ -585,6 +585,9 @@ int bootloader_main(void) {
         secret_bhk_regenerate();
 #endif
         ensure(erase_storage(NULL), NULL);
+#ifdef USE_BACKUP_RAM
+        ensure(backup_ram_erase_protected() * sectrue, NULL);
+#endif
         error_shutdown("Bootloader fatal error");
         break;
       }

--- a/core/embed/projects/bootloader/workflow/wf_empty_device.c
+++ b/core/embed/projects/bootloader/workflow/wf_empty_device.c
@@ -29,6 +29,10 @@
 #include <sec/secret.h>
 #endif
 
+#ifdef USE_BACKUP_RAM
+#include <sys/backup_ram.h>
+#endif
+
 #include "bootui.h"
 #include "rust_ui_bootloader.h"
 #include "workflow.h"
@@ -40,6 +44,9 @@ workflow_result_t workflow_empty_device(void) {
   secret_bhk_regenerate();
 #endif
   ensure(erase_storage(NULL), NULL);
+#ifdef USE_BACKUP_RAM
+  ensure(backup_ram_erase_protected() * sectrue, NULL);
+#endif
 
   protob_ios_t ios;
   workflow_ifaces_init(sectrue, &ios);

--- a/core/embed/projects/bootloader/workflow/wf_firmware_update.c
+++ b/core/embed/projects/bootloader/workflow/wf_firmware_update.c
@@ -29,6 +29,10 @@
 #include <sec/secret.h>
 #endif
 
+#ifdef USE_BACKUP_RAM
+#include <sys/backup_ram.h>
+#endif
+
 #include "bootui.h"
 #include "protob/protob.h"
 #include "version_check.h"
@@ -339,6 +343,9 @@ static upload_status_t process_msg_FirmwareUpload(protob_io_t *iface,
         secret_bhk_regenerate();
 #endif
         ensure(erase_storage(NULL), NULL);
+#ifdef USE_BACKUP_RAM
+        ensure(backup_ram_erase_protected() * sectrue, NULL);
+#endif
       }
 
       ctx->headers_offset = IMAGE_HEADER_SIZE + vhdr.hdrlen;

--- a/core/embed/projects/bootloader/workflow/wf_wipe_device.c
+++ b/core/embed/projects/bootloader/workflow/wf_wipe_device.c
@@ -26,6 +26,10 @@
 #include <io/ble.h>
 #endif
 
+#ifdef USE_BACKUP_RAM
+#include <sys/backup_ram.h>
+#endif
+
 #include <sys/systick.h>
 
 #include "bootui.h"
@@ -92,6 +96,12 @@ workflow_result_t workflow_wipe_device(protob_io_t* iface) {
   }
   ui_screen_wipe();
   secbool wipe_result = erase_device(ui_screen_wipe_progress);
+
+#ifdef USE_BACKUP_RAM
+  if (!backup_ram_erase_protected()) {
+    return WF_ERROR;
+  }
+#endif
 
 #ifdef USE_BLE
   if (!wipe_bonds(iface)) {

--- a/core/embed/projects/prodtest/cmd/prodtest_backup_ram.c
+++ b/core/embed/projects/prodtest/cmd/prodtest_backup_ram.c
@@ -125,14 +125,21 @@ static void prodtest_backup_ram_read(cli_t* cli) {
 }
 
 static void prodtest_backup_ram_write(cli_t* cli) {
-  if (cli_arg_count(cli) > 2) {
+  if (cli_arg_count(cli) > 3) {
     cli_error_arg_count(cli);
     return;
   }
 
   uint32_t key = 0;
+  uint32_t type = 0;
+
   if (!cli_arg_uint32(cli, "key", &key) && key < 0xFFFF) {
     cli_error_arg(cli, "Expecting key argument in range 0-65535");
+    return;
+  }
+
+  if (!cli_arg_uint32(cli, "type", &type) || type > 1) {
+    cli_error_arg(cli, "Expecting type argument in range 0-1");
     return;
   }
 
@@ -155,7 +162,7 @@ static void prodtest_backup_ram_write(cli_t* cli) {
     return;
   }
 
-  if (!backup_ram_write(key, data, len)) {
+  if (!backup_ram_write(key, type, data, len)) {
     cli_error(cli, CLI_ERROR, "Failed to write key #%d", key);
     return;
   }
@@ -200,7 +207,7 @@ PRODTEST_CLI_CMD(
    .name = "backup-ram-write",
    .func = prodtest_backup_ram_write,
    .info = "Write to backup RAM",
-   .args = "<key> [<hex-data>]",
+   .args = "<key> <type> [<hex-data>]",
 );
 
 #endif // !PRODUCTION

--- a/core/embed/projects/prodtest/cmd/prodtest_backup_ram.c
+++ b/core/embed/projects/prodtest/cmd/prodtest_backup_ram.c
@@ -84,8 +84,8 @@ static void prodtest_backup_ram_read(cli_t* cli) {
   }
 
   uint32_t key = 0;
-  if (!cli_arg_uint32(cli, "key", &key) && key < 0xFFFF) {
-    cli_error_arg(cli, "Expecting key argument in range 0-65535");
+  if (!cli_arg_uint32(cli, "key", &key) || key >= 0xFFFF) {
+    cli_error_arg(cli, "Expecting key argument in range 0-65534");
     return;
   }
 
@@ -133,8 +133,8 @@ static void prodtest_backup_ram_write(cli_t* cli) {
   uint32_t key = 0;
   uint32_t type = 0;
 
-  if (!cli_arg_uint32(cli, "key", &key) && key < 0xFFFF) {
-    cli_error_arg(cli, "Expecting key argument in range 0-65535");
+  if (!cli_arg_uint32(cli, "key", &key) || key >= 0xFFFF) {
+    cli_error_arg(cli, "Expecting key argument in range 0-65534");
     return;
   }
 

--- a/core/embed/sys/backup_ram/inc/sys/backup_ram.h
+++ b/core/embed/sys/backup_ram/inc/sys/backup_ram.h
@@ -27,6 +27,11 @@
 /** Maximum size of data stored under a single key in backup RAM */
 #define BACKUP_RAM_MAX_KEY_DATA_SIZE 512
 
+typedef enum {
+  BACKUP_RAM_ITEM_PUBLIC = 0,
+  BACKUP_RAM_ITEM_PROTECTED = 1,
+} backup_ram_item_type_t;
+
 /**
  * @brief Initializes backup RAM driver
  *
@@ -53,6 +58,13 @@ void backup_ram_deinit(void);
  */
 
 bool backup_ram_erase(void);
+
+/**
+ * @brief Erases protected backup RAM content
+ *
+ * @return true if the operation was successful, false otherwise.
+ */
+bool backup_ram_erase_protected(void);
 
 /**
  * @brief Erases a single item in backup RAM by its key.
@@ -83,12 +95,14 @@ uint16_t backup_ram_search(uint16_t min_key);
  *
  * @param key Key to identify the data
  * @param data Pointer to the data to be stored
+ * @param type Type of the data being stored
  * @param data_size Size of the data in bytes. If the key does not exist, this
- * value will be set to 0. If data_size == NULL, the size will not be retrieved.
+ * value will be set to 0. If data_size == 0, the item will be removed.
  *
  * @return true if the operation was successful, false otherwise.
  */
-bool backup_ram_write(uint16_t key, const void* data, size_t data_size);
+bool backup_ram_write(uint16_t key, backup_ram_item_type_t type,
+                      const void* data, size_t data_size);
 
 /**
  * @brief Reads key-value data from backup RAM.

--- a/core/embed/sys/power_manager/inc/sys/power_manager.h
+++ b/core/embed/sys/power_manager/inc/sys/power_manager.h
@@ -197,9 +197,3 @@ pm_status_t pm_charging_set_max_current(uint16_t current_ma);
  * @return pm_status_t Status code indicating success or failure
  */
 pm_status_t pm_set_soc_limit(uint8_t limit);
-
-/**
- * @brief Store power manager data to backup RAM
- * @return pm_status_t Status code indicating success or failure
- */
-pm_status_t pm_store_data_to_backup_ram();

--- a/core/embed/sys/power_manager/stm32u5/power_manager.c
+++ b/core/embed/sys/power_manager/stm32u5/power_manager.c
@@ -454,7 +454,8 @@ pm_status_t pm_store_data_to_backup_ram() {
   irq_unlock(irq_key);
 
   bool write_ok =
-      backup_ram_write(BACKUP_RAM_KEY_PM_RECOVERY, &recovery, sizeof(recovery));
+      backup_ram_write(BACKUP_RAM_KEY_PM_RECOVERY, BACKUP_RAM_ITEM_PUBLIC,
+                       &recovery, sizeof(recovery));
 
   if (!write_ok) {
     return PM_ERROR;

--- a/core/embed/sys/power_manager/stm32u5/power_manager_internal.h
+++ b/core/embed/sys/power_manager/stm32u5/power_manager_internal.h
@@ -127,6 +127,10 @@ void pm_pmic_data_ready(void* context, pmic_report_t* report);
 // pm_monitor_power_sources() to control the charging current and state.
 void pm_charging_controller(pm_driver_t* drv);
 
-// Battery initial state of charge guess function. This function use the sampled
-// battery data to guess the initial state of charge in case its unknown.
+// Battery initial state of charge guess function. This function uses the
+// sampled battery data to guess the initial state of charge in case its
+// unknown.
 void pm_battery_initial_soc_guess(void);
+
+// Store power manager data to backup RAM
+pm_status_t pm_store_data_to_backup_ram(void);

--- a/core/embed/sys/smcall/stm32/smcall_dispatch.c
+++ b/core/embed/sys/smcall/stm32/smcall_dispatch.c
@@ -391,9 +391,10 @@ __attribute((no_stack_protector)) void smcall_handler(uint32_t *args,
 
     case SMCALL_BACKUP_RAM_WRITE: {
       uint16_t key = (uint16_t)args[0];
-      const void *data = (const void *)args[1];
-      size_t data_size = (size_t)args[2];
-      args[0] = backup_ram_write__verified(key, data, data_size);
+      backup_ram_item_type_t type = (backup_ram_item_type_t)args[1];
+      const void *data = (const void *)args[2];
+      size_t data_size = (size_t)args[3];
+      args[0] = backup_ram_write__verified(key, type, data, data_size);
     } break;
 #endif
 

--- a/core/embed/sys/smcall/stm32/smcall_stubs.c
+++ b/core/embed/sys/smcall/stm32/smcall_stubs.c
@@ -368,8 +368,9 @@ bool backup_ram_read(uint16_t key, void *buffer, size_t buffer_size,
                               (uint32_t)data_size, SMCALL_BACKUP_RAM_READ);
 }
 
-bool backup_ram_write(uint16_t key, const void *data, size_t data_size) {
-  return (bool)smcall_invoke3(key, (uint32_t)data, data_size,
+bool backup_ram_write(uint16_t key, backup_ram_item_type_t type,
+                      const void *data, size_t data_size) {
+  return (bool)smcall_invoke4(key, type, (uint32_t)data, data_size,
                               SMCALL_BACKUP_RAM_WRITE);
 }
 

--- a/core/embed/sys/smcall/stm32/smcall_verifiers.c
+++ b/core/embed/sys/smcall/stm32/smcall_verifiers.c
@@ -494,13 +494,13 @@ access_violation:
   return false;
 }
 
-bool backup_ram_write__verified(uint16_t key, const void *data,
-                                size_t data_size) {
+bool backup_ram_write__verified(uint16_t key, backup_ram_item_type_t type,
+                                const void *data, size_t data_size) {
   if (!probe_read_access(data, data_size)) {
     goto access_violation;
   }
 
-  return backup_ram_write(key, data, data_size);
+  return backup_ram_write(key, type, data, data_size);
 access_violation:
   apptask_access_violation();
   return false;

--- a/core/embed/sys/smcall/stm32/smcall_verifiers.h
+++ b/core/embed/sys/smcall/stm32/smcall_verifiers.h
@@ -137,7 +137,7 @@ bool tropic_ecc_sign__verified(uint16_t key_slot_index, const uint8_t *dig,
 bool backup_ram_read__verified(uint16_t key, void *buffer, size_t buffer_size,
                                size_t *data_size);
 
-bool backup_ram_write__verified(uint16_t key, const void *data,
-                                size_t data_size);
+bool backup_ram_write__verified(uint16_t key, backup_ram_item_type_t type,
+                                const void *data, size_t data_size);
 
 #endif  // SECMON


### PR DESCRIPTION
This PR prepares backup ram for future use cases where we would store sensitive data in backup ram

Such data will be erased along with storage when bootloader i.e. changes firmware vendor.
