### PR TITLE
test(core): correct backup input flow

### DIFF
--- a/tests/device_tests/test_msg_backup_device.py
+++ b/tests/device_tests/test_msg_backup_device.py
@@ -115,12 +115,7 @@ def test_backup_slip39_single(session: Session, adapt_flow: "FlowAdapter"):
     assert session.features.backup_availability == messages.BackupAvailability.Required
 
     with session.test_ctx as client:
-        IF = InputFlowBip39Backup(
-            session,
-            confirm_success=(
-                session.layout_type not in (LayoutType.Delizia, LayoutType.Eckhart)
-            ),
-        )
+        IF = InputFlowBip39Backup(session)
         client.set_input_flow(adapt_flow(session, IF.get()))
         device.backup(session)
 

--- a/tests/device_tests/test_msg_backup_device.py
+++ b/tests/device_tests/test_msg_backup_device.py
@@ -48,13 +48,15 @@ FLOW_ADAPTERS = [normal, try_to_cancel()]
 @pytest.mark.models("core")  # TODO we want this for t1 too
 @pytest.mark.setup_client(needs_backup=True, mnemonic=MNEMONIC12)
 @pytest.mark.parametrize("adapt_flow", FLOW_ADAPTERS, ids=lambda f: f.__name__)
-def test_backup_bip39(session: Session, adapt_flow: "FlowAdapter"):
+def test_backup_bip39(
+    session: Session, adapt_flow: "FlowAdapter", backup_method: messages.BackupMethod
+):
     assert session.features.backup_availability == messages.BackupAvailability.Required
 
     with session.test_ctx as client:
-        IF = InputFlowBip39Backup(session)
+        IF = InputFlowBip39Backup(session, method=backup_method)
         client.set_input_flow(adapt_flow(session, IF.get()))
-        device.backup(session)
+        device.backup(session, backup_method=backup_method)
 
     assert IF.mnemonic == MNEMONIC12
     session.refresh_features()
@@ -82,7 +84,10 @@ SLIP39_BASIC_IDS = [
     ids=SLIP39_BASIC_IDS,
 )
 def test_backup_slip39_basic(
-    session: Session, click_info: bool, adapt_flow: "FlowAdapter"
+    session: Session,
+    click_info: bool,
+    adapt_flow: "FlowAdapter",
+    backup_method: messages.BackupMethod,
 ):
     if click_info and session.layout_type is LayoutType.Caesar:
         pytest.skip("click_info not implemented on T2B1")
