### PR TITLE
fix resuming from suspend when optiga is paired

### DIFF
--- a/core/embed/sys/suspend/stm32u5/suspend_io.c
+++ b/core/embed/sys/suspend/stm32u5/suspend_io.c
@@ -167,12 +167,13 @@ void resume_drivers(const power_save_wakeup_params_t *wakeup_params) {
 #ifdef USE_BLE
   ble_resume(&wakeup_params->ble);
 #endif
+
+  resume_secure_drivers();
+
 #ifdef USE_OPTIGA
   // Optiga kernel part of resume routine
   optiga_resume();
 #endif
-
-  resume_secure_drivers();
 }
 
 #endif  // KERNEL_MODE


### PR DESCRIPTION
When optiga is properly paired and bootloader is locked, the MCU attempts to establish secure channel on resume. For this, it needs to decrypt pairing secret from secret storage. The decryption is done via SAES peripheral, which needs to be re-initialized before this is attempted.