### PR TITLE
test(core): use 10s timeout for `make test_emu_sanity`

### DIFF
--- a/core/Makefile
+++ b/core/Makefile
@@ -186,7 +186,7 @@ test_rust: ## run rs unit tests
 		-- --test-threads=1 --nocapture
 
 test_emu_sanity: ## make sure the emulator doesn't crash on startup
-	$(EMU) --disable-animation --headless --temporary-profile --command true
+	timeout -v 10 $(EMU) --disable-animation --headless --temporary-profile --command true
 
 test_emu: ## run selected device tests from python-trezor
 	$(EMU_TEST) $(PYTEST) $(TESTPATH)/device_tests $(TESTOPTS) --lang=$(TEST_LANG)


### PR DESCRIPTION
Running the sanity test should take ~1s:
```
$ time make -C core test_emu_sanity
<snip>
real	0m0.918s
user	0m0.803s
sys	0m0.109s
```

<!--
For core developers:
- Assign yourself to the PR.
- Set the priority to match the original issue.
- Add the PR to the current sprint.
- If it's a draft PR, mark it as "In Progress."
- If it's a final PR, mark it as "Needs Review."
- If needed, add a `Notes for QA` section.

For external contributors:
- Please open an issue before submitting a PR so we can discuss whether we want to proceed with it.
-->
