### PR TITLE
fix(python): avoid dropping WebUSB chunks in case of a timeout

### DIFF
--- a/python/.changelog.d/6112.fixed
+++ b/python/.changelog.d/6112.fixed
@@ -1,0 +1,1 @@
+Avoid dropping WebUSB chunks in case of a timeout.


### PR DESCRIPTION
`libusb1` may return the received data even in case of a timeout https://github.com/vpelletier/python-libusb1/blob/292143c8f4465fdcb2c35ed40cdd7e4dd8d031e1/usb1/__init__.py#L1567

Should fix #6112.

Tested locally by running [the tests used for reproducing the issue](https://github.com/trezor/trezor-firmware/issues/6112#issuecomment-3722947599) for ~10 hours:
```
$ while pytest tests/device_tests/test_language.py tests/device_tests/test_msg_changepin_t2.py; do :; done
```