### PR TITLE
chore(python): allow ignoring xpub magic in trezorctl

### DIFF
--- a/python/src/trezorlib/cli/btc.py
+++ b/python/src/trezorlib/cli/btc.py
@@ -254,6 +254,7 @@ def get_address(
 @click.option("-e", "--curve")
 @click.option("-t", "--script-type", type=ChoiceType(INPUT_SCRIPTS))
 @click.option("-d", "--show-display", is_flag=True)
+@click.option("-i", "--ignore-xpub-magic", is_flag=True)
 @with_session
 def get_public_node(
     session: "Session",
@@ -262,6 +263,7 @@ def get_public_node(
     curve: Optional[str],
     script_type: Optional[messages.InputScriptType],
     show_display: bool,
+    ignore_xpub_magic: bool,
 ) -> dict:
     """Get public node of given path."""
     address_n = tools.parse_path(address)
@@ -275,6 +277,7 @@ def get_public_node(
         coin_name=coin,
         script_type=script_type,
         unlock_path=get_unlock_path(address_n),
+        ignore_xpub_magic=ignore_xpub_magic,
     )
     return {
         "node": {


### PR DESCRIPTION
[Output descriptors](https://github.com/bitcoin/bips/blob/master/bip-0380.mediawiki) don't use [ypub/zpubs](https://github.com/satoshilabs/slips/blob/master/slip-0132.md).

Can be tested using:
```
$ trezorctl btc get-public-node -n 'm/84h/0h/0h'
node.depth: 3
node.fingerprint: d4c3eca0
node.child_num: 2147483648
node.chain_code: 0a4cedfefa23737d00b4a724e1d8b47a0602472cbe6fb8b7efa72dcb021584f8
node.public_key: 03e36a4f3fee21bfe83447b209d8de6da1ce1ae38f76bc2c00652dc5e0a8c5c0b5
xpub: zpub6rszzdAK6RuafeRwyN8z1cgWcXCuKbLmjjfnrW4fWKtcoXQ8787214pNJjnBG5UATyghuNzjn6Lfp5k5xymrLFJnCy46bMYJPyZsbpFGagT

$ trezorctl btc get-public-node -n 'm/84h/0h/0h' --ignore-xpub-magic
node.depth: 3
node.fingerprint: d4c3eca0
node.child_num: 2147483648
node.chain_code: 0a4cedfefa23737d00b4a724e1d8b47a0602472cbe6fb8b7efa72dcb021584f8
node.public_key: 03e36a4f3fee21bfe83447b209d8de6da1ce1ae38f76bc2c00652dc5e0a8c5c0b5
xpub: xpub6DDUPHpUo4pcy43iJeZjbSVWGav1SMMmuWdMHiGtkK8rhKmfbomtkwW6GKs1GGAKehT6QRocrmda3WWxXawpjmwaUHfFRXuKrXSapdckEYF
```