### PR TITLE
chore: remove obsolete Darwin depedencies

### DIFF
--- a/shell.nix
+++ b/shell.nix
@@ -119,16 +119,6 @@ stdenvNoCC.mkDerivation ({
     procps
     valgrind
   ] ++ lib.optionals (stdenv.isDarwin) [
-    darwin.apple_sdk.frameworks.CoreAudio
-    darwin.apple_sdk.frameworks.AudioToolbox
-    darwin.apple_sdk.frameworks.ForceFeedback
-    darwin.apple_sdk.frameworks.CoreVideo
-    darwin.apple_sdk.frameworks.Cocoa
-    darwin.apple_sdk.frameworks.Carbon
-    darwin.apple_sdk.frameworks.IOKit
-    darwin.apple_sdk.frameworks.QuartzCore
-    darwin.apple_sdk.frameworks.Metal
-    darwin.libobjc
     libiconv
   ] ++ lib.optionals hardwareTest [
     uhubctl


### PR DESCRIPTION
Running `nix-shell` on MacOS throws a bunch of warnings regarding darwin.apple_sdk dependencies. Those are just stubs that do nothing and will be removed. Builds/emulator seems to be working fine without them.

<img width="839" height="316" alt="image" src="https://github.com/user-attachments/assets/94523055-5666-433e-850a-6e5da157ad5f" />

```
evaluation warning: darwin.apple_sdk_11_0.CoreAudio: these stubs do nothing and will be removed in Nixpkgs 25.11; see <https://nixos.org/manual/nixpkgs/stable/#sec-darwin> for documentation and migration instructions.
evaluation warning: darwin.apple_sdk_11_0.AudioToolbox: these stubs do nothing and will be removed in Nixpkgs 25.11; see <https://nixos.org/manual/nixpkgs/stable/#sec-darwin> for documentation and migration instructions.
evaluation warning: darwin.apple_sdk_11_0.ForceFeedback: these stubs do nothing and will be removed in Nixpkgs 25.11; see <https://nixos.org/manual/nixpkgs/stable/#sec-darwin> for documentation and migration instructions.
evaluation warning: darwin.apple_sdk_11_0.CoreVideo: these stubs do nothing and will be removed in Nixpkgs 25.11; see <https://nixos.org/manual/nixpkgs/stable/#sec-darwin> for documentation and migration instructions.
evaluation warning: darwin.apple_sdk_11_0.Cocoa: these stubs do nothing and will be removed in Nixpkgs 25.11; see <https://nixos.org/manual/nixpkgs/stable/#sec-darwin> for documentation and migration instructions.
evaluation warning: darwin.apple_sdk_11_0.Carbon: these stubs do nothing and will be removed in Nixpkgs 25.11; see <https://nixos.org/manual/nixpkgs/stable/#sec-darwin> for documentation and migration instructions.
evaluation warning: darwin.apple_sdk_11_0.IOKit: these stubs do nothing and will be removed in Nixpkgs 25.11; see <https://nixos.org/manual/nixpkgs/stable/#sec-darwin> for documentation and migration instructions.
evaluation warning: darwin.apple_sdk_11_0.QuartzCore: these stubs do nothing and will be removed in Nixpkgs 25.11; see <https://nixos.org/manual/nixpkgs/stable/#sec-darwin> for documentation and migration instructions.
evaluation warning: darwin.apple_sdk_11_0.Metal: these stubs do nothing and will be removed in Nixpkgs 25.11; see <https://nixos.org/manual/nixpkgs/stable/#sec-darwin> for documentation and migration instructions.
evaluation warning: darwin.libobjc: these stubs do nothing and will be removed in Nixpkgs 25.11; see <https://nixos.org/manual/nixpkgs/stable/#sec-darwin> for documentation and migration instructions.
```

<!--
For core developers:
- Set the priority to match the original issue.
- Add the PR to the current sprint.
- If it's a draft PR, mark it as "In Progress."
- If it's a final PR, mark it as "Needs Review."
- If needed, add a `Notes for QA` section.
-->
