### PR TITLE
Soundness fix for `catch_exception`

### DIFF
--- a/core/embed/rust/src/micropython/dict.rs
+++ b/core/embed/rust/src/micropython/dict.rs
@@ -14,13 +14,12 @@ impl Dict {
     /// Allocate a new dictionary on the GC heap, empty, but with a capacity of
     /// `capacity` items.
     pub fn alloc_with_capacity(capacity: usize) -> Result<Gc<Self>, Error> {
-        catch_exception(|| unsafe {
-            // SAFETY: We expect that `ffi::mp_obj_new_dict` either returns a GC-allocated
-            // pointer to `ffi::mp_obj_dict_t` or raises.
-            // EXCEPTION: Will raise if allocation fails.
-            let ptr = ffi::mp_obj_new_dict(capacity);
-            Gc::from_raw(ptr.as_ptr().cast())
-        })
+        // SAFETY: We expect that `ffi::mp_obj_new_dict` either returns a GC-allocated
+        // pointer to `ffi::mp_obj_dict_t` or raises.
+        // EXCEPTION: Will raise if allocation fails.
+        let ptr = catch_exception!(unsafe { ffi::mp_obj_new_dict } => { capacity })?;
+        // SAFETY: `ptr` is a freshly created dict
+        Ok(unsafe { Gc::from_raw(ptr.as_ptr().cast()) })
     }
 
     /// Constructs a dictionary definition by taking ownership of given [`Map`].

--- a/core/embed/rust/src/micropython/iter.rs
+++ b/core/embed/rust/src/micropython/iter.rs
@@ -59,7 +59,7 @@ impl<'a> Iter<'a> {
         //    `Iter`.
         //  - Returned obj is referencing into `iter_buf`.
         // EXCEPTION: Raises if `o` is not iterable and possibly in other cases too.
-        let iter = catch_exception(|| unsafe { ffi::mp_getiter(o, &mut iter_buf.iter_buf) })?;
+        let iter = catch_exception!(unsafe { ffi::mp_getiter } => { o, &mut iter_buf.iter_buf })?;
         Ok(Self {
             iter,
             iter_buf,
@@ -79,7 +79,7 @@ impl<'a> Iterator for Iter<'a> {
         //  - We assume that `mp_iternext` returns objects without any lifetime
         //    invariants, i.e. heap-allocated, unlike `mp_getiter`.
         // EXCEPTION: Can raise from the underlying iterator.
-        let item = catch_exception(|| unsafe { ffi::mp_iternext(self.iter) });
+        let item = catch_exception!(unsafe { ffi::mp_iternext } => { self.iter });
         match item {
             Err(Error::Exception(exc)) if self.iter_buf.error_checking => {
                 self.iter_buf.caught_exception = Some(exc);

--- a/core/embed/rust/src/micropython/list.rs
+++ b/core/embed/rust/src/micropython/list.rs
@@ -14,22 +14,23 @@ impl List {
         // SAFETY: Although `values` are copied into the new list and not mutated,
         // `mp_obj_new_list` is taking them through a mut pointer.
         // EXCEPTION: Will raise if allocation fails.
-        catch_exception(|| unsafe {
-            let list = ffi::mp_obj_new_list(values.len(), values.as_ptr() as *mut Obj);
-            Gc::from_raw(list.as_ptr().cast())
-        })
+        let list = catch_exception!(unsafe { ffi::mp_obj_new_list } => { values.len(), values.as_ptr() as *mut Obj })?;
+        // SAFETY: `list` is a freshly created list
+        Ok(unsafe { Gc::from_raw(list.as_ptr().cast()) })
     }
 
     pub fn with_capacity(capacity: usize) -> Result<GcBox<Self>, Error> {
         // EXCEPTION: Will raise if allocation fails.
-        catch_exception(|| unsafe {
-            let list = ffi::mp_obj_new_list(capacity, ptr::null_mut());
-            // By default, the new list will have its len set to n. We want to preallocate
-            // to a specific size and then use append() to add items, so we reset len to 0.
+        let list =
+            catch_exception!(unsafe { ffi::mp_obj_new_list } => { capacity, ptr::null_mut() })?;
+        // By default, the new list will have its len set to n. We want to preallocate
+        // to a specific size and then use append() to add items, so we reset len to 0.
+        unsafe {
+            // SAFETY: setting the length of the list to 0 is safe
             ffi::mp_obj_list_set_len(list, 0);
             // SAFETY: list is freshly allocated so we are still its unique owner.
-            GcBox::from_raw(list.as_ptr().cast())
-        })
+            Ok(GcBox::from_raw(list.as_ptr().cast()))
+        }
     }
 
     pub fn from_iter<T, E>(iter: impl Iterator<Item = T>) -> Result<GcBox<List>, Error>
@@ -62,9 +63,8 @@ impl List {
             // SAFETY: self is borrowed mutably.
             let list = self.as_mut_obj();
             // EXCEPTION: Will raise if allocation fails.
-            catch_exception(|| {
-                ffi::mp_obj_list_append(list, value);
-            })
+            catch_exception!(ffi::mp_obj_list_append => { list, value })?;
+            Ok(())
         }
     }
 

--- a/core/embed/rust/src/micropython/map.rs
+++ b/core/embed/rust/src/micropython/map.rs
@@ -60,9 +60,7 @@ impl Map {
         // the backing storage for `capacity` items on the heap.
         unsafe {
             // EXCEPTION: Will raise if allocation fails.
-            catch_exception(|| {
-                ffi::mp_map_init(map.as_mut_ptr(), capacity);
-            })?;
+            catch_exception!(ffi::mp_map_init => { map.as_mut_ptr(), capacity })?;
             Ok(map.assume_init())
         }
     }
@@ -123,26 +121,18 @@ impl Map {
     }
 
     pub fn set_obj(&mut self, index: Obj, value: Obj) -> Result<(), Error> {
+        let map = self as *mut Self;
         // SAFETY:
-        //  - `mp_map_lookup` with `_mp_map_lookup_kind_t_MP_MAP_LOOKUP_ADD_IF_NOT_FOUND
-        //    returns a pointer to a `mp_map_elem_t` value with a lifetime valid for the
-        //    whole lifetime of `&mut self`.
+        //  - `mp_map_lookup` with `MP_MAP_LOOKUP_ADD_IF_NOT_FOUND` returns a non-null
+        //    pointer to a `mp_map_elem_t` value with a lifetime valid for the whole
+        //    lifetime of `&mut self`.
         //  - adding an element is an allocation, so it might raise.
         //  - the original `elem.value` might be an `Obj` that will get GCd when we
         //    replace it.
-        unsafe {
-            let map = self as *mut Self;
-            // EXCEPTION: Will raise if allocation fails.
-            let elem = unwrap!(catch_exception(|| {
-                ffi::mp_map_lookup(
-                    map,
-                    index,
-                    ffi::_mp_map_lookup_kind_t_MP_MAP_LOOKUP_ADD_IF_NOT_FOUND,
-                )
-            })?
-            .as_mut()); // `MP_MAP_LOOKUP_ADD_IF_NOT_FOUND` should always return a non-null pointer.
-            elem.value = value;
-        }
+        // EXCEPTION: Will raise if allocation fails.
+        let elem_ptr = catch_exception!(unsafe { ffi::mp_map_lookup } => { map, index, ffi::_mp_map_lookup_kind_t_MP_MAP_LOOKUP_ADD_IF_NOT_FOUND })?;
+        let elem = unwrap!(unsafe { elem_ptr.as_mut() });
+        elem.value = value;
         Ok(())
     }
 

--- a/core/embed/rust/src/micropython/obj.rs
+++ b/core/embed/rust/src/micropython/obj.rs
@@ -128,9 +128,7 @@ impl Obj {
         // SAFETY:
         //  - Each of `args` has no lifetime bounds.
         // EXCEPTION: Calls Python code so can raise arbitrarily.
-        catch_exception(|| unsafe {
-            ffi::mp_call_function_n_kw(self, args.len(), 0, args.as_ptr())
-        })
+        catch_exception!(unsafe { ffi::mp_call_function_n_kw } => { self, args.len(), 0, args.as_ptr() })
     }
 }
 
@@ -146,8 +144,7 @@ impl TryFrom<Obj> for bool {
         // SAFETY:
         //  - `obj` can be anything uPy understands.
         // EXCEPTION: Can call Python code (on custom instances) and therefore raise.
-        let is_true = catch_exception(|| unsafe { ffi::mp_obj_is_true(obj) })?;
-        Ok(is_true)
+        catch_exception!(unsafe { ffi::mp_obj_is_true } => { obj })
     }
 }
 
@@ -163,7 +160,7 @@ impl TryFrom<Obj> for i32 {
         //  - `obj` can be anything uPy understands.
         // EXCEPTION: Can raise if `obj` is int but cannot fit into `cty::mp_int_t`.
         let result =
-            catch_exception(|| unsafe { ffi::mp_obj_get_int_maybe(obj.as_ptr(), &mut int) })?;
+            catch_exception!(unsafe { ffi::mp_obj_get_int_maybe } => { obj.as_ptr(), &mut int })?;
         if result {
             Ok(int.try_into()?)
         } else {
@@ -213,7 +210,7 @@ impl TryFrom<i32> for Obj {
         // conversion type as `i32`, but convert through `into()` if the types differ.
 
         // EXCEPTION: Can raise if `val` is larger than smallint and allocation fails.
-        catch_exception(|| unsafe { ffi::mp_obj_new_int(val.into()) })
+        catch_exception!(unsafe { ffi::mp_obj_new_int } => { val.into() })
     }
 }
 
@@ -226,7 +223,7 @@ impl TryFrom<i64> for Obj {
         match i32::try_from(val) {
             Ok(smaller_val) => smaller_val.try_into(),
             // EXCEPTION: Will raise if allocation fails.
-            Err(_) => catch_exception(|| unsafe { ffi::mp_obj_new_int_from_ll(val) }),
+            Err(_) => catch_exception!(unsafe { ffi::mp_obj_new_int_from_ll } => { val }),
         }
     }
 }
@@ -241,7 +238,7 @@ impl TryFrom<u32> for Obj {
         // if the types differ.
 
         // EXCEPTION: Can raise if `val` is larger than smallint and allocation fails.
-        catch_exception(|| unsafe { ffi::mp_obj_new_int_from_uint(val.into()) })
+        catch_exception!(unsafe { ffi::mp_obj_new_int_from_uint } => { val.into() })
     }
 }
 
@@ -254,7 +251,7 @@ impl TryFrom<u64> for Obj {
         match u32::try_from(val) {
             Ok(smaller_val) => smaller_val.try_into(),
             // EXCEPTION: Will raise if allocation fails.
-            Err(_) => catch_exception(|| unsafe { ffi::mp_obj_new_int_from_ull(val) }),
+            Err(_) => catch_exception!(unsafe { ffi::mp_obj_new_int_from_ull } => { val }),
         }
     }
 }
@@ -268,7 +265,7 @@ impl TryFrom<&[u8]> for Obj {
         // SAFETY:
         //  - Should work with any data
         // EXCEPTION: Will raise if allocation fails.
-        catch_exception(|| unsafe { ffi::mp_obj_new_bytes(val.as_ptr(), val.len()) })
+        catch_exception!(unsafe { ffi::mp_obj_new_bytes } => { val.as_ptr(), val.len() })
     }
 }
 
@@ -282,7 +279,7 @@ impl TryFrom<&str> for Obj {
         // SAFETY:
         //  - `str` is guaranteed to be UTF-8.
         // EXCEPTION: Will raise if allocation fails.
-        catch_exception(|| unsafe { ffi::mp_obj_new_str(val.as_ptr().cast(), val.len()) })
+        catch_exception!(unsafe { ffi::mp_obj_new_str } => { val.as_ptr().cast(), val.len() })
     }
 }
 

