### PR TITLE
test(core/caesar): visit menu only on last `ButtonPage`

### DIFF
--- a/core/embed/rust/src/ui/layout_caesar/component/page.rs
+++ b/core/embed/rust/src/ui/layout_caesar/component/page.rs
@@ -213,6 +213,6 @@ where
         t.int("page_count", self.pager().total() as i64);
         t.child("buttons", &self.buttons);
         t.child("content", &self.content);
-        t.bool("has_menu", self.has_menu);
+        t.bool("has_menu", self.has_menu && self.pager().is_last());
     }
 }


### PR DESCRIPTION
Non-last pages don't have an info button on Caesar.

<img width="274" height="558" alt="image" src="https://github.com/user-attachments/assets/c5844b94-e4dd-4732-8dea-7fc0a670305a" />
