### PR TITLE
feat(vendor): don't rebuild MicroPython to exclude source line data

### DIFF
--- a/core/Makefile
+++ b/core/Makefile
@@ -349,8 +349,7 @@ build_unix_debug: templates ## build unix port
 
 build_cross: ## build mpy-cross port
 	INC=-I$(CURDIR)/embed/upymod/mpycross_include/ \
-		$(MAKE) -C vendor/micropython/mpy-cross $(CROSS_PORT_OPTS) \
-		CFLAGS_EXTRA=-DMICROPY_ENABLE_SOURCE_LINE=$(MICROPY_ENABLE_SOURCE_LINE)
+		$(MAKE) -C vendor/micropython/mpy-cross $(CROSS_PORT_OPTS)
 
 ## clean commands:
 

--- a/core/SConscript.firmware
+++ b/core/SConscript.firmware
@@ -22,7 +22,7 @@ SCM_REVISION = ARGUMENTS.get('SCM_REVISION', None)
 THP = ARGUMENTS.get('THP', '0') == '1' # Trezor-Host Protocol
 BENCHMARK = ARGUMENTS.get('BENCHMARK', '0') == '1'
 LOG_STACK_USAGE = ARGUMENTS.get('LOG_STACK_USAGE', '0') == '1'
-MICROPY_ENABLE_SOURCE_LINE = ARGUMENTS.get('MICROPY_ENABLE_SOURCE_LINE', '0')
+MICROPY_ENABLE_SOURCE_LINE = ARGUMENTS.get('MICROPY_ENABLE_SOURCE_LINE', '0') == '1'
 DISABLE_ANIMATION = ARGUMENTS.get('TREZOR_DISABLE_ANIMATION', '0') == '1'
 BLOCK_ON_VCP = ARGUMENTS.get('BLOCK_ON_VCP', '0') == '1'
 UI_PERFORMANCE_OVERLAY = ARGUMENTS.get('UI_PERFORMANCE_OVERLAY', '0') == '1'
@@ -136,7 +136,7 @@ CPPDEFINES_MOD += [
     ('USE_CARDANO', '1' if EVERYTHING else '0'),
     ('USE_NEM', '1' if (EVERYTHING and TREZOR_MODEL == "T2T1") else '0'),
     ('USE_EOS', '1' if (EVERYTHING and TREZOR_MODEL == "T2T1") else '0'),
-    ('MICROPY_ENABLE_SOURCE_LINE', MICROPY_ENABLE_SOURCE_LINE),
+    ('MICROPY_ENABLE_SOURCE_LINE', '1' if MICROPY_ENABLE_SOURCE_LINE else '0'),
     ('DISABLE_ANIMATION', '1' if DISABLE_ANIMATION else '0'),
     ('LOG_STACK_USAGE', '1' if LOG_STACK_USAGE else '0'),
     ('BLOCK_ON_VCP', '1' if BLOCK_ON_VCP else '0'),
@@ -858,7 +858,8 @@ if FROZEN:
         ui_layout=ui.get_ui_layout(TREZOR_MODEL),
         thp=THP,
         power_manager='power_manager' in FEATURES_AVAILABLE,
-        )
+        include_source_lines=MICROPY_ENABLE_SOURCE_LINE,
+    )
 
     source_mpyc = env.FrozenCFile(
         target='frozen_mpy.c', source=source_mpy, qstr_header=qstr_preprocessed)

--- a/core/SConscript.unix
+++ b/core/SConscript.unix
@@ -17,7 +17,7 @@ PYOPT = ARGUMENTS.get('PYOPT', '1')
 DEBUGLINK = ARGUMENTS.get('DEBUGLINK', '0') == '1'
 FROZEN = ARGUMENTS.get('TREZOR_EMULATOR_FROZEN', 0)
 RASPI = os.getenv('TREZOR_EMULATOR_RASPI') == '1'
-MICROPY_ENABLE_SOURCE_LINE = ARGUMENTS.get('MICROPY_ENABLE_SOURCE_LINE', '1')
+MICROPY_ENABLE_SOURCE_LINE = ARGUMENTS.get('MICROPY_ENABLE_SOURCE_LINE', '1') == '1'
 DBG_CONSOLE = ARGUMENTS.get('DBG_CONSOLE', '')
 EXTAPP_SUPPORT = ARGUMENTS.get('EXTAPP_SUPPORT', '0') == '1'
 
@@ -119,7 +119,7 @@ CPPDEFINES_MOD += [
     ('USE_CARDANO', '1' if EVERYTHING else '0'),
     ('USE_NEM', '1' if (EVERYTHING and TREZOR_MODEL == "T2T1") else '0'),
     ('USE_EOS', '1' if (EVERYTHING and TREZOR_MODEL == "T2T1") else '0'),
-    ('MICROPY_ENABLE_SOURCE_LINE', MICROPY_ENABLE_SOURCE_LINE),
+    ('MICROPY_ENABLE_SOURCE_LINE', '1' if MICROPY_ENABLE_SOURCE_LINE else '0'),
 ]
 SOURCE_MOD += [
     'embed/upymod/trezorobj.c',
@@ -877,7 +877,8 @@ if FROZEN:
         ui_layout=ui.get_ui_layout(TREZOR_MODEL),
         thp=THP,
         power_manager='power_manager' in FEATURES_AVAILABLE,
-        )
+        include_source_lines=MICROPY_ENABLE_SOURCE_LINE,
+    )
 
     source_mpyc = env.FrozenCFile(
         target='frozen_mpy.c', source=source_mpy, qstr_header=qstr_preprocessed)

--- a/core/embed/projects/unix/main.c
+++ b/core/embed/projects/unix/main.c
@@ -495,6 +495,11 @@ MP_NOINLINE int main_(int argc, char **argv) {
 
   mp_init();
 
+#if MICROPY_ENABLE_COMPILER && MICROPY_ENABLE_SOURCE_LINE
+  // include source lines on non-frozen builds
+  MP_STATE_VM(include_source_lines) = true;
+#endif
+
   char *home = getenv("HOME");
   char *path = getenv("MICROPYPATH");
   if (path == NULL) {

--- a/core/site_scons/site_tools/micropython/__init__.py
+++ b/core/site_scons/site_tools/micropython/__init__.py
@@ -62,6 +62,7 @@ def generate(env):
         layout_eckhart = env["ui_layout"] == "UI_LAYOUT_ECKHART"
         thp = env["thp"]
         power_manager = env["power_manager"]
+        include_source_lines = env["include_source_lines"]
         interim = f"{target[:-4]}.i"  # replace .mpy with .i
         sed_scripts = [
             rf"-e 's/utils\.BITCOIN_ONLY/{btc_only}/g'",
@@ -94,7 +95,11 @@ def generate(env):
                 )
             )
 
-        return f"$SED {' '.join(sed_scripts)} {source} > {interim} && $MPY_CROSS -o {target} -s {source_name} {interim}"
+        mpy_cross_flags = f'-X {"" if include_source_lines else "no-"}source-lines'
+        return (
+            f"$SED {' '.join(sed_scripts)} {source} > {interim}"
+            f" && $MPY_CROSS {mpy_cross_flags} -o {target} -s {source_name} {interim}"
+        )
 
     env["BUILDERS"]["FrozenModule"] = SCons.Builder.Builder(
         generator=generate_frozen_module,


### PR DESCRIPTION
Fixes https://github.com/trezor/trezor-firmware/issues/6715 - `mpy-cross` will not be rebuild anymore (following https://github.com/trezor/trezor-firmware/pull/4926).

Needs https://github.com/trezor/micropython/pull/29.
