### PR TITLE
fix(core): handle THP during unlocking

### DIFF
--- a/core/.changelog.d/6145.fixed
+++ b/core/.changelog.d/6145.fixed
@@ -1,0 +1,1 @@
+[T3W1] Don't stall THP handling during PIN unlock.

--- a/tests/device_tests/thp/test_handshake.py
+++ b/tests/device_tests/thp/test_handshake.py
@@ -87,6 +87,11 @@ def test_unlock_pin(client: Client):
     protocol._send_handshake_init_request(try_to_unlock=True)
     protocol._read_ack()
     debug.synchronize_at("PinKeyboard")
+
+    # the device is responsive during unlock flow
+    protocol.transport.ping()
+    protocol.sync_responses()
+
     debug.input(PIN4)
 
     protocol._read_handshake_init_response()


### PR DESCRIPTION
Following https://github.com/trezor/trezor-firmware/pull/5922, we should continue processing low-level THP events while waiting for the device to be unlocked from a soft-lock.