### PR TITLE
Add compile time switch to disable power manager thermal control

### DIFF
--- a/core/embed/sys/power_manager/stm32u5/power_manager.c
+++ b/core/embed/sys/power_manager/stm32u5/power_manager.c
@@ -160,7 +160,10 @@ pm_status_t pm_init(bool inherit_state) {
   // Set default SOC target and max charging current limit
   drv->soc_target = 100;
   drv->i_chg_max_limit_ma = PM_BATTERY_CHARGING_CURRENT_MAX;
+
+#ifdef PM_ENABLE_TEMP_CONTROL
   drv->i_chg_temp_limit_ma = PM_BATTERY_CHARGING_CURRENT_MAX;
+#endif
 
   // Fuel gauge SoC available, set fuel_gauge initialized.
   drv->fuel_gauge_initialized = true;

--- a/core/embed/sys/power_manager/stm32u5/power_manager_internal.h
+++ b/core/embed/sys/power_manager/stm32u5/power_manager_internal.h
@@ -52,6 +52,10 @@
 #define PM_AUTO_HIBERNATE_TIMEOUT_S (2 * 60 * 60)  // 2 hours
 
 #define PM_STABILIZATION_TIMEOUT_MS 2000
+
+// Thermal controller switch, comment out to disable the thermal controller
+#define PM_ENABLE_TEMP_CONTROL
+
 // Temperature controller parameters
 #define PM_TEMP_CONTROL_IDLE_PERIOD_MS 2 * 60 * 1000  // 2 minutes
 #define PM_TEMP_CONTROL_BAND_1_MAX_TEMP 39.0f
@@ -97,9 +101,11 @@ typedef struct {
   uint16_t i_chg_target_ma;
   uint16_t i_chg_max_limit_ma;
 
+#ifdef PM_ENABLE_TEMP_CONTROL
   // Temp controller
   uint32_t temp_control_timeout;
   uint16_t i_chg_temp_limit_ma;
+#endif
 
   // Power source hardware state
   pmic_report_t pmic_data;

--- a/core/embed/sys/power_manager/stm32u5/power_monitoring.c
+++ b/core/embed/sys/power_manager/stm32u5/power_monitoring.c
@@ -29,9 +29,14 @@
 #include "../stwlc38/stwlc38.h"
 #include "power_manager_internal.h"
 
+#ifdef PM_ENABLE_TEMP_CONTROL
 static void pm_temperature_controller(pm_driver_t* drv);
+#endif
+
 static void pm_battery_sampling(float vbat, float ibat, float ntc_temp);
 static void pm_parse_power_source_state(pm_driver_t* drv);
+
+#ifdef PM_ENABLE_TEMP_CONTROL
 
 // Temperature controller LUT
 static const struct {
@@ -43,6 +48,8 @@ static const struct {
     {PM_TEMP_CONTROL_BAND_3_MAX_TEMP, 0.5},
     {PM_TEMP_CONTROL_BAND_4_MAX_TEMP, 0.3},
 };
+
+#endif
 
 void pm_monitor_power_sources(void) {
   // Periodically called timer to request PMIC measurements. PMIC will call
@@ -168,7 +175,9 @@ void pm_charging_controller(pm_driver_t* drv) {
     drv->i_chg_target_ma = drv->i_chg_max_limit_ma;
   }
 
+#ifdef PM_ENABLE_TEMP_CONTROL
   pm_temperature_controller(drv);
+#endif
 
   if (drv->soc_target == 100) {
     drv->soc_target_reached = false;
@@ -222,6 +231,8 @@ void pm_charging_controller(pm_driver_t* drv) {
   }
 }
 
+#ifdef PM_ENABLE_TEMP_CONTROL
+
 static void pm_temperature_controller(pm_driver_t* drv) {
   if (ticks_expired(drv->temp_control_timeout)) {
     uint16_t i_chg_temp_limit_ma = 0;
@@ -248,6 +259,8 @@ static void pm_temperature_controller(pm_driver_t* drv) {
     drv->i_chg_target_ma = drv->i_chg_temp_limit_ma;
   }
 }
+
+#endif
 
 static void pm_battery_sampling(float vbat, float ibat, float ntc_temp) {
   pm_driver_t* drv = &g_pm;


### PR DESCRIPTION
Add compile time switch to quickly disable power manager thermal control. Which is needed for battery characterization in thermal chamber.