### PR TITLE
feat(core): trim strings to specific bytes' limit

### DIFF
--- a/core/src/trezor/strings.py
+++ b/core/src/trezor/strings.py
@@ -153,3 +153,16 @@ def format_autolock_duration(auto_lock_ms: int) -> str:
         auto_lock_label = TR.plurals__lock_after_x_seconds
 
     return format_plural("{count} {plural}", auto_lock_num, auto_lock_label)
+
+
+def trim_str(s: str, max_bytes: int) -> str:
+    """
+    Trim a string, so the result's byte size will be less or equal to `max_bytes`.
+    """
+    assert max_bytes >= 0
+    for i, char in enumerate(s):
+        char_size = len(char.encode())
+        if max_bytes < char_size:
+            return s[:i]
+        max_bytes -= char_size
+    return s

--- a/core/tests/test_trezor.strings.py
+++ b/core/tests/test_trezor.strings.py
@@ -222,6 +222,27 @@ class TestStrings(unittest.TestCase):
 
         strings.format_timestamp(1616057224)
 
+    def test_trim_str(self):
+        # test ASCII
+        self.assertEqual(strings.trim_str("123", 4), "123")
+        self.assertEqual(strings.trim_str("123", 3), "123")
+        self.assertEqual(strings.trim_str("123", 2), "12")
+        self.assertEqual(strings.trim_str("123", 1), "1")
+        self.assertEqual(strings.trim_str("123", 0), "")
+
+        # test non-ASCII
+        self.assertEqual(strings.trim_str("➀➁➂", 10), "➀➁➂")
+        self.assertEqual(strings.trim_str("➀➁➂", 9), "➀➁➂")
+        self.assertEqual(strings.trim_str("➀➁➂", 8), "➀➁")
+        self.assertEqual(strings.trim_str("➀➁➂", 7), "➀➁")
+        self.assertEqual(strings.trim_str("➀➁➂", 6), "➀➁")
+        self.assertEqual(strings.trim_str("➀➁➂", 5), "➀")
+        self.assertEqual(strings.trim_str("➀➁➂", 4), "➀")
+        self.assertEqual(strings.trim_str("➀➁➂", 3), "➀")
+        self.assertEqual(strings.trim_str("➀➁➂", 2), "")
+        self.assertEqual(strings.trim_str("➀➁➂", 1), "")
+        self.assertEqual(strings.trim_str("➀➁➂", 0), "")
+
 
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
Will be used for trimming cached THP host names (https://satoshilabs.slack.com/docs/T0J8V2YBY/F09DU00DW0P).

<!--
For core developers:
- Assign yourself to the PR.
- Set the priority to match the original issue.
- Add the PR to the current sprint.
- If it's a draft PR, mark it as "In Progress."
- If it's a final PR, mark it as "Needs Review."

For external contributors:
- Please open an issue before submitting a PR so we can discuss whether we want to proceed with it.
-->
