### PR TITLE
ci: fix sync with trezor-common repository

### DIFF
--- a/.github/workflows/bot-common-sync.yml
+++ b/.github/workflows/bot-common-sync.yml
@@ -19,6 +19,8 @@ jobs:
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # actions/checkout@v6.0.2
         with:
           fetch-depth: 0
+          persist-credentials: false
+
       - name: Generate GitHub App token
         id: trezor-bot-token
         uses: actions/create-github-app-token@1b10c78c7865c340bc4f6099eb2f838309f1e8c3  # actions/create-github-app-token@v3.1.1
@@ -28,13 +30,14 @@ jobs:
           owner: ${{ github.repository_owner }}
           repositories: |
             trezor-common
+          permission-contents: write
 
       - name: Copy git-filter and script to temporary directory
         run: |
           cp ./ci/common_sync/common_repo_sync.sh ${{runner.temp}}/common_repo_sync.sh
           cp ./ci/common_sync/git-filter-repo ${{runner.temp}}/git-filter-repo
 
-      - name: Confiugre git user
+      - name: Configure git user
         run: |
           git config --global user.name "${BOT_USERNAME}"
           git config --global user.email "${BOT_EMAIL}"
@@ -49,5 +52,4 @@ jobs:
           BOT_TOKEN: ${{ steps.trezor-bot-token.outputs.token }}
         run: |
           echo "Synchronizing common with the trezor-common repository"
-          git config --unset-all http.https://github.com/.extraheader
           ${{ runner.temp }}/common_repo_sync.sh


### PR DESCRIPTION
Replaces #7358. I think the workflow broke after #6554 updated `actions/checkout` which changed how credentials are persisted, breaking the HTTP auth setup and also making the workflow exit on `git config ...` failure. If the checkout credential is not persisted it starts working again.

Successful workflow run: https://github.com/trezor/trezor-firmware/actions/runs/30300146706/job/90090805280

<!--
For external contributors:
- Please open an issue before submitting a PR so we can discuss whether we want to proceed with it.

For core developers:
1. Initial PR setup
- Assign yourself to the PR.
- Add it to the "Firmware" project
  - Set Priority (match issue priority if it exists)
  - Set Team
  - Set Sprint (target release)

2. Development status
- Draft PRs: Set status to "In Progress"
- Final PRs: Set status to "Needs Review"

3. Post-merge status
- Testable: Set status to "Needs QA" and add a `Notes for QA` section with clear instructions on how to test the functionality.
- Not Testable: Set status to "Done (no QA)"
-->
