### PR TITLE
fix(python): `trezorctl` should use recent THP credentials first

### DIFF
--- a/python/.changelog.d/6575.fixed
+++ b/python/.changelog.d/6575.fixed
@@ -1,0 +1,1 @@
+Fix THP pairing after credential invalidation.

--- a/python/src/trezorlib/cli/credentials.py
+++ b/python/src/trezorlib/cli/credentials.py
@@ -149,8 +149,10 @@ class CredentialStore:
 
     def list(self) -> t.Collection[Credential]:
         with self._with_app() as app_data:
+            # Use recent credentials first (in case older credentials were invalidated)
             return [
-                KeyringCredential(self.app_name, id).as_credential() for id in app_data
+                KeyringCredential(self.app_name, id).as_credential()
+                for id in reversed(app_data)
             ]
 
     def add(self, credential: Credential) -> None:


### PR DESCRIPTION
Otherwise, it may get stuck using an invalidated one (#6575).

## Note to QA:

1. run `trezorctl ping 123` (making sure pairing has succeeded)
2. click `"Forget all"` button (in `"Pair & Connect"` menu)
3. `trezorctl ping 123` should re-pair **once** - no additional pairing requested.
