### PR TITLE
ci(core): avoid running `core_ui_comment` job for other repositories

### DIFF
--- a/.github/workflows/core.yml
+++ b/.github/workflows/core.yml
@@ -690,8 +690,8 @@ jobs:
 
   core_ui_comment:
     name: Post comment with UI diff URLs
-    # skip UI comment job on external PRs (see #5381)
-    if: github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository
+    # run UI comment job only for 'trezor/trezor-firmware' scheduled workflows and internal PRs (see #5381)
+    if: (github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository) && github.repository == 'trezor/trezor-firmware'
     runs-on: ubuntu-latest
     needs:
       - param


### PR DESCRIPTION
Otherwise, it fails on `aws-actions/configure-aws-credentials`.

<img width="962" height="428" alt="image" src="https://github.com/user-attachments/assets/529ad75c-1163-4899-a3a1-970681814414" />
