### PR TITLE
nRF board runner change to nrfutil

### DIFF
--- a/nordic/trezor/boards/arm/t3w1_revA_nrf52832/board.cmake
+++ b/nordic/trezor/boards/arm/t3w1_revA_nrf52832/board.cmake
@@ -6,7 +6,7 @@ board_runner_args(pyocd "--target=nrf52832" "--frequency=4000000")
 
 set(OPENOCD_NRF5_SUBFAMILY "nrf52")
 
-include(${ZEPHYR_BASE}/boards/common/nrfjprog.board.cmake)
+include(${ZEPHYR_BASE}/boards/common/nrfutil.board.cmake)
 include(${ZEPHYR_BASE}/boards/common/jlink.board.cmake)
 include(${ZEPHYR_BASE}/boards/common/pyocd.board.cmake)
 include(${ZEPHYR_BASE}/boards/common/openocd-nrf5.board.cmake)


### PR DESCRIPTION
Nrfjprog as part of  nRF Command Line Tools has been archived and replaced with nrfutil.

See https://www.nordicsemi.com/Products/Development-tools/nRF-Command-Line-Tools/Download :

"Important: The nRF Command Line Tools have been archived and replaced by nRF Util. No further updates will be made to the nRF Command Line Tools. Last supported operating systems are Windows 10, Linux Ubuntu 22.04, and macOS 13. The nRF Command Line Tools will remain available for download, but do not install the SEGGER J-Link version they provide if you have a newer version installed."

and

"nrfjprog executable - tool for programming through SEGGER J-LINK programmers and debuggers - nrfjprog is officially deprecated and is being replaced by nRF Util. This affects the nRF Connect SDK v2.8.0, where nrfjprog will be removed in an upcoming release. Use nRF Util for all related tasks going forward."

**It's essential to have the "nrfutil device" command installed. Just execute: "nrfutil install device" .**

<!--
For core developers:
- Assign yourself to the PR.
- Set the priority to match the original issue.
- Add the PR to the current sprint.
- If it's a draft PR, mark it as "In Progress."
- If it's a final PR, mark it as "Needs Review."
- If needed, add a `Notes for QA` section.

For external contributors:
- Please open an issue before submitting a PR so we can discuss whether we want to proceed with it.
-->
