### PR TITLE
Add optiga-metadata-read command to prodtest

### DIFF
--- a/core/embed/projects/prodtest/.changelog.d/6334.added
+++ b/core/embed/projects/prodtest/.changelog.d/6334.added
@@ -1,0 +1,1 @@
+Add `optiga-metadata-read` command.

--- a/core/embed/projects/prodtest/README.md
+++ b/core/embed/projects/prodtest/README.md
@@ -924,6 +924,22 @@ optiga-counter-read
 OK 0E
 ```
 
+### optiga-metadata-read
+Retrieves the metadata of the specified data object in Optiga.
+
+Example:
+```
+optiga-metadata-read f1d0
+# Life cycle state: Operational
+# Maximum size: 140
+# Used size: 32
+# Read: Auto(F1D4)
+# Write: Always
+# Execute: Always
+# Data type: AUTOREF
+OK 2017C00107C4018CC50120D00100D10323F1D4D30100E80131
+```
+
 ### pm-new-soc-estimate
 Erase power manager recovery data from the backup RAM and immediately reboot the device to run new battery SoC estimate.
 

--- a/core/embed/sec/optiga/inc/sec/optiga_commands.h
+++ b/core/embed/sec/optiga/inc/sec/optiga_commands.h
@@ -95,12 +95,18 @@ typedef enum {
 
 // Access conditions.
 typedef enum {
-  OPTIGA_ACCESS_COND_ALW = 0x00,   // Always.
-  OPTIGA_ACCESS_COND_CONF = 0x20,  // Confidentiality protection required.
-  OPTIGA_ACCESS_COND_INT = 0x21,   // Integrity protection required.
-  OPTIGA_ACCESS_COND_AUTO = 0x23,  // Authorization required.
-  OPTIGA_ACCESS_COND_LUC = 0x40,   // Usage limited by counter.
-  OPTIGA_ACCESS_COND_NEV = 0xFF,   // Never.
+  OPTIGA_ACCESS_COND_ALW = 0x00,      // Always.
+  OPTIGA_ACCESS_COND_CONF = 0x20,     // Confidentiality protection required.
+  OPTIGA_ACCESS_COND_INT = 0x21,      // Integrity protection required.
+  OPTIGA_ACCESS_COND_AUTO = 0x23,     // Authorization required.
+  OPTIGA_ACCESS_COND_LUC = 0x40,      // Usage limited by counter.
+  OPTIGA_ACCESS_COND_LCSG = 0x70,     // Global lifecycle state.
+  OPTIGA_ACCESS_COND_LCSA = 0xE0,     // Application lifecycle state.
+  OPTIGA_ACCESS_COND_LCSO = 0xE1,     // Data object lifecycle state.
+  OPTIGA_ACCESS_COND_EQUAL = 0xFA,    // Equal.
+  OPTIGA_ACCESS_COND_GREATER = 0xFB,  // Greater than.
+  OPTIGA_ACCESS_COND_LESS = 0xFC,     // Less than.
+  OPTIGA_ACCESS_COND_NEV = 0xFF,      // Never.
 } optiga_access_cond;
 
 // Life cycle status.


### PR DESCRIPTION
Adds a new debugging command to prodtest, which retrieves the metadata of the specified data object in Optiga. The metadata is returned both in human-readable and binary form. Only simple access condition expressions are interpreted in human-readable form. Complex access conditions involving logical `&&` and `||` are not interpreted. However, we don't use complex access conditions in Optiga.

Optiga documentation: https://github.com/Infineon/optiga-trust-m-overview/blob/main/docs/OPTIGA%E2%84%A2%20Trust%20M%20Solution%20Reference%20Manual.md#access-conditions-acs

Example:
```
optiga-metadata-read f1d0
# Life cycle state: Operational
# Maximum size: 140
# Used size: 32
# Read: Auto(F1D4)
# Write: Always
# Execute: Always
# Data type: AUTOREF
OK 2017C00107C4018CC50120D00100D10323F1D4D30100E80131
```