### PR TITLE
nRF version readout for nRF App update using MCUboot SMP

### DIFF
--- a/core/embed/rust/rust_smp.h
+++ b/core/embed/rust/rust_smp.h
@@ -1,12 +1,96 @@
+/*
+ * This file is part of the Trezor project, https://trezor.io/
+ *
+ * Copyright (c) SatoshiLabs
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
 #pragma once
 
 #include <trezor_types.h>
 
+/**
+ * @brief Parsed nRF application version in format
+ * "major.minor.revision[.build_num]".
+ *
+ * Matches MCUboot image header layout (8 bytes total).
+ * If the optional build number is absent it defaults to 0.
+ */
+typedef struct __packed {
+  uint8_t major;      /**< Major version (0..255). */
+  uint8_t minor;      /**< Minor version (0..255). */
+  uint16_t revision;  /**< Revision (0..65535). */
+  uint32_t build_num; /**< Optional build number (0..4294967295). */
+} nrf_app_version_t;
+
+/**
+ * @brief Send an SMP Echo request with a small text payload.
+ *
+ * @param text Pointer to ASCII data (not null-terminated).
+ * @param text_len Number of bytes to send.
+ * @return true on successful send and valid response, false otherwise.
+ *
+ * @note Length is bounded by underlying SMP MTU; oversized input fails.
+ */
 bool smp_echo(const char* text, uint8_t text_len);
 
+/**
+ * @brief Issue an SMP Reset request to the remote nRF device.
+ *
+ * Sends a reset command and does not wait for the device to come back.
+ * @return void
+ */
 void smp_reset(void);
 
+/**
+ * @brief Retrieve and parse the active nRF application version via SMP.
+ *
+ * Performs an Image State read, extracts the version string, and fills
+ * the provided structure with numeric fields.
+ *
+ * @param out Pointer to nrf_app_version_t to be filled (must be valid).
+ * @return true on success, false on failure (communication or parse error).
+ *
+ * @warning Fails if SMP channel not acquired or version format invalid.
+ */
+bool smp_image_version_get(nrf_app_version_t* out);
+
+/**
+ * @brief Feed a received transport byte into the SMP RX state machine.
+ *
+ * Call for each byte arriving from the nRF link (i.e. UART).
+ * Assembles frames and dispatches completed SMP responses internally.
+ *
+ * @param byte Received raw byte.
+ * @return void
+ */
 void smp_process_rx_byte(uint8_t byte);
 
+/**
+ * @brief Upload an MCUboot image to the nRF device over SMP.
+ *
+ * Streams the binary image followed by hash metadata (if required) using
+ * SMP upload semantics.
+ *
+ * @param data Pointer to image buffer.
+ * @param len Size of image buffer in bytes.
+ * @param image_hash Pointer to hash bytes (may be NULL if not used).
+ * @param image_hash_len Length of hash (e.g. 32 for SHA-256).
+ * @return true if upload completed successfully, false on error.
+ *
+ * @note Caller must ensure image fits partition and hash matches expected size.
+ */
 bool smp_upload_app_image(const uint8_t* data, size_t len,
                           const uint8_t* image_hash, size_t image_hash_len);

