### PR TITLE
refactor(core): enforce scoping for homescreen layouts

### DIFF
--- a/core/embed/rust/src/ui/api/firmware_micropython.rs
+++ b/core/embed/rust/src/ui/api/firmware_micropython.rs
@@ -1964,7 +1964,7 @@ pub static mp_module_trezorui_api: Module = obj_module! {
     ///     notification: tuple[str, int, bool] | None = None,
     ///     lockable: bool,
     ///     skip_first_paint: bool,
-    /// ) -> LayoutObj[UiResult]:
+    /// ) -> LayoutContext[UiResult]:
     ///     """Idle homescreen."""
     Qstr::MP_QSTR_show_homescreen => obj_fn_kw!(0, new_show_homescreen).as_obj(),
 
@@ -2060,7 +2060,7 @@ pub static mp_module_trezorui_api: Module = obj_module! {
     ///     bootscreen: bool,
     ///     skip_first_paint: bool,
     ///     coinjoin_authorized: bool = False,
-    /// ) -> LayoutObj[UiResult]:
+    /// ) -> LayoutContext[UiResult]:
     ///     """Homescreen for locked device."""
     Qstr::MP_QSTR_show_lockscreen => obj_fn_kw!(0, new_show_lockscreen).as_obj(),
 
@@ -2074,7 +2074,7 @@ pub static mp_module_trezorui_api: Module = obj_module! {
     ///     indeterminate: bool = False,
     ///     title: str | None = None,
     ///     danger: bool = False,
-    /// ) -> LayoutObj[UiResult]:
+    /// ) -> LayoutContext[UiResult]:
     ///     """Show progress loader. Please note that the number of lines reserved on screen for
     ///     description is determined at construction time. If you want multiline descriptions
     ///     make sure the initial description has at least that amount of lines."""
@@ -2086,7 +2086,7 @@ pub static mp_module_trezorui_api: Module = obj_module! {
     ///     indeterminate: bool = False,
     ///     time_ms: int = 0,
     ///     skip_first_paint: bool = False,
-    /// ) -> LayoutObj[UiResult]:
+    /// ) -> LayoutContext[UiResult]:
     ///     """Show progress loader for coinjoin. Returns CANCELLED after a specified time when
     ///     time_ms timeout is passed."""
     Qstr::MP_QSTR_show_progress_coinjoin => obj_fn_kw!(0, new_show_progress_coinjoin).as_obj(),

--- a/core/mocks/generated/trezorui_api.pyi
+++ b/core/mocks/generated/trezorui_api.pyi
@@ -623,7 +623,7 @@ def show_homescreen(
     notification: tuple[str, int, bool] | None = None,
     lockable: bool,
     skip_first_paint: bool,
-) -> LayoutObj[UiResult]:
+) -> LayoutContext[UiResult]:
     """Idle homescreen."""
 
 
@@ -728,7 +728,7 @@ def show_lockscreen(
     bootscreen: bool,
     skip_first_paint: bool,
     coinjoin_authorized: bool = False,
-) -> LayoutObj[UiResult]:
+) -> LayoutContext[UiResult]:
     """Homescreen for locked device."""
 
 
@@ -744,7 +744,7 @@ def show_progress(
     indeterminate: bool = False,
     title: str | None = None,
     danger: bool = False,
-) -> LayoutObj[UiResult]:
+) -> LayoutContext[UiResult]:
     """Show progress loader. Please note that the number of lines reserved on screen for
     description is determined at construction time. If you want multiline descriptions
     make sure the initial description has at least that amount of lines."""
@@ -757,7 +757,7 @@ def show_progress_coinjoin(
     indeterminate: bool = False,
     time_ms: int = 0,
     skip_first_paint: bool = False,
-) -> LayoutObj[UiResult]:
+) -> LayoutContext[UiResult]:
     """Show progress loader for coinjoin. Returns CANCELLED after a specified time when
     time_ms timeout is passed."""
 

