### PR TITLE
shell.nix: workaround ERROR: SDL_CreateRenderer error

### DIFF
--- a/shell.nix
+++ b/shell.nix
@@ -89,8 +89,10 @@ stdenvNoCC.mkDerivation ({
     oldNixpkgs.python39
     oldNixpkgs.python38
   ] ++ [
-    SDL2
-    SDL2_image
+    # Current nixpkgs aliases SDL2 to sdl2-compat which on Ubuntu 25.04 makes the emulator
+    # crash with SDL_CreateRenderer error.
+    oldNixpkgs.SDL2
+    oldNixpkgs.SDL2_image
     bash
     bloaty  # for binsize
     check


### PR DESCRIPTION
Emulator can't be started on default Ubuntu 25.04 install. Let's see if it resolves in time or if we need to fix our code (or rewrite it to use SDL3, not sure if it doesn't break our library of old emulator binaries).

<!--
For core developers:
- Assign yourself to the PR.
- Set the priority to match the original issue.
- Add the PR to the current sprint.
- If it's a draft PR, mark it as "In Progress."
- If it's a final PR, mark it as "Needs Review."

For external contributors:
- Please open an issue before submitting a PR so we can discuss whether we want to proceed with it.
-->
