### PR TITLE
feat(core/delizia): enable external menus for `confirm_properties()`

### DIFF
--- a/core/embed/rust/src/ui/layout_delizia/ui_firmware.rs
+++ b/core/embed/rust/src/ui/layout_delizia/ui_firmware.rs
@@ -444,13 +444,17 @@ impl FirmwareUI for UIDelizia {
         items: Obj,
         hold: bool,
         _verb: Option<TString<'static>>,
-        _external_menu: bool,
+        external_menu: bool,
     ) -> Result<impl LayoutMaybeTrace, Error> {
         let paragraphs = PropsList::new(items)?;
 
         let flow = flow::new_confirm_action_simple(
             paragraphs.into_paragraphs(),
-            ConfirmActionExtra::Menu(ConfirmActionMenuStrings::new()),
+            if external_menu {
+                ConfirmActionExtra::ExternalMenu
+            } else {
+                ConfirmActionExtra::Menu(ConfirmActionMenuStrings::new())
+            },
             ConfirmActionStrings::new(title, subtitle, None, hold.then_some(title)),
             ConfirmActionOptions::new().with_hold(hold),
         )?;


### PR DESCRIPTION
Currently it is unused.

Needed for https://github.com/trezor/trezor-firmware/issues/6394.