### PR TITLE
feat(core): use menu for `confirm_value`-related info items on Caesar

### DIFF
--- a/core/src/apps/nostr/sign_event.py
+++ b/core/src/apps/nostr/sign_event.py
@@ -33,23 +33,16 @@ async def sign_event(msg: NostrSignEvent, keychain: Keychain) -> NostrEventSigna
 
     title = TR.nostr__event_kind_template.format(kind)
 
-    # confirm_value on TR only accepts one single info item
-    # which is why we concatenate all of them here.
-    # This is not great, but it gets the job done for now.
-    tags_str = f"created_at: {created_at}"
-    for t in tags:
-        tags_str += f"\n\n{t[0]}: " + (f" {' '.join(t[1:])}" if len(t) > 1 else "")
-
-    await confirm_value(
-        title, content, "", "nostr_sign_event", info_items=[("", tags_str)]
-    )
-
     # The event ID is obtained by serializing the event in a specific way:
     # "[0,pubkey,created_at,kind,tags,content]"
     # See NIP-01: https://github.com/nostr-protocol/nips/blob/master/01.md
     serialized_tags = ",".join(
         ["[" + ",".join(f'"{t}"' for t in tag) + "]" for tag in tags]
     )
+
+    info_items = [("Created", str(created_at)), ("Tags", serialized_tags)]
+    await confirm_value(title, content, "", "nostr_sign_event", info_items=info_items)
+
     serialized_event = f'[0,"{hexlify(pk).decode()}",{created_at},{kind},[{serialized_tags}],"{content}"]'
     event_id = sha256(serialized_event).digest()
 

--- a/core/src/apps/solana/layout.py
+++ b/core/src/apps/solana/layout.py
@@ -313,11 +313,10 @@ async def confirm_system_transfer(
     await confirm_solana_recipient(
         recipient=base58.encode(transfer_instruction.recipient_account[0]),
         title=TR.words__recipient,
+        items=[(TR.words__blockhash, base58.encode(blockhash))],
     )
 
-    await confirm_custom_transaction(
-        transfer_instruction.lamports, 9, "SOL", fee, blockhash
-    )
+    await confirm_custom_transaction(transfer_instruction.lamports, 9, "SOL", fee)
 
 
 async def confirm_token_transfer(
@@ -333,8 +332,9 @@ async def confirm_token_transfer(
     items = []
     if token_account != destination_account:
         items.append(
-            (f"{TR.solana__associated_token_account}:", base58.encode(token_account))
+            (TR.solana__associated_token_account, base58.encode(token_account))
         )
+    items.append((TR.words__blockhash, base58.encode(blockhash)))
 
     await confirm_solana_recipient(
         recipient=base58.encode(destination_account),
@@ -355,7 +355,7 @@ async def confirm_token_transfer(
             br_code=ButtonRequestType.ConfirmOutput,
         )
 
-    await confirm_custom_transaction(amount, decimals, token.symbol, fee, blockhash)
+    await confirm_custom_transaction(amount, decimals, token.symbol, fee)
 
 
 def _fee_ui_info(
@@ -386,10 +386,8 @@ async def confirm_custom_transaction(
     decimals: int,
     unit: str,
     fee: Fee,
-    blockhash: bytes,
 ) -> None:
     fee_title, fee_str, fee_items = _fee_ui_info(False, fee)
-    fee_items.append((TR.words__blockhash, base58.encode(blockhash)))
     await confirm_solana_tx(
         amount=f"{format_amount(amount, decimals)} {unit}",
         fee=fee_str,

--- a/core/src/trezor/ui/layouts/menu.py
+++ b/core/src/trezor/ui/layouts/menu.py
@@ -6,11 +6,13 @@ from trezor.ui.layouts.common import interact
 from trezor.wire import ActionCancelled
 
 if TYPE_CHECKING:
-    from typing import Callable, Iterable, Sequence
+    from typing import Callable, Iterable, Sequence, TypeVar
 
     from typing_extensions import Self
 
     from common import ExceptionType
+
+    T = TypeVar("T")
 
 
 class Menu:
@@ -29,13 +31,13 @@ class Menu:
 
 
 class Details:
-    def __init__(self, name: str, factory: Callable[[], Awaitable[None]]) -> None:
+    def __init__(self, name: str, factory: Callable[[], Awaitable[T]]) -> None:
         self.name = name
         self.factory = factory
 
     @classmethod
     def from_layout(
-        cls, name: str, layout_factory: Callable[[], trezorui_api.LayoutObj[None]]
+        cls, name: str, layout_factory: Callable[[], trezorui_api.LayoutObj[T]]
     ) -> Self:
         return cls(
             name,
@@ -71,7 +73,7 @@ async def show_menu(
         else:
             assert isinstance(menu, Details)
             # Details' layout is created on-demand (saving memory)
-            await menu.factory()
+            await menu.factory()  # the result is ignored
 
         # go one level up, or exit the menu
         if menu_path:

--- a/tests/input_flows_helpers.py
+++ b/tests/input_flows_helpers.py
@@ -694,12 +694,14 @@ class EthereumFlow:
         elif self.client.layout_type is LayoutType.Caesar:
             # confirm intro
             if info:
-                self.debug.press_right()
+                self.debug.press_right()  # enter menu
+                self.debug.press_middle()  # choose item
                 assert self.debug.read_layout().title() in (
                     TR.ethereum__staking_stake_address,
                     TR.ethereum__staking_claim_address,
                 )
-                self.debug.press_left()
+                self.debug.press_left()  # back to menu
+                self.debug.press_left()  # close menu
             self.debug.press_middle()
             yield
 


### PR DESCRIPTION
Also, move Solana `blockhash` to the first confirmation menu on all layouts.

<!--
For core developers:
- Assign yourself to the PR.
- Set the priority to match the original issue.
- Add the PR to the current sprint.
- If it's a draft PR, mark it as "In Progress."
- If it's a final PR, mark it as "Needs Review."

For external contributors:
- Please open an issue before submitting a PR so we can discuss whether we want to proceed with it.
-->
