### PR TITLE
test(core): wait for `Cancel` response before sending `Ping`

### DIFF
--- a/python/src/trezorlib/debuglink.py
+++ b/python/src/trezorlib/debuglink.py
@@ -1392,6 +1392,8 @@ class TrezorTestContext:
         self.debug.model = self.model = self.client.model
         self.layout_type = self.debug.layout_type
         self.is_emulator = self.features.fw_vendor == "EMULATOR"
+        # Optiga's presence is detected from the presence of its security counter.
+        self.has_optiga = self.features.optiga_sec is not None
 
     def _get_client(self) -> client.TrezorClient:
         if self.protocol_version is ProtocolVersion.V1:

--- a/python/src/trezorlib/protocol_v1.py
+++ b/python/src/trezorlib/protocol_v1.py
@@ -381,19 +381,22 @@ def sync_responses(
     retries: int = 10,
 ) -> None:
     """Sync responses from the transport."""
+
+    def _call(msg: MessageType, is_expected: t.Callable[[MessageType], bool]) -> None:
+        write(transport, *mapping.encode(msg))
+        for _ in range(retries):
+            resp_type, resp_bytes = read(transport, _ignore_bad_magic=True)
+            resp = mapping.decode(resp_type, resp_bytes)
+            if is_expected(resp):
+                return
+        raise exceptions.ProtocolError("Failed to sync responses")
+
     # cancel anything on screen -- on T1B1 this is the only way to exit e.g. a PIN prompt.
-    cancel_msg = mapping.encode(messages.Cancel())
-    write(transport, *cancel_msg)
+    _call(messages.Cancel(), lambda msg: isinstance(msg, messages.Failure))
 
     # prepare an unique message to wait for
     sync_string = "SYNC" + secrets.token_hex(8)
-    ping_msg = mapping.encode(messages.Ping(message=sync_string))
-    # prepare
-    write(transport, *ping_msg)
-
-    for _ in range(retries):
-        resp_type, resp_bytes = read(transport, _ignore_bad_magic=True)
-        resp = mapping.decode(resp_type, resp_bytes)
-        if isinstance(resp, messages.Success) and resp.message == sync_string:
-            return
-    raise exceptions.ProtocolError("Failed to sync responses")
+    _call(
+        messages.Ping(message=sync_string),
+        lambda msg: isinstance(msg, messages.Success) and msg.message == sync_string,
+    )

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -386,6 +386,7 @@ def _prepared_test_ctx(
 
     @pytest.mark.experimental
     """
+    # Early exit, if the test cannot be run:
     models_filter = ModelsFilter(request.node)
     if _raw_test_ctx.model not in models_filter:
         pytest.skip(f"Skipping test for model {_raw_test_ctx.model.internal_name}")
@@ -397,9 +398,10 @@ def _prepared_test_ctx(
     if request.node.get_closest_marker("altcoin") and is_btc_only:
         pytest.skip("Skipping altcoin test")
 
-    # Optiga's presence is detected from the presence of its security counter.
-    has_optiga = _raw_test_ctx.features.optiga_sec is not None
-    if request.node.get_closest_marker("xfail_if_no_optiga") and not has_optiga:
+    if (
+        request.node.get_closest_marker("xfail_if_no_optiga")
+        and not _raw_test_ctx.has_optiga
+    ):
         pytest.xfail("Optiga is not available on this device.")
 
     _check_protocol(request, _raw_test_ctx)
@@ -414,6 +416,7 @@ def _prepared_test_ctx(
 
     fail_on_gc_leak = not request.config.getoption("ignore_gc_leak")
 
+    # First, make sure the device is responsive:
     _raw_test_ctx.reset_debug_features()
     try:
         _raw_test_ctx.sync_responses()


### PR DESCRIPTION
Otherwise, we may get stuck when using USB transport - if the device is stuck sending, and not reading new messages from the host, the first write may get stuck - and the test will deadlock.

Also, check Optiga presence once per test session (and not on each test case) - we should first run `sync_responses()` to avoid getting stuck if the previous test failed due to a packet loss (i.e. `Missing chunk magic`).