### PR TITLE
fix(core): make sure SwipeFlow sends ButtonRequest on attach 

### DIFF
--- a/core/embed/rust/src/ui/flow/swipe.rs
+++ b/core/embed/rust/src/ui/flow/swipe.rs
@@ -194,7 +194,7 @@ impl SwipeFlow {
 
         let mut attach = false;
 
-        let event = if self.allow_swipe {
+        let mut event = if self.allow_swipe {
             let page = self.current_page();
             let pager = page.get_pager();
             let config = page.get_swipe_config().with_pager(pager);
@@ -232,8 +232,8 @@ impl SwipeFlow {
                 // swipe end.
                 if attach {
                     if let Event::Swipe(SwipeEvent::End(dir)) = event {
-                        self.current_page_mut()
-                            .event(ctx, Event::Attach(AttachType::Swipe(dir)));
+                        event = Event::Attach(AttachType::Swipe(dir));
+                        self.current_page_mut().event(ctx, event);
                     }
                 }
 

--- a/tests/input_flows_helpers.py
+++ b/tests/input_flows_helpers.py
@@ -402,16 +402,17 @@ class RecoveryFlow:
         self.debug.synchronize_at("VerticalMenu")
         self.debug.button_actions.navigate_to_menu_item(0)
         br = yield
+        assert br.name == "show_shares"
+        assert br.code == B.Other
         # Scroll through remaining share pages
         assert br.pages is not None
         for _ in range(br.pages - 1):
             if self.client.layout_type is LayoutType.Delizia:
                 self.debug.swipe_up()
+                assert br == (yield)
             elif self.client.layout_type is LayoutType.Eckhart:
                 self.debug.click(self.debug.screen_buttons.ok())
 
-        assert br.name == "show_shares"
-        assert br.code == B.Other
         # Getting back to the homepage
         self.debug.click(self.debug.screen_buttons.menu())
         self.debug.click(self.debug.screen_buttons.menu())


### PR DESCRIPTION
Otherwise, SLIP39 recovery device tests fail on Delizia, due to `repeated_button_request(Other, "show_shares")` when `debug_assert`s are enabled.

Found during #6243.