### PR TITLE
preserve BLE peer count info during suspend

### DIFF
--- a/core/embed/io/ble/inc/io/ble.h
+++ b/core/embed/io/ble/inc/io/ble.h
@@ -70,6 +70,7 @@ typedef struct {
 typedef struct {
   bool accept_msgs;
   bool reboot_on_resume;
+  uint8_t peer_count;
   ble_mode_t mode_requested;
   uint8_t connected_addr[6];
   uint8_t connected_addr_type;

--- a/core/embed/io/ble/stm32/ble.c
+++ b/core/embed/io/ble/stm32/ble.c
@@ -573,6 +573,7 @@ void ble_suspend(ble_wakeup_params_t *wakeup_params) {
     bool connected = drv->connected;
     wakeup_params->accept_msgs = connected;
     wakeup_params->mode_requested = drv->mode_requested;
+    wakeup_params->peer_count = drv->peer_count;
     memcpy(&wakeup_params->adv_data, &drv->adv_cmd, sizeof(drv->adv_cmd));
 
     ble_deinit_common(drv);
@@ -611,6 +612,7 @@ bool ble_resume(const ble_wakeup_params_t *wakeup_params) {
   irq_key_t key = irq_lock();
 
   drv->connected_addr_type = wakeup_params->connected_addr_type;
+  drv->peer_count = wakeup_params->peer_count;
   memcpy(drv->connected_addr, wakeup_params->connected_addr,
          sizeof(drv->connected_addr));
   memcpy(&drv->adv_cmd, &wakeup_params->adv_data, sizeof(drv->adv_cmd));


### PR DESCRIPTION
Some UI relies on that info, and it can takes some time to obtain the info after wakeup, especially if the nRF was in system off. As the peer count can't really change during suspend, it makes sense to preserve it in RAM.