### PR TITLE
fix(core): add missing `if utils.USE_POWER_MANAGER`

### DIFF
--- a/core/src/boot.py
+++ b/core/src/boot.py
@@ -114,7 +114,8 @@ async def bootscreen() -> None:
                 log.exception(__name__, e)
             utils.halt(e.__class__.__name__)
 
-    workflow.idle_timer.clear()
+    if utils.USE_POWER_MANAGER:
+        workflow.idle_timer.clear()
     loop.clear()
 
 


### PR DESCRIPTION
Found via the following traceback in emulator log:
```
0.419 trezor.loop ERROR exception:
Traceback (most recent call last):
  File "trezor/loop.py", line 169, in _step
  File "boot.py", line 117, in bootscreen
NameError: name 'workflow' isn't defined
```