### PR TITLE
test(core): make tests' translation logic consistent with firmware

### DIFF
--- a/tests/translations.py
+++ b/tests/translations.py
@@ -107,7 +107,8 @@ class Translation:
 
     def _translate_raw(self, key: str, _stacklevel: int = 0) -> str:
         tr = self.translations.get(key)
-        if tr is not None:
+        # Emulate firmware behaviour: English strings are used instead of missing & empty strings
+        if tr:
             # Handle layout-specific translations
             if isinstance(tr, dict) and hasattr(_CURRENT_TRANSLATION, "LAYOUT"):
                 # Try to get translation for current layout


### PR DESCRIPTION
Otherwise, some click tests may fail if translated JSONs contain empty strings.