### PR TITLE
Prevent deadlock between secrets-init and tropic-pair

### DIFF
--- a/core/embed/projects/prodtest/.changelog.d/6337.fixed
+++ b/core/embed/projects/prodtest/.changelog.d/6337.fixed
@@ -1,0 +1,1 @@
+Prevent deadlock between secrets-init and tropic-pair.


### PR DESCRIPTION
`tropic-pair` shouldn't proceed if `secrets-init` didn’t succeed yet. Otherwise we risk running into a deadlock. Untested.
https://satoshilabs.slack.com/archives/C0127FP419Q/p1768573895180599?thread_ts=1767877535.431719&cid=C0127FP419Q