### PR TITLE
fix(core): re-implement `draw_simple()` to avoid scoping violations

### DIFF
--- a/core/embed/rust/src/ui/api/firmware_micropython.rs
+++ b/core/embed/rust/src/ui/api/firmware_micropython.rs
@@ -2117,7 +2117,7 @@ pub static mp_module_trezorui_api: Module = obj_module! {
     ///     text: str,
     ///     title: str | None = None,
     ///     button: str | None = None,
-    /// ) -> LayoutObj[UiResult]:
+    /// ) -> LayoutContext[UiResult]:
     ///     """Simple dialog with text. TT: optional button."""
     Qstr::MP_QSTR_show_simple => obj_fn_kw!(0, new_show_simple).as_obj(),
 

--- a/core/mocks/generated/trezorui_api.pyi
+++ b/core/mocks/generated/trezorui_api.pyi
@@ -811,7 +811,7 @@ def show_simple(
     text: str,
     title: str | None = None,
     button: str | None = None,
-) -> LayoutObj[UiResult]:
+) -> LayoutContext[UiResult]:
     """Simple dialog with text. TT: optional button."""
 
 

--- a/core/src/apps/common/passphrase.py
+++ b/core/src/apps/common/passphrase.py
@@ -101,7 +101,7 @@ if not utils.USE_THP:
 
         async def _delay_request_passphrase_on_host() -> None:
             await loop.sleep(100)
-            return request_passphrase_on_host()
+            await request_passphrase_on_host()
 
         on_host = workflow.spawn(_delay_request_passphrase_on_host())
         try:

--- a/core/src/apps/webauthn/fido2.py
+++ b/core/src/apps/webauthn/fido2.py
@@ -8,8 +8,7 @@ import storage.device as storage_device
 from trezor import TR, config, io, log, loop, utils, wire, workflow
 from trezor.crypto import hashlib
 from trezor.crypto.curve import nist256p1
-from trezor.ui import Layout
-from trezor.ui.layouts import error_popup
+from trezor.ui.layouts import error_popup, interact_simple
 
 from apps.common import cbor
 from apps.common.lock_manager import set_homescreen
@@ -638,7 +637,7 @@ async def _show_error_popup(
         button=button,
         timeout_ms=timeout_ms,
     ) as popup:
-        await Layout(popup).get_result()
+        await interact_simple(popup)
 
 
 async def _confirm_bogus_app(title: str) -> None:

--- a/core/src/trezor/ui/layouts/bolt/__init__.py
+++ b/core/src/trezor/ui/layouts/bolt/__init__.py
@@ -6,7 +6,7 @@ from trezor import TR, ui, utils
 from trezor.enums import ButtonRequestType, RecoveryType
 from trezor.wire import ActionCancelled
 
-from ..common import draw_simple, interact, raise_if_not_confirmed, with_info
+from ..common import interact, interact_simple, raise_if_not_confirmed, with_info
 
 if TYPE_CHECKING:
     from buffer_types import AnyBytes, StrOrBytes
