### PR TITLE
feat(core+python): support device unlocking during THP handshake

### DIFF
--- a/core/.changelog.d/5922.added
+++ b/core/.changelog.d/5922.added
@@ -1,0 +1,1 @@
+[T3W1] Support device unlocking during THP handshake.

--- a/core/src/trezor/wire/thp/crypto.py
+++ b/core/src/trezor/wire/thp/crypto.py
@@ -96,6 +96,7 @@ class Handshake:
         self,
         device_properties: AnyBytes,
         host_ephemeral_public_key: AnyBytes,
+        payload: AnyBytes,
     ) -> tuple[bytes, bytes, bytes]:
 
         trezor_static_private_key, trezor_static_public_key = _derive_static_key_pair()
@@ -105,7 +106,7 @@ class Handshake:
         )
         self.h = _hash_of_two(PROTOCOL_NAME, device_properties)
         self.h = _hash_of_two(self.h, host_ephemeral_public_key)
-        self.h = _hash_of_two(self.h, b"")
+        self.h = _hash_of_two(self.h, payload)
         self.h = _hash_of_two(self.h, trezor_ephemeral_public_key)
         point = curve25519.multiply(
             self.trezor_ephemeral_private_key, host_ephemeral_public_key

--- a/core/tests/test_trezor.wire.thp.crypto.py
+++ b/core/tests/test_trezor.wire.thp.crypto.py
@@ -116,7 +116,7 @@ class TestTrezorHostProtocolCrypto(unittest.TestCase):
 
         host_ephemeral_private_key = curve25519.generate_secret()
         host_ephemeral_public_key = curve25519.publickey(host_ephemeral_private_key)
-        handshake.handle_th1_crypto(b"", host_ephemeral_public_key)
+        handshake.handle_th1_crypto(b"", host_ephemeral_public_key, payload=b"\x00")
 
     def test_th2_crypto(self):
         handshake = self.handshake

--- a/python/.changelog.d/5922.added
+++ b/python/.changelog.d/5922.added
@@ -1,0 +1,1 @@
+Support device unlocking during THP handshake.

--- a/python/src/trezorlib/transport/thp/protocol_v2.py
+++ b/python/src/trezorlib/transport/thp/protocol_v2.py
@@ -225,12 +225,14 @@ class ProtocolV2Channel(Channel):
         self._read_ack()
         return self._read_handshake_completion_response()
 
-    def _send_handshake_init_request(self) -> None:
-        ha_init_req_header = MessageHeader(0, self.channel_id, 36)
-        host_ephemeral_pubkey = self._noise.write_message()
+    def _send_handshake_init_request(self, try_to_unlock: bool = True) -> None:
+        payload = self._noise.write_message(bytes([try_to_unlock]))
+        ha_init_req_header = MessageHeader(
+            0, self.channel_id, len(payload) + CHECKSUM_LENGTH
+        )
 
         thp_io.write_payload_to_wire_and_add_checksum(
-            self.transport, ha_init_req_header, host_ephemeral_pubkey
+            self.transport, ha_init_req_header, payload
         )
 
     def _read_handshake_init_response(self) -> bytes:

--- a/tests/device_tests/thp/test_handshake.py
+++ b/tests/device_tests/thp/test_handshake.py
@@ -4,6 +4,7 @@ import pytest
 
 from trezorlib.client import ProtocolV2Channel
 from trezorlib.debuglink import TrezorClientDebugLink as Client
+from trezorlib.exceptions import DeviceLocked
 
 from .connect import prepare_protocol_for_handshake
 
@@ -49,3 +50,97 @@ def test_handshake(client: Client) -> None:
     # so far no luck in solving it - it should be also tackled in FW, as it causes unexpected FW error
     client.protocol = protocol
     client.do_pairing()
+
+
+PIN4 = "1234"
+
+
+@pytest.mark.setup_client(pin=PIN4)
+def test_no_unlock(client: Client):
+    protocol = prepare_protocol_for_handshake(client)
+
+    randomness_static = os.urandom(32)
+
+    protocol._do_channel_allocation()
+    protocol._init_noise(
+        randomness_static=randomness_static,
+    )
+    # the handshake should fail since the device is locked
+    protocol._send_handshake_init_request(try_to_unlock=False)
+    protocol._read_ack()
+    with pytest.raises(DeviceLocked):
+        protocol._read_handshake_init_response()
+
+
+@pytest.mark.setup_client(pin=PIN4)
+def test_unlock_pin(client: Client):
+    protocol = prepare_protocol_for_handshake(client)
+    debug = client.debug
+
+    randomness_static = os.urandom(32)
+
+    protocol._do_channel_allocation()
+    protocol._init_noise(
+        randomness_static=randomness_static,
+    )
+    # the device should show the PIN keyboard
+    protocol._send_handshake_init_request(try_to_unlock=True)
+    protocol._read_ack()
+    debug.synchronize_at("PinKeyboard")
+    debug.input(PIN4)
+
+    protocol._read_handshake_init_response()
+    protocol._send_handshake_completion_request()
+    protocol._read_ack()
+    protocol._read_handshake_completion_response()
+    client.do_pairing()
+    client.get_seedless_session().ping("unlocked")
+
+
+@pytest.mark.setup_client(pin=PIN4)
+def test_unlock_pin_wrong(client: Client):
+    protocol = prepare_protocol_for_handshake(client)
+    debug = client.debug
+
+    randomness_static = os.urandom(32)
+
+    protocol._do_channel_allocation()
+    protocol._init_noise(
+        randomness_static=randomness_static,
+    )
+    # the device should show the PIN keyboard
+    protocol._send_handshake_init_request(try_to_unlock=True)
+    protocol._read_ack()
+    debug.synchronize_at("PinKeyboard")
+    # enter wrong PIN
+    debug.input(PIN4 + "0")
+
+    debug.synchronize_at("PinKeyboard")
+    debug.input(PIN4)
+
+    protocol._read_handshake_init_response()
+    protocol._send_handshake_completion_request()
+    protocol._read_ack()
+    protocol._read_handshake_completion_response()
+    client.do_pairing()
+    client.get_seedless_session().ping("unlocked")
+
+
+@pytest.mark.setup_client(pin=PIN4)
+def test_unlock_cancel(client: Client):
+    protocol = prepare_protocol_for_handshake(client)
+    debug = client.debug
+
+    randomness_static = os.urandom(32)
+
+    protocol._do_channel_allocation()
+    protocol._init_noise(
+        randomness_static=randomness_static,
+    )
+    # cancelling unlock should fail the handshake
+    protocol._send_handshake_init_request(try_to_unlock=True)
+    protocol._read_ack()
+    debug.synchronize_at("PinKeyboard")
+    debug.click(debug.screen_buttons.pin_passphrase_erase())
+    with pytest.raises(DeviceLocked):
+        protocol._read_handshake_init_response()


### PR DESCRIPTION
Add a flag to the first THP handshake message, so the device can:

- fail the handshake if the device is locked (current behavior)
- prompt the user to enter the PIN (similar to other non-pairing flows)

:red_circle: This is a backward-incompatible change, so Suite THP implementation **MUST** be adapted as well :red_circle: 
:point_right: https://github.com/trezor/trezor-suite/pull/22146

In case an old host performs a handshake with a new device, the device will ignore the message and emit the following log:
```
trezor.wire.thp.received_message_handler ERROR Message received is not a valid handshake init request: 32 bytes
```

- the old hanshake init request is ***32*** bytes long
- the new hanshake init request is ***33*** bytes long

<!--
For core developers:
- Assign yourself to the PR.
- Set the priority to match the original issue.
- Add the PR to the current sprint.
- If it's a draft PR, mark it as "In Progress."
- If it's a final PR, mark it as "Needs Review."

For external contributors:
- Please open an issue before submitting a PR so we can discuss whether we want to proceed with it.
-->
