### PR TITLE
chore(core): remove Japan from regulatory screen

### DIFF
--- a/core/embed/rust/src/ui/layout_eckhart/firmware/homescreen.rs
+++ b/core/embed/rust/src/ui/layout_eckhart/firmware/homescreen.rs
@@ -5,7 +5,6 @@ use crate::{
     error::Error,
     io::BinaryData,
     strutil::TString,
-    time::ShortDuration,
     translations::TR,
     ui::{
         component::{text::TextStyle, Component, Event, EventCtx, Label, Never, Swipe},

--- a/core/embed/rust/src/ui/layout_eckhart/firmware/regulatory_screen.rs
+++ b/core/embed/rust/src/ui/layout_eckhart/firmware/regulatory_screen.rs
@@ -148,7 +148,7 @@ struct RegulatoryContent {
 }
 
 impl RegulatoryContent {
-    const SCREENS: usize = 9;
+    const SCREENS: usize = 8;
     const ZONES: [RegulatoryZone; RegulatoryContent::SCREENS] = [
         RegulatoryZone {
             name: Some("United States"),
@@ -186,12 +186,13 @@ impl RegulatoryContent {
             icon1: Some(theme::ICON_UKRAINE),
             icon2: None,
         },
-        RegulatoryZone {
-            name: Some("Japan"),
-            content: "",
-            icon1: Some(theme::ICON_JAPAN),
-            icon2: Some(theme::ICON_JAPAN_2),
-        },
+        // TODO: add Japan when certification completed
+        // RegulatoryZone {
+        //     name: Some("Japan"),
+        //     content: "",
+        //     icon1: Some(theme::ICON_JAPAN),
+        //     icon2: Some(theme::ICON_JAPAN_2),
+        // },
         RegulatoryZone {
             name: Some("South Korea"),
             content: "",

--- a/tests/click_tests/device_menu/common.py
+++ b/tests/click_tests/device_menu/common.py
@@ -36,7 +36,7 @@ REGULATORY_AREAS = [
     "Europe",
     "Australia",
     "Ukraine",
-    "Japan",
+    # "Japan",
     "South Korea",
     "Taiwan",
 ]


### PR DESCRIPTION
- temporarily remove the regulatory screen for Japan until the certification process is completed

[no changelog]

<!--
For core developers:
- Assign yourself to the PR.
- Set the priority to match the original issue.
- Add the PR to the current sprint.
- If it's a draft PR, mark it as "In Progress."
- If it's a final PR, mark it as "Needs Review."

For external contributors:
- Please open an issue before submitting a PR so we can discuss whether we want to proceed with it.
-->
