### PR TITLE
Fix broken `trezorctl get-session`

### DIFF
--- a/python/.changelog.d/7168.changed
+++ b/python/.changelog.d/7168.changed
@@ -1,0 +1,1 @@
+`TrezorClient.ensure_unlocked()` will not allocate a session and will not cause seed derivation. `Session.ensure_unlocked()` now just forwards to `TrezorClient`.

--- a/python/.changelog.d/7168.fixed
+++ b/python/.changelog.d/7168.fixed
@@ -1,0 +1,1 @@
+Fix non-functional `trezorctl get-session` with THP.

--- a/python/src/trezorlib/cli/__init__.py
+++ b/python/src/trezorlib/cli/__init__.py
@@ -298,17 +298,24 @@ class TrezorConnection:
         self._features = None
         self._version = None
 
-    def _passphrase_source_resolved(self) -> PassphraseSource:
+    def _passphrase_source_resolved(
+        self, prompt_passphrase: bool = True
+    ) -> PassphraseSource:
         """Resolve PassphraseSource.AUTO to a concrete PassphraseSource.
 
         Assumes that `self.features` is already populated.
 
         Returns:
+        * `PassphraseSource.EMPTY` if `prompt_passphrase` is False, indicating that
+           the caller does not ask for passphrase entry.
         * `self.passphrase_source` if it is not `PassphraseSource.AUTO`
         * `PassphraseSource.EMPTY` if passphrase protection is disabled
         * `PassphraseSource.DEVICE` if passphrase entry is supported
         * `PassphraseSource.PROMPT` otherwise
         """
