### PR TITLE
Optimize UI fixtures' action

### DIFF
--- a/.github/actions/ui-report/action.yml
+++ b/.github/actions/ui-report/action.yml
@@ -27,8 +27,8 @@ runs:
         OUTDIR=${{ github.run_id }}
         mkdir -p $OUTDIR
         nix-shell --run "uv run python ci/prepare_ui_artifacts.py || true"
-        mv -v tests/ui_tests/reports/test/* $OUTDIR
-        mv -v tests/ui_tests/fixtures.*.json $OUTDIR
+        mv tests/ui_tests/reports/test/* $OUTDIR
+        mv tests/ui_tests/fixtures.*.json $OUTDIR
 
         # rename all model/job-speficific report files, so they won't be overwritten during upload
         cd $OUTDIR
@@ -37,15 +37,15 @@ runs:
           if [ "$F" = "testreport.js" ]; then
             echo "Skip $F"
           elif [ -f "$F" ]; then
-            mv -v $F $MODELJOB-$F
+            mv $F $MODELJOB-$F
           fi
         done
         cd ..
 
         if [ "${{ inputs.status }}" = "success" ]; then
-          cp -v .github/actions/ui-report/success.png $OUTDIR/$MODELJOB-status.png
+          cp .github/actions/ui-report/success.png $OUTDIR/$MODELJOB-status.png
         else
-          cp -v .github/actions/ui-report/failure.png $OUTDIR/$MODELJOB-status.png
+          cp .github/actions/ui-report/failure.png $OUTDIR/$MODELJOB-status.png
         fi
       shell: sh
     - name: Upload test results

--- a/.github/actions/ui-report/action.yml
+++ b/.github/actions/ui-report/action.yml
@@ -18,10 +18,7 @@ runs:
       uses: aws-actions/configure-aws-credentials@8df5847569e6427dd6c4fb1cf565c83acfa8afa7  # aws-actions/configure-aws-credentials@v6.0.0
       with:
         role-to-assume: arn:aws:iam::538326561891:role/gh_actions_deploy_dev_firmware_data
-        aws-region: eu-west-1
-    - name: Increase AWS S3 max concurrency for faster uploads
-      run: aws configure set default.s3.max_concurrent_requests 50
-      shell: sh
+        aws-region: eu-central-1
     - run: |
         MODELJOB=${{ inputs.model }}-${{ inputs.lang }}-${{ github.job }}
         OUTDIR=${{ github.run_id }}
@@ -50,15 +47,19 @@ runs:
       shell: sh
     - name: Upload test results
       run: |
+        # Cache s5cmd package (to be reused by the next calls)
+        nix-shell --run "s5cmd version"
+
+        CMD="s5cmd --log error cp --concurrency 100"
+
         # Upload report
         du -sh ${{ github.run_id }}
-        ls -l ${{ github.run_id }}
-        aws s3 cp --no-overwrite --recursive --only-show-errors ${{ github.run_id }} s3://data.trezor.io/dev/firmware/ui_report/${{ github.run_id }} &
+        nix-shell --run "$CMD ${{ github.run_id }}/ s3://data.trezor.io/dev/firmware/ui_report/${{ github.run_id }}/" &
         PID1=$!
 
         # Upload test screen recording
         du -sh ci/ui_test_records
-        aws s3 cp --no-overwrite --recursive --only-show-errors ci/ui_test_records s3://data.trezor.io/dev/firmware/ui_tests &
+        nix-shell --run "$CMD ci/ui_test_records/ s3://data.trezor.io/dev/firmware/ui_tests/" &
         PID2=$!
         # TODO: generate directory listing / autoindex
 

--- a/ci/prepare_ui_artifacts.py
+++ b/ci/prepare_ui_artifacts.py
@@ -1,5 +1,6 @@
 import shutil
 import sys
+from multiprocessing import Pool
 from pathlib import Path
 
 ROOT = Path(__file__).resolve().parent.parent
@@ -10,10 +11,11 @@ from tests.ui_tests.common import get_current_fixtures  # isort:skip
 
 FIXTURES = get_current_fixtures()
 
-for result in TestResult.recent_results():
+
+def compute_hash(result: TestResult) -> TestResult | None:
     if not result.passed or result.expected_hash != result.actual_hash:
         print("WARNING: skipping failed test", result.test.id)
-        continue
+        return None
 
     actual_hash = _hash_files(result.test.actual_dir)
     expected_hash = (
@@ -23,6 +25,28 @@ for result in TestResult.recent_results():
     )
     assert result.expected_hash == actual_hash
     assert expected_hash == actual_hash
-    shutil.make_archive(
-        str(ROOT / "ci/ui_test_records" / actual_hash), "zip", result.test.actual_dir
-    )
+    return result
+
+
+def create_zip(item: tuple[str, TestResult]) -> None:
+    archive_path, result = item
+    shutil.make_archive(archive_path, "zip", result.test.actual_dir)
+
+
+def main():
+    with Pool() as pool:
+        all_results = list(TestResult.recent_results())
+        print(f"Hashing {len(all_results)} results")
+        # deduplicate results by `actual_hash`, and skip failed tests
+        results_map = {
+            str(ROOT / "ci/ui_test_records" / result.actual_hash): result
+            for result in pool.imap_unordered(compute_hash, all_results)
+            if result is not None
+        }
+        print(f"Creating {len(results_map)} ZIP files")
+        for _ in pool.imap_unordered(create_zip, results_map.items()):
+            pass
+
+
+if __name__ == "__main__":
+    main()

--- a/shell.nix
+++ b/shell.nix
@@ -108,6 +108,7 @@ stdenvNoCC.mkDerivation ({
     pyright
     python3
     (mkBinOnlyWrapper rustNightly)
+    s5cmd
     sccache
     uv
     wget


### PR DESCRIPTION
- [x] use [`s5cmd`](https://github.com/peak/s5cmd) for UI fixtures upload & increase upload parallelism.
- [x] optimize `ci/prepare_ui_artifacts.py` by increasing concurrency.

On T3W1, `ui-report` takes [1m30s now](https://github.com/trezor/trezor-firmware/actions/runs/28453079267/job/84321514482), down from [5m6s on `main`](https://github.com/trezor/trezor-firmware/actions/runs/28409725577/job/84180490812).