### PR TITLE
feat(common): add EIP-7702 delegation protobuf definitions

### DIFF
--- a/common/protob/messages-ethereum.proto
+++ b/common/protob/messages-ethereum.proto
@@ -100,10 +100,22 @@ message EthereumSignTxEIP1559 {
     optional bool chunkify = 13;                          // display the address in chunks of 4 characters
     optional common.PaymentRequest payment_req = 14;      // SLIP-24 payment request
     optional bool supports_definition_request = 15;       // whether the client supports EthereumDefinitionRequest
+    repeated EthereumAuth7702Entry auth_list = 16
+        [(experimental_field) = true];                    // EIP-7702 authorization list (only on Core)
 
     message EthereumAccessList {
         required string address = 1;
         repeated bytes storage_keys = 2;
+    }
+
+    message EthereumAuth7702Entry {
+        option (experimental_message) = true;
+
+        required uint64 chain_id = 1;                      // chain id on which the authorization is valid, or 0 for all
+        required string delegate = 2;                      // address of the code that will be delegated to the EOA
+        required uint64 nonce = 3;                         // account nonce for which the authorization is valid
+
+        optional EthereumAuth7702Signature signature = 4;  // if not provided, request a signature from this account
     }
 }
 
@@ -122,6 +134,9 @@ message EthereumTxRequest {
     optional uint32 signature_v = 2;  // Computed signature (recovery parameter, limited to 27 or 28)
     optional bytes signature_r = 3;   // Computed signature R component (256 bit)
     optional bytes signature_s = 4;   // Computed signature S component (256 bit)
+
+    // Done. Return EIP-7702 authorization list for this transaction.
+    repeated EthereumAuth7702Signature auth_list = 5;
 }
 
 /**

--- a/core/src/trezor/messages.py
+++ b/core/src/trezor/messages.py
@@ -4123,6 +4123,7 @@ if TYPE_CHECKING:
         chunkify: "bool | None"
         payment_req: "PaymentRequest | None"
         supports_definition_request: "bool | None"
+        auth_list: "list[EthereumAuth7702Entry]"
 
         def __init__(
             self,
@@ -4136,6 +4137,7 @@ if TYPE_CHECKING:
             chain_id: "int",
             address_n: "list[int] | None" = None,
             access_list: "list[EthereumAccessList] | None" = None,
+            auth_list: "list[EthereumAuth7702Entry] | None" = None,
             to: "str | None" = None,
             data_initial_chunk: "AnyBytes | None" = None,
             definitions: "EthereumDefinitions | None" = None,
@@ -4154,10 +4156,12 @@ if TYPE_CHECKING:
         signature_v: "int | None"
         signature_r: "AnyBytes | None"
         signature_s: "AnyBytes | None"
+        auth_list: "list[EthereumAuth7702Signature]"
 
         def __init__(
             self,
             *,
+            auth_list: "list[EthereumAuth7702Signature] | None" = None,
             data_length: "int | None" = None,
             signature_v: "int | None" = None,
             signature_r: "AnyBytes | None" = None,
@@ -4379,6 +4383,26 @@ if TYPE_CHECKING:
 
         @classmethod
         def is_type_of(cls, msg: Any) -> TypeGuard["EthereumAccessList"]:
+            return isinstance(msg, cls)
+
+    class EthereumAuth7702Entry(protobuf.MessageType):
+        chain_id: "int"
+        delegate: "str"
+        nonce: "int"
+        signature: "EthereumAuth7702Signature | None"
+
+        def __init__(
+            self,
+            *,
+            chain_id: "int",
+            delegate: "str",
+            nonce: "int",
+            signature: "EthereumAuth7702Signature | None" = None,
+        ) -> None:
+            pass
+
+        @classmethod
+        def is_type_of(cls, msg: Any) -> TypeGuard["EthereumAuth7702Entry"]:
             return isinstance(msg, cls)
 
     class EthereumSignTypedData(protobuf.MessageType):

--- a/legacy/firmware/protob/Makefile
+++ b/legacy/firmware/protob/Makefile
@@ -13,7 +13,7 @@ SKIPPED_MESSAGES := Cardano DebugMonero Eos Monero Ontology Ripple SdProtect Tez
 	GetNonce TxAckInput TxAckOutput TxAckPrev PaymentRequest \
 	EthereumABITupleInfo EthereumABIValueInfo EthereumERC7730FieldInfo EthereumDisplayFormatInfo EthereumERC7730Path \
 	EthereumDefinitionRequest EthereumDefinitionAck \
-	EthereumSignAuth7702 EthereumAuth7702Signature \
+	EthereumSignAuth7702 EthereumAuth7702Signature EthereumAuth7702Entry \
 	EthereumSignTypedData EthereumTypedDataStructRequest EthereumTypedDataStructAck \
 	EthereumTypedDataValueRequest EthereumTypedDataValueAck ShowDeviceTutorial \
 	UnlockBootloader AuthenticateDevice AuthenticityProof GetAuthenticityProofChunk \

--- a/legacy/firmware/protob/messages-ethereum.options
+++ b/legacy/firmware/protob/messages-ethereum.options
@@ -17,12 +17,14 @@ EthereumSignTxEIP1559.value              max_size:32
 EthereumSignTxEIP1559.data_initial_chunk max_size:1024
 EthereumSignTxEIP1559.access_list        max_count:12
 EthereumSignTxEIP1559.payment_req        type:FT_IGNORE
+EthereumSignTxEIP1559.auth_list          type:FT_IGNORE
 
 EthereumAccessList.address              max_size:43
 EthereumAccessList.storage_keys         max_count:12 max_size:32
 
 EthereumTxRequest.signature_r           max_size:32
 EthereumTxRequest.signature_s           max_size:32
+EthereumTxRequest.auth_list             type:FT_IGNORE
 
 EthereumTxAck.data_chunk                max_size:1024
 

--- a/python/src/trezorlib/messages.py
+++ b/python/src/trezorlib/messages.py
@@ -5695,6 +5695,7 @@ class EthereumSignTxEIP1559(protobuf.MessageType):
         13: protobuf.Field("chunkify", "bool", repeated=False, required=False, default=None),
         14: protobuf.Field("payment_req", "PaymentRequest", repeated=False, required=False, default=None),
         15: protobuf.Field("supports_definition_request", "bool", repeated=False, required=False, default=None),
+        16: protobuf.Field("auth_list", "EthereumAuth7702Entry", repeated=True, required=False, default=None),
     }
 
     def __init__(
@@ -5709,6 +5710,7 @@ class EthereumSignTxEIP1559(protobuf.MessageType):
         chain_id: "int",
         address_n: Optional[Sequence["int"]] = None,
         access_list: Optional[Sequence["EthereumAccessList"]] = None,
+        auth_list: Optional[Sequence["EthereumAuth7702Entry"]] = None,
         to: Optional["str"] = '',
         data_initial_chunk: Optional["bytes"] = b'',
         definitions: Optional["EthereumDefinitions"] = None,
@@ -5718,6 +5720,7 @@ class EthereumSignTxEIP1559(protobuf.MessageType):
     ) -> None:
         self.address_n: Sequence["int"] = address_n if address_n is not None else []
         self.access_list: Sequence["EthereumAccessList"] = access_list if access_list is not None else []
+        self.auth_list: Sequence["EthereumAuth7702Entry"] = auth_list if auth_list is not None else []
         self.nonce = nonce
         self.max_gas_fee = max_gas_fee
         self.max_priority_fee = max_priority_fee
@@ -5740,16 +5743,19 @@ class EthereumTxRequest(protobuf.MessageType):
         2: protobuf.Field("signature_v", "uint32", repeated=False, required=False, default=None),
         3: protobuf.Field("signature_r", "bytes", repeated=False, required=False, default=None),
         4: protobuf.Field("signature_s", "bytes", repeated=False, required=False, default=None),
+        5: protobuf.Field("auth_list", "EthereumAuth7702Signature", repeated=True, required=False, default=None),
     }
 
     def __init__(
         self,
         *,
+        auth_list: Optional[Sequence["EthereumAuth7702Signature"]] = None,
         data_length: Optional["int"] = None,
         signature_v: Optional["int"] = None,
         signature_r: Optional["bytes"] = None,
         signature_s: Optional["bytes"] = None,
     ) -> None:
+        self.auth_list: Sequence["EthereumAuth7702Signature"] = auth_list if auth_list is not None else []
         self.data_length = data_length
         self.signature_v = signature_v
         self.signature_r = signature_r
@@ -5988,6 +5994,29 @@ class EthereumAccessList(protobuf.MessageType):
     ) -> None:
         self.storage_keys: Sequence["bytes"] = storage_keys if storage_keys is not None else []
         self.address = address
+
+
+class EthereumAuth7702Entry(protobuf.MessageType):
+    MESSAGE_WIRE_TYPE = None
+    FIELDS = {
+        1: protobuf.Field("chain_id", "uint64", repeated=False, required=True),
+        2: protobuf.Field("delegate", "string", repeated=False, required=True),
+        3: protobuf.Field("nonce", "uint64", repeated=False, required=True),
+        4: protobuf.Field("signature", "EthereumAuth7702Signature", repeated=False, required=False, default=None),
+    }
+
+    def __init__(
+        self,
+        *,
+        chain_id: "int",
+        delegate: "str",
+        nonce: "int",
+        signature: Optional["EthereumAuth7702Signature"] = None,
+    ) -> None:
+        self.chain_id = chain_id
+        self.delegate = delegate
+        self.nonce = nonce
+        self.signature = signature
 
 
 class EthereumSignTypedData(protobuf.MessageType):

--- a/rust/trezor-client/src/protos/generated/messages_ethereum.rs
+++ b/rust/trezor-client/src/protos/generated/messages_ethereum.rs
@@ -1618,6 +1618,8 @@ pub struct EthereumSignTxEIP1559 {
     pub payment_req: ::protobuf::MessageField<super::messages_common::PaymentRequest>,
     // @@protoc_insertion_point(field:hw.trezor.messages.ethereum.EthereumSignTxEIP1559.supports_definition_request)
     pub supports_definition_request: ::std::option::Option<bool>,
+    // @@protoc_insertion_point(field:hw.trezor.messages.ethereum.EthereumSignTxEIP1559.auth_list)
+    pub auth_list: ::std::vec::Vec<ethereum_sign_tx_eip1559::EthereumAuth7702Entry>,
     // special fields
     // @@protoc_insertion_point(special_field:hw.trezor.messages.ethereum.EthereumSignTxEIP1559.special_fields)
     pub special_fields: ::protobuf::SpecialFields,
@@ -1963,7 +1965,7 @@ impl EthereumSignTxEIP1559 {
     }
 
     fn generated_message_descriptor_data() -> ::protobuf::reflect::GeneratedMessageDescriptorData {
-        let mut fields = ::std::vec::Vec::with_capacity(15);
+        let mut fields = ::std::vec::Vec::with_capacity(16);
         let mut oneofs = ::std::vec::Vec::with_capacity(0);
         fields.push(::protobuf::reflect::rt::v2::make_vec_simpler_accessor::<_, _>(
             "address_n",
@@ -2040,6 +2042,11 @@ impl EthereumSignTxEIP1559 {
             |m: &EthereumSignTxEIP1559| { &m.supports_definition_request },
             |m: &mut EthereumSignTxEIP1559| { &mut m.supports_definition_request },
         ));
+        fields.push(::protobuf::reflect::rt::v2::make_vec_simpler_accessor::<_, _>(
+            "auth_list",
+            |m: &EthereumSignTxEIP1559| { &m.auth_list },
+            |m: &mut EthereumSignTxEIP1559| { &mut m.auth_list },
+        ));
         ::protobuf::reflect::GeneratedMessageDescriptorData::new_2::<EthereumSignTxEIP1559>(
             "EthereumSignTxEIP1559",
             fields,
@@ -2084,6 +2091,11 @@ impl ::protobuf::Message for EthereumSignTxEIP1559 {
             }
         };
         for v in &self.payment_req {
+            if !v.is_initialized() {
+                return false;
+            }
+        };
+        for v in &self.auth_list {
             if !v.is_initialized() {
                 return false;
             }
@@ -2141,6 +2153,9 @@ impl ::protobuf::Message for EthereumSignTxEIP1559 {
                 },
                 120 => {
                     self.supports_definition_request = ::std::option::Option::Some(is.read_bool()?);
+                },
+                130 => {
+                    self.auth_list.push(is.read_message()?);
                 },
                 tag => {
                     ::protobuf::rt::read_unknown_or_skip_group(tag, is, self.special_fields.mut_unknown_fields())?;
@@ -2202,6 +2217,10 @@ impl ::protobuf::Message for EthereumSignTxEIP1559 {
         if let Some(v) = self.supports_definition_request {
             my_size += 1 + 1;
         }
+        for value in &self.auth_list {
+            let len = value.compute_size();
+            my_size += 2 + ::protobuf::rt::compute_raw_varint64_size(len) + len;
+        };
         my_size += ::protobuf::rt::unknown_fields_size(self.special_fields.unknown_fields());
         self.special_fields.cached_size().set(my_size as u32);
         my_size
@@ -2253,6 +2272,9 @@ impl ::protobuf::Message for EthereumSignTxEIP1559 {
         if let Some(v) = self.supports_definition_request {
             os.write_bool(15, v)?;
         }
+        for v in &self.auth_list {
+            ::protobuf::rt::write_message_field_with_cached_size(16, v, os)?;
+        };
         os.write_unknown_fields(self.special_fields.unknown_fields())?;
         ::std::result::Result::Ok(())
     }
@@ -2285,6 +2307,7 @@ impl ::protobuf::Message for EthereumSignTxEIP1559 {
         self.chunkify = ::std::option::Option::None;
         self.payment_req.clear();
         self.supports_definition_request = ::std::option::Option::None;
+        self.auth_list.clear();
         self.special_fields.clear();
     }
 
@@ -2305,6 +2328,7 @@ impl ::protobuf::Message for EthereumSignTxEIP1559 {
             chunkify: ::std::option::Option::None,
             payment_req: ::protobuf::MessageField::none(),
             supports_definition_request: ::std::option::Option::None,
+            auth_list: ::std::vec::Vec::new(),
             special_fields: ::protobuf::SpecialFields::new(),
         };
         &instance
@@ -2508,6 +2532,271 @@ pub mod ethereum_sign_tx_eip1559 {
     impl ::protobuf::reflect::ProtobufValue for EthereumAccessList {
         type RuntimeType = ::protobuf::reflect::rt::RuntimeTypeMessage<Self>;
     }
+
+    // @@protoc_insertion_point(message:hw.trezor.messages.ethereum.EthereumSignTxEIP1559.EthereumAuth7702Entry)
+    #[derive(PartialEq,Clone,Default,Debug)]
+    pub struct EthereumAuth7702Entry {
+        // message fields
+        // @@protoc_insertion_point(field:hw.trezor.messages.ethereum.EthereumSignTxEIP1559.EthereumAuth7702Entry.chain_id)
+        pub chain_id: ::std::option::Option<u64>,
+        // @@protoc_insertion_point(field:hw.trezor.messages.ethereum.EthereumSignTxEIP1559.EthereumAuth7702Entry.delegate)
+        pub delegate: ::std::option::Option<::std::string::String>,
+        // @@protoc_insertion_point(field:hw.trezor.messages.ethereum.EthereumSignTxEIP1559.EthereumAuth7702Entry.nonce)
+        pub nonce: ::std::option::Option<u64>,
+        // @@protoc_insertion_point(field:hw.trezor.messages.ethereum.EthereumSignTxEIP1559.EthereumAuth7702Entry.signature)
+        pub signature: ::protobuf::MessageField<super::EthereumAuth7702Signature>,
+        // special fields
+        // @@protoc_insertion_point(special_field:hw.trezor.messages.ethereum.EthereumSignTxEIP1559.EthereumAuth7702Entry.special_fields)
+        pub special_fields: ::protobuf::SpecialFields,
+    }
+
+    impl<'a> ::std::default::Default for &'a EthereumAuth7702Entry {
+        fn default() -> &'a EthereumAuth7702Entry {
+            <EthereumAuth7702Entry as ::protobuf::Message>::default_instance()
+        }
+    }
+
+    impl EthereumAuth7702Entry {
+        pub fn new() -> EthereumAuth7702Entry {
+            ::std::default::Default::default()
+        }
+
+        // required uint64 chain_id = 1;
+
+        pub fn chain_id(&self) -> u64 {
+            self.chain_id.unwrap_or(0)
+        }
+
+        pub fn clear_chain_id(&mut self) {
+            self.chain_id = ::std::option::Option::None;
+        }
+
+        pub fn has_chain_id(&self) -> bool {
+            self.chain_id.is_some()
+        }
+
+        // Param is passed by value, moved
+        pub fn set_chain_id(&mut self, v: u64) {
+            self.chain_id = ::std::option::Option::Some(v);
+        }
+
+        // required string delegate = 2;
+
+        pub fn delegate(&self) -> &str {
+            match self.delegate.as_ref() {
+                Some(v) => v,
+                None => "",
+            }
+        }
+
+        pub fn clear_delegate(&mut self) {
+            self.delegate = ::std::option::Option::None;
+        }
+
+        pub fn has_delegate(&self) -> bool {
+            self.delegate.is_some()
+        }
+
+        // Param is passed by value, moved
+        pub fn set_delegate(&mut self, v: ::std::string::String) {
+            self.delegate = ::std::option::Option::Some(v);
+        }
+
+        // Mutable pointer to the field.
+        // If field is not initialized, it is initialized with default value first.
+        pub fn mut_delegate(&mut self) -> &mut ::std::string::String {
+            if self.delegate.is_none() {
+                self.delegate = ::std::option::Option::Some(::std::string::String::new());
+            }
+            self.delegate.as_mut().unwrap()
+        }
+
+        // Take field
+        pub fn take_delegate(&mut self) -> ::std::string::String {
+            self.delegate.take().unwrap_or_else(|| ::std::string::String::new())
+        }
+
+        // required uint64 nonce = 3;
+
+        pub fn nonce(&self) -> u64 {
+            self.nonce.unwrap_or(0)
+        }
+
+        pub fn clear_nonce(&mut self) {
+            self.nonce = ::std::option::Option::None;
+        }
+
+        pub fn has_nonce(&self) -> bool {
+            self.nonce.is_some()
+        }
+
+        // Param is passed by value, moved
+        pub fn set_nonce(&mut self, v: u64) {
+            self.nonce = ::std::option::Option::Some(v);
+        }
+
+        pub(in super) fn generated_message_descriptor_data() -> ::protobuf::reflect::GeneratedMessageDescriptorData {
+            let mut fields = ::std::vec::Vec::with_capacity(4);
+            let mut oneofs = ::std::vec::Vec::with_capacity(0);
+            fields.push(::protobuf::reflect::rt::v2::make_option_accessor::<_, _>(
+                "chain_id",
+                |m: &EthereumAuth7702Entry| { &m.chain_id },
+                |m: &mut EthereumAuth7702Entry| { &mut m.chain_id },
+            ));
+            fields.push(::protobuf::reflect::rt::v2::make_option_accessor::<_, _>(
+                "delegate",
+                |m: &EthereumAuth7702Entry| { &m.delegate },
+                |m: &mut EthereumAuth7702Entry| { &mut m.delegate },
+            ));
+            fields.push(::protobuf::reflect::rt::v2::make_option_accessor::<_, _>(
+                "nonce",
+                |m: &EthereumAuth7702Entry| { &m.nonce },
+                |m: &mut EthereumAuth7702Entry| { &mut m.nonce },
+            ));
+            fields.push(::protobuf::reflect::rt::v2::make_message_field_accessor::<_, super::EthereumAuth7702Signature>(
+                "signature",
+                |m: &EthereumAuth7702Entry| { &m.signature },
+                |m: &mut EthereumAuth7702Entry| { &mut m.signature },
+            ));
+            ::protobuf::reflect::GeneratedMessageDescriptorData::new_2::<EthereumAuth7702Entry>(
+                "EthereumSignTxEIP1559.EthereumAuth7702Entry",
+                fields,
+                oneofs,
+            )
+        }
+    }
+
+    impl ::protobuf::Message for EthereumAuth7702Entry {
+        const NAME: &'static str = "EthereumAuth7702Entry";
+
+        fn is_initialized(&self) -> bool {
+            if self.chain_id.is_none() {
+                return false;
+            }
+            if self.delegate.is_none() {
+                return false;
+            }
+            if self.nonce.is_none() {
+                return false;
+            }
+            for v in &self.signature {
+                if !v.is_initialized() {
+                    return false;
+                }
+            };
+            true
+        }
+
+        fn merge_from(&mut self, is: &mut ::protobuf::CodedInputStream<'_>) -> ::protobuf::Result<()> {
+            while let Some(tag) = is.read_raw_tag_or_eof()? {
+                match tag {
+                    8 => {
+                        self.chain_id = ::std::option::Option::Some(is.read_uint64()?);
+                    },
+                    18 => {
+                        self.delegate = ::std::option::Option::Some(is.read_string()?);
+                    },
+                    24 => {
+                        self.nonce = ::std::option::Option::Some(is.read_uint64()?);
+                    },
+                    34 => {
+                        ::protobuf::rt::read_singular_message_into_field(is, &mut self.signature)?;
+                    },
+                    tag => {
+                        ::protobuf::rt::read_unknown_or_skip_group(tag, is, self.special_fields.mut_unknown_fields())?;
+                    },
+                };
+            }
+            ::std::result::Result::Ok(())
+        }
+
+        // Compute sizes of nested messages
+        #[allow(unused_variables)]
+        fn compute_size(&self) -> u64 {
+            let mut my_size = 0;
+            if let Some(v) = self.chain_id {
+                my_size += ::protobuf::rt::uint64_size(1, v);
+            }
+            if let Some(v) = self.delegate.as_ref() {
+                my_size += ::protobuf::rt::string_size(2, &v);
+            }
+            if let Some(v) = self.nonce {
+                my_size += ::protobuf::rt::uint64_size(3, v);
+            }
+            if let Some(v) = self.signature.as_ref() {
+                let len = v.compute_size();
+                my_size += 1 + ::protobuf::rt::compute_raw_varint64_size(len) + len;
+            }
+            my_size += ::protobuf::rt::unknown_fields_size(self.special_fields.unknown_fields());
+            self.special_fields.cached_size().set(my_size as u32);
+            my_size
+        }
+
+        fn write_to_with_cached_sizes(&self, os: &mut ::protobuf::CodedOutputStream<'_>) -> ::protobuf::Result<()> {
+            if let Some(v) = self.chain_id {
+                os.write_uint64(1, v)?;
+            }
+            if let Some(v) = self.delegate.as_ref() {
+                os.write_string(2, v)?;
+            }
+            if let Some(v) = self.nonce {
+                os.write_uint64(3, v)?;
+            }
+            if let Some(v) = self.signature.as_ref() {
+                ::protobuf::rt::write_message_field_with_cached_size(4, v, os)?;
+            }
+            os.write_unknown_fields(self.special_fields.unknown_fields())?;
+            ::std::result::Result::Ok(())
+        }
+
+        fn special_fields(&self) -> &::protobuf::SpecialFields {
+            &self.special_fields
+        }
+
+        fn mut_special_fields(&mut self) -> &mut ::protobuf::SpecialFields {
+            &mut self.special_fields
+        }
+
+        fn new() -> EthereumAuth7702Entry {
+            EthereumAuth7702Entry::new()
+        }
+
+        fn clear(&mut self) {
+            self.chain_id = ::std::option::Option::None;
+            self.delegate = ::std::option::Option::None;
+            self.nonce = ::std::option::Option::None;
+            self.signature.clear();
+            self.special_fields.clear();
+        }
+
+        fn default_instance() -> &'static EthereumAuth7702Entry {
+            static instance: EthereumAuth7702Entry = EthereumAuth7702Entry {
+                chain_id: ::std::option::Option::None,
+                delegate: ::std::option::Option::None,
+                nonce: ::std::option::Option::None,
+                signature: ::protobuf::MessageField::none(),
+                special_fields: ::protobuf::SpecialFields::new(),
+            };
+            &instance
+        }
+    }
+
+    impl ::protobuf::MessageFull for EthereumAuth7702Entry {
+        fn descriptor() -> ::protobuf::reflect::MessageDescriptor {
+            static descriptor: ::protobuf::rt::Lazy<::protobuf::reflect::MessageDescriptor> = ::protobuf::rt::Lazy::new();
+            descriptor.get(|| super::file_descriptor().message_by_package_relative_name("EthereumSignTxEIP1559.EthereumAuth7702Entry").unwrap()).clone()
+        }
+    }
+
+    impl ::std::fmt::Display for EthereumAuth7702Entry {
+        fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
+            ::protobuf::text_format::fmt(self, f)
+        }
+    }
+
+    impl ::protobuf::reflect::ProtobufValue for EthereumAuth7702Entry {
+        type RuntimeType = ::protobuf::reflect::rt::RuntimeTypeMessage<Self>;
+    }
 }
 
 // @@protoc_insertion_point(message:hw.trezor.messages.ethereum.EthereumTxRequest)
@@ -2522,6 +2811,8 @@ pub struct EthereumTxRequest {
     pub signature_r: ::std::option::Option<::std::vec::Vec<u8>>,
     // @@protoc_insertion_point(field:hw.trezor.messages.ethereum.EthereumTxRequest.signature_s)
     pub signature_s: ::std::option::Option<::std::vec::Vec<u8>>,
+    // @@protoc_insertion_point(field:hw.trezor.messages.ethereum.EthereumTxRequest.auth_list)
+    pub auth_list: ::std::vec::Vec<EthereumAuth7702Signature>,
     // special fields
     // @@protoc_insertion_point(special_field:hw.trezor.messages.ethereum.EthereumTxRequest.special_fields)
     pub special_fields: ::protobuf::SpecialFields,
@@ -2649,7 +2940,7 @@ impl EthereumTxRequest {
     }
 
     fn generated_message_descriptor_data() -> ::protobuf::reflect::GeneratedMessageDescriptorData {
-        let mut fields = ::std::vec::Vec::with_capacity(4);
+        let mut fields = ::std::vec::Vec::with_capacity(5);
         let mut oneofs = ::std::vec::Vec::with_capacity(0);
         fields.push(::protobuf::reflect::rt::v2::make_option_accessor::<_, _>(
             "data_length",
@@ -2671,6 +2962,11 @@ impl EthereumTxRequest {
             |m: &EthereumTxRequest| { &m.signature_s },
             |m: &mut EthereumTxRequest| { &mut m.signature_s },
         ));
+        fields.push(::protobuf::reflect::rt::v2::make_vec_simpler_accessor::<_, _>(
+            "auth_list",
+            |m: &EthereumTxRequest| { &m.auth_list },
+            |m: &mut EthereumTxRequest| { &mut m.auth_list },
+        ));
         ::protobuf::reflect::GeneratedMessageDescriptorData::new_2::<EthereumTxRequest>(
             "EthereumTxRequest",
             fields,
@@ -2683,6 +2979,11 @@ impl ::protobuf::Message for EthereumTxRequest {
     const NAME: &'static str = "EthereumTxRequest";
 
     fn is_initialized(&self) -> bool {
+        for v in &self.auth_list {
+            if !v.is_initialized() {
+                return false;
+            }
+        };
         true
     }
 
@@ -2700,6 +3001,9 @@ impl ::protobuf::Message for EthereumTxRequest {
                 },
                 34 => {
                     self.signature_s = ::std::option::Option::Some(is.read_bytes()?);
+                },
+                42 => {
+                    self.auth_list.push(is.read_message()?);
                 },
                 tag => {
                     ::protobuf::rt::read_unknown_or_skip_group(tag, is, self.special_fields.mut_unknown_fields())?;
@@ -2725,6 +3029,10 @@ impl ::protobuf::Message for EthereumTxRequest {
         if let Some(v) = self.signature_s.as_ref() {
             my_size += ::protobuf::rt::bytes_size(4, &v);
         }
+        for value in &self.auth_list {
+            let len = value.compute_size();
+            my_size += 1 + ::protobuf::rt::compute_raw_varint64_size(len) + len;
+        };
         my_size += ::protobuf::rt::unknown_fields_size(self.special_fields.unknown_fields());
         self.special_fields.cached_size().set(my_size as u32);
         my_size
@@ -2743,6 +3051,9 @@ impl ::protobuf::Message for EthereumTxRequest {
         if let Some(v) = self.signature_s.as_ref() {
             os.write_bytes(4, v)?;
         }
+        for v in &self.auth_list {
+            ::protobuf::rt::write_message_field_with_cached_size(5, v, os)?;
+        };
         os.write_unknown_fields(self.special_fields.unknown_fields())?;
         ::std::result::Result::Ok(())
     }
@@ -2764,6 +3075,7 @@ impl ::protobuf::Message for EthereumTxRequest {
         self.signature_v = ::std::option::Option::None;
         self.signature_r = ::std::option::Option::None;
         self.signature_s = ::std::option::Option::None;
+        self.auth_list.clear();
         self.special_fields.clear();
     }
 
@@ -2773,6 +3085,7 @@ impl ::protobuf::Message for EthereumTxRequest {
             signature_v: ::std::option::Option::None,
             signature_r: ::std::option::Option::None,
             signature_s: ::std::option::Option::None,
+            auth_list: ::std::vec::Vec::new(),
             special_fields: ::protobuf::SpecialFields::new(),
         };
         &instance
@@ -5482,7 +5795,7 @@ static file_descriptor_proto_data: &'static [u8] = b"\
     \x12\x1a\n\x08chunkify\x18\r\x20\x01(\x08R\x08chunkify\x12J\n\x0bpayment\
     _req\x18\x0e\x20\x01(\x0b2).hw.trezor.messages.common.PaymentRequestR\np\
     aymentReq\x12>\n\x1bsupports_definition_request\x18\x0f\x20\x01(\x08R\
-    \x19supportsDefinitionRequest\"\xfc\x05\n\x15EthereumSignTxEIP1559\x12\
+    \x19supportsDefinitionRequest\"\xac\x08\n\x15EthereumSignTxEIP1559\x12\
     \x1b\n\taddress_n\x18\x01\x20\x03(\rR\x08addressN\x12\x14\n\x05nonce\x18\
     \x02\x20\x02(\x0cR\x05nonce\x12\x1e\n\x0bmax_gas_fee\x18\x03\x20\x02(\
     \x0cR\tmaxGasFee\x12(\n\x10max_priority_fee\x18\x04\x20\x02(\x0cR\x0emax\
@@ -5497,47 +5810,55 @@ static file_descriptor_proto_data: &'static [u8] = b"\
     nitions\x12\x1a\n\x08chunkify\x18\r\x20\x01(\x08R\x08chunkify\x12J\n\x0b\
     payment_req\x18\x0e\x20\x01(\x0b2).hw.trezor.messages.common.PaymentRequ\
     estR\npaymentReq\x12>\n\x1bsupports_definition_request\x18\x0f\x20\x01(\
-    \x08R\x19supportsDefinitionRequest\x1aQ\n\x12EthereumAccessList\x12\x18\
-    \n\x07address\x18\x01\x20\x02(\tR\x07address\x12!\n\x0cstorage_keys\x18\
-    \x02\x20\x03(\x0cR\x0bstorageKeys\"\x97\x01\n\x11EthereumTxRequest\x12\
-    \x1f\n\x0bdata_length\x18\x01\x20\x01(\rR\ndataLength\x12\x1f\n\x0bsigna\
-    ture_v\x18\x02\x20\x01(\rR\nsignatureV\x12\x1f\n\x0bsignature_r\x18\x03\
-    \x20\x01(\x0cR\nsignatureR\x12\x1f\n\x0bsignature_s\x18\x04\x20\x01(\x0c\
-    R\nsignatureS\".\n\rEthereumTxAck\x12\x1d\n\ndata_chunk\x18\x01\x20\x02(\
-    \x0cR\tdataChunk\"v\n\x19EthereumDefinitionRequest\x12\x19\n\x08chain_id\
-    \x18\x01\x20\x02(\x04R\x07chainId\x12#\n\rtoken_address\x18\x02\x20\x02(\
-    \x0cR\x0ctokenAddress\x12\x19\n\x08func_sig\x18\x03\x20\x01(\x0cR\x07fun\
-    cSig\"k\n\x15EthereumDefinitionAck\x12R\n\x0bdefinitions\x18\x01\x20\x01\
-    (\x0b20.hw.trezor.messages.ethereum.EthereumDefinitionsR\x0bdefinitions\
-    \"\x91\x01\n\x13EthereumSignMessage\x12\x1b\n\taddress_n\x18\x01\x20\x03\
-    (\rR\x08addressN\x12\x18\n\x07message\x18\x02\x20\x02(\x0cR\x07message\
-    \x12'\n\x0fencoded_network\x18\x03\x20\x01(\x0cR\x0eencodedNetwork\x12\
-    \x1a\n\x08chunkify\x18\x04\x20\x01(\x08R\x08chunkify\"R\n\x18EthereumMes\
-    sageSignature\x12\x1c\n\tsignature\x18\x02\x20\x02(\x0cR\tsignature\x12\
-    \x18\n\x07address\x18\x03\x20\x02(\tR\x07address\"\x85\x01\n\x15Ethereum\
-    VerifyMessage\x12\x1c\n\tsignature\x18\x02\x20\x02(\x0cR\tsignature\x12\
-    \x18\n\x07message\x18\x03\x20\x02(\x0cR\x07message\x12\x18\n\x07address\
-    \x18\x04\x20\x02(\tR\x07address\x12\x1a\n\x08chunkify\x18\x05\x20\x01(\
-    \x08R\x08chunkify\"\xb4\x01\n\x15EthereumSignTypedHash\x12\x1b\n\taddres\
-    s_n\x18\x01\x20\x03(\rR\x08addressN\x122\n\x15domain_separator_hash\x18\
-    \x02\x20\x02(\x0cR\x13domainSeparatorHash\x12!\n\x0cmessage_hash\x18\x03\
-    \x20\x01(\x0cR\x0bmessageHash\x12'\n\x0fencoded_network\x18\x04\x20\x01(\
-    \x0cR\x0eencodedNetwork\"T\n\x1aEthereumTypedDataSignature\x12\x1c\n\tsi\
-    gnature\x18\x01\x20\x02(\x0cR\tsignature\x12\x18\n\x07address\x18\x02\
-    \x20\x02(\tR\x07address\"\x99\x01\n\x13EthereumDefinitions\x12'\n\x0fenc\
-    oded_network\x18\x01\x20\x01(\x0cR\x0eencodedNetwork\x12#\n\rencoded_tok\
-    en\x18\x02\x20\x01(\x0cR\x0cencodedToken\x124\n\x16encoded_display_forma\
-    t\x18\x03\x20\x01(\x0cR\x14encodedDisplayFormat\"\xda\x01\n\x14EthereumS\
-    ignAuth7702\x12\x1b\n\taddress_n\x18\x01\x20\x03(\rR\x08addressN\x12\x19\
-    \n\x08chain_id\x18\x02\x20\x02(\x04R\x07chainId\x12\x1a\n\x08delegate\
-    \x18\x03\x20\x02(\tR\x08delegate\x12\x14\n\x05nonce\x18\x04\x20\x02(\x04\
-    R\x05nonce\x12R\n\x0bdefinitions\x18\x05\x20\x01(\x0b20.hw.trezor.messag\
-    es.ethereum.EthereumDefinitionsR\x0bdefinitions:\x04\x88\xb2\x19\x01\"\
-    \x84\x01\n\x19EthereumAuth7702Signature\x12\x1f\n\x0bsignature_v\x18\x01\
-    \x20\x02(\rR\nsignatureV\x12\x1f\n\x0bsignature_r\x18\x02\x20\x02(\x0cR\
-    \nsignatureR\x12\x1f\n\x0bsignature_s\x18\x03\x20\x02(\x0cR\nsignatureS:\
-    \x04\x88\xb2\x19\x01B<\n#com.satoshilabs.trezor.lib.protobufB\x15TrezorM\
-    essageEthereum\
+    \x08R\x19supportsDefinitionRequest\x12k\n\tauth_list\x18\x10\x20\x03(\
+    \x0b2H.hw.trezor.messages.ethereum.EthereumSignTxEIP1559.EthereumAuth770\
+    2EntryR\x08authListB\x04\xc8\xf0\x19\x01\x1aQ\n\x12EthereumAccessList\
+    \x12\x18\n\x07address\x18\x01\x20\x02(\tR\x07address\x12!\n\x0cstorage_k\
+    eys\x18\x02\x20\x03(\x0cR\x0bstorageKeys\x1a\xc0\x01\n\x15EthereumAuth77\
+    02Entry\x12\x19\n\x08chain_id\x18\x01\x20\x02(\x04R\x07chainId\x12\x1a\n\
+    \x08delegate\x18\x02\x20\x02(\tR\x08delegate\x12\x14\n\x05nonce\x18\x03\
+    \x20\x02(\x04R\x05nonce\x12T\n\tsignature\x18\x04\x20\x01(\x0b26.hw.trez\
+    or.messages.ethereum.EthereumAuth7702SignatureR\tsignature:\x04\x88\xb2\
+    \x19\x01\"\xec\x01\n\x11EthereumTxRequest\x12\x1f\n\x0bdata_length\x18\
+    \x01\x20\x01(\rR\ndataLength\x12\x1f\n\x0bsignature_v\x18\x02\x20\x01(\r\
+    R\nsignatureV\x12\x1f\n\x0bsignature_r\x18\x03\x20\x01(\x0cR\nsignatureR\
+    \x12\x1f\n\x0bsignature_s\x18\x04\x20\x01(\x0cR\nsignatureS\x12S\n\tauth\
+    _list\x18\x05\x20\x03(\x0b26.hw.trezor.messages.ethereum.EthereumAuth770\
+    2SignatureR\x08authList\".\n\rEthereumTxAck\x12\x1d\n\ndata_chunk\x18\
+    \x01\x20\x02(\x0cR\tdataChunk\"v\n\x19EthereumDefinitionRequest\x12\x19\
+    \n\x08chain_id\x18\x01\x20\x02(\x04R\x07chainId\x12#\n\rtoken_address\
+    \x18\x02\x20\x02(\x0cR\x0ctokenAddress\x12\x19\n\x08func_sig\x18\x03\x20\
+    \x01(\x0cR\x07funcSig\"k\n\x15EthereumDefinitionAck\x12R\n\x0bdefinition\
+    s\x18\x01\x20\x01(\x0b20.hw.trezor.messages.ethereum.EthereumDefinitions\
+    R\x0bdefinitions\"\x91\x01\n\x13EthereumSignMessage\x12\x1b\n\taddress_n\
+    \x18\x01\x20\x03(\rR\x08addressN\x12\x18\n\x07message\x18\x02\x20\x02(\
+    \x0cR\x07message\x12'\n\x0fencoded_network\x18\x03\x20\x01(\x0cR\x0eenco\
+    dedNetwork\x12\x1a\n\x08chunkify\x18\x04\x20\x01(\x08R\x08chunkify\"R\n\
+    \x18EthereumMessageSignature\x12\x1c\n\tsignature\x18\x02\x20\x02(\x0cR\
+    \tsignature\x12\x18\n\x07address\x18\x03\x20\x02(\tR\x07address\"\x85\
+    \x01\n\x15EthereumVerifyMessage\x12\x1c\n\tsignature\x18\x02\x20\x02(\
+    \x0cR\tsignature\x12\x18\n\x07message\x18\x03\x20\x02(\x0cR\x07message\
+    \x12\x18\n\x07address\x18\x04\x20\x02(\tR\x07address\x12\x1a\n\x08chunki\
+    fy\x18\x05\x20\x01(\x08R\x08chunkify\"\xb4\x01\n\x15EthereumSignTypedHas\
+    h\x12\x1b\n\taddress_n\x18\x01\x20\x03(\rR\x08addressN\x122\n\x15domain_\
+    separator_hash\x18\x02\x20\x02(\x0cR\x13domainSeparatorHash\x12!\n\x0cme\
+    ssage_hash\x18\x03\x20\x01(\x0cR\x0bmessageHash\x12'\n\x0fencoded_networ\
+    k\x18\x04\x20\x01(\x0cR\x0eencodedNetwork\"T\n\x1aEthereumTypedDataSigna\
+    ture\x12\x1c\n\tsignature\x18\x01\x20\x02(\x0cR\tsignature\x12\x18\n\x07\
+    address\x18\x02\x20\x02(\tR\x07address\"\x99\x01\n\x13EthereumDefinition\
+    s\x12'\n\x0fencoded_network\x18\x01\x20\x01(\x0cR\x0eencodedNetwork\x12#\
+    \n\rencoded_token\x18\x02\x20\x01(\x0cR\x0cencodedToken\x124\n\x16encode\
+    d_display_format\x18\x03\x20\x01(\x0cR\x14encodedDisplayFormat\"\xda\x01\
+    \n\x14EthereumSignAuth7702\x12\x1b\n\taddress_n\x18\x01\x20\x03(\rR\x08a\
+    ddressN\x12\x19\n\x08chain_id\x18\x02\x20\x02(\x04R\x07chainId\x12\x1a\n\
+    \x08delegate\x18\x03\x20\x02(\tR\x08delegate\x12\x14\n\x05nonce\x18\x04\
+    \x20\x02(\x04R\x05nonce\x12R\n\x0bdefinitions\x18\x05\x20\x01(\x0b20.hw.\
+    trezor.messages.ethereum.EthereumDefinitionsR\x0bdefinitions:\x04\x88\
+    \xb2\x19\x01\"\x84\x01\n\x19EthereumAuth7702Signature\x12\x1f\n\x0bsigna\
+    ture_v\x18\x01\x20\x02(\rR\nsignatureV\x12\x1f\n\x0bsignature_r\x18\x02\
+    \x20\x02(\x0cR\nsignatureR\x12\x1f\n\x0bsignature_s\x18\x03\x20\x02(\x0c\
+    R\nsignatureS:\x04\x88\xb2\x19\x01B<\n#com.satoshilabs.trezor.lib.protob\
+    ufB\x15TrezorMessageEthereum\
 ";
 
 /// `FileDescriptorProto` object which was a source for this generated file
@@ -5557,7 +5878,7 @@ pub fn file_descriptor() -> &'static ::protobuf::reflect::FileDescriptor {
             let mut deps = ::std::vec::Vec::with_capacity(2);
             deps.push(super::messages_common::file_descriptor().clone());
             deps.push(super::options::file_descriptor().clone());
-            let mut messages = ::std::vec::Vec::with_capacity(19);
+            let mut messages = ::std::vec::Vec::with_capacity(20);
             messages.push(EthereumGetPublicKey::generated_message_descriptor_data());
             messages.push(EthereumPublicKey::generated_message_descriptor_data());
             messages.push(EthereumGetAddress::generated_message_descriptor_data());
@@ -5577,6 +5898,7 @@ pub fn file_descriptor() -> &'static ::protobuf::reflect::FileDescriptor {
             messages.push(EthereumSignAuth7702::generated_message_descriptor_data());
             messages.push(EthereumAuth7702Signature::generated_message_descriptor_data());
             messages.push(ethereum_sign_tx_eip1559::EthereumAccessList::generated_message_descriptor_data());
+            messages.push(ethereum_sign_tx_eip1559::EthereumAuth7702Entry::generated_message_descriptor_data());
             let mut enums = ::std::vec::Vec::with_capacity(0);
             ::protobuf::reflect::GeneratedFileDescriptor::new_generated(
                 file_descriptor_proto(),


### PR DESCRIPTION
Cherry-picked from https://github.com/trezor/trezor-firmware/pull/4945/changes/296ec3e9835879b3cbfd267aaed883745b683d1e.

Mark them as experimental for now.

- the host can ask the device to sign authorization tuple(s) by not setting `EthereumAuth7702Entry.signature`.

- the device will send all tuple-related signatures in `EthereumTxRequest.auth_list`, so the host will be able to serialize the signed transaction.

