### PR TITLE
refactor(core): enforce layout scoping using a helper `LayoutContext` type

### DIFF
--- a/core/embed/rust/src/ui/api/firmware_micropython.rs
+++ b/core/embed/rust/src/ui/api/firmware_micropython.rs
@@ -1763,7 +1763,7 @@ pub static mp_module_trezorui_api: Module = obj_module! {
     ///     xpubs: Sequence[tuple[str, str]],
     ///     br_code: ButtonRequestType,
     ///     br_name: str,
-    /// ) -> LayoutObj[UiResult]:
+    /// ) -> LayoutContext[UiResult]:
     ///     """Get address / receive funds."""
     Qstr::MP_QSTR_flow_get_address => obj_fn_kw!(0, new_flow_get_address).as_obj(),
 

--- a/core/embed/rust/src/ui/api/firmware_micropython.rs
+++ b/core/embed/rust/src/ui/api/firmware_micropython.rs
@@ -1447,8 +1447,19 @@ pub static mp_module_trezorui_api: Module = obj_module! {
     ///     def return_value(self) -> T:
     ///         """Retrieve the return value of the layout object."""
     ///
+    ///     # TODO: remove after https://github.com/trezor/trezor-firmware/issues/6811 is resolved.
     ///     def __del__(self) -> None:
     ///         """Calls drop on contents of the root component."""
+    ///
+    ///     # TODO: remove after https://github.com/trezor/trezor-firmware/issues/6811 is resolved.
+    ///     def __enter__(self) -> LayoutObj[T]:
+    ///         """Enters a context manager (checking the root component is not dropped)."""
+    ///
+    ///     def __exit__(self, exc_type: Any, exc_val: Any, exc_tb: Any) -> None:
+    ///         """Exits a context manager (dropping the root component)."""
+    ///
+    /// class LayoutContext(Generic[T]):
+    ///     """Scopes the lifetime of a Rust-based layout object."""
     ///
     ///     def __enter__(self) -> LayoutObj[T]:
     ///         """Enters a context manager (checking the root component is not dropped)."""
@@ -1792,7 +1803,7 @@ pub static mp_module_trezorui_api: Module = obj_module! {
     ///     prompt: str,
     ///     prefill_word: str,
     ///     can_go_back: bool,
-    /// ) -> LayoutObj[str]:
+    /// ) -> LayoutContext[str]:
     ///     """BIP39 word input keyboard."""
     Qstr::MP_QSTR_request_bip39 => obj_fn_kw!(0, new_request_bip39).as_obj(),
 
@@ -1801,7 +1812,7 @@ pub static mp_module_trezorui_api: Module = obj_module! {
     ///     prompt: str,
     ///     prefill_word: str,
     ///     can_go_back: bool,
-    /// ) -> LayoutObj[str]:
+    /// ) -> LayoutContext[str]:
     ///     """SLIP39 word input keyboard."""
     Qstr::MP_QSTR_request_slip39 => obj_fn_kw!(0, new_request_slip39).as_obj(),
 
@@ -1864,7 +1875,7 @@ pub static mp_module_trezorui_api: Module = obj_module! {
     ///     items: Iterable[str],
     ///     current: int,
     ///     cancel: str | None = None
-    /// ) -> LayoutObj[int]:
+    /// ) -> LayoutContext[int]:
     ///     """Select an item from a menu. Returns index in range `0..len(items)`."""
     Qstr::MP_QSTR_select_menu => obj_fn_kw!(0, new_select_menu).as_obj(),
 

--- a/core/mocks/generated/trezorui_api.pyi
+++ b/core/mocks/generated/trezorui_api.pyi
@@ -78,8 +78,19 @@ class LayoutObj(Generic[T]):
         """Return the transition type."""
     def return_value(self) -> T:
         """Retrieve the return value of the layout object."""
+    # TODO: remove after https://github.com/trezor/trezor-firmware/issues/6811 is resolved.
     def __del__(self) -> None:
         """Calls drop on contents of the root component."""
+    # TODO: remove after https://github.com/trezor/trezor-firmware/issues/6811 is resolved.
+    def __enter__(self) -> LayoutObj[T]:
+        """Enters a context manager (checking the root component is not dropped)."""
+    def __exit__(self, exc_type: Any, exc_val: Any, exc_tb: Any) -> None:
+        """Exits a context manager (dropping the root component)."""
+
+
+# rust/src/ui/api/firmware_micropython.rs
+class LayoutContext(Generic[T]):
+    """Scopes the lifetime of a Rust-based layout object."""
     def __enter__(self) -> LayoutObj[T]:
         """Enters a context manager (checking the root component is not dropped)."""
     def __exit__(self, exc_type: Any, exc_val: Any, exc_tb: Any) -> None:
@@ -439,7 +450,7 @@ def request_bip39(
     prompt: str,
     prefill_word: str,
     can_go_back: bool,
-) -> LayoutObj[str]:
+) -> LayoutContext[str]:
     """BIP39 word input keyboard."""
 
 
@@ -449,7 +460,7 @@ def request_slip39(
     prompt: str,
     prefill_word: str,
     can_go_back: bool,
-) -> LayoutObj[str]:
+) -> LayoutContext[str]:
     """SLIP39 word input keyboard."""
 
 
@@ -518,7 +529,7 @@ def select_menu(
     items: Iterable[str],
     current: int,
     cancel: str | None = None
-) -> LayoutObj[int]:
+) -> LayoutContext[int]:
     """Select an item from a menu. Returns index in range `0..len(items)`."""
 
 

--- a/core/mocks/generated/trezorui_api.pyi
+++ b/core/mocks/generated/trezorui_api.pyi
@@ -406,7 +406,7 @@ def flow_get_address(
     xpubs: Sequence[tuple[str, str]],
     br_code: ButtonRequestType,
     br_name: str,
-) -> LayoutObj[UiResult]:
+) -> LayoutContext[UiResult]:
     """Get address / receive funds."""
 
 

--- a/core/src/trezor/ui/layouts/bolt/recovery.py
+++ b/core/src/trezor/ui/layouts/bolt/recovery.py
@@ -37,17 +37,17 @@ async def request_word(
     can_go_back = word_index > 0
 
     if is_slip39:
-        keyboard = trezorui_api.request_slip39(
+        ctx = trezorui_api.request_slip39(
             prompt=prompt, prefill_word=prefill_word, can_go_back=can_go_back
         )
     else:
-        keyboard = trezorui_api.request_bip39(
+        ctx = trezorui_api.request_bip39(
             prompt=prompt, prefill_word=prefill_word, can_go_back=can_go_back
         )
 
-    with keyboard:
+    with ctx as obj:
         return await interact(
-            keyboard,
+            obj,
             "mnemonic" if send_button_request else None,
             ButtonRequestType.MnemonicInput,
         )

--- a/core/src/trezor/ui/layouts/caesar/recovery.py
+++ b/core/src/trezor/ui/layouts/caesar/recovery.py
@@ -43,17 +43,17 @@ async def request_word(
     can_go_back = word_index > 0
 
     if is_slip39:
-        keyboard = trezorui_api.request_slip39(
+        ctx = trezorui_api.request_slip39(
             prompt=prompt, prefill_word=prefill_word, can_go_back=can_go_back
         )
     else:
-        keyboard = trezorui_api.request_bip39(
+        ctx = trezorui_api.request_bip39(
             prompt=prompt, prefill_word=prefill_word, can_go_back=can_go_back
         )
 
-    with keyboard:
+    with ctx as obj:
         return await interact(
-            keyboard,
+            obj,
             "mnemonic" if send_button_request else None,
             ButtonRequestType.MnemonicInput,
         )

--- a/core/src/trezor/ui/layouts/delizia/__init__.py
+++ b/core/src/trezor/ui/layouts/delizia/__init__.py
@@ -344,24 +344,22 @@ async def show_address(
         )
         return result
 
-    await raise_if_not_confirmed(
-        trezorui_api.flow_get_address(
-            address=address,
-            title=title or TR.address__title_receive_address,
-            subtitle=None,
-            description=network or "",
-            hint=None,
-            chunkify=chunkify,
-            address_qr=address if address_qr is None else address_qr,
-            case_sensitive=case_sensitive,
-            account=account,
-            path=path,
-            xpubs=[(xpub_title(i), xpub) for i, xpub in enumerate(xpubs)],
-            br_name=br_name,
-            br_code=br_code,
-        ),
-        None,
-    )
+    with trezorui_api.flow_get_address(
+        address=address,
+        title=title or TR.address__title_receive_address,
+        subtitle=None,
+        description=network or "",
+        hint=None,
+        chunkify=chunkify,
+        address_qr=address if address_qr is None else address_qr,
+        case_sensitive=case_sensitive,
+        account=account,
+        path=path,
+        xpubs=[(xpub_title(i), xpub) for i, xpub in enumerate(xpubs)],
+        br_name=br_name,
+        br_code=br_code,
+    ) as obj:
+        await raise_if_not_confirmed(obj, br_name=None)
 
     show_continue_in_app(TR.address__confirmed)
 

--- a/core/src/trezor/ui/layouts/delizia/recovery.py
+++ b/core/src/trezor/ui/layouts/delizia/recovery.py
@@ -38,17 +38,17 @@ async def request_word(
     can_go_back = word_index > 0
 
     if is_slip39:
-        keyboard = trezorui_api.request_slip39(
+        ctx = trezorui_api.request_slip39(
             prompt=prompt, prefill_word=prefill_word, can_go_back=can_go_back
         )
     else:
-        keyboard = trezorui_api.request_bip39(
+        ctx = trezorui_api.request_bip39(
             prompt=prompt, prefill_word=prefill_word, can_go_back=can_go_back
         )
 
-    with keyboard:
+    with ctx as obj:
         return await interact(
-            keyboard,
+            obj,
             "mnemonic" if send_button_request else None,
             ButtonRequestType.MnemonicInput,
         )

--- a/core/src/trezor/ui/layouts/eckhart/__init__.py
+++ b/core/src/trezor/ui/layouts/eckhart/__init__.py
@@ -298,24 +298,22 @@ async def show_address(
 
     if warning is None and multisig_index is not None:
         warning = TR.send__receiving_to_multisig
-    await raise_if_not_confirmed(
-        trezorui_api.flow_get_address(
-            address=address,
-            title=title or TR.words__receive,
-            subtitle=subtitle,
-            description=network or "",
-            hint=warning,
-            chunkify=chunkify,
-            address_qr=address if address_qr is None else address_qr,
-            case_sensitive=case_sensitive,
-            account=account,
-            path=path,
-            xpubs=[(xpub_title(i), xpub) for i, xpub in enumerate(xpubs)],
-            br_name=br_name,
-            br_code=br_code,
-        ),
-        None,
-    )
+    with trezorui_api.flow_get_address(
+        address=address,
+        title=title or TR.words__receive,
+        subtitle=subtitle,
+        description=network or "",
+        hint=warning,
+        chunkify=chunkify,
+        address_qr=address if address_qr is None else address_qr,
+        case_sensitive=case_sensitive,
+        account=account,
+        path=path,
+        xpubs=[(xpub_title(i), xpub) for i, xpub in enumerate(xpubs)],
+        br_name=br_name,
+        br_code=br_code,
+    ) as obj:
+        await raise_if_not_confirmed(obj, br_name=None)
 
     show_continue_in_app(TR.address__confirmed)
 

--- a/core/src/trezor/ui/layouts/eckhart/recovery.py
+++ b/core/src/trezor/ui/layouts/eckhart/recovery.py
@@ -38,17 +38,17 @@ async def request_word(
 ) -> str:
     prompt = TR.recovery__word_x_of_y_template.format(word_index + 1, word_count)
     if is_slip39:
-        keyboard = trezorui_api.request_slip39(
+        ctx = trezorui_api.request_slip39(
             prompt=prompt, prefill_word=prefill_word, can_go_back=True
         )
     else:
-        keyboard = trezorui_api.request_bip39(
+        ctx = trezorui_api.request_bip39(
             prompt=prompt, prefill_word=prefill_word, can_go_back=True
         )
 
-    with keyboard:
+    with ctx as obj:
         return await interact(
-            keyboard,
+            obj,
             "mnemonic" if send_button_request else None,
             ButtonRequestType.MnemonicInput,
         )


### PR DESCRIPTION
Introduce `LayoutContext` type, which will be returned by some Rust layout factory functions. In order to get a `LayoutObj`, it has to be used as a context manager - thus enforcing proper layout scoping.

The change will be gradually introduced, since some UI flows require more refactoring.

<!--
For external contributors:
- Please open an issue before submitting a PR so we can discuss whether we want to proceed with it.

For core developers:
1. Initial PR setup
- Assign yourself to the PR.
- Add it to the "Firmware" project
  - Set Priority (match issue priority if it exists)
  - Set Team
  - Set Sprint (target release)

2. Development status
- Draft PRs: Set status to "In Progress"
- Final PRs: Set status to "Needs Review"

3. Post-merge status
- Testable: Set status to "Needs QA" and add a `Notes for QA` section with clear instructions on how to test the functionality.
- Not Testable: Set status to "Done (no QA)"
-->
