### PR TITLE
fix(core): enable debuglink when PYOPT=0

### DIFF
--- a/core/SConscript.firmware
+++ b/core/SConscript.firmware
@@ -75,6 +75,7 @@ if DISABLE_OPTIGA:
 
 if PYOPT == '0':
     DBG_CONSOLE = DBG_CONSOLE or "VCP"
+    FEATURES_WANTED += ["usb_iface_debug"]
 
 if DBG_CONSOLE != "":
     FEATURES_WANTED += ["dbg_console"]

--- a/core/SConscript.kernel
+++ b/core/SConscript.kernel
@@ -70,6 +70,7 @@ if BITCOIN_ONLY == '0':
 
 if PYOPT == '0':
     DBG_CONSOLE = DBG_CONSOLE or "VCP"
+    FEATURES_WANTED += ["usb_iface_debug"]
 
 if DBG_CONSOLE != "":
     FEATURES_WANTED += ["dbg_console"]

--- a/core/embed/io/usb/usb_config.c
+++ b/core/embed/io/usb/usb_config.c
@@ -213,8 +213,10 @@ static secbool usb_webauthn_iface_init(uint8_t *iface_num) {
 }
 #endif  // USE_USB_IFACE_WEBAUTHN
 
-#if defined(USE_USB_HS)
-#define VCP_PACKET_LEN 512
+#if defined(USE_USB_HS) && !defined(USE_USB_HS_IN_FS)
+#define VCP_PACKET_LEN 512  // HS periperal in HS mode
+#elif defined(USE_USB_HS) && defined(USE_USB_HS_IN_FS)
+#define VCP_PACKET_LEN 64  // HS peripheral in FS mode
 #elif defined(USE_USB_FS)
 #define VCP_PACKET_LEN 64
 #elif defined(TREZOR_EMULATOR)


### PR DESCRIPTION
This PR:

- Enables the debuglink interface in the hardware build when PYOPT=0, which was unintentionally disabled in #5619.
- Fixes an invalid buffer size used for VCP on STM32F4, which caused broken or missing functionality.

Fixes #5708
