### PR TITLE
USB VCP fixes

### DIFF
--- a/core/embed/io/usb/stm32/usb_rbuf.c
+++ b/core/embed/io/usb/stm32/usb_rbuf.c
@@ -1,0 +1,90 @@
+/*
+ * This file is part of the Trezor project, https://trezor.io/
+ *
+ * Copyright (c) SatoshiLabs
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#include <trezor_rtl.h>
+
+#include <sys/irq.h>
+
+#include "usb_rbuf.h"
+
+void usb_rbuf_init(usb_rbuf_t *b, uint8_t *buf, size_t buf_size) {
+  b->buf = buf;
+  b->cap = buf_size;
+  b->used = 0;
+  b->rptr = b->buf;
+  b->wptr = b->buf;
+}
+
+void usb_rbuf_reset(usb_rbuf_t *b) {
+  irq_key_t irq_key = irq_lock();
+  b->used = 0;
+  b->rptr = b->buf;
+  b->wptr = b->buf;
+  irq_unlock(irq_key);
+}
+
+size_t usb_rbuf_used_bytes(usb_rbuf_t *b) {
+  irq_key_t irq_key = irq_lock();
+  size_t size = b->used;
+  irq_unlock(irq_key);
+  return size;
+}
+
+size_t usb_rbuf_unused_bytes(usb_rbuf_t *b) {
+  irq_key_t irq_key = irq_lock();
+  size_t size = b->cap - b->used;
+  irq_unlock(irq_key);
+  return size;
+}
+
+bool usb_rbuf_is_empty(usb_rbuf_t *b) { return usb_rbuf_used_bytes(b) == 0; }
+
+bool usb_rbuf_is_full(usb_rbuf_t *b) { return usb_rbuf_unused_bytes(b) == 0; }
+
+size_t usb_rbuf_read(usb_rbuf_t *b, uint8_t *buf, size_t buf_size) {
+  irq_key_t irq_key = irq_lock();
+  size_t to_read = MIN(buf_size, b->used);
+  size_t first_part = MIN(to_read, b->cap - (b->rptr - b->buf));
+  memcpy(buf, b->rptr, first_part);
+  size_t second_part = to_read - first_part;
+  memcpy(buf + first_part, b->buf, second_part);
+  b->rptr += first_part;
+  if (b->rptr == b->buf + b->cap) {
+    b->rptr = b->buf + second_part;
+  }
+  b->used -= to_read;
+  irq_unlock(irq_key);
+  return to_read;
+}
+
+size_t usb_rbuf_write(usb_rbuf_t *b, const uint8_t *data, size_t data_size) {
+  irq_key_t irq_key = irq_lock();
+  size_t to_write = MIN(data_size, b->cap - b->used);
+  size_t first_part = MIN(to_write, b->cap - (b->wptr - b->buf));
+  memcpy(b->wptr, data, first_part);
+  size_t second_part = to_write - first_part;
+  memcpy(b->buf, data + first_part, second_part);
+  b->wptr += first_part;
+  if (b->wptr == b->buf + b->cap) {
+    b->wptr = b->buf + second_part;
+  }
+  b->used += to_write;
+  irq_unlock(irq_key);
+  return to_write;
+}

--- a/core/embed/io/usb/stm32/usb_rbuf.h
+++ b/core/embed/io/usb/stm32/usb_rbuf.h
@@ -1,0 +1,111 @@
+/*
+ * This file is part of the Trezor project, https://trezor.io/
+ *
+ * Copyright (c) SatoshiLabs
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#pragma once
+
+#include <trezor_types.h>
+
+/** Ring buffer structure */
+typedef struct {
+  uint8_t *buf;
+  size_t cap;
+  size_t used;
+  uint8_t *rptr;
+  uint8_t *wptr;
+} usb_rbuf_t;
+
+/**
+ * @brief Initialize the ring buffer.
+ *
+ * The buffer memory must be provided by the caller and must remain valid
+ * for the lifetime of the ring buffer.
+ *
+ * @param b Pointer to the ring buffer structure to initialize.
+ * @param buf Pointer to the buffer memory.
+ * @param buf_size Size of the buffer memory in bytes.
+ */
+void usb_rbuf_init(usb_rbuf_t *b, uint8_t *buf, size_t buf_size);
+
+/**
+ * @brief Reset the ring buffer to an empty state.
+ *
+ * This function clears the contents of the ring buffer and resets
+ * the read and write pointers to the beginning of the buffer.
+ *
+ * @param b Pointer to the ring buffer structure to reset.
+ */
+void usb_rbuf_reset(usb_rbuf_t *b);
+
+/**
+ * @brief Get the number of bytes used in the ring buffer.
+ *
+ * @param b Pointer to the ring buffer structure.
+ * @return Number of bytes used in the ring buffer.
+ */
+size_t usb_rbuf_used_bytes(usb_rbuf_t *b);
+
+/**
+ * @brief Get the number of unused bytes in the ring buffer.
+ *
+ * @param b Pointer to the ring buffer structure.
+ * @return Number of unused bytes in the ring buffer.
+ */
+size_t usb_rbuf_unused_bytes(usb_rbuf_t *b);
+
+/**
+ * @brief Check if the ring buffer is empty.
+ *
+ * @param b Pointer to the ring buffer structure.
+ * @return true if the ring buffer is empty, false otherwise.
+ */
+bool usb_rbuf_is_empty(usb_rbuf_t *b);
+
+/**
+ * @brief Check if the ring buffer is full.
+ *
+ * @param b Pointer to the ring buffer structure.
+ * @return true if the ring buffer is full, false otherwise.
+ */
+bool usb_rbuf_is_full(usb_rbuf_t *b);
+
+/**
+ * @brief Read data from the ring buffer.
+ *
+ * This function reads up to `buf_size` bytes from the ring buffer into
+ * the provided `buf`. The actual number of bytes read is returned.
+ *
+ * @param b Pointer to the ring buffer structure.
+ * @param buf Pointer to the buffer where read data will be stored.
+ * @param buf_size Size of the buffer in bytes.
+ * @return Number of bytes actually read from the ring buffer.
+ */
+size_t usb_rbuf_read(usb_rbuf_t *b, uint8_t *buf, size_t buf_size);
+
+/**
+ * @brief Write data to the ring buffer.
+ *
+ * This function writes up to `data_size` bytes from the provided `data`
+ * buffer into the ring buffer. The actual number of bytes written is returned.
+ *
+ * @param b Pointer to the ring buffer structure.
+ * @param data Pointer to the data to be written to the ring buffer.
+ * @param data_size Size of the data in bytes.
+ * @return Number of bytes actually written to the ring buffer.
+ */
+size_t usb_rbuf_write(usb_rbuf_t *b, const uint8_t *data, size_t data_size);

