### PR TITLE
ci(core): increase device_tests timeout to 50m on T3W1

### DIFF
--- a/.github/workflows/core.yml
+++ b/.github/workflows/core.yml
@@ -320,8 +320,8 @@ jobs:
       PYTEST_TIMEOUT: ${{ matrix.asan == 'asan' && 600 || 400 }}
       ACTIONS_DO_UI_TEST: ${{ matrix.coins == 'universal' && matrix.asan == 'noasan' }}
       TEST_LANG: ${{ matrix.lang }}
-      TESTOPTS: "--durations 10 --session-timeout ${{ matrix.model == 'T3W1' && '2400' || '1800' }}"  # pytest global timeout
-    timeout-minutes: 50  # CI job timeout
+      TESTOPTS: "--durations 10 --session-timeout ${{ matrix.model == 'T3W1' && '3000' || '1800' }}"  # pytest global timeout
+    timeout-minutes: ${{ matrix.model == 'T3W1' && 60 || 40 }}  # CI job timeout
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # actions/checkout@v6.0.2
         with:


### PR DESCRIPTION
When running with 2 workers, T3W1 UI tests timeout after 40m.
