### PR TITLE
Dbg console buffer

### DIFF
--- a/core/embed/sys/dbg/dbg_console.c
+++ b/core/embed/sys/dbg/dbg_console.c
@@ -23,7 +23,7 @@
 #include <sys/dbg_console.h>
 
 void dbg_console_vprintf(const char *fmt, va_list args) {
-  char temp[80];
+  char temp[160];
   mini_vsnprintf(temp, sizeof(temp), fmt, args);
   dbg_console_write(temp, strnlen(temp, sizeof(temp)));
 }


### PR DESCRIPTION
Increasing the buffer length in "dbg_console_vprintf()" function from 80B to 160B.  It will improve the debug messages' usage.

<!--
For core developers:
- Assign yourself to the PR.
- Set the priority to match the original issue.
- Add the PR to the current sprint.
- If it's a draft PR, mark it as "In Progress."
- If it's a final PR, mark it as "Needs Review."

For external contributors:
- Please open an issue before submitting a PR so we can discuss whether we want to proceed with it.
-->
