### PR TITLE
refactor(core/emulator): move drivers initialization to drivers_init

### DIFF
--- a/core/embed/projects/unix/main.c
+++ b/core/embed/projects/unix/main.c
@@ -37,6 +37,7 @@
 #include <unistd.h>
 
 #include <io/display.h>
+#include <sec/entropy.h>
 #include <sec/secret.h>
 #include <sys/system.h>
 #include <sys/systimer.h>
@@ -504,6 +505,23 @@ static int sdl_event_filter(void *userdata, SDL_Event *event) {
 }
 
 void drivers_init() {
+  flash_init();
+  flash_otp_init();
+
+  entropy_init();
+
+  unit_properties_init();
+
+  display_init(DISPLAY_RESET_CONTENT);
+
+#if USE_TOUCH
+  touch_init();
+#endif
+
+#ifdef USE_BUTTON
+  button_init();
+#endif
+
 #ifdef USE_TROPIC
   tropic_init();
 #endif
@@ -537,22 +555,6 @@ MP_NOINLINE int main_(int argc, char **argv) {
   drivers_init();
 
   SDL_SetEventFilter(sdl_event_filter, NULL);
-
-  display_init(DISPLAY_RESET_CONTENT);
-
-#if USE_TOUCH
-  touch_init();
-#endif
-
-#ifdef USE_BUTTON
-  button_init();
-#endif
-
-  // Map trezor.flash to memory.
-  flash_init();
-  flash_otp_init();
-
-  unit_properties_init();
 
 #if MICROPY_ENABLE_GC
   char *heap = malloc(heap_size);

--- a/core/embed/projects/unix/main_main.c
+++ b/core/embed/projects/unix/main_main.c
@@ -7,13 +7,9 @@
 #include "zkp_context.h"
 #endif
 
-#include <sec/entropy.h>
-
 MP_NOINLINE int main_(int argc, char **argv);
 
 int main(int argc, char **argv) {
-  entropy_init();
-
 #ifdef USE_SECP256K1_ZKP
   ensure(sectrue * (zkp_context_init() == 0), NULL);
 #endif


### PR DESCRIPTION
This PR moves the initialization of drivers in the emulator - previously scattered across multiple places in the code - into a single location - `drivers_init()`.

Th emulator functionality is not affected by this change.
