### PR TITLE
chore: drop `oldNixpkgs` from `shell.nix`

### DIFF
--- a/docs/tests/upgrade-tests.md
+++ b/docs/tests/upgrade-tests.md
@@ -3,7 +3,7 @@
 1. As always, use `nix-shell` + `uv` environment:
 
 ```sh
-nix-shell
+nix-shell --arg fullDeps true
 uv sync
 source .venv/bin/activate
 ```
@@ -43,3 +43,8 @@ TREZOR_UPGRADE_TEST="T1B1,T3W1" pytest tests/upgrade_tests
 If `TREZOR_UPGRADE_TEST` is not set, this command auto-selects targets based on locally available emulator builds.
 `T1B1` (legacy) runs when the local legacy emulator is available, and `T2T1`/`T3W1` (core) runs when the local core emulator is available.
 For local core builds, the suite detects the model from the build tree; if it cannot be determined, the run fails explicitly and you should set `TREZOR_UPGRADE_TEST` yourself.
+
+## Troubleshooting
+
+- Emulators from before 2026/05 are built using SDL2 library, and the library is required to for the emulators to run. This library is provided in nix-shell only with `--arg fullDeps true`.
+- On some systems, it is necessary to set env variable `SDL_VIDEODRIVER=x11` for the old emulators to run.

--- a/shell.nix
+++ b/shell.nix
@@ -23,10 +23,6 @@ let
     };
     overlays = [ rustOverlay ];
   };
-  oldNixpkgs = import (builtins.fetchTarball {
-    url = "https://github.com/NixOS/nixpkgs/archive/c58e6fbf258df1572b535ac1868ec42faf7675dd.tar.gz";
-    sha256 = "18pna0yinvdprhhcmhyanlgrmgf81nwpc0j2z9fy9mc8cqkx3937";
-  }) { };
   moneroTests = nixpkgs.fetchurl {
     url = "https://github.com/ph4r05/monero/releases/download/v0.18.3.1-dev-tests-u18.04-01/trezor_tests";
     sha256 = "d8938679b69f53132ddacea1de4b38b225b06b37b3309aa17911cfbe09b70b4a";
@@ -80,11 +76,9 @@ stdenvNoCC.mkDerivation ({
   nativeBuildInputs = lib.optionals (!stdenv.isDarwin) [ autoPatchelfHook ];
   buildInputs = lib.optionals fullDeps [
     bitcoind
+    sdl2-compat # for running old emulators used in upgrade tests
+    SDL2_image # for running old emulators used in upgrade tests
   ] ++ [
-    # Current nixpkgs aliases SDL2 to sdl2-compat which on Ubuntu 25.04 makes the emulator
-    # crash with SDL_CreateRenderer error.
-    oldNixpkgs.SDL2
-    oldNixpkgs.SDL2_image
     sdl3
     sdl3-image
     bash

--- a/tests/download_emulators.sh
+++ b/tests/download_emulators.sh
@@ -14,4 +14,4 @@ uv run python download_emulators.py "$MODEL"
 
 cd ..
 # are we in Nix(OS)?
-command -v nix-shell >/dev/null && nix-shell --run "NIX_BINTOOLS=\$NIX_BINTOOLS_FOR_TARGET autoPatchelf tests/emulators/$MODEL"
+command -v nix-shell >/dev/null && nix-shell --arg fullDeps true --run "NIX_BINTOOLS=\$NIX_BINTOOLS_FOR_TARGET autoPatchelf tests/emulators/$MODEL"


### PR DESCRIPTION
Importing `oldNixpkgs` is no longer needed, as SDL2 was replaced by SDL3, and they are not used anywhere else.

SDL2 libraries moved to fullDeps nix-shell to be used with upgrade tests.

Follows: https://github.com/trezor/trezor-firmware/pull/6858
