### PR TITLE
fix(core/caesar): fix `confirm_properties()` handling of `PageMsg::Info`

### DIFF
--- a/core/embed/rust/src/ui/layout_caesar/component_msg_obj.rs
+++ b/core/embed/rust/src/ui/layout_caesar/component_msg_obj.rs
@@ -61,6 +61,7 @@ where
         match msg {
             PageMsg::Confirmed => Ok(CONFIRMED.as_obj()),
             PageMsg::Cancelled => Ok(CANCELLED.as_obj()),
+            PageMsg::Info => Ok(INFO.as_obj()),
             _ => Err(Error::TypeError),
         }
     }


### PR DESCRIPTION
Following https://satoshilabs.slack.com/archives/C08LFLVN19R/p1782726192261719.

Tested locally, more tests will be added in a separate PR.