### PR TITLE
chore(core/eckhart): enable going back in the 1st recovery word

### DIFF
--- a/core/src/apps/management/recovery_device/homescreen.py
+++ b/core/src/apps/management/recovery_device/homescreen.py
@@ -134,6 +134,8 @@ async def _continue_recovery_process() -> Success:
 
         # if they were invalid or some checks failed we continue and request them again
         if not words:
+            if not is_first_step:
+                await _request_share_next_screen()
             continue
 
         try:

--- a/core/src/apps/management/recovery_device/layout.py
+++ b/core/src/apps/management/recovery_device/layout.py
@@ -56,9 +56,12 @@ async def request_mnemonic(
 
         if not word:
             # User has decided to go back
-            if i > 0:
-                words[i] = ""
-                i -= 1
+            if i == 0:
+                # Already at the first word; treat as cancel.
+                return None
+
+            words[i] = ""
+            i -= 1
             continue
 
         words[i] = word

--- a/core/src/trezor/ui/layouts/eckhart/recovery.py
+++ b/core/src/trezor/ui/layouts/eckhart/recovery.py
@@ -36,14 +36,13 @@ async def request_word(
     prefill_word: str = "",
 ) -> str:
     prompt = TR.recovery__word_x_of_y_template.format(word_index + 1, word_count)
-    can_go_back = word_index > 0
     if is_slip39:
         keyboard = trezorui_api.request_slip39(
-            prompt=prompt, prefill_word=prefill_word, can_go_back=can_go_back
+            prompt=prompt, prefill_word=prefill_word, can_go_back=True
         )
     else:
         keyboard = trezorui_api.request_bip39(
-            prompt=prompt, prefill_word=prefill_word, can_go_back=can_go_back
+            prompt=prompt, prefill_word=prefill_word, can_go_back=True
         )
 
     word: str = await interact(

--- a/tests/input_flows.py
+++ b/tests/input_flows.py
@@ -2674,6 +2674,28 @@ class InputFlowSlip39BasicRecoveryAbortBetweenShares(InputFlowBase):
         yield from self.REC.abort_recovery_between_shares()
 
 
+class InputFlowSlip39BasicRecoveryAbortOnMnemonic(InputFlowBase):
+    def __init__(self, client: Client, shares: list[str], cancel_first: bool):
+        super().__init__(client)
+        self.first_share = shares[0].split(" ")
+        self.word_count = len(self.first_share)
+        self.cancel_first = cancel_first
+
+    def input_flow_eckhart(self) -> BRGeneratorType:
+        yield from self.REC.confirm_recovery()
+        yield from self.REC.input_number_of_words(20)
+        yield from self.REC.enter_any_share()
+        if not self.cancel_first:
+            yield from self.REC.input_mnemonic(self.first_share)
+            yield from self.REC.success_more_shares_needed()
+        yield from self.REC.go_back_from_mnemonic_first_word()
+
+        if self.cancel_first:
+            yield from self.REC.abort_recovery_select_number_of_words()
+        else:
+            yield from self.REC.abort_recovery_between_shares()
+
+
 class InputFlowSlip39BasicRecoveryShareInfoBetweenShares(InputFlowBase):
 
     def __init__(self, session: Session, shares: list[str]):

--- a/tests/input_flows_helpers.py
+++ b/tests/input_flows_helpers.py
@@ -206,6 +206,25 @@ class RecoveryFlow:
         else:
             raise ValueError("Unknown model!")
 
+    def go_back_from_mnemonic_first_word(self) -> BRGeneratorType:
+        yield
+        if self.client.layout_type is LayoutType.Eckhart:
+            # Go back from the first word input screen
+            assert "MnemonicKeyboard" in self.debug.read_layout().all_components()
+            self.debug.click(self.debug.screen_buttons.mnemonic_erase())
+        else:
+            raise ValueError("Unknown model!")
+
+    def abort_recovery_select_number_of_words(self) -> BRGeneratorType:
+        yield
+        if self.client.layout_type is LayoutType.Eckhart:
+            # Cancel the word count screen
+            assert "SelectWordCountScreen" in self.debug.read_layout().all_components()
+            self.debug.click(self.debug.screen_buttons.word_count_all_cancel())
+
+        else:
+            raise ValueError("Unknown model!")
+
     def share_info_between_shares(self) -> BRGeneratorType:
         yield
         if self.client.layout_type is LayoutType.Eckhart:


### PR DESCRIPTION
### 1st-share back behavior
- [x] The flow goes back to the word number selection

### Higher-share back behavior
- [x] go to the previous checkpoint

### TODO
- [x] device/click tests
- [ ] Find out why the fixtures for other models changed.


<!--
For core developers:
- Assign yourself to the PR.
- Set the priority to match the original issue.
- Add the PR to the current sprint.
- If it's a draft PR, mark it as "In Progress."
- If it's a final PR, mark it as "Needs Review."

For external contributors:
- Please open an issue before submitting a PR so we can discuss whether we want to proceed with it.
-->
