### PR TITLE
rust/trezor-thp: ACK piggybacking

### DIFF
--- a/rust/trezor-thp/examples/host-cli/client.rs
+++ b/rust/trezor-thp/examples/host-cli/client.rs
@@ -2,7 +2,7 @@ use std::io::ErrorKind;
 use std::net::{SocketAddr, UdpSocket};
 use std::time::Duration;
 
-use trezor_thp::{Backend, ChannelIO, Error, channel::buffered::Buffered, channel::host::Mux};
+use trezor_thp::{Backend, ChannelIO, channel::buffered::Buffered, channel::host::Mux};
 
 use protobuf::{Enum, Message};
 
@@ -67,8 +67,7 @@ impl<C: ChannelIO> Client<C> {
                 None
             }
             Err(e) => {
-                log::error!("Cannot read from UDP socket: {}.", e);
-                panic!();
+                panic!("Cannot read from UDP socket: {}.", e);
             }
         }
     }
@@ -120,8 +119,7 @@ impl<C: ChannelIO> Client<C> {
             let mut done = false;
             while !done {
                 let Some(packet) = self.recv_from(READ_TIMEOUT) else {
-                    log::error!("Timed out waiting for response for {:?}.", READ_TIMEOUT);
-                    panic!();
+                    panic!("Timed out waiting for response for {:?}.", READ_TIMEOUT);
                 };
                 let pir = self.channel.packet_in(&packet).check_failed().unwrap();
                 assert!(!pir.got_transport_error());
@@ -130,13 +128,10 @@ impl<C: ChannelIO> Client<C> {
             }
             result = match self.channel.message_out() {
                 Ok(r) => Some(r),
-                Err(Error::InvalidChecksum | Error::MalformedData) => {
-                    log::error!("Received bad message, waiting for retransmission.");
-                    continue;
-                }
                 Err(e) => {
-                    log::error!("Cannot read message from channel: {:?}.", e);
-                    panic!();
+                    // Since checksum is verified in `packet_in`, there is no recoverable error
+                    // returned by `message_out`. Exit now to avoid getting stuck.
+                    panic!("Cannot read message from channel: {:?}.", e);
                 }
             };
         }

--- a/rust/trezor-thp/examples/host-cli/main.rs
+++ b/rust/trezor-thp/examples/host-cli/main.rs
@@ -43,6 +43,19 @@ where
     let device_properties =
         ThpDeviceProperties::parse_from_bytes(&client.device_properties).unwrap();
     log::debug!("Device properties: {:?}.", device_properties);
+    match (
+        device_properties.protocol_version_major,
+        device_properties.protocol_version_minor,
+    ) {
+        (Some(major), Some(minor)) => {
+            let major: u8 = major.try_into().unwrap();
+            let minor: u8 = minor.try_into().unwrap();
+            client.channel.set_device_protocol_version(major, minor);
+        }
+        _ => {
+            log::warn!("Protocol version missing in device properties.");
+        }
+    }
     // Handshake should finish within 2 request-response cycles.
     client.call(0, &[]);
     client.call(0, &[]);

--- a/rust/trezor-thp/src/alternating_bit.rs
+++ b/rust/trezor-thp/src/alternating_bit.rs
@@ -1,5 +1,5 @@
 use crate::{
-    control_byte::{ACK_BIT, SEQ_BIT},
+    control_byte::{ACK_BIT, SEQ_BIT, SYNC_MASK},
     error::Error,
 };
 
@@ -38,7 +38,7 @@ impl SyncBits {
 
 impl From<u8> for SyncBits {
     fn from(byte: u8) -> Self {
-        Self(byte)
+        Self(byte & SYNC_MASK)
     }
 }
 
@@ -99,7 +99,10 @@ impl ChannelSync {
             return None; // sending in progress, don't send
         }
 
-        let sb = SyncBits::new().with_seq_bit(self.sync_send);
+        let mut sb = SyncBits::new().with_seq_bit(self.sync_send);
+        if self.ack_piggybacking {
+            sb = sb.with_ack_bit(self.get_ack_bit());
+        }
         Some(sb) // start sending, use these bits
     }
 
@@ -120,7 +123,7 @@ impl ChannelSync {
     /// Call after receving initial fragment of a message.
     /// Returns true when seq_bit is correct and we should reassemble the message.
     /// If the function returns false all following continuation packets should be discarded.
-    pub fn receive_start(&mut self, sb: SyncBits) -> bool {
+    pub fn receive_start(&self, sb: SyncBits) -> bool {
         if sb.seq_bit() != self.sync_receive {
             // Either this message is a duplicate or previous one was dropped.
             return false;
@@ -133,9 +136,23 @@ impl ChannelSync {
     /// Call after receiving last fragment and successfully verifying CRC of the message.
     /// Caller needs to send ACK with the returned SyncBits.
     pub fn receive_acknowledge(&mut self) -> SyncBits {
-        let sb = SyncBits::new().with_ack_bit(self.sync_receive);
         self.sync_receive.increment();
-        sb
+        SyncBits::new().with_ack_bit(self.get_ack_bit())
+    }
+
+    // Returns previous value of the receive bit. We increment the bit after successfully
+    // receiving the message, an ACK is sent afterwards so it has to use the previous value.
+    fn get_ack_bit(&self) -> bool {
+        self.sync_receive.previous()
+    }
+
+    pub fn allow_ack_piggybacking(&mut self) {
+        log::debug!("Enabled ACK piggybacking.");
+        self.ack_piggybacking = true;
+    }
+
+    pub fn is_ack_piggybacking_allowed(&self) -> bool {
+        self.ack_piggybacking
     }
 
     /// Serialize for storage.
@@ -177,12 +194,20 @@ impl Default for ChannelSync {
 }
 
 trait BoolExt {
+    /// Increments the value.
     fn increment(&mut self);
+
+    /// Copies the value and decrements it.
+    fn previous(&self) -> Self;
 }
 
 impl BoolExt for bool {
     fn increment(&mut self) {
         *self = !*self;
+    }
+
+    fn previous(&self) -> Self {
+        !self
     }
 }
 

--- a/rust/trezor-thp/src/channel/buffered.rs
+++ b/rust/trezor-thp/src/channel/buffered.rs
@@ -37,17 +37,22 @@ impl<C: ChannelIO> Buffered<C> {
         let res = self
             .channel
             .packet_in(packet_buffer, self.receive_buffer.as_mut_slice());
-        if let PacketInResult::EnlargeBuffer {
+        if let PacketInResult::Accepted {
             ack_received,
-            buffer_size,
+            message_ready,
+            pong,
+            buffer_size: Some(s),
+            ..
         } = res
         {
-            log::debug!("Resizing receive buffer to {}.", buffer_size);
-            self.receive_buffer.resize(buffer_size.into(), 0u8);
+            let new_size: u16 = s.into();
+            log::debug!("Resizing receive buffer to {}.", new_size);
+            self.receive_buffer.resize(new_size.into(), 0u8);
             return PacketInResult::Accepted {
                 ack_received,
-                message_ready: false,
-                pong: false,
+                message_ready,
+                pong,
+                buffer_size: None,
             };
         }
         res

--- a/rust/trezor-thp/src/channel/device.rs
+++ b/rust/trezor-thp/src/channel/device.rs
@@ -4,8 +4,8 @@ use crate::{
     Backend, ChannelIO, Device, Error,
     alternating_bit::SyncBits,
     channel::{
-        ChannelState, HANDSHAKE_BUFFER_DTH_LEN, HANDSHAKE_BUFFER_HTD_LEN, Nonce, PRIVKEY_LEN,
-        PacketInResult, PairingState, noise::NoiseHandshake,
+        HANDSHAKE_BUFFER_DTH_LEN, HANDSHAKE_BUFFER_HTD_LEN, Nonce, PRIVKEY_LEN, PacketInResult,
+        PairingState, ReceiveState, SendState, noise::NoiseHandshake,
     },
     credential::CredentialVerifier,
     error::TransportError,
@@ -325,7 +325,7 @@ impl<C: CredentialVerifier, B: Backend> ChannelOpen<C, B> {
     }
 
     fn incoming_internal(&mut self) -> Result<(), Error> {
-        let ChannelState::Receiving { reassembler, .. } = &self.channel.state else {
+        let ReceiveState::Receiving { reassembler, .. } = &self.channel.receive_state else {
             return Err(Error::not_ready());
         };
         let sync_bits = reassembler.sync_bits();
@@ -402,7 +402,7 @@ impl<C: CredentialVerifier, B: Backend> ChannelOpen<C, B> {
     pub fn handshake_done(&self) -> bool {
         // Done only after peer acknowledges completion response.
         matches!(self.state, HandshakeState::SendingCompletionResponse { .. })
-            && matches!(self.channel.state, ChannelState::Idle)
+            && matches!(self.channel.send_state, SendState::Idle)
     }
 
     /// True if the handshake failed and the object should be discarded.
@@ -499,7 +499,7 @@ where
                 s
             );
             // Possibly damaged length field, ignore continuations.
-            self.channel.state = ChannelState::Idle;
+            self.channel.receive_state = ReceiveState::Idle;
             return PacketInResult::ignore(Error::malformed_data());
         }
         if res.got_message() {

--- a/rust/trezor-thp/src/channel/device.rs
+++ b/rust/trezor-thp/src/channel/device.rs
@@ -4,8 +4,8 @@ use crate::{
     Backend, ChannelIO, Device, Error,
     alternating_bit::SyncBits,
     channel::{
-        ChannelState, HANDSHAKE_BUFFER_LEN, Nonce, PRIVKEY_LEN, PacketInResult, PairingState,
-        noise::NoiseHandshake,
+        ChannelState, HANDSHAKE_BUFFER_DTH_LEN, HANDSHAKE_BUFFER_HTD_LEN, Nonce, PRIVKEY_LEN,
+        PacketInResult, PairingState, noise::NoiseHandshake,
     },
     credential::CredentialVerifier,
     error::TransportError,
@@ -291,34 +291,35 @@ pub struct ChannelOpen<C: CredentialVerifier, B: Backend> {
     channel: Channel<B>,
     state: HandshakeState,
     noise: NoiseHandshake<Device, B>,
-    internal_buffer: heapless::Vec<u8, HANDSHAKE_BUFFER_LEN>,
+    send_buffer: heapless::Vec<u8, HANDSHAKE_BUFFER_DTH_LEN>,
+    receive_buffer: heapless::Vec<u8, HANDSHAKE_BUFFER_HTD_LEN>,
     cred_verif: C,
 }
 
 impl<C: CredentialVerifier, B: Backend> ChannelOpen<C, B> {
     fn new(channel_id: u16, nonce: Nonce, cred_verif: C) -> Result<Self, Error> {
-        let mut internal_buffer = heapless::Vec::new();
-        internal_buffer
+        let mut send_buffer = heapless::Vec::new();
+        send_buffer
             .extend_from_slice(nonce.as_slice())
             .map_err(|_| Error::insufficient_buffer())?;
-        internal_buffer
+        send_buffer
             .extend_from_slice(&channel_id.to_be_bytes())
             .map_err(|_| Error::insufficient_buffer())?;
-        internal_buffer
+        send_buffer
             .extend_from_slice(cred_verif.device_properties())
             .map_err(|_| Error::insufficient_buffer())?;
+        let mut receive_buffer = heapless::Vec::new();
+        prepare_zeroed(&mut receive_buffer);
 
         // Sending `channel_allocation_response` on broadcast channel.
         let mut channel = Channel::new(channel_id);
-        channel.raw_in(
-            Header::new_channel_response(&internal_buffer)?,
-            &internal_buffer,
-        )?;
+        channel.raw_in(Header::new_channel_response(&send_buffer)?, &send_buffer)?;
         Ok(Self {
             channel,
             state: HandshakeState::SendingChannelResponse,
             noise: NoiseHandshake::prepare_responder(cred_verif.device_properties()),
-            internal_buffer,
+            send_buffer,
+            receive_buffer,
             cred_verif,
         })
     }
@@ -329,14 +330,14 @@ impl<C: CredentialVerifier, B: Backend> ChannelOpen<C, B> {
         };
         let sync_bits = reassembler.sync_bits();
 
-        let (header, len) = self.channel.raw_out(&self.internal_buffer)?;
-        self.internal_buffer.truncate(len);
+        let (header, len) = self.channel.raw_out(&self.receive_buffer)?;
+        self.receive_buffer.truncate(len);
 
         match (self.state, header.handshake_phase()) {
             (HandshakeState::SendingChannelResponse, Some(HandshakeMessage::InitiationRequest)) => {
                 // enable ACK piggybacking if requested
                 self.enable_ack_piggybacking_if_requested(sync_bits);
-                let try_to_unlock = self.noise.read_initiation_request(&self.internal_buffer)?;
+                let try_to_unlock = self.noise.read_initiation_request(&self.receive_buffer)?;
                 self.state = HandshakeState::StaticKeyRequired { try_to_unlock };
             }
             (
@@ -351,6 +352,7 @@ impl<C: CredentialVerifier, B: Backend> ChannelOpen<C, B> {
                 return Err(Error::unexpected_input());
             }
         }
+        prepare_zeroed(&mut self.receive_buffer);
         Ok(())
     }
 
@@ -364,38 +366,35 @@ impl<C: CredentialVerifier, B: Backend> ChannelOpen<C, B> {
         &mut self,
         static_privkey: &[u8; PRIVKEY_LEN],
     ) -> Result<(), Error> {
-        prepare_zeroed(&mut self.internal_buffer);
-        let msg = self
+        prepare_zeroed(&mut self.send_buffer);
+        let len = self
             .noise
-            .write_initiation_response(static_privkey, &mut self.internal_buffer)?;
+            .write_initiation_response(static_privkey, &mut self.send_buffer)?;
+        self.send_buffer.truncate(len);
         let header = Header::new_handshake(
             self.channel.channel_id,
             HandshakeMessage::InitiationResponse,
-            msg,
+            &self.send_buffer,
         )?;
-        self.channel.raw_in(header, msg)?;
-        let len = msg.len();
-        self.internal_buffer.truncate(len);
+        self.channel.raw_in(header, &self.send_buffer)?;
         Ok(())
     }
 
     fn send_completion_response(&mut self) -> Result<PairingState, Error> {
-        let payload = self.internal_buffer.clone();
-        prepare_zeroed(&mut self.internal_buffer);
-        let (nc, ps, msg) = self.noise.write_completion_response(
-            &payload,
+        prepare_zeroed(&mut self.send_buffer);
+        let (nc, ps, len) = self.noise.write_completion_response(
+            &self.receive_buffer,
             &self.cred_verif,
-            &mut self.internal_buffer,
+            &mut self.send_buffer,
         )?;
+        self.send_buffer.truncate(len);
         self.channel.noise = Some(nc);
         let header = Header::new_handshake(
             self.channel.channel_id,
             HandshakeMessage::CompletionResponse,
-            msg,
+            &self.send_buffer,
         )?;
-        self.channel.raw_in(header, msg)?;
-        let len = msg.len();
-        self.internal_buffer.truncate(len);
+        self.channel.raw_in(header, &self.send_buffer)?;
         Ok(ps)
     }
 
@@ -488,7 +487,7 @@ where
     fn packet_in(&mut self, packet_buffer: &[u8], _receive_buffer: &mut [u8]) -> PacketInResult {
         let res = self
             .channel
-            .packet_in(packet_buffer, &mut self.internal_buffer);
+            .packet_in(packet_buffer, &mut self.receive_buffer);
         if let PacketInResult::Accepted {
             buffer_size: Some(s),
             ..
@@ -516,22 +515,12 @@ where
             if let HandshakeState::StaticKeyRequired { try_to_unlock } = self.state {
                 return PacketInResult::HandshakeKeyRequired { try_to_unlock };
             }
-        } else if res.got_ack() {
-            prepare_zeroed(&mut self.internal_buffer);
         }
         res
     }
 
     fn packet_out(&mut self, packet_buffer: &mut [u8], _send_buffer: &[u8]) -> Result<(), Error> {
-        self.channel
-            .packet_out(packet_buffer, &self.internal_buffer)?;
-        // Do not wait for ack - `channel_allocation_response` is sent over broadcast channel.
-        if matches!(self.state, HandshakeState::SendingChannelResponse)
-            && matches!(self.channel.state, ChannelState::Idle)
-        {
-            prepare_zeroed(&mut self.internal_buffer);
-        }
-        Ok(())
+        self.channel.packet_out(packet_buffer, &self.send_buffer)
     }
 
     fn packet_out_ready(&self) -> bool {

--- a/rust/trezor-thp/src/channel/device.rs
+++ b/rust/trezor-thp/src/channel/device.rs
@@ -132,7 +132,7 @@ where
 
     // Returns true if allocation request has been received.
     fn handle_broadcast(&mut self, packet: &[u8]) -> Result<bool, Error> {
-        let (header, payload) = Reassembler::<Device>::single_inplace(packet)?;
+        let (header, payload) = Reassembler::<Device>::single(packet)?;
         match header {
             Header::Ping if payload.len() == Nonce::LEN => {
                 let (nonce, _rest) = Nonce::parse(payload)?;
@@ -328,11 +328,18 @@ impl<C: CredentialVerifier, B: Backend> ChannelOpen<C, B> {
     }
 
     fn incoming_internal(&mut self) -> Result<(), Error> {
+        let ChannelState::Receiving { reassembler, .. } = &self.channel.state else {
+            return Err(Error::not_ready());
+        };
+        let sync_bits = reassembler.sync_bits();
+
         let (header, len) = self.channel.raw_out(&self.internal_buffer)?;
         self.internal_buffer.truncate(len);
 
         match (self.state, header.handshake_phase()) {
             (HandshakeState::SendingChannelResponse, Some(HandshakeMessage::InitiationRequest)) => {
+                // enable ACK piggybacking if requested
+                self.enable_ack_piggybacking_if_requested(sync_bits);
                 let try_to_unlock = self.noise.read_initiation_request(&self.internal_buffer)?;
                 self.state = HandshakeState::StaticKeyRequired { try_to_unlock };
             }
@@ -349,6 +356,12 @@ impl<C: CredentialVerifier, B: Backend> ChannelOpen<C, B> {
             }
         }
         Ok(())
+    }
+
+    fn enable_ack_piggybacking_if_requested(&mut self, sync_bits: SyncBits) {
+        if sync_bits.ack_bit() {
+            self.channel.sync.allow_ack_piggybacking();
+        }
     }
 
     fn send_initiation_response(
@@ -480,18 +493,19 @@ where
         let res = self
             .channel
             .packet_in(packet_buffer, &mut self.internal_buffer);
-        if let PacketInResult::EnlargeBuffer { buffer_size, .. } = res {
+        if let PacketInResult::Accepted {
+            buffer_size: Some(s),
+            ..
+        } = res
+        {
             log::error!(
                 "[{:04x}] Payload length {} exceeds handshake limit.",
                 self.channel_id(),
-                buffer_size
+                s
             );
             // Possibly damaged length field, ignore continuations.
             self.channel.state = ChannelState::Idle;
             return PacketInResult::ignore(Error::malformed_data());
-        }
-        if res.got_ack() {
-            prepare_zeroed(&mut self.internal_buffer);
         }
         if res.got_message() {
             let handled = self.incoming_internal();
@@ -506,6 +520,8 @@ where
             if let HandshakeState::StaticKeyRequired { try_to_unlock } = self.state {
                 return PacketInResult::HandshakeKeyRequired { try_to_unlock };
             }
+        } else if res.got_ack() {
+            prepare_zeroed(&mut self.internal_buffer);
         }
         res
     }

--- a/rust/trezor-thp/src/channel/device.rs
+++ b/rust/trezor-thp/src/channel/device.rs
@@ -4,7 +4,8 @@ use crate::{
     Backend, ChannelIO, Device, Error,
     alternating_bit::SyncBits,
     channel::{
-        ChannelState, Nonce, PRIVKEY_LEN, PacketInResult, PairingState, noise::NoiseHandshake,
+        ChannelState, HANDSHAKE_BUFFER_LEN, Nonce, PRIVKEY_LEN, PacketInResult, PairingState,
+        noise::NoiseHandshake,
     },
     credential::CredentialVerifier,
     error::TransportError,
@@ -21,11 +22,6 @@ use core::{
     sync::atomic::{AtomicU16, Ordering},
 };
 
-// Must fit any of:
-// - device_properties + overhead
-// - 2 DH keys + 2 AEAD tags (2*32+2*16=96) + overhead
-// - DH key + credential + 2 AEAD tags + overhead
-const INTERNAL_BUFFER_LEN: usize = 192;
 // As long as `packet_out` is called soon after `packet_in` there shouldn't be an accumulation
 // of outgoing messages. However there still can be >1 during normal operation, e.g. when we're
 // responding to PING at the same time the application requests sending an error.
@@ -295,7 +291,7 @@ pub struct ChannelOpen<C: CredentialVerifier, B: Backend> {
     channel: Channel<B>,
     state: HandshakeState,
     noise: NoiseHandshake<Device, B>,
-    internal_buffer: heapless::Vec<u8, INTERNAL_BUFFER_LEN>,
+    internal_buffer: heapless::Vec<u8, HANDSHAKE_BUFFER_LEN>,
     cred_verif: C,
 }
 

--- a/rust/trezor-thp/src/channel/host.rs
+++ b/rust/trezor-thp/src/channel/host.rs
@@ -4,8 +4,9 @@ use crate::{
     Backend, ChannelIO, Error, Host,
     alternating_bit::SyncBits,
     channel::{
-        ChannelState, HANDSHAKE_BUFFER_DTH_LEN, HANDSHAKE_BUFFER_HTD_LEN, MAX_ALLOC_RESPONSE_LEN,
-        MAX_DEVICE_PROPERTIES_LEN, Nonce, PacketInResult, PairingState, noise::NoiseHandshake,
+        HANDSHAKE_BUFFER_DTH_LEN, HANDSHAKE_BUFFER_HTD_LEN, MAX_ALLOC_RESPONSE_LEN,
+        MAX_DEVICE_PROPERTIES_LEN, Nonce, PacketInResult, PairingState, ReceiveState,
+        noise::NoiseHandshake,
     },
     credential::CredentialStore,
     fragment::{Fragmenter, Reassembler},
@@ -519,7 +520,7 @@ where
                 s
             );
             // Possibly damaged length field, ignore continuations.
-            self.channel.state = ChannelState::Idle;
+            self.channel.receive_state = ReceiveState::Idle;
             return PacketInResult::ignore(Error::malformed_data());
         }
         if res.got_message() {

--- a/rust/trezor-thp/src/channel/host.rs
+++ b/rust/trezor-thp/src/channel/host.rs
@@ -137,7 +137,7 @@ where
         let (header, _rest) = Header::<Host>::parse(packet)?;
         match header {
             Header::Pong => {
-                let (_header, payload) = Reassembler::<Host>::single_inplace(packet)?;
+                let (_header, payload) = Reassembler::<Host>::single(packet)?;
                 let (nonce, _rest) = Nonce::parse(payload)?;
                 if PingState::AwaitingPong(nonce) != self.ping {
                     log::warn!("Ignoring PONG with invalid nonce.");
@@ -320,6 +320,8 @@ where
 
 #[derive(Copy, Clone)]
 enum HandshakeState {
+    /// Before first packet is sent, allowing user to call [`set_device_protocol_version`].
+    Initial,
     /// `HH1`.
     SendingInitiationRequest,
     /// `HH2`.
@@ -363,14 +365,11 @@ impl<C: CredentialStore, B: Backend> ChannelOpen<C, B> {
             try_to_unlock,
             &mut internal_buffer,
         )?;
-        let header = Header::new_handshake(channel_id, HandshakeMessage::InitiationRequest, msg)?;
-        let mut channel = Channel::new(channel_id);
-        channel.raw_in(header, msg)?;
         let len = msg.len();
         internal_buffer.truncate(len);
         let res = Self {
-            channel,
-            state: HandshakeState::SendingInitiationRequest,
+            channel: Channel::new(channel_id),
+            state: HandshakeState::Initial,
             noise: hss,
             internal_buffer,
             device_properties,
@@ -436,8 +435,26 @@ impl<C: CredentialStore, B: Backend> ChannelOpen<C, B> {
         PairingState::try_from(payload.as_slice())
     }
 
+    /// Returns device's `ThpDeviceProperties` protobuf structure.
     pub fn device_properties(&self) -> &[u8] {
         self.device_properties.as_slice()
+    }
+
+    /// Set peer's protocol version as indicated in `device_properties`.
+    /// This method must be called before the first call to [`ChannelOpen::packet_out`].
+    /// If it's not called, version 2.0 is assumed, which should be universally compatible.
+    /// The library cannot do it automatically because it doesn't understand protocol buffers.
+    pub fn set_device_protocol_version(&mut self, major: u8, minor: u8) {
+        if !matches!(self.state, HandshakeState::Initial) {
+            log::error!(
+                "[{:04x}] Setting protocol version after handshake started has no effect.",
+                self.channel_id()
+            );
+            return;
+        }
+        if (major, minor) >= (2, 1) {
+            self.channel.sync.allow_ack_piggybacking();
+        }
     }
 
     /// True if handshake finished and [`ChannelOpen::complete()`] can be called.
@@ -490,21 +507,26 @@ where
     B: Backend,
 {
     fn packet_in(&mut self, packet_buffer: &[u8], _receive_buffer: &mut [u8]) -> PacketInResult {
+        if matches!(self.state, HandshakeState::Initial) {
+            // Do not accept any packets before we started sending InitiationRequest;
+            return PacketInResult::ignore(Error::malformed_data());
+        }
         let res = self
             .channel
             .packet_in(packet_buffer, &mut self.internal_buffer);
-        if let PacketInResult::EnlargeBuffer { buffer_size, .. } = res {
+        if let PacketInResult::Accepted {
+            buffer_size: Some(s),
+            ..
+        } = res
+        {
             log::error!(
                 "[{:04x}] Payload length {} exceeds handshake limit.",
                 self.channel_id(),
-                buffer_size
+                s
             );
             // Possibly damaged length field, ignore continuations.
             self.channel.state = ChannelState::Idle;
             return PacketInResult::ignore(Error::malformed_data());
-        }
-        if res.got_ack() {
-            prepare_zeroed(&mut self.internal_buffer);
         }
         if res.got_message() {
             let handled = self.incoming_internal();
@@ -516,17 +538,29 @@ where
                     return PacketInResult::fail(e);
                 }
             }
+        } else if res.got_ack() {
+            prepare_zeroed(&mut self.internal_buffer);
         }
         res
     }
 
     fn packet_out(&mut self, packet_buffer: &mut [u8], _send_buffer: &[u8]) -> Result<(), Error> {
+        if matches!(self.state, HandshakeState::Initial) {
+            let header = Header::<Host>::new_handshake(
+                self.channel_id(),
+                HandshakeMessage::InitiationRequest,
+                &self.internal_buffer,
+            )?;
+            self.channel
+                .raw_in_ext(header, &self.internal_buffer, true)?;
+            self.state = HandshakeState::SendingInitiationRequest;
+        }
         self.channel
             .packet_out(packet_buffer, &self.internal_buffer)
     }
 
     fn packet_out_ready(&self) -> bool {
-        self.channel.packet_out_ready()
+        matches!(self.state, HandshakeState::Initial) || self.channel.packet_out_ready()
     }
 
     fn message_in(&mut self, _plaintext_len: usize, _send_buffer: &mut [u8]) -> Result<(), Error> {

--- a/rust/trezor-thp/src/channel/host.rs
+++ b/rust/trezor-thp/src/channel/host.rs
@@ -3,7 +3,10 @@ use heapless;
 use crate::{
     Backend, ChannelIO, Error, Host,
     alternating_bit::SyncBits,
-    channel::{ChannelState, Nonce, PacketInResult, PairingState, noise::NoiseHandshake},
+    channel::{
+        ChannelState, HANDSHAKE_BUFFER_LEN, MAX_ALLOC_RESPONSE_LEN, MAX_DEVICE_PROPERTIES_LEN,
+        Nonce, PacketInResult, PairingState, noise::NoiseHandshake,
+    },
     credential::CredentialStore,
     fragment::{Fragmenter, Reassembler},
     header::{
@@ -14,13 +17,6 @@ use crate::{
 };
 
 use core::marker::PhantomData;
-
-// Must fit any of:
-// - device_properties + overhead
-// - 2 DH keys + 2 AEAD tags (2*32+2*16=96) + overhead
-// - DH key + credential + 2 AEAD tags + overhead
-const INTERNAL_BUFFER_LEN: usize = 192;
-const MAX_DEVICE_PROPERTIES_LEN: usize = 128;
 
 pub type Channel<B> = super::Channel<Host, B>;
 
@@ -59,7 +55,7 @@ enum PingState {
 /// Because host often only needs a single channel, you can throw away the Mux
 /// after allocating one, if you don't need the keep-alive functionality.
 pub struct Mux<B> {
-    internal_buffer: heapless::Vec<u8, MAX_DEVICE_PROPERTIES_LEN>,
+    internal_buffer: heapless::Vec<u8, MAX_ALLOC_RESPONSE_LEN>,
     channel_allocation: AllocationState,
     ping: PingState,
     _phantom: PhantomData<B>,
@@ -343,7 +339,7 @@ pub struct ChannelOpen<C: CredentialStore, B: Backend> {
     channel: Channel<B>,
     state: HandshakeState,
     noise: NoiseHandshake<Host, B>,
-    internal_buffer: heapless::Vec<u8, INTERNAL_BUFFER_LEN>,
+    internal_buffer: heapless::Vec<u8, HANDSHAKE_BUFFER_LEN>,
     device_properties: heapless::Vec<u8, MAX_DEVICE_PROPERTIES_LEN>,
     cred_store: C,
 }

--- a/rust/trezor-thp/src/channel/host.rs
+++ b/rust/trezor-thp/src/channel/host.rs
@@ -4,8 +4,8 @@ use crate::{
     Backend, ChannelIO, Error, Host,
     alternating_bit::SyncBits,
     channel::{
-        ChannelState, HANDSHAKE_BUFFER_LEN, MAX_ALLOC_RESPONSE_LEN, MAX_DEVICE_PROPERTIES_LEN,
-        Nonce, PacketInResult, PairingState, noise::NoiseHandshake,
+        ChannelState, HANDSHAKE_BUFFER_DTH_LEN, HANDSHAKE_BUFFER_HTD_LEN, MAX_ALLOC_RESPONSE_LEN,
+        MAX_DEVICE_PROPERTIES_LEN, Nonce, PacketInResult, PairingState, noise::NoiseHandshake,
     },
     credential::CredentialStore,
     fragment::{Fragmenter, Reassembler},
@@ -339,7 +339,8 @@ pub struct ChannelOpen<C: CredentialStore, B: Backend> {
     channel: Channel<B>,
     state: HandshakeState,
     noise: NoiseHandshake<Host, B>,
-    internal_buffer: heapless::Vec<u8, HANDSHAKE_BUFFER_LEN>,
+    send_buffer: heapless::Vec<u8, HANDSHAKE_BUFFER_HTD_LEN>,
+    receive_buffer: heapless::Vec<u8, HANDSHAKE_BUFFER_DTH_LEN>,
     device_properties: heapless::Vec<u8, MAX_DEVICE_PROPERTIES_LEN>,
     cred_store: C,
 }
@@ -354,20 +355,22 @@ impl<C: CredentialStore, B: Backend> ChannelOpen<C, B> {
         let device_properties = heapless::Vec::from_slice(device_properties)
             .map_err(|_| Error::insufficient_buffer())?;
 
-        let mut internal_buffer = heapless::Vec::new();
-        prepare_zeroed(&mut internal_buffer);
-        let (hss, msg) = NoiseHandshake::write_initiation_request(
+        let mut send_buffer = heapless::Vec::new();
+        prepare_zeroed(&mut send_buffer);
+        let (hss, len) = NoiseHandshake::write_initiation_request(
             &device_properties,
             try_to_unlock,
-            &mut internal_buffer,
+            &mut send_buffer,
         )?;
-        let len = msg.len();
-        internal_buffer.truncate(len);
+        send_buffer.truncate(len);
+        let mut receive_buffer = heapless::Vec::new();
+        prepare_zeroed(&mut receive_buffer);
         let res = Self {
             channel: Channel::new(channel_id),
             state: HandshakeState::Initial,
             noise: hss,
-            internal_buffer,
+            send_buffer,
+            receive_buffer,
             device_properties,
             cred_store,
         };
@@ -375,8 +378,8 @@ impl<C: CredentialStore, B: Backend> ChannelOpen<C, B> {
     }
 
     fn incoming_internal(&mut self) -> Result<(), Error> {
-        let (header, len) = self.channel.raw_out(&self.internal_buffer)?;
-        self.internal_buffer.truncate(len);
+        let (header, len) = self.channel.raw_out(&self.receive_buffer)?;
+        self.receive_buffer.truncate(len);
 
         match (self.state, header.handshake_phase()) {
             (
@@ -398,37 +401,32 @@ impl<C: CredentialStore, B: Backend> ChannelOpen<C, B> {
                 return Err(Error::unexpected_input());
             }
         }
+        prepare_zeroed(&mut self.receive_buffer);
         Ok(())
     }
 
     fn continue_handshake(&mut self) -> Result<(), Error> {
-        let payload_len = self.internal_buffer.len();
-        // Buffer used both for input and output - pad with zeros.
-        self.internal_buffer
-            .resize(self.internal_buffer.capacity(), 0u8)
-            .unwrap();
-        let (nc, msg) = self.noise.write_completion_request(
+        prepare_zeroed(&mut self.send_buffer);
+        let (nc, len) = self.noise.write_completion_request(
             &mut self.cred_store,
-            &mut self.internal_buffer,
-            payload_len,
+            &self.receive_buffer,
+            &mut self.send_buffer,
         )?;
+        self.send_buffer.truncate(len);
         self.channel.noise = Some(nc);
         let header = Header::new_handshake(
             self.channel.channel_id,
             HandshakeMessage::CompletionRequest,
-            msg,
+            &self.send_buffer,
         )?;
-        self.channel.raw_in(header, msg)?;
-        let len = msg.len();
-        self.internal_buffer.truncate(len);
+        self.channel.raw_in(header, &self.send_buffer)?;
         Ok(())
     }
 
     fn finish_handshake(&mut self) -> Result<PairingState, Error> {
-        let payload = &mut self.internal_buffer;
-        let len = self.channel.noise()?.decrypt(payload.as_mut_slice())?;
-        payload.truncate(len); // assumes tag at the end
-        PairingState::try_from(payload.as_slice())
+        let len = self.channel.noise()?.decrypt(&mut self.receive_buffer)?;
+        let payload = &self.receive_buffer[..len]; // assumes tag at the end
+        PairingState::try_from(payload)
     }
 
     /// Returns device's `ThpDeviceProperties` protobuf structure.
@@ -509,7 +507,7 @@ where
         }
         let res = self
             .channel
-            .packet_in(packet_buffer, &mut self.internal_buffer);
+            .packet_in(packet_buffer, &mut self.receive_buffer);
         if let PacketInResult::Accepted {
             buffer_size: Some(s),
             ..
@@ -534,25 +532,21 @@ where
                     return PacketInResult::fail(e);
                 }
             }
-        } else if res.got_ack() {
-            prepare_zeroed(&mut self.internal_buffer);
         }
         res
     }
 
     fn packet_out(&mut self, packet_buffer: &mut [u8], _send_buffer: &[u8]) -> Result<(), Error> {
-        if matches!(self.state, HandshakeState::Initial) {
+        if let HandshakeState::Initial = self.state {
             let header = Header::<Host>::new_handshake(
                 self.channel_id(),
                 HandshakeMessage::InitiationRequest,
-                &self.internal_buffer,
+                &self.send_buffer,
             )?;
-            self.channel
-                .raw_in_ext(header, &self.internal_buffer, true)?;
+            self.channel.raw_in_ext(header, &self.send_buffer, true)?;
             self.state = HandshakeState::SendingInitiationRequest;
         }
-        self.channel
-            .packet_out(packet_buffer, &self.internal_buffer)
+        self.channel.packet_out(packet_buffer, &self.send_buffer)
     }
 
     fn packet_out_ready(&self) -> bool {

--- a/rust/trezor-thp/src/channel/mod.rs
+++ b/rust/trezor-thp/src/channel/mod.rs
@@ -14,6 +14,8 @@ use crate::{
     header::{BROADCAST_CHANNEL_ID, Header, NONCE_LEN, parse_cb_channel, parse_u16},
 };
 
+use core::num::NonZeroU16;
+
 use noise::NoiseCiphers;
 pub use noise::{
     Backend, Cipher, DH, HANDSHAKE_HASH_LEN, Hash, PRIVKEY_LEN, PUBKEY_LEN, TAG_LEN, U8Array,
@@ -178,11 +180,24 @@ impl<R: Role, B: Backend> Channel<R, B> {
         self.state = ChannelState::SendingError { error };
     }
 
-    fn raw_in(&mut self, header: Header<R>, send_buffer: &[u8]) -> Result<()> {
+    fn raw_in_ext(
+        &mut self,
+        header: Header<R>,
+        send_buffer: &[u8],
+        override_ack_bit: bool,
+    ) -> Result<()> {
         let ChannelState::Idle = self.state else {
             return Err(Error::not_ready());
         };
-        let sb = self.sync.send_start().ok_or_else(Error::not_ready)?;
+        let mut sb = self.sync.send_start().ok_or_else(Error::not_ready)?;
+        if self.sync.is_ack_piggybacking_allowed() {
+            // `sb` contains the ACK bit, cancel sending it as a message.
+            self.send_ack = None;
+            // Signal piggybacking support if host requested it.
+            if override_ack_bit {
+                sb = sb.with_ack_bit(true);
+            }
+        }
         let fragmenter = Fragmenter::new(header, sb, send_buffer)?;
         self.state = ChannelState::Sending {
             fragmenter,
@@ -191,23 +206,21 @@ impl<R: Role, B: Backend> Channel<R, B> {
         Ok(())
     }
 
+    fn raw_in(&mut self, header: Header<R>, send_buffer: &[u8]) -> Result<()> {
+        self.raw_in_ext(header, send_buffer, false)
+    }
+
     fn raw_out(&mut self, receive_buffer: &[u8]) -> Result<(Header<R>, usize)> {
-        let ChannelState::Receiving { reassembler } = &mut self.state else {
+        let ChannelState::Receiving { reassembler, .. } = &mut self.state else {
             return Err(Error::not_ready());
         };
         if !reassembler.is_done() {
             return Err(Error::not_ready());
         }
-        let len = match reassembler.verify(receive_buffer) {
-            Ok(len) => len,
-            Err(e) => {
-                log::warn!(
-                    "[{}] Reassembled message with invalid checksum.",
-                    self.channel_id
-                );
-                return Err(e);
-            }
-        };
+        // Possible optimization: provided receive_buffer is the same as passed to
+        // `packet_in`, we're verifying the CRC for the second time, would be nice to
+        // get rid of it but probably won't make things massively faster.
+        let len = reassembler.verify(receive_buffer)?;
         self.send_ack = Some(self.sync.receive_acknowledge());
         let header = reassembler.header().clone();
         self.state = ChannelState::Idle;
@@ -219,12 +232,12 @@ impl<R: Role, B: Backend> Channel<R, B> {
         packet_buffer: &[u8],
         receive_buffer: &mut [u8],
     ) -> Result<PacketInResult> {
-        let (cb, channel_id, _rest) = parse_cb_channel(packet_buffer)?;
-        if channel_id != self.channel_id {
+        let (cb, cid, _rest) = parse_cb_channel(packet_buffer)?;
+        if cid != self.channel_id {
             log::warn!(
-                "[{}] Invalid channel {}, ignoring.",
+                "[{:04x}] Invalid channel {:04x}, ignoring.",
                 self.channel_id,
-                channel_id
+                cid
             );
             return Err(Error::malformed_data());
         }
@@ -234,41 +247,41 @@ impl<R: Role, B: Backend> Channel<R, B> {
         } else if cb.is_error() {
             let te = self.handle_error(packet_buffer)?;
             return Ok(PacketInResult::transport_error(te));
-        }
-        let is_cont = cb.is_continuation();
-        if !(is_cont || cb.is_handshake() || cb.is_encrypted_transport()) {
+        } else if cb.is_continuation() {
+            self.handle_cont(packet_buffer, receive_buffer)?;
+        } else if cb.is_handshake() || cb.is_encrypted_transport() {
+            self.handle_invalid_seq(cb.sync_bits())?;
+            match &self.state {
+                // Initiation packet, normal case.
+                ChannelState::Idle | ChannelState::Receiving { .. } => {
+                    self.handle_init(packet_buffer, receive_buffer)?;
+                }
+                // Initiation packet while we're sending.
+                ChannelState::Sending { .. } if self.sync.is_ack_piggybacking_allowed() => {
+                    self.handle_init(packet_buffer, receive_buffer)?;
+                }
+                // Unexpected initiation packet.
+                _ => {
+                    return Err(Error::malformed_data());
+                }
+            }
+        } else {
             // Channel allocation and codec v1 are handled by Mux.
+            let cb = u8::from(cb);
             log::warn!(
-                "[{}] Unexpected control byte {}.",
+                "[{:04x}] Unexpected control byte 0x{:x}.",
                 self.channel_id,
-                u8::from(cb)
+                cb
             );
             return Err(Error::malformed_data());
         }
-        Ok(match &mut self.state {
-            // First fragment.
-            ChannelState::Receiving { .. } | ChannelState::Idle if !is_cont => {
-                let (is_done, enlarge) = self.handle_init(packet_buffer, receive_buffer)?;
-                PacketInResult::accept(is_done).with_buffer(enlarge)
-            }
-            // Continuation fragments.
-            ChannelState::Receiving { reassembler } => {
-                reassembler.update(packet_buffer, receive_buffer)?;
-                PacketInResult::accept(reassembler.is_done())
-            }
-            // Ignore unexpected continuations.
-            ChannelState::Idle => return Err(Error::malformed_data()),
-            // Might possibly happen when we've sent an ACK and it got lost.
-            // We end up sending reply while the other side is retransmitting.
-            // Is this recoverable?
-            ChannelState::Sending { .. } => return Err(Error::malformed_data()),
-            ChannelState::SendingError { .. } => return Err(Error::unexpected_input()),
-            ChannelState::Failed { .. } => return Err(Error::unexpected_input()),
-        })
+        self.handle_last_packet(receive_buffer)
     }
 
     fn handle_ack(&mut self, packet_buffer: &[u8]) -> Result<()> {
         if matches!(self.state, ChannelState::Sending { .. }) {
+            // Verify checksum.
+            let _ = Reassembler::<R>::single(packet_buffer)?;
             let sb = SyncBits::try_from(packet_buffer)?;
             self.sync.send_mark_delivered(sb);
             if self.sync.can_send() {
@@ -281,8 +294,7 @@ impl<R: Role, B: Backend> Channel<R, B> {
     }
 
     fn handle_error(&mut self, packet_buffer: &[u8]) -> Result<TransportError> {
-        let mut err_buf = [0u8; 16];
-        if let Ok((header, payload)) = Reassembler::<R>::single(packet_buffer, &mut err_buf) {
+        if let Ok((header, payload)) = Reassembler::<R>::single(packet_buffer) {
             if header.is_error() {
                 if let Ok(te) = TransportError::try_from(payload) {
                     log::error!(
@@ -312,23 +324,89 @@ impl<R: Role, B: Backend> Channel<R, B> {
         Err(Error::malformed_data())
     }
 
-    fn handle_init(
-        &mut self,
-        packet_buffer: &[u8],
-        receive_buffer: &mut [u8],
-    ) -> Result<(bool, Option<u16>)> {
-        let sb = SyncBits::try_from(packet_buffer)?;
-        if !self.sync.receive_start(sb) {
-            // Bad sync bit, drop this packet and continuations.
-            log::debug!("[{}] Bad sync bit, ignoring packet.", self.channel_id);
-            self.state = ChannelState::Idle;
+    fn handle_cont(&mut self, packet_buffer: &[u8], receive_buffer: &mut [u8]) -> Result<()> {
+        let ChannelState::Receiving { reassembler } = &mut self.state else {
             return Err(Error::malformed_data());
+        };
+        reassembler.update(packet_buffer, receive_buffer)
+    }
+
+    fn handle_invalid_seq(&mut self, sb: SyncBits) -> Result<()> {
+        if self.sync.receive_start(sb) {
+            return Ok(());
         }
+        match &self.state {
+            ChannelState::Receiving { .. } => {
+                // Bad sync bit, drop the packet.
+                log::debug!("[{:04x}] Bad sync bit, ignoring packet.", self.channel_id);
+            }
+            ChannelState::Sending { .. } if self.sync.is_ack_piggybacking_allowed() => {
+                // ACK we sent was lost. Will be retransmitted along current outgoing message.
+                log::debug!("[{:04x}] Bad sync bit, ignoring packet.", self.channel_id);
+            }
+            _ => {
+                // Might happen when we've sent an ACK and it got lost.
+                // We end up sending reply while the other side is retransmitting.
+                // NOTE: no checksum verification because we drop the continuations
+                log::debug!(
+                    "[{:04x}] Bad sync bit, resending last ACK.",
+                    self.channel_id
+                );
+                self.send_ack = Some(SyncBits::new().with_ack_bit(sb.seq_bit()));
+            }
+        }
+        Err(Error::malformed_data())
+    }
+
+    fn handle_init(&mut self, packet_buffer: &[u8], receive_buffer: &mut [u8]) -> Result<()> {
         receive_buffer.fill(0);
         let reassembler = Reassembler::new(packet_buffer, receive_buffer)?;
-        let is_done = reassembler.is_done();
+        self.state = ChannelState::Receiving { reassembler };
+        Ok(())
+    }
+
+    fn handle_last_packet(&mut self, receive_buffer: &mut [u8]) -> Result<PacketInResult> {
+        let ChannelState::Receiving { reassembler } = &self.state else {
+            return Err(Error::unexpected_input());
+        };
+        let mut message_ready = false;
+        let mut ack_received = false;
+        if reassembler.is_done() {
+            if let Err(e) = reassembler.verify(receive_buffer) {
+                log::warn!(
+                    "[{:04x}] Reassembled message with invalid checksum.",
+                    self.channel_id
+                );
+                self.state = ChannelState::Idle;
+                return Err(e);
+            }
+            message_ready = true;
+            if self.sync.is_ack_piggybacking_allowed() && !self.sync.can_send() {
+                self.sync.send_mark_delivered(reassembler.sync_bits());
+                if self.sync.can_send() {
+                    ack_received = true;
+                } else {
+                    log::warn!("[{:04x}] Unexpected ACK bit.", self.channel_id);
+                }
+            }
+        }
+        let pir = PacketInResult::Accepted {
+            ack_received,
+            message_ready,
+            pong: false,
+            buffer_size: self.check_buffer_len(receive_buffer),
+        };
+        Ok(pir)
+    }
+
+    fn check_buffer_len(&self, receive_buffer: &[u8]) -> Option<NonZeroU16> {
+        let ChannelState::Receiving { reassembler } = &self.state else {
+            return None;
+        };
         let payload_len = reassembler.header().payload_len();
-        let enlarge = (usize::from(payload_len) > receive_buffer.len()).then_some(payload_len);
+        let enlarge = (usize::from(payload_len) > receive_buffer.len())
+            .then_some(payload_len)
+            .and_then(NonZeroU16::new);
         if enlarge.is_some() {
             log::debug!(
                 "Message is larger ({}) than receive buffer ({}), requesting reallocation.",
@@ -336,8 +414,7 @@ impl<R: Role, B: Backend> Channel<R, B> {
                 receive_buffer.len()
             );
         }
-        self.state = ChannelState::Receiving { reassembler };
-        Ok((is_done, enlarge))
+        enlarge
     }
 }
 
@@ -354,15 +431,11 @@ pub enum PacketInResult {
         message_ready: bool,
         /// True if the packet was a valid keep-alive reply ("PONG") message.
         pong: bool,
-    },
-    /// Channel ingested the packet and started reassembling a message that is larger
-    /// than the current receive buffer. Resize it (keep the initial part) or destroy the channel.
-    EnlargeBuffer {
-        /// True if the packet contained valid ACK and channel is ready to send next message.
-        /// Reserved for ACK piggybacking.
-        ack_received: bool,
-        /// Message size including checksum, the minimum new size of receive buffer.
-        buffer_size: u16,
+        /// If Some, initiation packet was received for message that is larger than the current
+        /// receive buffer. Resize it (keep the initial part) or destroy the channel.
+        /// Please note the size is returned before checksum verification and can be unusually
+        /// large in presence of bit errors.
+        buffer_size: Option<NonZeroU16>,
     },
     /// Peer sent a `TRANSPORT_ERROR` message.
     TransportError {
@@ -399,16 +472,7 @@ impl PacketInResult {
             ack_received: false,
             message_ready,
             pong: false,
-        }
-    }
-
-    const fn with_buffer(self, enlarge_receive_buffer: Option<u16>) -> Self {
-        match enlarge_receive_buffer {
-            Some(buffer_size) => Self::EnlargeBuffer {
-                ack_received: self.got_ack(),
-                buffer_size,
-            },
-            None => self,
+            buffer_size: None,
         }
     }
 
@@ -421,6 +485,7 @@ impl PacketInResult {
             ack_received: true,
             message_ready: false,
             pong: false,
+            buffer_size: None,
         }
     }
 
@@ -445,6 +510,7 @@ impl PacketInResult {
             ack_received: false,
             message_ready: false,
             pong: true,
+            buffer_size: None,
         }
     }
 
@@ -452,7 +518,6 @@ impl PacketInResult {
     pub const fn got_ack(&self) -> bool {
         match self {
             Self::Accepted { ack_received, .. } => *ack_received,
-            Self::EnlargeBuffer { ack_received, .. } => *ack_received,
             _ => false,
         }
     }
@@ -518,7 +583,8 @@ impl PacketInResult {
 ///
 /// To give the application freedom in handling precious buffers used during message
 /// fragmentation and reassembly, channel does not keep ownership of them, instead they need
-/// to be passed along every call.
+/// to be passed along every call. You can wrap the channel in [`buffered::Buffered`] to
+/// handle the buffers for you.
 pub trait ChannelIO {
     /// Session ID (1B) + message type (2B) + AEAD tag (16B).
     const BUFFER_OVERHEAD: usize = APP_HEADER_LEN + TAG_LEN;
@@ -567,9 +633,6 @@ pub trait ChannelIO {
     /// Pick up reassembled and decrypted message. The channel will send ACK packet afterwards.
     ///
     /// Returns [`Error::NotReady`] if there is no reassembled message.
-    ///
-    /// Returns [`Error::InvalidChecksum`] if message integrity failed. Usually the other side
-    /// will retransmit the message.
     fn message_out<'a>(&mut self, receive_buffer: &'a mut [u8]) -> Result<(u8, u16, &'a [u8])>;
 
     /// Is there a reassembled incoming message ready?

--- a/rust/trezor-thp/src/channel/mod.rs
+++ b/rust/trezor-thp/src/channel/mod.rs
@@ -9,9 +9,11 @@ mod test;
 use crate::{
     Error, Role,
     alternating_bit::{ChannelSync, SyncBits},
+    crc32::CHECKSUM_LEN,
     error::{Result, TransportError},
     fragment::{Fragmenter, Reassembler},
     header::{BROADCAST_CHANNEL_ID, Header, NONCE_LEN, parse_cb_channel, parse_u16},
+    util::max,
 };
 
 use core::num::NonZeroU16;
@@ -20,6 +22,23 @@ use noise::NoiseCiphers;
 pub use noise::{
     Backend, Cipher, DH, HANDSHAKE_HASH_LEN, Hash, PRIVKEY_LEN, PUBKEY_LEN, TAG_LEN, U8Array,
 };
+
+pub const MAX_DEVICE_PROPERTIES_LEN: usize = 64;
+pub const MAX_CREDENTIAL_LEN: usize = 128;
+
+// Size of internal buffer needed when opening a channel: host-to-device direction.
+const HANDSHAKE_BUFFER_HTD_LEN: usize =
+    PUBKEY_LEN + MAX_CREDENTIAL_LEN + 2 * TAG_LEN + CHECKSUM_LEN; // HandshakeCompletionRequest
+
+const MAX_ALLOC_RESPONSE_LEN: usize =
+    (NONCE_LEN as usize) + 2 + MAX_DEVICE_PROPERTIES_LEN + CHECKSUM_LEN;
+// Size of internal buffer needed when opening a channel: device-to-host direction.
+const HANDSHAKE_BUFFER_DTH_LEN: usize = max(
+    MAX_ALLOC_RESPONSE_LEN,                      // ChannelAllocationResponse
+    2 * PUBKEY_LEN + 2 * TAG_LEN + CHECKSUM_LEN, // HandshakeInitiationResponse
+);
+
+const HANDSHAKE_BUFFER_LEN: usize = max(HANDSHAKE_BUFFER_HTD_LEN, HANDSHAKE_BUFFER_DTH_LEN);
 
 const APP_HEADER_LEN: usize = 3; // session id (1) + message type (2)
 

--- a/rust/trezor-thp/src/channel/mod.rs
+++ b/rust/trezor-thp/src/channel/mod.rs
@@ -38,8 +38,6 @@ const HANDSHAKE_BUFFER_DTH_LEN: usize = max(
     2 * PUBKEY_LEN + 2 * TAG_LEN + CHECKSUM_LEN, // HandshakeInitiationResponse
 );
 
-const HANDSHAKE_BUFFER_LEN: usize = max(HANDSHAKE_BUFFER_HTD_LEN, HANDSHAKE_BUFFER_DTH_LEN);
-
 const APP_HEADER_LEN: usize = 3; // session id (1) + message type (2)
 
 /// Used during channel allocation on broadcast channel.

--- a/rust/trezor-thp/src/channel/mod.rs
+++ b/rust/trezor-thp/src/channel/mod.rs
@@ -110,9 +110,9 @@ impl From<PairingState> for u8 {
     }
 }
 
-/// Is the channel currently sending or receiving a message?
-enum ChannelState<R: Role> {
-    /// Ready to send or receive.
+/// Is the channel currently sending a message?
+enum SendState<R: Role> {
+    /// Ready to send.
     Idle,
     /// In the process of sending a message, or waiting for ACK.
     Sending {
@@ -122,13 +122,19 @@ enum ChannelState<R: Role> {
     /// About to send Transport error, these are not ACKed.
     /// Transitions to Failed afterwards unless the error is recoverable.
     SendingError { error: TransportError },
+    /// Channel is inoperable.
+    Failed,
+}
+
+/// Is the channel currently receiving a message?
+enum ReceiveState<R: Role> {
+    /// Ready to receive.
+    Idle,
     /// In the process of receiving a message, or waiting for the consumer to pick up
     /// an assembled message.
     Receiving { reassembler: Reassembler<R> },
     /// Channel is inoperable.
-    /// None: local failure
-    /// Some: error message received from other side
-    Failed { error: Option<TransportError> },
+    Failed,
 }
 
 /// THP channel with established secure layer.
@@ -141,7 +147,8 @@ pub struct Channel<R: Role, B: Backend> {
     sync: ChannelSync,
     noise: Option<NoiseCiphers<B>>,
     send_ack: Option<SyncBits>,
-    state: ChannelState<R>,
+    send_state: SendState<R>,
+    receive_state: ReceiveState<R>,
     pairing_state: PairingState,
 }
 
@@ -152,7 +159,8 @@ impl<R: Role, B: Backend> Channel<R, B> {
             sync: ChannelSync::new(),
             noise: None,
             send_ack: None,
-            state: ChannelState::Idle,
+            send_state: SendState::Idle,
+            receive_state: ReceiveState::Idle,
             pairing_state: PairingState::Unpaired,
         }
     }
@@ -181,20 +189,26 @@ impl<R: Role, B: Backend> Channel<R, B> {
     }
 
     pub fn is_failed(&self) -> bool {
-        matches!(self.state, ChannelState::Failed { .. })
+        matches!(self.send_state, SendState::Failed)
+            || matches!(self.receive_state, ReceiveState::Failed)
+    }
+
+    fn become_failed(&mut self) {
+        self.send_state = SendState::Failed;
+        self.receive_state = ReceiveState::Failed;
     }
 
     /// Return the retransmission attempt number (the first transmission returns 0),
     /// or `None` if the channel is currently not sending anything.
     pub fn sending_retry(&self) -> Option<u8> {
-        match self.state {
-            ChannelState::Sending { retry, .. } => Some(retry),
+        match &self.send_state {
+            SendState::Sending { retry, .. } => Some(*retry),
             _ => None,
         }
     }
 
     pub fn send_error(&mut self, error: TransportError) {
-        self.state = ChannelState::SendingError { error };
+        self.send_state = SendState::SendingError { error };
     }
 
     fn raw_in_ext(
@@ -203,7 +217,7 @@ impl<R: Role, B: Backend> Channel<R, B> {
         send_buffer: &[u8],
         override_ack_bit: bool,
     ) -> Result<()> {
-        let ChannelState::Idle = self.state else {
+        let SendState::Idle = self.send_state else {
             return Err(Error::not_ready());
         };
         let mut sb = self.sync.send_start().ok_or_else(Error::not_ready)?;
@@ -216,7 +230,7 @@ impl<R: Role, B: Backend> Channel<R, B> {
             }
         }
         let fragmenter = Fragmenter::new(header, sb, send_buffer)?;
-        self.state = ChannelState::Sending {
+        self.send_state = SendState::Sending {
             fragmenter,
             retry: 0,
         };
@@ -228,7 +242,7 @@ impl<R: Role, B: Backend> Channel<R, B> {
     }
 
     fn raw_out(&mut self, receive_buffer: &[u8]) -> Result<(Header<R>, usize)> {
-        let ChannelState::Receiving { reassembler, .. } = &mut self.state else {
+        let ReceiveState::Receiving { reassembler, .. } = &mut self.receive_state else {
             return Err(Error::not_ready());
         };
         if !reassembler.is_done() {
@@ -240,7 +254,7 @@ impl<R: Role, B: Backend> Channel<R, B> {
         let len = reassembler.verify(receive_buffer)?;
         self.send_ack = Some(self.sync.receive_acknowledge());
         let header = reassembler.header().clone();
-        self.state = ChannelState::Idle;
+        self.receive_state = ReceiveState::Idle;
         Ok((header, len))
     }
 
@@ -268,20 +282,13 @@ impl<R: Role, B: Backend> Channel<R, B> {
             self.handle_cont(packet_buffer, receive_buffer)?;
         } else if cb.is_handshake() || cb.is_encrypted_transport() {
             self.handle_invalid_seq(cb.sync_bits())?;
-            match &self.state {
-                // Initiation packet, normal case.
-                ChannelState::Idle | ChannelState::Receiving { .. } => {
-                    self.handle_init(packet_buffer, receive_buffer)?;
-                }
-                // Initiation packet while we're sending.
-                ChannelState::Sending { .. } if self.sync.is_ack_piggybacking_allowed() => {
-                    self.handle_init(packet_buffer, receive_buffer)?;
-                }
-                // Unexpected initiation packet.
-                _ => {
-                    return Err(Error::malformed_data());
-                }
+            if matches!(self.send_state, SendState::Sending { .. })
+                && !self.sync.is_ack_piggybacking_allowed()
+            {
+                // Enforce half-duplex in 2.0.
+                return Err(Error::malformed_data());
             }
+            self.handle_init(packet_buffer, receive_buffer)?;
         } else {
             // Channel allocation and codec v1 are handled by Mux.
             let cb = u8::from(cb);
@@ -296,13 +303,13 @@ impl<R: Role, B: Backend> Channel<R, B> {
     }
 
     fn handle_ack(&mut self, packet_buffer: &[u8]) -> Result<()> {
-        if matches!(self.state, ChannelState::Sending { .. }) {
+        if matches!(self.send_state, SendState::Sending { .. }) {
             // Verify checksum.
             let _ = Reassembler::<R>::single(packet_buffer)?;
             let sb = SyncBits::try_from(packet_buffer)?;
             self.sync.send_mark_delivered(sb);
             if self.sync.can_send() {
-                self.state = ChannelState::Idle;
+                self.send_state = SendState::Idle;
                 return Ok(());
             }
         }
@@ -317,10 +324,10 @@ impl<R: Role, B: Backend> Channel<R, B> {
                     log::error!(
                         "[{:04x}] Peer sent an error: {}.",
                         self.channel_id,
-                        te as u8
+                        te.as_str()
                     );
                     if !te.is_recoverable() {
-                        self.state = ChannelState::Failed { error: Some(te) };
+                        self.become_failed();
                     }
                     return Ok(te);
                 } else {
@@ -331,7 +338,7 @@ impl<R: Role, B: Backend> Channel<R, B> {
                     );
                 }
             }
-            self.state = ChannelState::Failed { error: None };
+            self.become_failed();
             return Err(Error::malformed_data());
         }
         log::warn!(
@@ -342,7 +349,7 @@ impl<R: Role, B: Backend> Channel<R, B> {
     }
 
     fn handle_cont(&mut self, packet_buffer: &[u8], receive_buffer: &mut [u8]) -> Result<()> {
-        let ChannelState::Receiving { reassembler } = &mut self.state else {
+        let ReceiveState::Receiving { reassembler } = &mut self.receive_state else {
             return Err(Error::malformed_data());
         };
         reassembler.update(packet_buffer, receive_buffer)
@@ -352,25 +359,20 @@ impl<R: Role, B: Backend> Channel<R, B> {
         if self.sync.receive_start(sb) {
             return Ok(());
         }
-        match &self.state {
-            ChannelState::Receiving { .. } => {
-                // Bad sync bit, drop the packet.
-                log::debug!("[{:04x}] Bad sync bit, ignoring packet.", self.channel_id);
-            }
-            ChannelState::Sending { .. } if self.sync.is_ack_piggybacking_allowed() => {
-                // ACK we sent was lost. Will be retransmitted along current outgoing message.
-                log::debug!("[{:04x}] Bad sync bit, ignoring packet.", self.channel_id);
-            }
-            _ => {
-                // Might happen when we've sent an ACK and it got lost.
-                // We end up sending reply while the other side is retransmitting.
-                // NOTE: no checksum verification because we drop the continuations
-                log::debug!(
-                    "[{:04x}] Bad sync bit, resending last ACK.",
-                    self.channel_id
-                );
-                self.send_ack = Some(SyncBits::new().with_ack_bit(sb.seq_bit()));
-            }
+        if self.sync.is_ack_piggybacking_allowed()
+            && matches!(self.send_state, SendState::Sending { .. })
+        {
+            // ACK we sent was lost. Will be retransmitted along current outgoing message.
+            log::debug!("[{:04x}] Bad sync bit, ignoring packet.", self.channel_id);
+        } else if !matches!(self.receive_state, ReceiveState::Receiving { .. }) {
+            // Might happen when we've sent an ACK and it got lost or delayed.
+            // We end up sending reply while the other side is retransmitting.
+            // NOTE: no checksum verification because we drop the continuations
+            log::debug!(
+                "[{:04x}] Bad sync bit, resending last ACK.",
+                self.channel_id
+            );
+            self.send_ack = Some(SyncBits::new().with_ack_bit(sb.seq_bit()));
         }
         Err(Error::malformed_data())
     }
@@ -378,12 +380,12 @@ impl<R: Role, B: Backend> Channel<R, B> {
     fn handle_init(&mut self, packet_buffer: &[u8], receive_buffer: &mut [u8]) -> Result<()> {
         receive_buffer.fill(0);
         let reassembler = Reassembler::new(packet_buffer, receive_buffer)?;
-        self.state = ChannelState::Receiving { reassembler };
+        self.receive_state = ReceiveState::Receiving { reassembler };
         Ok(())
     }
 
     fn handle_last_packet(&mut self, receive_buffer: &mut [u8]) -> Result<PacketInResult> {
-        let ChannelState::Receiving { reassembler } = &self.state else {
+        let ReceiveState::Receiving { reassembler } = &self.receive_state else {
             return Err(Error::unexpected_input());
         };
         let mut message_ready = false;
@@ -394,14 +396,18 @@ impl<R: Role, B: Backend> Channel<R, B> {
                     "[{:04x}] Reassembled message with invalid checksum.",
                     self.channel_id
                 );
-                self.state = ChannelState::Idle;
+                self.receive_state = ReceiveState::Idle;
                 return Err(e);
             }
             message_ready = true;
-            if self.sync.is_ack_piggybacking_allowed() && !self.sync.can_send() {
+            if matches!(self.send_state, SendState::Sending { .. })
+                && self.sync.is_ack_piggybacking_allowed()
+                && !self.sync.can_send()
+            {
                 self.sync.send_mark_delivered(reassembler.sync_bits());
                 if self.sync.can_send() {
                     ack_received = true;
+                    self.send_state = SendState::Idle;
                 } else {
                     log::warn!("[{:04x}] Unexpected ACK bit.", self.channel_id);
                 }
@@ -417,7 +423,7 @@ impl<R: Role, B: Backend> Channel<R, B> {
     }
 
     fn check_buffer_len(&self, receive_buffer: &[u8]) -> Option<NonZeroU16> {
-        let ChannelState::Receiving { reassembler } = &self.state else {
+        let ReceiveState::Receiving { reassembler } = &self.receive_state else {
             return None;
         };
         let payload_len = reassembler.header().payload_len();
@@ -701,29 +707,29 @@ impl<R: Role, B: Backend> ChannelIO for Channel<R, B> {
         }
         let res = PacketInResult::from_result(self.handle_packet(packet_buffer, receive_buffer));
         if let PacketInResult::Failed { .. } = res {
-            self.state = ChannelState::Failed { error: None };
+            self.become_failed();
         }
         res
     }
 
     fn packet_out(&mut self, packet_buffer: &mut [u8], send_buffer: &[u8]) -> Result<()> {
-        // Send pending ACK.
+        // Send pending ACK, even if Failed.
         if let Some(sb) = self.send_ack.take() {
             let header = Header::<R>::new_ack(self.channel_id)?;
             Fragmenter::single(header, sb, &[], packet_buffer)?;
             return Ok(());
         }
-        if let ChannelState::SendingError { error } = self.state {
+        if let SendState::SendingError { error } = self.send_state {
             let header = Header::<R>::new_error(self.channel_id)?;
             Fragmenter::single(header, SyncBits::new(), &[error.into()], packet_buffer)?;
             if error.is_recoverable() {
-                self.state = ChannelState::Idle;
+                self.send_state = SendState::Idle;
             } else {
-                self.state = ChannelState::Failed { error: None };
+                self.become_failed();
             }
             return Ok(());
         }
-        let ChannelState::Sending { fragmenter, .. } = &mut self.state else {
+        let SendState::Sending { fragmenter, .. } = &mut self.send_state else {
             return Err(Error::not_ready());
         };
         let written = fragmenter.next(send_buffer, packet_buffer)?;
@@ -735,7 +741,7 @@ impl<R: Role, B: Backend> ChannelIO for Channel<R, B> {
                 // This is a special case for `channel_allocation_response` which is the only
                 // message sent through Channel (by `device::ChannelOpen`) but does not
                 // wait for ACK because as it is sent on broadcast channel.
-                self.state = ChannelState::Idle;
+                self.send_state = SendState::Idle;
             } else {
                 self.sync.send_finish();
             }
@@ -744,12 +750,10 @@ impl<R: Role, B: Backend> ChannelIO for Channel<R, B> {
     }
 
     fn packet_out_ready(&self) -> bool {
-        if self.send_ack.is_some() {
-            return true;
-        }
-        match &self.state {
-            ChannelState::Sending { fragmenter, .. } => !fragmenter.is_done(),
-            ChannelState::SendingError { .. } => true,
+        match &self.send_state {
+            _ if self.send_ack.is_some() => true,
+            SendState::SendingError { .. } => true,
+            SendState::Sending { fragmenter, .. } => !fragmenter.is_done(),
             _ => false,
         }
     }
@@ -768,7 +772,8 @@ impl<R: Role, B: Backend> ChannelIO for Channel<R, B> {
     }
 
     fn message_in_ready(&self) -> bool {
-        matches!(self.state, ChannelState::Idle)
+        matches!(self.send_state, SendState::Idle)
+            && !matches!(self.receive_state, ReceiveState::Failed)
     }
 
     fn message_out<'a>(&mut self, receive_buffer: &'a mut [u8]) -> Result<(u8, u16, &'a [u8])> {
@@ -788,7 +793,7 @@ impl<R: Role, B: Backend> ChannelIO for Channel<R, B> {
             Err(e) => {
                 if R::is_host() {
                     log::error!("[{:04x}] Decryption failed.", self.channel_id);
-                    self.state = ChannelState::Failed { error: None };
+                    self.become_failed();
                 } else {
                     log::error!(
                         "[{:04x}] Decryption failed, sending DECRYPTION_FAILED.",
@@ -811,14 +816,14 @@ impl<R: Role, B: Backend> ChannelIO for Channel<R, B> {
     }
 
     fn message_out_ready(&self) -> bool {
-        match &self.state {
-            ChannelState::Receiving { reassembler } => reassembler.is_done(),
+        match &self.receive_state {
+            ReceiveState::Receiving { reassembler } => reassembler.is_done(),
             _ => false,
         }
     }
 
     fn message_retransmit(&mut self) -> Result<()> {
-        let ChannelState::Sending { fragmenter, retry } = &mut self.state else {
+        let SendState::Sending { fragmenter, retry } = &mut self.send_state else {
             log::warn!("[{:04x}] Nothing to retransmit.", self.channel_id);
             return Ok(());
         };

--- a/rust/trezor-thp/src/channel/noise.rs
+++ b/rust/trezor-thp/src/channel/noise.rs
@@ -12,7 +12,7 @@ pub use trezor_noise_protocol::{Cipher, DH, Hash, U8Array};
 
 use crate::{
     Device, Error, Host, Role,
-    channel::PairingState,
+    channel::{MAX_CREDENTIAL_LEN, PairingState},
     credential::{CredentialStore, CredentialVerifier},
     util::prepare_zeroed,
 };
@@ -23,7 +23,6 @@ pub const HANDSHAKE_HASH_LEN: usize = 32;
 pub const PRIVKEY_LEN: usize = 32;
 pub const PUBKEY_LEN: usize = 32;
 pub const TAG_LEN: usize = 16;
-pub const MAX_KEY_AND_CREDENTIAL_LEN: usize = 128;
 
 /// Cryptography backend trait.
 ///
@@ -160,11 +159,11 @@ impl<B: Backend> NoiseHandshake<Host, B> {
         cs: &impl CredentialStore,
         re: &DHPubKey<B>,
         rs: &DHPubKey<B>,
-    ) -> Result<(DHPrivKey<B>, heapless::Vec<u8, MAX_KEY_AND_CREDENTIAL_LEN>), Error>
+    ) -> Result<(DHPrivKey<B>, heapless::Vec<u8, MAX_CREDENTIAL_LEN>), Error>
     where
         DHPrivKey<B>: U8Array,
     {
-        let mut buf = heapless::Vec::new();
+        let mut buf = heapless::Vec::<u8, { PRIVKEY_LEN + MAX_CREDENTIAL_LEN }>::new();
         prepare_zeroed(&mut buf);
         let result = cs.lookup(re.as_slice(), rs.as_slice(), buf.as_mut_slice());
         if let Some(found) = result {
@@ -173,9 +172,8 @@ impl<B: Backend> NoiseHandshake<Host, B> {
                 .map_err(|_| Error::insufficient_buffer())?;
             return Ok((found_key, found_credential));
         }
-        buf.clear();
         let new_key = <B::DH as DH>::genkey();
-        Ok((new_key, buf))
+        Ok((new_key, heapless::Vec::new()))
     }
 }
 
@@ -235,7 +233,7 @@ impl<B: Backend> NoiseHandshake<Device, B> {
             return Err(Error::malformed_data());
         }
         let cred_len = incoming.len().saturating_sub(overhead_len);
-        let mut cred = heapless::Vec::<u8, MAX_KEY_AND_CREDENTIAL_LEN>::new();
+        let mut cred = heapless::Vec::<u8, MAX_CREDENTIAL_LEN>::new();
         cred.resize(cred_len, 0u8)
             .map_err(|_| Error::insufficient_buffer())?;
         self.hss.read_message(incoming, &mut cred)?;

--- a/rust/trezor-thp/src/channel/noise.rs
+++ b/rust/trezor-thp/src/channel/noise.rs
@@ -83,11 +83,11 @@ impl<B: Backend> NoiseCiphers<B> {
 }
 
 impl<B: Backend> NoiseHandshake<Host, B> {
-    pub fn write_initiation_request<'a>(
+    pub fn write_initiation_request(
         device_properties: &[u8],
         try_to_unlock: bool,
-        dest: &'a mut [u8],
-    ) -> Result<(Self, &'a [u8]), Error> {
+        dest: &mut [u8],
+    ) -> Result<(Self, usize), Error> {
         let payload = &[u8::from(try_to_unlock)];
         let mut hss = HandshakeState::new(
             noise_xx(),
@@ -105,23 +105,20 @@ impl<B: Backend> NoiseHandshake<Host, B> {
             hss,
             _phantom: PhantomData,
         };
-        Ok((new, dest))
+        Ok((new, len))
     }
 
-    pub fn write_completion_request<'a>(
+    pub fn write_completion_request(
         &mut self,
         cred_store: &mut impl CredentialStore,
-        buffer: &'a mut [u8],
-        incoming_len: usize,
-    ) -> Result<(NoiseCiphers<B>, &'a [u8]), Error> {
-        if incoming_len != self.hss.get_next_message_overhead() {
+        receive_buffer: &[u8],
+        send_buffer: &mut [u8],
+    ) -> Result<(NoiseCiphers<B>, usize), Error> {
+        if receive_buffer.len() != self.hss.get_next_message_overhead() {
             log::error!("Unexpected message length during handshake.");
             return Err(Error::malformed_data());
         }
-        let incoming = buffer
-            .get(..incoming_len)
-            .ok_or_else(Error::insufficient_buffer)?;
-        self.hss.read_message(incoming, &mut [])?;
+        self.hss.read_message(receive_buffer, &mut [])?;
 
         // Look up static key based on remote keys, or generate a new one.
         let remote_static_pubkey = self.hss.get_rs().ok_or_else(Error::crypto_error)?;
@@ -133,9 +130,9 @@ impl<B: Backend> NoiseHandshake<Host, B> {
         )?;
         self.hss.set_s(local_static);
 
-        buffer.fill(0);
+        send_buffer.fill(0);
         let len = self.hss.get_next_message_overhead() + pairing_credential.len();
-        let dest = buffer
+        let dest = send_buffer
             .get_mut(..len)
             .ok_or_else(Error::insufficient_buffer)?;
         self.hss
@@ -152,7 +149,7 @@ impl<B: Backend> NoiseHandshake<Host, B> {
             handshake_hash,
             remote_static_pubkey: remote_static_pubkey.as_slice().try_into().unwrap(),
         };
-        Ok((nc, dest))
+        Ok((nc, len))
     }
 
     fn credential_from_store(
@@ -206,11 +203,11 @@ impl<B: Backend> NoiseHandshake<Device, B> {
         Ok(try_to_unlock)
     }
 
-    pub fn write_initiation_response<'a>(
+    pub fn write_initiation_response(
         &mut self,
         static_privkey: &[u8; PRIVKEY_LEN],
-        dest: &'a mut [u8],
-    ) -> Result<&'a [u8], Error> {
+        dest: &mut [u8],
+    ) -> Result<usize, Error> {
         let mk = Self::mask_key(static_privkey);
         self.hss.set_s(mk.static_privkey);
         self.hss.set_s_mask(mk.mask);
@@ -218,15 +215,15 @@ impl<B: Backend> NoiseHandshake<Device, B> {
         let len = self.hss.get_next_message_overhead();
         let dest = dest.get_mut(..len).ok_or_else(Error::insufficient_buffer)?;
         self.hss.write_message(/*payload*/ &[], dest)?; // no outgoing payload
-        Ok(dest)
+        Ok(len)
     }
 
-    pub fn write_completion_response<'a>(
+    pub fn write_completion_response(
         &mut self,
         incoming: &[u8],
         cred_verifier: &impl CredentialVerifier,
-        dest: &'a mut [u8],
-    ) -> Result<(NoiseCiphers<B>, PairingState, &'a [u8]), Error> {
+        dest: &mut [u8],
+    ) -> Result<(NoiseCiphers<B>, PairingState, usize), Error> {
         let overhead_len = self.hss.get_next_message_overhead();
         if incoming.len() < overhead_len {
             log::error!("Unexpected message length during handshake.");
@@ -265,7 +262,7 @@ impl<B: Backend> NoiseHandshake<Device, B> {
             .ok_or_else(Error::insufficient_buffer)?;
         dest[0..plaintext_len].copy_from_slice(payload);
         nc.encrypt(dest, plaintext_len)?;
-        Ok((nc, pairing_state, dest))
+        Ok((nc, pairing_state, dest.len()))
     }
 
     fn mask_key(static_privkey: &[u8; PRIVKEY_LEN]) -> MaskKeyResult<B>

--- a/rust/trezor-thp/src/channel/test.rs
+++ b/rust/trezor-thp/src/channel/test.rs
@@ -84,6 +84,7 @@ impl<C: CredentialVerifier, B: Backend> ChannelIO for WithKey<C, B> {
                 ack_received: false,
                 message_ready: false,
                 pong: false,
+                buffer_size: None,
             };
         }
         pir
@@ -149,51 +150,71 @@ impl<C: CredentialVerifier, B: Backend> WithKeyExt<C, B> for super::device::Chan
     }
 }
 
-fn take_turns_mutate<C1, C2, F>(
+fn take_turns_until_fn<C1, C2, Fu, Fw, T>(
+    until_func: &mut Fu,
     host: &mut Buffered<C1>,
     device: &mut Buffered<C2>,
-    mut func: F,
+    wire_func: &mut Fw,
+) -> Result<Option<T>>
+where
+    C1: ChannelIO,
+    C2: ChannelIO,
+    Fu: FnMut(Direction, &mut Buffered<C1>, &mut Buffered<C2>, PacketInResult) -> Option<T>,
+    Fw: FnMut(Direction, &mut VecDeque<Packet>),
+{
+    while host.packet_out_ready() || device.packet_out_ready() {
+        let pir = HostToDevice.transfer_fn(host, device, wire_func)?;
+        let res = until_func(HostToDevice, host, device, pir);
+        if res.is_some() {
+            return Ok(res);
+        }
+        let pir = DeviceToHost.transfer_fn(host, device, wire_func)?;
+        let res = until_func(DeviceToHost, host, device, pir);
+        if res.is_some() {
+            return Ok(res);
+        }
+    }
+    Ok(None)
+}
+
+fn until_stuck(
+    _dir: Direction,
+    _h: &mut Buffered<impl ChannelIO>,
+    _d: &mut Buffered<impl ChannelIO>,
+    _pir: PacketInResult,
+) -> Option<()> {
+    None
+}
+
+fn wire_flush_acks(_dir: Direction, wire: &mut VecDeque<Packet>) {
+    for packet in wire.iter() {
+        Header::<Host>::parse(packet)
+            .map(|(hdr, _)| assert!(hdr.is_ack()))
+            .unwrap();
+    }
+}
+
+fn take_turns_fn<C1, C2, F>(
+    host: &mut Buffered<C1>,
+    device: &mut Buffered<C2>,
+    wire_func: &mut F,
 ) -> Result<TakeTurnsResult>
 where
     C1: ChannelIO,
     C2: ChannelIO,
     F: FnMut(Direction, &mut VecDeque<Packet>),
 {
-    let mut msg = TakeTurnsResult::None;
-    let mut wire = VecDeque::<Packet>::new();
-    while host.packet_out_ready() || device.packet_out_ready() {
-        while host.packet_out_ready() {
-            wire.push_back(host.packet_out()?);
+    let mut message_ready = |dir, host: &mut Buffered<C1>, device: &mut Buffered<C2>, _pir| {
+        if dir == HostToDevice && device.message_out_ready() {
+            return Some((HostToDevice, device.message_out().unwrap()));
+        } else if dir == DeviceToHost && host.message_out_ready() {
+            return Some((DeviceToHost, host.message_out().unwrap()));
         }
-        if !wire.is_empty() {
-            func(HostToDevice, &mut wire);
-        }
-        for packet in wire.iter() {
-            log::trace!("> {}", hex::encode(packet));
-            device.packet_in(packet).check_failed()?;
-        }
-        if device.message_out_ready() {
-            assert!(msg.is_none());
-            msg = Some((HostToDevice, device.message_out()?));
-        }
-        wire.clear();
-        while device.packet_out_ready() {
-            wire.push_back(device.packet_out()?);
-        }
-        if !wire.is_empty() {
-            func(DeviceToHost, &mut wire);
-        }
-        for packet in wire.iter() {
-            log::trace!("< {}", hex::encode(packet));
-            host.packet_in(packet).check_failed()?;
-        }
-        if host.message_out_ready() {
-            assert!(msg.is_none());
-            msg = Some((DeviceToHost, host.message_out()?));
-        }
-        wire.clear();
-    }
-    Ok(msg)
+        None
+    };
+    let res = take_turns_until_fn(&mut message_ready, host, device, wire_func);
+    take_turns_until_fn(&mut until_stuck, host, device, &mut wire_flush_acks)?;
+    res
 }
 
 fn take_turns<C1, C2>(host: &mut Buffered<C1>, device: &mut Buffered<C2>) -> Result<TakeTurnsResult>
@@ -201,10 +222,77 @@ where
     C1: ChannelIO,
     C2: ChannelIO,
 {
-    take_turns_mutate(host, device, |_, _| {})
+    take_turns_fn(host, device, &mut |_, _| ())
 }
 
 impl Direction {
+    fn reverse_if(&self, cond: bool) -> Self {
+        if !cond {
+            return *self;
+        }
+        match self {
+            HostToDevice => DeviceToHost,
+            DeviceToHost => HostToDevice,
+        }
+    }
+    fn reverse(&self) -> Self {
+        self.reverse_if(true)
+    }
+
+    fn transfer_fn<C1, C2>(
+        self,
+        host: &mut Buffered<C1>,
+        device: &mut Buffered<C2>,
+        func: &mut impl FnMut(Direction, &mut VecDeque<Packet>),
+    ) -> Result<PacketInResult>
+    where
+        C1: ChannelIO,
+        C2: ChannelIO,
+    {
+        let mut wire = VecDeque::<Packet>::new();
+        let mut pir = PacketInResult::Ignored {
+            error: Error::NotReady,
+        };
+        if self == HostToDevice {
+            while host.packet_out_ready() {
+                wire.push_back(host.packet_out()?);
+            }
+        } else {
+            while device.packet_out_ready() {
+                wire.push_back(device.packet_out()?);
+            }
+        }
+        func(self, &mut wire);
+        for packet in wire.iter() {
+            // Only the last PacketInResult is returned, check that the others are "boring".
+            assert!(matches!(
+                pir,
+                PacketInResult::Ignored { .. }
+                    | PacketInResult::Accepted {
+                        message_ready: false,
+                        pong: false,
+                        ..
+                    }
+            ));
+            if self == HostToDevice {
+                log::trace!("> {}", hex::encode(packet));
+                pir = device.packet_in(packet).check_failed()?;
+            } else {
+                log::trace!("< {}", hex::encode(packet));
+                pir = host.packet_in(packet).check_failed()?;
+            }
+        }
+        Ok(pir)
+    }
+
+    fn transfer(
+        self,
+        host: &mut Buffered<impl ChannelIO>,
+        device: &mut Buffered<impl ChannelIO>,
+    ) -> Result<PacketInResult> {
+        self.transfer_fn(host, device, &mut |_, _| ())
+    }
+
     fn send_nocheck<C1, C2>(
         self,
         host: &mut Buffered<C1>,
@@ -238,7 +326,11 @@ impl Direction {
         C2: ChannelIO,
     {
         let msg = self.send_nocheck(host, device, sid, mty, message)?;
-        assert_eq!(msg, Some((self, (sid, mty, message.into()))));
+        if self == HostToDevice {
+            assert_eq!(msg, Some((HostToDevice, (sid, mty, message.into()))));
+        } else {
+            assert_eq!(msg, Some((DeviceToHost, (sid, mty, message.into()))));
+        }
         Ok(())
     }
 
@@ -252,22 +344,48 @@ impl Direction {
         assert_eq!(msg, None);
         Ok(())
     }
+
+    fn call<C1: ChannelIO, C2: ChannelIO>(
+        self,
+        host: &mut Buffered<C1>,
+        device: &mut Buffered<C2>,
+        msgs: &[&[u8]],
+    ) -> Result<()> {
+        let mut i: usize = 0;
+        let mut func = |dir, host: &mut Buffered<C1>, device: &mut Buffered<C2>, _pir| {
+            if dir == HostToDevice && device.message_out_ready() {
+                let (_, _, msg) = device.message_out().unwrap();
+                assert_eq!(msg, msgs[i]);
+                i += 1;
+                if i < msgs.len() {
+                    device.message_in(5, 10, msgs[i]).unwrap();
+                }
+            } else if dir == DeviceToHost && host.message_out_ready() {
+                let (_, _, msg) = host.message_out().unwrap();
+                assert_eq!(msg, msgs[i]);
+                i += 1;
+                if i < msgs.len() {
+                    host.message_in(5, 11, msgs[i]).unwrap();
+                }
+            }
+            None::<()>
+        };
+        if self == HostToDevice {
+            host.message_in(5, 10, msgs[0])?;
+        } else {
+            device.message_in(5, 11, msgs[0])?;
+        }
+        take_turns_until_fn(&mut func, host, device, &mut |_, _| ())?;
+        assert_eq!(i, msgs.len());
+        Ok(())
+    }
 }
 
 #[test]
 fn test_open() -> Result<()> {
     setup();
 
-    let (mut hm, mut dm, cids) = create_mux();
-    // channel allocation
-    hm.request_channel(false);
-    take_turns(&mut hm, &mut dm)?;
-    let mut d = dm
-        .channel_alloc(cids.get(), TestCredentialVerifier)?
-        .with_key(DEVICE_KEY)
-        .into_buffered();
-    take_turns(&mut hm, &mut d)?;
-    let mut h = hm.channel_alloc(NullCredentialStore)?.into_buffered();
+    let (mut h, mut d) = alloc_channel()?;
 
     // handshake
     assert!(!h.handshake_done());
@@ -292,8 +410,95 @@ fn test_open() -> Result<()> {
     Ok(())
 }
 
+fn check_number_of_packets(mut counts: Vec<usize>) -> impl FnMut(Direction, &mut VecDeque<Packet>) {
+    let mut turn: usize = 0;
+    counts.reverse();
+    return move |_: Direction, wire: &mut VecDeque<Packet>| {
+        turn += 1;
+        let count = counts.pop().unwrap_or(0);
+        assert!(
+            wire.len() == count,
+            "Turn {}: expected {} packets, got {:?}.",
+            turn,
+            count,
+            wire.iter().map(hex::encode).collect::<Vec<_>>(),
+        );
+    };
+}
+
+fn check_just_one(dir: Direction, wire: &mut VecDeque<Packet>) {
+    check_number_of_packets(vec![1])(dir, wire)
+}
+
 #[test]
-fn test_device_locked() -> Result<()> {
+fn test_open_piggybacking() -> Result<()> {
+    setup();
+
+    let (mut h, mut d) = alloc_channel()?;
+    h.set_device_protocol_version(2, 1); // Enable piggybacking.
+
+    // handshake
+    assert!(!h.handshake_done());
+    assert!(!d.handshake_done());
+    take_turns_fn(
+        &mut h,
+        &mut d,
+        &mut check_number_of_packets(vec![1, 2, 2, 1, 1]),
+    )?;
+    assert!(h.handshake_done());
+    assert!(d.handshake_done());
+    let mut h = h.map(|h| h.complete())?;
+    let mut d = d.map(|d| d.unwrap().complete())?;
+
+    // first message, no ACK
+    h.message_in(0, 1010, b"ThpSelectMethod with SkipParing")?;
+    let pir = HostToDevice.transfer_fn(&mut h, &mut d, &mut check_just_one)?;
+    assert!(!pir.got_ack() && pir.got_message());
+    d.message_out()?;
+
+    // piggybacked ACK
+    d.message_in(0, 1019, b"ThpEndResponse means done")?;
+    let pir = DeviceToHost.transfer_fn(&mut h, &mut d, &mut check_just_one)?;
+    assert!(pir.got_ack() && pir.got_message());
+    h.message_out()?;
+
+    // packet goes out before message - standalone ACK
+    let pir = HostToDevice.transfer_fn(&mut h, &mut d, &mut check_just_one)?;
+    assert!(pir.got_ack() && !pir.got_message());
+    h.message_in(0, 1234, b"Ping")?;
+    let pir = HostToDevice.transfer_fn(&mut h, &mut d, &mut check_just_one)?;
+    assert!(!pir.got_ack() && pir.got_message());
+    d.message_out()?;
+
+    // packet goes out before message - standalone ACK
+    let pir = DeviceToHost.transfer_fn(&mut h, &mut d, &mut check_just_one)?;
+    assert!(pir.got_ack() && !pir.got_message());
+    d.message_in(0, 5678, b"Pong")?;
+    let pir = DeviceToHost.transfer_fn(&mut h, &mut d, &mut check_just_one)?;
+    assert!(!pir.got_ack() && pir.got_message());
+    h.message_out()?;
+
+    // piggybacked ACK
+    h.message_in(1, 9999, &[0u8; 999])?;
+    let pir = HostToDevice.transfer(&mut h, &mut d)?;
+    assert!(pir.got_ack() && pir.got_message());
+    d.message_out()?;
+
+    // piggybacked ACK
+    d.message_in(1, 9998, &[9u8; 666])?;
+    let pir = DeviceToHost.transfer(&mut h, &mut d)?;
+    assert!(pir.got_ack() && pir.got_message());
+    h.message_out()?;
+
+    // no further message, just ACK
+    let pir = HostToDevice.transfer_fn(&mut h, &mut d, &mut check_just_one)?;
+    assert!(pir.got_ack() && !pir.got_message());
+    Ok(())
+}
+
+#[test_case(false; "v20")]
+#[test_case(true; "v21")]
+fn test_device_locked(ack_piggybacking: bool) -> Result<()> {
     setup();
 
     let (mut hm, mut dm, cids) = create_mux();
@@ -305,6 +510,9 @@ fn test_device_locked() -> Result<()> {
         .into_buffered();
     take_turns(&mut hm, &mut d)?;
     let mut h = hm.channel_alloc(NullCredentialStore)?.into_buffered();
+    if ack_piggybacking {
+        h.set_device_protocol_version(2, 1);
+    }
 
     // handshake
     assert!(!h.handshake_done());
@@ -334,11 +542,28 @@ fn create_mux() -> (
     (hm, dm, cids)
 }
 
+fn alloc_channel() -> Result<(
+    Buffered<host::ChannelOpen<NullCredentialStore, RustCrypto>>,
+    Buffered<WithKey<TestCredentialVerifier, RustCrypto>>,
+)> {
+    let (mut hm, mut dm, cids) = create_mux();
+    hm.request_channel(false);
+    take_turns(&mut hm, &mut dm)?;
+    let mut d = dm
+        .channel_alloc(cids.get(), TestCredentialVerifier)?
+        .with_key(DEVICE_KEY)
+        .into_buffered();
+    take_turns(&mut hm, &mut d)?;
+    let h = hm.channel_alloc(NullCredentialStore)?.into_buffered();
+    Ok((h, d))
+}
+
 fn open_channel(
     packet_len: usize,
+    enable_piggybacking: bool,
 ) -> Result<(
-    Buffered<Channel<Host, RustCrypto>>,
-    Buffered<Channel<Device, RustCrypto>>,
+    Buffered<host::Channel<RustCrypto>>,
+    Buffered<device::Channel<RustCrypto>>,
 )> {
     let (mut hm, mut dm, cids) = create_mux();
     hm.set_packet_len(packet_len);
@@ -351,6 +576,9 @@ fn open_channel(
         .into_buffered();
     take_turns(&mut d, &mut hm)?;
     let mut h = hm.channel_alloc(NullCredentialStore)?.into_buffered();
+    if enable_piggybacking {
+        h.set_device_protocol_version(2, 1);
+    }
     take_turns(&mut h, &mut d)?;
     let h = h.map(|h| h.complete())?;
     let d = d.map(|d| d.unwrap().complete())?;
@@ -358,32 +586,35 @@ fn open_channel(
     Ok((h, d))
 }
 
-#[test_case(10, 0; "empty messages")]
-#[test_case(30, 1; "short messages")]
-#[test_case(20, 2000; "medium messages")]
-#[test_case(5, 59976; "huge messages")]
-#[test_case(1000, 100; "lots of messages")]
-fn test_messages(count: usize, length: usize) -> Result<()> {
+#[test_case(10, 0, false; "empty messages")]
+#[test_case(30, 1, false; "short messages")]
+#[test_case(20, 2000, false; "medium messages")]
+#[test_case(5, 59976, false; "huge messages")]
+#[test_case(1000, 100, false; "lots of messages")]
+#[test_case(10, 0, true; "empty messages v21")]
+#[test_case(30, 1, true; "short messages v21")]
+#[test_case(5, 59976, true; "huge messages v21")]
+fn test_messages(count: usize, length: usize, ack_piggybacking: bool) -> Result<()> {
     setup();
-    let (mut h, mut d) = open_channel(DEFAULT_PACKET_LEN)?;
+    let (mut h, mut d) = open_channel(DEFAULT_PACKET_LEN, ack_piggybacking)?;
     let payload = vec![42u8; length];
     for _i in 0..count {
-        HostToDevice.send(&mut h, &mut d, 10, 100, &payload)?;
-        DeviceToHost.send(&mut h, &mut d, 10, 100, &payload)?;
+        HostToDevice.call(&mut h, &mut d, &[&payload, &payload])?;
     }
     Ok(())
 }
 
-#[test_case(17; "tiny")]
-#[test_case(256; "medium")]
-#[test_case(1500; "large")]
-fn test_packet_length(packet_len: usize) -> Result<()> {
+#[test_case(17, false; "tiny")]
+#[test_case(256, false; "medium")]
+#[test_case(1500, false; "large")]
+#[test_case(17, true; "tiny_v21")]
+#[test_case(256, true; "medium_v21")]
+fn test_packet_length(packet_len: usize, ack_piggybacking: bool) -> Result<()> {
     setup();
-    let (mut h, mut d) = open_channel(packet_len)?;
+    let (mut h, mut d) = open_channel(packet_len, ack_piggybacking)?;
     let payload = vec![69u8; 3200];
     for _i in 0..10 {
-        HostToDevice.send(&mut h, &mut d, 10, 100, &payload)?;
-        DeviceToHost.send(&mut h, &mut d, 10, 100, &payload)?;
+        HostToDevice.call(&mut h, &mut d, &[&payload, &payload])?;
     }
     Ok(())
 }
@@ -400,7 +631,7 @@ fn test_one_device_multiple_hosts() -> Result<()> {
     let mut host_chans = Vec::<Buffered<Channel<Host, RustCrypto>>>::new();
 
     // open channels
-    for _i in 0..NHOSTS {
+    for i in 0..NHOSTS {
         let mut hm = host::Mux::<RustCrypto>::new().into_buffered();
         hm.set_packet_len(DEFAULT_PACKET_LEN);
         hm.request_channel(false);
@@ -411,6 +642,7 @@ fn test_one_device_multiple_hosts() -> Result<()> {
             .into_buffered();
         take_turns(&mut d, &mut hm)?;
         let mut h = hm.channel_alloc(NullCredentialStore)?.into_buffered();
+        h.set_device_protocol_version(2, (i as u8) % 2); // odd => piggybacking
         take_turns(&mut h, &mut d)?;
         let h = h.map(|h| h.complete())?;
         let d = d.map(|d| d.unwrap().complete())?;
@@ -427,8 +659,11 @@ fn test_one_device_multiple_hosts() -> Result<()> {
     // normal operation
     let payload = vec![67u8; 160];
     for i in 0..NHOSTS {
-        HostToDevice.send(&mut host_chans[i], &mut device_chans[i], 10, 100, &payload)?;
-        DeviceToHost.send(&mut host_chans[i], &mut device_chans[i], 10, 100, &payload)?;
+        HostToDevice.call(
+            &mut host_chans[i],
+            &mut device_chans[i],
+            &[&payload, &payload],
+        )?;
     }
 
     // channel mismatch, packets should be ignored
@@ -473,7 +708,7 @@ fn test_packet_loss_alloc() -> Result<()> {
     let (mut hm, mut dm, cids) = create_mux();
     // channel allocation request lost
     hm.request_channel(false);
-    take_turns_mutate(&mut hm, &mut dm, lose_nth(HostToDevice, 0))?;
+    take_turns_fn(&mut hm, &mut dm, &mut lose_nth(HostToDevice, 0))?;
     assert!(!dm.channel_alloc_ready());
 
     // channel allocation response lost
@@ -482,7 +717,7 @@ fn test_packet_loss_alloc() -> Result<()> {
     let mut d = dm
         .channel_alloc(cids.get(), TestCredentialVerifier)?
         .into_buffered();
-    take_turns_mutate(&mut hm, &mut d, lose_nth(DeviceToHost, 0))?;
+    take_turns_fn(&mut hm, &mut d, &mut lose_nth(DeviceToHost, 0))?;
     assert!(!hm.channel_alloc_ready());
 
     // successful allocation
@@ -496,57 +731,99 @@ fn test_packet_loss_alloc() -> Result<()> {
     Ok(())
 }
 
-#[test_case(HostToDevice, 0; "handshake_init_request")]
-//#[test_case(HostToDevice, 1; "handshake_init_response_ack")]
-#[test_case(HostToDevice, 2; "handshake_completion_request")]
-#[test_case(HostToDevice, 3; "handshake_completion_request_cont")]
-//#[test_case(HostToDevice, 4, "handshake_completion_response_ack")]
-//#[test_case(DeviceToHost, 0, "handshake_init_request_ack")]
-#[test_case(DeviceToHost, 1; "handshake_init_response")]
-#[test_case(DeviceToHost, 2; "handshake_init_response_cont")]
-//#[test_case(DeviceToHost, 3; "handshake_completion_request_ack")]
-#[test_case(DeviceToHost, 4; "handshake_completion_response")]
-fn test_packet_loss_handshake(dir: Direction, lost_index: usize) -> Result<()> {
-    setup();
+fn handshake_timeout(
+    h: &mut Buffered<host::ChannelOpen<NullCredentialStore, RustCrypto>>,
+    d: &mut Buffered<WithKey<TestCredentialVerifier, RustCrypto>>,
+    who_retransmits: Direction,
+    max_timeouts: usize,
+) -> Result<()> {
+    let mut dir = who_retransmits;
+    for _ in 0..max_timeouts {
+        if dir == DeviceToHost {
+            assert!(d.sending_retry().is_some());
+            d.message_retransmit()?;
+        } else {
+            assert!(h.sending_retry().is_some());
+            h.message_retransmit()?;
+        }
+        take_turns_until_fn(&mut until_stuck, h, d, &mut |_, _| ())?;
+        if h.handshake_done() && d.handshake_done() {
+            return Ok(());
+        }
+        dir = dir.reverse();
+    }
+    panic!("Handshake did not finish within {} timeouts.", max_timeouts);
+}
 
-    let (mut hm, mut dm, cids) = create_mux();
-    // channel allocation
-    hm.request_channel(false);
-    take_turns(&mut hm, &mut dm)?;
-    let mut d = dm
-        .channel_alloc(cids.get(), TestCredentialVerifier)?
-        .with_key(DEVICE_KEY)
-        .into_buffered();
-    take_turns(&mut hm, &mut d)?;
-    let mut h = hm.channel_alloc(NullCredentialStore)?.into_buffered();
+// When an ACK is lost, depending on the timing, either peer can retransmit first.
+// Both cases are tested via the `who_retransmits` parameter, except the last ACK
+// awhere device does not want to send anything.
+#[test_case(HostToDevice, 0, HostToDevice; "handshake_init_request")]
+#[test_case(HostToDevice, 1, DeviceToHost; "handshake_init_response_ack1")]
+#[test_case(HostToDevice, 1, HostToDevice; "handshake_init_response_ack2")]
+#[test_case(HostToDevice, 2, HostToDevice; "handshake_completion_request")]
+#[test_case(HostToDevice, 3, HostToDevice; "handshake_completion_request_cont")]
+#[test_case(HostToDevice, 4, DeviceToHost; "handshake_completion_response_ack1")] // last ACK
+#[test_case(DeviceToHost, 0, HostToDevice; "handshake_init_request_ack1")]
+#[test_case(DeviceToHost, 0, DeviceToHost; "handshake_init_request_ack2")]
+#[test_case(DeviceToHost, 1, DeviceToHost; "handshake_init_response")]
+#[test_case(DeviceToHost, 2, DeviceToHost; "handshake_init_response_cont")]
+#[test_case(DeviceToHost, 3, HostToDevice; "handshake_completion_request_ack1")]
+#[test_case(DeviceToHost, 3, DeviceToHost; "handshake_completion_request_ack2")]
+#[test_case(DeviceToHost, 4, DeviceToHost; "handshake_completion_response")]
+fn test_packet_loss_handshake_v20(
+    dir: Direction,
+    lost_index: usize,
+    who_retransmits: Direction,
+) -> Result<()> {
+    setup();
+    let (mut h, mut d) = alloc_channel()?;
 
     // handshake
-    take_turns_mutate(&mut h, &mut d, lose_nth(dir, lost_index))?;
-    if dir == DeviceToHost {
-        assert!(!h.handshake_done());
-        assert_eq!(h.sending_retry(), None);
-        assert_eq!(d.sending_retry(), Some(0));
-        d.message_retransmit()?;
-        assert_eq!(d.sending_retry(), Some(1));
-    } else {
-        assert!(!d.handshake_done());
-        assert_eq!(d.sending_retry(), None);
-        assert_eq!(h.sending_retry(), Some(0));
-        h.message_retransmit()?;
-        assert_eq!(h.sending_retry(), Some(1));
-    }
-    take_turns(&mut h, &mut d)?;
+    take_turns_until_fn(
+        &mut until_stuck,
+        &mut h,
+        &mut d,
+        &mut lose_nth(dir, lost_index),
+    )?;
+    handshake_timeout(&mut h, &mut d, who_retransmits, 3)?;
     let mut h = h.map(|h| h.complete())?;
     let mut d = d.map(|d| d.unwrap().complete())?;
 
-    // pairing
-    HostToDevice.send(&mut h, &mut d, 0, 1010, b"ThpSelectMethod with SkipParing")?;
-    DeviceToHost.send(&mut h, &mut d, 0, 1019, b"ThpEndResponse means done")?;
+    // application messaging
+    HostToDevice.call(&mut h, &mut d, &[b"Ping", b"Pong"])?;
+
+    Ok(())
+}
+
+#[test_case(HostToDevice, 0; "handshake_init_request")]
+#[test_case(DeviceToHost, 0; "handshake_init_response")]
+#[test_case(DeviceToHost, 1; "handshake_init_response_cont")]
+#[test_case(HostToDevice, 1; "handshake_completion_request")]
+#[test_case(HostToDevice, 2; "handshake_completion_request_cont")]
+#[test_case(DeviceToHost, 2; "handshake_completion_response")]
+#[test_case(HostToDevice, 3; "handshake_completion_response_ack")] // standalone last ACK
+fn test_packet_loss_handshake_v21(dir: Direction, lost_index: usize) -> Result<()> {
+    setup();
+    let (mut h, mut d) = alloc_channel()?;
+    h.set_device_protocol_version(2, 1);
+
+    // handshake
+    take_turns_until_fn(
+        &mut until_stuck,
+        &mut h,
+        &mut d,
+        &mut lose_nth(dir, lost_index),
+    )?;
+    // When packet is lost in the middle of an exchange, either side can possibly
+    // retransmit first. This test assumes the sender does, except for the last ACK.
+    let who_retransmits = dir.reverse_if(dir == HostToDevice && lost_index == 3);
+    handshake_timeout(&mut h, &mut d, who_retransmits, 2)?;
+    let mut h = h.map(|h| h.complete())?;
+    let mut d = d.map(|d| d.unwrap().complete())?;
 
     // application messaging
-    HostToDevice.send(&mut h, &mut d, 0, 1234, b"Ping")?;
-    DeviceToHost.send(&mut h, &mut d, 0, 5678, b"Pong")?;
-    Ok(())
+    HostToDevice.call(&mut h, &mut d, &[b"Ping", b"Pong"])
 }
 
 fn damage_nth(
@@ -583,7 +860,11 @@ fn test_packet_damage_alloc(byte_index: usize) -> Result<()> {
     let (mut hm, mut dm, cids) = create_mux();
     // channel allocation request lost
     hm.request_channel(false);
-    take_turns_mutate(&mut hm, &mut dm, damage_nth(HostToDevice, 0, byte_index))?;
+    take_turns_fn(
+        &mut hm,
+        &mut dm,
+        &mut damage_nth(HostToDevice, 0, byte_index),
+    )?;
     assert!(!dm.channel_alloc_ready());
 
     // channel allocation response lost
@@ -592,7 +873,11 @@ fn test_packet_damage_alloc(byte_index: usize) -> Result<()> {
     let mut d = dm
         .channel_alloc(cids.get(), TestCredentialVerifier)?
         .into_buffered();
-    take_turns_mutate(&mut hm, &mut d, damage_nth(DeviceToHost, 0, byte_index))?;
+    take_turns_fn(
+        &mut hm,
+        &mut d,
+        &mut damage_nth(DeviceToHost, 0, byte_index),
+    )?;
     assert!(!hm.channel_alloc_ready());
 
     // successful allocation
@@ -602,7 +887,7 @@ fn test_packet_damage_alloc(byte_index: usize) -> Result<()> {
         .channel_alloc(cids.get(), TestCredentialVerifier)?
         .into_buffered();
     take_turns(&mut hm, &mut d)?;
-    let mut _h = hm.channel_alloc(NullCredentialStore)?.into_buffered();
+    let _h = hm.channel_alloc(NullCredentialStore)?.into_buffered();
     Ok(())
 }
 
@@ -611,81 +896,90 @@ fn test_packet_damage_alloc(byte_index: usize) -> Result<()> {
     [0, 1, 2, 3, 4],
     [0, 1, 3, 6]
 )]
-fn test_packet_damage_handshake(
+fn test_packet_damage_handshake_v20(
     dir: Direction,
     packet_index: usize,
     byte_index: usize,
 ) -> Result<()> {
     setup();
 
-    // Don't test ACKs for now.
-    let skip = [
+    let (mut h, mut d) = alloc_channel()?;
+    let acks = [
         (HostToDevice, 1),
         (HostToDevice, 4),
         (DeviceToHost, 0),
         (DeviceToHost, 3),
     ];
-    if skip.contains(&(dir, packet_index)) {
-        log::warn!("Skipping test case");
-        return Ok(());
-    }
-
-    let (mut hm, mut dm, cids) = create_mux();
-    // channel allocation
-    hm.request_channel(false);
-    take_turns(&mut hm, &mut dm)?;
-    let mut d = dm
-        .channel_alloc(cids.get(), TestCredentialVerifier)?
-        .with_key(DEVICE_KEY)
-        .into_buffered();
-    take_turns(&mut hm, &mut d)?;
-    let mut h = hm.channel_alloc(NullCredentialStore)?.into_buffered();
+    let who_retransmits = dir.reverse_if(acks.contains(&(dir, packet_index)));
 
     // handshake
-    take_turns_mutate(&mut h, &mut d, damage_nth(dir, packet_index, byte_index))?;
-    if dir == DeviceToHost {
-        assert!(!h.handshake_done());
-        assert_eq!(h.sending_retry(), None);
-        assert_eq!(d.sending_retry(), Some(0));
-        d.message_retransmit()?;
-        assert_eq!(d.sending_retry(), Some(1));
-    } else {
-        assert!(!d.handshake_done());
-        assert_eq!(d.sending_retry(), None);
-        assert_eq!(h.sending_retry(), Some(0));
-        h.message_retransmit()?;
-        assert_eq!(h.sending_retry(), Some(1));
-    }
-    take_turns(&mut h, &mut d)?;
+    take_turns_fn(
+        &mut h,
+        &mut d,
+        &mut damage_nth(dir, packet_index, byte_index),
+    )?;
+    handshake_timeout(&mut h, &mut d, who_retransmits, 2)?;
     let mut h = h.map(|h| h.complete())?;
     let mut d = d.map(|d| d.unwrap().complete())?;
 
-    // pairing
-    HostToDevice.send(&mut h, &mut d, 0, 1010, b"ThpSelectMethod with SkipParing")?;
-    DeviceToHost.send(&mut h, &mut d, 0, 1019, b"ThpEndResponse means done")?;
-
-    // application messaging
-    HostToDevice.send(&mut h, &mut d, 0, 1234, b"Ping")?;
-    DeviceToHost.send(&mut h, &mut d, 0, 5678, b"Pong")?;
-    Ok(())
+    // pairing, appdata
+    HostToDevice.call(
+        &mut h,
+        &mut d,
+        &[
+            b"ThpSelectMethod with SkipParing",
+            b"ThpEndResponse means done",
+            b"Ping",
+            b"Pong",
+        ],
+    )
 }
 
-#[test]
-fn test_packet_damage_application() -> Result<()> {
+#[test_matrix(
+    [HostToDevice, DeviceToHost],
+    [0, 1, 2],
+    [0, 1, 3, 6]
+)]
+fn test_packet_damage_handshake_v21(
+    dir: Direction,
+    packet_index: usize,
+    byte_index: usize,
+) -> Result<()> {
+    setup();
+    let (mut h, mut d) = alloc_channel()?;
+    h.set_device_protocol_version(2, 1);
+
+    take_turns_fn(
+        &mut h,
+        &mut d,
+        &mut damage_nth(dir, packet_index, byte_index),
+    )?;
+    handshake_timeout(&mut h, &mut d, dir, 1)?;
+    let mut h = h.map(|h| h.complete())?;
+    let mut d = d.map(|d| d.unwrap().complete())?;
+
+    HostToDevice.call(&mut h, &mut d, &[b"Ping", b"Pong"])
+}
+
+#[test_case(false; "v20")]
+#[test_case(true; "v21")]
+fn test_packet_damage_application(ack_piggybacking: bool) -> Result<()> {
     setup();
 
-    let (mut h, mut d) = open_channel(DEFAULT_PACKET_LEN)?;
+    let (mut h, mut d) = open_channel(DEFAULT_PACKET_LEN, ack_piggybacking)?;
     h.message_in(0, 0, b"the quick brown fox jumps over the lazy dog")?;
-    let res = take_turns_mutate(&mut h, &mut d, damage_nth(HostToDevice, 0, 16));
-    assert_eq!(res, Err(Error::InvalidChecksum));
-    h.message_retransmit().unwrap();
-    take_turns(&mut h, &mut d)?;
+    let res = take_turns_fn(&mut h, &mut d, &mut damage_nth(HostToDevice, 0, 16))?;
+    assert_eq!(res, None);
+    h.message_retransmit()?;
+    let res = take_turns(&mut h, &mut d)?;
+    assert!(matches!(res, Some((HostToDevice, _))));
 
     d.message_in(0, 0, b"the quick lazy dog crawls under the brown fox")?;
-    let res = take_turns_mutate(&mut h, &mut d, damage_nth(DeviceToHost, 0, 50));
-    assert_eq!(res, Err(Error::InvalidChecksum));
-    d.message_retransmit().unwrap();
-    take_turns(&mut h, &mut d)?;
+    let res = take_turns_fn(&mut h, &mut d, &mut damage_nth(DeviceToHost, 0, 50))?;
+    assert_eq!(res, None);
+    d.message_retransmit()?;
+    let res = take_turns(&mut h, &mut d)?;
+    assert!(matches!(res, Some((DeviceToHost, _))));
 
     Ok(())
 }
@@ -716,7 +1010,8 @@ fn test_codec_v1() -> Result<()> {
         PacketInResult::Accepted {
             ack_received: false,
             message_ready: false,
-            pong: false
+            pong: false,
+            buffer_size: None,
         }
     ));
     let response = dm.packet_out().unwrap();
@@ -728,7 +1023,7 @@ fn test_codec_v1() -> Result<()> {
     assert_ignored(&mut hm, &v1_cont);
 
     // non-broadcast handling
-    let (mut h, mut d) = open_channel(DEFAULT_PACKET_LEN)?;
+    let (mut h, mut d) = open_channel(DEFAULT_PACKET_LEN, false)?;
     assert_ne!(h.channel_id, 0x2323);
     assert_ne!(d.channel_id, 0x2323);
     assert_ignored(&mut d, &v1_init);
@@ -761,7 +1056,8 @@ fn test_ping() -> Result<()> {
         PacketInResult::Accepted {
             ack_received: false,
             message_ready: false,
-            pong: false
+            pong: false,
+            buffer_size: None,
         }
     ));
     let pong_packet = dm.packet_out()?;
@@ -771,7 +1067,8 @@ fn test_ping() -> Result<()> {
         PacketInResult::Accepted {
             ack_received: false,
             message_ready: false,
-            pong: true
+            pong: true,
+            buffer_size: None,
         }
     ));
     assert!(pir.got_pong());
@@ -785,7 +1082,7 @@ fn test_ping() -> Result<()> {
     assert!(matches!(pir, PacketInResult::Ignored { .. }));
 
     // non-broadcast channels ignore ping
-    let (mut h, mut d) = open_channel(DEFAULT_PACKET_LEN)?;
+    let (mut h, mut d) = open_channel(DEFAULT_PACKET_LEN, false)?;
     let pir = h.packet_in(&ping_packet);
     assert!(matches!(pir, PacketInResult::Ignored { .. }));
     let pir = d.packet_in(&ping_packet);
@@ -838,8 +1135,8 @@ fn test_invalid_channel_id() -> Result<()> {
     }
 
     // normal channels return error for invalid ids
-    let (mut h, mut d) = open_channel(DEFAULT_PACKET_LEN)?;
-    for channel_id in INVALID {
+    let (mut h, mut d) = open_channel(DEFAULT_PACKET_LEN, false)?;
+    for channel_id in INVALID.iter().chain(&[BROADCAST_CHANNEL_ID]) {
         assert_eq!(
             d.packet_in(&make_packet(*channel_id)),
             PacketInResult::Ignored {
@@ -902,21 +1199,34 @@ fn damage_nth_fix_crc(
     };
 }
 
-#[test]
-fn test_invalid_tag() -> Result<()> {
+#[test_case(false; "v20")]
+#[test_case(true; "v21")]
+fn test_invalid_tag(ack_piggybacking: bool) -> Result<()> {
     setup();
 
-    let (mut h, mut d) = open_channel(DEFAULT_PACKET_LEN)?;
+    let (mut h, mut d) = open_channel(DEFAULT_PACKET_LEN, ack_piggybacking)?;
     h.message_in(0, 404, b"hello world hello world hello")
         .unwrap();
-    let res = take_turns_mutate(&mut h, &mut d, damage_nth_fix_crc(HostToDevice, 0, 10));
-    assert_eq!(res, Err(Error::CryptoError));
+    take_turns_until_fn(
+        &mut until_stuck,
+        &mut h,
+        &mut d,
+        &mut damage_nth_fix_crc(HostToDevice, 0, 10),
+    )?;
+    assert!(d.message_out_ready());
+    assert_eq!(d.message_out(), Err(Error::CryptoError));
 
-    let (mut h, mut d) = open_channel(DEFAULT_PACKET_LEN)?;
+    let (mut h, mut d) = open_channel(DEFAULT_PACKET_LEN, ack_piggybacking)?;
     d.message_in(0, 403, b"hello world hello world hello")
         .unwrap();
-    let res = take_turns_mutate(&mut h, &mut d, damage_nth_fix_crc(DeviceToHost, 0, 20));
-    assert_eq!(res, Err(Error::CryptoError));
+    take_turns_until_fn(
+        &mut until_stuck,
+        &mut h,
+        &mut d,
+        &mut damage_nth_fix_crc(DeviceToHost, 0, 20),
+    )?;
+    assert!(h.message_out_ready());
+    assert_eq!(h.message_out(), Err(Error::CryptoError));
 
     Ok(())
 }

--- a/rust/trezor-thp/src/control_byte.rs
+++ b/rust/trezor-thp/src/control_byte.rs
@@ -125,7 +125,7 @@ impl ControlByte {
     }
 
     pub fn sync_bits(&self) -> SyncBits {
-        SyncBits::from(self.0 & SYNC_MASK)
+        SyncBits::from(self.0)
     }
 
     pub fn with_sync_bits(self, sb: SyncBits) -> Self {

--- a/rust/trezor-thp/src/error.rs
+++ b/rust/trezor-thp/src/error.rs
@@ -22,6 +22,15 @@ impl TransportError {
     pub fn is_recoverable(&self) -> bool {
         matches!(self, TransportError::TransportBusy)
     }
+
+    pub fn as_str(&self) -> &'static str {
+        match self {
+            TransportError::TransportBusy => "TRANSPORT_BUSY",
+            TransportError::UnallocatedChannel => "UNALLOCATED_CHANNEL",
+            TransportError::DecryptionFailed => "DECRYPTION_FAILED",
+            TransportError::DeviceLocked => "DEVICE_LOCKED",
+        }
+    }
 }
 
 impl From<TransportError> for u8 {

--- a/rust/trezor-thp/src/fragment.rs
+++ b/rust/trezor-thp/src/fragment.rs
@@ -109,6 +109,7 @@ impl<R: Role> Fragmenter<R> {
 
 pub struct Reassembler<R: Role> {
     header: Header<R>,
+    sync_bits: SyncBits,
     offset: usize,
     checksum: Crc32,
 }
@@ -116,6 +117,7 @@ pub struct Reassembler<R: Role> {
 impl<R: Role> Reassembler<R> {
     pub fn new(input: &[u8], buffer: &mut [u8]) -> Result<Self> {
         let (header, after_header) = Header::parse(input)?;
+        let sync_bits = SyncBits::try_from(input)?;
         if header.is_continuation() {
             return Err(Error::malformed_data());
         }
@@ -134,6 +136,7 @@ impl<R: Role> Reassembler<R> {
 
         Ok(Self {
             header,
+            sync_bits,
             offset: nbytes,
             checksum,
         })
@@ -200,19 +203,12 @@ impl<R: Role> Reassembler<R> {
         &self.header
     }
 
-    // Shortcut to deserialize single packet message.
-    pub fn single<'a>(buffer: &[u8], dest: &'a mut [u8]) -> Result<(Header<R>, &'a [u8])> {
-        let reassembler = Self::new(buffer, dest)?;
-        if !reassembler.is_done() {
-            log::error!("Single packet message expected.");
-            return Err(Error::malformed_data());
-        }
-        let reply_len = reassembler.verify(dest)?;
-        let header = reassembler.header;
-        Ok((header, &dest[..reply_len]))
+    pub fn sync_bits(&self) -> SyncBits {
+        self.sync_bits
     }
 
-    pub fn single_inplace(buffer: &[u8]) -> Result<(Header<R>, &[u8])> {
+    // Shortcut to deserialize single packet message.
+    pub fn single(buffer: &[u8]) -> Result<(Header<R>, &[u8])> {
         let (header, after_header) = Header::parse(buffer)?;
         if header.is_continuation() {
             return Err(Error::malformed_data());
@@ -318,7 +314,7 @@ mod test {
             let packets = fragment(header, SyncBits::new(), source, packet_size);
             assert_eq!(packets.len(), 1);
 
-            let res = Reassembler::<Device>::single_inplace(&packets[0]).unwrap();
+            let res = Reassembler::<Device>::single(&packets[0]).unwrap();
             let expected_hex = hex::encode(source);
             let received_hex = hex::encode(res.1);
             assert_eq!(received_hex, expected_hex);
@@ -328,15 +324,15 @@ mod test {
     #[test]
     fn test_reassemble_single_good() {
         let empty = hex::decode(EMPTY_PAYLOAD_EXPECTED).unwrap();
-        let res = Reassembler::<Device>::single_inplace(&empty).unwrap();
+        let res = Reassembler::<Device>::single(&empty).unwrap();
         assert_eq!(res.1, b"");
-        let res = Reassembler::<Host>::single_inplace(&empty).unwrap();
+        let res = Reassembler::<Host>::single(&empty).unwrap();
         assert_eq!(res.1, b"");
 
         let short = hex::decode(SHORT_PAYLOAD_EXPECTED).unwrap();
-        let res = Reassembler::<Device>::single_inplace(&short).unwrap();
+        let res = Reassembler::<Device>::single(&short).unwrap();
         assert_eq!(res.1, b"\x07");
-        let res = Reassembler::<Host>::single_inplace(&short).unwrap();
+        let res = Reassembler::<Host>::single(&short).unwrap();
         assert_eq!(res.1, b"\x07");
     }
 
@@ -344,16 +340,16 @@ mod test {
     fn test_reassemble_single_bad() {
         // failure expected when more data follows
         let incomplete = hex::decode(LONGER_PAYLOAD_EXPECTED[0]).unwrap();
-        let res = Reassembler::<Device>::single_inplace(&incomplete);
+        let res = Reassembler::<Device>::single(&incomplete);
         assert_eq!(res, Err(Error::MalformedData));
-        let res = Reassembler::<Host>::single_inplace(&incomplete);
+        let res = Reassembler::<Host>::single(&incomplete);
         assert_eq!(res, Err(Error::MalformedData));
 
         // failure expected on continuations
         let continuation = hex::decode(LONGER_PAYLOAD_EXPECTED[1]).unwrap();
-        let res = Reassembler::<Device>::single_inplace(&continuation);
+        let res = Reassembler::<Device>::single(&continuation);
         assert_eq!(res, Err(Error::MalformedData));
-        let res = Reassembler::<Host>::single_inplace(&continuation);
+        let res = Reassembler::<Host>::single(&continuation);
         assert_eq!(res, Err(Error::MalformedData));
     }
 
@@ -458,7 +454,7 @@ mod test {
         let reassembler = Reassembler::<Device>::new(packet, &mut received);
         assert!(matches!(reassembler, Err(Error::MalformedData)));
 
-        let inplace = Reassembler::<Device>::single_inplace(packet);
+        let inplace = Reassembler::<Device>::single(packet);
         assert!(matches!(inplace, Err(Error::MalformedData)));
     }
 }

--- a/rust/trezor-thp/src/util.rs
+++ b/rust/trezor-thp/src/util.rs
@@ -2,3 +2,8 @@ pub(crate) fn prepare_zeroed<const C: usize>(buf: &mut heapless::Vec<u8, C>) {
     buf.clear();
     buf.resize(buf.capacity(), 0u8).unwrap();
 }
+
+// Ord::max is not (yet) const.
+pub(crate) const fn max(lhs: usize, rhs: usize) -> usize {
+    if lhs > rhs { lhs } else { rhs }
+}


### PR DESCRIPTION
ACK piggybacking implementation for #6442. Needs #6790.

Also fixes some protocol 2.0 problems:
* ACK message checksum was not verified
* "lost ACK" scenario was not handled

<!--
For external contributors:
- Please open an issue before submitting a PR so we can discuss whether we want to proceed with it.

For core developers:
1. Initial PR setup
- Assign yourself to the PR.
- Add it to the "Firmware" project
  - Set Priority (match issue priority if it exists)
  - Set Team
  - Set Sprint (target release)

2. Development status
- Draft PRs: Set status to "In Progress"
- Final PRs: Set status to "Needs Review"

3. Post-merge status
- Testable: Set status to "Needs QA" and add a `Notes for QA` section with clear instructions on how to test the functionality.
- Not Testable: Set status to "Done (no QA)"
-->
