### PR TITLE
test(core): add a temporary workaround for UI tests flakiness on THP

### DIFF
--- a/tests/ui_tests/__init__.py
+++ b/tests/ui_tests/__init__.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import logging
 import shutil
+import time
 import typing as t
 from contextlib import contextmanager
 
@@ -10,6 +11,7 @@ from _pytest.nodes import Node
 from _pytest.outcomes import Failed
 from noise.exceptions import NoiseInvalidMessage
 
+from trezorlib.client import ProtocolVersion
 from trezorlib.debuglink import TrezorClientDebugLink as Client
 from trezorlib.exceptions import ThpError
 from trezorlib.transport import Timeout
@@ -59,6 +61,15 @@ def screen_recording(
     shutil.rmtree(testcase.actual_dir, ignore_errors=True)
     testcase.actual_dir.mkdir()
 
+    if client.protocol_version is ProtocolVersion.V2:
+        # In case of an event loop restart, it's possible that the first
+        # packet(s) of `DebugLinkRecordScreen` will be lost, resulting in
+        # `TrezorFailure: FirmwareError: Invalid magic` error responses
+        # during test setup.
+        # This issue will be resolved as part of THP event loop restart refactoring,
+        # but till then let's wait a bit here, to reduce the packet loss probability.
+        # TODO: remove after THP event loop restart refactoring
+        time.sleep(0.1)
     try:
         client.debug.start_recording(str(testcase.actual_dir))
         yield


### PR DESCRIPTION
In case of an event loop restart, it's possible that the first packet(s) of `DebugLinkRecordScreen` will be lost, resulting in `TrezorFailure: FirmwareError: Invalid magic` error responses during test setup.

This issue will be resolved as part of THP event loop restart refactoring, but till then let's wait a bit here, to reduce the packet loss probability.
