### PR TITLE
make secrets-init calling repeatable

### DIFF
--- a/core/embed/projects/prodtest/cmd/prodtest_secrets.c
+++ b/core/embed/projects/prodtest/cmd/prodtest_secrets.c
@@ -60,6 +60,9 @@ secbool set_random_secret(uint8_t slot, size_t length) {
   secbool ret = secfalse;
 
   if (secret_key_writable(slot) != sectrue) {
+    if (secret_key_get(slot, secret_read, sizeof(secret_read)) == sectrue) {
+      ret = sectrue;
+    }
     goto cleanup;
   }
 


### PR DESCRIPTION
as requested by tester team, it makes their live easier - if the keys are not writable and present, lets just say that the command succeeded.