### PR TITLE
test(core): keep `refresh_index` across event loop restarts

### DIFF
--- a/core/src/apps/debug/__init__.py
+++ b/core/src/apps/debug/__init__.py
@@ -39,8 +39,6 @@ if __debug__:
 
     DEBUG_CONTEXT: context.Context | None = None
 
-    REFRESH_INDEX = 0
-
     _DEADLOCK_SLEEP_MS = const(3000)
     _DEADLOCK_DETECT_SLEEP = loop.sleep(_DEADLOCK_SLEEP_MS)
 
@@ -49,7 +47,7 @@ if __debug__:
             # Starting with "refresh00", allowing for 100 emulator restarts
             # without losing the order of the screenshots based on filename.
             display.save(
-                f"{storage.save_screen_directory.decode()}/refresh{REFRESH_INDEX:0>2}-"
+                f"{storage.save_screen_directory.decode()}/refresh{storage.refresh_index:0>2}-"
             )
             return True
         return False
@@ -316,8 +314,7 @@ if __debug__:
             # In case emulator is restarted but we still want to record screenshots
             # into the same directory as before, we need to increment the refresh index,
             # so that the screenshots are not overwritten.
-            global REFRESH_INDEX
-            REFRESH_INDEX = msg.refresh_index
+            storage.refresh_index = msg.refresh_index
             storage.save_screen_directory[:] = msg.target_directory.encode()
             storage.save_screen = True
 

--- a/core/src/storage/debug.py
+++ b/core/src/storage/debug.py
@@ -6,6 +6,7 @@ if not __debug__:
 if __debug__:
     save_screen = False
     if EMULATOR:
+        refresh_index = 0
         save_screen_directory = bytearray(4096)
         save_screen_directory[:] = b"."
 


### PR DESCRIPTION
Otherwise, it may overwrite previous screenshots (happened in [THP-based persistence tests](https://data.trezor.io/dev/firmware/ui_report/16303918302/T3W1-en-core_persistence_test-index.html), where event loop restarts are handled differently than in Protocol v1).

<!--
For core developers:
- Assign yourself to the PR.
- Set the priority to match the original issue.
- Add the PR to the current sprint.
- If it's a draft PR, mark it as "In Progress."
- If it's a final PR, mark it as "Needs Review."

For external contributors:
- Please open an issue before submitting a PR so we can discuss whether we want to proceed with it.
-->