--- a/core/embed/projects/prodtest/.changelog.d/5940.added
+++ b/core/embed/projects/prodtest/.changelog.d/5940.added
@@ -1,0 +1,1 @@
+Added an argument to the ping command.

--- a/core/embed/projects/prodtest/.changelog.d/5940.fixed
+++ b/core/embed/projects/prodtest/.changelog.d/5940.fixed
@@ -1,0 +1,1 @@
+Fixed issues with USB VCP stability.

--- a/core/embed/projects/prodtest/README.md
+++ b/core/embed/projects/prodtest/README.md
@@ -98,10 +98,12 @@ OK
 ### ping
 The `ping` command serves as a no-operation request, and the device responds with `OK` to acknowledge receipt.
 
+`ping [<text>]`
+
 Example:
 ```
-ping
-OK
+ping ABC
+OK ABC
 ```
 
 ### reboot

--- a/core/embed/projects/prodtest/cmd/prodtest_ping.c
+++ b/core/embed/projects/prodtest/cmd/prodtest_ping.c
@@ -22,13 +22,13 @@
 #include <rtl/cli.h>
 
 static void prodtest_ping(cli_t* cli) {
-  if (cli_arg_count(cli) > 0) {
+  if (cli_arg_count(cli) > 1) {
     cli_error_arg_count(cli);
     return;
   }
 
   // Respond with an OK message
-  cli_ok(cli, "");
+  cli_ok(cli, "%s", cli_arg(cli, "text"));
 }
 
 // clang-format off
@@ -37,5 +37,5 @@ PRODTEST_CLI_CMD(
   .name = "ping",
   .func = prodtest_ping,
   .info = "Send a ping to the device",
-  .args = ""
+  .args = "[<text>]"
 );

--- a/core/embed/projects/prodtest/main.c
+++ b/core/embed/projects/prodtest/main.c
@@ -129,7 +129,12 @@ static ssize_t console_read(void *context, char *buf, size_t size) {
 }
 
 static ssize_t console_write(void *context, const char *buf, size_t size) {
-  return syshandle_write_blocking(SYSHANDLE_USB_VCP, buf, size, 100);
+  static uint32_t timeout = 2000;
+  int rc = syshandle_write_blocking(SYSHANDLE_USB_VCP, buf, size, timeout);
+  // Do not wait too long if the host is not connected.
+  // This is a workaround that needs to be fixed properly later.
+  timeout = rc < size ? 100 : 2000;
+  return rc;
 }
 
 static void usb_vcp_intr_callback(void) { cli_abort(&g_cli); }

--- a/core/site_scons/models/stm32f4_common.py
+++ b/core/site_scons/models/stm32f4_common.py
@@ -130,6 +130,7 @@ def stm32f4_common_files(env, features_wanted, defines, sources, paths):
             "embed/io/usb/stm32/usb_class_vcp.c",
             "embed/io/usb/stm32/usb_class_webusb.c",
             "embed/io/usb/stm32/usb.c",
+            "embed/io/usb/stm32/usb_rbuf.c",
             "embed/io/usb/stm32/usbd_conf.c",
             "embed/io/usb/stm32/usbd_core.c",
             "embed/io/usb/stm32/usbd_ctlreq.c",

--- a/core/site_scons/models/stm32u5_common.py
+++ b/core/site_scons/models/stm32u5_common.py
@@ -159,6 +159,7 @@ def stm32u5_common_files(env, features_wanted, defines, sources, paths):
             "embed/io/usb/stm32/usb_class_vcp.c",
             "embed/io/usb/stm32/usb_class_webusb.c",
             "embed/io/usb/stm32/usb.c",
+            "embed/io/usb/stm32/usb_rbuf.c",
             "embed/io/usb/stm32/usbd_conf.c",
             "embed/io/usb/stm32/usbd_core.c",
             "embed/io/usb/stm32/usbd_ctlreq.c",


### PR DESCRIPTION
This PR fixes several issues in USB VCP communication:

1) RX side fixes - completely refactored the USB VCP driver ring buffer

    - when the buffer is full, incoming data from the host is suspended
    - ring buffer synchronization between interrupt and main task
    - the buffer is no longer a true ring buffer

2) TX side fixes
    - `syshandle_write_blocking()` now uses the entire timeout to send data
    - prodtest console writes to USB with a longer timeout

3) Improved the prodtest ping command to support an optional text parameter to return - so the ping command can be used for vcp stress test.