### PR TITLE
Allow approve and transfer to send eth

### DIFF
--- a/common/tests/fixtures/ethereum/sign_tx_erc20.json
+++ b/common/tests/fixtures/ethereum/sign_tx_erc20.json
@@ -278,6 +278,132 @@
                 "sig_r": "23159b30f585016f909fdddc41951cb2aa2274a659d324b239fac41c5b94110c",
                 "sig_s": "401e555170f25b08c89c360992026a9a3bc0d3315091393910816478815e362e"
             }
+        },
+        {
+            "name": "erc20_approve_unknown_with_eth",
+            "parameters": {
+                "comment": "approve() on an unknown (non-builtin) token contract, carrying native ETH: the native amount is surfaced as the amount field on the approve summary page alongside fees.",
+                "data": "095ea7b30000000000000000000000001d1c328764a41bda0492b66baa30c4a339ff85ef0000000000000000000000000000000000000000000000000de0b6b3a7640000",
+                "path": "m/44'/60'/0'/0/0",
+                "to_address": "0xdddddddddddddddddddddddddddddddddddddddd",
+                "chain_id": 1,
+                "nonce": "0x0",
+                "gas_price": "0x4a817c800",
+                "gas_limit": "0x186a0",
+                "tx_type": null,
+                "value": "0xde0b6b3a7640000"
+            },
+            "result": {
+                "sig_v": 37,
+                "sig_r": "cae5c5a8d64293655e2f0f09865f26ae62f69bbefb40e7404735a98c9978bdc0",
+                "sig_s": "2b463c1c244e9ac8648aa8d317cf9501219e542a9ca1bc94980d83db78f4ab9c"
+            },
+            "skip_models": ["t1"]
+        },
+        {
+            "name": "erc20_transfer_unknown_with_eth",
+            "parameters": {
+                "comment": "transfer() on an unknown (non-builtin) token contract, carrying native ETH: the native amount is surfaced on the line after the token total amount on the transfer summary page alongside fees.",
+                "data": "a9059cbb0000000000000000000000001d1c328764a41bda0492b66baa30c4a339ff85ef0000000000000000000000000000000000000000000000000de0b6b3a7640000",
+                "path": "m/44'/60'/0'/0/0",
+                "to_address": "0xdddddddddddddddddddddddddddddddddddddddd",
+                "chain_id": 1,
+                "nonce": "0x0",
+                "gas_price": "0x4a817c800",
+                "gas_limit": "0x186a0",
+                "tx_type": null,
+                "value": "0xde0b6b3a7640000"
+            },
+            "result": {
+                "sig_v": 38,
+                "sig_r": "d9f59becea23a7ea0fb767158cb8f47595141480cbbf7e666a91cb2f43a4357c",
+                "sig_s": "7607d4827b2a85b2a59bbb9e3fddc7c719eb810602ad5b70aea38fca26f7a2d7"
+            },
+            "skip_models": ["t1"]
+        },
+        {
+            "name": "erc20_transfer_unknown_zero_with_eth",
+            "parameters": {
+                "comment": "transfer() of 0 tokens on an unknown contract, carrying 1 ETH native: renders '0 Wei UNKN' then the native amount on the line after, on the transfer summary page.",
+                "data": "a9059cbb0000000000000000000000001d1c328764a41bda0492b66baa30c4a339ff85ef0000000000000000000000000000000000000000000000000000000000000000",
+                "path": "m/44'/60'/0'/0/0",
+                "to_address": "0xdddddddddddddddddddddddddddddddddddddddd",
+                "chain_id": 1,
+                "nonce": "0x0",
+                "gas_price": "0x4a817c800",
+                "gas_limit": "0x186a0",
+                "tx_type": null,
+                "value": "0xde0b6b3a7640000"
+            },
+            "result": {
+                "sig_v": 38,
+                "sig_r": "f6287f91025f994a56c54468a29bb43a7055fb83533cf7aa538bd9a0722268e5",
+                "sig_s": "3812e6b2f3a4b25c97b02ecd3f1430e064b72166167e05877acac70c746c7a7f"
+            },
+            "skip_models": ["t1"]
+        },
+        {
+            "name": "erc20_approve_usdc_with_eth",
+            "parameters": {
+                "comment": "approve() on the builtin USDC token, carrying native ETH: token renders as USDC; the native amount is surfaced as the amount field on the approve summary page alongside fees.",
+                "data": "095ea7b30000000000000000000000001d1c328764a41bda0492b66baa30c4a339ff85ef0000000000000000000000000000000000000000000000000de0b6b3a7640000",
+                "path": "m/44'/60'/0'/0/0",
+                "to_address": "0xA0b86991c6218b36c1d19D4a2e9Eb0cE3606eB48",
+                "chain_id": 1,
+                "nonce": "0x0",
+                "gas_price": "0x4a817c800",
+                "gas_limit": "0x186a0",
+                "tx_type": null,
+                "value": "0xde0b6b3a7640000"
+            },
+            "result": {
+                "sig_v": 37,
+                "sig_r": "c77f25a859cf61409b5dffed5264f92412d40043896b4aad9e57baecd6ed0ee9",
+                "sig_s": "3fb934349498cfb33836e52da9ebda24508739b4835de4f408ac25381eb967a4"
+            },
+            "skip_models": ["t1"]
+        },
+        {
+            "name": "erc20_transfer_usdc_with_eth",
+            "parameters": {
+                "comment": "transfer() on the builtin USDC token, carrying native ETH: token renders as USDC; the native amount is surfaced on the line after the token total amount on the transfer summary page alongside fees.",
+                "data": "a9059cbb0000000000000000000000001d1c328764a41bda0492b66baa30c4a339ff85ef0000000000000000000000000000000000000000000000000de0b6b3a7640000",
+                "path": "m/44'/60'/0'/0/0",
+                "to_address": "0xA0b86991c6218b36c1d19D4a2e9Eb0cE3606eB48",
+                "chain_id": 1,
+                "nonce": "0x0",
+                "gas_price": "0x4a817c800",
+                "gas_limit": "0x186a0",
+                "tx_type": null,
+                "value": "0xde0b6b3a7640000"
+            },
+            "result": {
+                "sig_v": 37,
+                "sig_r": "cd92dd9dca42ab2f3bc389c8c011bd10e14f055d778ad0bd629145f194fff2dc",
+                "sig_s": "2a48801b6d2d8793469fc5cfd1e76a30536676e7f4d85cd179d3d0797373540f"
+            },
+            "skip_models": ["t1"]
+        },
+        {
+            "name": "erc20_transfer_usdc_zero_with_eth",
+            "parameters": {
+                "comment": "transfer() of 0 USDC on the builtin USDC token, carrying 1 ETH native: renders '0 USDC' then the native amount on the line after, on the transfer summary page.",
+                "data": "a9059cbb0000000000000000000000001d1c328764a41bda0492b66baa30c4a339ff85ef0000000000000000000000000000000000000000000000000000000000000000",
+                "path": "m/44'/60'/0'/0/0",
+                "to_address": "0xA0b86991c6218b36c1d19D4a2e9Eb0cE3606eB48",
+                "chain_id": 1,
+                "nonce": "0x0",
+                "gas_price": "0x4a817c800",
+                "gas_limit": "0x186a0",
+                "tx_type": null,
+                "value": "0xde0b6b3a7640000"
+            },
+            "result": {
+                "sig_v": 37,
+                "sig_r": "5d853e922f55aeef93d48390e8d71c10b55705055975ddbba161a25669f908ab",
+                "sig_s": "516f2b2a173ebf88002b4cdf717bbc9133bfc250ba477e93a17cec777f1a789b"
+            },
+            "skip_models": ["t1"]
         }
     ]
 }

