### PR TITLE
ci(core): avoid restarting MicroPython event loop for faster interaction

### DIFF
--- a/ci/prepare_ui_artifacts.py
+++ b/ci/prepare_ui_artifacts.py
@@ -5,9 +5,7 @@ from pathlib import Path
 
 ROOT = Path(__file__).resolve().parent.parent
 sys.path.insert(0, str(ROOT))
-# Needed for setup purposes, filling the FILE_HASHES dict
-from tests.ui_tests.common import TestResult, _hash_files  # isort:skip
-from tests.ui_tests.common import get_current_fixtures  # isort:skip
+from tests.ui_tests.common import TestResult, get_current_fixtures  # isort:skip
 
 FIXTURES = get_current_fixtures()
 
@@ -17,7 +15,7 @@ def compute_hash(result: TestResult) -> TestResult | None:
         print("WARNING: skipping failed test", result.test.id)
         return None
 
-    actual_hash = _hash_files(result.test.actual_dir)
+    actual_hash = result.actual_hash
     expected_hash = (
         FIXTURES.get(result.test.model, {})
         .get(result.test.group, {})

--- a/core/src/trezor/wire/message_handler.py
+++ b/core/src/trezor/wire/message_handler.py
@@ -179,11 +179,9 @@ async def handle_single_message(ctx: Context, msg: Message) -> bool:
     return msg.type in AVOID_RESTARTING_FOR
 
 
-if utils.UI_LAYOUT == "ECKHART":
-    # Don't close device menu when `GetFeatures` is received.
-    AVOID_RESTARTING_FOR: Container[int] = (MessageType.GetFeatures,)
-else:
-    AVOID_RESTARTING_FOR: Container[int] = ()
+# Don't restart MicroPython event loop, to lower device interaction latency.
+# Allows keeping T3W1 device menu open when `GetFeatures` is received (#6211).
+AVOID_RESTARTING_FOR: Container[int] = (MessageType.GetFeatures,)
 
 
 def failure(exc: BaseException) -> Failure:


### PR DESCRIPTION
Since `GetFeatures` imports `core/src/apps/base.py` and extensions modules, its heap footprint should be quite small.

`AVOID_RESTARTING_FOR` was introduced in 86089fa5ad, but since then it was used only for backup/recovery flows.

Also, IIUC we don't need to re-hash the screenshots at `ci/prepare_ui_artifacts.py`.