### PR TITLE
BootloaderV2Image signature verification

### DIFF
--- a/python/src/trezorlib/_internal/firmware_headers.py
+++ b/python/src/trezorlib/_internal/firmware_headers.py
@@ -57,7 +57,9 @@ def all_zero(data: bytes) -> bool:
     return all(b == 0 for b in data)
 
 
-def _check_signature_any(fw: "SignableImageProto", is_devel: bool = False) -> Status:
+def check_signature_any(
+    fw: SignableImageProto | BootloaderV2Image, is_devel: bool = False
+) -> Status:
     if not fw.signature_present():
         return Status.MISSING
     try:
@@ -80,7 +82,7 @@ class LiteralStr(str):
     pass
 
 
-def _format_container(
+def format_container(
     pb: t.Union[c.Container, Struct, dict],
     indent: int = 0,
     sep: str = " " * 4,
@@ -178,7 +180,7 @@ def format_header(
     all_ok = SYM_OK if hash_status.is_ok() and sig_status.is_ok() else SYM_FAIL
 
     output = [
-        "Firmware Header " + _format_container(header_out),
+        "Firmware Header " + format_container(header_out),
         f"Fingerprint: {click.style(digest.hex(), bold=True)}",
         f"{all_ok} Signature is {sig_status.value}, hashes are {hash_status.value}",
     ]
@@ -187,7 +189,7 @@ def format_header(
 
 
 def format_secmon_header(
-    header: firmware.SecmonHeader,
+    header: firmware.secmon.SecmonHeader,
     code_hash: bytes,
     digest: bytes,
     sig_status: Status,
@@ -213,7 +215,7 @@ def format_secmon_header(
     all_ok = SYM_OK if hash_status.is_ok() and sig_status.is_ok() else SYM_FAIL
 
     output = [
-        "SECMON Header " + _format_container(header_out),
+        "SECMON Header " + format_container(header_out),
         "Code hash: " + click.style(code_hash.hex(), bold=True),
         f"Fingerprint: {click.style(digest.hex(), bold=True)}",
         f"{all_ok} Signature is {sig_status.value}, hash is {hash_status.value}",
@@ -264,6 +266,8 @@ class CosiSignedImage(SignableImageProto, Protocol):
 
     def insert_signature(self, signature: bytes, sigmask: int) -> None: ...
 
+    def public_keys(self, dev_keys: bool = False) -> t.Sequence[bytes]: ...
+
 
 @runtime_checkable
 class LegacySignedImage(SignableImageProto, Protocol):
@@ -298,7 +302,7 @@ class CosiSignedMixin:
 
 class VendorHeader(firmware.VendorHeader, CosiSignedMixin):
     NAME: t.ClassVar[str] = "vendorheader"
-    DEV_KEYS = _make_dev_keys(b"\x44", b"\x45")
+    DEV_KEYS: t.ClassVar[t.Sequence[bytes]] = _make_dev_keys(b"\x44", b"\x45")
 
     SUBCON = c.Struct(*firmware.VendorHeader.SUBCON.subcons, c.Terminated)
 
@@ -308,7 +312,7 @@ class VendorHeader(firmware.VendorHeader, CosiSignedMixin):
     def _format(self, terse: bool) -> str:
         if not terse:
             output = [
-                "Vendor Header " + _format_container(self),
+                "Vendor Header " + format_container(self),
                 f"Pubkey bundle hash: {self.vhash().hex()}",
             ]
         else:
@@ -323,7 +327,7 @@ class VendorHeader(firmware.VendorHeader, CosiSignedMixin):
         if not terse:
             output.append(f"Fingerprint: {click.style(self.digest().hex(), bold=True)}")
 
-        sig_status = _check_signature_any(self)
+        sig_status = check_signature_any(self)
         sym = SYM_OK if sig_status.is_ok() else SYM_FAIL
         output.append(f"{sym} Signature is {sig_status.value}")
 
@@ -338,7 +342,7 @@ class VendorHeader(firmware.VendorHeader, CosiSignedMixin):
 
 class VendorFirmware(firmware.VendorFirmware, CosiSignedMixin):
     NAME: t.ClassVar[str] = "firmware"
-    DEV_KEYS = _make_dev_keys(b"\x47", b"\x48")
+    DEV_KEYS: t.ClassVar[t.Sequence[bytes]] = _make_dev_keys(b"\x47", b"\x48")
 
     def get_header(self) -> CosiSignatureHeaderProto:
         return self.firmware.header
@@ -356,7 +360,7 @@ class VendorFirmware(firmware.VendorFirmware, CosiSignedMixin):
                 self.firmware.header,
                 self.firmware.code_hashes(),
                 self.digest(),
-                _check_signature_any(self, is_devel),
+                check_signature_any(self, is_devel),
             )
         )
 
@@ -372,7 +376,7 @@ class VendorFirmware(firmware.VendorFirmware, CosiSignedMixin):
 
 class BootloaderImage(firmware.FirmwareImage, CosiSignedMixin):
     NAME: t.ClassVar[str] = "bootloader"
-    DEV_KEYS = _make_dev_keys(b"\x41", b"\x42")
+    DEV_KEYS: t.ClassVar[t.Sequence[bytes]] = _make_dev_keys(b"\x41", b"\x42")
 
     def get_header(self) -> CosiSignatureHeaderProto:
         return self.header
@@ -382,7 +386,7 @@ class BootloaderImage(firmware.FirmwareImage, CosiSignedMixin):
             self.header,
             self.code_hashes(),
             self.digest(),
-            _check_signature_any(self),
+            check_signature_any(self),
         )
 
     def verify(self, dev_keys: bool = False) -> None:
@@ -405,7 +409,7 @@ class BootloaderImage(firmware.FirmwareImage, CosiSignedMixin):
 
 class SecmonImage(firmware.SecmonImage, CosiSignedMixin):
     NAME: t.ClassVar[str] = "secmon"
-    DEV_KEYS = _make_dev_keys(b"\x41", b"\x42")
+    DEV_KEYS: t.ClassVar[t.Sequence[bytes]] = _make_dev_keys(b"\x41", b"\x42")
 
     def get_header(self) -> CosiSignatureHeaderProto:
         return self.header
@@ -415,7 +419,7 @@ class SecmonImage(firmware.SecmonImage, CosiSignedMixin):
             self.header,
             self.code_hash(),
             self.digest(),
-            _check_signature_any(self),
+            check_signature_any(self),
         )
 
     def verify(self, dev_keys: bool = False) -> None:
@@ -475,10 +479,14 @@ class BootloaderV2Image(firmware.BootableImage):
             if "version" in key:
                 header_out[key] = LiteralStr(_format_version(val))
 
+        sig_status = check_signature_any(self)
+        all_ok = SYM_OK if sig_status.is_ok() else SYM_FAIL
+
         output = [
-            "Firmware Header " + _format_container(header_out),
+            "Firmware Header " + format_container(header_out),
             f"Leaf hash: {click.style(self.leaf_hash().hex(), bold=True)}",
             f"Merkle root: {click.style(self.merkle_root().hex(), bold=True)}",
+            f"{all_ok} Signature is {sig_status.value}",
         ]
 
         return "\n".join(output)
@@ -487,18 +495,44 @@ class BootloaderV2Image(firmware.BootableImage):
         digest = self.merkle_root()
 
         hash_fn = self.get_hash_params().hash_function
+        mask = self.header.sigmask
 
-        for idx, key in enumerate(self.public_ec_keys(dev_keys)):
-            ext_digest = hash_fn(digest + self.unauth.slh_signatures[idx]).digest()
+        if (mask.bit_length() > len(self.public_ec_keys(dev_keys))) or (
+            mask.bit_length() > len(self.public_pq_keys(dev_keys))
+        ):
+            raise ValueError("Sigmask specifies more public keys than provided.")
+
+        # Verify ed25519 signatures
+        if mask.bit_count() != len(  # pyright: ignore[reportAttributeAccessIssue] # bit_count() is not available with Python 3.9
+            self.unauth.ec_signatures
+        ):
+            raise ValueError("Sigmask does not specify valid number of ed25519 keys.")
+
+        sig_idx = 0
+        for pubkey_idx, key in enumerate(self.public_ec_keys(dev_keys)):
+            if not (mask & (1 << pubkey_idx)):
+                continue
+            ext_digest = hash_fn(digest + self.unauth.slh_signatures[sig_idx]).digest()
             try:
-                _ed25519.checkvalid(self.unauth.ec_signatures[idx], ext_digest, key)
+                _ed25519.checkvalid(self.unauth.ec_signatures[sig_idx], ext_digest, key)
             except _ed25519.SignatureMismatch:
                 raise firmware.InvalidSignatureError("Invalid bootloader signature")
+            sig_idx += 1
 
-        for idx, key in enumerate(self.public_pq_keys(dev_keys)):
-            key = PublicKey.from_digest(key, sha2_128s)
-            if not key.verify(digest, self.unauth.slh_signatures[idx]):
+        # Verify slh-dsa signatures
+        if mask.bit_count() != len(  # pyright: ignore[reportAttributeAccessIssue] # bit_count() is not available with Python 3.9
+            self.unauth.slh_signatures
+        ):
+            raise ValueError("Sigmask does not specify valid number of slh-dsa keys.")
+
+        sig_idx = 0
+        for pubkey_idx, key in enumerate(self.public_pq_keys(dev_keys)):
+            if not (mask & (1 << pubkey_idx)):
+                continue
+            pq_key = PublicKey.from_digest(key, sha2_128s)
+            if not pq_key.verify(digest, self.unauth.slh_signatures[sig_idx]):
                 raise firmware.InvalidSignatureError("Invalid bootloader signature")
+            sig_idx += 1
 
 
 class LegacyFirmware(firmware.LegacyFirmware):
@@ -528,7 +562,7 @@ class LegacyFirmware(firmware.LegacyFirmware):
         else:
             embedded_content = ""
 
-        return _format_container(contents) + embedded_content
+        return format_container(contents) + embedded_content
 
     def public_keys(
         self, dev_keys: bool = False, signature_version: int = 2
@@ -567,7 +601,7 @@ class LegacyV2Firmware(firmware.LegacyV2Firmware):
             self.header,
             self.code_hashes(),
             self.digest(),
-            _check_signature_any(self),
+            check_signature_any(self),
         )
 
     def public_keys(

--- a/python/src/trezorlib/firmware/core.py
+++ b/python/src/trezorlib/firmware/core.py
@@ -44,6 +44,7 @@ class HeaderType(Enum):
     FIRMWARE = b"TRZF"
     BOOTLOADER = b"TRZB"
     BOOTLOADER_V2 = b"TRZQ"
+    NRF_FIRMWARE = bytes.fromhex("3DB8F396")
 
 
 class FirmwareHeader(Struct):
@@ -348,6 +349,26 @@ class BootableImage(Struct):
         if isinstance(self.header.hw_model, Model):
             return self.header.hw_model
         return None
+
+    def insert_sigmask(self, sigmask: int) -> None:
+        self.header.sigmask = sigmask
+
+    def insert_signatures(
+        self, slh_signature: bytes, ec_signature: bytes, slot_idx: int
+    ) -> None:
+        if not (
+            0 <= slot_idx < len(self.unauth.slh_signatures)
+            and 0 <= slot_idx < len(self.unauth.ec_signatures)
+        ):
+            raise ValueError("Invalid pubkey-pair slot_idx")
+        if len(slh_signature) != 7856:
+            raise ValueError(
+                f"slh_signature must be 7856 bytes, got {len(slh_signature)}"
+            )
+        if len(ec_signature) != 64:
+            raise ValueError(f"ec_signature must be 64 bytes, got {len(ec_signature)}")
+        self.unauth.slh_signatures[slot_idx] = slh_signature
+        self.unauth.ec_signatures[slot_idx] = ec_signature
 
     def public_pq_keys(self, dev_keys: bool = False) -> t.Sequence[bytes]:
         if dev_keys:

--- a/python/src/trezorlib/firmware/util.py
+++ b/python/src/trezorlib/firmware/util.py
@@ -35,6 +35,7 @@ class Unsigned(FirmwareIntegrityError):
 
 
 class DigestCalculator(Protocol):
+
     def update(self, __data: bytes) -> None: ...
 
     def digest(self) -> bytes: ...


### PR DESCRIPTION
- Fixes issues with verification of BootloaderV2Images.
- Minor code adjustments.

### Notes for QA
- Not sure whether to test this or not. This change can be visible through tools that verify that an image (firmware/bootloader,...) is properly signed. The BootloaderV2 can be tested using helper tool `headertool_pq.py`. Some minor changes affect also other image-types (secmon, ...) which can be tested using other tool - `headertool.py`. 