--- a/core/embed/rust/src/micropython/runtime.rs
+++ b/core/embed/rust/src/micropython/runtime.rs
@@ -6,9 +6,23 @@ use super::ffi;
 
 /// Execute `func` while catching MicroPython exceptions. Returns `Ok` in the
 /// successful case, and `Err` with the caught `Obj` in case of a raise.
-pub fn catch_exception<F, T>(mut func: F) -> Result<T, Error>
+///
+/// # Safety
+///
+/// **Not intended to be called directly**. Use [`catch_exception!`] macro
+/// instead.
+///
+/// Typically, the body of `func` will call a function that may raise. When it
+/// does, the NLR jump skips over the rest of the closure, which includes any
+/// Drop impls and possibly other finalizing code. _Any_ jumping over Rust code
+/// is currently considered undefined, see also [`raise_exception`].
+///
+/// The only acceptable contents of the `func` closure is a single call to a FFI
+/// function that may raise. All other Rust code, incl. type conversions, should
+/// be placed outside `func`.
+pub unsafe fn call_protected<F, T>(func: F) -> Result<T, Error>
 where
-    F: FnMut() -> T,
+    F: FnOnce() -> T,
 {
     // Because MicroPython exceptions use `setjmp` and `longjmp`-like mechanism that
     // doesn't play too well with Rust, we setup the non-local return pads in C, and
@@ -19,9 +33,11 @@ where
         // over the return type, we cannot pass the returned value over the FFI
         // boundary, so we assign it explicitly in `wrapper`.
         let mut result = MaybeUninit::zeroed();
-        let mut wrapper = || {
+        // func is FnOnce, so we wrap it in an Option, so that we can take it out and
+        // therefore know for a fact that it will not be called again.
+        let mut wrapper = Some(|| {
             result.write(func());
-        };
+        });
         // `wrapper` is a closure, and to pass it over the FFI, we split it into a
         // function pointer, and a user-data pointer.
         // `ffi::trezor_obj_call_protected` then calls the `callback` with the
@@ -40,12 +56,146 @@ where
     }
 }
 
