### PR TITLE
fix(core): raise `NotInitialized` on BTC-only seed derivation 

### DIFF
--- a/core/.changelog.d/6941.fixed
+++ b/core/.changelog.d/6941.fixed
@@ -1,0 +1,1 @@
+[T2B1,T2T1,T3B1,T3T1] Return an explicit error when try to derive seed on Bitcoin-only firmware.

--- a/core/src/apps/base.py
+++ b/core/src/apps/base.py
@@ -422,8 +422,9 @@ async def handle_LockDevice(msg: LockDevice) -> Success:
 
 
 async def handle_SetBusy(msg: SetBusy) -> Success:
-    if not storage_device.is_initialized():
-        raise wire.NotInitialized("Device is not initialized")
+    from apps.common.seed import raise_if_not_initialized
+
+    raise_if_not_initialized()
 
     if msg.expiry_ms:
         import utime

--- a/core/src/apps/cardano/seed.py
+++ b/core/src/apps/cardano/seed.py
@@ -151,8 +151,9 @@ async def _get_keychain_bip39(derivation_type: CardanoDerivationType) -> Keychai
     from trezor.enums import CardanoDerivationType
     from trezor.wire import context
 
-    if not device.is_initialized():
-        raise wire.NotInitialized("Device is not initialized")
+    from apps.common.seed import raise_if_not_initialized
+
+    raise_if_not_initialized()
 
     if derivation_type == CardanoDerivationType.LEDGER:
         seed = await get_seed()

--- a/core/src/apps/common/seed.py
+++ b/core/src/apps/common/seed.py
@@ -120,13 +120,16 @@ if utils.USE_THP:
                 ctx.cache.set_bool(APP_COMMON_DERIVE_CARDANO, True)
                 derive_and_store_secrets(ctx, passphrase)
 
-else:
+else:  # v1 protocol
+
     if utils.BITCOIN_ONLY:
         # === Bitcoin-only variant ===
         # We use the simple version of `get_seed` that never needs to derive anything else.
 
         @cache.stored_async(APP_COMMON_SEED)
         async def get_seed() -> bytes:
+            raise_if_not_initialized()
+
             passphrase = await get_passphrase_legacy()
             return mnemonic.get_seed(passphrase=passphrase)
 

--- a/core/src/apps/common/seed.py
+++ b/core/src/apps/common/seed.py
@@ -86,10 +86,10 @@ if utils.USE_THP:
             if msg.passphrase is not None and msg.on_device:
                 raise DataError("Passphrase provided when it shouldn't be!")
 
+            raise_if_not_initialized()
+
             if ctx.cache.is_set(APP_COMMON_SEED):
                 raise Exception("Seed is already set!")
-
-            raise_if_not_initialized()
 
             passphrase = await get_passphrase(msg)
             common_seed = mnemonic.get_seed(passphrase)

--- a/core/src/apps/common/seed.py
+++ b/core/src/apps/common/seed.py
@@ -30,6 +30,13 @@ if not utils.USE_THP:
     from .passphrase import get as get_passphrase_legacy
 
 
