### PR TITLE
chore(core): remove unused `EventCtx.transition_out` field

### DIFF
--- a/core/embed/rust/src/ui/component/base.rs
+++ b/core/embed/rust/src/ui/component/base.rs
@@ -478,7 +478,6 @@ pub struct EventCtx {
     root_repaint_requested: bool,
     swipe_disable_req: bool,
     swipe_enable_req: bool,
-    transition_out: Option<AttachType>,
 }
 
 impl EventCtx {
@@ -502,7 +501,6 @@ impl EventCtx {
             root_repaint_requested: false,
             swipe_disable_req: false,
             swipe_enable_req: false,
-            transition_out: None,
         }
     }
 
@@ -606,14 +604,6 @@ impl EventCtx {
             #[cfg(feature = "ui_debug")]
             fatal_error!("Timer queue is full");
         }
-    }
-
-    pub fn set_transition_out(&mut self, attach_type: AttachType) {
-        self.transition_out = Some(attach_type);
-    }
-
-    pub fn get_transition_out(&self) -> Option<AttachType> {
-        self.transition_out
     }
 }
 

--- a/core/embed/rust/src/ui/flow/swipe.rs
+++ b/core/embed/rust/src/ui/flow/swipe.rs
@@ -272,7 +272,6 @@ impl SwipeFlow {
                 Some(LayoutState::Attached(ctx.button_request()))
             }
             Decision::Return(msg) => {
-                ctx.set_transition_out(return_transition);
                 self.swipe.reset();
                 self.allow_swipe = true;
                 self.returned_value = Some(msg.try_into());

--- a/core/embed/rust/src/ui/layout_delizia/component/swipe_up_screen.rs
+++ b/core/embed/rust/src/ui/layout_delizia/component/swipe_up_screen.rs
@@ -1,5 +1,5 @@
 use crate::ui::{
-    component::{base::AttachType, Component, Event, EventCtx, SwipeDetect},
+    component::{Component, Event, EventCtx, SwipeDetect},
     event::SwipeEvent,
     flow::Swipable,
     geometry::Rect,
@@ -49,8 +49,7 @@ impl<T: Swipable + Component> Component for SwipeUpScreen<T> {
             .swipe
             .event(ctx, event, self.content.get_swipe_config())
         {
-            Some(SwipeEvent::End(dir)) => {
-                ctx.set_transition_out(AttachType::Swipe(dir));
+            Some(SwipeEvent::End(_dir)) => {
                 return Some(SwipeUpScreenMsg::Swiped);
             }
             Some(e) => Event::Swipe(e),


### PR DESCRIPTION
IIUC, there is `LayoutObjInner.transition_out` which is accessed via `ui_layout_get_transition_out()`.