### PR TITLE
build: prevent uv from using packages newer than 30 days

### DIFF
--- a/core/tools/pyproject.toml
+++ b/core/tools/pyproject.toml
@@ -18,11 +18,12 @@ combine_firmware = "trezor_core_tools.combine_firmware:main"
 bootloader_hashes = "trezor_core_tools.bootloader_hashes:main"
 
 [build-system]
-requires = ["hatchling"]
-build-backend = "hatchling.build"
+requires = ["flit_core >= 3.11,<5"]
+build-backend = "flit_core.buildapi"
 
 [tool.uv]
 package = true
+exclude-newer = "30 days"
 
 [tool.uv.sources]
 trezor = { path = "../../python", editable = true }

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -28,7 +28,7 @@ dependencies = [
     "isort>=5,<6",
     "flake8>=7",
     "black>=24.2",
-    "mako>=1.3.12,<2",
+    "mako>=1.3.10,<2",
     "munch>=4,<5",
     "autoflake",
     "flake8-requirements>=2.1.0",
@@ -71,6 +71,7 @@ dev = [
 
 [tool.uv]
 package = false
+exclude-newer = "30 days"
 
 [tool.uv.sources]
 trezor = { path = "./python", editable = true }

--- a/python/pyproject.toml
+++ b/python/pyproject.toml
@@ -65,6 +65,7 @@ build-backend = "flit_core.buildapi"
 
 [tool.uv]
 package = true
+exclude-newer = "30 days"
 
 [tool.flit.module]
 name = "trezorlib"

--- a/python/tools/toiftool/pyproject.toml
+++ b/python/tools/toiftool/pyproject.toml
@@ -1,6 +1,6 @@
 [build-system]
-requires = ["hatchling"]
-build-backend = "hatchling.build"
+requires = ["flit_core >= 3.11,<5"]
+build-backend = "flit_core.buildapi"
 
 [project]
 name = "toiftool"
@@ -17,3 +17,6 @@ dependencies = [
 
 [project.scripts]
 toiftool = "toiftool:cli"
+
+[tool.uv]
+exclude-newer = "30 days"

--- a/tools/trezor-pylint-plugin/pyproject.toml
+++ b/tools/trezor-pylint-plugin/pyproject.toml
@@ -1,6 +1,6 @@
 [build-system]
-requires = ["hatchling"]
-build-backend = "hatchling.build"
+requires = ["flit_core >= 3.11,<5"]
+build-backend = "flit_core.buildapi"
 
 [project]
 name = "trezor-pylint-plugin"
@@ -13,3 +13,6 @@ dependencies = [
     "pylint",
     "astroid",
 ]
+
+[tool.uv]
+exclude-newer = "30 days"

--- a/uv.lock
+++ b/uv.lock
@@ -7,6 +7,10 @@ resolution-markers = [
     "python_full_version < '3.11'",
 ]
 
+[options]
+exclude-newer = "2026-04-13T16:19:12.502244419Z"
+exclude-newer-span = "P30D"
+
 [[package]]
 name = "astroid"
 version = "2.15.8"
@@ -1084,14 +1088,14 @@ wheels = [
 
 [[package]]
 name = "mako"
-version = "1.3.12"
+version = "1.3.10"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "markupsafe" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/00/62/791b31e69ae182791ec67f04850f2f062716bbd205483d63a215f3e062d3/mako-1.3.12.tar.gz", hash = "sha256:9f778e93289bd410bb35daadeb4fc66d95a746f0b75777b942088b7fd7af550a", size = 400219, upload-time = "2026-04-28T19:01:08.512Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/9e/38/bd5b78a920a64d708fe6bc8e0a2c075e1389d53bef8413725c63ba041535/mako-1.3.10.tar.gz", hash = "sha256:99579a6f39583fa7e5630a28c3c1f440e4e97a414b80372649c0ce338da2ea28", size = 392474, upload-time = "2025-04-10T12:44:31.16Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/bc/b1/a0ec7a5a9db730a08daef1fdfb8090435b82465abbf758a596f0ea88727e/mako-1.3.12-py3-none-any.whl", hash = "sha256:8f61569480282dbf557145ce441e4ba888be453c30989f879f0d652e39f53ea9", size = 78521, upload-time = "2026-04-28T19:01:10.393Z" },
+    { url = "https://files.pythonhosted.org/packages/87/fb/99f81ac72ae23375f22b7afdb7642aba97c00a713c217124420147681a2f/mako-1.3.10-py3-none-any.whl", hash = "sha256:baef24a52fc4fc514a0887ac600f9f1cff3d82c61d4d700a1fa84d597b88db59", size = 78509, upload-time = "2025-04-10T12:50:53.297Z" },
 ]
 
 [[package]]
@@ -2345,7 +2349,7 @@ requires-dist = [
     { name = "inotify" },
     { name = "intelhex", specifier = "==2.3.0" },
     { name = "isort", specifier = ">=5,<6" },
-    { name = "mako", specifier = ">=1.3.12,<2" },
+    { name = "mako", specifier = ">=1.3.10,<2" },
     { name = "mnemonic", specifier = ">=0.21,<0.22" },
     { name = "munch", specifier = ">=4,<5" },
     { name = "nanopb", specifier = ">=0.4.3,<0.5" },


### PR DESCRIPTION
this limits exposure of the repo to supply chain compromise -- as long as you use uv.

i was not able to find a way to make a project-wide pip configuration

had to downgrade Mako that dependabot helpfully bumped for us five days ago for a path traversal vulnerability which is wholly irrelevant for us.
(but if a security fix lands that _is_ relevant, we'll have to whitelist that package -- `exclude-newer-package` feature is our friend here)

took the opportunity and switched buildsystem declaration from hatchling to flit everywhere

<!--
For external contributors:
- Please open an issue before submitting a PR so we can discuss whether we want to proceed with it.

For core developers:
1. Initial PR setup
- Assign yourself to the PR.
- Add it to the "Firmware" project
  - Set Priority (match issue priority if it exists)
  - Set Team
  - Set Sprint (target release)

2. Development status
- Draft PRs: Set status to "In Progress"
- Final PRs: Set status to "Needs Review"

3. Post-merge status
- Testable: Set status to "Needs QA" and add a `Notes for QA` section with clear instructions on how to test the functionality.
- Not Testable: Set status to "Done (no QA)"
-->
