### PR TITLE
fix(core): raise `wire.Error` from `EvoluIndexManagement` handler

### DIFF
--- a/core/src/apps/evolu/index_management.py
+++ b/core/src/apps/evolu/index_management.py
@@ -26,6 +26,8 @@ async def index_management(msg: EvoluIndexManagement) -> EvoluIndexManagementRes
             set_delegated_identity_key_rotation_index(msg.rotation_index)
             stored_index = msg.rotation_index
         else:
-            raise ValueError("Rotation index already set.")
+            from trezor.wire import ProcessError
+
+            raise ProcessError("Rotation index already set.")
 
     return EvoluIndexManagementResponse(rotation_index=stored_index)

--- a/tests/device_tests/evolu/test_delegated_identity_key_rotation.py
+++ b/tests/device_tests/evolu/test_delegated_identity_key_rotation.py
@@ -89,7 +89,7 @@ def test_rotate_affects_index_management(client: Client):
 
     with pytest.raises(
         TrezorFailure,
-        match=r"FirmwareError: Rotation index already set.",
+        match=r"ProcessError: Rotation index already set.",
     ):
         evolu.index_management(client.get_session(), rotation_index=50)
 
@@ -103,13 +103,13 @@ def test_index_management_cannot_overwrite_existing_index(client: Client):
 
     with pytest.raises(
         TrezorFailure,
-        match=r"FirmwareError: Rotation index already set.",
+        match=r"ProcessError: Rotation index already set.",
     ):
         evolu.index_management(client.get_session(), rotation_index=5)
 
     with pytest.raises(
         TrezorFailure,
-        match=r"FirmwareError: Rotation index already set.",
+        match=r"ProcessError: Rotation index already set.",
     ):
         evolu.index_management(client.get_session(), rotation_index=15)
 


### PR DESCRIPTION
Otherwise, it is sent to the host as a `FirmwareError`, which is usually used for unexpected errors (e.g. out-of-memory errors).

See also https://docs.trezor.io/trezor-firmware/core/misc/exceptions.html.

# Notes to QA

Let's try to trigger this error [from Suite](https://github.com/trezor/trezor-firmware/pull/7147#issuecomment-4857806217).