### PR TITLE
Fix failed python unit test detection

### DIFF
--- a/core/tests/run_tests.sh
+++ b/core/tests/run_tests.sh
@@ -1,8 +1,8 @@
 #!/usr/bin/env bash
 
 declare -a results
-declare -i passed=0 failed=0 exit_code=0
-declare COLOR_GREEN='\e[32m' COLOR_RED='\e[91m' COLOR_RESET='\e[39m'
+declare -i passed=0 failed=0 skipped=0 exit_code=0
+declare COLOR_GREEN='\e[32m' COLOR_RED='\e[91m' COLOR_YELLOW='\e[33m' COLOR_RESET='\e[39m'
 MICROPYTHON="${MICROPYTHON:-../build/unix/trezor-emu-core -X heapsize=2M}"
 export SDL_VIDEODRIVER=dummy
 
@@ -13,6 +13,7 @@ print_summary() {
     printf '%b\n' "${results[@]}"
     if [ $exit_code == 0 ]; then
         echo -e "${COLOR_GREEN}PASSED:${COLOR_RESET} $passed/$num_of_tests tests OK!"
+        echo -e "${COLOR_YELLOW}SKIPPED:${COLOR_RESET} $skipped/$num_of_tests tests skipped!"
     else
         echo -e "${COLOR_RED}FAILED:${COLOR_RESET} $failed/$num_of_tests tests failed!"
     fi
@@ -28,15 +29,25 @@ declare -i num_of_tests=${#tests[@]}
 
 export MICROPYPATH=.:../src  # for tests' imports to work as expected
 
-for test_case in ${tests[@]}; do
+for test_case in "${tests[@]}"; do
     echo
-    if $MICROPYTHON $test_case; then
+
+    output=$($MICROPYTHON "$test_case")
+    echo "$output"
+
+    # go through all lines that start with "RESULT:" and take the last one
+    result_line=$(grep -E '^RESULT:' <<< "$output" | tail -n1)
+
+    if [ "$result_line" = "RESULT:OK" ]; then
         results+=("${COLOR_GREEN}OK:${COLOR_RESET} $test_case")
         ((passed++))
-    else
+    elif [ "$result_line" = "RESULT:FAILED" ]; then
         results+=("${COLOR_RED}FAIL:${COLOR_RESET} $test_case")
         ((failed++))
         exit_code=1
+    else
+        results+=("${COLOR_YELLOW}SKIPPED:${COLOR_RESET} $test_case")
+        ((skipped++))
     fi
 done
 

--- a/core/tests/unittest.py
+++ b/core/tests/unittest.py
@@ -292,23 +292,31 @@ def main(module="__main__"):
             ):
                 yield c
 
-    m = __import__(module)
-    suite = TestSuite()
-    for c in test_cases(m):
-        suite.addTest(c)
-    runner = TestRunner()
-    result = runner.run(suite)
-    msg = f"Ran {result.testsRun} tests"
-    result_strs = []
-    if result.skippedNum > 0:
-        result_strs.append(f"{result.skippedNum} skipped")
-    if result.failuresNum > 0:
-        result_strs.append(f"{result.failuresNum} failed")
-    if result.errorsNum > 0:
-        result_strs.append(f"{result.errorsNum} errored")
-    if result_strs:
-        msg += " (" + ", ".join(result_strs) + ")"
-    print(msg)
+    wasSuccessful = False
+    try:
+        m = __import__(module)
+        suite = TestSuite()
+        for c in test_cases(m):
+            suite.addTest(c)
+        runner = TestRunner()
+        result = runner.run(suite)
+        msg = f"Ran {result.testsRun} tests"
+        result_strs = []
+        if result.skippedNum > 0:
+            result_strs.append(f"{result.skippedNum} skipped")
+        if result.failuresNum > 0:
+            result_strs.append(f"{result.failuresNum} failed")
+        if result.errorsNum > 0:
+            result_strs.append(f"{result.errorsNum} errored")
+        if result_strs:
+            msg += " (" + ", ".join(result_strs) + ")"
+        print(msg)
+        wasSuccessful = result.wasSuccessful()
+    except Exception as e:
+        print(f"{ERROR_COLOR}Unittest runner error:{DEFAULT_COLOR}", e)
+        sys.print_exception(e)
 
-    if not result.wasSuccessful():
-        raise SystemExit(1)
+    if wasSuccessful:
+        print("RESULT:OK")
+    else:
+        print("RESULT:FAILED")


### PR DESCRIPTION
Since https://github.com/trezor/trezor-firmware/pull/6094 was merged, coreapp is run as a task. Exit code from failed python unit test is not propagated to the `run_tests` shell script. 

This PR: The detection of failed tests was changed to rely on text output from the python test runner (looking for "RESULT:OK"/"RESULT: FAILED").

Note: the commit where the issue originates: https://github.com/trezor/trezor-firmware/pull/6094/changes/bfafbdd4068eef4b618a2f01617dc8f9e2a715b2