### PR TITLE
fix(ci): use both runners for HW tests of T2B1

### DIFF
--- a/.github/workflows/core-hw.yml
+++ b/.github/workflows/core-hw.yml
@@ -55,8 +55,7 @@ jobs:
     needs: param
     runs-on:
       - self-hosted
-      # FIXME runner4 with t2b1 does not work at the moment
-      - ${{ matrix.model == 'T2B1' && 'runner3' || matrix.model == 'T3T1' && 'hw-t3t1' || matrix.model == 'T3B1' && 'hw-t3b1' || matrix.model == 'T3W1' && 'hw-t3w1' || 'hw-t2t1' }}
+      - ${{ matrix.model == 'T2B1' && 'hw-t2b1' || matrix.model == 'T3T1' && 'hw-t3t1' || matrix.model == 'T3B1' && 'hw-t3b1' || matrix.model == 'T3W1' && 'hw-t3w1' || 'hw-t2t1' }}
     if: needs.param.outputs.core_models != '[]'
     strategy:
       fail-fast: false
@@ -116,8 +115,7 @@ jobs:
     needs: param
     runs-on:
       - self-hosted
-      # FIXME runner4 with t2b1 does not work at the moment
-      - ${{ matrix.model == 'T2B1' && 'runner3' || matrix.model == 'T3T1' && 'hw-t3t1' || matrix.model == 'T3B1' && 'hw-t3b1' || matrix.model == 'T3W1' && 'hw-t3w1' || 'hw-t2t1' }}
+      - ${{ matrix.model == 'T2B1' && 'hw-t2b1' || matrix.model == 'T3T1' && 'hw-t3t1' || matrix.model == 'T3B1' && 'hw-t3b1' || matrix.model == 'T3W1' && 'hw-t3w1' || 'hw-t2t1' }}
     if: needs.param.outputs.core_models != '[]' && false  # FIXME https://github.com/trezor/trezor-firmware/issues/3128
     strategy:
       fail-fast: false


### PR DESCRIPTION
TEST: both runners get picked up: https://github.com/trezor/trezor-firmware/actions/runs/29839244671

- [x] tests pass on both runners