### PR TITLE
chore(xtask): build prodtest emulator with tropic enabled by default

### DIFF
--- a/core/embed/xtask/src/feature_resolver.rs
+++ b/core/embed/xtask/src/feature_resolver.rs
@@ -159,7 +159,8 @@ pub fn resolve_features(args: &BuildArgs) -> Result<ResolvedBuild> {
     if args.disable_optiga {
         board_feat.retain(|f| f != "optiga");
     }
-    if args.disable_tropic.unwrap_or(args.emulator) {
+    let default_disable_tropic = args.emulator && args.project != Project::Prodtest;
+    if args.disable_tropic.unwrap_or(default_disable_tropic) {
         board_feat.retain(|f| f != "tropic");
     }
     features.extend(board_feat);


### PR DESCRIPTION
The prodtest emulator should be built with tropic enabled by default.