### PR TITLE
ci(core): print less test durations

### DIFF
--- a/.github/workflows/core.yml
+++ b/.github/workflows/core.yml
@@ -282,7 +282,7 @@ jobs:
       PYTEST_TIMEOUT: ${{ matrix.asan == 'asan' && 600 || 400 }}
       ACTIONS_DO_UI_TEST: ${{ matrix.coins == 'universal' && matrix.asan == 'noasan' }}
       TEST_LANG: ${{ matrix.lang }}
-      TESTOPTS: "--durations 50 --session-timeout 1800"  # 30m pytest global timeout
+      TESTOPTS: "--durations 10 --session-timeout 1800"  # 30m pytest global timeout
     timeout-minutes: 40
     steps:
       - uses: actions/checkout@v4
@@ -380,7 +380,7 @@ jobs:
     env:
       TREZOR_UPGRADE_TEST: core
       PYTEST_TIMEOUT: 20
-      TESTOPTS: "--durations 50"
+      TESTOPTS: "--durations 10"
     steps:
       - uses: actions/checkout@v4
         with:


### PR DESCRIPTION
Most of the tests take ~1s, so let's print only the top 10:
<img width="2422" height="1603" alt="image" src="https://github.com/user-attachments/assets/88b2e69d-c803-4afc-9627-b9ddcc8c0806" />

After this PR:
<img width="2497" height="1720" alt="image" src="https://github.com/user-attachments/assets/d75f6915-deaf-4ea0-9f83-315c8221a60e" />


<!--
For core developers:
- Assign yourself to the PR.
- Set the priority to match the original issue.
- Add the PR to the current sprint.
- If it's a draft PR, mark it as "In Progress."
- If it's a final PR, mark it as "Needs Review."

For external contributors:
- Please open an issue before submitting a PR so we can discuss whether we want to proceed with it.
-->
