### PR TITLE
chore(ci): add `uv.lock` prebuild check

### DIFF
--- a/.github/workflows/prebuild.yml
+++ b/.github/workflows/prebuild.yml
@@ -70,6 +70,21 @@ jobs:
       - name: "Run gen check"
         run: nix-shell --run "uv run make gen_check"
 
+  # Check uv.lock is up-to-date
+  uvlock_check:
+    name: uv.lock check
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # actions/checkout@v6.0.2
+        with:
+          submodules: "recursive"
+      - name: Install nix
+        uses: cachix/install-nix-action@2126ae7fc54c9df00dd18f7f18754393182c73cd  # cachix/install-nix-action@v31.9.1
+        with:
+          nix_path: nixpkgs=channel:nixos-unstable
+      - name: "Run uv.lock check"
+        run: nix-shell --run "make uvlock_check"
+
   # Verifying that all commits changing some functionality have a changelog entry
   # or contain `[no changelog]` in the commit message.
   changelog_check:

--- a/Makefile
+++ b/Makefile
@@ -202,3 +202,7 @@ hsm_keys_check:
 gen:  templates mocks icons protobuf vendorheader solana_templates bootloader_hashes lsgen tropic_model_config hsm_keys ## regenerate auto-generated files from sources
 
 gen_check: templates_check mocks_check icons_check protobuf_check vendorheader_check solana_templates_check bootloader_hashes_check lsgen_check tropic_model_config_check hsm_keys_check ## check validity of auto-generated files
+
+uvlock_check: ## check that uv.lock is up to date
+	@echo [UVLOCK-CHECK]
+	uv lock --check


### PR DESCRIPTION
Check whether the `uv.lock` file is up-to-date.

### Note for reviewers

This check cannot be a part of other pre-build checks. All of the existing pre-build checks use
`      - uses: ./.github/actions/environment`
which calls `uv sync` internally. Calling `uv sync` regenerates the `uv.lock` - before `make uvlock_check` can test it. 
