### PR TITLE
Improve dependency tree of trezorlib

### DIFF
--- a/python/.changelog.d/6202.added
+++ b/python/.changelog.d/6202.added
@@ -1,1 +1,0 @@
-Support THP ACK piggybacking.

--- a/python/.changelog.d/6349.added
+++ b/python/.changelog.d/6349.added
@@ -1,1 +1,0 @@
-Support WebAuthn credentials' pagination.

--- a/python/.changelog.d/6525.changed
+++ b/python/.changelog.d/6525.changed
@@ -1,1 +1,0 @@
-Default to advanced recovery for mnemonics shorter than 24 words on legacy.

--- a/python/.changelog.d/6555.fixed
+++ b/python/.changelog.d/6555.fixed
@@ -1,1 +1,0 @@
-Handle missing THP continuations during multi-chunk payloads.

--- a/python/.changelog.d/6564.deprecated
+++ b/python/.changelog.d/6564.deprecated
@@ -1,0 +1,1 @@
+`trezorlib.ui` is deprecated, the module has been moved to `trezorlib.cli.ui`.

--- a/python/.changelog.d/6564.deprecated
+++ b/python/.changelog.d/6564.deprecated
@@ -1,1 +1,0 @@
-`trezorlib.ui` is deprecated, the module has been moved to `trezorlib.cli.ui`.

--- a/python/.changelog.d/6564.deprecated.1
+++ b/python/.changelog.d/6564.deprecated.1
@@ -1,1 +1,0 @@
-`trezorlib.tools.EnumAdapter` and `TupleAdaper` have been moved to `trezorlib.construct_helpers`.

--- a/python/.changelog.d/6564.deprecated.1
+++ b/python/.changelog.d/6564.deprecated.1
@@ -1,0 +1,1 @@
+`trezorlib.tools.EnumAdapter` and `TupleAdaper` have been moved to `trezorlib.construct_helpers`.

--- a/python/.changelog.d/6575.fixed
+++ b/python/.changelog.d/6575.fixed
@@ -1,1 +1,0 @@
-Fix THP pairing after credential invalidation.

--- a/python/.changelog.d/6580.fixed
+++ b/python/.changelog.d/6580.fixed
@@ -1,1 +1,0 @@
-Fetch root fingerprint from older firmware.

--- a/python/.changelog.d/6588.fixed
+++ b/python/.changelog.d/6588.fixed
@@ -1,1 +1,0 @@
-Skip unrelated device response when probing transport.

--- a/python/.changelog.d/6633.fixed
+++ b/python/.changelog.d/6633.fixed
@@ -1,1 +1,0 @@
-Fix THP auto-connection after unlocking the device.

