### PR TITLE
fix(python): connect once during `trezorctl get-session`

### DIFF
--- a/python/.changelog.d/6009.fixed
+++ b/python/.changelog.d/6009.fixed
@@ -1,0 +1,1 @@
+Connect once during `trezorctl get-session`.

--- a/python/src/trezorlib/cli/trezorctl.py
+++ b/python/src/trezorlib/cli/trezorctl.py
@@ -360,11 +360,11 @@ def get_session(obj: TrezorConnection, derive_cardano: bool = False) -> str:
                 "Upgrade your firmware to enable session support."
             )
 
-    session = obj.get_session(derive_cardano=derive_cardano)
-    if session.id is None:
-        raise click.ClickException("Passphrase not enabled or firmware too old.")
-    else:
-        return session.id.hex()
+        session = client.get_session(derive_cardano=derive_cardano)
+        if session.id is None:
+            raise click.ClickException("Passphrase not enabled or firmware too old.")
+        else:
+            return session.id.hex()
 
 
 @cli.command()


### PR DESCRIPTION
Otherwise, the user is prompted for THP confirmation twice on T3W1.