### PR TITLE
[WIP] feat(core): don't block indefinitely on `codec_v1` writes

### DIFF
--- a/core/src/trezor/wire/codec/codec_v1.py
+++ b/core/src/trezor/wire/codec/codec_v1.py
@@ -16,6 +16,10 @@ _REP_INIT = ">BBBHL"  # marker, magic, magic, wire type, data length
 _REP_INIT_DATA = const(9)  # offset of data in the initial report
 _REP_CONT_DATA = const(1)  # offset of data in the continuation report
 
+# Don't block indefinitely on writes send if the host is not reading from WebUSB.
+# Otherwise, the device may get stuck - while ignoring new messages from the host.
+_WRITE_TIMEOUT_MS = const(5000)
+
 
 class CodecError(WireError):
     pass
@@ -80,7 +84,7 @@ async def read_message(
 
 
 async def write_message(iface: WireInterface, mtype: int, mdata: AnyBytes) -> None:
-    write = loop.wait(iface.iface_num() | io.POLL_WRITE)
+    write = loop.wait(iface.iface_num() | io.POLL_WRITE, timeout_ms=_WRITE_TIMEOUT_MS)
 
     # gather data from msg
     msize = len(mdata)

--- a/core/tests/mock_wire_interface.py
+++ b/core/tests/mock_wire_interface.py
@@ -46,5 +46,5 @@ class MockHID:
             self.packet = None
             return read
 
-    def wait_object(self, mode):
-        return wait(mode | self.num)
+    def wait_object(self, mode: int, timeout_ms: int | None = None):
+        return wait(mode | self.num, timeout_ms)

--- a/core/tests/test_trezor.wire.codec.codec_v1.py
+++ b/core/tests/test_trezor.wire.codec.codec_v1.py
@@ -21,6 +21,10 @@ def make_header(mtype, length):
 class TestWireCodecV1(unittest.TestCase):
     def setUp(self):
         self.interface = MockHID()
+        self._wait_write = self.interface.wait_object(
+            io.POLL_WRITE, codec_v1._WRITE_TIMEOUT_MS
+        )
+        self._wait_read = self.interface.wait_object(io.POLL_READ)
 
     def test_read_one_packet(self):
         # zero length message - just a header
@@ -30,7 +34,7 @@ class TestWireCodecV1(unittest.TestCase):
         gen = codec_v1.read_message(self.interface, lambda: buffer)
 
         query = gen.send(None)
-        self.assertObjectEqual(query, self.interface.wait_object(io.POLL_READ))
+        self.assertObjectEqual(query, self._wait_read)
 
         with self.assertRaises(StopIteration) as e:
             self.interface.mock_read(message_packet, gen)
@@ -49,7 +53,7 @@ class TestWireCodecV1(unittest.TestCase):
         gen = codec_v1.read_message(self.interface, lambda: None)
 
         query = gen.send(None)
-        self.assertObjectEqual(query, self.interface.wait_object(io.POLL_READ))
+        self.assertObjectEqual(query, self._wait_read)
 
         with self.assertRaises(WireError):
             self.interface.mock_read(message_packet, gen)
@@ -71,7 +75,7 @@ class TestWireCodecV1(unittest.TestCase):
         gen = codec_v1.read_message(self.interface, lambda: buffer)
         query = gen.send(None)
         for packet in packets[:-1]:
-            self.assertObjectEqual(query, self.interface.wait_object(io.POLL_READ))
+            self.assertObjectEqual(query, self._wait_read)
             query = self.interface.mock_read(packet, gen)
 
         # last packet will stop
@@ -99,7 +103,7 @@ class TestWireCodecV1(unittest.TestCase):
 
         gen = codec_v1.read_message(self.interface, lambda: buffer)
         query = gen.send(None)
-        self.assertObjectEqual(query, self.interface.wait_object(io.POLL_READ))
+        self.assertObjectEqual(query, self._wait_read)
         with self.assertRaises(StopIteration) as e:
             self.interface.mock_read(packet, gen)
 
@@ -115,7 +119,7 @@ class TestWireCodecV1(unittest.TestCase):
         gen = codec_v1.write_message(self.interface, MESSAGE_TYPE, b"")
 
         query = gen.send(None)
-        self.assertObjectEqual(query, self.interface.wait_object(io.POLL_WRITE))
+        self.assertObjectEqual(query, self._wait_write)
         with self.assertRaises(StopIteration):
             gen.send(None)
 
@@ -140,7 +144,7 @@ class TestWireCodecV1(unittest.TestCase):
         for _ in packets:
             # we receive as many queries as there are packets
             query = gen.send(None)
-            self.assertObjectEqual(query, self.interface.wait_object(io.POLL_WRITE))
+            self.assertObjectEqual(query, self._wait_write)
 
         # the first sent None only started the generator. the len(packets)-th None
         # will finish writing and raise StopIteration
@@ -162,13 +166,13 @@ class TestWireCodecV1(unittest.TestCase):
         # exhaust the iterator:
         # (XXX we can only do this because the iterator is only accepting None and returns None)
         for query in gen:
-            self.assertObjectEqual(query, self.interface.wait_object(io.POLL_WRITE))
+            self.assertObjectEqual(query, self._wait_write)
 
         buffer = bytearray(1024)
         gen = codec_v1.read_message(self.interface, lambda: buffer)
         query = gen.send(None)
         for packet in self.interface.data[:-1]:
-            self.assertObjectEqual(query, self.interface.wait_object(io.POLL_READ))
+            self.assertObjectEqual(query, self._wait_read)
             query = self.interface.mock_read(packet, gen)
 
         with self.assertRaises(StopIteration) as e:
@@ -193,7 +197,7 @@ class TestWireCodecV1(unittest.TestCase):
 
         query = gen.send(None)
         for _ in range(PACKET_COUNT - 1):
-            self.assertObjectEqual(query, self.interface.wait_object(io.POLL_READ))
+            self.assertObjectEqual(query, self._wait_read)
             query = self.interface.mock_read(packet, gen)
 
         with self.assertRaises(codec_v1.CodecError) as e:

--- a/python/src/trezorlib/protocol_v1.py
+++ b/python/src/trezorlib/protocol_v1.py
@@ -388,7 +388,7 @@ def sync_responses(
     transport: Transport,
     *,
     mapping: ProtobufMapping = mapping.DEFAULT_MAPPING,
-    retries: int = 10,
+    _chunks_to_skip: int = 100,
 ) -> None:
     """Sync responses from the transport."""
     # cancel anything on screen -- on T1B1 this is the only way to exit e.g. a PIN prompt.
@@ -398,12 +398,15 @@ def sync_responses(
     # prepare an unique message to wait for
     sync_string = "SYNC" + secrets.token_hex(8)
     ping_msg = mapping.encode(messages.Ping(message=sync_string))
-    # prepare
     write(transport, *ping_msg)
 
-    for _ in range(retries):
-        resp_type, resp_bytes = read(transport, _ignore_bad_magic=True)
-        resp = mapping.decode(resp_type, resp_bytes)
-        if isinstance(resp, messages.Success) and resp.message == sync_string:
+    # response must fit into one chunk
+    resp_msg = mapping.encode(messages.Success(message=sync_string))
+    [expected_chunk] = _iter_chunks(*resp_msg, chunk_size=transport.CHUNK_SIZE)
+
+    for _ in range(_chunks_to_skip):
+        # skip chunks from previous responses
+        chunk = transport.read_chunk(timeout=client._DEFAULT_READ_TIMEOUT)
+        if expected_chunk == chunk:
             return
     raise exceptions.ProtocolError("Failed to sync responses")

--- a/python/src/trezorlib/protocol_v1.py
+++ b/python/src/trezorlib/protocol_v1.py
@@ -43,20 +43,30 @@ HEADER_FMT = ">HL"
 HEADER_LEN = struct.calcsize(HEADER_FMT)
 
 
-def write(transport: Transport, message_type: int, message_data: bytes) -> None:
-    """Write message bytes to transport, chunked according to protocol v1."""
-    chunk_size = transport.CHUNK_SIZE
+def _iter_chunks(
+    message_type: int,
+    message_data: bytes,
+    *,
+    chunk_size: int | None,
+) -> t.Generator[bytes, None, None]:
     header = struct.pack(HEADER_FMT, message_type, len(message_data))
 
     if chunk_size is None:
-        transport.write_chunk(header + message_data)
+        yield header + message_data
         return
 
     buffer = io.BytesIO(b"##" + header + message_data)
     while chunk_payload := buffer.read(chunk_size - 1):
         chunk = b"?" + chunk_payload
         # pad to chunk size
-        chunk = chunk.ljust(chunk_size, b"\x00")
+        yield chunk.ljust(chunk_size, b"\x00")
+
+
+def write(transport: Transport, message_type: int, message_data: bytes) -> None:
+    """Write message bytes to transport, chunked according to protocol v1."""
+    for chunk in _iter_chunks(
+        message_type, message_data, chunk_size=transport.CHUNK_SIZE
+    ):
         transport.write_chunk(chunk)
 
 

--- a/tests/device_tests/test_basic.py
+++ b/tests/device_tests/test_basic.py
@@ -91,6 +91,18 @@ def test_desync_v1(client: Client):
     get_client(client.app, client.transport).ping("reconnect")
 
 
+@pytest.mark.protocol("v1")
+@pytest.mark.models(skip="legacy")
+def test_unblock_v1(session: Session):
+    # The response is not read - the device write will block
+    session.write(messages.Ping(message="A" * 1000))
+    # After write timeout, the device will be responsive
+    session.test_ctx.sync_responses()
+    large_msg = "B" * 1000
+    resp = session.call(messages.Ping(message=large_msg), expect=messages.Success)
+    assert resp.message == large_msg
+
+
 @pytest.mark.models("eckhart")
 def test_get_features_avoids_restart(session: Session):
     debug = session.debug


### PR DESCRIPTION
Otherwise, the device will be stuck writing, and will not be reading host requests - which may result in a deadlock:
https://github.com/trezor/trezor-firmware/actions/runs/28064441070/job/83085601022
```
FAILED tests/device_tests/reset_recovery/test_reset_recovery_slip39_basic.py::test_reset_recovery[Display] - trezorlib.exceptions.ProtocolError: Missing chunk magic: 3f204e4f542055534521d80100e00100e80100f00101f00102f00103f00104f00105f00107f00109f0010bf0010cf0010df00118f0010ef0010ff00110f00111
ERROR tests/device_tests/reset_recovery/test_recovery_bip39_t2.py::test_tt_nopin_nopassphrase - Failed: Timeout (>600.0s) from pytest-timeout.
ERROR tests/device_tests/reset_recovery/test_recovery_bip39_t2.py::test_already_initialized - Failed: Timeout (>600.0s) from pytest-timeout.
ERROR tests/device_tests/reset_recovery/test_recovery_bip39_t2.py::test_tt_pin_passphrase - Failed: Timeout (>600.0s) from pytest-timeout.
ERROR tests/device_tests/cardano/test_address_public_key.py::test_cardano_get_address[True-parameters5-result5] - Failed: Timeout (>600.0s) from pytest-timeout.
ERROR tests/device_tests/cardano/test_address_public_key.py::test_cardano_get_address[True-parameters20-result20] - Failed: Timeout (>600.0s) from pytest-timeout.
ERROR tests/device_tests/cardano/test_address_public_key.py::test_cardano_get_address[False-parameters13-result13] - Failed: Timeout (>600.0s) from pytest-timeout.
ERROR tests/device_tests/cardano/test_address_public_key.py::test_cardano_get_address[False-parameters24-result24] - Failed: Timeout (>600.0s) from pytest-timeout.
ERROR tests/device_tests/cardano/test_address_public_key.py::test_cardano_get_address[True-parameters16-result16] - Failed: Timeout (>600.0s) from pytest-timeout.
ERROR tests/device_tests/cardano/test_address_public_key.py::test_cardano_get_address[True-parameters7-result7] - Failed: Timeout (>600.0s) from pytest-timeout.
ERROR tests/device_tests/cardano/test_address_public_key.py::test_cardano_get_address[True-parameters6-result6] - Failed: Timeout (>600.0s) from pytest-timeout.
ERROR tests/device_tests/cardano/test_address_public_key.py::test_cardano_get_address[True-ledger-derivation] - Failed: Timeout (>600.0s) from pytest-timeout
```

Similar mechanism is also used in THP:
https://github.com/trezor/trezor-firmware/blob/01aa1bffd2c45fec406025122b7db4b2aefc2066/core/src/trezor/wire/thp/interface_context.py#L33-L36

Following https://github.com/trezor/trezor-firmware/issues/7184 - CI HW tests experiencing sporadic packet loss, getting stuck and eventually timing out.

- [x] add a device test