+def raise_if_not_initialized() -> None:
+    if not storage_device.is_initialized():
+        from trezor.wire import NotInitialized
+
+        raise NotInitialized("Device is not initialized")
+
+
 class Slip21Node:
     """
     This class implements the SLIP-0021 hierarchical derivation of symmetric keys, see
@@ -82,10 +89,7 @@ if utils.USE_THP:
             if ctx.cache.is_set(APP_COMMON_SEED):
                 raise Exception("Seed is already set!")
 
-            from trezor import wire
-
-            if not storage_device.is_initialized():
-                raise wire.NotInitialized("Device is not initialized")
+            raise_if_not_initialized()
 
             passphrase = await get_passphrase(msg)
             common_seed = mnemonic.get_seed(passphrase)
@@ -101,10 +105,7 @@ if utils.USE_THP:
             if msg.passphrase is not None and msg.on_device:
                 raise DataError("Passphrase provided when it shouldn't be!")
 
-            from trezor import wire
-
-            if not storage_device.is_initialized():
-                raise wire.NotInitialized("Device is not initialized")
+            raise_if_not_initialized()
 
             if ctx.cache.is_set(APP_CARDANO_ICARUS_SECRET):
                 raise Exception("Cardano icarus secret is already set!")
@@ -142,10 +143,7 @@ else:
             return common_seed
 
         async def derive_and_store_roots_legacy() -> None:
-            from trezor import wire
-
-            if not storage_device.is_initialized():
-                raise wire.NotInitialized("Device is not initialized")
+            raise_if_not_initialized()
 
             ctx = get_context()
             need_seed = not ctx.cache.is_set(APP_COMMON_SEED)

--- a/core/src/apps/evolu/get_node.py
+++ b/core/src/apps/evolu/get_node.py
@@ -23,14 +23,13 @@ async def get_node(msg: EvoluGetNode) -> EvoluNode:
         NotInitialized: If the device is not initialized.
         ValueError: If the proof of delegated identity is missing or invalid.
     """
-    from storage.device import is_initialized
     from trezor.messages import EvoluNode
-    from trezor.wire import NotInitialized
+
+    from apps.common.seed import raise_if_not_initialized
 
     from .common import check_delegated_identity_proof
 
