### PR TITLE
chore(core/eckhart): align back button behavior in device menu

### DIFF
--- a/core/embed/rust/src/ui/layout_eckhart/component_msg_obj.rs
+++ b/core/embed/rust/src/ui/layout_eckhart/component_msg_obj.rs
@@ -104,6 +104,8 @@ where
             TextScreenMsg::Cancelled => Ok(CANCELLED.as_obj()),
             TextScreenMsg::Confirmed => Ok(CONFIRMED.as_obj()),
             TextScreenMsg::Menu => Ok(INFO.as_obj()),
+            // back message is handled only in the flow
+            TextScreenMsg::Back => unreachable!(),
         }
     }
 }

--- a/core/embed/rust/src/ui/layout_eckhart/firmware/device_menu_screen.rs
+++ b/core/embed/rust/src/ui/layout_eckhart/firmware/device_menu_screen.rs
@@ -786,7 +786,14 @@ impl DeviceMenuScreen {
                         .into_paragraphs()
                         .with_placement(LinearPlacement::vertical()),
                     )
-                    .with_header(Header::new(TR::words__about.into()).with_close_button()),
+                    .with_header(
+                        Header::new(TR::words__about.into())
+                            .with_close_button()
+                            .with_left_button(
+                                Button::with_icon(theme::ICON_CHEVRON_LEFT),
+                                HeaderMsg::Back,
+                            ),
+                    ),
                 );
             }
             Subscreen::RegulatoryScreen => {
@@ -924,14 +931,16 @@ impl Component for DeviceMenuScreen {
                     _ => {}
                 }
             }
