### PR TITLE
fix(eckhart): improve haptics in scrollable menu

### DIFF
--- a/core/embed/rust/src/ui/layout_eckhart/component/button.rs
+++ b/core/embed/rust/src/ui/layout_eckhart/component/button.rs
@@ -32,6 +32,16 @@ enum RadiusOrGradient {
     None,
 }
 
+#[derive(Clone, Copy)]
+pub enum HapticMode {
+    /// Vibrate on TouchStart (default)
+    OnPress,
+    /// Vibrate only on confirmed click
+    OnClick,
+    /// No haptic feedback
+    Off,
+}
+
 pub struct Button {
     area: Rect,
     touch_expand: Insets,
@@ -44,7 +54,7 @@ pub struct Button {
     long_press: ShortDuration, // long press requires non-zero duration
     long_press_danger: bool,
     long_timer: Timer,
-    haptic: bool,
+    haptic: HapticMode,
     subtext_marquee: Option<Marquee>,
     #[cfg(feature = "ui_debug")]
     skip_test_visit: bool, // used by debuglink
@@ -87,7 +97,7 @@ impl Button {
             long_press: ShortDuration::ZERO,
             long_press_danger: false,
             long_timer: Timer::new(),
-            haptic: true,
+            haptic: HapticMode::OnPress,
             subtext_marquee,
             #[cfg(feature = "ui_debug")]
             skip_test_visit: false,
@@ -261,11 +271,6 @@ impl Button {
 
     pub fn with_radius(mut self, radius: u8) -> Self {
         self.radius_or_gradient = RadiusOrGradient::Radius(radius);
-        self
-    }
-
-    pub fn without_haptics(mut self) -> Self {
-        self.haptic = false;
         self
     }
 
@@ -452,6 +457,10 @@ impl Button {
             self.state = state;
             ctx.request_paint();
         }
+    }
+
+    pub fn set_haptic_mode(&mut self, mode: HapticMode) {
+        self.haptic = mode;
     }
 
     pub fn render_background<'s>(
@@ -714,7 +723,7 @@ impl Component for Button {
                         // Touch started in our area, transform to `Pressed` state.
                         if touch_area.contains(pos) {
                             #[cfg(feature = "haptic")]
-                            if self.haptic {
+                            if matches!(self.haptic, HapticMode::OnPress) {
                                 play(HapticEffect::ButtonPress);
                             }
                             self.set(ctx, State::Pressed);
@@ -745,6 +754,10 @@ impl Component for Button {
                     }
                     State::Pressed if touch_area.contains(pos) => {
                         // Touch finished in our area, we got clicked.
+                        #[cfg(feature = "haptic")]
+                        if matches!(self.haptic, HapticMode::OnClick) {
+                            play(HapticEffect::ButtonPress);
+                        }
                         self.set(ctx, State::Initial);
                         return Some(ButtonMsg::Clicked);
                     }
@@ -784,7 +797,7 @@ impl Component for Button {
             Event::Timer(_) if self.long_timer.expire(event) => {
                 if matches!(self.state, State::Pressed) {
                     #[cfg(feature = "haptic")]
-                    if self.haptic {
+                    if !matches!(self.haptic, HapticMode::Off) {
                         play(HapticEffect::ButtonPress);
                     }
                     self.set(ctx, State::Initial);

--- a/core/embed/rust/src/ui/layout_eckhart/component/mod.rs
+++ b/core/embed/rust/src/ui/layout_eckhart/component/mod.rs
@@ -4,7 +4,9 @@ mod fuel_gauge;
 mod update_screen;
 mod welcome_screen;
 
-pub use button::{Button, ButtonContent, ButtonMsg, ButtonStyle, ButtonStyleSheet, IconText};
+pub use button::{
+    Button, ButtonContent, ButtonMsg, ButtonStyle, ButtonStyleSheet, HapticMode, IconText,
+};
 pub use error::ErrorScreen;
 pub use fuel_gauge::FuelGauge;
 pub use update_screen::UpdateScreen;

--- a/core/embed/rust/src/ui/layout_eckhart/firmware/vertical_menu.rs
+++ b/core/embed/rust/src/ui/layout_eckhart/firmware/vertical_menu.rs
@@ -12,7 +12,7 @@ use crate::{
 };
 
 use super::{
-    super::component::{Button, ButtonMsg},
+    super::component::{Button, ButtonMsg, HapticMode},
     theme,
 };
 use heapless::Vec;
@@ -137,6 +137,13 @@ impl<T: MenuItems> VerticalMenu<T> {
     pub fn with_item(mut self, button: Button) -> Self {
         self.buttons.push(button);
         self
+    }
+
+    /// Set haptic mode for all buttons in the menu.
+    pub fn set_haptic_mode(&mut self, mode: HapticMode) {
+        for button in self.buttons.iter_mut() {
+            button.set_haptic_mode(mode);
+        }
     }
 
     pub fn item(&mut self, button: Button) -> &mut Self {

--- a/core/embed/rust/src/ui/layout_eckhart/firmware/vertical_menu_screen.rs
+++ b/core/embed/rust/src/ui/layout_eckhart/firmware/vertical_menu_screen.rs
@@ -16,8 +16,8 @@ use crate::{
 };
 
 use super::{
-    constant::SCREEN, theme, Header, HeaderMsg, MenuItems, ShortMenuVec, VerticalMenu,
-    VerticalMenuMsg,
+    super::component::HapticMode, constant::SCREEN, theme, Header, HeaderMsg, MenuItems,
+    ShortMenuVec, VerticalMenu, VerticalMenuMsg,
 };
 
 pub struct VerticalMenuScreen<T> {
@@ -95,13 +95,15 @@ impl<T: MenuItems> VerticalMenuScreen<T> {
         }
 
         // Switch swiping on/off based on the menu fit
-        self.swipe = if !self.menu.fits_area() {
+        if !self.menu.fits_area() {
             ctx.enable_swipe();
-            Some(SwipeDetect::new())
+            self.swipe = Some(SwipeDetect::new());
+            // Delay haptic feedback to click for scrollable menus
+            self.menu.set_haptic_mode(HapticMode::OnClick);
         } else {
             ctx.disable_swipe();
-            None
-        };
+            self.swipe = None;
+        }
 
         // Set default position for the sliding window
         self.menu.set_offset(0);


### PR DESCRIPTION
- if the menu is scrollable (i.e. buttons don't fit on the page) the haptics is postponed to the actual click (TouchEnd) rather than placing the finger there (TouchStart)

<!--
For external contributors:
- Please open an issue before submitting a PR so we can discuss whether we want to proceed with it.

For core developers:
1. Initial PR setup
- Assign yourself to the PR.
- Add it to the "Firmware" project
  - Set Priority (match issue priority if it exists)
  - Set Team
  - Set Sprint (target release)

2. Development status
- Draft PRs: Set status to "In Progress"
- Final PRs: Set status to "Needs Review"

3. Post-merge status
- Testable: Set status to "Needs QA" and add a `Notes for QA` section with clear instructions on how to test the functionality.
- Not Testable: Set status to "Done (no QA)"
-->

# Notes for QA
Test that longer submenu in T3W1 device menu does not produce unpleasant haptic feedback while scrolling.