### PR TITLE
chore: suppress black's warning when run locally

### DIFF
--- a/.github/workflows/prebuild.yml
+++ b/.github/workflows/prebuild.yml
@@ -42,7 +42,7 @@ jobs:
           git submodule update --init --recursive vendor/ts-tvl
       - uses: ./.github/actions/environment
       - name: "Run style check"
-        run: nix-shell --run "uv run make style_check"
+        run: nix-shell --run "uv run make style_check BLACK_FAST=0"
       - name: "Run .editorconfig check"
         run: nix-shell --run "uv run make editor_check"
 

--- a/Makefile
+++ b/Makefile
@@ -9,6 +9,15 @@ PY_FILES = $(shell find . -type f -name '*.py'   | sed 'sO^\./OO' | grep -f ./to
 C_FILES =  $(shell find . -type f -name '*.[ch]' | grep -f ./tools/style.c.include  | grep -v -f ./tools/style.c.exclude )
 PROTO_FILES = $(shell find common core -type f -name '*.proto')
 
+# suppress black's warning - remove when using Python 3.14
+BLACK_FAST ?= 1
+
+ifeq ($(BLACK_FAST),1)
+BLACK_FLAGS=--fast
+else
+BLACK_FLAGS=
+endif
+
 style_check: pystyle_check ruststyle_check cstyle_check protostyle_check changelog_check translations_style_check yaml_check docs_summary_check editor_check ## run all style checks
 
 style: pystyle ruststyle cstyle protostyle changelog_style translations_style ## apply all code styles (Python+Rust+C+protobuf+changelog+translation JSON)
@@ -28,22 +37,22 @@ pystyle_check: ## run code style check on application sources and tests
 	@echo [ISORT]
 	@isort --check-only $(PY_FILES)
 	@echo [BLACK]
-	@black --check $(PY_FILES)
+	@black --check $(BLACK_FLAGS) $(PY_FILES)
 	@echo [PYLINT]
 	@pylint $(PY_FILES)
 	@echo [PYTHON]
-	make -C python style_check
+	make -C python style_check BLACK_FLAGS=$(BLACK_FLAGS)
 
 pystyle_quick_check: ## run the basic style checks, suitable for a quick git hook
 	@isort --check-only $(PY_FILES)
-	@black --check $(PY_FILES)
-	make -C python style_quick_check
+	@black --check $(BLACK_FLAGS) $(PY_FILES)
+	make -C python style_quick_check BLACK_FLAGS=$(BLACK_FLAGS)
 
 pystyle: ## apply code style on application sources and tests
 	@echo [ISORT]
 	@isort $(PY_FILES)
 	@echo [BLACK]
-	@black $(PY_FILES)
+	@black $(BLACK_FLAGS) $(PY_FILES)
 	@echo [TYPECHECK]
 	@make -C core typecheck
 	@echo [TYPECHECK - COMMON and TOOLS]
@@ -53,7 +62,7 @@ pystyle: ## apply code style on application sources and tests
 	@echo [PYLINT]
 	@pylint $(PY_FILES)
 	@echo [PYTHON]
-	make -C python style
+	make -C python style BLACK_FLAGS=$(BLACK_FLAGS)
 
 changelog_check: ## check changelog format
 	@echo [CHANGELOG-CHECK]

--- a/python/Makefile
+++ b/python/Makefile
@@ -4,6 +4,9 @@ UV=uv
 EXCLUDES=.vscode
 STYLE_TARGETS=src tests tools helper-scripts
 
+# suppress black's warning
+BLACK_FLAGS ?=--fast
+
 dist: doc clean
 	$(UV) build
 
@@ -35,20 +38,20 @@ git-clean:
 	git clean -dfx -e $(EXCLUDES)
 
 style:
-	black $(STYLE_TARGETS)
+	black $(BLACK_FLAGS) $(STYLE_TARGETS)
 	isort $(STYLE_TARGETS)
 	autoflake -i --remove-all-unused-imports -r $(STYLE_TARGETS)
 	flake8
 	make pyright
 
 style_check:
-	black --check $(STYLE_TARGETS)
+	black --check $(BLACK_FLAGS) $(STYLE_TARGETS)
 	isort --check-only $(STYLE_TARGETS)
 	flake8
 	make pyright
 
 style_quick_check:
-	black --check $(STYLE_TARGETS)
+	black --check $(BLACK_FLAGS) $(STYLE_TARGETS)
 	isort --check-only $(STYLE_TARGETS)
 
 .PHONY: all build install clean style style_check git-clean clean-build clean-pyc clean-test


### PR DESCRIPTION
Update of `black` to 26.3.1 results in the following warning:
<img width="2109" height="136" alt="Screenshot from 2026-03-17 12-53-08" src="https://github.com/user-attachments/assets/9d20fd69-c5f3-496a-a543-ae2368b48364" />

~~This PR suppresses the warning by setting the `black`'s target python version to 3.13.~~

EDIT: This PR now suppresses the warning by using `--fast` flag - skipping all safety checks. The safety checks are still enabled in CI style check.

The safety checks can be enabled in local runs by using `BLACK_FAST=0` when calling make style commands (e.g. `make style_check BLACK_FAST=0`)

Note: No QA needed.