### PR TITLE
fix(core): make sure to increment THP `seq_bit`

### DIFF
--- a/core/.changelog.d/6138.fixed
+++ b/core/.changelog.d/6138.fixed
@@ -1,0 +1,1 @@
+Make sure to increment THP `seq_bit`.

--- a/core/tests/test_trezor.wire.thp.writer.py
+++ b/core/tests/test_trezor.wire.thp.writer.py
@@ -6,7 +6,10 @@ from typing import Any, Awaitable
 if utils.USE_THP:
     import thp_common
     from mock_wire_interface import MockHID
+    from trezor.loop import Timeout
     from trezor.wire.thp import ENCRYPTED, PacketHeader
+    from trezor.wire.thp import alternating_bit_protocol as ABP
+    from trezor.wire.thp.channel import _MAX_RETRANSMISSION_COUNT
     from trezor.wire.thp.interface_context import ThpContext
 
 
@@ -130,6 +133,43 @@ class TestTrezorHostProtocolWriter(unittest.TestCase):
                 hexlify(self.interface.data[i]),
                 self.longer_payload_with_checksum_expected[i],
             )
+
+    def test_write_timeout(self):
+        channel = thp_common.get_new_channel(self.interface)
+        seq_bit = ABP.get_send_seq_bit(channel.channel_cache)
+
+        task = channel.write_encrypted_payload(ENCRYPTED, b"PAYLOAD")
+        task.send(None)  # start the generator
+
+        for _ in range(_MAX_RETRANSMISSION_COUNT - 1):
+            task.send(None)  # complete write
+            task.throw(Timeout())  # no ACK is received
+
+        task.send(None)  # complete write last time
+        with self.assertRaises(Timeout):
+            task.throw(Timeout())  # no ACK is received
+
+        # next write should use the next `seq_bit` (see #6138)
+        self.assertNotEqual(ABP.get_send_seq_bit(channel.channel_cache), seq_bit)
+
+    def test_write_blocked(self):
+        channel = thp_common.get_new_channel(self.interface)
+        seq_bit = ABP.get_send_seq_bit(channel.channel_cache)
+
+        task = channel.write_encrypted_payload(ENCRYPTED, b"PAYLOAD")
+        task.send(None)  # start the generator
+
+        # Re-transmit a few times
+        for _ in range(3):
+            task.send(None)  # complete write
+            task.throw(Timeout())  # no ACK is received
+
+        with self.assertRaises(Timeout):
+            # timeout write (as if `loop.sleep` has completed) using dummy "ticks" integer value
+            task.send(12345)
+
+        # next write should use the next `seq_bit` (see #6138)
+        self.assertNotEqual(ABP.get_send_seq_bit(channel.channel_cache), seq_bit)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
Otherwise, the device may get "stuck" with an older `seq_bit` while Suite is waiting for a newer one ([when the last THP ACK is lost and the host USB connection is closed](https://github.com/trezor/trezor-suite/issues/22878#issuecomment-3490123756)).