### PR TITLE
Fixing very slow sync when uploading test results to AWS S3

### DIFF
--- a/.github/actions/ui-report/action.yml
+++ b/.github/actions/ui-report/action.yml
@@ -53,12 +53,12 @@ runs:
         # Upload report
         du -sh ${{ github.run_id }}
         ls -l ${{ github.run_id }}
-        aws s3 cp --recursive --only-show-errors ${{ github.run_id }} s3://data.trezor.io/dev/firmware/ui_report/${{ github.run_id }} &
+        aws s3 cp --no-overwrite --recursive --only-show-errors ${{ github.run_id }} s3://data.trezor.io/dev/firmware/ui_report/${{ github.run_id }} &
         PID1=$!
 
         # Upload test screen recording
         du -sh ci/ui_test_records
-        aws s3 cp --recursive --only-show-errors ci/ui_test_records s3://data.trezor.io/dev/firmware/ui_tests &
+        aws s3 cp --no-overwrite --recursive --only-show-errors ci/ui_test_records s3://data.trezor.io/dev/firmware/ui_tests &
         PID2=$!
         # TODO: generate directory listing / autoindex
 


### PR DESCRIPTION
 - use copy instead of sync save around 4 minutes (of every job that runs uploads reports which is quite a few)
 - not sure about negative impacts of using copy instead of sync, but hopefully they are not too bad, because the improvement is substantial