### PR TITLE
explicitly disable external tamper trigger

### DIFF
--- a/core/embed/projects/secmon/main.c
+++ b/core/embed/projects/secmon/main.c
@@ -64,6 +64,7 @@ static void drivers_init(void) {
 
 #ifdef USE_TAMPER
   tamper_init();
+  tamper_external_disable();
 #endif
 
   random_delays_init();

--- a/core/embed/sys/tamper/inc/sys/tamper.h
+++ b/core/embed/sys/tamper/inc/sys/tamper.h
@@ -35,4 +35,7 @@ uint8_t tamper_external_read(void);
 // Enable external tamper inputs
 void tamper_external_enable(void);
 
+// Disable external tamper inputs
+void tamper_external_disable(void);
+
 #endif  // SECURE_MODE

--- a/core/embed/sys/tamper/stm32u5/tamper.c
+++ b/core/embed/sys/tamper/stm32u5/tamper.c
@@ -199,6 +199,12 @@ void tamper_external_enable(void) {
 #endif
 }
 
+void tamper_external_disable(void) {
+#ifdef TAMPER_INPUT_2
+  TAMP->CR1 &= ~TAMP_CR1_TAMP2E;
+#endif
+}
+
 void tamper_build_pminfo(systask_postmortem_t* pminfo, uint32_t tamper_sr) {
   const char* title = "TAMPER";
 


### PR DESCRIPTION
This PR explicitly disables external tamper trigger, which might be still enabled from run of previous secmon version as it is not affected by system reset.