### PR TITLE
fix(core): invalidate THP credential authentication key on `Forget all`

### DIFF
--- a/core/src/apps/management/ble/unpair.py
+++ b/core/src/apps/management/ble/unpair.py
@@ -36,6 +36,11 @@ async def unpair(msg: BleUnpair) -> None:
         await ctx.write(Success(message="Erasing..."))
 
     if msg.all:
+        from apps.thp.credential_manager import invalidate_cred_auth_key
+
+        # THP credentials should be invalidated when "Forget all" is handled.
+        # Otherwise, the device will not ask for THP confirmation after reconnecting.
+        invalidate_cred_auth_key()
         ble.erase_bonds()
     else:
         ble.unpair(msg.addr)


### PR DESCRIPTION
[Slack](https://satoshilabs.slack.com/archives/C082Q0Y6WP3/p1758785256548679?thread_ts=1758783890.760069&cid=C082Q0Y6WP3)