### PR TITLE
fix(core/rust): preserve most significant bit in Obj::small_int

### DIFF
--- a/core/embed/rust/src/micropython/obj.rs
+++ b/core/embed/rust/src/micropython/obj.rs
@@ -114,7 +114,8 @@ impl Obj {
         // micropython/py/obj.h
         // #define MP_OBJ_NEW_SMALL_INT(small_int) \
         //     ((mp_obj_t)((((mp_uint_t)(small_int)) << 1) | 1))
-        unsafe { Self::from_bits(((val << 1) | 1) as usize) }
+        let val = val as usize;
+        unsafe { Self::from_bits((val << 1) | 1) }
     }
 }
 
@@ -471,5 +472,26 @@ impl Obj {
         } else {
             None
         }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_small_int() {
+        assert_eq!(
+            Obj::small_int(0x0000).as_bits(),
+            0b00000000000000000000000000000001
+        );
+        assert_eq!(
+            Obj::small_int(0x00f0).as_bits(),
+            0b00000000000000000000000111100001
+        );
+        assert_eq!(
+            Obj::small_int(0xffff).as_bits(),
+            0b00000000000000011111111111111111
+        );
     }
 }


### PR DESCRIPTION
Values above 32767 got mangled. We only use this conversion for some small constants and protobuf wire ids, so I think we haven't had the chance to trigger it before.

<details>
<summary>u16->Obj into() call sites</summary>

```
  --> src/coverage/mod.rs:26:31
   |
26 |         (Obj::from(val.file), Obj::from(val.line)).try_into()
   |                               ^^^ the trait `From<u16>` is not implemented for `mp_obj_t`
   |
   --> src/protobuf/decode.rs:244:33
    |
244 |                     Ok(enum_val.into())
    |                                 ^^^^ the trait `From<u16>` is not implemented for `mp_obj_t`
  --> src/protobuf/obj.rs:75:20
   |
75 |                 Ok(self.msg_wire_id.map_or_else(Obj::const_none, Into::into))
   |                    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ the trait `From<u16>` is not implemented for `mp_obj_t`
  --> src/protobuf/obj.rs:75:66
   |
75 |                 Ok(self.msg_wire_id.map_or_else(Obj::const_none, Into::into))
   |                                                                  ^^^^^^^^^^ the trait `From<u16>` is not implemented for `mp_obj_t`
  --> src/protobuf/obj.rs:81:72
   |
81 |                         .ok_or_else(|| Error::KeyError(self.msg_offset.into()))?,
   |                                                                        ^^^^ the trait `From<u16>` is not implemented for `mp_obj_t`
   --> src/protobuf/obj.rs:231:35
    |
231 |                 let wire_id_obj = this.def.wire_id.map_or_else(Obj::const_none, Into::into);
    |                                   ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ the trait `From<u16>` is not implemented for `mp_obj_t`
   --> src/protobuf/obj.rs:231:81
    |
231 |                 let wire_id_obj = this.def.wire_id.map_or_else(Obj::const_none, Into::into);
    |                                                                                 ^^^^^^^^^^ the trait `From<u16>` is not implemented for `mp_obj_t`
   --> src/protobuf/obj.rs:311:52
    |
311 |             .ok_or_else(|| Error::KeyError(wire_id.into()))?;
    |                                                    ^^^^ the trait `From<u16>` is not implemented for `mp_obj_t`
   --> src/ui/layout/obj.rs:363:25
    |
363 |         self.page_count.into()
    |                         ^^^^ the trait `From<u16>` is not implemented for `mp_obj_t`
   --> src/ui/layout/obj.rs:369:63
    |
369 |             Some(ButtonRequest { code, name }) => (code.num().into(), name.try_into()?).try_into(),
    |                                                               ^^^^ the trait `From<u16>` is not implemented for `mp_obj_t`
```
</details>
<!--
For external contributors:
- Please open an issue before submitting a PR so we can discuss whether we want to proceed with it.

For core developers:
1. Initial PR setup
- Assign yourself to the PR.
- Add it to the "Firmware" project
  - Set Priority (match issue priority if it exists)
  - Set Team
  - Set Sprint (target release)

2. Development status
- Draft PRs: Set status to "In Progress"
- Final PRs: Set status to "Needs Review"

3. Post-merge status
- Testable: Set status to "Needs QA" and add a `Notes for QA` section with clear instructions on how to test the functionality.
- Not Testable: Set status to "Done (no QA)"
-->
