### PR TITLE
shell.nix: workaround for sdl3 on non-NixOS distros

### DIFF
--- a/shell.nix
+++ b/shell.nix
@@ -72,6 +72,16 @@ let
     version = "stm-cubeide-v1.13.0";
     nativeBuildInputs = oldAttrs.nativeBuildInputs ++ [ nixpkgs.autoreconfHook ];
   }));
+  # Workaround for "sdl3 from nix-shell running on non-NixOS wayland"
+  # taken from https://github.com/nix-community/nixGL/blob/main/nixGL.nix
+  vkIcd = nixpkgs.runCommand "mesa_icd" { } (
+    # 64 bits icd
+    ''
+      ls ${nixpkgs.mesa}/share/vulkan/icd.d/*.json > f
+    ''
+    # concat everything as a one line string with ":" as separator
+    + ''cat f | xargs | sed "s/ /:/g" > $out'');
+  vkIcdFilenames = builtins.readFile vkIcd;
 in
 with nixpkgs;
 stdenvNoCC.mkDerivation ({
@@ -147,6 +157,8 @@ stdenvNoCC.mkDerivation ({
   ];
   DYLD_LIBRARY_PATH = "${libffi}/lib:${libjpeg.out}/lib:${libusb1}/lib:${libressl.out}/lib";
   NIX_ENFORCE_PURITY = 0;
+
+  VK_ICD_FILENAMES = vkIcdFilenames;
 
   # Fix bdist-wheel problem by setting source date epoch to a more recent date
   SOURCE_DATE_EPOCH = 1600000000;


### PR DESCRIPTION
Tries to work around "the OpenGL problem" by using nix-provided copies of some Vulkan libraries.

See also: https://alternativebit.fr/posts/nixos/nix-opengl-and-ubuntu-integration-nightmare/

See also: #6894 #6858

<!--
For external contributors:
- Please open an issue before submitting a PR so we can discuss whether we want to proceed with it.

For core developers:
1. Initial PR setup
- Assign yourself to the PR.
- Add it to the "Firmware" project
  - Set Priority (match issue priority if it exists)
  - Set Team
  - Set Sprint (target release)

2. Development status
- Draft PRs: Set status to "In Progress"
- Final PRs: Set status to "Needs Review"

3. Post-merge status
- Testable: Set status to "Needs QA" and add a `Notes for QA` section with clear instructions on how to test the functionality.
- Not Testable: Set status to "Done (no QA)"
-->
