### PR TITLE
feat(python/ethereum): use `ethereum.SignTxResult` instead of a tuple

### DIFF
--- a/python/.changelog.d/7510.changed
+++ b/python/.changelog.d/7510.changed
@@ -1,0 +1,1 @@
+Ethereum `sign_tx()` and `sign_tx_eip1559()` return `SignTxResult` instead of a tuple.

--- a/python/src/trezorlib/ethereum.py
+++ b/python/src/trezorlib/ethereum.py
@@ -15,7 +15,11 @@
 # If not, see <https://www.gnu.org/licenses/lgpl-3.0.html>.
 
 import re
-from typing import TYPE_CHECKING, Any, AnyStr, Dict, List, Optional, Tuple
+import warnings
+from dataclasses import dataclass
+from typing import TYPE_CHECKING, Any, AnyStr, Dict, List, Optional, Union
+
+from typing_extensions import Self
 
 from . import exceptions, messages
 from .tools import prepare_message_bytes, workflow
@@ -213,29 +217,47 @@ def _answer_definition_request(
     )
 
 
+@dataclass
+class SignTxResult:
+    v: int
+    r: bytes
+    s: bytes
+
+    def __getitem__(self, i: int) -> Union[int, bytes]:
+        """Used for backwards compatiblity, to allow accessing and unpacking the signature tuple."""
+        warnings.warn(
+            "Ethereum signature is a dataclass (`SignTxResult`), not a tuple.",
+            DeprecationWarning,
+            stacklevel=2,
+        )
+        return (self.v, self.r, self.s)[i]
+
+    @classmethod
+    def from_response(cls, msg: messages.EthereumTxRequest) -> Optional[Self]:
+        if (
+            msg.signature_v is not None
+            and msg.signature_r is not None
+            and msg.signature_s is not None
+        ):
+            # We got an EthereumTxRequest containing the signature which means we are done.
+            return cls(v=msg.signature_v, r=msg.signature_r, s=msg.signature_s)
+        else:
+            return None  # We are not done yet.
+
+
 def _ethereum_sign_loop(
     session: "Session",
-    msg_type: type,
-    response: Any,
+    msg: Union[messages.EthereumSignTx, messages.EthereumSignTxEIP1559],
     data: bytes,
-    chain_id: int,
     definition_source: Optional["Source"],
-) -> Tuple[int, bytes, bytes]:
+) -> SignTxResult:
     """Shared request/response loop for sign_tx and sign_tx_eip1559."""
+    response = session.call(msg)
+
     while True:
         if isinstance(response, messages.EthereumTxRequest):
-            if (
-                response.signature_v is not None
-                and response.signature_r is not None
-                and response.signature_s is not None
-            ):
-                # We got an EthereumTxRequest containing the signature which means we are done.
-                if msg_type is messages.EthereumSignTx:
-                    # https://github.com/trezor/trezor-core/pull/311
-                    # Only signature bit returned. Recalculate signature_v.
-                    if response.signature_v <= 1:
-                        response.signature_v += 2 * chain_id + 35
-                return response.signature_v, response.signature_r, response.signature_s
+            if (result := SignTxResult.from_response(response)) is not None:
+                return result
             else:
                 assert response.data_length is not None
                 # We got an EthereumTxRequest asking for more data.
@@ -277,7 +299,7 @@ def sign_tx(
     payment_req: Optional[messages.PaymentRequest] = None,
     supports_definition_request: Optional[bool] = None,
     definition_source: Optional["Source"] = None,
-) -> Tuple[int, bytes, bytes]:
+) -> SignTxResult:
     if chain_id is None:
         raise exceptions.TrezorException("Chain ID cannot be undefined")
 
@@ -303,11 +325,12 @@ def sign_tx(
     data, chunk = data[1024:], data[:1024]
     msg.data_initial_chunk = chunk
 
-    response = session.call(msg)
-
-    return _ethereum_sign_loop(
-        session, messages.EthereumSignTx, response, data, chain_id, definition_source
-    )
+    sig = _ethereum_sign_loop(session, msg, data, definition_source)
+    # https://github.com/trezor/trezor-core/pull/311
+    # Only signature bit returned. Recalculate signature_v.
+    if sig.v <= 1:
+        sig.v += 2 * chain_id + 35
+    return sig
 
 
 @workflow(capability=messages.Capability.Ethereum)
@@ -329,7 +352,7 @@ def sign_tx_eip1559(
     payment_req: Optional[messages.PaymentRequest] = None,
     supports_definition_request: Optional[bool] = None,
     definition_source: Optional["Source"] = None,
-) -> Tuple[int, bytes, bytes]:
+) -> SignTxResult:
     length = len(data)
     data, chunk = data[1024:], data[:1024]
     msg = messages.EthereumSignTxEIP1559(
@@ -350,16 +373,7 @@ def sign_tx_eip1559(
         supports_definition_request=supports_definition_request,
     )
 
-    response = session.call(msg)
-
-    return _ethereum_sign_loop(
-        session,
-        messages.EthereumSignTxEIP1559,
-        response,
-        data,
-        chain_id,
-        definition_source,
-    )
+    return _ethereum_sign_loop(session, msg, data, definition_source)
 
 
 @workflow(capability=messages.Capability.Ethereum)


### PR DESCRIPTION
It would support returning EIP-7702 delegation tuples (see #6394) as well.

For backwards compatibility, it also implements `__getitem__` (to support tuple unpacking).

Also, simplify `_ethereum_sign_loop()`.

<!--
For external contributors:
- Please open an issue before submitting a PR so we can discuss whether we want to proceed with it.

For core developers:
1. Initial PR setup
- Assign yourself to the PR.
- Add it to the "Firmware" project
  - Set Priority (match issue priority if it exists)
  - Set Team
  - Set Sprint (target release)

2. Development status
- Draft PRs: Set status to "In Progress"
- Final PRs: Set status to "Needs Review"

3. Post-merge status
- Testable: Set status to "Needs QA" and add a `Notes for QA` section with clear instructions on how to test the functionality.
- Not Testable: Set status to "Done (no QA)"
-->
