### PR TITLE
Bump rustc to recent nightly

### DIFF
--- a/core/embed/rust/Cargo.toml
+++ b/core/embed/rust/Cargo.toml
@@ -1,3 +1,5 @@
+cargo-features = ["panic-immediate-abort"]
+
 [package]
 name = "trezor_lib"
 version = "0.1.0"
@@ -93,12 +95,13 @@ universal_fw = []
 crate-type = ["staticlib"]
 
 [profile.dev]
+# Keep panic mechanism on emulator PYOPT=0 builds
 panic = "abort"
 split-debuginfo = "off"
 debug = 2
 
 [profile.release]
-panic = "abort"
+panic = "immediate-abort"
 opt-level = "z"
 lto = true
 codegen-units = 1

--- a/core/embed/rust/src/lib.rs
+++ b/core/embed/rust/src/lib.rs
@@ -10,6 +10,7 @@
 #![feature(lang_items)]
 #![feature(optimize_attribute)]
 #![feature(trait_alias)]
+#![feature(custom_test_frameworks)]
 #![no_main]
 #![reexport_test_harness_main = "test_main"]
 

--- a/core/embed/rust/src/lib.rs
+++ b/core/embed/rust/src/lib.rs
@@ -8,7 +8,6 @@
 // (when building for TR, a lot of code only used in TT would get marked as unused).
 #![allow(dead_code)]
 #![feature(lang_items)]
-#![feature(optimize_attribute)]
 #![feature(trait_alias)]
 #![feature(custom_test_frameworks)]
 #![no_main]

--- a/core/embed/rust/src/micropython/iter.rs
+++ b/core/embed/rust/src/micropython/iter.rs
@@ -30,7 +30,7 @@ impl IterBuf {
         new
     }
 
-    pub fn try_iterate(&mut self, o: Obj) -> Result<Iter, Error> {
+    pub fn try_iterate(&mut self, o: Obj) -> Result<Iter<'_>, Error> {
         Iter::try_from_obj_with_buf(o, self)
     }
 

