### PR TITLE
save flash by not using HAL for periph clock configuration

### DIFF
--- a/core/embed/io/rgb_led/stm32u5/rgb_led_lp.c
+++ b/core/embed/io/rgb_led/stm32u5/rgb_led_lp.c
@@ -77,13 +77,9 @@ void rgb_led_init(void) {
     }
   }
 
-  // select LSE as LPTIM clock source
-  RCC_PeriphCLKInitTypeDef PeriphClkInitStruct = {0};
-  PeriphClkInitStruct.PeriphClockSelection =
-      RCC_PERIPHCLK_LPTIM1 | RCC_PERIPHCLK_LPTIM34;
-  PeriphClkInitStruct.Lptim1ClockSelection = RCC_LPTIM1CLKSOURCE_HSI;
-  PeriphClkInitStruct.Lptim34ClockSelection = RCC_LPTIM34CLKSOURCE_HSI;
-  HAL_RCCEx_PeriphCLKConfig(&PeriphClkInitStruct);
+  // select HSI as LPTIM clock source
+  __HAL_RCC_LPTIM1_CONFIG(RCC_LPTIM1CLKSOURCE_HSI);
+  __HAL_RCC_LPTIM34_CONFIG(RCC_LPTIM34CLKSOURCE_HSI);
 
   __HAL_RCC_LPTIM1_CLK_ENABLE();
   __HAL_RCC_LPTIM1_FORCE_RESET();

--- a/core/embed/io/usb/stm32/usbd_conf.c
+++ b/core/embed/io/usb/stm32/usbd_conf.c
@@ -213,16 +213,10 @@ void HAL_PCD_MspInit(PCD_HandleTypeDef *hpcd)
     GPIO_InitStruct.Alternate = GPIO_AF10_USB_HS;
     HAL_GPIO_Init(GPIOA, &GPIO_InitStruct);
 
-    RCC_PeriphCLKInitTypeDef PeriphClkInit = {0};
-
     __HAL_RCC_SYSCFG_CLK_ENABLE();
 
-
-    /** Initializes the peripherals clock
-    */
-    PeriphClkInit.PeriphClockSelection = RCC_PERIPHCLK_USBPHY;
-    PeriphClkInit.UsbPhyClockSelection = RCC_USBPHYCLKSOURCE_HSE;
-    HAL_RCCEx_PeriphCLKConfig(&PeriphClkInit);
+    /** Initializes the peripherals clock */
+    __HAL_RCC_USBPHY_CONFIG(RCC_USBPHYCLKSOURCE_HSE);
 
     /** Set the OTG PHY reference clock selection
     */


### PR DESCRIPTION
Few drivers were using this - display, usb, led
