### PR TITLE
Update fuel gauge config v3

### DIFF
--- a/core/embed/sys/power_manager/fuel_gauge/battery_data_jyhpfl333838.h
+++ b/core/embed/sys/power_manager/fuel_gauge/battery_data_jyhpfl333838.h
@@ -34,99 +34,176 @@
  */
 
 // Configuration
-#define BATTERY_NUM_TEMP_POINTS 4
+#define BATTERY_NUM_TEMP_POINTS 8
 
 // SOC breakpoints for piecewise functions
 #define BATTERY_SOC_BREAKPOINT_1 0.25f
 #define BATTERY_SOC_BREAKPOINT_2 0.8f
 
-// Temperature points array (in Celsius)
-static const float BATTERY_TEMP_POINTS[BATTERY_NUM_TEMP_POINTS] = {
-    14.99f, 19.83f, 24.88f, 29.87f};
+// Temperature points arrays (in Celsius)
+// Discharge temperatures
+static const float BATTERY_TEMP_POINTS_DISCHG[BATTERY_NUM_TEMP_POINTS] = {
+    5.78f, 10.64f, 15.55f, 20.65f, 25.46f, 31.41f, 35.41f, 40.39f};
+
+// Charge temperatures
+static const float BATTERY_TEMP_POINTS_CHG[BATTERY_NUM_TEMP_POINTS] = {
+    7.28f, 12.60f, 17.51f, 22.50f, 27.54f, 32.31f, 37.36f, 42.34f};
 
 // Internal resistance curve parameters (rational function parameters
