### PR TITLE
test(python): configure tox not to skip missing interpreters

### DIFF
--- a/python/tox.ini
+++ b/python/tox.ini
@@ -4,6 +4,9 @@ envlist =
     py{39,310,311,312,313,314}-click8{0,1}
     py{310,311,312,313,314}-click82
 
+# workaround https://github.com/tox-dev/tox/pull/3966
+skip_missing_interpreters = false
+
 [testenv]
 runner = uv-venv-runner
 dependency_groups =


### PR DESCRIPTION
Followup of #7376 to workaround https://github.com/tox-dev/tox/pull/3966

<!--
For external contributors:
- Please open an issue before submitting a PR so we can discuss whether we want to proceed with it.

For core developers:
1. Initial PR setup
- Assign yourself to the PR.
- Add it to the "Firmware" project
  - Set Priority (match issue priority if it exists)
  - Set Team
  - Set Sprint (target release)

2. Development status
- Draft PRs: Set status to "In Progress"
- Final PRs: Set status to "Needs Review"

3. Post-merge status
- Testable: Set status to "Needs QA" and add a `Notes for QA` section with clear instructions on how to test the functionality.
- Not Testable: Set status to "Done (no QA)"
-->
