### PR TITLE
refactor(core/ethereum): simplify calldata streaming flow

### DIFF
--- a/core/src/apps/ethereum/helpers.py
+++ b/core/src/apps/ethereum/helpers.py
@@ -17,6 +17,10 @@ if TYPE_CHECKING:
 
     ConfirmDataFn = Callable[[AnyBytes], Awaitable[None]]
 
+    # Fetch the next calldata chunk from host.
+    # `data_left: int` argument is provided.
+    DataChunkLoader = Callable[[int], Awaitable[AnyBytes]]
+
 
 RSKIP60_NETWORKS = (30, 31)
 

--- a/core/src/apps/ethereum/sign_tx.py
+++ b/core/src/apps/ethereum/sign_tx.py
@@ -17,7 +17,7 @@ from .keychain import with_keychain_from_chain_id
 
 if TYPE_CHECKING:
     from buffer_types import AnyBytes
-    from typing import Any, Coroutine, Sequence
+    from typing import Sequence
 
     from trezor.messages import EthereumSignTx, EthereumTxAck
     from trezor.ui.layouts import StrPropertyType
@@ -26,7 +26,7 @@ if TYPE_CHECKING:
     from apps.common.payment_request import PaymentRequestVerifier
 
     from .definitions import Definitions
-    from .helpers import ConfirmDataFn
+    from .helpers import ConfirmDataFn, DataChunkLoader
     from .keychain import MsgInSignTx
 
 