-// (a+b*t)/(c+d*t)
+// a+b*t)/(c+d*t)
 static const float BATTERY_R_INT_PARAMS[4] = {
     // a, b, c, d for rational function (a + b*t)/(c + d*t)
-    16.085563f, -0.125445f, 19.792552f, 0.145223f};
+    2.454393f, 0.067324f, 2.343462f, 0.253930f};
 
 // Discharge OCV curve parameters for each temperature
 static const float BATTERY_OCV_DISCHARGE_PARAMS[BATTERY_NUM_TEMP_POINTS][10] = {
-    // Temperature: 14.99°C
+    // Temperature: 5.78°C (key: 5)
     {
-        0.106732f, 3.237046f,  // m, b (linear segment)
-        150.195726f, 1408.772874f, 49.011575f,
-        419.677576f,  // a1, b1, c1, d1 (first rational segment)
-        1095.896717f, -1094.237972f, 329.945276f,
-        -329.470389f  // a3, b3, c3, d3 (third rational segment)
+        0.118793f, 3.223549f,  // m, b (linear segment)
+        -28.710519f, -233.020734f, -9.387607f,
+        -69.377452f,  // a1, b1, c1, d1 (first rational segment)
+        1186.538824f, -1183.168718f, 357.662778f,
+        -356.677000f  // a3, b3, c3, d3 (third rational segment)
     },
-    // Temperature: 19.83°C
+    // Temperature: 10.64°C (key: 10)
     {
-        0.128675f, 3.229591f,  // m, b (linear segment)
-        40.245534f, 455.485581f, 13.138466f,
-        136.444634f,  // a1, b1, c1, d1 (first rational segment)
-        1639.259211f, -1636.939286f, 492.018097f,
-        -491.352439f  // a3, b3, c3, d3 (third rational segment)
+        0.116677f, 3.228169f,  // m, b (linear segment)
+        38.712861f, 310.693560f, 12.654472f,
+        92.304022f,  // a1, b1, c1, d1 (first rational segment)
+        1191.497665f, -1188.685202f, 358.808999f,
+        -357.984106f  // a3, b3, c3, d3 (third rational segment)
     },
-    // Temperature: 24.88°C
+    // Temperature: 15.55°C (key: 15)
     {
-        0.121191f, 3.232382f,  // m, b (linear segment)
-        -82.844039f, -1002.077813f, -27.091776f,
-        -300.331893f,  // a1, b1, c1, d1 (first rational segment)
-        1123.577420f, -1122.115068f, 337.570875f,
-        -337.154857f  // a3, b3, c3, d3 (third rational segment)
+        0.114203f, 3.232147f,  // m, b (linear segment)
+        46.343674f, 429.794749f, 15.123043f,
+        128.169726f,  // a1, b1, c1, d1 (first rational segment)
+        2376.881452f, -2370.146392f, 715.418936f,
+        -713.454126f  // a3, b3, c3, d3 (third rational segment)
     },
-    // Temperature: 29.87°C
+    // Temperature: 20.65°C (key: 20)
     {
-        0.124779f, 3.231043f,  // m, b (linear segment)
-        -105.157412f, -1529.966103f, -34.445200f,
-        -460.150974f,  // a1, b1, c1, d1 (first rational segment)
-        2810.755069f, -2807.662591f, 844.042035f,
-        -843.161340f  // a3, b3, c3, d3 (third rational segment)
+        0.114704f, 3.233252f,  // m, b (linear segment)
+        134.655526f, 1523.391576f, 43.909469f,
+        456.507698f,  // a1, b1, c1, d1 (first rational segment)
+        1107.209215f, -1104.640469f, 333.093622f,
+        -332.346061f  // a3, b3, c3, d3 (third rational segment)
+    },
+    // Temperature: 25.46°C (key: 25)
+    {
+        0.117246f, 3.235164f,  // m, b (linear segment)
+        98.176928f, 1423.543661f, 32.065495f,
+        428.106598f,  // a1, b1, c1, d1 (first rational segment)
+        2966.477437f, -2956.724203f, 891.503790f,
+        -888.671853f  // a3, b3, c3, d3 (third rational segment)
+    },
+    // Temperature: 31.41°C (key: 30)
+    {
+        0.117384f, 3.238390f,  // m, b (linear segment)
+        85.864212f, 1387.277542f, 28.067560f,
+        417.373016f,  // a1, b1, c1, d1 (first rational segment)
+        1149.478486f, -1147.371472f, 345.039987f,
+        -344.429990f  // a3, b3, c3, d3 (third rational segment)
+    },
+    // Temperature: 35.41°C (key: 35)
+    {
+        0.123742f, 3.235846f,  // m, b (linear segment)
+        142.926106f, 2413.781156f, 46.744426f,
+        726.914288f,  // a1, b1, c1, d1 (first rational segment)
+        4746.864260f, -4740.482325f, 1423.698973f,
+        -1421.856011f  // a3, b3, c3, d3 (third rational segment)
+    },
+    // Temperature: 40.39°C (key: 40)
+    {
+        0.123445f, 3.236911f,  // m, b (linear segment)
+        123.143807f, 2079.888064f, 40.268920f,
+        626.146547f,  // a1, b1, c1, d1 (first rational segment)
+        4400.930811f, -4394.510401f, 1319.644484f,
+        -1317.792008f  // a3, b3, c3, d3 (third rational segment)
     }};
 
 // Charge OCV curve parameters for each temperature
 static const float BATTERY_OCV_CHARGE_PARAMS[BATTERY_NUM_TEMP_POINTS][10] = {
-    // Temperature: 14.99°C
+    // Temperature: 7.28°C (key: 5)
     {
-        0.155811f, 3.250616f,  // m, b (linear segment)
-        882.012695f, 40175.064826f, 303.995510f,
-        12069.381036f,  // a1, b1, c1, d1 (first rational segment)
-        -4395.474187f, 3903.326115f, -1345.816241f,
-        1210.894940f  // a3, b3, c3, d3 (third rational segment)
+        0.119977f, 3.292032f,  // m, b (linear segment)
+        853.906052f, 23690.107718f, 265.829386f,
+        7096.080219f,  // a1, b1, c1, d1 (first rational segment)
+        -4674.103115f, 4463.128949f, -1397.627984f,
+        1339.864213f  // a3, b3, c3, d3 (third rational segment)
     },
-    // Temperature: 19.83°C
+    // Temperature: 12.60°C (key: 10)
     {
-        0.150987f, 3.250656f,  // m, b (linear segment)
-        1253.813370f, 53662.474550f, 433.721486f,
-        16108.954614f,  // a1, b1, c1, d1 (first rational segment)
-        -672.584219f, 615.456869f, -204.657772f,
-        189.004166f  // a3, b3, c3, d3 (third rational segment)
+        0.129893f, 3.273841f,  // m, b (linear segment)
+        5.758317f, 108.758491f, 1.807241f,
+        32.631657f,  // a1, b1, c1, d1 (first rational segment)
+        1901.784554f, -1766.844686f, 574.822406f,
+        -537.820435f  // a3, b3, c3, d3 (third rational segment)
     },
-    // Temperature: 24.88°C
+    // Temperature: 17.51°C (key: 15)
     {
-        0.137795f, 3.255241f,  // m, b (linear segment)
-        11079.770525f, 467803.865900f, 3799.664030f,
-        140476.474886f,  // a1, b1, c1, d1 (first rational segment)
-        23060.170644f, -21499.043288f, 6996.033171f,
-        -6568.182436f  // a3, b3, c3, d3 (third rational segment)
+        0.115642f, 3.275607f,  // m, b (linear segment)
+        37.820015f, 312.545982f, 11.836739f,
+        93.014230f,  // a1, b1, c1, d1 (first rational segment)
+        1114.586708f, -1075.733214f, 334.472803f,
+        -323.824737f  // a3, b3, c3, d3 (third rational segment)
     },
-    // Temperature: 29.87°C
+    // Temperature: 22.50°C (key: 20)
     {
-        0.133387f, 3.257527f,  // m, b (linear segment)
-        -51.838664f, -2099.240917f, -17.726544f,
-        -630.000601f,  // a1, b1, c1, d1 (first rational segment)
-        1610.609673f, -1520.476008f, 486.934271f,
-        -462.190000f  // a3, b3, c3, d3 (third rational segment)
+        0.118272f, 3.274047f,  // m, b (linear segment)
+        22.731575f, 173.069914f, 7.144899f,
+        51.331716f,  // a1, b1, c1, d1 (first rational segment)
+        1152.334851f, -1113.108848f, 345.641805f,
+        -334.889218f  // a3, b3, c3, d3 (third rational segment)
+    },
+    // Temperature: 27.54°C (key: 25)
+    {
+        0.111078f, 3.279982f,  // m, b (linear segment)
+        -6.914910f, -92.593412f, -2.171610f,
+        -27.668490f,  // a1, b1, c1, d1 (first rational segment)
+        1252.901718f, -1213.409067f, 375.520632f,
+        -364.700745f  // a3, b3, c3, d3 (third rational segment)
+    },
+    // Temperature: 32.31°C (key: 30)
+    {
+        0.105869f, 3.277491f,  // m, b (linear segment)
+        85.748575f, 803.500844f, 27.050103f,
+        238.806153f,  // a1, b1, c1, d1 (first rational segment)
+        639.263868f, -630.230568f, 190.960695f,
+        -188.480780f  // a3, b3, c3, d3 (third rational segment)
+    },
+    // Temperature: 37.36°C (key: 35)
+    {
+        0.103776f, 3.278805f,  // m, b (linear segment)
+        -64.738447f, -883.533215f, -20.434949f,
+        -263.970865f,  // a1, b1, c1, d1 (first rational segment)
+        1133.040608f, -1120.212998f, 338.203820f,
+        -334.681274f  // a3, b3, c3, d3 (third rational segment)
+    },
+    // Temperature: 42.34°C (key: 40)
+    {
+        0.105245f, 3.279165f,  // m, b (linear segment)
+        107.494439f, 1441.391508f, 34.356316f,
+        428.716770f,  // a1, b1, c1, d1 (first rational segment)
+        943.609378f, -933.154526f, 281.509060f,
+        -278.639013f  // a3, b3, c3, d3 (third rational segment)
     }};
 
 // Battery capacity data for each temperature
 static const float BATTERY_CAPACITY[BATTERY_NUM_TEMP_POINTS][2] = {
-    // Temperature: 14.99°C
-    {341.15f, 398.60f},
-    // Temperature: 19.83°C
-    {344.52f, 409.01f},
-    // Temperature: 24.88°C
-    {350.78f, 401.40f},
-    // Temperature: 29.87°C
-    {354.19f, 405.16f}};
+    // Temperature: 5.78°C (key: 5)
+    {325.07f, 336.55f},
+    // Temperature: 10.64°C (key: 10)
+    {343.23f, 366.44f},
+    // Temperature: 15.55°C (key: 15)
+    {355.86f, 378.79f},
+    // Temperature: 20.65°C (key: 20)
+    {362.69f, 394.38f},
+    // Temperature: 25.46°C (key: 25)
+    {369.62f, 375.32f},
+    // Temperature: 31.41°C (key: 30)
+    {361.17f, 379.75f},
+    // Temperature: 35.41°C (key: 35)
+    {357.76f, 366.75f},
+    // Temperature: 40.39°C (key: 40)
+    {358.06f, 383.63f}};

