### PR TITLE
test(core): avoid manipulating `sys.path`

### DIFF
--- a/core/tests/common.py
+++ b/core/tests/common.py
@@ -1,7 +1,3 @@
-import sys
-
-sys.path.append("../src")
-
 import unittest  # noqa: F401
 from typing import Any, Awaitable
 from ubinascii import hexlify, unhexlify  # noqa: F401

--- a/core/tests/run_tests.sh
+++ b/core/tests/run_tests.sh
@@ -26,6 +26,8 @@ cd $(dirname $0)
 
 declare -i num_of_tests=${#tests[@]}
 
+export MICROPYPATH=.:../src  # for tests' imports to work as expected
+
 for test_case in ${tests[@]}; do
     echo
     if $MICROPYTHON $test_case; then


### PR DESCRIPTION
Currently, our unittests require `from common import *  # isort:skip` to be the first import so other imports will work as expected, which is quite surprising and not very Pythonic.