### PR TITLE
Power manager battery reincarnation 

### DIFF
--- a/core/embed/sys/power_manager/inc/sys/pmic.h
+++ b/core/embed/sys/power_manager/inc/sys/pmic.h
@@ -47,6 +47,8 @@ typedef struct {
   // BUCKSTATUS register value
   // (for debugging purposes, see the datasheet)
   uint8_t charge_status;
+  uint8_t charge_err;
+  uint8_t charge_sensor_err;
   uint8_t buck_status;
   uint8_t usb_status;
 } pmic_report_t;
@@ -135,3 +137,6 @@ typedef enum {
 
 // Set the buck voltage regulator mode
 bool pmic_set_buck_mode(pmic_buck_mode_t buck_mode);
+
+// Clears all battery charger errors.
+bool pmic_clear_charger_errors(void);

--- a/core/embed/sys/power_manager/stm32u5/power_monitoring.c
+++ b/core/embed/sys/power_manager/stm32u5/power_monitoring.c
@@ -176,12 +176,6 @@ void pm_charging_controller(pm_driver_t* drv) {
 
   pm_temperature_controller(drv);
 
-  // Set charging target
-  if (drv->i_chg_target_ma != pmic_get_charging_limit()) {
-    // Set charging current limit
-    pmic_set_charging_limit(drv->i_chg_target_ma);
-  }
-
   if (drv->soc_target == 100) {
     drv->soc_target_reached = false;
   } else {
@@ -212,9 +206,20 @@ void pm_charging_controller(pm_driver_t* drv) {
     drv->i_chg_target_ma = 0;
   }
 
+  // Set charging target
+  if (drv->i_chg_target_ma != pmic_get_charging_limit()) {
+    // Set charging current limit
+    pmic_set_charging_limit(drv->i_chg_target_ma);
+  }
+
   if (drv->i_chg_target_ma == 0) {
     pmic_set_charging(false);
   } else {
+    // Clear and release charger if it has any errors
+    if (drv->pmic_data.charge_err || drv->pmic_data.charge_sensor_err) {
+      pmic_clear_charger_errors();
+    }
+
     pmic_set_charging(true);
   }
 }


### PR DESCRIPTION
This PR add a reincarnation feature to power manager charging controller. Charger should now be able to recover from errors during PMIC charging cycle. 

This feature was introduced mainly to handle jump start of highly depleted batteries (voltage under 2.1V so the battery protection circuit disconnects the battery and pmic see 0V), but it showed up that new NPM cut solved this already on HW level. Anyway, we should keep the feature for just in case.  