### PR TITLE
feat(core/eckhart): change connection indicator

### DIFF
--- a/core/embed/rust/src/ui/layout_eckhart/cshape/connected.rs
+++ b/core/embed/rust/src/ui/layout_eckhart/cshape/connected.rs
@@ -1,28 +1,15 @@
 use super::super::theme;
 use crate::ui::display::Color;
-use crate::ui::geometry::{Offset, Point, Rect};
+use crate::ui::geometry::Point;
 use crate::ui::shape::{self, Renderer};
 
 // outer circle
 pub const INDICATOR_OUTER_RADIUS: i16 = 10;
 const INDICATOR_OUTER_COLOR: Color = theme::GREEN_BRIGHT;
 
-// inner rectangle
-const INDICATOR_INNER_SIZE: i16 = 9;
-const INDICATOR_INNER_COLOR: Color = theme::GREEN;
-
 pub fn render_connected_indicator<'s>(point: Point, target: &mut impl Renderer<'s>) {
     shape::Circle::new(point, INDICATOR_OUTER_RADIUS)
         .with_fg(INDICATOR_OUTER_COLOR)
         .with_bg(INDICATOR_OUTER_COLOR)
         .render(target);
-
-    const HALF: i16 = INDICATOR_INNER_SIZE / 2;
-    let inner_top_left = Point::new(point.x - HALF, point.y - HALF);
-    shape::Bar::new(Rect::from_top_left_and_size(
-        inner_top_left,
-        Offset::uniform(INDICATOR_INNER_SIZE),
-    ))
-    .with_bg(INDICATOR_INNER_COLOR)
-    .render(target);
 }


### PR DESCRIPTION
- based on the feedback, do not draw the inner rectangle of the connection indicator

[no changelog]

<img width="844" height="577" alt="image" src="https://github.com/user-attachments/assets/8b43319e-c3ab-4a51-ab3b-9755ef46ded1" />

<!--
For external contributors:
- Please open an issue before submitting a PR so we can discuss whether we want to proceed with it.

For core developers:
1. Initial PR setup
- Assign yourself to the PR.
- Add it to the "Firmware" project
  - Set Priority (match issue priority if it exists)
  - Set Team
  - Set Sprint (target release)

2. Development status
- Draft PRs: Set status to "In Progress"
- Final PRs: Set status to "Needs Review"

3. Post-merge status
- Testable: Set status to "Needs QA" and add a `Notes for QA` section with clear instructions on how to test the functionality.
- Not Testable: Set status to "Done (no QA)"
-->

# Notes for QA
- see the connection indicator changed based on the screenshot above.