### PR TITLE
chore(python): update `lazy-object-proxy` dependency

### DIFF
--- a/poetry.lock
+++ b/poetry.lock
@@ -796,49 +796,26 @@ i18n = ["Babel (>=2.7)"]
 
 [[package]]
 name = "lazy-object-proxy"
-version = "1.7.1"
+version = "1.11.0"
 description = "A fast and thorough lazy object proxy."
 optional = false
-python-versions = ">=3.6"
+python-versions = ">=3.9"
 groups = ["main"]
 files = [
-    {file = "lazy-object-proxy-1.7.1.tar.gz", hash = "sha256:d609c75b986def706743cdebe5e47553f4a5a1da9c5ff66d76013ef396b5a8a4"},
-    {file = "lazy_object_proxy-1.7.1-cp310-cp310-macosx_10_9_x86_64.whl", hash = "sha256:bb8c5fd1684d60a9902c60ebe276da1f2281a318ca16c1d0a96db28f62e9166b"},
-    {file = "lazy_object_proxy-1.7.1-cp310-cp310-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:a57d51ed2997e97f3b8e3500c984db50a554bb5db56c50b5dab1b41339b37e36"},
-    {file = "lazy_object_proxy-1.7.1-cp310-cp310-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:fd45683c3caddf83abbb1249b653a266e7069a09f486daa8863fb0e7496a9fdb"},
-    {file = "lazy_object_proxy-1.7.1-cp310-cp310-musllinux_1_1_aarch64.whl", hash = "sha256:8561da8b3dd22d696244d6d0d5330618c993a215070f473b699e00cf1f3f6443"},
-    {file = "lazy_object_proxy-1.7.1-cp310-cp310-musllinux_1_1_x86_64.whl", hash = "sha256:fccdf7c2c5821a8cbd0a9440a456f5050492f2270bd54e94360cac663398739b"},
-    {file = "lazy_object_proxy-1.7.1-cp310-cp310-win32.whl", hash = "sha256:898322f8d078f2654d275124a8dd19b079080ae977033b713f677afcfc88e2b9"},
-    {file = "lazy_object_proxy-1.7.1-cp310-cp310-win_amd64.whl", hash = "sha256:85b232e791f2229a4f55840ed54706110c80c0a210d076eee093f2b2e33e1bfd"},
-    {file = "lazy_object_proxy-1.7.1-cp36-cp36m-macosx_10_9_x86_64.whl", hash = "sha256:46ff647e76f106bb444b4533bb4153c7370cdf52efc62ccfc1a28bdb3cc95442"},
-    {file = "lazy_object_proxy-1.7.1-cp36-cp36m-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:12f3bb77efe1367b2515f8cb4790a11cffae889148ad33adad07b9b55e0ab22c"},
-    {file = "lazy_object_proxy-1.7.1-cp36-cp36m-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:c19814163728941bb871240d45c4c30d33b8a2e85972c44d4e63dd7107faba44"},
-    {file = "lazy_object_proxy-1.7.1-cp36-cp36m-musllinux_1_1_aarch64.whl", hash = "sha256:e40f2013d96d30217a51eeb1db28c9ac41e9d0ee915ef9d00da639c5b63f01a1"},
-    {file = "lazy_object_proxy-1.7.1-cp36-cp36m-musllinux_1_1_x86_64.whl", hash = "sha256:2052837718516a94940867e16b1bb10edb069ab475c3ad84fd1e1a6dd2c0fcfc"},
-    {file = "lazy_object_proxy-1.7.1-cp36-cp36m-win32.whl", hash = "sha256:6a24357267aa976abab660b1d47a34aaf07259a0c3859a34e536f1ee6e76b5bb"},
-    {file = "lazy_object_proxy-1.7.1-cp36-cp36m-win_amd64.whl", hash = "sha256:6aff3fe5de0831867092e017cf67e2750c6a1c7d88d84d2481bd84a2e019ec35"},
-    {file = "lazy_object_proxy-1.7.1-cp37-cp37m-macosx_10_9_x86_64.whl", hash = "sha256:6a6e94c7b02641d1311228a102607ecd576f70734dc3d5e22610111aeacba8a0"},
-    {file = "lazy_object_proxy-1.7.1-cp37-cp37m-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:c4ce15276a1a14549d7e81c243b887293904ad2d94ad767f42df91e75fd7b5b6"},
-    {file = "lazy_object_proxy-1.7.1-cp37-cp37m-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:e368b7f7eac182a59ff1f81d5f3802161932a41dc1b1cc45c1f757dc876b5d2c"},
-    {file = "lazy_object_proxy-1.7.1-cp37-cp37m-musllinux_1_1_aarch64.whl", hash = "sha256:6ecbb350991d6434e1388bee761ece3260e5228952b1f0c46ffc800eb313ff42"},
-    {file = "lazy_object_proxy-1.7.1-cp37-cp37m-musllinux_1_1_x86_64.whl", hash = "sha256:553b0f0d8dbf21890dd66edd771f9b1b5f51bd912fa5f26de4449bfc5af5e029"},
-    {file = "lazy_object_proxy-1.7.1-cp37-cp37m-win32.whl", hash = "sha256:c7a683c37a8a24f6428c28c561c80d5f4fd316ddcf0c7cab999b15ab3f5c5c69"},
-    {file = "lazy_object_proxy-1.7.1-cp37-cp37m-win_amd64.whl", hash = "sha256:df2631f9d67259dc9620d831384ed7732a198eb434eadf69aea95ad18c587a28"},
-    {file = "lazy_object_proxy-1.7.1-cp38-cp38-macosx_10_9_x86_64.whl", hash = "sha256:07fa44286cda977bd4803b656ffc1c9b7e3bc7dff7d34263446aec8f8c96f88a"},
-    {file = "lazy_object_proxy-1.7.1-cp38-cp38-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:4dca6244e4121c74cc20542c2ca39e5c4a5027c81d112bfb893cf0790f96f57e"},
-    {file = "lazy_object_proxy-1.7.1-cp38-cp38-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:91ba172fc5b03978764d1df5144b4ba4ab13290d7bab7a50f12d8117f8630c38"},
-    {file = "lazy_object_proxy-1.7.1-cp38-cp38-musllinux_1_1_aarch64.whl", hash = "sha256:043651b6cb706eee4f91854da4a089816a6606c1428fd391573ef8cb642ae4f7"},
-    {file = "lazy_object_proxy-1.7.1-cp38-cp38-musllinux_1_1_x86_64.whl", hash = "sha256:b9e89b87c707dd769c4ea91f7a31538888aad05c116a59820f28d59b3ebfe25a"},
-    {file = "lazy_object_proxy-1.7.1-cp38-cp38-win32.whl", hash = "sha256:9d166602b525bf54ac994cf833c385bfcc341b364e3ee71e3bf5a1336e677b55"},
-    {file = "lazy_object_proxy-1.7.1-cp38-cp38-win_amd64.whl", hash = "sha256:8f3953eb575b45480db6568306893f0bd9d8dfeeebd46812aa09ca9579595148"},
-    {file = "lazy_object_proxy-1.7.1-cp39-cp39-macosx_10_9_x86_64.whl", hash = "sha256:dd7ed7429dbb6c494aa9bc4e09d94b778a3579be699f9d67da7e6804c422d3de"},
-    {file = "lazy_object_proxy-1.7.1-cp39-cp39-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:70ed0c2b380eb6248abdef3cd425fc52f0abd92d2b07ce26359fcbc399f636ad"},
-    {file = "lazy_object_proxy-1.7.1-cp39-cp39-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:7096a5e0c1115ec82641afbdd70451a144558ea5cf564a896294e346eb611be1"},
-    {file = "lazy_object_proxy-1.7.1-cp39-cp39-musllinux_1_1_aarch64.whl", hash = "sha256:f769457a639403073968d118bc70110e7dce294688009f5c24ab78800ae56dc8"},
-    {file = "lazy_object_proxy-1.7.1-cp39-cp39-musllinux_1_1_x86_64.whl", hash = "sha256:39b0e26725c5023757fc1ab2a89ef9d7ab23b84f9251e28f9cc114d5b59c1b09"},
-    {file = "lazy_object_proxy-1.7.1-cp39-cp39-win32.whl", hash = "sha256:2130db8ed69a48a3440103d4a520b89d8a9405f1b06e2cc81640509e8bf6548f"},
-    {file = "lazy_object_proxy-1.7.1-cp39-cp39-win_amd64.whl", hash = "sha256:677ea950bef409b47e51e733283544ac3d660b709cfce7b187f5ace137960d61"},
-    {file = "lazy_object_proxy-1.7.1-pp37.pp38-none-any.whl", hash = "sha256:d66906d5785da8e0be7360912e99c9188b70f52c422f9fc18223347235691a84"},
+    {file = "lazy_object_proxy-1.11.0-cp310-cp310-macosx_11_0_arm64.whl", hash = "sha256:132bc8a34f2f2d662a851acfd1b93df769992ed1b81e2b1fda7db3e73b0d5a18"},
+    {file = "lazy_object_proxy-1.11.0-cp310-cp310-win_amd64.whl", hash = "sha256:01261a3afd8621a1accb5682df2593dc7ec7d21d38f411011a5712dcd418fbed"},
+    {file = "lazy_object_proxy-1.11.0-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:090935756cc041e191f22f4f9c7fd4fe9a454717067adf5b1bbd2ce3046b556e"},
+    {file = "lazy_object_proxy-1.11.0-cp311-cp311-win_amd64.whl", hash = "sha256:76ec715017f06410f57df442c1a8d66e6b5f7035077785b129817f5ae58810a4"},
+    {file = "lazy_object_proxy-1.11.0-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:9a9f39098e93a63618a79eef2889ae3cf0605f676cd4797fdfd49fcd7ddc318b"},
+    {file = "lazy_object_proxy-1.11.0-cp312-cp312-win_amd64.whl", hash = "sha256:ee13f67f4fcd044ef27bfccb1c93d39c100046fec1fad6e9a1fcdfd17492aeb3"},
+    {file = "lazy_object_proxy-1.11.0-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:fd4c84eafd8dd15ea16f7d580758bc5c2ce1f752faec877bb2b1f9f827c329cd"},
+    {file = "lazy_object_proxy-1.11.0-cp313-cp313-win_amd64.whl", hash = "sha256:d2503427bda552d3aefcac92f81d9e7ca631e680a2268cbe62cd6a58de6409b7"},
+    {file = "lazy_object_proxy-1.11.0-cp313-cp313t-macosx_11_0_arm64.whl", hash = "sha256:0613116156801ab3fccb9e2b05ed83b08ea08c2517fdc6c6bc0d4697a1a376e3"},
+    {file = "lazy_object_proxy-1.11.0-cp313-cp313t-win_amd64.whl", hash = "sha256:bb03c507d96b65f617a6337dedd604399d35face2cdf01526b913fb50c4cb6e8"},
+    {file = "lazy_object_proxy-1.11.0-cp39-cp39-macosx_11_0_arm64.whl", hash = "sha256:28c174db37946f94b97a97b579932ff88f07b8d73a46b6b93322b9ac06794a3b"},
+    {file = "lazy_object_proxy-1.11.0-cp39-cp39-win_amd64.whl", hash = "sha256:d662f0669e27704495ff1f647070eb8816931231c44e583f4d0701b7adf6272f"},
+    {file = "lazy_object_proxy-1.11.0-py3-none-any.whl", hash = "sha256:a56a5093d433341ff7da0e89f9b486031ccd222ec8e52ec84d0ec1cdc819674b"},
+    {file = "lazy_object_proxy-1.11.0.tar.gz", hash = "sha256:18874411864c9fbbbaa47f9fc1dd7aea754c86cfde21278ef427639d1dd78e9c"},
 ]
 
 [[package]]


