### PR TITLE
Improve systask termination

### DIFF
--- a/core/embed/sys/task/unix/systask.c
+++ b/core/embed/sys/task/unix/systask.c
@@ -332,36 +332,41 @@ void systask_exit_fatal(systask_t* task, const char* message,
 
 void systask_print_pminfo(systask_t* task) {
 #ifdef USE_DBG_CONSOLE
-  dbg_printf("Task #%u terminated.\n", task->id);
-  dbg_printf("  Post-mortem info:\n");
 
   const systask_postmortem_t* pminfo = &task->pminfo;
 
+  if (pminfo->reason == TASK_TERM_REASON_EXIT && pminfo->exit.code == 0) {
+    dbg_printf("Task #%u terminated cleanly\n", task->id);
+    return;
+  }
+
+  dbg_printf("Task #%u terminated.\n", task->id);
+
   switch (pminfo->reason) {
     case TASK_TERM_REASON_EXIT:
-      dbg_printf("    EXIT: %d\n", pminfo->exit.code);
+      dbg_printf("Exit code: %d\n", pminfo->exit.code);
       break;
 
     case TASK_TERM_REASON_ERROR:
-      dbg_printf("    ERROR: %s\n", pminfo->error.message);
+      dbg_printf("Error: %s\n", pminfo->error.message);
       if (pminfo->error.title[0] != '\0') {
-        dbg_printf("      Title: %s\n", pminfo->error.title);
+        dbg_printf("Title: %s\n", pminfo->error.title);
       }
       if (pminfo->error.footer[0] != '\0') {
-        dbg_printf("      Footer: %s\n", pminfo->error.footer);
+        dbg_printf("Footer: %s\n", pminfo->error.footer);
       }
       break;
 
     case TASK_TERM_REASON_FATAL:
-      dbg_printf("    FATAL: %s\n", pminfo->fatal.expr);
+      dbg_printf("Fatal: %s", pminfo->fatal.expr);
       if (pminfo->fatal.file[0] != '\0') {
-        dbg_printf("      at %s:%u\n", pminfo->fatal.file,
-                   (unsigned int)pminfo->fatal.line);
+        dbg_printf(" at %s:%u", pminfo->fatal.file, pminfo->fatal.line);
       }
+      dbg_printf("\n");
       break;
 
     case TASK_TERM_REASON_FAULT:
-      dbg_printf("    FAULT\n");
+      dbg_printf("Fault\n");
       break;
   }
 #endif  // USE_DBG_CONSOLE


### PR DESCRIPTION
This PR improves task termination in the emulator:

1. Threads used for systask emulation are now terminated immediately when the systask terminates (via `system_exit()`, `system_error()`, `system_fatal()`, or when its main function exits).

2. Post-mortem output in the debug console is simplified. If the task terminates normally with exit_code = 0, only a single line is printed. Details are printed only when needed.

```
Task #1 terminated cleanly.
```

```
Task #1 terminated.
Exit code: 1
```

```
Task #1 terminated.
Error: SDL_Init error
```

```
Task #1 terminated.
Fatal: Assert at main.c:138
```

FYI: @M1nd3r 