### PR TITLE
chore(python): update `click` dependency versions

### DIFF
--- a/python/pyproject.toml
+++ b/python/pyproject.toml
@@ -24,7 +24,7 @@ dependencies = [
     "shamir-mnemonic>=0.3.0",
     "slip10>=1.0.1",
     "requests>=2.4.0",
-    "click>=8,<8.3",
+    "click>=8,<9",
     "libusb1>=1.6.4",
     "construct>=2.9,!=2.10.55",
     "typing_extensions>=4.7.1",

--- a/uv.lock
+++ b/uv.lock
@@ -2231,7 +2231,7 @@ dependencies = [
 requires-dist = [
     { name = "bleak", marker = "extra == 'ble'", specifier = ">=1.1.0" },
     { name = "bleak", marker = "extra == 'full'", specifier = ">=1.1.0" },
-    { name = "click", specifier = ">=8,<8.3" },
+    { name = "click", specifier = ">=8,<9" },
     { name = "construct", specifier = ">=2.9,!=2.10.55" },
     { name = "construct-classes", specifier = ">=0.1.2" },
     { name = "cryptography", specifier = ">=41" },


### PR DESCRIPTION
Allow all `8.x` click releases. 