### PR TITLE
ci: continue on nix environment install timeout

### DIFF
--- a/.github/actions/environment/action.yml
+++ b/.github/actions/environment/action.yml
@@ -13,7 +13,7 @@ runs:
       with:
         nix_path: nixpkgs=channel:nixos-unstable
     - name: Dependencies nixpkgs
-      run: timeout -v --kill-after=10 500 nix-shell --arg fullDeps "${{ inputs.full-deps }}" --run "true"
+      run: timeout -v --kill-after=10 500 nix-shell --arg fullDeps "${{ inputs.full-deps }}" --run "echo nixpkgs deps preinstalled" || echo "NIXPKGS PREINSTALL FAILURE"
       shell: sh
     - name: Dependencies uv
       run: timeout -v --kill-after=10 200 nix-shell --arg fullDeps "${{ inputs.full-deps }}" --run "uv sync"


### PR DESCRIPTION
Very ugly workaround for #5598 but as this is not locally reproducible and happens in ~1 % of jobs it is very hard to debug. According to strace the nix-shell process gets stuck waiting to read the `nix-daemon` socket, did not invest the time to find out what's happening on the other end.

It seems that when you kill the stuck nix-shell (as timeout does) things seem to work out fine afterwards? From what I tried, rerunning nix-shell again works fine.

<!--
For core developers:
- Assign yourself to the PR.
- Set the priority to match the original issue.
- Add the PR to the current sprint.
- If it's a draft PR, mark it as "In Progress."
- If it's a final PR, mark it as "Needs Review."

For external contributors:
- Please open an issue before submitting a PR so we can discuss whether we want to proceed with it.
-->
