### PR TITLE
fix(core): propagate the exit code from the core app emulator

### DIFF
--- a/core/embed/sys/task/unix/systask.c
+++ b/core/embed/sys/task/unix/systask.c
@@ -169,19 +169,10 @@ static void* thread_trampoline(void* arg) {
   }
   pthread_mutex_unlock(&scheduler->lock);
 
-  invoke_pushed_fn_call(task);
+  int exit_code = (int)invoke_pushed_fn_call(task);
 
-  // Cooperative exit: pick someone else if possible
-  pthread_mutex_lock(&scheduler->lock);
-  task->killed = true;
+  systask_exit(task, exit_code);
 
-  // If we're still active, hand off to the kernel thread
-  if (scheduler->active_task == task) {
-    scheduler->active_task = &scheduler->kernel_task;
-    pthread_cond_signal(&scheduler->kernel_task.cv);
-  }
-
-  pthread_mutex_unlock(&scheduler->lock);
   return 0;
 }
 


### PR DESCRIPTION
This PR fixes propagation of the exit code from the coreapp emulator `main()` function.

Before this fix, the coreapp `main()` function return value was ignored. The only way to return a non-zero exit code was to explicitly call `system_exit()`.

This PR affect only the emulator.