### PR TITLE
fix(core): show Caesar confirm value descriptions with info items

### DIFF
--- a/core/.changelog.d/6890.fixed
+++ b/core/.changelog.d/6890.fixed
@@ -1,0 +1,1 @@
+[T2B1,T3B1] Show description on Caesar `confirm_value` screens with info menu items.

--- a/core/.changelog.d/6890.fixed
+++ b/core/.changelog.d/6890.fixed
@@ -1,1 +1,1 @@
-[T2B1,T3B1] Show description on Caesar `confirm_value` screens with info menu items.
+[T2B1,T3B1] Description label fixed on confirmation screens with context menu.

--- a/core/embed/rust/src/ui/layout_caesar/component_msg_obj.rs
+++ b/core/embed/rust/src/ui/layout_caesar/component_msg_obj.rs
@@ -61,6 +61,7 @@ where
         match msg {
             PageMsg::Confirmed => Ok(CONFIRMED.as_obj()),
             PageMsg::Cancelled => Ok(CANCELLED.as_obj()),
+            PageMsg::Info => Ok(INFO.as_obj()),
             _ => Err(Error::TypeError),
         }
     }

--- a/core/embed/rust/src/ui/layout_caesar/ui_firmware.rs
+++ b/core/embed/rust/src/ui/layout_caesar/ui_firmware.rs
@@ -163,7 +163,7 @@ impl FirmwareUI for UICaesar {
         _cancel: bool,
         _back_button: bool,
         _footer: Option<(TString<'static>, bool)>,
-        _external_menu: bool,
+        external_menu: bool,
     ) -> Result<impl LayoutMaybeTrace, Error> {
         let paragraphs = ConfirmValueParams {
             description: description.unwrap_or("".into()),
@@ -188,7 +188,7 @@ impl FirmwareUI for UICaesar {
             verb.unwrap_or(TR::buttons__confirm.into()),
             verb_cancel,
             hold,
-            false,
+            external_menu,
         )
     }
 

--- a/core/src/trezor/ui/layouts/caesar/__init__.py
+++ b/core/src/trezor/ui/layouts/caesar/__init__.py
@@ -976,11 +976,16 @@ def confirm_value(
 
     from trezor.ui.layouts.menu import Details, Menu, confirm_with_menu
 
-    main = trezorui_api.confirm_with_info(
+    main = trezorui_api.confirm_value(
         title=title,
-        items=((value, False),),
+        value=value,
+        description=description,
         verb=verb or TR.buttons__confirm,
-        verb_info=INFO_ICON,
+        verb_cancel=verb_cancel or "",
+        hold=hold,
+        is_data=is_data,
+        chunkify=chunkify,
+        cancel=cancel,
         external_menu=True,
     )
 
@@ -990,7 +995,7 @@ def confirm_value(
         return lambda: trezorui_api.confirm_value(
             title=info_title,
             value=info_value,
-            description=description,
+            description=None,
             verb="",
             verb_cancel="",
             is_data=is_data,


### PR DESCRIPTION
fix #6890 