### PR TITLE
fix(solana): show the program id for unknown programs

### DIFF
--- a/common/tests/fixtures/solana/sign_tx.unknown_instructions.json
+++ b/common/tests/fixtures/solana/sign_tx.unknown_instructions.json
@@ -34,6 +34,43 @@
       "result": {
         "expected_signature": "90093762546ad274def9b20ca6c441564193f2c7213cac704aefc6b7d65ebb315415fa7528728279a6688e2c99aa572d5af17b21a15a1d06b94e03df4ce53205"
       }
+    },
+    {
+      "description": "Multiple unknown programs",
+      "parameters": {
+        "address": "m/44'/501'/0'/0'",
+        "construct": {
+          "version": null,
+          "header": {
+            "signers": 1,
+            "readonly_signers": 0,
+            "readonly_non_signers": 2
+          },
+          "accounts": [
+            "14CCvQzQzHCVgZM3j9soPnXuJXh1RmCfwLVUcdfbZVBS",
+            "AeDJ1BqA7ruBbd6mEcS1QNxFbT8FQbiBVuN9NqK94Taq",
+            "E9yCRPT8A2AyuEaMPwk2Mi9iJFDoQVMoExyYvKQuNhyN",
+            "3JUnusNfX8BZx6Gio4kLx1JHg9mHodSW9NbSnqwYwk1s"
+          ],
+          "blockhash": "2p4rYZAaFfV5Uk5ugdG5KPNty9Uda9B3b4gWB8qnNqak",
+          "instructions": [
+            {
+              "program_index": 2,
+              "accounts": [0, 1],
+              "data": "04deadbeef"
+            },
+            {
+              "program_index": 3,
+              "accounts": [0, 1],
+              "data": "04c0ffeeee"
+            }
+          ],
+          "luts": []
+        }
+      },
+      "result": {
+        "expected_signature": "c53b5ff26839df02ce781da299ef625f50a627ef58a97738e53102946b1847b76ca34e464d4dc7b6f21cc4a30a088619f15dca538cd2f8d42ce1f094c382b40b"
+      }
     }
   ]
 }

--- a/core/.changelog.d/7065.fixed
+++ b/core/.changelog.d/7065.fixed
@@ -1,0 +1,1 @@
+Solana: show each instruction's program id when displaying details for unknown programs instead of a generic "Unsupported program" label.

--- a/core/src/apps/solana/layout.py
+++ b/core/src/apps/solana/layout.py
@@ -298,6 +298,16 @@ async def confirm_unsupported_program_confirm(
 ) -> None:
     title = f"{instruction_index}/{instructions_count}: {instruction.ui_name}"
 
+    # Show the program id on its own screen so the user can tell which program
+    # this is; putting a 44-char base58 in the header overflows the layout.
+    await confirm_address(
+        title=title,
+        address=instruction.program_id,
+        verb=TR.buttons__continue,
+        br_name="unsupported_program",
+        br_code=ButtonRequestType.ConfirmOutput,
+    )
+
     return await confirm_unsupported_instruction_details(
         instruction, title, signer_path, signer_public_key
     )


### PR DESCRIPTION
Very simple fix here that shows the actual unknown program id instead of just "unknown program". 

It does add an extra confirm step for each unknown instruction, though. The other alternative could be to just surface the program id in the show details view instead, which keeps the same amount of taps but blind signing without tapping the details would remain truly blind. 

## With this change:
<img height="300" alt="image" src="https://github.com/user-attachments/assets/af151cec-9ecd-4439-a8d6-b30954a7baef" />

## Current view:
<img height="300" alt="image" src="https://github.com/user-attachments/assets/54ab16fb-1762-4d12-a541-8b8177e08ed8" />

The program id is never shown, and not surfaced via the transaction details view either.
<!--
For external contributors:
- Please open an issue before submitting a PR so we can discuss whether we want to proceed with it.

For core developers:
1. Initial PR setup
- Assign yourself to the PR.
- Add it to the "Firmware" project
  - Set Priority (match issue priority if it exists)
  - Set Team
  - Set Sprint (target release)

2. Development status
- Draft PRs: Set status to "In Progress"
- Final PRs: Set status to "Needs Review"

3. Post-merge status
- Testable: Set status to "Needs QA" and add a `Notes for QA` section with clear instructions on how to test the functionality.
- Not Testable: Set status to "Done (no QA)"
-->
