### PR TITLE
disconnect BLE on bond erase

### DIFF
--- a/core/embed/projects/bootloader/workflow/wf_wipe_device.c
+++ b/core/embed/projects/bootloader/workflow/wf_wipe_device.c
@@ -97,11 +97,22 @@ workflow_result_t workflow_wipe_device(protob_io_t* iface) {
   ui_screen_wipe();
   secbool wipe_result = erase_device(ui_screen_wipe_progress);
 
+  if (sectrue != wipe_result) {
+    send_error_conditionally(iface, "Could not erase flash");
+  }
+
 #ifdef USE_BACKUP_RAM
   if (!backup_ram_erase_protected()) {
     return WF_ERROR;
   }
 #endif
+
+  // sending success earlier to notify host before bonds deletion causes
+  // disconnect
+  if (iface != NULL) {
+    send_msg_success(iface, NULL);
+    systick_delay_ms(100);
+  }
 
 #ifdef USE_BLE
   if (!wipe_bonds(iface)) {
@@ -110,14 +121,10 @@ workflow_result_t workflow_wipe_device(protob_io_t* iface) {
 #endif
 
   if (sectrue != wipe_result) {
-    send_error_conditionally(iface, "Could not erase flash");
     screen_wipe_fail();
     return WF_ERROR;
   }
 
-  if (iface != NULL) {
-    send_msg_success(iface, NULL);
-  }
   screen_wipe_success();
   return WF_OK_DEVICE_WIPED;
 }


### PR DESCRIPTION
This PR fixes an unexpected behavior which caused BLE central to stay connected when its bond was deleted on Trezor. We now force a disconnect of the device which bond is deleted.

When doing factory reset, answer to host is send prior to deleting bonds, as the connection will be dropped and no (BLE) communication is possible.