### PR TITLE
Fixup Caesar `confirm_summary()` flow & test

### DIFF
--- a/core/embed/rust/src/ui/layout_caesar/component/flow.rs
+++ b/core/embed/rust/src/ui/layout_caesar/component/flow.rs
@@ -349,6 +349,9 @@ where
         t.child("scrollbar", &self.scrollbar);
         t.child("buttons", &self.buttons);
         t.child("flow_page", &self.current_page);
-        t.bool("has_menu", self.has_menu);
+        t.bool(
+            "has_menu",
+            self.has_menu && self.current_page.pager().is_last(),
+        );
     }
 }

--- a/core/embed/rust/src/ui/layout_caesar/ui_firmware.rs
+++ b/core/embed/rust/src/ui/layout_caesar/ui_firmware.rs
@@ -562,9 +562,11 @@ impl FirmwareUI for UICaesar {
                     if let Some(amount) = amount {
                         if let Some(amount_label) = amount_label {
                             has_amount = true;
-                            ops.add_text_with_font(amount_label, fonts::FONT_BOLD)
-                                .add_newline()
-                                .add_text_with_font(amount, fonts::FONT_MONO);
+                            ops.add_text_with_font(amount_label, fonts::FONT_BOLD);
+                            if !amount_label.is_empty() && !amount.is_empty() {
+                                ops.add_newline();
+                            }
+                            ops.add_text_with_font(amount, fonts::FONT_MONO);
                         }
                     }
 


### PR DESCRIPTION
- 865b8f3bd82b2f320a017fb16c255fa711a61466 skips newline in case it's not needed (in some cases it resulted in an extra empty page)
- 8b3a69b05070c89646ee63be7a5a95ece0aea157 visit the menu only if `[i]` button is shown