### PR TITLE
Visit summary menu items in tests

### DIFF
--- a/core/embed/rust/src/ui/layout_delizia/flow/confirm_output.rs
+++ b/core/embed/rust/src/ui/layout_delizia/flow/confirm_output.rs
@@ -211,6 +211,7 @@ pub fn new_confirm_output(
     let res = if let Some(summary_items_params) = summary_items_params {
         // Summary
         let content_summary = summary_items_params
+            .with_flow_menu(true)
             .into_layout()?
             .one_button_request(ButtonRequest::from_num(
                 summary_br_code.unwrap(),
@@ -224,6 +225,7 @@ pub fn new_confirm_output(
             SwipeContent::new(PromptScreen::new_hold_to_confirm()),
         )
         .with_menu_button()
+        .with_flow_menu()
         .with_footer(TR::instructions__hold_to_sign.into(), None)
         .with_swipe(Direction::Down, SwipeSettings::Default)
         .map(super::util::map_to_confirm);

--- a/core/embed/rust/src/ui/layout_delizia/flow/confirm_summary.rs
+++ b/core/embed/rust/src/ui/layout_delizia/flow/confirm_summary.rs
@@ -74,6 +74,7 @@ pub fn new_confirm_summary(
 ) -> Result<SwipeFlow, error::Error> {
     // Summary
     let content_summary = summary_params
+        .with_flow_menu(true)
         .into_layout()?
         // Summary(1) + Hold(1)
         .with_pages(|summary_pages| summary_pages + 1);
@@ -83,6 +84,7 @@ pub fn new_confirm_summary(
         TR::send__sign_transaction.into(),
         SwipeContent::new(PromptScreen::new_hold_to_confirm()),
     )
+    .with_flow_menu()
     .with_menu_button()
     .with_footer(TR::instructions__hold_to_sign.into(), None)
     .with_swipe(Direction::Down, SwipeSettings::Default)

--- a/core/embed/rust/src/ui/layout_delizia/flow/util.rs
+++ b/core/embed/rust/src/ui/layout_delizia/flow/util.rs
@@ -304,6 +304,7 @@ pub struct ShowInfoParams {
     swipe_up: bool,
     swipe_down: bool,
     items: Vec<(TString<'static>, TString<'static>), 4>,
+    flow_menu: bool,
 }
 
 impl ShowInfoParams {
@@ -318,6 +319,7 @@ impl ShowInfoParams {
             swipe_up: false,
             swipe_down: false,
             items: Vec::new(),
+            flow_menu: false,
         }
     }
 
@@ -380,6 +382,11 @@ impl ShowInfoParams {
         self
     }
 
+    pub const fn with_flow_menu(mut self, flow_menu: bool) -> Self {
+        self.flow_menu = flow_menu;
+        self
+    }
+
     #[inline(never)]
     pub fn into_layout(
         self,
@@ -415,6 +422,9 @@ impl ShowInfoParams {
         }
         if let Some(instruction) = self.footer_instruction {
             frame = frame.with_footer(instruction, self.footer_description);
+        }
+        if self.flow_menu {
+            frame = frame.with_flow_menu();
         }
 
         if self.swipe_up {

--- a/core/embed/rust/src/ui/layout_eckhart/flow/confirm_summary.rs
+++ b/core/embed/rust/src/ui/layout_eckhart/flow/confirm_summary.rs
@@ -123,6 +123,7 @@ pub fn new_confirm_summary(
             .with_placement(LinearPlacement::vertical()),
     )
     .with_header(Header::new(title).with_menu_button())
+    .with_flow_menu()
     .with_action_bar(if back_button {
         ActionBar::new_double(Button::with_icon(theme::ICON_CHEVRON_UP), confirm_button)
     } else {

--- a/python/src/trezorlib/debuglink.py
+++ b/python/src/trezorlib/debuglink.py
@@ -1119,12 +1119,12 @@ class DebugUI:
 
         # Paginating (going as further as possible)
         for _ in range(pages - 1):
+            self.visit_menu_items()
             if self.debuglink.model is models.T3W1:
                 self.debuglink.click(self.debuglink.screen_buttons.ok())
             else:
                 self.debuglink.swipe_up()
 
-        # Visit info menus (if exist)
         layout = self.visit_menu_items()
 
         # Confirm current layout

--- a/tests/input_flows.py
+++ b/tests/input_flows.py
@@ -3039,9 +3039,9 @@ class InputFlowConfirmAllWarnings(InputFlowBase):
             # Paginating (going as further as possible) and pressing Yes
             if br.pages is not None:
                 for _ in range(br.pages - 1):
+                    self.client.ui.visit_menu_items()
                     self.debug.swipe_up()
 
-            # Visit info menus (if exist)
             layout = self.client.ui.visit_menu_items()
 
             text = layout.footer().lower()
@@ -3069,8 +3069,10 @@ class InputFlowConfirmAllWarnings(InputFlowBase):
             # Paginating (going as further as possible) and pressing Yes
             if br.pages is not None:
                 for _ in range(br.pages - 1):
+                    self.client.ui.visit_menu_items()
                     self.debug.click(self.debug.screen_buttons.ok())
-            layout = self.debug.read_layout()
+
+            layout = self.client.ui.visit_menu_items()
             text = layout.action_bar().lower()
             # hi priority warning
             hi_prio = (


### PR DESCRIPTION
Follow up of #6133.

* visit menu items on the summary screen of `ConfirmOutputWithSummary`
* visit menu items of `flow_confirm_summary`

<!--
For core developers:
- Assign yourself to the PR.
- Set the priority to match the original issue.
- Add the PR to the current sprint.
- If it's a draft PR, mark it as "In Progress."
- If it's a final PR, mark it as "Needs Review."
- If needed, add a `Notes for QA` section.

For external contributors:
- Please open an issue before submitting a PR so we can discuss whether we want to proceed with it.
-->
