### PR TITLE
build(core): fix Rust library path in SConscript

### DIFF
--- a/core/SConscript.bootloader
+++ b/core/SConscript.bootloader
@@ -278,6 +278,7 @@ obj_program += env.Object(source=SOURCE_MOD_CRYPTO, CCFLAGS='$CCFLAGS -ftrivial-
 obj_program += env.Object(source=SOURCE_BOOTLOADER)
 obj_program += env.Object(source=SOURCE_NANOPB)
 obj_program += env.Object(source=SOURCE_HAL)
+obj_program += [rust]
 
 if 'boot_ucb' in FEATURES_AVAILABLE:
     obj_program += env.Object(
@@ -299,7 +300,6 @@ program_elf = env.Command(
 )
 
 env.Depends(program_elf, linkerscript_gen)
-env.Depends(program_elf, rust)
 
 SUFFIX = '_qa' if BOOTLOADER_QA else ''
 

--- a/core/SConscript.bootloader_emu
+++ b/core/SConscript.bootloader_emu
@@ -266,14 +266,13 @@ obj_program += env.Object(source=SOURCE_MOD_CRYPTO, CCFLAGS='$CCFLAGS -ftrivial-
 obj_program += env.Object(source=SOURCE_BOOTLOADER)
 obj_program += env.Object(source=SOURCE_NANOPB)
 obj_program += env.Object(source=SOURCE_UNIX)
+obj_program += [rust]
 
 program_elf = env.Command(
     target='bootloader.elf',
     source=obj_program,
     action=
     '$CC -o $TARGET $SOURCES $_LIBDIRFLAGS $_LIBFLAGS $LINKFLAGS')
-
-env.Depends(program_elf, rust)
 
 if CMAKELISTS != 0:
     env.Depends(program_elf, cmake_gen)

--- a/core/SConscript.firmware
+++ b/core/SConscript.firmware
@@ -904,6 +904,7 @@ rust = tools.add_rust_lib(
     all_paths=ALLPATHS,
     build_dir=str(Dir('.').abspath),
 )
+obj_program += [rust]
 
 
 env.Depends(rust, protobuf_blobs)
@@ -997,7 +998,6 @@ env.Depends(program_elf, linkerscript_gen)
 
 if CMAKELISTS != 0:
     env.Depends(program_elf, cmake_gen)
-env.Depends(program_elf, rust)
 
 BINARY_NAME = f"build/firmware/firmware-{TREZOR_MODEL}"
 if not EVERYTHING:

--- a/core/SConscript.kernel
+++ b/core/SConscript.kernel
@@ -444,6 +444,7 @@ rust = tools.add_rust_lib(
     all_paths=ALLPATHS,
     build_dir=str(Dir('.').abspath),
 )
+obj_program += [rust]
 
 
 if "secmon_layout" in FEATURES_AVAILABLE:
@@ -460,7 +461,6 @@ program_elf = env.Command(
 )
 
 env.Depends(program_elf, linkerscript_gen)
-env.Depends(program_elf, rust)
 
 if CMAKELISTS != 0:
     env.Depends(program_elf, cmake_gen)

--- a/core/SConscript.prodtest
+++ b/core/SConscript.prodtest
@@ -338,6 +338,7 @@ rust = tools.add_rust_lib(
     all_paths=ALLPATHS,
     build_dir=str(Dir('.').abspath),
 )
+obj_program += [rust]
 
 
 if (vh := ARGUMENTS.get("VENDOR_HEADER", None)):
@@ -378,7 +379,6 @@ program_elf = env.Command(
 )
 
 env.Depends(program_elf, linkerscript_gen)
-env.Depends(program_elf, rust)
 
 BINARY_NAME = f"build/prodtest/prodtest-{TREZOR_MODEL}"
 BINARY_NAME += "-" + tools.get_version('embed/projects/prodtest/version.h')

--- a/core/SConscript.prodtest_emu
+++ b/core/SConscript.prodtest_emu
@@ -302,14 +302,13 @@ obj_program += env.Object(source=SOURCE_MOD_CRYPTO, CCFLAGS='$CCFLAGS -ftrivial-
 obj_program += env.Object(source=SOURCE_PRODTEST)
 obj_program += env.Object(source=SOURCE_HAL)
 obj_program += env.Object(source=SOURCE_MLDSA)
+obj_program += [rust]
 
 program_elf = env.Command(
     target='prodtest.elf',
     source=obj_program,
     action=
     '$CC -o $TARGET $SOURCES $_LIBDIRFLAGS $_LIBFLAGS $LINKFLAGS')
-
-env.Depends(program_elf, rust)
 
 if CMAKELISTS != 0:
     env.Depends(program_elf, cmake_gen)

--- a/core/SConscript.unix
+++ b/core/SConscript.unix
@@ -925,7 +925,7 @@ rust = tools.add_rust_lib(
     all_paths=ALLPATHS,
     build_dir=str(Dir('.').abspath),
 )
-
+obj_program += [rust]
 
 env.Depends(rust, protobuf_blobs)
 env.Depends(rust, TRANSLATION_DATA)
@@ -938,4 +938,3 @@ program = env.Command(
 
 if CMAKELISTS != 0:
     env.Depends(program, cmake_gen)
-env.Depends(program, rust)


### PR DESCRIPTION
The reason for this PR is [incorrect dependency specification](https://github.com/trezor/trezor-firmware/issues/6060#issuecomment-3745144734) in `add_rust_lib()`.

It caused `cargo build` to be always called (since the Rust library was built in a different path than was expected by `scons`):
```
scons: building `build/unix/build/unix/rust/x86_64-unknown-linux-gnu/debug/libtrezor_lib.a' because it doesn't exist
    Finished `dev` profile [unoptimized + debuginfo] target(s) in 0.02s.a
```
After the issue was fixed, `env.AlwaysBuild(rust)` was added to keep running `cargo build` since we currently don't represent Rust-related dependencies in `scons` - so `scons` will not call `cargo build` if the Rust library already exists.

In addition, the linking was simplified, by replacing `env.Append(LINKFLAGS=...)` & `env.Depends(program_elf, rust)` with adding the Rust static library as a `program_elf`'s source.

Before this PR, the linker was using:
```
-Lbuild/unix/rust/x86_64-unknown-linux-gnu/debug -ltrezor_lib
```
After this PR, it will use:
```
build/unix/rust/x86_64-unknown-linux-gnu/debug/libtrezor_lib.a
```

Fixes https://github.com/trezor/trezor-firmware/issues/6060.
