### PR TITLE
fix(core/caesar): remove count limit in confirm_properties

### DIFF
--- a/core/embed/rust/src/ui/layout_caesar/theme/mod.rs
+++ b/core/embed/rust/src/ui/layout_caesar/theme/mod.rs
@@ -97,7 +97,9 @@ include_icon!(ICON_WARNING, "layout_caesar/res/warning.toif"); // 11*12
 include_icon!(ICON_WARN_TITLE, "layout_caesar/res/bld_header_warn.toif");
 
 // props settings
-pub const PROP_INNER_SPACING: i16 = PARAGRAPH_BOTTOM_SPACE;
+// Smaller than the default paragraph spacing so that 4 lines
+// (2 key:value pairs) fit on the same screen
+pub const PROP_INNER_SPACING: i16 = 2;
 pub const PROPS_SPACING: i16 = PARAGRAPH_BOTTOM_SPACE;
 pub const PROPS_KEY_FONT: TextStyle = TEXT_BOLD;
 pub const PROPS_VALUE_FONT: TextStyle = TEXT_MONO;

--- a/core/embed/rust/src/ui/layout_caesar/ui_firmware.rs
+++ b/core/embed/rust/src/ui/layout_caesar/ui_firmware.rs
@@ -22,7 +22,7 @@ use crate::{
         geometry,
         layout::{
             obj::{LayoutMaybeTrace, LayoutObj, RootComponent},
-            util::{ConfirmValueParams, RecoveryType},
+            util::{ConfirmValueParams, PropsList, RecoveryType},
         },
         notification::Notification,
         ui_firmware::{
@@ -439,7 +439,7 @@ impl FirmwareUI for UICaesar {
         verb: Option<TString<'static>>,
         external_menu: bool,
     ) -> Result<impl LayoutMaybeTrace, Error> {
-        let paragraphs = parse_properties(items)?;
+        let paragraphs = PropsList::new(items)?;
 
         let button_text = verb.unwrap_or(if hold {
             TR::buttons__hold_to_confirm.into()
@@ -1566,20 +1566,4 @@ fn add_paragraphs<'a>(
         };
         paragraphs.add(Paragraph::new(style, value));
     }
-}
-
-fn parse_properties(items: Obj) -> Result<ParagraphVecLong<'static>, Error> {
-    let mut paragraphs = ParagraphVecLong::new();
-
-    for para in IterBuf::new().try_iterate(items)? {
-        let [key, value, is_data]: [Obj; 3] = util::iter_into_array(para)?;
-        add_paragraphs(
-            &mut paragraphs,
-            key.try_into_option()?,
-            value.try_into_option()?,
-            is_data.try_into()?,
-        );
-    }
-
-    Ok(paragraphs)
 }


### PR DESCRIPTION
Properties were eagerly parsed into a fixed-capacity ParagraphVecLong (36 paragraphs, i.e. 18 key-value pairs), which panicked in debug builds and silently truncated the list in production when exceeded. Use the lazy PropsList paragraph source instead, as in the other layouts. PROP_INNER_SPACING is set to 2 px to match the key-value spacing hardcoded in the add_paragraphs helper, so rendering is unchanged.

[no changelog]

<!--
For external contributors:
- Please open an issue before submitting a PR so we can discuss whether we want to proceed with it.

For core developers:
1. Initial PR setup
- Assign yourself to the PR.
- Add it to the "Firmware" project
  - Set Priority (match issue priority if it exists)
  - Set Team
  - Set Sprint (target release)

2. Development status
- Draft PRs: Set status to "In Progress"
- Final PRs: Set status to "Needs Review"

3. Post-merge status
- Testable: Set status to "Needs QA" and add a `Notes for QA` section with clear instructions on how to test the functionality.
- Not Testable: Set status to "Done (no QA)"
-->
