### PR TITLE
fix(core): avoid infinite THP error loop

### DIFF
--- a/core/src/trezor/wire/thp/channel.py
+++ b/core/src/trezor/wire/thp/channel.py
@@ -247,7 +247,7 @@ class Channel:
 
             if expected_ctrl_byte is None or not expected_ctrl_byte(ctrl_byte):
                 if __debug__:
-                    self._log("Unexpected control byte", utils.hexlify_if_bytes(msg))
+                    self._log("Unexpected control byte: ", utils.hexlify_if_bytes(msg))
                 raise ThpError("Unexpected control byte")
 
             # 2: Handle message with unexpected sequential bit

--- a/core/src/trezor/wire/thp/session_context.py
+++ b/core/src/trezor/wire/thp/session_context.py
@@ -56,14 +56,15 @@ class GenericSessionContext(Context):
                 if __debug__:
                     log.exception(__name__, e, iface=self.iface)
                 await self.write(failure(e))
+                return
             except UnexpectedMessageException as unexpected:
                 # The workflow was interrupted by an unexpected message. We need to
                 # process it as if it was a new message...
                 message = unexpected.msg
             except Exception as exc:
-                # Log and try again.
                 if __debug__:
                     log.exception(__name__, exc, iface=self.iface)
+                return
 
     async def _read_next_message(self) -> Message:
         while True:


### PR DESCRIPTION
In case of an error, we cannot re-use the same message that has caused the error in the first place.

<details>

<summary> Device debug log </summary>

