### PR TITLE
refactor(core): avoid debug build warnings without `--dbg-console`

### DIFF
--- a/core/embed/rust/librust.h
+++ b/core/embed/rust/librust.h
@@ -12,11 +12,12 @@ extern mp_obj_module_t mp_module_trezorui_api;
 extern mp_obj_module_t mp_module_trezortranslate;
 extern mp_obj_module_t mp_module_trezorble;
 
-#if !PYOPT
-mp_obj_t ui_debug_layout_type();
 #ifdef USE_DBG_CONSOLE
 extern mp_obj_module_t mp_module_trezorlog;
 #endif
+
+#if !PYOPT
+mp_obj_t ui_debug_layout_type();
 
 #ifdef TREZOR_EMULATOR
 extern mp_obj_module_t mp_module_coveragedata;

--- a/core/embed/rust/librust.h
+++ b/core/embed/rust/librust.h
@@ -14,7 +14,9 @@ extern mp_obj_module_t mp_module_trezorble;
 
 #if !PYOPT
 mp_obj_t ui_debug_layout_type();
+#ifdef USE_DBG_CONSOLE
 extern mp_obj_module_t mp_module_trezorlog;
+#endif
 
 #ifdef TREZOR_EMULATOR
 extern mp_obj_module_t mp_module_coveragedata;

--- a/core/embed/rust/src/micropython/logging.rs
+++ b/core/embed/rust/src/micropython/logging.rs
@@ -1,6 +1,5 @@
 use crate::micropython::{map::Map, module::Module, obj::Obj, qstr::Qstr};
 
