### PR TITLE
chore(core/ethereum): drop EIP-7702 delegation support for now

### DIFF
--- a/common/tests/fixtures/ethereum/sign_tx.json
+++ b/common/tests/fixtures/ethereum/sign_tx.json
@@ -196,27 +196,6 @@
             }
         },
         {
-            "name": "EIP-7702 - Uniswap",
-            "skip_models": ["t1"],
-            "parameters": {
-                    "safety_checks": false,
-                    "data": "",
-                    "path": "m/44'/60'/0'/0/1",
-                    "to_address": "0x000000009B1D0aF20D8C6d0A44e162d11F9b8f00",
-                    "chain_id": 1,
-                    "nonce": "0x0",
-                    "gas_price": "0x14",
-                    "gas_limit": "0x14",
-                    "tx_type": 4,
-                    "value": "0x0"
-            },
-            "result": {
-                    "sig_v": 37,
-                    "sig_r": "869433a7e19c05d9beb0f223d18fb27c6fb6a1817d60b38144f249237b27a36d",
-                    "sig_s": "1379434319ea9953d6632cf54d8b2ec09c8d0d6fb932c530b67f0c03a318af57"
-            }
-        },
-        {
             "name": "deposit_known_vault",
             "skip_models": ["t1"],
             "parameters": {

--- a/common/tests/fixtures/ethereum/sign_tx_error.json
+++ b/common/tests/fixtures/ethereum/sign_tx_error.json
@@ -5,48 +5,6 @@
     },
     "tests": [
         {
-            "name": "EIP-7702 - Uniswap - fails because we have safety checks",
-            "skip_models": ["t1"],
-            "parameters": {
-                    "safety_checks": true,
-                    "data": "",
-                    "path": "m/44'/60'/0'/0/1",
-                    "to_address": "0x000000009B1D0aF20D8C6d0A44e162d11F9b8f00",
-                    "chain_id": 1,
-                    "nonce": "0x0",
-                    "gas_price": "0x14",
-                    "gas_limit": "0x14",
-                    "tx_type": 4,
-                    "value": "0x0"
-            },
-            "result": {
-                    "sig_v": 0,
-                    "sig_r": "0x0",
-                    "sig_s": "0x0"
-            }
-        },
-        {
-            "name": "EIP-7702 - unknown address - safety checks disabled but still fails",
-            "skip_models": ["t1"],
-            "parameters": {
-                    "safety_checks": false,
-                    "data": "",
-                    "path": "m/44'/60'/0'/0/1",
-                    "to_address": "0xfc6b5d6af8a13258f7cbd0d39e11b35e01a32f93",
-                    "chain_id": 1,
-                    "nonce": "0x0",
-                    "gas_price": "0x14",
-                    "gas_limit": "0x14",
-                    "tx_type": 4,
-                    "value": "0x0"
-            },
-            "result": {
-                    "sig_v": 0,
-                    "sig_r": "0x0",
-                    "sig_s": "0x0"
-            }
-        },
-        {
             "name": "vault_deposit_with_eth",
             "skip_models": ["t1"],
             "parameters": {

--- a/core/src/apps/ethereum/sign_tx.py
+++ b/core/src/apps/ethereum/sign_tx.py
@@ -1,6 +1,5 @@
 from micropython import const
 from typing import TYPE_CHECKING
-from ubinascii import unhexlify
 
 from trezor import TR
 from trezor.crypto import rlp
@@ -36,20 +35,6 @@ if TYPE_CHECKING:
 # the full value: v = 2 * chain_id + 35 + v_bit
 _MAX_CHAIN_ID = const(0xFFFF_FFFF - 36) // 2
 
-# EIP-7702
-
-_EIP_7702_TX_TYPE = const(4)
-EIP_7702_KNOWN_ADDRESSES = {
-    unhexlify("000000009B1D0aF20D8C6d0A44e162d11F9b8f00"): "Uniswap",
-    unhexlify("69007702764179f14F51cdce752f4f775d74E139"): "alchemyplatform",
-    unhexlify("5A7FC11397E9a8AD41BF10bf13F22B0a63f96f6d"): "AmbireTech",
-    unhexlify("63c0c19a282a1b52b07dd5a65b58948a07dae32b"): "MetaMask",
-    unhexlify(
-        "4Cd241E8d1510e30b2076397afc7508Ae59C66c9"
-    ): "Ethereum Foundation AA team",
-    unhexlify("17c11FDdADac2b341F2455aFe988fec4c3ba26e3"): "Luganodes",
-}
-
 
 @with_keychain_from_chain_id
 async def sign_tx(
@@ -61,7 +46,7 @@ async def sign_tx(
     from trezor.ui.layouts import show_continue_in_app
     from trezor.utils import HashWriter
 
-    from apps.common import paths, safety_checks
+    from apps.common import paths
 
     from .helpers import format_ethereum_amount, get_fee_items_regular
 
@@ -74,14 +59,9 @@ async def sign_tx(
 
     address_bytes = bytes_from_address(msg.to)
 
-    valid_tx_types = (1, 6, _EIP_7702_TX_TYPE, None)
+    valid_tx_types = (1, 6, None)
     if tx_type not in valid_tx_types:
         raise DataError("tx_type out of bounds")
-    if tx_type == _EIP_7702_TX_TYPE:
-        if safety_checks.is_strict():
-            raise DataError("EIP-7702 not allowed in strict checks")
-        if address_bytes not in EIP_7702_KNOWN_ADDRESSES:
-            raise DataError("Unknown EIP-7702 address")
     if len(msg.gas_price) + len(msg.gas_limit) > 30:
         raise DataError("Fee overflow")
 
@@ -124,7 +104,6 @@ async def sign_tx(
         initial_data,
         msg,
         defs,
-        tx_type,
         address_bytes,
         maximum_fee,
         fee_items,
@@ -218,7 +197,6 @@ async def confirm_tx_data(
     initial_data: AnyBytes,
     msg: MsgInSignTx,
     defs: Definitions,
-    tx_type: int | None,
     address_bytes: bytes,
     maximum_fee: str,
     fee_items: Sequence[StrPropertyType],
@@ -227,8 +205,6 @@ async def confirm_tx_data(
 ) -> tuple[ConfirmDataFn | None, Coroutine[Any, Any, None] | None]:
     """Returns data chunk callback and transaction summary layout to be awaited.
     [None, None] implies clear signing attempted and succeeded."""
-
-    from trezor.ui.layouts import confirm_value
 
     from . import clear_signing, staking, yielding
     from .helpers import format_ethereum_amount
@@ -253,16 +229,6 @@ async def confirm_tx_data(
         if payment_request_verifier is not None:
             raise DataError("Payment Requests don't support yielding")
         return yielding_approver
-
-    if tx_type == _EIP_7702_TX_TYPE:
-        # we have already made sure that the address is a known address
-        # as part of the initial validation
-        await confirm_value(
-            TR.ethereum__eip_7702_title,
-            EIP_7702_KNOWN_ADDRESSES[address_bytes],
-            TR.ethereum__eip_7702,
-            "confirm_provider",
-        )
 
     value = int.from_bytes(msg.value, "big")
 
@@ -332,7 +298,7 @@ async def confirm_tx_data(
             maximum_fee,
             fee_items,
             token,
-            is_send=(data_length == 0 and tx_type != _EIP_7702_TX_TYPE),
+            is_send=(data_length == 0),
             chunkify=bool(msg.chunkify),
         )
     else:

--- a/core/src/apps/ethereum/sign_tx_eip1559.py
+++ b/core/src/apps/ethereum/sign_tx_eip1559.py
@@ -109,7 +109,6 @@ async def sign_tx_eip1559(
         initial_data,
         msg,
         defs,
-        None,
         address_bytes,
         maximum_fee,
         fee_items,

--- a/tests/device_tests/ethereum/test_signtx.py
+++ b/tests/device_tests/ethereum/test_signtx.py
@@ -21,7 +21,7 @@ from itertools import product
 
 import pytest
 
-from trezorlib import device, ethereum, exceptions, messages, models
+from trezorlib import ethereum, exceptions, messages, models
 from trezorlib.debuglink import DebugSession as Session
 from trezorlib.debuglink import message_filters
 from trezorlib.exceptions import TrezorFailure
@@ -76,11 +76,6 @@ def test_signtx(session: Session, chunkify: bool, parameters: dict, result: dict
         if not session.debug.legacy_debug
         else None
     )
-
-    if not parameters.get("safety_checks", True):
-        device.apply_settings(
-            session, safety_checks=messages.SafetyCheckLevel.PromptTemporarily
-        )
 
     _do_test_signtx(session, parameters, result, input_flow, chunkify=chunkify)
 
@@ -558,11 +553,6 @@ def test_signtx_staking(
     "ethereum/sign_tx_error.json",
 )
 def test_signtx_error(session: Session, parameters: dict, result: dict):
-    if not parameters.get("safety_checks", True):
-        device.apply_settings(
-            session, safety_checks=messages.SafetyCheckLevel.PromptTemporarily
-        )
-
     # result not needed
     with pytest.raises(TrezorFailure, match=r"DataError"):
         ethereum.sign_tx(


### PR DESCRIPTION
Splitting #6983 into smaller PRs.

Reverts 307d601abe4ad0d3cd80b3fffab9ab3f7f80f085 functionality:
https://github.com/trezor/trezor-firmware/blob/c434e6a5b32bc8fc84fdcf9701f5b219ef3a44ee/core/src/apps/ethereum/sign_tx.py#L255

Will be re-added after EIP-7702 authorization is implemented.
