### PR TITLE
ci(core): fix nightly ARM emulator filename

### DIFF
--- a/.github/workflows/core.yml
+++ b/.github/workflows/core.yml
@@ -817,6 +817,9 @@ jobs:
         run: |
           rm -rf emulators/{bootloader,firmware}-emu emulators/mpy-files emulators/*.json
           pushd emulators
+          # trezor-user-env expected format for aarch64: trezor-emu-arm-core-T2T1-universal
+          for F in firmware-emu-arm-*; do NEWF=`echo $F | sed s/firmware-emu-arm/trezor-emu-arm-core/`; mv $F $NEWF; done
+          # trezor-user-env expected format for x86_64: trezor-emu-core-T2T1-universal
           for F in firmware-emu-*; do NEWF=`echo $F | sed s/firmware-emu/trezor-emu-core/`; mv $F $NEWF; done
           popd
           tree


### PR DESCRIPTION
I broke the naming during switch to new build system in #6802. Tested on [this CI run](https://github.com/trezor/trezor-firmware/actions/runs/30369163817/job/90310854751) @ c54cb30 and verified working by @STew790 (thanks!). 

CI has been uploading the binaries as `trezor-emu-core-arm-T2T1-universal` but t-u-e looks for `trezor-emu-arm-core-T2T1-universal`.

<!--
For external contributors:
- Please open an issue before submitting a PR so we can discuss whether we want to proceed with it.

For core developers:
1. Initial PR setup
- Assign yourself to the PR.
- Add it to the "Firmware" project
  - Set Priority (match issue priority if it exists)
  - Set Team
  - Set Sprint (target release)

2. Development status
- Draft PRs: Set status to "In Progress"
- Final PRs: Set status to "Needs Review"

3. Post-merge status
- Testable: Set status to "Needs QA" and add a `Notes for QA` section with clear instructions on how to test the functionality.
- Not Testable: Set status to "Done (no QA)"
-->
