### PR TITLE
fix(core): use consteq in thp crypto

### DIFF
--- a/core/src/trezor/wire/thp/crypto.py
+++ b/core/src/trezor/wire/thp/crypto.py
@@ -54,7 +54,7 @@ def dec(
     aes_ctx.auth(auth_data)
     aes_ctx.decrypt_in_place(buffer)
     computed_tag = aes_ctx.finish()
-    return computed_tag == tag
+    return utils.consteq(computed_tag, tag)
 
 
 class BusyDecoder:
@@ -69,7 +69,7 @@ class BusyDecoder:
 
     def finish_and_check_tag(self, tag: bytes) -> bool:
         computed_tag = self.aes_ctx.finish()
-        return computed_tag == tag
+        return utils.consteq(computed_tag, tag)
 
 
 PROTOCOL_NAME = b"Noise_XX_25519_AESGCM_SHA256\x00\x00\x00\x00"
@@ -173,7 +173,7 @@ class Handshake:
             :PUBKEY_LENGTH
         ]
         tag = aes_ctx.finish()
-        if tag != encrypted_host_static_public_key[-16:]:
+        if not utils.consteq(tag, encrypted_host_static_public_key[-16:]):
             raise ThpDecryptionError()
 
         self.ck, self.k = _hkdf(
@@ -191,7 +191,7 @@ class Handshake:
                 __name__, "th2 - dec (key: %s, nonce: %d)", hexlify_if_bytes(self.k), 0
             )
         tag = aes_ctx.finish()
-        if tag != encrypted_payload[-16:]:
+        if not utils.consteq(tag, encrypted_payload[-16:]):
             raise ThpDecryptionError()
 
         self.key_receive, self.key_send = _hkdf(self.ck, b"")


### PR DESCRIPTION
- Use of constant time comparison is preferred, as it is the correct way to verify cryptographic tags' validity.
- Note that the use of non-constant time comparison is not exploitable here. When the tag comparison fails, the secure channel is terminated. 