### PR TITLE
bootloader: disable 'pair new device' menu item in case BLE is disabled

### DIFF
--- a/core/embed/rust/src/ui/layout_eckhart/bootloader/bld_menu_screen.rs
+++ b/core/embed/rust/src/ui/layout_eckhart/bootloader/bld_menu_screen.rs
@@ -1,7 +1,10 @@
-use crate::ui::{
-    component::{Component, Event, EventCtx},
-    geometry::{Alignment, Rect},
-    shape::Renderer,
+use crate::{
+    trezorhal::ble,
+    ui::{
+        component::{Component, Event, EventCtx},
+        geometry::{Alignment, Rect},
+        shape::Renderer,
+    },
 };
 
 use super::{
@@ -33,7 +36,8 @@ impl BldMenuScreen {
     pub fn new() -> Self {
         let bluetooth = Button::with_text("Pair new device".into())
             .styled(theme::bootloader::button_bld_menu())
-            .with_text_align(Alignment::Start);
+            .with_text_align(Alignment::Start)
+            .initially_enabled(ble::get_enabled());
         let reboot = Button::with_text("Restart".into())
             .styled(theme::bootloader::button_bld_menu())
             .with_text_align(Alignment::Start);


### PR DESCRIPTION
bootloader: disable 'pair new device' menu item in case BLE is disabled

After discussion with @Hannsek . In next steps we should add some additional information on why it is disabled or something.