### PR TITLE
fix BLE busy after restart with BLE turned off

### DIFF
--- a/core/.changelog.d/6448.fixed
+++ b/core/.changelog.d/6448.fixed
@@ -1,0 +1,1 @@
+Fix 'Connected Trezor is used by another application' bug.

--- a/core/src/ble.py
+++ b/core/src/ble.py
@@ -10,8 +10,8 @@ from trezor import log, utils
 try:
     enable = storage.device.get_ble()
     ble.set_enabled(enable)
+    ble.start_comm()
     if enable:
-        ble.start_comm()
 
         start_ms = utime.ticks_ms()
 


### PR DESCRIPTION
This PR fixes a bug that prevents BLE communication if Trezor is rebooted while BLE is turned off. 

This was caused by not calling ble_start after enabling it from menu. The function is now called unconditionally after boot. It is kinda redundant to ble_enable so no need to call both, original intention was to allow 'pauses' on the BLE interface, but that is unused for now. We may want to rething the existence of this API but for now a quick fix.