### PR TITLE
chore: fix `yamllint` warning in `core-hw.yml`

### DIFF
--- a/.github/workflows/core-hw.yml
+++ b/.github/workflows/core-hw.yml
@@ -85,7 +85,7 @@ jobs:
       - self-hosted
       # FIXME runner4 with t2b1 does not work at the moment
       - ${{ matrix.model == 'T2B1' && 'runner3' || matrix.model == 'T3T1' && 'hw-t3t1' || matrix.model == 'T3B1' && 'hw-t3b1' || matrix.model == 'T3W1' && 'hw-t3w1' || 'hw-t2t1' }}
-    if: false # FIXME https://github.com/trezor/trezor-firmware/issues/3128
+    if: false  # FIXME https://github.com/trezor/trezor-firmware/issues/3128
     strategy:
       fail-fast: false
       matrix:

--- a/Makefile
+++ b/Makefile
@@ -83,7 +83,7 @@ translations_style_check: ## Check that translation files are properly formatted
 
 yaml_check: ## check yaml formatting
 	@echo [YAML-STYLE-CHECK]
-	yamllint .
+	yamllint --strict .
 
 editor_check: ## check editorconfig formatting
 	@echo [EDITORCONFIG-STYLE-CHECK]


### PR DESCRIPTION
```
./.github/workflows/core-hw.yml
  88:15     warning  too few spaces before comment: expected 2  (comments)
```
