### PR TITLE
fix: let pm stabilize when resuming from suspend.

### DIFF
--- a/core/embed/sys/power_manager/stm32u5/power_manager.c
+++ b/core/embed/sys/power_manager/stm32u5/power_manager.c
@@ -655,6 +655,7 @@ bool pm_driver_resume(void) {
   drv->suspended = false;
   drv->suspending = false;
   drv->woke_up_from_suspend = true;
+  drv->state_machine_stabilized = false;
 
 #ifdef USE_RTC
   rtc_wakeup_timer_stop();


### PR DESCRIPTION
power manager stabilization flag was not reset when resuming from suspend and did not wait to get actual PMIC measurements / compensate the fuel gauge. 