### PR TITLE
fix ble suspend/resume

### DIFF
--- a/core/embed/io/ble/inc/io/ble.h
+++ b/core/embed/io/ble/inc/io/ble.h
@@ -73,6 +73,7 @@ typedef struct {
   ble_mode_t mode_requested;
   uint8_t connected_addr[6];
   uint8_t connected_addr_type;
+  ble_adv_start_cmd_data_t adv_data;
 } ble_wakeup_params_t;
 
 typedef enum {

--- a/core/embed/io/ble/stm32/ble.c
+++ b/core/embed/io/ble/stm32/ble.c
@@ -540,6 +540,7 @@ void ble_suspend(ble_wakeup_params_t *wakeup_params) {
     bool connected = drv->connected;
     wakeup_params->accept_msgs = connected;
     wakeup_params->mode_requested = drv->mode_requested;
+    memcpy(&wakeup_params->adv_data, &drv->adv_cmd, sizeof(drv->adv_cmd));
 
     ble_deinit_common(drv);
 
@@ -579,6 +580,7 @@ bool ble_resume(const ble_wakeup_params_t *wakeup_params) {
   drv->connected_addr_type = wakeup_params->connected_addr_type;
   memcpy(drv->connected_addr, wakeup_params->connected_addr,
          sizeof(drv->connected_addr));
+  memcpy(&drv->adv_cmd, &wakeup_params->adv_data, sizeof(drv->adv_cmd));
   drv->mode_requested = wakeup_params->mode_requested;
 
   irq_unlock(key);

--- a/core/embed/io/nrf/stm32u5/nrf.c
+++ b/core/embed/io/nrf/stm32u5/nrf.c
@@ -331,6 +331,7 @@ void nrf_deinit(void) {
     HAL_EXTI_ClearConfigLine(&drv->exti);
 
     nrf_deinit_common(drv);
+    drv->initialized = false;
   }
 }
 


### PR DESCRIPTION
nRF driver wasn't properly reinitializaed
BLE advertising name wasn't preserved during suspend/resume cycle
