### PR TITLE
fix(python): avoid crash when scanning BLE multiple times

### DIFF
--- a/python/src/trezorlib/transport/ble.py
+++ b/python/src/trezorlib/transport/ble.py
@@ -194,7 +194,7 @@ class BleAsync:
         asyncio.run(self.main(pipe))
 
     async def main(self, pipe: Connection) -> None:
-        self.devices = {}
+        self.devices: dict[str, Peripheral] = {}
         self.did_scan = False
         LOG.debug("async BLE process started")
 
@@ -239,7 +239,7 @@ class BleAsync:
 
         # throw away non connected peripherals
         self.devices = {
-            addr: periph for addr, periph in self.devices.values() if periph.client
+            addr: periph for addr, periph in self.devices.items() if periph.client
         }
         for address, (dev, adv_data) in devices.items():
             if TREZOR_SERVICE_UUID not in adv_data.service_uuids:
@@ -254,7 +254,9 @@ class BleAsync:
                 self.devices[address] = Peripheral(dev, adv_data)
         self.did_scan = True
         return [
-            (periph.address, periph.device.name) for periph in self.devices.values()
+            (periph.address, periph.device.name)
+            for periph in self.devices.values()
+            if periph.device.name is not None
         ]
 
     async def connect(self, address: str) -> None:
@@ -263,7 +265,7 @@ class BleAsync:
 
         periph = self.devices.get(address)
         if not periph:
-            raise RuntimeError("device not found")
+            raise RuntimeError(f"Device not found: {address}")
 
         if periph.client:
             LOG.debug(f"Already connected to {periph.address}")
@@ -341,13 +343,17 @@ class BleAsync:
 
     async def read(self, address: str, timeout: float | None) -> bytes:
         periph = self.devices[address]
+        if periph.queue is None:
+            raise RuntimeError("Connect to peripheral before reading")
         try:
             return await asyncio.wait_for(periph.queue.get(), timeout=timeout)
-        except (TimeoutError, asyncio.TimeoutError):
-            raise Timeout(f"Timeout reading BLE packet ({timeout}s)")
+        except (TimeoutError, asyncio.TimeoutError) as err:
+            raise Timeout(f"Timeout reading BLE packet ({timeout}s)") from err
 
     async def write(self, address: str, chunk: bytes) -> None:
         periph = self.devices[address]
+        if periph.client is None:
+            raise RuntimeError("Connect to peripheral before writing")
         await periph.client.write_gatt_char(
             TREZOR_CHARACTERISTIC_RX, chunk, response=SHOULD_WRITE_WITH_RESPONSE
         )


### PR DESCRIPTION
Fixes #6640. Also fixes additional problems discovered by pyright.

<!--
For external contributors:
- Please open an issue before submitting a PR so we can discuss whether we want to proceed with it.

For core developers:
1. Initial PR setup
- Assign yourself to the PR.
- Add it to the "Firmware" project
  - Set Priority (match issue priority if it exists)
  - Set Team
  - Set Sprint (target release)

2. Development status
- Draft PRs: Set status to "In Progress"
- Final PRs: Set status to "Needs Review"

3. Post-merge status
- Testable: Set status to "Needs QA" and add a `Notes for QA` section with clear instructions on how to test the functionality.
- Not Testable: Set status to "Done (no QA)"
-->
