### PR TITLE
feat(core): expose `ble_get_bond_list` to MicroPython

### DIFF
--- a/core/embed/rust/build.rs
+++ b/core/embed/rust/build.rs
@@ -410,6 +410,7 @@ fn generate_trezorhal_bindings() {
         .allowlist_type("usb_event_t")
         .allowlist_function("usb_get_state")
         // ble
+        .allowlist_var("BLE_MAX_BONDS")
         .allowlist_var("BLE_PAIRING_CODE_LEN")
         .allowlist_var("BLE_RX_PACKET_SIZE")
         .allowlist_var("BLE_TX_PACKET_SIZE")
@@ -422,9 +423,11 @@ fn generate_trezorhal_bindings() {
         .allowlist_function("ble_read")
         .allowlist_function("ble_set_name")
         .allowlist_function("ble_unpair")
+        .allowlist_function("ble_get_bond_list")
         .allowlist_type("ble_command_t")
         .allowlist_type("ble_state_t")
         .allowlist_type("ble_event_t")
+        .allowlist_type("bt_le_addr_t")
         // touch
         .allowlist_function("touch_get_event")
         // button

--- a/core/embed/rust/librust_qstr.h
+++ b/core/embed/rust/librust_qstr.h
@@ -327,6 +327,7 @@ static void _librust_qstrs(void) {
   MP_QSTR_flow_get_address;
   MP_QSTR_flow_get_pubkey;
   MP_QSTR_get;
+  MP_QSTR_get_bonds;
   MP_QSTR_get_language;
   MP_QSTR_get_transition_out;
   MP_QSTR_haptic_feedback;

--- a/core/embed/rust/src/trezorhal/ble/mod.rs
+++ b/core/embed/rust/src/trezorhal/ble/mod.rs
@@ -9,6 +9,7 @@ use crate::{error::Error, trezorhal::ffi::bt_le_addr_t};
 use core::{mem::size_of, ptr};
 
 pub const ADV_NAME_LEN: usize = ffi::BLE_ADV_NAME_LEN as usize;
+pub const BLE_MAX_BONDS: usize = ffi::BLE_MAX_BONDS as usize;
 pub const PAIRING_CODE_LEN: usize = ffi::BLE_PAIRING_CODE_LEN as usize;
 pub const RX_PACKET_SIZE: usize = ffi::BLE_RX_PACKET_SIZE as usize;
 pub const TX_PACKET_SIZE: usize = ffi::BLE_TX_PACKET_SIZE as usize;
@@ -192,6 +193,15 @@ pub fn is_pairing_requested() -> bool {
 
 pub fn connected_addr() -> bt_le_addr_t {
     state().connected_addr
+}
+
+pub fn get_bonds<F, T>(f: F) -> T
+where
+    F: Fn(&[bt_le_addr_t]) -> T,
+{
+    let mut bonds = [bt_le_addr_t::zero(); BLE_MAX_BONDS];
+    let size = unsafe { ffi::ble_get_bond_list(bonds.as_mut_ptr(), bonds.len()) };
+    f(&bonds[..size.into()])
 }
 
 pub fn write(bytes: &[u8]) -> Result<(), Error> {

--- a/core/mocks/generated/trezorble.pyi
+++ b/core/mocks/generated/trezorble.pyi
@@ -126,6 +126,15 @@ def connection_flags() -> list[str]:
 
 
 # rust/src/trezorhal/ble/micropython.rs
+def get_bonds() -> list[tuple[bytes, int], ...]:
+    """
+    Returns a list of (addr_bytes, addr_type) tuples, representing the current bonds.
+    addr_bytes: bytes of length 6
+    addr_type: integer as provided by bt_le_addr_t (e.g., 0=public, 1=random)
+    """
+
+
+# rust/src/trezorhal/ble/micropython.rs
 def connected_addr() -> tuple[bytes, int] | None:
     """
     If connected, returns a tuple (addr_bytes, addr_type), otherwise None.


### PR DESCRIPTION
Manually tested on the emulator with the following patch:
```diff
diff --git a/core/embed/io/ble/unix/ble.c b/core/embed/io/ble/unix/ble.c
index 298fbb53e2..930cce3cdf 100644
--- a/core/embed/io/ble/unix/ble.c
+++ b/core/embed/io/ble/unix/ble.c
@@ -37,4 +37,11 @@ void ble_get_advertising_name(char *name, size_t max_len) {
 
 bool ble_unpair(const bt_le_addr_t *addr) { return false; }
 
-uint8_t ble_get_bond_list(bt_le_addr_t *bonds, size_t count) { return 0; }
+uint8_t ble_get_bond_list(bt_le_addr_t *bonds, size_t count) {
+  if (count < 1) {
+    return 0;
+  }
+  bt_le_addr_t bond = { 7, {1,2,3,4,5,6} };
+  bonds[0] = bond;
+  return 1;
+}
diff --git a/core/src/apps/homescreen/device_menu.py b/core/src/apps/homescreen/device_menu.py
index aa74f42a71..aa1c3ca849 100644
--- a/core/src/apps/homescreen/device_menu.py
+++ b/core/src/apps/homescreen/device_menu.py
@@ -18,6 +18,7 @@ async def handle_device_menu() -> None:
     # MOCK DATA
     paired_devices = ["Trezor Suite"]
     connected_idx = 0 if ble.is_connected() else None
+    print("BONDS", ble.get_bonds())
     bluetooth_version = "2.3.1.1"
     # ###
     firmware_version = ".".join(map(str, utils.VERSION))
```

Results in the following output:
```
BONDS [(b'\x01\x02\x03\x04\x05\x06', 7)]
```