### PR TITLE
Erase BLE bonds when wiping the device

### DIFF
--- a/core/src/apps/management/wipe_device.py
+++ b/core/src/apps/management/wipe_device.py
@@ -1,5 +1,6 @@
 from typing import TYPE_CHECKING
 
+from trezor import utils
 from trezor.wire.context import get_context, try_get_ctx_ids
 
 if TYPE_CHECKING:
@@ -58,5 +59,12 @@ async def wipe_device(msg: WipeDevice) -> NoReturn:
 
     # reload settings
     reload_settings_from_storage()
+
+    if utils.USE_BLE:
+        from trezorble import erase_bonds
+
+        # raise an exception if bonds erasing fails
+        erase_bonds()
+
     if __debug__:
         log.debug(__name__, "Device wipe - finished")

--- a/core/src/trezor/wire/context.py
+++ b/core/src/trezor/wire/context.py
@@ -218,6 +218,6 @@ def cache_delete(key: int) -> None:
 def _get_cache_for_key(key: int) -> DataCache:
     if key & SESSIONLESS_FLAG:
         return cache.get_sessionless_cache()
-    if CURRENT_CONTEXT:
-        return CURRENT_CONTEXT.cache
-    raise Exception("No wire context")
+    if CURRENT_CONTEXT is None:
+        raise NoWireContext
+    return CURRENT_CONTEXT.cache

--- a/core/src/trezor/wire/context.py
+++ b/core/src/trezor/wire/context.py
@@ -151,7 +151,10 @@ def try_get_ctx_ids() -> tuple[bytes, bytes] | None:
     if utils.USE_THP:
         from trezor.wire.thp.session_context import GenericSessionContext
 
-        ctx = get_context()
+        try:
+            ctx = get_context()
+        except NoWireContext:
+            return None
         if isinstance(ctx, GenericSessionContext):
             ids = (ctx.channel_id, ctx.session_id.to_bytes(1, "big"))
     return ids

--- a/tests/persistence_tests/test_shamir_persistence.py
+++ b/tests/persistence_tests/test_shamir_persistence.py
@@ -83,6 +83,9 @@ def test_abort(core_emulator: Emulator):
             common.go_next(debug)
 
     assert debug.read_layout().main_component() == "Homescreen"
+
+    # create a new client, since the existing THP channel state has been wiped
+    device_handler = BackgroundDeviceHandler(core_emulator.client.get_new_client())
     features = device_handler.features()
     assert features.recovery_status == RecoveryStatus.Nothing
 


### PR DESCRIPTION
[Slack](https://satoshilabs.slack.com/archives/C082Q0Y6WP3/p1756967548060319)

Also, don't fail when cancelling recovery via UI:
```
12.414 trezor.loop ERROR exception:
Traceback (most recent call last):
  File "trezor/loop.py", line 162, in _step
  File "apps/management/recovery_device/homescreen.py", line 33, in recovery_homescreen
  File "apps/management/recovery_device/homescreen.py", line 65, in recovery_process
  File "trezor/wire/context.py", line 154, in try_get_ctx_ids
  File "trezor/wire/context.py", line 114, in get_context
NoWireContext: 
```