### PR TITLE
fix(core): correct `debug_assert` in Eckhart `get_button_border()`

### DIFF
--- a/core/embed/rust/src/ui/layout_eckhart/firmware/keyboard/word_count_screen.rs
+++ b/core/embed/rust/src/ui/layout_eckhart/firmware/keyboard/word_count_screen.rs
@@ -166,7 +166,7 @@ impl ValueKeypad {
 
     fn get_button_border(&self, idx: usize) -> Rect {
         // Make sure the key is within bounds.
-        debug_assert!(idx < MAX_KEYS);
+        debug_assert!(idx <= MAX_KEYS);
         match idx {
             0 => Rect::from_top_left_and_size(self.area.top_left(), Self::BUTTON_SIZE),
             1 => Rect::from_center_and_size(
@@ -189,7 +189,7 @@ impl ValueKeypad {
     }
 
     fn get_touch_expand(&self, idx: usize) -> Insets {
-        debug_assert!(idx < MAX_KEYS); // Ensure the index is within bounds.
+        debug_assert!(idx <= MAX_KEYS); // Ensure the index is within bounds.
 
         let vertical_spacing = (self.area.height() - Self::BUTTON_SIZE.y * Self::ROWS as i16)
             / (Self::ROWS as i16 - 1);


### PR DESCRIPTION
There are `MAX_KEYS` buttons + the `cancel` button.

Found during #6243.