### PR TITLE
chore(core): drop unused `trezorui_api.show_wait_text()`

### DIFF
--- a/core/embed/rust/librust_qstr.h
+++ b/core/embed/rust/librust_qstr.h
@@ -868,7 +868,6 @@ static void _librust_qstrs(void) {
   MP_QSTR_show_simple;
   MP_QSTR_show_success;
   MP_QSTR_show_thp_pairing_code;
-  MP_QSTR_show_wait_text;
   MP_QSTR_show_warning;
   MP_QSTR_sign;
   MP_QSTR_sign_message__bytes_template;

--- a/core/embed/rust/src/ui/api/firmware_micropython.rs
+++ b/core/embed/rust/src/ui/api/firmware_micropython.rs
@@ -1263,17 +1263,6 @@ extern "C" fn new_show_success(n_args: usize, args: *const Obj, kwargs: *mut Map
     unsafe { util::try_with_args_and_kwargs(n_args, args, kwargs, block) }
 }
 
-extern "C" fn new_show_wait_text(message: Obj) -> Obj {
-    let block = || {
-        let message: TString<'static> = message.try_into()?;
-
-        let layout = ModelUI::show_wait_text(message)?;
-        Ok(LayoutObj::new_root(layout)?.into())
-    };
-
-    unsafe { util::try_or_raise(block) }
-}
-
 extern "C" fn new_show_warning(n_args: usize, args: *const Obj, kwargs: *mut Map) -> Obj {
     let block = move |_args: &[Obj], kwargs: &Map| {
         let title: Option<TString> = kwargs.get(Qstr::MP_QSTR_title)?.try_into_option()?;
@@ -2151,10 +2140,6 @@ pub static mp_module_trezorui_api: Module = obj_module! {
     /// ) -> LayoutContext[UiResult]:
     ///     """Success modal. No buttons shown when `button` is empty string."""
     Qstr::MP_QSTR_show_success => obj_fn_kw!(0, new_show_success).as_obj(),
-
-    /// def show_wait_text(message: str, /) -> LayoutObj[None]:
-    ///     """Show single-line text in the middle of the screen."""
-    Qstr::MP_QSTR_show_wait_text => obj_fn_1!(new_show_wait_text).as_obj(),
 
     /// def show_warning(
     ///     *,

--- a/core/embed/rust/src/ui/layout_bolt/ui_firmware.rs
+++ b/core/embed/rust/src/ui/layout_bolt/ui_firmware.rs
@@ -1265,12 +1265,6 @@ impl FirmwareUI for UIBolt {
         )
     }
 
-    fn show_wait_text(text: TString<'static>) -> Result<impl LayoutMaybeTrace, Error> {
-        Ok(RootComponent::new(
-            Paragraph::new(&theme::TEXT_NORMAL, text).into_paragraphs(),
-        ))
-    }
-
     fn show_warning(
         title: Option<TString<'static>>,
         button: TString<'static>,

--- a/core/embed/rust/src/ui/layout_caesar/ui_firmware.rs
+++ b/core/embed/rust/src/ui/layout_caesar/ui_firmware.rs
@@ -1362,12 +1362,6 @@ impl FirmwareUI for UICaesar {
         Err::<Gc<LayoutObj>, Error>(Error::NotImplementedError)
     }
 
-    fn show_wait_text(text: TString<'static>) -> Result<impl LayoutMaybeTrace, Error> {
-        Ok(RootComponent::new(
-            Paragraph::new(&theme::TEXT_NORMAL, text).into_paragraphs(),
-        ))
-    }
-
     fn show_warning(
         title: Option<TString<'static>>,
         button: TString<'static>,

--- a/core/embed/rust/src/ui/layout_delizia/ui_firmware.rs
+++ b/core/embed/rust/src/ui/layout_delizia/ui_firmware.rs
@@ -1227,12 +1227,6 @@ impl FirmwareUI for UIDelizia {
         Ok(layout)
     }
 
-    fn show_wait_text(text: TString<'static>) -> Result<impl LayoutMaybeTrace, Error> {
-        Ok(RootComponent::new(
-            Paragraph::new(&theme::TEXT_DEMIBOLD, text).into_paragraphs(),
-        ))
-    }
-
     fn show_warning(
         title: Option<TString<'static>>,
         button: TString<'static>,

--- a/core/embed/rust/src/ui/layout_eckhart/ui_firmware.rs
+++ b/core/embed/rust/src/ui/layout_eckhart/ui_firmware.rs
@@ -1542,15 +1542,6 @@ impl FirmwareUI for UIEckhart {
         Ok(layout)
     }
 
-    fn show_wait_text(text: TString<'static>) -> Result<impl LayoutMaybeTrace, Error> {
-        let paragraphs = Paragraph::new(&theme::TEXT_REGULAR, text)
-            .into_paragraphs()
-            .with_placement(LinearPlacement::vertical());
-        let screen = TextScreen::new(paragraphs);
-        let layout = RootComponent::new(screen);
-        Ok(layout)
-    }
-
     fn show_warning(
         title: Option<TString<'static>>,
         button: TString<'static>,

--- a/core/embed/rust/src/ui/ui_firmware.rs
+++ b/core/embed/rust/src/ui/ui_firmware.rs
@@ -462,8 +462,6 @@ pub trait FirmwareUI {
         time_ms: u32,
     ) -> Result<Gc<LayoutObj>, Error>; // TODO: return LayoutMaybeTrace
 
-    fn show_wait_text(text: TString<'static>) -> Result<impl LayoutMaybeTrace, Error>;
-
     fn show_warning(
         title: Option<TString<'static>>,
         button: TString<'static>,

--- a/core/mocks/generated/trezorui_api.pyi
+++ b/core/mocks/generated/trezorui_api.pyi
@@ -828,11 +828,6 @@ def show_success(
 
 
 # rust/src/ui/api/firmware_micropython.rs
-def show_wait_text(message: str, /) -> LayoutObj[None]:
-    """Show single-line text in the middle of the screen."""
-
-
-# rust/src/ui/api/firmware_micropython.rs
 def show_warning(
     *,
     title: str | None,

--- a/core/src/trezor/ui/layouts/bolt/__init__.py
+++ b/core/src/trezor/ui/layouts/bolt/__init__.py
@@ -2192,10 +2192,6 @@ def request_passphrase_on_host() -> None:
     draw_simple(trezorui_api.show_simple(title=None, text=TR.passphrase__please_enter))
 
 
-def show_wait_text(message: str) -> None:
-    draw_simple(trezorui_api.show_wait_text(message))
-
-
 async def request_passphrase_on_device(max_len: int) -> str:
     with trezorui_api.request_passphrase(
         prompt=TR.passphrase__title_enter,

--- a/core/src/trezor/ui/layouts/caesar/__init__.py
+++ b/core/src/trezor/ui/layouts/caesar/__init__.py
@@ -2230,10 +2230,6 @@ def request_passphrase_on_host() -> None:
     draw_simple(trezorui_api.show_simple(title=None, text=TR.passphrase__please_enter))
 
 
-def show_wait_text(message: str) -> None:
-    draw_simple(trezorui_api.show_wait_text(message))
-
-
 async def request_passphrase_on_device(max_len: int) -> str:
     with trezorui_api.request_passphrase(
         prompt=TR.passphrase__title_enter,

--- a/core/src/trezor/ui/layouts/delizia/__init__.py
+++ b/core/src/trezor/ui/layouts/delizia/__init__.py
@@ -2187,10 +2187,6 @@ def request_passphrase_on_host() -> None:
     draw_simple(trezorui_api.show_simple(title=None, text=TR.passphrase__please_enter))
 
 
-def show_wait_text(message: str) -> None:
-    draw_simple(trezorui_api.show_wait_text(message))
-
-
 async def request_passphrase_on_device(max_len: int) -> str:
     with trezorui_api.request_passphrase(
         prompt=TR.passphrase__title_enter,

--- a/core/src/trezor/ui/layouts/eckhart/__init__.py
+++ b/core/src/trezor/ui/layouts/eckhart/__init__.py
@@ -2309,10 +2309,6 @@ def request_passphrase_on_host() -> None:
     draw_simple(trezorui_api.show_simple(title=None, text=TR.passphrase__please_enter))
 
 
-def show_wait_text(message: str) -> None:
-    draw_simple(trezorui_api.show_wait_text(message))
-
-
 async def request_passphrase_on_device(max_len: int) -> str:
     with trezorui_api.request_passphrase(
         prompt=TR.passphrase__title_enter,


### PR DESCRIPTION
Found during #7282.