### PR TITLE
ci: remove retries from HW tests

### DIFF
--- a/.github/workflows/core-hw.yml
+++ b/.github/workflows/core-hw.yml
@@ -46,8 +46,6 @@ jobs:
         -k 'not test_authenticate_device'
         --durations=50
         --session-timeout 19800
-        --retries=5
-        --retry-delay=1
       TT_UHUB_PORT: 1
       QUIET_MODE: 1
     timeout-minutes: 360  # 6h CI job timeout

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -57,7 +57,6 @@ dependencies = [
     "trezor-core-tools",
     "flake8-annotations>=3.1.1,<4",
     "pyelftools>=0.32,<0.33",
-    "pytest-retry>=1.7.0,<2",
     "slh-dsa>=0.1.3,<0.2",
     "bleak>=1.1.0",
 ]

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -32,7 +32,7 @@ from trezorlib import client as client_module
 from trezorlib import debuglink, log, messages, models
 from trezorlib.debuglink import TrezorTestContext
 from trezorlib.device import apply_settings
-from trezorlib.transport import Timeout, enumerate_devices, get_transport
+from trezorlib.transport import enumerate_devices, get_transport
 from trezorlib.transport.ble import BleTransport
 
 # register rewrites before importing from local package
@@ -593,11 +593,6 @@ def pytest_runtest_setup(item: pytest.Item) -> None:
     models_filter = ModelsFilter(item)
     if not models_filter:
         raise RuntimeError("Don't skip tests for all trezor models!")
-
-
-def pytest_set_filtered_exceptions():
-    UnexpectedMagicError = "TOOD"
-    return (Timeout, UnexpectedMagicError)
 
 
 @pytest.hookimpl(tryfirst=True, hookwrapper=True)

--- a/uv.lock
+++ b/uv.lock
@@ -8,7 +8,7 @@ resolution-markers = [
 ]
 
 [options]
-exclude-newer = "2026-04-14T17:11:22.998829178Z"
+exclude-newer = "2026-04-22T08:40:57.146969307Z"
 exclude-newer-span = "P30D"
 
 [options.exclude-newer-package]
@@ -1701,18 +1701,6 @@ wheels = [
 ]
 
 [[package]]
-name = "pytest-retry"
-version = "1.7.0"
-source = { registry = "https://pypi.org/simple" }
-dependencies = [
-    { name = "pytest" },
-]
-sdist = { url = "https://files.pythonhosted.org/packages/c5/5b/607b017994cca28de3a1ad22a3eee8418e5d428dcd8ec25b26b18e995a73/pytest_retry-1.7.0.tar.gz", hash = "sha256:f8d52339f01e949df47c11ba9ee8d5b362f5824dff580d3870ec9ae0057df80f", size = 19977, upload-time = "2025-01-19T01:56:13.115Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/7c/ff/3266c8a73b9b93c4b14160a7e2b31d1e1088e28ed29f4c2d93ae34093bfd/pytest_retry-1.7.0-py3-none-any.whl", hash = "sha256:a2dac85b79a4e2375943f1429479c65beb6c69553e7dae6b8332be47a60954f4", size = 13775, upload-time = "2025-01-19T01:56:11.199Z" },
-]
-
-[[package]]
 name = "pytest-timeout"
 version = "2.4.0"
 source = { registry = "https://pypi.org/simple" }
@@ -2231,7 +2219,6 @@ dependencies = [
     { name = "pytest" },
     { name = "pytest-ordering" },
     { name = "pytest-random-order" },
-    { name = "pytest-retry" },
     { name = "pytest-timeout" },
     { name = "pytest-xdist" },
     { name = "python-bitcoinlib" },
@@ -2297,7 +2284,6 @@ requires-dist = [
     { name = "pytest", specifier = ">=9.0.3,<10" },
     { name = "pytest-ordering" },
     { name = "pytest-random-order" },
-    { name = "pytest-retry", specifier = ">=1.7.0,<2" },
     { name = "pytest-timeout" },
     { name = "pytest-xdist" },
     { name = "python-bitcoinlib", specifier = ">=0.11.0,<0.12" },


### PR DESCRIPTION
Retries were added as a workaround for sporadic USB packet loss, which was fixed in https://github.com/trezor/trezor-firmware/pull/6309.
