### PR TITLE
Revert "fix(trezor-client): send empty passphrase for standard wallets + formatting"

### DIFF
--- a/rust/trezor-client/src/client/common.rs
+++ b/rust/trezor-client/src/client/common.rs
@@ -221,10 +221,7 @@ pub fn handle_interaction<T, R: TrezorMessage>(resp: TrezorResponse<'_, T, R>) -
         TrezorResponse::Failure(_) => resp.ok(), // assering ok() returns the failure error
         TrezorResponse::ButtonRequest(req) => handle_interaction(req.ack()?),
         TrezorResponse::PinMatrixRequest(_) => Err(Error::UnsupportedNetwork),
-        TrezorResponse::PassphraseRequest(req) => handle_interaction({
-            let on_device = req.on_device();
-            req.ack(!on_device)?
-        }),
+        TrezorResponse::PassphraseRequest(req) => handle_interaction(req.ack(true)?),
     }
 }
 

--- a/rust/trezor-client/src/client/common.rs
+++ b/rust/trezor-client/src/client/common.rs
@@ -221,10 +221,9 @@ pub fn handle_interaction<T, R: TrezorMessage>(resp: TrezorResponse<'_, T, R>) -
         TrezorResponse::Failure(_) => resp.ok(), // assering ok() returns the failure error
         TrezorResponse::ButtonRequest(req) => handle_interaction(req.ack()?),
         TrezorResponse::PinMatrixRequest(_) => Err(Error::UnsupportedNetwork),
-        TrezorResponse::PassphraseRequest(req) => handle_interaction(if req.on_device() {
-            req.ack(true)?
-        } else {
-            req.ack_passphrase(String::new())?
+        TrezorResponse::PassphraseRequest(req) => handle_interaction({
+            let on_device = req.on_device();
+            req.ack(!on_device)?
         }),
     }
 }

--- a/rust/trezor-client/src/client/common.rs
+++ b/rust/trezor-client/src/client/common.rs
@@ -101,11 +101,6 @@ impl<'a, T, R: TrezorMessage> fmt::Debug for PassphraseRequest<'a, T, R> {
 }
 
 impl<'a, T, R: TrezorMessage> PassphraseRequest<'a, T, R> {
-    /// Check whether the use is supposed to enter the passphrase on the device or not.
-    pub fn on_device(&self) -> bool {
-        self.message._on_device()
-    }
-
     /// Ack the request with a passphrase and get the next message from the device.
     pub fn ack_passphrase(self, passphrase: String) -> Result<TrezorResponse<'a, T, R>> {
         let mut req = protos::PassphraseAck::new();


### PR DESCRIPTION
Reverts trezor/trezor-firmware#7136, following https://github.com/trezor/trezor-firmware/pull/7034#issuecomment-4742759741.