### PR TITLE
Add Stablecoin yielding claim flow.

### DIFF
--- a/common/tests/fixtures/ethereum/sign_tx.json
+++ b/common/tests/fixtures/ethereum/sign_tx.json
@@ -446,6 +446,69 @@
                 "sig_r": "20229b613ec8e857f7a94db85169d22010e44016f41f61f11f4e7b5c1e60a37c",
                 "sig_s": "3f8a9b3d39317d1e8f1a282b165c16a498124589cdd23131eb8f4d87127541ea"
             }
+        },
+        {
+            "name": "vault_deposit_trailing_bytes",
+            "skip_models": ["t1"],
+            "parameters": {
+                "comment": "ERC-4626 deposit - extra trailing bytes after the two ABI-encoded arguments",
+                "data": "6e553f6500000000000000000000000000000000000000000000000000000000000f42400000000000000000000000004f4f1488acb1ae1b46146ceff804f591dfe660acdeadfeed",
+                "path": "m/44'/60'/0'/0/1",
+                "to_address": "0xa511d618cD0F9d7cAD791009d7c5E3b19c9568da",
+                "chain_id": 1,
+                "nonce": "0x0",
+                "gas_price": "0x14",
+                "gas_limit": "0x14",
+                "tx_type": null,
+                "value": "0x0"
+            },
+            "result": {
+                "sig_v": 38,
+                "sig_r": "40528c6e70a33fb737147d86a61427e6de942f3e50d62c0289c0aa1bb4e9d1ac",
+                "sig_s": "737477b5a874a73fe5ee705c40262486c85255df61fed2b4094e1246e60ef9c5"
+            }
+        },
+        {
+            "name": "vault_redeem_trailing_bytes",
+            "skip_models": ["t1"],
+            "parameters": {
+                "comment": "ERC-4626 redeem - extra trailing bytes after the three ABI-encoded arguments",
+                "data": "ba08765200000000000000000000000000000000000000000000000000000000000f42400000000000000000000000004f4f1488acb1ae1b46146ceff804f591dfe660ac0000000000000000000000004f4f1488acb1ae1b46146ceff804f591dfe660acdeadfeed",
+                "path": "m/44'/60'/0'/0/1",
+                "to_address": "0xa511d618cD0F9d7cAD791009d7c5E3b19c9568da",
+                "chain_id": 1,
+                "nonce": "0x0",
+                "gas_price": "0x14",
+                "gas_limit": "0x14",
+                "tx_type": null,
+                "value": "0x0"
+            },
+            "result": {
+                "sig_v": 37,
+                "sig_r": "29889b25f7e8197bddd13afc7d32100b58086666771f2bcaa8925ca1e96112a3",
+                "sig_s": "1a312779756d2fa62e4e4779815080980a0f86773b8582aff9ca4e74b925e54f"
+            }
+        },
+        {
+            "name": "vault_withdraw_trailing_bytes",
+            "skip_models": ["t1"],
+            "parameters": {
+                "comment": "ERC-4626 withdraw - extra trailing bytes after the three ABI-encoded arguments",
+                "data": "b460af9400000000000000000000000000000000000000000000000000000000000f42400000000000000000000000004f4f1488acb1ae1b46146ceff804f591dfe660ac0000000000000000000000004f4f1488acb1ae1b46146ceff804f591dfe660acdeadfeed",
+                "path": "m/44'/60'/0'/0/1",
+                "to_address": "0xa511d618cD0F9d7cAD791009d7c5E3b19c9568da",
+                "chain_id": 1,
+                "nonce": "0x0",
+                "gas_price": "0x14",
+                "gas_limit": "0x14",
+                "tx_type": null,
+                "value": "0x0"
+            },
+            "result": {
+                "sig_v": 38,
+                "sig_r": "de16620898c6fe3cc5b7d3c5ff6581c2a7845a69bd22f37559f610d6253cfd2f",
+                "sig_s": "58e928b596c930f2f302386025e1eb2a74b342dd9005ae84a161df16a5a295bf"
+            }
         }
     ]
 }

