### PR TITLE
chore(core): remove "Continue in the app" screen after label is set

### DIFF
--- a/core/src/trezor/ui/layouts/eckhart/__init__.py
+++ b/core/src/trezor/ui/layouts/eckhart/__init__.py
@@ -230,8 +230,6 @@ async def confirm_change_label(
         verb=None,
     )
 
-    show_continue_in_app(TR.device_name__changed)
-
 
 def confirm_change_passphrase(use: bool) -> Awaitable[None]:
     description = TR.passphrase__turn_on if use else TR.passphrase__turn_off


### PR DESCRIPTION
It was added to T3W1, but not to other Core models - and unfortunately, it results in a timeout when using Suite Desktop.