### PR TITLE
Remove "more info" when there's no more info

### DIFF
--- a/core/.changelog.d/6053.fixed
+++ b/core/.changelog.d/6053.fixed
@@ -1,0 +1,1 @@
+Removed "More info" menu item from screens that don't have more info.

--- a/core/src/trezor/ui/layouts/bolt/__init__.py
+++ b/core/src/trezor/ui/layouts/bolt/__init__.py
@@ -271,7 +271,6 @@ async def show_passphrase_from_host(passphrase: str | None) -> None:
         "passphrase_host2",
         TR.passphrase__title_confirm,
         passphrase or "",
-        info=False,
     )
 
 
@@ -727,7 +726,6 @@ def confirm_blob(
     subtitle: str | None = None,
     verb: str | None = None,
     verb_cancel: str | None = None,
-    info: bool = True,
     hold: bool = False,
     br_code: ButtonRequestType = BR_CODE_OTHER,
     ask_pagination: bool = False,

--- a/core/src/trezor/ui/layouts/caesar/__init__.py
+++ b/core/src/trezor/ui/layouts/caesar/__init__.py
@@ -289,7 +289,6 @@ async def show_passphrase_from_host(passphrase: str | None) -> None:
         "passphrase_host2",
         TR.passphrase__title_confirm,
         passphrase or "",
-        info=False,
     )
 
 
@@ -741,7 +740,6 @@ def confirm_blob(
     subtitle: str | None = None,
     verb: str | None = None,
     verb_cancel: str | None = None,  # icon
-    info: bool = True,
     hold: bool = False,
     br_code: ButtonRequestType = BR_CODE_OTHER,
     ask_pagination: bool = False,

--- a/core/src/trezor/ui/layouts/delizia/__init__.py
+++ b/core/src/trezor/ui/layouts/delizia/__init__.py
@@ -296,7 +296,6 @@ async def show_passphrase_from_host(passphrase: str | None) -> None:
         "passphrase_host2",
         TR.passphrase__title_confirm,
         passphrase or "",
-        info=False,
     )
 
 
@@ -672,7 +671,6 @@ def confirm_blob(
     subtitle: str | None = None,
     verb: str | None = None,
     verb_cancel: str | None = None,
-    info: bool = True,
     hold: bool = False,
     br_code: ButtonRequestType = BR_CODE_OTHER,
     ask_pagination: bool = False,
@@ -721,7 +719,6 @@ def confirm_blob(
             subtitle=subtitle,
             verb=verb,
             verb_cancel=verb_cancel,
-            info=info,
             hold=hold,
             chunkify=chunkify,
             prompt_screen=prompt_screen,
@@ -1429,7 +1426,6 @@ def confirm_replacement(title: str, txid: str) -> Awaitable[None]:
         txid,
         TR.send__transaction_id,
         verb=TR.buttons__continue,
-        info=False,
         br_code=ButtonRequestType.SignTx,
         prompt_screen=False,
     )

--- a/core/src/trezor/ui/layouts/eckhart/__init__.py
+++ b/core/src/trezor/ui/layouts/eckhart/__init__.py
@@ -668,7 +668,6 @@ def confirm_blob(
     subtitle: str | None = None,
     verb: str | None = None,
     verb_cancel: str | None = None,
-    info: bool = True,
     hold: bool = False,
     br_code: ButtonRequestType = BR_CODE_OTHER,
     ask_pagination: bool = False,
@@ -713,7 +712,6 @@ def confirm_blob(
             description=description,
             subtitle=subtitle,
             verb=verb,
-            info=info,
             hold=hold,
             chunkify=chunkify,
             cancel=True,
@@ -1452,7 +1450,6 @@ def confirm_replacement(title: str, txid: str) -> Awaitable[None]:
         txid,
         subtitle=TR.send__transaction_id,
         verb=TR.buttons__continue,
-        info=False,
         br_code=ButtonRequestType.SignTx,
     )
 


### PR DESCRIPTION
<!--
For core developers:
- Assign yourself to the PR.
- Set the priority to match the original issue.
- Add the PR to the current sprint.
- If it's a draft PR, mark it as "In Progress."
- If it's a final PR, mark it as "Needs Review."

For external contributors:
- Please open an issue before submitting a PR so we can discuss whether we want to proceed with it.
-->
a leftover from some previous refactor, certain screens would show "More info" option even if there is nothing to show. The PR fixes those screens.
