### PR TITLE
test(core): use a shorter pin sequence

### DIFF
--- a/python/src/trezorlib/debuglink.py
+++ b/python/src/trezorlib/debuglink.py
@@ -502,6 +502,8 @@ class DebugLink:
         self.waiting_for_layout_change = False
 
         self.input_wait_type = DebugWaitType.IMMEDIATE
+
+        # For detecting GC leaks / heap fragmentation
         self.prev_gc_info: dict[str, int] = {}
 
     @property
@@ -1333,6 +1335,7 @@ class TrezorClientDebugLink(TrezorClient):
         new_client.debug.t1_screenshot_directory = self.debug.t1_screenshot_directory
         new_client.debug.t1_screenshot_counter = self.debug.t1_screenshot_counter
         new_client.debug.t1_take_screenshots = self.debug.t1_take_screenshots
+        new_client.debug.prev_gc_info = self.debug.prev_gc_info
         return new_client
 
     def close_transport(self) -> None:

--- a/tests/device_tests/test_msg_changepin_t2.py
+++ b/tests/device_tests/test_msg_changepin_t2.py
@@ -39,7 +39,7 @@ def _check_pin(session: Session, pin: str):
 
     with session.client as client:
         client.ui.__init__(session.client.debug)
-        client.use_pin_sequence([pin, pin, pin, pin, pin, pin])
+        client.use_pin_sequence([pin])
         session.lock()
         assert session.features.pin_protection is True
         assert session.features.unlocked is False


### PR DESCRIPTION
Also, keep the previous GC info result when creating a new THP channel.