### PR TITLE
Increase prodtest stack size on T3W1

### DIFF
--- a/core/embed/sys/linker/stm32u5g/prodtest.ld
+++ b/core/embed/sys/linker/stm32u5g/prodtest.ld
@@ -69,7 +69,7 @@ SECTIONS {
   } >FLASH AT>FLASH
 
   .stack : ALIGN(8) {
-    . = 12K; /* Overflow causes UsageFault */
+    . = 24K; /* Overflow causes UsageFault */
   } >MAIN_RAM
 
   .data : ALIGN(4) {


### PR DESCRIPTION
This PR increases the prodtest stack size on T3W1.

It is not required for prodtest itself but for the special HSM firmware that shares the same linker script.
