### PR TITLE
feat(core): adjust RSOD

### DIFF
--- a/core/embed/rtl/error_handling.c
+++ b/core/embed/rtl/error_handling.c
@@ -27,6 +27,15 @@
 uint32_t __stack_chk_guard = 0;
 #endif
 
+#define ALL_DATA_ERASED_MESSAGE "All data has been erased from the device"
+
+#ifdef TREZOR_MODEL_T3W1
+// empty message for T3W1 so that it falls to the more appropriate default
+#define RECONNECT_DEVICE_MESSAGE ""
+#else
+#define RECONNECT_DEVICE_MESSAGE "Please reconnect\nthe device"
+#endif
+
 // Calls to this function are inserted by the compiler
 // when stack protection is enabled.
 void __attribute__((noreturn, used)) __stack_chk_fail(void) {
@@ -52,19 +61,17 @@ __fatal_error(const char *msg, const char *file, int line) {
 }
 
 void __attribute__((noreturn)) show_wipe_code_screen(void) {
-  error_shutdown_ex("WIPE CODE ENTERED",
-                    "All data has been erased from the device",
-                    "PLEASE RECONNECT\nTHE DEVICE");
+  error_shutdown_ex("Wipe code entered", ALL_DATA_ERASED_MESSAGE,
+                    RECONNECT_DEVICE_MESSAGE);
 }
 
 void __attribute__((noreturn)) show_pin_too_many_screen(void) {
-  error_shutdown_ex("PIN ATTEMPTS\nEXCEEDED",
-                    "All data has been\nerased from the device",
-                    "Please reconnect the\ndevice");
+  error_shutdown_ex("Pin attempts exceeded", ALL_DATA_ERASED_MESSAGE,
+                    RECONNECT_DEVICE_MESSAGE);
 }
 
 void __attribute__((noreturn)) show_install_restricted_screen(void) {
-  error_shutdown_ex("INSTALL RESTRICTED",
+  error_shutdown_ex("Install restricted",
                     "Installation of custom firmware is currently restricted.",
-                    "Please visit\ntrezor.io/bootloader");
+                    "Please visit trezor.io/bootloader");
 }

--- a/core/embed/rust/src/ui/layout_caesar/component/error.rs
+++ b/core/embed/rust/src/ui/layout_caesar/component/error.rs
@@ -27,9 +27,9 @@ pub struct ErrorScreen<'a> {
 
 impl<'a> ErrorScreen<'a> {
     pub fn new(title: TString<'a>, message: TString<'a>, footer: TString<'a>) -> Self {
-        let title = Label::centered(title, theme::TEXT_BOLD);
+        let title = Label::centered(title, theme::TEXT_BOLD_UPPER);
         let message = Label::centered(message, theme::TEXT_NORMAL).vertically_centered();
-        let footer = Label::centered(footer, theme::TEXT_NORMAL).vertically_centered();
+        let footer = Label::centered(footer, theme::TEXT_NORMAL_UPPER).vertically_centered();
 
         Self {
             bg: Pad::with_background(BG).with_clear(),

--- a/core/embed/rust/src/ui/layout_caesar/theme/mod.rs
+++ b/core/embed/rust/src/ui/layout_caesar/theme/mod.rs
@@ -27,6 +27,10 @@ pub const TEXT_NORMAL: TextStyle = TextStyle::new(fonts::FONT_NORMAL, FG, BG, FG
     .with_page_breaking(PageBreaking::CutAndInsertEllipsisBoth)
     .with_ellipsis_icon(ICON_NEXT_PAGE, ELLIPSIS_ICON_MARGIN)
     .with_prev_page_icon(ICON_PREV_PAGE, PREV_PAGE_ICON_MARGIN);
+pub const TEXT_NORMAL_UPPER: TextStyle = TextStyle::new(fonts::FONT_NORMAL_UPPER, FG, BG, FG, FG)
+    .with_page_breaking(PageBreaking::CutAndInsertEllipsisBoth)
+    .with_ellipsis_icon(ICON_NEXT_PAGE, ELLIPSIS_ICON_MARGIN)
+    .with_prev_page_icon(ICON_PREV_PAGE, PREV_PAGE_ICON_MARGIN);
 pub const TEXT_BIG: TextStyle = TextStyle::new(fonts::FONT_BIG, FG, BG, FG, FG);
 pub const TEXT_CHOICE_ITEMS: TextStyle = TEXT_BIG
     .with_line_spacing(2)

--- a/core/embed/rust/src/ui/layout_eckhart/bootloader/bld_header.rs
+++ b/core/embed/rust/src/ui/layout_eckhart/bootloader/bld_header.rs
@@ -55,12 +55,6 @@ impl<'a> BldHeader<'a> {
         }
     }
 
-    pub fn new_rsod_header() -> Self {
-        Self::new("Failure".into())
-            .with_icon(theme::ICON_INFO, theme::RED)
-            .with_text_style(text_title(theme::RED))
-    }
-
     pub fn new_done(color: Color) -> Self {
         Self::new("Done".into())
             .with_icon(theme::ICON_DONE, color)

--- a/core/embed/rust/src/ui/layout_eckhart/component/error.rs
+++ b/core/embed/rust/src/ui/layout_eckhart/component/error.rs
@@ -53,20 +53,20 @@ impl<'a> Component for ErrorScreen<'a> {
     type Msg = Never;
 
     fn place(&mut self, _bounds: Rect) -> Rect {
-        const FOOTER_AREA_HEIGHT: i16 = 52;
         const AREA: Rect = SCREEN.inset(SIDE_INSETS);
 
         let (header_area, area) = AREA.split_top(HEADER_HEIGHT);
         let (area, actionbar_area) = area.split_bottom(ACTION_BAR_HEIGHT);
         let area = area.inset(Insets::bottom(PADDING));
-        let (area, footer_area) = area.split_bottom(FOOTER_AREA_HEIGHT);
 
         let title_height = self.title.text_height(area.width());
         let message_height = self.message.text_height(area.width());
+        let footer_height = self.footer.text_height(area.width());
         let (title_area, area) = area.split_top(title_height);
-        let (message_area, _) = area
+        let (message_area, area) = area
             .inset(Insets::top(TEXT_VERTICAL_SPACING))
             .split_top(message_height);
+        let (_, footer_area) = area.split_bottom(footer_height);
 
         self.header.place(header_area);
         self.title.place(title_area);

--- a/core/embed/util/rsod/rsod.c
+++ b/core/embed/util/rsod/rsod.c
@@ -28,10 +28,10 @@
 #include <util/scm_revision.h>
 #endif
 
-#define RSOD_DEFAULT_TITLE "INTERNAL ERROR";
-#define RSOD_DEFAULT_MESSAGE "UNSPECIFIED";
-#define RSOD_DEFAULT_FOOTER "PLEASE VISIT TREZOR.IO/RSOD";
-#define RSOD_EXIT_MESSAGE "EXIT %d"
+#define RSOD_DEFAULT_TITLE "Internal error";
+#define RSOD_DEFAULT_MESSAGE "Unspecified";
+#define RSOD_DEFAULT_FOOTER "Please visit trezor.io/rsod";
+#define RSOD_EXIT_MESSAGE "Exit %d"
 
 #ifdef KERNEL_MODE
 


### PR DESCRIPTION
- Eckhart RSOD now says "Wait for Trezor shutdown" (not restart)
- the footer now says "Please visit trezor.io/rsod" after wipe code entry or running out of PIN attempts
- default title/message/footer texts are lowercase for T3W1
- titles used in `error_handling.c` are lowercase so that it looks nicer. However we want to keep the readability on T2B1/T3B1 so the `_UPPER` font is used which renders it uppercase


<!--
For core developers:
- Assign yourself to the PR.
- Set the priority to match the original issue.
- Add the PR to the current sprint.
- If it's a draft PR, mark it as "In Progress."
- If it's a final PR, mark it as "Needs Review."

For external contributors:
- Please open an issue before submitting a PR so we can discuss whether we want to proceed with it.
-->
