### PR TITLE
fix(python): drop old THP credentials if auto-connect fails

### DIFF
--- a/python/.changelog.d/6575.fixed
+++ b/python/.changelog.d/6575.fixed
@@ -1,0 +1,1 @@
+Replace THP credentials on pairing.

--- a/python/src/trezorlib/cli/__init__.py
+++ b/python/src/trezorlib/cli/__init__.py
@@ -450,6 +450,11 @@ class TrezorConnection:
                 client.pairing, code_entry_callback=get_code_entry_code
             )
             if credential is not None:
+                trezor_public_keys = client.pairing.channel.trezor_public_keys
+                if trezor_public_keys is not None:
+                    # replace old credentials on successful pairing
+                    self.credentials.delete(trezor_public_keys)
+
                 self.credentials.add(credential)
 
         return client

--- a/python/src/trezorlib/cli/credentials.py
+++ b/python/src/trezorlib/cli/credentials.py
@@ -190,12 +190,13 @@ class CredentialStore:
 
     def delete(self, id_or_key: bytes | TrezorPublicKeys) -> None:
         with self._with_app() as app_data:
-            credential = self._get(app_data, id_or_key)
-            if credential is None:
-                LOG.warning("Credential not found: %s", id_or_key)
-            else:
+            found = False
+            while (credential := self._get(app_data, id_or_key)) is not None:
                 credential.delete()
                 app_data.remove(credential.id)
+                found = True
+            if not found:
+                LOG.warning("Credential not found: %s", id_or_key)
 
     def clear(self) -> None:
         with self._with_app() as app_data:


### PR DESCRIPTION
The tricky part here is that trezorctl currently relies on THP channel replacement feature:
- the host-side credential entry is used to choose `host_static_publickey`, which is sent to the device at `HANDSHAKE_COMP_REQ`.
- the device checks if it matches any of the currently cached channels.
- if so, no pairing is needed = auto-connect

But there are multiple credentials stored by the host, it is possible that we'll always choose an incorrect one -> the device will receive an outdated `host_static_publickey` -> pairing will be needed.

Following #6575.

<!--
For external contributors:
- Please open an issue before submitting a PR so we can discuss whether we want to proceed with it.

For core developers:
1. Initial PR setup
- Assign yourself to the PR.
- Add it to the "Firmware" project
  - Set Priority (match issue priority if it exists)
  - Set Team
  - Set Sprint (target release)

2. Development status
- Draft PRs: Set status to "In Progress"
- Final PRs: Set status to "Needs Review"

3. Post-merge status
- Testable: Set status to "Needs QA" and add a `Notes for QA` section with clear instructions on how to test the functionality.
- Not Testable: Set status to "Done (no QA)"
-->
