### PR TITLE
fix(core/delizia): warning title should be red if `danger=true`

### DIFF
--- a/core/embed/rust/src/ui/layout_delizia/ui_firmware.rs
+++ b/core/embed/rust/src/ui/layout_delizia/ui_firmware.rs
@@ -1252,7 +1252,7 @@ impl FirmwareUI for UIDelizia {
             Some(title) => {
                 let header = Header::left_aligned(title);
                 let header = if danger {
-                    header.with_danger_icon()
+                    header.with_danger().with_danger_icon()
                 } else {
                     header.with_warning_low_icon()
                 };


### PR DESCRIPTION
e.g. https://www.figma.com/design/3wF1eh3Ftj0XGX7wFmev8t/EIP-7702?node-id=6358-2048&t=5G4XAU8n04PqeYF1-4

<img width="605" height="267" alt="image" src="https://github.com/user-attachments/assets/b163a932-bcbf-41ad-b538-9dcd0f4be882" />
