### PR TITLE
refactor(core): optimize `SwipeConfig` memory

### DIFF
--- a/core/embed/rust/src/ui/component/swipe_detect.rs
+++ b/core/embed/rust/src/ui/component/swipe_detect.rs
@@ -11,24 +11,16 @@ use crate::{
 };
 
 #[derive(Copy, Clone)]
-pub struct SwipeSettings {
-    pub duration: Duration,
+pub enum SwipeSettings {
+    Default,
+    Immediate,
 }
 
 impl SwipeSettings {
-    pub const fn new(duration: Duration) -> Self {
-        Self { duration }
-    }
-
-    pub const fn default() -> Self {
-        Self {
-            duration: Duration::from_millis(333),
-        }
-    }
-
-    pub const fn immediate() -> Self {
-        Self {
-            duration: Duration::from_millis(0),
+    fn duration(&self) -> Duration {
+        match self {
+            Self::Default => Duration::from_millis(333),
+            Self::Immediate => Duration::from_millis(0),
         }
     }
 }
@@ -93,7 +85,7 @@ impl SwipeConfig {
     }
 
     pub fn duration(&self, dir: Direction) -> Option<Duration> {
-        self[dir].as_ref().map(|s| s.duration)
+        self[dir].as_ref().map(|s| s.duration())
     }
 
     pub fn with_horizontal_pages(mut self) -> Self {
@@ -110,18 +102,18 @@ impl SwipeConfig {
         match self.page_axis {
             Some(Axis::Horizontal) => {
                 if pager.has_prev() {
-                    self.right = Some(SwipeSettings::default());
+                    self.right = Some(SwipeSettings::Default);
                 }
                 if pager.has_next() {
-                    self.left = Some(SwipeSettings::default());
+                    self.left = Some(SwipeSettings::Default);
                 }
             }
             Some(Axis::Vertical) => {
                 if pager.has_prev() {
-                    self.down = Some(SwipeSettings::default());
+                    self.down = Some(SwipeSettings::Default);
                 }
                 if pager.has_next() {
-                    self.up = Some(SwipeSettings::default());
+                    self.up = Some(SwipeSettings::Default);
                 }
             }
             _ => {}

--- a/core/embed/rust/src/ui/layout_delizia/component/frame.rs
+++ b/core/embed/rust/src/ui/layout_delizia/component/frame.rs
@@ -213,7 +213,7 @@ where
         use crate::translations::TR;
 
         self.with_footer(TR::instructions__tap.into(), description)
-            .with_swipe(Direction::Up, SwipeSettings::default())
+            .with_swipe(Direction::Up, SwipeSettings::Default)
     }
 
     #[cfg(feature = "translations")]
@@ -221,7 +221,7 @@ where
         use crate::translations::TR;
 
         self.with_footer(TR::instructions__tap_to_continue.into(), description)
-            .with_swipe(Direction::Up, SwipeSettings::default())
+            .with_swipe(Direction::Up, SwipeSettings::Default)
     }
 
     #[inline(never)]

--- a/core/embed/rust/src/ui/layout_delizia/flow/confirm_action.rs
+++ b/core/embed/rust/src/ui/layout_delizia/flow/confirm_action.rs
@@ -413,7 +413,7 @@ fn create_confirm(
 
         let mut content_confirm = Frame::left_aligned(prompt_title, SwipeContent::new(prompt))
             .with_footer(prompt_action, None)
-            .with_swipe(Direction::Down, SwipeSettings::default());
+            .with_swipe(Direction::Down, SwipeSettings::Default);
 
         if matches!(extra, ConfirmActionExtra::Menu(_)) {
             content_confirm = content_confirm.with_menu_button();

--- a/core/embed/rust/src/ui/layout_delizia/flow/confirm_fido.rs
+++ b/core/embed/rust/src/ui/layout_delizia/flow/confirm_fido.rs
@@ -139,7 +139,7 @@ pub fn new_confirm_fido(
         TR::instructions__swipe_down.into(),
     )
     .register_footer_update_fn(footer_update_fn)
-    .with_swipe(Direction::Down, SwipeSettings::default())
+    .with_swipe(Direction::Down, SwipeSettings::Default)
     .with_vertical_pages()
     .map(super::util::map_to_choice);
 
@@ -163,7 +163,7 @@ pub fn new_confirm_fido(
     let content_tap = Frame::left_aligned(title, PromptScreen::new_tap_to_confirm())
         .with_menu_button()
         .with_footer(TR::instructions__tap_to_confirm.into(), None)
-        .with_swipe(Direction::Down, SwipeSettings::default())
+        .with_swipe(Direction::Down, SwipeSettings::Default)
         .map(super::util::map_to_confirm);
 
     let content_menu = Frame::left_aligned(

--- a/core/embed/rust/src/ui/layout_delizia/flow/confirm_firmware_update.rs
+++ b/core/embed/rust/src/ui/layout_delizia/flow/confirm_firmware_update.rs
@@ -97,7 +97,7 @@ pub fn new_confirm_firmware_update(
     )
     .with_menu_button()
     .with_footer(TR::instructions__hold_to_confirm.into(), None)
-    .with_swipe(Direction::Down, SwipeSettings::default())
+    .with_swipe(Direction::Down, SwipeSettings::Default)
     .map(super::util::map_to_confirm);
 
     let mut res = SwipeFlow::new(&ConfirmFirmwareUpdate::Intro)?;

--- a/core/embed/rust/src/ui/layout_delizia/flow/confirm_homescreen.rs
+++ b/core/embed/rust/src/ui/layout_delizia/flow/confirm_homescreen.rs
@@ -76,7 +76,7 @@ pub fn new_confirm_homescreen(
     )
     .with_menu_button()
     .with_footer(TR::instructions__tap_to_confirm.into(), None)
-    .with_swipe(Direction::Down, SwipeSettings::default())
+    .with_swipe(Direction::Down, SwipeSettings::Default)
     .map(super::util::map_to_confirm);
 
     let mut res = SwipeFlow::new(&ConfirmHomescreen::Homescreen)?;

--- a/core/embed/rust/src/ui/layout_delizia/flow/confirm_output.rs
+++ b/core/embed/rust/src/ui/layout_delizia/flow/confirm_output.rs
@@ -277,7 +277,7 @@ pub fn new_confirm_output(
         )
         .with_menu_button()
         .with_footer(TR::instructions__hold_to_sign.into(), None)
-        .with_swipe(Direction::Down, SwipeSettings::default())
+        .with_swipe(Direction::Down, SwipeSettings::Default)
         .map(super::util::map_to_confirm);
 
         // FeeInfo

--- a/core/embed/rust/src/ui/layout_delizia/flow/confirm_reset.rs
+++ b/core/embed/rust/src/ui/layout_delizia/flow/confirm_reset.rs
@@ -131,7 +131,7 @@ pub fn new_confirm_reset(recovery: bool) -> Result<SwipeFlow, error::Error> {
         )
         .with_menu_button()
         .with_footer(TR::instructions__hold_to_confirm.into(), None)
-        .with_swipe(Direction::Down, SwipeSettings::default())
+        .with_swipe(Direction::Down, SwipeSettings::Default)
         .map(super::util::map_to_confirm)
         .one_button_request(ButtonRequestCode::ResetDevice.with_name("confirm_setup_device"));
 

--- a/core/embed/rust/src/ui/layout_delizia/flow/confirm_set_new_pin.rs
+++ b/core/embed/rust/src/ui/layout_delizia/flow/confirm_set_new_pin.rs
@@ -93,7 +93,7 @@ pub fn new_set_new_pin(
     )
     .with_cancel_button()
     .with_footer(TR::instructions__tap_to_confirm.into(), None)
-    .with_swipe(Direction::Down, SwipeSettings::default())
+    .with_swipe(Direction::Down, SwipeSettings::Default)
     .map(super::util::map_to_confirm);
 
     let mut res = SwipeFlow::new(&SetNewPin::Intro)?;

--- a/core/embed/rust/src/ui/layout_delizia/flow/confirm_summary.rs
+++ b/core/embed/rust/src/ui/layout_delizia/flow/confirm_summary.rs
@@ -90,7 +90,7 @@ pub fn new_confirm_summary(
     )
     .with_menu_button()
     .with_footer(TR::instructions__hold_to_sign.into(), None)
-    .with_swipe(Direction::Down, SwipeSettings::default())
+    .with_swipe(Direction::Down, SwipeSettings::Default)
     .map(super::util::map_to_confirm);
 
     // ExtraInfo

--- a/core/embed/rust/src/ui/layout_delizia/flow/continue_recovery_homepage.rs
+++ b/core/embed/rust/src/ui/layout_delizia/flow/continue_recovery_homepage.rs
@@ -208,7 +208,7 @@ pub fn new_continue_recovery_homepage(
     )
     .with_cancel_button()
     .with_footer(TR::instructions__tap_to_confirm.into(), None)
-    .with_swipe(Direction::Down, SwipeSettings::default())
+    .with_swipe(Direction::Down, SwipeSettings::Default)
     .map(super::util::map_to_confirm);
 
     let res = if show_instructions {
@@ -253,7 +253,7 @@ pub fn new_continue_recovery_homepage(
             TR::instructions__swipe_down.into(),
         )
         .register_footer_update_fn(footer_update_fn)
-        .with_swipe(Direction::Up, SwipeSettings::default())
+        .with_swipe(Direction::Up, SwipeSettings::Default)
         .with_vertical_pages()
         .map_to_button_msg()
         .repeated_button_request(ButtonRequest::new(

--- a/core/embed/rust/src/ui/layout_delizia/flow/prompt_backup.rs
+++ b/core/embed/rust/src/ui/layout_delizia/flow/prompt_backup.rs
@@ -87,7 +87,7 @@ pub fn new_prompt_backup() -> Result<SwipeFlow, error::Error> {
     )
     .with_cancel_button()
     .with_swipeup_footer(Some(TR::words__continue_anyway_question.into()))
-    .with_swipe(Direction::Up, SwipeSettings::default())
+    .with_swipe(Direction::Up, SwipeSettings::Default)
     .map_to_button_msg();
 
     let content_skip_confirm = Frame::left_aligned(
@@ -96,7 +96,7 @@ pub fn new_prompt_backup() -> Result<SwipeFlow, error::Error> {
     )
     .with_cancel_button()
     .with_footer(TR::instructions__tap_to_confirm.into(), None)
-    .with_swipe(Direction::Down, SwipeSettings::default())
+    .with_swipe(Direction::Down, SwipeSettings::Default)
     .map(super::util::map_to_confirm);
 
     let mut res = SwipeFlow::new(&PromptBackup::Intro)?;

--- a/core/embed/rust/src/ui/layout_delizia/flow/receive.rs
+++ b/core/embed/rust/src/ui/layout_delizia/flow/receive.rs
@@ -123,7 +123,7 @@ pub fn new_receive(
     let content_tap =
         Frame::left_aligned(title, SwipeContent::new(PromptScreen::new_tap_to_confirm()))
             .with_footer(TR::instructions__tap_to_confirm.into(), None)
-            .with_swipe(Direction::Down, SwipeSettings::default())
+            .with_swipe(Direction::Down, SwipeSettings::Default)
             .map(super::util::map_to_confirm);
 
     // Menu
@@ -175,7 +175,7 @@ pub fn new_receive(
         Frame::left_aligned(cancel_title.into(), PromptScreen::new_tap_to_cancel())
             .with_cancel_button()
             .with_footer(TR::instructions__tap_to_confirm.into(), None)
-            .with_swipe(Direction::Down, SwipeSettings::default())
+            .with_swipe(Direction::Down, SwipeSettings::Default)
             .map(super::util::map_to_confirm);
 
     let mut res = SwipeFlow::new(&Receive::Content)?;

--- a/core/embed/rust/src/ui/layout_delizia/flow/set_brightness.rs
+++ b/core/embed/rust/src/ui/layout_delizia/flow/set_brightness.rs
@@ -79,7 +79,7 @@ pub fn new_set_brightness(brightness: u8) -> Result<SwipeFlow, Error> {
     )
     .with_subtitle(TR::homescreen__settings_subtitle.into())
     .with_cancel_button()
-    .with_swipe(Direction::Up, SwipeSettings::default())
+    .with_swipe(Direction::Up, SwipeSettings::Default)
     .with_footer(
         TR::instructions__swipe_horizontally.into(),
         Some(TR::setting__adjust.into()),

--- a/core/embed/rust/src/ui/layout_delizia/flow/show_share_words.rs
+++ b/core/embed/rust/src/ui/layout_delizia/flow/show_share_words.rs
@@ -106,8 +106,8 @@ pub fn new_show_share_words(
         title,
         InternallySwipableContent::new(ShareWords::new(share_words_vec, subtitle)),
     )
-    .with_swipe(Direction::Up, SwipeSettings::default())
-    .with_swipe(Direction::Down, SwipeSettings::default())
+    .with_swipe(Direction::Up, SwipeSettings::Default)
+    .with_swipe(Direction::Down, SwipeSettings::Default)
     .with_vertical_pages()
     .with_subtitle(subtitle)
     .register_header_update_fn(header_updating_func)
@@ -120,7 +120,7 @@ pub fn new_show_share_words(
         SwipeContent::new(PromptScreen::new_hold_to_confirm()),
     )
     .with_footer(TR::instructions__hold_to_confirm.into(), None)
-    .with_swipe(Direction::Down, SwipeSettings::default())
+    .with_swipe(Direction::Down, SwipeSettings::Default)
     .map(|_| Some(FlowMsg::Confirmed));
 
     let content_check_backup_intro = Frame::left_aligned(

--- a/core/embed/rust/src/ui/layout_delizia/flow/show_tutorial.rs
+++ b/core/embed/rust/src/ui/layout_delizia/flow/show_tutorial.rs
@@ -94,7 +94,7 @@ pub fn new_show_tutorial() -> Result<SwipeFlow, error::Error> {
         ))),
     )
     .with_swipeup_footer(None)
-    .with_swipe(Direction::Down, SwipeSettings::default())
+    .with_swipe(Direction::Down, SwipeSettings::Default)
     .map_to_button_msg();
 
     let content_step_menu = Frame::left_aligned(
@@ -107,7 +107,7 @@ pub fn new_show_tutorial() -> Result<SwipeFlow, error::Error> {
     .with_menu_button()
     .button_styled(theme::button_warning_low())
     .with_swipeup_footer(None)
-    .with_swipe(Direction::Down, SwipeSettings::default())
+    .with_swipe(Direction::Down, SwipeSettings::Default)
     .map_to_button_msg();
 
     let content_step_hold = Frame::left_aligned(
@@ -115,7 +115,7 @@ pub fn new_show_tutorial() -> Result<SwipeFlow, error::Error> {
         SwipeContent::new(PromptScreen::new_hold_to_confirm()),
     )
     .with_footer(TR::instructions__hold_to_exit_tutorial.into(), None)
-    .with_swipe(Direction::Down, SwipeSettings::default())
+    .with_swipe(Direction::Down, SwipeSettings::Default)
     .map(super::util::map_to_confirm);
 
     let content_step_done = Frame::left_aligned(
@@ -153,7 +153,7 @@ pub fn new_show_tutorial() -> Result<SwipeFlow, error::Error> {
         SwipeContent::new(PromptScreen::new_hold_to_confirm_danger()),
     )
     .with_footer(TR::instructions__hold_to_exit_tutorial.into(), None)
-    .with_swipe(Direction::Down, SwipeSettings::default())
+    .with_swipe(Direction::Down, SwipeSettings::Default)
     .map(super::util::map_to_confirm);
 
     let mut res = SwipeFlow::new(&ShowTutorial::StepWelcome)?;

--- a/core/embed/rust/src/ui/layout_delizia/flow/util.rs
+++ b/core/embed/rust/src/ui/layout_delizia/flow/util.rs
@@ -268,15 +268,15 @@ impl ConfirmValue {
         }
 
         if self.swipe_up {
-            frame = frame.with_swipe(Direction::Up, SwipeSettings::default());
+            frame = frame.with_swipe(Direction::Up, SwipeSettings::Default);
         }
 
         if self.swipe_down {
-            frame = frame.with_swipe(Direction::Down, SwipeSettings::default());
+            frame = frame.with_swipe(Direction::Down, SwipeSettings::Default);
         }
 
         if self.swipe_right {
-            frame = frame.with_swipe(Direction::Right, SwipeSettings::default());
+            frame = frame.with_swipe(Direction::Right, SwipeSettings::Default);
         }
 
         frame = frame.with_vertical_pages();
@@ -455,7 +455,7 @@ impl ShowInfoParams {
         if self.cancel_button {
             frame = frame
                 .with_cancel_button()
-                .with_swipe(Direction::Right, SwipeSettings::immediate());
+                .with_swipe(Direction::Right, SwipeSettings::Immediate);
         } else if self.menu_button {
             frame = frame.with_menu_button()
         }
@@ -464,11 +464,11 @@ impl ShowInfoParams {
         }
 
         if self.swipe_up {
-            frame = frame.with_swipe(Direction::Up, SwipeSettings::default());
+            frame = frame.with_swipe(Direction::Up, SwipeSettings::Default);
         }
 
         if self.swipe_down {
-            frame = frame.with_swipe(Direction::Down, SwipeSettings::default());
+            frame = frame.with_swipe(Direction::Down, SwipeSettings::Default);
         }
 
         frame = frame.with_vertical_pages();

--- a/core/embed/rust/src/ui/layout_delizia/ui_firmware.rs
+++ b/core/embed/rust/src/ui/layout_delizia/ui_firmware.rs
@@ -1291,7 +1291,7 @@ impl FirmwareUI for UIDelizia {
                 SwipeContent::new(content).with_no_attach_anim(),
             )
             .with_footer(instruction, description)
-            .with_swipe(Direction::Up, SwipeSettings::default())
+            .with_swipe(Direction::Up, SwipeSettings::Default)
             .with_result_icon(theme::ICON_BULLET_CHECKMARK, theme::GREEN_LIGHT),
         ))?;
         Ok(layout)

--- a/core/embed/rust/src/ui/layout_eckhart/firmware/vertical_menu_screen.rs
+++ b/core/embed/rust/src/ui/layout_eckhart/firmware/vertical_menu_screen.rs
@@ -54,8 +54,8 @@ impl<T: MenuItems> VerticalMenuScreen<T> {
             offset_base: 0,
             swipe: None,
             swipe_config: SwipeConfig::new()
-                .with_swipe(Direction::Up, SwipeSettings::default())
-                .with_swipe(Direction::Down, SwipeSettings::default()),
+                .with_swipe(Direction::Up, SwipeSettings::Default)
+                .with_swipe(Direction::Down, SwipeSettings::Default),
         }
     }
 


### PR DESCRIPTION
After:
```
print-type-size type: `ui::component::swipe_detect::SwipeConfig`: 5 bytes, alignment: 1 bytes
print-type-size     field `.page_axis`: 1 bytes
print-type-size     field `.up`: 1 bytes
print-type-size     field `.down`: 1 bytes
print-type-size     field `.left`: 1 bytes
print-type-size     field `.right`: 1 bytes
```

Before:
```
print-type-size type: `ui::component::swipe_detect::SwipeConfig`: 36 bytes, alignment: 4 bytes
print-type-size     field `.up`: 8 bytes
print-type-size     field `.down`: 8 bytes
print-type-size     field `.left`: 8 bytes
print-type-size     field `.right`: 8 bytes
print-type-size     field `.page_axis`: 1 bytes
print-type-size     end padding: 3 bytes
```

[no changelog]

<!--
For core developers:
- Assign yourself to the PR.
- Set the priority to match the original issue.
- Add the PR to the current sprint.
- If it's a draft PR, mark it as "In Progress."
- If it's a final PR, mark it as "Needs Review."

For external contributors:
- Please open an issue before submitting a PR so we can discuss whether we want to proceed with it.
-->
