### PR TITLE
fix(core): make rotation_index optional

### DIFF
--- a/common/protob/messages-evolu.proto
+++ b/common/protob/messages-evolu.proto
@@ -49,7 +49,7 @@ message EvoluSignRegistrationRequest {
 message EvoluRegistrationRequest {
     repeated bytes certificate_chain = 1;
     required bytes signature = 2;
-    required uint32 rotation_index = 3;  // the rotation index of the delegated identity key
+    optional uint32 rotation_index = 3;  // the rotation index of the delegated identity key
 }
 
 /**

--- a/core/src/trezor/messages.py
+++ b/core/src/trezor/messages.py
@@ -4471,14 +4471,14 @@ if TYPE_CHECKING:
     class EvoluRegistrationRequest(protobuf.MessageType):
         certificate_chain: "list[AnyBytes]"
         signature: "AnyBytes"
-        rotation_index: "int"
+        rotation_index: "int | None"
 
         def __init__(
             self,
             *,
             signature: "AnyBytes",
-            rotation_index: "int",
             certificate_chain: "list[AnyBytes] | None" = None,
+            rotation_index: "int | None" = None,
         ) -> None:
             pass
 

--- a/python/src/trezorlib/messages.py
+++ b/python/src/trezorlib/messages.py
@@ -6035,15 +6035,15 @@ class EvoluRegistrationRequest(protobuf.MessageType):
     FIELDS = {
         1: protobuf.Field("certificate_chain", "bytes", repeated=True, required=False, default=None),
         2: protobuf.Field("signature", "bytes", repeated=False, required=True),
-        3: protobuf.Field("rotation_index", "uint32", repeated=False, required=True),
+        3: protobuf.Field("rotation_index", "uint32", repeated=False, required=False, default=None),
     }
 
     def __init__(
         self,
         *,
         signature: "bytes",
-        rotation_index: "int",
         certificate_chain: Optional[Sequence["bytes"]] = None,
+        rotation_index: Optional["int"] = None,
     ) -> None:
         self.certificate_chain: Sequence["bytes"] = certificate_chain if certificate_chain is not None else []
         self.signature = signature

--- a/rust/trezor-client/src/protos/generated/messages_evolu.rs
+++ b/rust/trezor-client/src/protos/generated/messages_evolu.rs
@@ -703,7 +703,7 @@ impl EvoluRegistrationRequest {
         self.signature.take().unwrap_or_else(|| ::std::vec::Vec::new())
     }
 
-    // required uint32 rotation_index = 3;
+    // optional uint32 rotation_index = 3;
 
     pub fn rotation_index(&self) -> u32 {
         self.rotation_index.unwrap_or(0)
@@ -753,9 +753,6 @@ impl ::protobuf::Message for EvoluRegistrationRequest {
 
     fn is_initialized(&self) -> bool {
         if self.signature.is_none() {
-            return false;
-        }
-        if self.rotation_index.is_none() {
             return false;
         }
         true
@@ -1584,7 +1581,7 @@ static file_descriptor_proto_data: &'static [u8] = b"\
     (\x0cR\x18proofOfDelegatedIdentity\"\x8c\x01\n\x18EvoluRegistrationReque\
     st\x12+\n\x11certificate_chain\x18\x01\x20\x03(\x0cR\x10certificateChain\
     \x12\x1c\n\tsignature\x18\x02\x20\x02(\x0cR\tsignature\x12%\n\x0erotatio\
-    n_index\x18\x03\x20\x02(\rR\rrotationIndex\"\x8a\x01\n\x1cEvoluGetDelega\
+    n_index\x18\x03\x20\x01(\rR\rrotationIndex\"\x8a\x01\n\x1cEvoluGetDelega\
     tedIdentityKey\x12%\n\x0ethp_credential\x18\x01\x20\x01(\x0cR\rthpCreden\
     tial\x12%\n\x0erotation_index\x18\x03\x20\x01(\rR\rrotationIndex\x12\x16\
     \n\x06rotate\x18\x04\x20\x01(\x08R\x06rotateJ\x04\x08\x02\x10\x03\"c\n\


### PR DESCRIPTION
fix compatibility issue by making the new rotation_index field in Evolu's EvoluRegistrationRequest optional

# Testing instructions
Previous code was having issues with older FW not having the `required` protobuf message. Please check that Connect can communicate now with Trezor having an older firmware release (before this release) and the new firmware release with this patch. 