+/// Catch a MicroPython exception correctly.
+///
+/// This macro safely wraps the functionality of [`call_protected`]. As its
+/// argument, it expects a function name (more specifically, an expression that
+/// evaluates to a function item) and optionally a list of its arguments
+/// enclosed in curly braces.
+///
+/// The function item will typically be a FFI call to MicroPython C API that can
+/// raise an exception.
+///
+/// Internally, the macro will force all arguments to be evaluated, then
+/// generate a closure that only calls the given function with the evaluated
+/// arguments and then returns.
+///
+/// **Note:** the result of each argument expression is assigned with a let
+/// binding in a separate statement. Any temporaries are dropped at the end
+/// of the let-statement, *not* at the end of the macro invocation.
+///
+/// That means that a pointer created like this would be invalid:
+/// ```rust,ignore
+/// // VALID:
+/// call_foo(create_temporary_value().as_ptr())
+///
+/// // INVALID: temporary is dropped, by the time call_foo is invoked
+/// // from a closure, ptr is dangling
+/// catch_exception!(call_foo => { create_temporary_value().as_ptr() })
+/// ```
+///
+/// # Examples
+///
+/// ```rust,ignore
+/// let result = catch_exception!(safe_func_no_args);
+/// let result2 = catch_exception!(safe_func_no_args => { })?;
+/// catch_exception!(unsafe { ffi::mp_obj_list_append } => { list, value })?;
+/// ```
+///
+/// In case you need to call a method, you have to use the function call syntax:
+///
+/// ```rust,ignore
+/// let exception = Exception::new(TypeError, &[]);
+/// // intent: `exception.raise()`
+/// let result = catch_exception!(unsafe { Exception::raise } => { exception });
+/// ```
+///
+/// # Safety
+///
+/// While the invocation itself is safe, it will typically be invoking an unsafe
+/// function. For this reason, there is an "unsafe" spelling of the macro:
+///
+/// ```rust,ignore
+/// // Invocation of an unsafe function with safe arguments
+/// let result = catch_exception!(unsafe { unsafe_func } => { arg0, arg1 });
+/// ```
+///
+/// Invoking this way, a generated `unsafe` block will only cover the call of
+/// the unsafe function itself, but neither the macro invocation nor the
+/// argument expressions.
+///
+/// Placing the whole macro in an `unsafe` block also covers the unsafe function
+/// invocation, so the use of the internal `unsafe` is optional.
+#[macro_export]
+macro_rules! catch_exception {
+    // TERMINAL RULE: implementation of the safe catch_exception call
+    (@real safe $func:expr => { $($name:ident: $arg:expr,)* }) => {{
+        // evaluate the arguments
+        $(let $name = $arg;)*
+        // generate a closure
+        let closure = || { $func($($name),*) };
+        // call the closure
+        #[allow(unused_unsafe)]
+        unsafe { $crate::micropython::runtime::call_protected(closure) }
+    }};
+
+    // TERMINAL RULE: implementation of the unsafe catch_exception call
+    (@real not_safe $func:expr => { $($name:ident: $arg:expr,)* }) => {{
+        // evaluate the arguments
+        $(let $name = $arg;)*
+        // clippy warns that we're expanding $func in an unsafe block. The
+        // warning is spurious due to the quirk of this particular macro: in
+        // order to reach the not_safe branch, the user is already specifying
+        // $func as `unsafe { ... }`
+        #[allow(clippy::macro_metavars_in_unsafe)]
+        // generate a closure
+        let closure = || unsafe { $func($($name),*) };
+        // call the closure
+        unsafe { $crate::micropython::runtime::call_protected(closure) }
+    }};
+
+    // zip expansion: {$arg, ...}
+    (@zip $kind:ident $func:expr => { $arg:expr, $($nextarg:tt)* } { $name:ident $($nextname:ident)* } { $($collected:tt)* }) => {
+        $crate::micropython::runtime::catch_exception!(@zip $kind $func => { $($nextarg)* } { $($nextname)* } { $($collected)* $name: $arg, })
+    };
+    // zip terminator: {}
+    (@zip $kind:ident $func:expr => { } { $name:ident $($nextname:ident)* } { $($collected:tt)* }) => {
+        $crate::micropython::runtime::catch_exception!(@real $kind $func => { $($collected)* })
+    };
+
+    // start of the zip, with a list of new names
+    (@start $kind:ident $func:expr => { $($arg:expr,)* }) => {
+        $crate::micropython::runtime::catch_exception!(
+            @zip $kind $func =>
+                { $($arg,)* }
+                { _a _b _c _d _e _f _g _h _i _j _k _l _m _n _o _p _q _r _s _t _u _v _w _x _y _z }
+                { }
+        )
+    };
+
+    // INVOCATION RULE: call of unsafe function $func ($arg0, $arg1, $arg2) (no trailing comma)
+    (unsafe { $func:expr } => { $($arg:expr),* }) => {
+        $crate::micropython::runtime::catch_exception!(@start not_safe $func => { $($arg,)* })
+    };
+    // INVOCATION RULE: call of unsafe function $func ($arg0, $arg1, $arg2,) (trailing comma)
+    (unsafe { $func:expr } => { $($arg:expr,)* }) => {
+        $crate::micropython::runtime::catch_exception!(@start not_safe $func => { $($arg,)* })
+    };
+    // INVOCATION RULE: call of safe function $func ($arg0, $arg1, $arg2) (no trailing comma)
+    ($func:expr => { $($arg:expr),* }) => {
+        $crate::micropython::runtime::catch_exception!(@start safe $func => { $($arg,)* })
+    };
+    // INVOCATION RULE: call of safe function $func ($arg0, $arg1, $arg2,) (trailing comma)
+    ($func:expr => { $($arg:expr,)* }) => {
+        $crate::micropython::runtime::catch_exception!(@start safe $func => { $($arg,)* })
+    };
+
+    // INVOCATION RULES: call of $func (no arguments)
+    (unsafe { $func:expr }) => { $crate::micropython::runtime::catch_exception!(@real not_safe $func => { }) };
+    ($func:expr) => { $crate::micropython::runtime::catch_exception!(@real safe $func => { }) };
+
+}
+
+pub use catch_exception;
+
 type ProtectedArgument = *mut cty::c_void;
 type ProtectedCallback = unsafe extern "C" fn(ProtectedArgument);
 