--- a/common/tests/fixtures/ethereum/sign_tx_error.json
+++ b/common/tests/fixtures/ethereum/sign_tx_error.json
@@ -68,27 +68,6 @@
             }
         },
         {
-            "name": "vault_deposit_trailing_bytes",
-            "skip_models": ["t1"],
-            "parameters": {
-                "comment": "ERC-4626 deposit - extra trailing byte after the two ABI-encoded arguments",
-                "data": "6e553f6500000000000000000000000000000000000000000000000000000000000f42400000000000000000000000008b13dbef164beb9d984aeb715c31d1d1bb0bd8bb00",
-                "path": "m/44'/60'/0'/0/1",
-                "to_address": "0xBEEF01735c132Ada46AA9aA4c54623cAA92A64CB",
-                "chain_id": 1,
-                "nonce": "0x0",
-                "gas_price": "0x14",
-                "gas_limit": "0x14",
-                "tx_type": null,
-                "value": "0x0"
-            },
-            "result": {
-                "sig_v": 0,
-                "sig_r": "0x0",
-                "sig_s": "0x0"
-            }
-        },
-        {
             "name": "vault_redeem_with_eth",
             "skip_models": ["t1"],
             "parameters": {
@@ -110,27 +89,6 @@
             }
         },
         {
-            "name": "vault_redeem_trailing_bytes",
-            "skip_models": ["t1"],
-            "parameters": {
-                "comment": "ERC-4626 redeem - extra trailing byte after the three ABI-encoded arguments",
-                "data": "ba08765200000000000000000000000000000000000000000000000000000000000f42400000000000000000000000008b13dbef164beb9d984aeb715c31d1d1bb0bd8bb0000000000000000000000008b13dbef164beb9d984aeb715c31d1d1bb0bd8bb00",
-                "path": "m/44'/60'/0'/0/1",
-                "to_address": "0xBEEF01735c132Ada46AA9aA4c54623cAA92A64CB",
-                "chain_id": 1,
-                "nonce": "0x0",
-                "gas_price": "0x14",
-                "gas_limit": "0x14",
-                "tx_type": null,
-                "value": "0x0"
-            },
-            "result": {
-                "sig_v": 0,
-                "sig_r": "0x0",
-                "sig_s": "0x0"
-            }
-        },
-        {
             "name": "vault_withdraw_with_eth",
             "skip_models": ["t1"],
             "parameters": {
@@ -144,27 +102,6 @@
                 "gas_limit": "0x14",
                 "tx_type": null,
                 "value": "0xDE0B6B3A7640000"
-            },
-            "result": {
-                "sig_v": 0,
-                "sig_r": "0x0",
-                "sig_s": "0x0"
-            }
-        },
-        {
-            "name": "vault_withdraw_trailing_bytes",
-            "skip_models": ["t1"],
-            "parameters": {
-                "comment": "ERC-4626 withdraw - extra trailing byte after the three ABI-encoded arguments",
-                "data": "b460af9400000000000000000000000000000000000000000000000000000000000f42400000000000000000000000008b13dbef164beb9d984aeb715c31d1d1bb0bd8bb0000000000000000000000008b13dbef164beb9d984aeb715c31d1d1bb0bd8bb00",
-                "path": "m/44'/60'/0'/0/1",
-                "to_address": "0xBEEF01735c132Ada46AA9aA4c54623cAA92A64CB",
-                "chain_id": 1,
-                "nonce": "0x0",
-                "gas_price": "0x14",
-                "gas_limit": "0x14",
-                "tx_type": null,
-                "value": "0x0"
             },
             "result": {
                 "sig_v": 0,

--- a/core/embed/rust/librust_qstr.h
+++ b/core/embed/rust/librust_qstr.h
@@ -1236,6 +1236,7 @@ static void _librust_qstrs(void) {
   MP_QSTR_ethereum__approve_revoke_from;
   MP_QSTR_ethereum__approve_to;
   MP_QSTR_ethereum__approve_unlimited_template;
+  MP_QSTR_ethereum__calldata_suffix;
   MP_QSTR_ethereum__confirm_contract;
   MP_QSTR_ethereum__contract_address;
   MP_QSTR_ethereum__data_size_template;

--- a/core/embed/rust/src/translations/generated/translated_string.rs
+++ b/core/embed/rust/src/translations/generated/translated_string.rs
@@ -1613,6 +1613,8 @@ pub enum TranslatedString {
     ethereum__subtitle_input_data_bytes = 1217,  // {"Bolt": "", "Caesar": "", "Delizia": "{0} / {1} bytes", "Eckhart": ""}
     #[cfg(feature = "universal_fw")]
     ethereum__title_input_data_bytes = 1218,  // {"Bolt": "Data:\n{0} / {1} bytes", "Caesar": "Data: {0} / {1} bytes", "Delizia": "Data", "Eckhart": "Data:\n{0} / {1} bytes"}
+    #[cfg(feature = "universal_fw")]
+    ethereum__calldata_suffix = 1219,  // "Calldata suffix"
 }
 
 impl TranslatedString {
@@ -2839,6 +2841,7 @@ impl TranslatedString {
                 "Withdraw to",
                 "",
                 "Data:\n{0} / {1} bytes",
+                "Calldata suffix",
             );
 
             #[cfg(all(feature = "debug", feature = "universal_fw"))]
@@ -4063,6 +4066,7 @@ impl TranslatedString {
                 20224,
                 20224,
                 20245,
+                20260,
             ];
 
             #[cfg(all(feature = "debug", not(feature = "universal_fw")))]
@@ -5286,6 +5290,7 @@ impl TranslatedString {
                 "Withdraw to",
                 "",
                 "Data:\n{0} / {1} bytes",
+                "Calldata suffix",
             );
 
             #[cfg(all(feature = "debug", not(feature = "universal_fw")))]
@@ -6510,6 +6515,7 @@ impl TranslatedString {
                 20224,
                 20224,
                 20245,
+                20260,
             ];
 
             #[cfg(all(not(feature = "debug"), feature = "universal_fw"))]
@@ -7733,6 +7739,7 @@ impl TranslatedString {
                 "Withdraw to",
                 "",
                 "Data:\n{0} / {1} bytes",
+                "Calldata suffix",
             );
 
             #[cfg(all(not(feature = "debug"), feature = "universal_fw"))]
@@ -8957,6 +8964,7 @@ impl TranslatedString {
                 20224,
                 20224,
                 20245,
+                20260,
             ];
 
             #[cfg(all(not(feature = "debug"), not(feature = "universal_fw")))]
@@ -10180,6 +10188,7 @@ impl TranslatedString {
                 "Withdraw to",
                 "",
                 "Data:\n{0} / {1} bytes",
+                "Calldata suffix",
             );
 
             #[cfg(all(not(feature = "debug"), not(feature = "universal_fw")))]
@@ -11404,6 +11413,7 @@ impl TranslatedString {
                 20224,
                 20224,
                 20245,
+                20260,
             ];
 
         } else if #[cfg(feature = "layout_caesar")] {
@@ -12628,6 +12638,7 @@ impl TranslatedString {
                 "Withdraw to",
                 "",
                 "Data: {0} / {1} bytes",
+                "Calldata suffix",
             );
 
             #[cfg(all(feature = "debug", feature = "universal_fw"))]
@@ -13852,6 +13863,7 @@ impl TranslatedString {
                 18249,
                 18249,
                 18270,
+                18285,
             ];
 
             #[cfg(all(feature = "debug", not(feature = "universal_fw")))]
@@ -15075,6 +15087,7 @@ impl TranslatedString {
                 "Withdraw to",
                 "",
                 "Data: {0} / {1} bytes",
+                "Calldata suffix",
             );
 
             #[cfg(all(feature = "debug", not(feature = "universal_fw")))]
@@ -16299,6 +16312,7 @@ impl TranslatedString {
                 18249,
                 18249,
                 18270,
+                18285,
             ];
 
             #[cfg(all(not(feature = "debug"), feature = "universal_fw"))]
@@ -17522,6 +17536,7 @@ impl TranslatedString {
                 "Withdraw to",
                 "",
                 "Data: {0} / {1} bytes",
+                "Calldata suffix",
             );
 
             #[cfg(all(not(feature = "debug"), feature = "universal_fw"))]
@@ -18746,6 +18761,7 @@ impl TranslatedString {
                 18249,
                 18249,
                 18270,
+                18285,
             ];
 
             #[cfg(all(not(feature = "debug"), not(feature = "universal_fw")))]
@@ -19969,6 +19985,7 @@ impl TranslatedString {
                 "Withdraw to",
                 "",
                 "Data: {0} / {1} bytes",
+                "Calldata suffix",
             );
 
             #[cfg(all(not(feature = "debug"), not(feature = "universal_fw")))]
@@ -21193,6 +21210,7 @@ impl TranslatedString {
                 18249,
                 18249,
                 18270,
+                18285,
             ];
 
         } else if #[cfg(feature = "layout_delizia")] {
@@ -22417,6 +22435,7 @@ impl TranslatedString {
                 "Withdraw to",
                 "{0} / {1} bytes",
                 "Data",
+                "Calldata suffix",
             );
 
             #[cfg(all(feature = "debug", feature = "universal_fw"))]
@@ -23641,6 +23660,7 @@ impl TranslatedString {
                 19472,
                 19487,
                 19491,
+                19506,
             ];
 
             #[cfg(all(feature = "debug", not(feature = "universal_fw")))]
@@ -24864,6 +24884,7 @@ impl TranslatedString {
                 "Withdraw to",
                 "{0} / {1} bytes",
                 "Data",
+                "Calldata suffix",
             );
 
             #[cfg(all(feature = "debug", not(feature = "universal_fw")))]
@@ -26088,6 +26109,7 @@ impl TranslatedString {
                 19472,
                 19487,
                 19491,
+                19506,
             ];
 
             #[cfg(all(not(feature = "debug"), feature = "universal_fw"))]
@@ -27311,6 +27333,7 @@ impl TranslatedString {
                 "Withdraw to",
                 "{0} / {1} bytes",
                 "Data",
+                "Calldata suffix",
             );
 
             #[cfg(all(not(feature = "debug"), feature = "universal_fw"))]
@@ -28535,6 +28558,7 @@ impl TranslatedString {
                 19472,
                 19487,
                 19491,
+                19506,
             ];
 
             #[cfg(all(not(feature = "debug"), not(feature = "universal_fw")))]
@@ -29758,6 +29782,7 @@ impl TranslatedString {
                 "Withdraw to",
                 "{0} / {1} bytes",
                 "Data",
+                "Calldata suffix",
             );
 
             #[cfg(all(not(feature = "debug"), not(feature = "universal_fw")))]
@@ -30982,6 +31007,7 @@ impl TranslatedString {
                 19472,
                 19487,
                 19491,
+                19506,
             ];
 
         } else if #[cfg(feature = "layout_eckhart")] {
@@ -32206,6 +32232,7 @@ impl TranslatedString {
                 "Withdraw to",
                 "",
                 "Data:\n{0} / {1} bytes",
+                "Calldata suffix",
             );
 
             #[cfg(all(feature = "debug", feature = "universal_fw"))]
@@ -33430,6 +33457,7 @@ impl TranslatedString {
                 20554,
                 20554,
                 20575,
+                20590,
             ];
 
             #[cfg(all(feature = "debug", not(feature = "universal_fw")))]
@@ -34653,6 +34681,7 @@ impl TranslatedString {
                 "Withdraw to",
                 "",
                 "Data:\n{0} / {1} bytes",
+                "Calldata suffix",
             );
 
             #[cfg(all(feature = "debug", not(feature = "universal_fw")))]
@@ -35877,6 +35906,7 @@ impl TranslatedString {
                 20554,
                 20554,
                 20575,
+                20590,
             ];
 
             #[cfg(all(not(feature = "debug"), feature = "universal_fw"))]
@@ -37100,6 +37130,7 @@ impl TranslatedString {
                 "Withdraw to",
                 "",
                 "Data:\n{0} / {1} bytes",
+                "Calldata suffix",
             );
 
             #[cfg(all(not(feature = "debug"), feature = "universal_fw"))]
@@ -38324,6 +38355,7 @@ impl TranslatedString {
                 20554,
                 20554,
                 20575,
+                20590,
             ];
 
             #[cfg(all(not(feature = "debug"), not(feature = "universal_fw")))]
@@ -39547,6 +39579,7 @@ impl TranslatedString {
                 "Withdraw to",
                 "",
                 "Data:\n{0} / {1} bytes",
+                "Calldata suffix",
             );
 
             #[cfg(all(not(feature = "debug"), not(feature = "universal_fw")))]
@@ -40771,6 +40804,7 @@ impl TranslatedString {
                 20554,
                 20554,
                 20575,
+                20590,
             ];
 
         }
