### PR TITLE
ci(core): improve binaries' size formatting

### DIFF
--- a/.github/workflows/core.yml
+++ b/.github/workflows/core.yml
@@ -764,7 +764,7 @@ jobs:
           do
             (echo '##' ${build_type}; \
              echo '```'; \
-             find artifacts/core-firmware-*-${build_type}/ -name '*-*-*.bin' -printf "%-40f %10s\n" | sort; \
+             find artifacts/core-firmware-*-${build_type}/ -name '*-*-*.bin' -printf "%10s %f\n" | sort -k 2; \
              echo '```') >> $GITHUB_STEP_SUMMARY
           done
 


### PR DESCRIPTION
Before this PR:
<img width="631" height="323" alt="image" src="https://github.com/user-attachments/assets/73031866-580f-4017-a334-ead85b090a6a" />
https://github.com/trezor/trezor-firmware/actions/runs/30314579708

After this PR:
<img width="631" height="323" alt="image" src="https://github.com/user-attachments/assets/188bcceb-8898-40e2-84a3-7fc00285562b" />
