### PR TITLE
Fix and improve doc-links

### DIFF
--- a/docs/SUMMARY.md
+++ b/docs/SUMMARY.md
@@ -29,7 +29,7 @@
 - [Legacy](legacy/index.md)
     - [Firmware format](legacy/firmware-format.md)
 - [Python](python/index.md)
-  - [trezorlib](python/trezorlib.md)
+  - [trezorlib](../../python/README.md)
 - [Common](common/index.md)
   - [Protocol V1](common/protocol_v1/index.md)
     - [Sessions](common/protocol_v1/sessions.md)

--- a/docs/common/message-workflows.md
+++ b/docs/common/message-workflows.md
@@ -82,7 +82,7 @@ NIST256P1 public keys.
 ## SignTx
 
 > The following may contain imprecise/obsolete information. Refer to
-[Bitcoin signing flow](communication/bitcoin-signing.md) for more relevant
+[Bitcoin signing flow](bitcoin-signing.md) for more relevant
 information.
 
 Signing a transaction is a little bit complicated. The reason is that

--- a/docs/developers/hello_world_in_core.md
+++ b/docs/developers/hello_world_in_core.md
@@ -17,7 +17,7 @@ As already mentioned, to get something useful from Trezor, writing device logic 
 ### TLDR: [implementation in a single commit](https://github.com/trezor/trezor-firmware/commit/f43e7828281219b9770eea376e5dd6d5afd6ee3b)
 
 ### 1. Communication part (protobuf)
-Communication between Trezor and the computer is handled by a protocol called `protobuf`. It allows for the creation of specific messages (containing clearly defined data) that will be exchanged. More details about this can be seen in [docs](../common/communication/index.md).
+Communication between Trezor and the computer is handled by a protocol called `protobuf`. It allows for the creation of specific messages (containing clearly defined data) that will be exchanged. More details about this can be seen in [docs](../common/index.md).
 
 Trezor on its own cannot send data to the computer, it can only react to a "request" message it recognizes and send a "response" message.
 Both of these messages will need to be specified, and both parts of communication will need to understand them.

--- a/docs/index.md
+++ b/docs/index.md
@@ -23,7 +23,7 @@ Welcome to the Trezor Firmware repository. This repository is so called _monorep
 
 ## Contribute
 
-See [CONTRIBUTING.md](https://github.com/trezor/trezor-firmware/tree/main/CONTRIBUTING.md).
+See [CONTRIBUTING.md](misc/contributing.md).
 
 Also please have a look at the docs, either in the `docs` folder or at  [docs.trezor.io](https://docs.trezor.io) before contributing. The [misc](misc/index.md) chapter should be read in particular because it contains some useful assorted knowledge.
 

--- a/docs/legacy/firmware-format.md
+++ b/docs/legacy/firmware-format.md
@@ -37,7 +37,7 @@ Signature verification:
 
 ## V2 Header
 
-This header has the same format as [Model T Firmware Header](../model-t/boot.md#firmware-header),
+This header has the same format as [Model T Firmware Header](../core/misc/boot.md#firmware-header),
 however due to different signature scheme the `sigmask` and `sig` fields are zeroed and part of the
 reserved space is used for T1-specific fields `sig1`-`sig3`, `sigindex1-sigindex3`. Total length of
 v2 header is always 1024 bytes.

--- a/docs/misc/toif.md
+++ b/docs/misc/toif.md
@@ -68,5 +68,5 @@ zdata = z.compress(pixeldata) + z.flush()
 
 Tool for converting PNGs into TOI format and back, see the following links for more:
 
-* [README](https://github.com/trezor/trezor-firmware/blob/main/python/tools/toiftool/README.md)
+* [README](../../python/tools/toiftool/README.md)
 * [Code](https://github.com/trezor/trezor-firmware/blob/main/python/tools/toiftool/toiftool.py)

--- a/docs/python/index.md
+++ b/docs/python/index.md
@@ -2,4 +2,4 @@
 
 To be documented by @matejcik, see [#229](https://github.com/trezor/trezor-firmware/issues/229).
 
-In the meantime see `python/docs` and [README](trezorlib.md) for the [PyPI package](https://pypi.org/project/trezor).
+In the meantime see `python/docs` and [README](../../python/README.md) for the [PyPI package](https://pypi.org/project/trezor).

--- a/docs/python/trezorlib.md
+++ b/docs/python/trezorlib.md
@@ -1,1 +1,0 @@
-../../python/README.md


### PR DESCRIPTION
- Fixed broken links to non-existent places.
- Replaced doc links to github by relative links to the md files. This allows to use `docs.trezor.io` without being needlessly transported to the github version of the linked doc page.
- Replaced "links to symlinks" by" links to the original files". Symlinks do not work nicely on github - user must manually find the symlinked doc page.