### PR TITLE
fix(core): avoid LED blinking on event loop restart

### DIFF
--- a/core/.changelog.d/5990.fixed
+++ b/core/.changelog.d/5990.fixed
@@ -1,0 +1,1 @@
+[T3W1] Fix homescreen LED blinking.

--- a/core/embed/rust/src/trezorhal/rgb_led.rs
+++ b/core/embed/rust/src/trezorhal/rgb_led.rs
@@ -1,9 +1,18 @@
 #![allow(dead_code)]
 
+#[cfg(feature = "ui")]
+use crate::ui::display::Color;
+
 use super::ffi;
 
 pub fn set_color(color: u32) {
     unsafe {
         ffi::rgb_led_set_color(color);
     }
+}
+
+/// Set LED color if provided, otherwise turn the LED off.
+#[cfg(feature = "ui")]
+pub fn set(color: Color) {
+    set_color(color.to_u32());
 }

--- a/core/embed/rust/src/ui/flow/swipe.rs
+++ b/core/embed/rust/src/ui/flow/swipe.rs
@@ -1,3 +1,5 @@
+#[cfg(feature = "rgb_led")]
+use crate::trezorhal::rgb_led;
 use crate::{
     error::{self, Error},
     maybe_trace::MaybeTrace,
@@ -58,7 +60,7 @@ where
     }
 
     fn render(&'s self, target: &mut R) {
-        <Self as Component>::render(self, target)
+        <Self as Component>::render(self, target);
     }
 
     #[cfg(feature = "ui_debug")]
