### PR TITLE
Allow preempting stale THP channels

### DIFF
--- a/core/src/apps/thp/pairing.py
+++ b/core/src/apps/thp/pairing.py
@@ -143,7 +143,8 @@ async def handle_pairing_request(
             # Should raise UnexpectedMessageException
             result = await ctx.show_pairing_method_screen()
         except UnexpectedMessageException as e:
-            raw_response = e.msg
+            if (raw_response := e.msg) is None:
+                raise  # propagate stale channel preemption
             req_type = protobuf.type_for_wire(
                 ctx.message_type_enum_name, raw_response.type
             )

--- a/core/src/trezor/wire/context.py
+++ b/core/src/trezor/wire/context.py
@@ -40,9 +40,11 @@ class UnexpectedMessageException(Exception):
 
     Utility exception to inform the session handler that the current workflow
     should be aborted and a new one started as if `msg` was the first message.
+
+    If `msg` is `None`, the event loop should be restarted.
     """
 
-    def __init__(self, msg: Message) -> None:
+    def __init__(self, msg: Message | None) -> None:
         super().__init__()
         self.msg = msg
 

--- a/core/src/trezor/wire/thp/session_context.py
+++ b/core/src/trezor/wire/thp/session_context.py
@@ -55,10 +55,11 @@ class GenericSessionContext(Context):
                     log.exception(__name__, e, iface=self.iface)
                 await self.write(failure(e))
             except UnexpectedMessageException as unexpected:
-                # The workflow was interrupted by an unexpected message. We need to
-                # process it as if it was a new message...
-                message = unexpected.msg
-                continue
+                if unexpected.msg is not None:
+                    # The workflow was interrupted by an unexpected message. We need to
+                    # process it as if it was a new message...
+                    message = unexpected.msg
+                    continue
             except Exception as exc:
                 if __debug__:
                     log.exception(__name__, exc, iface=self.iface)


### PR DESCRIPTION
In case an existing channel becomes unresponsive, we allow another channel on the same interface to preempt the active workflow (by restarting the event loop).

If there are no other active channels, the existing channel will not be preempted.

In the future, we should use [the newly introduced `Ping`/`Pong` messages](https://github.com/trezor/trezor-firmware/pull/5563) - but since they are not supported by Suite, a channel can be preempted only 1 second after the last THP device->host write (giving the host enough time to respond).

# Notes: 
- the "preempting" message will be responded with `TRANSPORT_BUSY` so the host needs to retry to "acquire" its channel (after the stale workflow is cancelled and the event loop is restarted).
- initially it was done by time-based buffers locking, but was dropped in #5546.

<!--
For core developers:
- Assign yourself to the PR.
- Set the priority to match the original issue.
- Add the PR to the current sprint.
- If it's a draft PR, mark it as "In Progress."
- If it's a final PR, mark it as "Needs Review."

For external contributors:
- Please open an issue before submitting a PR so we can discuss whether we want to proceed with it.
-->