@@ -2188,8 +2188,9 @@ def error_popup(
     return layout
 
 
-def request_passphrase_on_host() -> None:
-    draw_simple(trezorui_api.show_simple(title=None, text=TR.passphrase__please_enter))
+async def request_passphrase_on_host() -> None:
+    ctx = trezorui_api.show_simple(title=None, text=TR.passphrase__please_enter)
+    await interact_simple(ctx)
 
 
 async def request_passphrase_on_device(max_len: int) -> str:

--- a/core/src/trezor/ui/layouts/bolt/fido.py
+++ b/core/src/trezor/ui/layouts/bolt/fido.py
@@ -1,9 +1,8 @@
 import trezorui_api
-from trezor import ui
 from trezor.enums import ButtonRequestType
 from trezor.ui.layouts import show_error_and_raise
 
-from ..common import interact
+from ..common import interact, interact_simple
 
 
 async def confirm_fido(
@@ -56,8 +55,7 @@ async def confirm_fido_reset() -> bool:
         description=TR.words__really_wanna,
         reverse=True,
     ) as layout:
-        confirm = ui.Layout(layout)
-        return (await confirm.get_result()) is trezorui_api.CONFIRMED
+        return await interact_simple(layout) is trezorui_api.CONFIRMED
 
 
 async def credential_warning(br_name: str, content: str) -> None:

--- a/core/src/trezor/ui/layouts/caesar/__init__.py
+++ b/core/src/trezor/ui/layouts/caesar/__init__.py
@@ -5,7 +5,7 @@ from trezor import TR, ui, utils
 from trezor.enums import ButtonRequestType, RecoveryType
 from trezor.wire import ActionCancelled
 
-from ..common import draw_simple, interact, raise_if_not_confirmed
+from ..common import interact, interact_simple, raise_if_not_confirmed
 
 if TYPE_CHECKING:
     from buffer_types import AnyBytes, StrOrBytes
@@ -2226,8 +2226,9 @@ def error_popup(
     )
 
 
-def request_passphrase_on_host() -> None:
-    draw_simple(trezorui_api.show_simple(title=None, text=TR.passphrase__please_enter))
+async def request_passphrase_on_host() -> None:
+    ctx = trezorui_api.show_simple(title=None, text=TR.passphrase__please_enter)
+    await interact_simple(ctx)
 
 
 async def request_passphrase_on_device(max_len: int) -> str:

--- a/core/src/trezor/ui/layouts/caesar/fido.py
+++ b/core/src/trezor/ui/layouts/caesar/fido.py
@@ -1,9 +1,8 @@
 import trezorui_api
-from trezor import ui
 from trezor.enums import ButtonRequestType
 from trezor.ui.layouts import show_error_and_raise
 
-from ..common import interact
+from ..common import interact, interact_simple
 
 
 async def confirm_fido(
@@ -42,7 +41,7 @@ async def confirm_fido_reset() -> bool:
         verb_cancel="",
         verb=TR.buttons__confirm,
     ) as confirm:
-        return (await ui.Layout(confirm).get_result()) is trezorui_api.CONFIRMED
+        return await interact_simple(confirm) is trezorui_api.CONFIRMED
 
 
 async def credential_warning(br_name: str, content: str) -> None:

--- a/core/src/trezor/ui/layouts/common.py
+++ b/core/src/trezor/ui/layouts/common.py
@@ -152,8 +152,20 @@ async def confirm_linear_flow(
             raise ActionCancelled
 
 
-def draw_simple(layout: trezorui_api.LayoutObj[Any]) -> None:
-    # IMPORTANT: after this call, `layout` is referenced by `trezor.ui.CURRENT_LAYOUT`
-    # and its event-handling tasks are still running. Therefore, it MUST NOT be dropped,
-    # until a new layout is started.
-    ui.Layout(layout).start()
+async def interact_simple(layout_ctx: trezorui_api.LayoutContext[T]) -> T:
+    """
+    Run a simple layout till completion, returning its result.
+
+    Neither closes other workflows, nor sends button requests, nor checks the result.
+    """
+
+    with layout_ctx as obj:
+        # Block until the user confirmation.
+        # Don't use `interact` to avoid cancelling current workflow.
+        layout = ui.Layout(obj)
+        layout.start()
+        # This task may have no access to I/O context.
+        # Therefore, the new layout won't start its own ButtonRequest handler,
+        # avoiding interference with the existing layout.
+        assert layout.button_request_handler is None
+        return await layout.get_result()

--- a/core/src/trezor/ui/layouts/delizia/__init__.py
+++ b/core/src/trezor/ui/layouts/delizia/__init__.py
@@ -7,8 +7,8 @@ from trezor.wire import ActionCancelled
 
 from ..common import (
     confirm_linear_flow,
-    draw_simple,
     interact,
+    interact_simple,
     raise_if_not_confirmed,
     with_info,
 )
@@ -2183,8 +2183,9 @@ def error_popup(
     )
 
 
-def request_passphrase_on_host() -> None:
-    draw_simple(trezorui_api.show_simple(title=None, text=TR.passphrase__please_enter))
+async def request_passphrase_on_host() -> None:
+    ctx = trezorui_api.show_simple(title=None, text=TR.passphrase__please_enter)
+    await interact_simple(ctx)
 
 
 async def request_passphrase_on_device(max_len: int) -> str:

--- a/core/src/trezor/ui/layouts/delizia/fido.py
+++ b/core/src/trezor/ui/layouts/delizia/fido.py
@@ -1,9 +1,8 @@
 import trezorui_api
-from trezor import ui
 from trezor.enums import ButtonRequestType
 from trezor.ui.layouts import show_error_and_raise
 
-from ..common import interact
+from ..common import interact, interact_simple
 
 
 async def confirm_fido(
@@ -50,8 +49,7 @@ async def confirm_fido_reset() -> bool:
         reverse=True,
         prompt_screen=True,
     ) as layout:
-        confirm = ui.Layout(layout)
-        return (await confirm.get_result()) is trezorui_api.CONFIRMED
+        return await interact_simple(layout) is trezorui_api.CONFIRMED
 
 
 async def credential_warning(br_name: str, content: str) -> None:

--- a/core/src/trezor/ui/layouts/eckhart/__init__.py
+++ b/core/src/trezor/ui/layouts/eckhart/__init__.py
@@ -7,8 +7,8 @@ from trezor.wire import ActionCancelled
 
 from ..common import (
     confirm_linear_flow,
-    draw_simple,
     interact,
+    interact_simple,
     raise_if_not_confirmed,
     with_info,
 )
@@ -2305,8 +2305,9 @@ def error_popup(
     )
 
 
-def request_passphrase_on_host() -> None:
-    draw_simple(trezorui_api.show_simple(title=None, text=TR.passphrase__please_enter))
+async def request_passphrase_on_host() -> None:
+    ctx = trezorui_api.show_simple(title=None, text=TR.passphrase__please_enter)
+    await interact_simple(ctx)
 
 
 async def request_passphrase_on_device(max_len: int) -> str:

--- a/core/src/trezor/ui/layouts/eckhart/fido.py
+++ b/core/src/trezor/ui/layouts/eckhart/fido.py
@@ -1,9 +1,9 @@
 import trezorui_api
-from trezor import TR, ui
+from trezor import TR
 from trezor.enums import ButtonRequestType
 from trezor.ui.layouts import show_error_and_raise
 
-from ..common import interact
+from ..common import interact, interact_simple
 
 
 async def confirm_fido(
@@ -51,8 +51,7 @@ async def confirm_fido_reset() -> bool:
         allow_cancel=True,
         danger=True,
     ) as layout:
-        confirm = ui.Layout(layout)
-        return (await confirm.get_result()) is trezorui_api.CONFIRMED
+        return await interact_simple(layout) is trezorui_api.CONFIRMED
 
 
 async def credential_warning(br_name: str, content: str) -> None:

--- a/core/src/trezor/wire/protocol_common.py
+++ b/core/src/trezor/wire/protocol_common.py
@@ -138,7 +138,7 @@ _UNRESPONSIVE_WARNING_TIMEOUT_MS = const(2000)
 async def _waiting_screen(raise_on_cancel: type[Exception] | None) -> None:
     import trezorui_api
     from trezor import TR
-    from trezor.ui import Layout
+    from trezor.ui.layouts import interact_simple
 
     if raise_on_cancel is not None:
         verb = TR.buttons__abort
@@ -155,15 +155,9 @@ async def _waiting_screen(raise_on_cancel: type[Exception] | None) -> None:
         danger=False,
         allow_cancel=False,
     ) as obj:
-        # Block until the user confirmation.
         # Don't use `interact` to avoid cancelling current workflow.
-        layout = Layout(obj)
-        layout.start()
-        # This task doesn't have access to I/O context - see `ButtonRequestHandler.join()`.
-        # Therefore, the new layout won't start its own ButtonRequest handler,
-        # avoiding interference with the existing layout (the one we are waiting for).
-        assert layout.button_request_handler is None
-        await layout.get_result()
+        # The new layout won't start its own ButtonRequest handler, avoiding interference with the existing layout (the one we are waiting for).
+        await interact_simple(obj)
 
     if raise_on_cancel:
         raise raise_on_cancel()


### PR DESCRIPTION
Use a basic form of `interact()`, to be sure that passphrase prompt layout will be properly stopped - otherwise it cannot be used as a context manager, since its Rust layout object will be deallocated, while it's still being referenced by `ui.CURRENT_LAYOUT` and its event-handling tasks still running. 

This was already done by FIDO-related layouts, so they can re-use the new helper function.

Partially reverts and fixes the underlying issue of #7282:
https://github.com/trezor/trezor-firmware/blob/814203e145ac58a2311ba5450fd2a13213f05b66/core/src/trezor/ui/layouts/common.py#L155-L159
