### PR TITLE
Release tooling: add script for unpacking firmware artifacts

### DIFF
--- a/.github/workflows/core.yml
+++ b/.github/workflows/core.yml
@@ -873,5 +873,37 @@ jobs:
       - run: nix-shell --run "uv run make -C core audit_rust"
       - run: nix-shell --run "uv run make -C core vet_rust"
 
+  unsigned_firmware_archive:
+    name: Unsigned firmware archive  # for release QA purposes
+    if: github.event_name == 'push'  # release branches only, only those currently trigger push
+    runs-on: ubuntu-latest
+    needs: core_firmware
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # actions/checkout@v6.0.2
+        with:
+          submodules: recursive
+          persist-credentials: false
+      - uses: ./.github/actions/environment
+      - name: Generate translation blobs
+        run: nix-shell --run "uv run make -C core translations"
+      - uses: actions/download-artifact@70fc10c6e5e1ce46ad2ea6f2b72d43f7d47b13c3  # actions/download-artifact@v8.0.0
+        with:
+          pattern: core-firmware-*-*-normal
+          path: downloaded-artifacts
+      - name: Run unpack-artifacts.py
+        run: |
+          mkdir -p to-upload/firmware
+          python tools/unpack-artifacts.py \
+              --releases common/releases.json \
+              --translations core/translations \
+              --output to-upload/firmware \
+              downloaded-artifacts
+      - uses: actions/upload-artifact@bbbca2ddaa5d8feaa63e36b76fdaad77386f024f  # actions/upload-artifact@v7.0.0
+        with:
+          name: unsigned
+          path: to-upload/firmware*  # path hierarchy preserved after the first wildcard
+          retention-days: 7
+
+
   # Connect
   # TODO: core_connect_test

--- a/tools/unpack-artifacts.py
+++ b/tools/unpack-artifacts.py
@@ -1,0 +1,82 @@
+#!/usr/bin/env python3
+"""
+Find firmware binaries in artifacts produced by `core_firmware` jobs in the `core.yml` workflow and copy them into directory structure used by release tooling.
+Only models in the latest entry in `common/releases.json` are copied.
+"""
+
+import json
+import shutil
+from pathlib import Path
+
+import click
+
+
+@click.command(help=__doc__)
+@click.argument(
+    "artifact_dir", type=click.Path(exists=True, file_okay=False, dir_okay=True)
+)
+@click.option(
+    "-o",
+    "--output",
+    "output_dir",
+    type=click.Path(exists=True, file_okay=False, dir_okay=True),
+    default="firmware",
+)
+@click.option(
+    "-r",
+    "--releases",
+    "releases_json",
+    type=click.Path(exists=True, file_okay=True, dir_okay=False),
+    default="common/releases.json",
+)
+@click.option(
+    "-t",
+    "--translations",
+    "translations_dir",
+    type=click.Path(exists=True, file_okay=False, dir_okay=True),
+    default="core/translations",
+)
+def main(
+    artifact_dir: str | Path,
+    output_dir: str | Path,
+    releases_json: str | Path,
+    translations_dir: str | Path,
+) -> None:
+    artifact_dir = Path(artifact_dir)
+    output_dir = Path(output_dir)
+    releases_json = Path(releases_json)
+    translations_dir = Path(translations_dir)
+
+    releases = json.loads(releases_json.read_text())["firmware"]
+    latest, models = max(
+        releases.items(), key=lambda item: [int(n) for n in item[0].split(".")]
+    )
+    click.echo(f"Version: {latest}")
+    click.echo(f"Models: {', '.join(models)}")
+
+    for model in models:
+        # firmware
+        model_dir = output_dir / "unsigned" / model.lower()
+        model_dir.mkdir(parents=True, exist_ok=True)
+
+        for coins in ("universal", "btconly"):
+            source_dir = artifact_dir / f"core-firmware-{model}-{coins}-normal" / "pub"
+            matching = list(source_dir.glob(f"firmware-{model}-*.bin"))
+            assert len(matching) == 1, f"{source_dir}: {matching}"
+            fw_file = matching[0]
+
+            click.echo(f"{fw_file} -> {model_dir / fw_file.name}")
+            shutil.copy(fw_file, model_dir / fw_file.name)
+
+        # translations
+        model_dir = output_dir / "unsigned" / "translations" / model.lower()
+        model_dir.mkdir(parents=True, exist_ok=True)
+
+        for f in translations_dir.glob(f"translation-{model}-*-unsigned.bin"):
+            fname = f.name
+            click.echo(f"{f} -> {model_dir / fname}")
+            shutil.copy(f, model_dir / fname)
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
Currently, after creating the release branch, unsigned firmware binaries need to be downloaded from CI artifacts and placed into certain private repo. Artifact download can be done using the `gh` CLI tool but they still need to be unpacked and copied to the right directories.

This PR adds a script that:
* expects a directory with artifact .zips, and a directory with built translations
* reads `common/releases.json` to determine the version string and affected models
* copies firmware binaries from the artifact zips to the destination directory tree
* copies translations for the affected models to the tree

Also a CI job is added that produces .zip that can be unpacked into the destination repository. Example: https://github.com/trezor/trezor-firmware/actions/runs/31399200469/job/93492352425

No T1B1 support, needs to be done manually.

<!--
For external contributors:
- Please open an issue before submitting a PR so we can discuss whether we want to proceed with it.

For core developers:
1. Initial PR setup
- Assign yourself to the PR.
- Add it to the "Firmware" project
  - Set Priority (match issue priority if it exists)
  - Set Team
  - Set Sprint (target release)

2. Development status
- Draft PRs: Set status to "In Progress"
- Final PRs: Set status to "Needs Review"

3. Post-merge status
- Testable: Set status to "Needs QA" and add a `Notes for QA` section with clear instructions on how to test the functionality.
- Not Testable: Set status to "Done (no QA)"
-->
