### PR TITLE
ci(core): increase individual test timeout for upgrade tests

### DIFF
--- a/.github/workflows/core.yml
+++ b/.github/workflows/core.yml
@@ -417,7 +417,7 @@ jobs:
         model: [T2T1, T3W1]
         asan: ${{ fromJSON(needs.param.outputs.asan) }}
     env:
-      PYTEST_TIMEOUT: 60
+      PYTEST_TIMEOUT: 70
       TESTOPTS: "--durations 10"
     timeout-minutes: 20
     steps:


### PR DESCRIPTION
T2T1 upgrade tests are timing out often lately, let's see if it helps

<!--
For external contributors:
- Please open an issue before submitting a PR so we can discuss whether we want to proceed with it.

For core developers:
1. Initial PR setup
- Assign yourself to the PR.
- Add it to the "Firmware" project
  - Set Priority (match issue priority if it exists)
  - Set Team
  - Set Sprint (target release)

2. Development status
- Draft PRs: Set status to "In Progress"
- Final PRs: Set status to "Needs Review"

3. Post-merge status
- Testable: Set status to "Needs QA" and add a `Notes for QA` section with clear instructions on how to test the functionality.
- Not Testable: Set status to "Done (no QA)"
-->
