### PR TITLE
overwrite sd card salt with random data before unlinking

### DIFF
--- a/core/src/storage/sd_salt.py
+++ b/core/src/storage/sd_salt.py
@@ -85,7 +85,14 @@ def load_sd_salt() -> bytearray | None:
 
     # Normal salt file does not exist, but new salt file exists. That means that
     # SD salt regeneration was interrupted earlier. Bring into consistent state.
-    # TODO Possibly overwrite salt file with random data.
+    # Overwrite salt file with random data before unlinking to prevent recovery.
+    try:
+        from trezor.crypto import random
+
+        with fatfs.open(salt_path, "w") as f:
+            f.write(random.bytes(SD_SALT_LEN_BYTES + _SD_SALT_AUTH_TAG_LEN_BYTES))
+    except fatfs.FatFSError:
+        pass
     try:
         fatfs.unlink(salt_path)
     except fatfs.FatFSError:
@@ -122,5 +129,12 @@ def commit_sd_salt() -> None:
 @with_filesystem
 def remove_sd_salt() -> None:
     salt_path = _get_salt_path()
-    # TODO Possibly overwrite salt file with random data.
+    # Overwrite salt file with random data before unlinking to prevent recovery.
+    try:
+        from trezor.crypto import random
+
+        with fatfs.open(salt_path, "w") as f:
+            f.write(random.bytes(SD_SALT_LEN_BYTES + _SD_SALT_AUTH_TAG_LEN_BYTES))
+    except fatfs.FatFSError:
+        pass
     fatfs.unlink(salt_path)

--- a/core/src/storage/sd_salt.py
+++ b/core/src/storage/sd_salt.py
@@ -22,6 +22,23 @@ class WrongSdCard(Exception):
     pass
 
 
+def _secure_overwrite(path: str) -> None:
+    """Overwrite a salt file with random data before deletion.
+
+    Best-effort: if the overwrite fails (e.g. card removed),
+    we still proceed with the unlink.
+    """
+    from trezor.crypto import random
+
+    try:
+        with fatfs.open(path, "w") as f:
+            f.write(
+                random.bytes(SD_SALT_LEN_BYTES + _SD_SALT_AUTH_TAG_LEN_BYTES, strong=True)
+            )
+    except fatfs.FatFSError:
+        pass
+
+
 def is_enabled() -> bool:
     return storage.device.get_sd_salt_auth_key() is not None
 
@@ -86,13 +103,7 @@ def load_sd_salt() -> bytearray | None:
     # Normal salt file does not exist, but new salt file exists. That means that
     # SD salt regeneration was interrupted earlier. Bring into consistent state.
     # Overwrite salt file with random data before unlinking to prevent recovery.
-    try:
-        from trezor.crypto import random
-
-        with fatfs.open(salt_path, "w") as f:
-            f.write(random.bytes(SD_SALT_LEN_BYTES + _SD_SALT_AUTH_TAG_LEN_BYTES))
-    except fatfs.FatFSError:
-        pass
+    _secure_overwrite(salt_path)
     try:
         fatfs.unlink(salt_path)
     except fatfs.FatFSError:
@@ -130,11 +141,5 @@ def commit_sd_salt() -> None:
 def remove_sd_salt() -> None:
     salt_path = _get_salt_path()
     # Overwrite salt file with random data before unlinking to prevent recovery.
-    try:
-        from trezor.crypto import random
-
-        with fatfs.open(salt_path, "w") as f:
-            f.write(random.bytes(SD_SALT_LEN_BYTES + _SD_SALT_AUTH_TAG_LEN_BYTES))
-    except fatfs.FatFSError:
-        pass
+    _secure_overwrite(salt_path)
     fatfs.unlink(salt_path)


### PR DESCRIPTION
## what this fixes

the sd salt files used for pin derivation were deleted via `fatfs.unlink()` without first overwriting the data. on a FAT filesystem, unlink only removes the directory entry — the actual data sectors remain on the sd card until overwritten by new files. an attacker with physical access to the sd card could recover the old salt using forensic tools, weakening one layer of the multi-factor pin protection.

this was flagged by two TODO comments in the code (`"Possibly overwrite salt file with random data"`). implemented the overwrite with random bytes before each unlink call. wrapped in try/except since the unlink should still proceed even if the overwrite fails for some reason.

## testing
this affects the sd card salt removal path, which is exercised when changing or removing the sd card salt. the overwrite uses the same `fatfs` api already used throughout the file.