@@ -41283,6 +41317,8 @@ impl TranslatedString {
         (Qstr::MP_QSTR_ethereum__approve_to, Self::ethereum__approve_to),
         #[cfg(feature = "universal_fw")]
         (Qstr::MP_QSTR_ethereum__approve_unlimited_template, Self::ethereum__approve_unlimited_template),
+        #[cfg(feature = "universal_fw")]
+        (Qstr::MP_QSTR_ethereum__calldata_suffix, Self::ethereum__calldata_suffix),
         #[cfg(feature = "universal_fw")]
         (Qstr::MP_QSTR_ethereum__confirm_contract, Self::ethereum__confirm_contract),
         #[cfg(feature = "universal_fw")]

--- a/core/mocks/trezortranslate_keys.pyi
+++ b/core/mocks/trezortranslate_keys.pyi
@@ -333,6 +333,7 @@ class TR:
     ethereum__approve_revoke_from: str = "Revoke from"
     ethereum__approve_to: str = "Approve to"
     ethereum__approve_unlimited_template: str = "Approving unlimited amount of {0}"
+    ethereum__calldata_suffix: str = "Calldata suffix"
     ethereum__confirm_contract: str = "Confirm contract"
     ethereum__contract_address: str = "Provider contract address"
     ethereum__data_size_template: str = "Size: {0} bytes"

--- a/core/src/apps/ethereum/clear_signing.py
+++ b/core/src/apps/ethereum/clear_signing.py
@@ -675,6 +675,7 @@ async def _handle_approve(
     from .clear_signing_definitions import SC_FUNC_APPROVE_REVOKE_AMOUNT
     from .layout import require_confirm_approve
     from .sc_constants import KNOWN_ADDRESSES
+    from .yielding_vaults import UNKNOWN_VAULT, lookup_vault
 
     args, fields = display_format.parse(
         calldata, msg.address_n, msg.value, definitions, token
@@ -695,6 +696,10 @@ async def _handle_approve(
     assert isinstance(arg1_raw_value, int)
 
     recipient_str = KNOWN_ADDRESSES.get(arg0_raw_value)
+    if recipient_str is None:
+        vault = lookup_vault(definitions.network, arg0_raw_value)
+        if vault is not UNKNOWN_VAULT:
+            recipient_str = vault.name
 
     is_revoke = arg1_raw_value == SC_FUNC_APPROVE_REVOKE_AMOUNT
 

--- a/core/src/apps/ethereum/layout.py
+++ b/core/src/apps/ethereum/layout.py
@@ -1,10 +1,12 @@
 from typing import TYPE_CHECKING
+from ubinascii import hexlify
 
 from trezor import TR
 from trezor.enums import ButtonRequestType
 from trezor.ui.layouts import (
     confirm_blob,
     confirm_ethereum_staking_tx,
+    confirm_ethereum_vault_claim,
     confirm_ethereum_vault_tx,
     confirm_text,
     should_show_more,
@@ -248,6 +250,7 @@ async def require_confirm_vault_tx(
     vault_str: str,
     token: EthereumTokenInfo,
     func_sig: AnyBytes,
+    extra_data: AnyBytes | None = None,
 ) -> None:
     from .yielding import FUNC_SIG_DEPOSIT, FUNC_SIG_REDEEM, FUNC_SIG_WITHDRAW
 
@@ -275,6 +278,10 @@ async def require_confirm_vault_tx(
     amount = format_ethereum_amount(value, token, network)
     account, account_path = get_account_and_path(address_n)
 
+    extra_data_str: str | None = (
+        "0x" + hexlify(extra_data).decode() if extra_data is not None else None
+    )
+
     await confirm_ethereum_vault_tx(
         title=title,
         intro_question=intro_question,
@@ -288,6 +295,27 @@ async def require_confirm_vault_tx(
         info_items=fee_info_items,
         chain=network.name,
         br_name=br_name,
+        extra_data=extra_data_str,
+    )
+
+
+async def require_confirm_claim_rewards(
+    address_n: list[int],
+    maximum_fee: str,
+    fee_info_items: Iterable[StrPropertyType],
+    token_labels: list[str],
+) -> None:
+    account, account_path = get_account_and_path(address_n)
+    token_list = "\n".join(token_labels)
+    await confirm_ethereum_vault_claim(
+        title=TR.ethereum__rewards_claim,
+        intro_question=TR.ethereum__vault_claim_intro,
+        account=account,
+        account_path=account_path,
+        maximum_fee=maximum_fee,
+        info_items=fee_info_items,
+        token_list=token_list,
+        br_name="ethereum/vault/claim",
     )
 
 

--- a/core/src/apps/ethereum/sign_tx.py
+++ b/core/src/apps/ethereum/sign_tx.py
@@ -237,7 +237,7 @@ async def confirm_tx_data(
         return staking_approver
 
     yielding_approver = yielding.get_approver(
-        msg, network, address_bytes, maximum_fee, fee_items, sender_bytes
+        msg, initial_data, network, address_bytes, maximum_fee, fee_items, sender_bytes
     )
     if yielding_approver is not None:
         if payment_request_verifier is not None:

--- a/core/src/apps/ethereum/yielding.py
+++ b/core/src/apps/ethereum/yielding.py
@@ -3,7 +3,7 @@ from typing import TYPE_CHECKING
 from trezor.utils import BufferReader
 from trezor.wire import DataError
 
-from .yielding_vaults import lookup_vault
+from .yielding_vaults import UNKNOWN_VAULT, lookup_vault
 
 if TYPE_CHECKING:
     from buffer_types import AnyBytes
@@ -14,11 +14,13 @@ if TYPE_CHECKING:
 
     from .helpers import ConfirmDataFn
     from .keychain import MsgInSignTx
+    from .yielding_vaults import EthereumVaultInfo
 
 # https://ethereum.org/developers/docs/standards/tokens/erc-4626
 FUNC_SIG_DEPOSIT = b"\x6e\x55\x3f\x65"
 FUNC_SIG_WITHDRAW = b"\xb4\x60\xaf\x94"
 FUNC_SIG_REDEEM = b"\xba\x08\x76\x52"
+FUNC_SIG_CLAIM = b"\x71\xee\x95\xc0"
 
 if __debug__:
     from trezor.crypto.hashlib import sha3_256
@@ -35,10 +37,17 @@ if __debug__:
         FUNC_SIG_REDEEM
         == sha3_256(b"redeem(uint256,address,address)", keccak=True).digest()[:4]
     )
+    assert (
+        FUNC_SIG_CLAIM
+        == sha3_256(
+            b"claim(address[],address[],uint256[],bytes32[][])", keccak=True
+        ).digest()[:4]
+    )
 
 
 def get_approver(
     msg: MsgInSignTx,
+    initial_data: AnyBytes,
     network: EthereumNetworkInfo,
     address_bytes: AnyBytes,
     maximum_fee: str,
@@ -49,21 +58,19 @@ def get_approver(
     from .clear_signing import SC_FUNC_SIG_BYTES
     from .helpers import get_progress_indicator
 
-    if msg.data_length > len(msg.data_initial_chunk):
+    if msg.data_length > len(initial_data):
         return None
 
-    data_reader = BufferReader(msg.data_initial_chunk)
+    data_reader = BufferReader(initial_data)
     if data_reader.remaining_count() < SC_FUNC_SIG_BYTES:
         return None
 
-    is_known_vault, vault_str, asset_token, vault_token = lookup_vault(
-        network, address_bytes
-    )
+    vault = lookup_vault(network, address_bytes)
 
     handler = None
     func_sig = data_reader.read_memoryview(SC_FUNC_SIG_BYTES)
     if func_sig in (FUNC_SIG_DEPOSIT, FUNC_SIG_WITHDRAW, FUNC_SIG_REDEEM):
-        token = vault_token if func_sig == FUNC_SIG_REDEEM else asset_token
+        token = vault.vault_token if func_sig == FUNC_SIG_REDEEM else vault.asset_token
         handler = _prepare_vault_tx(
             data_reader=data_reader,
             msg=msg,
@@ -71,10 +78,18 @@ def get_approver(
             maximum_fee=maximum_fee,
             fee_items=fee_items,
             sender_bytes=sender_bytes,
-            is_known_vault=is_known_vault,
-            vault_str=vault_str,
+            vault=vault,
             token=token,
             func_sig=func_sig,
+        )
+    elif func_sig == FUNC_SIG_CLAIM:
+        handler = _prepare_claim_rewards(
+            data_reader=data_reader,
+            msg=msg,
+            network=network,
+            maximum_fee=maximum_fee,
+            fee_items=fee_items,
+            sender_bytes=sender_bytes,
         )
 
     if handler is not None:
@@ -90,11 +105,10 @@ def _prepare_vault_tx(
     maximum_fee: str,
     fee_items: Iterable[StrPropertyType],
     sender_bytes: AnyBytes,
-    is_known_vault: bool,
-    vault_str: str,
+    vault: EthereumVaultInfo,
     token: EthereumTokenInfo,
-    func_sig: "AnyBytes",
-) -> "Coroutine[Any, Any, None] | None":
+    func_sig: AnyBytes,
+) -> Coroutine[Any, Any, None] | None:
 
     from .clear_signing import InvalidFunctionCall, parse_address, parse_uint256
     from .layout import require_confirm_vault_tx
@@ -110,8 +124,7 @@ def _prepare_vault_tx(
             None if is_deposit else parse_address(data_reader.read_memoryview(32))
         )
         if (
-            data_reader.remaining_count() != 0
-            or not isinstance(amount, int)
+            not isinstance(amount, int)
             or not isinstance(receiver_bytes, bytes)
             or (owner_bytes is not None and not isinstance(owner_bytes, bytes))
             or int.from_bytes(msg.value, "big") != 0
@@ -119,24 +132,119 @@ def _prepare_vault_tx(
         ):
             raise ValueError
     except (ValueError, EOFError, InvalidFunctionCall):
-        raise DataError("Invalid data for ERC-4626 vault transaction")
+        raise DataError("Invalid data for ERC-4626 vault transaction.")
 
-    if not _is_vault_tx_safe(is_known_vault, sender_bytes, receiver_bytes, owner_bytes):
+    if not _is_vault_tx_safe(vault, sender_bytes, receiver_bytes, owner_bytes):
         return None
+
+    extra_data = None
+    if data_reader.remaining_count() != 0:
+        extra_data = data_reader.read_memoryview(data_reader.remaining_count())
+
     return require_confirm_vault_tx(
         value=amount,
         address_n=msg.address_n,
         maximum_fee=maximum_fee,
         fee_info_items=fee_items,
         network=network,
-        vault_str=vault_str,
+        vault_str=(vault.name if vault is not UNKNOWN_VAULT else msg.to),
         token=token,
         func_sig=func_sig,
+        extra_data=extra_data,
+    )
+
+
+def _prepare_claim_rewards(
+    data_reader: BufferReader,
+    msg: MsgInSignTx,
+    network: EthereumNetworkInfo,
+    maximum_fee: str,
+    fee_items: Iterable[StrPropertyType],
+    sender_bytes: AnyBytes,
+) -> Coroutine[Any, Any, None] | None:
+
+    return None
+    # TODO: Finalize the UI in the next iteration.
+
+    from .clear_signing import InvalidFunctionCall, parse_address
+    from .layout import require_confirm_claim_rewards
+    from .yielding_vaults import get_token_label
+
+    _MERKL_XYZ_CLAIM_DISTRIBUTOR_ADDR = "0x3ef3d8ba38ebe18db133cec108f4d14ce00dd9ae"
+
+    if int.from_bytes(msg.value, "big") != 0:
+        raise DataError(
+            "Non-zero ETH transfer with ERC-4626 vault transaction not allowed"
+        )
+
+    # claim(address[] users, address[] tokens, uint256[] amounts, bytes32[][] proofs)
+    # All 4 params are dynamic; first 128 bytes are their ABI offsets (relative to abi_base).
+    try:
+        param_base = data_reader.offset
+
+        receivers_param_offset = int.from_bytes(data_reader.read_memoryview(32), "big")
+        tokens_param_offset = int.from_bytes(data_reader.read_memoryview(32), "big")
+        amounts_param_offset = int.from_bytes(data_reader.read_memoryview(32), "big")
+        proofs_param_offset = int.from_bytes(data_reader.read_memoryview(32), "big")
+
+        def _read_array_length(param_offset: int) -> int:
+            data_reader.seek(param_base + param_offset)
+            return int.from_bytes(data_reader.read_memoryview(32), "big")
+
+        receivers_array_length = _read_array_length(receivers_param_offset)
+        tokens_array_length = _read_array_length(tokens_param_offset)
+        amounts_array_length = _read_array_length(amounts_param_offset)
+        proofs_array_length = _read_array_length(proofs_param_offset)
+
+        if (
+            receivers_array_length != tokens_array_length
+            or tokens_array_length != amounts_array_length
+            or amounts_array_length != proofs_array_length
+        ):
+            raise ValueError
+
+        data_reader.seek(param_base + receivers_param_offset + 32)
+        first_receiver_address = parse_address(data_reader.read_memoryview(32))
+        if not isinstance(first_receiver_address, bytes):
+            raise InvalidFunctionCall
+
+        # Check if all users are the same. We validate if it's the sender in _is_vault_tx_safe()
+        # If either of these conditions are unmet, we revert to blind signing (return None).
+        for i in range(1, receivers_array_length):
+            data_reader.seek(param_base + receivers_param_offset + 32 + i * 32)
+            other = parse_address(data_reader.read_memoryview(32))
+            if other != first_receiver_address:
+                return None
+
+        token_labels: list[str] = []
+        for i in range(tokens_array_length):
+            data_reader.seek(param_base + tokens_param_offset + 32 + i * 32)
+            addr = parse_address(data_reader.read_memoryview(32))
+            if not isinstance(addr, bytes):
+                raise InvalidFunctionCall
+            label = get_token_label(addr, network)
+            token_labels.append(label)
+
+    except (ValueError, EOFError, InvalidFunctionCall):
+        raise DataError("Invalid data for claim rewards transaction")
+
+    # We don't show claim flows for any unknown distributor for now.
+    if (
+        msg.to != _MERKL_XYZ_CLAIM_DISTRIBUTOR_ADDR
+        or sender_bytes != first_receiver_address
+    ):
+        return None
+
+    return require_confirm_claim_rewards(
+        address_n=msg.address_n,
+        maximum_fee=maximum_fee,
+        fee_info_items=fee_items,
+        token_labels=token_labels,
     )
 
 
 def _is_vault_tx_safe(
-    is_known_vault: bool,
+    vault: EthereumVaultInfo,
     sender_bytes: AnyBytes,
     receiver_bytes: AnyBytes,
     owner_bytes: AnyBytes | None = None,
@@ -151,6 +259,6 @@ def _is_vault_tx_safe(
         return True
     else:
         # Hard fail for known (Trezor) vaults, blind sign for unknown vaults
-        if is_known_vault:
+        if vault is not UNKNOWN_VAULT:
             raise DataError("Vault tx: Signer receiver mismatch")
         return False

--- a/core/src/apps/ethereum/yielding_vaults.py
+++ b/core/src/apps/ethereum/yielding_vaults.py
@@ -6,45 +6,115 @@ if TYPE_CHECKING:
 
 from trezor.messages import EthereumTokenInfo
 
-# Stablecoin Yielding Vaults
-# Will be a list of tuples for each chain/network.
-KNOWN_VAULT = (
+from .tokens import UNKNOWN_TOKEN
+
+
+class EthereumVaultInfo:
+    def __init__(
+        self,
+        address: AnyBytes | None,
+        chain_id: int | None,
+        name: str,
+        asset_token: EthereumTokenInfo,
+        vault_token: EthereumTokenInfo,
+    ) -> None:
+        self.address = address
+        self.chain_id = chain_id
+        self.name = name
+        self.asset_token = asset_token
+        self.vault_token = vault_token
+
+
+KNOWN_VAULTS = (
     # Test vault: https://etherscan.io/address/0xa511d618cD0F9d7cAD791009d7c5E3b19c9568da
-    b"\xa5\x11\xd6\x18\xcd\x0f\x9d\x7c\xad\x79\x10\x09\xd7\xc5\xe3\xb1\x9c\x95\x68\xda",  # vault contract address
-    1,  # chain id (Ethereum)
-    "Test Steakhouse USDC Prime Vault",  # owner/protocol name
-    # Asset Token
-    EthereumTokenInfo(
-        symbol="USDC",
-        decimals=6,
-        address=b"\xa0\xb8\x69\x91\xc6\x21\x8b\x36\xc1\xd1\x9d\x4a\x2e\x9e\xb0\xce\x36\x06\xeb\x48",
+    EthereumVaultInfo(
+        address=b"\xa5\x11\xd6\x18\xcd\x0f\x9d\x7c\xad\x79\x10\x09\xd7\xc5\xe3\xb1\x9c\x95\x68\xda",
         chain_id=1,
-        name="USD Coin",
+        name="Test Steakhouse USDC Prime Vault",
+        asset_token=EthereumTokenInfo(
+            symbol="USDC",
+            decimals=6,
+            address=b"\xa0\xb8\x69\x91\xc6\x21\x8b\x36\xc1\xd1\x9d\x4a\x2e\x9e\xb0\xce\x36\x06\xeb\x48",
+            chain_id=1,
+            name="USD Coin",
+        ),
+        vault_token=EthereumTokenInfo(
+            symbol="tstSHUSDCp",
+            decimals=18,
+            address=b"\xa5\x11\xd6\x18\xcd\x0f\x9d\x7c\xad\x79\x10\x09\xd7\xc5\xe3\xb1\x9c\x95\x68\xda",
+            chain_id=1,
+            name="Test Steakhouse USDC Prime Vault",
+        ),
     ),
-    # Vault token
-    EthereumTokenInfo(
-        symbol="tstSHUSDCp",
-        decimals=18,
-        address=b"\xa5\x11\xd6\x18\xcd\x0f\x9d\x7c\xad\x79\x10\x09\xd7\xc5\xe3\xb1\x9c\x95\x68\xda",  # vault contract address
+    # https://etherscan.io/address/0xde6c23E561F3e55846207EC45A91b777e0F7C889
+    EthereumVaultInfo(
+        address=b"\xde\x6c\x23\xe5\x61\xf3\xe5\x58\x46\x20\x7e\xc4\x5a\x91\xb7\x77\xe0\xf7\xc8\x89",
         chain_id=1,
-        name="Test Steakhouse USDC Prime",
+        name="Trezor Steakhouse USDC Prime Vault",
+        asset_token=EthereumTokenInfo(
+            symbol="USDC",
+            decimals=6,
+            address=b"\xa0\xb8\x69\x91\xc6\x21\x8b\x36\xc1\xd1\x9d\x4a\x2e\x9e\xb0\xce\x36\x06\xeb\x48",
+            chain_id=1,
+            name="USD Coin",
+        ),
+        vault_token=EthereumTokenInfo(
+            symbol="trSHUSDCp",
+            decimals=18,
+            address=b"\xde\x6c\x23\xe5\x61\xf3\xe5\x58\x46\x20\x7e\xc4\x5a\x91\xb7\x77\xe0\xf7\xc8\x89",
+            chain_id=1,
+            name="Trezor Steakhouse USDC Prime Vault",
+        ),
+    ),
+    # https://etherscan.io/address/0xE4DB1c5A1B709CE4d2adA6985D9D506e58F73829
+    EthereumVaultInfo(
+        address=b"\xe4\xdb\x1c\x5a\x1b\x70\x9c\xe4\xd2\xad\xa6\x98\x5d\x9d\x50\x6e\x58\xf7\x38\x29",
+        chain_id=1,
+        name="Trezor Steakhouse USDT Prime Vault",
+        asset_token=EthereumTokenInfo(
+            symbol="USDT",
+            decimals=6,
+            address=b"\xda\xc1\x7f\x95\x8d\x2e\xe5\x23\xa2\x20\x62\x06\x99\x45\x97\xc1\x3d\x83\x1e\xc7",
+            chain_id=1,
+            name="Tether USD",
+        ),
+        vault_token=EthereumTokenInfo(
+            symbol="trSHUSDTp",
+            decimals=18,
+            address=b"\xe4\xdb\x1c\x5a\x1b\x70\x9c\xe4\xd2\xad\xa6\x98\x5d\x9d\x50\x6e\x58\xf7\x38\x29",
+            chain_id=1,
+            name="Trezor Steakhouse USDT Prime Vault",
+        ),
     ),
 )
+
+UNKNOWN_VAULT = EthereumVaultInfo(
+    address=None,
+    chain_id=None,
+    name="UNKNOWN VAULT",
+    asset_token=UNKNOWN_TOKEN,
+    vault_token=UNKNOWN_TOKEN,
+)
+
+
+def get_token_label(token_addr: AnyBytes, network: EthereumNetworkInfo) -> str:
+    # Only known token for now. We can use clear signing here to request token definitions from Connect, once it is done.
+    # Would move it to EthereumVaultInfo but there don't seem to be plans to add more tokens for now.
+    # https://etherscan.io/token/0x58d97b57bb95320f9a05dc918aef65434969c2b2
+    _MORPHO_ADDR = b"\x58\xd9\x7b\x57\xbb\x95\x32\x0f\x9a\x05\xdc\x91\x8a\xef\x65\x43\x49\x69\xc2\xb2"
+    if token_addr == _MORPHO_ADDR and network.chain_id == 1:
+        return "MORPHO"
+    else:
+        return "UNKNOWN"
 
 
 def lookup_vault(
     network: EthereumNetworkInfo, vault_addr: AnyBytes
-) -> tuple[bool, str, EthereumTokenInfo, EthereumTokenInfo]:
-    """Returns (is_known_vault, vault_name_or_address, asset_token, vault_token)"""
-    from .helpers import address_from_bytes
-    from .tokens import UNKNOWN_TOKEN
+) -> EthereumVaultInfo:
+    """Returns the vault info for the given address and network"""
 
-    if network.chain_id == KNOWN_VAULT[1] and vault_addr == KNOWN_VAULT[0]:
-        return True, KNOWN_VAULT[2], KNOWN_VAULT[3], KNOWN_VAULT[4]
-    else:
-        return (
-            False,
-            address_from_bytes(vault_addr, network),
-            UNKNOWN_TOKEN,
-            UNKNOWN_TOKEN,
-        )
+    for vault in KNOWN_VAULTS:
+        if network.chain_id == vault.chain_id and vault_addr == vault.address:
+            return vault
+
+    return UNKNOWN_VAULT

--- a/core/src/trezor/ui/layouts/bolt/__init__.py
+++ b/core/src/trezor/ui/layouts/bolt/__init__.py
@@ -1342,6 +1342,7 @@ if not utils.BITCOIN_ONLY:
         chain: str,
         br_name: str = "ethereum/vault",
         br_code: ButtonRequestType = ButtonRequestType.SignTx,
+        extra_data: str | None = None,
     ) -> None:
 
         account_properties: list[StrPropertyType] = []
@@ -1356,7 +1357,7 @@ if not utils.BITCOIN_ONLY:
             title=title,
             value=intro_question,
             description="",
-            br_name=br_name + "/intro",
+            br_name=f"{br_name}/intro",
             br_code=br_code,
             verb=TR.buttons__continue,
             is_data=False,
@@ -1367,19 +1368,82 @@ if not utils.BITCOIN_ONLY:
         await confirm_value(
             title=title,
             value=vault_str,
-            description="",
-            br_name=br_name + "/vault",
+            description=verb,
+            br_name=f"{br_name}/vault",
             br_code=br_code,
             verb=TR.buttons__continue,
         )
 
         await confirm_properties(
-            br_name=br_name + "/amount",
+            br_name=f"{br_name}/amount",
             title=title,
             props=[
                 (amount_label, amount, False),
                 (TR.words__chain, chain, False),
             ],
+            br_code=br_code,
+        )
+
+        if extra_data is not None:
+            await confirm_value(
+                title=title,
+                value=extra_data,
+                description=TR.ethereum__calldata_suffix,
+                br_name=f"{br_name}/extra_data",
+                br_code=br_code,
+                verb=TR.buttons__continue,
+                is_data=True,
+                cancel=True,
+            )
+
+        await _confirm_summary(
+            amount=None,
+            amount_label=None,
+            fee=maximum_fee,
+            fee_label=TR.send__maximum_fee,
+            title=title,
+            extra_items=info_items,
+            extra_title=TR.confirm_total__title_fee,
+            br_name=f"{br_name}/summary",
+            br_code=br_code,
+        )
+
+    async def confirm_ethereum_vault_claim(
+        title: str,
+        intro_question: str,
+        account: str | None,
+        account_path: str | None,
+        maximum_fee: str,
+        info_items: Iterable[StrPropertyType],
+        token_list: str,
+        br_name: str,
+        br_code: ButtonRequestType = ButtonRequestType.SignTx,
+    ) -> None:
+
+        account_properties: list[StrPropertyType] = []
+        if account:
+            account_properties.append((TR.words__account, account, None))
+        if account_path:
+            account_properties.append(
+                (TR.address_details__derivation_path, account_path, None)
+            )
+
+        await confirm_value(
+            title=title,
+            value=intro_question,
+            description="",
+            br_name=f"{br_name}/intro",
+            br_code=br_code,
+            verb=TR.buttons__continue,
+            is_data=False,
+            info_items=account_properties if account_properties else None,
+            info_title=TR.address_details__account_info,
+        )
+
+        await confirm_properties(
+            br_name=f"{br_name}/tokens",
+            title=title,
+            props=[(TR.ethereum__reward_tokens, token_list, False)],
             br_code=br_code,
         )
 
@@ -1391,7 +1455,7 @@ if not utils.BITCOIN_ONLY:
             title=title,
             extra_items=info_items,
             extra_title=TR.confirm_total__title_fee,
-            br_name=br_name + "/summary",
+            br_name=f"{br_name}/summary",
             br_code=br_code,
         )
 

--- a/core/src/trezor/ui/layouts/caesar/__init__.py
+++ b/core/src/trezor/ui/layouts/caesar/__init__.py
@@ -1317,6 +1317,7 @@ if not utils.BITCOIN_ONLY:
         chain: str,
         br_name: str = "ethereum/vault",
         br_code: ButtonRequestType = ButtonRequestType.SignTx,
+        extra_data: str | None = None,
     ) -> None:
         from ..properties import with_colon
 
@@ -1337,7 +1338,7 @@ if not utils.BITCOIN_ONLY:
             chunkify=False,
             info_items=account_properties if account_properties else None,
             cancel=True,
-            br_name=br_name + "/intro",
+            br_name=f"{br_name}/intro",
             br_code=br_code,
         )
 
@@ -1347,17 +1348,87 @@ if not utils.BITCOIN_ONLY:
             description=verb,
             verb=TR.buttons__continue,
             cancel=True,
-            br_name=br_name + "/vault",
+            br_name=f"{br_name}/vault",
             br_code=br_code,
         )
 
         await confirm_properties(
-            br_name + "/amount",
+            f"{br_name}/amount",
             title,
             [
                 (amount_label, amount, False),
                 (TR.words__chain, chain, False),
             ],
+        )
+
+        if extra_data is not None:
+            await confirm_value(
+                title=title,
+                value=extra_data,
+                description=TR.ethereum__calldata_suffix,
+                is_data=True,
+                verb=TR.buttons__continue,
+                cancel=True,
+                br_name=f"{br_name}/extra_data",
+                br_code=br_code,
+            )
+
+        await raise_if_not_confirmed(
+            trezorui_api.confirm_summary(
+                amount=None,
+                amount_label=None,
+                fee=maximum_fee,
+                fee_label=with_colon(TR.send__maximum_fee),
+                extra_title=TR.confirm_total__title_fee,
+                extra_items=with_colon(info_items),
+                title=title,
+            ),
+            br_name=f"{br_name}/summary",
+            br_code=br_code,
+        )
+
+    async def confirm_ethereum_vault_claim(
+        title: str,
+        intro_question: str,
+        account: str | None,
+        account_path: str | None,
+        maximum_fee: str,
+        info_items: Iterable[StrPropertyType],
+        token_list: str,
+        br_name: str,
+        br_code: ButtonRequestType = ButtonRequestType.SignTx,
+    ) -> None:
+
+        from ..properties import with_colon
+
+        account_properties: list[StrPropertyType] = []
+        if account:
+            account_properties.append((TR.words__account, account, None))
+        if account_path:
+            account_properties.append(
+                (TR.address_details__derivation_path, account_path, None)
+            )
+
+        await confirm_value(
+            title=title,
+            value=intro_question,
+            is_data=False,
+            description=None,
+            verb=TR.buttons__continue,
+            chunkify=False,
+            info_items=account_properties if account_properties else None,
+            cancel=True,
+            br_name=f"{br_name}/intro",
+            br_code=br_code,
+        )
+
+        await confirm_properties(
+            f"{br_name}/tokens",
+            title,
+            [
+                (TR.ethereum__reward_tokens, token_list, False),
+            ],
+            br_code=br_code,
         )
 
         await raise_if_not_confirmed(
@@ -1370,7 +1441,7 @@ if not utils.BITCOIN_ONLY:
                 extra_items=with_colon(info_items),
                 title=title,
             ),
-            br_name=br_name + "/summary",
+            br_name=f"{br_name}/summary",
             br_code=br_code,
         )
 

--- a/core/src/trezor/ui/layouts/delizia/__init__.py
+++ b/core/src/trezor/ui/layouts/delizia/__init__.py
@@ -1327,6 +1327,104 @@ if not utils.BITCOIN_ONLY:
         chain: str,
         br_name: str = "ethereum/vault",
         br_code: ButtonRequestType = ButtonRequestType.SignTx,
+        extra_data: str | None = None,
+    ) -> None:
+        from trezor.ui.layouts.menu import Menu, interact_with_menu
+
+        menu_items = []
+        account_info_items = _get_account_info_items(account, account_path)
+        if account_info_items:
+            menu_items.append(
+                create_details(
+                    TR.address_details__account_info,
+                    account_info_items[0][1],
+                    title=TR.address_details__account_info,
+                )
+            )
+
+        steps = [
+            lambda: interact_with_menu(
+                trezorui_api.confirm_value(
+                    title=title,
+                    value=intro_question,
+                    is_data=False,
+                    description=None,
+                    chunkify=False,
+                    external_menu=True,
+                ),
+                Menu.root(menu_items, TR.send__cancel_sign),
+                f"{br_name}/intro",
+                ButtonRequestType.SignTx,
+            ),
+            lambda: interact_with_menu(
+                trezorui_api.confirm_value(
+                    title=title,
+                    value=vault_str,
+                    is_data=False,
+                    description=verb,
+                    verb="",
+                ),
+                Menu.root(menu_items, TR.send__cancel_sign),
+                f"{br_name}/vault_name",
+            ),
+            lambda: interact_with_menu(
+                trezorui_api.confirm_properties(
+                    title=title,
+                    items=[
+                        (amount_label, amount, False),
+                        (TR.words__chain, chain, False),
+                    ],
+                    hold=False,
+                    verb=TR.buttons__continue,
+                ),
+                Menu.root(menu_items, TR.send__cancel_sign),
+                f"{br_name}/amount",
+                br_code,
+            ),
+        ]
+        if extra_data is not None:
+            steps.append(
+                lambda: interact_with_menu(
+                    trezorui_api.confirm_value(
+                        title=title,
+                        value=extra_data,
+                        description=TR.ethereum__calldata_suffix,
+                        is_data=True,
+                    ),
+                    Menu.root(menu_items, TR.send__cancel_sign),
+                    f"{br_name}/extra_data",
+                    br_code,
+                )
+            )
+        steps.append(
+            lambda: interact_with_menu(
+                trezorui_api.confirm_summary(
+                    amount=None,
+                    amount_label=None,
+                    fee=maximum_fee,
+                    fee_label=TR.send__maximum_fee,
+                    extra_title=TR.confirm_total__title_fee,
+                    extra_items=list(info_items),
+                    title=title,
+                    back_button=False,
+                ),
+                Menu.root(menu_items, TR.send__cancel_sign),
+                f"{br_name}/summary",
+                br_code,
+            )
+        )
+        await confirm_linear_flow(*steps)
+
+    async def confirm_ethereum_vault_claim(
+        title: str,
+        intro_question: str,
+        account: str | None,
+        account_path: str | None,
+        maximum_fee: str,
+        info_items: Iterable[StrPropertyType],
+        token_list: str,
+        br_name: str,
+        br_code: ButtonRequestType = ButtonRequestType.SignTx,
     ) -> None:
         from trezor.ui.layouts.menu import Menu, interact_with_menu
 
@@ -1352,32 +1450,20 @@ if not utils.BITCOIN_ONLY:
                     external_menu=True,
                 ),
                 Menu.root(menu_items, TR.send__cancel_sign),
-                br_name + "/intro",
-                ButtonRequestType.SignTx,
-            ),
-            lambda: interact_with_menu(
-                trezorui_api.confirm_value(
-                    title=title,
-                    value=vault_str,
-                    is_data=False,
-                    description=verb,
-                    verb="",
-                ),
-                Menu.root(menu_items, TR.send__cancel_sign),
-                br_name + "/vault_name",
+                f"{br_name}/intro",
+                br_code,
             ),
             lambda: interact_with_menu(
                 trezorui_api.confirm_properties(
                     title=title,
                     items=[
-                        (amount_label, amount, False),
-                        (TR.words__chain, chain, False),
+                        (TR.ethereum__reward_tokens, token_list, False),
                     ],
                     hold=False,
                     verb=TR.buttons__continue,
                 ),
                 Menu.root(menu_items, TR.send__cancel_sign),
-                br_name + "/amount",
+                f"{br_name}/tokens",
                 br_code,
             ),
             lambda: interact_with_menu(
@@ -1392,7 +1478,7 @@ if not utils.BITCOIN_ONLY:
                     back_button=False,
                 ),
                 Menu.root(menu_items, TR.send__cancel_sign),
-                br_name + "/summary",
+                f"{br_name}/summary",
                 br_code,
             ),
         )

--- a/core/src/trezor/ui/layouts/eckhart/__init__.py
+++ b/core/src/trezor/ui/layouts/eckhart/__init__.py
@@ -1312,6 +1312,7 @@ if not utils.BITCOIN_ONLY:
         chain: str,
         br_name: str = "ethereum/vault",
         br_code: ButtonRequestType = ButtonRequestType.SignTx,
+        extra_data: str | None = None,
     ) -> None:
         from trezor.ui.layouts.menu import Menu, interact_with_menu
 
@@ -1327,7 +1328,7 @@ if not utils.BITCOIN_ONLY:
                 )
             )
 
