### PR TITLE
test(core): check `DebugLink._call()` response to avoid dropping errors

### DIFF
--- a/python/src/trezorlib/debuglink.py
+++ b/python/src/trezorlib/debuglink.py
@@ -575,7 +575,10 @@ class DebugLink:
 
     def _call(self, msg: protobuf.MessageType, timeout: float | None = None) -> t.Any:
         self._write(msg)
-        return self._read(timeout=timeout)
+        result = self._read(timeout=timeout)
+        if isinstance(result, messages.Failure):
+            raise TrezorFailure(result)
+        return result
 
     def state(self, wait_type: DebugWaitType | None = None) -> messages.DebugLinkState:
         if wait_type is None:
@@ -636,8 +639,6 @@ class DebugLink:
         obj = self._call(
             messages.DebugLinkGetState(wait_layout=DebugWaitType.NEXT_LAYOUT)
         )
-        if isinstance(obj, messages.Failure):
-            raise TrezorFailure(obj)
         return LayoutContent(obj.tokens)
 
     @contextmanager

--- a/python/src/trezorlib/debuglink.py
+++ b/python/src/trezorlib/debuglink.py
@@ -471,10 +471,11 @@ def _make_input_func(
     def input_func(
         self: "DebugLink",
         hold_ms: int | None = None,
+        wait: bool | None = None,
     ) -> None:
         __tracebackhide__ = True  # for pytest # pylint: disable=W0612
         decision.hold_ms = hold_ms
-        self._decision(decision)
+        self._decision(decision, wait)
 
     return input_func  # type: ignore [Parameter name mismatch]
 

--- a/tests/click_tests/test_autolock.py
+++ b/tests/click_tests/test_autolock.py
@@ -211,12 +211,13 @@ def test_autolock_does_not_interrupt_signing(device_handler: "BackgroundDeviceHa
     with client:
         client.set_filter(messages.TxAck, sleepy_filter)
         # confirm transaction
+        # don't wait for layout change, to avoid "layout deadlock detected" error
         if debug.layout_type in (LayoutType.Bolt, LayoutType.Eckhart):
-            debug.click(debug.screen_buttons.ok())
+            debug.click(debug.screen_buttons.ok(), wait=False)
         elif debug.layout_type is LayoutType.Caesar:
-            debug.press_middle()
+            debug.press_middle(wait=False)
         elif debug.layout_type is LayoutType.Delizia:
-            debug.click(debug.screen_buttons.tap_to_confirm())
+            debug.click(debug.screen_buttons.tap_to_confirm(), wait=False)
         else:
             raise ValueError(f"Unsupported layout type: {debug.layout_type}")
 


### PR DESCRIPTION
Otherwise, some commands (e.g. `DebugLinkRecordScreen`) could fail without raising `TrezorFailure`.
