### PR TITLE
test(core): fix `test_emu_sanity` on T3W1 non-debug emulators

### DIFF
--- a/python/src/trezorlib/_internal/emulator.py
+++ b/python/src/trezorlib/_internal/emulator.py
@@ -22,7 +22,7 @@ import time
 from pathlib import Path
 from typing import Any, Dict, Iterable, List, Optional, Sequence, TextIO, Union, cast
 
-from ..debuglink import TrezorClientDebugLink
+from ..debuglink import DebugLinkNotFound, TrezorClientDebugLink
 from ..transport import Transport
 from ..transport.udp import UdpTransport
 
@@ -194,12 +194,16 @@ class Emulator:
         (self.profile_dir / "trezor.pid").write_text(str(self.process.pid) + "\n")
         (self.profile_dir / "trezor.port").write_text(str(self.port) + "\n")
 
-        self._client = TrezorClientDebugLink(
-            self.transport,
-            auto_interact=self.auto_interact,
-            open_transport=True,
-            debug_transport=debug_transport,
-        )
+        try:
+            self._client = TrezorClientDebugLink(
+                self.transport,
+                auto_interact=self.auto_interact,
+                open_transport=True,
+                debug_transport=debug_transport,
+            )
+        except DebugLinkNotFound as e:
+            # Don't fail `start()` to allow non-debug emulator sanity test.
+            LOG.warning("DebugLink not found: %s", e)
 
     def stop(self) -> None:
         if self._client:

--- a/python/src/trezorlib/debuglink.py
+++ b/python/src/trezorlib/debuglink.py
@@ -1245,6 +1245,10 @@ class SessionDebugWrapper(Session):
         self.refresh_features()
 
 
+class DebugLinkNotFound(Exception):
+    pass
+
+
 class TrezorClientDebugLink(TrezorClient):
     # This class implements automatic responses
     # and other functionality for unit tests
@@ -1277,7 +1281,7 @@ class TrezorClientDebugLink(TrezorClient):
                 self.debug.open()
                 # try to open debuglink, see if it works
                 if not self.debug.transport.ping():
-                    LOG.warning("DebugLink is not available")
+                    raise DebugLinkNotFound(self.debug.transport.get_path())
 
         except Exception:
             if not auto_interact:


### PR DESCRIPTION
Currently `TrezorClientDebugLink` is trying to perform THP pairing, which fails without DebugLink:
https://github.com/trezor/trezor-firmware/actions/runs/16763491862/job/47463919195
```
  File "/home/runner/work/trezor-firmware/trezor-firmware/core/emu.py", line 278, in cli
    emulator.start()
    ~~~~~~~~~~~~~~^^
  File "/home/runner/work/trezor-firmware/trezor-firmware/python/src/trezorlib/_internal/emulator.py", line 197, in start
    self._client = TrezorClientDebugLink(
                   ~~~~~~~~~~~~~~~~~~~~~^
        self.transport,
        ^^^^^^^^^^^^^^^
    ...<2 lines>...
        debug_transport=debug_transport,
        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    )
    ^
  File "/home/runner/work/trezor-firmware/trezor-firmware/python/src/trezorlib/debuglink.py", line 1319, in __init__
    self.do_pairing(pairing_method=messages.ThpPairingMethod.SkipPairing)
    ~~~~~~~~~~~~~~~^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/runner/work/trezor-firmware/trezor-firmware/python/src/trezorlib/client.py", line 123, in do_pairing
    session.call(
    ~~~~~~~~~~~~^
        messages.ThpPairingRequest(host_name="Trezorlib"),
        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
        expect=messages.ThpPairingRequestApproved,
        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
        skip_firmware_version_check=True,
        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    )
    ^
  File "/home/runner/work/trezor-firmware/trezor-firmware/python/src/trezorlib/transport/session.py", line 48, in call
    resp = self._callback_button(resp)
```