### PR TITLE
fix(trezor-client): send empty passphrase for standard wallets

### DIFF
--- a/rust/trezor-client/src/client/common.rs
+++ b/rust/trezor-client/src/client/common.rs
@@ -221,10 +221,13 @@ pub fn handle_interaction<T, R: TrezorMessage>(resp: TrezorResponse<'_, T, R>) -
         TrezorResponse::Failure(_) => resp.ok(), // assering ok() returns the failure error
         TrezorResponse::ButtonRequest(req) => handle_interaction(req.ack()?),
         TrezorResponse::PinMatrixRequest(_) => Err(Error::UnsupportedNetwork),
-        TrezorResponse::PassphraseRequest(req) => handle_interaction({
-            let on_device = req.on_device();
-            req.ack(!on_device)?
-        }),
+        TrezorResponse::PassphraseRequest(req) => handle_interaction(
+            if req.on_device() {
+                req.ack(true)?
+            } else {
+                req.ack_passphrase(String::new())?
+            }
+        ),
     }
 }
 


### PR DESCRIPTION
Fixes #7033

`handle_interaction` incorrectly handles `PassphraseRequest` for standard wallets (no passphrase configured).

When `on_device()` returns `false`, the current code calls `req.ack(!on_device)` which sets `on_device = true` in the `PassphraseAck`, causing the Trezor to prompt for passphrase entry on the device even when none is configured.

The fix sends an empty passphrase string via `ack_passphrase(String::new())` when `on_device()` is `false`, which is the correct protocol response for standard (non-hidden) wallets.