### PR TITLE
fix(build): no ui_debug_overlay only in prod

### DIFF
--- a/core/SConscript.firmware
+++ b/core/SConscript.firmware
@@ -862,12 +862,11 @@ features = ['micropython', 'protobuf', 'ui', 'translations'] + FEATURES_AVAILABL
 if PYOPT == '0':
     features.append('debug')
     features.append('ui_debug')
+    features.append('ui_debug_overlay')
 if EVERYTHING:
     features.append('universal_fw')
 if UI_PERFORMANCE_OVERLAY:
     features.append('ui_performance_overlay')
-if PYOPT:
-    features.append('ui_debug_overlay')
 
 
 rust = tools.add_rust_lib(


### PR DESCRIPTION
Seems like a mistake from https://github.com/trezor/trezor-firmware/pull/5454

<!--
For core developers:
- Assign yourself to the PR.
- Set the priority to match the original issue.
- Add the PR to the current sprint.
- If it's a draft PR, mark it as "In Progress."
- If it's a final PR, mark it as "Needs Review."

For external contributors:
- Please open an issue before submitting a PR so we can discuss whether we want to proceed with it.
-->
