### PR TITLE
fix(core): add missing `PropertyType` element for Solana confirmation

### DIFF
--- a/core/.changelog.d/5308.fixed
+++ b/core/.changelog.d/5308.fixed
@@ -1,0 +1,1 @@
+Fix Solana signing crash.

--- a/core/src/apps/solana/layout.py
+++ b/core/src/apps/solana/layout.py
@@ -242,8 +242,8 @@ async def confirm_unsupported_instruction_details(
             ),
         )
 
-        accounts = []
         for i, account in enumerate(instruction.accounts, 1):
+            accounts: list[PropertyType] = []
             if len(account) == 2:
                 account_public_key = account[0]
                 address_type = get_address_type(account[1])
@@ -256,6 +256,7 @@ async def confirm_unsupported_instruction_details(
                     (
                         f"{TR.words__account} {i}{path_str} {address_type}:",
                         base58.encode(account_public_key),
+                        True,
                     )
                 )
             elif len(account) == 3:
@@ -266,11 +267,11 @@ async def confirm_unsupported_instruction_details(
             else:
                 raise ValueError  # Invalid account value
 
-        await confirm_properties(
-            "accounts",
-            title,
-            accounts,
-        )
+            await confirm_properties(
+                "accounts",
+                title,
+                accounts,
+            )
 
 
 async def confirm_unsupported_instruction_confirm(


### PR DESCRIPTION
Also, confirm each account separately, in order to avoid overflowing `ParagraphVecLong`.

Tested locally using `solana/test_sign_tx.py::test_solana_sign_tx[unknown_instruction]` transaction:
```
$ SOLTX=0200010300d1699dcb1811b50bb0055f13044463128242e37a463b52f6c97a1f6eef88ad8f41927b2e58cbc31ed3aa5163a7b8ca4eb5590e8dc1dc682426cd2895aa9c0a8f41927b2e58cbc31ed3aa5163a7b8ca4eb5590e8dc1dc682426cd2895aa9c0a1aea57c9906a7cad656ff61b3893abda63f4b6b210c939855e7ab6e54049213d010202000104deadbeef
$ core/emu.py -sea -c trezorctl -v solana sign-tx -n 'm/44h/501h/0h/0h' $SOLTX
```

[Screencast from 2025-07-13 21-27-39.webm](https://github.com/user-attachments/assets/237961d1-8b2d-43de-9e68-138feff62e90)


<!--
For core developers:
- Assign yourself to the PR.
- Set the priority to match the original issue.
- Add the PR to the current sprint.
- If it's a draft PR, mark it as "In Progress."
- If it's a final PR, mark it as "Needs Review."

For external contributors:
- Please open an issue before submitting a PR so we can discuss whether we want to proceed with it.
-->

Followups:
- [ ] Modify device tests to reproduce this issue -> https://github.com/trezor/trezor-firmware/issues/5353.