### PR TITLE
docs(core): changelog for 2.9.6

### DIFF
--- a/core/.changelog.d/6109.fixed
+++ b/core/.changelog.d/6109.fixed
@@ -1,1 +1,0 @@
-Fixed Stellar Amount and Bitcoin lock time font.

--- a/core/.changelog.d/6138.fixed
+++ b/core/.changelog.d/6138.fixed
@@ -1,1 +1,0 @@
-Make sure to increment THP `seq_bit`.

--- a/core/.changelog.d/6145.fixed
+++ b/core/.changelog.d/6145.fixed
@@ -1,1 +1,0 @@
-[T3W1] Don't stall THP handling during PIN unlock.

--- a/core/CHANGELOG.T2B1.md
+++ b/core/CHANGELOG.T2B1.md
@@ -4,6 +4,8 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
+## [2.9.6] (internal release)
+
 ## [2.9.5] (internal release)
 
 ### Fixed
@@ -1224,4 +1226,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 [#6076]: https://github.com/trezor/trezor-firmware/pull/6076
 [#6096]: https://github.com/trezor/trezor-firmware/pull/6096
 [#6100]: https://github.com/trezor/trezor-firmware/pull/6100
+[#6109]: https://github.com/trezor/trezor-firmware/pull/6109
+[#6138]: https://github.com/trezor/trezor-firmware/pull/6138
+[#6145]: https://github.com/trezor/trezor-firmware/pull/6145
 [#6165]: https://github.com/trezor/trezor-firmware/pull/6165

--- a/core/CHANGELOG.T2T1.md
+++ b/core/CHANGELOG.T2T1.md
@@ -4,6 +4,8 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
+## [2.9.6] (internal release)
+
 ## [2.9.5] (internal release)
 
 ### Fixed
@@ -1221,4 +1223,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 [#6076]: https://github.com/trezor/trezor-firmware/pull/6076
 [#6096]: https://github.com/trezor/trezor-firmware/pull/6096
 [#6100]: https://github.com/trezor/trezor-firmware/pull/6100
+[#6109]: https://github.com/trezor/trezor-firmware/pull/6109
+[#6138]: https://github.com/trezor/trezor-firmware/pull/6138
+[#6145]: https://github.com/trezor/trezor-firmware/pull/6145
 [#6165]: https://github.com/trezor/trezor-firmware/pull/6165

--- a/core/CHANGELOG.T3B1.md
+++ b/core/CHANGELOG.T3B1.md
@@ -4,6 +4,8 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
+## [2.9.6] (internal release)
+
 ## [2.9.5] (internal release)
 
 ### Fixed
@@ -1217,4 +1219,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 [#6076]: https://github.com/trezor/trezor-firmware/pull/6076
 [#6096]: https://github.com/trezor/trezor-firmware/pull/6096
 [#6100]: https://github.com/trezor/trezor-firmware/pull/6100
+[#6109]: https://github.com/trezor/trezor-firmware/pull/6109
+[#6138]: https://github.com/trezor/trezor-firmware/pull/6138
+[#6145]: https://github.com/trezor/trezor-firmware/pull/6145
 [#6165]: https://github.com/trezor/trezor-firmware/pull/6165

--- a/core/CHANGELOG.T3T1.md
+++ b/core/CHANGELOG.T3T1.md
@@ -4,6 +4,8 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
+## [2.9.6] (internal release)
+
 ## [2.9.5] (internal release)
 
 ### Fixed
@@ -1265,4 +1267,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 [#6076]: https://github.com/trezor/trezor-firmware/pull/6076
 [#6096]: https://github.com/trezor/trezor-firmware/pull/6096
 [#6100]: https://github.com/trezor/trezor-firmware/pull/6100
+[#6109]: https://github.com/trezor/trezor-firmware/pull/6109
+[#6138]: https://github.com/trezor/trezor-firmware/pull/6138
+[#6145]: https://github.com/trezor/trezor-firmware/pull/6145
 [#6165]: https://github.com/trezor/trezor-firmware/pull/6165

--- a/core/CHANGELOG.T3W1.md
+++ b/core/CHANGELOG.T3W1.md
@@ -4,6 +4,13 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
+## [2.9.6] (4th December 2025)
+
+### Fixed
+- Fixed Stellar Amount and Bitcoin lock time font.  [#6109]
+- Make sure to increment THP `seq_bit`.  [#6138]
+- Don't stall THP handling during PIN unlock.  [#6145]
+
 ## [2.9.5] (28th November 2025)
 
 ### Fixed
@@ -75,4 +82,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 [#6076]: https://github.com/trezor/trezor-firmware/pull/6076
 [#6096]: https://github.com/trezor/trezor-firmware/pull/6096
 [#6100]: https://github.com/trezor/trezor-firmware/pull/6100
+[#6109]: https://github.com/trezor/trezor-firmware/pull/6109
+[#6138]: https://github.com/trezor/trezor-firmware/pull/6138
+[#6145]: https://github.com/trezor/trezor-firmware/pull/6145
 [#6165]: https://github.com/trezor/trezor-firmware/pull/6165

--- a/core/CHANGELOG.md
+++ b/core/CHANGELOG.md
@@ -4,6 +4,13 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
+## [2.9.6] (4th December 2025)
+
+### Fixed
+- [T3W1] Fixed Stellar Amount and Bitcoin lock time font.  [#6109]
+- [T3W1] Make sure to increment THP `seq_bit`.  [#6138]
+- [T3W1] Don't stall THP handling during PIN unlock.  [#6145]
+
 ## [2.9.5] (28th November 2025)
 
 ### Fixed
@@ -1324,4 +1331,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 [#6076]: https://github.com/trezor/trezor-firmware/pull/6076
 [#6096]: https://github.com/trezor/trezor-firmware/pull/6096
 [#6100]: https://github.com/trezor/trezor-firmware/pull/6100
+[#6109]: https://github.com/trezor/trezor-firmware/pull/6109
+[#6138]: https://github.com/trezor/trezor-firmware/pull/6138
+[#6145]: https://github.com/trezor/trezor-firmware/pull/6145
 [#6165]: https://github.com/trezor/trezor-firmware/pull/6165


### PR DESCRIPTION
Adding changelog for 2.9.6 - someone has already asked about "what has changed"

- All relevant entries changed to "T3W1 only" (as they should be by their content).
- I am not 💯 sure about the release date, I have used the date of signing.