### PR TITLE
fix(l10n): consistent FW operations wording

### DIFF
--- a/core/embed/rust/src/ui/layout_bolt/bootloader/mod.rs
+++ b/core/embed/rust/src/ui/layout_bolt/bootloader/mod.rs
@@ -199,15 +199,15 @@ impl BootloaderUI for UIBolt {
         unwrap!(version_str.push_str(vendor));
 
         let title_str = if is_newinstall {
-            "INSTALL FIRMWARE"
+            "INSTALL\nFIRMWARE"
         } else if is_newvendor {
-            "CHANGE FW\nVENDOR"
+            "CHANGE FIRMWARE\nVENDOR"
         } else if version_cmp > 0 {
-            "UPDATE FIRMWARE"
+            "UPGRADE\nFIRMWARE"
         } else if version_cmp == 0 {
-            "REINSTALL FW"
+            "REINSTALL\nFIRMWARE"
         } else {
-            "DOWNGRADE FW"
+            "DOWNGRADE\nFIRMWARE"
         };
         let title = Label::left_aligned(title_str.into(), TEXT_BOLD).vertically_centered();
         let msg = Label::left_aligned(version_str.as_str().into(), TEXT_NORMAL);
@@ -228,7 +228,7 @@ impl BootloaderUI for UIBolt {
 
         let mut frame = Confirm::new(BLD_BG, left, right, ConfirmTitle::Text(title), msg)
             .with_info(
-                "FW FINGERPRINT".into(),
+                "FIRMWARE\nFINGERPRINT".into(),
                 fingerprint.into(),
                 button_bld_menu(),
             );

--- a/core/embed/rust/src/ui/layout_bolt/bootloader/mod.rs
+++ b/core/embed/rust/src/ui/layout_bolt/bootloader/mod.rs
@@ -193,7 +193,7 @@ impl BootloaderUI for UIBolt {
         version_cmp: i32,
     ) -> u32 {
         let mut version_str: BootloaderString = String::new();
-        unwrap!(version_str.push_str("Firmware version "));
+        unwrap!(version_str.push_str("Firmware "));
         unwrap!(version_str.push_str(version));
         unwrap!(version_str.push_str("\nby "));
         unwrap!(version_str.push_str(vendor));
@@ -201,7 +201,7 @@ impl BootloaderUI for UIBolt {
         let title_str = if is_newinstall {
             "INSTALL\nFIRMWARE"
         } else if is_newvendor {
-            "CHANGE FIRMWARE\nVENDOR"
+            "CHANGE FIRM-\nWARE VENDOR"
         } else if version_cmp > 0 {
             "UPGRADE\nFIRMWARE"
         } else if version_cmp == 0 {
@@ -274,7 +274,7 @@ impl BootloaderUI for UIBolt {
         unwrap!(title_str.push_str(bld_version));
 
         let mut version_str: BootloaderString = String::new();
-        unwrap!(version_str.push_str("Firmware version "));
+        unwrap!(version_str.push_str("Firmware "));
         unwrap!(version_str.push_str(version));
         unwrap!(version_str.push_str("\nby "));
         unwrap!(version_str.push_str(vendor));

--- a/core/embed/rust/src/ui/layout_bolt/bootloader/mod.rs
+++ b/core/embed/rust/src/ui/layout_bolt/bootloader/mod.rs
@@ -198,15 +198,15 @@ impl BootloaderUI for UIBolt {
         unwrap!(version_str.push_str(vendor));
 
         let title_str = if is_newinstall {
-            "INSTALL FIRMWARE"
+            "INSTALL\nFIRMWARE"
         } else if is_newvendor {
-            "CHANGE FW\nVENDOR"
+            "CHANGE FIRMWARE\nVENDOR"
         } else if version_cmp > 0 {
-            "UPDATE FIRMWARE"
+            "UPGRADE\nFIRMWARE"
         } else if version_cmp == 0 {
-            "REINSTALL FW"
+            "REINSTALL\nFIRMWARE"
         } else {
-            "DOWNGRADE FW"
+            "DOWNGRADE\nFIRMWARE"
         };
         let title = Label::left_aligned(title_str.into(), TEXT_BOLD).vertically_centered();
         let msg = Label::left_aligned(version_str.as_str().into(), TEXT_NORMAL);
@@ -227,7 +227,7 @@ impl BootloaderUI for UIBolt {
 
         let mut frame = Confirm::new(BLD_BG, left, right, ConfirmTitle::Text(title), msg)
             .with_info(
-                "FW FINGERPRINT".into(),
+                "FIRMWARE\nFINGERPRINT".into(),
                 fingerprint.into(),
                 button_bld_menu(),
             );

--- a/core/embed/rust/src/ui/layout_bolt/bootloader/mod.rs
+++ b/core/embed/rust/src/ui/layout_bolt/bootloader/mod.rs
@@ -192,7 +192,7 @@ impl BootloaderUI for UIBolt {
         version_cmp: i32,
     ) -> u32 {
         let mut version_str: BootloaderString = String::new();
-        unwrap!(version_str.push_str("Firmware version "));
+        unwrap!(version_str.push_str("Firmware "));
         unwrap!(version_str.push_str(version));
         unwrap!(version_str.push_str("\nby "));
         unwrap!(version_str.push_str(vendor));
@@ -200,7 +200,7 @@ impl BootloaderUI for UIBolt {
         let title_str = if is_newinstall {
             "INSTALL\nFIRMWARE"
         } else if is_newvendor {
-            "CHANGE FIRMWARE\nVENDOR"
+            "CHANGE FIRM-\nWARE VENDOR"
         } else if version_cmp > 0 {
             "UPGRADE\nFIRMWARE"
         } else if version_cmp == 0 {
@@ -273,7 +273,7 @@ impl BootloaderUI for UIBolt {
         unwrap!(title_str.push_str(bld_version));
 
         let mut version_str: BootloaderString = String::new();
-        unwrap!(version_str.push_str("Firmware version "));
+        unwrap!(version_str.push_str("Firmware "));
         unwrap!(version_str.push_str(version));
         unwrap!(version_str.push_str("\nby "));
         unwrap!(version_str.push_str(vendor));

--- a/core/embed/rust/src/ui/layout_caesar/bootloader/mod.rs
+++ b/core/embed/rust/src/ui/layout_caesar/bootloader/mod.rs
@@ -154,13 +154,13 @@ impl BootloaderUI for UICaesar {
         let title_str = if is_newinstall {
             "INSTALL FIRMWARE"
         } else if is_newvendor {
-            "CHANGE FW VENDOR"
+            "CHANGE FIRMWARE VENDOR"
         } else if version_cmp > 0 {
-            "UPDATE FIRMWARE"
+            "UPGRADE FIRMWARE"
         } else if version_cmp == 0 {
-            "REINSTALL FW"
+            "REINSTALL FIRMWARE"
         } else {
-            "DOWNGRADE FW"
+            "DOWNGRADE FIRMWARE"
         };
 
         let message =
@@ -184,7 +184,7 @@ impl BootloaderUI for UICaesar {
             "INSTALL".into(),
             false,
         )
-        .with_info_screen("FW FINGERPRINT".into(), fingerprint);
+        .with_info_screen("FIRMWARE FINGERPRINT".into(), fingerprint);
 
         let (_, res) = run(&mut frame, true, false);
         res

--- a/core/embed/rust/src/ui/layout_caesar/bootloader/mod.rs
+++ b/core/embed/rust/src/ui/layout_caesar/bootloader/mod.rs
@@ -146,7 +146,7 @@ impl BootloaderUI for UICaesar {
         version_cmp: i32,
     ) -> u32 {
         let mut version_str: BootloaderString = String::new();
-        unwrap!(version_str.push_str("Firmware version "));
+        unwrap!(version_str.push_str("Firmware "));
         unwrap!(version_str.push_str(version));
         unwrap!(version_str.push_str("\nby "));
         unwrap!(version_str.push_str(vendor));
@@ -244,7 +244,7 @@ impl BootloaderUI for UICaesar {
         unwrap!(title_str.push_str(bld_version));
 
         let mut version_str: BootloaderString = String::new();
-        unwrap!(version_str.push_str("Firmware version "));
+        unwrap!(version_str.push_str("Firmware "));
         unwrap!(version_str.push_str(version));
         unwrap!(version_str.push_str("\nby "));
         unwrap!(version_str.push_str(vendor));

--- a/core/embed/rust/src/ui/layout_caesar/bootloader/mod.rs
+++ b/core/embed/rust/src/ui/layout_caesar/bootloader/mod.rs
@@ -152,13 +152,13 @@ impl BootloaderUI for UICaesar {
         let title_str = if is_newinstall {
             "INSTALL FIRMWARE"
         } else if is_newvendor {
-            "CHANGE FW VENDOR"
+            "CHANGE FIRMWARE VENDOR"
         } else if version_cmp > 0 {
-            "UPDATE FIRMWARE"
+            "UPGRADE FIRMWARE"
         } else if version_cmp == 0 {
-            "REINSTALL FW"
+            "REINSTALL FIRMWARE"
         } else {
-            "DOWNGRADE FW"
+            "DOWNGRADE FIRMWARE"
         };
 
         let message =
@@ -182,7 +182,7 @@ impl BootloaderUI for UICaesar {
             "INSTALL".into(),
             false,
         )
-        .with_info_screen("FW FINGERPRINT".into(), fingerprint);
+        .with_info_screen("FIRMWARE FINGERPRINT".into(), fingerprint);
 
         let (_, res) = run(&mut frame, true, false);
         res

--- a/core/embed/rust/src/ui/layout_caesar/bootloader/mod.rs
+++ b/core/embed/rust/src/ui/layout_caesar/bootloader/mod.rs
@@ -144,7 +144,7 @@ impl BootloaderUI for UICaesar {
         version_cmp: i32,
     ) -> u32 {
         let mut version_str: BootloaderString = String::new();
-        unwrap!(version_str.push_str("Firmware version "));
+        unwrap!(version_str.push_str("Firmware "));
         unwrap!(version_str.push_str(version));
         unwrap!(version_str.push_str("\nby "));
         unwrap!(version_str.push_str(vendor));
@@ -242,7 +242,7 @@ impl BootloaderUI for UICaesar {
         unwrap!(title_str.push_str(bld_version));
 
         let mut version_str: BootloaderString = String::new();
-        unwrap!(version_str.push_str("Firmware version "));
+        unwrap!(version_str.push_str("Firmware "));
         unwrap!(version_str.push_str(version));
         unwrap!(version_str.push_str("\nby "));
         unwrap!(version_str.push_str(vendor));

--- a/core/embed/rust/src/ui/layout_delizia/bootloader/mod.rs
+++ b/core/embed/rust/src/ui/layout_delizia/bootloader/mod.rs
@@ -194,15 +194,15 @@ impl BootloaderUI for UIDelizia {
         unwrap!(version_str.push_str(vendor));
 
         let title_str = if is_newinstall {
-            "INSTALL FW"
+            "INSTALL\nFIRMWARE"
         } else if is_newvendor {
-            "CHANGE FW\nVENDOR"
+            "CHANGE FIRMWARE\nVENDOR"
         } else if version_cmp > 0 {
-            "UPDATE FW"
+            "UPGRADE\nFIRMWARE"
         } else if version_cmp == 0 {
-            "REINSTALL FW"
+            "REINSTALL\nFIRMWARE"
         } else {
-            "DOWNGRADE FW"
+            "DOWNGRADE\nFIRMWARE"
         };
         let title = Label::left_aligned(title_str.into(), TEXT_BOLD).vertically_centered();
         let msg = Label::left_aligned(version_str.as_str().into(), TEXT_NORMAL);
@@ -231,7 +231,7 @@ impl BootloaderUI for UIDelizia {
 
         let mut frame = Confirm::new(BLD_BG, left, right, ConfirmTitle::Text(title), msg)
             .with_info(
-                "FW FINGERPRINT".into(),
+                "FIRMWARE\nFINGERPRINT".into(),
                 fingerprint.into(),
                 button_bld_menu(),
             );

--- a/core/embed/rust/src/ui/layout_delizia/bootloader/mod.rs
+++ b/core/embed/rust/src/ui/layout_delizia/bootloader/mod.rs
@@ -188,7 +188,7 @@ impl BootloaderUI for UIDelizia {
         version_cmp: i32,
     ) -> u32 {
         let mut version_str: BootloaderString = String::new();
-        unwrap!(version_str.push_str("Firmware version "));
+        unwrap!(version_str.push_str("Firmware "));
         unwrap!(version_str.push_str(version));
         unwrap!(version_str.push_str("\nby "));
         unwrap!(version_str.push_str(vendor));
@@ -196,7 +196,7 @@ impl BootloaderUI for UIDelizia {
         let title_str = if is_newinstall {
             "INSTALL\nFIRMWARE"
         } else if is_newvendor {
-            "CHANGE FIRMWARE\nVENDOR"
+            "CHANGE FIRM-\nWARE VENDOR"
         } else if version_cmp > 0 {
             "UPGRADE\nFIRMWARE"
         } else if version_cmp == 0 {
@@ -306,7 +306,7 @@ impl BootloaderUI for UIDelizia {
         unwrap!(title_str.push_str(bld_version));
 
         let mut version_str: BootloaderString = String::new();
-        unwrap!(version_str.push_str("Firmware version "));
+        unwrap!(version_str.push_str("Firmware "));
         unwrap!(version_str.push_str(version));
         unwrap!(version_str.push_str("\nby "));
         unwrap!(version_str.push_str(vendor));

--- a/core/embed/rust/src/ui/layout_delizia/bootloader/mod.rs
+++ b/core/embed/rust/src/ui/layout_delizia/bootloader/mod.rs
@@ -202,15 +202,15 @@ impl BootloaderUI for UIDelizia {
         let version_str = bld_string(&["Firmware version ", version, "\nby ", vendor]);
 
         let title_str = if is_newinstall {
-            "INSTALL FW"
+            "INSTALL\nFIRMWARE"
         } else if is_newvendor {
-            "CHANGE FW\nVENDOR"
+            "CHANGE FIRMWARE\nVENDOR"
         } else if version_cmp > 0 {
-            "UPDATE FW"
+            "UPGRADE\nFIRMWARE"
         } else if version_cmp == 0 {
-            "REINSTALL FW"
+            "REINSTALL\nFIRMWARE"
         } else {
-            "DOWNGRADE FW"
+            "DOWNGRADE\nFIRMWARE"
         };
         let title = Label::left_aligned(title_str.into(), TEXT_BOLD).vertically_centered();
         let msg = Label::left_aligned(version_str.as_str().into(), TEXT_NORMAL);
@@ -240,7 +240,7 @@ impl BootloaderUI for UIDelizia {
 
         let mut frame = Confirm::new(BLD_BG, left, right, ConfirmTitle::Text(title), msg)
             .with_info(
-                "FW FINGERPRINT".into(),
+                "FIRMWARE\nFINGERPRINT".into(),
                 fingerprint.into(),
                 button_bld_menu(),
             );

--- a/core/embed/rust/src/ui/layout_delizia/bootloader/mod.rs
+++ b/core/embed/rust/src/ui/layout_delizia/bootloader/mod.rs
@@ -204,7 +204,7 @@ impl BootloaderUI for UIDelizia {
         let title_str = if is_newinstall {
             "INSTALL\nFIRMWARE"
         } else if is_newvendor {
-            "CHANGE FIRMWARE\nVENDOR"
+            "CHANGE FIRM-\nWARE VENDOR"
         } else if version_cmp > 0 {
             "UPGRADE\nFIRMWARE"
         } else if version_cmp == 0 {

--- a/core/embed/rust/src/ui/layout_eckhart/ui_bootloader.rs
+++ b/core/embed/rust/src/ui/layout_eckhart/ui_bootloader.rs
@@ -183,15 +183,15 @@ impl BootloaderUI for UIEckhart {
         unwrap!(version_str.push_str(vendor));
 
         let title_str = if is_newinstall {
-            "Install firmware"
+            "Install Firmware"
         } else if is_newvendor {
-            "Change FW vendor"
+            "Change Firmware Vendor"
         } else if version_cmp > 0 {
-            "Update firmware"
+            "Upgrade Firmware"
         } else if version_cmp == 0 {
-            "Reinstall firmware"
+            "Reinstall Firmware"
         } else {
-            "Downgrade firmware"
+            "Downgrade Firmware"
         };
         let msg = Label::left_aligned(version_str.as_str().into(), TEXT_NORMAL);
         let alert = (!should_keep_seed).then_some(Label::left_aligned(
@@ -222,7 +222,7 @@ impl BootloaderUI for UIEckhart {
             .with_action_bar(BldActionBar::new_double(left, right))
             .with_screen_border(SCREEN_BORDER_BLUE)
             .with_more_info(
-                BldHeader::new("FW Fingerprint".into()).with_close_button(),
+                BldHeader::new("Firmware Fingerprint".into()).with_close_button(),
                 Label::left_aligned(fingerprint.into(), TEXT_FW_FINGERPRINT),
             );
 


### PR DESCRIPTION
- same wording for every operation
- same wording across layouts
- `FW` and `FIRMWARE` is not mixing anymore; it's always `FIRMWARE`
- it's `UPGRADE` now instead of `UPDATE`(to mirror `DOWNGRADE`)
- T3W1 uses proper title capitalization like `Change Firmware Vendor`
- with educated guessing `\n` is used so that no overflow into the info button happens
- shortened `Firmware version` to `Firmware` to fix issues with `SEED WILL BE ERASED!` not fitting