### PR TITLE
fix(core): correct device menu refresh mechanism

### DIFF
--- a/core/.changelog.d/6589.fixed
+++ b/core/.changelog.d/6589.fixed
@@ -1,0 +1,1 @@
+[T3W1] Fix device menu refresh on BLE-related events.

--- a/core/src/apps/homescreen/device_menu.py
+++ b/core/src/apps/homescreen/device_menu.py
@@ -164,14 +164,14 @@ async def handle_device_menu() -> None:
             raise RuntimeError(f"Unknown menu {menu_result}")
 
         action, arg, parent_submenu_idx = menu_result
-        handler = _MENU_HANDLERS.get(action)
-        if not handler:
-            raise RuntimeError(f"Unknown menu {menu_result}")
-
         # special handling
         if action == DeviceMenuResult.RefreshMenu:
             init_submenu_idx = arg
             continue
+
+        handler = _MENU_HANDLERS.get(action)
+        if not handler:
+            raise RuntimeError(f"Unknown menu {menu_result}")
 
         try:
             if arg is None:


### PR DESCRIPTION
Otherwise, BLE disconnection causes the device menu to terminate with:
```
[20:03:31.948] 1208.772 trezor.ui DBG ButtonRequest task not started, <Msg> ignored
[20:04:03.952] 1240.776 trezor.ui DBG BLE event: (1, None), state: connected
[20:04:03.953] 1240.777 trezor.ui DBG UI task was stopped: <generator object '_handle_button_events' at 0x201cffe0>
[20:04:03.953] 1240.777 trezor.ui DBG UI task was stopped: <generator object '_handle_touch_events' at 0x201d00b0>
[20:04:03.954] 1240.778 trezor.ui DBG UI task was stopped: <generator object '_handle_power_manager' at 0x201d0190>
[20:04:04.105] 1240.929 trezor.loop DBG finish: <generator object '_handle_ble_events' at 0x201d0120>
[20:04:04.105] 1240.929 trezor.ui DBG UI task exited by itself: <generator object '_handle_ble_events' at 0x201d0120>
[20:04:04.106] 1240.930 trezor.loop ERR exception:
[20:04:04.106] Traceback (most recent call last):
[20:04:04.106]   File "trezor/loop.py", in _step
[20:04:04.106]   File "apps/homescreen/__init__.py", in homescreen
[20:04:04.106]   File "apps/homescreen/device_menu.py", in handle_device_menu
[20:04:04.106] RuntimeError: Unknown menu (22, 1, 0)
[20:04:04.107] 1240.930 trezor.workflow DBG default closed: <generator object 'homescreen' at 0x201c9d10>
[20:04:04.107] 1240.931 trezor.loop DBG spawn new task: <generator object 'homescreen' at 0x201d1420>
```

## Notes to QA:
- Pair TS7 with Suite via BLE.
- Disable BLE via device menu
- Make sure the device is not closed: https://github.com/trezor/trezor-firmware/issues/6211#issue-3693809679
- The menu should show the correct BLE state.
