### PR TITLE
Display driver suspend API improvement

### DIFF
--- a/core/embed/io/display/inc/io/display.h
+++ b/core/embed/io/display/inc/io/display.h
@@ -80,18 +80,14 @@ typedef struct {
 // Suspends the display driver.
 //
 // Saves the current display state into `wakeup_params`.
-// `touch_wakeup_enabled` controls whether a light-suspend (keep panel powered
-// for touch wakeup) or a full deinit is performed.
-void display_suspend(display_wakeup_params_t *wakeup_params,
-                     bool touch_wakeup_enabled);
+void display_suspend(display_wakeup_params_t *wakeup_params);
 
 // Resumes the display driver.
 //
-// Restores the display state from `wakeup_params`.
-// `touch_wakeup_enabled` must match the value passed to `display_suspend()`;
-// it selects the matching light-resume or full reinit path.
-void display_resume(const display_wakeup_params_t *wakeup_params,
-                    bool touch_wakeup_enabled);
+// Restores the display state from `wakeup_params`. Handles both the
+// light-suspend case (driver still initialized) and the full-deinit
+// case (driver was fully deinitialized during suspend).
+void display_resume(const display_wakeup_params_t *wakeup_params);
 #endif  // USE_SUSPEND
 
 // Allows unprivileged access to the display framebuffer from

--- a/core/embed/io/display/ltdc_dsi/display_driver.c
+++ b/core/embed/io/display/ltdc_dsi/display_driver.c
@@ -633,21 +633,12 @@ void display_refresh_rate_config(void) {
 #endif  // REFRESH_RATE_SCALING_SUPPORTED
 
 #ifdef USE_SUSPEND
-void display_suspend(display_wakeup_params_t *wakeup_params,
-                     bool touch_wakeup_enabled) {
-#ifdef USE_TOUCH_WAKEUP
-  if (!touch_wakeup_enabled) {
-    wakeup_params->backlight_level = display_get_backlight();
-    display_deinit(DISPLAY_RESET_CONTENT);
-    return;
-  }
-
+void display_suspend(display_wakeup_params_t *wakeup_params) {
   display_driver_t *drv = &g_display_driver;
 
   memset(wakeup_params, 0, sizeof(display_wakeup_params_t));
 
   if (!drv->initialized) {
-    // The driver isn't initialized, wrong control flow applied
     return;
   }
 
@@ -662,26 +653,18 @@ void display_suspend(display_wakeup_params_t *wakeup_params,
   }
 
   memcpy(wakeup_params, &drv->wakeup_params, sizeof(display_wakeup_params_t));
-#else
-  UNUSED(touch_wakeup_enabled);
-  wakeup_params->backlight_level = display_get_backlight();
-  display_deinit(DISPLAY_RESET_CONTENT);
-#endif  // USE_TOUCH_WAKEUP
 }
 
-void display_resume(const display_wakeup_params_t *wakeup_params,
-                    bool touch_wakeup_enabled) {
-#ifdef USE_TOUCH_WAKEUP
-  if (!touch_wakeup_enabled) {
-    display_init(DISPLAY_RESET_CONTENT);
-    display_set_backlight(wakeup_params->backlight_level);
-    return;
-  }
-
+void display_resume(const display_wakeup_params_t *wakeup_params) {
   display_driver_t *drv = &g_display_driver;
 
   if (!drv->initialized) {
-    // The driver isn't initialized, wrong control flow applied
+    if (!display_init(DISPLAY_RESET_CONTENT)) {
+      return;
+    }
+    if (!display_set_backlight(wakeup_params->backlight_level)) {
+      goto cleanup;
+    }
     return;
   }
 
@@ -705,11 +688,6 @@ void display_resume(const display_wakeup_params_t *wakeup_params,
 cleanup:
   display_deinit(DISPLAY_RESET_CONTENT);
   return;
-#else
-  UNUSED(touch_wakeup_enabled);
-  display_init(DISPLAY_RESET_CONTENT);
-  display_set_backlight(wakeup_params->backlight_level);
-#endif  // USE_TOUCH_WAKEUP
 }
 #endif  // USE_SUSPEND
 

--- a/core/embed/io/suspend/stm32u5/suspend_io.c
+++ b/core/embed/io/suspend/stm32u5/suspend_io.c
@@ -78,11 +78,17 @@ void suspend_drivers_phase1(power_save_wakeup_params_t *wakeup_params) {
 #endif
 #ifdef USE_DISPLAY
 #ifdef USE_TOUCH_WAKEUP
-  display_suspend(&wakeup_params->display, touch_wakeup_get_enabled());
+  bool touch_wakeup_enabled = touch_wakeup_get_enabled();
 #else
-  display_suspend(&wakeup_params->display, false);
+  bool touch_wakeup_enabled = false;
 #endif
-#endif
+  if (touch_wakeup_enabled) {
+    display_suspend(&wakeup_params->display);
+  } else {
+    wakeup_params->display.backlight_level = display_get_backlight();
+    display_deinit(DISPLAY_RESET_CONTENT);
+  }
+#endif  // USE_DISPLAY
 }
 
 void suspend_drivers_phase2(void) {
@@ -98,11 +104,7 @@ void suspend_drivers_phase2(void) {
 // Reinitialize all drivers that were stopped earlier
 void resume_drivers(const power_save_wakeup_params_t *wakeup_params) {
 #ifdef USE_DISPLAY
-#ifdef USE_TOUCH_WAKEUP
-  display_resume(&wakeup_params->display, touch_wakeup_get_enabled());
-#else
-  display_resume(&wakeup_params->display, false);
-#endif
+  display_resume(&wakeup_params->display);
 #endif
 #ifdef USE_TOUCH
   touch_resume();


### PR DESCRIPTION
Remove `bool touch_wakeup_enabled` parameter from `display_suspend()` and  `display_resume()` — it was too specific to touch-panel hardware and leaked touch wakeup policy into the display driver.

Move the branching logic (light-suspend vs. full deinit) up to `suspend_io.c`, which is the appropriate level of abstraction. `display_resume()` now handles both cases internally: light-resume when the driver is still initialized, and full reinit when it was fully deinitialized during suspend.

<!--
For external contributors:
- Please open an issue before submitting a PR so we can discuss whether we want to proceed with it.

For core developers:
1. Initial PR setup
- Assign yourself to the PR.
- Add it to the "Firmware" project
  - Set Priority (match issue priority if it exists)
  - Set Team
  - Set Sprint (target release)

2. Development status
- Draft PRs: Set status to "In Progress"
- Final PRs: Set status to "Needs Review"

3. Post-merge status
- Testable: Set status to "Needs QA" and add a `Notes for QA` section with clear instructions on how to test the functionality.
- Not Testable: Set status to "Done (no QA)"
-->
