### PR TITLE
test(core): fix `test_autolock_cancels_ui` on T3W1

### DIFF
--- a/tests/device_tests/test_autolock.py
+++ b/tests/device_tests/test_autolock.py
@@ -130,6 +130,11 @@ def test_autolock_cancels_ui(session: Session):
     session._write(messages.ButtonAck())
     # sleep more than auto-lock delay
     time.sleep(10.5)
+
+    if session.model is models.T3W1:
+        # T3W1 device will suspend - wake it up using a DebugLink message
+        session.debug_client.debug.state(messages.DebugWaitType.IMMEDIATE)
+
     resp = session._read()
 
     assert isinstance(resp, messages.Failure)


### PR DESCRIPTION
Otherwise, it will fail due to `session._read()` timeout (since the device suspends on autolock).

[no changelog]

<!--
For core developers:
- Assign yourself to the PR.
- Set the priority to match the original issue.
- Add the PR to the current sprint.
- If it's a draft PR, mark it as "In Progress."
- If it's a final PR, mark it as "Needs Review."
- If needed, add a `Notes for QA` section.

For external contributors:
- Please open an issue before submitting a PR so we can discuss whether we want to proceed with it.
-->
