### PR TITLE
Fix broken Tropic initialization in prodtest

### DIFF
--- a/core/embed/sec/tropic/tropic.c
+++ b/core/embed/sec/tropic/tropic.c
@@ -61,7 +61,7 @@ static bool tropic_get_tropic_pubkey(lt_handle_t *handle,
 
 static bool session_start(tropic_driver_t *drv,
                           pkey_index_t pairing_key_index) {
-  drv->initialized = false;
+  bool ret = false;
 
   curve25519_key trezor_private = {0};
   switch (pairing_key_index) {
@@ -101,12 +101,12 @@ static bool session_start(tropic_driver_t *drv,
   }
 
   drv->pairing_key_index = pairing_key_index;
-  drv->initialized = true;
+  ret = true;
 
 cleanup:
   memzero(trezor_private, sizeof(trezor_private));
 
-  return drv->initialized;
+  return ret;
 }
 
 bool tropic_init(void) {
@@ -123,8 +123,9 @@ bool tropic_init(void) {
 #endif
 
   if (lt_init(&drv->handle) != LT_OK) {
-    goto cleanup;
+    return false;
   }
+  drv->initialized = true;
 
   // Wait for Tropic to boot before issuing any session commands.
   uint32_t boot_start_ms = hal_ticks_ms();
@@ -149,8 +150,6 @@ bool tropic_init(void) {
   }
 #endif
 
-cleanup:
-  tropic_deinit();
   return false;
 }
 


### PR DESCRIPTION
This PR improves how we wait for Tropic to boot up and reverts some changes made in 6cc6a8779a9a7bb002a76f87dda4d1ed3ff58c8b, which broke the Tropic initialization in prodtest.

The Tropic initialization and session establishment logic is a real mess right now and needs more thought, but this PR is not the place to rework it. This PR should be the minimal change that we need to make to get prodtest working again.
 
The proper fix needs to consistently define what `g_tropic_driver.initialized` means. The commit referenced above changed the meaning of `initialized` to mean that a secure session is established and this PR reverts that, because the rest of the code does not comply with that definition. Then I think that we either need to:
- reduce the number of places where `g_tropic_driver.initialized` is checked, especially if its meaning will be that a secure session is established, or
- reintroduce `g_tropic_driver.sec_chan_established` and check it in the right places instead of initialized.