### PR TITLE
fix(core): show label prefix during BLE pairing

### DIFF
--- a/core/embed/rust/src/trezorhal/ble/micropython.rs
+++ b/core/embed/rust/src/trezorhal/ble/micropython.rs
@@ -65,12 +65,12 @@ extern "C" fn py_start_advertising(whitelist: Obj, name: Obj) -> Obj {
         let name = name.try_into_option::<StrBuffer>()?;
         let name = name.as_deref().unwrap_or(model::FULL_NAME);
 
-        if whitelist {
-            switch_on(name)?;
+        let adv_name = if whitelist {
+            switch_on(name)?
         } else {
-            pairing_mode(name)?;
+            pairing_mode(name)?
         };
-        Ok(Obj::const_none())
+        adv_name.try_into()
     };
     unsafe { util::try_or_raise(block) }
 }
@@ -339,7 +339,7 @@ pub static mp_module_trezorble: Module = obj_module! {
     ///     """
     Qstr::MP_QSTR_start_comm => obj_fn_0!(py_start_comm).as_obj(),
 
-    /// def start_advertising(whitelist: bool, name: str | None):
+    /// def start_advertising(whitelist: bool, name: str | None) -> str:
     ///     """
     ///     Start advertising.
     ///     Raises exception if BLE driver reports an error.

--- a/core/embed/rust/src/trezorhal/ble/mod.rs
+++ b/core/embed/rust/src/trezorhal/ble/mod.rs
@@ -18,12 +18,12 @@ const COMMAND_FAILED: Error = Error::RuntimeError(c"BLE command failed");
 const WRITE_FAILED: Error = Error::RuntimeError(c"BLE write failed");
 
 // NOTE: replace with floor_char_boundary when stable
-fn prefix_utf8_bytes(text: &str, max_len: usize) -> &[u8] {
+fn prefix_utf8_bytes(text: &str, max_len: usize) -> &str {
     let mut i = text.len().min(max_len);
     while !text.is_char_boundary(i) {
         i -= 1;
     }
-    &text.as_bytes()[..i]
+    &text[..i]
 }
 
 pub fn res_to_result(res: bool) -> Result<(), Error> {
@@ -83,16 +83,18 @@ fn state() -> ffi::ble_state_t {
     state
 }
 
-pub fn pairing_mode(name: &str) -> Result<(), Error> {
-    let name = prefix_utf8_bytes(name, ADV_NAME_LEN);
-    let res = unsafe { ffi::ble_enter_pairing_mode(name.as_ptr(), name.len()) };
-    res_to_result(res)
+pub fn pairing_mode(name: &str) -> Result<&str, Error> {
+    let adv_name = prefix_utf8_bytes(name, ADV_NAME_LEN);
+    let res = unsafe { ffi::ble_enter_pairing_mode(adv_name.as_ptr(), adv_name.len()) };
+    res_to_result(res)?;
+    Ok(adv_name)
 }
 
-pub fn switch_on(name: &str) -> Result<(), Error> {
-    set_name(name);
+pub fn switch_on(name: &str) -> Result<&str, Error> {
+    let adv_name = set_name(name);
     let res = unsafe { ffi::ble_switch_on() };
-    res_to_result(res)
+    res_to_result(res)?;
+    Ok(adv_name)
 }
 
 pub fn switch_off() -> Result<(), Error> {
@@ -148,9 +150,10 @@ pub fn disconnect() -> Result<(), Error> {
     res_to_result(res)
 }
 
-pub fn set_name(name: &str) {
-    let bytes = prefix_utf8_bytes(name, ADV_NAME_LEN);
-    unsafe { ffi::ble_set_name(bytes.as_ptr(), bytes.len()) }
+pub fn set_name(name: &str) -> &str {
+    let adv_name = prefix_utf8_bytes(name, ADV_NAME_LEN);
+    unsafe { ffi::ble_set_name(adv_name.as_ptr(), adv_name.len()) }
+    adv_name
 }
 
 pub fn set_high_speed(enable: bool) {

--- a/core/mocks/generated/trezorble.pyi
+++ b/core/mocks/generated/trezorble.pyi
@@ -55,7 +55,7 @@ def start_comm():
 
 
 # rust/src/trezorhal/ble/micropython.rs
-def start_advertising(whitelist: bool, name: str | None):
+def start_advertising(whitelist: bool, name: str | None) -> str:
     """
     Start advertising.
     Raises exception if BLE driver reports an error.

--- a/core/src/apps/management/ble/pair_new_device.py
+++ b/core/src/apps/management/ble/pair_new_device.py
@@ -36,7 +36,7 @@ async def pair_new_device() -> None:
     from trezor import TR
 
     label = storage_device.get_label() or _default_ble_name()
-    ble.start_advertising(False, label)
+    label = ble.start_advertising(False, label)
     result = None
     try:
         code = await interact(
@@ -65,4 +65,4 @@ async def pair_new_device() -> None:
     finally:
         if result is not CONFIRMED:
             ble.reject_pairing()
-        ble.set_name(storage_device.get_label())
+        ble.set_name(label)


### PR DESCRIPTION
Following https://satoshilabs.slack.com/archives/CL1D61PQF/p1775643967434449?thread_ts=1775632146.486079&cid=CL1D61PQF.

If the label is longer than 20 bytes, show the truncated version on BLE pairing screen.

# Note to QA:
Please try label like "1234567890123456789Ř". Not sure if it's allowed but if it is then the last letter should be removed and there should be no garbage as the last letter.