### PR TITLE
Fix `tets_emu_sanity` failure on nightly CI

### DIFF
--- a/.github/workflows/core.yml
+++ b/.github/workflows/core.yml
@@ -234,7 +234,7 @@ jobs:
       - run: nix-shell --run "poetry run make -C core build_unix"
       - run: nix-shell --arg fullDeps true --run "cd vendor/ts-tvl/tvl/server/model_config && poetry env use 3.12 && poetry install && poetry run model_server tcp -c model_config.yml &"
       - run: nix-shell --run "poetry run make -C core test"
-      - run: nix-shell --run "poetry run core/emu.py -c true"  # sanity check non-frozen emulator
+      - run: nix-shell --run "poetry run make -C core test_emu_sanity"  # sanity check non-frozen emulator
 
   core_unit_rust_test:
     name: Rust unit tests (${{ matrix.model }}, ${{ matrix.asan }}${{ matrix.protocol=='v2' && ', THP' || ''}})

--- a/core/Makefile
+++ b/core/Makefile
@@ -185,7 +185,7 @@ test_rust: ## run rs unit tests
 		-- --test-threads=1 --nocapture
 
 test_emu_sanity: ## make sure the emulator doesn't crash on startup
-	$(EMU) --disable-animation --headless --temporary-profile --slip0014 --command true
+	$(EMU) --disable-animation --headless --temporary-profile --command true
 
 test_emu: ## run selected device tests from python-trezor
 	$(EMU_TEST) $(PYTEST) $(TESTPATH)/device_tests $(TESTOPTS) --lang=$(TEST_LANG)


### PR DESCRIPTION
https://github.com/trezor/trezor-firmware/actions/runs/16662101842/job/47161359553#step:6:19
```
Run nix-shell --run "poetry run make -C core test_emu_sanity"
Using udevCheckHook
make: Entering directory '/home/runner/work/trezor-firmware/trezor-firmware/core'
/home/runner/work/trezor-firmware/trezor-firmware/core/emu.py --disable-animation --headless --temporary-profile --slip0014 --command true
Error: Cannot load mnemonics in production mode
make: *** [Makefile:188: test_emu_sanity] Error 1
make: Leaving directory '/home/runner/work/trezor-firmware/trezor-firmware/core'
Error: Process completed with exit code 2.
```