### PR TITLE
refactor(core):  reconfigure mpu directly in the storage

### DIFF
--- a/core/embed/sys/smcall/stm32/smcall_dispatch.c
+++ b/core/embed/sys/smcall/stm32/smcall_dispatch.c
@@ -27,7 +27,6 @@
 #include <sys/bootargs.h>
 #include <sys/bootutils.h>
 #include <sys/irq.h>
-#include <sys/mpu.h>
 #include <sys/system.h>
 #include <util/board_capabilities.h>
 #include <util/fwutils.h>
@@ -197,22 +196,18 @@ __attribute((no_stack_protector)) void smcall_handler(uint32_t *args,
       PIN_UI_WAIT_CALLBACK callback = (PIN_UI_WAIT_CALLBACK)args[0];
       const uint8_t *salt = (const uint8_t *)args[1];
       uint16_t salt_len = args[2];
-      mpu_reconfig(MPU_MODE_STORAGE);
       storage_init__verified(callback, salt, salt_len);
     } break;
 
     case SMCALL_STORAGE_WIPE: {
-      mpu_reconfig(MPU_MODE_STORAGE);
       storage_wipe();
     } break;
 
     case SMCALL_STORAGE_IS_UNLOCKED: {
-      mpu_reconfig(MPU_MODE_STORAGE);
       args[0] = storage_is_unlocked();
     } break;
 
     case SMCALL_STORAGE_LOCK: {
-      mpu_reconfig(MPU_MODE_STORAGE);
       storage_lock();
     } break;
 
@@ -220,22 +215,18 @@ __attribute((no_stack_protector)) void smcall_handler(uint32_t *args,
       const uint8_t *pin = (const uint8_t *)args[0];
       size_t pin_len = args[1];
       const uint8_t *ext_salt = (const uint8_t *)args[2];
-      mpu_reconfig(MPU_MODE_STORAGE);
       args[0] = storage_unlock__verified(pin, pin_len, ext_salt);
     } break;
 
     case SMCALL_STORAGE_HAS_PIN: {
-      mpu_reconfig(MPU_MODE_STORAGE);
       args[0] = storage_has_pin();
     } break;
 
     case SMCALL_STORAGE_PIN_FAILS_INCREASE: {
-      mpu_reconfig(MPU_MODE_STORAGE);
       args[0] = storage_pin_fails_increase();
     } break;
 
     case SMCALL_STORAGE_GET_PIN_REM: {
-      mpu_reconfig(MPU_MODE_STORAGE);
       args[0] = storage_get_pin_rem();
     } break;
 
@@ -246,7 +237,6 @@ __attribute((no_stack_protector)) void smcall_handler(uint32_t *args,
       size_t newpin_len = args[3];
       const uint8_t *old_ext_salt = (const uint8_t *)args[4];
       const uint8_t *new_ext_salt = (const uint8_t *)args[5];
-      mpu_reconfig(MPU_MODE_STORAGE);
       args[0] = storage_change_pin__verified(
           oldpin, oldpin_len, newpin, newpin_len, old_ext_salt, new_ext_salt);
     } break;