--- a/core/src/apps/homescreen/__init__.py
+++ b/core/src/apps/homescreen/__init__.py
@@ -5,7 +5,7 @@ import storage.device
 import trezorui_api
 from trezor import config, utils, wire
 from trezor.enums import MessageType
-from trezor.ui.layouts.homescreen import Busyscreen, Homescreen, Lockscreen
+from trezor.ui.layouts.homescreen import run_busyscreen, run_homescreen, run_lockscreen
 from trezorui_api import NotificationLevel
 
 from apps.base import busy_expiry_ms
@@ -14,8 +14,7 @@ from apps.common.lock_manager import lock_device
 
 
 async def busyscreen() -> None:
-    with Busyscreen(busy_expiry_ms()) as obj:
-        await obj.get_result()
+    await run_busyscreen(busy_expiry_ms())
 
 
 async def homescreen() -> None:
@@ -66,12 +65,9 @@ async def homescreen() -> None:
             False,
         )
 
-    with Homescreen(
-        label=label,
-        notification=notification,
-        lockable=config.has_pin(),
-    ) as obj:
-        res = await obj.get_result()
+    res = await run_homescreen(
+        label=label, notification=notification, lockable=config.has_pin()
+    )
 
     if utils.INTERNAL_MODEL == "T3W1":
         if res is trezorui_api.INFO:
@@ -88,11 +84,11 @@ async def _lockscreen(screensaver: bool = False) -> None:
     # Only show the lockscreen UI if the device can in fact be locked, or if it is
     # and OLED device (in which case the lockscreen is a screensaver).
     if can_lock_device() or screensaver:
-        with Lockscreen(
+        await run_lockscreen(
             label=storage.device.get_label(),
             coinjoin_authorized=is_set_any_session(MessageType.AuthorizeCoinJoin),
-        ) as obj:
-            await obj.get_result()
+        )
+
     # Otherwise proceed directly to unlock() call. If the device is already unlocked,
     # it should be a no-op storage-wise, but it resets the internal configuration
     # to an unlocked state.

--- a/core/src/boot.py
+++ b/core/src/boot.py
@@ -17,7 +17,7 @@ from trezor.pin import (
     ignore_nonpin_loader_messages,
     show_pin_timeout,
 )
-from trezor.ui.layouts.homescreen import Lockscreen
+from trezor.ui.layouts.homescreen import run_lockscreen
 
 from apps.common.request_pin import can_lock_device, verify_user_pin
 
@@ -55,11 +55,7 @@ def enforce_welcome_screen_duration() -> None:
 if not utils.USE_POWER_MANAGER:
 
     async def pin_unlock_sequence() -> None:
-        with Lockscreen(
-            label=storage.device.get_label(),
-            bootscreen=True,
-        ) as lockscreen:
-            await lockscreen.get_result()
+        await run_lockscreen(label=storage.device.get_label(), bootscreen=True)
         await verify_user_pin()
 
 else:
@@ -72,11 +68,7 @@ else:
 
     async def pin_unlock_sequence() -> None:
         while True:
-            with Lockscreen(
-                label=storage.device.get_label(),
-                bootscreen=True,
-            ) as lockscreen:
-                await lockscreen.get_result()
+            await run_lockscreen(label=storage.device.get_label(), bootscreen=True)
             res = await loop.race(verify_user_pin(), wait_for_suspend())
             if res is _SUSPEND_MARKER:
                 # make some delay for the suspend

--- a/core/src/trezor/ui/layouts/homescreen.py
+++ b/core/src/trezor/ui/layouts/homescreen.py
@@ -9,7 +9,6 @@ if TYPE_CHECKING:
     from typing import Any, Callable, Iterator, ParamSpec, Tuple, TypeVar
 
     from trezor import loop
-    from typing_extensions import Self
 
     P = ParamSpec("P")
     R = TypeVar("R")
@@ -55,15 +54,14 @@ class UsbAwareLayout(ui.Layout):
         yield self.usb_checker_task()
 
 
