### PR TITLE
ci: collect reproducible build artifacts

### DIFF
--- a/.github/workflows/common.yml
+++ b/.github/workflows/common.yml
@@ -120,28 +120,29 @@ jobs:
 
       - run: git checkout ${REF}
 
-      - run: mkdir _fingerprints/
+      - run: mkdir _artifacts/
 
       - name: Build prodtest & bootloader
         run: |
           ./build-docker.sh --models ${{ matrix.model }} --targets 'prodtest,bootloader' --skip-bitcoinonly ${REF}
-          cp -v --parents build/*/*/*.fingerprint _fingerprints/
+          cd build/ && cp -v --recursive --parents * ../_artifacts/
 
       - name: Build secmon
         if: ${{ matrix.model == 'T3W1' }}
         run: |
           ./build-docker.sh --no-init --models ${{ matrix.model }} --targets 'secmon' --skip-bitcoinonly ${REF}
-          cp -v --parents build/*/*/*.fingerprint _fingerprints/
+          cd build/ && cp -v --recursive --parents * ../_artifacts/
 
       - name: Build firmware
         # T3W1 requires a signed secmon.
         run: |
           ./build-docker.sh --no-init --models ${{ matrix.model }} --targets 'firmware' ${REF}
-          cp -v --parents build/*/*/*.fingerprint _fingerprints/
+          cd build/ && cp -v --recursive --parents * ../_artifacts/
 
       - name: Show fingerprints
         run: |
-          for file in _fingerprints/build/*/*/*.fingerprint
+          tree _artifacts
+          for file in _artifacts/*/*/*.fingerprint
           do
             echo "\`$(tr -d '\n' < $file)\` ${file%.fingerprint}" >> $GITHUB_STEP_SUMMARY
           done
@@ -152,5 +153,5 @@ jobs:
         with:
           name: reproducible-${{ matrix.model }}
           path: |
-            build/*/*/*.bin
+            _artifacts/
           retention-days: 7


### PR DESCRIPTION
Also, collect `*.elf`, `*.map` and `secmon_api.o` files.

Sample run: https://github.com/trezor/trezor-firmware/actions/runs/21521219308

* T3W1
<img width="3022" height="1431" alt="Screenshot from 2026-01-30 16-50-14" src="https://github.com/user-attachments/assets/1c47da4f-a866-40f0-acc1-2a9cab95784e" />

* T3T1
<img width="3022" height="1431" alt="Screenshot from 2026-01-30 16-49-54" src="https://github.com/user-attachments/assets/2cc8937a-53e8-48de-8196-16a630b81294" />

* T1B1
<img width="3022" height="1431" alt="Screenshot from 2026-01-30 16-52-59" src="https://github.com/user-attachments/assets/603375ad-10ed-4cef-b19a-24e25dc00f48" />


<!--
For core developers:
- Assign yourself to the PR.
- Set the priority to match the original issue.
- Add the PR to the current sprint.
- If it's a draft PR, mark it as "In Progress."
- If it's a final PR, mark it as "Needs Review."
- If needed, add a `Notes for QA` section.

For external contributors:
- Please open an issue before submitting a PR so we can discuss whether we want to proceed with it.
-->
