### PR TITLE
Haptic support in emulator

### DIFF
--- a/core/.changelog.d/3735.added
+++ b/core/.changelog.d/3735.added
@@ -1,0 +1,1 @@
+[T3T1,T3W1] Haptic support in emulator.

--- a/core/SConscript.unix
+++ b/core/SConscript.unix
@@ -26,6 +26,7 @@ FEATURES_WANTED = [
     "ble",
     "display",
     "dma2d",
+    "haptic",
     "input",
     "kernel_mode",
     "optiga",

--- a/core/embed/io/display/inc/io/unix/sdl_display.h
+++ b/core/embed/io/display/inc/io/unix/sdl_display.h
@@ -1,8 +1,17 @@
 #pragma once
 
+#ifdef USE_HAPTIC
+#include <io/haptic.h>
+#endif /* USE_HAPTIC */
 #include <trezor_types.h>
 
 #ifdef USE_RGB_LED
 // Update the RGB LED color in the emulator
 void display_rgb_led(uint32_t color);
 #endif
+
+#ifdef USE_HAPTIC
+// Update the haptic color in the emulator
+void display_haptic_effect(haptic_effect_t effect);
+void display_custom_effect(uint32_t duration_ms);
+#endif /* USE_HAPTIC */

--- a/core/embed/io/haptic/unix/haptic_driver.c
+++ b/core/embed/io/haptic/unix/haptic_driver.c
@@ -1,0 +1,136 @@
+/*
+ * This file is part of the Trezor project, https://trezor.io/
+ *
+ * Copyright (c) SatoshiLabs
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#include <trezor_bsp.h>
+#include <trezor_rtl.h>
+
+#include <io/haptic.h>
+#include <io/unix/sdl_display.h>
+
+#ifdef KERNEL_MODE
+
+// Driver state
+typedef struct {
+  bool initialized;
+  bool enabled;
+} haptic_driver_t;
+
+// Haptic driver instance
+static haptic_driver_t g_haptic_driver = {
+    .initialized = true,
+    .enabled = false,
+};
+
+bool haptic_init(void) {
+  haptic_driver_t *driver = &g_haptic_driver;
+
+  if (driver->initialized) {
+    return true;
+  }
+
+  memset(driver, 0, sizeof(haptic_driver_t));
+
+  driver->initialized = true;
+  driver->enabled = true;
+
+  return true;
+}
+
+void haptic_deinit(void) {
+  haptic_driver_t *driver = &g_haptic_driver;
+  memset(driver, 0, sizeof(haptic_driver_t));
+}
+
+void haptic_set_enabled(bool enabled) {
+  haptic_driver_t *driver = &g_haptic_driver;
+
+  if (!driver->initialized) {
+    return;
+  }
+
+  driver->enabled = enabled;
+}
+
+bool haptic_get_enabled(void) {
+  haptic_driver_t *driver = &g_haptic_driver;
+
+  if (!driver->initialized) {
+    return false;
+  }
+
+  return driver->enabled;
+}
+
+bool haptic_test(uint16_t duration_ms) {
+  haptic_driver_t *driver = &g_haptic_driver;
+
+  if (!driver->initialized) {
+    return false;
+  }
+
+  if (!driver->enabled) {
+    return true;
+  }
+
+  // display_effect(0xff, duration_ms);
+  return true;
+}
+
+bool haptic_play(haptic_effect_t effect) {
+  haptic_driver_t *driver = &g_haptic_driver;
+
+  if (!driver->initialized) {
+    return false;
+  }
+
+  if (!driver->enabled) {
+    return true;
+  }
+
+  switch (effect) {
+    case HAPTIC_BUTTON_PRESS:
+      display_haptic_effect(HAPTIC_BUTTON_PRESS);
+      return true;
+    case HAPTIC_HOLD_TO_CONFIRM:
+      display_haptic_effect(HAPTIC_HOLD_TO_CONFIRM);
+      return true;
+    case HAPTIC_BOOTLOADER_ENTRY:
+      display_haptic_effect(HAPTIC_BOOTLOADER_ENTRY);
+      return true;
+    default:
+      return false;
+  }
+}
+
+bool haptic_play_custom(int8_t amplitude_pct, uint16_t duration_ms) {
+  haptic_driver_t *driver = &g_haptic_driver;
+
+  if (!driver->initialized) {
+    return false;
+  }
+
+  if (!driver->enabled) {
+    return true;
+  }
+
+  display_custom_effect(duration_ms);
+  return true;
+}
+
+#endif  // KERNEL_MODE

--- a/core/embed/io/touch/unix/touch.c
+++ b/core/embed/io/touch/unix/touch.c
@@ -21,6 +21,7 @@
 #include <trezor_rtl.h>
 
 #include <io/touch.h>
+#include <io/unix/sdl_display.h>
 #include <sys/systick.h>
 #include <sys/unix/sdl_event.h>
 
@@ -28,6 +29,7 @@
 
 extern int sdl_display_res_x, sdl_display_res_y;
 extern int sdl_touch_offset_x, sdl_touch_offset_y;
+extern int sdl_touch_x, sdl_touch_y;
 
 // distance from the edge where arrow button swipe starts [px]
 static const int _btn_swipe_begin = 120;
@@ -77,6 +79,11 @@ static bool is_inside_display(int x, int y) {
 
 static void handle_mouse_events(touch_driver_t* drv, SDL_Event* event) {
   bool inside_display = is_inside_display(event->button.x, event->button.y);
+
+  sdl_touch_x = inside_display ? event->button.x - sdl_touch_offset_x
+                               : touch_unpack_x(drv->last_event);
+  sdl_touch_y = inside_display ? event->button.y - sdl_touch_offset_y
+                               : touch_unpack_y(drv->last_event);
 
   switch (event->type) {
     case SDL_MOUSEBUTTONDOWN:

--- a/core/embed/rust/src/ui/layout_eckhart/ui_firmware.rs
+++ b/core/embed/rust/src/ui/layout_eckhart/ui_firmware.rs
@@ -58,7 +58,7 @@ impl FirmwareUI for UIEckhart {
         title: TString<'static>,
         action: Option<TString<'static>>,
         description: Option<TString<'static>>,
-        subtitle: Option<TString<'static>>,
+        _subtitle: Option<TString<'static>>,
         verb: Option<TString<'static>>,
         _verb_cancel: Option<TString<'static>>,
         hold: bool,
@@ -106,15 +106,12 @@ impl FirmwareUI for UIEckhart {
             }
         };
 
-        let mut screen = TextScreen::new(paragraphs)
+        let screen = TextScreen::new(paragraphs)
             .with_header(Header::new(title))
             .with_action_bar(ActionBar::new_double(
                 Button::with_icon(theme::ICON_CROSS),
                 right_button,
             ));
-        if let Some(subtitle) = subtitle {
-            screen = screen.with_hint(Hint::new_instruction(subtitle, None));
-        }
         let layout = RootComponent::new(screen);
         Ok(layout)
     }

--- a/core/embed/sys/task/sysevent.c
+++ b/core/embed/sys/task/sysevent.c
@@ -27,6 +27,7 @@
 #include <sys/systick.h>
 
 #ifdef TREZOR_EMULATOR
+#include <io/display.h>
 #include <sys/unix/sdl_event.h>
 #endif
 
@@ -188,6 +189,8 @@ void sysevents_poll(const sysevents_t *awaited, sysevents_t *signalled,
 #ifdef TREZOR_EMULATOR
     // Poll SDL events and dispatch them
     sdl_events_poll();
+    // Refresh display to catch the end of the haptic feedback
+    display_refresh();
 #endif
 
     syshandle_mask_t handles_to_read = 0;
@@ -233,6 +236,8 @@ void sysevents_poll(const sysevents_t *awaited, sysevents_t *signalled,
     }
 
 #ifdef TREZOR_EMULATOR
+    // Refresh display to catch the end of the haptic feedback
+    display_refresh();
     // Wait a bit to not consume 100% CPU
     systick_delay_ms(1);
 #else

--- a/core/site_scons/models/T3T1/emulator.py
+++ b/core/site_scons/models/T3T1/emulator.py
@@ -71,6 +71,14 @@ def configure(
         features_available.append("touch")
         defines += [("USE_TOUCH", "1")]
 
+    if "haptic" in features_wanted:
+        sources += [
+            "embed/io/haptic/unix/haptic_driver.c",
+        ]
+        paths += ["embed/io/haptic/inc"]
+        features_available.append("haptic")
+        defines += [("USE_HAPTIC", "1")]
+
     features_available.append("backlight")
     defines += [("USE_BACKLIGHT", "1")]
 

--- a/core/site_scons/models/T3W1/emulator.py
+++ b/core/site_scons/models/T3W1/emulator.py
@@ -102,6 +102,14 @@ def configure(
         features_available.append("button")
         defines += [("USE_BUTTON", "1")]
 
+    if "haptic" in features_wanted:
+        sources += [
+            "embed/io/haptic/unix/haptic_driver.c",
+        ]
+        paths += ["embed/io/haptic/inc"]
+        features_available.append("haptic")
+        defines += [("USE_HAPTIC", "1")]
+
     if "ble" in features_wanted:
         sources += ["embed/io/ble/unix/ble.c"]
         paths += ["embed/io/ble/inc"]


### PR DESCRIPTION
- [delizia, eckhart] haptic feedback support in emulator, the colored point is rendered on the touch coords: 
  - red - simple click
  - orange - intermediate HTC
  -  green - completed HTC
  - In case of tests, ~~the upper left corner pixel is rendered instead of the point~~, the haptic point is rendered out of the screen (coords [-1,-1]) because of too many new screens and their inconsistency (`press_yes` doesn't create one but clicking does, ...)
- [delizia, eckhart]: test for enabling/disabling the haptic feedback

<!--
For core developers:
- Assign yourself to the PR.
- Set the priority to match the original issue.
- Add the PR to the current sprint.
- If it's a draft PR, mark it as "In Progress."
- If it's a final PR, mark it as "Needs Review."

For external contributors:
- Please open an issue before submitting a PR so we can discuss whether we want to proceed with it.
-->
