### PR TITLE
feat(core): add chunkify param to TronSignTx

### DIFF
--- a/common/protob/messages-tron.proto
+++ b/common/protob/messages-tron.proto
@@ -47,6 +47,7 @@ message TronSignTx {
                                          // not a Tron protocol limitation)
     required uint64 timestamp = 6;       // Transaction timestamp, set as the transaction creation time
     optional uint64 fee_limit = 7;  // Not TRX. Maximum Energy cost. Only for deploying or triggering smart contracts.
+    optional bool chunkify = 8;     // Display the address in chunks of 4 characters
 }
 
 /**

--- a/common/tests/fixtures/tron/sign_tx.json
+++ b/common/tests/fixtures/tron/sign_tx.json
@@ -52,6 +52,53 @@
       }
     },
     {
+      "name": "TransferContract_chunkify_False",
+      "parameters": {
+        "address_n": "m/44'/195'/0'/0/0",
+        "chunkify": false,
+        "tx": {
+          "ref_block_bytes": "e942",
+          "ref_block_hash": "6394747da9fee421",
+          "expiration": 1752562632000,
+          "timestamp": 1752562572000
+        },
+        "contract": {
+          "_message_type": "TronTransferContract",
+          "owner_address": "41f2cd810c48c401d392ead3c6e1e1cb9f57750a58",
+          "to_address": "4141f82674a30ae1328745d08afe2d1a0a24195283",
+          "amount": 18123456
+        },
+        "raw_data_hex": "0a02e94222086394747da9fee42140c08afee680335a68080112640a2d747970652e676f6f676c65617069732e636f6d2f70726f746f636f6c2e5472616e73666572436f6e747261637412330a1541f2cd810c48c401d392ead3c6e1e1cb9f57750a5812154141f82674a30ae1328745d08afe2d1a0a2419528318c095d20870e0b5fae68033",
+        "raw": {
+          "visible": false,
+          "txID": "91813c4e057a4c881d9dc4981f041c33cffb17c41e860a53eb68e7995f5de821",
+          "raw_data_hex": "0a02e94222086394747da9fee42140c08afee680335a68080112640a2d747970652e676f6f676c65617069732e636f6d2f70726f746f636f6c2e5472616e73666572436f6e747261637412330a1541f2cd810c48c401d392ead3c6e1e1cb9f57750a5812154141f82674a30ae1328745d08afe2d1a0a2419528318c095d20870e0b5fae68033",
+          "raw_data": {
+            "contract": [
+              {
+                "parameter": {
+                  "value": {
+                    "to_address": "4141f82674a30ae1328745d08afe2d1a0a24195283",
+                    "owner_address": "41f2cd810c48c401d392ead3c6e1e1cb9f57750a58",
+                    "amount": 18123456
+                  },
+                  "type_url": "type.googleapis.com/protocol.TransferContract"
+                },
+                "type": "TransferContract"
+              }
+            ],
+            "ref_block_bytes": "e942",
+            "ref_block_hash": "6394747da9fee421",
+            "expiration": 1752562632000,
+            "timestamp": 1752562572000
+          }
+        }
+      },
+      "result": {
+        "signature": "a7f8602b02413e9dded0170daa5b4ada9a2679198af276be456f4faea1bc326f5070789bec5e6471de3f726f4fe0c9daced8df183e4a62804db26d5650c59a521C"
+      }
+    },
+    {
       "name": "TransferContract_amount_int64_max",
       "parameters": {
         "address_n": "m/44'/195'/0'/0/0",
@@ -660,8 +707,7 @@
       "result": {
         "signature": "6147d601b05fc3c2da8c33e303d4f2a866f5f6da424a87dd89c31ed92cbac204151d5ae4a316be889cc48f1cefefc742959f2eab40e62ff8a890c726dcb4be5d1B"
       }
-    }
-    ,
+    },
     {
       "name": "TriggerSmartContract_transfer_TRC20_fee_too_high",
       "parameters": {
@@ -756,8 +802,7 @@
       "result": {
         "signature": "41d04615b2aa579831d1b862194bba46251e23e8982e63d3a3da5d02e0a95bba1860859b6da4094f3d29527fbec0642e5592e1134399e5fa3fedcda12a6bdb9d1C"
       }
-    }
-    ,
+    },
     {
       "name": "Approve_TRC-20",
       "parameters": {
@@ -805,8 +850,7 @@
       "result": {
         "signature": "a98b753f6c2e6d63996327c452ba781e6f87f9cff100c356281998a270e937a60b7f009f84c94c80ee593b2cf28323897a9781ab4db49462d4194e3a926ea3ee1C"
       }
-    }
-    ,
+    },
     {
       "name": "Approve_TRC-20_Unlimited",
       "parameters": {

--- a/core/.changelog.d/6730.fixed
+++ b/core/.changelog.d/6730.fixed
@@ -1,0 +1,1 @@
+Tron: add `chunkify` support to SignTx address confirmation.

--- a/core/src/apps/tron/layout.py
+++ b/core/src/apps/tron/layout.py
@@ -32,19 +32,22 @@ def format_energy_amount(amount: int) -> str:
 
 
 async def confirm_trx_transfer(
-    contract: TronTransferContract, account_details: tuple[str | None, str]
+    contract: TronTransferContract,
+    account_details: tuple[str | None, str],
+    chunkify: bool,
 ) -> None:
     await layouts.confirm_tron_send(
         amount=format_trx_amount(contract.amount),
         fee=None,
         account_details=account_details,
         address=get_encoded_address(contract.to_address),
+        chunkify=chunkify,
     )
 
 
 # TODO: Refactor ETH references to crypto-neutral references.
 async def confirm_unknown_smart_contract(
-    contract: TronTriggerSmartContract, fee_limit: int
+    contract: TronTriggerSmartContract, fee_limit: int, chunkify: bool
 ) -> None:
 
     from trezor.enums import ButtonRequestType
@@ -61,7 +64,7 @@ async def confirm_unknown_smart_contract(
     await confirm_address(
         title=TR.ethereum__token_contract,
         address=contract_address,
-        chunkify=True,
+        chunkify=chunkify,
     )
 
     await confirm_blob(
@@ -87,6 +90,7 @@ async def confirm_known_trc20_smart_contract(
     fee_limit: int,
     token_decimals: int,
     token_symbol: str,
+    chunkify: bool,
 ) -> None:
     from trezor.ui.layouts import confirm_tron_approve, confirm_tron_transfer
 
@@ -106,7 +110,7 @@ async def confirm_known_trc20_smart_contract(
             amount_str=amount_str,
             is_revoke=is_revoke,
             maximum_fee=format_energy_amount(fee_limit),
-            chunkify=True,
+            chunkify=chunkify,
         )
     else:
         await confirm_tron_transfer(
@@ -115,7 +119,7 @@ async def confirm_known_trc20_smart_contract(
                 int.from_bytes(amount_arg, "big"), token_decimals, token_symbol
             ),
             maximum_fee=format_energy_amount(fee_limit),
-            chunkify=True,
+            chunkify=chunkify,
         )
 
 
@@ -124,6 +128,7 @@ async def confirm_freeze_operations(
     balance: int,
     resource: int,
     title: str,
+    chunkify: bool,
 ) -> None:
     from trezor.enums import TronResourceCode
     from trezor.ui.layouts import confirm_address, confirm_properties
@@ -131,7 +136,7 @@ async def confirm_freeze_operations(
     await confirm_address(
         title=title,
         address=get_encoded_address(owner_address),
-        chunkify=True,
+        chunkify=chunkify,
     )
 
     await confirm_properties(
@@ -153,6 +158,7 @@ async def confirm_claim(
     owner_address: str | None,
     account_details: tuple[str | None, str],
     intro_question: str,
+    chunkify: bool,
 ) -> None:
 
     title = TR.ethereum__staking_claim
@@ -166,7 +172,7 @@ async def confirm_claim(
             address=owner_address,
             verb=TR.buttons__continue,
             footer=(TR.address__warning_not_yours, True),
-            chunkify=True,
+            chunkify=chunkify,
         )
 
     await layouts.confirm_tron_claim(

--- a/core/src/apps/tron/sign_tx.py
+++ b/core/src/apps/tron/sign_tx.py
@@ -51,7 +51,7 @@ async def sign_tx(msg: TronSignTx, keychain: Keychain) -> TronSignature:
 
     fee_limit = msg.fee_limit or 0
     raw_contract = await process_contract(
-        contract, fee_limit, account_details, signer_address
+        contract, fee_limit, account_details, signer_address, bool(msg.chunkify)
     )
 
     raw_tx = messages.TronRawTransaction(
@@ -81,6 +81,7 @@ async def process_contract(
     fee_limit: int,
     account_details: tuple[str | None, str],
     signer_address: str,
+    chunkify: bool,
 ) -> TronRawContract:
 
     # Importing individual enums would de-clutter the code a bit.
@@ -109,11 +110,11 @@ async def process_contract(
         contract_type = TronRawContractType.TransferContract
         if contract.amount > _INT64_MAX:
             raise DataError("Tron: invalid transfer amount")
-        await confirm_trx_transfer(contract, account_details)
+        await confirm_trx_transfer(contract, account_details, chunkify)
 
     elif messages.TronTriggerSmartContract.is_type_of(contract):
         contract_type = TronRawContractType.TriggerSmartContract
-        await process_smart_contract(contract, fee_limit)
+        await process_smart_contract(contract, fee_limit, chunkify)
 
     elif messages.TronFreezeBalanceV2Contract.is_type_of(contract):
         from trezor.enums import TronResourceCode
@@ -125,6 +126,7 @@ async def process_contract(
             balance=contract.balance,
             resource=contract.resource,
             title=TR.ethereum__staking_stake,
+            chunkify=chunkify,
         )
 
         # TRON protocol uses proto3, which omits fields with default values from
@@ -146,6 +148,7 @@ async def process_contract(
             balance=contract.balance,
             resource=contract.resource,
             title=TR.ethereum__staking_unstake,
+            chunkify=chunkify,
         )
 
         if contract.resource == TronResourceCode.BANDWIDTH:
@@ -161,6 +164,7 @@ async def process_contract(
             owner_address if is_different_owner else None,
             account_details,
             TR.tron__claim_unfrozen_balance,
+            chunkify,
         )
 
     elif messages.TronWithdrawBalance.is_type_of(contract):
@@ -169,6 +173,7 @@ async def process_contract(
             owner_address if is_different_owner else None,
             account_details,
             TR.tron__claim_voting_rewards,
+            chunkify,
         )
 
     elif messages.TronVoteWitnessContract.is_type_of(contract):
@@ -193,18 +198,18 @@ async def process_contract(
 
 
 async def process_smart_contract(
-    contract: TronTriggerSmartContract, fee_limit: int
+    contract: TronTriggerSmartContract, fee_limit: int, chunkify: bool
 ) -> None:
-    if await process_known_trc20_contract(contract, fee_limit):
+    if await process_known_trc20_contract(contract, fee_limit, chunkify):
         return
     else:
-        await layout.confirm_unknown_smart_contract(contract, fee_limit)
+        await layout.confirm_unknown_smart_contract(contract, fee_limit, chunkify)
 
 
 async def process_known_trc20_contract(
-    contract: TronTriggerSmartContract, fee_limit: int
+    contract: TronTriggerSmartContract, fee_limit: int, chunkify: bool
 ) -> bool:
-    """Returns False when the contract is unrecoginsed. i.e. not (Transfer and known TRC-20)"""
+    """Returns False when the contract is unrecognised. i.e. not (Transfer and known TRC-20)"""
     from trezor.utils import BufferReader
 
     from .sc_constants import (
@@ -251,6 +256,7 @@ async def process_known_trc20_contract(
         fee_limit,
         token_decimals,
         token_symbol,
+        chunkify,
     )
     return True
 

--- a/core/src/trezor/messages.py
+++ b/core/src/trezor/messages.py
@@ -7304,6 +7304,7 @@ if TYPE_CHECKING:
         data: "AnyBytes | None"
         timestamp: "int"
         fee_limit: "int | None"
+        chunkify: "bool | None"
 
         def __init__(
             self,
@@ -7315,6 +7316,7 @@ if TYPE_CHECKING:
             address_n: "list[int] | None" = None,
             data: "AnyBytes | None" = None,
             fee_limit: "int | None" = None,
+            chunkify: "bool | None" = None,
         ) -> None:
             pass
 

--- a/core/src/trezor/ui/layouts/bolt/__init__.py
+++ b/core/src/trezor/ui/layouts/bolt/__init__.py
@@ -1775,7 +1775,7 @@ if not utils.BITCOIN_ONLY:
         fee: str | None,
         account_details: tuple[str | None, str],
         address: str,
-        chunkify: bool = True,
+        chunkify: bool = False,
     ) -> None:
         await confirm_address(
             title=TR.words__send,
@@ -1866,7 +1866,7 @@ if not utils.BITCOIN_ONLY:
         recipient_addr: str,
         amount_str: str,
         maximum_fee: str,
-        chunkify: bool = True,
+        chunkify: bool = False,
     ) -> None:
         br_name = "tron/transfer"
         title = TR.words__send

--- a/core/src/trezor/ui/layouts/caesar/__init__.py
+++ b/core/src/trezor/ui/layouts/caesar/__init__.py
@@ -1862,7 +1862,7 @@ if not utils.BITCOIN_ONLY:
         fee: str | None,
         account_details: tuple[str | None, str],
         address: str,
-        chunkify: bool = True,
+        chunkify: bool = False,
     ) -> None:
         await confirm_address(
             title=TR.words__send,
@@ -1889,7 +1889,7 @@ if not utils.BITCOIN_ONLY:
         amount_str: str,
         is_revoke: bool,
         maximum_fee: str,
-        chunkify: bool = True,
+        chunkify: bool = False,
     ) -> None:
         from ..properties import with_colon
 
@@ -1958,7 +1958,7 @@ if not utils.BITCOIN_ONLY:
         recipient_addr: str,
         amount_str: str,
         maximum_fee: str,
-        chunkify: bool = True,
+        chunkify: bool = False,
     ) -> None:
         from ..properties import with_colon
 

--- a/core/src/trezor/ui/layouts/delizia/__init__.py
+++ b/core/src/trezor/ui/layouts/delizia/__init__.py
@@ -1795,7 +1795,7 @@ if not utils.BITCOIN_ONLY:
         fee: str | None,
         account_details: tuple[str | None, str],
         address: str,
-        chunkify: bool = True,
+        chunkify: bool = False,
     ) -> None:
         await confirm_address(
             title=TR.words__send,
@@ -1818,7 +1818,7 @@ if not utils.BITCOIN_ONLY:
         recipient_addr: str,
         amount_str: str,
         maximum_fee: str,
-        chunkify: bool = True,
+        chunkify: bool = False,
     ) -> None:
 
         br_name = "tron/transfer"

--- a/core/src/trezor/ui/layouts/eckhart/__init__.py
+++ b/core/src/trezor/ui/layouts/eckhart/__init__.py
@@ -1898,7 +1898,7 @@ if not utils.BITCOIN_ONLY:
         fee: str | None,
         account_details: tuple[str | None, str],
         address: str,
-        chunkify: bool = True,
+        chunkify: bool = False,
     ) -> None:
         await confirm_address(
             title=TR.words__send,
@@ -1925,7 +1925,7 @@ if not utils.BITCOIN_ONLY:
         recipient_addr: str,
         amount_str: str,
         maximum_fee: str,
-        chunkify: bool = True,
+        chunkify: bool = False,
     ) -> None:
 
         br_name = "tron/transfer"
@@ -1974,7 +1974,7 @@ if not utils.BITCOIN_ONLY:
         amount_str: str,
         is_revoke: bool,
         maximum_fee: str,
-        chunkify: bool = True,
+        chunkify: bool = False,
     ) -> None:
 
         br_name = "tron/approve"

--- a/python/.changelog.d/6730.fixed
+++ b/python/.changelog.d/6730.fixed
@@ -1,0 +1,1 @@
+Tron: allow chunkified addresses.

--- a/python/src/trezorlib/messages.py
+++ b/python/src/trezorlib/messages.py
@@ -9213,6 +9213,7 @@ class TronSignTx(protobuf.MessageType):
         5: protobuf.Field("data", "bytes", repeated=False, required=False, default=None),
         6: protobuf.Field("timestamp", "uint64", repeated=False, required=True),
         7: protobuf.Field("fee_limit", "uint64", repeated=False, required=False, default=None),
+        8: protobuf.Field("chunkify", "bool", repeated=False, required=False, default=None),
     }
 
     def __init__(
@@ -9225,6 +9226,7 @@ class TronSignTx(protobuf.MessageType):
         address_n: Optional[Sequence["int"]] = None,
         data: Optional["bytes"] = None,
         fee_limit: Optional["int"] = None,
+        chunkify: Optional["bool"] = None,
     ) -> None:
         self.address_n: Sequence["int"] = address_n if address_n is not None else []
         self.ref_block_bytes = ref_block_bytes
@@ -9233,6 +9235,7 @@ class TronSignTx(protobuf.MessageType):
         self.timestamp = timestamp
         self.data = data
         self.fee_limit = fee_limit
+        self.chunkify = chunkify
 
 
 class TronContractRequest(protobuf.MessageType):

--- a/python/src/trezorlib/tron.py
+++ b/python/src/trezorlib/tron.py
@@ -136,8 +136,10 @@ def sign_tx(
     tx: messages.TronSignTx,
     contract: "TronMessageType",
     address_n: "Address",
+    chunkify: bool = False,
 ) -> messages.TronSignature:
     tx.address_n = address_n
+    tx.chunkify = chunkify
     resp = session.call(tx)
     messages.TronContractRequest.ensure_isinstance(resp)
     resp = session.call(contract)

--- a/rust/trezor-client/src/protos/generated/messages_tron.rs
+++ b/rust/trezor-client/src/protos/generated/messages_tron.rs
@@ -456,6 +456,8 @@ pub struct TronSignTx {
     pub timestamp: ::std::option::Option<u64>,
     // @@protoc_insertion_point(field:hw.trezor.messages.tron.TronSignTx.fee_limit)
     pub fee_limit: ::std::option::Option<u64>,
+    // @@protoc_insertion_point(field:hw.trezor.messages.tron.TronSignTx.chunkify)
+    pub chunkify: ::std::option::Option<bool>,
     // special fields
     // @@protoc_insertion_point(special_field:hw.trezor.messages.tron.TronSignTx.special_fields)
     pub special_fields: ::protobuf::SpecialFields,
@@ -637,8 +639,27 @@ impl TronSignTx {
         self.fee_limit = ::std::option::Option::Some(v);
     }
 
+    // optional bool chunkify = 8;
+
+    pub fn chunkify(&self) -> bool {
+        self.chunkify.unwrap_or(false)
+    }
+
+    pub fn clear_chunkify(&mut self) {
+        self.chunkify = ::std::option::Option::None;
+    }
+
+    pub fn has_chunkify(&self) -> bool {
+        self.chunkify.is_some()
+    }
+
+    // Param is passed by value, moved
+    pub fn set_chunkify(&mut self, v: bool) {
+        self.chunkify = ::std::option::Option::Some(v);
+    }
+
     fn generated_message_descriptor_data() -> ::protobuf::reflect::GeneratedMessageDescriptorData {
-        let mut fields = ::std::vec::Vec::with_capacity(7);
+        let mut fields = ::std::vec::Vec::with_capacity(8);
         let mut oneofs = ::std::vec::Vec::with_capacity(0);
         fields.push(::protobuf::reflect::rt::v2::make_vec_simpler_accessor::<_, _>(
             "address_n",
@@ -674,6 +695,11 @@ impl TronSignTx {
             "fee_limit",
             |m: &TronSignTx| { &m.fee_limit },
             |m: &mut TronSignTx| { &mut m.fee_limit },
+        ));
+        fields.push(::protobuf::reflect::rt::v2::make_option_accessor::<_, _>(
+            "chunkify",
+            |m: &TronSignTx| { &m.chunkify },
+            |m: &mut TronSignTx| { &mut m.chunkify },
         ));
         ::protobuf::reflect::GeneratedMessageDescriptorData::new_2::<TronSignTx>(
             "TronSignTx",
@@ -729,6 +755,9 @@ impl ::protobuf::Message for TronSignTx {
                 56 => {
                     self.fee_limit = ::std::option::Option::Some(is.read_uint64()?);
                 },
+                64 => {
+                    self.chunkify = ::std::option::Option::Some(is.read_bool()?);
+                },
                 tag => {
                     ::protobuf::rt::read_unknown_or_skip_group(tag, is, self.special_fields.mut_unknown_fields())?;
                 },
@@ -762,6 +791,9 @@ impl ::protobuf::Message for TronSignTx {
         if let Some(v) = self.fee_limit {
             my_size += ::protobuf::rt::uint64_size(7, v);
         }
+        if let Some(v) = self.chunkify {
+            my_size += 1 + 1;
+        }
         my_size += ::protobuf::rt::unknown_fields_size(self.special_fields.unknown_fields());
         self.special_fields.cached_size().set(my_size as u32);
         my_size
@@ -789,6 +821,9 @@ impl ::protobuf::Message for TronSignTx {
         if let Some(v) = self.fee_limit {
             os.write_uint64(7, v)?;
         }
+        if let Some(v) = self.chunkify {
+            os.write_bool(8, v)?;
+        }
         os.write_unknown_fields(self.special_fields.unknown_fields())?;
         ::std::result::Result::Ok(())
     }
@@ -813,6 +848,7 @@ impl ::protobuf::Message for TronSignTx {
         self.data = ::std::option::Option::None;
         self.timestamp = ::std::option::Option::None;
         self.fee_limit = ::std::option::Option::None;
+        self.chunkify = ::std::option::Option::None;
         self.special_fields.clear();
     }
 
@@ -825,6 +861,7 @@ impl ::protobuf::Message for TronSignTx {
             data: ::std::option::Option::None,
             timestamp: ::std::option::Option::None,
             fee_limit: ::std::option::Option::None,
+            chunkify: ::std::option::Option::None,
             special_fields: ::protobuf::SpecialFields::new(),
         };
         &instance
@@ -3813,53 +3850,54 @@ static file_descriptor_proto_data: &'static [u8] = b"\
     how_display\x18\x02\x20\x01(\x08R\x0bshowDisplay\x12\x1a\n\x08chunkify\
     \x18\x03\x20\x01(\x08R\x08chunkify\"9\n\x0bTronAddress\x12\x18\n\x07addr\
     ess\x18\x01\x20\x02(\tR\x07address\x12\x10\n\x03mac\x18\x02\x20\x01(\x0c\
-    R\x03mac\"\xe6\x01\n\nTronSignTx\x12\x1b\n\taddress_n\x18\x01\x20\x03(\r\
+    R\x03mac\"\x82\x02\n\nTronSignTx\x12\x1b\n\taddress_n\x18\x01\x20\x03(\r\
     R\x08addressN\x12&\n\x0fref_block_bytes\x18\x02\x20\x02(\x0cR\rrefBlockB\
     ytes\x12$\n\x0eref_block_hash\x18\x03\x20\x02(\x0cR\x0crefBlockHash\x12\
     \x1e\n\nexpiration\x18\x04\x20\x02(\x04R\nexpiration\x12\x12\n\x04data\
     \x18\x05\x20\x01(\x0cR\x04data\x12\x1c\n\ttimestamp\x18\x06\x20\x02(\x04\
-    R\ttimestamp\x12\x1b\n\tfee_limit\x18\x07\x20\x01(\x04R\x08feeLimit\"\
-    \x15\n\x13TronContractRequest\"r\n\x14TronTransferContract\x12#\n\rowner\
-    _address\x18\x01\x20\x02(\x0cR\x0cownerAddress\x12\x1d\n\nto_address\x18\
-    \x02\x20\x02(\x0cR\ttoAddress\x12\x16\n\x06amount\x18\x03\x20\x02(\x04R\
-    \x06amount\"\xcb\x01\n\x17TronVoteWitnessContract\x12#\n\rowner_address\
-    \x18\x01\x20\x02(\x0cR\x0cownerAddress\x12O\n\x05votes\x18\x02\x20\x03(\
-    \x0b29.hw.trezor.messages.tron.TronVoteWitnessContract.TronVoteR\x05vote\
-    s\x1a:\n\x08TronVote\x12\x18\n\x07address\x18\x01\x20\x02(\x0cR\x07addre\
-    ss\x12\x14\n\x05count\x18\x02\x20\x02(\x04R\x05count\"~\n\x18TronTrigger\
-    SmartContract\x12#\n\rowner_address\x18\x01\x20\x02(\x0cR\x0cownerAddres\
-    s\x12)\n\x10contract_address\x18\x02\x20\x02(\x0cR\x0fcontractAddress\
-    \x12\x12\n\x04data\x18\x04\x20\x02(\x0cR\x04data\"\xae\x01\n\x1bTronFree\
-    zeBalanceV2Contract\x12#\n\rowner_address\x18\x01\x20\x02(\x0cR\x0cowner\
-    Address\x12\x18\n\x07balance\x18\x02\x20\x02(\x04R\x07balance\x12P\n\x08\
-    resource\x18\x03\x20\x01(\x0e2).hw.trezor.messages.tron.TronResourceCode\
-    :\tBANDWIDTHR\x08resource\"\xb0\x01\n\x1dTronUnfreezeBalanceV2Contract\
-    \x12#\n\rowner_address\x18\x01\x20\x02(\x0cR\x0cownerAddress\x12\x18\n\
-    \x07balance\x18\x02\x20\x02(\x04R\x07balance\x12P\n\x08resource\x18\x03\
-    \x20\x01(\x0e2).hw.trezor.messages.tron.TronResourceCode:\tBANDWIDTHR\
-    \x08resource\";\n\x14TronWithdrawUnfreeze\x12#\n\rowner_address\x18\x01\
-    \x20\x02(\x0cR\x0cownerAddress\":\n\x13TronWithdrawBalance\x12#\n\rowner\
-    _address\x18\x01\x20\x02(\x0cR\x0cownerAddress\"-\n\rTronSignature\x12\
-    \x1c\n\tsignature\x18\x01\x20\x02(\x0cR\tsignature\"\xb2\x06\n\x12TronRa\
-    wTransaction\x12&\n\x0fref_block_bytes\x18\x01\x20\x02(\x0cR\rrefBlockBy\
-    tes\x12$\n\x0eref_block_hash\x18\x04\x20\x02(\x0cR\x0crefBlockHash\x12\
-    \x1e\n\nexpiration\x18\x08\x20\x02(\x04R\nexpiration\x12\x12\n\x04data\
-    \x18\n\x20\x01(\x0cR\x04data\x12W\n\x08contract\x18\x0b\x20\x03(\x0b2;.h\
-    w.trezor.messages.tron.TronRawTransaction.TronRawContractR\x08contract\
-    \x12\x1c\n\ttimestamp\x18\x0e\x20\x02(\x04R\ttimestamp\x12\x1b\n\tfee_li\
-    mit\x18\x12\x20\x01(\x04R\x08feeLimit\x1a\x85\x04\n\x0fTronRawContract\
-    \x12c\n\x04type\x18\x01\x20\x02(\x0e2O.hw.trezor.messages.tron.TronRawTr\
-    ansaction.TronRawContract.TronRawContractTypeR\x04type\x12j\n\tparameter\
-    \x18\x02\x20\x02(\x0b2L.hw.trezor.messages.tron.TronRawTransaction.TronR\
-    awContract.TronRawParameterR\tparameter\x1aC\n\x10TronRawParameter\x12\
-    \x19\n\x08type_url\x18\x01\x20\x02(\tR\x07typeUrl\x12\x14\n\x05value\x18\
-    \x02\x20\x02(\x0cR\x05value\"\xdb\x01\n\x13TronRawContractType\x12\x14\n\
-    \x10TransferContract\x10\x01\x12\x17\n\x13VoteWitnessContract\x10\x04\
-    \x12\x1b\n\x17WithdrawBalanceContract\x10\r\x12\x18\n\x14TriggerSmartCon\
-    tract\x10\x1f\x12\x1b\n\x17FreezeBalanceV2Contract\x106\x12\x1d\n\x19Unf\
-    reezeBalanceV2Contract\x107\x12\"\n\x1eWithdrawExpireUnfreezeContract\
-    \x108*-\n\x10TronResourceCode\x12\r\n\tBANDWIDTH\x10\0\x12\n\n\x06ENERGY\
-    \x10\x01B8\n#com.satoshilabs.trezor.lib.protobufB\x11TrezorMessageTron\
+    R\ttimestamp\x12\x1b\n\tfee_limit\x18\x07\x20\x01(\x04R\x08feeLimit\x12\
+    \x1a\n\x08chunkify\x18\x08\x20\x01(\x08R\x08chunkify\"\x15\n\x13TronCont\
+    ractRequest\"r\n\x14TronTransferContract\x12#\n\rowner_address\x18\x01\
+    \x20\x02(\x0cR\x0cownerAddress\x12\x1d\n\nto_address\x18\x02\x20\x02(\
+    \x0cR\ttoAddress\x12\x16\n\x06amount\x18\x03\x20\x02(\x04R\x06amount\"\
+    \xcb\x01\n\x17TronVoteWitnessContract\x12#\n\rowner_address\x18\x01\x20\
+    \x02(\x0cR\x0cownerAddress\x12O\n\x05votes\x18\x02\x20\x03(\x0b29.hw.tre\
+    zor.messages.tron.TronVoteWitnessContract.TronVoteR\x05votes\x1a:\n\x08T\
+    ronVote\x12\x18\n\x07address\x18\x01\x20\x02(\x0cR\x07address\x12\x14\n\
+    \x05count\x18\x02\x20\x02(\x04R\x05count\"~\n\x18TronTriggerSmartContrac\
+    t\x12#\n\rowner_address\x18\x01\x20\x02(\x0cR\x0cownerAddress\x12)\n\x10\
+    contract_address\x18\x02\x20\x02(\x0cR\x0fcontractAddress\x12\x12\n\x04d\
+    ata\x18\x04\x20\x02(\x0cR\x04data\"\xae\x01\n\x1bTronFreezeBalanceV2Cont\
+    ract\x12#\n\rowner_address\x18\x01\x20\x02(\x0cR\x0cownerAddress\x12\x18\
+    \n\x07balance\x18\x02\x20\x02(\x04R\x07balance\x12P\n\x08resource\x18\
+    \x03\x20\x01(\x0e2).hw.trezor.messages.tron.TronResourceCode:\tBANDWIDTH\
+    R\x08resource\"\xb0\x01\n\x1dTronUnfreezeBalanceV2Contract\x12#\n\rowner\
+    _address\x18\x01\x20\x02(\x0cR\x0cownerAddress\x12\x18\n\x07balance\x18\
+    \x02\x20\x02(\x04R\x07balance\x12P\n\x08resource\x18\x03\x20\x01(\x0e2).\
+    hw.trezor.messages.tron.TronResourceCode:\tBANDWIDTHR\x08resource\";\n\
+    \x14TronWithdrawUnfreeze\x12#\n\rowner_address\x18\x01\x20\x02(\x0cR\x0c\
+    ownerAddress\":\n\x13TronWithdrawBalance\x12#\n\rowner_address\x18\x01\
+    \x20\x02(\x0cR\x0cownerAddress\"-\n\rTronSignature\x12\x1c\n\tsignature\
+    \x18\x01\x20\x02(\x0cR\tsignature\"\xb2\x06\n\x12TronRawTransaction\x12&\
+    \n\x0fref_block_bytes\x18\x01\x20\x02(\x0cR\rrefBlockBytes\x12$\n\x0eref\
+    _block_hash\x18\x04\x20\x02(\x0cR\x0crefBlockHash\x12\x1e\n\nexpiration\
+    \x18\x08\x20\x02(\x04R\nexpiration\x12\x12\n\x04data\x18\n\x20\x01(\x0cR\
+    \x04data\x12W\n\x08contract\x18\x0b\x20\x03(\x0b2;.hw.trezor.messages.tr\
+    on.TronRawTransaction.TronRawContractR\x08contract\x12\x1c\n\ttimestamp\
+    \x18\x0e\x20\x02(\x04R\ttimestamp\x12\x1b\n\tfee_limit\x18\x12\x20\x01(\
+    \x04R\x08feeLimit\x1a\x85\x04\n\x0fTronRawContract\x12c\n\x04type\x18\
+    \x01\x20\x02(\x0e2O.hw.trezor.messages.tron.TronRawTransaction.TronRawCo\
+    ntract.TronRawContractTypeR\x04type\x12j\n\tparameter\x18\x02\x20\x02(\
+    \x0b2L.hw.trezor.messages.tron.TronRawTransaction.TronRawContract.TronRa\
+    wParameterR\tparameter\x1aC\n\x10TronRawParameter\x12\x19\n\x08type_url\
+    \x18\x01\x20\x02(\tR\x07typeUrl\x12\x14\n\x05value\x18\x02\x20\x02(\x0cR\
+    \x05value\"\xdb\x01\n\x13TronRawContractType\x12\x14\n\x10TransferContra\
+    ct\x10\x01\x12\x17\n\x13VoteWitnessContract\x10\x04\x12\x1b\n\x17Withdra\
+    wBalanceContract\x10\r\x12\x18\n\x14TriggerSmartContract\x10\x1f\x12\x1b\
+    \n\x17FreezeBalanceV2Contract\x106\x12\x1d\n\x19UnfreezeBalanceV2Contrac\
+    t\x107\x12\"\n\x1eWithdrawExpireUnfreezeContract\x108*-\n\x10TronResourc\
+    eCode\x12\r\n\tBANDWIDTH\x10\0\x12\n\n\x06ENERGY\x10\x01B8\n#com.satoshi\
+    labs.trezor.lib.protobufB\x11TrezorMessageTron\
 ";
 
 /// `FileDescriptorProto` object which was a source for this generated file

--- a/tests/device_tests/tron/test_sign_tx.py
+++ b/tests/device_tests/tron/test_sign_tx.py
@@ -31,11 +31,15 @@ def test_sign_tx(session: Session, parameters: dict, result: dict):
         if not session.debug.legacy_debug:
             client.set_input_flow(InputFlowConfirmAllWarnings(client).get())
         if "signature" in result:
-            response = tron.sign_tx(session, tx, contract, address_n)
+            response = tron.sign_tx(
+                session, tx, contract, address_n, parameters.get("chunkify", True)
+            )
             assert response.signature == binascii.unhexlify(result["signature"])
         elif "error_message" in result:
             with pytest.raises(TrezorFailure, match=result["error_message"]):
-                tron.sign_tx(session, tx, contract, address_n)
+                tron.sign_tx(
+                    session, tx, contract, address_n, parameters.get("chunkify", True)
+                )
         else:
             assert False, "Invalid expected result"
 


### PR DESCRIPTION
<!--
For external contributors:
- Please open an issue before submitting a PR so we can discuss whether we want to proceed with it.

For core developers:
1. Initial PR setup
- Assign yourself to the PR.
- Add it to the "Firmware" project
  - Set Priority (match issue priority if it exists)
  - Set Team
  - Set Sprint (target release)

2. Development status
- Draft PRs: Set status to "In Progress"
- Final PRs: Set status to "Needs Review"

3. Post-merge status
- Testable: Set status to "Needs QA" and add a `Notes for QA` section with clear instructions on how to test the functionality.
- Not Testable: Set status to "Done (no QA)"
-->
Fixes #6730 

Until now, `chunkify` was allowed only in `TronGetAddress`. The value in SignTX flow was hardcoded to `True` until now. This PR adds `chunkify` to `TronSignTx`.

As for other coin apps, the default for `chunkify` param is `False`, i.e. the drawback of this PR is that most fixtures are changed. Please coordinate with Suite/Connect @vanillaboy1987 

# Notes for QA
After Suite supports `chunkify` param in `TronSignTx` message. Test that addresses respect the user setting.