@@ -90,9 +95,9 @@ def test_backup_slip39_basic(
     assert session.features.backup_availability == messages.BackupAvailability.Required
 
     with session.test_ctx as client:
-        IF = InputFlowSlip39BasicBackup(session, click_info)
+        IF = InputFlowSlip39BasicBackup(session, click_info, method=backup_method)
         client.set_input_flow(adapt_flow(session, IF.get()))
-        device.backup(session)
+        device.backup(session, backup_method=backup_method)
 
     session.refresh_features()
     assert session.features.initialized is True
@@ -111,13 +116,15 @@ def test_backup_slip39_basic(
 @pytest.mark.models("core")
 @pytest.mark.setup_client(needs_backup=True, mnemonic=MNEMONIC_SLIP39_SINGLE_EXT_20)
 @pytest.mark.parametrize("adapt_flow", FLOW_ADAPTERS, ids=lambda f: f.__name__)
-def test_backup_slip39_single(session: Session, adapt_flow: "FlowAdapter"):
+def test_backup_slip39_single(
+    session: Session, adapt_flow: "FlowAdapter", backup_method: messages.BackupMethod
+):
     assert session.features.backup_availability == messages.BackupAvailability.Required
 
     with session.test_ctx as client:
-        IF = InputFlowBip39Backup(session)
+        IF = InputFlowBip39Backup(session, method=backup_method)
         client.set_input_flow(adapt_flow(session, IF.get()))
-        device.backup(session)
+        device.backup(session, backup_method=backup_method)
 
     assert session.features.initialized is True
     assert (
@@ -147,7 +154,10 @@ SLIP39_ADVANCED_IDS = [
     ids=SLIP39_ADVANCED_IDS,
 )
 def test_backup_slip39_advanced(
-    session: Session, click_info: bool, adapt_flow: "FlowAdapter"
+    session: Session,
+    click_info: bool,
+    adapt_flow: "FlowAdapter",
+    backup_method: messages.BackupMethod,
 ):
     if click_info and session.layout_type is LayoutType.Caesar:
         pytest.skip("click_info not implemented on T2B1")
@@ -155,9 +165,11 @@ def test_backup_slip39_advanced(
     assert session.features.backup_availability == messages.BackupAvailability.Required
 
     with session.test_ctx as client:
-        IF = InputFlowSlip39AdvancedBackup(session, click_info)
+        IF = InputFlowSlip39AdvancedBackup(
+            session, click_info, backup_method=backup_method
+        )
         client.set_input_flow(adapt_flow(session, IF.get()))
-        device.backup(session)
+        device.backup(session, backup_method=backup_method)
 
     session.refresh_features()
     assert session.features.initialized is True
@@ -194,15 +206,24 @@ SLIP39_CUSTOM_IDS = [
     ids=SLIP39_CUSTOM_IDS,
 )
 def test_backup_slip39_custom(
-    session: Session, share_threshold: int, share_count: int, adapt_flow: "FlowAdapter"
+    session: Session,
+    share_threshold: int,
+    share_count: int,
+    adapt_flow: "FlowAdapter",
+    backup_method: messages.BackupMethod,
 ):
     assert session.features.backup_availability == messages.BackupAvailability.Required
 
     with session.test_ctx as client:
-        IF = InputFlowSlip39CustomBackup(session, share_count)
+        IF = InputFlowSlip39CustomBackup(
+            session, share_count, backup_method=backup_method
+        )
         client.set_input_flow(adapt_flow(session, IF.get()))
         device.backup(
-            session, group_threshold=1, groups=[(share_threshold, share_count)]
+            session,
+            group_threshold=1,
+            groups=[(share_threshold, share_count)],
+            backup_method=backup_method,
         )
 
     session.refresh_features()
@@ -222,7 +243,7 @@ def test_backup_slip39_custom(
 
 # we only test this with bip39 because the code path is always the same
 @pytest.mark.setup_client(no_backup=True)
-def test_no_backup_fails(session: Session):
+def test_no_backup_fails(session: Session, backup_method: messages.BackupMethod):
     session.ensure_unlocked()
     assert session.features.initialized is True
     assert session.features.no_backup is True
@@ -232,12 +253,12 @@ def test_no_backup_fails(session: Session):
 
     # backup attempt should fail because no_backup=True
     with pytest.raises(TrezorFailure, match=r".*Seed already backed up"):
-        device.backup(session)
+        device.backup(session, backup_method=backup_method)
 
 
 # we only test this with bip39 because the code path is always the same
 @pytest.mark.setup_client(needs_backup=True)
-def test_interrupt_backup_fails(session: Session):
+def test_interrupt_backup_fails(session: Session, backup_method: messages.BackupMethod):
     session.ensure_unlocked()
     assert session.features.initialized is True
     assert session.features.backup_availability == messages.BackupAvailability.Required
@@ -245,7 +266,7 @@ def test_interrupt_backup_fails(session: Session):
     assert session.features.no_backup is False
 
     # start backup
-    resp = session.call_raw(messages.BackupDevice())
+    resp = session.call_raw(messages.BackupDevice(backup_method=backup_method))
     assert isinstance(resp, messages.ButtonRequest)
 
     # interrupt backup
@@ -274,4 +295,4 @@ def test_interrupt_backup_fails(session: Session):
 
     # Second attempt at backup should fail
     with pytest.raises(TrezorFailure, match=r".*Seed already backed up"):
-        device.backup(session)
+        device.backup(session, backup_method=backup_method)

--- a/tests/input_flows.py
+++ b/tests/input_flows.py
@@ -1793,23 +1793,20 @@ class InputFlowEthereumSignTxStaking(InputFlowBase):
         yield from self.ETH.confirm_tx_staking(info=True)
 
 
-def get_mnemonic(
-    debug: DebugLink,
-    confirm_success: bool = True,
-) -> Generator[None, "messages.ButtonRequest", str]:
+def get_mnemonic(debug: DebugLink) -> Generator[None, "messages.ButtonRequest", str]:
+    """Used for BIP39 or SLIP-39 1-of-1 backup."""
     # mnemonic phrases
     mnemonic = yield from read_and_confirm_mnemonic(debug)
 
-    is_slip39 = len(mnemonic.split()) in (20, 33)
-    if debug.layout_type in (LayoutType.Bolt, LayoutType.Caesar) or is_slip39:
+    if debug.layout_type in (LayoutType.Bolt, LayoutType.Caesar):
         br = yield  # confirm recovery share check
         assert br.code == B.Success
+        assert br.name == "success_share_confirm"
         debug.press_yes()
 
-    if confirm_success:
-        br = yield
-        assert br.code == B.Success
-
+    br = yield
+    assert br.code == B.Success
+    assert br.name == "success_backup"
     debug.press_yes()
 
     assert mnemonic is not None
@@ -1817,10 +1814,9 @@ def get_mnemonic(
 
 
 class InputFlowBip39Backup(InputFlowBase):
-    def __init__(self, client: Client, confirm_success: bool = True):
+    def __init__(self, client: Client):
         super().__init__(client)
         self.mnemonic = None
-        self.confirm_success = confirm_success
 
     def input_flow_common(self) -> BRGeneratorType:
         # 1. Backup intro
@@ -1828,7 +1824,7 @@ class InputFlowBip39Backup(InputFlowBase):
         yield from click_through(self.debug, screens=2, code=B.ResetDevice)
 
         # mnemonic phrases and rest
-        self.mnemonic = yield from get_mnemonic(self.debug, self.confirm_success)
+        self.mnemonic = yield from get_mnemonic(self.debug)
 
 
 class InputFlowBip39ResetBackup(InputFlowBase):

--- a/tests/input_flows.py
+++ b/tests/input_flows.py
@@ -1814,17 +1814,31 @@ def get_mnemonic(debug: DebugLink) -> Generator[None, "messages.ButtonRequest", 
 
 
 class InputFlowBip39Backup(InputFlowBase):
-    def __init__(self, client: Client):
+    def __init__(
+        self,
+        client: Client,
+        method: messages.BackupMethod = messages.BackupMethod.Display,
+    ):
         super().__init__(client)
         self.mnemonic = None
+        self.method = method
 
     def input_flow_common(self) -> BRGeneratorType:
-        # 1. Backup intro
-        # 2. Backup warning
-        yield from click_through(self.debug, screens=2, code=B.ResetDevice)
-
         # mnemonic phrases and rest
-        self.mnemonic = yield from get_mnemonic(self.debug)
+        if self.method is messages.BackupMethod.Display:
+            # 1. Backup intro
+            # 2. Backup warning
+            yield from click_through(self.debug, screens=2, code=B.ResetDevice)
+            self.mnemonic = yield from get_mnemonic(self.debug)
+        elif self.method is messages.BackupMethod.N4W1:
+            assert (yield).name == "backup_write"
+            self.mnemonic = n4w1_handle_write(self.debug).decode()
+            br = yield
+            assert br.name == "success_backup"
+            assert br.code == B.Success
+            self.debug.press_yes()
+        else:
+            raise RuntimeError
 
 
 class InputFlowBip39ResetBackup(InputFlowBase):
@@ -2246,14 +2260,20 @@ class InputFlowSlip39BasicResetRecovery(InputFlowBase):
 
 class InputFlowSlip39CustomBackup(InputFlowBase):
     def __init__(
-        self, client: Client | DebugSession, share_count: int, repeated: bool = False
+        self,
+        client: Client | DebugSession,
+        share_count: int,
+        repeated: bool = False,
+        backup_method: messages.BackupMethod = messages.BackupMethod.Display,
     ):
         super().__init__(client)
         self.mnemonics: list[str] = []
         self.share_count = share_count
         self.repeated = repeated
+        self.backup_method = backup_method
 
     def input_flow_bolt(self) -> BRGeneratorType:
+        assert self.backup_method is messages.BackupMethod.Display
         if self.repeated:
             yield
             self.debug.press_yes()
@@ -2276,6 +2296,7 @@ class InputFlowSlip39CustomBackup(InputFlowBase):
         self.debug.press_yes()
 
     def input_flow_caesar(self) -> BRGeneratorType:
+        assert self.backup_method is messages.BackupMethod.Display
         if self.repeated:
             yield
             self.debug.press_yes()
@@ -2298,6 +2319,7 @@ class InputFlowSlip39CustomBackup(InputFlowBase):
         self.debug.press_yes()
 
     def input_flow_delizia(self) -> BRGeneratorType:
+        assert self.backup_method is messages.BackupMethod.Display
         if self.repeated:
             yield
             self.debug.press_yes()
@@ -2324,18 +2346,27 @@ class InputFlowSlip39CustomBackup(InputFlowBase):
             yield
             self.debug.press_yes()
 
-        if self.share_count > 1:
-            yield  # Checklist
-            self.debug.press_yes()
-        else:
-            yield  # Backup intro
-            self.debug.press_yes()
+        if self.backup_method is messages.BackupMethod.Display:
+            if self.share_count > 1:
+                yield  # Checklist
+                self.debug.press_yes()
+            else:
+                yield  # Backup intro
+                self.debug.press_yes()
 
-        yield  # Confirm show seeds
-        self.debug.press_yes()
+            yield  # Confirm show seeds
+            self.debug.press_yes()
+        elif self.backup_method is messages.BackupMethod.N4W1:
+            if self.share_count > 1:
+                assert (yield).name == "warning_shamir_backup"
+                self.debug.press_yes()
+        else:
+            raise RuntimeError
 
         # Mnemonic phrases
-        self.mnemonics = yield from load_N_shares(self.debug, self.share_count)
+        self.mnemonics = yield from load_N_shares(
+            self.debug, self.share_count, self.backup_method
+        )
 
         br = yield  # Confirm backup
         assert br.code == B.Success
@@ -2344,29 +2375,44 @@ class InputFlowSlip39CustomBackup(InputFlowBase):
 
 def load_5_groups_5_shares(
     debug: DebugLink,
+    backup_method: messages.BackupMethod = messages.BackupMethod.Display,
 ) -> Generator[None, "messages.ButtonRequest", list[str]]:
     mnemonics: list[str] = []
 
     for _g in range(5):
         for _s in range(5):
-            # Phrase screen
-            mnemonic = yield from read_and_confirm_mnemonic(debug)
-            assert mnemonic is not None
+            if backup_method is messages.BackupMethod.Display:
+                # Phrase screen
+                mnemonic = yield from read_and_confirm_mnemonic(debug)
+                assert mnemonic is not None
+            elif backup_method is messages.BackupMethod.N4W1:
+                assert (yield).name == "backup_write"
+                mnemonic = n4w1_handle_write(debug).decode()
+            else:
+                raise RuntimeError
             mnemonics.append(mnemonic)
-            # Confirm continue to next
-            yield from swipe_if_necessary(debug, B.Success)
-            debug.press_yes()
+            if backup_method is messages.BackupMethod.Display:
+                # Confirm continue to next
+                yield from swipe_if_necessary(debug, B.Success)
+                debug.press_yes()
 
     return mnemonics
 
 
 class InputFlowSlip39AdvancedBackup(InputFlowBase):
-    def __init__(self, client: Client | DebugSession, click_info: bool):
+    def __init__(
+        self,
+        client: Client | DebugSession,
+        click_info: bool,
+        backup_method: messages.BackupMethod = messages.BackupMethod.Display,
+    ):
         super().__init__(client)
         self.mnemonics: list[str] = []
         self.click_info = click_info
+        self.backup_method = backup_method
 
     def input_flow_bolt(self) -> BRGeneratorType:
+        assert self.backup_method is messages.BackupMethod.Display
         assert (yield).name == "backup_intro"
         self.debug.press_yes()
         assert (yield).name == "slip39_checklist"
@@ -2407,6 +2453,7 @@ class InputFlowSlip39AdvancedBackup(InputFlowBase):
         self.debug.press_yes()
 
     def input_flow_caesar(self) -> BRGeneratorType:
+        assert self.backup_method is messages.BackupMethod.Display
         yield  # 1. Backup intro
         self.debug.press_yes()
         yield  # 2. Checklist
@@ -2432,13 +2479,16 @@ class InputFlowSlip39AdvancedBackup(InputFlowBase):
         self.debug.press_yes()
 
         # Mnemonic phrases - show & confirm shares for all groups
-        self.mnemonics = yield from load_5_groups_5_shares(self.debug)
+        self.mnemonics = yield from load_5_groups_5_shares(
+            self.debug, self.backup_method
+        )
 
         br = yield  # Confirm backup
         assert br.code == B.Success
         self.debug.press_yes()
 
     def input_flow_delizia(self) -> BRGeneratorType:
+        assert self.backup_method is messages.BackupMethod.Display
         assert (yield).name == "backup_intro"
         self.debug.swipe_up()
         assert (yield).name == "slip39_checklist"
@@ -2475,8 +2525,9 @@ class InputFlowSlip39AdvancedBackup(InputFlowBase):
         self.debug.press_yes()
 
     def input_flow_eckhart(self) -> BRGeneratorType:
-        assert (yield).name == "backup_intro"
-        self.debug.press_yes()
+        if self.backup_method is messages.BackupMethod.Display:
+            assert (yield).name == "backup_intro"
+            self.debug.press_yes()
         assert (yield).name == "slip39_checklist"
         self.debug.press_yes()
         assert (yield).name == "slip39_groups"
@@ -2500,11 +2551,14 @@ class InputFlowSlip39AdvancedBackup(InputFlowBase):
             if self.click_info:
                 click_info_button_delizia_eckhart(self.debug)
             self.debug.press_yes()
-        assert (yield).name == "backup_warning"
-        self.debug.press_yes()
+        if self.backup_method is messages.BackupMethod.Display:
+            assert (yield).name == "backup_warning"
+            self.debug.press_yes()
 
         # Mnemonic phrases - show & confirm shares for all groups
-        self.mnemonics = yield from load_5_groups_5_shares(self.debug)
+        self.mnemonics = yield from load_5_groups_5_shares(
+            self.debug, self.backup_method
+        )
 
         br = yield  # Confirm backup
         assert br.code == B.Success


### PR DESCRIPTION
- BIP39 and SLIP39 1-of-1 do not send `success_share_confirm`.
- All models send `success_backup`.
