### PR TITLE
prodtest crc adjustments

### DIFF
--- a/core/embed/projects/prodtest/README.md
+++ b/core/embed/projects/prodtest/README.md
@@ -323,6 +323,15 @@ crc-disable @939BC008
 OK
 ```
 
+### crc-status
+Returns the current CRC check status. Prints `OK 1` if CRC is enabled and `OK 0` if disabled.
+
+Example:
+```
+crc-status
+OK 1
+```
+
 ### display-bars
 Draws vertical color bars on the screen according to a specified string of color codes.
 

--- a/core/embed/projects/prodtest/cmd/prodtest_crc.c
+++ b/core/embed/projects/prodtest/cmd/prodtest_crc.c
@@ -39,6 +39,15 @@ static void prodtest_crc_disable(cli_t* cli) {
   cli_ok(cli, "");
 }
 
+static void prodtest_crc_status(cli_t* cli) {
+  if (cli_arg_count(cli) > 0) {
+    cli_error_arg_count(cli);
+    return;
+  }
+
+  cli_ok(cli, "%d", cli_crc_enabled(cli) ? 1 : 0);
+}
+
 // clang-format off
 
 PRODTEST_CLI_CMD(
@@ -51,4 +60,10 @@ PRODTEST_CLI_CMD(
   .name = "crc-disable",
   .func = prodtest_crc_disable,
   .info = "Disables CRC check",
+  .args = "");
+
+PRODTEST_CLI_CMD(
+  .name = "crc-status",
+  .func = prodtest_crc_status,
+  .info = "Returns CRC check status",
   .args = "");

--- a/core/embed/rtl/cli.c
+++ b/core/embed/rtl/cli.c
@@ -236,6 +236,8 @@ void cli_enable_crc(cli_t* cli) { cli->crc_auto = true; }
 
 void cli_disable_crc(cli_t* cli) { cli->crc_auto = false; }
 
+bool cli_crc_enabled(cli_t* cli) { return cli->crc_auto; }
+
 // Finds a command record by name
 //
 // Returns NULL if the command is not found

--- a/core/embed/rtl/inc/rtl/cli.h
+++ b/core/embed/rtl/inc/rtl/cli.h
@@ -269,3 +269,8 @@ void cli_enable_crc(cli_t* cli);
  * Disables CRC check for the CLI.
  */
 void cli_disable_crc(cli_t* cli);
+
+/**
+ * Returns true if CRC check is enabled.
+ */
+bool cli_crc_enabled(cli_t* cli);


### PR DESCRIPTION
This PR makes small adjustments in prodtest crc checks:
- space before crc value is excluded from its calculation
- new command to check crc enable/disable status is added