### PR TITLE
fix(core): return NotInitialized on legacy seed path

### DIFF
--- a/core/.changelog.d/6941.fixed
+++ b/core/.changelog.d/6941.fixed
@@ -1,0 +1,1 @@
+Return NotInitialized when deriving the Bitcoin-only seed on an uninitialized device.

--- a/core/src/apps/base.py
+++ b/core/src/apps/base.py
@@ -11,6 +11,7 @@ from trezor.wire.message_handler import filters
 
 from . import workflow_handlers
 from .common import lock_manager
+from .common.device import require_initialized
 
 if TYPE_CHECKING:
     from typing import NoReturn
@@ -418,8 +419,7 @@ async def handle_LockDevice(msg: LockDevice) -> Success:
 
 
 async def handle_SetBusy(msg: SetBusy) -> Success:
-    if not storage_device.is_initialized():
-        raise wire.NotInitialized("Device is not initialized")
+    require_initialized()
 
     if msg.expiry_ms:
         import utime

--- a/core/src/apps/cardano/seed.py
+++ b/core/src/apps/cardano/seed.py
@@ -10,6 +10,7 @@ from trezor import utils, wire
 from trezor.crypto import cardano
 
 from apps.common import mnemonic
+from apps.common.device import require_initialized
 from apps.common.seed import get_seed
 
 from .helpers.paths import BYRON_ROOT, MINTING_ROOT, MULTISIG_ROOT, SHELLEY_ROOT
@@ -151,8 +152,7 @@ async def _get_keychain_bip39(derivation_type: CardanoDerivationType) -> Keychai
     from trezor.enums import CardanoDerivationType
     from trezor.wire import context
 
-    if not device.is_initialized():
-        raise wire.NotInitialized("Device is not initialized")
+    require_initialized()
 
     if derivation_type == CardanoDerivationType.LEDGER:
         seed = await get_seed()

--- a/core/src/apps/common/device.py
+++ b/core/src/apps/common/device.py
@@ -1,0 +1,6 @@
+def require_initialized() -> None:
+    import storage.device as storage_device
+    from trezor import wire
+
+    if not storage_device.is_initialized():
+        raise wire.NotInitialized("Device is not initialized")

--- a/core/src/apps/common/device.py
+++ b/core/src/apps/common/device.py
@@ -1,6 +1,7 @@
-def require_initialized() -> None:
-    import storage.device as storage_device
-    from trezor import wire
+import storage.device as storage_device
+from trezor import wire
 
+
+def require_initialized() -> None:
     if not storage_device.is_initialized():
         raise wire.NotInitialized("Device is not initialized")

--- a/core/src/apps/common/seed.py
+++ b/core/src/apps/common/seed.py
@@ -11,6 +11,7 @@ from trezor.wire.errors import DataError
 from apps.common import cache
 
 from . import mnemonic
+from .device import require_initialized
 from .passphrase import get_passphrase
 
 if TYPE_CHECKING:
@@ -82,10 +83,7 @@ if utils.USE_THP:
             if ctx.cache.is_set(APP_COMMON_SEED):
                 raise Exception("Seed is already set!")
 
-            from trezor import wire
-
-            if not storage_device.is_initialized():
-                raise wire.NotInitialized("Device is not initialized")
+            require_initialized()
 
             passphrase = await get_passphrase(msg)
             common_seed = mnemonic.get_seed(passphrase)
@@ -101,10 +99,7 @@ if utils.USE_THP:
             if msg.passphrase is not None and msg.on_device:
                 raise DataError("Passphrase provided when it shouldn't be!")
 
-            from trezor import wire
-
-            if not storage_device.is_initialized():
-                raise wire.NotInitialized("Device is not initialized")
+            require_initialized()
 
             if ctx.cache.is_set(APP_CARDANO_ICARUS_SECRET):
                 raise Exception("Cardano icarus secret is already set!")
@@ -126,10 +121,7 @@ else:
 
         @cache.stored_async(APP_COMMON_SEED)
         async def get_seed() -> bytes:
-            from trezor import wire
-
-            if not storage_device.is_initialized():
-                raise wire.NotInitialized("Device is not initialized")
+            require_initialized()
 
             passphrase = await get_passphrase_legacy()
             return mnemonic.get_seed(passphrase=passphrase)
@@ -147,10 +139,7 @@ else:
             return common_seed
 
         async def derive_and_store_roots_legacy() -> None:
-            from trezor import wire
-
-            if not storage_device.is_initialized():
-                raise wire.NotInitialized("Device is not initialized")
+            require_initialized()
 
             ctx = get_context()
             need_seed = not ctx.cache.is_set(APP_COMMON_SEED)

