### PR TITLE
Rename  `raise_if_not_confirmed` to `raise_if_cancelled`

### DIFF
--- a/core/src/apps/management/ble/pair_new_device.py
+++ b/core/src/apps/management/ble/pair_new_device.py
@@ -3,7 +3,7 @@ import trezorui_api
 from storage import device as storage_device
 from trezor import utils
 from trezor.crypto import random
-from trezor.ui.layouts import CONFIRMED, raise_if_not_confirmed
+from trezor.ui.layouts import CONFIRMED, raise_if_cancelled
 from trezor.wire import ActionCancelled
 
 
@@ -35,7 +35,7 @@ async def pair_new_device() -> None:
     label = storage_device.get_label() or _default_ble_name()
     ble.start_advertising(False, label)
     try:
-        code = await raise_if_not_confirmed(
+        code = await raise_if_cancelled(
             trezorui_api.show_pairing_device_name(
                 device_name=label,
             ),
@@ -45,7 +45,7 @@ async def pair_new_device() -> None:
             raise ActionCancelled
 
         try:
-            result = await raise_if_not_confirmed(
+            result = await raise_if_cancelled(
                 trezorui_api.show_ble_pairing_code(
                     title="Bluetooth pairing",
                     description="Pairing code match?",

--- a/core/src/apps/management/ble/pair_new_device.py
+++ b/core/src/apps/management/ble/pair_new_device.py
@@ -3,7 +3,7 @@ import trezorui_api
 from storage import device as storage_device
 from trezor import utils
 from trezor.crypto import random
-from trezor.ui.layouts import CONFIRMED, raise_if_cancelled
+from trezor.ui.layouts import CONFIRMED, interact
 from trezor.wire import ActionCancelled
 
 
@@ -35,7 +35,7 @@ async def pair_new_device() -> None:
     label = storage_device.get_label() or _default_ble_name()
     ble.start_advertising(False, label)
     try:
-        code = await raise_if_cancelled(
+        code = await interact(
             trezorui_api.show_pairing_device_name(
                 device_name=label,
             ),
@@ -45,7 +45,7 @@ async def pair_new_device() -> None:
             raise ActionCancelled
 
         try:
-            result = await raise_if_cancelled(
+            result = await interact(
                 trezorui_api.show_ble_pairing_code(
                     title="Bluetooth pairing",
                     description="Pairing code match?",

--- a/core/src/trezor/ui/layouts/bolt/__init__.py
+++ b/core/src/trezor/ui/layouts/bolt/__init__.py
@@ -5,7 +5,7 @@ from trezor import TR, ui, utils
 from trezor.enums import ButtonRequestType, RecoveryType
 from trezor.wire import ActionCancelled
 
-from ..common import draw_simple, interact, raise_if_not_confirmed, with_info
+from ..common import draw_simple, interact, raise_if_cancelled, with_info
 
 if TYPE_CHECKING:
     from typing import Awaitable, Iterable, NoReturn, Sequence
@@ -42,7 +42,7 @@ def confirm_action(
     if description is not None and description_param is not None:
         description = description.format(description_param)
 
-    return raise_if_not_confirmed(
+    return raise_if_cancelled(
         trezorui_api.confirm_action(
             title=title,
             action=action,
@@ -74,7 +74,7 @@ def confirm_single(
     assert template_str in description
 
     begin, _separator, end = description.partition(template_str)
-    return raise_if_not_confirmed(
+    return raise_if_cancelled(
         trezorui_api.confirm_emphasized(
             title=title,
             items=(begin, (True, description_param), end),
@@ -86,7 +86,7 @@ def confirm_single(
 
 
 def confirm_reset_device(recovery: bool = False) -> Awaitable[None]:
-    return raise_if_not_confirmed(
+    return raise_if_cancelled(
         trezorui_api.confirm_reset_device(recovery=recovery),
         "recover_device" if recovery else "setup_device",
         (ButtonRequestType.ProtectCall if recovery else ButtonRequestType.ResetDevice),
@@ -152,7 +152,7 @@ def confirm_path_warning(path: str, path_type: str | None = None) -> Awaitable[N
         if not path_type
         else f"{TR.words__unknown} {path_type.lower()}."
     )
-    return raise_if_not_confirmed(
+    return raise_if_cancelled(
         trezorui_api.show_warning(
             title=title,
             value=path,
@@ -201,7 +201,7 @@ def lock_time_disabled_warning() -> Awaitable[None]:
 
 
 def confirm_homescreen(image: bytes) -> Awaitable[None]:
-    return raise_if_not_confirmed(
+    return raise_if_cancelled(
         trezorui_api.confirm_homescreen(
             title=TR.homescreen__title_set,
             image=image,
@@ -420,7 +420,7 @@ def show_warning(
     br_code: ButtonRequestType = ButtonRequestType.Warning,
 ) -> Awaitable[None]:
     button = button or TR.buttons__continue  # def_arg
-    return raise_if_not_confirmed(
+    return raise_if_cancelled(
         trezorui_api.show_warning(
             title=content,
             description=subheader or "",
@@ -454,7 +454,7 @@ def show_success(
     button: str | None = None,
 ) -> Awaitable[None]:
     button = button or TR.buttons__continue  # def_arg
-    return raise_if_not_confirmed(
+    return raise_if_cancelled(
         trezorui_api.show_success(
             title=content,
             description=subheader or "",
@@ -690,7 +690,7 @@ def confirm_blob(
         )
     else:
         assert not extra_confirmation_if_not_read
-        return raise_if_not_confirmed(
+        return raise_if_cancelled(
             layout,
             br_name,
             br_code,
@@ -817,7 +817,7 @@ def confirm_properties(
     if subtitle:
         title += ": " + subtitle
 
-    return raise_if_not_confirmed(
+    return raise_if_cancelled(
         trezorui_api.confirm_properties(
             title=title,
             items=list(props),
@@ -1259,7 +1259,7 @@ if not utils.BITCOIN_ONLY:
 
 
 def confirm_joint_total(spending_amount: str, total_amount: str) -> Awaitable[None]:
-    return raise_if_not_confirmed(
+    return raise_if_cancelled(
         # FIXME: arguments for amount/fee are misused here
         trezorui_api.confirm_summary(
             amount=spending_amount,
@@ -1370,7 +1370,7 @@ def confirm_modify_fee(
 
 
 def confirm_coinjoin(max_rounds: int, max_fee_per_vbyte: str) -> Awaitable[None]:
-    return raise_if_not_confirmed(
+    return raise_if_cancelled(
         trezorui_api.confirm_coinjoin(
             max_rounds=str(max_rounds),
             max_feerate=max_fee_per_vbyte,
@@ -1604,7 +1604,7 @@ def confirm_set_new_pin(
     information: str,
     br_code: ButtonRequestType = BR_CODE_OTHER,
 ) -> Awaitable[None]:
-    return raise_if_not_confirmed(
+    return raise_if_cancelled(
         trezorui_api.confirm_emphasized(
             title=title,
             items=(

--- a/core/src/trezor/ui/layouts/bolt/reset.py
+++ b/core/src/trezor/ui/layouts/bolt/reset.py
@@ -4,7 +4,7 @@ import trezorui_api
 from trezor import TR
 from trezor.enums import ButtonRequestType
 
-from ..common import interact, raise_if_not_confirmed
+from ..common import interact, raise_if_cancelled
 
 CONFIRMED = trezorui_api.CONFIRMED  # global_import_cache
 
@@ -23,7 +23,7 @@ def show_share_words(
             group_index + 1, share_index + 1
         )
 
-    return raise_if_not_confirmed(
+    return raise_if_cancelled(
         trezorui_api.show_share_words(
             words=share_words,
             title=title,
@@ -92,7 +92,7 @@ def slip39_show_checklist(
         )
     )
 
-    return raise_if_not_confirmed(
+    return raise_if_cancelled(
         trezorui_api.show_checklist(
             title=TR.reset__slip39_checklist_title,
             button=TR.buttons__continue,
@@ -286,7 +286,7 @@ def show_intro_backup(single_share: bool, num_of_words: int | None) -> Awaitable
     else:
         description = TR.backup__info_multi_share_backup
 
-    return raise_if_not_confirmed(
+    return raise_if_cancelled(
         trezorui_api.show_info(
             title="",
             description=description,

--- a/core/src/trezor/ui/layouts/caesar/__init__.py
+++ b/core/src/trezor/ui/layouts/caesar/__init__.py
@@ -5,7 +5,7 @@ from trezor import TR, ui, utils
 from trezor.enums import ButtonRequestType, RecoveryType
 from trezor.wire import ActionCancelled
 
-from ..common import draw_simple, interact, raise_if_not_confirmed
+from ..common import draw_simple, interact, raise_if_cancelled
 
 if TYPE_CHECKING:
     from typing import Awaitable, Iterable, NoReturn, Sequence
@@ -70,7 +70,7 @@ def confirm_action(
     if description is not None and description_param is not None:
         description = description.format(description_param)
 
-    return raise_if_not_confirmed(
+    return raise_if_cancelled(
         trezorui_api.confirm_action(
             title=title,
             action=action,
@@ -112,7 +112,7 @@ def confirm_single(
 def confirm_reset_device(
     recovery: bool = False,
 ) -> Awaitable[None]:
-    return raise_if_not_confirmed(
+    return raise_if_cancelled(
         trezorui_api.confirm_reset_device(recovery=recovery),
         "recover_device" if recovery else "setup_device",
         ButtonRequestType.ProtectCall if recovery else ButtonRequestType.ResetDevice,
@@ -219,7 +219,7 @@ def lock_time_disabled_warning() -> Awaitable[ui.UiResult]:
 
 
 def confirm_homescreen(image: bytes) -> Awaitable[None]:
-    return raise_if_not_confirmed(
+    return raise_if_cancelled(
         trezorui_api.confirm_homescreen(
             title=TR.homescreen__title_set,
             image=image,
@@ -488,7 +488,7 @@ def show_danger(
 ) -> Awaitable[None]:
     title = title or TR.words__warning
     verb_cancel = verb_cancel or TR.buttons__cancel
-    return raise_if_not_confirmed(
+    return raise_if_cancelled(
         trezorui_api.show_danger(
             title=title,
             description=content,
@@ -683,7 +683,7 @@ def confirm_blob(
             extra_confirmation_if_not_read,
         )
     else:
-        return raise_if_not_confirmed(layout, br_name, br_code)
+        return raise_if_cancelled(layout, br_name, br_code)
 
 
 async def _confirm_ask_pagination(
@@ -812,7 +812,7 @@ def confirm_properties(
     if subtitle:
         title += ": " + subtitle
 
-    return raise_if_not_confirmed(
+    return raise_if_cancelled(
         trezorui_api.confirm_properties(
             title=title,
             items=items,
@@ -845,7 +845,7 @@ async def confirm_value(
         description += ":"
 
     if not info_items:
-        return await raise_if_not_confirmed(
+        return await raise_if_cancelled(
             trezorui_api.confirm_value(
                 title=title,
                 value=value,
@@ -927,7 +927,7 @@ def confirm_total(
     if source_account:
         account_info_items.append((TR.words__account_colon, source_account))
 
-    return raise_if_not_confirmed(
+    return raise_if_cancelled(
         trezorui_api.confirm_summary(
             amount=total_amount,
             amount_label=total_label,
@@ -1056,7 +1056,7 @@ if not utils.BITCOIN_ONLY:
         if account_path:
             account_items.append((TR.address_details__derivation_path, account_path))
 
-        await raise_if_not_confirmed(
+        await raise_if_cancelled(
             trezorui_api.confirm_summary(
                 amount=None,
                 amount_label=None,
@@ -1105,7 +1105,7 @@ if not utils.BITCOIN_ONLY:
         else:
             amount_title = f"{TR.words__amount}:"
             amount_value = total_amount
-        await raise_if_not_confirmed(
+        await raise_if_cancelled(
             trezorui_api.confirm_summary(
                 amount=amount_value,
                 amount_label=amount_title,
@@ -1155,7 +1155,7 @@ if not utils.BITCOIN_ONLY:
             amount_title if amount_title is not None else f"{TR.words__amount}:"
         )  # def_arg
         fee_title = fee_title or TR.words__fee  # def_arg
-        return raise_if_not_confirmed(
+        return raise_if_cancelled(
             trezorui_api.confirm_summary(
                 amount=amount,
                 amount_label=amount_title,
@@ -1243,7 +1243,7 @@ if not utils.BITCOIN_ONLY:
         amount_title = f"{TR.send__total_amount}:"
         fee_title = TR.send__including_fee
 
-        return raise_if_not_confirmed(
+        return raise_if_cancelled(
             trezorui_api.confirm_summary(
                 amount=amount,
                 amount_label=amount_title,
@@ -1294,7 +1294,7 @@ if not utils.BITCOIN_ONLY:
             )
 
             try:
-                await raise_if_not_confirmed(
+                await raise_if_cancelled(
                     summary_layout,
                     br_name,
                     br_code,
@@ -1366,13 +1366,13 @@ async def confirm_modify_output(
 
     send_button_request = True
     while True:
-        await raise_if_not_confirmed(
+        await raise_if_cancelled(
             address_layout,
             "modify_output" if send_button_request else None,
             ButtonRequestType.ConfirmOutput,
         )
         try:
-            await raise_if_not_confirmed(
+            await raise_if_cancelled(
                 modify_layout,
                 "modify_output" if send_button_request else None,
                 ButtonRequestType.ConfirmOutput,
@@ -1391,7 +1391,7 @@ def confirm_modify_fee(
     total_fee_new: str,
     fee_rate_amount: str | None = None,
 ) -> Awaitable[None]:
-    return raise_if_not_confirmed(
+    return raise_if_cancelled(
         trezorui_api.confirm_modify_fee(
             title=title,
             sign=sign,
@@ -1405,7 +1405,7 @@ def confirm_modify_fee(
 
 
 def confirm_coinjoin(max_rounds: int, max_fee_per_vbyte: str) -> Awaitable[None]:
-    return raise_if_not_confirmed(
+    return raise_if_cancelled(
         trezorui_api.confirm_coinjoin(
             max_rounds=str(max_rounds),
             max_feerate=max_fee_per_vbyte,
@@ -1466,7 +1466,7 @@ async def confirm_signverify(
         )
         try:
             if message_layout.page_count() <= LONG_MSG_PAGE_THRESHOLD:
-                await raise_if_not_confirmed(
+                await raise_if_cancelled(
                     message_layout,
                     br_name,
                     BR_CODE_OTHER,
@@ -1592,7 +1592,7 @@ def _confirm_multiple_pages_texts(
     verb: str,
     br_code: ButtonRequestType = BR_CODE_OTHER,
 ) -> Awaitable[None]:
-    return raise_if_not_confirmed(
+    return raise_if_cancelled(
         trezorui_api.multiple_pages_texts(
             title=title,
             verb=verb,
@@ -1699,7 +1699,7 @@ async def success_pin_change(curpin: str | None, newpin: str | None) -> None:
 
 
 def confirm_firmware_update(description: str, fingerprint: str) -> Awaitable[None]:
-    return raise_if_not_confirmed(
+    return raise_if_cancelled(
         trezorui_api.confirm_firmware_update(
             description=description, fingerprint=fingerprint
         ),

--- a/core/src/trezor/ui/layouts/caesar/reset.py
+++ b/core/src/trezor/ui/layouts/caesar/reset.py
@@ -4,7 +4,7 @@ import trezorui_api
 from trezor import TR
 from trezor.enums import ButtonRequestType
 
-from ..common import interact, raise_if_not_confirmed
+from ..common import interact, raise_if_cancelled
 from . import confirm_action, show_success, show_warning
 
 CONFIRMED = trezorui_api.CONFIRMED  # global_import_cache
@@ -121,7 +121,7 @@ def slip39_show_checklist(
         )
     )
 
-    return raise_if_not_confirmed(
+    return raise_if_cancelled(
         trezorui_api.show_checklist(
             title=TR.reset__slip39_checklist_title,
             button=TR.buttons__continue,

--- a/core/src/trezor/ui/layouts/common.py
+++ b/core/src/trezor/ui/layouts/common.py
@@ -57,7 +57,7 @@ async def interact(
     return result
 
 
-def raise_if_not_confirmed(
+def raise_if_cancelled(
     layout_obj: ui.LayoutObj[ui.UiResult],
     br_name: str | None,
     br_code: ButtonRequestType = ButtonRequestType.Other,

--- a/core/src/trezor/ui/layouts/delizia/__init__.py
+++ b/core/src/trezor/ui/layouts/delizia/__init__.py
@@ -5,7 +5,7 @@ from trezor import TR, ui, utils, workflow
 from trezor.enums import ButtonRequestType, RecoveryType
 from trezor.wire import ActionCancelled
 
-from ..common import draw_simple, interact, raise_if_not_confirmed, with_info
+from ..common import draw_simple, interact, raise_if_cancelled, with_info
 
 if TYPE_CHECKING:
     from typing import Any, Awaitable, Coroutine, Iterable, NoReturn, Sequence, TypeVar
@@ -62,7 +62,7 @@ def confirm_action(
     if prompt_screen or hold:
         # Note: multi-step confirm (prompt_screen/hold)
         # can't work with external menus yet
-        return raise_if_not_confirmed(
+        return raise_if_cancelled(
             flow,
             br_name,
             br_code,
@@ -96,7 +96,7 @@ def confirm_single(
     assert template_str in description
 
     begin, _separator, end = description.partition(template_str)
-    return raise_if_not_confirmed(
+    return raise_if_cancelled(
         trezorui_api.confirm_emphasized(
             title=title,
             items=(begin, (True, description_param), end),
@@ -108,7 +108,7 @@ def confirm_single(
 
 
 def confirm_reset_device(recovery: bool = False) -> Awaitable[None]:
-    return raise_if_not_confirmed(
+    return raise_if_cancelled(
         trezorui_api.confirm_reset_device(recovery=recovery), None
     )
 
@@ -175,7 +175,7 @@ def confirm_multisig_warning() -> Awaitable[None]:
 
 
 def confirm_multisig_different_paths_warning() -> Awaitable[None]:
-    return raise_if_not_confirmed(
+    return raise_if_cancelled(
         trezorui_api.show_danger(
             title=f"{TR.words__important}!",
             description=TR.send__multisig_different_paths,
@@ -214,7 +214,7 @@ def confirm_homescreen(
     # in order to display the new homescreen image.
     workflow.close_others()
 
-    return raise_if_not_confirmed(
+    return raise_if_cancelled(
         trezorui_api.confirm_homescreen(
             title=TR.homescreen__title_set,
             image=image,
@@ -320,7 +320,7 @@ async def show_address(
         )
         return result
 
-    await raise_if_not_confirmed(
+    await raise_if_cancelled(
         trezorui_api.flow_get_address(
             address=address,
             title=title or TR.address__title_receive_address,
@@ -353,7 +353,7 @@ async def show_pubkey(
     br_name: str = "show_pubkey",
 ) -> None:
 
-    await raise_if_not_confirmed(
+    await raise_if_cancelled(
         trezorui_api.flow_get_pubkey(
             pubkey=pubkey,
             title=title or title or TR.address__public_key,
@@ -404,7 +404,7 @@ def show_warning(
     br_code: ButtonRequestType = ButtonRequestType.Warning,
 ) -> Awaitable[None]:
     button = button or TR.buttons__continue  # def_arg
-    return raise_if_not_confirmed(
+    return raise_if_cancelled(
         trezorui_api.show_warning(
             title=TR.words__important,
             value=content,
@@ -426,7 +426,7 @@ def show_danger(
 ) -> Awaitable[None]:
     title = title or TR.words__warning
     verb_cancel = verb_cancel or TR.buttons__cancel
-    return raise_if_not_confirmed(
+    return raise_if_cancelled(
         trezorui_api.show_danger(
             title=title,
             description=content,
@@ -445,7 +445,7 @@ def show_success(
     button: str | None = None,
     time_ms: int = 0,
 ) -> Coroutine[Any, Any, None]:
-    return raise_if_not_confirmed(
+    return raise_if_cancelled(
         trezorui_api.show_success(
             title=content,
             button=button or "",
@@ -490,7 +490,7 @@ async def confirm_output(
     else:
         title = TR.send__title_sending_to
 
-    await raise_if_not_confirmed(
+    await raise_if_cancelled(
         trezorui_api.flow_confirm_output(
             title=TR.words__address,
             subtitle=title,
@@ -645,7 +645,7 @@ def confirm_blob(
             chunkify=chunkify,
             prompt_screen=prompt_screen,
         )
-        return raise_if_not_confirmed(
+        return raise_if_cancelled(
             layout,
             br_name,
             br_code,
@@ -765,7 +765,7 @@ def confirm_properties(
     verb: str | None = None,
 ) -> Awaitable[None]:
 
-    return raise_if_not_confirmed(
+    return raise_if_cancelled(
         trezorui_api.confirm_properties(
             title=title,
             subtitle=subtitle,
@@ -802,7 +802,7 @@ def confirm_total(
     if fee_rate_amount:
         fee_items.append((TR.confirm_total__fee_rate, fee_rate_amount))
 
-    return raise_if_not_confirmed(
+    return raise_if_cancelled(
         trezorui_api.confirm_summary(
             amount=total_amount,
             amount_label=total_label,
@@ -832,7 +832,7 @@ def _confirm_summary(
 ) -> Awaitable[None]:
     title = title or TR.words__title_summary  # def_arg
 
-    return raise_if_not_confirmed(
+    return raise_if_cancelled(
         trezorui_api.confirm_summary(
             amount=amount,
             amount_label=amount_label,
@@ -871,7 +871,7 @@ if not utils.BITCOIN_ONLY:
         br_code: ButtonRequestType = ButtonRequestType.SignTx,
         chunkify: bool = False,
     ) -> None:
-        await raise_if_not_confirmed(
+        await raise_if_cancelled(
             trezorui_api.flow_confirm_output(
                 title=TR.words__address,
                 subtitle=(
@@ -1053,7 +1053,7 @@ if not utils.BITCOIN_ONLY:
                 (TR.words__amount, total_amount),
                 (TR.send__maximum_fee, maximum_fee),
             )
-        await raise_if_not_confirmed(
+        await raise_if_cancelled(
             trezorui_api.flow_confirm_output(
                 title=verb,
                 subtitle=None,
@@ -1142,7 +1142,7 @@ if not utils.BITCOIN_ONLY:
         br_name: str = "confirm_solana_staking_tx",
         br_code: ButtonRequestType = ButtonRequestType.SignTx,
     ) -> None:
-        await raise_if_not_confirmed(
+        await raise_if_cancelled(
             trezorui_api.flow_confirm_output(
                 title=title,
                 subtitle=None,
@@ -1256,7 +1256,7 @@ async def confirm_modify_output(
 
     send_button_request = True
     while True:
-        await raise_if_not_confirmed(
+        await raise_if_cancelled(
             address_layout,
             "modify_output" if send_button_request else None,
             ButtonRequestType.ConfirmOutput,
@@ -1298,7 +1298,7 @@ def confirm_modify_fee(
 
 
 def confirm_coinjoin(max_rounds: int, max_fee_per_vbyte: str) -> Awaitable[None]:
-    return raise_if_not_confirmed(
+    return raise_if_cancelled(
         trezorui_api.confirm_coinjoin(
             max_rounds=str(max_rounds),
             max_feerate=max_fee_per_vbyte,
@@ -1526,7 +1526,7 @@ def confirm_set_new_pin(
     information: str,
     br_code: ButtonRequestType = BR_CODE_OTHER,
 ) -> Awaitable[None]:
-    return raise_if_not_confirmed(
+    return raise_if_cancelled(
         trezorui_api.flow_confirm_set_new_pin(title=title, description=description),
         br_name,
         br_code,
@@ -1573,7 +1573,7 @@ async def success_pin_change(curpin: str | None, newpin: str | None) -> None:
 
 
 def confirm_firmware_update(description: str, fingerprint: str) -> Awaitable[None]:
-    return raise_if_not_confirmed(
+    return raise_if_cancelled(
         trezorui_api.confirm_firmware_update(
             description=description, fingerprint=fingerprint
         ),
@@ -1595,7 +1595,7 @@ def set_brightness(current: int | None = None) -> Awaitable[None]:
 
 def tutorial(br_code: ButtonRequestType = BR_CODE_OTHER) -> Awaitable[None]:
     """Showing users how to interact with the device."""
-    return raise_if_not_confirmed(
+    return raise_if_cancelled(
         trezorui_api.tutorial(),
         "tutorial",
         br_code,

--- a/core/src/trezor/ui/layouts/delizia/recovery.py
+++ b/core/src/trezor/ui/layouts/delizia/recovery.py
@@ -7,7 +7,7 @@ from trezor.enums import ButtonRequestType, RecoveryType
 from apps.common import backup_types
 
 from ..common import interact
-from . import raise_if_not_confirmed
+from . import raise_if_cancelled
 
 CONFIRMED = trezorui_api.CONFIRMED  # global_import_cache
 CANCELLED = trezorui_api.CANCELLED  # global_import_cache
@@ -90,7 +90,7 @@ def format_remaining_shares_info(
 
 
 async def show_group_share_success(share_index: int, group_index: int) -> None:
-    await raise_if_not_confirmed(
+    await raise_if_cancelled(
         trezorui_api.show_group_share_success(
             lines=[
                 TR.recovery__you_have_entered,
@@ -179,7 +179,7 @@ async def show_recovery_warning(
     br_code: ButtonRequestType = ButtonRequestType.Warning,
 ) -> None:
     button = button or TR.buttons__try_again  # def_arg
-    await raise_if_not_confirmed(
+    await raise_if_cancelled(
         trezorui_api.show_warning(
             title=content or TR.words__warning,
             value=subheader or "",

--- a/core/src/trezor/ui/layouts/delizia/reset.py
+++ b/core/src/trezor/ui/layouts/delizia/reset.py
@@ -6,7 +6,7 @@ from trezor.enums import ButtonRequestType
 from trezor.wire import ActionCancelled
 
 from ..common import interact
-from . import raise_if_not_confirmed, show_success
+from . import raise_if_cancelled, show_success
 
 CONFIRMED = trezorui_api.CONFIRMED  # global_import_cache
 
@@ -37,7 +37,7 @@ def show_share_words(
     assert len(instructions) < 3
     text_confirm = TR.reset__words_written_down_template.format(words_count)
 
-    return raise_if_not_confirmed(
+    return raise_if_cancelled(
         trezorui_api.show_share_words_extended(
             words=share_words,
             subtitle=subtitle,
@@ -327,7 +327,7 @@ def show_reset_warning(
     button: str | None = None,
     br_code: ButtonRequestType = ButtonRequestType.Warning,
 ) -> Awaitable[None]:
-    return raise_if_not_confirmed(
+    return raise_if_cancelled(
         trezorui_api.show_warning(
             title=subheader or "",
             description=content,

--- a/core/src/trezor/ui/layouts/eckhart/__init__.py
+++ b/core/src/trezor/ui/layouts/eckhart/__init__.py
@@ -5,7 +5,7 @@ from trezor import TR, ui, utils, workflow
 from trezor.enums import ButtonRequestType, RecoveryType
 from trezor.wire import ActionCancelled
 
-from ..common import draw_simple, interact, raise_if_not_confirmed, with_info
+from ..common import draw_simple, interact, raise_if_cancelled, with_info
 
 if TYPE_CHECKING:
     from typing import Any, Awaitable, Coroutine, Iterable, NoReturn, Sequence, TypeVar
@@ -42,7 +42,7 @@ def confirm_action(
     if description is not None and description_param is not None:
         description = description.format(description_param)
 
-    return raise_if_not_confirmed(
+    return raise_if_cancelled(
         trezorui_api.confirm_action(
             title=title,
             action=action,
@@ -76,7 +76,7 @@ def confirm_single(
     assert template_str in description
 
     begin, _separator, end = description.partition(template_str)
-    return raise_if_not_confirmed(
+    return raise_if_cancelled(
         trezorui_api.confirm_emphasized(
             title=title,
             items=(begin, (True, description_param), end),
@@ -88,7 +88,7 @@ def confirm_single(
 
 
 def confirm_reset_device(recovery: bool = False) -> Awaitable[None]:
-    return raise_if_not_confirmed(
+    return raise_if_cancelled(
         trezorui_api.confirm_reset_device(recovery=recovery), None
     )
 
@@ -194,7 +194,7 @@ def lock_time_disabled_warning() -> Awaitable[None]:
 def confirm_homescreen(
     image: bytes,
 ) -> Awaitable[None]:
-    return raise_if_not_confirmed(
+    return raise_if_cancelled(
         trezorui_api.confirm_homescreen(
             title=TR.homescreen__title_set,
             image=image,
@@ -300,7 +300,7 @@ async def show_address(
 
     if warning is None and multisig_index is not None:
         warning = TR.send__receiving_to_multisig
-    await raise_if_not_confirmed(
+    await raise_if_cancelled(
         trezorui_api.flow_get_address(
             address=address,
             title=title or TR.words__receive,
@@ -333,7 +333,7 @@ async def show_pubkey(
     br_name: str = "show_pubkey",
 ) -> None:
 
-    await raise_if_not_confirmed(
+    await raise_if_cancelled(
         trezorui_api.flow_get_pubkey(
             pubkey=pubkey,
             title=title or TR.address__public_key,
@@ -384,7 +384,7 @@ def show_warning(
     br_code: ButtonRequestType = ButtonRequestType.Warning,
 ) -> Awaitable[None]:
     button = button or TR.words__continue_anyway  # def_arg
-    return raise_if_not_confirmed(
+    return raise_if_cancelled(
         trezorui_api.show_warning(
             title=TR.words__important,
             button=button,
@@ -408,7 +408,7 @@ def show_danger(
 ) -> Awaitable[None]:
     title = title or TR.words__warning
     verb_cancel = verb_cancel or TR.buttons__cancel
-    return raise_if_not_confirmed(
+    return raise_if_cancelled(
         trezorui_api.show_danger(
             title=title,
             description=content,
@@ -429,7 +429,7 @@ def show_success(
     time_ms: int = 0,
 ) -> Coroutine[Any, Any, None]:
     button = button or TR.buttons__continue  # def_arg
-    return raise_if_not_confirmed(
+    return raise_if_cancelled(
         trezorui_api.show_success(
             title=subheader if subheader else TR.words__title_done,
             button=button,
@@ -475,7 +475,7 @@ async def confirm_output(
     else:
         title = TR.send__title_sending_to
 
-    await raise_if_not_confirmed(
+    await raise_if_cancelled(
         trezorui_api.flow_confirm_output(
             title=TR.words__send,
             subtitle=title,
@@ -628,7 +628,7 @@ def confirm_blob(
             chunkify=chunkify,
             cancel=True,
         )
-        return raise_if_not_confirmed(
+        return raise_if_cancelled(
             layout,
             br_name,
             br_code,
@@ -753,7 +753,7 @@ def confirm_properties(
     if subtitle:
         title += ": " + subtitle
 
-    return raise_if_not_confirmed(
+    return raise_if_cancelled(
         trezorui_api.confirm_properties(
             title=title,
             items=list(props),
@@ -790,7 +790,7 @@ def confirm_total(
     if fee_rate_amount:
         fee_items.append((TR.confirm_total__fee_rate, fee_rate_amount))
 
-    return raise_if_not_confirmed(
+    return raise_if_cancelled(
         trezorui_api.confirm_summary(
             amount=total_amount,
             amount_label=total_label,
@@ -820,7 +820,7 @@ def _confirm_summary(
 ) -> Awaitable[None]:
     title = title or TR.words__send  # def_arg
 
-    return raise_if_not_confirmed(
+    return raise_if_cancelled(
         trezorui_api.confirm_summary(
             amount=amount,
             amount_label=amount_label,
@@ -877,7 +877,7 @@ if not utils.BITCOIN_ONLY:
         )
         title = TR.words__send
 
-        await raise_if_not_confirmed(
+        await raise_if_cancelled(
             trezorui_api.flow_confirm_output(
                 title=title,
                 subtitle=subtitle,
@@ -1068,7 +1068,7 @@ if not utils.BITCOIN_ONLY:
                 (TR.words__amount, total_amount),
                 (TR.send__maximum_fee, maximum_fee),
             )
-        await raise_if_not_confirmed(
+        await raise_if_cancelled(
             trezorui_api.flow_confirm_output(
                 title=verb,
                 subtitle=None,
@@ -1149,7 +1149,7 @@ if not utils.BITCOIN_ONLY:
         br_name: str = "confirm_solana_staking_tx",
         br_code: ButtonRequestType = ButtonRequestType.SignTx,
     ) -> None:
-        await raise_if_not_confirmed(
+        await raise_if_cancelled(
             trezorui_api.flow_confirm_output(
                 title=title,
                 subtitle=None,
@@ -1264,7 +1264,7 @@ async def confirm_modify_output(
 
     send_button_request = True
     while True:
-        await raise_if_not_confirmed(
+        await raise_if_cancelled(
             address_layout,
             "modify_output" if send_button_request else None,
             ButtonRequestType.ConfirmOutput,
@@ -1306,7 +1306,7 @@ def confirm_modify_fee(
 
 
 def confirm_coinjoin(max_rounds: int, max_fee_per_vbyte: str) -> Awaitable[None]:
-    return raise_if_not_confirmed(
+    return raise_if_cancelled(
         trezorui_api.confirm_coinjoin(
             max_rounds=str(max_rounds),
             max_feerate=max_fee_per_vbyte,
@@ -1535,7 +1535,7 @@ def confirm_set_new_pin(
     information: str,
     br_code: ButtonRequestType = BR_CODE_OTHER,
 ) -> Awaitable[None]:
-    return raise_if_not_confirmed(
+    return raise_if_cancelled(
         trezorui_api.flow_confirm_set_new_pin(title=title, description=information),
         br_name,
         br_code,
@@ -1581,7 +1581,7 @@ async def success_pin_change(curpin: str | None, newpin: str | None) -> None:
 
 
 def confirm_firmware_update(description: str, fingerprint: str) -> Awaitable[None]:
-    return raise_if_not_confirmed(
+    return raise_if_cancelled(
         trezorui_api.confirm_firmware_update(
             description=description, fingerprint=fingerprint
         ),
@@ -1591,7 +1591,7 @@ def confirm_firmware_update(description: str, fingerprint: str) -> Awaitable[Non
 
 
 def set_brightness(current: int | None = None) -> Awaitable[None]:
-    return raise_if_not_confirmed(
+    return raise_if_cancelled(
         trezorui_api.set_brightness(current=current),
         "set_brightness",
         BR_CODE_OTHER,
@@ -1600,7 +1600,7 @@ def set_brightness(current: int | None = None) -> Awaitable[None]:
 
 def tutorial(br_code: ButtonRequestType = BR_CODE_OTHER) -> Awaitable[None]:
     """Showing users how to interact with the device."""
-    return raise_if_not_confirmed(
+    return raise_if_cancelled(
         trezorui_api.tutorial(),
         "tutorial",
         br_code,

--- a/core/src/trezor/ui/layouts/eckhart/recovery.py
+++ b/core/src/trezor/ui/layouts/eckhart/recovery.py
@@ -7,7 +7,7 @@ from trezor.enums import ButtonRequestType, RecoveryType
 from apps.common import backup_types
 
 from ..common import interact
-from . import raise_if_not_confirmed
+from . import raise_if_cancelled
 
 CONFIRMED = trezorui_api.CONFIRMED  # global_import_cache
 CANCELLED = trezorui_api.CANCELLED  # global_import_cache
@@ -90,7 +90,7 @@ def format_remaining_shares_info(
 
 
 async def show_group_share_success(share_index: int, group_index: int) -> None:
-    await raise_if_not_confirmed(
+    await raise_if_cancelled(
         trezorui_api.show_group_share_success(
             lines=[
                 f"{TR.recovery__share_from_group_entered_template.format(share_index + 1, group_index + 1)}",
@@ -176,7 +176,7 @@ async def show_recovery_warning(
     button: str | None = None,
     br_code: ButtonRequestType = ButtonRequestType.Warning,
 ) -> None:
-    await raise_if_not_confirmed(
+    await raise_if_cancelled(
         trezorui_api.show_warning(
             title=subheader or TR.words__important,
             value=content or "",

--- a/core/src/trezor/ui/layouts/eckhart/reset.py
+++ b/core/src/trezor/ui/layouts/eckhart/reset.py
@@ -6,7 +6,7 @@ from trezor.enums import ButtonRequestType
 from trezor.wire import ActionCancelled
 
 from ..common import interact
-from . import raise_if_not_confirmed, show_success
+from . import raise_if_cancelled, show_success
 
 CONFIRMED = trezorui_api.CONFIRMED  # global_import_cache
 
@@ -58,7 +58,7 @@ def show_share_words(
 
     text_confirm = TR.reset__words_written_down_template.format(words_count)
 
-    return raise_if_not_confirmed(
+    return raise_if_cancelled(
         trezorui_api.show_share_words_extended(
             words=share_words,
             subtitle=subtitle,
@@ -354,7 +354,7 @@ def show_reset_warning(
     button: str | None = None,
     br_code: ButtonRequestType = ButtonRequestType.Warning,
 ) -> Awaitable[None]:
-    return raise_if_not_confirmed(
+    return raise_if_cancelled(
         trezorui_api.show_warning(
             title=subheader or "",
             description="",


### PR DESCRIPTION
We do not care about the result of `interact` call, we let it raise if the action is cancelled. If the `interact` does not raise, any output (eg. `UiResult.CONFIRMED`, `UiResult.INFO`) is treated as valid - thus the renaming brings clarity to what this function actually does.