### PR TITLE
T3W1 tap-to-wake click tests

### DIFF
--- a/tests/click_tests/device_menu/test_device_settings.py
+++ b/tests/click_tests/device_menu/test_device_settings.py
@@ -32,6 +32,7 @@ pytestmark = [pytest.mark.models("eckhart")]
 LED_TITLE = "led__title"
 BRIGHTNESS_TITLE = "brightness__title"
 HAPTIC_FEEDBACK_TITLE = "haptic_feedback__title"
+TAP_TO_WAKE_TITLE = "words__tap_to_wake"
 
 
 def prepare_device_menu(debug: "DebugLink", features: "Features") -> None:
@@ -58,6 +59,7 @@ def test_device_settings_uninitialized(device_handler: "BackgroundDeviceHandler"
     assert TR.translate(LED_TITLE) not in items
     assert TR.translate(BRIGHTNESS_TITLE) not in items
     assert TR.translate(HAPTIC_FEEDBACK_TITLE) not in items
+    assert TR.translate(TAP_TO_WAKE_TITLE) not in items
 
 
 @pytest.mark.setup_client(pin=None)
@@ -121,6 +123,47 @@ def test_toggle_haptic(device_handler: "BackgroundDeviceHandler"):
     assert haptic_new is not None
     # Make sure the haptic setting was toggled
     assert haptic_new != haptic_old
+
+
+@pytest.mark.setup_client(pin=None)
+def test_toggle_tap_to_wake(device_handler: "BackgroundDeviceHandler"):
+    debug = device_handler.debuglink()
+    features = device_handler.features()
+
+    if features.tap_to_wake is None:
+        pytest.skip("tap to wake not supported")
+
+    assert features.initialized is True
+    assert features.pin_protection is False
+    # Default must be enabled on a fresh device
+    assert features.tap_to_wake is True
+
+    tap_to_wake_original = features.tap_to_wake
+
+    # Go to device settings
+    prepare_device_menu(debug, features)
+
+    items = debug.read_layout().vertical_menu_content()
+    assert TR.translate(TAP_TO_WAKE_TITLE) in items
+    tap_to_wake_idx = items.index(TR.translate(TAP_TO_WAKE_TITLE))
+
+    # First toggle — value must change
+    debug.button_actions.navigate_to_menu_item(tap_to_wake_idx)
+    assert_device_screen(debug, Menu.DEVICE)
+    close_device_menu(debug)
+    features = device_handler.features()
+    assert features.tap_to_wake == (not tap_to_wake_original)
+
+    # Second toggle — value must return to original
+    prepare_device_menu(debug, features)
+    items = debug.read_layout().vertical_menu_content()
+    tap_to_wake_idx = items.index(TR.translate(TAP_TO_WAKE_TITLE))
+    debug.button_actions.navigate_to_menu_item(tap_to_wake_idx)
+    assert_device_screen(debug, Menu.DEVICE)
+    close_device_menu(debug)
+
+    features = device_handler.features()
+    assert features.tap_to_wake == tap_to_wake_original
 
 
 @pytest.mark.setup_client(pin=None)


### PR DESCRIPTION
- Extends `test_device_settings_uninitialized` to assert the "Tap to wake" item is absent on uninitialized devices
- Adds `test_toggle_tap_to_wake` to verify:
  - `tap_to_wake` is `True` on a freshly initialized device,
  - the checkbox toggles the stored value and a round-trip restores the original.
- All new tests skip gracefully when `USE_TOUCH_WAKEUP` is not compiled in (i.e. `features.tap_to_wake is None`)

Closes #6972

<!--
For external contributors:
- Please open an issue before submitting a PR so we can discuss whether we want to proceed with it.

For core developers:
1. Initial PR setup
- Assign yourself to the PR.
- Add it to the "Firmware" project
  - Set Priority (match issue priority if it exists)
  - Set Team
  - Set Sprint (target release)

2. Development status
- Draft PRs: Set status to "In Progress"
- Final PRs: Set status to "Needs Review"

3. Post-merge status
- Testable: Set status to "Needs QA" and add a `Notes for QA` section with clear instructions on how to test the functionality.
- Not Testable: Set status to "Done (no QA)"
-->
