### PR TITLE
fix(core): correct BLE MAC address display

### DIFF
--- a/core/src/apps/homescreen/device_menu.py
+++ b/core/src/apps/homescreen/device_menu.py
@@ -9,7 +9,8 @@ BLE_MAX_BONDS = 8
 
 
 def _format_mac(ble_addr: bytes) -> str:
-    return ":".join(f"{byte:02X}" for byte in ble_addr)
+    """Internal MAC address representation is using reversed byte order."""
+    return ":".join(f"{byte:02X}" for byte in reversed(ble_addr))
 
 
 def _find_device(connected_addr: bytes | None, bonds: list[bytes]) -> int | None:


### PR DESCRIPTION
Otherwise, the device displays BLE MAC address bytes in reversed order.