### PR TITLE
fix(core): reduce +/- buttons' size to allow more text to fit

### DIFF
--- a/core/.changelog.d/6096.fixed
+++ b/core/.changelog.d/6096.fixed
@@ -1,0 +1,1 @@
+[T3W1] Reduce +/- buttons' size to allow more text to fit.

--- a/core/embed/rust/src/ui/layout_eckhart/firmware/value_input_screen.rs
+++ b/core/embed/rust/src/ui/layout_eckhart/firmware/value_input_screen.rs
@@ -163,7 +163,7 @@ struct ValueInputDialog<T: ValueInput> {
 impl<T: ValueInput> ValueInputDialog<T> {
     const BUTTON_PADDING: i16 = 10;
     const LABEL_OFFSET: i16 = 21;
-    const BUTTON_SIZE: Offset = Offset::new(138, 130);
+    const BUTTON_SIZE: Offset = Offset::new(130, 130);
     const BORDER_PADDING: i16 = 24;
     const HOLD_TIMEOUT_DURATION: Duration = Duration::from_millis(500);
     const BIG_INCREMENT: u32 = 10;


### PR DESCRIPTION
Otherwise, "seconds" translation may overflow on T3W1.

<img width="300" alt="Screenshot from 2025-10-31 09-50-31" src="https://github.com/user-attachments/assets/7ca1c96f-a221-474d-b504-69685cb2aa4b" /> => <img width="300" alt="Screenshot from 2025-10-31 09-59-26" src="https://github.com/user-attachments/assets/098f1682-3865-43c2-9848-37c1294b0cbe" />


<!--
For core developers:
- Assign yourself to the PR.
- Set the priority to match the original issue.
- Add the PR to the current sprint.
- If it's a draft PR, mark it as "In Progress."
- If it's a final PR, mark it as "Needs Review."
- If needed, add a `Notes for QA` section.

For external contributors:
- Please open an issue before submitting a PR so we can discuss whether we want to proceed with it.
-->
