### PR TITLE
fix(core): fix mpu settings in secmon

### DIFF
--- a/core/embed/sys/mpu/stm32u5/mpu.c
+++ b/core/embed/sys/mpu/stm32u5/mpu.c
@@ -163,9 +163,9 @@ _Static_assert(NORCOW_SECTOR_SIZE == STORAGE_2_MAXSIZE, "norcow misconfigured");
 #define OTP_AND_ID_SIZE 0x800
 
 #ifdef SECMON
-extern uint32_t _codelen;
+extern uint32_t _secmon_size;
 #define SECMON_START FIRMWARE_START_S
-#define SECMON_SIZE (uint32_t) & _codelen
+#define SECMON_SIZE (uint32_t) & _secmon_size
 #endif
 
 #ifdef KERNEL


### PR DESCRIPTION
This PR fixes a bug in the MPU settings of the secure monitor.

The `.text`/`.rodata` region size did not include the secmon header, so reads from `.rodata` at the end of the secmon image triggered an MM fault.