### PR TITLE
build(core): exclude `embed/rtl/printf.c` from non-prodtest & PRODUCTION=1 builds

### DIFF
--- a/core/SConscript.boardloader
+++ b/core/SConscript.boardloader
@@ -5,6 +5,7 @@ import tools, models
 
 TREZOR_MODEL = ARGUMENTS.get('TREZOR_MODEL', 'T2T1')
 CMAKELISTS = int(ARGUMENTS.get('CMAKELISTS', 0))
+PRODUCTION = ARGUMENTS.get('PRODUCTION', '0') == '1'
 HW_REVISION = ARGUMENTS.get('HW_REVISION', None)
 DBG_CONSOLE = ARGUMENTS.get('DBG_CONSOLE', '')
 
@@ -98,9 +99,11 @@ SOURCE_MOD += [
     'embed/util/rsod/rsod_special.c',
     'embed/util/scm_revision/scm_revision.c',
     'embed/rtl/error_handling.c',
-    'embed/rtl/printf.c',
     'embed/rtl/strutils.c',
 ]
+
+if not PRODUCTION:
+    SOURCE_MOD += ['embed/rtl/printf.c']
 
 SOURCE_BOARDLOADER = [
     'embed/projects/boardloader/main.c',

--- a/core/SConscript.bootloader
+++ b/core/SConscript.bootloader
@@ -124,12 +124,14 @@ SOURCE_MOD += [
     'embed/util/rsod/rsod_special.c',
     'embed/util/scm_revision/scm_revision.c',
     'embed/rtl/error_handling.c',
-    'embed/rtl/printf.c',
     'embed/rtl/strutils.c',
     'vendor/micropython/lib/uzlib/adler32.c',
     'vendor/micropython/lib/uzlib/crc32.c',
     'vendor/micropython/lib/uzlib/tinflate.c',
 ]
+
+if not PRODUCTION:
+    SOURCE_MOD += ['embed/rtl/printf.c']
 
 SOURCE_NANOPB = [
     'vendor/nanopb/pb_common.c',

--- a/core/SConscript.bootloader_ci
+++ b/core/SConscript.bootloader_ci
@@ -5,6 +5,7 @@ import tools, models, ui
 
 TREZOR_MODEL = ARGUMENTS.get('TREZOR_MODEL', 'T2T1')
 CMAKELISTS = int(ARGUMENTS.get('CMAKELISTS', 0))
+PRODUCTION = ARGUMENTS.get('PRODUCTION', '0') == '1'
 HW_REVISION = ARGUMENTS.get('HW_REVISION', None)
 
 FEATURES_WANTED = [
@@ -102,12 +103,14 @@ SOURCE_MOD += [
     'embed/util/rsod/rsod_special.c',
     'embed/util/scm_revision/scm_revision.c',
     'embed/rtl/error_handling.c',
-    'embed/rtl/printf.c',
     'embed/rtl/strutils.c',
     'vendor/micropython/lib/uzlib/adler32.c',
     'vendor/micropython/lib/uzlib/crc32.c',
     'vendor/micropython/lib/uzlib/tinflate.c',
 ]
+
+if not PRODUCTION:
+    SOURCE_MOD += ['embed/rtl/printf.c']
 
 SOURCE_NANOPB = [
     'vendor/nanopb/pb_common.c',

--- a/core/SConscript.bootloader_emu
+++ b/core/SConscript.bootloader_emu
@@ -6,6 +6,8 @@ import tools, models, ui
 
 TREZOR_MODEL = ARGUMENTS.get('TREZOR_MODEL', 'T2T1')
 CMAKELISTS = int(ARGUMENTS.get('CMAKELISTS', 0))
+BOOTLOADER_QA = ARGUMENTS.get('BOOTLOADER_QA', '0') == '1'
+PRODUCTION = 0 if BOOTLOADER_QA else ARGUMENTS.get('PRODUCTION', '0') == '1'
 HW_REVISION = 'emulator'
 DBG_CONSOLE = ARGUMENTS.get('DBG_CONSOLE', '')
 
@@ -97,12 +99,14 @@ SOURCE_MOD += [
     'embed/util/rsod/rsod_special.c',
     'embed/util/scm_revision/scm_revision.c',
     'embed/rtl/error_handling.c',
-    'embed/rtl/printf.c',
     'embed/rtl/strutils.c',
     'vendor/micropython/lib/uzlib/adler32.c',
     'vendor/micropython/lib/uzlib/crc32.c',
     'vendor/micropython/lib/uzlib/tinflate.c',
 ]
+
+if not PRODUCTION:
+    SOURCE_MOD += ['embed/rtl/printf.c']
 
 SOURCE_NANOPB = [
     'vendor/nanopb/pb_common.c',

--- a/core/SConscript.firmware
+++ b/core/SConscript.firmware
@@ -267,12 +267,14 @@ SOURCE_MOD += [
     'embed/util/rsod/rsod.c',
     'embed/util/scm_revision/scm_revision.c',
     'embed/rtl/error_handling.c',
-    'embed/rtl/printf.c',
     'embed/rtl/strutils.c',
     'vendor/micropython/lib/uzlib/adler32.c',
     'vendor/micropython/lib/uzlib/crc32.c',
     'vendor/micropython/lib/uzlib/tinflate.c',
 ]
+
+if not PRODUCTION:
+    SOURCE_MOD += ['embed/rtl/printf.c']
 
 CPPDEFINES_MOD += [
     'TRANSLATIONS',

--- a/core/SConscript.kernel
+++ b/core/SConscript.kernel
@@ -222,12 +222,14 @@ SOURCE_MOD += [
     'embed/util/rsod/rsod.c',
     'embed/util/rsod/rsod_special.c',
     'embed/rtl/error_handling.c',
-    'embed/rtl/printf.c',
     'embed/rtl/strutils.c',
     'vendor/micropython/lib/uzlib/adler32.c',
     'vendor/micropython/lib/uzlib/crc32.c',
     'vendor/micropython/lib/uzlib/tinflate.c',
 ]
+
+if not PRODUCTION:
+    SOURCE_MOD += ['embed/rtl/printf.c']
 
 CPPPATH_MOD += [
     'vendor/micropython/lib/uzlib',

--- a/core/SConscript.secmon
+++ b/core/SConscript.secmon
@@ -217,12 +217,14 @@ SOURCE_MOD += [
     'embed/util/image/image.c',
     'embed/util/rsod/rsod_special.c',
     'embed/rtl/error_handling.c',
-    'embed/rtl/printf.c',
     'embed/rtl/strutils.c',
     'vendor/micropython/lib/uzlib/adler32.c',
     'vendor/micropython/lib/uzlib/crc32.c',
     'vendor/micropython/lib/uzlib/tinflate.c',
 ]
+
+if not PRODUCTION:
+    SOURCE_MOD += ['embed/rtl/printf.c']
 
 CPPDEFINES_MOD += [
     'TRANSLATIONS',

--- a/core/SConscript.unix
+++ b/core/SConscript.unix
@@ -250,12 +250,14 @@ SOURCE_MOD += [
     'embed/util/rsod/rsod_special.c',
     'embed/util/scm_revision/scm_revision.c',
     'embed/rtl/error_handling.c',
-    'embed/rtl/printf.c',
     'embed/rtl/strutils.c',
     'vendor/micropython/lib/uzlib/adler32.c',
     'vendor/micropython/lib/uzlib/crc32.c',
     'vendor/micropython/lib/uzlib/tinflate.c',
 ]
+
+if not PRODUCTION:
+    SOURCE_MOD += ['embed/rtl/printf.c']
 
 CPPDEFINES_MOD += [
     'TRANSLATIONS',


### PR DESCRIPTION
Otherwise, nightly CI fails with:
https://github.com/trezor/trezor-firmware/actions/runs/20320385493/job/58431441939
https://github.com/trezor/trezor-firmware/actions/runs/20320445019/job/58374742444

We currently use `printf()` only in prodtest / non-production builds[^1].

[no changelog]

[^1]: https://github.com/trezor/trezor-firmware/pull/6208#discussion_r2610006444
