### PR TITLE
Build cache

### DIFF
--- a/core/.gitignore
+++ b/core/.gitignore
@@ -1,4 +1,5 @@
 build/
+build_cache/
 build-docker/
 .sconsign.dblite
 compile_commands.json

--- a/core/Makefile
+++ b/core/Makefile
@@ -49,6 +49,7 @@ STORAGE_INSECURE_TESTING_MODE ?= 0
 UI_PERFORMANCE_OVERLAY ?= 0
 DBG_CONSOLE ?=
 EXTAPP_SUPPORT ?= 0
+BUILD_CACHE ?= 0
 
 # If set, VCP writes will be blocking, in order to allow reliable debug data transmission over VCP.
 # Disabled by default, to prevent debug firmware from getting stuck while writing log messages (if the host is not reading them).
@@ -145,7 +146,8 @@ SCONS_VARS = \
 	UI_PERFORMANCE_OVERLAY="$(UI_PERFORMANCE_OVERLAY)" \
 	BLOCK_ON_VCP="$(BLOCK_ON_VCP)" \
 	DBG_CONSOLE="$(DBG_CONSOLE)" \
-	EXTAPP_SUPPORT="$(EXTAPP_SUPPORT)"
+	EXTAPP_SUPPORT="$(EXTAPP_SUPPORT)" \
+	BUILD_CACHE="$(BUILD_CACHE)"
 
 ifdef DISABLE_OPTIGA
 SCONS_VARS += DISABLE_OPTIGA="$(DISABLE_OPTIGA)"

--- a/core/SConscript.kernel
+++ b/core/SConscript.kernel
@@ -453,16 +453,13 @@ obj_program += [rust]
 
 
 if "secmon_layout" in FEATURES_AVAILABLE:
-    SECMON_LIB = SECMON_API
-else:
-    SECMON_LIB = ''
-
+    obj_program.append(SECMON_API)
 
 program_elf = env.Command(
     target='kernel.elf',
     source=obj_program,
     action=
-    f'$LINK -o $TARGET $CCFLAGS $CFLAGS $SOURCES $LINKFLAGS -lc_nano -lm -lgcc {SECMON_LIB} ',
+    f'$LINK -o $TARGET $CCFLAGS $CFLAGS $SOURCES $LINKFLAGS -lc_nano -lm -lgcc ',
 )
 
 env.Depends(program_elf, linkerscript_gen)

--- a/core/SConscript.secmon
+++ b/core/SConscript.secmon
@@ -406,7 +406,7 @@ linkerscript_gen = env.Command(
 )
 
 program_elf = env.Command(
-    target='secmon.elf',
+    target=['secmon.elf', 'secmon_api.o'],
     source=obj_program,
     action=
     '$LINK -o $TARGET $CCFLAGS $CFLAGS $SOURCES $LINKFLAGS -lc_nano -lm -lgcc',

--- a/core/SConstruct
+++ b/core/SConstruct
@@ -18,3 +18,6 @@ if ARGUMENTS.get('QUIET_MODE', '0') == '1':
     import sys
     if sys.stdout.isatty():
         Progress('$TARGET\r', overwrite=True)
+
+if ARGUMENTS.get('BUILD_CACHE', '0') == '1':
+    CacheDir('build_cache')


### PR DESCRIPTION
This is an experiment with scons build cache.

Build time when not using the cache (t3w1 firmware):
real time: 1m59
user time: 9m6
sys time: 1m11

Build time when using the cache (t3w1 firmware):
real time: 1m15
user time: 3m22
sys time: 0m23

It seems the cache will not help in CI, but it can help during development, especially when switching the build model (since we build into the same folder now).
