### PR TITLE
feat(core/eckhart): LED effect in HoldToConfirm

### DIFF
--- a/core/embed/rust/src/ui/layout_eckhart/firmware/mod.rs
+++ b/core/embed/rust/src/ui/layout_eckhart/firmware/mod.rs
@@ -29,7 +29,7 @@ pub use device_menu_screen::{DeviceMenuMsg, DeviceMenuScreen};
 pub use fido::{FidoAccountName, FidoCredential};
 pub use header::{Header, HeaderMsg};
 pub use hint::Hint;
-pub use hold_to_confirm::HoldToConfirmAnim;
+pub use hold_to_confirm::{HoldToConfirmAnim, HoldToConfirmMsg};
 pub use homescreen::{check_homescreen_format, Homescreen, HomescreenMsg};
 pub use keyboard::{
     bip39::Bip39Input,

--- a/core/embed/rust/src/ui/layout_eckhart/theme/mod.rs
+++ b/core/embed/rust/src/ui/layout_eckhart/theme/mod.rs
@@ -60,6 +60,18 @@ pub const LED_ORANGE: Color = Color::rgb(0xBC, 0x2A, 0x06);
 pub const LED_RED: Color = Color::rgb(0x64, 0x06, 0x03);
 pub const LED_YELLOW: Color = Color::rgb(0x16, 0x10, 0x00);
 pub const LED_BLUE: Color = Color::rgb(0x05, 0x05, 0x32);
+pub const fn color_to_led_color(color: Color) -> Color {
+    match color {
+        WHITE => LED_WHITE,
+        GREEN_LIME => LED_GREEN_LIME,
+        GREEN_LIGHT => LED_GREEN_LIGHT,
+        ORANGE => LED_ORANGE,
+        RED => LED_RED,
+        YELLOW => LED_YELLOW,
+        BLUE => LED_BLUE,
+        _ => color,
+    }
+}
 
 // Common constants
 pub const PADDING: i16 = 24; // [px]


### PR DESCRIPTION
This PR adds `Finalizing` phase to `HoldToConfirmAnim` for Eckhart UI. The controlling component `ActionBar` was adjusted accordingly. 

The Finalizing phase turns on the LED, shows the `ICON_DONE`, progressively dims the border and icon. `ActionBar` only waits for the result in this phase.

In the process, I slightly refactored the code, especially the animation state is now contained in one enum.

<!--
For core developers:
- Assign yourself to the PR.
- Set the priority to match the original issue.
- Add the PR to the current sprint.
- If it's a draft PR, mark it as "In Progress."
- If it's a final PR, mark it as "Needs Review."

For external contributors:
- Please open an issue before submitting a PR so we can discuss whether we want to proceed with it.
-->