-        await confirm_linear_flow(
+        steps = [
             lambda: interact_with_menu(
                 trezorui_api.confirm_action(
                     title=title,
@@ -1337,7 +1338,7 @@ if not utils.BITCOIN_ONLY:
                     cancel=False,
                 ),
                 Menu.root(menu_items, TR.send__cancel_sign),
-                br_name + "/intro",
+                f"{br_name}/intro",
                 br_code,
             ),
             lambda: interact_with_menu(
@@ -1348,7 +1349,7 @@ if not utils.BITCOIN_ONLY:
                     verb=TR.buttons__continue,
                 ),
                 Menu.root(menu_items, TR.send__cancel_sign),
-                br_name + "/vault_name",
+                f"{br_name}/vault_name",
                 br_code,
             ),
             lambda: interact_with_menu(
@@ -1362,7 +1363,92 @@ if not utils.BITCOIN_ONLY:
                     verb=TR.buttons__continue,
                 ),
                 Menu.root(menu_items, TR.send__cancel_sign),
-                br_name + "/amount",
+                f"{br_name}/amount",
+                br_code,
+            ),
+        ]
+        if extra_data is not None:
+            steps.append(
+                lambda: interact_with_menu(
+                    trezorui_api.confirm_properties(
+                        title=title,
+                        items=[(TR.ethereum__calldata_suffix, extra_data, True)],
+                        hold=False,
+                        verb=TR.buttons__continue,
+                    ),
+                    Menu.root(menu_items, TR.send__cancel_sign),
+                    f"{br_name}/extra_data",
+                    br_code,
+                )
+            )
+        steps.append(
+            lambda: interact_with_menu(
+                trezorui_api.confirm_summary(
+                    amount=None,
+                    amount_label=None,
+                    fee=maximum_fee,
+                    fee_label=TR.send__maximum_fee,
+                    extra_title=TR.confirm_total__title_fee,
+                    extra_items=list(info_items),
+                    title=title,
+                    back_button=False,
+                ),
+                Menu.root(menu_items, TR.send__cancel_sign),
+                f"{br_name}/summary",
+                br_code,
+            )
+        )
+        await confirm_linear_flow(*steps)
+
+    async def confirm_ethereum_vault_claim(
+        title: str,
+        intro_question: str,
+        account: str | None,
+        account_path: str | None,
+        maximum_fee: str,
+        info_items: Iterable[StrPropertyType],
+        token_list: str,
+        br_name: str,
+        br_code: ButtonRequestType = ButtonRequestType.SignTx,
+    ) -> None:
+
+        from trezor.ui.layouts.menu import Menu, interact_with_menu
+
+        menu_items = []
+        account_properties = _get_account_info_items(account, account_path)
+        if account_properties:
+            menu_items.append(
+                create_details(
+                    TR.address_details__account_info,
+                    account_properties,
+                    title=TR.address_details__account_info,
+                    subtitle=TR.send__send_from,
+                )
+            )
+        await confirm_linear_flow(
+            lambda: interact_with_menu(
+                trezorui_api.confirm_action(
+                    title=title,
+                    action=intro_question,
+                    description=None,
+                    external_menu=True,
+                    cancel=False,
+                ),
+                Menu.root(menu_items, TR.send__cancel_sign),
+                f"{br_name}/intro",
+                br_code,
+            ),
+            lambda: interact_with_menu(
+                trezorui_api.confirm_properties(
+                    title=title,
+                    items=[
+                        (TR.ethereum__reward_tokens, token_list, False),
+                    ],
+                    hold=False,
+                    verb=TR.buttons__continue,
+                ),
+                Menu.root(menu_items, TR.send__cancel_sign),
+                f"{br_name}/tokens",
                 br_code,
             ),
             lambda: interact_with_menu(
@@ -1377,7 +1463,7 @@ if not utils.BITCOIN_ONLY:
                     back_button=False,
                 ),
                 Menu.root(menu_items, TR.send__cancel_sign),
-                br_name + "/summary",
+                f"{br_name}/summary",
                 br_code,
             ),
         )

