### PR TITLE
rust/trezor-thp: minor improvements

### DIFF
--- a/rust/trezor-thp/examples/host-cli/client.rs
+++ b/rust/trezor-thp/examples/host-cli/client.rs
@@ -2,10 +2,7 @@ use std::io::ErrorKind;
 use std::net::{SocketAddr, UdpSocket};
 use std::time::Duration;
 
-use trezor_thp::{
-    Backend, ChannelIO, Error, channel::buffered::Buffered, channel::host::Mux,
-    credential::CredentialStore,
-};
+use trezor_thp::{Backend, ChannelIO, Error, channel::buffered::Buffered, channel::host::Mux};
 
 use protobuf::{Enum, Message};
 
@@ -23,12 +20,11 @@ pub struct Client<C> {
     emu_addr: SocketAddr,
 }
 
-impl<C, B> Client<Mux<C, B>>
+impl<B> Client<Mux<B>>
 where
     B: Backend,
-    C: CredentialStore,
 {
-    pub fn open(emu_addr: SocketAddr, channel: Mux<C, B>) -> Self {
+    pub fn open(emu_addr: SocketAddr, channel: Mux<B>) -> Self {
         let mut channel = Buffered::new(channel);
         channel.set_packet_len(PACKET_LEN);
         Client {

--- a/rust/trezor-thp/examples/host-cli/main.rs
+++ b/rust/trezor-thp/examples/host-cli/main.rs
@@ -6,8 +6,8 @@ use std::{env, net::SocketAddr, str::FromStr};
 use protobuf::Message;
 
 use trezor_thp::{
-    Backend, Channel, Host,
-    channel::host::{ChannelOpen, Mux},
+    Backend,
+    channel::host::{Channel, ChannelOpen, Mux},
     credential::{CredentialStore, NullCredentialStore},
 };
 
@@ -29,7 +29,7 @@ impl Backend for RustCrypto {
     }
 }
 
-type HostChannel = Channel<Host, RustCrypto>;
+type HostChannel = Channel<RustCrypto>;
 
 fn do_allocation(client: &mut Client<Mux<RustCrypto>>) {
     client.call(0, &[]);
@@ -87,7 +87,7 @@ fn do_pairing_skip(client: &mut Client<HostChannel>) {
     );
 }
 
-fn do_ping(client: &mut Client<Channel<Host, RustCrypto>>) {
+fn do_ping(client: &mut Client<HostChannel>) {
     let mut ping = Ping::new();
     ping.set_message("trezor-thp/examples".into());
     ping.set_button_protection(true);

--- a/rust/trezor-thp/examples/host-cli/main.rs
+++ b/rust/trezor-thp/examples/host-cli/main.rs
@@ -31,10 +31,7 @@ impl Backend for RustCrypto {
 
 type HostChannel = Channel<Host, RustCrypto>;
 
-fn do_allocation<C>(client: &mut Client<Mux<C, RustCrypto>>)
-where
-    C: CredentialStore,
-{
+fn do_allocation(client: &mut Client<Mux<RustCrypto>>) {
     client.call(0, &[]);
 }
 
@@ -108,13 +105,13 @@ pub fn main() -> std::io::Result<()> {
     env_logger::init_from_env(env_logger::Env::default().filter_or("RUST_LOG", "info"));
 
     let cred_lookup = NullCredentialStore;
-    let mut channel = Mux::<_, RustCrypto>::new(cred_lookup);
+    let mut channel = Mux::<RustCrypto>::new();
     channel.request_channel(false);
     let mut client = Client::open(get_address(), channel);
 
     do_allocation(&mut client);
     assert!(client.channel.channel_alloc_ready());
-    let mut client = client.map(|c| c.complete().unwrap());
+    let mut client = client.map(|c| c.complete(cred_lookup).unwrap());
 
     do_handshake(&mut client);
     assert!(client.channel.handshake_done());

--- a/rust/trezor-thp/examples/transport-level-ping.rs
+++ b/rust/trezor-thp/examples/transport-level-ping.rs
@@ -4,9 +4,7 @@ use std::net::{SocketAddr, UdpSocket};
 use std::str::FromStr;
 use std::time::Duration;
 
-use trezor_thp::{
-    Backend, channel::buffered::ChannelExt, channel::host::Mux, credential::NullCredentialStore,
-};
+use trezor_thp::{Backend, channel::buffered::ChannelExt, channel::host::Mux};
 
 struct RustCrypto;
 
@@ -31,7 +29,7 @@ pub fn main() -> std::io::Result<()> {
     let socket = UdpSocket::bind("127.0.0.1:0")?;
 
     let mut recvbuf = [0u8; PACKET_LEN];
-    let mut mux = Mux::<_, RustCrypto>::new(NullCredentialStore).into_buffered();
+    let mut mux = Mux::<RustCrypto>::new().into_buffered();
     mux.set_packet_len(PACKET_LEN);
 
     for _i in 0..REPEAT {

--- a/rust/trezor-thp/src/channel/device.rs
+++ b/rust/trezor-thp/src/channel/device.rs
@@ -144,7 +144,7 @@ where
             // No Header::TransportError for broadcast.
             _ => {
                 log::debug!(
-                    "Broadcast channel: ignoring packet with control byte {}.",
+                    "Broadcast channel: ignoring packet with control byte 0x{:x}.",
                     packet[0]
                 );
                 Err(Error::malformed_data())
@@ -198,7 +198,7 @@ where
             return self.handle_v1(packet_buffer);
         }
         if !channel_id_valid(channel_id) {
-            log::warn!("Invalid channel id {}.", channel_id);
+            log::warn!("Invalid channel id {:04x}.", channel_id);
             return PacketInResult::ignore(Error::malformed_data());
         }
         if channel_id != BROADCAST_CHANNEL_ID {
@@ -339,7 +339,7 @@ impl<C: CredentialVerifier, B: Backend> ChannelOpen<C, B> {
                 self.state = HandshakeState::SendingCompletionResponse { pairing_state };
             }
             _ => {
-                log::error!("[{}] Unexpected handshake state.", self.channel_id());
+                log::error!("[{:04x}] Unexpected handshake state.", self.channel_id());
                 return Err(Error::unexpected_input());
             }
         }
@@ -422,7 +422,7 @@ impl<C: CredentialVerifier, B: Backend> ChannelOpen<C, B> {
         if !self.handshake_done() {
             return Err(Error::not_ready());
         }
-        log::debug!("Handshake complete.");
+        log::debug!("[{:04x}] Handshake complete.", self.channel_id());
         Ok(match self.state {
             HandshakeState::SendingCompletionResponse { pairing_state } => {
                 self.channel.pairing_state = pairing_state;
@@ -477,7 +477,7 @@ where
             .packet_in(packet_buffer, &mut self.internal_buffer);
         if let PacketInResult::EnlargeBuffer { buffer_size, .. } = res {
             log::error!(
-                "[{}] Payload length {} exceeds handshake limit.",
+                "[{:04x}] Payload length {} exceeds handshake limit.",
                 self.channel_id(),
                 buffer_size
             );

--- a/rust/trezor-thp/src/channel/device.rs
+++ b/rust/trezor-thp/src/channel/device.rs
@@ -16,7 +16,10 @@ use crate::{
     util::prepare_zeroed,
 };
 
-use core::marker::PhantomData;
+use core::{
+    marker::PhantomData,
+    sync::atomic::{AtomicU16, Ordering},
+};
 
 // Must fit any of:
 // - device_properties + overhead
@@ -34,12 +37,9 @@ const CODEC_V1_RESPONSE: &[u8] = b"?##\x00\x03\x00\x00\x00\x02\x08\x11";
 /// Every packet interface on the device needs to have one Mux. Event loop should pass every
 /// incoming packet to [`Mux::packet_in`] in order to determine what to do with it.
 /// Single packet only. Does not keep track of opened channels.
-pub struct Mux<C, B> {
-    // is_locked: bool,
-    next_channel_id: u16,
-    cred_verif: C,
+pub struct Mux<B> {
     outgoing: heapless::Deque<MuxOutgoing, BROADCAST_OUTGOING_QUEUE_LEN>,
-    new_channel: Option<(u16, Nonce)>,
+    new_channel: Option<Nonce>,
     _phantom: PhantomData<B>,
 }
 
@@ -59,17 +59,12 @@ impl MuxOutgoing {
     }
 }
 
-impl<C, B> Mux<C, B>
+impl<B> Mux<B>
 where
-    C: CredentialVerifier,
     B: Backend,
 {
-    pub fn new(cred_verif: C) -> Self {
-        // Use random starting id to avoid giving out the number of channels allocated since boot.
-        let next_channel_id = random_channel_id::<B>();
+    pub const fn new() -> Self {
         Self {
-            next_channel_id,
-            cred_verif,
             outgoing: heapless::Deque::new(),
             new_channel: None,
             _phantom: PhantomData,
@@ -77,11 +72,21 @@ where
     }
 
     /// Create new [`ChannelOpen`] when channel allocation request is pending.
-    pub fn channel_alloc(&mut self) -> Result<ChannelOpen<C, B>, Error> {
-        let Some((channel_id, nonce)) = self.new_channel.take() else {
+    pub fn channel_alloc<C>(
+        &mut self,
+        channel_id: u16,
+        cred_verif: C,
+    ) -> Result<ChannelOpen<C, B>, Error>
+    where
+        C: CredentialVerifier,
+    {
+        if !channel_id_valid(channel_id) || channel_id == BROADCAST_CHANNEL_ID {
+            return Err(Error::unexpected_input());
+        }
+        let Some(nonce) = self.new_channel.take() else {
             return Err(Error::not_ready());
         };
-        ChannelOpen::<C, B>::new(channel_id, nonce, self.cred_verif.clone())
+        ChannelOpen::<C, B>::new(channel_id, nonce, cred_verif)
     }
 
     /// Returns `true` if there is channel allocation request pending.
@@ -118,26 +123,21 @@ where
         })
     }
 
-    fn handle_broadcast(&mut self, packet: &[u8]) -> Result<Option<u16>, Error> {
+    // Returns true if allocation request has been received.
+    fn handle_broadcast(&mut self, packet: &[u8]) -> Result<bool, Error> {
         let (header, payload) = Reassembler::<Device>::single_inplace(packet)?;
         match header {
             Header::Ping if payload.len() == Nonce::LEN => {
-                let (nonce, _rest) = Nonce::parse(payload).unwrap();
-                self.enqueue(MuxOutgoing::Pong(nonce)).map(|_| None)
+                let (nonce, _rest) = Nonce::parse(payload)?;
+                self.enqueue(MuxOutgoing::Pong(nonce)).map(|_| false)
             }
             Header::ChannelAllocationRequest if payload.len() == Nonce::LEN => {
                 let (nonce, _rest) = Nonce::parse(payload)?;
-                let channel_id = self.next_channel_id;
-                self.next_channel_id += 1;
-                if self.next_channel_id > MAX_CHANNEL_ID {
-                    log::debug!("Channel id max value reached, wrapping around.");
-                    self.next_channel_id = MIN_CHANNEL_ID;
-                }
                 if self.new_channel.is_some() {
                     log::warn!("Dropping previous channel allocation request.");
                 }
-                self.new_channel = Some((channel_id, nonce));
-                Ok(Some(channel_id))
+                self.new_channel = Some(nonce);
+                Ok(true)
             }
             // No Header::TransportError for broadcast.
             _ => {
@@ -172,17 +172,19 @@ where
         };
         PacketInResult::ignore(Error::malformed_data())
     }
+}
 
-    #[cfg(test)]
-    pub(crate) fn set_next_channel_id(&mut self, channel_id: u16) {
-        assert!(channel_id_valid(channel_id));
-        self.next_channel_id = channel_id;
+impl<B> Default for Mux<B>
+where
+    B: Backend,
+{
+    fn default() -> Self {
+        Self::new()
     }
 }
 
-impl<C, B> ChannelIO for Mux<C, B>
+impl<B> ChannelIO for Mux<B>
 where
-    C: CredentialVerifier,
     B: Backend,
 {
     fn packet_in(&mut self, packet_buffer: &[u8], _receive_buffer: &mut [u8]) -> PacketInResult {
@@ -200,11 +202,12 @@ where
         if channel_id != BROADCAST_CHANNEL_ID {
             return PacketInResult::route(channel_id);
         }
-        PacketInResult::from_result(self.handle_broadcast(packet_buffer).map(|r| {
-            r.map_or_else(
-                || PacketInResult::accept(false),
-                PacketInResult::channel_allocation,
-            )
+        PacketInResult::from_result(self.handle_broadcast(packet_buffer).map(|is_allocation| {
+            if is_allocation {
+                PacketInResult::channel_allocation()
+            } else {
+                PacketInResult::accept(false)
+            }
         }))
     }
 
@@ -543,14 +546,39 @@ where
     }
 }
 
-fn random_channel_id<B: Backend>() -> u16 {
-    let mut bytes = [0u8, 0u8];
-    for _i in 0..16 {
+/// Helper for assigning consecutive channel IDs.
+pub struct ChannelIdAllocator {
+    // Next value. Not guaranteed to be valid channel id, these are skipped
+    // in `ChannelIdAllocator::get()` until a valid one is found.
+    counter: AtomicU16,
+}
+
+impl ChannelIdAllocator {
+    /// Use random starting id to avoid giving out the number of channels allocated since boot.
+    pub fn new_random<B: Backend>() -> Self {
+        let mut bytes = [0u8, 0u8];
         B::random_bytes(&mut bytes);
-        let channel_id = u16::from_be_bytes(bytes);
-        if channel_id_valid(channel_id) && channel_id != BROADCAST_CHANNEL_ID {
-            return channel_id;
+        Self::new_from(u16::from_be_bytes(bytes))
+    }
+
+    /// Use fixed starting id, mainly useful for tests.
+    /// Please note [`ChannelIdAllocator::get()`] skips invalid values so the first result
+    /// is not necessarily the argument passed to this constructor.
+    pub const fn new_from(init_val: u16) -> Self {
+        Self {
+            counter: AtomicU16::new(init_val),
         }
     }
-    panic!("Cannot generate random channel id.");
+
+    /// Get next ID. Wraps around to `MIN_CHANNEL_ID`.
+    /// If the caller has multiple channels it needs to check whether the returned
+    /// ID is not currently in use.
+    pub fn get(&self) -> u16 {
+        loop {
+            let channel_id = self.counter.fetch_add(1, Ordering::Relaxed);
+            if (MIN_CHANNEL_ID..=MAX_CHANNEL_ID).contains(&channel_id) {
+                return channel_id;
+            }
+        }
+    }
 }

--- a/rust/trezor-thp/src/channel/device.rs
+++ b/rust/trezor-thp/src/channel/device.rs
@@ -73,6 +73,11 @@ where
         }
     }
 
+    /// Reset everything to initial state - discard outgoing messages and channel allocation.
+    pub fn reset(&mut self) {
+        *self = Self::new()
+    }
+
     /// Create new [`ChannelOpen`] when channel allocation request is pending.
     pub fn channel_alloc<C>(
         &mut self,

--- a/rust/trezor-thp/src/channel/device.rs
+++ b/rust/trezor-thp/src/channel/device.rs
@@ -385,13 +385,6 @@ impl<C: CredentialVerifier, B: Backend> ChannelOpen<C, B> {
         Ok(ps)
     }
 
-    pub fn pairing_state(&self) -> Option<PairingState> {
-        match self.state {
-            HandshakeState::SendingCompletionResponse { pairing_state } => Some(pairing_state),
-            _ => None,
-        }
-    }
-
     /// True if handshake finished and [`ChannelOpen::complete()`] can be called.
     pub fn handshake_done(&self) -> bool {
         // Done only after peer acknowledges completion response.
@@ -423,13 +416,19 @@ impl<C: CredentialVerifier, B: Backend> ChannelOpen<C, B> {
     ///
     /// [Pairing phase]: https://docs.trezor.io/trezor-firmware/common/thp/specification.html#pairing-phase
     /// [Credential phase]: https://docs.trezor.io/trezor-firmware/common/thp/specification.html#credential-phase
-    pub fn complete(self) -> Result<Channel<B>, Error> {
+    pub fn complete(mut self) -> Result<Channel<B>, Error> {
         if self.channel.noise.is_none() {
             return Err(Error::unexpected_input());
         }
+        if !self.handshake_done() {
+            return Err(Error::not_ready());
+        }
         log::debug!("Handshake complete.");
         Ok(match self.state {
-            HandshakeState::SendingCompletionResponse { .. } => self.channel,
+            HandshakeState::SendingCompletionResponse { pairing_state } => {
+                self.channel.pairing_state = pairing_state;
+                self.channel
+            }
             _ => return Err(Error::unexpected_input()),
         })
     }
@@ -466,6 +465,10 @@ impl<C: CredentialVerifier, B: Backend> ChannelOpen<C, B> {
         self.send_initiation_response(static_privkey)?;
         self.state = HandshakeState::SendingInitiationResponse;
         Ok(())
+    }
+
+    pub fn credential_verifier(&mut self) -> &mut C {
+        &mut self.cred_verif
     }
 }
 

--- a/rust/trezor-thp/src/channel/device.rs
+++ b/rust/trezor-thp/src/channel/device.rs
@@ -1,7 +1,7 @@
 use heapless;
 
 use crate::{
-    Backend, Channel, ChannelIO, Device, Error,
+    Backend, ChannelIO, Device, Error,
     alternating_bit::SyncBits,
     channel::{
         ChannelState, Nonce, PRIVKEY_LEN, PacketInResult, PairingState, noise::NoiseHandshake,
@@ -32,6 +32,8 @@ const INTERNAL_BUFFER_LEN: usize = 192;
 const BROADCAST_OUTGOING_QUEUE_LEN: usize = 8;
 // "?##" + Failure message type + msg_size + msg_data (code = "Failure_InvalidProtocol")
 const CODEC_V1_RESPONSE: &[u8] = b"?##\x00\x03\x00\x00\x00\x02\x08\x11";
+
+pub type Channel<B> = super::Channel<Device, B>;
 
 /// Maps packets to channels. Handles broadcast channel messages, notably channel allocation.
 /// Every packet interface on the device needs to have one Mux. Event loop should pass every
@@ -285,7 +287,7 @@ enum HandshakeState {
 /// Please note that this object also handles sending ChannelAllocationResponse
 /// which is a broadcast message, which are normally handled by [`Mux`].
 pub struct ChannelOpen<C: CredentialVerifier, B: Backend> {
-    channel: Channel<Device, B>,
+    channel: Channel<B>,
     state: HandshakeState,
     noise: NoiseHandshake<Device, B>,
     internal_buffer: heapless::Vec<u8, INTERNAL_BUFFER_LEN>,
@@ -421,7 +423,7 @@ impl<C: CredentialVerifier, B: Backend> ChannelOpen<C, B> {
     ///
     /// [Pairing phase]: https://docs.trezor.io/trezor-firmware/common/thp/specification.html#pairing-phase
     /// [Credential phase]: https://docs.trezor.io/trezor-firmware/common/thp/specification.html#credential-phase
-    pub fn complete(self) -> Result<Channel<Device, B>, Error> {
+    pub fn complete(self) -> Result<Channel<B>, Error> {
         if self.channel.noise.is_none() {
             return Err(Error::unexpected_input());
         }

--- a/rust/trezor-thp/src/channel/device.rs
+++ b/rust/trezor-thp/src/channel/device.rs
@@ -394,8 +394,7 @@ impl<C: CredentialVerifier, B: Backend> ChannelOpen<C, B> {
 
     /// True if the handshake failed and the object should be discarded.
     pub fn handshake_failed(&self) -> bool {
-        matches!(self.state, HandshakeState::Failed)
-            || matches!(self.channel.state, ChannelState::Failed(_))
+        matches!(self.state, HandshakeState::Failed) || self.channel.is_failed()
     }
 
     /// True if the handshake is waiting for device static key to be supplied using
@@ -446,12 +445,7 @@ impl<C: CredentialVerifier, B: Backend> ChannelOpen<C, B> {
         if !self.static_key_required() {
             return Err(Error::not_ready());
         }
-        let header = Header::new_error(self.channel.channel_id)?;
-        self.internal_buffer.clear();
-        let _ = self
-            .internal_buffer
-            .push(TransportError::DeviceLocked.into());
-        self.channel.raw_in(header, &self.internal_buffer)?;
+        self.channel.send_error(TransportError::DeviceLocked);
         self.state = HandshakeState::SendingDeviceLocked;
         Ok(())
     }
@@ -492,10 +486,6 @@ where
             return PacketInResult::ignore(Error::malformed_data());
         }
         if res.got_ack() {
-            if matches!(self.state, HandshakeState::SendingDeviceLocked) {
-                self.state = HandshakeState::Failed;
-                return res;
-            }
             prepare_zeroed(&mut self.internal_buffer);
         }
         if res.got_message() {

--- a/rust/trezor-thp/src/channel/device.rs
+++ b/rust/trezor-thp/src/channel/device.rs
@@ -438,6 +438,10 @@ impl<C: CredentialVerifier, B: Backend> ChannelOpen<C, B> {
         self.channel.channel_id
     }
 
+    pub fn sending_retry(&self) -> Option<u8> {
+        self.channel.sending_retry()
+    }
+
     /// Notify host that handshake cannot proceed because device static key is not available.
     pub fn send_device_locked(&mut self) -> Result<(), Error> {
         if !self.static_key_required() {

--- a/rust/trezor-thp/src/channel/host.rs
+++ b/rust/trezor-thp/src/channel/host.rs
@@ -178,7 +178,7 @@ where
             // No Header::TransportError for broadcast channel.
             _ => {
                 log::debug!(
-                    "Broadcast channel: ignoring packet with control byte {}.",
+                    "Broadcast channel: ignoring packet with control byte 0x{:x}.",
                     packet[0]
                 );
                 Err(Error::malformed_data())
@@ -215,7 +215,7 @@ where
             try_to_unlock: *try_to_unlock,
             channel_id,
         };
-        log::debug!("Got channel id {}.", channel_id);
+        log::debug!("Got channel id {:04x}.", channel_id);
         Ok(PacketInResult::channel_allocation())
     }
 }
@@ -239,7 +239,7 @@ where
             return PacketInResult::ignore(Error::malformed_data());
         };
         if !channel_id_valid(channel_id) {
-            log::warn!("Invalid channel id {}.", channel_id);
+            log::warn!("Invalid channel id {:04x}.", channel_id);
             return PacketInResult::ignore(Error::malformed_data());
         }
         if channel_id != BROADCAST_CHANNEL_ID && !cb.is_codec_v1() {
@@ -460,7 +460,7 @@ impl<C: CredentialStore, B: Backend> ChannelOpen<C, B> {
         if self.channel.noise.is_none() {
             return Err(Error::unexpected_input());
         }
-        log::debug!("Handshake complete.");
+        log::debug!("[{:04x}] Handshake complete.", self.channel_id());
         Ok(match self.state {
             HandshakeState::Finished { pairing_state } => {
                 self.channel.pairing_state = pairing_state;
@@ -490,7 +490,7 @@ where
             .packet_in(packet_buffer, &mut self.internal_buffer);
         if let PacketInResult::EnlargeBuffer { buffer_size, .. } = res {
             log::error!(
-                "[{}] Payload length {} exceeds handshake limit.",
+                "[{:04x}] Payload length {} exceeds handshake limit.",
                 self.channel_id(),
                 buffer_size
             );

--- a/rust/trezor-thp/src/channel/host.rs
+++ b/rust/trezor-thp/src/channel/host.rs
@@ -442,8 +442,7 @@ impl<C: CredentialStore, B: Backend> ChannelOpen<C, B> {
 
     /// True if the handshake failed and the object should be discarded.
     pub fn handshake_failed(&self) -> bool {
-        matches!(self.state, HandshakeState::Failed)
-            || matches!(self.channel.state, ChannelState::Failed(_))
+        matches!(self.state, HandshakeState::Failed) || self.channel.is_failed()
     }
 
     /// Finish the handshake.

--- a/rust/trezor-thp/src/channel/host.rs
+++ b/rust/trezor-thp/src/channel/host.rs
@@ -479,6 +479,10 @@ impl<C: CredentialStore, B: Backend> ChannelOpen<C, B> {
     pub fn channel_id(&self) -> u16 {
         self.channel.channel_id
     }
+
+    pub fn sending_retry(&self) -> Option<u8> {
+        self.channel.sending_retry()
+    }
 }
 
 impl<C, B> ChannelIO for ChannelOpen<C, B>

--- a/rust/trezor-thp/src/channel/host.rs
+++ b/rust/trezor-thp/src/channel/host.rs
@@ -435,17 +435,9 @@ impl<C: CredentialStore, B: Backend> ChannelOpen<C, B> {
         self.device_properties.as_slice()
     }
 
-    /// Returns pairing state if handshake finished, or None otherwise.
-    pub fn pairing_state(&self) -> Option<PairingState> {
-        match self.state {
-            HandshakeState::Finished { pairing_state } => Some(pairing_state),
-            _ => None,
-        }
-    }
-
     /// True if handshake finished and [`ChannelOpen::complete()`] can be called.
     pub fn handshake_done(&self) -> bool {
-        self.pairing_state().is_some()
+        matches!(self.state, HandshakeState::Finished { .. })
     }
 
     /// True if the handshake failed and the object should be discarded.
@@ -465,13 +457,16 @@ impl<C: CredentialStore, B: Backend> ChannelOpen<C, B> {
     ///
     /// [Pairing phase]: https://docs.trezor.io/trezor-firmware/common/thp/specification.html#pairing-phase
     /// [Credential phase]: https://docs.trezor.io/trezor-firmware/common/thp/specification.html#credential-phase
-    pub fn complete(self) -> Result<Channel<B>, Error> {
+    pub fn complete(mut self) -> Result<Channel<B>, Error> {
         if self.channel.noise.is_none() {
             return Err(Error::unexpected_input());
         }
         log::debug!("Handshake complete.");
         Ok(match self.state {
-            HandshakeState::Finished { .. } => self.channel,
+            HandshakeState::Finished { pairing_state } => {
+                self.channel.pairing_state = pairing_state;
+                self.channel
+            }
             _ => return Err(Error::unexpected_input()),
         })
     }

--- a/rust/trezor-thp/src/channel/host.rs
+++ b/rust/trezor-thp/src/channel/host.rs
@@ -80,6 +80,11 @@ where
         }
     }
 
+    /// Reset everything to initial state - discard keep-alive and channel allocation.
+    pub fn reset(&mut self) {
+        *self = Self::new()
+    }
+
     /// Enqueue a keep-alive message.
     pub fn ping(&mut self) {
         if !matches!(self.ping, PingState::None) {

--- a/rust/trezor-thp/src/channel/host.rs
+++ b/rust/trezor-thp/src/channel/host.rs
@@ -56,24 +56,21 @@ enum PingState {
 /// Handles broadcast channel messages, notably channel allocation requests.
 /// Because host often only needs a single channel, you can throw away the Mux
 /// after allocating one, if you don't need the keep-alive functionality.
-pub struct Mux<C, B> {
-    cred_store: C,
+pub struct Mux<B> {
     internal_buffer: heapless::Vec<u8, MAX_DEVICE_PROPERTIES_LEN>,
     channel_allocation: AllocationState,
     ping: PingState,
     _phantom: PhantomData<B>,
 }
 
-impl<C, B> Mux<C, B>
+impl<B> Mux<B>
 where
-    C: CredentialStore,
     B: Backend,
 {
-    pub fn new(cred_store: C) -> Self {
+    pub fn new() -> Self {
         let mut internal_buffer = heapless::Vec::new();
         prepare_zeroed(&mut internal_buffer);
         Self {
-            cred_store,
             internal_buffer,
             channel_allocation: AllocationState::None,
             ping: PingState::None,
@@ -98,7 +95,10 @@ where
     }
 
     /// Create new [`ChannelOpen`] after channel allocation response was received.
-    pub fn channel_alloc(&mut self) -> Result<ChannelOpen<C, B>, Error> {
+    pub fn channel_alloc<C>(&mut self, cred_store: C) -> Result<ChannelOpen<C, B>, Error>
+    where
+        C: CredentialStore,
+    {
         let AllocationState::ReceivedId {
             try_to_unlock,
             channel_id,
@@ -106,12 +106,7 @@ where
         else {
             return Err(Error::not_ready());
         };
-        let ch = ChannelOpen::new(
-            channel_id,
-            self.cred_store.clone(),
-            &self.internal_buffer,
-            try_to_unlock,
-        )?;
+        let ch = ChannelOpen::new(channel_id, cred_store, &self.internal_buffer, try_to_unlock)?;
         self.channel_allocation = AllocationState::None;
         prepare_zeroed(&mut self.internal_buffer);
         Ok(ch)
@@ -124,8 +119,11 @@ where
 
     /// Same as [`Mux::channel_alloc`] but destroys the [`Mux`],
     /// like `complete()` does for other types.
-    pub fn complete(mut self) -> Result<ChannelOpen<C, B>, Error> {
-        self.channel_alloc()
+    pub fn complete<C>(mut self, cred_store: C) -> Result<ChannelOpen<C, B>, Error>
+    where
+        C: CredentialStore,
+    {
+        self.channel_alloc(cred_store)
     }
 
     fn handle_broadcast(&mut self, packet: &[u8]) -> Result<PacketInResult, Error> {
@@ -216,13 +214,21 @@ where
             channel_id,
         };
         log::debug!("Got channel id {}.", channel_id);
-        Ok(PacketInResult::channel_allocation(channel_id))
+        Ok(PacketInResult::channel_allocation())
     }
 }
 
-impl<C, B> ChannelIO for Mux<C, B>
+impl<B> Default for Mux<B>
 where
-    C: CredentialStore,
+    B: Backend,
+{
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+impl<B> ChannelIO for Mux<B>
+where
     B: Backend,
 {
     fn packet_in(&mut self, packet_buffer: &[u8], _receive_buffer: &mut [u8]) -> PacketInResult {

--- a/rust/trezor-thp/src/channel/host.rs
+++ b/rust/trezor-thp/src/channel/host.rs
@@ -1,7 +1,7 @@
 use heapless;
 
 use crate::{
-    Backend, Channel, ChannelIO, Error, Host,
+    Backend, ChannelIO, Error, Host,
     alternating_bit::SyncBits,
     channel::{ChannelState, Nonce, PacketInResult, PairingState, noise::NoiseHandshake},
     credential::CredentialStore,
@@ -21,6 +21,8 @@ use core::marker::PhantomData;
 // - DH key + credential + 2 AEAD tags + overhead
 const INTERNAL_BUFFER_LEN: usize = 192;
 const MAX_DEVICE_PROPERTIES_LEN: usize = 128;
+
+pub type Channel<B> = super::Channel<Host, B>;
 
 enum AllocationState {
     None,
@@ -331,7 +333,7 @@ enum HandshakeState {
 /// - perform [`ChannelIO`] with empty messages until [`ChannelOpen::handshake_done`]
 /// - call [`ChannelOpen::complete`] to obtain [`Channel`]
 pub struct ChannelOpen<C: CredentialStore, B: Backend> {
-    channel: Channel<Host, B>,
+    channel: Channel<B>,
     state: HandshakeState,
     noise: NoiseHandshake<Host, B>,
     internal_buffer: heapless::Vec<u8, INTERNAL_BUFFER_LEN>,
@@ -463,7 +465,7 @@ impl<C: CredentialStore, B: Backend> ChannelOpen<C, B> {
     ///
     /// [Pairing phase]: https://docs.trezor.io/trezor-firmware/common/thp/specification.html#pairing-phase
     /// [Credential phase]: https://docs.trezor.io/trezor-firmware/common/thp/specification.html#credential-phase
-    pub fn complete(self) -> Result<Channel<Host, B>, Error> {
+    pub fn complete(self) -> Result<Channel<B>, Error> {
         if self.channel.noise.is_none() {
             return Err(Error::unexpected_input());
         }

--- a/rust/trezor-thp/src/channel/mod.rs
+++ b/rust/trezor-thp/src/channel/mod.rs
@@ -79,14 +79,17 @@ enum ChannelState<R: Role> {
     /// Ready to send or receive.
     Idle,
     /// In the process of sending a message, or waiting for ACK.
-    Sending(Fragmenter<R>),
+    Sending {
+        fragmenter: Fragmenter<R>,
+        retry: u8,
+    },
     /// In the process of receiving a message, or waiting for the consumer to pick up
     /// an assembled message.
-    Receiving(Reassembler<R>),
+    Receiving { reassembler: Reassembler<R> },
     /// Channel is inoperable.
     /// None: local failure
     /// Some: error message received from other side
-    Failed(Option<TransportError>),
+    Failed { error: Option<TransportError> },
 }
 
 /// THP channel with established secure layer.
@@ -125,24 +128,36 @@ impl<R: Role, B: Backend> Channel<R, B> {
         self.noise.as_ref().unwrap().handshake_hash()
     }
 
+    /// Return the retransmission attempt number (the first transmission returns 0),
+    /// or `None` if the channel is currently not sending anything.
+    pub fn sending_retry(&self) -> Option<u8> {
+        match self.state {
+            ChannelState::Sending { retry, .. } => Some(retry),
+            _ => None,
+        }
+    }
+
     fn raw_in(&mut self, header: Header<R>, send_buffer: &[u8]) -> Result<()> {
         let ChannelState::Idle = self.state else {
             return Err(Error::not_ready());
         };
         let sb = self.sync.send_start().ok_or_else(Error::not_ready)?;
-        let frag = Fragmenter::new(header, sb, send_buffer)?;
-        self.state = ChannelState::Sending(frag);
+        let fragmenter = Fragmenter::new(header, sb, send_buffer)?;
+        self.state = ChannelState::Sending {
+            fragmenter,
+            retry: 0,
+        };
         Ok(())
     }
 
     fn raw_out(&mut self, receive_buffer: &[u8]) -> Result<(Header<R>, usize)> {
-        let ChannelState::Receiving(r) = &mut self.state else {
+        let ChannelState::Receiving { reassembler } = &mut self.state else {
             return Err(Error::not_ready());
         };
-        if !r.is_done() {
+        if !reassembler.is_done() {
             return Err(Error::not_ready());
         }
-        let len = match r.verify(receive_buffer) {
+        let len = match reassembler.verify(receive_buffer) {
             Ok(len) => len,
             Err(e) => {
                 log::warn!(
@@ -153,7 +168,7 @@ impl<R: Role, B: Backend> Channel<R, B> {
             }
         };
         self.send_ack = Some(self.sync.receive_acknowledge());
-        let header = r.header().clone();
+        let header = reassembler.header().clone();
         self.state = ChannelState::Idle;
         Ok((header, len))
     }
@@ -191,27 +206,27 @@ impl<R: Role, B: Backend> Channel<R, B> {
         }
         Ok(match &mut self.state {
             // First fragment.
-            ChannelState::Receiving(_) | ChannelState::Idle if !is_cont => {
+            ChannelState::Receiving { .. } | ChannelState::Idle if !is_cont => {
                 let (is_done, enlarge) = self.handle_init(packet_buffer, receive_buffer)?;
                 PacketInResult::accept(is_done).with_buffer(enlarge)
             }
             // Continuation fragments.
-            ChannelState::Receiving(r) => {
-                r.update(packet_buffer, receive_buffer)?;
-                PacketInResult::accept(r.is_done())
+            ChannelState::Receiving { reassembler } => {
+                reassembler.update(packet_buffer, receive_buffer)?;
+                PacketInResult::accept(reassembler.is_done())
             }
             // Ignore unexpected continuations.
             ChannelState::Idle => return Err(Error::malformed_data()),
             // Might possibly happen when we've sent an ACK and it got lost.
             // We end up sending reply while the other side is retransmitting.
             // Is this recoverable?
-            ChannelState::Sending(_) => return Err(Error::malformed_data()),
-            ChannelState::Failed(_e) => return Err(Error::unexpected_input()),
+            ChannelState::Sending { .. } => return Err(Error::malformed_data()),
+            ChannelState::Failed { .. } => return Err(Error::unexpected_input()),
         })
     }
 
     fn handle_ack(&mut self, packet_buffer: &[u8]) -> Result<()> {
-        if matches!(self.state, ChannelState::Sending(_)) {
+        if matches!(self.state, ChannelState::Sending { .. }) {
             let sb = SyncBits::try_from(packet_buffer)?;
             self.sync.send_mark_delivered(sb);
             if self.sync.can_send() {
@@ -230,7 +245,7 @@ impl<R: Role, B: Backend> Channel<R, B> {
                 if let Ok(te) = TransportError::try_from(payload) {
                     log::error!("[{}] Peer sent an error: {}.", self.channel_id, te as u8);
                     if !te.is_recoverable() {
-                        self.state = ChannelState::Failed(Some(te));
+                        self.state = ChannelState::Failed { error: Some(te) };
                     }
                     return Ok(te);
                 } else {
@@ -241,7 +256,7 @@ impl<R: Role, B: Backend> Channel<R, B> {
                     );
                 }
             }
-            self.state = ChannelState::Failed(None);
+            self.state = ChannelState::Failed { error: None };
             return Err(Error::malformed_data());
         }
         log::warn!("[{}] Peer sent an error with invalid CRC.", self.channel_id);
@@ -261,9 +276,9 @@ impl<R: Role, B: Backend> Channel<R, B> {
             return Err(Error::malformed_data());
         }
         receive_buffer.fill(0);
-        let r = Reassembler::new(packet_buffer, receive_buffer)?;
-        let is_done = r.is_done();
-        let payload_len = r.header().payload_len();
+        let reassembler = Reassembler::new(packet_buffer, receive_buffer)?;
+        let is_done = reassembler.is_done();
+        let payload_len = reassembler.header().payload_len();
         let enlarge = (usize::from(payload_len) > receive_buffer.len()).then_some(payload_len);
         if enlarge.is_some() {
             log::debug!(
@@ -272,7 +287,7 @@ impl<R: Role, B: Backend> Channel<R, B> {
                 receive_buffer.len()
             );
         }
-        self.state = ChannelState::Receiving(r);
+        self.state = ChannelState::Receiving { reassembler };
         Ok((is_done, enlarge))
     }
 }
@@ -524,6 +539,8 @@ pub trait ChannelIO {
 
     /// Retransmit message previously submitted using [`Self::message_in`]. Does nothing if
     /// ACK was already received.
+    /// The library does not limit the number of retries - application needs to decide when
+    /// to abandon the channel.
     fn message_retransmit(&mut self) -> Result<()>;
 
     /// Submit message for channel to encrypt and fragment into packets.
@@ -557,12 +574,12 @@ pub trait ChannelIO {
 
 impl<R: Role, B: Backend> ChannelIO for Channel<R, B> {
     fn packet_in(&mut self, packet_buffer: &[u8], receive_buffer: &mut [u8]) -> PacketInResult {
-        if let ChannelState::Failed(_e) = self.state {
+        if let ChannelState::Failed { .. } = self.state {
             return PacketInResult::fail(Error::unexpected_input());
         }
         let res = PacketInResult::from_result(self.handle_packet(packet_buffer, receive_buffer));
         if let PacketInResult::Failed { .. } = res {
-            self.state = ChannelState::Failed(None);
+            self.state = ChannelState::Failed { error: None };
         }
         res
     }
@@ -574,15 +591,15 @@ impl<R: Role, B: Backend> ChannelIO for Channel<R, B> {
             Fragmenter::single(header, sb, &[], packet_buffer)?;
             return Ok(());
         }
-        let ChannelState::Sending(f) = &mut self.state else {
+        let ChannelState::Sending { fragmenter, .. } = &mut self.state else {
             return Err(Error::not_ready());
         };
-        let written = f.next(send_buffer, packet_buffer)?;
+        let written = fragmenter.next(send_buffer, packet_buffer)?;
         if !written {
             return Err(Error::not_ready());
         }
-        if f.is_done() {
-            if f.header().channel_id() == BROADCAST_CHANNEL_ID {
+        if fragmenter.is_done() {
+            if fragmenter.header().channel_id() == BROADCAST_CHANNEL_ID {
                 // This is a special case for `channel_allocation_response` which is the only
                 // message sent through Channel (by `device::ChannelOpen`) but does not
                 // wait for ACK because as it is sent on broadcast channel.
@@ -599,7 +616,7 @@ impl<R: Role, B: Backend> ChannelIO for Channel<R, B> {
             return true;
         }
         match &self.state {
-            ChannelState::Sending(f) => !f.is_done(),
+            ChannelState::Sending { fragmenter, .. } => !fragmenter.is_done(),
             _ => false,
         }
     }
@@ -637,7 +654,7 @@ impl<R: Role, B: Backend> ChannelIO for Channel<R, B> {
             Ok(plaintext_len) => &receive_buffer[..plaintext_len],
             Err(e) => {
                 log::error!("[{}] Decryption failed, channel closed.", self.channel_id);
-                self.state = ChannelState::Failed(None);
+                self.state = ChannelState::Failed { error: None };
                 return Err(e);
             }
         };
@@ -654,18 +671,32 @@ impl<R: Role, B: Backend> ChannelIO for Channel<R, B> {
 
     fn message_out_ready(&self) -> bool {
         match &self.state {
-            ChannelState::Receiving(r) => r.is_done(),
+            ChannelState::Receiving { reassembler } => reassembler.is_done(),
             _ => false,
         }
     }
 
     fn message_retransmit(&mut self) -> Result<()> {
-        let ChannelState::Sending(f) = &mut self.state else {
+        let ChannelState::Sending { fragmenter, retry } = &mut self.state else {
             log::warn!("[{}] Nothing to retransmit.", self.channel_id);
             return Ok(());
         };
         log::debug!("[{}] Retransmitting message.", self.channel_id);
-        f.reset();
+        fragmenter.reset();
+        *retry = retry.saturating_add(1);
         Ok(())
     }
+}
+
+/// Returns how many milliseconds to wait for an ACK for a given retransmission attempt.
+/// First timeout (0th retry) is after 200ms till ~3.52s.
+///
+/// Taken from the original micropython implementation - not part of the specification,
+/// you are free to use different function. It is recommended to measure the duration between
+/// sending last packet and receiving an ACK ("ack_latency") and add it to this number.
+pub fn retransmit_after_ms(retry: u8) -> u32 {
+    const MAX_RETRANSMISSION_COUNT: u8 = 50;
+    let retry: u32 = retry.min(MAX_RETRANSMISSION_COUNT - 1).into();
+
+    10300 - 1010000 / retry.saturating_add(100)
 }

--- a/rust/trezor-thp/src/channel/mod.rs
+++ b/rust/trezor-thp/src/channel/mod.rs
@@ -276,7 +276,7 @@ impl<R: Role, B: Backend> Channel<R, B> {
                 return Ok(());
             }
         }
-        log::warn!("[{}] Unexpected ACK.", self.channel_id);
+        log::warn!("[{:04x}] Unexpected ACK.", self.channel_id);
         Err(Error::malformed_data())
     }
 
@@ -285,14 +285,18 @@ impl<R: Role, B: Backend> Channel<R, B> {
         if let Ok((header, payload)) = Reassembler::<R>::single(packet_buffer, &mut err_buf) {
             if header.is_error() {
                 if let Ok(te) = TransportError::try_from(payload) {
-                    log::error!("[{}] Peer sent an error: {}.", self.channel_id, te as u8);
+                    log::error!(
+                        "[{:04x}] Peer sent an error: {}.",
+                        self.channel_id,
+                        te as u8
+                    );
                     if !te.is_recoverable() {
                         self.state = ChannelState::Failed { error: Some(te) };
                     }
                     return Ok(te);
                 } else {
                     log::error!(
-                        "[{}] Peer sent unknown error {}.",
+                        "[{:04x}] Peer sent unknown error 0x{:x}.",
                         self.channel_id,
                         payload.first().unwrap_or(&0)
                     );
@@ -301,7 +305,10 @@ impl<R: Role, B: Backend> Channel<R, B> {
             self.state = ChannelState::Failed { error: None };
             return Err(Error::malformed_data());
         }
-        log::warn!("[{}] Peer sent an error with invalid CRC.", self.channel_id);
+        log::warn!(
+            "[{:04x}] Peer sent an error with invalid CRC.",
+            self.channel_id
+        );
         Err(Error::malformed_data())
     }
 
@@ -690,7 +697,7 @@ impl<R: Role, B: Backend> ChannelIO for Channel<R, B> {
 
         if !header.is_encrypted() {
             log::error!(
-                "[{}] Invalid message type, expecting EncryptedTransport.",
+                "[{:04x}] Invalid message type, expecting EncryptedTransport.",
                 self.channel_id
             );
             return Err(Error::malformed_data());
@@ -713,7 +720,7 @@ impl<R: Role, B: Backend> ChannelIO for Channel<R, B> {
             }
         };
         if receive_buffer.len() < APP_HEADER_LEN {
-            log::error!("[{}] Incoming message too short.", self.channel_id);
+            log::error!("[{:04x}] Incoming message too short.", self.channel_id);
             // fails on the next two lines
         }
         let (session_id, rest) = receive_buffer
@@ -732,10 +739,10 @@ impl<R: Role, B: Backend> ChannelIO for Channel<R, B> {
 
     fn message_retransmit(&mut self) -> Result<()> {
         let ChannelState::Sending { fragmenter, retry } = &mut self.state else {
-            log::warn!("[{}] Nothing to retransmit.", self.channel_id);
+            log::warn!("[{:04x}] Nothing to retransmit.", self.channel_id);
             return Ok(());
         };
-        log::debug!("[{}] Retransmitting message.", self.channel_id);
+        log::debug!("[{:04x}] Retransmitting message.", self.channel_id);
         fragmenter.reset();
         *retry = retry.saturating_add(1);
         Ok(())

--- a/rust/trezor-thp/src/channel/mod.rs
+++ b/rust/trezor-thp/src/channel/mod.rs
@@ -324,11 +324,9 @@ pub enum PacketInResult {
     /// [`Mux::channel_alloc`] to create new channel object. Only [`device::Mux`] and [`host::Mux`]
     /// return this variant. There is no queue, do it before processing the next packet.
     ///
-    /// Please note that the library does not keep track of allocated ids, that is left to
-    /// the application. By creating a lot of new channels an attacker can obtain an id that
-    /// was issued earlier. If there is existing channel with such id it should be destroyed.
-    /// (This is only relevant on the device side.)
-    ChannelAllocation { channel_id: u16 },
+    /// On the device side, application is responsible for allocating unique ids. It can use
+    /// [`device::ChannelIdAllocator`] but still must check the result for uniqueness.
+    ChannelAllocation,
     /// Call [`device::ChannelOpen::set_static_key`] or [`device::ChannelOpen::send_device_locked`].
     /// Only [`device::ChannelOpen`] returns this variant.
     HandshakeKeyRequired { try_to_unlock: bool },
@@ -380,8 +378,8 @@ impl PacketInResult {
         Self::Failed { error }
     }
 
-    const fn channel_allocation(channel_id: u16) -> Self {
-        Self::ChannelAllocation { channel_id }
+    const fn channel_allocation() -> Self {
+        Self::ChannelAllocation
     }
 
     const fn pong() -> Self {
@@ -416,7 +414,7 @@ impl PacketInResult {
     }
 
     pub const fn got_channel(&self) -> bool {
-        matches!(self, Self::ChannelAllocation { .. })
+        matches!(self, Self::ChannelAllocation)
     }
 
     pub const fn got_pong(&self) -> bool {

--- a/rust/trezor-thp/src/channel/mod.rs
+++ b/rust/trezor-thp/src/channel/mod.rs
@@ -100,6 +100,9 @@ enum ChannelState<R: Role> {
         fragmenter: Fragmenter<R>,
         retry: u8,
     },
+    /// About to send Transport error, these are not ACKed.
+    /// Transitions to Failed afterwards unless the error is recoverable.
+    SendingError { error: TransportError },
     /// In the process of receiving a message, or waiting for the consumer to pick up
     /// an assembled message.
     Receiving { reassembler: Reassembler<R> },
@@ -169,6 +172,10 @@ impl<R: Role, B: Backend> Channel<R, B> {
             ChannelState::Sending { retry, .. } => Some(retry),
             _ => None,
         }
+    }
+
+    pub fn send_error(&mut self, error: TransportError) {
+        self.state = ChannelState::SendingError { error };
     }
 
     fn raw_in(&mut self, header: Header<R>, send_buffer: &[u8]) -> Result<()> {
@@ -255,6 +262,7 @@ impl<R: Role, B: Backend> Channel<R, B> {
             // We end up sending reply while the other side is retransmitting.
             // Is this recoverable?
             ChannelState::Sending { .. } => return Err(Error::malformed_data()),
+            ChannelState::SendingError { .. } => return Err(Error::unexpected_input()),
             ChannelState::Failed { .. } => return Err(Error::unexpected_input()),
         })
     }
@@ -351,9 +359,6 @@ pub enum PacketInResult {
     },
     /// Peer sent a `TRANSPORT_ERROR` message.
     TransportError {
-        /// True if the packet contained valid ACK and channel is ready to send next message.
-        /// Reserved for ACK piggybacking.
-        ack_received: bool,
         /// Error sent by the peer.
         error: TransportError,
     },
@@ -413,10 +418,7 @@ impl PacketInResult {
     }
 
     const fn transport_error(e: TransportError) -> Self {
-        Self::TransportError {
-            ack_received: false,
-            error: e,
-        }
+        Self::TransportError { error: e }
     }
 
     const fn route(channel_id: u16) -> Self {
@@ -444,7 +446,6 @@ impl PacketInResult {
         match self {
             Self::Accepted { ack_received, .. } => *ack_received,
             Self::EnlargeBuffer { ack_received, .. } => *ack_received,
-            Self::TransportError { ack_received, .. } => *ack_received,
             _ => false,
         }
     }
@@ -540,7 +541,7 @@ pub trait ChannelIO {
     ///
     /// The message including the application header (session id, message type) is passed in
     /// `send_buffer`, occupying first `plaintext_len` bytes. There must be at least 16 more
-    /// bytes in the buffer for authentication tag.
+    /// bytes in the buffer for the authentication tag.
     ///
     /// Instead of this function you can use [`Self::message_in_from`] to prepare the send
     /// buffer for you.
@@ -608,7 +609,7 @@ pub trait ChannelIO {
 
 impl<R: Role, B: Backend> ChannelIO for Channel<R, B> {
     fn packet_in(&mut self, packet_buffer: &[u8], receive_buffer: &mut [u8]) -> PacketInResult {
-        if let ChannelState::Failed { .. } = self.state {
+        if self.is_failed() {
             return PacketInResult::fail(Error::unexpected_input());
         }
         let res = PacketInResult::from_result(self.handle_packet(packet_buffer, receive_buffer));
@@ -623,6 +624,16 @@ impl<R: Role, B: Backend> ChannelIO for Channel<R, B> {
         if let Some(sb) = self.send_ack.take() {
             let header = Header::<R>::new_ack(self.channel_id)?;
             Fragmenter::single(header, sb, &[], packet_buffer)?;
+            return Ok(());
+        }
+        if let ChannelState::SendingError { error } = self.state {
+            let header = Header::<R>::new_error(self.channel_id)?;
+            Fragmenter::single(header, SyncBits::new(), &[error.into()], packet_buffer)?;
+            if error.is_recoverable() {
+                self.state = ChannelState::Idle;
+            } else {
+                self.state = ChannelState::Failed { error: None };
+            }
             return Ok(());
         }
         let ChannelState::Sending { fragmenter, .. } = &mut self.state else {
@@ -651,6 +662,7 @@ impl<R: Role, B: Backend> ChannelIO for Channel<R, B> {
         }
         match &self.state {
             ChannelState::Sending { fragmenter, .. } => !fragmenter.is_done(),
+            ChannelState::SendingError { .. } => true,
             _ => false,
         }
     }
@@ -687,8 +699,16 @@ impl<R: Role, B: Backend> ChannelIO for Channel<R, B> {
         let receive_buffer = match self.noise()?.decrypt(receive_buffer) {
             Ok(plaintext_len) => &receive_buffer[..plaintext_len],
             Err(e) => {
-                log::error!("[{}] Decryption failed, channel closed.", self.channel_id);
-                self.state = ChannelState::Failed { error: None };
+                if R::is_host() {
+                    log::error!("[{:04x}] Decryption failed.", self.channel_id);
+                    self.state = ChannelState::Failed { error: None };
+                } else {
+                    log::error!(
+                        "[{:04x}] Decryption failed, sending DECRYPTION_FAILED.",
+                        self.channel_id
+                    );
+                    self.send_error(TransportError::DecryptionFailed);
+                }
                 return Err(e);
             }
         };

--- a/rust/trezor-thp/src/channel/mod.rs
+++ b/rust/trezor-thp/src/channel/mod.rs
@@ -48,7 +48,7 @@ impl Nonce {
 
 /// Sent by device after successful handshake to indicate whether pairing is required.
 #[repr(u8)]
-#[derive(Copy, Clone)]
+#[derive(Copy, Clone, PartialEq, Eq)]
 pub enum PairingState {
     Unpaired = 0,
     Paired = 1,
@@ -66,11 +66,28 @@ impl TryFrom<&[u8]> for PairingState {
 
     fn try_from(bytes: &[u8]) -> Result<Self> {
         Ok(match bytes {
-            [0] => Self::Unpaired,
-            [1] => Self::Paired,
-            [2] => Self::PairedAutoconnect,
+            [n] => PairingState::try_from(*n)?,
             _ => return Err(Error::malformed_data()),
         })
+    }
+}
+
+impl TryFrom<u8> for PairingState {
+    type Error = Error;
+
+    fn try_from(val: u8) -> Result<Self> {
+        Ok(match val {
+            0 => Self::Unpaired,
+            1 => Self::Paired,
+            2 => Self::PairedAutoconnect,
+            _ => return Err(Error::malformed_data()),
+        })
+    }
+}
+
+impl From<PairingState> for u8 {
+    fn from(pairing_state: PairingState) -> Self {
+        pairing_state as u8
     }
 }
 
@@ -103,6 +120,7 @@ pub struct Channel<R: Role, B: Backend> {
     noise: Option<NoiseCiphers<B>>,
     send_ack: Option<SyncBits>,
     state: ChannelState<R>,
+    pairing_state: PairingState,
 }
 
 impl<R: Role, B: Backend> Channel<R, B> {
@@ -113,6 +131,7 @@ impl<R: Role, B: Backend> Channel<R, B> {
             noise: None,
             send_ack: None,
             state: ChannelState::Idle,
+            pairing_state: PairingState::Unpaired,
         }
     }
 
@@ -126,6 +145,21 @@ impl<R: Role, B: Backend> Channel<R, B> {
 
     pub fn handshake_hash(&self) -> &[u8; HANDSHAKE_HASH_LEN] {
         self.noise.as_ref().unwrap().handshake_hash()
+    }
+
+    /// Returns the channel pairing state at the end of the handshake.
+    /// This is read-only attribute to inform the application whether it needs to perform
+    /// pairing, or can directly transition to encrypted transport state.
+    pub fn handshake_pairing_state(&self) -> PairingState {
+        self.pairing_state
+    }
+
+    pub fn remote_static_pubkey(&self) -> &[u8; PUBKEY_LEN] {
+        self.noise.as_ref().unwrap().remote_static_pubkey()
+    }
+
+    pub fn is_failed(&self) -> bool {
+        matches!(self.state, ChannelState::Failed { .. })
     }
 
     /// Return the retransmission attempt number (the first transmission returns 0),

--- a/rust/trezor-thp/src/channel/noise.rs
+++ b/rust/trezor-thp/src/channel/noise.rs
@@ -48,10 +48,12 @@ pub struct NoiseHandshake<R: Role, B: Backend> {
     hss: HandshakeState<B::DH, B::Cipher, B::Hash>,
     _phantom: PhantomData<R>,
 }
+
 pub struct NoiseCiphers<B: Backend> {
     encrypt: CipherState<B::Cipher>,
     decrypt: CipherState<B::Cipher>,
     handshake_hash: [u8; HANDSHAKE_HASH_LEN],
+    remote_static_pubkey: [u8; PUBKEY_LEN],
 }
 
 impl<B: Backend> NoiseCiphers<B> {
@@ -74,6 +76,10 @@ impl<B: Backend> NoiseCiphers<B> {
 
     pub fn handshake_hash(&self) -> &[u8; HANDSHAKE_HASH_LEN] {
         &self.handshake_hash
+    }
+
+    pub fn remote_static_pubkey(&self) -> &[u8; PUBKEY_LEN] {
+        &self.remote_static_pubkey
     }
 }
 
@@ -119,10 +125,13 @@ impl<B: Backend> NoiseHandshake<Host, B> {
         self.hss.read_message(incoming, &mut [])?;
 
         // Look up static key based on remote keys, or generate a new one.
-        let remote_static_key = self.hss.get_rs().ok_or_else(Error::crypto_error)?;
-        let remote_ephemeral_key = self.hss.get_re().ok_or_else(Error::crypto_error)?;
-        let (local_static, pairing_credential) =
-            Self::credential_from_store(cred_store, &remote_ephemeral_key, &remote_static_key)?;
+        let remote_static_pubkey = self.hss.get_rs().ok_or_else(Error::crypto_error)?;
+        let remote_ephemeral_pubkey = self.hss.get_re().ok_or_else(Error::crypto_error)?;
+        let (local_static, pairing_credential) = Self::credential_from_store(
+            cred_store,
+            &remote_ephemeral_pubkey,
+            &remote_static_pubkey,
+        )?;
         self.hss.set_s(local_static);
 
         buffer.fill(0);
@@ -137,12 +146,12 @@ impl<B: Backend> NoiseHandshake<Host, B> {
             return Err(Error::crypto_error());
         }
         let (encrypt, decrypt) = self.hss.get_ciphers();
-        let mut handshake_hash = [0u8; HANDSHAKE_HASH_LEN];
-        handshake_hash.copy_from_slice(self.hss.get_hash());
+        let handshake_hash = self.hss.get_hash().try_into().unwrap();
         let nc = NoiseCiphers {
             encrypt,
             decrypt,
             handshake_hash,
+            remote_static_pubkey: remote_static_pubkey.as_slice().try_into().unwrap(),
         };
         Ok((nc, dest))
     }
@@ -235,16 +244,22 @@ impl<B: Backend> NoiseHandshake<Device, B> {
             return Err(Error::crypto_error());
         }
 
-        let remote_static_pubkey = self.hss.get_rs().ok_or_else(Error::crypto_error)?;
+        let remote_static_pubkey = self
+            .hss
+            .get_rs()
+            .ok_or_else(Error::crypto_error)?
+            .as_slice()
+            .try_into()
+            .unwrap();
+        let handshake_hash = self.hss.get_hash().try_into().unwrap();
         let (decrypt, encrypt) = self.hss.get_ciphers();
-        let mut handshake_hash = [0u8; HANDSHAKE_HASH_LEN];
-        handshake_hash.copy_from_slice(self.hss.get_hash());
         let mut nc = NoiseCiphers {
             encrypt,
             decrypt,
             handshake_hash,
+            remote_static_pubkey,
         };
-        let pairing_state = cred_verifier.verify(remote_static_pubkey.as_slice(), &cred);
+        let pairing_state = cred_verifier.verify(&nc.remote_static_pubkey, &cred);
         let payload = &[pairing_state as u8];
         let plaintext_len = payload.len();
         let dest = dest

--- a/rust/trezor-thp/src/channel/test.rs
+++ b/rust/trezor-thp/src/channel/test.rs
@@ -258,13 +258,16 @@ impl Direction {
 fn test_open() -> Result<()> {
     setup();
 
-    let (mut hm, mut dm) = create_mux();
+    let (mut hm, mut dm, cids) = create_mux();
     // channel allocation
     hm.request_channel(false);
     take_turns(&mut hm, &mut dm)?;
-    let mut d = dm.channel_alloc()?.with_key(DEVICE_KEY).into_buffered();
+    let mut d = dm
+        .channel_alloc(cids.get(), TestCredentialVerifier)?
+        .with_key(DEVICE_KEY)
+        .into_buffered();
     take_turns(&mut hm, &mut d)?;
-    let mut h = hm.channel_alloc()?.into_buffered();
+    let mut h = hm.channel_alloc(NullCredentialStore)?.into_buffered();
 
     // handshake
     assert!(!h.handshake_done());
@@ -293,13 +296,15 @@ fn test_open() -> Result<()> {
 fn test_device_locked() -> Result<()> {
     setup();
 
-    let (mut hm, mut dm) = create_mux();
+    let (mut hm, mut dm, cids) = create_mux();
     // channel allocation
     hm.request_channel(false);
     take_turns(&mut hm, &mut dm)?;
-    let mut d = dm.channel_alloc()?.into_buffered();
+    let mut d = dm
+        .channel_alloc(cids.get(), TestCredentialVerifier)?
+        .into_buffered();
     take_turns(&mut hm, &mut d)?;
-    let mut h = hm.channel_alloc()?.into_buffered();
+    let mut h = hm.channel_alloc(NullCredentialStore)?.into_buffered();
 
     // handshake
     assert!(!h.handshake_done());
@@ -318,14 +323,16 @@ fn test_device_locked() -> Result<()> {
 }
 
 fn create_mux() -> (
-    Buffered<host::Mux<NullCredentialStore, RustCrypto>>,
-    Buffered<device::Mux<TestCredentialVerifier, RustCrypto>>,
+    Buffered<host::Mux<RustCrypto>>,
+    Buffered<device::Mux<RustCrypto>>,
+    device::ChannelIdAllocator,
 ) {
-    let mut hm = host::Mux::<_, RustCrypto>::new(NullCredentialStore).into_buffered();
+    let mut hm = host::Mux::<RustCrypto>::new().into_buffered();
     hm.set_packet_len(DEFAULT_PACKET_LEN);
-    let mut dm = device::Mux::<_, RustCrypto>::new(TestCredentialVerifier).into_buffered();
+    let mut dm = device::Mux::<RustCrypto>::new().into_buffered();
     dm.set_packet_len(DEFAULT_PACKET_LEN);
-    (hm, dm)
+    let cids = device::ChannelIdAllocator::new_random::<RustCrypto>();
+    (hm, dm, cids)
 }
 
 fn open_channel(
@@ -334,14 +341,17 @@ fn open_channel(
     Buffered<Channel<Host, RustCrypto>>,
     Buffered<Channel<Device, RustCrypto>>,
 )> {
-    let (mut hm, mut dm) = create_mux();
+    let (mut hm, mut dm, cids) = create_mux();
     hm.set_packet_len(packet_len);
     dm.set_packet_len(packet_len);
     hm.request_channel(false);
     take_turns(&mut hm, &mut dm)?;
-    let mut d = dm.channel_alloc()?.with_key(DEVICE_KEY).into_buffered();
+    let mut d = dm
+        .channel_alloc(cids.get(), TestCredentialVerifier)?
+        .with_key(DEVICE_KEY)
+        .into_buffered();
     take_turns(&mut d, &mut hm)?;
-    let mut h = hm.channel_alloc()?.into_buffered();
+    let mut h = hm.channel_alloc(NullCredentialStore)?.into_buffered();
     take_turns(&mut h, &mut d)?;
     let h = h.map(|h| h.complete())?;
     let d = d.map(|d| d.unwrap().complete())?;
@@ -383,21 +393,25 @@ fn test_packet_length(packet_len: usize) -> Result<()> {
 fn test_one_device_multiple_hosts() -> Result<()> {
     const NHOSTS: usize = 4;
     setup();
-    let mut dm = device::Mux::<_, RustCrypto>::new(TestCredentialVerifier).into_buffered();
+    let mut dm = device::Mux::<RustCrypto>::new().into_buffered();
     dm.set_packet_len(DEFAULT_PACKET_LEN);
+    let cids = device::ChannelIdAllocator::new_from(42);
 
     let mut device_chans = Vec::<Buffered<Channel<Device, RustCrypto>>>::new();
     let mut host_chans = Vec::<Buffered<Channel<Host, RustCrypto>>>::new();
 
     // open channels
     for _i in 0..NHOSTS {
-        let mut hm = host::Mux::<_, RustCrypto>::new(NullCredentialStore).into_buffered();
+        let mut hm = host::Mux::<RustCrypto>::new().into_buffered();
         hm.set_packet_len(DEFAULT_PACKET_LEN);
         hm.request_channel(false);
         take_turns(&mut hm, &mut dm)?;
-        let mut d = dm.channel_alloc()?.with_key(DEVICE_KEY).into_buffered();
+        let mut d = dm
+            .channel_alloc(cids.get(), TestCredentialVerifier)?
+            .with_key(DEVICE_KEY)
+            .into_buffered();
         take_turns(&mut d, &mut hm)?;
-        let mut h = hm.channel_alloc()?.into_buffered();
+        let mut h = hm.channel_alloc(NullCredentialStore)?.into_buffered();
         take_turns(&mut h, &mut d)?;
         let h = h.map(|h| h.complete())?;
         let d = d.map(|d| d.unwrap().complete())?;
@@ -457,7 +471,7 @@ fn lose_nth(dir: Direction, i: usize) -> impl FnMut(Direction, &mut VecDeque<Pac
 fn test_packet_loss_alloc() -> Result<()> {
     setup();
 
-    let (mut hm, mut dm) = create_mux();
+    let (mut hm, mut dm, cids) = create_mux();
     // channel allocation request lost
     hm.request_channel(false);
     take_turns_mutate(&mut hm, &mut dm, lose_nth(HostToDevice, 0))?;
@@ -466,16 +480,20 @@ fn test_packet_loss_alloc() -> Result<()> {
     // channel allocation response lost
     hm.request_channel(false);
     take_turns(&mut hm, &mut dm)?;
-    let mut d = dm.channel_alloc()?.into_buffered();
+    let mut d = dm
+        .channel_alloc(cids.get(), TestCredentialVerifier)?
+        .into_buffered();
     take_turns_mutate(&mut hm, &mut d, lose_nth(DeviceToHost, 0))?;
     assert!(!hm.channel_alloc_ready());
 
     // successful allocation
     hm.request_channel(false);
     take_turns(&mut hm, &mut dm)?;
-    let mut d = dm.channel_alloc()?.into_buffered();
+    let mut d = dm
+        .channel_alloc(cids.get(), TestCredentialVerifier)?
+        .into_buffered();
     take_turns(&mut hm, &mut d)?;
-    let mut _h = hm.channel_alloc()?.into_buffered();
+    let mut _h = hm.channel_alloc(NullCredentialStore)?.into_buffered();
     Ok(())
 }
 
@@ -492,13 +510,16 @@ fn test_packet_loss_alloc() -> Result<()> {
 fn test_packet_loss_handshake(dir: Direction, lost_index: usize) -> Result<()> {
     setup();
 
-    let (mut hm, mut dm) = create_mux();
+    let (mut hm, mut dm, cids) = create_mux();
     // channel allocation
     hm.request_channel(false);
     take_turns(&mut hm, &mut dm)?;
-    let mut d = dm.channel_alloc()?.with_key(DEVICE_KEY).into_buffered();
+    let mut d = dm
+        .channel_alloc(cids.get(), TestCredentialVerifier)?
+        .with_key(DEVICE_KEY)
+        .into_buffered();
     take_turns(&mut hm, &mut d)?;
-    let mut h = hm.channel_alloc()?.into_buffered();
+    let mut h = hm.channel_alloc(NullCredentialStore)?.into_buffered();
 
     // handshake
     take_turns_mutate(&mut h, &mut d, lose_nth(dir, lost_index))?;
@@ -554,7 +575,7 @@ fn damage_nth(
 fn test_packet_damage_alloc(byte_index: usize) -> Result<()> {
     setup();
 
-    let (mut hm, mut dm) = create_mux();
+    let (mut hm, mut dm, cids) = create_mux();
     // channel allocation request lost
     hm.request_channel(false);
     take_turns_mutate(&mut hm, &mut dm, damage_nth(HostToDevice, 0, byte_index))?;
@@ -563,16 +584,20 @@ fn test_packet_damage_alloc(byte_index: usize) -> Result<()> {
     // channel allocation response lost
     hm.request_channel(false);
     take_turns(&mut hm, &mut dm)?;
-    let mut d = dm.channel_alloc()?.into_buffered();
+    let mut d = dm
+        .channel_alloc(cids.get(), TestCredentialVerifier)?
+        .into_buffered();
     take_turns_mutate(&mut hm, &mut d, damage_nth(DeviceToHost, 0, byte_index))?;
     assert!(!hm.channel_alloc_ready());
 
     // successful allocation
     hm.request_channel(false);
     take_turns(&mut hm, &mut dm)?;
-    let mut d = dm.channel_alloc()?.into_buffered();
+    let mut d = dm
+        .channel_alloc(cids.get(), TestCredentialVerifier)?
+        .into_buffered();
     take_turns(&mut hm, &mut d)?;
-    let mut _h = hm.channel_alloc()?.into_buffered();
+    let mut _h = hm.channel_alloc(NullCredentialStore)?.into_buffered();
     Ok(())
 }
 
@@ -600,13 +625,16 @@ fn test_packet_damage_handshake(
         return Ok(());
     }
 
-    let (mut hm, mut dm) = create_mux();
+    let (mut hm, mut dm, cids) = create_mux();
     // channel allocation
     hm.request_channel(false);
     take_turns(&mut hm, &mut dm)?;
-    let mut d = dm.channel_alloc()?.with_key(DEVICE_KEY).into_buffered();
+    let mut d = dm
+        .channel_alloc(cids.get(), TestCredentialVerifier)?
+        .with_key(DEVICE_KEY)
+        .into_buffered();
     take_turns(&mut hm, &mut d)?;
-    let mut h = hm.channel_alloc()?.into_buffered();
+    let mut h = hm.channel_alloc(NullCredentialStore)?.into_buffered();
 
     // handshake
     take_turns_mutate(&mut h, &mut d, damage_nth(dir, packet_index, byte_index))?;
@@ -669,7 +697,7 @@ fn test_codec_v1() -> Result<()> {
     let v1_cont = hex::decode(v1_cont).unwrap();
 
     // broadcast handling
-    let (mut hm, mut dm) = create_mux();
+    let (mut hm, mut dm, _cids) = create_mux();
     // device::Mux shoud respond
     let pir = dm.packet_in(&v1_init);
     assert!(matches!(
@@ -712,7 +740,7 @@ fn test_codec_v1() -> Result<()> {
 fn test_ping() -> Result<()> {
     setup();
 
-    let (mut hm, mut dm) = create_mux();
+    let (mut hm, mut dm, _cids) = create_mux();
     // host->device ping
     hm.ping();
     let ping_packet = hm.packet_out()?;
@@ -775,7 +803,7 @@ fn test_invalid_channel_id() -> Result<()> {
         res
     }
 
-    let (mut hm, mut dm) = create_mux();
+    let (mut hm, mut dm, _cids) = create_mux();
     // muxes return Route(cid) for valid non-broadcast channel
     let pir = dm.packet_in(&make_packet(66));
     assert_eq!(pir, PacketInResult::Route { channel_id: 66 });
@@ -887,25 +915,28 @@ fn test_channel_id_wraparound() -> Result<()> {
     setup();
 
     fn alloc_test(
-        hm: &mut Buffered<host::Mux<NullCredentialStore, RustCrypto>>,
-        dm: &mut Buffered<device::Mux<TestCredentialVerifier, RustCrypto>>,
+        hm: &mut Buffered<host::Mux<RustCrypto>>,
+        dm: &mut Buffered<device::Mux<RustCrypto>>,
+        cids: &device::ChannelIdAllocator,
         expected_id: u16,
     ) -> Result<()> {
         hm.request_channel(false);
         take_turns(hm, dm)?;
-        let mut d = dm.channel_alloc()?.into_buffered();
+        let mut d = dm
+            .channel_alloc(cids.get(), TestCredentialVerifier)?
+            .into_buffered();
         take_turns(hm, &mut d)?;
-        let h = hm.channel_alloc()?.into_buffered();
+        let h = hm.channel_alloc(NullCredentialStore)?.into_buffered();
         assert_eq!(h.channel_id(), expected_id);
         Ok(())
     }
 
-    let (mut hm, mut dm) = create_mux();
-    dm.set_next_channel_id(MAX_CHANNEL_ID - 1);
-    alloc_test(&mut hm, &mut dm, MAX_CHANNEL_ID - 1)?;
-    alloc_test(&mut hm, &mut dm, MAX_CHANNEL_ID)?;
-    alloc_test(&mut hm, &mut dm, MIN_CHANNEL_ID)?;
-    alloc_test(&mut hm, &mut dm, MIN_CHANNEL_ID + 1)?;
+    let (mut hm, mut dm, _) = create_mux();
+    let cids = device::ChannelIdAllocator::new_from(MAX_CHANNEL_ID - 1);
+    alloc_test(&mut hm, &mut dm, &cids, MAX_CHANNEL_ID - 1)?;
+    alloc_test(&mut hm, &mut dm, &cids, MAX_CHANNEL_ID)?;
+    alloc_test(&mut hm, &mut dm, &cids, MIN_CHANNEL_ID)?;
+    alloc_test(&mut hm, &mut dm, &cids, MIN_CHANNEL_ID + 1)?;
 
     Ok(())
 }

--- a/rust/trezor-thp/src/channel/test.rs
+++ b/rust/trezor-thp/src/channel/test.rs
@@ -525,10 +525,16 @@ fn test_packet_loss_handshake(dir: Direction, lost_index: usize) -> Result<()> {
     take_turns_mutate(&mut h, &mut d, lose_nth(dir, lost_index))?;
     if dir == DeviceToHost {
         assert!(!h.handshake_done());
+        assert_eq!(h.sending_retry(), None);
+        assert_eq!(d.sending_retry(), Some(0));
         d.message_retransmit()?;
+        assert_eq!(d.sending_retry(), Some(1));
     } else {
         assert!(!d.handshake_done());
+        assert_eq!(d.sending_retry(), None);
+        assert_eq!(h.sending_retry(), Some(0));
         h.message_retransmit()?;
+        assert_eq!(h.sending_retry(), Some(1));
     }
     take_turns(&mut h, &mut d)?;
     let mut h = h.map(|h| h.complete())?;
@@ -640,10 +646,16 @@ fn test_packet_damage_handshake(
     take_turns_mutate(&mut h, &mut d, damage_nth(dir, packet_index, byte_index))?;
     if dir == DeviceToHost {
         assert!(!h.handshake_done());
+        assert_eq!(h.sending_retry(), None);
+        assert_eq!(d.sending_retry(), Some(0));
         d.message_retransmit()?;
+        assert_eq!(d.sending_retry(), Some(1));
     } else {
         assert!(!d.handshake_done());
+        assert_eq!(d.sending_retry(), None);
+        assert_eq!(h.sending_retry(), Some(0));
         h.message_retransmit()?;
+        assert_eq!(h.sending_retry(), Some(1));
     }
     take_turns(&mut h, &mut d)?;
     let mut h = h.map(|h| h.complete())?;

--- a/rust/trezor-thp/src/channel/test.rs
+++ b/rust/trezor-thp/src/channel/test.rs
@@ -317,8 +317,7 @@ fn test_device_locked() -> Result<()> {
     d.send_device_locked()?;
     take_turns(&mut h, &mut d)?;
     assert!(h.handshake_failed());
-    // TODO: either the host needs to ACK the error, or host transitions to ack after sending it
-    // assert!(d.handshake_failed());
+    assert!(d.handshake_failed());
     Ok(())
 }
 

--- a/rust/trezor-thp/src/control_byte.rs
+++ b/rust/trezor-thp/src/control_byte.rs
@@ -149,7 +149,7 @@ impl TryFrom<u8> for ControlByte {
             || cb.is_handshake()
             || cb.is_codec_v1();
         if !valid {
-            log::warn!("Invalid control byte {}.", byte);
+            log::warn!("Invalid control byte 0x{:x}.", byte);
             return Err(Error::malformed_data());
         }
         Ok(cb)

--- a/rust/trezor-thp/src/credential.rs
+++ b/rust/trezor-thp/src/credential.rs
@@ -7,7 +7,7 @@ pub struct FoundCredential<'a> {
 
 /// Host-side credential store.
 /// Basically a set of (`remote_static_pubkey`, `local_static_privkey`, `auth_credential`).
-pub trait CredentialStore: Clone {
+pub trait CredentialStore {
     /// Find a record such that `remote_static_pubkey` satisfies
     /// `masked_static_pubkey == X25519(SHA-256(remote_static_pubkey || ephemeral_pubkey), remote_static_pubkey)`.
     /// If found, write `local_static_privkey` and `auth_credential` to `dest` and return the written subslices.
@@ -35,7 +35,7 @@ impl CredentialStore for NullCredentialStore {
 }
 
 /// Device-side credential handling.
-pub trait CredentialVerifier: Clone {
+pub trait CredentialVerifier {
     /// Validate given protobuf-encoded credential.
     fn verify(&self, remote_static_pubkey: &[u8], credential: &[u8]) -> PairingState;
 

--- a/rust/trezor-thp/src/fragment.rs
+++ b/rust/trezor-thp/src/fragment.rs
@@ -143,7 +143,7 @@ impl<R: Role> Reassembler<R> {
         let (header, after_header) = Header::<R>::parse(input)?;
         if !header.is_continuation() {
             log::error!(
-                "[{}] Unexpected initiation packet.",
+                "[{:04x}] Unexpected initiation packet.",
                 self.header.channel_id()
             );
             return Err(Error::unexpected_input());
@@ -151,7 +151,7 @@ impl<R: Role> Reassembler<R> {
 
         if header.channel_id() != self.header.channel_id() {
             log::error!(
-                "[{}] Unexpected channel id {}.",
+                "[{:04x}] Unexpected channel id {:04x}.",
                 self.header.channel_id(),
                 header.channel_id()
             );

--- a/rust/trezor-thp/src/header.rs
+++ b/rust/trezor-thp/src/header.rs
@@ -101,7 +101,7 @@ impl<R: Role> Header<R> {
             }
         }
         if !channel_id_valid(channel_id) {
-            log::error!("Invalid channel id {}.", channel_id);
+            log::error!("Invalid channel id {:04x}.", channel_id);
             return Err(Error::malformed_data());
         }
         if cb.is_continuation() {
@@ -132,7 +132,7 @@ impl<R: Role> Header<R> {
             return Ok((header, rest));
         }
         log::error!(
-            "Unknown header: ({}, {}, {}).",
+            "Unknown header: (0x{:x}, {:04x}, {}).",
             u8::from(cb),
             channel_id,
             payload_len
@@ -303,7 +303,7 @@ impl<R: Role> Header<R> {
 
     fn validate_channel(channel_id: u16) -> Result<u16> {
         if !channel_id_valid(channel_id) {
-            log::error!("Cannot construct: invalid channel id {}.", channel_id);
+            log::error!("Cannot construct: invalid channel id {:04x}.", channel_id);
             return Err(Error::unexpected_input());
         }
         Ok(channel_id)

--- a/rust/trezor-thp/src/lib.rs
+++ b/rust/trezor-thp/src/lib.rs
@@ -12,7 +12,7 @@ mod fragment;
 pub mod header;
 mod util;
 
-pub use channel::{Backend, Channel, ChannelIO};
+pub use channel::{Backend, ChannelIO};
 pub use error::Error;
 
 pub trait Role: Clone + PartialEq {


### PR DESCRIPTION
Several mostly unrelated improvements for #6442:

* 8080a68: moves the responsibility of allocating channel IDs to application
  * makes it possible to check if they are unused and unique across interfaces
  * helper struct for allocating sequential ids with random start
  * Mux no longer needs to hold onto CredentailVerifier/CredentialStore, simplifying type signatures a bit
* fd1d2a8: adds `host::Channel` and `device::Channel` type aliases for shorter type signatures
* 851f362: channels now keep track of how many times they retransmitted the current message
  * also ported the python function for computing ACK timeouts
  * application still needs to keep track of when to request retransmission, mainly because there is no universal `time::Instant` and it's probably not worth it to introduce another type parameter
* 1c2679b: channels remember the handshake pairing state and peer's static pubkey
* 71fc240: adds support for sending `transport_error` messages
  * device sends `DECRYPTION_FAILED` when AEAD tag verification fails
* 876ee8e: log channel numbers in hexadecimal

<!--
For external contributors:
- Please open an issue before submitting a PR so we can discuss whether we want to proceed with it.

For core developers:
1. Initial PR setup
- Assign yourself to the PR.
- Add it to the "Firmware" project
  - Set Priority (match issue priority if it exists)
  - Set Team
  - Set Sprint (target release)

2. Development status
- Draft PRs: Set status to "In Progress"
- Final PRs: Set status to "Needs Review"

3. Post-merge status
- Testable: Set status to "Needs QA" and add a `Notes for QA` section with clear instructions on how to test the functionality.
- Not Testable: Set status to "Done (no QA)"
-->
