### PR TITLE
Release trezor v0.20.2

### DIFF
--- a/python/.changelog.d/+master-fingerprint.added
+++ b/python/.changelog.d/+master-fingerprint.added
@@ -1,1 +1,0 @@
-Added master-fingerprint.py tool, which computes a master fingerprint over a set of labeled firmware fingerprints.

--- a/python/.changelog.d/+master-fingerprint.changed
+++ b/python/.changelog.d/+master-fingerprint.changed
@@ -1,1 +1,0 @@
-firmware-fingerprint.py now labels the fingerprint with the image's SLIP-26 model and purpose ("<model>_<purpose>: HEX") and supports vendor headers and new-style PQ bootloader images.

--- a/python/.changelog.d/3446.fixed
+++ b/python/.changelog.d/3446.fixed
@@ -1,1 +1,0 @@
-Solana: allow chunkified addresses.

--- a/python/.changelog.d/3471.incompatible
+++ b/python/.changelog.d/3471.incompatible
@@ -1,1 +1,0 @@
-Stellar: Enable signing Soroban smart contract transactions; `sign_tx` / `from_envelope` now accepts / returns a transaction extension.

--- a/python/.changelog.d/6730.fixed
+++ b/python/.changelog.d/6730.fixed
@@ -1,1 +1,0 @@
-Tron: allow chunkified addresses.

