### PR TITLE
refactor(core/ethereum): simplify empty calldata handling

### DIFF
--- a/core/src/apps/ethereum/helpers.py
+++ b/core/src/apps/ethereum/helpers.py
@@ -17,6 +17,10 @@ if TYPE_CHECKING:
 
     ConfirmDataFn = Callable[[AnyBytes], Awaitable[None]]
 
+    # Fetch the next calldata chunk from host.
+    # `data_left: int` argument is provided.
+    DataChunkLoader = Callable[[int], Awaitable[AnyBytes]]
+
 
 RSKIP60_NETWORKS = (30, 31)
 

--- a/core/src/apps/ethereum/sign_tx.py
+++ b/core/src/apps/ethereum/sign_tx.py
@@ -6,12 +6,7 @@ from trezor.crypto import rlp
 from trezor.messages import EthereumTxRequest
 from trezor.wire import DataError
 
-from .helpers import (
-    address_from_bytes,
-    bytes_from_address,
-    get_data_confirmer,
-    get_progress_indicator,
-)
+from .helpers import address_from_bytes, bytes_from_address, get_data_confirmer
 from .keychain import with_keychain_from_chain_id
 
 if TYPE_CHECKING:
@@ -243,17 +238,15 @@ async def confirm_tx_data(
         )
     elif not clear_signed:
         if data_length > 0:
