### PR TITLE
fix(core): fix swo console in boardloader

### DIFF
--- a/core/embed/projects/boardloader/Cargo.toml
+++ b/core/embed/projects/boardloader/Cargo.toml
@@ -31,8 +31,8 @@ sys.workspace = true
 bootloader_devel = ["sec/bootloader_devel"]
 clippy = []
 emulator = ["io/emulator"]
-dbg_console_swo = ["dbg_console"]
-dbg_console_system_view = ["dbg_console", "sys/system_view"]
+dbg_console_swo = ["dbg_console", "sys/dbg_console_swo"]
+dbg_console_system_view = ["dbg_console", "sys/dbg_console_system_view"]
 production = ["io/production"]
 
 # --------------------------------------------------------------------------


### PR DESCRIPTION
This small PR fixes `swo`/`system_view` debug console in boardloader. Neither of  them was functional since features were not properly forwarded.

Now xtask build `boardloader -m t3w1 --dbg-console=swo` works as expected.







