### PR TITLE
chore(core): increase retransmission timeout

### DIFF
--- a/core/src/trezor/wire/thp/channel.py
+++ b/core/src/trezor/wire/thp/channel.py
@@ -435,8 +435,8 @@ class Channel:
                     log.error(__name__, "Sending is stuck for %d ms", _WRITE_TIMEOUT_MS)
                 break
 
-            # starting from 100ms till ~3.42s
-            timeout_ms = round(10200 - 1010000 / (100 + i))
+            # starting from 200ms till ~3.52s
+            timeout_ms = round(10300 - 1010000 / (100 + i))
             try:
                 # wait and return after receiving an ACK, or raise in case of an unexpected message.
                 await self.recv_payload(expected_ctrl_byte=None, timeout_ms=timeout_ms)


### PR DESCRIPTION
Increase retransmission timeout. First retransmission will be after 200 ms instead of 100 ms. All changes are shown below.

```
i: (single_timeout, timeout_sum) | (single_timeout, timeout_sum)
 1: OLD (0.100 s,  0.100 s) | NEW: (0.200 s,   0.200 s)
 2: OLD (0.200 s,  0.300 s) | NEW: (0.300 s,   0.500 s)
 3: OLD (0.298 s,  0.598 s) | NEW: (0.398 s,   0.898 s)
 4: OLD (0.394 s,  0.992 s) | NEW: (0.494 s,   1.392 s)
 5: OLD (0.488 s,  1.480 s) | NEW: (0.588 s,   1.980 s)
 6: OLD (0.581 s,  2.061 s) | NEW: (0.681 s,   2.661 s)
 7: OLD (0.672 s,  2.733 s) | NEW: (0.772 s,   3.433 s)
 8: OLD (0.761 s,  3.494 s) | NEW: (0.861 s,   4.294 s)
 9: OLD (0.848 s,  4.342 s) | NEW: (0.948 s,   5.242 s)
10: OLD (0.934 s,  5.276 s) | NEW: (1.034 s,   6.276 s)
11: OLD (1.018 s,  6.294 s) | NEW: (1.118 s,   7.394 s)
12: OLD (1.101 s,  7.395 s) | NEW: (1.201 s,   8.595 s)
13: OLD (1.182 s,  8.577 s) | NEW: (1.282 s,   9.877 s)
14: OLD (1.262 s,  9.839 s) | NEW: (1.362 s,  11.239 s)
15: OLD (1.340 s, 11.179 s) | NEW: (1.440 s,  12.679 s)
16: OLD (1.417 s, 12.596 s) | NEW: (1.517 s,  14.196 s)
17: OLD (1.493 s, 14.089 s) | NEW: (1.593 s,  15.789 s)
18: OLD (1.568 s, 15.657 s) | NEW: (1.668 s,  17.457 s)
19: OLD (1.641 s, 17.298 s) | NEW: (1.741 s,  19.198 s)
20: OLD (1.713 s, 19.011 s) | NEW: (1.813 s,  21.011 s)
21: OLD (1.783 s, 20.794 s) | NEW: (1.883 s,  22.894 s)
22: OLD (1.853 s, 22.647 s) | NEW: (1.953 s,  24.847 s)
23: OLD (1.921 s, 24.568 s) | NEW: (2.021 s,  26.868 s)
24: OLD (1.989 s, 26.557 s) | NEW: (2.089 s,  28.957 s)
25: OLD (2.055 s, 28.612 s) | NEW: (2.155 s,  31.112 s)
26: OLD (2.120 s, 30.732 s) | NEW: (2.220 s,  33.332 s)
27: OLD (2.184 s, 32.916 s) | NEW: (2.284 s,  35.616 s)
28: OLD (2.247 s, 35.163 s) | NEW: (2.347 s,  37.963 s)
29: OLD (2.309 s, 37.472 s) | NEW: (2.409 s,  40.372 s)
30: OLD (2.371 s, 39.843 s) | NEW: (2.471 s,  42.843 s)
31: OLD (2.431 s, 42.274 s) | NEW: (2.531 s,  45.374 s)
32: OLD (2.490 s, 44.764 s) | NEW: (2.590 s,  47.964 s)
33: OLD (2.548 s, 47.312 s) | NEW: (2.648 s,  50.612 s)
34: OLD (2.606 s, 49.918 s) | NEW: (2.706 s,  53.318 s)
35: OLD (2.663 s, 52.581 s) | NEW: (2.763 s,  56.081 s)
36: OLD (2.719 s, 55.300 s) | NEW: (2.819 s,  58.900 s)
37: OLD (2.774 s, 58.074 s) | NEW: (2.874 s,  61.774 s)
38: OLD (2.828 s, 60.902 s) | NEW: (2.928 s,  64.702 s)
39: OLD (2.881 s, 63.783 s) | NEW: (2.981 s,  67.683 s)
40: OLD (2.934 s, 66.717 s) | NEW: (3.034 s,  70.717 s)
41: OLD (2.986 s, 69.703 s) | NEW: (3.086 s,  73.803 s)
42: OLD (3.037 s, 72.740 s) | NEW: (3.137 s,  76.940 s)
43: OLD (3.087 s, 75.827 s) | NEW: (3.187 s,  80.127 s)
44: OLD (3.137 s, 78.964 s) | NEW: (3.237 s,  83.364 s)
45: OLD (3.186 s, 82.150 s) | NEW: (3.286 s,  86.650 s)
46: OLD (3.234 s, 85.384 s) | NEW: (3.334 s,  89.984 s)
47: OLD (3.282 s, 88.666 s) | NEW: (3.382 s,  93.366 s)
48: OLD (3.329 s, 91.995 s) | NEW: (3.429 s,  96.795 s)
49: OLD (3.376 s, 95.371 s) | NEW: (3.476 s, 100.271 s)
50: OLD (3.421 s, 98.792 s) | NEW: (3.521 s, 103.792 s)

```