### PR TITLE
fix(crypto): fix cash_encode

### DIFF
--- a/crypto/cash_addr.h
+++ b/crypto/cash_addr.h
@@ -26,52 +26,55 @@
 
 /** Encode a Cashaddr address
  *
- *  Out: output:   Pointer to a buffer of size 105 + strlen(hrp) that will be
- *                 updated to contain the null-terminated address.
- *  In:  hrp:      Pointer to the null-terminated human readable part to use
+ *  Out: output:   Pointer to a buffer of size min(114 + strlen(hrp), 130)
+ *                 that will be updated to contain the null-terminated
+ *                 address.
+ *  In: hrp:       Pointer to the null-terminated human readable part to use
  *                 (chain/network specific).
- *       prog:     Data bytes for the hash (between 21 and 65 bytes).
- *       prog_len: Number of data bytes in prog.
+ *      prog:      Data bytes for the hash (between 21 and 65 bytes).
+ *      prog_size: Number of data bytes in prog.
  *  Returns 1 if successful.
  */
 int cash_addr_encode(char *output, const char *hrp, const uint8_t *prog,
-                     size_t prog_len);
+                     size_t prog_size);
 
 /** Decode a CashAddr address
  *
- *  Out: prog:     Pointer to a buffer of size 65 that will be updated to
- *                 contain the witness program bytes.
- *       prog_len: Pointer to a size_t that will be updated to contain the
- * length of bytes in prog. hrp:      Pointer to the null-terminated human
- * readable part that is expected (chain/network specific). addr:     Pointer to
- * the null-terminated address. Returns 1 if successful.
+ *  Out: prog:      Pointer to a buffer of size 65 that will be updated to
+ *                  contain the witness program bytes.
+ *       prog_size: Pointer to a size_t that will be updated to contain the
+ *                  length of bytes in prog.
+ *  In: hrp:        Pointer to the null-terminated human readable part that is
+ *                  expected (chain/network specific).
+ *      addr:       Pointer to the null-terminated address.
+ *  Returns 1 if successful.
  */
-int cash_addr_decode(uint8_t *prog, size_t *prog_len, const char *hrp,
+int cash_addr_decode(uint8_t *prog, size_t *prog_size, const char *hrp,
                      const char *addr);
 
 /** Encode a Cash string
  *
- *  Out: output:  Pointer to a buffer of size strlen(hrp) + data_len + 8 that
- *                will be updated to contain the null-terminated Cash string.
- *  In: hrp :     Pointer to the null-terminated human readable part.
- *      data :    Pointer to an array of 5-bit values.
- *      data_len: Length of the data array.
+ *  Out: output:   Pointer to a buffer of size strlen(hrp) + data_size + 10 that
+ *                 will be updated to contain the null-terminated Cash string.
+ *  In: hrp:       Pointer to the null-terminated human readable part.
+ *      data:      Pointer to an array of 5-bit values.
+ *      data_size: Length of the data array.
  *  Returns 1 if successful.
  */
 int cash_encode(char *output, const char *hrp, const uint8_t *data,
-                size_t data_len);
+                size_t data_size);
 
 /** Decode a Cash string
  *
- *  Out: hrp:      Pointer to a buffer of size strlen(input) - 6. Will be
- *                 updated to contain the null-terminated human readable part.
- *       data:     Pointer to a buffer of size strlen(input) - 8 that will
- *                 hold the encoded 5-bit data values.
- *       data_len: Pointer to a size_t that will be updated to be the number
- *                 of entries in data.
- *  In: input:     Pointer to a null-terminated Cash string.
+ *  Out: hrp:       Pointer to a buffer of size strlen(input) - 6. Will be
+ *                  updated to contain the null-terminated human readable part.
+ *       data:      Pointer to a buffer of size strlen(input) - 8 that will
+ *                  hold the encoded 5-bit data values.
+ *       data_size: Pointer to a size_t that will be updated to be the number
+ *                  of entries in data.
+ *  In: input:      Pointer to a null-terminated Cash string.
  *  Returns 1 if succesful.
  */
-int cash_decode(char *hrp, uint8_t *data, size_t *data_len, const char *input);
+int cash_decode(char *hrp, uint8_t *data, size_t *data_size, const char *input);
 
 #endif


### PR DESCRIPTION
- Fixed description of buffer sizes in the header file.
- Added check of hrp length in `cash_encode`. Otherwise it allows to encode addresses that cannot be decoded using `cash_decode`.
- Adjusted naming of constants and parameters for clarity and consistency.