### PR TITLE
fix(core): don't use bridge if other transports are available

### DIFF
--- a/python/src/trezorlib/transport/__init__.py
+++ b/python/src/trezorlib/transport/__init__.py
@@ -168,13 +168,13 @@ def all_transports() -> t.Iterable[type[Transport]]:
     from .webusb import WebUsbTransport
 
     transports: tuple[type[Transport], ...] = (
-        BridgeTransport,
         HidTransport,
         UdpTransport,
         WebUsbTransport,
         BleTransport,
+        BridgeTransport,
     )
-    return set(t for t in transports if t.ENABLED)
+    return [t for t in transports if t.ENABLED]
 
 
 def enumerate_devices(


### PR DESCRIPTION
Before this PR, trezorctl was trying to connect to an available transport randomly.
If Suite is running, trezorctl was trying to connect to it and (probably due to an unrelated bug) got stuck...

After this PR, trezorctl will make the connection order deterministic, and will connect to non-bridge transports first.

Don't use `set()` as it doesn't preserve insertion order.