### PR TITLE
fix(core/thp): correct `Failure_InvalidProtocol` constant message

### DIFF
--- a/core/src/trezor/wire/thp/interface_context.py
+++ b/core/src/trezor/wire/thp/interface_context.py
@@ -172,7 +172,7 @@ class InterfaceContext:
             response = bytearray(self._iface.TX_PACKET_LEN)
             # Codec_v1 magic constant:
             # "?##" + Failure message type + msg_size + msg_data (code = "Failure_InvalidProtocol")
-            utils.memcpy(response, 0, b"?##\x00\x03\x00\x00\x00\x14\x08\x11", 0)
+            utils.memcpy(response, 0, b"?##\x00\x03\x00\x00\x00\x02\x08\x11", 0)
             await self._write_packets([response])
 
     async def _handle_broadcast(self, packet: AnyBytes) -> None:

--- a/tests/device_tests/thp/test_basic.py
+++ b/tests/device_tests/thp/test_basic.py
@@ -24,8 +24,11 @@ def test_v1(client: Client):
     # There should be a failure response to received init packet (starts with "?##")
     write_padded(client.transport, b"?## Init packet")
     res_id, res_data = protocol_v1.read(client.transport)
+    expected = messages.Failure(code=messages.FailureType.InvalidProtocol)
     res = DEFAULT_MAPPING.decode(res_id, res_data)
-    assert res == messages.Failure(code=messages.FailureType.InvalidProtocol)
+    assert res == expected
+    # make sure the constant "InvalidProtocol" response doesn't have trailing bytes (#6549)
+    assert (res_id, res_data) == DEFAULT_MAPPING.encode(expected)
 
     # There should be no response for continuation packet (starts with "?" only)
     write_padded(client.transport, b"? Cont packet")


### PR DESCRIPTION
Otherwise, the host will receive `b'\x08\x11' + b'\x00'*18`.
The trailing bytes are skipped by trezorlib, since our Python protobuf parser ignores unknown fields:
https://github.com/trezor/trezor-firmware/blob/53ac49c2f79f4bcb1e32c38d1c109032f710c56a/python/src/trezorlib/protobuf.py#L443-L453



<!--
For external contributors:
- Please open an issue before submitting a PR so we can discuss whether we want to proceed with it.

For core developers:
1. Initial PR setup
- Assign yourself to the PR.
- Add it to the "Firmware" project
  - Set Priority (match issue priority if it exists)
  - Set Team
  - Set Sprint (target release)

2. Development status
- Draft PRs: Set status to "In Progress"
- Final PRs: Set status to "Needs Review"

3. Post-merge status
- Testable: Set status to "Needs QA" and add a `Notes for QA` section with clear instructions on how to test the functionality.
- Not Testable: Set status to "Done (no QA)"
-->
