### PR TITLE
ci(core): check symbols at ELF files

### DIFF
--- a/.github/workflows/core.yml
+++ b/.github/workflows/core.yml
@@ -95,6 +95,10 @@ jobs:
       # - run: nix-shell --run "uv run ./tools/print-rust-type-sizes.sh core/build/firmware/rust-type-sizes.log" | awk '$1 >= 1000' | sort -k1 -n
       - run: nix-shell --run "uv run ./tools/check-bitcoin-only core/build-xtask/artifacts/latest/firmware.bin"
         if: matrix.coins == 'btconly' && matrix.type != 'debuglink'
+
+      # this check must pass on normal ELFs, and fail on debug ELFs:
+      - run: nix-shell --run "${{ matrix.type == 'debuglink' && '!' || '' }} ./tools/check-symbols.sh core/build-xtask/artifacts/latest/*.elf"
+
       - uses: actions/upload-artifact@bbbca2ddaa5d8feaa63e36b76fdaad77386f024f  # actions/upload-artifact@v7.0.0
         with:
           name: core-firmware-${{ matrix.model }}-${{ matrix.coins }}-${{ matrix.type }}${{ matrix.n4w1 && '-n4w1' || '' }}

--- a/tools/check-symbols.sh
+++ b/tools/check-symbols.sh
@@ -1,0 +1,19 @@
+#!/usr/bin/env bash
+
+set -eu
+
+trap 'echo "🔴 FAILED"' EXIT
+
+if [ $# -eq 0 ]; then
+    echo "No ELF files specified"
+    exit 1
+fi
+
+for ELF in $@
+do
+    echo "🔵 $ELF"
+    arm-none-eabi-nm --line-numbers "$ELF" > "$ELF.symbols"
+    grep -E 'insecure|random_reseed|debug' "$ELF.symbols" --color && exit 1
+done
+
+trap 'echo "🟢 OK"' EXIT


### PR DESCRIPTION
The excluded symbols appear in emulator debug builds:
```
$ nm --line-number core/build-xtask/debug/unix | grep "insecure"
0000000000373560 T random_buffer	/home/rzeyde/src/trezor-firmware/core/vendor/trezor-crypto/rand_insecure.c:42
0000000000373520 T random_reseed	/home/rzeyde/src/trezor-firmware/core/vendor/trezor-crypto/rand_insecure.c:33
0000000000689528 b seed	/home/rzeyde/src/trezor-firmware/core/vendor/trezor-crypto/rand_insecure.c:31

$ nm --line-number core/build-xtask/debug/unix | grep "random_reseed"
00000000003973c8 T mod_trezorcrypto_random_reseed	/home/rzeyde/src/trezor-firmware/core/embed/upymod/modtrezorcrypto/modtrezorcrypto-random.h:103
0000000000606ff0 D mod_trezorcrypto_random_reseed_obj	/home/rzeyde/src/trezor-firmware/core/embed/upymod/modtrezorcrypto/modtrezorcrypto-random.h:107
0000000000373520 T random_reseed	/home/rzeyde/src/trezor-firmware/core/vendor/trezor-crypto/rand_insecure.c:33

$ nm --line-number core/build-xtask/debug/unix | grep "debug"
0000000000682fa0 b button_debug	/home/rzeyde/src/trezor-firmware/core/embed/io/button/button_debug.c:38
000000000033b157 T button_debug_deinit	/home/rzeyde/src/trezor-firmware/core/embed/io/button/button_debug.c:47
000000000033b218 T button_debug_get_state	/home/rzeyde/src/trezor-firmware/core/embed/io/button/button_debug.c:92
000000000033b0fd T button_debug_init	/home/rzeyde/src/trezor-firmware/core/embed/io/button/button_debug.c:40
000000000033b196 T button_debug_next	/home/rzeyde/src/trezor-firmware/core/embed/io/button/button_debug.c:76
000000000066f060 D compressed_string_data	/home/rzeyde/src/trezor-firmware/core/embed/upymod/../../build-xtask/debug/build/upymod-f7ded83e2862dd3c/out/genhdr/compressed.data.h:2
0000000000684d40 b debug_iface_buffer.2	/home/rzeyde/src/trezor-firmware/core/embed/io/usb/usb_config.c:137
00000000004a2d40 T protobuf_debug_msg_def_type	/home/rzeyde/src/trezor-firmware/core/embed/rust/src/protobuf/obj.rs:284
00000000004a2d50 T protobuf_debug_msg_type	/home/rzeyde/src/trezor-firmware/core/embed/rust/src/protobuf/obj.rs:279
00000000004bf4b0 T _RINvMNtCsbIC2BzoNb4A_4core6resultINtB3_6ResultNtNtNtCs1gl0sGltAyE_10trezor_lib11micropython3ffi8mp_obj_tNtNtBO_5error5ErrorE14unwrap_or_elseNCINvNtBM_4util12try_or_raiseBI_NCINvB2j_24try_with_args_and_kwargsNCNvNtBM_7logging8py_debug0E0E0EBO_	/nix/store/474wsqvczslhcqfra3yq3a1c6j0isakd-rust-minimal-1.96.0-nightly-2026-03-16/lib/rustlib/src/rust/library/core/src/result.rs:1616
...
```