### PR TITLE
chore(core): add error string to static_assert

### DIFF
--- a/core/embed/upymod/modtrezorio/modtrezorio-poll.h
+++ b/core/embed/upymod/modtrezorio/modtrezorio-poll.h
@@ -53,7 +53,7 @@ static mp_obj_t parse_ble_event_data(const ble_event_t *event) {
     return mp_const_none;
   }
   // Parse pairing code
-  _Static_assert(sizeof(event->data) <= 6);
+  _Static_assert(sizeof(event->data) <= 6, "pairing code is too long");
   uint32_t code = 0;
   for (int i = 0; i < event->data_len; ++i) {
     uint8_t byte = event->data[i];


### PR DESCRIPTION
to fix C23 extension warning in clang 21

<!--
For core developers:
- Assign yourself to the PR.
- Set the priority to match the original issue.
- Add the PR to the current sprint.
- If it's a draft PR, mark it as "In Progress."
- If it's a final PR, mark it as "Needs Review."

For external contributors:
- Please open an issue before submitting a PR so we can discuss whether we want to proceed with it.
-->
