### PR TITLE
fix(core): increase `MAX_SUBSCREENS` a bit

### DIFF
--- a/core/embed/rust/src/ui/layout_eckhart/firmware/device_menu_screen.rs
+++ b/core/embed/rust/src/ui/layout_eckhart/firmware/device_menu_screen.rs
@@ -33,7 +33,7 @@ use super::{
 use heapless::Vec;
 
 const MAX_DEPTH: usize = 3;
-const MAX_SUBSCREENS: usize = 8;
+const MAX_SUBSCREENS: usize = 10;
 const MAX_SUBMENUS: usize = MAX_SUBSCREENS - 2 /* (about and device screen) */;
 
 const DISCONNECT_DEVICE_MENU_INDEX: usize = 1;


### PR DESCRIPTION
Otherwise, [entering the menu when connected via BLE results in a RSOD](https://drive.google.com/file/d/1RPv42auw1Ya6XWB0NJ3zy8ZD54m4AR0J).


```
[23:04:01.509] === FATAL ERROR
[23:04:01.509] Location: src/ui/layout_eckhart/firmware/device_menu_screen.rs:373
[23:04:01.509] Message: unwrap failed
```

Reproduced on 375d6e10ca.