### PR TITLE
feat(core): allow using `LayoutObj` as a context manager 

### DIFF
--- a/core/embed/rust/librust_qstr.h
+++ b/core/embed/rust/librust_qstr.h
@@ -78,6 +78,8 @@ static void _librust_qstrs(void) {
   MP_QSTR_WipeDevice;
   MP_QSTR___del__;
   MP_QSTR___dict__;
+  MP_QSTR___enter__;
+  MP_QSTR___exit__;
   MP_QSTR___name__;
   MP_QSTR_about_items;
   MP_QSTR_account;

--- a/core/embed/rust/src/ui/api/firmware_micropython.rs
+++ b/core/embed/rust/src/ui/api/firmware_micropython.rs
@@ -1441,6 +1441,12 @@ pub static mp_module_trezorui_api: Module = obj_module! {
     ///     def __del__(self) -> None:
     ///         """Calls drop on contents of the root component."""
     ///
+    ///     def __enter__(self) -> LayoutObj[T]:
+    ///         """Enters a context manager (checking the root component is not dropped)."""
+    ///
+    ///     def __exit__(self, exc_type: Any, exc_val: Any, exc_tb: Any) -> None:
+    ///         """Exits a context manager (dropping the root component)."""
+    ///
     /// class UiResult:
     ///     """Result of a UI operation."""
     ///     pass

--- a/core/embed/rust/src/ui/layout/obj.rs
+++ b/core/embed/rust/src/ui/layout/obj.rs
@@ -423,6 +423,10 @@ impl LayoutObj {
                 Qstr::MP_QSTR_button_request => obj_fn_1!(ui_layout_button_request).as_obj(),
                 Qstr::MP_QSTR_get_transition_out => obj_fn_1!(ui_layout_get_transition_out).as_obj(),
                 Qstr::MP_QSTR_return_value => obj_fn_1!(ui_layout_return_value).as_obj(),
+
+                // Allow using LayoutObj as context manager for explicit deallocation.
+                Qstr::MP_QSTR___enter__ => obj_fn_1!(ui_layout_enter).as_obj(),
+                Qstr::MP_QSTR___exit__ => obj_fn_var!(4, 4, ui_layout_exit).as_obj(),
             }),
         };
         &TYPE
@@ -717,4 +721,29 @@ extern "C" fn ui_layout_delete(this: Obj) -> Obj {
         Ok(Obj::const_none())
     };
     unsafe { util::try_or_raise(block) }
+}
+
+extern "C" fn ui_layout_enter(this: Obj) -> Obj {
+    let block = || {
+        let obj: Gc<LayoutObj> = this.try_into()?;
+        // Raise an exception if the root layout has been already dropped.
+        obj.inner_mut()
+            .root
+            .as_ref()
+            .ok_or(Error::RuntimeError(c"No root layout on enter"))?;
+        Ok(this)
+    };
+    unsafe { util::try_or_raise(block) }
+}
+
+extern "C" fn ui_layout_exit(n_args: usize, args: *const Obj) -> Obj {
+    let block = |args: &[Obj], _kwargs: &Map| {
+        if args.len() != 4 {
+            return Err(Error::TypeError);
+        }
+        let this: Gc<LayoutObj> = args[0].try_into()?;
+        this.inner_mut().obj_delete();
+        Ok(Obj::const_none())
+    };
+    unsafe { util::try_with_args_and_kwargs(n_args, args, &Map::EMPTY, block) }
 }

--- a/core/mocks/generated/trezorui_api.pyi
+++ b/core/mocks/generated/trezorui_api.pyi
@@ -80,6 +80,10 @@ class LayoutObj(Generic[T]):
         """Retrieve the return value of the layout object."""
     def __del__(self) -> None:
         """Calls drop on contents of the root component."""
+    def __enter__(self) -> LayoutObj[T]:
+        """Enters a context manager (checking the root component is not dropped)."""
+    def __exit__(self, exc_type: Any, exc_val: Any, exc_tb: Any) -> None:
+        """Exits a context manager (dropping the root component)."""
 
 
 # rust/src/ui/api/firmware_micropython.rs

--- a/tests/device_tests/ethereum/test_signtx.py
+++ b/tests/device_tests/ethereum/test_signtx.py
@@ -501,12 +501,20 @@ def test_sanity_checks_eip1559(session: Session):
         )
 
 
-HEXDATA = "0123456789abcd000023456789abcd010003456789abcd020000456789abcd030000056789abcd040000006789abcd050000000789abcd060000000089abcd070000000009abcd080000000000abcd090000000001abcd0a0000000011abcd0b0000000111abcd0c0000001111abcd0d0000011111abcd0e0000111111abcd0f0000000002abcd100000000022abcd110000000222abcd120000002222abcd130000022222abcd140000222222abcd15"
+DATA_FOR_PAGINATION = bytes.fromhex(
+    "0123456789abcd000023456789abcd010003456789abcd020000456789abcd030000056789abcd040000006789abcd050000000789abcd060000000089abcd070000000009abcd080000000000abcd090000000001abcd0a0000000011abcd0b0000000111abcd0c0000001111abcd0d0000011111abcd0e0000111111abcd0f0000000002abcd100000000022abcd110000000222abcd120000002222abcd130000022222abcd140000222222abcd15"
+)
 
 
-@pytest.mark.parametrize("scroll", [True, False])
+@pytest.mark.parametrize(
+    "scroll,size", product([True, False], [len(DATA_FOR_PAGINATION), 10_000])
+)
 @pytest.mark.models("core")
-def test_signtx_data_pagination(session: Session, scroll: bool):
+def test_signtx_data_pagination(session: Session, scroll: bool, size: int):
+    data = DATA_FOR_PAGINATION * (1 + (size // len(DATA_FOR_PAGINATION)))
+    data = data[:size]
+    assert len(data) == size
+
     def _sign_tx_call():
         ethereum.sign_tx(
             session,
@@ -518,7 +526,7 @@ def test_signtx_data_pagination(session: Session, scroll: bool):
             chain_id=1,
             value=0xA,
             tx_type=None,
-            data=bytes.fromhex(HEXDATA),
+            data=data,
         )
 
     # test pagination


### PR DESCRIPTION
Preparation for #6780 fix (see #6794).

It would allow explicitly scoping `LayoutObj` lifetime (without relying on MicroPython GC).