--- a/core/embed/sys/power_manager/fuel_gauge/battery_model.c
+++ b/core/embed/sys/power_manager/fuel_gauge/battery_model.c
@@ -121,23 +121,26 @@ float battery_rint(float temperature) {
 }
 
 float battery_total_capacity(float temperature, bool discharging_mode) {
+  // Select appropriate temperature array based on mode
+  const float* temp_points =
+      discharging_mode ? BATTERY_TEMP_POINTS_DISCHG : BATTERY_TEMP_POINTS_CHG;
+
   // Handle out-of-bounds temperatures
-  if (temperature <= BATTERY_TEMP_POINTS[0]) {
+  if (temperature <= temp_points[0]) {
     return BATTERY_CAPACITY[0][discharging_mode ? 0 : 1];
   }
 
-  if (temperature >= BATTERY_TEMP_POINTS[BATTERY_NUM_TEMP_POINTS - 1]) {
+  if (temperature >= temp_points[BATTERY_NUM_TEMP_POINTS - 1]) {
     return BATTERY_CAPACITY[BATTERY_NUM_TEMP_POINTS - 1]
                            [discharging_mode ? 0 : 1];
   }
 
   // Find temperature bracket
   for (int i = 0; i < BATTERY_NUM_TEMP_POINTS - 1; i++) {
-    if (temperature < BATTERY_TEMP_POINTS[i + 1]) {
+    if (temperature < temp_points[i + 1]) {
       return linear_interpolate(
-          temperature, BATTERY_TEMP_POINTS[i],
-          BATTERY_CAPACITY[i][discharging_mode ? 0 : 1],
-          BATTERY_TEMP_POINTS[i + 1],
+          temperature, temp_points[i],
+          BATTERY_CAPACITY[i][discharging_mode ? 0 : 1], temp_points[i + 1],
           BATTERY_CAPACITY[i + 1][discharging_mode ? 0 : 1]);
     }
   }
@@ -159,14 +162,18 @@ float battery_ocv(float soc, float temperature, bool discharging_mode) {
   // Clamp SOC to valid range
   soc = (soc < 0.0f) ? 0.0f : ((soc > 1.0f) ? 1.0f : soc);
 
+  // Select appropriate temperature array based on mode
+  const float* temp_points =
+      discharging_mode ? BATTERY_TEMP_POINTS_DISCHG : BATTERY_TEMP_POINTS_CHG;
+
   // Handle out-of-bounds temperatures
-  if (temperature <= BATTERY_TEMP_POINTS[0]) {
+  if (temperature <= temp_points[0]) {
     const float* params = discharging_mode ? BATTERY_OCV_DISCHARGE_PARAMS[0]
                                            : BATTERY_OCV_CHARGE_PARAMS[0];
     return calc_ocv(params, soc);
   }
 
-  if (temperature >= BATTERY_TEMP_POINTS[BATTERY_NUM_TEMP_POINTS - 1]) {
+  if (temperature >= temp_points[BATTERY_NUM_TEMP_POINTS - 1]) {
     const float* params =
         discharging_mode
             ? BATTERY_OCV_DISCHARGE_PARAMS[BATTERY_NUM_TEMP_POINTS - 1]
@@ -176,7 +183,7 @@ float battery_ocv(float soc, float temperature, bool discharging_mode) {
 
   // Find temperature bracket and interpolate
   for (int i = 0; i < BATTERY_NUM_TEMP_POINTS - 1; i++) {
-    if (temperature < BATTERY_TEMP_POINTS[i + 1]) {
+    if (temperature < temp_points[i + 1]) {
       const float* params_low = discharging_mode
                                     ? BATTERY_OCV_DISCHARGE_PARAMS[i]
                                     : BATTERY_OCV_CHARGE_PARAMS[i];
@@ -188,8 +195,8 @@ float battery_ocv(float soc, float temperature, bool discharging_mode) {
       float ocv_low = calc_ocv(params_low, soc);
       float ocv_high = calc_ocv(params_high, soc);
 
-      return linear_interpolate(temperature, BATTERY_TEMP_POINTS[i], ocv_low,
-                                BATTERY_TEMP_POINTS[i + 1], ocv_high);
+      return linear_interpolate(temperature, temp_points[i], ocv_low,
+                                temp_points[i + 1], ocv_high);
     }
   }
 
@@ -203,14 +210,18 @@ float battery_ocv_slope(float soc, float temperature, bool discharging_mode) {
   // Clamp SOC to valid range
   soc = (soc < 0.0f) ? 0.0f : ((soc > 1.0f) ? 1.0f : soc);
 
+  // Select appropriate temperature array based on mode
+  const float* temp_points =
+      discharging_mode ? BATTERY_TEMP_POINTS_DISCHG : BATTERY_TEMP_POINTS_CHG;
+
   // Handle out-of-bounds temperatures
-  if (temperature <= BATTERY_TEMP_POINTS[0]) {
+  if (temperature <= temp_points[0]) {
     const float* params = discharging_mode ? BATTERY_OCV_DISCHARGE_PARAMS[0]
                                            : BATTERY_OCV_CHARGE_PARAMS[0];
     return calc_ocv_slope(params, soc);
   }
 
-  if (temperature >= BATTERY_TEMP_POINTS[BATTERY_NUM_TEMP_POINTS - 1]) {
+  if (temperature >= temp_points[BATTERY_NUM_TEMP_POINTS - 1]) {
     const float* params =
         discharging_mode
             ? BATTERY_OCV_DISCHARGE_PARAMS[BATTERY_NUM_TEMP_POINTS - 1]
@@ -220,7 +231,7 @@ float battery_ocv_slope(float soc, float temperature, bool discharging_mode) {
 
   // Find temperature bracket and interpolate
   for (int i = 0; i < BATTERY_NUM_TEMP_POINTS - 1; i++) {
-    if (temperature < BATTERY_TEMP_POINTS[i + 1]) {
+    if (temperature < temp_points[i + 1]) {
       const float* params_low = discharging_mode
                                     ? BATTERY_OCV_DISCHARGE_PARAMS[i]
                                     : BATTERY_OCV_CHARGE_PARAMS[i];
@@ -232,8 +243,8 @@ float battery_ocv_slope(float soc, float temperature, bool discharging_mode) {
       float slope_low = calc_ocv_slope(params_low, soc);
       float slope_high = calc_ocv_slope(params_high, soc);
 
-      return linear_interpolate(temperature, BATTERY_TEMP_POINTS[i], slope_low,
-                                BATTERY_TEMP_POINTS[i + 1], slope_high);
+      return linear_interpolate(temperature, temp_points[i], slope_low,
+                                temp_points[i + 1], slope_high);
     }
   }
 
@@ -244,14 +255,18 @@ float battery_ocv_slope(float soc, float temperature, bool discharging_mode) {
 }
 
 float battery_soc(float ocv, float temperature, bool discharging_mode) {
+  // Select appropriate temperature array based on mode
+  const float* temp_points =
+      discharging_mode ? BATTERY_TEMP_POINTS_DISCHG : BATTERY_TEMP_POINTS_CHG;
+
   // Handle out-of-bounds temperatures
-  if (temperature <= BATTERY_TEMP_POINTS[0]) {
+  if (temperature <= temp_points[0]) {
     const float* params = discharging_mode ? BATTERY_OCV_DISCHARGE_PARAMS[0]
                                            : BATTERY_OCV_CHARGE_PARAMS[0];
     return calc_soc_from_ocv(params, ocv);
   }
 
-  if (temperature >= BATTERY_TEMP_POINTS[BATTERY_NUM_TEMP_POINTS - 1]) {
+  if (temperature >= temp_points[BATTERY_NUM_TEMP_POINTS - 1]) {
     const float* params =
         discharging_mode
             ? BATTERY_OCV_DISCHARGE_PARAMS[BATTERY_NUM_TEMP_POINTS - 1]
@@ -261,7 +276,7 @@ float battery_soc(float ocv, float temperature, bool discharging_mode) {
 
   // Find temperature bracket and interpolate
   for (int i = 0; i < BATTERY_NUM_TEMP_POINTS - 1; i++) {
-    if (temperature < BATTERY_TEMP_POINTS[i + 1]) {
+    if (temperature < temp_points[i + 1]) {
       const float* params_low = discharging_mode
                                     ? BATTERY_OCV_DISCHARGE_PARAMS[i]
                                     : BATTERY_OCV_CHARGE_PARAMS[i];
@@ -273,8 +288,8 @@ float battery_soc(float ocv, float temperature, bool discharging_mode) {
       float soc_low = calc_soc_from_ocv(params_low, ocv);
       float soc_high = calc_soc_from_ocv(params_high, ocv);
 
-      return linear_interpolate(temperature, BATTERY_TEMP_POINTS[i], soc_low,
-                                BATTERY_TEMP_POINTS[i + 1], soc_high);
+      return linear_interpolate(temperature, temp_points[i], soc_low,
+                                temp_points[i + 1], soc_high);
     }
   }
 

--- a/core/embed/sys/power_manager/stm32u5/power_manager_internal.h
+++ b/core/embed/sys/power_manager/stm32u5/power_manager_internal.h
@@ -44,9 +44,9 @@
 
 // Fuel gauge extended kalman filter parameters
 #define PM_FUEL_GAUGE_R 2000.0f
-#define PM_FUEL_GAUGE_Q 0.001f
-#define PM_FUEL_GAUGE_R_AGGRESSIVE 1000.0f
-#define PM_FUEL_GAUGE_Q_AGGRESSIVE 0.001f
+#define PM_FUEL_GAUGE_Q 0.0003f
+#define PM_FUEL_GAUGE_R_AGGRESSIVE 1500.0f
+#define PM_FUEL_GAUGE_Q_AGGRESSIVE 0.0004f
 #define PM_FUEL_GAUGE_P_INIT 0.1f
 
 // Timeout after which the device automatically transit from suspend to


### PR DESCRIPTION
This PR brings quite significant improvements to the fuel gauge estimator.

### 1) Updated battery model
The battery model (battery_model.h) was adjusted to **distinguish between temperatures for charging and discharging**. When creating the OCV curves during battery identification, we link each curve with a specific temperature so the fuel gauge can look up and interpolate between them.

Previously, we extracted a single temperature for both charging and discharging curves from a given chamber test as the mean value of all NTC measurements, but this was not very accurate. In general, the battery temperature is higher by ~2-3°C when charging in the same ambient temperature because of self-heating from the charging current. Using different temperature lookup tables for charging and discharging scenarios should compensate for that offset.

2) More accurate identification data
The updated JYH battery model battery_data_jyhpfl333838.h is composed of updated battery characterization data from the tool introduced in https://github.com/trezor/trezor-firmware/pull/5536 and a more precise battery dataset captured with an automated tool on 5 parallel fresh battery samples across a wider temperature range of 5-40°C.

3) Fuel gauge parameters update
The PR also updates the Fuel Gauge R and Q parameters. The previous version showed great results in simulation, but we observed quite different behavior on the physical device. This was very likely due to different sampling rates – while on the device we sample data and update the fuel gauge estimation every 100ms, in the simulator we used data sampled every 1.3s. In such cases, we need to scale the Q parameter properly.