### PR TITLE
Rust logging connector

### DIFF
--- a/core/embed/rust/Cargo.lock
+++ b/core/embed/rust/Cargo.lock
@@ -168,6 +168,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4ec2a862134d2a7d32d7983ddcdd1c4923530833c9f2ea1a44fc5fa473989058"
 
 [[package]]
+name = "log"
+version = "0.4.29"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5e5032e24019045c762d3c0f28f5b6b8bbf38563a65908389bf7978758920897"
+
+[[package]]
 name = "memchr"
 version = "2.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -355,6 +361,7 @@ dependencies = [
  "glob",
  "heapless",
  "hex",
+ "log",
  "minicbor",
  "num-derive",
  "num-traits",

--- a/core/embed/rust/Cargo.toml
+++ b/core/embed/rust/Cargo.toml
@@ -130,6 +130,11 @@ version = "0.9.2"
 features = ["ufmt"]
 default-features = false
 
+[dependencies.log]
+version = "0.4.29"
+# Disable logging for release profile.
+features = ["max_level_trace", "release_max_level_off"]
+
 [dependencies.num-traits]
 version = "0.2.19"
 default-features = false

--- a/core/embed/rust/src/micropython/logging.rs
+++ b/core/embed/rust/src/micropython/logging.rs
@@ -5,6 +5,7 @@ use crate::{
     error::Error,
     micropython::{buffer::StrBuffer, util},
     trezorhal::syslog::{syslog_start_record, syslog_write_chunk, LogLevel},
+    util::logger::init_rust_logging,
 };
 
 #[cfg(feature = "dbg_console")]
@@ -75,6 +76,20 @@ extern "C" fn py_error(n_args: usize, args: *const Obj, kwargs: *mut Map) -> Obj
     Obj::const_none()
 }
 
