### PR TITLE
refactor(core): use `async` function instead of a generator

### DIFF
--- a/core/src/trezor/wire/thp/channel.py
+++ b/core/src/trezor/wire/thp/channel.py
@@ -41,7 +41,7 @@ if __debug__:
 
 if TYPE_CHECKING:
     from buffer_types import AnyBuffer, AnyBytes
-    from typing import Any, Awaitable, Callable, Generator
+    from typing import Any, Awaitable, Callable
 
     from trezor.messages import ThpPairingCredential
     from trezor.wire import WireInterface
@@ -458,7 +458,7 @@ class Channel:
         # allows preempting this channel, if another channel becomes active
         self.last_write_ms = utime.ticks_ms()
 
-        def _write_loop() -> Generator[Any, Any, None]:
+        async def _write_loop() -> None:
             """
             Retransmit the payload (with increasing delay), raising `Timeout` in the end.
 
@@ -470,17 +470,17 @@ class Channel:
 
             for i in range(_MAX_RETRANSMISSION_COUNT):
                 # Try to send the payload (split into packets), or raise if transport is blocked
-                yield from self._write_payload_once(header, payload)
+                await self._write_payload_once(header, payload)
                 # Channel's estimated latency + a variable delay (from 200ms till ~3.52s)
                 delay_ms = ack_latency_ms + round(10300 - 1010000 / (100 + i))
-                yield from sleep(delay_ms)
+                await sleep(delay_ms)
                 if __debug__:
                     log.warning(__name__, "Retransmit after %d ms", delay_ms)
 
             # restart event loop due to unresponsive channel
             raise Timeout("THP retransmission timeout")
 
-        def _wait_for_ack() -> Generator[Any, Any, None]:
+        async def _wait_for_ack() -> None:
             """
             Wait for the expected ACK to be received.
 
@@ -489,7 +489,7 @@ class Channel:
             """
             while not ABP.is_sending_allowed(self.channel_cache):
                 # `ABP.set_sending_allowed()` will be called after a valid ACK
-                yield from self.recv_payload(expected_ctrl_byte=None)
+                await self.recv_payload(expected_ctrl_byte=None)
 
         try:
             # wait and return after receiving an ACK, or raise in case of an unexpected message / retransmission timeout.


### PR DESCRIPTION
Following https://satoshilabs.slack.com/archives/C054XGU77QV/p1777387713801909.

`yield from` and `await` both allocate, so let's use `await` for better readability.

Checked `core/build/firmware/frozen_mpy.c`, the same code is generated:
```c
// child of trezor_wire_thp_channel_Channel_write_encrypted_payload
// frozen bytecode for file trezor/wire/thp/channel.py, scope trezor_wire_thp_channel_Channel_write_encrypted_payload__wait_for_ack
static const byte fun_data_trezor_wire_thp_channel_Channel_write_encrypted_payload__wait_for_ack[39] = {
    0xa1,0x40,0x08, // prelude
    0x81,0x1b,0x81,0x2d, // names: _wait_for_ack, *
     // code info
    0x42,0x4f, // JUMP 15
    0x25,0x00, // LOAD_DEREF 0
    0x14,0x74, // LOAD_METHOD 'recv_payload'
    0x10,0x81,0x1c, // LOAD_CONST_STRING 'expected_ctrl_byte'
    0x51, // LOAD_CONST_NONE
    0x36,0x82,0x00, // CALL_METHOD 256
    0x5e, // GET_ITER
    0x51, // LOAD_CONST_NONE
    0x68, // YIELD_FROM
    0x59, // POP_TOP
    0x12,0x81,0x1d, // LOAD_GLOBAL 'ABP'
    0x14,0x7b, // LOAD_METHOD 'is_sending_allowed'
    0x25,0x00, // LOAD_DEREF 0
    0x13,0x45, // LOAD_ATTR 'channel_cache'
    0x36,0x01, // CALL_METHOD 1
    0x44,0x24, // POP_JUMP_IF_FALSE -28
    0x51, // LOAD_CONST_NONE
    0x63, // RETURN_VALUE
};
```
