### PR TITLE
fix(core): fix fw hash calculation

### DIFF
--- a/core/embed/util/flash/stm32u5/flash.c
+++ b/core/embed/util/flash/stm32u5/flash.c
@@ -60,7 +60,7 @@ void flash_init(void) {
       .subarea[1] =
           {
               .first_sector = KERNEL_SECTOR_START,
-              .num_sectors = FIRMWARE_SECTOR_END - KERNEL_SECTOR_START - 1,
+              .num_sectors = FIRMWARE_SECTOR_END - KERNEL_SECTOR_START + 1,
           },
   };
 #endif


### PR DESCRIPTION
This PR fixes an incorrect `FIRMWARE_AREA` size calculation that affects firmware hash on T3W1 (`trezorctl fw get-hash`)

When hash was calculated, the last 16KB of `FIRMWARE_AREA` was omitted. 

This bug affects only the firmware (not the bootloader or the boardloader) and only build that use secure monitor - so T3W1.

