### PR TITLE
fix(trezor-client): finite read timeouts and drain stale buffers

### DIFF
--- a/rust/trezor-client/src/transport/udp.rs
+++ b/rust/trezor-client/src/transport/udp.rs
@@ -106,9 +106,9 @@ impl UdpLink {
             // reported that nothing is listening. That just means "not here",
             // not an error worth propagating up through discovery.
             Err(e)
-                if e.kind() == ErrorKind::WouldBlock
-                    || e.kind() == ErrorKind::TimedOut
-                    || e.kind() == ErrorKind::ConnectionRefused =>
+                if e.kind() == ErrorKind::WouldBlock ||
+                    e.kind() == ErrorKind::TimedOut ||
+                    e.kind() == ErrorKind::ConnectionRefused =>
             {
                 Ok(false)
             }
@@ -279,10 +279,7 @@ mod tests {
         // Nothing is left to read, so the watchdog fires rather than handing
         // back the stale bytes that drain was supposed to discard.
         let deadline = Instant::now() + Duration::from_millis(150);
-        assert!(matches!(
-            link.read_chunk_until(deadline).unwrap_err(),
-            Error::DeviceReadTimeout
-        ));
+        assert!(matches!(link.read_chunk_until(deadline).unwrap_err(), Error::DeviceReadTimeout));
     }
 
     #[test]

--- a/rust/trezor-client/src/transport/udp.rs
+++ b/rust/trezor-client/src/transport/udp.rs
@@ -144,16 +144,23 @@ impl UdpLink {
     /// Discard any stale datagrams left buffered from a previous, interrupted
     /// session. Without this, the first response can be paired with a leftover
     /// message and the link stays desynchronised for the rest of its life.
-    fn drain(&mut self) {
+    fn drain(&mut self) -> Result<(), Error> {
         let mut chunk = vec![0; CHUNK_SIZE];
-        if self.socket.set_read_timeout(Some(DRAIN_TIMEOUT)).is_err() {
-            return;
-        }
+        self.socket.set_read_timeout(Some(DRAIN_TIMEOUT))?;
         for _ in 0..DRAIN_MAX_CHUNKS {
-            if self.socket.recv(&mut chunk).is_err() {
-                break;
+            match self.socket.recv(&mut chunk) {
+                // A stale datagram; keep draining.
+                Ok(_) => {}
+                // Buffer is empty (nothing more queued) -- a clean finish.
+                Err(e) if e.kind() == ErrorKind::WouldBlock || e.kind() == ErrorKind::TimedOut => {
+                    break
+                }
+                // A real transport error (e.g. the peer vanished): surface it
+                // rather than handing back a half-broken transport.
+                Err(e) => return Err(e.into()),
             }
         }
+        Ok(())
     }
 }
 
@@ -200,7 +207,7 @@ impl UdpTransport {
         path.push_str(&transport.port);
         let mut link = UdpLink::open(&path)?;
         // Drop any stale datagrams before the first real exchange.
-        link.drain();
+        link.drain()?;
         Ok(Box::new(UdpTransport { protocol: ProtocolV1 { link } }))
     }
 }
@@ -265,7 +272,9 @@ mod tests {
         peer.send_to(&[0xAA; CHUNK_SIZE], client_addr).unwrap();
         std::thread::sleep(Duration::from_millis(50));
 
-        link.drain();
+        // Draining the stale chunk and then finding the buffer empty is a
+        // clean finish, not an error.
+        link.drain().unwrap();
 
         // Nothing is left to read, so the watchdog fires rather than handing
         // back the stale bytes that drain was supposed to discard.

--- a/rust/trezor-client/src/transport/udp.rs
+++ b/rust/trezor-client/src/transport/udp.rs
@@ -4,7 +4,13 @@ use super::{
     AvailableDeviceTransport, ProtoMessage, Transport,
 };
 use crate::{AvailableDevice, Model};
-use std::{fmt, net::UdpSocket, result::Result, time::Duration};
+use std::{
+    fmt,
+    io::ErrorKind,
+    net::UdpSocket,
+    result::Result,
+    time::{Duration, Instant},
+};
 
 // A collection of constants related to the Emulator Ports.
 mod constants {
@@ -19,8 +25,25 @@ use constants::{DEFAULT_DEBUG_PORT, DEFAULT_HOST, DEFAULT_PORT, LOCAL_LISTENER};
 /// The chunk size for the serial protocol.
 const CHUNK_SIZE: usize = 64;
 
-const READ_TIMEOUT: Option<Duration> = None;
-const WRITE_TIMEOUT: Option<Duration> = Some(Duration::from_secs(1));
+/// Total time to wait for a single chunk before giving up. Deliberately
+/// generous, because the emulator legitimately blocks on the user. The point
+/// is only that the wait is now *finite*: a wedged or vanished peer surfaces a
+/// [`Error::DeviceReadTimeout`] instead of blocking forever, which the
+/// previous value of `None` ("block indefinitely") allowed.
+const READ_TIMEOUT: Duration = Duration::from_secs(600);
+/// Poll slice within [`READ_TIMEOUT`]; we retry the blocking `recv` until the
+/// deadline is reached.
+const READ_POLL: Duration = Duration::from_millis(100);
+const WRITE_TIMEOUT: Duration = Duration::from_secs(1);
+/// Per-read timeout while discarding stale chunks on connect.
+const DRAIN_TIMEOUT: Duration = Duration::from_millis(10);
+/// Upper bound on datagrams discarded while draining, so a peer that keeps
+/// sending can never hold the connect path open (worst case
+/// `DRAIN_MAX_CHUNKS * DRAIN_TIMEOUT`). A real stale buffer is a few chunks.
+const DRAIN_MAX_CHUNKS: usize = 1024;
+/// Timeout for the discovery probe, so scanning for an emulator that never
+/// answers cannot hang the caller.
+const PROBE_TIMEOUT: Duration = Duration::from_millis(500);
 
 /// An available transport for connecting with a device.
 #[derive(Debug)]
@@ -45,7 +68,7 @@ struct UdpLink {
 impl Link for UdpLink {
     fn write_chunk(&mut self, chunk: Vec<u8>) -> Result<(), Error> {
         debug_assert_eq!(CHUNK_SIZE, chunk.len());
-        self.socket.set_write_timeout(WRITE_TIMEOUT)?;
+        self.socket.set_write_timeout(Some(WRITE_TIMEOUT))?;
         if let Err(e) = self.socket.send(&chunk) {
             return Err(e.into());
         }
@@ -53,15 +76,7 @@ impl Link for UdpLink {
     }
 
     fn read_chunk(&mut self) -> Result<Vec<u8>, Error> {
-        let mut chunk = vec![0; CHUNK_SIZE];
-        self.socket.set_read_timeout(READ_TIMEOUT)?;
-
-        let n = self.socket.recv(&mut chunk)?;
-        if n == CHUNK_SIZE {
-            Ok(chunk)
-        } else {
-            Err(Error::DeviceReadTimeout)
-        }
+        self.read_chunk_until(Instant::now() + READ_TIMEOUT)
     }
 }
 
@@ -82,9 +97,63 @@ impl UdpLink {
     // Ping the port and compare against expected response
     fn ping(&self) -> Result<bool, Error> {
         let mut resp = [0; CHUNK_SIZE];
+        // Bound the probe so discovery cannot hang on a port that never replies.
+        self.socket.set_read_timeout(Some(PROBE_TIMEOUT))?;
         self.socket.send("PINGPING".as_bytes())?;
-        let size = self.socket.recv(&mut resp)?;
-        Ok(&resp[..size] == "PONGPONG".as_bytes())
+        match self.socket.recv(&mut resp) {
+            Ok(size) => Ok(&resp[..size] == "PONGPONG".as_bytes()),
+            // No emulator answered within the probe window, or the socket
+            // reported that nothing is listening. That just means "not here",
+            // not an error worth propagating up through discovery.
+            Err(e)
+                if e.kind() == ErrorKind::WouldBlock
+                    || e.kind() == ErrorKind::TimedOut
+                    || e.kind() == ErrorKind::ConnectionRefused =>
+            {
+                Ok(false)
+            }
+            Err(e) => Err(e.into()),
+        }
+    }
+
+    /// Read one chunk, polling in [`READ_POLL`] slices until `deadline`, after
+    /// which [`Error::DeviceReadTimeout`] is returned instead of blocking
+    /// forever on a peer that has gone silent.
+    fn read_chunk_until(&mut self, deadline: Instant) -> Result<Vec<u8>, Error> {
+        let mut chunk = vec![0; CHUNK_SIZE];
+        loop {
+            let now = Instant::now();
+            if now >= deadline {
+                return Err(Error::DeviceReadTimeout);
+            }
+            // Floor at 1 ms to match the webusb path and keep the per-poll
+            // timeout safely non-zero.
+            let poll = READ_POLL.min(deadline - now).max(Duration::from_millis(1));
+            self.socket.set_read_timeout(Some(poll))?;
+            match self.socket.recv(&mut chunk) {
+                Ok(n) if n == CHUNK_SIZE => return Ok(chunk),
+                Ok(n) => return Err(Error::UnexpectedChunkSizeFromDevice(n)),
+                Err(e) if e.kind() == ErrorKind::WouldBlock || e.kind() == ErrorKind::TimedOut => {
+                    continue
+                }
+                Err(e) => return Err(e.into()),
+            }
+        }
+    }
+
+    /// Discard any stale datagrams left buffered from a previous, interrupted
+    /// session. Without this, the first response can be paired with a leftover
+    /// message and the link stays desynchronised for the rest of its life.
+    fn drain(&mut self) {
+        let mut chunk = vec![0; CHUNK_SIZE];
+        if self.socket.set_read_timeout(Some(DRAIN_TIMEOUT)).is_err() {
+            return;
+        }
+        for _ in 0..DRAIN_MAX_CHUNKS {
+            if self.socket.recv(&mut chunk).is_err() {
+                break;
+            }
+        }
     }
 }
 
@@ -129,7 +198,9 @@ impl UdpTransport {
         path.push_str(&transport.host);
         path.push(':');
         path.push_str(&transport.port);
-        let link = UdpLink::open(&path)?;
+        let mut link = UdpLink::open(&path)?;
+        // Drop any stale datagrams before the first real exchange.
+        link.drain();
         Ok(Box::new(UdpTransport { protocol: ProtocolV1 { link } }))
     }
 }
@@ -147,5 +218,79 @@ impl super::Transport for UdpTransport {
     }
     fn read_message(&mut self) -> Result<ProtoMessage, Error> {
         self.protocol.read()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// Bind a loopback UDP socket, returning `None` (so the test is skipped)
+    /// if the sandbox forbids it.
+    fn loopback() -> Option<UdpSocket> {
+        UdpSocket::bind("127.0.0.1:0").ok()
+    }
+
+    fn link_connected_to(addr: &str) -> Option<UdpLink> {
+        let socket = loopback()?;
+        socket.connect(addr).ok()?;
+        Some(UdpLink { socket, device: ("127.0.0.1".to_owned(), "0".to_owned()) })
+    }
+
+    #[test]
+    fn read_chunk_times_out_against_a_silent_peer() {
+        let Some(peer) = loopback() else {
+            eprintln!("skipping: no loopback UDP available");
+            return;
+        };
+        let addr = peer.local_addr().unwrap().to_string();
+        let mut link = link_connected_to(&addr).unwrap();
+
+        let deadline = Instant::now() + Duration::from_millis(150);
+        let err = link.read_chunk_until(deadline).unwrap_err();
+        assert!(matches!(err, Error::DeviceReadTimeout), "unexpected error: {err:?}");
+    }
+
+    #[test]
+    fn drain_discards_stale_chunks() {
+        let Some(peer) = loopback() else {
+            eprintln!("skipping: no loopback UDP available");
+            return;
+        };
+        let peer_addr = peer.local_addr().unwrap().to_string();
+        let mut link = link_connected_to(&peer_addr).unwrap();
+        let client_addr = link.socket.local_addr().unwrap();
+
+        // The peer leaves a stale chunk buffered for the client.
+        peer.send_to(&[0xAA; CHUNK_SIZE], client_addr).unwrap();
+        std::thread::sleep(Duration::from_millis(50));
+
+        link.drain();
+
+        // Nothing is left to read, so the watchdog fires rather than handing
+        // back the stale bytes that drain was supposed to discard.
+        let deadline = Instant::now() + Duration::from_millis(150);
+        assert!(matches!(
+            link.read_chunk_until(deadline).unwrap_err(),
+            Error::DeviceReadTimeout
+        ));
+    }
+
+    #[test]
+    fn read_chunk_returns_a_full_chunk() {
+        let Some(peer) = loopback() else {
+            eprintln!("skipping: no loopback UDP available");
+            return;
+        };
+        let peer_addr = peer.local_addr().unwrap().to_string();
+        let mut link = link_connected_to(&peer_addr).unwrap();
+        let client_addr = link.socket.local_addr().unwrap();
+
+        peer.send_to(&[0x7E; CHUNK_SIZE], client_addr).unwrap();
+
+        let deadline = Instant::now() + Duration::from_secs(2);
+        let chunk = link.read_chunk_until(deadline).unwrap();
+        assert_eq!(chunk.len(), CHUNK_SIZE);
+        assert!(chunk.iter().all(|&b| b == 0x7E));
     }
 }

--- a/rust/trezor-client/src/transport/webusb.rs
+++ b/rust/trezor-client/src/transport/webusb.rs
@@ -111,14 +111,21 @@ impl WebUsbLink {
     /// Discard any stale chunks left buffered from a previous, interrupted
     /// session. Without this, the first response can be paired with a leftover
     /// message and the link stays desynchronised for the rest of its life.
-    fn drain(&mut self) {
+    fn drain(&mut self) -> Result<(), Error> {
         let endpoint = constants::READ_ENDPOINT_MASK | self.endpoint;
         let mut chunk = vec![0; CHUNK_SIZE];
         for _ in 0..DRAIN_MAX_CHUNKS {
-            if self.handle.read_interrupt(endpoint, &mut chunk, DRAIN_TIMEOUT).is_err() {
-                break;
+            match self.handle.read_interrupt(endpoint, &mut chunk, DRAIN_TIMEOUT) {
+                // A stale chunk; keep draining.
+                Ok(_) => {}
+                // Nothing more queued -- a clean finish.
+                Err(rusb::Error::Timeout) => break,
+                // A real USB error (e.g. the device was unplugged): surface it
+                // rather than handing back a half-broken transport.
+                Err(e) => return Err(e.into()),
             }
         }
+        Ok(())
     }
 }
 
@@ -201,7 +208,7 @@ impl WebUsbTransport {
         };
         // Drain any chunks already queued on the IN endpoint after claiming
         // the interface, so the first exchange starts from a clean state.
-        link.drain();
+        link.drain()?;
 
         Ok(Box::new(WebUsbTransport { protocol: ProtocolV1 { link } }))
     }

--- a/rust/trezor-client/src/transport/webusb.rs
+++ b/rust/trezor-client/src/transport/webusb.rs
@@ -8,7 +8,11 @@ use crate::{
     AvailableDevice,
 };
 use rusb::*;
-use std::{fmt, result::Result, time::Duration};
+use std::{
+    fmt,
+    result::Result,
+    time::{Duration, Instant},
+};
 
 // A collection of constants related to the WebUsb protocol.
 mod constants {
@@ -26,8 +30,23 @@ mod constants {
 /// The chunk size for the serial protocol.
 const CHUNK_SIZE: usize = 64;
 
-const READ_TIMEOUT: Duration = Duration::from_secs(0);
+/// Total time to wait for a single chunk before giving up. Deliberately
+/// generous, because the device legitimately blocks on the user (a button
+/// press or PIN entry can take as long as the user needs). The point is only
+/// that the wait is now *finite*: a vanished or wedged device surfaces a
+/// [`Error::DeviceReadTimeout`] instead of blocking forever, which the
+/// previous value of `0` ("wait indefinitely") allowed.
+const READ_TIMEOUT: Duration = Duration::from_secs(600);
+/// Poll slice within [`READ_TIMEOUT`]: a libusb interrupt read returns
+/// `Timeout` after each slice with no data, and we retry until the deadline.
+const READ_POLL: Duration = Duration::from_millis(100);
 const WRITE_TIMEOUT: Duration = Duration::from_secs(1);
+/// Per-read timeout while discarding stale chunks on connect.
+const DRAIN_TIMEOUT: Duration = Duration::from_millis(10);
+/// Upper bound on chunks discarded while draining, so a device that keeps
+/// producing data can never hold the connect path open (worst case
+/// `DRAIN_MAX_CHUNKS * DRAIN_TIMEOUT`). A real stale buffer is a few chunks.
+const DRAIN_MAX_CHUNKS: usize = 1024;
 
 /// An available transport for connecting with a device.
 #[derive(Debug)]
@@ -58,14 +77,47 @@ impl Link for WebUsbLink {
     }
 
     fn read_chunk(&mut self) -> Result<Vec<u8>, Error> {
-        let mut chunk = vec![0; CHUNK_SIZE];
-        let endpoint = constants::READ_ENDPOINT_MASK | self.endpoint;
+        self.read_chunk_until(Instant::now() + READ_TIMEOUT)
+    }
+}
 
-        let n = self.handle.read_interrupt(endpoint, &mut chunk, READ_TIMEOUT)?;
-        if n == CHUNK_SIZE {
-            Ok(chunk)
-        } else {
-            Err(Error::DeviceReadTimeout)
+impl WebUsbLink {
+    /// Read one chunk, polling in [`READ_POLL`] slices until `deadline`, after
+    /// which [`Error::DeviceReadTimeout`] is returned instead of blocking
+    /// forever on a device that has gone away.
+    fn read_chunk_until(&mut self, deadline: Instant) -> Result<Vec<u8>, Error> {
+        let endpoint = constants::READ_ENDPOINT_MASK | self.endpoint;
+        let mut chunk = vec![0; CHUNK_SIZE];
+        loop {
+            let now = Instant::now();
+            if now >= deadline {
+                return Err(Error::DeviceReadTimeout);
+            }
+            // Floor at 1 ms: rusb converts the timeout to whole milliseconds
+            // (`as_millis() as c_uint`), so a sub-millisecond value truncates
+            // to 0, which libusb treats as "block indefinitely" -- the exact
+            // hang this loop exists to prevent. Overshooting the deadline by up
+            // to one poll slice is harmless; the next iteration catches it.
+            let poll = READ_POLL.min(deadline - now).max(Duration::from_millis(1));
+            match self.handle.read_interrupt(endpoint, &mut chunk, poll) {
+                Ok(n) if n == CHUNK_SIZE => return Ok(chunk),
+                Ok(n) => return Err(Error::UnexpectedChunkSizeFromDevice(n)),
+                Err(rusb::Error::Timeout) => continue,
+                Err(e) => return Err(e.into()),
+            }
+        }
+    }
+
+    /// Discard any stale chunks left buffered from a previous, interrupted
+    /// session. Without this, the first response can be paired with a leftover
+    /// message and the link stays desynchronised for the rest of its life.
+    fn drain(&mut self) {
+        let endpoint = constants::READ_ENDPOINT_MASK | self.endpoint;
+        let mut chunk = vec![0; CHUNK_SIZE];
+        for _ in 0..DRAIN_MAX_CHUNKS {
+            if self.handle.read_interrupt(endpoint, &mut chunk, DRAIN_TIMEOUT).is_err() {
+                break;
+            }
         }
     }
 }
@@ -140,17 +192,18 @@ impl WebUsbTransport {
         let handle = dev.open()?;
         handle.claim_interface(interface)?;
 
-        Ok(Box::new(WebUsbTransport {
-            protocol: ProtocolV1 {
-                link: WebUsbLink {
-                    handle,
-                    endpoint: match device.debug {
-                        false => constants::ENDPOINT,
-                        true => constants::ENDPOINT_DEBUG,
-                    },
-                },
+        let mut link = WebUsbLink {
+            handle,
+            endpoint: match device.debug {
+                false => constants::ENDPOINT,
+                true => constants::ENDPOINT_DEBUG,
             },
-        }))
+        };
+        // Drain any chunks already queued on the IN endpoint after claiming
+        // the interface, so the first exchange starts from a clean state.
+        link.drain();
+
+        Ok(Box::new(WebUsbTransport { protocol: ProtocolV1 { link } }))
     }
 }
 


### PR DESCRIPTION
I hit two robustness problems in both the WebUSB and the UDP transport:

1. **Reads can block forever.** The WebUSB read timeout is `0` and the UDP read
   timeout is `None`, both of which mean "wait indefinitely". If the device is
   unplugged or wedged mid-read, `read_message()` never returns and the calling
   thread hangs.
2. **Stale buffers desynchronise the link.** Nothing discards data left
   buffered from a previous, interrupted session, so the first response can be
   paired with a leftover message and the link stays out of sync for the rest
   of its life.
3. UDP discovery (`PINGPING`/`PONGPONG`) also had no timeout, so probing for an
   emulator that never answers could hang.

This PR:

- Replaces the infinite reads with a poll loop bounded by a finite but generous
  (600 s) watchdog deadline, so a vanished or wedged peer surfaces
  `DeviceReadTimeout` instead of hanging. The device legitimately blocks on the
  user (button press, PIN entry), so the deadline is deliberately large; the
  point is only that it is now finite. The per-poll timeout is floored at 1 ms,
  because rusb rounds the libusb timeout down to whole milliseconds and a
  sub-millisecond value would truncate to `0`, which libusb treats as "block
  indefinitely".
- Drains any stale buffered chunks on connect.
- Bounds the UDP discovery probe and treats a non-answering probe as "no
  device" rather than an error, so hardware-only discovery stays quiet.

Added device-free loopback tests cover the UDP timeout and drain behaviour.

**Behaviour change:** a short read is now reported as
`UnexpectedChunkSizeFromDevice` rather than being conflated with
`DeviceReadTimeout`. `Error` is public, so this is visible to any caller that
matches on the transport error variant.