+        if not prompt_passphrase:
+            return PassphraseSource.EMPTY
+
         if (
             not self.features.passphrase_protection
             and not self.passphrase_source.ok_if_disabled()
@@ -353,10 +360,15 @@ class TrezorConnection:
                 raise
 
         # nothing to resume, allocate a new session
-        return self.get_new_session(derive_cardano=derive_cardano)
+        return self.get_new_session(
+            prompt_passphrase=prompt_passphrase, derive_cardano=derive_cardano
+        )
 
     def get_new_session(
-        self, derive_cardano: bool = False, randomize_id: bool = False
+        self,
+        prompt_passphrase: bool = True,
+        derive_cardano: bool = False,
+        randomize_id: bool = False,
     ) -> Session:
         """Allocate a new session.
 
@@ -377,7 +389,7 @@ class TrezorConnection:
                 random_value = random.randint(128, 255)
             client._session_id_counter = random_value - 1
 
-        passphrase_source = self._passphrase_source_resolved()
+        passphrase_source = self._passphrase_source_resolved(prompt_passphrase)
         if passphrase_source == PassphraseSource.EMPTY:
             return client.get_session(
                 passphrase=PassphraseSetting.STANDARD_WALLET,

--- a/python/src/trezorlib/cli/__init__.py
+++ b/python/src/trezorlib/cli/__init__.py
@@ -169,7 +169,7 @@ class SessionIdentifier:
 
     def to_session_str(self) -> str:
         session_str_plain = json.dumps(dataclasses.asdict(self))
-        LOG.info(f"Decoded ession string: {session_str_plain}")
+        LOG.info(f"Decoded session string: {session_str_plain}")
         return base64.b64encode(session_str_plain.encode()).decode()
 
     def resume(self, client: TrezorClient) -> Session:
@@ -198,7 +198,6 @@ class TrezorConnection:
     _features: messages.Features | None = None
     _version: tuple[int, int, int] | None = None
     _transport: Transport | None = None
-    _standard_session: Session | None = None
 
     def __init__(
         self,
@@ -212,12 +211,20 @@ class TrezorConnection:
     ) -> None:
         self.session_str = session_str
 
-        if session_str is None:
+        decoded_session = None
+        if session_str is not None:
+            try:
+                decoded_session = SessionIdentifier.from_session_str(session_str)
+            except Exception:
+                LOG.warning("Failed to decode session string, not resuming.")
+                LOG.debug("Exception details:", exc_info=True)
+
+        if decoded_session is None:
             self.session = None
             self.path = path
         else:
-            self.session = SessionIdentifier.from_session_str(session_str)
-            if path is not None and self.session.path != path:
+            self.session = decoded_session
+            if path is not None and decoded_session.path != path:
                 click.echo("Attempting to resume a session on a different device.")
                 click.echo(
                     "Hint: omit -p or unset TREZOR_PATH to use the appropriate device for this session."
@@ -229,7 +236,7 @@ class TrezorConnection:
                 raise click.ClickException(
                     "Session path does not match the provided path"
                 )
-            self.path = self.session.path
+            self.path = decoded_session.path
 
         self.passphrase_source = passphrase_source
         self.script = script
@@ -244,36 +251,12 @@ class TrezorConnection:
             self.app.button_callback = click_ui.button_request
             self.app.pin_callback = click_ui.get_pin
 
-    def ensure_unlocked(self) -> None:
-        """Ensure that the device is unlocked.
-
-        Separate from `client.ensure_unlocked()` because we want to reuse the
-        standard session.
-        """
-        with self.client_context() as client:
-            if not client.features.initialized:
-                # uninitialized device cannot be locked
-                return
-            # query the standard session instead
-            self.standard_session.ensure_unlocked()
-
-    @property
-    def standard_session(self) -> Session:
-        if self._standard_session is None:
-            with self.client_context() as client:
-                self._standard_session = client.get_session(
-                    passphrase=PassphraseSetting.STANDARD_WALLET
-                )
-        # seems to be a weird typechecker limitation that it still thinks that
-        # session could be None here
-        return self._standard_session  # type: ignore ["None" is not assignable]
-
     @property
     def features(self) -> messages.Features:
         if self._features is None:
-            self.ensure_unlocked()
-            assert self._client is not None  # after ensure_unlocked
-            self._features = self._client.features
+            with self.client_context() as client:
+                client.ensure_unlocked()
+                self._features = client.features
         return self._features
 
     @property
@@ -314,7 +297,6 @@ class TrezorConnection:
         self._client = None
         self._features = None
         self._version = None
-        self._standard_session = None
 
     def _passphrase_source_resolved(self) -> PassphraseSource:
         """Resolve PassphraseSource.AUTO to a concrete PassphraseSource.
@@ -343,14 +325,14 @@ class TrezorConnection:
 
     def get_session(
         self,
-        use_passphrase: bool = True,
+        prompt_passphrase: bool = True,
         seedless: bool = False,
         derive_cardano: bool = False,
     ) -> Session:
         """Get a session from this connection.
 
         Arguments:
-        - use_passphrase: if True, user should get a passphrase prompt
+        - prompt_passphrase: if True, user should get a passphrase prompt
           (either on host or on device)
         - seedless: if True, create a session without a derived seed
         - derive_cardano: whether to derive a Cardano session
@@ -361,14 +343,8 @@ class TrezorConnection:
         if seedless:
             return client.get_session(passphrase=None)
 
-        passphrase_source = self._passphrase_source_resolved()
-
-        # if empty passphrase is requested, do not try to resume and just use
-        # the standard session that we already have
-        if not use_passphrase or passphrase_source == PassphraseSource.EMPTY:
-            return self.standard_session
-
-        # Try resume session from id
+        # Try to resume session from id first. A previous `get-session` call might have
+        # derived an unlocked session for us already.
         if self.session is not None:
             try:
                 return self.session.resume(client)
@@ -376,7 +352,7 @@ class TrezorConnection:
                 LOG.error("Failed to resume session", exc_info=True)
                 raise
 
-        # if all else fails, allocate a new session
+        # nothing to resume, allocate a new session
         return self.get_new_session(derive_cardano=derive_cardano)
 
     def get_new_session(
@@ -452,6 +428,8 @@ class TrezorConnection:
             if credential is not None:
                 self.credentials.add(credential)
 
+        client.pairing.finish()
+
         return client
 
     def get_client(self) -> TrezorClient:
@@ -509,13 +487,13 @@ class TrezorConnection:
     def session_context(
         self,
         *,
-        use_passphrase: bool = True,
+        prompt_passphrase: bool = True,
         derive_cardano: bool = False,
         seedless: bool = False,
     ) -> t.Generator[Session, None, None]:
         yield from self._connection_context(
             self.get_session,
-            use_passphrase=use_passphrase,
+            prompt_passphrase=prompt_passphrase,
             derive_cardano=derive_cardano,
             seedless=seedless,
         )
@@ -554,7 +532,7 @@ def with_session(
     """Provides a Click command with parameter `session=obj.get_session(...)`
     based on the parameters provided:
 
-    * if `passphrase` is set to False, a standard wallet is always used for this session
+    * if `passphrase` is set to False, the user will not be prompted for a passphrase
     * if `cardano` is set to True, Cardano-specific operations are enabled for this session
     * if `seedless` is set to True, a seedless session is used for this session
 
@@ -571,7 +549,7 @@ def with_session(
             obj: TrezorConnection, *args: "P.args", **kwargs: "P.kwargs"
         ) -> "R":
             with obj.session_context(
-                use_passphrase=passphrase,
+                prompt_passphrase=passphrase,
                 derive_cardano=cardano,
                 seedless=seedless,
             ) as session:

--- a/python/src/trezorlib/client.py
+++ b/python/src/trezorlib/client.py
@@ -97,8 +97,10 @@ class Session(t.Generic[ClientType, SessionIdType]):
     @enter_context
     def get_root_fingerprint(self) -> bytes:
         if self._root_fingerprint is None:
-            self.ensure_unlocked()
-            assert self._root_fingerprint is not None
+            pubkey = self.call(GET_ROOT_FINGERPRINT_MESSAGE, expect=messages.PublicKey)
+            # can't use resp.root_fingerprint because it's not available on <1.9.4 & <2.3.5
+            assert pubkey.node.fingerprint is not None
+            self._root_fingerprint = pubkey.node.fingerprint.to_bytes(4, "big")
         return self._root_fingerprint
 
     def call(

--- a/python/src/trezorlib/client.py
+++ b/python/src/trezorlib/client.py
@@ -173,22 +173,8 @@ class Session(t.Generic[ClientType, SessionIdType]):
 
     @enter_context
     def ensure_unlocked(self) -> None:
-        """Ensure that the device is unlocked.
-
-        This method only works on sessions that have a passphrase derived, and
-        transitively, only on an initialized device.
-
-        Go through `client.ensure_unlocked()` if you want to abstract away the
-        choice of a correct session for this operation.
-        """
-        resp = self.call(GET_ROOT_FINGERPRINT_MESSAGE, expect=messages.PublicKey)
-        # resp.root_fingerprint is not available on <1.9.4 & <2.3.5
-        assert resp.node.fingerprint is not None
-        root_fingerprint = resp.node.fingerprint.to_bytes(4, "big")
-        if self._root_fingerprint is None:
-            self._root_fingerprint = root_fingerprint
-        assert self._root_fingerprint == root_fingerprint
-        self.refresh_features()
+        """Ensure that the device is unlocked."""
+        self.client.ensure_unlocked(_use_session=self)
 
     @enter_context
     def lock(self) -> None:
@@ -573,14 +559,24 @@ class TrezorClient(t.Generic[SessionType], metaclass=ABCMeta):
             session.call_raw(messages.LockDevice())
         self.refresh_features()
 
-    def ensure_unlocked(self) -> None:
-        """Ensure the device is unlocked."""
+    def ensure_unlocked(self, *, _use_session: SessionType | None = None) -> None:
+        """Ensure the device is unlocked.
+
+        If the device has PIN set, this will trigger a PIN unlock.
+        """
         if not self.features.initialized:
             # uninitialized device cannot be locked
             return
-        session = self.get_session(passphrase=PassphraseSetting.STANDARD_WALLET)
+        session = _use_session or self._get_any_session()
         with session:
-            session.ensure_unlocked()
+            # ApplyFlags(0) is a no-op because the device (1) ORs the flags into
+            # the current value, which does nothing, then (2) only writes the
+            # flags if modified.
+            # It needs PIN unlock to access the flags value but does not derive seed.
+            session.call(messages.ApplyFlags(flags=0), expect=messages.Success)
+
+        # refresh features to update fields whose state is different after unlock.
+        self.refresh_features()
 
     def _invalidate(self) -> None:
         """Invalidate the client after a device wipe.

--- a/tests/device_tests/test_protection_levels.py
+++ b/tests/device_tests/test_protection_levels.py
@@ -97,22 +97,14 @@ def _get_test_address(session: Session) -> None:
     )
 
 
-def _assert_protection(client: Client, pin: bool = True, passphrase: bool = True):
+def _assert_protection(test_ctx: Client, pin: bool = True, passphrase: bool = True):
     """Make sure PIN and passphrase protection have expected values"""
-    with client:
-        client.use_pin_sequence([PIN4])
-        session = client.get_session()
-        try:
-            session.ensure_unlocked()
-        except exceptions.InvalidSessionError:
-            session.cancel()
-            session.read()
-
-        client.refresh_features()
-        assert client.features.pin_protection is pin
-        assert client.features.passphrase_protection is passphrase
-        session.lock()
-        session.close()
+    with test_ctx:
+        test_ctx.use_pin_sequence([PIN4])
+        test_ctx.client.ensure_unlocked()
+        assert test_ctx.features.pin_protection is pin
+        assert test_ctx.features.passphrase_protection is passphrase
+        test_ctx.lock()
 
 
 def test_initialize(client: Client):
@@ -501,3 +493,23 @@ def test_unlocked(client: Client):
     with client:
         client.set_expected_responses([messages.Address])
         _get_test_address(session)
+
+
+@pytest.mark.parametrize("passphrase", (True, False))
+def test_ensure_unlocked(test_ctx: Client, passphrase: bool):
+    assert test_ctx.features.pin_protection is True
+
+    with test_ctx:
+        test_ctx.use_pin_sequence([PIN4])
+        session = test_ctx.get_session()
+        device.apply_settings(session, use_passphrase=passphrase)
+
+    _assert_protection(test_ctx, passphrase=passphrase)
+
+    test_ctx.lock()
+    with test_ctx:
+        test_ctx.use_pin_sequence([PIN4])
+
+        assert test_ctx.features.unlocked is False
+        test_ctx.client.ensure_unlocked()
+        assert test_ctx.features.unlocked is True

--- a/tests/device_tests/test_sdcard.py
+++ b/tests/device_tests/test_sdcard.py
@@ -246,7 +246,7 @@ def test_sd_protect_lock(session: Session, lock_func: "t.Callable[[Session], Non
         client.set_expected_responses(
             [
                 messages.ButtonRequest(code=B.PinEntry),
-                messages.PublicKey,
+                messages.Success,
                 messages.Features,
             ]
         )


### PR DESCRIPTION
* if an invalid base64 string is set in TREZOR_SESSION_ID, trezorctl would crash
* when resuming a THP session, pairing.finish() was not called, leading to an invalid state. ~~The current fix is worse than I'd like, explicitly pinging the client instance to do whatever the client instance does normally, but I don't have a better idea.~~
* change `@get_session(passphrase=False)` to mean "do not prompt for passphrase" as opposed to "force use standard wallet". That matches the actual usages in code.
* ~~try resuming session first in `get_session` before (indirectly) invoking ensure_unlocked, because the session-to-be-resumed may already have been unlocked. Also, there is no situation where we want to force an empty passphrase, so "prompt_passphrase=False" should be satisfied by a resumed session, not force derivation of a standard wallet.~~
* try resuming session first in `get_session`, so that if we do have
  a session to resume, prompt_passphrase=False will use it without
  (re)deriving a standard wallet. (There is no situation where we explicitly
  *need* a standard wallet for something, what we actually have are situations
  where we *don't need* to ask for passphrase.)
* take advantage of improved ensure_unlocked() and remove trezorctl-specific
  reuse of standard session (which is now no longer auto-created).

see commit comments for details

<!--
For external contributors:
- Please open an issue before submitting a PR so we can discuss whether we want to proceed with it.

For core developers:
1. Initial PR setup
- Assign yourself to the PR.
- Add it to the "Firmware" project
  - Set Priority (match issue priority if it exists)
  - Set Team
  - Set Sprint (target release)

2. Development status
- Draft PRs: Set status to "In Progress"
- Final PRs: Set status to "Needs Review"

3. Post-merge status
- Testable: Set status to "Needs QA" and add a `Notes for QA` section with clear instructions on how to test the functionality.
- Not Testable: Set status to "Done (no QA)"
-->
