### PR TITLE
fix(core): fix usb driver event signalling

### DIFF
--- a/core/.changelog.d/5980.fixed
+++ b/core/.changelog.d/5980.fixed
@@ -1,0 +1,1 @@
+Fix false "NO USB CONNECTION" warning on the home screen.


### PR DESCRIPTION
This PR fixes the issue where the "NO USB CONNECTION" warning is displayed on the home screen even when the Trezor is properly connected and communicating.

The bug is purely cosmetic (it disappears when the home screen is redrawn) and has no functional impact. As far as I know, the issue affects T3T1 and T2T1 (and possibly T3B1) - the models that display this warning on the home screen.

This PR is more a hotfix than a final solution.

Steps to Reproduce
- Wipe T3T1
- Connect it to Suite
- Start the Tutorial and complete it by tapping through the steps
- After finishing the Tutorial, the home screen incorrectly shows the NO USB CONNECTION warning


Resolves #5972


