### PR TITLE
Update pm charging state evaluation.

### DIFF
--- a/core/embed/sys/power_manager/stm32u5/power_manager.c
+++ b/core/embed/sys/power_manager/stm32u5/power_manager.c
@@ -214,9 +214,9 @@ pm_status_t pm_get_state(pm_state_t* state) {
   state->usb_connected = drv->usb_connected;
   state->wireless_connected = drv->wireless_connected;
 
-  if (drv->pmic_data.ibat > 0.0f) {
+  if (!drv->usb_connected && !drv->wireless_connected) {
     state->charging_status = PM_BATTERY_DISCHARGING;
-  } else if (drv->pmic_data.ibat < 0.0f) {
+  } else if (drv->charging_current_target_ma > 0) {
     state->charging_status = PM_BATTERY_CHARGING;
   } else {
     state->charging_status = PM_BATTERY_IDLE;


### PR DESCRIPTION
Power manager reported charging status directly based on the floating current measured by pmic. Since the pmic cannot change the charging current during the active charging cycle, every time the charging controller decided to change the charging current (maybe due to temperature limitations or any other reason) charging state goes from CHARGING to IDLE and then back to CHARGING. App would probably propagates this to a screen leaving impression that charging got interrupted. 

This PR links the charging status to charging_current_target_ma variable which is more relevant and should be stable even if charging controller change the charging setup. 