### PR TITLE
Suppress sdl errors in python unit tests

### DIFF
--- a/core/tests/run_tests.sh
+++ b/core/tests/run_tests.sh
@@ -5,6 +5,7 @@ declare -i passed=0 failed=0 exit_code=0
 declare COLOR_GREEN='\e[32m' COLOR_RED='\e[91m' COLOR_RESET='\e[39m'
 declare MICROPYTHON="${MICROPYTHON:-../build-xtask/artifacts/latest/firmware-emu -X heapsize=2M}"
 export SDL_VIDEODRIVER=dummy
+export SDL_LOGGING="input=critical"
 
 print_summary() {
     echo


### PR DESCRIPTION
There are lot of (useless) errors in the python unit tests log, see e.g.:
https://github.com/trezor/trezor-firmware/actions/runs/27539221865/job/81396406599?pr=7107

<img width="743" height="990" alt="Screenshot from 2026-06-15 20-09-55" src="https://github.com/user-attachments/assets/89fd86bd-0297-4a9d-84e9-00c29a248052" />

---

I was not able to find the source of the errors in a reasonable amount of time, so this one-liner suppresses all sdl errors in the unit tests - https://github.com/trezor/trezor-firmware/actions/runs/27565715082/job/81489041912

This change allows logging of errors with level critical and above, silencing the logging of errors of level error.