@@ -254,12 +244,10 @@ __attribute((no_stack_protector)) void smcall_handler(uint32_t *args,
     case SMCALL_STORAGE_ENSURE_NOT_WIPE_CODE: {
       const uint8_t *pin = (const uint8_t *)args[0];
       size_t pin_len = args[1];
-      mpu_reconfig(MPU_MODE_STORAGE);
       storage_ensure_not_wipe_code__verified(pin, pin_len);
     } break;
 
     case SMCALL_STORAGE_HAS_WIPE_CODE: {
-      mpu_reconfig(MPU_MODE_STORAGE);
       args[0] = storage_has_wipe_code();
     } break;
 
@@ -269,14 +257,12 @@ __attribute((no_stack_protector)) void smcall_handler(uint32_t *args,
       const uint8_t *ext_salt = (const uint8_t *)args[2];
       const uint8_t *wipe_code = (const uint8_t *)args[3];
       size_t wipe_code_len = args[4];
-      mpu_reconfig(MPU_MODE_STORAGE);
       args[0] = storage_change_wipe_code__verified(pin, pin_len, ext_salt,
                                                    wipe_code, wipe_code_len);
     } break;
 
     case SMCALL_STORAGE_HAS: {
       uint16_t key = (uint16_t)args[0];
-      mpu_reconfig(MPU_MODE_STORAGE);
       args[0] = storage_has(key);
     } break;
 
@@ -285,7 +271,6 @@ __attribute((no_stack_protector)) void smcall_handler(uint32_t *args,
       void *val = (void *)args[1];
       uint16_t max_len = (uint16_t)args[2];
       uint16_t *len = (uint16_t *)args[3];
-      mpu_reconfig(MPU_MODE_STORAGE);
       args[0] = storage_get__verified(key, val, max_len, len);
     } break;
 
@@ -293,27 +278,23 @@ __attribute((no_stack_protector)) void smcall_handler(uint32_t *args,
       uint16_t key = (uint16_t)args[0];
       const void *val = (const void *)args[1];
       uint16_t len = (uint16_t)args[2];
-      mpu_reconfig(MPU_MODE_STORAGE);
       args[0] = storage_set__verified(key, val, len);
     } break;
 
     case SMCALL_STORAGE_DELETE: {
       uint16_t key = (uint16_t)args[0];
-      mpu_reconfig(MPU_MODE_STORAGE);
       args[0] = storage_delete(key);
     } break;
 
     case SMCALL_STORAGE_SET_COUNTER: {
       uint16_t key = (uint16_t)args[0];
       uint32_t count = args[1];
-      mpu_reconfig(MPU_MODE_STORAGE);
       args[0] = storage_set_counter(key, count);
     } break;
 
     case SMCALL_STORAGE_NEXT_COUNTER: {
       uint16_t key = (uint16_t)args[0];
       uint32_t *count = (uint32_t *)args[1];
-      mpu_reconfig(MPU_MODE_STORAGE);
       args[0] = storage_next_counter__verified(key, count);
     } break;
 

--- a/core/embed/sys/syscall/stm32/syscall_dispatch.c
+++ b/core/embed/sys/syscall/stm32/syscall_dispatch.c
@@ -32,7 +32,6 @@
 #include <sec/secret.h>
 #include <sys/bootutils.h>
 #include <sys/irq.h>
-#include <sys/mpu.h>
 #include <sys/sysevent.h>
 #include <sys/systask.h>
 #include <sys/system.h>
@@ -553,22 +552,18 @@ __attribute((no_stack_protector)) void syscall_handler(uint32_t *args,
       storage_init_callback = (PIN_UI_WAIT_CALLBACK)args[0];
       const uint8_t *salt = (const uint8_t *)args[1];
       uint16_t salt_len = args[2];
-      mpu_reconfig(MPU_MODE_STORAGE);
       storage_init__verified(storage_init_callback_wrapper, salt, salt_len);
     } break;
 
     case SYSCALL_STORAGE_WIPE: {
-      mpu_reconfig(MPU_MODE_STORAGE);
       storage_wipe();
     } break;
 
     case SYSCALL_STORAGE_IS_UNLOCKED: {
-      mpu_reconfig(MPU_MODE_STORAGE);
       args[0] = storage_is_unlocked();
     } break;
 
     case SYSCALL_STORAGE_LOCK: {
-      mpu_reconfig(MPU_MODE_STORAGE);
       storage_lock();
     } break;
 
@@ -576,22 +571,18 @@ __attribute((no_stack_protector)) void syscall_handler(uint32_t *args,
       const uint8_t *pin = (const uint8_t *)args[0];
       size_t pin_len = args[1];
       const uint8_t *ext_salt = (const uint8_t *)args[2];
-      mpu_reconfig(MPU_MODE_STORAGE);
       args[0] = storage_unlock__verified(pin, pin_len, ext_salt);
     } break;
 
     case SYSCALL_STORAGE_HAS_PIN: {
-      mpu_reconfig(MPU_MODE_STORAGE);
       args[0] = storage_has_pin();
     } break;
 
     case SYSCALL_STORAGE_PIN_FAILS_INCREASE: {
-      mpu_reconfig(MPU_MODE_STORAGE);
       args[0] = storage_pin_fails_increase();
     } break;
 
     case SYSCALL_STORAGE_GET_PIN_REM: {
-      mpu_reconfig(MPU_MODE_STORAGE);
       args[0] = storage_get_pin_rem();
     } break;
 
@@ -602,7 +593,6 @@ __attribute((no_stack_protector)) void syscall_handler(uint32_t *args,
       size_t newpin_len = args[3];
       const uint8_t *old_ext_salt = (const uint8_t *)args[4];
       const uint8_t *new_ext_salt = (const uint8_t *)args[5];
-      mpu_reconfig(MPU_MODE_STORAGE);
       args[0] = storage_change_pin__verified(
           oldpin, oldpin_len, newpin, newpin_len, old_ext_salt, new_ext_salt);
     } break;
@@ -610,12 +600,10 @@ __attribute((no_stack_protector)) void syscall_handler(uint32_t *args,
     case SYSCALL_STORAGE_ENSURE_NOT_WIPE_CODE: {
       const uint8_t *pin = (const uint8_t *)args[0];
       size_t pin_len = args[1];
-      mpu_reconfig(MPU_MODE_STORAGE);
       storage_ensure_not_wipe_code__verified(pin, pin_len);
     } break;
 
     case SYSCALL_STORAGE_HAS_WIPE_CODE: {
-      mpu_reconfig(MPU_MODE_STORAGE);
       args[0] = storage_has_wipe_code();
     } break;
 
@@ -625,14 +613,12 @@ __attribute((no_stack_protector)) void syscall_handler(uint32_t *args,
       const uint8_t *ext_salt = (const uint8_t *)args[2];
       const uint8_t *wipe_code = (const uint8_t *)args[3];
       size_t wipe_code_len = args[4];
-      mpu_reconfig(MPU_MODE_STORAGE);
       args[0] = storage_change_wipe_code__verified(pin, pin_len, ext_salt,
                                                    wipe_code, wipe_code_len);
     } break;
 
     case SYSCALL_STORAGE_HAS: {
       uint16_t key = (uint16_t)args[0];
-      mpu_reconfig(MPU_MODE_STORAGE);
       args[0] = storage_has(key);
     } break;
 
@@ -641,7 +627,6 @@ __attribute((no_stack_protector)) void syscall_handler(uint32_t *args,
       void *val = (void *)args[1];
       uint16_t max_len = (uint16_t)args[2];
       uint16_t *len = (uint16_t *)args[3];
-      mpu_reconfig(MPU_MODE_STORAGE);
       args[0] = storage_get__verified(key, val, max_len, len);
     } break;
 
@@ -649,27 +634,23 @@ __attribute((no_stack_protector)) void syscall_handler(uint32_t *args,
       uint16_t key = (uint16_t)args[0];
       const void *val = (const void *)args[1];
       uint16_t len = (uint16_t)args[2];
-      mpu_reconfig(MPU_MODE_STORAGE);
       args[0] = storage_set__verified(key, val, len);
     } break;
 
     case SYSCALL_STORAGE_DELETE: {
       uint16_t key = (uint16_t)args[0];
-      mpu_reconfig(MPU_MODE_STORAGE);
       args[0] = storage_delete(key);
     } break;
 
     case SYSCALL_STORAGE_SET_COUNTER: {
       uint16_t key = (uint16_t)args[0];
       uint32_t count = args[1];
-      mpu_reconfig(MPU_MODE_STORAGE);
       args[0] = storage_set_counter(key, count);
     } break;
 
     case SYSCALL_STORAGE_NEXT_COUNTER: {
       uint16_t key = (uint16_t)args[0];
       uint32_t *count = (uint32_t *)args[1];
-      mpu_reconfig(MPU_MODE_STORAGE);
       args[0] = storage_next_counter__verified(key, count);
     } break;
 

--- a/legacy/sys/mpu.h
+++ b/legacy/sys/mpu.h
@@ -1,0 +1,32 @@
+/*
+ * This file is part of the Trezor project, https://trezor.io/
+ *
+ * Copyright (c) SatoshiLabs
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#pragma once
+
+// Empty implementation of mpu.h
+
+typedef int mpu_mode_t;
+
+#define MPU_MODE_STORAGE 0
+
+#define mpu_reconfig(mode) (mode)
+#define mpu_restore(mode) \
+  do {                    \
+    (void)mode;           \
+  } while (0)

--- a/storage/tests/c/sys/mpu.h
+++ b/storage/tests/c/sys/mpu.h
@@ -1,0 +1,32 @@
+/*
+ * This file is part of the Trezor project, https://trezor.io/
+ *
+ * Copyright (c) SatoshiLabs
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#pragma once
+
+// Empty implementation of mpu.h for the storage tests
+
+typedef int mpu_mode_t;
+
+#define MPU_MODE_STORAGE 0
+
+#define mpu_reconfig(mode) (mode)
+#define mpu_restore(mode) \
+  do {                    \
+    (void)mode;           \
+  } while (0)


### PR DESCRIPTION
This PR moves MPU reconfiguration - enabling access to the storage flash region - directly to the storage module. 

This change fixes the following issues:
1) The MPU was reconfigured in the wrong place - the storage API could only be called via smcall or syscall
2) The MPU reconfiguration code was duplicated in both the smcall and syscall dispatchers
3) On models with secmon, the MPU was reconfigured in the kernel even when it was not necessary

The change has no effect on device behavior.
