### PR TITLE
Set `Features.language_version_matches` to true even if `build_version` differs

### DIFF
--- a/core/src/apps/base.py
+++ b/core/src/apps/base.py
@@ -63,7 +63,7 @@ def _language_version_matches() -> bool:
     if header is None:
         return True
 
-    return header.version == utils.VERSION
+    return header.version[:3] == utils.VERSION[:3]
 
 
 def get_features() -> Features:

--- a/python/src/trezorlib/testing/translations.py
+++ b/python/src/trezorlib/testing/translations.py
@@ -50,7 +50,7 @@ _CURRENT_TRANSLATION = threading.local()
 def prepare_blob(
     lang_or_def: translations.JsonDef | Path | str,
     model: models.TrezorModel,
-    version: translations.VersionTuple | tuple[int, int, int] | None = None,
+    version: translations.VersionTuple | None = None,
 ) -> translations.TranslationsBlob:
     """
     Prepare a translation blob for a given language and device model.
@@ -72,9 +72,6 @@ def prepare_blob(
     # generate raw blob
     if version is None:
         version = translations.version_from_json(lang_or_def["header"]["version"])
-    elif len(version) == 3:
-        # version coming from client object does not have build item
-        version = *version, 0
     return translations.blob_from_defs(lang_or_def, order, model, version, FONTS_DIR)
 
 
@@ -113,7 +110,9 @@ def build_and_sign_blob(
     Returns:
         bytes: The signed translation blob.
     """
-    blob = prepare_blob(lang_or_def, session.model, session.version)
+    f = session.client.features
+    version = (f.major_version, f.minor_version, f.patch_version, f.build_version or 0)
+    blob = prepare_blob(lang_or_def, session.model, version)
     return sign_blob(blob)
 
 

--- a/tests/device_tests/test_language.py
+++ b/tests/device_tests/test_language.py
@@ -60,6 +60,11 @@ def get_ping_title(lang: str) -> str:
     return content["translations"]["words__confirm"]
 
 
+def get_version(session: Session) -> tuple[int, int, int, int]:
+    f = session.client.features
+    return (f.major_version, f.minor_version, f.patch_version, f.build_version)
+
+
 @pytest.fixture
 def client(client: Client) -> Iterator[Client]:
     session = client.get_seedless_session()
@@ -201,7 +206,7 @@ def test_error_invalid_signature(session: Session):
         pytest.raises(exceptions.TrezorFailure, match="Invalid translations data"),
         session.test_ctx,
     ):
-        blob = prepare_blob("cs", session.model, session.version)
+        blob = prepare_blob("cs", session.model, get_version(session))
         blob.proof = translations.Proof(
             merkle_proof=[],
             sigmask=0b011,
@@ -243,18 +248,19 @@ def test_build_version_mismatch(session: Session):
     assert session.features.language == "en-US"
     # Translations build version is allowed to differ from FW build version.
     # Change the build version to one not matching the current device
-    version = session.version
-    assert len(session.version) == 3
-    version = version + (1,)
-    blob = prepare_blob("cs", session.model, version)
+    cur_version = get_version(session)
+    bumped_version = cur_version[:3] + (cur_version[3] + 1,)
+    blob = prepare_blob("cs", session.model, bumped_version)
     device.change_language(
         session,
         language_data=sign_blob(blob),
     )
     assert session.features.language == "cs-CZ"
+    assert session.features.language_version_matches is True
     _check_ping_screen_texts(
         session, get_ping_title("cs"), get_ping_button("cs", session.client)
     )
+    # Would be nice to test lower build_version but firmware's is usually 0 and hard to change
 
 
 def test_language_is_removed_after_wipe(client: Client):
@@ -460,7 +466,7 @@ def test_header_trailing_data(session: Session):
 
     assert session.features.language == "en-US"
     lang = "cs"
-    blob = prepare_blob(lang, session.model, session.version)
+    blob = prepare_blob(lang, session.model, get_version(session))
     blob.header_bytes += b"trailing dataa"
     assert len(blob.header_bytes) % 2 == 0, "Trailing data must keep the 2-alignment"
     language_data = sign_blob(blob)


### PR DESCRIPTION
`test_full_language_change` fails on firmware that has `VERSION_BUILD` != 0. While this is a test issue it raises question how translations with different build versions should be handled wrt `Features.language_version_matches`:

1. set to True if entire version matches, including build version (current state)
2. ***set to True if major, minor, patch version match (this PR)***
3. set to True if major, minor, patch version match and firmware_build_version <= translation_build_version

Related: #6234

<!--
For external contributors:
- Please open an issue before submitting a PR so we can discuss whether we want to proceed with it.

For core developers:
1. Initial PR setup
- Assign yourself to the PR.
- Add it to the "Firmware" project
  - Set Priority (match issue priority if it exists)
  - Set Team
  - Set Sprint (target release)

2. Development status
- Draft PRs: Set status to "In Progress"
- Final PRs: Set status to "Needs Review"

3. Post-merge status
- Testable: Set status to "Needs QA" and add a `Notes for QA` section with clear instructions on how to test the functionality.
- Not Testable: Set status to "Done (no QA)"
-->
