### PR TITLE
docs(prodtest): changelog for 0.3.0

### DIFF
--- a/core/embed/projects/prodtest/.changelog.d/4534.incompatible
+++ b/core/embed/projects/prodtest/.changelog.d/4534.incompatible
@@ -1,1 +1,0 @@
-Completely redesigned. See the updated documentation for details.

--- a/core/embed/projects/prodtest/.changelog.d/4564.fixed
+++ b/core/embed/projects/prodtest/.changelog.d/4564.fixed
@@ -1,1 +1,0 @@
-[T2B1,T3B1] Fix displaying QR code and text.

--- a/core/embed/projects/prodtest/.changelog.d/4682.added
+++ b/core/embed/projects/prodtest/.changelog.d/4682.added
@@ -1,1 +1,0 @@
-[T3B1,T3T1] Added hw-revision command.

--- a/core/embed/projects/prodtest/.changelog.d/4735.added
+++ b/core/embed/projects/prodtest/.changelog.d/4735.added
@@ -1,1 +1,0 @@
-Added device ID write/read commands.

--- a/core/embed/projects/prodtest/.changelog.d/4735.changed
+++ b/core/embed/projects/prodtest/.changelog.d/4735.changed
@@ -1,1 +1,0 @@
-Show device ID in protest QR code.

--- a/core/embed/projects/prodtest/.changelog.d/5050.changed
+++ b/core/embed/projects/prodtest/.changelog.d/5050.changed
@@ -1,1 +1,0 @@
-Report build version in prodtest intro and version command.

--- a/core/embed/projects/prodtest/.changelog.d/5227.added
+++ b/core/embed/projects/prodtest/.changelog.d/5227.added
@@ -1,1 +1,0 @@
-Added command for updating bootloader.

--- a/core/embed/projects/prodtest/CHANGELOG.md
+++ b/core/embed/projects/prodtest/CHANGELOG.md
@@ -1,4 +1,21 @@
 
+## 0.3.0 [16th July 2025]
+
+### Added
+- [T3B1,T3T1] Added hw-revision command.  [#4682]
+- Added device ID write/read commands.  [#4735]
+- Added command for updating bootloader.  [#5227]
+
+### Changed
+- Show device ID in protest QR code.  [#4735]
+- Report build version in prodtest intro and version command.  [#5050]
+
+### Fixed
+- [T2B1,T3B1] Fix displaying QR code and text.  [#4564]
+
+### Incompatible changes
+- Completely redesigned. See the updated documentation for details.  [#4534]
+
 ## 0.2.12 [22th January 2025]
 
 ### Changed
@@ -102,3 +119,9 @@
 [#4313]: https://github.com/trezor/trezor-firmware/pull/4313
 [#4405]: https://github.com/trezor/trezor-firmware/pull/4405
 [#4407]: https://github.com/trezor/trezor-firmware/pull/4407
+[#4534]: https://github.com/trezor/trezor-firmware/pull/4534
+[#4564]: https://github.com/trezor/trezor-firmware/pull/4564
+[#4682]: https://github.com/trezor/trezor-firmware/pull/4682
+[#4735]: https://github.com/trezor/trezor-firmware/pull/4735
+[#5050]: https://github.com/trezor/trezor-firmware/pull/5050
+[#5227]: https://github.com/trezor/trezor-firmware/pull/5227


### PR DESCRIPTION
This PR generates prodtest changelog and adds `prodtest/v0.3.0` to the commit `a09e6f04d4204607d821d9b742dcf7ffe9c4e2f5`

This was forgotten in https://github.com/trezor/trezor-firmware/pull/5361
<!--
For core developers:
- Assign yourself to the PR.
- Set the priority to match the original issue.
- Add the PR to the current sprint.
- If it's a draft PR, mark it as "In Progress."
- If it's a final PR, mark it as "Needs Review."

For external contributors:
- Please open an issue before submitting a PR so we can discuss whether we want to proceed with it.
-->
