### PR TITLE
Hide written chars in passphrase keyboard

### DIFF
--- a/core/.changelog.d/6342.fixed
+++ b/core/.changelog.d/6342.fixed
@@ -1,0 +1,1 @@
+[T2T1,T3T1] Hide written characters in passphrase keyboard.

--- a/core/embed/rust/src/ui/component/text/common.rs
+++ b/core/embed/rust/src/ui/component/text/common.rs
@@ -36,12 +36,28 @@ impl TextBox {
         &self.text
     }
 
+    /// Length of the content in *bytes* (matches `std::String::len`). Use
+    /// `count()` for the number of characters.
     pub fn len(&self) -> usize {
         self.text.len()
     }
 
+    /// Number of *characters* in the content. O(n) in the byte length.
+    pub fn count(&self) -> usize {
+        self.text.chars().count()
+    }
+
     pub fn is_empty(&self) -> bool {
         self.text.is_empty()
+    }
+
+    /// Returns the last character of the content as a string slice, if any.
+    /// Safe to use without knowing the byte width of the last UTF-8 sequence.
+    pub fn last_char_str(&self) -> Option<&str> {
+        self.text
+            .char_indices()
+            .next_back()
+            .map(|(i, _)| &self.text[i..])
     }
 
     /// Delete the last character of content, if any.

