### PR TITLE
refactor(core): close other workflows when starting `ProgressLayout`

### DIFF
--- a/core/src/apps/bitcoin/sign_tx/progress.py
+++ b/core/src/apps/bitcoin/sign_tx/progress.py
@@ -109,11 +109,10 @@ class Progress:
         self.report()
 
     def report_init(self) -> None:
-        from trezor import TR, workflow
+        from trezor import TR
         from trezor.ui.layouts.progress import bitcoin_progress, coinjoin_progress
 
         progress_layout = coinjoin_progress if self.is_coinjoin else bitcoin_progress
-        workflow.close_others()
         text = (
             TR.progress__signing_transaction
             if self.signing

--- a/core/src/apps/common/mnemonic.py
+++ b/core/src/apps/common/mnemonic.py
@@ -107,14 +107,10 @@ _progress_obj: ProgressLayout | None = None
 
 
 def _start_progress() -> None:
-    from trezor import workflow
     from trezor.ui.layouts.progress import progress
 
     global _progress_obj
 
-    # Because we are drawing to the screen manually, without a layout, we
-    # should make sure that no other layout is running.
-    workflow.close_others()
     _progress_obj = progress()
 
 

--- a/core/src/apps/management/change_language.py
+++ b/core/src/apps/management/change_language.py
@@ -11,11 +11,10 @@ if TYPE_CHECKING:
 
 
 async def change_language(msg: ChangeLanguage) -> Success:
-    from trezor import utils, workflow
+    from trezor import utils
     from trezor.messages import Success
     from trezor.ui.layouts.progress import progress
 
-    workflow.close_others()
     loader: ProgressLayout | None = None
 
     def report(value: int) -> None:

--- a/core/src/trezor/ui/__init__.py
+++ b/core/src/trezor/ui/__init__.py
@@ -568,6 +568,8 @@ class ProgressLayout:
         self.value = value
 
     def start(self) -> None:
+        workflow.close_others()  # request exclusive UI access
+
         if CURRENT_LAYOUT is not self and CURRENT_LAYOUT is not None:
             CURRENT_LAYOUT.stop()
 


### PR DESCRIPTION
It should make sure homescreen is reloaded in case an exception is raised while "progress" layout is active.

Following https://github.com/trezor/trezor-firmware/pull/7151#discussion_r3450599231.

## Notes to QA

Please try to interrupt flows that show a progress bar (e.g. signing a large transaction), to be sure the progress is properly closed:
```
trezorctl set homescreen tests/device_tests/test_bg_eckhart.jpg 
# kill with Ctrl+C after 1 second.
# the progress screen should disappear after a few seconds (on THP timeout), 
# or on the next `trezorctl` invocation (on v1).
```