### PR TITLE
Font kerning

### DIFF
--- a/core/embed/rust/src/ui/shape/text.rs
+++ b/core/embed/rust/src/ui/shape/text.rs
@@ -94,9 +94,15 @@ impl<'a> Shape<'_> for Text<'a> {
         // TODO: optimize  text clipping, use canvas.viewport()
 
         self.font.with_glyph_data(|glyph_data| {
+            let mut prev_char: Option<char> = None;
+
             for ch in self.text.chars() {
                 if r.x0 >= r.x1 {
                     break;
+                }
+
+                if let Some(left) = prev_char {
+                    r.x0 += self.font.get_kerning(left, ch) as i16;
                 }
 
                 let glyph = glyph_data.get_glyph(ch);
@@ -110,7 +116,9 @@ impl<'a> Shape<'_> for Text<'a> {
                     ));
 
                 canvas.blend_bitmap(r, glyph_view);
+
                 r.x0 += glyph.adv;
+                prev_char = Some(ch)
             }
         });
     }

--- a/core/tools/codegen/gen_font.mako
+++ b/core/tools/codegen/gen_font.mako
@@ -35,6 +35,16 @@ const Font_${name}_upper: [&[u8]; ${len(glyph_array_upper)}] = [
 % endif
 % if gen_normal:
 
+/// Array of kerning tripples
+const Font_${name}_kernings: [(u8, u8, i8); ${len(kernings)}] = [
+% for ref in kernings:
+    ${ref}, // ${chr(ref[0])} + ${chr(ref[1])}
+%endfor
+];
+% endif
+% if gen_normal:
+
+
 /// FontInfo struct for normal ASCII usage
 pub const Font_${name}_info: FontInfo = FontInfo {
     translation_blob_idx: ${font_info["translation_blob_idx"]},
@@ -43,6 +53,7 @@ pub const Font_${name}_info: FontInfo = FontInfo {
     baseline: ${font_info["baseline"]},
     glyph_data: &${font_info["glyph_array"]},
     glyph_nonprintable: &${font_info["nonprintable"]},
+    kernings: &${font_info["kernings"]},
 };
 % endif
 % if gen_upper:
@@ -55,5 +66,6 @@ pub const Font_${name}_upper_info: FontInfo = FontInfo {
     baseline: ${font_info_upper["baseline"]},
     glyph_data: &${font_info_upper["glyph_array"]},
     glyph_nonprintable: &${font_info_upper["nonprintable"]},
+    kernings: &${font_info_upper["kernings"]},
 };
 % endif

--- a/core/tools/codegen/gen_font.py
+++ b/core/tools/codegen/gen_font.py
@@ -430,6 +430,22 @@ class FaceProcessor:
             self.font_ymin = min(self.font_ymin, yMin)
             self.font_ymax = max(self.font_ymax, yMax)
 
+        kernings = []
+        for left in range(MIN_GLYPH, MAX_GLYPH + 1):
+            for right in range(MIN_GLYPH, MAX_GLYPH + 1):
+                kerning = self.face.get_kerning(
+                    left, right, freetype.FT_KERNING_DEFAULT
+                )
+                if kerning.x != 0:
+                    kernings.append((left, right, kerning.x // 64))
+                    print(
+                        f"left glyph: {chr(left)} right glyph:{chr(right)} kerning {kerning.x // 64}"
+                    )
+
+        print(
+            f"Font: {self._name_style_size} {self.style} {self.size} : Num of kernirngs {len(kernings)}"
+        )
+
         # 5) Build FontInfo definitions.
         font_info = None
         font_info_upper = None
@@ -446,6 +462,7 @@ class FaceProcessor:
                 "baseline": -self.font_ymin,
                 "glyph_array": f"Font_{self._name_style_size}",
                 "nonprintable": f"Font_{self._name_style_size}_glyph_nonprintable",
+                "kernings": f"Font_{self._name_style_size}_kernings",
             }
         if self.gen_upper:
             if self.font_idx_upper is None:
@@ -460,6 +477,7 @@ class FaceProcessor:
                 "baseline": -self.font_ymin,
                 "glyph_array": f"Font_{self._name_style_size}_upper",
                 "nonprintable": f"Font_{self._name_style_size}_glyph_nonprintable",
+                "kernings": f"Font_{self._name_style_size}_kernings",
             }
 
         data = {
@@ -469,6 +487,7 @@ class FaceProcessor:
             "nonprintable": nonprintable,
             "glyph_array": glyph_array,
             "glyph_array_upper": glyph_array_upper,
+            "kernings": kernings,
             "gen_normal": self.gen_normal,
             "gen_upper": self.gen_upper,
             "font_info": font_info,


### PR DESCRIPTION
This PR updates the text rendering routines to take into account the font kernings + updates fonts export scripts to extract the kerning pairs from .odt files.

_Note: Currently the fonts for T3W1 do not contain any kerning pairs probably due to incorrect export from its font parent, this will be most likely fixed in near feature._