### PR TITLE
Fix build-docker noise

### DIFF
--- a/build-docker.sh
+++ b/build-docker.sh
@@ -370,7 +370,10 @@ for TREZOR_MODEL in ${MODELS[@]}; do
           mkdir -p /build/\$item/
           gzip build-xtask/artifacts/$TREZOR_MODEL/\$item.elf
           cp -v build-xtask/artifacts/$TREZOR_MODEL/\$item* /build/\$item/
-          cp -v build-xtask/artifacts/pub/\$item-$TREZOR_MODEL-*.bin /build/\$item/ || true  # n/a for kernel
+          pub_bin=(build-xtask/artifacts/pub/\$item-$TREZOR_MODEL-*.bin)
+          if [ -f "\$pub_bin" ]; then
+            cp -v "\${pub_bin[@]}" /build/\$item/
+          fi  # no pub bin for kernel, or for secmon when built only as a dependency
         fi
       done
       chown -R $USER:$GROUP /build

--- a/build-docker.sh
+++ b/build-docker.sh
@@ -367,7 +367,7 @@ for TREZOR_MODEL in ${MODELS[@]}; do
         fi
         if [ -f build-xtask/artifacts/$TREZOR_MODEL/\$item.elf ]; then
           # copy only the artifacts to the build output directory
-          mkdir /build/\$item/
+          mkdir -p /build/\$item/
           gzip build-xtask/artifacts/$TREZOR_MODEL/\$item.elf
           cp -v build-xtask/artifacts/$TREZOR_MODEL/\$item* /build/\$item/
           cp -v build-xtask/artifacts/pub/\$item-$TREZOR_MODEL-*.bin /build/\$item/ || true  # n/a for kernel


### PR DESCRIPTION
**Make artifact dir creation idempotent**
mkdir failed with "File exists" when a target's `/build/<item>/ directory` was already present, e.g. when reusing a `build/core-<model>` output dir across separate build-docker.sh invocations.

**Stop swallowing pub-bin copy errors**
kernel never has a pub bin, and secmon has none when built only as a firmware dependency; skip the copy in those known-benign cases instead of:
1. producing "cp: cannot stat" noise and
2. blanket-ignoring cp's exit status, so a genuine copy failure is no longer silently discarded.