### PR TITLE
build(core): add secmon to nightly Docker builds

### DIFF
--- a/.github/workflows/common.yml
+++ b/.github/workflows/common.yml
@@ -111,22 +111,43 @@ jobs:
       fail-fast: false
       matrix:
         model: [T1B1, T2T1, T2B1, T3B1, T3T1, T3W1]
+    env:
+      REF: ${{ github.head_ref || github.ref_name }}
     steps:
       - uses: actions/checkout@v4
         with:
           fetch-depth: 0
-      - run: git checkout ${{ github.head_ref || github.ref_name }}
-      - run: ./build-docker.sh --models ${{ matrix.model }} --targets bootloader,firmware,prodtest ${{ github.head_ref || github.ref_name }}
+
+      - run: git checkout ${REF}
+
+      - run: mkdir _fingerprints/
+
+      - name: Build prodtest & bootloader
+        run: |
+          ./build-docker.sh --models ${{ matrix.model }} --targets 'prodtest,bootloader' --skip-bitcoinonly ${REF}
+          cp -v --parents build/*/*/*.fingerprint _fingerprints/
+
+      - name: Build secmon
+        if: ${{ matrix.model == 'T3W1' }}
+        run: |
+          ./build-docker.sh --no-init --models ${{ matrix.model }} --targets 'secmon' --skip-bitcoinonly ${REF}
+          cp -v --parents build/*/*/*.fingerprint _fingerprints/
+
+      - name: Build firmware
+        # T3W1 requires a signed secmon.
+        run: |
+          ./build-docker.sh --no-init --models ${{ matrix.model }} --targets 'firmware' ${REF}
+          cp -v --parents build/*/*/*.fingerprint _fingerprints/
+
       - name: Show fingerprints
         run: |
-          for file in build/*/*/*.fingerprint; do
-            if [ -f "$file" ]; then
-              origfile="${file%.fingerprint}"
-              fingerprint=$(tr -d '\n' < $file)
-              echo "\`$fingerprint\` $origfile" >> $GITHUB_STEP_SUMMARY
-            fi
+          for file in _fingerprints/build/*/*/*.fingerprint
+          do
+            echo "\`$(tr -d '\n' < $file)\` ${file%.fingerprint}" >> $GITHUB_STEP_SUMMARY
           done
           cat $GITHUB_STEP_SUMMARY
+        if: always()
+
       - uses: actions/upload-artifact@v4
         with:
           name: reproducible-${{ matrix.model }}


### PR DESCRIPTION
Also, build firmware in a separate step (in case it fails - e.g. [due to a missing secmon](https://github.com/trezor/trezor-firmware/actions/runs/21491805106/job/61915995837#step:8:1))

Sample run: https://github.com/trezor/trezor-firmware/actions/runs/21491805106

<img width="1980" height="1047" alt="image" src="https://github.com/user-attachments/assets/48af5cf0-869d-4108-9b05-983a16faf13a" />

<img width="1935" height="1233" alt="image" src="https://github.com/user-attachments/assets/f62f9786-70ae-4246-9fdb-7a6080157b25" />

<img width="2988" height="1830" alt="image" src="https://github.com/user-attachments/assets/0207e305-862a-4f25-9a45-fccd9127195f" />
