### PR TITLE
Remove `fonttools` from `automatic_battery_tester`

### DIFF
--- a/tools/automatic_battery_tester/requirements.txt
+++ b/tools/automatic_battery_tester/requirements.txt
@@ -4,7 +4,6 @@ charset-normalizer==3.4.2
 click==8.2.1
 contourpy==1.3.2
 cycler==0.12.1
-fonttools==4.58.4
 idna==3.10
 ifaddr==0.2.0
 inquirerpy==0.3.4


### PR DESCRIPTION
This PR removes `fonttools` from `requirements.txt` for `automatic_battery_tester`.

Should fix:
https://github.com/trezor/trezor-firmware/security/dependabot/88