### PR TITLE
Show plain warning for multisig GetAddress.

### DIFF
--- a/core/src/trezor/ui/layouts/delizia/__init__.py
+++ b/core/src/trezor/ui/layouts/delizia/__init__.py
@@ -180,11 +180,9 @@ def confirm_path_warning(
 
 
 def confirm_multisig_warning() -> Awaitable[None]:
-    return show_danger(
+    return show_warning(
         "warning_multisig",
         TR.send__receiving_to_multisig,
-        title=TR.words__important,
-        verb_cancel=TR.words__cancel_and_exit,
     )
 
 
@@ -201,10 +199,9 @@ async def confirm_multisig_different_paths_warning() -> None:
 
 
 def confirm_multiple_accounts_warning() -> Awaitable[None]:
-    return show_danger(
+    return show_warning(
         "sending_from_multiple_accounts",
         TR.send__from_multiple_accounts,
-        verb_cancel=TR.send__cancel_transaction,
         br_code=ButtonRequestType.SignTx,
     )
 

--- a/core/src/trezor/ui/layouts/eckhart/__init__.py
+++ b/core/src/trezor/ui/layouts/eckhart/__init__.py
@@ -143,12 +143,9 @@ def confirm_path_warning(
 
 
 def confirm_multisig_warning() -> Awaitable[None]:
-    return show_danger(
+    return show_warning(
         "warning_multisig",
         TR.send__receiving_to_multisig,
-        title=TR.words__important,
-        menu_title=TR.words__receive,
-        verb_cancel=TR.words__cancel_and_exit,
     )
 
 
@@ -164,11 +161,9 @@ def confirm_multisig_different_paths_warning() -> Awaitable[None]:
 
 
 def confirm_multiple_accounts_warning() -> Awaitable[None]:
-    return show_danger(
+    return show_warning(
         "sending_from_multiple_accounts",
         TR.send__from_multiple_accounts,
-        title=TR.words__important,
-        verb_cancel=TR.send__cancel_transaction,
         br_code=ButtonRequestType.SignTx,
     )
 

--- a/tests/input_flows.py
+++ b/tests/input_flows.py
@@ -767,9 +767,7 @@ class InputFlowShowMultisigXPUBs(InputFlowBase):
 
     def input_flow_delizia(self) -> BRGeneratorType:
         yield  # multisig address warning
-        self.debug.click(self.debug.screen_buttons.menu())
-        self.debug.synchronize_at("VerticalMenu")
-        self.debug.button_actions.navigate_to_menu_item(1)
+        self.debug.press_yes()
 
         yield  # show address
         layout = self.debug.read_layout()
@@ -819,9 +817,7 @@ class InputFlowShowMultisigXPUBs(InputFlowBase):
 
     def input_flow_eckhart(self) -> BRGeneratorType:
         yield  # multisig address warning
-        self.debug.click(self.debug.screen_buttons.menu())
-        self.debug.synchronize_at("VerticalMenu")
-        self.debug.button_actions.navigate_to_menu_item(1)
+        self.debug.press_yes()
 
         yield  # show address
         layout = self.debug.read_layout()
@@ -1121,9 +1117,7 @@ def sign_tx_go_to_info_delizia(
     if multi_account:
         yield
         client.debug.read_layout()
-        client.debug.click(client.debug.screen_buttons.menu())
-        client.debug.synchronize_at("VerticalMenu")
-        client.debug.button_actions.navigate_to_menu_item(1)
+        client.debug.press_yes()
 
     yield  # confirm transaction
     client.debug.read_layout()
@@ -1163,9 +1157,7 @@ def sign_tx_go_to_info_eckhart(
     if multi_account:
         yield
         client.debug.read_layout()
-        client.debug.click(client.debug.screen_buttons.menu())
-        client.debug.synchronize_at("VerticalMenu")
-        client.debug.button_actions.navigate_to_menu_item(1)
+        client.debug.press_yes()
 
     yield  # confirm transaction
     client.debug.read_layout()


### PR DESCRIPTION
T3T1 and T3W1 show a danger dialog for multisig GetAddress and for multi-account spends, which is unjustified, since there is nothing inherently dangerous about these operations. A danger dialog is very difficult to bypass, resulting in the user not even being able to verify the multisig address. A standard warning dialog is sufficient.