### PR TITLE
Prevent derivation of unserializable extended keys

### DIFF
--- a/core/tests/test_trezor.crypto.bip32.py
+++ b/core/tests/test_trezor.crypto.bip32.py
@@ -727,6 +727,32 @@ class TestCryptoBip32(unittest.TestCase):
             "xpub6FnCn6nSzZAw5Tw7cgR9bi15UV96gLZhjDstkXXxvCLsUXBGXPdSnLFbdpq8p9HmGsApME5hQTZ3emM2rnY5agb9rXpVGyy3bdW6EEgAtqt",
         )
 
+    def test_that_derive_cannot_overflow_depth(self):
+        xkey = bip32.from_seed(
+            unhexlify("000102030405060708090a0b0c0d0e0f"), SECP256K1_NAME
+        )
+
+        for _ in range(255):
+            xkey.derive(0)
+
+        self.assertEqual(xkey.depth(), 255)
+
+        with self.assertRaises(ValueError):
+            xkey.derive(0)
+
+    def test_that_derive_path_cannot_overflow_depth(self):
+        xkey = bip32.from_seed(
+            unhexlify("000102030405060708090a0b0c0d0e0f"), SECP256K1_NAME
+        )
+
+        for _ in range(7):
+            xkey.derive_path([0] * 32)
+
+        self.assertEqual(xkey.depth(), 224)
+
+        with self.assertRaises(ValueError):
+            xkey.derive_path([0] * 32)
+
 
 if __name__ == "__main__":
     unittest.main()

--- a/crypto/bip32.c
+++ b/crypto/bip32.c
@@ -204,7 +204,10 @@ int hdnode_private_ckd_bip32(HDNode *inout, uint32_t i) {
   }
 #endif
 
-  if (inout->depth == UINT32_MAX) {
+  // Note: Due to serialization format in BIP32, the depth of the extended key
+  // must fit into one byte. Thus, keys of depth greater than 255 cannot be
+  // serialized.
+  if (inout->depth >= 255) {
     return 0;
   }
 
@@ -293,7 +296,10 @@ int hdnode_public_ckd(HDNode *inout, uint32_t i) {
     return 0;
   }
 
-  if (inout->depth == UINT32_MAX) {
+  // Note: Due to serialization format in BIP32, the depth of the extended key
+  // must fit into one byte. Thus, keys of depth greater than 255 cannot be
+  // serialized.
+  if (inout->depth >= 255) {
     return 0;
   }
 


### PR DESCRIPTION
After prior discussion with @tsusanka, I am opening a PR/discussion into the depth of extended keys.

BIP32 serializes the `depth` of an extended key as a single byte. Thus, extended keys that are of depth greater than 255 are not possible to be serialized (in the BIP32 specified format). This commit introduces backwards-incompatible change that prevents a key of depth 256 and greater to be derived.

For more information and related issues in other implementations, see https://github.com/bitcoin/bitcoin/issues/32201.

Note, there might be other parts in the code base, such as [this one in cardano.c](https://github.com/trezor/trezor-firmware/blob/main/crypto/cardano.c#L143), where similar problem could reside.