### PR TITLE
feat(core): allow disabling button and adding a menu on Eckhart `show_info()` layout

### DIFF
--- a/core/embed/rust/src/ui/api/firmware_micropython.rs
+++ b/core/embed/rust/src/ui/api/firmware_micropython.rs
@@ -1081,8 +1081,9 @@ extern "C" fn new_show_info(n_args: usize, args: *const Obj, kwargs: *mut Map) -
             })
             .transpose()?;
         let time_ms: u32 = kwargs.get_or(Qstr::MP_QSTR_time_ms, 0)?.try_into()?;
+        let external_menu: bool = kwargs.get_or(Qstr::MP_QSTR_external_menu, false)?;
 
-        let obj = ModelUI::show_info(title, description, button, time_ms)?;
+        let obj = ModelUI::show_info(title, description, button, time_ms, external_menu)?;
         Ok(obj.into())
     };
     unsafe { util::try_with_args_and_kwargs(n_args, args, kwargs, block) }
@@ -2022,6 +2023,7 @@ pub static mp_module_trezorui_api: Module = obj_module! {
     ///     description: str = "",
     ///     button: tuple[str, bool] | None = None,
     ///     time_ms: int = 0,
+    ///     external_menu: bool = False,
     /// ) -> LayoutObj[UiResult]:
     ///     """Info screen."""
     Qstr::MP_QSTR_show_info => obj_fn_kw!(0, new_show_info).as_obj(),

--- a/core/embed/rust/src/ui/api/firmware_micropython.rs
+++ b/core/embed/rust/src/ui/api/firmware_micropython.rs
@@ -1071,7 +1071,15 @@ extern "C" fn new_show_info(n_args: usize, args: *const Obj, kwargs: *mut Map) -
     let block = move |_args: &[Obj], kwargs: &Map| {
         let title: TString = kwargs.get(Qstr::MP_QSTR_title)?.try_into()?;
         let description: TString = kwargs.get(Qstr::MP_QSTR_description)?.try_into()?;
-        let button: TString = kwargs.get_or(Qstr::MP_QSTR_button, TString::empty())?;
+        let button = kwargs
+            .get(Qstr::MP_QSTR_button)
+            .unwrap_or_else(|_| Obj::const_none())
+            .try_into_option::<Obj>()?
+            .map(|obj| -> Result<(TString<'_>, bool), Error> {
+                let [text, enabled]: [Obj; 2] = util::iter_into_array(obj)?;
+                Ok((text.try_into()?, enabled.try_into()?))
+            })
+            .transpose()?;
         let time_ms: u32 = kwargs.get_or(Qstr::MP_QSTR_time_ms, 0)?.try_into()?;
 
         let obj = ModelUI::show_info(title, description, button, time_ms)?;
@@ -2006,7 +2014,7 @@ pub static mp_module_trezorui_api: Module = obj_module! {
     ///     *,
     ///     title: str,
     ///     description: str = "",
-    ///     button: str = "",
+    ///     button: tuple[str, bool] | None = None,
     ///     time_ms: int = 0,
     /// ) -> LayoutObj[UiResult]:
     ///     """Info screen."""

--- a/core/embed/rust/src/ui/api/firmware_micropython.rs
+++ b/core/embed/rust/src/ui/api/firmware_micropython.rs
@@ -1071,7 +1071,15 @@ extern "C" fn new_show_info(n_args: usize, args: *const Obj, kwargs: *mut Map) -
     let block = move |_args: &[Obj], kwargs: &Map| {
         let title: TString = kwargs.get(Qstr::MP_QSTR_title)?.try_into()?;
         let description: TString = kwargs.get(Qstr::MP_QSTR_description)?.try_into()?;
-        let button: TString = kwargs.get_or(Qstr::MP_QSTR_button, TString::empty())?;
+        let button = kwargs
+            .get(Qstr::MP_QSTR_button)
+            .unwrap_or_else(|_| Obj::const_none())
+            .try_into_option::<Obj>()?
+            .map(|obj| -> Result<(TString<'_>, bool), Error> {
+                let [text, enabled]: [Obj; 2] = util::iter_into_array(obj)?;
+                Ok((text.try_into()?, enabled.try_into()?))
+            })
+            .transpose()?;
         let time_ms: u32 = kwargs.get_or(Qstr::MP_QSTR_time_ms, 0)?.try_into()?;
 
         let obj = ModelUI::show_info(title, description, button, time_ms)?;
@@ -2012,7 +2020,7 @@ pub static mp_module_trezorui_api: Module = obj_module! {
     ///     *,
     ///     title: str,
     ///     description: str = "",
-    ///     button: str = "",
+    ///     button: tuple[str, bool] | None = None,
     ///     time_ms: int = 0,
     /// ) -> LayoutObj[UiResult]:
     ///     """Info screen."""

--- a/core/embed/rust/src/ui/api/firmware_micropython.rs
+++ b/core/embed/rust/src/ui/api/firmware_micropython.rs
@@ -1081,8 +1081,9 @@ extern "C" fn new_show_info(n_args: usize, args: *const Obj, kwargs: *mut Map) -
             })
             .transpose()?;
         let time_ms: u32 = kwargs.get_or(Qstr::MP_QSTR_time_ms, 0)?.try_into()?;
+        let external_menu: bool = kwargs.get_or(Qstr::MP_QSTR_external_menu, false)?;
 
-        let obj = ModelUI::show_info(title, description, button, time_ms)?;
+        let obj = ModelUI::show_info(title, description, button, time_ms, external_menu)?;
         Ok(obj.into())
     };
     unsafe { util::try_with_args_and_kwargs(n_args, args, kwargs, block) }
@@ -2016,6 +2017,7 @@ pub static mp_module_trezorui_api: Module = obj_module! {
     ///     description: str = "",
     ///     button: tuple[str, bool] | None = None,
     ///     time_ms: int = 0,
+    ///     external_menu: bool = False,
     /// ) -> LayoutObj[UiResult]:
     ///     """Info screen."""
     Qstr::MP_QSTR_show_info => obj_fn_kw!(0, new_show_info).as_obj(),

--- a/core/embed/rust/src/ui/layout_bolt/ui_firmware.rs
+++ b/core/embed/rust/src/ui/layout_bolt/ui_firmware.rs
@@ -884,7 +884,7 @@ impl FirmwareUI for UIBolt {
             title,
             TString::empty(),
             description,
-            button,
+            (!button.is_empty()).then_some(button),
             allow_cancel,
             time_ms,
             icon,
@@ -990,13 +990,17 @@ impl FirmwareUI for UIBolt {
     fn show_info(
         title: TString<'static>,
         description: TString<'static>,
-        button: TString<'static>,
+        button: Option<(TString<'static>, bool)>,
         time_ms: u32,
     ) -> Result<Gc<LayoutObj>, Error> {
-        assert!(
-            !button.is_empty() || time_ms > 0,
-            "either button or timeout must be set"
-        );
+        let button_text = match (button, time_ms) {
+            // either button or timeout must be set
+            (None, 0) => return Err(Error::NotImplementedError),
+            (None, _) => None,
+            // disabled buttons are not supported on Bolt
+            (Some((_, false)), _) => return Err(Error::NotImplementedError),
+            (Some((text, true)), _) => Some(text),
+        };
 
         let icon = BlendedImage::new(
             theme::IMAGE_BG_CIRCLE,
@@ -1009,7 +1013,7 @@ impl FirmwareUI for UIBolt {
             title,
             TString::empty(),
             description,
-            button,
+            button_text,
             false,
             time_ms,
             icon,
@@ -1247,7 +1251,7 @@ impl FirmwareUI for UIBolt {
             title,
             TString::empty(),
             description,
-            button,
+            (!button.is_empty()).then_some(button),
             allow_cancel,
             time_ms,
             icon,
@@ -1280,7 +1284,7 @@ impl FirmwareUI for UIBolt {
             title,
             value,
             description,
-            button,
+            (!button.is_empty()).then_some(button),
             allow_cancel,
             0,
             icon,
@@ -1302,62 +1306,70 @@ fn new_show_modal(
     title: TString<'static>,
     value: TString<'static>,
     description: TString<'static>,
-    button: TString<'static>,
+    button: Option<TString<'static>>,
     allow_cancel: bool,
     time_ms: u32,
     icon: BlendedImage,
     button_style: ButtonStyleSheet,
 ) -> Result<Gc<LayoutObj>, Error> {
-    let no_buttons = button.is_empty();
-    let obj = if no_buttons && time_ms == 0 {
-        // No buttons and no timer, used when we only want to draw the dialog once and
-        // then throw away the layout object.
-        LayoutObj::new(
-            IconDialog::new(icon, title, Empty)
-                .with_value(value)
-                .with_description(description),
-        )?
-    } else if no_buttons && time_ms > 0 {
-        // Timeout, no buttons.
-        LayoutObj::new(
-            IconDialog::new(
-                icon,
-                title,
-                Timeout::new(time_ms).map(|_| Some(CancelConfirmMsg::Confirmed)),
-            )
-            .with_value(value)
-            .with_description(description),
-        )?
-    } else if allow_cancel {
-        // Two buttons.
-        LayoutObj::new(
-            IconDialog::new(
-                icon,
-                title,
-                Button::cancel_confirm(
-                    Button::with_icon(theme::ICON_CANCEL),
-                    Button::with_text(button).styled(button_style),
-                    false,
-                ),
-            )
-            .with_value(value)
-            .with_description(description),
-        )?
-    } else {
-        // Single button.
-        LayoutObj::new(
-            IconDialog::new(
-                icon,
-                title,
-                theme::button_bar(Button::with_text(button).styled(button_style).map(|msg| {
-                    (matches!(msg, ButtonMsg::Clicked)).then(|| CancelConfirmMsg::Confirmed)
-                })),
-            )
-            .with_value(value)
-            .with_description(description),
-        )?
+    let obj = match button {
+        None => {
+            if time_ms == 0 {
+                // No buttons and no timer, used when we only want to draw the dialog once and
+                // then throw away the layout object.
+                LayoutObj::new(
+                    IconDialog::new(icon, title, Empty)
+                        .with_value(value)
+                        .with_description(description),
+                )?
+            } else {
+                // Timeout, no buttons.
+                LayoutObj::new(
+                    IconDialog::new(
+                        icon,
+                        title,
+                        Timeout::new(time_ms).map(|_| Some(CancelConfirmMsg::Confirmed)),
+                    )
+                    .with_value(value)
+                    .with_description(description),
+                )?
+            }
+        }
+        Some(button) => {
+            if allow_cancel {
+                // Two buttons.
+                LayoutObj::new(
+                    IconDialog::new(
+                        icon,
+                        title,
+                        Button::cancel_confirm(
+                            Button::with_icon(theme::ICON_CANCEL),
+                            Button::with_text(button).styled(button_style),
+                            false,
+                        ),
+                    )
+                    .with_value(value)
+                    .with_description(description),
+                )?
+            } else {
+                // Single button.
+                LayoutObj::new(
+                    IconDialog::new(
+                        icon,
+                        title,
+                        theme::button_bar(Button::with_text(button).styled(button_style).map(
+                            |msg| {
+                                (matches!(msg, ButtonMsg::Clicked))
+                                    .then(|| CancelConfirmMsg::Confirmed)
+                            },
+                        )),
+                    )
+                    .with_value(value)
+                    .with_description(description),
+                )?
+            }
+        }
     };
-
     Ok(obj)
 }
 

--- a/core/embed/rust/src/ui/layout_bolt/ui_firmware.rs
+++ b/core/embed/rust/src/ui/layout_bolt/ui_firmware.rs
@@ -992,7 +992,11 @@ impl FirmwareUI for UIBolt {
         description: TString<'static>,
         button: Option<(TString<'static>, bool)>,
         time_ms: u32,
+        external_menu: bool, // TODO: will eventually replace the internal menu
     ) -> Result<Gc<LayoutObj>, Error> {
+        if external_menu {
+            return Err(Error::NotImplementedError);
+        }
         let button_text = match (button, time_ms) {
             // either button or timeout must be set
             (None, 0) => return Err(Error::NotImplementedError),

--- a/core/embed/rust/src/ui/layout_caesar/ui_firmware.rs
+++ b/core/embed/rust/src/ui/layout_caesar/ui_firmware.rs
@@ -1173,7 +1173,7 @@ impl FirmwareUI for UICaesar {
     fn show_info(
         title: TString<'static>,
         description: TString<'static>,
-        _button: TString<'static>,
+        _button: Option<(TString<'static>, bool)>,
         time_ms: u32,
     ) -> Result<Gc<LayoutObj>, Error> {
         let content = Frame::new(

--- a/core/embed/rust/src/ui/layout_caesar/ui_firmware.rs
+++ b/core/embed/rust/src/ui/layout_caesar/ui_firmware.rs
@@ -1175,7 +1175,11 @@ impl FirmwareUI for UICaesar {
         description: TString<'static>,
         _button: Option<(TString<'static>, bool)>,
         time_ms: u32,
+        external_menu: bool, // TODO: will eventually replace the internal menu
     ) -> Result<Gc<LayoutObj>, Error> {
+        if external_menu {
+            return Err(Error::NotImplementedError);
+        }
         let content = Frame::new(
             title,
             Paragraphs::new([Paragraph::new(&theme::TEXT_NORMAL, description)]),

--- a/core/embed/rust/src/ui/layout_delizia/ui_firmware.rs
+++ b/core/embed/rust/src/ui/layout_delizia/ui_firmware.rs
@@ -973,7 +973,11 @@ impl FirmwareUI for UIDelizia {
         description: TString<'static>,
         _button: Option<(TString<'static>, bool)>,
         _time_ms: u32,
+        external_menu: bool, // TODO: will eventually replace the internal menu
     ) -> Result<Gc<LayoutObj>, Error> {
+        if external_menu {
+            return Err(Error::NotImplementedError);
+        }
         let content = Paragraphs::new(Paragraph::new(&theme::TEXT_MAIN_GREY_LIGHT, description));
         let obj = LayoutObj::new(SwipeUpScreen::new(
             Frame::left_aligned(title, SwipeContent::new(content)).with_swipeup_footer(None),

--- a/core/embed/rust/src/ui/layout_delizia/ui_firmware.rs
+++ b/core/embed/rust/src/ui/layout_delizia/ui_firmware.rs
@@ -971,7 +971,7 @@ impl FirmwareUI for UIDelizia {
     fn show_info(
         title: TString<'static>,
         description: TString<'static>,
-        _button: TString<'static>,
+        _button: Option<(TString<'static>, bool)>,
         _time_ms: u32,
     ) -> Result<Gc<LayoutObj>, Error> {
         let content = Paragraphs::new(Paragraph::new(&theme::TEXT_MAIN_GREY_LIGHT, description));

--- a/core/embed/rust/src/ui/layout_eckhart/firmware/action_bar.rs
+++ b/core/embed/rust/src/ui/layout_eckhart/firmware/action_bar.rs
@@ -79,7 +79,8 @@ impl ActionBar {
     /// paginated content.
     pub fn new_single(button: Button) -> Self {
         let mut right_button = button.with_expanded_touch_area(Self::BUTTON_EXPAND_TOUCH);
-        if right_button.stylesheet() == &theme::button_default() {
+        // If the button is disabled, don't override its stylesheet.
+        if right_button.is_enabled() && right_button.stylesheet() == &theme::button_default() {
             right_button = right_button.styled(theme::firmware::button_actionbar_right_default());
         };
         if !right_button.has_gradient() {

--- a/core/embed/rust/src/ui/layout_eckhart/ui_firmware.rs
+++ b/core/embed/rust/src/ui/layout_eckhart/ui_firmware.rs
@@ -1233,15 +1233,18 @@ impl FirmwareUI for UIEckhart {
     fn show_info(
         title: TString<'static>,
         description: TString<'static>,
-        button: TString<'static>,
+        button: Option<(TString<'static>, bool)>,
         _time_ms: u32,
     ) -> Result<Gc<LayoutObj>, Error> {
         let content = Paragraphs::new(Paragraph::new(&theme::TEXT_REGULAR, description))
             .with_placement(LinearPlacement::vertical());
 
+        let button = button.map_or_else(Button::empty, |(text, enabled)| {
+            Button::with_text(text).initially_enabled(enabled)
+        });
         let screen = TextScreen::new(content)
             .with_header(Header::new(title))
-            .with_action_bar(ActionBar::new_single(Button::with_text(button)));
+            .with_action_bar(ActionBar::new_single(button));
         let obj = LayoutObj::new(screen)?;
         Ok(obj)
     }

--- a/core/embed/rust/src/ui/layout_eckhart/ui_firmware.rs
+++ b/core/embed/rust/src/ui/layout_eckhart/ui_firmware.rs
@@ -1235,6 +1235,7 @@ impl FirmwareUI for UIEckhart {
         description: TString<'static>,
         button: Option<(TString<'static>, bool)>,
         _time_ms: u32,
+        external_menu: bool, // TODO: will eventually replace the internal menu
     ) -> Result<Gc<LayoutObj>, Error> {
         let content = Paragraphs::new(Paragraph::new(&theme::TEXT_REGULAR, description))
             .with_placement(LinearPlacement::vertical());
@@ -1242,8 +1243,14 @@ impl FirmwareUI for UIEckhart {
         let button = button.map_or_else(Button::empty, |(text, enabled)| {
             Button::with_text(text).initially_enabled(enabled)
         });
+        let header = Header::new(title);
         let screen = TextScreen::new(content)
-            .with_header(Header::new(title))
+            .with_header(if external_menu {
+                header.with_menu_button()
+            } else {
+                header
+            })
+            .with_external_menu(external_menu)
             .with_action_bar(ActionBar::new_single(button));
         let obj = LayoutObj::new(screen)?;
         Ok(obj)

--- a/core/embed/rust/src/ui/ui_firmware.rs
+++ b/core/embed/rust/src/ui/ui_firmware.rs
@@ -385,7 +385,7 @@ pub trait FirmwareUI {
     fn show_info(
         title: TString<'static>,
         description: TString<'static>,
-        button: TString<'static>,
+        button: Option<(TString<'static>, bool)>,
         time_ms: u32,
     ) -> Result<Gc<LayoutObj>, Error>; // TODO: return LayoutMaybeTrace
 

--- a/core/embed/rust/src/ui/ui_firmware.rs
+++ b/core/embed/rust/src/ui/ui_firmware.rs
@@ -387,6 +387,7 @@ pub trait FirmwareUI {
         description: TString<'static>,
         button: Option<(TString<'static>, bool)>,
         time_ms: u32,
+        external_menu: bool, // TODO: will eventually replace the internal menu
     ) -> Result<Gc<LayoutObj>, Error>; // TODO: return LayoutMaybeTrace
 
     fn show_info_with_cancel(

--- a/core/mocks/generated/trezorui_api.pyi
+++ b/core/mocks/generated/trezorui_api.pyi
@@ -691,7 +691,7 @@ def show_info(
     *,
     title: str,
     description: str = "",
-    button: str = "",
+    button: tuple[str, bool] | None = None,
     time_ms: int = 0,
 ) -> LayoutObj[UiResult]:
     """Info screen."""

--- a/core/mocks/generated/trezorui_api.pyi
+++ b/core/mocks/generated/trezorui_api.pyi
@@ -687,7 +687,7 @@ def show_info(
     *,
     title: str,
     description: str = "",
-    button: str = "",
+    button: tuple[str, bool] | None = None,
     time_ms: int = 0,
 ) -> LayoutObj[UiResult]:
     """Info screen."""

--- a/core/mocks/generated/trezorui_api.pyi
+++ b/core/mocks/generated/trezorui_api.pyi
@@ -693,6 +693,7 @@ def show_info(
     description: str = "",
     button: tuple[str, bool] | None = None,
     time_ms: int = 0,
+    external_menu: bool = False,
 ) -> LayoutObj[UiResult]:
     """Info screen."""
 

--- a/core/mocks/generated/trezorui_api.pyi
+++ b/core/mocks/generated/trezorui_api.pyi
@@ -689,6 +689,7 @@ def show_info(
     description: str = "",
     button: tuple[str, bool] | None = None,
     time_ms: int = 0,
+    external_menu: bool = False,
 ) -> LayoutObj[UiResult]:
     """Info screen."""
 

--- a/core/src/trezor/ui/layouts/bolt/reset.py
+++ b/core/src/trezor/ui/layouts/bolt/reset.py
@@ -289,7 +289,7 @@ def show_intro_backup(num_of_words: int | None) -> Awaitable[None]:
         trezorui_api.show_info(
             title="",
             description=description,
-            button=TR.buttons__continue,
+            button=(TR.buttons__continue, True),
         ),
         "backup_intro",
         ButtonRequestType.ResetDevice,
@@ -301,7 +301,7 @@ def show_warning_backup() -> Awaitable[trezorui_api.UiResult]:
         trezorui_api.show_info(
             title=TR.reset__never_make_digital_copy,
             description="",
-            button=TR.buttons__ok_i_understand,
+            button=(TR.buttons__ok_i_understand, True),
         ),
         "backup_warning",
         ButtonRequestType.ResetDevice,

--- a/core/src/trezor/ui/layouts/eckhart/reset.py
+++ b/core/src/trezor/ui/layouts/eckhart/reset.py
@@ -316,7 +316,7 @@ async def show_intro_backup(num_of_words: int | None) -> None:
         trezorui_api.show_info(
             title=TR.reset__recovery_wallet_backup_title,
             description=description,
-            button=TR.buttons__continue,
+            button=(TR.buttons__continue, True),
         ),
         "backup_intro",
         ButtonRequestType.ResetDevice,


### PR DESCRIPTION
It will be used for N4W1 I/O layouts:

<img width="300" alt="Screenshot from 2026-04-15 14-32-28" src="https://github.com/user-attachments/assets/3309e129-713e-489c-852f-15fd223b7cdc" />

Before this PR:

<img width="300" alt="Screenshot from 2026-04-15 14-26-13" src="https://github.com/user-attachments/assets/a2541ea4-f536-4b6e-a267-1a41f015c2d7" />
