### PR TITLE
fix(core): skip bitcoin.signtx_decred test on BTC_ONLY

### DIFF
--- a/core/tests/test_apps.bitcoin.signtx_decred.py
+++ b/core/tests/test_apps.bitcoin.signtx_decred.py
@@ -1,7 +1,10 @@
 # flake8: noqa: F403,F405
 from common import *  # isort:skip
 
-if utils.INTERNAL_MODEL in ("T2T1",):  # pylint: disable=internal-model-tuple-comparison
+if (
+    utils.INTERNAL_MODEL in ("T2T1",)  # pylint: disable=internal-model-tuple-comparison
+    and not utils.BITCOIN_ONLY
+):
     from trezor.crypto import bip39
     from trezor.enums import AmountUnit, OutputScriptType
     from trezor.enums.RequestType import TXFINISHED, TXINPUT, TXMETA, TXOUTPUT


### PR DESCRIPTION
Python unit tests are failing on T2T1 BitcoinOnly FW. (See nightly run: https://github.com/trezor/trezor-firmware/actions/runs/26545217329/job/78195573389).

- The failing unit test is supposed to run on T2T1 universal FW only, but test's imports were not skipped on BTC Only - fixed in this PR.
- Related PRs:
  - https://github.com/trezor/trezor-firmware/pull/6976
  - https://github.com/trezor/trezor-firmware/pull/6968