### PR TITLE
chore(python): update uv.lock after `trezorlib` release

### DIFF
--- a/uv.lock
+++ b/uv.lock
@@ -2208,7 +2208,7 @@ wheels = [
 
 [[package]]
 name = "trezor"
-version = "0.20.0"
+version = "0.20.1"
 source = { editable = "python" }
 dependencies = [
     { name = "click" },


### PR DESCRIPTION
Maybe we should add a CI job to make sure it stays synced?

Currently, it is tested in `common.yml` nightly run, e.g.: https://github.com/trezor/trezor-firmware/actions/runs/21927106848/job/63322258087

<!--
For core developers:
- Assign yourself to the PR.
- Set the priority to match the original issue.
- Add the PR to the current sprint.
- If it's a draft PR, mark it as "In Progress."
- If it's a final PR, mark it as "Needs Review."
- If needed, add a `Notes for QA` section.

For external contributors:
- Please open an issue before submitting a PR so we can discuss whether we want to proceed with it.
-->
