### PR TITLE
Proper rendering of default ellipsis

### DIFF
--- a/core/.changelog.d/5882.fixed
+++ b/core/.changelog.d/5882.fixed
@@ -1,0 +1,1 @@
+Fix incorrect chunkified address rendering.


### PR DESCRIPTION
- proper rendering of default leading ellipsis
- do not show incomplete chunks
- proper evaluation of the last chunk
- render trailing ellipsis within the text bound