### PR TITLE
refactor(core/ethereum): handle staking/yielding in `confirm_tx_data()`

### DIFF
--- a/core/src/apps/ethereum/sign_tx.py
+++ b/core/src/apps/ethereum/sign_tx.py
@@ -214,7 +214,7 @@ async def confirm_tx_data(
     if staking_approver is not None:
         if payment_request_verifier is not None:
             raise DataError("Payment Requests don't support staking")
-        return staking_approver
+        return await staking_approver
 
     yielding_approver = await yielding.get_approver(
         msg, initial_data, network, address_bytes, maximum_fee, fee_items, sender_bytes
@@ -222,7 +222,7 @@ async def confirm_tx_data(
     if yielding_approver is not None:
         if payment_request_verifier is not None:
             raise DataError("Payment Requests don't support yielding")
-        return yielding_approver
+        return await yielding_approver
 
     value = int.from_bytes(msg.value, "big")
 

--- a/core/src/apps/ethereum/staking.py
+++ b/core/src/apps/ethereum/staking.py
@@ -10,7 +10,6 @@ if TYPE_CHECKING:
     from trezor.messages import EthereumNetworkInfo
     from trezor.ui.layouts import StrPropertyType
 
-    from .helpers import ConfirmDataFn
     from .keychain import MsgInSignTx
 
 
@@ -35,7 +34,7 @@ def get_approver(
     address_bytes: bytes,
     maximum_fee: str,
     fee_items: Iterable[StrPropertyType],
-) -> tuple[ConfirmDataFn, Coroutine[Any, Any, None]] | None:
+) -> Coroutine[Any, Any, None] | None:
     """
     Returns a awaitable confirmation for ETH staking approval.
 
@@ -43,7 +42,6 @@ def get_approver(
     """
 
     from .clear_signing import SC_FUNC_SIG_BYTES
-    from .helpers import get_progress_indicator
 
     # local_cache_attribute
     data_length = msg.data_length
@@ -51,6 +49,7 @@ def get_approver(
     if data_length > len(msg.data_initial_chunk):
         return None
 
+    # No more data should be loaded from host:
     data_reader = BufferReader(msg.data_initial_chunk)
     if data_reader.remaining_count() < SC_FUNC_SIG_BYTES:
         return None
@@ -58,17 +57,17 @@ def get_approver(
     func_sig = data_reader.read_memoryview(SC_FUNC_SIG_BYTES)
     if address_bytes in ADDRESSES_POOL:
         if func_sig == FUNC_SIG_STAKE:
-            return get_progress_indicator(data_length), _handle_staking_tx_stake(
+            return _handle_staking_tx_stake(
                 data_reader, msg, network, address_bytes, maximum_fee, fee_items
             )
         if func_sig == FUNC_SIG_UNSTAKE:
-            return get_progress_indicator(data_length), _handle_staking_tx_unstake(
+            return _handle_staking_tx_unstake(
                 data_reader, msg, network, address_bytes, maximum_fee, fee_items
             )
 
     if address_bytes in ADDRESSES_ACCOUNTING:
         if func_sig == FUNC_SIG_CLAIM:
-            return get_progress_indicator(data_length), _handle_staking_tx_claim(
+            return _handle_staking_tx_claim(
                 data_reader,
                 msg,
                 address_bytes,

--- a/core/src/apps/ethereum/yielding.py
+++ b/core/src/apps/ethereum/yielding.py
@@ -12,7 +12,6 @@ if TYPE_CHECKING:
     from trezor.messages import EthereumNetworkInfo, EthereumTokenInfo
     from trezor.ui.layouts import StrPropertyType
 
-    from .helpers import ConfirmDataFn
     from .keychain import MsgInSignTx
     from .yielding_vaults import EthereumVaultInfo
 
@@ -117,14 +116,14 @@ async def get_approver(
     maximum_fee: str,
     fee_items: Iterable[StrPropertyType],
     sender_bytes: AnyBytes,
-) -> tuple[ConfirmDataFn, Coroutine[Any, Any, None]] | None:
+) -> Coroutine[Any, Any, None] | None:
 
     from .clear_signing import SC_FUNC_SIG_BYTES
-    from .helpers import get_progress_indicator
 
     if msg.data_length > len(initial_data):
         return None
 
+    # No more data should be loaded from host:
     if len(initial_data) < SC_FUNC_SIG_BYTES:
         return None
 
@@ -169,10 +168,7 @@ async def get_approver(
             sender_bytes=sender_bytes,
         )
 
-    if handler is not None:
-        progress_indicator = get_progress_indicator(msg.data_length)
-        return progress_indicator, handler
-    return None
+    return handler
 
 
 async def _prepare_vault_tx(


### PR DESCRIPTION
This way, we don't need to call `get_progress_indicator()`, since all the data has been already loaded and hashed.

Related to #6680.