### PR TITLE
test(core): ignore stale responses during `protocol_v1.sync_responses()`

### DIFF
--- a/python/src/trezorlib/protocol_v1.py
+++ b/python/src/trezorlib/protocol_v1.py
@@ -354,23 +354,11 @@ def probe(
     retries: int = 10,
 ) -> bool:
     """Probe the transport to see if it supports protocol v1."""
-    for _ in range(retries):
-        try:
-            # skip stale responses (to prevent the device from blocking during sending)
-            resp = read(transport, _ignore_bad_magic=True, timeout=0.1)
-            LOG.debug("stale response: %s", resp)
-        except Timeout:
-            break
-    cancel_msg = messages.Cancel()
-    cancel_msg_type, cancel_msg_bytes = mapping.encode(cancel_msg)
-    write(transport, cancel_msg_type, cancel_msg_bytes)
-    # Ignore previously sent unexpected packets, while waiting for the response.
-    resp_type, resp_bytes = read(transport, _ignore_bad_magic=True)
-    resp = mapping.decode(resp_type, resp_bytes)
-    if isinstance(resp, messages.Failure):
-        if resp.code == messages.FailureType.InvalidProtocol:
-            return False
-    return True
+    try:
+        sync_responses(transport, mapping=mapping, retries=retries)
+        return True
+    except NotImplementedError:
+        return False
 
 
 @enter_context
@@ -379,8 +367,17 @@ def sync_responses(
     *,
     mapping: ProtobufMapping = mapping.DEFAULT_MAPPING,
     retries: int = 10,
+    _max_stale_responses: int = 10,
 ) -> None:
     """Sync responses from the transport."""
+    for _ in range(_max_stale_responses):
+        try:
+            # skip stale responses (also to prevent the device from blocking during sending)
+            resp = read(transport, _ignore_bad_magic=True, timeout=0.1)
+            LOG.debug("stale response: %s", resp)
+        except Timeout:
+            break
+
     # cancel anything on screen -- on T1B1 this is the only way to exit e.g. a PIN prompt.
     cancel_msg = mapping.encode(messages.Cancel())
     write(transport, *cancel_msg)
@@ -394,6 +391,12 @@ def sync_responses(
     for _ in range(retries):
         resp_type, resp_bytes = read(transport)
         resp = mapping.decode(resp_type, resp_bytes)
+        if (
+            isinstance(resp, messages.Failure)
+            and resp.code is messages.FailureType.InvalidProtocol
+        ):
+            # v1 protocol is not supported
+            raise NotImplementedError(resp.message)
         if isinstance(resp, messages.Success) and resp.message == sync_string:
             return
     raise exceptions.ProtocolError("Failed to sync responses")

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -358,8 +358,10 @@ def _prepared_test_ctx(
     try:
         _raw_test_ctx.sync_responses()
     except Exception:
-        request.session.shouldstop = "Failed to communicate with Trezor"
-        pytest.fail("Failed to communicate with Trezor")
+        msg = "Failed to communicate with Trezor"
+        LOG.exception(msg)
+        request.session.shouldstop = msg
+        pytest.fail(msg)
 
     # Use DebugLink to wipe (since THP channel requires unlocked device)
     _raw_test_ctx.wipe_device()

--- a/tests/device_tests/test_protection_levels.py
+++ b/tests/device_tests/test_protection_levels.py
@@ -381,6 +381,9 @@ def test_sign_message_seedless(client: Client):
             btc.sign_message(
                 session, "Bitcoin", parse_path("m/44h/0h/0h/0/0"), "testing message"
             )
+        # Otherwise, the device will continue waiting for "PassphraseAck" and display
+        # "Please enter your passphrase." message, resulting in UI fixtures' flakiness.
+        session.cancel()
 
 
 @pytest.mark.models("legacy")


### PR DESCRIPTION
`sync_responses` is called before each test (at `_prepared_test_ctx`).

Also:
* avoid stopping the test session there was a packet loss in the previous test.
* re-implement `probe()` via `sync_responses()`.
* log the exception & traceback when stopping test session.

It should help with #7184 from timing out during `sync_responses`:
```
        fail_on_gc_leak = not request.config.getoption("ignore_gc_leak")
    
        _raw_test_ctx.reset_debug_features()
        try:
>           _raw_test_ctx.sync_responses()

tests/conftest.py:359: 
_ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ 
python/src/trezorlib/debuglink.py:1547: in sync_responses
    protocol_v1.sync_responses(self.transport)
python/src/trezorlib/protocol_v1.py:392: in sync_responses
    write(transport, *ping_msg)
python/src/trezorlib/protocol_v1.py:60: in write
    transport.write_chunk(chunk)
python/src/trezorlib/transport/webusb.py:143: in write_chunk
    bytes_written = self.handle.interruptWrite(
.venv/lib/python3.13/site-packages/usb1/__init__.py:1535: in interruptWrite
    return self._interruptTransfer(endpoint, data, sizeof(data), timeout)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
_ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ 

self = <usb1.USBDeviceHandle object at 0x7dc7e746c5f0>, endpoint = 1
data = <usb1.c_char_Array_64 object at 0x7dc7e741d6d0>, length = 64
timeout = 300

    def _interruptTransfer(self, endpoint, data, length, timeout):
        transferred = c_int()
        try:
>           mayRaiseUSBError(libusb1.libusb_interrupt_transfer(
                self.__handle,
                endpoint,
                data,
                length,
                byref(transferred),
                timeout,
            ))
E           Failed: Timeout (>600.0s) from pytest-timeout.
```
https://github.com/trezor/trezor-firmware/actions/runs/28064441070/job/83085601022