### PR TITLE
add secmon support on U58x mcu

### DIFF
--- a/core/embed/io/usb/stm32/usbd_conf.c
+++ b/core/embed/io/usb/stm32/usbd_conf.c
@@ -128,7 +128,9 @@ void HAL_PCD_MspInit(PCD_HandleTypeDef *hpcd)
     /* Enable USB FS Clocks */
     __HAL_RCC_USB_OTG_FS_CLK_ENABLE();
 
-#ifdef STM32U5
+#if defined(STM32U5) && defined(SECURE_MODE)
+    // If not in secure mode, this initialization is done
+    // in secure monitor
 
     /* Enable VDDUSB */
     __HAL_RCC_PWR_CLK_ENABLE();

--- a/core/embed/projects/prodtest/cmd/prodtest_backup_ram.c
+++ b/core/embed/projects/prodtest/cmd/prodtest_backup_ram.c
@@ -21,7 +21,6 @@
 
 #include <trezor_rtl.h>
 
-#include <io/power_manager.h>
 #include <rtl/cli.h>
 #include <sec/backup_ram.h>
 #include <sys/systick.h>

--- a/core/embed/projects/secmon/main.c
+++ b/core/embed/projects/secmon/main.c
@@ -70,6 +70,28 @@ void usb_power_init(void) {
   HAL_PWREx_EnableUSBHSTranceiverSupply();
   __HAL_RCC_PWR_CLK_DISABLE();
 }
+#elif defined(USE_USB_FS) || defined(USE_USB_HS_IN_FS)
+void usb_power_init(void) {
+  __HAL_RCC_PWR_CLK_ENABLE();
+  // Enable VDDUSB (the full-speed peripheral has no separate HS PHY supply)
+  HAL_PWREx_EnableVddUSB();
+  __HAL_RCC_PWR_CLK_DISABLE();
+
+  // Configure the HSI48 clock recovery system (CRS). HSI48 (already enabled
+  // during the secure clock init) and the CRS configuration live in the
+  // secure RCC domain, so they are set up here in the secure monitor rather
+  // than in the non-secure kernel. The CRS trims HSI48 against the USB SOF
+  // once the (non-secure) kernel starts the USB peripheral.
+  __HAL_RCC_CRS_CLK_ENABLE();
+  RCC_CRSInitTypeDef crs_init = {0};
+  crs_init.Prescaler = RCC_CRS_SYNC_DIV1;
+  crs_init.Source = RCC_CRS_SYNC_SOURCE_USB;
+  crs_init.Polarity = RCC_CRS_SYNC_POLARITY_RISING;
+  crs_init.ReloadValue = __HAL_RCC_CRS_RELOADVALUE_CALCULATE(48000000, 1000);
+  crs_init.ErrorLimitValue = RCC_CRS_ERRORLIMIT_DEFAULT;
+  crs_init.HSI48CalibrationValue = RCC_CRS_HSI48CALIBRATION_DEFAULT;
+  HAL_RCCEx_CRSConfig(&crs_init);
+}
 #else
 #error Not implemented
 #endif

