### PR TITLE
ci(core): increase pytest timeout for T3W1 device tests

### DIFF
--- a/.github/workflows/core.yml
+++ b/.github/workflows/core.yml
@@ -288,8 +288,8 @@ jobs:
       PYTEST_TIMEOUT: ${{ matrix.asan == 'asan' && 600 || 400 }}
       ACTIONS_DO_UI_TEST: ${{ matrix.coins == 'universal' && matrix.asan == 'noasan' }}
       TEST_LANG: ${{ matrix.lang }}
-      TESTOPTS: "--durations 10 --session-timeout 1800"  # 30m pytest global timeout
-    timeout-minutes: 40
+      TESTOPTS: "--durations 10 --session-timeout ${{ matrix.model == 'T3W1' && '2400' || '1800' }}"  # pytest global timeout
+    timeout-minutes: 50  # CI job timeout
     steps:
       - uses: actions/checkout@v4
         with:


### PR DESCRIPTION
Sometimes `Device tests (T3W1, universal, noasan, en)` job take >30m.

<img width="1641" height="1227" alt="image" src="https://github.com/user-attachments/assets/19e31fbe-2887-4acb-af0f-ba705bb94d8a" />