-            (Subscreen::AboutScreen, ActiveScreen::About(about)) => {
-                if let Some(TextScreenMsg::Cancelled) = about.event(ctx, event) {
-                    return self.go_back(ctx);
-                }
-            }
+            (Subscreen::AboutScreen, ActiveScreen::About(about)) => match about.event(ctx, event) {
+                Some(TextScreenMsg::Cancelled) => return Some(DeviceMenuMsg::Close),
+                Some(TextScreenMsg::Back) => return self.go_back(ctx),
+                _ => {}
+            },
             (Subscreen::RegulatoryScreen, ActiveScreen::Regulatory(regulatory)) => {
-                if let Some(RegulatoryMsg::Cancelled) = regulatory.event(ctx, event) {
-                    return self.go_back(ctx);
+                match regulatory.event(ctx, event) {
+                    Some(RegulatoryMsg::Cancelled) => return Some(DeviceMenuMsg::Close),
+                    Some(RegulatoryMsg::Back) => return self.go_back(ctx),
+                    _ => {}
                 }
             }
             _ => {}

--- a/core/embed/rust/src/ui/layout_eckhart/firmware/regulatory_screen.rs
+++ b/core/embed/rust/src/ui/layout_eckhart/firmware/regulatory_screen.rs
@@ -18,6 +18,7 @@ use crate::{
 };
 
 use super::super::{
+    component::Button,
     constant::SCREEN,
     firmware::{ActionBar, ActionBarMsg, Header, HeaderMsg},
     theme,
@@ -31,7 +32,10 @@ pub struct RegulatoryScreen {
 }
 
 pub enum RegulatoryMsg {
+    /// Right header button clicked
     Cancelled,
+    /// Left header button clicked
+    Back,
 }
 
 impl RegulatoryScreen {
@@ -42,7 +46,9 @@ impl RegulatoryScreen {
         action_bar.update(content.pager());
 
         Self {
-            header: Header::new(TR::regulatory_certification__title.into()).with_close_button(),
+            header: Header::new(TR::regulatory_certification__title.into())
+                .with_close_button()
+                .with_left_button(Button::with_icon(theme::ICON_CHEVRON_LEFT), HeaderMsg::Back),
             content,
             action_bar,
         }
@@ -96,8 +102,10 @@ impl Component for RegulatoryScreen {
     }
 
     fn event(&mut self, ctx: &mut EventCtx, event: Event) -> Option<Self::Msg> {
-        if let Some(HeaderMsg::Cancelled) = self.header.event(ctx, event) {
-            return Some(RegulatoryMsg::Cancelled);
+        match self.header.event(ctx, event) {
+            Some(HeaderMsg::Cancelled) => return Some(RegulatoryMsg::Cancelled),
+            Some(HeaderMsg::Back) => return Some(RegulatoryMsg::Back),
+            _ => {}
         }
 
         if let Some(msg) = self.action_bar.event(ctx, event) {

--- a/core/embed/rust/src/ui/layout_eckhart/firmware/text_screen.rs
+++ b/core/embed/rust/src/ui/layout_eckhart/firmware/text_screen.rs
@@ -43,8 +43,13 @@ pub struct TextScreen<T> {
 }
 
 pub enum TextScreenMsg {
+    /// Left header button clicked
+    Back,
+    /// Right header/ left action bar button clicked
     Cancelled,
+    /// Right action bar button clicked
     Confirmed,
+    /// Menu item selected
     Menu,
 }
 
@@ -199,7 +204,7 @@ where
             match msg {
                 HeaderMsg::Cancelled => return Some(TextScreenMsg::Cancelled),
                 HeaderMsg::Menu => return Some(TextScreenMsg::Menu),
-                _ => {}
+                HeaderMsg::Back => return Some(TextScreenMsg::Back),
             }
         }
         if let Some(msg) = self.action_bar.event(ctx, event) {

--- a/core/embed/rust/src/ui/layout_eckhart/flow/confirm_fido.rs
+++ b/core/embed/rust/src/ui/layout_eckhart/flow/confirm_fido.rs
@@ -160,6 +160,7 @@ pub fn new_confirm_fido(
                 TextScreenMsg::Cancelled => Some(FlowMsg::Cancelled),
                 TextScreenMsg::Confirmed => Some(FlowMsg::Confirmed),
                 TextScreenMsg::Menu => Some(FlowMsg::Info),
+                _ => None,
             });
 
     // Menu screen

--- a/core/embed/rust/src/ui/layout_eckhart/flow/confirm_output.rs
+++ b/core/embed/rust/src/ui/layout_eckhart/flow/confirm_output.rs
@@ -295,6 +295,7 @@ pub fn new_confirm_output(
             TextScreenMsg::Confirmed => Some(FlowMsg::Confirmed),
             TextScreenMsg::Cancelled => Some(FlowMsg::Cancelled),
             TextScreenMsg::Menu => Some(FlowMsg::Info),
+            _ => None,
         })
         .one_button_request(ButtonRequest::from_num(br_code, br_name));
 
@@ -332,6 +333,7 @@ pub fn new_confirm_output(
             TextScreenMsg::Confirmed => Some(FlowMsg::Confirmed),
             TextScreenMsg::Cancelled => Some(FlowMsg::Cancelled),
             TextScreenMsg::Menu => Some(FlowMsg::Info),
+            _ => None,
         })
         .one_button_request(ButtonRequest::from_num(br_code, br_name));
 
@@ -402,6 +404,7 @@ pub fn new_confirm_output(
             TextScreenMsg::Confirmed => Some(FlowMsg::Confirmed),
             TextScreenMsg::Cancelled => Some(FlowMsg::Cancelled),
             TextScreenMsg::Menu => Some(FlowMsg::Info),
+            _ => None,
         })
         .one_button_request(ButtonRequest::from_num(
             summary_br_code.unwrap(),

--- a/core/embed/rust/src/ui/layout_eckhart/flow/confirm_summary.rs
+++ b/core/embed/rust/src/ui/layout_eckhart/flow/confirm_summary.rs
@@ -140,6 +140,7 @@ pub fn new_confirm_summary(
             FlowMsg::Cancelled
         }),
         TextScreenMsg::Menu => Some(FlowMsg::Info),
+        _ => None,
     });
 
     // Menu

--- a/core/embed/rust/src/ui/layout_eckhart/flow/confirm_value_intro.rs
+++ b/core/embed/rust/src/ui/layout_eckhart/flow/confirm_value_intro.rs
@@ -110,6 +110,7 @@ pub fn new_confirm_value_intro(
         // special case for the "view all data" button
         TextScreenMsg::Cancelled => Some(FlowMsg::Cancelled),
         TextScreenMsg::Menu => Some(FlowMsg::Info),
+        _ => None,
     });
 
     let menu_items = VerticalMenu::<ShortMenuVec>::empty()

--- a/core/embed/rust/src/ui/layout_eckhart/flow/confirm_with_menu.rs
+++ b/core/embed/rust/src/ui/layout_eckhart/flow/confirm_with_menu.rs
@@ -91,6 +91,7 @@ pub fn new_confirm_with_menu<T: AllowedTextContent + MaybeTrace + 'static>(
         TextScreenMsg::Confirmed => Some(FlowMsg::Confirmed),
         TextScreenMsg::Cancelled => Some(FlowMsg::Cancelled),
         TextScreenMsg::Menu => Some(FlowMsg::Info),
+        _ => None,
     });
 
     let mut menu_items = VerticalMenu::<ShortMenuVec>::empty();

