### PR TITLE
fix(core): remove unused ipc syscalls

### DIFF
--- a/core/SConscript.firmware
+++ b/core/SConscript.firmware
@@ -63,7 +63,6 @@ FEATURES_WANTED = [
     "dma2d",
     "haptic",
     "input",
-    "ipc",
     "optiga",
     "power_manager",
     "rgb_led",
@@ -95,7 +94,7 @@ if DBG_CONSOLE != "":
     FEATURES_WANTED += ["dbg_console"]
 
 if TREZOR_MODEL in ['T3W1'] and EXTAPP_SUPPORT:
-    FEATURES_WANTED += ["app_loading"]
+    FEATURES_WANTED += ["app_loading", "ipc"]
 
 if N4W1:
     assert PYOPT == "0", "N4W1 requires PYOPT=0"

--- a/core/SConscript.kernel
+++ b/core/SConscript.kernel
@@ -50,7 +50,6 @@ FEATURES_WANTED = [
     "dma2d",
     "haptic",
     "input",
-    "ipc",
     "kernel_mode",
     "optiga",
     "power_manager",
@@ -83,7 +82,7 @@ if not TREZOR_MODEL in ['T3W1', 'D002']:
     FEATURES_WANTED += ["secure_mode"]
 
 if TREZOR_MODEL in ['T3W1'] and EXTAPP_SUPPORT:
-    FEATURES_WANTED += ["app_loading"]
+    FEATURES_WANTED += ["app_loading", "ipc"]
 
 if DISABLE_OPTIGA:
     # TODO use PYOPT instead of PRODUCTION, same as in firmware, blocked on #4253

--- a/core/SConscript.unix
+++ b/core/SConscript.unix
@@ -38,7 +38,6 @@ FEATURES_WANTED = [
     "display",
     "dma2d",
     "input",
-    "ipc",
     "kernel_mode",
     "optiga",
     "powerctl",
@@ -68,7 +67,7 @@ if not DISABLE_TROPIC:
     FEATURES_WANTED.append('tropic')
 
 if TREZOR_MODEL in ['T3W1'] and EXTAPP_SUPPORT:
-    FEATURES_WANTED += ["app_loading"]
+    FEATURES_WANTED += ["app_loading", "ipc"]
 
 if N4W1:
     assert PYOPT == "0", "N4W1 requires PYOPT=0"


### PR DESCRIPTION
This PR removes the unused IPC syscall for external apps from the regular build.

IPC syscalls are now enabled only in builds with external app support.

This PR does not affect any functionality.