-    if not is_initialized():
-        raise NotInitialized("Device is not initialized")
+    raise_if_not_initialized()
 
     if not check_delegated_identity_proof(
         bytes(msg.proof_of_delegated_identity),

--- a/core/src/apps/management/apply_flags.py
+++ b/core/src/apps/management/apply_flags.py
@@ -5,12 +5,12 @@ if TYPE_CHECKING:
 
 
 async def apply_flags(msg: ApplyFlags) -> Success:
-    import storage.device
     from storage.device import set_flags
     from trezor.messages import Success
-    from trezor.wire import NotInitialized
 
-    if not storage.device.is_initialized():
-        raise NotInitialized("Device is not initialized")
+    from apps.common.seed import raise_if_not_initialized
+
+    raise_if_not_initialized()
+
     set_flags(msg.flags)
     return Success(message="Flags applied")

--- a/core/src/apps/management/apply_settings.py
+++ b/core/src/apps/management/apply_settings.py
@@ -50,13 +50,13 @@ def _validate_homescreen(homescreen: AnyBytes) -> None:
 
 async def apply_settings(msg: ApplySettings) -> Success:
     from trezor.messages import Success
-    from trezor.wire import NotInitialized, ProcessError
+    from trezor.wire import ProcessError
 
     from apps.common import safety_checks
     from apps.common.lock_manager import reload_settings_from_storage
+    from apps.common.seed import raise_if_not_initialized
 
-    if not storage_device.is_initialized():
-        raise NotInitialized("Device is not initialized")
+    raise_if_not_initialized()
 
     homescreen = msg.homescreen  # local_cache_attribute
     homescreen_length = msg.homescreen_length  # local_cache_attribute

--- a/core/src/apps/management/backup_device.py
+++ b/core/src/apps/management/backup_device.py
@@ -92,14 +92,15 @@ async def backup_device(msg: BackupDevice) -> Success:
     from trezor.messages import Success
 
     from apps.common import backup, mnemonic
+    from apps.common.seed import raise_if_not_initialized
 
     # do this early before we show any UI
     # the homescreen will clear the flag right after its own UI is gone
     repeated_backup_enabled = backup.repeated_backup_enabled()
     is_repeated_backup = repeated_backup_enabled and not storage_device.needs_backup()
 
-    if not storage_device.is_initialized():
-        raise wire.NotInitialized("Device is not initialized")
+    raise_if_not_initialized()
+
     if not storage_device.needs_backup() and not repeated_backup_enabled:
         raise wire.ProcessError("Seed already backed up")
 

--- a/core/src/apps/management/change_wipe_code.py
+++ b/core/src/apps/management/change_wipe_code.py
@@ -9,16 +9,14 @@ if TYPE_CHECKING:
 
 
 async def change_wipe_code(msg: ChangeWipeCode) -> Success:
-    from storage.device import is_initialized
     from trezor import config
     from trezor.messages import Success
     from trezor.ui.layouts import show_success, wipe_code_pin_not_set_popup
-    from trezor.wire import NotInitialized
 
     from apps.common.request_pin import error_pin_invalid, request_pin_and_sd_salt
+    from apps.common.seed import raise_if_not_initialized
 
-    if not is_initialized():
-        raise NotInitialized("Device is not initialized")
+    raise_if_not_initialized()
 
     # Confirm that user wants to set or remove the wipe code.
     has_wipe_code = config.has_wipe_code()

--- a/core/src/apps/management/get_next_u2f_counter.py
+++ b/core/src/apps/management/get_next_u2f_counter.py
@@ -10,10 +10,10 @@ async def get_next_u2f_counter(msg: GetNextU2FCounter) -> NextU2FCounter:
     from trezor.enums import ButtonRequestType
     from trezor.messages import NextU2FCounter
     from trezor.ui.layouts import confirm_action
-    from trezor.wire import NotInitialized
 
-    if not storage_device.is_initialized():
-        raise NotInitialized("Device is not initialized")
+    from apps.common.seed import raise_if_not_initialized
+
+    raise_if_not_initialized()
 
     await confirm_action(
         "get_u2f_counter",

--- a/core/src/apps/management/recovery_device/__init__.py
+++ b/core/src/apps/management/recovery_device/__init__.py
@@ -50,9 +50,11 @@ async def recovery_device(msg: RecoveryDevice) -> Success:
         if storage_device.is_initialized():
             raise wire.UnexpectedMessage("Already initialized")
     elif recovery_type in (RecoveryType.DryRun, RecoveryType.UnlockRepeatedBackup):
-        if not storage_device.is_initialized():
-            raise wire.NotInitialized("Device is not initialized")
-        elif recovery_type is RecoveryType.DryRun:
+        from apps.common.seed import raise_if_not_initialized
+
+        raise_if_not_initialized()
+
+        if recovery_type is RecoveryType.DryRun:
             if storage_device.no_backup():
                 raise wire.ProcessError("Dry-run not available for seedless devices")
             elif storage_device.needs_backup() or storage_device.unfinished_backup():

--- a/core/src/apps/management/sd_protect.py
+++ b/core/src/apps/management/sd_protect.py
@@ -38,10 +38,9 @@ async def _set_salt(salt: bytes, salt_tag: bytes, stage: bool = False) -> None:
 
 
 async def sd_protect(msg: SdProtect) -> Success:
-    from trezor.wire import NotInitialized
+    from apps.common.seed import raise_if_not_initialized
 
-    if not storage_device.is_initialized():
-        raise NotInitialized("Device is not initialized")
+    raise_if_not_initialized()
 
     if msg.operation == SdProtectOperationType.ENABLE:
         return await _sd_protect_enable(msg)

--- a/core/src/apps/management/set_brightness.py
+++ b/core/src/apps/management/set_brightness.py
@@ -5,13 +5,12 @@ if TYPE_CHECKING:
 
 
 async def set_brightness(msg: SetBrightness) -> Success:
-    import storage.device as storage_device
     from trezor.messages import Success
     from trezor.ui.layouts import set_brightness
-    from trezor.wire import NotInitialized
 
-    if not storage_device.is_initialized():
-        raise NotInitialized("Device is not initialized")
+    from apps.common.seed import raise_if_not_initialized
+
+    raise_if_not_initialized()
 
     await set_brightness(msg.value)
     return Success(message="Settings applied")

--- a/core/src/apps/management/set_u2f_counter.py
+++ b/core/src/apps/management/set_u2f_counter.py
@@ -11,8 +11,10 @@ async def set_u2f_counter(msg: SetU2FCounter) -> Success:
     from trezor.messages import Success
     from trezor.ui.layouts import confirm_action
 
-    if not storage_device.is_initialized():
-        raise wire.NotInitialized("Device is not initialized")
+    from apps.common.seed import raise_if_not_initialized
+
+    raise_if_not_initialized()
+
     if msg.u2f_counter is None:
         raise wire.ProcessError("No value provided")
 

--- a/core/src/apps/webauthn/add_resident_credential.py
+++ b/core/src/apps/webauthn/add_resident_credential.py
@@ -5,16 +5,17 @@ if TYPE_CHECKING:
 
 
 async def add_resident_credential(msg: WebAuthnAddResidentCredential) -> Success:
-    import storage.device as storage_device
     from trezor import TR, wire
     from trezor.messages import Success
     from trezor.ui.layouts.fido import confirm_fido, credential_warning
 
+    from apps.common.seed import raise_if_not_initialized
+
     from .credential import Fido2Credential
     from .resident_credentials import store_resident_credential
 
-    if not storage_device.is_initialized():
-        raise wire.NotInitialized("Device is not initialized")
+    raise_if_not_initialized()
+
     if not msg.credential_id:
         raise wire.ProcessError("Missing credential ID parameter.")
 

--- a/core/src/apps/webauthn/remove_resident_credential.py
+++ b/core/src/apps/webauthn/remove_resident_credential.py
@@ -5,16 +5,17 @@ if TYPE_CHECKING:
 
 
 async def remove_resident_credential(msg: WebAuthnRemoveResidentCredential) -> Success:
-    import storage.device
     import storage.resident_credentials
     from trezor import TR, wire
     from trezor.messages import Success
     from trezor.ui.layouts.fido import confirm_fido
 
+    from apps.common.seed import raise_if_not_initialized
+
     from .resident_credentials import get_resident_credential
 
-    if not storage.device.is_initialized():
-        raise wire.NotInitialized("Device is not initialized")
+    raise_if_not_initialized()
+
     if msg.index is None:
         raise wire.ProcessError("Missing credential index parameter.")
 

--- a/tests/device_tests/test_basic.py
+++ b/tests/device_tests/test_basic.py
@@ -14,6 +14,8 @@
 # You should have received a copy of the License along with this library.
 # If not, see <https://www.gnu.org/licenses/lgpl-3.0.html>.
 
+import pytest
+
 from trezorlib import messages, models
 from trezorlib.debuglink import DebugSession as Session
 from trezorlib.debuglink import TrezorTestContext as Client
@@ -59,3 +61,14 @@ def test_device_id_different(client: Client):
 
     # Device ID must be fresh after every reset
     assert id1 != id2
+
+
+@pytest.mark.setup_client(uninitialized=True)
+def test_not_initialized(session: Session):
+    resp = session.call_raw(messages.GetPublicKey(address_n=[0]))
+    resp = messages.Failure.ensure_isinstance(resp)
+    expected = (
+        messages.FailureType.NotInitialized,
+        messages.FailureType.InvalidSession,
+    )
+    assert resp.code == expected[session.test_ctx.is_thp()]


### PR DESCRIPTION
Also add device test for `NotInitialized` exception.

Fixes https://github.com/trezor/trezor-firmware/issues/6941.

## Notes to QA:
Use BTC-only FW on non-THP device: 
```
TREZOR_MODEL=T3T1 PYOPT=0 QUIET_MODE=1 BITCOIN_ONLY=1 make -C core clean build_firmware upload
```
`trezorctl -v btc get-public-node -n 'm/0h'` should return `NotInitialized` (instead of `FirmwareError`)