### PR TITLE
fix(core): render progress text in Bolt & Delizia

### DIFF
--- a/core/embed/rust/src/ui/layout_bolt/component/homescreen.rs
+++ b/core/embed/rust/src/ui/layout_bolt/component/homescreen.rs
@@ -103,12 +103,13 @@ impl Homescreen {
     }
 
     fn render_loader<'s>(&'s self, target: &mut impl Renderer<'s>) {
+        self.loader.render(target);
         TR::progress__locking_device.map_translated(|t| {
             shape::Text::new(TOP_CENTER + Offset::y(HOLD_Y), t, fonts::FONT_NORMAL)
                 .with_align(Alignment::Center)
-                .with_fg(theme::FG);
+                .with_fg(theme::FG)
+                .render(target);
         });
-        self.loader.render(target)
     }
 
     pub fn set_paint_notification(&mut self) {

--- a/core/embed/rust/src/ui/layout_delizia/component/homescreen.rs
+++ b/core/embed/rust/src/ui/layout_delizia/component/homescreen.rs
@@ -582,12 +582,13 @@ impl Homescreen {
     }
 
     fn render_loader<'s>(&'s self, target: &mut impl Renderer<'s>) {
+        self.loader.render(target);
         TR::progress__locking_device.map_translated(|t| {
             shape::Text::new(TOP_CENTER + Offset::y(HOLD_Y), t, fonts::FONT_DEMIBOLD)
                 .with_align(Alignment::Center)
-                .with_fg(theme::FG);
+                .with_fg(theme::FG)
+                .render(target);
         });
-        self.loader.render(target)
     }
 
     fn event_usb(&mut self, ctx: &mut EventCtx, event: Event) {


### PR DESCRIPTION
- seems like the code was incorrectly omitting `render` and also the order was incorrect because the loader pads the whole screen

[no changelog]

<!--
For external contributors:
- Please open an issue before submitting a PR so we can discuss whether we want to proceed with it.

For core developers:
1. Initial PR setup
- Assign yourself to the PR.
- Add it to the "Firmware" project
  - Set Priority (match issue priority if it exists)
  - Set Team
  - Set Sprint (target release)

2. Development status
- Draft PRs: Set status to "In Progress"
- Final PRs: Set status to "Needs Review"

3. Post-merge status
- Testable: Set status to "Needs QA" and add a `Notes for QA` section with clear instructions on how to test the functionality.
- Not Testable: Set status to "Done (no QA)"
-->
