### PR TITLE
refactor(core): use generic `Provider` for Protocol v1 buffer

### DIFF
--- a/core/src/apps/debug/__init__.py
+++ b/core/src/apps/debug/__init__.py
@@ -434,7 +434,7 @@ if __debug__:
 
         global DEBUG_CONTEXT
 
-        DEBUG_CONTEXT = ctx = CodecContext(iface, wire.BufferProvider(1024))
+        DEBUG_CONTEXT = ctx = CodecContext(iface, wire.Provider(bytearray(1024)))
 
         if storage.layout_watcher:
             try:

--- a/core/src/trezor/wire/codec/codec_context.py
+++ b/core/src/trezor/wire/codec/codec_context.py
@@ -15,7 +15,7 @@ if __debug__:
 if TYPE_CHECKING:
     from typing import TypeVar
 
-    from .. import BufferProvider, WireInterface
+    from .. import Provider, WireInterface
 
     LoadedMessageType = TypeVar("LoadedMessageType", bound=protobuf.MessageType)
 
@@ -26,7 +26,7 @@ class CodecContext(Context):
     def __init__(
         self,
         iface: WireInterface,
-        buffer_provider: BufferProvider,
+        buffer_provider: Provider[bytearray],
     ) -> None:
         self.buffer_provider = buffer_provider
         self._buffer = None


### PR DESCRIPTION
It will be used for providing rx/tx buffers to THP sessions.
