### PR TITLE
fix(rust): handle other non-mainnet BTC networks

### DIFF
--- a/rust/trezor-client/src/client/bitcoin.rs
+++ b/rust/trezor-client/src/client/bitcoin.rs
@@ -18,7 +18,7 @@ impl Trezor {
         let mut req = protos::GetPublicKey::new();
         req.address_n = utils::convert_path(path);
         req.set_show_display(show_display);
-        req.set_coin_name(utils::coin_name(network)?);
+        req.set_coin_name(utils::coin_name(network));
         req.set_script_type(script_type);
         self.call(req, Box::new(|_, m| Ok(m.xpub().parse()?)))
     }
@@ -33,7 +33,7 @@ impl Trezor {
     ) -> Result<TrezorResponse<'_, Address, protos::Address>> {
         let mut req = protos::GetAddress::new();
         req.address_n = utils::convert_path(path);
-        req.set_coin_name(utils::coin_name(network)?);
+        req.set_coin_name(utils::coin_name(network));
         req.set_show_display(show_display);
         req.set_script_type(script_type);
         self.call(req, Box::new(|_, m| parse_address(m.address())))
@@ -48,7 +48,7 @@ impl Trezor {
         let mut req = protos::SignTx::new();
         req.set_inputs_count(tx.input.len() as u32);
         req.set_outputs_count(tx.output.len() as u32);
-        req.set_coin_name(utils::coin_name(network)?);
+        req.set_coin_name(utils::coin_name(network));
         req.set_version(tx.version.0 as u32);
         req.set_lock_time(tx.lock_time.to_consensus_u32());
         self.call(req, Box::new(|c, m| Ok(SignTxProgress::new(c, m))))
@@ -66,7 +66,7 @@ impl Trezor {
         // Normalize to Unicode NFC.
         let msg_bytes = nfc_normalize(&message).into_bytes();
         req.set_message(msg_bytes);
-        req.set_coin_name(utils::coin_name(network)?);
+        req.set_coin_name(utils::coin_name(network));
         req.set_script_type(script_type);
         self.call(
             req,

--- a/rust/trezor-client/src/utils.rs
+++ b/rust/trezor-client/src/utils.rs
@@ -57,12 +57,12 @@ pub fn parse_recoverable_signature(
 }
 
 /// Convert a bitcoin network constant to the Trezor-compatible coin_name string.
-pub fn coin_name(network: Network) -> Result<String> {
+pub fn coin_name(network: Network) -> String {
     match network {
-        Network::Bitcoin => Ok("Bitcoin".to_owned()),
-        Network::Testnet => Ok("Testnet".to_owned()),
-        _ => Err(Error::UnsupportedNetwork),
+        Network::Bitcoin => "Bitcoin",
+        _ => "Testnet",
     }
+    .to_owned()
 }
 
 /// Convert a BIP-32 derivation path into a `Vec<u32>`.


### PR DESCRIPTION
It would allow supporting testnet4/signet/regtest as well: https://docs.rs/bitcoin/latest/bitcoin/network/enum.Network.html

[no changelog]

<!--
For external contributors:
- Please open an issue before submitting a PR so we can discuss whether we want to proceed with it.

For core developers:
1. Initial PR setup
- Assign yourself to the PR.
- Add it to the "Firmware" project
  - Set Priority (match issue priority if it exists)
  - Set Team
  - Set Sprint (target release)

2. Development status
- Draft PRs: Set status to "In Progress"
- Final PRs: Set status to "Needs Review"

3. Post-merge status
- Testable: Set status to "Needs QA" and add a `Notes for QA` section with clear instructions on how to test the functionality.
- Not Testable: Set status to "Done (no QA)"
-->
