### PR TITLE
chore(core):  optimize size of build artifacts

### DIFF
--- a/core/embed/.cargo/config.toml
+++ b/core/embed/.cargo/config.toml
@@ -3,7 +3,7 @@ target-dir = "../build-xtask"
 #rustc-wrapper = "sccache"
 
 [alias]
-xtask = "run -p xtask --"
+xtask = "run --profile xtask -p xtask --"
 
 [target.x86_64-unknown-linux-gnu]
 

--- a/core/embed/Cargo.toml
+++ b/core/embed/Cargo.toml
@@ -53,6 +53,24 @@ opt-level = 3
 split-debuginfo = "off"
 debug = 2
 
+# Optimized profile for build related binaries
+[profile.release.build-override]
+debug = false
+strip = true
+opt-level = "s"
+
+# Optimized profile for build related binaries
+[profile.dev.build-override]
+debug = false
+strip = true
+opt-level = "s"
+
+# Optimized profile for xtask binary
+[profile.xtask]
+inherits = "dev"
+debug = false
+strip = true
+
 [workspace.dependencies]
 cfg-if = "1.0"
 cty = "0.2.2"

--- a/core/embed/models/build.rs
+++ b/core/embed/models/build.rs
@@ -53,8 +53,7 @@ fn main() -> Result<()> {
             "-fsingle-precision-constant",
             "-fdata-sections",
             "-ffunction-sections",
-            "-g3",
-            "-ggdb",
+            "-g",
         ]);
 
         if cfg!(feature = "emulator") {


### PR DESCRIPTION
This PR optimizes the size of build artifacts and significantly reduces the overall size of `build-xtask` after several builds.

The size of the `build-xtask` folder after running `xtask build firmware -m t3w1` was reduced from 4.1 GB to 800 MB.

There are three measures in place:

1) build-related binaries (built from `build.rs`) are now built without debug information *(-2.5GB)*
3) C files are built with just `-g` instead of the original `-g3` and `-ggdb` *(-1.4GB)*
2) `xtask` binaries are built without debug information *(-300MB)*



