### PR TITLE
chore(ci): skip `auto-assign` job for bots

### DIFF
--- a/.github/workflows/bot-auto-assign.yml
+++ b/.github/workflows/bot-auto-assign.yml
@@ -9,8 +9,8 @@ permissions:
 
 jobs:
   auto-assign:
-    # run only in 'trezor/trezor-firmware' repository
-    if: github.repository == 'trezor/trezor-firmware'
+    # run only in 'trezor/trezor-firmware' repository, skipped for bots
+    if: github.repository == 'trezor/trezor-firmware' && !endsWith(github.event.pull_request.user.login, '[bot]')
     runs-on: ubuntu-latest
     steps:
       - name: Assign PR author to PR


### PR DESCRIPTION
Auto assign job fails for bots - see https://github.com/trezor/trezor-firmware/actions/runs/26632048871/job/78483060973?pr=7023.

This PR skips the job for bots entirely.