### PR TITLE
Use a shorter timeout when rebooting

### DIFF
--- a/core/embed/rust/librust_qstr.h
+++ b/core/embed/rust/librust_qstr.h
@@ -20,9 +20,9 @@ static void _librust_qstrs(void) {
   MP_QSTR_AttachType;
   MP_QSTR_AutoLockDelay;
   MP_QSTR_BACK;
+  MP_QSTR_BLEIF;
   MP_QSTR_BacklightLevels;
   MP_QSTR_BackupFailed;
-  MP_QSTR_BleInterface;
   MP_QSTR_Bluetooth;
   MP_QSTR_CANCELLED;
   MP_QSTR_CONFIRMED;

--- a/core/embed/rust/src/trezorhal/ble/micropython.rs
+++ b/core/embed/rust/src/trezorhal/ble/micropython.rs
@@ -212,7 +212,7 @@ extern "C" fn py_iface_read(n_args: usize, args: *const Obj) -> Obj {
 }
 
 static BLE_INTERFACE_TYPE: Type = obj_type! {
-    name: Qstr::MP_QSTR_BleInterface,
+    name: Qstr::MP_QSTR_BLEIF,
     locals: &obj_dict!(obj_map! {
         Qstr::MP_QSTR_iface_num => obj_fn_1!(py_iface_num).as_obj(),
         Qstr::MP_QSTR_write => obj_fn_2!(py_iface_write).as_obj(),
@@ -229,7 +229,7 @@ static BLE_INTERFACE_OBJ: SimpleTypeObj = SimpleTypeObj::new(&BLE_INTERFACE_TYPE
 pub static mp_module_trezorble: Module = obj_module! {
     Qstr::MP_QSTR___name__ => Qstr::MP_QSTR_trezorble.to_obj(),
 
-    /// class BleInterface:
+    /// class BLEIF:
     ///     """
     ///     BLE interface wrapper.
     ///     """
@@ -257,7 +257,7 @@ pub static mp_module_trezorble: Module = obj_module! {
     ///
     /// mock:global
     ///
-    /// interface: BleInterface
+    /// interface: BLEIF
     /// """BLE interface instance."""
     Qstr::MP_QSTR_interface => BLE_INTERFACE_OBJ.as_obj(),
 

--- a/core/embed/upymod/modtrezorio/modtrezorio.c
+++ b/core/embed/upymod/modtrezorio/modtrezorio.c
@@ -88,7 +88,7 @@ uint32_t last_touch_sample_time = 0;
 
 /// USB_EVENT: int # interface id for USB events
 
-/// WireInterface = Union[USBIF, BleInterface]
+/// WireInterface = Union[USBIF, BLEIF]
 /// USBIF_WIRE: int  # interface id of the USB wire interface
 /// USBIF_DEBUG: int  # interface id of the USB debug interface
 /// USBIF_WEBAUTHN: int  # interface id of the USB WebAuthn

--- a/core/mocks/generated/trezorble.pyi
+++ b/core/mocks/generated/trezorble.pyi
@@ -2,7 +2,7 @@ from typing import *
 
 
 # rust/src/trezorhal/ble/micropython.rs
-class BleInterface:
+class BLEIF:
     """
     BLE interface wrapper.
     """
@@ -25,7 +25,7 @@ class BleInterface:
         """
         Reads message using BLE (device).
         """
-interface: BleInterface
+interface: BLEIF
 """BLE interface instance."""
 
 

--- a/core/mocks/generated/trezorio/__init__.pyi
+++ b/core/mocks/generated/trezorio/__init__.pyi
@@ -97,7 +97,7 @@ BUTTON_RELEASED: int  # button up event
 BUTTON_LEFT: int  # button number of left button
 BUTTON_RIGHT: int  # button number of right button
 USB_EVENT: int # interface id for USB events
-WireInterface = Union[USBIF, BleInterface]
+WireInterface = Union[USBIF, BLEIF]
 USBIF_WIRE: int  # interface id of the USB wire interface
 USBIF_DEBUG: int  # interface id of the USB debug interface
 USBIF_WEBAUTHN: int  # interface id of the USB WebAuthn

--- a/core/src/trezor/wire/thp/interface_context.py
+++ b/core/src/trezor/wire/thp/interface_context.py
@@ -43,6 +43,11 @@ def _timeout_after(ms: int) -> Generator[sleep, int, NoReturn]:
 
 
 class ThpContext:
+    """
+    This class handles THP receiving from multiple wire interfaces.
+    It also handles and responds to low-level single packet THP messages, creating new channels if needed.
+    """
+
     def __init__(self, *ifaces: WireInterface) -> None:
         max_packet_len = max(iface.RX_PACKET_LEN for iface in ifaces)
         self._packet_buf = bytearray(max_packet_len)


### PR DESCRIPTION
In general, Trezor should not wait for too long for a THP ACK when sending the `Success` response (since the last ACK may be lost, similar to [Two generals' agreement and TCP handshake](https://stackoverflow.com/q/36352236)).

This PR will allow sending `Success` response 3 times (due to THP retransmissions) and proceed to reboot the device.

Fixes #5667.

<!--
For core developers:
- Assign yourself to the PR.
- Set the priority to match the original issue.
- Add the PR to the current sprint.
- If it's a draft PR, mark it as "In Progress."
- If it's a final PR, mark it as "Needs Review."

For external contributors:
- Please open an issue before submitting a PR so we can discuss whether we want to proceed with it.
-->
