### PR TITLE
fix(core): scope `trezorui_api.confirm_with_info()` layouts 

### DIFF
--- a/core/.changelog.d/6780.fixed
+++ b/core/.changelog.d/6780.fixed
@@ -1,0 +1,1 @@
+Fix out-of-memory failure when confirming large input data.

--- a/core/src/apps/homescreen/__init__.py
+++ b/core/src/apps/homescreen/__init__.py
@@ -14,11 +14,8 @@ from apps.common.lock_manager import lock_device
 
 
 async def busyscreen() -> None:
-    obj = Busyscreen(busy_expiry_ms())
-    try:
+    with Busyscreen(busy_expiry_ms()) as obj:
         await obj.get_result()
-    finally:
-        obj.__del__()
 
 
 async def homescreen() -> None:
@@ -69,15 +66,12 @@ async def homescreen() -> None:
             False,
         )
 
-    obj = Homescreen(
+    with Homescreen(
         label=label,
         notification=notification,
         lockable=config.has_pin(),
-    )
-    try:
+    ) as obj:
         res = await obj.get_result()
-    finally:
-        obj.__del__()
 
     if utils.INTERNAL_MODEL == "T3W1":
         if res is trezorui_api.INFO:
@@ -94,14 +88,11 @@ async def _lockscreen(screensaver: bool = False) -> None:
     # Only show the lockscreen UI if the device can in fact be locked, or if it is
     # and OLED device (in which case the lockscreen is a screensaver).
     if can_lock_device() or screensaver:
-        obj = Lockscreen(
+        with Lockscreen(
             label=storage.device.get_label(),
             coinjoin_authorized=is_set_any_session(MessageType.AuthorizeCoinJoin),
-        )
-        try:
+        ) as obj:
             await obj.get_result()
-        finally:
-            obj.__del__()
     # Otherwise proceed directly to unlock() call. If the device is already unlocked,
     # it should be a no-op storage-wise, but it resets the internal configuration
     # to an unlocked state.

--- a/core/src/boot.py
+++ b/core/src/boot.py
@@ -55,9 +55,11 @@ def enforce_welcome_screen_duration() -> None:
 if not utils.USE_POWER_MANAGER:
 
     async def pin_unlock_sequence() -> None:
-        lockscreen = Lockscreen(label=storage.device.get_label(), bootscreen=True)
-        await lockscreen.get_result()
-        lockscreen.__del__()
+        with Lockscreen(
+            label=storage.device.get_label(),
+            bootscreen=True,
+        ) as lockscreen:
+            await lockscreen.get_result()
         await verify_user_pin()
 
 else:
@@ -70,9 +72,11 @@ else:
 
     async def pin_unlock_sequence() -> None:
         while True:
-            lockscreen = Lockscreen(label=storage.device.get_label(), bootscreen=True)
-            await lockscreen.get_result()
-            lockscreen.__del__()
+            with Lockscreen(
+                label=storage.device.get_label(),
+                bootscreen=True,
+            ) as lockscreen:
+                await lockscreen.get_result()
             res = await loop.race(verify_user_pin(), wait_for_suspend())
             if res is _SUSPEND_MARKER:
                 # make some delay for the suspend

--- a/core/src/trezor/ui/__init__.py
+++ b/core/src/trezor/ui/__init__.py
@@ -564,6 +564,7 @@ class Layout(Generic[T]):
         loop.schedule(task, finalizer=self._task_finalizer)
 
     def __del__(self) -> None:
+        # safe to call even if `self.layout` has been already dropped.
         self.layout.__del__()
 
 

