### PR TITLE
Bootloader emulator fixes

### DIFF
--- a/core/embed/io/power_manager/unix/power_manager.c
+++ b/core/embed/io/power_manager/unix/power_manager.c
@@ -84,7 +84,9 @@ pm_status_t pm_suspend(wakeup_flags_t* wakeup_reason) {
       exit(1);
     }
     if (event.type == SDL_EVENT_KEY_DOWN || event.type == SDL_EVENT_KEY_UP) {
-      *wakeup_reason = WAKEUP_FLAG_BUTTON;
+      if (wakeup_reason != NULL) {
+        *wakeup_reason = WAKEUP_FLAG_BUTTON;
+      }
       break;
     }
 #ifdef USE_TOUCH_WAKEUP
@@ -94,7 +96,9 @@ pm_status_t pm_suspend(wakeup_flags_t* wakeup_reason) {
         /* tap-to-wake disabled: ignore touch and stay suspended */
         continue;
       }
-      *wakeup_reason = WAKEUP_FLAG_TOUCH;
+      if (wakeup_reason != NULL) {
+        *wakeup_reason = WAKEUP_FLAG_TOUCH;
+      }
       break;
     }
 #endif

--- a/core/embed/projects/boardloader/main.c
+++ b/core/embed/projects/boardloader/main.c
@@ -23,6 +23,7 @@
 #include <io/display.h>
 #include <io/rsod.h>
 #include <sec/board_capabilities.h>
+#include <sec/monoctr.h>
 #include <sec/option_bytes.h>
 #include <sec/rsod_special.h>
 #include <sys/bootutils.h>
