### PR TITLE
CI: hardware tests: add runners with T3B1, T3T1, T3W1

### DIFF
--- a/.github/workflows/core-hw.yml
+++ b/.github/workflows/core-hw.yml
@@ -23,11 +23,11 @@ jobs:
     runs-on:
       - self-hosted
       # FIXME runner4 with t2b1 does not work at the moment
-      - ${{ matrix.model == 'T2B1' && 'runner3' || matrix.model == 'T3T1' && 'hw-t3t1' || 'hw-t2t1' }}
+      - ${{ matrix.model == 'T2B1' && 'runner3' || matrix.model == 'T3T1' && 'hw-t3t1' || matrix.model == 'T3B1' && 'hw-t3b1' || matrix.model == 'T3W1' && 'hw-t3w1' || 'hw-t2t1' }}
     strategy:
       fail-fast: false
       matrix:
-        model: [T2T1, T2B1, T3T1]
+        model: [T2T1, T2B1, T3B1, T3T1, T3W1]
         coins: [universal, btconly]
     env:
       TREZOR_MODEL: ${{ matrix.model }}
@@ -35,6 +35,7 @@ jobs:
       PYTEST_TIMEOUT: 600  # 10m single test timeout
       PYOPT: 0
       DISABLE_OPTIGA: 1
+      DISABLE_TROPIC: 1
       STORAGE_INSECURE_TESTING_MODE: 1
       BOOTLOADER_DEVEL: ${{ matrix.model == 'T2T1' && '0' || '1' }}
       # TODO: enable SD-related tests after fixing #4924
@@ -76,17 +77,19 @@ jobs:
     runs-on:
       - self-hosted
       # FIXME runner4 with t2b1 does not work at the moment
-      - ${{ matrix.model == 'T2B1' && 'runner3' || matrix.model == 'T3T1' && 'hw-t3t1' || 'hw-t2t1' }}
+      - ${{ matrix.model == 'T2B1' && 'runner3' || matrix.model == 'T3T1' && 'hw-t3t1' || matrix.model == 'T3B1' && 'hw-t3b1' || matrix.model == 'T3W1' && 'hw-t3w1' || 'hw-t2t1' }}
     if: false # FIXME https://github.com/trezor/trezor-firmware/issues/3128
     strategy:
       fail-fast: false
       matrix:
-        model: [T2T1, T2B1, T3T1]
+        model: [T2T1, T2B1, T3B1, T3T1, T3W1]
     env:
       TREZOR_MODEL: ${{ matrix.model }}
       PYTEST_TIMEOUT: 1200
       PYOPT: 0
       DISABLE_OPTIGA: 1
+      DISABLE_TROPIC: 1
+      STORAGE_INSECURE_TESTING_MODE: 1
       BOOTLOADER_DEVEL: ${{ matrix.model == 'T2T1' && '0' || '1' }}
       TT_UHUB_PORT: all
     steps:

--- a/.github/workflows/core-hw.yml
+++ b/.github/workflows/core-hw.yml
@@ -45,7 +45,7 @@ jobs:
         -k 'not test_authenticate_device'
         --durations=50
         --session-timeout 19800
-      TT_UHUB_PORT: 1
+      TT_UHUB_PORT: all
     timeout-minutes: 360  # 6h CI job timeout
     steps:
       - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5  # actions/checkout@v4.3.1
@@ -87,7 +87,7 @@ jobs:
       PYOPT: 0
       DISABLE_OPTIGA: 1
       BOOTLOADER_DEVEL: ${{ matrix.model == 'T2T1' && '0' || '1' }}
-      TT_UHUB_PORT: 1
+      TT_UHUB_PORT: all
     steps:
       - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5  # actions/checkout@v4.3.1
         with:

--- a/.github/workflows/core-hw.yml
+++ b/.github/workflows/core-hw.yml
@@ -52,6 +52,13 @@ jobs:
       - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5  # actions/checkout@v4.3.1
         with:
           submodules: recursive
