### PR TITLE
fix(eckhart, ui): consistent cancel layout

### DIFF
--- a/core/.changelog.d/6707.changed
+++ b/core/.changelog.d/6707.changed
@@ -1,0 +1,1 @@
+[T3W1] Consistent cancel option across screens.

--- a/core/embed/rust/librust_qstr.h
+++ b/core/embed/rust/librust_qstr.h
@@ -349,6 +349,7 @@ static void _librust_qstrs(void) {
   MP_QSTR_flow_confirm_set_new_code;
   MP_QSTR_flow_get_address;
   MP_QSTR_flow_get_pubkey;
+  MP_QSTR_footer;
   MP_QSTR_get;
   MP_QSTR_get_bonds;
   MP_QSTR_get_enabled;
@@ -940,7 +941,6 @@ static void _librust_qstrs(void) {
   MP_QSTR_version;
   MP_QSTR_wait_ble_host_confirmation;
   MP_QSTR_warning;
-  MP_QSTR_warning_footer;
   MP_QSTR_wipe__info;
   MP_QSTR_wipe__start_again;
   MP_QSTR_wipe__title;

--- a/core/embed/rust/src/ui/api/firmware_micropython.rs
+++ b/core/embed/rust/src/ui/api/firmware_micropython.rs
@@ -169,10 +169,15 @@ extern "C" fn new_confirm_value(n_args: usize, args: *const Obj, kwargs: *mut Ma
         let prompt_screen: bool = kwargs.get_or(Qstr::MP_QSTR_prompt_screen, false)?;
         let cancel: bool = kwargs.get_or(Qstr::MP_QSTR_cancel, false)?;
         let back_button: bool = kwargs.get_or(Qstr::MP_QSTR_back_button, false)?;
-        let warning_footer: Option<TString> = kwargs
-            .get(Qstr::MP_QSTR_warning_footer)
-            .unwrap_or_else(|_| Obj::const_none())
-            .try_into_option()?;
+        let footer_obj: Obj = kwargs
+            .get(Qstr::MP_QSTR_footer)
+            .unwrap_or_else(|_| Obj::const_none());
+        let footer: Option<(TString, bool)> = if footer_obj == Obj::const_none() {
+            None
+        } else {
+            let [text_obj, is_warning_obj]: [Obj; 2] = util::iter_into_array(footer_obj)?;
+            Some((text_obj.try_into()?, is_warning_obj.try_into()?))
+        };
         let external_menu: bool = kwargs.get_or(Qstr::MP_QSTR_external_menu, false)?;
 
         let layout = ModelUI::confirm_value(
@@ -191,7 +196,7 @@ extern "C" fn new_confirm_value(n_args: usize, args: *const Obj, kwargs: *mut Ma
             prompt_screen,
             cancel,
             back_button,
-            warning_footer,
+            footer,
             external_menu,
         )?;
 
@@ -1535,7 +1540,7 @@ pub static mp_module_trezorui_api: Module = obj_module! {
     ///     prompt_screen: bool = False,
     ///     cancel: bool = False,
     ///     back_button: bool = False,
-    ///     warning_footer: str | None = None,
+    ///     footer: tuple[str, bool] | None = None,
     ///     external_menu: bool = False,
     /// ) -> LayoutObj[UiResult]:
     ///     """Confirm a generic piece of information on the screen.

--- a/core/embed/rust/src/ui/api/firmware_micropython.rs
+++ b/core/embed/rust/src/ui/api/firmware_micropython.rs
@@ -2014,7 +2014,7 @@ pub static mp_module_trezorui_api: Module = obj_module! {
     ///     horizontal: bool = False,
     ///     chunkify: bool = False,
     /// ) -> LayoutObj[UiResult]:
-    ///     """Show metadata for outgoing transaction."""
+    ///     """Show metadata for outgoing transaction with a 'close' button."""
     Qstr::MP_QSTR_show_info_with_cancel => obj_fn_kw!(0, new_show_info_with_cancel).as_obj(),
 
     /// def show_lockscreen(

--- a/core/embed/rust/src/ui/layout_bolt/ui_firmware.rs
+++ b/core/embed/rust/src/ui/layout_bolt/ui_firmware.rs
@@ -131,7 +131,7 @@ impl FirmwareUI for UIBolt {
         _prompt_screen: bool,
         _cancel: bool,
         _back_button: bool,
-        _warning_footer: Option<TString<'static>>,
+        _footer: Option<(TString<'static>, bool)>,
         _external_menu: bool,
     ) -> Result<impl LayoutMaybeTrace, Error> {
         let frame = ConfirmValue::new(title, value, description, verb, verb_cancel, hold)

--- a/core/embed/rust/src/ui/layout_caesar/ui_firmware.rs
+++ b/core/embed/rust/src/ui/layout_caesar/ui_firmware.rs
@@ -162,7 +162,7 @@ impl FirmwareUI for UICaesar {
         _prompt_screen: bool,
         _cancel: bool,
         _back_button: bool,
-        _warning_footer: Option<TString<'static>>,
+        _footer: Option<(TString<'static>, bool)>,
         _external_menu: bool,
     ) -> Result<impl LayoutMaybeTrace, Error> {
         let paragraphs = ConfirmValueParams {

--- a/core/embed/rust/src/ui/layout_delizia/ui_firmware.rs
+++ b/core/embed/rust/src/ui/layout_delizia/ui_firmware.rs
@@ -125,7 +125,7 @@ impl FirmwareUI for UIDelizia {
         prompt_screen: bool,
         cancel: bool,
         back_button: bool,
-        _warning_footer: Option<TString<'static>>,
+        _footer: Option<(TString<'static>, bool)>,
         external_menu: bool,
     ) -> Result<impl LayoutMaybeTrace, Error> {
         if info && external_menu {

--- a/core/embed/rust/src/ui/layout_eckhart/ui_firmware.rs
+++ b/core/embed/rust/src/ui/layout_eckhart/ui_firmware.rs
@@ -464,7 +464,7 @@ impl FirmwareUI for UIEckhart {
         _prompt_screen: bool,
         cancel: bool,
         back_button: bool,
-        warning_footer: Option<TString<'static>>,
+        footer: Option<(TString<'static>, bool)>, // true implies warning style
         external_menu: bool,
     ) -> Result<impl LayoutMaybeTrace, Error> {
         if info && external_menu {
@@ -512,7 +512,7 @@ impl FirmwareUI for UIEckhart {
         } else {
             Button::with_text(TR::buttons__confirm.into()).styled(button_confirm())
         };
-        if warning_footer.is_some() {
+        if matches!(footer, Some((_, true))) {
             right_button = right_button
                 .styled(theme::button_actionbar_danger())
                 .with_gradient(Gradient::Alert);
@@ -542,8 +542,12 @@ impl FirmwareUI for UIEckhart {
             .with_external_menu(external_menu);
         if page_counter {
             screen = screen.with_hint(Hint::new_page_counter())
-        } else if let Some(warning_footer) = warning_footer {
-            screen = screen.with_hint(Hint::new_warning_caution(warning_footer));
+        } else if let Some((footer_text, is_warning)) = footer {
+            screen = screen.with_hint(if is_warning {
+                Hint::new_warning_caution(footer_text)
+            } else {
+                Hint::new_instruction(footer_text, Some(theme::ICON_INFO))
+            });
         }
         let screen = screen.map(move |msg| match msg {
             TextScreenMsg::Cancelled => Some(if back_button {

--- a/core/embed/rust/src/ui/ui_firmware.rs
+++ b/core/embed/rust/src/ui/ui_firmware.rs
@@ -71,7 +71,7 @@ pub trait FirmwareUI {
         prompt_screen: bool,
         cancel: bool,
         back_button: bool,
-        warning_footer: Option<TString<'static>>,
+        footer: Option<(TString<'static>, bool)>,
         external_menu: bool,
     ) -> Result<impl LayoutMaybeTrace, Error>;
 

--- a/core/mocks/generated/trezorui_api.pyi
+++ b/core/mocks/generated/trezorui_api.pyi
@@ -701,7 +701,7 @@ def show_info_with_cancel(
     horizontal: bool = False,
     chunkify: bool = False,
 ) -> LayoutObj[UiResult]:
-    """Show metadata for outgoing transaction."""
+    """Show metadata for outgoing transaction with a 'close' button."""
 
 
 # rust/src/ui/api/firmware_micropython.rs

--- a/core/mocks/generated/trezorui_api.pyi
+++ b/core/mocks/generated/trezorui_api.pyi
@@ -181,7 +181,7 @@ def confirm_value(
     prompt_screen: bool = False,
     cancel: bool = False,
     back_button: bool = False,
-    warning_footer: str | None = None,
+    footer: tuple[str, bool] | None = None,
     external_menu: bool = False,
 ) -> LayoutObj[UiResult]:
     """Confirm a generic piece of information on the screen.

--- a/core/src/apps/ethereum/layout.py
+++ b/core/src/apps/ethereum/layout.py
@@ -340,7 +340,7 @@ def require_confirm_address(
     subtitle: str | None = None,
     verb: str | None = None,
     br_name: str | None = None,
-    warning_footer: str | None = None,
+    footer: str | None = None,
 ) -> Awaitable[None]:
     from ubinascii import hexlify
 
@@ -352,7 +352,7 @@ def require_confirm_address(
         address_hex,
         subtitle=subtitle,
         verb=verb,
-        warning_footer=warning_footer,
+        footer=(footer, True) if footer is not None else None,
         br_name=br_name,
         br_code=ButtonRequestType.SignTx,
     )

--- a/core/src/apps/ethereum/layout.py
+++ b/core/src/apps/ethereum/layout.py
@@ -372,7 +372,6 @@ async def confirm_message_hash(message_hash: bytes) -> None:
         "confirm_message_hash",
         verb=TR.buttons__confirm,
         br_code=ButtonRequestType.SignTx,
-        cancel=True,
     )
 
 

--- a/core/src/apps/tron/layout.py
+++ b/core/src/apps/tron/layout.py
@@ -156,7 +156,6 @@ async def confirm_withdraw_unfreeze(owner_address: AnyBytes) -> None:
         chunkify=True,
         hold=True,
         br_name="tron/claim",
-        cancel=True,
     )
 
 

--- a/core/src/trezor/ui/layouts/bolt/__init__.py
+++ b/core/src/trezor/ui/layouts/bolt/__init__.py
@@ -811,7 +811,7 @@ def confirm_address(
     subtitle: str | None = None,
     description: str | None = None,
     verb: str | None = None,
-    warning_footer: str | None = None,
+    footer: tuple[str, bool] | None = None,
     chunkify: bool = True,
     br_name: str | None = None,
     br_code: ButtonRequestType = BR_CODE_OTHER,

--- a/core/src/trezor/ui/layouts/caesar/__init__.py
+++ b/core/src/trezor/ui/layouts/caesar/__init__.py
@@ -869,7 +869,7 @@ def confirm_address(
     subtitle: str | None = None,
     description: str | None = None,
     verb: str | None = None,
-    warning_footer: str | None = None,
+    footer: tuple[str, bool] | None = None,
     chunkify: bool = True,
     br_name: str | None = None,
     br_code: ButtonRequestType = BR_CODE_OTHER,

--- a/core/src/trezor/ui/layouts/delizia/__init__.py
+++ b/core/src/trezor/ui/layouts/delizia/__init__.py
@@ -787,7 +787,7 @@ def confirm_address(
     subtitle: str | None = None,
     description: str | None = None,
     verb: str | None = None,
-    warning_footer: str | None = None,
+    footer: tuple[str, bool] | None = None,
     chunkify: bool = True,
     br_name: str | None = None,
     br_code: ButtonRequestType = BR_CODE_OTHER,

--- a/core/src/trezor/ui/layouts/eckhart/__init__.py
+++ b/core/src/trezor/ui/layouts/eckhart/__init__.py
@@ -786,7 +786,7 @@ def confirm_address(
     subtitle: str | None = None,
     description: str | None = None,
     verb: str | None = TR.buttons__confirm,
-    warning_footer: str | None = None,
+    footer: tuple[str, bool] | None = None,
     chunkify: bool = True,
     br_name: str | None = None,
     br_code: ButtonRequestType = BR_CODE_OTHER,
@@ -800,7 +800,7 @@ def confirm_address(
         subtitle=subtitle,
         verb=verb,
         chunkify=chunkify,
-        warning_footer=warning_footer,
+        footer=footer,
     )
 
 
@@ -851,7 +851,7 @@ def confirm_value(
     chunkify: bool = False,
     info_items: Iterable[StrPropertyType] | None = None,
     info_title: str | None = None,
-    warning_footer: str | None = None,
+    footer: tuple[str, bool] | None = None,
 ) -> Awaitable[None]:
     """General confirmation dialog, used by many other confirm_* functions."""
     from trezor.ui.layouts.menu import Menu, confirm_with_menu
@@ -874,7 +874,7 @@ def confirm_value(
             info=False,
             hold=hold,
             chunkify=chunkify,
-            warning_footer=warning_footer,
+            footer=footer,
             external_menu=True,
         ),
         menu,
@@ -1635,7 +1635,7 @@ if not utils.BITCOIN_ONLY:
     async def confirm_tron_send(amount: str | None, fee: str | None) -> None:
         await _confirm_summary(
             amount or "",
-            TR.send__total_amount if amount else "",
+            TR.words__amount if amount else "",
             fee or "",
             TR.words__fee_limit if fee else "",
             extra_items=None,

--- a/core/src/trezor/ui/layouts/eckhart/__init__.py
+++ b/core/src/trezor/ui/layouts/eckhart/__init__.py
@@ -248,7 +248,6 @@ async def show_passphrase_from_host(passphrase: str | None) -> None:
         description="",
         br_name="passphrase_host2",
         verb=TR.passphrase__title_confirm,
-        cancel=True,
     )
 
 
@@ -736,7 +735,6 @@ def confirm_blob(
     ask_pagination: bool = False,
     verb_skip_pagination: str | None = None,
     chunkify: bool = False,
-    _prompt_screen: bool = True,
 ) -> Awaitable[None]:
 
     if ask_pagination:
@@ -769,20 +767,16 @@ def confirm_blob(
             info_layout_can_confirm=True,
         )
     else:
-        layout = trezorui_api.confirm_value(
+        return confirm_value(
+            br_name=br_name,
             title=title,
             value=data,
-            description=description,
+            description=description or "",
             subtitle=subtitle,
             verb=verb,
             hold=hold,
             chunkify=chunkify,
-            cancel=True,
-        )
-        return raise_if_not_confirmed(
-            layout,
-            br_name,
-            br_code,
+            br_code=br_code,
         )
 
 
@@ -791,7 +785,7 @@ def confirm_address(
     address: str,
     subtitle: str | None = None,
     description: str | None = None,
-    verb: str | None = None,
+    verb: str | None = TR.buttons__confirm,
     warning_footer: str | None = None,
     chunkify: bool = True,
     br_name: str | None = None,
@@ -807,7 +801,6 @@ def confirm_address(
         verb=verb,
         chunkify=chunkify,
         warning_footer=warning_footer,
-        cancel=True,
     )
 
 
@@ -846,7 +839,7 @@ def confirm_amount(
 
 def confirm_value(
     title: str,
-    value: str,
+    value: StrOrBytes,
     description: str,
     br_name: str,
     br_code: ButtonRequestType = BR_CODE_OTHER,
@@ -858,20 +851,19 @@ def confirm_value(
     chunkify: bool = False,
     info_items: Iterable[StrPropertyType] | None = None,
     info_title: str | None = None,
-    chunkify_info: bool = False,
     warning_footer: str | None = None,
-    cancel: bool = False,
 ) -> Awaitable[None]:
     """General confirmation dialog, used by many other confirm_* functions."""
+    from trezor.ui.layouts.menu import Menu, confirm_with_menu
 
-    items = list(info_items) if info_items else []
-    info_layout = trezorui_api.show_info_with_cancel(
-        title=info_title if info_title else TR.words__title_information,
-        items=items,
-        chunkify=chunkify_info,
+    menu_items = (
+        [create_details(info_title or TR.words__title_information, list(info_items))]
+        if info_items
+        else []
     )
+    menu = Menu.root(menu_items, TR.buttons__cancel)
 
-    return with_info(
+    return confirm_with_menu(
         trezorui_api.confirm_value(
             title=title,
             value=value,
@@ -879,13 +871,13 @@ def confirm_value(
             description=description,
             subtitle=subtitle,
             verb=verb,
-            info=bool(info_items),
+            info=False,
             hold=hold,
             chunkify=chunkify,
             warning_footer=warning_footer,
-            cancel=cancel,
+            external_menu=True,
         ),
-        info_layout,
+        menu,
         br_name,
         br_code,
     )
@@ -1172,7 +1164,6 @@ if not utils.BITCOIN_ONLY:
                 chunkify=chunkify,
                 br_name=br_name,
                 verb=TR.buttons__continue,
-                cancel=True,
             )
         else:
             main_layout = trezorui_api.confirm_with_info(
@@ -1207,7 +1198,6 @@ if not utils.BITCOIN_ONLY:
                 subtitle=TR.ethereum__token_contract,
                 chunkify=chunkify,
                 br_name=br_name,
-                cancel=True,
             )
 
         if is_unknown_network:
@@ -1217,7 +1207,6 @@ if not utils.BITCOIN_ONLY:
                 chain_id,
                 TR.ethereum__approve_chain_id,
                 br_name=br_name,
-                cancel=True,
             )
 
         properties: list[PropertyType] = (
@@ -1453,7 +1442,6 @@ if not utils.BITCOIN_ONLY:
             br_code=br_code,
             verb=TR.buttons__continue,
             info_items=items,
-            cancel=True,
         )
 
     def confirm_solana_tx(
@@ -1641,7 +1629,6 @@ if not utils.BITCOIN_ONLY:
             info_items=info_items,
             info_title=TR.stellar__token_info,
             is_data=False,
-            chunkify_info=True,
             chunkify=False,
         )
 
@@ -1675,7 +1662,6 @@ if not utils.BITCOIN_ONLY:
             chunkify=chunkify,
             br_name=br_name,
             verb=TR.buttons__continue,
-            cancel=True,
         )
 
         properties: Iterable[StrPropertyType] = (
@@ -1744,7 +1730,6 @@ if not utils.BITCOIN_ONLY:
             chunkify=chunkify,
             br_name=br_name,
             verb=TR.buttons__continue,
-            cancel=True,
         )
 
         properties: list[StrPropertyType] = [


### PR DESCRIPTION
Eckhart should not have cancel option as a 'x' on the action bar but should instead be an option in the menu, like Delizia. This is not supposed to fix it everywhere but possibly in a lot of places.

`confirm_action` still uses the old layout. It can be fixed separately as this PR itself affects a lot of places.

The `footer` label code has been changed to a tuple ==> `warning_footer` => `(footer ,is_footer_warning)`
as not all footer labels need to be scary warnings. Some can be gentle reminders like this:

<img width="30%" height="30%" alt="image" src="https://github.com/user-attachments/assets/0738b436-9e64-4ccf-9721-f440a77e1fdc" />
 
The code changes have also introduced menu icon in some places to switch from ℹ️ to regular 'burger' style context menu. @lapohoda agrees with the change and it has led to better coverage in UI tests.

## Notes for QA

Generally look out for changes in Eckhart layout wherever previously there was an option in the action bar to cancel. Report any places where the old design remains. It is not a blocker if that happens but good to fix them in future.

Make sure the footers shown in Eckhart have not changed their font.