### PR TITLE
fix combining binaries in xtask

### DIFF
--- a/core/embed/xtask/src/combine.rs
+++ b/core/embed/xtask/src/combine.rs
@@ -1,4 +1,4 @@
-use anyhow::{Context, Result};
+use anyhow::{Context, Result, ensure};
 use std::fs;
 
 use crate::{
@@ -8,6 +8,10 @@ use crate::{
 
 const COMBINED_PREFIX: &str = "combined-";
 
+/// Byte used to pad the gaps between combined sections. Matches the original
+/// `combine_firmware.py`, which padded with zero bytes.
+const SECTION_PADDING: u8 = 0x00;
+
 fn load_binary(model: Model, project: Project) -> Result<Vec<u8>> {
     let path = helpers::artifacts_dir(model)?.join(format!("{}.bin", project.binary_name()));
     println!("Loading `{}`", path.display());
@@ -16,37 +20,87 @@ fn load_binary(model: Model, project: Project) -> Result<Vec<u8>> {
     Ok(data)
 }
 
+/// Places `data` at `offset` within `binary`, padding any preceding gap with
+/// [`SECTION_PADDING`]. Each section must start at or after the current end of
+/// the image, otherwise the sections would overlap.
+fn place_section(binary: &mut Vec<u8>, offset: usize, data: &[u8]) -> Result<()> {
+    ensure!(
+        binary.len() <= offset,
+        "combined sections overlap: next section starts at 0x{:X} but image is already 0x{:X} bytes",
+        offset,
+        binary.len()
+    );
+    binary.resize(offset, SECTION_PADDING);
+    binary.extend_from_slice(data);
+    Ok(())
+}
+
 /// Combines multiple firmware projects into a single binary for flashing.
+///
+/// The combined image starts at `BOARDLOADER_START` (the address it is flashed
+/// to) and places every section at its real offset within flash, padding the
+/// gaps between sections.
 pub fn combine(args: CombineArgs) -> Result<()> {
     let memory_ld = args.model.model_memory_ld()?;
 
-    // Calculate the offset of boardloader from the start of flash
-    let flash_start = helpers::read_symbol(&memory_ld, "FLASH_START")?;
-    let boardloader_start = helpers::read_symbol(&memory_ld, "BOARDLOADER_START")?;
-    let offset = boardloader_start - flash_start;
+    // All offsets are relative to the boardloader, which sits at the start of
+    // the combined image.
+    let base = helpers::read_symbol(&memory_ld, "BOARDLOADER_START")?;
+    let offset_of = |symbol: &str| -> Result<usize> {
+        Ok((helpers::read_symbol(&memory_ld, symbol)? - base) as usize)
+    };
 
-    // Create an binary with leading offset zeroes
-    let mut binary = vec![0u8; offset as usize];
+    let mut binary = Vec::new();
 
-    binary.extend_from_slice(&load_binary(args.model, Project::Boardloader)?);
+    place_section(
+        &mut binary,
+        0,
+        &load_binary(args.model, Project::Boardloader)?,
+    )?;
+
+    let bootloader_off = offset_of("BOOTLOADER_START")?;
 
     match args.project {
         Project::Bootloader => {
-            binary.extend_from_slice(&load_binary(args.model, Project::Bootloader)?);
+            place_section(
+                &mut binary,
+                bootloader_off,
+                &load_binary(args.model, Project::Bootloader)?,
+            )?;
         }
 
         Project::BootloaderCi => {
-            binary.extend_from_slice(&load_binary(args.model, Project::BootloaderCi)?);
+            place_section(
+                &mut binary,
+                bootloader_off,
+                &load_binary(args.model, Project::BootloaderCi)?,
+            )?;
         }
 
         Project::Firmware => {
-            binary.extend_from_slice(&load_binary(args.model, Project::Bootloader)?);
-            binary.extend_from_slice(&load_binary(args.model, Project::Firmware)?);
+            place_section(
+                &mut binary,
+                bootloader_off,
+                &load_binary(args.model, Project::Bootloader)?,
+            )?;
+            place_section(
+                &mut binary,
+                offset_of("FIRMWARE_START")?,
+                &load_binary(args.model, Project::Firmware)?,
+            )?;
         }
 
         Project::Prodtest => {
-            binary.extend_from_slice(&load_binary(args.model, Project::Bootloader)?);
-            binary.extend_from_slice(&load_binary(args.model, Project::Prodtest)?);
+            place_section(
+                &mut binary,
+                bootloader_off,
+                &load_binary(args.model, Project::Bootloader)?,
+            )?;
+            place_section(
+                &mut binary,
+                offset_of("FIRMWARE_START")?,
+                &load_binary(args.model, Project::Prodtest)?,
+            )?;
         }
 
         _ => anyhow::bail!(
@@ -83,4 +137,41 @@ pub fn combine(args: CombineArgs) -> Result<()> {
     )?;
 
     Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{SECTION_PADDING, place_section};
+
+    #[test]
+    fn places_sections_at_their_offsets_and_pads_gaps() {
+        let mut binary = Vec::new();
+        place_section(&mut binary, 0, &[1, 2, 3]).unwrap();
+        // Gap from 3 to 8 must be padded with the padding byte.
+        place_section(&mut binary, 8, &[4, 5]).unwrap();
+
+        assert_eq!(
+            binary,
+            [
+                1,
+                2,
+                3,
+                SECTION_PADDING,
+                SECTION_PADDING,
+                SECTION_PADDING,
+                SECTION_PADDING,
+                SECTION_PADDING,
+                4,
+                5
+            ]
+        );
+    }
+
+    #[test]
+    fn rejects_overlapping_sections() {
+        let mut binary = Vec::new();
+        place_section(&mut binary, 0, &[1, 2, 3, 4]).unwrap();
+        // Offset 2 falls inside the already-placed first section.
+        assert!(place_section(&mut binary, 2, &[5, 6]).is_err());
+    }
 }


### PR DESCRIPTION
combine concatenated boardloader/bootloader/firmware back-to-back, but the .bin files are content-sized, so every section after the boardloader landed too early and the flashed image didn't boot. Place each section at its memory.ld offset (relative to BOARDLOADER_START), padding gaps with zeros. Affects all models.

<!--
For external contributors:
- Please open an issue before submitting a PR so we can discuss whether we want to proceed with it.

For core developers:
1. Initial PR setup
- Assign yourself to the PR.
- Add it to the "Firmware" project
  - Set Priority (match issue priority if it exists)
  - Set Team
  - Set Sprint (target release)

2. Development status
- Draft PRs: Set status to "In Progress"
- Final PRs: Set status to "Needs Review"

3. Post-merge status
- Testable: Set status to "Needs QA" and add a `Notes for QA` section with clear instructions on how to test the functionality.
- Not Testable: Set status to "Done (no QA)"
-->
