### PR TITLE
core/rust: update heapless to 0.9.2

### DIFF
--- a/core/embed/rust/Cargo.lock
+++ b/core/embed/rust/Cargo.lock
@@ -114,12 +114,13 @@ dependencies = [
 
 [[package]]
 name = "heapless"
-version = "0.8.0"
+version = "0.9.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0bfb9eb618601c89945a70e254898da93b13be0388091d42117462b265bb3fad"
+checksum = "2af2455f757db2b292a9b1768c4b70186d443bcb3b316252d6b540aec1cd89ed"
 dependencies = [
  "hash32",
  "stable_deref_trait",
+ "ufmt",
  "ufmt-write",
 ]
 

--- a/core/embed/rust/Cargo.toml
+++ b/core/embed/rust/Cargo.toml
@@ -123,7 +123,7 @@ zeroize = { version = "1.8.2", default-features = false, optional = true }
 version = "0.2.2"
 
 [dependencies.heapless]
-version = "0.8.0"
+version = "0.9.2"
 features = ["ufmt"]
 default-features = false
 

--- a/core/embed/rust/src/coverage/mod.rs
+++ b/core/embed/rust/src/coverage/mod.rs
@@ -1,5 +1,5 @@
 /// Off-heap data structure for collecting code coverage data.
-use heapless::{Entry, FnvIndexMap};
+use heapless::index_map::{Entry, FnvIndexMap};
 use spin::RwLock;
 
 use crate::{


### PR DESCRIPTION
Changes: https://docs.rs/crate/heapless/0.9.2/source/CHANGELOG.md
Diff: https://github.com/rust-embedded/heapless/compare/v0.8.0...v0.9.2

Notable changes:
* adds *View types, e.g. [VecView](https://docs.rs/heapless/0.9.2/heapless/vec/type.VecView.html) that don't have the const generic parameter and can help avoid excessive monomorphization
* better integration with ufmt and zeroize
* T3W1 debug firmware is about 0.5K smaller
* LinearMap improvements helpful for trezor-thp:  `LinearMap::as_view`, `LinearMap::retain`, `LinearMap::is_full`

<!--
For external contributors:
- Please open an issue before submitting a PR so we can discuss whether we want to proceed with it.

For core developers:
1. Initial PR setup
- Assign yourself to the PR.
- Add it to the "Firmware" project
  - Set Priority (match issue priority if it exists)
  - Set Team
  - Set Sprint (target release)

2. Development status
- Draft PRs: Set status to "In Progress"
- Final PRs: Set status to "Needs Review"

3. Post-merge status
- Testable: Set status to "Needs QA" and add a `Notes for QA` section with clear instructions on how to test the functionality.
- Not Testable: Set status to "Done (no QA)"
-->
