### PR TITLE
chore(docs): adjust description of `core` in the readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@
 * **[`common/defs`](common/defs/)**: JSON coin definitions and support tables
 * **[`common/protob`](common/protob/)**: Common protobuf definitions for the Trezor protocol
 * **[`common/tools`](common/tools/)**: Tools for managing coin definitions and related data
-* **[`core`](core/)**: Trezor Core, firmware implementation for Trezor T
+* **[`core`](core/)**: Trezor Core, a firmware implementation for Trezor T, Trezor Safe 3, Trezor Safe 5, and Trezor Safe 7
 * **[`crypto`](crypto/)**: Stand-alone cryptography library used by both Trezor Core and the Trezor One firmware
 * **[`docs`](docs/)**: Assorted documentation
 * **[`legacy`](legacy/)**: Trezor One firmware implementation
@@ -18,16 +18,15 @@
 * **[`tools`](tools/)**: Miscellaneous build and helper scripts
 * **[`vendor`](vendor/)**: Submodules for external dependencies
 
-
 ## Contribute
 
 See [CONTRIBUTING.md](docs/misc/contributing.md).
 
-Using [Conventional Commits](COMMITS.md) is strongly recommended and might be enforced in future.
+Using [Conventional Commits](COMMITS.md) is strongly recommended and might be enforced in the future.
 
-Also please have a look at the docs, either in the `docs` folder or at  [docs.trezor.io](https://docs.trezor.io) before contributing. The [misc](docs/misc/index.md) chapter should be read in particular because it contains some useful assorted knowledge.
+Also, please have a look at the docs, either in the `docs` folder or at [docs.trezor.io](https://docs.trezor.io) before contributing. The [misc](docs/misc/index.md) chapter should be read in particular, as it contains useful assorted knowledge.
 
-## Security vulnerability disclosure
+## Security Vulnerability Disclosure
 
 Please do NOT create publicly viewable issues for suspected security vulnerabilities. See the [Security tab](https://github.com/trezor/trezor-firmware/security/policy) for reporting instructions.
 


### PR DESCRIPTION
- Adjusted description of `core`, because it contains firmware implementation for Trezor Safe models, too - not only Trezor T.
- Added few minor readme fixes.


Note: I acknowledge that this change is a super nit - I am just not happy with the current description of `core` ...