### PR TITLE
ble: stop advertising when suspended

### DIFF
--- a/nordic/trezor/trezor-ble/src/ble/ble_internal.h
+++ b/nordic/trezor/trezor-ble/src/ble/ble_internal.h
@@ -28,6 +28,7 @@
 #include <zephyr/bluetooth/hci.h>
 #include <zephyr/bluetooth/uuid.h>
 
+#include <ble/ble.h>
 #include <trz_comm/trz_comm.h>
 
 /** @brief UUID of the NUS Service. **/
@@ -148,8 +149,6 @@ void advertising_init(void);
 // Start advertising, with or without whitelist
 void advertising_start(bool wl, uint8_t color, uint8_t device_code,
                        bool static_addr, char *name, int name_len);
-// Stop advertising
-void advertising_stop(void);
 // Check if advertising is active
 bool advertising_is_advertising(void);
 // Check if advertising is active with whitelist

--- a/nordic/trezor/trezor-ble/src/ble/inc/ble/ble.h
+++ b/nordic/trezor/trezor-ble/src/ble/inc/ble/ble.h
@@ -23,3 +23,6 @@
 
 // Initializes the BLE module
 bool ble_init(void);
+
+// Stop advertising
+void advertising_stop(void);

--- a/nordic/trezor/trezor-ble/src/management/management.c
+++ b/nordic/trezor/trezor-ble/src/management/management.c
@@ -33,6 +33,7 @@
 
 #include <errno.h>
 
+#include <ble/ble.h>
 #include <prodtest/prodtest.h>
 #include <signals/signals.h>
 #include <trz_comm/trz_comm.h>
@@ -192,6 +193,7 @@ static void process_command(uint8_t *data, uint16_t len) {
     case MGMT_CMD_SUSPEND:
       LOG_INF("Suspend");
       trz_comm_suspend();
+      advertising_stop();
       break;
     case MGMT_CMD_RESUME:
       LOG_INF("Resume");


### PR DESCRIPTION
This PR fixes issue with advertising still running in suspend mode, if some device was connected before suspending and there is more than one device bonded.