@@ -72,6 +73,8 @@
 #endif
 
 static void drivers_init(void) {
+  monoctr_init();
+
 #ifdef USE_PMIC
   pmic_init();
 #endif

--- a/core/embed/projects/bootloader/emulator.c
+++ b/core/embed/projects/bootloader/emulator.c
@@ -8,6 +8,7 @@
 #include <SDL3/SDL.h>
 
 #include <io/display.h>
+#include <sec/monoctr.h>
 #include <sys/bootargs.h>
 #include <sys/bootutils.h>
 #include <sys/flash.h>

--- a/core/embed/projects/bootloader/main.c
+++ b/core/embed/projects/bootloader/main.c
@@ -26,6 +26,7 @@
 #include <io/rsod.h>
 #include <io/usb_config.h>
 #include <sec/image.h>
+#include <sec/monoctr.h>
 #include <sec/random_delays.h>
 #include <sec/rsod_special.h>
 #include <sec/unit_properties.h>
@@ -161,6 +162,8 @@ static void display_touch_init(secbool manufacturing_mode,
 
 static secbool boot_sequence(void) {
   secbool stay_in_bootloader = secfalse;
+
+  monoctr_init();
 
 #ifdef USE_SECRET
   secret_init();

--- a/core/embed/projects/bootloader_ci/main.c
+++ b/core/embed/projects/bootloader_ci/main.c
@@ -28,6 +28,7 @@
 #include <io/usb.h>
 #include <io/usb_config.h>
 #include <sec/image.h>
+#include <sec/monoctr.h>
 #include <sec/random_delays.h>
 #include <sec/rsod_special.h>
 #include <sys/bootargs.h>
@@ -60,6 +61,8 @@
 #define USB_IFACE_NUM SYSHANDLE_USB_WIRE
 
 static void drivers_init(void) {
+  monoctr_init();
+
   display_init(DISPLAY_RESET_CONTENT);
 
   random_delays_init();

--- a/core/embed/projects/kernel/main.c
+++ b/core/embed/projects/kernel/main.c
@@ -25,6 +25,7 @@
 #include <io/rsod.h>
 #include <sec/board_capabilities.h>
 #include <sec/boot_image.h>
+#include <sec/monoctr.h>
 #include <sec/option_bytes.h>
 #include <sec/random_delays.h>
 #include <sec/unit_properties.h>
@@ -124,6 +125,8 @@ void drivers_init() {
   UNUSED(status);
 
 #ifdef SECURE_MODE
+  monoctr_init();
+
   parse_boardloader_capabilities();
   unit_properties_init();
 

--- a/core/embed/projects/prodtest/main.c
+++ b/core/embed/projects/prodtest/main.c
@@ -28,6 +28,7 @@
 #include <io/usb_config.h>
 #include <rtl/cli.h>
 #include <sec/board_capabilities.h>
+#include <sec/monoctr.h>
 #include <sec/rsod_special.h>
 #include <sec/unit_properties.h>
 #include <sys/flash_otp.h>
@@ -149,6 +150,7 @@ static bool g_rgbled_control_disabled = false;
 void prodtest_disable_rgbled_control(void) { g_rgbled_control_disabled = true; }
 
 static void drivers_init(void) {
+  monoctr_init();
   parse_boardloader_capabilities();
   unit_properties_init();
 

--- a/core/embed/projects/secmon/main.c
+++ b/core/embed/projects/secmon/main.c
@@ -22,6 +22,7 @@
 
 #include <sec/board_capabilities.h>
 #include <sec/boot_image.h>
+#include <sec/monoctr.h>
 #include <sec/option_bytes.h>
 #include <sec/random_delays.h>
 #include <sec/secure_aes.h>
@@ -98,6 +99,8 @@ void usb_power_init(void) {
 
 static void drivers_init(void) {
   flash_init();
+
+  monoctr_init();
 
   parse_boardloader_capabilities();
   unit_properties_init();

--- a/core/embed/projects/unix/main_main.c
+++ b/core/embed/projects/unix/main_main.c
@@ -24,6 +24,7 @@
 #include <io/display.h>
 #include <io/rsod.h>
 #include <io/usb_config.h>
+#include <sec/monoctr.h>
 #include <sec/rsod_special.h>
 #include <sec/unit_properties.h>
 #include <sys/applet.h>
@@ -86,6 +87,8 @@ static void drivers_deinit(void) { flash_deinit(); }
 static void drivers_init(void) {
   flash_init();
   flash_otp_init();
+
+  monoctr_init();
 
   unit_properties_init();
 

--- a/core/embed/sec/backup_ram/unix/backup_ram.c
+++ b/core/embed/sec/backup_ram/unix/backup_ram.c
@@ -23,9 +23,9 @@ bool backup_ram_init(void) { return true; }
 
 void backup_ram_deinit(void) {}
 
-bool backup_ram_erase(void) { return false; }
+bool backup_ram_erase(void) { return true; }
 
-bool backup_ram_erase_protected(void) { return false; }
+bool backup_ram_erase_protected(void) { return true; }
 
 bool backup_ram_erase_item(uint16_t key) { return false; }
 

--- a/core/embed/sec/monoctr/inc/sec/monoctr.h
+++ b/core/embed/sec/monoctr/inc/sec/monoctr.h
@@ -27,18 +27,43 @@
 
 #define MONOCTR_MAX_VALUE 63
 
+/**
+ * @brief Enum representing the types of available monotonic counters.
+ */
 typedef enum {
   MONOCTR_BOOTLOADER_VERSION = 0,
   MONOCTR_FIRMWARE_VERSION = 1,
   MONOCTR_SECMON_VERSION = 2,
 } monoctr_type_t;
 
-// Write a new value to the monotonic counter
-// Returns sectrue on success, when value is lower than the current value
-// the write fails and returns secfalse
+/**
+ * @brief Initializes the monotonic counter module.
+ *
+ * This function should be called before any other operations on the monotonic
+ * counter.
+ */
+void monoctr_init(void);
+
+/**
+ * @brief Write a new value to the monotonic counter
+ *
+ * @param type The type of the monotonic counter to write to.
+ * @param value The new value to write to the monotonic counter.
+ *              Maximum value is defined by MONOCTR_MAX_VALUE.
+ *
+ * @return Returns sectrue on success when value is not lower than the current
+ *         value. If the write fails, returns secfalse.
+ * */
 secbool monoctr_write(monoctr_type_t type, uint8_t value);
 
-// Read the current value of the monotonic counter
+/**
+ * @brief Read the current value of the monotonic counter
+ *
+ * @param type The type of the monotonic counter to read from.
+ * @param value Pointer to store the current value of the monotonic counter.
+ *
+ * @return Returns sectrue on success, or secfalse if the read fails.
+ */
 secbool monoctr_read(monoctr_type_t type, uint8_t* value);
 
 #endif  // SECURE_MODE

--- a/core/embed/sec/monoctr/stm32f4/monoctr.c
+++ b/core/embed/sec/monoctr/stm32f4/monoctr.c
@@ -32,6 +32,8 @@
 static uint8_t dummy_version = 0;
 #endif
 
+void monoctr_init(void) {}
+
 #if PRODUCTION
 static int get_otp_block(monoctr_type_t type) {
   switch (type) {

--- a/core/embed/sec/monoctr/stm32u5/monoctr.c
+++ b/core/embed/sec/monoctr/stm32u5/monoctr.c
@@ -26,6 +26,8 @@
 #include <sys/flash.h>
 #include <sys/mpu.h>
 
+void monoctr_init(void) {}
+
 static int32_t get_offset(monoctr_type_t type) {
   switch (type) {
     case MONOCTR_BOOTLOADER_VERSION:

--- a/core/embed/sec/monoctr/unix/monoctr.c
+++ b/core/embed/sec/monoctr/unix/monoctr.c
@@ -25,12 +25,26 @@
 #include <sec/monoctr.h>
 #include <sys/flash_otp.h>
 
+void monoctr_init(void) {
+  ensure(monoctr_write(MONOCTR_BOOTLOADER_VERSION, 0),
+         "initialize bootloader monotonic counter");
+  ensure(monoctr_write(MONOCTR_FIRMWARE_VERSION, 0),
+         "initialize firmware monotonic counter");
+#ifdef USE_SECMON_VERIFICATION
+  ensure(monoctr_write(MONOCTR_SECMON_VERSION, 0),
+         "initialize secure-monitor monotonic counter");
+#endif
+}
+
 static int get_otp_block(monoctr_type_t type) {
   switch (type) {
     case MONOCTR_BOOTLOADER_VERSION:
       return FLASH_OTP_BLOCK_BOOTLOADER_VERSION;
     case MONOCTR_FIRMWARE_VERSION:
       return FLASH_OTP_BLOCK_FIRMWARE_VERSION;
+    case MONOCTR_SECMON_VERSION:
+      return 31;  // Workaround until we implement STM32U5 monoctr emulator
+                  // properly
     default:
       return -1;
   }

--- a/core/embed/sys/startup/inc/sys/bootutils.h
+++ b/core/embed/sys/startup/inc/sys/bootutils.h
@@ -79,7 +79,7 @@ void __attribute__((noreturn)) reboot_or_halt_after_rsod(void);
 
 // Platform dependent alignment for vector table addresses
 #define IMAGE_CODE_ALIGN(addr) \
-  ((((uint32_t)(uintptr_t)addr) + (CODE_ALIGNMENT - 1)) & ~(CODE_ALIGNMENT - 1))
+  ((((uintptr_t)addr) + (CODE_ALIGNMENT - 1)) & ~(CODE_ALIGNMENT - 1))
 
 // Jumps to the next booting stage (e.g. bootloader to firmware).
 // `vectbl_address` points to the flash at the vector table of the next stage.

--- a/core/embed/sys/task/unix/system.c
+++ b/core/embed/sys/task/unix/system.c
@@ -55,8 +55,13 @@ const char* system_fault_message(const system_fault_t* fault) {
 
 void system_emergency_rescue(systask_error_handler_t error_handler,
                              const systask_postmortem_t* pminfo) {
+  // Copy the post-mortem information to a new memory location.
+  // This is necessary because the original `pminfo` may be overwritten
+  // by system_init() called in error_handler().
+  systask_postmortem_t pminfo_copy = *pminfo;
+
   if (error_handler != NULL) {
-    error_handler(pminfo);
+    error_handler(&pminfo_copy);
   }
 
   // We should never reach this point


### PR DESCRIPTION
This PR fixes several issues that were introduced recently and prevented the bootloader emulator from running properly:

1. The RSOD screen did not display the correct content (`EXIT 0` was always shown).
2. The suspend implementation crashed because it is used slightly differently than in the firmware emulator.
3. Monotonic counter emulation are not implemented correctly for U5 devices. I added a small workaround for now, but we should revisit this in the future.
4. The minimal backup RAM driver emulator was updated to provide an erase function that returns a success status code.
5. Fixed the `IMAGE_CODE_ALIGN()` macro, which unnecessarily truncated pointer values.

The bootloader emulator is now working. However, I encountered a new issue with the UDP transport. It seems that transferring a 128 KB chunk as thousands of small UDP packets (naively emulating USB) does not work reliably on all machines. I will address in the follow up PR #7498.

This PR has no effect on firmware running on hardware.

Fixes #7439
