### PR TITLE
Fix: Unify pm monitoring periods.

### DIFF
--- a/core/embed/sys/power_manager/stm32u5/power_manager.c
+++ b/core/embed/sys/power_manager/stm32u5/power_manager.c
@@ -87,7 +87,7 @@ pm_status_t pm_init(bool inherit_state) {
     return PM_ERROR;
   }
 
-  systimer_set_periodic(drv->monitoring_timer, PM_BATTERY_SAMPLING_PERIOD_MS);
+  systimer_set_periodic(drv->monitoring_timer, PM_TIMER_PERIOD_MS);
 
   // Initial power source measurement
   pmic_measure(pm_pmic_data_ready, NULL);
@@ -359,9 +359,6 @@ pm_status_t pm_turn_on(void) {
   if (drv->state == PM_STATE_HIBERNATE || drv->state == PM_STATE_CHARGING) {
     return PM_REQUEST_REJECTED;
   }
-
-  // Set monitoiring timer with longer period
-  systimer_set_periodic(drv->monitoring_timer, PM_TIMER_PERIOD_MS);
 
   return PM_OK;
 }
@@ -666,7 +663,7 @@ bool pm_driver_resume(void) {
   pmic_measure(pm_pmic_data_ready, NULL);
 
   // Set the periodic sampling period
-  systimer_set_periodic(drv->monitoring_timer, PM_BATTERY_SAMPLING_PERIOD_MS);
+  systimer_set_periodic(drv->monitoring_timer, PM_TIMER_PERIOD_MS);
 
   return true;
 }

--- a/core/embed/sys/power_manager/stm32u5/power_manager_internal.h
+++ b/core/embed/sys/power_manager/stm32u5/power_manager_internal.h
@@ -28,8 +28,7 @@
 #include "../stwlc38/stwlc38.h"
 
 // Power manager thresholds & timings
-#define PM_TIMER_PERIOD_MS 300
-#define PM_BATTERY_SAMPLING_PERIOD_MS 100
+#define PM_TIMER_PERIOD_MS 100
 #define PM_SHUTDOWN_TIMEOUT_MS 15000
 #define PM_BATTERY_UNDERVOLT_THR_V 3.0f
 #define PM_BATTERY_UNDERVOLT_RECOVERY_THR_V 3.1f

--- a/core/embed/sys/power_manager/stm32u5/power_monitoring.c
+++ b/core/embed/sys/power_manager/stm32u5/power_monitoring.c
@@ -56,7 +56,7 @@ void pm_pmic_data_ready(void* context, pmic_report_t* report) {
 
   // Store measurement timestamp
   if (drv->pmic_last_update_us == 0) {
-    drv->pmic_sampling_period_ms = PM_BATTERY_SAMPLING_PERIOD_MS;
+    drv->pmic_sampling_period_ms = PM_TIMER_PERIOD_MS;
     drv->vbat_tau = report->vbat;
   } else {
     // Calculate the time since the last PMIC update


### PR DESCRIPTION
This PR fixes the inconsistency in the power manager monitoring sampling period.

Originally, the intention was to set the power monitor period to 300ms to have sufficiently frequent monitoring with quick response for power events (USB connected/disconnected, etc.), but that number was not high enough for initial battery sampling when the battery SoC was unknown. Because of this, the power manager also introduced the PM_BATTERY_SAMPLING_PERIOD_MS constant equal to 100ms, which was used during the battery sampling period and switched to 300ms when the pm_turn_on() command was called.

While this worked well in the bootloader, in the firmware the power manager inherits the estimated SoC and the pm_turn_on() command was never called. The sampling period then remained at 100ms.

I have profiled the pm_pmic_data_ready() callback function, which does all the monitoring work with DWT, and it showed that the profile is only ~8,500 CPU cycles (monitoring with systick_us() is aligned and shows roughly 50-55μs), which means that even if we stick to the 100ms monitoring period, the overall CPU time will be ~0.06% and it make sense to unify both cases to 100ms.