### PR TITLE
fix(core): don't drop layout objects after `draw_simple()`

### DIFF
--- a/core/embed/rust/src/ui/api/firmware_micropython.rs
+++ b/core/embed/rust/src/ui/api/firmware_micropython.rs
@@ -2137,7 +2137,7 @@ pub static mp_module_trezorui_api: Module = obj_module! {
     ///     text: str,
     ///     title: str | None = None,
     ///     button: str | None = None,
-    /// ) -> LayoutContext[UiResult]:
+    /// ) -> LayoutObj[UiResult]:
     ///     """Simple dialog with text. TT: optional button."""
     Qstr::MP_QSTR_show_simple => obj_fn_kw!(0, new_show_simple).as_obj(),
 
@@ -2152,7 +2152,7 @@ pub static mp_module_trezorui_api: Module = obj_module! {
     ///     """Success modal. No buttons shown when `button` is empty string."""
     Qstr::MP_QSTR_show_success => obj_fn_kw!(0, new_show_success).as_obj(),
 
-    /// def show_wait_text(message: str, /) -> LayoutContext[None]:
+    /// def show_wait_text(message: str, /) -> LayoutObj[None]:
     ///     """Show single-line text in the middle of the screen."""
     Qstr::MP_QSTR_show_wait_text => obj_fn_1!(new_show_wait_text).as_obj(),
 

--- a/core/mocks/generated/trezorui_api.pyi
+++ b/core/mocks/generated/trezorui_api.pyi
@@ -811,7 +811,7 @@ def show_simple(
     text: str,
     title: str | None = None,
     button: str | None = None,
-) -> LayoutContext[UiResult]:
+) -> LayoutObj[UiResult]:
     """Simple dialog with text. TT: optional button."""
 
 
@@ -828,7 +828,7 @@ def show_success(
 
 
 # rust/src/ui/api/firmware_micropython.rs
-def show_wait_text(message: str, /) -> LayoutContext[None]:
+def show_wait_text(message: str, /) -> LayoutObj[None]:
     """Show single-line text in the middle of the screen."""
 
 

--- a/core/src/trezor/ui/layouts/bolt/__init__.py
+++ b/core/src/trezor/ui/layouts/bolt/__init__.py
@@ -2189,15 +2189,11 @@ def error_popup(
 
 
 def request_passphrase_on_host() -> None:
-    with trezorui_api.show_simple(
-        title=None, text=TR.passphrase__please_enter
-    ) as layout:
-        draw_simple(layout)
+    draw_simple(trezorui_api.show_simple(title=None, text=TR.passphrase__please_enter))
 
 
 def show_wait_text(message: str) -> None:
-    with trezorui_api.show_wait_text(message) as layout:
-        draw_simple(layout)
+    draw_simple(trezorui_api.show_wait_text(message))
 
 
 async def request_passphrase_on_device(max_len: int) -> str:

--- a/core/src/trezor/ui/layouts/caesar/__init__.py
+++ b/core/src/trezor/ui/layouts/caesar/__init__.py
@@ -2227,15 +2227,11 @@ def error_popup(
 
 
 def request_passphrase_on_host() -> None:
-    with trezorui_api.show_simple(
-        title=None, text=TR.passphrase__please_enter
-    ) as layout:
-        draw_simple(layout)
+    draw_simple(trezorui_api.show_simple(title=None, text=TR.passphrase__please_enter))
 
 
 def show_wait_text(message: str) -> None:
-    with trezorui_api.show_wait_text(message) as layout:
-        draw_simple(layout)
+    draw_simple(trezorui_api.show_wait_text(message))
 
 
 async def request_passphrase_on_device(max_len: int) -> str:

--- a/core/src/trezor/ui/layouts/common.py
+++ b/core/src/trezor/ui/layouts/common.py
@@ -153,4 +153,7 @@ async def confirm_linear_flow(
 
 
 def draw_simple(layout: trezorui_api.LayoutObj[Any]) -> None:
+    # IMPORTANT: after this call, `layout` is referenced by `trezor.ui.CURRENT_LAYOUT`
+    # and its event-handling tasks are still running. Therefore, it MUST NOT be dropped,
+    # until a new layout is started.
     ui.Layout(layout).start()

--- a/core/src/trezor/ui/layouts/delizia/__init__.py
+++ b/core/src/trezor/ui/layouts/delizia/__init__.py
@@ -2184,15 +2184,11 @@ def error_popup(
 
 
 def request_passphrase_on_host() -> None:
-    with trezorui_api.show_simple(
-        title=None, text=TR.passphrase__please_enter
-    ) as layout:
-        draw_simple(layout)
+    draw_simple(trezorui_api.show_simple(title=None, text=TR.passphrase__please_enter))
 
 
 def show_wait_text(message: str) -> None:
-    with trezorui_api.show_wait_text(message) as layout:
-        draw_simple(layout)
+    draw_simple(trezorui_api.show_wait_text(message))
 
 
 async def request_passphrase_on_device(max_len: int) -> str:

--- a/core/src/trezor/ui/layouts/eckhart/__init__.py
+++ b/core/src/trezor/ui/layouts/eckhart/__init__.py
@@ -2306,15 +2306,11 @@ def error_popup(
 
 
 def request_passphrase_on_host() -> None:
-    with trezorui_api.show_simple(
-        title=None, text=TR.passphrase__please_enter
-    ) as layout:
-        draw_simple(layout)
+    draw_simple(trezorui_api.show_simple(title=None, text=TR.passphrase__please_enter))
 
 
 def show_wait_text(message: str) -> None:
-    with trezorui_api.show_wait_text(message) as layout:
-        draw_simple(layout)
+    draw_simple(trezorui_api.show_wait_text(message))
 
 
 async def request_passphrase_on_device(max_len: int) -> str:


### PR DESCRIPTION
After `draw_simple()` is called, `layout` is still referenced by `trezor.ui.CURRENT_LAYOUT` and its event-handling tasks are still running.

Therefore, it MUST NOT be dropped, until a new layout is started.

Related discussion: https://satoshilabs.slack.com/archives/C054XGU77QV/p1783955433273839

This issue has been introduced in https://github.com/trezor/trezor-firmware/pull/7058.