### PR TITLE
test(core): fix `test_softlock_instability` failure on hardware tests

### DIFF
--- a/core/src/apps/debug/__init__.py
+++ b/core/src/apps/debug/__init__.py
@@ -376,6 +376,9 @@ if __debug__:
         if msg.value is not None:
             from trezor.crypto import random
 
+            if not utils.EMULATOR:
+                raise wire.UnexpectedMessage("reseed only supported on emulator")
+
             random.reseed(msg.value)
         return Success()
 


### PR DESCRIPTION
Following #5457.

Previously the device responded with `FirmwareError: 'module' object has no attribute 'reseed'`.

Tested 44639cb9c9b21c807fac898ada3d1e9c2ffdd97b on T3T1:
```
[2025-08-02 19:09:54,105] trezorlib.transport.thp.protocol_v1 DEBUG: sending message: DebugLinkReseedRandom
DebugLinkReseedRandom (2 bytes) {
    value: 0,
}
[2025-08-02 19:09:54,293] trezorlib.transport.thp.protocol_v1 DEBUG: received message: Failure
Failure (37 bytes) {
    code: UnexpectedMessage (1),
    message: 'reseed only supported on emulator',
}
```
