### PR TITLE
fixup! test(core): fix `test_emu_sanity` on THP emulators

### DIFF
--- a/.github/workflows/core.yml
+++ b/.github/workflows/core.yml
@@ -191,8 +191,6 @@ jobs:
         if: matrix.coins == 'universal' && matrix.asan == 'noasan'
       - run: nix-shell --run "poetry run make -C core build_unix_frozen"
       - run: nix-shell --run "poetry run make -C core test_emu_sanity"
-        # Skip `test_emu_sanity` on THP emulators
-        if: matrix.protocol == 'v1'
       - run: cp core/build/unix/trezor-emu-core core/build/unix/trezor-emu-core-${{ matrix.model }}-${{ matrix.coins }}
       - uses: actions/upload-artifact@v4
         with:

--- a/core/Makefile
+++ b/core/Makefile
@@ -183,7 +183,7 @@ test_rust: ## run rs unit tests
 		-- --test-threads=1 --nocapture
 
 test_emu_sanity: ## make sure the emulator doesn't crash on startup
-	$(EMU) --disable-animation --headless --temporary-profile -c -- trezorctl -v ping "Hello World!"
+	$(EMU) --disable-animation --headless --temporary-profile --slip0014 --command true
 
 test_emu: ## run selected device tests from python-trezor
 	$(EMU_TEST) $(PYTEST) $(TESTPATH)/device_tests $(TESTOPTS) --lang=$(TEST_LANG)


### PR DESCRIPTION
Don't use `trezorctl` for sanity test, since it requires pairing confirmation.

Should be squashed in fd6135445859c7c315f598bc89a3046e26d6b6bc.

<img width="2806" height="1848" alt="image" src="https://github.com/user-attachments/assets/9e202465-f783-424d-8803-640578a65c02" />



<!--
For core developers:
- Assign yourself to the PR.
- Set the priority to match the original issue.
- Add the PR to the current sprint.
- If it's a draft PR, mark it as "In Progress."
- If it's a final PR, mark it as "Needs Review."

For external contributors:
- Please open an issue before submitting a PR so we can discuss whether we want to proceed with it.
-->
