### PR TITLE
Allow changing title of PIN unlock progress screen

### DIFF
--- a/core/src/trezor/pin.py
+++ b/core/src/trezor/pin.py
@@ -9,6 +9,7 @@ if TYPE_CHECKING:
 
 _previous_seconds: int | None = None
 _previous_remaining: str | None = None
+_previous_message: config.StorageMessage | None = None
 _progress_layout: ProgressLayout | None = None
 _started_with_empty_loader = False
 keepalive_callback: Any = None
@@ -38,6 +39,7 @@ def render_empty_loader(
     """
     from trezor.ui.layouts.progress import pin_progress
 
+    global _previous_message
     global _progress_layout
     global _started_with_empty_loader
 
@@ -45,6 +47,7 @@ def render_empty_loader(
     _progress_layout.report(0, None)
 
     _started_with_empty_loader = True
+    _previous_message = message
 
 
 def show_pin_timeout(
@@ -62,6 +65,7 @@ def show_pin_timeout(
 
     global _previous_seconds
     global _previous_remaining
+    global _previous_message
     global _progress_layout
     global _started_with_empty_loader
 
@@ -85,8 +89,13 @@ def show_pin_timeout(
         remaining = _previous_remaining
 
     # create the layout if it doesn't exist yet or should be started again
-    if _progress_layout is None or (progress == 0 and not _started_with_empty_loader):
+    if (
+        _progress_layout is None
+        or (progress == 0 and not _started_with_empty_loader)
+        or message != _previous_message
+    ):
         _progress_layout = pin_progress(message, description=remaining or "")
+        _previous_message = message
 
     # reset the flag - the render_empty_loader() has the effect only in the first call
     # of this function, where we do not want to re-initialize the layout
@@ -100,5 +109,6 @@ def show_pin_timeout(
     if progress >= 1000:
         _progress_layout = None
         _previous_remaining = None
+        _previous_message = None
 
     return False


### PR DESCRIPTION
The PIN unlock progress UI code has assumed that the screen title won't change after it is initialized. This is no longer true since #3329, where in case of wrong PIN the title is changed to _Wrong PIN_ and the animation is allowed to finish in the estimated time.

I suspect this has only ever worked on emulator sometimes (and tripped up UI tests in #6956) - the title only changes when progress==0 and on emulator it's [computed differently](https://github.com/trezor/trezor-firmware/blob/core/v2.12.0/storage/storage.c#L545-L558). If we want to keep the existing UI we can delete `ui_message = WRONG_PIN_MSG;` in storage.c instead.

<!--
For external contributors:
- Please open an issue before submitting a PR so we can discuss whether we want to proceed with it.

For core developers:
1. Initial PR setup
- Assign yourself to the PR.
- Add it to the "Firmware" project
  - Set Priority (match issue priority if it exists)
  - Set Team
  - Set Sprint (target release)

2. Development status
- Draft PRs: Set status to "In Progress"
- Final PRs: Set status to "Needs Review"

3. Post-merge status
- Testable: Set status to "Needs QA" and add a `Notes for QA` section with clear instructions on how to test the functionality.
- Not Testable: Set status to "Done (no QA)"
-->
