### PR TITLE
ci(core): use `core/Makefile` to run upgrade tests

### DIFF
--- a/.github/workflows/core.yml
+++ b/.github/workflows/core.yml
@@ -436,7 +436,7 @@ jobs:
         with:
           full-deps: "true"
       - run: nix-shell --arg fullDeps true --run "tests/download_emulators.sh ${{ matrix.model }}"
-      - run: nix-shell --arg fullDeps true --run "uv run pytest tests/upgrade_tests"
+      - run: nix-shell --arg fullDeps true --run "uv run make -C core test_emu_upgrade"
       - uses: actions/upload-artifact@bbbca2ddaa5d8feaa63e36b76fdaad77386f024f  # actions/upload-artifact@v7.0.0
         with:
           name: core-test-upgrade-${{ matrix.model }}-${{ matrix.asan }}

--- a/core/Makefile
+++ b/core/Makefile
@@ -143,6 +143,9 @@ test_emu_persistence_ui: ## run persistence tests with UI testing
 	$(PYTEST) $(TESTPATH)/persistence_tests $(TESTOPTS) \
 		--ui=test --ui-check-missing --do-master-diff --lang=$(TEST_LANG)
 
+test_emu_upgrade: ## run upgrade tests
+	$(PYTEST) $(TESTPATH)/upgrade_tests $(TESTOPTS) --lang=$(TEST_LANG)
+
 test_emu_ui: ## run ui integration tests
 	$(EMU_TEST) $(PYTEST) $(TESTPATH)/device_tests $(TESTOPTS) \
 		--ui=test --ui-check-missing --do-master-diff \


### PR DESCRIPTION
Otherwise, `TESTOPTS` are not propagated.