--- a/core/embed/rust/src/micropython/map.rs
+++ b/core/embed/rust/src/micropython/map.rs
@@ -42,7 +42,7 @@ impl Map {
 }
 
 impl Map {
-    pub fn from_fixed(table: &[MapElem]) -> MapRef {
+    pub fn from_fixed(table: &[MapElem]) -> MapRef<'_> {
         let mut map = MaybeUninit::uninit();
         // SAFETY: `mp_map_init_fixed_table` completely initializes all fields of `map`.
         unsafe {

--- a/core/embed/rust/src/protobuf/defs.rs
+++ b/core/embed/rust/src/protobuf/defs.rs
@@ -225,7 +225,10 @@ pub fn get_msg(msg_offset: u16) -> MsgDef {
     // * FieldDef has the same alignment
     debug_assert!(mem::align_of::<FieldDef>() == mem::align_of::<u16>());
     // * both msg_offset and fields_start added together keep the alignment:
-    debug_assert!(fields_byteslice.as_ptr().addr() % mem::align_of::<FieldDef>() == 0);
+    debug_assert!(fields_byteslice
+        .as_ptr()
+        .addr()
+        .is_multiple_of(mem::align_of::<FieldDef>()));
 
     // SAFETY: FieldDef is a packed struct of ints, so all bit patterns are valid.
     let (_pre, fields, _post) = unsafe { fields_byteslice.align_to::<FieldDef>() };
@@ -263,7 +266,7 @@ fn get_enum(enum_offset: u16) -> EnumDef {
 
     // enum_offset is a raw byte offset, we check that it is also a valid index of
     // an u16
-    assert!(enum_offset % SIZE == 0);
+    assert!(enum_offset.is_multiple_of(SIZE));
     let offset: usize = (enum_offset / SIZE).into();
     let count: usize = enum_defs[offset].into();
     EnumDef {

--- a/core/embed/rust/src/smp/base64.rs
+++ b/core/embed/rust/src/smp/base64.rs
@@ -67,7 +67,7 @@ fn base64_char_value(c: u8) -> Option<u8> {
 /// Returns the number of bytes written on success.
 pub fn base64_decode(input: &[u8], output: &mut [u8]) -> Result<usize, Base64Error> {
     let len = input.len();
-    if len % 4 != 0 {
+    if !len.is_multiple_of(4) {
         return Err(Base64Error::InvalidLength);
     }
 

--- a/core/embed/rust/src/trezorhal/ble/mod.rs
+++ b/core/embed/rust/src/trezorhal/ble/mod.rs
@@ -17,13 +17,9 @@ pub const TX_PACKET_SIZE: usize = ffi::BLE_TX_PACKET_SIZE as usize;
 const COMMAND_FAILED: Error = Error::RuntimeError(c"BLE command failed");
 const WRITE_FAILED: Error = Error::RuntimeError(c"BLE write failed");
 
-// NOTE: replace with floor_char_boundary when stable
 fn prefix_utf8_bytes(text: &str, max_len: usize) -> &str {
-    let mut i = text.len().min(max_len);
-    while !text.is_char_boundary(i) {
-        i -= 1;
-    }
-    &text[..i]
+    let boundary = text.floor_char_boundary(max_len);
+    &text[..boundary]
 }
 
 pub fn res_to_result(res: bool) -> Result<(), Error> {

--- a/core/embed/rust/src/trezorhal/ble/mod.rs
+++ b/core/embed/rust/src/trezorhal/ble/mod.rs
@@ -40,7 +40,7 @@ pub fn ble_parse_event(event: ffi::ble_event_t) -> BLEEvent {
                 .data
                 .iter()
                 .take(6)
-                .map(|&b| (b - b'0'))
+                .map(|&b| b - b'0')
                 .fold(0, |acc, d| acc * 10 + d as u32);
             BLEEvent::PairingRequest(code)
         }

--- a/core/embed/rust/src/trezorhal/ffi.rs
+++ b/core/embed/rust/src/trezorhal/ffi.rs
@@ -3,6 +3,7 @@
 #![allow(clippy::upper_case_acronyms)]
 #![allow(non_snake_case)]
 #![allow(dead_code)]
+#![allow(unnecessary_transmutes)]
 #![allow(clippy::transmute_int_to_bool)]
 #![allow(clippy::too_many_arguments)]
 

--- a/core/embed/rust/src/ui/component/marquee.rs
+++ b/core/embed/rust/src/ui/component/marquee.rs
@@ -182,17 +182,13 @@ impl Component for Marquee {
             }
 
             match self.state {
-                State::Right(_) => {
-                    if self.is_at_right(now) {
-                        self.pause_timer.start(ctx, self.pause);
-                        self.state = State::PauseRight;
-                    }
+                State::Right(_) if self.is_at_right(now) => {
+                    self.pause_timer.start(ctx, self.pause);
+                    self.state = State::PauseRight;
                 }
-                State::Left(_) => {
-                    if self.is_at_left(now) {
-                        self.pause_timer.start(ctx, self.pause);
-                        self.state = State::PauseLeft;
-                    }
+                State::Left(_) if self.is_at_left(now) => {
+                    self.pause_timer.start(ctx, self.pause);
+                    self.state = State::PauseLeft;
                 }
                 _ => {}
             }

--- a/core/embed/rust/src/ui/component/text/paragraphs.rs
+++ b/core/embed/rust/src/ui/component/text/paragraphs.rs
@@ -142,7 +142,7 @@ where
         }
     }
 
-    fn break_pages_from(&self, offset: Option<PageOffset>) -> PageBreakIterator<T> {
+    fn break_pages_from(&self, offset: Option<PageOffset>) -> PageBreakIterator<'_, T> {
         PageBreakIterator {
             paragraphs: self,
             current: offset,
@@ -152,14 +152,14 @@ where
     /// Break pages from the start of the document.
     ///
     /// The first pagebreak is at the start of the first screen.
-    fn break_pages_from_start(&self) -> PageBreakIterator<T> {
+    fn break_pages_from_start(&self) -> PageBreakIterator<'_, T> {
         self.break_pages_from(None)
     }
 
     /// Break pages, continuing from the current page.
     ///
     /// The first pagebreak is at the start of the next screen.
-    fn break_pages_from_next(&self) -> PageBreakIterator<T> {
+    fn break_pages_from_next(&self) -> PageBreakIterator<'_, T> {
         self.break_pages_from(Some(self.offset))
     }
 

--- a/core/embed/rust/src/ui/layout/obj.rs
+++ b/core/embed/rust/src/ui/layout/obj.rs
@@ -399,7 +399,7 @@ impl LayoutObj {
         }
     }
 
-    fn inner_mut(&self) -> RefMut<LayoutObjInner> {
+    fn inner_mut(&self) -> RefMut<'_, LayoutObjInner> {
         self.inner.borrow_mut()
     }
 

--- a/core/embed/rust/src/ui/layout/util.rs
+++ b/core/embed/rust/src/ui/layout/util.rs
@@ -159,7 +159,7 @@ impl ParagraphSource<'static> for PropsList {
             let obj: Obj;
             let style: &TextStyle;
 
-            if index % 2 == 0 {
+            if index.is_multiple_of(2) {
                 if !key.is_str() && key != Obj::const_none() {
                     return Err(Error::TypeError);
                 }

--- a/core/embed/rust/src/ui/layout_bolt/component/coinjoin_progress.rs
+++ b/core/embed/rust/src/ui/layout_bolt/component/coinjoin_progress.rs
@@ -100,10 +100,10 @@ where
                 ctx.request_anim_frame();
                 ctx.request_paint();
             }
-            Event::Progress(new_value, _new_description) => {
-                if mem::replace(&mut self.value, new_value) != new_value {
-                    ctx.request_paint();
-                }
+            Event::Progress(new_value, _new_description)
+                if mem::replace(&mut self.value, new_value) != new_value =>
+            {
+                ctx.request_paint();
             }
             _ => {}
         }

--- a/core/embed/rust/src/ui/layout_caesar/component/changing_text.rs
+++ b/core/embed/rust/src/ui/layout_caesar/component/changing_text.rs
@@ -138,7 +138,11 @@ impl ChangingTextLine {
         // Creating the notion of motion by shifting the text left and right with
         // each new text character.
         // (So that it is apparent for the user that the text is changing.)
-        let x_offset = if self.text.len() % 2 == 0 { 0 } else { 2 };
+        let x_offset = if self.text.len().is_multiple_of(2) {
+            0
+        } else {
+            2
+        };
 
         let baseline = Point::new(self.pad.area.x0 + x_offset, self.y_baseline());
         shape::Text::new(baseline, &text_to_display, self.font).render(target);

--- a/core/embed/rust/src/ui/layout_caesar/component/hold_to_confirm.rs
+++ b/core/embed/rust/src/ui/layout_caesar/component/hold_to_confirm.rs
@@ -100,10 +100,8 @@ impl Component for HoldToConfirm {
             Event::Button(ButtonEvent::HoldStarted) => {
                 self.loader.start_growing(ctx, Instant::now());
             }
-            Event::Button(ButtonEvent::HoldEnded) => {
-                if self.loader.is_animating() {
-                    self.loader.start_shrinking(ctx, Instant::now());
-                }
+            Event::Button(ButtonEvent::HoldEnded) if self.loader.is_animating() => {
+                self.loader.start_shrinking(ctx, Instant::now());
             }
             Event::Button(ButtonEvent::HoldCanceled) => {
                 self.loader.shrink_completely(ctx, Instant::now());

--- a/core/embed/rust/src/ui/layout_caesar/component/input_methods/pin.rs
+++ b/core/embed/rust/src/ui/layout_caesar/component/input_methods/pin.rs
@@ -270,11 +270,9 @@ impl Component for PinEntry<'_> {
         });
         match event {
             // Timeout for showing the last digit.
-            Event::Timer(_) if self.timeout_timer.expire(event) => {
-                if self.show_last_digit {
-                    self.show_last_digit = false;
-                    self.update(ctx)
-                }
+            Event::Timer(_) if self.timeout_timer.expire(event) && self.show_last_digit => {
+                self.show_last_digit = false;
+                self.update(ctx)
             }
             // Other timers are ignored.
             Event::Timer(_) => {}

--- a/core/embed/rust/src/ui/layout_caesar/component/loader.rs
+++ b/core/embed/rust/src/ui/layout_caesar/component/loader.rs
@@ -178,7 +178,7 @@ impl Loader {
         let split_point = (((width as i32 + 1) * done) / (display::LOADER_MAX as i32)) as i16;
         let (r_left, r_right) = self.area.split_left(split_point);
         let parts = [(r_left, true), (r_right, false)];
-        parts.map(|(r, invert)| {
+        parts.iter().for_each(|&(r, invert)| {
             target.in_clip(r, &|target| {
                 if invert {
                     shape::Bar::new(self.area)

--- a/core/embed/rust/src/ui/layout_caesar/component/title.rs
+++ b/core/embed/rust/src/ui/layout_caesar/component/title.rs
@@ -33,7 +33,7 @@ impl Title {
         self
     }
 
-    pub fn get_text(&self) -> TString {
+    pub fn get_text(&self) -> TString<'_> {
         self.title
     }
 

--- a/core/embed/rust/src/ui/layout_delizia/component/button.rs
+++ b/core/embed/rust/src/ui/layout_delizia/component/button.rs
@@ -194,10 +194,10 @@ impl Button {
         style: &ButtonStyle,
         alpha: u8,
     ) {
-        if self.radius.is_some() {
+        if let Some(r) = self.radius {
             shape::Bar::new(self.area)
                 .with_bg(style.background_color)
-                .with_radius(self.radius.unwrap() as i16)
+                .with_radius(r.into())
                 .with_thickness(2)
                 .with_fg(style.button_color)
                 .with_alpha(alpha)

--- a/core/embed/rust/src/ui/layout_delizia/component/coinjoin_progress.rs
+++ b/core/embed/rust/src/ui/layout_delizia/component/coinjoin_progress.rs
@@ -95,10 +95,10 @@ where
                 ctx.request_anim_frame();
                 ctx.request_paint();
             }
-            Event::Progress(new_value, _new_description) => {
-                if mem::replace(&mut self.value, new_value) != new_value {
-                    ctx.request_paint();
-                }
+            Event::Progress(new_value, _new_description)
+                if mem::replace(&mut self.value, new_value) != new_value =>
+            {
+                ctx.request_paint();
             }
             _ => {}
         }

--- a/core/embed/rust/src/ui/layout_delizia/component/hold_to_confirm.rs
+++ b/core/embed/rust/src/ui/layout_delizia/component/hold_to_confirm.rs
@@ -217,23 +217,19 @@ impl Component for HoldToConfirm {
     fn event(&mut self, ctx: &mut EventCtx, event: Event) -> Option<Self::Msg> {
         let btn_msg = self.button.event(ctx, event);
         match btn_msg {
-            Some(ButtonMsg::Pressed) => {
-                if !self.anim.is_locked() {
-                    self.anim.start();
-                    ctx.request_anim_frame();
-                    ctx.request_paint();
-                    ctx.disable_swipe();
-                    self.finalizing = false;
-                }
+            Some(ButtonMsg::Pressed) if !self.anim.is_locked() => {
+                self.anim.start();
+                ctx.request_anim_frame();
+                ctx.request_paint();
+                ctx.disable_swipe();
+                self.finalizing = false;
             }
-            Some(ButtonMsg::Released) => {
-                if !self.anim.is_locked() {
-                    self.anim.reset();
-                    ctx.request_anim_frame();
-                    ctx.request_paint();
-                    ctx.enable_swipe();
-                    self.finalizing = false;
-                }
+            Some(ButtonMsg::Released) if !self.anim.is_locked() => {
+                self.anim.reset();
+                ctx.request_anim_frame();
+                ctx.request_paint();
+                ctx.enable_swipe();
+                self.finalizing = false;
             }
             Some(ButtonMsg::Clicked) => {
                 if animation_disabled() {

--- a/core/embed/rust/src/ui/layout_delizia/component/homescreen.rs
+++ b/core/embed/rust/src/ui/layout_delizia/component/homescreen.rs
@@ -797,14 +797,12 @@ impl LockscreenAnim {
                     ctx.request_anim_frame();
                 }
             }
-            Event::Timer(EventCtx::ANIM_FRAME_TIMER) => {
-                if !animation_disabled() {
-                    if !self.timer.is_running() {
-                        self.timer.start();
-                    }
-                    ctx.request_anim_frame();
-                    ctx.request_paint();
+            Event::Timer(EventCtx::ANIM_FRAME_TIMER) if !animation_disabled() => {
+                if !self.timer.is_running() {
+                    self.timer.start();
                 }
+                ctx.request_anim_frame();
+                ctx.request_paint();
             }
             _ => {}
         }

--- a/core/embed/rust/src/ui/layout_delizia/component/swipe_content.rs
+++ b/core/embed/rust/src/ui/layout_delizia/component/swipe_content.rs
@@ -222,11 +222,9 @@ impl SwipeContext {
 
         if let Event::Swipe(SwipeEvent::Move(dir, progress)) = event {
             match dir {
-                Direction::Up | Direction::Down => {
-                    if animate {
-                        self.dir = dir;
-                        self.progress = progress;
-                    }
+                Direction::Up | Direction::Down if animate => {
+                    self.dir = dir;
+                    self.progress = progress;
                 }
                 _ => {}
             }

--- a/core/embed/rust/src/ui/layout_eckhart/bootloader/bld_text_screen.rs
+++ b/core/embed/rust/src/ui/layout_eckhart/bootloader/bld_text_screen.rs
@@ -149,11 +149,9 @@ impl<'a> Component for BldTextScreen<'a> {
             match self.header.event(ctx, event) {
                 // FIXME: This is a hack for `screen_install_confirm` which expects `2` for the Menu
                 Some(BldHeaderMsg::Menu) => return Some(BldTextScreenMsg::Cancelled),
-                Some(BldHeaderMsg::Info) => {
-                    if !self.more_info_showing {
-                        self.more_info_showing = true;
-                        return None;
-                    }
+                Some(BldHeaderMsg::Info) if !self.more_info_showing => {
+                    self.more_info_showing = true;
+                    return None;
                 }
                 _ => (),
             }

--- a/core/embed/rust/src/ui/layout_eckhart/component/button.rs
+++ b/core/embed/rust/src/ui/layout_eckhart/component/button.rs
@@ -408,7 +408,7 @@ impl Button {
             self.style().font.line_height()
         } else if break_words {
             if self.stylesheet.normal.font.text_width(text) <= width {
-                return self.style().font.line_height();
+                self.style().font.line_height()
             } else {
                 self.style().font.line_height() * 2 - constant::LINE_SPACE
             }

--- a/core/embed/rust/src/ui/layout_eckhart/firmware/homescreen.rs
+++ b/core/embed/rust/src/ui/layout_eckhart/firmware/homescreen.rs
@@ -653,11 +653,10 @@ impl ShowLabelAnimation {
 
     pub fn process_event(&mut self, ctx: &mut EventCtx, event: Event) {
         match event {
-            Event::Attach(_) => {
-                if !self.hidden {
+            Event::Attach(_)
+                if !self.hidden => {
                     self.timer.start(ctx, Self::HIDE_AFTER);
                 }
-            }
             Event::Timer(EventCtx::ANIM_FRAME_TIMER) => {
                 if self.is_active() {
                     ctx.request_anim_frame();
@@ -685,9 +684,9 @@ impl ShowLabelAnimation {
                     ctx.request_paint();
                 }
             }
-            Event::Touch(TouchEvent::TouchStart(point)) => {
+            Event::Touch(TouchEvent::TouchStart(point))
                 // Only trigger animation at the top of the screen
-                if point.y <= SCREEN.height() / 2 {
+                if point.y <= SCREEN.height() / 2 => {
                     if self.animated {
                         if !self.animating {
                             if self.hidden {
@@ -715,7 +714,6 @@ impl ShowLabelAnimation {
                         }
                     }
                 }
-            }
             _ => {}
         }
     }

--- a/core/embed/rust/src/ui/layout_eckhart/firmware/keyboard/mnemonic.rs
+++ b/core/embed/rust/src/ui/layout_eckhart/firmware/keyboard/mnemonic.rs
@@ -195,12 +195,11 @@ where
                 self.on_input_change(ctx);
                 return None;
             }
-            Some(KeypadMsg::Back) => {
+            Some(KeypadMsg::Back)
                 // Back button will cause going back to the previous word when allowed.
-                if self.can_go_back {
+                if self.can_go_back => {
                     return Some(MnemonicKeyboardMsg::Previous);
                 }
-            }
             Some(KeypadMsg::EraseShort) => {
                 self.input.on_backspace_click(ctx);
                 self.on_input_change(ctx);

--- a/core/embed/rust/src/ui/layout_eckhart/firmware/keyboard/passphrase.rs
+++ b/core/embed/rust/src/ui/layout_eckhart/firmware/keyboard/passphrase.rs
@@ -121,7 +121,10 @@ impl PassphraseInput {
         let visible_icons = visible_len - last_char as usize;
 
         // Jiggle when overflowed.
-        if pp_len > visible_len && pp_len % 2 == 0 && self.display_style != DisplayStyle::Shown {
+        if pp_len > visible_len
+            && pp_len.is_multiple_of(2)
+            && self.display_style != DisplayStyle::Shown
+        {
             cursor.x += Self::TWITCH;
         }
 

--- a/core/embed/rust/src/ui/layout_eckhart/firmware/keyboard/pin.rs
+++ b/core/embed/rust/src/ui/layout_eckhart/firmware/keyboard/pin.rs
@@ -410,7 +410,10 @@ impl PinInput {
         let visible_icons = visible_len - last_digit as usize;
 
         // Jiggle when overflowed.
-        if pin_len > visible_len && pin_len % 2 == 0 && self.display_style != DisplayStyle::Shown {
+        if pin_len > visible_len
+            && pin_len.is_multiple_of(2)
+            && self.display_style != DisplayStyle::Shown
+        {
             cursor.x += Self::TWITCH;
         }
 

--- a/core/embed/rust/src/ui/layout_eckhart/firmware/keyboard/string.rs
+++ b/core/embed/rust/src/ui/layout_eckhart/firmware/keyboard/string.rs
@@ -119,8 +119,7 @@ impl<I: StringInput> StringKeyboard<I> {
         let layout = self.active_layout as usize;
         let styles = Self::key_style(self.active_layout);
 
-        for idx in 0..KEY_COUNT {
-            let text = KEYBOARD[layout][idx];
+        for (idx, text) in KEYBOARD[layout].iter().enumerate() {
             let content = Self::key_content(text);
             self.keypad.set_key_content(idx, content);
             self.keypad

--- a/core/embed/rust/src/ui/layout_eckhart/firmware/keyboard/word_count_screen.rs
+++ b/core/embed/rust/src/ui/layout_eckhart/firmware/keyboard/word_count_screen.rs
@@ -194,7 +194,7 @@ impl ValueKeypad {
         let vertical_spacing = (self.area.height() - Self::BUTTON_SIZE.y * Self::ROWS as i16)
             / (Self::ROWS as i16 - 1);
 
-        if idx % Self::ROWS == 0 {
+        if idx.is_multiple_of(Self::ROWS) {
             Insets::bottom(vertical_spacing / 2)
         } else if idx % Self::ROWS == Self::ROWS - 1 {
             Insets::top(vertical_spacing / 2)

--- a/core/embed/rust/src/ui/layout_eckhart/firmware/progress_screen.rs
+++ b/core/embed/rust/src/ui/layout_eckhart/firmware/progress_screen.rs
@@ -121,15 +121,15 @@ impl Component for ProgressScreen {
                 ctx.request_anim_frame();
                 ctx.request_paint();
             }
-            Event::Progress(new_value, new_description) => {
-                if mem::replace(&mut self.value, new_value) != new_value {
-                    if !animation_disabled() {
-                        ctx.request_paint();
-                    }
-                    if self.description.text() != &new_description {
-                        self.description.set_text(new_description);
-                        ctx.request_paint();
-                    }
+            Event::Progress(new_value, new_description)
+                if mem::replace(&mut self.value, new_value) != new_value =>
+            {
+                if !animation_disabled() {
+                    ctx.request_paint();
+                }
+                if self.description.text() != &new_description {
+                    self.description.set_text(new_description);
+                    ctx.request_paint();
                 }
             }
             _ => {}

--- a/core/embed/rust/src/ui/shape/base.rs
+++ b/core/embed/rust/src/ui/shape/base.rs
@@ -46,6 +46,7 @@ pub trait ShapeClone<'s> {
     ///
     /// The method is used by `ProgressiveRenderer` to store shape objects for
     /// deferred drawing.
+    #[allow(clippy::mut_from_ref)]
     fn clone_at_bump<T>(self, bump: &'s T) -> Option<&'s mut dyn Shape<'s>>
     where
         T: LocalAllocLeakExt<'s>;

--- a/core/embed/rust/src/ui/shape/bitmap.rs
+++ b/core/embed/rust/src/ui/shape/bitmap.rs
@@ -87,13 +87,9 @@ impl<'a> Bitmap<'a> {
 
         assert!(stride >= min_stride);
         assert!(buff.as_ptr().align_offset(alignment) == 0);
-        assert!(stride % alignment == 0);
+        assert!(stride.is_multiple_of(alignment));
 
-        let max_height = if stride == 0 {
-            size.y as usize
-        } else {
-            buff.len() / stride
-        };
+        let max_height = buff.len().checked_div(stride).unwrap_or(size.y as usize);
 
         if size.y as usize > max_height {
             if let Some(min_height) = min_height {
@@ -164,7 +160,7 @@ impl<'a> Bitmap<'a> {
         self.format
     }
 
-    pub fn view(&self) -> BitmapView {
+    pub fn view(&self) -> BitmapView<'_> {
         BitmapView::new(self)
     }
 
@@ -178,7 +174,7 @@ impl<'a> Bitmap<'a> {
 
         let offset = row as usize * (self.stride / core::mem::size_of::<T>());
 
-        if offset % core::mem::align_of::<T>() != 0 {
+        if !offset.is_multiple_of(core::mem::align_of::<T>()) {
             return None;
         }
 
@@ -210,7 +206,7 @@ impl<'a> Bitmap<'a> {
 
         let offset = row as usize * (self.stride / core::mem::size_of::<T>());
 
-        if offset % core::mem::align_of::<T>() != 0 {
+        if !offset.is_multiple_of(core::mem::align_of::<T>()) {
             return None;
         }
 
@@ -243,7 +239,7 @@ impl<'a> Bitmap<'a> {
 
         let offset = self.stride * row as usize;
 
-        if offset % core::mem::align_of::<T>() != 0 {
+        if !offset.is_multiple_of(core::mem::align_of::<T>()) {
             return None;
         }
 

--- a/core/embed/rust/src/ui/shape/cache/drawing_cache.rs
+++ b/core/embed/rust/src/ui/shape/cache/drawing_cache.rs
@@ -99,19 +99,19 @@ impl<'a> DrawingCache<'a> {
     }
 
     /// Returns an object for decompression of TOIF images
-    pub fn zlib(&self) -> RefMut<ZlibCache<'a>> {
+    pub fn zlib(&self) -> RefMut<'_, ZlibCache<'a>> {
         self.zlib_cache.borrow_mut()
     }
 
     /// Returns an object for decompression of JPEG images
     #[cfg(all(feature = "ui_jpeg", not(feature = "hw_jpeg_decoder")))]
-    pub fn jpeg(&self) -> RefMut<JpegCache<'a>> {
+    pub fn jpeg(&self) -> RefMut<'_, JpegCache<'a>> {
         self.jpeg_cache.borrow_mut()
     }
 
     /// Returns an object providing blurring algorithm
     #[cfg(feature = "ui_blurring")]
-    pub fn blur(&self) -> RefMut<BlurCache<'a>> {
+    pub fn blur(&self) -> RefMut<'_, BlurCache<'a>> {
         self.blur_cache.borrow_mut()
     }
 

--- a/core/embed/rust/src/ui/shape/canvas/common.rs
+++ b/core/embed/rust/src/ui/shape/canvas/common.rs
@@ -83,7 +83,7 @@ pub trait CanvasBuilder<'a> {
 
 pub trait Canvas: BasicCanvas {
     /// Returns a non-mutable view of the underlying bitmap.
-    fn view(&self) -> BitmapView;
+    fn view(&self) -> BitmapView<'_>;
 
     /// Draw a pixel at specified coordinates.
     fn draw_pixel(&mut self, pt: Point, color: Color);

--- a/core/embed/rust/src/ui/shape/canvas/mono8.rs
+++ b/core/embed/rust/src/ui/shape/canvas/mono8.rs
@@ -88,7 +88,7 @@ impl<'a> CanvasBuilder<'a> for Mono8Canvas<'a> {
 }
 
 impl<'a> Canvas for Mono8Canvas<'a> {
-    fn view(&self) -> BitmapView {
+    fn view(&self) -> BitmapView<'_> {
         BitmapView::new(&self.bitmap)
     }
 

--- a/core/embed/rust/src/ui/shape/canvas/rgb565.rs
+++ b/core/embed/rust/src/ui/shape/canvas/rgb565.rs
@@ -88,7 +88,7 @@ impl<'a> CanvasBuilder<'a> for Rgb565Canvas<'a> {
 }
 
 impl<'a> Canvas for Rgb565Canvas<'a> {
-    fn view(&self) -> BitmapView {
+    fn view(&self) -> BitmapView<'_> {
         BitmapView::new(&self.bitmap)
     }
 

--- a/core/embed/rust/src/ui/shape/canvas/rgba8888.rs
+++ b/core/embed/rust/src/ui/shape/canvas/rgba8888.rs
@@ -88,7 +88,7 @@ impl<'a> CanvasBuilder<'a> for Rgba8888Canvas<'a> {
 }
 
 impl<'a> Canvas for Rgba8888Canvas<'a> {
-    fn view(&self) -> BitmapView {
+    fn view(&self) -> BitmapView<'_> {
         BitmapView::new(&self.bitmap)
     }
 

--- a/core/embed/rust/src/ui/shape/utils/imagebuf.rs
+++ b/core/embed/rust/src/ui/shape/utils/imagebuf.rs
@@ -80,7 +80,7 @@ where
     }
 
     /// Returns the immutable view of the bitmap in the image buffer.
-    pub fn view(&self) -> BitmapView {
+    pub fn view(&self) -> BitmapView<'_> {
         self.canvas.view()
     }
 }

--- a/core/site_scons/tools.py
+++ b/core/site_scons/tools.py
@@ -168,11 +168,10 @@ def add_rust_lib(*, env, build, profile, features, all_paths, build_dir):
             "--no-default-features",
             "--features " + ",".join(lib_features),
         ]
-        if not (build == "unix" and is_debug):
-            # Keep panic mechanism on debug emulator (for `debug_assert!`)
+        if not is_debug:
             cargo_opts += [
+                # Needed by panic=immediate-abort
                 "-Z build-std=core",
-                "-Z build-std-features=panic_immediate_abort",
             ]
 
         build_cmd = "cargo build " + " ".join(cargo_opts)

--- a/docs/core/build/emulator.md
+++ b/docs/core/build/emulator.md
@@ -61,7 +61,7 @@ The protocol buffer compiler `protoc` is needed to (unsurprisingly) compile prot
 
 ## Rust
 
-You will require Rust and Cargo. The currently supported version is 1.88 nightly. The
+You will require Rust and Cargo. The currently supported version is 1.96 nightly. The
 recommended way to install both is with [`rustup`](https://rustup.rs/). Make sure you
 are up to date:
 

--- a/shell.nix
+++ b/shell.nix
@@ -5,6 +5,7 @@
 
 let
   # the last commit from master as of 2026-03-16
+  # when updating please also bump rustProfiles below
   rustOverlay = import (builtins.fetchTarball {
     url = "https://github.com/oxalica/rust-overlay/archive/f600ea449c7b5bb596fa1cf21c871cc5b9e31316.tar.gz";
     sha256 = "0x70l5b4v5zljnwkzbv7yi5ld04vb75zb6wk620sfm6vd406166c";
@@ -51,7 +52,7 @@ let
       done
     '';
   # NOTE: don't forget to update Minimum Supported Rust Version in docs/core/build/emulator.md
-  rustProfiles = nixpkgs.rust-bin.nightly."2025-04-15";
+  rustProfiles = nixpkgs.rust-bin.nightly."2026-03-16";
   rustNightly = rustProfiles.minimal.override {
     targets = [
       "thumbv7em-none-eabihf" # TT


### PR DESCRIPTION
We forgot to increase the version in #6623.

Nightly features before:
```
// panic handling
-Z build-std=core
-Z build-std-features=panic_immediate_abort

// layout_bolt only
#![feature(trait_alias)]

// unused
#![feature(optimize_attribute)]

// emulator `opt-level = 0` debuginfo
#![feature(lang_items)]
#[lang = "eh_personality"]

// size profiling
-Z print-type-sizes
-Z emit-stack-sizes
```

Nightly features after:
```
// unit test initialization
#![feature(custom_test_frameworks)]

// panic handling
-Z build-std=core
cargo-features = ["panic-immediate-abort"]

// emulator `opt-level = 0` debuginfo
#![feature(lang_items)]
#[lang = "eh_personality"]

// size profiling
-Z print-type-sizes
-Z emit-stack-sizes
```

<!--
For external contributors:
- Please open an issue before submitting a PR so we can discuss whether we want to proceed with it.

For core developers:
1. Initial PR setup
- Assign yourself to the PR.
- Add it to the "Firmware" project
  - Set Priority (match issue priority if it exists)
  - Set Team
  - Set Sprint (target release)

2. Development status
- Draft PRs: Set status to "In Progress"
- Final PRs: Set status to "Needs Review"

3. Post-merge status
- Testable: Set status to "Needs QA" and add a `Notes for QA` section with clear instructions on how to test the functionality.
- Not Testable: Set status to "Done (no QA)"
-->
