### PR TITLE
refactor(core/ethereum): simplify calldata hashing

### DIFF
--- a/core/src/apps/ethereum/sign_tx.py
+++ b/core/src/apps/ethereum/sign_tx.py
@@ -132,35 +132,23 @@ _DATA_CHUNK_SIZE = const(1024)
 
 async def request_initial_data(msg: MsgInSignTx, sha: HashWriter) -> AnyBytes:
     """Request at most `MAX_DATA_STORED` which we keep locally"""
+    from trezor.utils import empty_bytearray
 
     data_length = msg.data_length
     if data_length > len(msg.data_initial_chunk):
         # pre-allocate memory
-        initial_data = bytearray(min(data_length, _MAX_DATA_STORED))
+        buf_capacity = min(data_length, _MAX_DATA_STORED)
+        buf = empty_bytearray(buf_capacity)
 
-        chunk = msg.data_initial_chunk
-        initial_data[0 : len(chunk)] = chunk
-        initial_data_length = len(chunk)
-        rlp.write_header(sha, data_length, rlp.STRING_HEADER_BYTE, chunk)
-        sha.extend(chunk)
-        data_left = data_length - initial_data_length
-        while (
-            data_left > 0 and initial_data_length + _DATA_CHUNK_SIZE <= _MAX_DATA_STORED
-        ):
-            chunk = await _get_next_chunk(data_left)
-            initial_data[initial_data_length : initial_data_length + len(chunk)] = chunk
-            data_left -= len(chunk)
-            initial_data_length += len(chunk)
-            sha.extend(chunk)
+        buf.extend(msg.data_initial_chunk)
+        while (data_left := buf_capacity - len(buf)) > 0:
+            buf.extend(await _get_next_chunk(data_left))
     else:
-        initial_data = msg.data_initial_chunk
-        initial_data_length = len(msg.data_initial_chunk)
-        rlp.write_header(
-            sha, data_length, rlp.STRING_HEADER_BYTE, msg.data_initial_chunk
-        )
-        sha.extend(msg.data_initial_chunk)
+        buf = msg.data_initial_chunk
 
