### PR TITLE
test(core): don't fail codec_v1 `sync_responses()` on unexpected magic

### DIFF
--- a/python/src/trezorlib/protocol_v1.py
+++ b/python/src/trezorlib/protocol_v1.py
@@ -392,7 +392,7 @@ def sync_responses(
     write(transport, *ping_msg)
 
     for _ in range(retries):
-        resp_type, resp_bytes = read(transport)
+        resp_type, resp_bytes = read(transport, _ignore_bad_magic=True)
         resp = mapping.decode(resp_type, resp_bytes)
         if isinstance(resp, messages.Success) and resp.message == sync_string:
             return

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -358,8 +358,10 @@ def _prepared_test_ctx(
     try:
         _raw_test_ctx.sync_responses()
     except Exception:
-        request.session.shouldstop = "Failed to communicate with Trezor"
-        pytest.fail("Failed to communicate with Trezor")
+        msg = "Failed to communicate with Trezor"
+        LOG.exception(msg)
+        request.session.shouldstop = msg
+        pytest.fail(msg)
 
     # Use DebugLink to wipe (since THP channel requires unlocked device)
     _raw_test_ctx.wipe_device()


### PR DESCRIPTION
Otherwise, pytest's session will be unnecessarily stopped:
https://github.com/trezor/trezor-firmware/actions/runs/28702783301/job/85123464184
https://github.com/trezor/trezor-firmware/blob/3c61e237eac801626e3b8b89504c638210c8ade2/tests/conftest.py#L357-L364

Also, log the exception's traceback.

Following https://github.com/trezor/trezor-firmware/issues/7184 - CI HW tests experiencing sporadic packet loss, getting stuck and eventually timing out.
