### PR TITLE
binctl makefile target removal

### DIFF
--- a/core/Makefile
+++ b/core/Makefile
@@ -474,10 +474,6 @@ gdb_firmware: $(FIRMWARE_BUILD_DIR)/firmware.elf ## start remote gdb session to 
 
 ## misc commands:
 
-binctl: ## print info about binary files
-	./tools/headertool.py $(BOOTLOADER_BUILD_DIR)/bootloader.bin
-	./tools/headertool.py $(FIRMWARE_BUILD_DIR)/firmware.bin
-
 bloaty: ## run bloaty size profiler
 	bloaty -d symbols -n 0 -s file $(FIRMWARE_BUILD_DIR)/firmware.elf | less
 	bloaty -d compileunits -n 0 -s file $(FIRMWARE_BUILD_DIR)/firmware.elf | less


### PR DESCRIPTION
This PR removes an unused "binctl" Makefile target from "core/Makefile".

The "headertool.py" script location has changed to "core/tools/trezor_core_tools/". Moreover, the "headertool_pq.py" has been introduced for PQ crypto based headers e.g. TS7 bootloader.bin at the moment.

Removing the Makefile binctl target as it's not used and the fix with the automatic script (i.e. headertool vs headertool_pq) selection would be complicated.

<!--
For core developers:
- Assign yourself to the PR.
- Set the priority to match the original issue.
- Add the PR to the current sprint.
- If it's a draft PR, mark it as "In Progress."
- If it's a final PR, mark it as "Needs Review."
- If needed, add a `Notes for QA` section.

For external contributors:
- Please open an issue before submitting a PR so we can discuss whether we want to proceed with it.
-->
