### PR TITLE
feat(trezor-client): return full SignedIdentity and accept challenge_visual

### DIFF
--- a/rust/trezor-client/src/client/mod.rs
+++ b/rust/trezor-client/src/client/mod.rs
@@ -236,18 +236,30 @@ impl Trezor {
         self.call(req, Box::new(|_, _| Ok(())))
     }
 
+    /// Sign an identity challenge (SLIP-0013 / SLIP-0019).
+    ///
+    /// `digest` is the `challenge_hidden` value that is actually signed, while
+    /// `challenge_visual` is the human-readable string shown to the user on the
+    /// device screen (pass an empty string for no visual challenge).
+    ///
+    /// The full [`protos::SignedIdentity`] response is returned, so the caller
+    /// can read the device-derived `public_key` alongside the `signature` (for
+    /// example to cross-check the signature host-side). This mirrors
+    /// [`Trezor::get_ecdh_session_key`], which already returns its full
+    /// response message.
     pub fn sign_identity(
         &mut self,
         identity: protos::IdentityType,
         digest: Vec<u8>,
+        challenge_visual: String,
         curve: String,
-    ) -> Result<TrezorResponse<'_, Vec<u8>, protos::SignedIdentity>> {
+    ) -> Result<TrezorResponse<'_, protos::SignedIdentity, protos::SignedIdentity>> {
         let mut req = protos::SignIdentity::new();
         req.identity = MessageField::some(identity);
         req.set_challenge_hidden(digest);
-        req.set_challenge_visual("".to_owned());
+        req.set_challenge_visual(challenge_visual);
         req.set_ecdsa_curve_name(curve);
-        self.call(req, Box::new(|_, m| Ok(m.signature().to_owned())))
+        self.call(req, Box::new(|_, m| Ok(m)))
     }
 
     pub fn get_ecdh_session_key(


### PR DESCRIPTION
While building an identity-signing flow on top of `trezor-client`
(SLIP-0013/0019, the SSH/GPG-style auth path), I ran into two limitations in
`Trezor::sign_identity()`:

1. It hardcodes `challenge_visual = ""`, so there is no way to set the
   human-readable string the device shows the user when asking them to approve
   the signature.
2. It returns only the raw signature bytes (`Vec<u8>`) and discards the rest of
   the `SignedIdentity` response, including the device-derived `public_key`. I
   need that `public_key` to verify the returned signature host-side, so today
   I have to skip the helper and build the `SignIdentity` message and call
   `call()` by hand.

This PR extends the helper to take the `challenge_visual` string and to return
the whole `SignedIdentity` message. As a bonus it makes the helper consistent
with `get_ecdh_session_key()`, which already returns its full response message.

```rust
// before
pub fn sign_identity(&mut self, identity: IdentityType, digest: Vec<u8>, curve: String)
    -> Result<TrezorResponse<'_, Vec<u8>, SignedIdentity>>

// after
pub fn sign_identity(&mut self, identity: IdentityType, digest: Vec<u8>, challenge_visual: String, curve: String)
    -> Result<TrezorResponse<'_, SignedIdentity, SignedIdentity>>
```

**Breaking change:** this changes the signature and return type of
`sign_identity()`. Existing callers need to pass the visual string (use `""`
for none) and read `.signature()` off the returned message instead of getting
the bytes directly.

>> Note: this is an API-completeness change, independent of #7144. It doesn't sign or add any field - it surfaces the challenge_visual the firmware already displays (and already signs for non-ssh/gpg identities), and returns the full SignedIdentity the firmware already produces, matching get_ecdh_session_key().
