### PR TITLE
Regenerate OPTIONS.rst

### DIFF
--- a/python/docs/OPTIONS.rst
+++ b/python/docs/OPTIONS.rst
@@ -288,6 +288,7 @@ Ethereum commands.
   Commands:
     get-address           Get Ethereum address in hex encoding.
     get-public-node       Get Ethereum public node of given path.
+    sign-auth-eip7702     Sign EIP-7702 authorization.
     sign-message          Sign message with Ethereum address.
     sign-tx               Sign (and optionally publish) Ethereum transaction.
     sign-typed-data       Sign typed data (EIP-712) with Ethereum address.
@@ -509,8 +510,9 @@ Stellar commands.
     --help  Show this message and exit.
 
   Commands:
-    get-address       Get Stellar public address.
-    sign-transaction  Sign a base64-encoded transaction envelope.
+    get-address                 Get Stellar public address.
+    sign-soroban-authorization  Sign a base64-encoded Soroban authorization entry.
+    sign-transaction            Sign a base64-encoded transaction envelope.
 
 Telemetry commands.
 ~~~~~~~~~~~~~~~~~~~


### PR DESCRIPTION
Regenerated `OPTIONS.rst` as a part of preparation for the next python trezor release. Same as https://github.com/trezor/trezor-firmware/pull/7383

Docs regenerated using `python/helper-scripts/make-options-rst.py`.

## Notes
- The OPTIONS.rst should be regenerated when modifying CLI commands. https://github.com/trezor/trezor-firmware/issues/6938
- It would be really nice if we had the CI check.