### PR TITLE
build(core): remove `#error` from `core/embed/upymod/qstrdefsport.h`

### DIFF
--- a/core/embed/upymod/qstrdefsport.h
+++ b/core/embed/upymod/qstrdefsport.h
@@ -3,7 +3,8 @@
 // do not edit manually!
 // fmt: off
 
-#error This header should not be part of the build, its purpose is only to add missed Qstrings
+// This header should not be part of the build, its purpose is only to add
+// missed Qstrings to MicroPython frozen Qstr pool.
 
 // explanation:
 // uPy collects string literals and symbol names from all frozen modules, and

--- a/core/embed/upymod/qstrdefsport.h.mako
+++ b/core/embed/upymod/qstrdefsport.h.mako
@@ -60,7 +60,8 @@ def make_import_qstrs(import_names):
     return sorted(import_qstrs)
 %>\
 
-#error This header should not be part of the build, its purpose is only to add missed Qstrings
+// This header should not be part of the build, its purpose is only to add
+// missed Qstrings to MicroPython frozen Qstr pool.
 
 // explanation:
 // uPy collects string literals and symbol names from all frozen modules, and


### PR DESCRIPTION
Otherwise, every build emits the following unhelpful message during `PreprocessQstr` step:
```
<stdin>:5279:2: error: #error This header should not be part of the build, its purpose is only to add missed Qstrings
```

Since [generated `qstrdefsport.h` file](https://github.com/trezor/trezor-firmware/blob/main/core/embed/upymod/qstrdefsport.h) doesn't look as a valid C header, it should be fine to remove the `#error`.