### PR TITLE
core(ci): added run-name for hardware tests workflow

### DIFF
--- a/.github/workflows/core-hw.yml
+++ b/.github/workflows/core-hw.yml
@@ -1,4 +1,5 @@
 name: Hardware tests
+run-name: Hardware tests on ${{ inputs.models_json != '' && join(fromJSON(inputs.models_json), ', ') || 'all models' }}
 
 on:
   schedule:


### PR DESCRIPTION
makes it obvious which devices are part of a given run, see for example [here](https://github.com/trezor/trezor-firmware/actions/runs/28171071008)

<img width="330" height="74" alt="image" src="https://github.com/user-attachments/assets/a2db3a88-4d9d-4485-a167-8a2206857bee" />