### PR TITLE
feat(core): RSOD on tropic_init fail

### DIFF
--- a/core/embed/projects/kernel/main.c
+++ b/core/embed/projects/kernel/main.c
@@ -207,7 +207,7 @@ void drivers_init() {
   optiga_init_and_configure();
 #endif
 #ifdef USE_TROPIC
-  tropic_init(NULL);
+  ensure_true(tropic_init(NULL) == LT_OK, "Failed to initialize Tropic driver");
 #endif
 #endif  // SECURE_MODE
 

--- a/core/embed/projects/kernel/main.c
+++ b/core/embed/projects/kernel/main.c
@@ -207,7 +207,7 @@ void drivers_init() {
   optiga_init_and_configure();
 #endif
 #ifdef USE_TROPIC
-  ensure_true(tropic_init(NULL), "Failed to initialize Tropic driver");
+  ensure_true(tropic_init(NULL) == LT_OK, "Failed to initialize Tropic driver");
 #endif
 #endif  // SECURE_MODE
 

--- a/core/embed/projects/kernel/main.c
+++ b/core/embed/projects/kernel/main.c
@@ -207,7 +207,7 @@ void drivers_init() {
   optiga_init_and_configure();
 #endif
 #ifdef USE_TROPIC
-  tropic_init(NULL);
+  ensure_true(tropic_init(NULL), "Failed to initialize Tropic driver");
 #endif
 #endif  // SECURE_MODE
 

--- a/core/embed/projects/kernel/main.c
+++ b/core/embed/projects/kernel/main.c
@@ -207,7 +207,8 @@ void drivers_init() {
   optiga_init_and_configure();
 #endif
 #ifdef USE_TROPIC
-  ensure_true(tropic_init(NULL) == LT_OK, "Failed to initialize Tropic driver");
+  lt_ret_t tropic_ret = tropic_init(NULL);
+  ensure_true(tropic_ret == LT_OK, tropic_init_error_message(tropic_ret));
 #endif
 #endif  // SECURE_MODE
 

--- a/core/embed/projects/kernel/main.c
+++ b/core/embed/projects/kernel/main.c
@@ -207,8 +207,7 @@ void drivers_init() {
   optiga_init_and_configure();
 #endif
 #ifdef USE_TROPIC
-  lt_ret_t tropic_ret = tropic_init(NULL);
-  ensure_true(tropic_ret == LT_OK, tropic_init_error_message(tropic_ret));
+  ensure_true(tropic_init(NULL) == LT_OK, "Failed to initialize Tropic driver");
 #endif
 #endif  // SECURE_MODE
 

--- a/core/embed/projects/secmon/main.c
+++ b/core/embed/projects/secmon/main.c
@@ -125,7 +125,7 @@ static void drivers_init(void) {
 #endif
 
 #ifdef USE_TROPIC
-  tropic_init(NULL);
+  ensure_true(tropic_init(NULL), "Failed to initialize Tropic driver");
 #if defined(USE_SECRET) && defined(LOCKABLE_BOOTLOADER)
   if (secfalse != secret_bootloader_locked()) {
     ensure(tropic_ensure_configuration(), "Tropic configuration check failed");

--- a/core/embed/projects/secmon/main.c
+++ b/core/embed/projects/secmon/main.c
@@ -125,7 +125,7 @@ static void drivers_init(void) {
 #endif
 
 #ifdef USE_TROPIC
-  tropic_init(NULL);
+  ensure_true(tropic_init(NULL) == LT_OK, "Failed to initialize Tropic driver");
 #if defined(USE_SECRET) && defined(LOCKABLE_BOOTLOADER)
   if (secfalse != secret_bootloader_locked()) {
     ensure(tropic_ensure_configuration(), "Tropic configuration check failed");

--- a/core/embed/projects/secmon/main.c
+++ b/core/embed/projects/secmon/main.c
@@ -125,7 +125,7 @@ static void drivers_init(void) {
 #endif
 
 #ifdef USE_TROPIC
-  ensure_true(tropic_init(NULL), "Failed to initialize Tropic driver");
+  ensure_true(tropic_init(NULL) == LT_OK, "Failed to initialize Tropic driver");
 #if defined(USE_SECRET) && defined(LOCKABLE_BOOTLOADER)
   if (secfalse != secret_bootloader_locked()) {
     ensure(tropic_ensure_configuration(), "Tropic configuration check failed");

--- a/core/embed/projects/secmon/main.c
+++ b/core/embed/projects/secmon/main.c
@@ -125,7 +125,8 @@ static void drivers_init(void) {
 #endif
 
 #ifdef USE_TROPIC
-  ensure_true(tropic_init(NULL) == LT_OK, "Failed to initialize Tropic driver");
+  lt_ret_t tropic_ret = tropic_init(NULL);
+  ensure_true(tropic_ret == LT_OK, tropic_init_error_message(tropic_ret));
 #if defined(USE_SECRET) && defined(LOCKABLE_BOOTLOADER)
   if (secfalse != secret_bootloader_locked()) {
     ensure(tropic_ensure_configuration(), "Tropic configuration check failed");

--- a/core/embed/projects/secmon/main.c
+++ b/core/embed/projects/secmon/main.c
@@ -125,8 +125,7 @@ static void drivers_init(void) {
 #endif
 
 #ifdef USE_TROPIC
-  lt_ret_t tropic_ret = tropic_init(NULL);
-  ensure_true(tropic_ret == LT_OK, tropic_init_error_message(tropic_ret));
+  ensure_true(tropic_init(NULL) == LT_OK, "Failed to initialize Tropic driver");
 #if defined(USE_SECRET) && defined(LOCKABLE_BOOTLOADER)
   if (secfalse != secret_bootloader_locked()) {
     ensure(tropic_ensure_configuration(), "Tropic configuration check failed");

--- a/core/embed/projects/unix/main_main.c
+++ b/core/embed/projects/unix/main_main.c
@@ -100,7 +100,7 @@ static void drivers_init(void) {
 #endif
 
 #ifdef USE_TROPIC
-  ensure_true(tropic_init(NULL), "Failed to initialize Tropic driver");
+  ensure_true(tropic_init(NULL) == LT_OK, "Failed to initialize Tropic driver");
   ensure(tropic_ensure_configuration(), "Tropic configuration check failed");
 #endif
 

--- a/core/embed/projects/unix/main_main.c
+++ b/core/embed/projects/unix/main_main.c
@@ -100,7 +100,7 @@ static void drivers_init(void) {
 #endif
 
 #ifdef USE_TROPIC
-  tropic_init(NULL);
+  ensure_true(tropic_init(NULL), "Failed to initialize Tropic driver");
   ensure(tropic_ensure_configuration(), "Tropic configuration check failed");
 #endif
 

--- a/core/embed/projects/unix/main_main.c
+++ b/core/embed/projects/unix/main_main.c
@@ -100,8 +100,7 @@ static void drivers_init(void) {
 #endif
 
 #ifdef USE_TROPIC
-  lt_ret_t tropic_ret = tropic_init(NULL);
-  ensure_true(tropic_ret == LT_OK, tropic_init_error_message(tropic_ret));
+  ensure_true(tropic_init(NULL) == LT_OK, "Failed to initialize Tropic driver");
   ensure(tropic_ensure_configuration(), "Tropic configuration check failed");
 #endif
 

--- a/core/embed/projects/unix/main_main.c
+++ b/core/embed/projects/unix/main_main.c
@@ -100,7 +100,8 @@ static void drivers_init(void) {
 #endif
 
 #ifdef USE_TROPIC
-  ensure_true(tropic_init(NULL) == LT_OK, "Failed to initialize Tropic driver");
+  lt_ret_t tropic_ret = tropic_init(NULL);
+  ensure_true(tropic_ret == LT_OK, tropic_init_error_message(tropic_ret));
   ensure(tropic_ensure_configuration(), "Tropic configuration check failed");
 #endif
 

--- a/core/embed/projects/unix/main_main.c
+++ b/core/embed/projects/unix/main_main.c
@@ -100,7 +100,9 @@ static void drivers_init(void) {
 #endif
 
 #ifdef USE_TROPIC
-  tropic_init(NULL);
+  ensure_true(tropic_init(NULL) == LT_OK,
+              "Failed to initialize Tropic driver. Make sure the "
+              "`model_server` is running.");
   ensure(tropic_ensure_configuration(), "Tropic configuration check failed");
 #endif
 

--- a/core/embed/projects/unix/rust_c_setup.c
+++ b/core/embed/projects/unix/rust_c_setup.c
@@ -59,7 +59,7 @@ void rust_tests_c_setup(void) {
 #endif
 
 #ifdef USE_TROPIC
-  tropic_init(NULL);
+  ensure_true(tropic_init(NULL) == LT_OK, "Failed to initialize Tropic driver");
 #endif
 
   usb_configure(NULL);

--- a/core/embed/projects/unix/rust_c_setup.c
+++ b/core/embed/projects/unix/rust_c_setup.c
@@ -59,7 +59,8 @@ void rust_tests_c_setup(void) {
 #endif
 
 #ifdef USE_TROPIC
-  ensure_true(tropic_init(NULL) == LT_OK, "Failed to initialize Tropic driver");
+  lt_ret_t tropic_ret = tropic_init(NULL);
+  ensure_true(tropic_ret == LT_OK, tropic_init_error_message(tropic_ret));
 #endif
 
   usb_configure(NULL);

--- a/core/embed/projects/unix/rust_c_setup.c
+++ b/core/embed/projects/unix/rust_c_setup.c
@@ -59,8 +59,7 @@ void rust_tests_c_setup(void) {
 #endif
 
 #ifdef USE_TROPIC
-  lt_ret_t tropic_ret = tropic_init(NULL);
-  ensure_true(tropic_ret == LT_OK, tropic_init_error_message(tropic_ret));
+  ensure_true(tropic_init(NULL) == LT_OK, "Failed to initialize Tropic driver");
 #endif
 
   usb_configure(NULL);

--- a/core/embed/rust/src/test_setup.c
+++ b/core/embed/rust/src/test_setup.c
@@ -60,7 +60,7 @@ void rust_tests_c_setup(void) {
 #endif
 
 #ifdef USE_TROPIC
-  tropic_init(NULL);
+  ensure_true(tropic_init(NULL) == LT_OK, "Failed to initialize Tropic driver");
 #endif
 
   usb_configure(NULL);

--- a/core/embed/sec/suspend/stm32u5/suspend_io.c
+++ b/core/embed/sec/suspend/stm32u5/suspend_io.c
@@ -72,7 +72,7 @@ void resume_secure_drivers() {
   secure_aes_init();
 #endif
 #ifdef USE_TROPIC
-  tropic_init(NULL);
+  ensure_true(tropic_init(NULL) == LT_OK, "Failed to initialize Tropic driver");
 #endif
 }
 

--- a/core/embed/sec/suspend/stm32u5/suspend_io.c
+++ b/core/embed/sec/suspend/stm32u5/suspend_io.c
@@ -72,7 +72,8 @@ void resume_secure_drivers() {
   secure_aes_init();
 #endif
 #ifdef USE_TROPIC
-  ensure_true(tropic_init(NULL) == LT_OK, "Failed to initialize Tropic driver");
+  lt_ret_t tropic_ret = tropic_init(NULL);
+  ensure_true(tropic_ret == LT_OK, tropic_init_error_message(tropic_ret));
 #endif
 }
 

--- a/core/embed/sec/suspend/stm32u5/suspend_io.c
+++ b/core/embed/sec/suspend/stm32u5/suspend_io.c
@@ -72,8 +72,7 @@ void resume_secure_drivers() {
   secure_aes_init();
 #endif
 #ifdef USE_TROPIC
-  lt_ret_t tropic_ret = tropic_init(NULL);
-  ensure_true(tropic_ret == LT_OK, tropic_init_error_message(tropic_ret));
+  ensure_true(tropic_init(NULL) == LT_OK, "Failed to initialize Tropic driver");
 #endif
 }
 

--- a/core/embed/sec/tropic/inc/sec/tropic.h
+++ b/core/embed/sec/tropic/inc/sec/tropic.h
@@ -71,6 +71,20 @@
 
 lt_ret_t tropic_init(cli_t* cli);
 
+/**
+ * @brief Builds an RSOD message describing a failed `tropic_init()`.
+ *
+ * Intended to be passed to `ensure_true()`, so that the libtropic return code
+ * is visible on screen instead of a generic message:
+ *
+ *   lt_ret_t ret = tropic_init(NULL);
+ *   ensure_true(ret == LT_OK, tropic_init_error_message(ret));
+ *
+ * @param ret Return value of the failed `tropic_init()` call.
+ * @return Pointer to a static buffer holding the message.
+ */
+const char* tropic_init_error_message(lt_ret_t ret);
+
 void tropic01_reset(void);
 
 void tropic_deinit(void);

--- a/core/embed/sec/tropic/inc/sec/tropic.h
+++ b/core/embed/sec/tropic/inc/sec/tropic.h
@@ -71,20 +71,6 @@
 
 lt_ret_t tropic_init(cli_t* cli);
 
-/**
- * @brief Builds an RSOD message describing a failed `tropic_init()`.
- *
- * Intended to be passed to `ensure_true()`, so that the libtropic return code
- * is visible on screen instead of a generic message:
- *
- *   lt_ret_t ret = tropic_init(NULL);
- *   ensure_true(ret == LT_OK, tropic_init_error_message(ret));
- *
- * @param ret Return value of the failed `tropic_init()` call.
- * @return Pointer to a static buffer holding the message.
- */
-const char* tropic_init_error_message(lt_ret_t ret);
-
 void tropic01_reset(void);
 
 void tropic_deinit(void);

--- a/core/embed/sec/tropic/inc/sec/tropic.h
+++ b/core/embed/sec/tropic/inc/sec/tropic.h
@@ -71,8 +71,6 @@
 
 lt_ret_t tropic_init(cli_t* cli);
 
-void tropic01_reset(void);
-
 void tropic_deinit(void);
 
 typedef struct {

--- a/core/embed/sec/tropic/stm32/tropic01.c
+++ b/core/embed/sec/tropic/stm32/tropic01.c
@@ -39,15 +39,6 @@ static tropic_ui_progress_t ui_progress = NULL;
 
 void tropic_set_ui_progress(tropic_ui_progress_t f) { ui_progress = f; }
 
-void tropic01_reset(void) {
-  HAL_GPIO_WritePin(TROPIC01_SPI_NSS_PORT, TROPIC01_SPI_NSS_PIN,
-                    GPIO_PIN_RESET);
-  HAL_GPIO_WritePin(TROPIC01_PWR_PORT, TROPIC01_PWR_PIN, GPIO_PIN_SET);
-  systick_delay_ms(10);
-  HAL_GPIO_WritePin(TROPIC01_PWR_PORT, TROPIC01_PWR_PIN, GPIO_PIN_RESET);
-  HAL_GPIO_WritePin(TROPIC01_SPI_NSS_PORT, TROPIC01_SPI_NSS_PIN, GPIO_PIN_SET);
-}
-
 lt_ret_t lt_port_init(lt_l2_state_t *s2) {
   tropic01_hal_driver_t *drv = &g_tropic01_hal_driver;
 

--- a/core/embed/sec/tropic/tropic.c
+++ b/core/embed/sec/tropic/tropic.c
@@ -127,6 +127,11 @@ typedef enum {
 
 #ifdef TREZOR_EMULATOR
 #define TROPIC_RETRY_COMMAND(command) command
+
+static lt_ret_t lt_init_retry(lt_handle_t *tropic_handle) {
+  return lt_init(tropic_handle);
+}
+
 #else
 #define TROPIC_MAX_RETRIES 10
 
@@ -165,6 +170,17 @@ static bool is_retryable(lt_ret_t ret) {
     }                                                                     \
     TROPIC_RETRY_COMMAND_res;                                             \
   })
+
+static lt_ret_t lt_init_retry(lt_handle_t *tropic_handle) {
+  lt_ret_t ret = lt_init(tropic_handle);
+  for (int i = 0; i < TROPIC_MAX_RETRIES - 1 && is_retryable(ret); i++) {
+    tropic01_reset();
+    lt_deinit(tropic_handle);
+    ret = lt_init(tropic_handle);
+  }
+  return ret;
+}
+
 #endif  // TREZOR_EMULATOR
 
 typedef struct {
@@ -983,7 +999,7 @@ lt_ret_t tropic_init(cli_t *cli) {
   // Initialize crypto context
   drv->handle.l3.crypto_ctx = &drv->crypto_ctx;
 
-  lt_ret_t ret = lt_init(&drv->handle);
+  lt_ret_t ret = lt_init_retry(&drv->handle);
   if (ret != LT_OK) {
 #ifdef TREZOR_PRODTEST
     if (cli) {

--- a/core/embed/sec/tropic/tropic.c
+++ b/core/embed/sec/tropic/tropic.c
@@ -127,11 +127,6 @@ typedef enum {
 
 #ifdef TREZOR_EMULATOR
 #define TROPIC_RETRY_COMMAND(command) command
-
-static lt_ret_t lt_init_retry(lt_handle_t *tropic_handle) {
-  return lt_init(tropic_handle);
-}
-
 #else
 #define TROPIC_MAX_RETRIES 10
 
@@ -157,7 +152,6 @@ static bool is_retryable(lt_ret_t ret) {
       if (!is_retryable(TROPIC_RETRY_COMMAND_res)) {                      \
         break;                                                            \
       }                                                                   \
-      tropic01_reset();                                                   \
       tropic_deinit();                                                    \
       tropic_init(NULL);                                                  \
       if (TROPIC_RETRY_COMMAND_session_started) {                         \
@@ -170,16 +164,6 @@ static bool is_retryable(lt_ret_t ret) {
     }                                                                     \
     TROPIC_RETRY_COMMAND_res;                                             \
   })
-
-static lt_ret_t lt_init_retry(lt_handle_t *tropic_handle) {
-  lt_ret_t ret = lt_init(tropic_handle);
-  for (int i = 0; i < TROPIC_MAX_RETRIES - 1 && is_retryable(ret); i++) {
-    tropic01_reset();
-    lt_deinit(tropic_handle);
-    ret = lt_init(tropic_handle);
-  }
-  return ret;
-}
 
 #endif  // TREZOR_EMULATOR
 
@@ -994,12 +978,22 @@ lt_ret_t tropic_init(cli_t *cli) {
   drv->device.addr = inet_addr("127.0.0.1");
   drv->device.port = get_tropic_model_port();
   drv->handle.l2.device = &drv->device;
-#endif
+#endif  // TREZOR_EMULATOR
 
   // Initialize crypto context
   drv->handle.l3.crypto_ctx = &drv->crypto_ctx;
 
-  lt_ret_t ret = lt_init_retry(&drv->handle);
+  lt_ret_t ret = lt_init(&drv->handle);
+#if !defined(TREZOR_PRODTEST) && !defined(TREZOR_EMULATOR)
+  // On HW Firmware, retry a failed init.
+  // Prodtest skips it to surface the init error.
+  // Emulator has no retry logic.
+  for (int i = 0; i < TROPIC_MAX_RETRIES - 1 && is_retryable(ret); i++) {
+    lt_deinit(&drv->handle);
+    ret = lt_init(&drv->handle);
+  }
+#endif  // !TREZOR_PRODTEST && !TREZOR_EMULATOR
+
   if (ret != LT_OK) {
 #ifdef TREZOR_PRODTEST
     if (cli) {

--- a/core/embed/sec/tropic/tropic.c
+++ b/core/embed/sec/tropic/tropic.c
@@ -761,14 +761,6 @@ static bool set_backup_distribution_version_to(uint32_t distribution_version) {
   return true;
 }
 
-static secbool tropic_restart_chip(void) {
-  tropic_deinit();
-  if (tropic_init(NULL) != LT_OK) {
-    return secfalse;
-  }
-  return sectrue;
-}
-
 // Applies `expected_config` and writes the new distribution version to slot 6.
 //
 // Crash-safety: the write order is designed so that a power-cut leaves slot 6
@@ -869,7 +861,11 @@ static secbool set_expected_config(
     return secfalse;
   }
 
-  return tropic_restart_chip();
+  if (lt_reboot(&g_tropic_driver.handle, TR01_REBOOT) != LT_OK) {
+    return secfalse;
+  }
+
+  return sectrue;
 }
 
 // clang-format off

--- a/core/embed/sec/tropic/tropic.c
+++ b/core/embed/sec/tropic/tropic.c
@@ -164,7 +164,6 @@ static bool is_retryable(lt_ret_t ret) {
     }                                                                     \
     TROPIC_RETRY_COMMAND_res;                                             \
   })
-
 #endif  // TREZOR_EMULATOR
 
 typedef struct {

--- a/core/embed/sec/tropic/tropic.c
+++ b/core/embed/sec/tropic/tropic.c
@@ -762,9 +762,6 @@ static bool set_backup_distribution_version_to(uint32_t distribution_version) {
 }
 
 static secbool tropic_restart_chip(void) {
-#ifndef TREZOR_EMULATOR
-  tropic01_reset();
-#endif
   tropic_deinit();
   if (tropic_init(NULL) != LT_OK) {
     return secfalse;

--- a/core/embed/sec/tropic/tropic.c
+++ b/core/embed/sec/tropic/tropic.c
@@ -20,7 +20,6 @@
 #include <trezor_rtl.h>
 #include <trezor_types.h>
 
-#include <rtl/strutils.h>
 #include <sec/rng_strong.h>
 #include <sec/secret_keys.h>
 #include <sec/tropic.h>
@@ -1006,16 +1005,6 @@ lt_ret_t tropic_init(cli_t *cli) {
   drv->initialized = true;
 
   return LT_OK;
-}
-
-const char *tropic_init_error_message(lt_ret_t ret) {
-  static char message[64] = "";
-
-  message[0] = '\0';
-  cstr_append(message, sizeof(message), "Tropic init failed: ");
-  cstr_append(message, sizeof(message), lt_ret_verbose(ret));
-
-  return message;
 }
 
 void tropic_deinit(void) {

--- a/core/embed/sec/tropic/tropic.c
+++ b/core/embed/sec/tropic/tropic.c
@@ -20,6 +20,7 @@
 #include <trezor_rtl.h>
 #include <trezor_types.h>
 
+#include <rtl/strutils.h>
 #include <sec/rng_strong.h>
 #include <sec/secret_keys.h>
 #include <sec/tropic.h>
@@ -1003,6 +1004,16 @@ lt_ret_t tropic_init(cli_t *cli) {
   drv->initialized = true;
 
   return LT_OK;
+}
+
+const char *tropic_init_error_message(lt_ret_t ret) {
+  static char message[64] = "";
+
+  message[0] = '\0';
+  cstr_append(message, sizeof(message), "Tropic init failed: ");
+  cstr_append(message, sizeof(message), lt_ret_verbose(ret));
+
+  return message;
 }
 
 void tropic_deinit(void) {

--- a/core/embed/sec/tropic/tropic.c
+++ b/core/embed/sec/tropic/tropic.c
@@ -70,6 +70,10 @@ static const uint8_t TROPIC_BATCHES_V1[][LT_MEMBER_SIZE(
 // {0x19, 0x0a, 0x1f, 0x0f, 0x2c}, {0x19, 0x0c, 0x03, 0x0d, 0x38},
 // };
 
+// How long we wait after `tropic_deinit()` before calling `tropic_init()`
+// again.
+#define TROPIC_RESTART_DELAY_MS 10
+
 // clang-format off
 // Temporary address table for config objects, ordered to match lt_config_t.obj[].
 // Using a local const table instead of `cfg_desc_table` from libtropic because including
@@ -152,9 +156,11 @@ static bool is_retryable(lt_ret_t ret) {
       if (!is_retryable(TROPIC_RETRY_COMMAND_res)) {                      \
         break;                                                            \
       }                                                                   \
-      tropic01_reset();                                                   \
       tropic_deinit();                                                    \
-      tropic_init(NULL);                                                  \
+      systick_delay_ms(TROPIC_RESTART_DELAY_MS);                          \
+      if (tropic_init(NULL) != LT_OK) {                                   \
+        break;                                                            \
+      }                                                                   \
       if (TROPIC_RETRY_COMMAND_session_started) {                         \
         if (tropic_custom_session_start(                                  \
                 NULL, TROPIC_RETRY_COMMAND_pairing_key_index) != LT_OK) { \
@@ -762,17 +768,6 @@ static bool set_backup_distribution_version_to(uint32_t distribution_version) {
   return true;
 }
 
-static secbool tropic_restart_chip(void) {
-#ifndef TREZOR_EMULATOR
-  tropic01_reset();
-#endif
-  tropic_deinit();
-  if (tropic_init(NULL) != LT_OK) {
-    return secfalse;
-  }
-  return sectrue;
-}
-
 // Applies `expected_config` and writes the new distribution version to slot 6.
 //
 // Crash-safety: the write order is designed so that a power-cut leaves slot 6
@@ -873,7 +868,14 @@ static secbool set_expected_config(
     return secfalse;
   }
 
-  return tropic_restart_chip();
+  // restart Tropic so the new config takes effect.
+  tropic_deinit();
+  systick_delay_ms(TROPIC_RESTART_DELAY_MS);
+  if (tropic_init(NULL) != LT_OK) {
+    return secfalse;
+  }
+
+  return sectrue;
 }
 
 // clang-format off
@@ -978,12 +980,23 @@ lt_ret_t tropic_init(cli_t *cli) {
   drv->device.addr = inet_addr("127.0.0.1");
   drv->device.port = get_tropic_model_port();
   drv->handle.l2.device = &drv->device;
-#endif
+#endif  // TREZOR_EMULATOR
 
   // Initialize crypto context
   drv->handle.l3.crypto_ctx = &drv->crypto_ctx;
 
   lt_ret_t ret = lt_init(&drv->handle);
+#if !defined(TREZOR_PRODTEST) && !defined(TREZOR_EMULATOR)
+  // On HW Firmware, retry a failed init.
+  // Prodtest skips it to surface the init error.
+  // Emulator has no retry logic.
+  for (int i = 0; i < TROPIC_MAX_RETRIES - 1 && is_retryable(ret); i++) {
+    lt_deinit(&drv->handle);
+    systick_delay_ms(TROPIC_RESTART_DELAY_MS);
+    ret = lt_init(&drv->handle);
+  }
+#endif  // !TREZOR_PRODTEST && !TREZOR_EMULATOR
+
   if (ret != LT_OK) {
 #ifdef TREZOR_PRODTEST
     if (cli) {

--- a/core/embed/sec/tropic/tropic.c
+++ b/core/embed/sec/tropic/tropic.c
@@ -869,7 +869,9 @@ static secbool set_expected_config(
   // restart Tropic so the new config takes effect.
   tropic_deinit();
   systick_delay_ms(TROPIC_RESTART_DELAY_MS);
-  tropic_init(NULL);
+  if (tropic_init(NULL) != LT_OK) {
+    return secfalse;
+  }
 
   return sectrue;
 }

--- a/core/embed/sec/tropic/tropic.c
+++ b/core/embed/sec/tropic/tropic.c
@@ -70,7 +70,8 @@ static const uint8_t TROPIC_BATCHES_V1[][LT_MEMBER_SIZE(
 // {0x19, 0x0a, 0x1f, 0x0f, 0x2c}, {0x19, 0x0c, 0x03, 0x0d, 0x38},
 // };
 
-// How long we wait after `tropic_deinit()` before calling `tropic_init()` again.
+// How long we wait after `tropic_deinit()` before calling `tropic_init()`
+// again.
 #define TROPIC_RESTART_DELAY_MS 10
 
 // clang-format off
@@ -157,7 +158,9 @@ static bool is_retryable(lt_ret_t ret) {
       }                                                                   \
       tropic_deinit();                                                    \
       systick_delay_ms(TROPIC_RESTART_DELAY_MS);                          \
-      tropic_init(NULL);                                                  \
+      if (tropic_init(NULL) != LT_OK) {                                   \
+        break;                                                            \
+      }                                                                   \
       if (TROPIC_RETRY_COMMAND_session_started) {                         \
         if (tropic_custom_session_start(                                  \
                 NULL, TROPIC_RETRY_COMMAND_pairing_key_index) != LT_OK) { \

--- a/core/embed/sec/tropic/tropic.c
+++ b/core/embed/sec/tropic/tropic.c
@@ -70,6 +70,9 @@ static const uint8_t TROPIC_BATCHES_V1[][LT_MEMBER_SIZE(
 // {0x19, 0x0a, 0x1f, 0x0f, 0x2c}, {0x19, 0x0c, 0x03, 0x0d, 0x38},
 // };
 
+// How long we wait after `tropic_deinit()` before calling `tropic_init()` again.
+#define TROPIC_RESTART_DELAY_MS 10
+
 // clang-format off
 // Temporary address table for config objects, ordered to match lt_config_t.obj[].
 // Using a local const table instead of `cfg_desc_table` from libtropic because including
@@ -153,6 +156,7 @@ static bool is_retryable(lt_ret_t ret) {
         break;                                                            \
       }                                                                   \
       tropic_deinit();                                                    \
+      systick_delay_ms(TROPIC_RESTART_DELAY_MS);                          \
       tropic_init(NULL);                                                  \
       if (TROPIC_RETRY_COMMAND_session_started) {                         \
         if (tropic_custom_session_start(                                  \
@@ -861,9 +865,10 @@ static secbool set_expected_config(
     return secfalse;
   }
 
-  if (lt_reboot(&g_tropic_driver.handle, TR01_REBOOT) != LT_OK) {
-    return secfalse;
-  }
+  // restart Tropic so the new config takes effect.
+  tropic_deinit();
+  systick_delay_ms(TROPIC_RESTART_DELAY_MS);
+  tropic_init(NULL);
 
   return sectrue;
 }
@@ -982,6 +987,7 @@ lt_ret_t tropic_init(cli_t *cli) {
   // Emulator has no retry logic.
   for (int i = 0; i < TROPIC_MAX_RETRIES - 1 && is_retryable(ret); i++) {
     lt_deinit(&drv->handle);
+    systick_delay_ms(TROPIC_RESTART_DELAY_MS);
     ret = lt_init(&drv->handle);
   }
 #endif  // !TREZOR_PRODTEST && !TREZOR_EMULATOR


### PR DESCRIPTION
When the `tropic_init` function fails, cause RSOD immediately with informative message that the tropic chip was at fault.

Also, retry the `lt_init` command to give the chip more chances to boot successfully.

[no changelog]