### PR TITLE
ci: auto-assign PR to its author

### DIFF
--- a/.github/workflows/bot-auto-assign.yml
+++ b/.github/workflows/bot-auto-assign.yml
@@ -1,0 +1,37 @@
+name: "[Bot] auto-assign PR author"
+
+on:
+  pull_request:
+    types: [opened]
+
+permissions:
+  pull-requests: write
+
+jobs:
+  auto-assign:
+    # run only in 'trezor/trezor-firmware' repository
+    if: github.repository == 'trezor/trezor-firmware'
+    runs-on: ubuntu-latest
+    steps:
+      - name: Assign PR author to PR
+        uses: actions/github-script@v8
+        with:
+          script: |
+            const author = context.payload.pull_request.user.login;
+
+            try {
+                const response = await github.rest.issues.addAssignees({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                issue_number: context.issue.number,
+                assignees: [author]
+                });
+                const isAssigned = (response.data.assignees || []).some(
+                    a => a.login === author
+                );
+                if (!isAssigned) {
+                    core.info(`Could not assign ${author} (not assignable in this repo). Skipping.`);
+                }
+            } catch (e) {
+                core.setFailed(`Failed to assign ${author}: ${e.status ?? "unknown"} ${e.message}`);
+            }


### PR DESCRIPTION
This PR adds an action that auto-assigns opened PR to its author.

This implementation uses  `actions/github-script@v8`. 

Alternatively, we could use [Auto Assign Action](https://github.com/marketplace/actions/auto-assign-action) that was developed by [kentaro-m](https://github.com/kentaro-m). I have opted for not adding a new dependency - even though the repository exist for more than 7 years and seems to be actively maintained.