--- a/core/embed/rust/src/smp/image_info.rs
+++ b/core/embed/rust/src/smp/image_info.rs
@@ -1,0 +1,173 @@
+use super::{
+    receiver_acquire, receiver_release, send_request, wait_for_response, MsgType, SmpBuffer,
+    SmpHeader, SMP_CMD_ID_IMAGE_STATE, SMP_GROUP_IMAGE, SMP_HEADER_SIZE, SMP_OP_READ,
+};
+use crate::time::Duration;
+use minicbor::{data::Type, decode, Decoder, Encoder};
+
+/// MCUboot-compatible version structure matching image header format
+#[derive(Clone, Copy, Debug)]
+pub struct AppVersion {
+    pub major: u8,
+    pub minor: u8,
+    pub revision: u16,
+    pub build_num: u32,
+}
+
+/// Parse "<major>.<minor>.<revision>[.<build>]" into AppVersion (no allocation)
+/// Matches MCUboot image header version format
+/// Examples: "1.0.3", "1.0.3.0", "255.255.65535.4294967295"
+fn parse_app_version(s: &str) -> Option<AppVersion> {
+    let mut parts = s.split('.');
+
+    let major = parts.next()?.parse::<u8>().ok()?;
+    let minor = parts.next()?.parse::<u8>().ok()?;
+    let revision = parts.next()?.parse::<u16>().ok()?;
+
+    // Build number is optional (defaults to 0 if absent)
+    let build_num = parts
+        .next()
+        .filter(|b| !b.is_empty())
+        .map_or(Some(0), |b| b.parse::<u32>().ok())?;
+
+    // Reject if there are more than 4 parts
+    if parts.next().is_some() {
+        return None;
+    }
+
+    Some(AppVersion {
+        major,
+        minor,
+        revision,
+        build_num,
+    })
+}
+
+/// Send SMP Image State request, parse CBOR, and return parsed version numbers.
+pub fn get_version_numbers() -> Option<AppVersion> {
+    let mut cbor_data = [0u8; 16];
+    let mut data = [0u8; 32];
+    let mut tx_buf = [0u8; 64];
+
+    let mut writer = SmpBuffer::new(&mut cbor_data);
+    let mut enc = Encoder::new(&mut writer);
+    // Empty map as request body
+    unwrap!(enc.map(0));
+
+    unwrap!(receiver_acquire());
+
+    let data_len = writer.bytes_written();
+    let header = SmpHeader::new(
+        SMP_OP_READ,
+        data_len,
+        SMP_GROUP_IMAGE,
+        0,
+        SMP_CMD_ID_IMAGE_STATE,
+    )
+    .to_bytes();
+
+    data[..SMP_HEADER_SIZE].copy_from_slice(&header);
+    data[SMP_HEADER_SIZE..SMP_HEADER_SIZE + data_len].copy_from_slice(&cbor_data[..data_len]);
+
+    if send_request(&mut data[..SMP_HEADER_SIZE + data_len], &mut tx_buf).is_err() {
+        receiver_release();
+        return None;
+    }
+
+    let mut cbor_payload = [0u8; 256];
+    let res = wait_for_response(
+        MsgType::ImageStateResponse,
+        &mut cbor_payload,
+        Duration::from_millis(2000),
+    );
+    if res.is_err() {
+        return None;
+    }
+
+    extract_version_numbers_from_cbor(&cbor_payload).ok()
+}
+
+// Walk CBOR: { "images": [ { "version": "x.y.z[.t]" , ... } , ... ], ... }
+fn extract_version_numbers_from_cbor(cbor: &[u8]) -> Result<AppVersion, decode::Error> {
+    let mut dec = Decoder::new(cbor);
+
+    // Outer map (definite/indefinite)
+    match dec.map()? {
+        Some(n) => {
+            for _ in 0..n {
+                let key = dec.str()?;
+                if key == "images" {
+                    return parse_images_array_for_version(&mut dec);
+                } else {
+                    dec.skip()?;
+                }
+            }
+        }
+        None => loop {
+            if let Type::Break = dec.datatype()? {
+                dec.skip()?;
+                break;
+            }
+            let key = dec.str()?;
+            if key == "images" {
+                return parse_images_array_for_version(&mut dec);
+            } else {
+                dec.skip()?;
+            }
+        },
+    }
+
+    Err(decode::Error::message("images not found"))
+}
+
+fn parse_images_array_for_version(dec: &mut Decoder) -> Result<AppVersion, decode::Error> {
+    match dec.array()? {
+        Some(n) => {
+            // Read first element only
+            if n == 0 {
+                return Err(decode::Error::message("no images"));
+            }
+            parse_image_map_for_version(dec)
+        }
+        None => {
+            // Indefinite array: read first item, then stop
+            if let Type::Break = dec.datatype()? {
+                dec.skip()?;
+                return Err(decode::Error::message("no images"));
+            }
+            parse_image_map_for_version(dec)
+        }
+    }
+}
+
+fn parse_image_map_for_version(dec: &mut Decoder) -> Result<AppVersion, decode::Error> {
+    match dec.map()? {
+        Some(n) => {
+            for _ in 0..n {
+                let key = dec.str()?;
+                if key == "version" {
+                    let s = dec.str()?;
+                    return parse_app_version(s)
+                        .ok_or_else(|| decode::Error::message("bad version string"));
+                } else {
+                    dec.skip()?;
+                }
+            }
+        }
+        None => loop {
+            if let Type::Break = dec.datatype()? {
+                dec.skip()?;
+                break;
+            }
+            let key = dec.str()?;
+            if key == "version" {
+                let s = dec.str()?;
+                return parse_app_version(s)
+                    .ok_or_else(|| decode::Error::message("bad version string"));
+            } else {
+                dec.skip()?;
+            }
+        },
+    }
+    Err(decode::Error::message("version not found"))
+}

