### PR TITLE
chore(trezor-client): bump version to 0.1.6

### DIFF
--- a/rust/trezor-client/Cargo.lock
+++ b/rust/trezor-client/Cargo.lock
@@ -789,7 +789,7 @@ dependencies = [
 
 [[package]]
 name = "trezor-client"
-version = "0.1.5"
+version = "0.1.6"
 dependencies = [
  "bitcoin",
  "byteorder",

--- a/rust/trezor-client/Cargo.toml
+++ b/rust/trezor-client/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "trezor-client"
-version = "0.1.5"
+version = "0.1.6"
 authors = [
     "Piyush Kumar <piyushkumar2k02@kgpian.iitkgp.ac.in>",
     "joshieDo <ranriver@protonmail.com>",


### PR DESCRIPTION
Bump `trezor-client` crate to 0.1.6

## Changelog

### New coin/protocol support
- **Tron** (`tron` feature)
- **Nostr** (`nostr` feature)
- **Evolu** (`evolu` feature)
- **Binance Chain removed** (`binance` feature and messages dropped, BSC support remains via `ethereum` feature)

### Bug fixes
- Fixed button request handling during Ethereum sign data streaming — `ButtonRequest` interactions mid-stream are now correctly handled via `handle_interaction` instead of being silently skipped

### API additions
- `Trezor::send_message()` — fire-and-forget method for sending a message without waiting for a response (useful for `DebugLinkDecision` and similar messages the firmware does not reply to)

### Transport cleanup
- UDP and WebUSB transports: read/write timeout constants expressed as typed `Duration` / `Option<Duration>` values instead of raw `u64` milliseconds; UDP read timeout changed from `Some(0ms)` to
`None` (block indefinitely)

### Protobuf message changes
- Various additions and updates across coins and protocols

### Dependency updates
- `protobuf` / `protobuf-codegen`: `3.3.0` → `3.7.2`
- `bitcoin`: `0.31` → `0.32` (updated `address_from_script` to use `Address::from_script` / `Params`)
- `thiserror`: `1.0` → `2.0`
- `serial_test`: `2.0` → `3`
