### PR TITLE
chore: bump versions

### DIFF
--- a/core/embed/projects/bootloader/version.h
+++ b/core/embed/projects/bootloader/version.h
@@ -4,7 +4,7 @@
 
 #define VERSION_MAJOR 2
 #define VERSION_MINOR 1
-#define VERSION_PATCH 16
+#define VERSION_PATCH 17
 #define VERSION_BUILD 0
 #define VERSION_UINT32                                            \
   (VERSION_MAJOR | (VERSION_MINOR << 8) | (VERSION_PATCH << 16) | \

--- a/core/embed/projects/firmware/version.h
+++ b/core/embed/projects/firmware/version.h
@@ -4,7 +4,7 @@
 
 #define VERSION_MAJOR 2
 #define VERSION_MINOR 10
-#define VERSION_PATCH 1
+#define VERSION_PATCH 2
 #define VERSION_BUILD 0
 
 #define FIX_VERSION_MAJOR 2

--- a/core/embed/projects/prodtest/version.h
+++ b/core/embed/projects/prodtest/version.h
@@ -4,7 +4,7 @@
 
 #define VERSION_MAJOR 0
 #define VERSION_MINOR 3
-#define VERSION_PATCH 6
+#define VERSION_PATCH 7
 #define VERSION_BUILD 0
 
 #define FIX_VERSION_MAJOR 0

--- a/core/embed/projects/secmon/version.h
+++ b/core/embed/projects/secmon/version.h
@@ -4,5 +4,5 @@
 
 #define VERSION_MAJOR 1
 #define VERSION_MINOR 0
-#define VERSION_PATCH 7
+#define VERSION_PATCH 8
 #define VERSION_BUILD 0

--- a/core/translations/cs.json
+++ b/core/translations/cs.json
@@ -33,7 +33,7 @@
   },
   "header": {
     "language": "cs-CZ",
-    "version": "2.10.1"
+    "version": "2.10.2"
   },
   "translations": {
     "addr_mismatch__contact_support_at": "Kontaktujte naši podporu na",

--- a/core/translations/de.json
+++ b/core/translations/de.json
@@ -33,7 +33,7 @@
   },
   "header": {
     "language": "de-DE",
-    "version": "2.10.1"
+    "version": "2.10.2"
   },
   "translations": {
     "addr_mismatch__contact_support_at": "Kontaktiere den Trezor Support unter",

--- a/core/translations/en.json
+++ b/core/translations/en.json
@@ -1,7 +1,7 @@
 {
   "header": {
     "language": "en-US",
-    "version": "2.10.1"
+    "version": "2.10.2"
   },
   "translations": {
     "addr_mismatch__contact_support_at": "Please contact Trezor support at",

--- a/core/translations/es.json
+++ b/core/translations/es.json
@@ -33,7 +33,7 @@
   },
   "header": {
     "language": "es-ES",
-    "version": "2.10.1"
+    "version": "2.10.2"
   },
   "translations": {
     "addr_mismatch__contact_support_at": "Contacta con atención al cliente de Trezor en",

--- a/core/translations/fr.json
+++ b/core/translations/fr.json
@@ -33,7 +33,7 @@
   },
   "header": {
     "language": "fr-FR",
-    "version": "2.10.1"
+    "version": "2.10.2"
   },
   "translations": {
     "addr_mismatch__contact_support_at": {

--- a/core/translations/pt.json
+++ b/core/translations/pt.json
@@ -33,7 +33,7 @@
   },
   "header": {
     "language": "pt-BR",
-    "version": "2.10.1"
+    "version": "2.10.2"
   },
   "translations": {
     "addr_mismatch__contact_support_at": "Entre em contato com o suporte Trezor em",

--- a/core/translations/signatures.json
+++ b/core/translations/signatures.json
@@ -1,8 +1,8 @@
 {
   "current": {
-    "merkle_root": "77330a4cf318f9f3e8ad9c86818abdc3b946dbeb389fbd5ec9a563c99e3a19f8",
-    "datetime": "2026-01-26T14:44:48.094660+00:00",
-    "commit": "094ecaef1c04aa8145ee54bf305ba0c35c99d53c"
+    "merkle_root": "21ec09f914745b48d01aefb30b62bec9e04973bd3dbd52ed0f7ec6a5c446009a",
+    "datetime": "2026-01-27T18:58:11.093581+00:00",
+    "commit": "860ef85c4a86e0d00f8372d227cdd89f9d02ddd4"
   },
   "history": [
     {


### PR DESCRIPTION
```
tools/bump-version.py core 2.10.2
tools/bump-version.py core/embed/projects/secmon 1.0.8
tools/bump-version.py core/embed/projects/bootloader 2.1.17
tools/bump-version.py core/embed/projects/prodtest 0.3.7
```
