### PR TITLE
fix(core): cache host and app name also at credential-based connection 

### DIFF
--- a/core/.changelog.d/5867.fixed
+++ b/core/.changelog.d/5867.fixed
@@ -1,0 +1,1 @@
+[T3W1] Cache THP host info also during credential-based pairing.

--- a/core/src/apps/thp/pairing.py
+++ b/core/src/apps/thp/pairing.py
@@ -50,6 +50,7 @@ if __debug__:
     from trezor import log
 
 if TYPE_CHECKING:
+    from buffer_types import AnyBytes
     from typing import Any, Callable, Concatenate, ParamSpec
 
     from trezorui_api import UiResult
@@ -117,7 +118,8 @@ async def handle_pairing_request(
     if not message.app_name:
         raise DataError("Missing app_name.")
 
-    peer_addr = ctx.channel_ctx.iface_ctx.connected_addr()
+    # will be `None` on USB interface, to be ignored by `cache_host_info()`
+    peer_addr: AnyBytes | None = ctx.channel_ctx.iface_ctx.connected_addr()
     await ui.show_pairing_dialog(message.host_name, message.app_name)
     ctx.host_name = message.host_name
     ctx.app_name = message.app_name

--- a/core/src/trezor/wire/thp/interface_context.py
+++ b/core/src/trezor/wire/thp/interface_context.py
@@ -234,7 +234,7 @@ class InterfaceContext:
         header = PacketHeader.get_error_header(cid, length)
         return self.write_payload(header, msg_data)
 
-    def connected_addr(self) -> bytes | None:
+    def connected_addr(self) -> AnyBytes | None:
         """
         Return peer MAC address (if connected).
 


### PR DESCRIPTION
If THP pairing is done over USB (which doesn't have a MAC address) the cache won't be populated.

In order to fix this, we will also update the cache on credential-based connection.

Fixes https://github.com/trezor/trezor-suite/issues/21886.

Rebased over #5869.


<!--
For core developers:
- Assign yourself to the PR.
- Set the priority to match the original issue.
- Add the PR to the current sprint.
- If it's a draft PR, mark it as "In Progress."
- If it's a final PR, mark it as "Needs Review."

For external contributors:
- Please open an issue before submitting a PR so we can discuss whether we want to proceed with it.
-->
