### PR TITLE
Send DebugLinkOptigaSetSecMax via debuglink

### DIFF
--- a/python/src/trezorlib/cli/debug.py
+++ b/python/src/trezorlib/cli/debug.py
@@ -71,7 +71,11 @@ def prodtest_t1(session: "Session") -> None:
 @with_session(seedless=True)
 def optiga_set_sec_max(session: "Session") -> None:
     """Set Optiga's security event counter to maximum."""
-    debuglink_optiga_set_sec_max(session)
+    debug_transport = session.client.protocol.transport.find_debug()
+    debug_transport.open()
+    debug = DebugLink(transport=debug_transport)
+    debuglink_optiga_set_sec_max(debug)
+    debug_transport.close()
 
 
 @cli.command()

--- a/python/src/trezorlib/debuglink.py
+++ b/python/src/trezorlib/debuglink.py
@@ -1837,8 +1837,8 @@ def _is_emulator(debug_client: "TrezorClientDebugLink") -> bool:
     return debug_client.features.fw_vendor == "EMULATOR"
 
 
-def optiga_set_sec_max(session: "Session") -> None:
-    session.call(messages.DebugLinkOptigaSetSecMax(), expect=messages.Success)
+def optiga_set_sec_max(debug: DebugLink) -> None:
+    debug._call(messages.DebugLinkOptigaSetSecMax())
 
 
 def set_log_filter(debug: DebugLink, filter: str) -> None:


### PR DESCRIPTION
Trezor expects this message on debug interface only. This PR redirects the message to that if send from trezorctl.