+extern "C" fn py_init(level: Obj) -> Obj {
+    #[cfg(feature = "dbg_console")]
+    {
+        let block = || {
+            init_rust_logging(level.try_into()?);
+            Ok(())
+        };
+        unsafe {
+            util::try_or_raise(block);
+        }
+    }
+    Obj::const_none()
+}
+
 #[no_mangle]
 #[rustfmt::skip]
 pub static mp_module_trezorlog: Module = obj_module! {
@@ -97,4 +112,10 @@ pub static mp_module_trezorlog: Module = obj_module! {
     /// def error(name: str, msg: str, *args: Any, *, iface: WireInterface | None = None) -> None:
     ///     ...
     Qstr::MP_QSTR_error => obj_fn_kw!(2, py_error).as_obj(),
+
+    /// def init(level: int) -> None:
+    ///     """
+    ///     Initialize Rust logging connector.
+    ///     """
+    Qstr::MP_QSTR_init => obj_fn_1!(py_init).as_obj(),
 };

--- a/core/embed/rust/src/util/logger.rs
+++ b/core/embed/rust/src/util/logger.rs
@@ -1,0 +1,74 @@
+//! Connects the `log::error!`, `log::warn!`, ... macros from the `log` crate to
+//! our C logging backend.
+
+use heapless::Vec;
+use log::{set_logger, set_max_level, Level, LevelFilter, Log, Metadata, Record};
+
+use core::{
+    fmt::Write,
+    sync::atomic::{AtomicBool, Ordering},
+};
+
+use crate::trezorhal::syslog::{syslog_start_record, syslog_write_chunk, LogLevel};
+
+const MAX_MESSAGE_LEN: usize = 128;
+
+static INITIALIZED: AtomicBool = AtomicBool::new(false);
+
+struct SysLogger;
+
+fn sys_level(level: Level) -> LogLevel {
+    match level {
+        Level::Error => LogLevel::Error,
+        Level::Warn => LogLevel::Warn,
+        Level::Info => LogLevel::Info,
+        Level::Debug | Level::Trace => LogLevel::Debug,
+    }
+}
+
+impl Log for SysLogger {
+    fn enabled(&self, _metadata: &Metadata) -> bool {
+        // The `log` crate already compares the level, `syslog_start_record` takes care
+        // of filtering by module. Implementing it here would only make sense if we used
+        // `log_enabled!` heavily.
+        true
+    }
+
+    fn log(&self, record: &Record) {
+        if !self.enabled(record.metadata()) {
+            return;
+        }
+
+        let should_log = syslog_start_record(record.target(), sys_level(record.level()));
+        if !should_log {
+            return;
+        }
+
+        let mut msg = Vec::<u8, MAX_MESSAGE_LEN>::new();
+        // Might still get partial message on error.
+        let _ = msg.write_fmt(*record.args());
+
+        // SAFETY: passed to C which doesn't care about UTF-8
+        let text = unsafe { str::from_utf8_unchecked(&msg) };
+        syslog_write_chunk(text, true);
+    }
+
+    fn flush(&self) {}
+}
+
+fn to_filter(val: u8) -> LevelFilter {
+    match val {
+        0 => LevelFilter::Trace, // corresponds to debug in micropython
+        1 => LevelFilter::Info,
+        2 => LevelFilter::Warn,
+        3 => LevelFilter::Error,
+        _ => LevelFilter::Off,
+    }
+}
+
+pub fn init_rust_logging(level: u8) {
+    if !INITIALIZED.swap(true, Ordering::Relaxed) {
+        let _ = set_logger(&SysLogger);
+        set_max_level(to_filter(level));
+    }
+}

--- a/core/embed/rust/src/util/mod.rs
+++ b/core/embed/rust/src/util/mod.rs
@@ -1,5 +1,7 @@
 #[cfg(feature = "micropython")]
 pub mod interpolate;
+#[cfg(feature = "dbg_console")]
+pub mod logger;
 
 /// Constructs a string from a C string.
 ///

--- a/core/embed/sys/dbg/syslog.c
+++ b/core/embed/sys/dbg/syslog.c
@@ -153,7 +153,7 @@ bool syslog_start_record(const log_source_t* source, log_level_t level) {
     int name_len = (int)MIN(source->name_len, INT32_MAX);
 
     dbg_console_printf("%s%" PRIu32 ".%03" PRIu32 " " ESC_COLOR_SOURCE
-                       "%*s" ESC_COLOR_NORMAL " %s ",
+                       "%.*s" ESC_COLOR_NORMAL " %s ",
                        eol, seconds, msec, name_len, source->name, level_str);
 
     return true;

--- a/core/embed/sys/inc/sys/logging.h
+++ b/core/embed/sys/inc/sys/logging.h
@@ -31,7 +31,8 @@ typedef enum {
 
 /** Information about a source module */
 typedef struct {
-  /** Source module name shown in the logs */
+  /** Source module name shown in the logs (doesn't have to be NULL terminated)
+   */
   const char* name;
   /** Length of the module name in characters */
   size_t name_len;

--- a/core/mocks/generated/trezorlog.pyi
+++ b/core/mocks/generated/trezorlog.pyi
@@ -20,3 +20,10 @@ def warning(name: str, msg: str, *args: Any, *, iface: WireInterface | None = No
 # rust/src/micropython/logging.rs
 def error(name: str, msg: str, *args: Any, *, iface: WireInterface | None = None) -> None:
     ...
+
+
+# rust/src/micropython/logging.rs
+def init(level: int) -> None:
+    """
+    Initialize Rust logging connector.
+    """

--- a/core/src/trezor/log.py
+++ b/core/src/trezor/log.py
@@ -11,11 +11,12 @@ def _no_op(name: str, msg: str, *args: Any, iface: WireInterface | None = None) 
 
 
 if __debug__:
-    from trezorlog import debug, error, info, warning  # noqa: F401
+    from trezorlog import debug, error, info, init, warning  # noqa: F401
 
     _levels = [debug, info, warning, error]
     _min_level = 0  # can be used for manually disabling low-priority logging levels
     debug, info, warning, error = [_no_op] * _min_level + _levels[_min_level:]
+    init(_min_level)  # initialize rust logging connector
 else:
     # logging is disabled in non-debug builds
     debug = warning = info = error = _no_op


### PR DESCRIPTION
Allows rust code to access centralized logging (#6208) using [log crate](https://docs.rs/log/latest/log/) macros `log::error!`, `log::warn!`, `log::info!`, `log::debug!`. This also works for any rust dependencies that are using `log`.

The disadvantage is that `log` has deep ties to [core::fmt](https://doc.rust-lang.org/core/fmt/index.html) which we are trying to avoid for flash size reasons. There is no `ufmt` integration, you can explicitly format with `uformat!` but can't force other crates to do so. For this reason the connector is only enabled on PYOPT=0 emulator (actually on [profiles other than release](https://docs.rs/log/latest/log/#compile-time-filters)).

Enabling it on firmware and adding `log::info!("Rendering text {} (length: {})", text, text.len())` increases the image size by 2KiB and gets worse the more types you try to format.

<!--
For external contributors:
- Please open an issue before submitting a PR so we can discuss whether we want to proceed with it.

For core developers:
1. Initial PR setup
- Assign yourself to the PR.
- Add it to the "Firmware" project
  - Set Priority (match issue priority if it exists)
  - Set Team
  - Set Sprint (target release)

2. Development status
- Draft PRs: Set status to "In Progress"
- Final PRs: Set status to "Needs Review"

3. Post-merge status
- Testable: Set status to "Needs QA" and add a `Notes for QA` section with clear instructions on how to test the functionality.
- Not Testable: Set status to "Done (no QA)"
-->
