### PR TITLE
[WIP] test(core): test UI abort after missing ButtonAck

### DIFF
--- a/core/.changelog.d/6348.fixed
+++ b/core/.changelog.d/6348.fixed
@@ -1,0 +1,1 @@
+Avoid failing backup flow on I/O errors.

--- a/core/src/trezor/ui/__init__.py
+++ b/core/src/trezor/ui/__init__.py
@@ -52,9 +52,6 @@ _REQUEST_ANIMATION_FRAME = const(1)
 See `trezor::ui::layout::base::EventCtx::ANIM_FRAME_TIMER`.
 """
 
-_UNRESPONSIVE_WARNING_TIMEOUT_MS = const(2000)
-
-
 # allow only one alert at a time to avoid alerts overlapping
 _alert_in_progress = False
 
@@ -82,14 +79,6 @@ def alert(count: int = 3) -> None:
 
         _alert_in_progress = True
         loop.schedule(_alert(count))
-
-
-async def _waiting_screen() -> None:
-    from trezor import TR
-    from trezor.ui.layouts import show_wait_text
-
-    await loop.sleep(_UNRESPONSIVE_WARNING_TIMEOUT_MS)
-    show_wait_text(TR.words__comm_trouble)
 
 
 class Shutdown(Exception):
@@ -282,7 +271,7 @@ class Layout(Generic[T]):
             if br_handler is not None:
                 # Make sure ButtonRequest is ACKed, before the result is returned.
                 # Otherwise, THP channel may become desynced (due to two consecutive writes).
-                await br_handler.join(_waiting_screen())
+                await br_handler.join()
 
             return result
         finally:

--- a/core/src/trezor/wire/protocol_common.py
+++ b/core/src/trezor/wire/protocol_common.py
@@ -1,3 +1,4 @@
+from micropython import const
 from typing import TYPE_CHECKING
 
 from trezor import loop, protobuf
@@ -13,7 +14,6 @@ if TYPE_CHECKING:
         Awaitable,
         Callable,
         Container,
-        Generator,
         Literal,
         NoReturn,
         TypeVar,
@@ -131,11 +131,43 @@ class Context:
         ...
 
 
+# Show "trouble communicating" warning after 2s of "blank" screen (if ButtonRequest is not ACKed)
+_UNRESPONSIVE_WARNING_TIMEOUT_MS = const(2000)
+
+
+async def _waiting_screen(raise_on_cancel: type[Exception] | None) -> None:
+    import trezorui_api
+    from trezor import TR
+    from trezor.ui import Layout
+
+    verb = TR.buttons__abort if raise_on_cancel is not None else TR.buttons__continue
+
+    await loop.sleep(_UNRESPONSIVE_WARNING_TIMEOUT_MS)
+    with trezorui_api.show_warning(
+        title="",
+        description=TR.words__comm_trouble,
+        button=verb,
+        danger=True,
+        allow_cancel=False,
+    ) as obj:
+        # Block until the user confirmation.
+        # Don't use `interact` to avoid cancelling current workflow.
+        await Layout(obj).get_result()
+
+    if raise_on_cancel:
+        raise raise_on_cancel()
+
+
 class ButtonRequestHandler:
     """Handle button requests and unexpected messages from host."""
 
     def __init__(self, ctx: Context) -> None:
+        from trezor.wire.errors import ActionCancelled
+
         self.ctx = ctx  # used for communication with the host.
+
+        # will be raised from `self.join()` on user cancellation.
+        self.raise_on_cancel: type[ActionCancelled] | None = ActionCancelled
 
         # Receives ButtonRequest notifications from the active layout,
         # or `None` when the layout is closed.
@@ -164,27 +196,23 @@ class ButtonRequestHandler:
         # in production, we don't want this to fail, hence replace=True
         self.box.put(br, replace=True)
 
-    def br_task(self, ack_callback: AckCallback) -> Generator[Any, Any, None]:
+    async def br_task(self, ack_callback: AckCallback) -> None:
         assert self.is_done.is_empty()
         try:
-            yield from self._handle(ack_callback)
+            await self._handle(ack_callback)
         finally:
             # no pending I/O - mark as done, to unblock `join()`.
             self.is_done.put(None)
 
-    async def join(self, wait_task: loop.Task[None]) -> None:
+    async def join(self) -> None:
         # `br_task()` must be scheduled before joining.
 
         # notify the handler that no more button requests are expected
         # in production, we don't want this to fail, hence replace=True
         self.box.put(None, replace=True)
 
-        task = loop.spawn(wait_task)
-        try:
-            await self.is_done
-        finally:
-            assert self.is_done.is_empty()
-            task.close()
+        # Wait for the ButtonRequest handler to finish (or user cancellation)
+        await loop.race(self.is_done, _waiting_screen(self.raise_on_cancel))
 
     async def _handle(self, ack_callback: AckCallback) -> None:
         from trezor.messages import ButtonAck
@@ -214,29 +242,71 @@ class ContinueOnErrors(ButtonRequestHandler):
 
     def __init__(self, ctx: Context, msg: str) -> None:
         super().__init__(ctx)
+        self.raise_on_cancel = None  # continue on user cancellation
         self._prev_handler: ButtonRequestHandler | None = None
         self.msg = msg
+        self.ignore = False
+
+    def put(self, br: ButtonRequest) -> None:
+        if self.ignore:
+            # Stop handling ButtonRequests in case of unexpected error.
+            if __debug__:
+                log.debug(__name__, "ButtonRequest: skipped %s (%s)", br.code, br.name)
+            return
+
+        super().put(br)
+
+    async def join(self) -> None:
+        if self.ignore:
+            # Stop handling ButtonRequests in case of unexpected error.
+            return
+
+        await super().join()
+
+    async def br_task(self, ack_callback: AckCallback) -> None:
+        if self.ignore:
+            # Stop handling ButtonRequests in case of unexpected error.
+            return None
+
+        return await super().br_task(ack_callback)
 
     async def _handle(self, ack_callback: AckCallback) -> None:
         """Unexpected messages will not cause the handler to fail."""
+
         from .context import UnexpectedMessageException
 
-        while True:
-            try:
-                # Exit the loop when the layout is done.
-                return await super()._handle(ack_callback)
-            except UnexpectedMessageException as exc:
-                # in case of THP channel preemption, `msg` is not set.
-                # TRANSPORT_BUSY error has been already sent by `InterfaceContext.handle_packet()`.
-                if exc.msg:
-                    from trezor.enums import FailureType
-                    from trezor.messages import Failure
+        # In case of an unexpected error, stop handling ButtonRequests till the end of this workflow.
+        # The host will be ignored, disabling host-side cancellation of this workflow.
+        success = False
+        try:
+            while True:
+                try:
+                    # Exit the loop when the layout is done.
+                    await super(ContinueOnErrors, self)._handle(ack_callback)
+                    # All is well, continue handling ButtonRequests.
+                    success = True
+                    return
+                except UnexpectedMessageException as exc:
+                    # in case of THP channel preemption, `msg` is not set.
+                    # TRANSPORT_BUSY error has been already sent by `InterfaceContext.handle_packet()`.
+                    if exc.msg:
+                        from trezor.enums import FailureType
+                        from trezor.messages import Failure
 
-                    # notify the host that the device cannot be preempted
-                    await self.ctx.write(
-                        Failure(code=FailureType.InProgress, message=self.msg)
-                    )
-                # continue receiving messages
+                        # notify the host that the device cannot be preempted
+                        await self.ctx.write(
+                            Failure(code=FailureType.InProgress, message=self.msg)
+                        )
+                    # continue receiving messages
+                except Exception as exc:
+                    if __debug__:
+                        log.error(__name__, "ButtonRequest: ignored %s", exc)
+                        log.exception(__name__, exc)
+                    # Stop handling ButtonRequests in case of unexpected error (without failing the flow)
+                    return
+        finally:
+            # Handles GeneratorExit as well (in case of task cancellation).
+            self.ignore = not success
 
     def __enter__(self) -> None:
         assert self._prev_handler is None

--- a/core/src/trezor/wire/protocol_common.py
+++ b/core/src/trezor/wire/protocol_common.py
@@ -152,7 +152,13 @@ async def _waiting_screen(raise_on_cancel: type[Exception] | None) -> None:
     ) as obj:
         # Block until the user confirmation.
         # Don't use `interact` to avoid cancelling current workflow.
-        await Layout(obj).get_result()
+        layout = Layout(obj)
+        layout.start()
+        # This task doesn't have access to I/O context - see `ButtonRequestHandler.join()`.
+        # Therefore, the new layout won't start its own ButtonRequest handler,
+        # avoiding interference with the existing layout (the one we are waiting for).
+        assert layout.button_request_handler is None
+        await layout.get_result()
 
     if raise_on_cancel:
         raise raise_on_cancel()
@@ -212,6 +218,7 @@ class ButtonRequestHandler:
         self.box.put(None, replace=True)
 
         # Wait for the ButtonRequest handler to finish (or user cancellation)
+        # `_waiting_screen` layout won't have an I/O context, since it runs in a separate task.
         await loop.race(self.is_done, _waiting_screen(self.raise_on_cancel))
 
     async def _handle(self, ack_callback: AckCallback) -> None:

--- a/core/translations/de.json
+++ b/core/translations/de.json
@@ -3529,7 +3529,7 @@
     },
     "words__chain": "Chain",
     "words__comm_trouble": {
-      "Bolt": "Dein Trezor hat Probleme bei der Kommunikation mit deinem verbundenen Gerät.",
+      "Bolt": "Dein Trezor hat Probleme, mit deinem verbundenen Gerät zu kommunizieren.",
       "Caesar": "Dein Trezor hat Schwierigkeiten, mit deinem verbundenen Gerät zu kommunizieren.",
       "Delizia": "Dein Trezor hat Probleme, mit deinem verbundenen Gerät zu kommunizieren.",
       "Eckhart": "Dein Trezor hat Schwierigkeiten, mit deinem verbundenen Gerät zu kommunizieren."

--- a/core/translations/signatures.json
+++ b/core/translations/signatures.json
@@ -1,8 +1,8 @@
 {
   "current": {
-    "merkle_root": "0e59628386f44b47e66a934a1b6c632cf4ee048b0322e82cf27eb0690cb5e2c1",
-    "datetime": "2026-04-29T14:48:26.117421+00:00",
-    "commit": "9d3c6ce08ab9e21bbbd16b6e40fbb18debd3641a"
+    "merkle_root": "09882e5140c5d907b2f6c18eb9d117c3264b634149151db9bd17dadd8d5ac8b6",
+    "datetime": "2026-05-03T07:49:33.210129+00:00",
+    "commit": "aa59dd493946f2885e2453a1e5e62c47500b863d"
   },
   "history": [
     {

--- a/tests/click_tests/test_reset_bip39.py
+++ b/tests/click_tests/test_reset_bip39.py
@@ -88,7 +88,8 @@ def test_reset_bip39(device_handler: "BackgroundDeviceHandler"):
     if debug.layout_type is not LayoutType.Eckhart:
         go_next(debug)
 
-    # TODO: some validation of the generated secret?
+    secret = debug.state().mnemonic_secret
+    assert secret == " ".join(words).encode()
 
     # retrieve the result to check that it's not a TrezorFailure exception
     device_handler.result()

--- a/tests/device_tests/test_msg_delayed_ack.py
+++ b/tests/device_tests/test_msg_delayed_ack.py
@@ -14,6 +14,8 @@
 
 import time
 
+import pytest
+
 from trezorlib import messages
 from trezorlib.debuglink import DebugSession as Session
 
@@ -28,4 +30,21 @@ def test_delayed_ack(session: Session):
     # (following https://github.com/trezor/trezor-firmware/issues/5884)
     time.sleep(2.5)
     res = session.call_raw(messages.ButtonAck())
+    res = messages.Success.ensure_isinstance(res)
     assert res.message == "delayed"
+
+
+@pytest.mark.models("core")
+def test_delayed_ack_abort(session: Session):
+    br = session.call_raw(messages.Ping(message="delayed", button_protection=True))
+    assert isinstance(br, messages.ButtonRequest)
+    assert br.code == messages.ButtonRequestType.ProtectCall
+    # confirm layout instead of sending ButtonAck
+    session.debug.press_yes()
+    # "waiting" screen should be shown after 2 seconds on Core models
+    # (following https://github.com/trezor/trezor-firmware/issues/5884)
+    time.sleep(2.5)
+    session.debug.press_yes()  # abort flow on device (instead of ButtonAck)
+    res = session.read()
+    res = messages.Failure.ensure_isinstance(res)
+    assert res.code == messages.FailureType.ActionCancelled


### PR DESCRIPTION
- [x] `de` string should be shorter: https://data.trezor.io/dev/firmware/ui_report/25261207813/diff/T2T1_de-device_tests-test_msg_delayed_ack.py%3A%3Atest_delayed_ack.html