### PR TITLE
fix(core): remove rcc module from non-secure kernel

### DIFF
--- a/core/embed/sys/startup/stm32u5/startup_init.c
+++ b/core/embed/sys/startup/stm32u5/startup_init.c
@@ -69,6 +69,28 @@ uint32_t SystemCoreClock = DEFAULT_FREQ * 1000000U;
 #pragma GCC optimize( \
     "no-stack-protector")  // applies to all functions in this file
 
+#ifndef SECURE_MODE
+
+// The following functions replace ST HAL routines from
+// stm32u5xx_hal_rcc.c and stm32u5xx_hal_rcc_ex.c that are not safe to call in
+// non-secure mode (e.g. the kernel running in non-secure mode),
+// because the RCC peripheral is not fully accessible.
+
+// Clocks are fully configured by secure monitor and the kernel can
+// rely on SystemCoreClock variable being set correctly.
+
+uint32_t HAL_RCC_GetHCLKFreq(void) { return SystemCoreClock; }
+
+uint32_t HAL_RCC_GetSysClockFreq(void) { return SystemCoreClock; }
+
+uint32_t HAL_RCCEx_GetPeriphCLKFreq(uint64_t PeriphClk) {
+  ensure(sectrue * (PeriphClk == RCC_PERIPHCLK_USART3),
+         "Only USART3 supported");
+  return SystemCoreClock;
+}
+
+#endif  // SECURE_MODE
+
 // This function replaces calls to universal, but flash-wasting
 //  function HAL_RCC_OscConfig.
 //

--- a/core/site_scons/models/stm32u5_common.py
+++ b/core/site_scons/models/stm32u5_common.py
@@ -70,8 +70,6 @@ def stm32u5_common_files(env, features_wanted, defines, sources, paths):
         "vendor/stm32u5xx_hal_driver/Src/stm32u5xx_hal_pwr.c",
         "vendor/stm32u5xx_hal_driver/Src/stm32u5xx_hal_pwr_ex.c",
         "vendor/stm32u5xx_hal_driver/Src/stm32u5xx_hal_ramcfg.c",
-        "vendor/stm32u5xx_hal_driver/Src/stm32u5xx_hal_rcc.c",
-        "vendor/stm32u5xx_hal_driver/Src/stm32u5xx_hal_rcc_ex.c",
         "vendor/stm32u5xx_hal_driver/Src/stm32u5xx_hal_rtc.c",
         "vendor/stm32u5xx_hal_driver/Src/stm32u5xx_hal_rtc_ex.c",
         "vendor/stm32u5xx_hal_driver/Src/stm32u5xx_hal_spi.c",
@@ -80,6 +78,12 @@ def stm32u5_common_files(env, features_wanted, defines, sources, paths):
         "vendor/stm32u5xx_hal_driver/Src/stm32u5xx_hal_tim_ex.c",
         "vendor/stm32u5xx_hal_driver/Src/stm32u5xx_ll_fmc.c",
     ]
+
+    if "secure_mode" in features_wanted:
+        sources += [
+            "vendor/stm32u5xx_hal_driver/Src/stm32u5xx_hal_rcc.c",
+            "vendor/stm32u5xx_hal_driver/Src/stm32u5xx_hal_rcc_ex.c",
+        ]
 
     sources += [
         "embed/sec/hash_processor/stm32u5/hash_processor.c",


### PR DESCRIPTION
This PR fixes an issue introduced in #6066.

The kernel incorrectly read the system clock as 48MHz instead of 160MHz, even though all clocks were configured correctly in the secure monitor. This resulted in incorrect timing for logs, animations, and misconfiguration of several peripherals.

The fix removes the RCC HAL driver from the non-secure kernel entirely, as it cannot be safely used there when some RCC registers or their fields may be inaccessible due to peripheral isolation configured by the secure monitor.