### PR TITLE
Ensure longer auto-suspend time in critical flows

### DIFF
--- a/core/.changelog.d/6567.added
+++ b/core/.changelog.d/6567.added
@@ -1,0 +1,1 @@
+[T3W1] Prolong minimal auto-suspend time during backup and recovery to 2 minutes.

--- a/core/src/apps/common/lock_manager.py
+++ b/core/src/apps/common/lock_manager.py
@@ -15,8 +15,13 @@ if utils.USE_BLE:
     import trezorble as ble
 
 if TYPE_CHECKING:
+    from typing import Awaitable, Callable, ParamSpec, TypeVar
+
     from trezor import protobuf
     from trezor.wire import Handler, Msg
+
+    P = ParamSpec("P")
+    R = TypeVar("R")
 
 _SCREENSAVER_IS_ON = False
 
@@ -27,6 +32,8 @@ if not utils.USE_POWER_MANAGER:
         pass
 
 else:
+    from micropython import const
+
     from trezor import loop
 
     _SHOULD_SUSPEND = False
@@ -101,12 +108,35 @@ else:
             lock_device_if_unlocked()
 
     def configure_autodim() -> None:
-        """Configure the autodim setting via idle timer."""
+        """Configure the autodim setting via idle timer (battery-specific)."""
         workflow.idle_timer.set(storage_device.AUTODIM_DELAY_MS, autodim_display)
+
+    def configure_autolock(min_delay_ms: int = 0) -> None:
+        """Configure the autolock setting via idle timer (battery-specific)."""
+        delay_ms = max(min_delay_ms, storage_device.get_autolock_delay_battery_ms())
         workflow.idle_timer.set(
-            storage_device.get_autolock_delay_battery_ms(),
+            delay_ms,
             lock_device_if_unlocked_on_battery,
         )
+
+
+def with_prolonged_suspend_time(
+    func: Callable[P, Awaitable[R]],
+) -> Callable[P, Awaitable[R]]:
+    """Decorator to prolong the suspend time to at least 2 minutes while executing the decorated function."""
+    if utils.USE_POWER_MANAGER:
+
+        async def wrapper(*args: "P.args", **kwargs: "P.kwargs") -> R:
+            _PROLONGED_SUSPEND_TIME_MS = const(2 * 60 * 1000)
+            configure_autolock(min_delay_ms=_PROLONGED_SUSPEND_TIME_MS)
+            try:
+                return await func(*args, **kwargs)
+            finally:
+                configure_autolock(min_delay_ms=0)
+
+        return wrapper
+    else:
+        return func
 
 
 def set_homescreen() -> None:
@@ -224,6 +254,7 @@ def reload_settings_from_storage() -> None:
 
     if utils.USE_POWER_MANAGER:
         configure_autodim()
+        configure_autolock()
 
     if utils.USE_HAPTIC:
         io.haptic.haptic_set_enabled(storage_device.get_haptic_feedback())

--- a/core/src/apps/management/recovery_device/homescreen.py
+++ b/core/src/apps/management/recovery_device/homescreen.py
@@ -7,6 +7,7 @@ from trezor.messages import Success
 from trezor.wire import message_handler
 
 from apps.common import backup_types
+from apps.common.lock_manager import with_prolonged_suspend_time
 
 from . import layout, recover
 
@@ -29,6 +30,7 @@ async def recovery_homescreen() -> None:
         await recovery_process(None)
 
 
+@with_prolonged_suspend_time
 async def recovery_process(method: BackupMethod | None) -> Success:
     import storage
     from trezor.enums import MessageType, RecoveryType

--- a/core/src/apps/management/reset_device/__init__.py
+++ b/core/src/apps/management/reset_device/__init__.py
@@ -9,6 +9,7 @@ from trezor.ui.layouts import confirm_action
 from trezor.wire import ProcessError
 
 from apps.common import backup_types
+from apps.common.lock_manager import with_prolonged_suspend_time
 
 from . import layout
 
@@ -354,6 +355,7 @@ def _compute_secret_from_entropy(
     return secret
 
 
+@with_prolonged_suspend_time
 async def backup_seed(
     handler: layout.BackupHandler,
     backup_type: BackupType,

--- a/core/src/boot.py
+++ b/core/src/boot.py
@@ -96,6 +96,7 @@ async def bootscreen() -> None:
     """
     if utils.USE_POWER_MANAGER:
         lock_manager.configure_autodim()
+        lock_manager.configure_autolock()
 
     while True:
         try:


### PR DESCRIPTION
- we want to use longer auto-lock (rather auto-suspend) time in critical onboarding flows, i.e. creating a backup, and recovering a wallet, when the device is powered by a battery
- this involves only battery-powered device (currently T3W1)
- the auto-lock is set to 2 minutes, a device default is 40 seconds

Notes for QA:
- check that a fresh device (after wipe) does not suspend (turn off the screen) after less than 2 minutes when performing a backup or doing a recovery.
<!--
For external contributors:
- Please open an issue before submitting a PR so we can discuss whether we want to proceed with it.

For core developers:
1. Initial PR setup
- Assign yourself to the PR.
- Add it to the "Firmware" project
  - Set Priority (match issue priority if it exists)
  - Set Team
  - Set Sprint (target release)

2. Development status
- Draft PRs: Set status to "In Progress"
- Final PRs: Set status to "Needs Review"

3. Post-merge status
- Testable: Set status to "Needs QA" and add a `Notes for QA` section with clear instructions on how to test the functionality.
- Not Testable: Set status to "Done (no QA)"
-->
