### PR TITLE
docs: remove SECURITY.md to fall back to the organization default

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,7 +29,7 @@ Also please have a look at the docs, either in the `docs` folder or at  [docs.tr
 
 ## Security vulnerability disclosure
 
-Please report suspected security vulnerabilities in private to [security@satoshilabs.com](mailto:security@satoshilabs.com), also see [the disclosure section on the Trezor.io website](https://trezor.io/support/a/how-to-report-a-security-issue). Please do NOT create publicly viewable issues for suspected security vulnerabilities.
+Please do NOT create publicly viewable issues for suspected security vulnerabilities. See the [Security tab](https://github.com/trezor/trezor-firmware/security/policy) for reporting instructions.
 
 ## Documentation
 

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,7 +1,0 @@
-# Security Policy
-
-## Reporting a Vulnerability
-
-Please report suspected security vulnerabilities in private to security@satoshilabs.com. Our guidance on this topic can be found at our [website](https://trezor.io/support/a/how-to-report-a-security-issue) and list of past issues at [GitHub](https://github.com/orgs/trezor/discussions).
-
-Thank you for your cooperation in making Trezor more secure.


### PR DESCRIPTION
Removing local SECURITY.MD with a dead link so that the global MD file set for the whole organization is used, same as in [Suite](https://github.com/trezor/trezor-suite?tab=security-ov-file).

The info was also duplicated in Readme.md so I replaced it with a pointer to SECURITY.md instead.