### PR TITLE
chore: bump `cachix/install-nix-action` to v31

### DIFF
--- a/.github/actions/environment/action.yml
+++ b/.github/actions/environment/action.yml
@@ -9,7 +9,7 @@ runs:
   using: "composite"
   steps:
     - name: Install nix
-      uses: cachix/install-nix-action@v23
+      uses: cachix/install-nix-action@v31
       with:
         nix_path: nixpkgs=channel:nixos-unstable
     - name: Dependencies nixpkgs


### PR DESCRIPTION
It seems that our current Nix version should be upgraded:
https://github.com/trezor/trezor-firmware/actions/runs/16978909959/job/48134519339#step:3:403
```
Run timeout -v --kill-after=10 500 nix-shell --arg fullDeps "false" --run "true"
error:
       … while calling the 'import' builtin

         at «string»:1:2:

            1| (import <nixpkgs> {}).bashInteractive
             |  ^

       … while evaluating the file '/nix/store/igpm3ksd9v9ypbmwk1fg4chgxzmjqjip-source/default.nix':

       … while calling the 'abort' builtin

         at /nix/store/igpm3ksd9v9ypbmwk1fg4chgxzmjqjip-source/default.nix:7:3:

            6|
            7|   abort ''
             |   ^
            8|

       error: evaluation aborted with the following error message: '
       This version of Nixpkgs requires Nix >= 2.18, please upgrade:

       - If you are running NixOS, `nixos-rebuild' can be used to upgrade your system.

       - Alternatively, with Nix > 2.0 `nix upgrade-nix' can be used to imperatively
         upgrade Nix. You may use `nix-env --version' to check which version you have.

       - If you installed Nix using the install script (https://nixos.org/nix/install),
         it is safe to upgrade by running it again:

             curl -L https://nixos.org/nix/install | sh

       For more information, please see the NixOS release notes at
       https://nixos.org/nixos/manual or locally at
       /nix/store/igpm3ksd9v9ypbmwk1fg4chgxzmjqjip-source/nixos/doc/manual/release-notes.

       If you need further help, see https://nixos.org/nixos/support.html
       '
```