### PR TITLE
Remove useless change_code params

### DIFF
--- a/core/embed/rust/src/ui/api/firmware_micropython.rs
+++ b/core/embed/rust/src/ui/api/firmware_micropython.rs
@@ -579,11 +579,9 @@ extern "C" fn new_flow_confirm_set_new_code(
     kwargs: *mut Map,
 ) -> Obj {
     let block = move |_args: &[Obj], kwargs: &Map| {
-        let title: TString = kwargs.get(Qstr::MP_QSTR_title)?.try_into()?;
-        let description: TString = kwargs.get(Qstr::MP_QSTR_description)?.try_into()?;
         let is_wipe_code: bool = kwargs.get(Qstr::MP_QSTR_is_wipe_code)?.try_into()?;
 
-        let layout = ModelUI::flow_confirm_set_new_code(title, description, is_wipe_code)?;
+        let layout = ModelUI::flow_confirm_set_new_code(is_wipe_code)?;
         Ok(LayoutObj::new_root(layout)?.into())
     };
     unsafe { util::try_with_args_and_kwargs(n_args, args, kwargs, block) }
@@ -1714,8 +1712,6 @@ pub static mp_module_trezorui_api: Module = obj_module! {
 
     /// def flow_confirm_set_new_code(
     ///     *,
-    ///     title: str,
-    ///     description: str,
     ///     is_wipe_code: bool,
     /// ) -> LayoutObj[UiResult]:
     ///     """Confirm new PIN/wipe code setup with an option to cancel action."""

--- a/core/embed/rust/src/ui/layout_bolt/ui_firmware.rs
+++ b/core/embed/rust/src/ui/layout_bolt/ui_firmware.rs
@@ -601,11 +601,7 @@ impl FirmwareUI for UIBolt {
         Err::<RootComponent<Empty, ModelUI>, Error>(Error::NotImplementedError)
     }
 
-    fn flow_confirm_set_new_code(
-        _title: TString<'static>,
-        _description: TString<'static>,
-        _is_wipe_code: bool,
-    ) -> Result<impl LayoutMaybeTrace, Error> {
+    fn flow_confirm_set_new_code(_is_wipe_code: bool) -> Result<impl LayoutMaybeTrace, Error> {
         Err::<RootComponent<Empty, ModelUI>, Error>(Error::NotImplementedError)
     }
 

--- a/core/embed/rust/src/ui/layout_caesar/ui_firmware.rs
+++ b/core/embed/rust/src/ui/layout_caesar/ui_firmware.rs
@@ -730,11 +730,7 @@ impl FirmwareUI for UICaesar {
         Err::<RootComponent<Empty, ModelUI>, Error>(Error::NotImplementedError)
     }
 
-    fn flow_confirm_set_new_code(
-        _title: TString<'static>,
-        _description: TString<'static>,
-        _is_wipe_code: bool,
-    ) -> Result<impl LayoutMaybeTrace, Error> {
+    fn flow_confirm_set_new_code(_is_wipe_code: bool) -> Result<impl LayoutMaybeTrace, Error> {
         Err::<RootComponent<Empty, ModelUI>, Error>(Error::NotImplementedError)
     }
 

--- a/core/embed/rust/src/ui/layout_delizia/flow/confirm_set_new_code.rs
+++ b/core/embed/rust/src/ui/layout_delizia/flow/confirm_set_new_code.rs
@@ -56,39 +56,59 @@ impl FlowController for SetNewCode {
     }
 }
 
-pub fn new_set_new_code(
-    title: TString<'static>,
-    description: TString<'static>,
-    _is_wipe_code: bool,
-) -> Result<SwipeFlow, error::Error> {
+pub fn new_set_new_code(is_wipe_code: bool) -> Result<SwipeFlow, error::Error> {
+    let (title, description, cancel, cancel_menu_item) = if is_wipe_code {
+        (
+            TR::wipe_code__title_settings,
+            TR::wipe_code__turn_on,
+            TR::wipe_code__cancel_setup,
+            TR::buttons__cancel,
+        )
+    } else {
+        (
+            TR::pin__title_settings,
+            TR::pin__turn_on,
+            TR::pin__cancel_setup,
+            TR::pin__cancel_setup,
+        )
+    };
     let paragraphs = Paragraphs::new(Paragraph::new(&theme::TEXT_MAIN_GREY_LIGHT, description));
-    let content_intro = Frame::left_aligned(title, SwipeContent::new(paragraphs))
+    let content_intro = Frame::left_aligned(title.into(), SwipeContent::new(paragraphs))
         .with_menu_button()
         .with_swipeup_footer(None)
         .map_to_button_msg();
 
     let content_menu = Frame::left_aligned(
         "".into(),
-        VerticalMenu::empty().danger(theme::ICON_CANCEL, TR::pin__cancel_setup.into()),
+        VerticalMenu::empty().danger(theme::ICON_CANCEL, cancel_menu_item.into()),
     )
     .with_cancel_button()
     .map(super::util::map_to_choice);
 
-    let paragraphs_cancel_intro = ParagraphVecShort::from_iter([
-        Paragraph::new(&theme::TEXT_WARNING, TR::words__not_recommended),
-        Paragraph::new(&theme::TEXT_MAIN_GREY_LIGHT, TR::pin__cancel_info),
-    ])
+    let paragraphs_cancel_intro = ParagraphVecShort::from_iter(if is_wipe_code {
+        [
+            Paragraph::new(&theme::TEXT_WARNING, TR::wipe_code__cancel_setup),
+            Paragraph::new(&theme::TEXT_MAIN_GREY_LIGHT, TString::empty()),
+        ]
+    } else {
+        [
+            Paragraph::new(&theme::TEXT_WARNING, TR::words__not_recommended),
+            Paragraph::new(&theme::TEXT_MAIN_GREY_LIGHT, TR::pin__cancel_info),
+        ]
+    })
     .into_paragraphs();
-    let content_cancel_intro = Frame::left_aligned(
-        TR::pin__cancel_setup.into(),
-        SwipeContent::new(paragraphs_cancel_intro),
-    )
-    .with_cancel_button()
-    .with_swipeup_footer(Some(TR::pin__cancel_description.into()))
-    .map_to_button_msg();
+    let content_cancel_intro =
+        Frame::left_aligned(cancel.into(), SwipeContent::new(paragraphs_cancel_intro))
+            .with_cancel_button()
+            .with_swipeup_footer(Some(if is_wipe_code {
+                TR::buttons__cancel.into()
+            } else {
+                TR::pin__cancel_description.into()
+            }))
+            .map_to_button_msg();
 
     let content_cancel_confirm = Frame::left_aligned(
-        TR::pin__cancel_setup.into(),
+        cancel.into(),
         SwipeContent::new(PromptScreen::new_tap_to_cancel()),
     )
     .with_cancel_button()

--- a/core/embed/rust/src/ui/layout_delizia/ui_firmware.rs
+++ b/core/embed/rust/src/ui/layout_delizia/ui_firmware.rs
@@ -652,12 +652,8 @@ impl FirmwareUI for UIDelizia {
         Ok(flow)
     }
 
-    fn flow_confirm_set_new_code(
-        title: TString<'static>,
-        description: TString<'static>,
-        is_wipe_code: bool,
-    ) -> Result<impl LayoutMaybeTrace, Error> {
-        let flow = flow::confirm_set_new_code::new_set_new_code(title, description, is_wipe_code)?;
+    fn flow_confirm_set_new_code(is_wipe_code: bool) -> Result<impl LayoutMaybeTrace, Error> {
+        let flow = flow::confirm_set_new_code::new_set_new_code(is_wipe_code)?;
         Ok(flow)
     }
 

--- a/core/embed/rust/src/ui/layout_eckhart/flow/confirm_set_new_code.rs
+++ b/core/embed/rust/src/ui/layout_eckhart/flow/confirm_set_new_code.rs
@@ -54,15 +54,17 @@ impl FlowController for SetNewCode {
     }
 }
 
-pub fn new_set_new_code(
-    title: TString<'static>,
-    description: TString<'static>,
-    is_wipe_code: bool,
-) -> Result<SwipeFlow, error::Error> {
+pub fn new_set_new_code(is_wipe_code: bool) -> Result<SwipeFlow, error::Error> {
+    let (title, description) = if is_wipe_code {
+        (TR::wipe_code__title_settings, TR::wipe_code__info)
+    } else {
+        (TR::pin__title_settings, TR::pin__info)
+    };
+
     let paragraphs = Paragraphs::new(Paragraph::new(&theme::firmware::TEXT_REGULAR, description))
         .with_placement(LinearPlacement::vertical());
     let content_intro = TextScreen::new(paragraphs)
-        .with_header(Header::new(title).with_menu_button())
+        .with_header(Header::new(title.into()).with_menu_button())
         .with_action_bar(ActionBar::new_single(Button::with_text(
             TR::buttons__continue.into(),
         )))
@@ -76,7 +78,7 @@ pub fn new_set_new_code(
     let content_menu = VerticalMenuScreen::new(VerticalMenu::<ShortMenuVec>::empty().with_item(
         Button::new_menu_item(TR::buttons__cancel.into(), theme::menu_item_title_orange()),
     ))
-    .with_header(Header::new(title).with_close_button())
+    .with_header(Header::new(title.into()).with_close_button())
     .map(|msg| match msg {
         VerticalMenuScreenMsg::Close => Some(FlowMsg::Cancelled),
         VerticalMenuScreenMsg::Selected(i) => Some(FlowMsg::Choice(i)),

--- a/core/embed/rust/src/ui/layout_eckhart/ui_firmware.rs
+++ b/core/embed/rust/src/ui/layout_eckhart/ui_firmware.rs
@@ -790,12 +790,8 @@ impl FirmwareUI for UIEckhart {
         Ok(flow)
     }
 
-    fn flow_confirm_set_new_code(
-        title: TString<'static>,
-        description: TString<'static>,
-        is_wipe_code: bool,
-    ) -> Result<impl LayoutMaybeTrace, Error> {
-        let flow = flow::confirm_set_new_code::new_set_new_code(title, description, is_wipe_code)?;
+    fn flow_confirm_set_new_code(is_wipe_code: bool) -> Result<impl LayoutMaybeTrace, Error> {
+        let flow = flow::confirm_set_new_code::new_set_new_code(is_wipe_code)?;
         Ok(flow)
     }
 

--- a/core/embed/rust/src/ui/ui_firmware.rs
+++ b/core/embed/rust/src/ui/ui_firmware.rs
@@ -205,11 +205,7 @@ pub trait FirmwareUI {
         cancel_text: Option<TString<'static>>,
     ) -> Result<impl LayoutMaybeTrace, Error>;
 
-    fn flow_confirm_set_new_code(
-        title: TString<'static>,
-        description: TString<'static>,
-        is_wipe_code: bool,
-    ) -> Result<impl LayoutMaybeTrace, Error>;
+    fn flow_confirm_set_new_code(is_wipe_code: bool) -> Result<impl LayoutMaybeTrace, Error>;
 
     #[allow(clippy::too_many_arguments)]
     fn flow_get_address(

--- a/core/mocks/generated/trezorui_api.pyi
+++ b/core/mocks/generated/trezorui_api.pyi
@@ -378,8 +378,6 @@ def flow_confirm_output(
 # rust/src/ui/api/firmware_micropython.rs
 def flow_confirm_set_new_code(
     *,
-    title: str,
-    description: str,
     is_wipe_code: bool,
 ) -> LayoutObj[UiResult]:
     """Confirm new PIN/wipe code setup with an option to cancel action."""

--- a/core/src/apps/management/change_pin.py
+++ b/core/src/apps/management/change_pin.py
@@ -93,10 +93,6 @@ def _require_confirm_change_pin(msg: ChangePin) -> Awaitable[None]:
 
     if not msg.remove and not has_pin:  # setting new pin
         return confirm_set_new_code(
-            "set_pin",
-            TR.pin__title_settings,
-            TR.pin__turn_on,
-            TR.pin__info,
             is_wipe_code=False,
         )
 

--- a/core/src/apps/management/change_wipe_code.py
+++ b/core/src/apps/management/change_wipe_code.py
@@ -90,10 +90,6 @@ def _require_confirm_action(
 
     if not msg.remove and not has_wipe_code:  # setting new wipe code
         return confirm_set_new_code(
-            "set_wipe_code",
-            TR.wipe_code__title_settings,
-            TR.wipe_code__turn_on,
-            TR.wipe_code__info,
             is_wipe_code=True,
         )
 

--- a/core/src/trezor/ui/layouts/bolt/__init__.py
+++ b/core/src/trezor/ui/layouts/bolt/__init__.py
@@ -1815,13 +1815,19 @@ async def pin_wipe_code_exists_popup(
 
 
 def confirm_set_new_code(
-    br_name: str,
-    title: str,
-    description: str,
-    information: str,
     is_wipe_code: bool,
-    br_code: ButtonRequestType = BR_CODE_OTHER,
 ) -> Awaitable[None]:
+    if is_wipe_code:
+        title = TR.wipe_code__title_settings
+        description = TR.wipe_code__turn_on
+        information = TR.wipe_code__info
+        br_name = "set_wipe_code"
+    else:
+        title = TR.pin__title_settings
+        description = TR.pin__turn_on
+        information = TR.pin__info
+        br_name = "set_pin"
+
     return raise_if_cancelled(
         trezorui_api.confirm_emphasized(
             title=title,
@@ -1832,7 +1838,7 @@ def confirm_set_new_code(
             verb=TR.buttons__turn_on,
         ),
         br_name,
-        br_code,
+        BR_CODE_OTHER,
     )
 
 

--- a/core/src/trezor/ui/layouts/caesar/__init__.py
+++ b/core/src/trezor/ui/layouts/caesar/__init__.py
@@ -1842,19 +1842,25 @@ async def pin_wipe_code_exists_popup(
 
 
 async def confirm_set_new_code(
-    br_name: str,
-    title: str,
-    description: str,
-    information: str,
     is_wipe_code: bool,
-    br_code: ButtonRequestType = BR_CODE_OTHER,
 ) -> None:
+    if is_wipe_code:
+        title = TR.wipe_code__title_settings
+        description = TR.wipe_code__turn_on
+        information = TR.wipe_code__info
+        br_name = "set_wipe_code"
+    else:
+        title = TR.pin__title_settings
+        description = TR.pin__turn_on
+        information = TR.pin__info
+        br_name = "set_pin"
+
     await _confirm_multiple_pages_texts(
         br_name,
         title,
         [description, information],
         TR.buttons__turn_on,
-        br_code,
+        BR_CODE_OTHER,
     )
 
     # Not showing extra info for wipe code
@@ -1871,7 +1877,7 @@ async def confirm_set_new_code(
         title,
         next_info,
         TR.buttons__continue,
-        br_code,
+        BR_CODE_OTHER,
     )
 
 

--- a/core/src/trezor/ui/layouts/delizia/__init__.py
+++ b/core/src/trezor/ui/layouts/delizia/__init__.py
@@ -1736,19 +1736,12 @@ async def pin_wipe_code_exists_popup(
 
 
 def confirm_set_new_code(
-    br_name: str,
-    title: str,
-    description: str,
-    information: str,
     is_wipe_code: bool,
-    br_code: ButtonRequestType = BR_CODE_OTHER,
 ) -> Awaitable[None]:
     return raise_if_cancelled(
-        trezorui_api.flow_confirm_set_new_code(
-            title=title, description=description, is_wipe_code=is_wipe_code
-        ),
-        br_name,
-        br_code,
+        trezorui_api.flow_confirm_set_new_code(is_wipe_code=is_wipe_code),
+        "set_wipe_code" if is_wipe_code else "set_pin",
+        BR_CODE_OTHER,
     )
 
 

--- a/core/src/trezor/ui/layouts/eckhart/__init__.py
+++ b/core/src/trezor/ui/layouts/eckhart/__init__.py
@@ -1801,19 +1801,12 @@ async def pin_wipe_code_exists_popup(
 
 
 def confirm_set_new_code(
-    br_name: str,
-    title: str,
-    description: str,
-    information: str,
     is_wipe_code: bool,
-    br_code: ButtonRequestType = BR_CODE_OTHER,
 ) -> Awaitable[None]:
     return raise_if_cancelled(
-        trezorui_api.flow_confirm_set_new_code(
-            title=title, description=information, is_wipe_code=is_wipe_code
-        ),
-        br_name,
-        br_code,
+        trezorui_api.flow_confirm_set_new_code(is_wipe_code=is_wipe_code),
+        "set_wipe_code" if is_wipe_code else "set_pin",
+        BR_CODE_OTHER,
     )
 
 

--- a/tests/device_tests/test_msg_change_wipe_code_t2.py
+++ b/tests/device_tests/test_msg_change_wipe_code_t2.py
@@ -22,7 +22,7 @@ from trezorlib.debuglink import LayoutType
 from trezorlib.debuglink import SessionDebugWrapper as Session
 from trezorlib.exceptions import Cancelled, TrezorFailure
 
-from ..input_flows import InputFlowNewCodeMismatch
+from ..input_flows import InputFlowNewCodeCancel, InputFlowNewCodeMismatch
 
 PIN4 = "1234"
 WIPE_CODE4 = "4321"
@@ -122,6 +122,13 @@ def test_set_wipe_code_mismatch(session: Session):
     # Check that there's still no wipe code protection now
     # session.init_device()
     assert session.features.wipe_code_protection is False
+
+
+def test_set_wipe_code_cancel(session: Session):
+    with session.client as client, pytest.raises(Cancelled):
+        IF = InputFlowNewCodeCancel(session.client)
+        client.set_input_flow(IF.get())
+        device.change_wipe_code(session)
 
 
 @pytest.mark.setup_client(pin=PIN4)

--- a/tests/device_tests/test_msg_change_wipe_code_t2.py
+++ b/tests/device_tests/test_msg_change_wipe_code_t2.py
@@ -22,7 +22,7 @@ from trezorlib.debuglink import LayoutType
 from trezorlib.debuglink import SessionDebugWrapper as Session
 from trezorlib.exceptions import Cancelled, TrezorFailure
 
-from ..input_flows import InputFlowNewCodeCancel, InputFlowNewCodeMismatch
+from ..input_flows import InputFlowNewCodeMismatch, InputFlowNewWipeCodeCancel
 
 PIN4 = "1234"
 WIPE_CODE4 = "4321"
@@ -126,7 +126,7 @@ def test_set_wipe_code_mismatch(session: Session):
 
 def test_set_wipe_code_cancel(session: Session):
     with session.client as client, pytest.raises(Cancelled):
-        IF = InputFlowNewCodeCancel(session.client)
+        IF = InputFlowNewWipeCodeCancel(session.client)
         client.set_input_flow(IF.get())
         device.change_wipe_code(session)
 

--- a/tests/input_flows.py
+++ b/tests/input_flows.py
@@ -91,6 +91,43 @@ class InputFlowBase:
         return self.debug.read_layout().title()
 
 
+class InputFlowNewCodeCancel(InputFlowBase):
+    def input_flow_bolt(self) -> BRGeneratorType:
+        br = yield
+        assert br.name == "set_wipe_code"
+        self.debug.press_no()
+
+    def input_flow_caesar(self) -> BRGeneratorType:
+        br = yield
+        assert br.name == "set_wipe_code"
+        self.debug.press_no()
+
+    def input_flow_delizia(self) -> BRGeneratorType:
+        br = yield
+        assert br.name == "set_wipe_code"
+
+        self.debug.click(self.debug.screen_buttons.menu())
+        self.debug.synchronize_at("VerticalMenu")
+        self.debug.button_actions.navigate_to_menu_item(0)
+
+        self.debug.read_layout().title == TR.wipe_code__cancel_setup
+        self.debug.swipe_up()
+        self.debug.read_layout()
+        self.debug.synchronize_at("PromptScreen")
+        self.debug.click(self.debug.screen_buttons.tap_to_confirm())
+
+    def input_flow_eckhart(self) -> BRGeneratorType:
+        br = yield
+        assert br.name == "set_wipe_code"
+
+        self.debug.click(self.debug.screen_buttons.menu())
+        self.debug.synchronize_at("VerticalMenu")
+        self.debug.button_actions.navigate_to_menu_item(0)
+
+        self.debug.read_layout().title == TR.wipe_code__cancel_setup
+        self.debug.press_no()
+
+
 class InputFlowNewCodeMismatch(InputFlowBase):
     def __init__(
         self,

--- a/tests/input_flows.py
+++ b/tests/input_flows.py
@@ -91,7 +91,7 @@ class InputFlowBase:
         return self.debug.read_layout().title()
 
 
-class InputFlowNewCodeCancel(InputFlowBase):
+class InputFlowNewWipeCodeCancel(InputFlowBase):
     def input_flow_bolt(self) -> BRGeneratorType:
         br = yield
         assert br.name == "set_wipe_code"


### PR DESCRIPTION
Following #5782 some parameters became useless...

Also added a test that cancels the wipe code setup on all models to exercise the new code path.

<!--
For core developers:
- Assign yourself to the PR.
- Set the priority to match the original issue.
- Add the PR to the current sprint.
- If it's a draft PR, mark it as "In Progress."
- If it's a final PR, mark it as "Needs Review."

For external contributors:
- Please open an issue before submitting a PR so we can discuss whether we want to proceed with it.
-->
