### PR TITLE
fix(core): ignore unexpected messages in backup flow during setup

### DIFF
--- a/core/src/apps/management/reset_device/__init__.py
+++ b/core/src/apps/management/reset_device/__init__.py
@@ -40,7 +40,7 @@ async def reset_device(msg: ResetDevice) -> Success:
         prompt_backup,
         show_wallet_created_success,
     )
-    from trezor.wire.context import call, try_get_ctx_ids
+    from trezor.wire.context import call, continue_on_errors, try_get_ctx_ids
 
     from apps.common.request_pin import request_pin_confirm
 
@@ -125,13 +125,14 @@ async def reset_device(msg: ResetDevice) -> Success:
 
     # generate and display backup information for the master secret
     if perform_backup:
-        # choose backup handler (prompt the user if method is `None`)
-        handler = await layout.choose_backup_handler(msg.backup_method)
-        await backup_seed(
-            handler=handler,
-            backup_type=backup_type,
-            mnemonic_secret=secret,
-        )
+        with continue_on_errors("Backup in progress"):
+            # choose backup handler (prompt the user if method is `None`)
+            handler = await layout.choose_backup_handler(msg.backup_method)
+            await backup_seed(
+                handler=handler,
+                backup_type=backup_type,
+                mnemonic_secret=secret,
+            )
 
     # write settings and master secret into storage
     if msg.label is not None:

--- a/tests/device_tests/reset_recovery/test_reset_bip39_t2.py
+++ b/tests/device_tests/reset_recovery/test_reset_bip39_t2.py
@@ -25,19 +25,34 @@ from trezorlib.exceptions import TrezorFailure
 
 from ...common import EXTERNAL_ENTROPY, MNEMONIC12, MOCK_GET_ENTROPY, generate_entropy
 from ...input_flows import (
+    FlowAdapter,
     InputFlowBip39ResetBackup,
     InputFlowBip39ResetFailedCheck,
     InputFlowBip39ResetPIN,
+    normal,
+    try_to_cancel,
 )
 
 pytestmark = pytest.mark.models("core")
 
+FLOW_ADAPTERS = [
+    normal,
+    try_to_cancel(
+        {
+            "setup_device",
+            "confirm_setup_device",
+            "backup_device",
+            "success_backup",
+        }
+    ),
+]
 
-def reset_device(session: Session, strength: int):
+
+def reset_device(session: Session, strength: int, adapt_flow: FlowAdapter):
     debug = session.debug
     with session.test_ctx as client:
         IF = InputFlowBip39ResetBackup(session)