-class HomescreenBase(UsbAwareLayout):
-    RENDER_INDICATOR: object | None = None
-
-    def __init__(self, layout: trezorui_api.LayoutObj[trezorui_api.UiResult]) -> None:
-        super().__init__(layout=layout)
-        self.should_resume = self._should_resume()
-
-    def _should_resume(self) -> bool:
-        return storage_cache.homescreen_shown is self.RENDER_INDICATOR
+class HomescreenLayout(UsbAwareLayout):
+    def __init__(
+        self,
+        layout: trezorui_api.LayoutObj[trezorui_api.UiResult],
+        render_indicator: object,
+    ) -> None:
+        super().__init__(layout)
+        self.render_indicator = render_indicator
 
     def _paint(self) -> None:
         self.layout.paint()
@@ -71,96 +69,107 @@ class HomescreenBase(UsbAwareLayout):
     def _first_paint(self) -> None:
         if not self.should_resume:
             super()._first_paint()
-            storage_cache.homescreen_shown = self.RENDER_INDICATOR
+            storage_cache.homescreen_shown = self.render_indicator
         else:
             self._paint()
 
-    def __enter__(self) -> Self:
-        self.layout.__enter__()
-        return self
+
+class HomescreenBase:
+
+    RENDER_INDICATOR: object | None = None
+
+    def __init__(self, ctx: trezorui_api.LayoutContext[trezorui_api.UiResult]) -> None:
+        self.ctx = ctx
+
+    @classmethod
+    def _should_resume(cls) -> bool:
+        return storage_cache.homescreen_shown is cls.RENDER_INDICATOR
+
+    def __enter__(self) -> HomescreenLayout:
+        layout = HomescreenLayout(self.ctx.__enter__(), self.RENDER_INDICATOR)
+        layout.should_resume = self._should_resume()
+        return layout
 
     def __exit__(self, exc_type: Any, exc_val: Any, exc_tb: Any) -> None:
         """Drop internal Rust root component."""
-        self.layout.__exit__(exc_type, exc_val, exc_tb)
+        self.ctx.__exit__(exc_type, exc_val, exc_tb)
 
 
 class Homescreen(HomescreenBase):
     RENDER_INDICATOR = storage_cache.HOMESCREEN_ON
 
