### PR TITLE
Power device menu for Eckhart

### DIFF
--- a/core/embed/rust/librust_qstr.h
+++ b/core/embed/rust/librust_qstr.h
@@ -55,6 +55,8 @@ static void _librust_qstrs(void) {
   MP_QSTR_PinRemove;
   MP_QSTR_RESUME;
   MP_QSTR_RX_PACKET_LEN;
+  MP_QSTR_Reboot;
+  MP_QSTR_RebootToBootloader;
   MP_QSTR_SWIPE_DOWN;
   MP_QSTR_SWIPE_LEFT;
   MP_QSTR_SWIPE_RIGHT;
@@ -64,6 +66,7 @@ static void _librust_qstrs(void) {
   MP_QSTR_TRANSITIONING;
   MP_QSTR_TX_PACKET_LEN;
   MP_QSTR_TranslationsHeader;
+  MP_QSTR_TurnOff;
   MP_QSTR_WipeCode;
   MP_QSTR_WipeDevice;
   MP_QSTR_WipeRemove;
@@ -965,6 +968,7 @@ static void _librust_qstrs(void) {
   MP_QSTR_words__pay_attention;
   MP_QSTR_words__please_check_again;
   MP_QSTR_words__please_try_again;
+  MP_QSTR_words__power;
   MP_QSTR_words__provider;
   MP_QSTR_words__really_wanna;
   MP_QSTR_words__receive;

--- a/core/embed/rust/src/translations/generated/translated_string.rs
+++ b/core/embed/rust/src/translations/generated/translated_string.rs
@@ -1515,6 +1515,7 @@ pub enum TranslatedString {
     ble__forget_all = 1124,  // "Forget all"
     words__connect = 1125,  // "Connect"
     words__forget = 1126,  // "Forget"
+    words__power = 1127,  // "Power"
 }
 
 impl TranslatedString {
@@ -3356,6 +3357,7 @@ impl TranslatedString {
             (Self::ble__forget_all, "Forget all"),
             (Self::words__connect, "Connect"),
             (Self::words__forget, "Forget"),
+            (Self::words__power, "Power"),
     ];
 
     #[cfg(feature = "micropython")]
@@ -4830,6 +4832,7 @@ impl TranslatedString {
         (Qstr::MP_QSTR_words__pay_attention, Self::words__pay_attention),
         (Qstr::MP_QSTR_words__please_check_again, Self::words__please_check_again),
         (Qstr::MP_QSTR_words__please_try_again, Self::words__please_try_again),
+        (Qstr::MP_QSTR_words__power, Self::words__power),
         (Qstr::MP_QSTR_words__provider, Self::words__provider),
         (Qstr::MP_QSTR_words__really_wanna, Self::words__really_wanna),
         (Qstr::MP_QSTR_words__receive, Self::words__receive),

--- a/core/embed/rust/src/ui/api/firmware_micropython.rs
+++ b/core/embed/rust/src/ui/api/firmware_micropython.rs
@@ -2126,5 +2126,8 @@ pub static mp_module_trezorui_api: Module = obj_module! {
     ///     HapticFeedback: ClassVar[DeviceMenuResult]
     ///     LedEnabled: ClassVar[DeviceMenuResult]
     ///     WipeDevice: ClassVar[DeviceMenuResult]
+    ///     Reboot: ClassVar[DeviceMenuResult]
+    ///     RebootToBootloader: ClassVar[DeviceMenuResult]
+    ///     TurnOff: ClassVar[DeviceMenuResult]
     Qstr::MP_QSTR_DeviceMenuResult => DEVICE_MENU_RESULT.as_obj(),
 };

--- a/core/embed/rust/src/ui/layout/device_menu_result.rs
+++ b/core/embed/rust/src/ui/layout/device_menu_result.rs
@@ -30,6 +30,10 @@ pub static SCREEN_BRIGHTNESS: SimpleTypeObj = SimpleTypeObj::new(&DEVICE_MENU_RE
 pub static HAPTIC_FEEDBACK: SimpleTypeObj = SimpleTypeObj::new(&DEVICE_MENU_RESULT_BASE_TYPE);
 pub static LED_ENABLED: SimpleTypeObj = SimpleTypeObj::new(&DEVICE_MENU_RESULT_BASE_TYPE);
 pub static WIPE_DEVICE: SimpleTypeObj = SimpleTypeObj::new(&DEVICE_MENU_RESULT_BASE_TYPE);
+// Power settings
+pub static TURN_OFF: SimpleTypeObj = SimpleTypeObj::new(&DEVICE_MENU_RESULT_BASE_TYPE);
+pub static REBOOT: SimpleTypeObj = SimpleTypeObj::new(&DEVICE_MENU_RESULT_BASE_TYPE);
+pub static REBOOT_TO_BOOTLOADER: SimpleTypeObj = SimpleTypeObj::new(&DEVICE_MENU_RESULT_BASE_TYPE);
 
 // Create a DeviceMenuResult class that contains all result types
 static DEVICE_MENU_RESULT_TYPE: Type = obj_type! {
@@ -53,6 +57,9 @@ static DEVICE_MENU_RESULT_TYPE: Type = obj_type! {
         Qstr::MP_QSTR_HapticFeedback => HAPTIC_FEEDBACK.as_obj(),
         Qstr::MP_QSTR_LedEnabled => LED_ENABLED.as_obj(),
         Qstr::MP_QSTR_WipeDevice => WIPE_DEVICE.as_obj(),
+        Qstr::MP_QSTR_TurnOff => TURN_OFF.as_obj(),
+        Qstr::MP_QSTR_Reboot => REBOOT.as_obj(),
+        Qstr::MP_QSTR_RebootToBootloader => REBOOT_TO_BOOTLOADER.as_obj(),
     } },
 };
 

--- a/core/embed/rust/src/ui/layout_eckhart/component_msg_obj.rs
+++ b/core/embed/rust/src/ui/layout_eckhart/component_msg_obj.rs
@@ -184,6 +184,10 @@ impl ComponentMsgObj for DeviceMenuScreen {
             DeviceMenuMsg::HapticFeedback => Ok(HAPTIC_FEEDBACK.as_obj()),
             DeviceMenuMsg::LedEnabled => Ok(LED_ENABLED.as_obj()),
             DeviceMenuMsg::WipeDevice => Ok(WIPE_DEVICE.as_obj()),
+            // Power settings
+            DeviceMenuMsg::TurnOff => Ok(TURN_OFF.as_obj()),
+            DeviceMenuMsg::Reboot => Ok(REBOOT.as_obj()),
+            DeviceMenuMsg::RebootToBootloader => Ok(REBOOT_TO_BOOTLOADER.as_obj()),
             // nothing selected
             DeviceMenuMsg::Close => Ok(CANCELLED.as_obj()),
         }

--- a/core/embed/upymod/modtrezorio/modtrezorio-pm.h
+++ b/core/embed/upymod/modtrezorio/modtrezorio-pm.h
@@ -52,6 +52,20 @@ STATIC mp_obj_t mod_trezorio_pm_suspend() {
 STATIC MP_DEFINE_CONST_FUN_OBJ_0(mod_trezorio_pm_suspend_obj,
                                  mod_trezorio_pm_suspend);
 
+/// def hibernate() -> None:
+///     """
+///     Hibernates the device. Raises RuntimeError on failure.
+///     """
+STATIC mp_obj_t mod_trezorio_pm_hibernate() {
+  pm_status_t res = pm_hibernate();
+  if (res != PM_OK) {
+    mp_raise_msg(&mp_type_RuntimeError, MP_ERROR_TEXT("Failed to hibernate"));
+  }
+  return mp_const_none;
+}
+STATIC MP_DEFINE_CONST_FUN_OBJ_0(mod_trezorio_pm_hibernate_obj,
+                                 mod_trezorio_pm_hibernate);
+
 /// def is_usb_connected() -> bool:
 ///     """
 ///     Returns True if USB is connected, False otherwise. Raises RuntimeError
@@ -72,6 +86,8 @@ STATIC MP_DEFINE_CONST_FUN_OBJ_0(mod_trezorio_pm_is_usb_connected_obj,
 STATIC const mp_rom_map_elem_t mod_trezorio_pm_globals_table[] = {
     {MP_ROM_QSTR(MP_QSTR___name__), MP_ROM_QSTR(MP_QSTR_pm)},
     {MP_ROM_QSTR(MP_QSTR_suspend), MP_ROM_PTR(&mod_trezorio_pm_suspend_obj)},
+    {MP_ROM_QSTR(MP_QSTR_hibernate),
+     MP_ROM_PTR(&mod_trezorio_pm_hibernate_obj)},
     {MP_ROM_QSTR(MP_QSTR_is_usb_connected),
      MP_ROM_PTR(&mod_trezorio_pm_is_usb_connected_obj)},
 

--- a/core/mocks/generated/trezorio/pm.pyi
+++ b/core/mocks/generated/trezorio/pm.pyi
@@ -24,6 +24,13 @@ def suspend() -> int:
 
 
 # upymod/modtrezorio/modtrezorio-pm.h
+def hibernate() -> None:
+    """
+    Hibernates the device. Raises RuntimeError on failure.
+    """
+
+
+# upymod/modtrezorio/modtrezorio-pm.h
 def is_usb_connected() -> bool:
     """
     Returns True if USB is connected, False otherwise. Raises RuntimeError

--- a/core/mocks/generated/trezorui_api.pyi
+++ b/core/mocks/generated/trezorui_api.pyi
@@ -869,3 +869,6 @@ class DeviceMenuResult:
     HapticFeedback: ClassVar[DeviceMenuResult]
     LedEnabled: ClassVar[DeviceMenuResult]
     WipeDevice: ClassVar[DeviceMenuResult]
+    Reboot: ClassVar[DeviceMenuResult]
+    RebootToBootloader: ClassVar[DeviceMenuResult]
+    TurnOff: ClassVar[DeviceMenuResult]

--- a/core/mocks/trezortranslate_keys.pyi
+++ b/core/mocks/trezortranslate_keys.pyi
@@ -1054,6 +1054,7 @@ class TR:
     words__pay_attention: str = "Pay attention"
     words__please_check_again: str = "Please check again"
     words__please_try_again: str = "Please try again"
+    words__power: str = "Power"
     words__provider: str = "Provider"
     words__really_wanna: str = "Do you really want to"
     words__receive: str = "Receive"

--- a/core/src/apps/homescreen/device_menu.py
+++ b/core/src/apps/homescreen/device_menu.py
@@ -275,5 +275,20 @@ async def handle_device_menu() -> None:
         from apps.management.wipe_device import wipe_device
 
         await wipe_device(WipeDevice())
+    # Power settings
+    elif menu_result is DeviceMenuResult.TurnOff:
+        from trezor import io
+
+        io.pm.hibernate()
+    elif menu_result is DeviceMenuResult.Reboot:
+        from trezor.utils import reboot_to_bootloader
+
+        # Empty boot command results to a normal reboot
+        reboot_to_bootloader()
+    elif menu_result is DeviceMenuResult.RebootToBootloader:
+        from trezor.enums import BootCommand
+        from trezor.utils import reboot_to_bootloader
+
+        reboot_to_bootloader(BootCommand.STOP_AND_WAIT)
     else:
         raise RuntimeError(f"Unknown menu {menu_result}")

--- a/core/translations/en.json
+++ b/core/translations/en.json
@@ -1276,6 +1276,7 @@
     "words__pay_attention": "Pay attention",
     "words__please_check_again": "Please check again",
     "words__please_try_again": "Please try again",
+    "words__power": "Power",
     "words__provider": "Provider",
     "words__really_wanna": "Do you really want to",
     "words__receive": "Receive",

--- a/core/translations/order.json
+++ b/core/translations/order.json
@@ -1125,5 +1125,6 @@
   "1123": "words__disconnected",
   "1124": "ble__forget_all",
   "1125": "words__connect",
-  "1126": "words__forget"
+  "1126": "words__forget",
+  "1127": "words__power"
 }

--- a/core/translations/signatures.json
+++ b/core/translations/signatures.json
@@ -1,8 +1,8 @@
 {
   "current": {
-    "merkle_root": "eb4654ab34827848bf4ce3e15aef4ef1ee47e74f83e8d1518c07b292b1de2ba5",
-    "datetime": "2025-08-27T08:55:36.117610+00:00",
-    "commit": "746c7925c3de19c287019e5926a3cc5e30d8d503"
+    "merkle_root": "e3766059df9be721b1496be806e72af7049c6c693a7f93f2219a3036843c472f",
+    "datetime": "2025-09-01T07:40:50.006760+00:00",
+    "commit": "bb3eb7cc5b0af90a979683bb828aff5344e3d57b"
   },
   "history": [
     {


### PR DESCRIPTION
Temporary power menu for Eckhart with the following actions:
- restart
- reboot to bootloader
- turn off (hibernate)

This should be reverted when we are able to implement the design in [Figma](https://www.figma.com/design/Dkl7W5PLqpr3TnXJ5hbnfd/--Future-Prod---Safe-7?node-id=11722-3609&t=eLZgwJFpPqTYQnfa-0).


<!--
For core developers:
- Assign yourself to the PR.
- Set the priority to match the original issue.
- Add the PR to the current sprint.
- If it's a draft PR, mark it as "In Progress."
- If it's a final PR, mark it as "Needs Review."

For external contributors:
- Please open an issue before submitting a PR so we can discuss whether we want to proceed with it.
-->
