### PR TITLE
chore: bump versions

### DIFF
--- a/core/embed/projects/bootloader/version.h
+++ b/core/embed/projects/bootloader/version.h
@@ -4,7 +4,7 @@
 
 #define VERSION_MAJOR 2
 #define VERSION_MINOR 1
-#define VERSION_PATCH 15
+#define VERSION_PATCH 16
 #define VERSION_BUILD 0
 #define VERSION_UINT32                                            \
   (VERSION_MAJOR | (VERSION_MINOR << 8) | (VERSION_PATCH << 16) | \

--- a/core/embed/projects/firmware/version.h
+++ b/core/embed/projects/firmware/version.h
@@ -4,7 +4,7 @@
 
 #define VERSION_MAJOR 2
 #define VERSION_MINOR 9
-#define VERSION_PATCH 4
+#define VERSION_PATCH 5
 #define VERSION_BUILD 0
 
 #define FIX_VERSION_MAJOR 2

--- a/core/embed/projects/prodtest/version.h
+++ b/core/embed/projects/prodtest/version.h
@@ -4,7 +4,7 @@
 
 #define VERSION_MAJOR 0
 #define VERSION_MINOR 3
-#define VERSION_PATCH 5
+#define VERSION_PATCH 6
 #define VERSION_BUILD 0
 
 #define FIX_VERSION_MAJOR 0

--- a/core/embed/projects/secmon/version.h
+++ b/core/embed/projects/secmon/version.h
@@ -1,4 +1,4 @@
 #define VERSION_MAJOR 1
 #define VERSION_MINOR 0
-#define VERSION_PATCH 3
+#define VERSION_PATCH 4
 #define VERSION_BUILD 0

--- a/core/translations/cs.json
+++ b/core/translations/cs.json
@@ -33,7 +33,7 @@
   },
   "header": {
     "language": "cs-CZ",
-    "version": "2.9.4"
+    "version": "2.9.5"
   },
   "translations": {
     "addr_mismatch__contact_support_at": {

--- a/core/translations/de.json
+++ b/core/translations/de.json
@@ -33,7 +33,7 @@
   },
   "header": {
     "language": "de-DE",
-    "version": "2.9.4"
+    "version": "2.9.5"
   },
   "translations": {
     "addr_mismatch__contact_support_at": "Kontaktiere den Trezor Support unter",

--- a/core/translations/en.json
+++ b/core/translations/en.json
@@ -1,7 +1,7 @@
 {
   "header": {
     "language": "en-US",
-    "version": "2.9.4"
+    "version": "2.9.5"
   },
   "translations": {
     "addr_mismatch__contact_support_at": "Please contact Trezor support at",

--- a/core/translations/es.json
+++ b/core/translations/es.json
@@ -33,7 +33,7 @@
   },
   "header": {
     "language": "es-ES",
-    "version": "2.9.4"
+    "version": "2.9.5"
   },
   "translations": {
     "addr_mismatch__contact_support_at": "Contacta con atención al cliente de Trezor en",

--- a/core/translations/fr.json
+++ b/core/translations/fr.json
@@ -33,7 +33,7 @@
   },
   "header": {
     "language": "fr-FR",
-    "version": "2.9.4"
+    "version": "2.9.5"
   },
   "translations": {
     "addr_mismatch__contact_support_at": {

--- a/core/translations/it.json
+++ b/core/translations/it.json
@@ -33,7 +33,7 @@
   },
   "header": {
     "language": "it-IT",
-    "version": "2.9.4"
+    "version": "2.9.5"
   },
   "translations": {
     "addr_mismatch__contact_support_at": "Contatta l'Assistenza di Trezor all'indirizzo",

--- a/core/translations/pt.json
+++ b/core/translations/pt.json
@@ -33,7 +33,7 @@
   },
   "header": {
     "language": "pt-BR",
-    "version": "2.9.4"
+    "version": "2.9.5"
   },
   "translations": {
     "addr_mismatch__contact_support_at": "Entre em contato com o suporte Trezor em",

--- a/core/translations/signatures.json
+++ b/core/translations/signatures.json
@@ -1,8 +1,8 @@
 {
   "current": {
-    "merkle_root": "9750b0eafa3592171e519f2e549920f03831b2d8efc0b0b3612856cf041ca1b1",
-    "datetime": "2025-11-05T11:48:29.513845+00:00",
-    "commit": "fb257c66ff6ebace190b80fb1d9345533fd4a9e0"
+    "merkle_root": "9df761d89c5d8daa880ffdefa326db84ef33476667acd10d3e4d6231872ef0a9",
+    "datetime": "2025-11-06T12:36:37.140191+00:00",
+    "commit": "af302850f8b66919309100310128deacf2c8adb6"
   },
   "history": [
     {


### PR DESCRIPTION
```
tools/bump-version.py core 2.9.5
tools/bump-version.py core/embed/projects/secmon 1.0.4
tools/bump-version.py core/embed/projects/bootloader 2.1.16
tools/bump-version.py core/embed/projects/prodtest 0.3.6
```