-#[cfg(feature = "dbg_console")]
 use crate::{
     error::Error,
     micropython::{buffer::StrBuffer, util},
@@ -8,7 +7,6 @@ use crate::{
     util::logger::init_rust_logging,
 };
 
-#[cfg(feature = "dbg_console")]
 fn _log(level: LogLevel, args: &[Obj], kwargs: &Map) -> Result<Obj, Error> {
     let [module, fmt, fmt_args @ ..] = args else {
         return Err(Error::TypeError);
@@ -33,59 +31,44 @@ fn _log(level: LogLevel, args: &[Obj], kwargs: &Map) -> Result<Obj, Error> {
 }
 
 extern "C" fn py_debug(n_args: usize, args: *const Obj, kwargs: *mut Map) -> Obj {
-    #[cfg(feature = "dbg_console")]
-    {
-        let block = |args: &[Obj], kwargs: &Map| _log(LogLevel::Debug, args, kwargs);
-        unsafe {
-            util::try_with_args_and_kwargs(n_args, args, kwargs, block);
-        }
+    let block = |args: &[Obj], kwargs: &Map| _log(LogLevel::Debug, args, kwargs);
+    unsafe {
+        util::try_with_args_and_kwargs(n_args, args, kwargs, block);
     }
     Obj::const_none()
 }
 
 extern "C" fn py_info(n_args: usize, args: *const Obj, kwargs: *mut Map) -> Obj {
-    #[cfg(feature = "dbg_console")]
-    {
-        let block = |args: &[Obj], kwargs: &Map| _log(LogLevel::Info, args, kwargs);
-        unsafe {
-            util::try_with_args_and_kwargs(n_args, args, kwargs, block);
-        }
+    let block = |args: &[Obj], kwargs: &Map| _log(LogLevel::Info, args, kwargs);
+    unsafe {
+        util::try_with_args_and_kwargs(n_args, args, kwargs, block);
     }
     Obj::const_none()
 }
 
 extern "C" fn py_warning(n_args: usize, args: *const Obj, kwargs: *mut Map) -> Obj {
-    #[cfg(feature = "dbg_console")]
-    {
-        let block = |args: &[Obj], kwargs: &Map| _log(LogLevel::Warn, args, kwargs);
-        unsafe {
-            util::try_with_args_and_kwargs(n_args, args, kwargs, block);
-        }
+    let block = |args: &[Obj], kwargs: &Map| _log(LogLevel::Warn, args, kwargs);
+    unsafe {
+        util::try_with_args_and_kwargs(n_args, args, kwargs, block);
     }
     Obj::const_none()
 }
 
 extern "C" fn py_error(n_args: usize, args: *const Obj, kwargs: *mut Map) -> Obj {
-    #[cfg(feature = "dbg_console")]
-    {
-        let block = |args: &[Obj], kwargs: &Map| _log(LogLevel::Error, args, kwargs);
-        unsafe {
-            util::try_with_args_and_kwargs(n_args, args, kwargs, block);
-        }
+    let block = |args: &[Obj], kwargs: &Map| _log(LogLevel::Error, args, kwargs);
+    unsafe {
+        util::try_with_args_and_kwargs(n_args, args, kwargs, block);
     }
     Obj::const_none()
 }
 
 extern "C" fn py_init(level: Obj) -> Obj {
-    #[cfg(feature = "dbg_console")]
-    {
-        let block = || {
-            init_rust_logging(level.try_into()?);
-            Ok(())
-        };
-        unsafe {
-            util::try_or_raise(block);
-        }
+    let block = || {
+        init_rust_logging(level.try_into()?);
+        Ok(())
+    };
+    unsafe {
+        util::try_or_raise(block);
     }
     Obj::const_none()
 }

--- a/core/embed/rust/src/micropython/mod.rs
+++ b/core/embed/rust/src/micropython/mod.rs
@@ -19,7 +19,7 @@ pub mod simple_type;
 pub mod typ;
 pub mod util;
 
-#[cfg(all(feature = "debug", feature = "dbg_console"))]
+#[cfg(feature = "dbg_console")]
 pub mod logging;
 
 #[cfg(test)]

--- a/core/embed/rust/src/micropython/mod.rs
+++ b/core/embed/rust/src/micropython/mod.rs
@@ -19,7 +19,7 @@ pub mod simple_type;
 pub mod typ;
 pub mod util;
 
-#[cfg(feature = "debug")]
+#[cfg(all(feature = "debug", feature = "dbg_console"))]
 pub mod logging;
 
 #[cfg(test)]

--- a/core/embed/rust/src/micropython/typ.rs
+++ b/core/embed/rust/src/micropython/typ.rs
@@ -25,7 +25,7 @@ impl Type {
         unsafe { Obj::from_ptr(self as *const _ as *mut _) }
     }
 
-    #[cfg(feature = "debug")]
+    #[cfg(any(feature = "debug", feature = "dbg_console"))]
     pub fn name(&self) -> &'static str {
         use super::qstr::Qstr;
 

--- a/core/embed/upymod/rustmods.c
+++ b/core/embed/upymod/rustmods.c
@@ -40,6 +40,6 @@ MP_REGISTER_MODULE(MP_QSTR_trezorble, mp_module_trezorble);
 MP_REGISTER_MODULE(MP_QSTR_coveragedata, mp_module_coveragedata);
 #endif
 
-#if !PYOPT && defined(USE_DBG_CONSOLE)
+#if defined(USE_DBG_CONSOLE)
 MP_REGISTER_MODULE(MP_QSTR_trezorlog, mp_module_trezorlog);
 #endif

--- a/core/embed/upymod/rustmods.c
+++ b/core/embed/upymod/rustmods.c
@@ -40,6 +40,6 @@ MP_REGISTER_MODULE(MP_QSTR_trezorble, mp_module_trezorble);
 MP_REGISTER_MODULE(MP_QSTR_coveragedata, mp_module_coveragedata);
 #endif
 
-#if !PYOPT
+#if !PYOPT && defined(USE_DBG_CONSOLE)
 MP_REGISTER_MODULE(MP_QSTR_trezorlog, mp_module_trezorlog);
 #endif

--- a/core/src/trezor/log.py
+++ b/core/src/trezor/log.py
@@ -12,7 +12,7 @@ def _no_op(name: str, msg: str, *args: Any, iface: WireInterface | None = None) 
     return None
 
 
-if __debug__ and utils.USE_DBG_CONSOLE:
+if utils.USE_DBG_CONSOLE:
     from trezorlog import debug, error, info, init, warning  # noqa: F401
 
     _levels = [debug, info, warning, error]
@@ -20,7 +20,6 @@ if __debug__ and utils.USE_DBG_CONSOLE:
     debug, info, warning, error = [_no_op] * _min_level + _levels[_min_level:]
     init(_min_level)  # initialize rust logging connector
 else:
-    # logging is disabled in non-debug builds
     debug = warning = info = error = _no_op
 
 

--- a/core/src/trezor/log.py
+++ b/core/src/trezor/log.py
@@ -1,6 +1,8 @@
 import sys
 from typing import TYPE_CHECKING
 
+from . import utils
+
 if TYPE_CHECKING:
     from trezorio import WireInterface
     from typing import Any
@@ -10,7 +12,7 @@ def _no_op(name: str, msg: str, *args: Any, iface: WireInterface | None = None) 
     return None
 
 
-if __debug__:
+if __debug__ and utils.USE_DBG_CONSOLE:
     from trezorlog import debug, error, info, init, warning  # noqa: F401
 
     _levels = [debug, info, warning, error]


### PR DESCRIPTION
```
warning: unused variable: `n_args`
  --> rust/src/micropython/logging.rs:35:24
   |
35 | extern "C" fn py_debug(n_args: usize, args: *const Obj, kwargs: *mut Map) -> Obj {
   |                        ^^^^^^ help: if this is intentional, prefix it with an underscore: `_n_args`
   |
   = note: `#[warn(unused_variables)]` (part of `#[warn(unused)]`) on by default

warning: unused variable: `args`
  --> rust/src/micropython/logging.rs:35:39
   |
35 | extern "C" fn py_debug(n_args: usize, args: *const Obj, kwargs: *mut Map) -> Obj {
   |                                       ^^^^ help: if this is intentional, prefix it with an underscore: `_args`

warning: unused variable: `kwargs`
  --> rust/src/micropython/logging.rs:35:57
   |
35 | extern "C" fn py_debug(n_args: usize, args: *const Obj, kwargs: *mut Map) -> Obj {
   |                                                         ^^^^^^ help: if this is intentional, prefix it with an underscore: `_kwargs`

warning: unused variable: `n_args`
  --> rust/src/micropython/logging.rs:46:23
   |
46 | extern "C" fn py_info(n_args: usize, args: *const Obj, kwargs: *mut Map) -> Obj {
   |                       ^^^^^^ help: if this is intentional, prefix it with an underscore: `_n_args`

warning: unused variable: `args`
  --> rust/src/micropython/logging.rs:46:38
   |
46 | extern "C" fn py_info(n_args: usize, args: *const Obj, kwargs: *mut Map) -> Obj {
   |                                      ^^^^ help: if this is intentional, prefix it with an underscore: `_args`

warning: unused variable: `kwargs`
  --> rust/src/micropython/logging.rs:46:56
   |
46 | extern "C" fn py_info(n_args: usize, args: *const Obj, kwargs: *mut Map) -> Obj {
   |                                                        ^^^^^^ help: if this is intentional, prefix it with an underscore: `_kwargs`

warning: unused variable: `n_args`
  --> rust/src/micropython/logging.rs:57:26
   |
57 | extern "C" fn py_warning(n_args: usize, args: *const Obj, kwargs: *mut Map) -> Obj {
   |                          ^^^^^^ help: if this is intentional, prefix it with an underscore: `_n_args`

warning: unused variable: `args`
  --> rust/src/micropython/logging.rs:57:41
   |
57 | extern "C" fn py_warning(n_args: usize, args: *const Obj, kwargs: *mut Map) -> Obj {
   |                                         ^^^^ help: if this is intentional, prefix it with an underscore: `_args`

warning: unused variable: `kwargs`
  --> rust/src/micropython/logging.rs:57:59
   |
57 | extern "C" fn py_warning(n_args: usize, args: *const Obj, kwargs: *mut Map) -> Obj {
   |                                                           ^^^^^^ help: if this is intentional, prefix it with an underscore: `_kwargs`

warning: unused variable: `n_args`
  --> rust/src/micropython/logging.rs:68:24
   |
68 | extern "C" fn py_error(n_args: usize, args: *const Obj, kwargs: *mut Map) -> Obj {
   |                        ^^^^^^ help: if this is intentional, prefix it with an underscore: `_n_args`

warning: unused variable: `args`
  --> rust/src/micropython/logging.rs:68:39
   |
68 | extern "C" fn py_error(n_args: usize, args: *const Obj, kwargs: *mut Map) -> Obj {
   |                                       ^^^^ help: if this is intentional, prefix it with an underscore: `_args`

warning: unused variable: `kwargs`
  --> rust/src/micropython/logging.rs:68:57
   |
68 | extern "C" fn py_error(n_args: usize, args: *const Obj, kwargs: *mut Map) -> Obj {
   |                                                         ^^^^^^ help: if this is intentional, prefix it with an underscore: `_kwargs`
```