### PR TITLE
Small fix for running `make gen` on older python version

### DIFF
--- a/core/embed/rust/src/translations/generated/translated_string.rs.mako
+++ b/core/embed/rust/src/translations/generated/translated_string.rs.mako
@@ -100,7 +100,7 @@ def filter_by_features(values: list[str], keep_debug: bool, keep_altcoin: bool) 
         feature if is_enabled else f'not({feature})'
         for is_enabled, feature in zip(enabled_features, features)
     ]
-    cfg_line = f'#[cfg(all({', '.join(configs)}))]'
+    cfg_line = f'#[cfg(all({", ".join(configs)}))]'
 
     # Currently all English words fit into a single chunk
     [encoded] = TranslatedStringsChunk.from_items(filter_by_features(layout_data, *enabled_features))


### PR DESCRIPTION
One line change in #6313 to use `"` instead of `'`. It is cleaner and doesn't throw error when running on older python version like `3.11`
