### PR TITLE
T3W1 startup adjustment

### DIFF
--- a/core/embed/projects/bootloader/workflow/wf_empty_device.c
+++ b/core/embed/projects/bootloader/workflow/wf_empty_device.c
@@ -33,6 +33,10 @@
 #include <sys/backup_ram.h>
 #endif
 
+#ifdef USE_BLE
+#include <io/ble.h>
+#endif
+
 #include "bootui.h"
 #include "rust_ui_bootloader.h"
 #include "workflow.h"
@@ -46,6 +50,18 @@ workflow_result_t workflow_empty_device(void) {
   ensure(erase_storage(NULL), NULL);
 #ifdef USE_BACKUP_RAM
   ensure(backup_ram_erase_protected() * sectrue, NULL);
+#endif
+
+#ifdef USE_BLE
+  screen_boot_empty();
+  uint32_t timeout = ticks_timeout(5000);
+  ble_state_t state = {0};
+  do {
+    ble_get_state(&state);
+    if (state.state_known) {
+      break;
+    }
+  } while (!ticks_expired(timeout));
 #endif
 
   protob_ios_t ios;

--- a/core/embed/rust/rust_ui_bootloader.h
+++ b/core/embed/rust/rust_ui_bootloader.h
@@ -35,6 +35,7 @@ void screen_bootloader_entry_progress(uint16_t progress, bool initialize);
 // simple screens with no interaction
 
 void screen_boot_stage_1(bool fading);
+void screen_boot_empty(void);
 void screen_boot(bool warning, const char* vendor_str, size_t vendor_str_len,
                  uint32_t version, const void* vendor_img,
                  size_t vendor_img_len, int wait);

--- a/core/embed/rust/src/ui/api/bootloader_c.rs
+++ b/core/embed/rust/src/ui/api/bootloader_c.rs
@@ -141,6 +141,11 @@ extern "C" fn screen_boot_stage_1(fading: bool) {
 }
 
 #[no_mangle]
+extern "C" fn screen_boot_empty() {
+    ModelUI::screen_boot_empty()
+}
+
+#[no_mangle]
 extern "C" fn screen_boot(
     warning: bool,
     vendor_str: *const cty::c_char,

--- a/core/embed/rust/src/ui/layout_eckhart/ui_bootloader.rs
+++ b/core/embed/rust/src/ui/layout_eckhart/ui_bootloader.rs
@@ -16,7 +16,7 @@ use super::{
         BldActionBar, BldHeader, BldHeaderMsg, BldMenuScreen, BldTextScreen, BldWelcomeScreen,
         ConnectScreen, WirelessSetupScreen,
     },
-    component::Button,
+    component::{render_logo, Button},
     cshape::{render_loader, ScreenBorder},
     fonts::{FONT_SATOSHI_MEDIUM_26, FONT_SATOSHI_REGULAR_38},
     theme::{
@@ -120,7 +120,7 @@ impl BootloaderLayoutType for BootloaderLayout {
 
     fn show(&mut self) -> u32 {
         match self {
-            BootloaderLayout::Welcome(f) => show(f, true),
+            BootloaderLayout::Welcome(f) => show(f, false),
             BootloaderLayout::Menu(f) => show(f, true),
             BootloaderLayout::Connect(f) => show(f, true),
             #[cfg(feature = "ble")]
@@ -366,6 +366,15 @@ impl BootloaderUI for UIEckhart {
     }
 
     fn screen_boot_stage_1(_fading: bool) {}
+
+    fn screen_boot_empty() {
+        render_on_display(None, Some(BLACK), |target| {
+            render_logo(target);
+        });
+
+        display::refresh();
+        Self::fadein();
+    }
 
     fn screen_wipe_progress(progress: u16, initialize: bool) {
         Self::screen_progress(

--- a/core/embed/rust/src/ui/ui_bootloader.rs
+++ b/core/embed/rust/src/ui/ui_bootloader.rs
@@ -44,6 +44,10 @@ pub trait BootloaderUI {
 
     fn screen_boot_stage_1(fading: bool);
 
+    fn screen_boot_empty() {
+        unimplemented!();
+    }
+
     fn screen_wipe_progress(progress: u16, initialize: bool);
 
     fn screen_install_progress(progress: u16, initialize: bool, initial_setup: bool);


### PR DESCRIPTION
This PR adjust startup of empty T3W1 device. Since nRF is starting slow, its undesirable to immediately show controls to user as clicking these will lead to failures. Let just show logo and wait for nRF being ready
