### PR TITLE
ci(core): report debuglink/normal artifact sizes separately

### DIFF
--- a/.github/workflows/core.yml
+++ b/.github/workflows/core.yml
@@ -697,10 +697,16 @@ jobs:
       - uses: actions/download-artifact@70fc10c6e5e1ce46ad2ea6f2b72d43f7d47b13c3  # actions/download-artifact@v8.0.0
         with:
           pattern: core-firmware-*
-          path: core/build
-          merge-multiple: true
+          path: artifacts
       - run: |
-          (echo '```'; find core/build/ -name '*-*-*.bin' -printf "%-40f %10s\n" | sort; echo '```') >> $GITHUB_STEP_SUMMARY
+          for build_type in normal debuglink
+          do
+            (echo '##' ${build_type}; \
+             echo '```'; \
+             find artifacts/core-firmware-*-${build_type}/ -name '*-*-*.bin' -printf "%-40f %10s\n" | sort; \
+             echo '```') >> $GITHUB_STEP_SUMMARY
+          done
+
 
   core_ui_comment:
     name: Post comment with UI diff URLs


### PR DESCRIPTION
https://github.com/trezor/trezor-firmware/pull/6562 was overwriting debuglink & normal binaries due to `merge-multiple: true`.

An example run: https://github.com/trezor/trezor-firmware/actions/runs/23248096287#summary-67583589501

<!--
For external contributors:
- Please open an issue before submitting a PR so we can discuss whether we want to proceed with it.

For core developers:
1. Initial PR setup
- Assign yourself to the PR.
- Add it to the "Firmware" project
  - Set Priority (match issue priority if it exists)
  - Set Team
  - Set Sprint (target release)

2. Development status
- Draft PRs: Set status to "In Progress"
- Final PRs: Set status to "Needs Review"

3. Post-merge status
- Testable: Set status to "Needs QA" and add a `Notes for QA` section with clear instructions on how to test the functionality.
- Not Testable: Set status to "Done (no QA)"
-->
