### PR TITLE
feat(core/eckhart): enable external menus for `confirm_properties()`

### DIFF
--- a/core/embed/rust/src/ui/layout_eckhart/flow/confirm_with_menu.rs
+++ b/core/embed/rust/src/ui/layout_eckhart/flow/confirm_with_menu.rs
@@ -7,6 +7,7 @@ use super::super::firmware::{
 };
 use super::super::theme::gradient::Gradient;
 use super::super::theme::{self};
+use super::util::single_page;
 use crate::error;
 use crate::maybe_trace::MaybeTrace;
 use crate::strutil::TString;
@@ -58,6 +59,7 @@ pub fn new_confirm_with_menu<T: AllowedTextContent + MaybeTrace + 'static>(
     hold: bool,
     extra_menu_label: Option<TString<'static>>,
     cancel_menu_label: Option<TString<'static>>,
+    external_menu: bool,
 ) -> Result<SwipeFlow, error::Error> {
     // Value
     let confirm_button = if hold {
@@ -77,7 +79,9 @@ pub fn new_confirm_with_menu<T: AllowedTextContent + MaybeTrace + 'static>(
     let mut value_screen = TextScreen::new(content)
         .with_header(Header::new(title).with_menu_button())
         .with_action_bar(ActionBar::new_single(confirm_button))
-        .with_subtitle(subtitle.unwrap_or(TString::empty()));
+        .with_subtitle(subtitle.unwrap_or(TString::empty()))
+        .with_external_menu(external_menu);
+
     if let Some(hint) = hint {
         value_screen = value_screen.with_hint(Hint::new_instruction(hint, Some(theme::ICON_INFO)));
     }
@@ -86,7 +90,13 @@ pub fn new_confirm_with_menu<T: AllowedTextContent + MaybeTrace + 'static>(
         TextScreenMsg::Cancelled => Some(FlowMsg::Cancelled),
         TextScreenMsg::Menu => Some(FlowMsg::Info),
     });
-
+    if external_menu {
+        // TODO: will eventually replace the internal menu
+        if extra_menu_label.is_some() || cancel_menu_label.is_some() {
+            return Err(error::Error::NotImplementedError);
+        }
+        return single_page(content_value);
+    }
     // Menu
     let mut menu = VerticalMenu::<ShortMenuVec>::empty();
     let mut menu_items = Vec::<usize, 2>::new();

--- a/core/embed/rust/src/ui/layout_eckhart/ui_firmware.rs
+++ b/core/embed/rust/src/ui/layout_eckhart/ui_firmware.rs
@@ -281,6 +281,7 @@ impl FirmwareUI for UIEckhart {
             false,
             Some(TR::confirm_total__title_fee.into()),
             None,
+            false,
         )?;
         Ok(flow)
     }
@@ -381,7 +382,7 @@ impl FirmwareUI for UIEckhart {
         items: Obj,
         hold: bool,
         verb: Option<TString<'static>>,
-        _external_menu: bool,
+        external_menu: bool,
     ) -> Result<impl LayoutMaybeTrace, Error> {
         let paragraphs = PropsList::new_styled(
             items,
@@ -394,8 +395,17 @@ impl FirmwareUI for UIEckhart {
         .into_paragraphs()
         .with_placement(LinearPlacement::vertical());
 
-        let flow =
-            flow::new_confirm_with_menu(title, None, paragraphs, None, verb, hold, None, None)?;
+        let flow = flow::new_confirm_with_menu(
+            title,
+            None,
+            paragraphs,
+            None,
+            verb,
+            hold,
+            None,
+            None,
+            external_menu,
+        )?;
         Ok(flow)
     }
 
@@ -613,6 +623,7 @@ impl FirmwareUI for UIEckhart {
             false,
             verb_info,
             None,
+            false,
         )?;
         LayoutObj::new_root(flow)
     }


### PR DESCRIPTION
Currently it is unused.

Needed for https://github.com/trezor/trezor-firmware/issues/6394.