@@ -313,6 +315,10 @@ impl Layout<Result<Obj, Error>> for SwipeFlow {
         let overflow: bool = false;
         render_on_display(None, Some(Color::black()), |target| {
             self.current_page().render(target);
+
+            #[cfg(feature = "rgb_led")]
+            rgb_led::set(target.led_color());
+
             #[cfg(feature = "ui_debug")]
             if target.should_raise_overflow_exception() {
                 overflow = true;

--- a/core/embed/rust/src/ui/layout/obj.rs
+++ b/core/embed/rust/src/ui/layout/obj.rs
@@ -14,6 +14,8 @@ use num_traits::ToPrimitive;
 #[cfg(feature = "ble")]
 use crate::ui::event::BLEEvent;
 
+#[cfg(feature = "rgb_led")]
+use crate::trezorhal::rgb_led;
 #[cfg(feature = "button")]
 use crate::{
     trezorhal::button::{PhysicalButton, PhysicalButtonEvent},
@@ -52,7 +54,7 @@ use crate::{
     },
 };
 
-#[cfg(feature = "ui_debug")]
+#[cfg(any(feature = "rgb_led", feature = "ui_debug"))]
 use crate::ui::shape::Renderer;
 
 impl AttachType {
@@ -157,6 +159,10 @@ where
         let mut overflow: bool = false;
         render_on_display(None, Some(Color::black()), |target| {
             self.inner.render(target);
+
+            #[cfg(feature = "rgb_led")]
+            rgb_led::set(target.led_color());
+
             #[cfg(feature = "ui_debug")]
             if target.should_raise_overflow_exception() {
                 overflow = true;

--- a/core/embed/rust/src/ui/layout_eckhart/component/error.rs
+++ b/core/embed/rust/src/ui/layout_eckhart/component/error.rs
@@ -1,6 +1,3 @@
-#[cfg(feature = "rgb_led")]
-use crate::trezorhal::rgb_led;
-
 use crate::{
     strutil::TString,
     ui::{
@@ -88,6 +85,6 @@ impl<'a> Component for ErrorScreen<'a> {
         self.wait_for_restart.render(target);
         self.screen_border.render(u8::MAX, target);
         #[cfg(feature = "rgb_led")]
-        rgb_led::set_color(LED_RED.into());
+        target.set_led_color(LED_RED);
     }
 }

--- a/core/embed/rust/src/ui/layout_eckhart/firmware/homescreen.rs
+++ b/core/embed/rust/src/ui/layout_eckhart/firmware/homescreen.rs
@@ -1,6 +1,3 @@
-#[cfg(feature = "rgb_led")]
-use crate::trezorhal::rgb_led;
-
 use crate::{
     error::Error,
     io::BinaryData,
@@ -150,14 +147,6 @@ impl Homescreen {
     }
 }
 
-impl Drop for Homescreen {
-    fn drop(&mut self) {
-        // Turn off the LED when homescreen is destroyed
-        #[cfg(feature = "rgb_led")]
-        rgb_led::set_color(0);
-    }
-}
-
 impl Component for Homescreen {
     type Msg = HomescreenMsg;
 
@@ -220,11 +209,7 @@ impl Component for Homescreen {
         }
 
         #[cfg(feature = "rgb_led")]
-        if let Some(rgb_led) = self.led_color {
-            rgb_led::set_color(rgb_led.to_u32());
-        } else {
-            rgb_led::set_color(0);
-        }
+        target.set_led_color(self.led_color.unwrap_or_else(Color::black));
     }
 }
 

--- a/core/embed/rust/src/ui/layout_eckhart/firmware/tutorial_screen.rs
+++ b/core/embed/rust/src/ui/layout_eckhart/firmware/tutorial_screen.rs
@@ -11,9 +11,6 @@ use crate::{
     },
 };
 
-#[cfg(feature = "rgb_led")]
-use crate::trezorhal::rgb_led;
-
 use super::{
     super::{
         component::Button,
@@ -44,6 +41,8 @@ pub struct TutorialWelcomeScreen {
     /// Timer for the led color change
     #[cfg(feature = "rgb_led")]
     timer: Timeout,
+    #[cfg(feature = "rgb_led")]
+    led_color: Color,
     /// Stopwatch for the loader animation
     stopwatch: Stopwatch,
     border: ScreenBorder,
@@ -65,6 +64,8 @@ impl TutorialWelcomeScreen {
             } else {
                 LOADER_DURATION.to_millis()
             }),
+            #[cfg(feature = "rgb_led")]
+            led_color: Color::black(),
             stopwatch: Stopwatch::new_started(),
             border: ScreenBorder::new(theme::GREEN_LIME),
         }
@@ -88,15 +89,12 @@ impl Component for TutorialWelcomeScreen {
 
     fn event(&mut self, ctx: &mut EventCtx, event: Event) -> Option<Self::Msg> {
         if let Some(ActionBarMsg::Confirmed) = self.action_bar.event(ctx, event) {
-            // Turn off the LED when the screen is destroyed
-            #[cfg(feature = "rgb_led")]
-            rgb_led::set_color(0);
             return Some(TutorialWelcomeScreenMsg::Confirmed);
         }
 
         #[cfg(feature = "rgb_led")]
         if self.timer.event(ctx, event).is_some() {
-            rgb_led::set_color(LED_COLOR.to_u32());
+            self.led_color = LED_COLOR;
             return None;
         }
 
@@ -152,6 +150,9 @@ impl Component for TutorialWelcomeScreen {
             let loader_val = (progress * LOADER_MAX_VAL as f32) as u16;
             render_loader_indeterminate(loader_val, &self.border, target);
         }
+
+        #[cfg(feature = "rgb_led")]
+        target.set_led_color(self.led_color);
     }
 }
 


### PR DESCRIPTION
If a component doesn't set the LED, it will be automatically turned off.
This way, we don't need to turn it off at `Homescreen::drop()` - which was causing blinking during event loop restarts.

Can be tested using:

```diff
diff --git a/python/src/trezorlib/cli/trezorctl.py b/python/src/trezorlib/cli/trezorctl.py
index 5b21a35185..aa3eb1ed3b 100755
--- a/python/src/trezorlib/cli/trezorctl.py
+++ b/python/src/trezorlib/cli/trezorctl.py
@@ -338,6 +338,8 @@ def version() -> str:
 @with_session(seedless=True)
 def ping(session: "Session", message: str, button_protection: bool) -> str:
     """Send ping message."""
+    for i in range(10):
+        session.ping(message, button_protection)
     return session.ping(message, button_protection)
``` 

<!--
For core developers:
- Assign yourself to the PR.
- Set the priority to match the original issue.
- Add the PR to the current sprint.
- If it's a draft PR, mark it as "In Progress."
- If it's a final PR, mark it as "Needs Review."

For external contributors:
- Please open an issue before submitting a PR so we can discuss whether we want to proceed with it.
-->
