### PR TITLE
fix(core): add missing tz_init in kernel binary

### DIFF
--- a/core/embed/projects/kernel/main.c
+++ b/core/embed/projects/kernel/main.c
@@ -309,6 +309,10 @@ static void kernel_panic(const systask_postmortem_t *pminfo) {
 }
 
 int main(void) {
+#if defined(USE_TRUSTZONE) && defined(SECURE_MODE)
+  tz_init();
+#endif
+
   // Initialize system's core services
   system_init(&kernel_panic);
 


### PR DESCRIPTION
This PR adds the missing TrustZone initialization in the kernel for the T3T1 and T3B1 models that was accidentally dropped in #6749. Although the device behavior remains correct (because TrustZone was already initialized in the bootloader), this is still a bug. Fortunately, it was not included in any release.

