### PR TITLE
fix(core/bolt): do not use untraslated strings

### DIFF
--- a/core/embed/rust/src/ui/layout_bolt/component/number_input_slider.rs
+++ b/core/embed/rust/src/ui/layout_bolt/component/number_input_slider.rs
@@ -27,10 +27,8 @@ impl NumberInputSliderDialog {
         Self {
             area: Rect::zero(),
             input: NumberInputSlider::new(min, max, init_value).into_child(),
-            cancel_button: Button::with_text("CANCEL".into())
-                .styled(theme::button_cancel())
-                .into_child(),
-            confirm_button: Button::with_text("CONFIRM".into())
+            cancel_button: Button::with_icon(theme::ICON_CANCEL).into_child(),
+            confirm_button: Button::with_icon(theme::ICON_CONFIRM)
                 .styled(theme::button_confirm())
                 .into_child(),
         }


### PR DESCRIPTION
- use icon buttons of untranslated texts in Bolt set brightness dialog

fixes https://github.com/trezor/trezor-firmware/issues/7258

<img width="398" height="632" alt="image" src="https://github.com/user-attachments/assets/5d7f2de7-c9c9-4551-ab2e-42e6b1b90a65" />

<!--
For external contributors:
- Please open an issue before submitting a PR so we can discuss whether we want to proceed with it.

For core developers:
1. Initial PR setup
- Assign yourself to the PR.
- Add it to the "Firmware" project
  - Set Priority (match issue priority if it exists)
  - Set Team
  - Set Sprint (target release)

2. Development status
- Draft PRs: Set status to "In Progress"
- Final PRs: Set status to "Needs Review"

3. Post-merge status
- Testable: Set status to "Needs QA" and add a `Notes for QA` section with clear instructions on how to test the functionality.
- Not Testable: Set status to "Done (no QA)"
-->
