### PR TITLE
Add type annotation to `loop.py`

### DIFF
--- a/core/embed/rust/src/ui/api/firmware_micropython.rs
+++ b/core/embed/rust/src/ui/api/firmware_micropython.rs
@@ -1303,6 +1303,7 @@ pub extern "C" fn upy_backlight_fade(_level: Obj) -> Obj {
 #[no_mangle]
 pub static mp_module_trezorui_api: Module = obj_module! {
     /// from trezor import utils
+    /// from trezor.enums import ButtonRequestType
     ///
     /// PropertyType = tuple[str | None, str | bytes | None, bool | None]
     /// T = TypeVar("T")
@@ -1379,7 +1380,7 @@ pub static mp_module_trezorui_api: Module = obj_module! {
     ///     def page_count(self) -> int:
     ///         """Return the number of pages in the layout object."""
     ///
-    ///     def button_request(self) -> tuple[int, str] | None:
+    ///     def button_request(self) -> tuple[ButtonRequestType, str] | None:
     ///         """Return (code, type) of button request made during the last event or timer pass."""
     ///
     ///     def get_transition_out(self) -> AttachType:

--- a/core/mocks/generated/trezorui_api.pyi
+++ b/core/mocks/generated/trezorui_api.pyi
@@ -1,5 +1,6 @@
 from typing import *
 from trezor import utils
+from trezor.enums import ButtonRequestType
 PropertyType = tuple[str | None, str | bytes | None, bool | None]
 T = TypeVar("T")
 
@@ -58,7 +59,7 @@ class LayoutObj(Generic[T]):
             """Paint bounds of individual components on screen."""
     def page_count(self) -> int:
         """Return the number of pages in the layout object."""
-    def button_request(self) -> tuple[int, str] | None:
+    def button_request(self) -> tuple[ButtonRequestType, str] | None:
         """Return (code, type) of button request made during the last event or timer pass."""
     def get_transition_out(self) -> AttachType:
         """Return the transition type."""

--- a/core/src/apps/debug/__init__.py
+++ b/core/src/apps/debug/__init__.py
@@ -41,7 +41,7 @@ if __debug__:
 
         Handler = Callable[[Any], Awaitable[Any]]
 
-    layout_change_box = loop.mailbox()
+    layout_change_box: loop.mailbox[Layout | None] = loop.mailbox()
 
     DEBUG_CONTEXT: Context | None = None
 
@@ -434,8 +434,8 @@ if __debug__:
         return Success()
 
     _EXIT_FLAG = False
-    _EXIT_BOX = loop.mailbox()
-    _SESSION_TASK: loop.spawn | None = None
+    _EXIT_BOX: loop.mailbox[None] = loop.mailbox()
+    _SESSION_TASK: loop.spawn[None] | None = None
 
     _CLOSE_TIMEOUT_MS = const(5000)
 


### PR DESCRIPTION
Added type annotation to `race`, `sleep`, and `spawn` functions in `loop.py`.

Type annotation for `wait` and `mailbox` would be nice too, but it is harder to do because the type cannot be (easily) inferred from the constructor. It either requires implementing "true" Generic, or passing the types to the constructor directly. There might be other solutions. However, I have not found anything nice-enough/user-friendly that would be without impact on PROD, yet.

EDIT:
Both `mailbox` and `wait` are annotated, too. However, `wait` annotation does not work properly yet as it would require additional changes mentioned here: https://github.com/trezor/trezor-firmware/pull/5713#issuecomment-3257947079