### PR TITLE
Improve state handling around Tropic locking

### DIFF
--- a/core/embed/projects/prodtest/README.md
+++ b/core/embed/projects/prodtest/README.md
@@ -362,8 +362,7 @@ Updates the nRF firmware. Use `core/tools/bin_update.py` script to update the nR
 
 ### nrf-pair
 Writes the pairing secret to the nRF chip to pair it with the MCU.
-The command `secrets-init` must be executed before calling this command.
-Pairing needs to be done before writing device serial number in the OTP memory and before locking the Optiga chip.
+This command may be called only after `secrets-init` was executed and before `secrets-lock` is executed.
 
 Example:
 ```

--- a/core/embed/projects/prodtest/cmd/common.c
+++ b/core/embed/projects/prodtest/cmd/common.c
@@ -406,7 +406,7 @@ bool check_cert_chain(cli_t* cli, const uint8_t* chain, size_t chain_size,
                               sizeof(OID_SERIAL_NUMBER), &subject_sn,
                               &subject_sn_size)) {
         cli_error(cli, CLI_ERROR,
-                  "check_device_cert_chain, device_sn not set.");
+                  "check_device_cert_chain, serialNumber not set.");
       }
 
       if (subject_sn_size != device_sn_size ||

--- a/core/embed/projects/prodtest/cmd/prodtest_nrf.c
+++ b/core/embed/projects/prodtest/cmd/prodtest_nrf.c
@@ -24,10 +24,9 @@
 
 #include <io/nrf.h>
 #include <rtl/cli.h>
-#include <util/flash_otp.h>
+#include <sec/secret.h>
 
 #include "common.h"
-#include "prodtest_optiga.h"
 
 static void prodtest_nrf_communication(cli_t* cli) {
   cli_trace(cli, "Testing SPI communication...");
@@ -88,16 +87,10 @@ static void prodtest_nrf_pair(cli_t* cli) {
     return;
   }
 
-  if (OPTIGA_LOCKED_FALSE != get_optiga_locked_status(cli)) {
+  if (secfalse != secret_is_locked()) {
     cli_error(cli, CLI_ERROR,
-              "Optiga is not unlocked. Pairing is not allowed.");
+              "Secrets sector is locked. Pairing is not allowed.");
     return;
-  }
-
-  if (secfalse != flash_otp_is_locked(FLASH_OTP_BLOCK_DEVICE_SN)) {
-    cli_error(
-        cli, CLI_ERROR,
-        "OTP Device serial number block is locked. Pairing is not allowed.");
   }
 
   if (nrf_test_pair()) {

--- a/core/embed/projects/prodtest/cmd/prodtest_otp_variant.c
+++ b/core/embed/projects/prodtest/cmd/prodtest_otp_variant.c
@@ -142,6 +142,20 @@ static void prodtest_otp_variant_write(cli_t* cli) {
   }
 #endif
 
+#ifdef USE_TROPIC
+  tropic_locked_status tropic_status = get_tropic_locked_status(cli);
+
+  if (tropic_status == TROPIC_LOCKED_FALSE) {
+    cli_error(cli, CLI_ERROR, "Tropic not locked");
+    return;
+  }
+
+  if (tropic_status != TROPIC_LOCKED_TRUE) {
+    // Error reported by get_optiga_locked_status().
+    return;
+  }
+#endif
+
   if (sectrue == flash_otp_is_locked(FLASH_OTP_BLOCK_DEVICE_VARIANT)) {
     cli_error(cli, CLI_ERROR_LOCKED,
               "OTP block is locked and cannot be written again.");

--- a/core/embed/projects/prodtest/cmd/prodtest_otp_variant.c
+++ b/core/embed/projects/prodtest/cmd/prodtest_otp_variant.c
@@ -29,6 +29,10 @@
 #include <stdlib.h>
 #include "prodtest_optiga.h"
 
+#ifdef USE_TROPIC
+#include "prodtest_tropic.h"
+#endif
+
 static void prodtest_otp_variant_read(cli_t* cli) {
   if (cli_arg_count(cli) > 0) {
     cli_error_arg_count(cli);

--- a/core/embed/projects/prodtest/cmd/prodtest_tropic.h
+++ b/core/embed/projects/prodtest/cmd/prodtest_tropic.h
@@ -19,4 +19,16 @@
 
 #pragma once
 
+#include <rtl/cli.h>
+
+#include <libtropic.h>
+
+typedef enum {
+  TROPIC_LOCKED_TRUE,
+  TROPIC_LOCKED_FALSE,
+  TROPIC_LOCKED_ERROR,
+} tropic_locked_status;
+
+tropic_locked_status get_tropic_locked_status(cli_t* cli);
+
 bool prodtest_tropic_factory_session_start(lt_handle_t* tropic_handle);


### PR DESCRIPTION
Changes:
- Return `OK NO` in `tropic-lock-check` if Tropic hasn't been paired.
- Fail `secrets-init` if Tropic locking has already started so that we don't overwrite MCU's pairing secrets.
- Changed global static variable `tropic_is_paired` to a local static variable. It seems confusing to me that it can and was being read, when we don't know whether it has been set correctly.
- Make sure that Tropic is paired before locking. Probably not necessary, since if the privileged key works, everything is probably OK, and if it is partially paired, e.g. factory slot was not erased, then access to it's functionality should be blocked by the config. But better safe than sorry.