### PR TITLE
test(core): don't run FIDO2 tests on BTC-only builds

### DIFF
--- a/core/tests/test_apps.webauthn.credential.py
+++ b/core/tests/test_apps.webauthn.credential.py
@@ -5,11 +5,17 @@ import storage
 import storage.device
 from trezor.crypto.hashlib import sha256
 
-from apps.common import mnemonic
-from apps.webauthn.credential import _NAME_MAX_LENGTH, Fido2Credential, U2fCredential
-from apps.webauthn.fido2 import _distinguishable_cred_list
+if not utils.BITCOIN_ONLY:
+    from apps.common import mnemonic
+    from apps.webauthn.credential import (
+        _NAME_MAX_LENGTH,
+        Fido2Credential,
+        U2fCredential,
+    )
+    from apps.webauthn.fido2 import _distinguishable_cred_list
 
 
+@unittest.skipUnless(not utils.BITCOIN_ONLY, "fido2")
 class TestCredential(unittest.TestCase):
     def test_fido2_credential_decode(self):
         mnemonic_secret = b"all all all all all all all all all all all all"


### PR DESCRIPTION
Otherwise, it fails on CI following https://github.com/trezor/trezor-firmware/pull/7155:
```
Traceback (most recent call last):
  File "test_apps.webauthn.credential.py", line 10, in <module>
  File "../src/apps/webauthn/fido2.py", line 1, in <module>
ImportError: no module named 'uctypes'
```
https://github.com/trezor/trezor-firmware/actions/runs/28207562855/job/83561571439