### PR TITLE
Power manager suspend during shutting down

### DIFF
--- a/core/embed/sys/power_manager/stm32u5/power_states.c
+++ b/core/embed/sys/power_manager/stm32u5/power_states.c
@@ -184,6 +184,11 @@ static pm_power_status_t pm_handle_state_shutting_down(pm_driver_t* drv) {
     return PM_STATE_HIBERNATE;
   }
 
+  if (drv->request_suspend) {
+    drv->request_suspend = false;
+    return PM_STATE_SUSPEND;
+  }
+
   // Return to power save if external power or battery recovered
   if (drv->usb_connected || !drv->battery_critical) {
     return PM_STATE_POWER_SAVE;


### PR DESCRIPTION
This PR add transition from PM_STATE_SHUTTING_DOWN to PM_STATE_SUSPEND to power manager state machine, which means that app is now able to suspend the device during the device 15s shutting down period.

Even though such transition do not make a perfect sense, pm is suspended from lots of different places (core app + several bootloader workflows) and some of those workflows do not handle the shutting down corner case. In case the `pm_suspend` was called during shutting down it led to weird behavior when device fade down while trying to suspend -> suspend got rejected -> device fade up again and hibernate next couple of seconds. 

Now if the workflow call `pm_suspend`, device got suspended with slightly higher power consumption but on wake-up it goes back to PM_STATE_POWER_SAVE, from which most likely transit back to SHUTTING down in few seconds. 