### PR TITLE
fix(core): don't reuse `TASK_CLOSED` exception object

### DIFF
--- a/core/src/trezor/loop.py
+++ b/core/src/trezor/loop.py
@@ -37,9 +37,6 @@ class TaskClosed(Exception):
     pass
 
 
-TASK_CLOSED = TaskClosed()
-
-
 def schedule(
     task: Task,
     value: Any = None,
@@ -510,7 +507,7 @@ class spawn(Syscall):
         self.finished = True
         if isinstance(value, GeneratorExit):
             # coerce GeneratorExit to a catchable TaskClosed
-            self.return_value = TASK_CLOSED
+            self.return_value = TaskClosed()
         else:
             self.return_value = value
 


### PR DESCRIPTION
Following https://github.com/trezor/trezor-firmware/issues/5472#issuecomment-3174382038 and https://github.com/trezor/trezor-firmware/pull/5523.

Also related to https://github.com/trezor/trezor-firmware/issues/5526.