### PR TITLE
test(core/ethereum): add EIP-7702 test vectors

### DIFF
--- a/common/tests/fixtures/ethereum/sign_auth_eip7702.json
+++ b/common/tests/fixtures/ethereum/sign_auth_eip7702.json
@@ -1,0 +1,128 @@
+{
+    "setup": {
+        "mnemonic": "all all all all all all all all all all all all",
+        "passphrase": ""
+    },
+    "tests": [
+        {
+            "name": "ambire_nonce_1_chainid_0_all_networks",
+            "skip_models": ["t1", "t2t1"],
+            "parameters": {
+                "path": "m/44'/60'/0'/0/0",
+                "delegate": "0x5A7fC11397E9A8AD41Bf10bF13f22b0A63F96f6D",
+                "nonce": 1,
+                "chain_id": 0
+            },
+            "result": {
+                "sig_v": 0,
+                "sig_r": "cc1dcf73e6451d217031fd4d04fa9392736977b343dc4ac616b171889367e182",
+                "sig_s": "2c705977a6e066f807d9c2aa1fba02a32069bd92d2edf2c440533f0e05592d46"
+            }
+        },
+        {
+            "name": "ambire_nonce_1_chainid_1_mainnet",
+            "skip_models": ["t1", "t2t1"],
+            "parameters": {
+                "path": "m/44'/60'/0'/0/0",
+                "delegate": "0x5A7fC11397E9A8AD41Bf10bF13f22b0A63F96f6D",
+                "nonce": 1,
+                "chain_id": 1
+            },
+            "result": {
+                "sig_v": 0,
+                "sig_r": "77400904e30c320d62b65641f612898ca209fd3b2a8885d0b85d912dc8c40de2",
+                "sig_s": "7938228fd841d148463bb080ace6a580309dbf94a165b3c885db984609123ffd"
+            }
+        },
+        {
+            "name": "ambire_nonce_3_chainid_8453_base",
+            "skip_models": ["t1", "t2t1"],
+            "parameters": {
+                "path": "m/44'/60'/0'/0/0",
+                "delegate": "0x5A7fC11397E9A8AD41Bf10bF13f22b0A63F96f6D",
+                "nonce": 3,
+                "chain_id": 8453
+            },
+            "result": {
+                "sig_v": 0,
+                "sig_r": "fc60335ce74ebf14fe5f3e530d8a0e69cee885220114856653749d7174029a6e",
+                "sig_s": "777fe9db053cdf3b6eccc950524e9b4dd1f745f0d6ea2da538b59b6cd022ea01"
+            }
+        },
+        {
+            "name": "ambire_nonce_2_chainid_42161_arbitrum",
+            "skip_models": ["t1", "t2t1"],
+            "parameters": {
+                "path": "m/44'/60'/0'/0/0",
+                "delegate": "0x5A7fC11397E9A8AD41Bf10bF13f22b0A63F96f6D",
+                "nonce": 2,
+                "chain_id": 42161
+            },
+            "result": {
+                "sig_v": 0,
+                "sig_r": "74cec49fb8d385917ee9a81cb02ce7636df04853e3b3e9c31fc432b03e0dbbd6",
+                "sig_s": "60070f26d933a49b15db5b46d1443b92ff87916ea9eca9c9b6f36788ce181106"
+            }
+        },
+        {
+            "name": "revoke_nonce_123456_chainid_0_all_networks",
+            "skip_models": ["t1", "t2t1"],
+            "parameters": {
+                "path": "m/44'/60'/0'/0/0",
+                "delegate": "0x0000000000000000000000000000000000000000",
+                "nonce": 123456,
+                "chain_id": 0
+            },
+            "result": {
+                "sig_v": 0,
+                "sig_r": "e6a8160dc4cedb2766f3d6e555902abdfb8a92db37c02668d3035642dbb15215",
+                "sig_s": "6842785735df1a34b04ed1684e670cd6797ea8d0290f927b9b959a196f01749e"
+            }
+        },
+        {
+            "name": "revoke_nonce_123456_chainid_1_mainnet",
+            "skip_models": ["t1", "t2t1"],
+            "parameters": {
+                "path": "m/44'/60'/0'/0/0",
+                "delegate": "0x0000000000000000000000000000000000000000",
+                "nonce": 123456,
+                "chain_id": 1
+            },
+            "result": {
+                "sig_v": 0,
+                "sig_r": "ff76c404053009259385fcdd9f388debc4b0bdc6ba9361d2cab3405defc11850",
+                "sig_s": "153441cc873ad1bab4a025a9dac51a7dd915a9f521b7e38f83bb9e13a9b9b4d5"
+            }
+        },
+        {
+            "name": "revoke_nonce_123456_chainid_8453_base",
+            "skip_models": ["t1", "t2t1"],
+            "parameters": {
+                "path": "m/44'/60'/0'/0/0",
+                "delegate": "0x0000000000000000000000000000000000000000",
+                "nonce": 123456,
+                "chain_id": 8453
+            },
+            "result": {
+                "sig_v": 0,
+                "sig_r": "2077e516624d629605e47a3773dd5cc2d165ac3ec6af6edcba659d4962d1684d",
+                "sig_s": "7e8fa86d1a39dc5f5494d9649734a6a4dfe4e9e810b02136c3a84381cecaf8b9"
+            }
+        },
+        {
+            "name": "revoke_nonce_123456_chainid_42161_arbitrum",
+            "skip_models": ["t1", "t2t1"],
+            "parameters": {
+                "path": "m/44'/60'/0'/0/0",
+                "delegate": "0x0000000000000000000000000000000000000000",
+                "nonce": 123456,
+                "chain_id": 42161
+            },
+            "result": {
+                "sig_v": 0,
+                "sig_r": "092e59d6486520ea8fdcb1f4639fc8d3c02273f7f84bc83a527fbb9a95b8c70d",
+                "sig_s": "3a384fd28a3044fadf937511c795f50e1adeec94118a51dfab42b478a0bf860c"
+            }
+        }
+    ]
+}


### PR DESCRIPTION
Taken from https://github.com/trezor/trezor-firmware/pull/6983/changes/f99e148229e30034412986b1e89b25f189a03cd2.

Test vectors validated with Foundry:
```
cast wallet sign-auth $ADDRESS \
  --mnemonic $MNEMONIC \
  --mnemonic-derivation-path "m/44'/60'/0'/0/0" \
  --nonce $NONCE --chain $CHAINID 
```
https://www.getfoundry.sh/reference/cast/wallet/sign-auth
