### PR TITLE
fix(core/prodtest): exclude `backup-ram-erase` command from production prodtest

### DIFF
--- a/core/embed/projects/prodtest/cmd/prodtest_backup_ram.c
+++ b/core/embed/projects/prodtest/cmd/prodtest_backup_ram.c
@@ -187,14 +187,14 @@ PRODTEST_CLI_CMD(
    .args = ""
 );
 
+#if !PRODUCTION
+
 PRODTEST_CLI_CMD(
     .name = "backup-ram-erase",
     .func = prodtest_backup_ram_erase,
     .info = "Erase all backup RAM",
     .args = ""
 );
-
-#if !PRODUCTION
 
 PRODTEST_CLI_CMD(
    .name = "backup-ram-read",


### PR DESCRIPTION
Following 73684a2811101d2c5207fac96551e6ff27f3a6a3.

Otherwise, the reproducible build fails with:
```
$ PRODUCTION=1 TREZOR_MODEL=T3W1 QUIET_MODE=1 make -C core build_prodtest
make: Entering directory './core'
scons -Q -j 12 --quiet BENCHMARK="0" BITCOIN_ONLY="0" BOOTLOADER_DEVEL="0" BOOTLOADER_QA="0" UNSAFE_FW="0" CFLAGS="-DSCM_REVISION_INIT='{0x43,0xad,0xb9,0x3b,0x27,0xdb,0x79,0x96,0x37,0x55,0xdd,0x9f,0xaa,0xb1,0x6b,0xf7,0x59,0x9e,0x3d,0x38,}'" CMAKELISTS="0" HW_REVISION="" LOG_STACK_USAGE="0" MICROPY_ENABLE_SOURCE_LINE="" PRODUCTION="1" PYOPT="1" QUIET_MODE="1" SCM_REVISION="'43adb93b27db79963755dd9faab16bf7599e3d38'" STORAGE_INSECURE_TESTING_MODE="0" THP="1" TREZOR_DISABLE_ANIMATION="0" TREZOR_EMULATOR_ASAN="0" TREZOR_EMULATOR_DEBUGGABLE=0 TREZOR_MEMPERF="0" TREZOR_MODEL="T3W1" UI_PERFORMANCE_OVERLAY="0" BLOCK_ON_VCP="0" DBG_CONSOLE="" EXTAPP_SUPPORT="0" build/prodtest/prodtest.bin
In file included from embed/projects/prodtest/cmd/prodtest_backup_ram.c:25:
embed/projects/prodtest/cmd/prodtest_backup_ram.c:192:13: error: 'prodtest_backup_ram_erase' undeclared here (not in a function); did you mean 'prodtest_backup_ram_list'?
  192 |     .func = prodtest_backup_ram_erase,
      |             ^~~~~~~~~~~~~~~~~~~~~~~~~
embed/rtl/inc/rtl/cli.h:89:48: note: in definition of macro 'PRODTEST_CLI_CMD'
   89 |       CONCAT(_cli_cmd_handler, __COUNTER__) = {__VA_ARGS__};
      |                                                ^~~~~~~~~~~
scons: *** [build/prodtest/embed/projects/prodtest/cmd/prodtest_backup_ram.o] Error 1
make: *** [Makefile:320: build_prodtest] Error 2
make: Leaving directory './core'
```