### PR TITLE
chore(deps): bump urllib3 from 2.6.3 to 2.7.0

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -72,6 +72,7 @@ dev = [
 [tool.uv]
 package = false
 exclude-newer = "30 days"
+exclude-newer-package = { urllib3 = "2026-05-07T16:13:17.152Z" }
 
 [tool.uv.sources]
 trezor = { path = "./python", editable = true }

--- a/uv.lock
+++ b/uv.lock
@@ -11,6 +11,9 @@ resolution-markers = [
 exclude-newer = "2026-04-13T16:19:12.502244419Z"
 exclude-newer-span = "P30D"
 
+[options.exclude-newer-package]
+urllib3 = "2026-05-07T16:13:17.152Z"
+
 [[package]]
 name = "astroid"
 version = "2.15.8"
@@ -2477,11 +2480,11 @@ sdist = { url = "https://files.pythonhosted.org/packages/3e/ff/87c166a4e1eb9a7fb
 
 [[package]]
 name = "urllib3"
-version = "2.6.3"
+version = "2.7.0"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/c7/24/5f1b3bdffd70275f6661c76461e25f024d5a38a46f04aaca912426a2b1d3/urllib3-2.6.3.tar.gz", hash = "sha256:1b62b6884944a57dbe321509ab94fd4d3b307075e0c2eae991ac71ee15ad38ed", size = 435556, upload-time = "2026-01-07T16:24:43.925Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/53/0c/06f8b233b8fd13b9e5ee11424ef85419ba0d8ba0b3138bf360be2ff56953/urllib3-2.7.0.tar.gz", hash = "sha256:231e0ec3b63ceb14667c67be60f2f2c40a518cb38b03af60abc813da26505f4c", size = 433602, upload-time = "2026-05-07T16:13:18.596Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/39/08/aaaad47bc4e9dc8c725e68f9d04865dbcb2052843ff09c97b08904852d84/urllib3-2.6.3-py3-none-any.whl", hash = "sha256:bf272323e553dfb2e87d9bfd225ca7b0f467b919d7bbd355436d3fd37cb0acd4", size = 131584, upload-time = "2026-01-07T16:24:42.685Z" },
+    { url = "https://files.pythonhosted.org/packages/7f/3e/5db95bcf282c52709639744ca2a8b149baccf648e39c8cc87553df9eae0c/urllib3-2.7.0-py3-none-any.whl", hash = "sha256:9fb4c81ebbb1ce9531cce37674bbc6f1360472bc18ca9a553ede278ef7276897", size = 131087, upload-time = "2026-05-07T16:13:17.151Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
This PR should resolve the following dependabot reports:
- https://github.com/trezor/trezor-firmware/security/dependabot/129
- https://github.com/trezor/trezor-firmware/security/dependabot/126

This urllib3 release does not satisfy 30 days moratorium. However:
- As of today, it has been out for 7 days.
- I've checked the code-changes between 2.6.3->2.7.0 and I did not notice anything suspicious.

I am not sure, whether we are affected by the issues from dependabot - urllib3 is also used by `requests` library. I assume updating the uv.lock to be safer than not updating.

Regarding the usage of `urllib3` in automatic-battery-tester (`requirements.txt`)
- There already exists a PR from dependabot #6910 
- Also, imo it can wait for the moratorium to pass, as this is an internal tool only.