### PR TITLE
refactor(core): support `ICON_DOWN` for `confirm_with_info()` in Caesar

### DIFF
--- a/core/embed/rust/src/ui/layout_caesar/component/button.rs
+++ b/core/embed/rust/src/ui/layout_caesar/component/button.rs
@@ -397,6 +397,8 @@ impl ButtonDetails {
             "" => Self::cancel_icon(),
             "<" => Self::left_arrow_icon(),
             "^" => Self::up_arrow_icon(),
+            "V" => Self::down_arrow_icon(),
+            "i" => Self::info_icon(),
             _ => Self::text(text),
         })
     }
@@ -409,6 +411,13 @@ impl ButtonDetails {
     /// Cross-style-icon cancel button with no outline.
     pub fn cancel_icon() -> Self {
         Self::icon(theme::ICON_CANCEL).with_offset(Offset::new(3, -3))
+    }
+
+    /// Info icon with an outline.
+    pub fn info_icon() -> Self {
+        Self::text("i".into())
+            .with_fixed_width(theme::BUTTON_ICON_WIDTH)
+            .with_font(fonts::FONT_NORMAL)
     }
 
     /// Left arrow to signal going back. No outline.
@@ -425,6 +434,12 @@ impl ButtonDetails {
     /// to not be on the boundary.
     pub fn up_arrow_icon() -> Self {
         Self::icon(theme::ICON_ARROW_UP).with_offset(Offset::new(3, -4))
+    }
+
+    /// Down arrow to signal paginating forward. No outline. Offsetted little
+    /// right to not be on the boundary.
+    pub fn down_arrow_icon() -> Self {
+        Self::icon(theme::ICON_ARROW_DOWN).with_offset(Offset::new(-3, -4))
     }
 
     /// Down arrow to signal paginating forward. Takes half the screen's width
@@ -558,24 +573,38 @@ impl ButtonLayout {
         Self::new(
             Some(ButtonDetails::from_text_possible_icon(left)),
             Some(ButtonDetails::armed_text(middle)),
-            Some(
-                ButtonDetails::text("i".into())
-                    .with_fixed_width(theme::BUTTON_ICON_WIDTH)
-                    .with_font(fonts::FONT_NORMAL),
-            ),
+            Some(ButtonDetails::info_icon()),
         )
     }
 
-    /// Left cancel, armed text and right info icon/text.
+    /// Left text, armed text and right info text.
+    pub fn text_armed_text(
+        left: TString<'static>,
+        middle: TString<'static>,
+        right: TString<'static>,
+    ) -> Self {
+        Self::new(
+            Some(ButtonDetails::from_text_possible_icon(left)),
+            Some(ButtonDetails::armed_text(middle)),
+            Some(ButtonDetails::from_text_possible_icon(right)),
+        )
+    }
+
+    /// Left cancel, armed text and right info icon.
     pub fn cancel_armed_info(middle: TString<'static>) -> Self {
         Self::new(
             Some(ButtonDetails::cancel_icon()),
             Some(ButtonDetails::armed_text(middle)),
-            Some(
-                ButtonDetails::text("i".into())
-                    .with_fixed_width(theme::BUTTON_ICON_WIDTH)
-                    .with_font(fonts::FONT_NORMAL),
-            ),
+            Some(ButtonDetails::info_icon()),
+        )
+    }
+
+    /// Left cancel, armed text and right info icon/text.
+    pub fn cancel_armed_text(middle: TString<'static>, right: TString<'static>) -> Self {
+        Self::new(
+            Some(ButtonDetails::cancel_icon()),
+            Some(ButtonDetails::armed_text(middle)),
+            Some(ButtonDetails::from_text_possible_icon(right)),
         )
     }
 
@@ -692,11 +721,7 @@ impl ButtonLayout {
         Self::new(
             Some(ButtonDetails::up_arrow_icon()),
             Some(ButtonDetails::armed_text(text)),
-            Some(
-                ButtonDetails::text("i".into())
-                    .with_fixed_width(theme::BUTTON_ICON_WIDTH)
-                    .with_font(fonts::FONT_NORMAL),
-            ),
+            Some(ButtonDetails::info_icon()),
         )
     }
 

--- a/core/embed/rust/src/ui/layout_caesar/component/mod.rs
+++ b/core/embed/rust/src/ui/layout_caesar/component/mod.rs
@@ -8,7 +8,7 @@ mod loader;
 mod result;
 mod welcome_screen;
 
-use super::{common_messages, constant, fonts, theme};
+use super::{common_messages, constant, theme};
 pub use button::{
     Button, ButtonAction, ButtonActions, ButtonContent, ButtonDetails, ButtonLayout, ButtonPos,
     ButtonStyle, ButtonStyleSheet,

--- a/core/embed/rust/src/ui/layout_caesar/component/page.rs
+++ b/core/embed/rust/src/ui/layout_caesar/component/page.rs
@@ -10,8 +10,7 @@ use crate::{
 };
 
 use super::{
-    constant, fonts, theme, ButtonController, ButtonControllerMsg, ButtonDetails, ButtonLayout,
-    ButtonPos,
+    constant, theme, ButtonController, ButtonControllerMsg, ButtonDetails, ButtonLayout, ButtonPos,
 };
 
 pub struct ButtonPage<T>
@@ -114,11 +113,7 @@ where
             (false, false) => (None, self.confirm_btn_details.clone()),
             (false, true) => (
                 self.confirm_btn_details.clone().map(|b| b.with_arms()),
-                Some(
-                    ButtonDetails::text("i".into())
-                        .with_fixed_width(theme::BUTTON_ICON_WIDTH)
-                        .with_font(fonts::FONT_NORMAL),
-                ),
+                Some(ButtonDetails::info_icon()),
             ),
         };
         ButtonLayout::new(btn_left, btn_middle, btn_right)

--- a/core/embed/rust/src/ui/layout_caesar/component/show_more.rs
+++ b/core/embed/rust/src/ui/layout_caesar/component/show_more.rs
@@ -30,11 +30,12 @@ where
         content: T,
         cancel_button: Option<TString<'static>>,
         button: TString<'static>,
+        verb_info: TString<'static>,
     ) -> Self {
         let btn_layout = if let Some(cancel_text) = cancel_button {
-            ButtonLayout::text_armed_info(cancel_text, button)
+            ButtonLayout::text_armed_text(cancel_text, button, verb_info)
         } else {
-            ButtonLayout::cancel_armed_info(button)
+            ButtonLayout::cancel_armed_text(button, verb_info)
         };
         Self {
             content: Child::new(content),

--- a/core/embed/rust/src/ui/layout_caesar/ui_firmware.rs
+++ b/core/embed/rust/src/ui/layout_caesar/ui_firmware.rs
@@ -515,11 +515,7 @@ impl FirmwareUI for UICaesar {
             // if there are no info pages, the right button is not needed
             // if verb_cancel is "^", the left button is an arrow pointing up
             let left_btn = Some(ButtonDetails::from_text_possible_icon(verb_cancel));
-            let right_btn = (has_pages_after || external_menu).then(|| {
-                ButtonDetails::text("i".into())
-                    .with_fixed_width(theme::BUTTON_ICON_WIDTH)
-                    .with_font(fonts::FONT_NORMAL)
-            });
+            let right_btn = (has_pages_after || external_menu).then(ButtonDetails::info_icon);
             let middle_btn = Some(ButtonDetails::armed_text(TR::buttons__confirm.into()));
 
             (
@@ -627,7 +623,7 @@ impl FirmwareUI for UICaesar {
         _subtitle: Option<TString<'static>>,
         items: Obj,
         verb: TString<'static>,
-        _verb_info: TString<'static>,
+        verb_info: TString<'static>,
         verb_cancel: Option<TString<'static>>,
         external_menu: bool,
     ) -> Result<impl LayoutMaybeTrace, Error> {
@@ -654,6 +650,7 @@ impl FirmwareUI for UICaesar {
                 paragraphs.into_paragraphs(),
                 verb_cancel,
                 verb,
+                verb_info,
             )
             .with_menu(external_menu),
         ));

--- a/core/src/trezor/ui/layouts/caesar/__init__.py
+++ b/core/src/trezor/ui/layouts/caesar/__init__.py
@@ -23,6 +23,7 @@ CANCELLED = trezorui_api.CANCELLED
 INFO = trezorui_api.INFO
 
 DOWN_ARROW = "V"
+INFO_ICON = "i"
 BR_CODE_OTHER = ButtonRequestType.Other  # global_import_cache
 
 
@@ -605,7 +606,7 @@ async def confirm_payment_request(
             title=title,
             items=[(TR.words__provider, True), (recipient_name, False)],
             verb=TR.buttons__continue,
-            verb_info=TR.buttons__info,
+            verb_info=INFO_ICON,
             external_menu=True,
         )
 
@@ -721,13 +722,15 @@ async def should_show_more(
     Raises ActionCancelled if the user cancels.
     """
 
+    if button_text != DOWN_ARROW:
+        button_text = INFO_ICON
     result = await interact(
         trezorui_api.confirm_with_info(
             title=title,
             items=para,
             verb=confirm or TR.buttons__confirm,
             verb_cancel=verb_cancel,
-            verb_info=button_text or TR.buttons__show_all,  # unused on caesar
+            verb_info=button_text,  # use info icon by default
         ),
         br_name,
         br_code,
@@ -967,7 +970,7 @@ def confirm_value(
         title=title,
         items=((value, False),),
         verb=verb or TR.buttons__confirm,
-        verb_info=TR.buttons__info,
+        verb_info=INFO_ICON,
         external_menu=True,
     )
 


### PR DESCRIPTION
Also, simplify info-related button creation.
