### PR TITLE
chore(python): re-introduce sleep when starting Tropic emulator

### DIFF
--- a/python/src/trezorlib/_internal/emulator.py
+++ b/python/src/trezorlib/_internal/emulator.py
@@ -123,7 +123,12 @@ class TropicModel:
         while True:
             try:
                 with socket.create_connection(("127.0.0.1", self.port), timeout=1):
-                    break  # if we can connect to the model, it means it is ready
+                    # seems that even if the model is listening for connections
+                    # it sometimes needs up to 2 seconds more
+                    # before it actually correctly processes requests
+                    # TODO: https://github.com/trezor/trezor-firmware/pull/6128
+                    time.sleep(2)
+                    break
             except OSError:
                 pass
 


### PR DESCRIPTION
It seems that even if the model is listening for connections it sometimes needs up to 2 seconds more before it actually correctly processes requests. See https://github.com/trezor/trezor-firmware/issues/6128.

The sleep was removed in #6079

See also this: https://github.com/tropicsquare/ts-tvl/issues/5

<!--
For core developers:
- Assign yourself to the PR.
- Set the priority to match the original issue.
- Add the PR to the current sprint.
- If it's a draft PR, mark it as "In Progress."
- If it's a final PR, mark it as "Needs Review."
- If needed, add a `Notes for QA` section.

For external contributors:
- Please open an issue before submitting a PR so we can discuss whether we want to proceed with it.
-->