--- a/core/src/apps/common/seed.py
+++ b/core/src/apps/common/seed.py
@@ -126,6 +126,11 @@ else:
 
         @cache.stored_async(APP_COMMON_SEED)
         async def get_seed() -> bytes:
+            from trezor import wire
+
+            if not storage_device.is_initialized():
+                raise wire.NotInitialized("Device is not initialized")
+
             passphrase = await get_passphrase_legacy()
             return mnemonic.get_seed(passphrase=passphrase)
 

--- a/core/src/apps/common/seed.py
+++ b/core/src/apps/common/seed.py
@@ -11,7 +11,6 @@ from trezor.wire.errors import DataError
 from apps.common import cache
 
 from . import mnemonic
-from .device import require_initialized
 from .passphrase import get_passphrase
 
 if TYPE_CHECKING:
@@ -83,6 +82,8 @@ if utils.USE_THP:
             if ctx.cache.is_set(APP_COMMON_SEED):
                 raise Exception("Seed is already set!")
 
+            from .device import require_initialized
+
             require_initialized()
 
             passphrase = await get_passphrase(msg)
@@ -98,6 +99,8 @@ if utils.USE_THP:
 
             if msg.passphrase is not None and msg.on_device:
                 raise DataError("Passphrase provided when it shouldn't be!")
+
+            from .device import require_initialized
 
             require_initialized()
 
@@ -121,6 +124,8 @@ else:
 
         @cache.stored_async(APP_COMMON_SEED)
         async def get_seed() -> bytes:
+            from .device import require_initialized
+
             require_initialized()
 
             passphrase = await get_passphrase_legacy()
@@ -139,6 +144,8 @@ else:
             return common_seed
 
         async def derive_and_store_roots_legacy() -> None:
+            from .device import require_initialized
+
             require_initialized()
 
             ctx = get_context()

