### PR TITLE
fix(core): avoid interrupting `BackupDevice` flow by unexpected messages

### DIFF
--- a/core/src/apps/management/backup_device.py
+++ b/core/src/apps/management/backup_device.py
@@ -76,6 +76,7 @@ async def perform_backup(
 async def backup_device(msg: BackupDevice) -> Success:
     from trezor import wire
     from trezor.messages import Success
+    from trezor.wire import context
 
     from apps.common import backup, mnemonic
 
@@ -103,6 +104,7 @@ async def backup_device(msg: BackupDevice) -> Success:
     elif len(groups) > 0:
         raise wire.DataError("group_threshold is missing")
 
-    await perform_backup(is_repeated_backup, group_threshold, groups)
+    with context.AvoidCancellation("Backup in progress"):
+        await perform_backup(is_repeated_backup, group_threshold, groups)
 
     return Success(message="Seed successfully backed up")

--- a/core/src/trezor/ui/__init__.py
+++ b/core/src/trezor/ui/__init__.py
@@ -478,8 +478,11 @@ class Layout(Generic[T]):
             if self.context is None:
                 return
             while True:
-                # The following task will raise `UnexpectedMessageException` on any message.
-                unexpected_read = self.context.read(())
+                # Continue listening to host, so we can respond to unexpected messages:
+                # - most of the flows should be cancelled via `UnexpectedMessageException`
+                # - some flows should avoid cancellation and notify the host
+                unexpected_read = self.context.create_unexpected_handler()
+
                 result = await loop.race(unexpected_read, self.button_request_box)
                 if result is None:
                     return  # exit the loop when the layout is done.


### PR DESCRIPTION
Since THP channel preemption is using the same mechanism, it will be disabled as well during this workflow.
