### PR TITLE
Backlight brightness increase lagging

### DIFF
--- a/core/embed/io/display/ltdc_dsi/display_driver.c
+++ b/core/embed/io/display/ltdc_dsi/display_driver.c
@@ -450,7 +450,7 @@ bool display_set_backlight(uint8_t level) {
   }
 
 #ifdef USE_BACKLIGHT
-  if (level > backlight_get()) {
+  if (level > 0 && backlight_get() == 0) {
     display_ensure_refreshed();
   }
 


### PR DESCRIPTION
While trying to increase the backlight brightness at T3W1 using the slider, it lags. The reason is implemented wait for making sure that the display gets refreshed during fade out/fade in transitions. The PR implementation of the condition limits the wait only to such cases and not to all when the brightness needs to be increased.

<!--
For core developers:
- Assign yourself to the PR.
- Set the priority to match the original issue.
- Add the PR to the current sprint.
- If it's a draft PR, mark it as "In Progress."
- If it's a final PR, mark it as "Needs Review."

For external contributors:
- Please open an issue before submitting a PR so we can discuss whether we want to proceed with it.
-->