--- a/core/src/apps/ethereum/clear_signing.py
+++ b/core/src/apps/ethereum/clear_signing.py
@@ -1080,6 +1080,14 @@ async def _handle_approve(
     from .sc_constants import KNOWN_ADDRESSES
     from .yielding_vaults import UNKNOWN_VAULT, lookup_vault
 
+    # approve() is not payable; surface any native ETH sent along with it.
+    native_value = int.from_bytes(msg.value, "big")
+    native_amount = (
+        format_ethereum_amount(native_value, None, defs.network)
+        if native_value
+        else None
+    )
+
     args, fields = await display_format.parse_calldata(calldata, msg, defs)
 
     if len(args) != 2 or len(fields) != 2:
@@ -1121,6 +1129,7 @@ async def _handle_approve(
         address_bytes,
         is_revoke,
         bool(msg.chunkify),
+        native_amount=native_amount,
     )
 
 
@@ -1135,6 +1144,14 @@ async def _handle_transfer(
     payment_request_verifier: PaymentRequestVerifier | None,
 ) -> None:
     from .layout import require_confirm_payment_request, require_confirm_tx
+
+    # transfer() is not payable; surface any native ETH sent along with it.
+    native_value = int.from_bytes(msg.value, "big")
+    native_amount = (
+        format_ethereum_amount(native_value, None, defs.network)
+        if native_value
+        else None
+    )
 
     args, fields = await display_format.parse_calldata(calldata, msg, defs)
 
@@ -1184,6 +1201,7 @@ async def _handle_transfer(
             actual_token or defs.get_token(address_bytes),
             is_send=True,
             chunkify=bool(msg.chunkify),
+            native_amount=native_amount,
         )
 
 
@@ -1200,6 +1218,23 @@ async def _handle_generic_ui(
     from .helpers import bytes_from_address
     from .layout import require_confirm_clear_signing
     from .sc_constants import KNOWN_ADDRESSES
+
+    # Surface the native ETH value in the summary when non-zero - unless the
+    # display format already renders it as an `AmountFormatter` field (e.g. a
+    # swap's "Amount to Send"). That field shows the same canonical string the
+    # summary would, so repeating it there is pure duplication. A `@.value`
+    # field formatted any other way still gets its own summary line.
+    value = int.from_bytes(msg.value, "big")
+    value_shown_as_amount_field = any(
+        fd.path == ContainerPath.Value
+        and isinstance(fd.get_formatter(), AmountFormatter)
+        for fd in display_format.field_definitions
+    )
+    amount = (
+        format_ethereum_amount(value, None, defs.network)
+        if value and not value_shown_as_amount_field
+        else None
+    )
 
     _, fields = await display_format.parse_calldata(calldata, msg, defs)
 
@@ -1224,5 +1259,5 @@ async def _handle_generic_ui(
     )
 
     await require_confirm_clear_signing(
-        recipient_str, display_format.intent, properties_to_confirm, maximum_fee
+        recipient_str, display_format.intent, properties_to_confirm, maximum_fee, amount
     )

--- a/core/src/apps/ethereum/layout.py
+++ b/core/src/apps/ethereum/layout.py
@@ -47,6 +47,7 @@ async def require_confirm_approve(
     token_address: AnyBytes,
     is_revoke: bool,
     chunkify: bool,
+    native_amount: str | None = None,
 ) -> None:
     from trezor.ui.layouts import confirm_ethereum_approve
 
@@ -81,15 +82,22 @@ async def require_confirm_approve(
         maximum_fee,
         fee_info_items,
         chunkify=chunkify,
+        native_amount=native_amount,
     )
 
 
 async def require_confirm_clear_signing(
-    recipient_str: str, intent: str, properties: list[StrPropertyType], maximum_fee: str
+    recipient_str: str,
+    intent: str,
+    properties: list[StrPropertyType],
+    maximum_fee: str,
+    amount: str | None = None,
 ) -> None:
     from trezor.ui.layouts import confirm_ethereum_clear_signing
 
-    await confirm_ethereum_clear_signing(recipient_str, intent, properties, maximum_fee)
+    await confirm_ethereum_clear_signing(
+        recipient_str, intent, properties, maximum_fee, amount
+    )
 
 
 async def require_confirm_tx(
@@ -102,6 +110,7 @@ async def require_confirm_tx(
     token: EthereumTokenInfo | None,
     is_send: bool,
     chunkify: bool,
+    native_amount: str | None = None,
 ) -> None:
     from trezor.ui.layouts import confirm_ethereum_tx, ethereum_address_title
 
@@ -132,6 +141,7 @@ async def require_confirm_tx(
         maximum_fee,
         fee_info_items,
         is_send,
+        native_amount=native_amount,
         chunkify=chunkify,
     )
 

--- a/core/src/trezor/ui/layouts/bolt/__init__.py
+++ b/core/src/trezor/ui/layouts/bolt/__init__.py
@@ -1099,8 +1099,14 @@ if not utils.BITCOIN_ONLY:
         br_name: str = "confirm_ethereum_tx",
         br_code: ButtonRequestType = ButtonRequestType.SignTx,
         chunkify: bool = False,
+        native_amount: str | None = None,
     ) -> None:
         from ..properties import with_colon
+
+        if native_amount is not None:
+            # A non-zero native ETH value carried alongside a token transfer;
+            # show it next to the token amount so it can't be signed unseen.
+            total_amount = f"{total_amount}\n{native_amount}"
 
         if is_send:
             description = f"{TR.words__recipient}:"
@@ -1181,6 +1187,7 @@ if not utils.BITCOIN_ONLY:
         maximum_fee: str,
         fee_info_items: Iterable[StrPropertyType],
         chunkify: bool = False,
+        native_amount: str | None = None,
     ) -> None:
         from ..properties import AboveThreshold
 
@@ -1269,8 +1276,8 @@ if not utils.BITCOIN_ONLY:
         )
 
         await _confirm_summary(
-            None,
-            None,
+            native_amount,
+            f"{TR.words__amount}:" if native_amount else None,
             maximum_fee,
             TR.send__maximum_fee,
             TR.words__title_summary,
@@ -1285,6 +1292,7 @@ if not utils.BITCOIN_ONLY:
         intent: str,
         properties: list[StrPropertyType],
         maximum_fee: str,
+        amount: str | None = None,
     ) -> None:
         from ..properties import with_colon
 
