### PR TITLE
fix(core): temporary fix for RSOD triggered by rng_fill_buffer_strong

### DIFF
--- a/core/embed/sec/rng/rng_common.c
+++ b/core/embed/sec/rng/rng_common.c
@@ -55,6 +55,7 @@ bool rng_fill_buffer_strong(void* buffer, size_t buffer_size) {
       dst[i] ^= block[i];
     }
 #endif
+#if PRODUCTION  // // HOTFIX -- DELETE IT --
 #ifdef USE_TROPIC
     if (!tropic_random_buffer(block, block_size)) {
       return false;
@@ -63,6 +64,7 @@ bool rng_fill_buffer_strong(void* buffer, size_t buffer_size) {
     for (size_t i = 0; i < block_size; i++) {
       dst[i] ^= block[i];
     }
+#endif
 #endif
     dst += block_size;
     remaining -= block_size;


### PR DESCRIPTION
This PR is a temporary hot-fix that resolves an issue with partially provisioned T3W1 devices that trigger an RSOD in `rng_fill_buffer_strong()`.