--- a/python/CHANGELOG.md
+++ b/python/CHANGELOG.md
@@ -5,6 +5,27 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.20.1] (2026-05-11)
+[0.20.1]: https://github.com/trezor/trezor-firmware/compare/python/v0.20.0...python/v0.20.1
+
+### Added
+- Support THP ACK piggybacking.  [#6202]
+- Support WebAuthn credentials' pagination.  [#6349]
+
+### Changed
+- Default to advanced recovery for mnemonics shorter than 24 words on legacy.  [#6525]
+
+### Deprecated
+- `trezorlib.ui` is deprecated, the module has been moved to `trezorlib.cli.ui`.  [#6564]
+- `trezorlib.tools.EnumAdapter` and `TupleAdaper` have been moved to `trezorlib.construct_helpers`.  [#6564]
+
+### Fixed
+- Handle missing THP continuations during multi-chunk payloads.  [#6555]
+- Fix THP pairing after credential invalidation.  [#6575]
+- Fetch root fingerprint from older firmware.  [#6580]
+- Skip unrelated device response when probing transport.  [#6588]
+- Fix THP auto-connection after unlocking the device.  [#6633]
+
 ## [0.20.0] (2026-02-10)
 [0.20.0]: https://github.com/trezor/trezor-firmware/compare/python/v0.20.0-dev0...python/v0.20.0
 
@@ -966,5 +987,14 @@ This version is a pre-release. The new API is unstable and may change until 0.20
 [#5928]: https://github.com/trezor/trezor-firmware/pull/5928
 [#6103]: https://github.com/trezor/trezor-firmware/pull/6103
 [#6112]: https://github.com/trezor/trezor-firmware/pull/6112
+[#6202]: https://github.com/trezor/trezor-firmware/pull/6202
 [#6273]: https://github.com/trezor/trezor-firmware/pull/6273
+[#6349]: https://github.com/trezor/trezor-firmware/pull/6349
 [#6449]: https://github.com/trezor/trezor-firmware/pull/6449
+[#6525]: https://github.com/trezor/trezor-firmware/pull/6525
+[#6555]: https://github.com/trezor/trezor-firmware/pull/6555
+[#6564]: https://github.com/trezor/trezor-firmware/pull/6564
+[#6575]: https://github.com/trezor/trezor-firmware/pull/6575
+[#6580]: https://github.com/trezor/trezor-firmware/pull/6580
+[#6588]: https://github.com/trezor/trezor-firmware/pull/6588
+[#6633]: https://github.com/trezor/trezor-firmware/pull/6633

--- a/python/pyproject.toml
+++ b/python/pyproject.toml
@@ -60,23 +60,29 @@ Documentation = "https://github.com/trezor/trezor-firmware/tree/main/python"
 trezorctl = "trezorlib.cli.trezorctl:cli"
 
 [build-system]
-requires = ["hatchling"]
-build-backend = "hatchling.build"
+requires = ["flit_core >= 3.11,<5"]
+build-backend = "flit_core.buildapi"
 
 [tool.uv]
 package = true
 
-[tool.hatch.build.targets.wheel]
-packages = ["src/trezorlib"]
+[tool.flit.module]
+name = "trezorlib"
 
-[tool.hatch.build.targets.sdist]
+[tool.flit.sdist]
+include = [
+    "bash_completion.d",
+    "docs",
+    "stubs",
+    "tests",
+    "tools",
+    "AUTHORS",
+    "CHANGELOG.md",
+    "setup.cfg",
+    "pyrightconfig.json",
+    "tox.ini",
+]
 exclude = [
-    "/.*",
-    "/helper-scripts",
-    "/CHANGELOG.unreleased",
-    "/default.nix",
-    "/Makefile",
-    "/towncrier.toml",
     "tests/*.bin",
     "src/trezorlib/_proto_messages.mako",
 ]

--- a/python/pyproject.toml
+++ b/python/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "trezor"
-version = "0.20.1"
+version = "0.20.2"
 description = "Python library for communicating with Trezor Hardware Wallet"
 readme = "README.md"
 license = "LGPL-3.0-only"

--- a/python/src/trezorlib/_internal/emu_ble.py
+++ b/python/src/trezorlib/_internal/emu_ble.py
@@ -25,8 +25,8 @@ from typing import TYPE_CHECKING, Iterable, Tuple
 import construct as c
 from construct_classes import Struct
 
+from ..construct_helpers import EnumAdapter
 from ..log import DUMP_PACKETS
-from ..tools import EnumAdapter
 from ..transport import Timeout, Transport, TransportException
 from ..transport.udp import UdpTransport
 

--- a/python/src/trezorlib/_internal/translations.py
+++ b/python/src/trezorlib/_internal/translations.py
@@ -27,10 +27,10 @@ import construct as c
 from construct_classes import Struct, subcon
 from typing_extensions import Self, TypedDict
 
+from ..construct_helpers import EnumAdapter, TupleAdapter
 from ..debuglink import LayoutType
 from ..firmware.models import Model
 from ..models import TrezorModel
-from ..tools import EnumAdapter, TupleAdapter
 
 # All sections need to be aligned to 2 bytes for the offset tables using u16 to work properly
 ALIGNMENT = 2

--- a/python/src/trezorlib/cli/__init__.py
+++ b/python/src/trezorlib/cli/__init__.py
@@ -33,11 +33,11 @@ from pathlib import Path
 import click
 from typing_extensions import Self
 
-from .. import exceptions, messages, protocol_v1, transport, ui
+from .. import exceptions, messages, protocol_v1, transport
 from ..client import AppManifest, PassphraseSetting, Session, TrezorClient, get_client
 from ..thp import client as thp_client
 from ..transport import Transport
-from . import credentials
+from . import credentials, ui
 
 LOG = logging.getLogger(__name__)
 

--- a/python/src/trezorlib/cli/device.py
+++ b/python/src/trezorlib/cli/device.py
@@ -24,9 +24,9 @@ import typing as t
 import click
 import requests
 
-from .. import authentication, debuglink, device, exceptions, messages, ui
+from .. import authentication, debuglink, device, exceptions, messages
 from ..tools import format_path
-from . import ChoiceType, with_session
+from . import ChoiceType, ui, with_session
 
 if t.TYPE_CHECKING:
     from ..client import Session

--- a/python/src/trezorlib/cli/ui.py
+++ b/python/src/trezorlib/cli/ui.py
@@ -22,10 +22,10 @@ import typing as t
 import click
 from mnemonic import Mnemonic
 
-from . import device, messages
-from .client import MAX_PIN_LENGTH
-from .exceptions import Cancelled
-from .messages import PinMatrixRequestType, WordRequestType
+from .. import device, messages
+from ..client import MAX_PIN_LENGTH
+from ..exceptions import Cancelled
+from ..messages import PinMatrixRequestType, WordRequestType
 
 PIN_MATRIX_DESCRIPTION = """
 Use the numeric keypad or lowercase letters to describe number positions.

--- a/python/src/trezorlib/construct_helpers.py
+++ b/python/src/trezorlib/construct_helpers.py
@@ -1,0 +1,50 @@
+# This file is part of the Trezor project.
+#
+# Copyright (C) SatoshiLabs and contributors
+#
+# This library is free software: you can redistribute it and/or modify
+# it under the terms of the GNU Lesser General Public License version 3
+# as published by the Free Software Foundation.
+#
+# This library is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU Lesser General Public License for more details.
+#
+# You should have received a copy of the License along with this library.
+# If not, see <https://www.gnu.org/licenses/lgpl-3.0.html>.
+
+from __future__ import annotations
+
+import typing as t
+from enum import Enum
+
+import construct
+
+
+class EnumAdapter(construct.Adapter):
+    def __init__(self, subcon: construct.Adapter, enum: type[Enum]) -> None:
+        self.enum = enum
+        super().__init__(subcon)
+
+    def _encode(self, obj: t.Any, context: t.Any, path: t.Any) -> t.Any:
+        if isinstance(obj, self.enum):
+            return obj.value
+        return obj
+
+    def _decode(self, obj: t.Any, context: t.Any, path: t.Any) -> t.Any:
+        try:
+            return self.enum(obj)
+        except ValueError:
+            return obj
+
+
+class TupleAdapter(construct.Adapter):
+    def __init__(self, *subcons: construct.Adapter) -> None:
+        super().__init__(construct.Sequence(*subcons))
+
+    def _encode(self, obj: t.Any, context: t.Any, path: t.Any) -> t.Any:
+        return obj
+
+    def _decode(self, obj: t.Any, context: t.Any, path: t.Any) -> t.Any:
+        return tuple(obj)

--- a/python/src/trezorlib/definitions.py
+++ b/python/src/trezorlib/definitions.py
@@ -24,8 +24,8 @@ import requests
 from construct_classes import Struct, subcon
 
 from . import cosi, merkle_tree
+from .construct_helpers import EnumAdapter
 from .messages import DefinitionType
-from .tools import EnumAdapter
 
 LOG = logging.getLogger(__name__)
 

--- a/python/src/trezorlib/firmware/core.py
+++ b/python/src/trezorlib/firmware/core.py
@@ -25,7 +25,7 @@ import construct as c
 from construct_classes import Struct, subcon
 
 from .. import cosi, merkle_tree
-from ..tools import EnumAdapter, TupleAdapter
+from ..construct_helpers import EnumAdapter, TupleAdapter
 from . import consts, models, util
 from .models import Model
 from .vendor import VendorHeader

--- a/python/src/trezorlib/firmware/secmon.py
+++ b/python/src/trezorlib/firmware/secmon.py
@@ -21,7 +21,7 @@ from copy import copy
 import construct as c
 from construct_classes import Struct, subcon
 
-from ..tools import EnumAdapter, TupleAdapter
+from ..construct_helpers import EnumAdapter, TupleAdapter
 from . import util
 from .models import Model
 

--- a/python/src/trezorlib/firmware/vendor.py
+++ b/python/src/trezorlib/firmware/vendor.py
@@ -24,8 +24,8 @@ import construct as c
 from construct_classes import Struct, subcon
 
 from .. import cosi
+from ..construct_helpers import EnumAdapter, TupleAdapter
 from ..toif import ToifStruct
-from ..tools import EnumAdapter, TupleAdapter
 from . import util
 from .models import Model
 

--- a/python/src/trezorlib/toif.py
+++ b/python/src/trezorlib/toif.py
@@ -23,7 +23,7 @@ from typing import Sequence, Tuple
 import construct as c
 from typing_extensions import Literal
 
-from .tools import EnumAdapter
+from .construct_helpers import EnumAdapter
 
 try:
     # Explanation of having to use "Image.Image" in typing:

--- a/python/src/trezorlib/tools.py
+++ b/python/src/trezorlib/tools.py
@@ -23,9 +23,7 @@ import struct
 import typing as t
 import unicodedata
 from contextlib import AbstractContextManager
-from enum import Enum
 
-import construct
 import typing_extensions as tx
 
 from . import messages
@@ -322,34 +320,6 @@ def descriptor_checksum(desc: str) -> str:
     for j in range(0, 8):
         ret[j] = CHECKSUM_CHARSET[(c >> (5 * (7 - j))) & 31]
     return "".join(ret)
-
-
-class EnumAdapter(construct.Adapter):
-    def __init__(self, subcon: construct.Adapter, enum: type[Enum]) -> None:
-        self.enum = enum
-        super().__init__(subcon)
-
-    def _encode(self, obj: t.Any, context: t.Any, path: t.Any) -> t.Any:
-        if isinstance(obj, self.enum):
-            return obj.value
-        return obj
-
-    def _decode(self, obj: t.Any, context: t.Any, path: t.Any) -> t.Any:
-        try:
-            return self.enum(obj)
-        except ValueError:
-            return obj
-
-
-class TupleAdapter(construct.Adapter):
-    def __init__(self, *subcons: construct.Adapter) -> None:
-        super().__init__(construct.Sequence(*subcons))
-
-    def _encode(self, obj: t.Any, context: t.Any, path: t.Any) -> t.Any:
-        return obj
-
-    def _decode(self, obj: t.Any, context: t.Any, path: t.Any) -> t.Any:
-        return tuple(obj)
 
 
 def enter_context(context_func: ContextFunc[CM, P, R]) -> ContextFunc[CM, P, R]:

--- a/python/src/trezorlib/tools.py
+++ b/python/src/trezorlib/tools.py
@@ -387,3 +387,23 @@ class workflow(t.Generic[P, R]):
             session.refresh_features()
 
         return result
+
+
+def __getattr__(name: str) -> t.Any:
+    import warnings
+
+    if name not in ("EnumAdapter", "TupleAdapter"):
+        raise AttributeError(f"module 'trezorlib.tools' has no attribute '{name}'")
+    warnings.warn(
+        f"trezorlib.tools.{name} is deprecated and will be removed in 0.21. Use trezorlib.construct_helpers.{name} instead.",
+        DeprecationWarning,
+        stacklevel=2,
+    )
+
+    from . import construct_helpers
+
+    if name == "EnumAdapter":
+        return construct_helpers.EnumAdapter
+    if name == "TupleAdapter":
+        return construct_helpers.TupleAdapter
+    raise AttributeError(f"module 'trezorlib.tools' has no attribute '{name}'")

--- a/python/src/trezorlib/ui.py
+++ b/python/src/trezorlib/ui.py
@@ -1,0 +1,13 @@
+import warnings
+from typing import Any
+
+
+def __getattr__(name: str) -> Any:
+    from .cli import ui
+
+    warnings.warn(
+        "trezorlib.ui is deprecated and will be removed in 0.21. Use trezorlib.cli.ui instead.",
+        DeprecationWarning,
+        stacklevel=2,
+    )
+    return getattr(ui, name)


### PR DESCRIPTION
<!--
For external contributors:
- Please open an issue before submitting a PR so we can discuss whether we want to proceed with it.

For core developers:
1. Initial PR setup
- Assign yourself to the PR.
- Add it to the "Firmware" project
  - Set Priority (match issue priority if it exists)
  - Set Team
  - Set Sprint (target release)

2. Development status
- Draft PRs: Set status to "In Progress"
- Final PRs: Set status to "Needs Review"

3. Post-merge status
- Testable: Set status to "Needs QA" and add a `Notes for QA` section with clear instructions on how to test the functionality.
- Not Testable: Set status to "Done (no QA)"
-->
This should help https://github.com/spesmilo/electrum/pull/10465 by reducing the number of required dependencies:

* builds trezorlib with `flit` which is much less dependency-heavy than hatchling
* also reorders pieces here and there so that the library works if you blacklist some things, specifically:
  * `construct`
  * `construct_classes`
  * `click`
  * `platformdirs`
  * `keyring`

unfortunately this doesn't straightforwardly help the above PR, because far as I was able to figure out, there is no nice way to blacklist dependencies.

one option is stuffing the above deps into some sort of extra ... with the rather significant drawback that `pip install trezor` would no longer give you a functioning trezorctl! unless you specified an extra like `pip install trezor[cli]` or something.

technically viable but do we really, _really_ want that? i think not.

the preferable route would be to **split up the library**:
* `trezorlib` for the core library plus ~everything that doesn't pull in extra deps
  * extra for `hidapi` and optionally also bridge to get rid of `requests`
* `trezorlib-formats` for definitions and TOIF -- requires `construct` and friends
  * extra for `Pillow` for nicer TOIF functionalities
* `trezorlib-firmware` for firmware parsing code. requires `construct` and also `trezorlib-formats` for TOIF
* `trezor` would provide `trezorlib.cli` module and the `trezorctl` executable. requires all of the above, plus click, platformdirs, keyring, hoooonestly i'd just straight up add `Pillow` and `bleak` to that.
  *   extras for ethereum / stellar / whatever other dependency we come to learn about

...but doing the above is somewhat more work