--- a/core/embed/rust/src/ui/layout_bolt/component/keyboard/passphrase.rs
+++ b/core/embed/rust/src/ui/layout_bolt/component/keyboard/passphrase.rs
@@ -407,7 +407,6 @@ impl Input {
     const STYLE: TextStyle =
         theme::label_keyboard().with_line_breaking(LineBreaking::BreakWordsNoHyphen);
     const SHOWN_INSETS: Insets = Insets::new(8, 10, 8, 10);
-    const SHOWN_TOUCH_OUTSET: Insets = Insets::bottom(80);
 
     fn new(max_len: usize) -> Self {
         Self {
@@ -538,11 +537,6 @@ impl Component for Input {
             return None;
         }
 
-        let extended_shown_area = self
-            .shown_area
-            .outset(Self::SHOWN_TOUCH_OUTSET)
-            .clamp(SCREEN);
-
         match event {
             // Reveal on touch start within the extended input area
             Event::Touch(TouchEvent::TouchStart(pos)) if self.reveal_area.get().contains(pos) => {
@@ -553,15 +547,8 @@ impl Component for Input {
                 self.pad.clear();
                 ctx.request_paint();
             }
+            // Hide on touch end anywhere on the screen
             Event::Touch(TouchEvent::TouchEnd(_)) if self.display_style == DisplayStyle::Shown => {
-                self.display_style = DisplayStyle::Hidden;
-                self.pad.clear();
-                ctx.request_paint();
-            }
-            Event::Touch(TouchEvent::TouchMove(pos))
-                if !extended_shown_area.contains(pos)
-                    && self.display_style == DisplayStyle::Shown =>
-            {
                 self.display_style = DisplayStyle::Hidden;
                 self.pad.clear();
                 ctx.request_paint();

--- a/core/embed/rust/src/ui/layout_bolt/component/keyboard/passphrase.rs
+++ b/core/embed/rust/src/ui/layout_bolt/component/keyboard/passphrase.rs
@@ -1,18 +1,26 @@
 use crate::{
-    strutil::TString,
+    strutil::{ShortString, TString},
+    time::Duration,
     ui::{
         component::{
-            base::ComponentExt, text::common::TextBox, Child, Component, Event, EventCtx, Never,
-            Paginate,
+            base::ComponentExt,
+            text::{
+                common::TextBox,
+                layout::{LayoutFit, LineBreaking},
+                TextStyle,
+            },
+            Child, Component, Event, EventCtx, Never, Pad, Paginate, TextLayout, Timer,
         },
         display,
-        geometry::{Grid, Offset, Rect},
-        shape::{self, Renderer},
-        util::{long_line_content_with_ellipsis, Pager},
+        event::TouchEvent,
+        geometry::{Alignment, Grid, Insets, Offset, Rect},
+        shape::{Bar, Renderer, Text},
+        util::{DisplayStyle, Pager},
     },
 };
 
 use super::super::{
+    super::constant::SCREEN,
     button::{Button, ButtonContent, ButtonMsg},
     keyboard::common::{render_pending_marker, MultiTapKeyboard},
     swipe::{Swipe, SwipeDirection},
@@ -134,9 +142,15 @@ impl PassphraseKeyboard {
         };
 
         self.scrollbar.set_pager(pager);
-        // Clear the pending state.
-        self.input
-            .mutate(ctx, |ctx, i| i.multi_tap.clear_pending_state(ctx));
+        // Clear the pending state. If there was a pending character, it has been
+        // committed; show it briefly then hide.
+        self.input.mutate(ctx, |ctx, i| {
+            if i.multi_tap.pending_key().is_some() {
+                i.multi_tap.clear_pending_state(ctx);
+                i.display_style = DisplayStyle::LastOnly;
+                i.last_char_timer.start(ctx, Input::LAST_DIGIT_TIMEOUT);
+            }
+        });
         // Update buttons.
         self.replace_button_content(ctx, pager.current().into());
         // Reset backlight to normal level on next paint.
@@ -219,18 +233,19 @@ impl Component for PassphraseKeyboard {
     fn place(&mut self, bounds: Rect) -> Rect {
         let bounds = bounds.inset(theme::borders());
 
-        let (input_area, key_grid_area) =
+        let (top_area, key_grid_area) =
             bounds.split_bottom(4 * theme::PIN_BUTTON_HEIGHT + 3 * theme::BUTTON_SPACING);
 
-        let (input_area, scroll_area) = input_area.split_bottom(INPUT_AREA_HEIGHT);
+        let (input_area, scroll_area) = top_area.split_bottom(INPUT_AREA_HEIGHT);
         let (scroll_area, _) = scroll_area.split_top(ScrollBar::DOT_SIZE);
 
         let key_grid = Grid::new(key_grid_area, 4, 3).with_spacing(theme::BUTTON_SPACING);
         let confirm_btn_area = key_grid.cell(11);
         let back_btn_area = key_grid.cell(9);
 
-        self.page_swipe.place(bounds);
+        self.page_swipe.place(key_grid_area);
         self.input.place(input_area);
+        self.input.inner().reveal_area.set(top_area);
         self.confirm.place(confirm_btn_area);
         self.back.place(back_btn_area);
         self.scrollbar.place(scroll_area);
@@ -255,17 +270,32 @@ impl Component for PassphraseKeyboard {
     }
 
     fn event(&mut self, ctx: &mut EventCtx, event: Event) -> Option<Self::Msg> {
+        // Handle multi-tap timeout: commit the pending character and show it briefly
         let multitap_timeout = self.input.mutate(ctx, |ctx, i| {
             if i.multi_tap.timeout_event(event) {
                 i.multi_tap.clear_pending_state(ctx);
+                i.display_style = DisplayStyle::LastOnly;
+                i.last_char_timer.start(ctx, Input::LAST_DIGIT_TIMEOUT);
                 true
             } else {
                 false
             }
         });
         if multitap_timeout {
+            // Disable keypad when the passphrase reached the max length
+            if self.input.inner().textbox.len() >= self.max_len {
+                self.update_input_btns_state(ctx);
+            }
             return None;
         }
+
+        self.input.event(ctx, event);
+
+        // When passphrase is shown in full, disable all keypad interaction
+        if self.input.inner().display_style == DisplayStyle::Shown {
+            return None;
+        }
+
         if let Some(swipe) = self.page_swipe.event(ctx, event) {
             // We have detected a horizontal swipe. Change the keyboard page.
             self.on_page_swipe(ctx, swipe);
@@ -286,6 +316,7 @@ impl Component for PassphraseKeyboard {
                     self.input.mutate(ctx, |ctx, i| {
                         i.multi_tap.clear_pending_state(ctx);
                         i.textbox.delete_last(ctx);
+                        i.display_style = DisplayStyle::Hidden;
                     });
                     self.after_edit(ctx);
                     None
@@ -295,6 +326,7 @@ impl Component for PassphraseKeyboard {
                 self.input.mutate(ctx, |ctx, i| {
                     i.multi_tap.clear_pending_state(ctx);
                     i.textbox.clear(ctx);
+                    i.display_style = DisplayStyle::Hidden;
                 });
                 self.after_edit(ctx);
                 return None;
@@ -319,6 +351,15 @@ impl Component for PassphraseKeyboard {
                 self.input.mutate(ctx, |ctx, i| {
                     let edit = text.map(|c| i.multi_tap.click_key(ctx, key, c));
                     i.textbox.apply(ctx, edit);
+                    if text.len() == 1 {
+                        // Single-char key: immediately applied, show last char briefly
+                        i.display_style = DisplayStyle::LastOnly;
+                        i.last_char_timer.start(ctx, Input::LAST_DIGIT_TIMEOUT);
+                    } else {
+                        // Multi-tap key: pending state, show char with marker
+                        i.last_char_timer.stop();
+                        i.display_style = DisplayStyle::LastWithMarker;
+                    }
                 });
                 self.after_edit(ctx);
                 return None;
@@ -328,16 +369,21 @@ impl Component for PassphraseKeyboard {
     }
 
     fn render<'s>(&'s self, target: &mut impl Renderer<'s>) {
-        self.input.render(target);
-        self.scrollbar.render(target);
-        self.confirm.render(target);
-        self.back.render(target);
-        for btn in &self.keys {
-            btn.render(target);
-        }
-        if self.fade.take() {
-            // Note that this is blocking and takes some time.
-            display::fade_backlight(theme::backlight::get_backlight_normal());
+        if self.input.inner().display_style == DisplayStyle::Shown {
+            // When passphrase is revealed, render only the shown overlay
+            self.input.render(target);
+        } else {
+            self.input.render(target);
+            self.scrollbar.render(target);
+            self.confirm.render(target);
+            self.back.render(target);
+            for btn in &self.keys {
+                btn.render(target);
+            }
+            if self.fade.take() {
+                // Note that this is blocking and takes some time.
+                display::fade_backlight(theme::backlight::get_backlight_normal());
+            }
         }
     }
 }
@@ -346,14 +392,133 @@ struct Input {
     area: Rect,
     textbox: TextBox,
     multi_tap: MultiTapKeyboard,
+    display_style: DisplayStyle,
+    last_char_timer: Timer,
+    pad: Pad,
+    /// Area in which a touch start triggers the passphrase reveal
+    reveal_area: Cell<Rect>,
+    /// Area in which the passphrase reveal window appears
+    shown_area: Rect,
 }
 
 impl Input {
+    const TWITCH: i16 = 4;
+    const LAST_DIGIT_TIMEOUT: Duration = Duration::from_secs(1);
+    const STYLE: TextStyle =
+        theme::label_keyboard().with_line_breaking(LineBreaking::BreakWordsNoHyphen);
+    const SHOWN_INSETS: Insets = Insets::new(8, 10, 8, 10);
+    const SHOWN_TOUCH_OUTSET: Insets = Insets::bottom(80);
+
     fn new(max_len: usize) -> Self {
         Self {
             area: Rect::zero(),
+            reveal_area: Cell::new(Rect::zero()),
             textbox: TextBox::empty(max_len),
             multi_tap: MultiTapKeyboard::new(),
+            display_style: DisplayStyle::Hidden,
+            last_char_timer: Timer::new(),
+            pad: Pad::with_background(theme::BG),
+            shown_area: Rect::zero(),
+        }
+    }
+
+    fn update_shown_area(&mut self) {
+        let line_height = Self::STYLE.text_font.line_height();
+
+        // Start with full screen width, positioned at the input area top
+        let initial_height = line_height + Self::SHOWN_INSETS.top + Self::SHOWN_INSETS.bottom;
+        let mut shown_area = SCREEN.inset(Self::SHOWN_INSETS).with_height(initial_height);
+
+        // Extend the shown area until the text fits
+        while let LayoutFit::OutOfBounds { .. } = TextLayout::new(Self::STYLE)
+            .with_align(Alignment::Start)
+            .with_bounds(shown_area.inset(Self::SHOWN_INSETS))
+            .fit_text(self.textbox.content())
+        {
+            shown_area = shown_area.outset(Insets::bottom(line_height));
+        }
+
+        self.shown_area = shown_area;
+    }
+
+    fn render_shown<'s>(&self, target: &mut impl Renderer<'s>) {
+        debug_assert_eq!(self.display_style, DisplayStyle::Shown);
+
+        Bar::new(self.shown_area)
+            .with_bg(theme::GREY_DARK)
+            .with_radius(theme::RADIUS as i16)
+            .render(target);
+
+        TextLayout::new(Self::STYLE)
+            .with_bounds(self.shown_area.inset(Self::SHOWN_INSETS))
+            .with_align(Alignment::Start)
+            .render_text(self.textbox.content(), target, true);
+    }
+
+    fn render_hidden<'s>(&self, target: &mut impl Renderer<'s>) {
+        debug_assert_ne!(self.display_style, DisplayStyle::Shown);
+
+        let style = theme::label_keyboard();
+        let pp_len = self.textbox.count();
+        if pp_len == 0 {
+            return;
+        }
+
+        let last_char_visible = self.display_style == DisplayStyle::LastOnly
+            || self.display_style == DisplayStyle::LastWithMarker;
+
+        // Compute how many characters fit in the available width. Account for the
+        // pending marker, which draws itself one pixel longer than the last char.
+        let available_width = self.area.width() - 1;
+        let asterisk_width = style.text_font.char_width('*').max(1);
+        let max_visible = (available_width / asterisk_width).max(1) as usize;
+        let visible_count = pp_len.min(max_visible);
+        let asterisk_count = visible_count.saturating_sub(last_char_visible as usize);
+
+        // Build asterisks string
+        let mut asterisks = ShortString::new();
+        for _ in 0..asterisk_count {
+            let _ = asterisks.push('*');
+        }
+
+        let mut text_baseline = self.area.top_left() + Offset::y(style.text_font.text_height())
+            - Offset::y(style.text_font.text_baseline());
+
+        // Twitch when overflowed (alternates so user sees feedback when typing past
+        // what fits)
+        if pp_len > max_visible && pp_len % 2 == 1 {
+            text_baseline.x += Self::TWITCH;
+        }
+
+        // Render asterisks in GREY_LIGHT
+        if !asterisks.is_empty() {
+            Text::new(text_baseline, &asterisks, style.text_font)
+                .with_align(Alignment::Start)
+                .with_fg(theme::GREY_LIGHT)
+                .render(target);
+        }
+
+        // Render the visible last character in the regular text color
+        if last_char_visible {
+            if let Some(last) = self.textbox.last_char_str() {
+                let last_baseline =
+                    text_baseline + Offset::x(style.text_font.text_width(&asterisks));
+
+                Text::new(last_baseline, last, style.text_font)
+                    .with_align(Alignment::Start)
+                    .with_fg(style.text_color)
+                    .render(target);
+
+                if self.display_style == DisplayStyle::LastWithMarker {
+                    render_pending_marker(
+                        target,
+                        last_baseline,
+                        last,
+                        style.text_font,
+                        style.text_color,
+                    );
+                }
+            }
         }
     }
 }
@@ -362,44 +527,66 @@ impl Component for Input {
     type Msg = Never;
 
     fn place(&mut self, bounds: Rect) -> Rect {
+        self.pad.place(bounds);
         self.area = bounds;
+        self.reveal_area.set(bounds);
         self.area
     }
 
-    fn event(&mut self, _ctx: &mut EventCtx, _event: Event) -> Option<Self::Msg> {
+    fn event(&mut self, ctx: &mut EventCtx, event: Event) -> Option<Self::Msg> {
+        if self.textbox.is_empty() {
+            return None;
+        }
+
+        let extended_shown_area = self
+            .shown_area
+            .outset(Self::SHOWN_TOUCH_OUTSET)
+            .clamp(SCREEN);
+
+        match event {
+            // Reveal on touch start within the extended input area
+            Event::Touch(TouchEvent::TouchStart(pos)) if self.reveal_area.get().contains(pos) => {
+                self.multi_tap.clear_pending_state(ctx);
+                self.last_char_timer.stop();
+                self.display_style = DisplayStyle::Shown;
+                self.update_shown_area();
+                self.pad.clear();
+                ctx.request_paint();
+            }
+            Event::Touch(TouchEvent::TouchEnd(_)) if self.display_style == DisplayStyle::Shown => {
+                self.display_style = DisplayStyle::Hidden;
+                self.pad.clear();
+                ctx.request_paint();
+            }
+            Event::Touch(TouchEvent::TouchMove(pos))
+                if !extended_shown_area.contains(pos)
+                    && self.display_style == DisplayStyle::Shown =>
+            {
+                self.display_style = DisplayStyle::Hidden;
+                self.pad.clear();
+                ctx.request_paint();
+            }
+            // Timeout for showing the last char
+            Event::Timer(_) if self.last_char_timer.expire(event) => {
+                self.display_style = DisplayStyle::Hidden;
+                self.request_complete_repaint(ctx);
+                ctx.request_paint();
+            }
+            _ => {}
+        }
         None
     }
 
     fn render<'s>(&'s self, target: &mut impl Renderer<'s>) {
-        let style = theme::label_keyboard();
+        self.pad.render(target);
 
-        let text_baseline = self.area.top_left() + Offset::y(style.text_font.text_height())
-            - Offset::y(style.text_font.text_baseline());
+        if self.textbox.is_empty() {
+            return;
+        }
 
-        let text = self.textbox.content();
-
-        shape::Bar::new(self.area).with_bg(theme::BG).render(target);
-
-        // Find out how much text can fit into the textbox.
-        // Accounting for the pending marker, which draws itself one pixel longer than
-        // the last character
-        let available_area_width = self.area.width() - 1;
-        let text_to_display =
-            long_line_content_with_ellipsis(text, "...", style.text_font, available_area_width);
-
-        shape::Text::new(text_baseline, &text_to_display, style.text_font)
-            .with_fg(style.text_color)
-            .render(target);
-
-        // Paint the pending marker.
-        if self.multi_tap.pending_key().is_some() {
-            render_pending_marker(
-                target,
-                text_baseline,
-                &text_to_display,
-                style.text_font,
-                style.text_color,
-            );
+        match self.display_style {
+            DisplayStyle::Shown => self.render_shown(target),
+            _ => self.render_hidden(target),
         }
     }
 }
@@ -410,8 +597,10 @@ impl crate::trace::Trace for PassphraseKeyboard {
         let page = self.scrollbar.pager().current();
         debug_assert!(page < PAGE_COUNT as u16);
         let active_layout = uformat!("{:?}", KeyboardLayout::from_page_unchecked(page.into()));
+        let display_style = uformat!("{:?}", self.input.inner().display_style);
         t.component("PassphraseKeyboard");
         t.string("active_layout", active_layout.as_str().into());
         t.string("passphrase", self.passphrase().into());
+        t.string("display_style", display_style.as_str().into());
     }
 }

--- a/core/embed/rust/src/ui/layout_delizia/component/keyboard/passphrase.rs
+++ b/core/embed/rust/src/ui/layout_delizia/component/keyboard/passphrase.rs
@@ -477,7 +477,6 @@ impl Input {
     const STYLE: TextStyle =
         theme::label_keyboard().with_line_breaking(LineBreaking::BreakWordsNoHyphen);
     const SHOWN_INSETS: Insets = Insets::new(8, 10, 8, 10);
-    const SHOWN_TOUCH_OUTSET: Insets = Insets::bottom(80);
 
     fn new(max_len: usize) -> Self {
         Self {
@@ -626,12 +625,8 @@ impl Component for Input {
             return None;
         }
 
-        let extended_shown_area = self
-            .shown_area
-            .outset(Self::SHOWN_TOUCH_OUTSET)
-            .clamp(SCREEN);
-
         match event {
+            // Reveal on touch start within the input area
             Event::Touch(TouchEvent::TouchStart(pos)) if self.area.contains(pos) => {
                 self.multi_tap.clear_pending_state(ctx);
                 self.last_char_timer.stop();
@@ -640,15 +635,8 @@ impl Component for Input {
                 self.pad.clear();
                 ctx.request_paint();
             }
+            // Hide on touch end anywhere on the screen
             Event::Touch(TouchEvent::TouchEnd(_)) if self.display_style == DisplayStyle::Shown => {
-                self.display_style = DisplayStyle::Hidden;
-                self.pad.clear();
-                ctx.request_paint();
-            }
-            Event::Touch(TouchEvent::TouchMove(pos))
-                if !extended_shown_area.contains(pos)
-                    && self.display_style == DisplayStyle::Shown =>
-            {
                 self.display_style = DisplayStyle::Hidden;
                 self.pad.clear();
                 ctx.request_paint();

--- a/core/embed/rust/src/ui/layout_delizia/component/keyboard/passphrase.rs
+++ b/core/embed/rust/src/ui/layout_delizia/component/keyboard/passphrase.rs
@@ -1,14 +1,22 @@
 use crate::{
     strutil::{ShortString, TString},
+    time::Duration,
     ui::{
         component::{
-            base::ComponentExt, swipe_detect::SwipeConfig, text::common::TextBox, Component, Event,
-            EventCtx, Label, Maybe, Never, Swipe,
+            base::ComponentExt,
+            swipe_detect::SwipeConfig,
+            text::{
+                common::TextBox,
+                layout::{LayoutFit, LineBreaking},
+                TextStyle,
+            },
+            Component, Event, EventCtx, Label, Maybe, Never, Pad, Swipe, TextLayout, Timer,
         },
         display,
-        geometry::{Alignment, Direction, Grid, Insets, Offset, Rect},
-        shape::{self, Renderer},
-        util::{long_line_content_with_ellipsis, Pager},
+        event::TouchEvent,
+        geometry::{Alignment, Alignment2D, Direction, Grid, Insets, Rect},
+        shape::{Bar, Renderer, Text, ToifImage},
+        util::{DisplayStyle, Pager},
     },
 };
 
@@ -18,6 +26,7 @@ use super::super::super::{
         keyboard::common::{render_pending_marker, MultiTapKeyboard},
         theme,
     },
+    constant::SCREEN,
     cshape,
 };
 
@@ -182,7 +191,14 @@ impl PassphraseKeyboard {
             _ => self.active_layout,
         };
         // Clear the pending state.
-        self.input.multi_tap.clear_pending_state(ctx);
+        if self.input.multi_tap.pending_key().is_some() {
+            self.input.multi_tap.clear_pending_state(ctx);
+            // The character has been committed, show it briefly then hide
+            self.input.display_style = DisplayStyle::LastOnly;
+            self.input
+                .last_char_timer
+                .start(ctx, Input::LAST_DIGIT_TIMEOUT);
+        }
         // Update keys.
         self.replace_keys_contents(ctx);
         // Reset backlight to normal level on next paint.
@@ -218,6 +234,7 @@ impl PassphraseKeyboard {
         self.cancel_btn.inner_mut().enable_if(ctx, is_empty);
 
         self.update_input_btns_state(ctx);
+        self.input.request_complete_repaint(ctx);
     }
 
     /// When the input has reached max length, disable all the input buttons.
@@ -269,7 +286,6 @@ impl Component for PassphraseKeyboard {
         const CONFIRM_EMPTY_BTN_WIDTH: i16 = 32;
         const INPUT_INSETS: Insets = Insets::new(10, 2, 10, 4);
 
-        let bounds = bounds.inset(theme::borders());
         let (top_area, keypad_area) =
             bounds.split_bottom(4 * theme::PASSPHRASE_BUTTON_HEIGHT + 3 * theme::BUTTON_SPACING);
         self.keypad_area = keypad_area;
@@ -316,10 +332,28 @@ impl Component for PassphraseKeyboard {
     }
 
     fn event(&mut self, ctx: &mut EventCtx, event: Event) -> Option<Self::Msg> {
+        // Handle multi-tap timeout: commit the pending character
         if self.input.multi_tap.timeout_event(event) {
             self.input.multi_tap.clear_pending_state(ctx);
+            self.input
+                .last_char_timer
+                .start(ctx, Input::LAST_DIGIT_TIMEOUT);
+            self.input.display_style = DisplayStyle::LastOnly;
+            // Disable keypad when the passphrase reached the max length
+            if self.input.textbox.len() >= self.max_len {
+                self.update_input_btns_state(ctx);
+            }
             return None;
         }
+
+        // Handle input touch events (reveal/hide passphrase)
+        self.input.event(ctx, event);
+
+        // When passphrase is shown in full, disable all keypad interaction
+        if self.input.display_style == DisplayStyle::Shown {
+            return None;
+        }
+
         if let Some(swipe) = self.page_swipe.event(ctx, event) {
             // We have detected a horizontal swipe. Change the keyboard page.
             self.on_page_change(ctx, swipe);
@@ -349,12 +383,14 @@ impl Component for PassphraseKeyboard {
             Some(ButtonMsg::Clicked) => {
                 self.input.multi_tap.clear_pending_state(ctx);
                 self.input.textbox.delete_last(ctx);
+                self.input.display_style = DisplayStyle::Hidden;
                 self.after_edit(ctx);
                 return None;
             }
             Some(ButtonMsg::LongPressed) => {
                 self.input.multi_tap.clear_pending_state(ctx);
                 self.input.textbox.clear(ctx);
+                self.input.display_style = DisplayStyle::Hidden;
                 self.after_edit(ctx);
                 return None;
             }
@@ -377,6 +413,17 @@ impl Component for PassphraseKeyboard {
                 let text = Self::key_text(btn.content());
                 let edit = text.map(|c| self.input.multi_tap.click_key(ctx, key, c));
                 self.input.textbox.apply(ctx, edit);
+                if text.len() == 1 {
+                    // Single-char key: immediately applied, show last char briefly
+                    self.input.display_style = DisplayStyle::LastOnly;
+                    self.input
+                        .last_char_timer
+                        .start(ctx, Input::LAST_DIGIT_TIMEOUT);
+                } else {
+                    // Multi-tap key: pending state, show char with marker
+                    self.input.last_char_timer.stop();
+                    self.input.display_style = DisplayStyle::LastWithMarker;
+                }
                 self.after_edit(ctx);
                 return None;
             }
@@ -385,25 +432,30 @@ impl Component for PassphraseKeyboard {
     }
 
     fn render<'s>(&'s self, target: &mut impl Renderer<'s>) {
-        self.input.render(target);
-        self.next_btn.render(target);
-        if self.input.textbox.is_empty() {
-            self.confirm_empty_btn.render(target);
-            self.cancel_btn.render(target);
-            self.input_prompt.render(target);
+        if self.input.display_style == DisplayStyle::Shown {
+            // When passphrase is revealed, render only the shown overlay
+            self.input.render(target);
         } else {
-            self.confirm_btn.render(target);
-            self.erase_btn.render(target);
-        }
-        for btn in &self.keys {
-            btn.render(target);
-        }
-        if self.fade.take() {
-            // Note that this is blocking and takes some time.
-            display::fade_backlight(theme::backlight::get_backlight_normal());
-        }
+            self.input.render(target);
+            self.next_btn.render(target);
+            if self.input.textbox.is_empty() {
+                self.confirm_empty_btn.render(target);
+                self.cancel_btn.render(target);
+                self.input_prompt.render(target);
+            } else {
+                self.confirm_btn.render(target);
+                self.erase_btn.render(target);
+            }
+            for btn in &self.keys {
+                btn.render(target);
+            }
+            if self.fade.take() {
+                // Note that this is blocking and takes some time.
+                display::fade_backlight(theme::backlight::get_backlight_normal());
+            }
 
-        cshape::KeyboardOverlay::new(self.keypad_area).render(target);
+            cshape::KeyboardOverlay::new(self.keypad_area).render(target);
+        }
     }
 }
 
@@ -411,14 +463,151 @@ struct Input {
     area: Rect,
     textbox: TextBox,
     multi_tap: MultiTapKeyboard,
+    display_style: DisplayStyle,
+    last_char_timer: Timer,
+    pad: Pad,
+    shown_area: Rect,
 }
 
 impl Input {
+    const DOT_ICON_WIDTH: i16 = theme::DOT_ACTIVE.toif.width();
+    const DOT_ICON_SPACING: i16 = 7;
+    const TWITCH: i16 = 4;
+    const LAST_DIGIT_TIMEOUT: Duration = Duration::from_secs(1);
+    const STYLE: TextStyle =
+        theme::label_keyboard().with_line_breaking(LineBreaking::BreakWordsNoHyphen);
+    const SHOWN_INSETS: Insets = Insets::new(8, 10, 8, 10);
+    const SHOWN_TOUCH_OUTSET: Insets = Insets::bottom(80);
+
     fn new(max_len: usize) -> Self {
         Self {
             area: Rect::zero(),
             textbox: TextBox::empty(max_len),
             multi_tap: MultiTapKeyboard::new(),
+            display_style: DisplayStyle::Hidden,
+            last_char_timer: Timer::new(),
+            pad: Pad::with_background(theme::BG),
+            shown_area: Rect::zero(),
+        }
+    }
+
+    /// Maximum number of dots that fit in the input area (accounting for the
+    /// confirm button taking the right portion of the row).
+    fn max_shown_dots(&self) -> usize {
+        let step = Self::DOT_ICON_WIDTH + Self::DOT_ICON_SPACING;
+        let dots_space = (self.area.width() + Self::DOT_ICON_SPACING) / step;
+        // reduce by one to create more space between the written dots and `confirm_btn`
+        let dots_space = dots_space - 1;
+        (dots_space).max(1) as usize
+    }
+
+    fn update_shown_area(&mut self) {
+        let line_height = Self::STYLE.text_font.line_height();
+
+        // Start with full screen width
+        let initial_height = line_height + Self::SHOWN_INSETS.top + Self::SHOWN_INSETS.bottom;
+        let mut shown_area = SCREEN.inset(Self::SHOWN_INSETS).with_height(initial_height);
+
+        // Extend the shown area until the text fits
+        while let LayoutFit::OutOfBounds { .. } = TextLayout::new(Self::STYLE)
+            .with_align(Alignment::Start)
+            .with_bounds(shown_area.inset(Self::SHOWN_INSETS))
+            .fit_text(self.textbox.content())
+        {
+            shown_area = shown_area.outset(Insets::bottom(line_height));
+        }
+
+        self.shown_area = shown_area;
+    }
+
+    fn render_shown<'s>(&self, target: &mut impl Renderer<'s>) {
+        debug_assert_eq!(self.display_style, DisplayStyle::Shown);
+
+        Bar::new(self.shown_area)
+            .with_bg(theme::GREY_EXTRA_DARK)
+            .with_radius(12)
+            .render(target);
+
+        TextLayout::new(Self::STYLE)
+            .with_align(Alignment::Start)
+            .with_bounds(self.shown_area.inset(Self::SHOWN_INSETS))
+            .render_text(self.textbox.content(), target, true);
+    }
+
+    fn render_hidden<'s>(&self, target: &mut impl Renderer<'s>) {
+        debug_assert_ne!(self.display_style, DisplayStyle::Shown);
+
+        let style = theme::label_keyboard();
+        let mut cursor = self.area.left_center();
+
+        let pp_len = self.textbox.count();
+        let last_char = self.display_style == DisplayStyle::LastOnly
+            || self.display_style == DisplayStyle::LastWithMarker;
+        let step = Self::DOT_ICON_WIDTH + Self::DOT_ICON_SPACING;
+        let max_dots = self.max_shown_dots();
+
+        if pp_len == 0 {
+            return;
+        }
+
+        let visible_len = pp_len.min(max_dots);
+        let visible_icons = visible_len - last_char as usize;
+
+        // Jiggle when overflowed
+        if pp_len > visible_len && pp_len % 2 == 1 && self.display_style != DisplayStyle::Shown {
+            cursor.x += Self::TWITCH;
+        }
+
+        let mut char_idx = 0;
+
+        // Small leftmost dot (fading indicator for overflow)
+        if pp_len > max_dots + 1 {
+            ToifImage::new(cursor, theme::DOT_ACTIVE.toif)
+                .with_align(Alignment2D::CENTER_LEFT)
+                .with_fg(theme::GREY_DARK)
+                .render(target);
+            cursor.x += step;
+            char_idx += 1;
+        }
+
+        // Greyed out dot
+        if pp_len > max_dots {
+            ToifImage::new(cursor, theme::DOT_ACTIVE.toif)
+                .with_align(Alignment2D::CENTER_LEFT)
+                .with_fg(theme::GREY)
+                .render(target);
+            cursor.x += step;
+            char_idx += 1;
+        }
+
+        // Normal dots
+        if visible_icons > 0 {
+            for _ in char_idx..visible_icons {
+                ToifImage::new(cursor, theme::DOT_ACTIVE.toif)
+                    .with_align(Alignment2D::CENTER_LEFT)
+                    .with_fg(style.text_color)
+                    .render(target);
+                cursor.x += step;
+            }
+        }
+
+        // Last character (if visible)
+        if last_char {
+            if let Some(last) = self.textbox.last_char_str() {
+                // Adapt y position for the character
+                cursor.y =
+                    self.area.left_center().y + (style.text_font.visible_text_height("1") / 2);
+
+                Text::new(cursor, last, style.text_font)
+                    .with_align(Alignment::Start)
+                    .with_fg(style.text_color)
+                    .render(target);
+
+                // Paint the pending marker
+                if self.display_style == DisplayStyle::LastWithMarker {
+                    render_pending_marker(target, cursor, last, style.text_font, style.text_color);
+                }
+            }
         }
     }
 }
@@ -427,44 +616,64 @@ impl Component for Input {
     type Msg = Never;
 
     fn place(&mut self, bounds: Rect) -> Rect {
+        self.pad.place(bounds);
         self.area = bounds;
         self.area
     }
 
-    fn event(&mut self, _ctx: &mut EventCtx, _event: Event) -> Option<Self::Msg> {
+    fn event(&mut self, ctx: &mut EventCtx, event: Event) -> Option<Self::Msg> {
+        if self.textbox.is_empty() {
+            return None;
+        }
+
+        let extended_shown_area = self
+            .shown_area
+            .outset(Self::SHOWN_TOUCH_OUTSET)
+            .clamp(SCREEN);
+
+        match event {
+            Event::Touch(TouchEvent::TouchStart(pos)) if self.area.contains(pos) => {
+                self.multi_tap.clear_pending_state(ctx);
+                self.last_char_timer.stop();
+                self.display_style = DisplayStyle::Shown;
+                self.update_shown_area();
+                self.pad.clear();
+                ctx.request_paint();
+            }
+            Event::Touch(TouchEvent::TouchEnd(_)) if self.display_style == DisplayStyle::Shown => {
+                self.display_style = DisplayStyle::Hidden;
+                self.pad.clear();
+                ctx.request_paint();
+            }
+            Event::Touch(TouchEvent::TouchMove(pos))
+                if !extended_shown_area.contains(pos)
+                    && self.display_style == DisplayStyle::Shown =>
+            {
+                self.display_style = DisplayStyle::Hidden;
+                self.pad.clear();
+                ctx.request_paint();
+            }
+            // Timeout for showing the last char
+            Event::Timer(_) if self.last_char_timer.expire(event) => {
+                self.display_style = DisplayStyle::Hidden;
+                self.request_complete_repaint(ctx);
+                ctx.request_paint();
+            }
+            _ => {}
+        }
         None
     }
 
     fn render<'s>(&'s self, target: &mut impl Renderer<'s>) {
-        let style = theme::label_keyboard();
+        self.pad.render(target);
 
-        let text_baseline = self.area.top_left() + Offset::y(style.text_font.text_height())
-            - Offset::y(style.text_font.text_baseline());
+        if self.textbox.is_empty() {
+            return;
+        }
 
-        let text = self.textbox.content();
-
-        shape::Bar::new(self.area).with_bg(theme::BG).render(target);
-
-        // Find out how much text can fit into the textbox.
-        // Accounting for the pending marker, which draws itself one pixel longer than
-        // the last character
-        let available_area_width = self.area.width() - 1;
-        let text_to_display =
-            long_line_content_with_ellipsis(text, "...", style.text_font, available_area_width);
-
-        shape::Text::new(text_baseline, &text_to_display, style.text_font)
-            .with_fg(style.text_color)
-            .render(target);
-
-        // Paint the pending marker.
-        if self.multi_tap.pending_key().is_some() {
-            render_pending_marker(
-                target,
-                text_baseline,
-                &text_to_display,
-                style.text_font,
-                style.text_color,
-            );
+        match self.display_style {
+            DisplayStyle::Shown => self.render_shown(target),
+            _ => self.render_hidden(target),
         }
     }
 }
@@ -484,8 +693,10 @@ impl crate::ui::flow::Swipable for PassphraseKeyboard {
 impl crate::trace::Trace for PassphraseKeyboard {
     fn trace(&self, t: &mut dyn crate::trace::Tracer) {
         let active_layout = uformat!("{:?}", self.active_layout);
+        let display_style = uformat!("{:?}", self.input.display_style);
         t.component("PassphraseKeyboard");
         t.string("passphrase", self.passphrase().into());
         t.string("active_layout", active_layout.as_str().into());
+        t.string("display_style", display_style.as_str().into());
     }
 }

--- a/core/embed/rust/src/ui/layout_delizia/component/progress.rs
+++ b/core/embed/rust/src/ui/layout_delizia/component/progress.rs
@@ -30,7 +30,7 @@ pub struct Progress {
 }
 
 impl Progress {
-    const AREA: Rect = constant::screen().inset(theme::borders());
+    const AREA: Rect = constant::screen();
 
     pub fn new(
         title: TString<'static>,

--- a/core/embed/rust/src/ui/layout_delizia/theme/mod.rs
+++ b/core/embed/rust/src/ui/layout_delizia/theme/mod.rs
@@ -826,17 +826,6 @@ pub const fn button_bar<T>(inner: T) -> FixedHeightBar<T> {
     FixedHeightBar::bottom(inner, BUTTON_HEIGHT)
 }
 
-/// +----------+
-/// |     6    |
-/// |  +----+  |
-/// | 6|    | 6|
-/// |  +----+  |
-/// |     6    |
-/// +----------+
-pub const fn borders() -> Insets {
-    Insets::new(0, 0, 0, 0)
-}
-
 pub const fn borders_notification() -> Insets {
     Insets::new(42, 0, 0, 0)
 }

--- a/core/embed/rust/src/ui/layout_delizia/theme/mod.rs
+++ b/core/embed/rust/src/ui/layout_delizia/theme/mod.rs
@@ -400,7 +400,7 @@ pub const fn button_keyboard() -> ButtonStyleSheet {
             font: fonts::FONT_DEMIBOLD,
             text_color: GREY_DARK,
             button_color: BG, // so there is no "button" itself, just the text
-            icon_color: GREY_LIGHT,
+            icon_color: GREY_DARK,
             background_color: BG,
         },
     }

--- a/core/embed/rust/src/ui/layout_delizia/ui_firmware.rs
+++ b/core/embed/rust/src/ui/layout_delizia/ui_firmware.rs
@@ -18,7 +18,7 @@ use crate::{
                 },
                 TextStyle,
             },
-            Border, CachedJpeg, ComponentExt, Empty, FormattedText, MsgMap, Never, Timeout,
+            CachedJpeg, ComponentExt, Empty, FormattedText, MsgMap, Never, Timeout,
         },
         flow::FlowMsg,
         geometry::{self, Direction, Offset},
@@ -1164,10 +1164,7 @@ impl FirmwareUI for UIDelizia {
         _title: Option<TString<'static>>,
         _button: Option<TString<'static>>,
     ) -> Result<Gc<LayoutObj>, Error> {
-        let obj = LayoutObj::new(Border::new(
-            theme::borders(),
-            Paragraphs::new(Paragraph::new(&theme::TEXT_DEMIBOLD, text)),
-        ))?;
+        let obj = LayoutObj::new(Paragraphs::new(Paragraph::new(&theme::TEXT_DEMIBOLD, text)))?;
         Ok(obj)
     }
 

--- a/core/embed/rust/src/ui/layout_eckhart/firmware/keyboard/passphrase.rs
+++ b/core/embed/rust/src/ui/layout_eckhart/firmware/keyboard/passphrase.rs
@@ -46,7 +46,6 @@ impl PassphraseInput {
     const TWITCH: i16 = 4;
     const STYLE: TextStyle =
         theme::TEXT_REGULAR.with_line_breaking(LineBreaking::BreakWordsNoHyphen);
-    const SHOWN_TOUCH_OUTSET: Insets = Insets::bottom(200);
     const ICON: Icon = theme::ICON_DASH_VERTICAL;
     const ICON_WIDTH: i16 = Self::ICON.toif.width();
     const ICON_SPACE: i16 = 12;
@@ -298,13 +297,6 @@ impl Component for PassphraseInput {
             return None;
         }
 
-        // Extend the passphrase area downward to allow touch input without the finger
-        // covering the passphrase
-        let extended_shown_area = self
-            .shown_area
-            .outset(Self::SHOWN_TOUCH_OUTSET)
-            .clamp(SCREEN);
-
         match event {
             Event::Timer(_) if self.multi_tap.timeout_event(event) => {
                 self.multi_tap.clear_pending_state(ctx);
@@ -316,7 +308,7 @@ impl Component for PassphraseInput {
                 }
                 return None;
             }
-            // Return touch start if the touch is detected inside the touchable area
+            // Reveal on touch start within the input area
             Event::Touch(TouchEvent::TouchStart(pos)) if self.area.contains(pos) => {
                 self.multi_tap.clear_pending_state(ctx);
                 // Stop the last char timer
@@ -326,17 +318,8 @@ impl Component for PassphraseInput {
                 self.update_shown_area();
                 return Some(StringInputMsg::UpdateKeypad);
             }
-            // Return touch end if the touch end is detected
+            // Hide on touch end anywhere on the screen
             Event::Touch(TouchEvent::TouchEnd(_)) if self.display_style == DisplayStyle::Shown => {
-                self.multi_tap.clear_pending_state(ctx);
-                self.display_style = DisplayStyle::Hidden;
-                return Some(StringInputMsg::UpdateKeypad);
-            }
-            // Return touch end if the touch moves out of the visible area
-            Event::Touch(TouchEvent::TouchMove(pos))
-                if !extended_shown_area.contains(pos)
-                    && self.display_style == DisplayStyle::Shown =>
-            {
                 self.multi_tap.clear_pending_state(ctx);
                 self.display_style = DisplayStyle::Hidden;
                 return Some(StringInputMsg::UpdateKeypad);

--- a/core/embed/rust/src/ui/layout_eckhart/firmware/keyboard/passphrase.rs
+++ b/core/embed/rust/src/ui/layout_eckhart/firmware/keyboard/passphrase.rs
@@ -326,11 +326,8 @@ impl Component for PassphraseInput {
                 self.update_shown_area();
                 return Some(StringInputMsg::UpdateKeypad);
             }
-            // Return touch end if the touch end is detected inside the visible area
-            Event::Touch(TouchEvent::TouchEnd(pos))
-                if extended_shown_area.contains(pos)
-                    && self.display_style == DisplayStyle::Shown =>
-            {
+            // Return touch end if the touch end is detected
+            Event::Touch(TouchEvent::TouchEnd(_)) if self.display_style == DisplayStyle::Shown => {
                 self.multi_tap.clear_pending_state(ctx);
                 self.display_style = DisplayStyle::Hidden;
                 return Some(StringInputMsg::UpdateKeypad);

--- a/core/embed/rust/src/ui/layout_eckhart/firmware/keyboard/passphrase.rs
+++ b/core/embed/rust/src/ui/layout_eckhart/firmware/keyboard/passphrase.rs
@@ -106,7 +106,7 @@ impl PassphraseInput {
         debug_assert_ne!(self.display_style, DisplayStyle::Shown);
 
         let hidden_area: Rect = self.area.inset(KEYBOARD_INPUT_INSETS);
-        let pp_len = self.content().len();
+        let pp_len = self.textbox.count();
         let last_char = self.display_style != DisplayStyle::Hidden;
 
         let mut cursor = hidden_area.left_center().ofs(Offset::x(12));
@@ -154,27 +154,26 @@ impl PassphraseInput {
         }
 
         if last_char {
-            // This should not fail because pp_len > 0
-            let last = &self.content()[(pp_len - 1)..pp_len];
+            if let Some(last) = self.textbox.last_char_str() {
+                // Adapt x and y positions for the character
+                cursor.y += Self::STYLE.text_font.visible_text_height("1") / 2;
 
-            // Adapt x and y positions for the character
-            cursor.y += Self::STYLE.text_font.visible_text_height("1") / 2;
+                // Paint the last character
+                Text::new(cursor, last, Self::STYLE.text_font)
+                    .with_align(Alignment::Start)
+                    .with_fg(Self::STYLE.text_color)
+                    .render(target);
 
-            // Paint the last character
-            Text::new(cursor, last, Self::STYLE.text_font)
-                .with_align(Alignment::Start)
-                .with_fg(Self::STYLE.text_color)
-                .render(target);
-
-            // Paint the pending marker.
-            if self.display_style == DisplayStyle::LastWithMarker {
-                render_pending_marker(
-                    target,
-                    cursor,
-                    last,
-                    Self::STYLE.text_font,
-                    Self::STYLE.text_color,
-                );
+                // Paint the pending marker.
+                if self.display_style == DisplayStyle::LastWithMarker {
+                    render_pending_marker(
+                        target,
+                        cursor,
+                        last,
+                        Self::STYLE.text_font,
+                        Self::STYLE.text_color,
+                    );
+                }
             }
         }
     }


### PR DESCRIPTION
<!--
For external contributors:
- Please open an issue before submitting a PR so we can discuss whether we want to proceed with it.

For core developers:
1. Initial PR setup
- Assign yourself to the PR.
- Add it to the "Firmware" project
  - Set Priority (match issue priority if it exists)
  - Set Team
  - Set Sprint (target release)

2. Development status
- Draft PRs: Set status to "In Progress"
- Final PRs: Set status to "Needs Review"

3. Post-merge status
- Testable: Set status to "Needs QA" and add a `Notes for QA` section with clear instructions on how to test the functionality.
- Not Testable: Set status to "Done (no QA)"
-->
Fixes #3959 and #6342 

Design:
- delizia: https://www.figma.com/design/n43caWJFGJlT167AQcxruu/branch/9GpyZVAnqHNUPxTx7jv3Ag/--Prod---Safe-5?node-id=26-4174&p=f&t=dk5MHehOqp401FbV-0
- bolt: https://www.figma.com/design/WbzQVEk1WzP0n9lRMJUB9S/branch/im4BXMfGrvtcEw9bSi9QNl/--Prod---Model-T?node-id=26-4174&p=f&t=vNUxBpFjxiCDuGHG-0

Diff:
- delizia
<img width="813" height="276" alt="image" src="https://github.com/user-attachments/assets/e96c4a9a-78ed-4718-a0f6-66f9a3dde9c1" />
- bolt
<img width="812" height="271" alt="image" src="https://github.com/user-attachments/assets/a72c78c3-a324-47bb-aa59-87e6f350ca04" />

# Notes for QA

Properly test passphrase keyboard of Bolt (T2T1) and Delizia (T3T1). The characters should now disappear similarly to Eckhart (T3W1). A reveal passphrase functionality should also be available if you hold finger in the input area.