+          persist-credentials: false
+        if: matrix.model == 'T2B1' || matrix.model == 'T2T1'
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # actions/checkout@v6.0.2
+        with:
+          submodules: recursive
+          persist-credentials: false
+        if: matrix.model != 'T2B1' && matrix.model != 'T2T1'
       - uses: ./.github/actions/environment
       - run: nix-shell --arg hardwareTest true --run uhubctl
       - run: nix-shell --run "uv run make -C core build_firmware"
@@ -63,14 +70,14 @@ jobs:
           nix-shell --run "uv run pytest -v --verbose-log-file pytest.log tests/device_tests $TESTOPTS"
       - run: tail -n50 trezor.log || true
         if: failure()
-      - uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02  # actions/upload-artifact@v4.6.2
+      - uses: actions/upload-artifact@bbbca2ddaa5d8feaa63e36b76fdaad77386f024f  # actions/upload-artifact@v7.0.0
         with:
           name: core-hardware-${{ matrix.model }}-${{ matrix.coins }}
           path: |
             trezor.log
             pytest.log
           retention-days: 7
-        if: always()
+        if: always() && matrix.model != 'T2B1' && matrix.model != 'T2T1'
 
   core_monero_test:
     name: Monero tests
@@ -93,9 +100,10 @@ jobs:
       BOOTLOADER_DEVEL: ${{ matrix.model == 'T2T1' && '0' || '1' }}
       TT_UHUB_PORT: all
     steps:
-      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5  # actions/checkout@v4.3.1
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # actions/checkout@v6.0.2
         with:
           submodules: recursive
+          persist-credentials: false
       - uses: ./.github/actions/environment
         with:
           full-deps: "true"
@@ -109,7 +117,7 @@ jobs:
           nix-shell --arg fullDeps true --run "./core/tests/run_tests_device_emu_monero.sh --trezor-path webusb:"
       - run: tail -n50 trezor.log || true
         if: failure()
-      - uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02  # actions/upload-artifact@v4.6.2
+      - uses: actions/upload-artifact@bbbca2ddaa5d8feaa63e36b76fdaad77386f024f  # actions/upload-artifact@v7.0.0
         with:
           name: core-hardware-monero-${{ matrix.model }}
           path: trezor.log
@@ -137,6 +145,7 @@ jobs:
       - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5  # actions/checkout@v4.3.1
         with:
           submodules: recursive
+          persist-credentials: false
       - uses: ./.github/actions/environment
       - run: nix-shell --arg hardwareTest true --run uhubctl
       - run: nix-shell --run "uv run legacy/script/setup"

--- a/.github/workflows/core-hw.yml
+++ b/.github/workflows/core-hw.yml
@@ -77,6 +77,7 @@ jobs:
       - self-hosted
       # FIXME runner4 with t2b1 does not work at the moment
       - ${{ matrix.model == 'T2B1' && 'runner3' || matrix.model == 'T3T1' && 'hw-t3t1' || 'hw-t2t1' }}
+    if: false # FIXME https://github.com/trezor/trezor-firmware/issues/3128
     strategy:
       fail-fast: false
       matrix:

--- a/.github/workflows/core-hw.yml
+++ b/.github/workflows/core-hw.yml
@@ -22,13 +22,12 @@ jobs:
     name: Device tests
     runs-on:
       - self-hosted
-      - ${{ matrix.model == 'T2B1' && 'runner3' || 'hw-t2t1' }}
-      # runner4 does not work at the moment
-      # - ${{ matrix.model == 'T2B1' && 'hw-t2b1' || 'hw-t2t1' }}
+      # FIXME runner4 with t2b1 does not work at the moment
+      - ${{ matrix.model == 'T2B1' && 'runner3' || matrix.model == 'T3T1' && 'hw-t3t1' || 'hw-t2t1' }}
     strategy:
       fail-fast: false
       matrix:
-        model: [T2T1, T2B1]
+        model: [T2T1, T2B1, T3T1]
         coins: [universal, btconly]
     env:
       TREZOR_MODEL: ${{ matrix.model }}