--- a/core/src/apps/evolu/get_node.py
+++ b/core/src/apps/evolu/get_node.py
@@ -23,14 +23,13 @@ async def get_node(msg: EvoluGetNode) -> EvoluNode:
         NotInitialized: If the device is not initialized.
         ValueError: If the proof of delegated identity is missing or invalid.
     """
-    from storage.device import is_initialized
     from trezor.messages import EvoluNode
-    from trezor.wire import NotInitialized
+
+    from apps.common.device import require_initialized
 
     from .common import check_delegated_identity_proof
 
-    if not is_initialized():
-        raise NotInitialized("Device is not initialized")
+    require_initialized()
 
     if not check_delegated_identity_proof(
         bytes(msg.proof_of_delegated_identity),

--- a/core/src/apps/management/apply_flags.py
+++ b/core/src/apps/management/apply_flags.py
@@ -5,12 +5,11 @@ if TYPE_CHECKING:
 
 
 async def apply_flags(msg: ApplyFlags) -> Success:
-    import storage.device
     from storage.device import set_flags
     from trezor.messages import Success
-    from trezor.wire import NotInitialized
 
-    if not storage.device.is_initialized():
-        raise NotInitialized("Device is not initialized")
+    from apps.common.device import require_initialized
+
+    require_initialized()
     set_flags(msg.flags)
     return Success(message="Flags applied")

--- a/core/src/apps/management/apply_settings.py
+++ b/core/src/apps/management/apply_settings.py
@@ -50,13 +50,13 @@ def _validate_homescreen(homescreen: AnyBytes) -> None:
 
 async def apply_settings(msg: ApplySettings) -> Success:
     from trezor.messages import Success
-    from trezor.wire import NotInitialized, ProcessError
+    from trezor.wire import ProcessError
 
     from apps.common import safety_checks
+    from apps.common.device import require_initialized
     from apps.common.lock_manager import reload_settings_from_storage
 
-    if not storage_device.is_initialized():
-        raise NotInitialized("Device is not initialized")
+    require_initialized()
 
     homescreen = msg.homescreen  # local_cache_attribute
     homescreen_length = msg.homescreen_length  # local_cache_attribute

--- a/core/src/apps/management/backup_device.py
+++ b/core/src/apps/management/backup_device.py
@@ -3,6 +3,8 @@ from typing import TYPE_CHECKING
 import storage.device as storage_device
 from trezor.enums import BackupType
 
+from apps.common.device import require_initialized
+
 if TYPE_CHECKING:
     from typing import Sequence
 
@@ -98,8 +100,7 @@ async def backup_device(msg: BackupDevice) -> Success:
     repeated_backup_enabled = backup.repeated_backup_enabled()
     is_repeated_backup = repeated_backup_enabled and not storage_device.needs_backup()
 
-    if not storage_device.is_initialized():
-        raise wire.NotInitialized("Device is not initialized")
+    require_initialized()
     if not storage_device.needs_backup() and not repeated_backup_enabled:
         raise wire.ProcessError("Seed already backed up")
 

--- a/core/src/apps/management/change_pin.py
+++ b/core/src/apps/management/change_pin.py
@@ -9,10 +9,10 @@ if TYPE_CHECKING:
 
 
 async def change_pin(msg: ChangePin) -> Success:
-    from storage.device import is_initialized
     from trezor.messages import Success
     from trezor.ui.layouts import pin_wipe_code_exists_popup, success_pin_change
 
+    from apps.common.device import require_initialized
     from apps.common.request_pin import (
         error_pin_invalid,
         error_pin_matches_wipe_code,
@@ -20,8 +20,7 @@ async def change_pin(msg: ChangePin) -> Success:
         request_pin_confirm,
     )
 
-    if not is_initialized():
-        raise wire.NotInitialized("Device is not initialized")
+    require_initialized()
 
     # confirm that user wants to change the pin
     await _require_confirm_change_pin(msg)

--- a/core/src/apps/management/change_wipe_code.py
+++ b/core/src/apps/management/change_wipe_code.py
@@ -9,16 +9,14 @@ if TYPE_CHECKING:
 
 
 async def change_wipe_code(msg: ChangeWipeCode) -> Success:
-    from storage.device import is_initialized
     from trezor import config
     from trezor.messages import Success
     from trezor.ui.layouts import show_success, wipe_code_pin_not_set_popup
-    from trezor.wire import NotInitialized
 
+    from apps.common.device import require_initialized
     from apps.common.request_pin import error_pin_invalid, request_pin_and_sd_salt
 
-    if not is_initialized():
-        raise NotInitialized("Device is not initialized")
+    require_initialized()
 
     # Confirm that user wants to set or remove the wipe code.
     has_wipe_code = config.has_wipe_code()

--- a/core/src/apps/management/get_next_u2f_counter.py
+++ b/core/src/apps/management/get_next_u2f_counter.py
@@ -10,10 +10,10 @@ async def get_next_u2f_counter(msg: GetNextU2FCounter) -> NextU2FCounter:
     from trezor.enums import ButtonRequestType
     from trezor.messages import NextU2FCounter
     from trezor.ui.layouts import confirm_action
-    from trezor.wire import NotInitialized
 
-    if not storage_device.is_initialized():
-        raise NotInitialized("Device is not initialized")
+    from apps.common.device import require_initialized
+
+    require_initialized()
 
     await confirm_action(
         "get_u2f_counter",

--- a/core/src/apps/management/recovery_device/__init__.py
+++ b/core/src/apps/management/recovery_device/__init__.py
@@ -34,6 +34,7 @@ async def recovery_device(msg: RecoveryDevice) -> Success:
     from trezor.wire.context import try_get_ctx_ids
 
     from apps.common import mnemonic
+    from apps.common.device import require_initialized
     from apps.common.request_pin import (
         error_pin_invalid,
         request_pin_and_sd_salt,
@@ -50,9 +51,8 @@ async def recovery_device(msg: RecoveryDevice) -> Success:
         if storage_device.is_initialized():
             raise wire.UnexpectedMessage("Already initialized")
     elif recovery_type in (RecoveryType.DryRun, RecoveryType.UnlockRepeatedBackup):
-        if not storage_device.is_initialized():
-            raise wire.NotInitialized("Device is not initialized")
-        elif recovery_type is RecoveryType.DryRun:
+        require_initialized()
+        if recovery_type is RecoveryType.DryRun:
             if storage_device.no_backup():
                 raise wire.ProcessError("Dry-run not available for seedless devices")
             elif storage_device.needs_backup() or storage_device.unfinished_backup():

--- a/core/src/apps/management/sd_protect.py
+++ b/core/src/apps/management/sd_protect.py
@@ -8,6 +8,7 @@ from trezor.messages import Success
 from trezor.ui.layouts import show_success
 from trezor.wire import ProcessError
 
+from apps.common.device import require_initialized
 from apps.common.request_pin import error_pin_invalid, request_pin_and_sd_salt
 from apps.common.sdcard import ensure_sdcard
 
@@ -38,10 +39,7 @@ async def _set_salt(salt: bytes, salt_tag: bytes, stage: bool = False) -> None:
 
 
 async def sd_protect(msg: SdProtect) -> Success:
-    from trezor.wire import NotInitialized
-
-    if not storage_device.is_initialized():
-        raise NotInitialized("Device is not initialized")
+    require_initialized()
 
     if msg.operation == SdProtectOperationType.ENABLE:
         return await _sd_protect_enable(msg)

--- a/core/src/apps/management/set_brightness.py
+++ b/core/src/apps/management/set_brightness.py
@@ -5,13 +5,12 @@ if TYPE_CHECKING:
 
 
 async def set_brightness(msg: SetBrightness) -> Success:
-    import storage.device as storage_device
     from trezor.messages import Success
     from trezor.ui.layouts import set_brightness
-    from trezor.wire import NotInitialized
 
-    if not storage_device.is_initialized():
-        raise NotInitialized("Device is not initialized")
+    from apps.common.device import require_initialized
+
+    require_initialized()
 
     await set_brightness(msg.value)
     return Success(message="Settings applied")

--- a/core/src/apps/management/set_u2f_counter.py
+++ b/core/src/apps/management/set_u2f_counter.py
@@ -11,8 +11,9 @@ async def set_u2f_counter(msg: SetU2FCounter) -> Success:
     from trezor.messages import Success
     from trezor.ui.layouts import confirm_action
 
-    if not storage_device.is_initialized():
-        raise wire.NotInitialized("Device is not initialized")
+    from apps.common.device import require_initialized
+
+    require_initialized()
     if msg.u2f_counter is None:
         raise wire.ProcessError("No value provided")
 

--- a/core/src/apps/webauthn/add_resident_credential.py
+++ b/core/src/apps/webauthn/add_resident_credential.py
@@ -5,16 +5,16 @@ if TYPE_CHECKING:
 
 
 async def add_resident_credential(msg: WebAuthnAddResidentCredential) -> Success:
-    import storage.device as storage_device
     from trezor import TR, wire
     from trezor.messages import Success
     from trezor.ui.layouts.fido import confirm_fido, credential_warning
 
+    from apps.common.device import require_initialized
+
     from .credential import Fido2Credential
     from .resident_credentials import store_resident_credential
 
-    if not storage_device.is_initialized():
-        raise wire.NotInitialized("Device is not initialized")
+    require_initialized()
     if not msg.credential_id:
         raise wire.ProcessError("Missing credential ID parameter.")
 

--- a/core/src/apps/webauthn/remove_resident_credential.py
+++ b/core/src/apps/webauthn/remove_resident_credential.py
@@ -5,16 +5,16 @@ if TYPE_CHECKING:
 
 
 async def remove_resident_credential(msg: WebAuthnRemoveResidentCredential) -> Success:
-    import storage.device
     import storage.resident_credentials
     from trezor import TR, wire
     from trezor.messages import Success
     from trezor.ui.layouts.fido import confirm_fido
 
+    from apps.common.device import require_initialized
+
     from .resident_credentials import get_resident_credential
 
-    if not storage.device.is_initialized():
-        raise wire.NotInitialized("Device is not initialized")
+    require_initialized()
     if msg.index is None:
         raise wire.ProcessError("Missing credential index parameter.")
 

--- a/core/tests/test_apps.common.seed.py
+++ b/core/tests/test_apps.common.seed.py
@@ -1,12 +1,17 @@
 # flake8: noqa: F403,F405
 from common import *  # isort:skip
 
+from mock_storage import mock_storage
+from storage import cache
 from trezor.crypto import bip39
-from trezor.wire import DataError
+from trezor.wire import DataError, NotInitialized
 
 from apps.common.keychain import ForbiddenKeyPath, Keychain
 from apps.common.paths import address_n_slip21_to_str
-from apps.common.seed import Slip21Node
+from apps.common.seed import Slip21Node, get_seed
+
+if not utils.USE_THP:
+    from storage import cache_codec
 
 
 class TestSeed(unittest.TestCase):
@@ -92,6 +97,23 @@ class TestSeed(unittest.TestCase):
             address_n_slip21_to_str([label, label, label]),
             "m/\\xc5\\x99e\\xc5\\x99icha/\\xc5\\x99e\\xc5\\x99icha/\\xc5\\x99e\\xc5\\x99icha",
         )
+
+
+@unittest.skipUnless(
+    utils.BITCOIN_ONLY and not utils.USE_THP,
+    "bitcoin-only legacy seed path",
+)
+class TestLegacyBitcoinOnlySeed(TestCaseWithContext):
+    def setUp(self):
+        cache_codec.start_session()
+
+    def tearDown(self):
+        cache.clear_all()
+
+    @mock_storage
+    def test_get_seed_requires_initialized_device(self):
+        with self.assertRaises(NotInitialized):
+            await_result(get_seed())
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
Fixes #6941

While learning the Core codebase, I looked into #6941 and found that the legacy Bitcoin-only seed path bypassed the initialization guard used by the other seed paths.

## Summary
- return `NotInitialized` before legacy Bitcoin-only seed derivation on uninitialized devices
- factor the repeated initialized-device guard into `apps.common.device.require_initialized()` and reuse it across existing call sites, following review feedback
- add regression coverage for the `BITCOIN_ONLY=1`, `THP=0` path

## Testing
- `make build_unix BITCOIN_ONLY=1 THP=0`
- `make test BITCOIN_ONLY=1 THP=0 TESTOPTS=test_apps.common.seed.py`