### PR TITLE
fix(python): don't send `EndSession` to bootloader

### DIFF
--- a/python/src/trezorlib/cli/__init__.py
+++ b/python/src/trezorlib/cli/__init__.py
@@ -360,7 +360,7 @@ def with_session(
                     return func(session, *args, **kwargs)
 
                 finally:
-                    if not is_resume_mandatory:
+                    if not is_resume_mandatory and not session.features.bootloader_mode:
                         session.end()
 
         return function_with_session


### PR DESCRIPTION
Should fix HW CI workflow: https://github.com/trezor/trezor-firmware/actions/runs/16662126836/job/47161429388#step:6:50
```
$ trezorctl -v get-features
[2025-08-01 11:20:23,488] trezorlib.transport INFO: Enumerating WebUsbTransport: found 1 devices
[2025-08-01 11:20:23,488] trezorlib.transport INFO: Enumerating UdpTransport: found 0 devices
[2025-08-01 11:20:23,489] trezorlib.transport INFO: Enumerating BridgeTransport: found 0 devices
[2025-08-01 11:20:23,490] trezorlib.client INFO: creating client instance for device: webusb:003:4
[2025-08-01 11:20:23,490] trezorlib.transport.thp.protocol_v1 DEBUG: sending message: Initialize
Initialize (0 bytes) {
}
[2025-08-01 11:20:23,493] trezorlib.transport.thp.protocol_v1 DEBUG: received message: Features (59 bytes)
[2025-08-01 11:20:23,493] trezorlib.transport.thp.protocol_v1 DEBUG: sending message: GetFeatures
GetFeatures (0 bytes) {
}
[2025-08-01 11:20:23,496] trezorlib.transport.thp.protocol_v1 DEBUG: received message: Features (59 bytes)
[2025-08-01 11:20:23,496] trezorlib.transport.thp.protocol_v1 DEBUG: sending message: Initialize
Initialize (2 bytes) {
    derive_cardano: False,
}
[2025-08-01 11:20:23,499] trezorlib.transport.thp.protocol_v1 DEBUG: received message: Features (59 bytes)
[2025-08-01 11:20:23,499] trezorlib.transport.thp.protocol_v1 DEBUG: sending message: EndSession
EndSession (0 bytes) {
}
[2025-08-01 11:20:23,501] trezorlib.transport.thp.protocol_v1 DEBUG: received message: Failure
Failure (22 bytes) {
    code: UnexpectedMessage (1),
    message: 'Unexpected message',
}
Error: UnexpectedMessage: Unexpected message
```