### PR TITLE
fix(core): make sure to signal `ButtonRequest` handler to exit

### DIFF
--- a/core/src/trezor/ui/__init__.py
+++ b/core/src/trezor/ui/__init__.py
@@ -248,7 +248,12 @@ class Layout(Generic[T]):
             set_current_layout(None)
             if __debug__:
                 if self.button_request_ack_pending:
-                    raise wire.FirmwareError("button request ack pending")
+                    msg = "button request ack pending"
+                    if utils.USE_THP:
+                        # Don't raise to avoid THP desync
+                        log.error(__name__, msg)
+                    else:
+                        raise wire.FirmwareError(msg)
                 self.notify_debuglink(None)
 
     async def get_result(self) -> T:


### PR DESCRIPTION
`button_request_box` value should be replaced to `None`, otherwise `button_request_task` will not exit.

Following https://github.com/trezor/trezor-firmware/pull/5850#discussion_r2375901120.