### PR TITLE
test: bitcoin change addresses handling

### DIFF
--- a/tests/device_tests/bitcoin/test_signtx.py
+++ b/tests/device_tests/bitcoin/test_signtx.py
@@ -1805,7 +1805,7 @@ def test_change_output_wrong_coin_type_is_rejected(session: Session):
     )
 
     # Change output using a DIFFERENT coin_type (1h = Testnet instead of 0h = Bitcoin).
-    # This must NOT be treated as change — the user must be asked to confirm it.
+    # This must be rejected by the device.
     out1 = messages.TxOutputType(
         address_n=parse_path("m/44h/1h/0h/1/0"),
         amount=50_248,


### PR DESCRIPTION
- test that hypothetical attack scenarios are correctly handled
- first: test that a change address belonging to a different coin type is rejected by firmware
- secondly: test that a change address belonging to a different account which is supposed to be under user's control is not treated silently but goes through a regular output confirmation

[no changelog]

<!--
For external contributors:
- Please open an issue before submitting a PR so we can discuss whether we want to proceed with it.

For core developers:
1. Initial PR setup
- Assign yourself to the PR.
- Add it to the "Firmware" project
  - Set Priority (match issue priority if it exists)
  - Set Team
  - Set Sprint (target release)

2. Development status
- Draft PRs: Set status to "In Progress"
- Final PRs: Set status to "Needs Review"

3. Post-merge status
- Testable: Set status to "Needs QA" and add a `Notes for QA` section with clear instructions on how to test the functionality.
- Not Testable: Set status to "Done (no QA)"
-->
