### PR TITLE
fix(python): fix `trezorctl get-session` for legacy

### DIFF
--- a/python/src/trezorlib/cli/__init__.py
+++ b/python/src/trezorlib/cli/__init__.py
@@ -196,6 +196,7 @@ ENV_TREZOR_SESSION_ID = os.environ.get("TREZOR_SESSION_ID")
 class TrezorConnection:
     _client: TrezorClient | None = None
     _features: messages.Features | None = None
+    _version: tuple[int, int, int] | None = None
     _transport: Transport | None = None
     _standard_session: Session | None = None
 
@@ -312,6 +313,7 @@ class TrezorConnection:
         self._transport = None
         self._client = None
         self._features = None
+        self._version = None
         self._standard_session = None
 
     def _passphrase_source_resolved(self) -> PassphraseSource:


### PR DESCRIPTION
`TrezorConnection._version` wasn't set, so the command was failing with:
```
Traceback (most recent call last):
  File "./venv/bin/trezorctl", line 8, in <module>
    sys.exit(cli())
             ^^^^^
  File "./venv/lib/python3.12/site-packages/click/core.py", line 1161, in __call__
    return self.main(*args, **kwargs)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "./venv/lib/python3.12/site-packages/click/core.py", line 1082, in main
    rv = self.invoke(ctx)
         ^^^^^^^^^^^^^^^^
  File "/home/rzeyde/src/trezor-firmware/python/src/trezorlib/cli/trezorctl.py", line 161, in invoke
    return super().invoke(ctx)
           ^^^^^^^^^^^^^^^^^^^
  File "./venv/lib/python3.12/site-packages/click/core.py", line 1697, in invoke
    return _process_result(sub_ctx.command.invoke(sub_ctx))
                           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "./venv/lib/python3.12/site-packages/click/core.py", line 1443, in invoke
    return ctx.invoke(self.callback, **ctx.params)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "./venv/lib/python3.12/site-packages/click/core.py", line 788, in invoke
    return __callback(*args, **kwargs)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "./venv/lib/python3.12/site-packages/click/decorators.py", line 45, in new_func
    return f(get_current_context().obj, *args, **kwargs)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/rzeyde/src/trezor-firmware/python/src/trezorlib/cli/trezorctl.py", line 361, in get_session
    if obj.features.model == "1" and obj.version < (1, 9, 0):
                                     ^^^^^^^^^^^
  File "/home/rzeyde/src/trezor-firmware/python/src/trezorlib/cli/__init__.py", line 280, in version
    if self._version is None:
       ^^^^^^^^^^^^^
AttributeError: 'TrezorConnection' object has no attribute '_version'. Did you mean: 'version'?
```


<!--
For core developers:
- Assign yourself to the PR.
- Set the priority to match the original issue.
- Add the PR to the current sprint.
- If it's a draft PR, mark it as "In Progress."
- If it's a final PR, mark it as "Needs Review."
- If needed, add a `Notes for QA` section.

For external contributors:
- Please open an issue before submitting a PR so we can discuss whether we want to proceed with it.
-->
