### PR TITLE
fix(rust/trezor-thp): channel desync after duplicate ACK

### DIFF
--- a/rust/trezor-thp/src/alternating_bit.rs
+++ b/rust/trezor-thp/src/alternating_bit.rs
@@ -112,12 +112,14 @@ impl ChannelSync {
         self.can_send = false;
     }
 
-    /// Call after receiving an ACK message.
-    pub fn send_mark_delivered(&mut self, sb: SyncBits) {
+    /// Call after receiving an ACK message. Return true if its ACK bit was correct.
+    pub fn send_mark_delivered(&mut self, sb: SyncBits) -> bool {
         if self.sync_send == sb.ack_bit() {
             self.sync_send.increment();
             self.can_send = true;
+            return true;
         }
+        false
     }
 
     /// Call after receving initial fragment of a message.

--- a/rust/trezor-thp/src/channel/mod.rs
+++ b/rust/trezor-thp/src/channel/mod.rs
@@ -353,10 +353,11 @@ impl<R: Role, B: Backend> Channel<R, B> {
             // Verify checksum.
             let _ = Reassembler::<R>::single(packet_buffer)?;
             let sb = SyncBits::try_from(packet_buffer)?;
-            self.sync.send_mark_delivered(sb);
-            if self.sync.can_send() {
+            if self.sync.send_mark_delivered(sb) {
                 self.send_state = SendState::Idle;
                 return Ok(());
+            } else {
+                log::warn!("[{:04x}] Unexpected ACK bit.", self.channel_id);
             }
         }
         log::warn!("[{:04x}] Unexpected ACK.", self.channel_id);
@@ -447,8 +448,7 @@ impl<R: Role, B: Backend> Channel<R, B> {
                 && self.sync.is_ack_piggybacking_allowed()
                 && !self.sync.can_send()
             {
-                self.sync.send_mark_delivered(reassembler.sync_bits());
-                if self.sync.can_send() {
+                if self.sync.send_mark_delivered(reassembler.sync_bits()) {
                     ack_received = true;
                     self.send_state = SendState::Idle;
                 } else {


### PR DESCRIPTION
Fixes the following scenario which seems to happen fairly often when trying to run device tests over BLE:

```
trezorlib                                            firmware
          (piggybacking enabled)
          ...
          <-- handshake_init_response
          (timeout)
          <-- handshake_init_response (retry)
          --> ACK
          --> handshake_completion_request
          (firmware prepares to send handshake_completion_response)
          --> ACK (of retry)
          --> handshake_completion_request (retry)
          --> handshake_completion_request (retry)
          --> handshake_completion_request (retry)
          ...
          (firmware considers handshake_completion_response delivered despite bad ACK bit)
```
Trezorlib is sending standalone ACK because there are no active contexts.
<!--
For external contributors:
- Please open an issue before submitting a PR so we can discuss whether we want to proceed with it.

For core developers:
1. Initial PR setup
- Assign yourself to the PR.
- Add it to the "Firmware" project
  - Set Priority (match issue priority if it exists)
  - Set Team
  - Set Sprint (target release)

2. Development status
- Draft PRs: Set status to "In Progress"
- Final PRs: Set status to "Needs Review"

3. Post-merge status
- Testable: Set status to "Needs QA" and add a `Notes for QA` section with clear instructions on how to test the functionality.
- Not Testable: Set status to "Done (no QA)"
-->
