### PR TITLE
feat(core): allow blanking `select_word()` items

### DIFF
--- a/core/embed/rust/src/ui/layout_eckhart/firmware/select_word_screen.rs
+++ b/core/embed/rust/src/ui/layout_eckhart/firmware/select_word_screen.rs
@@ -102,6 +102,7 @@ impl SelectWordButtons {
         for word in share_words_vec {
             unwrap!(buttons.push(
                 Button::with_text(word)
+                    .initially_enabled(!word.is_empty())
                     .styled(theme::button_select_word())
                     .with_radius(12)
                     .with_text_align(Alignment::Center),
@@ -111,11 +112,13 @@ impl SelectWordButtons {
     }
 
     fn render_separators<'s>(&'s self, target: &mut impl Renderer<'s>) {
-        for i in 1..self.buttons.len() {
-            let button = &self.buttons[i];
-            let button_prev = &self.buttons[i - 1];
+        for pair in self.buttons.windows(2) {
+            let should_render = pair
+                .iter()
+                .all(|button| button.is_enabled() && !button.is_pressed());
 
-            if !button.is_pressed() && !button_prev.is_pressed() {
+            if should_render {
+                let button = &pair[1];
                 let separator = Rect::from_top_left_and_size(
                     button
                         .area()


### PR DESCRIPTION
Will be used to allow choosing 2 options (instead of 3), for choosing the backup type in #6569.
In that case, the 2nd separator should not be rendered.


<!--
For external contributors:
- Please open an issue before submitting a PR so we can discuss whether we want to proceed with it.

For core developers:
1. Initial PR setup
- Assign yourself to the PR.
- Add it to the "Firmware" project
  - Set Priority (match issue priority if it exists)
  - Set Team
  - Set Sprint (target release)

2. Development status
- Draft PRs: Set status to "In Progress"
- Final PRs: Set status to "Needs Review"

3. Post-merge status
- Testable: Set status to "Needs QA" and add a `Notes for QA` section with clear instructions on how to test the functionality.
- Not Testable: Set status to "Done (no QA)"
-->