-        client.set_input_flow(IF.get())
+        client.set_input_flow(adapt_flow(session, IF.get()))
 
         # No PIN, no passphrase, don't display random
         device.setup(
@@ -76,13 +91,15 @@ def reset_device(session: Session, strength: int):
 
 
 @pytest.mark.setup_client(uninitialized=True)
-def test_reset_device(session: Session):
-    reset_device(session, 128)  # 12 words
+@pytest.mark.parametrize("adapt_flow", FLOW_ADAPTERS, ids=lambda f: f.__name__)
+def test_reset_device(session: Session, adapt_flow: FlowAdapter):
+    reset_device(session, 128, adapt_flow)  # 12 words
 
 
 @pytest.mark.setup_client(uninitialized=True)
-def test_reset_device_192(session: Session):
-    reset_device(session, 192)  # 18 words
+@pytest.mark.parametrize("adapt_flow", FLOW_ADAPTERS, ids=lambda f: f.__name__)
+def test_reset_device_192(session: Session, adapt_flow: FlowAdapter):
+    reset_device(session, 192, adapt_flow)  # 18 words
 
 
 @pytest.mark.setup_client(uninitialized=True)

--- a/tests/device_tests/reset_recovery/test_reset_slip39_advanced.py
+++ b/tests/device_tests/reset_recovery/test_reset_slip39_advanced.py
@@ -23,21 +23,32 @@ from trezorlib.exceptions import TrezorFailure
 from trezorlib.messages import BackupAvailability, BackupType
 
 from ...common import EXTERNAL_ENTROPY, MOCK_GET_ENTROPY, generate_entropy
-from ...input_flows import InputFlowSlip39AdvancedResetRecovery
+from ...input_flows import (
+    FlowAdapter,
+    InputFlowSlip39AdvancedResetRecovery,
+    normal,
+    try_to_cancel,
+)
 
 pytestmark = pytest.mark.models("core")
+
+FLOW_ADAPTERS = [
+    normal,
+    try_to_cancel({"backup_device", "setup_device", "success_backup"}),
+]
 
 
 # TODO: test with different options
 @pytest.mark.setup_client(uninitialized=True)
-def test_reset_device_slip39_advanced(client: Client):
+@pytest.mark.parametrize("adapt_flow", FLOW_ADAPTERS, ids=lambda f: f.__name__)
+def test_reset_device_slip39_advanced(client: Client, adapt_flow: FlowAdapter):
     strength = 128
     member_threshold = 3
 
     session = client.get_seedless_session()
     with session.test_ctx as client:
         IF = InputFlowSlip39AdvancedResetRecovery(client, False)
-        client.set_input_flow(IF.get())
+        client.set_input_flow(adapt_flow(session, IF.get()))
         # No PIN, no passphrase, don't display random
         device.setup(
             session,

--- a/tests/device_tests/reset_recovery/test_reset_slip39_basic.py
+++ b/tests/device_tests/reset_recovery/test_reset_slip39_basic.py
@@ -26,17 +26,27 @@ from trezorlib.exceptions import TrezorFailure
 from trezorlib.messages import BackupAvailability, BackupType
 
 from ...common import EXTERNAL_ENTROPY, MOCK_GET_ENTROPY, generate_entropy
-from ...input_flows import InputFlowSlip39BasicResetRecovery
+from ...input_flows import (
+    FlowAdapter,
+    InputFlowSlip39BasicResetRecovery,
+    normal,
+    try_to_cancel,
+)
 
 pytestmark = pytest.mark.models("core")
 
+FLOW_ADAPTERS = [
+    normal,
+    try_to_cancel({"backup_device", "setup_device", "success_backup"}),
+]
 
-def reset_device(session: Session, strength: int):
+
+def reset_device(session: Session, strength: int, adapt_flow: FlowAdapter):
     member_threshold = 3
 
     with session.test_ctx as client:
         IF = InputFlowSlip39BasicResetRecovery(session)
-        client.set_input_flow(IF.get())
+        client.set_input_flow(adapt_flow(session, IF.get()))
 
         # No PIN, no passphrase, don't display random
         device.setup(
@@ -71,24 +81,27 @@ def reset_device(session: Session, strength: int):
 
 
 @pytest.mark.setup_client(uninitialized=True)
-def test_reset_device_slip39_basic(session: Session):
-    reset_device(session, 128)
+@pytest.mark.parametrize("adapt_flow", FLOW_ADAPTERS, ids=lambda f: f.__name__)
+def test_reset_device_slip39_basic(session: Session, adapt_flow: FlowAdapter):
+    reset_device(session, 128, adapt_flow)
+
+
+@pytest.mark.parametrize("adapt_flow", FLOW_ADAPTERS, ids=lambda f: f.__name__)
+@pytest.mark.setup_client(uninitialized=True)
+def test_reset_device_slip39_basic_256(session: Session, adapt_flow: FlowAdapter):
+    reset_device(session, 256, adapt_flow)
 
 
 @pytest.mark.setup_client(uninitialized=True)
-def test_reset_device_slip39_basic_256(session: Session):
-    reset_device(session, 256)
-
-
-@pytest.mark.setup_client(uninitialized=True)
-def test_reset_entropy_check(session: Session):
+@pytest.mark.parametrize("adapt_flow", FLOW_ADAPTERS, ids=lambda f: f.__name__)
+def test_reset_entropy_check(session: Session, adapt_flow: FlowAdapter):
     member_threshold = 3
 
     strength = 128  # 20 words
 
     with session.test_ctx as client:
         IF = InputFlowSlip39BasicResetRecovery(session)
-        client.set_input_flow(IF.get())
+        client.set_input_flow(adapt_flow(session, IF.get()))
 
         # No PIN, no passphrase.
         path_xpubs = device.setup(

--- a/tests/device_tests/test_msg_backup_device.py
+++ b/tests/device_tests/test_msg_backup_device.py
@@ -15,12 +15,10 @@
 # If not, see <https://www.gnu.org/licenses/lgpl-3.0.html>.
 
 import itertools
-import typing as t
 
 import pytest
 import shamir_mnemonic as shamir
 
-from tests.common import BRGeneratorType
 from trezorlib import device, messages, models
 from trezorlib.debuglink import DebugSession as Session
 from trezorlib.debuglink import LayoutType
@@ -35,55 +33,21 @@ from ..common import (
     MNEMONIC_SLIP39_CUSTOM_1of1,
 )
 from ..input_flows import (
+    FlowAdapter,
     InputFlowBip39Backup,
     InputFlowSlip39AdvancedBackup,
     InputFlowSlip39BasicBackup,
     InputFlowSlip39CustomBackup,
+    normal,
+    try_to_cancel,
 )
 
-BACKUP_IN_PROGRESS = messages.Failure(
-    code=messages.FailureType.InProgress,
-    message="Backup in progress",
-)
-
-
-def _normal(
-    _session: Session, flow: t.Callable[[], BRGeneratorType]
-) -> BRGeneratorType:
-    return flow()
-
-
-def _try_to_cancel(
-    session: Session, flow: t.Callable[[], BRGeneratorType]
-) -> BRGeneratorType:
-    gen = flow()
-    next(gen)
-    while True:
-        br = yield
-        # Entering session's context will send an explicit THP ACK after `BACKUP_IN_PROGRESS` is received.
-        with session.client._interact(force_flush=True):
-            # Try to cancel the backup flow on Core
-            with pytest.raises(TrezorFailure) as exc_info:
-                session.call(messages.Cancel(), expect=messages.Failure)
-            # Following #6483, backup is not cancellable
-            assert exc_info.value.failure == BACKUP_IN_PROGRESS
-        try:
-            gen.send(br)
-        except StopIteration:
-            return
-
-
-if t.TYPE_CHECKING:
-    FlowAdapter = t.Callable[
-        [Session, t.Callable[[], BRGeneratorType]], BRGeneratorType
-    ]
+FLOW_ADAPTERS = [normal, try_to_cancel()]
 
 
 @pytest.mark.models("core")  # TODO we want this for t1 too
 @pytest.mark.setup_client(needs_backup=True, mnemonic=MNEMONIC12)
-@pytest.mark.parametrize(
-    "adapt_flow", [_try_to_cancel, _normal], ids=lambda f: f.__name__
-)
+@pytest.mark.parametrize("adapt_flow", FLOW_ADAPTERS, ids=lambda f: f.__name__)
 def test_backup_bip39(session: Session, adapt_flow: "FlowAdapter"):
     assert session.features.backup_availability == messages.BackupAvailability.Required
 
@@ -103,7 +67,7 @@ def test_backup_bip39(session: Session, adapt_flow: "FlowAdapter"):
     assert session.features.backup_type is messages.BackupType.Bip39
 
 
-SLIP39_BASIC_PARAMS = list(itertools.product([True, False], [_try_to_cancel, _normal]))
+SLIP39_BASIC_PARAMS = list(itertools.product([True, False], FLOW_ADAPTERS))
 SLIP39_BASIC_IDS = [
     f"{['no_click_info', 'click_info'][click_info]}_{adapt_flow.__name__}"
     for click_info, adapt_flow in SLIP39_BASIC_PARAMS
@@ -146,9 +110,7 @@ def test_backup_slip39_basic(
 
 @pytest.mark.models("core")
 @pytest.mark.setup_client(needs_backup=True, mnemonic=MNEMONIC_SLIP39_SINGLE_EXT_20)
-@pytest.mark.parametrize(
-    "adapt_flow", [_try_to_cancel, _normal], ids=lambda f: f.__name__
-)
+@pytest.mark.parametrize("adapt_flow", FLOW_ADAPTERS, ids=lambda f: f.__name__)
 def test_backup_slip39_single(session: Session, adapt_flow: "FlowAdapter"):
     assert session.features.backup_availability == messages.BackupAvailability.Required
 
@@ -175,9 +137,7 @@ def test_backup_slip39_single(session: Session, adapt_flow: "FlowAdapter"):
     )
 
 
-SLIP39_ADVANCED_PARAMS = list(
-    itertools.product([True, False], [_try_to_cancel, _normal])
-)
+SLIP39_ADVANCED_PARAMS = list(itertools.product([True, False], FLOW_ADAPTERS))
 SLIP39_ADVANCED_IDS = [
     f"{['no_click_info', 'click_info'][click_info]}_{adapt_flow.__name__}"
     for click_info, adapt_flow in SLIP39_ADVANCED_PARAMS
@@ -223,7 +183,7 @@ def test_backup_slip39_advanced(
 SLIP39_CUSTOM_PARAMS = [
     (threshold, count, adapt_flow)
     for threshold, count in ((1, 1), (2, 2), (3, 5))
-    for adapt_flow in (_try_to_cancel, _normal)
+    for adapt_flow in FLOW_ADAPTERS
 ]
 SLIP39_CUSTOM_IDS = [
     f"{threshold}_of_{count}_{adapt_flow.__name__}"

--- a/tests/input_flows.py
+++ b/tests/input_flows.py
@@ -14,11 +14,14 @@ from __future__ import annotations
 import time
 from typing import Callable, Generator, Sequence
 
+import pytest
+
 from trezorlib import messages
 from trezorlib.client import Session
 from trezorlib.debuglink import DebugLink, DebugSession, LayoutContent, LayoutType
 from trezorlib.debuglink import TrezorTestContext as Client
 from trezorlib.debuglink import multipage_content
+from trezorlib.exceptions import TrezorFailure
 
 from . import translations as TR
 from .common import (
@@ -34,6 +37,8 @@ from .common import (
 from .input_flows_helpers import BackupFlow, EthereumFlow, PinFlow, RecoveryFlow
 
 B = messages.ButtonRequestType
+
+FlowAdapter = Callable[[Session, Callable[[], BRGeneratorType]], BRGeneratorType]
 
 
 class InputFlowBase:
@@ -3181,3 +3186,47 @@ class InputFlowCancelBrightness(InputFlowBase):
     def input_flow_delizia(self):
         yield
         self.debug.click(self.debug.screen_buttons.menu())
+
+
+# InputFlow adaptors
+
+
+def normal(_session: Session, flow: Callable[[], BRGeneratorType]) -> BRGeneratorType:
+    return flow()
+
+
+def try_to_cancel(skip_cancel: set[str] | None = None) -> FlowAdapter:
+    BACKUP_IN_PROGRESS = messages.Failure(
+        code=messages.FailureType.InProgress,
+        message="Backup in progress",
+    )
+
+    if skip_cancel is None:
+        skip_cancel = set()
+
+    def _try_to_cancel(
+        session: Session, flow: Callable[[], BRGeneratorType]
+    ) -> BRGeneratorType:
+        gen = flow()
+        next(gen)
+        cancels = 0
+        while True:
+            br = yield
+
+            # Don't cancel if the button request appears in `skip_cancel`
+            if br.name not in skip_cancel:
+                # Entering session's context will send an explicit THP ACK after `BACKUP_IN_PROGRESS` is received.
+                with session.client._interact(force_flush=True):
+                    # Try to cancel the backup flow on Core
+                    with pytest.raises(TrezorFailure) as exc_info:
+                        session.call(messages.Cancel(), expect=messages.Failure)
+                    # Following #6483, backup is not cancellable
+                    assert exc_info.value.failure == BACKUP_IN_PROGRESS
+                    cancels += 1
+            try:
+                gen.send(br)
+            except StopIteration:
+                assert cancels > 0
+                return
+
+    return _try_to_cancel


### PR DESCRIPTION
Similar to https://github.com/trezor/trezor-firmware/pull/6483 (backup should not fail due to unexpected messages from host), but for [`ResetDevice`](https://github.com/trezor/trezor-firmware/blob/c17fd1dc60db4a9f9d37d7ca078941901c86890a/common/protob/messages-management.proto#L449)-based backup, which is being used in https://github.com/trezor/trezor-suite/pull/25084.

Related to https://github.com/trezor/trezor-firmware/issues/6348.

CC: @STew790 

This PR doesn't solve I/O error handling (i.e. ButtonRequest write errors due to dead host) -> should be done in #6651.

## TODOs:

- [x] improve cancellation test coverage

## Note to QA:

Please test on both v1 & THP (e.g. TS5 & TS7):

- run `trezorctl device setup -b single` (single-share SLIP-39 wallet).
- exit `trezorctl` with Ctrl+C when the first mnemonic words are shown.
 - it should fail with:
```
Please confirm action on your Trezor device.
^CFailed to end session: InProgress: Backup in progress

Aborted!
```  
- try to run `trezorctl ping 123` 
  - the backup flow MUST NOT be interrupted.
  - `trezorctl` should fail with:
```
Failed to connect: UnexpectedMessageError (Expected Features but Trezor sent <Failure: {'code': <FailureType.InProgress: 19>, 'message': 'Backup in progress'}>)
```  
- complete the backup and the quiz - the flow should succeed even with disconnected host.
  - it is expected to show `"Your Trezor is having trouble communicating with your connected device."` warning after the backup succeeds.
  - it can be dismissed by calling `trezorctl ping 123`
  - the device should be correctly initialized.