### PR TITLE
ci(core): skip UI comment job on external PRs

### DIFF
--- a/.github/workflows/core.yml
+++ b/.github/workflows/core.yml
@@ -697,7 +697,7 @@ jobs:
 
   core_ui_comment:
     name: Post comment with UI diff URLs
-    if: github.event_name == 'pull_request'
+    if: github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name == github.repository
     runs-on: ubuntu-latest
     needs:
       - param


### PR DESCRIPTION
- the comment action fails when run on a PR created from a fork
- see https://github.com/peter-evans/create-or-update-comment/blob/9fa92b4fea95714d51d64d8e90d8817fe499e1cb/README.md

[no changelog]

<!--
For core developers:
- Assign yourself to the PR.
- Set the priority to match the original issue.
- Add the PR to the current sprint.
- If it's a draft PR, mark it as "In Progress."
- If it's a final PR, mark it as "Needs Review."

For external contributors:
- Please open an issue before submitting a PR so we can discuss whether we want to proceed with it.
-->
