### PR TITLE
fix(python): avoid failing `emu.py` if non-debug emulator is used

### DIFF
--- a/python/src/trezorlib/debuglink.py
+++ b/python/src/trezorlib/debuglink.py
@@ -1276,7 +1276,9 @@ class TrezorClientDebugLink(TrezorClient):
             if open_transport:
                 self.debug.open()
                 # try to open debuglink, see if it works
-                assert self.debug.transport.ping()
+                if not self.debug.transport.ping():
+                    LOG.warning("DebugLink is not available")
+
         except Exception:
             if not auto_interact:
                 self.debug = NullDebugLink()


### PR DESCRIPTION
Otherwise, it fails nightly core CI:
https://github.com/trezor/trezor-firmware/actions/runs/16687051058/job/47238433930

Tested with:
```
$ TREZOR_MODEL=T2T1 PYOPT=1 QUIET_MODE=1 make -C core build_unix_frozen test_emu_sanity 
```