### PR TITLE
refactor(core): introduce Notification rust type

### DIFF
--- a/core/embed/rust/librust_qstr.h
+++ b/core/embed/rust/librust_qstr.h
@@ -16,6 +16,7 @@ static void _librust_qstrs(void) {
   MP_QSTR_8;
   MP_QSTR_9;
   MP_QSTR_;
+  MP_QSTR_ALERT;
   MP_QSTR_ATTACHED;
   MP_QSTR_AttachType;
   MP_QSTR_BACK;
@@ -42,6 +43,7 @@ static void _librust_qstrs(void) {
   MP_QSTR_MsgDef;
   MP_QSTR_NONE;
   MP_QSTR_NORMAL;
+  MP_QSTR_NotificationLevel;
   MP_QSTR_PairDevice;
   MP_QSTR_RESUME;
   MP_QSTR_RX_PACKET_LEN;
@@ -51,6 +53,7 @@ static void _librust_qstrs(void) {
   MP_QSTR_RemovePin;
   MP_QSTR_RemoveWipeCode;
   MP_QSTR_ReviewFailedBackup;
+  MP_QSTR_SUCCESS;
   MP_QSTR_SWIPE_DOWN;
   MP_QSTR_SWIPE_LEFT;
   MP_QSTR_SWIPE_RIGHT;
@@ -71,6 +74,7 @@ static void _librust_qstrs(void) {
   MP_QSTR_TurnOff;
   MP_QSTR_UnpairAllDevices;
   MP_QSTR_UnpairDevice;
+  MP_QSTR_WARNING;
   MP_QSTR_WipeDevice;
   MP_QSTR___del__;
   MP_QSTR___dict__;
@@ -478,7 +482,6 @@ static void _librust_qstrs(void) {
   MP_QSTR_more_info_callback;
   MP_QSTR_multiple_pages_texts;
   MP_QSTR_notification;
-  MP_QSTR_notification_level;
   MP_QSTR_page_count;
   MP_QSTR_page_counter;
   MP_QSTR_pages;

--- a/core/embed/rust/src/ui/layout_bolt/ui_firmware.rs
+++ b/core/embed/rust/src/ui/layout_bolt/ui_firmware.rs
@@ -25,6 +25,7 @@ use crate::{
             obj::{LayoutMaybeTrace, LayoutObj, RootComponent},
             util::{ConfirmValueParams, PropsList, RecoveryType},
         },
+        notification::Notification,
         ui_firmware::{
             FirmwareUI, MAX_CHECKLIST_ITEMS, MAX_GROUP_SHARE_LINES, MAX_MENU_ITEMS,
             MAX_PAIRED_DEVICES, MAX_WORD_QUIZ_ITEMS,
@@ -922,11 +923,9 @@ impl FirmwareUI for UIBolt {
 
     fn show_homescreen(
         label: TString<'static>,
-        notification: Option<TString<'static>>,
-        notification_level: u8,
+        notification: Option<Notification>,
         lockable: bool,
     ) -> Result<impl LayoutMaybeTrace, Error> {
-        let notification = notification.map(|w| (w, notification_level));
         let layout = RootComponent::new(Homescreen::new(label, notification, lockable));
         Ok(layout)
     }

--- a/core/embed/rust/src/ui/layout_caesar/component/homescreen.rs
+++ b/core/embed/rust/src/ui/layout_caesar/component/homescreen.rs
@@ -12,8 +12,8 @@ use crate::{
         },
         geometry::{Alignment, Alignment2D, Insets, Offset, Point, Rect},
         layout::util::get_user_custom_image,
-        shape,
-        shape::Renderer,
+        notification::Notification,
+        shape::{self, Renderer},
     },
 };
 
@@ -59,7 +59,7 @@ pub struct Homescreen {
     // TODO label should be a Child in theory, but the homescreen image is not, so it is
     // always painted, so we need to always paint the label too
     label: Label<'static>,
-    notification: Option<(TString<'static>, u8)>,
+    notification: Option<Notification>,
     custom_image: Option<BinaryData<'static>>,
     /// Used for HTC functionality to lock device from homescreen
     invisible_buttons: Child<ButtonController>,
@@ -74,7 +74,7 @@ pub struct Homescreen {
 impl Homescreen {
     pub fn new(
         label: TString<'static>,
-        notification: Option<(TString<'static>, u8)>,
+        notification: Option<Notification>,
         loader_description: Option<TString<'static>>,
     ) -> Self {
         // Buttons will not be visible, we only need both left and right to be existing
@@ -118,12 +118,12 @@ impl Homescreen {
                     .with_align(Alignment::Center)
                     .render(target)
             });
-        } else if let Some((notification, _level)) = &self.notification {
+        } else if let Some(notification) = &self.notification {
             shape::Bar::new(AREA.split_top(NOTIFICATION_HEIGHT).0)
                 .with_bg(theme::BG)
                 .render(target);
 
-            notification.map(|c| {
+            notification.text.map(|c| {
                 shape::Text::new(baseline, c, NOTIFICATION_FONT)
                     .with_align(Alignment::Center)
                     .render(target)
@@ -132,7 +132,7 @@ impl Homescreen {
             // Painting warning icons in top corners when the text is short enough not to
             // collide with them
             let icon_width = NOTIFICATION_ICON.toif.width();
-            let text_width = notification.map(|c| NOTIFICATION_FONT.text_width(c));
+            let text_width = notification.text.map(|c| NOTIFICATION_FONT.text_width(c));
             if AREA.width() >= text_width + (icon_width + 1) * 2 {
                 shape::ToifImage::new(AREA.top_left(), NOTIFICATION_ICON.toif)
                     .with_align(Alignment2D::TOP_LEFT)

--- a/core/embed/rust/src/ui/layout_caesar/ui_firmware.rs
+++ b/core/embed/rust/src/ui/layout_caesar/ui_firmware.rs
@@ -24,6 +24,7 @@ use crate::{
             obj::{LayoutMaybeTrace, LayoutObj, RootComponent},
             util::{ConfirmValueParams, RecoveryType},
         },
+        notification::Notification,
         ui_firmware::{
             FirmwareUI, MAX_CHECKLIST_ITEMS, MAX_GROUP_SHARE_LINES, MAX_MENU_ITEMS,
             MAX_PAIRED_DEVICES, MAX_WORD_QUIZ_ITEMS,
@@ -1115,11 +1116,9 @@ impl FirmwareUI for UICaesar {
 
     fn show_homescreen(
         label: TString<'static>,
-        notification: Option<TString<'static>>,
-        notification_level: u8,
+        notification: Option<Notification>,
         lockable: bool,
     ) -> Result<impl LayoutMaybeTrace, Error> {
-        let notification = notification.map(|w| (w, notification_level));
         let loader_description = lockable.then_some("Locking the device...".into());
         let layout = RootComponent::new(Homescreen::new(label, notification, loader_description));
         Ok(layout)

--- a/core/embed/rust/src/ui/layout_delizia/ui_firmware.rs
+++ b/core/embed/rust/src/ui/layout_delizia/ui_firmware.rs
@@ -26,6 +26,7 @@ use crate::{
             obj::{LayoutMaybeTrace, LayoutObj, RootComponent},
             util::{ContentType, PropsList, RecoveryType, StrOrBytes},
         },
+        notification::Notification,
         ui_firmware::{
             FirmwareUI, MAX_CHECKLIST_ITEMS, MAX_GROUP_SHARE_LINES, MAX_MENU_ITEMS,
             MAX_PAIRED_DEVICES, MAX_WORD_QUIZ_ITEMS,
@@ -982,11 +983,9 @@ impl FirmwareUI for UIDelizia {
 
     fn show_homescreen(
         label: TString<'static>,
-        notification: Option<TString<'static>>,
-        notification_level: u8,
+        notification: Option<Notification>,
         lockable: bool,
     ) -> Result<impl LayoutMaybeTrace, Error> {
-        let notification = notification.map(|w| (w, notification_level));
         let layout = RootComponent::new(Homescreen::new(label, notification, lockable)?);
         Ok(layout)
     }

--- a/core/embed/rust/src/ui/layout_eckhart/theme/firmware.rs
+++ b/core/embed/rust/src/ui/layout_eckhart/theme/firmware.rs
@@ -1,8 +1,11 @@
 use crate::{
     time::ShortDuration,
-    ui::component::text::{
-        layout::{Chunks, LineBreaking, PageBreaking},
-        TextStyle,
+    ui::{
+        component::text::{
+            layout::{Chunks, LineBreaking, PageBreaking},
+            TextStyle,
+        },
+        notification::NotificationLevel,
     },
 };
 
@@ -414,14 +417,16 @@ macro_rules! button_homebar_style {
         }
     };
 }
-pub const fn button_homebar_style(notification_level: u8) -> (ButtonStyleSheet, Gradient) {
-    // NOTE: 0 is the highest severity.
-    match notification_level {
-        0 => (button_homebar_style!(RED), Gradient::Alert),
-        1 => (button_homebar_style!(GREY_LIGHT), Gradient::Warning),
-        2 => (button_homebar_style!(GREY_LIGHT), Gradient::DefaultGrey),
-        3 => (button_homebar_style!(GREY_LIGHT), Gradient::SignGreen),
-        _ => (button_homebar_style!(GREY_LIGHT), Gradient::DefaultGrey),
+
+pub const fn button_homebar_style(nl: Option<NotificationLevel>) -> (ButtonStyleSheet, Gradient) {
+    match nl {
+        Some(NotificationLevel::Alert) => (button_homebar_style!(RED), Gradient::Alert),
+        Some(NotificationLevel::Warning) => (button_homebar_style!(GREY_LIGHT), Gradient::Warning),
+        Some(NotificationLevel::Info) => (button_homebar_style!(GREY_LIGHT), Gradient::DefaultGrey),
+        Some(NotificationLevel::Success) => {
+            (button_homebar_style!(GREY_LIGHT), Gradient::SignGreen)
+        }
+        None => (button_homebar_style!(GREY_LIGHT), Gradient::DefaultGrey),
     }
 }
 

--- a/core/embed/rust/src/ui/layout_eckhart/ui_firmware.rs
+++ b/core/embed/rust/src/ui/layout_eckhart/ui_firmware.rs
@@ -25,6 +25,7 @@ use crate::{
             obj::{LayoutMaybeTrace, LayoutObj, RootComponent},
             util::{ConfirmValueParams, ContentType, PropsList, RecoveryType, StrOrBytes},
         },
+        notification::Notification,
         ui_firmware::{
             FirmwareUI, MAX_CHECKLIST_ITEMS, MAX_GROUP_SHARE_LINES, MAX_MENU_ITEMS,
             MAX_PAIRED_DEVICES, MAX_WORD_QUIZ_ITEMS,
@@ -1203,14 +1204,12 @@ impl FirmwareUI for UIEckhart {
 
     fn show_homescreen(
         label: TString<'static>,
-        notification: Option<TString<'static>>,
-        notification_level: u8,
+        notification: Option<Notification>,
         lockable: bool,
     ) -> Result<impl LayoutMaybeTrace, Error> {
         let locked = false;
         let bootscreen = false;
         let coinjoin_authorized = false;
-        let notification = notification.map(|w| (w, notification_level));
         let layout = RootComponent::new(Homescreen::new(
             label,
             lockable,

--- a/core/embed/rust/src/ui/mod.rs
+++ b/core/embed/rust/src/ui/mod.rs
@@ -10,6 +10,7 @@ pub mod event;
 pub mod flow;
 pub mod geometry;
 pub mod lerp;
+pub mod notification;
 pub mod shape;
 pub mod util;
 

--- a/core/embed/rust/src/ui/notification.rs
+++ b/core/embed/rust/src/ui/notification.rs
@@ -1,0 +1,76 @@
+use crate::{error::Error, strutil::TString};
+
+#[cfg(feature = "micropython")]
+use crate::micropython::{
+    macros::{obj_dict, obj_map, obj_type},
+    obj::Obj,
+    qstr::Qstr,
+    simple_type::SimpleTypeObj,
+    typ::Type,
+};
+
+/// Homescreen notification.
+#[derive(Clone)]
+#[cfg_attr(test, derive(Debug))]
+pub struct Notification {
+    pub text: TString<'static>,
+    pub level: NotificationLevel,
+}
+
+impl Notification {
+    pub fn new(text: TString<'static>, level: NotificationLevel) -> Self {
+        Self { text, level }
+    }
+}
+
+/// Notification level determining the style of notification.
+#[repr(u8)]
+#[derive(Clone, Copy, Debug)]
+pub enum NotificationLevel {
+    /// Strong warning, e.g. "Backup failed"
+    Alert = 0,
+    /// Warning, e.g. "PIN not set"
+    Warning = 1,
+    /// Information, e.g. "Connected" or "Experimental features"
+    Info = 2,
+    /// Successful operation, e.g. "Coinjoin authorized"
+    Success = 3,
+}
+
+impl TryFrom<u8> for NotificationLevel {
+    type Error = Error;
+    fn try_from(value: u8) -> Result<Self, Self::Error> {
+        match value {
+            0 => Ok(NotificationLevel::Alert),
+            1 => Ok(NotificationLevel::Warning),
+            2 => Ok(NotificationLevel::Info),
+            3 => Ok(NotificationLevel::Success),
+            _ => Err(Error::OutOfRange),
+        }
+    }
+}
+
+#[cfg(feature = "micropython")]
+impl TryFrom<Obj> for NotificationLevel {
+    type Error = Error;
+
+    fn try_from(obj: Obj) -> Result<Self, Self::Error> {
+        let val = u8::try_from(obj)?;
+        let this = Self::try_from(val)?;
+        Ok(this)
+    }
+}
+
+#[cfg(feature = "micropython")]
+static NOTIFICATION_LEVEL_TYPE: Type = obj_type! {
+    name: Qstr::MP_QSTR_NotificationLevel,
+    locals: &obj_dict!(obj_map! {
+        Qstr::MP_QSTR_ALERT => Obj::small_int(0),
+        Qstr::MP_QSTR_WARNING => Obj::small_int(1),
+        Qstr::MP_QSTR_INFO => Obj::small_int(2),
+        Qstr::MP_QSTR_SUCCESS => Obj::small_int(3),
+    }),
+};
+
+#[cfg(feature = "micropython")]
+pub static NOTIFICATION_LEVEL_OBJ: SimpleTypeObj = SimpleTypeObj::new(&NOTIFICATION_LEVEL_TYPE);

--- a/core/embed/rust/src/ui/ui_firmware.rs
+++ b/core/embed/rust/src/ui/ui_firmware.rs
@@ -3,6 +3,7 @@ use crate::{
     io::BinaryData,
     micropython::{buffer::StrBuffer, gc::Gc, list::List, obj::Obj},
     strutil::TString,
+    ui::notification::Notification,
 };
 use heapless::Vec;
 
@@ -351,8 +352,7 @@ pub trait FirmwareUI {
 
     fn show_homescreen(
         label: TString<'static>,
-        notification: Option<TString<'static>>,
-        notification_level: u8,
+        notification: Option<Notification>,
         lockable: bool,
     ) -> Result<impl LayoutMaybeTrace, Error>;
 

--- a/core/mocks/generated/trezorui_api.pyi
+++ b/core/mocks/generated/trezorui_api.pyi
@@ -614,8 +614,7 @@ def show_group_share_success(
 def show_homescreen(
     *,
     label: str,
-    notification: str | None,
-    notification_level: int = 0,
+    notification: tuple[str, int] | None = None,
     lockable: bool,
     skip_first_paint: bool,
 ) -> LayoutObj[UiResult]:
@@ -866,6 +865,15 @@ class AttachType:
     SWIPE_DOWN: ClassVar[int]
     SWIPE_LEFT: ClassVar[int]
     SWIPE_RIGHT: ClassVar[int]
+
+
+# rust/src/ui/api/firmware_micropython.rs
+class NotificationLevel:
+    """Notification level determining the style of notification."""
+    ALERT: ClassVar[int]
+    WARNING: ClassVar[int]
+    INFO: ClassVar[int]
+    SUCCESS: ClassVar[int]
 
 
 # rust/src/ui/api/firmware_micropython.rs

--- a/core/src/apps/homescreen/__init__.py
+++ b/core/src/apps/homescreen/__init__.py
@@ -6,6 +6,7 @@ import trezorui_api
 from trezor import config, utils, wire
 from trezor.enums import MessageType
 from trezor.ui.layouts.homescreen import Busyscreen, Homescreen, Lockscreen
+from trezorui_api import NotificationLevel
 
 from apps.base import busy_expiry_ms
 from apps.common.authorization import is_set_any_session
@@ -31,30 +32,25 @@ async def homescreen() -> None:
     # TODO: add notification that translations are out of date
 
     notification = None
-    notification_level = 1  # 0 = strong warning, 1 = warning, 2 = info, 3 = success
     if is_set_any_session(MessageType.AuthorizeCoinJoin):
-        notification = TR.homescreen__title_coinjoin_authorized
-        notification_level = 3
+        notification = (
+            TR.homescreen__title_coinjoin_authorized,
+            NotificationLevel.SUCCESS,
+        )
     elif storage.device.is_initialized() and storage.device.no_backup():
-        notification = TR.homescreen__title_seedless
-        notification_level = 0
+        notification = (TR.homescreen__title_seedless, NotificationLevel.ALERT)
     elif storage.device.is_initialized() and storage.device.unfinished_backup():
-        notification = TR.homescreen__title_backup_failed
-        notification_level = 0
+        notification = (TR.homescreen__title_backup_failed, NotificationLevel.ALERT)
     elif storage.device.is_initialized() and storage.device.needs_backup():
-        notification = TR.homescreen__title_backup_needed
-        notification_level = 1
+        notification = (TR.homescreen__title_backup_needed, NotificationLevel.WARNING)
     elif storage.device.is_initialized() and not config.has_pin():
-        notification = TR.homescreen__title_pin_not_set
-        notification_level = 1
+        notification = (TR.homescreen__title_pin_not_set, NotificationLevel.WARNING)
     elif storage.device.get_experimental_features():
-        notification = TR.homescreen__title_experimental_mode
-        notification_level = 2
+        notification = (TR.homescreen__title_experimental_mode, NotificationLevel.INFO)
 
     obj = Homescreen(
         label=label,
         notification=notification,
-        notification_level=notification_level,
         lockable=config.has_pin(),
     )
     try:

--- a/core/src/trezor/ui/layouts/homescreen.py
+++ b/core/src/trezor/ui/layouts/homescreen.py
@@ -6,7 +6,7 @@ from storage.cache_common import APP_COMMON_BUSY_DEADLINE_MS
 from trezor import TR, ui, utils
 
 if TYPE_CHECKING:
-    from typing import Any, Callable, Iterator, ParamSpec, TypeVar
+    from typing import Any, Callable, Iterator, ParamSpec, Tuple, TypeVar
 
     from trezor import loop
 
@@ -65,8 +65,7 @@ class Homescreen(HomescreenBase):
     def __init__(
         self,
         label: str | None,
-        notification: str | None,
-        notification_level: int,
+        notification: Tuple[str, int] | None,
         lockable: bool,
     ) -> None:
         super().__init__(
@@ -74,7 +73,6 @@ class Homescreen(HomescreenBase):
                 trezorui_api.show_homescreen,
                 label=label or utils.MODEL_FULL_NAME,
                 notification=notification,
-                notification_level=notification_level,
                 lockable=lockable,
                 skip_first_paint=self._should_resume(),
             )


### PR DESCRIPTION
- introduce a type rather than carrying a tuple around
- this should make working with notifs easier in the future as we can add fields to the struct
- export the NotificationLevel to uPy

[no changelog]

<!--
For core developers:
- Assign yourself to the PR.
- Set the priority to match the original issue.
- Add the PR to the current sprint.
- If it's a draft PR, mark it as "In Progress."
- If it's a final PR, mark it as "Needs Review."
- If needed, add a `Notes for QA` section.

For external contributors:
- Please open an issue before submitting a PR so we can discuss whether we want to proceed with it.
-->
