### PR TITLE
style(core/rust): apply uniform import grouping

### DIFF
--- a/core/embed/io/touch/build.rs
+++ b/core/embed/io/touch/build.rs
@@ -50,8 +50,8 @@ pub fn def_module(lib: &mut CLibrary) -> Result<()> {
 // -------------------------------------------------------------------------
 
 fn set_panel_t2t1(_lib: &mut CLibrary) {
-    // The T2T1 panel needs no touch coordinate correction; the driver falls back
-    // to identity mapping when no TOUCH_PANEL_* macro is defined.
+    // The T2T1 panel needs no touch coordinate correction; the driver falls
+    // back to identity mapping when no TOUCH_PANEL_* macro is defined.
 }
 
 fn set_panel_lx154a2422cpt23(lib: &mut CLibrary) {

--- a/core/embed/models/build.rs
+++ b/core/embed/models/build.rs
@@ -1,7 +1,8 @@
 use xbuild::{CLibrary, Result, bail_unsupported};
 
 fn main() -> Result<()> {
-    // Emit model identity for dependent build scripts (readable as DEP_MODELS_MODEL).
+    // Emit model identity for dependent build scripts (readable as
+    // DEP_MODELS_MODEL).
     let model_id = if cfg!(feature = "model_t2t1") {
         "T2T1"
     } else if cfg!(feature = "model_t2b1") {
@@ -195,9 +196,9 @@ fn main() -> Result<()> {
 ///
 /// Reads the model's `default_board` from `<model>/model.toml` and that board's
 /// `header` (or `emulator_header` for an emulator build) from
-/// `<model>/boards/<default_board>.toml`, so the tomls stay the single source of
-/// truth. Returns "" for an unselected model; that case is rejected later by the
-/// model dispatch in `main`.
+/// `<model>/boards/<default_board>.toml`, so the tomls stay the single source
+/// of truth. Returns "" for an unselected model; that case is rejected later by
+/// the model dispatch in `main`.
 fn default_board_header(model_id: &str) -> Result<String> {
     if model_id.is_empty() {
         return Ok(String::new());

--- a/core/embed/projects/firmware/build.rs
+++ b/core/embed/projects/firmware/build.rs
@@ -1,4 +1,5 @@
-use std::{env, path::PathBuf};
+use std::env;
+use std::path::PathBuf;
 
 use xbuild::{CLibrary, Result, bail_unsupported};
 

--- a/core/embed/projects/kernel/build.rs
+++ b/core/embed/projects/kernel/build.rs
@@ -1,4 +1,5 @@
-use std::{env, path::PathBuf};
+use std::env;
+use std::path::PathBuf;
 
 use xbuild::{CLibrary, Result};
 

--- a/core/embed/rtl/build.rs
+++ b/core/embed/rtl/build.rs
@@ -1,6 +1,6 @@
-use xbuild::{Result, WrapErr, bail, ensure};
-
 use std::process::Command;
+
+use xbuild::{Result, WrapErr, bail, ensure};
 
 fn main() -> Result<()> {
     xbuild::build(|lib| {

--- a/core/embed/rust/build.rs
+++ b/core/embed/rust/build.rs
@@ -1,7 +1,7 @@
+use std::env;
 #[cfg(all(feature = "test", not(feature = "with_new_crates")))]
 use std::ffi::OsStr;
-use std::{env, path::PathBuf};
-
+use std::path::PathBuf;
 #[cfg(not(feature = "with_new_crates"))]
 use std::process::Command;
 

--- a/core/embed/rust/rustfmt.toml
+++ b/core/embed/rust/rustfmt.toml
@@ -1,2 +1,0 @@
-wrap_comments = true
-imports_granularity = "Crate"

--- a/core/embed/rust/src/bootloader/mod.rs
+++ b/core/embed/rust/src/bootloader/mod.rs
@@ -1,23 +1,25 @@
+use heapless::Vec;
+
+#[cfg(feature = "power_manager")]
+use crate::time::Duration;
+#[cfg(feature = "ble")]
+use crate::trezorhal::bootloader::bootloader_process_ble;
+use crate::trezorhal::bootloader::{bootloader_process_usb, BootloaderWFResult};
+#[cfg(feature = "debuglink")]
+use crate::trezorhal::bootloader::{
+    debuglink_notify_layout_change, debuglink_process, DebuglinkResult,
+};
+#[cfg(all(feature = "haptic", feature = "power_manager"))]
+use crate::trezorhal::haptic::{play, HapticEffect};
+use crate::trezorhal::sysevent::{sysevents_poll, Syshandle};
+use crate::ui::component::base::AttachType;
+use crate::ui::component::{Component, Event, EventCtx};
 #[cfg(all(feature = "button", feature = "power_manager"))]
 use crate::ui::event::ButtonEvent;
 #[cfg(feature = "button")]
 use crate::ui::layout::simplified::button_eval;
-
-use crate::{
-    trezorhal::{
-        bootloader::{bootloader_process_usb, BootloaderWFResult},
-        sysevent::{sysevents_poll, Syshandle},
-    },
-    ui::{
-        component::{base::AttachType, Component, Event, EventCtx},
-        layout::simplified::{render, ReturnToC},
-        CommonUI, ModelUI,
-    },
-};
-
-#[cfg(feature = "ble")]
-use crate::trezorhal::bootloader::bootloader_process_ble;
-
+use crate::ui::layout::simplified::{render, ReturnToC};
+use crate::ui::{CommonUI, ModelUI};
 #[cfg(feature = "power_manager")]
 use crate::{
     time::Instant,
@@ -25,19 +27,6 @@ use crate::{
     ui::display::fade_backlight_duration,
     ui::event::PhysicalButton,
 };
-
-#[cfg(all(feature = "haptic", feature = "power_manager"))]
-use crate::trezorhal::haptic::{play, HapticEffect};
-
-#[cfg(feature = "debuglink")]
-use crate::trezorhal::bootloader::{
-    debuglink_notify_layout_change, debuglink_process, DebuglinkResult,
-};
-
-use heapless::Vec;
-
-#[cfg(feature = "power_manager")]
-use crate::time::Duration;
 #[cfg(feature = "power_manager")]
 const FADE_TIME: Duration = Duration::from_millis(30000);
 #[cfg(feature = "power_manager")]

--- a/core/embed/rust/src/coverage/mod.rs
+++ b/core/embed/rust/src/coverage/mod.rs
@@ -2,17 +2,13 @@
 use heapless::index_map::{Entry, FnvIndexMap};
 use spin::RwLock;
 
-use crate::{
-    error::Error,
-    micropython::{
-        list::List,
-        macros::{obj_fn_0, obj_fn_2, obj_module},
-        module::Module,
-        obj::Obj,
-        qstr::Qstr,
-        util,
-    },
-};
+use crate::error::Error;
+use crate::micropython::list::List;
+use crate::micropython::macros::{obj_fn_0, obj_fn_2, obj_module};
+use crate::micropython::module::Module;
+use crate::micropython::obj::Obj;
+use crate::micropython::qstr::Qstr;
+use crate::micropython::util;
 
 struct Key {
     file: Qstr,

--- a/core/embed/rust/src/crypto/aesgcm.rs
+++ b/core/embed/rust/src/crypto/aesgcm.rs
@@ -2,7 +2,8 @@ use core::pin::Pin;
 
 use zeroize::Zeroize;
 
-use super::{consteq, ffi, memory::Memory, Error};
+use super::memory::Memory;
+use super::{consteq, ffi, Error};
 
 // Tag size is a parameter but we fix it to 16 here for simplicity.
 pub const TAG_SIZE: usize = 16;
@@ -225,7 +226,8 @@ impl Drop for AesGcmInner<'_> {
 
 #[cfg(test)]
 mod test {
-    use super::{super::memory::init_ctx, *};
+    use super::super::memory::init_ctx;
+    use super::*;
 
     struct Vector {
         key: &'static str,

--- a/core/embed/rust/src/crypto/crc32.rs
+++ b/core/embed/rust/src/crypto/crc32.rs
@@ -33,9 +33,8 @@ pub fn digest(data: &[u8]) -> [u8; 4] {
 
 #[cfg(test)]
 mod test {
-    use crate::strutil::hexlify;
-
     use super::*;
+    use crate::strutil::hexlify;
 
     const CRC32_VECTORS: &[(&[u8], &[u8])] = &[
         (b"", b"00000000"),

--- a/core/embed/rust/src/crypto/hmac.rs
+++ b/core/embed/rust/src/crypto/hmac.rs
@@ -2,10 +2,8 @@ use core::pin::Pin;
 
 use zeroize::{Zeroize, ZeroizeOnDrop};
 
-use super::{
-    ffi,
-    memory::{init_ctx, Memory},
-};
+use super::ffi;
+use super::memory::{init_ctx, Memory};
 
 pub const DIGEST_SIZE: usize = ffi::SHA256_DIGEST_LENGTH as usize;
 pub type Digest = [u8; DIGEST_SIZE];
@@ -52,9 +50,8 @@ pub fn digest(key: &[u8], data: &[u8]) -> Digest {
 
 #[cfg(test)]
 mod test {
-    use crate::strutil::hexlify;
-
     use super::*;
+    use crate::strutil::hexlify;
 
     const HMAC_SHA256_EMPTY: &[u8] =
         b"b613679a0814d9ec772f95d778c35fc5ff1697c493715653c6c712144292c5ad";

--- a/core/embed/rust/src/crypto/memory.rs
+++ b/core/embed/rust/src/crypto/memory.rs
@@ -1,4 +1,6 @@
-use core::{marker::PhantomPinned, mem::MaybeUninit, pin::Pin};
+use core::marker::PhantomPinned;
+use core::mem::MaybeUninit;
+use core::pin::Pin;
 
 use zeroize::{zeroize_flat_type, Zeroize};
 

--- a/core/embed/rust/src/crypto/merkle.rs
+++ b/core/embed/rust/src/crypto/merkle.rs
@@ -1,4 +1,5 @@
-use super::{memory::init_ctx, sha256};
+use super::memory::init_ctx;
+use super::sha256;
 
 /// Calculate a Merkle root based on a leaf element and a proof of inclusion.
 ///

--- a/core/embed/rust/src/crypto/sha256.rs
+++ b/core/embed/rust/src/crypto/sha256.rs
@@ -1,11 +1,10 @@
-use core::{mem::MaybeUninit, pin::Pin};
+use core::mem::MaybeUninit;
+use core::pin::Pin;
 
 use zeroize::{Zeroize, ZeroizeOnDrop};
 
-use super::{
-    ffi,
-    memory::{init_ctx, Memory},
-};
+use super::ffi;
+use super::memory::{init_ctx, Memory};
 
 pub const BLOCK_SIZE: usize = ffi::SHA256_BLOCK_LENGTH as usize;
 pub const DIGEST_SIZE: usize = ffi::SHA256_DIGEST_LENGTH as usize;
@@ -88,9 +87,8 @@ impl NoPinSha256 {
 
 #[cfg(test)]
 mod test {
-    use crate::strutil::hexlify;
-
     use super::*;
+    use crate::strutil::hexlify;
 
     const SHA256_EMPTY: &[u8] = b"e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855";
     const SHA256_VECTORS: &[(&[u8], &[u8])] = &[

--- a/core/embed/rust/src/crypto/sha512.rs
+++ b/core/embed/rust/src/crypto/sha512.rs
@@ -1,11 +1,9 @@
 use core::pin::Pin;
 
-use super::{
-    ffi,
-    memory::{init_ctx, Memory},
-};
-
 use zeroize::{Zeroize, ZeroizeOnDrop};
+
+use super::ffi;
+use super::memory::{init_ctx, Memory};
 
 pub const BLOCK_SIZE: usize = ffi::SHA512_BLOCK_LENGTH as usize;
 pub const DIGEST_SIZE: usize = ffi::SHA512_DIGEST_LENGTH as usize;
@@ -54,9 +52,8 @@ pub fn digest(data: &[u8]) -> Digest {
 
 #[cfg(test)]
 mod test {
-    use crate::strutil::hexlify;
-
     use super::*;
+    use crate::strutil::hexlify;
 
     const SHA512_EMPTY: &[u8] = b"cf83e1357eefb8bdf1542850d66d8007d620e4050b5715dc83f4a921d36ce9ce47d0d13c5d85f2b0ff8318d2877eec2f63b931bd47417a81a538327af927da3e";
     const SHA512_VECTORS: &[(&[u8], &[u8])] = &[

--- a/core/embed/rust/src/debug.rs
+++ b/core/embed/rust/src/debug.rs
@@ -12,10 +12,11 @@ mod unix_ffi {
     }
 }
 
-#[cfg(feature = "micropython")]
-use crate::micropython::print::print;
 #[cfg(not(feature = "micropython"))]
 pub use unix_ffi::print;
+
+#[cfg(feature = "micropython")]
+use crate::micropython::print::print;
 
 pub struct DebugConsole;
 

--- a/core/embed/rust/src/error.rs
+++ b/core/embed/rust/src/error.rs
@@ -1,4 +1,6 @@
-use core::{convert::Infallible, ffi::CStr, num::TryFromIntError};
+use core::convert::Infallible;
+use core::ffi::CStr;
+use core::num::TryFromIntError;
 
 #[cfg(feature = "micropython")]
 use {

--- a/core/embed/rust/src/io.rs
+++ b/core/embed/rust/src/io.rs
@@ -1,5 +1,4 @@
 use crate::error::Error;
-
 #[cfg(feature = "micropython")]
 use crate::micropython::{buffer::get_buffer, gc::Gc, obj::Obj};
 

--- a/core/embed/rust/src/micropython/buffer.rs
+++ b/core/embed/rust/src/micropython/buffer.rs
@@ -1,8 +1,11 @@
-use core::{convert::TryFrom, ops::Deref, ptr, slice, str};
-
-use crate::{error::Error, micropython::obj::Obj, strutil::hexlify};
+use core::convert::TryFrom;
+use core::ops::Deref;
+use core::{ptr, slice, str};
 
 use super::ffi;
+use crate::error::Error;
+use crate::micropython::obj::Obj;
+use crate::strutil::hexlify;
 
 /// Represents an immutable UTF-8 string managed by MicroPython GC.
 /// This either means static data, or a valid GC object.

--- a/core/embed/rust/src/micropython/dict.rs
+++ b/core/embed/rust/src/micropython/dict.rs
@@ -1,8 +1,11 @@
 use core::convert::TryFrom;
 
+use super::ffi;
+use super::gc::Gc;
+use super::map::Map;
+use super::obj::Obj;
+use super::runtime::catch_exception;
 use crate::error::Error;
-
-use super::{ffi, gc::Gc, map::Map, obj::Obj, runtime::catch_exception};
 
 /// Insides of the MicroPython `dict` object.
 pub type Dict = ffi::mp_obj_dict_t;

--- a/core/embed/rust/src/micropython/exception.rs
+++ b/core/embed/rust/src/micropython/exception.rs
@@ -1,6 +1,9 @@
 #![allow(non_upper_case_globals)]
 
-use super::{ffi, obj::Obj, qstr::Qstr, typ::Type};
+use super::ffi;
+use super::obj::Obj;
+use super::qstr::Qstr;
+use super::typ::Type;
 
 pub const AttributeError: &Type = unsafe { &ffi::mp_type_AttributeError };
 pub const EOFError: &Type = unsafe { &ffi::mp_type_EOFError };

--- a/core/embed/rust/src/micropython/func.rs
+++ b/core/embed/rust/src/micropython/func.rs
@@ -1,4 +1,5 @@
-use super::{ffi, obj::Obj};
+use super::ffi;
+use super::obj::Obj;
 
 pub type Func = ffi::mp_obj_fun_builtin_fixed_t;
 

--- a/core/embed/rust/src/micropython/gc.rs
+++ b/core/embed/rust/src/micropython/gc.rs
@@ -1,12 +1,9 @@
-use core::{
-    alloc::Layout,
-    ops::{Deref, DerefMut},
-    ptr::{self, NonNull},
-};
-
-use crate::error::Error;
+use core::alloc::Layout;
+use core::ops::{Deref, DerefMut};
+use core::ptr::{self, NonNull};
 
 use super::ffi;
+use crate::error::Error;
 
 /// A pointer type for values on the garbage-collected heap.
 pub struct Gc<T: ?Sized>(NonNull<T>);
@@ -296,9 +293,8 @@ impl<T: ?Sized> Drop for GcBox<T> {
 mod test {
     use core::cell::Cell;
 
-    use crate::micropython::testutil::mpy_init;
-
     use super::*;
+    use crate::micropython::testutil::mpy_init;
 
     struct SignalDrop<'a>(&'a Cell<bool>);
 

--- a/core/embed/rust/src/micropython/iter.rs
+++ b/core/embed/rust/src/micropython/iter.rs
@@ -1,8 +1,9 @@
 use core::ptr;
 
-use crate::{error::Error, micropython::obj::Obj};
-
-use super::{ffi, runtime::catch_exception};
+use super::ffi;
+use super::runtime::catch_exception;
+use crate::error::Error;
+use crate::micropython::obj::Obj;
 
 pub struct IterBuf {
     iter_buf: ffi::mp_obj_iter_buf_t,

--- a/core/embed/rust/src/micropython/list.rs
+++ b/core/embed/rust/src/micropython/list.rs
@@ -1,13 +1,11 @@
-use core::{convert::TryFrom, ptr};
+use core::convert::TryFrom;
+use core::ptr;
 
+use super::ffi;
+use super::gc::{Gc, GcBox};
+use super::obj::Obj;
+use super::runtime::catch_exception;
 use crate::error::Error;
-
-use super::{
-    ffi,
-    gc::{Gc, GcBox},
-    obj::Obj,
-    runtime::catch_exception,
-};
 
 pub type List = ffi::mp_obj_list_t;
 
@@ -149,10 +147,11 @@ impl TryFrom<Obj> for Gc<List> {
 
 #[cfg(test)]
 mod tests {
-    use crate::micropython::{iter::IterBuf, testutil::mpy_init};
+    use heapless::Vec;
 
     use super::*;
-    use heapless::Vec;
+    use crate::micropython::iter::IterBuf;
+    use crate::micropython::testutil::mpy_init;
 
     #[test]
     fn list_from_iter() {

--- a/core/embed/rust/src/micropython/logging.rs
+++ b/core/embed/rust/src/micropython/logging.rs
@@ -1,11 +1,12 @@
-use crate::micropython::{map::Map, module::Module, obj::Obj, qstr::Qstr};
-
-use crate::{
-    error::Error,
-    micropython::{buffer::StrBuffer, util},
-    trezorhal::syslog::{syslog_start_record, syslog_write_chunk, LogLevel},
-    util::logger::init_rust_logging,
-};
+use crate::error::Error;
+use crate::micropython::buffer::StrBuffer;
+use crate::micropython::map::Map;
+use crate::micropython::module::Module;
+use crate::micropython::obj::Obj;
+use crate::micropython::qstr::Qstr;
+use crate::micropython::util;
+use crate::trezorhal::syslog::{syslog_start_record, syslog_write_chunk, LogLevel};
+use crate::util::logger::init_rust_logging;
 
 fn _log(level: LogLevel, args: &[Obj], kwargs: &Map) -> Result<Obj, Error> {
     let [module, fmt, fmt_args @ ..] = args else {

--- a/core/embed/rust/src/micropython/macros.rs
+++ b/core/embed/rust/src/micropython/macros.rs
@@ -256,7 +256,6 @@ macro_rules! attr_tuple {
 // required because they are used in expansion of macros below
 pub(crate) use _obj_fn_make_fixed;
 pub(crate) use _obj_fn_make_var;
-
 pub(crate) use attr_tuple;
 pub(crate) use obj_dict;
 pub(crate) use obj_fn_0;

--- a/core/embed/rust/src/micropython/map.rs
+++ b/core/embed/rust/src/micropython/map.rs
@@ -1,11 +1,13 @@
-use core::{marker::PhantomData, mem::MaybeUninit, ops::Deref, ptr, slice};
+use core::marker::PhantomData;
+use core::mem::MaybeUninit;
+use core::ops::Deref;
+use core::{ptr, slice};
 
-use crate::{
-    error::Error,
-    micropython::{obj::Obj, qstr::Qstr},
-};
-
-use super::{ffi, runtime::catch_exception};
+use super::ffi;
+use super::runtime::catch_exception;
+use crate::error::Error;
+use crate::micropython::obj::Obj;
+use crate::micropython::qstr::Qstr;
 
 pub type Map = ffi::mp_map_t;
 pub type MapElem = ffi::mp_map_elem_t;

--- a/core/embed/rust/src/micropython/obj.rs
+++ b/core/embed/rust/src/micropython/obj.rs
@@ -1,11 +1,9 @@
-use core::{
-    convert::{TryFrom, TryInto},
-    ffi::CStr,
-};
+use core::convert::{TryFrom, TryInto};
+use core::ffi::CStr;
 
+use super::ffi;
+use super::runtime::catch_exception;
 use crate::error::Error;
-
-use super::{ffi, runtime::catch_exception};
 
 pub type Obj = ffi::mp_obj_t;
 pub type ObjBase = ffi::mp_obj_base_t;

--- a/core/embed/rust/src/micropython/qstr.rs
+++ b/core/embed/rust/src/micropython/qstr.rs
@@ -2,18 +2,21 @@
 #![allow(non_upper_case_globals)]
 #![allow(dead_code)]
 
-use core::{convert::TryFrom, slice, str::from_utf8};
+use core::convert::TryFrom;
+use core::slice;
+use core::str::from_utf8;
 
+use super::ffi;
+use super::obj::Obj;
 use crate::error::Error;
-
-use super::{ffi, obj::Obj};
 
 impl Qstr {
     pub const fn to_obj(self) -> Obj {
         // SAFETY:
         //  - Micropython compiled with `MICROPY_OBJ_REPR == MICROPY_OBJ_REPR_A`.
-        //    micropython/py/obj.h #define MP_OBJ_NEW_QSTR(qst)
-        //    ((mp_obj_t)((((mp_uint_t)(qst)) << 3) | 2))
+        //
+        // micropython/py/obj.h
+        // #define MP_OBJ_NEW_QSTR(qst) ((mp_obj_t)((((mp_uint_t)(qst)) << 3) | 2))
         let bits = (self.0 << 3) | 2;
         unsafe { Obj::from_bits(bits) }
     }

--- a/core/embed/rust/src/micropython/runtime.rs
+++ b/core/embed/rust/src/micropython/runtime.rs
@@ -1,8 +1,7 @@
 use core::mem::MaybeUninit;
 
-use crate::error::Error;
-
 use super::ffi;
+use crate::error::Error;
 
 /// Raise a micropython exception via NLR jump.
 /// Jumps directly out of the context without running any destructors,

--- a/core/embed/rust/src/micropython/simple_type.rs
+++ b/core/embed/rust/src/micropython/simple_type.rs
@@ -1,7 +1,5 @@
-use super::{
-    obj::{Obj, ObjBase},
-    typ::Type,
-};
+use super::obj::{Obj, ObjBase};
+use super::typ::Type;
 
 /// Simple MicroPython object type builder.
 ///

--- a/core/embed/rust/src/micropython/typ.rs
+++ b/core/embed/rust/src/micropython/typ.rs
@@ -1,7 +1,5 @@
-use super::{
-    ffi,
-    obj::{Obj, ObjBase},
-};
+use super::ffi;
+use super::obj::{Obj, ObjBase};
 
 pub type Type = ffi::mp_obj_type_t;
 

--- a/core/embed/rust/src/micropython/util.rs
+++ b/core/embed/rust/src/micropython/util.rs
@@ -2,14 +2,12 @@ use core::slice;
 
 use heapless::Vec;
 
-use super::{
-    ffi,
-    iter::IterBuf,
-    map::{Map, MapElem},
-    obj::Obj,
-    qstr::Qstr,
-    runtime::{catch_exception, raise_exception},
-};
+use super::ffi;
+use super::iter::IterBuf;
+use super::map::{Map, MapElem};
+use super::obj::Obj;
+use super::qstr::Qstr;
+use super::runtime::{catch_exception, raise_exception};
 use crate::error::{value_error, Error};
 
 /// Perform a call and convert errors into a raised MicroPython exception.

--- a/core/embed/rust/src/protobuf/decode.rs
+++ b/core/embed/rust/src/protobuf/decode.rs
@@ -1,20 +1,17 @@
-use core::{
-    convert::{TryFrom, TryInto},
-    str,
-};
+use core::convert::{TryFrom, TryInto};
+use core::str;
 
-use crate::{
-    error::Error,
-    io::InputStream,
-    micropython::{buffer, gc::Gc, list::List, map::Map, obj::Obj, qstr::Qstr, util},
-};
-
-use super::{
-    defs::{self, FieldDef, FieldType, MsgDef},
-    error,
-    obj::{MsgDefObj, MsgObj},
-    zigzag,
-};
+use super::defs::{self, FieldDef, FieldType, MsgDef};
+use super::obj::{MsgDefObj, MsgObj};
+use super::{error, zigzag};
+use crate::error::Error;
+use crate::io::InputStream;
+use crate::micropython::gc::Gc;
+use crate::micropython::list::List;
+use crate::micropython::map::Map;
+use crate::micropython::obj::Obj;
+use crate::micropython::qstr::Qstr;
+use crate::micropython::{buffer, util};
 
 pub extern "C" fn protobuf_decode(buf: Obj, msg_def: Obj, enable_experimental: Obj) -> Obj {
     let block = || {

--- a/core/embed/rust/src/protobuf/encode.rs
+++ b/core/embed/rust/src/protobuf/encode.rs
@@ -1,16 +1,15 @@
 use core::convert::{TryFrom, TryInto};
 
-use crate::{
-    error::Error,
-    micropython::{buffer, gc::Gc, iter::IterBuf, list::List, obj::Obj, qstr::Qstr, util},
-};
-
-use super::{
-    defs::{FieldDef, FieldType, MsgDef},
-    error,
-    obj::MsgObj,
-    zigzag,
-};
+use super::defs::{FieldDef, FieldType, MsgDef};
+use super::obj::MsgObj;
+use super::{error, zigzag};
+use crate::error::Error;
+use crate::micropython::gc::Gc;
+use crate::micropython::iter::IterBuf;
+use crate::micropython::list::List;
+use crate::micropython::obj::Obj;
+use crate::micropython::qstr::Qstr;
+use crate::micropython::{buffer, util};
 
 pub extern "C" fn protobuf_len(obj: Obj) -> Obj {
     let block = || {

--- a/core/embed/rust/src/protobuf/error.rs
+++ b/core/embed/rust/src/protobuf/error.rs
@@ -1,7 +1,5 @@
-use crate::{
-    error::{value_error, Error},
-    micropython::qstr::Qstr,
-};
+use crate::error::{value_error, Error};
+use crate::micropython::qstr::Qstr;
 
 pub const fn experimental_not_enabled() -> Error {
     value_error!(c"Experimental features are disabled.")

--- a/core/embed/rust/src/protobuf/obj.rs
+++ b/core/embed/rust/src/protobuf/obj.rs
@@ -1,26 +1,18 @@
 use core::convert::TryFrom;
 
-use crate::{
-    error::Error,
-    micropython::{
-        dict::Dict,
-        ffi,
-        gc::Gc,
-        macros::{obj_fn_1, obj_fn_2, obj_fn_3, obj_module, obj_type},
-        map::Map,
-        module::Module,
-        obj::{Obj, ObjBase},
-        qstr::Qstr,
-        typ::Type,
-        util,
-    },
-};
-
-use super::{
-    decode::{protobuf_decode, Decoder},
-    defs::{find_name_by_msg_offset, get_msg, MsgDef},
-    encode::{protobuf_encode, protobuf_len},
-};
+use super::decode::{protobuf_decode, Decoder};
+use super::defs::{find_name_by_msg_offset, get_msg, MsgDef};
+use super::encode::{protobuf_encode, protobuf_len};
+use crate::error::Error;
+use crate::micropython::dict::Dict;
+use crate::micropython::gc::Gc;
+use crate::micropython::macros::{obj_fn_1, obj_fn_2, obj_fn_3, obj_module, obj_type};
+use crate::micropython::map::Map;
+use crate::micropython::module::Module;
+use crate::micropython::obj::{Obj, ObjBase};
+use crate::micropython::qstr::Qstr;
+use crate::micropython::typ::Type;
+use crate::micropython::{ffi, util};
 
 #[repr(C)]
 pub struct MsgObj {

--- a/core/embed/rust/src/smp/api.rs
+++ b/core/embed/rust/src/smp/api.rs
@@ -1,5 +1,4 @@
 use super::{echo, image_info, process_rx_byte, reset, upload};
-
 use crate::util::from_c_array;
 
 #[no_mangle]

--- a/core/embed/rust/src/smp/echo.rs
+++ b/core/embed/rust/src/smp/echo.rs
@@ -1,9 +1,11 @@
+use minicbor::data::Type;
+use minicbor::{decode, Decoder, Encoder};
+
 use super::{
     receiver_acquire, receiver_release, send_request, wait_for_response, MsgType, SmpBuffer,
     SmpHeader, SMP_CMD_ID_ECHO, SMP_GROUP_OS, SMP_HEADER_SIZE, SMP_OP_READ,
 };
 use crate::time::Duration;
-use minicbor::{data::Type, decode, Decoder, Encoder};
 
 pub fn send(text: &str) -> bool {
     let mut cbor_data = [0u8; 64];

--- a/core/embed/rust/src/smp/image_info.rs
+++ b/core/embed/rust/src/smp/image_info.rs
@@ -1,9 +1,11 @@
+use minicbor::data::Type;
+use minicbor::{decode, Decoder, Encoder};
+
 use super::{
     receiver_acquire, receiver_release, send_request, wait_for_response, MsgType, SmpBuffer,
     SmpHeader, SMP_CMD_ID_IMAGE_STATE, SMP_GROUP_IMAGE, SMP_HEADER_SIZE, SMP_OP_READ,
 };
 use crate::time::Duration;
-use minicbor::{data::Type, decode, Decoder, Encoder};
 
 /// MCUboot-compatible version structure matching image header format
 #[derive(Clone, Copy, Debug)]

--- a/core/embed/rust/src/smp/mod.rs
+++ b/core/embed/rust/src/smp/mod.rs
@@ -6,17 +6,16 @@ mod image_info;
 mod reset;
 mod upload;
 
-use crate::{
-    time::{Duration, Instant},
-    trezorhal::{
-        irq::{irq_lock, irq_unlock},
-        nrf::send_data,
-    },
-};
+use core::cell::UnsafeCell;
+use core::convert::Infallible;
+
 use base64::{base64_decode, base64_encode};
-use core::{cell::UnsafeCell, convert::Infallible};
 use crc16::crc16_itu_t;
 use minicbor::encode::write::Write;
+
+use crate::time::{Duration, Instant};
+use crate::trezorhal::irq::{irq_lock, irq_unlock};
+use crate::trezorhal::nrf::send_data;
 
 pub const SMP_HEADER_SIZE: usize = 8;
 

--- a/core/embed/rust/src/smp/upload.rs
+++ b/core/embed/rust/src/smp/upload.rs
@@ -1,9 +1,10 @@
+use minicbor::Encoder;
+
 use super::{
     receiver_acquire, receiver_release, send_request, wait_for_response, MsgType, SmpBuffer,
     SmpHeader, SMP_CMD_ID_IMAGE_UPLOAD, SMP_GROUP_IMAGE, SMP_HEADER_SIZE, SMP_OP_WRITE,
 };
 use crate::time::Duration;
-use minicbor::Encoder;
 
 const CHUNK_SIZE: usize = 256;
 const MAX_PACKET_SIZE: usize = 512;

--- a/core/embed/rust/src/strutil.rs
+++ b/core/embed/rust/src/strutil.rs
@@ -2,10 +2,8 @@ use heapless::String;
 
 #[cfg(feature = "micropython")]
 use crate::error::Error;
-
 #[cfg(feature = "micropython")]
 use crate::micropython::{buffer::StrBuffer, obj::Obj};
-
 #[cfg(feature = "translations")]
 use crate::translations::TR;
 

--- a/core/embed/rust/src/thp/crypto.rs
+++ b/core/embed/rust/src/thp/crypto.rs
@@ -1,8 +1,8 @@
 use trezor_thp::channel::{Backend, Cipher, Hash, U8Array, DH};
-
 use zeroize::{Zeroize, Zeroizing};
 
-use crate::crypto::{aesgcm, curve25519, memory::init_ctx, sha256};
+use crate::crypto::memory::init_ctx;
+use crate::crypto::{aesgcm, curve25519, sha256};
 
 /// Array wrapper that zeroizes on `drop()`. Can't use zeroizing directly due to
 /// the orphan rule.

--- a/core/embed/rust/src/thp/micropython.rs
+++ b/core/embed/rust/src/thp/micropython.rs
@@ -2,25 +2,19 @@ use trezor_thp::channel::{
     Phase, APP_HEADER_LEN, MAX_CREDENTIAL_LEN, MAX_DEVICE_PROPERTIES_LEN, SEND_BUFFER_OVERHEAD,
 };
 
-use crate::{
-    error::Error,
-    micropython::{
-        buffer::{get_buffer, get_buffer_mut},
-        exception,
-        macros::{
-            attr_tuple, obj_fn_0, obj_fn_1, obj_fn_2, obj_fn_3, obj_fn_kw, obj_module, obj_type,
-        },
-        map::Map,
-        module::Module,
-        obj::Obj,
-        qstr::Qstr,
-        simple_type::SimpleTypeObj,
-        typ::Type,
-        util,
-    },
-};
-
 use super::{TrezorInResult, CANNOT_UNLOCK, THP_AUX, THP_CONTEXT};
+use crate::error::Error;
+use crate::micropython::buffer::{get_buffer, get_buffer_mut};
+use crate::micropython::macros::{
+    attr_tuple, obj_fn_0, obj_fn_1, obj_fn_2, obj_fn_3, obj_fn_kw, obj_module, obj_type,
+};
+use crate::micropython::map::Map;
+use crate::micropython::module::Module;
+use crate::micropython::obj::Obj;
+use crate::micropython::qstr::Qstr;
+use crate::micropython::simple_type::SimpleTypeObj;
+use crate::micropython::typ::Type;
+use crate::micropython::{exception, util};
 
 extern "C" fn thp_init(iface_num: Obj, device_properties: Obj) -> Obj {
     let block = || {

--- a/core/embed/rust/src/thp/mod.rs
+++ b/core/embed/rust/src/thp/mod.rs
@@ -4,31 +4,27 @@ pub mod micropython;
 mod tests;
 mod time;
 
-use crate::{error::Error, micropython::obj::Obj, time::Instant};
-
-use core::{mem::replace, num::NonZeroU16};
-
-use heapless::{
-    deque::{Deque, DequeView},
-    linear_map::{Entry, LinearMap, LinearMapView},
-    Vec,
-};
-use spin::{Lazy, Mutex};
-
-use trezor_thp::{
-    channel::{
-        device::{Channel, ChannelIdAllocator, ChannelOpen, Mux},
-        PacketInResult, PairingState, Phase, MAX_CREDENTIAL_LEN, MAX_RETRANSMISSION_COUNT,
-        PUBKEY_LEN,
-    },
-    control_byte::ControlByte,
-    credential::CredentialVerifier,
-    error::TransportError,
-    ChannelIO, Error as ThpError,
-};
+use core::mem::replace;
+use core::num::NonZeroU16;
 
 use crypto::TrezorCrypto;
+use heapless::deque::{Deque, DequeView};
+use heapless::linear_map::{Entry, LinearMap, LinearMapView};
+use heapless::Vec;
+use spin::{Lazy, Mutex};
 use time::{least_recently_used, ChannelTiming};
+use trezor_thp::channel::device::{Channel, ChannelIdAllocator, ChannelOpen, Mux};
+use trezor_thp::channel::{
+    PacketInResult, PairingState, Phase, MAX_CREDENTIAL_LEN, MAX_RETRANSMISSION_COUNT, PUBKEY_LEN,
+};
+use trezor_thp::control_byte::ControlByte;
+use trezor_thp::credential::CredentialVerifier;
+use trezor_thp::error::TransportError;
+use trezor_thp::{ChannelIO, Error as ThpError};
+
+use crate::error::Error;
+use crate::micropython::obj::Obj;
+use crate::time::Instant;
 
 type TrezorMux = Mux<TrezorCrypto>;
 type TrezorChannelOpen = ChannelOpen<TrezorCredentialVerifier, TrezorCrypto>;

--- a/core/embed/rust/src/thp/tests.rs
+++ b/core/embed/rust/src/thp/tests.rs
@@ -1,25 +1,22 @@
-use crate::micropython::{func::Func, macros::obj_fn_2, obj::Obj, testutil::mpy_init};
-
-use std::{
-    assert_matches,
-    collections::{HashMap, VecDeque},
-    iter::repeat_n,
-};
+use std::assert_matches;
+use std::collections::{HashMap, VecDeque};
+use std::iter::repeat_n;
 
 use spin::MutexGuard;
-
-use trezor_thp::{
-    channel::{
-        buffered::{Buffered, ChannelExt},
-        host, ChannelIO, PacketInResult, PairingState, Phase, APP_HEADER_LEN, PRIVKEY_LEN, TAG_LEN,
-    },
-    credential::{CredentialStore, FoundCredential, NullCredentialStore},
-    error::TransportError,
+use trezor_thp::channel::buffered::{Buffered, ChannelExt};
+use trezor_thp::channel::{
+    host, ChannelIO, PacketInResult, PairingState, Phase, APP_HEADER_LEN, PRIVKEY_LEN, TAG_LEN,
 };
+use trezor_thp::credential::{CredentialStore, FoundCredential, NullCredentialStore};
+use trezor_thp::error::TransportError;
 
 use super::{
     Error, ThpAuxiliaryInfo, ThpContext, TrezorCrypto, TrezorInResult, THP_AUX, THP_CONTEXT,
 };
+use crate::micropython::func::Func;
+use crate::micropython::macros::obj_fn_2;
+use crate::micropython::obj::Obj;
+use crate::micropython::testutil::mpy_init;
 
 type HostChannel = host::Channel<TrezorCrypto>;
 type HostChannelOpen<C> = host::ChannelOpen<C, TrezorCrypto>;

--- a/core/embed/rust/src/thp/time.rs
+++ b/core/embed/rust/src/thp/time.rs
@@ -1,6 +1,6 @@
-use crate::time::{Duration, Instant};
-
 use trezor_thp::channel::retransmit_after_ms;
+
+use crate::time::{Duration, Instant};
 
 const MAX_LATENCY_MS: Duration = Duration::from_millis(800);
 
@@ -103,9 +103,10 @@ pub fn least_recently_used(
 
 #[cfg(test)]
 mod tests {
-    use super::*;
     use heapless::Vec;
     use trezor_thp::channel::MAX_RETRANSMISSION_COUNT;
+
+    use super::*;
 
     fn make_map(channels: &[(u16, u32)]) -> Vec<(u16, ChannelTiming), 16> {
         let mut chans = Vec::new();

--- a/core/embed/rust/src/time.rs
+++ b/core/embed/rust/src/time.rs
@@ -1,7 +1,5 @@
-use core::{
-    cmp::Ordering,
-    ops::{Div, Mul},
-};
+use core::cmp::Ordering;
+use core::ops::{Div, Mul};
 
 use crate::trezorhal::time;
 

--- a/core/embed/rust/src/translations/blob.rs
+++ b/core/embed/rust/src/translations/blob.rs
@@ -2,13 +2,12 @@ use core::{mem, str};
 
 use heapless::Vec;
 
-use crate::{
-    crypto::{cosi, ed25519, merkle::merkle_root, sha256},
-    error::{value_error, Error},
-    io::InputStream,
-};
-
-use super::{public_keys, translated_string::TranslatedString};
+use super::public_keys;
+use super::translated_string::TranslatedString;
+use crate::crypto::merkle::merkle_root;
+use crate::crypto::{cosi, ed25519, sha256};
+use crate::error::{value_error, Error};
+use crate::io::InputStream;
 
 pub const MAX_HEADER_LEN: u16 = 1024;
 pub const EMPTY_BYTE: u8 = 0xFF;

--- a/core/embed/rust/src/translations/flash.rs
+++ b/core/embed/rust/src/translations/flash.rs
@@ -1,11 +1,8 @@
 use spin::{RwLock, RwLockReadGuard};
 
-use crate::{
-    error::{value_error, Error},
-    trezorhal::translations,
-};
-
 use super::blob::Translations;
+use crate::error::{value_error, Error};
+use crate::trezorhal::translations;
 
 static TRANSLATIONS_ON_FLASH: RwLock<Option<Translations>> = RwLock::new(None);
 

--- a/core/embed/rust/src/translations/obj.rs
+++ b/core/embed/rust/src/translations/obj.rs
@@ -1,24 +1,18 @@
-use crate::{
-    error::Error,
-    io::InputStream,
-    micropython::{
-        buffer::get_buffer,
-        ffi,
-        macros::{
-            attr_tuple, obj_dict, obj_fn_0, obj_fn_1, obj_fn_2, obj_map, obj_module, obj_type,
-        },
-        map::Map,
-        module::Module,
-        obj::Obj,
-        qstr::Qstr,
-        simple_type::SimpleTypeObj,
-        typ::Type,
-        util,
-    },
-    trezorhal::translations,
-};
-
 use super::translated_string::TranslatedString;
+use crate::error::Error;
+use crate::io::InputStream;
+use crate::micropython::buffer::get_buffer;
+use crate::micropython::macros::{
+    attr_tuple, obj_dict, obj_fn_0, obj_fn_1, obj_fn_2, obj_map, obj_module, obj_type,
+};
+use crate::micropython::map::Map;
+use crate::micropython::module::Module;
+use crate::micropython::obj::Obj;
+use crate::micropython::qstr::Qstr;
+use crate::micropython::simple_type::SimpleTypeObj;
+use crate::micropython::typ::Type;
+use crate::micropython::{ffi, util};
+use crate::trezorhal::translations;
 
 // SAFETY: Caller is supposed to be MicroPython, or copy MicroPython contracts
 // about the meaning of arguments.

--- a/core/embed/rust/src/translations/translated_string.rs
+++ b/core/embed/rust/src/translations/translated_string.rs
@@ -1,10 +1,8 @@
-use crate::strutil::TString;
-
 use super::blob::{Translations, ENGLISH_CHUNK};
 pub use super::generated::translated_string::TranslatedString;
-
 #[cfg(feature = "micropython")]
 use crate::micropython::qstr::Qstr;
+use crate::strutil::TString;
 
 impl TranslatedString {
     fn untranslated(self) -> &'static str {

--- a/core/embed/rust/src/trezorhal/bip39.rs
+++ b/core/embed/rust/src/trezorhal/bip39.rs
@@ -1,4 +1,5 @@
-use super::{ffi, wordlist::Wordlist};
+use super::ffi;
+use super::wordlist::Wordlist;
 
 pub fn complete_word(prefix: &str) -> Option<&'static str> {
     if prefix.is_empty() {

--- a/core/embed/rust/src/trezorhal/bitblt.rs
+++ b/core/embed/rust/src/trezorhal/bitblt.rs
@@ -1,12 +1,8 @@
 use super::ffi;
-
-use crate::ui::{
-    display::Color,
-    geometry::Rect,
-    shape::{Bitmap, BitmapFormat, BitmapView},
-};
-
 use crate::trezorhal::display::{DISPLAY_RESX, DISPLAY_RESY};
+use crate::ui::display::Color;
+use crate::ui::geometry::Rect;
+use crate::ui::shape::{Bitmap, BitmapFormat, BitmapView};
 
 /// Waits for the DMA2D peripheral transfer to complete.
 pub fn wait_for_transfer() {

--- a/core/embed/rust/src/trezorhal/ble/micropython.rs
+++ b/core/embed/rust/src/trezorhal/ble/micropython.rs
@@ -1,19 +1,16 @@
-use super::{super::model, *};
-use crate::{
-    error::Error,
-    micropython::{
-        buffer::{get_buffer, get_buffer_mut, StrBuffer},
-        list::List,
-        macros::*,
-        map::Map,
-        module::Module,
-        obj::Obj,
-        qstr::Qstr,
-        simple_type::SimpleTypeObj,
-        typ::Type,
-        util,
-    },
-};
+use super::super::model;
+use super::*;
+use crate::error::Error;
+use crate::micropython::buffer::{get_buffer, get_buffer_mut, StrBuffer};
+use crate::micropython::list::List;
+use crate::micropython::macros::*;
+use crate::micropython::map::Map;
+use crate::micropython::module::Module;
+use crate::micropython::obj::Obj;
+use crate::micropython::qstr::Qstr;
+use crate::micropython::simple_type::SimpleTypeObj;
+use crate::micropython::typ::Type;
+use crate::micropython::util;
 
 extern "C" fn py_erase_bonds() -> Obj {
     let block = || {

--- a/core/embed/rust/src/trezorhal/ble/mod.rs
+++ b/core/embed/rust/src/trezorhal/ble/mod.rs
@@ -1,12 +1,13 @@
 #[cfg(feature = "micropython")]
 mod micropython;
 
-#[cfg(feature = "ui")]
-use crate::ui::event::BLEEvent;
+use core::ptr;
 
 use super::ffi;
-use crate::{error::Error, trezorhal::ffi::bt_le_addr_t};
-use core::ptr;
+use crate::error::Error;
+use crate::trezorhal::ffi::bt_le_addr_t;
+#[cfg(feature = "ui")]
+use crate::ui::event::BLEEvent;
 
 pub const ADV_NAME_LEN: usize = ffi::BLE_ADV_NAME_LEN as usize;
 pub const BLE_MAX_BONDS: usize = ffi::BLE_MAX_BONDS as usize;

--- a/core/embed/rust/src/trezorhal/bootloader.rs
+++ b/core/embed/rust/src/trezorhal/bootloader.rs
@@ -1,6 +1,6 @@
-use super::ffi;
-
 use num_traits::FromPrimitive;
+
+use super::ffi;
 
 #[derive(PartialEq, Debug, Eq, Clone, Copy, FromPrimitive, ToPrimitive)]
 pub enum BootloaderWFResult {

--- a/core/embed/rust/src/trezorhal/button.rs
+++ b/core/embed/rust/src/trezorhal/button.rs
@@ -1,6 +1,6 @@
-use super::ffi;
-
 use num_traits::FromPrimitive;
+
+use super::ffi;
 
 #[derive(Copy, Clone, PartialEq, Eq, FromPrimitive)]
 #[cfg_attr(feature = "debug", derive(ufmt::derive::uDebug))]

--- a/core/embed/rust/src/trezorhal/display.rs
+++ b/core/embed/rust/src/trezorhal/display.rs
@@ -1,9 +1,9 @@
-use super::ffi;
-
 #[cfg(feature = "framebuffer")]
 use core::ptr;
 
 use ffi::{DISPLAY_RESX_, DISPLAY_RESY_};
+
+use super::ffi;
 
 pub const DISPLAY_RESX: u32 = DISPLAY_RESX_;
 pub const DISPLAY_RESY: u32 = DISPLAY_RESY_;

--- a/core/embed/rust/src/trezorhal/irq.rs
+++ b/core/embed/rust/src/trezorhal/irq.rs
@@ -1,6 +1,6 @@
-use super::ffi;
-
 pub use ffi::irq_key_t as IrqKey;
+
+use super::ffi;
 
 pub fn irq_lock() -> IrqKey {
     unsafe { ffi::irq_lock_fn() }

--- a/core/embed/rust/src/trezorhal/jpegdec.rs
+++ b/core/embed/rust/src/trezorhal/jpegdec.rs
@@ -1,12 +1,9 @@
-use super::ffi;
-
-use crate::ui::{
-    geometry::{Offset, Point, Rect},
-    shape::{Bitmap, BitmapFormat, BitmapView},
-};
-
-use crate::io::BinaryData;
 use num_traits::FromPrimitive;
+
+use super::ffi;
+use crate::io::BinaryData;
+use crate::ui::geometry::{Offset, Point, Rect};
+use crate::ui::shape::{Bitmap, BitmapFormat, BitmapView};
 
 pub const RGBA8888_BUFFER_SIZE: usize = ffi::JPEGDEC_RGBA8888_BUFFER_SIZE as _;
 pub const MONO8_BUFFER_SIZE: usize = ffi::JPEGDEC_MONO8_BUFFER_SIZE as _;

--- a/core/embed/rust/src/trezorhal/layout_buf.rs
+++ b/core/embed/rust/src/trezorhal/layout_buf.rs
@@ -1,4 +1,6 @@
-use core::{marker::PhantomData, mem::MaybeUninit, ptr::NonNull};
+use core::marker::PhantomData;
+use core::mem::MaybeUninit;
+use core::ptr::NonNull;
 
 pub use super::ffi::c_layout_t;
 

--- a/core/embed/rust/src/trezorhal/power_manager.rs
+++ b/core/embed/rust/src/trezorhal/power_manager.rs
@@ -1,6 +1,6 @@
-use super::ffi;
 use core::ptr::null_mut;
 
+use super::ffi;
 #[cfg(feature = "ui")]
 use crate::ui::event::PMEvent;
 

--- a/core/embed/rust/src/trezorhal/secbool.rs
+++ b/core/embed/rust/src/trezorhal/secbool.rs
@@ -1,5 +1,5 @@
 #![allow(unused_imports)]
 
-use super::ffi;
-
 pub use ffi::{secbool, secfalse, sectrue};
+
+use super::ffi;

--- a/core/embed/rust/src/trezorhal/slip39.rs
+++ b/core/embed/rust/src/trezorhal/slip39.rs
@@ -1,4 +1,5 @@
-use core::{ffi::CStr, str};
+use core::ffi::CStr;
+use core::str;
 
 use super::ffi;
 

--- a/core/embed/rust/src/trezorhal/storage.rs
+++ b/core/embed/rust/src/trezorhal/storage.rs
@@ -1,10 +1,11 @@
 #![allow(dead_code)]
 
-use super::ffi;
-use crate::error::{value_error, Error};
 use core::ptr;
 
 use num_traits::FromPrimitive;
+
+use super::ffi;
+use crate::error::{value_error, Error};
 
 /// Result of PIN delay callback.
 #[derive(Copy, Clone, Debug, PartialEq, Eq)]

--- a/core/embed/rust/src/trezorhal/sysevent.rs
+++ b/core/embed/rust/src/trezorhal/sysevent.rs
@@ -1,33 +1,30 @@
 #![allow(unused_imports)]
 
-use super::ffi;
 use core::mem::{self, MaybeUninit};
 
-use crate::ui::component::Event;
 pub use ffi::{sysevents_t, syshandle_t};
 
+use super::ffi;
 #[cfg(feature = "ble")]
 use crate::trezorhal::ble::ble_parse_event;
-#[cfg(feature = "ble")]
-use crate::ui::event::BLEEvent;
-
-#[cfg(feature = "touch")]
-use crate::trezorhal::touch::touch_get_event;
-#[cfg(feature = "touch")]
-use crate::ui::event::TouchEvent;
-
-#[cfg(feature = "power_manager")]
-use crate::trezorhal::power_manager::pm_parse_event;
-#[cfg(feature = "power_manager")]
-use crate::ui::event::PMEvent;
-
 #[cfg(feature = "button")]
 use crate::trezorhal::button::button_parse_event;
 #[cfg(feature = "button")]
 use crate::trezorhal::ffi::button_get_event;
+#[cfg(feature = "power_manager")]
+use crate::trezorhal::power_manager::pm_parse_event;
 use crate::trezorhal::time::ticks_ms;
+#[cfg(feature = "touch")]
+use crate::trezorhal::touch::touch_get_event;
+use crate::ui::component::Event;
+#[cfg(feature = "ble")]
+use crate::ui::event::BLEEvent;
 #[cfg(feature = "button")]
 use crate::ui::event::ButtonEvent;
+#[cfg(feature = "power_manager")]
+use crate::ui::event::PMEvent;
+#[cfg(feature = "touch")]
+use crate::ui::event::TouchEvent;
 
 #[derive(PartialEq, Debug, Eq, Clone, Copy)]
 pub enum Syshandle {

--- a/core/embed/rust/src/trezorhal/time.rs
+++ b/core/embed/rust/src/trezorhal/time.rs
@@ -1,6 +1,5 @@
-use crate::time::Duration;
-
 use super::ffi;
+use crate::time::Duration;
 
 /// Returns the current time in milliseconds since the device was reset.
 /// Time is represented as a 32-bit number that wraps around every 49.7 days.

--- a/core/embed/rust/src/trezorhal/uzlib.rs
+++ b/core/embed/rust/src/trezorhal/uzlib.rs
@@ -1,6 +1,10 @@
+use core::cell::RefCell;
+use core::marker::PhantomData;
+use core::mem::MaybeUninit;
+use core::ptr;
+
 use super::ffi;
 use crate::io::BinaryData;
-use core::{cell::RefCell, marker::PhantomData, mem::MaybeUninit, ptr};
 
 pub const UZLIB_WINDOW_SIZE: usize = 1 << 10;
 pub use ffi::uzlib_uncomp;

--- a/core/embed/rust/src/trezorhal/wordlist.rs
+++ b/core/embed/rust/src/trezorhal/wordlist.rs
@@ -1,5 +1,7 @@
+use core::cmp::Ordering;
+use core::ffi::CStr;
+
 use super::ffi;
-use core::{cmp::Ordering, ffi::CStr};
 
 /// Holds all the possible words with the possibility to interact
 /// with the "list" - filtering it further, getting their count, etc.

--- a/core/embed/rust/src/ui/animation.rs
+++ b/core/embed/rust/src/ui/animation.rs
@@ -1,7 +1,5 @@
-use crate::{
-    time::{Duration, Instant},
-    ui::lerp::{InvLerp, Lerp},
-};
+use crate::time::{Duration, Instant};
+use crate::ui::lerp::{InvLerp, Lerp};
 
 /// Running, time-based linear progression of a value.
 #[derive(Clone)]

--- a/core/embed/rust/src/ui/api/bootloader_c.rs
+++ b/core/embed/rust/src/ui/api/bootloader_c.rs
@@ -1,8 +1,7 @@
-use crate::{
-    strutil::hexlify,
-    ui::{ui_bootloader::BootloaderUI, ModelUI},
-    util::{from_c_array, from_c_str},
-};
+use crate::strutil::hexlify;
+use crate::ui::ui_bootloader::BootloaderUI;
+use crate::ui::ModelUI;
+use crate::util::{from_c_array, from_c_str};
 
 #[no_mangle]
 extern "C" fn screen_welcome(ui_action_result: *mut u32) -> u32 {

--- a/core/embed/rust/src/ui/api/common_c.rs
+++ b/core/embed/rust/src/ui/api/common_c.rs
@@ -1,12 +1,10 @@
 //! Reexporting the `screens` module according to the
 //! current feature (Trezor model)
 
-use crate::ui::{CommonUI, ModelUI};
-
-use crate::{ui::shape, util::from_c_str};
-
 #[cfg(feature = "ui_debug")]
 use crate::ui::util::set_animation_disabled;
+use crate::ui::{shape, CommonUI, ModelUI};
+use crate::util::from_c_str;
 
 #[no_mangle]
 extern "C" fn display_rsod_rust(

--- a/core/embed/rust/src/ui/api/firmware_micropython.rs
+++ b/core/embed/rust/src/ui/api/firmware_micropython.rs
@@ -1,42 +1,33 @@
-use crate::{
-    error::Error,
-    io::BinaryData,
-    micropython::{
-        buffer::StrBuffer,
-        gc::Gc,
-        iter::IterBuf,
-        list::List,
-        macros::{obj_fn_0, obj_fn_1, obj_fn_kw, obj_module},
-        map::Map,
-        module::Module,
-        obj::Obj,
-        qstr::Qstr,
-        util,
-    },
-    strutil::TString,
-    trezorhal::model,
-    ui::{
-        backlight::BACKLIGHT_LEVELS_OBJ,
-        component::Empty,
-        layout::{
-            base::LAYOUT_STATE,
-            device_menu_result::DEVICE_MENU_RESULT,
-            obj::{ComponentMsgObj, LayoutObj, ATTACH_TYPE_OBJ},
-            result::{BACK, CANCELLED, CONFIRMED, INFO},
-            util::{upy_disable_animation, RecoveryType},
-        },
-        notification::{Notification, NotificationLevel, NOTIFICATION_LEVEL_OBJ},
-        ui_firmware::{
-            FirmwareUI, MAX_CHECKLIST_ITEMS, MAX_GROUP_SHARE_LINES, MAX_PAIRED_DEVICES,
-            MAX_WORD_QUIZ_ITEMS,
-        },
-        ModelUI,
-    },
-};
 use heapless::Vec;
 
+use crate::error::Error;
+use crate::io::BinaryData;
+use crate::micropython::buffer::StrBuffer;
+use crate::micropython::gc::Gc;
+use crate::micropython::iter::IterBuf;
+use crate::micropython::list::List;
+use crate::micropython::macros::{obj_fn_0, obj_fn_1, obj_fn_kw, obj_module};
+use crate::micropython::map::Map;
+use crate::micropython::module::Module;
+use crate::micropython::obj::Obj;
+use crate::micropython::qstr::Qstr;
+use crate::micropython::util;
+use crate::strutil::TString;
+use crate::trezorhal::model;
+use crate::ui::backlight::BACKLIGHT_LEVELS_OBJ;
+use crate::ui::component::Empty;
 #[cfg(feature = "backlight")]
 use crate::ui::display::{fade_backlight_duration, get_backlight, set_backlight};
+use crate::ui::layout::base::LAYOUT_STATE;
+use crate::ui::layout::device_menu_result::DEVICE_MENU_RESULT;
+use crate::ui::layout::obj::{ComponentMsgObj, LayoutObj, ATTACH_TYPE_OBJ};
+use crate::ui::layout::result::{BACK, CANCELLED, CONFIRMED, INFO};
+use crate::ui::layout::util::{upy_disable_animation, RecoveryType};
+use crate::ui::notification::{Notification, NotificationLevel, NOTIFICATION_LEVEL_OBJ};
+use crate::ui::ui_firmware::{
+    FirmwareUI, MAX_CHECKLIST_ITEMS, MAX_GROUP_SHARE_LINES, MAX_PAIRED_DEVICES, MAX_WORD_QUIZ_ITEMS,
+};
+use crate::ui::ModelUI;
 
 /// Dummy implementation so that we can use `Empty` in a return type of
 /// unimplemented trait function

--- a/core/embed/rust/src/ui/api/prodtest_c.rs
+++ b/core/embed/rust/src/ui/api/prodtest_c.rs
@@ -1,23 +1,17 @@
-use crate::{
-    trezorhal::{
-        layout_buf::{c_layout_t, LayoutBuffer},
-        sysevent::{parse_event, sysevents_t},
-    },
-    ui::{
-        ui_prodtest::{ProdtestLayoutType, ProdtestUI},
-        ModelUI,
-    },
-    util::from_c_array,
-};
-
-#[cfg(feature = "touch")]
-use crate::ui::geometry::{Offset, Point, Rect};
-#[cfg(feature = "touch")]
-use crate::ui::{event::TouchEvent, layout::simplified::touch_unpack};
 #[cfg(feature = "touch")]
 use cty::int16_t;
 #[cfg(feature = "touch")]
 use heapless::Vec;
+
+use crate::trezorhal::layout_buf::{c_layout_t, LayoutBuffer};
+use crate::trezorhal::sysevent::{parse_event, sysevents_t};
+#[cfg(feature = "touch")]
+use crate::ui::geometry::{Offset, Point, Rect};
+use crate::ui::ui_prodtest::{ProdtestLayoutType, ProdtestUI};
+use crate::ui::ModelUI;
+#[cfg(feature = "touch")]
+use crate::ui::{event::TouchEvent, layout::simplified::touch_unpack};
+use crate::util::from_c_array;
 
 #[no_mangle]
 extern "C" fn screen_prodtest_event(layout: *mut c_layout_t, signalled: &sysevents_t) -> u32 {

--- a/core/embed/rust/src/ui/backlight.rs
+++ b/core/embed/rust/src/ui/backlight.rs
@@ -1,10 +1,11 @@
-use crate::{
-    error::Error,
-    micropython::{
-        ffi, macros::obj_type, obj::Obj, qstr::Qstr, simple_type::SimpleTypeObj, typ::Type, util,
-    },
-    ui::{CommonUI, ModelUI},
-};
+use crate::error::Error;
+use crate::micropython::macros::obj_type;
+use crate::micropython::obj::Obj;
+use crate::micropython::qstr::Qstr;
+use crate::micropython::simple_type::SimpleTypeObj;
+use crate::micropython::typ::Type;
+use crate::micropython::{ffi, util};
+use crate::ui::{CommonUI, ModelUI};
 
 /*
  * This whole module should be removed, in favor of fully

--- a/core/embed/rust/src/ui/button_request.rs
+++ b/core/embed/rust/src/ui/button_request.rs
@@ -1,5 +1,6 @@
-use crate::strutil::TString;
 use num_traits::FromPrimitive;
+
+use crate::strutil::TString;
 
 // ButtonRequestType from messages-common.proto
 // Eventually this should be generated

--- a/core/embed/rust/src/ui/component/bar.rs
+++ b/core/embed/rust/src/ui/component/bar.rs
@@ -1,10 +1,8 @@
-use crate::ui::{
-    component::{Component, Event, EventCtx, Never},
-    display::Color,
-    geometry::Rect,
-    shape,
-    shape::Renderer,
-};
+use crate::ui::component::{Component, Event, EventCtx, Never};
+use crate::ui::display::Color;
+use crate::ui::geometry::Rect;
+use crate::ui::shape;
+use crate::ui::shape::Renderer;
 
 pub struct Bar {
     area: Rect,

--- a/core/embed/rust/src/ui/component/base.rs
+++ b/core/embed/rust/src/ui/component/base.rs
@@ -1,18 +1,11 @@
 use heapless::Vec;
 
-use crate::{
-    error::Error,
-    strutil::{ShortString, TString},
-    time::Duration,
-    ui::{
-        button_request::{ButtonRequest, ButtonRequestCode},
-        component::{MsgMap, PageMap},
-        geometry::{Offset, Rect},
-        shape::Renderer,
-        util::Pager,
-    },
-};
-
+use super::Paginate;
+use crate::error::Error;
+use crate::strutil::{ShortString, TString};
+use crate::time::Duration;
+use crate::ui::button_request::{ButtonRequest, ButtonRequestCode};
+use crate::ui::component::{MsgMap, PageMap};
 #[cfg(feature = "ble")]
 use crate::ui::event::BLEEvent;
 #[cfg(feature = "button")]
@@ -20,13 +13,14 @@ use crate::ui::event::ButtonEvent;
 #[cfg(feature = "power_manager")]
 use crate::ui::event::PMEvent;
 use crate::ui::event::USBEvent;
+use crate::ui::geometry::{Offset, Rect};
+use crate::ui::shape::Renderer;
+use crate::ui::util::Pager;
 #[cfg(feature = "touch")]
 use crate::ui::{
     event::{SwipeEvent, TouchEvent},
     geometry::Direction,
 };
-
-use super::Paginate;
 
 /// Type used by components that do not return any messages.
 ///

--- a/core/embed/rust/src/ui/component/ble.rs
+++ b/core/embed/rust/src/ui/component/ble.rs
@@ -1,12 +1,9 @@
-use crate::ui::{
-    component::{Component, Event, EventCtx},
-    event::BLEEvent,
-    geometry::Rect,
-    shape::Renderer,
-};
-
+use crate::ui::component::{Component, Event, EventCtx};
+use crate::ui::event::BLEEvent;
+use crate::ui::geometry::Rect;
 #[cfg(feature = "rgb_led")]
 use crate::ui::led::{Effect, LedState};
+use crate::ui::shape::Renderer;
 
 pub enum BLEHandlerMode {
     /// Advertising without whitelist started, waiting for some host to respond
@@ -87,14 +84,10 @@ where
 #[cfg(feature = "micropython")]
 mod micropython {
     use super::*;
-    use crate::{
-        error::Error,
-        micropython::obj::Obj,
-        ui::layout::{
-            obj::ComponentMsgObj,
-            result::{CANCELLED, CONFIRMED},
-        },
-    };
+    use crate::error::Error;
+    use crate::micropython::obj::Obj;
+    use crate::ui::layout::obj::ComponentMsgObj;
+    use crate::ui::layout::result::{CANCELLED, CONFIRMED};
     impl<T> ComponentMsgObj for BLEHandler<T>
     where
         T: ComponentMsgObj,

--- a/core/embed/rust/src/ui/component/border.rs
+++ b/core/embed/rust/src/ui/component/border.rs
@@ -1,8 +1,6 @@
 use super::{Component, Event, EventCtx};
-use crate::ui::{
-    geometry::{Insets, Rect},
-    shape::Renderer,
-};
+use crate::ui::geometry::{Insets, Rect};
+use crate::ui::shape::Renderer;
 
 pub struct Border<T> {
     border: Insets,
@@ -55,7 +53,9 @@ where
 
 #[cfg(feature = "micropython")]
 mod micropython {
-    use crate::{error::Error, micropython::obj::Obj, ui::layout::obj::ComponentMsgObj};
+    use crate::error::Error;
+    use crate::micropython::obj::Obj;
+    use crate::ui::layout::obj::ComponentMsgObj;
     impl<T: ComponentMsgObj> ComponentMsgObj for super::Border<T> {
         fn msg_try_into_obj(&self, msg: Self::Msg) -> Result<Obj, Error> {
             self.inner().msg_try_into_obj(msg)

--- a/core/embed/rust/src/ui/component/button_request.rs
+++ b/core/embed/rust/src/ui/component/button_request.rs
@@ -1,11 +1,8 @@
-use crate::ui::{
-    button_request::ButtonRequest,
-    component::{Component, Event, EventCtx},
-    geometry::Rect,
-};
-
+use crate::ui::button_request::ButtonRequest;
 #[cfg(all(feature = "micropython", feature = "touch"))]
 use crate::ui::component::swipe_detect::SwipeConfig;
+use crate::ui::component::{Component, Event, EventCtx};
+use crate::ui::geometry::Rect;
 
 /// Component that sends a ButtonRequest after receiving Event::Attach. The
 /// request is either sent only once or on every Event::Attach configured by

--- a/core/embed/rust/src/ui/component/cached_jpeg.rs
+++ b/core/embed/rust/src/ui/component/cached_jpeg.rs
@@ -1,15 +1,10 @@
-use crate::{
-    error::Error,
-    io::BinaryData,
-    ui::{
-        component::{Component, Event, EventCtx, Never},
-        display::image::ImageInfo,
-        geometry::{Offset, Point, Rect},
-        shape::{self, render_on_canvas, ImageBuffer, Renderer, Rgb565Canvas},
-    },
-};
-
 use super::paginated::SinglePage;
+use crate::error::Error;
+use crate::io::BinaryData;
+use crate::ui::component::{Component, Event, EventCtx, Never};
+use crate::ui::display::image::ImageInfo;
+use crate::ui::geometry::{Offset, Point, Rect};
+use crate::ui::shape::{self, render_on_canvas, ImageBuffer, Renderer, Rgb565Canvas};
 
 pub struct CachedJpeg {
     area: Rect,
@@ -86,7 +81,9 @@ impl crate::trace::Trace for CachedJpeg {
 
 #[cfg(feature = "micropython")]
 mod micropython {
-    use crate::{error::Error, micropython::obj::Obj, ui::layout::obj::ComponentMsgObj};
+    use crate::error::Error;
+    use crate::micropython::obj::Obj;
+    use crate::ui::layout::obj::ComponentMsgObj;
     impl ComponentMsgObj for super::CachedJpeg {
         fn msg_try_into_obj(&self, _msg: Self::Msg) -> Result<Obj, Error> {
             unreachable!();

--- a/core/embed/rust/src/ui/component/connect.rs
+++ b/core/embed/rust/src/ui/component/connect.rs
@@ -1,12 +1,8 @@
-use crate::{
-    strutil::TString,
-    ui::{
-        component::{Component, Event, EventCtx, Never, Pad},
-        display::{Color, Font},
-        geometry::{Alignment, Offset, Rect},
-        shape::{self, Renderer},
-    },
-};
+use crate::strutil::TString;
+use crate::ui::component::{Component, Event, EventCtx, Never, Pad};
+use crate::ui::display::{Color, Font};
+use crate::ui::geometry::{Alignment, Offset, Rect};
+use crate::ui::shape::{self, Renderer};
 
 pub struct Connect {
     fg: Color,
@@ -62,9 +58,10 @@ impl Component for Connect {
 
 #[cfg(feature = "micropython")]
 mod micropython {
-    use crate::{error::Error, micropython::obj::Obj, ui::layout::obj::ComponentMsgObj};
-
     use super::Connect;
+    use crate::error::Error;
+    use crate::micropython::obj::Obj;
+    use crate::ui::layout::obj::ComponentMsgObj;
 
     impl ComponentMsgObj for Connect {
         fn msg_try_into_obj(&self, _msg: Self::Msg) -> Result<Obj, Error> {

--- a/core/embed/rust/src/ui/component/empty.rs
+++ b/core/embed/rust/src/ui/component/empty.rs
@@ -1,5 +1,6 @@
 use super::{Component, Event, EventCtx, Never};
-use crate::ui::{geometry::Rect, shape::Renderer};
+use crate::ui::geometry::Rect;
+use crate::ui::shape::Renderer;
 
 #[derive(Clone)]
 pub struct Empty;

--- a/core/embed/rust/src/ui/component/image.rs
+++ b/core/embed/rust/src/ui/component/image.rs
@@ -1,13 +1,9 @@
-use crate::ui::{
-    component::{Component, Event, EventCtx, Never},
-    display::{
-        toif::{Toif, ToifFormat},
-        Color, Icon,
-    },
-    geometry::{Alignment2D, Offset, Point, Rect},
-    shape,
-    shape::Renderer,
-};
+use crate::ui::component::{Component, Event, EventCtx, Never};
+use crate::ui::display::toif::{Toif, ToifFormat};
+use crate::ui::display::{Color, Icon};
+use crate::ui::geometry::{Alignment2D, Offset, Point, Rect};
+use crate::ui::shape;
+use crate::ui::shape::Renderer;
 
 #[derive(PartialEq, Eq, Clone, Copy)]
 pub struct Image {

--- a/core/embed/rust/src/ui/component/jpeg.rs
+++ b/core/embed/rust/src/ui/component/jpeg.rs
@@ -1,12 +1,8 @@
-use crate::{
-    io::BinaryData,
-    ui::{
-        component::{Component, Event, EventCtx, Never},
-        geometry::{Alignment2D, Rect},
-        shape,
-        shape::Renderer,
-    },
-};
+use crate::io::BinaryData;
+use crate::ui::component::{Component, Event, EventCtx, Never};
+use crate::ui::geometry::{Alignment2D, Rect};
+use crate::ui::shape;
+use crate::ui::shape::Renderer;
 
 pub struct Jpeg {
     area: Rect,
@@ -53,7 +49,9 @@ impl crate::trace::Trace for Jpeg {
 
 #[cfg(feature = "micropython")]
 mod micropython {
-    use crate::{error::Error, micropython::obj::Obj, ui::layout::obj::ComponentMsgObj};
+    use crate::error::Error;
+    use crate::micropython::obj::Obj;
+    use crate::ui::layout::obj::ComponentMsgObj;
     impl ComponentMsgObj for super::Jpeg {
         fn msg_try_into_obj(&self, _msg: Self::Msg) -> Result<Obj, Error> {
             unreachable!();

--- a/core/embed/rust/src/ui/component/label.rs
+++ b/core/embed/rust/src/ui/component/label.rs
@@ -1,14 +1,10 @@
-use crate::{
-    strutil::TString,
-    ui::{
-        component::{Component, Event, EventCtx, Never},
-        display::Font,
-        geometry::{Alignment, Insets, Offset, Point, Rect},
-        shape::Renderer,
-    },
-};
-
-use super::{text::TextStyle, TextLayout};
+use super::text::TextStyle;
+use super::TextLayout;
+use crate::strutil::TString;
+use crate::ui::component::{Component, Event, EventCtx, Never};
+use crate::ui::display::Font;
+use crate::ui::geometry::{Alignment, Insets, Offset, Point, Rect};
+use crate::ui::shape::Renderer;
 
 #[derive(Clone)]
 pub struct Label<'a> {

--- a/core/embed/rust/src/ui/component/map.rs
+++ b/core/embed/rust/src/ui/component/map.rs
@@ -1,8 +1,8 @@
 use super::{Component, Event, EventCtx};
-use crate::ui::{geometry::Rect, shape::Renderer};
-
 #[cfg(all(feature = "micropython", feature = "touch"))]
 use crate::ui::component::swipe_detect::SwipeConfig;
+use crate::ui::geometry::Rect;
+use crate::ui::shape::Renderer;
 
 pub struct MsgMap<T, F> {
     inner: T,

--- a/core/embed/rust/src/ui/component/marquee.rs
+++ b/core/embed/rust/src/ui/component/marquee.rs
@@ -1,15 +1,11 @@
-use crate::{
-    strutil::TString,
-    time::{Duration, Instant},
-    ui::{
-        animation::Animation,
-        component::{Component, Event, EventCtx, Never, Timer},
-        display::{Color, Font},
-        geometry::{Offset, Rect},
-        shape::{self, Renderer},
-        util::animation_disabled,
-    },
-};
+use crate::strutil::TString;
+use crate::time::{Duration, Instant};
+use crate::ui::animation::Animation;
+use crate::ui::component::{Component, Event, EventCtx, Never, Timer};
+use crate::ui::display::{Color, Font};
+use crate::ui::geometry::{Offset, Rect};
+use crate::ui::shape::{self, Renderer};
+use crate::ui::util::animation_disabled;
 
 const ANIMATION_DURATION_MS: u32 = 2000;
 const PAUSE_DURATION_MS: u32 = 1000;

--- a/core/embed/rust/src/ui/component/maybe.rs
+++ b/core/embed/rust/src/ui/component/maybe.rs
@@ -1,9 +1,7 @@
-use crate::ui::{
-    component::{Component, ComponentExt, Event, EventCtx, Pad},
-    display::Color,
-    geometry::Rect,
-    shape::Renderer,
-};
+use crate::ui::component::{Component, ComponentExt, Event, EventCtx, Pad};
+use crate::ui::display::Color;
+use crate::ui::geometry::Rect;
+use crate::ui::shape::Renderer;
 
 pub struct Maybe<T> {
     inner: T,

--- a/core/embed/rust/src/ui/component/mod.rs
+++ b/core/embed/rust/src/ui/component/mod.rs
@@ -59,8 +59,6 @@ pub use qr_code::Qr;
 pub use swipe::Swipe;
 #[cfg(feature = "touch")]
 pub use swipe_detect::SwipeDetect;
-pub use text::{
-    formatted::FormattedText,
-    layout::{LineBreaking, PageBreaking, TextLayout},
-};
+pub use text::formatted::FormattedText;
+pub use text::layout::{LineBreaking, PageBreaking, TextLayout};
 pub use timeout::Timeout;

--- a/core/embed/rust/src/ui/component/pad.rs
+++ b/core/embed/rust/src/ui/component/pad.rs
@@ -1,4 +1,7 @@
-use crate::ui::{display::Color, geometry::Rect, shape, shape::Renderer};
+use crate::ui::display::Color;
+use crate::ui::geometry::Rect;
+use crate::ui::shape;
+use crate::ui::shape::Renderer;
 
 pub struct Pad {
     pub area: Rect,

--- a/core/embed/rust/src/ui/component/placed.rs
+++ b/core/embed/rust/src/ui/component/placed.rs
@@ -1,10 +1,7 @@
-use crate::ui::{
-    component::{Component, Event, EventCtx},
-    geometry::{Alignment, Alignment2D, Axis, Grid, GridCellSpan, Insets, Offset, Rect},
-    shape::Renderer,
-};
-
 use super::paginated::SinglePage;
+use crate::ui::component::{Component, Event, EventCtx};
+use crate::ui::geometry::{Alignment, Alignment2D, Axis, Grid, GridCellSpan, Insets, Offset, Rect};
+use crate::ui::shape::Renderer;
 
 pub struct GridPlaced<T> {
     inner: T,

--- a/core/embed/rust/src/ui/component/qr_code.rs
+++ b/core/embed/rust/src/ui/component/qr_code.rs
@@ -1,18 +1,13 @@
 use heapless::String;
 use qrcodegen::{QrCode, QrCodeEcc, Version};
 
-use crate::{
-    error::Error,
-    ui::{
-        component::{Component, Event, EventCtx, Never},
-        display::Color,
-        geometry::{Offset, Rect},
-        shape,
-        shape::Renderer,
-    },
-};
-
 use super::paginated::SinglePage;
+use crate::error::Error;
+use crate::ui::component::{Component, Event, EventCtx, Never};
+use crate::ui::display::Color;
+use crate::ui::geometry::{Offset, Rect};
+use crate::ui::shape;
+use crate::ui::shape::Renderer;
 
 const NVERSIONS: usize = 10; // range of versions (=capacities) that we support
 const THRESHOLDS_BINARY: [usize; NVERSIONS] = [14, 26, 42, 62, 84, 106, 122, 152, 180, 213];
@@ -137,7 +132,9 @@ impl crate::trace::Trace for Qr {
 
 #[cfg(feature = "micropython")]
 mod micropython {
-    use crate::{error::Error, micropython::obj::Obj, ui::layout::obj::ComponentMsgObj};
+    use crate::error::Error;
+    use crate::micropython::obj::Obj;
+    use crate::ui::layout::obj::ComponentMsgObj;
     impl ComponentMsgObj for super::Qr {
         fn msg_try_into_obj(&self, _msg: Self::Msg) -> Result<Obj, Error> {
             unreachable!();

--- a/core/embed/rust/src/ui/component/swipe.rs
+++ b/core/embed/rust/src/ui/component/swipe.rs
@@ -1,9 +1,7 @@
-use crate::ui::{
-    component::{Component, Event, EventCtx},
-    event::TouchEvent,
-    geometry::{Direction, Point, Rect},
-    shape::Renderer,
-};
+use crate::ui::component::{Component, Event, EventCtx};
+use crate::ui::event::TouchEvent;
+use crate::ui::geometry::{Direction, Point, Rect};
+use crate::ui::shape::Renderer;
 
 #[derive(Clone)]
 pub struct Swipe {

--- a/core/embed/rust/src/ui/component/swipe_detect.rs
+++ b/core/embed/rust/src/ui/component/swipe_detect.rs
@@ -1,14 +1,10 @@
-use crate::{
-    time::{Duration, Instant},
-    ui::{
-        animation::Animation,
-        component::{Event, EventCtx},
-        constant::screen,
-        event::{SwipeEvent, TouchEvent},
-        geometry::{Axis, Direction, Offset, Point},
-        util::{animation_disabled, Pager},
-    },
-};
+use crate::time::{Duration, Instant};
+use crate::ui::animation::Animation;
+use crate::ui::component::{Event, EventCtx};
+use crate::ui::constant::screen;
+use crate::ui::event::{SwipeEvent, TouchEvent};
+use crate::ui::geometry::{Axis, Direction, Offset, Point};
+use crate::ui::util::{animation_disabled, Pager};
 
 #[derive(Copy, Clone)]
 pub enum SwipeSettings {

--- a/core/embed/rust/src/ui/component/text/common.rs
+++ b/core/embed/rust/src/ui/component/text/common.rs
@@ -1,7 +1,6 @@
-use crate::{
-    strutil::ShortString,
-    ui::{component::EventCtx, util::ResultExt},
-};
+use crate::strutil::ShortString;
+use crate::ui::component::EventCtx;
+use crate::ui::util::ResultExt;
 
 /// Reified editing operations of `TextBox`.
 ///

--- a/core/embed/rust/src/ui/component/text/formatted.rs
+++ b/core/embed/rust/src/ui/component/text/formatted.rs
@@ -1,14 +1,9 @@
-use crate::ui::{
-    component::{Component, Event, EventCtx, Never, Paginate},
-    geometry::{Alignment, Offset, Rect},
-    shape::Renderer,
-    util::Pager,
-};
-
-use super::{
-    layout::{LayoutFit, LayoutSink, TextNoOp, TextRenderer},
-    op::OpTextLayout,
-};
+use super::layout::{LayoutFit, LayoutSink, TextNoOp, TextRenderer};
+use super::op::OpTextLayout;
+use crate::ui::component::{Component, Event, EventCtx, Never, Paginate};
+use crate::ui::geometry::{Alignment, Offset, Rect};
+use crate::ui::shape::Renderer;
+use crate::ui::util::Pager;
 
 #[derive(Clone)]
 pub struct FormattedText {
@@ -175,7 +170,9 @@ impl crate::trace::Trace for FormattedText {
 
 #[cfg(feature = "micropython")]
 mod micropython {
-    use crate::{error::Error, micropython::obj::Obj, ui::layout::obj::ComponentMsgObj};
+    use crate::error::Error;
+    use crate::micropython::obj::Obj;
+    use crate::ui::layout::obj::ComponentMsgObj;
     impl ComponentMsgObj for super::FormattedText {
         fn msg_try_into_obj(&self, _msg: Self::Msg) -> Result<Obj, Error> {
             unreachable!();

--- a/core/embed/rust/src/ui/component/text/layout.rs
+++ b/core/embed/rust/src/ui/component/text/layout.rs
@@ -1,8 +1,7 @@
-use crate::ui::{
-    display::{toif::Icon, Color, Font, GlyphMetrics},
-    geometry::{Alignment, Alignment2D, Dimensions, Offset, Point, Rect},
-    shape::{self, Renderer},
-};
+use crate::ui::display::toif::Icon;
+use crate::ui::display::{Color, Font, GlyphMetrics};
+use crate::ui::geometry::{Alignment, Alignment2D, Dimensions, Offset, Point, Rect};
+use crate::ui::shape::{self, Renderer};
 
 const ELLIPSIS: &str = "...";
 
@@ -581,9 +580,9 @@ where
 
 #[cfg(feature = "ui_debug")]
 pub mod trace {
-    use crate::{trace::ListTracer, ui::geometry::Point};
-
     use super::*;
+    use crate::trace::ListTracer;
+    use crate::ui::geometry::Point;
 
     /// `LayoutSink` for debugging purposes.
     pub struct TraceSink<'a>(pub &'a mut dyn ListTracer);

--- a/core/embed/rust/src/ui/component/text/op.rs
+++ b/core/embed/rust/src/ui/component/text/op.rs
@@ -1,18 +1,11 @@
-use crate::{
-    strutil::TString,
-    ui::{
-        display::{Color, Font},
-        geometry::{Alignment, Offset, Rect},
-        util::ResultExt,
-    },
-};
-
-use super::{
-    layout::{Chunks, LayoutFit, LayoutSink, TextLayout},
-    LineBreaking, TextStyle,
-};
-
 use heapless::Vec;
+
+use super::layout::{Chunks, LayoutFit, LayoutSink, TextLayout};
+use super::{LineBreaking, TextStyle};
+use crate::strutil::TString;
+use crate::ui::display::{Color, Font};
+use crate::ui::geometry::{Alignment, Offset, Rect};
+use crate::ui::util::ResultExt;
 
 // So that there is only one implementation, and not multiple generic ones
 // as would be via `const N: usize` generics.

--- a/core/embed/rust/src/ui/component/text/paragraphs.rs
+++ b/core/embed/rust/src/ui/component/text/paragraphs.rs
@@ -1,17 +1,15 @@
 use heapless::Vec;
 
-use crate::{
-    strutil::TString,
-    ui::{
-        component::{paginated::SinglePage, Component, Event, EventCtx, Never, Paginate},
-        display::{font::Font, toif::Icon, Color},
-        geometry::{Alignment, Dimensions, Insets, LinearPlacement, Offset, Point, Rect},
-        shape::{self, Renderer},
-        util::Pager,
-    },
-};
-
 use super::layout::{LayoutFit, TextLayout, TextStyle};
+use crate::strutil::TString;
+use crate::ui::component::paginated::SinglePage;
+use crate::ui::component::{Component, Event, EventCtx, Never, Paginate};
+use crate::ui::display::font::Font;
+use crate::ui::display::toif::Icon;
+use crate::ui::display::Color;
+use crate::ui::geometry::{Alignment, Dimensions, Insets, LinearPlacement, Offset, Point, Rect};
+use crate::ui::shape::{self, Renderer};
+use crate::ui::util::Pager;
 
 /// Used as an upper bound of number of different styles we may render on single
 /// page.
@@ -275,9 +273,8 @@ where
 
 #[cfg(feature = "ui_debug")]
 pub mod trace {
-    use crate::ui::component::text::layout::trace::TraceSink;
-
     use super::*;
+    use crate::ui::component::text::layout::trace::TraceSink;
 
     impl<'a, T: ParagraphSource<'a>> crate::trace::Trace for Paragraphs<T> {
         fn trace(&self, t: &mut dyn crate::trace::Tracer) {
@@ -765,7 +762,9 @@ impl<'a, T: ParagraphSource<'a>> crate::trace::Trace for Checklist<T> {
 
 #[cfg(feature = "micropython")]
 mod micropython {
-    use crate::{error::Error, micropython::obj::Obj, ui::layout::obj::ComponentMsgObj};
+    use crate::error::Error;
+    use crate::micropython::obj::Obj;
+    use crate::ui::layout::obj::ComponentMsgObj;
     impl<'a, T: super::ParagraphSource<'a>> ComponentMsgObj for super::Checklist<T> {
         fn msg_try_into_obj(&self, _msg: Self::Msg) -> Result<Obj, Error> {
             unreachable!();

--- a/core/embed/rust/src/ui/component/text/util.rs
+++ b/core/embed/rust/src/ui/component/text/util.rs
@@ -1,16 +1,9 @@
-use crate::{
-    strutil::TString,
-    ui::{
-        display::{Color, Font},
-        geometry::{Alignment, Rect},
-        shape::Renderer,
-    },
-};
-
-use super::{
-    layout::{LayoutFit, TextLayout},
-    TextStyle,
-};
+use super::layout::{LayoutFit, TextLayout};
+use super::TextStyle;
+use crate::strutil::TString;
+use crate::ui::display::{Color, Font};
+use crate::ui::geometry::{Alignment, Rect};
+use crate::ui::shape::Renderer;
 
 /// Draws longer multiline texts inside an area.
 /// Splits lines on word boundaries/whitespace.

--- a/core/embed/rust/src/ui/component/timeout.rs
+++ b/core/embed/rust/src/ui/component/timeout.rs
@@ -1,11 +1,7 @@
-use crate::{
-    time::Duration,
-    ui::{
-        component::{Component, Event, EventCtx, Timer},
-        geometry::Rect,
-        shape::Renderer,
-    },
-};
+use crate::time::Duration;
+use crate::ui::component::{Component, Event, EventCtx, Timer};
+use crate::ui::geometry::Rect;
+use crate::ui::shape::Renderer;
 
 pub struct Timeout {
     time_ms: u32,

--- a/core/embed/rust/src/ui/display/font.rs
+++ b/core/embed/rust/src/ui/display/font.rs
@@ -3,16 +3,13 @@ use core::num::Saturating;
 #[cfg(feature = "translations")]
 use spin::RwLockReadGuard;
 
-use crate::ui::{
-    constant,
-    geometry::Offset,
-    shape::{Bitmap, BitmapFormat},
-};
-
 #[cfg(feature = "translations")]
 use crate::translations::flash;
 #[cfg(feature = "translations")]
 use crate::translations::Translations;
+use crate::ui::constant;
+use crate::ui::geometry::Offset;
+use crate::ui::shape::{Bitmap, BitmapFormat};
 
 #[cfg(feature = "ui_font_kerning")]
 /// Two-level kerning lookup table.

--- a/core/embed/rust/src/ui/display/image.rs
+++ b/core/embed/rust/src/ui/display/image.rs
@@ -1,4 +1,5 @@
-use crate::{io::BinaryData, ui::geometry::Offset};
+use crate::io::BinaryData;
+use crate::ui::geometry::Offset;
 
 impl<'a> BinaryData<'a> {
     fn read_u8(&self, ofs: usize) -> Option<u8> {

--- a/core/embed/rust/src/ui/display/mod.rs
+++ b/core/embed/rust/src/ui/display/mod.rs
@@ -3,23 +3,20 @@ pub mod font;
 pub mod image;
 pub mod toif;
 
-use super::geometry::{Offset, Point, Rect};
-
-#[cfg(feature = "backlight")]
-use crate::{time::Duration, trezorhal::time};
-
-use crate::{strutil::TString, trezorhal::display};
-
-#[cfg(feature = "backlight")]
-use crate::ui::lerp::Lerp;
-
-#[cfg(feature = "backlight")]
-use crate::{time::Stopwatch, ui::util::animation_disabled};
-
-// Reexports
-pub use crate::ui::display::toif::Icon;
 pub use color::Color;
 pub use font::{Font, Glyph, GlyphMetrics};
+
+use super::geometry::{Offset, Point, Rect};
+use crate::strutil::TString;
+use crate::trezorhal::display;
+// Reexports
+pub use crate::ui::display::toif::Icon;
+#[cfg(feature = "backlight")]
+use crate::ui::lerp::Lerp;
+#[cfg(feature = "backlight")]
+use crate::{time::Duration, trezorhal::time};
+#[cfg(feature = "backlight")]
+use crate::{time::Stopwatch, ui::util::animation_disabled};
 
 pub const LOADER_MIN: u16 = 0;
 pub const LOADER_MAX: u16 = 1000;

--- a/core/embed/rust/src/ui/display/toif.rs
+++ b/core/embed/rust/src/ui/display/toif.rs
@@ -1,7 +1,5 @@
-use crate::{
-    error::{value_error, Error},
-    ui::geometry::Offset,
-};
+use crate::error::{value_error, Error};
+use crate::ui::geometry::Offset;
 
 const TOIF_HEADER_LENGTH: usize = 12;
 

--- a/core/embed/rust/src/ui/event/button.rs
+++ b/core/embed/rust/src/ui/event/button.rs
@@ -1,5 +1,4 @@
 use crate::error::Error;
-
 pub use crate::trezorhal::button::PhysicalButton;
 use crate::trezorhal::button::PhysicalButtonEvent;
 

--- a/core/embed/rust/src/ui/event/mod.rs
+++ b/core/embed/rust/src/ui/event/mod.rs
@@ -19,5 +19,4 @@ pub use button::{ButtonEvent, PhysicalButton};
 pub use power_manager::PMEvent;
 #[cfg(feature = "touch")]
 pub use touch::{SwipeEvent, TouchEvent};
-
 pub use usb::USBEvent;

--- a/core/embed/rust/src/ui/event/touch.rs
+++ b/core/embed/rust/src/ui/event/touch.rs
@@ -1,7 +1,5 @@
-use crate::{
-    error::Error,
-    ui::geometry::{Direction, Point},
-};
+use crate::error::Error;
+use crate::ui::geometry::{Direction, Point};
 
 #[derive(Copy, Clone, PartialEq, Eq)]
 #[cfg_attr(feature = "debug", derive(ufmt::derive::uDebug))]

--- a/core/embed/rust/src/ui/flow/base.rs
+++ b/core/embed/rust/src/ui/flow/base.rs
@@ -1,10 +1,8 @@
-use crate::ui::{
-    component::{base::AttachType, swipe_detect::SwipeConfig},
-    geometry::Direction,
-    util::Pager,
-};
-
+use crate::ui::component::base::AttachType;
+use crate::ui::component::swipe_detect::SwipeConfig;
 pub use crate::ui::component::FlowMsg;
+use crate::ui::geometry::Direction;
+use crate::ui::util::Pager;
 
 pub trait Swipable {
     fn get_swipe_config(&self) -> SwipeConfig;

--- a/core/embed/rust/src/ui/flow/mod.rs
+++ b/core/embed/rust/src/ui/flow/mod.rs
@@ -2,7 +2,8 @@ pub mod base;
 pub mod page;
 mod swipe;
 
-pub use crate::ui::component::FlowMsg;
 pub use base::{FlowController, Swipable};
 pub use page::SwipePage;
 pub use swipe::SwipeFlow;
+
+pub use crate::ui::component::FlowMsg;

--- a/core/embed/rust/src/ui/flow/page.rs
+++ b/core/embed/rust/src/ui/flow/page.rs
@@ -1,10 +1,8 @@
-use crate::ui::{
-    component::{Component, Event, EventCtx, Paginate},
-    event::SwipeEvent,
-    geometry::{Axis, Direction, Rect},
-    shape::Renderer,
-    util::Pager,
-};
+use crate::ui::component::{Component, Event, EventCtx, Paginate};
+use crate::ui::event::SwipeEvent;
+use crate::ui::geometry::{Axis, Direction, Rect};
+use crate::ui::shape::Renderer;
+use crate::ui::util::Pager;
 
 /// Allows any implementor of `Paginate` to be part of `Swipable` UI flow.
 /// Renders sliding animation when changing pages.

--- a/core/embed/rust/src/ui/flow/swipe.rs
+++ b/core/embed/rust/src/ui/flow/swipe.rs
@@ -1,29 +1,22 @@
-use crate::{
-    error::{self, Error},
-    maybe_trace::MaybeTrace,
-    micropython::{
-        gc::{self, GcBox},
-        obj::Obj,
-    },
-    ui::{
-        component::{
-            base::AttachType::{self, Swipe},
-            Component, Event, EventCtx, FlowMsg, SwipeDetect,
-        },
-        display::Color,
-        event::SwipeEvent,
-        flow::{base::Decision, FlowController},
-        geometry::{Direction, Rect},
-        layout::base::{Layout, LayoutState},
-        shape::{render_on_display, ConcreteRenderer, Renderer, ScopedRenderer},
-        util::animation_disabled,
-        CommonUI, ModelUI,
-    },
-};
-
-use super::{base::FlowState, Swipable};
-
 use heapless::Vec;
+
+use super::base::FlowState;
+use super::Swipable;
+use crate::error::{self, Error};
+use crate::maybe_trace::MaybeTrace;
+use crate::micropython::gc::{self, GcBox};
+use crate::micropython::obj::Obj;
+use crate::ui::component::base::AttachType::{self, Swipe};
+use crate::ui::component::{Component, Event, EventCtx, FlowMsg, SwipeDetect};
+use crate::ui::display::Color;
+use crate::ui::event::SwipeEvent;
+use crate::ui::flow::base::Decision;
+use crate::ui::flow::FlowController;
+use crate::ui::geometry::{Direction, Rect};
+use crate::ui::layout::base::{Layout, LayoutState};
+use crate::ui::shape::{render_on_display, ConcreteRenderer, Renderer, ScopedRenderer};
+use crate::ui::util::animation_disabled;
+use crate::ui::{CommonUI, ModelUI};
 
 /// Component-like proto-object-safe trait.
 ///

--- a/core/embed/rust/src/ui/geometry.rs
+++ b/core/embed/rust/src/ui/geometry.rs
@@ -1,5 +1,6 @@
-use crate::ui::lerp::Lerp;
 use core::ops::{Add, Mul, Neg, Sub};
+
+use crate::ui::lerp::Lerp;
 
 const fn min(a: i16, b: i16) -> i16 {
     if a < b {

--- a/core/embed/rust/src/ui/layout/base.rs
+++ b/core/embed/rust/src/ui/layout/base.rs
@@ -1,9 +1,7 @@
-use crate::ui::{
-    button_request::ButtonRequest,
-    component::{base::AttachType, Event, EventCtx},
-};
-
 use crate::error::Error;
+use crate::ui::button_request::ButtonRequest;
+use crate::ui::component::base::AttachType;
+use crate::ui::component::{Event, EventCtx};
 
 #[derive(Clone, Copy, PartialEq, Eq)]
 pub enum LayoutState {
@@ -22,15 +20,12 @@ pub trait Layout<T> {
 
 #[cfg(feature = "micropython")]
 mod micropython {
-    use crate::micropython::{
-        macros::{obj_dict, obj_map, obj_type},
-        obj::Obj,
-        qstr::Qstr,
-        simple_type::SimpleTypeObj,
-        typ::Type,
-    };
-
     use super::LayoutState;
+    use crate::micropython::macros::{obj_dict, obj_map, obj_type};
+    use crate::micropython::obj::Obj;
+    use crate::micropython::qstr::Qstr;
+    use crate::micropython::simple_type::SimpleTypeObj;
+    use crate::micropython::typ::Type;
 
     static STATE_INITIAL_TYPE: Type = obj_type! {
         name: Qstr::MP_QSTR_INITIAL,

--- a/core/embed/rust/src/ui/layout/device_menu_result.rs
+++ b/core/embed/rust/src/ui/layout/device_menu_result.rs
@@ -1,9 +1,10 @@
-use crate::{
-    error::Error,
-    micropython::{
-        ffi, macros::obj_type, obj::Obj, qstr::Qstr, simple_type::SimpleTypeObj, typ::Type, util,
-    },
-};
+use crate::error::Error;
+use crate::micropython::macros::obj_type;
+use crate::micropython::obj::Obj;
+use crate::micropython::qstr::Qstr;
+use crate::micropython::simple_type::SimpleTypeObj;
+use crate::micropython::typ::Type;
+use crate::micropython::{ffi, util};
 
 #[derive(Copy, Clone)]
 pub enum DeviceMenuMsg {

--- a/core/embed/rust/src/ui/layout/obj.rs
+++ b/core/embed/rust/src/ui/layout/obj.rs
@@ -1,59 +1,47 @@
-use core::{
-    cell::{RefCell, RefMut},
-    convert::{TryFrom, TryInto},
-    marker::PhantomData,
-    ops::{Deref, DerefMut},
-};
-use num_traits::FromPrimitive;
+use core::cell::{RefCell, RefMut};
+use core::convert::{TryFrom, TryInto};
+use core::marker::PhantomData;
+use core::ops::{Deref, DerefMut};
 
-#[cfg(feature = "touch")]
-use crate::ui::{event::TouchEvent, geometry::Direction};
+use num_traits::FromPrimitive;
 #[cfg(feature = "touch")]
 use num_traits::ToPrimitive;
 
+use super::base::{Layout, LayoutState};
+use crate::error::Error;
+use crate::maybe_trace::MaybeTrace;
+use crate::micropython::buffer::StrBuffer;
+use crate::micropython::gc::{self, Gc, GcBox};
+use crate::micropython::macros::{
+    obj_dict, obj_fn_1, obj_fn_2, obj_fn_3, obj_fn_var, obj_map, obj_type,
+};
+use crate::micropython::map::Map;
+use crate::micropython::obj::{Obj, ObjBase};
+use crate::micropython::qstr::Qstr;
+use crate::micropython::simple_type::SimpleTypeObj;
+use crate::micropython::typ::Type;
+use crate::micropython::util;
+use crate::time::Duration;
+use crate::ui::button_request::ButtonRequest;
+use crate::ui::component::base::{AttachType, TimerToken};
+use crate::ui::component::{Component, Event, EventCtx, Never};
+use crate::ui::display::{self, Color};
 #[cfg(feature = "ble")]
 use crate::ui::event::BLEEvent;
-
+#[cfg(feature = "power_manager")]
+use crate::ui::event::PMEvent;
+use crate::ui::event::USBEvent;
+use crate::ui::shape::render_on_display;
+#[cfg(any(feature = "rgb_led", feature = "ui_debug"))]
+use crate::ui::shape::Renderer;
+#[cfg(feature = "touch")]
+use crate::ui::{event::TouchEvent, geometry::Direction};
+use crate::ui::{CommonUI, ModelUI};
 #[cfg(feature = "button")]
 use crate::{
     trezorhal::button::{PhysicalButton, PhysicalButtonEvent},
     ui::event::ButtonEvent,
 };
-
-#[cfg(feature = "power_manager")]
-use crate::ui::event::PMEvent;
-
-use super::base::{Layout, LayoutState};
-use crate::{
-    error::Error,
-    maybe_trace::MaybeTrace,
-    micropython::{
-        buffer::StrBuffer,
-        gc::{self, Gc, GcBox},
-        macros::{obj_dict, obj_fn_1, obj_fn_2, obj_fn_3, obj_fn_var, obj_map, obj_type},
-        map::Map,
-        obj::{Obj, ObjBase},
-        qstr::Qstr,
-        simple_type::SimpleTypeObj,
-        typ::Type,
-        util,
-    },
-    time::Duration,
-    ui::{
-        button_request::ButtonRequest,
-        component::{
-            base::{AttachType, TimerToken},
-            Component, Event, EventCtx, Never,
-        },
-        display::{self, Color},
-        event::USBEvent,
-        shape::render_on_display,
-        CommonUI, ModelUI,
-    },
-};
-
-#[cfg(any(feature = "rgb_led", feature = "ui_debug"))]
-use crate::ui::shape::Renderer;
 
 impl AttachType {
     fn to_obj(self) -> Obj {

--- a/core/embed/rust/src/ui/layout/result.rs
+++ b/core/embed/rust/src/ui/layout/result.rs
@@ -1,4 +1,7 @@
-use crate::micropython::{macros::obj_type, qstr::Qstr, simple_type::SimpleTypeObj, typ::Type};
+use crate::micropython::macros::obj_type;
+use crate::micropython::qstr::Qstr;
+use crate::micropython::simple_type::SimpleTypeObj;
+use crate::micropython::typ::Type;
 
 static CONFIRMED_TYPE: Type = obj_type! { name: Qstr::MP_QSTR_CONFIRMED, };
 static CANCELLED_TYPE: Type = obj_type! { name: Qstr::MP_QSTR_CANCELLED, };

--- a/core/embed/rust/src/ui/layout/simplified.rs
+++ b/core/embed/rust/src/ui/layout/simplified.rs
@@ -1,17 +1,16 @@
+use num_traits::ToPrimitive;
+
 #[cfg(feature = "button")]
 use crate::trezorhal::button::button_get_event;
+use crate::ui::component::base::AttachType;
+use crate::ui::component::{Component, Event, EventCtx, Never};
+use crate::ui::display::color::Color;
 #[cfg(feature = "button")]
 use crate::ui::event::ButtonEvent;
 #[cfg(feature = "touch")]
 use crate::ui::event::TouchEvent;
-use crate::ui::{
-    component::{base::AttachType, Component, EventCtx, Never},
-    display, CommonUI, ModelUI,
-};
-
-use crate::ui::{component::Event, display::color::Color, shape::render_on_display};
-
-use num_traits::ToPrimitive;
+use crate::ui::shape::render_on_display;
+use crate::ui::{display, CommonUI, ModelUI};
 
 pub trait ReturnToC {
     fn return_to_c(self) -> u32;

--- a/core/embed/rust/src/ui/layout/util.rs
+++ b/core/embed/rust/src/ui/layout/util.rs
@@ -1,23 +1,15 @@
-use crate::{
-    error::{value_error, Error},
-    io::BinaryData,
-    micropython::{
-        buffer::{hexlify_bytes, StrBuffer},
-        gc::Gc,
-        list::List,
-        obj::Obj,
-        util::{iter_into_array, try_or_raise},
-    },
-    storage::{get_avatar_len, load_avatar},
-    strutil::TString,
-    ui::{
-        component::text::{
-            paragraphs::{Paragraph, ParagraphSource},
-            TextStyle,
-        },
-        util::set_animation_disabled,
-    },
-};
+use crate::error::{value_error, Error};
+use crate::io::BinaryData;
+use crate::micropython::buffer::{hexlify_bytes, StrBuffer};
+use crate::micropython::gc::Gc;
+use crate::micropython::list::List;
+use crate::micropython::obj::Obj;
+use crate::micropython::util::{iter_into_array, try_or_raise};
+use crate::storage::{get_avatar_len, load_avatar};
+use crate::strutil::TString;
+use crate::ui::component::text::paragraphs::{Paragraph, ParagraphSource};
+use crate::ui::component::text::TextStyle;
+use crate::ui::util::set_animation_disabled;
 
 cfg_if::cfg_if! {
     if #[cfg(feature = "layout_bolt")] {

--- a/core/embed/rust/src/ui/layout_bolt/bootloader/connect.rs
+++ b/core/embed/rust/src/ui/layout_bolt/bootloader/connect.rs
@@ -1,21 +1,14 @@
-use crate::{
-    strutil::TString,
-    ui::{
-        component::{Component, Event, EventCtx, Pad},
-        display::{Color, Font, Icon},
-        geometry::{Alignment, Insets, Offset, Point, Rect},
-        shape::{self, Renderer},
-    },
+use super::super::component::{Button, ButtonMsg};
+use super::super::constant::WIDTH;
+use super::super::theme::bootloader::{
+    button_bld, button_bld_menu, button_initial, BLD_BG, BUTTON_AREA_START, BUTTON_HEIGHT,
+    CONTENT_PADDING, CORNER_BUTTON_AREA, MENU32, WELCOME_COLOR,
 };
-
-use super::super::{
-    component::{Button, ButtonMsg},
-    constant::WIDTH,
-    theme::bootloader::{
-        button_bld, button_bld_menu, button_initial, BLD_BG, BUTTON_AREA_START, BUTTON_HEIGHT,
-        CONTENT_PADDING, CORNER_BUTTON_AREA, MENU32, WELCOME_COLOR,
-    },
-};
+use crate::strutil::TString;
+use crate::ui::component::{Component, Event, EventCtx, Pad};
+use crate::ui::display::{Color, Font, Icon};
+use crate::ui::geometry::{Alignment, Insets, Offset, Point, Rect};
+use crate::ui::shape::{self, Renderer};
 
 #[repr(u32)]
 #[derive(Copy, Clone, ToPrimitive)]

--- a/core/embed/rust/src/ui/layout_bolt/bootloader/intro.rs
+++ b/core/embed/rust/src/ui/layout_bolt/bootloader/intro.rs
@@ -1,22 +1,16 @@
-use crate::{
-    strutil::TString,
-    ui::{
-        component::{Component, Event, EventCtx, Label, Pad},
-        constant::screen,
-        display::Icon,
-        geometry::{Alignment, Insets, Point, Rect},
-        shape::Renderer,
-    },
+use super::super::component::Button;
+use super::super::component::ButtonMsg::Clicked;
+use super::super::constant::WIDTH;
+use super::super::theme::bootloader::{
+    button_bld, button_bld_menu, text_title, BLD_BG, BUTTON_AREA_START, BUTTON_HEIGHT,
+    CONTENT_PADDING, CORNER_BUTTON_AREA, MENU32, TEXT_NORMAL, TEXT_WARNING, TITLE_AREA,
 };
-
-use super::super::{
-    component::{Button, ButtonMsg::Clicked},
-    constant::WIDTH,
-    theme::bootloader::{
-        button_bld, button_bld_menu, text_title, BLD_BG, BUTTON_AREA_START, BUTTON_HEIGHT,
-        CONTENT_PADDING, CORNER_BUTTON_AREA, MENU32, TEXT_NORMAL, TEXT_WARNING, TITLE_AREA,
-    },
-};
+use crate::strutil::TString;
+use crate::ui::component::{Component, Event, EventCtx, Label, Pad};
+use crate::ui::constant::screen;
+use crate::ui::display::Icon;
+use crate::ui::geometry::{Alignment, Insets, Point, Rect};
+use crate::ui::shape::Renderer;
 
 #[repr(u32)]
 #[derive(Copy, Clone, ToPrimitive)]

--- a/core/embed/rust/src/ui/layout_bolt/bootloader/menu.rs
+++ b/core/embed/rust/src/ui/layout_bolt/bootloader/menu.rs
@@ -1,18 +1,14 @@
-use crate::ui::{
-    component::{Component, Event, EventCtx, Label, Pad},
-    constant::{screen, WIDTH},
-    display::Icon,
-    geometry::{Insets, Point, Rect},
-    shape::Renderer,
+use super::super::component::ButtonMsg::Clicked;
+use super::super::component::{Button, IconText};
+use super::super::theme::bootloader::{
+    button_bld, button_bld_menu, text_title, BLD_BG, BUTTON_HEIGHT, CONTENT_PADDING,
+    CORNER_BUTTON_AREA, CORNER_BUTTON_TOUCH_EXPANSION, FIRE24, REFRESH24, TITLE_AREA, X32,
 };
-
-use super::super::{
-    component::{Button, ButtonMsg::Clicked, IconText},
-    theme::bootloader::{
-        button_bld, button_bld_menu, text_title, BLD_BG, BUTTON_HEIGHT, CONTENT_PADDING,
-        CORNER_BUTTON_AREA, CORNER_BUTTON_TOUCH_EXPANSION, FIRE24, REFRESH24, TITLE_AREA, X32,
-    },
-};
+use crate::ui::component::{Component, Event, EventCtx, Label, Pad};
+use crate::ui::constant::{screen, WIDTH};
+use crate::ui::display::Icon;
+use crate::ui::geometry::{Insets, Point, Rect};
+use crate::ui::shape::Renderer;
 
 const BUTTON_AREA_START: i16 = 56;
 const BUTTON_SPACING: i16 = 8;

--- a/core/embed/rust/src/ui/layout_bolt/bootloader/mod.rs
+++ b/core/embed/rust/src/ui/layout_bolt/bootloader/mod.rs
@@ -7,52 +7,41 @@ pub mod welcome;
 pub mod pairing_finalization;
 
 use heapless::String;
-use ufmt::uwrite;
-
-use super::{
-    bootloader::{connect::Connect, welcome::Welcome},
-    component::{
-        bl_confirm::{Confirm, ConfirmTitle},
-        Button, ResultScreen, WelcomeScreen,
-    },
-    cshape::{render_loader, LoaderRange},
-    fonts,
-    theme::{
-        self,
-        bootloader::{
-            button_bld, button_bld_menu, button_confirm, button_wipe_cancel, button_wipe_confirm,
-            BLD_BG, BLD_FG, BLD_TITLE_COLOR, BLD_WARN_COLOR, BLD_WIPE_COLOR, CHECK24, CHECK40,
-            DOWNLOAD32, FIRE32, FIRE40, RESULT_FW_INSTALL, RESULT_INITIAL, RESULT_WIPE, TEXT_BOLD,
-            TEXT_NORMAL, TEXT_WIPE_BOLD, TEXT_WIPE_NORMAL, WARNING40, WELCOME_COLOR, X24,
-        },
-        FG,
-    },
-    UIBolt,
-};
-use crate::{
-    bootloader::run,
-    time::Duration,
-    trezorhal::time,
-    ui::{
-        component::Label,
-        display::{self, toif::Toif, Color, Icon, LOADER_MAX},
-        geometry::{Alignment, Alignment2D, Offset, Point, Rect},
-        layout::simplified::show,
-        shape::{self, render_on_display},
-        ui_bootloader::BootloaderUI,
-        util::animation_disabled,
-        CommonUI,
-    },
-};
 use intro::Intro;
 use menu::Menu;
+use ufmt::uwrite;
 
+use super::bootloader::connect::Connect;
+use super::bootloader::welcome::Welcome;
+use super::component::bl_confirm::{Confirm, ConfirmTitle};
+use super::component::{Button, ResultScreen, WelcomeScreen};
+use super::cshape::{render_loader, LoaderRange};
+use super::theme::bootloader::{
+    button_bld, button_bld_menu, button_confirm, button_wipe_cancel, button_wipe_confirm, BLD_BG,
+    BLD_FG, BLD_TITLE_COLOR, BLD_WARN_COLOR, BLD_WIPE_COLOR, CHECK24, CHECK40, DOWNLOAD32, FIRE32,
+    FIRE40, RESULT_FW_INSTALL, RESULT_INITIAL, RESULT_WIPE, TEXT_BOLD, TEXT_NORMAL, TEXT_WIPE_BOLD,
+    TEXT_WIPE_NORMAL, WARNING40, WELCOME_COLOR, X24,
+};
+use super::theme::{self, FG};
 #[cfg(feature = "ble")]
 use super::{
     bootloader::pairing_finalization::PairingFinalization,
     component::{confirm_pairing::ConfirmPairing, pairing_mode::PairingMode},
     theme::bootloader::{button_confirm_initial, button_initial},
 };
+use super::{fonts, UIBolt};
+use crate::bootloader::run;
+use crate::time::Duration;
+use crate::trezorhal::time;
+use crate::ui::component::Label;
+use crate::ui::display::toif::Toif;
+use crate::ui::display::{self, Color, Icon, LOADER_MAX};
+use crate::ui::geometry::{Alignment, Alignment2D, Offset, Point, Rect};
+use crate::ui::layout::simplified::show;
+use crate::ui::shape::{self, render_on_display};
+use crate::ui::ui_bootloader::BootloaderUI;
+use crate::ui::util::animation_disabled;
+use crate::ui::CommonUI;
 
 pub type BootloaderString = String<128>;
 

--- a/core/embed/rust/src/ui/layout_bolt/bootloader/pairing_finalization.rs
+++ b/core/embed/rust/src/ui/layout_bolt/bootloader/pairing_finalization.rs
@@ -1,19 +1,12 @@
-use crate::{
-    strutil::TString,
-    ui::{
-        component::{Component, Event, EventCtx, Pad},
-        display::{Color, Font},
-        event::BLEEvent,
-        geometry::{Alignment, Offset, Point, Rect},
-        shape::{self, Renderer},
-    },
-};
-
-use super::super::{
-    component::{Button, ButtonMsg},
-    constant::WIDTH,
-    theme::bootloader::{BUTTON_AREA_START, BUTTON_HEIGHT, CONTENT_PADDING},
-};
+use super::super::component::{Button, ButtonMsg};
+use super::super::constant::WIDTH;
+use super::super::theme::bootloader::{BUTTON_AREA_START, BUTTON_HEIGHT, CONTENT_PADDING};
+use crate::strutil::TString;
+use crate::ui::component::{Component, Event, EventCtx, Pad};
+use crate::ui::display::{Color, Font};
+use crate::ui::event::BLEEvent;
+use crate::ui::geometry::{Alignment, Offset, Point, Rect};
+use crate::ui::shape::{self, Renderer};
 
 #[repr(u32)]
 #[derive(Copy, Clone, ToPrimitive)]

--- a/core/embed/rust/src/ui/layout_bolt/bootloader/welcome.rs
+++ b/core/embed/rust/src/ui/layout_bolt/bootloader/welcome.rs
@@ -1,25 +1,17 @@
-use super::super::{
-    fonts,
-    theme::{
-        bootloader::{START_URL, WELCOME_COLOR},
-        GREY_MEDIUM, WHITE,
-    },
-};
-use crate::ui::{
-    component::{Component, Event, EventCtx, Pad},
-    constant::screen,
-    display::{toif::Toif, Icon},
-    geometry::{Alignment, Alignment2D, Insets, Offset, Rect},
-    shape::{self, Renderer},
-};
-
-use super::super::{
-    component::Button,
-    theme::bootloader::{button_initial, CORNER_BUTTON_AREA, MENU32},
-};
-
+use super::super::component::Button;
 #[cfg(feature = "power_manager")]
 use super::super::component::ButtonMsg::Clicked;
+use super::super::fonts;
+use super::super::theme::bootloader::{
+    button_initial, CORNER_BUTTON_AREA, MENU32, START_URL, WELCOME_COLOR,
+};
+use super::super::theme::{GREY_MEDIUM, WHITE};
+use crate::ui::component::{Component, Event, EventCtx, Pad};
+use crate::ui::constant::screen;
+use crate::ui::display::toif::Toif;
+use crate::ui::display::Icon;
+use crate::ui::geometry::{Alignment, Alignment2D, Insets, Offset, Rect};
+use crate::ui::shape::{self, Renderer};
 
 #[repr(u32)]
 #[derive(Copy, Clone, ToPrimitive)]

--- a/core/embed/rust/src/ui/layout_bolt/component/address_details.rs
+++ b/core/embed/rust/src/ui/layout_bolt/component/address_details.rs
@@ -1,23 +1,18 @@
 use heapless::Vec;
 
-use crate::{
-    error::Error,
-    micropython::buffer::StrBuffer,
-    strutil::TString,
-    translations::TR,
-    ui::{
-        component::{
-            text::paragraphs::{Paragraph, ParagraphSource, ParagraphVecShort, Paragraphs, VecExt},
-            Component, Event, EventCtx, Paginate, Qr,
-        },
-        geometry::Rect,
-        layout::util::MAX_XPUBS,
-        shape::Renderer,
-        util::Pager,
-    },
-};
-
 use super::{theme, Frame, FrameMsg};
+use crate::error::Error;
+use crate::micropython::buffer::StrBuffer;
+use crate::strutil::TString;
+use crate::translations::TR;
+use crate::ui::component::text::paragraphs::{
+    Paragraph, ParagraphSource, ParagraphVecShort, Paragraphs, VecExt,
+};
+use crate::ui::component::{Component, Event, EventCtx, Paginate, Qr};
+use crate::ui::geometry::Rect;
+use crate::ui::layout::util::MAX_XPUBS;
+use crate::ui::shape::Renderer;
+use crate::ui::util::Pager;
 
 pub struct AddressDetails {
     qr_code: Frame<Qr>,

--- a/core/embed/rust/src/ui/layout_bolt/component/bl_confirm.rs
+++ b/core/embed/rust/src/ui/layout_bolt/component/bl_confirm.rs
@@ -1,31 +1,18 @@
-use crate::{
-    strutil::TString,
-    ui::{
-        component::{Child, Component, ComponentExt, Event, EventCtx, Label, Pad},
-        constant,
-        constant::screen,
-        display::{Color, Icon},
-        geometry::{Alignment2D, Insets, Offset, Point, Rect},
-        shape,
-        shape::Renderer,
-    },
+use super::super::constant::WIDTH;
+use super::super::theme::bootloader::{
+    text_fingerprint, text_title, BUTTON_AREA_START, BUTTON_HEIGHT, CONTENT_PADDING,
+    CORNER_BUTTON_AREA, CORNER_BUTTON_TOUCH_EXPANSION, INFO32, TITLE_AREA, X32,
 };
-
-use super::{
-    super::{
-        constant::WIDTH,
-        theme::{
-            bootloader::{
-                text_fingerprint, text_title, BUTTON_AREA_START, BUTTON_HEIGHT, CONTENT_PADDING,
-                CORNER_BUTTON_AREA, CORNER_BUTTON_TOUCH_EXPANSION, INFO32, TITLE_AREA, X32,
-            },
-            WHITE,
-        },
-    },
-    Button,
-    ButtonMsg::Clicked,
-    ButtonStyleSheet,
-};
+use super::super::theme::WHITE;
+use super::ButtonMsg::Clicked;
+use super::{Button, ButtonStyleSheet};
+use crate::strutil::TString;
+use crate::ui::component::{Child, Component, ComponentExt, Event, EventCtx, Label, Pad};
+use crate::ui::constant::screen;
+use crate::ui::display::{Color, Icon};
+use crate::ui::geometry::{Alignment2D, Insets, Offset, Point, Rect};
+use crate::ui::shape::Renderer;
+use crate::ui::{constant, shape};
 
 const ICON_TOP: i16 = 17;
 const CONTENT_START: i16 = 72;

--- a/core/embed/rust/src/ui/layout_bolt/component/button.rs
+++ b/core/embed/rust/src/ui/layout_bolt/component/button.rs
@@ -1,22 +1,18 @@
+use super::theme;
+use crate::strutil::TString;
+use crate::time::ShortDuration;
 #[cfg(feature = "haptic")]
 use crate::trezorhal::haptic::{self, HapticEffect};
-use crate::{
-    strutil::TString,
-    time::ShortDuration,
-    ui::{
-        component::{
-            Component, ComponentExt, Event, EventCtx, FixedHeightBar, MsgMap, Split, Timer,
-        },
-        constant,
-        display::{toif::Icon, Color, Font},
-        event::TouchEvent,
-        geometry::{Alignment2D, Insets, Offset, Point, Rect},
-        shape::{self, Renderer},
-        util::split_two_lines,
-    },
+use crate::ui::component::{
+    Component, ComponentExt, Event, EventCtx, FixedHeightBar, MsgMap, Split, Timer,
 };
-
-use super::theme;
+use crate::ui::constant;
+use crate::ui::display::toif::Icon;
+use crate::ui::display::{Color, Font};
+use crate::ui::event::TouchEvent;
+use crate::ui::geometry::{Alignment2D, Insets, Offset, Point, Rect};
+use crate::ui::shape::{self, Renderer};
+use crate::ui::util::split_two_lines;
 
 #[cfg_attr(feature = "debug", derive(ufmt::derive::uDebug))]
 pub enum ButtonMsg {

--- a/core/embed/rust/src/ui/layout_bolt/component/coinjoin_progress.rs
+++ b/core/embed/rust/src/ui/layout_bolt/component/coinjoin_progress.rs
@@ -1,23 +1,18 @@
 use core::mem;
 
-use crate::{
-    error::Error,
-    maybe_trace::MaybeTrace,
-    strutil::TString,
-    translations::TR,
-    ui::{
-        component::{
-            base::Never, Bar, Child, Component, ComponentExt, Empty, Event, EventCtx, Label, Split,
-        },
-        constant,
-        geometry::{Insets, Offset, Rect},
-        shape,
-        shape::Renderer,
-        util::animation_disabled,
-    },
-};
-
 use super::{theme, Frame};
+use crate::error::Error;
+use crate::maybe_trace::MaybeTrace;
+use crate::strutil::TString;
+use crate::translations::TR;
+use crate::ui::component::base::Never;
+use crate::ui::component::{
+    Bar, Child, Component, ComponentExt, Empty, Event, EventCtx, Label, Split,
+};
+use crate::ui::geometry::{Insets, Offset, Rect};
+use crate::ui::shape::Renderer;
+use crate::ui::util::animation_disabled;
+use crate::ui::{constant, shape};
 
 const RECTANGLE_HEIGHT: i16 = 56;
 const LABEL_TOP: i16 = 135;

--- a/core/embed/rust/src/ui/layout_bolt/component/confirm_pairing.rs
+++ b/core/embed/rust/src/ui/layout_bolt/component/confirm_pairing.rs
@@ -1,25 +1,18 @@
-use super::{
-    super::{
-        constant::WIDTH,
-        theme::bootloader::{BUTTON_AREA_START, BUTTON_HEIGHT, CONTENT_PADDING, TITLE_AREA},
-    },
-    Button,
-    ButtonMsg::Clicked,
+use super::super::constant::WIDTH;
+use super::super::fonts;
+use super::super::theme::bootloader::{
+    BUTTON_AREA_START, BUTTON_HEIGHT, CONTENT_PADDING, TITLE_AREA,
 };
-use crate::{
-    strutil::format_i64,
-    ui::{
-        component::{Child, Component, Event, EventCtx, Label, Pad},
-        constant,
-        display::Color,
-        event::BLEEvent,
-        geometry::{Offset, Point, Rect},
-        shape,
-        shape::Renderer,
-    },
-};
-
-use super::{super::fonts, theme::WHITE};
+use super::theme::WHITE;
+use super::Button;
+use super::ButtonMsg::Clicked;
+use crate::strutil::format_i64;
+use crate::ui::component::{Child, Component, Event, EventCtx, Label, Pad};
+use crate::ui::display::Color;
+use crate::ui::event::BLEEvent;
+use crate::ui::geometry::{Offset, Point, Rect};
+use crate::ui::shape::Renderer;
+use crate::ui::{constant, shape};
 
 const ICON_TOP: i16 = 17;
 const CONTENT_START: i16 = 72;

--- a/core/embed/rust/src/ui/layout_bolt/component/dialog.rs
+++ b/core/embed/rust/src/ui/layout_bolt/component/dialog.rs
@@ -1,20 +1,13 @@
-use crate::{
-    strutil::TString,
-    ui::{
-        component::{
-            image::BlendedImage,
-            text::{
-                paragraphs::{Paragraph, ParagraphSource, ParagraphVecShort, Paragraphs, VecExt},
-                TextStyle,
-            },
-            Child, Component, Event, EventCtx, Never,
-        },
-        geometry::{Insets, LinearPlacement, Rect},
-        shape::Renderer,
-    },
-};
-
 use super::theme;
+use crate::strutil::TString;
+use crate::ui::component::image::BlendedImage;
+use crate::ui::component::text::paragraphs::{
+    Paragraph, ParagraphSource, ParagraphVecShort, Paragraphs, VecExt,
+};
+use crate::ui::component::text::TextStyle;
+use crate::ui::component::{Child, Component, Event, EventCtx, Never};
+use crate::ui::geometry::{Insets, LinearPlacement, Rect};
+use crate::ui::shape::Renderer;
 
 #[cfg_attr(feature = "debug", derive(ufmt::derive::uDebug))]
 pub enum DialogMsg<T, U> {

--- a/core/embed/rust/src/ui/layout_bolt/component/error.rs
+++ b/core/embed/rust/src/ui/layout_bolt/component/error.rs
@@ -1,23 +1,14 @@
-use crate::{
-    strutil::TString,
-    ui::{
-        component::{Child, Component, Event, EventCtx, Label, Never, Pad},
-        constant::screen,
-        geometry::{Alignment2D, Point, Rect},
-        shape,
-        shape::Renderer,
-    },
+use super::super::constant::WIDTH;
+use super::super::theme::{
+    self, FATAL_ERROR_COLOR, ICON_WARNING40, RESULT_FOOTER_START, RESULT_PADDING, WHITE,
 };
-
-use super::{
-    super::{
-        constant::WIDTH,
-        theme::{
-            self, FATAL_ERROR_COLOR, ICON_WARNING40, RESULT_FOOTER_START, RESULT_PADDING, WHITE,
-        },
-    },
-    ResultFooter, ResultStyle,
-};
+use super::{ResultFooter, ResultStyle};
+use crate::strutil::TString;
+use crate::ui::component::{Child, Component, Event, EventCtx, Label, Never, Pad};
+use crate::ui::constant::screen;
+use crate::ui::geometry::{Alignment2D, Point, Rect};
+use crate::ui::shape;
+use crate::ui::shape::Renderer;
 
 const ICON_TOP: i16 = 23;
 const TITLE_AREA_START: i16 = 70;

--- a/core/embed/rust/src/ui/layout_bolt/component/fido.rs
+++ b/core/embed/rust/src/ui/layout_bolt/component/fido.rs
@@ -1,25 +1,16 @@
-use crate::{
-    strutil::TString,
-    ui::{
-        component::{
-            image::Image,
-            text::paragraphs::{Paragraph, ParagraphSource, Paragraphs},
-            Child, Component, Event, EventCtx, Label, Paginate,
-        },
-        display,
-        geometry::{Insets, Rect},
-        shape::{self, Renderer},
-        util::Pager,
-    },
-};
-
-use super::{
-    fido_icons::get_fido_icon_data,
-    swipe::{Swipe, SwipeDirection},
-    theme, CancelConfirmMsg, ScrollBar,
-};
-
 use core::cell::Cell;
+
+use super::fido_icons::get_fido_icon_data;
+use super::swipe::{Swipe, SwipeDirection};
+use super::{theme, CancelConfirmMsg, ScrollBar};
+use crate::strutil::TString;
+use crate::ui::component::image::Image;
+use crate::ui::component::text::paragraphs::{Paragraph, ParagraphSource, Paragraphs};
+use crate::ui::component::{Child, Component, Event, EventCtx, Label, Paginate};
+use crate::ui::display;
+use crate::ui::geometry::{Insets, Rect};
+use crate::ui::shape::{self, Renderer};
+use crate::ui::util::Pager;
 
 const ICON_HEIGHT: i16 = 70;
 const SCROLLBAR_INSET_TOP: i16 = 5;

--- a/core/embed/rust/src/ui/layout_bolt/component/frame.rs
+++ b/core/embed/rust/src/ui/layout_bolt/component/frame.rs
@@ -1,17 +1,12 @@
-use super::theme;
-use crate::{
-    strutil::TString,
-    ui::{
-        component::{
-            base::ComponentExt, label::Label, text::TextStyle, Child, Component, Event, EventCtx,
-        },
-        display::Icon,
-        geometry::{Alignment, Insets, Offset, Rect},
-        shape::Renderer,
-    },
-};
-
-use super::{Button, ButtonMsg, CancelInfoConfirmMsg};
+use super::{theme, Button, ButtonMsg, CancelInfoConfirmMsg};
+use crate::strutil::TString;
+use crate::ui::component::base::ComponentExt;
+use crate::ui::component::label::Label;
+use crate::ui::component::text::TextStyle;
+use crate::ui::component::{Child, Component, Event, EventCtx};
+use crate::ui::display::Icon;
+use crate::ui::geometry::{Alignment, Insets, Offset, Rect};
+use crate::ui::shape::Renderer;
 
 pub struct Frame<T> {
     border: Insets,

--- a/core/embed/rust/src/ui/layout_bolt/component/homescreen.rs
+++ b/core/embed/rust/src/ui/layout_bolt/component/homescreen.rs
@@ -1,30 +1,22 @@
-use crate::{
-    io::BinaryData,
-    strutil::TString,
-    time::{Duration, Instant},
-    translations::TR,
-    trezorhal::usb::usb_configured,
-    ui::{
-        component::{text::TextStyle, Component, Event, EventCtx, Pad, Timer},
-        display::{
-            image::{ImageInfo, ToifFormat},
-            toif::Icon,
-            Color,
-        },
-        event::TouchEvent,
-        geometry::{Alignment, Alignment2D, Insets, Offset, Point, Rect},
-        layout::util::get_user_custom_image,
-        notification::{Notification, NotificationLevel},
-        shape::{self, Renderer},
-    },
-};
-
+use super::super::theme::IMAGE_HOMESCREEN;
+use super::super::{constant, fonts};
+use super::{theme, Loader, LoaderMsg};
+use crate::io::BinaryData;
+use crate::strutil::TString;
+use crate::time::{Duration, Instant};
+use crate::translations::TR;
+use crate::trezorhal::usb::usb_configured;
+use crate::ui::component::text::TextStyle;
+use crate::ui::component::{Component, Event, EventCtx, Pad, Timer};
 use crate::ui::constant::{HEIGHT, WIDTH};
-
-use super::{
-    super::{constant, fonts, theme::IMAGE_HOMESCREEN},
-    theme, Loader, LoaderMsg,
-};
+use crate::ui::display::image::{ImageInfo, ToifFormat};
+use crate::ui::display::toif::Icon;
+use crate::ui::display::Color;
+use crate::ui::event::TouchEvent;
+use crate::ui::geometry::{Alignment, Alignment2D, Insets, Offset, Point, Rect};
+use crate::ui::layout::util::get_user_custom_image;
+use crate::ui::notification::{Notification, NotificationLevel};
+use crate::ui::shape::{self, Renderer};
 
 const AREA: Rect = constant::screen();
 const TOP_CENTER: Point = AREA.top_center();

--- a/core/embed/rust/src/ui/layout_bolt/component/keyboard/bip39.rs
+++ b/core/embed/rust/src/ui/layout_bolt/component/keyboard/bip39.rs
@@ -1,21 +1,13 @@
-use crate::{
-    trezorhal::bip39,
-    ui::{
-        component::{text::common::TextBox, Component, Event, EventCtx},
-        geometry::{Alignment2D, Offset, Rect},
-        shape,
-        shape::Renderer,
-    },
-};
-
-use super::super::{
-    super::theme,
-    keyboard::{
-        common::{render_pending_marker, MultiTapKeyboard},
-        mnemonic::{MnemonicInput, MnemonicInputMsg, MNEMONIC_KEY_COUNT},
-    },
-    Button, ButtonContent, ButtonMsg,
-};
+use super::super::super::theme;
+use super::super::keyboard::common::{render_pending_marker, MultiTapKeyboard};
+use super::super::keyboard::mnemonic::{MnemonicInput, MnemonicInputMsg, MNEMONIC_KEY_COUNT};
+use super::super::{Button, ButtonContent, ButtonMsg};
+use crate::trezorhal::bip39;
+use crate::ui::component::text::common::TextBox;
+use crate::ui::component::{Component, Event, EventCtx};
+use crate::ui::geometry::{Alignment2D, Offset, Rect};
+use crate::ui::shape;
+use crate::ui::shape::Renderer;
 
 const MAX_LENGTH: usize = 8;
 

--- a/core/embed/rust/src/ui/layout_bolt/component/keyboard/common.rs
+++ b/core/embed/rust/src/ui/layout_bolt/component/keyboard/common.rs
@@ -1,13 +1,10 @@
-use crate::{
-    time::Duration,
-    ui::{
-        component::{text::common::TextEdit, Event, EventCtx, Timer},
-        display::{Color, Font},
-        geometry::{Offset, Point, Rect},
-        shape,
-        shape::Renderer,
-    },
-};
+use crate::time::Duration;
+use crate::ui::component::text::common::TextEdit;
+use crate::ui::component::{Event, EventCtx, Timer};
+use crate::ui::display::{Color, Font};
+use crate::ui::geometry::{Offset, Point, Rect};
+use crate::ui::shape;
+use crate::ui::shape::Renderer;
 
 /// Contains state commonly used in implementations multi-tap keyboards.
 pub struct MultiTapKeyboard {

--- a/core/embed/rust/src/ui/layout_bolt/component/keyboard/mnemonic.rs
+++ b/core/embed/rust/src/ui/layout_bolt/component/keyboard/mnemonic.rs
@@ -1,13 +1,9 @@
-use crate::{
-    strutil::TString,
-    ui::{
-        component::{Child, Component, Event, EventCtx, Label, Maybe},
-        geometry::{Alignment2D, Grid, Offset, Rect},
-        shape::Renderer,
-    },
-};
-
-use super::super::{super::theme, Button, ButtonMsg, Swipe, SwipeDirection};
+use super::super::super::theme;
+use super::super::{Button, ButtonMsg, Swipe, SwipeDirection};
+use crate::strutil::TString;
+use crate::ui::component::{Child, Component, Event, EventCtx, Label, Maybe};
+use crate::ui::geometry::{Alignment2D, Grid, Offset, Rect};
+use crate::ui::shape::Renderer;
 
 pub const MNEMONIC_KEY_COUNT: usize = 9;
 

--- a/core/embed/rust/src/ui/layout_bolt/component/keyboard/passphrase.rs
+++ b/core/embed/rust/src/ui/layout_bolt/component/keyboard/passphrase.rs
@@ -1,33 +1,24 @@
-use crate::{
-    strutil::{ShortString, TString},
-    time::Duration,
-    ui::{
-        component::{
-            base::ComponentExt,
-            text::{
-                common::TextBox,
-                layout::{LayoutFit, LineBreaking},
-                TextStyle,
-            },
-            Child, Component, Event, EventCtx, Never, Pad, Paginate, TextLayout, Timer,
-        },
-        display,
-        event::TouchEvent,
-        geometry::{Alignment, Grid, Insets, Offset, Rect},
-        shape::{Bar, Renderer, Text},
-        util::{DisplayStyle, Pager},
-    },
-};
-
-use super::super::{
-    super::constant::SCREEN,
-    button::{Button, ButtonContent, ButtonMsg},
-    keyboard::common::{render_pending_marker, MultiTapKeyboard},
-    swipe::{Swipe, SwipeDirection},
-    theme, ScrollBar,
-};
-
 use core::cell::Cell;
+
+use super::super::super::constant::SCREEN;
+use super::super::button::{Button, ButtonContent, ButtonMsg};
+use super::super::keyboard::common::{render_pending_marker, MultiTapKeyboard};
+use super::super::swipe::{Swipe, SwipeDirection};
+use super::super::{theme, ScrollBar};
+use crate::strutil::{ShortString, TString};
+use crate::time::Duration;
+use crate::ui::component::base::ComponentExt;
+use crate::ui::component::text::common::TextBox;
+use crate::ui::component::text::layout::{LayoutFit, LineBreaking};
+use crate::ui::component::text::TextStyle;
+use crate::ui::component::{
+    Child, Component, Event, EventCtx, Never, Pad, Paginate, TextLayout, Timer,
+};
+use crate::ui::display;
+use crate::ui::event::TouchEvent;
+use crate::ui::geometry::{Alignment, Grid, Insets, Offset, Rect};
+use crate::ui::shape::{Bar, Renderer, Text};
+use crate::ui::util::{DisplayStyle, Pager};
 
 #[cfg_attr(feature = "debug", derive(ufmt::derive::uDebug))]
 pub enum PassphraseKeyboardMsg {

--- a/core/embed/rust/src/ui/layout_bolt/component/keyboard/pin.rs
+++ b/core/embed/rust/src/ui/layout_bolt/component/keyboard/pin.rs
@@ -1,29 +1,19 @@
 use core::mem;
 
-use crate::{
-    strutil::{ShortString, TString},
-    time::Duration,
-    trezorhal::random,
-    ui::{
-        component::{
-            base::ComponentExt, text::TextStyle, Child, Component, Event, EventCtx, Label, Maybe,
-            Never, Pad, Timer,
-        },
-        event::TouchEvent,
-        geometry::{Alignment, Alignment2D, Grid, Insets, Offset, Rect},
-        shape::{Renderer, Text, ToifImage},
-        util::DisplayStyle,
-    },
-};
-
-use super::super::{
-    super::fonts,
-    button::{
-        Button, ButtonContent,
-        ButtonMsg::{self, Clicked},
-    },
-    theme,
-};
+use super::super::super::fonts;
+use super::super::button::ButtonMsg::{self, Clicked};
+use super::super::button::{Button, ButtonContent};
+use super::super::theme;
+use crate::strutil::{ShortString, TString};
+use crate::time::Duration;
+use crate::trezorhal::random;
+use crate::ui::component::base::ComponentExt;
+use crate::ui::component::text::TextStyle;
+use crate::ui::component::{Child, Component, Event, EventCtx, Label, Maybe, Never, Pad, Timer};
+use crate::ui::event::TouchEvent;
+use crate::ui::geometry::{Alignment, Alignment2D, Grid, Insets, Offset, Rect};
+use crate::ui::shape::{Renderer, Text, ToifImage};
+use crate::ui::util::DisplayStyle;
 
 #[cfg_attr(feature = "debug", derive(ufmt::derive::uDebug))]
 pub enum PinKeyboardMsg {

--- a/core/embed/rust/src/ui/layout_bolt/component/keyboard/slip39.rs
+++ b/core/embed/rust/src/ui/layout_bolt/component/keyboard/slip39.rs
@@ -1,27 +1,16 @@
 use core::iter;
 
-use crate::{
-    strutil::ShortString,
-    trezorhal::slip39,
-    ui::{
-        component::{
-            text::common::{TextBox, TextEdit},
-            Component, Event, EventCtx,
-        },
-        geometry::{Alignment2D, Offset, Rect},
-        shape::{self, Renderer},
-        util::ResultExt,
-    },
-};
-
-use super::super::{
-    super::theme,
-    keyboard::{
-        common::{render_pending_marker, MultiTapKeyboard},
-        mnemonic::{MnemonicInput, MnemonicInputMsg, MNEMONIC_KEY_COUNT},
-    },
-    Button, ButtonContent, ButtonMsg,
-};
+use super::super::super::theme;
+use super::super::keyboard::common::{render_pending_marker, MultiTapKeyboard};
+use super::super::keyboard::mnemonic::{MnemonicInput, MnemonicInputMsg, MNEMONIC_KEY_COUNT};
+use super::super::{Button, ButtonContent, ButtonMsg};
+use crate::strutil::ShortString;
+use crate::trezorhal::slip39;
+use crate::ui::component::text::common::{TextBox, TextEdit};
+use crate::ui::component::{Component, Event, EventCtx};
+use crate::ui::geometry::{Alignment2D, Offset, Rect};
+use crate::ui::shape::{self, Renderer};
+use crate::ui::util::ResultExt;
 
 const MAX_LENGTH: usize = 8;
 

--- a/core/embed/rust/src/ui/layout_bolt/component/keyboard/word_count.rs
+++ b/core/embed/rust/src/ui/layout_bolt/component/keyboard/word_count.rs
@@ -1,18 +1,11 @@
-use crate::{
-    strutil::TString,
-    ui::{
-        component::{Component, Event, EventCtx},
-        geometry::{Grid, GridCellSpan, Rect},
-        shape::Renderer,
-    },
-};
-
-use super::super::{
-    super::theme,
-    button::{Button, ButtonMsg},
-};
-
 use heapless::Vec;
+
+use super::super::super::theme;
+use super::super::button::{Button, ButtonMsg};
+use crate::strutil::TString;
+use crate::ui::component::{Component, Event, EventCtx};
+use crate::ui::geometry::{Grid, GridCellSpan, Rect};
+use crate::ui::shape::Renderer;
 
 #[derive(Copy, Clone)]
 pub enum SelectWordCountMsg {

--- a/core/embed/rust/src/ui/layout_bolt/component/loader.rs
+++ b/core/embed/rust/src/ui/layout_bolt/component/loader.rs
@@ -1,22 +1,16 @@
-use super::{
-    super::cshape::{render_loader, LoaderRange},
-    theme,
-};
+use super::super::constant;
+use super::super::cshape::{render_loader, LoaderRange};
+use super::theme;
+use crate::time::{Duration, Instant};
 #[cfg(feature = "haptic")]
 use crate::trezorhal::haptic::{self, HapticEffect};
-use crate::{
-    time::{Duration, Instant},
-    ui::{
-        animation::Animation,
-        component::{Component, Event, EventCtx, Pad},
-        display::{self, toif::Icon, Color, LOADER_MAX},
-        geometry::{Alignment2D, Offset, Rect},
-        shape::{self, Renderer},
-        util::animation_disabled,
-    },
-};
-
-use super::super::constant;
+use crate::ui::animation::Animation;
+use crate::ui::component::{Component, Event, EventCtx, Pad};
+use crate::ui::display::toif::Icon;
+use crate::ui::display::{self, Color, LOADER_MAX};
+use crate::ui::geometry::{Alignment2D, Offset, Rect};
+use crate::ui::shape::{self, Renderer};
+use crate::ui::util::animation_disabled;
 
 const GROWING_DURATION_MS: u32 = 1000;
 const SHRINKING_DURATION_MS: u32 = 500;

--- a/core/embed/rust/src/ui/layout_bolt/component/mod.rs
+++ b/core/embed/rust/src/ui/layout_bolt/component/mod.rs
@@ -49,14 +49,12 @@ pub use fido::{FidoConfirm, FidoMsg};
 pub use frame::{Frame, FrameMsg};
 #[cfg(feature = "micropython")]
 pub use homescreen::{check_homescreen_format, Homescreen, HomescreenMsg, Lockscreen};
-pub use keyboard::{
-    bip39::Bip39Input,
-    mnemonic::{MnemonicInput, MnemonicKeyboard, MnemonicKeyboardMsg},
-    passphrase::{PassphraseKeyboard, PassphraseKeyboardMsg},
-    pin::{PinKeyboard, PinKeyboardMsg},
-    slip39::Slip39Input,
-    word_count::{SelectWordCount, SelectWordCountLayout, SelectWordCountMsg},
-};
+pub use keyboard::bip39::Bip39Input;
+pub use keyboard::mnemonic::{MnemonicInput, MnemonicKeyboard, MnemonicKeyboardMsg};
+pub use keyboard::passphrase::{PassphraseKeyboard, PassphraseKeyboardMsg};
+pub use keyboard::pin::{PinKeyboard, PinKeyboardMsg};
+pub use keyboard::slip39::Slip39Input;
+pub use keyboard::word_count::{SelectWordCount, SelectWordCountLayout, SelectWordCountMsg};
 pub use loader::{Loader, LoaderMsg, LoaderStyle, LoaderStyleSheet};
 #[cfg(feature = "translations")]
 pub use number_input::{NumberInputDialog, NumberInputDialogMsg};

--- a/core/embed/rust/src/ui/layout_bolt/component/number_input.rs
+++ b/core/embed/rust/src/ui/layout_bolt/component/number_input.rs
@@ -1,19 +1,13 @@
-use crate::{
-    error::Error,
-    strutil::{self, TString},
-    translations::TR,
-    ui::{
-        component::{
-            base::ComponentExt,
-            text::paragraphs::{Paragraph, Paragraphs},
-            Child, Component, Event, EventCtx, Pad,
-        },
-        geometry::{Alignment, Grid, Insets, Offset, Rect},
-        shape::{self, Renderer},
-    },
-};
-
-use super::{super::fonts, theme, Button, ButtonMsg};
+use super::super::fonts;
+use super::{theme, Button, ButtonMsg};
+use crate::error::Error;
+use crate::strutil::{self, TString};
+use crate::translations::TR;
+use crate::ui::component::base::ComponentExt;
+use crate::ui::component::text::paragraphs::{Paragraph, Paragraphs};
+use crate::ui::component::{Child, Component, Event, EventCtx, Pad};
+use crate::ui::geometry::{Alignment, Grid, Insets, Offset, Rect};
+use crate::ui::shape::{self, Renderer};
 
 #[cfg_attr(feature = "debug", derive(ufmt::derive::uDebug))]
 pub enum NumberInputDialogMsg {

--- a/core/embed/rust/src/ui/layout_bolt/component/number_input_slider.rs
+++ b/core/embed/rust/src/ui/layout_bolt/component/number_input_slider.rs
@@ -1,12 +1,10 @@
-use crate::ui::{
-    component::{base::ComponentExt, Child, Component, Event, EventCtx},
-    constant::screen,
-    event::TouchEvent,
-    geometry::{Grid, Insets, Point, Rect},
-    shape::{self, Renderer},
-};
-
 use super::{theme, Button, ButtonMsg};
+use crate::ui::component::base::ComponentExt;
+use crate::ui::component::{Child, Component, Event, EventCtx};
+use crate::ui::constant::screen;
+use crate::ui::event::TouchEvent;
+use crate::ui::geometry::{Grid, Insets, Point, Rect};
+use crate::ui::shape::{self, Renderer};
 
 pub enum NumberInputSliderDialogMsg {
     Changed(u8),

--- a/core/embed/rust/src/ui/layout_bolt/component/page.rs
+++ b/core/embed/rust/src/ui/layout_bolt/component/page.rs
@@ -1,24 +1,20 @@
-use crate::{
-    error::Error,
-    strutil::TString,
-    time::Instant,
-    translations::TR,
-    ui::{
-        component::{paginated::PageMsg, Component, ComponentExt, Event, EventCtx, Pad, Paginate},
-        constant,
-        display::{self, Color},
-        geometry::{Insets, Rect},
-        shape::Renderer,
-        util::{animation_disabled, Pager},
-    },
-};
+use core::cell::Cell;
 
 use super::{
     theme, Button, ButtonContent, ButtonMsg, ButtonStyleSheet, Loader, LoaderMsg, ScrollBar, Swipe,
     SwipeDirection,
 };
-
-use core::cell::Cell;
+use crate::error::Error;
+use crate::strutil::TString;
+use crate::time::Instant;
+use crate::translations::TR;
+use crate::ui::component::paginated::PageMsg;
+use crate::ui::component::{Component, ComponentExt, Event, EventCtx, Pad, Paginate};
+use crate::ui::constant;
+use crate::ui::display::{self, Color};
+use crate::ui::geometry::{Insets, Rect};
+use crate::ui::shape::Renderer;
+use crate::ui::util::{animation_disabled, Pager};
 
 /// Allows pagination of inner component. Shows scroll bar, confirm & cancel
 /// buttons. Optionally handles hold-to-confirm with loader.
@@ -466,16 +462,12 @@ impl PageLayout {
 
 #[cfg(test)]
 mod tests {
-    use crate::{
-        trace::tests::trace,
-        ui::{
-            component::text::paragraphs::{Paragraph, Paragraphs},
-            event::TouchEvent,
-            geometry::Point,
-        },
-    };
-
-    use super::{super::super::constant, *};
+    use super::super::super::constant;
+    use super::*;
+    use crate::trace::tests::trace;
+    use crate::ui::component::text::paragraphs::{Paragraph, Paragraphs};
+    use crate::ui::event::TouchEvent;
+    use crate::ui::geometry::Point;
 
     const SCREEN: Rect = constant::screen().inset(theme::borders());
 

--- a/core/embed/rust/src/ui/layout_bolt/component/pairing_mode.rs
+++ b/core/embed/rust/src/ui/layout_bolt/component/pairing_mode.rs
@@ -1,16 +1,11 @@
-use crate::{
-    strutil::TString,
-    ui::{
-        component::{Component, Event, EventCtx, Pad},
-        display::{Color, Font},
-        event::BLEEvent,
-        geometry::{Alignment, Offset, Rect},
-        layout::simplified::ReturnToC,
-        shape::{self, Renderer},
-    },
-};
-
 use super::{Button, ButtonMsg};
+use crate::strutil::TString;
+use crate::ui::component::{Component, Event, EventCtx, Pad};
+use crate::ui::display::{Color, Font};
+use crate::ui::event::BLEEvent;
+use crate::ui::geometry::{Alignment, Offset, Rect};
+use crate::ui::layout::simplified::ReturnToC;
+use crate::ui::shape::{self, Renderer};
 
 #[repr(u32)]
 pub enum PairingMsg {

--- a/core/embed/rust/src/ui/layout_bolt/component/progress.rs
+++ b/core/embed/rust/src/ui/layout_bolt/component/progress.rs
@@ -1,25 +1,16 @@
 use core::mem;
 
-use super::{
-    super::cshape::{render_loader, LoaderRange},
-    theme,
-};
-use crate::{
-    strutil::TString,
-    ui::{
-        component::{
-            base::ComponentExt,
-            text::paragraphs::{Paragraph, Paragraphs},
-            Child, Component, Event, EventCtx, Label, Never, Pad,
-        },
-        display::LOADER_MAX,
-        geometry::{Insets, Offset, Rect},
-        shape::Renderer,
-        util::animation_disabled,
-    },
-};
-
+use super::super::cshape::{render_loader, LoaderRange};
 use super::super::{constant, fonts};
+use super::theme;
+use crate::strutil::TString;
+use crate::ui::component::base::ComponentExt;
+use crate::ui::component::text::paragraphs::{Paragraph, Paragraphs};
+use crate::ui::component::{Child, Component, Event, EventCtx, Label, Never, Pad};
+use crate::ui::display::LOADER_MAX;
+use crate::ui::geometry::{Insets, Offset, Rect};
+use crate::ui::shape::Renderer;
+use crate::ui::util::animation_disabled;
 
 pub struct Progress {
     title: Child<Label<'static>>,

--- a/core/embed/rust/src/ui/layout_bolt/component/result.rs
+++ b/core/embed/rust/src/ui/layout_bolt/component/result.rs
@@ -1,20 +1,14 @@
-use crate::{
-    strutil::TString,
-    ui::{
-        component::{text::TextStyle, Child, Component, Event, EventCtx, Label, Never, Pad},
-        constant::screen,
-        display::{Color, Icon},
-        geometry::{Alignment2D, Insets, Offset, Point, Rect},
-        shape,
-        shape::Renderer,
-    },
-};
-
-use super::super::{
-    constant::WIDTH,
-    fonts,
-    theme::{FG, RESULT_FOOTER_START, RESULT_PADDING},
-};
+use super::super::constant::WIDTH;
+use super::super::fonts;
+use super::super::theme::{FG, RESULT_FOOTER_START, RESULT_PADDING};
+use crate::strutil::TString;
+use crate::ui::component::text::TextStyle;
+use crate::ui::component::{Child, Component, Event, EventCtx, Label, Never, Pad};
+use crate::ui::constant::screen;
+use crate::ui::display::{Color, Icon};
+use crate::ui::geometry::{Alignment2D, Insets, Offset, Point, Rect};
+use crate::ui::shape;
+use crate::ui::shape::Renderer;
 
 const MESSAGE_AREA_START: i16 = 97;
 const ICON_CENTER_Y: i16 = 62;

--- a/core/embed/rust/src/ui/layout_bolt/component/scroll.rs
+++ b/core/embed/rust/src/ui/layout_bolt/component/scroll.rs
@@ -1,12 +1,9 @@
-use crate::ui::{
-    component::{Component, Event, EventCtx, Never, Paginate},
-    display::toif::Icon,
-    geometry::{Alignment2D, Axis, LinearPlacement, Offset, Rect},
-    shape::{self, Renderer},
-    util::Pager,
-};
-
 use super::theme;
+use crate::ui::component::{Component, Event, EventCtx, Never, Paginate};
+use crate::ui::display::toif::Icon;
+use crate::ui::geometry::{Alignment2D, Axis, LinearPlacement, Offset, Rect};
+use crate::ui::shape::{self, Renderer};
+use crate::ui::util::Pager;
 
 pub struct ScrollBar {
     area: Rect,

--- a/core/embed/rust/src/ui/layout_bolt/component/set_brightness.rs
+++ b/core/embed/rust/src/ui/layout_bolt/component/set_brightness.rs
@@ -1,18 +1,11 @@
-use crate::{
-    storage,
-    trezorhal::display,
-    ui::{
-        component::{Component, Event, EventCtx},
-        geometry::Rect,
-        shape::Renderer,
-    },
-};
-
-use super::{
-    super::theme,
-    number_input_slider::{NumberInputSliderDialog, NumberInputSliderDialogMsg},
-    CancelConfirmMsg,
-};
+use super::super::theme;
+use super::number_input_slider::{NumberInputSliderDialog, NumberInputSliderDialogMsg};
+use super::CancelConfirmMsg;
+use crate::storage;
+use crate::trezorhal::display;
+use crate::ui::component::{Component, Event, EventCtx};
+use crate::ui::geometry::Rect;
+use crate::ui::shape::Renderer;
 
 pub struct SetBrightnessDialog(NumberInputSliderDialog);
 

--- a/core/embed/rust/src/ui/layout_bolt/component/share_words.rs
+++ b/core/embed/rust/src/ui/layout_bolt/component/share_words.rs
@@ -1,19 +1,14 @@
-use crate::{
-    strutil::TString,
-    ui::{
-        component::{Component, Event, EventCtx, Never, Paginate},
-        display::Font,
-        geometry::{Offset, Rect},
-        shape::{self, Renderer},
-        util::Pager,
-    },
-};
-
-use super::super::{fonts, theme};
-
 use heapless::Vec;
 #[cfg(feature = "ui_debug")]
 use ufmt::uwrite;
+
+use super::super::{fonts, theme};
+use crate::strutil::TString;
+use crate::ui::component::{Component, Event, EventCtx, Never, Paginate};
+use crate::ui::display::Font;
+use crate::ui::geometry::{Offset, Rect};
+use crate::ui::shape::{self, Renderer};
+use crate::ui::util::Pager;
 
 const WORDS_PER_PAGE: usize = 4;
 const TOP_PADDING_OFFSET: i16 = 13;

--- a/core/embed/rust/src/ui/layout_bolt/component/simple_page.rs
+++ b/core/embed/rust/src/ui/layout_bolt/component/simple_page.rs
@@ -1,12 +1,11 @@
-use crate::ui::{
-    component::{base::ComponentExt, Component, Event, EventCtx, Pad, PageMsg, Paginate},
-    display::{self, Color},
-    geometry::{Axis, Insets, Rect},
-    shape::Renderer,
-};
+use core::cell::Cell;
 
 use super::{theme, ScrollBar, Swipe, SwipeDirection};
-use core::cell::Cell;
+use crate::ui::component::base::ComponentExt;
+use crate::ui::component::{Component, Event, EventCtx, Pad, PageMsg, Paginate};
+use crate::ui::display::{self, Color};
+use crate::ui::geometry::{Axis, Insets, Rect};
+use crate::ui::shape::Renderer;
 
 const SCROLLBAR_HEIGHT: i16 = 18;
 const SCROLLBAR_BORDER: i16 = 4;

--- a/core/embed/rust/src/ui/layout_bolt/component/swipe.rs
+++ b/core/embed/rust/src/ui/layout_bolt/component/swipe.rs
@@ -1,12 +1,9 @@
-use crate::ui::{
-    component::{Component, Event, EventCtx},
-    display,
-    event::TouchEvent,
-    geometry::{Point, Rect},
-    shape::Renderer,
-};
-
 use super::super::theme::backlight;
+use crate::ui::component::{Component, Event, EventCtx};
+use crate::ui::display;
+use crate::ui::event::TouchEvent;
+use crate::ui::geometry::{Point, Rect};
+use crate::ui::shape::Renderer;
 
 pub enum SwipeDirection {
     Up,

--- a/core/embed/rust/src/ui/layout_bolt/component/welcome_screen.rs
+++ b/core/embed/rust/src/ui/layout_bolt/component/welcome_screen.rs
@@ -1,17 +1,14 @@
-use crate::ui::{
-    component::{Component, Event, EventCtx, Never},
-    geometry::{Alignment2D, Offset, Rect},
-    shape,
-    shape::Renderer,
-};
-
 #[cfg(not(feature = "bootloader"))]
 use super::super::fonts;
 use super::theme;
 #[cfg(feature = "bootloader")]
 use super::theme::bootloader::DEVICE_NAME;
+use crate::ui::component::{Component, Event, EventCtx, Never};
 #[cfg(feature = "bootloader")]
 use crate::ui::display::toif::Toif;
+use crate::ui::geometry::{Alignment2D, Offset, Rect};
+use crate::ui::shape;
+use crate::ui::shape::Renderer;
 
 const TEXT_BOTTOM_MARGIN: i16 = 24; // matching the homescreen label margin
 const ICON_TOP_MARGIN: i16 = 48;

--- a/core/embed/rust/src/ui/layout_bolt/component_msg_obj.rs
+++ b/core/embed/rust/src/ui/layout_bolt/component_msg_obj.rs
@@ -7,26 +7,17 @@ use super::component::{
     NumberInputDialogMsg, PassphraseKeyboard, PassphraseKeyboardMsg, PinKeyboard, PinKeyboardMsg,
     Progress, SelectWordCountMsg, SelectWordMsg, SetBrightnessDialog, SimplePage,
 };
-use crate::{
-    error::Error,
-    micropython::obj::Obj,
-    strutil::TString,
-    ui::{
-        component::{
-            paginated::PageMsg,
-            placed::GridPlaced,
-            text::paragraphs::{ParagraphSource, Paragraphs},
-            Component, FormattedText, Never, Paginate,
-        },
-        layout::{
-            obj::ComponentMsgObj,
-            result::{CANCELLED, CONFIRMED, INFO},
-        },
-    },
-};
-
+use crate::error::Error;
+use crate::micropython::obj::Obj;
+use crate::strutil::TString;
+use crate::ui::component::paginated::PageMsg;
+use crate::ui::component::placed::GridPlaced;
+use crate::ui::component::text::paragraphs::{ParagraphSource, Paragraphs};
 #[cfg(not(feature = "clippy"))]
 use crate::ui::component::Timeout;
+use crate::ui::component::{Component, FormattedText, Never, Paginate};
+use crate::ui::layout::obj::ComponentMsgObj;
+use crate::ui::layout::result::{CANCELLED, CONFIRMED, INFO};
 
 impl TryFrom<CancelConfirmMsg> for Obj {
     type Error = Error;

--- a/core/embed/rust/src/ui/layout_bolt/constant.rs
+++ b/core/embed/rust/src/ui/layout_bolt/constant.rs
@@ -1,6 +1,5 @@
-use crate::ui::geometry::{Offset, Point, Rect};
-
 use crate::trezorhal::display::{DISPLAY_RESX, DISPLAY_RESY};
+use crate::ui::geometry::{Offset, Point, Rect};
 
 pub const WIDTH: i16 = DISPLAY_RESX as _;
 pub const HEIGHT: i16 = DISPLAY_RESY as _;

--- a/core/embed/rust/src/ui/layout_bolt/cshape/loader.rs
+++ b/core/embed/rust/src/ui/layout_bolt/cshape/loader.rs
@@ -1,4 +1,7 @@
-use crate::ui::{constant, display::Color, geometry::Point, shape, shape::Renderer};
+use crate::ui::display::Color;
+use crate::ui::geometry::Point;
+use crate::ui::shape::Renderer;
+use crate::ui::{constant, shape};
 
 pub enum LoaderRange {
     Full,

--- a/core/embed/rust/src/ui/layout_bolt/mod.rs
+++ b/core/embed/rust/src/ui/layout_bolt/mod.rs
@@ -1,13 +1,11 @@
-use super::{geometry::Rect, CommonUI};
-
+use super::geometry::Rect;
 #[cfg(any(feature = "ui_debug_overlay", feature = "ui_performance_overlay"))]
 use super::shape;
-
-#[cfg(feature = "ui_debug_overlay")]
-use super::{display::Color, geometry::Offset};
-
+use super::CommonUI;
 #[cfg(feature = "ui_performance_overlay")]
 use super::PerformanceOverlay;
+#[cfg(feature = "ui_debug_overlay")]
+use super::{display::Color, geometry::Offset};
 
 #[cfg(feature = "bootloader")]
 pub mod bootloader;
@@ -23,9 +21,9 @@ use theme::backlight;
 pub mod component_msg_obj;
 pub mod cshape;
 
-use crate::ui::layout::simplified::show;
-
 use component::{ErrorScreen, WelcomeScreen};
+
+use crate::ui::layout::simplified::show;
 
 pub struct UIBolt;
 

--- a/core/embed/rust/src/ui/layout_bolt/prodtest/mod.rs
+++ b/core/embed/rust/src/ui/layout_bolt/prodtest/mod.rs
@@ -1,23 +1,19 @@
 mod welcome;
 
-use crate::ui::{
-    component::Event,
-    constant::screen,
-    display,
-    display::Color,
-    event::{
-        TouchEvent,
-        TouchEvent::{TouchEnd, TouchMove, TouchStart},
-    },
-    geometry::{Alignment, Offset, Rect},
-    layout::simplified::{process_frame_event, show},
-    shape,
-    shape::render_on_display,
-    ui_prodtest::{ProdtestLayoutType, ProdtestUI},
-};
 use heapless::Vec;
 
-use super::{fonts, prodtest::welcome::Welcome, UIBolt};
+use super::prodtest::welcome::Welcome;
+use super::{fonts, UIBolt};
+use crate::ui::component::Event;
+use crate::ui::constant::screen;
+use crate::ui::display::Color;
+use crate::ui::event::TouchEvent;
+use crate::ui::event::TouchEvent::{TouchEnd, TouchMove, TouchStart};
+use crate::ui::geometry::{Alignment, Offset, Rect};
+use crate::ui::layout::simplified::{process_frame_event, show};
+use crate::ui::shape::render_on_display;
+use crate::ui::ui_prodtest::{ProdtestLayoutType, ProdtestUI};
+use crate::ui::{display, shape};
 
 #[allow(clippy::large_enum_variant)]
 pub enum ProdtestLayout {

--- a/core/embed/rust/src/ui/layout_bolt/prodtest/welcome.rs
+++ b/core/embed/rust/src/ui/layout_bolt/prodtest/welcome.rs
@@ -1,13 +1,10 @@
-use super::super::{
-    fonts,
-    theme::{bootloader::WELCOME_COLOR, WHITE},
-};
-use crate::ui::{
-    component::{Component, Event, EventCtx, Never, Pad, Qr},
-    constant::screen,
-    geometry::{Alignment, Offset, Point, Rect},
-    shape::{self, Renderer},
-};
+use super::super::fonts;
+use super::super::theme::bootloader::WELCOME_COLOR;
+use super::super::theme::WHITE;
+use crate::ui::component::{Component, Event, EventCtx, Never, Pad, Qr};
+use crate::ui::constant::screen;
+use crate::ui::geometry::{Alignment, Offset, Point, Rect};
+use crate::ui::shape::{self, Renderer};
 #[cfg(feature = "power_manager")]
 use crate::{
     strutil::format_i64,

--- a/core/embed/rust/src/ui/layout_bolt/theme/bootloader.rs
+++ b/core/embed/rust/src/ui/layout_bolt/theme/bootloader.rs
@@ -1,17 +1,13 @@
-use super::super::{
-    component::{ButtonStyle, ButtonStyleSheet, ResultStyle},
-    fonts,
-    theme::{BLACK, FG, GREY_DARK, GREY_LIGHT, WHITE},
-};
-use crate::ui::{
-    component::{text::TextStyle, LineBreaking::BreakWordsNoHyphen},
-    constant::{HEIGHT, WIDTH},
-    display::Color,
-    geometry::{Offset, Point, Rect},
-    util::include_res,
-};
-
+use super::super::component::{ButtonStyle, ButtonStyleSheet, ResultStyle};
+use super::super::fonts;
+use super::super::theme::{BLACK, FG, GREY_DARK, GREY_LIGHT, WHITE};
 use super::GREY_MEDIUM;
+use crate::ui::component::text::TextStyle;
+use crate::ui::component::LineBreaking::BreakWordsNoHyphen;
+use crate::ui::constant::{HEIGHT, WIDTH};
+use crate::ui::display::Color;
+use crate::ui::geometry::{Offset, Point, Rect};
+use crate::ui::util::include_res;
 
 pub const BLD_BG: Color = Color::rgb(0x00, 0x1E, 0xAD);
 pub const BLD_FG: Color = WHITE;

--- a/core/embed/rust/src/ui/layout_bolt/theme/mod.rs
+++ b/core/embed/rust/src/ui/layout_bolt/theme/mod.rs
@@ -1,26 +1,16 @@
 pub mod backlight;
 pub mod bootloader;
 
-use crate::{
-    time::ShortDuration,
-    ui::{
-        component::{
-            text::{
-                layout::Chunks, paragraphs::PARAGRAPH_BOTTOM_SPACE, LineBreaking, PageBreaking,
-                TextStyle,
-            },
-            FixedHeightBar,
-        },
-        display::Color,
-        geometry::{Insets, Offset},
-        util::{include_icon, include_res},
-    },
-};
-
-use super::{
-    component::{ButtonStyle, ButtonStyleSheet, LoaderStyle, LoaderStyleSheet, ResultStyle},
-    fonts,
-};
+use super::component::{ButtonStyle, ButtonStyleSheet, LoaderStyle, LoaderStyleSheet, ResultStyle};
+use super::fonts;
+use crate::time::ShortDuration;
+use crate::ui::component::text::layout::Chunks;
+use crate::ui::component::text::paragraphs::PARAGRAPH_BOTTOM_SPACE;
+use crate::ui::component::text::{LineBreaking, PageBreaking, TextStyle};
+use crate::ui::component::FixedHeightBar;
+use crate::ui::display::Color;
+use crate::ui::geometry::{Insets, Offset};
+use crate::ui::util::{include_icon, include_res};
 
 pub const ERASE_HOLD_DURATION: ShortDuration = ShortDuration::from_millis(1500);
 

--- a/core/embed/rust/src/ui/layout_bolt/ui_firmware.rs
+++ b/core/embed/rust/src/ui/layout_bolt/ui_firmware.rs
@@ -1,49 +1,41 @@
 use core::cmp::Ordering;
 
-use crate::{
-    error::{value_error, Error},
-    io::BinaryData,
-    micropython::{buffer::StrBuffer, gc::Gc, iter::IterBuf, list::List, obj::Obj, util},
-    storage,
-    strutil::TString,
-    translations::TR,
-    ui::{
-        component::{
-            image::BlendedImage,
-            text::{
-                op::OpTextLayout,
-                paragraphs::{
-                    Checklist, Paragraph, ParagraphSource, ParagraphVecLong, ParagraphVecShort,
-                    Paragraphs, VecExt,
-                },
-                TextStyle,
-            },
-            Border, ComponentExt, Empty, FormattedText, Jpeg, Label, Never, Timeout,
-        },
-        geometry,
-        layout::{
-            obj::{LayoutMaybeTrace, LayoutObj, RootComponent},
-            util::{ConfirmValueParams, PropsList, RecoveryType},
-        },
-        notification::Notification,
-        ui_firmware::{
-            FirmwareUI, MAX_CHECKLIST_ITEMS, MAX_GROUP_SHARE_LINES, MAX_MENU_ITEMS,
-            MAX_PAIRED_DEVICES, MAX_WORD_QUIZ_ITEMS,
-        },
-        ModelUI,
-    },
+use super::component::{
+    check_homescreen_format, AddressDetails, Bip39Input, Button, ButtonMsg, ButtonPage,
+    ButtonStyleSheet, CancelConfirmMsg, CoinJoinProgress, Dialog, FidoConfirm, Frame, Homescreen,
+    IconDialog, Lockscreen, MnemonicKeyboard, NumberInputDialog, PassphraseKeyboard, PinKeyboard,
+    Progress, SelectWordCount, SelectWordCountLayout, SetBrightnessDialog, ShareWords, SimplePage,
+    Slip39Input,
 };
-
-use super::{
-    component::{
-        check_homescreen_format, AddressDetails, Bip39Input, Button, ButtonMsg, ButtonPage,
-        ButtonStyleSheet, CancelConfirmMsg, CoinJoinProgress, Dialog, FidoConfirm, Frame,
-        Homescreen, IconDialog, Lockscreen, MnemonicKeyboard, NumberInputDialog,
-        PassphraseKeyboard, PinKeyboard, Progress, SelectWordCount, SelectWordCountLayout,
-        SetBrightnessDialog, ShareWords, SimplePage, Slip39Input,
-    },
-    fonts, theme, UIBolt,
+use super::{fonts, theme, UIBolt};
+use crate::error::{value_error, Error};
+use crate::io::BinaryData;
+use crate::micropython::buffer::StrBuffer;
+use crate::micropython::gc::Gc;
+use crate::micropython::iter::IterBuf;
+use crate::micropython::list::List;
+use crate::micropython::obj::Obj;
+use crate::micropython::util;
+use crate::storage;
+use crate::strutil::TString;
+use crate::translations::TR;
+use crate::ui::component::image::BlendedImage;
+use crate::ui::component::text::op::OpTextLayout;
+use crate::ui::component::text::paragraphs::{
+    Checklist, Paragraph, ParagraphSource, ParagraphVecLong, ParagraphVecShort, Paragraphs, VecExt,
 };
+use crate::ui::component::text::TextStyle;
+use crate::ui::component::{
+    Border, ComponentExt, Empty, FormattedText, Jpeg, Label, Never, Timeout,
+};
+use crate::ui::layout::obj::{LayoutMaybeTrace, LayoutObj, RootComponent};
+use crate::ui::layout::util::{ConfirmValueParams, PropsList, RecoveryType};
+use crate::ui::notification::Notification;
+use crate::ui::ui_firmware::{
+    FirmwareUI, MAX_CHECKLIST_ITEMS, MAX_GROUP_SHARE_LINES, MAX_MENU_ITEMS, MAX_PAIRED_DEVICES,
+    MAX_WORD_QUIZ_ITEMS,
+};
+use crate::ui::{geometry, ModelUI};
 
 impl FirmwareUI for UIBolt {
     fn confirm_action(
@@ -1492,15 +1484,12 @@ impl ConfirmValue {
 mod tests {
     use serde_json;
 
-    use crate::{
-        trace::tests::trace,
-        ui::{
-            component::{text::op::OpTextLayout, Component},
-            geometry::Rect,
-        },
-    };
-
-    use super::{super::constant, *};
+    use super::super::constant;
+    use super::*;
+    use crate::trace::tests::trace;
+    use crate::ui::component::text::op::OpTextLayout;
+    use crate::ui::component::Component;
+    use crate::ui::geometry::Rect;
 
     const SCREEN: Rect = constant::screen().inset(theme::borders());
 

--- a/core/embed/rust/src/ui/layout_caesar/bootloader/connect.rs
+++ b/core/embed/rust/src/ui/layout_caesar/bootloader/connect.rs
@@ -1,17 +1,10 @@
-use crate::{
-    strutil::TString,
-    ui::{
-        component::{Component, Event, EventCtx, Pad},
-        display::{Color, Font},
-        geometry::{Alignment, Offset, Rect},
-        shape::{self, Renderer},
-    },
-};
-
-use super::super::{
-    component::{ButtonController, ButtonControllerMsg, ButtonLayout, ButtonPos},
-    theme::{BUTTON_HEIGHT, TITLE_AREA_HEIGHT},
-};
+use super::super::component::{ButtonController, ButtonControllerMsg, ButtonLayout, ButtonPos};
+use super::super::theme::{BUTTON_HEIGHT, TITLE_AREA_HEIGHT};
+use crate::strutil::TString;
+use crate::ui::component::{Component, Event, EventCtx, Pad};
+use crate::ui::display::{Color, Font};
+use crate::ui::geometry::{Alignment, Offset, Rect};
+use crate::ui::shape::{self, Renderer};
 
 #[repr(u32)]
 #[derive(Copy, Clone, ToPrimitive)]

--- a/core/embed/rust/src/ui/layout_caesar/bootloader/intro.rs
+++ b/core/embed/rust/src/ui/layout_caesar/bootloader/intro.rs
@@ -1,21 +1,13 @@
-use crate::{
-    strutil::TString,
-    ui::{
-        component::{Child, Component, Event, EventCtx, Label, Pad},
-        geometry::{Alignment, Alignment2D, Rect},
-        layout::simplified::ReturnToC,
-        shape,
-        shape::Renderer,
-    },
-};
-
-use super::super::{
-    component::{ButtonController, ButtonControllerMsg::Triggered, ButtonLayout, ButtonPos},
-    theme::{
-        bootloader::{BLD_BG, BLD_FG, TEXT_NORMAL},
-        BUTTON_HEIGHT, ICON_WARN_TITLE, TITLE_AREA_HEIGHT,
-    },
-};
+use super::super::component::ButtonControllerMsg::Triggered;
+use super::super::component::{ButtonController, ButtonLayout, ButtonPos};
+use super::super::theme::bootloader::{BLD_BG, BLD_FG, TEXT_NORMAL};
+use super::super::theme::{BUTTON_HEIGHT, ICON_WARN_TITLE, TITLE_AREA_HEIGHT};
+use crate::strutil::TString;
+use crate::ui::component::{Child, Component, Event, EventCtx, Label, Pad};
+use crate::ui::geometry::{Alignment, Alignment2D, Rect};
+use crate::ui::layout::simplified::ReturnToC;
+use crate::ui::shape;
+use crate::ui::shape::Renderer;
 
 const LEFT_BUTTON_TEXT: &str = "Init connection";
 const RIGHT_BUTTON_TEXT: &str = "MENU";

--- a/core/embed/rust/src/ui/layout_caesar/bootloader/menu.rs
+++ b/core/embed/rust/src/ui/layout_caesar/bootloader/menu.rs
@@ -1,20 +1,15 @@
+use super::super::component::{ButtonLayout, Choice, ChoiceFactory, ChoiceMsg, ChoicePage};
+use super::super::fonts;
+use super::super::theme::bootloader::{BLD_BG, BLD_FG, ICON_EXIT, ICON_REDO, ICON_TRASH};
 #[cfg(feature = "ui_debug")]
 use crate::trace::{Trace, Tracer};
-use crate::ui::{
-    component::{Child, Component, Event, EventCtx, Pad},
-    constant::screen,
-    display::Icon,
-    geometry::{Alignment, Alignment2D, Offset, Point, Rect},
-    layout::simplified::ReturnToC,
-    shape,
-    shape::Renderer,
-};
-
-use super::super::{
-    component::{ButtonLayout, Choice, ChoiceFactory, ChoiceMsg, ChoicePage},
-    fonts,
-    theme::bootloader::{BLD_BG, BLD_FG, ICON_EXIT, ICON_REDO, ICON_TRASH},
-};
+use crate::ui::component::{Child, Component, Event, EventCtx, Pad};
+use crate::ui::constant::screen;
+use crate::ui::display::Icon;
+use crate::ui::geometry::{Alignment, Alignment2D, Offset, Point, Rect};
+use crate::ui::layout::simplified::ReturnToC;
+use crate::ui::shape;
+use crate::ui::shape::Renderer;
 
 #[repr(u32)]
 #[derive(Copy, Clone)]

--- a/core/embed/rust/src/ui/layout_caesar/bootloader/mod.rs
+++ b/core/embed/rust/src/ui/layout_caesar/bootloader/mod.rs
@@ -1,32 +1,21 @@
 use heapless::String;
-
-use crate::ui::{
-    component::{Label, LineBreaking::BreakWordsNoHyphen},
-    constant::{self, HEIGHT, SCREEN},
-    display::{self, Color, Icon},
-    geometry::{Alignment2D, Offset, Point},
-    layout::simplified::{show, ReturnToC},
-};
-
-use super::{
-    component::{
-        bl_confirm::{Confirm, ConfirmMsg},
-        ResultScreen, WelcomeScreen,
-    },
-    cshape, fonts,
-    theme::{
-        bootloader::{BLD_BG, BLD_FG, ICON_ALERT, ICON_SPINNER, ICON_SUCCESS},
-        ICON_ARM_LEFT, ICON_ARM_RIGHT, TEXT_BOLD, TEXT_NORMAL,
-    },
-    UICaesar,
-};
-
-use crate::{
-    bootloader::run,
-    ui::{display::toif::Toif, geometry::Alignment, shape, shape::render_on_display},
-};
-
 use ufmt::uwrite;
+
+use super::component::bl_confirm::{Confirm, ConfirmMsg};
+use super::component::{ResultScreen, WelcomeScreen};
+use super::theme::bootloader::{BLD_BG, BLD_FG, ICON_ALERT, ICON_SPINNER, ICON_SUCCESS};
+use super::theme::{ICON_ARM_LEFT, ICON_ARM_RIGHT, TEXT_BOLD, TEXT_NORMAL};
+use super::{cshape, fonts, UICaesar};
+use crate::bootloader::run;
+use crate::ui::component::Label;
+use crate::ui::component::LineBreaking::BreakWordsNoHyphen;
+use crate::ui::constant::{self, HEIGHT, SCREEN};
+use crate::ui::display::toif::Toif;
+use crate::ui::display::{self, Color, Icon};
+use crate::ui::geometry::{Alignment, Alignment2D, Offset, Point};
+use crate::ui::layout::simplified::{show, ReturnToC};
+use crate::ui::shape;
+use crate::ui::shape::render_on_display;
 
 mod intro;
 mod menu;
@@ -34,15 +23,15 @@ mod welcome;
 
 mod connect;
 
-use crate::{
-    time::Duration,
-    trezorhal::time,
-    ui::{ui_bootloader::BootloaderUI, util::animation_disabled},
-};
 use connect::Connect;
 use intro::Intro;
 use menu::Menu;
 use welcome::Welcome;
+
+use crate::time::Duration;
+use crate::trezorhal::time;
+use crate::ui::ui_bootloader::BootloaderUI;
+use crate::ui::util::animation_disabled;
 
 pub type BootloaderString = String<128>;
 

--- a/core/embed/rust/src/ui/layout_caesar/bootloader/welcome.rs
+++ b/core/embed/rust/src/ui/layout_caesar/bootloader/welcome.rs
@@ -1,14 +1,9 @@
-use crate::ui::{
-    component::{Component, Event, EventCtx, Never, Pad},
-    geometry::{Alignment, Offset, Rect},
-    shape,
-    shape::Renderer,
-};
-
-use super::{
-    super::theme::bootloader::{BLD_BG, BLD_FG},
-    fonts,
-};
+use super::super::theme::bootloader::{BLD_BG, BLD_FG};
+use super::fonts;
+use crate::ui::component::{Component, Event, EventCtx, Never, Pad};
+use crate::ui::geometry::{Alignment, Offset, Rect};
+use crate::ui::shape;
+use crate::ui::shape::Renderer;
 
 pub struct Welcome {
     bg: Pad,

--- a/core/embed/rust/src/ui/layout_caesar/component/address_details.rs
+++ b/core/embed/rust/src/ui/layout_caesar/component/address_details.rs
@@ -1,24 +1,19 @@
 use heapless::Vec;
 
-use crate::{
-    error::Error,
-    micropython::buffer::StrBuffer,
-    strutil::TString,
-    translations::TR,
-    ui::{
-        component::{
-            text::paragraphs::{Paragraph, ParagraphSource, ParagraphVecShort, Paragraphs, VecExt},
-            Child, Component, Event, EventCtx, Pad, Paginate, Qr,
-        },
-        geometry::Rect,
-        layout::util::MAX_XPUBS,
-        shape::Renderer,
-    },
-};
-
 use super::{
     theme, ButtonController, ButtonControllerMsg, ButtonDetails, ButtonLayout, ButtonPos, Frame,
 };
+use crate::error::Error;
+use crate::micropython::buffer::StrBuffer;
+use crate::strutil::TString;
+use crate::translations::TR;
+use crate::ui::component::text::paragraphs::{
+    Paragraph, ParagraphSource, ParagraphVecShort, Paragraphs, VecExt,
+};
+use crate::ui::component::{Child, Component, Event, EventCtx, Pad, Paginate, Qr};
+use crate::ui::geometry::Rect;
+use crate::ui::layout::util::MAX_XPUBS;
+use crate::ui::shape::Renderer;
 
 const QR_BORDER: i16 = 3;
 

--- a/core/embed/rust/src/ui/layout_caesar/component/bl_confirm.rs
+++ b/core/embed/rust/src/ui/layout_caesar/component/bl_confirm.rs
@@ -1,17 +1,10 @@
-use crate::{
-    strutil::TString,
-    ui::{
-        component::{Component, ComponentExt, Event, EventCtx, Label, Pad},
-        display::Color,
-        geometry::Rect,
-        shape::Renderer,
-    },
-};
-
-use super::{
-    theme::{BUTTON_HEIGHT, TEXT_BOLD, TITLE_AREA_HEIGHT},
-    ButtonController, ButtonControllerMsg, ButtonLayout, ButtonPos,
-};
+use super::theme::{BUTTON_HEIGHT, TEXT_BOLD, TITLE_AREA_HEIGHT};
+use super::{ButtonController, ButtonControllerMsg, ButtonLayout, ButtonPos};
+use crate::strutil::TString;
+use crate::ui::component::{Component, ComponentExt, Event, EventCtx, Label, Pad};
+use crate::ui::display::Color;
+use crate::ui::geometry::Rect;
+use crate::ui::shape::Renderer;
 
 const ALERT_AREA_START: i16 = 39;
 

--- a/core/embed/rust/src/ui/layout_caesar/component/button.rs
+++ b/core/embed/rust/src/ui/layout_caesar/component/button.rs
@@ -1,18 +1,14 @@
-use crate::{
-    strutil::TString,
-    time::Duration,
-    ui::{
-        component::{Component, Event, EventCtx, Never},
-        constant,
-        display::{Font, Icon},
-        event::PhysicalButton,
-        geometry::{Alignment2D, Offset, Point, Rect},
-        shape,
-        shape::Renderer,
-    },
-};
-
-use super::{super::fonts, loader::DEFAULT_DURATION_MS, theme};
+use super::super::fonts;
+use super::loader::DEFAULT_DURATION_MS;
+use super::theme;
+use crate::strutil::TString;
+use crate::time::Duration;
+use crate::ui::component::{Component, Event, EventCtx, Never};
+use crate::ui::display::{Font, Icon};
+use crate::ui::event::PhysicalButton;
+use crate::ui::geometry::{Alignment2D, Offset, Point, Rect};
+use crate::ui::shape::Renderer;
+use crate::ui::{constant, shape};
 
 const HALF_SCREEN_BUTTON_WIDTH: i16 = constant::WIDTH / 2 - 1;
 

--- a/core/embed/rust/src/ui/layout_caesar/component/button_controller.rs
+++ b/core/embed/rust/src/ui/layout_caesar/component/button_controller.rs
@@ -1,15 +1,12 @@
 use super::{
     theme, Button, ButtonDetails, ButtonLayout, ButtonPos, HoldToConfirm, HoldToConfirmMsg,
 };
-use crate::{
-    time::{Duration, Instant},
-    ui::{
-        component::{base::Event, Component, EventCtx, Pad, Timer},
-        event::{ButtonEvent, PhysicalButton},
-        geometry::Rect,
-        shape::Renderer,
-    },
-};
+use crate::time::{Duration, Instant};
+use crate::ui::component::base::Event;
+use crate::ui::component::{Component, EventCtx, Pad, Timer};
+use crate::ui::event::{ButtonEvent, PhysicalButton};
+use crate::ui::geometry::Rect;
+use crate::ui::shape::Renderer;
 
 /// All possible states buttons (left and right) can be at.
 #[derive(Copy, Clone, PartialEq, Eq)]

--- a/core/embed/rust/src/ui/layout_caesar/component/changing_text.rs
+++ b/core/embed/rust/src/ui/layout_caesar/component/changing_text.rs
@@ -1,15 +1,11 @@
-use crate::{
-    strutil::ShortString,
-    ui::{
-        component::{Component, Event, EventCtx, Never, Pad},
-        display::Font,
-        geometry::{Alignment, Point, Rect},
-        shape::{self, Renderer},
-        util::long_line_content_with_ellipsis,
-    },
-};
-
-use super::{super::fonts, theme};
+use super::super::fonts;
+use super::theme;
+use crate::strutil::ShortString;
+use crate::ui::component::{Component, Event, EventCtx, Never, Pad};
+use crate::ui::display::Font;
+use crate::ui::geometry::{Alignment, Point, Rect};
+use crate::ui::shape::{self, Renderer};
+use crate::ui::util::long_line_content_with_ellipsis;
 
 /// Component that allows for "allocating" a standalone line of text anywhere
 /// on the screen and updating it arbitrarily - without affecting the rest

--- a/core/embed/rust/src/ui/layout_caesar/component/coinjoin_progress.rs
+++ b/core/embed/rust/src/ui/layout_caesar/component/coinjoin_progress.rs
@@ -1,22 +1,15 @@
 use core::mem;
 
-use crate::{
-    strutil::TString,
-    translations::TR,
-    ui::{
-        component::{
-            base::Never,
-            text::util::{text_multiline, text_multiline_bottom},
-            Component, Event, EventCtx,
-        },
-        geometry::{Alignment, Alignment2D, Insets, Offset, Rect},
-        shape,
-        shape::Renderer,
-        util::animation_disabled,
-    },
-};
-
 use super::super::{cshape, fonts, theme};
+use crate::strutil::TString;
+use crate::translations::TR;
+use crate::ui::component::base::Never;
+use crate::ui::component::text::util::{text_multiline, text_multiline_bottom};
+use crate::ui::component::{Component, Event, EventCtx};
+use crate::ui::geometry::{Alignment, Alignment2D, Insets, Offset, Rect};
+use crate::ui::shape;
+use crate::ui::shape::Renderer;
+use crate::ui::util::animation_disabled;
 
 const FOOTER_TEXT_MARGIN: i16 = 8;
 const LOADER_OFFSET: i16 = -15;

--- a/core/embed/rust/src/ui/layout_caesar/component/error.rs
+++ b/core/embed/rust/src/ui/layout_caesar/component/error.rs
@@ -1,18 +1,11 @@
-use crate::{
-    strutil::TString,
-    ui::{
-        component::{Child, Component, Event, EventCtx, Label, Never, Pad},
-        constant::{screen, WIDTH},
-        geometry::{Alignment2D, Offset, Point, Rect},
-        shape,
-        shape::Renderer,
-    },
-};
-
-use super::super::{
-    cshape, theme,
-    theme::{BG, FG, TITLE_AREA_HEIGHT},
-};
+use super::super::theme::{BG, FG, TITLE_AREA_HEIGHT};
+use super::super::{cshape, theme};
+use crate::strutil::TString;
+use crate::ui::component::{Child, Component, Event, EventCtx, Label, Never, Pad};
+use crate::ui::constant::{screen, WIDTH};
+use crate::ui::geometry::{Alignment2D, Offset, Point, Rect};
+use crate::ui::shape;
+use crate::ui::shape::Renderer;
 
 const FOOTER_AREA_HEIGHT: i16 = 20;
 const DIVIDER_POSITION: i16 = 43;

--- a/core/embed/rust/src/ui/layout_caesar/component/flow.rs
+++ b/core/embed/rust/src/ui/layout_caesar/component/flow.rs
@@ -1,17 +1,14 @@
-use crate::{
-    strutil::TString,
-    ui::{
-        component::{Child, Component, ComponentExt, Event, EventCtx, Pad, Paginate},
-        constant::SCREEN,
-        geometry::Rect,
-        shape::Renderer,
-    },
-};
-
+use super::scrollbar::SCROLLBAR_SPACE;
+use super::title::Title;
 use super::{
-    scrollbar::SCROLLBAR_SPACE, theme, title::Title, ButtonAction, ButtonController,
-    ButtonControllerMsg, ButtonLayout, ButtonPos, CancelInfoConfirmMsg, FlowPages, Page, ScrollBar,
+    theme, ButtonAction, ButtonController, ButtonControllerMsg, ButtonLayout, ButtonPos,
+    CancelInfoConfirmMsg, FlowPages, Page, ScrollBar,
 };
+use crate::strutil::TString;
+use crate::ui::component::{Child, Component, ComponentExt, Event, EventCtx, Pad, Paginate};
+use crate::ui::constant::SCREEN;
+use crate::ui::geometry::Rect;
+use crate::ui::shape::Renderer;
 
 pub struct Flow<F>
 where

--- a/core/embed/rust/src/ui/layout_caesar/component/flow_pages.rs
+++ b/core/embed/rust/src/ui/layout_caesar/component/flow_pages.rs
@@ -1,14 +1,10 @@
-use crate::{
-    strutil::TString,
-    ui::{
-        component::{base::Component, FormattedText, Paginate},
-        geometry::Rect,
-        shape::Renderer,
-        util::Pager,
-    },
-};
-
 use super::{ButtonActions, ButtonDetails, ButtonLayout};
+use crate::strutil::TString;
+use crate::ui::component::base::Component;
+use crate::ui::component::{FormattedText, Paginate};
+use crate::ui::geometry::Rect;
+use crate::ui::shape::Renderer;
+use crate::ui::util::Pager;
 
 // So that there is only one implementation, and not multiple generic ones
 // as would be via `const N: usize` generics.
@@ -184,8 +180,9 @@ impl Paginate for Page {
 #[cfg(feature = "ui_debug")]
 impl crate::trace::Trace for Page {
     fn trace(&self, t: &mut dyn crate::trace::Tracer) {
-        use crate::ui::component::text::layout::LayoutFit;
         use core::cell::Cell;
+
+        use crate::ui::component::text::layout::LayoutFit;
         let fit: Cell<Option<LayoutFit>> = Cell::new(None);
         t.component("Page");
         if let Some(title) = &self.title {

--- a/core/embed/rust/src/ui/layout_caesar/component/frame.rs
+++ b/core/embed/rust/src/ui/layout_caesar/component/frame.rs
@@ -1,14 +1,12 @@
-use crate::{
-    strutil::TString,
-    ui::{
-        component::{Child, Component, ComponentExt, Event, EventCtx, Paginate},
-        geometry::{Insets, Rect},
-        shape::Renderer,
-        util::Pager,
-    },
-};
-
-use super::{super::constant, scrollbar::SCROLLBAR_SPACE, theme, title::Title, ScrollBar};
+use super::super::constant;
+use super::scrollbar::SCROLLBAR_SPACE;
+use super::title::Title;
+use super::{theme, ScrollBar};
+use crate::strutil::TString;
+use crate::ui::component::{Child, Component, ComponentExt, Event, EventCtx, Paginate};
+use crate::ui::geometry::{Insets, Rect};
+use crate::ui::shape::Renderer;
+use crate::ui::util::Pager;
 
 /// Component for holding another component and displaying a title.
 pub struct Frame<T>

--- a/core/embed/rust/src/ui/layout_caesar/component/hold_to_confirm.rs
+++ b/core/embed/rust/src/ui/layout_caesar/component/hold_to_confirm.rs
@@ -1,17 +1,10 @@
-use crate::{
-    time::{Duration, Instant},
-    ui::{
-        component::{Component, Event, EventCtx},
-        event::ButtonEvent,
-        geometry::Rect,
-        shape::Renderer,
-    },
-};
-
-use super::{
-    loader::{Loader, DEFAULT_DURATION_MS},
-    theme, ButtonContent, ButtonDetails, LoaderMsg, LoaderStyleSheet,
-};
+use super::loader::{Loader, DEFAULT_DURATION_MS};
+use super::{theme, ButtonContent, ButtonDetails, LoaderMsg, LoaderStyleSheet};
+use crate::time::{Duration, Instant};
+use crate::ui::component::{Component, Event, EventCtx};
+use crate::ui::event::ButtonEvent;
+use crate::ui::geometry::Rect;
+use crate::ui::shape::Renderer;
 
 pub enum HoldToConfirmMsg {
     Confirmed,

--- a/core/embed/rust/src/ui/layout_caesar/component/homescreen.rs
+++ b/core/embed/rust/src/ui/layout_caesar/component/homescreen.rs
@@ -1,27 +1,20 @@
-use crate::{
-    io::BinaryData,
-    strutil::TString,
-    translations::TR,
-    trezorhal::usb::usb_configured,
-    ui::{
-        component::{Child, Component, Event, EventCtx, Label},
-        constant::{HEIGHT, WIDTH},
-        display::{
-            image::{ImageInfo, ToifFormat},
-            Font, Icon,
-        },
-        geometry::{Alignment, Alignment2D, Insets, Offset, Point, Rect},
-        layout::util::get_user_custom_image,
-        notification::Notification,
-        shape::{self, Renderer},
-    },
-};
-
+use super::super::{constant, fonts};
 use super::{
-    super::{constant, fonts},
     theme, ButtonController, ButtonControllerMsg, ButtonLayout, ButtonPos, CancelConfirmMsg,
     LoaderMsg, ProgressLoader,
 };
+use crate::io::BinaryData;
+use crate::strutil::TString;
+use crate::translations::TR;
+use crate::trezorhal::usb::usb_configured;
+use crate::ui::component::{Child, Component, Event, EventCtx, Label};
+use crate::ui::constant::{HEIGHT, WIDTH};
+use crate::ui::display::image::{ImageInfo, ToifFormat};
+use crate::ui::display::{Font, Icon};
+use crate::ui::geometry::{Alignment, Alignment2D, Insets, Offset, Point, Rect};
+use crate::ui::layout::util::get_user_custom_image;
+use crate::ui::notification::Notification;
+use crate::ui::shape::{self, Renderer};
 
 const AREA: Rect = constant::screen();
 const TOP_CENTER: Point = AREA.top_center();

--- a/core/embed/rust/src/ui/layout_caesar/component/input_methods/choice.rs
+++ b/core/embed/rust/src/ui/layout_caesar/component/input_methods/choice.rs
@@ -1,13 +1,10 @@
-use crate::ui::{
-    component::{Child, Component, Event, EventCtx, Pad},
-    geometry::{Offset, Rect},
-    shape::Renderer,
-    util::animation_disabled,
-};
-
 use super::super::{
     constant, theme, AutomaticMover, ButtonController, ButtonControllerMsg, ButtonLayout, ButtonPos,
 };
+use crate::ui::component::{Child, Component, Event, EventCtx, Pad};
+use crate::ui::geometry::{Offset, Rect};
+use crate::ui::shape::Renderer;
+use crate::ui::util::animation_disabled;
 
 const DEFAULT_ITEMS_DISTANCE: i16 = 10;
 

--- a/core/embed/rust/src/ui/layout_caesar/component/input_methods/choice_item.rs
+++ b/core/embed/rust/src/ui/layout_caesar/component/input_methods/choice_item.rs
@@ -1,17 +1,13 @@
-use crate::{
-    strutil::ShortString,
-    ui::{
-        component::text::{layout::Lines, TextStyle},
-        constant::screen,
-        display::Icon,
-        geometry::{Alignment2D, Offset, Point, Rect},
-        shape::{self, Renderer},
-    },
-};
-
 use heapless::{String, Vec};
 
 use super::super::{theme, ButtonDetails, ButtonLayout, Choice};
+use crate::strutil::ShortString;
+use crate::ui::component::text::layout::Lines;
+use crate::ui::component::text::TextStyle;
+use crate::ui::constant::screen;
+use crate::ui::display::Icon;
+use crate::ui::geometry::{Alignment2D, Offset, Point, Rect};
+use crate::ui::shape::{self, Renderer};
 
 const ICON_RIGHT_PADDING: i16 = 2;
 

--- a/core/embed/rust/src/ui/layout_caesar/component/input_methods/number_input.rs
+++ b/core/embed/rust/src/ui/layout_caesar/component/input_methods/number_input.rs
@@ -1,14 +1,9 @@
-use crate::{
-    strutil::ShortString,
-    translations::TR,
-    ui::{
-        component::{Component, Event, EventCtx},
-        geometry::Rect,
-        shape::Renderer,
-    },
-};
-
 use super::super::{ButtonLayout, ChoiceFactory, ChoiceItem, ChoiceMsg, ChoicePage};
+use crate::strutil::ShortString;
+use crate::translations::TR;
+use crate::ui::component::{Component, Event, EventCtx};
+use crate::ui::geometry::Rect;
+use crate::ui::shape::Renderer;
 
 struct ChoiceFactoryNumberInput {
     min: u32,

--- a/core/embed/rust/src/ui/layout_caesar/component/input_methods/passphrase.rs
+++ b/core/embed/rust/src/ui/layout_caesar/component/input_methods/passphrase.rs
@@ -1,20 +1,16 @@
-use crate::{
-    strutil::{ShortString, TString},
-    translations::TR,
-    trezorhal::random,
-    ui::{
-        component::{text::common::TextBox, Child, Component, ComponentExt, Event, EventCtx},
-        display::Icon,
-        geometry::Rect,
-        shape::Renderer,
-        util::char_to_string,
-    },
-};
-
 use super::super::{
     theme, ButtonDetails, ButtonLayout, CancelConfirmMsg, ChangingTextLine, ChoiceControls,
     ChoiceFactory, ChoiceItem, ChoiceMsg, ChoicePage,
 };
+use crate::strutil::{ShortString, TString};
+use crate::translations::TR;
+use crate::trezorhal::random;
+use crate::ui::component::text::common::TextBox;
+use crate::ui::component::{Child, Component, ComponentExt, Event, EventCtx};
+use crate::ui::display::Icon;
+use crate::ui::geometry::Rect;
+use crate::ui::shape::Renderer;
+use crate::ui::util::char_to_string;
 
 /// Defines the choices currently available on the screen
 #[derive(PartialEq, Clone, Copy)]

--- a/core/embed/rust/src/ui/layout_caesar/component/input_methods/pin.rs
+++ b/core/embed/rust/src/ui/layout_caesar/component/input_methods/pin.rs
@@ -1,22 +1,18 @@
-use crate::{
-    strutil::{ShortString, TString},
-    time::Duration,
-    translations::TR,
-    trezorhal::random,
-    ui::{
-        component::{
-            text::common::TextBox, Child, Component, ComponentExt, Event, EventCtx, Timer,
-        },
-        display::Icon,
-        geometry::Rect,
-        shape::Renderer,
-    },
-};
-
+use super::super::super::fonts;
+use super::super::title::Title;
 use super::super::{
-    super::fonts, theme, title::Title, ButtonDetails, ButtonLayout, CancelConfirmMsg,
-    ChangingTextLine, ChoiceControls, ChoiceFactory, ChoiceItem, ChoiceMsg, ChoicePage,
+    theme, ButtonDetails, ButtonLayout, CancelConfirmMsg, ChangingTextLine, ChoiceControls,
+    ChoiceFactory, ChoiceItem, ChoiceMsg, ChoicePage,
 };
+use crate::strutil::{ShortString, TString};
+use crate::time::Duration;
+use crate::translations::TR;
+use crate::trezorhal::random;
+use crate::ui::component::text::common::TextBox;
+use crate::ui::component::{Child, Component, ComponentExt, Event, EventCtx, Timer};
+use crate::ui::display::Icon;
+use crate::ui::geometry::Rect;
+use crate::ui::shape::Renderer;
 
 #[derive(Clone, Copy)]
 enum PinAction {

--- a/core/embed/rust/src/ui/layout_caesar/component/input_methods/simple_choice.rs
+++ b/core/embed/rust/src/ui/layout_caesar/component/input_methods/simple_choice.rs
@@ -1,16 +1,12 @@
-use crate::{
-    strutil::TString,
-    ui::{
-        component::{Component, Event, EventCtx},
-        geometry::Rect,
-        shape::Renderer,
-    },
-};
+use heapless::Vec;
 
 use super::super::{
     ButtonDetails, ButtonLayout, ChoiceControls, ChoiceFactory, ChoiceItem, ChoiceMsg, ChoicePage,
 };
-use heapless::Vec;
+use crate::strutil::TString;
+use crate::ui::component::{Component, Event, EventCtx};
+use crate::ui::geometry::Rect;
+use crate::ui::shape::Renderer;
 
 // So that there is only one implementation, and not multiple generic ones
 // as would be via `const N: usize` generics.
@@ -154,14 +150,10 @@ impl Component for SimpleChoice {
 #[cfg(feature = "micropython")]
 mod micropython {
     use super::SimpleChoice;
-    use crate::{
-        error::Error,
-        micropython::obj::Obj,
-        ui::layout::{
-            obj::ComponentMsgObj,
-            result::{CANCELLED, CONFIRMED},
-        },
-    };
+    use crate::error::Error;
+    use crate::micropython::obj::Obj;
+    use crate::ui::layout::obj::ComponentMsgObj;
+    use crate::ui::layout::result::{CANCELLED, CONFIRMED};
 
     impl ComponentMsgObj for SimpleChoice {
         fn msg_try_into_obj(&self, msg: Self::Msg) -> Result<Obj, Error> {

--- a/core/embed/rust/src/ui/layout_caesar/component/input_methods/wordlist.rs
+++ b/core/embed/rust/src/ui/layout_caesar/component/input_methods/wordlist.rs
@@ -1,19 +1,17 @@
-use crate::{
-    translations::TR,
-    trezorhal::{random, wordlist::Wordlist},
-    ui::{
-        component::{text::common::TextBox, Child, Component, ComponentExt, Event, EventCtx},
-        geometry::Rect,
-        shape::Renderer,
-        util::char_to_string,
-    },
-};
+use heapless::Vec;
 
 use super::super::{
     theme, ButtonLayout, ChangingTextLine, ChoiceControls, ChoiceFactory, ChoiceItem, ChoiceMsg,
     ChoicePage,
 };
-use heapless::Vec;
+use crate::translations::TR;
+use crate::trezorhal::random;
+use crate::trezorhal::wordlist::Wordlist;
+use crate::ui::component::text::common::TextBox;
+use crate::ui::component::{Child, Component, ComponentExt, Event, EventCtx};
+use crate::ui::geometry::Rect;
+use crate::ui::shape::Renderer;
+use crate::ui::util::char_to_string;
 
 enum WordlistAction {
     Letter(char),

--- a/core/embed/rust/src/ui/layout_caesar/component/loader.rs
+++ b/core/embed/rust/src/ui/layout_caesar/component/loader.rs
@@ -1,19 +1,13 @@
-use crate::{
-    strutil::TString,
-    time::{Duration, Instant},
-    ui::{
-        animation::Animation,
-        component::{Child, Component, Event, EventCtx},
-        constant,
-        display::{self, Color, Font, LOADER_MAX},
-        geometry::{Offset, Point, Rect},
-        shape,
-        shape::Renderer,
-        util::animation_disabled,
-    },
-};
-
 use super::{theme, Progress};
+use crate::strutil::TString;
+use crate::time::{Duration, Instant};
+use crate::ui::animation::Animation;
+use crate::ui::component::{Child, Component, Event, EventCtx};
+use crate::ui::display::{self, Color, Font, LOADER_MAX};
+use crate::ui::geometry::{Offset, Point, Rect};
+use crate::ui::shape::Renderer;
+use crate::ui::util::animation_disabled;
+use crate::ui::{constant, shape};
 
 pub const DEFAULT_DURATION_MS: u32 = 1000;
 pub const SHRINKING_DURATION_MS: u32 = 500;

--- a/core/embed/rust/src/ui/layout_caesar/component/mod.rs
+++ b/core/embed/rust/src/ui/layout_caesar/component/mod.rs
@@ -8,7 +8,6 @@ mod loader;
 mod result;
 mod welcome_screen;
 
-use super::{common_messages, constant, theme};
 pub use button::{
     Button, ButtonAction, ButtonActions, ButtonContent, ButtonDetails, ButtonLayout, ButtonPos,
 };
@@ -16,13 +15,13 @@ pub use button_controller::{AutomaticMover, ButtonController, ButtonControllerMs
 pub use common_messages::CancelConfirmMsg;
 pub use error::ErrorScreen;
 pub use hold_to_confirm::{HoldToConfirm, HoldToConfirmMsg};
-pub use input_methods::{
-    choice::{Choice, ChoiceControls, ChoiceFactory, ChoiceMsg, ChoicePage},
-    choice_item::ChoiceItem,
-};
+pub use input_methods::choice::{Choice, ChoiceControls, ChoiceFactory, ChoiceMsg, ChoicePage};
+pub use input_methods::choice_item::ChoiceItem;
 pub use loader::{Loader, LoaderMsg, LoaderStyle, LoaderStyleSheet, ProgressLoader};
 pub use result::ResultScreen;
 pub use welcome_screen::WelcomeScreen;
+
+use super::{common_messages, constant, theme};
 
 #[cfg(all(feature = "micropython", feature = "translations"))]
 mod address_details;
@@ -45,7 +44,6 @@ mod title;
 
 #[cfg(all(feature = "micropython", feature = "translations"))]
 pub use address_details::AddressDetails;
-
 pub use changing_text::ChangingTextLine;
 #[cfg(feature = "translations")]
 pub use coinjoin_progress::CoinJoinProgress;

--- a/core/embed/rust/src/ui/layout_caesar/component/page.rs
+++ b/core/embed/rust/src/ui/layout_caesar/component/page.rs
@@ -1,17 +1,14 @@
-use crate::{
-    translations::TR,
-    ui::{
-        component::{Child, Component, ComponentExt, Event, EventCtx, Pad, PageMsg, Paginate},
-        display::Color,
-        geometry::{Insets, Rect},
-        shape::Renderer,
-        util::Pager,
-    },
-};
-
 use super::{
     constant, theme, ButtonController, ButtonControllerMsg, ButtonDetails, ButtonLayout, ButtonPos,
 };
+use crate::translations::TR;
+use crate::ui::component::{
+    Child, Component, ComponentExt, Event, EventCtx, Pad, PageMsg, Paginate,
+};
+use crate::ui::display::Color;
+use crate::ui::geometry::{Insets, Rect};
+use crate::ui::shape::Renderer;
+use crate::ui::util::Pager;
 
 pub struct ButtonPage<T>
 where

--- a/core/embed/rust/src/ui/layout_caesar/component/progress.rs
+++ b/core/embed/rust/src/ui/layout_caesar/component/progress.rs
@@ -1,22 +1,14 @@
 use core::mem;
 
-use crate::{
-    strutil::TString,
-    ui::{
-        component::{
-            text::paragraphs::{Paragraph, Paragraphs},
-            Child, Component, Event, EventCtx, Label, Never, Pad,
-        },
-        constant,
-        display::{Icon, LOADER_MAX},
-        geometry::{Alignment2D, Offset, Rect},
-        shape,
-        shape::Renderer,
-        util::animation_disabled,
-    },
-};
-
 use super::super::{cshape, fonts, theme};
+use crate::strutil::TString;
+use crate::ui::component::text::paragraphs::{Paragraph, Paragraphs};
+use crate::ui::component::{Child, Component, Event, EventCtx, Label, Never, Pad};
+use crate::ui::display::{Icon, LOADER_MAX};
+use crate::ui::geometry::{Alignment2D, Offset, Rect};
+use crate::ui::shape::Renderer;
+use crate::ui::util::animation_disabled;
+use crate::ui::{constant, shape};
 
 const BOTTOM_DESCRIPTION_MARGIN: i16 = 11;
 const LOADER_Y_OFFSET_TITLE: i16 = -10;

--- a/core/embed/rust/src/ui/layout_caesar/component/result.rs
+++ b/core/embed/rust/src/ui/layout_caesar/component/result.rs
@@ -1,11 +1,9 @@
-use crate::ui::{
-    component::{Child, Component, Event, EventCtx, Label, Never, Pad},
-    constant::{screen, HEIGHT, WIDTH},
-    display::{Color, Icon},
-    geometry::{Alignment2D, Offset, Point, Rect},
-    shape,
-    shape::Renderer,
-};
+use crate::ui::component::{Child, Component, Event, EventCtx, Label, Never, Pad};
+use crate::ui::constant::{screen, HEIGHT, WIDTH};
+use crate::ui::display::{Color, Icon};
+use crate::ui::geometry::{Alignment2D, Offset, Point, Rect};
+use crate::ui::shape;
+use crate::ui::shape::Renderer;
 
 const MESSAGE_AREA_START: i16 = 24 + 11;
 const MESSAGE_AREA_START_2L: i16 = 24 + 7;

--- a/core/embed/rust/src/ui/layout_caesar/component/scrollbar.rs
+++ b/core/embed/rust/src/ui/layout_caesar/component/scrollbar.rs
@@ -1,13 +1,10 @@
-use crate::ui::{
-    component::{Component, Event, EventCtx, Never, Pad, Paginate},
-    geometry::{Offset, Point, Rect},
-    shape::{self, Renderer},
-    util::Pager,
-};
+use heapless::Vec;
 
 use super::super::theme;
-
-use heapless::Vec;
+use crate::ui::component::{Component, Event, EventCtx, Never, Pad, Paginate};
+use crate::ui::geometry::{Offset, Point, Rect};
+use crate::ui::shape::{self, Renderer};
+use crate::ui::util::Pager;
 
 /// Scrollbar to be painted horizontally at the top right of the screen.
 pub struct ScrollBar {

--- a/core/embed/rust/src/ui/layout_caesar/component/share_words.rs
+++ b/core/embed/rust/src/ui/layout_caesar/component/share_words.rs
@@ -1,22 +1,18 @@
-use crate::{
-    strutil::{ShortString, TString},
-    translations::TR,
-    ui::{
-        component::{
-            text::util::text_multiline, Child, Component, Event, EventCtx, Never, Paginate,
-        },
-        display::Font,
-        geometry::{Alignment, Offset, Rect},
-        shape::{self, Renderer},
-        util::Pager,
-    },
-};
-
 use heapless::Vec;
 #[cfg(feature = "ui_debug")]
 use ufmt::uwrite;
 
-use super::{super::fonts, scrollbar::SCROLLBAR_SPACE, theme, ScrollBar};
+use super::super::fonts;
+use super::scrollbar::SCROLLBAR_SPACE;
+use super::{theme, ScrollBar};
+use crate::strutil::{ShortString, TString};
+use crate::translations::TR;
+use crate::ui::component::text::util::text_multiline;
+use crate::ui::component::{Child, Component, Event, EventCtx, Never, Paginate};
+use crate::ui::display::Font;
+use crate::ui::geometry::{Alignment, Offset, Rect};
+use crate::ui::shape::{self, Renderer};
+use crate::ui::util::Pager;
 
 const WORDS_PER_PAGE: usize = 3;
 const EXTRA_LINE_HEIGHT: i16 = -2;

--- a/core/embed/rust/src/ui/layout_caesar/component/show_more.rs
+++ b/core/embed/rust/src/ui/layout_caesar/component/show_more.rs
@@ -1,13 +1,8 @@
-use crate::{
-    strutil::TString,
-    ui::{
-        component::{Child, Component, Event, EventCtx, Never},
-        geometry::{Insets, Rect},
-        shape::Renderer,
-    },
-};
-
 use super::{theme, ButtonController, ButtonControllerMsg, ButtonLayout, ButtonPos};
+use crate::strutil::TString;
+use crate::ui::component::{Child, Component, Event, EventCtx, Never};
+use crate::ui::geometry::{Insets, Rect};
+use crate::ui::shape::Renderer;
 
 pub enum CancelInfoConfirmMsg {
     Cancelled,

--- a/core/embed/rust/src/ui/layout_caesar/component/title.rs
+++ b/core/embed/rust/src/ui/layout_caesar/component/title.rs
@@ -1,15 +1,10 @@
-use crate::{
-    strutil::TString,
-    time::Instant,
-    ui::{
-        component::{Component, Event, EventCtx, Marquee, Never},
-        geometry::{Alignment, Offset, Rect},
-        shape,
-        shape::Renderer,
-    },
-};
-
 use super::super::theme;
+use crate::strutil::TString;
+use crate::time::Instant;
+use crate::ui::component::{Component, Event, EventCtx, Marquee, Never};
+use crate::ui::geometry::{Alignment, Offset, Rect};
+use crate::ui::shape;
+use crate::ui::shape::Renderer;
 
 pub struct Title {
     area: Rect,

--- a/core/embed/rust/src/ui/layout_caesar/component/welcome_screen.rs
+++ b/core/embed/rust/src/ui/layout_caesar/component/welcome_screen.rs
@@ -1,11 +1,8 @@
-use crate::ui::{
-    component::{Component, Event, EventCtx, Never},
-    geometry::{Alignment2D, Offset, Rect},
-    shape,
-    shape::Renderer,
-};
-
 use super::super::theme;
+use crate::ui::component::{Component, Event, EventCtx, Never};
+use crate::ui::geometry::{Alignment2D, Offset, Rect};
+use crate::ui::shape;
+use crate::ui::shape::Renderer;
 
 const ICON_TOP_MARGIN: i16 = 12;
 

--- a/core/embed/rust/src/ui/layout_caesar/component_msg_obj.rs
+++ b/core/embed/rust/src/ui/layout_caesar/component_msg_obj.rs
@@ -5,22 +5,14 @@ use super::component::{
     ConfirmHomescreen, Flow, Frame, Homescreen, Lockscreen, NumberInput, Page, PassphraseEntry,
     PinEntry, Progress, ScrollableFrame, ShowMore, WordlistEntry,
 };
-use crate::{
-    error::Error,
-    micropython::obj::Obj,
-    ui::{
-        component::{
-            base::Component,
-            paginated::{PageMsg, Paginate},
-            text::paragraphs::{ParagraphSource, Paragraphs},
-            Never, Timeout,
-        },
-        layout::{
-            obj::ComponentMsgObj,
-            result::{CANCELLED, CONFIRMED, INFO},
-        },
-    },
-};
+use crate::error::Error;
+use crate::micropython::obj::Obj;
+use crate::ui::component::base::Component;
+use crate::ui::component::paginated::{PageMsg, Paginate};
+use crate::ui::component::text::paragraphs::{ParagraphSource, Paragraphs};
+use crate::ui::component::{Never, Timeout};
+use crate::ui::layout::obj::ComponentMsgObj;
+use crate::ui::layout::result::{CANCELLED, CONFIRMED, INFO};
 
 impl From<CancelConfirmMsg> for Obj {
     fn from(value: CancelConfirmMsg) -> Self {

--- a/core/embed/rust/src/ui/layout_caesar/constant.rs
+++ b/core/embed/rust/src/ui/layout_caesar/constant.rs
@@ -1,6 +1,5 @@
-use crate::ui::geometry::{Offset, Point, Rect};
-
 use crate::trezorhal::display::{DISPLAY_RESX, DISPLAY_RESY};
+use crate::ui::geometry::{Offset, Point, Rect};
 
 pub const WIDTH: i16 = DISPLAY_RESX as _;
 pub const HEIGHT: i16 = DISPLAY_RESY as _;

--- a/core/embed/rust/src/ui/layout_caesar/cshape/dotted_line.rs
+++ b/core/embed/rust/src/ui/layout_caesar/cshape/dotted_line.rs
@@ -1,10 +1,8 @@
-use crate::ui::{
-    display::Color,
-    geometry::{Offset, Point, Rect},
-    shape::{Canvas, DrawingCache, Renderer, Shape, ShapeClone},
-};
-
 use without_alloc::alloc::LocalAllocLeakExt;
+
+use crate::ui::display::Color;
+use crate::ui::geometry::{Offset, Point, Rect};
+use crate::ui::shape::{Canvas, DrawingCache, Renderer, Shape, ShapeClone};
 
 // Shape of horizontal solid/dotted line
 pub struct HorizontalLine {

--- a/core/embed/rust/src/ui/layout_caesar/cshape/loader_circular.rs
+++ b/core/embed/rust/src/ui/layout_caesar/cshape/loader_circular.rs
@@ -1,10 +1,8 @@
-use crate::ui::{
-    display::Color,
-    geometry::{Offset, Point, Rect},
-    shape::{Canvas, DrawingCache, Renderer, Shape, ShapeClone},
-};
-
 use without_alloc::alloc::LocalAllocLeakExt;
+
+use crate::ui::display::Color;
+use crate::ui::geometry::{Offset, Point, Rect};
+use crate::ui::shape::{Canvas, DrawingCache, Renderer, Shape, ShapeClone};
 
 static CELLS: [Offset; 24] = [
     Offset::new(1, -4),

--- a/core/embed/rust/src/ui/layout_caesar/cshape/loader_small.rs
+++ b/core/embed/rust/src/ui/layout_caesar/cshape/loader_small.rs
@@ -1,12 +1,10 @@
-use crate::ui::{
-    display::Color,
-    geometry::{Offset, Point, Rect},
-    shape::{Canvas, DrawingCache, Renderer, Shape, ShapeClone},
-};
+use core::f32::consts::SQRT_2;
 
 use without_alloc::alloc::LocalAllocLeakExt;
 
-use core::f32::consts::SQRT_2;
+use crate::ui::display::Color;
+use crate::ui::geometry::{Offset, Point, Rect};
+use crate::ui::shape::{Canvas, DrawingCache, Renderer, Shape, ShapeClone};
 
 const STAR_COUNT: usize = 8;
 const RADIUS: i16 = 3;

--- a/core/embed/rust/src/ui/layout_caesar/cshape/loader_starry.rs
+++ b/core/embed/rust/src/ui/layout_caesar/cshape/loader_starry.rs
@@ -1,12 +1,10 @@
-use crate::ui::{
-    display::Color,
-    geometry::{Offset, Point, Rect},
-    shape::{Canvas, DrawingCache, Renderer, Shape, ShapeClone},
-};
+use core::f32::consts::SQRT_2;
 
 use without_alloc::alloc::LocalAllocLeakExt;
 
-use core::f32::consts::SQRT_2;
+use crate::ui::display::Color;
+use crate::ui::geometry::{Offset, Point, Rect};
+use crate::ui::shape::{Canvas, DrawingCache, Renderer, Shape, ShapeClone};
 
 const STAR_COUNT: usize = 8;
 const STAR_SMALL: i16 = 2;

--- a/core/embed/rust/src/ui/layout_caesar/mod.rs
+++ b/core/embed/rust/src/ui/layout_caesar/mod.rs
@@ -1,13 +1,11 @@
-use super::{geometry::Rect, CommonUI};
-
+use super::geometry::Rect;
 #[cfg(any(feature = "ui_debug_overlay", feature = "ui_performance_overlay"))]
 use super::shape;
-
-#[cfg(feature = "ui_debug_overlay")]
-use super::{display::Color, geometry::Offset};
-
+use super::CommonUI;
 #[cfg(feature = "ui_performance_overlay")]
 use super::PerformanceOverlay;
+#[cfg(feature = "ui_debug_overlay")]
+use super::{display::Color, geometry::Offset};
 
 #[cfg(feature = "bootloader")]
 pub mod bootloader;
@@ -24,8 +22,9 @@ pub mod cshape;
 pub mod fonts;
 pub mod theme;
 
-use crate::ui::layout::simplified::show;
 use component::{ErrorScreen, WelcomeScreen};
+
+use crate::ui::layout::simplified::show;
 
 pub struct UICaesar {}
 

--- a/core/embed/rust/src/ui/layout_caesar/prodtest/mod.rs
+++ b/core/embed/rust/src/ui/layout_caesar/prodtest/mod.rs
@@ -1,24 +1,20 @@
 mod welcome;
 
 #[cfg(feature = "touch")]
-use crate::ui::event::TouchEvent;
-use crate::ui::{
-    component::Event,
-    constant::screen,
-    display,
-    display::Color,
-    geometry::{Alignment, Offset, Rect},
-    layout::simplified::{process_frame_event, show},
-    shape,
-    shape::render_on_display,
-    ui_prodtest::{ProdtestLayoutType, ProdtestUI},
-};
-
-use super::{fonts, UICaesar};
+use heapless::Vec;
 use welcome::Welcome;
 
+use super::{fonts, UICaesar};
+use crate::ui::component::Event;
+use crate::ui::constant::screen;
+use crate::ui::display::Color;
 #[cfg(feature = "touch")]
-use heapless::Vec;
+use crate::ui::event::TouchEvent;
+use crate::ui::geometry::{Alignment, Offset, Rect};
+use crate::ui::layout::simplified::{process_frame_event, show};
+use crate::ui::shape::render_on_display;
+use crate::ui::ui_prodtest::{ProdtestLayoutType, ProdtestUI};
+use crate::ui::{display, shape};
 
 #[allow(clippy::large_enum_variant)]
 pub enum ProdtestLayout {

--- a/core/embed/rust/src/ui/layout_caesar/prodtest/welcome.rs
+++ b/core/embed/rust/src/ui/layout_caesar/prodtest/welcome.rs
@@ -1,10 +1,8 @@
 use super::super::theme::{BLACK, WHITE};
-use crate::ui::{
-    component::{Component, Event, EventCtx, Never, Qr},
-    constant::screen,
-    geometry::{Offset, Point, Rect},
-    shape::{self, Renderer},
-};
+use crate::ui::component::{Component, Event, EventCtx, Never, Qr};
+use crate::ui::constant::screen;
+use crate::ui::geometry::{Offset, Point, Rect};
+use crate::ui::shape::{self, Renderer};
 
 pub struct Welcome {
     id: Option<&'static str>,

--- a/core/embed/rust/src/ui/layout_caesar/theme/bootloader.rs
+++ b/core/embed/rust/src/ui/layout_caesar/theme/bootloader.rs
@@ -1,7 +1,8 @@
-use crate::ui::{component::text::TextStyle, display::Color, util::include_icon};
-
 use super::super::fonts;
 pub use super::super::theme::{BLACK, WHITE};
+use crate::ui::component::text::TextStyle;
+use crate::ui::display::Color;
+use crate::ui::util::include_icon;
 
 pub const BLD_BG: Color = BLACK;
 pub const BLD_FG: Color = WHITE;

--- a/core/embed/rust/src/ui/layout_caesar/theme/mod.rs
+++ b/core/embed/rust/src/ui/layout_caesar/theme/mod.rs
@@ -1,14 +1,11 @@
-use crate::ui::{
-    component::{
-        text::{layout::Chunks, paragraphs::PARAGRAPH_BOTTOM_SPACE, TextStyle},
-        LineBreaking, PageBreaking,
-    },
-    display::{Color, Font},
-    geometry::Offset,
-    util::include_icon,
-};
-
 use super::fonts;
+use crate::ui::component::text::layout::Chunks;
+use crate::ui::component::text::paragraphs::PARAGRAPH_BOTTOM_SPACE;
+use crate::ui::component::text::TextStyle;
+use crate::ui::component::{LineBreaking, PageBreaking};
+use crate::ui::display::{Color, Font};
+use crate::ui::geometry::Offset;
+use crate::ui::util::include_icon;
 
 pub mod bootloader;
 

--- a/core/embed/rust/src/ui/layout_caesar/ui_firmware.rs
+++ b/core/embed/rust/src/ui/layout_caesar/ui_firmware.rs
@@ -1,49 +1,41 @@
 use core::cmp::Ordering;
 
-use crate::{
-    error::Error,
-    io::BinaryData,
-    maybe_trace::MaybeTrace,
-    micropython::{buffer::StrBuffer, gc::Gc, iter::IterBuf, list::List, obj::Obj, util},
-    strutil::TString,
-    translations::TR,
-    ui::{
-        component::{
-            text::{
-                op::OpTextLayout,
-                paragraphs::{
-                    Checklist, Paragraph, ParagraphSource, ParagraphVecLong, ParagraphVecShort,
-                    Paragraphs, VecExt,
-                },
-                TextStyle,
-            },
-            Component, ComponentExt, Empty, FormattedText, Label, LineBreaking, Paginate, Timeout,
-        },
-        geometry,
-        layout::{
-            obj::{LayoutMaybeTrace, LayoutObj, RootComponent},
-            util::{ConfirmValueParams, PropsList, RecoveryType},
-        },
-        notification::Notification,
-        ui_firmware::{
-            FirmwareUI, MAX_CHECKLIST_ITEMS, MAX_GROUP_SHARE_LINES, MAX_MENU_ITEMS,
-            MAX_PAIRED_DEVICES, MAX_WORD_QUIZ_ITEMS,
-        },
-        ModelUI,
-    },
-};
-
-use super::{
-    component::{
-        AddressDetails, ButtonActions, ButtonDetails, ButtonLayout, ButtonPage, ChoiceControls,
-        CoinJoinProgress, ConfirmHomescreen, Flow, FlowPages, Frame, Homescreen, Lockscreen,
-        NumberInput, Page, PassphraseEntry, PinEntry, Progress, ScrollableFrame, ShareWords,
-        ShowMore, SimpleChoice, WordlistEntry, WordlistType,
-    },
-    constant, fonts, theme, UICaesar,
-};
-
 use heapless::Vec;
+
+use super::component::{
+    AddressDetails, ButtonActions, ButtonDetails, ButtonLayout, ButtonPage, ChoiceControls,
+    CoinJoinProgress, ConfirmHomescreen, Flow, FlowPages, Frame, Homescreen, Lockscreen,
+    NumberInput, Page, PassphraseEntry, PinEntry, Progress, ScrollableFrame, ShareWords, ShowMore,
+    SimpleChoice, WordlistEntry, WordlistType,
+};
+use super::{constant, fonts, theme, UICaesar};
+use crate::error::Error;
+use crate::io::BinaryData;
+use crate::maybe_trace::MaybeTrace;
+use crate::micropython::buffer::StrBuffer;
+use crate::micropython::gc::Gc;
+use crate::micropython::iter::IterBuf;
+use crate::micropython::list::List;
+use crate::micropython::obj::Obj;
+use crate::micropython::util;
+use crate::strutil::TString;
+use crate::translations::TR;
+use crate::ui::component::text::op::OpTextLayout;
+use crate::ui::component::text::paragraphs::{
+    Checklist, Paragraph, ParagraphSource, ParagraphVecLong, ParagraphVecShort, Paragraphs, VecExt,
+};
+use crate::ui::component::text::TextStyle;
+use crate::ui::component::{
+    Component, ComponentExt, Empty, FormattedText, Label, LineBreaking, Paginate, Timeout,
+};
+use crate::ui::layout::obj::{LayoutMaybeTrace, LayoutObj, RootComponent};
+use crate::ui::layout::util::{ConfirmValueParams, PropsList, RecoveryType};
+use crate::ui::notification::Notification;
+use crate::ui::ui_firmware::{
+    FirmwareUI, MAX_CHECKLIST_ITEMS, MAX_GROUP_SHARE_LINES, MAX_MENU_ITEMS, MAX_PAIRED_DEVICES,
+    MAX_WORD_QUIZ_ITEMS,
+};
+use crate::ui::{geometry, ModelUI};
 
 impl FirmwareUI for UICaesar {
     fn confirm_action(

--- a/core/embed/rust/src/ui/layout_delizia/bootloader/connect.rs
+++ b/core/embed/rust/src/ui/layout_delizia/bootloader/connect.rs
@@ -1,18 +1,13 @@
-use crate::{
-    strutil::TString,
-    ui::{
-        component::{Component, Event, EventCtx, Pad},
-        display::{Color, Font},
-        geometry::{Alignment, Offset, Point, Rect},
-        shape::{self, Renderer},
-    },
+use super::super::component::{Button, ButtonMsg};
+use super::super::constant::WIDTH;
+use super::super::theme::bootloader::{
+    button_bld, BUTTON_AREA_START, BUTTON_HEIGHT, CONTENT_PADDING,
 };
-
-use super::super::{
-    component::{Button, ButtonMsg},
-    constant::WIDTH,
-    theme::bootloader::{button_bld, BUTTON_AREA_START, BUTTON_HEIGHT, CONTENT_PADDING},
-};
+use crate::strutil::TString;
+use crate::ui::component::{Component, Event, EventCtx, Pad};
+use crate::ui::display::{Color, Font};
+use crate::ui::geometry::{Alignment, Offset, Point, Rect};
+use crate::ui::shape::{self, Renderer};
 
 #[repr(u32)]
 #[derive(Copy, Clone, ToPrimitive)]

--- a/core/embed/rust/src/ui/layout_delizia/bootloader/intro.rs
+++ b/core/embed/rust/src/ui/layout_delizia/bootloader/intro.rs
@@ -1,22 +1,16 @@
-use crate::{
-    strutil::TString,
-    ui::{
-        component::{Child, Component, Event, EventCtx, Label, Pad},
-        constant::screen,
-        display::Icon,
-        geometry::{Alignment, Insets, Point, Rect},
-        shape::Renderer,
-    },
+use super::super::component::Button;
+use super::super::component::ButtonMsg::Clicked;
+use super::super::constant::WIDTH;
+use super::super::theme::bootloader::{
+    button_bld, button_bld_menu, text_title, BLD_BG, BUTTON_AREA_START, BUTTON_HEIGHT,
+    CONTENT_PADDING, CORNER_BUTTON_AREA, MENU32, TEXT_NORMAL, TEXT_WARNING, TITLE_AREA,
 };
-
-use super::super::{
-    component::{Button, ButtonMsg::Clicked},
-    constant::WIDTH,
-    theme::bootloader::{
-        button_bld, button_bld_menu, text_title, BLD_BG, BUTTON_AREA_START, BUTTON_HEIGHT,
-        CONTENT_PADDING, CORNER_BUTTON_AREA, MENU32, TEXT_NORMAL, TEXT_WARNING, TITLE_AREA,
-    },
-};
+use crate::strutil::TString;
+use crate::ui::component::{Child, Component, Event, EventCtx, Label, Pad};
+use crate::ui::constant::screen;
+use crate::ui::display::Icon;
+use crate::ui::geometry::{Alignment, Insets, Point, Rect};
+use crate::ui::shape::Renderer;
 
 #[repr(u32)]
 #[derive(Copy, Clone, ToPrimitive)]

--- a/core/embed/rust/src/ui/layout_delizia/bootloader/menu.rs
+++ b/core/embed/rust/src/ui/layout_delizia/bootloader/menu.rs
@@ -1,18 +1,14 @@
-use crate::ui::{
-    component::{Child, Component, Event, EventCtx, Label, Pad},
-    constant::{screen, WIDTH},
-    display::Icon,
-    geometry::{Insets, Point, Rect},
-    shape::Renderer,
+use super::super::component::ButtonMsg::Clicked;
+use super::super::component::{Button, IconText};
+use super::super::theme::bootloader::{
+    button_bld, button_bld_menu, text_title, BLD_BG, BUTTON_HEIGHT, CONTENT_PADDING,
+    CORNER_BUTTON_AREA, CORNER_BUTTON_TOUCH_EXPANSION, FIRE24, REFRESH24, TITLE_AREA, X32,
 };
-
-use super::super::{
-    component::{Button, ButtonMsg::Clicked, IconText},
-    theme::bootloader::{
-        button_bld, button_bld_menu, text_title, BLD_BG, BUTTON_HEIGHT, CONTENT_PADDING,
-        CORNER_BUTTON_AREA, CORNER_BUTTON_TOUCH_EXPANSION, FIRE24, REFRESH24, TITLE_AREA, X32,
-    },
-};
+use crate::ui::component::{Child, Component, Event, EventCtx, Label, Pad};
+use crate::ui::constant::{screen, WIDTH};
+use crate::ui::display::Icon;
+use crate::ui::geometry::{Insets, Point, Rect};
+use crate::ui::shape::Renderer;
 
 const BUTTON_AREA_START: i16 = 56;
 const BUTTON_SPACING: i16 = 8;

--- a/core/embed/rust/src/ui/layout_delizia/bootloader/mod.rs
+++ b/core/embed/rust/src/ui/layout_delizia/bootloader/mod.rs
@@ -1,48 +1,33 @@
-use heapless::String;
-
-use super::{
-    bootloader::welcome::Welcome,
-    component::{
-        bl_confirm::{Confirm, ConfirmTitle},
-        Button, ResultScreen, WelcomeScreen,
-    },
-    cshape::{render_loader, LoaderRange},
-    fonts,
-    theme::{
-        backlight,
-        bootloader::{
-            button_bld, button_bld_menu, button_confirm, button_wipe_cancel, button_wipe_confirm,
-            BLD_BG, BLD_FG, BLD_TITLE_COLOR, BLD_WARN_COLOR, BLD_WIPE_COLOR, CHECK24, CHECK40,
-            DOWNLOAD24, FIRE32, FIRE40, RESULT_FW_INSTALL, RESULT_WIPE, TEXT_BOLD, TEXT_NORMAL,
-            TEXT_WIPE_BOLD, TEXT_WIPE_NORMAL, WARNING40, WELCOME_COLOR, X24,
-        },
-        GREEN_LIGHT, GREY,
-    },
-    UIDelizia,
-};
-
-use crate::{
-    bootloader::run,
-    time::Duration,
-    trezorhal::time,
-    ui::{
-        component::Label,
-        display::{self, toif::Toif, Color, Icon, LOADER_MAX},
-        geometry::{Alignment, Alignment2D, Offset, Point, Rect},
-        layout::simplified::show,
-        shape,
-        shape::render_on_display,
-        ui_bootloader::BootloaderUI,
-        util::animation_disabled,
-        CommonUI,
-    },
-};
-
-use ufmt::uwrite;
-
 use connect::Connect;
+use heapless::String;
 use intro::Intro;
 use menu::Menu;
+use ufmt::uwrite;
+
+use super::bootloader::welcome::Welcome;
+use super::component::bl_confirm::{Confirm, ConfirmTitle};
+use super::component::{Button, ResultScreen, WelcomeScreen};
+use super::cshape::{render_loader, LoaderRange};
+use super::theme::bootloader::{
+    button_bld, button_bld_menu, button_confirm, button_wipe_cancel, button_wipe_confirm, BLD_BG,
+    BLD_FG, BLD_TITLE_COLOR, BLD_WARN_COLOR, BLD_WIPE_COLOR, CHECK24, CHECK40, DOWNLOAD24, FIRE32,
+    FIRE40, RESULT_FW_INSTALL, RESULT_WIPE, TEXT_BOLD, TEXT_NORMAL, TEXT_WIPE_BOLD,
+    TEXT_WIPE_NORMAL, WARNING40, WELCOME_COLOR, X24,
+};
+use super::theme::{backlight, GREEN_LIGHT, GREY};
+use super::{fonts, UIDelizia};
+use crate::bootloader::run;
+use crate::time::Duration;
+use crate::trezorhal::time;
+use crate::ui::component::Label;
+use crate::ui::display::toif::Toif;
+use crate::ui::display::{self, Color, Icon, LOADER_MAX};
+use crate::ui::geometry::{Alignment, Alignment2D, Offset, Point, Rect};
+use crate::ui::layout::simplified::show;
+use crate::ui::shape::render_on_display;
+use crate::ui::ui_bootloader::BootloaderUI;
+use crate::ui::util::animation_disabled;
+use crate::ui::{shape, CommonUI};
 
 pub mod intro;
 pub mod menu;

--- a/core/embed/rust/src/ui/layout_delizia/bootloader/welcome.rs
+++ b/core/embed/rust/src/ui/layout_delizia/bootloader/welcome.rs
@@ -1,14 +1,9 @@
-use crate::ui::{
-    component::{Component, Event, EventCtx, Never, Pad},
-    constant::screen,
-    geometry::{Offset, Point, Rect},
-    shape::{self, Renderer},
-};
-
-use super::{
-    super::theme::{BLACK, GREY, WHITE},
-    fonts,
-};
+use super::super::theme::{BLACK, GREY, WHITE};
+use super::fonts;
+use crate::ui::component::{Component, Event, EventCtx, Never, Pad};
+use crate::ui::constant::screen;
+use crate::ui::geometry::{Offset, Point, Rect};
+use crate::ui::shape::{self, Renderer};
 
 const TEXT_ORIGIN: Point = Point::new(0, 105);
 const STRIDE: i16 = 22;

--- a/core/embed/rust/src/ui/layout_delizia/component/address_details.rs
+++ b/core/embed/rust/src/ui/layout_delizia/component/address_details.rs
@@ -1,26 +1,22 @@
 use heapless::Vec;
 
-use crate::{
-    error::Error,
-    micropython::{buffer::StrBuffer, gc::GcBox},
-    strutil::TString,
-    translations::TR,
-    ui::{
-        component::{
-            swipe_detect::SwipeConfig,
-            text::paragraphs::{Paragraph, ParagraphSource, ParagraphVecShort, Paragraphs, VecExt},
-            Component, Event, EventCtx, Paginate,
-        },
-        event::SwipeEvent,
-        flow::Swipable,
-        geometry::{Direction, Rect},
-        layout::util::MAX_XPUBS,
-        shape::Renderer,
-        util::Pager,
-    },
-};
-
 use super::{theme, Frame, FrameMsg, Header};
+use crate::error::Error;
+use crate::micropython::buffer::StrBuffer;
+use crate::micropython::gc::GcBox;
+use crate::strutil::TString;
+use crate::translations::TR;
+use crate::ui::component::swipe_detect::SwipeConfig;
+use crate::ui::component::text::paragraphs::{
+    Paragraph, ParagraphSource, ParagraphVecShort, Paragraphs, VecExt,
+};
+use crate::ui::component::{Component, Event, EventCtx, Paginate};
+use crate::ui::event::SwipeEvent;
+use crate::ui::flow::Swipable;
+use crate::ui::geometry::{Direction, Rect};
+use crate::ui::layout::util::MAX_XPUBS;
+use crate::ui::shape::Renderer;
+use crate::ui::util::Pager;
 
 pub struct AddressDetails {
     details: Frame<Paragraphs<ParagraphVecShort<'static>>>,

--- a/core/embed/rust/src/ui/layout_delizia/component/binary_selection.rs
+++ b/core/embed/rust/src/ui/layout_delizia/component/binary_selection.rs
@@ -1,10 +1,8 @@
-use crate::ui::{
-    component::{Component, Event, EventCtx},
-    geometry::{Alignment, Alignment2D, Offset, Rect},
-    shape::Renderer,
-};
-
-use super::{super::cshape, theme, Button, ButtonContent, ButtonMsg, ButtonStyleSheet};
+use super::super::cshape;
+use super::{theme, Button, ButtonContent, ButtonMsg, ButtonStyleSheet};
+use crate::ui::component::{Component, Event, EventCtx};
+use crate::ui::geometry::{Alignment, Alignment2D, Offset, Rect};
+use crate::ui::shape::Renderer;
 
 pub enum BinarySelectionMsg {
     Left,

--- a/core/embed/rust/src/ui/layout_delizia/component/bl_confirm.rs
+++ b/core/embed/rust/src/ui/layout_delizia/component/bl_confirm.rs
@@ -1,29 +1,18 @@
-use crate::{
-    strutil::TString,
-    ui::{
-        component::{Child, Component, ComponentExt, Event, EventCtx, Label, Pad},
-        constant,
-        constant::screen,
-        display::{Color, Icon},
-        geometry::{Alignment2D, Insets, Offset, Point, Rect},
-        shape,
-        shape::Renderer,
-    },
+use super::constant::WIDTH;
+use super::theme::bootloader::{
+    text_fingerprint, text_title, BUTTON_AREA_START, BUTTON_HEIGHT, CONTENT_PADDING,
+    CORNER_BUTTON_AREA, CORNER_BUTTON_TOUCH_EXPANSION, INFO32, TITLE_AREA, X32,
 };
-
-use super::{
-    constant::WIDTH,
-    theme::{
-        bootloader::{
-            text_fingerprint, text_title, BUTTON_AREA_START, BUTTON_HEIGHT, CONTENT_PADDING,
-            CORNER_BUTTON_AREA, CORNER_BUTTON_TOUCH_EXPANSION, INFO32, TITLE_AREA, X32,
-        },
-        WHITE,
-    },
-    Button,
-    ButtonMsg::Clicked,
-    ButtonStyleSheet,
-};
+use super::theme::WHITE;
+use super::ButtonMsg::Clicked;
+use super::{Button, ButtonStyleSheet};
+use crate::strutil::TString;
+use crate::ui::component::{Child, Component, ComponentExt, Event, EventCtx, Label, Pad};
+use crate::ui::constant::screen;
+use crate::ui::display::{Color, Icon};
+use crate::ui::geometry::{Alignment2D, Insets, Offset, Point, Rect};
+use crate::ui::shape::Renderer;
+use crate::ui::{constant, shape};
 
 const ICON_TOP: i16 = 17;
 const CONTENT_START: i16 = 72;

--- a/core/embed/rust/src/ui/layout_delizia/component/button.rs
+++ b/core/embed/rust/src/ui/layout_delizia/component/button.rs
@@ -1,19 +1,15 @@
+use super::theme;
+use crate::strutil::TString;
+use crate::time::ShortDuration;
 #[cfg(feature = "haptic")]
 use crate::trezorhal::haptic::{play, HapticEffect};
-use crate::{
-    strutil::TString,
-    time::ShortDuration,
-    ui::{
-        component::{Component, Event, EventCtx, Timer},
-        display::{toif::Icon, Color, Font},
-        event::TouchEvent,
-        geometry::{Alignment, Alignment2D, Insets, Offset, Point, Rect},
-        shape::{self, Renderer},
-        util::split_two_lines,
-    },
-};
-
-use super::theme;
+use crate::ui::component::{Component, Event, EventCtx, Timer};
+use crate::ui::display::toif::Icon;
+use crate::ui::display::{Color, Font};
+use crate::ui::event::TouchEvent;
+use crate::ui::geometry::{Alignment, Alignment2D, Insets, Offset, Point, Rect};
+use crate::ui::shape::{self, Renderer};
+use crate::ui::util::split_two_lines;
 
 pub enum ButtonMsg {
     Pressed,

--- a/core/embed/rust/src/ui/layout_delizia/component/coinjoin_progress.rs
+++ b/core/embed/rust/src/ui/layout_delizia/component/coinjoin_progress.rs
@@ -1,20 +1,16 @@
 use core::mem;
 
-use crate::{
-    error::Error,
-    maybe_trace::MaybeTrace,
-    strutil::TString,
-    translations::TR,
-    ui::{
-        component::{base::Never, Bar, Component, Empty, Event, EventCtx, Label, Split},
-        geometry::{Insets, Offset, Rect},
-        shape,
-        shape::Renderer,
-        util::animation_disabled,
-    },
-};
-
 use super::{constant, theme, Frame, Header};
+use crate::error::Error;
+use crate::maybe_trace::MaybeTrace;
+use crate::strutil::TString;
+use crate::translations::TR;
+use crate::ui::component::base::Never;
+use crate::ui::component::{Bar, Component, Empty, Event, EventCtx, Label, Split};
+use crate::ui::geometry::{Insets, Offset, Rect};
+use crate::ui::shape;
+use crate::ui::shape::Renderer;
+use crate::ui::util::animation_disabled;
 
 const RECTANGLE_HEIGHT: i16 = 56;
 const LABEL_TOP: i16 = 135;

--- a/core/embed/rust/src/ui/layout_delizia/component/error.rs
+++ b/core/embed/rust/src/ui/layout_delizia/component/error.rs
@@ -1,19 +1,12 @@
-use crate::{
-    strutil::TString,
-    ui::{
-        component::{Component, Event, EventCtx, Label, Never, Pad},
-        constant::screen,
-        geometry::{Alignment2D, Point, Rect},
-        shape,
-        shape::Renderer,
-    },
-};
-
-use super::{
-    constant::WIDTH,
-    theme::{FATAL_ERROR_COLOR, ICON_WARNING40, RESULT_FOOTER_START, RESULT_PADDING, WHITE},
-    ResultFooter, ResultStyle,
-};
+use super::constant::WIDTH;
+use super::theme::{FATAL_ERROR_COLOR, ICON_WARNING40, RESULT_FOOTER_START, RESULT_PADDING, WHITE};
+use super::{ResultFooter, ResultStyle};
+use crate::strutil::TString;
+use crate::ui::component::{Component, Event, EventCtx, Label, Never, Pad};
+use crate::ui::constant::screen;
+use crate::ui::geometry::{Alignment2D, Point, Rect};
+use crate::ui::shape;
+use crate::ui::shape::Renderer;
 
 const ICON_TOP: i16 = 23;
 const TITLE_AREA_START: i16 = 70;

--- a/core/embed/rust/src/ui/layout_delizia/component/fido.rs
+++ b/core/embed/rust/src/ui/layout_delizia/component/fido.rs
@@ -1,18 +1,14 @@
-use crate::{
-    strutil::TString,
-    ui::{
-        component::{
-            image::Image,
-            paginated::SinglePage,
-            text::paragraphs::{Paragraph, ParagraphSource, ParagraphVecShort, Paragraphs},
-            Component, Event, EventCtx,
-        },
-        geometry::{Insets, Offset, Rect},
-        shape::Renderer,
-    },
+use super::super::component::fido_icons::get_fido_icon_data;
+use super::super::component::theme;
+use crate::strutil::TString;
+use crate::ui::component::image::Image;
+use crate::ui::component::paginated::SinglePage;
+use crate::ui::component::text::paragraphs::{
+    Paragraph, ParagraphSource, ParagraphVecShort, Paragraphs,
 };
-
-use super::super::component::{fido_icons::get_fido_icon_data, theme};
+use crate::ui::component::{Component, Event, EventCtx};
+use crate::ui::geometry::{Insets, Offset, Rect};
+use crate::ui::shape::Renderer;
 
 pub struct FidoCredential<F: Fn() -> TString<'static>> {
     app_icon: Option<Image>,

--- a/core/embed/rust/src/ui/layout_delizia/component/footer.rs
+++ b/core/embed/rust/src/ui/layout_delizia/component/footer.rs
@@ -1,18 +1,15 @@
-use crate::{
-    strutil::TString,
-    ui::{
-        component::{text::TextStyle, Component, Event, EventCtx},
-        display::{Color, Font},
-        event::SwipeEvent,
-        geometry::{Alignment, Alignment2D, Direction, Insets, Offset, Point, Rect},
-        lerp::Lerp,
-        shape::{self, Renderer, Text},
-        util::Pager,
-        CommonUI, ModelUI,
-    },
-};
-
-use super::{super::fonts::FONT_SUB, theme, Button, ButtonMsg};
+use super::super::fonts::FONT_SUB;
+use super::{theme, Button, ButtonMsg};
+use crate::strutil::TString;
+use crate::ui::component::text::TextStyle;
+use crate::ui::component::{Component, Event, EventCtx};
+use crate::ui::display::{Color, Font};
+use crate::ui::event::SwipeEvent;
+use crate::ui::geometry::{Alignment, Alignment2D, Direction, Insets, Offset, Point, Rect};
+use crate::ui::lerp::Lerp;
+use crate::ui::shape::{self, Renderer, Text};
+use crate::ui::util::Pager;
+use crate::ui::{CommonUI, ModelUI};
 
 /// Component showing a task instruction, e.g. "Swipe up", and an optional
 /// content consisting of one of these:

--- a/core/embed/rust/src/ui/layout_delizia/component/frame.rs
+++ b/core/embed/rust/src/ui/layout_delizia/component/frame.rs
@@ -1,26 +1,17 @@
+use super::super::theme::TITLE_HEIGHT;
 use super::{theme, Footer, Header};
-use crate::{
-    strutil::TString,
-    ui::{
-        component::{
-            base::AttachType,
-            paginated::Paginate,
-            swipe_detect::{SwipeConfig, SwipeSettings},
-            Component,
-            Event::{self, Swipe},
-            EventCtx, FlowMsg, MsgMap, SwipeDetect,
-        },
-        event::SwipeEvent,
-        geometry::{Direction, Insets, Point, Rect},
-        lerp::Lerp,
-        shape::{self, Renderer},
-    },
-};
-
+use crate::strutil::TString;
+use crate::ui::component::base::AttachType;
+use crate::ui::component::paginated::Paginate;
+use crate::ui::component::swipe_detect::{SwipeConfig, SwipeSettings};
+use crate::ui::component::Event::{self, Swipe};
+use crate::ui::component::{Component, EventCtx, FlowMsg, MsgMap, SwipeDetect};
+use crate::ui::event::SwipeEvent;
+use crate::ui::geometry::{Direction, Insets, Point, Rect};
+use crate::ui::lerp::Lerp;
+use crate::ui::shape::{self, Renderer};
 #[cfg(feature = "micropython")]
 use crate::ui::util::Pager;
-
-use super::super::theme::TITLE_HEIGHT;
 
 #[derive(Clone)]
 pub struct HorizontalSwipe {

--- a/core/embed/rust/src/ui/layout_delizia/component/header.rs
+++ b/core/embed/rust/src/ui/layout_delizia/component/header.rs
@@ -1,20 +1,14 @@
-use crate::{
-    strutil::TString,
-    time::{Duration, Stopwatch},
-    ui::{
-        component::{text::TextStyle, Component, Event, EventCtx, FlowMsg, Label},
-        display::{Color, Icon},
-        geometry::{Alignment, Alignment2D, Insets, Offset, Rect},
-        lerp::Lerp,
-        shape::{self, Renderer},
-        util::animation_disabled,
-    },
-};
-
-use super::super::{
-    component::{Button, ButtonMsg, ButtonStyleSheet},
-    theme::{self, TITLE_HEIGHT},
-};
+use super::super::component::{Button, ButtonMsg, ButtonStyleSheet};
+use super::super::theme::{self, TITLE_HEIGHT};
+use crate::strutil::TString;
+use crate::time::{Duration, Stopwatch};
+use crate::ui::component::text::TextStyle;
+use crate::ui::component::{Component, Event, EventCtx, FlowMsg, Label};
+use crate::ui::display::{Color, Icon};
+use crate::ui::geometry::{Alignment, Alignment2D, Insets, Offset, Rect};
+use crate::ui::lerp::Lerp;
+use crate::ui::shape::{self, Renderer};
+use crate::ui::util::animation_disabled;
 
 const ANIMATION_TIME_MS: u32 = 1000;
 

--- a/core/embed/rust/src/ui/layout_delizia/component/hold_to_confirm.rs
+++ b/core/embed/rust/src/ui/layout_delizia/component/hold_to_confirm.rs
@@ -1,33 +1,19 @@
-use crate::{
-    time::{Duration, ShortDuration},
-    translations::TR,
-    ui::{
-        component::{Component, Event, EventCtx},
-        display::Color,
-        geometry::{Alignment2D, Offset, Rect},
-        lerp::Lerp,
-        shape,
-        shape::Renderer,
-        util::animation_disabled,
-    },
-};
+use pareen;
 
-use super::{
-    theme::{self, TITLE_HEIGHT},
-    Button, ButtonContent, ButtonMsg,
-};
-
+use super::theme::{self, TITLE_HEIGHT};
+use super::{Button, ButtonContent, ButtonMsg};
+use crate::time::{Duration, ShortDuration, Stopwatch};
+use crate::translations::TR;
 #[cfg(feature = "haptic")]
 use crate::trezorhal::haptic::{self, HapticEffect};
-use crate::{
-    time::Stopwatch,
-    ui::{
-        component::Label,
-        constant::screen,
-        geometry::{Alignment, Point},
-    },
-};
-use pareen;
+use crate::ui::component::{Component, Event, EventCtx, Label};
+use crate::ui::constant::screen;
+use crate::ui::display::Color;
+use crate::ui::geometry::{Alignment, Alignment2D, Offset, Point, Rect};
+use crate::ui::lerp::Lerp;
+use crate::ui::shape;
+use crate::ui::shape::Renderer;
+use crate::ui::util::animation_disabled;
 
 #[derive(Default, Clone)]
 struct HoldToConfirmAnim {

--- a/core/embed/rust/src/ui/layout_delizia/component/homescreen.rs
+++ b/core/embed/rust/src/ui/layout_delizia/component/homescreen.rs
@@ -1,41 +1,27 @@
+use super::super::cshape::{self, UnlockOverlay};
+use super::super::fonts;
+use super::theme::{self, GREY_LIGHT, HOMESCREEN_ICON, ICON_KEY};
+use super::{constant, Loader, LoaderMsg};
+use crate::error::Error;
+use crate::io::BinaryData;
+use crate::strutil::TString;
+use crate::time::{Duration, Instant, Stopwatch};
+use crate::translations::TR;
 #[cfg(feature = "haptic")]
 use crate::trezorhal::haptic::{play, HapticEffect};
-
-use crate::{
-    error::Error,
-    io::BinaryData,
-    strutil::TString,
-    time::{Duration, Instant, Stopwatch},
-    translations::TR,
-    trezorhal::usb::usb_configured,
-    ui::{
-        component::{Component, Event, EventCtx, Timer},
-        display::{image::ImageInfo, Color},
-        event::TouchEvent,
-        geometry::{Alignment, Alignment2D, Insets, Offset, Point, Rect},
-        layout::util::get_user_custom_image,
-        notification::{Notification, NotificationLevel},
-        shape::{self, Renderer},
-    },
-};
-
-use crate::ui::{
-    component::{base::AttachType, Label},
-    constant::{screen, HEIGHT, WIDTH},
-    lerp::Lerp,
-    shape::{render_on_canvas, ImageBuffer, Rgb565Canvas},
-    util::animation_disabled,
-};
-
-use super::{
-    super::{
-        cshape::{self, UnlockOverlay},
-        fonts,
-    },
-    constant,
-    theme::{self, GREY_LIGHT, HOMESCREEN_ICON, ICON_KEY},
-    Loader, LoaderMsg,
-};
+use crate::trezorhal::usb::usb_configured;
+use crate::ui::component::base::AttachType;
+use crate::ui::component::{Component, Event, EventCtx, Label, Timer};
+use crate::ui::constant::{screen, HEIGHT, WIDTH};
+use crate::ui::display::image::ImageInfo;
+use crate::ui::display::Color;
+use crate::ui::event::TouchEvent;
+use crate::ui::geometry::{Alignment, Alignment2D, Insets, Offset, Point, Rect};
+use crate::ui::layout::util::get_user_custom_image;
+use crate::ui::lerp::Lerp;
+use crate::ui::notification::{Notification, NotificationLevel};
+use crate::ui::shape::{self, render_on_canvas, ImageBuffer, Renderer, Rgb565Canvas};
+use crate::ui::util::animation_disabled;
 
 const AREA: Rect = constant::screen();
 const AREA_TAP_TO_UNLOCK: Rect =

--- a/core/embed/rust/src/ui/layout_delizia/component/keyboard/bip39.rs
+++ b/core/embed/rust/src/ui/layout_delizia/component/keyboard/bip39.rs
@@ -1,24 +1,18 @@
-use crate::{
-    trezorhal::bip39,
-    ui::{
-        component::{text::common::TextBox, Component, Event, EventCtx},
-        geometry::{Alignment, Alignment2D, Offset, Point, Rect},
-        shape,
-        shape::Renderer,
-    },
+use super::super::super::component::keyboard::common::{
+    render_pending_marker, render_pill_shape, MultiTapKeyboard,
 };
-
-use super::super::{
-    super::component::{
-        keyboard::{
-            common::{render_pending_marker, render_pill_shape, MultiTapKeyboard},
-            mnemonic::{MnemonicInput, MnemonicInputMsg, MNEMONIC_KEY_COUNT},
-        },
-        Button, ButtonMsg,
-    },
-    constant::WIDTH,
-    theme,
+use super::super::super::component::keyboard::mnemonic::{
+    MnemonicInput, MnemonicInputMsg, MNEMONIC_KEY_COUNT,
 };
+use super::super::super::component::{Button, ButtonMsg};
+use super::super::constant::WIDTH;
+use super::super::theme;
+use crate::trezorhal::bip39;
+use crate::ui::component::text::common::TextBox;
+use crate::ui::component::{Component, Event, EventCtx};
+use crate::ui::geometry::{Alignment, Alignment2D, Offset, Point, Rect};
+use crate::ui::shape;
+use crate::ui::shape::Renderer;
 
 const MAX_LENGTH: usize = 8;
 

--- a/core/embed/rust/src/ui/layout_delizia/component/keyboard/common.rs
+++ b/core/embed/rust/src/ui/layout_delizia/component/keyboard/common.rs
@@ -1,14 +1,10 @@
-use crate::{
-    time::Duration,
-    ui::{
-        component::{text::common::TextEdit, Event, EventCtx, Timer},
-        display::{Color, Font},
-        geometry::{Alignment2D, Offset, Point, Rect},
-        shape::{self, Renderer},
-    },
-};
-
 use super::super::ButtonStyle;
+use crate::time::Duration;
+use crate::ui::component::text::common::TextEdit;
+use crate::ui::component::{Event, EventCtx, Timer};
+use crate::ui::display::{Color, Font};
+use crate::ui::geometry::{Alignment2D, Offset, Point, Rect};
+use crate::ui::shape::{self, Renderer};
 
 /// Contains state commonly used in implementations multi-tap keyboards.
 pub struct MultiTapKeyboard {

--- a/core/embed/rust/src/ui/layout_delizia/component/keyboard/mnemonic.rs
+++ b/core/embed/rust/src/ui/layout_delizia/component/keyboard/mnemonic.rs
@@ -1,16 +1,9 @@
-use crate::{
-    strutil::TString,
-    ui::{
-        component::{Component, Event, EventCtx, Label, Maybe},
-        geometry::{Alignment, Grid, Insets, Rect},
-        shape::Renderer,
-    },
-};
-
-use super::super::super::{
-    component::{Button, ButtonMsg},
-    cshape, theme,
-};
+use super::super::super::component::{Button, ButtonMsg};
+use super::super::super::{cshape, theme};
+use crate::strutil::TString;
+use crate::ui::component::{Component, Event, EventCtx, Label, Maybe};
+use crate::ui::geometry::{Alignment, Grid, Insets, Rect};
+use crate::ui::shape::Renderer;
 
 pub const MNEMONIC_KEY_COUNT: usize = 9;
 const BACK_BUTTON_RIGHT_EXPAND: i16 = 24;

--- a/core/embed/rust/src/ui/layout_delizia/component/keyboard/passphrase.rs
+++ b/core/embed/rust/src/ui/layout_delizia/component/keyboard/passphrase.rs
@@ -1,37 +1,27 @@
-use crate::{
-    strutil::{ShortString, TString},
-    time::Duration,
-    ui::{
-        component::{
-            base::ComponentExt,
-            swipe_detect::SwipeConfig,
-            text::{
-                common::TextBox,
-                layout::{LayoutFit, LineBreaking},
-                TextStyle,
-            },
-            Component, Event, EventCtx, Label, Maybe, Never, Pad, Swipe, TextLayout, Timer,
-        },
-        display,
-        event::TouchEvent,
-        geometry::{Alignment, Alignment2D, Direction, Grid, Insets, Rect},
-        shape::{Bar, Renderer, Text, ToifImage},
-        util::{DisplayStyle, Pager},
-    },
-};
-
-use super::super::super::{
-    component::{
-        button::{Button, ButtonContent, ButtonMsg},
-        keyboard::common::{render_pending_marker, MultiTapKeyboard},
-        theme,
-    },
-    constant::SCREEN,
-    cshape,
-};
-
 use core::cell::Cell;
+
 use num_traits::ToPrimitive;
+
+use super::super::super::component::button::{Button, ButtonContent, ButtonMsg};
+use super::super::super::component::keyboard::common::{render_pending_marker, MultiTapKeyboard};
+use super::super::super::component::theme;
+use super::super::super::constant::SCREEN;
+use super::super::super::cshape;
+use crate::strutil::{ShortString, TString};
+use crate::time::Duration;
+use crate::ui::component::base::ComponentExt;
+use crate::ui::component::swipe_detect::SwipeConfig;
+use crate::ui::component::text::common::TextBox;
+use crate::ui::component::text::layout::{LayoutFit, LineBreaking};
+use crate::ui::component::text::TextStyle;
+use crate::ui::component::{
+    Component, Event, EventCtx, Label, Maybe, Never, Pad, Swipe, TextLayout, Timer,
+};
+use crate::ui::display;
+use crate::ui::event::TouchEvent;
+use crate::ui::geometry::{Alignment, Alignment2D, Direction, Grid, Insets, Rect};
+use crate::ui::shape::{Bar, Renderer, Text, ToifImage};
+use crate::ui::util::{DisplayStyle, Pager};
 
 pub enum PassphraseKeyboardMsg {
     Confirmed(ShortString),

--- a/core/embed/rust/src/ui/layout_delizia/component/keyboard/pin.rs
+++ b/core/embed/rust/src/ui/layout_delizia/component/keyboard/pin.rs
@@ -1,33 +1,20 @@
 use core::mem;
 
-use crate::{
-    strutil::{ShortString, TString},
-    time::{Duration, Stopwatch},
-    trezorhal::random,
-    ui::{
-        component::{
-            base::{AttachType, ComponentExt},
-            text::TextStyle,
-            Component, Event, EventCtx, Label, Never, Pad, Timer,
-        },
-        event::TouchEvent,
-        geometry::{Alignment, Alignment2D, Direction, Grid, Insets, Offset, Rect},
-        shape::{Bar, Renderer, Text, ToifImage},
-        util::{animation_disabled, DisplayStyle},
-    },
-};
-
-use super::super::super::{
-    component::{
-        button::{
-            Button, ButtonContent,
-            ButtonMsg::{self, Clicked},
-        },
-        theme,
-    },
-    cshape,
-    fonts::FONT_MONO,
-};
+use super::super::super::component::button::ButtonMsg::{self, Clicked};
+use super::super::super::component::button::{Button, ButtonContent};
+use super::super::super::component::theme;
+use super::super::super::cshape;
+use super::super::super::fonts::FONT_MONO;
+use crate::strutil::{ShortString, TString};
+use crate::time::{Duration, Stopwatch};
+use crate::trezorhal::random;
+use crate::ui::component::base::{AttachType, ComponentExt};
+use crate::ui::component::text::TextStyle;
+use crate::ui::component::{Component, Event, EventCtx, Label, Never, Pad, Timer};
+use crate::ui::event::TouchEvent;
+use crate::ui::geometry::{Alignment, Alignment2D, Direction, Grid, Insets, Offset, Rect};
+use crate::ui::shape::{Bar, Renderer, Text, ToifImage};
+use crate::ui::util::{animation_disabled, DisplayStyle};
 
 pub enum PinKeyboardMsg {
     Confirmed,

--- a/core/embed/rust/src/ui/layout_delizia/component/keyboard/slip39.rs
+++ b/core/embed/rust/src/ui/layout_delizia/component/keyboard/slip39.rs
@@ -1,30 +1,21 @@
 use core::iter;
 
-use crate::{
-    strutil::ShortString,
-    trezorhal::slip39,
-    ui::{
-        component::{
-            text::common::{TextBox, TextEdit},
-            Component, Event, EventCtx,
-        },
-        constant::WIDTH,
-        geometry::{Alignment, Alignment2D, Offset, Point, Rect},
-        shape::{self, Renderer},
-        util::ResultExt,
-    },
+use super::super::super::component::keyboard::common::{
+    render_pending_marker, render_pill_shape, MultiTapKeyboard,
 };
-
-use super::super::{
-    super::component::{
-        keyboard::{
-            common::{render_pending_marker, render_pill_shape, MultiTapKeyboard},
-            mnemonic::{MnemonicInput, MnemonicInputMsg, MNEMONIC_KEY_COUNT},
-        },
-        Button, ButtonContent, ButtonMsg,
-    },
-    theme,
+use super::super::super::component::keyboard::mnemonic::{
+    MnemonicInput, MnemonicInputMsg, MNEMONIC_KEY_COUNT,
 };
+use super::super::super::component::{Button, ButtonContent, ButtonMsg};
+use super::super::theme;
+use crate::strutil::ShortString;
+use crate::trezorhal::slip39;
+use crate::ui::component::text::common::{TextBox, TextEdit};
+use crate::ui::component::{Component, Event, EventCtx};
+use crate::ui::constant::WIDTH;
+use crate::ui::geometry::{Alignment, Alignment2D, Offset, Point, Rect};
+use crate::ui::shape::{self, Renderer};
+use crate::ui::util::ResultExt;
 
 const MAX_LENGTH: usize = 8;
 

--- a/core/embed/rust/src/ui/layout_delizia/component/keyboard/word_count.rs
+++ b/core/embed/rust/src/ui/layout_delizia/component/keyboard/word_count.rs
@@ -1,18 +1,12 @@
-use crate::{
-    strutil::TString,
-    ui::{
-        component::{paginated::SinglePage, Component, Event, EventCtx},
-        geometry::{Alignment, Grid, GridCellSpan, Rect},
-        shape::Renderer,
-    },
-};
-
 use heapless::Vec;
 
-use super::super::super::{
-    component::button::{Button, ButtonMsg},
-    cshape, theme,
-};
+use super::super::super::component::button::{Button, ButtonMsg};
+use super::super::super::{cshape, theme};
+use crate::strutil::TString;
+use crate::ui::component::paginated::SinglePage;
+use crate::ui::component::{Component, Event, EventCtx};
+use crate::ui::geometry::{Alignment, Grid, GridCellSpan, Rect};
+use crate::ui::shape::Renderer;
 
 #[derive(Copy, Clone)]
 pub enum SelectWordCountMsg {

--- a/core/embed/rust/src/ui/layout_delizia/component/loader.rs
+++ b/core/embed/rust/src/ui/layout_delizia/component/loader.rs
@@ -1,21 +1,15 @@
+use super::super::cshape::{render_loader, LoaderRange};
+use super::{constant, theme};
+use crate::time::{Duration, Instant};
 #[cfg(feature = "haptic")]
 use crate::trezorhal::haptic::{play, HapticEffect};
-use crate::{
-    time::{Duration, Instant},
-    ui::{
-        animation::Animation,
-        component::{Component, Event, EventCtx, Pad},
-        display::{self, toif::Icon, Color, LOADER_MAX},
-        geometry::{Alignment2D, Offset, Rect},
-        shape::{self, Renderer},
-        util::animation_disabled,
-    },
-};
-
-use super::{
-    super::cshape::{render_loader, LoaderRange},
-    constant, theme,
-};
+use crate::ui::animation::Animation;
+use crate::ui::component::{Component, Event, EventCtx, Pad};
+use crate::ui::display::toif::Icon;
+use crate::ui::display::{self, Color, LOADER_MAX};
+use crate::ui::geometry::{Alignment2D, Offset, Rect};
+use crate::ui::shape::{self, Renderer};
+use crate::ui::util::animation_disabled;
 
 const GROWING_DURATION_MS: u32 = 1000;
 const SHRINKING_DURATION_MS: u32 = 500;

--- a/core/embed/rust/src/ui/layout_delizia/component/number_input.rs
+++ b/core/embed/rust/src/ui/layout_delizia/component/number_input.rs
@@ -1,19 +1,13 @@
-use crate::{
-    error::Error,
-    strutil::{self, TString},
-    ui::{
-        component::{
-            paginated::SinglePage,
-            text::paragraphs::{Paragraph, Paragraphs},
-            Component, Event, EventCtx, Pad,
-        },
-        event::TouchEvent,
-        geometry::{Alignment, Grid, Insets, Offset, Rect},
-        shape::{self, Renderer},
-    },
-};
-
-use super::{super::fonts::FONT_DEMIBOLD, theme, Button, ButtonMsg};
+use super::super::fonts::FONT_DEMIBOLD;
+use super::{theme, Button, ButtonMsg};
+use crate::error::Error;
+use crate::strutil::{self, TString};
+use crate::ui::component::paginated::SinglePage;
+use crate::ui::component::text::paragraphs::{Paragraph, Paragraphs};
+use crate::ui::component::{Component, Event, EventCtx, Pad};
+use crate::ui::event::TouchEvent;
+use crate::ui::geometry::{Alignment, Grid, Insets, Offset, Rect};
+use crate::ui::shape::{self, Renderer};
 
 pub enum NumberInputDialogMsg {
     Changed(u16),

--- a/core/embed/rust/src/ui/layout_delizia/component/number_input_slider.rs
+++ b/core/embed/rust/src/ui/layout_delizia/component/number_input_slider.rs
@@ -1,14 +1,11 @@
 use super::theme;
-use crate::{
-    strutil::ShortString,
-    ui::{
-        component::{paginated::SinglePage, Component, Event, EventCtx},
-        constant::screen,
-        event::TouchEvent,
-        geometry::{Alignment, Alignment2D, Insets, Offset, Point, Rect},
-        shape::{self, Renderer},
-    },
-};
+use crate::strutil::ShortString;
+use crate::ui::component::paginated::SinglePage;
+use crate::ui::component::{Component, Event, EventCtx};
+use crate::ui::constant::screen;
+use crate::ui::event::TouchEvent;
+use crate::ui::geometry::{Alignment, Alignment2D, Insets, Offset, Point, Rect};
+use crate::ui::shape::{self, Renderer};
 
 pub enum NumberInputSliderDialogMsg {
     Changed(u16),

--- a/core/embed/rust/src/ui/layout_delizia/component/progress.rs
+++ b/core/embed/rust/src/ui/layout_delizia/component/progress.rs
@@ -1,24 +1,14 @@
 use core::mem;
 
-use crate::{
-    strutil::TString,
-    ui::{
-        component::{
-            text::paragraphs::{Paragraph, Paragraphs},
-            Component, Event, EventCtx, Label, Never, Pad,
-        },
-        display::LOADER_MAX,
-        geometry::{Insets, Offset, Rect},
-        shape::Renderer,
-        util::animation_disabled,
-    },
-};
-
-use super::super::{
-    constant,
-    cshape::{render_loader, LoaderRange},
-    fonts, theme,
-};
+use super::super::cshape::{render_loader, LoaderRange};
+use super::super::{constant, fonts, theme};
+use crate::strutil::TString;
+use crate::ui::component::text::paragraphs::{Paragraph, Paragraphs};
+use crate::ui::component::{Component, Event, EventCtx, Label, Never, Pad};
+use crate::ui::display::LOADER_MAX;
+use crate::ui::geometry::{Insets, Offset, Rect};
+use crate::ui::shape::Renderer;
+use crate::ui::util::animation_disabled;
 
 pub struct Progress {
     title: Label<'static>,

--- a/core/embed/rust/src/ui/layout_delizia/component/prompt_screen.rs
+++ b/core/embed/rust/src/ui/layout_delizia/component/prompt_screen.rs
@@ -1,10 +1,9 @@
-use crate::ui::{
-    component::{paginated::SinglePage, Component, Event, EventCtx},
-    geometry::Rect,
-    shape::Renderer,
-};
-
-use super::{super::theme, BinarySelection, ButtonContent, HoldToConfirm, TapToConfirm};
+use super::super::theme;
+use super::{BinarySelection, ButtonContent, HoldToConfirm, TapToConfirm};
+use crate::ui::component::paginated::SinglePage;
+use crate::ui::component::{Component, Event, EventCtx};
+use crate::ui::geometry::Rect;
+use crate::ui::shape::Renderer;
 
 /// Component requesting an action from a user. Most typically embedded as a
 /// content of a Frame. Options are:

--- a/core/embed/rust/src/ui/layout_delizia/component/result.rs
+++ b/core/embed/rust/src/ui/layout_delizia/component/result.rs
@@ -1,19 +1,13 @@
-use crate::{
-    strutil::TString,
-    ui::{
-        component::{text::TextStyle, Component, Event, EventCtx, Label, Never, Pad},
-        constant::screen,
-        display::{Color, Icon},
-        geometry::{Alignment2D, Insets, Offset, Point, Rect},
-        shape::{self, Renderer},
-    },
-};
-
-use super::{
-    super::fonts,
-    constant::WIDTH,
-    theme::{FG, RESULT_FOOTER_START, RESULT_PADDING},
-};
+use super::super::fonts;
+use super::constant::WIDTH;
+use super::theme::{FG, RESULT_FOOTER_START, RESULT_PADDING};
+use crate::strutil::TString;
+use crate::ui::component::text::TextStyle;
+use crate::ui::component::{Component, Event, EventCtx, Label, Never, Pad};
+use crate::ui::constant::screen;
+use crate::ui::display::{Color, Icon};
+use crate::ui::geometry::{Alignment2D, Insets, Offset, Point, Rect};
+use crate::ui::shape::{self, Renderer};
 
 const MESSAGE_AREA_START: i16 = 97;
 const ICON_CENTER_Y: i16 = 62;

--- a/core/embed/rust/src/ui/layout_delizia/component/share_words.rs
+++ b/core/embed/rust/src/ui/layout_delizia/component/share_words.rs
@@ -1,21 +1,17 @@
-use crate::{
-    strutil::TString,
-    translations::TR,
-    ui::{
-        component::{
-            base::AttachType, paginated::Paginate, text::TextStyle, Component, Event, EventCtx,
-            Never,
-        },
-        event::SwipeEvent,
-        geometry::{Alignment, Alignment2D, Direction, Insets, Offset, Rect},
-        shape::{self, Renderer},
-        util::Pager,
-    },
-};
-
 use heapless::Vec;
 
-use super::{super::component::swipe_content::SwipeAttachAnimation, theme};
+use super::super::component::swipe_content::SwipeAttachAnimation;
+use super::theme;
+use crate::strutil::TString;
+use crate::translations::TR;
+use crate::ui::component::base::AttachType;
+use crate::ui::component::paginated::Paginate;
+use crate::ui::component::text::TextStyle;
+use crate::ui::component::{Component, Event, EventCtx, Never};
+use crate::ui::event::SwipeEvent;
+use crate::ui::geometry::{Alignment, Alignment2D, Direction, Insets, Offset, Rect};
+use crate::ui::shape::{self, Renderer};
+use crate::ui::util::Pager;
 
 const MAX_WORDS: usize = 33; // super-shamir has 33 words, all other have less
 

--- a/core/embed/rust/src/ui/layout_delizia/component/status_screen.rs
+++ b/core/embed/rust/src/ui/layout_delizia/component/status_screen.rs
@@ -1,17 +1,14 @@
 use super::theme;
-use crate::{
-    strutil::TString,
-    time::{Duration, Stopwatch},
-    ui::{
-        component::{paginated::SinglePage, Component, Event, EventCtx, Label, Timeout},
-        constant::screen,
-        display::{Color, Icon},
-        geometry::{Alignment, Alignment2D, Insets, Point, Rect},
-        lerp::Lerp,
-        shape::{self, Renderer},
-        util::animation_disabled,
-    },
-};
+use crate::strutil::TString;
+use crate::time::{Duration, Stopwatch};
+use crate::ui::component::paginated::SinglePage;
+use crate::ui::component::{Component, Event, EventCtx, Label, Timeout};
+use crate::ui::constant::screen;
+use crate::ui::display::{Color, Icon};
+use crate::ui::geometry::{Alignment, Alignment2D, Insets, Point, Rect};
+use crate::ui::lerp::Lerp;
+use crate::ui::shape::{self, Renderer};
+use crate::ui::util::animation_disabled;
 
 const ANIMATION_TIME_MS: u32 = 1200;
 const TIMEOUT_MS: u32 = ANIMATION_TIME_MS + 2000;

--- a/core/embed/rust/src/ui/layout_delizia/component/swipe_content.rs
+++ b/core/embed/rust/src/ui/layout_delizia/component/swipe_content.rs
@@ -1,19 +1,13 @@
-use crate::{
-    time::{Duration, Stopwatch},
-    ui::{
-        component::{
-            base::{AttachType, EventPropagation},
-            Component, Event, EventCtx, Paginate,
-        },
-        constant::screen,
-        display::Color,
-        event::SwipeEvent,
-        geometry::{Direction, Offset, Rect},
-        lerp::Lerp,
-        shape::{self, Renderer},
-        util::{animation_disabled, Pager},
-    },
-};
+use crate::time::{Duration, Stopwatch};
+use crate::ui::component::base::{AttachType, EventPropagation};
+use crate::ui::component::{Component, Event, EventCtx, Paginate};
+use crate::ui::constant::screen;
+use crate::ui::display::Color;
+use crate::ui::event::SwipeEvent;
+use crate::ui::geometry::{Direction, Offset, Rect};
+use crate::ui::lerp::Lerp;
+use crate::ui::shape::{self, Renderer};
+use crate::ui::util::{animation_disabled, Pager};
 
 #[derive(Default, Clone)]
 pub struct SwipeAttachAnimation {

--- a/core/embed/rust/src/ui/layout_delizia/component/swipe_up_screen.rs
+++ b/core/embed/rust/src/ui/layout_delizia/component/swipe_up_screen.rs
@@ -1,10 +1,8 @@
-use crate::ui::{
-    component::{Component, Event, EventCtx, SwipeDetect},
-    event::SwipeEvent,
-    flow::Swipable,
-    geometry::Rect,
-    shape::Renderer,
-};
+use crate::ui::component::{Component, Event, EventCtx, SwipeDetect};
+use crate::ui::event::SwipeEvent;
+use crate::ui::flow::Swipable;
+use crate::ui::geometry::Rect;
+use crate::ui::shape::Renderer;
 
 /// Wrapper component adding "swipe up" handling to `content`.
 pub struct SwipeUpScreen<T> {

--- a/core/embed/rust/src/ui/layout_delizia/component/tap_to_confirm.rs
+++ b/core/embed/rust/src/ui/layout_delizia/component/tap_to_confirm.rs
@@ -1,20 +1,16 @@
-use crate::{
-    time::Duration,
-    ui::{
-        component::{Component, Event, EventCtx},
-        display::{toif::Icon, Color},
-        geometry::{Alignment2D, Offset, Rect},
-        lerp::Lerp,
-        shape,
-        shape::Renderer,
-        util::animation_disabled,
-    },
-};
+use pareen;
 
 use super::{theme, Button, ButtonContent, ButtonMsg};
-
-use crate::{time::Stopwatch, ui::constant::screen};
-use pareen;
+use crate::time::{Duration, Stopwatch};
+use crate::ui::component::{Component, Event, EventCtx};
+use crate::ui::constant::screen;
+use crate::ui::display::toif::Icon;
+use crate::ui::display::Color;
+use crate::ui::geometry::{Alignment2D, Offset, Rect};
+use crate::ui::lerp::Lerp;
+use crate::ui::shape;
+use crate::ui::shape::Renderer;
+use crate::ui::util::animation_disabled;
 
 #[derive(Default, Clone)]
 struct TapToConfirmAnim {

--- a/core/embed/rust/src/ui/layout_delizia/component/trade_screen.rs
+++ b/core/embed/rust/src/ui/layout_delizia/component/trade_screen.rs
@@ -1,13 +1,9 @@
-use crate::{
-    strutil::TString,
-    ui::{
-        component::{paginated::SinglePage, Bar, Component, Event, EventCtx, Label, Never},
-        geometry::{Insets, Rect},
-        shape::Renderer,
-    },
-};
-
 use super::super::theme;
+use crate::strutil::TString;
+use crate::ui::component::paginated::SinglePage;
+use crate::ui::component::{Bar, Component, Event, EventCtx, Label, Never};
+use crate::ui::geometry::{Insets, Rect};
+use crate::ui::shape::Renderer;
 
 pub struct TradeScreen {
     sell_amount: Option<Label<'static>>,

--- a/core/embed/rust/src/ui/layout_delizia/component/updatable_more_info.rs
+++ b/core/embed/rust/src/ui/layout_delizia/component/updatable_more_info.rs
@@ -1,17 +1,10 @@
-use crate::{
-    strutil::TString,
-    ui::{
-        component::{
-            paginated::SinglePage,
-            text::paragraphs::{Paragraph, Paragraphs},
-            Component, Event, EventCtx, Never,
-        },
-        geometry::Rect,
-        shape::Renderer,
-    },
-};
-
 use super::theme;
+use crate::strutil::TString;
+use crate::ui::component::paginated::SinglePage;
+use crate::ui::component::text::paragraphs::{Paragraph, Paragraphs};
+use crate::ui::component::{Component, Event, EventCtx, Never};
+use crate::ui::geometry::Rect;
+use crate::ui::shape::Renderer;
 
 pub struct UpdatableMoreInfo<F>
 where

--- a/core/embed/rust/src/ui/layout_delizia/component/vertical_menu.rs
+++ b/core/embed/rust/src/ui/layout_delizia/component/vertical_menu.rs
@@ -1,27 +1,18 @@
 use heapless::Vec;
 
-use crate::{
-    strutil::TString,
-    time::{Duration, Stopwatch},
-    ui::{
-        component::{
-            base::{AttachType, Component},
-            paginated::SinglePage,
-            Event, EventCtx, Paginate,
-        },
-        constant::screen,
-        display::{Color, Icon},
-        geometry::{Direction, Offset, Rect},
-        lerp::Lerp,
-        shape::{Bar, Renderer},
-        util::{animation_disabled, Pager},
-    },
-};
-
-use super::{
-    super::component::button::{Button, ButtonContent, ButtonMsg, IconText},
-    theme,
-};
+use super::super::component::button::{Button, ButtonContent, ButtonMsg, IconText};
+use super::theme;
+use crate::strutil::TString;
+use crate::time::{Duration, Stopwatch};
+use crate::ui::component::base::{AttachType, Component};
+use crate::ui::component::paginated::SinglePage;
+use crate::ui::component::{Event, EventCtx, Paginate};
+use crate::ui::constant::screen;
+use crate::ui::display::{Color, Icon};
+use crate::ui::geometry::{Direction, Offset, Rect};
+use crate::ui::lerp::Lerp;
+use crate::ui::shape::{Bar, Renderer};
+use crate::ui::util::{animation_disabled, Pager};
 
 pub enum VerticalMenuChoiceMsg {
     Selected(usize),

--- a/core/embed/rust/src/ui/layout_delizia/component/welcome_screen.rs
+++ b/core/embed/rust/src/ui/layout_delizia/component/welcome_screen.rs
@@ -1,10 +1,8 @@
-use crate::ui::{
-    component::{Component, Event, EventCtx, Never},
-    geometry::{Alignment, Alignment2D, Offset, Rect},
-    shape::{self, Renderer},
-};
-
-use super::{super::fonts, theme};
+use super::super::fonts;
+use super::theme;
+use crate::ui::component::{Component, Event, EventCtx, Never};
+use crate::ui::geometry::{Alignment, Alignment2D, Offset, Rect};
+use crate::ui::shape::{self, Renderer};
 
 const TEXT_BOTTOM_MARGIN: i16 = 54;
 const ICON_TOP_MARGIN: i16 = 48;

--- a/core/embed/rust/src/ui/layout_delizia/component_msg_obj.rs
+++ b/core/embed/rust/src/ui/layout_delizia/component_msg_obj.rs
@@ -6,24 +6,19 @@ use super::component::{
     PromptScreen, SelectWordCount, SelectWordCountMsg, StatusScreen, SwipeContent, SwipeUpScreen,
     SwipeUpScreenMsg, VerticalMenu, VerticalMenuChoiceMsg,
 };
-use crate::{
-    error::Error,
-    micropython::{gc::GcBox, obj::Obj},
-    ui::{
-        component::{paginated::Paginate, Component, Never},
-        flow::Swipable,
-        layout::{
-            obj::ComponentMsgObj,
-            result::{CANCELLED, CONFIRMED},
-        },
-    },
-};
-
+use crate::error::Error;
+use crate::micropython::gc::GcBox;
+use crate::micropython::obj::Obj;
+use crate::ui::component::paginated::Paginate;
 #[cfg(not(feature = "clippy"))]
 use crate::ui::component::{
     text::paragraphs::{ParagraphSource, Paragraphs},
     Timeout,
 };
+use crate::ui::component::{Component, Never};
+use crate::ui::flow::Swipable;
+use crate::ui::layout::obj::ComponentMsgObj;
+use crate::ui::layout::result::{CANCELLED, CONFIRMED};
 
 impl TryFrom<SelectWordCountMsg> for Obj {
     type Error = Error;

--- a/core/embed/rust/src/ui/layout_delizia/constant.rs
+++ b/core/embed/rust/src/ui/layout_delizia/constant.rs
@@ -1,6 +1,5 @@
-use crate::ui::geometry::{Offset, Point, Rect};
-
 use crate::trezorhal::display::{DISPLAY_RESX, DISPLAY_RESY};
+use crate::ui::geometry::{Offset, Point, Rect};
 
 pub const WIDTH: i16 = DISPLAY_RESX as _;
 pub const HEIGHT: i16 = DISPLAY_RESY as _;

--- a/core/embed/rust/src/ui/layout_delizia/cshape/keyboard_overlay.rs
+++ b/core/embed/rust/src/ui/layout_delizia/cshape/keyboard_overlay.rs
@@ -1,10 +1,8 @@
-use crate::ui::{
-    display::Color,
-    geometry::Rect,
-    shape::{Canvas, DrawingCache, Mono8Canvas, Renderer, Shape, ShapeClone},
-};
-
 use without_alloc::alloc::LocalAllocLeakExt;
+
+use crate::ui::display::Color;
+use crate::ui::geometry::Rect;
+use crate::ui::shape::{Canvas, DrawingCache, Mono8Canvas, Renderer, Shape, ShapeClone};
 
 /// A special shape for rendering keyboard overlay.
 /// Makes the corner buttons have rounded corners.

--- a/core/embed/rust/src/ui/layout_delizia/cshape/loader.rs
+++ b/core/embed/rust/src/ui/layout_delizia/cshape/loader.rs
@@ -1,6 +1,8 @@
-use crate::ui::{display::Color, geometry::Point, shape, shape::Renderer};
-
 use super::super::constant;
+use crate::ui::display::Color;
+use crate::ui::geometry::Point;
+use crate::ui::shape;
+use crate::ui::shape::Renderer;
 
 pub enum LoaderRange {
     Full,

--- a/core/embed/rust/src/ui/layout_delizia/cshape/mod.rs
+++ b/core/embed/rust/src/ui/layout_delizia/cshape/mod.rs
@@ -7,9 +7,7 @@ mod unlock_overlay;
 mod keyboard_overlay;
 
 #[cfg(feature = "ui_overlay")]
-pub use unlock_overlay::UnlockOverlay;
-
-#[cfg(feature = "ui_overlay")]
 pub use keyboard_overlay::KeyboardOverlay;
-
 pub use loader::{render_loader, LoaderRange};
+#[cfg(feature = "ui_overlay")]
+pub use unlock_overlay::UnlockOverlay;

--- a/core/embed/rust/src/ui/layout_delizia/cshape/unlock_overlay.rs
+++ b/core/embed/rust/src/ui/layout_delizia/cshape/unlock_overlay.rs
@@ -1,10 +1,8 @@
-use crate::ui::{
-    display::Color,
-    geometry::{Offset, Point, Rect},
-    shape::{Canvas, DrawingCache, Mono8Canvas, Renderer, Shape, ShapeClone},
-};
-
 use without_alloc::alloc::LocalAllocLeakExt;
+
+use crate::ui::display::Color;
+use crate::ui::geometry::{Offset, Point, Rect};
+use crate::ui::shape::{Canvas, DrawingCache, Mono8Canvas, Renderer, Shape, ShapeClone};
 
 /// A special shape for rendering 7 differently rotated circular
 /// sectors on 5 concentric circles, used as an overlay on the background

--- a/core/embed/rust/src/ui/layout_delizia/flow/confirm_action.rs
+++ b/core/embed/rust/src/ui/layout_delizia/flow/confirm_action.rs
@@ -1,30 +1,21 @@
 use heapless::Vec;
 
-use crate::{
-    error::{self, Error},
-    maybe_trace::MaybeTrace,
-    strutil::TString,
-    translations::TR,
-    ui::{
-        component::{
-            swipe_detect::SwipeSettings,
-            text::paragraphs::{Paragraph, ParagraphSource, ParagraphVecShort, VecExt},
-            Component, ComponentExt, EventCtx, Paginate,
-        },
-        flow::{
-            base::{Decision, DecisionBuilder as _},
-            FlowController, FlowMsg, SwipeFlow, SwipePage,
-        },
-        geometry::Direction,
-    },
+use super::super::component::{
+    Footer, Frame, Header, PromptScreen, SwipeContent, VerticalMenu, VerticalMenuChoiceMsg,
 };
-
-use super::super::{
-    component::{
-        Footer, Frame, Header, PromptScreen, SwipeContent, VerticalMenu, VerticalMenuChoiceMsg,
-    },
-    theme,
+use super::super::theme;
+use crate::error::{self, Error};
+use crate::maybe_trace::MaybeTrace;
+use crate::strutil::TString;
+use crate::translations::TR;
+use crate::ui::component::swipe_detect::SwipeSettings;
+use crate::ui::component::text::paragraphs::{
+    Paragraph, ParagraphSource, ParagraphVecShort, VecExt,
 };
+use crate::ui::component::{Component, ComponentExt, EventCtx, Paginate};
+use crate::ui::flow::base::{Decision, DecisionBuilder as _};
+use crate::ui::flow::{FlowController, FlowMsg, SwipeFlow, SwipePage};
+use crate::ui::geometry::Direction;
 
 const MENU_ITEM_CANCEL: usize = 0;
 const MENU_ITEM_INFO: usize = 1;

--- a/core/embed/rust/src/ui/layout_delizia/flow/confirm_fido.rs
+++ b/core/embed/rust/src/ui/layout_delizia/flow/confirm_fido.rs
@@ -1,32 +1,22 @@
-use crate::{
-    error,
-    micropython::{gc::Gc, list::List},
-    strutil::TString,
-    translations::TR,
-    ui::{
-        component::{
-            paginated::Paginate as _,
-            swipe_detect::SwipeSettings,
-            text::paragraphs::{Paragraph, Paragraphs},
-            EventCtx,
-        },
-        flow::{
-            base::{Decision, DecisionBuilder as _},
-            FlowController, FlowMsg, SwipeFlow, SwipePage,
-        },
-        geometry::Direction,
-    },
-};
-
-use super::super::{
-    component::{
-        FidoCredential, Footer, Frame, Header, PagedVerticalMenu, PromptScreen, SwipeContent,
-        VerticalMenu,
-    },
-    theme,
-};
-
 use core::sync::atomic::{AtomicBool, AtomicUsize, Ordering};
+
+use super::super::component::{
+    FidoCredential, Footer, Frame, Header, PagedVerticalMenu, PromptScreen, SwipeContent,
+    VerticalMenu,
+};
+use super::super::theme;
+use crate::error;
+use crate::micropython::gc::Gc;
+use crate::micropython::list::List;
+use crate::strutil::TString;
+use crate::translations::TR;
+use crate::ui::component::paginated::Paginate as _;
+use crate::ui::component::swipe_detect::SwipeSettings;
+use crate::ui::component::text::paragraphs::{Paragraph, Paragraphs};
+use crate::ui::component::EventCtx;
+use crate::ui::flow::base::{Decision, DecisionBuilder as _};
+use crate::ui::flow::{FlowController, FlowMsg, SwipeFlow, SwipePage};
+use crate::ui::geometry::Direction;
 
 #[derive(Copy, Clone, PartialEq, Eq)]
 pub enum ConfirmFido {

--- a/core/embed/rust/src/ui/layout_delizia/flow/confirm_firmware_update.rs
+++ b/core/embed/rust/src/ui/layout_delizia/flow/confirm_firmware_update.rs
@@ -1,24 +1,13 @@
-use crate::{
-    error,
-    strutil::TString,
-    translations::TR,
-    ui::{
-        component::{
-            swipe_detect::SwipeSettings,
-            text::paragraphs::{Paragraph, Paragraphs},
-        },
-        flow::{
-            base::{Decision, DecisionBuilder as _},
-            FlowController, FlowMsg, SwipeFlow,
-        },
-        geometry::Direction,
-    },
-};
-
-use super::super::{
-    component::{Frame, Header, PromptScreen, SwipeContent, VerticalMenu},
-    theme,
-};
+use super::super::component::{Frame, Header, PromptScreen, SwipeContent, VerticalMenu};
+use super::super::theme;
+use crate::error;
+use crate::strutil::TString;
+use crate::translations::TR;
+use crate::ui::component::swipe_detect::SwipeSettings;
+use crate::ui::component::text::paragraphs::{Paragraph, Paragraphs};
+use crate::ui::flow::base::{Decision, DecisionBuilder as _};
+use crate::ui::flow::{FlowController, FlowMsg, SwipeFlow};
+use crate::ui::geometry::Direction;
 
 #[derive(Copy, Clone, PartialEq, Eq)]
 pub enum ConfirmFirmwareUpdate {

--- a/core/embed/rust/src/ui/layout_delizia/flow/confirm_homescreen.rs
+++ b/core/embed/rust/src/ui/layout_delizia/flow/confirm_homescreen.rs
@@ -1,18 +1,12 @@
-use crate::{
-    error,
-    strutil::TString,
-    translations::TR,
-    ui::{
-        component::{swipe_detect::SwipeSettings, CachedJpeg, ComponentExt},
-        flow::{
-            base::{Decision, DecisionBuilder},
-            FlowController, FlowMsg, SwipeFlow,
-        },
-        geometry::Direction,
-    },
-};
-
 use super::super::component::{Frame, Header, PromptScreen, SwipeContent, VerticalMenu};
+use crate::error;
+use crate::strutil::TString;
+use crate::translations::TR;
+use crate::ui::component::swipe_detect::SwipeSettings;
+use crate::ui::component::{CachedJpeg, ComponentExt};
+use crate::ui::flow::base::{Decision, DecisionBuilder};
+use crate::ui::flow::{FlowController, FlowMsg, SwipeFlow};
+use crate::ui::geometry::Direction;
 
 /// Flow for a setting of homescreen wallpaper showing a preview of the image,
 /// menu to cancel and tap to confirm prompt.

--- a/core/embed/rust/src/ui/layout_delizia/flow/confirm_reset.rs
+++ b/core/embed/rust/src/ui/layout_delizia/flow/confirm_reset.rs
@@ -1,26 +1,15 @@
-use crate::{
-    error,
-    strutil::TString,
-    translations::TR,
-    ui::{
-        button_request::ButtonRequestCode,
-        component::{
-            swipe_detect::SwipeSettings,
-            text::paragraphs::{Paragraph, ParagraphSource, ParagraphVecShort},
-            ButtonRequestExt,
-        },
-        flow::{
-            base::{Decision, DecisionBuilder as _},
-            FlowController, FlowMsg, SwipeFlow,
-        },
-        geometry::Direction,
-    },
-};
-
-use super::super::{
-    component::{Frame, Header, PromptScreen, SwipeContent, VerticalMenu},
-    theme,
-};
+use super::super::component::{Frame, Header, PromptScreen, SwipeContent, VerticalMenu};
+use super::super::theme;
+use crate::error;
+use crate::strutil::TString;
+use crate::translations::TR;
+use crate::ui::button_request::ButtonRequestCode;
+use crate::ui::component::swipe_detect::SwipeSettings;
+use crate::ui::component::text::paragraphs::{Paragraph, ParagraphSource, ParagraphVecShort};
+use crate::ui::component::ButtonRequestExt;
+use crate::ui::flow::base::{Decision, DecisionBuilder as _};
+use crate::ui::flow::{FlowController, FlowMsg, SwipeFlow};
+use crate::ui::geometry::Direction;
 
 #[derive(Copy, Clone, PartialEq, Eq)]
 pub enum ConfirmResetCreate {

--- a/core/embed/rust/src/ui/layout_delizia/flow/confirm_set_new_code.rs
+++ b/core/embed/rust/src/ui/layout_delizia/flow/confirm_set_new_code.rs
@@ -1,24 +1,15 @@
-use crate::{
-    error,
-    strutil::TString,
-    translations::TR,
-    ui::{
-        component::{
-            swipe_detect::SwipeSettings,
-            text::paragraphs::{Paragraph, ParagraphSource, ParagraphVecShort, Paragraphs},
-        },
-        flow::{
-            base::{Decision, DecisionBuilder as _},
-            FlowController, FlowMsg, SwipeFlow,
-        },
-        geometry::Direction,
-    },
+use super::super::component::{Frame, Header, PromptScreen, SwipeContent, VerticalMenu};
+use super::super::theme;
+use crate::error;
+use crate::strutil::TString;
+use crate::translations::TR;
+use crate::ui::component::swipe_detect::SwipeSettings;
+use crate::ui::component::text::paragraphs::{
+    Paragraph, ParagraphSource, ParagraphVecShort, Paragraphs,
 };
-
-use super::super::{
-    component::{Frame, Header, PromptScreen, SwipeContent, VerticalMenu},
-    theme,
-};
+use crate::ui::flow::base::{Decision, DecisionBuilder as _};
+use crate::ui::flow::{FlowController, FlowMsg, SwipeFlow};
+use crate::ui::geometry::Direction;
 
 #[derive(Copy, Clone, PartialEq, Eq)]
 pub enum SetNewCode {

--- a/core/embed/rust/src/ui/layout_delizia/flow/confirm_summary.rs
+++ b/core/embed/rust/src/ui/layout_delizia/flow/confirm_summary.rs
@@ -1,28 +1,18 @@
 use heapless::Vec;
 
-use crate::{
-    error,
-    strutil::TString,
-    translations::TR,
-    ui::{
-        component::{swipe_detect::SwipeSettings, ComponentExt},
-        flow::{
-            base::{Decision, DecisionBuilder as _},
-            FlowController, FlowMsg, SwipeFlow,
-        },
-        geometry::Direction,
-    },
+use super::super::component::{
+    Frame, Header, PromptScreen, SwipeContent, VerticalMenu, VerticalMenuChoiceMsg,
 };
-
-use super::{
-    super::{
-        component::{
-            Frame, Header, PromptScreen, SwipeContent, VerticalMenu, VerticalMenuChoiceMsg,
-        },
-        theme,
-    },
-    util::{dummy_page, ShowInfoParams},
-};
+use super::super::theme;
+use super::util::{dummy_page, ShowInfoParams};
+use crate::error;
+use crate::strutil::TString;
+use crate::translations::TR;
+use crate::ui::component::swipe_detect::SwipeSettings;
+use crate::ui::component::ComponentExt;
+use crate::ui::flow::base::{Decision, DecisionBuilder as _};
+use crate::ui::flow::{FlowController, FlowMsg, SwipeFlow};
+use crate::ui::geometry::Direction;
 
 const MENU_ITEM_CANCEL: usize = 0;
 const MENU_ITEM_EXTRA_INFO: usize = 1;

--- a/core/embed/rust/src/ui/layout_delizia/flow/continue_recovery_homepage.rs
+++ b/core/embed/rust/src/ui/layout_delizia/flow/continue_recovery_homepage.rs
@@ -1,30 +1,19 @@
-use crate::{
-    error,
-    strutil::TString,
-    translations::TR,
-    ui::{
-        button_request::{ButtonRequest, ButtonRequestCode},
-        component::{
-            button_request::ButtonRequestExt,
-            swipe_detect::SwipeSettings,
-            text::paragraphs::{
-                Paragraph, ParagraphSource, ParagraphVecLong, ParagraphVecShort, Paragraphs, VecExt,
-            },
-            ComponentExt, EventCtx, Paginate as _,
-        },
-        flow::{
-            base::{Decision, DecisionBuilder as _},
-            FlowController, FlowMsg, SwipeFlow, SwipePage,
-        },
-        geometry::Direction,
-        layout::util::RecoveryType,
-    },
+use super::super::component::{Footer, Frame, Header, PromptScreen, SwipeContent, VerticalMenu};
+use super::super::theme;
+use crate::error;
+use crate::strutil::TString;
+use crate::translations::TR;
+use crate::ui::button_request::{ButtonRequest, ButtonRequestCode};
+use crate::ui::component::button_request::ButtonRequestExt;
+use crate::ui::component::swipe_detect::SwipeSettings;
+use crate::ui::component::text::paragraphs::{
+    Paragraph, ParagraphSource, ParagraphVecLong, ParagraphVecShort, Paragraphs, VecExt,
 };
-
-use super::super::{
-    component::{Footer, Frame, Header, PromptScreen, SwipeContent, VerticalMenu},
-    theme,
-};
+use crate::ui::component::{ComponentExt, EventCtx, Paginate as _};
+use crate::ui::flow::base::{Decision, DecisionBuilder as _};
+use crate::ui::flow::{FlowController, FlowMsg, SwipeFlow, SwipePage};
+use crate::ui::geometry::Direction;
+use crate::ui::layout::util::RecoveryType;
 
 #[derive(Copy, Clone, PartialEq, Eq)]
 pub enum ContinueRecoveryBeforeShares {

--- a/core/embed/rust/src/ui/layout_delizia/flow/prompt_backup.rs
+++ b/core/embed/rust/src/ui/layout_delizia/flow/prompt_backup.rs
@@ -1,24 +1,15 @@
-use crate::{
-    error,
-    strutil::TString,
-    translations::TR,
-    ui::{
-        component::{
-            swipe_detect::SwipeSettings,
-            text::paragraphs::{Paragraph, ParagraphSource, ParagraphVecShort, Paragraphs},
-        },
-        flow::{
-            base::{Decision, DecisionBuilder as _},
-            FlowController, FlowMsg, SwipeFlow,
-        },
-        geometry::Direction,
-    },
+use super::super::component::{Frame, Header, PromptScreen, SwipeContent, VerticalMenu};
+use super::super::theme;
+use crate::error;
+use crate::strutil::TString;
+use crate::translations::TR;
+use crate::ui::component::swipe_detect::SwipeSettings;
+use crate::ui::component::text::paragraphs::{
+    Paragraph, ParagraphSource, ParagraphVecShort, Paragraphs,
 };
-
-use super::super::{
-    component::{Frame, Header, PromptScreen, SwipeContent, VerticalMenu},
-    theme,
-};
+use crate::ui::flow::base::{Decision, DecisionBuilder as _};
+use crate::ui::flow::{FlowController, FlowMsg, SwipeFlow};
+use crate::ui::geometry::Direction;
 
 #[derive(Copy, Clone, PartialEq, Eq)]
 pub enum PromptBackup {

--- a/core/embed/rust/src/ui/layout_delizia/flow/receive.rs
+++ b/core/embed/rust/src/ui/layout_delizia/flow/receive.rs
@@ -1,29 +1,23 @@
-use crate::{
-    error,
-    micropython::{buffer::StrBuffer, obj::Obj, util},
-    strutil::TString,
-    translations::TR,
-    ui::{
-        button_request::ButtonRequest,
-        component::{
-            swipe_detect::SwipeSettings,
-            text::paragraphs::{Paragraph, ParagraphSource, Paragraphs},
-            ButtonRequestExt, ComponentExt, Qr,
-        },
-        flow::{
-            base::{Decision, DecisionBuilder as _},
-            FlowController, FlowMsg, SwipeFlow, SwipePage,
-        },
-        geometry::Direction,
-        layout::util::{ConfirmValueParams, ContentType, MAX_XPUBS},
-    },
-};
 use heapless::Vec;
 
-use super::super::{
-    component::{AddressDetails, Frame, Header, PromptScreen, SwipeContent, VerticalMenu},
-    theme,
+use super::super::component::{
+    AddressDetails, Frame, Header, PromptScreen, SwipeContent, VerticalMenu,
 };
+use super::super::theme;
+use crate::error;
+use crate::micropython::buffer::StrBuffer;
+use crate::micropython::obj::Obj;
+use crate::micropython::util;
+use crate::strutil::TString;
+use crate::translations::TR;
+use crate::ui::button_request::ButtonRequest;
+use crate::ui::component::swipe_detect::SwipeSettings;
+use crate::ui::component::text::paragraphs::{Paragraph, ParagraphSource, Paragraphs};
+use crate::ui::component::{ButtonRequestExt, ComponentExt, Qr};
+use crate::ui::flow::base::{Decision, DecisionBuilder as _};
+use crate::ui::flow::{FlowController, FlowMsg, SwipeFlow, SwipePage};
+use crate::ui::geometry::Direction;
+use crate::ui::layout::util::{ConfirmValueParams, ContentType, MAX_XPUBS};
 
 const QR_BORDER: i16 = 4;
 

--- a/core/embed/rust/src/ui/layout_delizia/flow/request_number.rs
+++ b/core/embed/rust/src/ui/layout_delizia/flow/request_number.rs
@@ -1,25 +1,16 @@
-use crate::{
-    error,
-    strutil::TString,
-    translations::TR,
-    ui::{
-        flow::{
-            base::{Decision, DecisionBuilder as _},
-            FlowController, FlowMsg, SwipeFlow,
-        },
-        geometry::Direction,
-    },
-};
-
 use core::sync::atomic::{AtomicU16, Ordering};
 
-use super::super::{
-    component::{
-        Frame, Header, NumberInputDialog, NumberInputDialogMsg, SwipeContent, UpdatableMoreInfo,
-        VerticalMenu,
-    },
-    theme,
+use super::super::component::{
+    Frame, Header, NumberInputDialog, NumberInputDialogMsg, SwipeContent, UpdatableMoreInfo,
+    VerticalMenu,
 };
+use super::super::theme;
+use crate::error;
+use crate::strutil::TString;
+use crate::translations::TR;
+use crate::ui::flow::base::{Decision, DecisionBuilder as _};
+use crate::ui::flow::{FlowController, FlowMsg, SwipeFlow};
+use crate::ui::geometry::Direction;
 
 #[derive(Copy, Clone, PartialEq, Eq)]
 pub enum RequestNumber {

--- a/core/embed/rust/src/ui/layout_delizia/flow/request_passphrase.rs
+++ b/core/embed/rust/src/ui/layout_delizia/flow/request_passphrase.rs
@@ -1,19 +1,12 @@
-use crate::{
-    error,
-    strutil::{ShortString, TString},
-    ui::{
-        component::ComponentExt,
-        flow::{
-            base::{Decision, DecisionBuilder as _},
-            FlowController, FlowMsg, SwipeFlow,
-        },
-        geometry::Direction,
-    },
-};
-
 use super::super::component::{
     Frame, Header, PassphraseKeyboard, PassphraseKeyboardMsg, PromptScreen,
 };
+use crate::error;
+use crate::strutil::{ShortString, TString};
+use crate::ui::component::ComponentExt;
+use crate::ui::flow::base::{Decision, DecisionBuilder as _};
+use crate::ui::flow::{FlowController, FlowMsg, SwipeFlow};
+use crate::ui::geometry::Direction;
 
 #[derive(Copy, Clone, PartialEq, Eq)]
 pub enum RequestPassphrase {

--- a/core/embed/rust/src/ui/layout_delizia/flow/set_brightness.rs
+++ b/core/embed/rust/src/ui/layout_delizia/flow/set_brightness.rs
@@ -1,27 +1,19 @@
 use core::sync::atomic::{AtomicU8, Ordering};
 
-use crate::{
-    error::Error,
-    storage,
-    translations::TR,
-    trezorhal::display,
-    ui::{
-        component::{swipe_detect::SwipeSettings, EventCtx, FlowMsg},
-        flow::{
-            base::{Decision, DecisionBuilder as _},
-            FlowController, SwipeFlow,
-        },
-        geometry::Direction,
-    },
+use super::super::component::number_input_slider::{
+    NumberInputSliderDialog, NumberInputSliderDialogMsg,
 };
-
-use super::super::{
-    component::{
-        number_input_slider::{NumberInputSliderDialog, NumberInputSliderDialogMsg},
-        Footer, Frame, Header,
-    },
-    theme,
-};
+use super::super::component::{Footer, Frame, Header};
+use super::super::theme;
+use crate::error::Error;
+use crate::storage;
+use crate::translations::TR;
+use crate::trezorhal::display;
+use crate::ui::component::swipe_detect::SwipeSettings;
+use crate::ui::component::{EventCtx, FlowMsg};
+use crate::ui::flow::base::{Decision, DecisionBuilder as _};
+use crate::ui::flow::{FlowController, SwipeFlow};
+use crate::ui::geometry::Direction;
 
 #[derive(Copy, Clone, PartialEq, Eq, ToPrimitive)]
 pub enum SetBrightness {

--- a/core/embed/rust/src/ui/layout_delizia/flow/show_danger.rs
+++ b/core/embed/rust/src/ui/layout_delizia/flow/show_danger.rs
@@ -1,21 +1,12 @@
-use crate::{
-    error,
-    strutil::TString,
-    translations::TR,
-    ui::{
-        component::text::paragraphs::{Paragraph, ParagraphSource},
-        flow::{
-            base::{Decision, DecisionBuilder as _},
-            FlowController, FlowMsg, SwipeFlow,
-        },
-        geometry::Direction,
-    },
-};
-
-use super::super::{
-    component::{Frame, Header, StatusScreen, SwipeContent, VerticalMenu},
-    theme,
-};
+use super::super::component::{Frame, Header, StatusScreen, SwipeContent, VerticalMenu};
+use super::super::theme;
+use crate::error;
+use crate::strutil::TString;
+use crate::translations::TR;
+use crate::ui::component::text::paragraphs::{Paragraph, ParagraphSource};
+use crate::ui::flow::base::{Decision, DecisionBuilder as _};
+use crate::ui::flow::{FlowController, FlowMsg, SwipeFlow};
+use crate::ui::geometry::Direction;
 
 #[derive(Copy, Clone, PartialEq, Eq)]
 pub enum ShowDanger {

--- a/core/embed/rust/src/ui/layout_delizia/flow/show_share_words.rs
+++ b/core/embed/rust/src/ui/layout_delizia/flow/show_share_words.rs
@@ -1,29 +1,21 @@
-use crate::{
-    error,
-    strutil::TString,
-    translations::TR,
-    ui::{
-        button_request::ButtonRequestCode,
-        component::{
-            swipe_detect::SwipeSettings,
-            text::paragraphs::{Paragraph, ParagraphSource, ParagraphVecShort, Paragraphs},
-            ButtonRequestExt, ComponentExt, EventCtx, Paginate as _,
-        },
-        flow::{
-            base::{Decision, DecisionBuilder as _},
-            FlowController, FlowMsg, SwipeFlow,
-        },
-        geometry::Direction,
-    },
-};
 use heapless::Vec;
 
-use super::super::{
-    component::{
-        Footer, Frame, Header, InternallySwipableContent, PromptScreen, ShareWords, SwipeContent,
-    },
-    theme,
+use super::super::component::{
+    Footer, Frame, Header, InternallySwipableContent, PromptScreen, ShareWords, SwipeContent,
 };
+use super::super::theme;
+use crate::error;
+use crate::strutil::TString;
+use crate::translations::TR;
+use crate::ui::button_request::ButtonRequestCode;
+use crate::ui::component::swipe_detect::SwipeSettings;
+use crate::ui::component::text::paragraphs::{
+    Paragraph, ParagraphSource, ParagraphVecShort, Paragraphs,
+};
+use crate::ui::component::{ButtonRequestExt, ComponentExt, EventCtx, Paginate as _};
+use crate::ui::flow::base::{Decision, DecisionBuilder as _};
+use crate::ui::flow::{FlowController, FlowMsg, SwipeFlow};
+use crate::ui::geometry::Direction;
 
 #[derive(Copy, Clone, PartialEq, Eq)]
 pub enum ShowShareWords {

--- a/core/embed/rust/src/ui/layout_delizia/flow/show_tutorial.rs
+++ b/core/embed/rust/src/ui/layout_delizia/flow/show_tutorial.rs
@@ -1,23 +1,12 @@
-use crate::{
-    error,
-    translations::TR,
-    ui::{
-        component::{
-            swipe_detect::SwipeSettings,
-            text::paragraphs::{Paragraph, Paragraphs},
-        },
-        flow::{
-            base::{Decision, DecisionBuilder as _},
-            FlowController, FlowMsg, SwipeFlow,
-        },
-        geometry::Direction,
-    },
-};
-
-use super::super::{
-    component::{Frame, Header, PromptScreen, SwipeContent, VerticalMenu},
-    theme,
-};
+use super::super::component::{Frame, Header, PromptScreen, SwipeContent, VerticalMenu};
+use super::super::theme;
+use crate::error;
+use crate::translations::TR;
+use crate::ui::component::swipe_detect::SwipeSettings;
+use crate::ui::component::text::paragraphs::{Paragraph, Paragraphs};
+use crate::ui::flow::base::{Decision, DecisionBuilder as _};
+use crate::ui::flow::{FlowController, FlowMsg, SwipeFlow};
+use crate::ui::geometry::Direction;
 
 #[derive(Copy, Clone, PartialEq, Eq)]
 pub enum ShowTutorial {

--- a/core/embed/rust/src/ui/layout_delizia/flow/util.rs
+++ b/core/embed/rust/src/ui/layout_delizia/flow/util.rs
@@ -1,34 +1,26 @@
-use crate::{
-    error::Error,
-    maybe_trace::MaybeTrace,
-    strutil::TString,
-    translations::TR,
-    ui::{
-        component::{
-            swipe_detect::SwipeSettings,
-            text::{
-                paragraphs::{Paragraph, ParagraphSource, ParagraphVecLong, VecExt},
-                TextStyle,
-            },
-            Component,
-        },
-        flow::{
-            base::{Decision, DecisionBuilder},
-            FlowController, FlowMsg, Swipable, SwipeFlow, SwipePage,
-        },
-        geometry::Direction,
-        layout::util::{ConfirmValueParams, StrOrBytes},
-    },
-};
 use heapless::Vec;
 
+use super::super::component::{
+    Frame, Header, PromptMsg, SwipeContent, VerticalMenu, VerticalMenuChoiceMsg,
+};
+use super::super::{flow, theme};
 use super::{
-    super::{
-        component::{Frame, Header, PromptMsg, SwipeContent, VerticalMenu, VerticalMenuChoiceMsg},
-        flow, theme,
-    },
     ConfirmActionExtra, ConfirmActionMenuStrings, ConfirmActionOptions, ConfirmActionStrings,
 };
+use crate::error::Error;
+use crate::maybe_trace::MaybeTrace;
+use crate::strutil::TString;
+use crate::translations::TR;
+use crate::ui::component::swipe_detect::SwipeSettings;
+use crate::ui::component::text::paragraphs::{
+    Paragraph, ParagraphSource, ParagraphVecLong, VecExt,
+};
+use crate::ui::component::text::TextStyle;
+use crate::ui::component::Component;
+use crate::ui::flow::base::{Decision, DecisionBuilder};
+use crate::ui::flow::{FlowController, FlowMsg, Swipable, SwipeFlow, SwipePage};
+use crate::ui::geometry::Direction;
+use crate::ui::layout::util::{ConfirmValueParams, StrOrBytes};
 
 pub struct ConfirmValue {
     title: TString<'static>,

--- a/core/embed/rust/src/ui/layout_delizia/mod.rs
+++ b/core/embed/rust/src/ui/layout_delizia/mod.rs
@@ -1,18 +1,16 @@
-use super::{geometry::Rect, CommonUI};
+use theme::backlight;
 
+use super::geometry::Rect;
+use super::CommonUI;
 #[cfg(any(feature = "ui_debug_overlay", feature = "ui_performance_overlay"))]
 use super::{display::Color, geometry::Offset, shape};
-
 #[cfg(feature = "ui_performance_overlay")]
 use super::{
     geometry::{Alignment, Alignment2D, Point},
     PerformanceOverlay,
 };
-
 #[cfg(feature = "ui_performance_overlay")]
 use crate::strutil::ShortString;
-
-use theme::backlight;
 
 #[cfg(feature = "bootloader")]
 pub mod bootloader;
@@ -30,8 +28,9 @@ pub mod fonts;
 #[cfg(feature = "micropython")]
 pub mod ui_firmware;
 
-use crate::ui::layout::simplified::show;
 use component::{ErrorScreen, WelcomeScreen};
+
+use crate::ui::layout::simplified::show;
 
 pub struct UIDelizia;
 

--- a/core/embed/rust/src/ui/layout_delizia/theme/bootloader.rs
+++ b/core/embed/rust/src/ui/layout_delizia/theme/bootloader.rs
@@ -1,16 +1,12 @@
-use crate::ui::{
-    component::{text::TextStyle, LineBreaking::BreakWordsNoHyphen},
-    constant::{HEIGHT, WIDTH},
-    display::Color,
-    geometry::{Offset, Point, Rect},
-    util::include_res,
-};
-
-use super::super::{
-    component::{ButtonStyle, ButtonStyleSheet, ResultStyle},
-    fonts,
-    theme::{BLACK, FG, GREY_DARK, GREY_LIGHT, WHITE},
-};
+use super::super::component::{ButtonStyle, ButtonStyleSheet, ResultStyle};
+use super::super::fonts;
+use super::super::theme::{BLACK, FG, GREY_DARK, GREY_LIGHT, WHITE};
+use crate::ui::component::text::TextStyle;
+use crate::ui::component::LineBreaking::BreakWordsNoHyphen;
+use crate::ui::constant::{HEIGHT, WIDTH};
+use crate::ui::display::Color;
+use crate::ui::geometry::{Offset, Point, Rect};
+use crate::ui::util::include_res;
 
 pub const BLD_BG: Color = Color::rgb(0x00, 0x1E, 0xAD);
 pub const BLD_FG: Color = WHITE;

--- a/core/embed/rust/src/ui/layout_delizia/theme/mod.rs
+++ b/core/embed/rust/src/ui/layout_delizia/theme/mod.rs
@@ -2,26 +2,16 @@ pub mod bootloader;
 
 pub mod backlight;
 
-use crate::{
-    time::ShortDuration,
-    ui::{
-        component::{
-            text::{
-                layout::Chunks, paragraphs::PARAGRAPH_BOTTOM_SPACE, LineBreaking, PageBreaking,
-                TextStyle,
-            },
-            FixedHeightBar,
-        },
-        display::Color,
-        geometry::Offset,
-        util::include_icon,
-    },
-};
-
-use super::{
-    component::{ButtonStyle, ButtonStyleSheet, LoaderStyle, LoaderStyleSheet, ResultStyle},
-    fonts,
-};
+use super::component::{ButtonStyle, ButtonStyleSheet, LoaderStyle, LoaderStyleSheet, ResultStyle};
+use super::fonts;
+use crate::time::ShortDuration;
+use crate::ui::component::text::layout::Chunks;
+use crate::ui::component::text::paragraphs::PARAGRAPH_BOTTOM_SPACE;
+use crate::ui::component::text::{LineBreaking, PageBreaking, TextStyle};
+use crate::ui::component::FixedHeightBar;
+use crate::ui::display::Color;
+use crate::ui::geometry::Offset;
+use crate::ui::util::include_icon;
 
 pub const ERASE_HOLD_DURATION: ShortDuration = ShortDuration::from_millis(1500);
 

--- a/core/embed/rust/src/ui/layout_delizia/ui_firmware.rs
+++ b/core/embed/rust/src/ui/layout_delizia/ui_firmware.rs
@@ -1,55 +1,48 @@
 use core::cmp::Ordering;
 
-use crate::{
-    error::{value_error, Error},
-    io::BinaryData,
-    micropython::{buffer::StrBuffer, gc::Gc, iter::IterBuf, list::List, obj::Obj, util},
-    storage,
-    strutil::TString,
-    translations::TR,
-    ui::{
-        component::{
-            swipe_detect::SwipeSettings,
-            text::{
-                op::OpTextLayout,
-                paragraphs::{
-                    Checklist, Paragraph, ParagraphSource, ParagraphVecLong, ParagraphVecShort,
-                    Paragraphs, VecExt,
-                },
-                TextStyle,
-            },
-            CachedJpeg, ComponentExt, Empty, FormattedText, MsgMap, Never, Timeout,
-        },
-        flow::FlowMsg,
-        geometry::{self, Direction, Offset},
-        layout::{
-            obj::{LayoutMaybeTrace, LayoutObj, RootComponent},
-            util::{ContentType, PropsList, RecoveryType},
-        },
-        notification::Notification,
-        ui_firmware::{
-            FirmwareUI, MAX_CHECKLIST_ITEMS, MAX_GROUP_SHARE_LINES, MAX_MENU_ITEMS,
-            MAX_PAIRED_DEVICES, MAX_WORD_QUIZ_ITEMS,
-        },
-        ModelUI,
-    },
-};
 use heapless::Vec;
 
-use super::{
-    component::{
-        check_homescreen_format, Bip39Input, CoinJoinProgress, Frame, FrameMsg, Header, Homescreen,
-        Lockscreen, MnemonicKeyboard, PinKeyboard, Progress, PromptScreen, ScrolledVerticalMenu,
-        SelectWordCount, SelectWordCountLayout, Slip39Input, StatusScreen, SwipeContent,
-        SwipeUpScreen, TradeScreen, VerticalMenu, VerticalMenuChoiceMsg, VerticalMenuItem,
-        VerticalMenuItems,
-    },
-    flow::{
-        self, new_confirm_action_simple, ConfirmActionExtra, ConfirmActionMenuStrings,
-        ConfirmActionOptions, ConfirmActionStrings, ConfirmValue, ShowInfoParams,
-    },
-    fonts, theme, UIDelizia,
+use super::component::{
+    check_homescreen_format, Bip39Input, CoinJoinProgress, Frame, FrameMsg, Header, Homescreen,
+    Lockscreen, MnemonicKeyboard, PinKeyboard, Progress, PromptScreen, ScrolledVerticalMenu,
+    SelectWordCount, SelectWordCountLayout, Slip39Input, StatusScreen, SwipeContent, SwipeUpScreen,
+    TradeScreen, VerticalMenu, VerticalMenuChoiceMsg, VerticalMenuItem, VerticalMenuItems,
 };
+use super::flow::{
+    self, new_confirm_action_simple, ConfirmActionExtra, ConfirmActionMenuStrings,
+    ConfirmActionOptions, ConfirmActionStrings, ConfirmValue, ShowInfoParams,
+};
+use super::{fonts, theme, UIDelizia};
+use crate::error::{value_error, Error};
+use crate::io::BinaryData;
+use crate::micropython::buffer::StrBuffer;
+use crate::micropython::gc::Gc;
+use crate::micropython::iter::IterBuf;
+use crate::micropython::list::List;
+use crate::micropython::obj::Obj;
+use crate::micropython::util;
+use crate::storage;
+use crate::strutil::TString;
+use crate::translations::TR;
+use crate::ui::component::swipe_detect::SwipeSettings;
+use crate::ui::component::text::op::OpTextLayout;
+use crate::ui::component::text::paragraphs::{
+    Checklist, Paragraph, ParagraphSource, ParagraphVecLong, ParagraphVecShort, Paragraphs, VecExt,
+};
+use crate::ui::component::text::TextStyle;
+use crate::ui::component::{
+    CachedJpeg, ComponentExt, Empty, FormattedText, MsgMap, Never, Timeout,
+};
+use crate::ui::flow::FlowMsg;
+use crate::ui::geometry::{self, Direction, Offset};
+use crate::ui::layout::obj::{LayoutMaybeTrace, LayoutObj, RootComponent};
+use crate::ui::layout::util::{ContentType, PropsList, RecoveryType};
+use crate::ui::notification::Notification;
+use crate::ui::ui_firmware::{
+    FirmwareUI, MAX_CHECKLIST_ITEMS, MAX_GROUP_SHARE_LINES, MAX_MENU_ITEMS, MAX_PAIRED_DEVICES,
+    MAX_WORD_QUIZ_ITEMS,
+};
+use crate::ui::ModelUI;
 
 impl FirmwareUI for UIDelizia {
     fn confirm_action(

--- a/core/embed/rust/src/ui/layout_eckhart/bootloader/bld_actionbar.rs
+++ b/core/embed/rust/src/ui/layout_eckhart/bootloader/bld_actionbar.rs
@@ -1,13 +1,8 @@
-use crate::ui::{
-    component::{Component, Event, EventCtx},
-    geometry::{Alignment2D, Insets, Offset, Rect},
-    shape::{self, Renderer},
-};
-
-use super::super::{
-    component::{Button, ButtonMsg},
-    theme,
-};
+use super::super::component::{Button, ButtonMsg};
+use super::super::theme;
+use crate::ui::component::{Component, Event, EventCtx};
+use crate::ui::geometry::{Alignment2D, Insets, Offset, Rect};
+use crate::ui::shape::{self, Renderer};
 
 /// Component for control buttons in the bottom of the screen. Reduced variant
 /// for Bootloader UI.

--- a/core/embed/rust/src/ui/layout_eckhart/bootloader/bld_header.rs
+++ b/core/embed/rust/src/ui/layout_eckhart/bootloader/bld_header.rs
@@ -1,18 +1,12 @@
-use crate::{
-    strutil::TString,
-    ui::{
-        component::{Component, Event, EventCtx, Label},
-        display::{Color, Icon},
-        geometry::{Alignment2D, Insets, Rect},
-        shape::{self, Renderer},
-    },
-};
-
-use super::super::{
-    component::{Button, ButtonContent, ButtonMsg, FuelGauge},
-    constant,
-    theme::{self, bootloader::text_title},
-};
+use super::super::component::{Button, ButtonContent, ButtonMsg, FuelGauge};
+use super::super::constant;
+use super::super::theme::bootloader::text_title;
+use super::super::theme::{self};
+use crate::strutil::TString;
+use crate::ui::component::{Component, Event, EventCtx, Label};
+use crate::ui::display::{Color, Icon};
+use crate::ui::geometry::{Alignment2D, Insets, Rect};
+use crate::ui::shape::{self, Renderer};
 
 const BUTTON_EXPAND_BORDER: i16 = 32;
 

--- a/core/embed/rust/src/ui/layout_eckhart/bootloader/bld_menu.rs
+++ b/core/embed/rust/src/ui/layout_eckhart/bootloader/bld_menu.rs
@@ -1,14 +1,10 @@
-use crate::ui::{
-    component::{Component, Event, EventCtx},
-    geometry::{Offset, Rect},
-    shape::{Bar, Renderer},
-};
-
-use super::super::{
-    component::{Button, ButtonMsg},
-    theme::{self, GREY_EXTRA_DARK},
-};
 use heapless::Vec;
+
+use super::super::component::{Button, ButtonMsg};
+use super::super::theme::{self, GREY_EXTRA_DARK};
+use crate::ui::component::{Component, Event, EventCtx};
+use crate::ui::geometry::{Offset, Rect};
+use crate::ui::shape::{Bar, Renderer};
 
 pub const MENU_MAX_ITEMS: usize = 4;
 

--- a/core/embed/rust/src/ui/layout_eckhart/bootloader/bld_menu_screen.rs
+++ b/core/embed/rust/src/ui/layout_eckhart/bootloader/bld_menu_screen.rs
@@ -1,17 +1,12 @@
-use crate::{
-    trezorhal::ble,
-    ui::{
-        component::{Component, Event, EventCtx},
-        geometry::{Alignment, Rect},
-        shape::Renderer,
-    },
-};
-
-use super::{
-    super::{component::Button, cshape::ScreenBorder, theme},
-    bld_menu::BldMenuSelectionMsg,
-    BldHeader, BldHeaderMsg, BldMenu,
-};
+use super::super::component::Button;
+use super::super::cshape::ScreenBorder;
+use super::super::theme;
+use super::bld_menu::BldMenuSelectionMsg;
+use super::{BldHeader, BldHeaderMsg, BldMenu};
+use crate::trezorhal::ble;
+use crate::ui::component::{Component, Event, EventCtx};
+use crate::ui::geometry::{Alignment, Rect};
+use crate::ui::shape::Renderer;
 
 const BUTTON_AREA_START: i16 = 56;
 const BUTTON_SPACING: i16 = 8;

--- a/core/embed/rust/src/ui/layout_eckhart/bootloader/bld_text_screen.rs
+++ b/core/embed/rust/src/ui/layout_eckhart/bootloader/bld_text_screen.rs
@@ -1,17 +1,10 @@
-use crate::ui::{
-    component::{Component, Event, EventCtx, Label},
-    constant::SCREEN,
-    geometry::{Insets, Rect},
-    shape::Renderer,
-};
-
-use super::{
-    super::{
-        cshape::ScreenBorder,
-        theme::{ACTION_BAR_HEIGHT, HEADER_HEIGHT, SIDE_INSETS, TEXT_VERTICAL_SPACING},
-    },
-    BldActionBar, BldActionBarMsg, BldHeader, BldHeaderMsg,
-};
+use super::super::cshape::ScreenBorder;
+use super::super::theme::{ACTION_BAR_HEIGHT, HEADER_HEIGHT, SIDE_INSETS, TEXT_VERTICAL_SPACING};
+use super::{BldActionBar, BldActionBarMsg, BldHeader, BldHeaderMsg};
+use crate::ui::component::{Component, Event, EventCtx, Label};
+use crate::ui::constant::SCREEN;
+use crate::ui::geometry::{Insets, Rect};
+use crate::ui::shape::Renderer;
 
 /// Full-screen component for rendering text. Reduced variant for Bootloader UI.
 ///

--- a/core/embed/rust/src/ui/layout_eckhart/bootloader/confirm_pairing.rs
+++ b/core/embed/rust/src/ui/layout_eckhart/bootloader/confirm_pairing.rs
@@ -1,20 +1,15 @@
-use crate::{
-    strutil::{format_pairing_code, ShortString},
-    trezorhal::ble::PAIRING_CODE_LEN,
-    ui::{
-        component::{Component, Event, EventCtx, Label},
-        constant::SCREEN,
-        display::Font,
-        event::BLEEvent,
-        geometry::{Alignment, Offset, Point, Rect},
-        shape::{self, Renderer},
-    },
-};
-
-use super::{
-    super::{component::Button, cshape::ScreenBorder, fonts, theme},
-    BldActionBar, BldActionBarMsg, BldHeader,
-};
+use super::super::component::Button;
+use super::super::cshape::ScreenBorder;
+use super::super::{fonts, theme};
+use super::{BldActionBar, BldActionBarMsg, BldHeader};
+use crate::strutil::{format_pairing_code, ShortString};
+use crate::trezorhal::ble::PAIRING_CODE_LEN;
+use crate::ui::component::{Component, Event, EventCtx, Label};
+use crate::ui::constant::SCREEN;
+use crate::ui::display::Font;
+use crate::ui::event::BLEEvent;
+use crate::ui::geometry::{Alignment, Offset, Point, Rect};
+use crate::ui::shape::{self, Renderer};
 
 #[derive(Copy, Clone, ToPrimitive)]
 #[cfg_attr(feature = "debug", derive(ufmt::derive::uDebug))]

--- a/core/embed/rust/src/ui/layout_eckhart/bootloader/connect.rs
+++ b/core/embed/rust/src/ui/layout_eckhart/bootloader/connect.rs
@@ -1,16 +1,13 @@
-use crate::ui::{
-    component::{Component, Event, EventCtx, Label},
-    geometry::Rect,
-    shape::Renderer,
-};
-
-use super::{
-    super::{component::Button, constant::SCREEN, cshape::ScreenBorder, theme},
-    BldActionBar, BldActionBarMsg, BldHeader,
-};
-
+use super::super::component::Button;
+use super::super::constant::SCREEN;
+use super::super::cshape::ScreenBorder;
+use super::super::theme;
 #[cfg(feature = "power_manager")]
 use super::BldHeaderMsg;
+use super::{BldActionBar, BldActionBarMsg, BldHeader};
+use crate::ui::component::{Component, Event, EventCtx, Label};
+use crate::ui::geometry::Rect;
+use crate::ui::shape::Renderer;
 
 #[repr(u32)]
 #[derive(Copy, Clone, ToPrimitive)]

--- a/core/embed/rust/src/ui/layout_eckhart/bootloader/mod.rs
+++ b/core/embed/rust/src/ui/layout_eckhart/bootloader/mod.rs
@@ -26,7 +26,6 @@ pub use connect::ConnectScreen;
 pub use pairing_finalization::PairingFinalizationScreen;
 #[cfg(feature = "ble")]
 pub use pairing_mode::PairingModeScreen;
+pub use welcome_screen::BldWelcomeScreen;
 #[cfg(feature = "ble")]
 pub use wireless_setup_screen::WirelessSetupScreen;
-
-pub use welcome_screen::BldWelcomeScreen;

--- a/core/embed/rust/src/ui/layout_eckhart/bootloader/pairing_finalization.rs
+++ b/core/embed/rust/src/ui/layout_eckhart/bootloader/pairing_finalization.rs
@@ -1,14 +1,11 @@
-use crate::ui::{
-    component::{Component, Event, EventCtx, Label},
-    event::BLEEvent,
-    geometry::Rect,
-    shape::Renderer,
-};
-
-use super::{
-    super::{component::Button, cshape::ScreenBorder, theme, CANCEL_MESSAGE},
-    BldActionBar, BldActionBarMsg, BldHeader,
-};
+use super::super::component::Button;
+use super::super::cshape::ScreenBorder;
+use super::super::{theme, CANCEL_MESSAGE};
+use super::{BldActionBar, BldActionBarMsg, BldHeader};
+use crate::ui::component::{Component, Event, EventCtx, Label};
+use crate::ui::event::BLEEvent;
+use crate::ui::geometry::Rect;
+use crate::ui::shape::Renderer;
 
 #[repr(u32)]
 #[derive(Copy, Clone, ToPrimitive)]

--- a/core/embed/rust/src/ui/layout_eckhart/bootloader/pairing_mode.rs
+++ b/core/embed/rust/src/ui/layout_eckhart/bootloader/pairing_mode.rs
@@ -1,17 +1,13 @@
-use super::{
-    super::{cshape::ScreenBorder, theme},
-    BldHeader, BldHeaderMsg,
-};
-use crate::{
-    strutil::TString,
-    ui::{
-        component::{text::TextStyle, Component, Event, EventCtx, Label},
-        event::BLEEvent,
-        geometry::{Insets, Rect},
-        layout::simplified::ReturnToC,
-        shape::Renderer,
-    },
-};
+use super::super::cshape::ScreenBorder;
+use super::super::theme;
+use super::{BldHeader, BldHeaderMsg};
+use crate::strutil::TString;
+use crate::ui::component::text::TextStyle;
+use crate::ui::component::{Component, Event, EventCtx, Label};
+use crate::ui::event::BLEEvent;
+use crate::ui::geometry::{Insets, Rect};
+use crate::ui::layout::simplified::ReturnToC;
+use crate::ui::shape::Renderer;
 
 #[repr(u32)]
 pub enum PairingMsg {

--- a/core/embed/rust/src/ui/layout_eckhart/bootloader/welcome_screen.rs
+++ b/core/embed/rust/src/ui/layout_eckhart/bootloader/welcome_screen.rs
@@ -1,24 +1,14 @@
-use crate::{
-    strutil::TString,
-    trezorhal::ble,
-    ui::{
-        component::{Component, Event, EventCtx},
-        geometry::{Alignment2D, Offset, Point, Rect},
-        shape::{self, Renderer},
-    },
-};
-
-use super::{
-    super::{
-        component::{render_logo, Button},
-        constant::SCREEN,
-        fonts, theme,
-    },
-    BldActionBar, BldActionBarMsg, BldHeader,
-};
-
+use super::super::component::{render_logo, Button};
+use super::super::constant::SCREEN;
+use super::super::{fonts, theme};
 #[cfg(feature = "power_manager")]
 use super::BldHeaderMsg;
+use super::{BldActionBar, BldActionBarMsg, BldHeader};
+use crate::strutil::TString;
+use crate::trezorhal::ble;
+use crate::ui::component::{Component, Event, EventCtx};
+use crate::ui::geometry::{Alignment2D, Offset, Point, Rect};
+use crate::ui::shape::{self, Renderer};
 
 #[repr(u32)]
 #[derive(Copy, Clone, ToPrimitive)]

--- a/core/embed/rust/src/ui/layout_eckhart/bootloader/wireless_setup_screen.rs
+++ b/core/embed/rust/src/ui/layout_eckhart/bootloader/wireless_setup_screen.rs
@@ -1,18 +1,13 @@
-use crate::{
-    strutil::TString,
-    ui::{
-        component::{Component, Event, EventCtx, Label},
-        event::BLEEvent,
-        geometry::{Alignment2D, Insets, Offset, Rect},
-        shape::{self, Renderer},
-    },
-};
-
-use super::{
-    super::{component::Button, constant::SCREEN, theme},
-    pairing_mode::PairingMsg,
-    BldActionBar, BldActionBarMsg, BldHeader, BldHeaderMsg,
-};
+use super::super::component::Button;
+use super::super::constant::SCREEN;
+use super::super::theme;
+use super::pairing_mode::PairingMsg;
+use super::{BldActionBar, BldActionBarMsg, BldHeader, BldHeaderMsg};
+use crate::strutil::TString;
+use crate::ui::component::{Component, Event, EventCtx, Label};
+use crate::ui::event::BLEEvent;
+use crate::ui::geometry::{Alignment2D, Insets, Offset, Rect};
+use crate::ui::shape::{self, Renderer};
 
 /// Full-screen component for the wireless setup screen. It shows instructions
 /// for the user and QR code to download the Trezor Suite app.

--- a/core/embed/rust/src/ui/layout_eckhart/component/button.rs
+++ b/core/embed/rust/src/ui/layout_eckhart/component/button.rs
@@ -1,26 +1,20 @@
+use super::super::component::ConnectionIndicator;
+use super::super::theme::{self, Gradient};
+use crate::strutil::TString;
+use crate::time::{Duration, Instant, ShortDuration};
 #[cfg(feature = "translations")]
 use crate::translations::TR;
 #[cfg(feature = "haptic")]
 use crate::trezorhal::haptic::{play, HapticEffect};
-
-use crate::{
-    strutil::TString,
-    time::{Duration, Instant, ShortDuration},
-    ui::{
-        component::{text::TextStyle, Component, Event, EventCtx, Marquee, Timer},
-        constant,
-        display::{toif::Icon, Color, Font},
-        event::TouchEvent,
-        geometry::{Alignment, Alignment2D, Insets, Offset, Point, Rect},
-        shape::{self, Renderer},
-        util::split_two_lines,
-    },
-};
-
-use super::super::{
-    component::ConnectionIndicator,
-    theme::{self, Gradient},
-};
+use crate::ui::component::text::TextStyle;
+use crate::ui::component::{Component, Event, EventCtx, Marquee, Timer};
+use crate::ui::constant;
+use crate::ui::display::toif::Icon;
+use crate::ui::display::{Color, Font};
+use crate::ui::event::TouchEvent;
+use crate::ui::geometry::{Alignment, Alignment2D, Insets, Offset, Point, Rect};
+use crate::ui::shape::{self, Renderer};
+use crate::ui::util::split_two_lines;
 
 pub enum ButtonMsg {
     Pressed,

--- a/core/embed/rust/src/ui/layout_eckhart/component/connection_indicator.rs
+++ b/core/embed/rust/src/ui/layout_eckhart/component/connection_indicator.rs
@@ -1,17 +1,11 @@
-use crate::{
-    trezorhal::usb,
-    ui::{
-        component::{Component, Event, EventCtx},
-        event::USBEvent,
-        geometry::Rect,
-        shape::Renderer,
-    },
-};
-
+use super::super::cshape::{render_connected_indicator, INDICATOR_OUTER_RADIUS};
+use crate::trezorhal::usb;
+use crate::ui::component::{Component, Event, EventCtx};
+use crate::ui::event::USBEvent;
+use crate::ui::geometry::Rect;
+use crate::ui::shape::Renderer;
 #[cfg(feature = "ble")]
 use crate::{trezorhal::ble, ui::event::BLEEvent};
-
-use super::super::cshape::{render_connected_indicator, INDICATOR_OUTER_RADIUS};
 
 pub struct ConnectionIndicator {
     pub area: Rect,

--- a/core/embed/rust/src/ui/layout_eckhart/component/error.rs
+++ b/core/embed/rust/src/ui/layout_eckhart/component/error.rs
@@ -1,24 +1,16 @@
+use super::super::cshape::ScreenBorder;
+use super::super::theme::{
+    ACTION_BAR_HEIGHT, HEADER_HEIGHT, LED_RED, PADDING, RED, SIDE_INSETS, TEXT_NORMAL, TEXT_SMALL,
+    TEXT_SMALL_GREY, TEXT_SMALL_GREY_EXTRA_LIGHT, TEXT_SMALL_RED, TEXT_VERTICAL_SPACING,
+};
+use super::super::WAIT_FOR_RESTART_MESSAGE;
+use crate::strutil::TString;
+use crate::ui::component::{Component, Event, EventCtx, Label, Never};
+use crate::ui::constant::SCREEN;
+use crate::ui::geometry::{Insets, Rect};
 #[cfg(feature = "rgb_led")]
 use crate::ui::led::LedState;
-use crate::{
-    strutil::TString,
-    ui::{
-        component::{Component, Event, EventCtx, Label, Never},
-        constant::SCREEN,
-        geometry::{Insets, Rect},
-        shape::Renderer,
-    },
-};
-
-use super::super::{
-    cshape::ScreenBorder,
-    theme::{
-        ACTION_BAR_HEIGHT, HEADER_HEIGHT, LED_RED, PADDING, RED, SIDE_INSETS, TEXT_NORMAL,
-        TEXT_SMALL, TEXT_SMALL_GREY, TEXT_SMALL_GREY_EXTRA_LIGHT, TEXT_SMALL_RED,
-        TEXT_VERTICAL_SPACING,
-    },
-    WAIT_FOR_RESTART_MESSAGE,
-};
+use crate::ui::shape::Renderer;
 
 /// Full-screen component showing Eckhart RSOD. To keep it minimal, this screen
 /// does not use any other components.

--- a/core/embed/rust/src/ui/layout_eckhart/component/fuel_gauge.rs
+++ b/core/embed/rust/src/ui/layout_eckhart/component/fuel_gauge.rs
@@ -1,27 +1,18 @@
-use crate::{
-    strutil::ShortString,
-    trezorhal::power_manager::{self, ChargingState},
-    ui::{
-        component::{Component, Event, EventCtx, Never},
-        display::{Color, Font, Icon},
-        geometry::{Alignment, Alignment2D, Offset, Point, Rect},
-        shape::{self, Renderer},
-    },
-};
-
-#[cfg(feature = "micropython")]
-use crate::ui::component::Timer;
-
-use super::super::{
-    fonts,
-    theme::{
-        GREY_LIGHT, ICON_BATTERY_EMPTY, ICON_BATTERY_FULL, ICON_BATTERY_LOW,
-        ICON_BATTERY_MID_MINUS, ICON_BATTERY_MID_PLUS, ICON_BATTERY_ZAP, RED, YELLOW,
-    },
-};
-
+use super::super::fonts;
 #[cfg(feature = "micropython")]
 use super::super::theme::firmware::FUEL_GAUGE_DURATION;
+use super::super::theme::{
+    GREY_LIGHT, ICON_BATTERY_EMPTY, ICON_BATTERY_FULL, ICON_BATTERY_LOW, ICON_BATTERY_MID_MINUS,
+    ICON_BATTERY_MID_PLUS, ICON_BATTERY_ZAP, RED, YELLOW,
+};
+use crate::strutil::ShortString;
+use crate::trezorhal::power_manager::{self, ChargingState};
+#[cfg(feature = "micropython")]
+use crate::ui::component::Timer;
+use crate::ui::component::{Component, Event, EventCtx, Never};
+use crate::ui::display::{Color, Font, Icon};
+use crate::ui::geometry::{Alignment, Alignment2D, Offset, Point, Rect};
+use crate::ui::shape::{self, Renderer};
 
 const ICON_PERCENT_GAP: i16 = 16;
 

--- a/core/embed/rust/src/ui/layout_eckhart/component/mod.rs
+++ b/core/embed/rust/src/ui/layout_eckhart/component/mod.rs
@@ -15,11 +15,9 @@ pub use update_screen::UpdateScreen;
 pub use welcome_screen::WelcomeScreen;
 
 use super::{fonts, theme};
-use crate::ui::{
-    display::Font,
-    geometry::{Alignment2D, Offset, Point},
-    shape::{self, Renderer},
-};
+use crate::ui::display::Font;
+use crate::ui::geometry::{Alignment2D, Offset, Point};
+use crate::ui::shape::{self, Renderer};
 
 pub fn render_logo<'s>(target: &mut impl Renderer<'s>) {
     const TEXT_ORIGIN: Point = Point::new(24, 76);

--- a/core/embed/rust/src/ui/layout_eckhart/component/update_screen.rs
+++ b/core/embed/rust/src/ui/layout_eckhart/component/update_screen.rs
@@ -1,10 +1,8 @@
-use crate::ui::{
-    component::{Component, Event, EventCtx, Label, Never},
-    geometry::{Alignment2D, Rect},
-    shape::{self, Renderer},
-};
-
-use super::super::{constant::SCREEN, theme, WAIT_MESSAGE};
+use super::super::constant::SCREEN;
+use super::super::{theme, WAIT_MESSAGE};
+use crate::ui::component::{Component, Event, EventCtx, Label, Never};
+use crate::ui::geometry::{Alignment2D, Rect};
+use crate::ui::shape::{self, Renderer};
 
 pub struct UpdateScreen {
     text_header: Label<'static>,

--- a/core/embed/rust/src/ui/layout_eckhart/component/welcome_screen.rs
+++ b/core/embed/rust/src/ui/layout_eckhart/component/welcome_screen.rs
@@ -1,10 +1,7 @@
-use crate::ui::{
-    component::{Component, Event, EventCtx, Never},
-    geometry::{Offset, Rect},
-    shape::Renderer,
-};
-
 use super::super::component::render_logo;
+use crate::ui::component::{Component, Event, EventCtx, Never};
+use crate::ui::geometry::{Offset, Rect};
+use crate::ui::shape::Renderer;
 
 const TEXT_OFFSET: Offset = Offset::new(30, 40);
 

--- a/core/embed/rust/src/ui/layout_eckhart/component_msg_obj.rs
+++ b/core/embed/rust/src/ui/layout_eckhart/component_msg_obj.rs
@@ -1,19 +1,5 @@
 use num_traits::ToPrimitive;
 
-#[cfg(not(feature = "clippy"))]
-use crate::ui::component::{
-    text::paragraphs::{ParagraphSource, Paragraphs},
-    Component, Timeout,
-};
-use crate::{
-    error::Error,
-    micropython::{obj::Obj, util::new_tuple},
-    ui::layout::{
-        obj::ComponentMsgObj,
-        result::{CANCELLED, CONFIRMED, INFO},
-    },
-};
-
 use super::firmware::{
     AllowedTextContent, ConfirmHomescreen, ConfirmHomescreenMsg, DeviceMenuScreen, Homescreen,
     HomescreenMsg, MnemonicInput, MnemonicKeyboard, MnemonicKeyboardMsg, PinKeyboard,
@@ -21,6 +7,16 @@ use super::firmware::{
     SelectWordScreen, SetBrightnessScreen, StringInput, StringKeyboard, StringKeyboardMsg,
     TextScreen, TextScreenMsg, ValueInput, ValueInputScreen, ValueInputScreenMsg,
 };
+use crate::error::Error;
+use crate::micropython::obj::Obj;
+use crate::micropython::util::new_tuple;
+#[cfg(not(feature = "clippy"))]
+use crate::ui::component::{
+    text::paragraphs::{ParagraphSource, Paragraphs},
+    Component, Timeout,
+};
+use crate::ui::layout::obj::ComponentMsgObj;
+use crate::ui::layout::result::{CANCELLED, CONFIRMED, INFO};
 
 impl ComponentMsgObj for PinKeyboard<'_> {
     fn msg_try_into_obj(&self, msg: Self::Msg) -> Result<Obj, Error> {

--- a/core/embed/rust/src/ui/layout_eckhart/constant.rs
+++ b/core/embed/rust/src/ui/layout_eckhart/constant.rs
@@ -1,6 +1,5 @@
-use crate::ui::geometry::{Offset, Point, Rect};
-
 use crate::trezorhal::display::{DISPLAY_RESX, DISPLAY_RESY};
+use crate::ui::geometry::{Offset, Point, Rect};
 
 pub const WIDTH: i16 = DISPLAY_RESX as _;
 pub const HEIGHT: i16 = DISPLAY_RESY as _;

--- a/core/embed/rust/src/ui/layout_eckhart/cshape/connected.rs
+++ b/core/embed/rust/src/ui/layout_eckhart/cshape/connected.rs
@@ -1,10 +1,7 @@
-use crate::ui::{
-    display::Color,
-    geometry::{Offset, Point, Rect},
-    shape::{self, Renderer},
-};
-
 use super::super::theme;
+use crate::ui::display::Color;
+use crate::ui::geometry::{Offset, Point, Rect};
+use crate::ui::shape::{self, Renderer};
 
 // outer circle
 pub const INDICATOR_OUTER_RADIUS: i16 = 10;

--- a/core/embed/rust/src/ui/layout_eckhart/cshape/loader.rs
+++ b/core/embed/rust/src/ui/layout_eckhart/cshape/loader.rs
@@ -1,15 +1,10 @@
-use crate::ui::{
-    constant::SCREEN,
-    geometry::{Alignment2D, Offset, Point, Rect},
-    lerp::Lerp,
-    shape::{self, Renderer},
-    util::animation_disabled,
-};
-
-use super::{
-    super::theme::{self, ICON_BORDER_BL, ICON_BORDER_BR},
-    ScreenBorder,
-};
+use super::super::theme::{self, ICON_BORDER_BL, ICON_BORDER_BR};
+use super::ScreenBorder;
+use crate::ui::constant::SCREEN;
+use crate::ui::geometry::{Alignment2D, Offset, Point, Rect};
+use crate::ui::lerp::Lerp;
+use crate::ui::shape::{self, Renderer};
+use crate::ui::util::animation_disabled;
 
 /// Renders the loader. Higher `progress` reveals the `border` from the top in
 /// clock-wise direction. Used in ProgressScreen and Bootloader. `progress` goes

--- a/core/embed/rust/src/ui/layout_eckhart/cshape/screen_border.rs
+++ b/core/embed/rust/src/ui/layout_eckhart/cshape/screen_border.rs
@@ -1,13 +1,8 @@
-use crate::ui::{
-    display::Color,
-    geometry::{Alignment2D, Rect},
-    shape::{self, Renderer},
-};
-
-use super::super::{
-    constant::SCREEN,
-    theme::{ICON_BORDER_BL, ICON_BORDER_BR, ICON_BORDER_TOP},
-};
+use super::super::constant::SCREEN;
+use super::super::theme::{ICON_BORDER_BL, ICON_BORDER_BR, ICON_BORDER_TOP};
+use crate::ui::display::Color;
+use crate::ui::geometry::{Alignment2D, Rect};
+use crate::ui::shape::{self, Renderer};
 
 /// Custom shape for a full screen border overlay, parameterizable by color.
 pub struct ScreenBorder {

--- a/core/embed/rust/src/ui/layout_eckhart/firmware/action_bar.rs
+++ b/core/embed/rust/src/ui/layout_eckhart/firmware/action_bar.rs
@@ -1,22 +1,14 @@
-use crate::{
-    strutil::TString,
-    time::Duration,
-    translations::TR,
-    ui::{
-        component::{Component, Event, EventCtx, Timeout},
-        geometry::{Alignment2D, Insets, Offset, Rect},
-        shape::{self, Renderer},
-        util::{animation_disabled, Pager},
-    },
-};
-
+use super::super::component::{Button, ButtonMsg};
+use super::{theme, HoldToConfirmAnim};
+use crate::strutil::TString;
+use crate::time::Duration;
+use crate::translations::TR;
 #[cfg(feature = "haptic")]
 use crate::trezorhal::haptic::{self, HapticEffect};
-
-use super::{
-    super::component::{Button, ButtonMsg},
-    theme, HoldToConfirmAnim,
-};
+use crate::ui::component::{Component, Event, EventCtx, Timeout};
+use crate::ui::geometry::{Alignment2D, Insets, Offset, Rect};
+use crate::ui::shape::{self, Renderer};
+use crate::ui::util::{animation_disabled, Pager};
 
 /// Component for control buttons in the bottom of the screen.
 pub struct ActionBar {

--- a/core/embed/rust/src/ui/layout_eckhart/firmware/brightness_screen.rs
+++ b/core/embed/rust/src/ui/layout_eckhart/firmware/brightness_screen.rs
@@ -1,21 +1,14 @@
-use crate::{
-    storage,
-    translations::TR,
-    trezorhal::display,
-    ui::{
-        component::{Component, Event, EventCtx},
-        event::TouchEvent,
-        geometry::{Alignment2D, Insets, Offset, Point, Rect},
-        shape::{Bar, Renderer},
-    },
-};
-
-use super::super::{
-    component::Button,
-    constant::SCREEN,
-    firmware::{Header, HeaderMsg},
-    theme,
-};
+use super::super::component::Button;
+use super::super::constant::SCREEN;
+use super::super::firmware::{Header, HeaderMsg};
+use super::super::theme;
+use crate::storage;
+use crate::translations::TR;
+use crate::trezorhal::display;
+use crate::ui::component::{Component, Event, EventCtx};
+use crate::ui::event::TouchEvent;
+use crate::ui::geometry::{Alignment2D, Insets, Offset, Point, Rect};
+use crate::ui::shape::{Bar, Renderer};
 
 pub struct SetBrightnessScreen {
     header: Header,
@@ -214,7 +207,8 @@ impl crate::trace::Trace for VerticalSlider {
 
 #[cfg(test)]
 mod tests {
-    use super::{super::super::constant::SCREEN, *};
+    use super::super::super::constant::SCREEN;
+    use super::*;
 
     #[test]
     fn test_component_heights_fit_screen() {

--- a/core/embed/rust/src/ui/layout_eckhart/firmware/confirm_homescreen.rs
+++ b/core/embed/rust/src/ui/layout_eckhart/firmware/confirm_homescreen.rs
@@ -1,18 +1,13 @@
-use crate::{
-    error::{value_error, Error},
-    io::BinaryData,
-    strutil::TString,
-    translations::TR,
-    ui::{
-        component::{Component, Event, EventCtx, Label},
-        constant::SCREEN,
-        display::image::ImageInfo,
-        geometry::{Insets, Rect},
-        shape::{self, Renderer},
-    },
-};
-
 use super::{check_homescreen_format, theme, ActionBar, ActionBarMsg, Header};
+use crate::error::{value_error, Error};
+use crate::io::BinaryData;
+use crate::strutil::TString;
+use crate::translations::TR;
+use crate::ui::component::{Component, Event, EventCtx, Label};
+use crate::ui::constant::SCREEN;
+use crate::ui::display::image::ImageInfo;
+use crate::ui::geometry::{Insets, Rect};
+use crate::ui::shape::{self, Renderer};
 
 /// Full-screen component for confirming a new homescreen image. If the image is
 /// empty, the user is asked to confirm the default homescreen.

--- a/core/embed/rust/src/ui/layout_eckhart/firmware/device_menu_screen.rs
+++ b/core/embed/rust/src/ui/layout_eckhart/firmware/device_menu_screen.rs
@@ -1,45 +1,34 @@
 use core::ops::{Deref, DerefMut};
 
-pub use crate::ui::layout::device_menu_result::DeviceMenuMsg;
-use crate::{
-    error::Error,
-    micropython::{gc::GcBox, obj::Obj},
-    strutil::TString,
-    translations::TR,
-    trezorhal::usb,
-    ui::{
-        component::{
-            text::{
-                paragraphs::{Paragraph, ParagraphSource, ParagraphVecShort, Paragraphs, VecExt},
-                TextStyle,
-            },
-            Component, Event, EventCtx,
-        },
-        geometry::{LinearPlacement, Rect},
-        layout::util::PropsList,
-        shape::Renderer,
-        ui_firmware::MAX_PAIRED_DEVICES,
-    },
-};
-
-#[cfg(feature = "ble")]
-use crate::{trezorhal::ble, ui::event::BLEEvent};
-
-use crate::ui::event::USBEvent;
-
-use super::{
-    super::{
-        component::{Button, ButtonStyleSheet, FuelGauge},
-        constant::SCREEN,
-        firmware::{
-            Header, HeaderMsg, RegulatoryMsg, RegulatoryScreen, TextScreen, TextScreenMsg,
-            VerticalMenu, VerticalMenuScreen, VerticalMenuScreenMsg, MEDIUM_MENU_ITEMS,
-        },
-    },
-    theme, MediumMenuVec, ShortMenuVec,
-};
 use heapless::Vec;
 use num_traits::{FromPrimitive, ToPrimitive};
+
+use super::super::component::{Button, ButtonStyleSheet, FuelGauge};
+use super::super::constant::SCREEN;
+use super::super::firmware::{
+    Header, HeaderMsg, RegulatoryMsg, RegulatoryScreen, TextScreen, TextScreenMsg, VerticalMenu,
+    VerticalMenuScreen, VerticalMenuScreenMsg, MEDIUM_MENU_ITEMS,
+};
+use super::{theme, MediumMenuVec, ShortMenuVec};
+use crate::error::Error;
+use crate::micropython::gc::GcBox;
+use crate::micropython::obj::Obj;
+use crate::strutil::TString;
+use crate::translations::TR;
+use crate::trezorhal::usb;
+use crate::ui::component::text::paragraphs::{
+    Paragraph, ParagraphSource, ParagraphVecShort, Paragraphs, VecExt,
+};
+use crate::ui::component::text::TextStyle;
+use crate::ui::component::{Component, Event, EventCtx};
+use crate::ui::event::USBEvent;
+use crate::ui::geometry::{LinearPlacement, Rect};
+pub use crate::ui::layout::device_menu_result::DeviceMenuMsg;
+use crate::ui::layout::util::PropsList;
+use crate::ui::shape::Renderer;
+use crate::ui::ui_firmware::MAX_PAIRED_DEVICES;
+#[cfg(feature = "ble")]
+use crate::{trezorhal::ble, ui::event::BLEEvent};
 
 #[repr(u8)]
 #[derive(Copy, Clone, Default, FromPrimitive, ToPrimitive, PartialEq, Eq)]

--- a/core/embed/rust/src/ui/layout_eckhart/firmware/fido.rs
+++ b/core/embed/rust/src/ui/layout_eckhart/firmware/fido.rs
@@ -1,21 +1,15 @@
-use crate::{
-    strutil::TString,
-    ui::{
-        component::{
-            image::Image,
-            paginated::SinglePage,
-            text::{
-                paragraphs::{Paragraph, ParagraphSource, ParagraphVecShort, Paragraphs},
-                TextStyle,
-            },
-            Component, Event, EventCtx, LineBreaking, Never,
-        },
-        geometry::{LinearPlacement, Rect},
-        shape::Renderer,
-    },
+use super::super::firmware::fido_icons::get_fido_icon_data;
+use super::super::theme;
+use crate::strutil::TString;
+use crate::ui::component::image::Image;
+use crate::ui::component::paginated::SinglePage;
+use crate::ui::component::text::paragraphs::{
+    Paragraph, ParagraphSource, ParagraphVecShort, Paragraphs,
 };
-
-use super::super::{firmware::fido_icons::get_fido_icon_data, theme};
+use crate::ui::component::text::TextStyle;
+use crate::ui::component::{Component, Event, EventCtx, LineBreaking, Never};
+use crate::ui::geometry::{LinearPlacement, Rect};
+use crate::ui::shape::Renderer;
 
 pub trait FidoAccountName: Fn() -> TString<'static> {}
 impl<T: Fn() -> TString<'static>> FidoAccountName for T {}

--- a/core/embed/rust/src/ui/layout_eckhart/firmware/header.rs
+++ b/core/embed/rust/src/ui/layout_eckhart/firmware/header.rs
@@ -1,17 +1,11 @@
-use crate::{
-    strutil::TString,
-    ui::{
-        component::{text::TextStyle, Component, Event, EventCtx, Label},
-        display::{Color, Icon},
-        geometry::{Alignment2D, Insets, Rect},
-        shape::{self, Renderer},
-    },
-};
-
-use super::{
-    super::component::{Button, ButtonContent, ButtonMsg, FuelGauge},
-    constant, theme,
-};
+use super::super::component::{Button, ButtonContent, ButtonMsg, FuelGauge};
+use super::{constant, theme};
+use crate::strutil::TString;
+use crate::ui::component::text::TextStyle;
+use crate::ui::component::{Component, Event, EventCtx, Label};
+use crate::ui::display::{Color, Icon};
+use crate::ui::geometry::{Alignment2D, Insets, Rect};
+use crate::ui::shape::{self, Renderer};
 
 /// Component for the header of a screen. Eckhart UI shows the title (can be two
 /// lines), optional icon button on the left, and optional icon button

--- a/core/embed/rust/src/ui/layout_eckhart/firmware/hint.rs
+++ b/core/embed/rust/src/ui/layout_eckhart/firmware/hint.rs
@@ -1,16 +1,13 @@
-use crate::{
-    strutil::{ShortString, TString},
-    ui::{
-        component::{text::TextStyle, Component, Event, EventCtx, Label, Never},
-        constant::screen,
-        display::{Color, Font, Icon},
-        geometry::{Alignment, Alignment2D, Insets, Point, Rect},
-        shape::{self, Renderer, Text},
-        util::Pager,
-    },
-};
-
-use super::{super::fonts, theme};
+use super::super::fonts;
+use super::theme;
+use crate::strutil::{ShortString, TString};
+use crate::ui::component::text::TextStyle;
+use crate::ui::component::{Component, Event, EventCtx, Label, Never};
+use crate::ui::constant::screen;
+use crate::ui::display::{Color, Font, Icon};
+use crate::ui::geometry::{Alignment, Alignment2D, Insets, Point, Rect};
+use crate::ui::shape::{self, Renderer, Text};
+use crate::ui::util::Pager;
 
 /// Component rendered above ActionBar, showing one of these:
 ///     - a task instruction/hint with optional icon, e.g. "Confirm

--- a/core/embed/rust/src/ui/layout_eckhart/firmware/hold_to_confirm.rs
+++ b/core/embed/rust/src/ui/layout_eckhart/firmware/hold_to_confirm.rs
@@ -1,28 +1,21 @@
-use crate::{
-    strutil::TString,
-    time::{Duration, Stopwatch},
-    ui::{
-        component::{Component, Event, EventCtx},
-        display::Color,
-        geometry::{Alignment2D, Insets, Offset, Rect},
-        lerp::Lerp,
-        shape::{self, Renderer},
-    },
-};
-
-use super::{
-    super::{cshape::ScreenBorder, firmware::Header, theme},
-    constant::SCREEN,
-};
-
 #[cfg(feature = "haptic")]
 use pareen;
 
+use super::super::cshape::ScreenBorder;
+use super::super::firmware::Header;
+use super::super::theme;
+use super::constant::SCREEN;
+use crate::strutil::TString;
+use crate::time::{Duration, Stopwatch};
 #[cfg(feature = "haptic")]
 use crate::trezorhal::haptic;
-
+use crate::ui::component::{Component, Event, EventCtx};
+use crate::ui::display::Color;
+use crate::ui::geometry::{Alignment2D, Insets, Offset, Rect};
 #[cfg(feature = "rgb_led")]
 use crate::ui::led::LedState;
+use crate::ui::lerp::Lerp;
+use crate::ui::shape::{self, Renderer};
 
 /// A component that displays a border that grows from the bottom of the screen
 /// to the top. The animation is parametrizable by color and duration.

--- a/core/embed/rust/src/ui/layout_eckhart/firmware/homescreen/header.rs
+++ b/core/embed/rust/src/ui/layout_eckhart/firmware/homescreen/header.rs
@@ -1,26 +1,17 @@
 use core::sync::atomic::{AtomicBool, Ordering};
 
-use crate::{
-    strutil::TString,
-    time::{Duration, Instant, Stopwatch},
-    ui::{
-        component::{Component, Event, EventCtx, Label, Never, Timer},
-        event::TouchEvent,
-        geometry::{Alignment2D, Offset, Point, Rect},
-        lerp::Lerp,
-        shape::Renderer,
-        util::animation_disabled,
-    },
-};
-
-use super::{
-    super::{
-        super::component::{ConnectionIndicator, FuelGauge},
-        constant::SCREEN,
-        theme,
-    },
-    helpers::{render_pill_shaped_background, SHADOW_HEIGHT},
-};
+use super::super::super::component::{ConnectionIndicator, FuelGauge};
+use super::super::constant::SCREEN;
+use super::super::theme;
+use super::helpers::{render_pill_shaped_background, SHADOW_HEIGHT};
+use crate::strutil::TString;
+use crate::time::{Duration, Instant, Stopwatch};
+use crate::ui::component::{Component, Event, EventCtx, Label, Never, Timer};
+use crate::ui::event::TouchEvent;
+use crate::ui::geometry::{Alignment2D, Offset, Point, Rect};
+use crate::ui::lerp::Lerp;
+use crate::ui::shape::Renderer;
+use crate::ui::util::animation_disabled;
 
 static FIRST_BOOT: AtomicBool = AtomicBool::new(true);
 

--- a/core/embed/rust/src/ui/layout_eckhart/firmware/homescreen/helpers.rs
+++ b/core/embed/rust/src/ui/layout_eckhart/firmware/homescreen/helpers.rs
@@ -1,17 +1,10 @@
-use crate::{
-    io::BinaryData,
-    ui::{
-        display::image::ImageInfo,
-        geometry::Rect,
-        layout::util::get_user_custom_image,
-        shape::{self, Renderer},
-    },
-};
-
-use super::super::{
-    constant::{HEIGHT, WIDTH},
-    theme,
-};
+use super::super::constant::{HEIGHT, WIDTH};
+use super::super::theme;
+use crate::io::BinaryData;
+use crate::ui::display::image::ImageInfo;
+use crate::ui::geometry::Rect;
+use crate::ui::layout::util::get_user_custom_image;
+use crate::ui::shape::{self, Renderer};
 
 pub const SHADOW_HEIGHT: i16 = 54;
 

--- a/core/embed/rust/src/ui/layout_eckhart/firmware/homescreen/mod.rs
+++ b/core/embed/rust/src/ui/layout_eckhart/firmware/homescreen/mod.rs
@@ -3,32 +3,25 @@ mod helpers;
 mod notification_center;
 
 use header::HomescreenHeader;
+pub use helpers::check_homescreen_format;
 use helpers::get_homescreen_image;
 use notification_center::HomescreenNotificationCenter;
 
-pub use helpers::check_homescreen_format;
-
-use crate::{
-    error::Error,
-    io::BinaryData,
-    strutil::TString,
-    translations::TR,
-    ui::{
-        component::{Component, Event, EventCtx, Swipe},
-        display::image::ImageInfo,
-        geometry::{Direction, Rect},
-        notification::Notification,
-        shape::{self, Renderer},
-        util::animation_disabled,
-    },
-};
-
-use super::{
-    super::component::{Button, ButtonContent},
-    constant::SCREEN,
-    theme::{self, firmware::button_homebar_style},
-    ActionBar, ActionBarMsg,
-};
+use super::super::component::{Button, ButtonContent};
+use super::constant::SCREEN;
+use super::theme::firmware::button_homebar_style;
+use super::theme::{self};
+use super::{ActionBar, ActionBarMsg};
+use crate::error::Error;
+use crate::io::BinaryData;
+use crate::strutil::TString;
+use crate::translations::TR;
+use crate::ui::component::{Component, Event, EventCtx, Swipe};
+use crate::ui::display::image::ImageInfo;
+use crate::ui::geometry::{Direction, Rect};
+use crate::ui::notification::Notification;
+use crate::ui::shape::{self, Renderer};
+use crate::ui::util::animation_disabled;
 
 /// Full-screen component for the homescreen and lockscreen.
 pub struct Homescreen {

--- a/core/embed/rust/src/ui/layout_eckhart/firmware/homescreen/notification_center.rs
+++ b/core/embed/rust/src/ui/layout_eckhart/firmware/homescreen/notification_center.rs
@@ -1,28 +1,19 @@
-use crate::{
-    strutil::TString,
-    time::Duration,
-    translations::TR,
-    ui::{
-        component::{Component, Event, EventCtx, Never, Timer},
-        display::Color,
-        geometry::{Alignment2D, Offset, Rect},
-        notification::{Notification, NotificationLevel},
-        shape::Renderer,
-        util::animation_disabled,
-    },
-};
-
-use super::{
-    super::{
-        super::component::{Button, ButtonContent},
-        theme::{self, firmware::button_homebar_style, ScreenBackground},
-        Hint,
-    },
-    helpers::{render_pill_shaped_background, SHADOW_HEIGHT},
-};
-
+use super::super::super::component::{Button, ButtonContent};
+use super::super::theme::firmware::button_homebar_style;
+use super::super::theme::{self, ScreenBackground};
+use super::super::Hint;
+use super::helpers::{render_pill_shaped_background, SHADOW_HEIGHT};
+use crate::strutil::TString;
+use crate::time::Duration;
+use crate::translations::TR;
+use crate::ui::component::{Component, Event, EventCtx, Never, Timer};
+use crate::ui::display::Color;
+use crate::ui::geometry::{Alignment2D, Offset, Rect};
 #[cfg(feature = "rgb_led")]
 use crate::ui::led::LedState;
+use crate::ui::notification::{Notification, NotificationLevel};
+use crate::ui::shape::Renderer;
+use crate::ui::util::animation_disabled;
 
 pub(super) struct HomescreenNotificationCenter {
     /// Current notification to display, if any

--- a/core/embed/rust/src/ui/layout_eckhart/firmware/keyboard/bip39.rs
+++ b/core/embed/rust/src/ui/layout_eckhart/firmware/keyboard/bip39.rs
@@ -1,20 +1,14 @@
-use crate::{
-    trezorhal::bip39,
-    ui::{
-        component::{text::common::TextBox, Component, Event, EventCtx},
-        geometry::{Alignment, Offset, Rect},
-        shape::{Renderer, Text},
-    },
+use super::super::super::component::{Button, ButtonMsg};
+use super::super::super::firmware::keyboard::common::{render_pending_marker, MultiTapKeyboard};
+use super::super::super::firmware::keyboard::mnemonic::{
+    MnemonicInput, MnemonicInputMsg, MNEMONIC_KEY_COUNT,
 };
-
-use super::super::super::{
-    component::{Button, ButtonMsg},
-    firmware::keyboard::{
-        common::{render_pending_marker, MultiTapKeyboard},
-        mnemonic::{MnemonicInput, MnemonicInputMsg, MNEMONIC_KEY_COUNT},
-    },
-    theme,
-};
+use super::super::super::theme;
+use crate::trezorhal::bip39;
+use crate::ui::component::text::common::TextBox;
+use crate::ui::component::{Component, Event, EventCtx};
+use crate::ui::geometry::{Alignment, Offset, Rect};
+use crate::ui::shape::{Renderer, Text};
 
 const MAX_LENGTH: usize = 8;
 

--- a/core/embed/rust/src/ui/layout_eckhart/firmware/keyboard/common.rs
+++ b/core/embed/rust/src/ui/layout_eckhart/firmware/keyboard/common.rs
@@ -1,14 +1,11 @@
-use crate::{
-    time::Duration,
-    ui::{
-        component::{text::common::TextEdit, Event, EventCtx, Timer},
-        display::{Color, Font},
-        geometry::{Insets, Offset, Point, Rect},
-        shape::{Bar, Renderer},
-    },
-};
-
-use super::super::{super::component::ButtonContent, theme};
+use super::super::super::component::ButtonContent;
+use super::super::theme;
+use crate::time::Duration;
+use crate::ui::component::text::common::TextEdit;
+use crate::ui::component::{Event, EventCtx, Timer};
+use crate::ui::display::{Color, Font};
+use crate::ui::geometry::{Insets, Offset, Point, Rect};
+use crate::ui::shape::{Bar, Renderer};
 
 /// Contains state commonly used in implementations multi-tap keyboards.
 pub struct MultiTapKeyboard {

--- a/core/embed/rust/src/ui/layout_eckhart/firmware/keyboard/keypad.rs
+++ b/core/embed/rust/src/ui/layout_eckhart/firmware/keyboard/keypad.rs
@@ -1,20 +1,11 @@
-use crate::{
-    trezorhal::random,
-    ui::{
-        component::{Component, Event, EventCtx, Maybe},
-        geometry::{Alignment, Insets, Offset, Rect},
-        shape::Renderer,
-    },
-};
-
-use super::{
-    super::super::{
-        component::{Button, ButtonContent, ButtonMsg, ButtonStyleSheet},
-        constant::SCREEN,
-        theme,
-    },
-    common::KEYPAD_VISIBLE_HEIGHT,
-};
+use super::super::super::component::{Button, ButtonContent, ButtonMsg, ButtonStyleSheet};
+use super::super::super::constant::SCREEN;
+use super::super::super::theme;
+use super::common::KEYPAD_VISIBLE_HEIGHT;
+use crate::trezorhal::random;
+use crate::ui::component::{Component, Event, EventCtx, Maybe};
+use crate::ui::geometry::{Alignment, Insets, Offset, Rect};
+use crate::ui::shape::Renderer;
 
 #[derive(PartialEq)]
 pub enum KeypadButton {
@@ -539,13 +530,9 @@ impl KeypadGrid {
 #[cfg(test)]
 mod tests {
 
-    use super::{
-        super::{
-            super::constant::SCREEN,
-            common::{INPUT_TOUCH_HEIGHT, KEYPAD_VISIBLE_HEIGHT},
-        },
-        *,
-    };
+    use super::super::super::constant::SCREEN;
+    use super::super::common::{INPUT_TOUCH_HEIGHT, KEYPAD_VISIBLE_HEIGHT};
+    use super::*;
 
     #[test]
     fn test_layout_constraints() {

--- a/core/embed/rust/src/ui/layout_eckhart/firmware/keyboard/label.rs
+++ b/core/embed/rust/src/ui/layout_eckhart/firmware/keyboard/label.rs
@@ -1,32 +1,19 @@
-use crate::{
-    strutil::TString,
-    ui::{
-        component::{
-            text::{
-                common::TextBox,
-                layout::{LayoutFit, LineBreaking},
-                TextStyle,
-            },
-            Component, Event, EventCtx, TextLayout,
-        },
-        event::TouchEvent,
-        geometry::{Alignment, Insets, Offset, Rect},
-        shape::{Bar, Renderer, Text},
-        util::long_line_content_with_ellipsis,
-    },
+use super::super::constant::SCREEN;
+use super::super::keyboard::common::{
+    render_pending_marker, MultiTapKeyboard, KEYBOARD_INPUT_INSETS, KEYBOARD_INPUT_RADIUS,
+    SHOWN_INSETS,
 };
-
-use super::super::{
-    constant::SCREEN,
-    keyboard::{
-        common::{
-            render_pending_marker, MultiTapKeyboard, KEYBOARD_INPUT_INSETS, KEYBOARD_INPUT_RADIUS,
-            SHOWN_INSETS,
-        },
-        keypad::{ButtonState, KeypadState},
-    },
-    theme, StringInput, StringInputMsg,
-};
+use super::super::keyboard::keypad::{ButtonState, KeypadState};
+use super::super::{theme, StringInput, StringInputMsg};
+use crate::strutil::TString;
+use crate::ui::component::text::common::TextBox;
+use crate::ui::component::text::layout::{LayoutFit, LineBreaking};
+use crate::ui::component::text::TextStyle;
+use crate::ui::component::{Component, Event, EventCtx, TextLayout};
+use crate::ui::event::TouchEvent;
+use crate::ui::geometry::{Alignment, Insets, Offset, Rect};
+use crate::ui::shape::{Bar, Renderer, Text};
+use crate::ui::util::long_line_content_with_ellipsis;
 
 #[derive(PartialEq, Debug, Copy, Clone)]
 #[cfg_attr(feature = "ui_debug", derive(ufmt::derive::uDebug))]

--- a/core/embed/rust/src/ui/layout_eckhart/firmware/keyboard/mnemonic.rs
+++ b/core/embed/rust/src/ui/layout_eckhart/firmware/keyboard/mnemonic.rs
@@ -1,22 +1,17 @@
-use crate::{
-    strutil::TString,
-    translations::TR,
-    ui::{
-        component::{Component, Event, EventCtx, Label},
-        geometry::Rect,
-        shape::Renderer,
-    },
+use super::super::super::component::ButtonContent;
+use super::super::super::constant::SCREEN;
+use super::super::super::firmware::keyboard::common::{
+    INPUT_TOUCH_HEIGHT, KEYBOARD_INPUT_INSETS, KEYPAD_VISIBLE_HEIGHT,
 };
-
-use super::super::super::{
-    component::ButtonContent,
-    constant::SCREEN,
-    firmware::keyboard::{
-        common::{INPUT_TOUCH_HEIGHT, KEYBOARD_INPUT_INSETS, KEYPAD_VISIBLE_HEIGHT},
-        keypad::{ButtonState, Keypad, KeypadButton, KeypadMsg},
-    },
-    theme,
+use super::super::super::firmware::keyboard::keypad::{
+    ButtonState, Keypad, KeypadButton, KeypadMsg,
 };
+use super::super::super::theme;
+use crate::strutil::TString;
+use crate::translations::TR;
+use crate::ui::component::{Component, Event, EventCtx, Label};
+use crate::ui::geometry::Rect;
+use crate::ui::shape::Renderer;
 
 pub const MNEMONIC_KEY_COUNT: usize = 9;
 

--- a/core/embed/rust/src/ui/layout_eckhart/firmware/keyboard/passphrase.rs
+++ b/core/embed/rust/src/ui/layout_eckhart/firmware/keyboard/passphrase.rs
@@ -1,34 +1,21 @@
-use crate::{
-    strutil::TString,
-    time::Duration,
-    ui::{
-        component::{
-            text::{
-                common::TextBox,
-                layout::{LayoutFit, LineBreaking},
-                TextStyle,
-            },
-            Component, Event, EventCtx, TextLayout, Timer,
-        },
-        display::Icon,
-        event::TouchEvent,
-        geometry::{Alignment, Alignment2D, Insets, Offset, Rect},
-        shape::{Bar, Renderer, Text, ToifImage},
-        util::DisplayStyle,
-    },
+use super::super::constant::SCREEN;
+use super::super::keyboard::common::{
+    render_pending_marker, MultiTapKeyboard, FADING_ICON_COLORS, FADING_ICON_COUNT,
+    KEYBOARD_INPUT_INSETS, KEYBOARD_INPUT_RADIUS, SHOWN_INSETS,
 };
-
-use super::super::{
-    constant::SCREEN,
-    keyboard::{
-        common::{
-            render_pending_marker, MultiTapKeyboard, FADING_ICON_COLORS, FADING_ICON_COUNT,
-            KEYBOARD_INPUT_INSETS, KEYBOARD_INPUT_RADIUS, SHOWN_INSETS,
-        },
-        keypad::{ButtonState, KeypadState},
-    },
-    theme, StringInput, StringInputMsg,
-};
+use super::super::keyboard::keypad::{ButtonState, KeypadState};
+use super::super::{theme, StringInput, StringInputMsg};
+use crate::strutil::TString;
+use crate::time::Duration;
+use crate::ui::component::text::common::TextBox;
+use crate::ui::component::text::layout::{LayoutFit, LineBreaking};
+use crate::ui::component::text::TextStyle;
+use crate::ui::component::{Component, Event, EventCtx, TextLayout, Timer};
+use crate::ui::display::Icon;
+use crate::ui::event::TouchEvent;
+use crate::ui::geometry::{Alignment, Alignment2D, Insets, Offset, Rect};
+use crate::ui::shape::{Bar, Renderer, Text, ToifImage};
+use crate::ui::util::DisplayStyle;
 
 pub struct PassphraseInput {
     area: Rect,

--- a/core/embed/rust/src/ui/layout_eckhart/firmware/keyboard/pin.rs
+++ b/core/embed/rust/src/ui/layout_eckhart/firmware/keyboard/pin.rs
@@ -1,29 +1,23 @@
 use heapless::String;
 
-use crate::{
-    strutil::{ShortString, TString},
-    time::Duration,
-    ui::{
-        component::{
-            text::{layout::LayoutFit, LineBreaking, TextStyle},
-            Component, Event, EventCtx, Label, TextLayout, Timer,
-        },
-        display::Icon,
-        event::TouchEvent,
-        geometry::{Alignment, Alignment2D, Insets, Offset, Rect},
-        shape::{Bar, Renderer, Text, ToifImage},
-        util::DisplayStyle,
-    },
+use super::super::super::component::ButtonContent;
+use super::super::super::constant::SCREEN;
+use super::super::super::theme;
+use super::common::{
+    FADING_ICON_COLORS, FADING_ICON_COUNT, INPUT_TOUCH_HEIGHT, KEYBOARD_INPUT_INSETS,
+    KEYBOARD_INPUT_RADIUS, KEYBOARD_PROMPT_INSETS, KEYPAD_VISIBLE_HEIGHT, SHOWN_INSETS,
 };
-
-use super::{
-    super::super::{component::ButtonContent, constant::SCREEN, theme},
-    common::{
-        FADING_ICON_COLORS, FADING_ICON_COUNT, INPUT_TOUCH_HEIGHT, KEYBOARD_INPUT_INSETS,
-        KEYBOARD_INPUT_RADIUS, KEYBOARD_PROMPT_INSETS, KEYPAD_VISIBLE_HEIGHT, SHOWN_INSETS,
-    },
-    keypad::{ButtonState, Keypad, KeypadMsg, KeypadState},
-};
+use super::keypad::{ButtonState, Keypad, KeypadMsg, KeypadState};
+use crate::strutil::{ShortString, TString};
+use crate::time::Duration;
+use crate::ui::component::text::layout::LayoutFit;
+use crate::ui::component::text::{LineBreaking, TextStyle};
+use crate::ui::component::{Component, Event, EventCtx, Label, TextLayout, Timer};
+use crate::ui::display::Icon;
+use crate::ui::event::TouchEvent;
+use crate::ui::geometry::{Alignment, Alignment2D, Insets, Offset, Rect};
+use crate::ui::shape::{Bar, Renderer, Text, ToifImage};
+use crate::ui::util::DisplayStyle;
 
 pub enum PinKeyboardMsg {
     Confirmed,

--- a/core/embed/rust/src/ui/layout_eckhart/firmware/keyboard/slip39.rs
+++ b/core/embed/rust/src/ui/layout_eckhart/firmware/keyboard/slip39.rs
@@ -1,26 +1,17 @@
-use crate::{
-    strutil::ShortString,
-    trezorhal::slip39,
-    ui::{
-        component::{
-            text::common::{TextBox, TextEdit},
-            Component, Event, EventCtx,
-        },
-        display::Icon,
-        geometry::{Alignment, Alignment2D, Offset, Rect},
-        shape::{Renderer, Text, ToifImage},
-        util::ResultExt,
-    },
+use super::super::super::component::{Button, ButtonMsg};
+use super::super::super::firmware::keyboard::common::{render_pending_marker, MultiTapKeyboard};
+use super::super::super::firmware::keyboard::mnemonic::{
+    MnemonicInput, MnemonicInputMsg, MNEMONIC_KEY_COUNT,
 };
-
-use super::super::super::{
-    component::{Button, ButtonMsg},
-    firmware::keyboard::{
-        common::{render_pending_marker, MultiTapKeyboard},
-        mnemonic::{MnemonicInput, MnemonicInputMsg, MNEMONIC_KEY_COUNT},
-    },
-    theme,
-};
+use super::super::super::theme;
+use crate::strutil::ShortString;
+use crate::trezorhal::slip39;
+use crate::ui::component::text::common::{TextBox, TextEdit};
+use crate::ui::component::{Component, Event, EventCtx};
+use crate::ui::display::Icon;
+use crate::ui::geometry::{Alignment, Alignment2D, Offset, Rect};
+use crate::ui::shape::{Renderer, Text, ToifImage};
+use crate::ui::util::ResultExt;
 
 const MAX_LENGTH: usize = 8;
 

--- a/core/embed/rust/src/ui/layout_eckhart/firmware/keyboard/string.rs
+++ b/core/embed/rust/src/ui/layout_eckhart/firmware/keyboard/string.rs
@@ -1,25 +1,17 @@
-use crate::{
-    strutil::{ShortString, TString},
-    ui::{
-        component::{swipe_detect::SwipeConfig, Component, Event, EventCtx, Label, Swipe},
-        flow::Swipable,
-        geometry::{Alignment, Direction, Insets, Rect},
-        shape::Renderer,
-        util::Pager,
-    },
+use super::super::super::component::{Button, ButtonContent, ButtonMsg, ButtonStyleSheet};
+use super::super::constant::SCREEN;
+use super::super::keyboard::common::{
+    KeyboardLayout, INPUT_TOUCH_HEIGHT, KEYBOARD_PROMPT_INSETS, KEYPAD_VISIBLE_HEIGHT,
 };
-
-use super::super::{
-    super::component::{Button, ButtonContent, ButtonMsg, ButtonStyleSheet},
-    constant::SCREEN,
-    keyboard::{
-        common::{
-            KeyboardLayout, INPUT_TOUCH_HEIGHT, KEYBOARD_PROMPT_INSETS, KEYPAD_VISIBLE_HEIGHT,
-        },
-        keypad::{Keypad, KeypadButton, KeypadMsg, KeypadState},
-    },
-    theme,
-};
+use super::super::keyboard::keypad::{Keypad, KeypadButton, KeypadMsg, KeypadState};
+use super::super::theme;
+use crate::strutil::{ShortString, TString};
+use crate::ui::component::swipe_detect::SwipeConfig;
+use crate::ui::component::{Component, Event, EventCtx, Label, Swipe};
+use crate::ui::flow::Swipable;
+use crate::ui::geometry::{Alignment, Direction, Insets, Rect};
+use crate::ui::shape::Renderer;
+use crate::ui::util::Pager;
 
 pub enum StringKeyboardMsg {
     Confirmed(ShortString),

--- a/core/embed/rust/src/ui/layout_eckhart/firmware/keyboard/word_count_screen.rs
+++ b/core/embed/rust/src/ui/layout_eckhart/firmware/keyboard/word_count_screen.rs
@@ -1,22 +1,13 @@
-use crate::{
-    strutil::TString,
-    ui::{
-        component::{Component, Event, EventCtx, Label},
-        geometry::{Alignment, Insets, Offset, Rect},
-        shape::Renderer,
-    },
-};
-
-use super::super::{
-    super::{
-        super::constant::SCREEN,
-        component::{Button, ButtonMsg},
-        theme,
-    },
-    Header,
-};
-
 use heapless::Vec;
+
+use super::super::super::super::constant::SCREEN;
+use super::super::super::component::{Button, ButtonMsg};
+use super::super::super::theme;
+use super::super::Header;
+use crate::strutil::TString;
+use crate::ui::component::{Component, Event, EventCtx, Label};
+use crate::ui::geometry::{Alignment, Insets, Offset, Rect};
+use crate::ui::shape::Renderer;
 
 pub enum SelectWordCountMsg {
     Cancelled,
@@ -280,7 +271,8 @@ impl Component for ValueKeypad {
 
 #[cfg(test)]
 mod tests {
-    use super::{super::super::constant::SCREEN, *};
+    use super::super::super::constant::SCREEN;
+    use super::*;
 
     #[test]
     fn test_component_heights_fit_screen() {

--- a/core/embed/rust/src/ui/layout_eckhart/firmware/mod.rs
+++ b/core/embed/rust/src/ui/layout_eckhart/firmware/mod.rs
@@ -31,16 +31,14 @@ pub use header::{Header, HeaderMsg};
 pub use hint::Hint;
 pub use hold_to_confirm::{HoldToConfirmAnim, HoldToConfirmMsg};
 pub use homescreen::{check_homescreen_format, Homescreen, HomescreenMsg};
-pub use keyboard::{
-    bip39::Bip39Input,
-    label::LabelInput,
-    mnemonic::{MnemonicInput, MnemonicKeyboard, MnemonicKeyboardMsg},
-    passphrase::PassphraseInput,
-    pin::{PinKeyboard, PinKeyboardMsg},
-    slip39::Slip39Input,
-    string::{StringInput, StringInputMsg, StringKeyboard, StringKeyboardMsg},
-    word_count_screen::{SelectWordCountMsg, SelectWordCountScreen},
-};
+pub use keyboard::bip39::Bip39Input;
+pub use keyboard::label::LabelInput;
+pub use keyboard::mnemonic::{MnemonicInput, MnemonicKeyboard, MnemonicKeyboardMsg};
+pub use keyboard::passphrase::PassphraseInput;
+pub use keyboard::pin::{PinKeyboard, PinKeyboardMsg};
+pub use keyboard::slip39::Slip39Input;
+pub use keyboard::string::{StringInput, StringInputMsg, StringKeyboard, StringKeyboardMsg};
+pub use keyboard::word_count_screen::{SelectWordCountMsg, SelectWordCountScreen};
 pub use progress_screen::ProgressScreen;
 pub use qr_screen::{QrMsg, QrScreen};
 pub use regulatory_screen::{RegulatoryMsg, RegulatoryScreen};

--- a/core/embed/rust/src/ui/layout_eckhart/firmware/progress_screen.rs
+++ b/core/embed/rust/src/ui/layout_eckhart/firmware/progress_screen.rs
@@ -1,21 +1,14 @@
 use core::mem;
 
-use crate::{
-    strutil::TString,
-    translations::TR,
-    ui::{
-        component::{Component, Event, EventCtx, Label, Never},
-        geometry::{Alignment2D, Offset, Rect},
-        shape::Renderer,
-        util::animation_disabled,
-    },
-};
-
-use super::super::{
-    constant::SCREEN,
-    cshape::{render_loader, render_loader_indeterminate, ScreenBorder},
-    theme,
-};
+use super::super::constant::SCREEN;
+use super::super::cshape::{render_loader, render_loader_indeterminate, ScreenBorder};
+use super::super::theme;
+use crate::strutil::TString;
+use crate::translations::TR;
+use crate::ui::component::{Component, Event, EventCtx, Label, Never};
+use crate::ui::geometry::{Alignment2D, Offset, Rect};
+use crate::ui::shape::Renderer;
+use crate::ui::util::animation_disabled;
 
 const LOADER_SPEED: u16 = 5;
 

--- a/core/embed/rust/src/ui/layout_eckhart/firmware/qr_screen.rs
+++ b/core/embed/rust/src/ui/layout_eckhart/firmware/qr_screen.rs
@@ -1,19 +1,13 @@
-use crate::{
-    strutil::TString,
-    ui::{
-        component::{swipe_detect::SwipeConfig, Component, Event, EventCtx, Label, Pad, Qr},
-        flow::Swipable,
-        geometry::{Alignment, Insets, Rect},
-        shape::Renderer,
-        util::Pager,
-    },
-};
-
-use super::super::{
-    component::{Button, ButtonMsg},
-    constant::SCREEN,
-    firmware::{theme, Header},
-};
+use super::super::component::{Button, ButtonMsg};
+use super::super::constant::SCREEN;
+use super::super::firmware::{theme, Header};
+use crate::strutil::TString;
+use crate::ui::component::swipe_detect::SwipeConfig;
+use crate::ui::component::{Component, Event, EventCtx, Label, Pad, Qr};
+use crate::ui::flow::Swipable;
+use crate::ui::geometry::{Alignment, Insets, Rect};
+use crate::ui::shape::Renderer;
+use crate::ui::util::Pager;
 
 pub enum QrMsg {
     Cancelled,

--- a/core/embed/rust/src/ui/layout_eckhart/firmware/regulatory_screen.rs
+++ b/core/embed/rust/src/ui/layout_eckhart/firmware/regulatory_screen.rs
@@ -1,28 +1,17 @@
-use crate::{
-    strutil::TString,
-    translations::TR,
-    ui::{
-        component::{
-            swipe_detect::SwipeConfig,
-            text::{
-                layout::{LayoutFit, TextLayout},
-                TextStyle,
-            },
-            Component, Event, EventCtx, Never, Paginate,
-        },
-        display::Icon,
-        flow::Swipable,
-        geometry::{Alignment, Alignment2D, Direction, Rect},
-        shape::{Renderer, ToifImage},
-        util::Pager,
-    },
-};
-
-use super::super::{
-    constant::SCREEN,
-    firmware::{ActionBar, ActionBarMsg, Header, HeaderMsg},
-    theme,
-};
+use super::super::constant::SCREEN;
+use super::super::firmware::{ActionBar, ActionBarMsg, Header, HeaderMsg};
+use super::super::theme;
+use crate::strutil::TString;
+use crate::translations::TR;
+use crate::ui::component::swipe_detect::SwipeConfig;
+use crate::ui::component::text::layout::{LayoutFit, TextLayout};
+use crate::ui::component::text::TextStyle;
+use crate::ui::component::{Component, Event, EventCtx, Never, Paginate};
+use crate::ui::display::Icon;
+use crate::ui::flow::Swipable;
+use crate::ui::geometry::{Alignment, Alignment2D, Direction, Rect};
+use crate::ui::shape::{Renderer, ToifImage};
+use crate::ui::util::Pager;
 
 /// Full-screen component for rendering Regulatory certification.
 pub struct RegulatoryScreen {

--- a/core/embed/rust/src/ui/layout_eckhart/firmware/select_word_screen.rs
+++ b/core/embed/rust/src/ui/layout_eckhart/firmware/select_word_screen.rs
@@ -1,22 +1,15 @@
 use heapless::Vec;
 
-use crate::{
-    strutil::TString,
-    ui::{
-        component::{Component, Event, EventCtx, Label},
-        geometry::{Alignment, Insets, Offset, Rect},
-        shape,
-        shape::Renderer,
-        ui_firmware::MAX_WORD_QUIZ_ITEMS,
-    },
-};
-
-use super::super::{
-    component::{Button, ButtonMsg},
-    constant::SCREEN,
-    firmware::{Header, HeaderMsg},
-    theme,
-};
+use super::super::component::{Button, ButtonMsg};
+use super::super::constant::SCREEN;
+use super::super::firmware::{Header, HeaderMsg};
+use super::super::theme;
+use crate::strutil::TString;
+use crate::ui::component::{Component, Event, EventCtx, Label};
+use crate::ui::geometry::{Alignment, Insets, Offset, Rect};
+use crate::ui::shape;
+use crate::ui::shape::Renderer;
+use crate::ui::ui_firmware::MAX_WORD_QUIZ_ITEMS;
 
 pub struct SelectWordScreen {
     header: Header,
@@ -183,7 +176,8 @@ impl crate::trace::Trace for SelectWordScreen {
 
 #[cfg(test)]
 mod tests {
-    use super::{super::super::constant::SCREEN, *};
+    use super::super::super::constant::SCREEN;
+    use super::*;
 
     #[test]
     fn test_component_heights_fit_screen() {

--- a/core/embed/rust/src/ui/layout_eckhart/firmware/share_words.rs
+++ b/core/embed/rust/src/ui/layout_eckhart/firmware/share_words.rs
@@ -1,26 +1,18 @@
-use crate::{
-    strutil::TString,
-    translations::TR,
-    ui::{
-        component::{
-            swipe_detect::SwipeConfig, text::TextStyle, Component, Event, EventCtx, Label, Never,
-            Paginate, Swipe,
-        },
-        flow::Swipable,
-        geometry::{Alignment, Direction, Insets, Offset, Rect},
-        shape::{Bar, Renderer, Text},
-        util::Pager,
-    },
-};
-
 use heapless::Vec;
 
-use super::super::{
-    component::Button,
-    constant::SCREEN,
-    firmware::{ActionBar, ActionBarMsg, Header, HeaderMsg, Hint},
-    fonts, theme,
-};
+use super::super::component::Button;
+use super::super::constant::SCREEN;
+use super::super::firmware::{ActionBar, ActionBarMsg, Header, HeaderMsg, Hint};
+use super::super::{fonts, theme};
+use crate::strutil::TString;
+use crate::translations::TR;
+use crate::ui::component::swipe_detect::SwipeConfig;
+use crate::ui::component::text::TextStyle;
+use crate::ui::component::{Component, Event, EventCtx, Label, Never, Paginate, Swipe};
+use crate::ui::flow::Swipable;
+use crate::ui::geometry::{Alignment, Direction, Insets, Offset, Rect};
+use crate::ui::shape::{Bar, Renderer, Text};
+use crate::ui::util::Pager;
 
 const MAX_WORDS: usize = 33; // super-shamir has 33 words, all other have less
 type IndexVec = Vec<u8, MAX_WORDS>;
@@ -340,7 +332,8 @@ impl<'a> crate::trace::Trace for ShareWords<'a> {
 
 #[cfg(test)]
 mod tests {
-    use super::{super::super::constant::SCREEN, *};
+    use super::super::super::constant::SCREEN;
+    use super::*;
 
     #[test]
     fn test_component_heights_fit_screen() {

--- a/core/embed/rust/src/ui/layout_eckhart/firmware/text_screen.rs
+++ b/core/embed/rust/src/ui/layout_eckhart/firmware/text_screen.rs
@@ -1,26 +1,17 @@
-use crate::{
-    strutil::TString,
-    ui::{
-        component::{
-            swipe_detect::SwipeConfig,
-            text::{
-                layout::LayoutFit,
-                paragraphs::{Checklist, ParagraphSource, Paragraphs},
-                TextStyle,
-            },
-            Component, Event, EventCtx, FormattedText, Label, Paginate, TextLayout,
-        },
-        flow::Swipable,
-        geometry::{Offset, Rect},
-        shape::Renderer,
-        util::Pager,
-    },
+use super::theme::{self, ScreenBackground, CONTENT_INSETS_NO_HEADER, SIDE_INSETS};
+use super::{ActionBar, ActionBarMsg, FidoAccountName, FidoCredential, Header, HeaderMsg, Hint};
+use crate::strutil::TString;
+use crate::ui::component::swipe_detect::SwipeConfig;
+use crate::ui::component::text::layout::LayoutFit;
+use crate::ui::component::text::paragraphs::{Checklist, ParagraphSource, Paragraphs};
+use crate::ui::component::text::TextStyle;
+use crate::ui::component::{
+    Component, Event, EventCtx, FormattedText, Label, Paginate, TextLayout,
 };
-
-use super::{
-    theme::{self, ScreenBackground, CONTENT_INSETS_NO_HEADER, SIDE_INSETS},
-    ActionBar, ActionBarMsg, FidoAccountName, FidoCredential, Header, HeaderMsg, Hint,
-};
+use crate::ui::flow::Swipable;
+use crate::ui::geometry::{Offset, Rect};
+use crate::ui::shape::Renderer;
+use crate::ui::util::Pager;
 
 const SUBTITLE_HEIGHT: i16 = 44;
 const SUBTITLE_DOUBLE_HEIGHT: i16 = 76;

--- a/core/embed/rust/src/ui/layout_eckhart/firmware/tutorial_screen.rs
+++ b/core/embed/rust/src/ui/layout_eckhart/firmware/tutorial_screen.rs
@@ -1,28 +1,20 @@
-use crate::{
-    time::{Duration, Stopwatch},
-    translations::TR,
-    ui::{
-        component::{swipe_detect::SwipeConfig, Component, Event, EventCtx, Label},
-        display::{toif::Toif, Color},
-        flow::Swipable,
-        geometry::{Alignment, Alignment2D, Insets, Offset, Point, Rect},
-        shape::{Bar, Renderer, ToifImage},
-        util::{animation_disabled, Pager},
-    },
-};
-
-use super::{
-    super::{
-        component::Button,
-        constant::SCREEN,
-        cshape::{render_loader_indeterminate, ScreenBorder},
-        theme::{self, ScreenBackground},
-    },
-    ActionBar, ActionBarMsg,
-};
-
+use super::super::component::Button;
+use super::super::constant::SCREEN;
+use super::super::cshape::{render_loader_indeterminate, ScreenBorder};
+use super::super::theme::{self, ScreenBackground};
+use super::{ActionBar, ActionBarMsg};
+use crate::time::{Duration, Stopwatch};
+use crate::translations::TR;
+use crate::ui::component::swipe_detect::SwipeConfig;
+use crate::ui::component::{Component, Event, EventCtx, Label};
+use crate::ui::display::toif::Toif;
+use crate::ui::display::Color;
+use crate::ui::flow::Swipable;
+use crate::ui::geometry::{Alignment, Alignment2D, Insets, Offset, Point, Rect};
 #[cfg(feature = "rgb_led")]
 use crate::ui::led::LedState;
+use crate::ui::shape::{Bar, Renderer, ToifImage};
+use crate::ui::util::{animation_disabled, Pager};
 
 // Duration of the loader animation
 const LOADER_DURATION: Duration = Duration::from_secs(3);

--- a/core/embed/rust/src/ui/layout_eckhart/firmware/updatable_info_screen.rs
+++ b/core/embed/rust/src/ui/layout_eckhart/firmware/updatable_info_screen.rs
@@ -1,20 +1,14 @@
-use crate::{
-    strutil::TString,
-    translations::TR,
-    ui::{
-        component::{
-            swipe_detect::SwipeConfig,
-            text::paragraphs::{Paragraph, ParagraphSource, Paragraphs},
-            Component, Event, EventCtx, Paginate,
-        },
-        flow::Swipable,
-        geometry::{LinearPlacement, Rect},
-        shape::Renderer,
-        util::Pager,
-    },
-};
-
-use super::{constant::SCREEN, theme, ActionBar, ActionBarMsg, Header};
+use super::constant::SCREEN;
+use super::{theme, ActionBar, ActionBarMsg, Header};
+use crate::strutil::TString;
+use crate::translations::TR;
+use crate::ui::component::swipe_detect::SwipeConfig;
+use crate::ui::component::text::paragraphs::{Paragraph, ParagraphSource, Paragraphs};
+use crate::ui::component::{Component, Event, EventCtx, Paginate};
+use crate::ui::flow::Swipable;
+use crate::ui::geometry::{LinearPlacement, Rect};
+use crate::ui::shape::Renderer;
+use crate::ui::util::Pager;
 
 pub enum UpdatableInfoScreenMsg {
     Close,

--- a/core/embed/rust/src/ui/layout_eckhart/firmware/value_input_screen.rs
+++ b/core/embed/rust/src/ui/layout_eckhart/firmware/value_input_screen.rs
@@ -1,24 +1,16 @@
-use crate::{
-    strutil::{self, plural_form, ShortString, TString},
-    time::Duration,
-    translations::TR,
-    ui::{
-        component::{swipe_detect::SwipeConfig, Component, Event, EventCtx, Label, Maybe, Timer},
-        flow::Swipable,
-        geometry::{Alignment, Insets, Offset, Rect},
-        shape::{self, Renderer},
-        util::Pager,
-    },
-};
-
-use super::{
-    super::{
-        super::constant::SCREEN,
-        component::{Button, ButtonMsg},
-        fonts, theme,
-    },
-    ActionBar, ActionBarMsg, Header, HeaderMsg,
-};
+use super::super::super::constant::SCREEN;
+use super::super::component::{Button, ButtonMsg};
+use super::super::{fonts, theme};
+use super::{ActionBar, ActionBarMsg, Header, HeaderMsg};
+use crate::strutil::{self, plural_form, ShortString, TString};
+use crate::time::Duration;
+use crate::translations::TR;
+use crate::ui::component::swipe_detect::SwipeConfig;
+use crate::ui::component::{Component, Event, EventCtx, Label, Maybe, Timer};
+use crate::ui::flow::Swipable;
+use crate::ui::geometry::{Alignment, Insets, Offset, Rect};
+use crate::ui::shape::{self, Renderer};
+use crate::ui::util::Pager;
 
 pub enum ValueInputScreenMsg {
     Cancelled,
@@ -525,7 +517,8 @@ impl DurationInput {
 
 #[cfg(test)]
 mod tests {
-    use super::{super::super::constant::SCREEN, *};
+    use super::super::super::constant::SCREEN;
+    use super::*;
 
     #[test]
     fn test_component_heights_fit_screen() {

--- a/core/embed/rust/src/ui/layout_eckhart/firmware/vertical_menu.rs
+++ b/core/embed/rust/src/ui/layout_eckhart/firmware/vertical_menu.rs
@@ -1,21 +1,15 @@
 use core::ops::DerefMut;
 
-use crate::{
-    micropython::gc::GcBox,
-    ui::{
-        component::{Component, Event, EventCtx},
-        event::TouchEvent,
-        geometry::{Direction, Insets, Offset, Rect},
-        shape::{Bar, Renderer},
-        util::animation_disabled,
-    },
-};
-
-use super::{
-    super::component::{Button, ButtonMsg, HapticMode},
-    theme,
-};
 use heapless::Vec;
+
+use super::super::component::{Button, ButtonMsg, HapticMode};
+use super::theme;
+use crate::micropython::gc::GcBox;
+use crate::ui::component::{Component, Event, EventCtx};
+use crate::ui::event::TouchEvent;
+use crate::ui::geometry::{Direction, Insets, Offset, Rect};
+use crate::ui::shape::{Bar, Renderer};
+use crate::ui::util::animation_disabled;
 
 /// Number of buttons.
 /// Presently, VerticalMenu holds only fixed number of buttons.

--- a/core/embed/rust/src/ui/layout_eckhart/firmware/vertical_menu_screen.rs
+++ b/core/embed/rust/src/ui/layout_eckhart/firmware/vertical_menu_screen.rs
@@ -1,25 +1,20 @@
-use crate::{
-    strutil::TString,
-    time::Instant,
-    ui::{
-        component::{
-            swipe_detect::{SwipeConfig, SwipeSettings},
-            text::{layout::LayoutFit, TextStyle},
-            Component, Event, EventCtx, Label, LineBreaking, SwipeDetect, TextLayout,
-        },
-        display::Icon,
-        event::SwipeEvent,
-        flow::Swipable,
-        geometry::{Alignment2D, Direction, Insets, Offset, Rect},
-        shape::{Renderer, ToifImage},
-        util::{animation_disabled, Pager},
-    },
+use super::super::component::HapticMode;
+use super::constant::SCREEN;
+use super::{theme, Header, HeaderMsg, MenuItems, ShortMenuVec, VerticalMenu, VerticalMenuMsg};
+use crate::strutil::TString;
+use crate::time::Instant;
+use crate::ui::component::swipe_detect::{SwipeConfig, SwipeSettings};
+use crate::ui::component::text::layout::LayoutFit;
+use crate::ui::component::text::TextStyle;
+use crate::ui::component::{
+    Component, Event, EventCtx, Label, LineBreaking, SwipeDetect, TextLayout,
 };
-
-use super::{
-    super::component::HapticMode, constant::SCREEN, theme, Header, HeaderMsg, MenuItems,
-    ShortMenuVec, VerticalMenu, VerticalMenuMsg,
-};
+use crate::ui::display::Icon;
+use crate::ui::event::SwipeEvent;
+use crate::ui::flow::Swipable;
+use crate::ui::geometry::{Alignment2D, Direction, Insets, Offset, Rect};
+use crate::ui::shape::{Renderer, ToifImage};
+use crate::ui::util::{animation_disabled, Pager};
 
 pub struct VerticalMenuScreen<T> {
     header: Header,
@@ -474,7 +469,8 @@ impl<T: MenuItems> crate::trace::Trace for VerticalMenuScreen<T> {
 
 #[cfg(test)]
 mod tests {
-    use super::{super::VerticalMenu, *};
+    use super::super::VerticalMenu;
+    use super::*;
 
     #[test]
     fn test_min_offset() {

--- a/core/embed/rust/src/ui/layout_eckhart/flow/confirm_fido.rs
+++ b/core/embed/rust/src/ui/layout_eckhart/flow/confirm_fido.rs
@@ -1,31 +1,22 @@
-use crate::{
-    error,
-    micropython::{gc::Gc, list::List},
-    strutil::TString,
-    translations::TR,
-    ui::{
-        component::{
-            base::ComponentExt,
-            text::paragraphs::{Paragraph, ParagraphSource},
-        },
-        flow::{
-            base::{Decision, DecisionBuilder as _},
-            FlowController, FlowMsg, SwipeFlow,
-        },
-        geometry::{Direction, LinearPlacement},
-    },
-};
-
-use super::super::{
-    component::Button,
-    firmware::{
-        ActionBar, FidoCredential, Header, LongMenuGc, ShortMenuVec, TextScreen, TextScreenMsg,
-        VerticalMenu, VerticalMenuScreen, VerticalMenuScreenMsg,
-    },
-    theme::{self, gradient::Gradient},
-};
-
 use core::sync::atomic::{AtomicBool, AtomicUsize, Ordering};
+
+use super::super::component::Button;
+use super::super::firmware::{
+    ActionBar, FidoCredential, Header, LongMenuGc, ShortMenuVec, TextScreen, TextScreenMsg,
+    VerticalMenu, VerticalMenuScreen, VerticalMenuScreenMsg,
+};
+use super::super::theme::gradient::Gradient;
+use super::super::theme::{self};
+use crate::error;
+use crate::micropython::gc::Gc;
+use crate::micropython::list::List;
+use crate::strutil::TString;
+use crate::translations::TR;
+use crate::ui::component::base::ComponentExt;
+use crate::ui::component::text::paragraphs::{Paragraph, ParagraphSource};
+use crate::ui::flow::base::{Decision, DecisionBuilder as _};
+use crate::ui::flow::{FlowController, FlowMsg, SwipeFlow};
+use crate::ui::geometry::{Direction, LinearPlacement};
 
 #[derive(Copy, Clone, PartialEq, Eq)]
 pub enum ConfirmFido {

--- a/core/embed/rust/src/ui/layout_eckhart/flow/confirm_firmware_update.rs
+++ b/core/embed/rust/src/ui/layout_eckhart/flow/confirm_firmware_update.rs
@@ -1,28 +1,17 @@
-use crate::{
-    error,
-    strutil::TString,
-    translations::TR,
-    ui::{
-        component::{
-            text::paragraphs::{Paragraph, ParagraphSource},
-            ComponentExt,
-        },
-        flow::{
-            base::{Decision, DecisionBuilder as _},
-            FlowController, FlowMsg, SwipeFlow,
-        },
-        geometry::{Direction, LinearPlacement},
-    },
+use super::super::component::Button;
+use super::super::firmware::{
+    ActionBar, Header, Hint, ShortMenuVec, TextScreen, TextScreenMsg, VerticalMenu,
+    VerticalMenuScreen, VerticalMenuScreenMsg,
 };
-
-use super::super::{
-    component::Button,
-    firmware::{
-        ActionBar, Header, Hint, ShortMenuVec, TextScreen, TextScreenMsg, VerticalMenu,
-        VerticalMenuScreen, VerticalMenuScreenMsg,
-    },
-    theme,
-};
+use super::super::theme;
+use crate::error;
+use crate::strutil::TString;
+use crate::translations::TR;
+use crate::ui::component::text::paragraphs::{Paragraph, ParagraphSource};
+use crate::ui::component::ComponentExt;
+use crate::ui::flow::base::{Decision, DecisionBuilder as _};
+use crate::ui::flow::{FlowController, FlowMsg, SwipeFlow};
+use crate::ui::geometry::{Direction, LinearPlacement};
 
 #[derive(Copy, Clone, PartialEq, Eq)]
 pub enum ConfirmFirmwareUpdate {

--- a/core/embed/rust/src/ui/layout_eckhart/flow/confirm_reset.rs
+++ b/core/embed/rust/src/ui/layout_eckhart/flow/confirm_reset.rs
@@ -1,28 +1,18 @@
-use crate::{
-    error,
-    translations::TR,
-    ui::{
-        button_request::ButtonRequestCode,
-        component::{
-            text::paragraphs::{Paragraph, ParagraphSource},
-            ButtonRequestExt, ComponentExt,
-        },
-        flow::{
-            base::{Decision, DecisionBuilder as _},
-            FlowController, FlowMsg, SwipeFlow,
-        },
-        geometry::{Direction, LinearPlacement},
-    },
+use super::super::component::Button;
+use super::super::firmware::{
+    ActionBar, Header, Hint, ShortMenuVec, TextScreen, TextScreenMsg, VerticalMenu,
+    VerticalMenuScreen, VerticalMenuScreenMsg,
 };
-
-use super::super::{
-    component::Button,
-    firmware::{
-        ActionBar, Header, Hint, ShortMenuVec, TextScreen, TextScreenMsg, VerticalMenu,
-        VerticalMenuScreen, VerticalMenuScreenMsg,
-    },
-    theme::{self, gradient::Gradient},
-};
+use super::super::theme::gradient::Gradient;
+use super::super::theme::{self};
+use crate::error;
+use crate::translations::TR;
+use crate::ui::button_request::ButtonRequestCode;
+use crate::ui::component::text::paragraphs::{Paragraph, ParagraphSource};
+use crate::ui::component::{ButtonRequestExt, ComponentExt};
+use crate::ui::flow::base::{Decision, DecisionBuilder as _};
+use crate::ui::flow::{FlowController, FlowMsg, SwipeFlow};
+use crate::ui::geometry::{Direction, LinearPlacement};
 
 #[derive(Copy, Clone, PartialEq, Eq)]
 pub enum ConfirmReset {

--- a/core/embed/rust/src/ui/layout_eckhart/flow/confirm_set_new_code.rs
+++ b/core/embed/rust/src/ui/layout_eckhart/flow/confirm_set_new_code.rs
@@ -1,28 +1,20 @@
-use crate::{
-    error,
-    strutil::TString,
-    translations::TR,
-    ui::{
-        component::{
-            text::paragraphs::{Paragraph, ParagraphSource, ParagraphVecShort, Paragraphs},
-            ComponentExt as _,
-        },
-        flow::{
-            base::{Decision, DecisionBuilder as _},
-            FlowController, FlowMsg, SwipeFlow,
-        },
-        geometry::{Direction, LinearPlacement},
-    },
+use super::super::component::Button;
+use super::super::firmware::{
+    ActionBar, Header, ShortMenuVec, TextScreen, TextScreenMsg, VerticalMenu, VerticalMenuScreen,
+    VerticalMenuScreenMsg,
 };
-
-use super::super::{
-    component::Button,
-    firmware::{
-        ActionBar, Header, ShortMenuVec, TextScreen, TextScreenMsg, VerticalMenu,
-        VerticalMenuScreen, VerticalMenuScreenMsg,
-    },
-    theme::{self, gradient::Gradient},
+use super::super::theme::gradient::Gradient;
+use super::super::theme::{self};
+use crate::error;
+use crate::strutil::TString;
+use crate::translations::TR;
+use crate::ui::component::text::paragraphs::{
+    Paragraph, ParagraphSource, ParagraphVecShort, Paragraphs,
 };
+use crate::ui::component::ComponentExt as _;
+use crate::ui::flow::base::{Decision, DecisionBuilder as _};
+use crate::ui::flow::{FlowController, FlowMsg, SwipeFlow};
+use crate::ui::geometry::{Direction, LinearPlacement};
 
 #[derive(Copy, Clone, PartialEq, Eq)]
 pub enum SetNewCode {

--- a/core/embed/rust/src/ui/layout_eckhart/flow/confirm_summary.rs
+++ b/core/embed/rust/src/ui/layout_eckhart/flow/confirm_summary.rs
@@ -1,34 +1,26 @@
 use heapless::Vec;
 
-use crate::{
-    error::{self},
-    strutil::TString,
-    time::Duration,
-    translations::TR,
-    ui::{
-        component::{
-            text::paragraphs::{Paragraph, ParagraphSource, ParagraphVecShort, VecExt},
-            ComponentExt,
-        },
-        flow::{
-            base::{Decision, DecisionBuilder as _},
-            FlowController, FlowMsg, SwipeFlow,
-        },
-        geometry::{Direction, LinearPlacement},
-        layout::util::PropsList,
-    },
+use super::super::component::Button;
+use super::super::firmware::{
+    ActionBar, Header, Hint, ShortMenuVec, TextScreen, TextScreenMsg, VerticalMenu,
+    VerticalMenuScreen, VerticalMenuScreenMsg,
 };
-
-use super::super::{
-    component::Button,
-    firmware::{
-        ActionBar, Header, Hint, ShortMenuVec, TextScreen, TextScreenMsg, VerticalMenu,
-        VerticalMenuScreen, VerticalMenuScreenMsg,
-    },
-    flow,
-    flow::util::content_menu_info,
-    theme::{self, gradient::Gradient},
+use super::super::flow;
+use super::super::flow::util::content_menu_info;
+use super::super::theme::gradient::Gradient;
+use super::super::theme::{self};
+use crate::error::{self};
+use crate::strutil::TString;
+use crate::time::Duration;
+use crate::translations::TR;
+use crate::ui::component::text::paragraphs::{
+    Paragraph, ParagraphSource, ParagraphVecShort, VecExt,
 };
+use crate::ui::component::ComponentExt;
+use crate::ui::flow::base::{Decision, DecisionBuilder as _};
+use crate::ui::flow::{FlowController, FlowMsg, SwipeFlow};
+use crate::ui::geometry::{Direction, LinearPlacement};
+use crate::ui::layout::util::PropsList;
 
 const MENU_ITEM_CANCEL: usize = 0;
 const MENU_ITEM_EXTRA_INFO: usize = 1;

--- a/core/embed/rust/src/ui/layout_eckhart/flow/confirm_value_intro.rs
+++ b/core/embed/rust/src/ui/layout_eckhart/flow/confirm_value_intro.rs
@@ -1,30 +1,19 @@
-use crate::{
-    error,
-    micropython::obj::Obj,
-    strutil::TString,
-    translations::TR,
-    ui::{
-        component::{
-            text::paragraphs::{Paragraph, ParagraphSource},
-            ComponentExt,
-        },
-        flow::{
-            base::{Decision, DecisionBuilder as _},
-            FlowController, FlowMsg, SwipeFlow,
-        },
-        geometry::{Direction, LinearPlacement},
-        layout::util::StrOrBytes,
-    },
+use super::super::component::Button;
+use super::super::firmware::{
+    ActionBar, Header, ShortMenuVec, TextScreen, TextScreenMsg, VerticalMenu, VerticalMenuScreen,
+    VerticalMenuScreenMsg,
 };
-
-use super::super::{
-    component::Button,
-    firmware::{
-        ActionBar, Header, ShortMenuVec, TextScreen, TextScreenMsg, VerticalMenu,
-        VerticalMenuScreen, VerticalMenuScreenMsg,
-    },
-    theme,
-};
+use super::super::theme;
+use crate::error;
+use crate::micropython::obj::Obj;
+use crate::strutil::TString;
+use crate::translations::TR;
+use crate::ui::component::text::paragraphs::{Paragraph, ParagraphSource};
+use crate::ui::component::ComponentExt;
+use crate::ui::flow::base::{Decision, DecisionBuilder as _};
+use crate::ui::flow::{FlowController, FlowMsg, SwipeFlow};
+use crate::ui::geometry::{Direction, LinearPlacement};
+use crate::ui::layout::util::StrOrBytes;
 
 const TIMEOUT_MS: u32 = 2000;
 

--- a/core/embed/rust/src/ui/layout_eckhart/flow/confirm_with_menu.rs
+++ b/core/embed/rust/src/ui/layout_eckhart/flow/confirm_with_menu.rs
@@ -1,28 +1,20 @@
 use heapless::Vec;
 
-use crate::{
-    error,
-    maybe_trace::MaybeTrace,
-    strutil::TString,
-    translations::TR,
-    ui::{
-        component::ComponentExt,
-        flow::{
-            base::{Decision, DecisionBuilder as _},
-            FlowController, FlowMsg, SwipeFlow,
-        },
-        geometry::Direction,
-    },
+use super::super::component::Button;
+use super::super::firmware::{
+    ActionBar, AllowedTextContent, Header, Hint, ShortMenuVec, TextScreen, TextScreenMsg,
+    VerticalMenu, VerticalMenuScreen, VerticalMenuScreenMsg,
 };
-
-use super::super::{
-    component::Button,
-    firmware::{
-        ActionBar, AllowedTextContent, Header, Hint, ShortMenuVec, TextScreen, TextScreenMsg,
-        VerticalMenu, VerticalMenuScreen, VerticalMenuScreenMsg,
-    },
-    theme::{self, gradient::Gradient},
-};
+use super::super::theme::gradient::Gradient;
+use super::super::theme::{self};
+use crate::error;
+use crate::maybe_trace::MaybeTrace;
+use crate::strutil::TString;
+use crate::translations::TR;
+use crate::ui::component::ComponentExt;
+use crate::ui::flow::base::{Decision, DecisionBuilder as _};
+use crate::ui::flow::{FlowController, FlowMsg, SwipeFlow};
+use crate::ui::geometry::Direction;
 
 const TIMEOUT_MS: u32 = 2000;
 const MENU_ITEM_CANCEL: usize = 0;

--- a/core/embed/rust/src/ui/layout_eckhart/flow/continue_recovery_homepage.rs
+++ b/core/embed/rust/src/ui/layout_eckhart/flow/continue_recovery_homepage.rs
@@ -1,34 +1,24 @@
-use crate::{
-    error,
-    strutil::TString,
-    translations::TR,
-    ui::{
-        button_request::{ButtonRequest, ButtonRequestCode},
-        component::{
-            button_request::ButtonRequestExt,
-            text::{
-                op::OpTextLayout,
-                paragraphs::{Paragraph, ParagraphSource, ParagraphVecShort, Paragraphs, VecExt},
-            },
-            ComponentExt, FormattedText, MsgMap, SendButtonRequest,
-        },
-        flow::{
-            base::{Decision, DecisionBuilder as _},
-            FlowController, FlowMsg, SwipeFlow,
-        },
-        geometry::{Direction, LinearPlacement},
-        layout::util::RecoveryType,
-    },
+use super::super::component::Button;
+use super::super::firmware::{
+    ActionBar, Header, ShortMenuVec, TextScreen, TextScreenMsg, VerticalMenu, VerticalMenuScreen,
+    VerticalMenuScreenMsg,
 };
-
-use super::super::{
-    component::Button,
-    firmware::{
-        ActionBar, Header, ShortMenuVec, TextScreen, TextScreenMsg, VerticalMenu,
-        VerticalMenuScreen, VerticalMenuScreenMsg,
-    },
-    theme::{self, gradient::Gradient},
+use super::super::theme::gradient::Gradient;
+use super::super::theme::{self};
+use crate::error;
+use crate::strutil::TString;
+use crate::translations::TR;
+use crate::ui::button_request::{ButtonRequest, ButtonRequestCode};
+use crate::ui::component::button_request::ButtonRequestExt;
+use crate::ui::component::text::op::OpTextLayout;
+use crate::ui::component::text::paragraphs::{
+    Paragraph, ParagraphSource, ParagraphVecShort, Paragraphs, VecExt,
 };
+use crate::ui::component::{ComponentExt, FormattedText, MsgMap, SendButtonRequest};
+use crate::ui::flow::base::{Decision, DecisionBuilder as _};
+use crate::ui::flow::{FlowController, FlowMsg, SwipeFlow};
+use crate::ui::geometry::{Direction, LinearPlacement};
+use crate::ui::layout::util::RecoveryType;
 
 #[derive(Copy, Clone, PartialEq, Eq)]
 pub enum ContinueRecoveryBeforeShares {

--- a/core/embed/rust/src/ui/layout_eckhart/flow/prompt_backup.rs
+++ b/core/embed/rust/src/ui/layout_eckhart/flow/prompt_backup.rs
@@ -1,28 +1,18 @@
-use crate::{
-    error,
-    strutil::TString,
-    translations::TR,
-    ui::{
-        component::{
-            text::paragraphs::{Paragraph, ParagraphSource, Paragraphs},
-            ComponentExt,
-        },
-        flow::{
-            base::{Decision, DecisionBuilder as _},
-            FlowController, FlowMsg, SwipeFlow,
-        },
-        geometry::{Direction, LinearPlacement},
-    },
+use super::super::component::Button;
+use super::super::firmware::{
+    ActionBar, Header, Hint, ShortMenuVec, TextScreen, TextScreenMsg, VerticalMenu,
+    VerticalMenuScreen, VerticalMenuScreenMsg,
 };
-
-use super::super::{
-    component::Button,
-    firmware::{
-        ActionBar, Header, Hint, ShortMenuVec, TextScreen, TextScreenMsg, VerticalMenu,
-        VerticalMenuScreen, VerticalMenuScreenMsg,
-    },
-    theme::{self, gradient::Gradient},
-};
+use super::super::theme::gradient::Gradient;
+use super::super::theme::{self};
+use crate::error;
+use crate::strutil::TString;
+use crate::translations::TR;
+use crate::ui::component::text::paragraphs::{Paragraph, ParagraphSource, Paragraphs};
+use crate::ui::component::ComponentExt;
+use crate::ui::flow::base::{Decision, DecisionBuilder as _};
+use crate::ui::flow::{FlowController, FlowMsg, SwipeFlow};
+use crate::ui::geometry::{Direction, LinearPlacement};
 
 #[derive(Copy, Clone, PartialEq, Eq)]
 pub enum PromptBackup {

--- a/core/embed/rust/src/ui/layout_eckhart/flow/receive.rs
+++ b/core/embed/rust/src/ui/layout_eckhart/flow/receive.rs
@@ -1,34 +1,26 @@
-use crate::{
-    error,
-    micropython::{obj::Obj, util},
-    strutil::TString,
-    translations::TR,
-    ui::{
-        button_request::ButtonRequest,
-        component::{
-            text::paragraphs::{
-                Paragraph, ParagraphSource, ParagraphVecLong, ParagraphVecShort, VecExt,
-            },
-            ButtonRequestExt, ComponentExt, Qr,
-        },
-        flow::{
-            base::{Decision, DecisionBuilder as _},
-            FlowController, FlowMsg, SwipeFlow,
-        },
-        geometry::{Direction, LinearPlacement},
-        layout::util::{ContentType, MAX_XPUBS},
-    },
-};
 use heapless::Vec;
 
-use super::super::{
-    component::Button,
-    firmware::{
-        ActionBar, Header, Hint, QrScreen, ShortMenuVec, TextScreen, TextScreenMsg, VerticalMenu,
-        VerticalMenuScreen, VerticalMenuScreenMsg,
-    },
-    theme::{self, gradient::Gradient},
+use super::super::component::Button;
+use super::super::firmware::{
+    ActionBar, Header, Hint, QrScreen, ShortMenuVec, TextScreen, TextScreenMsg, VerticalMenu,
+    VerticalMenuScreen, VerticalMenuScreenMsg,
 };
+use super::super::theme::gradient::Gradient;
+use super::super::theme::{self};
+use crate::error;
+use crate::micropython::obj::Obj;
+use crate::micropython::util;
+use crate::strutil::TString;
+use crate::translations::TR;
+use crate::ui::button_request::ButtonRequest;
+use crate::ui::component::text::paragraphs::{
+    Paragraph, ParagraphSource, ParagraphVecLong, ParagraphVecShort, VecExt,
+};
+use crate::ui::component::{ButtonRequestExt, ComponentExt, Qr};
+use crate::ui::flow::base::{Decision, DecisionBuilder as _};
+use crate::ui::flow::{FlowController, FlowMsg, SwipeFlow};
+use crate::ui::geometry::{Direction, LinearPlacement};
+use crate::ui::layout::util::{ContentType, MAX_XPUBS};
 
 #[derive(Copy, Clone, PartialEq, Eq)]
 pub enum Receive {

--- a/core/embed/rust/src/ui/layout_eckhart/flow/request_number.rs
+++ b/core/embed/rust/src/ui/layout_eckhart/flow/request_number.rs
@@ -1,27 +1,18 @@
-use crate::{
-    error,
-    strutil::TString,
-    translations::TR,
-    ui::{
-        component::ComponentExt,
-        flow::{
-            base::{Decision, DecisionBuilder as _},
-            FlowController, FlowMsg, SwipeFlow,
-        },
-        geometry::Direction,
-    },
-};
-
 use core::sync::atomic::{AtomicU16, Ordering};
 
-use super::super::{
-    component::Button,
-    firmware::{
-        ActionBar, Header, NumberInput, ShortMenuVec, UpdatableInfoScreen, ValueInputScreen,
-        ValueInputScreenMsg, VerticalMenu, VerticalMenuScreen, VerticalMenuScreenMsg,
-    },
-    theme,
+use super::super::component::Button;
+use super::super::firmware::{
+    ActionBar, Header, NumberInput, ShortMenuVec, UpdatableInfoScreen, ValueInputScreen,
+    ValueInputScreenMsg, VerticalMenu, VerticalMenuScreen, VerticalMenuScreenMsg,
 };
+use super::super::theme;
+use crate::error;
+use crate::strutil::TString;
+use crate::translations::TR;
+use crate::ui::component::ComponentExt;
+use crate::ui::flow::base::{Decision, DecisionBuilder as _};
+use crate::ui::flow::{FlowController, FlowMsg, SwipeFlow};
+use crate::ui::geometry::Direction;
 
 #[derive(Copy, Clone, PartialEq, Eq)]
 pub enum RequestNumber {

--- a/core/embed/rust/src/ui/layout_eckhart/flow/request_passphrase.rs
+++ b/core/embed/rust/src/ui/layout_eckhart/flow/request_passphrase.rs
@@ -1,28 +1,17 @@
-use crate::{
-    error,
-    strutil::{ShortString, TString},
-    translations::TR,
-    ui::{
-        component::{
-            text::paragraphs::{Paragraph, ParagraphSource},
-            ComponentExt,
-        },
-        flow::{
-            base::{Decision, DecisionBuilder as _},
-            FlowController, FlowMsg, SwipeFlow,
-        },
-        geometry::{Direction, LinearPlacement},
-    },
+use super::super::component::Button;
+use super::super::firmware::{
+    ActionBar, Header, PassphraseInput, StringKeyboard, StringKeyboardMsg, TextScreen,
+    TextScreenMsg,
 };
-
-use super::super::{
-    component::Button,
-    firmware::{
-        ActionBar, Header, PassphraseInput, StringKeyboard, StringKeyboardMsg, TextScreen,
-        TextScreenMsg,
-    },
-    theme,
-};
+use super::super::theme;
+use crate::error;
+use crate::strutil::{ShortString, TString};
+use crate::translations::TR;
+use crate::ui::component::text::paragraphs::{Paragraph, ParagraphSource};
+use crate::ui::component::ComponentExt;
+use crate::ui::flow::base::{Decision, DecisionBuilder as _};
+use crate::ui::flow::{FlowController, FlowMsg, SwipeFlow};
+use crate::ui::geometry::{Direction, LinearPlacement};
 
 #[derive(Copy, Clone, PartialEq, Eq)]
 pub enum RequestPassphrase {

--- a/core/embed/rust/src/ui/layout_eckhart/flow/show_danger.rs
+++ b/core/embed/rust/src/ui/layout_eckhart/flow/show_danger.rs
@@ -1,29 +1,18 @@
-use crate::{
-    error,
-    strutil::TString,
-    time::Duration,
-    translations::TR,
-    ui::{
-        component::{
-            text::paragraphs::{Paragraph, ParagraphSource},
-            ComponentExt,
-        },
-        flow::{
-            base::{Decision, DecisionBuilder as _},
-            FlowController, FlowMsg, SwipeFlow,
-        },
-        geometry::{Direction, LinearPlacement},
-    },
+use super::super::component::Button;
+use super::super::firmware::{
+    ActionBar, Header, ShortMenuVec, TextScreen, TextScreenMsg, VerticalMenu, VerticalMenuScreen,
+    VerticalMenuScreenMsg,
 };
-
-use super::super::{
-    component::Button,
-    firmware::{
-        ActionBar, Header, ShortMenuVec, TextScreen, TextScreenMsg, VerticalMenu,
-        VerticalMenuScreen, VerticalMenuScreenMsg,
-    },
-    theme,
-};
+use super::super::theme;
+use crate::error;
+use crate::strutil::TString;
+use crate::time::Duration;
+use crate::translations::TR;
+use crate::ui::component::text::paragraphs::{Paragraph, ParagraphSource};
+use crate::ui::component::ComponentExt;
+use crate::ui::flow::base::{Decision, DecisionBuilder as _};
+use crate::ui::flow::{FlowController, FlowMsg, SwipeFlow};
+use crate::ui::geometry::{Direction, LinearPlacement};
 
 const TIMEOUT: Duration = Duration::from_secs(2);
 

--- a/core/embed/rust/src/ui/layout_eckhart/flow/show_share_words.rs
+++ b/core/embed/rust/src/ui/layout_eckhart/flow/show_share_words.rs
@@ -1,30 +1,20 @@
-use crate::{
-    error,
-    strutil::TString,
-    translations::TR,
-    ui::{
-        button_request::{ButtonRequest, ButtonRequestCode},
-        component::{
-            text::paragraphs::{Paragraph, ParagraphSource, ParagraphVecShort},
-            ButtonRequestExt, ComponentExt,
-        },
-        flow::{
-            base::{Decision, DecisionBuilder as _},
-            FlowController, FlowMsg, SwipeFlow,
-        },
-        geometry::{Direction, LinearPlacement},
-    },
-};
-
 use heapless::Vec;
 
-use super::super::{
-    component::Button,
-    firmware::{
-        ActionBar, Header, ShareWordsScreen, ShareWordsScreenMsg, TextScreen, TextScreenMsg,
-    },
-    theme::{self, gradient::Gradient},
+use super::super::component::Button;
+use super::super::firmware::{
+    ActionBar, Header, ShareWordsScreen, ShareWordsScreenMsg, TextScreen, TextScreenMsg,
 };
+use super::super::theme::gradient::Gradient;
+use super::super::theme::{self};
+use crate::error;
+use crate::strutil::TString;
+use crate::translations::TR;
+use crate::ui::button_request::{ButtonRequest, ButtonRequestCode};
+use crate::ui::component::text::paragraphs::{Paragraph, ParagraphSource, ParagraphVecShort};
+use crate::ui::component::{ButtonRequestExt, ComponentExt};
+use crate::ui::flow::base::{Decision, DecisionBuilder as _};
+use crate::ui::flow::{FlowController, FlowMsg, SwipeFlow};
+use crate::ui::geometry::{Direction, LinearPlacement};
 
 #[derive(Copy, Clone, PartialEq, Eq)]
 pub enum ShowShareWords {

--- a/core/embed/rust/src/ui/layout_eckhart/flow/show_thp_pairing_code.rs
+++ b/core/embed/rust/src/ui/layout_eckhart/flow/show_thp_pairing_code.rs
@@ -1,25 +1,17 @@
-use crate::{
-    error,
-    strutil::TString,
-    translations::TR,
-    ui::{
-        component::{text::op::OpTextLayout, ComponentExt, FormattedText},
-        flow::{
-            base::{Decision, DecisionBuilder as _},
-            FlowController, FlowMsg, SwipeFlow,
-        },
-        geometry::{Alignment, Direction},
-    },
+use super::super::component::Button;
+use super::super::firmware::{
+    Header, ShortMenuVec, TextScreen, TextScreenMsg, VerticalMenu, VerticalMenuScreen,
+    VerticalMenuScreenMsg,
 };
-
-use super::super::{
-    component::Button,
-    firmware::{
-        Header, ShortMenuVec, TextScreen, TextScreenMsg, VerticalMenu, VerticalMenuScreen,
-        VerticalMenuScreenMsg,
-    },
-    fonts, theme,
-};
+use super::super::{fonts, theme};
+use crate::error;
+use crate::strutil::TString;
+use crate::translations::TR;
+use crate::ui::component::text::op::OpTextLayout;
+use crate::ui::component::{ComponentExt, FormattedText};
+use crate::ui::flow::base::{Decision, DecisionBuilder as _};
+use crate::ui::flow::{FlowController, FlowMsg, SwipeFlow};
+use crate::ui::geometry::{Alignment, Direction};
 
 #[derive(Copy, Clone, PartialEq, Eq)]
 pub enum ShowPairingCode {

--- a/core/embed/rust/src/ui/layout_eckhart/flow/show_tutorial.rs
+++ b/core/embed/rust/src/ui/layout_eckhart/flow/show_tutorial.rs
@@ -1,29 +1,18 @@
-use crate::{
-    error,
-    strutil::TString,
-    translations::TR,
-    ui::{
-        component::{
-            text::paragraphs::{Paragraph, ParagraphSource, Paragraphs},
-            ComponentExt, MsgMap,
-        },
-        flow::{
-            base::{Decision, DecisionBuilder as _},
-            FlowController, FlowMsg, SwipeFlow,
-        },
-        geometry::{Direction, LinearPlacement},
-    },
+use super::super::component::Button;
+use super::super::firmware::{
+    ActionBar, Header, HeaderMsg, Hint, ShortMenuVec, TextScreen, TextScreenMsg,
+    TutorialPowerScreen, TutorialPowerScreenMsg, TutorialWelcomeScreen, TutorialWelcomeScreenMsg,
+    VerticalMenu, VerticalMenuScreen, VerticalMenuScreenMsg,
 };
-
-use super::super::{
-    component::Button,
-    firmware::{
-        ActionBar, Header, HeaderMsg, Hint, ShortMenuVec, TextScreen, TextScreenMsg,
-        TutorialPowerScreen, TutorialPowerScreenMsg, TutorialWelcomeScreen,
-        TutorialWelcomeScreenMsg, VerticalMenu, VerticalMenuScreen, VerticalMenuScreenMsg,
-    },
-    theme::{self, Gradient, ScreenBackground},
-};
+use super::super::theme::{self, Gradient, ScreenBackground};
+use crate::error;
+use crate::strutil::TString;
+use crate::translations::TR;
+use crate::ui::component::text::paragraphs::{Paragraph, ParagraphSource, Paragraphs};
+use crate::ui::component::{ComponentExt, MsgMap};
+use crate::ui::flow::base::{Decision, DecisionBuilder as _};
+use crate::ui::flow::{FlowController, FlowMsg, SwipeFlow};
+use crate::ui::geometry::{Direction, LinearPlacement};
 
 const WELCOME_SCREEN_DURATION_MS: u32 = 3000;
 type TropicScreen = TextScreen<Paragraphs<Paragraph<'static>>>;

--- a/core/embed/rust/src/ui/layout_eckhart/flow/util.rs
+++ b/core/embed/rust/src/ui/layout_eckhart/flow/util.rs
@@ -1,21 +1,12 @@
-use crate::{
-    error::Error,
-    maybe_trace::MaybeTrace,
-    strutil::TString,
-    ui::{
-        component::{
-            text::paragraphs::{ParagraphSource, Paragraphs},
-            Component, ComponentExt, MsgMap,
-        },
-        flow::{
-            base::{Decision, DecisionBuilder},
-            FlowController, FlowMsg, Swipable, SwipeFlow,
-        },
-        geometry::{Direction, LinearPlacement},
-    },
-};
-
 use super::super::firmware::{Header, TextScreen, TextScreenMsg};
+use crate::error::Error;
+use crate::maybe_trace::MaybeTrace;
+use crate::strutil::TString;
+use crate::ui::component::text::paragraphs::{ParagraphSource, Paragraphs};
+use crate::ui::component::{Component, ComponentExt, MsgMap};
+use crate::ui::flow::base::{Decision, DecisionBuilder};
+use crate::ui::flow::{FlowController, FlowMsg, Swipable, SwipeFlow};
+use crate::ui::geometry::{Direction, LinearPlacement};
 
 enum SinglePage {
     Show,

--- a/core/embed/rust/src/ui/layout_eckhart/mod.rs
+++ b/core/embed/rust/src/ui/layout_eckhart/mod.rs
@@ -1,15 +1,14 @@
-use super::{geometry::Rect, CommonUI};
 use theme::backlight;
 
+use super::geometry::Rect;
+use super::CommonUI;
 #[cfg(any(feature = "ui_debug_overlay", feature = "ui_performance_overlay"))]
 use super::{display::Color, geometry::Offset, shape};
-
 #[cfg(feature = "ui_performance_overlay")]
 use super::{
     geometry::{Alignment, Alignment2D, Point},
     PerformanceOverlay,
 };
-
 #[cfg(feature = "ui_performance_overlay")]
 use crate::strutil::ShortString;
 
@@ -36,8 +35,9 @@ pub mod ui_firmware;
 #[cfg(feature = "prodtest")]
 mod prodtest;
 
-use crate::ui::layout::simplified::show;
 use component::{ErrorScreen, UpdateScreen, WelcomeScreen};
+
+use crate::ui::layout::simplified::show;
 
 pub const WAIT_FOR_RESTART_MESSAGE: &str = "Wait for Trezor restart";
 pub const WAIT_MESSAGE: &str = "Wait";

--- a/core/embed/rust/src/ui/layout_eckhart/prodtest/mod.rs
+++ b/core/embed/rust/src/ui/layout_eckhart/prodtest/mod.rs
@@ -1,22 +1,20 @@
 mod welcome;
 
-use crate::ui::{
-    component::Event,
-    constant::screen,
-    display,
-    display::Color,
-    event::{
-        TouchEvent,
-        TouchEvent::{TouchEnd, TouchMove, TouchStart},
-    },
-    geometry::{Alignment, Offset, Rect},
-    layout::simplified::{process_frame_event, show},
-    shape::{self, render_on_display},
-    ui_prodtest::{ProdtestLayoutType, ProdtestUI},
-};
 use heapless::Vec;
 
-use super::{cshape::ScreenBorder, fonts, prodtest::welcome::Welcome, UIEckhart};
+use super::cshape::ScreenBorder;
+use super::prodtest::welcome::Welcome;
+use super::{fonts, UIEckhart};
+use crate::ui::component::Event;
+use crate::ui::constant::screen;
+use crate::ui::display;
+use crate::ui::display::Color;
+use crate::ui::event::TouchEvent;
+use crate::ui::event::TouchEvent::{TouchEnd, TouchMove, TouchStart};
+use crate::ui::geometry::{Alignment, Offset, Rect};
+use crate::ui::layout::simplified::{process_frame_event, show};
+use crate::ui::shape::{self, render_on_display};
+use crate::ui::ui_prodtest::{ProdtestLayoutType, ProdtestUI};
 
 #[allow(clippy::large_enum_variant)]
 pub enum ProdtestLayout {

--- a/core/embed/rust/src/ui/layout_eckhart/prodtest/welcome.rs
+++ b/core/embed/rust/src/ui/layout_eckhart/prodtest/welcome.rs
@@ -1,24 +1,19 @@
-use super::super::{
-    component::{Button, ButtonMsg},
-    constant::SCREEN,
-    cshape::ScreenBorder,
-    fonts,
-    theme::{bootloader::button_cancel, BLUE, GREEN, RED, WHITE},
+use super::super::component::{Button, ButtonMsg};
+use super::super::constant::SCREEN;
+use super::super::cshape::ScreenBorder;
+use super::super::fonts;
+use super::super::theme::bootloader::button_cancel;
+use super::super::theme::{BLUE, GREEN, RED, WHITE};
+use crate::strutil::format_i64;
+use crate::trezorhal::power_manager::{
+    charging_disable, charging_enable, charging_state, is_battery_connected, is_charging_limited,
+    is_ntc_connected, soc, ChargingState,
 };
-use crate::{
-    strutil::format_i64,
-    trezorhal::power_manager::{
-        charging_disable, charging_enable, charging_state, is_battery_connected,
-        is_charging_limited, is_ntc_connected, soc, ChargingState,
-    },
-    ui::{
-        component::{Component, Event, EventCtx, Never, Qr},
-        constant::screen,
-        display::Color,
-        geometry::{Alignment, Offset, Point, Rect},
-        shape::{self, Renderer},
-    },
-};
+use crate::ui::component::{Component, Event, EventCtx, Never, Qr};
+use crate::ui::constant::screen;
+use crate::ui::display::Color;
+use crate::ui::geometry::{Alignment, Offset, Point, Rect};
+use crate::ui::shape::{self, Renderer};
 
 pub struct Welcome {
     id: Option<&'static str>,

--- a/core/embed/rust/src/ui/layout_eckhart/theme/background.rs
+++ b/core/embed/rust/src/ui/layout_eckhart/theme/background.rs
@@ -1,13 +1,8 @@
-use crate::ui::{
-    display::Color,
-    geometry::{Alignment2D, Insets},
-    shape::{self, Renderer},
-};
-
-use super::super::{
-    constant::SCREEN,
-    theme::{self, Gradient, TILES_GRID},
-};
+use super::super::constant::SCREEN;
+use super::super::theme::{self, Gradient, TILES_GRID};
+use crate::ui::display::Color;
+use crate::ui::geometry::{Alignment2D, Insets};
+use crate::ui::shape::{self, Renderer};
 
 #[derive(Clone, Copy, PartialEq, Eq)]
 pub struct ScreenBackground {

--- a/core/embed/rust/src/ui/layout_eckhart/theme/bootloader.rs
+++ b/core/embed/rust/src/ui/layout_eckhart/theme/bootloader.rs
@@ -1,17 +1,13 @@
-use crate::ui::{
-    component::{text::TextStyle, LineBreaking::BreakWordsNoHyphen},
-    display::Color,
-    util::include_icon,
-};
-
+use super::super::component::{ButtonStyle, ButtonStyleSheet};
+use super::super::fonts;
 use super::{
-    super::{
-        component::{ButtonStyle, ButtonStyleSheet},
-        fonts,
-    },
     BLACK, BLUE, GREY, GREY_DARK, GREY_EXTRA_DARK, GREY_EXTRA_LIGHT, GREY_LIGHT, GREY_SUPER_DARK,
     ORANGE, RED, WHITE,
 };
+use crate::ui::component::text::TextStyle;
+use crate::ui::component::LineBreaking::BreakWordsNoHyphen;
+use crate::ui::display::Color;
+use crate::ui::util::include_icon;
 
 pub const BLD_BG: Color = BLACK;
 pub const BLD_FG: Color = WHITE;

--- a/core/embed/rust/src/ui/layout_eckhart/theme/firmware.rs
+++ b/core/embed/rust/src/ui/layout_eckhart/theme/firmware.rs
@@ -1,21 +1,10 @@
-use crate::{
-    time::ShortDuration,
-    ui::{
-        component::text::{
-            layout::{Chunks, LineBreaking, PageBreaking},
-            TextStyle,
-        },
-        notification::NotificationLevel,
-    },
-};
-
-use super::{
-    super::{
-        component::{ButtonStyle, ButtonStyleSheet},
-        fonts,
-    },
-    *,
-};
+use super::super::component::{ButtonStyle, ButtonStyleSheet};
+use super::super::fonts;
+use super::*;
+use crate::time::ShortDuration;
+use crate::ui::component::text::layout::{Chunks, LineBreaking, PageBreaking};
+use crate::ui::component::text::TextStyle;
+use crate::ui::notification::NotificationLevel;
 
 // props settings
 pub const PROP_INNER_SPACING: i16 = 12; // [px]

--- a/core/embed/rust/src/ui/layout_eckhart/theme/gradient.rs
+++ b/core/embed/rust/src/ui/layout_eckhart/theme/gradient.rs
@@ -1,11 +1,8 @@
-use crate::ui::{
-    display::Color,
-    geometry::{Axis, Point, Rect},
-    lerp::Lerp,
-    shape::{self, Renderer},
-};
-
 use super::super::theme;
+use crate::ui::display::Color;
+use crate::ui::geometry::{Axis, Point, Rect};
+use crate::ui::lerp::Lerp;
+use crate::ui::shape::{self, Renderer};
 
 #[derive(Clone, Copy, PartialEq, Eq)]
 pub enum Gradient {

--- a/core/embed/rust/src/ui/layout_eckhart/theme/mod.rs
+++ b/core/embed/rust/src/ui/layout_eckhart/theme/mod.rs
@@ -7,19 +7,16 @@ pub mod bootloader;
 pub mod firmware;
 pub mod gradient;
 #[cfg(feature = "micropython")]
+pub use background::ScreenBackground;
+#[cfg(feature = "micropython")]
 pub use firmware::*;
-
-use crate::ui::{
-    component::text::TextStyle,
-    display::Color,
-    geometry::{Grid, Insets, Offset, Point, Rect},
-    util::include_icon,
-};
+pub use gradient::Gradient;
 
 use super::fonts;
-#[cfg(feature = "micropython")]
-pub use background::ScreenBackground;
-pub use gradient::Gradient;
+use crate::ui::component::text::TextStyle;
+use crate::ui::display::Color;
+use crate::ui::geometry::{Grid, Insets, Offset, Point, Rect};
+use crate::ui::util::include_icon;
 
 // Color palette.
 pub const WHITE: Color = Color::rgb(0xFF, 0xFF, 0xFF);

--- a/core/embed/rust/src/ui/layout_eckhart/ui_bootloader.rs
+++ b/core/embed/rust/src/ui/layout_eckhart/ui_bootloader.rs
@@ -1,41 +1,35 @@
-use crate::{
-    bootloader::run,
-    ui::{
-        component::{base::Component, text::TextStyle, Label},
-        display::{self, toif::Toif, Color},
-        geometry::{Alignment, Alignment2D, Offset, Point, Rect},
-        layout::simplified::show,
-        shape::{self, render_on_display},
-        ui_bootloader::BootloaderUI,
-        CommonUI,
-    },
-};
-
 use heapless::String;
 use ufmt::uwrite;
 
-use super::{
-    bootloader::{
-        BldActionBar, BldHeader, BldHeaderMsg, BldMenuScreen, BldTextScreen, BldWelcomeScreen,
-        ConnectScreen, WirelessSetupScreen,
-    },
-    component::{render_logo, Button},
-    cshape::{render_loader, ScreenBorder},
-    fonts::{FONT_SATOSHI_MEDIUM_26, FONT_SATOSHI_REGULAR_38},
-    theme::{
-        self,
-        bootloader::{
-            button_cancel, button_confirm, button_default, button_wipe_confirm, BLD_BG, BLD_FG,
-            TEXT_FW_FINGERPRINT, TEXT_WARNING, WELCOME_COLOR,
-        },
-        BLACK, BLUE, GREEN_LIGHT, GREY, ICON_CHECKMARK, ICON_CROSS, RED, TEXT_NORMAL,
-        TEXT_SMALL_GREY, WHITE,
-    },
-    UIEckhart, CANCEL_MESSAGE, WAIT_FOR_RESTART_MESSAGE, WAIT_MESSAGE,
+use super::bootloader::{
+    BldActionBar, BldHeader, BldHeaderMsg, BldMenuScreen, BldTextScreen, BldWelcomeScreen,
+    ConnectScreen, WirelessSetupScreen,
 };
-
 #[cfg(feature = "ble")]
 use super::bootloader::{ConfirmPairingScreen, PairingFinalizationScreen, PairingModeScreen};
+use super::component::{render_logo, Button};
+use super::cshape::{render_loader, ScreenBorder};
+use super::fonts::{FONT_SATOSHI_MEDIUM_26, FONT_SATOSHI_REGULAR_38};
+use super::theme::bootloader::{
+    button_cancel, button_confirm, button_default, button_wipe_confirm, BLD_BG, BLD_FG,
+    TEXT_FW_FINGERPRINT, TEXT_WARNING, WELCOME_COLOR,
+};
+use super::theme::{
+    self, BLACK, BLUE, GREEN_LIGHT, GREY, ICON_CHECKMARK, ICON_CROSS, RED, TEXT_NORMAL,
+    TEXT_SMALL_GREY, WHITE,
+};
+use super::{UIEckhart, CANCEL_MESSAGE, WAIT_FOR_RESTART_MESSAGE, WAIT_MESSAGE};
+use crate::bootloader::run;
+use crate::ui::component::base::Component;
+use crate::ui::component::text::TextStyle;
+use crate::ui::component::Label;
+use crate::ui::display::toif::Toif;
+use crate::ui::display::{self, Color};
+use crate::ui::geometry::{Alignment, Alignment2D, Offset, Point, Rect};
+use crate::ui::layout::simplified::show;
+use crate::ui::shape::{self, render_on_display};
+use crate::ui::ui_bootloader::BootloaderUI;
+use crate::ui::CommonUI;
 
 pub type BootloaderString = String<128>;
 

--- a/core/embed/rust/src/ui/layout_eckhart/ui_firmware.rs
+++ b/core/embed/rust/src/ui/layout_eckhart/ui_firmware.rs
@@ -1,60 +1,50 @@
 use core::cmp::Ordering;
 
-use crate::{
-    error::Error,
-    io::BinaryData,
-    micropython::{buffer::StrBuffer, gc::Gc, iter::IterBuf, list::List, obj::Obj, util},
-    storage,
-    strutil::TString,
-    time::Duration,
-    translations::TR,
-    ui::{
-        component::{
-            text::{
-                op::OpTextLayout,
-                paragraphs::{
-                    Checklist, Paragraph, ParagraphSource, ParagraphVecShort, Paragraphs, VecExt,
-                },
-                TextStyle,
-            },
-            ComponentExt as _, Empty, FormattedText, Timeout,
-        },
-        flow::FlowMsg,
-        geometry::{Alignment, LinearPlacement, Offset},
-        layout::{
-            obj::{LayoutMaybeTrace, LayoutObj, RootComponent},
-            util::{ConfirmValueParams, ContentType, PropsList, RecoveryType, StrOrBytes},
-        },
-        notification::Notification,
-        ui_firmware::{
-            FirmwareUI, MAX_CHECKLIST_ITEMS, MAX_GROUP_SHARE_LINES, MAX_MENU_ITEMS,
-            MAX_PAIRED_DEVICES, MAX_WORD_QUIZ_ITEMS,
-        },
-        ModelUI,
-    },
-    util::interpolate,
+use super::component::Button;
+use super::firmware::{
+    ActionBar, Bip39Input, ConfirmHomescreen, DeviceMenuScreen, DurationInput, Header, HeaderMsg,
+    Hint, Homescreen, LabelInput, MnemonicKeyboard, PinKeyboard, ProgressScreen,
+    SelectWordCountScreen, SelectWordScreen, SetBrightnessScreen, ShortMenuVec, Slip39Input,
+    StringKeyboard, TextScreen, TextScreenMsg, ValueInputScreen, VerticalMenu, VerticalMenuScreen,
+    VerticalMenuScreenMsg,
 };
-
+use super::theme::firmware::{button_actionbar_danger, button_confirm};
+use super::theme::gradient::Gradient;
+use super::theme::{self};
+use super::{flow, fonts, UIEckhart};
+use crate::error::Error;
+use crate::io::BinaryData;
+use crate::micropython::buffer::StrBuffer;
+use crate::micropython::gc::Gc;
+use crate::micropython::iter::IterBuf;
+use crate::micropython::list::List;
+use crate::micropython::obj::Obj;
+use crate::micropython::util;
+use crate::storage;
+use crate::strutil::TString;
+use crate::time::Duration;
+use crate::translations::TR;
+use crate::ui::component::text::op::OpTextLayout;
+use crate::ui::component::text::paragraphs::{
+    Checklist, Paragraph, ParagraphSource, ParagraphVecShort, Paragraphs, VecExt,
+};
+use crate::ui::component::text::TextStyle;
 #[cfg(feature = "ble")]
 use crate::ui::component::{BLEHandler, BLEHandlerMode};
-
-use super::{
-    component::Button,
-    firmware::{
-        ActionBar, Bip39Input, ConfirmHomescreen, DeviceMenuScreen, DurationInput, Header,
-        HeaderMsg, Hint, Homescreen, LabelInput, MnemonicKeyboard, PinKeyboard, ProgressScreen,
-        SelectWordCountScreen, SelectWordScreen, SetBrightnessScreen, ShortMenuVec, Slip39Input,
-        StringKeyboard, TextScreen, TextScreenMsg, ValueInputScreen, VerticalMenu,
-        VerticalMenuScreen, VerticalMenuScreenMsg,
-    },
-    flow, fonts,
-    theme::{
-        self,
-        firmware::{button_actionbar_danger, button_confirm},
-        gradient::Gradient,
-    },
-    UIEckhart,
+use crate::ui::component::{ComponentExt as _, Empty, FormattedText, Timeout};
+use crate::ui::flow::FlowMsg;
+use crate::ui::geometry::{Alignment, LinearPlacement, Offset};
+use crate::ui::layout::obj::{LayoutMaybeTrace, LayoutObj, RootComponent};
+use crate::ui::layout::util::{
+    ConfirmValueParams, ContentType, PropsList, RecoveryType, StrOrBytes,
 };
+use crate::ui::notification::Notification;
+use crate::ui::ui_firmware::{
+    FirmwareUI, MAX_CHECKLIST_ITEMS, MAX_GROUP_SHARE_LINES, MAX_MENU_ITEMS, MAX_PAIRED_DEVICES,
+    MAX_WORD_QUIZ_ITEMS,
+};
+use crate::ui::ModelUI;
+use crate::util::interpolate;
 
 impl FirmwareUI for UIEckhart {
     fn confirm_action(

--- a/core/embed/rust/src/ui/led.rs
+++ b/core/embed/rust/src/ui/led.rs
@@ -1,8 +1,6 @@
-pub use crate::trezorhal::rgb_led::Effect;
-
-use crate::trezorhal::rgb_led::set_color;
-
 use super::display::Color;
+use crate::trezorhal::rgb_led::set_color;
+pub use crate::trezorhal::rgb_led::Effect;
 
 #[derive(PartialEq, Eq, Clone, Copy)]
 pub enum LedState {

--- a/core/embed/rust/src/ui/mod.rs
+++ b/core/embed/rust/src/ui/mod.rs
@@ -41,7 +41,6 @@ pub mod ui_common;
 pub mod ui_firmware;
 
 pub use ui_common::CommonUI;
-
 #[cfg(feature = "ui_performance_overlay")]
 pub use ui_common::PerformanceOverlay;
 

--- a/core/embed/rust/src/ui/notification.rs
+++ b/core/embed/rust/src/ui/notification.rs
@@ -1,5 +1,4 @@
-use crate::{error::Error, strutil::TString};
-
+use crate::error::Error;
 #[cfg(feature = "micropython")]
 use crate::micropython::{
     macros::{obj_dict, obj_map, obj_type},
@@ -8,6 +7,7 @@ use crate::micropython::{
     simple_type::SimpleTypeObj,
     typ::Type,
 };
+use crate::strutil::TString;
 
 /// Homescreen notification.
 #[derive(Clone)]

--- a/core/embed/rust/src/ui/shape/bar.rs
+++ b/core/embed/rust/src/ui/shape/bar.rs
@@ -1,8 +1,8 @@
-use crate::ui::{display::Color, geometry::Rect};
+use without_alloc::alloc::LocalAllocLeakExt;
 
 use super::{Canvas, DrawingCache, Renderer, Shape, ShapeClone};
-
-use without_alloc::alloc::LocalAllocLeakExt;
+use crate::ui::display::Color;
+use crate::ui::geometry::Rect;
 
 /// A shape for the rendering variuous type of rectangles.
 pub struct Bar {

--- a/core/embed/rust/src/ui/shape/base.rs
+++ b/core/embed/rust/src/ui/shape/base.rs
@@ -1,8 +1,7 @@
-use crate::ui::geometry::Rect;
+use without_alloc::alloc::LocalAllocLeakExt;
 
 use super::{Canvas, DrawingCache};
-
-use without_alloc::alloc::LocalAllocLeakExt;
+use crate::ui::geometry::Rect;
 
 // ==========================================================================
 // trait Shape

--- a/core/embed/rust/src/ui/shape/bitmap.rs
+++ b/core/embed/rust/src/ui/shape/bitmap.rs
@@ -1,8 +1,10 @@
-use crate::{error::Error, trezorhal::bitblt};
+use core::cell::Cell;
+use core::marker::PhantomData;
 
-use crate::ui::{display::Color, geometry::Offset};
-
-use core::{cell::Cell, marker::PhantomData};
+use crate::error::Error;
+use crate::trezorhal::bitblt;
+use crate::ui::display::Color;
+use crate::ui::geometry::Offset;
 
 #[derive(Copy, Clone, PartialEq, Eq)]
 pub enum BitmapFormat {

--- a/core/embed/rust/src/ui/shape/blur.rs
+++ b/core/embed/rust/src/ui/shape/blur.rs
@@ -1,8 +1,7 @@
-use crate::ui::geometry::Rect;
+use without_alloc::alloc::LocalAllocLeakExt;
 
 use super::{Canvas, DrawingCache, Renderer, Shape, ShapeClone};
-
-use without_alloc::alloc::LocalAllocLeakExt;
+use crate::ui::geometry::Rect;
 
 pub struct Blurring {
     // Blurred area

--- a/core/embed/rust/src/ui/shape/cache/blur_cache.rs
+++ b/core/embed/rust/src/ui/shape/cache/blur_cache.rs
@@ -1,9 +1,9 @@
-use crate::ui::{
-    geometry::Offset,
-    shape::utils::{BlurAlgorithm, BlurBuff},
-};
 use core::cell::UnsafeCell;
+
 use without_alloc::alloc::LocalAllocLeakExt;
+
+use crate::ui::geometry::Offset;
+use crate::ui::shape::utils::{BlurAlgorithm, BlurBuff};
 
 pub struct BlurCache<'a> {
     algo: Option<BlurAlgorithm<'a>>,

--- a/core/embed/rust/src/ui/shape/cache/drawing_cache.rs
+++ b/core/embed/rust/src/ui/shape/cache/drawing_cache.rs
@@ -1,16 +1,14 @@
-use super::zlib_cache::ZlibCache;
+use core::cell::{RefCell, RefMut};
+
+use without_alloc::alloc::LocalAllocLeakExt;
 
 #[cfg(feature = "ui_blurring")]
 use super::blur_cache::BlurCache;
-
 #[cfg(all(feature = "ui_jpeg", not(feature = "hw_jpeg_decoder")))]
 use super::jpeg_cache::JpegCache;
-
+use super::zlib_cache::ZlibCache;
 #[cfg(feature = "hw_jpeg_decoder")]
 use crate::trezorhal::jpegdec;
-
-use core::cell::{RefCell, RefMut};
-use without_alloc::alloc::LocalAllocLeakExt;
 
 const ALIGN_PAD: usize = 8;
 

--- a/core/embed/rust/src/ui/shape/cache/jpeg_cache.rs
+++ b/core/embed/rust/src/ui/shape/cache/jpeg_cache.rs
@@ -1,15 +1,12 @@
-use crate::{
-    io::BinaryData,
-    ui::{
-        constant::WIDTH,
-        geometry::{Offset, Point, Rect},
-        shape::{BasicCanvas, Bitmap, BitmapFormat, BitmapView, Canvas, Rgb565Canvas},
-    },
-};
-
 use core::cell::UnsafeCell;
+
 use trezor_tjpgdec as tjpgd;
 use without_alloc::alloc::LocalAllocLeakExt;
+
+use crate::io::BinaryData;
+use crate::ui::constant::WIDTH;
+use crate::ui::geometry::{Offset, Point, Rect};
+use crate::ui::shape::{BasicCanvas, Bitmap, BitmapFormat, BitmapView, Canvas, Rgb565Canvas};
 
 // JDEC work buffer size
 //

--- a/core/embed/rust/src/ui/shape/cache/zlib_cache.rs
+++ b/core/embed/rust/src/ui/shape/cache/zlib_cache.rs
@@ -1,10 +1,11 @@
-use crate::{
-    io::BinaryData,
-    trezorhal::uzlib::{ZlibInflate, UZLIB_WINDOW_SIZE},
-    ui::display::image::ToifInfo,
-};
 use core::cell::UnsafeCell;
-use without_alloc::{alloc::LocalAllocLeakExt, FixedVec};
+
+use without_alloc::alloc::LocalAllocLeakExt;
+use without_alloc::FixedVec;
+
+use crate::io::BinaryData;
+use crate::trezorhal::uzlib::{ZlibInflate, UZLIB_WINDOW_SIZE};
+use crate::ui::display::image::ToifInfo;
 
 struct ZlibCacheSlot<'a> {
     /// Decompression context for the current zdata.

--- a/core/embed/rust/src/ui/shape/canvas/common.rs
+++ b/core/embed/rust/src/ui/shape/canvas/common.rs
@@ -1,13 +1,7 @@
-use crate::ui::{
-    display::Color,
-    geometry::{Offset, Point, Rect},
-};
-
-use super::super::{
-    utils::{circle_points, line_points, sin_f32},
-    Bitmap, BitmapFormat, BitmapView, Viewport,
-};
-
+use super::super::utils::{circle_points, line_points, sin_f32};
+use super::super::{Bitmap, BitmapFormat, BitmapView, Viewport};
+use crate::ui::display::Color;
+use crate::ui::geometry::{Offset, Point, Rect};
 #[cfg(feature = "ui_blurring")]
 use crate::ui::shape::DrawingCache;
 

--- a/core/embed/rust/src/ui/shape/canvas/mono8.rs
+++ b/core/embed/rust/src/ui/shape/canvas/mono8.rs
@@ -1,19 +1,11 @@
-use crate::{
-    error::Error,
-    trezorhal::bitblt::{BitBltCopy, BitBltFill},
-    ui::{
-        display::Color,
-        geometry::{Offset, Point, Rect},
-    },
-};
-
-use super::{
-    super::{Bitmap, BitmapFormat, BitmapView},
-    BasicCanvas, Canvas, CanvasBuilder, Viewport,
-};
-
 #[cfg(feature = "ui_blurring")]
 use super::super::DrawingCache;
+use super::super::{Bitmap, BitmapFormat, BitmapView};
+use super::{BasicCanvas, Canvas, CanvasBuilder, Viewport};
+use crate::error::Error;
+use crate::trezorhal::bitblt::{BitBltCopy, BitBltFill};
+use crate::ui::display::Color;
+use crate::ui::geometry::{Offset, Point, Rect};
 
 /// A struct representing 8-bit monochromatic canvas
 pub struct Mono8Canvas<'a> {

--- a/core/embed/rust/src/ui/shape/canvas/rgb565.rs
+++ b/core/embed/rust/src/ui/shape/canvas/rgb565.rs
@@ -1,19 +1,11 @@
-use crate::{
-    error::Error,
-    trezorhal::bitblt::{BitBltCopy, BitBltFill},
-    ui::{
-        display::Color,
-        geometry::{Offset, Point, Rect},
-    },
-};
-
-use super::{
-    super::{Bitmap, BitmapFormat, BitmapView},
-    BasicCanvas, Canvas, CanvasBuilder, Viewport,
-};
-
 #[cfg(feature = "ui_blurring")]
 use super::super::DrawingCache;
+use super::super::{Bitmap, BitmapFormat, BitmapView};
+use super::{BasicCanvas, Canvas, CanvasBuilder, Viewport};
+use crate::error::Error;
+use crate::trezorhal::bitblt::{BitBltCopy, BitBltFill};
+use crate::ui::display::Color;
+use crate::ui::geometry::{Offset, Point, Rect};
 
 /// A struct representing 16-bit (RGB565) color canvas
 pub struct Rgb565Canvas<'a> {

--- a/core/embed/rust/src/ui/shape/canvas/rgba8888.rs
+++ b/core/embed/rust/src/ui/shape/canvas/rgba8888.rs
@@ -1,19 +1,11 @@
-use crate::{
-    error::Error,
-    trezorhal::bitblt::{BitBltCopy, BitBltFill},
-    ui::{
-        display::Color,
-        geometry::{Offset, Point, Rect},
-    },
-};
-
-use super::{
-    super::{Bitmap, BitmapFormat, BitmapView},
-    BasicCanvas, Canvas, CanvasBuilder, Viewport,
-};
-
 #[cfg(feature = "ui_blurring")]
 use super::super::DrawingCache;
+use super::super::{Bitmap, BitmapFormat, BitmapView};
+use super::{BasicCanvas, Canvas, CanvasBuilder, Viewport};
+use crate::error::Error;
+use crate::trezorhal::bitblt::{BitBltCopy, BitBltFill};
+use crate::ui::display::Color;
+use crate::ui::geometry::{Offset, Point, Rect};
 
 /// A struct representing 32-bit (RGBA8888) color canvas
 pub struct Rgba8888Canvas<'a> {

--- a/core/embed/rust/src/ui/shape/circle.rs
+++ b/core/embed/rust/src/ui/shape/circle.rs
@@ -1,11 +1,8 @@
-use crate::ui::{
-    display::Color,
-    geometry::{Point, Rect},
-};
+use without_alloc::alloc::LocalAllocLeakExt;
 
 use super::{Canvas, DrawingCache, Renderer, Shape, ShapeClone};
-
-use without_alloc::alloc::LocalAllocLeakExt;
+use crate::ui::display::Color;
+use crate::ui::geometry::{Point, Rect};
 
 /// A shape for rendering various types of circles or circle sectors.
 pub struct Circle {

--- a/core/embed/rust/src/ui/shape/corner_highlight.rs
+++ b/core/embed/rust/src/ui/shape/corner_highlight.rs
@@ -1,10 +1,8 @@
-use crate::ui::{
-    display::Color,
-    geometry::{Alignment2D, Offset, Point, Rect},
-    shape::{Canvas, DrawingCache, Renderer, Shape, ShapeClone},
-};
-
 use without_alloc::alloc::LocalAllocLeakExt;
+
+use crate::ui::display::Color;
+use crate::ui::geometry::{Alignment2D, Offset, Point, Rect};
+use crate::ui::shape::{Canvas, DrawingCache, Renderer, Shape, ShapeClone};
 
 #[derive(Clone, Copy)]
 pub enum CornerPosition {

--- a/core/embed/rust/src/ui/shape/display/bumps.rs
+++ b/core/embed/rust/src/ui/shape/display/bumps.rs
@@ -1,6 +1,6 @@
-use crate::ui::shape::DrawingCache;
-
 use static_alloc::Bump;
+
+use crate::ui::shape::DrawingCache;
 
 /// Memory reserved for `ProgressiveRenderer`s shape storage.
 /// ProgressiveRenderer is used if framebuffer is not available.

--- a/core/embed/rust/src/ui/shape/display/direct_canvas.rs
+++ b/core/embed/rust/src/ui/shape/display/direct_canvas.rs
@@ -1,9 +1,7 @@
-use crate::ui::{
-    display::Color,
-    shape::{render::ScopedRenderer, Canvas, DirectRenderer, DrawingCache},
-};
-
 use super::bumps::run_with_bumps;
+use crate::ui::display::Color;
+use crate::ui::shape::render::ScopedRenderer;
+use crate::ui::shape::{Canvas, DirectRenderer, DrawingCache};
 
 /// Creates the `Renderer` object for drawing on a specified canvas and invokes
 /// a user-defined function that takes a single argument `target`. The user's

--- a/core/embed/rust/src/ui/shape/display/fake_display.rs
+++ b/core/embed/rust/src/ui/shape/display/fake_display.rs
@@ -1,7 +1,6 @@
-use crate::ui::{
-    display::Color,
-    shape::{render::ScopedRenderer, DirectRenderer, Mono8Canvas, Viewport},
-};
+use crate::ui::display::Color;
+use crate::ui::shape::render::ScopedRenderer;
+use crate::ui::shape::{DirectRenderer, Mono8Canvas, Viewport};
 
 pub type ConcreteRenderer<'a, 'alloc> = DirectRenderer<'a, 'alloc, Mono8Canvas<'alloc>>;
 

--- a/core/embed/rust/src/ui/shape/display/fb_mono8.rs
+++ b/core/embed/rust/src/ui/shape/display/fb_mono8.rs
@@ -1,17 +1,12 @@
-use crate::ui::{
-    display::Color,
-    geometry::Offset,
-    shape::{
-        render::ScopedRenderer, BasicCanvas, DirectRenderer, DrawingCache, Mono8Canvas, Viewport,
-    },
-};
-
-#[cfg(feature = "ui_debug_overlay")]
-use crate::ui::{CommonUI, ModelUI};
+use static_alloc::Bump;
 
 use crate::trezorhal::display;
-
-use static_alloc::Bump;
+use crate::ui::display::Color;
+use crate::ui::geometry::Offset;
+use crate::ui::shape::render::ScopedRenderer;
+use crate::ui::shape::{BasicCanvas, DirectRenderer, DrawingCache, Mono8Canvas, Viewport};
+#[cfg(feature = "ui_debug_overlay")]
+use crate::ui::{CommonUI, ModelUI};
 
 pub type ConcreteRenderer<'a, 'alloc> = DirectRenderer<'a, 'alloc, Mono8Canvas<'alloc>>;
 

--- a/core/embed/rust/src/ui/shape/display/fb_rgb565.rs
+++ b/core/embed/rust/src/ui/shape/display/fb_rgb565.rs
@@ -1,22 +1,13 @@
-use crate::{
-    trezorhal::display,
-    ui::{
-        display::Color,
-        geometry::Offset,
-        shape::{
-            render::ScopedRenderer, BasicCanvas, DirectRenderer, DrawingCache, Rgb565Canvas,
-            Viewport,
-        },
-    },
-};
-
+use super::bumps;
+use crate::trezorhal::display;
+use crate::ui::display::Color;
+use crate::ui::geometry::Offset;
+use crate::ui::shape::render::ScopedRenderer;
+use crate::ui::shape::{BasicCanvas, DirectRenderer, DrawingCache, Rgb565Canvas, Viewport};
 #[cfg(any(feature = "ui_debug_overlay", feature = "ui_performance_overlay"))]
 use crate::ui::{CommonUI, ModelUI};
-
 #[cfg(feature = "ui_performance_overlay")]
 use crate::{trezorhal::time, ui::PerformanceOverlay};
-
-use super::bumps;
 
 pub type ConcreteRenderer<'a, 'alloc> = DirectRenderer<'a, 'alloc, Rgb565Canvas<'alloc>>;
 

--- a/core/embed/rust/src/ui/shape/display/fb_rgba8888.rs
+++ b/core/embed/rust/src/ui/shape/display/fb_rgba8888.rs
@@ -1,21 +1,13 @@
+use super::bumps;
+use crate::trezorhal::display;
+use crate::ui::display::Color;
+use crate::ui::geometry::Offset;
+use crate::ui::shape::render::ScopedRenderer;
+use crate::ui::shape::{BasicCanvas, DirectRenderer, DrawingCache, Rgba8888Canvas, Viewport};
 #[cfg(any(feature = "ui_debug_overlay", feature = "ui_performance_overlay"))]
 use crate::ui::{CommonUI, ModelUI};
-use crate::{
-    trezorhal::display,
-    ui::{
-        display::Color,
-        geometry::Offset,
-        shape::{
-            render::ScopedRenderer, BasicCanvas, DirectRenderer, DrawingCache, Rgba8888Canvas,
-            Viewport,
-        },
-    },
-};
-
 #[cfg(feature = "ui_performance_overlay")]
 use crate::{trezorhal::time, ui::PerformanceOverlay};
-
-use super::bumps;
 
 pub type ConcreteRenderer<'a, 'alloc> = DirectRenderer<'a, 'alloc, Rgba8888Canvas<'alloc>>;
 

--- a/core/embed/rust/src/ui/shape/display/mod.rs
+++ b/core/embed/rust/src/ui/shape/display/mod.rs
@@ -16,32 +16,28 @@ pub mod nofb_rgb565;
 mod _new_rendering {
     #[cfg(not(feature = "framebuffer"))]
     mod _framebuffer {
-        #[cfg(feature = "display_rgb565")]
-        pub use super::super::nofb_rgb565::{render_on_display, ConcreteRenderer};
-
         #[cfg(not(feature = "display_rgb565"))]
         pub use super::super::fake_display::{render_on_display, ConcreteRenderer};
+        #[cfg(feature = "display_rgb565")]
+        pub use super::super::nofb_rgb565::{render_on_display, ConcreteRenderer};
     }
 
     #[cfg(feature = "framebuffer")]
     mod _framebuffer {
-        #[cfg(feature = "display_rgb565")]
-        pub use super::super::fb_rgb565::{render_on_display, ConcreteRenderer};
-
-        #[cfg(all(feature = "display_rgba8888", not(feature = "display_rgb565")))]
-        pub use super::super::fb_rgba8888::{render_on_display, ConcreteRenderer};
-
         #[cfg(all(
             feature = "display_mono",
             not(feature = "display_rgb565"),
             not(feature = "display_rgba8888")
         ))]
         pub use super::super::fb_mono8::{render_on_display, ConcreteRenderer};
+        #[cfg(feature = "display_rgb565")]
+        pub use super::super::fb_rgb565::{render_on_display, ConcreteRenderer};
+        #[cfg(all(feature = "display_rgba8888", not(feature = "display_rgb565")))]
+        pub use super::super::fb_rgba8888::{render_on_display, ConcreteRenderer};
     }
 
     pub use _framebuffer::{render_on_display, ConcreteRenderer};
 }
 
 pub use _new_rendering::{render_on_display, ConcreteRenderer};
-
 pub use bumps::unlock_bumps_on_failure;

--- a/core/embed/rust/src/ui/shape/display/nofb_rgb565.rs
+++ b/core/embed/rust/src/ui/shape/display/nofb_rgb565.rs
@@ -1,24 +1,14 @@
-use crate::{
-    trezorhal::{
-        bitblt::{BitBltCopy, BitBltFill},
-        display,
-    },
-    ui::shape::render::ScopedRenderer,
-};
-
-#[cfg(feature = "ui_debug_overlay")]
-use crate::ui::{CommonUI, ModelUI};
-
-use crate::ui::{
-    display::Color,
-    geometry::{Offset, Rect},
-};
+use static_alloc::Bump;
 
 use super::super::{BasicCanvas, BitmapView, DrawingCache, ProgressiveRenderer, Viewport};
-
 use super::bumps;
-
-use static_alloc::Bump;
+use crate::trezorhal::bitblt::{BitBltCopy, BitBltFill};
+use crate::trezorhal::display;
+use crate::ui::display::Color;
+use crate::ui::geometry::{Offset, Rect};
+use crate::ui::shape::render::ScopedRenderer;
+#[cfg(feature = "ui_debug_overlay")]
+use crate::ui::{CommonUI, ModelUI};
 
 pub type ConcreteRenderer<'a, 'alloc> =
     ProgressiveRenderer<'a, 'alloc, Bump<[u8; bumps::BUMP_A_SIZE]>, DisplayCanvas>;

--- a/core/embed/rust/src/ui/shape/jpeg.rs
+++ b/core/embed/rust/src/ui/shape/jpeg.rs
@@ -1,20 +1,13 @@
-use crate::{
-    io::BinaryData,
-    ui::{
-        display::image::JpegInfo,
-        geometry::{Alignment2D, Offset, Point, Rect},
-    },
-};
-
-use super::{Canvas, DrawingCache, Renderer, Shape, ShapeClone};
+use without_alloc::alloc::LocalAllocLeakExt;
 
 #[cfg(not(feature = "hw_jpeg_decoder"))]
 use super::{Bitmap, BitmapFormat, BitmapView};
-
+use super::{Canvas, DrawingCache, Renderer, Shape, ShapeClone};
+use crate::io::BinaryData;
+use crate::ui::display::image::JpegInfo;
+use crate::ui::geometry::{Alignment2D, Offset, Point, Rect};
 #[cfg(feature = "hw_jpeg_decoder")]
 use crate::{trezorhal::jpegdec::JpegDecoder, ui::display::Color};
-
-use without_alloc::alloc::LocalAllocLeakExt;
 
 /// A shape for rendering compressed JPEG images.
 pub struct JpegImage<'a> {

--- a/core/embed/rust/src/ui/shape/jpeg_overlay.rs
+++ b/core/embed/rust/src/ui/shape/jpeg_overlay.rs
@@ -1,16 +1,11 @@
-use crate::{
-    io::BinaryData,
-    ui::{
-        display::image::JpegInfo,
-        geometry::{Alignment2D, Offset, Point, Rect},
-    },
-};
+use without_alloc::alloc::LocalAllocLeakExt;
 
 use super::{Canvas, DrawingCache, Renderer, Shape, ShapeClone};
-
-use crate::{trezorhal::jpegdec::JpegDecoder, ui::display::Color};
-
-use without_alloc::alloc::LocalAllocLeakExt;
+use crate::io::BinaryData;
+use crate::trezorhal::jpegdec::JpegDecoder;
+use crate::ui::display::image::JpegInfo;
+use crate::ui::display::Color;
+use crate::ui::geometry::{Alignment2D, Offset, Point, Rect};
 
 /// A shape for rendering grayscale JPEG images as a transparent overlay
 /// over the existing content.

--- a/core/embed/rust/src/ui/shape/mod.rs
+++ b/core/embed/rust/src/ui/shape/mod.rs
@@ -42,7 +42,6 @@ pub use progressive_render::ProgressiveRenderer;
 pub use qrcode::QrImage;
 pub use rawimage::RawImage;
 pub use render::{DirectRenderer, Renderer, ScopedRenderer};
-
 pub use text::Text;
 pub use toif::ToifImage;
 #[cfg(feature = "ui_image_buffer")]

--- a/core/embed/rust/src/ui/shape/progressive_render.rs
+++ b/core/embed/rust/src/ui/shape/progressive_render.rs
@@ -1,11 +1,10 @@
-use crate::ui::{
-    display::Color,
-    geometry::{Offset, Point, Rect},
-    shape::{BasicCanvas, Canvas, DrawingCache, Renderer, Shape, ShapeClone, Viewport},
-};
-use without_alloc::{alloc::LocalAllocLeakExt, FixedVec};
+use without_alloc::alloc::LocalAllocLeakExt;
+use without_alloc::FixedVec;
 
 use super::Rgb565Canvas;
+use crate::ui::display::Color;
+use crate::ui::geometry::{Offset, Point, Rect};
+use crate::ui::shape::{BasicCanvas, Canvas, DrawingCache, Renderer, Shape, ShapeClone, Viewport};
 
 struct ShapeHolder<'a> {
     shape: &'a mut dyn Shape<'a>,

--- a/core/embed/rust/src/ui/shape/qrcode.rs
+++ b/core/embed/rust/src/ui/shape/qrcode.rs
@@ -1,15 +1,10 @@
-use crate::ui::{
-    display::Color,
-    geometry::{Offset, Rect},
-};
-
 use qrcodegen::QrCode;
-
-use super::{
-    utils::line_points, Bitmap, BitmapFormat, Canvas, DrawingCache, Renderer, Shape, ShapeClone,
-};
-
 use without_alloc::alloc::LocalAllocLeakExt;
+
+use super::utils::line_points;
+use super::{Bitmap, BitmapFormat, Canvas, DrawingCache, Renderer, Shape, ShapeClone};
+use crate::ui::display::Color;
+use crate::ui::geometry::{Offset, Rect};
 
 const MAX_QRCODE_BYTES: usize = 400;
 

--- a/core/embed/rust/src/ui/shape/rawimage.rs
+++ b/core/embed/rust/src/ui/shape/rawimage.rs
@@ -1,8 +1,7 @@
-use crate::ui::geometry::Rect;
+use without_alloc::alloc::LocalAllocLeakExt;
 
 use super::{BitmapView, Canvas, DrawingCache, Renderer, Shape, ShapeClone};
-
-use without_alloc::alloc::LocalAllocLeakExt;
+use crate::ui::geometry::Rect;
 
 /// A shape for rendering compressed TOIF images.
 pub struct RawImage<'a> {

--- a/core/embed/rust/src/ui/shape/render.rs
+++ b/core/embed/rust/src/ui/shape/render.rs
@@ -1,11 +1,8 @@
+use super::{Canvas, DrawingCache, Shape, ShapeClone, Viewport};
+use crate::ui::display::Color;
+use crate::ui::geometry::{Offset, Rect};
 #[cfg(feature = "rgb_led")]
 use crate::ui::led::LedState;
-use crate::ui::{
-    display::Color,
-    geometry::{Offset, Rect},
-};
-
-use super::{Canvas, DrawingCache, Shape, ShapeClone, Viewport};
 
 // ==========================================================================
 // trait Renderer

--- a/core/embed/rust/src/ui/shape/text.rs
+++ b/core/embed/rust/src/ui/shape/text.rs
@@ -1,11 +1,8 @@
-use crate::ui::{
-    display::{Color, Font},
-    geometry::{Alignment, Offset, Point, Rect},
-};
+use without_alloc::alloc::LocalAllocLeakExt;
 
 use super::{BitmapView, Canvas, DrawingCache, Renderer, Shape, ShapeClone};
-
-use without_alloc::alloc::LocalAllocLeakExt;
+use crate::ui::display::{Color, Font};
+use crate::ui::geometry::{Alignment, Offset, Point, Rect};
 
 /// A shape for text strings rendering.
 pub struct Text<'a> {

--- a/core/embed/rust/src/ui/shape/toif.rs
+++ b/core/embed/rust/src/ui/shape/toif.rs
@@ -1,14 +1,11 @@
-use crate::{
-    io::BinaryData,
-    ui::{
-        display::{image::ToifInfo, toif::Toif, Color},
-        geometry::{Alignment2D, Offset, Point, Rect},
-    },
-};
+use without_alloc::alloc::LocalAllocLeakExt;
 
 use super::{Bitmap, BitmapFormat, Canvas, DrawingCache, Renderer, Shape, ShapeClone};
-
-use without_alloc::alloc::LocalAllocLeakExt;
+use crate::io::BinaryData;
+use crate::ui::display::image::ToifInfo;
+use crate::ui::display::toif::Toif;
+use crate::ui::display::Color;
+use crate::ui::geometry::{Alignment2D, Offset, Point, Rect};
 
 /// A shape for rendering compressed TOIF images.
 pub struct ToifImage<'a> {

--- a/core/embed/rust/src/ui/shape/utils/blur.rs
+++ b/core/embed/rust/src/ui/shape/utils/blur.rs
@@ -1,4 +1,3 @@
-use crate::{trezorhal::display, ui::geometry::Offset};
 /// This is a simple and fast blurring algorithm that uses a box filter -
 /// a square kernel with all coefficients set to 1.
 ///
@@ -39,6 +38,9 @@ use crate::{trezorhal::display, ui::geometry::Offset};
 /// }
 /// ```
 use core::mem::size_of;
+
+use crate::trezorhal::display;
+use crate::ui::geometry::Offset;
 
 const MAX_RADIUS: usize = 4;
 const MAX_SIDE: usize = 1 + MAX_RADIUS * 2;

--- a/core/embed/rust/src/ui/shape/utils/imagebuf.rs
+++ b/core/embed/rust/src/ui/shape/utils/imagebuf.rs
@@ -1,10 +1,6 @@
-use crate::{
-    error::Error,
-    ui::{
-        geometry::Offset,
-        shape::{Bitmap, BitmapView, Canvas, CanvasBuilder},
-    },
-};
+use crate::error::Error;
+use crate::ui::geometry::Offset;
+use crate::ui::shape::{Bitmap, BitmapView, Canvas, CanvasBuilder};
 
 /// Size of image buffer in bytes
 /// (up to 240x240 pixel, 16-bit RGB565 image)

--- a/core/embed/rust/src/ui/shape/utils/mod.rs
+++ b/core/embed/rust/src/ui/shape/utils/mod.rs
@@ -8,9 +8,7 @@ mod trigo;
 
 pub use blur::{BlurAlgorithm, BlurBuff};
 pub use circle::circle_points;
-
 #[cfg(feature = "ui_image_buffer")]
 pub use imagebuf::ImageBuffer;
-
 pub use line::line_points;
 pub use trigo::sin_f32;

--- a/core/embed/rust/src/ui/ui_common.rs
+++ b/core/embed/rust/src/ui/ui_common.rs
@@ -1,5 +1,4 @@
 use crate::ui::geometry::Rect;
-
 #[cfg(any(feature = "ui_debug_overlay", feature = "ui_performance_overlay"))]
 use crate::ui::shape::Renderer;
 

--- a/core/embed/rust/src/ui/ui_firmware.rs
+++ b/core/embed/rust/src/ui/ui_firmware.rs
@@ -1,16 +1,15 @@
-use crate::{
-    error::Error,
-    io::BinaryData,
-    micropython::{buffer::StrBuffer, gc::Gc, list::List, obj::Obj},
-    strutil::TString,
-    ui::notification::Notification,
-};
 use heapless::Vec;
 
-use super::layout::{
-    obj::{LayoutMaybeTrace, LayoutObj},
-    util::RecoveryType,
-};
+use super::layout::obj::{LayoutMaybeTrace, LayoutObj};
+use super::layout::util::RecoveryType;
+use crate::error::Error;
+use crate::io::BinaryData;
+use crate::micropython::buffer::StrBuffer;
+use crate::micropython::gc::Gc;
+use crate::micropython::list::List;
+use crate::micropython::obj::Obj;
+use crate::strutil::TString;
+use crate::ui::notification::Notification;
 
 pub const MAX_CHECKLIST_ITEMS: usize = 3;
 pub const MAX_WORD_QUIZ_ITEMS: usize = 3;

--- a/core/embed/rust/src/ui/ui_prodtest.rs
+++ b/core/embed/rust/src/ui/ui_prodtest.rs
@@ -1,9 +1,9 @@
 #[cfg(feature = "touch")]
-use crate::ui::{event::TouchEvent, geometry::Rect};
-#[cfg(feature = "touch")]
 use heapless::Vec;
 
 use crate::ui::component::Event;
+#[cfg(feature = "touch")]
+use crate::ui::{event::TouchEvent, geometry::Rect};
 
 pub trait ProdtestLayoutType {
     fn event(&mut self, event: Option<Event>) -> u32;

--- a/core/embed/rust/src/ui/util.rs
+++ b/core/embed/rust/src/ui/util.rs
@@ -1,6 +1,5 @@
-use crate::strutil::ShortString;
-
 use super::display::Font;
+use crate::strutil::ShortString;
 
 pub trait ResultExt {
     fn assert_if_debugging_ui(self, message: &str);

--- a/core/embed/rust/src/util/logger.rs
+++ b/core/embed/rust/src/util/logger.rs
@@ -1,13 +1,11 @@
 //! Connects the `log::error!`, `log::warn!`, ... macros from the `log` crate to
 //! our C logging backend.
 
+use core::fmt::Write;
+use core::sync::atomic::{AtomicBool, Ordering};
+
 use heapless::Vec;
 use log::{set_logger, set_max_level, Level, LevelFilter, Log, Metadata, Record};
-
-use core::{
-    fmt::Write,
-    sync::atomic::{AtomicBool, Ordering},
-};
 
 use crate::trezorhal::syslog::{syslog_start_record, syslog_write_chunk, LogLevel};
 

--- a/core/embed/rustfmt.toml
+++ b/core/embed/rustfmt.toml
@@ -1,0 +1,4 @@
+wrap_comments = true
+imports_granularity = "Module"
+reorder_imports = true
+group_imports = "StdExternalCrate"

--- a/core/embed/sec/tropic/build.rs
+++ b/core/embed/sec/tropic/build.rs
@@ -1,6 +1,6 @@
-use xbuild::{CLibrary, Result, bail_unsupported};
-
 use std::path::PathBuf;
+
+use xbuild::{CLibrary, Result, bail_unsupported};
 
 pub fn def_module(lib: &mut CLibrary) -> Result<()> {
     lib.add_include("tropic/inc");

--- a/core/embed/upymod/build.rs
+++ b/core/embed/upymod/build.rs
@@ -1,11 +1,9 @@
-use std::{
-    env,
-    fs::{self, File},
-    io::{BufRead, BufReader, Write},
-    iter::once,
-    os::unix,
-    path::{Path, PathBuf},
-};
+use std::env;
+use std::fs::{self, File};
+use std::io::{BufRead, BufReader, Write};
+use std::iter::once;
+use std::os::unix;
+use std::path::{Path, PathBuf};
 
 use xbuild::{
     CLibrary, InputFiles, OutputType, Result, WrapErr, bail, bail_unsupported, current_model_id,
@@ -848,7 +846,8 @@ impl<'a> MpyBuilder<'a> {
         let mut mpy_files = xbuild::run_parallel(py_files.as_paths(), compile_func)
             .context("Failed to build frozen modules")?;
 
-        // Sort .mpy files by their path to ensure deterministic order in the generated C file
+        // Sort .mpy files by their path to ensure deterministic order in the generated
+        // C file
         mpy_files.sort_by_key(|mpy_file| mpy_file.display().to_string());
 
         // Build C file from mpy modules

--- a/core/embed/xbuild/src/attrs.rs
+++ b/core/embed/xbuild/src/attrs.rs
@@ -1,15 +1,14 @@
 use std::path::{Path, PathBuf};
 
-use color_eyre::{
-    Result,
-    eyre::{WrapErr, ensure},
-};
+use color_eyre::Result;
+use color_eyre::eyre::{WrapErr, ensure};
 
 use crate::helpers::{join_paths_lexically, library_metadata, relative_to_manifest};
 
 /// Attributes for configuring C compilation.
 ///
-/// This struct holds compiler flags, defines, and include paths for use when compiling C code.
+/// This struct holds compiler flags, defines, and include paths for use when
+/// compiling C code.
 #[derive(Debug, Clone, Default, PartialEq, Eq)]
 pub struct CompileAttrs {
     /// Compiler flags (e.g. `-O3`, `-fno-exceptions`, etc.)
@@ -28,7 +27,8 @@ impl CompileAttrs {
         Self::default()
     }
 
-    /// Appends a compiler flag and returns the modified `CompileAttrs` for chaining.
+    /// Appends a compiler flag and returns the modified `CompileAttrs` for
+    /// chaining.
     ///
     /// # Parameters
     /// - `flag`: The compiler flag to add (e.g., `-O2`).
@@ -41,7 +41,8 @@ impl CompileAttrs {
         self
     }
 
-    /// Appends an include path and returns the modified `CompileAttrs` for chaining.
+    /// Appends an include path and returns the modified `CompileAttrs` for
+    /// chaining.
     ///
     /// # Parameters
     /// - `path`: The include path to add.
@@ -70,7 +71,8 @@ impl CompileAttrs {
         self.flags.retain(|f| f != flag);
     }
 
-    /// Adds a preprocessor define, with an optional value, if not already present.
+    /// Adds a preprocessor define, with an optional value, if not already
+    /// present.
     ///
     /// # Parameters
     /// - `name`: The name of the define (e.g., `FOO`).
@@ -82,7 +84,8 @@ impl CompileAttrs {
         }
     }
 
-    /// Adds an include path, making it relative to the Cargo manifest if possible, if not already present.
+    /// Adds an include path, making it relative to the Cargo manifest if
+    /// possible, if not already present.
     ///
     /// # Parameters
     /// - `path`: The include path to add.
@@ -93,7 +96,8 @@ impl CompileAttrs {
         }
     }
 
-    /// Merges another `CompileAttrs` into this one, combining their flags, defines, and includes.
+    /// Merges another `CompileAttrs` into this one, combining their flags,
+    /// defines, and includes.
     ///
     /// Duplicate flags are allowed, but defines and includes are deduplicated.
     ///
@@ -124,7 +128,8 @@ impl CompileAttrs {
         self
     }
 
-    /// Configures and returns a `cc::Tool` based on the current compile attributes.
+    /// Configures and returns a `cc::Tool` based on the current compile
+    /// attributes.
     ///
     /// This can be used to compile C code with the same settings.
     ///
@@ -150,13 +155,16 @@ impl CompileAttrs {
         build.get_compiler()
     }
 
-    /// Exports the compile attributes as Cargo metadata for use in dependent crates.
+    /// Exports the compile attributes as Cargo metadata for use in dependent
+    /// crates.
     ///
-    /// This function prints metadata for includes, defines, and flags to stdout for Cargo to consume.
+    /// This function prints metadata for includes, defines, and flags to stdout
+    /// for Cargo to consume.
     ///
     /// # Errors
     ///
-    /// Returns an error if the manifest directory is not set or if path conversion fails.
+    /// Returns an error if the manifest directory is not set or if path
+    /// conversion fails.
     pub fn export_as_metadata(&self) -> Result<()> {
         let manifest_dir = std::env::var("CARGO_MANIFEST_DIR")
             .context("CARGO_MANIFEST_DIR is required but not set")?;
@@ -197,7 +205,8 @@ impl CompileAttrs {
         Ok(())
     }
 
-    /// Imports the specified crate's public C compiler attributes from Cargo metadata.
+    /// Imports the specified crate's public C compiler attributes from Cargo
+    /// metadata.
     ///
     /// # Parameters
     /// - `library`: The name of the library whose metadata to import.
@@ -240,7 +249,8 @@ impl CompileAttrs {
     ///
     /// # Errors
     ///
-    /// Returns an error if the compiler cannot be executed or its output cannot be parsed.
+    /// Returns an error if the compiler cannot be executed or its output cannot
+    /// be parsed.
     pub fn import_cc_compiler_includes(&mut self) -> Result<()> {
         let compiler = cc::Build::new().get_compiler();
         let cc_output = compiler
@@ -270,7 +280,8 @@ impl CompileAttrs {
         Ok(())
     }
 
-    /// Returns a list of arguments that represent the compile attributes, suitable for passing to a C compiler.
+    /// Returns a list of arguments that represent the compile attributes,
+    /// suitable for passing to a C compiler.
     ///
     /// # Returns
     ///

--- a/core/embed/xbuild/src/clibrary/cc_generator.rs
+++ b/core/embed/xbuild/src/clibrary/cc_generator.rs
@@ -1,7 +1,7 @@
-use color_eyre::{Result, eyre::WrapErr};
+use color_eyre::Result;
+use color_eyre::eyre::WrapErr;
 
 use super::CLibrary;
-
 use crate::helpers::{derive_output_path, join_paths_lexically, links_name, path_from_env};
 
 /// Path to the partial compile_commands.json fragment within OUT_DIR.

--- a/core/embed/xbuild/src/clibrary/compile.rs
+++ b/core/embed/xbuild/src/clibrary/compile.rs
@@ -1,16 +1,16 @@
 use std::path::{Path, PathBuf};
 
-use color_eyre::{Result, eyre::WrapErr};
+use color_eyre::Result;
+use color_eyre::eyre::WrapErr;
 
 use super::CLibrary;
 use crate::attrs::CompileAttrs;
 use crate::dep_tracking::{run_command, run_command_with_cc_dep};
-use crate::parallel::run_parallel;
-
 use crate::helpers::{
     derive_output_path, ensure_parent_directory, join_paths_lexically, links_name, measure_time,
     path_from_env,
 };
+use crate::parallel::run_parallel;
 
 // Represents a single compilation task
 #[derive(Clone)]
@@ -85,14 +85,17 @@ impl CompileUnit {
 }
 
 impl CLibrary {
-    /// Compiles all sources in parallel and generates object files for the library.
+    /// Compiles all sources in parallel and generates object files for the
+    /// library.
     ///
-    /// This function compiles all source files associated with the library in parallel,
-    /// creates a static library archive, and exports the library's metadata for downstream crates.
+    /// This function compiles all source files associated with the library in
+    /// parallel, creates a static library archive, and exports the
+    /// library's metadata for downstream crates.
     ///
     /// # Errors
     ///
-    /// Returns an error if compilation or archiving fails, or if required environment variables are missing.
+    /// Returns an error if compilation or archiving fails, or if required
+    /// environment variables are missing.
     pub(crate) fn compile(&self) -> Result<()> {
         let lib_name = links_name()?;
 
@@ -116,9 +119,11 @@ impl CLibrary {
     ///
     /// # Parameters
     ///
-    /// - `output_ext`: The file extension for the output files (e.g., `"upydef"`).
+    /// - `output_ext`: The file extension for the output files (e.g.,
+    ///   `"upydef"`).
     /// - `extra_args`: Additional compiler/preprocessor flags.
-    /// - `extra_sources`: Additional source files to process beyond the library's own sources.
+    /// - `extra_sources`: Additional source files to process beyond the
+    ///   library's own sources.
     ///
     /// # Returns
     ///
@@ -199,12 +204,14 @@ impl CLibrary {
 
     /// Preprocesses a C header or source file using the configured C compiler.
     ///
-    /// This runs the compiler in preprocessor mode (`-E`) and writes the output to the specified file.
+    /// This runs the compiler in preprocessor mode (`-E`) and writes the output
+    /// to the specified file.
     ///
     /// # Parameters
     ///
     /// - `input`: Path to the input C header or source file.
-    /// - `output`: Path to the output file where the preprocessed result will be written.
+    /// - `output`: Path to the output file where the preprocessed result will
+    ///   be written.
     ///
     /// # Errors
     ///

--- a/core/embed/xbuild/src/clibrary/embed.rs
+++ b/core/embed/xbuild/src/clibrary/embed.rs
@@ -1,18 +1,13 @@
 use std::path::Path;
 
-use color_eyre::{
-    Result,
-    eyre::{WrapErr, ensure},
-};
+use color_eyre::Result;
+use color_eyre::eyre::{WrapErr, ensure};
+use zlib_rs::{DeflateConfig, ReturnCode, compress_bound, compress_slice};
 
 use super::CLibrary;
+use crate::dep_tracking::{run_command, run_if_changed};
 use crate::helpers::{derive_output_path, ensure_parent_directory, path_from_env};
-use crate::{
-    dep_tracking::{run_command, run_if_changed},
-    is_rust_analyzer,
-};
-
-use zlib_rs::{DeflateConfig, ReturnCode, compress_bound, compress_slice};
+use crate::is_rust_analyzer;
 
 impl CLibrary {
     /// Embeds a binary file into the library by converting it into an object
@@ -93,7 +88,8 @@ impl CLibrary {
         self.embed_binary(compressed_path, section)
     }
 
-    /// Compresses a file using zlib and write the compressed data to an output file.
+    /// Compresses a file using zlib and write the compressed data to an output
+    /// file.
     fn compress_file(&self, input: impl AsRef<Path>, output: impl AsRef<Path>) -> Result<()> {
         let input = input.as_ref();
         let output = output.as_ref();

--- a/core/embed/xbuild/src/clibrary/mod.rs
+++ b/core/embed/xbuild/src/clibrary/mod.rs
@@ -5,7 +5,8 @@ pub mod rust_bindings;
 
 use std::path::{Path, PathBuf};
 
-use color_eyre::{Result, eyre::WrapErr};
+use color_eyre::Result;
+use color_eyre::eyre::WrapErr;
 
 use crate::attrs::CompileAttrs;
 use crate::helpers::{library_metadata, relative_to_manifest};
@@ -21,7 +22,8 @@ pub struct SourceEntry {
     pub attrs: Option<CompileAttrs>,
 }
 
-/// A C static library built from source files with configurable compile attributes.
+/// A C static library built from source files with configurable compile
+/// attributes.
 pub struct CLibrary {
     // List of source files to compile into the library, along with optional
     // per-source compile attributes that are merged with the
@@ -54,7 +56,8 @@ pub struct CLibrary {
 }
 
 impl CLibrary {
-    /// Creates a new `CLibrary` instance with default attributes and no sources or libraries.
+    /// Creates a new `CLibrary` instance with default attributes and no sources
+    /// or libraries.
     ///
     /// # Returns
     ///
@@ -75,7 +78,8 @@ impl CLibrary {
     ///
     /// # Parameters
     ///
-    /// - `src`: Path to the source file, relative to the crate root or absolute.
+    /// - `src`: Path to the source file, relative to the crate root or
+    ///   absolute.
     pub fn add_source(&mut self, src: impl AsRef<Path>) {
         self.add_source_with_attrs(src, None);
     }
@@ -84,7 +88,8 @@ impl CLibrary {
     ///
     /// # Parameters
     ///
-    /// - `sources`: Iterator of paths to source files, each relative to the crate root or absolute.
+    /// - `sources`: Iterator of paths to source files, each relative to the
+    ///   crate root or absolute.
     pub fn add_sources<I, P>(&mut self, sources: I)
     where
         I: IntoIterator<Item = P>,
@@ -98,7 +103,8 @@ impl CLibrary {
     /// # Parameters
     ///
     /// - `dir`: Path to the directory containing the sources.
-    /// - `sources`: Iterator of source file paths, each relative to the directory or absolute.
+    /// - `sources`: Iterator of source file paths, each relative to the
+    ///   directory or absolute.
     pub fn add_sources_in_dir<I, P>(&mut self, dir: impl AsRef<Path>, sources: I)
     where
         I: IntoIterator<Item = P>,
@@ -107,13 +113,16 @@ impl CLibrary {
         self.add_sources_in_dir_with_attrs(dir, sources, None);
     }
 
-    /// Adds a single C or assembly source file with per-source compile attributes.
+    /// Adds a single C or assembly source file with per-source compile
+    /// attributes.
     ///
-    /// This source will be compiled with the library-level attributes merged with the provided attributes.
+    /// This source will be compiled with the library-level attributes merged
+    /// with the provided attributes.
     ///
     /// # Parameters
     ///
-    /// - `src`: Path to the source file, relative to the crate root or absolute.
+    /// - `src`: Path to the source file, relative to the crate root or
+    ///   absolute.
     /// - `attrs`: Optional compile attributes specific to this source file.
     pub fn add_source_with_attrs(&mut self, src: impl AsRef<Path>, attrs: Option<CompileAttrs>) {
         let src = relative_to_manifest(src);
@@ -125,11 +134,13 @@ impl CLibrary {
 
     /// Adds multiple source files with specific compile attributes.
     ///
-    /// All sources will be compiled with the library-level attributes merged with the provided attributes.
+    /// All sources will be compiled with the library-level attributes merged
+    /// with the provided attributes.
     ///
     /// # Parameters
     ///
-    /// - `sources`: Iterator of source file paths, each relative to the crate root or absolute.
+    /// - `sources`: Iterator of source file paths, each relative to the crate
+    ///   root or absolute.
     /// - `attrs`: Optional compile attributes to apply to all sources.
     pub fn add_sources_with_attrs<I, P>(&mut self, sources: I, attrs: Option<CompileAttrs>)
     where
@@ -150,7 +161,8 @@ impl CLibrary {
     /// # Parameters
     ///
     /// - `dir`: Path to the directory containing the sources.
-    /// - `sources`: Iterator of source file paths, each relative to the directory or absolute.
+    /// - `sources`: Iterator of source file paths, each relative to the
+    ///   directory or absolute.
     /// - `attrs`: Optional compile attributes to apply to all sources.
     pub fn add_sources_in_dir_with_attrs<I, P>(
         &mut self,
@@ -187,7 +199,8 @@ impl CLibrary {
     ///
     /// # Parameters
     ///
-    /// - `path`: Path to the include directory, relative to the crate root or absolute.
+    /// - `path`: Path to the include directory, relative to the crate root or
+    ///   absolute.
     pub fn add_private_include(&mut self, path: impl AsRef<Path>) {
         self.private_attrs.add_include(path);
     }
@@ -196,7 +209,8 @@ impl CLibrary {
     ///
     /// # Parameters
     ///
-    /// - `paths`: Iterator of include directory paths, each relative to the crate root or absolute.
+    /// - `paths`: Iterator of include directory paths, each relative to the
+    ///   crate root or absolute.
     pub fn add_private_includes<I, P>(&mut self, paths: I)
     where
         I: IntoIterator<Item = P>,
@@ -209,22 +223,26 @@ impl CLibrary {
 
     /// Adds a public include directory.
     ///
-    /// Public include directories are visible to downstream crates that use this library.
+    /// Public include directories are visible to downstream crates that use
+    /// this library.
     ///
     /// # Parameters
     ///
-    /// - `path`: Path to the public include directory, relative to the crate root or absolute.
+    /// - `path`: Path to the public include directory, relative to the crate
+    ///   root or absolute.
     pub fn add_include(&mut self, path: impl AsRef<Path>) {
         self.public_attrs.add_include(path);
     }
 
     /// Adds multiple public include directories.
     ///
-    /// Public include directories are visible to downstream crates that use this library.
+    /// Public include directories are visible to downstream crates that use
+    /// this library.
     ///
     /// # Parameters
     ///
-    /// - `paths`: Iterator of public include directory paths, each relative to the crate root or absolute.
+    /// - `paths`: Iterator of public include directory paths, each relative to
+    ///   the crate root or absolute.
     pub fn add_includes<I, P>(&mut self, paths: I)
     where
         I: IntoIterator<Item = P>,
@@ -240,7 +258,8 @@ impl CLibrary {
     /// # Parameters
     ///
     /// - `name`: The name of the define (do not include `-D` or `=`).
-    /// - `value`: Optional value for the define. If `None`, treated as `-DNAME`.
+    /// - `value`: Optional value for the define. If `None`, treated as
+    ///   `-DNAME`.
     pub fn add_private_define(&mut self, name: &str, value: Option<&str>) {
         self.private_attrs.add_define(name, value);
     }
@@ -249,7 +268,8 @@ impl CLibrary {
     ///
     /// # Parameters
     ///
-    /// - `defines`: Iterator of (name, optional value) tuples. Names must not include `-D` or `=`.
+    /// - `defines`: Iterator of (name, optional value) tuples. Names must not
+    ///   include `-D` or `=`.
     pub fn add_private_defines<I, N, V>(&mut self, defines: I)
     where
         I: IntoIterator<Item = (N, Option<V>)>,
@@ -268,7 +288,8 @@ impl CLibrary {
     /// # Parameters
     ///
     /// - `name`: The name of the define (do not include `-D` or `=`).
-    /// - `value`: Optional value for the define. If `None`, treated as `-DNAME`.
+    /// - `value`: Optional value for the define. If `None`, treated as
+    ///   `-DNAME`.
     pub fn add_define(&mut self, name: &str, value: Option<&str>) {
         self.public_attrs.add_define(name, value);
     }
@@ -279,7 +300,8 @@ impl CLibrary {
     ///
     /// # Parameters
     ///
-    /// - `defines`: Iterator of (name, optional value) tuples. Names must not include `-D` or `=`.
+    /// - `defines`: Iterator of (name, optional value) tuples. Names must not
+    ///   include `-D` or `=`.
     pub fn add_defines<I, N, V>(&mut self, defines: I)
     where
         I: IntoIterator<Item = (N, Option<V>)>,
@@ -293,7 +315,8 @@ impl CLibrary {
 
     /// Adds a compile flag private to the library.
     ///
-    /// Private compile flags are not visible to downstream crates. Not for linker flags.
+    /// Private compile flags are not visible to downstream crates. Not for
+    /// linker flags.
     ///
     /// # Parameters
     ///
@@ -304,7 +327,8 @@ impl CLibrary {
 
     /// Adds multiple compile flags private to the library.
     ///
-    /// Private compile flags are not visible to downstream crates. Not for linker flags.
+    /// Private compile flags are not visible to downstream crates. Not for
+    /// linker flags.
     ///
     /// # Parameters
     ///
@@ -347,12 +371,14 @@ impl CLibrary {
         }
     }
 
-    /// Returns the merged compile attributes for the library, combining both private and public attributes.
+    /// Returns the merged compile attributes for the library, combining both
+    /// private and public attributes.
     pub fn get_merged_attrs(&self) -> CompileAttrs {
         self.private_attrs.clone().merge(&self.public_attrs)
     }
 
-    /// Returns the public compile attributes for the library, which are visible to downstream crates that use this library.
+    /// Returns the public compile attributes for the library, which are visible
+    /// to downstream crates that use this library.
     pub fn get_public_attrs(&self) -> &CompileAttrs {
         &self.public_attrs
     }
@@ -362,7 +388,8 @@ impl CLibrary {
     /// # Parameters
     ///
     /// - `library_name`: The name of the external library to import.
-    /// - `make_public`: If `true`, include paths are treated as public (visible to downstream crates); otherwise, they are private.
+    /// - `make_public`: If `true`, include paths are treated as public (visible
+    ///   to downstream crates); otherwise, they are private.
     ///
     /// # Errors
     ///
@@ -392,8 +419,8 @@ impl CLibrary {
 
     /// Adds an external library to the list of dependencies for this library.
     ///
-    /// This function is used internally to track external libraries that must be
-    /// linked when building the final binary.
+    /// This function is used internally to track external libraries that must
+    /// be linked when building the final binary.
     ///
     /// # Parameters
     ///
@@ -404,10 +431,11 @@ impl CLibrary {
         }
     }
 
-    /// Returns an iterator over the external libraries that this library depends on,
-    /// which must be linked when using this library.
+    /// Returns an iterator over the external libraries that this library
+    /// depends on, which must be linked when using this library.
     ///
-    /// This includes both libraries added directly to this library and libraries imported from other crates.
+    /// This includes both libraries added directly to this library and
+    /// libraries imported from other crates.
     ///
     /// # Returns
     ///
@@ -418,7 +446,8 @@ impl CLibrary {
 
     /// Adds a library to the list of dependencies for this library.
     ///
-    /// This function is used internally to track libraries that must be linked when using this library.
+    /// This function is used internally to track libraries that must be linked
+    /// when using this library.
     ///
     /// # Parameters
     ///
@@ -429,9 +458,11 @@ impl CLibrary {
         }
     }
 
-    /// Returns an iterator over the libraries that this library depends on, which must be linked when using this library.
+    /// Returns an iterator over the libraries that this library depends on,
+    /// which must be linked when using this library.
     ///
-    /// This includes both libraries added directly to this library and libraries imported from other crates.
+    /// This includes both libraries added directly to this library and
+    /// libraries imported from other crates.
     ///
     /// # Returns
     ///
@@ -442,12 +473,14 @@ impl CLibrary {
 
     /// Imports another C library defined in a different crate.
     ///
-    /// This function automatically imports the public include paths, defines, flags,
-    /// and dependent libraries from the specified crate, making them available to this library.
+    /// This function automatically imports the public include paths, defines,
+    /// flags, and dependent libraries from the specified crate, making them
+    /// available to this library.
     ///
     /// # Parameters
     ///
-    /// - `crate_name`: The name of the crate whose public C library attributes should be imported.
+    /// - `crate_name`: The name of the crate whose public C library attributes
+    ///   should be imported.
     ///
     /// If the crate has already been imported, this function does nothing.
     pub fn import_lib(&mut self, lib_name: &str) -> Result<()> {

--- a/core/embed/xbuild/src/clibrary/rust_bindings.rs
+++ b/core/embed/xbuild/src/clibrary/rust_bindings.rs
@@ -1,8 +1,8 @@
 use bindgen;
-use color_eyre::{Result, eyre::WrapErr};
+use color_eyre::Result;
+use color_eyre::eyre::WrapErr;
 
 use super::CLibrary;
-
 use crate::helpers::{links_name, path_from_env};
 
 impl CLibrary {
@@ -44,8 +44,8 @@ impl CLibrary {
                 .use_core()
                 .ctypes_prefix("cty")
                 .size_t_is_usize(true)
-                // Disable the layout tests. They spew out a lot of code-style bindings, and are not too
-                // relevant for our use-case.
+                // Disable the layout tests. They spew out a lot of code-style bindings, and are not
+                // too relevant for our use-case.
                 .layout_tests(false)
                 // Tell cargo to invalidate the built crate whenever any of the
                 // included header files change.

--- a/core/embed/xbuild/src/dep_tracking.rs
+++ b/core/embed/xbuild/src/dep_tracking.rs
@@ -1,17 +1,14 @@
-use std::{
-    fs,
-    path::{Path, PathBuf},
-    time::SystemTime,
-};
+use std::fs;
+use std::path::{Path, PathBuf};
+use std::time::SystemTime;
 
-use color_eyre::{
-    Result,
-    eyre::{WrapErr, ensure},
-};
+use color_eyre::Result;
+use color_eyre::eyre::{WrapErr, ensure};
 
 use crate::helpers::{delete_file_if_exists, emit_rerun_if_changed, ensure_parent_directory};
 
-/// Runs a command with dependency tracking and optional C compiler dependency file support.
+/// Runs a command with dependency tracking and optional C compiler dependency
+/// file support.
 ///
 /// Executes the command if any input is newer than any output, any output is
 /// missing, or the command arguments have changed (tracked via a .dep file).
@@ -26,7 +23,8 @@ use crate::helpers::{delete_file_if_exists, emit_rerun_if_changed, ensure_parent
 /// * `outputs` - Output files to check for existence and modification time.
 ///
 /// # Returns
-/// * `Result<()>` - Ok if the command was run or skipped successfully, Err otherwise.
+/// * `Result<()>` - Ok if the command was run or skipped successfully, Err
+///   otherwise.
 pub fn run_command<I, O, In, Out>(
     cmd: &mut std::process::Command,
     inputs: In,
@@ -41,7 +39,8 @@ where
     run_command_with_cc_dep(cmd, inputs, outputs, None)
 }
 
-/// Runs a command with dependency tracking and optional C compiler dependency file support.
+/// Runs a command with dependency tracking and optional C compiler dependency
+/// file support.
 ///
 /// Executes the command if any input is newer than any output, any output is
 /// missing, or the command arguments have changed (tracked via a .dep file).
@@ -61,7 +60,8 @@ where
 /// * `cc_dep` - Optional path to a C compiler dependency file.
 ///
 /// # Returns
-/// * `Result<()>` - Ok if the command was run or skipped successfully, Err otherwise.
+/// * `Result<()>` - Ok if the command was run or skipped successfully, Err
+///   otherwise.
 pub fn run_command_with_cc_dep<I, O, In, Out>(
     cmd: &mut std::process::Command,
     inputs: In,
@@ -111,7 +111,8 @@ where
 /// * `output` - Output file to check for existence and modification time.
 ///
 /// # Returns
-/// * `Result<()>` - Ok if the command was run or skipped successfully, Err otherwise.
+/// * `Result<()>` - Ok if the command was run or skipped successfully, Err
+///   otherwise.
 pub fn run_command_to_file<I, O, In>(
     cmd: &mut std::process::Command,
     inputs: In,
@@ -156,7 +157,8 @@ where
 
 /// Checks if any of the input files are newer than any of the output files.
 ///
-/// Returns true if any input file is newer than the oldest output file, or if any output is missing.
+/// Returns true if any input file is newer than the oldest output file, or if
+/// any output is missing.
 ///
 /// # Arguments
 /// * `inputs` - Slice of input file paths.
@@ -252,13 +254,15 @@ fn cc_dep_paths(cc_dep: &str) -> impl Iterator<Item = &str> {
 
 /// Runs a function with dependency tracking.
 ///
-/// Executes the function if any input is newer than any output, any output is missing,
-/// or the command arguments have changed (tracked via a `.dep` file). The `.dep` file,
-/// named after the first output with a `.dep` extension (e.g., `build/main.o.dep`), records
-/// arguments and dependencies and is updated on each run.
+/// Executes the function if any input is newer than any output, any output is
+/// missing, or the command arguments have changed (tracked via a `.dep` file).
+/// The `.dep` file, named after the first output with a `.dep` extension (e.g.,
+/// `build/main.o.dep`), records arguments and dependencies and is updated on
+/// each run.
 ///
-/// If `cc_dep` is given, it should be a dependency file (e.g., `.d` from a C compiler);
-/// if missing or if any of its dependencies are newer than the outputs, the function is re-run.
+/// If `cc_dep` is given, it should be a dependency file (e.g., `.d` from a C
+/// compiler); if missing or if any of its dependencies are newer than the
+/// outputs, the function is re-run.
 pub fn run_if_changed<I, O, In, Out, F>(
     inputs: In,
     outputs: Out,

--- a/core/embed/xbuild/src/helpers.rs
+++ b/core/embed/xbuild/src/helpers.rs
@@ -1,16 +1,10 @@
-use std::{
-    env,
-    ffi::OsStr,
-    fs,
-    path::{Component, Path, PathBuf},
-};
+use std::ffi::OsStr;
+use std::path::{Component, Path, PathBuf};
+use std::{env, fs};
 
+use color_eyre::Result;
+use color_eyre::eyre::{WrapErr, eyre};
 use pathdiff::diff_paths;
-
-use color_eyre::{
-    Result,
-    eyre::{WrapErr, eyre},
-};
 
 /// Checks if the parent directory of the given output path exists,
 /// and creates it if it doesn't.
@@ -33,9 +27,11 @@ pub fn delete_file_if_exists(path: impl AsRef<Path>) -> Result<()> {
     Ok(())
 }
 
-/// Returns the library name from the `CARGO_MANIFEST_LINKS` environment variable.
+/// Returns the library name from the `CARGO_MANIFEST_LINKS` environment
+/// variable.
 ///
-/// This variable is set by Cargo when building a crate that has a `links` field in its `Cargo.toml`.
+/// This variable is set by Cargo when building a crate that has a `links` field
+/// in its `Cargo.toml`.
 ///
 /// # Errors
 ///
@@ -44,7 +40,8 @@ pub fn links_name() -> Result<String> {
     env::var("CARGO_MANIFEST_LINKS").context("Failed to get CARGO_MANIFEST_LINKS")
 }
 
-/// Reads a `DEP_<CRATE>_PUBLIC_C_<KEY>` metadata variable exported by a dependency's build script.
+/// Reads a `DEP_<CRATE>_PUBLIC_C_<KEY>` metadata variable exported by a
+/// dependency's build script.
 pub fn library_metadata(lib_name: &str, kind: &str) -> Result<String> {
     std::env::var(format!("DEP_{}_PUBLIC_C_{}", lib_name.to_uppercase(), kind)).context(format!(
         "Failed to get public C metadata for crate `{lib_name}` and kind `{kind}`"
@@ -115,7 +112,8 @@ fn starts_with_parent(path: &Path) -> bool {
     matches!(path.components().next(), Some(Component::ParentDir))
 }
 
-/// Makes an output path for a source file, placing it under `out_dir` and changing the extension.
+/// Makes an output path for a source file, placing it under `out_dir` and
+/// changing the extension.
 pub fn derive_output_path(base_dir: &Path, src: &Path, out_dir: &Path, extension: &str) -> PathBuf {
     // If `src` is absolute or starts with `..`, treat it as out-of-tree and
     // place it under `OUT_DIR/__oot/...`.

--- a/core/embed/xbuild/src/input_files.rs
+++ b/core/embed/xbuild/src/input_files.rs
@@ -1,10 +1,8 @@
-use std::{
-    fs,
-    path::{Path, PathBuf},
-};
+use std::fs;
+use std::path::{Path, PathBuf};
 
-use color_eyre::{Result, eyre::WrapErr};
-
+use color_eyre::Result;
+use color_eyre::eyre::WrapErr;
 use globset::Glob;
 
 /// Helper struct for managing input files based on glob-like filters.
@@ -61,7 +59,8 @@ impl InputFiles {
         Ok(())
     }
 
-    /// Removes files matching the given filter under the specified base directory.
+    /// Removes files matching the given filter under the specified base
+    /// directory.
     pub fn remove(&mut self, base: impl AsRef<Path>, filter: &str) {
         let base = base.as_ref();
         let normalized_filter = filter.trim_start_matches('/');
@@ -182,8 +181,9 @@ fn filter_search_dirs(base: &Path, filter: &str) -> Result<Vec<PathBuf>> {
 
 #[cfg(test)]
 mod tests {
-    use super::InputFiles;
     use std::path::PathBuf;
+
+    use super::InputFiles;
 
     #[test]
     fn remove_files_removes_only_matching_files_under_base() {

--- a/core/embed/xbuild/src/lib.rs
+++ b/core/embed/xbuild/src/lib.rs
@@ -9,37 +9,21 @@ mod trezor;
 pub use attrs::CompileAttrs;
 pub use clibrary::CLibrary;
 pub use clibrary::compile::OutputType;
-pub use input_files::InputFiles;
-
-pub use dep_tracking::format_command_error;
-pub use dep_tracking::needs_rebuild;
-pub use dep_tracking::run_command;
-pub use dep_tracking::run_command_to_file;
-pub use dep_tracking::run_if_changed;
-
-pub use helpers::cargo_target_dir;
-pub use helpers::derive_output_path;
-pub use helpers::emit_rerun_if_changed;
-pub use helpers::is_rust_analyzer;
-
-pub use parallel::optimal_parallel_job_count;
-pub use parallel::run_parallel;
-
-pub use trezor::build;
-pub use trezor::build_and_link;
-pub use trezor::current_model_id;
-pub use trezor::model_ids;
-pub use trezor::vendor_header_path;
-
 // Re-exports from color_eyre
 pub use color_eyre::Result;
-pub use color_eyre::eyre::WrapErr;
-pub use color_eyre::eyre::bail;
-pub use color_eyre::eyre::ensure;
+pub use color_eyre::eyre::{WrapErr, bail, ensure};
+pub use dep_tracking::{
+    format_command_error, needs_rebuild, run_command, run_command_to_file, run_if_changed,
+};
+pub use helpers::{cargo_target_dir, derive_output_path, emit_rerun_if_changed, is_rust_analyzer};
+pub use input_files::InputFiles;
+pub use parallel::{optimal_parallel_job_count, run_parallel};
+pub use trezor::{build, build_and_link, current_model_id, model_ids, vendor_header_path};
 
 /// Return early with an error.
 ///
-/// This macro is equivalent to `return Err(eyre!("Unsupported Configuration"))`.
+/// This macro is equivalent to `return Err(eyre!("Unsupported
+/// Configuration"))`.
 ///
 /// Use in situations where the current configuration or any combination
 /// of features is not supported and the code cannot proceed.

--- a/core/embed/xbuild/src/parallel.rs
+++ b/core/embed/xbuild/src/parallel.rs
@@ -1,8 +1,5 @@
-use std::{
-    env,
-    sync::{Arc, Mutex, mpsc},
-    thread,
-};
+use std::sync::{Arc, Mutex, mpsc};
+use std::{env, thread};
 
 use color_eyre::Result;
 

--- a/core/embed/xbuild/src/trezor.rs
+++ b/core/embed/xbuild/src/trezor.rs
@@ -5,15 +5,11 @@
 //! selection, and the top-level `build_and_link()` entry point that ties
 //! them together.
 
-use std::{
-    env, fs,
-    path::{Path, PathBuf},
-};
+use std::path::{Path, PathBuf};
+use std::{env, fs};
 
-use color_eyre::{
-    Result,
-    eyre::{WrapErr, bail},
-};
+use color_eyre::Result;
+use color_eyre::eyre::{WrapErr, bail};
 
 use crate::CLibrary;
 use crate::helpers::{is_rust_analyzer, links_name};
@@ -39,7 +35,8 @@ pub fn current_model_id() -> Result<String> {
 
 /// Returns the sorted list of model ids found in `models_dir` — the names of
 /// subdirectories that contain a `model.toml`. Emits `rerun-if-changed` for the
-/// directory and each `model.toml` so callers rebuild when the model set changes.
+/// directory and each `model.toml` so callers rebuild when the model set
+/// changes.
 pub fn model_ids(models_dir: &Path) -> Result<Vec<String>> {
     println!("cargo::rerun-if-changed={}", models_dir.display());
     let mut models = Vec::new();

--- a/core/embed/xtask/src/args.rs
+++ b/core/embed/xtask/src/args.rs
@@ -1,6 +1,7 @@
+use std::process;
+
 use anyhow::{Result, anyhow};
 use clap::{Args, Parser, Subcommand, ValueEnum};
-use std::process;
 
 pub use crate::model::Model;
 
@@ -230,8 +231,10 @@ pub struct BuildArgs {
     #[arg(long)]
     pub log_stack_usage: bool,
 
-    /// Use blocking VCP writes, in order to allow reliable debug data transmission over VCP.
-    /// Disabled by default, to prevent debug firmware from getting stuck while writing log messages (if the host is not reading them).
+    /// Use blocking VCP writes, in order to allow reliable debug data
+    /// transmission over VCP. Disabled by default, to prevent debug
+    /// firmware from getting stuck while writing log messages (if the host
+    /// is not reading them).
     #[arg(long)]
     pub block_on_vcp: bool,
 

--- a/core/embed/xtask/src/artifacts.rs
+++ b/core/embed/xtask/src/artifacts.rs
@@ -1,11 +1,11 @@
-use anyhow::{Context, Result};
-use std::{
-    fs,
-    os::unix,
-    path::{Path, PathBuf},
-};
+use std::fs;
+use std::os::unix;
+use std::path::{Path, PathBuf};
 
-use crate::{args::BuildArgs, helpers};
+use anyhow::{Context, Result};
+
+use crate::args::BuildArgs;
+use crate::helpers;
 
 /// Returns whether a filesystem entry exists without following symlinks, so
 /// broken symlinks are still treated as present and can be replaced.

--- a/core/embed/xtask/src/cargo.rs
+++ b/core/embed/xtask/src/cargo.rs
@@ -1,11 +1,10 @@
-use anyhow::{Context, Result, ensure};
-use owo_colors::OwoColorize;
 use std::process;
 
-use crate::{
-    args::{BuildArgs, Project, TestArgs},
-    artifacts, helpers, memusage, postbuild, prebuild,
-};
+use anyhow::{Context, Result, ensure};
+use owo_colors::OwoColorize;
+
+use crate::args::{BuildArgs, Project, TestArgs};
+use crate::{artifacts, helpers, memusage, postbuild, prebuild};
 
 pub fn build(args: BuildArgs) -> Result<()> {
     build_impl(args.clone(), false)?;

--- a/core/embed/xtask/src/combine.rs
+++ b/core/embed/xtask/src/combine.rs
@@ -1,10 +1,9 @@
-use anyhow::{Context, Result, ensure};
 use std::fs;
 
-use crate::{
-    args::{CombineArgs, Model, Project},
-    helpers, postbuild,
-};
+use anyhow::{Context, Result, ensure};
+
+use crate::args::{CombineArgs, Model, Project};
+use crate::{helpers, postbuild};
 
 const COMBINED_PREFIX: &str = "combined-";
 

--- a/core/embed/xtask/src/config.rs
+++ b/core/embed/xtask/src/config.rs
@@ -1,6 +1,7 @@
+use std::collections::{HashMap, HashSet};
+
 use anyhow::{Context, Result, anyhow, bail};
 use serde::Deserialize;
-use std::collections::{HashMap, HashSet};
 
 use crate::args::Project;
 use crate::helpers::workspace_dir;

--- a/core/embed/xtask/src/feature_resolver.rs
+++ b/core/embed/xtask/src/feature_resolver.rs
@@ -1,10 +1,9 @@
-use anyhow::{Result, bail};
 use std::process;
 
-use crate::{
-    args::{BuildArgs, ConsoleType, Project, ResolvedBuild},
-    config, helpers,
-};
+use anyhow::{Result, bail};
+
+use crate::args::{BuildArgs, ConsoleType, Project, ResolvedBuild};
+use crate::{config, helpers};
 
 /// Resolves cargo features and target triple from the provided CLI arguments.
 pub fn resolve_features(args: &BuildArgs) -> Result<ResolvedBuild> {
@@ -203,8 +202,9 @@ pub fn configure_cargo(args: &BuildArgs, cmd: &mut process::Command) -> Result<(
         // - https://blog.japaric.io/stack-analysis/
         // - https://github.com/japaric/stack-sizes/
         //
-        // Use --config instead of RUSTFLAGS env so that rustflags in .cargo/config.toml are
-        // not overridden (RUSTFLAGS env has higher precedence and replaces them entirely).
+        // Use --config instead of RUSTFLAGS env so that rustflags in .cargo/config.toml
+        // are not overridden (RUSTFLAGS env has higher precedence and replaces
+        // them entirely).
         cmd.args([
             "--config",
             "build.rustflags=[\"-Zprint-type-sizes\", \"-Zemit-stack-sizes\"]",
@@ -214,11 +214,12 @@ pub fn configure_cargo(args: &BuildArgs, cmd: &mut process::Command) -> Result<(
     if args.emulator && args.asan {
         // -Zsanitizer=address is a rustc flag passed via RUSTFLAGS.
         //
-        // Without an explicit --target, cargo compiles proc-macros and the firmware in the
-        // same pass and RUSTFLAGS leaks into proc-macro crates, causing "can't find crate"
-        // errors. Passing --target explicitly (even the same triple as the host) makes cargo
-        // separate the host (proc-macros / build scripts) and target (firmware) compilation
-        // units, so RUSTFLAGS only reaches the firmware crates.
+        // Without an explicit --target, cargo compiles proc-macros and the firmware in
+        // the same pass and RUSTFLAGS leaks into proc-macro crates, causing
+        // "can't find crate" errors. Passing --target explicitly (even the same
+        // triple as the host) makes cargo separate the host (proc-macros /
+        // build scripts) and target (firmware) compilation units, so RUSTFLAGS
+        // only reaches the firmware crates.
         cmd.args(["--target", &helpers::host_triple()?]);
         cmd.args([
             "--config",

--- a/core/embed/xtask/src/flash.rs
+++ b/core/embed/xtask/src/flash.rs
@@ -1,13 +1,10 @@
-use anyhow::{Context, Result, ensure};
-use std::{
-    fs,
-    {path::Path, process},
-};
+use std::path::Path;
+use std::{fs, process};
 
-use crate::{
-    args::{FlashArgs, FlashEraseArgs, FlashSection, Model, ResetArgs},
-    helpers,
-};
+use anyhow::{Context, Result, ensure};
+
+use crate::args::{FlashArgs, FlashEraseArgs, FlashSection, Model, ResetArgs};
+use crate::helpers;
 
 /// Flashes the specified project to the device using OpenOCD.
 pub fn flash(args: FlashArgs) -> Result<()> {
@@ -39,8 +36,8 @@ pub fn flash(args: FlashArgs) -> Result<()> {
     run_openocd(args.model, &flash_instruction)
 }
 
-/// Erase specified flash section using OpenOCD. The section boundaries are determined
-/// by reading symbols from the model's memory.ld file.
+/// Erase specified flash section using OpenOCD. The section boundaries are
+/// determined by reading symbols from the model's memory.ld file.
 pub fn flash_erase(args: FlashEraseArgs) -> Result<()> {
     let mem_ld = args.model.model_memory_ld()?;
     let content = fs::read_to_string(&mem_ld)
@@ -121,9 +118,10 @@ fn build_flash_erase_instruction(content: &str, section: FlashSection) -> Result
 
 #[cfg(test)]
 mod tests {
+    use std::path::Path;
+
     use super::{build_flash_erase_instruction, build_flash_write_instruction};
     use crate::args::FlashSection;
-    use std::path::Path;
 
     #[test]
     fn builds_flash_write_instruction() {

--- a/core/embed/xtask/src/helpers.rs
+++ b/core/embed/xtask/src/helpers.rs
@@ -1,9 +1,8 @@
+use std::path::{Path, PathBuf};
+use std::{env, fs};
+
 use anyhow::{Context, Result, anyhow};
 use cargo_metadata::MetadataCommand;
-use std::{
-    env, fs,
-    path::{Path, PathBuf},
-};
 
 use crate::args::{BuildArgs, Model, Project};
 
@@ -13,7 +12,8 @@ pub fn elf_path(args: &BuildArgs) -> Result<PathBuf> {
     Ok(profile_dir(args)?.join(elf_name))
 }
 
-/// Returns the profile output directory (e.g. `build/thumbv7em-none-eabihf/release`).
+/// Returns the profile output directory (e.g.
+/// `build/thumbv7em-none-eabihf/release`).
 pub fn profile_dir(args: &BuildArgs) -> Result<PathBuf> {
     let mut path = build_dir()?;
     if !args.emulator {
@@ -59,7 +59,8 @@ pub fn publish_dir() -> Result<PathBuf> {
     Ok(build_dir()?.join("artifacts").join("pub"))
 }
 
-/// Returns the host target triple (e.g. `x86_64-unknown-linux-gnu`) by querying `rustc -vV`.
+/// Returns the host target triple (e.g. `x86_64-unknown-linux-gnu`) by querying
+/// `rustc -vV`.
 pub fn host_triple() -> Result<String> {
     let output = std::process::Command::new("rustc")
         .args(["-vV"])
@@ -117,7 +118,8 @@ pub fn git_modified() -> Result<bool> {
     Ok(modified)
 }
 
-/// Parses a version file and returns the version string in the format "major.minor.patch".
+/// Parses a version file and returns the version string in the format
+/// "major.minor.patch".
 pub fn parse_version_file(file_name: &Path) -> Result<String> {
     let content = std::fs::read_to_string(file_name)
         .with_context(|| format!("Failed to read version file: {}", file_name.display()))?;
@@ -187,8 +189,9 @@ pub fn get_version_file(project: Project) -> Result<PathBuf> {
 
 #[cfg(test)]
 mod tests {
-    use super::{parse_address, parse_version_file, read_symbol_from_content};
     use std::fs;
+
+    use super::{parse_address, parse_version_file, read_symbol_from_content};
 
     #[test]
     fn parses_version_file_symbols() {

--- a/core/embed/xtask/src/main.rs
+++ b/core/embed/xtask/src/main.rs
@@ -1,10 +1,7 @@
 use anyhow::Result;
 use clap::Parser;
-
-use xtask::{
-    args::{Cli, Cmd},
-    cargo, combine, flash, upload,
-};
+use xtask::args::{Cli, Cmd};
+use xtask::{cargo, combine, flash, upload};
 
 fn main() -> Result<()> {
     let cli = Cli::parse();

--- a/core/embed/xtask/src/memusage.rs
+++ b/core/embed/xtask/src/memusage.rs
@@ -1,5 +1,8 @@
+use std::fs;
+use std::ops::Range;
+use std::path::Path;
+
 use anyhow::{Context, Result, bail};
-use std::{fs, ops::Range, path::Path};
 
 #[derive(Debug, Clone)]
 struct MemoryRegion {

--- a/core/embed/xtask/src/postbuild.rs
+++ b/core/embed/xtask/src/postbuild.rs
@@ -1,20 +1,16 @@
+use std::path::{Path, PathBuf};
+use std::{fs, process};
+
 use anyhow::{Context, Result, ensure};
-use std::{
-    fs,
-    path::{Path, PathBuf},
-    process,
-};
 
-use crate::{
-    args::Project,
-    config::{ModelConfig, ProjectProfile},
-    helpers,
-    model::Model,
-};
+use crate::args::Project;
+use crate::config::{ModelConfig, ProjectProfile};
+use crate::helpers;
+use crate::model::Model;
 
-/// Extracts appropriate sections from the ELF file and creates a raw unsigned binary.
-/// Section lists are read from the project's `project.toml`; model-specific split
-/// behaviour is controlled by `model_config`.
+/// Extracts appropriate sections from the ELF file and creates a raw unsigned
+/// binary. Section lists are read from the project's `project.toml`;
+/// model-specific split behaviour is controlled by `model_config`.
 pub fn elf_to_bin(
     source: &Path,
     project: Project,
@@ -128,8 +124,9 @@ pub fn sign_binary(
     Ok(())
 }
 
-/// Extracts specified sections from an ELF file into a raw binary using objcopy.
-/// The output file is created in the same directory as the input with the same name but .bin extension.
+/// Extracts specified sections from an ELF file into a raw binary using
+/// objcopy. The output file is created in the same directory as the input with
+/// the same name but .bin extension.
 fn objcopy<S, I>(input: &Path, sections: I) -> Result<PathBuf>
 where
     S: AsRef<str>,
@@ -308,9 +305,11 @@ pub fn publish_artifact(
 
 #[cfg(test)]
 mod tests {
-    use super::merge_compile_commands;
-    use serde_json::Value;
     use std::fs;
+
+    use serde_json::Value;
+
+    use super::merge_compile_commands;
 
     #[test]
     fn merge_compile_commands_prefers_first_input_for_duplicates() {

--- a/core/embed/xtask/src/prebuild.rs
+++ b/core/embed/xtask/src/prebuild.rs
@@ -1,5 +1,6 @@
-use anyhow::{Context, Result, ensure};
 use std::process;
+
+use anyhow::{Context, Result, ensure};
 
 use crate::helpers;
 

--- a/core/embed/xtask/src/upload.rs
+++ b/core/embed/xtask/src/upload.rs
@@ -1,7 +1,9 @@
-use anyhow::{Context, Result, ensure};
 use std::process;
 
-use crate::{args::UploadArgs, helpers};
+use anyhow::{Context, Result, ensure};
+
+use crate::args::UploadArgs;
+use crate::helpers;
 
 pub fn upload(args: UploadArgs) -> Result<()> {
     ensure!(


### PR DESCRIPTION
move rustfmt.toml one level up to cover all of core's rust, not just trezor_lib

uniform grouping of use statements:
* group_imports = "StdExternalCrate" to get std imports first, then 3rd party, then crate local (like isort already does in python)
* reorder_imports = true to enforce alphabetical sorting
* imports_granularity = "Module" to put every module on one line, instead of (the default) compressing with braces

this also means wrap_comments=true now applies in places it didn't before, so some line noise about that

there aren't supposed to be any functional changes in this PR

<!--
For external contributors:
- Please open an issue before submitting a PR so we can discuss whether we want to proceed with it.

For core developers:
1. Initial PR setup
- Assign yourself to the PR.
- Add it to the "Firmware" project
  - Set Priority (match issue priority if it exists)
  - Set Team
  - Set Sprint (target release)

2. Development status
- Draft PRs: Set status to "In Progress"
- Final PRs: Set status to "Needs Review"

3. Post-merge status
- Testable: Set status to "Needs QA" and add a `Notes for QA` section with clear instructions on how to test the functionality.
- Not Testable: Set status to "Done (no QA)"
-->
