### PR TITLE
Don't request marquee animation frames if text fits

### DIFF
--- a/core/embed/rust/src/ui/component/marquee.rs
+++ b/core/embed/rust/src/ui/component/marquee.rs
@@ -70,6 +70,11 @@ impl Marquee {
             self.min_offset = 0;
             self.max_offset = max_offset;
 
+            // If text fits completely, don't start animation
+            if max_offset >= 0 {
+                return;
+            }
+
             let anim = Animation::new(self.min_offset, max_offset, self.duration, now);
 
             self.state = State::Left(anim);
@@ -141,8 +146,9 @@ impl Component for Marquee {
     }
 
     fn event(&mut self, ctx: &mut EventCtx, event: Event) -> Option<Self::Msg> {
-        // Not doing anything if animations are disabled.
-        if animation_disabled() {
+        // Not doing anything if animations are disabled or if we never started (text
+        // fits)
+        if animation_disabled() || matches!(self.state, State::Initial) {
             return None;
         }
 

--- a/core/embed/rust/src/ui/layout_eckhart/component/button.rs
+++ b/core/embed/rust/src/ui/layout_eckhart/component/button.rs
@@ -65,13 +65,20 @@ impl Button {
             ButtonContent::TextAndSubtext {
                 subtext,
                 subtext_style,
+                subtext_is_marquee,
                 ..
-            } => Some(Marquee::new(
-                subtext,
-                subtext_style.text_font,
-                subtext_style.text_color,
-                subtext_style.background_color,
-            )),
+            } => {
+                if subtext_is_marquee {
+                    Some(Marquee::new(
+                        subtext,
+                        subtext_style.text_font,
+                        subtext_style.text_color,
+                        subtext_style.background_color,
+                    ))
+                } else {
+                    None
+                }
+            }
             _ => None,
         };
         Self {


### PR DESCRIPTION
Optimization: when a marquee is not needed due to the text fitting we should not request animation frames!

<!--
For core developers:
- Assign yourself to the PR.
- Set the priority to match the original issue.
- Add the PR to the current sprint.
- If it's a draft PR, mark it as "In Progress."
- If it's a final PR, mark it as "Needs Review."

For external contributors:
- Please open an issue before submitting a PR so we can discuss whether we want to proceed with it.
-->
