### PR TITLE
feat: Add tropic-capable emulator builds as subcategory in release wo…

### DIFF
--- a/.github/workflows/release-emu.yml
+++ b/.github/workflows/release-emu.yml
@@ -23,6 +23,11 @@ on:
         type: string
         required: true
         default: "[\"T2B1\",\"T2T1\",\"T3B1\",\"T3T1\"]"
+      tropic_models:
+        description: tropic-capable models as a JSON list
+        type: string
+        required: false
+        default: "[\"T3W1\"]"
 
 permissions:
   id-token: write       # for fetching the OIDC token
@@ -34,6 +39,7 @@ jobs:
     runs-on: ubuntu-latest
     outputs:
       models: ${{ steps.get_models.outputs.models }}
+      tropic_models: ${{ steps.get_models.outputs.tropic_models }}
       version: ${{ steps.get_models.outputs.version }}
     steps:
       - uses: actions/checkout@v4
@@ -46,11 +52,17 @@ jobs:
           elif [[ $GITHUB_REF == refs/tags/legacy/* ]]; then
             VERSION=${GITHUB_REF#refs/tags/legacy/v}
             MODELS=$(jq -cr --arg version "$VERSION" '.firmware[$version]' ./common/releases.json)
+            TROPIC_MODELS='[]'
           else
             VERSION="${{ inputs.version }}"
             MODELS='${{ inputs.models_json }}'
+            TROPIC_MODELS='${{ inputs.tropic_models }}'
+          fi
+          if [[ -z "$TROPIC_MODELS" ]]; then
+            TROPIC_MODELS='["T3W1"]'
           fi
           echo "models=$MODELS" >> $GITHUB_OUTPUT
+          echo "tropic_models=$TROPIC_MODELS" >> $GITHUB_OUTPUT
           echo "version=$VERSION" >> $GITHUB_OUTPUT
           cat $GITHUB_OUTPUT
 
@@ -149,6 +161,108 @@ jobs:
       - uses: actions/upload-artifact@v4
         with:
           name: core-emu-arm-${{ matrix.model }}-${{ matrix.coins }}-${{ matrix.type }}-${{ matrix.asan }}
+          path: |
+            core/build/unix/trezor-emu-core*
+            core/build/bootloader_emu/bootloader.elf
+          retention-days: 7
+
+  core_emu_tropic_capable:
+    if: startsWith(github.ref, 'refs/tags/core/v') || inputs.project == 'core'
+    name: Build emu (tropic capable)
+    needs: get_models
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        model: ${{ fromJson(needs.get_models.outputs.tropic_models) }}
+        coins: [universal]
+        type: [debuglink]
+        asan: [noasan]
+        exclude:
+          - type: normal
+            asan: asan
+    env:
+      TREZOR_MODEL: ${{ matrix.model }}
+      BITCOIN_ONLY: ${{ matrix.coins == 'universal' && '0' || '1' }}
+      PYOPT: ${{ matrix.type == 'debuglink' && '0' || '1' }}
+      ADDRESS_SANITIZER: "0"
+      LSAN_OPTIONS: "suppressions=../../asan_suppressions.txt"
+      DISABLE_TROPIC: "0"
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          submodules: recursive
+      - uses: ./.github/actions/environment
+      - run: nix-shell --run "uv run make -C core build_bootloader_emu"
+        if: matrix.coins == 'universal'
+      - run: nix-shell --run "uv run make -C core build_unix_frozen"
+      - run: cp core/build/unix/trezor-emu-core core/build/unix/trezor-emu-core-${{ matrix.model }}-v${{ needs.get_models.outputs.version }}
+
+      - name: Configure aws credentials
+        uses: aws-actions/configure-aws-credentials@v4
+        with:
+          role-to-assume: arn:aws:iam::538326561891:role/gh_actions_deploy_dev_firmware_data
+          aws-region: eu-west-1
+        continue-on-error: true
+
+      - name: Upload emulator binaries
+        run: |
+            aws s3 mv core/build/unix/trezor-emu-core-${{ matrix.model }}-v${{ needs.get_models.outputs.version }} s3://data.trezor.io/dev/firmware/releases/emulators-new/${{ matrix.model}}/${{ matrix.model }}_tropic_on/
+
+      - uses: actions/upload-artifact@v4
+        with:
+          name: core-emu-tropic-capable-${{ matrix.model }}-${{ matrix.coins }}-${{ matrix.type }}-${{ matrix.asan }}
+          path: |
+            core/build/unix/trezor-emu-core*
+            core/build/bootloader_emu/bootloader.elf
+          retention-days: 7
+
+  core_emu_arm_tropic_capable:
+    if: startsWith(github.ref, 'refs/tags/core/v') || inputs.project == 'core'
+    name: Build core emu arm (tropic capable)
+    needs: get_models
+    runs-on: ubuntu-latest-arm64
+    strategy:
+      fail-fast: false
+      matrix:
+        model: ${{ fromJson(needs.get_models.outputs.tropic_models) }}
+        coins: [universal]
+        type: [debuglink]
+        asan: [noasan]
+        exclude:
+          - type: normal
+            asan: asan
+    env:
+      TREZOR_MODEL: ${{ matrix.model }}
+      BITCOIN_ONLY: ${{ matrix.coins == 'universal' && '0' || '1' }}
+      PYOPT: ${{ matrix.type == 'debuglink' && '0' || '1' }}
+      ADDRESS_SANITIZER: ${{ matrix.asan == 'asan' && '1' || '0' }}
+      LSAN_OPTIONS: "suppressions=../../asan_suppressions.txt"
+      DISABLE_TROPIC: "0"
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          submodules: recursive
+      - uses: ./.github/actions/environment
+      - run: nix-shell --run "uv run make -C core build_bootloader_emu"
+        if: matrix.coins == 'universal'
+      - run: nix-shell --run "uv run make -C core build_unix_frozen"
+      - run: mv core/build/unix/trezor-emu-core core/build/unix/trezor-emu-core-${{ matrix.model }}-v${{ needs.get_models.outputs.version }}-arm
+
+      - name: Configure aws credentials
+        uses: aws-actions/configure-aws-credentials@v4
+        with:
+          role-to-assume: arn:aws:iam::538326561891:role/gh_actions_deploy_dev_firmware_data
+          aws-region: eu-west-1
+        continue-on-error: true
+
+      - name: Upload emulator binaries
+        run: |
+            aws s3 cp core/build/unix/trezor-emu-core-${{ matrix.model }}-v${{ needs.get_models.outputs.version }}-arm s3://data.trezor.io/dev/firmware/releases/emulators-new/${{ matrix.model}}/${{ matrix.model }}_tropic_on/
+
+      - uses: actions/upload-artifact@v4
+        with:
+          name: core-emu-arm-tropic-capable-${{ matrix.model }}-${{ matrix.coins }}-${{ matrix.type }}-${{ matrix.asan }}
           path: |
             core/build/unix/trezor-emu-core*
             core/build/bootloader_emu/bootloader.elf


### PR DESCRIPTION


<!--
For external contributors:
- Please open an issue before submitting a PR so we can discuss whether we want to proceed with it.

For core developers:
1. Initial PR setup
- Assign yourself to the PR.
- Add it to the "Firmware" project
  - Set Priority (match issue priority if it exists)
  - Set Team
  - Set Sprint (target release)

2. Development status
- Draft PRs: Set status to "In Progress"
- Final PRs: Set status to "Needs Review"

3. Post-merge status
- Testable: Set status to "Needs QA" and add a `Notes for QA` section with clear instructions on how to test the functionality.
- Not Testable: Set status to "Done (no QA)"
-->

- Add tropic_models input to workflow_dispatch for model selection
- Expand get_models job to output tropic_models (defaults to T3W1)
- Add core_emu_tropic_capable job (x86) building with DISABLE_TROPIC=0
- Add core_emu_arm_tropic_capable job (arm64) building with DISABLE_TROPIC=0
- Tropic emulators uploaded to separate subdirectory (/{model}/{model}_tropic_on/)
- New emulators keep standard naming for consistency
- Tropic model list centralized for easy maintenance and configuration