### PR TITLE
add reset command to xtask

### DIFF
--- a/core/embed/xtask/src/args.rs
+++ b/core/embed/xtask/src/args.rs
@@ -141,6 +141,8 @@ pub enum Cmd {
     Flash(FlashArgs),
     /// Erase flash or part of it using OpenOCD
     FlashErase(FlashEraseArgs),
+    /// Reset the connected device using OpenOCD
+    Reset(ResetArgs),
     /// Upload firmware to device
     Upload(UploadArgs),
     /// Combine multiple firmware projects into a single binary for flashing
@@ -321,6 +323,13 @@ pub struct FlashEraseArgs {
     #[arg(default_value = "all")]
     pub section: FlashSection,
 
+    /// Target model
+    #[arg(long, short = 'm', ignore_case = true)]
+    pub model: Model,
+}
+
+#[derive(Args, Debug)]
+pub struct ResetArgs {
     /// Target model
     #[arg(long, short = 'm', ignore_case = true)]
     pub model: Model,

--- a/core/embed/xtask/src/flash.rs
+++ b/core/embed/xtask/src/flash.rs
@@ -5,7 +5,7 @@ use std::{
 };
 
 use crate::{
-    args::{FlashArgs, FlashEraseArgs, FlashSection},
+    args::{FlashArgs, FlashEraseArgs, FlashSection, ResetArgs},
     helpers,
 };
 
@@ -66,6 +66,26 @@ pub fn flash_erase(args: FlashEraseArgs) -> Result<()> {
         .args(["-f", model_config.openocd_target()?])
         .arg("-c")
         .arg(instr)
+        .status()
+        .context("Failed to spawn `openocd`")?;
+
+    ensure!(status.success(), "`openocd` failed with status: {status}");
+
+    Ok(())
+}
+
+/// Resets the connected device using OpenOCD.
+pub fn reset(args: ResetArgs) -> Result<()> {
+    let model_config = args.model.config()?;
+
+    println!("Resetting `{:?}`", args.model);
+
+    let status = process::Command::new("openocd")
+        .args(["-f", "interface/stlink.cfg"])
+        .args(["-c", "transport select hla_swd"])
+        .args(["-f", model_config.openocd_target()?])
+        .arg("-c")
+        .arg("init; reset; exit")
         .status()
         .context("Failed to spawn `openocd`")?;
 

--- a/core/embed/xtask/src/flash.rs
+++ b/core/embed/xtask/src/flash.rs
@@ -5,7 +5,7 @@ use std::{
 };
 
 use crate::{
-    args::{FlashArgs, FlashEraseArgs, FlashSection, ResetArgs},
+    args::{FlashArgs, FlashEraseArgs, FlashSection, Model, ResetArgs},
     helpers,
 };
 
@@ -35,20 +35,8 @@ pub fn flash(args: FlashArgs) -> Result<()> {
     );
 
     let flash_instruction = build_flash_write_instruction(&binary, address);
-    let model_config = args.model.config()?;
 
-    let status = process::Command::new("openocd")
-        .args(["-f", "interface/stlink.cfg"])
-        .args(["-c", "transport select hla_swd"])
-        .args(["-f", model_config.openocd_target()?])
-        .arg("-c")
-        .arg(flash_instruction)
-        .status()
-        .context("Failed to spawn `openocd`")?;
-
-    ensure!(status.success(), "`openocd` failed with status: {status}");
-
-    Ok(())
+    run_openocd(args.model, &flash_instruction)
 }
 
 /// Erase specified flash section using OpenOCD. The section boundaries are determined
@@ -58,34 +46,27 @@ pub fn flash_erase(args: FlashEraseArgs) -> Result<()> {
     let content = fs::read_to_string(&mem_ld)
         .with_context(|| format!("Failed to read `{}`", mem_ld.display()))?;
     let instr = build_flash_erase_instruction(&content, args.section)?;
-    let model_config = args.model.config()?;
 
-    let status = process::Command::new("openocd")
-        .args(["-f", "interface/stlink.cfg"])
-        .args(["-c", "transport select hla_swd"])
-        .args(["-f", model_config.openocd_target()?])
-        .arg("-c")
-        .arg(instr)
-        .status()
-        .context("Failed to spawn `openocd`")?;
-
-    ensure!(status.success(), "`openocd` failed with status: {status}");
-
-    Ok(())
+    run_openocd(args.model, &instr)
 }
 
 /// Resets the connected device using OpenOCD.
 pub fn reset(args: ResetArgs) -> Result<()> {
-    let model_config = args.model.config()?;
-
     println!("Resetting `{:?}`", args.model);
+
+    run_openocd(args.model, "init; reset; exit")
+}
+
+/// Runs OpenOCD instructions against the connected device for the given model.
+fn run_openocd(model: Model, instructions: &str) -> Result<()> {
+    let model_config = model.config()?;
 
     let status = process::Command::new("openocd")
         .args(["-f", "interface/stlink.cfg"])
         .args(["-c", "transport select hla_swd"])
         .args(["-f", model_config.openocd_target()?])
         .arg("-c")
-        .arg("init; reset; exit")
+        .arg(instructions)
         .status()
         .context("Failed to spawn `openocd`")?;
 

--- a/core/embed/xtask/src/main.rs
+++ b/core/embed/xtask/src/main.rs
@@ -18,6 +18,7 @@ fn main() -> Result<()> {
         Cmd::Fmt => cargo::fmt(),
         Cmd::Flash(args) => flash::flash(args),
         Cmd::FlashErase(args) => flash::flash_erase(args),
+        Cmd::Reset(args) => flash::reset(args),
         Cmd::Upload(args) => upload::upload(args),
         Cmd::Combine(args) => combine::combine(args),
     }


### PR DESCRIPTION
added  a command to reset connect MCU via openocd (replacement for `make openocd_reset`)