### PR TITLE
fix(core/eckhart): use a timeout when showing FIDO-related errors

### DIFF
--- a/core/.changelog.d/6984.fixed
+++ b/core/.changelog.d/6984.fixed
@@ -1,0 +1,1 @@
+[T3W1] Close FIDO2 error popup after 4 seconds.

--- a/core/embed/rust/src/ui/layout_eckhart/ui_firmware.rs
+++ b/core/embed/rust/src/ui/layout_eckhart/ui_firmware.rs
@@ -1016,7 +1016,7 @@ impl FirmwareUI for UIEckhart {
         button: TString<'static>,
         description: TString<'static>,
         allow_cancel: bool,
-        _time_ms: u32,
+        time_ms: u32,
     ) -> Result<Gc<LayoutObj>, Error> {
         let content = Paragraphs::new(Paragraph::new(&theme::firmware::TEXT_REGULAR, description))
             .with_placement(LinearPlacement::vertical());
@@ -1027,7 +1027,11 @@ impl FirmwareUI for UIEckhart {
                 Button::with_text(button),
             )
         } else {
-            ActionBar::new_single(Button::with_text(button))
+            let button = Button::with_text(button);
+            match time_ms {
+                0 => ActionBar::new_single(button),
+                _ => ActionBar::new_timeout(button, Duration::from_millis(time_ms)),
+            }
         };
         let screen = TextScreen::new(content)
             .with_header(


### PR DESCRIPTION
Similar to how it's done in Bolt & Caesar - see `_show_error_popup()` at `core/src/apps/webauthn/fido2.py`. 

# Notes to QA:
- setup the device
- set a PIN
- register the same "username" twice on https://webauthn.io/ 
- the following popup should appear and automatically disappear:

<img width="373" height="419" alt="Screenshot from 2026-06-03 08-39-21" src="https://github.com/user-attachments/assets/d2bc76c7-9479-4f80-9dea-7e2c72c54758" />
