### PR TITLE
chore(core): remove unused mpu configuration

### DIFF
--- a/core/embed/sys/mpu/stm32f4/mpu.c
+++ b/core/embed/sys/mpu/stm32f4/mpu.c
@@ -147,21 +147,6 @@ static void mpu_init_fixed_regions(void) {
   // SubRegion: 8KB at the beginning + 16KB at the end of 64KB CCMRAM
   SET_REGION( 4, CCMDATARAM_BASE,       SIZE_64KB,  0x3E, SRAM,       PRIV_RW );
   // clang-format on
-#elif defined(FIRMWARE)
-  // clang-format off
-  // Code in the Flash Bank #1 (Unprivileged, Read-Only, Executable)
-  // Subregion: 768KB = 1024KB except 2/8 at start
-  SET_REGION( 0, FLASH_BASE,            SIZE_1MB,   0x03, FLASH_CODE, PRIV_RO_URO );
-  // Code in the Flash Bank #2 (Unprivileged, Read-Only, Executable)
-  // Subregion: 896KB = 1024KB except 1/8 at start
-  SET_REGION( 1, FLASH_BASE + 0x100000, SIZE_1MB,   0x01, FLASH_CODE, PRIV_RO_URO );
-  // All CCMRAM (Unprivileged, Read-Write, Non-Executable)
-  SET_REGION( 2, CCMDATARAM_BASE,       SIZE_64KB,  0x00, SRAM,       FULL_ACCESS );
-  // All SRAM (Unprivileged, Read-Write, Non-Executable)
-  // Subregion:  192KB = 256KB except 2/8 at end
-  SET_REGION( 3, SRAM_BASE,             SIZE_256KB, 0xC0, SRAM,       FULL_ACCESS );
-  DIS_REGION( 4 );
-  // clang-format on
 #elif defined(TREZOR_PRODTEST)
   // clang-format off
   // Code in the Flash Bank #1 (Unprivileged, Read-Only, Executable)

--- a/core/embed/sys/mpu/stm32u5/mpu.c
+++ b/core/embed/sys/mpu/stm32u5/mpu.c
@@ -264,14 +264,6 @@ static void mpu_init_fixed_regions(void) {
   DIS_REGION( 2 ); // reserved for applets
   DIS_REGION( 3 ); // reserved for applets
   DIS_REGION( 4 ); // reserved for applets
-
-#elif defined(FIRMWARE)
-  //   REGION    ADDRESS                   SIZE                TYPE       WRITE   UNPRIV
-  SET_REGION( 0, FIRMWARE_START,           FIRMWARE_MAXSIZE,   FLASH_CODE,   NO,    NO );
-  SET_REGION( 1, MAIN_RAM_START,           MAIN_RAM_SIZE,      SRAM,        YES,    NO );
-  DIS_REGION( 2 );
-  DIS_REGION( 3 );
-  SET_REGION( 4, AUX1_RAM_START,           AUX1_RAM_SIZE,      SRAM,        YES,    NO );
 #elif defined(TREZOR_PRODTEST)
   SET_REGION( 0, FIRMWARE_START,           1024,               FLASH_DATA,  YES,    NO );
   SET_REGION( 1, FIRMWARE_START + 1024,    FIRMWARE_MAXSIZE - 1024, FLASH_CODE,   NO,    NO );


### PR DESCRIPTION
This PR removes an unused MPU configuration left over from the time before we started using the kernel.

The `FIRMWARE` symbol is no longer defined by the build system.

Testing: This PR removes dead code. No testing is required.