### PR TITLE
fix(core): use paragraphs for `show_wait_text()`

### DIFF
--- a/core/embed/rust/src/ui/layout_bolt/ui_firmware.rs
+++ b/core/embed/rust/src/ui/layout_bolt/ui_firmware.rs
@@ -9,7 +9,6 @@ use crate::{
     translations::TR,
     ui::{
         component::{
-            connect::Connect,
             image::BlendedImage,
             text::{
                 op::OpTextLayout,
@@ -1270,9 +1269,9 @@ impl FirmwareUI for UIBolt {
     }
 
     fn show_wait_text(text: TString<'static>) -> Result<impl LayoutMaybeTrace, Error> {
-        let layout =
-            RootComponent::new(Connect::new(text, fonts::FONT_NORMAL, theme::FG, theme::BG));
-        Ok(layout)
+        Ok(RootComponent::new(
+            Paragraph::new(&theme::TEXT_NORMAL, text).into_paragraphs(),
+        ))
     }
 
     fn show_warning(

--- a/core/embed/rust/src/ui/layout_caesar/ui_firmware.rs
+++ b/core/embed/rust/src/ui/layout_caesar/ui_firmware.rs
@@ -9,7 +9,6 @@ use crate::{
     translations::TR,
     ui::{
         component::{
-            connect::Connect,
             text::{
                 op::OpTextLayout,
                 paragraphs::{
@@ -1383,9 +1382,9 @@ impl FirmwareUI for UICaesar {
     }
 
     fn show_wait_text(text: TString<'static>) -> Result<impl LayoutMaybeTrace, Error> {
-        let layout =
-            RootComponent::new(Connect::new(text, fonts::FONT_NORMAL, theme::FG, theme::BG));
-        Ok(layout)
+        Ok(RootComponent::new(
+            Paragraph::new(&theme::TEXT_NORMAL, text).into_paragraphs(),
+        ))
     }
 
     fn show_warning(

--- a/core/embed/rust/src/ui/layout_delizia/ui_firmware.rs
+++ b/core/embed/rust/src/ui/layout_delizia/ui_firmware.rs
@@ -9,7 +9,6 @@ use crate::{
     translations::TR,
     ui::{
         component::{
-            connect::Connect,
             swipe_detect::SwipeSettings,
             text::{
                 op::OpTextLayout,
@@ -1301,13 +1300,9 @@ impl FirmwareUI for UIDelizia {
     }
 
     fn show_wait_text(text: TString<'static>) -> Result<impl LayoutMaybeTrace, Error> {
-        let layout = RootComponent::new(Connect::new(
-            text,
-            fonts::FONT_DEMIBOLD,
-            theme::FG,
-            theme::BG,
-        ));
-        Ok(layout)
+        Ok(RootComponent::new(
+            Paragraph::new(&theme::TEXT_DEMIBOLD, text).into_paragraphs(),
+        ))
     }
 
     fn show_warning(


### PR DESCRIPTION
It should allow multi-line text rendering for https://github.com/trezor/trezor-firmware/pull/5973#issuecomment-3436355155.

<!--
For core developers:
- Assign yourself to the PR.
- Set the priority to match the original issue.
- Add the PR to the current sprint.
- If it's a draft PR, mark it as "In Progress."
- If it's a final PR, mark it as "Needs Review."

For external contributors:
- Please open an issue before submitting a PR so we can discuss whether we want to proceed with it.
-->
