### PR TITLE
test(core): fix `InputFlowEthereumSignTxData` on non-English

### DIFF
--- a/tests/input_flows.py
+++ b/tests/input_flows.py
@@ -1737,7 +1737,7 @@ class InputFlowEthereumSignTxData(InputFlowBase):
 
                 # Only intro layout contains "view all" functionality:
                 assert is_intro == (
-                    TR.instructions__view_all_data in layout.screen_content()
+                    TR.instructions__view_all_data in layout.text_content()
                     or TR.buttons__view_all_data in layout.button_contents()
                 )
 


### PR DESCRIPTION
https://github.com/trezor/trezor-firmware/pull/6758 used `LayoutContent.screen_content()` which returns the screen text with `\n` characters, but it didn't run `translations` CI jobs.