### PR TITLE
Fix Eckhart device menu refresh

### DIFF
--- a/core/.changelog.d/7202.fixed
+++ b/core/.changelog.d/7202.fixed
@@ -1,0 +1,1 @@
+[T3W1] Fix device menu refresh.

--- a/core/embed/rust/librust_qstr.h
+++ b/core/embed/rust/librust_qstr.h
@@ -25,6 +25,7 @@ static void _librust_qstrs(void) {
   MP_QSTR_CANCELLED;
   MP_QSTR_CONFIRMED;
   MP_QSTR_CheckBackup;
+  MP_QSTR_Close;
   MP_QSTR_DIM;
   MP_QSTR_DONE;
   MP_QSTR_DeviceMenuResult;

--- a/core/embed/rust/librust_qstr.h
+++ b/core/embed/rust/librust_qstr.h
@@ -392,6 +392,7 @@ static void _librust_qstrs(void) {
   MP_QSTR_info_button;
   MP_QSTR_init;
   MP_QSTR_init_submenu_idx;
+  MP_QSTR_init_submenu_offset;
   MP_QSTR_inputs__back;
   MP_QSTR_inputs__cancel;
   MP_QSTR_inputs__delete;

--- a/core/embed/rust/src/micropython/obj.rs
+++ b/core/embed/rust/src/micropython/obj.rs
@@ -382,6 +382,16 @@ impl TryFrom<Obj> for u16 {
     }
 }
 
+impl TryFrom<Obj> for i16 {
+    type Error = Error;
+
+    fn try_from(obj: Obj) -> Result<Self, Self::Error> {
+        let val = i32::try_from(obj)?;
+        let this = Self::try_from(val)?;
+        Ok(this)
+    }
+}
+
 impl TryFrom<Obj> for u32 {
     type Error = Error;
 

--- a/core/embed/rust/src/ui/api/firmware_micropython.rs
+++ b/core/embed/rust/src/ui/api/firmware_micropython.rs
@@ -913,6 +913,7 @@ extern "C" fn new_show_device_menu(n_args: usize, args: *const Obj, kwargs: *mut
         let init_submenu_idx: Option<u8> = kwargs
             .get(Qstr::MP_QSTR_init_submenu_idx)?
             .try_into_option()?;
+        let init_submenu_offset: i16 = kwargs.get(Qstr::MP_QSTR_init_submenu_offset)?.try_into()?;
         let backup_failed: bool = kwargs.get(Qstr::MP_QSTR_backup_failed)?.try_into()?;
         let backup_needed: bool = kwargs.get(Qstr::MP_QSTR_backup_needed)?.try_into()?;
         let ble_enabled: bool = kwargs.get(Qstr::MP_QSTR_ble_enabled)?.try_into()?;
@@ -963,6 +964,7 @@ extern "C" fn new_show_device_menu(n_args: usize, args: *const Obj, kwargs: *mut
             .try_into_option()?;
         let layout = ModelUI::show_device_menu(
             init_submenu_idx,
+            init_submenu_offset,
             backup_failed,
             backup_needed,
             ble_enabled,
@@ -1971,6 +1973,7 @@ pub static mp_module_trezorui_api: Module = obj_module! {
     /// def show_device_menu(
     ///     *,
     ///     init_submenu_idx: int | None,
+    ///     init_submenu_offset: int,
     ///     backup_failed: bool,
     ///     backup_needed: bool,
     ///     ble_enabled: bool,
@@ -1987,8 +1990,8 @@ pub static mp_module_trezorui_api: Module = obj_module! {
     ///     led_enabled: bool | None,
     ///     about_items: Sequence[tuple[str | None, StrOrBytes | None, bool | None]],
     ///     production_year: str | None,
-    /// ) -> LayoutContext[tuple[str, int | None, int]]:
-    ///     """Show the device menu. Result is a tuple (action, action_arg, parent_menu_id)."""
+    /// ) -> LayoutContext[tuple[str, int | None, int, int]]:
+    ///     """Show the device menu. Result is a tuple (action, action_arg, next_menu_id, next_menu_offset)."""
     Qstr::MP_QSTR_show_device_menu => obj_fn_kw!(0, new_show_device_menu).as_obj(),
 
     /// def show_pairing_device_name(

--- a/core/embed/rust/src/ui/api/firmware_micropython.rs
+++ b/core/embed/rust/src/ui/api/firmware_micropython.rs
@@ -1987,8 +1987,8 @@ pub static mp_module_trezorui_api: Module = obj_module! {
     ///     led_enabled: bool | None,
     ///     about_items: Sequence[tuple[str | None, StrOrBytes | None, bool | None]],
     ///     production_year: str | None,
-    /// ) -> LayoutContext[UiResult | tuple[int, int | None, int]]:
-    ///     """Show the device menu. Result is either CANCELLED or a tuple (action, action_arg, parent_menu_id)."""
+    /// ) -> LayoutContext[tuple[str, int | None, int]]:
+    ///     """Show the device menu. Result is a tuple (action, action_arg, parent_menu_id)."""
     Qstr::MP_QSTR_show_device_menu => obj_fn_kw!(0, new_show_device_menu).as_obj(),
 
     /// def show_pairing_device_name(
@@ -2212,28 +2212,29 @@ pub static mp_module_trezorui_api: Module = obj_module! {
 
     /// class DeviceMenuResult:
     ///     """Result of a device menu operation."""
-    ///     ReviewFailedBackup: ClassVar[int]
-    ///     DisconnectDevice: ClassVar[int]
-    ///     PairDevice: ClassVar[int]
-    ///     UnpairDevice: ClassVar[int]
-    ///     UnpairAllDevices: ClassVar[int]
-    ///     ToggleBluetooth: ClassVar[int]
-    ///     SetOrChangePin: ClassVar[int]
-    ///     RemovePin: ClassVar[int]
-    ///     SetAutoLockBattery: ClassVar[int]
-    ///     SetAutoLockUSB: ClassVar[int]
-    ///     SetOrChangeWipeCode: ClassVar[int]
-    ///     RemoveWipeCode: ClassVar[int]
-    ///     CheckBackup: ClassVar[int]
-    ///     SetDeviceName: ClassVar[int]
-    ///     SetBrightness: ClassVar[int]
-    ///     ToggleTapToWake: ClassVar[int]
-    ///     ToggleHaptics: ClassVar[int]
-    ///     ToggleLed: ClassVar[int]
-    ///     WipeDevice: ClassVar[int]
-    ///     Reboot: ClassVar[int]
-    ///     RebootToBootloader: ClassVar[int]
-    ///     TurnOff: ClassVar[int]
-    ///     RefreshMenu: ClassVar[int]
+    ///     Close: ClassVar[str]
+    ///     ReviewFailedBackup: ClassVar[str]
+    ///     DisconnectDevice: ClassVar[str]
+    ///     PairDevice: ClassVar[str]
+    ///     UnpairDevice: ClassVar[str]
+    ///     UnpairAllDevices: ClassVar[str]
+    ///     ToggleBluetooth: ClassVar[str]
+    ///     SetOrChangePin: ClassVar[str]
+    ///     RemovePin: ClassVar[str]
+    ///     SetAutoLockBattery: ClassVar[str]
+    ///     SetAutoLockUSB: ClassVar[str]
+    ///     SetOrChangeWipeCode: ClassVar[str]
+    ///     RemoveWipeCode: ClassVar[str]
+    ///     CheckBackup: ClassVar[str]
+    ///     SetDeviceName: ClassVar[str]
+    ///     SetBrightness: ClassVar[str]
+    ///     ToggleTapToWake: ClassVar[str]
+    ///     ToggleHaptics: ClassVar[str]
+    ///     ToggleLed: ClassVar[str]
+    ///     WipeDevice: ClassVar[str]
+    ///     Reboot: ClassVar[str]
+    ///     RebootToBootloader: ClassVar[str]
+    ///     TurnOff: ClassVar[str]
+    ///     RefreshMenu: ClassVar[str]
     Qstr::MP_QSTR_DeviceMenuResult => DEVICE_MENU_RESULT.as_obj(),
 };

--- a/core/embed/rust/src/ui/layout/device_menu_result.rs
+++ b/core/embed/rust/src/ui/layout/device_menu_result.rs
@@ -5,19 +5,16 @@ use crate::{
     },
 };
 
-use num_traits::ToPrimitive;
-
-#[repr(u8)]
-#[derive(Copy, Clone, ToPrimitive)]
+#[derive(Copy, Clone)]
 pub enum DeviceMenuMsg {
-    Close = 0,
+    Close,
     // Root menu
     ReviewFailedBackup,
 
     // "Pair & Connect"
     PairDevice,       // pair a new device
     DisconnectDevice, // disconnect a device
-    UnpairDevice,     // unpair a device, its index is in result_arg
+    UnpairDevice(u8), // unpair a device
     UnpairAllDevices,
 
     // Power
@@ -46,14 +43,45 @@ pub enum DeviceMenuMsg {
     WipeDevice,
 
     // Misc
-    RefreshMenu, // menu id is in result_arg
+    RefreshMenu,
 }
 
 impl DeviceMenuMsg {
-    pub fn as_obj(&self) -> Obj {
-        assert!(!matches!(self, DeviceMenuMsg::Close));
-        let n = unwrap!(self.to_u8());
-        n.into()
+    pub fn id_to_obj(&self) -> Obj {
+        match self {
+            Self::Close => Qstr::MP_QSTR_Close,
+            Self::ReviewFailedBackup => Qstr::MP_QSTR_ReviewFailedBackup,
+            Self::PairDevice => Qstr::MP_QSTR_PairDevice,
+            Self::DisconnectDevice => Qstr::MP_QSTR_DisconnectDevice,
+            Self::UnpairDevice(_) => Qstr::MP_QSTR_UnpairDevice,
+            Self::UnpairAllDevices => Qstr::MP_QSTR_UnpairAllDevices,
+            Self::TurnOff => Qstr::MP_QSTR_TurnOff,
+            Self::Reboot => Qstr::MP_QSTR_Reboot,
+            Self::RebootToBootloader => Qstr::MP_QSTR_RebootToBootloader,
+            Self::ToggleBluetooth => Qstr::MP_QSTR_ToggleBluetooth,
+            Self::SetOrChangePin => Qstr::MP_QSTR_SetOrChangePin,
+            Self::RemovePin => Qstr::MP_QSTR_RemovePin,
+            Self::SetAutoLockBattery => Qstr::MP_QSTR_SetAutoLockBattery,
+            Self::SetAutoLockUSB => Qstr::MP_QSTR_SetAutoLockUSB,
+            Self::SetOrChangeWipeCode => Qstr::MP_QSTR_SetOrChangeWipeCode,
+            Self::RemoveWipeCode => Qstr::MP_QSTR_RemoveWipeCode,
+            Self::CheckBackup => Qstr::MP_QSTR_CheckBackup,
+            Self::SetDeviceName => Qstr::MP_QSTR_SetDeviceName,
+            Self::SetBrightness => Qstr::MP_QSTR_SetBrightness,
+            Self::ToggleTapToWake => Qstr::MP_QSTR_ToggleTapToWake,
+            Self::ToggleHaptics => Qstr::MP_QSTR_ToggleHaptics,
+            Self::ToggleLed => Qstr::MP_QSTR_ToggleLed,
+            Self::WipeDevice => Qstr::MP_QSTR_WipeDevice,
+            Self::RefreshMenu => Qstr::MP_QSTR_RefreshMenu,
+        }
+        .to_obj()
+    }
+
+    pub fn args_to_obj(&self) -> Obj {
+        match self {
+            Self::UnpairDevice(id) => (*id).into(),
+            _ => Obj::const_none(),
+        }
     }
 }
 
@@ -71,33 +99,34 @@ unsafe extern "C" fn device_menu_result_attr(_self_in: Obj, attr: ffi::qstr, des
             return Err(Error::TypeError);
         }
         let attr = Qstr::from_u16(attr as _);
-        let value = match attr {
-            Qstr::MP_QSTR_ReviewFailedBackup => DeviceMenuMsg::ReviewFailedBackup.as_obj(),
-            Qstr::MP_QSTR_PairDevice => DeviceMenuMsg::PairDevice.as_obj(),
-            Qstr::MP_QSTR_DisconnectDevice => DeviceMenuMsg::DisconnectDevice.as_obj(),
-            Qstr::MP_QSTR_UnpairDevice => DeviceMenuMsg::UnpairDevice.as_obj(),
-            Qstr::MP_QSTR_UnpairAllDevices => DeviceMenuMsg::UnpairAllDevices.as_obj(),
-            Qstr::MP_QSTR_ToggleBluetooth => DeviceMenuMsg::ToggleBluetooth.as_obj(),
-            Qstr::MP_QSTR_SetOrChangePin => DeviceMenuMsg::SetOrChangePin.as_obj(),
-            Qstr::MP_QSTR_RemovePin => DeviceMenuMsg::RemovePin.as_obj(),
-            Qstr::MP_QSTR_SetAutoLockBattery => DeviceMenuMsg::SetAutoLockBattery.as_obj(),
-            Qstr::MP_QSTR_SetAutoLockUSB => DeviceMenuMsg::SetAutoLockUSB.as_obj(),
-            Qstr::MP_QSTR_SetOrChangeWipeCode => DeviceMenuMsg::SetOrChangeWipeCode.as_obj(),
-            Qstr::MP_QSTR_RemoveWipeCode => DeviceMenuMsg::RemoveWipeCode.as_obj(),
-            Qstr::MP_QSTR_CheckBackup => DeviceMenuMsg::CheckBackup.as_obj(),
-            Qstr::MP_QSTR_SetDeviceName => DeviceMenuMsg::SetDeviceName.as_obj(),
-            Qstr::MP_QSTR_SetBrightness => DeviceMenuMsg::SetBrightness.as_obj(),
-            Qstr::MP_QSTR_ToggleTapToWake => DeviceMenuMsg::ToggleTapToWake.as_obj(),
-            Qstr::MP_QSTR_ToggleHaptics => DeviceMenuMsg::ToggleHaptics.as_obj(),
-            Qstr::MP_QSTR_ToggleLed => DeviceMenuMsg::ToggleLed.as_obj(),
-            Qstr::MP_QSTR_WipeDevice => DeviceMenuMsg::WipeDevice.as_obj(),
-            Qstr::MP_QSTR_TurnOff => DeviceMenuMsg::TurnOff.as_obj(),
-            Qstr::MP_QSTR_Reboot => DeviceMenuMsg::Reboot.as_obj(),
-            Qstr::MP_QSTR_RebootToBootloader => DeviceMenuMsg::RebootToBootloader.as_obj(),
-            Qstr::MP_QSTR_RefreshMenu => DeviceMenuMsg::RefreshMenu.as_obj(),
+        let msg = match attr {
+            Qstr::MP_QSTR_Close => Qstr::MP_QSTR_Close,
+            Qstr::MP_QSTR_ReviewFailedBackup => Qstr::MP_QSTR_ReviewFailedBackup,
+            Qstr::MP_QSTR_PairDevice => Qstr::MP_QSTR_PairDevice,
+            Qstr::MP_QSTR_DisconnectDevice => Qstr::MP_QSTR_DisconnectDevice,
+            Qstr::MP_QSTR_UnpairDevice => Qstr::MP_QSTR_UnpairDevice,
+            Qstr::MP_QSTR_UnpairAllDevices => Qstr::MP_QSTR_UnpairAllDevices,
+            Qstr::MP_QSTR_ToggleBluetooth => Qstr::MP_QSTR_ToggleBluetooth,
+            Qstr::MP_QSTR_SetOrChangePin => Qstr::MP_QSTR_SetOrChangePin,
+            Qstr::MP_QSTR_RemovePin => Qstr::MP_QSTR_RemovePin,
+            Qstr::MP_QSTR_SetAutoLockBattery => Qstr::MP_QSTR_SetAutoLockBattery,
+            Qstr::MP_QSTR_SetAutoLockUSB => Qstr::MP_QSTR_SetAutoLockUSB,
+            Qstr::MP_QSTR_SetOrChangeWipeCode => Qstr::MP_QSTR_SetOrChangeWipeCode,
+            Qstr::MP_QSTR_RemoveWipeCode => Qstr::MP_QSTR_RemoveWipeCode,
+            Qstr::MP_QSTR_CheckBackup => Qstr::MP_QSTR_CheckBackup,
+            Qstr::MP_QSTR_SetDeviceName => Qstr::MP_QSTR_SetDeviceName,
+            Qstr::MP_QSTR_SetBrightness => Qstr::MP_QSTR_SetBrightness,
+            Qstr::MP_QSTR_ToggleTapToWake => Qstr::MP_QSTR_ToggleTapToWake,
+            Qstr::MP_QSTR_ToggleHaptics => Qstr::MP_QSTR_ToggleHaptics,
+            Qstr::MP_QSTR_ToggleLed => Qstr::MP_QSTR_ToggleLed,
+            Qstr::MP_QSTR_WipeDevice => Qstr::MP_QSTR_WipeDevice,
+            Qstr::MP_QSTR_TurnOff => Qstr::MP_QSTR_TurnOff,
+            Qstr::MP_QSTR_Reboot => Qstr::MP_QSTR_Reboot,
+            Qstr::MP_QSTR_RebootToBootloader => Qstr::MP_QSTR_RebootToBootloader,
+            Qstr::MP_QSTR_RefreshMenu => Qstr::MP_QSTR_RefreshMenu,
             _ => return Err(Error::AttributeError(attr)),
         };
-        unsafe { dest.write(value) };
+        unsafe { dest.write(msg.to_obj()) };
         Ok(())
     };
     unsafe { util::try_or_raise(block) }

--- a/core/embed/rust/src/ui/layout_bolt/ui_firmware.rs
+++ b/core/embed/rust/src/ui/layout_bolt/ui_firmware.rs
@@ -915,6 +915,7 @@ impl FirmwareUI for UIBolt {
 
     fn show_device_menu(
         _init_submenu_idx: Option<u8>,
+        _init_submenu_offset: i16,
         _backup_failed: bool,
         _backup_needed: bool,
         _ble_enabled: bool,

--- a/core/embed/rust/src/ui/layout_caesar/ui_firmware.rs
+++ b/core/embed/rust/src/ui/layout_caesar/ui_firmware.rs
@@ -1098,6 +1098,7 @@ impl FirmwareUI for UICaesar {
 
     fn show_device_menu(
         _init_submenu_idx: Option<u8>,
+        _init_submenu_offset: i16,
         _backup_failed: bool,
         _backup_needed: bool,
         _ble_enabled: bool,

--- a/core/embed/rust/src/ui/layout_delizia/ui_firmware.rs
+++ b/core/embed/rust/src/ui/layout_delizia/ui_firmware.rs
@@ -915,6 +915,7 @@ impl FirmwareUI for UIDelizia {
 
     fn show_device_menu(
         _init_submenu_idx: Option<u8>,
+        _init_submenu_offset: i16,
         _backup_failed: bool,
         _backup_needed: bool,
         _ble_enabled: bool,

--- a/core/embed/rust/src/ui/layout_eckhart/component_msg_obj.rs
+++ b/core/embed/rust/src/ui/layout_eckhart/component_msg_obj.rs
@@ -159,7 +159,20 @@ impl ComponentMsgObj for DeviceMenuScreen {
     fn msg_try_into_obj(&self, msg: Self::Msg) -> Result<Obj, Error> {
         let action_obj = msg.id_to_obj();
         let result_obj = msg.args_to_obj();
-        let next_menu_obj = self.next_menu_id(msg).to_u8().into();
-        new_tuple(&[action_obj, result_obj, next_menu_obj])
+        let next_menu_id = self.next_menu_id(msg);
+        let vertical_offset: u16 = match self.current_state() {
+            // If the same menu will be displayed, reuse current menu offset.
+            Some((current_menu_id, vertical_offset)) if current_menu_id == next_menu_id => {
+                // Only non-negative offsets are used.
+                vertical_offset.try_into().unwrap_or(0)
+            }
+            _ => 0, // Otherwise, don't reapply current menu offset.
+        };
+        new_tuple(&[
+            action_obj,
+            result_obj,
+            next_menu_id.to_u8().into(),
+            vertical_offset.into(),
+        ])
     }
 }

--- a/core/embed/rust/src/ui/layout_eckhart/component_msg_obj.rs
+++ b/core/embed/rust/src/ui/layout_eckhart/component_msg_obj.rs
@@ -15,8 +15,8 @@ use crate::{
 };
 
 use super::firmware::{
-    AllowedTextContent, ConfirmHomescreen, ConfirmHomescreenMsg, DeviceMenuMsg, DeviceMenuScreen,
-    Homescreen, HomescreenMsg, MnemonicInput, MnemonicKeyboard, MnemonicKeyboardMsg, PinKeyboard,
+    AllowedTextContent, ConfirmHomescreen, ConfirmHomescreenMsg, DeviceMenuScreen, Homescreen,
+    HomescreenMsg, MnemonicInput, MnemonicKeyboard, MnemonicKeyboardMsg, PinKeyboard,
     PinKeyboardMsg, ProgressScreen, SelectWordCountMsg, SelectWordCountScreen, SelectWordMsg,
     SelectWordScreen, SetBrightnessScreen, StringInput, StringKeyboard, StringKeyboardMsg,
     TextScreen, TextScreenMsg, ValueInput, ValueInputScreen, ValueInputScreenMsg,
@@ -157,16 +157,9 @@ impl ComponentMsgObj for SetBrightnessScreen {
 
 impl ComponentMsgObj for DeviceMenuScreen {
     fn msg_try_into_obj(&self, msg: Self::Msg) -> Result<Obj, Error> {
-        if matches!(msg, DeviceMenuMsg::Close) {
-            return Ok(CANCELLED.as_obj());
-        }
-        let action_obj = msg.to_u8().into();
-        let result: Option<u8> = match msg {
-            DeviceMenuMsg::UnpairDevice | DeviceMenuMsg::RefreshMenu => self.result_arg,
-            _ => None,
-        };
-        let result_obj = result.into();
-        let parent_idx_obj = DeviceMenuScreen::parent(msg).to_u8().into();
-        new_tuple(&[action_obj, result_obj, parent_idx_obj])
+        let action_obj = msg.id_to_obj();
+        let result_obj = msg.args_to_obj();
+        let next_menu_obj = self.next_menu_id(msg).to_u8().into();
+        new_tuple(&[action_obj, result_obj, next_menu_obj])
     }
 }

--- a/core/embed/rust/src/ui/layout_eckhart/firmware/device_menu_screen.rs
+++ b/core/embed/rust/src/ui/layout_eckhart/firmware/device_menu_screen.rs
@@ -42,7 +42,7 @@ use heapless::Vec;
 use num_traits::{FromPrimitive, ToPrimitive};
 
 #[repr(u8)]
-#[derive(Copy, Clone, Default, FromPrimitive, ToPrimitive)]
+#[derive(Copy, Clone, Default, FromPrimitive, ToPrimitive, PartialEq, Eq)]
 #[cfg_attr(test, derive(Debug))]
 pub enum DeviceMenuId {
     #[default]
@@ -289,6 +289,7 @@ impl DeviceMenuScreen {
     #[allow(clippy::too_many_arguments)]
     pub fn new(
         init_submenu_idx: Option<u8>,
+        init_submenu_offset: i16,
         backup_failed: bool,
         backup_needed: bool,
         ble_enabled: bool,
@@ -401,7 +402,7 @@ impl DeviceMenuScreen {
             .unwrap_or_default();
 
         let init_subscreen = unwrap!(screen.try_resolve_submenu(init_submenu_id));
-        screen.set_active_subscreen(init_subscreen);
+        screen.set_active_subscreen(init_subscreen, init_submenu_offset);
 
         Ok(screen)
     }
@@ -779,14 +780,15 @@ impl DeviceMenuScreen {
         self.subscreens.len() as u8 - 1
     }
 
-    fn set_active_subscreen(&mut self, idx: u8) {
+    fn set_active_subscreen(&mut self, idx: u8, offset: i16) {
         assert!(usize::from(idx) < self.subscreens.len());
         self.active_subscreen = idx;
-        self.build_active_subscreen();
+        self.build_active_subscreen(offset);
     }
 
     fn activate_subscreen(&mut self, idx: u8, ctx: &mut EventCtx) {
-        self.set_active_subscreen(idx);
+        // A new subscreen is shown - previous offset is not reused.
+        self.set_active_subscreen(idx, 0);
         self.place(self.bounds);
         if let ActiveScreen::Menu(screen, ..) = self.active_screen.deref_mut() {
             screen.initialize_screen(ctx);
@@ -795,7 +797,15 @@ impl DeviceMenuScreen {
         }
     }
 
-    fn build_active_subscreen(&mut self) {
+    /// Used to avoid flickering on menu refresh.
+    pub fn current_state(&self) -> Option<(DeviceMenuId, i16)> {
+        match self.active_screen.deref() {
+            ActiveScreen::Menu(menu, id) => Some((*id, menu.get_offset())),
+            _ => None,
+        }
+    }
+
+    fn build_active_subscreen(&mut self, offset: i16) {
         match self.subscreens[usize::from(self.active_subscreen)] {
             Subscreen::Submenu(submenu_index, id) => {
                 let submenu = &self.submenus[usize::from(submenu_index)];
@@ -830,7 +840,8 @@ impl DeviceMenuScreen {
                 *self.active_screen.deref_mut() = ActiveScreen::Menu(
                     VerticalMenuScreen::new(menu)
                         .with_header(header)
-                        .with_subtitle(submenu.subtitle.unwrap_or(TString::empty())),
+                        .with_subtitle(submenu.subtitle.unwrap_or(TString::empty()))
+                        .with_initial_offset(offset),
                     id,
                 );
             }

--- a/core/embed/rust/src/ui/layout_eckhart/firmware/device_menu_screen.rs
+++ b/core/embed/rust/src/ui/layout_eckhart/firmware/device_menu_screen.rs
@@ -73,12 +73,14 @@ enum Action {
 }
 
 impl DeviceMenuScreen {
-    pub fn parent(msg: DeviceMenuMsg) -> DeviceMenuId {
+    /// Which submenu should be reloaded after msg is handled.
+    pub fn next_menu_id(&self, msg: DeviceMenuMsg) -> DeviceMenuId {
         match msg {
+            DeviceMenuMsg::Close => DeviceMenuId::Root,
             DeviceMenuMsg::ReviewFailedBackup => DeviceMenuId::Root,
             DeviceMenuMsg::PairDevice => DeviceMenuId::PairAndConnect,
             DeviceMenuMsg::DisconnectDevice => DeviceMenuId::PairAndConnect,
-            DeviceMenuMsg::UnpairDevice => DeviceMenuId::PairAndConnect,
+            DeviceMenuMsg::UnpairDevice(_) => DeviceMenuId::PairAndConnect,
             DeviceMenuMsg::UnpairAllDevices => DeviceMenuId::PairAndConnect,
             DeviceMenuMsg::TurnOff => DeviceMenuId::Power,
             DeviceMenuMsg::Reboot => DeviceMenuId::Power,
@@ -97,8 +99,13 @@ impl DeviceMenuScreen {
             DeviceMenuMsg::ToggleHaptics => DeviceMenuId::Device,
             DeviceMenuMsg::ToggleLed => DeviceMenuId::Device,
             DeviceMenuMsg::WipeDevice => DeviceMenuId::Device,
-            DeviceMenuMsg::RefreshMenu => DeviceMenuId::Root,
-            DeviceMenuMsg::Close => DeviceMenuId::Root,
+            DeviceMenuMsg::RefreshMenu => match self.active_screen.deref() {
+                ActiveScreen::Menu(_, id) => *id,
+                ActiveScreen::Device(_) => DeviceMenuId::PairAndConnect,
+                ActiveScreen::Regulatory(_) | ActiveScreen::About(_) => DeviceMenuId::Device,
+                ActiveScreen::Empty | ActiveScreen::BackupInfo(_) => DeviceMenuId::Root,
+                ActiveScreen::HostInfo(_) => DeviceMenuId::PairAndConnect,
+            },
         }
     }
 }
@@ -274,9 +281,6 @@ pub struct DeviceMenuScreen {
     // index of the current subscreen in the list of subscreens
     active_subscreen: u8,
 
-    // Integer argument for DeviceMenuMsg::RefreshMenu and DeviceMenuMsg::UnpairDevice
-    pub result_arg: Option<u8>,
-
     // Production year string for Regulatory screen
     production_year: Option<TString<'static>>,
 }
@@ -310,7 +314,6 @@ impl DeviceMenuScreen {
             submenus: GcBox::new(Vec::new())?,
             subscreens: Vec::new(),
             submenu_index: [None; MAX_SUBMENUS],
-            result_arg: None,
             production_year,
         };
 
@@ -545,18 +548,13 @@ impl DeviceMenuScreen {
 
     fn register_auto_lock_menu(&mut self, auto_lock_delay: [TString<'static>; 2]) {
         let mut items: Vec<MenuItem, MEDIUM_MENU_ITEMS> = Vec::new();
-        let battery_delay = MenuItem::new(
-            auto_lock_delay[0],
-            Some(Action::Return(DeviceMenuMsg::SetAutoLockBattery)),
-        )
-        .with_subtext(Some((TR::auto_lock__on_battery.into(), None)));
+        let battery_delay =
+            MenuItem::return_msg(auto_lock_delay[0], DeviceMenuMsg::SetAutoLockBattery)
+                .with_subtext(Some((TR::auto_lock__on_battery.into(), None)));
         items.add(battery_delay);
 
-        let usb_delay = MenuItem::new(
-            auto_lock_delay[1],
-            Some(Action::Return(DeviceMenuMsg::SetAutoLockUSB)),
-        )
-        .with_subtext(Some((TR::auto_lock__on_usb.into(), None)));
+        let usb_delay = MenuItem::return_msg(auto_lock_delay[1], DeviceMenuMsg::SetAutoLockUSB)
+            .with_subtext(Some((TR::auto_lock__on_usb.into(), None)));
         items.add(usb_delay);
 
         self.register_submenu(DeviceMenuId::AutoLock, Submenu::new(items));
@@ -1031,28 +1029,19 @@ impl Component for DeviceMenuScreen {
     }
 
     fn event(&mut self, ctx: &mut EventCtx, event: Event) -> Option<Self::Msg> {
-        let refresh = match event {
-            Event::USB(USBEvent::Configured | USBEvent::Deconfigured) => true,
+        // Refresh this layout after reloading connection status
+        match event {
+            Event::USB(USBEvent::Configured | USBEvent::Deconfigured) => {
+                return Some(DeviceMenuMsg::RefreshMenu)
+            }
 
             #[cfg(feature = "ble")]
             Event::BLE(
                 BLEEvent::Connected | BLEEvent::Disconnected | BLEEvent::ConnectionChanged,
-            ) => true,
+            ) => return Some(DeviceMenuMsg::RefreshMenu),
 
-            _ => false,
+            _ => (),
         };
-        if refresh {
-            let submenu_idx = match self.active_screen.deref() {
-                ActiveScreen::Menu(_, id) => *id,
-                ActiveScreen::Device(_) => DeviceMenuId::PairAndConnect,
-                ActiveScreen::Regulatory(_) | ActiveScreen::About(_) => DeviceMenuId::Device,
-                ActiveScreen::Empty | ActiveScreen::BackupInfo(_) => DeviceMenuId::Root,
-                ActiveScreen::HostInfo(_) => DeviceMenuId::PairAndConnect,
-            };
-
-            self.result_arg = submenu_idx.to_u8();
-            return Some(DeviceMenuMsg::RefreshMenu);
-        }
 
         // Handle the event for the active menu
         let subscreen = &self.subscreens[usize::from(self.active_subscreen)];
@@ -1083,8 +1072,9 @@ impl Component for DeviceMenuScreen {
                                 return None;
                             }
                             (1, false) | (2, true) => {
-                                self.result_arg = Some(device_screen.device_index);
-                                return Some(DeviceMenuMsg::UnpairDevice);
+                                return Some(DeviceMenuMsg::UnpairDevice(
+                                    device_screen.device_index,
+                                ));
                             }
                             _ => {}
                         }

--- a/core/embed/rust/src/ui/layout_eckhart/firmware/vertical_menu_screen.rs
+++ b/core/embed/rust/src/ui/layout_eckhart/firmware/vertical_menu_screen.rs
@@ -35,6 +35,8 @@ pub struct VerticalMenuScreen<T> {
     swipe_config: SwipeConfig,
     /// Inertia scrolling state
     inertia: InertiaState,
+    /// Initial vertical offset
+    initial_offset: i16,
 }
 
 pub enum VerticalMenuScreenMsg {
@@ -68,6 +70,7 @@ impl<T: MenuItems> VerticalMenuScreen<T> {
                 .with_swipe(Direction::Up, SwipeSettings::Default)
                 .with_swipe(Direction::Down, SwipeSettings::Default),
             inertia: InertiaState::new(),
+            initial_offset: 0,
         }
     }
 
@@ -86,13 +89,25 @@ impl<T: MenuItems> VerticalMenuScreen<T> {
         self
     }
 
+    pub fn with_initial_offset(mut self, offset: i16) -> Self {
+        self.initial_offset = offset;
+        self
+    }
+
+    pub fn get_offset(&self) -> i16 {
+        self.menu.get_offset()
+    }
+
     /// Update swipe detection and buttons state based on menu size
     pub fn initialize_screen(&mut self, ctx: &mut EventCtx) {
+        // `self.initial_offset` replaced with 0, so next screens are not "resumed".
+        let initial_offset = core::mem::take(&mut self.initial_offset);
+
         if animation_disabled() {
             self.swipe = Some(SwipeDetect::new());
             ctx.enable_swipe();
             // Set default position for the sliding window
-            self.menu.set_offset(0);
+            self.menu.set_offset(initial_offset);
             // Update the menu buttons state
             self.menu.update_button_states(ctx);
             return;
@@ -110,7 +125,7 @@ impl<T: MenuItems> VerticalMenuScreen<T> {
         }
 
         // Set default position for the sliding window
-        self.menu.set_offset(0);
+        self.menu.set_offset(initial_offset);
         // Update button states
         self.menu.update_button_states(ctx);
     }

--- a/core/embed/rust/src/ui/layout_eckhart/ui_firmware.rs
+++ b/core/embed/rust/src/ui/layout_eckhart/ui_firmware.rs
@@ -1086,6 +1086,7 @@ impl FirmwareUI for UIEckhart {
 
     fn show_device_menu(
         init_submenu_idx: Option<u8>,
+        init_submenu_offset: i16,
         backup_failed: bool,
         backup_needed: bool,
         ble_enabled: bool,
@@ -1108,6 +1109,7 @@ impl FirmwareUI for UIEckhart {
     ) -> Result<impl LayoutMaybeTrace, Error> {
         let layout = RootComponent::new(DeviceMenuScreen::new(
             init_submenu_idx,
+            init_submenu_offset,
             backup_failed,
             backup_needed,
             ble_enabled,

--- a/core/embed/rust/src/ui/ui_firmware.rs
+++ b/core/embed/rust/src/ui/ui_firmware.rs
@@ -336,6 +336,7 @@ pub trait FirmwareUI {
     #[allow(clippy::too_many_arguments)]
     fn show_device_menu(
         init_submenu_idx: Option<u8>,
+        init_submenu_offset: i16,
         backup_failed: bool,
         backup_needed: bool,
         ble_enabled: bool,

--- a/core/mocks/generated/trezorui_api.pyi
+++ b/core/mocks/generated/trezorui_api.pyi
@@ -631,6 +631,7 @@ def show_homescreen(
 def show_device_menu(
     *,
     init_submenu_idx: int | None,
+    init_submenu_offset: int,
     backup_failed: bool,
     backup_needed: bool,
     ble_enabled: bool,
@@ -647,8 +648,8 @@ def show_device_menu(
     led_enabled: bool | None,
     about_items: Sequence[tuple[str | None, StrOrBytes | None, bool | None]],
     production_year: str | None,
-) -> LayoutContext[tuple[str, int | None, int]]:
-    """Show the device menu. Result is a tuple (action, action_arg, parent_menu_id)."""
+) -> LayoutContext[tuple[str, int | None, int, int]]:
+    """Show the device menu. Result is a tuple (action, action_arg, next_menu_id, next_menu_offset)."""
 
 
 # rust/src/ui/api/firmware_micropython.rs

--- a/core/mocks/generated/trezorui_api.pyi
+++ b/core/mocks/generated/trezorui_api.pyi
@@ -647,8 +647,8 @@ def show_device_menu(
     led_enabled: bool | None,
     about_items: Sequence[tuple[str | None, StrOrBytes | None, bool | None]],
     production_year: str | None,
-) -> LayoutContext[UiResult | tuple[int, int | None, int]]:
-    """Show the device menu. Result is either CANCELLED or a tuple (action, action_arg, parent_menu_id)."""
+) -> LayoutContext[tuple[str, int | None, int]]:
+    """Show the device menu. Result is a tuple (action, action_arg, parent_menu_id)."""
 
 
 # rust/src/ui/api/firmware_micropython.rs
@@ -896,26 +896,27 @@ class LayoutState:
 # rust/src/ui/api/firmware_micropython.rs
 class DeviceMenuResult:
     """Result of a device menu operation."""
-    ReviewFailedBackup: ClassVar[int]
-    DisconnectDevice: ClassVar[int]
-    PairDevice: ClassVar[int]
-    UnpairDevice: ClassVar[int]
-    UnpairAllDevices: ClassVar[int]
-    ToggleBluetooth: ClassVar[int]
-    SetOrChangePin: ClassVar[int]
-    RemovePin: ClassVar[int]
-    SetAutoLockBattery: ClassVar[int]
-    SetAutoLockUSB: ClassVar[int]
-    SetOrChangeWipeCode: ClassVar[int]
-    RemoveWipeCode: ClassVar[int]
-    CheckBackup: ClassVar[int]
-    SetDeviceName: ClassVar[int]
-    SetBrightness: ClassVar[int]
-    ToggleTapToWake: ClassVar[int]
-    ToggleHaptics: ClassVar[int]
-    ToggleLed: ClassVar[int]
-    WipeDevice: ClassVar[int]
-    Reboot: ClassVar[int]
-    RebootToBootloader: ClassVar[int]
-    TurnOff: ClassVar[int]
-    RefreshMenu: ClassVar[int]
+    Close: ClassVar[str]
+    ReviewFailedBackup: ClassVar[str]
+    DisconnectDevice: ClassVar[str]
+    PairDevice: ClassVar[str]
+    UnpairDevice: ClassVar[str]
+    UnpairAllDevices: ClassVar[str]
+    ToggleBluetooth: ClassVar[str]
+    SetOrChangePin: ClassVar[str]
+    RemovePin: ClassVar[str]
+    SetAutoLockBattery: ClassVar[str]
+    SetAutoLockUSB: ClassVar[str]
+    SetOrChangeWipeCode: ClassVar[str]
+    RemoveWipeCode: ClassVar[str]
+    CheckBackup: ClassVar[str]
+    SetDeviceName: ClassVar[str]
+    SetBrightness: ClassVar[str]
+    ToggleTapToWake: ClassVar[str]
+    ToggleHaptics: ClassVar[str]
+    ToggleLed: ClassVar[str]
+    WipeDevice: ClassVar[str]
+    Reboot: ClassVar[str]
+    RebootToBootloader: ClassVar[str]
+    TurnOff: ClassVar[str]
+    RefreshMenu: ClassVar[str]

--- a/core/src/apps/homescreen/device_menu.py
+++ b/core/src/apps/homescreen/device_menu.py
@@ -74,6 +74,7 @@ async def handle_device_menu() -> None:
     from trezor.wire.thp import paired_cache
 
     init_submenu_idx = None
+    init_submenu_offset = 0
 
     # Remain in the device loop until the menu is explicitly closed
     while True:
@@ -135,6 +136,7 @@ async def handle_device_menu() -> None:
 
         with trezorui_api.show_device_menu(
             init_submenu_idx=init_submenu_idx,
+            init_submenu_offset=init_submenu_offset,
             backup_failed=backup_failed,
             backup_needed=backup_needed,
             ble_enabled=ble_enabled,
@@ -168,10 +170,10 @@ async def handle_device_menu() -> None:
                 layout, br_name=None, layout_type=UsbAwareLayout
             )
 
-        if not isinstance(menu_result, tuple) or len(menu_result) != 3:
+        if not isinstance(menu_result, tuple) or len(menu_result) != 4:
             raise RuntimeError(f"Unknown menu {menu_result}")
 
-        action, arg, init_submenu_idx = menu_result
+        action, arg, init_submenu_idx, init_submenu_offset = menu_result
         handler = _MENU_HANDLERS.get(action)
         if not handler:
             raise RuntimeError(f"Unknown menu {menu_result}")

--- a/core/src/apps/homescreen/device_menu.py
+++ b/core/src/apps/homescreen/device_menu.py
@@ -165,21 +165,13 @@ async def handle_device_menu() -> None:
             production_year=production_year,
         ) as layout:
             menu_result = await interact(
-                layout,
-                br_name=None,
-                raise_on_cancel=None,
-                layout_type=UsbAwareLayout,
+                layout, br_name=None, layout_type=UsbAwareLayout
             )
 
         if not isinstance(menu_result, tuple) or len(menu_result) != 3:
             raise RuntimeError(f"Unknown menu {menu_result}")
 
-        action, arg, parent_submenu_idx = menu_result
-        # special handling
-        if action == DeviceMenuResult.RefreshMenu:
-            init_submenu_idx = arg
-            continue
-
+        action, arg, init_submenu_idx = menu_result
         handler = _MENU_HANDLERS.get(action)
         if not handler:
             raise RuntimeError(f"Unknown menu {menu_result}")
@@ -192,11 +184,12 @@ async def handle_device_menu() -> None:
         except ExitDeviceMenu:
             break
         except (ActionCancelled, PinCancelled):
-            # return to the submenu if flow was cancelled
+            # return to the submenu if handler was cancelled / succeeded
             continue
-        finally:
-            # return to submenu on success or cancellation
-            init_submenu_idx = parent_submenu_idx
+
+
+async def handle_Close() -> None:
+    raise ExitDeviceMenu  # return to homescreen
 
 
 async def handle_ReviewFailedBackup() -> None:
@@ -493,7 +486,12 @@ async def handle_RebootToBootloader() -> None:
     raise RuntimeError
 
 
+async def handle_RefreshMenu() -> None:
+    pass
+
+
 _MENU_HANDLERS = {
+    DeviceMenuResult.Close: handle_Close,
     DeviceMenuResult.ReviewFailedBackup: handle_ReviewFailedBackup,
     DeviceMenuResult.DisconnectDevice: handle_DisconnectDevice,
     DeviceMenuResult.PairDevice: handle_PairDevice,
@@ -516,4 +514,5 @@ _MENU_HANDLERS = {
     DeviceMenuResult.TurnOff: handle_TurnOff,
     DeviceMenuResult.Reboot: handle_Reboot,
     DeviceMenuResult.RebootToBootloader: handle_RebootToBootloader,
+    DeviceMenuResult.RefreshMenu: handle_RefreshMenu,
 }


### PR DESCRIPTION
For example, when a toggle-based menu item is clicked, we would like to keep the current vertical offset when reloading the menu in `handle_device_menu()`.

<img width="778" height="1064" alt="image" src="https://github.com/user-attachments/assets/72d9f754-98ad-4097-be86-2b78a4717b69" />

Also simplify device menu handling a bit.