### PR TITLE
fix(core): don't access `TR` in global context

### DIFF
--- a/core/src/apps/common/request_pin.py
+++ b/core/src/apps/common/request_pin.py
@@ -81,15 +81,15 @@ def _set_last_unlock_time() -> None:
     context.cache_set_int(APP_COMMON_REQUEST_PIN_LAST_UNLOCK, now)
 
 
-_DEF_ARG_PIN_ENTER: str = TR.pin__enter
-
-
 async def verify_user_pin(
-    prompt: str = _DEF_ARG_PIN_ENTER,
+    prompt: str | None = None,
     allow_cancel: bool = True,
     retry: bool = True,
     cache_time_ms: int = 0,
 ) -> None:
+    if prompt is None:
+        prompt = TR.pin__enter
+
     # _get_last_unlock_time
     last_unlock = int.from_bytes(
         context.cache_get(APP_COMMON_REQUEST_PIN_LAST_UNLOCK, b""), "big"

--- a/core/src/trezor/ui/layouts/eckhart/__init__.py
+++ b/core/src/trezor/ui/layouts/eckhart/__init__.py
@@ -781,7 +781,7 @@ def confirm_address(
     address: str,
     subtitle: str | None = None,
     description: str | None = None,
-    verb: str | None = TR.buttons__confirm,
+    verb: str | None = None,
     footer: tuple[str, bool] | None = None,
     chunkify: bool = True,
     br_name: str | None = None,


### PR DESCRIPTION
Otherwise, the bootscreen may use non-translated strings:

https://github.com/user-attachments/assets/d00a48c4-07f4-485d-8652-224de2b6fbbc

Also, make Eckhart confirmation more consistent by switching to "green" confirm button, as done by some layouts before this PR:
https://data.trezor.io/dev/firmware/ui_report/25757329481/T3W1-en-core_device_test-index.html

(found by @Thalarion - "Enter PIN" was shown in English on the bootscreen, but not on lockscreen)

There are a few more Cardano-related instances - will be fixed in https://github.com/trezor/trezor-firmware/issues/6914.