### PR TITLE
refactor(core): print exception details

### DIFF
--- a/core/src/apps/management/recovery_device/layout.py
+++ b/core/src/apps/management/recovery_device/layout.py
@@ -320,6 +320,7 @@ else:
 
     class RetryRead(Exception):
         def __init__(self, msg: str) -> None:
+            super().__init__(msg)
             self.msg = msg
 
     async def _read_share() -> str:

--- a/core/src/apps/management/reset_device/layout.py
+++ b/core/src/apps/management/reset_device/layout.py
@@ -230,6 +230,7 @@ if utils.USE_N4W1:
 
     class RetryWrite(Exception):
         def __init__(self, msg: str) -> None:
+            super().__init__(msg)
             self.msg = msg
 
     class _N4W1Backup:

--- a/core/src/trezor/wire/context.py
+++ b/core/src/trezor/wire/context.py
@@ -47,7 +47,7 @@ class UnexpectedMessageException(Exception):
     """
 
     def __init__(self, msg: Message | None) -> None:
-        super().__init__()
+        super().__init__(msg.type)
         self.msg = msg
 
 

--- a/core/src/trezor/wire/errors.py
+++ b/core/src/trezor/wire/errors.py
@@ -3,14 +3,14 @@ from trezor.enums import FailureType
 
 class Error(Exception):
     def __init__(self, code: FailureType, message: str) -> None:
-        super().__init__()
+        super().__init__(message)
         self.code = code
         self.message = message
 
 
 class SilentError(Exception):
     def __init__(self, message: str) -> None:
-        super().__init__()
+        super().__init__(message)
         self.message = message
 
 


### PR DESCRIPTION
When instantiating Exception subclass, pass the details to the base class ctor so that they can be printed along with the type. Not sure why we haven't been doing that, maybe I'm overlooking a reason. It's true that it's only useful for debugging and also allocates additional tuple.

Before
```
2364.239 trezor.loop ERR exception:
Traceback (most recent call last):
  File "trezor/loop.py", in _step
  File "trezor/wire/__init__.py", in handle_session_thp
FirmwareError:
```

After
```
2364.239 trezor.loop ERR exception:
Traceback (most recent call last):
  File "trezor/loop.py", in _step
  File "trezor/wire/__init__.py", in handle_session_thp
FirmwareError: Failed to get a sufficiently large buffer
```

<!--
For external contributors:
- Please open an issue before submitting a PR so we can discuss whether we want to proceed with it.

For core developers:
1. Initial PR setup
- Assign yourself to the PR.
- Add it to the "Firmware" project
  - Set Priority (match issue priority if it exists)
  - Set Team
  - Set Sprint (target release)

2. Development status
- Draft PRs: Set status to "In Progress"
- Final PRs: Set status to "Needs Review"

3. Post-merge status
- Testable: Set status to "Needs QA" and add a `Notes for QA` section with clear instructions on how to test the functionality.
- Not Testable: Set status to "Done (no QA)"
-->
