### PR TITLE
docs(thp): add low-order point verification to CodeEntry

### DIFF
--- a/docs/common/thp/specification.md
+++ b/docs/common/thp/specification.md
@@ -876,10 +876,12 @@ The behavior of Trezor in the state **TP2** is defined as follows:
 - When the message ThpSelectMethod(*selected_pairing_method*) is received, transition to the intermediate state “selected method”.
 - When the message ThpCodeEntryCpaceHostTag(*cpace_host_public_key*, *tag*) is received, take the following actions:
     1. Clear the screen.
-    2. Set *shared_secret* = X25519(*cpace_trezor_private_key*, *cpace_host_public_key*).
-    3. Assert that *tag* == SHA-256(*shared_secret*).
-    4. Send the message ThpCodeEntrySecret(*code_entry_secret*) to the host.
-    5. Transition to the state **TC1**.
+    2. Assert that *cpace_host_public_key* != 0x00 ^ 32.
+    3. Set *shared_secret* = X25519(*cpace_trezor_private_key*, *cpace_host_public_key*).
+    4. Assert that *shared_secret* != 0x00 ^ 32. This prevents the host from using low-order points to bypass code entry authentication.
+    5. Assert that *tag* == SHA-256(*shared_secret*).
+    6. Send the message ThpCodeEntrySecret(*code_entry_secret*) to the host.
+    7. Transition to the state **TC1**.
 
 #### State TP3b
 
@@ -1104,7 +1106,7 @@ sequenceDiagram
   Trezor -->> host - first time: code (user rewrites code from Trezor to host)
   note over host - first time: pregenerator = sha512(prefix || code || padding || handshake_hash_H || 0x00)[:32]<br>generator = ELLIGATOR2(pregenerator)<br>cpace_host_private_key = random_bytes(32)<br>cpace_host_public_key = X25519(cpace_host_private_key, generator)<br>shared_secret = X25519(cpace_host_private_key, cpace_trezor_public_key)<br>tag=sha256(shared_secret)
   host - first time ->> Trezor: cpace_host_public_key, tag
-  note over Trezor: shared_secret = X25519(cpace_trezor_private_key, cpace_host_public_key)
+  note over Trezor: assert cpace_host_public_key != 0x00 ^ 32<br>shared_secret = X25519(cpace_trezor_private_key, cpace_host_public_key)<br>assert shared_secret != 0x00 ^ 32
   note over Trezor: assert tag == sha256(shared_secret)
   Trezor ->> host - first time: secret
   note over host - first time: assert commitment == sha256(secret)
@@ -1122,7 +1124,7 @@ sequenceDiagram
   Trezor -->> host - second (or more) time : code (user rewrites code from Trezor to host)
   note over host - second (or more) time : pregenerator = sha512(prefix || code || padding || handshake_hash_H || 0x00)[:32]<br>generator = ELLIGATOR2(pregenerator)<br>cpace_host_private_key = random_bytes(32)<br>cpace_host_public_key = X25519(cpace_host_private_key, generator)<br>shared_secret = X25519(cpace_host_private_key, cpace_trezor_public_key)<br>tag=sha256(shared_secret)
   host - second (or more) time  ->> Trezor: cpace_host_public_key, tag
-  note over Trezor: shared_secret = X25519(cpace_trezor_private_key, cpace_host_public_key)
+  note over Trezor: assert cpace_host_public_key != 0x00 ^ 32<br>shared_secret = X25519(cpace_trezor_private_key, cpace_host_public_key)<br>assert shared_secret != 0x00 ^ 32
   note over Trezor: assert tag == sha256(shared_secret)
   Trezor ->> host - second (or more) time : secret
   note over host - second (or more) time : assert commitment == sha256(secret)
@@ -1152,7 +1154,7 @@ sequenceDiagram
   Trezor -->> host: code (user rewrites code from Trezor to host)
   note over host: pregenerator = sha512(prefix || code || padding || handshake_hash_H || 0x00)[:32]<br>generator = ELLIGATOR2(pregenerator)<br>cpace_host_private_key = random_bytes(32)<br>cpace_host_public_key = X25519(cpace_host_private_key, generator)<br>shared_secret = X25519(cpace_host_private_key, cpace_trezor_public_key)<br>tag=sha256(shared_secret)
   host ->> Trezor: cpace_host_public_key, tag
-  note over Trezor: shared_secret = X25519(cpace_trezor_private_key, cpace_host_public_key)
+  note over Trezor: assert cpace_host_public_key != 0x00 ^ 32<br>shared_secret = X25519(cpace_trezor_private_key, cpace_host_public_key)<br>assert shared_secret != 0x00 ^ 32
   note over Trezor: assert tag == sha256(shared_secret)
   Trezor ->> host: secret
   note over host: assert commitment == sha256(secret)


### PR DESCRIPTION
Documents changes done in: https://github.com/trezor/trezor-firmware/commit/328d692f59192be4ce9009c01c36c44d98bb23e9