### PR TITLE
fix(core): fix firmware build with extapp support

### DIFF
--- a/core/embed/io/app_loader/build.rs
+++ b/core/embed/io/app_loader/build.rs
@@ -18,7 +18,7 @@ pub fn def_module(lib: &mut CLibrary) -> Result<()> {
     if cfg!(feature = "emulator") {
         lib.add_source("app_loader/unix/elf_loader.c");
     } else if cfg!(feature = "mcu_stm32") {
-        lib.add_source("app_loader/stm32/app_loader.c");
+        lib.add_source("app_loader/stm32/elf_loader.c");
     } else {
         bail_unsupported!();
     }

--- a/core/embed/sec/secure_aes/inc/sec/secure_aes.h
+++ b/core/embed/sec/secure_aes/inc/sec/secure_aes.h
@@ -21,7 +21,7 @@
 
 #include <trezor_types.h>
 
-#ifdef USE_APPLETS
+#if defined(USE_APPLETS) && defined(KERNEL_MODE)
 #include <sys/applet.h>
 #endif
 
@@ -38,7 +38,7 @@ secbool secure_aes_init(void);
 
 // Sets the applet to be used for AES operation
 // with unprivileged key (XORK_SN).
-#ifdef USE_APPLETS
+#if defined(USE_APPLETS) && defined(KERNEL_MODE)
 void secure_aes_set_applet(applet_t* applet);
 #endif
 

--- a/core/embed/sec/secure_aes/stm32u5/secure_aes_unpriv.c
+++ b/core/embed/sec/secure_aes/stm32u5/secure_aes_unpriv.c
@@ -106,7 +106,7 @@ __attribute((no_stack_protector)) void saes_unpriv_callback(void) {
 // -----------------------------------------------------------------------
 // Code running privileged mode
 
-#ifdef USE_APPLETS
+#if defined(USE_APPLETS) && defined(KERNEL_MODE)
 
 #include <sys/coreapp.h>
 #include <sys/mpu.h>
@@ -182,4 +182,4 @@ secbool secure_aes_unpriv_encrypt(const uint8_t *input, size_t size,
 
   return retval;
 }
-#endif  // USE_APPLETS
+#endif  // USE_APPLETS && KERNEL_MODE

--- a/core/embed/sys/syscall/stm32/syscall_internal.h
+++ b/core/embed/sys/syscall/stm32/syscall_internal.h
@@ -21,7 +21,6 @@
 
 #include <trezor_types.h>
 
-#include <sys/applet.h>
 #include <sys/syscall.h>
 #include <sys/syscall_numbers.h>
 

--- a/core/embed/sys/task/applet.c
+++ b/core/embed/sys/task/applet.c
@@ -17,13 +17,13 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
+#if defined(USE_APPLETS) && defined(KERNEL_MODE)
+
 #include <trezor_rtl.h>
 
 #include <sys/applet.h>
 #include <sys/sysevent_source.h>
 #include <sys/systask.h>
-
-#ifdef USE_APPLETS
 
 void applet_init(applet_t* applet, const applet_privileges_t* privileges,
                  applet_unload_cb_t unload_cb) {
@@ -65,4 +65,4 @@ applet_t* applet_active(void) {
   return (applet_t*)task->applet;
 }
 
-#endif  // USE_APPLETS
+#endif  // USE_APPLETS && KERNEL_MODE

--- a/core/embed/sys/task/stm32/coreapp.c
+++ b/core/embed/sys/task/stm32/coreapp.c
@@ -17,7 +17,7 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-#ifdef USE_APPLETS
+#if defined(USE_APPLETS) && defined(KERNEL_MODE)
 
 #include <trezor_model.h>
 #include <trezor_rtl.h>
@@ -160,4 +160,4 @@ mpu_area_t coreapp_get_tls_area(void) { return coreapp_tls_area; }
 
 void* coreapp_get_api_getter(void) { return coreapp_api_getter; }
 
-#endif  // USE_APPLETS
+#endif  // USE_APPLETS && KERNEL_MODE


### PR DESCRIPTION
This PR fixes the firmware build when external app support is enabled (`xtask build firmware -m t3w1 --apps`).

It does not affect any current firmware functionality.







