### PR TITLE
fix(python): skip pairing when auto-connected after unlocking

### DIFF
--- a/python/.changelog.d/6633.fixed
+++ b/python/.changelog.d/6633.fixed
@@ -1,0 +1,1 @@
+Fix THP auto-connection after unlocking the device.

--- a/python/src/trezorlib/thp/pairing.py
+++ b/python/src/trezorlib/thp/pairing.py
@@ -385,6 +385,9 @@ def default_pairing_flow(
     code_entry_callback: t.Callable[[], str] | None = None,
     request_credential: bool = True,
 ) -> Credential | None:
+    # make sure a channel has been established
+    pairing.client.connect()
+    # no need to pair if auto-connected
     if pairing.is_paired():
         return
 


### PR DESCRIPTION
Fixes #6633.

## Notes to QA:
Let's make sure https://github.com/trezor/trezor-firmware/issues/6633 doesn't reproduce.


<!--
For external contributors:
- Please open an issue before submitting a PR so we can discuss whether we want to proceed with it.

For core developers:
1. Initial PR setup
- Assign yourself to the PR.
- Add it to the "Firmware" project
  - Set Priority (match issue priority if it exists)
  - Set Team
  - Set Sprint (target release)

2. Development status
- Draft PRs: Set status to "In Progress"
- Final PRs: Set status to "Needs Review"

3. Post-merge status
- Testable: Set status to "Needs QA" and add a `Notes for QA` section with clear instructions on how to test the functionality.
- Not Testable: Set status to "Done (no QA)"
-->
