### PR TITLE
fix(core/thp): disable THP ACK piggybacking as a workaround for #6506

### DIFF
--- a/core/.changelog.d/6202.added
+++ b/core/.changelog.d/6202.added
@@ -1,1 +1,0 @@
-Support receive-side THP ACK piggybacking.

--- a/core/src/trezor/wire/thp/__init__.py
+++ b/core/src/trezor/wire/thp/__init__.py
@@ -210,7 +210,8 @@ def _get_device_properties(iface: WireInterface) -> ThpDeviceProperties:
         internal_model=utils.INTERNAL_MODEL,
         model_variant=model_variant,
         protocol_version_major=2,
-        protocol_version_minor=1,
+        # TODO: re-enable THP ACK piggybacking after #6506 is fixed
+        protocol_version_minor=0,
     )
 
 

--- a/core/src/trezor/wire/thp/received_message_handler.py
+++ b/core/src/trezor/wire/thp/received_message_handler.py
@@ -106,10 +106,11 @@ async def _handle_state_handshake(
     def _handshake_callback(ctrl_byte: int) -> bool:
         success = control_byte.is_handshake_init_req(ctrl_byte)
 
-        if success and control_byte.get_ack_bit(ctrl_byte) == 1:
-            # Newer Suite versions will send `handshake_init_req` with a non-zero ACK bit.
-            # The device should not use ACK piggybacking with older Suite versions.
-            ABP.allow_ack_piggybacking(ctx.channel_cache)
+        # TODO: re-enable THP ACK piggybacking after #6506 is fixed
+        # if success and control_byte.get_ack_bit(ctrl_byte) == 1:
+        #     # Newer Suite versions will send `handshake_init_req` with a non-zero ACK bit.
+        #     # The device should not use ACK piggybacking with older Suite versions.
+        #     ABP.allow_ack_piggybacking(ctx.channel_cache)
 
         if __debug__:
             ctx._log(


### PR DESCRIPTION
The underlying bug (#6506) can also happen without THP ACK piggybacking but with much lower probability (it requires >200ms THP ACK delay over USB).

## Notes to QA:
- please make sure basic functionality works over THP over USB/BLE with trezorctl & Suite.
