### PR TITLE
fix(python): use `node.fingerprint` to support older FW

### DIFF
--- a/python/.changelog.d/6580.fixed
+++ b/python/.changelog.d/6580.fixed
@@ -1,0 +1,1 @@
+Fetch root fingerprint from older firmware.

--- a/python/src/trezorlib/client.py
+++ b/python/src/trezorlib/client.py
@@ -181,8 +181,9 @@ class Session(t.Generic[ClientType, SessionIdType]):
         choice of a correct session for this operation.
         """
         resp = self.call(GET_ROOT_FINGERPRINT_MESSAGE, expect=messages.PublicKey)
-        assert resp.root_fingerprint is not None
-        root_fingerprint = resp.root_fingerprint.to_bytes(4, "big")
+        # resp.root_fingerprint is not available on <1.9.4 & <2.3.5
+        assert resp.node.fingerprint is not None
+        root_fingerprint = resp.node.fingerprint.to_bytes(4, "big")
         if self._root_fingerprint is None:
             self._root_fingerprint = root_fingerprint
         assert self._root_fingerprint == root_fingerprint

--- a/python/src/trezorlib/protocol_v1.py
+++ b/python/src/trezorlib/protocol_v1.py
@@ -25,7 +25,7 @@ import warnings
 
 import typing_extensions as tx
 
-from . import client, exceptions, mapping, messages, models
+from . import client, exceptions, mapping, messages
 from .log import DUMP_BYTES
 from .thp import pairing
 from .tools import enter_context
@@ -198,16 +198,12 @@ class SessionV1(client.Session["TrezorClientV1", t.Optional[bytes]]):
             # Looks like the session is already initialized. Bail out.
             raise exceptions.PassphraseError("Failed to activate passphrase session")
 
-        # after processing any PassphraseRequest, we should have an Address response
+        # after processing any PassphraseRequest, we should have an PublicKey response
         resp = messages.PublicKey.ensure_isinstance(resp)
 
-        # `root_fingerprint` is not available on older models.
-        min_version = (1, 9, 4) if self.model is models.T1B1 else (2, 3, 5)
-        if self.version >= min_version:
-            assert resp.root_fingerprint is not None
-            self._root_fingerprint = resp.root_fingerprint.to_bytes(4, "big")
-        else:
-            warnings.warn("Your Trezor firmware does not support root fingerprint.")
+        # resp.root_fingerprint is not available on <1.9.4 & <2.3.5
+        assert resp.node.fingerprint is not None
+        self._root_fingerprint = resp.node.fingerprint.to_bytes(4, "big")
 
         self.client.refresh_features()
 


### PR DESCRIPTION
`PublicKey.root_fingerprint` support was added in:
```
* 5728f54b78 Pavol Rusnak:  core: return root_fingerprint in PublicKey (5 years ago)
* 4d45a68fd0 Pavol Rusnak:  legacy: return root_fingerprint in PublicKey (5 years ago)
```

Found in https://github.com/spesmilo/electrum/pull/10465#discussion_r2896876731.

<!--
For external contributors:
- Please open an issue before submitting a PR so we can discuss whether we want to proceed with it.

For core developers:
1. Initial PR setup
- Assign yourself to the PR.
- Add it to the "Firmware" project
  - Set Priority (match issue priority if it exists)
  - Set Team
  - Set Sprint (target release)

2. Development status
- Draft PRs: Set status to "In Progress"
- Final PRs: Set status to "Needs Review"

3. Post-merge status
- Testable: Set status to "Needs QA" and add a `Notes for QA` section with clear instructions on how to test the functionality.
- Not Testable: Set status to "Done (no QA)"
-->

## Notes to QA

If possible, please also test `trezorctl` from this PR with older FWs:
 - Core <2.3.5
 - Legacy <1.9.4
 
```
trezorctl get-features
trezorctl ping
trezorctl device setup
trezorctl device recover
trezorctl btc get-public-node -n 'm/0h'
```