### PR TITLE
fix(core): fix irq locking in ble driver

### DIFF
--- a/core/embed/io/ble/stm32/ble.c
+++ b/core/embed/io/ble/stm32/ble.c
@@ -762,6 +762,7 @@ uint32_t ble_read(uint8_t *data, uint16_t max_len) {
 
   if (read_len != BLE_DATA_SIZE ||
       max_len < (read_len - BLE_DATA_HEADER_SIZE)) {
+    irq_unlock(key);
     return 0;
   }
 


### PR DESCRIPTION
Fixes `irq_lock()`/`irq_unlock()` pairing in ble driver - causing hard faults in the syscall following `ble_read()`.
