### PR TITLE
fix(core/xtask): pass block_on_vcp and app_loading features to the ke…

### DIFF
--- a/core/embed/sys/dbg/stm32/dbg_console_backend.c
+++ b/core/embed/sys/dbg/stm32/dbg_console_backend.c
@@ -25,6 +25,7 @@
 
 #include <sys/dbg_console.h>
 #include <sys/sysevent.h>
+#include <sys/systick.h>
 
 #ifdef USE_DBG_CONSOLE_SYSTEM_VIEW
 #include "SEGGER_RTT.h"
@@ -79,8 +80,29 @@ static ssize_t usb_vcp_write(const void *data, size_t data_size) {
   // In interrupt context, we must not block.
   uint32_t ipsr = __get_IPSR();
   bool thread_mode = (ipsr == 0 || ipsr == 11);  // Thread mode or SVCall
-  uint32_t timeout = thread_mode ? 1000 : 0;
-  return syshandle_write_blocking(SYSHANDLE_USB_VCP, data, data_size, timeout);
+  uint32_t deadline = ticks_timeout(thread_mode ? 1000 : 0);
+
+  const uint8_t *ptr = (const uint8_t *)data;
+  size_t remaining = data_size;
+
+  while (remaining > 0) {
+    ssize_t written = syshandle_write(SYSHANDLE_USB_VCP, ptr, remaining);
+
+    if (written < 0) {
+      break;
+    }
+
+    ptr += written;
+    remaining -= written;
+
+    if (ticks_expired(deadline)) {
+      break;
+    } else if (remaining > 0) {
+      systick_delay_ms(1);
+    }
+  }
+
+  return data_size - remaining;
 #else
   return syshandle_write(SYSHANDLE_USB_VCP, data, data_size);
 #endif

--- a/core/embed/sys/task/inc/sys/sysevent.h
+++ b/core/embed/sys/task/inc/sys/sysevent.h
@@ -78,6 +78,8 @@ ssize_t syshandle_write(syshandle_t handle, const void* data, size_t data_size);
  *
  * If the timeout is 0, the function behaves like `syshandle_read`.
  *
+ * This function must not be called from an interrupt context
+ *
  * @param handle Handle of the device to read from
  * @param buffer Pointer to the buffer where the read data will be stored
  * @param buffer_size Size of the buffer in bytes
@@ -93,6 +95,8 @@ ssize_t syshandle_read_blocking(syshandle_t handle, void* buffer,
  * or timeout expires.
  *
  * If the timeout is 0, the function behaves like `syshandle_write`.
+ *
+ * This function must not be called from an interrupt context
  *
  * @param handle Handle of the device to write to
  * @param data Pointer to the data to write

--- a/core/embed/xtask/src/feature_resolver.rs
+++ b/core/embed/xtask/src/feature_resolver.rs
@@ -66,14 +66,6 @@ pub fn resolve_features(args: &BuildArgs) -> Result<ResolvedBuild> {
             features.push("log_stack_usage".into());
         }
 
-        if args.block_on_vcp {
-            features.push("block_on_vcp".into());
-        }
-
-        if args.apps {
-            features.push("app_loading".into());
-        }
-
         if args.mem_perf {
             features.push("memperf".into());
         }
@@ -84,6 +76,16 @@ pub fn resolve_features(args: &BuildArgs) -> Result<ResolvedBuild> {
 
         if args.n4w1 {
             features.push("n4w1".into());
+        }
+    }
+
+    if matches!(args.project, Project::Firmware | Project::Kernel) {
+        if args.block_on_vcp {
+            features.push("block_on_vcp".into());
+        }
+
+        if args.apps {
+            features.push("app_loading".into());
         }
     }
 


### PR DESCRIPTION
This PR fixes the functionality of xtask's `--block-on-vcp` and `--apps` arguments. After this fix, the kernel is built with the `block_on_vcp` and/or `app_loading` features enabled when the corresponding arguments are used.

Besides that, the VCP logging backend was fixed when `BLOCK_ON_VCP` is enabled. It seems that this feature has not worked at all since we introduced event polling into the kernel.

The bug does not affect any released firmware.

Fixes #7116 