--- a/core/src/trezor/ui/layouts/bolt/__init__.py
+++ b/core/src/trezor/ui/layouts/bolt/__init__.py
@@ -645,16 +645,13 @@ async def should_show_more(
     Raises ActionCancelled if the user cancels.
     """
 
-    result = await interact(
-        trezorui_api.confirm_with_info(
-            title=title,
-            items=items,
-            verb=confirm or TR.buttons__confirm,
-            verb_info=button_text,
-        ),
-        br_name,
-        br_code,
-    )
+    with trezorui_api.confirm_with_info(
+        title=title,
+        items=items,
+        verb=confirm or TR.buttons__confirm,
+        verb_info=button_text,
+    ) as layout_obj:
+        result = await interact(layout_obj, br_name, br_code)
 
     if result is CONFIRMED:
         return False

--- a/core/src/trezor/ui/layouts/bolt/recovery.py
+++ b/core/src/trezor/ui/layouts/bolt/recovery.py
@@ -45,15 +45,12 @@ async def request_word(
             prompt=prompt, prefill_word=prefill_word, can_go_back=can_go_back
         )
 
-    try:
-        word: str = await interact(
+    with keyboard:
+        return await interact(
             keyboard,
             "mnemonic" if send_button_request else None,
             ButtonRequestType.MnemonicInput,
         )
-    finally:
-        keyboard.__del__()
-    return word
 
 
 def format_remaining_shares_info(

--- a/core/src/trezor/ui/layouts/caesar/__init__.py
+++ b/core/src/trezor/ui/layouts/caesar/__init__.py
@@ -724,17 +724,14 @@ async def should_show_more(
 
     if button_text not in (DOWN_ARROW, ""):
         button_text = INFO_ICON
-    result = await interact(
-        trezorui_api.confirm_with_info(
-            title=title,
-            items=para,
-            verb=confirm or TR.buttons__confirm,
-            verb_cancel=verb_cancel,
-            verb_info=button_text,  # use info icon by default
-        ),
-        br_name,
-        br_code,
-    )
+    with trezorui_api.confirm_with_info(
+        title=title,
+        items=para,
+        verb=confirm or TR.buttons__confirm,
+        verb_cancel=verb_cancel,
+        verb_info=button_text,  # use info icon by default
+    ) as layout_obj:
+        result = await interact(layout_obj, br_name, br_code)
 
     if result is CONFIRMED:
         return False

--- a/core/src/trezor/ui/layouts/caesar/recovery.py
+++ b/core/src/trezor/ui/layouts/caesar/recovery.py
@@ -51,15 +51,12 @@ async def request_word(
             prompt=prompt, prefill_word=prefill_word, can_go_back=can_go_back
         )
 
-    try:
-        word: str = await interact(
+    with keyboard:
+        return await interact(
             keyboard,
             "mnemonic" if send_button_request else None,
             ButtonRequestType.MnemonicInput,
         )
-    finally:
-        keyboard.__del__()
-    return word
 
 
 async def show_remaining_shares(

--- a/core/src/trezor/ui/layouts/delizia/__init__.py
+++ b/core/src/trezor/ui/layouts/delizia/__init__.py
@@ -664,17 +664,14 @@ async def should_show_more(
     """
     button_text = button_text or TR.buttons__show_all  # def_arg
 
-    result = await interact(
-        trezorui_api.confirm_with_info(
-            title=title,
-            subtitle=subtitle,
-            items=para,
-            verb=(TR.buttons__confirm if confirm is None else confirm),
-            verb_info=button_text,
-        ),
-        br_name,
-        br_code,
-    )
+    with trezorui_api.confirm_with_info(
+        title=title,
+        subtitle=subtitle,
+        items=para,
+        verb=(TR.buttons__confirm if confirm is None else confirm),
+        verb_info=button_text,
+    ) as layout_obj:
+        result = await interact(layout_obj, br_name, br_code)
 
     if result is CONFIRMED:
         return False

--- a/core/src/trezor/ui/layouts/delizia/recovery.py
+++ b/core/src/trezor/ui/layouts/delizia/recovery.py
@@ -46,15 +46,12 @@ async def request_word(
             prompt=prompt, prefill_word=prefill_word, can_go_back=can_go_back
         )
 
-    try:
-        word: str = await interact(
+    with keyboard:
+        return await interact(
             keyboard,
             "mnemonic" if send_button_request else None,
             ButtonRequestType.MnemonicInput,
         )
-    finally:
-        keyboard.__del__()
-    return word
 
 
 def format_remaining_shares_info(

--- a/core/src/trezor/ui/layouts/eckhart/__init__.py
+++ b/core/src/trezor/ui/layouts/eckhart/__init__.py
@@ -673,16 +673,13 @@ async def should_show_more(
     if confirm is None or not isinstance(confirm, str):
         confirm = TR.buttons__confirm
 
-    result = await interact(
-        trezorui_api.confirm_with_info(
-            title=title,
-            items=para,
-            verb=confirm,
-            verb_info=button_text,
-        ),
-        br_name,
-        br_code,
-    )
+    with trezorui_api.confirm_with_info(
+        title=title,
+        items=para,
+        verb=confirm,
+        verb_info=button_text,
+    ) as layout_obj:
+        result = await interact(layout_obj, br_name, br_code)
 
     if result is CONFIRMED:
         return False

--- a/core/src/trezor/ui/layouts/eckhart/recovery.py
+++ b/core/src/trezor/ui/layouts/eckhart/recovery.py
@@ -46,12 +46,12 @@ async def request_word(
             prompt=prompt, prefill_word=prefill_word, can_go_back=True
         )
 
-    word: str = await interact(
-        keyboard,
-        "mnemonic" if send_button_request else None,
-        ButtonRequestType.MnemonicInput,
-    )
-    return word
+    with keyboard:
+        return await interact(
+            keyboard,
+            "mnemonic" if send_button_request else None,
+            ButtonRequestType.MnemonicInput,
+        )
 
 
 def format_remaining_shares_info(

--- a/core/src/trezor/ui/layouts/homescreen.py
+++ b/core/src/trezor/ui/layouts/homescreen.py
@@ -9,6 +9,7 @@ if TYPE_CHECKING:
     from typing import Any, Callable, Iterator, ParamSpec, Tuple, TypeVar
 
     from trezor import loop
+    from typing_extensions import Self
 
     P = ParamSpec("P")
     R = TypeVar("R")
@@ -57,7 +58,7 @@ class UsbAwareLayout(ui.Layout):
 class HomescreenBase(UsbAwareLayout):
     RENDER_INDICATOR: object | None = None
 
-    def __init__(self, layout: Any) -> None:
+    def __init__(self, layout: trezorui_api.LayoutObj[trezorui_api.UiResult]) -> None:
         super().__init__(layout=layout)
         self.should_resume = self._should_resume()
 
@@ -73,6 +74,14 @@ class HomescreenBase(UsbAwareLayout):
             storage_cache.homescreen_shown = self.RENDER_INDICATOR
         else:
             self._paint()
+
+    def __enter__(self) -> Self:
+        self.layout.__enter__()
+        return self
+
+    def __exit__(self, exc_type: Any, exc_val: Any, exc_tb: Any) -> None:
+        """Drop internal Rust root component."""
+        self.layout.__exit__(exc_type, exc_val, exc_tb)
 
 
 class Homescreen(HomescreenBase):


### PR DESCRIPTION
Also, avoid explicit calls to `LayoutObj.__del__` in homescreen and keyboard-related flows. 

Fixes OOM from #6780, by freeing Rust layout objects explicitly (instead of relying on MicroPython GC).

Requires #6792 - see also https://github.com/trezor/trezor-firmware/pull/6792#issuecomment-4275998018.

## Notes for QA:
Can be tested using https://github.com/trezor/trezor-firmware/pull/6794#issuecomment-4278435760