### PR TITLE
fix(core): execute `race()` callback immediately

### DIFF
--- a/core/src/trezor/loop.py
+++ b/core/src/trezor/loop.py
@@ -339,7 +339,7 @@ class race(Syscall):
         if not self.finished:
             self.finished = True
             self.exit(task)
-            schedule(self.callback, result)
+            _step(self.callback, result)
 
     def __iter__(self) -> Task:
         try:


### PR DESCRIPTION
It should avoid scheduling delay when using `loop.race()`.