### PR TITLE
ci(core): correct `asan` definition for THP-based unittests jobs

### DIFF
--- a/.github/workflows/core.yml
+++ b/.github/workflows/core.yml
@@ -218,6 +218,7 @@ jobs:
         protocol: [v1]
         include:
           - model: T3W1
+            asan: noasan
             protocol: v2
     env:
       TREZOR_MODEL: ${{ matrix.model }}
@@ -249,6 +250,7 @@ jobs:
         protocol: [v1]
         include:
           - model: T3W1
+            asan: noasan
             protocol: v2
     env:
       TREZOR_MODEL: ${{ matrix.model }}


### PR DESCRIPTION
Currently, THP-related unittest jobs have an empty `asan` field in their description:

<img width="366" height="700" alt="image" src="https://github.com/user-attachments/assets/c2899579-e1a3-4ce3-9fc2-c74d25007d3f" />

https://github.com/trezor/trezor-firmware/actions/runs/16657817123/job/47147539150?pr=5459


IIUC, if `asan` value is not specified, it won't appear in the resulting matrix combination:
https://docs.github.com/en/actions/how-tos/write-workflows/choose-what-workflows-do/run-job-variations#expanding-or-adding-matrix-configurations