### PR TITLE
fix(stellar): properly bound string length

### DIFF
--- a/core/src/apps/stellar/operations/serialize.py
+++ b/core/src/apps/stellar/operations/serialize.py
@@ -73,9 +73,9 @@ def write_create_passive_sell_offer_op(
 
 
 def write_manage_data_op(w: Writer, msg: StellarManageDataOp) -> None:
-    if len(msg.key) > 64:
+    written = write_string(w, msg.key)
+    if written > 64:
         raise ProcessError("Stellar: max length of a key is 64 bytes")
-    write_string(w, msg.key)
     write_bool(w, bool(msg.value))
     if msg.value:
         write_string(w, msg.value)
@@ -165,9 +165,9 @@ def write_set_options_op(w: Writer, msg: StellarSetOptionsOp) -> None:
         write_bool(w, False)
     else:
         write_bool(w, True)
-        if len(msg.home_domain) > 32:
+        written = write_string(w, msg.home_domain)
+        if written > 32:
             raise ProcessError("Stellar: max length of a home domain is 32 bytes")
-        write_string(w, msg.home_domain)
 
     # signer
     if msg.signer_type is None:

--- a/core/src/apps/stellar/sign_tx.py
+++ b/core/src/apps/stellar/sign_tx.py
@@ -87,9 +87,9 @@ async def sign_tx(msg: StellarSignTx, keychain: Slip21Keychain) -> StellarSigned
         # Text: 4 bytes (size) + up to 28 bytes
         if memo_text is None:
             raise DataError("Stellar: Missing memo text")
-        if len(memo_text) > 28:
+        written = writers.write_string(w, memo_text)
+        if written > 28:
             raise ProcessError("Stellar: max length of a memo text is 28 bytes")
-        writers.write_string(w, memo_text)
         memo_confirm_text = memo_text
     elif memo_type == StellarMemoType.ID:
         # ID: 64 bit unsigned integer

--- a/core/src/apps/stellar/writers.py
+++ b/core/src/apps/stellar/writers.py
@@ -13,8 +13,10 @@ if TYPE_CHECKING:
     from trezor.utils import Writer
 
 
-def write_string(w: Writer, s: StrOrBytes) -> None:
-    """Write XDR string padded to a multiple of 4 bytes."""
+def write_string(w: Writer, s: StrOrBytes) -> int:
+    """Write XDR string padded to a multiple of 4 bytes.
+    Returns the length of the string written to the buffer (without padding).
+    """
     # NOTE: 2 bytes smaller than if-else
     buf = s.encode() if isinstance(s, str) else s
     write_uint32(w, len(buf))
@@ -23,6 +25,7 @@ def write_string(w: Writer, s: StrOrBytes) -> None:
     remainder = len(buf) % 4
     if remainder:
         writers.write_bytes_unchecked(w, bytes([0] * (4 - remainder)))
+    return len(buf)
 
 
 def write_bool(w: Writer, val: bool) -> None:


### PR DESCRIPTION
Currently, the length of all bounded strings is checked using `len(str)`. This returns the number of Unicode code points. However, the XDR spec defines `string object<m>` as a sequence of at most `m` bytes, see https://datatracker.ietf.org/doc/html/rfc4506#section-4.11. A single Unicode code point can consist of multiple bytes.

[no changelog]

<!--
For external contributors:
- Please open an issue before submitting a PR so we can discuss whether we want to proceed with it.

For core developers:
1. Initial PR setup
- Assign yourself to the PR.
- Add it to the "Firmware" project
  - Set Priority (match issue priority if it exists)
  - Set Team
  - Set Sprint (target release)

2. Development status
- Draft PRs: Set status to "In Progress"
- Final PRs: Set status to "Needs Review"

3. Post-merge status
- Testable: Set status to "Needs QA" and add a `Notes for QA` section with clear instructions on how to test the functionality.
- Not Testable: Set status to "Done (no QA)"
-->
