### PR TITLE
do not disconnect BLE when rebooting to firmware

### DIFF
--- a/core/embed/io/ble/inc/io/ble.h
+++ b/core/embed/io/ble/inc/io/ble.h
@@ -40,6 +40,8 @@ typedef enum {
   BLE_ALLOW_PAIRING = 5,   // Accept pairing request
   BLE_REJECT_PAIRING = 6,  // Reject pairing request
   BLE_UNPAIR = 7,          // Erase bond for currently connected device
+  BLE_KEEP_CONNECTION =
+      8,  // Keep connection to the connected device, but do not advertise
 } ble_command_type_t;
 
 typedef enum {

--- a/core/embed/projects/bootloader/wire/wire_iface_ble.c
+++ b/core/embed/projects/bootloader/wire/wire_iface_ble.c
@@ -137,7 +137,7 @@ void ble_iface_deinit(void) {
   }
 
   ble_command_t cmd = {
-      .cmd_type = BLE_SWITCH_OFF,
+      .cmd_type = BLE_KEEP_CONNECTION,
   };
   ble_issue_command(&cmd);
 

--- a/core/embed/projects/bootloader/workflow/wf_bootloader.c
+++ b/core/embed/projects/bootloader/workflow/wf_bootloader.c
@@ -27,12 +27,15 @@
 #include <sys/power_manager.h>
 #endif
 
+#ifdef USE_BLE
+#include <io/ble.h>
+#endif
+
 #include <io/display.h>
 #include <io/display_utils.h>
 
 #include "bootui.h"
 #include "rust_ui_bootloader.h"
-#include "wire/wire_iface_usb.h"
 #include "workflow.h"
 
 workflow_result_t workflow_menu(const vendor_header* const vhdr,
@@ -60,6 +63,12 @@ workflow_result_t workflow_menu(const vendor_header* const vhdr,
       workflow_ifaces_pause(ios);
       workflow_ble_pairing_request(vhdr, hdr);
       workflow_ifaces_resume(ios);
+      if (ios == NULL) {
+        // in case we were not in connected-mode, stop advertising
+        ble_command_t cmd = {0};
+        cmd.cmd_type = BLE_KEEP_CONNECTION;
+        ble_issue_command(&cmd);
+      }
       continue;
     }
 #endif


### PR DESCRIPTION
This PR fixes a bug that caused disconnection of BLE when deinitializing interface and thus, caused unexpected disconnection when jumping to firmware.

Along with that, an edge situation is fixed where leaving pairing mode in bootloader left the device advertising even if the paring was launched from bootloader state that did not allow connection to host. For this, new BLE driver state is introduced to keep track whether advertisement should be restarted after disconnect (end of KEEP_CONNECTED mode) , and a new command that resets this flag when needed. 