### PR TITLE
ci(core): always upload coverage report

### DIFF
--- a/.github/workflows/core.yml
+++ b/.github/workflows/core.yml
@@ -669,6 +669,7 @@ jobs:
           path: core/htmlcov
           retention-days: 7
           include-hidden-files: true
+        if: always()
 
   core_ui_comment:
     name: Post comment with UI diff URLs


### PR DESCRIPTION
Otherwise, we don't have the coverage report in case the job fails:
https://github.com/trezor/trezor-firmware/actions/runs/18283216173/job/52053655433