@@ -98,7 +98,8 @@ async def sign_tx(
 
     initial_data = await request_initial_data(msg, sha)
 
-    confirmation = await confirm_tx_data(
+    # Confirm the transaction, using special layouts for staking, yielding and clear-signing (if supported).
+    await confirm_tx_data(
         initial_data,
         msg,
         defs,
@@ -107,9 +108,9 @@ async def sign_tx(
         fee_items,
         payment_req_verifier,
         sender_bytes,
+        # Hash and confirm the rest of transaction calldata while loading it from the host.
+        create_data_chunk_loader(sha),
     )
-
-    await confirm_data_and_summary(confirmation, initial_data, data_length, sha)
 
     # eip 155 replay protection
     rlp.write(sha, msg.chain_id)
@@ -123,30 +124,6 @@ async def sign_tx(
 
     show_continue_in_app(TR.send__transaction_signed)
     return result
-
-
-async def confirm_data_and_summary(
-    confirmation: tuple[ConfirmDataFn, Coroutine[Any, Any, None]] | None,
-    initial_data: AnyBytes,
-    data_length: int,
-    sha: HashWriter,
-) -> None:
-    if confirmation is None:
-        return  # clear-signing took place - nothing more to confirm
-
-    confirm_data_chunk, confirm_summary = confirmation
-    await confirm_data_chunk(initial_data)
-
-    data_left = data_length - len(initial_data)
-    while data_left > 0:
-        resp = await _send_request_chunk(data_left)
-        chunk = resp.data_chunk
-        await confirm_data_chunk(chunk)
-        data_left -= len(chunk)
-        sha.extend(chunk)
-
-    # blind signer's summary
-    await confirm_summary
 
 
 _MAX_DATA_STORED = const(6144)
@@ -196,9 +173,9 @@ async def confirm_tx_data(
     fee_items: Sequence[StrPropertyType],
     payment_request_verifier: PaymentRequestVerifier | None,
     sender_bytes: AnyBytes,
-) -> tuple[ConfirmDataFn, Coroutine[Any, Any, None]] | None:
-    """Returns data chunk callback and transaction summary layout to be awaited.
-    `None` implies clear signing attempted and succeeded."""
+    data_chunk_loader: DataChunkLoader,
+) -> None:
+    """Clear-sign the transaction or confirm calldata chunks."""
 
     from . import clear_signing, staking, yielding
     from .helpers import format_ethereum_amount
@@ -264,7 +241,7 @@ async def confirm_tx_data(
 
         payment_request_verifier.add_output(value, recipient_str or "")
         payment_request_verifier.verify()
-        return get_progress_indicator(data_length), require_confirm_payment_request(
+        return await require_confirm_payment_request(
             recipient_str,
             msg.payment_req,
             msg.address_n,
@@ -284,7 +261,11 @@ async def confirm_tx_data(
             None  # what we want to confirm here is the ETH amount being sent on-chain
         )
 
-        return confirm_data_chunk, require_confirm_tx(
+        # Stream, confirm and hash the rest of the calldata chunks.
+        await _confirm_data_chunks(
+            confirm_data_chunk, initial_data, data_length, data_chunk_loader
+        )
+        return await require_confirm_tx(
             recipient_str,
             format_ethereum_amount(value, token, network),
             address_bytes,
@@ -295,8 +276,6 @@ async def confirm_tx_data(
             is_send=(data_length == 0),
             chunkify=bool(msg.chunkify),
         )
-    else:
-        return None
 
 
 def _get_digest_length(msg: EthereumSignTx, data_total: int) -> int:
@@ -322,6 +301,32 @@ def _get_digest_length(msg: EthereumSignTx, data_total: int) -> int:
     length += data_total
 
     return length
+
+
+def create_data_chunk_loader(h: HashWriter) -> DataChunkLoader:
+    async def data_chunk_loader(data_left: int) -> AnyBytes:
+        resp = await _send_request_chunk(data_left)
+        chunk = resp.data_chunk
+        h.extend(chunk)
+        return chunk
+
+    return data_chunk_loader
+
+
+async def _confirm_data_chunks(
+    confirm_data_chunk: ConfirmDataFn,
+    initial_data: AnyBytes,
+    data_length: int,
+    data_chunk_loader: DataChunkLoader,
+) -> None:
+    await confirm_data_chunk(initial_data)
+    data_left = data_length - len(initial_data)
+    while data_left > 0:
+        chunk = await data_chunk_loader(data_left)
+        # `confirm_data_chunk` will raise on cancellation, so
+        # `data_chunk_loader`-computed hash will be discarded.
+        await confirm_data_chunk(chunk)
+        data_left -= len(chunk)
 
 
 async def _send_request_chunk(data_left: int) -> EthereumTxAck:

--- a/core/src/apps/ethereum/sign_tx_eip1559.py
+++ b/core/src/apps/ethereum/sign_tx_eip1559.py
@@ -44,8 +44,8 @@ async def sign_tx_eip1559(
     from .helpers import format_ethereum_amount, get_fee_items_eip1559, keccak256
     from .sign_tx import (
         check_common_fields,
-        confirm_data_and_summary,
         confirm_tx_data,
+        create_data_chunk_loader,
         request_initial_data,
     )
 
@@ -103,7 +103,8 @@ async def sign_tx_eip1559(
 
     initial_data = await request_initial_data(msg, sha)
 
-    confirmation = await confirm_tx_data(
+    # Confirm the transaction, using special layouts for staking, yielding and clear-signing (if supported).
+    await confirm_tx_data(
         initial_data,
         msg,
         defs,
@@ -112,9 +113,9 @@ async def sign_tx_eip1559(
         fee_items,
         payment_req_verifier,
         sender_bytes,
+        # Hash and confirm the rest of transaction calldata while loading it from the host.
+        create_data_chunk_loader(sha),
     )
-
-    await confirm_data_and_summary(confirmation, initial_data, data_length, sha)
 
     # write_access_list
     payload_length = sum(access_list_item_length(i) for i in msg.access_list)


### PR DESCRIPTION
There is no need for calling `confirm_tx_data` and then `confirm_data_and_summary`, since we can do calldata streaming (while hashing and confirming) in `confirm_tx_data`.

~Rebased over #7299.~
Related to #6680.