### PR TITLE
power managere simple temperature controller

### DIFF
--- a/core/embed/sys/power_manager/stm32u5/power_manager.c
+++ b/core/embed/sys/power_manager/stm32u5/power_manager.c
@@ -158,7 +158,7 @@ pm_status_t pm_init(bool inherit_state) {
 
   // Set default SOC target and max charging current limit
   drv->soc_target = 100;
-  drv->charging_current_max_limit_ma = PM_BATTERY_CHARGING_CURRENT_MAX;
+  drv->i_chg_max_limit_ma = PM_BATTERY_CHARGING_CURRENT_MAX;
   drv->i_chg_temp_limit_ma = PM_BATTERY_CHARGING_CURRENT_MAX;
 
   // Fuel gauge SoC available, set fuel_gauge initialized.
@@ -442,7 +442,7 @@ pm_status_t pm_charging_set_max_current(uint16_t current_ma) {
   }
 
   irq_key_t irq_key = irq_lock();
-  drv->charging_current_max_limit_ma = current_ma;
+  drv->i_chg_max_limit_ma = current_ma;
   pm_charging_controller(drv);
   irq_unlock(irq_key);
 

--- a/core/embed/sys/power_manager/stm32u5/power_manager.c
+++ b/core/embed/sys/power_manager/stm32u5/power_manager.c
@@ -159,6 +159,7 @@ pm_status_t pm_init(bool inherit_state) {
   // Set default SOC target and max charging current limit
   drv->soc_target = 100;
   drv->charging_current_max_limit_ma = PM_BATTERY_CHARGING_CURRENT_MAX;
+  drv->i_chg_temp_limit_ma = PM_BATTERY_CHARGING_CURRENT_MAX;
 
   // Fuel gauge SoC available, set fuel_gauge initialized.
   drv->fuel_gauge_initialized = true;

--- a/core/embed/sys/power_manager/stm32u5/power_manager_internal.h
+++ b/core/embed/sys/power_manager/stm32u5/power_manager_internal.h
@@ -55,6 +55,12 @@
 
 #define PM_SUSPENDED_CHARGING_TIMEOUT_S 60
 #define PM_STABILIZATION_TIMEOUT_MS 2000
+// Temperature controller parameters
+#define PM_TEMP_CONTROL_IDLE_PERIOD_MS 2 * 60 * 1000  // 2 minutes
+#define PM_TEMP_CONTROL_BAND_1_MAX_TEMP 39.0f
+#define PM_TEMP_CONTROL_BAND_2_MAX_TEMP 43.0f
+#define PM_TEMP_CONTROL_BAND_3_MAX_TEMP 45.0f
+#define PM_TEMP_CONTROL_BAND_4_MAX_TEMP 47.0f
 
 // Power manager battery sampling data structure
 typedef struct {
@@ -92,6 +98,10 @@ typedef struct {
   bool charging_enabled;
   uint16_t charging_current_target_ma;
   uint16_t charging_current_max_limit_ma;
+
+  // Temp controller
+  uint32_t temp_control_timeout;
+  uint16_t i_chg_temp_limit_ma;
 
   // Power source hardware state
   pmic_report_t pmic_data;

--- a/core/embed/sys/power_manager/stm32u5/power_manager_internal.h
+++ b/core/embed/sys/power_manager/stm32u5/power_manager_internal.h
@@ -96,8 +96,8 @@ typedef struct {
 
   // Battery charging state
   bool charging_enabled;
-  uint16_t charging_current_target_ma;
-  uint16_t charging_current_max_limit_ma;
+  uint16_t i_chg_target_ma;
+  uint16_t i_chg_max_limit_ma;
 
   // Temp controller
   uint32_t temp_control_timeout;

--- a/core/embed/sys/power_manager/stm32u5/power_monitoring.c
+++ b/core/embed/sys/power_manager/stm32u5/power_monitoring.c
@@ -152,34 +152,34 @@ void pm_pmic_data_ready(void* context, pmic_report_t* report) {
 void pm_charging_controller(pm_driver_t* drv) {
   if (drv->charging_enabled == false) {
     // Charging is disabled
-    if (drv->charging_current_target_ma != 0) {
-      drv->charging_current_target_ma = 0;
+    if (drv->i_chg_target_ma != 0) {
+      drv->i_chg_target_ma = 0;
     } else {
       // No action required
       return;
     }
   } else if (drv->usb_connected) {
-    drv->charging_current_target_ma = PM_BATTERY_CHARGING_CURRENT_MAX;
+    drv->i_chg_target_ma = PM_BATTERY_CHARGING_CURRENT_MAX;
 
   } else if (drv->wireless_connected) {
-    drv->charging_current_target_ma = PM_BATTERY_CHARGING_CURRENT_MAX;
+    drv->i_chg_target_ma = PM_BATTERY_CHARGING_CURRENT_MAX;
 
   } else {
     // Charging enabled but no external power source, clear charging target
-    drv->charging_current_target_ma = 0;
+    drv->i_chg_target_ma = 0;
   }
 
   // charging current software limit
-  if (drv->charging_current_target_ma > drv->charging_current_max_limit_ma) {
-    drv->charging_current_target_ma = drv->charging_current_max_limit_ma;
+  if (drv->i_chg_target_ma > drv->i_chg_max_limit_ma) {
+    drv->i_chg_target_ma = drv->i_chg_max_limit_ma;
   }
 
   pm_temperature_controller(drv);
 
   // Set charging target
-  if (drv->charging_current_target_ma != pmic_get_charging_limit()) {
+  if (drv->i_chg_target_ma != pmic_get_charging_limit()) {
     // Set charging current limit
-    pmic_set_charging_limit(drv->charging_current_target_ma);
+    pmic_set_charging_limit(drv->i_chg_target_ma);
   }
 
   if (drv->soc_target == 100) {
@@ -212,7 +212,7 @@ void pm_charging_controller(pm_driver_t* drv) {
     drv->i_chg_target_ma = 0;
   }
 
-  if (drv->charging_current_target_ma == 0) {
+  if (drv->i_chg_target_ma == 0) {
     pmic_set_charging(false);
   } else {
     pmic_set_charging(true);
@@ -240,9 +240,9 @@ static void pm_temperature_controller(pm_driver_t* drv) {
     }
   }
 
-  if (drv->charging_current_target_ma > drv->i_chg_temp_limit_ma) {
+  if (drv->i_chg_target_ma > drv->i_chg_temp_limit_ma) {
     // Limit the charging current by temperature controller
-    drv->charging_current_target_ma = drv->i_chg_temp_limit_ma;
+    drv->i_chg_target_ma = drv->i_chg_temp_limit_ma;
   }
 }
 


### PR DESCRIPTION
This PR introduce simple temperature controller which limits the charging current based on the device temperature to prevent overheating during charging (especially on WPC).

Temperature controller defines 4 temperature bands for which continuously decrease charging current limit. 

- T < 39°C : NO LIMIT
- T >= 39°C && T < 43°C : 70% of max charging current
- T >= 43°C && T< 45°C : 50% of max charging current
- T >=45°C && T< 47°C : 30% of max charging current
- T >= 47°C : CHARGING STOPPED

temperature controller is debounced with 2min interval after every control action to avoid fuzzy behavior during crossing the threshold from band to band. 

PR also refactors some charging controller variables which were to long. 

## Temperature control example
<img width="3127" height="1818" alt="image" src="https://github.com/user-attachments/assets/c51d27c9-31a6-4d83-b774-2bd2a8a30aa2" />



