### PR TITLE
chore(storage): add error string to static_assert

### DIFF
--- a/storage/storage.c
+++ b/storage/storage.c
@@ -715,7 +715,8 @@ static secbool __wur derive_kek_set(const uint8_t *pin, size_t pin_len,
   }
 #endif
 #if USE_TROPIC
-  _Static_assert(SHA256_DIGEST_LENGTH == TROPIC_MAC_AND_DESTROY_SIZE);
+  _Static_assert(SHA256_DIGEST_LENGTH == TROPIC_MAC_AND_DESTROY_SIZE,
+                 "SHA256_DIGEST_LENGTH != TROPIC_MAC_AND_DESTROY_SIZE");
   uint8_t tropic_mac_and_destroy_reset_key[TROPIC_MAC_AND_DESTROY_SIZE] = {0};
   if (!tropic_pin_set(ui_progress, stretched_pins,
                       tropic_mac_and_destroy_reset_key)) {
@@ -728,7 +729,8 @@ static secbool __wur derive_kek_set(const uint8_t *pin, size_t pin_len,
   }
 #endif
 #if USE_OPTIGA
-  _Static_assert(SHA256_DIGEST_LENGTH == OPTIGA_PIN_SECRET_SIZE);
+  _Static_assert(SHA256_DIGEST_LENGTH == OPTIGA_PIN_SECRET_SIZE,
+                 "SHA256_DIGEST_LENGTH != OPTIGA_PIN_SECRET_SIZE");
   uint8_t optiga_hmac_reset_key[SHA256_DIGEST_LENGTH] = {0};
   if (!optiga_pin_set(ui_progress, stretched_pins, optiga_hmac_reset_key)) {
     goto cleanup;


### PR DESCRIPTION
otherwise clang 21 complains that not using the string is a C23 extension

<!--
For core developers:
- Assign yourself to the PR.
- Set the priority to match the original issue.
- Add the PR to the current sprint.
- If it's a draft PR, mark it as "In Progress."
- If it's a final PR, mark it as "Needs Review."

For external contributors:
- Please open an issue before submitting a PR so we can discuss whether we want to proceed with it.
-->
