### PR TITLE
fix(core/eckhart): don't close device menu on `GetFeatures`

### DIFF
--- a/core/.changelog.d/6211.fixed
+++ b/core/.changelog.d/6211.fixed
@@ -1,0 +1,1 @@
+[T3W1] Fix menu closing after change of settings.

--- a/core/src/trezor/wire/message_handler.py
+++ b/core/src/trezor/wire/message_handler.py
@@ -2,7 +2,7 @@ from typing import TYPE_CHECKING
 
 from storage.cache_common import InvalidSessionError
 from trezor import log, loop, protobuf, utils, workflow
-from trezor.enums import FailureType
+from trezor.enums import FailureType, MessageType
 from trezor.messages import Failure
 
 from .context import UnexpectedMessageException, with_context
@@ -179,7 +179,11 @@ async def handle_single_message(ctx: Context, msg: Message) -> bool:
     return msg.type in AVOID_RESTARTING_FOR
 
 
-AVOID_RESTARTING_FOR: Container[int] = ()
+if utils.UI_LAYOUT == "ECKHART":
+    # Don't close device menu when `GetFeatures` is received.
+    AVOID_RESTARTING_FOR: Container[int] = (MessageType.GetFeatures,)
+else:
+    AVOID_RESTARTING_FOR: Container[int] = ()
 
 
 def failure(exc: BaseException) -> Failure:

--- a/tests/device_tests/test_basic.py
+++ b/tests/device_tests/test_basic.py
@@ -21,6 +21,8 @@ from trezorlib.client import get_client
 from trezorlib.debuglink import DebugSession as Session
 from trezorlib.debuglink import TrezorTestContext as Client
 
+from ..click_tests.device_menu.common import open_device_menu
+
 
 def test_capabilities(session: Session):
     assert (messages.Capability.Translations in session.features.capabilities) == (
@@ -87,3 +89,15 @@ def test_desync_v1(client: Client):
     # Creating a new client fails without skipping stale responses
     # (see https://github.com/trezor/trezor-firmware/issues/6859)
     get_client(client.app, client.transport).ping("reconnect")
+
+
+@pytest.mark.models("eckhart")
+def test_get_features_avoids_restart(session: Session):
+    debug = session.debug
+    assert "Homescreen" == debug.read_layout().main_component()
+    open_device_menu(debug)
+    assert "DeviceMenuScreen" == debug.read_layout().main_component()
+
+    # GetFeatures doesn't restart MicroPython event loop - device menu is still open.
+    session.refresh_features()
+    assert "DeviceMenuScreen" == debug.read_layout().main_component()


### PR DESCRIPTION
Requires #7175.

Fixes #6211.

## Notes to QA:

 - connect to Suite via BLE
 - use on-device menu to change the label, or any other notification-causing flow:
```
homescreen/device_menu.py
223-    utils.ensure(ble.is_connected())
224-
225:    utils.notify_send(utils.NOTIFY_DISCONNECT)
--
428-
429-    await set_brightness(SetBrightness())
430:    utils.notify_send(utils.NOTIFY_SETTING_CHANGE)
--
439-    io.touch.touch_wakeup_set_enabled(enable)
440-    storage_device.set_tap_to_wake(enable)
441:    utils.notify_send(utils.NOTIFY_SETTING_CHANGE)
--
450-    io.haptic.haptic_set_enabled(enable)
451-    storage_device.set_haptic_feedback(enable)
452:    utils.notify_send(utils.NOTIFY_SETTING_CHANGE)
--
461-    io.rgb_led.rgb_led_set_enabled(enable)
462-    storage_device.set_rgb_led(enable)
463:    utils.notify_send(utils.NOTIFY_SETTING_CHANGE)
```
 - the device should not go back to the homescreen

https://github.com/user-attachments/assets/0a47979a-c58e-410b-a582-bf06c98be5fd

### TODO:

 - [x] add a specific device test (to run on HW CI)