-            confirm_data_chunk = get_data_confirmer(data_length)
-        else:
-            confirm_data_chunk = get_progress_indicator(data_length)
-        token = (
-            None  # what we want to confirm here is the ETH amount being sent on-chain
-        )
-
-        # Stream, confirm and hash the rest of the calldata chunks.
-        await _confirm_data_chunks(
-            confirm_data_chunk, initial_data, data_length, data_chunk_loader
-        )
+            # Stream, confirm and hash the rest of the calldata chunks.
+            await _confirm_data_chunks(
+                get_data_confirmer(data_length),
+                initial_data,
+                data_length,
+                data_chunk_loader,
+            )
+        # what we want to confirm here is the ETH amount being sent on-chain
+        token = None
         return await require_confirm_tx(
             recipient_str,
             format_ethereum_amount(value, token, network),

--- a/core/src/apps/ethereum/sign_tx.py
+++ b/core/src/apps/ethereum/sign_tx.py
@@ -132,35 +132,25 @@ _DATA_CHUNK_SIZE = const(1024)
 
 async def request_initial_data(msg: MsgInSignTx, sha: HashWriter) -> AnyBytes:
     """Request at most `MAX_DATA_STORED` which we keep locally"""
+    from trezor.utils import empty_bytearray
 
     data_length = msg.data_length
     if data_length > len(msg.data_initial_chunk):
         # pre-allocate memory
-        initial_data = bytearray(min(data_length, _MAX_DATA_STORED))
+        buf_capacity = min(data_length, _MAX_DATA_STORED)
+        buf = empty_bytearray(buf_capacity)
+        buf.extend(msg.data_initial_chunk)
 
-        chunk = msg.data_initial_chunk
-        initial_data[0 : len(chunk)] = chunk
-        initial_data_length = len(chunk)
-        rlp.write_header(sha, data_length, rlp.STRING_HEADER_BYTE, chunk)
-        sha.extend(chunk)
-        data_left = data_length - initial_data_length
-        while (
-            data_left > 0 and initial_data_length + _DATA_CHUNK_SIZE <= _MAX_DATA_STORED
-        ):
+        # preload `buf_capacity` bytes from the host into `buf`
+        while (data_left := buf_capacity - len(buf)) > 0:
             chunk = await _get_next_chunk(data_left)
-            initial_data[initial_data_length : initial_data_length + len(chunk)] = chunk
-            data_left -= len(chunk)
-            initial_data_length += len(chunk)
-            sha.extend(chunk)
+            buf.extend(chunk)
     else:
-        initial_data = msg.data_initial_chunk
-        initial_data_length = len(msg.data_initial_chunk)
-        rlp.write_header(
-            sha, data_length, rlp.STRING_HEADER_BYTE, msg.data_initial_chunk
-        )
-        sha.extend(msg.data_initial_chunk)
+        buf = msg.data_initial_chunk
 
-    return initial_data
+    rlp.write_header(sha, data_length, rlp.STRING_HEADER_BYTE, buf)
+    sha.extend(buf)
+    return buf
 
 
 async def confirm_tx_data(

--- a/core/src/apps/ethereum/sign_tx.py
+++ b/core/src/apps/ethereum/sign_tx.py
@@ -19,7 +19,7 @@ if TYPE_CHECKING:
     from buffer_types import AnyBytes
     from typing import Sequence
 
-    from trezor.messages import EthereumSignTx, EthereumTxAck
+    from trezor.messages import EthereumSignTx
     from trezor.ui.layouts import StrPropertyType
 
     from apps.common.keychain import Keychain
@@ -147,8 +147,7 @@ async def request_initial_data(msg: MsgInSignTx, sha: HashWriter) -> AnyBytes:
         while (
             data_left > 0 and initial_data_length + _DATA_CHUNK_SIZE <= _MAX_DATA_STORED
         ):
-            resp = await _send_request_chunk(data_left)
-            chunk = resp.data_chunk
+            chunk = await _get_next_chunk(data_left)
             initial_data[initial_data_length : initial_data_length + len(chunk)] = chunk
             data_left -= len(chunk)
             initial_data_length += len(chunk)
@@ -305,8 +304,7 @@ def _get_digest_length(msg: EthereumSignTx, data_total: int) -> int:
 
 def create_data_chunk_loader(h: HashWriter) -> DataChunkLoader:
     async def data_chunk_loader(data_left: int) -> AnyBytes:
-        resp = await _send_request_chunk(data_left)
-        chunk = resp.data_chunk
+        chunk = await _get_next_chunk(data_left)
         h.extend(chunk)
         return chunk
 
@@ -329,13 +327,17 @@ async def _confirm_data_chunks(
         data_left -= len(chunk)
 
 
-async def _send_request_chunk(data_left: int) -> EthereumTxAck:
+async def _get_next_chunk(data_left: int) -> AnyBytes:
     from trezor.messages import EthereumTxAck
     from trezor.wire.context import call
 
     req = EthereumTxRequest()
     req.data_length = min(data_left, _DATA_CHUNK_SIZE)
-    return await call(req, EthereumTxAck)
+    resp = await call(req, EthereumTxAck)
+    data_chunk = resp.data_chunk
+    if len(data_chunk) != req.data_length:
+        raise DataError("Data length mismatch")
+    return data_chunk
 
 
 def _sign_digest(

--- a/core/src/apps/ethereum/sign_tx.py
+++ b/core/src/apps/ethereum/sign_tx.py
@@ -17,7 +17,7 @@ from .keychain import with_keychain_from_chain_id
 
 if TYPE_CHECKING:
     from buffer_types import AnyBytes
-    from typing import Any, Coroutine, Sequence
+    from typing import Sequence
 
     from trezor.messages import EthereumSignTx, EthereumTxAck
     from trezor.ui.layouts import StrPropertyType
@@ -26,7 +26,7 @@ if TYPE_CHECKING:
     from apps.common.payment_request import PaymentRequestVerifier
 
     from .definitions import Definitions
-    from .helpers import ConfirmDataFn
+    from .helpers import ConfirmDataFn, DataChunkLoader
     from .keychain import MsgInSignTx
 
 
@@ -98,7 +98,8 @@ async def sign_tx(
 
     initial_data = await request_initial_data(msg, sha)
 
-    confirmation = await confirm_tx_data(
+    # Confirm the transaction, using special layouts for staking, yielding and clear-signing (if supported).
+    await confirm_tx_data(
         initial_data,
         msg,
         defs,
@@ -107,9 +108,9 @@ async def sign_tx(
         fee_items,
         payment_req_verifier,
         sender_bytes,
+        # Hash and confirm the rest of transaction calldata while loading it from the host.
+        create_data_chunk_loader(sha),
     )
-
-    await confirm_data_and_summary(confirmation, initial_data, data_length, sha)
 
     # eip 155 replay protection
     rlp.write(sha, msg.chain_id)
@@ -123,30 +124,6 @@ async def sign_tx(
 
     show_continue_in_app(TR.send__transaction_signed)
     return result
-
-
-async def confirm_data_and_summary(
-    confirmation: tuple[ConfirmDataFn, Coroutine[Any, Any, None]] | None,
-    initial_data: AnyBytes,
-    data_length: int,
-    sha: HashWriter,
-) -> None:
-    if confirmation is None:
-        return  # clear-signing took place - nothing more to confirm
-
-    confirm_data_chunk, confirm_summary = confirmation
-    await confirm_data_chunk(initial_data)
-
-    data_left = data_length - len(initial_data)
-    while data_left > 0:
-        resp = await _send_request_chunk(data_left)
-        chunk = resp.data_chunk
-        await confirm_data_chunk(chunk)
-        data_left -= len(chunk)
-        sha.extend(chunk)
-
-    # blind signer's summary
-    await confirm_summary
 
 
 _MAX_DATA_STORED = const(6144)
@@ -196,9 +173,9 @@ async def confirm_tx_data(
     fee_items: Sequence[StrPropertyType],
     payment_request_verifier: PaymentRequestVerifier | None,
     sender_bytes: AnyBytes,
-) -> tuple[ConfirmDataFn, Coroutine[Any, Any, None]] | None:
-    """Returns data chunk callback and transaction summary layout to be awaited.
-    `None` implies clear signing attempted and succeeded."""
+    data_chunk_loader: DataChunkLoader,
+) -> None:
+    """Clear-sign the transaction or confirm calldata chunks."""
 
     from . import clear_signing, staking, yielding
     from .helpers import format_ethereum_amount
@@ -264,7 +241,7 @@ async def confirm_tx_data(
 
         payment_request_verifier.add_output(value, recipient_str or "")
         payment_request_verifier.verify()
-        return get_progress_indicator(data_length), require_confirm_payment_request(
+        return await require_confirm_payment_request(
             recipient_str,
             msg.payment_req,
             msg.address_n,
@@ -284,7 +261,11 @@ async def confirm_tx_data(
             None  # what we want to confirm here is the ETH amount being sent on-chain
         )
 
-        return confirm_data_chunk, require_confirm_tx(
+        # Stream, confirm and hash the rest of the calldata chunks.
+        await _confirm_data_chunks(
+            confirm_data_chunk, initial_data, data_length, data_chunk_loader
+        )
+        return await require_confirm_tx(
             recipient_str,
             format_ethereum_amount(value, token, network),
             address_bytes,
@@ -295,8 +276,6 @@ async def confirm_tx_data(
             is_send=(data_length == 0),
             chunkify=bool(msg.chunkify),
         )
-    else:
-        return None
 
 
 def _get_digest_length(msg: EthereumSignTx, data_total: int) -> int:
@@ -322,6 +301,32 @@ def _get_digest_length(msg: EthereumSignTx, data_total: int) -> int:
     length += data_total
 
     return length
+
+
+def create_data_chunk_loader(h: HashWriter) -> DataChunkLoader:
+    async def data_chunk_loader(data_left: int) -> AnyBytes:
+        resp = await _send_request_chunk(data_left)
+        chunk = resp.data_chunk
+        h.extend(chunk)
+        return chunk
+
+    return data_chunk_loader
+
+
+async def _confirm_data_chunks(
+    confirm_data_chunk: ConfirmDataFn,
+    initial_data: AnyBytes,
+    data_length: int,
+    data_chunk_loader: DataChunkLoader,
+) -> None:
+    await confirm_data_chunk(initial_data)
+    data_left = data_length - len(initial_data)
+    while data_left > 0:
+        chunk = await data_chunk_loader(data_left)
+        # `confirm_data_chunk` will raise on cancellation, so
+        # `data_chunk_loader`-computed hash will be discarded.
+        await confirm_data_chunk(chunk)
+        data_left -= len(chunk)
 
 
 async def _send_request_chunk(data_left: int) -> EthereumTxAck:

--- a/core/src/apps/ethereum/sign_tx.py
+++ b/core/src/apps/ethereum/sign_tx.py
@@ -4,7 +4,6 @@ from typing import TYPE_CHECKING
 from trezor import TR
 from trezor.crypto import rlp
 from trezor.messages import EthereumTxRequest
-from trezor.utils import HashWriter
 from trezor.wire import DataError
 
 from .helpers import (
@@ -21,6 +20,7 @@ if TYPE_CHECKING:
 
     from trezor.messages import EthereumSignTx
     from trezor.ui.layouts import StrPropertyType
+    from trezor.utils import HashWriter
 
     from apps.common.keychain import Keychain
     from apps.common.payment_request import PaymentRequestVerifier

--- a/core/src/apps/ethereum/sign_tx_eip1559.py
+++ b/core/src/apps/ethereum/sign_tx_eip1559.py
@@ -44,8 +44,8 @@ async def sign_tx_eip1559(
     from .helpers import format_ethereum_amount, get_fee_items_eip1559, keccak256
     from .sign_tx import (
         check_common_fields,
-        confirm_data_and_summary,
         confirm_tx_data,
+        create_data_chunk_loader,
         request_initial_data,
     )
 
@@ -103,7 +103,8 @@ async def sign_tx_eip1559(
 
     initial_data = await request_initial_data(msg, sha)
 
-    confirmation = await confirm_tx_data(
+    # Confirm the transaction, using special layouts for staking, yielding and clear-signing (if supported).
+    await confirm_tx_data(
         initial_data,
         msg,
         defs,
@@ -112,9 +113,9 @@ async def sign_tx_eip1559(
         fee_items,
         payment_req_verifier,
         sender_bytes,
+        # Hash and confirm the rest of transaction calldata while loading it from the host.
+        create_data_chunk_loader(sha),
     )
-
-    await confirm_data_and_summary(confirmation, initial_data, data_length, sha)
 
     # write_access_list
     payload_length = sum(access_list_item_length(i) for i in msg.access_list)


### PR DESCRIPTION
No need to call `get_progress_indicator()` if there is not calldata.
We don't need to confirm/hash it as well.

Rebased over #7297.