### PR TITLE
fix(core/ui): avoid RSOD when paragraph area is too small

### DIFF
--- a/core/embed/rust/src/ui/component/text/paragraphs.rs
+++ b/core/embed/rust/src/ui/component/text/paragraphs.rs
@@ -560,8 +560,9 @@ impl<'a, T: ParagraphSource<'a>> PageBreakIterator<'_, T> {
     fn dyn_next(
         mut area: Rect,
         paragraphs: &dyn ParagraphSource<'_>,
-        mut offset: PageOffset,
+        initial_offset: PageOffset,
     ) -> Option<PageOffset> {
+        let mut offset = initial_offset;
         let full_height = area.height();
 
         while offset.par < paragraphs.size() {
@@ -574,6 +575,14 @@ impl<'a, T: ParagraphSource<'a>> PageBreakIterator<'_, T> {
                 assert_eq!(advance.offset.par, offset.par + 1);
                 area = remaining_area;
                 offset = advance.offset;
+            } else if advance.offset == initial_offset {
+                // No space remaining yet no advance - not a single letter fits, bail.
+                #[cfg(feature = "ui_debug")]
+                paragraphs
+                    .at(advance.offset.par, advance.offset.chr)
+                    .content()
+                    .map(|s| log::error!("Paragraphs area too small, content invisible: {}", s));
+                return None;
             } else {
                 return Some(advance.offset);
             }


### PR DESCRIPTION
Fixes #6446 - in the issue the RSOD happens on the following screen:

<img width="240" height="240" alt="Screenshot 2026-07-02 at 17-04-16 T2T1_cs-device_tests-test_msg_backup_device py test_backup_slip39_advanced Display-no_click_info_normal" src="https://github.com/user-attachments/assets/df92c5d4-66f3-4466-a8ef-59f1ba300ba0" />

This particular instance is alright but if the title is long enough to occupy 2 lines then there's no space left to render the "choose 8 of 20" and the code hits an assert. The PR changes the behavior to not rendering anything and writing an error into log.

Not really sure how to handle this - in this case the missing text is caught by tests but I wonder if there could be circumstances that we don't test for where not rendering something would be worse than RSOD.

<!--
For external contributors:
- Please open an issue before submitting a PR so we can discuss whether we want to proceed with it.

For core developers:
1. Initial PR setup
- Assign yourself to the PR.
- Add it to the "Firmware" project
  - Set Priority (match issue priority if it exists)
  - Set Team
  - Set Sprint (target release)

2. Development status
- Draft PRs: Set status to "In Progress"
- Final PRs: Set status to "Needs Review"

3. Post-merge status
- Testable: Set status to "Needs QA" and add a `Notes for QA` section with clear instructions on how to test the functionality.
- Not Testable: Set status to "Done (no QA)"
-->
