### PR TITLE
fix(python): skip `EndSession` in case of invalidated THP channel

### DIFF
--- a/python/src/trezorlib/cli/__init__.py
+++ b/python/src/trezorlib/cli/__init__.py
@@ -360,7 +360,11 @@ def with_session(
                     return func(session, *args, **kwargs)
 
                 finally:
-                    if not is_resume_mandatory and not session.features.bootloader_mode:
+                    if (
+                        not is_resume_mandatory
+                        and not session.features.bootloader_mode
+                        and not session.client.is_invalidated
+                    ):
                         session.end()
 
         return function_with_session


### PR DESCRIPTION
Tested on T3W1 emulator:
```
$ trezorctl -v device wipe
<snip>
424.514 apps.management.wipe_device DEBUG Device wipe - start
424.726 trezor.wire.thp.channel INFO [WebUSB] (cid: 81ff) write message: Success
424.726 trezor.wire.thp.channel DEBUG [WebUSB] message contents:
Success {
    message: 'Device wiped'
}
424.726 trezor.wire.thp.channel DEBUG [WebUSB] (cid: 81ff) encrypt
424.726 trezor.wire.thp.crypto DEBUG enc (key: fff11760b101be1d7ee2acac529dc539c566e66fbbec982a0fe5186b77818617, nonce: 6)
424.726 trezor.wire.thp.channel DEBUG [WebUSB] (cid: 81ff) New nonce_send: 7
424.726 trezor.wire.thp.channel WARNING [WebUSB] (cid: 81ff) Closed write task
424.726 trezor.wire.thp.channel DEBUG [WebUSB] (cid: 81ff) Writing FORCE message (without async or retransmission).
424.726 trezor.wire.thp.channel DEBUG [WebUSB] (cid: 81ff) write_encrypted_payload_loop
424.726 trezor.wire.thp.channel DEBUG [WebUSB] (cid: 81ff) Starting transmission loop
424.726 trezor.loop DEBUG spawn new task: <generator object '_wait' at 0x7729f2280e80>
[2025-08-18 12:10:45,204] trezorlib.transport.thp.protocol_v2 DEBUG: --> Get sequence bit 1 from control byte 14
[2025-08-18 12:10:45,204] trezorlib.transport.thp.protocol_v2 DEBUG: sending ack 1
[2025-08-18 12:10:45,204] trezorlib.transport.session DEBUG: reading message <class 'trezorlib.messages.Success'>
424.727 trezor.wire.thp.channel DEBUG [WebUSB] (cid: 81ff) get_channel_state: ENCRYPTED_TRANSPORT
424.727 trezor.wire.thp.received_message_handler DEBUG [WebUSB] handle_received_message
424.727 trezor.wire.thp.received_message_handler DEBUG check_checksum
424.727 trezor.wire.thp.received_message_handler DEBUG [WebUSB] handle_completed_message - seq bit of message: 0, ack bit of message: 1
424.727 trezor.wire.thp.received_message_handler DEBUG [WebUSB] Received ACK message with correct ack bit
424.727 trezor.loop DEBUG close spawned task: <generator object '_wait' at 0x7729f2280e80>
424.727 trezor.wire.thp.received_message_handler DEBUG [WebUSB] Stopped transmission loop
424.727 trezor.wire.thp.received_message_handler DEBUG [WebUSB] Control to "write_encrypted_payload_loop" task
424.728 apps.management.wipe_device DEBUG Device wipe - finished
424.728 trezor.loop DEBUG finish: <generator object 'with_context' at 0x7729f2170c20>
424.728 session DEBUG Restarting main loop
424.839 trezor.workflow DEBUG setting a new default: <generator>
424.839 trezor.loop DEBUG spawn new task: <generator object 'homescreen' at 0x7729f2107fe0>
424.839 trezor.workflow DEBUG start default: <generator object 'homescreen' at 0x7729f2107fe0>
```