### PR TITLE
fix(xbuild): emit raw deflate for embedded binaries

### DIFF
--- a/core/embed/xbuild/src/clibrary/embed.rs
+++ b/core/embed/xbuild/src/clibrary/embed.rs
@@ -105,7 +105,13 @@ impl CLibrary {
 
         let mut data_out = vec![0u8; compress_bound(data_in.len())];
 
-        let config = DeflateConfig::best_compression();
+        let config = DeflateConfig {
+            // < 0 => raw deflate stream (no zlib header)
+            // -10 => 1KB window
+            window_bits: -10,
+            ..DeflateConfig::best_compression()
+        };
+
         let (compressed, code) = compress_slice(&mut data_out, &data_in, config);
 
         ensure!(


### PR DESCRIPTION
This PR fixes a bug introduced by the new build system. Compressed binaries embedded in the firmware (the bootloader on all models except TS7) were compressed with incorrect settings, preventing the firmware from decompressing them.

As a result, firmware upgrades failed on models that required a bootloader update (RSOD screen with error at boot_image.c:110)

The `uzlib_decompress()` function used to decompress the bootloader requires a raw default stream (without zlib headers) and a 10-bit window size. This fix configures the compression with the correct settings.

All models except TS7 are affected.

