### PR TITLE
docs(python): mention git submodules in trezorctl setup

### DIFF
--- a/python/README.md
+++ b/python/README.md
@@ -94,6 +94,7 @@ Install the [Poetry](https://python-poetry.org/) tool, checkout
 pip3 install poetry
 git clone https://github.com/trezor/trezor-firmware
 cd trezor-firmware
+git submodule update --init --recursive
 poetry install
 poetry shell
 ```


### PR DESCRIPTION
Add git submodule instruction to local trezorctl setup, because it is not clear at first glance that I have to do it.
When I don't, `poetry install` crashes because `vendor/ts-tvl/` is not a python module.