### PR TITLE
build(core): warn when translation blob size become too high

### DIFF
--- a/core/translations/cli.py
+++ b/core/translations/cli.py
@@ -213,6 +213,12 @@ def build_all_blobs(
     signature: bytes,
     production: bool = False,
 ) -> None:
+    max_sizes = {}
+    for model in ALL_MODELS:
+        parser_output = subprocess.check_output(args=["layout_parser", model.internal_name, "ASSETS_MAXSIZE"])
+        max_sizes[model.internal_name] = int(parser_output.decode().strip())
+
+    sizes = []
     for blob in all_blobs:
         proof = translations.Proof(
             merkle_proof=merkle_tree.get_proof(blob.header_bytes),
@@ -228,8 +234,23 @@ def build_all_blobs(
         else:
             suffix = "-unsigned"
         filename = f"translation-{model}-{header.language}-{version}{suffix}.bin"
-        (HERE / filename).write_bytes(blob.build())
+        blob_bytes = blob.build()
+        (HERE / filename).write_bytes(blob_bytes)
+
+        sizes.append((filename, len(blob_bytes), model))
         LOG.info(f"Wrote {header.language} for {model} v{version}: {filename}")
+
+    for filename, size, model in sorted(sizes):
+        max_size = max_sizes[model]
+        ratio = size / max_size
+        if ratio < 0.95:
+            continue
+        elif ratio < 0.99:
+            log_fn, icon = LOG.warning, "🟡"
+        else:
+            log_fn, icon = LOG.error, "🔴"
+
+        log_fn(f"{icon} {filename} flash utilization is {ratio * 100:.1f}% (out of {max_size / 1024:.1f} kB)")
 
 
 @click.group()


### PR DESCRIPTION
When I manually tweak the thresholds, it looks like:
```
$ time make translations -C core
make: Entering directory '/home/rzeyde/src/trezor-firmware/core'
python ./translations/order.py
No new items found.
python ./translations/cli.py gen
🟡 translation-T2B1-cs-CZ-2.11.1-unsigned.bin flash utilization is 82.7% (out of 32.0 kB)
🟡 translation-T2B1-es-ES-2.11.1-unsigned.bin flash utilization is 81.4% (out of 32.0 kB)
🔴 translation-T2B1-fr-FR-2.11.1-unsigned.bin flash utilization is 93.9% (out of 32.0 kB)
🟡 translation-T2B1-pt-BR-2.11.1-unsigned.bin flash utilization is 82.2% (out of 32.0 kB)
🟡 translation-T2T1-cs-CZ-2.11.1-unsigned.bin flash utilization is 82.3% (out of 48.0 kB)
🔴 translation-T2T1-fr-FR-2.11.1-unsigned.bin flash utilization is 91.2% (out of 48.0 kB)
signatures.json is already up-to-date
make: Leaving directory '/home/rzeyde/src/trezor-firmware/core'

real	0m0.757s
user	0m0.677s
sys	0m0.080s
```