### PR TITLE
Fix suspend loop exit after wakeup from connected power source

### DIFF
--- a/core/embed/sys/suspend/stm32u5/suspend.c
+++ b/core/embed/sys/suspend/stm32u5/suspend.c
@@ -94,14 +94,15 @@ wakeup_flags_t system_suspend(void) {
     if (wakeup_flags == 0) {
       // Enter low-power mode
       suspend_cpu();
-
-      // At this point, all pending interrupts are processed.
-      // Some of them may set wakeup flags.
-      wakeup_flags_get(&wakeup_flags);
     }
 
     // Resume state machines running in the interrupt context
     background_tasks_resume();
+
+    // Some wakeup flags may be set in interrupts right after CPU wakes up, and
+    // some may be set in the background tasks resume routine. Read them here
+    // to wake up immediately if any are set.
+    wakeup_flags_get(&wakeup_flags);
   }
 
   // Reinitialize all drivers that were stopped earlier


### PR DESCRIPTION
When the device is woke up from suspend by connecting the USB cable or WPC, WAKEUP_FLAG_POWER is not set during the interrupt right after the CPU wakes up, but only after the pmic driver is resumed in `background_task_resume()` function. 

This caused that suspend flag is missed, suspend loop will start another iteration and start suspending the background task again. After doing that, WAKEUP_FLAG_POWER is read while waiting to all background tasks to get suspended, resumed drivers again and finally exit the suspend. 

This PR fixes this by reading the wakeup flags again after the background tasks got resume