### PR TITLE
build(core): fix firmware build with DISABLE_OPTIGA=1

### DIFF
--- a/core/embed/sec/secret/stm32u5/secret_keys.c
+++ b/core/embed/sec/secret/stm32u5/secret_keys.c
@@ -49,12 +49,12 @@ secbool secret_key_optiga_masking(uint8_t dest[ECDSA_PRIVATE_KEY_SIZE]) {
                                      KEY_INDEX_OPTIGA_MASKING, dest);
 }
 
+#endif  // USE_OPTIGA
+
 secbool secret_key_delegated_identity(uint8_t dest[ECDSA_PRIVATE_KEY_SIZE]) {
   return secret_key_derive_nist256p1(SECRET_UNPRIVILEGED_MASTER_KEY_SLOT,
                                      KEY_INDEX_DELEGATED_IDENTITY, dest);
 }
-
-#endif  // USE_OPTIGA
 
 #ifdef USE_TROPIC
 static secbool secret_key_derive_curve25519(uint8_t slot, uint16_t index,


### PR DESCRIPTION
Fixes `make build_firmware TREZOR_MODEL=T3W1 DISABLE_OPTIGA=1`. ~~It only makes the build pass, trying to use the Evolu app throws an exception regarding missing Optiga. While we have Optiga model used for emulator I don't think we should include in any of the firmware builds. Instead we should probably disable the Evolu app altogether in such cases (or is it supposed to work on T2T1?).~~

<!--
For core developers:
- Assign yourself to the PR.
- Set the priority to match the original issue.
- Add the PR to the current sprint.
- If it's a draft PR, mark it as "In Progress."
- If it's a final PR, mark it as "Needs Review."
- If needed, add a `Notes for QA` section.

For external contributors:
- Please open an issue before submitting a PR so we can discuss whether we want to proceed with it.
-->
