### PR TITLE
fix(core): fix MPU configuration

### DIFF
--- a/core/.changelog.d/5378.fixed
+++ b/core/.changelog.d/5378.fixed
@@ -1,0 +1,1 @@
+[T3B1,T3T1] Fix crash on first boot.


### PR DESCRIPTION
This PR fixes an issue that causes a crash on STM32U5 devices (T3B1, T3T1, and T3W1) when the firmware is downloaded and run for the first time.

The crash results in a RSOD, but it does not leave the device in an invalid state. After a power cycle (powering the device off and on), the device operates normally.

The issue is caused by incorrect MPU configuration for a specific sequence of FLASH memory writes that occurs immediately after the device is run for the first time. For more details, see the added comment in the source code.