### PR TITLE
fix(core): fix device_menu crash on devices without a serial number

### DIFF
--- a/core/src/apps/homescreen/device_menu.py
+++ b/core/src/apps/homescreen/device_menu.py
@@ -117,7 +117,12 @@ async def handle_device_menu() -> None:
 
         firmware_type = "Bitcoin-only" if utils.BITCOIN_ONLY else "Universal"
         production_year = _get_production_year()
-        serial_no = utils.serial_number() if utils.USE_SERIAL_NUMBER else None
+
+        try:
+            serial_no = utils.serial_number() if utils.USE_SERIAL_NUMBER else None
+        except RuntimeError:
+            # Unprovisioned devices might not have a serial number
+            serial_no = "N/A"
 
         about_items: list[tuple[str | None, str | None, bool]] = [
             (TR.homescreen__firmware_version, firmware_version, False),


### PR DESCRIPTION
Fixes an issue on unprovisioned devices in development.

When a device has not yet been provisioned no serial number is assigned or written to OTP), opening the device menu on T3W1 throws an exception and results in a black screen.

With this fix, unprovisioned devices display **N/A** instead of a serial number.
