### PR TITLE
fix(core): build emulator without pyopt enabled

### DIFF
--- a/core/Makefile
+++ b/core/Makefile
@@ -242,7 +242,7 @@ build_firmware: ## build firmware with frozen modules
 	xtask build firmware $(XTASK_BUILD_OPTS)
 
 build_unix: ## build unix port
-	xtask build firmware --emulator $(XTASK_BUILD_OPTS)
+	xtask build firmware --emulator $(XTASK_BUILD_OPTS) --pyopt=false
 
 build_unix_frozen: ## build unix port with frozen modules
 	xtask build firmware --emulator --frozen $(XTASK_BUILD_OPTS)

--- a/core/embed/xtask/src/args.rs
+++ b/core/embed/xtask/src/args.rs
@@ -272,7 +272,7 @@ pub struct BuildArgs {
     pub source_lines: Option<bool>,
 
     /// Optimize MicroPython bytecode
-    #[arg(long, num_args = 0..=1, default_missing_value = "true")]
+    #[arg(long, num_args = 0..=1, default_missing_value = "true", overrides_with = "pyopt")]
     pub pyopt: Option<bool>,
 
     /// Enable Micropython memory performance measurements


### PR DESCRIPTION
This PR restores the original behavior of the `make build_unix` command from the SCons build system era.

- Disables pyopt in the `build_unix` Makefile target.
- Allows `pyopt` to be overridden in xtask by later occurrences of the option.

This is a temporary hot fix that should be replaced by a more systematic long-term solution soon.

