### PR TITLE
fix(ci/hw-test): downgrade checkout and upload-artifact actions

### DIFF
--- a/.github/workflows/core-hw.yml
+++ b/.github/workflows/core-hw.yml
@@ -52,7 +52,7 @@ jobs:
       QUIET_MODE: 1
     timeout-minutes: 360  # 6h CI job timeout
     steps:
-      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # actions/checkout@v6.0.2
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5  # actions/checkout@v4.3.1
         with:
           submodules: recursive
       - uses: ./.github/actions/environment
@@ -66,7 +66,7 @@ jobs:
           nix-shell --run "uv run pytest -v --verbose-log-file pytest.log tests/device_tests $TESTOPTS"
       - run: tail -n50 trezor.log || true
         if: failure()
-      - uses: actions/upload-artifact@bbbca2ddaa5d8feaa63e36b76fdaad77386f024f  # actions/upload-artifact@v7.0.0
+      - uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02  # actions/upload-artifact@v4.6.2
         with:
           name: core-hardware-${{ matrix.model }}-${{ matrix.coins }}
           path: |
@@ -95,7 +95,7 @@ jobs:
       TT_UHUB_PORT: 1
       QUIET_MODE: 1
     steps:
-      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # actions/checkout@v6.0.2
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5  # actions/checkout@v4.3.1
         with:
           submodules: recursive
       - uses: ./.github/actions/environment
@@ -109,7 +109,7 @@ jobs:
           nix-shell --arg fullDeps true --run "./core/tests/run_tests_device_emu_monero.sh --trezor-path webusb:"
       - run: tail -n50 trezor.log || true
         if: failure()
-      - uses: actions/upload-artifact@bbbca2ddaa5d8feaa63e36b76fdaad77386f024f  # actions/upload-artifact@v7.0.0
+      - uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02  # actions/upload-artifact@v4.6.2
         with:
           name: core-hardware-monero-${{ matrix.model }}
           path: trezor.log
@@ -134,7 +134,7 @@ jobs:
       BITCOIN_ONLY: ${{ matrix.coins == 'universal' && '0' || '1' }}
       DEBUG_LINK: 1
     steps:
-      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # actions/checkout@v6.0.2
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5  # actions/checkout@v4.3.1
         with:
           submodules: recursive
       - uses: ./.github/actions/environment
@@ -142,7 +142,7 @@ jobs:
       - run: nix-shell --run "uv run legacy/script/setup"
       - run: nix-shell --run "export PRODUCTION=0 && uv run legacy/script/cibuild"
       - run: nix-shell --arg hardwareTest true --run "ci/hardware_tests/t1_hw_test.sh"
-      - uses: actions/upload-artifact@bbbca2ddaa5d8feaa63e36b76fdaad77386f024f  # actions/upload-artifact@v7.0.0
+      - uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02  # actions/upload-artifact@v4.6.2
         with:
           name: legacy-hardware-${{ matrix.coins }}
           path: ci/hardware_tests/*.mp4


### PR DESCRIPTION
- HW tests are failing after recent actions upgrade, possibly caused by incompatible runners in the self-hosted environment. This PR essentially reverts the upgrade of actions in the `core-hw.yml`, while keeping the actions fixed to a commit-hash.
 
 Hardware tests run: 
 Standard: https://github.com/trezor/trezor-firmware/actions/runs/22694264991
 Failing (current): https://github.com/trezor/trezor-firmware/actions/runs/22741600107/job/65955999048
 After the downgrade - this PR: https://github.com/trezor/trezor-firmware/actions/runs/22770701673/