### PR TITLE
fix(core): avoid backup flow failure due to communication issues

### DIFF
--- a/core/.changelog.d/6348.fixed
+++ b/core/.changelog.d/6348.fixed
@@ -1,0 +1,1 @@
+Don't abort backup flow due to host communication issues.

--- a/core/src/apps/management/reset_device/__init__.py
+++ b/core/src/apps/management/reset_device/__init__.py
@@ -6,7 +6,7 @@ from trezor import TR
 from trezor.crypto import hmac, slip39
 from trezor.enums import BackupType, MessageType
 from trezor.ui.layouts import confirm_action
-from trezor.wire import ProcessError
+from trezor.wire import ProcessError, context
 
 from apps.common import backup_types
 
@@ -125,7 +125,9 @@ async def reset_device(msg: ResetDevice) -> Success:
 
     # generate and display backup information for the master secret
     if perform_backup:
-        await backup_seed(backup_type, secret)
+        with context.ignore_host():
+            # Avoid failing the backup due to host communication.
+            await backup_seed(backup_type, secret)
 
     # write settings and master secret into storage
     if msg.label is not None:

--- a/core/src/trezor/wire/context.py
+++ b/core/src/trezor/wire/context.py
@@ -129,6 +129,18 @@ def with_context(ctx: Context, workflow: loop.Task) -> Generator:
             send_exc = None
 
 
+class ignore_host:
+    """Some workflows must not fail due to communication issues - see `ui.Layout.start()` and #6348."""
+
+    def __enter__(self) -> None:
+        if CURRENT_CONTEXT is not None:
+            CURRENT_CONTEXT.ignore_host = True
+
+    def __exit__(self, exc_type: Any, _exc_value: Any, _tb: Any) -> None:
+        if CURRENT_CONTEXT is not None:
+            CURRENT_CONTEXT.ignore_host = False
+
+
 def try_get_ctx_ids() -> tuple[AnyBytes, AnyBytes] | None:
     ids = None
     if utils.USE_THP:

--- a/core/src/trezor/wire/protocol_common.py
+++ b/core/src/trezor/wire/protocol_common.py
@@ -50,6 +50,9 @@ class Context:
         if channel_id is not None:
             self.channel_id = channel_id
 
+        # Some workflows must not fail due to communication issues - see `ui.Layout.start()` and #6348.
+        self.ignore_host: bool = False
+
     if TYPE_CHECKING:
 
         @overload


### PR DESCRIPTION
We prefer to continue the backup flow, because aborting it will require the user to reset the device (since the backup can be shown only once).

Therefore, this PR skips button requests handling and ignores host-side communication attempts during backup flow. It means that it won't be possible to abort the backup process via the host.

The final `Success` message is still sent (after the backup is successfully completed).

Fixes #6348.

# TODO:

 - [ ] add explicit tests for:
   1. host unavailability after the flow was started
   1. host-side interruption during the flow
 - [ ] fix existing device tests (which are tightly coupled to existing button requests)
