### PR TITLE
Suspend driver backlight refactoring

### DIFF
--- a/core/embed/sys/suspend/inc/sys/suspend_io.h
+++ b/core/embed/sys/suspend/inc/sys/suspend_io.h
@@ -42,7 +42,7 @@ void suspend_cpu(void);
 typedef struct {
 #ifdef USE_BACKLIGHT
   /** Backlight level */
-  int backlight_level;
+  uint8_t backlight_level;
 #endif
 #ifdef USE_BLE
   /** State of the ble driver */


### PR DESCRIPTION
The "int backlight_level" member of struct "power_save_wakeup_params_t" has been refactored to "uint8_t data type" in order to ensure consistency throughout the whole codebase.

This PR is tightly coupled with #5797 one.

<!--
For core developers:
- Assign yourself to the PR.
- Set the priority to match the original issue.
- Add the PR to the current sprint.
- If it's a draft PR, mark it as "In Progress."
- If it's a final PR, mark it as "Needs Review."

For external contributors:
- Please open an issue before submitting a PR so we can discuss whether we want to proceed with it.
-->
