### PR TITLE
Eckhart vertical menu DQA

### DIFF
--- a/core/embed/rust/src/ui/layout_eckhart/firmware/device_menu_screen.rs
+++ b/core/embed/rust/src/ui/layout_eckhart/firmware/device_menu_screen.rs
@@ -699,6 +699,8 @@ impl DeviceMenuScreen {
         self.place(self.bounds);
         if let ActiveScreen::Menu(screen, ..) = self.active_screen.deref_mut() {
             screen.initialize_screen(ctx);
+        } else if let ActiveScreen::Device(screen) = self.active_screen.deref_mut() {
+            screen.initialize_screen(ctx);
         }
     }
 

--- a/core/embed/rust/src/ui/layout_eckhart/firmware/header.rs
+++ b/core/embed/rust/src/ui/layout_eckhart/firmware/header.rs
@@ -129,6 +129,13 @@ impl Header {
         ctx.request_paint();
     }
 
+    /// Whether any of the buttons is currently pressed
+    /// Used for defining the order of rendering of overlapping components
+    pub fn pressed(&self) -> bool {
+        self.left_button.as_ref().is_some_and(|b| b.is_pressed())
+            || self.right_button.as_ref().is_some_and(|b| b.is_pressed())
+    }
+
     /// Calculates the width needed for the right button
     fn right_button_width(&self) -> i16 {
         if let Some(b) = &self.right_button {

--- a/core/embed/rust/src/ui/layout_eckhart/firmware/vertical_menu.rs
+++ b/core/embed/rust/src/ui/layout_eckhart/firmware/vertical_menu.rs
@@ -108,6 +108,8 @@ pub enum VerticalMenuMsg {
 impl<T: MenuItems> VerticalMenu<T> {
     const SIDE_INSETS: Insets = Insets::sides(12);
     const MENU_ITEM_CONTENT_PADDING: i16 = 32;
+    #[cfg(test)]
+    pub const TEST_MENU_ITEM_CONTENT_PADDING: i16 = 32;
 
     fn new(buttons: T) -> Self {
         Self {

--- a/core/embed/rust/src/ui/layout_eckhart/firmware/vertical_menu_screen.rs
+++ b/core/embed/rust/src/ui/layout_eckhart/firmware/vertical_menu_screen.rs
@@ -6,6 +6,7 @@ use crate::{
             text::{layout::LayoutFit, TextStyle},
             Component, Event, EventCtx, Label, SwipeDetect, TextLayout,
         },
+        display::Icon,
         event::SwipeEvent,
         flow::Swipable,
         geometry::{Alignment2D, Direction, Offset, Rect},
@@ -45,6 +46,8 @@ impl<T: MenuItems> VerticalMenuScreen<T> {
     const SUBTITLE_STYLE: TextStyle = theme::TEXT_MEDIUM_GREY;
     const SUBTITLE_HEIGHT: i16 = 68;
     const SUBTITLE_DOUBLE_HEIGHT: i16 = 100;
+    const OVERFLOW_ARROW_Y_OFFSET: i16 = 18;
+    const OVERFLOW_ARROW_ICON: Icon = theme::ICON_CHEVRON_DOWN_MINI;
 
     pub fn new(menu: VerticalMenu<T>) -> Self {
         Self {
@@ -170,10 +173,15 @@ impl<T: MenuItems> VerticalMenuScreen<T> {
 
         // Render the down arrow if the menu overflows and can be scrolled further down
         if self.swipe.is_some() && !self.menu.is_max_offset() {
-            ToifImage::new(SCREEN.bottom_center(), theme::ICON_CHEVRON_DOWN_MINI.toif)
-                .with_align(Alignment2D::BOTTOM_CENTER)
-                .with_fg(theme::GREY_LIGHT)
-                .render(target);
+            ToifImage::new(
+                SCREEN
+                    .bottom_center()
+                    .ofs(Offset::y(Self::OVERFLOW_ARROW_Y_OFFSET).neg()),
+                Self::OVERFLOW_ARROW_ICON.toif,
+            )
+            .with_align(Alignment2D::BOTTOM_CENTER)
+            .with_fg(theme::GREY_LIGHT)
+            .render(target);
         }
     }
 }
@@ -265,5 +273,23 @@ impl<T: MenuItems> crate::trace::Trace for VerticalMenuScreen<T> {
         t.component("VerticalMenuScreen");
         t.child("Header", &self.header);
         t.child("Menu", &self.menu);
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{super::VerticalMenu, *};
+
+    #[test]
+    fn test_min_offset() {
+        // The top of the overflow arrow must be less than the bottom padding to avoid
+        // hiding the button content
+        debug_assert!(
+            VerticalMenuScreen::<ShortMenuVec>::OVERFLOW_ARROW_Y_OFFSET
+                + VerticalMenuScreen::<ShortMenuVec>::OVERFLOW_ARROW_ICON
+                    .toif
+                    .height()
+                < VerticalMenu::<ShortMenuVec>::TEST_MENU_ITEM_CONTENT_PADDING
+        );
     }
 }

--- a/core/embed/rust/src/ui/layout_eckhart/firmware/vertical_menu_screen.rs
+++ b/core/embed/rust/src/ui/layout_eckhart/firmware/vertical_menu_screen.rs
@@ -77,7 +77,7 @@ impl<T: MenuItems> VerticalMenuScreen<T> {
             self.subtitle =
                 Some(Label::left_aligned(subtitle, Self::SUBTITLE_STYLE).vertically_centered());
             // The menu shouldn't overlap the subtitle area
-            self.menu.no_first_item_shrink();
+            self.menu.no_top_component_overlap();
         }
         self
     }


### PR DESCRIPTION
- Fix misplaced overflow arrow: [Figma](https://www.figma.com/design/MXUm0sDc1CjPNTIzzWwTAu/DQA?node-id=12054-2165&t=Nhz9Nwo2H57Y9ihg-0) 
- Header + VerticalMenu
  - shift the menu up by approx. a top button padding: [Figma](https://www.figma.com/design/MXUm0sDc1CjPNTIzzWwTAu/DQA?node-id=12054-2164&t=tVjTW0eOF8oRPHQY-0)  
- Header + Subtitle + VerticalMenu: [Figma](https://www.figma.com/design/Dkl7W5PLqpr3TnXJ5hbnfd/--Future-Prod---Safe-7?node-id=9814-10156&t=joyZlW6Kzw9NENoC-0)
  - Do not overlap the menu with the subtitle
  - render the separator even before the first menu item
- Do not hide partially hidden device menu items. Limit their touch area instead. 




<!--
For core developers:
- Assign yourself to the PR.
- Set the priority to match the original issue.
- Add the PR to the current sprint.
- If it's a draft PR, mark it as "In Progress."
- If it's a final PR, mark it as "Needs Review."

For external contributors:
- Please open an issue before submitting a PR so we can discuss whether we want to proceed with it.
-->