-    return initial_data
+    rlp.write_header(sha, data_length, rlp.STRING_HEADER_BYTE, buf)
+    sha.extend(buf)
+    return buf
 
 
 async def confirm_tx_data(

--- a/core/src/apps/ethereum/sign_tx.py
+++ b/core/src/apps/ethereum/sign_tx.py
@@ -18,7 +18,7 @@ if TYPE_CHECKING:
     from buffer_types import AnyBytes
     from typing import Sequence
 
-    from trezor.messages import EthereumSignTx, EthereumTxAck
+    from trezor.messages import EthereumSignTx
     from trezor.ui.layouts import StrPropertyType
     from trezor.utils import HashWriter
 
@@ -147,8 +147,7 @@ async def request_initial_data(msg: MsgInSignTx, sha: HashWriter) -> AnyBytes:
         while (
             data_left > 0 and initial_data_length + _DATA_CHUNK_SIZE <= _MAX_DATA_STORED
         ):
-            resp = await _send_request_chunk(data_left)
-            chunk = resp.data_chunk
+            chunk = await _get_next_chunk(data_left)
             initial_data[initial_data_length : initial_data_length + len(chunk)] = chunk
             data_left -= len(chunk)
             initial_data_length += len(chunk)
@@ -305,8 +304,7 @@ def _get_digest_length(msg: EthereumSignTx, data_total: int) -> int:
 
 def create_data_chunk_loader(h: HashWriter) -> DataChunkLoader:
     async def data_chunk_loader(data_left: int) -> AnyBytes:
-        resp = await _send_request_chunk(data_left)
-        chunk = resp.data_chunk
+        chunk = await _get_next_chunk(data_left)
         h.extend(chunk)
         return chunk
 
@@ -329,13 +327,17 @@ async def _confirm_data_chunks(
         data_left -= len(chunk)
 
 
-async def _send_request_chunk(data_left: int) -> EthereumTxAck:
+async def _get_next_chunk(data_left: int) -> AnyBytes:
     from trezor.messages import EthereumTxAck
     from trezor.wire.context import call
 
     req = EthereumTxRequest()
     req.data_length = min(data_left, _DATA_CHUNK_SIZE)
-    return await call(req, EthereumTxAck)
+    resp = await call(req, EthereumTxAck)
+    data_chunk = resp.data_chunk
+    if len(data_chunk) > req.data_length:
+        raise DataError("Too much data")
+    return data_chunk
 
 
 def _sign_digest(

--- a/core/src/apps/ethereum/sign_tx.py
+++ b/core/src/apps/ethereum/sign_tx.py
@@ -6,12 +6,7 @@ from trezor.crypto import rlp
 from trezor.messages import EthereumTxRequest
 from trezor.wire import DataError
 
-from .helpers import (
-    address_from_bytes,
-    bytes_from_address,
-    get_data_confirmer,
-    get_progress_indicator,
-)
+from .helpers import address_from_bytes, bytes_from_address, get_data_confirmer
 from .keychain import with_keychain_from_chain_id
 
 if TYPE_CHECKING:
@@ -241,17 +236,15 @@ async def confirm_tx_data(
         )
     elif not clear_signed:
         if data_length > 0:
-            confirm_data_chunk = get_data_confirmer(data_length)
-        else:
-            confirm_data_chunk = get_progress_indicator(data_length)
-        token = (
-            None  # what we want to confirm here is the ETH amount being sent on-chain
-        )
-
-        # Stream, confirm and hash the rest of the calldata chunks.
-        await _confirm_data_chunks(
-            confirm_data_chunk, initial_data, data_length, data_chunk_loader
-        )
+            # Stream, confirm and hash the rest of the calldata chunks.
+            await _confirm_data_chunks(
+                get_data_confirmer(data_length),
+                initial_data,
+                data_length,
+                data_chunk_loader,
+            )
+        # what we want to confirm here is the ETH amount being sent on-chain
+        token = None
         return await require_confirm_tx(
             recipient_str,
             format_ethereum_amount(value, token, network),

--- a/core/src/apps/ethereum/sign_tx.py
+++ b/core/src/apps/ethereum/sign_tx.py
@@ -4,7 +4,6 @@ from typing import TYPE_CHECKING
 from trezor import TR
 from trezor.crypto import rlp
 from trezor.messages import EthereumTxRequest
-from trezor.utils import HashWriter
 from trezor.wire import DataError
 
 from .helpers import (
@@ -21,6 +20,7 @@ if TYPE_CHECKING:
 
     from trezor.messages import EthereumSignTx, EthereumTxAck
     from trezor.ui.layouts import StrPropertyType
+    from trezor.utils import HashWriter
 
     from apps.common.keychain import Keychain
     from apps.common.payment_request import PaymentRequestVerifier

--- a/tests/device_tests/ethereum/test_signtx.py
+++ b/tests/device_tests/ethereum/test_signtx.py
@@ -25,6 +25,7 @@ from trezorlib import ethereum, exceptions, messages, models
 from trezorlib.debuglink import DebugSession as Session
 from trezorlib.debuglink import message_filters
 from trezorlib.exceptions import TrezorFailure
+from trezorlib.protobuf import MessageType
 from trezorlib.tools import parse_path, unharden
 
 from ...common import parametrize_using_common_fixtures
@@ -533,6 +534,60 @@ def test_signtx_data_pagination(session: Session, scroll: bool, size: int):
     with client, pytest.raises(exceptions.Cancelled):
         client.set_input_flow(flow.get())
         _sign_tx_call()
+
+
+def test_signtx_data_bad_init(session: Session):
+    DATA = b"A" * 256
+
+    with session.test_ctx as client:
+
+        def _filter(msg: MessageType) -> MessageType:
+            req = messages.EthereumSignTx.ensure_isinstance(msg)
+            assert req.data_initial_chunk is not None
+            req.data_initial_chunk += b"EXTRA"
+            return req
+
+        client.set_filter(message_type=messages.EthereumSignTx, callback=_filter)
+        with pytest.raises(TrezorFailure, match="Invalid size of initial chunk"):
+            ethereum.sign_tx(
+                session,
+                n=parse_path("m/44h/60h/0h/0/0"),
+                nonce=0x0,
+                gas_price=0x14,
+                gas_limit=0x14,
+                to="0x1d1c328764a41bda0492b66baa30c4a339ff85ef",
+                chain_id=1,
+                value=0xA,
+                tx_type=None,
+                data=DATA,
+            )
+
+
+def test_signtx_data_bad_ack(session: Session):
+    DATA = b"A" * 2000
+
+    with session.test_ctx as client:
+
+        def _filter(msg: MessageType) -> MessageType:
+            req = messages.EthereumTxAck.ensure_isinstance(msg)
+            assert req.data_chunk is not None
+            req.data_chunk = req.data_chunk + b"EXTRA"
+            return req
+
+        client.set_filter(message_type=messages.EthereumTxAck, callback=_filter)
+        with pytest.raises(TrezorFailure, match="Too much data"):
+            ethereum.sign_tx(
+                session,
+                n=parse_path("m/44h/60h/0h/0/0"),
+                nonce=0x0,
+                gas_price=0x14,
+                gas_limit=0x14,
+                to="0x1d1c328764a41bda0492b66baa30c4a339ff85ef",
+                chain_id=1,
+                value=0xA,
+                tx_type=None,
+                data=DATA,
+            )
 
 
 @parametrize_using_common_fixtures("ethereum/sign_tx_staking.json")


### PR DESCRIPTION
- hash after initial data is loaded into RAM.
- check `EthereumTxAck.data_chunk` size:
https://github.com/trezor/trezor-firmware/blob/efccb7aaa3171aee3c3d1b59b8d684ee4ee52231/python/src/trezorlib/ethereum.py#L209-L212
Connect does the same: https://github.com/trezor/trezor-suite/blob/b542f7b8ee3d10748bcac853f8341b6cd7de920d/packages/connect/src/api/ethereum/ethereumSignTx.ts#L61
- drop progress bar if there is no calldata to confirm.

~Rebased over #7301.~

- [x] add device tests


# Notes to QA:

- Please sign ETH transactions with small and large calldata (>1kB) via Connect.