### PR TITLE
Allow dropping Bolt icon if title is unset

### DIFF
--- a/core/embed/rust/src/ui/api/firmware_micropython.rs
+++ b/core/embed/rust/src/ui/api/firmware_micropython.rs
@@ -1274,7 +1274,7 @@ extern "C" fn new_show_wait_text(message: Obj) -> Obj {
 
 extern "C" fn new_show_warning(n_args: usize, args: *const Obj, kwargs: *mut Map) -> Obj {
     let block = move |_args: &[Obj], kwargs: &Map| {
-        let title: TString = kwargs.get(Qstr::MP_QSTR_title)?.try_into()?;
+        let title: Option<TString> = kwargs.get(Qstr::MP_QSTR_title)?.try_into_option()?;
         let button: TString = kwargs.get(Qstr::MP_QSTR_button)?.try_into()?;
         let value: TString = kwargs.get_or(Qstr::MP_QSTR_value, "".into())?;
         let description: TString = kwargs.get_or(Qstr::MP_QSTR_description, "".into())?;
@@ -2155,7 +2155,7 @@ pub static mp_module_trezorui_api: Module = obj_module! {
 
     /// def show_warning(
     ///     *,
-    ///     title: str,
+    ///     title: str | None,
     ///     button: str,
     ///     value: str = "",
     ///     description: str = "",

--- a/core/embed/rust/src/ui/layout_bolt/component/dialog.rs
+++ b/core/embed/rust/src/ui/layout_bolt/component/dialog.rs
@@ -88,7 +88,7 @@ where
 }
 
 pub struct IconDialog<U> {
-    image: Child<BlendedImage>,
+    image: Option<Child<BlendedImage>>,
     paragraphs: Paragraphs<ParagraphVecShort<'static>>,
     controls: Child<U>,
 }
@@ -97,15 +97,21 @@ impl<U> IconDialog<U>
 where
     U: Component,
 {
-    pub fn new(icon: BlendedImage, title: impl Into<TString<'static>>, controls: U) -> Self {
+    pub fn new(
+        icon: BlendedImage,
+        title: Option<impl Into<TString<'static>>>,
+        controls: U,
+    ) -> Self {
+        let (image, paragraphs) = if let Some(title) = title {
+            let title = Paragraph::new(&theme::TEXT_DEMIBOLD, title).centered();
+            let para = ParagraphVecShort::from_iter([title]);
+            (Some(Child::new(icon)), para)
+        } else {
+            (None, ParagraphVecShort::new())
+        };
         Self {
-            image: Child::new(icon),
-            paragraphs: Paragraphs::new(ParagraphVecShort::from_iter([Paragraph::new(
-                &theme::TEXT_DEMIBOLD,
-                title,
-            )
-            .centered()]))
-            .with_placement(
+            image,
+            paragraphs: Paragraphs::new(paragraphs).with_placement(
                 LinearPlacement::vertical()
                     .align_at_center()
                     .with_spacing(Self::VALUE_SPACE),
@@ -138,13 +144,13 @@ where
     pub fn new_shares(lines: [impl Into<TString<'static>>; 4], controls: U) -> Self {
         let [l0, l1, l2, l3] = lines;
         Self {
-            image: Child::new(BlendedImage::new(
+            image: Some(Child::new(BlendedImage::new(
                 theme::IMAGE_BG_CIRCLE,
                 theme::IMAGE_FG_SUCCESS,
                 theme::SUCCESS_COLOR,
                 theme::FG,
                 theme::BG,
-            )),
+            ))),
             paragraphs: ParagraphVecShort::from_iter([
                 Paragraph::new(&theme::TEXT_NORMAL_OFF_WHITE, l0).centered(),
                 Paragraph::new(&theme::TEXT_DEMIBOLD, l1).centered(),
@@ -176,9 +182,14 @@ where
         let controls_area = self.controls.place(bounds);
         let content_area = bounds.inset(Insets::bottom(controls_area.height()));
 
-        let (image_area, content_area) = content_area.split_top(Self::ICON_AREA_HEIGHT);
+        let content_area = if let Some(image) = &mut self.image {
+            let (image_area, content_area) = content_area.split_top(Self::ICON_AREA_HEIGHT);
+            image.place(image_area);
+            content_area
+        } else {
+            content_area
+        };
 
-        self.image.place(image_area);
         self.paragraphs.place(content_area);
         bounds
     }
@@ -189,7 +200,9 @@ where
     }
 
     fn render<'s>(&'s self, target: &mut impl Renderer<'s>) {
-        self.image.render(target);
+        if let Some(image) = &self.image {
+            image.render(target);
+        }
         self.paragraphs.render(target);
         self.controls.render(target);
     }
@@ -202,7 +215,9 @@ where
 {
     fn trace(&self, t: &mut dyn crate::trace::Tracer) {
         t.component("IconDialog");
-        t.child("image", &self.image);
+        if let Some(image) = &self.image {
+            t.child("image", image);
+        }
         t.child("content", &self.paragraphs);
         t.child("controls", &self.controls);
     }

--- a/core/embed/rust/src/ui/layout_bolt/ui_firmware.rs
+++ b/core/embed/rust/src/ui/layout_bolt/ui_firmware.rs
@@ -1276,7 +1276,7 @@ impl FirmwareUI for UIBolt {
         value: TString<'static>,
         description: TString<'static>,
         allow_cancel: bool,
-        _danger: bool,
+        danger: bool,
     ) -> Result<Gc<LayoutObj>, Error> {
         let icon = BlendedImage::new(
             theme::IMAGE_BG_OCTAGON,
@@ -1285,6 +1285,10 @@ impl FirmwareUI for UIBolt {
             theme::FG,
             theme::BG,
         );
+        if danger && title.is_none() {
+            // Disallow showing "dangerous" warning with no header.
+            return Err(Error::ValueError(c"Non-empty title is required"));
+        }
         new_show_modal(
             title.unwrap_or(TString::empty()),
             value,

--- a/core/embed/rust/src/ui/layout_bolt/ui_firmware.rs
+++ b/core/embed/rust/src/ui/layout_bolt/ui_firmware.rs
@@ -1271,7 +1271,7 @@ impl FirmwareUI for UIBolt {
     }
 
     fn show_warning(
-        title: TString<'static>,
+        title: Option<TString<'static>>,
         button: TString<'static>,
         value: TString<'static>,
         description: TString<'static>,
@@ -1286,7 +1286,7 @@ impl FirmwareUI for UIBolt {
             theme::BG,
         );
         new_show_modal(
-            title,
+            title.unwrap_or(TString::empty()),
             value,
             description,
             (!button.is_empty()).then_some(button),

--- a/core/embed/rust/src/ui/layout_bolt/ui_firmware.rs
+++ b/core/embed/rust/src/ui/layout_bolt/ui_firmware.rs
@@ -881,7 +881,7 @@ impl FirmwareUI for UIBolt {
             theme::BG,
         );
         new_show_modal(
-            title,
+            Some(title),
             TString::empty(),
             description,
             (!button.is_empty()).then_some(button),
@@ -1015,7 +1015,7 @@ impl FirmwareUI for UIBolt {
             theme::BG,
         );
         new_show_modal(
-            title,
+            Some(title),
             TString::empty(),
             description,
             button_text,
@@ -1089,7 +1089,7 @@ impl FirmwareUI for UIBolt {
         let layout = RootComponent::new(
             IconDialog::new(
                 icon,
-                title,
+                Some(title),
                 Button::cancel_confirm(
                     Button::with_icon(theme::ICON_BACK),
                     Button::with_text(button).styled(theme::button_reset()),
@@ -1253,7 +1253,7 @@ impl FirmwareUI for UIBolt {
             theme::BG,
         );
         new_show_modal(
-            title,
+            Some(title),
             TString::empty(),
             description,
             (!button.is_empty()).then_some(button),
@@ -1290,7 +1290,7 @@ impl FirmwareUI for UIBolt {
             return Err(Error::ValueError(c"Non-empty title is required"));
         }
         new_show_modal(
-            title.unwrap_or(TString::empty()),
+            title,
             value,
             description,
             (!button.is_empty()).then_some(button),
@@ -1312,7 +1312,7 @@ impl FirmwareUI for UIBolt {
 
 #[allow(clippy::too_many_arguments)]
 fn new_show_modal(
-    title: TString<'static>,
+    title: Option<TString<'static>>,
     value: TString<'static>,
     description: TString<'static>,
     button: Option<TString<'static>>,

--- a/core/embed/rust/src/ui/layout_caesar/ui_firmware.rs
+++ b/core/embed/rust/src/ui/layout_caesar/ui_firmware.rs
@@ -1366,7 +1366,7 @@ impl FirmwareUI for UICaesar {
     }
 
     fn show_warning(
-        _title: TString<'static>,
+        _title: Option<TString<'static>>,
         button: TString<'static>,
         value: TString<'static>,
         description: TString<'static>,

--- a/core/embed/rust/src/ui/layout_caesar/ui_firmware.rs
+++ b/core/embed/rust/src/ui/layout_caesar/ui_firmware.rs
@@ -1366,13 +1366,17 @@ impl FirmwareUI for UICaesar {
     }
 
     fn show_warning(
-        _title: Option<TString<'static>>,
+        title: Option<TString<'static>>,
         button: TString<'static>,
         value: TString<'static>,
         description: TString<'static>,
         _allow_cancel: bool,
-        _danger: bool,
+        danger: bool,
     ) -> Result<Gc<LayoutObj>, Error> {
+        if danger && title.is_none() {
+            // Disallow showing "dangerous" warning with no header.
+            return Err(Error::ValueError(c"Non-empty title is required"));
+        }
         let get_page = move |page_index| {
             assert!(page_index == 0);
 

--- a/core/embed/rust/src/ui/layout_delizia/ui_firmware.rs
+++ b/core/embed/rust/src/ui/layout_delizia/ui_firmware.rs
@@ -1233,7 +1233,7 @@ impl FirmwareUI for UIDelizia {
     }
 
     fn show_warning(
-        title: TString<'static>,
+        title: Option<TString<'static>>,
         button: TString<'static>,
         value: TString<'static>,
         description: TString<'static>,
@@ -1253,20 +1253,23 @@ impl FirmwareUI for UIDelizia {
             .into_paragraphs(),
         );
 
-        let frame = if title.is_empty() {
-            if danger {
-                // Disallow showing "dangerous" warning with no header.
-                return Err(Error::ValueError(c"Non-empty title is required"));
+        let frame = match title {
+            None => {
+                if danger {
+                    // Disallow showing "dangerous" warning with no header.
+                    return Err(Error::ValueError(c"Non-empty title is required"));
+                }
+                Frame::content(content)
             }
-            Frame::content(content)
-        } else {
-            let header = Header::left_aligned(title);
-            let header = if danger {
-                header.with_danger_icon()
-            } else {
-                header.with_warning_low_icon()
-            };
-            Frame::with_header(header, content)
+            Some(title) => {
+                let header = Header::left_aligned(title);
+                let header = if danger {
+                    header.with_danger_icon()
+                } else {
+                    header.with_warning_low_icon()
+                };
+                Frame::with_header(header, content)
+            }
         };
         let frame = if danger {
             frame.with_tap_footer(action)

--- a/core/embed/rust/src/ui/layout_eckhart/ui_firmware.rs
+++ b/core/embed/rust/src/ui/layout_eckhart/ui_firmware.rs
@@ -1576,7 +1576,13 @@ impl FirmwareUI for UIEckhart {
         };
         let screen = TextScreen::new(paragraphs).with_action_bar(action_bar);
         let screen = match title {
-            None => screen,
+            None => {
+                if danger {
+                    // Disallow showing "dangerous" warning with no header.
+                    return Err(Error::ValueError(c"Non-empty title is required"));
+                }
+                screen
+            }
             Some(title) => screen.with_header(
                 Header::new(title)
                     .with_icon(theme::ICON_INFO, color)

--- a/core/embed/rust/src/ui/layout_eckhart/ui_firmware.rs
+++ b/core/embed/rust/src/ui/layout_eckhart/ui_firmware.rs
@@ -1546,7 +1546,7 @@ impl FirmwareUI for UIEckhart {
     }
 
     fn show_warning(
-        title: TString<'static>,
+        title: Option<TString<'static>>,
         button: TString<'static>,
         value: TString<'static>,
         description: TString<'static>,
@@ -1575,14 +1575,13 @@ impl FirmwareUI for UIEckhart {
             ActionBar::new_single(Button::with_text(button))
         };
         let screen = TextScreen::new(paragraphs).with_action_bar(action_bar);
-        let screen = if title.is_empty() {
-            screen
-        } else {
-            screen.with_header(
+        let screen = match title {
+            None => screen,
+            Some(title) => screen.with_header(
                 Header::new(title)
                     .with_icon(theme::ICON_INFO, color)
                     .with_text_style(style),
-            )
+            ),
         };
         let layout = LayoutObj::new(screen)?;
         Ok(layout)

--- a/core/embed/rust/src/ui/ui_firmware.rs
+++ b/core/embed/rust/src/ui/ui_firmware.rs
@@ -464,7 +464,7 @@ pub trait FirmwareUI {
     fn show_wait_text(text: TString<'static>) -> Result<impl LayoutMaybeTrace, Error>;
 
     fn show_warning(
-        title: TString<'static>,
+        title: Option<TString<'static>>,
         button: TString<'static>,
         value: TString<'static>,
         description: TString<'static>,

--- a/core/mocks/generated/trezorui_api.pyi
+++ b/core/mocks/generated/trezorui_api.pyi
@@ -834,7 +834,7 @@ def show_wait_text(message: str, /) -> LayoutObj[None]:
 # rust/src/ui/api/firmware_micropython.rs
 def show_warning(
     *,
-    title: str,
+    title: str | None,
     button: str,
     value: str = "",
     description: str = "",


### PR DESCRIPTION
Use `None` as a special marker for explicitly hiding the header (instead of checking for an empty title strings).

Following https://github.com/trezor/trezor-firmware/pull/6651#pullrequestreview-4219282847, similar to #7012 (for Delizia) & #6980 (for Eckhart).