--- a/core/embed/rust/src/smp/mod.rs
+++ b/core/embed/rust/src/smp/mod.rs
@@ -2,6 +2,7 @@ mod api;
 mod base64;
 mod crc16;
 mod echo;
+mod image_info;
 mod reset;
 mod upload;
 
@@ -24,6 +25,7 @@ pub const SMP_GROUP_IMAGE: u16 = 1;
 
 pub const SMP_CMD_ID_ECHO: u8 = 0;
 pub const SMP_CMD_ID_RESET: u8 = 5;
+pub const SMP_CMD_ID_IMAGE_STATE: u8 = 0;
 pub const SMP_CMD_ID_IMAGE_UPLOAD: u8 = 1;
 
 pub const SMP_OP_READ: u8 = 0;
@@ -226,6 +228,7 @@ impl<'a> Write for SmpBuffer<'a> {
 #[derive(Copy, Clone, PartialEq)]
 pub enum MsgType {
     Echo,
+    ImageStateResponse,
     ImageUploadResponse,
     Unknown,
 }
@@ -343,6 +346,9 @@ impl SmpReceiver {
         match (group, cmd_id) {
             (SMP_GROUP_OS, SMP_CMD_ID_ECHO) => {
                 self.msg_type = Some(MsgType::Echo);
+            }
+            (SMP_GROUP_IMAGE, SMP_CMD_ID_IMAGE_STATE) => {
+                self.msg_type = Some(MsgType::ImageStateResponse);
             }
             (SMP_GROUP_IMAGE, SMP_CMD_ID_IMAGE_UPLOAD) => {
                 self.msg_type = Some(MsgType::ImageUploadResponse);


### PR DESCRIPTION
This PR resolves https://github.com/trezor/trezor-firmware/issues/6043 issue.

The nRF FW is divided into 2 parts: MCUboot and application. Both parts are flashed as a merged binary file at the production line where the MCUboot is immutable and application ca be updated throughout the time. The update in the field is performed by MCU FW which embeds the nRF application inside. The decision whether an update is needed is based on MCU to nRF application SPI communication and hash comparison. In case it fails, there is no information available for decision => it was assumed that nRF app image is corrupted and update is needed.

The PR leaves the MCU to nRF SPI communication and has comparison intact but offers another option of nRF app version readout via nRF MCUboot by using UART interface with MCUboot's SMP serial recovery feature see https://docs.nordicsemi.com/bundle/ncs-latest/page/zephyr/services/device_mgmt/smp_groups/smp_group_1.html . Specifically "Get state of images request/response".

<!--
For core developers:
- Assign yourself to the PR.
- Set the priority to match the original issue.
- Add the PR to the current sprint.
- If it's a draft PR, mark it as "In Progress."
- If it's a final PR, mark it as "Needs Review."
- If needed, add a `Notes for QA` section.

For external contributors:
- Please open an issue before submitting a PR so we can discuss whether we want to proceed with it.
-->
