### PR TITLE
respect BLE settings in bootloader

### DIFF
--- a/core/.changelog.d/5952.fixed
+++ b/core/.changelog.d/5952.fixed
@@ -1,0 +1,1 @@
+[T3W1] Restart BLE advertising after re-enabling BLE.

--- a/core/embed/projects/bootloader/.changelog.d/5952.fixed
+++ b/core/embed/projects/bootloader/.changelog.d/5952.fixed
@@ -1,0 +1,1 @@
+[T3W1] Respect BLE on/off settings in bootloader.

--- a/core/embed/projects/bootloader/main.c
+++ b/core/embed/projects/bootloader/main.c
@@ -539,6 +539,10 @@ int bootloader_main(void) {
     wipe_bonds(NULL);
 #endif
 
+#ifdef USE_BACKUP_RAM
+    backup_ram_erase_protected();
+#endif
+
     // wipe info was left in bootargs
     boot_args_t args;
     bootargs_get_args(&args);

--- a/core/embed/projects/bootloader/workflow/wf_ble_pairing_request.c
+++ b/core/embed/projects/bootloader/workflow/wf_ble_pairing_request.c
@@ -45,6 +45,8 @@ static bool encode_pairing_code(uint32_t code, uint8_t *outbuf) {
 }
 
 workflow_result_t workflow_ble_pairing_request(const fw_info_t *fw) {
+  ble_set_enabled(true);
+
   if (!ble_iface_start_pairing()) {
     return WF_OK_PAIRING_FAILED;
   }
@@ -125,6 +127,8 @@ workflow_result_t workflow_ble_pairing_request(const fw_info_t *fw) {
 
 workflow_result_t workflow_wireless_setup(const fw_info_t *fw,
                                           protob_ios_t *ios) {
+  ble_set_enabled(true);
+
   if (!ble_iface_start_pairing()) {
     return WF_OK_PAIRING_FAILED;
   }

--- a/core/embed/sys/backup_ram/inc/sys/backup_ram.h
+++ b/core/embed/sys/backup_ram/inc/sys/backup_ram.h
@@ -22,14 +22,17 @@
 #include <trezor_types.h>
 
 /** Global keys for items stored in the backup RAM */
-#define BACKUP_RAM_KEY_PM_RECOVERY 0x0001  // Power management recovery data
+#define BACKUP_RAM_KEY_PM_RECOVERY 0x0001   // Power management recovery data
+#define BACKUP_RAM_KEY_BLE_SETTINGS 0x0002  // BLE settings
 
 /** Maximum size of data stored under a single key in backup RAM */
 #define BACKUP_RAM_MAX_KEY_DATA_SIZE 512
 
 typedef enum {
-  BACKUP_RAM_ITEM_PUBLIC = 0,
-  BACKUP_RAM_ITEM_PROTECTED = 1,
+  BACKUP_RAM_ITEM_PUBLIC =
+      0, /**< Public data - will be preserved on device wipe */
+  BACKUP_RAM_ITEM_PROTECTED =
+      1, /**< Protected data - will be erased on device wipe */
 } backup_ram_item_type_t;
 
 /**

--- a/core/src/apps/homescreen/device_menu.py
+++ b/core/src/apps/homescreen/device_menu.py
@@ -261,6 +261,8 @@ async def handle_UnpairDevice(index: int) -> None:
 
 async def handle_ToggleBluetooth() -> None:
     ble_enable(not ble.get_enabled())
+    if ble.get_enabled() and ble.peer_count() > 0:
+        ble.start_advertising(True, storage_device.get_label())
 
 
 async def handle_SetOrChangePin() -> None:


### PR DESCRIPTION
This PR implements a system that enables bootloader to respect BLE on/off settings as set by user in firmware.

This setting is copied to backup RAM, so that bootloader can read it after booting.

In bootloader, when user starts new pairing in menu, BLE is re-enabled automatically, but is not respected for next firmware run. 

Using backup RAM for this means that if the device is entirely discharged, and user enters bootloader on next switch on before running FW, the bluetooth will be enabled. Should be very rare situation.

Few fixes added:
- start advertising after re-enabling BLE in fimrware device menu
- wipe backup RAM along with storage/bonds in bootloader after receiving WIPE boot command.