@@ -1296,8 +1304,8 @@ if not utils.BITCOIN_ONLY:
             properties,
         )
         with trezorui_api.confirm_summary(
-            amount=None,
-            amount_label=None,
+            amount=amount,
+            amount_label=with_colon(TR.words__amount) if amount is not None else None,
             fee=maximum_fee,
             fee_label=with_colon(TR.send__maximum_fee),
             extra_items=None,

--- a/core/src/trezor/ui/layouts/caesar/__init__.py
+++ b/core/src/trezor/ui/layouts/caesar/__init__.py
@@ -1151,6 +1151,7 @@ if not utils.BITCOIN_ONLY:
         maximum_fee: str,
         fee_info_items: Iterable[StrPropertyType],
         chunkify: bool = False,
+        native_amount: str | None = None,
     ) -> None:
         from ..properties import AboveThreshold, with_colon
 
@@ -1241,8 +1242,8 @@ if not utils.BITCOIN_ONLY:
             account_items = ((TR.address_details__derivation_path, account_path, None),)
 
         with trezorui_api.confirm_summary(
-            amount=None,
-            amount_label=None,
+            amount=native_amount,
+            amount_label=with_colon(TR.words__amount) if native_amount else None,
             fee=maximum_fee,
             fee_label=with_colon(TR.send__maximum_fee),
             title=TR.words__title_summary,
@@ -1261,6 +1262,7 @@ if not utils.BITCOIN_ONLY:
         intent: str,
         properties: list[StrPropertyType],
         maximum_fee: str,
+        amount: str | None = None,
     ) -> None:
         from ..properties import with_colon
 