--- a/core/embed/rust/src/ui/layout_eckhart/flow/prompt_backup.rs
+++ b/core/embed/rust/src/ui/layout_eckhart/flow/prompt_backup.rs
@@ -111,6 +111,7 @@ pub fn new_prompt_backup() -> Result<SwipeFlow, error::Error> {
             TextScreenMsg::Menu => Some(FlowMsg::Cancelled),
             TextScreenMsg::Confirmed => Some(FlowMsg::Confirmed),
             TextScreenMsg::Cancelled => Some(FlowMsg::Cancelled),
+            _ => None,
         });
 
     let mut res = SwipeFlow::new(&PromptBackup::Intro)?;

--- a/core/embed/rust/src/ui/layout_eckhart/flow/receive.rs
+++ b/core/embed/rust/src/ui/layout_eckhart/flow/receive.rs
@@ -140,6 +140,7 @@ pub fn new_receive(
             TextScreenMsg::Cancelled => Some(FlowMsg::Cancelled),
             TextScreenMsg::Confirmed => Some(FlowMsg::Confirmed),
             TextScreenMsg::Menu => Some(FlowMsg::Info),
+            _ => None,
         })
         .one_button_request(ButtonRequest::from_num(br_code, br_name));
 

--- a/core/embed/rust/src/ui/layout_eckhart/flow/show_share_words.rs
+++ b/core/embed/rust/src/ui/layout_eckhart/flow/show_share_words.rs
@@ -113,6 +113,7 @@ pub fn new_show_share_words_flow(
             TextScreenMsg::Cancelled => Some(FlowMsg::Cancelled),
             TextScreenMsg::Confirmed => Some(FlowMsg::Confirmed),
             TextScreenMsg::Menu => Some(FlowMsg::Cancelled),
+            _ => None,
         });
 
     let check_backup_paragraphs = Paragraph::new(&theme::TEXT_REGULAR, text_check)

--- a/core/embed/rust/src/ui/layout_eckhart/flow/show_thp_pairing_code.rs
+++ b/core/embed/rust/src/ui/layout_eckhart/flow/show_thp_pairing_code.rs
@@ -67,6 +67,7 @@ pub fn new_show_thp_pairing_code(
         TextScreenMsg::Cancelled => Some(FlowMsg::Cancelled),
         TextScreenMsg::Confirmed => Some(FlowMsg::Confirmed),
         TextScreenMsg::Menu => Some(FlowMsg::Info),
+        _ => None,
     });
 
     let mut menu = VerticalMenu::<ShortMenuVec>::empty();

--- a/core/embed/rust/src/ui/layout_eckhart/ui_firmware.rs
+++ b/core/embed/rust/src/ui/layout_eckhart/ui_firmware.rs
@@ -431,6 +431,7 @@ impl FirmwareUI for UIEckhart {
                 }),
                 TextScreenMsg::Menu => Some(FlowMsg::Info),
                 TextScreenMsg::Confirmed => Some(FlowMsg::Confirmed),
+                _ => None,
             });
         flow::util::single_page(screen)
     }


### PR DESCRIPTION
- close button closes the entire device menu
- back button navigates one level back

<!--
For core developers:
- Assign yourself to the PR.
- Set the priority to match the original issue.
- Add the PR to the current sprint.
- If it's a draft PR, mark it as "In Progress."
- If it's a final PR, mark it as "Needs Review."

For external contributors:
- Please open an issue before submitting a PR so we can discuss whether we want to proceed with it.
-->
