### PR TITLE
fix(core): fix missing TOUCH_END in touch driver

### DIFF
--- a/core/.changelog.d/6075.fixed
+++ b/core/.changelog.d/6075.fixed
@@ -1,0 +1,1 @@
+[T2T1,T3T1,T3W1] Fixed touch issue causing stuck hold-to-confirm buttons.

--- a/core/embed/io/touch/touch_poll.c
+++ b/core/embed/io/touch/touch_poll.c
@@ -79,8 +79,8 @@ void trace_event(uint32_t event) {
 
   systask_id_t task_id = systask_id(systask_active());
 
-  printf("%04ld [task=%d, event=%c, x=%3d, y=%3d]\r\n", time, task_id,
-         event_type, x, y);
+  dbg_printf("%d [task=%d, event=%c, x=%d, y=%d]\r\n", time, task_id,
+             event_type, x, y);
 }
 #endif
 
@@ -136,6 +136,10 @@ uint32_t touch_fsm_get_event(touch_fsm_t* fsm, uint32_t touch_state) {
         // This suggests that the previous touch was very short,
         // or/and the driver is not called very frequently.
         event = TOUCH_START | xy;
+
+        // We have to remember "false" touch state to convince
+        // the state machine to signal the TOUCH_END event next.
+        touch_state = event;
       } else {
         // Either the driver is starving or the coordinates
         // have not changed, which would suggest that the TOUCH_END


### PR DESCRIPTION
This PR fixes an issue in the touch driver where a `TOUCH_START` event might be reported without a corresponding `TOUCH_END`, which could lead to incorrect behavior on screens that use a hold-to-confirm button.

How to reproduce:
1) Go to any screen with a hold-to-confirm button.
2) Press and release the hold-to-confirm button several times in quick succession (4–5 times), then wait a second without touching the screen.
3) Repeat step 2 until you observe the erroneous behavior (usually within about 5 rounds).