### PR TITLE
translations: fix build version handling

### DIFF
--- a/core/embed/rust/librust_qstr.h
+++ b/core/embed/rust/librust_qstr.h
@@ -972,6 +972,7 @@ static void _librust_qstrs(void) {
   MP_QSTR_verb_info;
   MP_QSTR_verify;
   MP_QSTR_version;
+  MP_QSTR_version_matches_firmware;
   MP_QSTR_wait_ble_host_confirmation;
   MP_QSTR_warning;
   MP_QSTR_wipe__info;

--- a/core/embed/rust/librust_qstr.h
+++ b/core/embed/rust/librust_qstr.h
@@ -983,6 +983,7 @@ static void _librust_qstrs(void) {
   MP_QSTR_verb_view_all;
   MP_QSTR_verify;
   MP_QSTR_version;
+  MP_QSTR_version_matches_firmware;
   MP_QSTR_wait_ble_host_confirmation;
   MP_QSTR_warning;
   MP_QSTR_wipe__info;

--- a/core/embed/rust/src/translations/obj.rs
+++ b/core/embed/rust/src/translations/obj.rs
@@ -155,6 +155,17 @@ extern "C" fn verify(data: Obj) -> Obj {
     unsafe { util::try_or_raise(block) }
 }
 
+extern "C" fn version_matches_firmware(translations_version: Obj, firmware_version: Obj) -> Obj {
+    let block = || {
+        let tver: [u8; 4] = util::iter_into_array(translations_version)?;
+        let fver: [u8; 4] = util::iter_into_array(firmware_version)?;
+        let matches = tver[..3] == fver[..3];
+        Ok(matches.into())
+    };
+
+    unsafe { util::try_or_raise(block) }
+}
+
 #[no_mangle]
 #[rustfmt::skip]
 pub static mp_module_trezortranslate: Module = obj_module! {
@@ -196,6 +207,10 @@ pub static mp_module_trezortranslate: Module = obj_module! {
     /// def verify(data: AnyBytes) -> None:
     ///     """Verify the translations blob."""
     Qstr::MP_QSTR_verify => obj_fn_1!(verify).as_obj(),
+
+    /// def version_matches_firmware(translations_version: tuple[int, int, int, int], firmware_version: tuple[int, int, int, int]) -> bool:
+    ///     """Returns true if translations version and firmware version are compatible."""
+    Qstr::MP_QSTR_version_matches_firmware => obj_fn_2!(version_matches_firmware).as_obj(),
 
     /// class TranslationsHeader:
     ///     """Metadata about the translations blob."""

--- a/core/embed/rust/src/translations/obj.rs
+++ b/core/embed/rust/src/translations/obj.rs
@@ -161,6 +161,17 @@ extern "C" fn verify(data: Obj) -> Obj {
     unsafe { util::try_or_raise(block) }
 }
 
+extern "C" fn version_matches_firmware(translations_version: Obj, firmware_version: Obj) -> Obj {
+    let block = || {
+        let tver: [u8; 4] = util::iter_into_array(translations_version)?;
+        let fver: [u8; 4] = util::iter_into_array(firmware_version)?;
+        let matches = tver[..3] == fver[..3];
+        Ok(matches.into())
+    };
+
+    unsafe { util::try_or_raise(block) }
+}
+
 #[no_mangle]
 #[rustfmt::skip]
 pub static mp_module_trezortranslate: Module = obj_module! {
@@ -202,6 +213,10 @@ pub static mp_module_trezortranslate: Module = obj_module! {
     /// def verify(data: AnyBytes) -> None:
     ///     """Verify the translations blob."""
     Qstr::MP_QSTR_verify => obj_fn_1!(verify).as_obj(),
+
+    /// def version_matches_firmware(translations_version: tuple[int, int, int, int], firmware_version: tuple[int, int, int, int]) -> bool:
+    ///     """Returns true if translations version and firmware version are compatible."""
+    Qstr::MP_QSTR_version_matches_firmware => obj_fn_2!(version_matches_firmware).as_obj(),
 
     /// class TranslationsHeader:
     ///     """Metadata about the translations blob."""

--- a/core/mocks/generated/trezortranslate.pyi
+++ b/core/mocks/generated/trezortranslate.pyi
@@ -45,6 +45,11 @@ def verify(data: AnyBytes) -> None:
 
 
 # rust/src/translations/obj.rs
+def version_matches_firmware(translations_version: tuple[int, int, int, int], firmware_version: tuple[int, int, int, int]) -> bool:
+    """Returns true if translations version and firmware version are compatible."""
+
+
+# rust/src/translations/obj.rs
 class TranslationsHeader:
     """Metadata about the translations blob."""
     language: str

--- a/core/pyrightconfig.json
+++ b/core/pyrightconfig.json
@@ -2,6 +2,7 @@
     "include": [
         "src",
         "tools",
+        "translations",
         "site_scons",
         "*.py"
     ],

--- a/core/pyrightconfig.json
+++ b/core/pyrightconfig.json
@@ -2,6 +2,7 @@
     "include": [
         "src",
         "tools",
+        "translations",
         "*.py"
     ],
     "exclude": [

--- a/core/src/apps/base.py
+++ b/core/src/apps/base.py
@@ -63,7 +63,7 @@ def _language_version_matches() -> bool:
     if header is None:
         return True
 
-    return header.version[:3] == utils.VERSION[:3]
+    return translations.version_matches_firmware(header.version, utils.VERSION)
 
 
 def get_features() -> Features:

--- a/core/src/apps/management/change_language.py
+++ b/core/src/apps/management/change_language.py
@@ -79,7 +79,7 @@ async def do_change_language(
     # Compare only (VERSION_MAJOR, VERSION_MINOR, VERSION_PATCH):
     if len(header.version) != 4 or len(expected_version) != 4:
         raise DataError("Invalid version format")
-    if header.version[:3] != expected_version[:3]:
+    if not translations.version_matches_firmware(header.version, expected_version):
         raise DataError("Translations version mismatch")
 
     current_header = translations.TranslationsHeader.load_from_flash()
@@ -91,7 +91,9 @@ async def do_change_language(
         # if a blob is present, it can only be silently upgraded to expected_version
         silent_install = (
             current_header.language == header.language
-            and current_header.version != expected_version
+            and not translations.version_matches_firmware(
+                current_header.version, expected_version
+            )
         )
 
     # Confirm with user

--- a/core/translations/blank_translations.py
+++ b/core/translations/blank_translations.py
@@ -11,17 +11,17 @@ Usage:
 import json
 import re
 from pathlib import Path
-from typing import Any, Dict, List, Optional
+from typing import Any
 
 import click
 
 
-def load_json(path: Path) -> Dict[str, Any]:
+def load_json(path: Path) -> dict[str, Any]:
     with path.open("r", encoding="utf-8") as f:
         return json.load(f)
 
 
-def save_json(path: Path, data: Dict[str, Any]) -> None:
+def save_json(path: Path, data: dict[str, Any]) -> None:
     with path.open("w", encoding="utf-8") as f:
         json.dump(data, f, ensure_ascii=False, indent=2)
         f.write("\n")
@@ -36,7 +36,7 @@ def infer_layout(file_path: Path) -> str:
     return parts[1]
 
 
-def compile_rules(raw_rules: List[Dict[str, Any]]):
+def compile_rules(raw_rules: list[dict[str, Any]]) -> list[dict]:
     compiled = []
     for r in raw_rules:
         kinds = [k for k in ("exact", "prefix", "regex") if k in r]
@@ -86,7 +86,7 @@ def compile_rules(raw_rules: List[Dict[str, Any]]):
     return compiled
 
 
-def match_rule(key: str, rules):
+def match_rule(key: str, rules: list[dict]) -> list:
     matches = []
     for rule in rules:
         t = rule["type"]
@@ -108,7 +108,7 @@ def match_rule(key: str, rules):
     return matches
 
 
-def process_file(file_path: Path, rules, dry_run: bool = False):
+def process_file(file_path: Path, rules: list[dict], dry_run: bool = False) -> dict:
     data = load_json(file_path)
     if "translations" not in data or not isinstance(data["translations"], dict):
         raise ValueError(f"No 'translations' object in {file_path}")
@@ -126,7 +126,7 @@ def process_file(file_path: Path, rules, dry_run: bool = False):
 
     changed = 0
     total = len(translations)
-    blanked_keys: List[str] = []
+    blanked_keys: list[str] = []
     for key, value in list(translations.items()):
         if not isinstance(value, str):
             continue
@@ -159,7 +159,9 @@ def process_file(file_path: Path, rules, dry_run: bool = False):
     }
 
 
-def write_blanked_file(out_dir: Path, original_filename: str, blanked_keys: List[str]):
+def write_blanked_file(
+    out_dir: Path, original_filename: str, blanked_keys: list[str]
+) -> None:
     if not blanked_keys:
         return
     out_dir.mkdir(parents=True, exist_ok=True)
@@ -175,10 +177,10 @@ def run_cleanup(
     locales_dir: Path,
     *,
     lang: str = "en",
-    dry_run: Optional[bool] = None,
-    only: Optional[List[str]] = None,
-    blanked_out_dir: Optional[Path] = None,
-):
+    dry_run: bool | None = None,
+    only: list[str] | None = None,
+    blanked_out_dir: Path | None = None,
+) -> dict:
     """
     Execute cleanup using rules. Returns a dict with a summary and counts.
     Does not print or exit; raises exceptions on fatal errors.
@@ -257,8 +259,8 @@ def click_cleanup(
     lang: str,
     dry_run: bool,
     only: tuple[str, ...],
-    blanked_out_dir: Optional[Path],
-):
+    blanked_out_dir: Path | None,
+) -> None:
     """
     Standalone CLI entrypoint using click. Also usable programmatically via run_cleanup().
     """

--- a/core/translations/cli.py
+++ b/core/translations/cli.py
@@ -1,3 +1,4 @@
+#!/usr/bin/env python3
 from __future__ import annotations
 
 import datetime
@@ -11,7 +12,7 @@ import click
 
 from trezorlib import cosi, models, merkle_tree
 from trezorlib._internal import translations
-from trezorlib._internal.translations import VersionTuple
+from trezorlib._internal.translations import VersionTuple, version_matches_firmware
 
 HERE = Path(__file__).parent.resolve()
 LOG = logging.getLogger(__name__)
@@ -139,23 +140,44 @@ class TranslationsDir:
         )
 
     def all_languages(self) -> t.Iterable[str]:
-        return (lang_file.stem for lang_file in self.path.glob("??.json"))
+        return (lang_file.stem for lang_file in sorted(self.path.glob("??.json")))
 
-    def update_version_from_h(self, check: bool = False) -> VersionTuple:
+    def get_version(self, lang: str) -> VersionTuple:
+        blob_json = self.load_lang(lang)
+        return translations.version_from_json(blob_json["header"]["version"])
+
+    def update_version_from_h(self, check: bool = False) -> None:
         version = _version_from_version_h()
+        new_version = None
         for lang in self.all_languages():
             blob_json = self.load_lang(lang)
             blob_version = translations.version_from_json(
                 blob_json["header"]["version"]
             )
-            if blob_version != version:
+            if not version_matches_firmware(blob_version, version):
                 if check:
                     raise ValueError(
                         f"Language {lang} has version {blob_version} not matching firmware version {version}"
                     )
-                blob_json["header"]["version"] = _version_str(version[:3])
-                self.save_lang(lang, blob_json)
-        return version
+                else:
+                    if new_version is None:
+                        new_version = (*version[:3], 0)
+                    blob_json["header"]["version"] = _version_str(new_version)
+                    self.save_lang(lang, blob_json)
+        if new_version and version[3] != 0:
+            click.echo(
+                f"Warning: resetting language versions when firmware build != 0: {version}"
+            )
+
+    def bump_build_version(self) -> None:
+        for lang in self.all_languages():
+            blob_json = self.load_lang(lang)
+            blob_version = translations.version_from_json(
+                blob_json["header"]["version"]
+            )
+            new_version = (*blob_version[:3], blob_version[3] + 1)
+            blob_json["header"]["version"] = _version_str(new_version)
+            self.save_lang(lang, blob_json)
 
     def generate_single_blob(
         self,
@@ -264,7 +286,7 @@ def cli() -> None:
     "--version", "version_str", help="Set the blob version independent of JSON data."
 )
 @click.option("--check", is_flag=True, help="Only check if JSON version matches firmware.")
-def gen(signed: bool | None, version_str: str | None, check: bool | None) -> None:
+def gen(signed: bool, version_str: str | None, check: bool) -> None:
     """Generate all language blobs for all models.
 
     The generated blobs will be signed with the development keys.
@@ -272,7 +294,9 @@ def gen(signed: bool | None, version_str: str | None, check: bool | None) -> Non
     tdir = TranslationsDir()
 
     if version_str is None:
-        version = tdir.update_version_from_h(check=check)
+        if check:
+            tdir.update_version_from_h(check=True)
+        version = None
     else:
         if check:
             raise click.ClickException("Options --version and --check are mutually exclusive.")
@@ -454,6 +478,53 @@ def lowercase(lang_file: Path) -> None:
     data["translations"] = new_translations
     with open(lang_file, "w") as fh:
         json.dump(data, fh, indent=2, ensure_ascii=False)
+
+
+@cli.command()
+@click.option(
+    "--reset",
+    is_flag=True,
+    help="Set translations version from firmware version. Use when firmware version changed.",
+)
+@click.option(
+    "--bump",
+    is_flag=True,
+    help="Increase the build version of all translations. Use when releasing updated translations without releasing firmware.",
+)
+@click.pass_context
+def version(ctx: click.Context, reset: bool, bump: bool) -> None:
+    """Print versions of all language blobs and whether they match firmware.
+
+    The --reset option can be used to reconcile the translation versions with
+    the firmware version. If the versions match (i.e. differ at most in the build
+    version) the translations are left as-is. Otherwise translation versions are
+    set to the firmware version but with build version 0.
+    """
+    tdir = TranslationsDir()
+
+    if reset and bump:
+        raise click.ClickException("Options --reset and --bump are mutually exclusive.")
+    elif reset:
+        tdir.update_version_from_h(check=False)
+    elif bump:
+        tdir.bump_build_version()
+
+    firmware_version = _version_from_version_h()
+    click.echo(f"firmware {_version_str(firmware_version)} matches?")
+    all_match = True
+    for lang in tdir.all_languages():
+        blob_version = tdir.get_version(lang)
+        matches_fw = version_matches_firmware(blob_version, firmware_version)
+        all_match = all_match and matches_fw
+        matches_fw_str = "ok" if matches_fw else "VERSION MISMATCH"
+        click.echo(f"{lang}       {_version_str(blob_version)} {matches_fw_str}")
+
+    if not all_match:
+        raise click.ClickException("JSON versions do not match firmware.")
+
+    if reset or bump:
+        ctx.invoke(gen, signed=False, version_str=None, check=False)
+
 
 if __name__ == "__main__":
     cli()

--- a/core/translations/cli.py
+++ b/core/translations/cli.py
@@ -4,13 +4,13 @@ from __future__ import annotations
 import datetime
 import json
 import logging
-import typing as t
 import subprocess
+import typing as t
 from pathlib import Path
 
 import click
 
-from trezorlib import cosi, models, merkle_tree
+from trezorlib import cosi, merkle_tree, models
 from trezorlib._internal import translations
 from trezorlib._internal.translations import VersionTuple, version_matches_firmware
 
@@ -112,7 +112,7 @@ def update_merkle_root(signature_file: SignatureFile, merkle_root: bytes) -> boo
 
 
 class TranslationsDir:
-    def __init__(self, path: Path = HERE):
+    def __init__(self, path: Path = HERE) -> None:
         self.path = path
         self.order = translations.order_from_json(
             json.loads((self.path / "order.json").read_text())
@@ -237,7 +237,9 @@ def build_all_blobs(
 ) -> None:
     max_sizes = {}
     for model in ALL_MODELS:
-        parser_output = subprocess.check_output(args=["layout_parser", model.internal_name, "ASSETS_MAXSIZE"])
+        parser_output = subprocess.check_output(
+            args=["layout_parser", model.internal_name, "ASSETS_MAXSIZE"]
+        )
         max_sizes[model.internal_name] = int(parser_output.decode().strip())
 
     sizes = []
@@ -272,7 +274,9 @@ def build_all_blobs(
         else:
             log_fn, icon = LOG.error, "🔴"
 
-        log_fn(f"{icon} {filename} flash utilization is {ratio * 100:.1f}% (out of {max_size / 1024:.1f} kB)")
+        log_fn(
+            f"{icon} {filename} flash utilization is {ratio * 100:.1f}% (out of {max_size / 1024:.1f} kB)"
+        )
 
 
 @click.group()
@@ -285,7 +289,9 @@ def cli() -> None:
 @click.option(
     "--version", "version_str", help="Set the blob version independent of JSON data."
 )
-@click.option("--check", is_flag=True, help="Only check if JSON version matches firmware.")
+@click.option(
+    "--check", is_flag=True, help="Only check if JSON version matches firmware."
+)
 def gen(signed: bool, version_str: str | None, check: bool) -> None:
     """Generate all language blobs for all models.
 
@@ -299,7 +305,9 @@ def gen(signed: bool, version_str: str | None, check: bool) -> None:
         version = None
     else:
         if check:
-            raise click.ClickException("Options --version and --check are mutually exclusive.")
+            raise click.ClickException(
+                "Options --version and --check are mutually exclusive."
+            )
         version = translations.version_from_json(version_str)
 
     all_blobs = tdir.generate_all_blobs(version)
@@ -320,10 +328,9 @@ def gen(signed: bool, version_str: str | None, check: bool) -> None:
                 sigmask, signature = signature_bytes[0], signature_bytes[1:]
                 build_all_blobs(all_blobs, tree, sigmask, signature, production=True)
                 return
-        else:
-            raise click.ClickException(
-                "No matching signature found in signatures.json. Run `cli.py sign` first."
-            )
+        raise click.ClickException(
+            "No matching signature found in signatures.json. Run `cli.py sign` first."
+        )
 
     signature = cosi.sign_with_privkeys(root, PRIVATE_KEYS_DEV)
     sigmask = 0b111
@@ -441,7 +448,7 @@ def merge(update_json: t.Tuple[t.TextIO, ...]) -> None:
         new_data = json.load(f)
         lang = new_data["header"]["language"][:2]
         orig_data = tdir.load_lang(lang)
-        _dict_merge(orig_data, new_data)
+        _dict_merge(orig_data, new_data)  # type: ignore ["JsonDef" is not assignable to "dict[Unknown, Unknown]"]
         tdir.save_lang(lang, orig_data)
         click.echo(f"Updated {lang}")
 
@@ -454,7 +461,7 @@ def characters(lang_file: t.TextIO) -> None:
     chars = filter(lambda c: ord(c) > 127, all_chars)
     print("(")
     for c in sorted(chars):
-        print(f"    \"{c}\",")
+        print(f'    "{c}",')
     print(")")
 
 
@@ -472,7 +479,7 @@ def lowercase(lang_file: Path) -> None:
         else:
             return s[0] + s[1:].lower()
 
-    for k, v in data['translations'].items():
+    for k, v in data["translations"].items():
         new_translations[k] = f(v)
 
     data["translations"] = new_translations

--- a/core/translations/cli.py
+++ b/core/translations/cli.py
@@ -184,7 +184,7 @@ class TranslationsDir:
             for model in ALL_MODELS:
                 try:
                     blob = self.generate_single_blob(blob_json, model, version)
-                    blob_version = blob.header.firmware_version
+                    blob_version = blob.header.version
                     if common_version is None:
                         common_version = blob_version
                     elif blob_version != common_version:
@@ -228,7 +228,7 @@ def build_all_blobs(
         blob.proof = proof
         header = blob.header
         model = header.model.value.decode("ascii")
-        version = _version_str(header.firmware_version[:3])
+        version = _version_str(header.version[:3])
         if production:
             suffix = ""
         else:
@@ -366,7 +366,7 @@ def sign(signature_hex: str, force: bool | None, version_str: str | None) -> Non
     tree = merkle_tree.MerkleTree(b.header_bytes for b in all_blobs)
     root = tree.get_root_hash()
 
-    blob_version = all_blobs[0].header.firmware_version
+    blob_version = all_blobs[0].header.version
     signature_file: SignatureFile = json.loads(SIGNATURES_JSON.read_text())
 
     if version_str is None:

--- a/core/translations/cli.py
+++ b/core/translations/cli.py
@@ -4,13 +4,13 @@ from __future__ import annotations
 import datetime
 import json
 import logging
-import typing as t
 import subprocess
+import typing as t
 from pathlib import Path
 
 import click
 
-from trezorlib import cosi, models, merkle_tree
+from trezorlib import cosi, merkle_tree, models
 from trezorlib._internal import translations
 from trezorlib._internal.translations import VersionTuple, version_matches_firmware
 
@@ -112,7 +112,7 @@ def update_merkle_root(signature_file: SignatureFile, merkle_root: bytes) -> boo
 
 
 class TranslationsDir:
-    def __init__(self, path: Path = HERE):
+    def __init__(self, path: Path = HERE) -> None:
         self.path = path
         self.order = translations.order_from_json(
             json.loads((self.path / "order.json").read_text())
@@ -234,7 +234,9 @@ def build_all_blobs(
 ) -> None:
     max_sizes = {}
     for model in ALL_MODELS:
-        parser_output = subprocess.check_output(args=["layout_parser", model.internal_name, "ASSETS_MAXSIZE"])
+        parser_output = subprocess.check_output(
+            args=["layout_parser", model.internal_name, "ASSETS_MAXSIZE"]
+        )
         max_sizes[model.internal_name] = int(parser_output.decode().strip())
 
     sizes = []
@@ -269,7 +271,9 @@ def build_all_blobs(
         else:
             log_fn, icon = LOG.error, "🔴"
 
-        log_fn(f"{icon} {filename} flash utilization is {ratio * 100:.1f}% (out of {max_size / 1024:.1f} kB)")
+        log_fn(
+            f"{icon} {filename} flash utilization is {ratio * 100:.1f}% (out of {max_size / 1024:.1f} kB)"
+        )
 
 
 @click.group()
@@ -282,7 +286,9 @@ def cli() -> None:
 @click.option(
     "--version", "version_str", help="Set the blob version independent of JSON data."
 )
-@click.option("--check", is_flag=True, help="Only check if JSON version matches firmware.")
+@click.option(
+    "--check", is_flag=True, help="Only check if JSON version matches firmware."
+)
 def gen(signed: bool, version_str: str | None, check: bool) -> None:
     """Generate all language blobs for all models.
 
@@ -296,7 +302,9 @@ def gen(signed: bool, version_str: str | None, check: bool) -> None:
         version = None
     else:
         if check:
-            raise click.ClickException("Options --version and --check are mutually exclusive.")
+            raise click.ClickException(
+                "Options --version and --check are mutually exclusive."
+            )
         version = translations.version_from_json(version_str)
 
     all_blobs = tdir.generate_all_blobs(version)
@@ -317,10 +325,9 @@ def gen(signed: bool, version_str: str | None, check: bool) -> None:
                 sigmask, signature = signature_bytes[0], signature_bytes[1:]
                 build_all_blobs(all_blobs, tree, sigmask, signature, production=True)
                 return
-        else:
-            raise click.ClickException(
-                "No matching signature found in signatures.json. Run `cli.py sign` first."
-            )
+        raise click.ClickException(
+            "No matching signature found in signatures.json. Run `cli.py sign` first."
+        )
 
     signature = cosi.sign_with_privkeys(root, PRIVATE_KEYS_DEV)
     sigmask = 0b111
@@ -438,7 +445,7 @@ def merge(update_json: t.Tuple[t.TextIO, ...]) -> None:
         new_data = json.load(f)
         lang = new_data["header"]["language"][:2]
         orig_data = tdir.load_lang(lang)
-        _dict_merge(orig_data, new_data)
+        _dict_merge(orig_data, new_data)  # type: ignore ["JsonDef" is not assignable to "dict[Unknown, Unknown]"]
         tdir.save_lang(lang, orig_data)
         click.echo(f"Updated {lang}")
 
@@ -451,7 +458,7 @@ def characters(lang_file: t.TextIO) -> None:
     chars = filter(lambda c: ord(c) > 127, all_chars)
     print("(")
     for c in sorted(chars):
-        print(f"    \"{c}\",")
+        print(f'    "{c}",')
     print(")")
 
 
@@ -469,7 +476,7 @@ def lowercase(lang_file: Path) -> None:
         else:
             return s[0] + s[1:].lower()
 
-    for k, v in data['translations'].items():
+    for k, v in data["translations"].items():
         new_translations[k] = f(v)
 
     data["translations"] = new_translations

--- a/core/translations/cli.py
+++ b/core/translations/cli.py
@@ -1,3 +1,4 @@
+#!/usr/bin/env python3
 from __future__ import annotations
 
 import datetime
@@ -11,7 +12,7 @@ import click
 
 from trezorlib import cosi, models, merkle_tree
 from trezorlib._internal import translations
-from trezorlib._internal.translations import VersionTuple
+from trezorlib._internal.translations import VersionTuple, version_matches_firmware
 
 HERE = Path(__file__).parent.resolve()
 LOG = logging.getLogger(__name__)
@@ -71,7 +72,7 @@ def _version_from_version_h() -> VersionTuple:
     )
 
 
-def _version_str(version: tuple[int, ...]) -> str:
+def _version_str(version: VersionTuple | tuple[int, int, int]) -> str:
     return ".".join(str(v) for v in version)
 
 
@@ -139,23 +140,41 @@ class TranslationsDir:
         )
 
     def all_languages(self) -> t.Iterable[str]:
-        return (lang_file.stem for lang_file in self.path.glob("??.json"))
+        return (lang_file.stem for lang_file in sorted(self.path.glob("??.json")))
 
-    def update_version_from_h(self, check: bool = False) -> VersionTuple:
+    def get_version(self, lang: str) -> VersionTuple:
+        blob_json = self.load_lang(lang)
+        return translations.version_from_json(blob_json["header"]["version"])
+
+    def update_version_from_h(self, check: bool = False) -> None:
         version = _version_from_version_h()
+        if version[3] != 0 and not check:
+            click.echo(f"Warning: firmware build != 0: {version}")
+        new_version = _version_str((*version[:3], 0))
+
         for lang in self.all_languages():
             blob_json = self.load_lang(lang)
             blob_version = translations.version_from_json(
                 blob_json["header"]["version"]
             )
-            if blob_version != version:
+            if not version_matches_firmware(blob_version, version):
                 if check:
                     raise ValueError(
                         f"Language {lang} has version {blob_version} not matching firmware version {version}"
                     )
-                blob_json["header"]["version"] = _version_str(version[:3])
-                self.save_lang(lang, blob_json)
-        return version
+                else:
+                    blob_json["header"]["version"] = new_version
+                    self.save_lang(lang, blob_json)
+
+    def bump_build_version(self) -> None:
+        for lang in self.all_languages():
+            blob_json = self.load_lang(lang)
+            blob_version = translations.version_from_json(
+                blob_json["header"]["version"]
+            )
+            new_version = (*blob_version[:3], blob_version[3] + 1)
+            blob_json["header"]["version"] = _version_str(new_version)
+            self.save_lang(lang, blob_json)
 
     def generate_single_blob(
         self,
@@ -264,7 +283,7 @@ def cli() -> None:
     "--version", "version_str", help="Set the blob version independent of JSON data."
 )
 @click.option("--check", is_flag=True, help="Only check if JSON version matches firmware.")
-def gen(signed: bool | None, version_str: str | None, check: bool | None) -> None:
+def gen(signed: bool, version_str: str | None, check: bool) -> None:
     """Generate all language blobs for all models.
 
     The generated blobs will be signed with the development keys.
@@ -272,7 +291,9 @@ def gen(signed: bool | None, version_str: str | None, check: bool | None) -> Non
     tdir = TranslationsDir()
 
     if version_str is None:
-        version = tdir.update_version_from_h(check=check)
+        if check:
+            tdir.update_version_from_h(check=True)
+        version = None
     else:
         if check:
             raise click.ClickException("Options --version and --check are mutually exclusive.")
@@ -454,6 +475,55 @@ def lowercase(lang_file: Path) -> None:
     data["translations"] = new_translations
     with open(lang_file, "w") as fh:
         json.dump(data, fh, indent=2, ensure_ascii=False)
+
+
+@cli.command()
+@click.option(
+    "--reset",
+    is_flag=True,
+    help="Set translations version from firmware version. Use when firmware version changed.",
+)
+@click.option(
+    "--bump",
+    is_flag=True,
+    help="Increase the build version of all translations. Use when releasing updated translations without releasing firmware.",
+)
+@click.pass_context
+def version(ctx: click.Context, reset: bool, bump: bool) -> None:
+    """Print versions of all language blobs and whether they match firmware.
+
+    The --reset option can be used to reconcile the translation versions with
+    the firmware version. If the versions match (i.e. differ at most in the build
+    version) the translations are left as-is. Otherwise translation versions are
+    set to the firmware version but with build version 0.
+
+    Using --reset or --bump will cause blobs to be re-generated.
+    """
+    tdir = TranslationsDir()
+
+    if reset and bump:
+        raise click.ClickException("Options --reset and --bump are mutually exclusive.")
+    elif reset:
+        tdir.update_version_from_h(check=False)
+    elif bump:
+        tdir.bump_build_version()
+
+    firmware_version = _version_from_version_h()
+    click.echo(f"firmware {_version_str(firmware_version)} matches?")
+    all_match = True
+    for lang in tdir.all_languages():
+        blob_version = tdir.get_version(lang)
+        matches_fw = version_matches_firmware(blob_version, firmware_version)
+        all_match = all_match and matches_fw
+        matches_fw_str = "ok" if matches_fw else "VERSION MISMATCH"
+        click.echo(f"{lang}       {_version_str(blob_version)} {matches_fw_str}")
+
+    if not all_match:
+        raise click.ClickException("JSON versions do not match firmware.")
+
+    if reset or bump:
+        ctx.invoke(gen, signed=False, version_str=None, check=False)
+
 
 if __name__ == "__main__":
     cli()

--- a/core/translations/crowdin.py
+++ b/core/translations/crowdin.py
@@ -1,20 +1,20 @@
 from __future__ import annotations
 
-from pathlib import Path
 import collections
 import json
 import re
+from pathlib import Path
 
 import click
-
 from cli import TranslationsDir
-from trezorlib._internal import translations
 
+from trezorlib._internal import translations
 
 HERE = Path(__file__).parent
 
 # staging directory for layout-specific translation JSON files
 CROWDIN_DIR = HERE / "crowdin"
+
 
 @click.group()
 def cli() -> None:
@@ -42,7 +42,9 @@ def split() -> None:
             with open(CROWDIN_DIR / f"{lang}_{layout_type.name}.json", "w") as f:
                 json.dump(result, f, indent=2, ensure_ascii=False)
 
-    click.echo(f"Successfully generated layout-specific translation files in '{CROWDIN_DIR}'")
+    click.echo(
+        f"Successfully generated layout-specific translation files in '{CROWDIN_DIR}'"
+    )
 
 
 @cli.command()
@@ -54,7 +56,7 @@ def merge() -> None:
         """Remove or replace non-printable characters in translation strings."""
         # Replace non-breaking spaces with regular spaces, EXCEPT before ? ! and :
         # Use negative lookahead to avoid replacing before French punctuation
-        text = re.sub(r'\u00A0(?![?!:])', ' ', text)
+        text = re.sub(r"\u00A0(?![?!:])", " ", text)
         # Replace double newlines with newline-carriage return
         # This is needed because Crowdin converts \n\r to \n\n on import
         text = text.replace("\n\n", "\n\r")
@@ -65,17 +67,23 @@ def merge() -> None:
         # This is happening because English was added to Crowdin as a target language
         if lang == "en":
             continue
-        merged_translations: dict[str, str | dict[str, str]] = collections.defaultdict(dict)
+        merged_translations: dict[str, str | dict[str, str]] = collections.defaultdict(
+            dict
+        )
 
         for layout_type in translations.ALL_LAYOUTS:
             with open(CROWDIN_DIR / f"{lang}_{layout_type.name}.json", "r") as f:
                 blob_json = json.load(f)
 
             # mapping string name to its translation (for the current layout)
-            layout_specific_translations: dict[str, str] = blob_json.get("translations", {})
+            layout_specific_translations: dict[str, str] = blob_json.get(
+                "translations", {}
+            )
             for key, value in layout_specific_translations.items():
                 cleaned_value = clean_translation(value)
-                merged_translations[key][layout_type.name] = cleaned_value
+                layout_specific = merged_translations[key]
+                assert isinstance(layout_specific, dict)
+                layout_specific[layout_type.name] = cleaned_value
 
         # Ensure all layouts are present per key, fill missing with empty strings
         for key, layout_map in merged_translations.items():
@@ -98,7 +106,9 @@ def merge() -> None:
         tdir.save_lang(lang, blob_json)
         click.echo(f"Updated {lang}")
 
-    click.echo(f"Successfully merged back layout-specific translation files from '{CROWDIN_DIR}'")
+    click.echo(
+        f"Successfully merged back layout-specific translation files from '{CROWDIN_DIR}'"
+    )
 
 
 if __name__ == "__main__":

--- a/core/translations/crowdin.py
+++ b/core/translations/crowdin.py
@@ -1,20 +1,20 @@
 from __future__ import annotations
 
-from pathlib import Path
 import collections
 import json
 import re
+from pathlib import Path
 
 import click
-
 from cli import TranslationsDir
-from trezorlib._internal import translations
 
+from trezorlib._internal import translations
 
 HERE = Path(__file__).parent
 
 # staging directory for layout-specific translation JSON files
 CROWDIN_DIR = HERE / "crowdin"
+
 
 @click.group()
 def cli() -> None:
@@ -42,7 +42,9 @@ def split() -> None:
             with open(CROWDIN_DIR / f"{lang}_{layout_type.name}.json", "w") as f:
                 json.dump(result, f, indent=2, ensure_ascii=False)
 
-    click.echo(f"Successfully generated layout-specific translation files in '{CROWDIN_DIR}'")
+    click.echo(
+        f"Successfully generated layout-specific translation files in '{CROWDIN_DIR}'"
+    )
 
 
 @cli.command()
@@ -54,24 +56,30 @@ def merge() -> None:
         """Remove or replace non-printable characters in translation strings."""
         # Replace non-breaking spaces with regular spaces, EXCEPT before ? ! and :
         # Use negative lookahead to avoid replacing before French punctuation
-        text = re.sub(r'\u00A0(?![?!:])', ' ', text)
+        text = re.sub(r"\u00A0(?![?!:])", " ", text)
         # Replace double newlines with newline-carriage return
         # This is needed because Crowdin converts \n\r to \n\n on import
         text = text.replace("\n\n", "\n\r")
         return text
 
     for lang in sorted(tdir.all_languages()):
-        merged_translations: dict[str, str | dict[str, str]] = collections.defaultdict(dict)
+        merged_translations: dict[str, str | dict[str, str]] = collections.defaultdict(
+            dict
+        )
 
         for layout_type in translations.ALL_LAYOUTS:
             with open(CROWDIN_DIR / f"{lang}_{layout_type.name}.json", "r") as f:
                 blob_json = json.load(f)
 
             # mapping string name to its translation (for the current layout)
-            layout_specific_translations: dict[str, str] = blob_json.get("translations", {})
+            layout_specific_translations: dict[str, str] = blob_json.get(
+                "translations", {}
+            )
             for key, value in layout_specific_translations.items():
                 cleaned_value = clean_translation(value)
-                merged_translations[key][layout_type.name] = cleaned_value
+                layout_specific = merged_translations[key]
+                assert isinstance(layout_specific, dict)
+                layout_specific[layout_type.name] = cleaned_value
 
         # Ensure all layouts are present per key, fill missing with empty strings
         for key, layout_map in merged_translations.items():
@@ -94,7 +102,9 @@ def merge() -> None:
         tdir.save_lang(lang, blob_json)
         click.echo(f"Updated {lang}")
 
-    click.echo(f"Successfully merged back layout-specific translation files from '{CROWDIN_DIR}'")
+    click.echo(
+        f"Successfully merged back layout-specific translation files from '{CROWDIN_DIR}'"
+    )
 
 
 if __name__ == "__main__":

--- a/core/translations/cs.json
+++ b/core/translations/cs.json
@@ -33,7 +33,7 @@
   },
   "header": {
     "language": "cs-CZ",
-    "version": "2.12.3"
+    "version": "2.12.3.0"
   },
   "translations": {
     "addr_mismatch__contact_support_at": "Kontaktujte naši podporu na",

--- a/core/translations/cs.json
+++ b/core/translations/cs.json
@@ -33,7 +33,7 @@
   },
   "header": {
     "language": "cs-CZ",
-    "version": "2.12.5"
+    "version": "2.12.5.0"
   },
   "translations": {
     "addr_mismatch__contact_support_at": "Kontaktujte naši podporu na",

--- a/core/translations/de.json
+++ b/core/translations/de.json
@@ -33,7 +33,7 @@
   },
   "header": {
     "language": "de-DE",
-    "version": "2.12.3"
+    "version": "2.12.3.0"
   },
   "translations": {
     "addr_mismatch__contact_support_at": "Kontaktiere den Trezor Support unter",

--- a/core/translations/de.json
+++ b/core/translations/de.json
@@ -33,7 +33,7 @@
   },
   "header": {
     "language": "de-DE",
-    "version": "2.12.5"
+    "version": "2.12.5.0"
   },
   "translations": {
     "addr_mismatch__contact_support_at": "Kontaktiere den Trezor Support unter",

--- a/core/translations/en.json
+++ b/core/translations/en.json
@@ -1,7 +1,7 @@
 {
   "header": {
     "language": "en-US",
-    "version": "2.12.3"
+    "version": "2.12.3.0"
   },
   "translations": {
     "addr_mismatch__contact_support_at": "Please contact Trezor support at",

--- a/core/translations/en.json
+++ b/core/translations/en.json
@@ -1,7 +1,7 @@
 {
   "header": {
     "language": "en-US",
-    "version": "2.12.5"
+    "version": "2.12.5.0"
   },
   "translations": {
     "addr_mismatch__contact_support_at": "Please contact Trezor support at",

--- a/core/translations/es.json
+++ b/core/translations/es.json
@@ -33,7 +33,7 @@
   },
   "header": {
     "language": "es-ES",
-    "version": "2.12.3"
+    "version": "2.12.3.0"
   },
   "translations": {
     "addr_mismatch__contact_support_at": "Contacta con atención al cliente de Trezor en",

--- a/core/translations/es.json
+++ b/core/translations/es.json
@@ -33,7 +33,7 @@
   },
   "header": {
     "language": "es-ES",
-    "version": "2.12.5"
+    "version": "2.12.5.0"
   },
   "translations": {
     "addr_mismatch__contact_support_at": "Contacta con atención al cliente de Trezor en",

--- a/core/translations/fr.json
+++ b/core/translations/fr.json
@@ -33,7 +33,7 @@
   },
   "header": {
     "language": "fr-FR",
-    "version": "2.12.3"
+    "version": "2.12.3.0"
   },
   "translations": {
     "addr_mismatch__contact_support_at": {

--- a/core/translations/fr.json
+++ b/core/translations/fr.json
@@ -33,7 +33,7 @@
   },
   "header": {
     "language": "fr-FR",
-    "version": "2.12.5"
+    "version": "2.12.5.0"
   },
   "translations": {
     "addr_mismatch__contact_support_at": {

--- a/core/translations/order.py
+++ b/core/translations/order.py
@@ -1,4 +1,5 @@
 from __future__ import annotations
+
 import json
 import os
 import sys
@@ -40,14 +41,16 @@ def generate_new_order() -> None:
 
 def check_order() -> None:
     old_order: dict[str, str] = json.loads(output_file.read_text())
-    keys = { int(k) for k in old_order.keys() }
+    keys = {int(k) for k in old_order.keys()}
     for i in range(len(old_order)):
         if i not in keys:
             raise ValueError(f"order.json is missing index {i}")
 
 
 @click.command()
-@click.option("--check", is_flag=True, help="Do not modify order.json, only check if it's valid.")
+@click.option(
+    "--check", is_flag=True, help="Do not modify order.json, only check if it's valid."
+)
 def main(check: bool | None) -> None:
     check_order()
     if check:

--- a/core/translations/pt.json
+++ b/core/translations/pt.json
@@ -33,7 +33,7 @@
   },
   "header": {
     "language": "pt-BR",
-    "version": "2.12.3"
+    "version": "2.12.3.0"
   },
   "translations": {
     "addr_mismatch__contact_support_at": "Entre em contato com o suporte Trezor em",

--- a/core/translations/pt.json
+++ b/core/translations/pt.json
@@ -33,7 +33,7 @@
   },
   "header": {
     "language": "pt-BR",
-    "version": "2.12.5"
+    "version": "2.12.5.0"
   },
   "translations": {
     "addr_mismatch__contact_support_at": "Entre em contato com o suporte Trezor em",

--- a/docs/core/misc/translations.md
+++ b/docs/core/misc/translations.md
@@ -8,6 +8,8 @@ When no foreign-language is present, the English version is used - [en.json](../
 
 Translations files contain the translated strings and also all the special font characters as a link to `.json` files in [fonts](../../../core/translations/fonts) directory. Font files are not needed for `english`, which uses just default/built-in `ASCII` characters.
 
+Please note that while both firmware and translation blobs use version format with 4 components `major.minor.patch.build`, only the first 3 must match. The build numbers have no relation to each other.
+
 ## Generating blobs
 
 To generate up-to-date blobs, use `python core/translations/cli.py gen` - they will appear in `core/translations` as `translations-*.bin` files. The files contain information about the specific hardware model, language and device version.

--- a/docs/core/misc/translations.md
+++ b/docs/core/misc/translations.md
@@ -8,6 +8,8 @@ When no foreign-language is present, the English version is used - [en.json](htt
 
 Translations files contain the translated strings and also all the special font characters as a link to `.json` files in [fonts](https://github.com/trezor/trezor-firmware/tree/main/core/translations/fonts) directory. Font files are not needed for `english`, which uses just default/built-in `ASCII` characters.
 
+Please note that while both firmware and translation blobs use version format with 4 components `major.minor.patch.build`, only the first 3 must match. The build numbers have no relation to each other.
+
 ## Generating blobs
 
 To generate up-to-date blobs, use `python core/translations/cli.py gen` - they will appear in `core/translations` as `translations-*.bin` files. The files contain information about the specific hardware model, language and device version.

--- a/python/src/trezorlib/_internal/translations.py
+++ b/python/src/trezorlib/_internal/translations.py
@@ -63,9 +63,17 @@ class JsonDef(TypedDict):
 
 def version_from_json(json_str: str) -> VersionTuple:
     version_digits = [int(v) for v in json_str.split(".")]
-    if len(version_digits) < 4:
-        version_digits.extend([0] * (4 - len(version_digits)))
+    if len(version_digits) != 4:
+        raise RuntimeError(
+            f"Version string '{json_str}' does not have MAJOR.MINOR.PATCH.LANGBUILD format"
+        )
     return t.cast(VersionTuple, tuple(version_digits))
+
+
+def version_matches_firmware(
+    translation_version: VersionTuple, firmware_version: VersionTuple
+) -> bool:
+    return translation_version[:3] == firmware_version[:3]
 
 
 def _normalize(what: str) -> str:
@@ -86,7 +94,7 @@ def offsets_seq(data: t.Iterable[bytes]) -> t.Iterator[int]:
 class Header(Struct):
     language: str
     model: Model
-    firmware_version: VersionTuple
+    version: VersionTuple
     data_len: int
     data_hash: bytes
 
@@ -95,7 +103,7 @@ class Header(Struct):
         "magic" / c.Const(b"TR"),
         "language" / c.PaddedString(8, "ascii"),  # BCP47 language tag
         "model" / EnumAdapter(c.Bytes(4), Model),
-        "firmware_version" / TupleAdapter(c.Int8ul, c.Int8ul, c.Int8ul, c.Int8ul),
+        "version" / TupleAdapter(c.Int8ul, c.Int8ul, c.Int8ul, c.Int8ul),
         "data_len" / c.Int32ul,
         "data_hash" / c.Bytes(32),
         ALIGN_SUBCON,
@@ -527,7 +535,7 @@ def blob_from_defs(
     header = Header(
         language=json_header["language"],
         model=Model.from_trezor_model(model),
-        firmware_version=version,
+        version=version,
         data_len=len(data),
         data_hash=sha256(data).digest(),
     )

--- a/tools/bump-version.py
+++ b/tools/bump-version.py
@@ -101,7 +101,9 @@ def cli(project: str | Path, version: str) -> None:
             VERSION_PATCH=patch,
         )
         # also bump language JSONs
-        subprocess.run(["python", project / "translations" / "cli.py", "gen"])
+        subprocess.run(
+            ["python", project / "translations" / "cli.py", "version", "--reset"]
+        )
     elif parts[-1] == "legacy":
         bump_header(
             project / "firmware" / "version.h",

--- a/tools/bump-version.py
+++ b/tools/bump-version.py
@@ -110,7 +110,12 @@ def cli(project: str | Path, version: str) -> None:
         if project.match("core/embed/projects/firmware"):
             # also bump language JSONs
             subprocess.check_call(
-                ["python", project.parents[2] / "translations" / "cli.py", "gen"]
+                [
+                    "python",
+                    project.parents[2] / "translations" / "cli.py",
+                    "version",
+                    "--reset",
+                ]
             )
         if project.match("core/embed/projects/prodtest"):
             # refresh error_codes.json

--- a/tools/style.py.include
+++ b/tools/style.py.include
@@ -3,6 +3,7 @@
 ^core/site_scons/
 ^core/tests/
 ^core/tools/
+^core/translations/
 ^crypto/
 ^legacy/
 ^storage/


### PR DESCRIPTION
Followup of #7289. If `BUILD_VERSION` != 0 in `version.h` then `make gen_check` currently fails with:
```
python ./translations/cli.py gen --check
Traceback (most recent call last):
(...)
  File "/home/runner/work/trezor-firmware/trezor-firmware/core/./translations/cli.py", line 275, in gen
    version = tdir.update_version_from_h(check=check)
  File "/home/runner/work/trezor-firmware/trezor-firmware/core/./translations/cli.py", line 153, in update_version_from_h
    raise ValueError(
        f"Language {lang} has version {blob_version} not matching firmware version {version}"
    )
ValueError: Language en has version (2, 12, 3, 0) not matching firmware version (2, 12, 3, 66)
```

and, if skipped, also:

```
python ./translations/cli.py merkle-root > /dev/null
Error: Merkle root mismatch!
Expected:                  4cdc0abc51cbf4effe401a4a027bafc22e81a910520e03e31e6a78dff9d4325a
Stored in signatures.json: 69d2bab34080ef714f6c87b301fb645813036983c3b6f5ccb238203b5eeb7e70
Run `cli.py gen` to update the stored Merkle root.
```

If I understand this correctly the firmware build version and the translation build version are pretty much independent. To fix the issue, the PR:
* ignores the build versions in `cli.py gen --check`
* uses version string from the JSON in `cli.py gen` instead of from `version.h`

Since it confused me initially, I added some changes to try to avoid that in the future:
* make storing the build version in translation JSONs mandatory
* add helper functions for checking whether a translation version is compatible with a firmware version
* add `cli.py version` command to inspect/update translation versions
* fix minor firmware bug in `change_language.py` in the condition for silent install

CI results for firmware=2.12.3.66, translations=2.12.3.0: [prebuild](https://github.com/trezor/trezor-firmware/actions/runs/29461992351) [common](https://github.com/trezor/trezor-firmware/actions/runs/29462053724) [core](https://github.com/trezor/trezor-firmware/actions/runs/29461655701)
CI results for firmware=2.12.3.0, translations=2.12.3.4: [prebuild](https://github.com/trezor/trezor-firmware/actions/runs/29463773126) [common](https://github.com/trezor/trezor-firmware/actions/runs/29463755114) [core](https://github.com/trezor/trezor-firmware/actions/runs/29463741574)

----
outdated original description below

~~This change:~~
* ~~ignores the build version in `gen --check`~~
* ~~defaults to what's in `version.h` for `cli.py merkle-root` and `cli.py sign` if version is not explicitly specified, like `cli.py gen` does~~