### PR TITLE
fix(prodtest): fix unhandled return code of secret_write()

### DIFF
--- a/core/embed/projects/prodtest/cmd/prodtest_secrets.c
+++ b/core/embed/projects/prodtest/cmd/prodtest_secrets.c
@@ -282,8 +282,11 @@ static void prodtest_secrets_certdev_write(cli_t* cli) {
     return;
   }
 
-  secret_write(prefixed_certificate, SECRET_MCU_DEVICE_CERT_OFFSET,
-               sizeof(prefixed_certificate));
+  if (secret_write(prefixed_certificate, SECRET_MCU_DEVICE_CERT_OFFSET,
+                   sizeof(prefixed_certificate)) != sectrue) {
+    cli_error(cli, CLI_ERROR, "`secret_write()` failed.");
+    return;
+  }
 
   cli_ok(cli, "");
 #endif


### PR DESCRIPTION
This PR fixes an unhandled return code of `secret_write()` in the `secret-certdev-write` command, which caused misleading behavior when writing a certificate a second time, since `secret_write()` always fails in that case.
