### PR TITLE
test(core): don't run `test_evolu_get_delegated_identity_test_vector` on HW devices

### DIFF
--- a/tests/device_tests/evolu/test_get_delegated_identity_key.py
+++ b/tests/device_tests/evolu/test_get_delegated_identity_key.py
@@ -15,6 +15,8 @@ def test_evolu_get_delegated_identity_is_constant(session: Session):
 
 
 def test_evolu_get_delegated_identity_test_vector(session: Session):
+    if session.features.fw_vendor != "EMULATOR":
+        pytest.skip("Only for emulator")
     # on emulator, the master key is all zeroes. So the delegated identity key is constant.
     private_key = evolu.get_delegated_identity_key(session)
     assert private_key == bytes.fromhex(

--- a/tests/device_tests/evolu/test_get_delegated_identity_key_thp.py
+++ b/tests/device_tests/evolu/test_get_delegated_identity_key_thp.py
@@ -80,6 +80,8 @@ def test_evolu_get_delegated_identity_is_constant(client: Client):
 
 
 def test_evolu_get_delegated_identity_test_vector(client: Client):
+    if client.features.fw_vendor != "EMULATOR":
+        pytest.skip("Only for emulator")
     # on emulator, the master key is all zeroes. So the delegated identity key is constant.
 
     pairing_data = pair_and_get_credential(client)


### PR DESCRIPTION
It uses a fixed test vector, which depends on a secret that is random for each device. 
The test vector corresponds to a constant secret that is used in the emulator.

Related to #6272.
