### PR TITLE
add support for different NCS sdk versions

### DIFF
--- a/nordic/trezor/README.md
+++ b/nordic/trezor/README.md
@@ -1,7 +1,8 @@
 # Trezor BLE Gateway
 
 Welcome to the **Trezor BLE Gateway** project!
-This repository contains the source code and instructions to build and flash the application onto the `t3w1_nrf52833` board.
+This repository contains the source code and instructions to build and flash the
+application.
 
 ## Table of Contents
 
@@ -11,6 +12,7 @@ This repository contains the source code and instructions to build and flash the
     - [Launch the nRF Shell](#launch-the-nrf-shell)
     - [Initialize the Workspace](#initialize-the-workspace)
     - [Update nRF Connect SDK Modules](#update-nrf-connect-sdk-modules)
+    - [Selecting the nRF Connect SDK version](#selecting-the-nrf-connect-sdk-version)
     - [Build the Application](#build-the-application)
     - [Flash the Application](#flash-the-application)
 - [Contributing](#contributing)
@@ -29,17 +31,34 @@ Follow these steps to set up the project on your local machine.
 
 ### Install the toolchain
 
-Using nrfutil, install the required toolchain for the nRF Connect SDK:
+Using nrfutil, install the toolchain for the nRF Connect SDK. The project
+defaults to **NCS v3.3.0**; install the matching toolchain:
+```sh
+nrfutil toolchain-manager install --ncs-version v3.3.0
+```
+
+The regulatory-frozen build still uses **NCS v2.9.0**. If you need to switch to
+it (see [Selecting the SDK version](#selecting-the-nrf-connect-sdk-version)),
+install that toolchain as well:
 ```sh
 nrfutil toolchain-manager install --ncs-version v2.9.0
 ```
 
 ### Launch the nRF Shell
 
-First, launch the nRF shell using the `nrfutil` toolchain manager and set the NCS to chosen version:
+> Note: `build_sign_flash.sh` selects and pins the correct toolchain
+> automatically. Launching the nRF shell manually is only needed if you want to
+> run `west` or other NCS commands directly outside the script.
+
+Launch the nRF shell with the toolchain matching the SDK you intend to build
+for:
 
 ```sh
-nrfutil toolchain-manager launch --shell
+# For the default NCS 3.3.0 build
+nrfutil toolchain-manager launch --shell --ncs-version v3.3.0
+
+# For the regulatory-frozen NCS 2.9.0 build (t3w1_revA_nrf52832)
+nrfutil toolchain-manager launch --shell --ncs-version v2.9.0
 ```
 
 ### Initialize the Workspace
@@ -55,6 +74,48 @@ Update the modules:
 ```sh
 west update
 ```
+
+### Selecting the nRF Connect SDK version
+
+The workspace ships two manifests, sharing a single checkout:
+
+| Manifest            | SDK        | Role                              |
+|---------------------|------------|-----------------------------------|
+| `west.yml`          | NCS v3.3.0 | **Default** (used by `west init`) |
+| `west-ncs2.9.yml`   | NCS v2.9.0 | Regulatory-frozen, occasional     |
+
+`west init -l ./trezor` selects `west.yml` (3.3.0). To switch the active
+manifest, change it and re-run `west update` in the same workspace:
+
+```sh
+# Drop to the frozen 2.9.x SDK
+west config manifest.file west-ncs2.9.yml
+west update
+
+# Return to the default 3.3.x SDK
+west config manifest.file west.yml
+west update
+```
+
+Each board is tied to one SDK — build the matching board for the active manifest:
+
+| Manifest          | SDK        | Board to build                |
+| `west-ncs2.9.yml` | NCS v2.9.0 | `t3w1_revA_nrf52832`          |
+
+
+Notes:
+- Only one SDK is checked out at a time, so always rebuild with
+  `--pristine=always` after switching.
+- Switch the toolchain to match the manifest (`nrfutil toolchain-manager
+  launch --shell` with the corresponding NCS version), or builds will fail in
+  confusing ways.
+- SDK differences in application **code** are handled with `<ncs_version.h>`,
+  writing for the current default (3.3) and gating the older SDK as the
+  exception: `#if NCS_VERSION_NUMBER < 0x030300  /* NCS 2.9 */ … #else … #endif`.
+- Board/SoC differences in **Kconfig and devicetree** go in
+  `boards/<board>.{conf,overlay}` (auto-merged by Zephyr for the matching board).
+  Since each board targets a single SDK, this also covers version-specific
+  config/DT without a separate version gate.
 
 
 ## Recommended build methods

--- a/nordic/trezor/scripts/build_sign_flash.sh
+++ b/nordic/trezor/scripts/build_sign_flash.sh
@@ -19,6 +19,8 @@ HEADER_SIZE=
 SLOT_ADDR=
 SLOT_SIZE=
 MODEL_IDENTIFIER=
+# Resolved by verify_environment(); pins the toolchain used by the build subshell.
+NCS_TOOLCHAIN_VERSION=
 
 fatal() {
     echo "$@"
@@ -49,10 +51,23 @@ run_under_ncs_subshell() {
         # Docker/Nix environment - run directly
         eval "$@" || fatal "Error in direct command execution"
     else
-        # Local development environment - use nrfutil
-        (source <(nrfutil toolchain-manager env | perl -pe 's/^(\w+)\s*:\s*(.*)/export \1=\2/'); bash -x -c "$@") \
+        # Local development environment - use nrfutil. Pin the toolchain to the
+        # version resolved by verify_environment() so the build does not silently
+        # use whatever toolchain happens to be the active ('*') default.
+        local tcm_env="nrfutil toolchain-manager env"
+        [ -n "$NCS_TOOLCHAIN_VERSION" ] && tcm_env="$tcm_env --ncs-version $NCS_TOOLCHAIN_VERSION"
+        (source <($tcm_env | perl -pe 's/^(\w+)\s*:\s*(.*)/export \1=\2/'); bash -x -c "$@") \
             || fatal "Error in nrfutil subshell"
     fi
+}
+
+# Run host-side signing/merge tools in the *current* shell. imgtool, hash_signer
+# and the helper Python scripts come from the uv/.venv (or nix) environment and
+# must NOT inherit the NCS toolchain's Python env (PYTHONHOME), which points a
+# different-version interpreter at the wrong stdlib ("SRE module mismatch").
+# Only 'west build'/'west flash' need the NCS toolchain (run_under_ncs_subshell).
+run_native() {
+    eval "$@" || fatal "Error running host command: $*"
 }
 
 usage() {
@@ -101,6 +116,85 @@ parse_partition_info() {
     MODEL_IDENTIFIER="0x${hex:6:2}${hex:4:2}${hex:2:2}${hex:0:2}"
 }
 
+# Verify the active nRF Connect SDK / toolchain match the target board before
+# building. Each board is pinned to one SDK: t3w1 -> NCS 2.9 (west-ncs2.9.yml).
+# Building with the wrong SDK or toolchain active produces confusing,
+# hard-to-diagnose failures.
+verify_environment() {
+    local board="$1"
+    local required_major expected_manifest
+    case "$board" in
+        t3w1*)   required_major=2; expected_manifest="west-ncs2.9.yml" ;;
+        *)
+            echo "verify: board '$board' has no known SDK pairing; skipping SDK/toolchain check."
+            return 0
+            ;;
+    esac
+
+    # Authoritative: the SDK actually checked out into the workspace by the last
+    # 'west update'. This is what the build will really use, regardless of what
+    # 'west config manifest.file' currently says.
+    local nrf_version_file="../nrf/VERSION"
+    [ -f "$nrf_version_file" ] || fatal "verify: cannot read $nrf_version_file - is the west workspace initialized and updated?"
+    local sdk_version sdk_major sdk_mm
+    sdk_version=$(tr -d '[:space:]' < "$nrf_version_file")
+    sdk_major="${sdk_version%%.*}"
+    sdk_mm="${sdk_version%.*}"   # major.minor, e.g. 2.9
+
+    if [ "$sdk_major" != "$required_major" ]; then
+        fatal "verify: board '$board' requires NCS v${required_major}.x, but the checked-out SDK is v${sdk_version}.
+Select the matching manifest, update the workspace, then rebuild pristine:
+    (cd .. && west config manifest.file ${expected_manifest} && west update)
+    $0 -b ${board} <flags> -c"
+    fi
+
+    # West manifest selection (advisory; the SDK check above is authoritative).
+    if command -v west >/dev/null 2>&1; then
+        local active_manifest
+        active_manifest=$(west config manifest.file 2>/dev/null)
+        if [ -n "$active_manifest" ] && [ "$active_manifest" != "$expected_manifest" ]; then
+            echo "verify: WARNING active west manifest is '$active_manifest' (expected '$expected_manifest' for '$board')."
+            echo "        Checked-out SDK v${sdk_version} matches the board; run 'west update' if you just changed the manifest."
+        fi
+    fi
+
+    # Toolchain selection depends on the execution environment (see
+    # detect_environment): under nix/Docker the toolchain is pre-provided via
+    # GNUARMEMB_TOOLCHAIN_PATH and the build runs directly, so there is nothing
+    # to pin. Only the local nrfutil path needs a pinned toolchain.
+    if [ -n "$GNUARMEMB_TOOLCHAIN_PATH" ] && [ -n "$ZEPHYR_TOOLCHAIN_VARIANT" ]; then
+        echo "verify: OK - board '$board' <-> NCS v${sdk_version} (manifest ${expected_manifest}); using pre-set ${ZEPHYR_TOOLCHAIN_VARIANT} toolchain."
+        return 0
+    fi
+
+    # Local nrfutil path: 'nrfutil toolchain-manager list' marks the active/default
+    # toolchain with a leading '*'. The build subshell sources 'toolchain-manager
+    # env', which returns that active toolchain unless we pin one - so resolve the
+    # toolchain matching the checked-out SDK and pin the build to it.
+    if command -v nrfutil >/dev/null 2>&1; then
+        local tc_list active_tc resolved_tc
+        tc_list=$(nrfutil toolchain-manager list 2>/dev/null)
+        active_tc=$(echo "$tc_list" | awk '$1=="*"{print $2}')
+        # Prefer an exact match for the checked-out SDK, else any vMAJOR.MINOR.*.
+        resolved_tc=$(echo "$tc_list" | grep -oE 'v[0-9]+\.[0-9]+\.[0-9]+' | grep -xE "v${sdk_version}" | head -1)
+        [ -n "$resolved_tc" ] || resolved_tc=$(echo "$tc_list" | grep -oE 'v[0-9]+\.[0-9]+\.[0-9]+' | grep -E "^v${sdk_mm}\." | head -1)
+
+        if [ -z "$resolved_tc" ]; then
+            fatal "verify: no NCS v${sdk_mm}.x toolchain installed (needed for '$board').
+Install it with:
+    nrfutil toolchain-manager install --ncs-version v${sdk_mm}.0"
+        fi
+
+        NCS_TOOLCHAIN_VERSION="$resolved_tc"
+        if [ "$active_tc" != "$resolved_tc" ]; then
+            echo "verify: active toolchain is '${active_tc:-none}', but '$board' needs NCS v${sdk_mm}.x;"
+            echo "        pinning this build to toolchain ${resolved_tc}."
+        fi
+    fi
+
+    echo "verify: OK - board '$board' <-> NCS v${sdk_version}, toolchain ${NCS_TOOLCHAIN_VERSION:-<pre-set>} (manifest ${expected_manifest})."
+}
+
 while getopts ${OPTSTRING} opt; do
   case ${opt} in
     b)
@@ -110,7 +204,10 @@ while getopts ${OPTSTRING} opt; do
       APP_DIR="$OPTARG"
       ;;
     c)
-      PRISTINE="--pristine"
+      # Force a full wipe (not 'auto'): switching SDK/toolchain leaves a
+      # CMakeCache.txt with stale toolchain paths (ninja, zephyr-sdk) that 'auto'
+      # will not detect because the board is unchanged.
+      PRISTINE="--pristine=always"
       ;;
     d)
       DEBUG="-- -DOVERLAY_CONFIG=debug.conf -Dmcuboot_EXTRA_CONF_FILE=\"$PWD/$APP_DIR/sysbuild/mcuboot.conf;$PWD/$APP_DIR/sysbuild/mcuboot_debug.conf\""
@@ -132,6 +229,7 @@ while getopts ${OPTSTRING} opt; do
 done
 
 if [ -n "$BOARD" ]; then
+    verify_environment "$BOARD"
     run_under_ncs_subshell \
         "west build ./$APP_DIR -b $BOARD --sysbuild $PRISTINE $DEBUG $PRODUCTION"
 fi
@@ -171,7 +269,7 @@ if [ "$SIGN" -eq 1 ]; then
         of="build/$APP_DIR/zephyr/zephyr_nohdr.bin" \
         || { rm -f "build/$APP_DIR/zephyr/zephyr_nohdr.bin"; fatal "dd failed to strip header from zephyr.bin"; }
 
-    run_under_ncs_subshell \
+    run_native \
         "imgtool sign --version $VERSION --align 4 --header-size $HEADER_SIZE -S $SLOT_SIZE --pad-header build/$APP_DIR/zephyr/zephyr_nohdr.bin build/$APP_DIR/zephyr/zephyr.prep.bin --custom-tlv 0x00A2 0x03 --custom-tlv 0x00A3 $MODEL_IDENTIFIER && \
          ../bootloader/mcuboot/scripts/imgtool.py dumpinfo ./build/$APP_DIR/zephyr/zephyr.prep.bin > ./build/$APP_DIR/zephyr/dump.txt"
 
@@ -180,7 +278,7 @@ if [ "$SIGN" -eq 1 ]; then
     SIGNATURE1=$(hash_signer -d "$HASH" -s1)
     echo "Signed hash $HASH, signature0 $SIGNATURE0, signature1 $SIGNATURE1"
 
-    run_under_ncs_subshell \
+    run_native \
         "python ./scripts/insert_signatures.py ./build/$APP_DIR/zephyr/zephyr.prep.bin $SIGNATURE0 $SIGNATURE1 -o ./build/$APP_DIR/zephyr/zephyr.signed_trz.bin && \
          python -c \"from intelhex import IntelHex; ih = IntelHex(); ih.loadbin('build/$APP_DIR/zephyr/zephyr.signed_trz.bin', offset=$SLOT_ADDR); ih.tofile('build/$APP_DIR/zephyr/zephyr.signed_trz.hex', format='hex')\" && \
          python ../zephyr/scripts/build/mergehex.py build/mcuboot/zephyr/zephyr.hex build/$APP_DIR/zephyr/zephyr.signed_trz.hex -o build/zephyr.merged.signed_trz.hex"

--- a/nordic/trezor/trezor-ble/boards/t3w1_revA_nrf52832.conf
+++ b/nordic/trezor/trezor-ble/boards/t3w1_revA_nrf52832.conf
@@ -4,3 +4,16 @@
 # SPDX-License-Identifier: LicenseRef-Nordic-5-Clause
 #
 
+# nRF52832-specific peripheral selection. These nrfx instance symbols and the
+# PAN-58 erratum workaround exist only on the nRF52832 SoC. They live here
+# (auto-merged for this board only) rather than in the shared prj.conf, so other
+# SoCs such as the nRF54L do not hit "assign to undefined symbol" Kconfig errors.
+# The merged t3w1 configuration is unchanged.
+CONFIG_NRFX_UARTE0=y
+CONFIG_NRFX_SPIM0=y
+CONFIG_SOC_NRF52832_ALLOW_SPIM_DESPITE_PAN_58=y
+
+# Device Information Service identity. NCS 2.9 (Zephyr 3.7) uses these symbol
+# names; they are deprecated/renamed on 3.3, so they live in the board conf.
+CONFIG_BT_DIS_MANUF="Trezor Company s.r.o"
+CONFIG_BT_DIS_MODEL="Trezor Safe 7"

--- a/nordic/trezor/trezor-ble/prj.conf
+++ b/nordic/trezor/trezor-ble/prj.conf
@@ -15,13 +15,10 @@ CONFIG_MINIMAL_LIBC=y
 
 # Enable the UART driver
 CONFIG_UART_ASYNC_API=y
-CONFIG_NRFX_UARTE0=y
 CONFIG_SERIAL=y
 
 # Enable the SPI driver
 CONFIG_SPI=y
-CONFIG_NRFX_SPIM0=y
-CONFIG_SOC_NRF52832_ALLOW_SPIM_DESPITE_PAN_58=y
 
 CONFIG_GPIO=y
 
@@ -59,8 +56,9 @@ CONFIG_BT_USER_PHY_UPDATE=y
 CONFIG_BT_BAS=y
 
 CONFIG_BT_DIS=y
-CONFIG_BT_DIS_MANUF="Trezor Company s.r.o"
-CONFIG_BT_DIS_MODEL="Trezor Safe 7"
+# Manufacturer/model are board/product-specific AND use different Kconfig symbol
+# names across NCS versions (BT_DIS_MANUF/BT_DIS_MODEL on 2.9; the *_NAME_STR/
+# *_NUMBER_STR symbols on 3.3). Set them per board in boards/<board>.conf.
 CONFIG_BT_DIS_FW_REV=y
 CONFIG_BT_DIS_FW_REV_STR="0.0.0.0"
 CONFIG_BT_DIS_SW_REV=y

--- a/nordic/trezor/trezor-ble/src/ble/advertising.c
+++ b/nordic/trezor/trezor-ble/src/ble/advertising.c
@@ -24,7 +24,16 @@
 
 #include <zephyr/logging/log.h>
 
+#include <ncs_version.h>
+
 #include "ble_internal.h"
+
+/* BT_LE_ADV_OPT_CONNECTABLE was renamed to BT_LE_ADV_OPT_CONN in Zephyr 4.x
+ * (NCS 3.x). The code below uses the current name; alias it back for the
+ * legacy NCS 2.9 SDK. */
+#if NCS_VERSION_NUMBER < 0x030300
+#define BT_LE_ADV_OPT_CONN BT_LE_ADV_OPT_CONNECTABLE
+#endif
 
 #define LOG_MODULE_NAME ble_advertising
 LOG_MODULE_REGISTER(LOG_MODULE_NAME);
@@ -184,7 +193,7 @@ void advertising_start(bool wl, bool user_disconnect, uint8_t color,
     advertising_setup_wl();
     LOG_INF("Advertising with whitelist");
 
-    uint32_t options = BT_LE_ADV_OPT_CONNECTABLE | BT_LE_ADV_OPT_SCANNABLE |
+    uint32_t options = BT_LE_ADV_OPT_CONN | BT_LE_ADV_OPT_SCANNABLE |
                        BT_LE_ADV_OPT_FILTER_CONN |
                        BT_LE_ADV_OPT_FILTER_SCAN_REQ;
     if (static_addr) {
@@ -203,7 +212,7 @@ void advertising_start(bool wl, bool user_disconnect, uint8_t color,
 
     manufacturer_data[2] |= ADV_FLAG_PAIRING;
 
-    uint32_t options = BT_LE_ADV_OPT_CONNECTABLE | BT_LE_ADV_OPT_SCANNABLE;
+    uint32_t options = BT_LE_ADV_OPT_CONN | BT_LE_ADV_OPT_SCANNABLE;
     if (static_addr) {
       LOG_ERR("Advertising with static ADDR");
       options |= BT_LE_ADV_OPT_USE_IDENTITY;

--- a/nordic/trezor/trezor-ble/src/ble/ble.c
+++ b/nordic/trezor/trezor-ble/src/ble/ble.c
@@ -31,6 +31,7 @@
 #include <zephyr/settings/settings.h>
 
 #include <app_version.h>
+#include <ncs_version.h>
 
 #include "ble_internal.h"
 
@@ -167,7 +168,14 @@ static int ble_configure_tx_power(int8_t tx_power_level, struct bt_conn *conn) {
   struct net_buf *buf, *rsp = NULL;
   int err;
 
+  /* bt_hci_cmd_create(opcode, param_len) was replaced by
+   * bt_hci_cmd_alloc(timeout) in Zephyr 4.x (NCS 3.x); the opcode is now passed
+   * only to bt_hci_cmd_send_sync() below. */
+#if NCS_VERSION_NUMBER < 0x030300
   buf = bt_hci_cmd_create(BT_HCI_OP_VS_WRITE_TX_POWER_LEVEL, sizeof(*cp));
+#else
+  buf = bt_hci_cmd_alloc(K_FOREVER);
+#endif
   if (!buf) {
     LOG_ERR("Unable to allocate command buffer for TX power");
     return -ENOMEM;

--- a/nordic/trezor/trezor-ble/src/ble/connection.c
+++ b/nordic/trezor/trezor-ble/src/ble/connection.c
@@ -27,6 +27,8 @@
 
 #include <zephyr/logging/log.h>
 
+#include <ncs_version.h>
+
 #include "ble_internal.h"
 
 #define LOG_MODULE_NAME ble_connection
@@ -47,11 +49,18 @@ static void show_params(struct bt_conn *conn) {
   struct bt_conn_info info;
   if (bt_conn_get_info(conn, &info) == 0 && info.type == BT_CONN_TYPE_LE) {
     const struct bt_conn_le_info *le = &info.le;
-    /* Bluetooth units: interval = 1.25 ms, timeout = 10 ms */
-    uint32_t interval_ms = le->interval * 125 / 100;  // 1.25 ms units → ms
-    uint32_t timeout_ms = le->timeout * 10;           // 10 ms units  → ms
+    /* interval_us was added in Zephyr 4.x (NCS 3.x), where the 1.25 ms-unit
+     * `interval` field is deprecated. Normalize to microseconds so the rest is
+     * version-independent. timeout stays in 10 ms units on both. */
+#if NCS_VERSION_NUMBER < 0x030300
+    uint32_t interval_us = (uint32_t)le->interval * 1250;  // 1.25 ms units → us
+#else
+    uint32_t interval_us = le->interval_us;
+#endif
+    uint32_t interval_ms = interval_us / 1000;
+    uint32_t timeout_ms = le->timeout * 10;  // 10 ms units → ms
     LOG_INF("Conn params: interval=%u.%02u ms, latency=%u, timeout=%u ms",
-            interval_ms, (le->interval * 125) % 100, le->latency, timeout_ms);
+            interval_ms, (interval_us / 10) % 100, le->latency, timeout_ms);
   }
 }
 

--- a/nordic/trezor/trezor-ble/src/trz_comm/spi.c
+++ b/nordic/trezor/trezor-ble/src/trz_comm/spi.c
@@ -30,6 +30,8 @@
 #include <signals/signals.h>
 #include <trz_comm/trz_comm.h>
 
+#include <ncs_version.h>
+
 #include "trz_comm_internal.h"
 
 #define LOG_MODULE_NAME trz_comm_spi
@@ -54,6 +56,13 @@ static const struct spi_config spi_cfg = {
         {
             .gpio = SPI_CS_GPIOS_DT_SPEC_GET(DT_NODELABEL(trezor_spi_dev)),
             .delay = 0,
+/* struct spi_cs_control gained the cs_is_gpio member in Zephyr 4.x (NCS 3.x).
+ */
+#if NCS_VERSION_NUMBER < 0x030300
+/* NCS 2.9: struct spi_cs_control has no cs_is_gpio member. */
+#else
+            .cs_is_gpio = true,
+#endif
         },
 };
 

--- a/nordic/trezor/west-ncs2.9.yml
+++ b/nordic/trezor/west-ncs2.9.yml
@@ -13,10 +13,9 @@ manifest:
     - name: nrf
       remote: ncs
       repo-path: sdk-nrf
-      revision: ba167d9f3db4abbdc9b67887ca3ea66c64f2d956 #v3.3.0
+      revision: 60d0d6c8d42dd9c7bafe544a8fdf1234d6beb916 #v2.9.0
       import: true
     - name: mcuboot
       url: https://github.com/trezor/mcuboot
-      revision: de2be1c9718ccf531ad1d85ce35e4926faabe92e #trezor-ncs3.3.0
+      revision: 4f72f4eaa6c204f1193231f9695a5d8c3b253730 # trezor-v2.1.0-ncs3
       path: bootloader/mcuboot
-


### PR DESCRIPTION
This PR adds a support for NCS version 3.3.0

Since for T3W1 we still need to build on 2.9.0, the support is added in such way, that we support both version while sharing the same code. 

In C code, version gating is introduced based on NCS_VERSION.

Individual boards (currently only T3W1) are tied with specific SDK version and toolchain. Build script is amended to check compatibility with selected toolchain and SDK.

SDK switching is documented in readme.


Note: only trezor-ble app is changed, radio test and direct test mode are left for future work.