### PR TITLE
refactor(core/delizia): remove `Header`-related helpers from `Frame`

### DIFF
--- a/core/embed/rust/src/ui/layout_delizia/component/address_details.rs
+++ b/core/embed/rust/src/ui/layout_delizia/component/address_details.rs
@@ -20,7 +20,7 @@ use crate::{
     },
 };
 
-use super::{theme, Frame, FrameMsg};
+use super::{theme, Frame, FrameMsg, Header};
 
 pub struct AddressDetails {
     details: Frame<Paragraphs<ParagraphVecShort<'static>>>,
@@ -58,14 +58,15 @@ impl AddressDetails {
             para.add(Paragraph::new(&theme::TEXT_MONO_GREY_LIGHT, p));
         }
         let result = Self {
-            details: Frame::left_aligned(details_title, para.into_paragraphs())
-                .with_cancel_button()
-                .with_horizontal_pages(),
-            xpub_view: Frame::left_aligned(
-                " \n ".into(),
+            details: Frame::new(
+                Header::left_aligned(details_title).with_cancel_button(),
+                para.into_paragraphs(),
+            )
+            .with_horizontal_pages(),
+            xpub_view: Frame::new(
+                Header::left_aligned(" \n ".into()).with_cancel_button(),
                 Paragraph::new(&theme::TEXT_MONO_GREY_LIGHT, "").into_paragraphs(),
             )
-            .with_cancel_button()
             .with_horizontal_pages(),
             xpubs: Vec::new(),
             xpub_page_count: Vec::new(),

--- a/core/embed/rust/src/ui/layout_delizia/component/coinjoin_progress.rs
+++ b/core/embed/rust/src/ui/layout_delizia/component/coinjoin_progress.rs
@@ -14,7 +14,7 @@ use crate::{
     },
 };
 
-use super::{constant, theme, Frame};
+use super::{constant, theme, Frame, Header};
 
 const RECTANGLE_HEIGHT: i16 = 56;
 const LABEL_TOP: i16 = 135;
@@ -58,8 +58,8 @@ where
         Ok(Self {
             value: 0,
             indeterminate,
-            content: Frame::left_aligned(
-                TR::coinjoin__title_progress.into(),
+            content: Frame::new(
+                Header::left_aligned(TR::coinjoin__title_progress.into()),
                 Split::bottom(RECTANGLE_HEIGHT, 0, Empty, inner),
             ),
             label: Label::centered(text, theme::TEXT_NORMAL),

--- a/core/embed/rust/src/ui/layout_delizia/component/frame.rs
+++ b/core/embed/rust/src/ui/layout_delizia/component/frame.rs
@@ -1,4 +1,4 @@
-use super::{header::HeaderMsg, theme, ButtonStyleSheet, Footer, Header};
+use super::{theme, Footer, Header};
 use crate::{
     strutil::TString,
     ui::{
@@ -6,14 +6,12 @@ use crate::{
             base::AttachType,
             paginated::Paginate,
             swipe_detect::{SwipeConfig, SwipeSettings},
-            text::TextStyle,
             Component,
             Event::{self, Swipe},
             EventCtx, FlowMsg, MsgMap, SwipeDetect,
         },
-        display::{Color, Icon},
         event::SwipeEvent,
-        geometry::{Alignment, Direction, Insets, Point, Rect},
+        geometry::{Direction, Insets, Point, Rect},
         lerp::Lerp,
         shape::{self, Renderer},
     },
@@ -110,11 +108,12 @@ impl<T> Frame<T>
 where
     T: Component + Paginate,
 {
-    pub const fn new(alignment: Alignment, title: TString<'static>, content: T) -> Self {
+    #[inline(never)]
+    pub const fn new(header: Header, content: T) -> Self {
         Self {
             bounds: Rect::zero(),
             content,
-            header: Header::new(alignment, title),
+            header,
             header_update_fn: None,
             footer: None,
             footer_update_fn: None,
@@ -128,58 +127,8 @@ where
         }
     }
 
-    #[inline(never)]
-    pub const fn left_aligned(title: TString<'static>, content: T) -> Self {
-        Self::new(Alignment::Start, title, content)
-    }
-
-    #[inline(never)]
-    pub const fn right_aligned(title: TString<'static>, content: T) -> Self {
-        Self::new(Alignment::End, title, content)
-    }
-
-    #[inline(never)]
-    pub const fn centered(title: TString<'static>, content: T) -> Self {
-        Self::new(Alignment::Center, title, content)
-    }
-
-    #[inline(never)]
-    pub fn with_subtitle(mut self, subtitle: TString<'static>) -> Self {
-        self.header = self.header.with_subtitle(subtitle);
-        self
-    }
-
-    #[inline(never)]
-    fn with_button(mut self, icon: Icon, msg: HeaderMsg, enabled: bool) -> Self {
-        self.header = self.header.with_button(icon, enabled, msg);
-        self
-    }
-
-    pub fn with_cancel_button(self) -> Self {
-        self.with_button(theme::ICON_CLOSE, HeaderMsg::Cancelled, true)
-    }
-
-    pub fn with_menu_button(self) -> Self {
-        self.with_button(theme::ICON_MENU, HeaderMsg::Info, true)
-    }
-
-    pub fn with_danger_menu_button(self) -> Self {
-        self.with_button(theme::ICON_MENU, HeaderMsg::Info, true)
-            .button_styled(theme::button_warning_high())
-    }
-
-    pub fn with_warning_low_icon(self) -> Self {
-        self.with_button(theme::ICON_WARNING, HeaderMsg::Info, false)
-            .button_styled(theme::button_warning_low())
-    }
-
-    pub fn with_danger_icon(self) -> Self {
-        self.with_button(theme::ICON_WARNING, HeaderMsg::Info, false)
-            .button_styled(theme::button_danger())
-    }
-
     // `has_menu` is used to gradually introduce multi-item menus (#5189).
-    // TODO: After the migration, this flag should be set in `with_button()`.
+    // TODO: After the migration, this flag should be set in `self.header`.
     #[cfg(feature = "ui_debug")]
     pub fn with_external_menu(mut self) -> Self {
         // Allow visiting this menu automatically by tests
@@ -203,26 +152,6 @@ where
     }
     #[cfg(not(feature = "ui_debug"))]
     pub fn with_flow_menu(self) -> Self {
-        self
-    }
-
-    pub fn title_styled(mut self, style: TextStyle) -> Self {
-        self.header = self.header.styled(style);
-        self
-    }
-
-    pub fn subtitle_styled(mut self, style: TextStyle) -> Self {
-        self.header = self.header.subtitle_styled(style);
-        self
-    }
-
-    pub fn button_styled(mut self, style: ButtonStyleSheet) -> Self {
-        self.header = self.header.button_styled(style);
-        self
-    }
-
-    pub fn with_result_icon(mut self, icon: Icon, color: Color) -> Self {
-        self.header = self.header.with_result_icon(icon, color);
         self
     }
 
@@ -286,11 +215,6 @@ where
     ) -> Self {
         self.footer_update_fn = Some(f);
         self
-    }
-
-    pub fn with_danger(self) -> Self {
-        self.button_styled(theme::button_danger())
-            .title_styled(theme::label_title_danger())
     }
 
     pub fn inner(&self) -> &T {

--- a/core/embed/rust/src/ui/layout_delizia/component/header.rs
+++ b/core/embed/rust/src/ui/layout_delizia/component/header.rs
@@ -90,6 +90,19 @@ pub struct Header {
 }
 
 impl Header {
+    pub const fn left_aligned(title: TString<'static>) -> Self {
+        Self::new(Alignment::Start, title)
+    }
+
+    pub const fn centered(title: TString<'static>) -> Self {
+        Self::new(Alignment::Center, title)
+    }
+
+    pub const fn right_aligned(title: TString<'static>) -> Self {
+        Self::new(Alignment::End, title)
+    }
+
+    #[inline(never)]
     pub const fn new(alignment: Alignment, title: TString<'static>) -> Self {
         Self {
             area: Rect::zero(),
@@ -103,6 +116,35 @@ impl Header {
             button_msg: HeaderMsg::Cancelled,
         }
     }
+
+    pub fn with_cancel_button(self) -> Self {
+        self.with_button(theme::ICON_CLOSE, true, HeaderMsg::Cancelled)
+    }
+
+    pub fn with_menu_button(self) -> Self {
+        self.with_button(theme::ICON_MENU, true, HeaderMsg::Info)
+    }
+
+    pub fn with_danger_menu_button(self) -> Self {
+        self.with_button(theme::ICON_MENU, true, HeaderMsg::Info)
+            .button_styled(theme::button_warning_high())
+    }
+
+    pub fn with_warning_low_icon(self) -> Self {
+        self.with_button(theme::ICON_WARNING, false, HeaderMsg::Info)
+            .button_styled(theme::button_warning_low())
+    }
+
+    pub fn with_danger_icon(self) -> Self {
+        self.with_button(theme::ICON_WARNING, false, HeaderMsg::Info)
+            .button_styled(theme::button_danger())
+    }
+
+    pub fn with_danger(self) -> Self {
+        self.button_styled(theme::button_danger())
+            .styled(theme::label_title_danger())
+    }
+
     #[inline(never)]
     pub fn with_subtitle(mut self, subtitle: TString<'static>) -> Self {
         let style = theme::TEXT_SUB_GREY;

--- a/core/embed/rust/src/ui/layout_delizia/flow/confirm_action.rs
+++ b/core/embed/rust/src/ui/layout_delizia/flow/confirm_action.rs
@@ -20,7 +20,9 @@ use crate::{
 };
 
 use super::super::{
-    component::{Footer, Frame, PromptScreen, SwipeContent, VerticalMenu, VerticalMenuChoiceMsg},
+    component::{
+        Footer, Frame, Header, PromptScreen, SwipeContent, VerticalMenu, VerticalMenuChoiceMsg,
+    },
     theme,
 };
 
@@ -333,19 +335,27 @@ fn new_confirm_action_uni<T: Component + Paginate + MaybeTrace + 'static>(
     let (prompt_screen, prompt_pages, flow, page) =
         create_flow(strings.title, strings.prompt_screen, options.hold, &extra);
 
-    let mut content = Frame::left_aligned(strings.title, content)
+    let header = Header::left_aligned(strings.title);
+    let has_external_menu = matches!(extra, ConfirmActionExtra::ExternalMenu);
+    let mut header = match extra {
+        ConfirmActionExtra::ExternalMenu => header.with_menu_button(),
+        ConfirmActionExtra::Menu(_) => header.with_menu_button(),
+        ConfirmActionExtra::Cancel => header.with_cancel_button(),
+    };
+    if let Some(subtitle) = strings.subtitle {
+        header = header.with_subtitle(subtitle);
+    }
+
+    let mut content = Frame::new(header, content)
         .with_margin(options.frame_margin)
         .with_swipeup_footer(strings.footer_description)
         .with_vertical_pages();
+    if has_external_menu {
+        content = content.with_external_menu();
+    }
     if options.swipe_down {
         content = content.with_swipe(Direction::Down, SwipeSettings::Default);
     }
-
-    content = match extra {
-        ConfirmActionExtra::ExternalMenu => content.with_menu_button().with_external_menu(),
-        ConfirmActionExtra::Menu { .. } => content.with_menu_button(),
-        ConfirmActionExtra::Cancel => content.with_cancel_button(),
-    };
 
     if options.page_counter {
         fn footer_update_fn<T: Component + Paginate>(
@@ -359,10 +369,6 @@ fn new_confirm_action_uni<T: Component + Paginate + MaybeTrace + 'static>(
         content = content
             .with_footer_counter(TR::instructions__tap_to_continue.into())
             .register_footer_update_fn(footer_update_fn::<T>);
-    }
-
-    if let Some(subtitle) = strings.subtitle {
-        content = content.with_subtitle(subtitle);
     }
 
     let content = content
@@ -449,7 +455,7 @@ fn create_menu(
     menu = menu.cancel_item(menu_strings.verb_cancel);
     unwrap!(menu_items.push(MENU_ITEM_CANCEL));
 
-    let content_menu = Frame::left_aligned("".into(), menu).with_cancel_button();
+    let content_menu = Frame::new(Header::left_aligned("".into()).with_cancel_button(), menu);
 
     let content_menu = content_menu.map(move |msg| match msg {
         VerticalMenuChoiceMsg::Selected(i) => {
@@ -483,17 +489,16 @@ fn create_confirm(
         )
     };
 
-    let mut content_confirm = Frame::left_aligned(prompt_title, SwipeContent::new(prompt))
+    let mut header = Header::left_aligned(prompt_title);
+    if matches!(extra, ConfirmActionExtra::Menu(_)) {
+        header = header.with_menu_button();
+    }
+    if let Some(subtitle) = subtitle {
+        header = header.with_subtitle(subtitle);
+    }
+    let content_confirm = Frame::new(header, SwipeContent::new(prompt))
         .with_footer(prompt_action, None)
         .with_swipe(Direction::Down, SwipeSettings::Default);
-
-    if matches!(extra, ConfirmActionExtra::Menu(_)) {
-        content_confirm = content_confirm.with_menu_button();
-    }
-
-    if let Some(subtitle) = subtitle {
-        content_confirm = content_confirm.with_subtitle(subtitle);
-    }
 
     flow.add_page(
         prompt_state,

--- a/core/embed/rust/src/ui/layout_delizia/flow/confirm_fido.rs
+++ b/core/embed/rust/src/ui/layout_delizia/flow/confirm_fido.rs
@@ -20,7 +20,8 @@ use crate::{
 
 use super::super::{
     component::{
-        FidoCredential, Footer, Frame, PagedVerticalMenu, PromptScreen, SwipeContent, VerticalMenu,
+        FidoCredential, Footer, Frame, Header, PagedVerticalMenu, PromptScreen, SwipeContent,
+        VerticalMenu,
     },
     theme,
 };
@@ -102,14 +103,14 @@ pub fn new_confirm_fido(
     SINGLE_CRED.store(num_accounts <= 1, Ordering::Relaxed);
     CRED_SELECTED.store(0, Ordering::Relaxed);
 
-    let content_intro = Frame::left_aligned(
-        title,
+    let header = Header::left_aligned(title).with_menu_button();
+    let content_intro = Frame::new(
+        header,
         SwipeContent::new(Paragraphs::new(Paragraph::new::<TString>(
             &theme::TEXT_MAIN_GREY_LIGHT,
             TR::fido__select_intro.into(),
         ))),
     )
-    .with_menu_button()
     .with_swipeup_footer(None)
     .map_to_button_msg();
 
@@ -123,15 +124,16 @@ pub fn new_confirm_fido(
             .unwrap_or_else(|_| TString::from_str("-"))
     };
 
-    let content_choose_credential = Frame::left_aligned(
-        TR::fido__title_select_credential.into(),
+    let header = Header::left_aligned(TR::fido__title_select_credential.into())
+        .with_subtitle(TR::fido__title_for_authentication.into())
+        .with_menu_button();
+    let content_choose_credential = Frame::new(
+        header,
         SwipeContent::new(SwipePage::vertical(PagedVerticalMenu::new(
             num_accounts,
             label_fn,
         ))),
     )
-    .with_subtitle(TR::fido__title_for_authentication.into())
-    .with_menu_button()
     .with_footer_page_hint(
         TR::fido__more_credentials.into(),
         TR::buttons__go_back.into(),
@@ -148,29 +150,29 @@ pub fn new_confirm_fido(
         let account = unwrap!(accounts.get(current));
         account.try_into().unwrap_or_else(|_| TString::from_str(""))
     };
-    let content_details = Frame::left_aligned(
-        TR::fido__title_credential_details.into(),
+    let header = Header::left_aligned(TR::fido__title_credential_details.into());
+    let header = if single_cred() {
+        header.with_menu_button()
+    } else {
+        header.with_cancel_button()
+    };
+    let content_details = Frame::new(
+        header,
         SwipeContent::new(FidoCredential::new(icon_name, app_name, get_account)),
     )
-    .with_swipeup_footer(Some(title));
-    let content_details = if single_cred() {
-        content_details.with_menu_button()
-    } else {
-        content_details.with_cancel_button()
-    }
+    .with_swipeup_footer(Some(title))
     .map_to_button_msg();
 
-    let content_tap = Frame::left_aligned(title, PromptScreen::new_tap_to_confirm())
-        .with_menu_button()
+    let header = Header::left_aligned(title).with_menu_button();
+    let content_tap = Frame::new(header, PromptScreen::new_tap_to_confirm())
         .with_footer(TR::instructions__tap_to_confirm.into(), None)
         .with_swipe(Direction::Down, SwipeSettings::Default)
         .map(super::util::map_to_confirm);
 
-    let content_menu = Frame::left_aligned(
-        "".into(),
+    let content_menu = Frame::new(
+        Header::left_aligned("".into()).with_cancel_button(),
         VerticalMenu::empty().cancel_item(TR::buttons__cancel.into()),
     )
-    .with_cancel_button()
     .map(super::util::map_to_choice);
 
     let initial_page = if single_cred() {

--- a/core/embed/rust/src/ui/layout_delizia/flow/confirm_firmware_update.rs
+++ b/core/embed/rust/src/ui/layout_delizia/flow/confirm_firmware_update.rs
@@ -16,7 +16,7 @@ use crate::{
 };
 
 use super::super::{
-    component::{Frame, PromptScreen, SwipeContent, VerticalMenu},
+    component::{Frame, Header, PromptScreen, SwipeContent, VerticalMenu},
     theme,
 };
 
@@ -62,16 +62,15 @@ pub fn new_confirm_firmware_update(
     fingerprint: TString<'static>,
 ) -> Result<SwipeFlow, error::Error> {
     let paragraphs = Paragraphs::new(Paragraph::new(&theme::TEXT_MAIN_GREY_LIGHT, description));
-    let content_intro = Frame::left_aligned(
-        TR::firmware_update__title.into(),
+    let content_intro = Frame::new(
+        Header::left_aligned(TR::firmware_update__title.into()).with_menu_button(),
         SwipeContent::new(paragraphs),
     )
-    .with_menu_button()
     .with_swipeup_footer(None)
     .map_to_button_msg();
 
-    let content_menu = Frame::left_aligned(
-        TString::empty(),
+    let content_menu = Frame::new(
+        Header::left_aligned(TString::empty()).with_cancel_button(),
         VerticalMenu::empty()
             .item(
                 theme::ICON_CHEVRON_RIGHT,
@@ -79,23 +78,20 @@ pub fn new_confirm_firmware_update(
             )
             .cancel_item(TR::buttons__cancel.into()),
     )
-    .with_cancel_button()
     .map(super::util::map_to_choice);
 
     let paragraphs_fingerprint =
         Paragraphs::new(Paragraph::new(&theme::TEXT_MONO_GREY_LIGHT, fingerprint));
-    let content_fingerprint = Frame::left_aligned(
-        TR::firmware_update__title_fingerprint.into(),
+    let content_fingerprint = Frame::new(
+        Header::left_aligned(TR::firmware_update__title_fingerprint.into()).with_cancel_button(),
         SwipeContent::new(paragraphs_fingerprint),
     )
-    .with_cancel_button()
     .map_to_button_msg();
 
-    let content_confirm = Frame::left_aligned(
-        TR::firmware_update__title.into(),
+    let content_confirm = Frame::new(
+        Header::left_aligned(TR::firmware_update__title.into()).with_menu_button(),
         SwipeContent::new(PromptScreen::new_hold_to_confirm()),
     )
-    .with_menu_button()
     .with_footer(TR::instructions__hold_to_confirm.into(), None)
     .with_swipe(Direction::Down, SwipeSettings::Default)
     .map(super::util::map_to_confirm);

--- a/core/embed/rust/src/ui/layout_delizia/flow/confirm_homescreen.rs
+++ b/core/embed/rust/src/ui/layout_delizia/flow/confirm_homescreen.rs
@@ -12,7 +12,7 @@ use crate::{
     },
 };
 
-use super::super::component::{Frame, PromptScreen, SwipeContent, VerticalMenu};
+use super::super::component::{Frame, Header, PromptScreen, SwipeContent, VerticalMenu};
 
 /// Flow for a setting of homescreen wallpaper showing a preview of the image,
 /// menu to cancel and tap to confirm prompt.
@@ -53,25 +53,25 @@ pub fn new_confirm_homescreen(
     title: TString<'static>,
     image: CachedJpeg,
 ) -> Result<SwipeFlow, error::Error> {
-    let content_homescreen = Frame::left_aligned(title, SwipeContent::new(image))
-        .with_menu_button()
-        .with_swipeup_footer(Some(TR::buttons__change.into()))
-        .map_to_button_msg()
-        // Homescreen + Tap to confirm
-        .with_pages(|_| 2);
+    let content_homescreen = Frame::new(
+        Header::left_aligned(title).with_menu_button(),
+        SwipeContent::new(image),
+    )
+    .with_swipeup_footer(Some(TR::buttons__change.into()))
+    .map_to_button_msg()
+    // Homescreen + Tap to confirm
+    .with_pages(|_| 2);
 
-    let content_menu = Frame::left_aligned(
-        TString::empty(),
+    let content_menu = Frame::new(
+        Header::left_aligned(TString::empty()).with_cancel_button(),
         VerticalMenu::empty().cancel_item(TR::buttons__cancel.into()),
     )
-    .with_cancel_button()
     .map(super::util::map_to_choice);
 
-    let content_confirm = Frame::left_aligned(
-        TR::homescreen__title_set.into(),
+    let content_confirm = Frame::new(
+        Header::left_aligned(TR::homescreen__title_set.into()).with_menu_button(),
         SwipeContent::new(PromptScreen::new_tap_to_confirm()),
     )
-    .with_menu_button()
     .with_footer(TR::instructions__tap_to_confirm.into(), None)
     .with_swipe(Direction::Down, SwipeSettings::Default)
     .map(super::util::map_to_confirm);

--- a/core/embed/rust/src/ui/layout_delizia/flow/confirm_reset.rs
+++ b/core/embed/rust/src/ui/layout_delizia/flow/confirm_reset.rs
@@ -18,7 +18,7 @@ use crate::{
 };
 
 use super::super::{
-    component::{Frame, PromptScreen, SwipeContent, VerticalMenu},
+    component::{Frame, Header, PromptScreen, SwipeContent, VerticalMenu},
     theme,
 };
 
@@ -106,17 +106,18 @@ pub fn new_confirm_reset(recovery: bool) -> Result<SwipeFlow, error::Error> {
         Paragraph::new(&theme::TEXT_SUB_GREY_LIGHT, TR::reset__tos_link),
     ])
     .into_paragraphs();
-    let content_intro = Frame::left_aligned(title, SwipeContent::new(paragraphs))
-        .with_menu_button()
-        .with_swipeup_footer(None)
-        .map_to_button_msg()
-        .one_button_request(br);
+    let content_intro = Frame::new(
+        Header::left_aligned(title).with_menu_button(),
+        SwipeContent::new(paragraphs),
+    )
+    .with_swipeup_footer(None)
+    .map_to_button_msg()
+    .one_button_request(br);
 
-    let content_menu = Frame::left_aligned(
-        TString::empty(),
+    let content_menu = Frame::new(
+        Header::left_aligned(TString::empty()).with_cancel_button(),
         VerticalMenu::empty().cancel_item(cancel_btn_text),
     )
-    .with_cancel_button()
     .map(super::util::map_to_choice);
 
     let res = if recovery {
@@ -125,11 +126,10 @@ pub fn new_confirm_reset(recovery: bool) -> Result<SwipeFlow, error::Error> {
             .add_page(&ConfirmResetRecover::Menu, content_menu)?;
         res
     } else {
-        let content_confirm = Frame::left_aligned(
-            TR::reset__title_create_wallet.into(),
+        let content_confirm = Frame::new(
+            Header::left_aligned(TR::reset__title_create_wallet.into()).with_menu_button(),
             SwipeContent::new(PromptScreen::new_hold_to_confirm()),
         )
-        .with_menu_button()
         .with_footer(TR::instructions__hold_to_confirm.into(), None)
         .with_swipe(Direction::Down, SwipeSettings::Default)
         .map(super::util::map_to_confirm)

--- a/core/embed/rust/src/ui/layout_delizia/flow/confirm_set_new_code.rs
+++ b/core/embed/rust/src/ui/layout_delizia/flow/confirm_set_new_code.rs
@@ -16,7 +16,7 @@ use crate::{
 };
 
 use super::super::{
-    component::{Frame, PromptScreen, SwipeContent, VerticalMenu},
+    component::{Frame, Header, PromptScreen, SwipeContent, VerticalMenu},
     theme,
 };
 
@@ -73,16 +73,17 @@ pub fn new_set_new_code(is_wipe_code: bool) -> Result<SwipeFlow, error::Error> {
         )
     };
     let paragraphs = Paragraphs::new(Paragraph::new(&theme::TEXT_MAIN_GREY_LIGHT, description));
-    let content_intro = Frame::left_aligned(title.into(), SwipeContent::new(paragraphs))
-        .with_menu_button()
-        .with_swipeup_footer(None)
-        .map_to_button_msg();
+    let content_intro = Frame::new(
+        Header::left_aligned(title.into()).with_menu_button(),
+        SwipeContent::new(paragraphs),
+    )
+    .with_swipeup_footer(None)
+    .map_to_button_msg();
 
-    let content_menu = Frame::left_aligned(
-        "".into(),
+    let content_menu = Frame::new(
+        Header::left_aligned("".into()).with_cancel_button(),
         VerticalMenu::empty().cancel_item(cancel_menu_item.into()),
     )
-    .with_cancel_button()
     .map(super::util::map_to_choice);
 
     let paragraphs_cancel_intro = ParagraphVecShort::from_iter(if is_wipe_code {
@@ -97,21 +98,21 @@ pub fn new_set_new_code(is_wipe_code: bool) -> Result<SwipeFlow, error::Error> {
         ]
     })
     .into_paragraphs();
-    let content_cancel_intro =
-        Frame::left_aligned(cancel.into(), SwipeContent::new(paragraphs_cancel_intro))
-            .with_cancel_button()
-            .with_swipeup_footer(Some(if is_wipe_code {
-                TR::buttons__cancel.into()
-            } else {
-                TR::pin__cancel_description.into()
-            }))
-            .map_to_button_msg();
+    let content_cancel_intro = Frame::new(
+        Header::left_aligned(cancel.into()).with_cancel_button(),
+        SwipeContent::new(paragraphs_cancel_intro),
+    )
+    .with_swipeup_footer(Some(if is_wipe_code {
+        TR::buttons__cancel.into()
+    } else {
+        TR::pin__cancel_description.into()
+    }))
+    .map_to_button_msg();
 
-    let content_cancel_confirm = Frame::left_aligned(
-        cancel.into(),
+    let content_cancel_confirm = Frame::new(
+        Header::left_aligned(cancel.into()).with_cancel_button(),
         SwipeContent::new(PromptScreen::new_tap_to_cancel()),
     )
-    .with_cancel_button()
     .with_footer(TR::instructions__tap_to_confirm.into(), None)
     .with_swipe(Direction::Down, SwipeSettings::Default)
     .map(super::util::map_to_confirm);

--- a/core/embed/rust/src/ui/layout_delizia/flow/confirm_summary.rs
+++ b/core/embed/rust/src/ui/layout_delizia/flow/confirm_summary.rs
@@ -16,7 +16,9 @@ use crate::{
 
 use super::{
     super::{
-        component::{Frame, PromptScreen, SwipeContent, VerticalMenu, VerticalMenuChoiceMsg},
+        component::{
+            Frame, Header, PromptScreen, SwipeContent, VerticalMenu, VerticalMenuChoiceMsg,
+        },
         theme,
     },
     util::{dummy_page, ShowInfoParams},
@@ -86,12 +88,11 @@ pub fn new_confirm_summary(
         .with_pages(|summary_pages| summary_pages + 1);
 
     // Hold to confirm
-    let content_hold = Frame::left_aligned(
-        TR::send__sign_transaction.into(),
+    let content_hold = Frame::new(
+        Header::left_aligned(TR::send__sign_transaction.into()).with_menu_button(),
         SwipeContent::new(PromptScreen::new_hold_to_confirm()),
     )
     .with_flow_menu()
-    .with_menu_button()
     .with_footer(TR::instructions__hold_to_sign.into(), None)
     .with_swipe(Direction::Down, SwipeSettings::Default)
     .map(super::util::map_to_confirm);
@@ -124,21 +125,22 @@ pub fn new_confirm_summary(
     }
     menu = menu.cancel_item(verb_cancel.unwrap_or(TR::send__cancel_sign.into()));
     unwrap!(menu_items.push(MENU_ITEM_CANCEL));
-    let content_menu = Frame::left_aligned(TString::empty(), menu)
-        .with_cancel_button()
-        .map(move |msg| match msg {
-            VerticalMenuChoiceMsg::Selected(i) => {
-                let selected_item = menu_items[i];
-                Some(FlowMsg::Choice(selected_item))
-            }
-        });
+    let content_menu = Frame::new(
+        Header::left_aligned(TString::empty()).with_cancel_button(),
+        menu,
+    )
+    .map(move |msg| match msg {
+        VerticalMenuChoiceMsg::Selected(i) => {
+            let selected_item = menu_items[i];
+            Some(FlowMsg::Choice(selected_item))
+        }
+    });
 
     // CancelTap
-    let content_cancel_tap = Frame::left_aligned(
-        TR::send__cancel_sign.into(),
+    let content_cancel_tap = Frame::new(
+        Header::left_aligned(TR::send__cancel_sign.into()).with_cancel_button(),
         PromptScreen::new_tap_to_cancel(),
     )
-    .with_cancel_button()
     .with_footer(TR::instructions__tap_to_confirm.into(), None)
     .map(super::util::map_to_confirm);
 

--- a/core/embed/rust/src/ui/layout_delizia/flow/continue_recovery_homepage.rs
+++ b/core/embed/rust/src/ui/layout_delizia/flow/continue_recovery_homepage.rs
@@ -22,7 +22,7 @@ use crate::{
 };
 
 use super::super::{
-    component::{Footer, Frame, PromptScreen, SwipeContent, VerticalMenu},
+    component::{Footer, Frame, Header, PromptScreen, SwipeContent, VerticalMenu},
     theme,
 };
 
@@ -175,48 +175,49 @@ pub fn new_continue_recovery_homepage(
         Some(TR::instructions__enter_next_share.into())
     };
 
-    let content_main =
-        Frame::left_aligned(title.into(), SwipeContent::new(pars_main.into_paragraphs()))
+    let content_main = Frame::new(
+        Header::left_aligned(title.into())
             .with_subtitle(TR::words__instructions.into())
-            .with_menu_button()
-            .with_swipeup_footer(footer_description)
-            .map_to_button_msg()
-            .repeated_button_request(ButtonRequest::new(
-                ButtonRequestCode::RecoveryHomepage,
-                "recovery".into(),
-            ))
-            .with_pages(|_| 1);
+            .with_menu_button(),
+        SwipeContent::new(pars_main.into_paragraphs()),
+    )
+    .with_swipeup_footer(footer_description)
+    .map_to_button_msg()
+    .repeated_button_request(ButtonRequest::new(
+        ButtonRequestCode::RecoveryHomepage,
+        "recovery".into(),
+    ))
+    .with_pages(|_| 1);
 
     let paragraphs_cancel = ParagraphVecShort::from_iter([
         Paragraph::new(&theme::TEXT_MAIN_GREY_LIGHT, cancel_intro).with_bottom_padding(17),
         Paragraph::new(&theme::TEXT_WARNING, TR::recovery__progress_will_be_lost),
     ])
     .into_paragraphs();
-    let content_cancel_intro =
-        Frame::left_aligned(cancel_title.into(), SwipeContent::new(paragraphs_cancel))
-            .with_cancel_button()
-            .with_swipeup_footer(Some(TR::words__continue_anyway_question.into()))
-            .map_to_button_msg()
-            .repeated_button_request(ButtonRequest::new(
-                ButtonRequestCode::ProtectCall,
-                "abort_recovery".into(),
-            ));
+    let content_cancel_intro = Frame::new(
+        Header::left_aligned(cancel_title.into()).with_cancel_button(),
+        SwipeContent::new(paragraphs_cancel),
+    )
+    .with_swipeup_footer(Some(TR::words__continue_anyway_question.into()))
+    .map_to_button_msg()
+    .repeated_button_request(ButtonRequest::new(
+        ButtonRequestCode::ProtectCall,
+        "abort_recovery".into(),
+    ));
 
-    let content_cancel_confirm = Frame::left_aligned(
-        cancel_title.into(),
+    let content_cancel_confirm = Frame::new(
+        Header::left_aligned(cancel_title.into()).with_cancel_button(),
         SwipeContent::new(PromptScreen::new_tap_to_cancel()),
     )
-    .with_cancel_button()
     .with_footer(TR::instructions__tap_to_confirm.into(), None)
     .with_swipe(Direction::Down, SwipeSettings::Default)
     .map(super::util::map_to_confirm);
 
     let res = if show_instructions {
-        let content_menu = Frame::left_aligned(
-            TString::empty(),
+        let content_menu = Frame::new(
+            Header::left_aligned(TString::empty()).with_cancel_button(),
             VerticalMenu::empty().cancel_item(cancel_btn.into()),
         )
-        .with_cancel_button()
         .map(super::util::map_to_choice);
 
         let mut res = SwipeFlow::new(&ContinueRecoveryBeforeShares::Main)?;
@@ -224,8 +225,8 @@ pub fn new_continue_recovery_homepage(
             .add_page(&ContinueRecoveryBeforeShares::Menu, content_menu)?;
         res
     } else if pages.is_some() {
-        let content_menu = Frame::left_aligned(
-            TString::empty(),
+        let content_menu = Frame::new(
+            Header::left_aligned(TString::empty()).with_cancel_button(),
             VerticalMenu::empty()
                 .item(
                     theme::ICON_CHEVRON_RIGHT,
@@ -233,7 +234,6 @@ pub fn new_continue_recovery_homepage(
                 )
                 .cancel_item(cancel_btn.into()),
         )
-        .with_cancel_button()
         .map(super::util::map_to_choice);
 
         let (footer_instruction, footer_description) = (
@@ -241,11 +241,10 @@ pub fn new_continue_recovery_homepage(
             TR::recovery__more_shares_needed.into(),
         );
         let n_remaining_shares = pages.as_ref().unwrap().len() as u16 / 2;
-        let content_remaining_shares = Frame::left_aligned(
-            TR::recovery__title_remaining_shares.into(),
+        let content_remaining_shares = Frame::new(
+            Header::left_aligned(TR::recovery__title_remaining_shares.into()).with_cancel_button(),
             SwipeContent::new(SwipePage::vertical(pages.unwrap().into_paragraphs())),
         )
-        .with_cancel_button()
         .with_footer_page_hint(
             footer_description,
             TString::empty(),
@@ -279,11 +278,10 @@ pub fn new_continue_recovery_homepage(
             )?;
         res
     } else {
-        let content_menu = Frame::left_aligned(
-            TString::empty(),
+        let content_menu = Frame::new(
+            Header::left_aligned(TString::empty()).with_cancel_button(),
             VerticalMenu::empty().cancel_item(cancel_btn.into()),
         )
-        .with_cancel_button()
         .map(super::util::map_to_choice);
 
         let mut res = SwipeFlow::new(&ContinueRecoveryBetweenShares::Main)?;

--- a/core/embed/rust/src/ui/layout_delizia/flow/prompt_backup.rs
+++ b/core/embed/rust/src/ui/layout_delizia/flow/prompt_backup.rs
@@ -16,7 +16,7 @@ use crate::{
 };
 
 use super::super::{
-    component::{Frame, PromptScreen, SwipeContent, VerticalMenu},
+    component::{Frame, Header, PromptScreen, SwipeContent, VerticalMenu},
     theme,
 };
 
@@ -61,16 +61,17 @@ pub fn new_prompt_backup() -> Result<SwipeFlow, error::Error> {
     let text_intro: TString = TR::backup__it_should_be_backed_up.into();
 
     let paragraphs = Paragraphs::new(Paragraph::new(&theme::TEXT_MAIN_GREY_LIGHT, text_intro));
-    let content_intro = Frame::left_aligned(title, SwipeContent::new(paragraphs))
-        .with_menu_button()
-        .with_swipeup_footer(None)
-        .map_to_button_msg();
+    let content_intro = Frame::new(
+        Header::left_aligned(title).with_menu_button(),
+        SwipeContent::new(paragraphs),
+    )
+    .with_swipeup_footer(None)
+    .map_to_button_msg();
 
-    let content_menu = Frame::left_aligned(
-        "".into(),
+    let content_menu = Frame::new(
+        Header::left_aligned("".into()).with_cancel_button(),
         VerticalMenu::empty().cancel_item(TR::backup__title_skip.into()),
     )
-    .with_cancel_button()
     .map(super::util::map_to_choice);
 
     let paragraphs_skip_intro = ParagraphVecShort::from_iter([
@@ -81,20 +82,18 @@ pub fn new_prompt_backup() -> Result<SwipeFlow, error::Error> {
         ),
     ])
     .into_paragraphs();
-    let content_skip_intro = Frame::left_aligned(
-        TR::backup__title_skip.into(),
+    let content_skip_intro = Frame::new(
+        Header::left_aligned(TR::backup__title_skip.into()).with_cancel_button(),
         SwipeContent::new(paragraphs_skip_intro),
     )
-    .with_cancel_button()
     .with_swipeup_footer(Some(TR::words__continue_anyway_question.into()))
     .with_swipe(Direction::Up, SwipeSettings::Default)
     .map_to_button_msg();
 
-    let content_skip_confirm = Frame::left_aligned(
-        TR::backup__title_skip.into(),
+    let content_skip_confirm = Frame::new(
+        Header::left_aligned(TR::backup__title_skip.into()).with_cancel_button(),
         SwipeContent::new(PromptScreen::new_tap_to_cancel()),
     )
-    .with_cancel_button()
     .with_footer(TR::instructions__tap_to_confirm.into(), None)
     .with_swipe(Direction::Down, SwipeSettings::Default)
     .map(super::util::map_to_confirm);

--- a/core/embed/rust/src/ui/layout_delizia/flow/receive.rs
+++ b/core/embed/rust/src/ui/layout_delizia/flow/receive.rs
@@ -21,7 +21,7 @@ use crate::{
 use heapless::Vec;
 
 use super::super::{
-    component::{AddressDetails, Frame, PromptScreen, SwipeContent, VerticalMenu},
+    component::{AddressDetails, Frame, Header, PromptScreen, SwipeContent, VerticalMenu},
     theme,
 };
 
@@ -109,26 +109,29 @@ pub fn new_receive(
         extra_font: &theme::TEXT_DEMIBOLD,
     }
     .into_paragraphs();
-    let content_address =
-        Frame::left_aligned(title, SwipeContent::new(SwipePage::vertical(paragraphs)))
-            .with_menu_button()
-            .with_swipeup_footer(None)
-            .with_vertical_pages()
-            .map_to_button_msg()
-            .one_button_request(ButtonRequest::from_num(br_code, br_name))
-            // Count tap-to-confirm screen towards page count
-            .with_pages(|address_pages| address_pages + 1);
+    let content_address = Frame::new(
+        Header::left_aligned(title).with_menu_button(),
+        SwipeContent::new(SwipePage::vertical(paragraphs)),
+    )
+    .with_swipeup_footer(None)
+    .with_vertical_pages()
+    .map_to_button_msg()
+    .one_button_request(ButtonRequest::from_num(br_code, br_name))
+    // Count tap-to-confirm screen towards page count
+    .with_pages(|address_pages| address_pages + 1);
 
     // Tap
-    let content_tap =
-        Frame::left_aligned(title, SwipeContent::new(PromptScreen::new_tap_to_confirm()))
-            .with_footer(TR::instructions__tap_to_confirm.into(), None)
-            .with_swipe(Direction::Down, SwipeSettings::Default)
-            .map(super::util::map_to_confirm);
+    let content_tap = Frame::new(
+        Header::left_aligned(title),
+        SwipeContent::new(PromptScreen::new_tap_to_confirm()),
+    )
+    .with_footer(TR::instructions__tap_to_confirm.into(), None)
+    .with_swipe(Direction::Down, SwipeSettings::Default)
+    .map(super::util::map_to_confirm);
 
     // Menu
-    let content_menu = Frame::left_aligned(
-        "".into(),
+    let content_menu = Frame::new(
+        Header::left_aligned("".into()).with_cancel_button(),
         VerticalMenu::empty()
             .item(theme::ICON_QR_CODE, TR::address__qr_code.into())
             .item(
@@ -137,16 +140,14 @@ pub fn new_receive(
             )
             .cancel_item(cancel_title.into()),
     )
-    .with_cancel_button()
     .map(super::util::map_to_choice);
 
     // QrCode
-    let content_qr = Frame::left_aligned(
-        title,
+    let content_qr = Frame::new(
+        Header::left_aligned(title).with_cancel_button(),
         qr.map(|s| Qr::new(s, case_sensitive))?
             .with_border(QR_BORDER),
     )
-    .with_cancel_button()
     .map_to_button_msg();
 
     // AccountInfo
@@ -159,24 +160,24 @@ pub fn new_receive(
     let content_account = ad.map(|_| Some(FlowMsg::Cancelled));
 
     // Cancel
-    let content_cancel_info = Frame::left_aligned(
-        cancel_title.into(),
+    let content_cancel_info = Frame::new(
+        Header::left_aligned(cancel_title.into()).with_cancel_button(),
         SwipeContent::new(Paragraphs::new(Paragraph::new(
             &theme::TEXT_MAIN_GREY_LIGHT,
             cancel_content,
         ))),
     )
-    .with_cancel_button()
     .with_swipeup_footer(None)
     .map_to_button_msg();
 
     // CancelTap
-    let content_cancel_tap =
-        Frame::left_aligned(cancel_title.into(), PromptScreen::new_tap_to_cancel())
-            .with_cancel_button()
-            .with_footer(TR::instructions__tap_to_confirm.into(), None)
-            .with_swipe(Direction::Down, SwipeSettings::Default)
-            .map(super::util::map_to_confirm);
+    let content_cancel_tap = Frame::new(
+        Header::left_aligned(cancel_title.into()).with_cancel_button(),
+        PromptScreen::new_tap_to_cancel(),
+    )
+    .with_footer(TR::instructions__tap_to_confirm.into(), None)
+    .with_swipe(Direction::Down, SwipeSettings::Default)
+    .map(super::util::map_to_confirm);
 
     let mut res = SwipeFlow::new(&Receive::Content)?;
     res.add_page(&Receive::Content, content_address)?

--- a/core/embed/rust/src/ui/layout_delizia/flow/request_number.rs
+++ b/core/embed/rust/src/ui/layout_delizia/flow/request_number.rs
@@ -15,7 +15,7 @@ use core::sync::atomic::{AtomicU16, Ordering};
 
 use super::super::{
     component::{
-        Frame, NumberInputDialog, NumberInputDialogMsg, SwipeContent, UpdatableMoreInfo,
+        Frame, Header, NumberInputDialog, NumberInputDialogMsg, SwipeContent, UpdatableMoreInfo,
         VerticalMenu,
     },
     theme,
@@ -79,27 +79,30 @@ pub fn new_request_number(
         count as u16,
         description,
     )?;
-    let content_number_input = Frame::left_aligned(title, SwipeContent::new(number_input_dialog))
-        .with_menu_button()
-        .with_swipeup_footer(None)
-        .map(|msg| match msg {
-            NumberInputDialogMsg::Changed(n) => {
-                NUM_DISPLAYED.store(n, Ordering::Relaxed);
-                None
-            }
-        });
+    let content_number_input = Frame::new(
+        Header::left_aligned(title).with_menu_button(),
+        SwipeContent::new(number_input_dialog),
+    )
+    .with_swipeup_footer(None)
+    .map(|msg| match msg {
+        NumberInputDialogMsg::Changed(n) => {
+            NUM_DISPLAYED.store(n, Ordering::Relaxed);
+            None
+        }
+    });
 
-    let content_menu = Frame::left_aligned(
-        TString::empty(),
+    let content_menu = Frame::new(
+        Header::left_aligned(TString::empty()).with_cancel_button(),
         VerticalMenu::empty().item(theme::ICON_CHEVRON_RIGHT, TR::buttons__more_info.into()),
     )
-    .with_cancel_button()
     .map(super::util::map_to_choice);
 
     let updatable_info = UpdatableMoreInfo::new(info_closure);
-    let content_info = Frame::left_aligned(TString::empty(), SwipeContent::new(updatable_info))
-        .with_cancel_button()
-        .map_to_button_msg();
+    let content_info = Frame::new(
+        Header::left_aligned(TString::empty()).with_cancel_button(),
+        SwipeContent::new(updatable_info),
+    )
+    .map_to_button_msg();
 
     let mut res = SwipeFlow::new(&RequestNumber::Number)?;
     res.add_page(&RequestNumber::Number, content_number_input)?

--- a/core/embed/rust/src/ui/layout_delizia/flow/request_passphrase.rs
+++ b/core/embed/rust/src/ui/layout_delizia/flow/request_passphrase.rs
@@ -11,7 +11,9 @@ use crate::{
     },
 };
 
-use super::super::component::{Frame, PassphraseKeyboard, PassphraseKeyboardMsg, PromptScreen};
+use super::super::component::{
+    Frame, Header, PassphraseKeyboard, PassphraseKeyboardMsg, PromptScreen,
+};
 
 #[derive(Copy, Clone, PartialEq, Eq)]
 pub enum RequestPassphrase {
@@ -53,8 +55,11 @@ pub fn new_request_passphrase(
     prompt_empty: TString<'static>,
     max_len: usize,
 ) -> Result<SwipeFlow, error::Error> {
-    let content_confirm_empty = Frame::left_aligned(prompt_empty, PromptScreen::new_yes_or_no())
-        .map(super::util::map_to_prompt);
+    let content_confirm_empty = Frame::new(
+        Header::left_aligned(prompt_empty),
+        PromptScreen::new_yes_or_no(),
+    )
+    .map(super::util::map_to_prompt);
 
     let content_keypad = PassphraseKeyboard::new(prompt, max_len).map(|msg| match msg {
         PassphraseKeyboardMsg::Confirmed(s) => Some(FlowMsg::Text(s)),

--- a/core/embed/rust/src/ui/layout_delizia/flow/set_brightness.rs
+++ b/core/embed/rust/src/ui/layout_delizia/flow/set_brightness.rs
@@ -18,7 +18,7 @@ use crate::{
 use super::super::{
     component::{
         number_input_slider::{NumberInputSliderDialog, NumberInputSliderDialogMsg},
-        Footer, Frame,
+        Footer, Frame, Header,
     },
     theme,
 };
@@ -69,16 +69,16 @@ fn footer_update_fn(
 }
 
 pub fn new_set_brightness(brightness: u8) -> Result<SwipeFlow, Error> {
-    let content_slider = Frame::left_aligned(
-        TR::brightness__title.into(),
+    let content_slider = Frame::new(
+        Header::left_aligned(TR::brightness__title.into())
+            .with_subtitle(TR::homescreen__settings_subtitle.into())
+            .with_cancel_button(),
         NumberInputSliderDialog::new(
             theme::backlight::get_backlight_min().into(),
             theme::backlight::get_backlight_max().into(),
             brightness.into(),
         ),
     )
-    .with_subtitle(TR::homescreen__settings_subtitle.into())
-    .with_cancel_button()
     .with_swipe(Direction::Up, SwipeSettings::Default)
     .with_footer(
         TR::instructions__swipe_horizontally.into(),

--- a/core/embed/rust/src/ui/layout_delizia/flow/show_danger.rs
+++ b/core/embed/rust/src/ui/layout_delizia/flow/show_danger.rs
@@ -13,7 +13,7 @@ use crate::{
 };
 
 use super::super::{
-    component::{Frame, StatusScreen, SwipeContent, VerticalMenu},
+    component::{Frame, Header, StatusScreen, SwipeContent, VerticalMenu},
     theme,
 };
 
@@ -68,30 +68,30 @@ pub fn new_show_danger(
         Paragraph::new(&theme::TEXT_MAIN_GREY_EXTRA_LIGHT, value).with_top_padding(EXTRA_PADDING),
     ]
     .into_paragraphs();
-    let content_message = Frame::left_aligned(title, SwipeContent::new(paragraphs))
-        .with_menu_button()
-        .with_tap_footer(Some(verb_cancel))
-        .with_danger()
-        .map_to_button_msg();
+    let content_message = Frame::new(
+        Header::left_aligned(title).with_menu_button().with_danger(),
+        SwipeContent::new(paragraphs),
+    )
+    .with_tap_footer(Some(verb_cancel))
+    .map_to_button_msg();
     // .one_button_request(ButtonRequestCode::Warning, br_name);
 
     // Menu
-    let content_menu = Frame::left_aligned(
-        "".into(),
+    let content_menu = Frame::new(
+        Header::left_aligned("".into()).with_cancel_button(),
         VerticalMenu::empty()
             .item(theme::ICON_CANCEL, verb_cancel)
             .danger_item(theme::ICON_CHEVRON_RIGHT, confirm),
     )
-    .with_cancel_button()
     .map(super::util::map_to_choice);
 
     // Cancelled
-    let content_cancelled = Frame::left_aligned(
-        TR::words__title_done.into(),
+    let content_cancelled = Frame::new(
+        Header::left_aligned(TR::words__title_done.into())
+            .with_result_icon(theme::ICON_BULLET_CHECKMARK, theme::GREY_DARK),
         StatusScreen::new_neutral_timeout(done_title),
     )
     .with_footer(TR::instructions__continue_in_app.into(), None)
-    .with_result_icon(theme::ICON_BULLET_CHECKMARK, theme::GREY_DARK)
     .map(|_| Some(FlowMsg::Cancelled));
 
     let mut res = SwipeFlow::new(&ShowDanger::Message)?;

--- a/core/embed/rust/src/ui/layout_delizia/flow/show_share_words.rs
+++ b/core/embed/rust/src/ui/layout_delizia/flow/show_share_words.rs
@@ -88,43 +88,41 @@ pub fn new_show_share_words(
     let paragraphs_spacing = 8;
     let title = TR::reset__recovery_wallet_backup_title.into();
 
-    let content_instruction = Frame::left_aligned(
-        title,
+    let content_instruction = Frame::new(
+        Header::left_aligned(title).with_subtitle(TR::words__instructions.into()),
         SwipeContent::new(
             instructions_paragraphs
                 .into_paragraphs()
                 .with_spacing(paragraphs_spacing),
         ),
     )
-    .with_subtitle(TR::words__instructions.into())
     .with_swipeup_footer(text_footer)
     .map_to_button_msg()
     .one_button_request(ButtonRequestCode::ResetDevice.with_name("share_words"))
     .with_pages(move |_| nwords + 2);
 
-    let content_words = Frame::left_aligned(
-        title,
+    let content_words = Frame::new(
+        Header::left_aligned(title).with_subtitle(subtitle),
         InternallySwipableContent::new(ShareWords::new(share_words_vec, subtitle)),
     )
     .with_swipe(Direction::Up, SwipeSettings::Default)
     .with_swipe(Direction::Down, SwipeSettings::Default)
     .with_vertical_pages()
-    .with_subtitle(subtitle)
     .register_header_update_fn(header_updating_func)
     .with_footer_counter(TR::instructions__tap_to_continue.into())
     .register_footer_update_fn(footer_updating_func)
     .map_to_button_msg();
 
-    let content_confirm = Frame::left_aligned(
-        text_confirm,
+    let content_confirm = Frame::new(
+        Header::left_aligned(text_confirm),
         SwipeContent::new(PromptScreen::new_hold_to_confirm()),
     )
     .with_footer(TR::instructions__hold_to_confirm.into(), None)
     .with_swipe(Direction::Down, SwipeSettings::Default)
     .map(|_| Some(FlowMsg::Confirmed));
 
-    let content_check_backup_intro = Frame::left_aligned(
-        TR::reset__check_wallet_backup_title.into(),
+    let content_check_backup_intro = Frame::new(
+        Header::left_aligned(TR::reset__check_wallet_backup_title.into()),
         SwipeContent::new(Paragraphs::new(Paragraph::new(
             &theme::TEXT_MAIN_GREY_LIGHT,
             text_check,

--- a/core/embed/rust/src/ui/layout_delizia/flow/show_tutorial.rs
+++ b/core/embed/rust/src/ui/layout_delizia/flow/show_tutorial.rs
@@ -15,7 +15,7 @@ use crate::{
 };
 
 use super::super::{
-    component::{Frame, PromptScreen, SwipeContent, VerticalMenu},
+    component::{Frame, Header, PromptScreen, SwipeContent, VerticalMenu},
     theme,
 };
 
@@ -69,15 +69,15 @@ impl FlowController for ShowTutorial {
 }
 
 pub fn new_show_tutorial() -> Result<SwipeFlow, error::Error> {
-    let content_step_welcome = Frame::left_aligned(
-        TR::tutorial__welcome_safe5.into(),
+    let content_step_welcome = Frame::new(
+        Header::left_aligned(TR::tutorial__welcome_safe5.into()),
         SwipeContent::new(PromptScreen::new_tap_to_start()),
     )
     .with_footer(TR::instructions__tap_to_continue.into(), None)
     .map(super::util::map_to_confirm);
 
-    let content_step_begin = Frame::left_aligned(
-        TR::tutorial__title_lets_begin.into(),
+    let content_step_begin = Frame::new(
+        Header::left_aligned(TR::tutorial__title_lets_begin.into()),
         SwipeContent::new(Paragraphs::new(Paragraph::new(
             &theme::TEXT_MAIN_GREY_LIGHT,
             TR::tutorial__lets_begin,
@@ -86,8 +86,8 @@ pub fn new_show_tutorial() -> Result<SwipeFlow, error::Error> {
     .with_swipeup_footer(None)
     .map_to_button_msg();
 
-    let content_step_navigation = Frame::left_aligned(
-        TR::tutorial__title_easy_navigation.into(),
+    let content_step_navigation = Frame::new(
+        Header::left_aligned(TR::tutorial__title_easy_navigation.into()),
         SwipeContent::new(Paragraphs::new(Paragraph::new(
             &theme::TEXT_MAIN_GREY_LIGHT,
             TR::tutorial__swipe_up_and_down,
@@ -97,29 +97,29 @@ pub fn new_show_tutorial() -> Result<SwipeFlow, error::Error> {
     .with_swipe(Direction::Down, SwipeSettings::Default)
     .map_to_button_msg();
 
-    let content_step_menu = Frame::left_aligned(
-        TR::tutorial__title_handy_menu.into(),
+    let content_step_menu = Frame::new(
+        Header::left_aligned(TR::tutorial__title_handy_menu.into())
+            .with_menu_button()
+            .button_styled(theme::button_warning_low()),
         SwipeContent::new(Paragraphs::new(Paragraph::new(
             &theme::TEXT_MAIN_GREY_LIGHT,
             TR::tutorial__menu,
         ))),
     )
-    .with_menu_button()
-    .button_styled(theme::button_warning_low())
     .with_swipeup_footer(None)
     .with_swipe(Direction::Down, SwipeSettings::Default)
     .map_to_button_msg();
 
-    let content_step_hold = Frame::left_aligned(
-        TR::tutorial__title_hold.into(),
+    let content_step_hold = Frame::new(
+        Header::left_aligned(TR::tutorial__title_hold.into()),
         SwipeContent::new(PromptScreen::new_hold_to_confirm()),
     )
     .with_footer(TR::instructions__hold_to_exit_tutorial.into(), None)
     .with_swipe(Direction::Down, SwipeSettings::Default)
     .map(super::util::map_to_confirm);
 
-    let content_step_done = Frame::left_aligned(
-        TR::tutorial__title_well_done.into(),
+    let content_step_done = Frame::new(
+        Header::left_aligned(TR::tutorial__title_well_done.into()),
         SwipeContent::new(Paragraphs::new(Paragraph::new(
             &theme::TEXT_MAIN_GREY_LIGHT,
             TR::tutorial__ready_to_use_safe5,
@@ -128,28 +128,26 @@ pub fn new_show_tutorial() -> Result<SwipeFlow, error::Error> {
     .with_swipeup_footer(None)
     .map_to_button_msg();
 
-    let content_menu = Frame::left_aligned(
-        "".into(),
+    let content_menu = Frame::new(
+        Header::left_aligned("".into()).with_cancel_button(),
         VerticalMenu::empty()
             .item(theme::ICON_CHEVRON_RIGHT, TR::tutorial__did_you_know.into())
             .item(theme::ICON_REBOOT, TR::tutorial__restart_tutorial.into())
             .cancel_item(TR::tutorial__exit.into()),
     )
-    .with_cancel_button()
     .map(super::util::map_to_choice);
 
-    let content_did_you_know = Frame::left_aligned(
-        "".into(),
+    let content_did_you_know = Frame::new(
+        Header::left_aligned("".into()).with_cancel_button(),
         SwipeContent::new(Paragraphs::new(Paragraph::new(
             &theme::TEXT_MAIN_GREY_LIGHT,
             TR::tutorial__first_wallet,
         ))),
     )
-    .with_cancel_button()
     .map_to_button_msg();
 
-    let content_hold_to_exit = Frame::left_aligned(
-        TR::tutorial__title_hold.into(),
+    let content_hold_to_exit = Frame::new(
+        Header::left_aligned(TR::tutorial__title_hold.into()),
         SwipeContent::new(PromptScreen::new_hold_to_confirm_danger()),
     )
     .with_footer(TR::instructions__hold_to_exit_tutorial.into(), None)

--- a/core/embed/rust/src/ui/layout_delizia/flow/util.rs
+++ b/core/embed/rust/src/ui/layout_delizia/flow/util.rs
@@ -24,7 +24,7 @@ use heapless::Vec;
 
 use super::{
     super::{
-        component::{Frame, PromptMsg, SwipeContent, VerticalMenu, VerticalMenuChoiceMsg},
+        component::{Frame, Header, PromptMsg, SwipeContent, VerticalMenu, VerticalMenuChoiceMsg},
         flow, theme,
     },
     ConfirmActionExtra, ConfirmActionMenuStrings, ConfirmActionOptions, ConfirmActionStrings,
@@ -211,17 +211,18 @@ impl ConfirmValue {
         }
         .into_paragraphs();
 
-        let page = SwipeContent::new(SwipePage::vertical(paragraphs));
-        let mut frame = Frame::left_aligned(self.title, page);
+        let mut header = Header::left_aligned(self.title);
         if let Some(subtitle) = self.subtitle {
-            frame = frame.with_subtitle(subtitle);
+            header = header.with_subtitle(subtitle);
         }
         if self.menu_button {
-            frame = frame.with_menu_button();
+            header = header.with_menu_button();
         }
         if self.cancel_button {
-            frame = frame.with_cancel_button();
+            header = header.with_cancel_button();
         }
+        let page = SwipeContent::new(SwipePage::vertical(paragraphs));
+        let mut frame = Frame::new(header, page);
         if let Some(instruction) = self.footer_instruction {
             frame = frame.with_footer(instruction, self.footer_description);
         }
@@ -406,19 +407,22 @@ impl ShowInfoParams {
             paragraphs.add(Paragraph::new(&theme::TEXT_MONO_GREY_LIGHT, item.1));
         }
 
-        let mut frame = Frame::left_aligned(
-            self.title,
-            SwipeContent::new(SwipePage::vertical(paragraphs.into_paragraphs())),
-        );
+        let mut header = Header::left_aligned(self.title);
         if let Some(subtitle) = self.subtitle {
-            frame = frame.with_subtitle(subtitle);
+            header = header.with_subtitle(subtitle);
         }
         if self.cancel_button {
-            frame = frame
-                .with_cancel_button()
-                .with_swipe(Direction::Right, SwipeSettings::Immediate);
+            header = header.with_cancel_button()
         } else if self.menu_button {
-            frame = frame.with_menu_button()
+            header = header.with_menu_button()
+        }
+
+        let mut frame = Frame::new(
+            header,
+            SwipeContent::new(SwipePage::vertical(paragraphs.into_paragraphs())),
+        );
+        if self.cancel_button {
+            frame = frame.with_swipe(Direction::Right, SwipeSettings::Immediate);
         }
         if let Some(instruction) = self.footer_instruction {
             frame = frame.with_footer(instruction, self.footer_description);
@@ -490,5 +494,9 @@ where
 }
 
 pub fn dummy_page() -> impl Component<Msg = FlowMsg> + Swipable + MaybeTrace {
-    Frame::left_aligned(TString::empty(), VerticalMenu::empty()).map(|_| Some(FlowMsg::Cancelled))
+    Frame::new(
+        Header::left_aligned(TString::empty()),
+        VerticalMenu::empty(),
+    )
+    .map(|_| Some(FlowMsg::Cancelled))
 }

--- a/core/embed/rust/src/ui/layout_delizia/ui_firmware.rs
+++ b/core/embed/rust/src/ui/layout_delizia/ui_firmware.rs
@@ -38,7 +38,7 @@ use heapless::Vec;
 
 use super::{
     component::{
-        check_homescreen_format, Bip39Input, CoinJoinProgress, Frame, FrameMsg, Homescreen,
+        check_homescreen_format, Bip39Input, CoinJoinProgress, Frame, FrameMsg, Header, Homescreen,
         Lockscreen, MnemonicKeyboard, PinKeyboard, Progress, PromptScreen, ScrolledVerticalMenu,
         SelectWordCount, SelectWordCountLayout, Slip39Input, StatusScreen, SwipeContent,
         SwipeUpScreen, TradeScreen, VerticalMenu, VerticalMenuChoiceMsg, VerticalMenuItem,
@@ -361,9 +361,11 @@ impl FirmwareUI for UIDelizia {
         .into_paragraphs();
 
         let layout = RootComponent::new(SwipeUpScreen::new(
-            Frame::left_aligned(TR::modify_amount__title.into(), paragraphs)
-                .with_cancel_button()
-                .with_swipeup_footer(None),
+            Frame::new(
+                Header::left_aligned(TR::modify_amount__title.into()).with_cancel_button(),
+                paragraphs,
+            )
+            .with_swipeup_footer(None),
         ));
         Ok(layout)
     }
@@ -725,7 +727,10 @@ impl FirmwareUI for UIDelizia {
             unwrap!(menu_items.push(VerticalMenuItem::Item(text)));
         }
         let menu = ScrolledVerticalMenu::new(menu_items, current);
-        let frame = Frame::left_aligned(TString::empty(), menu).with_cancel_button();
+        let frame = Frame::new(
+            Header::left_aligned(TString::empty()).with_cancel_button(),
+            menu,
+        );
         let layout = MsgMap::new(frame, move |msg| {
             let choice = match msg {
                 FrameMsg::Content(VerticalMenuChoiceMsg::Selected(i)) => i,
@@ -747,8 +752,10 @@ impl FirmwareUI for UIDelizia {
         words: [TString<'static>; MAX_WORD_QUIZ_ITEMS],
     ) -> Result<impl LayoutMaybeTrace, Error> {
         let content = VerticalMenu::select_word(words);
-        let layout =
-            RootComponent::new(Frame::left_aligned(title, content).with_subtitle(description));
+        let layout = RootComponent::new(Frame::new(
+            Header::left_aligned(title).with_subtitle(description),
+            content,
+        ));
         Ok(layout)
     }
 
@@ -760,8 +767,8 @@ impl FirmwareUI for UIDelizia {
                 SelectWordCountLayout::LAYOUT_ALL
             },
         );
-        let layout = RootComponent::new(Frame::left_aligned(
-            TR::recovery__num_of_words.into(),
+        let layout = RootComponent::new(Frame::new(
+            Header::left_aligned(TR::recovery__num_of_words.into()),
             selector,
         ));
         Ok(layout)
@@ -827,8 +834,11 @@ impl FirmwareUI for UIDelizia {
         .with_done_offset(theme::CHECKLIST_DONE_OFFSET);
 
         let layout = RootComponent::new(SwipeUpScreen::new(
-            Frame::left_aligned(title, SwipeContent::new(checklist_content))
-                .with_swipeup_footer(None),
+            Frame::new(
+                Header::left_aligned(title),
+                SwipeContent::new(checklist_content),
+            )
+            .with_swipeup_footer(None),
         ));
         Ok(layout)
     }
@@ -853,14 +863,19 @@ impl FirmwareUI for UIDelizia {
     ) -> Result<Gc<LayoutObj>, Error> {
         let content = Paragraphs::new(Paragraph::new(&theme::TEXT_MAIN_GREY_LIGHT, description));
         let frame = if allow_cancel {
-            Frame::left_aligned(title, SwipeContent::new(content))
-                .with_cancel_button()
-                .with_danger()
-                .with_swipeup_footer(None)
+            Frame::new(
+                Header::left_aligned(title)
+                    .with_cancel_button()
+                    .with_danger(),
+                SwipeContent::new(content),
+            )
+            .with_swipeup_footer(None)
         } else {
-            Frame::left_aligned(title, SwipeContent::new(content))
-                .with_danger()
-                .with_swipeup_footer(None)
+            Frame::new(
+                Header::left_aligned(title).with_danger(),
+                SwipeContent::new(content),
+            )
+            .with_swipeup_footer(None)
         };
 
         let obj = LayoutObj::new(SwipeUpScreen::new(frame))?;
@@ -880,7 +895,11 @@ impl FirmwareUI for UIDelizia {
         .with_placement(geometry::LinearPlacement::vertical().align_at_center());
 
         let layout = RootComponent::new(SwipeUpScreen::new(
-            Frame::left_aligned("".into(), SwipeContent::new(paragraphs)).with_swipeup_footer(None),
+            Frame::new(
+                Header::left_aligned("".into()),
+                SwipeContent::new(paragraphs),
+            )
+            .with_swipeup_footer(None),
         ));
         Ok(layout)
     }
@@ -981,7 +1000,8 @@ impl FirmwareUI for UIDelizia {
         }
         let content = Paragraphs::new(Paragraph::new(&theme::TEXT_MAIN_GREY_LIGHT, description));
         let obj = LayoutObj::new(SwipeUpScreen::new(
-            Frame::left_aligned(title, SwipeContent::new(content)).with_swipeup_footer(None),
+            Frame::new(Header::left_aligned(title), SwipeContent::new(content))
+                .with_swipeup_footer(None),
         ))?;
         Ok(obj)
     }
@@ -1006,10 +1026,10 @@ impl FirmwareUI for UIDelizia {
             }
         }
 
-        let layout = RootComponent::new(SwipeUpScreen::new(
-            Frame::left_aligned(title, SwipeContent::new(paragraphs.into_paragraphs()))
-                .with_cancel_button(),
-        ));
+        let layout = RootComponent::new(SwipeUpScreen::new(Frame::new(
+            Header::left_aligned(title).with_cancel_button(),
+            SwipeContent::new(paragraphs.into_paragraphs()),
+        )));
         Ok(layout)
     }
 
@@ -1034,9 +1054,11 @@ impl FirmwareUI for UIDelizia {
         .into_paragraphs();
 
         let layout = RootComponent::new(SwipeUpScreen::new(
-            Frame::left_aligned(title, SwipeContent::new(paragraphs))
-                .with_cancel_button()
-                .with_swipeup_footer(Some(button)),
+            Frame::new(
+                Header::left_aligned(title).with_cancel_button(),
+                SwipeContent::new(paragraphs),
+            )
+            .with_swipeup_footer(Some(button)),
         ));
 
         Ok(layout)
@@ -1193,13 +1215,13 @@ impl FirmwareUI for UIDelizia {
             StatusScreen::new_success(title)
         };
         let layout = LayoutObj::new(SwipeUpScreen::new(
-            Frame::left_aligned(
-                TR::words__title_success.into(),
+            Frame::new(
+                Header::left_aligned(TR::words__title_success.into())
+                    .with_result_icon(theme::ICON_BULLET_CHECKMARK, theme::GREEN_LIGHT),
                 SwipeContent::new(content).with_no_attach_anim(),
             )
             .with_footer(instruction, description)
-            .with_swipe(Direction::Up, SwipeSettings::Default)
-            .with_result_icon(theme::ICON_BULLET_CHECKMARK, theme::GREEN_LIGHT),
+            .with_swipe(Direction::Up, SwipeSettings::Default),
         ))?;
         Ok(layout)
     }
@@ -1229,24 +1251,27 @@ impl FirmwareUI for UIDelizia {
         ])
         .into_paragraphs();
 
-        let frame = Frame::left_aligned(title, SwipeContent::new(content));
-        let frame = if danger {
-            frame.with_danger_icon().with_tap_footer(action)
+        let header = Header::left_aligned(title);
+        let header = if danger {
+            header.with_danger_icon()
         } else {
-            frame.with_warning_low_icon().with_swipeup_footer(action)
+            header.with_warning_low_icon()
         };
-
-        let layout = LayoutObj::new(SwipeUpScreen::new(frame))?;
-        Ok(layout)
+        let frame = Frame::new(header, SwipeContent::new(content));
+        let frame = if danger {
+            frame.with_tap_footer(action)
+        } else {
+            frame.with_swipeup_footer(action)
+        };
+        LayoutObj::new(SwipeUpScreen::new(frame))
     }
 
     fn confirm_cancel() -> Result<impl LayoutMaybeTrace, Error> {
         Ok(RootComponent::new(
-            Frame::left_aligned(
-                TR::send__cancel_sign.into(),
+            Frame::new(
+                Header::left_aligned(TR::send__cancel_sign.into()).with_cancel_button(),
                 SwipeContent::new(PromptScreen::new_tap_to_cancel()),
             )
-            .with_cancel_button()
             .with_footer(TR::instructions__tap_to_confirm.into(), None),
         ))
     }


### PR DESCRIPTION
Needed to allow dropping empty header on Delizia (similar to af8bfeb308, will be used in https://github.com/trezor/trezor-firmware/pull/6651).

Also reduces `TREZOR_MODEL=T3T1 PYOPT=0 make build_firmware` flash size by 4kB = 1645056 - 1640960.

<!--
For external contributors:
- Please open an issue before submitting a PR so we can discuss whether we want to proceed with it.

For core developers:
1. Initial PR setup
- Assign yourself to the PR.
- Add it to the "Firmware" project
  - Set Priority (match issue priority if it exists)
  - Set Team
  - Set Sprint (target release)

2. Development status
- Draft PRs: Set status to "In Progress"
- Final PRs: Set status to "Needs Review"

3. Post-merge status
- Testable: Set status to "Needs QA" and add a `Notes for QA` section with clear instructions on how to test the functionality.
- Not Testable: Set status to "Done (no QA)"
-->
