### PR TITLE
refactor(core): rename "skip" flag for non-idempotent menu items

### DIFF
--- a/core/embed/rust/src/ui/layout_delizia/component/button.rs
+++ b/core/embed/rust/src/ui/layout_delizia/component/button.rs
@@ -34,7 +34,7 @@ pub struct Button {
     long_timer: Timer,
     haptic: bool,
     #[cfg(feature = "ui_debug")]
-    is_cancel: bool, // used by debuglink
+    skip_test_visit: bool, // used by debuglink
 }
 
 impl Button {
@@ -56,7 +56,7 @@ impl Button {
             long_timer: Timer::new(),
             haptic: true,
             #[cfg(feature = "ui_debug")]
-            is_cancel: false,
+            skip_test_visit: false,
         }
     }
 
@@ -109,7 +109,7 @@ impl Button {
 
     #[cfg(feature = "ui_debug")]
     pub fn set_is_cancel(mut self) -> Self {
-        self.is_cancel = true;
+        self.skip_test_visit = true;
         self
     }
 
@@ -376,7 +376,7 @@ impl Component for Button {
 impl crate::trace::Trace for Button {
     fn trace(&self, t: &mut dyn crate::trace::Tracer) {
         t.component("Button");
-        t.bool("is_cancel", self.is_cancel);
+        t.bool("skip_test_visit", self.skip_test_visit);
         match &self.content {
             ButtonContent::Empty => {}
             ButtonContent::Text(text) => t.string("text", *text),

--- a/core/embed/rust/src/ui/layout_eckhart/component/button.rs
+++ b/core/embed/rust/src/ui/layout_eckhart/component/button.rs
@@ -47,7 +47,7 @@ pub struct Button {
     haptic: bool,
     subtext_marquee: Option<Marquee>,
     #[cfg(feature = "ui_debug")]
-    is_cancel: bool, // used by debuglink
+    skip_test_visit: bool, // used by debuglink
 }
 
 impl Button {
@@ -90,7 +90,7 @@ impl Button {
             haptic: true,
             subtext_marquee,
             #[cfg(feature = "ui_debug")]
-            is_cancel: false,
+            skip_test_visit: false,
         }
     }
 
@@ -280,7 +280,7 @@ impl Button {
 
     #[cfg(feature = "ui_debug")]
     pub fn set_is_cancel(mut self) -> Self {
-        self.is_cancel = true;
+        self.skip_test_visit = true;
         self
     }
 
@@ -808,7 +808,7 @@ impl Component for Button {
 impl crate::trace::Trace for Button {
     fn trace(&self, t: &mut dyn crate::trace::Tracer) {
         t.component("Button");
-        t.bool("is_cancel", self.is_cancel);
+        t.bool("skip_test_visit", self.skip_test_visit);
         match &self.content {
             ButtonContent::Empty => {}
             ButtonContent::Text { text, .. } => t.string("text", *text),

--- a/python/src/trezorlib/debuglink.py
+++ b/python/src/trezorlib/debuglink.py
@@ -1032,8 +1032,8 @@ class DebugUI:
             key="buttons", default=None, only_type=list
         )
         for menu_button, item_button in zip(menu_buttons, item_buttons):
-            if menu_button.get("is_cancel"):
-                continue  # don't click cancel
+            if menu_button.get("skip_test_visit"):
+                continue  # visit only idempotent entries (e.g. for showing more information)
             self.debuglink.click(item_button)
             self.debuglink.click(close_button)
 


### PR DESCRIPTION
We would like to add menu-based actions (in addition to cancel), so this PR will allow the tests to skip them via the default debuglink-based visitor. 