```
[22:14:24.273] 429.849 trezor.loop DEBUG finish: <generator object 'timer_task' at 0x201e3c20>
[22:14:24.387] 429.963 trezor.loop DEBUG finish: <generator object 'timer_task' at 0x201e3d50>
[22:14:24.503] 430.079 trezor.loop DEBUG finish: <generator object 'timer_task' at 0x201e3e80>
[22:14:24.618] 430.193 trezor.loop DEBUG finish: <generator object 'timer_task' at 0x201e3fb0>
[22:14:24.733] 430.309 trezor.loop DEBUG finish: <generator object 'timer_task' at 0x201e40e0>
[22:14:24.975] 430.551 trezor.loop DEBUG finish: <generator object 'timer_task' at 0x201d3640>
[22:14:24.976] 430.552 trezor.loop DEBUG finish: <generator object 'timer_task' at 0x201e4210>
[22:14:31.127] 436.703 trezor.wire.thp.channel DEBUG [WebUSB] (cid: 540c) get_channel_state: ENCRYPTED_TRANSPORT
[22:14:31.129] 436.705 trezor.wire.thp.channel DEBUG [WebUSB] Writing ACK message to a channel with cid: 540c, ack_bit: 1
[22:14:31.134] 436.709 trezor.wire.thp.channel DEBUG [WebUSB] (cid: 540c) Buffer before decryption: a0bc0c
[22:14:31.135] 436.711 trezor.wire.thp.crypto DEBUG dec (key: 2684a8365c48aa1177d8bdf6a4834f53ff45cc6cfa776b257d5f16e6491b93be, nonce: 11)
[22:14:31.138] 436.714 trezor.wire.thp.channel DEBUG [WebUSB] (cid: 540c) Buffer after decryption: 000014
[22:14:31.140] 436.716 trezor.wire.thp.channel DEBUG [WebUSB] (cid: 540c) Is decrypted tag valid? True
[22:14:31.143] 436.718 trezor.wire.thp.channel DEBUG [WebUSB] (cid: 540c) Received tag: 4b2996c815c43ed98c30163e8e4858c0
[22:14:31.144] 436.720 trezor.wire.thp.channel DEBUG [WebUSB] (cid: 540c) New nonce_receive: 12
[22:14:31.145] 436.720 trezor.wire.thp.session_context DEBUG [WebUSB] EXPECTED TYPES: ()
[22:14:31.145] RECEIVED TYPE: 20
[22:14:31.145] 436.721 trezor.loop ERROR exception:
[22:14:31.145] Traceback (most recent call last):
[22:14:31.145]   File "trezor/loop.py", in _step
[22:14:31.146]   File "trezor/wire/thp/session_context.py", in read
[22:14:31.146] UnexpectedMessageException: 
[22:14:31.146] 436.722 trezor.loop ERROR exception:
[22:14:31.147] Traceback (most recent call last):
[22:14:31.147]   File "trezor/loop.py", in _step
[22:14:31.147]   File "trezor/ui/__init__.py", in _handle_usb_iface
[22:14:31.147]   File "trezor/loop.py", in __iter__
[22:14:31.147]   File "trezor/loop.py", in _step
[22:14:31.147]   File "trezor/wire/thp/session_context.py", in read
[22:14:31.148] UnexpectedMessageException: 
[22:14:31.148] 436.724 trezor.ui DEBUG UI task was stopped: <generator object '_handle_ble_events' at 0x201d3750>
[22:14:31.148] 436.724 trezor.ui DEBUG UI task was stopped: <generator object '_handle_power_manager' at 0x201d37b0>
[22:14:31.149] 436.725 trezor.ui DEBUG UI task was stopped: <generator object '_handle_button_events' at 0x201d3690>
[22:14:31.149] 436.725 trezor.ui DEBUG UI task was stopped: <generator object '_handle_touch_events' at 0x201d36f0>
[22:14:31.302] 436.878 trezor.loop ERROR exception:
[22:14:31.302] Traceback (most recent call last):
[22:14:31.302]   File "trezor/loop.py", in _step
[22:14:31.303]   File "trezor/wire/context.py", in with_context
[22:14:31.303]   File "apps/management/show_tutorial.py", in show_tutorial
[22:14:31.303]   File "trezor/ui/layouts/common.py", in interact
[22:14:31.303]   File "trezor/ui/__init__.py", in get_result
[22:14:31.303]   File "trezor/loop.py", in __iter__
[22:14:31.303]   File "trezor/wire/context.py", in with_context
[22:14:31.304]   File "trezor/loop.py", in _step
[22:14:31.304]   File "trezor/ui/__init__.py", in _handle_usb_iface
[22:14:31.304]   File "trezor/loop.py", in __iter__
[22:14:31.304]   File "trezor/loop.py", in _step
[22:14:31.304]   File "trezor/wire/thp/session_context.py", in read
[22:14:31.305] UnexpectedMessageException: 
[22:14:31.305] 436.879 trezor.workflow DEBUG close: <generator object 'with_context' at 0x201cf4a0>
[22:14:31.305] 436.879 trezor.loop DEBUG spawn new task: <generator object 'homescreen' at 0x201e5b90>
[22:14:31.306] 436.880 trezor.workflow DEBUG start default: <generator object 'homescreen' at 0x201e5b90>
[22:14:31.306] 436.882 trezor.wire.message_handler INFO [WebUSB] (cid: 540c) received message: Cancel
[22:14:31.307] 436.883 trezor.loop DEBUG spawn new task: <generator object 'with_context' at 0x201e5e80>
[22:14:31.308] 436.883 trezor.workflow DEBUG start: <generator object 'with_context' at 0x201e5e80>
[22:14:31.547] 437.123 trezor.loop DEBUG close spawned task: <generator object 'homescreen' at 0x201e5b90>
[22:14:31.548] 437.123 trezor.ui DEBUG UI task was stopped: <generator object '_handle_power_manager' at 0x201e6880>
[22:14:31.548] 437.124 trezor.ui DEBUG UI task was stopped: <generator object '_handle_button_events' at 0x201e6720>
[22:14:31.548] 437.124 trezor.ui DEBUG UI task was stopped: <generator object '_handle_ble_events' at 0x201e6810>
[22:14:31.549] 437.125 trezor.ui DEBUG UI task was stopped: <generator object '_handle_touch_events' at 0x201e67a0>
[22:14:31.549] 437.125 trezor.ui DEBUG UI task was stopped: <generator object 'usb_checker_task' at 0x201e68f0>
[22:14:31.700] 437.275 trezor.workflow DEBUG default closed: <generator object 'homescreen' at 0x201e5b90>
[22:14:31.700] 437.276 trezor.loop ERROR exception:
[22:14:31.701] Traceback (most recent call last):
[22:14:31.701]   File "trezor/loop.py", in _step
[22:14:31.701]   File "trezor/wire/context.py", in with_context
[22:14:31.701]   File "apps/base.py", in handle_Cancel
[22:14:31.702] ActionCancelled: 
[22:14:31.702] 437.276 trezor.workflow DEBUG close: <generator object 'with_context' at 0x201e5e80>
[22:14:31.702] 437.277 trezor.loop DEBUG spawn new task: <generator object 'homescreen' at 0x201e62e0>
[22:14:31.703] 437.277 trezor.workflow DEBUG start default: <generator object 'homescreen' at 0x201e62e0>
[22:14:31.703] 437.278 trezor.wire.message_handler DEBUG [WebUSB] cancelled: Cancelled
[22:14:31.704] 437.279 trezor.wire.thp.channel INFO [WebUSB] (cid: 540c) write message: Failure
[22:14:31.706] 437.281 trezor.wire.thp.channel DEBUG [WebUSB] (cid: 540c) encrypt
[22:14:31.707] 437.283 trezor.wire.thp.crypto DEBUG enc (key: 6cc1d92d00b5f1b5d2eb26ebe76faac97df4ac417b4a6d0e25915ec7547a3564, nonce: 11)
[22:14:31.709] 437.285 trezor.wire.thp.channel DEBUG [WebUSB] (cid: 540c) New nonce_send: 12
[22:14:31.711] 437.286 trezor.wire.thp.channel DEBUG [WebUSB] (cid: 540c) write_encrypted_payload_loop

[22:14:31.721] Disconnected
[22:14:32.723] Connected
[22:14:33.799] 439.375 trezor.loop DEBUG finish: <generator object 'timer_task' at 0x201e8010>
[22:14:34.458] 440.034 trezor.wire.thp.channel DEBUG [WebUSB] (cid: 540c) get_channel_state: ENCRYPTED_TRANSPORT
[22:14:34.461] 440.037 trezor.wire.thp.channel DEBUG [WebUSB] (cid: 540c) Unexpected control byte 04540c00179fe9041cdb2ce79121091a459c818bcef12a9342159cfe
[22:14:34.462] 440.037 trezor.wire.thp.session_context ERROR [WebUSB] exception:
[22:14:34.462] Traceback (most recent call last):
[22:14:34.462]   File "trezor/wire/thp/session_context.py", in handle
[22:14:34.462]   File "trezor/wire/message_handler.py", in handle_single_message
[22:14:34.462]   File "trezor/wire/thp/channel.py", in write
[22:14:34.463]   File "trezor/wire/thp/channel.py", in write_encrypted_payload
[22:14:34.463]   File "trezor/wire/thp/channel.py", in recv_payload
[22:14:34.463] ThpError: Unexpected control byte
[22:14:34.464] 440.040 trezor.wire.thp.channel INFO [WebUSB] (cid: 540c) write message: Failure
[22:14:34.466] 440.042 trezor.wire.thp.channel DEBUG [WebUSB] (cid: 540c) encrypt
[22:14:34.468] 440.044 trezor.wire.thp.crypto DEBUG enc (key: 6cc1d92d00b5f1b5d2eb26ebe76faac97df4ac417b4a6d0e25915ec7547a3564, nonce: 12)
[22:14:34.470] 440.046 trezor.wire.thp.channel DEBUG [WebUSB] (cid: 540c) New nonce_send: 13
[22:14:34.471] 440.047 trezor.wire.thp.channel DEBUG [WebUSB] (cid: 540c) write_encrypted_payload_loop
[22:14:34.472] 440.048 trezor.workflow DEBUG joining 0 workflows
[22:14:34.473] 440.049 trezor.loop DEBUG finish: <generator object '__iter__' at 0x201cc9d0>
[22:14:34.474] 440.050 trezor.loop DEBUG finish: <generator object 'handle_session' at 0x201caa70>
[22:14:34.474] 440.050 trezor.loop DEBUG finish: <generator object '__iter__' at 0x201ea250>
[22:14:34.475] 440.051 trezor.loop ERROR exception:
[22:14:34.475] Traceback (most recent call last):
[22:14:34.475]   File "trezor/loop.py", in _step
[22:14:34.475]   File "trezor/wire/__init__.py", in handle_session
[22:14:34.476]   File "trezor/wire/thp/received_message_handler.py", in handle_received_message
[22:14:34.476]   File "trezor/wire/thp/received_message_handler.py", in _handle_state_ENCRYPTED_TRANSPORT
[22:14:34.476]   File "trezor/wire/thp/session_context.py", in handle
[22:14:34.476]   File "trezor/wire/thp/channel.py", in write
[22:14:34.476]   File "trezor/wire/thp/channel.py", in write_encrypted_payload
[22:14:34.476] AssertionError: 
[22:14:34.476] 440.052 session DEBUG Restarting main loop
[22:14:34.731] 440.306 trezor.loop DEBUG spawn new task: <generator object 'handle_session' at 0x201caa70>
[22:14:34.747] 440.323 trezor.workflow DEBUG setting a new default: <generator>
[22:14:34.747] 440.323 trezor.loop DEBUG spawn new task: <generator object 'homescreen' at 0x201cb8c0>
[22:14:34.748] 440.323 trezor.workflow DEBUG start default: <generator object 'homescreen' at 0x201cb8c0>
[22:14:36.851] 442.426 trezor.loop DEBUG finish: <generator object 'timer_task' at 0x201cd000>

[22:14:37.454] Disconnected
[22:14:38.456] Connected
[22:14:48.203] 453.779 trezor.wire.thp.channel DEBUG [WebUSB] (cid: 540c) channel initialization
[22:14:48.206] 453.781 trezor.wire.thp.channel DEBUG [WebUSB] (cid: 540c) get_channel_state: ENCRYPTED_TRANSPORT
[22:14:48.208] 453.784 trezor.wire.thp.channel DEBUG [WebUSB] (cid: 540c) get_channel_state: ENCRYPTED_TRANSPORT
[22:14:48.208] 453.784 trezor.wire.thp.received_message_handler DEBUG [WebUSB] handle_state_ENCRYPTED_TRANSPORT
[22:14:48.210] 453.786 trezor.wire.thp.channel DEBUG [WebUSB] Writing ACK message to a channel with cid: 540c, ack_bit: 0
[22:14:48.215] 453.790 trezor.wire.thp.channel DEBUG [WebUSB] (cid: 540c) Buffer before decryption: 9fe904
[22:14:48.216] 453.792 trezor.wire.thp.crypto DEBUG dec (key: 2684a8365c48aa1177d8bdf6a4834f53ff45cc6cfa776b257d5f16e6491b93be, nonce: 12)
[22:14:48.219] 453.795 trezor.wire.thp.channel DEBUG [WebUSB] (cid: 540c) Buffer after decryption: 000037
[22:14:48.221] 453.797 trezor.wire.thp.channel DEBUG [WebUSB] (cid: 540c) Is decrypted tag valid? True
[22:14:48.224] 453.800 trezor.wire.thp.channel DEBUG [WebUSB] (cid: 540c) Received tag: 1cdb2ce79121091a459c818bcef12a93
[22:14:48.226] 453.801 trezor.wire.thp.channel DEBUG [WebUSB] (cid: 540c) New nonce_receive: 13
[22:14:48.230] 453.806 trezor.wire.thp.session_context DEBUG [WebUSB] handle - start (channel_id (bytes): 540c, session_id: 0)
[22:14:48.232] 453.807 trezor.wire.message_handler INFO [WebUSB] (cid: 540c) received message: GetFeatures
[22:14:48.233] 453.809 trezor.loop DEBUG spawn new task: <generator object 'with_context' at 0x201cf9d0>
[22:14:48.233] 453.809 trezor.workflow DEBUG start: <generator object 'with_context' at 0x201cf9d0>
[22:14:48.288] 453.863 trezor.loop DEBUG finish: <generator object 'with_context' at 0x201cf9d0>
[22:14:48.288] 453.863 trezor.workflow DEBUG close: <generator object 'with_context' at 0x201cf9d0>
[22:14:48.288] 453.863 trezor.workflow DEBUG default already started
[22:14:48.290] 453.865 trezor.wire.thp.channel INFO [WebUSB] (cid: 540c) write message: Features
[22:14:48.292] 453.868 trezor.wire.thp.channel DEBUG [WebUSB] (cid: 540c) encrypt
[22:14:48.294] 453.870 trezor.wire.thp.crypto DEBUG enc (key: 6cc1d92d00b5f1b5d2eb26ebe76faac97df4ac417b4a6d0e25915ec7547a3564, nonce: 13)
[22:14:48.297] 453.872 trezor.wire.thp.channel DEBUG [WebUSB] (cid: 540c) New nonce_send: 14
[22:14:48.298] 453.874 trezor.wire.thp.channel DEBUG [WebUSB] (cid: 540c) write_encrypted_payload_loop
[22:14:48.299] 453.874 trezor.wire.thp.session_context ERROR [WebUSB] exception:
[22:14:48.299] Traceback (most recent call last):
[22:14:48.299]   File "trezor/wire/thp/session_context.py", in handle
[22:14:48.299]   File "trezor/wire/message_handler.py", in handle_single_message
[22:14:48.300]   File "trezor/wire/thp/channel.py", in write
[22:14:48.300]   File "trezor/wire/thp/channel.py", in write_encrypted_payload
[22:14:48.300] AssertionError: 
[22:14:48.301] 453.876 trezor.wire.message_handler INFO [WebUSB] (cid: 540c) received message: GetFeatures
[22:14:48.302] 453.878 trezor.loop DEBUG spawn new task: <generator object 'with_context' at 0x201d0f00>
[22:14:48.302] 453.878 trezor.workflow DEBUG start: <generator object 'with_context' at 0x201d0f00>
[22:14:48.346] 453.921 trezor.loop DEBUG finish: <generator object 'with_context' at 0x201d0f00>
[22:14:48.346] 453.922 trezor.workflow DEBUG close: <generator object 'with_context' at 0x201d0f00>
[22:14:48.346] 453.922 trezor.workflow DEBUG default already started
[22:14:48.348] 453.924 trezor.wire.thp.channel INFO [WebUSB] (cid: 540c) write message: Features
[22:14:48.351] 453.927 trezor.wire.thp.channel DEBUG [WebUSB] (cid: 540c) encrypt
[22:14:48.353] 453.928 trezor.wire.thp.crypto DEBUG enc (key: 6cc1d92d00b5f1b5d2eb26ebe76faac97df4ac417b4a6d0e25915ec7547a3564, nonce: 14)
[22:14:48.356] 453.931 trezor.wire.thp.channel DEBUG [WebUSB] (cid: 540c) New nonce_send: 15
[22:14:48.357] 453.933 trezor.wire.thp.channel DEBUG [WebUSB] (cid: 540c) write_encrypted_payload_loop
[22:14:48.357] 453.933 trezor.wire.thp.session_context ERROR [WebUSB] exception:
[22:14:48.358] Traceback (most recent call last):
[22:14:48.358]   File "trezor/wire/thp/session_context.py", in handle
[22:14:48.358]   File "trezor/wire/message_handler.py", in handle_single_message
[22:14:48.358]   File "trezor/wire/thp/channel.py", in write
[22:14:48.358]   File "trezor/wire/thp/channel.py", in write_encrypted_payload
[22:14:48.358] AssertionError: 
[22:14:48.359] 453.935 trezor.wire.message_handler INFO [WebUSB] (cid: 540c) received message: GetFeatures
[22:14:48.361] 453.936 trezor.loop DEBUG spawn new task: <generator object 'with_context' at 0x201d20a0>
[22:14:48.361] 453.937 trezor.workflow DEBUG start: <generator object 'with_context' at 0x201d20a0>
[22:14:48.405] 453.981 trezor.loop DEBUG finish: <generator object 'with_context' at 0x201d20a0>
[22:14:48.406] 453.981 trezor.workflow DEBUG close: <generator object 'with_context' at 0x201d20a0>
[22:14:48.406] 453.982 trezor.workflow DEBUG default already started
[22:14:48.408] 453.983 trezor.wire.thp.channel INFO [WebUSB] (cid: 540c) write message: Features
[22:14:48.410] 453.986 trezor.wire.thp.channel DEBUG [WebUSB] (cid: 540c) encrypt
[22:14:48.412] 453.988 trezor.wire.thp.crypto DEBUG enc (key: 6cc1d92d00b5f1b5d2eb26ebe76faac97df4ac417b4a6d0e25915ec7547a3564, nonce: 15)
[22:14:48.415] 453.990 trezor.wire.thp.channel DEBUG [WebUSB] (cid: 540c) New nonce_send: 16
[22:14:48.416] 453.992 trezor.wire.thp.channel DEBUG [WebUSB] (cid: 540c) write_encrypted_payload_loop
[22:14:48.417] 453.992 trezor.wire.thp.session_context ERROR [WebUSB] exception:
[22:14:48.417] Traceback (most recent call last):
[22:14:48.417]   File "trezor/wire/thp/session_context.py", in handle
[22:14:48.418]   File "trezor/wire/message_handler.py", in handle_single_message
[22:14:48.418]   File "trezor/wire/thp/channel.py", in write
[22:14:48.418]   File "trezor/wire/thp/channel.py", in write_encrypted_payload
[22:14:48.418] AssertionError: 
[22:14:48.419] 453.994 trezor.wire.message_handler INFO [WebUSB] (cid: 540c) received message: GetFeatures
[22:14:48.420] 453.996 trezor.loop DEBUG spawn new task: <generator object 'with_context' at 0x201d3240>
[22:14:48.420] 453.996 trezor.workflow DEBUG start: <generator object 'with_context' at 0x201d3240>
[22:14:48.465] 454.040 trezor.loop DEBUG finish: <generator object 'with_context' at 0x201d3240>
[22:14:48.465] 454.041 trezor.workflow DEBUG close: <generator object 'with_context' at 0x201d3240>
[22:14:48.465] 454.041 trezor.workflow DEBUG default already started
[22:14:48.467] 454.043 trezor.wire.thp.channel INFO [WebUSB] (cid: 540c) write message: Features
[22:14:48.470] 454.046 trezor.wire.thp.channel DEBUG [WebUSB] (cid: 540c) encrypt
[22:14:48.472] 454.047 trezor.wire.thp.crypto DEBUG enc (key: 6cc1d92d00b5f1b5d2eb26ebe76faac97df4ac417b4a6d0e25915ec7547a3564, nonce: 16)
[22:14:48.474] 454.050 trezor.wire.thp.channel DEBUG [WebUSB] (cid: 540c) New nonce_send: 17
[22:14:48.476] 454.052 trezor.wire.thp.channel DEBUG [WebUSB] (cid: 540c) write_encrypted_payload_loop
[22:14:48.476] 454.052 trezor.wire.thp.session_context ERROR [WebUSB] exception:
[22:14:48.477] Traceback (most recent call last):
[22:14:48.477]   File "trezor/wire/thp/session_context.py", in handle
[22:14:48.477]   File "trezor/wire/message_handler.py", in handle_single_message
[22:14:48.477]   File "trezor/wire/thp/channel.py", in write
[22:14:48.477]   File "trezor/wire/thp/channel.py", in write_encrypted_payload
[22:14:48.478] AssertionError: 
[22:14:48.478] 454.054 trezor.wire.message_handler INFO [WebUSB] (cid: 540c) received message: GetFeatures
[22:14:48.479] 454.055 trezor.loop DEBUG spawn new task: <generator object 'with_context' at 0x201d43e0>
[22:14:48.480] 454.056 trezor.workflow DEBUG start: <generator object 'with_context' at 0x201d43e0>
[22:14:48.524] 454.100 trezor.loop DEBUG finish: <generator object 'with_context' at 0x201d43e0>
[22:14:48.525] 454.100 trezor.workflow DEBUG close: <generator object 'with_context' at 0x201d43e0>
[22:14:48.525] 454.100 trezor.workflow DEBUG default already started
[22:14:48.527] 454.102 trezor.wire.thp.channel INFO [WebUSB] (cid: 540c) write message: Features
[22:14:48.529] 454.105 trezor.wire.thp.channel DEBUG [WebUSB] (cid: 540c) encrypt
[22:14:48.531] 454.107 trezor.wire.thp.crypto DEBUG enc (key: 6cc1d92d00b5f1b5d2eb26ebe76faac97df4ac417b4a6d0e25915ec7547a3564, nonce: 17)
[22:14:48.534] 454.109 trezor.wire.thp.channel DEBUG [WebUSB] (cid: 540c) New nonce_send: 18
[22:14:48.535] 454.111 trezor.wire.thp.channel DEBUG [WebUSB] (cid: 540c) write_encrypted_payload_loop
[22:14:48.536] 454.111 trezor.wire.thp.session_context ERROR [WebUSB] exception:
[22:14:48.536] Traceback (most recent call last):
[22:14:48.536]   File "trezor/wire/thp/session_context.py", in handle
[22:14:48.536]   File "trezor/wire/message_handler.py", in handle_single_message
[22:14:48.536]   File "trezor/wire/thp/channel.py", in write
[22:14:48.537]   File "trezor/wire/thp/channel.py", in write_encrypted_payload
[22:14:48.537] AssertionError: 
[22:14:48.538] 454.113 trezor.wire.message_handler INFO [WebUSB] (cid: 540c) received message: GetFeatures
[22:14:48.539] 454.115 trezor.loop DEBUG spawn new task: <generator object 'with_context' at 0x201d5580>
[22:14:48.539] 454.115 trezor.workflow DEBUG start: <generator object 'with_context' at 0x201d5580>
[22:14:48.583] 454.159 trezor.loop DEBUG finish: <generator object 'with_context' at 0x201d5580>
[22:14:48.583] 454.159 trezor.workflow DEBUG close: <generator object 'with_context' at 0x201d5580>
[22:14:48.584] 454.159 trezor.workflow DEBUG default already started
[22:14:48.586] 454.161 trezor.wire.thp.channel INFO [WebUSB] (cid: 540c) write message: Features
[22:14:48.588] 454.164 trezor.wire.thp.channel DEBUG [WebUSB] (cid: 540c) encrypt
[22:14:48.590] 454.166 trezor.wire.thp.crypto DEBUG enc (key: 6cc1d92d00b5f1b5d2eb26ebe76faac97df4ac417b4a6d0e25915ec7547a3564, nonce: 18)
[22:14:48.593] 454.168 trezor.wire.thp.channel DEBUG [WebUSB] (cid: 540c) New nonce_send: 19
[22:14:48.594] 454.170 trezor.wire.thp.channel DEBUG [WebUSB] (cid: 540c) write_encrypted_payload_loop
[22:14:48.595] 454.170 trezor.wire.thp.session_context ERROR [WebUSB] exception:
[22:14:48.595] Traceback (most recent call last):
[22:14:48.595]   File "trezor/wire/thp/session_context.py", in handle
[22:14:48.595]   File "trezor/wire/message_handler.py", in handle_single_message
[22:14:48.596]   File "trezor/wire/thp/channel.py", in write
[22:14:48.596]   File "trezor/wire/thp/channel.py", in write_encrypted_payload
[22:14:48.596] AssertionError: 
[22:14:48.597] 454.172 trezor.wire.message_handler INFO [WebUSB] (cid: 540c) received message: GetFeatures
[22:14:48.598] 454.173 trezor.loop DEBUG spawn new task: <generator object 'with_context' at 0x201d6720>
[22:14:48.598] 454.174 trezor.workflow DEBUG start: <generator object 'with_context' at 0x201d6720>
[22:14:48.641] 454.217 trezor.loop DEBUG finish: <generator object 'with_context' at 0x201d6720>
[22:14:48.642] 454.217 trezor.workflow DEBUG close: <generator object 'with_context' at 0x201d6720>
[22:14:48.642] 454.217 trezor.workflow DEBUG default already started
[22:14:48.644] 454.219 trezor.wire.thp.channel INFO [WebUSB] (cid: 540c) write message: Features
[22:14:48.646] 454.222 trezor.wire.thp.channel DEBUG [WebUSB] (cid: 540c) encrypt
[22:14:48.648] 454.224 trezor.wire.thp.crypto DEBUG enc (key: 6cc1d92d00b5f1b5d2eb26ebe76faac97df4ac417b4a6d0e25915ec7547a3564, nonce: 19)
[22:14:48.651] 454.226 trezor.wire.thp.channel DEBUG [WebUSB] (cid: 540c) New nonce_send: 20
[22:14:48.652] 454.228 trezor.wire.thp.channel DEBUG [WebUSB] (cid: 540c) write_encrypted_payload_loop
[22:14:48.653] 454.228 trezor.wire.thp.session_context ERROR [WebUSB] exception:
[22:14:48.653] Traceback (most recent call last):
[22:14:48.653]   File "trezor/wire/thp/session_context.py", in handle
[22:14:48.653]   File "trezor/wire/message_handler.py", in handle_single_message
[22:14:48.654]   File "trezor/wire/thp/channel.py", in write
[22:14:48.654]   File "trezor/wire/thp/channel.py", in write_encrypted_payload
[22:14:48.654] AssertionError: 
```

</details>

Found when running the tutorial via Suite over USB.