### PR TITLE
fix(python): improve `trezorctl` THP error handling

### DIFF
--- a/core/src/apps/thp/pairing.py
+++ b/core/src/apps/thp/pairing.py
@@ -1,5 +1,4 @@
 from typing import TYPE_CHECKING
-from ubinascii import hexlify
 
 from trezor import protobuf
 from trezor.crypto import random
@@ -308,13 +307,6 @@ async def _handle_code_entry_cpace(
     ctx.cpace.compute_shared_secret(message.cpace_host_public_key)
     expected_tag = sha256(ctx.cpace.shared_secret).digest()
     if expected_tag != message.tag:
-        print(
-            "expected code entry tag:", hexlify(expected_tag).decode()
-        )  # TODO remove after testing
-        print(
-            "expected code entry shared secret:",
-            hexlify(ctx.cpace.shared_secret).decode(),
-        )  # TODO remove after testing
         raise ThpError("Unexpected Code Entry Tag")
 
     if ctx.code_entry_secret is None:

--- a/python/src/trezorlib/client.py
+++ b/python/src/trezorlib/client.py
@@ -173,20 +173,14 @@ class TrezorClient:
         sha_ctx = sha256(cpace.shared_secret)
         tag = sha_ctx.digest()
 
-        try:
-            secret_msg = session.call(
-                messages.ThpCodeEntryCpaceHostTag(
-                    cpace_host_public_key=cpace.host_public_key,
-                    tag=tag,
-                ),
-                expect=messages.ThpCodeEntrySecret,
-                skip_firmware_version_check=True,
-            )
-        except exceptions.TrezorFailure as e:
-            if e.message == "Unexpected Code Entry Tag":
-                raise exceptions.UnexpectedCodeEntryTagException
-            else:
-                raise e
+        secret_msg = session.call(
+            messages.ThpCodeEntryCpaceHostTag(
+                cpace_host_public_key=cpace.host_public_key,
+                tag=tag,
+            ),
+            expect=messages.ThpCodeEntrySecret,
+            skip_firmware_version_check=True,
+        )
 
         # Check `commitment` and `code`
         assert secret_msg.secret is not None
@@ -219,14 +213,7 @@ class TrezorClient:
     ) -> Session:
         """
         Returns a new session.
-
-        In the case of seed derivation, the function will fail if the device is not initialized.
         """
-        if self.features.initialized is False and passphrase is not SEEDLESS:
-            raise exceptions.DerivationOnUninitaizedDeviceError(
-                "Calling uninitialized device with a passphrase. Call get_seedless_session instead."
-            )
-
         if isinstance(self.protocol, ProtocolV1Channel):
             from .transport.session import SessionV1, derive_seed
 

--- a/python/src/trezorlib/exceptions.py
+++ b/python/src/trezorlib/exceptions.py
@@ -105,16 +105,6 @@ class InvalidSessionError(TrezorException):
     Raised when Trezor returns unexpected PassphraseRequest"""
 
 
-class DerivationOnUninitaizedDeviceError(TrezorException):
-    """Tried to derive seed on uninitialized device.
-
-    To communicate with uninitialized device, use seedless session instead."""
-
-
-class UnexpectedCodeEntryTagException(TrezorException):
-    pass
-
-
 class ThpError(TrezorException):
     pass
 

--- a/tests/device_tests/thp/test_pairing.py
+++ b/tests/device_tests/thp/test_pairing.py
@@ -101,7 +101,7 @@ def test_pairing_qr_code(client: Client) -> None:
     protocol._send_message(ThpEndRequest())
     protocol._read_message(ThpEndResponse)
 
-    protocol._has_valid_channel = True
+    protocol._is_paired = True
 
 
 @pytest.mark.filterwarnings(
@@ -172,7 +172,7 @@ def test_pairing_code_entry(
     protocol._send_message(ThpEndRequest())
     protocol._read_message(ThpEndResponse)
 
-    protocol._has_valid_channel = True
+    protocol._is_paired = True
 
 
 @pytest.mark.filterwarnings(
@@ -241,7 +241,7 @@ def test_pairing_nfc(client: Client) -> None:
 
     protocol._send_message(ThpEndRequest())
     protocol._read_message(ThpEndResponse)
-    protocol._has_valid_channel = True
+    protocol._is_paired = True
 
 
 def _nfc_pairing(client: Client, protocol: ProtocolV2Channel) -> None:
@@ -486,9 +486,9 @@ def test_credential_request_in_encrypted_transport_phase(client: Client) -> None
     credential = credential_response.credential
     protocol._send_message(ThpEndRequest())
     protocol._read_message(ThpEndResponse)
+    protocol._is_paired = True  # pairing has been done above
 
     session = client.get_seedless_session()
-
     session.call(
         ThpCredentialRequest(
             host_static_public_key=host_static_public_key,


### PR DESCRIPTION
Following https://github.com/trezor/trezor-firmware/pull/5613.

A few error examples:
```md
$ trezorctl ping 123 
## no device is connected
Failed to connect: TransportException (No Trezor device found)

$ trezorctl ping 123
Please confirm action on your Trezor device.
## don't confirm THP pairing
Failed to connect: Cancelled

$ trezorctl btc get-address -n m/44h/0h/0h/0/0 
Please confirm action on your Trezor device.
## fail to get address on uninitialized device
Failed to connect: TrezorFailure (NotInitialized: Device is not initialized)

$ trezorctl ping 123
Please confirm action on your Trezor device.
## enter invalid pairing code
Enter code from Trezor: 000000
Failed to connect: TrezorFailure (FirmwareError: Unexpected Code Entry Tag)

$ trezorctl ping 123 -b
Please confirm action on your Trezor device.
## don't confirm Ping
Action was cancelled.
```