### PR TITLE
shell.nix: fix missing python package referenece to llibstd++.so.6

### DIFF
--- a/shell.nix
+++ b/shell.nix
@@ -148,7 +148,7 @@ stdenvNoCC.mkDerivation ({
     nrfutil
     nrfconnect
   ];
-  LD_LIBRARY_PATH = "${libffi}/lib:${libjpeg.out}/lib:${libusb1}/lib:${libressl.out}/lib";
+  LD_LIBRARY_PATH = "${libffi}/lib:${libjpeg.out}/lib:${libusb1}/lib:${libressl.out}/lib:${pkgs.stdenv.cc.cc.lib}/lib";
   DYLD_LIBRARY_PATH = "${libffi}/lib:${libjpeg.out}/lib:${libusb1}/lib:${libressl.out}/lib";
   NIX_ENFORCE_PURITY = 0;
 

--- a/shell.nix
+++ b/shell.nix
@@ -148,7 +148,7 @@ stdenvNoCC.mkDerivation ({
     nrfutil
     nrfconnect
   ];
-  LD_LIBRARY_PATH = "${libffi}/lib:${libjpeg.out}/lib:${libusb1}/lib:${libressl.out}/lib:${pkgs.stdenv.cc.cc.lib}/lib";
+  LD_LIBRARY_PATH = "${libffi}/lib:${libjpeg.out}/lib:${libusb1}/lib:${libressl.out}/lib:${nixpkgs.stdenv.cc.cc.lib}/lib";
   DYLD_LIBRARY_PATH = "${libffi}/lib:${libjpeg.out}/lib:${libusb1}/lib:${libressl.out}/lib";
   NIX_ENFORCE_PURITY = 0;
 


### PR DESCRIPTION
Adds stdenv.cc.cc.lib in LD_LIBRARY_PATH to fix python packages missing reference to libstd++.so.6 

see:
https://discourse.nixos.org/t/how-to-solve-libstdc-not-found-in-shell-nix/25458

In my case I was unable to import numpy with following error:

```
Traceback (most recent call last):                                                                                                                                                             │-rwxr-xr-x  1 root root         5167 čec 25 19:26  xsubpp
  File "/home/dkopecky/Projects/trezor-firmware/.venv/lib/python3.13/site-packages/numpy/_core/__init__.py", line 22, in <module>                                                              │lrwxrwxrwx  1 root root           37 pro  2  2024  x-terminal-emulator -> /etc/alternatives/x-terminal-emulator
    from . import multiarray                                                                                                                                                                   │-rwxr-xr-x  1 root root        44808 bře 31  2024  xvidtune
  File "/home/dkopecky/Projects/trezor-firmware/.venv/lib/python3.13/site-packages/numpy/_core/multiarray.py", line 11, in <module>                                                            │-rwxr-xr-x  1 root root        18744 bře 31  2024  xvinfo
    from . import _multiarray_umath, overrides                                                                                                                                                 │-rwxr-xr-x  1 root root        14640 bře 31  2024  xvminitoppm
ImportError: libstdc++.so.6: cannot open shared object file: No such file or directory                                                                                                         │-rwxr-xr-x  1 root root      2241784 čen 11 15:02  Xwayland
                                                                                                                                                                                               │-rwxr-xr-x  1 root root        31040 bře 31  2024  xwd
The above exception was the direct cause of the following exception:                                                                                                                           │-rwxr-xr-x  1 root root        26928 bře 31  2024  xwdtopnm
                                                                                                                                                                                               │-rwxr-xr-x  1 root root        51592 bře 31  2024  xwininfo
Traceback (most recent call last):                                                                                                                                                             │-rwxr-xr-x  1 root root        31024 bře 31  2024  xwud
  File "/home/dkopecky/Projects/trezor-firmware/.venv/lib/python3.13/site-packages/numpy/__init__.py", line 112, in <module>                                                                   │lrwxrwxrwx  1 root root           31 pro  2  2024  x-www-browser -> /etc/alternatives/x-www-browser
    from numpy.__config__ import show_config                                                                                                                                                   │-rwxr-xr-x  1 root root        22816 zář  5 21:44  xxd
  File "/home/dkopecky/Projects/trezor-firmware/.venv/lib/python3.13/site-packages/numpy/__config__.py", line 4, in <module>                                                                   │-rwxr-xr-x  1 root root        89008 bře 31 20:22  xz
    from numpy._core._multiarray_umath import (                                                                                                                                                │lrwxrwxrwx  1 root root            2 bře 31 20:22  xzcat -> xz
    ...<3 lines>...                                                                                                                                                                            │lrwxrwxrwx  1 root root            6 bře 31 20:22  xzcmp -> xzdiff
    )                                                                                                                                                                                          │-rwxr-xr-x  1 root root         7422 bře 31 20:22  xzdiff
  File "/home/dkopecky/Projects/trezor-firmware/.venv/lib/python3.13/site-packages/numpy/_core/__init__.py", line 48, in <module>                                                              │lrwxrwxrwx  1 root root            6 bře 31 20:22  xzegrep -> xzgrep
    raise ImportError(msg) from exc                                                                                                                                                            │lrwxrwxrwx  1 root root            6 bře 31 20:22  xzfgrep -> xzgrep
ImportError:                                                                                                                                                                                   │-rwxr-xr-x  1 root root        10333 bře 31 20:22  xzgrep
                                                                                                                                                                                               │-rwxr-xr-x  1 root root         1813 bře 31 20:22  xzless
IMPORTANT: PLEASE READ THIS FOR ADVICE ON HOW TO SOLVE THIS ISSUE!                                                                                                                             │-rwxr-xr-x  1 root root         2190 bře 31 20:22  xzmore
                                                                                                                                                                                               │lrwxrwxrwx  1 root root           27 bře 30  2024  yaml2obj -> ../lib/llvm-18/bin/yaml2obj
Importing the numpy C-extensions failed. This error can happen for                                                                                                                             │lrwxrwxrwx  1 root root           27 kvě 27  2024  yaml2obj-18 -> ../lib/llvm-18/bin/yaml2obj
many reasons, often due to issues with your setup or how NumPy was                                                                                                                             │lrwxrwxrwx  1 root root           29 kvě 27  2024  yaml-bench-18 -> ../lib/llvm-18/bin/yaml-bench
installed.                                                                                                                                                                                     │-rwxr-xr-x  1 root root        14640 bře 31  2024  ybmtopbm
                                                                                                                                                                                               │-rwxr-xr-x  1 root root        59624 dub 17 16:58  yelp
We have compiled some common reasons and troubleshooting tips at:                                                                                                                              │-rwxr-xr-x  1 root root        35208 dub  5  2024  yes
                                                                                                                                                                                               │lrwxrwxrwx  1 root root            8 dub  8  2024  ypdomainname -> hostname
    https://numpy.org/devdocs/user/troubleshooting-importerror.html                                                                                                                            │lrwxrwxrwx  1 root root           47 úno 14  2024  yplan -> ../share/texlive/texmf-dist/scripts/yplan/yplan
                                                                                                                                                                                               │-rwxr-xr-x  1 root root        14640 bře 31  2024  yuvsplittoppm
Please note and check the following:                                                                                                                                                           │-rwxr-xr-x  1 root root        14640 bře 31  2024  yuvtoppm
                                                                                                                                                                                               │-rwxr-xr-x  1 root root        14640 bře 31  2024  yuy2topam
  * The Python version is: Python3.13 from "/home/dkopecky/Projects/trezor-firmware/.venv/bin/python"                                                                                          │-rwxr-xr-x  1 root root         1984 led 27  2025  zcat
  * The NumPy version is: "2.3.3"                                                                                                                                                              │-rwxr-xr-x  1 root root         1678 led 27  2025  zcmp
                                                                                                                                                                                               │-rwxr-xr-x  1 root root         6460 led 27  2025  zdiff
and make sure that they are the versions you expect.                                                                                                                                           │-rwxr-xr-x  1 root root        31008 zář 17 16:55  zdump
Please carefully study the documentation linked above for further help.                                                                                                                        │-rwxr-xr-x  1 root root           29 led 27  2025  zegrep
                                                                                                                                                                                               │-rwxr-xr-x  1 root root        14640 bře 31  2024  zeisstopnm
Original error was: libstdc++.so.6: cannot open shared object file: No such file or directory                                                                                                  │-rwxr-xr-x  1 root root       131888 bře 31  2024  zenity
                                   
```
