### PR TITLE
UDP transport throttling

### DIFF
--- a/python/src/trezorlib/transport/udp.py
+++ b/python/src/trezorlib/transport/udp.py
@@ -19,7 +19,8 @@ from __future__ import annotations
 import logging
 import socket
 import time
-from typing import TYPE_CHECKING, Iterable, Tuple
+from collections import deque
+from typing import TYPE_CHECKING, Deque, Iterable, Tuple
 
 from ..log import DUMP_PACKETS
 from . import Timeout, Transport, TransportException
@@ -32,6 +33,26 @@ SOCKET_TIMEOUT = 0.1
 LOG = logging.getLogger(__name__)
 
 
+class _SendRateLimiter:
+    def __init__(self, max_events: int, window: float) -> None:
+        self.max_events = max_events
+        self.window = window
+        self._events: Deque[float] = deque()
+
+    def wait(self) -> None:
+        now = time.monotonic()
+        self._discard_expired(now)
+        while len(self._events) >= self.max_events:
+            time.sleep(self.window - (now - self._events[0]))
+            now = time.monotonic()
+            self._discard_expired(now)
+        self._events.append(now)
+
+    def _discard_expired(self, now: float) -> None:
+        while self._events and now - self._events[0] >= self.window:
+            self._events.popleft()
+
+
 class UdpTransport(Transport):
 
     DEFAULT_HOST = "127.0.0.1"
@@ -39,6 +60,8 @@ class UdpTransport(Transport):
     PATH_PREFIX = "udp"
     ENABLED = True
     CHUNK_SIZE = 64
+    SEND_WINDOW_MAX_CHUNKS = 100
+    SEND_WINDOW_SEC = 0.05
 
     def __init__(self, device: str | None = None) -> None:
         if not device:
@@ -51,6 +74,9 @@ class UdpTransport(Transport):
         self.device: Tuple[str, int] = (host, port)
 
         self.socket: socket.socket | None = None
+        self._send_limiter = _SendRateLimiter(
+            self.SEND_WINDOW_MAX_CHUNKS, self.SEND_WINDOW_SEC
+        )
         super().__init__()
 
     @classmethod
@@ -109,6 +135,8 @@ class UdpTransport(Transport):
         assert self.socket is not None
         if len(chunk) != 64:
             raise TransportException("Unexpected data length")
+
+        self._send_limiter.wait()
         LOG.log(DUMP_PACKETS, f"sending packet: {chunk.hex()}")
         self.socket.sendall(chunk)
 

--- a/python/tests/test_transport.py
+++ b/python/tests/test_transport.py
@@ -43,6 +43,29 @@ def test_import_all_transports():
     assert UdpTransport
 
 
+def test_udp_transport_throttles_packets():
+    from trezorlib.transport.udp import UdpTransport
+
+    transport = UdpTransport()
+    transport.socket = mock.Mock()
+    packet = bytes(64)
+    chunk_count = UdpTransport.SEND_WINDOW_MAX_CHUNKS + 1
+
+    with (
+        mock.patch(
+            "trezorlib.transport.udp.time.monotonic",
+            side_effect=[0.0] * chunk_count + [UdpTransport.SEND_WINDOW_SEC],
+        ) as monotonic,
+        mock.patch("trezorlib.transport.udp.time.sleep") as sleep,
+    ):
+        for _ in range(chunk_count):
+            transport.write_chunk(packet)
+
+    assert transport.socket.sendall.call_count == chunk_count
+    assert monotonic.call_count == chunk_count + 1
+    sleep.assert_called_once_with(UdpTransport.SEND_WINDOW_SEC)
+
+
 def test_transport_dependencies():
     import trezorlib.transport.hid as hid_transport
 


### PR DESCRIPTION
When sending very large packets over the UDP transport (which emulates USB bulk endpoints), we run into reliability issues.

We use UdpTransport from udp.py to communicate with the Trezor emulator. It emulates data transfer over USB bulk endpoints by sending all data in 64-byte chunks. When transferring very large packets (e.g., 128 KB in the bootloader), this results in thousands of UDP packets being sent in a short period of time. The operating system has to buffer all of them, and it seems this is too much - some packets are dropped even when the UDP socket buffer is configured to much larger values.

I implemented simple throttling on the Python side that limits the number of chunks sent within a given time interval. With this modification, the bootloader emulator (including 128 KB transfers) works reliably.

I consider this a workaround - or just an initial idea how to proceed. The proper solution would be to migrate to TCP, which is more appropriate for this type of communication.

It looks like this change has no impact on the duration of the CI tests.

@onvej-sl  It might be related to issues you've found in prodtest emulator.