### PR TITLE
Clear signing definitions pipeline: 2. Definitions request mechanism

### DIFF
--- a/common/protob/messages-definitions.proto
+++ b/common/protob/messages-definitions.proto
@@ -136,6 +136,7 @@ enum EthereumERC7730FieldFormatterType {
 enum EthereumERC7730ContainerPath {
     FROM = 1;
     VALUE = 2;
+    TO = 3;
 }
 
 /**

--- a/common/protob/messages-ethereum.proto
+++ b/common/protob/messages-ethereum.proto
@@ -73,6 +73,7 @@ message EthereumSignTx {
     optional EthereumDefinitions definitions = 12;        // network and/or token definitions for tx
     optional bool chunkify = 13;                          // display the address in chunks of 4 characters
     optional common.PaymentRequest payment_req = 14;      // SLIP-24 payment request
+    optional bool supports_definition_request = 15;       // whether the client supports EthereumDefinitionRequest
 }
 
 /**
@@ -97,6 +98,7 @@ message EthereumSignTxEIP1559 {
     optional EthereumDefinitions definitions = 12;        // network and/or token definitions for tx
     optional bool chunkify = 13;                          // display the address in chunks of 4 characters
     optional common.PaymentRequest payment_req = 14;      // SLIP-24 payment request
+    optional bool supports_definition_request = 15;       // whether the client supports EthereumDefinitionRequest
 
     message EthereumAccessList {
         required string address = 1;
@@ -124,9 +126,30 @@ message EthereumTxRequest {
 /**
  * Request: Transaction payload data.
  * @next EthereumTxRequest
+ * @next EthereumDefinitionRequest
  */
 message EthereumTxAck {
     required bytes data_chunk = 1;  // requested number of bytes from transaction payload (<= 1024)
+}
+
+/**
+ * Structure representing a request for network / token definitions
+ * and optionally also for an ERC-7730 display format.
+ * @next EthereumDefinitionAck
+ */
+message EthereumDefinitionRequest {
+    required uint64 chain_id = 1;
+    required bytes token_address = 2;
+    optional bytes func_sig = 3;
+}
+
+/**
+ * Request: Definitions payload data.
+ * @next EthereumTxRequest
+ * @next EthereumDefinitionRequest
+ */
+message EthereumDefinitionAck {
+    optional EthereumDefinitions definitions = 1;
 }
 
 /**
@@ -187,11 +210,11 @@ message EthereumTypedDataSignature {
 }
 
 /**
- * Contains encoded network, token and ERC-7730 display format definitions. See external-definitions.md for details.
+ * Contains encoded network, token and display format definitions. See external-definitions.md for details.
  * @embed
  */
 message EthereumDefinitions {
-    optional bytes encoded_network = 1;                 // encoded ethereum network
-    optional bytes encoded_token = 2;                   // encoded ethereum token
-    optional bytes encoded_erc7730_display_format = 3;  // encoded ERC-7730 display format
+    optional bytes encoded_network = 1;         // encoded ethereum network
+    optional bytes encoded_token = 2;           // encoded ethereum token
+    optional bytes encoded_display_format = 3;  // encoded display format
 }

--- a/common/protob/messages-ethereum.proto
+++ b/common/protob/messages-ethereum.proto
@@ -133,8 +133,10 @@ message EthereumTxAck {
 }
 
 /**
- * Structure representing a request for network / token definitions
- * and optionally also for an ERC-7730 display format.
+ * Structure representing a request for extra Ethereum definitions.
+ * `token_address` carries the token address for token-definition lookups, or
+ * the target contract address when `func_sig` is set and a display format is
+ * being requested.
  * @next EthereumDefinitionAck
  */
 message EthereumDefinitionRequest {
@@ -145,6 +147,7 @@ message EthereumDefinitionRequest {
 
 /**
  * Request: Definitions payload data.
+ * `definitions` can be missing if the host did not find matching definitions.
  * @next EthereumTxRequest
  * @next EthereumDefinitionRequest
  */

--- a/common/protob/messages.proto
+++ b/common/protob/messages.proto
@@ -172,6 +172,8 @@ enum MessageType {
     MessageType_EthereumTypedDataValueAck = 468 [(wire_in) = true];
     MessageType_EthereumTypedDataSignature = 469 [(wire_out) = true];
     MessageType_EthereumSignTypedHash = 470 [(wire_in) = true];
+    MessageType_EthereumDefinitionRequest = 471 [(wire_out) = true];
+    MessageType_EthereumDefinitionAck = 472 [(wire_in) = true];
 
     // NEM
     MessageType_NEMGetAddress = 67 [(wire_in) = true];

--- a/core/src/apps/ethereum/clear_signing.py
+++ b/core/src/apps/ethereum/clear_signing.py
@@ -21,6 +21,7 @@ if TYPE_CHECKING:
         EthereumTokenInfo,
     )
     from trezor.ui.layouts import StrPropertyType
+    from trezor.ui.layouts.properties import AboveThreshold
     from typing_extensions import Self
 
     from apps.common.payment_request import PaymentRequestVerifier
@@ -225,7 +226,7 @@ class FieldFormatter:
         msg: MsgInSignTx,
         defs: Definitions,
         path_walker: PathWalker,
-    ) -> tuple[str | None, EthereumTokenInfo | None, AnyBytes | None]:
+    ) -> tuple[str | AboveThreshold | None, EthereumTokenInfo | None, AnyBytes | None]:
         """
         Format a field using the current formatter.
         Return the formatted value and optionally a token and a token address,
@@ -242,7 +243,7 @@ class AddressNameFormatter(FieldFormatter):
         _msg: MsgInSignTx,
         defs: Definitions,
         _path_walker: PathWalker,
-    ) -> tuple[str | None, EthereumTokenInfo | None, AnyBytes | None]:
+    ) -> tuple[str | AboveThreshold | None, EthereumTokenInfo | None, AnyBytes | None]:
         if address is None:
             return None, None, None
         elif isinstance(address, str):
@@ -260,7 +261,7 @@ class AmountFormatter(FieldFormatter):
         _msg: MsgInSignTx,
         defs: Definitions,
         _path_walker: PathWalker,
-    ) -> tuple[str | None, EthereumTokenInfo | None, AnyBytes | None]:
+    ) -> tuple[str | AboveThreshold | None, EthereumTokenInfo | None, AnyBytes | None]:
         if amount is None:
             return None, None, None
         else:
@@ -274,11 +275,6 @@ class AmountFormatter(FieldFormatter):
 
 
 class TokenAmountFormatter(FieldFormatter):
-    # TODO: figure out a way for the formatter to signal that the amount was above the threshold.
-    # For now we return None and `confirm_ethereum_approve` shows the "Unlimited amount" warning,
-    # but the `tokenAmount` spec allows this message to be customized in which case
-    # being above the threshold could mean something else, not just "Unlimited".
-
     def __init__(
         self,
         token_path: Path,
@@ -295,7 +291,9 @@ class TokenAmountFormatter(FieldFormatter):
         msg: MsgInSignTx,
         defs: Definitions,
         path_walker: PathWalker,
-    ) -> tuple[str | None, EthereumTokenInfo | None, AnyBytes | None]:
+    ) -> tuple[str | AboveThreshold | None, EthereumTokenInfo | None, AnyBytes | None]:
+        from trezor.ui.layouts.properties import AboveThreshold
+
         from .tokens import UNKNOWN_TOKEN
 
         if amount is None:
@@ -311,7 +309,7 @@ class TokenAmountFormatter(FieldFormatter):
         if self.native_currency_address is not None:
             if token_address in self.native_currency_address:
                 if self.threshold is not None and amount > self.threshold:
-                    return None, None, None
+                    return AboveThreshold(TR.words__unlimited), None, None
                 else:
                     return (
                         format_ethereum_amount(amount, None, defs.network),
@@ -331,7 +329,7 @@ class TokenAmountFormatter(FieldFormatter):
                     token = received_definitions.get_token(token_address)
 
         if self.threshold is not None and amount > self.threshold:
-            return None, token, token_address
+            return AboveThreshold(TR.words__unlimited), token, token_address
         else:
             return (
                 format_ethereum_amount(amount, token, defs.network),
@@ -352,7 +350,7 @@ class UnitFormatter(FieldFormatter):
         _msg: MsgInSignTx,
         _definitions: Definitions,
         _path_walker: PathWalker,
-    ) -> tuple[str | None, EthereumTokenInfo | None, AnyBytes | None]:
+    ) -> tuple[str | AboveThreshold | None, EthereumTokenInfo | None, AnyBytes | None]:
         if value is None:
             return None, None, None
         else:
@@ -660,7 +658,13 @@ class DisplayFormat:
         defs: Definitions,
     ) -> tuple[
         list[AnyValue],
-        list[tuple[StrPropertyType, EthereumTokenInfo | None, AnyBytes | None]],
+        list[
+            tuple[
+                tuple[str, str | AboveThreshold | None, bool | None],
+                EthereumTokenInfo | None,
+                AnyBytes | None,
+            ]
+        ],
     ]:
         parameters: list[AnyValue] = []
 
@@ -718,7 +722,11 @@ class DisplayFormat:
                 return p
 
         fields: list[
-            tuple[StrPropertyType, EthereumTokenInfo | None, AnyBytes | None]
+            tuple[
+                tuple[str, str | AboveThreshold | None, bool | None],
+                EthereumTokenInfo | None,
+                AnyBytes | None,
+            ]
         ] = []
         for field_definition in self.field_definitions:
             value = get_value_for_path(field_definition.path)
@@ -994,6 +1002,8 @@ async def _handle_generic_ui(
     defs: Definitions,
     maximum_fee: str,
 ) -> None:
+    from trezor.ui.layouts.properties import AboveThreshold
+
     from . import tokens
     from .helpers import bytes_from_address
     from .layout import require_confirm_clear_signing
@@ -1003,8 +1013,10 @@ async def _handle_generic_ui(
 
     properties_to_confirm = []
 
-    for field, actual_token, actual_token_address in fields:
-        properties_to_confirm.append(field)
+    for (label, formatted, hint), actual_token, actual_token_address in fields:
+        if isinstance(formatted, AboveThreshold):
+            formatted = formatted.message
+        properties_to_confirm.append((label, formatted, hint))
         if actual_token is tokens.UNKNOWN_TOKEN:
             assert actual_token_address is not None
             token_address_str = address_from_bytes(actual_token_address, defs.network)

--- a/core/src/apps/ethereum/clear_signing.py
+++ b/core/src/apps/ethereum/clear_signing.py
@@ -2,6 +2,7 @@ from micropython import const
 from typing import TYPE_CHECKING
 
 from trezor import TR
+from trezor.wire import DataError
 
 from .definitions import Definitions
 from .helpers import (
@@ -845,6 +846,12 @@ async def try_confirm(
 
     if display_format is None:
         return False
+
+    if (
+        payment_request_verifier is not None
+        and display_format.func_sig != TRANSFER_DISPLAY_FORMAT.func_sig
+    ):
+        raise DataError("Payment Requests only supported for ERC-20 transfers.")
 
     calldata = memoryview(data)[SC_FUNC_SIG_BYTES:]
 

--- a/core/src/apps/ethereum/clear_signing.py
+++ b/core/src/apps/ethereum/clear_signing.py
@@ -900,7 +900,7 @@ async def _handle_approve(
     assert isinstance(recipient_addr, str)
 
     arg1_raw_value = args[1]
-    (field1_name, value, _), _, _ = fields[1]
+    (field1_name, value, _), actual_token, _ = fields[1]
     assert field1_name == "Amount"
     assert isinstance(arg1_raw_value, int)
 
@@ -921,7 +921,7 @@ async def _handle_approve(
         fee_items,
         msg.chain_id,
         defs.network,
-        defs.get_token(address_bytes),
+        actual_token or defs.get_token(address_bytes),
         address_bytes,
         is_revoke,
         bool(msg.chunkify),
@@ -951,7 +951,7 @@ async def _handle_transfer(
 
     arg1_raw_value = args[1]
     assert isinstance(arg1_raw_value, int)
-    (arg1_name, value, _), _, _ = fields[1]
+    (arg1_name, value, _), actual_token, _ = fields[1]
     assert arg1_name == "Amount"
     assert isinstance(value, str)
 
@@ -970,7 +970,7 @@ async def _handle_transfer(
             fee_items,
             msg.chain_id,
             defs.network,
-            defs.get_token(address_bytes),
+            actual_token or defs.get_token(address_bytes),
             address_from_bytes(address_bytes, defs.network),
         )
     else:
@@ -981,7 +981,7 @@ async def _handle_transfer(
             msg.address_n,
             maximum_fee,
             fee_items,
-            defs.get_token(address_bytes),
+            actual_token or defs.get_token(address_bytes),
             is_send=True,
             chunkify=bool(msg.chunkify),
         )

--- a/core/src/apps/ethereum/clear_signing.py
+++ b/core/src/apps/ethereum/clear_signing.py
@@ -271,7 +271,7 @@ class AmountFormatter(FieldFormatter):
 class TokenAmountFormatter(FieldFormatter):
     def __init__(
         self,
-        token_path: Path | None = None,
+        token_path: Path,
         native_currency_address: list[bytes] | None = None,
         threshold: int | None = None,
     ) -> None:
@@ -549,6 +549,7 @@ class Array(ABIValue):
 class ContainerPath:
     From = 1
     Value = 2
+    To = 3
 
 
 class FieldDefinition:
@@ -633,13 +634,11 @@ class DisplayFormat:
 
         return self.binding_context.matches(chain_id, address)
 
-    def parse(
+    async def parse_calldata(
         self,
         calldata: memoryview,
-        address_n: list[int],
-        tx_value: AnyBytes,
-        definitions: Definitions,
-        token: EthereumTokenInfo,
+        msg: MsgInSignTx,
+        defs: Definitions,
     ) -> tuple[
         list[AnyValue],
         list[tuple[StrPropertyType, EthereumTokenInfo | None, AnyBytes | None]],
@@ -656,10 +655,12 @@ class DisplayFormat:
             if isinstance(path, int):  # ContainerPath
                 # standard container paths like @.from, @.value...
                 if path == ContainerPath.From:
-                    account, _ = get_account_and_path(address_n)
+                    account, _ = get_account_and_path(msg.address_n)
                     return account
                 elif path == ContainerPath.Value:
-                    return int.from_bytes(tx_value, "big")
+                    return int.from_bytes(msg.value, "big")
+                elif path == ContainerPath.To:
+                    return bytes_from_address(msg.to)
                 else:
                     raise NotImplementedError  # TODO
             else:
@@ -701,25 +702,17 @@ class DisplayFormat:
             tuple[StrPropertyType, EthereumTokenInfo | None, AnyBytes | None]
         ] = []
         for field_definition in self.field_definitions:
-            (
-                formatted_value,
-                actual_token,
-                actual_token_address,
-            ) = field_definition.get_formatter().format(
-                get_value_for_path(field_definition.path),
-                definitions,
-                token,
-                get_value_for_path,
+            value = get_value_for_path(field_definition.path)
+            formatter = field_definition.get_formatter()
+
+            formatted, token, token_address = await formatter.format(
+                value, msg, defs, get_value_for_path
             )
             fields.append(
                 (
-                    (
-                        field_definition.label,
-                        formatted_value,
-                        None,
-                    ),
-                    actual_token,
-                    actual_token_address,
+                    (field_definition.label, formatted, None),
+                    token,
+                    token_address,
                 )
             )
 
@@ -788,7 +781,6 @@ async def try_parse(
         return False
 
     calldata = memoryview(data)[SC_FUNC_SIG_BYTES:]
-    token = definitions.get_token(address_bytes)
 
     # custom treatment of certain functions (APPROVE, TRANSFER)
     if display_format.func_sig == APPROVE_DISPLAY_FORMAT.func_sig:
@@ -797,8 +789,7 @@ async def try_parse(
             display_format,
             address_bytes,
             msg,
-            definitions,
-            token,
+            defs,
             maximum_fee,
             fee_items,
         )
@@ -808,8 +799,7 @@ async def try_parse(
             display_format,
             address_bytes,
             msg,
-            definitions,
-            token,
+            defs,
             maximum_fee,
             fee_items,
             payment_request_verifier,
@@ -820,8 +810,7 @@ async def try_parse(
             calldata,
             display_format,
             msg,
-            definitions,
-            token,
+            defs,
             maximum_fee,
         )
     return True
@@ -832,8 +821,7 @@ async def _handle_approve(
     display_format: DisplayFormat,
     address_bytes: bytes,
     msg: MsgInSignTx,
-    definitions: Definitions,
-    token: EthereumTokenInfo,
+    defs: Definitions,
     maximum_fee: str,
     fee_items: Iterable[StrPropertyType],
 ) -> None:
@@ -842,9 +830,7 @@ async def _handle_approve(
     from .sc_constants import KNOWN_ADDRESSES
     from .yielding_vaults import UNKNOWN_VAULT, lookup_vault
 
-    args, fields = display_format.parse(
-        calldata, msg.address_n, msg.value, definitions, token
-    )
+    args, fields = await display_format.parse_calldata(calldata, msg, defs)
 
     assert len(args) == 2
     assert len(fields) == 2
@@ -862,7 +848,7 @@ async def _handle_approve(
 
     recipient_str = KNOWN_ADDRESSES.get(arg0_raw_value)
     if recipient_str is None:
-        vault = lookup_vault(definitions.network, arg0_raw_value)
+        vault = lookup_vault(defs.network, arg0_raw_value)
         if vault is not UNKNOWN_VAULT:
             recipient_str = vault.name
 
@@ -876,8 +862,8 @@ async def _handle_approve(
         maximum_fee,
         fee_items,
         msg.chain_id,
-        definitions.network,
-        token,
+        defs.network,
+        defs.get_token(address_bytes),
         address_bytes,
         is_revoke,
         bool(msg.chunkify),
@@ -889,17 +875,14 @@ async def _handle_transfer(
     display_format: DisplayFormat,
     address_bytes: bytes,
     msg: MsgInSignTx,
-    definitions: Definitions,
-    token: EthereumTokenInfo,
+    defs: Definitions,
     maximum_fee: str,
     fee_items: Iterable[StrPropertyType],
     payment_request_verifier: PaymentRequestVerifier | None,
 ) -> None:
     from .layout import require_confirm_payment_request, require_confirm_tx
 
-    args, fields = display_format.parse(
-        calldata, msg.address_n, msg.value, definitions, token
-    )
+    args, fields = await display_format.parse_calldata(calldata, msg, defs)
 
     assert len(args) == 2
     assert len(fields) == 2
@@ -928,9 +911,9 @@ async def _handle_transfer(
             maximum_fee,
             fee_items,
             msg.chain_id,
-            definitions.network,
-            token,
-            address_from_bytes(address_bytes, definitions.network),
+            defs.network,
+            defs.get_token(address_bytes),
+            address_from_bytes(address_bytes, defs.network),
         )
     else:
         await require_confirm_tx(
@@ -940,7 +923,7 @@ async def _handle_transfer(
             msg.address_n,
             maximum_fee,
             fee_items,
-            token,
+            defs.get_token(address_bytes),
             is_send=True,
             chunkify=bool(msg.chunkify),
         )
@@ -950,8 +933,7 @@ async def _handle_generic_ui(
     calldata: memoryview,
     display_format: DisplayFormat,
     msg: MsgInSignTx,
-    definitions: Definitions,
-    token: EthereumTokenInfo,
+    defs: Definitions,
     maximum_fee: str,
 ) -> None:
     from . import tokens
@@ -959,9 +941,7 @@ async def _handle_generic_ui(
     from .layout import require_confirm_clear_signing
     from .sc_constants import KNOWN_ADDRESSES
 
-    _, fields = display_format.parse(
-        calldata, msg.address_n, msg.value, definitions, token
-    )
+    _, fields = await display_format.parse_calldata(calldata, msg, defs)
 
     properties_to_confirm = []
 
@@ -969,9 +949,7 @@ async def _handle_generic_ui(
         properties_to_confirm.append(field)
         if actual_token is tokens.UNKNOWN_TOKEN:
             assert actual_token_address is not None
-            token_address_str = address_from_bytes(
-                actual_token_address, definitions.network
-            )
+            token_address_str = address_from_bytes(actual_token_address, defs.network)
             token_address_property: StrPropertyType = (
                 TR.ethereum__token_contract,
                 token_address_str,

--- a/core/src/apps/ethereum/clear_signing.py
+++ b/core/src/apps/ethereum/clear_signing.py
@@ -4,7 +4,12 @@ from typing import TYPE_CHECKING
 from trezor import TR
 
 from .definitions import Definitions
-from .helpers import address_from_bytes, format_ethereum_amount, get_account_and_path
+from .helpers import (
+    address_from_bytes,
+    bytes_from_address,
+    format_ethereum_amount,
+    get_account_and_path,
+)
 
 if TYPE_CHECKING:
     from buffer_types import AnyBytes
@@ -214,11 +219,11 @@ def _get_leaf_parser(info: EthereumABIValueInfo) -> Parser:
 
 
 class FieldFormatter:
-    def format(
+    async def format(
         self,
         value: AnyValue,
-        definitions: Definitions,
-        token: EthereumTokenInfo,
+        msg: MsgInSignTx,
+        defs: Definitions,
         path_walker: PathWalker,
     ) -> tuple[str | None, EthereumTokenInfo | None, AnyBytes | None]:
         """
@@ -231,11 +236,11 @@ class FieldFormatter:
 
 
 class AddressNameFormatter(FieldFormatter):
-    def format(
+    async def format(
         self,
         address: AnyValue,
-        definitions: Definitions,
-        _token: EthereumTokenInfo,
+        _msg: MsgInSignTx,
+        defs: Definitions,
         _path_walker: PathWalker,
     ) -> tuple[str | None, EthereumTokenInfo | None, AnyBytes | None]:
         if address is None:
@@ -245,16 +250,16 @@ class AddressNameFormatter(FieldFormatter):
         else:
             if not isinstance(address, bytes):
                 raise InvalidFormatDefinition
-            return address_from_bytes(address, definitions.network), None, None
+            return address_from_bytes(address, defs.network), None, None
 
 
 class AmountFormatter(FieldFormatter):
-    def format(
+    async def format(
         self,
         amount: AnyValue,
-        definitions: Definitions,
-        _token: EthereumTokenInfo,
-        _path_Walker: PathWalker,
+        _msg: MsgInSignTx,
+        defs: Definitions,
+        _path_walker: PathWalker,
     ) -> tuple[str | None, EthereumTokenInfo | None, AnyBytes | None]:
         if amount is None:
             return None, None, None
@@ -265,10 +270,15 @@ class AmountFormatter(FieldFormatter):
             # Note: we are passing None rather than `_token`
             # to `format_ethereum_amount` because this formatter
             # is meant to be used with native ETH amounts
-            return format_ethereum_amount(amount, None, definitions.network), None, None
+            return format_ethereum_amount(amount, None, defs.network), None, None
 
 
 class TokenAmountFormatter(FieldFormatter):
+    # TODO: figure out a way for the formatter to signal that the amount was above the threshold.
+    # For now we return None and `confirm_ethereum_approve` shows the "Unlimited amount" warning,
+    # but the `tokenAmount` spec allows this message to be customized in which case
+    # being above the threshold could mean something else, not just "Unlimited".
+
     def __init__(
         self,
         token_path: Path,
@@ -279,45 +289,54 @@ class TokenAmountFormatter(FieldFormatter):
         self.native_currency_address = native_currency_address
         self.threshold = threshold
 
-    def format(
+    async def format(
         self,
         amount: AnyValue,
-        definitions: Definitions,
-        token: EthereumTokenInfo | None,
+        msg: MsgInSignTx,
+        defs: Definitions,
         path_walker: PathWalker,
     ) -> tuple[str | None, EthereumTokenInfo | None, AnyBytes | None]:
+        from .tokens import UNKNOWN_TOKEN
+
         if amount is None:
             return None, None, None
-        else:
-            if not isinstance(amount, int):
-                raise InvalidFormatDefinition
-            if self.threshold is not None and amount > self.threshold:
-                # TODO: figure out a way for the formatter to signal that the amount was above the threshold.
-                # For now we return None and `confirm_ethereum_approve` shows the "Unlimited amount" warning,
-                # but the `tokenAmount` spec allows this message to be customized in which case
-                # being above the threshold could mean something else, not just "Unlimited".
-                return None, None, None
-            if self.token_path is not None:
-                token_address = path_walker(self.token_path)
-                if not isinstance(token_address, bytes):
-                    raise InvalidFormatDefinition
-                is_native_currency = False
-                if self.native_currency_address is not None:
-                    if token_address in self.native_currency_address:
-                        is_native_currency = True
-                if is_native_currency:
-                    token = None
+
+        if not isinstance(amount, int):
+            raise InvalidFormatDefinition
+
+        token_address = path_walker(self.token_path)
+        if not isinstance(token_address, bytes):
+            raise InvalidFormatDefinition
+
+        if self.native_currency_address is not None:
+            if token_address in self.native_currency_address:
+                if self.threshold is not None and amount > self.threshold:
+                    return None, None, None
                 else:
-                    token = definitions.get_token(token_address)
-                return (
-                    format_ethereum_amount(amount, token, definitions.network),
-                    token,
-                    token_address if not is_native_currency else None,
+                    return (
+                        format_ethereum_amount(amount, None, defs.network),
+                        None,
+                        None,
+                    )
+
+        # Non-native currency - dealing with tokens
+
+        token = defs.get_token(token_address)
+        if token is UNKNOWN_TOKEN:
+            if msg.supports_definition_request:
+                received_definitions, _ = await _request_definitions(
+                    msg.chain_id, token_address, func_sig=None
                 )
+                if received_definitions is not None:
+                    token = received_definitions.get_token(token_address)
+
+        if self.threshold is not None and amount > self.threshold:
+            return None, token, token_address
+        else:
             return (
-                format_ethereum_amount(amount, token, definitions.network),
+                format_ethereum_amount(amount, token, defs.network),
                 token,
-                token.address if token else None,
+                token_address,
             )
 
 
@@ -327,11 +346,11 @@ class UnitFormatter(FieldFormatter):
         self.base = base
         self.prefix = prefix
 
-    def format(
+    async def format(
         self,
         value: AnyValue,
+        _msg: MsgInSignTx,
         _definitions: Definitions,
-        _token: EthereumTokenInfo,
         _path_walker: PathWalker,
     ) -> tuple[str | None, EthereumTokenInfo | None, AnyBytes | None]:
         if value is None:
@@ -708,6 +727,7 @@ class DisplayFormat:
             formatted, token, token_address = await formatter.format(
                 value, msg, defs, get_value_for_path
             )
+
             fields.append(
                 (
                     (field_definition.label, formatted, None),
@@ -739,11 +759,40 @@ class DisplayFormat:
         )
 
 
-async def try_parse(
+async def _request_definitions(
+    chain_id: int, token_address: bytes, func_sig: bytes | None
+) -> tuple[Definitions | None, DisplayFormat | None]:
+    from trezor.messages import EthereumDefinitionAck, EthereumDefinitionRequest
+    from trezor.wire.context import call
+
+    req = EthereumDefinitionRequest(
+        chain_id=chain_id,
+        token_address=token_address,
+        func_sig=func_sig,
+    )
+    res = await call(req, EthereumDefinitionAck)
+
+    if res.definitions is None:
+        return None, None
+
+    definitions = Definitions.from_encoded(
+        res.definitions.encoded_network, res.definitions.encoded_token, chain_id
+    )
+
+    display_format = (
+        DisplayFormat.from_encoded(res.definitions.encoded_display_format)
+        if res.definitions.encoded_display_format is not None
+        else None
+    )
+
+    return definitions, display_format
+
+
+async def try_confirm(
     data: AnyBytes,
     address_bytes: bytes,
     msg: MsgInSignTx,
-    definitions: Definitions,
+    defs: Definitions,
     maximum_fee: str,
     fee_items: Iterable[StrPropertyType],
     payment_request_verifier: PaymentRequestVerifier | None,
@@ -760,24 +809,33 @@ async def try_parse(
     if len(data) < SC_FUNC_SIG_BYTES:
         return False
 
-    func_sig = data[0:SC_FUNC_SIG_BYTES]
+    func_sig = bytes(data[0:SC_FUNC_SIG_BYTES])
 
     display_format = None
     for f in ALL_DISPLAY_FORMATS:
-        if f.func_sig == func_sig:
+        # Start by trying built-in definitions...
+        if f.func_sig == func_sig and f.matches_context(msg.chain_id, address_bytes):
             display_format = f
             break
     else:
-        if msg.definitions and msg.definitions.encoded_erc7730_display_format:
-            f = DisplayFormat.from_encoded(
-                msg.definitions.encoded_erc7730_display_format
-            )
-            if f.func_sig == func_sig:
+        if msg.definitions and msg.definitions.encoded_display_format:
+            # ... look at definitions provided in the initial request...
+            f = DisplayFormat.from_encoded(msg.definitions.encoded_display_format)
+            if f.func_sig == func_sig and f.matches_context(
+                msg.chain_id, address_bytes
+            ):
                 display_format = f
+        if display_format is None:
+            # ... finally request the display format via another call!
+            if msg.supports_definition_request:
+                _, f = await _request_definitions(msg.chain_id, address_bytes, func_sig)
+                if f:
+                    if f.func_sig == func_sig and f.matches_context(
+                        msg.chain_id, address_bytes
+                    ):
+                        display_format = f
 
-    if display_format is None or not display_format.matches_context(
-        msg.chain_id, address_bytes
-    ):
+    if display_format is None:
         return False
 
     calldata = memoryview(data)[SC_FUNC_SIG_BYTES:]

--- a/core/src/apps/ethereum/clear_signing_definitions.py
+++ b/core/src/apps/ethereum/clear_signing_definitions.py
@@ -41,7 +41,8 @@ APPROVE_DISPLAY_FORMAT = DisplayFormat(
             (1,),
             "Amount",
             TokenAmountFormatter(
-                threshold=0x8000000000000000000000000000000000000000000000000000000000000000
+                token_path=ContainerPath.To,
+                threshold=0x8000000000000000000000000000000000000000000000000000000000000000,
             ),
         ),
     ],
@@ -58,7 +59,9 @@ TRANSFER_DISPLAY_FORMAT = DisplayFormat(
     ],
     field_definitions=[
         FieldDefinition((0,), "To", AddressNameFormatter),
-        FieldDefinition((1,), "Amount", TokenAmountFormatter),
+        FieldDefinition(
+            (1,), "Amount", TokenAmountFormatter(token_path=ContainerPath.To)
+        ),
     ],
 )
 

--- a/core/src/apps/ethereum/layout.py
+++ b/core/src/apps/ethereum/layout.py
@@ -31,11 +31,12 @@ if TYPE_CHECKING:
         PaymentRequest,
     )
     from trezor.ui.layouts import StrPropertyType
+    from trezor.ui.layouts.properties import AboveThreshold
 
 
 async def require_confirm_approve(
     recipient_addr: str,
-    total_amount: str | None,
+    total_amount: str | AboveThreshold | None,
     recipient_str: str | None,
     address_n: list[int],
     maximum_fee: str,

--- a/core/src/apps/ethereum/sign_tx.py
+++ b/core/src/apps/ethereum/sign_tx.py
@@ -273,7 +273,7 @@ async def confirm_tx_data(
         clear_signed = False
     else:
         try:
-            clear_signed = await clear_signing.try_parse(
+            clear_signed = await clear_signing.try_confirm(
                 initial_data,
                 address_bytes,
                 msg,

--- a/core/src/trezor/enums/EthereumERC7730ContainerPath.py
+++ b/core/src/trezor/enums/EthereumERC7730ContainerPath.py
@@ -4,3 +4,4 @@
 
 FROM = 1
 VALUE = 2
+TO = 3

--- a/core/src/trezor/enums/MessageType.py
+++ b/core/src/trezor/enums/MessageType.py
@@ -153,6 +153,8 @@ if not utils.BITCOIN_ONLY:
     EthereumTypedDataValueAck = 468
     EthereumTypedDataSignature = 469
     EthereumSignTypedHash = 470
+    EthereumDefinitionRequest = 471
+    EthereumDefinitionAck = 472
     NEMGetAddress = 67
     NEMAddress = 68
     NEMSignTx = 69

--- a/core/src/trezor/enums/__init__.py
+++ b/core/src/trezor/enums/__init__.py
@@ -321,6 +321,7 @@ if TYPE_CHECKING:
     class EthereumERC7730ContainerPath(IntEnum):
         FROM = 1
         VALUE = 2
+        TO = 3
 
     class EthereumDataType(IntEnum):
         UINT = 1

--- a/core/src/trezor/enums/__init__.py
+++ b/core/src/trezor/enums/__init__.py
@@ -553,6 +553,8 @@ if TYPE_CHECKING:
         EthereumTypedDataValueAck = 468
         EthereumTypedDataSignature = 469
         EthereumSignTypedHash = 470
+        EthereumDefinitionRequest = 471
+        EthereumDefinitionAck = 472
         NEMGetAddress = 67
         NEMAddress = 68
         NEMSignTx = 69

--- a/core/src/trezor/messages.py
+++ b/core/src/trezor/messages.py
@@ -3981,6 +3981,7 @@ if TYPE_CHECKING:
         definitions: "EthereumDefinitions | None"
         chunkify: "bool | None"
         payment_req: "PaymentRequest | None"
+        supports_definition_request: "bool | None"
 
         def __init__(
             self,
@@ -3998,6 +3999,7 @@ if TYPE_CHECKING:
             definitions: "EthereumDefinitions | None" = None,
             chunkify: "bool | None" = None,
             payment_req: "PaymentRequest | None" = None,
+            supports_definition_request: "bool | None" = None,
         ) -> None:
             pass
 
@@ -4020,6 +4022,7 @@ if TYPE_CHECKING:
         definitions: "EthereumDefinitions | None"
         chunkify: "bool | None"
         payment_req: "PaymentRequest | None"
+        supports_definition_request: "bool | None"
 
         def __init__(
             self,
@@ -4038,6 +4041,7 @@ if TYPE_CHECKING:
             definitions: "EthereumDefinitions | None" = None,
             chunkify: "bool | None" = None,
             payment_req: "PaymentRequest | None" = None,
+            supports_definition_request: "bool | None" = None,
         ) -> None:
             pass
 
@@ -4077,6 +4081,38 @@ if TYPE_CHECKING:
 
         @classmethod
         def is_type_of(cls, msg: Any) -> TypeGuard["EthereumTxAck"]:
+            return isinstance(msg, cls)
+
+    class EthereumDefinitionRequest(protobuf.MessageType):
+        chain_id: "int"
+        token_address: "AnyBytes"
+        func_sig: "AnyBytes | None"
+
+        def __init__(
+            self,
+            *,
+            chain_id: "int",
+            token_address: "AnyBytes",
+            func_sig: "AnyBytes | None" = None,
+        ) -> None:
+            pass
+
+        @classmethod
+        def is_type_of(cls, msg: Any) -> TypeGuard["EthereumDefinitionRequest"]:
+            return isinstance(msg, cls)
+
+    class EthereumDefinitionAck(protobuf.MessageType):
+        definitions: "EthereumDefinitions | None"
+
+        def __init__(
+            self,
+            *,
+            definitions: "EthereumDefinitions | None" = None,
+        ) -> None:
+            pass
+
+        @classmethod
+        def is_type_of(cls, msg: Any) -> TypeGuard["EthereumDefinitionAck"]:
             return isinstance(msg, cls)
 
     class EthereumSignMessage(protobuf.MessageType):
@@ -4174,14 +4210,14 @@ if TYPE_CHECKING:
     class EthereumDefinitions(protobuf.MessageType):
         encoded_network: "AnyBytes | None"
         encoded_token: "AnyBytes | None"
-        encoded_erc7730_display_format: "AnyBytes | None"
+        encoded_display_format: "AnyBytes | None"
 
         def __init__(
             self,
             *,
             encoded_network: "AnyBytes | None" = None,
             encoded_token: "AnyBytes | None" = None,
-            encoded_erc7730_display_format: "AnyBytes | None" = None,
+            encoded_display_format: "AnyBytes | None" = None,
         ) -> None:
             pass
 

--- a/core/src/trezor/ui/layouts/bolt/__init__.py
+++ b/core/src/trezor/ui/layouts/bolt/__init__.py
@@ -15,6 +15,7 @@ if TYPE_CHECKING:
     from trezor.messages import StellarAsset
 
     from ..common import ExceptionType, PropertyType, StrPropertyType
+    from ..properties import AboveThreshold
     from ..slip24 import Refund, Trade
 
 
@@ -1151,13 +1152,15 @@ if not utils.BITCOIN_ONLY:
         chain_id: str,
         network_name: str,
         is_revoke: bool,
-        total_amount: str | None,
+        total_amount: str | AboveThreshold | None,
         account: str | None,
         account_path: str | None,
         maximum_fee: str,
         fee_info_items: Iterable[StrPropertyType],
         chunkify: bool = False,
     ) -> None:
+        from ..properties import AboveThreshold
+
         await confirm_value(
             (
                 TR.ethereum__approve_intro_title_revoke
@@ -1184,7 +1187,7 @@ if not utils.BITCOIN_ONLY:
             chunkify=False if recipient_str else chunkify,
         )
 
-        if total_amount is None:
+        if isinstance(total_amount, AboveThreshold):
             await show_warning(
                 "confirm_ethereum_approve",
                 TR.ethereum__approve_unlimited_template.format(token_symbol),
@@ -1217,7 +1220,11 @@ if not utils.BITCOIN_ONLY:
             else [
                 (
                     TR.ethereum__approve_amount_allowance,
-                    total_amount or TR.words__unlimited,
+                    (
+                        total_amount.message
+                        if isinstance(total_amount, AboveThreshold)
+                        else total_amount
+                    ),
                     False,
                 )
             ]

--- a/core/src/trezor/ui/layouts/caesar/__init__.py
+++ b/core/src/trezor/ui/layouts/caesar/__init__.py
@@ -15,6 +15,7 @@ if TYPE_CHECKING:
 
     from ..common import ExceptionType, PropertyType, StrPropertyType
     from ..menu import Details
+    from ..properties import AboveThreshold
     from ..slip24 import Refund, Trade
 
 
@@ -1122,14 +1123,14 @@ if not utils.BITCOIN_ONLY:
         chain_id: str,
         network_name: str,
         is_revoke: bool,
-        total_amount: str | None,
+        total_amount: str | AboveThreshold | None,
         account: str | None,
         account_path: str | None,
         maximum_fee: str,
         fee_info_items: Iterable[StrPropertyType],
         chunkify: bool = False,
     ) -> None:
-        from ..properties import with_colon
+        from ..properties import AboveThreshold, with_colon
 
         await confirm_value(
             (
@@ -1159,7 +1160,7 @@ if not utils.BITCOIN_ONLY:
             chunkify=False if recipient_str else chunkify,
         )
 
-        if total_amount is None:
+        if isinstance(total_amount, AboveThreshold):
             await show_warning(
                 "confirm_ethereum_approve",
                 TR.ethereum__approve_unlimited_template.format(token_symbol),
@@ -1194,7 +1195,11 @@ if not utils.BITCOIN_ONLY:
             else [
                 (
                     TR.ethereum__approve_amount_allowance,
-                    total_amount or TR.words__unlimited,
+                    (
+                        total_amount.message
+                        if isinstance(total_amount, AboveThreshold)
+                        else total_amount
+                    ),
                     False,
                 )
             ]

--- a/core/src/trezor/ui/layouts/delizia/__init__.py
+++ b/core/src/trezor/ui/layouts/delizia/__init__.py
@@ -21,6 +21,7 @@ if TYPE_CHECKING:
 
     from ..common import ExceptionType, PropertyType, StrPropertyType
     from ..menu import Details
+    from ..properties import AboveThreshold
     from ..slip24 import Refund, Trade
 
     T = TypeVar("T")
@@ -1124,13 +1125,15 @@ if not utils.BITCOIN_ONLY:
         chain_id: str,
         network_name: str,
         is_revoke: bool,
-        total_amount: str | None,
+        total_amount: str | AboveThreshold | None,
         account: str | None,
         account_path: str | None,
         maximum_fee: str,
         fee_info_items: Iterable[StrPropertyType],
         chunkify: bool = False,
     ) -> None:
+        from ..properties import AboveThreshold
+
         br_name = "confirm_ethereum_approve"
         br_code = ButtonRequestType.Other
         await confirm_value(
@@ -1175,7 +1178,7 @@ if not utils.BITCOIN_ONLY:
             )
             await with_info(main_layout, info_layout, br_name, br_code)
 
-        if total_amount is None:
+        if isinstance(total_amount, AboveThreshold):
             await show_warning(
                 br_name,
                 TR.ethereum__approve_unlimited_template.format(token_symbol),
@@ -1206,7 +1209,11 @@ if not utils.BITCOIN_ONLY:
             else [
                 (
                     TR.ethereum__approve_amount_allowance,
-                    total_amount or TR.words__unlimited,
+                    (
+                        total_amount.message
+                        if isinstance(total_amount, AboveThreshold)
+                        else total_amount
+                    ),
                     False,
                 )
             ]

--- a/core/src/trezor/ui/layouts/eckhart/__init__.py
+++ b/core/src/trezor/ui/layouts/eckhart/__init__.py
@@ -21,6 +21,7 @@ if TYPE_CHECKING:
     from trezor.ui.layouts.menu import Details
 
     from ..common import ExceptionType, PropertyType, StrPropertyType
+    from ..properties import AboveThreshold
     from ..slip24 import Refund, Trade
 
     T = TypeVar("T")
@@ -1148,13 +1149,14 @@ if not utils.BITCOIN_ONLY:
         chain_id: str,
         network_name: str,
         is_revoke: bool,
-        total_amount: str | None,
+        total_amount: str | AboveThreshold | None,
         account: str | None,
         account_path: str | None,
         maximum_fee: str,
         fee_info_items: Iterable[StrPropertyType],
         chunkify: bool = False,
     ) -> None:
+        from ..properties import AboveThreshold
 
         br_name = "confirm_ethereum_approve"
         br_code = ButtonRequestType.Other
@@ -1208,7 +1210,7 @@ if not utils.BITCOIN_ONLY:
             )
             await with_info(main_layout, info_layout, br_name, br_code)
 
-        if total_amount is None:
+        if isinstance(total_amount, AboveThreshold):
             await show_warning(
                 br_name,
                 TR.ethereum__approve_unlimited_template.format(token_symbol),
@@ -1239,7 +1241,11 @@ if not utils.BITCOIN_ONLY:
             else [
                 (
                     TR.ethereum__approve_amount_allowance,
-                    total_amount or TR.words__unlimited,
+                    (
+                        total_amount.message
+                        if isinstance(total_amount, AboveThreshold)
+                        else total_amount
+                    ),
                     False,
                 )
             ]

--- a/core/src/trezor/ui/layouts/properties.py
+++ b/core/src/trezor/ui/layouts/properties.py
@@ -13,6 +13,17 @@ if TYPE_CHECKING:
     def with_colon(properties: str) -> str: ...
 
 
+class AboveThreshold:
+    """Signals that an amount exceeds a threshold.
+
+    Passed to layout functions instead of a plain amount string so they can
+    show the appropriate warning and display text.
+    """
+
+    def __init__(self, message: str) -> None:
+        self.message = message
+
+
 def with_colon(
     properties: Iterable[StrPropertyType] | str | None = None,
 ) -> list[StrPropertyType] | str | None:

--- a/legacy/firmware/protob/Makefile
+++ b/legacy/firmware/protob/Makefile
@@ -10,6 +10,7 @@ SKIPPED_MESSAGES := Cardano DebugMonero Eos Monero Ontology Ripple SdProtect Tez
 	DebugLinkOptigaSetSecMax DebugLinkSetLogFilter \
 	GetNonce TxAckInput TxAckOutput TxAckPrev PaymentRequest \
 	EthereumABITupleInfo EthereumABIValueInfo EthereumERC7730FieldInfo EthereumDisplayFormatInfo EthereumERC7730Path \
+	EthereumDefinitionRequest EthereumDefinitionAck \
 	EthereumSignTypedData EthereumTypedDataStructRequest EthereumTypedDataStructAck \
 	EthereumTypedDataValueRequest EthereumTypedDataValueAck ShowDeviceTutorial \
 	UnlockBootloader AuthenticateDevice AuthenticityProof \

--- a/legacy/firmware/protob/messages-ethereum.options
+++ b/legacy/firmware/protob/messages-ethereum.options
@@ -55,6 +55,6 @@ EthereumAddress.address                 max_size:43
 EthereumAddress.mac                     type:FT_IGNORE
 EthereumPublicKey.xpub                  max_size:113
 
-EthereumDefinitions.encoded_network                max_size:1024
-EthereumDefinitions.encoded_token                  max_size:1024
-EthereumDefinitions.encoded_erc7730_display_format type:FT_IGNORE
+EthereumDefinitions.encoded_network        max_size:1024
+EthereumDefinitions.encoded_token          max_size:1024
+EthereumDefinitions.encoded_display_format type:FT_IGNORE

--- a/python/src/trezorlib/ethereum.py
+++ b/python/src/trezorlib/ethereum.py
@@ -15,7 +15,7 @@
 # If not, see <https://www.gnu.org/licenses/lgpl-3.0.html>.
 
 import re
-from typing import TYPE_CHECKING, Any, AnyStr, Dict, List, Optional, Tuple
+from typing import TYPE_CHECKING, Any, AnyStr, Callable, Dict, List, Optional, Tuple
 
 from . import exceptions, messages
 from .tools import prepare_message_bytes, workflow
@@ -179,6 +179,54 @@ def get_public_node(
     )
 
 
+def _ethereum_sign_loop(
+    session: "Session",
+    msg_type: type,
+    response: Any,
+    data: bytes,
+    chain_id: int,
+    definition_provider: Optional[
+        Callable[[messages.EthereumDefinitionRequest], messages.EthereumDefinitionAck]
+    ],
+) -> Tuple[int, bytes, bytes]:
+    """Shared request/response loop for sign_tx and sign_tx_eip1559."""
+    while True:
+        if isinstance(response, messages.EthereumTxRequest):
+            if (
+                response.signature_v is not None
+                and response.signature_r is not None
+                and response.signature_s is not None
+            ):
+                # We got an EthereumTxRequest containing the signature which means we are done.
+                if msg_type is messages.EthereumSignTx:
+                    # https://github.com/trezor/trezor-core/pull/311
+                    # Only signature bit returned. Recalculate signature_v.
+                    if response.signature_v <= 1:
+                        response.signature_v += 2 * chain_id + 35
+                return response.signature_v, response.signature_r, response.signature_s
+            else:
+                assert response.data_length is not None
+                # We got an EthereumTxRequest asking for more data.
+                data_length = response.data_length
+                data, chunk = data[data_length:], data[:data_length]
+                response = session.call(messages.EthereumTxAck(data_chunk=chunk))
+        elif isinstance(response, messages.EthereumDefinitionRequest):
+            # We are being asked for a function definition.
+            if definition_provider is not None:
+                try:
+                    ack = definition_provider(response)
+                except Exception:
+                    session.cancel()
+                    raise
+            else:
+                ack = messages.EthereumDefinitionAck(
+                    definitions=None,
+                )
+            response = session.call(ack)
+        else:
+            raise AssertionError("Unknown Ethereum request")
+
+
 @workflow(capability=messages.Capability.Ethereum)
 def sign_tx(
     session: "Session",
@@ -194,6 +242,10 @@ def sign_tx(
     definitions: Optional[messages.EthereumDefinitions] = None,
     chunkify: bool = False,
     payment_req: Optional[messages.PaymentRequest] = None,
+    supports_definition_request: Optional[bool] = None,
+    definition_provider: Optional[
+        Callable[[messages.EthereumDefinitionRequest], messages.EthereumDefinitionAck]
+    ] = None,
 ) -> Tuple[int, bytes, bytes]:
     if chain_id is None:
         raise exceptions.TrezorException("Chain ID cannot be undefined")
@@ -210,6 +262,7 @@ def sign_tx(
         definitions=definitions,
         chunkify=chunkify,
         payment_req=payment_req,
+        supports_definition_request=supports_definition_request,
     )
 
     if data is None:
@@ -220,24 +273,10 @@ def sign_tx(
     msg.data_initial_chunk = chunk
 
     response = session.call(msg)
-    assert isinstance(response, messages.EthereumTxRequest)
 
-    while response.data_length is not None:
-        data_length = response.data_length
-        data, chunk = data[data_length:], data[:data_length]
-        response = session.call(messages.EthereumTxAck(data_chunk=chunk))
-        assert isinstance(response, messages.EthereumTxRequest)
-
-    assert response.signature_v is not None
-    assert response.signature_r is not None
-    assert response.signature_s is not None
-
-    # https://github.com/trezor/trezor-core/pull/311
-    # only signature bit returned. recalculate signature_v
-    if response.signature_v <= 1:
-        response.signature_v += 2 * chain_id + 35
-
-    return response.signature_v, response.signature_r, response.signature_s
+    return _ethereum_sign_loop(
+        session, messages.EthereumSignTx, response, data, chain_id, definition_provider
+    )
 
 
 @workflow(capability=messages.Capability.Ethereum)
@@ -257,6 +296,10 @@ def sign_tx_eip1559(
     definitions: Optional[messages.EthereumDefinitions] = None,
     chunkify: bool = False,
     payment_req: Optional[messages.PaymentRequest] = None,
+    supports_definition_request: Optional[bool] = None,
+    definition_provider: Optional[
+        Callable[[messages.EthereumDefinitionRequest], messages.EthereumDefinitionAck]
+    ] = None,
 ) -> Tuple[int, bytes, bytes]:
     length = len(data)
     data, chunk = data[1024:], data[:1024]
@@ -275,21 +318,19 @@ def sign_tx_eip1559(
         definitions=definitions,
         chunkify=chunkify,
         payment_req=payment_req,
+        supports_definition_request=supports_definition_request,
     )
 
     response = session.call(msg)
-    assert isinstance(response, messages.EthereumTxRequest)
 
-    while response.data_length is not None:
-        data_length = response.data_length
-        data, chunk = data[data_length:], data[:data_length]
-        response = session.call(messages.EthereumTxAck(data_chunk=chunk))
-        assert isinstance(response, messages.EthereumTxRequest)
-
-    assert response.signature_v is not None
-    assert response.signature_r is not None
-    assert response.signature_s is not None
-    return response.signature_v, response.signature_r, response.signature_s
+    return _ethereum_sign_loop(
+        session,
+        messages.EthereumSignTxEIP1559,
+        response,
+        data,
+        chain_id,
+        definition_provider,
+    )
 
 
 @workflow(capability=messages.Capability.Ethereum)

--- a/python/src/trezorlib/messages.py
+++ b/python/src/trezorlib/messages.py
@@ -612,6 +612,8 @@ class MessageType(IntEnum):
     EthereumTypedDataValueAck = 468
     EthereumTypedDataSignature = 469
     EthereumSignTypedHash = 470
+    EthereumDefinitionRequest = 471
+    EthereumDefinitionAck = 472
     NEMGetAddress = 67
     NEMAddress = 68
     NEMSignTx = 69
@@ -5488,6 +5490,7 @@ class EthereumSignTx(protobuf.MessageType):
         12: protobuf.Field("definitions", "EthereumDefinitions", repeated=False, required=False, default=None),
         13: protobuf.Field("chunkify", "bool", repeated=False, required=False, default=None),
         14: protobuf.Field("payment_req", "PaymentRequest", repeated=False, required=False, default=None),
+        15: protobuf.Field("supports_definition_request", "bool", repeated=False, required=False, default=None),
     }
 
     def __init__(
@@ -5506,6 +5509,7 @@ class EthereumSignTx(protobuf.MessageType):
         definitions: Optional["EthereumDefinitions"] = None,
         chunkify: Optional["bool"] = None,
         payment_req: Optional["PaymentRequest"] = None,
+        supports_definition_request: Optional["bool"] = None,
     ) -> None:
         self.address_n: Sequence["int"] = address_n if address_n is not None else []
         self.gas_price = gas_price
@@ -5520,6 +5524,7 @@ class EthereumSignTx(protobuf.MessageType):
         self.definitions = definitions
         self.chunkify = chunkify
         self.payment_req = payment_req
+        self.supports_definition_request = supports_definition_request
 
 
 class EthereumSignTxEIP1559(protobuf.MessageType):
@@ -5539,6 +5544,7 @@ class EthereumSignTxEIP1559(protobuf.MessageType):
         12: protobuf.Field("definitions", "EthereumDefinitions", repeated=False, required=False, default=None),
         13: protobuf.Field("chunkify", "bool", repeated=False, required=False, default=None),
         14: protobuf.Field("payment_req", "PaymentRequest", repeated=False, required=False, default=None),
+        15: protobuf.Field("supports_definition_request", "bool", repeated=False, required=False, default=None),
     }
 
     def __init__(
@@ -5558,6 +5564,7 @@ class EthereumSignTxEIP1559(protobuf.MessageType):
         definitions: Optional["EthereumDefinitions"] = None,
         chunkify: Optional["bool"] = None,
         payment_req: Optional["PaymentRequest"] = None,
+        supports_definition_request: Optional["bool"] = None,
     ) -> None:
         self.address_n: Sequence["int"] = address_n if address_n is not None else []
         self.access_list: Sequence["EthereumAccessList"] = access_list if access_list is not None else []
@@ -5573,6 +5580,7 @@ class EthereumSignTxEIP1559(protobuf.MessageType):
         self.definitions = definitions
         self.chunkify = chunkify
         self.payment_req = payment_req
+        self.supports_definition_request = supports_definition_request
 
 
 class EthereumTxRequest(protobuf.MessageType):
@@ -5610,6 +5618,40 @@ class EthereumTxAck(protobuf.MessageType):
         data_chunk: "bytes",
     ) -> None:
         self.data_chunk = data_chunk
+
+
+class EthereumDefinitionRequest(protobuf.MessageType):
+    MESSAGE_WIRE_TYPE = 471
+    FIELDS = {
+        1: protobuf.Field("chain_id", "uint64", repeated=False, required=True),
+        2: protobuf.Field("token_address", "bytes", repeated=False, required=True),
+        3: protobuf.Field("func_sig", "bytes", repeated=False, required=False, default=None),
+    }
+
+    def __init__(
+        self,
+        *,
+        chain_id: "int",
+        token_address: "bytes",
+        func_sig: Optional["bytes"] = None,
+    ) -> None:
+        self.chain_id = chain_id
+        self.token_address = token_address
+        self.func_sig = func_sig
+
+
+class EthereumDefinitionAck(protobuf.MessageType):
+    MESSAGE_WIRE_TYPE = 472
+    FIELDS = {
+        1: protobuf.Field("definitions", "EthereumDefinitions", repeated=False, required=False, default=None),
+    }
+
+    def __init__(
+        self,
+        *,
+        definitions: Optional["EthereumDefinitions"] = None,
+    ) -> None:
+        self.definitions = definitions
 
 
 class EthereumSignMessage(protobuf.MessageType):
@@ -5720,7 +5762,7 @@ class EthereumDefinitions(protobuf.MessageType):
     FIELDS = {
         1: protobuf.Field("encoded_network", "bytes", repeated=False, required=False, default=None),
         2: protobuf.Field("encoded_token", "bytes", repeated=False, required=False, default=None),
-        3: protobuf.Field("encoded_erc7730_display_format", "bytes", repeated=False, required=False, default=None),
+        3: protobuf.Field("encoded_display_format", "bytes", repeated=False, required=False, default=None),
     }
 
     def __init__(
@@ -5728,11 +5770,11 @@ class EthereumDefinitions(protobuf.MessageType):
         *,
         encoded_network: Optional["bytes"] = None,
         encoded_token: Optional["bytes"] = None,
-        encoded_erc7730_display_format: Optional["bytes"] = None,
+        encoded_display_format: Optional["bytes"] = None,
     ) -> None:
         self.encoded_network = encoded_network
         self.encoded_token = encoded_token
-        self.encoded_erc7730_display_format = encoded_erc7730_display_format
+        self.encoded_display_format = encoded_display_format
 
 
 class EthereumAccessList(protobuf.MessageType):

--- a/python/src/trezorlib/messages.py
+++ b/python/src/trezorlib/messages.py
@@ -364,6 +364,7 @@ class EthereumERC7730FieldFormatterType(IntEnum):
 class EthereumERC7730ContainerPath(IntEnum):
     FROM = 1
     VALUE = 2
+    TO = 3
 
 
 class EthereumDataType(IntEnum):

--- a/rust/trezor-client/src/messages/generated.rs
+++ b/rust/trezor-client/src/messages/generated.rs
@@ -194,6 +194,8 @@ trezor_message_impl! {
     EthereumTypedDataValueAck => MessageType_EthereumTypedDataValueAck,
     EthereumTypedDataSignature => MessageType_EthereumTypedDataSignature,
     EthereumSignTypedHash => MessageType_EthereumSignTypedHash,
+    EthereumDefinitionRequest => MessageType_EthereumDefinitionRequest,
+    EthereumDefinitionAck => MessageType_EthereumDefinitionAck,
 }
 
 #[cfg(feature = "evolu")]

--- a/rust/trezor-client/src/protos/generated/messages.rs
+++ b/rust/trezor-client/src/protos/generated/messages.rs
@@ -289,6 +289,10 @@ pub enum MessageType {
     MessageType_EthereumTypedDataSignature = 469,
     // @@protoc_insertion_point(enum_value:hw.trezor.messages.MessageType.MessageType_EthereumSignTypedHash)
     MessageType_EthereumSignTypedHash = 470,
+    // @@protoc_insertion_point(enum_value:hw.trezor.messages.MessageType.MessageType_EthereumDefinitionRequest)
+    MessageType_EthereumDefinitionRequest = 471,
+    // @@protoc_insertion_point(enum_value:hw.trezor.messages.MessageType.MessageType_EthereumDefinitionAck)
+    MessageType_EthereumDefinitionAck = 472,
     // @@protoc_insertion_point(enum_value:hw.trezor.messages.MessageType.MessageType_NEMGetAddress)
     MessageType_NEMGetAddress = 67,
     // @@protoc_insertion_point(enum_value:hw.trezor.messages.MessageType.MessageType_NEMAddress)
@@ -737,6 +741,8 @@ impl ::protobuf::Enum for MessageType {
             468 => ::std::option::Option::Some(MessageType::MessageType_EthereumTypedDataValueAck),
             469 => ::std::option::Option::Some(MessageType::MessageType_EthereumTypedDataSignature),
             470 => ::std::option::Option::Some(MessageType::MessageType_EthereumSignTypedHash),
+            471 => ::std::option::Option::Some(MessageType::MessageType_EthereumDefinitionRequest),
+            472 => ::std::option::Option::Some(MessageType::MessageType_EthereumDefinitionAck),
             67 => ::std::option::Option::Some(MessageType::MessageType_NEMGetAddress),
             68 => ::std::option::Option::Some(MessageType::MessageType_NEMAddress),
             69 => ::std::option::Option::Some(MessageType::MessageType_NEMSignTx),
@@ -1027,6 +1033,8 @@ impl ::protobuf::Enum for MessageType {
             "MessageType_EthereumTypedDataValueAck" => ::std::option::Option::Some(MessageType::MessageType_EthereumTypedDataValueAck),
             "MessageType_EthereumTypedDataSignature" => ::std::option::Option::Some(MessageType::MessageType_EthereumTypedDataSignature),
             "MessageType_EthereumSignTypedHash" => ::std::option::Option::Some(MessageType::MessageType_EthereumSignTypedHash),
+            "MessageType_EthereumDefinitionRequest" => ::std::option::Option::Some(MessageType::MessageType_EthereumDefinitionRequest),
+            "MessageType_EthereumDefinitionAck" => ::std::option::Option::Some(MessageType::MessageType_EthereumDefinitionAck),
             "MessageType_NEMGetAddress" => ::std::option::Option::Some(MessageType::MessageType_NEMGetAddress),
             "MessageType_NEMAddress" => ::std::option::Option::Some(MessageType::MessageType_NEMAddress),
             "MessageType_NEMSignTx" => ::std::option::Option::Some(MessageType::MessageType_NEMSignTx),
@@ -1316,6 +1324,8 @@ impl ::protobuf::Enum for MessageType {
         MessageType::MessageType_EthereumTypedDataValueAck,
         MessageType::MessageType_EthereumTypedDataSignature,
         MessageType::MessageType_EthereumSignTypedHash,
+        MessageType::MessageType_EthereumDefinitionRequest,
+        MessageType::MessageType_EthereumDefinitionAck,
         MessageType::MessageType_NEMGetAddress,
         MessageType::MessageType_NEMAddress,
         MessageType::MessageType_NEMSignTx,
@@ -1611,159 +1621,161 @@ impl ::protobuf::EnumFull for MessageType {
             MessageType::MessageType_EthereumTypedDataValueAck => 128,
             MessageType::MessageType_EthereumTypedDataSignature => 129,
             MessageType::MessageType_EthereumSignTypedHash => 130,
-            MessageType::MessageType_NEMGetAddress => 131,
-            MessageType::MessageType_NEMAddress => 132,
-            MessageType::MessageType_NEMSignTx => 133,
-            MessageType::MessageType_NEMSignedTx => 134,
-            MessageType::MessageType_NEMDecryptMessage => 135,
-            MessageType::MessageType_NEMDecryptedMessage => 136,
-            MessageType::MessageType_TezosGetAddress => 137,
-            MessageType::MessageType_TezosAddress => 138,
-            MessageType::MessageType_TezosSignTx => 139,
-            MessageType::MessageType_TezosSignedTx => 140,
-            MessageType::MessageType_TezosGetPublicKey => 141,
-            MessageType::MessageType_TezosPublicKey => 142,
-            MessageType::MessageType_StellarSignTx => 143,
-            MessageType::MessageType_StellarTxOpRequest => 144,
-            MessageType::MessageType_StellarGetAddress => 145,
-            MessageType::MessageType_StellarAddress => 146,
-            MessageType::MessageType_StellarCreateAccountOp => 147,
-            MessageType::MessageType_StellarPaymentOp => 148,
-            MessageType::MessageType_StellarPathPaymentStrictReceiveOp => 149,
-            MessageType::MessageType_StellarManageSellOfferOp => 150,
-            MessageType::MessageType_StellarCreatePassiveSellOfferOp => 151,
-            MessageType::MessageType_StellarSetOptionsOp => 152,
-            MessageType::MessageType_StellarChangeTrustOp => 153,
-            MessageType::MessageType_StellarAllowTrustOp => 154,
-            MessageType::MessageType_StellarAccountMergeOp => 155,
-            MessageType::MessageType_StellarManageDataOp => 156,
-            MessageType::MessageType_StellarBumpSequenceOp => 157,
-            MessageType::MessageType_StellarManageBuyOfferOp => 158,
-            MessageType::MessageType_StellarPathPaymentStrictSendOp => 159,
-            MessageType::MessageType_StellarClaimClaimableBalanceOp => 160,
-            MessageType::MessageType_StellarSignedTx => 161,
-            MessageType::MessageType_CardanoGetPublicKey => 162,
-            MessageType::MessageType_CardanoPublicKey => 163,
-            MessageType::MessageType_CardanoGetAddress => 164,
-            MessageType::MessageType_CardanoAddress => 165,
-            MessageType::MessageType_CardanoTxItemAck => 166,
-            MessageType::MessageType_CardanoTxAuxiliaryDataSupplement => 167,
-            MessageType::MessageType_CardanoTxWitnessRequest => 168,
-            MessageType::MessageType_CardanoTxWitnessResponse => 169,
-            MessageType::MessageType_CardanoTxHostAck => 170,
-            MessageType::MessageType_CardanoTxBodyHash => 171,
-            MessageType::MessageType_CardanoSignTxFinished => 172,
-            MessageType::MessageType_CardanoSignTxInit => 173,
-            MessageType::MessageType_CardanoTxInput => 174,
-            MessageType::MessageType_CardanoTxOutput => 175,
-            MessageType::MessageType_CardanoAssetGroup => 176,
-            MessageType::MessageType_CardanoToken => 177,
-            MessageType::MessageType_CardanoTxCertificate => 178,
-            MessageType::MessageType_CardanoTxWithdrawal => 179,
-            MessageType::MessageType_CardanoTxAuxiliaryData => 180,
-            MessageType::MessageType_CardanoPoolOwner => 181,
-            MessageType::MessageType_CardanoPoolRelayParameters => 182,
-            MessageType::MessageType_CardanoGetNativeScriptHash => 183,
-            MessageType::MessageType_CardanoNativeScriptHash => 184,
-            MessageType::MessageType_CardanoTxMint => 185,
-            MessageType::MessageType_CardanoTxCollateralInput => 186,
-            MessageType::MessageType_CardanoTxRequiredSigner => 187,
-            MessageType::MessageType_CardanoTxInlineDatumChunk => 188,
-            MessageType::MessageType_CardanoTxReferenceScriptChunk => 189,
-            MessageType::MessageType_CardanoTxReferenceInput => 190,
-            MessageType::MessageType_CardanoSignMessageInit => 191,
-            MessageType::MessageType_CardanoMessageDataRequest => 192,
-            MessageType::MessageType_CardanoMessageDataResponse => 193,
-            MessageType::MessageType_CardanoMessageSignature => 194,
-            MessageType::MessageType_RippleGetAddress => 195,
-            MessageType::MessageType_RippleAddress => 196,
-            MessageType::MessageType_RippleSignTx => 197,
-            MessageType::MessageType_RippleSignedTx => 198,
-            MessageType::MessageType_MoneroTransactionInitRequest => 199,
-            MessageType::MessageType_MoneroTransactionInitAck => 200,
-            MessageType::MessageType_MoneroTransactionSetInputRequest => 201,
-            MessageType::MessageType_MoneroTransactionSetInputAck => 202,
-            MessageType::MessageType_MoneroTransactionInputViniRequest => 203,
-            MessageType::MessageType_MoneroTransactionInputViniAck => 204,
-            MessageType::MessageType_MoneroTransactionAllInputsSetRequest => 205,
-            MessageType::MessageType_MoneroTransactionAllInputsSetAck => 206,
-            MessageType::MessageType_MoneroTransactionSetOutputRequest => 207,
-            MessageType::MessageType_MoneroTransactionSetOutputAck => 208,
-            MessageType::MessageType_MoneroTransactionAllOutSetRequest => 209,
-            MessageType::MessageType_MoneroTransactionAllOutSetAck => 210,
-            MessageType::MessageType_MoneroTransactionSignInputRequest => 211,
-            MessageType::MessageType_MoneroTransactionSignInputAck => 212,
-            MessageType::MessageType_MoneroTransactionFinalRequest => 213,
-            MessageType::MessageType_MoneroTransactionFinalAck => 214,
-            MessageType::MessageType_MoneroKeyImageExportInitRequest => 215,
-            MessageType::MessageType_MoneroKeyImageExportInitAck => 216,
-            MessageType::MessageType_MoneroKeyImageSyncStepRequest => 217,
-            MessageType::MessageType_MoneroKeyImageSyncStepAck => 218,
-            MessageType::MessageType_MoneroKeyImageSyncFinalRequest => 219,
-            MessageType::MessageType_MoneroKeyImageSyncFinalAck => 220,
-            MessageType::MessageType_MoneroGetAddress => 221,
-            MessageType::MessageType_MoneroAddress => 222,
-            MessageType::MessageType_MoneroGetWatchKey => 223,
-            MessageType::MessageType_MoneroWatchKey => 224,
-            MessageType::MessageType_DebugMoneroDiagRequest => 225,
-            MessageType::MessageType_DebugMoneroDiagAck => 226,
-            MessageType::MessageType_MoneroGetTxKeyRequest => 227,
-            MessageType::MessageType_MoneroGetTxKeyAck => 228,
-            MessageType::MessageType_MoneroLiveRefreshStartRequest => 229,
-            MessageType::MessageType_MoneroLiveRefreshStartAck => 230,
-            MessageType::MessageType_MoneroLiveRefreshStepRequest => 231,
-            MessageType::MessageType_MoneroLiveRefreshStepAck => 232,
-            MessageType::MessageType_MoneroLiveRefreshFinalRequest => 233,
-            MessageType::MessageType_MoneroLiveRefreshFinalAck => 234,
-            MessageType::MessageType_EosGetPublicKey => 235,
-            MessageType::MessageType_EosPublicKey => 236,
-            MessageType::MessageType_EosSignTx => 237,
-            MessageType::MessageType_EosTxActionRequest => 238,
-            MessageType::MessageType_EosTxActionAck => 239,
-            MessageType::MessageType_EosSignedTx => 240,
-            MessageType::MessageType_WebAuthnListResidentCredentials => 241,
-            MessageType::MessageType_WebAuthnCredentials => 242,
-            MessageType::MessageType_WebAuthnAddResidentCredential => 243,
-            MessageType::MessageType_WebAuthnRemoveResidentCredential => 244,
-            MessageType::MessageType_WebAuthnCredentialsAck => 245,
-            MessageType::MessageType_SolanaGetPublicKey => 246,
-            MessageType::MessageType_SolanaPublicKey => 247,
-            MessageType::MessageType_SolanaGetAddress => 248,
-            MessageType::MessageType_SolanaAddress => 249,
-            MessageType::MessageType_SolanaSignTx => 250,
-            MessageType::MessageType_SolanaTxSignature => 251,
-            MessageType::MessageType_ThpCreateNewSession => 252,
-            MessageType::MessageType_ThpCredentialRequest => 253,
-            MessageType::MessageType_ThpCredentialResponse => 254,
-            MessageType::MessageType_NostrGetPubkey => 255,
-            MessageType::MessageType_NostrPubkey => 256,
-            MessageType::MessageType_NostrSignEvent => 257,
-            MessageType::MessageType_NostrEventSignature => 258,
-            MessageType::MessageType_EvoluGetNode => 259,
-            MessageType::MessageType_EvoluNode => 260,
-            MessageType::MessageType_EvoluSignRegistrationRequest => 261,
-            MessageType::MessageType_EvoluRegistrationRequest => 262,
-            MessageType::MessageType_EvoluGetDelegatedIdentityKey => 263,
-            MessageType::MessageType_EvoluDelegatedIdentityKey => 264,
-            MessageType::MessageType_EvoluIndexManagement => 265,
-            MessageType::MessageType_EvoluIndexManagementResponse => 266,
-            MessageType::MessageType_TronGetAddress => 267,
-            MessageType::MessageType_TronAddress => 268,
-            MessageType::MessageType_TronSignTx => 269,
-            MessageType::MessageType_TronSignature => 270,
-            MessageType::MessageType_TronContractRequest => 271,
-            MessageType::MessageType_TronTransferContract => 272,
-            MessageType::MessageType_TronTriggerSmartContract => 273,
-            MessageType::MessageType_TronFreezeBalanceV2Contract => 274,
-            MessageType::MessageType_TronUnfreezeBalanceV2Contract => 275,
-            MessageType::MessageType_TronWithdrawUnfreeze => 276,
-            MessageType::MessageType_TronVoteWitnessContract => 277,
-            MessageType::MessageType_BenchmarkListNames => 278,
-            MessageType::MessageType_BenchmarkNames => 279,
-            MessageType::MessageType_BenchmarkRun => 280,
-            MessageType::MessageType_BenchmarkResult => 281,
-            MessageType::MessageType_TelemetryGet => 282,
-            MessageType::MessageType_Telemetry => 283,
+            MessageType::MessageType_EthereumDefinitionRequest => 131,
+            MessageType::MessageType_EthereumDefinitionAck => 132,
+            MessageType::MessageType_NEMGetAddress => 133,
+            MessageType::MessageType_NEMAddress => 134,
+            MessageType::MessageType_NEMSignTx => 135,
+            MessageType::MessageType_NEMSignedTx => 136,
+            MessageType::MessageType_NEMDecryptMessage => 137,
+            MessageType::MessageType_NEMDecryptedMessage => 138,
+            MessageType::MessageType_TezosGetAddress => 139,
+            MessageType::MessageType_TezosAddress => 140,
+            MessageType::MessageType_TezosSignTx => 141,
+            MessageType::MessageType_TezosSignedTx => 142,
+            MessageType::MessageType_TezosGetPublicKey => 143,
+            MessageType::MessageType_TezosPublicKey => 144,
+            MessageType::MessageType_StellarSignTx => 145,
+            MessageType::MessageType_StellarTxOpRequest => 146,
+            MessageType::MessageType_StellarGetAddress => 147,
+            MessageType::MessageType_StellarAddress => 148,
+            MessageType::MessageType_StellarCreateAccountOp => 149,
+            MessageType::MessageType_StellarPaymentOp => 150,
+            MessageType::MessageType_StellarPathPaymentStrictReceiveOp => 151,
+            MessageType::MessageType_StellarManageSellOfferOp => 152,
+            MessageType::MessageType_StellarCreatePassiveSellOfferOp => 153,
+            MessageType::MessageType_StellarSetOptionsOp => 154,
+            MessageType::MessageType_StellarChangeTrustOp => 155,
+            MessageType::MessageType_StellarAllowTrustOp => 156,
+            MessageType::MessageType_StellarAccountMergeOp => 157,
+            MessageType::MessageType_StellarManageDataOp => 158,
+            MessageType::MessageType_StellarBumpSequenceOp => 159,
+            MessageType::MessageType_StellarManageBuyOfferOp => 160,
+            MessageType::MessageType_StellarPathPaymentStrictSendOp => 161,
+            MessageType::MessageType_StellarClaimClaimableBalanceOp => 162,
+            MessageType::MessageType_StellarSignedTx => 163,
+            MessageType::MessageType_CardanoGetPublicKey => 164,
+            MessageType::MessageType_CardanoPublicKey => 165,
+            MessageType::MessageType_CardanoGetAddress => 166,
+            MessageType::MessageType_CardanoAddress => 167,
+            MessageType::MessageType_CardanoTxItemAck => 168,
+            MessageType::MessageType_CardanoTxAuxiliaryDataSupplement => 169,
+            MessageType::MessageType_CardanoTxWitnessRequest => 170,
+            MessageType::MessageType_CardanoTxWitnessResponse => 171,
+            MessageType::MessageType_CardanoTxHostAck => 172,
+            MessageType::MessageType_CardanoTxBodyHash => 173,
+            MessageType::MessageType_CardanoSignTxFinished => 174,
+            MessageType::MessageType_CardanoSignTxInit => 175,
+            MessageType::MessageType_CardanoTxInput => 176,
+            MessageType::MessageType_CardanoTxOutput => 177,
+            MessageType::MessageType_CardanoAssetGroup => 178,
+            MessageType::MessageType_CardanoToken => 179,
+            MessageType::MessageType_CardanoTxCertificate => 180,
+            MessageType::MessageType_CardanoTxWithdrawal => 181,
+            MessageType::MessageType_CardanoTxAuxiliaryData => 182,
+            MessageType::MessageType_CardanoPoolOwner => 183,
+            MessageType::MessageType_CardanoPoolRelayParameters => 184,
+            MessageType::MessageType_CardanoGetNativeScriptHash => 185,
+            MessageType::MessageType_CardanoNativeScriptHash => 186,
+            MessageType::MessageType_CardanoTxMint => 187,
+            MessageType::MessageType_CardanoTxCollateralInput => 188,
+            MessageType::MessageType_CardanoTxRequiredSigner => 189,
+            MessageType::MessageType_CardanoTxInlineDatumChunk => 190,
+            MessageType::MessageType_CardanoTxReferenceScriptChunk => 191,
+            MessageType::MessageType_CardanoTxReferenceInput => 192,
+            MessageType::MessageType_CardanoSignMessageInit => 193,
+            MessageType::MessageType_CardanoMessageDataRequest => 194,
+            MessageType::MessageType_CardanoMessageDataResponse => 195,
+            MessageType::MessageType_CardanoMessageSignature => 196,
+            MessageType::MessageType_RippleGetAddress => 197,
+            MessageType::MessageType_RippleAddress => 198,
+            MessageType::MessageType_RippleSignTx => 199,
+            MessageType::MessageType_RippleSignedTx => 200,
+            MessageType::MessageType_MoneroTransactionInitRequest => 201,
+            MessageType::MessageType_MoneroTransactionInitAck => 202,
+            MessageType::MessageType_MoneroTransactionSetInputRequest => 203,
+            MessageType::MessageType_MoneroTransactionSetInputAck => 204,
+            MessageType::MessageType_MoneroTransactionInputViniRequest => 205,
+            MessageType::MessageType_MoneroTransactionInputViniAck => 206,
+            MessageType::MessageType_MoneroTransactionAllInputsSetRequest => 207,
+            MessageType::MessageType_MoneroTransactionAllInputsSetAck => 208,
+            MessageType::MessageType_MoneroTransactionSetOutputRequest => 209,
+            MessageType::MessageType_MoneroTransactionSetOutputAck => 210,
+            MessageType::MessageType_MoneroTransactionAllOutSetRequest => 211,
+            MessageType::MessageType_MoneroTransactionAllOutSetAck => 212,
+            MessageType::MessageType_MoneroTransactionSignInputRequest => 213,
+            MessageType::MessageType_MoneroTransactionSignInputAck => 214,
+            MessageType::MessageType_MoneroTransactionFinalRequest => 215,
+            MessageType::MessageType_MoneroTransactionFinalAck => 216,
+            MessageType::MessageType_MoneroKeyImageExportInitRequest => 217,
+            MessageType::MessageType_MoneroKeyImageExportInitAck => 218,
+            MessageType::MessageType_MoneroKeyImageSyncStepRequest => 219,
+            MessageType::MessageType_MoneroKeyImageSyncStepAck => 220,
+            MessageType::MessageType_MoneroKeyImageSyncFinalRequest => 221,
+            MessageType::MessageType_MoneroKeyImageSyncFinalAck => 222,
+            MessageType::MessageType_MoneroGetAddress => 223,
+            MessageType::MessageType_MoneroAddress => 224,
+            MessageType::MessageType_MoneroGetWatchKey => 225,
+            MessageType::MessageType_MoneroWatchKey => 226,
+            MessageType::MessageType_DebugMoneroDiagRequest => 227,
+            MessageType::MessageType_DebugMoneroDiagAck => 228,
+            MessageType::MessageType_MoneroGetTxKeyRequest => 229,
+            MessageType::MessageType_MoneroGetTxKeyAck => 230,
+            MessageType::MessageType_MoneroLiveRefreshStartRequest => 231,
+            MessageType::MessageType_MoneroLiveRefreshStartAck => 232,
+            MessageType::MessageType_MoneroLiveRefreshStepRequest => 233,
+            MessageType::MessageType_MoneroLiveRefreshStepAck => 234,
+            MessageType::MessageType_MoneroLiveRefreshFinalRequest => 235,
+            MessageType::MessageType_MoneroLiveRefreshFinalAck => 236,
+            MessageType::MessageType_EosGetPublicKey => 237,
+            MessageType::MessageType_EosPublicKey => 238,
+            MessageType::MessageType_EosSignTx => 239,
+            MessageType::MessageType_EosTxActionRequest => 240,
+            MessageType::MessageType_EosTxActionAck => 241,
+            MessageType::MessageType_EosSignedTx => 242,
+            MessageType::MessageType_WebAuthnListResidentCredentials => 243,
+            MessageType::MessageType_WebAuthnCredentials => 244,
+            MessageType::MessageType_WebAuthnAddResidentCredential => 245,
+            MessageType::MessageType_WebAuthnRemoveResidentCredential => 246,
+            MessageType::MessageType_WebAuthnCredentialsAck => 247,
+            MessageType::MessageType_SolanaGetPublicKey => 248,
+            MessageType::MessageType_SolanaPublicKey => 249,
+            MessageType::MessageType_SolanaGetAddress => 250,
+            MessageType::MessageType_SolanaAddress => 251,
+            MessageType::MessageType_SolanaSignTx => 252,
+            MessageType::MessageType_SolanaTxSignature => 253,
+            MessageType::MessageType_ThpCreateNewSession => 254,
+            MessageType::MessageType_ThpCredentialRequest => 255,
+            MessageType::MessageType_ThpCredentialResponse => 256,
+            MessageType::MessageType_NostrGetPubkey => 257,
+            MessageType::MessageType_NostrPubkey => 258,
+            MessageType::MessageType_NostrSignEvent => 259,
+            MessageType::MessageType_NostrEventSignature => 260,
+            MessageType::MessageType_EvoluGetNode => 261,
+            MessageType::MessageType_EvoluNode => 262,
+            MessageType::MessageType_EvoluSignRegistrationRequest => 263,
+            MessageType::MessageType_EvoluRegistrationRequest => 264,
+            MessageType::MessageType_EvoluGetDelegatedIdentityKey => 265,
+            MessageType::MessageType_EvoluDelegatedIdentityKey => 266,
+            MessageType::MessageType_EvoluIndexManagement => 267,
+            MessageType::MessageType_EvoluIndexManagementResponse => 268,
+            MessageType::MessageType_TronGetAddress => 269,
+            MessageType::MessageType_TronAddress => 270,
+            MessageType::MessageType_TronSignTx => 271,
+            MessageType::MessageType_TronSignature => 272,
+            MessageType::MessageType_TronContractRequest => 273,
+            MessageType::MessageType_TronTransferContract => 274,
+            MessageType::MessageType_TronTriggerSmartContract => 275,
+            MessageType::MessageType_TronFreezeBalanceV2Contract => 276,
+            MessageType::MessageType_TronUnfreezeBalanceV2Contract => 277,
+            MessageType::MessageType_TronWithdrawUnfreeze => 278,
+            MessageType::MessageType_TronVoteWitnessContract => 279,
+            MessageType::MessageType_BenchmarkListNames => 280,
+            MessageType::MessageType_BenchmarkNames => 281,
+            MessageType::MessageType_BenchmarkRun => 282,
+            MessageType::MessageType_BenchmarkResult => 283,
+            MessageType::MessageType_TelemetryGet => 284,
+            MessageType::MessageType_Telemetry => 285,
         };
         Self::enum_descriptor().value_by_index(index)
     }
@@ -1782,7 +1794,7 @@ impl MessageType {
 }
 
 static file_descriptor_proto_data: &'static [u8] = b"\
-    \n\x0emessages.proto\x12\x12hw.trezor.messages\x1a\roptions.proto*\xdec\
+    \n\x0emessages.proto\x12\x12hw.trezor.messages\x1a\roptions.proto*\xbed\
     \n\x0bMessageType\x12(\n\x16MessageType_Initialize\x10\0\x1a\x0c\xb0\xb5\
     \x18\x01\x80\xa6\x1d\x01\x90\xb5\x18\x01\x12\x1e\n\x10MessageType_Ping\
     \x10\x01\x1a\x08\x80\xa6\x1d\x01\x90\xb5\x18\x01\x12%\n\x13MessageType_S\
@@ -1938,62 +1950,64 @@ static file_descriptor_proto_data: &'static [u8] = b"\
     \x18\x01\x120\n%MessageType_EthereumTypedDataValueAck\x10\xd4\x03\x1a\
     \x04\x90\xb5\x18\x01\x121\n&MessageType_EthereumTypedDataSignature\x10\
     \xd5\x03\x1a\x04\x98\xb5\x18\x01\x12,\n!MessageType_EthereumSignTypedHas\
-    h\x10\xd6\x03\x1a\x04\x90\xb5\x18\x01\x12#\n\x19MessageType_NEMGetAddres\
-    s\x10C\x1a\x04\x90\xb5\x18\x01\x12\x20\n\x16MessageType_NEMAddress\x10D\
-    \x1a\x04\x98\xb5\x18\x01\x12\x1f\n\x15MessageType_NEMSignTx\x10E\x1a\x04\
-    \x90\xb5\x18\x01\x12!\n\x17MessageType_NEMSignedTx\x10F\x1a\x04\x98\xb5\
-    \x18\x01\x12'\n\x1dMessageType_NEMDecryptMessage\x10K\x1a\x04\x90\xb5\
-    \x18\x01\x12)\n\x1fMessageType_NEMDecryptedMessage\x10L\x1a\x04\x98\xb5\
-    \x18\x01\x12&\n\x1bMessageType_TezosGetAddress\x10\x96\x01\x1a\x04\x90\
-    \xb5\x18\x01\x12#\n\x18MessageType_TezosAddress\x10\x97\x01\x1a\x04\x98\
-    \xb5\x18\x01\x12\"\n\x17MessageType_TezosSignTx\x10\x98\x01\x1a\x04\x90\
-    \xb5\x18\x01\x12$\n\x19MessageType_TezosSignedTx\x10\x99\x01\x1a\x04\x98\
-    \xb5\x18\x01\x12(\n\x1dMessageType_TezosGetPublicKey\x10\x9a\x01\x1a\x04\
-    \x90\xb5\x18\x01\x12%\n\x1aMessageType_TezosPublicKey\x10\x9b\x01\x1a\
-    \x04\x98\xb5\x18\x01\x12$\n\x19MessageType_StellarSignTx\x10\xca\x01\x1a\
-    \x04\x90\xb5\x18\x01\x12)\n\x1eMessageType_StellarTxOpRequest\x10\xcb\
-    \x01\x1a\x04\x98\xb5\x18\x01\x12(\n\x1dMessageType_StellarGetAddress\x10\
-    \xcf\x01\x1a\x04\x90\xb5\x18\x01\x12%\n\x1aMessageType_StellarAddress\
-    \x10\xd0\x01\x1a\x04\x98\xb5\x18\x01\x12-\n\"MessageType_StellarCreateAc\
-    countOp\x10\xd2\x01\x1a\x04\x90\xb5\x18\x01\x12'\n\x1cMessageType_Stella\
-    rPaymentOp\x10\xd3\x01\x1a\x04\x90\xb5\x18\x01\x128\n-MessageType_Stella\
-    rPathPaymentStrictReceiveOp\x10\xd4\x01\x1a\x04\x90\xb5\x18\x01\x12/\n$M\
-    essageType_StellarManageSellOfferOp\x10\xd5\x01\x1a\x04\x90\xb5\x18\x01\
-    \x126\n+MessageType_StellarCreatePassiveSellOfferOp\x10\xd6\x01\x1a\x04\
-    \x90\xb5\x18\x01\x12*\n\x1fMessageType_StellarSetOptionsOp\x10\xd7\x01\
-    \x1a\x04\x90\xb5\x18\x01\x12+\n\x20MessageType_StellarChangeTrustOp\x10\
-    \xd8\x01\x1a\x04\x90\xb5\x18\x01\x12*\n\x1fMessageType_StellarAllowTrust\
-    Op\x10\xd9\x01\x1a\x04\x90\xb5\x18\x01\x12,\n!MessageType_StellarAccount\
-    MergeOp\x10\xda\x01\x1a\x04\x90\xb5\x18\x01\x12*\n\x1fMessageType_Stella\
-    rManageDataOp\x10\xdc\x01\x1a\x04\x90\xb5\x18\x01\x12,\n!MessageType_Ste\
-    llarBumpSequenceOp\x10\xdd\x01\x1a\x04\x90\xb5\x18\x01\x12.\n#MessageTyp\
-    e_StellarManageBuyOfferOp\x10\xde\x01\x1a\x04\x90\xb5\x18\x01\x125\n*Mes\
-    sageType_StellarPathPaymentStrictSendOp\x10\xdf\x01\x1a\x04\x90\xb5\x18\
-    \x01\x125\n*MessageType_StellarClaimClaimableBalanceOp\x10\xe1\x01\x1a\
-    \x04\x90\xb5\x18\x01\x12&\n\x1bMessageType_StellarSignedTx\x10\xe6\x01\
-    \x1a\x04\x98\xb5\x18\x01\x12*\n\x1fMessageType_CardanoGetPublicKey\x10\
-    \xb1\x02\x1a\x04\x90\xb5\x18\x01\x12'\n\x1cMessageType_CardanoPublicKey\
-    \x10\xb2\x02\x1a\x04\x98\xb5\x18\x01\x12(\n\x1dMessageType_CardanoGetAdd\
-    ress\x10\xb3\x02\x1a\x04\x90\xb5\x18\x01\x12%\n\x1aMessageType_CardanoAd\
-    dress\x10\xb4\x02\x1a\x04\x98\xb5\x18\x01\x12'\n\x1cMessageType_CardanoT\
-    xItemAck\x10\xb9\x02\x1a\x04\x98\xb5\x18\x01\x127\n,MessageType_CardanoT\
-    xAuxiliaryDataSupplement\x10\xba\x02\x1a\x04\x98\xb5\x18\x01\x12.\n#Mess\
-    ageType_CardanoTxWitnessRequest\x10\xbb\x02\x1a\x04\x90\xb5\x18\x01\x12/\
-    \n$MessageType_CardanoTxWitnessResponse\x10\xbc\x02\x1a\x04\x98\xb5\x18\
-    \x01\x12'\n\x1cMessageType_CardanoTxHostAck\x10\xbd\x02\x1a\x04\x90\xb5\
-    \x18\x01\x12(\n\x1dMessageType_CardanoTxBodyHash\x10\xbe\x02\x1a\x04\x98\
-    \xb5\x18\x01\x12,\n!MessageType_CardanoSignTxFinished\x10\xbf\x02\x1a\
-    \x04\x98\xb5\x18\x01\x12(\n\x1dMessageType_CardanoSignTxInit\x10\xc0\x02\
-    \x1a\x04\x90\xb5\x18\x01\x12%\n\x1aMessageType_CardanoTxInput\x10\xc1\
-    \x02\x1a\x04\x90\xb5\x18\x01\x12&\n\x1bMessageType_CardanoTxOutput\x10\
-    \xc2\x02\x1a\x04\x90\xb5\x18\x01\x12(\n\x1dMessageType_CardanoAssetGroup\
-    \x10\xc3\x02\x1a\x04\x90\xb5\x18\x01\x12#\n\x18MessageType_CardanoToken\
-    \x10\xc4\x02\x1a\x04\x90\xb5\x18\x01\x12+\n\x20MessageType_CardanoTxCert\
-    ificate\x10\xc5\x02\x1a\x04\x90\xb5\x18\x01\x12*\n\x1fMessageType_Cardan\
-    oTxWithdrawal\x10\xc6\x02\x1a\x04\x90\xb5\x18\x01\x12-\n\"MessageType_Ca\
-    rdanoTxAuxiliaryData\x10\xc7\x02\x1a\x04\x90\xb5\x18\x01\x12'\n\x1cMessa\
-    geType_CardanoPoolOwner\x10\xc8\x02\x1a\x04\x90\xb5\x18\x01\x121\n&Messa\
-    geType_CardanoPoolRelayParameters\x10\xc9\x02\x1a\x04\x90\xb5\x18\x01\
+    h\x10\xd6\x03\x1a\x04\x90\xb5\x18\x01\x120\n%MessageType_EthereumDefinit\
+    ionRequest\x10\xd7\x03\x1a\x04\x98\xb5\x18\x01\x12,\n!MessageType_Ethere\
+    umDefinitionAck\x10\xd8\x03\x1a\x04\x90\xb5\x18\x01\x12#\n\x19MessageTyp\
+    e_NEMGetAddress\x10C\x1a\x04\x90\xb5\x18\x01\x12\x20\n\x16MessageType_NE\
+    MAddress\x10D\x1a\x04\x98\xb5\x18\x01\x12\x1f\n\x15MessageType_NEMSignTx\
+    \x10E\x1a\x04\x90\xb5\x18\x01\x12!\n\x17MessageType_NEMSignedTx\x10F\x1a\
+    \x04\x98\xb5\x18\x01\x12'\n\x1dMessageType_NEMDecryptMessage\x10K\x1a\
+    \x04\x90\xb5\x18\x01\x12)\n\x1fMessageType_NEMDecryptedMessage\x10L\x1a\
+    \x04\x98\xb5\x18\x01\x12&\n\x1bMessageType_TezosGetAddress\x10\x96\x01\
+    \x1a\x04\x90\xb5\x18\x01\x12#\n\x18MessageType_TezosAddress\x10\x97\x01\
+    \x1a\x04\x98\xb5\x18\x01\x12\"\n\x17MessageType_TezosSignTx\x10\x98\x01\
+    \x1a\x04\x90\xb5\x18\x01\x12$\n\x19MessageType_TezosSignedTx\x10\x99\x01\
+    \x1a\x04\x98\xb5\x18\x01\x12(\n\x1dMessageType_TezosGetPublicKey\x10\x9a\
+    \x01\x1a\x04\x90\xb5\x18\x01\x12%\n\x1aMessageType_TezosPublicKey\x10\
+    \x9b\x01\x1a\x04\x98\xb5\x18\x01\x12$\n\x19MessageType_StellarSignTx\x10\
+    \xca\x01\x1a\x04\x90\xb5\x18\x01\x12)\n\x1eMessageType_StellarTxOpReques\
+    t\x10\xcb\x01\x1a\x04\x98\xb5\x18\x01\x12(\n\x1dMessageType_StellarGetAd\
+    dress\x10\xcf\x01\x1a\x04\x90\xb5\x18\x01\x12%\n\x1aMessageType_StellarA\
+    ddress\x10\xd0\x01\x1a\x04\x98\xb5\x18\x01\x12-\n\"MessageType_StellarCr\
+    eateAccountOp\x10\xd2\x01\x1a\x04\x90\xb5\x18\x01\x12'\n\x1cMessageType_\
+    StellarPaymentOp\x10\xd3\x01\x1a\x04\x90\xb5\x18\x01\x128\n-MessageType_\
+    StellarPathPaymentStrictReceiveOp\x10\xd4\x01\x1a\x04\x90\xb5\x18\x01\
+    \x12/\n$MessageType_StellarManageSellOfferOp\x10\xd5\x01\x1a\x04\x90\xb5\
+    \x18\x01\x126\n+MessageType_StellarCreatePassiveSellOfferOp\x10\xd6\x01\
+    \x1a\x04\x90\xb5\x18\x01\x12*\n\x1fMessageType_StellarSetOptionsOp\x10\
+    \xd7\x01\x1a\x04\x90\xb5\x18\x01\x12+\n\x20MessageType_StellarChangeTrus\
+    tOp\x10\xd8\x01\x1a\x04\x90\xb5\x18\x01\x12*\n\x1fMessageType_StellarAll\
+    owTrustOp\x10\xd9\x01\x1a\x04\x90\xb5\x18\x01\x12,\n!MessageType_Stellar\
+    AccountMergeOp\x10\xda\x01\x1a\x04\x90\xb5\x18\x01\x12*\n\x1fMessageType\
+    _StellarManageDataOp\x10\xdc\x01\x1a\x04\x90\xb5\x18\x01\x12,\n!MessageT\
+    ype_StellarBumpSequenceOp\x10\xdd\x01\x1a\x04\x90\xb5\x18\x01\x12.\n#Mes\
+    sageType_StellarManageBuyOfferOp\x10\xde\x01\x1a\x04\x90\xb5\x18\x01\x12\
+    5\n*MessageType_StellarPathPaymentStrictSendOp\x10\xdf\x01\x1a\x04\x90\
+    \xb5\x18\x01\x125\n*MessageType_StellarClaimClaimableBalanceOp\x10\xe1\
+    \x01\x1a\x04\x90\xb5\x18\x01\x12&\n\x1bMessageType_StellarSignedTx\x10\
+    \xe6\x01\x1a\x04\x98\xb5\x18\x01\x12*\n\x1fMessageType_CardanoGetPublicK\
+    ey\x10\xb1\x02\x1a\x04\x90\xb5\x18\x01\x12'\n\x1cMessageType_CardanoPubl\
+    icKey\x10\xb2\x02\x1a\x04\x98\xb5\x18\x01\x12(\n\x1dMessageType_CardanoG\
+    etAddress\x10\xb3\x02\x1a\x04\x90\xb5\x18\x01\x12%\n\x1aMessageType_Card\
+    anoAddress\x10\xb4\x02\x1a\x04\x98\xb5\x18\x01\x12'\n\x1cMessageType_Car\
+    danoTxItemAck\x10\xb9\x02\x1a\x04\x98\xb5\x18\x01\x127\n,MessageType_Car\
+    danoTxAuxiliaryDataSupplement\x10\xba\x02\x1a\x04\x98\xb5\x18\x01\x12.\n\
+    #MessageType_CardanoTxWitnessRequest\x10\xbb\x02\x1a\x04\x90\xb5\x18\x01\
+    \x12/\n$MessageType_CardanoTxWitnessResponse\x10\xbc\x02\x1a\x04\x98\xb5\
+    \x18\x01\x12'\n\x1cMessageType_CardanoTxHostAck\x10\xbd\x02\x1a\x04\x90\
+    \xb5\x18\x01\x12(\n\x1dMessageType_CardanoTxBodyHash\x10\xbe\x02\x1a\x04\
+    \x98\xb5\x18\x01\x12,\n!MessageType_CardanoSignTxFinished\x10\xbf\x02\
+    \x1a\x04\x98\xb5\x18\x01\x12(\n\x1dMessageType_CardanoSignTxInit\x10\xc0\
+    \x02\x1a\x04\x90\xb5\x18\x01\x12%\n\x1aMessageType_CardanoTxInput\x10\
+    \xc1\x02\x1a\x04\x90\xb5\x18\x01\x12&\n\x1bMessageType_CardanoTxOutput\
+    \x10\xc2\x02\x1a\x04\x90\xb5\x18\x01\x12(\n\x1dMessageType_CardanoAssetG\
+    roup\x10\xc3\x02\x1a\x04\x90\xb5\x18\x01\x12#\n\x18MessageType_CardanoTo\
+    ken\x10\xc4\x02\x1a\x04\x90\xb5\x18\x01\x12+\n\x20MessageType_CardanoTxC\
+    ertificate\x10\xc5\x02\x1a\x04\x90\xb5\x18\x01\x12*\n\x1fMessageType_Car\
+    danoTxWithdrawal\x10\xc6\x02\x1a\x04\x90\xb5\x18\x01\x12-\n\"MessageType\
+    _CardanoTxAuxiliaryData\x10\xc7\x02\x1a\x04\x90\xb5\x18\x01\x12'\n\x1cMe\
+    ssageType_CardanoPoolOwner\x10\xc8\x02\x1a\x04\x90\xb5\x18\x01\x121\n&Me\
+    ssageType_CardanoPoolRelayParameters\x10\xc9\x02\x1a\x04\x90\xb5\x18\x01\
     \x121\n&MessageType_CardanoGetNativeScriptHash\x10\xca\x02\x1a\x04\x90\
     \xb5\x18\x01\x12.\n#MessageType_CardanoNativeScriptHash\x10\xcb\x02\x1a\
     \x04\x98\xb5\x18\x01\x12$\n\x19MessageType_CardanoTxMint\x10\xcc\x02\x1a\

--- a/rust/trezor-client/src/protos/generated/messages_definitions.rs
+++ b/rust/trezor-client/src/protos/generated/messages_definitions.rs
@@ -2635,6 +2635,8 @@ pub enum EthereumERC7730ContainerPath {
     FROM = 1,
     // @@protoc_insertion_point(enum_value:hw.trezor.messages.definitions.EthereumERC7730ContainerPath.VALUE)
     VALUE = 2,
+    // @@protoc_insertion_point(enum_value:hw.trezor.messages.definitions.EthereumERC7730ContainerPath.TO)
+    TO = 3,
 }
 
 impl ::protobuf::Enum for EthereumERC7730ContainerPath {
@@ -2648,6 +2650,7 @@ impl ::protobuf::Enum for EthereumERC7730ContainerPath {
         match value {
             1 => ::std::option::Option::Some(EthereumERC7730ContainerPath::FROM),
             2 => ::std::option::Option::Some(EthereumERC7730ContainerPath::VALUE),
+            3 => ::std::option::Option::Some(EthereumERC7730ContainerPath::TO),
             _ => ::std::option::Option::None
         }
     }
@@ -2656,6 +2659,7 @@ impl ::protobuf::Enum for EthereumERC7730ContainerPath {
         match str {
             "FROM" => ::std::option::Option::Some(EthereumERC7730ContainerPath::FROM),
             "VALUE" => ::std::option::Option::Some(EthereumERC7730ContainerPath::VALUE),
+            "TO" => ::std::option::Option::Some(EthereumERC7730ContainerPath::TO),
             _ => ::std::option::Option::None
         }
     }
@@ -2663,6 +2667,7 @@ impl ::protobuf::Enum for EthereumERC7730ContainerPath {
     const VALUES: &'static [EthereumERC7730ContainerPath] = &[
         EthereumERC7730ContainerPath::FROM,
         EthereumERC7730ContainerPath::VALUE,
+        EthereumERC7730ContainerPath::TO,
     ];
 }
 
@@ -2676,6 +2681,7 @@ impl ::protobuf::EnumFull for EthereumERC7730ContainerPath {
         let index = match self {
             EthereumERC7730ContainerPath::FROM => 0,
             EthereumERC7730ContainerPath::VALUE => 1,
+            EthereumERC7730ContainerPath::TO => 2,
         };
         Self::enum_descriptor().value_by_index(index)
     }
@@ -2747,9 +2753,9 @@ static file_descriptor_proto_data: &'static [u8] = b"\
     _STRING\x10\x15*\x85\x01\n!EthereumERC7730FieldFormatterType\x12\x1a\n\
     \x16FORMATTER_ADDRESS_NAME\x10\0\x12\x14\n\x10FORMATTER_AMOUNT\x10\x01\
     \x12\x1a\n\x16FORMATTER_TOKEN_AMOUNT\x10\x02\x12\x12\n\x0eFORMATTER_UNIT\
-    \x10\x03*3\n\x1cEthereumERC7730ContainerPath\x12\x08\n\x04FROM\x10\x01\
-    \x12\t\n\x05VALUE\x10\x02B?\n#com.satoshilabs.trezor.lib.protobufB\x18Tr\
-    ezorMessageDefinitions\
+    \x10\x03*;\n\x1cEthereumERC7730ContainerPath\x12\x08\n\x04FROM\x10\x01\
+    \x12\t\n\x05VALUE\x10\x02\x12\x06\n\x02TO\x10\x03B?\n#com.satoshilabs.tr\
+    ezor.lib.protobufB\x18TrezorMessageDefinitions\
 ";
 
 /// `FileDescriptorProto` object which was a source for this generated file

--- a/rust/trezor-client/src/protos/generated/messages_ethereum.rs
+++ b/rust/trezor-client/src/protos/generated/messages_ethereum.rs
@@ -923,6 +923,8 @@ pub struct EthereumSignTx {
     pub chunkify: ::std::option::Option<bool>,
     // @@protoc_insertion_point(field:hw.trezor.messages.ethereum.EthereumSignTx.payment_req)
     pub payment_req: ::protobuf::MessageField<super::messages_common::PaymentRequest>,
+    // @@protoc_insertion_point(field:hw.trezor.messages.ethereum.EthereumSignTx.supports_definition_request)
+    pub supports_definition_request: ::std::option::Option<bool>,
     // special fields
     // @@protoc_insertion_point(special_field:hw.trezor.messages.ethereum.EthereumSignTx.special_fields)
     pub special_fields: ::protobuf::SpecialFields,
@@ -1231,8 +1233,27 @@ impl EthereumSignTx {
         self.chunkify = ::std::option::Option::Some(v);
     }
 
+    // optional bool supports_definition_request = 15;
+
+    pub fn supports_definition_request(&self) -> bool {
+        self.supports_definition_request.unwrap_or(false)
+    }
+
+    pub fn clear_supports_definition_request(&mut self) {
+        self.supports_definition_request = ::std::option::Option::None;
+    }
+
+    pub fn has_supports_definition_request(&self) -> bool {
+        self.supports_definition_request.is_some()
+    }
+
+    // Param is passed by value, moved
+    pub fn set_supports_definition_request(&mut self, v: bool) {
+        self.supports_definition_request = ::std::option::Option::Some(v);
+    }
+
     fn generated_message_descriptor_data() -> ::protobuf::reflect::GeneratedMessageDescriptorData {
-        let mut fields = ::std::vec::Vec::with_capacity(13);
+        let mut fields = ::std::vec::Vec::with_capacity(14);
         let mut oneofs = ::std::vec::Vec::with_capacity(0);
         fields.push(::protobuf::reflect::rt::v2::make_vec_simpler_accessor::<_, _>(
             "address_n",
@@ -1298,6 +1319,11 @@ impl EthereumSignTx {
             "payment_req",
             |m: &EthereumSignTx| { &m.payment_req },
             |m: &mut EthereumSignTx| { &mut m.payment_req },
+        ));
+        fields.push(::protobuf::reflect::rt::v2::make_option_accessor::<_, _>(
+            "supports_definition_request",
+            |m: &EthereumSignTx| { &m.supports_definition_request },
+            |m: &mut EthereumSignTx| { &mut m.supports_definition_request },
         ));
         ::protobuf::reflect::GeneratedMessageDescriptorData::new_2::<EthereumSignTx>(
             "EthereumSignTx",
@@ -1378,6 +1404,9 @@ impl ::protobuf::Message for EthereumSignTx {
                 114 => {
                     ::protobuf::rt::read_singular_message_into_field(is, &mut self.payment_req)?;
                 },
+                120 => {
+                    self.supports_definition_request = ::std::option::Option::Some(is.read_bool()?);
+                },
                 tag => {
                     ::protobuf::rt::read_unknown_or_skip_group(tag, is, self.special_fields.mut_unknown_fields())?;
                 },
@@ -1431,6 +1460,9 @@ impl ::protobuf::Message for EthereumSignTx {
             let len = v.compute_size();
             my_size += 1 + ::protobuf::rt::compute_raw_varint64_size(len) + len;
         }
+        if let Some(v) = self.supports_definition_request {
+            my_size += 1 + 1;
+        }
         my_size += ::protobuf::rt::unknown_fields_size(self.special_fields.unknown_fields());
         self.special_fields.cached_size().set(my_size as u32);
         my_size
@@ -1476,6 +1508,9 @@ impl ::protobuf::Message for EthereumSignTx {
         if let Some(v) = self.payment_req.as_ref() {
             ::protobuf::rt::write_message_field_with_cached_size(14, v, os)?;
         }
+        if let Some(v) = self.supports_definition_request {
+            os.write_bool(15, v)?;
+        }
         os.write_unknown_fields(self.special_fields.unknown_fields())?;
         ::std::result::Result::Ok(())
     }
@@ -1506,6 +1541,7 @@ impl ::protobuf::Message for EthereumSignTx {
         self.definitions.clear();
         self.chunkify = ::std::option::Option::None;
         self.payment_req.clear();
+        self.supports_definition_request = ::std::option::Option::None;
         self.special_fields.clear();
     }
 
@@ -1524,6 +1560,7 @@ impl ::protobuf::Message for EthereumSignTx {
             definitions: ::protobuf::MessageField::none(),
             chunkify: ::std::option::Option::None,
             payment_req: ::protobuf::MessageField::none(),
+            supports_definition_request: ::std::option::Option::None,
             special_fields: ::protobuf::SpecialFields::new(),
         };
         &instance
@@ -1579,6 +1616,8 @@ pub struct EthereumSignTxEIP1559 {
     pub chunkify: ::std::option::Option<bool>,
     // @@protoc_insertion_point(field:hw.trezor.messages.ethereum.EthereumSignTxEIP1559.payment_req)
     pub payment_req: ::protobuf::MessageField<super::messages_common::PaymentRequest>,
+    // @@protoc_insertion_point(field:hw.trezor.messages.ethereum.EthereumSignTxEIP1559.supports_definition_request)
+    pub supports_definition_request: ::std::option::Option<bool>,
     // special fields
     // @@protoc_insertion_point(special_field:hw.trezor.messages.ethereum.EthereumSignTxEIP1559.special_fields)
     pub special_fields: ::protobuf::SpecialFields,
@@ -1904,8 +1943,27 @@ impl EthereumSignTxEIP1559 {
         self.chunkify = ::std::option::Option::Some(v);
     }
 
+    // optional bool supports_definition_request = 15;
+
+    pub fn supports_definition_request(&self) -> bool {
+        self.supports_definition_request.unwrap_or(false)
+    }
+
+    pub fn clear_supports_definition_request(&mut self) {
+        self.supports_definition_request = ::std::option::Option::None;
+    }
+
+    pub fn has_supports_definition_request(&self) -> bool {
+        self.supports_definition_request.is_some()
+    }
+
+    // Param is passed by value, moved
+    pub fn set_supports_definition_request(&mut self, v: bool) {
+        self.supports_definition_request = ::std::option::Option::Some(v);
+    }
+
     fn generated_message_descriptor_data() -> ::protobuf::reflect::GeneratedMessageDescriptorData {
-        let mut fields = ::std::vec::Vec::with_capacity(14);
+        let mut fields = ::std::vec::Vec::with_capacity(15);
         let mut oneofs = ::std::vec::Vec::with_capacity(0);
         fields.push(::protobuf::reflect::rt::v2::make_vec_simpler_accessor::<_, _>(
             "address_n",
@@ -1976,6 +2034,11 @@ impl EthereumSignTxEIP1559 {
             "payment_req",
             |m: &EthereumSignTxEIP1559| { &m.payment_req },
             |m: &mut EthereumSignTxEIP1559| { &mut m.payment_req },
+        ));
+        fields.push(::protobuf::reflect::rt::v2::make_option_accessor::<_, _>(
+            "supports_definition_request",
+            |m: &EthereumSignTxEIP1559| { &m.supports_definition_request },
+            |m: &mut EthereumSignTxEIP1559| { &mut m.supports_definition_request },
         ));
         ::protobuf::reflect::GeneratedMessageDescriptorData::new_2::<EthereumSignTxEIP1559>(
             "EthereumSignTxEIP1559",
@@ -2076,6 +2139,9 @@ impl ::protobuf::Message for EthereumSignTxEIP1559 {
                 114 => {
                     ::protobuf::rt::read_singular_message_into_field(is, &mut self.payment_req)?;
                 },
+                120 => {
+                    self.supports_definition_request = ::std::option::Option::Some(is.read_bool()?);
+                },
                 tag => {
                     ::protobuf::rt::read_unknown_or_skip_group(tag, is, self.special_fields.mut_unknown_fields())?;
                 },
@@ -2133,6 +2199,9 @@ impl ::protobuf::Message for EthereumSignTxEIP1559 {
             let len = v.compute_size();
             my_size += 1 + ::protobuf::rt::compute_raw_varint64_size(len) + len;
         }
+        if let Some(v) = self.supports_definition_request {
+            my_size += 1 + 1;
+        }
         my_size += ::protobuf::rt::unknown_fields_size(self.special_fields.unknown_fields());
         self.special_fields.cached_size().set(my_size as u32);
         my_size
@@ -2181,6 +2250,9 @@ impl ::protobuf::Message for EthereumSignTxEIP1559 {
         if let Some(v) = self.payment_req.as_ref() {
             ::protobuf::rt::write_message_field_with_cached_size(14, v, os)?;
         }
+        if let Some(v) = self.supports_definition_request {
+            os.write_bool(15, v)?;
+        }
         os.write_unknown_fields(self.special_fields.unknown_fields())?;
         ::std::result::Result::Ok(())
     }
@@ -2212,6 +2284,7 @@ impl ::protobuf::Message for EthereumSignTxEIP1559 {
         self.definitions.clear();
         self.chunkify = ::std::option::Option::None;
         self.payment_req.clear();
+        self.supports_definition_request = ::std::option::Option::None;
         self.special_fields.clear();
     }
 
@@ -2231,6 +2304,7 @@ impl ::protobuf::Message for EthereumSignTxEIP1559 {
             definitions: ::protobuf::MessageField::none(),
             chunkify: ::std::option::Option::None,
             payment_req: ::protobuf::MessageField::none(),
+            supports_definition_request: ::std::option::Option::None,
             special_fields: ::protobuf::SpecialFields::new(),
         };
         &instance
@@ -2880,6 +2954,384 @@ impl ::std::fmt::Display for EthereumTxAck {
 }
 
 impl ::protobuf::reflect::ProtobufValue for EthereumTxAck {
+    type RuntimeType = ::protobuf::reflect::rt::RuntimeTypeMessage<Self>;
+}
+
+// @@protoc_insertion_point(message:hw.trezor.messages.ethereum.EthereumDefinitionRequest)
+#[derive(PartialEq,Clone,Default,Debug)]
+pub struct EthereumDefinitionRequest {
+    // message fields
+    // @@protoc_insertion_point(field:hw.trezor.messages.ethereum.EthereumDefinitionRequest.chain_id)
+    pub chain_id: ::std::option::Option<u64>,
+    // @@protoc_insertion_point(field:hw.trezor.messages.ethereum.EthereumDefinitionRequest.token_address)
+    pub token_address: ::std::option::Option<::std::vec::Vec<u8>>,
+    // @@protoc_insertion_point(field:hw.trezor.messages.ethereum.EthereumDefinitionRequest.func_sig)
+    pub func_sig: ::std::option::Option<::std::vec::Vec<u8>>,
+    // special fields
+    // @@protoc_insertion_point(special_field:hw.trezor.messages.ethereum.EthereumDefinitionRequest.special_fields)
+    pub special_fields: ::protobuf::SpecialFields,
+}
+
+impl<'a> ::std::default::Default for &'a EthereumDefinitionRequest {
+    fn default() -> &'a EthereumDefinitionRequest {
+        <EthereumDefinitionRequest as ::protobuf::Message>::default_instance()
+    }
+}
+
+impl EthereumDefinitionRequest {
+    pub fn new() -> EthereumDefinitionRequest {
+        ::std::default::Default::default()
+    }
+
+    // required uint64 chain_id = 1;
+
+    pub fn chain_id(&self) -> u64 {
+        self.chain_id.unwrap_or(0)
+    }
+
+    pub fn clear_chain_id(&mut self) {
+        self.chain_id = ::std::option::Option::None;
+    }
+
+    pub fn has_chain_id(&self) -> bool {
+        self.chain_id.is_some()
+    }
+
+    // Param is passed by value, moved
+    pub fn set_chain_id(&mut self, v: u64) {
+        self.chain_id = ::std::option::Option::Some(v);
+    }
+
+    // required bytes token_address = 2;
+
+    pub fn token_address(&self) -> &[u8] {
+        match self.token_address.as_ref() {
+            Some(v) => v,
+            None => &[],
+        }
+    }
+
+    pub fn clear_token_address(&mut self) {
+        self.token_address = ::std::option::Option::None;
+    }
+
+    pub fn has_token_address(&self) -> bool {
+        self.token_address.is_some()
+    }
+
+    // Param is passed by value, moved
+    pub fn set_token_address(&mut self, v: ::std::vec::Vec<u8>) {
+        self.token_address = ::std::option::Option::Some(v);
+    }
+
+    // Mutable pointer to the field.
+    // If field is not initialized, it is initialized with default value first.
+    pub fn mut_token_address(&mut self) -> &mut ::std::vec::Vec<u8> {
+        if self.token_address.is_none() {
+            self.token_address = ::std::option::Option::Some(::std::vec::Vec::new());
+        }
+        self.token_address.as_mut().unwrap()
+    }
+
+    // Take field
+    pub fn take_token_address(&mut self) -> ::std::vec::Vec<u8> {
+        self.token_address.take().unwrap_or_else(|| ::std::vec::Vec::new())
+    }
+
+    // optional bytes func_sig = 3;
+
+    pub fn func_sig(&self) -> &[u8] {
+        match self.func_sig.as_ref() {
+            Some(v) => v,
+            None => &[],
+        }
+    }
+
+    pub fn clear_func_sig(&mut self) {
+        self.func_sig = ::std::option::Option::None;
+    }
+
+    pub fn has_func_sig(&self) -> bool {
+        self.func_sig.is_some()
+    }
+
+    // Param is passed by value, moved
+    pub fn set_func_sig(&mut self, v: ::std::vec::Vec<u8>) {
+        self.func_sig = ::std::option::Option::Some(v);
+    }
+
+    // Mutable pointer to the field.
+    // If field is not initialized, it is initialized with default value first.
+    pub fn mut_func_sig(&mut self) -> &mut ::std::vec::Vec<u8> {
+        if self.func_sig.is_none() {
+            self.func_sig = ::std::option::Option::Some(::std::vec::Vec::new());
+        }
+        self.func_sig.as_mut().unwrap()
+    }
+
+    // Take field
+    pub fn take_func_sig(&mut self) -> ::std::vec::Vec<u8> {
+        self.func_sig.take().unwrap_or_else(|| ::std::vec::Vec::new())
+    }
+
+    fn generated_message_descriptor_data() -> ::protobuf::reflect::GeneratedMessageDescriptorData {
+        let mut fields = ::std::vec::Vec::with_capacity(3);
+        let mut oneofs = ::std::vec::Vec::with_capacity(0);
+        fields.push(::protobuf::reflect::rt::v2::make_option_accessor::<_, _>(
+            "chain_id",
+            |m: &EthereumDefinitionRequest| { &m.chain_id },
+            |m: &mut EthereumDefinitionRequest| { &mut m.chain_id },
+        ));
+        fields.push(::protobuf::reflect::rt::v2::make_option_accessor::<_, _>(
+            "token_address",
+            |m: &EthereumDefinitionRequest| { &m.token_address },
+            |m: &mut EthereumDefinitionRequest| { &mut m.token_address },
+        ));
+        fields.push(::protobuf::reflect::rt::v2::make_option_accessor::<_, _>(
+            "func_sig",
+            |m: &EthereumDefinitionRequest| { &m.func_sig },
+            |m: &mut EthereumDefinitionRequest| { &mut m.func_sig },
+        ));
+        ::protobuf::reflect::GeneratedMessageDescriptorData::new_2::<EthereumDefinitionRequest>(
+            "EthereumDefinitionRequest",
+            fields,
+            oneofs,
+        )
+    }
+}
+
+impl ::protobuf::Message for EthereumDefinitionRequest {
+    const NAME: &'static str = "EthereumDefinitionRequest";
+
+    fn is_initialized(&self) -> bool {
+        if self.chain_id.is_none() {
+            return false;
+        }
+        if self.token_address.is_none() {
+            return false;
+        }
+        true
+    }
+
+    fn merge_from(&mut self, is: &mut ::protobuf::CodedInputStream<'_>) -> ::protobuf::Result<()> {
+        while let Some(tag) = is.read_raw_tag_or_eof()? {
+            match tag {
+                8 => {
+                    self.chain_id = ::std::option::Option::Some(is.read_uint64()?);
+                },
+                18 => {
+                    self.token_address = ::std::option::Option::Some(is.read_bytes()?);
+                },
+                26 => {
+                    self.func_sig = ::std::option::Option::Some(is.read_bytes()?);
+                },
+                tag => {
+                    ::protobuf::rt::read_unknown_or_skip_group(tag, is, self.special_fields.mut_unknown_fields())?;
+                },
+            };
+        }
+        ::std::result::Result::Ok(())
+    }
+
+    // Compute sizes of nested messages
+    #[allow(unused_variables)]
+    fn compute_size(&self) -> u64 {
+        let mut my_size = 0;
+        if let Some(v) = self.chain_id {
+            my_size += ::protobuf::rt::uint64_size(1, v);
+        }
+        if let Some(v) = self.token_address.as_ref() {
+            my_size += ::protobuf::rt::bytes_size(2, &v);
+        }
+        if let Some(v) = self.func_sig.as_ref() {
+            my_size += ::protobuf::rt::bytes_size(3, &v);
+        }
+        my_size += ::protobuf::rt::unknown_fields_size(self.special_fields.unknown_fields());
+        self.special_fields.cached_size().set(my_size as u32);
+        my_size
+    }
+
+    fn write_to_with_cached_sizes(&self, os: &mut ::protobuf::CodedOutputStream<'_>) -> ::protobuf::Result<()> {
+        if let Some(v) = self.chain_id {
+            os.write_uint64(1, v)?;
+        }
+        if let Some(v) = self.token_address.as_ref() {
+            os.write_bytes(2, v)?;
+        }
+        if let Some(v) = self.func_sig.as_ref() {
+            os.write_bytes(3, v)?;
+        }
+        os.write_unknown_fields(self.special_fields.unknown_fields())?;
+        ::std::result::Result::Ok(())
+    }
+
+    fn special_fields(&self) -> &::protobuf::SpecialFields {
+        &self.special_fields
+    }
+
+    fn mut_special_fields(&mut self) -> &mut ::protobuf::SpecialFields {
+        &mut self.special_fields
+    }
+
+    fn new() -> EthereumDefinitionRequest {
+        EthereumDefinitionRequest::new()
+    }
+
+    fn clear(&mut self) {
+        self.chain_id = ::std::option::Option::None;
+        self.token_address = ::std::option::Option::None;
+        self.func_sig = ::std::option::Option::None;
+        self.special_fields.clear();
+    }
+
+    fn default_instance() -> &'static EthereumDefinitionRequest {
+        static instance: EthereumDefinitionRequest = EthereumDefinitionRequest {
+            chain_id: ::std::option::Option::None,
+            token_address: ::std::option::Option::None,
+            func_sig: ::std::option::Option::None,
+            special_fields: ::protobuf::SpecialFields::new(),
+        };
+        &instance
+    }
+}
+
+impl ::protobuf::MessageFull for EthereumDefinitionRequest {
+    fn descriptor() -> ::protobuf::reflect::MessageDescriptor {
+        static descriptor: ::protobuf::rt::Lazy<::protobuf::reflect::MessageDescriptor> = ::protobuf::rt::Lazy::new();
+        descriptor.get(|| file_descriptor().message_by_package_relative_name("EthereumDefinitionRequest").unwrap()).clone()
+    }
+}
+
+impl ::std::fmt::Display for EthereumDefinitionRequest {
+    fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
+        ::protobuf::text_format::fmt(self, f)
+    }
+}
+
+impl ::protobuf::reflect::ProtobufValue for EthereumDefinitionRequest {
+    type RuntimeType = ::protobuf::reflect::rt::RuntimeTypeMessage<Self>;
+}
+
+// @@protoc_insertion_point(message:hw.trezor.messages.ethereum.EthereumDefinitionAck)
+#[derive(PartialEq,Clone,Default,Debug)]
+pub struct EthereumDefinitionAck {
+    // message fields
+    // @@protoc_insertion_point(field:hw.trezor.messages.ethereum.EthereumDefinitionAck.definitions)
+    pub definitions: ::protobuf::MessageField<EthereumDefinitions>,
+    // special fields
+    // @@protoc_insertion_point(special_field:hw.trezor.messages.ethereum.EthereumDefinitionAck.special_fields)
+    pub special_fields: ::protobuf::SpecialFields,
+}
+
+impl<'a> ::std::default::Default for &'a EthereumDefinitionAck {
+    fn default() -> &'a EthereumDefinitionAck {
+        <EthereumDefinitionAck as ::protobuf::Message>::default_instance()
+    }
+}
+
+impl EthereumDefinitionAck {
+    pub fn new() -> EthereumDefinitionAck {
+        ::std::default::Default::default()
+    }
+
+    fn generated_message_descriptor_data() -> ::protobuf::reflect::GeneratedMessageDescriptorData {
+        let mut fields = ::std::vec::Vec::with_capacity(1);
+        let mut oneofs = ::std::vec::Vec::with_capacity(0);
+        fields.push(::protobuf::reflect::rt::v2::make_message_field_accessor::<_, EthereumDefinitions>(
+            "definitions",
+            |m: &EthereumDefinitionAck| { &m.definitions },
+            |m: &mut EthereumDefinitionAck| { &mut m.definitions },
+        ));
+        ::protobuf::reflect::GeneratedMessageDescriptorData::new_2::<EthereumDefinitionAck>(
+            "EthereumDefinitionAck",
+            fields,
+            oneofs,
+        )
+    }
+}
+
+impl ::protobuf::Message for EthereumDefinitionAck {
+    const NAME: &'static str = "EthereumDefinitionAck";
+
+    fn is_initialized(&self) -> bool {
+        true
+    }
+
+    fn merge_from(&mut self, is: &mut ::protobuf::CodedInputStream<'_>) -> ::protobuf::Result<()> {
+        while let Some(tag) = is.read_raw_tag_or_eof()? {
+            match tag {
+                10 => {
+                    ::protobuf::rt::read_singular_message_into_field(is, &mut self.definitions)?;
+                },
+                tag => {
+                    ::protobuf::rt::read_unknown_or_skip_group(tag, is, self.special_fields.mut_unknown_fields())?;
+                },
+            };
+        }
+        ::std::result::Result::Ok(())
+    }
+
+    // Compute sizes of nested messages
+    #[allow(unused_variables)]
+    fn compute_size(&self) -> u64 {
+        let mut my_size = 0;
+        if let Some(v) = self.definitions.as_ref() {
+            let len = v.compute_size();
+            my_size += 1 + ::protobuf::rt::compute_raw_varint64_size(len) + len;
+        }
+        my_size += ::protobuf::rt::unknown_fields_size(self.special_fields.unknown_fields());
+        self.special_fields.cached_size().set(my_size as u32);
+        my_size
+    }
+
+    fn write_to_with_cached_sizes(&self, os: &mut ::protobuf::CodedOutputStream<'_>) -> ::protobuf::Result<()> {
+        if let Some(v) = self.definitions.as_ref() {
+            ::protobuf::rt::write_message_field_with_cached_size(1, v, os)?;
+        }
+        os.write_unknown_fields(self.special_fields.unknown_fields())?;
+        ::std::result::Result::Ok(())
+    }
+
+    fn special_fields(&self) -> &::protobuf::SpecialFields {
+        &self.special_fields
+    }
+
+    fn mut_special_fields(&mut self) -> &mut ::protobuf::SpecialFields {
+        &mut self.special_fields
+    }
+
+    fn new() -> EthereumDefinitionAck {
+        EthereumDefinitionAck::new()
+    }
+
+    fn clear(&mut self) {
+        self.definitions.clear();
+        self.special_fields.clear();
+    }
+
+    fn default_instance() -> &'static EthereumDefinitionAck {
+        static instance: EthereumDefinitionAck = EthereumDefinitionAck {
+            definitions: ::protobuf::MessageField::none(),
+            special_fields: ::protobuf::SpecialFields::new(),
+        };
+        &instance
+    }
+}
+
+impl ::protobuf::MessageFull for EthereumDefinitionAck {
+    fn descriptor() -> ::protobuf::reflect::MessageDescriptor {
+        static descriptor: ::protobuf::rt::Lazy<::protobuf::reflect::MessageDescriptor> = ::protobuf::rt::Lazy::new();
+        descriptor.get(|| file_descriptor().message_by_package_relative_name("EthereumDefinitionAck").unwrap()).clone()
+    }
+}
+
+impl ::std::fmt::Display for EthereumDefinitionAck {
+    fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
+        ::protobuf::text_format::fmt(self, f)
+    }
+}
+
+impl ::protobuf::reflect::ProtobufValue for EthereumDefinitionAck {
     type RuntimeType = ::protobuf::reflect::rt::RuntimeTypeMessage<Self>;
 }
 
@@ -4202,8 +4654,8 @@ pub struct EthereumDefinitions {
     pub encoded_network: ::std::option::Option<::std::vec::Vec<u8>>,
     // @@protoc_insertion_point(field:hw.trezor.messages.ethereum.EthereumDefinitions.encoded_token)
     pub encoded_token: ::std::option::Option<::std::vec::Vec<u8>>,
-    // @@protoc_insertion_point(field:hw.trezor.messages.ethereum.EthereumDefinitions.encoded_erc7730_display_format)
-    pub encoded_erc7730_display_format: ::std::option::Option<::std::vec::Vec<u8>>,
+    // @@protoc_insertion_point(field:hw.trezor.messages.ethereum.EthereumDefinitions.encoded_display_format)
+    pub encoded_display_format: ::std::option::Option<::std::vec::Vec<u8>>,
     // special fields
     // @@protoc_insertion_point(special_field:hw.trezor.messages.ethereum.EthereumDefinitions.special_fields)
     pub special_fields: ::protobuf::SpecialFields,
@@ -4292,40 +4744,40 @@ impl EthereumDefinitions {
         self.encoded_token.take().unwrap_or_else(|| ::std::vec::Vec::new())
     }
 
-    // optional bytes encoded_erc7730_display_format = 3;
+    // optional bytes encoded_display_format = 3;
 
-    pub fn encoded_erc7730_display_format(&self) -> &[u8] {
-        match self.encoded_erc7730_display_format.as_ref() {
+    pub fn encoded_display_format(&self) -> &[u8] {
+        match self.encoded_display_format.as_ref() {
             Some(v) => v,
             None => &[],
         }
     }
 
-    pub fn clear_encoded_erc7730_display_format(&mut self) {
-        self.encoded_erc7730_display_format = ::std::option::Option::None;
+    pub fn clear_encoded_display_format(&mut self) {
+        self.encoded_display_format = ::std::option::Option::None;
     }
 
-    pub fn has_encoded_erc7730_display_format(&self) -> bool {
-        self.encoded_erc7730_display_format.is_some()
+    pub fn has_encoded_display_format(&self) -> bool {
+        self.encoded_display_format.is_some()
     }
 
     // Param is passed by value, moved
-    pub fn set_encoded_erc7730_display_format(&mut self, v: ::std::vec::Vec<u8>) {
-        self.encoded_erc7730_display_format = ::std::option::Option::Some(v);
+    pub fn set_encoded_display_format(&mut self, v: ::std::vec::Vec<u8>) {
+        self.encoded_display_format = ::std::option::Option::Some(v);
     }
 
     // Mutable pointer to the field.
     // If field is not initialized, it is initialized with default value first.
-    pub fn mut_encoded_erc7730_display_format(&mut self) -> &mut ::std::vec::Vec<u8> {
-        if self.encoded_erc7730_display_format.is_none() {
-            self.encoded_erc7730_display_format = ::std::option::Option::Some(::std::vec::Vec::new());
+    pub fn mut_encoded_display_format(&mut self) -> &mut ::std::vec::Vec<u8> {
+        if self.encoded_display_format.is_none() {
+            self.encoded_display_format = ::std::option::Option::Some(::std::vec::Vec::new());
         }
-        self.encoded_erc7730_display_format.as_mut().unwrap()
+        self.encoded_display_format.as_mut().unwrap()
     }
 
     // Take field
-    pub fn take_encoded_erc7730_display_format(&mut self) -> ::std::vec::Vec<u8> {
-        self.encoded_erc7730_display_format.take().unwrap_or_else(|| ::std::vec::Vec::new())
+    pub fn take_encoded_display_format(&mut self) -> ::std::vec::Vec<u8> {
+        self.encoded_display_format.take().unwrap_or_else(|| ::std::vec::Vec::new())
     }
 
     fn generated_message_descriptor_data() -> ::protobuf::reflect::GeneratedMessageDescriptorData {
@@ -4342,9 +4794,9 @@ impl EthereumDefinitions {
             |m: &mut EthereumDefinitions| { &mut m.encoded_token },
         ));
         fields.push(::protobuf::reflect::rt::v2::make_option_accessor::<_, _>(
-            "encoded_erc7730_display_format",
-            |m: &EthereumDefinitions| { &m.encoded_erc7730_display_format },
-            |m: &mut EthereumDefinitions| { &mut m.encoded_erc7730_display_format },
+            "encoded_display_format",
+            |m: &EthereumDefinitions| { &m.encoded_display_format },
+            |m: &mut EthereumDefinitions| { &mut m.encoded_display_format },
         ));
         ::protobuf::reflect::GeneratedMessageDescriptorData::new_2::<EthereumDefinitions>(
             "EthereumDefinitions",
@@ -4371,7 +4823,7 @@ impl ::protobuf::Message for EthereumDefinitions {
                     self.encoded_token = ::std::option::Option::Some(is.read_bytes()?);
                 },
                 26 => {
-                    self.encoded_erc7730_display_format = ::std::option::Option::Some(is.read_bytes()?);
+                    self.encoded_display_format = ::std::option::Option::Some(is.read_bytes()?);
                 },
                 tag => {
                     ::protobuf::rt::read_unknown_or_skip_group(tag, is, self.special_fields.mut_unknown_fields())?;
@@ -4391,7 +4843,7 @@ impl ::protobuf::Message for EthereumDefinitions {
         if let Some(v) = self.encoded_token.as_ref() {
             my_size += ::protobuf::rt::bytes_size(2, &v);
         }
-        if let Some(v) = self.encoded_erc7730_display_format.as_ref() {
+        if let Some(v) = self.encoded_display_format.as_ref() {
             my_size += ::protobuf::rt::bytes_size(3, &v);
         }
         my_size += ::protobuf::rt::unknown_fields_size(self.special_fields.unknown_fields());
@@ -4406,7 +4858,7 @@ impl ::protobuf::Message for EthereumDefinitions {
         if let Some(v) = self.encoded_token.as_ref() {
             os.write_bytes(2, v)?;
         }
-        if let Some(v) = self.encoded_erc7730_display_format.as_ref() {
+        if let Some(v) = self.encoded_display_format.as_ref() {
             os.write_bytes(3, v)?;
         }
         os.write_unknown_fields(self.special_fields.unknown_fields())?;
@@ -4428,7 +4880,7 @@ impl ::protobuf::Message for EthereumDefinitions {
     fn clear(&mut self) {
         self.encoded_network = ::std::option::Option::None;
         self.encoded_token = ::std::option::Option::None;
-        self.encoded_erc7730_display_format = ::std::option::Option::None;
+        self.encoded_display_format = ::std::option::Option::None;
         self.special_fields.clear();
     }
 
@@ -4436,7 +4888,7 @@ impl ::protobuf::Message for EthereumDefinitions {
         static instance: EthereumDefinitions = EthereumDefinitions {
             encoded_network: ::std::option::Option::None,
             encoded_token: ::std::option::Option::None,
-            encoded_erc7730_display_format: ::std::option::Option::None,
+            encoded_display_format: ::std::option::Option::None,
             special_fields: ::protobuf::SpecialFields::new(),
         };
         &instance
@@ -4473,7 +4925,7 @@ static file_descriptor_proto_data: &'static [u8] = b"\
     \x01(\x08R\x08chunkify\"c\n\x0fEthereumAddress\x12$\n\x0c_old_address\
     \x18\x01\x20\x01(\x0cR\nOldAddressB\x02\x18\x01\x12\x18\n\x07address\x18\
     \x02\x20\x01(\tR\x07address\x12\x10\n\x03mac\x18\x03\x20\x01(\x0cR\x03ma\
-    c\"\xed\x03\n\x0eEthereumSignTx\x12\x1b\n\taddress_n\x18\x01\x20\x03(\rR\
+    c\"\xad\x04\n\x0eEthereumSignTx\x12\x1b\n\taddress_n\x18\x01\x20\x03(\rR\
     \x08addressN\x12\x16\n\x05nonce\x18\x02\x20\x01(\x0c:\0R\x05nonce\x12\
     \x1b\n\tgas_price\x18\x03\x20\x02(\x0cR\x08gasPrice\x12\x1b\n\tgas_limit\
     \x18\x04\x20\x02(\x0cR\x08gasLimit\x12\x10\n\x02to\x18\x0b\x20\x01(\t:\0\
@@ -4484,48 +4936,55 @@ static file_descriptor_proto_data: &'static [u8] = b"\
     R\x06txType\x12R\n\x0bdefinitions\x18\x0c\x20\x01(\x0b20.hw.trezor.messa\
     ges.ethereum.EthereumDefinitionsR\x0bdefinitions\x12\x1a\n\x08chunkify\
     \x18\r\x20\x01(\x08R\x08chunkify\x12J\n\x0bpayment_req\x18\x0e\x20\x01(\
-    \x0b2).hw.trezor.messages.common.PaymentRequestR\npaymentReq\"\xbc\x05\n\
-    \x15EthereumSignTxEIP1559\x12\x1b\n\taddress_n\x18\x01\x20\x03(\rR\x08ad\
-    dressN\x12\x14\n\x05nonce\x18\x02\x20\x02(\x0cR\x05nonce\x12\x1e\n\x0bma\
-    x_gas_fee\x18\x03\x20\x02(\x0cR\tmaxGasFee\x12(\n\x10max_priority_fee\
-    \x18\x04\x20\x02(\x0cR\x0emaxPriorityFee\x12\x1b\n\tgas_limit\x18\x05\
-    \x20\x02(\x0cR\x08gasLimit\x12\x10\n\x02to\x18\x06\x20\x01(\t:\0R\x02to\
-    \x12\x14\n\x05value\x18\x07\x20\x02(\x0cR\x05value\x12.\n\x12data_initia\
-    l_chunk\x18\x08\x20\x01(\x0c:\0R\x10dataInitialChunk\x12\x1f\n\x0bdata_l\
-    ength\x18\t\x20\x02(\rR\ndataLength\x12\x19\n\x08chain_id\x18\n\x20\x02(\
-    \x04R\x07chainId\x12f\n\x0baccess_list\x18\x0b\x20\x03(\x0b2E.hw.trezor.\
-    messages.ethereum.EthereumSignTxEIP1559.EthereumAccessListR\naccessList\
-    \x12R\n\x0bdefinitions\x18\x0c\x20\x01(\x0b20.hw.trezor.messages.ethereu\
-    m.EthereumDefinitionsR\x0bdefinitions\x12\x1a\n\x08chunkify\x18\r\x20\
-    \x01(\x08R\x08chunkify\x12J\n\x0bpayment_req\x18\x0e\x20\x01(\x0b2).hw.t\
-    rezor.messages.common.PaymentRequestR\npaymentReq\x1aQ\n\x12EthereumAcce\
-    ssList\x12\x18\n\x07address\x18\x01\x20\x02(\tR\x07address\x12!\n\x0csto\
-    rage_keys\x18\x02\x20\x03(\x0cR\x0bstorageKeys\"\x97\x01\n\x11EthereumTx\
-    Request\x12\x1f\n\x0bdata_length\x18\x01\x20\x01(\rR\ndataLength\x12\x1f\
-    \n\x0bsignature_v\x18\x02\x20\x01(\rR\nsignatureV\x12\x1f\n\x0bsignature\
-    _r\x18\x03\x20\x01(\x0cR\nsignatureR\x12\x1f\n\x0bsignature_s\x18\x04\
-    \x20\x01(\x0cR\nsignatureS\".\n\rEthereumTxAck\x12\x1d\n\ndata_chunk\x18\
-    \x01\x20\x02(\x0cR\tdataChunk\"\x91\x01\n\x13EthereumSignMessage\x12\x1b\
-    \n\taddress_n\x18\x01\x20\x03(\rR\x08addressN\x12\x18\n\x07message\x18\
-    \x02\x20\x02(\x0cR\x07message\x12'\n\x0fencoded_network\x18\x03\x20\x01(\
-    \x0cR\x0eencodedNetwork\x12\x1a\n\x08chunkify\x18\x04\x20\x01(\x08R\x08c\
-    hunkify\"R\n\x18EthereumMessageSignature\x12\x1c\n\tsignature\x18\x02\
-    \x20\x02(\x0cR\tsignature\x12\x18\n\x07address\x18\x03\x20\x02(\tR\x07ad\
-    dress\"\x85\x01\n\x15EthereumVerifyMessage\x12\x1c\n\tsignature\x18\x02\
-    \x20\x02(\x0cR\tsignature\x12\x18\n\x07message\x18\x03\x20\x02(\x0cR\x07\
-    message\x12\x18\n\x07address\x18\x04\x20\x02(\tR\x07address\x12\x1a\n\
-    \x08chunkify\x18\x05\x20\x01(\x08R\x08chunkify\"\xb4\x01\n\x15EthereumSi\
-    gnTypedHash\x12\x1b\n\taddress_n\x18\x01\x20\x03(\rR\x08addressN\x122\n\
-    \x15domain_separator_hash\x18\x02\x20\x02(\x0cR\x13domainSeparatorHash\
-    \x12!\n\x0cmessage_hash\x18\x03\x20\x01(\x0cR\x0bmessageHash\x12'\n\x0fe\
-    ncoded_network\x18\x04\x20\x01(\x0cR\x0eencodedNetwork\"T\n\x1aEthereumT\
-    ypedDataSignature\x12\x1c\n\tsignature\x18\x01\x20\x02(\x0cR\tsignature\
-    \x12\x18\n\x07address\x18\x02\x20\x02(\tR\x07address\"\xa8\x01\n\x13Ethe\
-    reumDefinitions\x12'\n\x0fencoded_network\x18\x01\x20\x01(\x0cR\x0eencod\
-    edNetwork\x12#\n\rencoded_token\x18\x02\x20\x01(\x0cR\x0cencodedToken\
-    \x12C\n\x1eencoded_erc7730_display_format\x18\x03\x20\x01(\x0cR\x1bencod\
-    edErc7730DisplayFormatB<\n#com.satoshilabs.trezor.lib.protobufB\x15Trezo\
-    rMessageEthereum\
+    \x0b2).hw.trezor.messages.common.PaymentRequestR\npaymentReq\x12>\n\x1bs\
+    upports_definition_request\x18\x0f\x20\x01(\x08R\x19supportsDefinitionRe\
+    quest\"\xfc\x05\n\x15EthereumSignTxEIP1559\x12\x1b\n\taddress_n\x18\x01\
+    \x20\x03(\rR\x08addressN\x12\x14\n\x05nonce\x18\x02\x20\x02(\x0cR\x05non\
+    ce\x12\x1e\n\x0bmax_gas_fee\x18\x03\x20\x02(\x0cR\tmaxGasFee\x12(\n\x10m\
+    ax_priority_fee\x18\x04\x20\x02(\x0cR\x0emaxPriorityFee\x12\x1b\n\tgas_l\
+    imit\x18\x05\x20\x02(\x0cR\x08gasLimit\x12\x10\n\x02to\x18\x06\x20\x01(\
+    \t:\0R\x02to\x12\x14\n\x05value\x18\x07\x20\x02(\x0cR\x05value\x12.\n\
+    \x12data_initial_chunk\x18\x08\x20\x01(\x0c:\0R\x10dataInitialChunk\x12\
+    \x1f\n\x0bdata_length\x18\t\x20\x02(\rR\ndataLength\x12\x19\n\x08chain_i\
+    d\x18\n\x20\x02(\x04R\x07chainId\x12f\n\x0baccess_list\x18\x0b\x20\x03(\
+    \x0b2E.hw.trezor.messages.ethereum.EthereumSignTxEIP1559.EthereumAccessL\
+    istR\naccessList\x12R\n\x0bdefinitions\x18\x0c\x20\x01(\x0b20.hw.trezor.\
+    messages.ethereum.EthereumDefinitionsR\x0bdefinitions\x12\x1a\n\x08chunk\
+    ify\x18\r\x20\x01(\x08R\x08chunkify\x12J\n\x0bpayment_req\x18\x0e\x20\
+    \x01(\x0b2).hw.trezor.messages.common.PaymentRequestR\npaymentReq\x12>\n\
+    \x1bsupports_definition_request\x18\x0f\x20\x01(\x08R\x19supportsDefinit\
+    ionRequest\x1aQ\n\x12EthereumAccessList\x12\x18\n\x07address\x18\x01\x20\
+    \x02(\tR\x07address\x12!\n\x0cstorage_keys\x18\x02\x20\x03(\x0cR\x0bstor\
+    ageKeys\"\x97\x01\n\x11EthereumTxRequest\x12\x1f\n\x0bdata_length\x18\
+    \x01\x20\x01(\rR\ndataLength\x12\x1f\n\x0bsignature_v\x18\x02\x20\x01(\r\
+    R\nsignatureV\x12\x1f\n\x0bsignature_r\x18\x03\x20\x01(\x0cR\nsignatureR\
+    \x12\x1f\n\x0bsignature_s\x18\x04\x20\x01(\x0cR\nsignatureS\".\n\rEthere\
+    umTxAck\x12\x1d\n\ndata_chunk\x18\x01\x20\x02(\x0cR\tdataChunk\"v\n\x19E\
+    thereumDefinitionRequest\x12\x19\n\x08chain_id\x18\x01\x20\x02(\x04R\x07\
+    chainId\x12#\n\rtoken_address\x18\x02\x20\x02(\x0cR\x0ctokenAddress\x12\
+    \x19\n\x08func_sig\x18\x03\x20\x01(\x0cR\x07funcSig\"k\n\x15EthereumDefi\
+    nitionAck\x12R\n\x0bdefinitions\x18\x01\x20\x01(\x0b20.hw.trezor.message\
+    s.ethereum.EthereumDefinitionsR\x0bdefinitions\"\x91\x01\n\x13EthereumSi\
+    gnMessage\x12\x1b\n\taddress_n\x18\x01\x20\x03(\rR\x08addressN\x12\x18\n\
+    \x07message\x18\x02\x20\x02(\x0cR\x07message\x12'\n\x0fencoded_network\
+    \x18\x03\x20\x01(\x0cR\x0eencodedNetwork\x12\x1a\n\x08chunkify\x18\x04\
+    \x20\x01(\x08R\x08chunkify\"R\n\x18EthereumMessageSignature\x12\x1c\n\ts\
+    ignature\x18\x02\x20\x02(\x0cR\tsignature\x12\x18\n\x07address\x18\x03\
+    \x20\x02(\tR\x07address\"\x85\x01\n\x15EthereumVerifyMessage\x12\x1c\n\t\
+    signature\x18\x02\x20\x02(\x0cR\tsignature\x12\x18\n\x07message\x18\x03\
+    \x20\x02(\x0cR\x07message\x12\x18\n\x07address\x18\x04\x20\x02(\tR\x07ad\
+    dress\x12\x1a\n\x08chunkify\x18\x05\x20\x01(\x08R\x08chunkify\"\xb4\x01\
+    \n\x15EthereumSignTypedHash\x12\x1b\n\taddress_n\x18\x01\x20\x03(\rR\x08\
+    addressN\x122\n\x15domain_separator_hash\x18\x02\x20\x02(\x0cR\x13domain\
+    SeparatorHash\x12!\n\x0cmessage_hash\x18\x03\x20\x01(\x0cR\x0bmessageHas\
+    h\x12'\n\x0fencoded_network\x18\x04\x20\x01(\x0cR\x0eencodedNetwork\"T\n\
+    \x1aEthereumTypedDataSignature\x12\x1c\n\tsignature\x18\x01\x20\x02(\x0c\
+    R\tsignature\x12\x18\n\x07address\x18\x02\x20\x02(\tR\x07address\"\x99\
+    \x01\n\x13EthereumDefinitions\x12'\n\x0fencoded_network\x18\x01\x20\x01(\
+    \x0cR\x0eencodedNetwork\x12#\n\rencoded_token\x18\x02\x20\x01(\x0cR\x0ce\
+    ncodedToken\x124\n\x16encoded_display_format\x18\x03\x20\x01(\x0cR\x14en\
+    codedDisplayFormatB<\n#com.satoshilabs.trezor.lib.protobufB\x15TrezorMes\
+    sageEthereum\
 ";
 
 /// `FileDescriptorProto` object which was a source for this generated file
@@ -4544,7 +5003,7 @@ pub fn file_descriptor() -> &'static ::protobuf::reflect::FileDescriptor {
         let generated_file_descriptor = generated_file_descriptor_lazy.get(|| {
             let mut deps = ::std::vec::Vec::with_capacity(1);
             deps.push(super::messages_common::file_descriptor().clone());
-            let mut messages = ::std::vec::Vec::with_capacity(15);
+            let mut messages = ::std::vec::Vec::with_capacity(17);
             messages.push(EthereumGetPublicKey::generated_message_descriptor_data());
             messages.push(EthereumPublicKey::generated_message_descriptor_data());
             messages.push(EthereumGetAddress::generated_message_descriptor_data());
@@ -4553,6 +5012,8 @@ pub fn file_descriptor() -> &'static ::protobuf::reflect::FileDescriptor {
             messages.push(EthereumSignTxEIP1559::generated_message_descriptor_data());
             messages.push(EthereumTxRequest::generated_message_descriptor_data());
             messages.push(EthereumTxAck::generated_message_descriptor_data());
+            messages.push(EthereumDefinitionRequest::generated_message_descriptor_data());
+            messages.push(EthereumDefinitionAck::generated_message_descriptor_data());
             messages.push(EthereumSignMessage::generated_message_descriptor_data());
             messages.push(EthereumMessageSignature::generated_message_descriptor_data());
             messages.push(EthereumVerifyMessage::generated_message_descriptor_data());

--- a/tests/definitions.py
+++ b/tests/definitions.py
@@ -160,7 +160,7 @@ def encode_solana_token(
     return payload + proof + signature
 
 
-def make_eth_erc7730_display_format(
+def make_eth_display_format(
     chain_id: int = 0,
     address: t.AnyStr = b"",
     func_sig: bytes = b"",
@@ -184,7 +184,7 @@ def make_eth_erc7730_display_format(
     )
 
 
-def encode_eth_erc7730_display_format(
+def encode_eth_display_format(
     display_format: messages.EthereumDisplayFormatInfo,
 ) -> bytes:
     payload = make_payload(

--- a/tests/device_tests/ethereum/test_definitions.py
+++ b/tests/device_tests/ethereum/test_definitions.py
@@ -436,7 +436,7 @@ def _sign_tx_with_display_format(
             session,
             **sign_tx_params,
             definitions=messages.EthereumDefinitions(
-                encoded_erc7730_display_format=definitions.encode_eth_erc7730_display_format(
+                encoded_display_format=definitions.encode_eth_display_format(
                     display_format
                 ),
                 encoded_token=(

--- a/tests/device_tests/ethereum/test_definitions.py
+++ b/tests/device_tests/ethereum/test_definitions.py
@@ -335,6 +335,7 @@ UNISWAP_WETH_WETH2_CALLDATA = bytes.fromhex(
 
 def get_clear_signing_sign_tx_params(
     data: bytes = UNISWAP_EXACT_INPUT_SINGLE_CALLDATA,
+    supports_definition_request: bool = False,
 ) -> dict:
     return dict(
         n=parse_path("m/44h/60h/0h/0/1"),
@@ -345,12 +346,31 @@ def get_clear_signing_sign_tx_params(
         value=0x0,
         data=data,
         chain_id=1,
+        supports_definition_request=supports_definition_request,
+    )
+
+
+def get_clear_signing_sign_tx_eip1559_params(
+    data: bytes = UNISWAP_EXACT_INPUT_SINGLE_CALLDATA,
+    supports_definition_request: bool = False,
+) -> dict:
+    return dict(
+        n=parse_path("m/44h/60h/0h/0/1"),
+        nonce=0x0,
+        max_gas_fee=0x14,
+        gas_limit=0x14,
+        max_priority_fee=0x14,
+        to=UNISWAP_V3_ROUTER2,
+        value=0x0,
+        data=data,
+        chain_id=1,
+        supports_definition_request=supports_definition_request,
     )
 
 
 # ERC-7730 display format for Uniswap V3 `exactInputSingle`.
 # `exactInputSingle` takes one struct parameter with 7 fields.
-UNISWAP_EXACT_INPUT_SINGLE_DISPLAY_FORMAT = definitions.make_eth_erc7730_display_format(
+UNISWAP_EXACT_INPUT_SINGLE_DISPLAY_FORMAT = definitions.make_eth_display_format(
     chain_id=1,
     address=UNISWAP_V3_ROUTER2,
     func_sig=FUNC_SIG_FAKE,
@@ -446,7 +466,7 @@ def _sign_tx_with_display_format(
         )
 
 
-def _make_label_checker(
+def make_label_checker(
     expected: set[str] | None = None,
     absent: set[str] | None = None,
 ) -> tuple[Callable, Callable[[], None]]:
@@ -473,7 +493,7 @@ def _make_label_checker(
 @pytest.mark.models("core")
 def test_clear_signing_with_definition_and_token(session: Session) -> None:
     # With WETH provided, TokenAmountFormatter can resolve the token symbol.
-    on_page, assert_all_seen = _make_label_checker(
+    on_page, assert_all_seen = make_label_checker(
         expected=UNISWAP_EXACT_INPUT_SINGLE_DISPLAY_FORMAT_LABELS | {"FAKE WETH"},
         absent={"UNKN"},
     )
@@ -491,7 +511,7 @@ def test_clear_signing_builtin_token_no_override(session: Session) -> None:
     # With USDT (tokenOut) provided as encoded_token.
     # Note however that we still render it as "USDT" (built in token)
     # rather than "FAKE USDT"!
-    on_page, assert_all_seen = _make_label_checker(
+    on_page, assert_all_seen = make_label_checker(
         expected=UNISWAP_EXACT_INPUT_SINGLE_DISPLAY_FORMAT_LABELS | {"UNKN"},
         absent={"FAKE USDT"},
     )
@@ -507,7 +527,7 @@ def test_clear_signing_builtin_token_no_override(session: Session) -> None:
 @pytest.mark.models("core")
 def test_clear_signing_without_token(session: Session) -> None:
     # Without token definitions, amounts are shown as UNKNOWN tokens.
-    on_page, assert_all_seen = _make_label_checker(
+    on_page, assert_all_seen = make_label_checker(
         expected=(UNISWAP_EXACT_INPUT_SINGLE_DISPLAY_FORMAT_LABELS | {"UNKN"}),
         absent={"WETH", "USDT"},
     )
@@ -524,7 +544,7 @@ def test_clear_signing_without_token(session: Session) -> None:
 def test_clear_signing_with_definition_without_token(session: Session) -> None:
     # Without a token definition, amounts are shown as UNKNOWN token
     # (but builtin USDT is resolved).
-    on_page, assert_all_seen = _make_label_checker(
+    on_page, assert_all_seen = make_label_checker(
         expected=(UNISWAP_EXACT_INPUT_SINGLE_DISPLAY_FORMAT_LABELS | {"UNKN", "USDT"}),
         absent={"WETH"},
     )
@@ -554,7 +574,7 @@ def test_clear_signing_with_mismatched_definition(session: Session) -> None:
         ],
         is_dynamic=False,
     )
-    bad_display_format = definitions.make_eth_erc7730_display_format(
+    bad_display_format = definitions.make_eth_display_format(
         chain_id=UNISWAP_EXACT_INPUT_SINGLE_DISPLAY_FORMAT.chain_id,
         address=UNISWAP_EXACT_INPUT_SINGLE_DISPLAY_FORMAT.address,
         func_sig=UNISWAP_EXACT_INPUT_SINGLE_DISPLAY_FORMAT.func_sig,
@@ -564,7 +584,7 @@ def test_clear_signing_with_mismatched_definition(session: Session) -> None:
             UNISWAP_EXACT_INPUT_SINGLE_DISPLAY_FORMAT.field_definitions
         ),
     )
-    on_page, assert_all_seen = _make_label_checker(
+    on_page, assert_all_seen = make_label_checker(
         absent=(
             UNISWAP_EXACT_INPUT_SINGLE_DISPLAY_FORMAT_LABELS | {"UNKN", "WETH", "USDT"}
         )

--- a/tests/device_tests/ethereum/test_definitions_bad.py
+++ b/tests/device_tests/ethereum/test_definitions_bad.py
@@ -11,7 +11,7 @@ from trezorlib.messages import DefinitionType
 from trezorlib.tools import parse_path
 
 from ...definitions import (
-    make_eth_erc7730_display_format,
+    make_eth_display_format,
     make_eth_network,
     make_eth_token,
     make_payload,
@@ -47,17 +47,42 @@ def _fails_token(session: Session, token: bytes, match: str) -> None:
         )
 
 
-def _fails_erc7730_display_format(
-    session: Session, erc7730_display_format: bytes, match: str
-) -> None:
+def _fails_display_format(session: Session, display_format: bytes, match: str) -> None:
     with pytest.raises(TrezorFailure, match=match):
         ethereum.sign_tx(
             session,
             **get_clear_signing_sign_tx_params(),
             definitions=messages.EthereumDefinitions(
-                encoded_erc7730_display_format=erc7730_display_format,
+                encoded_display_format=display_format,
             ),
         )
+
+
+def _fails_display_format_via_request(
+    session: Session, display_format: bytes, match: str
+) -> None:
+    calls: list[messages.EthereumDefinitionRequest] = []
+
+    def provider(
+        req: messages.EthereumDefinitionRequest,
+    ) -> messages.EthereumDefinitionAck:
+        calls.append(req)
+        return messages.EthereumDefinitionAck(
+            definitions=messages.EthereumDefinitions(
+                encoded_display_format=display_format,
+            )
+        )
+
+    with pytest.raises(TrezorFailure, match=match):
+        ethereum.sign_tx(
+            session,
+            **get_clear_signing_sign_tx_params(supports_definition_request=True),
+            definition_provider=provider,
+        )
+
+    # Firmware requests the display format once then fails validation. No token requests follow.
+    assert len(calls) == 1
+    assert calls[0].func_sig is not None
 
 
 def _make_token_payload(
@@ -76,7 +101,7 @@ def _make_display_format_payload(
     message: messages.EthereumDisplayFormatInfo | bytes | None = None,
 ) -> bytes:
     if message is None:
-        message = make_eth_erc7730_display_format()
+        message = make_eth_display_format()
     return make_payload(
         data_type=DefinitionType.ETHEREUM_DISPLAY_FORMAT,
         message=message,
@@ -90,7 +115,8 @@ def _cases(session: Session) -> list[tuple]:
         (_make_token_payload, _fails_token),
     ]
     if session.model in models.CORE_MODELS:
-        cases.append((_make_display_format_payload, _fails_erc7730_display_format))
+        cases.append((_make_display_format_payload, _fails_display_format))
+        cases.append((_make_display_format_payload, _fails_display_format_via_request))
     return cases
 
 
@@ -170,23 +196,33 @@ def test_bad_type(session: Session) -> None:
         cases += [
             (
                 DefinitionType.ETHEREUM_DISPLAY_FORMAT,
-                make_eth_erc7730_display_format(),
+                make_eth_display_format(),
                 _fails_network,
             ),
             (
                 DefinitionType.ETHEREUM_DISPLAY_FORMAT,
-                make_eth_erc7730_display_format(),
+                make_eth_display_format(),
                 _fails_token,
             ),
             (
                 DefinitionType.ETHEREUM_TOKEN,
                 make_eth_token(),
-                _fails_erc7730_display_format,
+                _fails_display_format,
             ),
             (
                 DefinitionType.ETHEREUM_NETWORK,
                 make_eth_network(),
-                _fails_erc7730_display_format,
+                _fails_display_format,
+            ),
+            (
+                DefinitionType.ETHEREUM_TOKEN,
+                make_eth_token(),
+                _fails_display_format_via_request,
+            ),
+            (
+                DefinitionType.ETHEREUM_NETWORK,
+                make_eth_network(),
+                _fails_display_format_via_request,
             ),
         ]
     for data_type, message, check in cases:
@@ -218,23 +254,33 @@ def test_protobuf_mismatch(session: Session) -> None:
         cases += [
             (
                 DefinitionType.ETHEREUM_NETWORK,
-                make_eth_erc7730_display_format(),
+                make_eth_display_format(),
                 _fails_network,
             ),
             (
                 DefinitionType.ETHEREUM_TOKEN,
-                make_eth_erc7730_display_format(),
+                make_eth_display_format(),
                 _fails_token,
             ),
             (
                 DefinitionType.ETHEREUM_DISPLAY_FORMAT,
                 make_eth_token(),
-                _fails_erc7730_display_format,
+                _fails_display_format,
             ),
             (
                 DefinitionType.ETHEREUM_DISPLAY_FORMAT,
                 make_eth_network(),
-                _fails_erc7730_display_format,
+                _fails_display_format,
+            ),
+            (
+                DefinitionType.ETHEREUM_DISPLAY_FORMAT,
+                make_eth_token(),
+                _fails_display_format_via_request,
+            ),
+            (
+                DefinitionType.ETHEREUM_DISPLAY_FORMAT,
+                make_eth_network(),
+                _fails_display_format_via_request,
             ),
         ]
     for data_type, message, check in cases:

--- a/tests/device_tests/ethereum/test_definitions_request.py
+++ b/tests/device_tests/ethereum/test_definitions_request.py
@@ -1,0 +1,284 @@
+from __future__ import annotations
+
+from binascii import hexlify
+from typing import Callable
+
+import pytest
+
+from trezorlib import ethereum, messages
+from trezorlib.debuglink import DebugSession as Session
+
+from ... import definitions
+from ...input_flows import InputFlowConfirmAllWarnings
+from .test_definitions import (
+    FUNC_SIG_FAKE,
+    UNISWAP_EXACT_INPUT_SINGLE_DISPLAY_FORMAT,
+    UNISWAP_EXACT_INPUT_SINGLE_DISPLAY_FORMAT_LABELS,
+    UNISWAP_V3_ROUTER2,
+    UNISWAP_WETH_WETH2_CALLDATA,
+    WETH2_TOKEN_DEFINITION,
+    WETH_TOKEN_DEFINITION,
+    get_clear_signing_sign_tx_eip1559_params,
+    get_clear_signing_sign_tx_params,
+    make_label_checker,
+)
+
+pytestmark = [pytest.mark.altcoin, pytest.mark.ethereum, pytest.mark.models("core")]
+
+
+def _make_display_format_definition_provider(
+    display_format_requests: list,
+    token_requests: list,
+    display_format_info: messages.EthereumDisplayFormatInfo,
+    token_definitions: dict[str, dict] | None = None,
+) -> Callable[[messages.EthereumDefinitionRequest], messages.EthereumDefinitionAck]:
+    if token_definitions is None:
+        token_definitions = {
+            WETH_TOKEN_DEFINITION["address"][2:].lower(): WETH_TOKEN_DEFINITION
+        }
+
+    def provider(
+        req: messages.EthereumDefinitionRequest,
+    ) -> messages.EthereumDefinitionAck:
+        if not req.func_sig:
+            # No func_sig means the firmware is requesting a token/network definition
+            # only (e.g. from `TokenAmountFormatter` during field formatting).
+            token_requests.append(req)
+            addr = hexlify(req.token_address).decode("ascii").lower()
+            token_def = token_definitions.get(addr)
+            assert token_def is not None, f"Unexpected token request for {addr}"
+            assert req.chain_id == token_def["chain_id"]
+
+            return messages.EthereumDefinitionAck(
+                definitions=messages.EthereumDefinitions(
+                    encoded_network=definitions.encode_eth_network(
+                        chain_id=token_def["chain_id"]
+                    ),
+                    encoded_token=definitions.encode_eth_token(**token_def),
+                ),
+            )
+        else:  # Display format was requested.
+            display_format_requests.append(req)
+            return messages.EthereumDefinitionAck(
+                definitions=messages.EthereumDefinitions(
+                    encoded_display_format=definitions.encode_eth_display_format(
+                        display_format_info
+                    )
+                ),
+            )
+
+    return provider
+
+
+def test_definition_request_sent(session: Session) -> None:
+    # When clear signing data is present the firmware requests a display format
+    # mid-flow via EthereumDefinitionRequest (if the host signaled that it supports that).
+    # Verify it is called with the right fields and that signing completes
+    # without clear signing when we reply with no definition.
+
+    def provider(
+        req: messages.EthereumDefinitionRequest,
+    ) -> messages.EthereumDefinitionAck:
+        definition_requests.append(req)
+        return messages.EthereumDefinitionAck(definitions=None)
+
+    for sign_tx, param_getter in [
+        (ethereum.sign_tx, get_clear_signing_sign_tx_params),
+        (ethereum.sign_tx_eip1559, get_clear_signing_sign_tx_eip1559_params),
+    ]:
+        on_page, assert_all_seen = make_label_checker(
+            expected=set(),
+            absent=UNISWAP_EXACT_INPUT_SINGLE_DISPLAY_FORMAT_LABELS
+            | {"WETH", "USDT", "UNKN"},
+        )
+
+        definition_requests: list[messages.EthereumDefinitionRequest] = []
+        with session.test_ctx as client:
+            if not session.debug.legacy_debug:
+                client.set_input_flow(
+                    InputFlowConfirmAllWarnings(session, on_page=on_page).get()
+                )
+            sign_tx(
+                session,
+                **param_getter(supports_definition_request=True),
+                definition_provider=provider,
+            )
+
+        assert len(definition_requests) == 1
+        req = definition_requests[0]
+        assert req.chain_id == 1
+        assert req.token_address == bytes.fromhex(UNISWAP_V3_ROUTER2[2:].lower())
+        assert req.func_sig == FUNC_SIG_FAKE
+
+        assert_all_seen()
+
+
+def test_definition_request_not_sent(session: Session) -> None:
+    # When clear signing data is present the firmware does not request a display format
+    # mid-flow via EthereumDefinitionRequest if the host did not signal that it supports that.
+
+    def provider(
+        req: messages.EthereumDefinitionRequest,
+    ) -> messages.EthereumDefinitionAck:
+        definition_requests.append(req)
+        return messages.EthereumDefinitionAck(definitions=None)
+
+    for sign_tx, param_getter in [
+        (ethereum.sign_tx, get_clear_signing_sign_tx_params),
+        (ethereum.sign_tx_eip1559, get_clear_signing_sign_tx_eip1559_params),
+    ]:
+        on_page, assert_all_seen = make_label_checker(
+            expected=set(),
+            absent=UNISWAP_EXACT_INPUT_SINGLE_DISPLAY_FORMAT_LABELS
+            | {"WETH", "USDT", "UNKN"},
+        )
+
+        definition_requests: list[messages.EthereumDefinitionRequest] = []
+        with session.test_ctx as client:
+            if not session.debug.legacy_debug:
+                client.set_input_flow(
+                    InputFlowConfirmAllWarnings(session, on_page=on_page).get()
+                )
+            sign_tx(
+                session,
+                **param_getter(supports_definition_request=False),
+                definition_provider=provider,
+            )
+
+        assert len(definition_requests) == 0
+
+        assert_all_seen()
+
+
+def test_definition_request_with_display_format(session: Session) -> None:
+    # When we reply to EthereumDefinitionRequest with a valid display format,
+    # the firmware performs clear signing using the provided display format.
+
+    for sign_tx, param_getter in [
+        (ethereum.sign_tx, get_clear_signing_sign_tx_params),
+        (ethereum.sign_tx_eip1559, get_clear_signing_sign_tx_eip1559_params),
+    ]:
+        on_page, assert_all_seen = make_label_checker(
+            expected=UNISWAP_EXACT_INPUT_SINGLE_DISPLAY_FORMAT_LABELS
+            | {"FAKE WETH", "USDT"},
+            absent={"UNKN"},
+        )
+
+        display_format_requests: list[messages.EthereumDefinitionRequest] = []
+        token_requests: list[messages.EthereumDefinitionRequest] = []
+        with session.test_ctx as client:
+            if not session.debug.legacy_debug:
+                client.set_input_flow(
+                    InputFlowConfirmAllWarnings(session, on_page=on_page).get()
+                )
+            sign_tx(
+                session,
+                **param_getter(supports_definition_request=True),
+                definition_provider=_make_display_format_definition_provider(
+                    display_format_requests,
+                    token_requests,
+                    UNISWAP_EXACT_INPUT_SINGLE_DISPLAY_FORMAT,
+                ),
+            )
+        assert_all_seen()
+        assert len(display_format_requests) == 1
+        assert len(token_requests) == 1  # WETH requested, built in USDT not requested
+
+
+def test_definition_request_with_invalid_display_format(session: Session) -> None:
+    # A definition whose tuple claims an extra field causes the firmware to fail parsing it
+    # and reverting to blind signing.
+
+    assert (
+        UNISWAP_EXACT_INPUT_SINGLE_DISPLAY_FORMAT.parameter_definitions[0].tuple
+        is not None
+    )
+    bad_tuple = messages.EthereumABITupleInfo(
+        fields=[
+            *UNISWAP_EXACT_INPUT_SINGLE_DISPLAY_FORMAT.parameter_definitions[
+                0
+            ].tuple.fields,
+            # extra field — causes OutOfBounds during clear signing
+            messages.EthereumABIValueInfo(atomic=messages.EthereumABIType.ABI_UINT256),
+        ],
+        is_dynamic=False,
+    )
+    bad_display_format = definitions.make_eth_display_format(
+        chain_id=UNISWAP_EXACT_INPUT_SINGLE_DISPLAY_FORMAT.chain_id,
+        address=UNISWAP_EXACT_INPUT_SINGLE_DISPLAY_FORMAT.address,
+        func_sig=UNISWAP_EXACT_INPUT_SINGLE_DISPLAY_FORMAT.func_sig,
+        intent=UNISWAP_EXACT_INPUT_SINGLE_DISPLAY_FORMAT.intent,
+        parameter_definitions=[messages.EthereumABIValueInfo(tuple=bad_tuple)],
+        field_definitions=list(
+            UNISWAP_EXACT_INPUT_SINGLE_DISPLAY_FORMAT.field_definitions
+        ),
+    )
+
+    for sign_tx, param_getter in [
+        (ethereum.sign_tx, get_clear_signing_sign_tx_params),
+        (ethereum.sign_tx_eip1559, get_clear_signing_sign_tx_eip1559_params),
+    ]:
+        on_page, assert_all_seen = make_label_checker(
+            absent=UNISWAP_EXACT_INPUT_SINGLE_DISPLAY_FORMAT_LABELS
+            | {"UNKN", "WETH", "USDT"},
+        )
+
+        display_format_requests: list[messages.EthereumDefinitionRequest] = []
+        token_requests: list[messages.EthereumDefinitionRequest] = []
+        with session.test_ctx as client:
+            if not session.debug.legacy_debug:
+                client.set_input_flow(
+                    InputFlowConfirmAllWarnings(session, on_page=on_page).get()
+                )
+            sign_tx(
+                session,
+                **param_getter(supports_definition_request=True),
+                definition_provider=_make_display_format_definition_provider(
+                    display_format_requests, token_requests, bad_display_format
+                ),
+            )
+
+        assert len(display_format_requests) == 1
+        assert len(token_requests) == 0
+        assert_all_seen()
+
+
+def test_definition_request_two_tokens(session: Session) -> None:
+    # When the calldata references two non-builtin tokens (WETH and WETH2),
+    # the firmware sends a separate token definition request for each.
+    token_defs = {
+        WETH_TOKEN_DEFINITION["address"][2:].lower(): WETH_TOKEN_DEFINITION,
+        WETH2_TOKEN_DEFINITION["address"][2:].lower(): WETH2_TOKEN_DEFINITION,
+    }
+    for sign_tx, param_getter in [
+        (ethereum.sign_tx, get_clear_signing_sign_tx_params),
+        (ethereum.sign_tx_eip1559, get_clear_signing_sign_tx_eip1559_params),
+    ]:
+        on_page, assert_all_seen = make_label_checker(
+            expected=UNISWAP_EXACT_INPUT_SINGLE_DISPLAY_FORMAT_LABELS
+            | {"FAKE WETH", "FAKE WETH2"},
+            absent={"UNKN"},
+        )
+        display_format_requests: list[messages.EthereumDefinitionRequest] = []
+        token_requests: list[messages.EthereumDefinitionRequest] = []
+        with session.test_ctx as client:
+            if not session.debug.legacy_debug:
+                client.set_input_flow(
+                    InputFlowConfirmAllWarnings(session, on_page=on_page).get()
+                )
+            sign_tx(
+                session,
+                **param_getter(
+                    data=UNISWAP_WETH_WETH2_CALLDATA,
+                    supports_definition_request=True,
+                ),
+                definition_provider=_make_display_format_definition_provider(
+                    display_format_requests,
+                    token_requests,
+                    UNISWAP_EXACT_INPUT_SINGLE_DISPLAY_FORMAT,
+                    token_definitions=token_defs,
+                ),
+            )
+        assert_all_seen()
+        assert len(display_format_requests) == 1
+        assert len(token_requests) == 2


### PR DESCRIPTION
Follow up for #6748

Add a mechanism through which firmware can request extra definitions (`token` but also `display format` definitions, introduced in #6748) from the host as needed during the signing of Ethereum transactions.

<!--
For external contributors:
- Please open an issue before submitting a PR so we can discuss whether we want to proceed with it.

For core developers:
1. Initial PR setup
- Assign yourself to the PR.
- Add it to the "Firmware" project
  - Set Priority (match issue priority if it exists)
  - Set Team
  - Set Sprint (target release)

2. Development status
- Draft PRs: Set status to "In Progress"
- Final PRs: Set status to "Needs Review"

3. Post-merge status
- Testable: Set status to "Needs QA" and add a `Notes for QA` section with clear instructions on how to test the functionality.
- Not Testable: Set status to "Done (no QA)"
-->
