### PR TITLE
prevent NFC driver crash on repeated deinitialization

### DIFF
--- a/core/embed/io/nfc/st25/nfc.c
+++ b/core/embed/io/nfc/st25/nfc.c
@@ -262,7 +262,9 @@ void nfc_deinit(void) {
     drv->rfal_initialized = false;
   }
 
-  HAL_SPI_DeInit(&drv->hspi);
+  if (drv->hspi.Instance != NULL) {
+    HAL_SPI_DeInit(&drv->hspi);
+  }
 
   HAL_GPIO_DeInit(NFC_SPI_MISO_PORT, NFC_SPI_MISO_PIN);
   HAL_GPIO_DeInit(NFC_SPI_MOSI_PORT, NFC_SPI_MOSI_PIN);


### PR DESCRIPTION
Spi deinit causes the crash when receiving NULL instance.