### PR TITLE
Proper `raise_if_not_confirmed` behavior

### DIFF
--- a/core/src/apps/homescreen/device_menu.py
+++ b/core/src/apps/homescreen/device_menu.py
@@ -6,7 +6,7 @@ import storage.device as storage_device
 import trezorble as ble
 import trezorui_api
 from trezor import TR, config, log, utils
-from trezor.ui.layouts import interact, raise_if_cancelled
+from trezor.ui.layouts import interact, raise_if_not_confirmed
 from trezor.wire import ActionCancelled, PinCancelled
 from trezorui_api import CANCELLED, DeviceMenuResult
 
@@ -161,7 +161,7 @@ async def handle_device_menu() -> None:
             from apps.management.wipe_device import wipe_device
 
             try:
-                await raise_if_cancelled(
+                await raise_if_not_confirmed(
                     trezorui_api.show_warning(
                         title=TR.homescreen__title_backup_failed,
                         button=TR.words__wipe,

--- a/core/src/trezor/ui/layouts/bolt/__init__.py
+++ b/core/src/trezor/ui/layouts/bolt/__init__.py
@@ -5,7 +5,7 @@ from trezor import TR, ui, utils
 from trezor.enums import ButtonRequestType, RecoveryType
 from trezor.wire import ActionCancelled
 
-from ..common import draw_simple, interact, raise_if_cancelled, with_info
+from ..common import draw_simple, interact, raise_if_not_confirmed, with_info
 
 if TYPE_CHECKING:
     from buffer_types import AnyBytes, StrOrBytes
@@ -45,7 +45,7 @@ def confirm_action(
     if description is not None and description_param is not None:
         description = description.format(description_param)
 
-    return raise_if_cancelled(
+    return raise_if_not_confirmed(
         trezorui_api.confirm_action(
             title=title,
             action=action,
@@ -77,7 +77,7 @@ def confirm_single(
     assert template_str in description
 
     begin, _separator, end = description.partition(template_str)
-    return raise_if_cancelled(
+    return raise_if_not_confirmed(
         trezorui_api.confirm_emphasized(
             title=title,
             items=(begin, (True, description_param), end),
@@ -89,7 +89,7 @@ def confirm_single(
 
 
 def confirm_reset_device(recovery: bool = False) -> Awaitable[None]:
-    return raise_if_cancelled(
+    return raise_if_not_confirmed(
         trezorui_api.confirm_reset_device(recovery=recovery),
         "recover_device" if recovery else "setup_device",
         (ButtonRequestType.ProtectCall if recovery else ButtonRequestType.ResetDevice),
@@ -155,7 +155,7 @@ def confirm_path_warning(path: str, path_type: str | None = None) -> Awaitable[N
         if not path_type
         else f"{TR.words__unknown} {path_type.lower()}."
     )
-    return raise_if_cancelled(
+    return raise_if_not_confirmed(
         trezorui_api.show_warning(
             title=title,
             value=path,
@@ -204,7 +204,7 @@ def lock_time_disabled_warning() -> Awaitable[None]:
 
 
 def confirm_homescreen(image: AnyBytes) -> Awaitable[None]:
-    return raise_if_cancelled(
+    return raise_if_not_confirmed(
         trezorui_api.confirm_homescreen(
             title=TR.homescreen__title_set,
             image=image,
@@ -436,7 +436,7 @@ def show_warning(
     br_code: ButtonRequestType = ButtonRequestType.Warning,
 ) -> Awaitable[None]:
     button = button or TR.buttons__continue  # def_arg
-    return raise_if_cancelled(
+    return raise_if_not_confirmed(
         trezorui_api.show_warning(
             title=content,
             description=subheader or "",
@@ -470,7 +470,7 @@ def show_success(
     button: str | None = None,
 ) -> Awaitable[None]:
     button = button or TR.buttons__continue  # def_arg
-    return raise_if_cancelled(
+    return raise_if_not_confirmed(
         trezorui_api.show_success(
             title=content,
             description=subheader or "",
@@ -502,7 +502,7 @@ async def confirm_payment_request(
     is_swap = len(trades) != 0
 
     for title, text in texts:
-        await raise_if_cancelled(
+        await raise_if_not_confirmed(
             trezorui_api.confirm_value(
                 title=(title or (TR.words__swap if is_swap else TR.words__confirm)),
                 value=text,
@@ -762,7 +762,7 @@ def confirm_blob(
         )
     else:
         assert not extra_confirmation_if_not_read
-        return raise_if_cancelled(
+        return raise_if_not_confirmed(
             layout,
             br_name,
             br_code,
@@ -888,7 +888,7 @@ def confirm_properties(
     if subtitle:
         title += ": " + subtitle
 
-    return raise_if_cancelled(
+    return raise_if_not_confirmed(
         trezorui_api.confirm_properties(
             title=title,
             items=list(props),
@@ -1452,7 +1452,7 @@ if not utils.BITCOIN_ONLY:
 
 
 def confirm_joint_total(spending_amount: str, total_amount: str) -> Awaitable[None]:
-    return raise_if_cancelled(
+    return raise_if_not_confirmed(
         # FIXME: arguments for amount/fee are misused here
         trezorui_api.confirm_summary(
             amount=spending_amount,
@@ -1563,7 +1563,7 @@ def confirm_modify_fee(
 
 
 def confirm_coinjoin(max_rounds: int, max_fee_per_vbyte: str) -> Awaitable[None]:
-    return raise_if_cancelled(
+    return raise_if_not_confirmed(
         trezorui_api.confirm_coinjoin(
             max_rounds=str(max_rounds),
             max_feerate=max_fee_per_vbyte,
@@ -1828,7 +1828,7 @@ def confirm_set_new_code(
         information = TR.pin__info
         br_name = "set_pin"
 
-    return raise_if_cancelled(
+    return raise_if_not_confirmed(
         trezorui_api.confirm_emphasized(
             title=title,
             items=(

--- a/core/src/trezor/ui/layouts/bolt/reset.py
+++ b/core/src/trezor/ui/layouts/bolt/reset.py
@@ -4,7 +4,7 @@ import trezorui_api
 from trezor import TR
 from trezor.enums import ButtonRequestType
 
-from ..common import interact, raise_if_cancelled
+from ..common import interact, raise_if_not_confirmed
 
 CONFIRMED = trezorui_api.CONFIRMED  # global_import_cache
 
@@ -23,7 +23,7 @@ def show_share_words(
             group_index + 1, share_index + 1
         )
 
-    return raise_if_cancelled(
+    return raise_if_not_confirmed(
         trezorui_api.show_share_words(
             words=share_words,
             title=title,
@@ -92,7 +92,7 @@ def slip39_show_checklist(
         )
     )
 
-    return raise_if_cancelled(
+    return raise_if_not_confirmed(
         trezorui_api.show_checklist(
             title=TR.reset__slip39_checklist_title,
             button=TR.buttons__continue,
@@ -286,7 +286,7 @@ def show_intro_backup(single_share: bool, num_of_words: int | None) -> Awaitable
     else:
         description = TR.backup__info_multi_share_backup
 
-    return raise_if_cancelled(
+    return raise_if_not_confirmed(
         trezorui_api.show_info(
             title="",
             description=description,

--- a/core/src/trezor/ui/layouts/caesar/reset.py
+++ b/core/src/trezor/ui/layouts/caesar/reset.py
@@ -4,7 +4,7 @@ import trezorui_api
 from trezor import TR
 from trezor.enums import ButtonRequestType
 
-from ..common import interact, raise_if_cancelled
+from ..common import interact, raise_if_not_confirmed
 from . import confirm_action, show_success, show_warning
 
 CONFIRMED = trezorui_api.CONFIRMED  # global_import_cache
@@ -121,7 +121,7 @@ def slip39_show_checklist(
         )
     )
 
-    return raise_if_cancelled(
+    return raise_if_not_confirmed(
         trezorui_api.show_checklist(
             title=TR.reset__slip39_checklist_title,
             button=TR.buttons__continue,

--- a/core/src/trezor/ui/layouts/delizia/recovery.py
+++ b/core/src/trezor/ui/layouts/delizia/recovery.py
@@ -7,7 +7,7 @@ from trezor.enums import ButtonRequestType, RecoveryType
 from apps.common import backup_types
 
 from ..common import interact
-from . import raise_if_cancelled
+from . import raise_if_not_confirmed
 
 CONFIRMED = trezorui_api.CONFIRMED  # global_import_cache
 CANCELLED = trezorui_api.CANCELLED  # global_import_cache
@@ -91,7 +91,7 @@ def format_remaining_shares_info(
 
 
 async def show_group_share_success(share_index: int, group_index: int) -> None:
-    await raise_if_cancelled(
+    await raise_if_not_confirmed(
         trezorui_api.show_group_share_success(
             lines=[
                 TR.recovery__you_have_entered,
@@ -180,7 +180,7 @@ async def show_recovery_warning(
     br_code: ButtonRequestType = ButtonRequestType.Warning,
 ) -> None:
     button = button or TR.buttons__try_again  # def_arg
-    await raise_if_cancelled(
+    await raise_if_not_confirmed(
         trezorui_api.show_warning(
             title=content or TR.words__warning,
             value=subheader or "",

--- a/core/src/trezor/ui/layouts/delizia/reset.py
+++ b/core/src/trezor/ui/layouts/delizia/reset.py
@@ -6,7 +6,7 @@ from trezor.enums import ButtonRequestType
 from trezor.wire import ActionCancelled
 
 from ..common import interact
-from . import raise_if_cancelled, show_success
+from . import raise_if_not_confirmed, show_success
 
 CONFIRMED = trezorui_api.CONFIRMED  # global_import_cache
 
@@ -37,7 +37,7 @@ def show_share_words(
     assert len(instructions) < 3
     text_confirm = TR.reset__words_written_down_template.format(words_count)
 
-    return raise_if_cancelled(
+    return raise_if_not_confirmed(
         trezorui_api.show_share_words_extended(
             words=share_words,
             subtitle=subtitle,
@@ -327,7 +327,7 @@ def show_reset_warning(
     button: str | None = None,
     br_code: ButtonRequestType = ButtonRequestType.Warning,
 ) -> Awaitable[None]:
-    return raise_if_cancelled(
+    return raise_if_not_confirmed(
         trezorui_api.show_warning(
             title=subheader or "",
             description=content,

--- a/core/src/trezor/ui/layouts/eckhart/__init__.py
+++ b/core/src/trezor/ui/layouts/eckhart/__init__.py
@@ -5,7 +5,7 @@ from trezor import TR, ui, utils, workflow
 from trezor.enums import ButtonRequestType, RecoveryType
 from trezor.wire import ActionCancelled
 
-from ..common import draw_simple, interact, raise_if_cancelled, with_info
+from ..common import draw_simple, interact, raise_if_not_confirmed, with_info
 
 if TYPE_CHECKING:
     from buffer_types import AnyBytes, StrOrBytes
@@ -56,7 +56,7 @@ def confirm_action(
     if description is not None and description_param is not None:
         description = description.format(description_param)
 
-    return raise_if_cancelled(
+    return raise_if_not_confirmed(
         trezorui_api.confirm_action(
             title=title,
             action=action,
@@ -77,7 +77,7 @@ def confirm_action(
 
 
 def confirm_reset_device(recovery: bool = False) -> Awaitable[None]:
-    return raise_if_cancelled(
+    return raise_if_not_confirmed(
         trezorui_api.confirm_reset_device(recovery=recovery), None
     )
 
@@ -183,7 +183,7 @@ def lock_time_disabled_warning() -> Awaitable[None]:
 def confirm_homescreen(
     image: AnyBytes,
 ) -> Awaitable[None]:
-    return raise_if_cancelled(
+    return raise_if_not_confirmed(
         trezorui_api.confirm_homescreen(
             title=TR.homescreen__title_set,
             image=image,
@@ -301,7 +301,7 @@ async def show_address(
 
     if warning is None and multisig_index is not None:
         warning = TR.send__receiving_to_multisig
-    await raise_if_cancelled(
+    await raise_if_not_confirmed(
         trezorui_api.flow_get_address(
             address=address,
             title=title or TR.words__receive,
@@ -334,7 +334,7 @@ async def show_pubkey(
     br_name: str = "show_pubkey",
 ) -> None:
 
-    await raise_if_cancelled(
+    await raise_if_not_confirmed(
         trezorui_api.flow_get_pubkey(
             pubkey=pubkey,
             title=title or TR.address__public_key,
@@ -385,7 +385,7 @@ def show_warning(
     br_code: ButtonRequestType = ButtonRequestType.Warning,
 ) -> Awaitable[None]:
     button = button or TR.words__continue_anyway  # def_arg
-    return raise_if_cancelled(
+    return raise_if_not_confirmed(
         trezorui_api.show_warning(
             title=TR.words__important,
             button=button,
@@ -409,7 +409,7 @@ def show_danger(
 ) -> Awaitable[None]:
     title = title or TR.words__warning
     verb_cancel = verb_cancel or TR.buttons__cancel
-    return raise_if_cancelled(
+    return raise_if_not_confirmed(
         trezorui_api.show_danger(
             title=title,
             description=content,
@@ -430,7 +430,7 @@ def show_success(
     time_ms: int = 0,
 ) -> Coroutine[Any, Any, None]:
     button = button or TR.buttons__continue  # def_arg
-    return raise_if_cancelled(
+    return raise_if_not_confirmed(
         trezorui_api.show_success(
             title=subheader if subheader else TR.words__title_done,
             button=button,
@@ -471,7 +471,7 @@ async def confirm_payment_request(
     is_swap = len(trades) != 0
 
     for title, text in texts:
-        await raise_if_cancelled(
+        await raise_if_not_confirmed(
             trezorui_api.confirm_value(
                 title=(title or (TR.words__swap if is_swap else TR.words__confirm)),
                 value=text,
@@ -595,7 +595,7 @@ async def confirm_output(
     else:
         title = TR.send__title_sending_to
 
-    await raise_if_cancelled(
+    await raise_if_not_confirmed(
         trezorui_api.flow_confirm_output(
             title=TR.words__send,
             subtitle=title,
@@ -718,7 +718,7 @@ def confirm_blob(
             chunkify=chunkify,
             cancel=True,
         )
-        return raise_if_cancelled(
+        return raise_if_not_confirmed(
             layout,
             br_name,
             br_code,
@@ -843,7 +843,7 @@ def confirm_properties(
     if subtitle:
         title += ": " + subtitle
 
-    return raise_if_cancelled(
+    return raise_if_not_confirmed(
         trezorui_api.confirm_properties(
             title=title,
             items=list(props),
@@ -882,7 +882,7 @@ def confirm_total(
     if fee_rate_amount:
         fee_items.append((TR.confirm_total__fee_rate, fee_rate_amount, True))
 
-    return raise_if_cancelled(
+    return raise_if_not_confirmed(
         trezorui_api.confirm_summary(
             amount=total_amount,
             amount_label=total_label,
@@ -917,7 +917,7 @@ def _confirm_summary(
         list(account_items) if account_items else None
     )
     extra_props: list[PropertyType] | None = list(extra_items) if extra_items else None
-    return raise_if_cancelled(
+    return raise_if_not_confirmed(
         trezorui_api.confirm_summary(
             amount=amount,
             amount_label=amount_label,
@@ -978,7 +978,7 @@ if not utils.BITCOIN_ONLY:
         fee_items: list[PropertyType] | None = (
             list(fee_info_items) if fee_info_items else None
         )
-        await raise_if_cancelled(
+        await raise_if_not_confirmed(
             trezorui_api.flow_confirm_output(
                 title=title,
                 subtitle=subtitle,
@@ -1214,7 +1214,7 @@ if not utils.BITCOIN_ONLY:
                 ]
             )
         fee_items: list[PropertyType] | None = list(info_items) if info_items else None
-        await raise_if_cancelled(
+        await raise_if_not_confirmed(
             trezorui_api.flow_confirm_output(
                 title=verb,
                 subtitle=None,
@@ -1299,7 +1299,7 @@ if not utils.BITCOIN_ONLY:
         summary_items: list[PropertyType] = [fee_item]
         if amount_item:
             summary_items.append(amount_item)
-        await raise_if_cancelled(
+        await raise_if_not_confirmed(
             trezorui_api.flow_confirm_output(
                 title=title,
                 subtitle=None,
@@ -1480,7 +1480,7 @@ async def confirm_modify_output(
 
     send_button_request = True
     while True:
-        await raise_if_cancelled(
+        await raise_if_not_confirmed(
             address_layout,
             "modify_output" if send_button_request else None,
             ButtonRequestType.ConfirmOutput,
@@ -1522,7 +1522,7 @@ def confirm_modify_fee(
 
 
 def confirm_coinjoin(max_rounds: int, max_fee_per_vbyte: str) -> Awaitable[None]:
-    return raise_if_cancelled(
+    return raise_if_not_confirmed(
         trezorui_api.confirm_coinjoin(
             max_rounds=str(max_rounds),
             max_feerate=max_fee_per_vbyte,
@@ -1776,7 +1776,7 @@ async def pin_wipe_code_exists_popup(
 def confirm_set_new_code(
     is_wipe_code: bool,
 ) -> Awaitable[None]:
-    return raise_if_cancelled(
+    return raise_if_not_confirmed(
         trezorui_api.flow_confirm_set_new_code(is_wipe_code=is_wipe_code),
         "set_wipe_code" if is_wipe_code else "set_pin",
         BR_CODE_OTHER,
@@ -1822,7 +1822,7 @@ async def success_pin_change(curpin: str | None, newpin: str | None) -> None:
 
 
 def confirm_firmware_update(description: str, fingerprint: str) -> Awaitable[None]:
-    return raise_if_cancelled(
+    return raise_if_not_confirmed(
         trezorui_api.confirm_firmware_update(
             description=description, fingerprint=fingerprint
         ),
@@ -1832,7 +1832,7 @@ def confirm_firmware_update(description: str, fingerprint: str) -> Awaitable[Non
 
 
 def set_brightness(current: int | None = None) -> Awaitable[None]:
-    return raise_if_cancelled(
+    return raise_if_not_confirmed(
         trezorui_api.set_brightness(current=current),
         "set_brightness",
         BR_CODE_OTHER,
@@ -1841,7 +1841,7 @@ def set_brightness(current: int | None = None) -> Awaitable[None]:
 
 def tutorial(br_code: ButtonRequestType = BR_CODE_OTHER) -> Awaitable[None]:
     """Showing users how to interact with the device."""
-    return raise_if_cancelled(
+    return raise_if_not_confirmed(
         trezorui_api.tutorial(),
         "tutorial",
         br_code,

--- a/core/src/trezor/ui/layouts/eckhart/recovery.py
+++ b/core/src/trezor/ui/layouts/eckhart/recovery.py
@@ -7,7 +7,7 @@ from trezor.enums import ButtonRequestType, RecoveryType
 from apps.common import backup_types
 
 from ..common import interact
-from . import raise_if_cancelled
+from . import raise_if_not_confirmed
 
 CONFIRMED = trezorui_api.CONFIRMED  # global_import_cache
 CANCELLED = trezorui_api.CANCELLED  # global_import_cache
@@ -90,7 +90,7 @@ def format_remaining_shares_info(
 
 
 async def show_group_share_success(share_index: int, group_index: int) -> None:
-    await raise_if_cancelled(
+    await raise_if_not_confirmed(
         trezorui_api.show_group_share_success(
             lines=[
                 f"{TR.recovery__share_from_group_entered_template.format(share_index + 1, group_index + 1)}",
@@ -176,7 +176,7 @@ async def show_recovery_warning(
     button: str | None = None,
     br_code: ButtonRequestType = ButtonRequestType.Warning,
 ) -> None:
-    await raise_if_cancelled(
+    await raise_if_not_confirmed(
         trezorui_api.show_warning(
             title=subheader or TR.words__important,
             value=content or "",

--- a/core/src/trezor/ui/layouts/eckhart/reset.py
+++ b/core/src/trezor/ui/layouts/eckhart/reset.py
@@ -6,7 +6,7 @@ from trezor.enums import ButtonRequestType
 from trezor.wire import ActionCancelled
 
 from ..common import interact
-from . import raise_if_cancelled, show_success
+from . import raise_if_not_confirmed, show_success
 
 CONFIRMED = trezorui_api.CONFIRMED  # global_import_cache
 
@@ -58,7 +58,7 @@ def show_share_words(
 
     text_confirm = TR.reset__words_written_down_template.format(words_count)
 
-    return raise_if_cancelled(
+    return raise_if_not_confirmed(
         trezorui_api.show_share_words_extended(
             words=share_words,
             subtitle=subtitle,
@@ -354,7 +354,7 @@ def show_reset_warning(
     button: str | None = None,
     br_code: ButtonRequestType = ButtonRequestType.Warning,
 ) -> Awaitable[None]:
-    return raise_if_cancelled(
+    return raise_if_not_confirmed(
         trezorui_api.show_warning(
             title=subheader or "",
             description="",

--- a/core/src/trezor/wire/thp/ui.py
+++ b/core/src/trezor/wire/thp/ui.py
@@ -14,7 +14,7 @@ def confirm_pairing(
     short_text: str,
     long_text: str,
 ) -> Awaitable[None]:
-    from trezor.ui.layouts.common import raise_if_cancelled
+    from trezor.ui.layouts.common import raise_if_not_confirmed
     from trezorui_api import confirm_thp_pairing
 
     if app_name and host_name:
@@ -24,7 +24,7 @@ def confirm_pairing(
         args = (app_name or host_name or "(unknown)",)
         description = short_text
 
-    return raise_if_cancelled(
+    return raise_if_not_confirmed(
         confirm_thp_pairing(title=title, description=description, args=args),
         br_name=br_name,
     )


### PR DESCRIPTION
bd501ad8a3 renamed `raise_if_not_confirmed` to `raise_if_cancelled`, because the function did in fact only raise when a CANCELLED result was returned.

In practice, we want "raise if NOT CONFIRMED" behavior to cover other unexpected results, so this PR reverts the name change and implements the desired behavior.

<!--
For core developers:
- Assign yourself to the PR.
- Set the priority to match the original issue.
- Add the PR to the current sprint.
- If it's a draft PR, mark it as "In Progress."
- If it's a final PR, mark it as "Needs Review."

For external contributors:
- Please open an issue before submitting a PR so we can discuss whether we want to proceed with it.
-->
