### PR TITLE
Store the packet that caused channel preemption across session restart

### DIFF
--- a/core/src/apps/thp/credential_manager.py
+++ b/core/src/apps/thp/credential_manager.py
@@ -87,7 +87,7 @@ def issue_credential(
 
 def unwrap_credential(encoded_noise_payload: AnyBytes) -> AnyBytes | None:
     expected_type = protobuf.type_for_name("ThpHandshakeCompletionReqNoisePayload")
-    msg = wrap_protobuf_load(encoded_noise_payload, expected_type)
+    msg = wrap_protobuf_load(encoded_noise_payload, expected_type, is_message=False)
     if not ThpHandshakeCompletionReqNoisePayload.is_type_of(msg):
         raise TypeError
     return msg.host_pairing_credential
@@ -100,7 +100,9 @@ def decode_credential(
     Decode a protobuf encoded pairing credential.
     """
     expected_type = protobuf.type_for_name("ThpPairingCredential")
-    credential = wrap_protobuf_load(encoded_pairing_credential_message, expected_type)
+    credential = wrap_protobuf_load(
+        encoded_pairing_credential_message, expected_type, is_message=False
+    )
     if not ThpPairingCredential.is_type_of(credential):
         raise TypeError
     return credential

--- a/core/src/storage/cache_thp.py
+++ b/core/src/storage/cache_thp.py
@@ -243,3 +243,48 @@ def clear_all_except_one_session_keys(excluded: tuple[AnyBytes, AnyBytes]) -> No
             s_last_usage = session.last_usage
             session.clear()
             session.set_int(LAST_USAGE, s_last_usage)
+
+
+# Used to store single packet across loop restart when channel preemption happens.
+class PreemptingPacket:
+    MAX_PACKET_LEN = 244  # maximum packet len across all interface types
+
+    def __init__(self) -> None:
+        self.packet_buffer = bytearray(self.MAX_PACKET_LEN)
+        self.reset()
+
+    def reset(self) -> None:
+        self.iface_num = None
+        self.cid_hint = 0
+        self.packet_len = 0
+
+    def set(self, iface_num: int, cid_hint: int, packet_buffer: AnyBytes) -> bool:
+        """Store packet across session restart.
+
+        cid_hint = channel_id | ((buffer_hint//8) << 16),
+        see InterfaceContext.read_packet_for_channel
+
+        Returns False if a packet is already stored (possibly by other interface).
+        """
+        assert len(packet_buffer) <= self.MAX_PACKET_LEN
+        if self.iface_num is not None:
+            return False
+        self.iface_num = iface_num
+        self.cid_hint = cid_hint
+        self.packet_len = len(packet_buffer)
+        self.packet_buffer[: self.packet_len] = packet_buffer
+        return True
+
+    def get(self, iface_num: int) -> tuple[int, memoryview] | None:
+        """
+        Take the packet if there is one, return None otherwise. The returned
+        memoryview must be processed before `set()` overwrites the contents.
+        """
+        if self.iface_num != iface_num:
+            return None
+        res = (self.cid_hint, memoryview(self.packet_buffer)[: self.packet_len])
+        self.reset()
+        return res
+
+
+PREEMPTING_PACKET = PreemptingPacket()

--- a/core/src/trezor/wire/message_handler.py
+++ b/core/src/trezor/wire/message_handler.py
@@ -25,6 +25,7 @@ EXPERIMENTAL_ENABLED = False
 def wrap_protobuf_load(
     buffer: AnyBytes,
     expected_type: type[LoadedMessageType],
+    is_message: bool = True,
 ) -> LoadedMessageType:
     try:
         if __debug__ and utils.EMULATOR and utils.USE_THP:
@@ -35,17 +36,18 @@ def wrap_protobuf_load(
             )
         msg = protobuf.decode(buffer, expected_type, EXPERIMENTAL_ENABLED)
         if __debug__ and utils.EMULATOR:
-            log.debug(
-                __name__, "received message contents:\n%s", utils.dump_protobuf(msg)
-            )
+            what = "received message contents" if is_message else "decoded protobuf"
+            log.debug(__name__, "%s:\n%s", what, utils.dump_protobuf(msg))
         return msg
     except Exception as e:
+        what = "message" if is_message else "protobuf"
         if __debug__:
             log.exception(__name__, e)
-        if e.args:
-            raise DataError("Failed to decode message: " + " ".join(e.args))
-        else:
-            raise DataError("Failed to decode message")
+            if e.args:
+                raise DataError(
+                    f"Failed to decode {what}: " + " ".join(str(arg) for arg in e.args)
+                )
+        raise DataError(f"Failed to decode {what}")
 
 
 async def handle_single_message(ctx: Context, msg: Message) -> bool:

--- a/core/src/trezor/wire/thp/interface_context.py
+++ b/core/src/trezor/wire/thp/interface_context.py
@@ -2,7 +2,7 @@ from micropython import const
 from typing import TYPE_CHECKING
 
 import trezorthp
-from storage.cache_thp import clear_sessions_without_channel
+from storage.cache_thp import PREEMPTING_PACKET, clear_sessions_without_channel
 from trezor import config, io, loop, utils
 from trezor.loop import race, wait
 
@@ -62,17 +62,32 @@ class ThpContext:
         assert self.active_channel is not None
         return self.active_channel
 
-    def preempt_active_channel_if_stale(self) -> None:
+    def preempt_active_channel_if_stale(
+        self, iface_num: int, cid_hint: int, packet_buffer: AnyBytes
+    ) -> bool:
+        """
+        If the active channel is idle for more than _PREEMPT_TIMEOUT_MS, kill
+        it and save the packet passed as an argument to be processed as if it
+        was received when the next loop session is started.
+
+        Returns True on success, False if the caller should send TRANSPORT_BUSY.
+        """
         if not self.active_channel:
-            return
+            return False
         last_write_ms = self.active_channel.get_last_write()
         if last_write_ms is None or last_write_ms > _PREEMPT_TIMEOUT_MS:
+            self.active_channel.kill(ChannelPreemptedException())
+            saved = PREEMPTING_PACKET.set(iface_num, cid_hint, packet_buffer)
             if __debug__:
                 log.error(
                     __name__,
                     f"Interrupted channel {hex(self.active_channel.channel_id)} after {last_write_ms} ms",
                 )
-            self.active_channel.kill(ChannelPreemptedException())
+                log.debug(
+                    __name__, f"Packet will be processed in next session: {saved}"
+                )
+            return saved
+        return False
 
     async def close(self) -> None:
         for iface_ctx in self._iface_ctxs:
@@ -153,6 +168,12 @@ class InterfaceContext:
         verify_fn = self.verify_credential
         packet_buffer = self._rx_packet_buf
 
+        if (pep := PREEMPTING_PACKET.get(iface_num)) is not None:
+            if __debug__:
+                log.debug(__name__, "got packet from previous session", iface=iface)
+            cid_hint, buf = pep
+            self.read_packet_for_channel(cid_hint, buf)
+
         while True:
             while not self.should_read():
                 if __debug__ and _TRACE:
@@ -177,7 +198,6 @@ class InterfaceContext:
             result = trezorthp.packet_in(iface_num, packet_buffer, verify_fn)
             if isinstance(result, int):
                 self.read_packet_for_channel(result, packet_buffer)
-                self.clear_closed_sessions()
                 continue
 
             if __debug__ and _TRACE and result is not None:
@@ -237,10 +257,13 @@ class InterfaceContext:
                     self.thp_ctx.channel_ready_box.put(None, replace=True)
 
         if self.active_channel is None or self.active_channel.channel_id != channel_id:
-            trezorthp.send_transport_busy(channel_id)
-            self.inactive_channels.add(channel_id)
-            self.request_write()
-            self.thp_ctx.preempt_active_channel_if_stale()
+            preempted = self.thp_ctx.preempt_active_channel_if_stale(
+                self._iface.iface_num(), result, packet_buffer
+            )
+            if not preempted:
+                trezorthp.send_transport_busy(channel_id)
+                self.inactive_channels.add(channel_id)
+                self.request_write()
             return
 
         try:
@@ -250,6 +273,7 @@ class InterfaceContext:
                 log.exception(__name__, exc)
             self.active_channel.kill(exc)
             self.active_channel = None
+        self.clear_closed_sessions()
 
     def write_loop(self) -> Generator[Any, Any, None]:
         """

--- a/docs/common/thp/specification.md
+++ b/docs/common/thp/specification.md
@@ -320,6 +320,8 @@ The primary function of the synchronization layer is to work as the *Alternating
 
 It is possible that some packets are lost by the Data transfer layer (L1). In order to guarantee reliable communication, THP uses the *Alternating Bit Protocol* in combination with a *CRC32* checksum.
 
+Only the following message types take part in the synchronization layer: `handshake_init_request`, `handshake_init_response`, `handshake_completion_request`, `handshake_completion_response`, `encrypted_transport` and `ACK`. Notably `channel_allocation_request`, `channel_allocation_response` and `transport_error` don't carry a sequence number and are not acknowledged.
+
 ### Alternating Bit Protocol
 
 The *Alternating Bit Protocol* (ABP) is a protocol between a sender and a receiver over an unreliable channel. The channel is unreliable in the sense that it can discard or duplicate messages, but it cannot change their order or content. The protocol guarantees the eventual and non-duplicative delivery of messages.
@@ -407,6 +409,12 @@ flowchart LR
     R1 -- in: Message(Seq=1); out: Ack(Seq=1); return Message for processing --> R0
     R1 -- in: Message(Seq=0); out: Ack(Seq=0); discard Message as duplicate --> R1
 ```
+
+#### Encoding
+
+The sequence bit is encoded into the control byte of the applicable messages, mask 0x10 (00010000).
+
+The ACK bit can be similarly accessed using the mask 0x08 (00001000). On messages other than ACK, the ACK number is ignored unless piggybacking is enabled.
 
 ### ACK Message structure
 

--- a/python/src/trezorlib/thp/channel.py
+++ b/python/src/trezorlib/thp/channel.py
@@ -537,7 +537,7 @@ class Channel:
             if message.seq_bit is not None:
                 if message.seq_bit != self.sync_bit_receive:
                     LOG.warning(
-                        "Received unexpected message: sync bit=%d, expected=%d",
+                        "Received unexpected message: seq bit=%d, expected=%d",
                         message.seq_bit,
                         self.sync_bit_receive,
                     )

--- a/rust/trezor-thp/src/channel/mod.rs
+++ b/rust/trezor-thp/src/channel/mod.rs
@@ -409,15 +409,12 @@ impl<R: Role, B: Backend> Channel<R, B> {
             && matches!(self.send_state, SendState::Sending { .. })
         {
             // ACK we sent was lost. Will be retransmitted along current outgoing message.
-            log::debug!("[{:04x}] Bad sync bit, ignoring packet.", self.channel_id);
+            log::debug!("[{:04x}] Bad seq bit, ignoring packet.", self.channel_id);
         } else if !matches!(self.receive_state, ReceiveState::Receiving { .. }) {
             // Might happen when we've sent an ACK and it got lost or delayed.
             // We end up sending reply while the other side is retransmitting.
             // NOTE: no checksum verification because we drop the continuations
-            log::debug!(
-                "[{:04x}] Bad sync bit, resending last ACK.",
-                self.channel_id
-            );
+            log::debug!("[{:04x}] Bad seq bit, resending last ACK.", self.channel_id);
             self.send_ack = Some(SyncBits::new().with_ack_bit(sb.seq_bit()));
         }
         Err(Error::malformed_data())

--- a/tests/device_tests/thp/test_multiple_hosts.py
+++ b/tests/device_tests/thp/test_multiple_hosts.py
@@ -6,6 +6,7 @@ import pytest
 from trezorlib.debuglink import TrezorTestContext
 from trezorlib.thp.channel import Channel
 from trezorlib.thp.exceptions import ThpError, ThpErrorCode
+from trezorlib.thp.pairing import PairingController
 
 from .connect import prepare_channel_for_pairing
 
@@ -102,3 +103,52 @@ def test_concurrent_channels(test_ctx: TrezorTestContext) -> None:
     for channel in channels[1:]:
         test_ctx.channel = channel
         test_ctx.ping("hi2")
+
+
+def _open_channel_no_retries(test_ctx: TrezorTestContext) -> Channel:
+    new_channel = Channel.allocate(test_ctx.transport)
+    new_channel.open(credentials=[])
+    new_channel.BUSY_RETRIES = 0
+    return new_channel
+
+
+def _replace_channel_and_do_pairing(
+    test_ctx: TrezorTestContext, channel: Channel
+) -> None:
+    test_ctx.channel = channel
+    test_ctx.client._interact_ctx = test_ctx.client._interact()
+    test_ctx.client.pairing = PairingController(test_ctx.client)
+    test_ctx.client.pairing.skip()
+    test_ctx.client.pairing.finish()
+
+
+# It's possible for this test to fail if CI is very slow. If this happens
+# we should first try marking it with @pytest.mark.flaky(retries=5)
+def test_preemption_busy(test_ctx: TrezorTestContext) -> None:
+    channel_1 = _open_channel_no_retries(test_ctx)
+    channel_2 = _open_channel_no_retries(test_ctx)
+
+    # GetFeatures is in AVOID_RESTARTING_FOR and keeps channel active
+    test_ctx.refresh_features()
+
+    # hopefully less than _PREEMPT_TIMEOUT_MS passed and we get TRANSPORT_BUSY
+    with pytest.raises(ThpError, match="TRANSPORT_BUSY"):
+        _replace_channel_and_do_pairing(test_ctx, channel_1)
+    # channel_1 is desynced now
+
+    time.sleep(1.1)  # _PREEMPT_TIMEOUT_MS + epsilon
+
+    # initial test_ctx.channel is preempted, no TRANSPORT_BUSY is sent
+    _replace_channel_and_do_pairing(test_ctx, channel_2)
+
+
+def test_preemption_wait(test_ctx: TrezorTestContext) -> None:
+    channel_1 = _open_channel_no_retries(test_ctx)
+
+    # GetFeatures is in AVOID_RESTARTING_FOR and keeps channel active
+    test_ctx.refresh_features()
+
+    time.sleep(1.1)  # _PREEMPT_TIMEOUT_MS + epsilon
+
+    # no TRANSPORT_BUSY after _PREEMPT_TIMEOUT_MS
+    _replace_channel_and_do_pairing(test_ctx, channel_1)


### PR DESCRIPTION
Seems to resolve #7244 with older Suite which doesn't handle `TRANSPORT_BUSY` correctly.

Eats some 256B from the micropython heap space - I suppose on T3W1 we can afford it but perhaps we should drop/change it once we start using THP on some weaker device.

----

More generally this is yet another THP related thing that always takes up memory but is not used very often and we should probably consider storing it on GC heap anchored in `storage.cache` so it's not wiped on session restart:
* (this)
* host static pubkeys to use when deciding if channel should be replaced (`ThpAuxiliaryInfo.host_keys`)
* temporary credential storage for passing from Rust to MicroPython (`ThpAuxiliaryInfo.credentials`)

We'd need to adjust the free heap size checking code on debug builds.

<!--
For external contributors:
- Please open an issue before submitting a PR so we can discuss whether we want to proceed with it.

For core developers:
1. Initial PR setup
- Assign yourself to the PR.
- Add it to the "Firmware" project
  - Set Priority (match issue priority if it exists)
  - Set Team
  - Set Sprint (target release)

2. Development status
- Draft PRs: Set status to "In Progress"
- Final PRs: Set status to "Needs Review"

3. Post-merge status
- Testable: Set status to "Needs QA" and add a `Notes for QA` section with clear instructions on how to test the functionality.
- Not Testable: Set status to "Done (no QA)"
-->
