### PR TITLE
bootloader: send attach events to layout after creation

### DIFF
--- a/core/embed/projects/bootloader/workflow/wf_host_control.c
+++ b/core/embed/projects/bootloader/workflow/wf_host_control.c
@@ -92,6 +92,16 @@ workflow_result_t workflow_host_control(const vendor_header *const vhdr,
   awaited.read_ready |= 1 << SYSHANDLE_POWER_MANAGER;
 #endif
 
+  uint32_t res = screen_attach(wait_layout);
+
+  if (res != 0) {
+    if (ui_action_result != NULL) {
+      *ui_action_result = res;
+    }
+    result = WF_OK_UI_ACTION;
+    goto exit_host_control;
+  }
+
   for (;;) {
     sysevents_t signalled = {0};
 

--- a/core/embed/rust/rust_ui_bootloader.h
+++ b/core/embed/rust/rust_ui_bootloader.h
@@ -8,6 +8,9 @@
 
 // todo: use bindgen to bind return values to rust
 
+// send attach event to the layout
+uint32_t screen_attach(c_layout_t* layout);
+
 // common event function for screens that need UI + communication
 uint32_t screen_event(c_layout_t* layout, sysevents_t* signalled);
 

--- a/core/embed/rust/src/ui/api/bootloader_c.rs
+++ b/core/embed/rust/src/ui/api/bootloader_c.rs
@@ -12,6 +12,17 @@ use crate::{
 };
 
 #[no_mangle]
+extern "C" fn screen_attach(layout: *mut c_layout_t) -> u32 {
+    // SAFETY: calling code is supposed to give us exclusive access to an already
+    // initialized layout
+    unsafe {
+        let mut layout = LayoutBuffer::<<ModelUI as BootloaderUI>::CLayoutType>::new(layout);
+        let layout = layout.get_mut();
+        layout.show()
+    }
+}
+
+#[no_mangle]
 extern "C" fn screen_event(layout: *mut c_layout_t, signalled: &sysevents_t) -> u32 {
     let e = parse_event(signalled);
     // SAFETY: calling code is supposed to give us exclusive access to an already
@@ -34,8 +45,7 @@ extern "C" fn screen_render(layout: *mut c_layout_t) {
 
 #[no_mangle]
 extern "C" fn screen_welcome(layout: *mut c_layout_t) {
-    let mut screen = <ModelUI as BootloaderUI>::CLayoutType::init_welcome();
-    screen.show();
+    let screen = <ModelUI as BootloaderUI>::CLayoutType::init_welcome();
     // SAFETY: calling code is supposed to give us exclusive access to the layout
     let mut layout = unsafe { LayoutBuffer::new(layout) };
     layout.store(screen);
@@ -104,8 +114,7 @@ extern "C" fn screen_unlock_bootloader_success() {
 
 #[no_mangle]
 extern "C" fn screen_menu(initial_setup: bool, layout: *mut c_layout_t) {
-    let mut screen = <ModelUI as BootloaderUI>::CLayoutType::init_menu(initial_setup);
-    screen.show();
+    let screen = <ModelUI as BootloaderUI>::CLayoutType::init_menu(initial_setup);
     // SAFETY: calling code is supposed to give us exclusive access to the layout
     let mut layout = unsafe { LayoutBuffer::new(layout) };
     layout.store(screen);
@@ -164,9 +173,7 @@ extern "C" fn screen_install_progress(progress: u16, initialize: bool, initial_s
 
 #[no_mangle]
 extern "C" fn screen_connect(initial_setup: bool, auto_update: bool, layout: *mut c_layout_t) {
-    let mut screen =
-        <ModelUI as BootloaderUI>::CLayoutType::init_connect(initial_setup, auto_update);
-    screen.show();
+    let screen = <ModelUI as BootloaderUI>::CLayoutType::init_connect(initial_setup, auto_update);
     // SAFETY: calling code is supposed to give us exclusive access to the layout
     let mut layout = unsafe { LayoutBuffer::new(layout) };
     layout.store(screen);
@@ -197,8 +204,7 @@ extern "C" fn screen_pairing_mode(
     layout: *mut c_layout_t,
 ) {
     let name = unsafe { from_c_array(name, name_len).unwrap_or("") };
-    let mut screen = <ModelUI as BootloaderUI>::CLayoutType::init_pairing_mode(initial_setup, name);
-    screen.show();
+    let screen = <ModelUI as BootloaderUI>::CLayoutType::init_pairing_mode(initial_setup, name);
     // SAFETY: calling code is supposed to give us exclusive access to the layout
     let mut layout = unsafe { LayoutBuffer::new(layout) };
     layout.store(screen);
@@ -212,8 +218,7 @@ extern "C" fn screen_wireless_setup(
     layout: *mut c_layout_t,
 ) {
     let name = unsafe { from_c_array(name, name_len).unwrap_or("") };
-    let mut screen = <ModelUI as BootloaderUI>::CLayoutType::init_wireless_setup(name);
-    screen.show();
+    let screen = <ModelUI as BootloaderUI>::CLayoutType::init_wireless_setup(name);
     // SAFETY: calling code is supposed to give us exclusive access to the layout
     let mut layout = unsafe { LayoutBuffer::new(layout) };
     layout.store(screen);

--- a/core/embed/rust/src/ui/layout_bolt/bootloader/mod.rs
+++ b/core/embed/rust/src/ui/layout_bolt/bootloader/mod.rs
@@ -158,7 +158,7 @@ impl BootloaderLayoutType for BootloaderLayout {
         }
     }
 
-    fn show(&mut self) {
+    fn show(&mut self) -> u32 {
         match self {
             BootloaderLayout::Welcome(f) => show(f, true),
             BootloaderLayout::Menu(f) => show(f, true),

--- a/core/embed/rust/src/ui/layout_bolt/prodtest/mod.rs
+++ b/core/embed/rust/src/ui/layout_bolt/prodtest/mod.rs
@@ -30,7 +30,7 @@ impl ProdtestLayoutType for ProdtestLayout {
         }
     }
 
-    fn show(&mut self) {
+    fn show(&mut self) -> u32 {
         match self {
             ProdtestLayout::Welcome(f) => show(f, false),
         }

--- a/core/embed/rust/src/ui/layout_caesar/bootloader/mod.rs
+++ b/core/embed/rust/src/ui/layout_caesar/bootloader/mod.rs
@@ -108,7 +108,7 @@ impl BootloaderLayoutType for BootloaderLayout {
         }
     }
 
-    fn show(&mut self) {
+    fn show(&mut self) -> u32 {
         match self {
             BootloaderLayout::Welcome(f) => show(f, false),
             BootloaderLayout::Menu(f) => show(f, false),

--- a/core/embed/rust/src/ui/layout_caesar/prodtest/mod.rs
+++ b/core/embed/rust/src/ui/layout_caesar/prodtest/mod.rs
@@ -31,7 +31,7 @@ impl ProdtestLayoutType for ProdtestLayout {
         }
     }
 
-    fn show(&mut self) {
+    fn show(&mut self) -> u32 {
         match self {
             ProdtestLayout::Welcome(f) => show(f, true),
         }

--- a/core/embed/rust/src/ui/layout_delizia/bootloader/mod.rs
+++ b/core/embed/rust/src/ui/layout_delizia/bootloader/mod.rs
@@ -144,7 +144,7 @@ impl BootloaderLayoutType for BootloaderLayout {
         }
     }
 
-    fn show(&mut self) {
+    fn show(&mut self) -> u32 {
         match self {
             BootloaderLayout::Welcome(f) => show(f, true),
             BootloaderLayout::Menu(f) => show(f, true),

--- a/core/embed/rust/src/ui/layout_eckhart/prodtest/mod.rs
+++ b/core/embed/rust/src/ui/layout_eckhart/prodtest/mod.rs
@@ -30,7 +30,7 @@ impl ProdtestLayoutType for ProdtestLayout {
         }
     }
 
-    fn show(&mut self) {
+    fn show(&mut self) -> u32 {
         match self {
             ProdtestLayout::Welcome(f) => show(f, false),
         }

--- a/core/embed/rust/src/ui/layout_eckhart/ui_bootloader.rs
+++ b/core/embed/rust/src/ui/layout_eckhart/ui_bootloader.rs
@@ -121,7 +121,7 @@ impl BootloaderLayoutType for BootloaderLayout {
         }
     }
 
-    fn show(&mut self) {
+    fn show(&mut self) -> u32 {
         match self {
             BootloaderLayout::Welcome(f) => show(f, true),
             BootloaderLayout::Menu(f) => show(f, true),

--- a/core/embed/rust/src/ui/ui_bootloader.rs
+++ b/core/embed/rust/src/ui/ui_bootloader.rs
@@ -7,7 +7,7 @@ pub trait BootloaderLayoutType {
         unimplemented!();
     }
 
-    fn show(&mut self);
+    fn show(&mut self) -> u32;
     fn init_welcome() -> Self;
     fn init_menu(initial_setup: bool) -> Self;
     fn init_connect(initial_setup: bool, auto_update: bool) -> Self;

--- a/core/embed/rust/src/ui/ui_prodtest.rs
+++ b/core/embed/rust/src/ui/ui_prodtest.rs
@@ -7,7 +7,7 @@ use crate::ui::component::Event;
 
 pub trait ProdtestLayoutType {
     fn event(&mut self, event: Option<Event>) -> u32;
-    fn show(&mut self);
+    fn show(&mut self) -> u32;
     fn init_welcome(id: Option<&'static str>) -> Self;
 }
 


### PR DESCRIPTION
This PR ensures that attach events are sent to layout at the beginning of their life.

This solves an issue with using fuel gauge in bootloader, which relies on that behavior - until some change occurred, it displayed unknown battery state.

(this could also be solved by modifying the fuel gauge which may be simplified - but generally speaking sending attach events may be expected by components)