--- a/python/.changelog.d/6759.added
+++ b/python/.changelog.d/6759.added
@@ -1,1 +1,0 @@
-Support for [Solana off-chain message signing v0](https://docs.anza.xyz/proposals/off-chain-message-signing).

--- a/python/.changelog.d/6826.added
+++ b/python/.changelog.d/6826.added
@@ -1,1 +1,0 @@
-Add ML-DSA-44 device authenticity check.

--- a/python/.changelog.d/6859.fixed
+++ b/python/.changelog.d/6859.fixed
@@ -1,1 +1,0 @@
-Skip stale protocol v1 responses on probing.

--- a/python/.changelog.d/6994.added
+++ b/python/.changelog.d/6994.added
@@ -1,1 +1,0 @@
-Add testing module to trezorlib.

--- a/python/.changelog.d/7053.incompatible
+++ b/python/.changelog.d/7053.incompatible
@@ -1,1 +1,0 @@
-Solana: add support for off-chain message signing (OCMS) v1 and remove v0.

--- a/python/.changelog.d/7101.added
+++ b/python/.changelog.d/7101.added
@@ -1,1 +1,0 @@
-Tron: Claim voting rewards (WithdrawBalanceContract).

--- a/python/.changelog.d/7168.changed
+++ b/python/.changelog.d/7168.changed
@@ -1,1 +1,0 @@
-`TrezorClient.ensure_unlocked()` will not allocate a session and will not cause seed derivation. `Session.ensure_unlocked()` now just forwards to `TrezorClient`.

--- a/python/.changelog.d/7168.fixed
+++ b/python/.changelog.d/7168.fixed
@@ -1,1 +1,0 @@
-Fix non-functional `trezorctl get-session` with THP.

--- a/python/.changelog.d/7312.added
+++ b/python/.changelog.d/7312.added
@@ -1,1 +1,0 @@
-Stellar: Support signing Soroban authorization entries (`stellar.sign_soroban_authorization`, `stellar.from_authorization_entry` and `trezorctl stellar sign-soroban-authorization`).

--- a/python/.changelog.d/7359.changed
+++ b/python/.changelog.d/7359.changed
@@ -1,1 +1,0 @@
-Generated Merkle trees are now balanced.

--- a/python/.changelog.d/tbd_hid_transport_chunk_size_fix.fixed
+++ b/python/.changelog.d/tbd_hid_transport_chunk_size_fix.fixed
@@ -1,0 +1,1 @@
+Fix broken HID transport.

--- a/python/.changelog.d/tbd_hid_transport_chunk_size_fix.fixed
+++ b/python/.changelog.d/tbd_hid_transport_chunk_size_fix.fixed
@@ -1,1 +1,0 @@
-Fix broken HID transport.

--- a/python/CHANGELOG.md
+++ b/python/CHANGELOG.md
@@ -5,6 +5,31 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.20.2] (29th July 2026)
+[0.20.2]: https://github.com/trezor/trezor-firmware/compare/python/v0.20.1...python/v0.20.2
+
+### Added
+- Support for [Solana off-chain message signing v0](https://docs.anza.xyz/proposals/off-chain-message-signing).  [#6759]
+- Add ML-DSA-44 device authenticity check.  [#6826]
+- Add testing module to trezorlib.  [#6994]
+- Tron: Claim voting rewards (WithdrawBalanceContract).  [#7101]
+- Stellar: Support signing Soroban authorization entries (`stellar.sign_soroban_authorization`, `stellar.from_authorization_entry` and `trezorctl stellar sign-soroban-authorization`).  [#7365]
+
+### Changed
+- `TrezorClient.ensure_unlocked()` will not allocate a session and will not cause seed derivation. `Session.ensure_unlocked()` now just forwards to `TrezorClient`.  [#7168]
+- Generated Merkle trees are now balanced.  [#7359]
+
+### Fixed
+- Solana: allow chunkified addresses.  [#6545]
+- Tron: allow chunkified addresses.  [#6730]
+- Skip stale protocol v1 responses on probing.  [#6859]
+- Fix non-functional `trezorctl get-session` with THP.  [#7168]
+- Fix broken HID transport.  [#7428]
+
+### Incompatible changes
+- Solana: add support for off-chain message signing (OCMS) v1 and remove v0.  [#7053]
+- Stellar: Enable signing Soroban smart contract transactions; `sign_tx` / `from_envelope` now accepts / returns a transaction extension.  [#7259]
+
 ## [0.20.1] (11th May 2026)
 [0.20.1]: https://github.com/trezor/trezor-firmware/compare/python/v0.20.0...python/v0.20.1
 
@@ -992,9 +1017,22 @@ This version is a pre-release. The new API is unstable and may change until 0.20
 [#6349]: https://github.com/trezor/trezor-firmware/pull/6349
 [#6449]: https://github.com/trezor/trezor-firmware/pull/6449
 [#6525]: https://github.com/trezor/trezor-firmware/pull/6525
+[#6545]: https://github.com/trezor/trezor-firmware/pull/6545
 [#6555]: https://github.com/trezor/trezor-firmware/pull/6555
 [#6564]: https://github.com/trezor/trezor-firmware/pull/6564
 [#6575]: https://github.com/trezor/trezor-firmware/pull/6575
 [#6580]: https://github.com/trezor/trezor-firmware/pull/6580
 [#6588]: https://github.com/trezor/trezor-firmware/pull/6588
 [#6633]: https://github.com/trezor/trezor-firmware/pull/6633
+[#6730]: https://github.com/trezor/trezor-firmware/pull/6730
+[#6759]: https://github.com/trezor/trezor-firmware/pull/6759
+[#6826]: https://github.com/trezor/trezor-firmware/pull/6826
+[#6859]: https://github.com/trezor/trezor-firmware/pull/6859
+[#6994]: https://github.com/trezor/trezor-firmware/pull/6994
+[#7053]: https://github.com/trezor/trezor-firmware/pull/7053
+[#7101]: https://github.com/trezor/trezor-firmware/pull/7101
+[#7168]: https://github.com/trezor/trezor-firmware/pull/7168
+[#7259]: https://github.com/trezor/trezor-firmware/pull/7259
+[#7359]: https://github.com/trezor/trezor-firmware/pull/7359
+[#7365]: https://github.com/trezor/trezor-firmware/pull/7365
+[#7428]: https://github.com/trezor/trezor-firmware/pull/7428

--- a/python/pyproject.toml
+++ b/python/pyproject.toml
@@ -78,7 +78,7 @@ exclude-newer = "30 days"
 # Exempt stellar-sdk from the 30-day rule so the freshly released 15.0.0
 # final (needed for Protocol 27 support) can be resolved.
 # TODO: remove after 2026-08-04
-exclude-newer-package = { stellar-sdk = "2026-07-051T00:00:00Z" }
+exclude-newer-package = { stellar-sdk = "2026-07-05T00:00:00Z" }
 
 [tool.flit.module]
 name = "trezorlib"

--- a/python/pyproject.toml
+++ b/python/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "trezor"
-version = "0.20.2"
+version = "0.20.3"
 description = "Python library for communicating with Trezor Hardware Wallet"
 readme = "README.md"
 license = "LGPL-3.0-only"

--- a/python/src/trezorlib/transport/hid.py
+++ b/python/src/trezorlib/transport/hid.py
@@ -47,6 +47,7 @@ class HidTransport(Transport):
 
     PATH_PREFIX = "hid"
     ENABLED = HID_IMPORTED
+    CHUNK_SIZE = 64
 
     def __init__(self, device: HidDevice, probe_hid_version: bool = False) -> None:
         self.device = device

--- a/uv.lock
+++ b/uv.lock
@@ -2085,7 +2085,7 @@ wheels = [
 
 [[package]]
 name = "trezor"
-version = "0.20.2"
+version = "0.20.3"
 source = { editable = "python" }
 dependencies = [
     { name = "click" },


### PR DESCRIPTION
Release branch/PR for python trezor version 0.20.2.

This PR adds two additional changes related to python code:
- Fix of exclusion date in pyproject.toml.
- Fix of broken HID transport.

All other changes have already been merged in `main` in between release of v0.20.1 and now.

---
# Changelog for v0.20.2

## [0.20.2] (29th July 2026)
[0.20.2]: https://github.com/trezor/trezor-firmware/compare/python/v0.20.1...python/v0.20.2

### Added
- Support for [Solana off-chain message signing v0](https://docs.anza.xyz/proposals/off-chain-message-signing).  [#6759]
- Add ML-DSA-44 device authenticity check.  [#6826]
- Add testing module to trezorlib.  [#6994]
- Tron: Claim voting rewards (WithdrawBalanceContract).  [#7101]
- Stellar: Support signing Soroban authorization entries (`stellar.sign_soroban_authorization`, `stellar.from_authorization_entry` and `trezorctl stellar sign-soroban-authorization`).  [#7365]

### Changed
- `TrezorClient.ensure_unlocked()` will not allocate a session and will not cause seed derivation. `Session.ensure_unlocked()` now just forwards to `TrezorClient`.  [#7168]
- Generated Merkle trees are now balanced.  [#7359]

### Fixed
- Solana: allow chunkified addresses.  [#6545]
- Tron: allow chunkified addresses.  [#6730]
- Skip stale protocol v1 responses on probing.  [#6859]
- Fix non-functional `trezorctl get-session` with THP.  [#7168]
- Fix broken HID transport.  [#7428]

### Incompatible changes
- Solana: add support for off-chain message signing (OCMS) v1 and remove v0.  [#7053]
- Stellar: Enable signing Soroban smart contract transactions; `sign_tx` / `from_envelope` now accepts / returns a transaction extension.  [#7259]
---
# Comparison with v0.20.1 artifacts
- no files were removed
## Added files: trezor-0.20.2.tar.gz 
```
> ./src/trezorlib/firmware/nrf.py
> ./src/trezorlib/firmware/sanity_struct.py
> ./src/trezorlib/_internal/master_fingerprint.py
> ./src/trezorlib/_internal/prodtest_client.py
> ./src/trezorlib/_internal/prodtest_emulator.py
> ./src/trezorlib/_internal/prodtest_transport.py
> ./src/trezorlib/_internal/slip26.py
> ./src/trezorlib/testing/common.py
> ./src/trezorlib/testing/device_handler.py
> ./src/trezorlib/testing/__init__.py
> ./src/trezorlib/testing/translations.py
> ./tests/test_master_fingerprint.py
> ./tools/master-fingerprint.py
```
## Added files: trezor-0.20.2-py3-none-any.whl
```
> ./trezorlib/firmware/nrf.py
> ./trezorlib/firmware/sanity_struct.py
> ./trezorlib/_internal/master_fingerprint.py
> ./trezorlib/_internal/prodtest_client.py
> ./trezorlib/_internal/prodtest_emulator.py
> ./trezorlib/_internal/prodtest_transport.py
> ./trezorlib/_internal/slip26.py
> ./trezorlib/testing/common.py
> ./trezorlib/testing/device_handler.py
> ./trezorlib/testing/__init__.py
> ./trezorlib/testing/translations.py
```
---
# Testing
- `trezor-0.20.2-py3-none-any.whl` installed in a clean environment a smoke-tested for 15 minutes. Used Trezor devices: T2T1, T3W1. 
- tox testing done in CI only (see `Common / Python test` job).
---
# Notes for QA
- I am unsure what exactly to test. I think it might be good to do a `trezorctl` smoke-test, which could be enough.