### PR TITLE
fix(xbuild): fix incremental build of upydef files

### DIFF
--- a/common/tools/cointool.py
+++ b/common/tools/cointool.py
@@ -160,10 +160,7 @@ DEBUG_PREFIXES = ("debug",)
 def render_file(
     src: Path, dst: Path, coins: CoinsInfo, support_info: SupportInfo, models: list[str]
 ) -> None:
-    """Renders `src` template into `dst`.
-
-    `src` is a filename, `dst` is an open file object.
-    """
+    """Renders `src` template into `dst`."""
     template = mako.template.Template(filename=str(src.resolve()))
     eth_defs_date = datetime.datetime.fromisoformat(
         DEFINITIONS_TIMESTAMP_PATH.read_text().strip()
@@ -181,9 +178,14 @@ def render_file(
         **MAKO_FILTERS,
         ALL_MODELS=models,
     )
-    dst.write_text(str(result))
-    src_stat = src.stat()
-    os.utime(dst, ns=(src_stat.st_atime_ns, src_stat.st_mtime_ns))
+
+    try:
+        orig_content = dst.read_text()
+    except FileNotFoundError:
+        orig_content = None
+
+    if orig_content != str(result):
+        dst.write_text(str(result))
 
 
 # ====== validation functions ======
@@ -869,7 +871,7 @@ def dump(
 # fmt: on
 def render(
     paths: tuple[Path, ...],
-    outfile: Path,
+    outfile: Path | None,
     verbose: bool,
     bitcoin_only: bool,
     model_exclude: tuple[str, ...],

--- a/core/embed/xbuild/src/clibrary/compile.rs
+++ b/core/embed/xbuild/src/clibrary/compile.rs
@@ -150,10 +150,9 @@ impl CLibrary {
             let output = derive_output_path(&base_dir, &src, &out_dir, output_type.extension());
 
             // Only generate .d files for object files compiled from C/C++ sources
-            let cc_dep = if matches!(output_type, OutputType::Object)
-                && src
-                    .extension()
-                    .is_some_and(|ext| ext == "c" || ext == "cpp" || ext == "cc")
+            let cc_dep = if src
+                .extension()
+                .is_some_and(|ext| ext == "c" || ext == "cpp" || ext == "cc")
             {
                 Some(output.with_extension("d"))
             } else {


### PR DESCRIPTION
This PR fixes incremental builds for upydef files. It ensures that `qstrs_generated.h` and `qstr.rs` are automatically regenerated whenever qstr definitions are added, removed, or modified anywhere in the codebase.

Previously, upydef files were not automatically rebuilt when any of the header files they depended on changed.

Additionally, `cointool.py` has been updated to refresh the output file's timestamp only when its contents have changed.
