### PR TITLE
feat(core): add `TString::prefix()` method 

### DIFF
--- a/core/embed/rust/src/micropython/buffer.rs
+++ b/core/embed/rust/src/micropython/buffer.rs
@@ -105,6 +105,17 @@ impl StrBuffer {
             off: self.off + off,
         }
     }
+
+    pub fn prefix(&self, bytes: usize) -> Self {
+        let new_len: u16 = unwrap!(bytes.try_into());
+        assert!(new_len <= self.len);
+        assert!(self.as_ref().is_char_boundary(bytes));
+        Self {
+            ptr: self.ptr,
+            len: new_len,
+            off: self.off,
+        }
+    }
 }
 
 impl Default for StrBuffer {

--- a/core/embed/rust/src/micropython/buffer.rs
+++ b/core/embed/rust/src/micropython/buffer.rs
@@ -21,6 +21,7 @@ use super::ffi;
 /// substring slices while keeping the head pointer as required by GC.
 #[repr(C)]
 #[derive(Copy, Clone)]
+#[cfg_attr(test, derive(Debug))]
 pub struct StrBuffer {
     ptr: *const u8,
     len: u16,

--- a/core/embed/rust/src/smp/base64.rs
+++ b/core/embed/rust/src/smp/base64.rs
@@ -5,7 +5,7 @@
 /// - `InvalidLength` if the input length is not a multiple of 4 for decoding.
 /// - `InvalidCharacter` if an invalid Base64 character is encountered during
 ///   decoding.
-#[derive(Debug)]
+#[cfg_attr(test, derive(Debug))]
 pub enum Base64Error {
     OutputBufferTooSmall,
     InvalidLength,

--- a/core/embed/rust/src/smp/base64.rs
+++ b/core/embed/rust/src/smp/base64.rs
@@ -127,7 +127,6 @@ extern crate std;
 #[cfg(test)]
 mod tests {
     use super::*;
-    use std::vec::Vec;
 
     #[test]
     fn test_encode_decode() {

--- a/core/embed/rust/src/smp/mod.rs
+++ b/core/embed/rust/src/smp/mod.rs
@@ -61,7 +61,7 @@ static SMP_RECEIVER: ReceiverStorage = ReceiverStorage(UnsafeCell::new(None));
 /// SMP_RECEIVER without locking IRQ, data races could occur.
 unsafe impl Sync for ReceiverStorage {}
 
-#[derive(Debug)]
+#[cfg_attr(test, derive(Debug))]
 pub enum SmpError {
     Timeout,
     WrongMessage,

--- a/core/embed/rust/src/strutil.rs
+++ b/core/embed/rust/src/strutil.rs
@@ -141,6 +141,7 @@ pub fn plural_form(template: &str, count: u32) -> ShortString {
 }
 
 #[derive(Copy, Clone)]
+#[cfg_attr(test, derive(Debug))]
 pub enum TString<'a> {
     #[cfg(feature = "micropython")]
     Allocated(StrBuffer),

--- a/core/embed/rust/src/translations/generated/translated_string.rs
+++ b/core/embed/rust/src/translations/generated/translated_string.rs
@@ -8,6 +8,7 @@ use crate::micropython::qstr::Qstr;
 
 #[derive(Copy, Clone, FromPrimitive, PartialEq, Eq, PartialOrd, Ord)]
 #[cfg_attr(feature = "debug", derive(ufmt::derive::uDebug))]
+#[cfg_attr(test, derive(Debug))]
 #[repr(u16)]
 #[allow(non_camel_case_types)]
 pub enum TranslatedString {

--- a/core/embed/rust/src/translations/generated/translated_string.rs.mako
+++ b/core/embed/rust/src/translations/generated/translated_string.rs.mako
@@ -38,6 +38,7 @@ use crate::micropython::qstr::Qstr;
 
 #[derive(Copy, Clone, FromPrimitive, PartialEq, Eq, PartialOrd, Ord)]
 #[cfg_attr(feature = "debug", derive(ufmt::derive::uDebug))]
+#[cfg_attr(test, derive(Debug))]
 #[repr(u16)]
 #[allow(non_camel_case_types)]
 pub enum TranslatedString {

--- a/core/embed/rust/src/ui/layout_caesar/component/scrollbar.rs
+++ b/core/embed/rust/src/ui/layout_caesar/component/scrollbar.rs
@@ -16,7 +16,7 @@ pub struct ScrollBar {
 }
 
 /// Carrying the appearance of the scrollbar dot.
-#[derive(Debug)]
+#[cfg_attr(test, derive(Debug))]
 enum DotType {
     BigFull, // *
     Big,     // O


### PR DESCRIPTION
It will be used to implement `TString`-based interpolation in #5687.

Also, add unit-tests for `TString` slicing operation.

Rebased over #5689.