### PR TITLE
feat(core): use "Initiate connection" bootloader label on T2T1, T3B1, T3T1

### DIFF
--- a/core/embed/rust/src/ui/layout_bolt/bootloader/intro.rs
+++ b/core/embed/rust/src/ui/layout_bolt/bootloader/intro.rs
@@ -42,7 +42,7 @@ impl<'a> Intro<'a> {
             menu: Button::with_icon(Icon::new(MENU32))
                 .styled(button_bld_menu())
                 .with_expanded_touch_area(Insets::uniform(13)),
-            host: Button::with_text("INSTALL FIRMWARE".into()).styled(button_bld()),
+            host: Button::with_text("INITIATE CONNECTION".into()).styled(button_bld()),
             text: Label::left_aligned(content, TEXT_NORMAL).vertically_centered(),
             warn: (!fw_ok).then_some(
                 Label::new("FIRMWARE CORRUPTED".into(), Alignment::Start, TEXT_WARNING)

--- a/core/embed/rust/src/ui/layout_caesar/bootloader/intro.rs
+++ b/core/embed/rust/src/ui/layout_caesar/bootloader/intro.rs
@@ -17,7 +17,7 @@ use super::super::{
     },
 };
 
-const LEFT_BUTTON_TEXT: &str = "INSTALL FW";
+const LEFT_BUTTON_TEXT: &str = "Init connection";
 const RIGHT_BUTTON_TEXT: &str = "MENU";
 
 #[repr(u32)]

--- a/core/embed/rust/src/ui/layout_delizia/bootloader/intro.rs
+++ b/core/embed/rust/src/ui/layout_delizia/bootloader/intro.rs
@@ -45,7 +45,7 @@ impl<'a> Intro<'a> {
                     .with_expanded_touch_area(Insets::uniform(13)),
             ),
             host: Child::new(
-                Button::with_text("INSTALL FIRMWARE".into())
+                Button::with_text("INITIATE CONNECTION".into())
                     .styled(button_bld())
                     .with_text_align(Alignment::Center),
             ),


### PR DESCRIPTION
## Summary

- Replaces the outdated `INSTALL FIRMWARE` / `INSTALL FW` button label on the bootloader intro screen with a label that accurately describes what tapping it does — initiating the USB connection to the host
- T3W1 (Safe 7) already used `Initiate connection`; this aligns all other Core devices with that wording
- T3B1 (Safe 3) uses the shortened `Init connection` to fit the 128×64 px display with the split-button layout

| Device | Layout | Old label | New label |
|---|---|---|---|
| T3B1 (Safe 3) | `layout_caesar` | `INSTALL FW` | `Init connection` (auto-uppercased by `FONT_NORMAL_UPPER`) |
| T3T1 (Safe 5) | `layout_delizia` | `INSTALL FIRMWARE` | `INITIATE CONNECTION` |
| T2T1 (Model T) | `layout_bolt` | `INSTALL FIRMWARE` | `INITIATE CONNECTION` |

## Test plan

- [ ] Build bootloader emulator for each model (`TREZOR_MODEL=T3T1/T3B1/T2T1 make build_bootloader_emu`) and verify the intro screen shows the new label
- [ ] Confirm label fits within button bounds on T3B1 (128×64 display)
- [ ] Update Crowdin translation strings for all three models

Closes #6824

🤖 Generated with [Claude Code](https://claude.com/claude-code)