-fn split_func_into_callback_and_argument<F>(func: &mut F) -> (ProtectedCallback, ProtectedArgument)
+fn split_func_into_callback_and_argument<F>(
+    func: &mut Option<F>,
+) -> (ProtectedCallback, ProtectedArgument)
 where
-    F: FnMut(),
+    F: FnOnce(),
 {
     // Here we mono-morphize a version of `trampoline` for each type `F`, so it
     // calls the correct `FnMut` impl, and cast `func` into its data part to use
@@ -55,33 +205,47 @@ where
 
 unsafe extern "C" fn trampoline<F>(arg: ProtectedArgument)
 where
-    F: FnMut(),
+    F: FnOnce(),
 {
-    // Synthesize a callable `*mut F` from the closure environment pointer `arg`,
-    // and call it.
-    let func = arg as *mut F;
-    unsafe {
-        (*func)();
-    }
+    // Re-synthesize a `*mut Option<F>` from the closure environment pointer `arg`
+    // SAFETY:
+    // - caller must pass a valid pointer to an Option<F>
+    // - this is the only &mut reference to arg
+    // - it is discarded immediately
+    // (furthermore, C promises not to call this function again)
+    let func = unsafe { &mut *(arg as *mut Option<F>) };
+    unwrap!(func.take())();
 }
 
 #[cfg(test)]
 mod tests {
-    use super::super::exception;
-    use super::*;
+    use super::super::exception::builtin::TypeError;
+    use super::super::exception::Exception;
+
+    fn safe_func() -> i32 {
+        1
+    }
+
+    unsafe fn unsafe_func() -> i32 {
+        2
+    }
 
     #[test]
-    fn except_returns_ok_on_no_exception() {
-        let result = catch_exception(|| 1);
-        assert!(result.is_ok());
-        assert_eq!(result.unwrap(), 1);
+    fn catch_exception_safe() {
+        let result = catch_exception!(safe_func);
+        assert!(matches!(result, Ok(1)));
+    }
+
+    #[test]
+    fn catch_exception_unsafe() {
+        let result = catch_exception!(unsafe { unsafe_func });
+        assert!(matches!(result, Ok(2)));
     }
 
     #[test]
     fn except_catches_raised() {
-        let result = catch_exception(|| unsafe {
-            exception::Exception::new(exception::builtin::TypeError, &[]).raise()
-        });
+        let result =
+            catch_exception!(unsafe { Exception::raise } => { Exception::new(TypeError, &[]) });
         assert!(result.is_err());
     }
 }

--- a/core/embed/rust/src/micropython/tuple.rs
+++ b/core/embed/rust/src/micropython/tuple.rs
@@ -26,10 +26,9 @@ impl Tuple {
         // SAFETY: Although `values` are copied into the new tuple and not mutated,
         // `mp_obj_new_tuple` is taking them through a mut pointer.
         // EXCEPTION: Will raise if allocation fails.
-        catch_exception(|| unsafe {
-            let tuple = ffi::mp_obj_new_tuple(values.len(), values.as_ptr() as *mut Obj);
-            Gc::from_raw(tuple.as_ptr().cast())
-        })
+        let tuple = catch_exception!(unsafe { ffi::mp_obj_new_tuple } => { values.len(), values.as_ptr() as *mut Obj })?;
+        // SAFETY: The tuple is valid and allocated by MicroPython.
+        Ok(unsafe { Gc::from_raw(tuple.as_ptr().cast()) })
     }
 
     pub fn as_slice(&self) -> &[Obj] {

--- a/core/embed/rust/src/micropython/util.rs
+++ b/core/embed/rust/src/micropython/util.rs
@@ -104,14 +104,7 @@ pub fn new_attrtuple(field_qstrs: &'static [Qstr], values: &[Obj]) -> Result<Obj
     //   usize. (py/qstr.h:48). This is valid for as long as Qstr is
     //   repr(transparent) and the only field is a usize. Check generated qstr.rs.
     // EXCEPTION: Raises if allocation fails, does not return NULL.
-    let obj = catch_exception(|| unsafe {
-        ffi::mp_obj_new_attrtuple(
-            field_qstrs.as_ptr() as *const _,
-            values.len(),
-            values.as_ptr(),
-        )
-    })?;
-    Ok(obj)
+    catch_exception!(unsafe { ffi::mp_obj_new_attrtuple } => { field_qstrs.as_ptr() as *const _, values.len(), values.as_ptr() })
 }
 
 pub fn iter_into_array<T, E, const N: usize>(iterable: Obj) -> Result<[T; N], Error>
@@ -139,9 +132,7 @@ where
 }
 
 pub fn modulo_format(format: Obj, args: &[Obj]) -> Result<Obj, Error> {
-    catch_exception(|| unsafe {
-        ffi::str_modulo_format(format, args.len(), args.as_ptr(), Obj::const_none())
-    })
+    catch_exception!(unsafe { ffi::str_modulo_format } => { format, args.len(), args.as_ptr(), Obj::const_none() })
 }
 
 /// Return `obj[offset : offset + len]`.
@@ -149,10 +140,8 @@ pub fn get_slice(obj: Obj, offset: u16, len: u16) -> Result<Obj, Error> {
     let start = Obj::small_int(offset);
     let stop = Obj::small_int(offset.checked_add(len).ok_or(Error::OutOfRange)?);
     let step = Obj::small_int(1);
-    catch_exception(|| unsafe {
-        let slice_obj = ffi::mp_obj_new_slice(start, stop, step);
-        ffi::mp_obj_subscr(obj, slice_obj, Obj::const_sentinel())
-    })
+    let slice_obj = catch_exception!(unsafe { ffi::mp_obj_new_slice } => { start, stop, step })?;
+    catch_exception!(unsafe { ffi::mp_obj_subscr } => { obj, slice_obj, Obj::const_sentinel() })
 }
 
 pub static EXTERNAL_DATA_ERROR: exception::ExceptionType = exception::ExceptionType::new(


### PR DESCRIPTION
<!--
For core developers:
- Assign yourself to the PR.
- Set the priority to match the original issue.
- Add the PR to the current sprint.
- If it's a draft PR, mark it as "In Progress."
- If it's a final PR, mark it as "Needs Review."

For external contributors:
- Please open an issue before submitting a PR so we can discuss whether we want to proceed with it.
-->
As mentioned on Slack, I discovered a soundness hole in the supposedly safe function `catch_exception`.

The problem is that a closure passed into `catch_exception` can raise, and the resulting NLR jump will skip over the closure finalizer. Which, while it doesn't seem to be straight out UB, certainly breaks a lot of correctness assumptions in a nasty way.
https://github.com/rust-lang/rfcs/issues/2625

To the best of my current understanding, we are (a) avoiding the miscompilation of `returns_twice` by calling `nlr_push` (that is, the target of `setjmp` equivalent) from C code that should compile it correctly. And (b) our code is not _currently_ skipping over any finalizers.

That said, "be careful about what closure you're putting in" is very much not the behavior of a safe function.

---

This PR changes the originally safe `catch_exception` to unsafe and dangerously named `_catch_exception_dangerous_do_not_call_directly`, which sort of "resolves" the soundness issues.

In addition, a helpful `catch_exception!` macro is introduced that can construct the closure in a safe way, that is:
1. first, force evaluation of all argument expressions
2. second, call the closure whose body _only_ contains the FFI function call and its already-evaluated arguments.

This way, no finalizing code should be present that could be skipped over in the NLR jump -- any relevant finalization happens only _after_ the NLR jump has been caught via the `catch_exception_dangerous` mechanism.