@@ -1273,8 +1275,8 @@ if not utils.BITCOIN_ONLY:
         )
 
         with trezorui_api.confirm_summary(
-            amount=None,
-            amount_label=None,
+            amount=amount,
+            amount_label=with_colon(TR.words__amount) if amount is not None else None,
             fee=maximum_fee,
             fee_label=with_colon(TR.send__maximum_fee),
             extra_items=None,
@@ -1646,8 +1648,14 @@ if not utils.BITCOIN_ONLY:
         br_name: str = "confirm_ethereum_tx",
         br_code: ButtonRequestType = ButtonRequestType.SignTx,
         chunkify: bool = False,
+        native_amount: str | None = None,
     ) -> None:
         from ..properties import with_colon
+
+        if native_amount is not None:
+            # A non-zero native ETH value carried alongside a token transfer;
+            # show it next to the token amount so it can't be signed unseen.
+            total_amount = f"{total_amount}\n{native_amount}"
 
         with trezorui_api.confirm_summary(
             amount=total_amount,

--- a/core/src/trezor/ui/layouts/delizia/__init__.py
+++ b/core/src/trezor/ui/layouts/delizia/__init__.py
@@ -1085,7 +1085,13 @@ if not utils.BITCOIN_ONLY:
         br_name: str = "confirm_ethereum_tx",
         br_code: ButtonRequestType = ButtonRequestType.SignTx,
         chunkify: bool = False,
+        native_amount: str | None = None,
     ) -> None:
