### PR TITLE
fix always active power management errors in emulator

### DIFF
--- a/core/embed/io/power_manager/unix/power_manager.c
+++ b/core/embed/io/power_manager/unix/power_manager.c
@@ -69,6 +69,8 @@ pm_status_t pm_get_state(pm_state_t* state) {
   state->charging_status = PM_BATTERY_IDLE;
   state->power_status = PM_STATE_ACTIVE;
   state->soc = 100;
+  state->ntc_connected = true;
+  state->battery_connected = true;
   return PM_OK;
 }
 


### PR DESCRIPTION
NTC and battery disconnected errors were always active due to the flags not being set.