@@ -37,7 +36,7 @@ jobs:
       PYOPT: 0
       DISABLE_OPTIGA: 1
       STORAGE_INSECURE_TESTING_MODE: 1
-      BOOTLOADER_DEVEL: ${{ matrix.model == 'T2B1' && '1' || '0' }}
+      BOOTLOADER_DEVEL: ${{ matrix.model == 'T2T1' && '0' || '1' }}
       # TODO: enable SD-related tests after fixing #4924
       # Disable authenticity test since it requires DISABLE_OPTIGA=0
       # 5.5h pytest global timeout
@@ -76,19 +75,18 @@ jobs:
     name: Monero tests
     runs-on:
       - self-hosted
-      - ${{ matrix.model == 'T2B1' && 'runner3' || 'hw-t2t1' }}
-      # runner4 does not work at the moment
-      # - ${{ matrix.model == 'T2B1' && 'hw-t2b1' || 'hw-t2t1' }}
+      # FIXME runner4 with t2b1 does not work at the moment
+      - ${{ matrix.model == 'T2B1' && 'runner3' || matrix.model == 'T3T1' && 'hw-t3t1' || 'hw-t2t1' }}
     strategy:
       fail-fast: false
       matrix:
-        model: [T2T1, T2B1]
+        model: [T2T1, T2B1, T3T1]
     env:
       TREZOR_MODEL: ${{ matrix.model }}
       PYTEST_TIMEOUT: 1200
       PYOPT: 0
       DISABLE_OPTIGA: 1
-      BOOTLOADER_DEVEL: ${{ matrix.model == 'T2B1' && '1' || '0' }}
+      BOOTLOADER_DEVEL: ${{ matrix.model == 'T2T1' && '0' || '1' }}
       TT_UHUB_PORT: 1
     steps:
       - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5  # actions/checkout@v4.3.1

--- a/ci/hardware_tests/bootstrap.py
+++ b/ci/hardware_tests/bootstrap.py
@@ -23,10 +23,12 @@ def main(model: str, file: str = None):
     elif model == "T2T1":
         # t1.power_off()
         path = tt.update_firmware(file, "Trezor T")
-    elif model == "T2B1":
+    elif model in ("T2B1", "T3B1"):
         path = tt.update_firmware(file, "Safe 3")
     elif model == "T3T1":
         path = tt.update_firmware(file, "Safe 5")
+    elif model == "T3W1":
+        path = tt.update_firmware(file, "Safe 7")
     else:
         raise ValueError("Unknown Trezor model.")
 

--- a/ci/hardware_tests/bootstrap.py
+++ b/ci/hardware_tests/bootstrap.py
@@ -25,6 +25,8 @@ def main(model: str, file: str = None):
         path = tt.update_firmware(file, "Trezor T")
     elif model == "T2B1":
         path = tt.update_firmware(file, "Safe 3")
+    elif model == "T3T1":
+        path = tt.update_firmware(file, "Safe 5")
     else:
         raise ValueError("Unknown Trezor model.")
 


### PR DESCRIPTION
~~Marking as a draft since bumping actions version breaks the existing runners.~~

TBD:
- [x] T1B1 tests (uhubctl doesn't see the hub)
- [x] T2B1 on runner4 (uhubctl doesn't see the hub)
- [x] T3B1 on runner9 can see the hub but device disappeared
- [x] T3T1 on runner6 can't see hub anymore
- [x] T3W1 gets stuck on `Please confirm action on your Trezor device.` after uploading firmware

<!--
For external contributors:
- Please open an issue before submitting a PR so we can discuss whether we want to proceed with it.

For core developers:
1. Initial PR setup
- Assign yourself to the PR.
- Add it to the "Firmware" project
  - Set Priority (match issue priority if it exists)
  - Set Team
  - Set Sprint (target release)

2. Development status
- Draft PRs: Set status to "In Progress"
- Final PRs: Set status to "Needs Review"

3. Post-merge status
- Testable: Set status to "Needs QA" and add a `Notes for QA` section with clear instructions on how to test the functionality.
- Not Testable: Set status to "Done (no QA)"
-->
