### PR TITLE
fix(core): avoid integer underflow in `VerticalMenu::place()`

### DIFF
--- a/core/embed/rust/src/ui/layout_delizia/component/vertical_menu.rs
+++ b/core/embed/rust/src/ui/layout_delizia/component/vertical_menu.rs
@@ -228,15 +228,14 @@ impl Component for VerticalMenu {
         self.n_items = n_items as usize;
 
         let mut remaining = bounds;
-        let n_seps = self.buttons.len() - 1;
         for (i, button) in self.buttons.iter_mut().take(self.n_items).enumerate() {
-            let (area_button, new_remaining) = remaining.split_top(MENU_BUTTON_HEIGHT);
-            button.place(area_button);
-            remaining = new_remaining;
-            if i < n_seps {
+            if i > 0 {
                 let (_area_sep, new_remaining) = remaining.split_top(MENU_SEP_HEIGHT);
                 remaining = new_remaining;
             }
+            let (area_button, new_remaining) = remaining.split_top(MENU_BUTTON_HEIGHT);
+            button.place(area_button);
+            remaining = new_remaining;
         }
         bounds
     }


### PR DESCRIPTION
[no changelog]

<!--
For core developers:
- Assign yourself to the PR.
- Set the priority to match the original issue.
- Add the PR to the current sprint.
- If it's a draft PR, mark it as "In Progress."
- If it's a final PR, mark it as "Needs Review."

For external contributors:
- Please open an issue before submitting a PR so we can discuss whether we want to proceed with it.
-->
