### PR TITLE
chore: bump project versions

### DIFF
--- a/core/embed/projects/firmware/version.h
+++ b/core/embed/projects/firmware/version.h
@@ -4,7 +4,7 @@
 
 #define VERSION_MAJOR 2
 #define VERSION_MINOR 12
-#define VERSION_PATCH 2
+#define VERSION_PATCH 3
 #define VERSION_BUILD 0
 
 #define FIX_VERSION_MAJOR 2

--- a/core/embed/projects/prodtest/error_codes.json
+++ b/core/embed/projects/prodtest/error_codes.json
@@ -1,6 +1,6 @@
 {
   "source": "prodtest_error_codes.h",
-  "prodtest_version": "0.3.8.0",
+  "prodtest_version": "0.3.9.0",
   "framework_codes": [
     {
       "code": 10,

--- a/core/embed/projects/prodtest/version.h
+++ b/core/embed/projects/prodtest/version.h
@@ -4,7 +4,7 @@
 
 #define VERSION_MAJOR 0
 #define VERSION_MINOR 3
-#define VERSION_PATCH 8
+#define VERSION_PATCH 9
 #define VERSION_BUILD 0
 
 #define FIX_VERSION_MAJOR 0

--- a/core/embed/projects/secmon/version.h
+++ b/core/embed/projects/secmon/version.h
@@ -4,5 +4,5 @@
 
 #define VERSION_MAJOR 1
 #define VERSION_MINOR 0
-#define VERSION_PATCH 12
+#define VERSION_PATCH 13
 #define VERSION_BUILD 0

--- a/core/translations/cs.json
+++ b/core/translations/cs.json
@@ -33,7 +33,7 @@
   },
   "header": {
     "language": "cs-CZ",
-    "version": "2.12.2"
+    "version": "2.12.3"
   },
   "translations": {
     "addr_mismatch__contact_support_at": "Kontaktujte naši podporu na",

--- a/core/translations/de.json
+++ b/core/translations/de.json
@@ -33,7 +33,7 @@
   },
   "header": {
     "language": "de-DE",
-    "version": "2.12.2"
+    "version": "2.12.3"
   },
   "translations": {
     "addr_mismatch__contact_support_at": "Kontaktiere den Trezor Support unter",

--- a/core/translations/en.json
+++ b/core/translations/en.json
@@ -1,7 +1,7 @@
 {
   "header": {
     "language": "en-US",
-    "version": "2.12.2"
+    "version": "2.12.3"
   },
   "translations": {
     "addr_mismatch__contact_support_at": "Please contact Trezor support at",

--- a/core/translations/es.json
+++ b/core/translations/es.json
@@ -33,7 +33,7 @@
   },
   "header": {
     "language": "es-ES",
-    "version": "2.12.2"
+    "version": "2.12.3"
   },
   "translations": {
     "addr_mismatch__contact_support_at": "Contacta con atención al cliente de Trezor en",

--- a/core/translations/fr.json
+++ b/core/translations/fr.json
@@ -33,7 +33,7 @@
   },
   "header": {
     "language": "fr-FR",
-    "version": "2.12.2"
+    "version": "2.12.3"
   },
   "translations": {
     "addr_mismatch__contact_support_at": {

--- a/core/translations/pt.json
+++ b/core/translations/pt.json
@@ -33,7 +33,7 @@
   },
   "header": {
     "language": "pt-BR",
-    "version": "2.12.2"
+    "version": "2.12.3"
   },
   "translations": {
     "addr_mismatch__contact_support_at": "Entre em contato com o suporte Trezor em",

--- a/core/translations/signatures.json
+++ b/core/translations/signatures.json
@@ -1,8 +1,8 @@
 {
   "current": {
-    "merkle_root": "57f304271b6774f246b56393be88b28401a9c2a4ecbf638e51157b2818253ea7",
-    "datetime": "2026-07-02T15:53:10.642360+00:00",
-    "commit": "d0435b0b74927b3ac6e925f7def292cfcb3bbeb0"
+    "merkle_root": "1ccbe437b4b90e3184e537e64c3284f7c29ec06358d1378b443e24836373fb18",
+    "datetime": "2026-07-13T11:41:30.654995+00:00",
+    "commit": "b235e018c03c13eaddf718aa052e2ce3f9f1f014"
   },
   "history": [
     {


### PR DESCRIPTION
core 2.12.3
secmon 1.0.13
prodtest 0.3.9

```
./tools/bump-version.py core 2.12.3
./tools/bump-version.py core/embed/projects/secmon 1.0.13
./tools/bump-version.py core/embed/projects/prodtest/ 0.3.9
make gen
```