### PR TITLE
fix(python): skip stale protocol v1 responses

### DIFF
--- a/python/.changelog.d/6859.fixed
+++ b/python/.changelog.d/6859.fixed
@@ -1,0 +1,1 @@
+Skip stale protocol v1 responses on probing.

--- a/python/src/trezorlib/protocol_v1.py
+++ b/python/src/trezorlib/protocol_v1.py
@@ -29,6 +29,7 @@ from . import client, exceptions, mapping, messages
 from .log import DUMP_BYTES
 from .thp import pairing
 from .tools import enter_context
+from .transport import Timeout
 
 if t.TYPE_CHECKING:
     from .mapping import ProtobufMapping
@@ -347,9 +348,19 @@ class TrezorClientV1(client.TrezorClient[SessionV1]):
 
 @enter_context
 def probe(
-    transport: Transport, *, mapping: ProtobufMapping = mapping.DEFAULT_MAPPING
+    transport: Transport,
+    *,
+    mapping: ProtobufMapping = mapping.DEFAULT_MAPPING,
+    retries: int = 10,
 ) -> bool:
     """Probe the transport to see if it supports protocol v1."""
+    for _ in range(retries):
+        try:
+            # skip stale responses (to prevent the device from blocking during sending)
+            resp = read(transport, _ignore_bad_magic=True, timeout=0.1)
+            LOG.debug("stale response: %s", resp)
+        except Timeout:
+            break
     cancel_msg = messages.Cancel()
     cancel_msg_type, cancel_msg_bytes = mapping.encode(cancel_msg)
     write(transport, cancel_msg_type, cancel_msg_bytes)

--- a/tests/device_tests/test_basic.py
+++ b/tests/device_tests/test_basic.py
@@ -17,6 +17,7 @@
 import pytest
 
 from trezorlib import messages, models
+from trezorlib.client import get_client
 from trezorlib.debuglink import DebugSession as Session
 from trezorlib.debuglink import TrezorTestContext as Client
 
@@ -72,3 +73,17 @@ def test_not_initialized(session: Session):
         messages.FailureType.InvalidSession,
     )
     assert resp.code == expected[session.test_ctx.is_thp()]
+
+
+@pytest.mark.protocol("v1")
+def test_desync_v1(client: Client):
+    with client.get_session(passphrase=None) as session:
+        resp = session.call_raw(messages.Ping(message="test", button_protection=True))
+        messages.ButtonRequest.ensure_isinstance(resp)
+        session.write(messages.ButtonAck())
+        session.debug.press_no()
+        # don't read the response - simulating host disconnection
+
+    # Creating a new client fails without skipping stale responses
+    # (see https://github.com/trezor/trezor-firmware/issues/6859)
+    get_client(client.app, client.transport).ping("reconnect")


### PR DESCRIPTION
Fixes #6859.

- [x] add a device test for HW CI
- [x] update UI fixtures

Was implemented in 49c9ad04cd333dc61714bc25f3df472e367889d1.

## Note to QA:
See https://github.com/trezor/trezor-firmware/issues/6859#issue-4359748527 for reproduction.