### PR TITLE
fix(prodtest): fix secrets-certdev-write arg count check

### DIFF
--- a/core/embed/projects/prodtest/.changelog.d/5604.fixed
+++ b/core/embed/projects/prodtest/.changelog.d/5604.fixed
@@ -1,0 +1,1 @@
+Fixed arguments count check in the secrets-certdev-write command.

--- a/core/embed/projects/prodtest/cmd/prodtest_secrets.c
+++ b/core/embed/projects/prodtest/cmd/prodtest_secrets.c
@@ -163,7 +163,7 @@ cleanup:
 }
 
 static void prodtest_secrets_certdev_write(cli_t* cli) {
-  if (cli_arg_count(cli) > 0) {
+  if (cli_arg_count(cli) != 1) {
     cli_error_arg_count(cli);
     return;
   }


### PR DESCRIPTION
This PR fixes argument count checking of `secrets-certdev-write` command. 

