### PR TITLE
update nordic mcuboot

### DIFF
--- a/nordic/trezor/west-ncs2.9.yml
+++ b/nordic/trezor/west-ncs2.9.yml
@@ -17,5 +17,5 @@ manifest:
       import: true
     - name: mcuboot
       url: https://github.com/trezor/mcuboot
-      revision: 4f72f4eaa6c204f1193231f9695a5d8c3b253730 # trezor-v2.1.0-ncs3
+      revision: 3daca2a182073f0c64a4f42b62d6fe78a3dea9a4 # trezor-v2.1.0-ncs3
       path: bootloader/mcuboot

--- a/nordic/trezor/west.yml
+++ b/nordic/trezor/west.yml
@@ -17,6 +17,6 @@ manifest:
       import: true
     - name: mcuboot
       url: https://github.com/trezor/mcuboot
-      revision: de2be1c9718ccf531ad1d85ce35e4926faabe92e #trezor-ncs3.3.0
+      revision: 155694179aa290f0d692a26c1a9a08f5eec0c970 #trezor-ncs3.3.0
       path: bootloader/mcuboot
 


### PR DESCRIPTION
This PR fixes mcuboot build, which was broken by latest trezor-crypto updates.

As part of review, review the relevant mcuboot changes on respective branches for 2.9.0 and 3.3.0 sdks.