### PR TITLE
Eckhart UI: adjust bootloader install flow & progress screen

### DIFF
--- a/core/embed/rust/src/ui/display/font.rs
+++ b/core/embed/rust/src/ui/display/font.rs
@@ -282,19 +282,19 @@ impl FontInfo {
         self.with_glyph_data(|data| data.get_glyph(ch).adv)
     }
 
-    pub fn text_height(&'static self) -> i16 {
+    pub const fn text_height(&'static self) -> i16 {
         self.height
     }
 
-    pub fn text_max_height(&'static self) -> i16 {
+    pub const fn text_max_height(&'static self) -> i16 {
         self.max_height
     }
 
-    pub fn text_baseline(&'static self) -> i16 {
+    pub const fn text_baseline(&'static self) -> i16 {
         self.baseline
     }
 
-    pub fn line_height(&'static self) -> i16 {
+    pub const fn line_height(&'static self) -> i16 {
         constant::LINE_SPACE + self.text_height()
     }
 

--- a/core/embed/rust/src/ui/layout_eckhart/bootloader/bld_actionbar.rs
+++ b/core/embed/rust/src/ui/layout_eckhart/bootloader/bld_actionbar.rs
@@ -6,7 +6,7 @@ use crate::ui::{
 
 use super::super::{
     component::{Button, ButtonMsg},
-    theme::{self, Gradient},
+    theme,
 };
 
 /// Component for control buttons in the bottom of the screen. Reduced variant
@@ -49,9 +49,7 @@ impl BldActionBar {
         Self::new(
             Mode::Single,
             None,
-            button
-                .with_expanded_touch_area(Self::BUTTON_EXPAND_TOUCH)
-                .with_gradient(Gradient::DefaultGrey),
+            button.with_expanded_touch_area(Self::BUTTON_EXPAND_TOUCH),
         )
     }
 

--- a/core/embed/rust/src/ui/layout_eckhart/bootloader/bld_header.rs
+++ b/core/embed/rust/src/ui/layout_eckhart/bootloader/bld_header.rs
@@ -1,7 +1,7 @@
 use crate::{
     strutil::TString,
     ui::{
-        component::{Component, Event, EventCtx, Label},
+        component::{text::TextStyle, Component, Event, EventCtx, Label},
         display::{Color, Icon},
         geometry::{Alignment2D, Insets, Rect},
         shape::{self, Renderer},
@@ -10,7 +10,8 @@ use crate::{
 
 use super::super::{
     component::{Button, ButtonContent, ButtonMsg, FuelGauge},
-    constant, theme,
+    constant,
+    theme::{self, bootloader::text_title},
 };
 
 const BUTTON_EXPAND_BORDER: i16 = 32;
@@ -48,11 +49,7 @@ impl<'a> BldHeader<'a> {
     pub const fn new(title: TString<'a>) -> Self {
         Self {
             area: Rect::zero(),
-            title: Label::left_aligned(
-                title,
-                theme::bootloader::text_title(theme::bootloader::BLD_BG),
-            )
-            .vertically_centered(),
+            title: Label::left_aligned(title, text_title(theme::GREY)).vertically_centered(),
             right_button: None,
             left_button: None,
             right_button_msg: BldHeaderMsg::Cancelled,
@@ -64,15 +61,27 @@ impl<'a> BldHeader<'a> {
     }
 
     pub fn new_rsod_header() -> Self {
-        Self::new("Failure".into()).with_icon(theme::ICON_INFO, theme::RED)
+        Self::new("Failure".into())
+            .with_icon(theme::ICON_INFO, theme::RED)
+            .with_text_style(text_title(theme::RED))
     }
 
-    pub fn new_done() -> Self {
-        Self::new("Done".into()).with_icon(theme::ICON_DONE, theme::GREY)
+    pub fn new_done(color: Color) -> Self {
+        Self::new("Done".into())
+            .with_icon(theme::ICON_DONE, color)
+            .with_text_style(text_title(color))
     }
 
-    pub fn new_pay_attention() -> Self {
-        Self::new("Pay attention".into()).with_icon(theme::ICON_WARNING, theme::GREY)
+    pub fn new_important() -> Self {
+        Self::new("Important".into())
+            .with_icon(theme::ICON_WARNING, theme::RED)
+            .with_text_style(text_title(theme::RED))
+    }
+
+    #[inline(never)]
+    pub fn with_text_style(mut self, style: TextStyle) -> Self {
+        self.title = self.title.styled(style);
+        self
     }
 
     #[inline(never)]

--- a/core/embed/rust/src/ui/layout_eckhart/bootloader/confirm_pairing.rs
+++ b/core/embed/rust/src/ui/layout_eckhart/bootloader/confirm_pairing.rs
@@ -33,8 +33,10 @@ pub struct ConfirmPairingScreen<'a> {
 impl<'a> ConfirmPairingScreen<'a> {
     pub fn new(code: u32) -> Self {
         let (left, right) = (
-            Button::with_icon(theme::ICON_CROSS),
-            Button::with_icon(theme::ICON_CHECKMARK),
+            Button::with_icon(theme::ICON_CROSS)
+                .styled(theme::bootloader::button_bld_initial_setup()),
+            Button::with_icon(theme::ICON_CHECKMARK)
+                .styled(theme::bootloader::button_bld_initial_setup()),
         );
 
         Self {

--- a/core/embed/rust/src/ui/layout_eckhart/bootloader/connect.rs
+++ b/core/embed/rust/src/ui/layout_eckhart/bootloader/connect.rs
@@ -28,8 +28,12 @@ pub struct ConnectScreen {
 }
 
 impl ConnectScreen {
-    pub fn new() -> Self {
-        let btn = Button::with_text("Cancel".into());
+    pub fn new(initial_setup: bool) -> Self {
+        let mut btn = Button::with_text("Cancel".into());
+        if initial_setup {
+            btn = btn.with_gradient(theme::Gradient::DefaultGrey);
+        };
+
         Self {
             header: None,
             message: Label::left_aligned("Waiting for host...".into(), theme::TEXT_NORMAL),

--- a/core/embed/rust/src/ui/layout_eckhart/bootloader/pairing_finalization.rs
+++ b/core/embed/rust/src/ui/layout_eckhart/bootloader/pairing_finalization.rs
@@ -6,7 +6,7 @@ use crate::ui::{
 };
 
 use super::{
-    super::{component::Button, cshape::ScreenBorder, theme},
+    super::{component::Button, cshape::ScreenBorder, theme, CANCEL_MESSAGE},
     BldActionBar, BldActionBarMsg, BldHeader,
 };
 
@@ -26,8 +26,13 @@ pub struct PairingFinalizationScreen {
 }
 
 impl PairingFinalizationScreen {
-    pub fn new() -> Self {
-        let btn = Button::with_text("Cancel".into());
+    pub fn new(initial_setup: bool) -> Self {
+        let mut btn = Button::with_text(CANCEL_MESSAGE.into());
+        if initial_setup {
+            btn = btn
+                .styled(theme::bootloader::button_bld_initial_setup())
+                .with_gradient(theme::Gradient::DefaultGrey);
+        }
         Self {
             header: BldHeader::new("Bluetooth pairing".into()),
             message: Label::left_aligned(

--- a/core/embed/rust/src/ui/layout_eckhart/bootloader/pairing_mode.rs
+++ b/core/embed/rust/src/ui/layout_eckhart/bootloader/pairing_mode.rs
@@ -7,7 +7,7 @@ use crate::{
     ui::{
         component::{text::TextStyle, Component, Event, EventCtx, Label},
         event::BLEEvent,
-        geometry::Rect,
+        geometry::{Insets, Rect},
         layout::simplified::ReturnToC,
         shape::Renderer,
     },
@@ -67,6 +67,7 @@ impl Component for PairingModeScreen {
         let (rest, action_bar_area) = rest.split_bottom(theme::ACTION_BAR_HEIGHT);
         let rest = rest.inset(theme::SIDE_INSETS);
         let (name_area, content_area) = rest.split_top(self.name.text_height(rest.width()));
+        let content_area = content_area.inset(Insets::top(4));
         self.header.place(header_area);
         self.name.place(name_area);
         self.message.place(content_area);

--- a/core/embed/rust/src/ui/layout_eckhart/bootloader/welcome_screen.rs
+++ b/core/embed/rust/src/ui/layout_eckhart/bootloader/welcome_screen.rs
@@ -44,14 +44,15 @@ impl BldWelcomeScreen {
             (
                 Some(BldHeader::new(TString::empty()).with_menu_button()),
                 Button::with_text("More at trezor.io/start".into())
-                    .styled(theme::bootloader::button_welcome_screen())
+                    .styled(theme::bootloader::button_bld_initial_setup())
                     .initially_enabled(false),
             )
         } else {
             (
                 None,
                 Button::with_text("Tap to begin setup".into())
-                    .styled(theme::bootloader::button_welcome_screen())
+                    .styled(theme::bootloader::button_bld_initial_setup())
+                    .with_gradient(theme::Gradient::DefaultGrey)
                     .initially_enabled(true),
             )
         };

--- a/core/embed/rust/src/ui/layout_eckhart/bootloader/wireless_setup_screen.rs
+++ b/core/embed/rust/src/ui/layout_eckhart/bootloader/wireless_setup_screen.rs
@@ -48,7 +48,9 @@ impl WirelessSetupScreen {
             "Get the Trezor Suite app to begin setup.".into(),
             theme::TEXT_NORMAL,
         );
-        let btn = Button::with_text("More info".into());
+        let btn = Button::with_text("More info".into())
+            .styled(theme::bootloader::button_bld_initial_setup())
+            .with_gradient(theme::Gradient::DefaultGrey);
         let btn_more_info =
             Button::with_text("More at trezor.io/start".into()).initially_enabled(false);
         let more_info = MoreInfo {

--- a/core/embed/rust/src/ui/layout_eckhart/component/button.rs
+++ b/core/embed/rust/src/ui/layout_eckhart/component/button.rs
@@ -49,13 +49,18 @@ impl Button {
     const MENU_ITEM_ALIGNMENT: Alignment = Alignment::Start;
     pub const MENU_ITEM_CONTENT_OFFSET: Offset = Offset::x(12);
 
+    #[cfg(feature = "micropython")]
+    const DEFAULT_STYLESHEET: ButtonStyleSheet = theme::firmware::button_default();
+    #[cfg(not(feature = "micropython"))]
+    const DEFAULT_STYLESHEET: ButtonStyleSheet = theme::bootloader::button_default();
+
     pub const fn new(content: ButtonContent) -> Self {
         Self {
             content,
             content_offset: Offset::zero(),
             area: Rect::zero(),
             touch_expand: Insets::zero(),
-            stylesheet: theme::button_default(),
+            stylesheet: Self::DEFAULT_STYLESHEET,
             text_align: Alignment::Center,
             radius_or_gradient: RadiusOrGradient::None,
             state: State::Initial,

--- a/core/embed/rust/src/ui/layout_eckhart/component/update_screen.rs
+++ b/core/embed/rust/src/ui/layout_eckhart/component/update_screen.rs
@@ -4,7 +4,7 @@ use crate::ui::{
     shape::{self, Renderer},
 };
 
-use super::super::{constant::SCREEN, theme};
+use super::super::{constant::SCREEN, theme, WAIT_MESSAGE};
 
 pub struct UpdateScreen {
     text_header: Label<'static>,
@@ -16,7 +16,7 @@ pub struct UpdateScreen {
 impl UpdateScreen {
     const UPDATE_HEADER: &'static str = "Update done";
     const UPDATE_MESSAGE: &'static str = "Completing final steps...";
-    const UPDATE_FOOTER: &'static str = "Wait";
+    const UPDATE_FOOTER: &'static str = WAIT_MESSAGE;
 
     pub fn new() -> Self {
         Self {

--- a/core/embed/rust/src/ui/layout_eckhart/firmware/action_bar.rs
+++ b/core/embed/rust/src/ui/layout_eckhart/firmware/action_bar.rs
@@ -232,11 +232,9 @@ impl ActionBar {
             timeout,
             pager: Pager::default(),
             prev_button: Button::with_icon(theme::ICON_CHEVRON_UP)
-                .styled(theme::button_default())
                 .with_expanded_touch_area(Self::BUTTON_EXPAND_TOUCH)
                 .with_content_offset(Self::BUTTON_CONTENT_OFFSET),
             next_button: Button::with_icon(theme::ICON_CHEVRON_DOWN)
-                .styled(theme::button_default())
                 .with_expanded_touch_area(Self::BUTTON_EXPAND_TOUCH)
                 .with_content_offset(Self::BUTTON_CONTENT_OFFSET.neg()),
         }

--- a/core/embed/rust/src/ui/layout_eckhart/firmware/header.rs
+++ b/core/embed/rust/src/ui/layout_eckhart/firmware/header.rs
@@ -21,7 +21,6 @@ const BUTTON_EXPAND_BORDER: i16 = 32;
 pub struct Header {
     area: Rect,
     title: Label<'static>,
-    title_style: TextStyle,
     /// button in the top-right corner
     right_button: Option<Button>,
     /// button in the top-left corner
@@ -51,7 +50,6 @@ impl Header {
         Self {
             area: Rect::zero(),
             title: Label::left_aligned(title, theme::label_title_main()).vertically_centered(),
-            title_style: theme::label_title_main(),
             right_button: None,
             left_button: None,
             right_button_msg: HeaderMsg::Cancelled,
@@ -64,7 +62,6 @@ impl Header {
 
     #[inline(never)]
     pub fn with_text_style(mut self, style: TextStyle) -> Self {
-        self.title_style = style;
         self.title = self.title.styled(style);
         self
     }

--- a/core/embed/rust/src/ui/layout_eckhart/mod.rs
+++ b/core/embed/rust/src/ui/layout_eckhart/mod.rs
@@ -37,7 +37,9 @@ mod prodtest;
 use crate::ui::layout::simplified::show;
 use component::{ErrorScreen, UpdateScreen, WelcomeScreen};
 
-pub const WAIT_FOR_RESTART_MESSAGE: &str = "Wait for device restart";
+pub const WAIT_FOR_RESTART_MESSAGE: &str = "Wait for Trezor restart";
+pub const WAIT_MESSAGE: &str = "Wait";
+pub const CANCEL_MESSAGE: &str = "Cancel";
 
 pub struct UIEckhart;
 

--- a/core/embed/rust/src/ui/layout_eckhart/theme/bootloader.rs
+++ b/core/embed/rust/src/ui/layout_eckhart/theme/bootloader.rs
@@ -9,8 +9,8 @@ use super::{
         component::{ButtonStyle, ButtonStyleSheet},
         fonts,
     },
-    BLACK, BLUE, GREY, GREY_DARK, GREY_EXTRA_LIGHT, GREY_LIGHT, GREY_SUPER_DARK, ORANGE, RED,
-    WHITE,
+    BLACK, BLUE, GREY, GREY_DARK, GREY_EXTRA_DARK, GREY_EXTRA_LIGHT, GREY_LIGHT, GREY_SUPER_DARK,
+    ORANGE, RED, WHITE,
 };
 
 pub const BLD_BG: Color = BLACK;
@@ -20,11 +20,35 @@ pub const WELCOME_COLOR: Color = BLACK;
 
 // UI icons specific to bootloader (white color)
 include_icon!(ICON_SEVEN, "layout_eckhart/res/bootloader/7.toif");
-// alternatively: "layout_eckhart/res/bootloader/QRCode_smaller.toif"
+// TODO: use "layout_eckhart/res/bootloader/QRCode.toif" when more space
+// available
 include_icon!(
     ICON_QR_TREZOR_IO_START,
-    "layout_eckhart/res/bootloader/QRCode.toif"
+    "layout_eckhart/res/bootloader/QRCode_smaller.toif"
 );
+
+pub const fn button_default() -> ButtonStyleSheet {
+    ButtonStyleSheet {
+        normal: &ButtonStyle {
+            font: fonts::FONT_SATOSHI_MEDIUM_26,
+            text_color: GREY_EXTRA_LIGHT,
+            button_color: GREY_SUPER_DARK,
+            icon_color: GREY_EXTRA_LIGHT,
+        },
+        active: &ButtonStyle {
+            font: fonts::FONT_SATOSHI_MEDIUM_26,
+            text_color: GREY_LIGHT,
+            button_color: GREY_EXTRA_DARK,
+            icon_color: GREY_LIGHT,
+        },
+        disabled: &ButtonStyle {
+            font: fonts::FONT_SATOSHI_MEDIUM_26,
+            text_color: GREY,
+            button_color: BLD_BG,
+            icon_color: GREY,
+        },
+    }
+}
 
 pub fn button_confirm() -> ButtonStyleSheet {
     ButtonStyleSheet {
@@ -165,7 +189,7 @@ pub fn button_bld_menu_danger() -> ButtonStyleSheet {
 }
 
 /// Button style for the welcome screen
-pub fn button_welcome_screen() -> ButtonStyleSheet {
+pub fn button_bld_initial_setup() -> ButtonStyleSheet {
     ButtonStyleSheet {
         normal: &ButtonStyle {
             font: fonts::FONT_SATOSHI_MEDIUM_26,
@@ -188,8 +212,14 @@ pub fn button_welcome_screen() -> ButtonStyleSheet {
     }
 }
 
-pub const fn text_title(bg: Color) -> TextStyle {
-    TextStyle::new(fonts::FONT_SATOSHI_MEDIUM_26, GREY, bg, GREY, GREY)
+pub const fn text_title(text_color: Color) -> TextStyle {
+    TextStyle::new(
+        fonts::FONT_SATOSHI_MEDIUM_26,
+        text_color,
+        BLD_BG,
+        text_color,
+        text_color,
+    )
 }
 
 pub const TEXT_FW_FINGERPRINT: TextStyle = TextStyle::new(

--- a/core/embed/rust/src/ui/layout_eckhart/theme/firmware.rs
+++ b/core/embed/rust/src/ui/layout_eckhart/theme/firmware.rs
@@ -170,6 +170,29 @@ pub const fn label_title_warning() -> TextStyle {
 }
 
 // Button styles
+pub const fn button_default() -> ButtonStyleSheet {
+    ButtonStyleSheet {
+        normal: &ButtonStyle {
+            font: fonts::FONT_SATOSHI_MEDIUM_26,
+            text_color: GREY_LIGHT,
+            button_color: BG,
+            icon_color: GREY_LIGHT,
+        },
+        active: &ButtonStyle {
+            font: fonts::FONT_SATOSHI_MEDIUM_26,
+            text_color: GREY_LIGHT,
+            button_color: GREY_SUPER_DARK,
+            icon_color: GREY_LIGHT,
+        },
+        disabled: &ButtonStyle {
+            font: fonts::FONT_SATOSHI_MEDIUM_26,
+            text_color: GREY,
+            button_color: BG,
+            icon_color: GREY,
+        },
+    }
+}
+
 pub const fn button_confirm() -> ButtonStyleSheet {
     ButtonStyleSheet {
         normal: &ButtonStyle {

--- a/core/embed/rust/src/ui/layout_eckhart/theme/mod.rs
+++ b/core/embed/rust/src/ui/layout_eckhart/theme/mod.rs
@@ -1,5 +1,5 @@
 pub mod backlight;
-#[cfg(feature = "bootloader")]
+#[cfg(any(feature = "bootloader", feature = "prodtest"))]
 pub mod bootloader;
 #[cfg(feature = "micropython")]
 pub mod firmware;
@@ -14,10 +14,7 @@ use crate::ui::{
     util::include_icon,
 };
 
-use super::{
-    component::{ButtonStyle, ButtonStyleSheet},
-    fonts,
-};
+use super::fonts;
 
 pub use gradient::Gradient;
 
@@ -163,26 +160,3 @@ pub const TEXT_SMALL_GREY_EXTRA_LIGHT: TextStyle = TextStyle {
     text_color: GREY_EXTRA_LIGHT,
     ..TEXT_SMALL
 };
-
-pub const fn button_default() -> ButtonStyleSheet {
-    ButtonStyleSheet {
-        normal: &ButtonStyle {
-            font: fonts::FONT_SATOSHI_MEDIUM_26,
-            text_color: GREY_LIGHT,
-            button_color: BG,
-            icon_color: GREY_LIGHT,
-        },
-        active: &ButtonStyle {
-            font: fonts::FONT_SATOSHI_MEDIUM_26,
-            text_color: GREY_LIGHT,
-            button_color: GREY_SUPER_DARK,
-            icon_color: GREY_LIGHT,
-        },
-        disabled: &ButtonStyle {
-            font: fonts::FONT_SATOSHI_MEDIUM_26,
-            text_color: GREY,
-            button_color: BG,
-            icon_color: GREY,
-        },
-    }
-}


### PR DESCRIPTION
- "Restarting in X" shown in the footer area without progress
- allow different color in `show_progress`
- show "Wait" in the footer area in `show_progress`
- also fix RSOD header color

TODO:
- [x] fix the default button style mess
- [x] FLASH size
  - fix by temporarily putting smaller QR code
<!--
For core developers:
- Assign yourself to the PR.
- Set the priority to match the original issue.
- Add the PR to the current sprint.
- If it's a draft PR, mark it as "In Progress."
- If it's a final PR, mark it as "Needs Review."

For external contributors:
- Please open an issue before submitting a PR so we can discuss whether we want to proceed with it.
-->
