### PR TITLE
fix(core): fix storage migration

### DIFF
--- a/core/.changelog.d/7354.fixed
+++ b/core/.changelog.d/7354.fixed
@@ -1,0 +1,1 @@
+[T3B1,T3T1] Fixed a crash during PIN verification when upgrading from firmware versions older than 2.9.0.

--- a/core/embed/models/build.rs
+++ b/core/embed/models/build.rs
@@ -111,7 +111,7 @@ fn main() -> Result<()> {
                     "-mtune=cortex-m33",
                 ]);
 
-                if cfg!(feature = "secure_mode") {
+                if cfg!(feature = "secure_mode") || !cfg!(feature = "secmon_layout") {
                     lib.add_flag("-mcmse");
                 }
             } else {


### PR DESCRIPTION
This PR fixes a storage key migration bug introduced in #6802.

With the new build system, `secure_aes_unpriv.c` was compiled without the required `-mcmse` flag. As a result, the key migration callback used SAES_NS instead of SAES_S, causing a MemFault during storage migration. The issue was manifested as an RSOD with the text "callback crashed".

The bug affected the T3B1 and T3T1 models.

The fix adds `-mcmse` flag to all coreapp sources on TS3/TS5 builds, restoring the correct secure peripheral access during key migration.