### PR DESCRIPTION
The old version seems to break our CI:
https://github.com/trezor/trezor-firmware/actions/runs/16760594943/job/47454918872#step:3:4024
```
PEP517 build of a dependency failed

Backend subprocess exited when trying to invoke build_wheel

    | Command '['/run/user/1001/tmpcu9crtyz/.venv/bin/python', '/nix/store/hv8xyk68b48ybj912m3a3kz904s0djas-python3.13-pyproject-hooks-1.2.0/lib/python3.13/site-packages/pyproject_hooks/_in_process/_in_process.py', 'build_wheel', '/run/user/1001/tmptlwpj4s8']' returned non-zero exit status 1.
    | 
    | toml section missing 'pyproject.toml does not contain a tool.setuptools_scm section'
    | Traceback (most recent call last):
    |   File "/run/user/1001/tmpcu9crtyz/.venv/lib/python3.13/site-packages/setuptools_scm/_integration/pyproject_reading.py", line 71, in read_pyproject
    |     section = defn.get("tool", {})[tool_name]
    |               ~~~~~~~~~~~~~~~~~~~~^^^^^^^^^^^
    | KeyError: 'setuptools_scm'
    | toml section missing 'pyproject.toml does not contain a tool.setuptools_scm section'
    | Traceback (most recent call last):
    |   File "/run/user/1001/tmpcu9crtyz/.venv/lib/python3.13/site-packages/setuptools_scm/_integration/pyproject_reading.py", line 71, in read_pyproject
    |     section = defn.get("tool", {})[tool_name]
    |               ~~~~~~~~~~~~~~~~~~~~^^^^^^^^^^^
    | KeyError: 'setuptools_scm'
    | Traceback (most recent call last):
    |   File "/nix/store/hv8xyk68b48ybj912m3a3kz904s0djas-python3.13-pyproject-hooks-1.2.0/lib/python3.13/site-packages/pyproject_hooks/_in_process/_in_process.py", line 389, in <module>
    |     main()
    |     ~~~~^^
    |   File "/nix/store/hv8xyk68b48ybj912m3a3kz904s0djas-python3.13-pyproject-hooks-1.2.0/lib/python3.13/site-packages/pyproject_hooks/_in_process/_in_process.py", line 373, in main
    |     json_out["return_val"] = hook(**hook_input["kwargs"])
    |                              ~~~~^^^^^^^^^^^^^^^^^^^^^^^^
    |   File "/nix/store/hv8xyk68b48ybj912m3a3kz904s0djas-python3.13-pyproject-hooks-1.2.0/lib/python3.13/site-packages/pyproject_hooks/_in_process/_in_process.py", line 280, in build_wheel
    |     return _build_backend().build_wheel(
    |            ~~~~~~~~~~~~~~~~~~~~~~~~~~~~^
    |         wheel_directory, config_settings, metadata_directory
    |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    |     )
    |     ^
    |   File "/run/user/1001/tmpcu9crtyz/.venv/lib/python3.13/site-packages/setuptools/build_meta.py", line 432, in build_wheel
    |     return _build(['bdist_wheel'])
    |   File "/run/user/1001/tmpcu9crtyz/.venv/lib/python3.13/site-packages/setuptools/build_meta.py", line 423, in _build
    |     return self._build_with_temp_dir(
    |            ~~~~~~~~~~~~~~~~~~~~~~~~~^
    |         cmd,
    |         ^^^^
    |     ...<3 lines>...
    |         self._arbitrary_args(config_settings),
    |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    |     )
    |     ^
    |   File "/run/user/1001/tmpcu9crtyz/.venv/lib/python3.13/site-packages/setuptools/build_meta.py", line 404, in _build_with_temp_dir
    |     self.run_setup()
    |     ~~~~~~~~~~~~~~^^
    |   File "/run/user/1001/tmpcu9crtyz/.venv/lib/python3.13/site-packages/setuptools/build_meta.py", line 512, in run_setup
    |     super().run_setup(setup_script=setup_script)
    |     ~~~~~~~~~~~~~~~~~^^^^^^^^^^^^^^^^^^^^^^^^^^^
    |   File "/run/user/1001/tmpcu9crtyz/.venv/lib/python3.13/site-packages/setuptools/build_meta.py", line 317, in run_setup
    |     exec(code, locals())
    |     ~~~~^^^^^^^^^^^^^^^^
    |   File "<string>", line 73, in <module>
    |   File "/run/user/1001/tmpcu9crtyz/.venv/lib/python3.13/site-packages/setuptools/__init__.py", line 115, in setup
    |     return distutils.core.setup(**attrs)
    |            ~~~~~~~~~~~~~~~~~~~~^^^^^^^^^
    |   File "/run/user/1001/tmpcu9crtyz/.venv/lib/python3.13/site-packages/setuptools/_distutils/core.py", line 148, in setup
    |     _setup_distribution = dist = klass(attrs)
    |                                  ~~~~~^^^^^^^
    |   File "/run/user/1001/tmpcu9crtyz/.venv/lib/python3.13/site-packages/setuptools/dist.py", line 321, in __init__
    |     _Distribution.__init__(self, dist_attrs)
    |     ~~~~~~~~~~~~~~~~~~~~~~^^^^^^^^^^^^^^^^^^
    |   File "/run/user/1001/tmpcu9crtyz/.venv/lib/python3.13/site-packages/setuptools/_distutils/dist.py", line 309, in __init__
    |     self.finalize_options()
    |     ~~~~~~~~~~~~~~~~~~~~~^^
    |   File "/run/user/1001/tmpcu9crtyz/.venv/lib/python3.13/site-packages/setuptools/dist.py", line 784, in finalize_options
    |     ep(self)
    |     ~~^^^^^^
    |   File "/run/user/1001/tmpcu9crtyz/.venv/lib/python3.13/site-packages/setuptools/dist.py", line 804, in _finalize_setup_keywords
    |     ep.load()(self, ep.name, value)
    |     ~~~~~~~~~^^^^^^^^^^^^^^^^^^^^^^
    |   File "/run/user/1001/tmpcu9crtyz/.venv/lib/python3.13/site-packages/setuptools_scm/_integration/setuptools.py", line 131, in version_keyword
    |     config = _config.Configuration.from_file(
    |         dist_name=dist_name,
    |     ...<2 lines>...
    |         **overrides,
    |     )
    |   File "/run/user/1001/tmpcu9crtyz/.venv/lib/python3.13/site-packages/setuptools_scm/_config.py", line 296, in from_file
    |     pyproject_data = _read_pyproject(
    |         Path(name), missing_section_ok=missing_section_ok
    |     )
    |   File "/run/user/1001/tmpcu9crtyz/.venv/lib/python3.13/site-packages/setuptools_scm/_integration/pyproject_reading.py", line 95, in read_pyproject
    |     pyproject_data.verify_dynamic_version_when_required()
    |     ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~^^
    |   File "/run/user/1001/tmpcu9crtyz/.venv/lib/python3.13/site-packages/setuptools_scm/_integration/pyproject_reading.py", line 38, in verify_dynamic_version_when_required
    |     raise ValueError(
    |     ...<3 lines>...
    |     )
    | ValueError: pyproject.toml: setuptools-scm is present in [build-system].requires but dynamic=['version'] is not set in [project]. Either add dynamic=['version'] to [project] or add a [tool.setuptools_scm] section.

Note: This error originates from the build backend, and is likely not a problem with poetry but one of the following issues with lazy-object-proxy (1.7.1)

  - not supporting PEP 517 builds
  - not specifying PEP 517 build requirements correctly
  - the build requirements are incompatible with your operating system or Python version
  - the build requirements are missing system dependencies (eg: compilers, libraries, headers).

You can verify this by running pip wheel --no-cache-dir --use-pep517 "lazy-object-proxy (==1.7.1)".
```