### PR TITLE
chore(vendor): update `ts-tvl` to version 2.4

### DIFF
--- a/core/tools/generate_tropic_model_config.py
+++ b/core/tools/generate_tropic_model_config.py
@@ -30,11 +30,6 @@ EXTRA_FILES = [
     VENDOR_CONFIG_DIR / "tropic01_ese_public_key_1.pem",
 ]
 
-# Version of the RISCV Firmware (also know as Application FW)
-RISCV_FW_MAJOR = 1
-RISCV_FW_MINOR = 0
-RISCV_FW_PATCH = 0
-
 
 @click.command()
 @click.option("--check", is_flag=True)
@@ -97,13 +92,6 @@ def generate_config(check: bool) -> None:
                 data += b"\x00" * (SLOT_LEN - len(data))
             user_data[TROPIC_DEVICE_CERT_FIRST_SLOT + i] = {"value": data}
 
-    # Set RISC-V FW version
-    riscv_fw_version = (
-        b"\x00"
-        + RISCV_FW_PATCH.to_bytes(1, "little")
-        + RISCV_FW_MINOR.to_bytes(1, "little")
-        + RISCV_FW_MAJOR.to_bytes(1, "little")
-    )
     config_dict = {
         "s_t_priv": "tropic01_ese_private_key_1.pem",
         "s_t_pub": "tropic01_ese_public_key_1.pem",
@@ -118,7 +106,8 @@ def generate_config(check: bool) -> None:
                 "origin": 2,  # imported key
             }
         },
-        "riscv_fw_version": riscv_fw_version,
+        "riscv_fw_version": "1.0.0",  # Version of the RISCV Firmware (also know as Application FW) used in TS7 devices
+        "spect_fw_version": "1.0.0",
     }
 
     config = yaml.dump(config_dict)

--- a/tests/tropic_model/config.yml
+++ b/tests/tropic_model/config.yml
@@ -30,8 +30,8 @@ r_user_data:
       AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA
       AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA
       AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA
-riscv_fw_version: !!binary |
-  AAAAAQ==
+riscv_fw_version: 1.0.0
 s_t_priv: tropic01_ese_private_key_1.pem
 s_t_pub: tropic01_ese_public_key_1.pem
+spect_fw_version: 1.0.0
 x509_certificate: tropic01_ese_certificate_1.pem


### PR DESCRIPTION
- Updates `ts-tvl` submodule to version 2.4.
- Release notes: https://github.com/tropicsquare/ts-tvl/releases/tag/2.4
- Follows #6561, where `ts-tvl` was pinned to a non-release commit to enable support for `cryptography >=43`.


Also, the tropic model config was adjusted:
- Uses string representation instead of bytes for `riscv_fw_version`.
- Specifies `spect_fw_version` to 1.0.0, which would otherwise be set to a different default value (1.2.0).