### PR TITLE
fix(core): continue backup workflow even after I/O errors & timeouts

### DIFF
--- a/core/.changelog.d/6348.fixed
+++ b/core/.changelog.d/6348.fixed
@@ -1,0 +1,1 @@
+Avoid failing backup flow on I/O errors.

--- a/core/embed/rust/src/ui/layout_delizia/ui_firmware.rs
+++ b/core/embed/rust/src/ui/layout_delizia/ui_firmware.rs
@@ -1271,7 +1271,7 @@ impl FirmwareUI for UIDelizia {
                 Frame::with_header(header, content)
             }
         };
-        let frame = if danger {
+        let frame = if danger || title.is_none() {
             frame.with_tap_footer(action)
         } else {
             frame.with_swipeup_footer(action)

--- a/core/src/trezor/ui/__init__.py
+++ b/core/src/trezor/ui/__init__.py
@@ -52,9 +52,6 @@ _REQUEST_ANIMATION_FRAME = const(1)
 See `trezor::ui::layout::base::EventCtx::ANIM_FRAME_TIMER`.
 """
 
-_UNRESPONSIVE_WARNING_TIMEOUT_MS = const(2000)
-
-
 # allow only one alert at a time to avoid alerts overlapping
 _alert_in_progress = False
 
@@ -82,14 +79,6 @@ def alert(count: int = 3) -> None:
 
         _alert_in_progress = True
         loop.schedule(_alert(count))
-
-
-async def _waiting_screen() -> None:
-    from trezor import TR
-    from trezor.ui.layouts import show_wait_text
-
-    await loop.sleep(_UNRESPONSIVE_WARNING_TIMEOUT_MS)
-    show_wait_text(TR.words__comm_trouble)
 
 
 class Shutdown(Exception):
@@ -282,7 +271,7 @@ class Layout(Generic[T]):
             if br_handler is not None:
                 # Make sure ButtonRequest is ACKed, before the result is returned.
                 # Otherwise, THP channel may become desynced (due to two consecutive writes).
-                await br_handler.join(_waiting_screen())
+                await br_handler.join()
 
             return result
         finally:
@@ -342,8 +331,7 @@ class Layout(Generic[T]):
             return False
 
         br = ButtonRequest(code=msg[0], name=msg[1], pages=self.layout.page_count())
-        self.button_request_handler.put(br)
-        return True
+        return self.button_request_handler.put(br)
 
     def _paint(self) -> None:
         """Paint the layout and ensure that homescreen cache is properly invalidated."""

--- a/core/src/trezor/wire/protocol_common.py
+++ b/core/src/trezor/wire/protocol_common.py
@@ -157,7 +157,13 @@ async def _waiting_screen(raise_on_cancel: type[Exception] | None) -> None:
     ) as obj:
         # Block until the user confirmation.
         # Don't use `interact` to avoid cancelling current workflow.
-        await Layout(obj).get_result()
+        layout = Layout(obj)
+        layout.start()
+        # This task doesn't have access to I/O context - see `ButtonRequestHandler.join()`.
+        # Therefore, the new layout won't start its own ButtonRequest handler,
+        # avoiding interference with the existing layout (the one we are waiting for).
+        assert layout.button_request_handler is None
+        await layout.get_result()
 
     if raise_on_cancel:
         raise raise_on_cancel()
@@ -218,6 +224,7 @@ class ButtonRequestHandler:
         self.box.put(None, replace=True)
 
         # Wait for the ButtonRequest handler to finish (or user cancellation)
+        # `_waiting_screen` layout won't have an I/O context, since it runs in a separate task.
         await loop.race(self.is_done, _waiting_screen(self.raise_on_cancel))
 
     async def _handle(self, ack_callback: AckCallback) -> None:

--- a/core/src/trezor/wire/protocol_common.py
+++ b/core/src/trezor/wire/protocol_common.py
@@ -1,3 +1,4 @@
+from micropython import const
 from typing import TYPE_CHECKING
 
 from trezor import loop, protobuf
@@ -13,7 +14,6 @@ if TYPE_CHECKING:
         Awaitable,
         Callable,
         Container,
-        Generator,
         Literal,
         NoReturn,
         TypeVar,
@@ -131,11 +131,48 @@ class Context:
         ...
 
 
+# Show "trouble communicating" warning after 2s of "blank" screen (if ButtonRequest is not ACKed)
+_UNRESPONSIVE_WARNING_TIMEOUT_MS = const(2000)
+
+
+async def _waiting_screen(raise_on_cancel: type[Exception] | None) -> None:
+    import trezorui_api
+    from trezor import TR
+    from trezor.ui import Layout
+
+    if raise_on_cancel is not None:
+        verb = TR.buttons__abort
+        description = TR.words__comm_trouble
+    else:
+        verb = TR.buttons__continue
+        description = TR.words__comm_continue
+
+    await loop.sleep(_UNRESPONSIVE_WARNING_TIMEOUT_MS)
+    with trezorui_api.show_warning(
+        title=None,
+        description=description,
+        button=verb,
+        danger=False,
+        allow_cancel=False,
+    ) as obj:
+        # Block until the user confirmation.
+        # Don't use `interact` to avoid cancelling current workflow.
+        await Layout(obj).get_result()
+
+    if raise_on_cancel:
+        raise raise_on_cancel()
+
+
 class ButtonRequestHandler:
     """Handle button requests and unexpected messages from host."""
 
     def __init__(self, ctx: Context) -> None:
+        from trezor.wire.errors import ActionCancelled
+
         self.ctx = ctx  # used for communication with the host.
+
+        # will be raised from `self.join()` on user cancellation.
+        self.raise_on_cancel: type[ActionCancelled] | None = ActionCancelled
 
         # Receives ButtonRequest notifications from the active layout,
         # or `None` when the layout is closed.
@@ -150,7 +187,7 @@ class ButtonRequestHandler:
             # Used for detecting missing ButtonAck in debug builds.
             self.pending = False
 
-    def put(self, br: ButtonRequest) -> None:
+    def put(self, br: ButtonRequest) -> bool:
         if __debug__:
             if self.pending:
                 from . import FirmwareError
@@ -163,28 +200,25 @@ class ButtonRequestHandler:
 
         # in production, we don't want this to fail, hence replace=True
         self.box.put(br, replace=True)
+        return True
 
-    def br_task(self, ack_callback: AckCallback) -> Generator[Any, Any, None]:
+    async def br_task(self, ack_callback: AckCallback) -> None:
         assert self.is_done.is_empty()
         try:
-            yield from self._handle(ack_callback)
+            await self._handle(ack_callback)
         finally:
             # no pending I/O - mark as done, to unblock `join()`.
             self.is_done.put(None)
 
-    async def join(self, wait_task: loop.Task[None]) -> None:
+    async def join(self) -> None:
         # `br_task()` must be scheduled before joining.
 
         # notify the handler that no more button requests are expected
         # in production, we don't want this to fail, hence replace=True
         self.box.put(None, replace=True)
 
-        task = loop.spawn(wait_task)
-        try:
-            await self.is_done
-        finally:
-            assert self.is_done.is_empty()
-            task.close()
+        # Wait for the ButtonRequest handler to finish (or user cancellation)
+        await loop.race(self.is_done, _waiting_screen(self.raise_on_cancel))
 
     async def _handle(self, ack_callback: AckCallback) -> None:
         from trezor.messages import ButtonAck
@@ -214,29 +248,71 @@ class ContinueOnErrors(ButtonRequestHandler):
 
     def __init__(self, ctx: Context, msg: str) -> None:
         super().__init__(ctx)
+        self.raise_on_cancel = None  # continue on user cancellation
         self._prev_handler: ButtonRequestHandler | None = None
         self.msg = msg
+        self.ignore = False
+
+    def put(self, br: ButtonRequest) -> bool:
+        if self.ignore:
+            # Stop handling ButtonRequests in case of unexpected error.
+            if __debug__:
+                log.debug(__name__, "ButtonRequest: skipped %s (%s)", br.code, br.name)
+            return False
+
+        return super().put(br)
+
+    async def join(self) -> None:
+        if self.ignore:
+            # Stop handling ButtonRequests in case of unexpected error.
+            return
+
+        await super().join()
+
+    async def br_task(self, ack_callback: AckCallback) -> None:
+        if self.ignore:
+            # Stop handling ButtonRequests in case of unexpected error.
+            return None
+
+        return await super().br_task(ack_callback)
 
     async def _handle(self, ack_callback: AckCallback) -> None:
         """Unexpected messages will not cause the handler to fail."""
+
         from .context import UnexpectedMessageException
 
-        while True:
-            try:
-                # Exit the loop when the layout is done.
-                return await super()._handle(ack_callback)
-            except UnexpectedMessageException as exc:
-                # in case of THP channel preemption, `msg` is not set.
-                # TRANSPORT_BUSY error has been already sent by `InterfaceContext.handle_packet()`.
-                if exc.msg:
-                    from trezor.enums import FailureType
-                    from trezor.messages import Failure
+        # In case of an unexpected error, stop handling ButtonRequests till the end of this workflow.
+        # The host will be ignored, disabling host-side cancellation of this workflow.
+        success = False
+        try:
+            while True:
+                try:
+                    # Exit the loop when the layout is done.
+                    await super(ContinueOnErrors, self)._handle(ack_callback)
+                    # All is well, continue handling ButtonRequests.
+                    success = True
+                    return
+                except UnexpectedMessageException as exc:
+                    # in case of THP channel preemption, `msg` is not set.
+                    # TRANSPORT_BUSY error has been already sent by `InterfaceContext.handle_packet()`.
+                    if exc.msg:
+                        from trezor.enums import FailureType
+                        from trezor.messages import Failure
 
-                    # notify the host that the device cannot be preempted
-                    await self.ctx.write(
-                        Failure(code=FailureType.InProgress, message=self.msg)
-                    )
-                # continue receiving messages
+                        # notify the host that the device cannot be preempted
+                        await self.ctx.write(
+                            Failure(code=FailureType.InProgress, message=self.msg)
+                        )
+                    # continue receiving messages
+                except Exception as exc:
+                    if __debug__:
+                        log.error(__name__, "ButtonRequest: ignored %s", exc)
+                        log.exception(__name__, exc)
+                    # Stop handling ButtonRequests in case of unexpected error (without failing the flow)
+                    return
+        finally:
+            # Handles GeneratorExit as well (in case of task cancellation).
+            self.ignore = not success
 
     def __enter__(self) -> None:
         assert self._prev_handler is None

--- a/tests/device_tests/test_msg_delayed_ack.py
+++ b/tests/device_tests/test_msg_delayed_ack.py
@@ -13,12 +13,21 @@
 # If not, see <https://www.gnu.org/licenses/lgpl-3.0.html>.
 
 import time
+import typing as t
 
-from trezorlib import messages
+import pytest
+
+from trezorlib import device, messages
 from trezorlib.debuglink import DebugSession as Session
+from trezorlib.debuglink import LayoutType
+
+from ..common import MNEMONIC12, MOCK_GET_ENTROPY, click_through, generate_entropy
+
+if t.TYPE_CHECKING:
+    from trezorlib.debuglink import InputFlowType
 
 
-def test_delayed_ack(session: Session):
+def ping_without_ack(session: Session):
     br = session.call_raw(messages.Ping(message="delayed", button_protection=True))
     assert isinstance(br, messages.ButtonRequest)
     assert br.code == messages.ButtonRequestType.ProtectCall
@@ -27,5 +36,166 @@ def test_delayed_ack(session: Session):
     # "waiting" screen should be shown after 2 seconds on Core models
     # (following https://github.com/trezor/trezor-firmware/issues/5884)
     time.sleep(2.5)
+
+
+def test_delayed_ack(session: Session):
+    ping_without_ack(session)
+
     res = session.call_raw(messages.ButtonAck())
+    res = messages.Success.ensure_isinstance(res)
     assert res.message == "delayed"
+
+
+@pytest.mark.models("core")
+def test_abort(session: Session):
+    ping_without_ack(session)
+
+    session.debug.press_yes()
+    assert session.read() == messages.Failure(
+        code=messages.FailureType.ActionCancelled, message="Cancelled"
+    )
+    assert session.client.ping("again") == "again"
+
+
+@pytest.mark.setup_client(needs_backup=True, mnemonic=MNEMONIC12)
+@pytest.mark.models("core")
+def test_backup_no_acks(session: Session):
+    assert session.features.backup_availability == messages.BackupAvailability.Required
+
+    words = []
+    with session.test_ctx as client:
+
+        def flow() -> "InputFlowType":
+            nonlocal words
+            words = yield from _perform_backup(session)
+
+        client.set_input_flow(flow())
+        client.set_expected_responses(
+            [
+                messages.ButtonRequest,  # backup_intro
+                messages.ButtonRequest,  # backup_warning
+                messages.Success,
+                messages.Features,
+            ]
+        )
+        device.backup(session)
+
+    assert words == MNEMONIC12
+    session.refresh_features()
+    assert session.features.initialized is True
+    assert (
+        session.features.backup_availability == messages.BackupAvailability.NotAvailable
+    )
+    assert session.features.unfinished_backup is False
+    assert session.features.no_backup is False
+    assert session.features.backup_type is messages.BackupType.Bip39
+
+
+@pytest.mark.setup_client(uninitialized=True)
+@pytest.mark.models("core")
+def test_setup_no_acks(session: Session):
+    from tests.click_tests import reset
+
+    assert session.features.initialized is False
+
+    debug = session.debug
+
+    words = ""
+    with session.test_ctx as client:
+
+        setup_success: int = {
+            LayoutType.Bolt: False,
+            LayoutType.Caesar: False,
+            LayoutType.Delizia: True,
+            LayoutType.Eckhart: True,
+        }[session.layout_type]
+
+        def flow() -> "InputFlowType":
+            # confirm new wallet & first backup-related ButtonRequest
+            yield from click_through(
+                debug,
+                screens=(1 + int(setup_success)),
+                code=messages.ButtonRequestType.ResetDevice,
+            )
+
+            assert (yield).name == "backup_device"
+            debug.press_yes()
+
+            nonlocal words
+            words = yield from _perform_backup(session)
+
+        client.set_input_flow(flow())
+        client.set_expected_responses(
+            [
+                (client.is_protocol_v1(), messages.Features),
+                messages.ButtonRequest,
+                messages.EntropyRequest,
+                (setup_success, messages.ButtonRequest),
+                messages.ButtonRequest,  # backup_device
+                messages.ButtonRequest,  # backup_intro
+                messages.ButtonRequest,  # backup_warning
+                messages.Success,
+                messages.Features,
+            ]
+        )
+        device.setup(
+            session,
+            entropy_check_count=0,
+            _get_entropy=MOCK_GET_ENTROPY,
+        )
+
+    # generate secret locally
+    internal_entropy = debug.state().reset_entropy
+    assert internal_entropy is not None
+    secret = generate_entropy(128, internal_entropy, MOCK_GET_ENTROPY())
+
+    # validate that all combinations will result in the correct master secret
+    reset.validate_mnemonics([words], secret)
+
+    session.refresh_features()
+    assert session.features.initialized is True
+    assert (
+        session.features.backup_availability == messages.BackupAvailability.NotAvailable
+    )
+    assert session.features.unfinished_backup is False
+    assert session.features.no_backup is False
+    assert session.features.backup_type is messages.BackupType.Slip39_Single_Extendable
+
+
+def _perform_backup(
+    session: Session,
+) -> t.Generator[t.Any, messages.ButtonRequest, str]:
+    from tests.click_tests import reset
+
+    debug = session.debug
+
+    # Wait until the first backup-related ButtonRequest is sent
+    assert (yield).name == "backup_intro"
+    reset.confirm_read(debug)
+
+    # Don't next ACK backup-related ButtonRequest messages
+    with session.client._interact(force_flush=True):
+        # - read ButtonRequest, without sending ButtonAck back to the device
+        # - send THP-level ACK (to avoid retransmissions and assertion when sending `Success`)
+        messages.ButtonRequest.ensure_isinstance(session.read())
+
+    # proceed with backup (even if no ButtonAck)
+    reset.confirm_read(debug, middle_r=True)
+
+    # confirm warning
+    reset.confirm_read(debug, middle_r=True)
+
+    # read words
+    words = reset.read_words(debug)
+
+    # confirm words
+    reset.confirm_words(debug, words)
+
+    # confirm backup done
+    reset.confirm_read(debug)
+
+    # Your backup is done
+    if debug.layout_type is not LayoutType.Eckhart:
+        reset.confirm_read(debug)
+
+    return " ".join(words)


### PR DESCRIPTION
Related to https://github.com/trezor/trezor-firmware/pull/3686#discussion_r2362274029.

No more button requests / errors will be sent later during the backup workflow after an I/O-related error/timeout.

Host will be **ignored** until the backup workflow is over - sending the final "Success" response may fail.

Other workflows can be aborted after user cancellation on `_waiting_screen()`.

## Timeout handling

In case the button request is not ACKed for 2s, [the "trouble communicating" layout](https://www.figma.com/design/XzPdVcLsDdvJrMfzyLho5Y/GitHub--6348?node-id=8028-49&t=Gqe4fyfXxmgBVyEu-11) will allow aborting (for regular workflows) or continuing (for backup workflow).

## Notes: 
- On THP, if there is no THP ACK after 5 seconds (due to the transport being blocked by retransmissions), the device will automatically continue the backup flow - i.e. the "communication trouble" screen will be shown for at most 3 seconds (and may be even skipped if the user takes more than 5 seconds to confirm the layout whose ButtonRequest is not ACKed).

<details>

<summary> UI layouts </summary>

| Layout | Abort | Continue |
|-|-|-|
|Bolt|<img width="240" height="240" alt="image" src="https://github.com/user-attachments/assets/d63ee2bf-ffda-4ab3-a6a5-363bf636c327" />|<img width="240" height="240" alt="image" src="https://github.com/user-attachments/assets/f234eb3d-5609-46fa-ba65-145f172f2277" />
|Caesar|<img width="256" height="128" alt="image" src="https://github.com/user-attachments/assets/2d79387b-7e1a-49c3-9fdc-e42560922ee9" />|<img width="256" height="128" alt="image" src="https://github.com/user-attachments/assets/e6902ab5-dece-41fb-a7c1-02c80a7936b7" />|
|Delizia|<img width="240" height="240" alt="image" src="https://github.com/user-attachments/assets/a6f96fd9-c1fb-4373-8c3e-faf68d7dd5b4" />|<img width="240" height="240" alt="image" src="https://github.com/user-attachments/assets/f9acc53e-e022-4637-b791-d51d72e2de6c" />|
|Eckhart|<img height="260" alt="image" src="https://github.com/user-attachments/assets/98b3d09f-fbfc-4895-b4e8-99f0b03eaf23" />|<img height="260" alt="image" src="https://github.com/user-attachments/assets/ba2e9599-fce7-4360-8fb9-8d9767f6a33f" />|

</details>

## Tasks:

- [x] improve error test coverage.
- [x] test with Suite over USB/BLE.