### PR TITLE
xbuild error reporting

### DIFF
--- a/core/embed/models/build.rs
+++ b/core/embed/models/build.rs
@@ -1,4 +1,4 @@
-use xbuild::{CLibrary, Result, bail_unsupported};
+use xbuild::{CLibrary, Result, bail_unsupported, cargo_out};
 
 fn main() -> Result<()> {
     // Emit model identity for dependent build scripts (readable as
@@ -24,14 +24,14 @@ fn main() -> Result<()> {
     } else {
         ""
     };
-    println!("cargo:model={model_id}");
+    cargo_out::metadata("model", model_id);
 
     // Board header is resolved by xtask from the selected board's TOML and
     // passed here so the correct revision header is used regardless of which
     // board revision is active. When building outside xtask (rust-analyzer or a
     // bare `cargo` invocation) the variable is unset, so fall back to the
     // model's default board header to keep the build working.
-    println!("cargo:rerun-if-env-changed=TREZOR_BOARD_HEADER");
+    cargo_out::rerun_if_env_changed("TREZOR_BOARD_HEADER");
     let board_header_path = match std::env::var("TREZOR_BOARD_HEADER") {
         Ok(path) => path,
         Err(_) => default_board_header(model_id)?,
@@ -205,7 +205,7 @@ fn default_board_header(model_id: &str) -> Result<String> {
     let model_dir = std::path::PathBuf::from(std::env::var("CARGO_MANIFEST_DIR")?).join(model_id);
 
     let read_toml = |path: &std::path::Path| -> Result<toml::Value> {
-        println!("cargo:rerun-if-changed={}", path.display());
+        cargo_out::rerun_if_changed(path);
         let content = std::fs::read_to_string(path)?;
         Ok(toml::from_str(&content)?)
     };

--- a/core/embed/models/build.rs
+++ b/core/embed/models/build.rs
@@ -1,4 +1,4 @@
-use xbuild::{CLibrary, Result, bail_unsupported};
+use xbuild::{CLibrary, Result, bail_unsupported, cargo_out};
 
 fn main() -> Result<()> {
     // Emit model identity for dependent build scripts (readable as
@@ -24,14 +24,14 @@ fn main() -> Result<()> {
     } else {
         ""
     };
-    println!("cargo:model={model_id}");
+    cargo_out::metadata("model", model_id);
 
     // Board header is resolved by xtask from the selected board's TOML and
     // passed here so the correct revision header is used regardless of which
     // board revision is active. When building outside xtask (rust-analyzer or a
     // bare `cargo` invocation) the variable is unset, so fall back to the
     // model's default board header to keep the build working.
-    println!("cargo:rerun-if-env-changed=TREZOR_BOARD_HEADER");
+    cargo_out::rerun_if_env_changed("TREZOR_BOARD_HEADER");
     let board_header_path = match std::env::var("TREZOR_BOARD_HEADER") {
         Ok(path) => path,
         Err(_) => default_board_header(model_id)?,
@@ -207,7 +207,7 @@ fn default_board_header(model_id: &str) -> Result<String> {
     let model_dir = std::path::PathBuf::from(std::env::var("CARGO_MANIFEST_DIR")?).join(model_id);
 
     let read_toml = |path: &std::path::Path| -> Result<toml::Value> {
-        println!("cargo:rerun-if-changed={}", path.display());
+        cargo_out::rerun_if_changed(path);
         let content = std::fs::read_to_string(path)?;
         Ok(toml::from_str(&content)?)
     };

--- a/core/embed/upymod/build.rs
+++ b/core/embed/upymod/build.rs
@@ -829,9 +829,12 @@ impl<'a> MpyBuilder<'a> {
             .output()
             .with_context(|| format!("Failed to execute {:?}", cmd))?;
 
+        // Forward make's own output instead of folding it into the error
+        xbuild::emit_command_output(&cmd_output, true);
+
         // Check if the command executed successfully
         if !cmd_output.status.success() {
-            bail!(xbuild::format_command_error(&cmd, &cmd_output));
+            bail!("make failed with {}", cmd_output.status);
         }
 
         Ok(build_dir.join("mpy-cross"))

--- a/core/embed/xbuild/src/attrs.rs
+++ b/core/embed/xbuild/src/attrs.rs
@@ -3,6 +3,7 @@ use std::path::{Path, PathBuf};
 use color_eyre::Result;
 use color_eyre::eyre::{WrapErr, ensure};
 
+use crate::cargo_out;
 use crate::helpers::{join_paths_lexically, library_metadata, relative_to_manifest};
 
 /// Attributes for configuring C compilation.
@@ -183,7 +184,7 @@ impl CompileAttrs {
             })
             .collect::<Vec<_>>()
             .join(";");
-        println!("cargo::metadata=public_c_includes={}", includes);
+        cargo_out::metadata("public_c_includes", includes);
 
         let defines = self
             .defines
@@ -197,10 +198,10 @@ impl CompileAttrs {
             })
             .collect::<Vec<_>>()
             .join(";");
-        println!("cargo::metadata=public_c_defines={}", defines);
+        cargo_out::metadata("public_c_defines", defines);
 
         let flags = self.flags.join(";");
-        println!("cargo::metadata=public_c_flags={}", flags);
+        cargo_out::metadata("public_c_flags", flags);
 
         Ok(())
     }

--- a/core/embed/xbuild/src/cargo_out.rs
+++ b/core/embed/xbuild/src/cargo_out.rs
@@ -1,0 +1,93 @@
+//! Buffering of `cargo::` directives written to stdout.
+//!
+//! Cargo echoes a failed build script's entire stdout back to the user, where
+//! the directives bury the actual compiler diagnostics. They are worthless on
+//! failure anyway - Cargo discards the run and re-executes the build script
+//! next time no matter what it printed - so they are collected while a build
+//! is in progress and written out only once it succeeds.
+//!
+//! [`warning`] is the exception: Cargo hides build script warnings when the
+//! build fails, so buffering one would lose it exactly when it is needed.
+
+use std::fmt::Display;
+use std::io::{self, Write};
+use std::path::Path;
+use std::sync::Mutex;
+
+/// Pending directives, or None when nothing is buffering and they should go
+/// straight out.
+static PENDING: Mutex<Option<Vec<String>>> = Mutex::new(None);
+
+/// Emits `cargo::warning=` - a message Cargo shows to the user.
+///
+/// Written immediately so it survives a later build failure; see the module
+/// documentation.
+pub fn warning(message: impl Display) {
+    println!("cargo::warning={message}");
+}
+
+/// Emits `cargo::metadata=` - a `key=value` pair passed to the build scripts
+/// of dependent crates as `DEP_<links>_<KEY>`.
+pub fn metadata(key: &str, value: impl Display) {
+    defer(format!("cargo::metadata={key}={value}"));
+}
+
+/// Emits `cargo::rustc-link-lib=`
+pub fn rustc_link_lib(lib: impl Display) {
+    defer(format!("cargo::rustc-link-lib={lib}"));
+}
+
+/// Emits `cargo::rustc-link-arg=`
+pub fn rustc_link_arg(arg: impl Display) {
+    defer(format!("cargo::rustc-link-arg={arg}"));
+}
+
+/// Emits `cargo::rustc-link-search=`
+pub fn rustc_link_search(path: impl Display) {
+    defer(format!("cargo::rustc-link-search={path}"));
+}
+
+/// Emits `cargo::rerun-if-changed=`.
+pub fn rerun_if_changed(path: impl AsRef<Path>) {
+    defer(format!(
+        "cargo::rerun-if-changed={}",
+        path.as_ref().display()
+    ));
+}
+
+/// Emits `cargo::rerun-if-env-changed=`.
+pub fn rerun_if_env_changed(var: &str) {
+    defer(format!("cargo::rerun-if-env-changed={var}"));
+}
+
+/// Holds a directive back if a build is in progress, writes it out otherwise.
+fn defer(directive: String) {
+    match PENDING.lock().expect("cargo output poisoned").as_mut() {
+        Some(pending) => pending.push(directive),
+        None => println!("{directive}"),
+    }
+}
+
+/// Starts collecting directives instead of writing them out.
+///
+/// Anything deferred from here on is written only by a matching [`flush`], so
+/// every path that starts buffering must flush on success.
+pub(crate) fn start_buffering() {
+    *PENDING.lock().expect("cargo output poisoned") = Some(Vec::new());
+}
+
+/// Writes out everything collected since [`start_buffering`] and returns to
+/// writing directives immediately.
+pub(crate) fn flush() {
+    let pending = PENDING.lock().expect("cargo output poisoned").take();
+
+    let Some(pending) = pending else {
+        return;
+    };
+
+    let stdout = io::stdout();
+    let mut lock = stdout.lock();
+    for directive in pending {
+        let _ = writeln!(lock, "{directive}");
+    }
+}

--- a/core/embed/xbuild/src/cargo_out.rs
+++ b/core/embed/xbuild/src/cargo_out.rs
@@ -1,0 +1,86 @@
+//! Buffering of `cargo::` directives written to stdout.
+//!
+//! Cargo echoes a failed build script's entire stdout back to the user, where
+//! the directives bury the actual compiler diagnostics. They are worthless on
+//! failure anyway - Cargo discards the run and re-executes the build script
+//! next time no matter what it printed - so they are collected while a build
+//! is in progress and written out only once it succeeds.
+//!
+//! [`warning`] is the exception: buffering one would drop it on failure, and
+//! Cargo does surface build script warnings then - so it is written as soon as
+//! it is produced.
+
+use std::fmt::Display;
+use std::io::{self, Write};
+use std::path::Path;
+use std::sync::Mutex;
+
+/// Pending directives since the first deferred directive after the last flush.
+static PENDING: Mutex<Option<Vec<String>>> = Mutex::new(None);
+
+/// Emits `cargo::warning=` - a message Cargo shows to the user.
+///
+/// Written immediately so it survives a later build failure; see the module
+/// documentation.
+pub fn warning(message: impl Display) {
+    println!("cargo::warning={message}");
+}
+
+/// Emits `cargo::metadata=` - a `key=value` pair passed to the build scripts
+/// of dependent crates as `DEP_<links>_<KEY>`.
+pub fn metadata(key: &str, value: impl Display) {
+    defer(format!("cargo::metadata={key}={value}"));
+}
+
+/// Emits `cargo::rustc-link-lib=`
+pub fn rustc_link_lib(lib: impl Display) {
+    defer(format!("cargo::rustc-link-lib={lib}"));
+}
+
+/// Emits `cargo::rustc-link-arg=`
+pub fn rustc_link_arg(arg: impl Display) {
+    defer(format!("cargo::rustc-link-arg={arg}"));
+}
+
+/// Emits `cargo::rustc-link-search=`
+pub fn rustc_link_search(path: impl Display) {
+    defer(format!("cargo::rustc-link-search={path}"));
+}
+
+/// Emits `cargo::rerun-if-changed=`.
+pub fn rerun_if_changed(path: impl AsRef<Path>) {
+    defer(format!(
+        "cargo::rerun-if-changed={}",
+        path.as_ref().display()
+    ));
+}
+
+/// Emits `cargo::rerun-if-env-changed=`.
+pub fn rerun_if_env_changed(var: &str) {
+    defer(format!("cargo::rerun-if-env-changed={var}"));
+}
+
+/// Holds a directive back until [`flush`] is called.
+fn defer(directive: String) {
+    PENDING
+        .lock()
+        .expect("cargo output poisoned")
+        .get_or_insert_default()
+        .push(directive);
+}
+
+/// Writes out everything collected since the first deferred directive after
+/// the previous flush.
+pub(crate) fn flush() {
+    let pending = PENDING.lock().expect("cargo output poisoned").take();
+
+    let Some(pending) = pending else {
+        return;
+    };
+
+    let stdout = io::stdout();
+    let mut lock = stdout.lock();
+    for directive in pending {
+        let _ = writeln!(lock, "{directive}");
+    }
+}

--- a/core/embed/xbuild/src/cargo_out.rs
+++ b/core/embed/xbuild/src/cargo_out.rs
@@ -14,8 +14,7 @@ use std::io::{self, Write};
 use std::path::Path;
 use std::sync::Mutex;
 
-/// Pending directives, or None when nothing is buffering and they should go
-/// straight out.
+/// Pending directives since the first deferred directive after the last flush.
 static PENDING: Mutex<Option<Vec<String>>> = Mutex::new(None);
 
 /// Emits `cargo::warning=` - a message Cargo shows to the user.
@@ -60,24 +59,17 @@ pub fn rerun_if_env_changed(var: &str) {
     defer(format!("cargo::rerun-if-env-changed={var}"));
 }
 
-/// Holds a directive back if a build is in progress, writes it out otherwise.
+/// Holds a directive back until [`flush`] is called.
 fn defer(directive: String) {
-    match PENDING.lock().expect("cargo output poisoned").as_mut() {
-        Some(pending) => pending.push(directive),
-        None => println!("{directive}"),
-    }
+    PENDING
+        .lock()
+        .expect("cargo output poisoned")
+        .get_or_insert_default()
+        .push(directive);
 }
 
-/// Starts collecting directives instead of writing them out.
-///
-/// Anything deferred from here on is written only by a matching [`flush`], so
-/// every path that starts buffering must flush on success.
-pub(crate) fn start_buffering() {
-    *PENDING.lock().expect("cargo output poisoned") = Some(Vec::new());
-}
-
-/// Writes out everything collected since [`start_buffering`] and returns to
-/// writing directives immediately.
+/// Writes out everything collected since the first deferred directive after
+/// the previous flush.
 pub(crate) fn flush() {
     let pending = PENDING.lock().expect("cargo output poisoned").take();
 

--- a/core/embed/xbuild/src/clibrary/cc_generator.rs
+++ b/core/embed/xbuild/src/clibrary/cc_generator.rs
@@ -2,6 +2,7 @@ use color_eyre::Result;
 use color_eyre::eyre::WrapErr;
 
 use super::CLibrary;
+use crate::cargo_out;
 use crate::helpers::{derive_output_path, join_paths_lexically, links_name, path_from_env};
 
 /// Path to the partial compile_commands.json fragment within OUT_DIR.
@@ -61,10 +62,7 @@ impl CLibrary {
             .with_context(|| format!("Failed to write {}", output_path.display()))?;
 
         // Export path to partial compile_commands.json
-        println!(
-            "cargo::metadata=public_c_compile_commands={}",
-            output_path.display()
-        );
+        cargo_out::metadata("public_c_compile_commands", output_path.display());
 
         Ok(())
     }

--- a/core/embed/xbuild/src/clibrary/compile.rs
+++ b/core/embed/xbuild/src/clibrary/compile.rs
@@ -5,6 +5,7 @@ use color_eyre::eyre::WrapErr;
 
 use super::CLibrary;
 use crate::attrs::CompileAttrs;
+use crate::cargo_out;
 use crate::dep_tracking::{run_command, run_command_with_cc_dep};
 use crate::helpers::{
     derive_output_path, diagnostics_color_flag, ensure_parent_directory, join_paths_lexically,
@@ -238,23 +239,23 @@ impl CLibrary {
         self.get_public_attrs().export_as_metadata()?;
 
         // Export linked libraries (so the top-level crate can re-export them)
-        println!(
-            "cargo::metadata=public_c_libs={}",
+        cargo_out::metadata(
+            "public_c_libs",
             self.get_libs()
                 .into_iter()
                 .map(|lib| lib.to_string())
                 .collect::<Vec<_>>()
-                .join(";")
+                .join(";"),
         );
 
         // Export linked libraries (so the top-level crate can re-export them)
-        println!(
-            "cargo::metadata=public_c_extlibs={}",
+        cargo_out::metadata(
+            "public_c_extlibs",
             self.get_external_libs()
                 .into_iter()
                 .map(|lib| lib.to_string())
                 .collect::<Vec<_>>()
-                .join(";")
+                .join(";"),
         );
 
         Ok(())
@@ -303,7 +304,7 @@ fn make_static_library(objects: Vec<PathBuf>, lib_name: &str) -> Result<()> {
         .with_context(|| format!("Failed to create static library {}", output.display()))?;
 
     // Expose archive directory to the linker, both for rebuilt and cached archives
-    println!("cargo:rustc-link-search=native={}", out_dir.display());
+    cargo_out::rustc_link_search(format!("native={}", out_dir.display()));
 
     Ok(())
 }

--- a/core/embed/xbuild/src/clibrary/compile.rs
+++ b/core/embed/xbuild/src/clibrary/compile.rs
@@ -7,8 +7,8 @@ use super::CLibrary;
 use crate::attrs::CompileAttrs;
 use crate::dep_tracking::{run_command, run_command_with_cc_dep};
 use crate::helpers::{
-    derive_output_path, ensure_parent_directory, join_paths_lexically, links_name, measure_time,
-    path_from_env,
+    derive_output_path, diagnostics_color_flag, ensure_parent_directory, join_paths_lexically,
+    links_name, measure_time, path_from_env,
 };
 use crate::parallel::run_parallel;
 
@@ -55,6 +55,10 @@ struct CompileArtifact {
 impl CompileUnit {
     fn compile(&self, tool: &cc::Tool) -> Result<CompileArtifact> {
         let mut cmd = tool.to_command();
+
+        if let Some(flag) = diagnostics_color_flag(tool) {
+            cmd.arg(flag);
+        }
 
         if let Some(attrs) = &self.attrs {
             for arg in attrs.to_compiler_args() {

--- a/core/embed/xbuild/src/clibrary/compile.rs
+++ b/core/embed/xbuild/src/clibrary/compile.rs
@@ -7,8 +7,8 @@ use super::CLibrary;
 use crate::attrs::CompileAttrs;
 use crate::dep_tracking::{run_command, run_command_with_cc_dep};
 use crate::helpers::{
-    derive_output_path, ensure_parent_directory, join_paths_lexically, links_name, measure_time,
-    path_from_env,
+    derive_output_path, diagnostics_color_flag, ensure_parent_directory, join_paths_lexically,
+    links_name, measure_time, path_from_env,
 };
 use crate::parallel::run_parallel;
 
@@ -55,6 +55,10 @@ struct CompileArtifact {
 impl CompileUnit {
     fn compile(&self, tool: &cc::Tool) -> Result<CompileArtifact> {
         let mut cmd = tool.to_command();
+
+        if let Some(flag) = diagnostics_color_flag(tool) {
+            cmd.arg(flag);
+        }
 
         if let Some(attrs) = &self.attrs {
             for arg in attrs.to_compiler_args() {
@@ -216,10 +220,11 @@ impl CLibrary {
     ///
     /// Returns an error if preprocessing fails.
     pub fn preprocess_file(&self, input: &Path, output: &Path) -> Result<()> {
-        let mut cmd = self
-            .get_merged_attrs()
-            .get_configured_compiler()
-            .to_command();
+        let tool = self.get_merged_attrs().get_configured_compiler();
+        let mut cmd = tool.to_command();
+        if let Some(flag) = diagnostics_color_flag(&tool) {
+            cmd.arg(flag);
+        }
 
         cmd.arg("-E").arg(input).arg("-o").arg(output);
 

--- a/core/embed/xbuild/src/clibrary/compile.rs
+++ b/core/embed/xbuild/src/clibrary/compile.rs
@@ -221,10 +221,11 @@ impl CLibrary {
     ///
     /// Returns an error if preprocessing fails.
     pub fn preprocess_file(&self, input: &Path, output: &Path) -> Result<()> {
-        let mut cmd = self
-            .get_merged_attrs()
-            .get_configured_compiler()
-            .to_command();
+        let tool = self.get_merged_attrs().get_configured_compiler();
+        let mut cmd = tool.to_command();
+        if let Some(flag) = diagnostics_color_flag(&tool) {
+            cmd.arg(flag);
+        }
 
         cmd.arg("-E").arg(input).arg("-o").arg(output);
 

--- a/core/embed/xbuild/src/clibrary/compile.rs
+++ b/core/embed/xbuild/src/clibrary/compile.rs
@@ -5,6 +5,7 @@ use color_eyre::eyre::WrapErr;
 
 use super::CLibrary;
 use crate::attrs::CompileAttrs;
+use crate::cargo_out;
 use crate::dep_tracking::{run_command, run_command_with_cc_dep};
 use crate::helpers::{
     derive_output_path, diagnostics_color_flag, ensure_parent_directory, join_paths_lexically,
@@ -239,23 +240,23 @@ impl CLibrary {
         self.get_public_attrs().export_as_metadata()?;
 
         // Export linked libraries (so the top-level crate can re-export them)
-        println!(
-            "cargo::metadata=public_c_libs={}",
+        cargo_out::metadata(
+            "public_c_libs",
             self.get_libs()
                 .into_iter()
                 .map(|lib| lib.to_string())
                 .collect::<Vec<_>>()
-                .join(";")
+                .join(";"),
         );
 
         // Export linked libraries (so the top-level crate can re-export them)
-        println!(
-            "cargo::metadata=public_c_extlibs={}",
+        cargo_out::metadata(
+            "public_c_extlibs",
             self.get_external_libs()
                 .into_iter()
                 .map(|lib| lib.to_string())
                 .collect::<Vec<_>>()
-                .join(";")
+                .join(";"),
         );
 
         Ok(())
@@ -304,7 +305,7 @@ fn make_static_library(objects: Vec<PathBuf>, lib_name: &str) -> Result<()> {
         .with_context(|| format!("Failed to create static library {}", output.display()))?;
 
     // Expose archive directory to the linker, both for rebuilt and cached archives
-    println!("cargo:rustc-link-search=native={}", out_dir.display());
+    cargo_out::rustc_link_search(format!("native={}", out_dir.display()));
 
     Ok(())
 }

--- a/core/embed/xbuild/src/clibrary/mod.rs
+++ b/core/embed/xbuild/src/clibrary/mod.rs
@@ -10,6 +10,7 @@ use color_eyre::Result;
 use color_eyre::eyre::WrapErr;
 
 use crate::attrs::CompileAttrs;
+use crate::cargo_out;
 use crate::helpers::{library_metadata, relative_to_manifest};
 
 /// A source file entry with optional per-file compile attributes.
@@ -409,7 +410,7 @@ impl CLibrary {
         });
 
         extlib.link_paths.iter().for_each(|path| {
-            println!("cargo:rustc-link-search={}", path.display());
+            cargo_out::rustc_link_search(path.display());
         });
 
         extlib.libs.iter().for_each(|lib| {

--- a/core/embed/xbuild/src/dep_tracking.rs
+++ b/core/embed/xbuild/src/dep_tracking.rs
@@ -243,7 +243,13 @@ fn command_to_dep_string(cmd: &std::process::Command) -> String {
     text.push_str(&cmd.get_program().to_string_lossy());
     text.push('\n');
     for arg in cmd.get_args() {
-        text.push_str(&arg.to_string_lossy());
+        let arg = arg.to_string_lossy();
+        // Diagnostic coloring has no effect on the produced artifacts, so
+        // toggling it must not invalidate the dependency cache.
+        if arg.starts_with("-fdiagnostics-color") {
+            continue;
+        }
+        text.push_str(&arg);
         text.push('\n');
     }
     text

--- a/core/embed/xbuild/src/dep_tracking.rs
+++ b/core/embed/xbuild/src/dep_tracking.rs
@@ -6,7 +6,9 @@ use std::time::SystemTime;
 use color_eyre::Result;
 use color_eyre::eyre::{WrapErr, ensure};
 
-use crate::helpers::{delete_file_if_exists, emit_rerun_if_changed, ensure_parent_directory};
+use crate::helpers::{
+    delete_file_if_exists, emit_rerun_if_changed, ensure_parent_directory, trace,
+};
 
 /// Runs a command with dependency tracking and optional C compiler dependency
 /// file support.
@@ -94,7 +96,7 @@ where
             command_failed_error(cmd, cmd_output.status)
         );
 
-        eprintln!("@@ command executed: {:?}", cmd);
+        trace!("@@ command executed: {:?}", cmd);
 
         Ok(())
     })
@@ -157,7 +159,7 @@ where
         fs::write(&output, &cmd_output.stdout)
             .with_context(|| format!("Failed to write to {}", output.as_ref().display()))?;
 
-        eprintln!("@@ command executed: {:?}", cmd);
+        trace!("@@ command executed: {:?}", cmd);
 
         Ok(())
     })

--- a/core/embed/xbuild/src/dep_tracking.rs
+++ b/core/embed/xbuild/src/dep_tracking.rs
@@ -1,4 +1,5 @@
 use std::fs;
+use std::io::{self, Write};
 use std::path::{Path, PathBuf};
 use std::time::SystemTime;
 
@@ -83,10 +84,14 @@ where
             .output()
             .with_context(|| format!("Failed to execute {:?}", cmd))?;
 
+        // Print the command's own diagnostics (warnings on success, errors on
+        // failure) before turning the exit status into an error.
+        emit_command_output(&cmd_output, true);
+
         // Check if the command executed successfully
         ensure!(
             cmd_output.status.success(),
-            format_command_error(cmd, &cmd_output)
+            command_failed_error(cmd, cmd_output.status)
         );
 
         eprintln!("@@ command executed: {:?}", cmd);
@@ -136,10 +141,13 @@ where
             .output()
             .with_context(|| format!("Failed to execute {:?}", cmd))?;
 
+        // Only stderr is forwarded here - stdout is the payload written below
+        emit_command_output(&cmd_output, false);
+
         // Check if the command executed successfully
         ensure!(
             cmd_output.status.success(),
-            format_command_error(cmd, &cmd_output)
+            command_failed_error(cmd, cmd_output.status)
         );
 
         // Ensure the output directory exists before writing the output
@@ -361,24 +369,27 @@ where
     Ok(())
 }
 
-// Formats the error message from a failed command execution, prioritizing
-// stderr, then stdout, and finally a generic message if both are empty.
-pub fn format_command_error(
-    cmd: &std::process::Command,
-    cmd_output: &std::process::Output,
-) -> String {
-    let stderr = String::from_utf8_lossy(&cmd_output.stderr)
-        .trim()
-        .to_string();
-    let stdout = String::from_utf8_lossy(&cmd_output.stdout)
-        .trim()
-        .to_string();
+/// Forwards a command's captured output to this process's stderr.
+///
+/// Diagnostics are written as-is instead of being folded into an error message,
+/// so the compiler's own formatting (carets, colors) survives and multi-line
+/// output is not swallowed by the error reporter.
+pub fn emit_command_output(cmd_output: &std::process::Output, with_stdout: bool) {
+    let stdout: &[u8] = if with_stdout { &cmd_output.stdout } else { &[] };
 
-    if !stderr.is_empty() {
-        stderr
-    } else if !stdout.is_empty() {
-        stdout
-    } else {
-        format!("Failed to execute {}", cmd.get_program().to_string_lossy())
-    }
+    let stderr = io::stderr();
+    let mut lock = stderr.lock();
+    let _ = lock.write_all(stdout);
+    let _ = lock.write_all(&cmd_output.stderr);
+    let _ = lock.flush();
+}
+
+/// Builds the short one-line error for a command that exited with a failure
+/// status
+fn command_failed_error(cmd: &std::process::Command, status: std::process::ExitStatus) -> String {
+    format!(
+        "{} failed with {}",
+        cmd.get_program().to_string_lossy(),
+        status
+    )
 }

--- a/core/embed/xbuild/src/helpers.rs
+++ b/core/embed/xbuild/src/helpers.rs
@@ -1,5 +1,6 @@
 use std::ffi::OsStr;
 use std::path::{Component, Path, PathBuf};
+use std::sync::OnceLock;
 use std::{env, fs};
 
 use color_eyre::Result;
@@ -182,6 +183,33 @@ pub fn cargo_target_dir() -> Result<PathBuf> {
     };
 
     Ok(target_dir.to_path_buf())
+}
+
+/// Returns the `-fdiagnostics-color` flag to pass to `tool`, or None if the
+/// tool is not GCC- or Clang-like and would not understand it.
+///
+/// Compiler output is captured (see `emit_command_output`), so the compiler
+/// sees a pipe and disables color unless explicitly told otherwise.
+pub fn diagnostics_color_flag(tool: &cc::Tool) -> Option<&'static str> {
+    if !(tool.is_like_gnu() || tool.is_like_clang()) {
+        return None;
+    }
+
+    Some(if color_diagnostics_enabled() {
+        "-fdiagnostics-color=always"
+    } else {
+        "-fdiagnostics-color=never"
+    })
+}
+
+/// Decides whether compiler diagnostics should be colored.
+///
+/// The answer comes from `CARGO_TERM_COLOR`, resolved to `always`/`never` by
+/// `xtask` (see `forward_color_choice` there). A build script cannot detect
+/// the terminal itself - Cargo pipes its output - so under a bare
+/// `cargo build` the variable is unset and diagnostics stay plain.
+fn color_diagnostics_enabled() -> bool {
+    env::var_os("CARGO_TERM_COLOR").is_some_and(|v| v == "always")
 }
 
 /// Checks if the `IS_RUST_ANALYZER` environment variable is set,

--- a/core/embed/xbuild/src/helpers.rs
+++ b/core/embed/xbuild/src/helpers.rs
@@ -1,5 +1,7 @@
 use std::ffi::OsStr;
+use std::io::IsTerminal;
 use std::path::{Component, Path, PathBuf};
+use std::sync::OnceLock;
 use std::{env, fs};
 
 use color_eyre::Result;
@@ -182,6 +184,54 @@ pub fn cargo_target_dir() -> Result<PathBuf> {
     };
 
     Ok(target_dir.to_path_buf())
+}
+
+/// Returns the `-fdiagnostics-color` flag to pass to `tool`, or None if the
+/// tool is not GCC- or Clang-like and would not understand it.
+///
+/// Compiler output is captured (see `emit_command_output`), so the compiler
+/// sees a pipe and disables color unless explicitly told otherwise.
+pub fn diagnostics_color_flag(tool: &cc::Tool) -> Option<&'static str> {
+    if !(tool.is_like_gnu() || tool.is_like_clang()) {
+        return None;
+    }
+
+    Some(if color_diagnostics_enabled() {
+        "-fdiagnostics-color=always"
+    } else {
+        "-fdiagnostics-color=never"
+    })
+}
+
+/// Decides whether compiler diagnostics should be colored.
+///
+/// Explicit settings win, in the usual precedence: `NO_COLOR`, then
+/// `CLICOLOR_FORCE`, then Cargo's own `CARGO_TERM_COLOR`. Otherwise the
+/// destination is auto-detected.
+///
+/// The result is cached: sources compile in parallel and the answer cannot
+/// change during a build.
+fn color_diagnostics_enabled() -> bool {
+    static ENABLED: OnceLock<bool> = OnceLock::new();
+
+    *ENABLED.get_or_init(|| {
+        // https://no-color.org — set to any non-empty value disables color.
+        if env::var_os("NO_COLOR").is_some_and(|v| !v.is_empty()) {
+            return false;
+        }
+
+        // https://bixense.com/clicolors — anything but "0" forces color on.
+        if env::var_os("CLICOLOR_FORCE").is_some_and(|v| !v.is_empty() && v != "0") {
+            return true;
+        }
+
+        match env::var("CARGO_TERM_COLOR").unwrap_or_default().as_str() {
+            "always" => true,
+            "never" => false,
+            // "auto" or unset
+            _ => std::io::stderr().is_terminal(),
+        }
+    })
 }
 
 /// Checks if the `IS_RUST_ANALYZER` environment variable is set,

--- a/core/embed/xbuild/src/helpers.rs
+++ b/core/embed/xbuild/src/helpers.rs
@@ -52,7 +52,20 @@ pub fn library_metadata(lib_name: &str, kind: &str) -> Result<String> {
     ))
 }
 
+/// Writes a progress message to stderr, but only when trace output is enabled
+#[macro_export]
+macro_rules! trace {
+    ($($arg:tt)*) => {
+        if $crate::trace_enabled() {
+            eprintln!($($arg)*);
+        }
+    };
+}
+
+pub use trace;
+
 /// Measures the execution time of a closure and prints it with the given label
+/// when trace output is enabled.
 pub fn measure_time<T, F>(label: impl AsRef<str>, f: F) -> T
 where
     F: FnOnce() -> T,
@@ -60,8 +73,23 @@ where
     let start_time = std::time::Instant::now();
     let result = f();
     let duration = start_time.elapsed();
-    eprintln!("{}: {:.2?}", label.as_ref(), duration);
+    trace!("{}: {:.2?}", label.as_ref(), duration);
     result
+}
+
+/// Reports whether the build was asked for trace output.
+///
+/// Cargo does not pass its own `--verbose` down to build scripts, so `xtask`
+/// sets `XBUILD_TRACE` alongside it.
+pub fn trace_enabled() -> bool {
+    static TRACE: OnceLock<bool> = OnceLock::new();
+
+    *TRACE.get_or_init(|| {
+        // Without this, toggling the variable would not re-run build scripts
+        // that Cargo considers up to date, and nothing would be logged.
+        cargo_out::rerun_if_env_changed("XBUILD_TRACE");
+        env::var_os("XBUILD_TRACE").is_some_and(|v| !v.is_empty() && v != "0")
+    })
 }
 
 /// Converts `path` to a path relative to `CARGO_MANIFEST_DIR` when possible.

--- a/core/embed/xbuild/src/helpers.rs
+++ b/core/embed/xbuild/src/helpers.rs
@@ -7,6 +7,8 @@ use color_eyre::Result;
 use color_eyre::eyre::{WrapErr, eyre};
 use pathdiff::diff_paths;
 
+use crate::cargo_out;
+
 /// Checks if the parent directory of the given output path exists,
 /// and creates it if it doesn't.
 pub fn ensure_parent_directory(output: impl AsRef<Path>) -> Result<()> {
@@ -225,6 +227,6 @@ where
     P: AsRef<Path>,
 {
     for file in files {
-        println!("cargo:rerun-if-changed={}", file.as_ref().display());
+        cargo_out::rerun_if_changed(file);
     }
 }

--- a/core/embed/xbuild/src/helpers.rs
+++ b/core/embed/xbuild/src/helpers.rs
@@ -8,6 +8,8 @@ use color_eyre::Result;
 use color_eyre::eyre::{WrapErr, eyre};
 use pathdiff::diff_paths;
 
+use crate::cargo_out;
+
 /// Checks if the parent directory of the given output path exists,
 /// and creates it if it doesn't.
 pub fn ensure_parent_directory(output: impl AsRef<Path>) -> Result<()> {
@@ -247,6 +249,6 @@ where
     P: AsRef<Path>,
 {
     for file in files {
-        println!("cargo:rerun-if-changed={}", file.as_ref().display());
+        cargo_out::rerun_if_changed(file);
     }
 }

--- a/core/embed/xbuild/src/helpers.rs
+++ b/core/embed/xbuild/src/helpers.rs
@@ -51,7 +51,20 @@ pub fn library_metadata(lib_name: &str, kind: &str) -> Result<String> {
     ))
 }
 
+/// Writes a progress message to stderr, but only when trace output is enabled
+#[macro_export]
+macro_rules! trace {
+    ($($arg:tt)*) => {
+        if $crate::trace_enabled() {
+            eprintln!($($arg)*);
+        }
+    };
+}
+
+pub use trace;
+
 /// Measures the execution time of a closure and prints it with the given label
+/// when trace output is enabled.
 pub fn measure_time<T, F>(label: impl AsRef<str>, f: F) -> T
 where
     F: FnOnce() -> T,
@@ -59,8 +72,23 @@ where
     let start_time = std::time::Instant::now();
     let result = f();
     let duration = start_time.elapsed();
-    eprintln!("{}: {:.2?}", label.as_ref(), duration);
+    trace!("{}: {:.2?}", label.as_ref(), duration);
     result
+}
+
+/// Reports whether the build was asked for trace output.
+///
+/// Cargo does not pass its own `--verbose` down to build scripts, so `xtask`
+/// sets `XBUILD_TRACE` alongside it.
+pub fn trace_enabled() -> bool {
+    static TRACE: OnceLock<bool> = OnceLock::new();
+
+    *TRACE.get_or_init(|| {
+        // Without this, toggling the variable would not re-run build scripts
+        // that Cargo considers up to date, and nothing would be logged.
+        cargo_out::rerun_if_env_changed("XBUILD_TRACE");
+        env::var_os("XBUILD_TRACE").is_some_and(|v| !v.is_empty() && v != "0")
+    })
 }
 
 /// Converts `path` to a path relative to `CARGO_MANIFEST_DIR` when possible.

--- a/core/embed/xbuild/src/lib.rs
+++ b/core/embed/xbuild/src/lib.rs
@@ -13,7 +13,7 @@ pub use clibrary::compile::OutputType;
 pub use color_eyre::Result;
 pub use color_eyre::eyre::{WrapErr, bail, ensure};
 pub use dep_tracking::{
-    format_command_error, needs_rebuild, run_command, run_command_to_file, run_if_changed,
+    emit_command_output, needs_rebuild, run_command, run_command_to_file, run_if_changed,
 };
 pub use helpers::{cargo_target_dir, derive_output_path, emit_rerun_if_changed, is_rust_analyzer};
 pub use input_files::InputFiles;

--- a/core/embed/xbuild/src/lib.rs
+++ b/core/embed/xbuild/src/lib.rs
@@ -18,7 +18,7 @@ pub use dep_tracking::{
 };
 pub use helpers::{
     cargo_target_dir, derive_output_path, diagnostics_color_flag, emit_rerun_if_changed,
-    is_rust_analyzer,
+    is_rust_analyzer, trace_enabled,
 };
 pub use input_files::InputFiles;
 pub use parallel::{optimal_parallel_job_count, run_parallel};

--- a/core/embed/xbuild/src/lib.rs
+++ b/core/embed/xbuild/src/lib.rs
@@ -1,4 +1,5 @@
 mod attrs;
+pub mod cargo_out;
 mod clibrary;
 mod dep_tracking;
 mod helpers;

--- a/core/embed/xbuild/src/lib.rs
+++ b/core/embed/xbuild/src/lib.rs
@@ -15,7 +15,10 @@ pub use color_eyre::eyre::{WrapErr, bail, ensure};
 pub use dep_tracking::{
     emit_command_output, needs_rebuild, run_command, run_command_to_file, run_if_changed,
 };
-pub use helpers::{cargo_target_dir, derive_output_path, emit_rerun_if_changed, is_rust_analyzer};
+pub use helpers::{
+    cargo_target_dir, derive_output_path, diagnostics_color_flag, emit_rerun_if_changed,
+    is_rust_analyzer,
+};
 pub use input_files::InputFiles;
 pub use parallel::{optimal_parallel_job_count, run_parallel};
 pub use trezor::{build, build_and_link, current_model_id, model_ids, vendor_header_path};

--- a/core/embed/xbuild/src/parallel.rs
+++ b/core/embed/xbuild/src/parallel.rs
@@ -3,7 +3,7 @@ use std::{env, thread};
 
 use color_eyre::Result;
 
-use crate::helpers::measure_time;
+use crate::helpers::{measure_time, trace};
 
 /// Executes a function in parallel across multiple worker threads for a
 /// collection of input units.
@@ -38,7 +38,7 @@ where
 
     let n_jobs = optimal_parallel_job_count(unit_count);
 
-    eprintln!(
+    trace!(
         "$$ Parallel processing of {} units with {} worker threads",
         unit_count, n_jobs
     );

--- a/core/embed/xbuild/src/trezor.rs
+++ b/core/embed/xbuild/src/trezor.rs
@@ -11,8 +11,8 @@ use std::{env, fs};
 use color_eyre::Result;
 use color_eyre::eyre::{WrapErr, bail};
 
-use crate::CLibrary;
 use crate::helpers::{is_rust_analyzer, links_name};
+use crate::{CLibrary, cargo_out};
 
 fn package_name() -> Result<String> {
     Ok(env::var("CARGO_PKG_NAME")?)
@@ -38,7 +38,7 @@ pub fn current_model_id() -> Result<String> {
 /// directory and each `model.toml` so callers rebuild when the model set
 /// changes.
 pub fn model_ids(models_dir: &Path) -> Result<Vec<String>> {
-    println!("cargo::rerun-if-changed={}", models_dir.display());
+    cargo_out::rerun_if_changed(models_dir);
     let mut models = Vec::new();
     for entry in fs::read_dir(models_dir).context("Failed to read models directory")? {
         let entry = entry?;
@@ -46,7 +46,7 @@ pub fn model_ids(models_dir: &Path) -> Result<Vec<String>> {
         if !model_toml.exists() {
             continue;
         }
-        println!("cargo::rerun-if-changed={}", model_toml.display());
+        cargo_out::rerun_if_changed(&model_toml);
         models.push(entry.file_name().to_string_lossy().into_owned());
     }
     models.sort();
@@ -61,7 +61,7 @@ pub fn vendor_header_path(models_dir: impl AsRef<Path>, target: &str) -> Result<
     if let Ok(vendor_header) = env::var("VENDOR_HEADER")
         && !vendor_header.is_empty()
     {
-        println!("cargo:warning=Using custom vendor header: {vendor_header}");
+        cargo_out::warning(format!("Using custom vendor header: {vendor_header}"));
         return Ok(PathBuf::from(vendor_header));
     }
 
@@ -136,6 +136,9 @@ pub fn build(f: impl FnOnce(&mut CLibrary) -> Result<()>) -> Result<()> {
         }
     }
 
+    // The build succeeded — release the collected `cargo::` directives.
+    cargo_out::flush();
+
     Ok(())
 }
 
@@ -161,6 +164,9 @@ pub fn build_and_link(target: &str, f: impl FnOnce(&mut CLibrary) -> Result<()>)
     }
 
     lib.link_as(target)?;
+
+    // The build succeeded — release the collected `cargo::` directives.
+    cargo_out::flush();
 
     Ok(())
 }
@@ -190,21 +196,21 @@ impl CLibrary {
         // to each archive instead of toggling global linker state.
         std::iter::once(this_lib.as_str())
             .chain(self.get_libs())
-            .for_each(|dep| println!("cargo:rustc-link-lib=static:+whole-archive={dep}"));
+            .for_each(|dep| cargo_out::rustc_link_lib(format!("static:+whole-archive={dep}")));
 
         self.get_external_libs()
             .into_iter()
-            .for_each(|dep| println!("cargo:rustc-link-arg=-l{dep}"));
+            .for_each(|dep| cargo_out::rustc_link_arg(format!("-l{dep}")));
 
         if has_feature("emulator") {
-            println!("cargo:rustc-link-lib=c");
-            println!("cargo:rustc-link-lib=m");
-            println!("cargo:rustc-link-lib=dl");
-            println!("cargo:rustc-link-lib=pthread");
+            cargo_out::rustc_link_lib("c");
+            cargo_out::rustc_link_lib("m");
+            cargo_out::rustc_link_lib("dl");
+            cargo_out::rustc_link_lib("pthread");
         } else {
-            println!("cargo:rustc-link-arg=-lm");
-            println!("cargo:rustc-link-arg=-lgcc");
-            println!("cargo:rustc-link-arg=-lc_nano");
+            cargo_out::rustc_link_arg("-lm");
+            cargo_out::rustc_link_arg("-lgcc");
+            cargo_out::rustc_link_arg("-lc_nano");
 
             // Include the linker script that defines memory layout constants
             // according to the current model.
@@ -219,8 +225,8 @@ impl CLibrary {
                 format!("models/{model_id}/memory{suffix}.ld")
             };
 
-            println!("cargo:rustc-link-arg=-T{memory_ld}");
-            println!("cargo:rerun-if-changed={memory_ld}");
+            cargo_out::rustc_link_arg(format!("-T{memory_ld}"));
+            cargo_out::rerun_if_changed(&memory_ld);
 
             // Include the linker script that defines the layout of the
             // final binary according to the selected binary type.
@@ -236,20 +242,20 @@ impl CLibrary {
                 bail!("Unsupported configuration");
             };
 
-            println!("cargo:rustc-link-arg=-T{target_ld}");
-            println!("cargo:rerun-if-changed={target_ld}");
+            cargo_out::rustc_link_arg(format!("-T{target_ld}"));
+            cargo_out::rerun_if_changed(&target_ld);
 
             // Generate a map file for the final binary in the same directory
             // as the final binary.
             let out_dir = PathBuf::from(env::var("OUT_DIR").unwrap());
             let map_file = out_dir.join(format!("../../../{package_name}.map"));
-            println!("cargo:rustc-link-arg=-Wl,-Map={}", map_file.display());
+            cargo_out::rustc_link_arg(format!("-Wl,-Map={}", map_file.display()));
 
             // Instruct the linker to perform garbage collection of
             // unused sections to minimize the final binary size.
-            println!("cargo:rustc-link-arg=-Wl,--gc-sections");
+            cargo_out::rustc_link_arg("-Wl,--gc-sections");
 
-            println!("cargo:rustc-link-arg=-nostdlib");
+            cargo_out::rustc_link_arg("-nostdlib");
 
             if binary_type == "secmon" {
                 // Generate an import library for the CMSE veneer functions
@@ -257,11 +263,8 @@ impl CLibrary {
                 // against this import library to call the secure monitor API.
 
                 let implib_file = out_dir.join("../../../secmon_api.o");
-                println!("cargo:rustc-link-arg=-Wl,-cmse-implib");
-                println!(
-                    "cargo:rustc-link-arg=-Wl,--out-implib={}",
-                    implib_file.display()
-                );
+                cargo_out::rustc_link_arg("-Wl,-cmse-implib");
+                cargo_out::rustc_link_arg(format!("-Wl,--out-implib={}", implib_file.display()));
             }
         }
 

--- a/core/embed/xbuild/src/trezor.rs
+++ b/core/embed/xbuild/src/trezor.rs
@@ -117,7 +117,6 @@ fn get_prodtest_vendor() -> Result<&'static str> {
 /// then compiles the library. Also installs the error reporting handler.
 pub fn build(f: impl FnOnce(&mut CLibrary) -> Result<()>) -> Result<()> {
     color_eyre::install()?;
-    cargo_out::start_buffering();
 
     let mut lib = CLibrary::new();
     configure_compiler_defaults(&mut lib);
@@ -149,7 +148,6 @@ pub fn build(f: impl FnOnce(&mut CLibrary) -> Result<()>) -> Result<()> {
 /// compiles the library, and links it as the specified binary type.
 pub fn build_and_link(target: &str, f: impl FnOnce(&mut CLibrary) -> Result<()>) -> Result<()> {
     color_eyre::install()?;
-    cargo_out::start_buffering();
 
     let mut lib = CLibrary::new();
     configure_compiler_defaults(&mut lib);

--- a/core/embed/xbuild/src/trezor.rs
+++ b/core/embed/xbuild/src/trezor.rs
@@ -11,8 +11,8 @@ use std::{env, fs};
 use color_eyre::Result;
 use color_eyre::eyre::{WrapErr, bail};
 
-use crate::CLibrary;
 use crate::helpers::{is_rust_analyzer, links_name};
+use crate::{CLibrary, cargo_out};
 
 fn package_name() -> Result<String> {
     Ok(env::var("CARGO_PKG_NAME")?)
@@ -38,7 +38,7 @@ pub fn current_model_id() -> Result<String> {
 /// directory and each `model.toml` so callers rebuild when the model set
 /// changes.
 pub fn model_ids(models_dir: &Path) -> Result<Vec<String>> {
-    println!("cargo::rerun-if-changed={}", models_dir.display());
+    cargo_out::rerun_if_changed(models_dir);
     let mut models = Vec::new();
     for entry in fs::read_dir(models_dir).context("Failed to read models directory")? {
         let entry = entry?;
@@ -46,7 +46,7 @@ pub fn model_ids(models_dir: &Path) -> Result<Vec<String>> {
         if !model_toml.exists() {
             continue;
         }
-        println!("cargo::rerun-if-changed={}", model_toml.display());
+        cargo_out::rerun_if_changed(&model_toml);
         models.push(entry.file_name().to_string_lossy().into_owned());
     }
     models.sort();
@@ -61,7 +61,7 @@ pub fn vendor_header_path(models_dir: impl AsRef<Path>, target: &str) -> Result<
     if let Ok(vendor_header) = env::var("VENDOR_HEADER")
         && !vendor_header.is_empty()
     {
-        println!("cargo:warning=Using custom vendor header: {vendor_header}");
+        cargo_out::warning(format!("Using custom vendor header: {vendor_header}"));
         return Ok(PathBuf::from(vendor_header));
     }
 
@@ -117,6 +117,7 @@ fn get_prodtest_vendor() -> Result<&'static str> {
 /// then compiles the library. Also installs the error reporting handler.
 pub fn build(f: impl FnOnce(&mut CLibrary) -> Result<()>) -> Result<()> {
     color_eyre::install()?;
+    cargo_out::start_buffering();
 
     let mut lib = CLibrary::new();
     configure_compiler_defaults(&mut lib);
@@ -136,6 +137,9 @@ pub fn build(f: impl FnOnce(&mut CLibrary) -> Result<()>) -> Result<()> {
         }
     }
 
+    // The build succeeded — release the collected `cargo::` directives.
+    cargo_out::flush();
+
     Ok(())
 }
 
@@ -145,6 +149,7 @@ pub fn build(f: impl FnOnce(&mut CLibrary) -> Result<()>) -> Result<()> {
 /// compiles the library, and links it as the specified binary type.
 pub fn build_and_link(target: &str, f: impl FnOnce(&mut CLibrary) -> Result<()>) -> Result<()> {
     color_eyre::install()?;
+    cargo_out::start_buffering();
 
     let mut lib = CLibrary::new();
     configure_compiler_defaults(&mut lib);
@@ -161,6 +166,9 @@ pub fn build_and_link(target: &str, f: impl FnOnce(&mut CLibrary) -> Result<()>)
     }
 
     lib.link_as(target)?;
+
+    // The build succeeded — release the collected `cargo::` directives.
+    cargo_out::flush();
 
     Ok(())
 }
@@ -190,21 +198,21 @@ impl CLibrary {
         // to each archive instead of toggling global linker state.
         std::iter::once(this_lib.as_str())
             .chain(self.get_libs())
-            .for_each(|dep| println!("cargo:rustc-link-lib=static:+whole-archive={dep}"));
+            .for_each(|dep| cargo_out::rustc_link_lib(format!("static:+whole-archive={dep}")));
 
         self.get_external_libs()
             .into_iter()
-            .for_each(|dep| println!("cargo:rustc-link-arg=-l{dep}"));
+            .for_each(|dep| cargo_out::rustc_link_arg(format!("-l{dep}")));
 
         if has_feature("emulator") {
-            println!("cargo:rustc-link-lib=c");
-            println!("cargo:rustc-link-lib=m");
-            println!("cargo:rustc-link-lib=dl");
-            println!("cargo:rustc-link-lib=pthread");
+            cargo_out::rustc_link_lib("c");
+            cargo_out::rustc_link_lib("m");
+            cargo_out::rustc_link_lib("dl");
+            cargo_out::rustc_link_lib("pthread");
         } else {
-            println!("cargo:rustc-link-arg=-lm");
-            println!("cargo:rustc-link-arg=-lgcc");
-            println!("cargo:rustc-link-arg=-lc_nano");
+            cargo_out::rustc_link_arg("-lm");
+            cargo_out::rustc_link_arg("-lgcc");
+            cargo_out::rustc_link_arg("-lc_nano");
 
             // Include the linker script that defines memory layout constants
             // according to the current model.
@@ -219,8 +227,8 @@ impl CLibrary {
                 format!("models/{model_id}/memory{suffix}.ld")
             };
 
-            println!("cargo:rustc-link-arg=-T{memory_ld}");
-            println!("cargo:rerun-if-changed={memory_ld}");
+            cargo_out::rustc_link_arg(format!("-T{memory_ld}"));
+            cargo_out::rerun_if_changed(&memory_ld);
 
             // Include the linker script that defines the layout of the
             // final binary according to the selected binary type.
@@ -236,20 +244,20 @@ impl CLibrary {
                 bail!("Unsupported configuration");
             };
 
-            println!("cargo:rustc-link-arg=-T{target_ld}");
-            println!("cargo:rerun-if-changed={target_ld}");
+            cargo_out::rustc_link_arg(format!("-T{target_ld}"));
+            cargo_out::rerun_if_changed(&target_ld);
 
             // Generate a map file for the final binary in the same directory
             // as the final binary.
             let out_dir = PathBuf::from(env::var("OUT_DIR").unwrap());
             let map_file = out_dir.join(format!("../../../{package_name}.map"));
-            println!("cargo:rustc-link-arg=-Wl,-Map={}", map_file.display());
+            cargo_out::rustc_link_arg(format!("-Wl,-Map={}", map_file.display()));
 
             // Instruct the linker to perform garbage collection of
             // unused sections to minimize the final binary size.
-            println!("cargo:rustc-link-arg=-Wl,--gc-sections");
+            cargo_out::rustc_link_arg("-Wl,--gc-sections");
 
-            println!("cargo:rustc-link-arg=-nostdlib");
+            cargo_out::rustc_link_arg("-nostdlib");
 
             if binary_type == "secmon" {
                 // Generate an import library for the CMSE veneer functions
@@ -257,11 +265,8 @@ impl CLibrary {
                 // against this import library to call the secure monitor API.
 
                 let implib_file = out_dir.join("../../../secmon_api.o");
-                println!("cargo:rustc-link-arg=-Wl,-cmse-implib");
-                println!(
-                    "cargo:rustc-link-arg=-Wl,--out-implib={}",
-                    implib_file.display()
-                );
+                cargo_out::rustc_link_arg("-Wl,-cmse-implib");
+                cargo_out::rustc_link_arg(format!("-Wl,--out-implib={}", implib_file.display()));
             }
         }
 

--- a/core/embed/xtask/src/features.rs
+++ b/core/embed/xtask/src/features.rs
@@ -156,7 +156,14 @@ pub fn configure_cargo(args: &ResolvedBuildArgs, cmd: &mut process::Command) -> 
         cmd.arg("--timings");
     }
 
-    if args.verbose {
+    if args.xbuild_trace {
+        // Cargo does not pass its own verbosity on to build scripts, so
+        // `xbuild` reads the request from the environment instead.
+        cmd.env("XBUILD_TRACE", "1");
+        // `-vv`, not `-v`: Cargo relays build script output only at the second
+        // verbosity level, and would otherwise discard what `xbuild` logs.
+        cmd.arg("-vv");
+    } else if args.verbose {
         cmd.arg("--verbose");
     }
 

--- a/core/embed/xtask/src/features.rs
+++ b/core/embed/xtask/src/features.rs
@@ -1,4 +1,5 @@
-use std::process;
+use std::io::IsTerminal;
+use std::{env, io, process};
 
 use anyhow::{Result, bail};
 
@@ -106,6 +107,33 @@ pub fn resolve_features(args: &ResolvedBuildArgs) -> Result<ResolvedBuildFeature
     })
 }
 
+/// Resolves `CARGO_TERM_COLOR` to `always`/`never` for the spawned Cargo.
+///
+/// Build scripts see only pipes (Cargo captures their output), so `xtask` -
+/// the last process attached to the real terminal - decides for them; `xbuild`
+/// reads the result to color C compiler diagnostics. An explicit
+/// `always`/`never` in the environment is left alone (the child inherits it).
+fn forward_color_choice(cmd: &mut process::Command) {
+    let explicit = env::var("CARGO_TERM_COLOR").is_ok_and(|v| v == "always" || v == "never");
+    if explicit {
+        return;
+    }
+
+    // https://no-color.org
+    let color = if env::var_os("NO_COLOR").is_some_and(|v| !v.is_empty()) {
+        "never"
+    // https://bixense.com/clicolors
+    } else if env::var_os("CLICOLOR_FORCE").is_some_and(|v| !v.is_empty() && v != "0") {
+        "always"
+    } else if io::stderr().is_terminal() {
+        "always"
+    } else {
+        "never"
+    };
+
+    cmd.env("CARGO_TERM_COLOR", color);
+}
+
 /// Configures a cargo command with the appropriate arguments and features.
 pub fn configure_cargo(args: &ResolvedBuildArgs, cmd: &mut process::Command) -> Result<()> {
     let resolved = resolve_features(args)?;
@@ -171,6 +199,8 @@ pub fn configure_cargo(args: &ResolvedBuildArgs, cmd: &mut process::Command) -> 
     if rebuild_std {
         cmd.arg("-Zbuild-std=core");
     }
+
+    forward_color_choice(cmd);
 
     Ok(())
 }

--- a/core/embed/xtask/src/features.rs
+++ b/core/embed/xtask/src/features.rs
@@ -192,7 +192,14 @@ pub fn configure_cargo(args: &ResolvedBuildArgs, cmd: &mut process::Command) -> 
         cmd.arg("--timings");
     }
 
-    if args.verbose {
+    if args.xbuild_trace {
+        // Cargo does not pass its own verbosity on to build scripts, so
+        // `xbuild` reads the request from the environment instead.
+        cmd.env("XBUILD_TRACE", "1");
+        // `-vv`, not `-v`: Cargo relays build script output only at the second
+        // verbosity level, and would otherwise discard what `xbuild` logs.
+        cmd.arg("-vv");
+    } else if args.verbose {
         cmd.arg("--verbose");
     }
 

--- a/core/embed/xtask/src/options.rs
+++ b/core/embed/xtask/src/options.rs
@@ -260,6 +260,10 @@ build_options! {
     /// Enable verbose output
     #[arg(long, num_args = 0..=1, default_missing_value = "true")]
     opt verbose: bool,
+
+    /// Log build script progress (executed commands and timings)
+    #[arg(long, num_args = 0..=1, default_missing_value = "true")]
+    opt xbuild_trace: bool,
 }
 
 impl ResolvedBuildArgs {

--- a/docs/core/build/xtask.md
+++ b/docs/core/build/xtask.md
@@ -90,6 +90,7 @@ cannot be used bare:
 - `--emit-memory-analysis` — emit type/stack size analysis.
 - `--timings` — output cargo timings.
 - `--verbose` — verbose cargo output.
+- `--xbuild-trace` — log build script progress (executed commands and timings).
 - `--apps` — enable external app loading.
 - `--n4w1` — enable N4W1 support.
 - `--unsafe-fw` — enable unsafe firmware features.


### PR DESCRIPTION
This PR improves xbuild compile error reporting.

- Prints compiler diagnostics directly to stderr without changing their formatting so standard problem matchers can parse them.
- Keeps compiler color output when supported. 
- Hides noisy build-script directives and xbuild command logs unless tracing is enabled.
- Adds xtask `--xbuild-trace` option, which enables xbuild trace messages.