### PR TITLE
chore(core/caesar): avoid allocation in `confirm_payment_request`

### DIFF
--- a/core/embed/rust/src/ui/api/firmware_micropython.rs
+++ b/core/embed/rust/src/ui/api/firmware_micropython.rs
@@ -2094,7 +2094,7 @@ pub static mp_module_trezorui_api: Module = obj_module! {
     /// def show_properties(
     ///     *,
     ///     title: str,
-    ///     value: Sequence[PropertyType] | str,
+    ///     value: Iterable[PropertyType] | str,
     ///     subtitle: str | None = None,
     /// ) -> LayoutContext[None]:
     ///     """Show a list of key-value pairs, or a monospace string."""

--- a/core/mocks/generated/trezorui_api.pyi
+++ b/core/mocks/generated/trezorui_api.pyi
@@ -766,7 +766,7 @@ def show_progress_coinjoin(
 def show_properties(
     *,
     title: str,
-    value: Sequence[PropertyType] | str,
+    value: Iterable[PropertyType] | str,
     subtitle: str | None = None,
 ) -> LayoutContext[None]:
     """Show a list of key-value pairs, or a monospace string."""

--- a/core/src/trezor/ui/layouts/caesar/__init__.py
+++ b/core/src/trezor/ui/layouts/caesar/__init__.py
@@ -638,8 +638,8 @@ async def confirm_payment_request(
         )
 
         summary_menu_items = [
-            create_details(TR.confirm_total__title_fee, list(fee_info_items)),
-            create_details(TR.address_details__account_info, list(account_items)),
+            create_details(TR.confirm_total__title_fee, fee_info_items),
+            create_details(TR.address_details__account_info, account_items),
         ]
 
         summary_menu = Menu.root(summary_menu_items)
@@ -2400,7 +2400,7 @@ async def confirm_firmware_update(description: str, fingerprint: str) -> None:
         )
 
 
-def create_details(name: str, value: list[StrPropertyType] | str) -> Details:
+def create_details(name: str, value: Iterable[StrPropertyType] | str) -> Details:
     from trezor.ui.layouts.menu import Details
 
     return Details.from_layout(

--- a/core/src/trezor/ui/layouts/delizia/__init__.py
+++ b/core/src/trezor/ui/layouts/delizia/__init__.py
@@ -2321,7 +2321,7 @@ async def tutorial(br_code: ButtonRequestType = BR_CODE_OTHER) -> None:
 
 def create_details(
     name: str,
-    value: list[StrPropertyType] | str,
+    value: Iterable[StrPropertyType] | str,
     title: str | None = None,
 ) -> Details:
     from trezor.ui.layouts.menu import Details

--- a/core/src/trezor/ui/layouts/eckhart/__init__.py
+++ b/core/src/trezor/ui/layouts/eckhart/__init__.py
@@ -2446,7 +2446,7 @@ async def tutorial(br_code: ButtonRequestType = BR_CODE_OTHER) -> None:
 
 def create_details(
     name: str,
-    value: list[StrPropertyType] | str,
+    value: Iterable[StrPropertyType] | str,
     title: str | None = None,
     subtitle: str | None = None,
 ) -> Details:


### PR DESCRIPTION
Rust `show_properties` layouts accept an iterable object.
