### PR TITLE
nrf pairing

### DIFF
--- a/core/embed/io/nrf/inc/io/nrf.h
+++ b/core/embed/io/nrf/inc/io/nrf.h
@@ -229,4 +229,12 @@ bool nrf_test_gpio_stay_in_bld(void);
  * @return true if the GPIO behavior is correct; false otherwise
  */
 bool nrf_test_gpio_reserved(void);
+
+/**
+ * @brief Pair the NRF MCU with Trezor.
+ *
+ * @return true if pairing is successful; false otherwise
+ */
+bool nrf_test_pair(void);
+
 ///////////////////////////////////////////////////////////////////////////////

--- a/core/embed/projects/prodtest/README.md
+++ b/core/embed/projects/prodtest/README.md
@@ -326,6 +326,18 @@ OK 0.1.2.3
 Updates the nRF firmware.
 
 
+### nrf-pair
+Writes the pairing secret to the nRF chip to pair it with the MCU.
+The command `secrets-init` must be executed before calling this command.
+Pairing needs to be done before writing device ID in the OTP memory and before locking the Optiga chip.
+
+Example:
+```
+nrf-pair
+OK
+```
+
+
 ### touch-draw
 Starts a drawing canvas, where user can draw with finger on pen. Canvas is exited by sending CTRL+C command.
 ```

--- a/core/embed/projects/prodtest/cmd/prodtest_secrets.c
+++ b/core/embed/projects/prodtest/cmd/prodtest_secrets.c
@@ -60,26 +60,25 @@ secbool set_random_secret(uint8_t slot, size_t length) {
   secbool ret = secfalse;
 
   if (secret_key_writable(slot) != sectrue) {
-    if (generate_random_secret(secret, sizeof(secret)) != sectrue) {
-      ret = secfalse;
-      goto cleanup;
-    }
-
-    if (secret_key_set(slot, secret, sizeof(secret)) != sectrue) {
-      ret = secfalse;
-      goto cleanup;
-    }
-
-    if (secret_key_get(slot, secret_read, sizeof(secret_read)) != sectrue) {
-      ret = secfalse;
-      goto cleanup;
-    }
-
-    if (memcmp(secret, secret_read, sizeof(secret)) != 0) {
-      ret = secfalse;
-      goto cleanup;
-    }
+    goto cleanup;
   }
+
+  if (generate_random_secret(secret, sizeof(secret)) != sectrue) {
+    goto cleanup;
+  }
+
+  if (secret_key_set(slot, secret, sizeof(secret)) != sectrue) {
+    goto cleanup;
+  }
+
+  if (secret_key_get(slot, secret_read, sizeof(secret_read)) != sectrue) {
+    goto cleanup;
+  }
+
+  if (memcmp(secret, secret_read, sizeof(secret)) != 0) {
+    goto cleanup;
+  }
+
   ret = sectrue;
 
 cleanup:

--- a/core/embed/sec/secret/inc/sec/secret_keys.h
+++ b/core/embed/sec/secret/inc/sec/secret_keys.h
@@ -56,4 +56,11 @@ secbool secret_key_tropic_masking(uint8_t dest[ECDSA_PRIVATE_KEY_SIZE]);
 
 #endif  // USE_TROPIC
 
+#ifdef USE_NRF
+
+#define NRF_PAIRING_SECRET_SIZE 32
+secbool secret_key_nrf_pairing(uint8_t dest[NRF_PAIRING_SECRET_SIZE]);
+
+#endif
+
 #endif  // SECURE_MODE

--- a/core/embed/sec/secret/stm32u5/secret_keys.c
+++ b/core/embed/sec/secret/stm32u5/secret_keys.c
@@ -39,6 +39,7 @@
 #define KEY_INDEX_TROPIC_PAIRING_UNPRIVILEGED 3
 #define KEY_INDEX_TROPIC_PAIRING_PRIVILEGED 4
 #define KEY_INDEX_TROPIC_MASKING 5
+#define KEY_INDEX_NRF_PAIRING 6
 
 static secbool secret_key_derive_sym(uint8_t slot, uint16_t index,
                                      uint16_t subindex,
@@ -154,6 +155,16 @@ secbool secret_key_tropic_masking(uint8_t dest[ECDSA_PRIVATE_KEY_SIZE]) {
 }
 
 #endif  // USE_TROPIC
+
+#ifdef USE_NRF
+
+secbool secret_key_nrf_pairing(uint8_t dest[NRF_PAIRING_SECRET_SIZE]) {
+  _Static_assert(NRF_PAIRING_SECRET_SIZE == SHA256_DIGEST_LENGTH);
+  return secret_key_derive_sym(SECRET_UNPRIVILEGED_MASTER_KEY_SLOT,
+                               KEY_INDEX_NRF_PAIRING, 0, dest);
+}
+
+#endif
 
 #else  // SECRET_PRIVILEGED_MASTER_KEY_SLOT
 

--- a/nordic/trezor/trezor-ble/src/prodtest/prodtest.c
+++ b/nordic/trezor/trezor-ble/src/prodtest/prodtest.c
@@ -21,6 +21,7 @@
 #include <stdint.h>
 
 #include <zephyr/kernel.h>
+#include <zephyr/settings/settings.h>
 #include <zephyr/types.h>
 
 #include <zephyr/logging/log.h>
@@ -37,14 +38,52 @@ typedef enum {
   PRODTEST_CMD_SPI_DATA = 0x00,
   PRODTEST_CMD_UART_DATA = 0x01,
   PRODTEST_CMD_SET_OUTPUT = 0x02,
+  PRODTEST_CMD_PAIR = 0x03,
 } prodtest_cmd_t;
 
 typedef enum {
   PRODTEST_RESP_SPI = 0x00,
   PRODTEST_RESP_UART = 0x01,
+  PRODTEST_RESP_SUCCESS = 0x02,
+  PRODTEST_RESP_FAILURE = 0x03,
 } prodtest_resp_t;
 
 void prodtest_init(void) { k_sem_give(&prodtest_ok); }
+
+#define PAIRING_SECRET_SIZE 32
+
+static uint8_t pairing_secret[PAIRING_SECRET_SIZE] = {0};
+
+static int prodtest_set(const char *key, size_t len, settings_read_cb read_cb,
+                        void *cb_arg) {
+  if (strcmp(key, "pairing_secret") == 0) {
+    ssize_t rc = read_cb(cb_arg, pairing_secret, sizeof(pairing_secret));
+    return rc < 0 ? (int)rc : 0;
+  }
+  return -ENOENT;
+}
+
+SETTINGS_STATIC_HANDLER_DEFINE(prodtest, "prodtest", NULL, prodtest_set, NULL,
+                               NULL);
+
+bool prodtest_pair(uint8_t *data, uint16_t len) {
+  if (len != PAIRING_SECRET_SIZE) {
+    LOG_ERR("Invalid pairing data length: %d", len);
+    return false;
+  }
+
+  // Save pairing data to settings
+  int rc = settings_save_one("prodtest/pairing_secret", data, len);
+
+  if (rc != 0) {
+    LOG_ERR("Failed to save pairing secret: %d", rc);
+    return false;
+  }
+
+  settings_commit();  // Commit settings to persistent storage
+
+  return true;
+}
 
 static void process_command(uint8_t *data, uint16_t len) {
   uint8_t resp_data[244] = {0};
@@ -60,6 +99,23 @@ static void process_command(uint8_t *data, uint16_t len) {
       break;
     case PRODTEST_CMD_SET_OUTPUT:
       signals_set_reserved(data[1]);
+      break;
+    case PRODTEST_CMD_PAIR:
+      if (len < 1 + PAIRING_SECRET_SIZE) {
+        LOG_ERR("Pairing data too short: %d", len);
+        return;
+      }
+      bool ok = prodtest_pair(&data[1], PAIRING_SECRET_SIZE);
+
+      if (!ok) {
+        resp_data[0] = PRODTEST_RESP_FAILURE;
+        LOG_ERR("Failed to pair");
+        trz_comm_send_msg(NRF_SERVICE_PRODTEST, resp_data, 1);
+        return;
+      }
+
+      resp_data[0] = PRODTEST_RESP_SUCCESS;
+      trz_comm_send_msg(NRF_SERVICE_PRODTEST, resp_data, 1);
       break;
     default:
       break;


### PR DESCRIPTION
This PR adds support for basic pairing of main MCU and nRF. 

Symmetric keys is exchanged in prodtest and stored on nRF. Trezor derives the key from master secret key.