### PR TITLE
chore(core): remove unused import

### DIFF
--- a/core/embed/rust/src/ui/layout_delizia/component/trade_screen.rs
+++ b/core/embed/rust/src/ui/layout_delizia/component/trade_screen.rs
@@ -2,7 +2,7 @@ use crate::{
     strutil::TString,
     ui::{
         component::{paginated::SinglePage, Bar, Component, Event, EventCtx, Label, Never},
-        geometry::{Grid, Insets, Rect},
+        geometry::{Insets, Rect},
         shape::Renderer,
     },
 };


### PR DESCRIPTION
```
warning: unused import: `Grid`
 --> src/ui/layout_delizia/component/trade_screen.rs:5:20
  |
5 |         geometry::{Grid, Insets, Rect},
  |                    ^^^^
  |
  = note: `#[warn(unused_imports)]` on by default
```