### PR TITLE
chore(ci): differentiate `UI_FAILED` and `UI_MISSING`

### DIFF
--- a/tests/ui_tests/__init__.py
+++ b/tests/ui_tests/__init__.py
@@ -152,7 +152,10 @@ def terminal_summary(
         println("-------- UI tests summary: --------")
         for result in TestResult.recent_results():
             if result.passed and not result.ui_passed:
-                println(f"UI_FAILED: {result.test.id} ({result.actual_hash})")
+                if result.expected_hash is None:
+                    println(f"UI_MISSING: {result.test.id} ({result.actual_hash})")
+                else:
+                    println(f"UI_FAILED: {result.test.id} ({result.actual_hash})")
         println("Run ./tests/show_results.py to open test summary")
         println("")
 


### PR DESCRIPTION
When an expected hash is not found (most likely case: a new test was added), the result now shows `UI_MISSING` instead of `UI_FAILED`. 

This change was tested on a PR with new tests...

Before: (https://github.com/trezor/trezor-firmware/actions/runs/26295285205/job/77406944942)
<img width="1607" height="737" alt="Screenshot from 2026-05-22 17-42-40" src="https://github.com/user-attachments/assets/67e34764-f4f8-4441-a46e-495d1424637c" />

After: (https://github.com/trezor/trezor-firmware/actions/runs/26296849015/job/77412386945)
<img width="1607" height="737" alt="Screenshot from 2026-05-22 17-51-59" src="https://github.com/user-attachments/assets/34e3eac7-c7e0-47df-ad09-319bd4b0fafa" />

