### PR TITLE
fix(ci): allow `python_test` to download older python versions

### DIFF
--- a/.github/workflows/common.yml
+++ b/.github/workflows/common.yml
@@ -78,7 +78,7 @@ jobs:
           submodules: recursive
       - uses: ./.github/actions/environment
       # LD_LIBRARY_PATH workaround: https://discourse.nixos.org/t/nixpkgs-nixos-unstable-many-package-fail-with-glibc-2-38-not-found/35078 https://github.com/NixOS/nixpkgs/issues/287764
-      - run: nix-shell --run "unset LD_LIBRARY_PATH && cd python && uv run tox"
+      - run: nix-shell --arg pythonTest true --run "unset LD_LIBRARY_PATH && cd python && uv run tox"
 
   rust_test:
     name: Rust crates test

--- a/python/tox.ini
+++ b/python/tox.ini
@@ -1,8 +1,8 @@
 [tox]
 envlist =
-    py{39,310,311,312,313}-{minimal,default,full}
-    py{39,310,311,312,313}-click8{0,1}
-    py{310,311,312,313}-click82
+    py{39,310,311,312,313,314}-{minimal,default,full}
+    py{39,310,311,312,313,314}-click8{0,1}
+    py{310,311,312,313,314}-click82
 
 [testenv]
 runner = uv-venv-runner
@@ -18,7 +18,7 @@ commands =
     # Run test suite
     !minimal: pytest -c setup.cfg --random-order tests
 
-[testenv:py{39,310,311,312,313}-click{80,81,82}]
+[testenv:py{39,310,311,312,313,314}-click{80,81,82}]
 commands =
     click80: uv pip install "click>=8.0,<8.1"
     click81: uv pip install "click>=8.1,<8.2"

--- a/shell.nix
+++ b/shell.nix
@@ -1,6 +1,7 @@
 { fullDeps ? false
 , hardwareTest ? false
 , devTools ? false
+, pythonTest ? false
  }:
 
 let
@@ -146,12 +147,6 @@ stdenvNoCC.mkDerivation ({
   DYLD_LIBRARY_PATH = "${libffi}/lib:${libjpeg.out}/lib:${libusb1}/lib:${libressl.out}/lib";
   NIX_ENFORCE_PURITY = 0;
 
-  # Force uv to use the nix-provided Python instead of its own managed builds.
-  # Without this, uv defaults to python-preference=managed + python-downloads=automatic,
-  # silently downloading/reusing its own interpreter and ignoring python3 on PATH.
-  UV_PYTHON_PREFERENCE = "only-system";
-  UV_PYTHON_DOWNLOADS = "never";
-
   # Fix bdist-wheel problem by setting source date epoch to a more recent date
   SOURCE_DATE_EPOCH = 1600000000;
 
@@ -167,6 +162,16 @@ stdenvNoCC.mkDerivation ({
 
   # Avoid printing "Using udevCheckHook", there are no rules to check
   dontUdevCheck = 1;
-} // (lib.optionalAttrs fullDeps) {
+} // (if pythonTest then {
+  # Allow uv to use any python version for python tests
+  UV_PYTHON_PREFERENCE = "managed";
+  UV_PYTHON_DOWNLOADS = "automatic";
+} else {
+  # Force uv to use the nix-provided Python instead of its own managed builds.
+  # Without this, uv defaults to python-preference=managed + python-downloads=automatic,
+  # silently downloading/reusing its own interpreter and ignoring python3 on PATH.
+  UV_PYTHON_PREFERENCE = "only-system";
+  UV_PYTHON_DOWNLOADS = "never";
+}) // (lib.optionalAttrs fullDeps) {
   TREZOR_MONERO_TESTS_PATH = moneroTestsPatched;
 })


### PR DESCRIPTION
CI job `common::python_test` started failing recently. This PR should fix it.

- Also, added Python 3.14 to the versions that are tested.

CI job run before this fix (❌): https://github.com/trezor/trezor-firmware/actions/runs/30037609521/job/89309403370
vs. 
now (✅): https://github.com/trezor/trezor-firmware/actions/runs/30099606344/job/89502054166