### PR TITLE
Convert `r != buf.len` to OSError in WebUSB write

### DIFF
--- a/core/embed/upymod/modtrezorio/modtrezorio-webusb.h
+++ b/core/embed/upymod/modtrezorio/modtrezorio-webusb.h
@@ -121,7 +121,17 @@ STATIC mp_obj_t mod_trezorio_WebUSB_write(mp_obj_t self, mp_obj_t msg) {
   mp_obj_WebUSB_t *o = MP_OBJ_TO_PTR(self);
   mp_buffer_info_t buf = {0};
   mp_get_buffer_raise(msg, &buf, MP_BUFFER_READ);
+
+  if (buf.len != USB_PACKET_LEN) {
+    mp_raise_msg(&mp_type_ValueError, MP_ERROR_TEXT("Invalid buffer length"));
+  }
+
   ssize_t r = usb_webusb_write(o->info.iface_num, buf.buf, buf.len);
+
+  if (r != buf.len) {
+    mp_raise_msg(&mp_type_OSError, MP_ERROR_TEXT("Write failed"));
+  }
+
   return MP_OBJ_NEW_SMALL_INT(r);
 }
 STATIC MP_DEFINE_CONST_FUN_OBJ_2(mod_trezorio_WebUSB_write_obj,


### PR DESCRIPTION

<!--
For core developers:
- Assign yourself to the PR.
- Set the priority to match the original issue.
- Add the PR to the current sprint.
- If it's a draft PR, mark it as "In Progress."
- If it's a final PR, mark it as "Needs Review."

For external contributors:
- Please open an issue before submitting a PR so we can discuss whether we want to proceed with it.
-->
