### PR TITLE
Run tropic model_server in uv environment

### DIFF
--- a/.github/workflows/core.yml
+++ b/.github/workflows/core.yml
@@ -153,7 +153,9 @@ jobs:
       - run: nix-shell --run "uv run make -C core build_bootloader_emu"
         if: matrix.coins == 'universal' && matrix.asan == 'noasan'
       - run: nix-shell --run "uv run make -C core build_unix_frozen"
-      - run: nix-shell --arg fullDeps true --run "cd vendor/ts-tvl && poetry env use 3.12 && poetry install && poetry run model_server tcp -c ../../tests/tropic_model/config.yml > ../../tests/trezor-tropic-model.log 2>&1 &"
+      - name: Start Tropic model
+        if: ${{ matrix.model == 'T3W1' }}
+        run: nix-shell --arg fullDeps true --run "uv run model_server tcp -c tests/tropic_model/config.yml > tests/trezor-tropic-model.log 2>&1 &"
       - run: nix-shell --run "uv run make -C core test_emu_sanity"
       - run: cp core/build/unix/trezor-emu-core core/build/unix/trezor-emu-core-${{ matrix.model }}-${{ matrix.coins }}${{ matrix.n4w1 && '-n4w1' || '' }}
       - uses: actions/upload-artifact@bbbca2ddaa5d8feaa63e36b76fdaad77386f024f  # actions/upload-artifact@v7.0.0
@@ -229,7 +231,9 @@ jobs:
           submodules: recursive
       - uses: ./.github/actions/environment
       - run: nix-shell --run "uv run make -C core build_unix"
-      - run: nix-shell --arg fullDeps true --run "cd vendor/ts-tvl && poetry env use 3.12 && poetry install && poetry run model_server tcp -c ../../tests/tropic_model/config.yml > ../../tests/trezor-tropic-model.log 2>&1 &"
+      - name: Start Tropic model
+        if: ${{ matrix.model == 'T3W1' }}
+        run: nix-shell --arg fullDeps true --run "uv run model_server tcp -c tests/tropic_model/config.yml > tests/trezor-tropic-model.log 2>&1 &"
       - run: nix-shell --run "uv run make -C core test"
       - run: nix-shell --run "uv run make -C core test_emu_sanity"  # sanity check non-frozen emulator
 
@@ -330,7 +334,7 @@ jobs:
       - uses: ./.github/actions/environment
       - name: Start Tropic model
         if: ${{ env.TREZOR_MODEL == 'T3W1' && env.ACTIONS_DO_UI_TEST != 'true' }}  # ACTIONS_DO_UI_TEST refers to the test_emu_ui_multicore below which uses --control-emulators and starts tvl internally
-        run: nix-shell --arg fullDeps true --run "cd vendor/ts-tvl && poetry env use 3.12 && poetry install && poetry run model_server tcp -c ../../tests/tropic_model/config.yml > ../../tests/trezor-tropic-model.log 2>&1 &"
+        run: nix-shell --arg fullDeps true --run "uv run model_server tcp -c tests/tropic_model/config.yml > tests/trezor-tropic-model.log 2>&1 &"
       - name: Run device tests
         if: ${{ !matrix.n4w1 }}
         run: nix-shell --run "uv run make -C core ${{ env.ACTIONS_DO_UI_TEST == 'true' && 'test_emu_ui_multicore' || 'test_emu' }}"
@@ -485,7 +489,7 @@ jobs:
       - uses: ./.github/actions/environment
       - name: Start Tropic model
         if: ${{ matrix.model == 'T3W1' }}
-        run: nix-shell --arg fullDeps true --run "cd vendor/ts-tvl && poetry env use 3.12 && poetry install && poetry run model_server tcp -c ../../tests/tropic_model/config.yml > ../../tests/trezor-tropic-model.log 2>&1 &"
+        run: nix-shell --arg fullDeps true --run "uv run model_server tcp -c tests/tropic_model/config.yml > tests/trezor-tropic-model.log 2>&1 &"
       - run: nix-shell --run "uv run make -C core test_emu_persistence_ui"
         if: ${{ matrix.asan == 'noasan' }}
       - run: nix-shell --run "uv run make -C core test_emu_persistence"
@@ -650,7 +654,7 @@ jobs:
       - uses: ./.github/actions/environment
       - name: Start Tropic model
         if: ${{ matrix.model == 'T3W1' }}
-        run: nix-shell --arg fullDeps true --run "cd vendor/ts-tvl && poetry env use 3.12 && poetry install && poetry run model_server tcp -c ../../tests/tropic_model/config.yml > ../../tests/trezor-tropic-model.log 2>&1 &"
+        run: nix-shell --arg fullDeps true --run "uv run model_server tcp -c tests/tropic_model/config.yml > tests/trezor-tropic-model.log 2>&1 &"
       - run: nix-shell --run "uv run make -C tests/fido_tests/u2f-tests-hid"
       - run: nix-shell --run "uv run make -C core test_emu_u2f"
       - uses: actions/upload-artifact@bbbca2ddaa5d8feaa63e36b76fdaad77386f024f  # actions/upload-artifact@v7.0.0
@@ -688,7 +692,7 @@ jobs:
       - uses: ./.github/actions/environment
       - name: Start Tropic model
         if: ${{ matrix.model == 'T3W1' }}
-        run: nix-shell --arg fullDeps true --run "cd vendor/ts-tvl && poetry env use 3.12 && poetry install && poetry run model_server tcp -c ../../tests/tropic_model/config.yml > ../../tests/trezor-tropic-model.log 2>&1 &"
+        run: nix-shell --arg fullDeps true --run "uv run model_server tcp -c tests/tropic_model/config.yml > tests/trezor-tropic-model.log 2>&1 &"
       - run: nix-shell --run "uv run make -C core test_emu_fido2"
       - uses: actions/upload-artifact@bbbca2ddaa5d8feaa63e36b76fdaad77386f024f  # actions/upload-artifact@v7.0.0
         with:


### PR DESCRIPTION
- It is not necessary to rely on poetry from ts-tvl, tropic model_server can be run directly in the uv environment from trezor-firmware.