### PR TITLE
exit pairing screen when an already bonded device connects

### DIFF
--- a/core/.changelog.d/5897.fixed
+++ b/core/.changelog.d/5897.fixed
@@ -1,0 +1,1 @@
+Exit pairing screen when already paired host connects.

--- a/core/embed/io/ble/inc/io/ble.h
+++ b/core/embed/io/ble/inc/io/ble.h
@@ -106,14 +106,15 @@ typedef struct {
 } ble_wakeup_params_t;
 
 typedef enum {
-  BLE_NONE = 0,               // No event
-  BLE_CONNECTED = 1,          // Connected to a device
-  BLE_DISCONNECTED = 2,       // Disconnected from a device
-  BLE_PAIRING_REQUEST = 3,    // Pairing request received
-  BLE_PAIRING_CANCELLED = 4,  // Pairing was canceled by host
-  BLE_PAIRING_COMPLETED = 5,  // Pairing was completed successfully
+  BLE_NONE = 0,                // No event
+  BLE_CONNECTED = 1,           // Connected to a device
+  BLE_DISCONNECTED = 2,        // Disconnected from a device
+  BLE_PAIRING_REQUEST = 3,     // Pairing request received
+  BLE_PAIRING_CANCELLED = 4,   // Pairing was canceled by host
+  BLE_PAIRING_COMPLETED = 5,   // Pairing was completed successfully
+  BLE_PAIRING_NOT_NEEDED = 6,  // Pairing is not needed
   BLE_CONNECTION_CHANGED =
-      6,  // Connection change (e.g. different device connected)
+      7,  // Connection change (e.g. different device connected)
 } ble_event_type_t;
 
 typedef struct {

--- a/core/embed/io/ble/stm32/ble.c
+++ b/core/embed/io/ble/stm32/ble.c
@@ -338,6 +338,10 @@ static void ble_process_rx_msg_status(const uint8_t *data, uint32_t len) {
   if (msg.connected && msg.flags.bonded_connection &&
       drv->mode_requested == BLE_MODE_PAIRING) {
     // bonded device connected in pairing mode - end pairing
+
+    ble_event_t event = {.type = BLE_PAIRING_NOT_NEEDED};
+    tsqueue_enqueue(&drv->event_queue, (uint8_t *)&event, sizeof(event), NULL);
+
     ble_pairing_end(drv);
   }
 

--- a/core/embed/projects/prodtest/.changelog.d/5897.fixed
+++ b/core/embed/projects/prodtest/.changelog.d/5897.fixed
@@ -1,0 +1,1 @@
+Exit pairing screen when already paired host connects.

--- a/core/embed/rust/src/trezorhal/ble/mod.rs
+++ b/core/embed/rust/src/trezorhal/ble/mod.rs
@@ -42,6 +42,7 @@ pub fn ble_parse_event(event: ffi::ble_event_t) -> BLEEvent {
         }
         ffi::ble_event_type_t_BLE_PAIRING_CANCELLED => BLEEvent::PairingCanceled,
         ffi::ble_event_type_t_BLE_PAIRING_COMPLETED => BLEEvent::PairingCompleted,
+        ffi::ble_event_type_t_BLE_PAIRING_NOT_NEEDED => BLEEvent::PairingNotNeeded,
         ffi::ble_event_type_t_BLE_CONNECTION_CHANGED => BLEEvent::ConnectionChanged,
         _ => panic!(),
     }

--- a/core/embed/rust/src/ui/component/ble.rs
+++ b/core/embed/rust/src/ui/component/ble.rs
@@ -53,9 +53,12 @@ where
                 Event::BLE(BLEEvent::PairingCompleted),
                 BLEHandlerMode::WaitingForPairingCompletion,
             ) => return Some(BLEHandlerMsg::PairingCompleted),
-            (Event::BLE(BLEEvent::PairingCanceled | BLEEvent::Disconnected), _) => {
-                return Some(BLEHandlerMsg::Cancelled)
-            }
+            (
+                Event::BLE(
+                    BLEEvent::PairingCanceled | BLEEvent::Disconnected | BLEEvent::PairingNotNeeded,
+                ),
+                _,
+            ) => return Some(BLEHandlerMsg::Cancelled),
             _ => {}
         }
         self.inner.event(ctx, event).map(BLEHandlerMsg::Content)

--- a/core/embed/rust/src/ui/event/ble.rs
+++ b/core/embed/rust/src/ui/event/ble.rs
@@ -8,6 +8,7 @@ pub enum BLEEvent {
     ConnectionChanged,
     PairingRequest(u32),
     PairingCanceled,
+    PairingNotNeeded,
     PairingCompleted,
 }
 
@@ -19,7 +20,8 @@ impl BLEEvent {
             (3, Some(code)) => Self::PairingRequest(code),
             (4, None) => Self::PairingCanceled,
             (5, None) => Self::PairingCompleted,
-            (6, None) => Self::ConnectionChanged,
+            (6, None) => Self::PairingNotNeeded,
+            (7, None) => Self::ConnectionChanged,
             _ => return Err(Error::ValueError(c"Invalid BLE event")),
         };
         Ok(result)

--- a/core/embed/rust/src/ui/layout_eckhart/bootloader/pairing_mode.rs
+++ b/core/embed/rust/src/ui/layout_eckhart/bootloader/pairing_mode.rs
@@ -89,6 +89,9 @@ impl Component for PairingModeScreen {
         if let Event::BLE(BLEEvent::Disconnected) = event {
             return Some(PairingMsg::Cancel);
         }
+        if let Event::BLE(BLEEvent::PairingNotNeeded) = event {
+            return Some(PairingMsg::Cancel);
+        }
 
         None
     }


### PR DESCRIPTION
<!--
For core developers:
- Assign yourself to the PR.
- Set the priority to match the original issue.
- Add the PR to the current sprint.
- If it's a draft PR, mark it as "In Progress."
- If it's a final PR, mark it as "Needs Review."

For external contributors:
- Please open an issue before submitting a PR so we can discuss whether we want to proceed with it.
-->
