### PR TITLE
Avoid out-of-bounds read in utils.consteq()

### DIFF
--- a/core/embed/upymod/modtrezorutils/modtrezorutils.c
+++ b/core/embed/upymod/modtrezorutils/modtrezorutils.c
@@ -98,9 +98,8 @@ STATIC MP_DEFINE_CONST_FUN_OBJ_0(mod_trezorutils_telemetry_get_obj,
 /// def consteq(sec: AnyBytes, pub: AnyBytes) -> bool:
 ///     """
 ///     Compares the private information in `sec` with public, user-provided
-///     information in `pub`.  Runs in constant time, corresponding to a length
-///     of `pub`.  Can access memory behind valid length of `sec`, caller is
-///     expected to avoid any invalid memory access.
+///     information in `pub`.  Runs in constant time, corresponding to the
+///     length of `pub`.
 ///     """
 STATIC mp_obj_t mod_trezorutils_consteq(mp_obj_t sec, mp_obj_t pub) {
   mp_buffer_info_t secbuf = {0};
@@ -108,11 +107,11 @@ STATIC mp_obj_t mod_trezorutils_consteq(mp_obj_t sec, mp_obj_t pub) {
   mp_buffer_info_t pubbuf = {0};
   mp_get_buffer_raise(pub, &pubbuf, MP_BUFFER_READ);
 
+  const uint8_t *s = (uint8_t *)secbuf.buf;
+  const uint8_t *p = (uint8_t *)pubbuf.buf;
   size_t diff = secbuf.len - pubbuf.len;
   for (size_t i = 0; i < pubbuf.len; i++) {
-    const uint8_t *s = (uint8_t *)secbuf.buf;
-    const uint8_t *p = (uint8_t *)pubbuf.buf;
-    diff |= s[i] - p[i];
+    diff |= s[i % secbuf.len] - p[i];
   }
 
   if (diff == 0) {

--- a/core/embed/upymod/modtrezorutils/modtrezorutils.c
+++ b/core/embed/upymod/modtrezorutils/modtrezorutils.c
@@ -98,9 +98,8 @@ STATIC MP_DEFINE_CONST_FUN_OBJ_0(mod_trezorutils_telemetry_get_obj,
 /// def consteq(sec: AnyBytes, pub: AnyBytes) -> bool:
 ///     """
 ///     Compares the private information in `sec` with public, user-provided
-///     information in `pub`.  Runs in constant time, corresponding to a length
-///     of `pub`.  Can access memory behind valid length of `sec`, caller is
-///     expected to avoid any invalid memory access.
+///     information in `pub`.  Runs in constant time, corresponding to the
+///     length of `pub`.
 ///     """
 STATIC mp_obj_t mod_trezorutils_consteq(mp_obj_t sec, mp_obj_t pub) {
   mp_buffer_info_t secbuf = {0};
@@ -108,10 +107,14 @@ STATIC mp_obj_t mod_trezorutils_consteq(mp_obj_t sec, mp_obj_t pub) {
   mp_buffer_info_t pubbuf = {0};
   mp_get_buffer_raise(pub, &pubbuf, MP_BUFFER_READ);
 
-  size_t diff = secbuf.len - pubbuf.len;
+  // Redirect s to p when lengths differ so the loop cannot read past sec,
+  // while keeping the instruction count independent of the secret length.
+  uint8_t diff = (secbuf.len != pubbuf.len);
+  uintptr_t mask = -(uintptr_t)diff;
+  const uint8_t *s = (const uint8_t *)(((uintptr_t)secbuf.buf & ~mask) |
+                                       ((uintptr_t)pubbuf.buf & mask));
+  const uint8_t *p = (const uint8_t *)pubbuf.buf;
   for (size_t i = 0; i < pubbuf.len; i++) {
-    const uint8_t *s = (uint8_t *)secbuf.buf;
-    const uint8_t *p = (uint8_t *)pubbuf.buf;
     diff |= s[i] - p[i];
   }
 

--- a/core/mocks/generated/trezorutils.pyi
+++ b/core/mocks/generated/trezorutils.pyi
@@ -24,9 +24,8 @@ def telemetry_get() -> tuple[int, int, int, int] | None:
 def consteq(sec: AnyBytes, pub: AnyBytes) -> bool:
     """
     Compares the private information in `sec` with public, user-provided
-    information in `pub`.  Runs in constant time, corresponding to a length
-    of `pub`.  Can access memory behind valid length of `sec`, caller is
-    expected to avoid any invalid memory access.
+    information in `pub`.  Runs in constant time, corresponding to the
+    length of `pub`.
     """
 
 

--- a/core/tests/test_trezor.utils.py
+++ b/core/tests/test_trezor.utils.py
@@ -101,6 +101,22 @@ class TestUtils(unittest.TestCase):
         utils.memzero(data)
         self.assertEqual(data, bytearray(10))
 
+    def test_consteq(self):
+        self.assertTrue(utils.consteq(b"", b""))
+        self.assertFalse(utils.consteq(b"", b"\x42"))
+        self.assertFalse(utils.consteq(b"\x42", b""))
+        self.assertFalse(utils.consteq(b"hell", b"hello"))
+        self.assertFalse(utils.consteq(b"hello", b"ello"))
+        long1 = b"x" * 999 + b"y"
+        long2 = b"x" * 1000
+        self.assertFalse(utils.consteq(bytearray(long1), long2))
+        self.assertFalse(utils.consteq(long1, bytearray(long2)))
+        self.assertTrue(utils.consteq(long1, bytearray(long1)))
+        self.assertTrue(utils.consteq(bytearray(long1), long1))
+        self.assertFalse(utils.consteq(b"", long1))
+        self.assertTrue(utils.consteq(memoryview(b"hello"), b"hello"))
+        self.assertTrue(utils.consteq(b"hello", memoryview(b"hello")))
+
 
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
`utils.consteq()` is written to avoid leaking the length of the first input parameter, however it risks an out-of-bounds read if the first string is shorter than the second, which I think is a nasty footgun. I don't know whether modular division is perfectly constant time on ARM (probably UDIV + MSUB), however even if it's not, I propose what seems to be a better tradeoff in terms of code safety vs. side-channel leakage. What do you guys think? AFAICS, right now we don't actually use `consteq()` on variable-length strings anyway.