--- a/core/embed/sec/trustzone/stm32u5/tz_init.c
+++ b/core/embed/sec/trustzone/stm32u5/tz_init.c
@@ -89,7 +89,9 @@ static void tz_configure_sau(void) {
   SET_REGION(4, NONSECURE_RAM1_START,  NONSECURE_RAM1_SIZE, 0);
   SET_REGION(5, NONSECURE_RAM2_START,  NONSECURE_RAM2_SIZE, 0);
   SET_REGION(6, PERIPH_BASE_NS,        SIZE_256M,           0);
+#if defined STM32U5A9xx || defined STM32U5G9xx
   SET_REGION(7, GFXMMU_VIRTUAL_BUFFERS_BASE_NS, SIZE_16M,   0);
+#endif
   // clang-format on
 
   SAU->CTRL = SAU_CTRL_ENABLE_Msk;
@@ -277,8 +279,10 @@ void tz_init(void) {
       GTZC_PERIPH_ICACHE_REG, GTZC_TZSC_PERIPH_SEC | GTZC_TZSC_PERIPH_PRIV);
   HAL_GTZC_TZSC_ConfigPeriphAttributes(
       GTZC_PERIPH_DCACHE1_REG, GTZC_TZSC_PERIPH_SEC | GTZC_TZSC_PERIPH_PRIV);
+#if defined STM32U5A9xx || defined STM32U5G9xx
   HAL_GTZC_TZSC_ConfigPeriphAttributes(
       GTZC_PERIPH_DCACHE2_REG, GTZC_TZSC_PERIPH_SEC | GTZC_TZSC_PERIPH_PRIV);
+#endif
 
   // Set all interrupts as non-secure
   for (int i = 0; i < 512; i++) {
@@ -292,8 +296,10 @@ void tz_init(void) {
   SYSCFG->SECCFGR |= SYSCFG_SECCFGR_FPUSEC | SYSCFG_SECCFGR_CLASSBSEC |
                      SYSCFG_SECCFGR_SYSCFGSEC;
 
+#if defined STM32U5A9xx || defined STM32U5G9xx
   // Disable chaching of SRAM in DCACHE2 (used only by GPU which we do not use)
   SYSCFG->CFGR1 &= ~SYSCFG_CFGR1_SRAMCACHED;
+#endif
 
   // All RCC peripherals secure by default
   const uint32_t RCC_SECCFGR_ALL_BITS =

--- a/core/embed/sys/linker/stm32u58/bootloader.ld
+++ b/core/embed/sys/linker/stm32u58/bootloader.ld
@@ -22,12 +22,21 @@ _bss_section_end = ADDR(.bss) + SIZEOF(.bss);
 _bootargs_ram_start = BOOTARGS_START;
 _bootargs_ram_end = BOOTARGS_START + BOOTARGS_SIZE;
 
+/* _bootloader_code_size is used by the PQ (boot_ucb) header; _codelen is used
+   by the classic header.S. Both are defined so this single script serves both
+   bootloader header formats. */
+_bootloader_code_size = _bootloader_code_end - ADDR(.padding);
 _codelen = _bootloader_code_end - ADDR(.flash);
 
 SECTIONS {
   .header : ALIGN(4) {
     KEEP(*(.header));
-  } >FLASH AT>FLASH
+  } >FLASH
+
+  .padding : ALIGN(4) {
+    . = ALIGN(4);
+    . = ALIGN(CODE_ALIGNMENT);
+  } >FLASH
 
   .flash : ALIGN(CODE_ALIGNMENT) {
     KEEP(*(.vector_table));
@@ -36,7 +45,7 @@ SECTIONS {
     . = ALIGN(4);
     *(.rodata*);
     . = ALIGN(4);
-  } >FLASH AT>FLASH
+  } >FLASH
 
   .data : ALIGN(4) {
     *(.data*);
@@ -80,12 +89,11 @@ SECTIONS {
     . = ALIGN(8);
   } >BOOT_ARGS
 
-  .flash : ALIGN(4) {
+  .flash : {
     /* Pad the rest of bootloader area with zeros */
     BYTE(0x00)
     FILL(0x00)
-    /* Use alignment required by the boardloader */
-    . = ALIGN(512);
+    . = ADDR(.header) + BOOTLOADER_MAXSIZE;
     _bootloader_code_end = .;
   } >FLASH
 }

--- a/core/embed/sys/linker/stm32u58/bootloader.ld
+++ b/core/embed/sys/linker/stm32u58/bootloader.ld
@@ -28,6 +28,10 @@ _bootargs_ram_end = BOOTARGS_START + BOOTARGS_SIZE;
 _bootloader_code_size = _bootloader_code_end - ADDR(.padding);
 _codelen = _bootloader_code_end - ADDR(.flash);
 
+/* Size of the zero fill that pads the image to the full BOOTLOADER_MAXSIZE.
+   Reported by the memory-usage tool so it can show real content vs padding. */
+__flash_padding_size = _bootloader_code_end - __flash_padding_start;
+
 SECTIONS {
   .header : ALIGN(4) {
     KEEP(*(.header));
@@ -91,6 +95,7 @@ SECTIONS {
 
   .flash : {
     /* Pad the rest of bootloader area with zeros */
+    __flash_padding_start = .;
     BYTE(0x00)
     FILL(0x00)
     . = ADDR(.header) + BOOTLOADER_MAXSIZE;

--- a/core/embed/sys/linker/stm32u58/prodtest.ld
+++ b/core/embed/sys/linker/stm32u58/prodtest.ld
@@ -23,7 +23,12 @@ _bss_section_end = ADDR(.bss) + SIZEOF(.bss);
 _bootargs_ram_start = BOOTARGS_START;
 _bootargs_ram_end = BOOTARGS_START + BOOTARGS_SIZE;
 
-_codelen = _image_flash_end - ADDR(.flash);
+/* `_codelen` is the firmware-signed length (covers the secmon header + body);
+   `_secmon_codelen` is the secmon-signed body length. On non-secmon models the
+   `.secmon_header`/`.padding` sections are empty, so `_codelen` is unchanged and
+   `_secmon_codelen` is unused. */
+_codelen = _image_flash_end - ADDR(.secmon_header);
+_secmon_codelen = _image_flash_end - ADDR(.padding);
 
 SECTIONS {
   .vendorheader : ALIGN(4) {
@@ -32,6 +37,15 @@ SECTIONS {
 
   .header : ALIGN(4) {
     KEEP(*(.header));
+  } >FLASH AT>FLASH
+
+  .secmon_header : ALIGN(CODE_ALIGNMENT) {
+    KEEP(*(.secmon_header));
+  } >FLASH AT>FLASH
+
+  .padding : ALIGN(4) {
+    . = ALIGN(4);
+    . = ALIGN(CODE_ALIGNMENT);
   } >FLASH AT>FLASH
 
   .flash : ALIGN(CODE_ALIGNMENT) {

--- a/core/embed/sys/linker/stm32u58/secmon.ld
+++ b/core/embed/sys/linker/stm32u58/secmon.ld
@@ -1,12 +1,15 @@
 ENTRY(reset_handler)
 
 MEMORY {
-  FLASH  (rx)    : ORIGIN = FIRMWARE_START, LENGTH = FIRMWARE_MAXSIZE
-  MAIN_RAM (rw)  : ORIGIN = MAIN_RAM_START, LENGTH = MAIN_RAM_SIZE
+  FLASH (rx)     : ORIGIN = FIRMWARE_START_S, LENGTH = FIRMWARE_MAXSIZE
+  RAM (rw)       : ORIGIN = SECMON_RAM_START, LENGTH = SECMON_RAM_SIZE
   BOOT_ARGS (rw) : ORIGIN = BOOTARGS_START, LENGTH = BOOTARGS_SIZE
   FB1_RAM (rw)   : ORIGIN = FB1_RAM_START, LENGTH = FB1_RAM_SIZE
   FB2_RAM (rw)   : ORIGIN = FB2_RAM_START, LENGTH = FB2_RAM_SIZE
 }
+
+_sgstubs_section_start = ADDR(.gnu.sgstubs);
+_sgstubs_section_end = ADDR(.gnu.sgstubs) + SIZEOF(.gnu.sgstubs);
 
 _stack_section_start = ADDR(.stack);
 _stack_section_end = ADDR(.stack) + SIZEOF(.stack);
@@ -21,54 +24,63 @@ _bss_section_end = ADDR(.bss) + SIZEOF(.bss);
 _bootargs_ram_start = BOOTARGS_START;
 _bootargs_ram_end = BOOTARGS_START + BOOTARGS_SIZE;
 
-_codelen = _kernel_flash_end - ORIGIN(FLASH);
+_codelen = _secmon_flash_end - _secmon_code_start;
+_secmon_size = _secmon_flash_end - ORIGIN(FLASH);
 
 SECTIONS {
   .vendorheader : ALIGN(4) {
     KEEP(*(.vendorheader))
-  } >FLASH AT>FLASH
+  } >FLASH
 
   .header : ALIGN(4) {
     . += 1K;
     . = ALIGN(CODE_ALIGNMENT);
+  } >FLASH
+
+  .secmon_header : ALIGN(4) {
+    KEEP(*(.secmon_header));
+  } >FLASH
+
+  .padding : ALIGN(4) {
+    _secmon_code_start = .;
+    . = ALIGN(CODE_ALIGNMENT);
   } >FLASH AT>FLASH
 
-  /* Secure monitor binary, embedded at the start of the firmware region by
-     the kernel build when the model uses the secmon layout. Empty (no-op) for
-     models without a secure monitor. */
   .flash : ALIGN(CODE_ALIGNMENT) {
-    KEEP(*(.secmon));
-  } >FLASH AT>FLASH
-
-  .flash : ALIGN(CODE_ALIGNMENT) {
-    _kernel_flash_start = .;
     KEEP(*(.vector_table));
     . = ALIGN(4);
+  } >FLASH
+
+  .gnu.sgstubs : ALIGN (32) {
+    . = ALIGN(32);
+    KEEP(*(.gnu.sgstubs*));
+    . = ALIGN(32);
+  } >FLASH
+
+  .flash : {
     *(.text*);
     . = ALIGN(4);
     *(.rodata*);
-    . = ALIGN(512);
-  } >FLASH AT>FLASH
+    . = ALIGN(4);
+  } >FLASH
 
-  .stack : ALIGN(8) {
-    . += 8K; /* Overflow causes UsageFault */
-  } >MAIN_RAM
+  /* .data and .bss are intentionally placed before the .stack
+     section to ensure they are located in SRAM2, which is
+     cleared on security events */
 
   .data : ALIGN(4) {
     *(.data*);
-    . = ALIGN(512);
-  } >MAIN_RAM AT>FLASH
-
-  /DISCARD/ : {
-    *(.ARM.exidx*);
-  }
+    . = ALIGN(4);
+  } >RAM AT>FLASH
 
   .bss : ALIGN(4) {
-    *(.no_dma_buffers*);
-    *(.buf*);
     *(.bss*);
     . = ALIGN(4);
-  } >MAIN_RAM
+  } >RAM
+
+  .stack : ALIGN(8) {
+    . = 80K; /* Overflow causes UsageFault */
+  } >RAM
 
   .fb1 : ALIGN(4) {
     *(.fb1*);
@@ -87,7 +99,14 @@ SECTIONS {
     . = ALIGN(8);
   } >BOOT_ARGS
 
-  .flash : ALIGN(4) {
-    _kernel_flash_end = .;
+  /DISCARD/ : {
+    *(.ARM.exidx*);
+  }
+
+  .flash : {
+    BYTE(0x00)
+    FILL(0x00)
+    . = ALIGN(8K);
+    _secmon_flash_end = .;
   } >FLASH
 }

--- a/core/embed/sys/linker/stm32u5g/bootloader.ld
+++ b/core/embed/sys/linker/stm32u5g/bootloader.ld
@@ -24,6 +24,10 @@ _bootargs_ram_end = BOOTARGS_START + BOOTARGS_SIZE;
 
 _bootloader_code_size = _bootloader_code_end - ADDR(.padding);
 
+/* Size of the zero fill that pads the image to the full BOOTLOADER_MAXSIZE.
+   Reported by the memory-usage tool so it can show real content vs padding. */
+__flash_padding_size = _bootloader_code_end - __flash_padding_start;
+
 SECTIONS {
   .header : ALIGN(4) {
     KEEP(*(.header));
@@ -87,6 +91,7 @@ SECTIONS {
 
   .flash : {
     /* Pad the rest of bootloader area with zeros */
+    __flash_padding_start = .;
     BYTE(0x00)
     FILL(0x00)
     . = ADDR(.header) + BOOTLOADER_MAXSIZE;

--- a/core/embed/xtask/src/memusage.rs
+++ b/core/embed/xtask/src/memusage.rs
@@ -10,9 +10,23 @@ struct MemoryRegion {
 
 #[derive(Debug, Clone)]
 struct OutputSection {
+    name: String,
     address: u64,
     size: u64,
     load_address: Option<u64>,
+}
+
+/// Returns true for zero-initialized / reserved sections (`.bss`, `.stack`,
+/// `.heap`). These are NOBITS: they occupy RAM but carry no bytes in the flash
+/// image. GNU ld nonetheless reports a `load address` for them (the LMA cursor
+/// continues past the preceding `AT>FLASH` `.data` section), which must NOT be
+/// counted as flash usage — otherwise a large reserved stack inflates the
+/// reported figure well beyond the real image size.
+fn is_nobits_section(name: &str) -> bool {
+    const NOBITS: [&str; 3] = [".bss", ".stack", ".heap"];
+    NOBITS
+        .iter()
+        .any(|prefix| name == *prefix || name.starts_with(&format!("{prefix}.")))
 }
 
 /// Prints a table of memory usage by region, based on the contents of
@@ -198,7 +212,7 @@ fn parse_output_sections(content: &str) -> Result<Vec<OutputSection>> {
         }
 
         let mut parts = line.split_whitespace();
-        let Some(_name) = parts.next() else {
+        let Some(name) = parts.next() else {
             continue;
         };
         let Some(address) = parts.next() else {
@@ -224,6 +238,7 @@ fn parse_output_sections(content: &str) -> Result<Vec<OutputSection>> {
         }
 
         sections.push(OutputSection {
+            name: name.to_string(),
             address,
             size,
             load_address,
@@ -246,8 +261,12 @@ fn used_bytes_for_region(region: &MemoryRegion, sections: &[OutputSection]) -> u
             ranges.push(range);
         }
 
+        // A NOBITS section (.bss/.stack/.heap) carries no bytes in the flash
+        // image; its reported load address is a phantom from the LMA cursor and
+        // must not be counted as flash usage.
         if let Some(load_address) = section.load_address
             && load_address != section.address
+            && !is_nobits_section(&section.name)
             && let Some(range) =
                 intersect_range(load_address, section.size, region.origin, region_end)
         {
@@ -375,6 +394,40 @@ Linker script and memory map
         );
         // A symbol that is not present yields None (no padding to subtract).
         assert_eq!(parse_symbol_value(map, "__missing_symbol"), None);
+    }
+
+    #[test]
+    fn ignores_nobits_load_addresses() {
+        // `.bss` and `.stack` are NOBITS: they live in RAM but the linker
+        // reports a flash `load address` for them. That phantom LMA (here a
+        // huge 64 KB stack) must not be counted as flash usage.
+        let map = r#"
+Memory Configuration
+
+Name             Origin             Length             Attributes
+FLASH            0x08000000         0x00010000         xr
+RAM              0x20000000         0x00020000         rw
+*default*        0x00000000         0xffffffff
+
+Linker script and memory map
+
+.flash          0x08000000       0x100
+.data           0x20000000        0x20 load address 0x08000100
+.bss            0x20000020        0x40 load address 0x08000120
+.stack          0x20000060     0x10000 load address 0x08000120
+"#;
+
+        let regions = parse_memory_regions(map).expect("memory regions should parse");
+        let sections = parse_output_sections(map).expect("sections should parse");
+
+        let flash = regions.iter().find(|r| r.name == "FLASH").unwrap();
+        let ram = regions.iter().find(|r| r.name == "RAM").unwrap();
+
+        // Flash: .flash (0x100) + .data load image (0x20); the .bss/.stack
+        // phantom LMAs are excluded.
+        assert_eq!(used_bytes_for_region(flash, &sections), 0x120);
+        // RAM: .data + .bss + .stack VMAs are all counted as usual.
+        assert_eq!(used_bytes_for_region(ram, &sections), 0x10060);
     }
 
     #[test]

--- a/core/embed/xtask/src/memusage.rs
+++ b/core/embed/xtask/src/memusage.rs
@@ -24,6 +24,11 @@ pub fn print_memusage(mapfile: &Path) -> Result<()> {
     let regions = parse_memory_regions(&content)?;
     let sections = parse_output_sections(&content)?;
 
+    // Some images (e.g. the boot_ucb bootloader) are zero-padded to fill their
+    // whole flash region. The linker exports `__flash_padding_size` so we can
+    // report real content usage instead of a misleading 100%.
+    let flash_padding = parse_symbol_value(&content, "__flash_padding_size");
+
     println!(
         "xtask: Memory usage from `{}`",
         mapfile
@@ -37,7 +42,19 @@ pub fn print_memusage(mapfile: &Path) -> Result<()> {
     );
 
     for region in regions {
-        let used = used_bytes_for_region(&region, &sections);
+        let mut used = used_bytes_for_region(&region, &sections);
+
+        // Exclude the fixed-size image padding from the reported usage so the
+        // figure reflects real content. The padding only applies to the FLASH
+        // region the image is linked into.
+        let mut note = String::new();
+        if region.name == "FLASH"
+            && let Some(padding) = flash_padding
+        {
+            used = used.saturating_sub(padding);
+            note = format!("  (+{} padding)", format_bytes(padding));
+        }
+
         let percent = if region.length == 0 {
             0.0
         } else {
@@ -45,15 +62,31 @@ pub fn print_memusage(mapfile: &Path) -> Result<()> {
         };
 
         println!(
-            "{:<16} {:>12} {:>12} {:>7.2}%",
+            "{:<16} {:>12} {:>12} {:>7.2}%{}",
             region.name,
             format_bytes(used),
             format_bytes(region.length),
-            percent
+            percent,
+            note
         );
     }
 
     Ok(())
+}
+
+/// Parses the value of a symbol assignment from the map file, i.e. a line of
+/// the form `0x<value>  <name> = ...`.
+fn parse_symbol_value(content: &str, name: &str) -> Option<u64> {
+    for line in content.lines() {
+        let mut parts = line.split_whitespace();
+        let (Some(value), Some(symbol)) = (parts.next(), parts.next()) else {
+            continue;
+        };
+        if symbol == name && parts.next() == Some("=") {
+            return parse_hex(value).ok();
+        }
+    }
+    None
 }
 
 /// Parses the memory regions from the "Memory Configuration" part of
@@ -287,7 +320,9 @@ fn format_bytes(value: u64) -> String {
 
 #[cfg(test)]
 mod tests {
-    use super::{parse_memory_regions, parse_output_sections, used_bytes_for_region};
+    use super::{
+        parse_memory_regions, parse_output_sections, parse_symbol_value, used_bytes_for_region,
+    };
 
     #[test]
     fn counts_runtime_and_load_addresses() {
@@ -318,5 +353,43 @@ Linker script and memory map
 
         assert_eq!(used_bytes_for_region(flash, &sections), 0x1a0);
         assert_eq!(used_bytes_for_region(ram, &sections), 0x60);
+    }
+
+    #[test]
+    fn parses_padding_symbol_value() {
+        // Symbol assignment lines look like this in the map file.
+        let map = r#"
+Linker script and memory map
+
+                0x000018e4                        __flash_padding_size = (_bootloader_code_end - __flash_padding_start)
+                0x0c03c000                        _bootloader_code_end = .
+"#;
+
+        assert_eq!(
+            parse_symbol_value(map, "__flash_padding_size"),
+            Some(0x18e4)
+        );
+        assert_eq!(
+            parse_symbol_value(map, "_bootloader_code_end"),
+            Some(0x0c03c000)
+        );
+        // A symbol that is not present yields None (no padding to subtract).
+        assert_eq!(parse_symbol_value(map, "__missing_symbol"), None);
+    }
+
+    #[test]
+    fn padding_symbol_does_not_confuse_section_parsing() {
+        // A symbol line (leading whitespace, no leading '.') must not be picked
+        // up as an output section.
+        let map = r#"
+Linker script and memory map
+
+.flash          0x0c016000     0x1f5d0
+                0x000018e4                        __flash_padding_size = 0x18e4
+"#;
+
+        let sections = parse_output_sections(map).expect("sections should parse");
+        assert_eq!(sections.len(), 1);
+        assert_eq!(sections[0].address, 0x0c016000);
     }
 }


### PR DESCRIPTION
This PR add few changes that allow using secmon on U58x MCU.

- USB power initialization in secmon
- added missing secmon.ld linkerscript
- add secmon binary to kernel linkerscript
- modified TZ init and excluded unsupported peripherals

Support for PQ bootloader is also added by adding padding into bootloader linker script.

As this change enlarges the problem of hidden flash usage in bootloaders, the memusage build script is modified to exclude the padding from report. along with that, secmon flash usage calculation is also fixed.
