### PR TITLE
refactor(core/ethereum): encapsulate calldata preload/confirm

### DIFF
--- a/core/src/apps/ethereum/clear_signing.py
+++ b/core/src/apps/ethereum/clear_signing.py
@@ -1316,7 +1316,7 @@ async def _expand_one_subcall(
 
 
 async def try_confirm(
-    data: AnyBytes,
+    calldata: memoryview,
     address_bytes: bytes,
     msg: MsgInSignTx,
     defs: Definitions,
@@ -1332,10 +1332,10 @@ async def try_confirm(
     if not address_bytes:
         return False
 
-    if len(data) < SC_FUNC_SIG_BYTES:
+    if len(calldata) < SC_FUNC_SIG_BYTES:
         return False
 
-    func_sig = bytes(data[0:SC_FUNC_SIG_BYTES])
+    func_sig = bytes(calldata[0:SC_FUNC_SIG_BYTES])
 
     display_format = await _find_display_format(func_sig, address_bytes, msg)
     if display_format is None:
@@ -1347,7 +1347,7 @@ async def try_confirm(
     ):
         raise DataError("Payment Requests only supported for ERC-20 transfers.")
 
-    calldata = memoryview(data)[SC_FUNC_SIG_BYTES:]
+    calldata = calldata[SC_FUNC_SIG_BYTES:]
 
     # custom treatment of certain functions (APPROVE, TRANSFER)
     if display_format.func_sig == APPROVE_DISPLAY_FORMAT.func_sig:

--- a/core/src/apps/ethereum/sign_tx.py
+++ b/core/src/apps/ethereum/sign_tx.py
@@ -91,11 +91,11 @@ async def sign_tx(
     for field in (msg.nonce, msg.gas_price, msg.gas_limit, address_bytes, msg.value):
         rlp.write(sha, field)
 
-    initial_data = await request_initial_data(msg, sha)
+    calldata = await preload_calldata(msg, sha)
 
     # Confirm the transaction, using special layouts for staking, yielding and clear-signing (if supported).
     await confirm_tx_data(
-        initial_data,
+        calldata,
         msg,
         defs,
         address_bytes,
@@ -125,7 +125,30 @@ _MAX_DATA_STORED = const(6144)
 _DATA_CHUNK_SIZE = const(1024)
 
 
-async def request_initial_data(msg: MsgInSignTx, sha: HashWriter) -> AnyBytes:
+class Calldata:
+    def __init__(self, init: memoryview, length: int) -> None:
+        self._init = init
+        self.length = length  # total length
+        self.preloaded = init if len(init) == length else None
+
+    async def confirm(self, data_chunk_loader: DataChunkLoader) -> None:
+        if self.length > 0:
+            from .helpers import DataChunkConfirmer
+
+            data_chunk_confirmer = DataChunkConfirmer(self.length)
+            await data_chunk_confirmer.confirm(self._init)
+            data_left = self.length - len(self._init)
+            while data_left > 0:
+                chunk = await data_chunk_loader(data_left)
+                # `data_chunk_confirmer.confirm` will raise on cancellation,
+                # so `data_chunk_loader`-computed hash will be discarded.
+                await data_chunk_confirmer.confirm(chunk)
+                data_left -= len(chunk)
+
+            await data_chunk_confirmer.confirm_digest()
+
+
+async def preload_calldata(msg: MsgInSignTx, sha: HashWriter) -> Calldata:
     """Request at most `MAX_DATA_STORED` which we keep locally"""
     from trezor.utils import empty_bytearray
 
@@ -143,11 +166,11 @@ async def request_initial_data(msg: MsgInSignTx, sha: HashWriter) -> AnyBytes:
 
     rlp.write_header(sha, data_length, rlp.STRING_HEADER_BYTE, buf)
     sha.extend(buf)
-    return buf
+    return Calldata(memoryview(buf), msg.data_length)
 
 
 async def confirm_tx_data(
-    initial_data: AnyBytes,
+    calldata: Calldata,
     msg: MsgInSignTx,
     defs: Definitions,
     address_bytes: bytes,
@@ -164,36 +187,39 @@ async def confirm_tx_data(
     from .layout import require_confirm_payment_request, require_confirm_tx
 
     # local_cache_attribute
-    data_length = msg.data_length
     network = defs.network
+    preloaded = calldata.preloaded
 
+    # Try to match staking:
     staking_approver = staking.get_approver(
-        msg, network, address_bytes, maximum_fee, fee_items
+        preloaded, msg, network, address_bytes, maximum_fee, fee_items
     )
     if staking_approver is not None:
         if payment_request_verifier is not None:
             raise DataError("Payment Requests don't support staking")
+        # confirm and return
         return await staking_approver
 
+    # Try to match yielding:
     yielding_approver = await yielding.get_approver(
-        msg, initial_data, network, address_bytes, maximum_fee, fee_items, sender_bytes
+        preloaded, msg, network, address_bytes, maximum_fee, fee_items, sender_bytes
     )
     if yielding_approver is not None:
         if payment_request_verifier is not None:
             raise DataError("Payment Requests don't support yielding")
+        # confirm and return
         return await yielding_approver
 
-    value = int.from_bytes(msg.value, "big")
-
-    if len(initial_data) < data_length:
+    if preloaded is None:
         # Don't even attempt to clear sign if we have a calldata larger than `MAX_DATA_STORED`.
         # this is because clear signing doesn't currently support fetching additional data,
         # which is because if it did, we would not be able to fall back to blind signing anymore.
         clear_signed = False
     else:
+        # Try to match clear-signing:
         try:
             clear_signed = await clear_signing.try_confirm(
-                initial_data,
+                preloaded,
                 address_bytes,
                 msg,
                 defs,
@@ -208,8 +234,10 @@ async def confirm_tx_data(
         address_from_bytes(address_bytes, network) if address_bytes else None
     )
 
+    value = int.from_bytes(msg.value, "big")
+
     if payment_request_verifier is not None:
-        if data_length != 0:
+        if calldata.length != 0:
             raise DataError(
                 "Data length must be 0 when `payment_request_verifier` is provided."
             )
@@ -235,13 +263,8 @@ async def confirm_tx_data(
             None,
         )
     elif not clear_signed:
-        if data_length > 0:
-            # Stream, confirm and hash the rest of the calldata chunks.
-            await _confirm_data_chunks(
-                initial_data,
-                data_length,
-                data_chunk_loader,
-            )
+        # Stream, confirm and hash the rest of the calldata chunks.
+        await calldata.confirm(data_chunk_loader)
         # what we want to confirm here is the ETH amount being sent on-chain
         token = None
         return await require_confirm_tx(
@@ -252,7 +275,7 @@ async def confirm_tx_data(
             maximum_fee,
             fee_items,
             token,
-            is_send=(data_length == 0),
+            is_send=(calldata.length == 0),
             chunkify=bool(msg.chunkify),
         )
 
@@ -289,26 +312,6 @@ def create_data_chunk_loader(h: HashWriter) -> DataChunkLoader:
         return chunk
 
     return data_chunk_loader
-
-
-async def _confirm_data_chunks(
-    initial_data: AnyBytes,
-    data_length: int,
-    data_chunk_loader: DataChunkLoader,
-) -> None:
-    from .helpers import DataChunkConfirmer
-
-    data_chunk_confirmer = DataChunkConfirmer(data_length)
-    await data_chunk_confirmer.confirm(initial_data)
-    data_left = data_length - len(initial_data)
-    while data_left > 0:
-        chunk = await data_chunk_loader(data_left)
-        # `data_chunk_confirmer.confirm` will raise on cancellation,
-        # so `data_chunk_loader`-computed hash will be discarded.
-        await data_chunk_confirmer.confirm(chunk)
-        data_left -= len(chunk)
-
-    await data_chunk_confirmer.confirm_digest()
 
 
 async def _get_next_chunk(data_left: int) -> AnyBytes:

--- a/core/src/apps/ethereum/sign_tx_eip1559.py
+++ b/core/src/apps/ethereum/sign_tx_eip1559.py
@@ -46,7 +46,7 @@ async def sign_tx_eip1559(
         check_common_fields,
         confirm_tx_data,
         create_data_chunk_loader,
-        request_initial_data,
+        preload_calldata,
     )
 
     gas_limit = msg.gas_limit  # local_cache_attribute
@@ -101,11 +101,11 @@ async def sign_tx_eip1559(
     for field in fields:
         rlp.write(sha, field)
 
-    initial_data = await request_initial_data(msg, sha)
+    calldata = await preload_calldata(msg, sha)
 
     # Confirm the transaction, using special layouts for staking, yielding and clear-signing (if supported).
     await confirm_tx_data(
-        initial_data,
+        calldata,
         msg,
         defs,
         address_bytes,

--- a/core/src/apps/ethereum/staking.py
+++ b/core/src/apps/ethereum/staking.py
@@ -29,6 +29,7 @@ ADDRESSES_ACCOUNTING = (
 
 
 def get_approver(
+    calldata: memoryview | None,
     msg: MsgInSignTx,
     network: EthereumNetworkInfo,
     address_bytes: bytes,
@@ -41,16 +42,13 @@ def get_approver(
     `None` is returned for non-staking related transactions.
     """
 
-    from .clear_signing import SC_FUNC_SIG_BYTES
-
-    # local_cache_attribute
-    data_length = msg.data_length
-
-    if data_length > len(msg.data_initial_chunk):
+    if calldata is None:
         return None
 
+    from .clear_signing import SC_FUNC_SIG_BYTES
+
     # No more data should be loaded from host:
-    data_reader = BufferReader(msg.data_initial_chunk)
+    data_reader = BufferReader(calldata)
     if data_reader.remaining_count() < SC_FUNC_SIG_BYTES:
         return None
 

--- a/core/src/apps/ethereum/yielding.py
+++ b/core/src/apps/ethereum/yielding.py
@@ -85,8 +85,8 @@ CLAIM_DISPLAY_FORMAT = DisplayFormat(
 
 
 async def get_approver(
+    calldata: memoryview | None,
     msg: MsgInSignTx,
-    initial_data: AnyBytes,
     network: EthereumNetworkInfo,
     address_bytes: AnyBytes,
     maximum_fee: str,
@@ -94,19 +94,19 @@ async def get_approver(
     sender_bytes: AnyBytes,
 ) -> Coroutine[Any, Any, None] | None:
 
-    from .clear_signing import SC_FUNC_SIG_BYTES
-
-    if msg.data_length > len(initial_data):
+    if calldata is None:
         return None
 
+    from .clear_signing import SC_FUNC_SIG_BYTES
+
     # No more data should be loaded from host:
-    if len(initial_data) < SC_FUNC_SIG_BYTES:
+    if len(calldata) < SC_FUNC_SIG_BYTES:
         return None
 
     vault = lookup_vault(network, address_bytes)
 
-    func_sig = bytes(initial_data[:SC_FUNC_SIG_BYTES])
-    calldata = memoryview(initial_data)[SC_FUNC_SIG_BYTES:]
+    func_sig = bytes(calldata[:SC_FUNC_SIG_BYTES])
+    calldata = calldata[SC_FUNC_SIG_BYTES:]
 
     handler = None
     if func_sig == FUNC_SIG_DEPOSIT:


### PR DESCRIPTION
Let's consolidate the comparisons of `len(initial_data)` and `msg.data_length`.

This PR introduces `Calldata` class, allowing its users to access an optional `preloaded` prefix (if it fits), and confirming its contents if clear-signing is not possible.