### PR TITLE
Allow device name to overflow

### DIFF
--- a/core/embed/rust/src/ui/layout_eckhart/firmware/device_menu_screen.rs
+++ b/core/embed/rust/src/ui/layout_eckhart/firmware/device_menu_screen.rs
@@ -97,6 +97,7 @@ pub enum DeviceMenuMsg {
 struct MenuItem {
     text: TString<'static>,
     subtext: Option<(TString<'static>, Option<&'static TextStyle>)>,
+    subtext_overflow: bool,
     stylesheet: &'static ButtonStyleSheet,
     connection_status: Option<bool>,
     action: Option<Action>,
@@ -111,6 +112,7 @@ impl MenuItem {
         Self {
             text,
             subtext: None,
+            subtext_overflow: false,
             stylesheet: MENU_ITEM_NORMAL,
             action,
             connection_status: None,
@@ -122,6 +124,16 @@ impl MenuItem {
         subtext: Option<(TString<'static>, Option<&'static TextStyle>)>,
     ) -> &mut Self {
         self.subtext = subtext;
+        self.subtext_overflow = false;
+        self
+    }
+
+    pub fn with_overflowing_subtext(
+        &mut self,
+        subtext: Option<(TString<'static>, Option<&'static TextStyle>)>,
+    ) -> &mut Self {
+        self.subtext = subtext;
+        self.subtext_overflow = true;
         self
     }
 
@@ -465,7 +477,7 @@ impl DeviceMenuScreen {
                 TR::words__name.into(),
                 Some(Action::Return(DeviceMenuMsg::DeviceName)),
             );
-            item_device_name.with_subtext(Some((device_name, None)));
+            item_device_name.with_overflowing_subtext(Some((device_name, None)));
             unwrap!(items.push(item_device_name));
         }
 
@@ -606,12 +618,21 @@ impl DeviceMenuScreen {
                     } else if let Some((subtext, subtext_style)) = item.subtext {
                         let subtext_style =
                             subtext_style.unwrap_or(&theme::TEXT_MENU_ITEM_SUBTITLE);
-                        Button::new_menu_item_with_subtext(
-                            item.text,
-                            *item.stylesheet,
-                            subtext,
-                            subtext_style,
-                        )
+                        if item.subtext_overflow {
+                            Button::new_menu_item_with_overflowing_subtext(
+                                item.text,
+                                *item.stylesheet,
+                                subtext,
+                                subtext_style,
+                            )
+                        } else {
+                            Button::new_menu_item_with_subtext(
+                                item.text,
+                                *item.stylesheet,
+                                subtext,
+                                subtext_style,
+                            )
+                        }
                     } else {
                         Button::new_menu_item(item.text, *item.stylesheet)
                     };


### PR DESCRIPTION
1. In the device menu, the device name could be longer than what fits in the subtitle, so we should let it overflow rather than crash!
2. In the pair & connect menu, the device name could be longer than what can fit in the text, so we should let that overflow as well!

Related to #4897

Basically we need to revert the debug-only check for the subtext introduced by #4907 in the case of the device name, while letting it crash in any other case to catch copy errors...

And also we should allow *menu items with text and subtext* have `single_line` text - which does not use `split_two_lines` which checks for overflow...

<!--
For core developers:
- Assign yourself to the PR.
- Set the priority to match the original issue.
- Add the PR to the current sprint.
- If it's a draft PR, mark it as "In Progress."
- If it's a final PR, mark it as "Needs Review."

For external contributors:
- Please open an issue before submitting a PR so we can discuss whether we want to proceed with it.
-->