--- a/core/translations/en.json
+++ b/core/translations/en.json
@@ -755,6 +755,7 @@
     "ethereum__approve_revoke_from": "Revoke from",
     "ethereum__approve_to": "Approve to",
     "ethereum__approve_unlimited_template": "Approving unlimited amount of {0}",
+    "ethereum__calldata_suffix": "Calldata suffix",
     "ethereum__confirm_contract": "Confirm contract",
     "ethereum__contract_address": "Provider contract address",
     "ethereum__data_size_template": "Size: {0} bytes",

--- a/core/translations/order.json
+++ b/core/translations/order.json
@@ -1217,5 +1217,6 @@
   "1215": "ethereum__withdraw_amount",
   "1216": "ethereum__withdraw_to",
   "1217": "ethereum__subtitle_input_data_bytes",
-  "1218": "ethereum__title_input_data_bytes"
+  "1218": "ethereum__title_input_data_bytes",
+  "1219": "ethereum__calldata_suffix"
 }

--- a/core/translations/signatures.json
+++ b/core/translations/signatures.json
@@ -1,8 +1,8 @@
 {
   "current": {
-    "merkle_root": "71da2fb2f690d79f8d3d449101adc938e589bbb5d66bc676708f82c7231f3fd5",
-    "datetime": "2026-04-27T14:34:40.640020+00:00",
-    "commit": "4f6ccfdfb316230bd712e5f03ccd9c185fc55760"
+    "merkle_root": "2d5ffc0e044f37c58d76e20cc093d873b213f9df2f1ad411bdfcf83d6957c237",
+    "datetime": "2026-04-27T16:03:24.332866+00:00",
+    "commit": "1bc9b317f54f83c0e2bc9c71c9d486429be7185d"
   },
   "history": [
     {


### PR DESCRIPTION
Need to coordinate with Suite, how and when to show the claim flow. This PR contains the main parsing logic albeit subverted by an early `return None` to induce blind signing.

We also add an `appended data` screen to other flows since a lot of vaults use it and we can no longer forbid the flow just because of it.

Other refactorings like making the vaults their own class, etc.

Notes on Claim call
---
Merkl Claims are used to claim reward tokens.  For multiple tokens to be claimed at once, the user address is to be multiplicated in the users[] array (CC @tomasklim )

Since many Morpho Vaults use an appended small data tag for off-chain indexing, tracking or some other internal use case, We now show an additional screen to the user when such a data is found. This design will be perfected later.

Such addtional data can only be detected for regular vault transaction like deposit, withdraw, and redeem. For claim, the proofs can be of varied lengths therefore we can't detect whether any data is an appendix or part of the proof.

CC @tomasklim for EVM/ERC-4626 correctness.
@Hannsek for 'appended data' screens.