+        if native_amount is not None:
+            # A non-zero native ETH value carried alongside a token transfer;
+            # show it next to the token amount so it can't be signed unseen.
+            total_amount = f"{total_amount}\n{native_amount}"
+
         await confirm_linear_flow(
             lambda: confirm_value(
                 TR.words__address,
@@ -1135,6 +1141,7 @@ if not utils.BITCOIN_ONLY:
         maximum_fee: str,
         fee_info_items: Iterable[StrPropertyType],
         chunkify: bool = False,
+        native_amount: str | None = None,
     ) -> None:
         from ..properties import AboveThreshold
 
@@ -1240,8 +1247,8 @@ if not utils.BITCOIN_ONLY:
         )
 
         await _confirm_summary(
-            None,
-            None,
+            native_amount,
+            TR.words__amount if native_amount else None,
             maximum_fee,
             TR.send__maximum_fee,
             TR.words__title_summary,
@@ -1256,6 +1263,7 @@ if not utils.BITCOIN_ONLY:
         intent: str,
         properties: list[StrPropertyType],
         maximum_fee: str,
+        amount: str | None = None,
     ) -> None:
         await confirm_action("confirm_contract", TR.words__provider, recipient_str)
         await confirm_action("confirm_contract", TR.words__intent, intent)
@@ -1265,8 +1273,8 @@ if not utils.BITCOIN_ONLY:
             properties,
         )
         with trezorui_api.confirm_summary(
-            amount=None,
-            amount_label=None,
+            amount=amount,
+            amount_label=TR.words__amount if amount is not None else None,
             fee=maximum_fee,
             fee_label=TR.send__maximum_fee,
             extra_items=None,

--- a/core/src/trezor/ui/layouts/eckhart/__init__.py
+++ b/core/src/trezor/ui/layouts/eckhart/__init__.py
@@ -1084,8 +1084,14 @@ if not utils.BITCOIN_ONLY:
         br_name: str = "confirm_total",
         br_code: ButtonRequestType = ButtonRequestType.SignTx,
         chunkify: bool = False,
+        native_amount: str | None = None,
     ) -> None:
         from trezor.ui.layouts.menu import Menu, interact_with_menu
+
+        if native_amount is not None:
+            # A non-zero native ETH value carried alongside a token transfer;
+            # show it next to the token amount so it can't be signed unseen.
+            total_amount = f"{total_amount}\n{native_amount}"
 
         subtitle = (
             None
@@ -1166,6 +1172,7 @@ if not utils.BITCOIN_ONLY:
         maximum_fee: str,
         fee_info_items: Iterable[StrPropertyType],
         chunkify: bool = False,
+        native_amount: str | None = None,
     ) -> None:
         from ..properties import AboveThreshold
 
@@ -1280,8 +1287,8 @@ if not utils.BITCOIN_ONLY:
         )
 
         await _confirm_summary(
-            None,
-            None,
+            native_amount,
+            TR.words__amount if native_amount else None,
             maximum_fee,
             TR.send__maximum_fee,
             title,
@@ -1296,6 +1303,7 @@ if not utils.BITCOIN_ONLY:
         intent: str,
         properties: list[StrPropertyType],
         maximum_fee: str,
+        amount: str | None = None,
     ) -> None:
         await confirm_action("confirm_contract", TR.words__provider, recipient_str)
         await confirm_action("confirm_contract", TR.words__intent, intent)
@@ -1305,8 +1313,8 @@ if not utils.BITCOIN_ONLY:
             properties,
         )
         with trezorui_api.confirm_summary(
-            amount=None,
-            amount_label=None,
+            amount=amount,
+            amount_label=TR.words__amount if amount is not None else None,
             fee=maximum_fee,
             fee_label=TR.send__maximum_fee,
             extra_items=None,


### PR DESCRIPTION
Notes for QA:

Try sending some ETH with known or unknown contracts for Approve and Transfer functions.
From those in the clear signing repo, and totally random ones.
(Optional) lookup solady smart contracts if you can and try with them