### PR TITLE
Tests: replace repeated xfail/suppresion by decorators

### DIFF
--- a/tests/REGISTERED_MARKERS
+++ b/tests/REGISTERED_MARKERS
@@ -18,4 +18,5 @@ solana
 stellar
 tezos
 tron
+xfail_if_no_optiga
 zcash

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -397,6 +397,11 @@ def _prepared_test_ctx(
     if request.node.get_closest_marker("altcoin") and is_btc_only:
         pytest.skip("Skipping altcoin test")
 
+    # Optiga's presence is detected from the presence of its security counter.
+    has_optiga = _raw_test_ctx.features.optiga_sec is not None
+    if request.node.get_closest_marker("xfail_if_no_optiga") and not has_optiga:
+        pytest.xfail("Optiga is not available on this device.")
+
     _check_protocol(request, _raw_test_ctx)
 
     sd_marker = request.node.get_closest_marker("sd_card")

--- a/tests/device_tests/evolu/test_sign_registration.py
+++ b/tests/device_tests/evolu/test_sign_registration.py
@@ -27,11 +27,6 @@ def signing_buffer(
     return b"".join((compact_size(len(comp)) + comp) for comp in components)
 
 
-def optiga_unavailable(client: Client) -> bool:
-    """Check if Optiga is unavailable from the presence of its security counter."""
-    return client.features.optiga_sec is None
-
-
 @pytest.mark.models("t2t1")
 def test_evolu_sign_request_t2t1(client: Client):
     challenge = bytes.fromhex("1234")
@@ -53,9 +48,8 @@ def test_evolu_sign_request_t2t1(client: Client):
 
 
 @pytest.mark.models("safe")
+@pytest.mark.xfail_if_no_optiga
 def test_evolu_sign_request(client: Client):
-    if optiga_unavailable(client):
-        pytest.xfail("Optiga is not available on this device.")
     delegated_identity_key = get_delegated_identity_key(client).private_key
     challenge = bytes.fromhex("1234")
     size = 10
@@ -81,9 +75,8 @@ def test_evolu_sign_request(client: Client):
 
 
 @pytest.mark.models("safe")
+@pytest.mark.xfail_if_no_optiga
 def test_evolu_sign_request_invalid_proof(client: Client):
-    if optiga_unavailable(client):
-        pytest.xfail("Optiga is not available on this device.")
     challenge = bytes.fromhex("1234")
     size = 10
     invalid_proof = get_invalid_proof(
@@ -103,9 +96,8 @@ def test_evolu_sign_request_invalid_proof(client: Client):
 
 
 @pytest.mark.models("safe")
+@pytest.mark.xfail_if_no_optiga
 def test_evolu_sign_request_challenge_too_long(client: Client):
-    if optiga_unavailable(client):
-        pytest.xfail("Optiga is not available on this device.")
     challenge = b"\x01" * 300  # 300 bytes, max is 255
     size = 10
     proof = get_proof(
@@ -125,9 +117,8 @@ def test_evolu_sign_request_challenge_too_long(client: Client):
 
 
 @pytest.mark.models("safe")
+@pytest.mark.xfail_if_no_optiga
 def test_evolu_sign_request_challenge_too_short(client: Client):
-    if optiga_unavailable(client):
-        pytest.xfail("Optiga is not available on this device.")
     challenge = b""  # 0 bytes, minimum is 1
     size = 10
     proof = get_proof(
@@ -147,9 +138,8 @@ def test_evolu_sign_request_challenge_too_short(client: Client):
 
 
 @pytest.mark.models("safe")
+@pytest.mark.xfail_if_no_optiga
 def test_evolu_sign_request_size_too_small(client: Client):
-    if optiga_unavailable(client):
-        pytest.xfail("Optiga is not available on this device.")
     challenge = bytes.fromhex("1234")
     size = -10
     proof = get_proof(
@@ -171,9 +161,8 @@ def test_evolu_sign_request_size_too_small(client: Client):
 
 
 @pytest.mark.models("safe")
+@pytest.mark.xfail_if_no_optiga
 def test_evolu_sign_request_size_too_large(client: Client):
-    if optiga_unavailable(client):
-        pytest.xfail("Optiga is not available on this device.")
     challenge = bytes.fromhex("1234")
     size = 0xFFFFFFFF + 1
     proof = get_proof(
@@ -193,9 +182,8 @@ def test_evolu_sign_request_size_too_large(client: Client):
 
 
 @pytest.mark.models("safe")
+@pytest.mark.xfail_if_no_optiga
 def test_evolu_sign_request_data_higher_bound(client: Client):
-    if optiga_unavailable(client):
-        pytest.xfail("Optiga is not available on this device.")
     delegated_identity_key = get_delegated_identity_key(client).private_key
     challenge = b"\x12" * 255
     size = 0xFFFFFFFF
@@ -222,12 +210,10 @@ def test_evolu_sign_request_data_higher_bound(client: Client):
 
 @pytest.mark.models("safe")
 @pytest.mark.parametrize("rotation_index", [None, 0, 1, 2, 42])
+@pytest.mark.xfail_if_no_optiga
 def test_evolu_sign_request_with_different_rotation_indices(
     client: Client, rotation_index
 ):
-    if optiga_unavailable(client):
-        pytest.xfail("Optiga is not available on this device.")
-
     evolu.index_management(client.get_session(), rotation_index=rotation_index)
     delegated_identity_key = get_delegated_identity_key(client).private_key
     challenge = bytes.fromhex("1234")

--- a/tests/device_tests/thp/test_pairing.py
+++ b/tests/device_tests/thp/test_pairing.py
@@ -37,6 +37,10 @@ MT = t.TypeVar("MT", bound=protobuf.MessageType)
 
 pytestmark = [pytest.mark.protocol("thp")]
 
+ignore_ephemeral_keypair_warning = pytest.mark.filterwarnings(
+    "ignore:One of ephemeral keypairs is already set. This is OK for testing, but should NEVER happen in production!"
+)
+
 
 @contextmanager
 def deterministic_secrets() -> t.Generator[None, None, None]:
@@ -73,9 +77,7 @@ def test_pairing_qr_code(test_ctx: TrezorTestContext) -> None:
     pairing.finish()
 
 
-@pytest.mark.filterwarnings(
-    "ignore:One of ephemeral keypairs is already set. This is OK for testing, but should NEVER happen in production!"
-)
+@ignore_ephemeral_keypair_warning
 @deterministic_secrets()
 def test_pairing_code_entry(test_ctx: TrezorTestContext) -> None:
     pairing = prepare_channel_for_pairing(test_ctx, fixed_entropy=True)
@@ -92,9 +94,7 @@ def test_pairing_code_entry(test_ctx: TrezorTestContext) -> None:
     pairing.finish()
 
 
-@pytest.mark.filterwarnings(
-    "ignore:One of ephemeral keypairs is already set. This is OK for testing, but should NEVER happen in production!"
-)
+@ignore_ephemeral_keypair_warning
 @deterministic_secrets()
 def test_pairing_code_entry_invalid_cpace_key(test_ctx: TrezorTestContext) -> None:
     pairing = prepare_channel_for_pairing(test_ctx, fixed_entropy=True)
@@ -117,9 +117,7 @@ def test_pairing_code_entry_invalid_cpace_key(test_ctx: TrezorTestContext) -> No
         method.send_code(code_str)
 
 
-@pytest.mark.filterwarnings(
-    "ignore:One of ephemeral keypairs is already set. This is OK for testing, but should NEVER happen in production!"
-)
+@ignore_ephemeral_keypair_warning
 @deterministic_secrets()
 def test_pairing_code_entry_invalid_cpace_key_length(
     test_ctx: TrezorTestContext,
@@ -145,9 +143,7 @@ def test_pairing_code_entry_invalid_cpace_key_length(
         method.send_code(code_str)
 
 
-@pytest.mark.filterwarnings(
-    "ignore:One of ephemeral keypairs is already set. This is OK for testing, but should NEVER happen in production!"
-)
+@ignore_ephemeral_keypair_warning
 @deterministic_secrets()
 def test_pairing_code_entry_cancel(test_ctx: TrezorTestContext) -> None:
     pairing = prepare_channel_for_pairing(test_ctx, fixed_entropy=True)


### PR DESCRIPTION
- Replaced repeated "optiga xfail" in `evolu/test_sign_registration` by a decorator.
- Replaced repeated ephemeral key warning suppression in `thp/test-pairing` by marker alias.



### Evolu - optiga xfail

The Evolu tests pass when optiga is enabled, and xfail when optiga is disabled:

```
xtask build firmware -e -m t3w1 --pyopt false
pytest tests/device_tests/evolu/test_sign_registration.py 

tests/device_tests/evolu/test_sign_registration.py .....s.......

=== 12 passed, 1 skipped in 49.78s ===
```

```
xtask build firmware -e -m t3w1 --pyopt false --disable-optiga
pytest tests/device_tests/evolu/test_sign_registration.py 

tests/device_tests/evolu/test_sign_registration.py xxxxxsxxxxxxx

=== 1 skipped, 12 xfailed in 12.43s ===
```

### THP - ephemeral key warning

The THP device tests have the warning suppressed.


```
pytest tests/device_tests/thp/test_pairing.py 

tests/device_tests/thp/test_pairing.py .............x

=== 13 passed, 1 xfailed in 60.04s (0:01:00) ===

[NO WARNINGS]
```