### PR TITLE
Upgrade address font in Eckhart

### DIFF
--- a/core/embed/rust/src/ui/layout_eckhart/theme/firmware.rs
+++ b/core/embed/rust/src/ui/layout_eckhart/theme/firmware.rs
@@ -122,12 +122,12 @@ pub const TEXT_SMALL_LIGHT: TextStyle =
 
 /// Makes sure that the displayed text (usually address) will get divided into
 /// smaller chunks.
-pub const TEXT_MONO_ADDRESS_CHUNKS: TextStyle = TEXT_MONO_LIGHT
+pub const TEXT_MONO_ADDRESS_CHUNKS: TextStyle = TEXT_MONO_MEDIUM_LIGHT
     .with_chunks(Chunks::new(4, 13).with_max_rows(5))
     .with_line_spacing(22)
     .with_page_breaking(PageBreaking::CutAndInsertEllipsisBoth);
 
-pub const TEXT_MONO_ADDRESS: TextStyle = TEXT_MONO_LIGHT
+pub const TEXT_MONO_ADDRESS: TextStyle = TEXT_MONO_MEDIUM_LIGHT
     .with_line_breaking(LineBreaking::BreakWordsNoHyphen)
     .with_page_breaking(PageBreaking::CutAndInsertEllipsisBoth);
 


### PR DESCRIPTION
Eckhart is kind of under-utilising the space. Experimental upgrade. Changelog to be added if and when it's approved.
**Old smaller font:**
<img width="277" height="361" alt="image" src="https://github.com/user-attachments/assets/a018d344-2a79-412c-b1fe-09333a102bcc" />
<img width="277" height="361" alt="image" src="https://github.com/user-attachments/assets/0ee767da-774b-4e2c-b218-8cee5d615d58" />
**New bigger font:**
<img width="277" height="361" alt="image" src="https://github.com/user-attachments/assets/4df380d5-fb5c-48d3-b53d-bba040f08df5" />
<img width="277" height="361" alt="image" src="https://github.com/user-attachments/assets/34e1fae4-ecb8-4d61-9585-f4d26c64b6c9" />