-    def __init__(
-        self,
-        label: str | None,
-        notification: Tuple[str, int, bool] | None,
-        lockable: bool,
-    ) -> None:
-        super().__init__(
-            layout=_retry_with_gc(
-                trezorui_api.show_homescreen,
-                label=label or utils.MODEL_FULL_NAME,
-                notification=notification,
-                lockable=lockable,
-                skip_first_paint=self._should_resume(),
-            )
+
+async def run_homescreen(
+    label: str | None,
+    notification: Tuple[str, int, bool] | None,
+    lockable: bool,
+) -> ui.UiResult:
+
+    with Homescreen(
+        _retry_with_gc(
+            trezorui_api.show_homescreen,
+            label=label or utils.MODEL_FULL_NAME,
+            notification=notification,
+            lockable=lockable,
+            skip_first_paint=Homescreen._should_resume(),
         )
+    ) as layout:
+        return await layout.get_result()
 
 
 class Lockscreen(HomescreenBase):
     RENDER_INDICATOR = storage_cache.LOCKSCREEN_ON
 
-    def __init__(
-        self,
-        label: str | None,
-        bootscreen: bool = False,
-        coinjoin_authorized: bool = False,
-    ) -> None:
-        self.bootscreen = bootscreen
-        self.backlight_level = ui.BacklightLevels.LOW
+
+async def run_lockscreen(
+    label: str | None,
+    bootscreen: bool = False,
+    coinjoin_authorized: bool = False,
+) -> ui.UiResult:
+
+    skip = not bootscreen and Lockscreen._should_resume()
+    with Lockscreen(
+        _retry_with_gc(
+            trezorui_api.show_lockscreen,
+            label=label,
+            bootscreen=bootscreen,
+            skip_first_paint=skip,
+            coinjoin_authorized=coinjoin_authorized,
+        )
+    ) as layout:
+        layout.backlight_level = ui.BacklightLevels.LOW
         if bootscreen:
-            self.backlight_level = ui.BacklightLevels.NORMAL
+            layout.backlight_level = ui.BacklightLevels.NORMAL
+        layout.should_resume = skip
 
-        skip = (
-            not bootscreen and storage_cache.homescreen_shown is self.RENDER_INDICATOR
-        )
-        super().__init__(
-            layout=_retry_with_gc(
-                trezorui_api.show_lockscreen,
-                label=label,
-                bootscreen=bootscreen,
-                skip_first_paint=skip,
-                coinjoin_authorized=coinjoin_authorized,
-            ),
-        )
-        self.should_resume = skip
-
-    async def get_result(self) -> Any:
-        result = await super().get_result()
-        if self.bootscreen:
+        result = await layout.get_result()
+        if bootscreen:
             # todo: should this be repaint()?
-            self.request_complete_repaint()
+            layout.request_complete_repaint()
         return result
 
 
 class Busyscreen(HomescreenBase):
     RENDER_INDICATOR = storage_cache.BUSYSCREEN_ON
 
-    def __init__(self, delay_ms: int) -> None:
-        super().__init__(
-            layout=_retry_with_gc(
-                trezorui_api.show_progress_coinjoin,
-                title=TR.coinjoin__waiting_for_others,
-                indeterminate=True,
-                time_ms=delay_ms,
-                skip_first_paint=self._should_resume(),
-            )
-        )
 
-    async def get_result(self) -> Any:
+async def run_busyscreen(delay_ms: int) -> ui.UiResult:
+    with Busyscreen(
+        _retry_with_gc(
+            trezorui_api.show_progress_coinjoin,
+            title=TR.coinjoin__waiting_for_others,
+            indeterminate=True,
+            time_ms=delay_ms,
+            skip_first_paint=Busyscreen._should_resume(),
+        )
+    ) as layout:
         from trezor.wire import context
 
         from apps.common.lock_manager import set_homescreen
 
+        result = await layout.get_result()
+
         # Handle timeout.
-        result = await super().get_result()
         assert result == trezorui_api.CANCELLED
         context.cache_delete(APP_COMMON_BUSY_DEADLINE_MS)
         set_homescreen()

--- a/core/src/trezor/ui/layouts/progress.py
+++ b/core/src/trezor/ui/layouts/progress.py
@@ -41,14 +41,14 @@ def progress(
     if description is None:
         description = TR.progress__please_wait  # def_arg
 
-    return ui.ProgressLayout(
-        layout=trezorui_api.show_progress(
-            description=description,
-            title=title,
-            indeterminate=indeterminate,
-            danger=danger,
-        )
+    ctx = trezorui_api.show_progress(
+        description=description,
+        title=title,
+        indeterminate=indeterminate,
+        danger=danger,
     )
+    # TODO: use explicit scope for progress layout
+    return ui.ProgressLayout(layout=ctx.__enter__())
 
 
 def bitcoin_progress(message: str) -> ui.ProgressLayout:
@@ -56,9 +56,9 @@ def bitcoin_progress(message: str) -> ui.ProgressLayout:
 
 
 def coinjoin_progress(message: str) -> ui.ProgressLayout:
-    return ui.ProgressLayout(
-        layout=trezorui_api.show_progress_coinjoin(title=message, indeterminate=False)
-    )
+    ctx = trezorui_api.show_progress_coinjoin(title=message, indeterminate=False)
+    # TODO: use explicit scope for progress layout
+    return ui.ProgressLayout(layout=ctx.__enter__())
 
 
 def pin_progress(


### PR DESCRIPTION
Progress layouts still rely on GC for deallocation.

Following https://github.com/trezor/trezor-firmware/pull/6812.
