### PR TITLE
chore: refresh `uv.lock`

### DIFF
--- a/uv.lock
+++ b/uv.lock
@@ -2183,7 +2183,7 @@ wheels = [
 
 [[package]]
 name = "trezor"
-version = "0.20.1"
+version = "0.20.2"
 source = { editable = "python" }
 dependencies = [
     { name = "click" },


### PR DESCRIPTION
- Version bumped here: https://github.com/trezor/trezor-firmware/commit/4eab2a988cb658d4c663303713fd3fa9251beb72 (in [PR # 6564 - Improve dependency tree of trezorlib](https://github.com/trezor/trezor-firmware/pull/6564))


