### PR TITLE
test(solana): sign message with many cosigners

### DIFF
--- a/tests/device_tests/solana/test_sign_message.py
+++ b/tests/device_tests/solana/test_sign_message.py
@@ -23,6 +23,7 @@ ED25519_PRIV_SIZE = 32
         pytest.param(0, "Hello, 🌍! Spëcial châräctérs.", id="utf-8"),
         pytest.param(0, "Much " + "much " * 42 + "longer message.", id="long"),
         pytest.param(2, "Multi-party agreement.", id="multi"),
+        pytest.param(64, "Large multi-party agreement.", id="large-multi"),
     ],
 )
 def test_sign_verify(session: Session, n_cosigners: int, message: str) -> None:


### PR DESCRIPTION
Related: https://github.com/trezor/trezor-firmware/issues/6780

`n_cosigners=64` was chosen to also check that the message format is computed correctly by trezorlib (`format == 2` because the total message size is `> 64 * 32 = 2 kB`, which exceeds `1232 B`).
<!--
For external contributors:
- Please open an issue before submitting a PR so we can discuss whether we want to proceed with it.

For core developers:
1. Initial PR setup
- Assign yourself to the PR.
- Add it to the "Firmware" project
  - Set Priority (match issue priority if it exists)
  - Set Team
  - Set Sprint (target release)

2. Development status
- Draft PRs: Set status to "In Progress"
- Final PRs: Set status to "Needs Review"

3. Post-merge status
- Testable: Set status to "Needs QA" and add a `Notes for QA` section with clear instructions on how to test the functionality.
- Not Testable: Set status to "Done (no QA)"
-->
