### PR TITLE
fix(core/fido2): wait for interface to become writable

### DIFF
--- a/core/.changelog.d/7487.fixed
+++ b/core/.changelog.d/7487.fixed
@@ -1,0 +1,1 @@
+Fix intermittent SSH signature failure over FIDO2.

--- a/core/embed/upymod/modtrezorio/modtrezorio-usb-if.h
+++ b/core/embed/upymod/modtrezorio/modtrezorio-usb-if.h
@@ -97,6 +97,8 @@ static MP_DEFINE_CONST_FUN_OBJ_2(mod_trezorio_USBIF_write_obj,
 /// def write_blocking(self, msg: AnyBytes, timeout_ms: int) -> int:
 ///     """
 ///     Sends message using USB interface.
+///     Returns the number of bytes written, or a negative error value only if
+///     no bytes were written.
 ///     """
 static mp_obj_t mod_trezorio_USBIF_write_blocking(mp_obj_t self, mp_obj_t msg,
                                                   mp_obj_t timeout_ms) {

--- a/core/mocks/generated/trezorio/__init__.pyi
+++ b/core/mocks/generated/trezorio/__init__.pyi
@@ -80,6 +80,8 @@ class USBIF:
     def write_blocking(self, msg: AnyBytes, timeout_ms: int) -> int:
         """
         Sends message using USB interface.
+        Returns the number of bytes written, or a negative error value only if
+        no bytes were written.
         """
 
     def read(self, buf: bytearray, offset: int = 0) -> int:

--- a/core/src/apps/webauthn/fido2.py
+++ b/core/src/apps/webauthn/fido2.py
@@ -519,7 +519,9 @@ async def send_cmd(cmd: Cmd, iface: HID) -> None:
         seq += 1
 
 
-def send_cmd_sync(cmd: Cmd, iface: HID) -> None:
+def try_send_cmd_sync(cmd: Cmd, iface: HID) -> None:
+    """Try to send `cmd` synchronously, but don't fail if HID interface is blocked."""
+
     init_desc = frame_init()
     cont_desc = frame_cont()
     offset = 0
@@ -532,7 +534,10 @@ def send_cmd_sync(cmd: Cmd, iface: HID) -> None:
     frm.bcnt = datalen
 
     offset += utils.memcpy(frm.data, 0, cmd.data, offset, datalen)
-    iface.write(buf)
+    # Note: `write_blocking()` with zero timeout doesn't raise an exception.
+    if iface.write_blocking(buf, 0) != len(buf):
+        # If first packet is blocked, skip the rest.
+        return
 
     if offset < datalen:
         frm = overlay_struct(buf, cont_desc)
@@ -571,7 +576,9 @@ class KeepaliveCallback:
         self.iface = iface
 
     def __call__(self) -> None:
-        send_cmd_sync(cmd_keepalive(self.cid, _KEEPALIVE_STATUS_PROCESSING), self.iface)
+        try_send_cmd_sync(
+            cmd_keepalive(self.cid, _KEEPALIVE_STATUS_PROCESSING), self.iface
+        )
 
 
 async def verify_user(keepalive_callback: KeepaliveCallback) -> bool:
@@ -843,14 +850,16 @@ class Fido2ConfirmMakeCredential(Fido2State):
         cid = self.cid  # local_cache_attribute
 
         self._cred.generate_id()
-        send_cmd_sync(cmd_keepalive(cid, _KEEPALIVE_STATUS_PROCESSING), self.iface)
+        try_send_cmd_sync(cmd_keepalive(cid, _KEEPALIVE_STATUS_PROCESSING), self.iface)
         response_data = _cbor_make_credential_sign(
             self._client_data_hash, self._cred, self._user_verification
         )
 
         cmd = Cmd(cid, _CMD_CBOR, bytes([_ERR_NONE]) + response_data)
         if self._resident:
-            send_cmd_sync(cmd_keepalive(cid, _KEEPALIVE_STATUS_PROCESSING), self.iface)
+            try_send_cmd_sync(
+                cmd_keepalive(cid, _KEEPALIVE_STATUS_PROCESSING), self.iface
+            )
             if not store_resident_credential(self._cred):
                 cmd = cbor_error(cid, _ERR_KEY_STORE_FULL)
         await send_cmd(cmd, self.iface)
@@ -911,7 +920,9 @@ class Fido2ConfirmGetAssertion(Fido2State):
 
         assert self._selected_cred is not None
         try:
-            send_cmd_sync(cmd_keepalive(cid, _KEEPALIVE_STATUS_PROCESSING), self.iface)
+            try_send_cmd_sync(
+                cmd_keepalive(cid, _KEEPALIVE_STATUS_PROCESSING), self.iface
+            )
             response_data = cbor_get_assertion_sign(
                 self._client_data_hash,
                 self._selected_cred.rp_id_hash,


### PR DESCRIPTION
Otherwise, an OSError is raised by `mod_trezorio_USBIF_write` if the outgoing buffer is full.

We shouldn't raise if sending `_KEEPALIVE_STATUS_PROCESSING` is blocked.

Related to https://github.com/trezor/trezor-firmware/issues/7487.

There is a similar issue in `fido2.send_cmd()` -> #7553.

## Notes to QA:
Please use the following commands to generate an SSH key, and make sure SSH authentication works as expected:
```
$ ssh-keygen -t ed25519-sk -O application=ssh:ABCDEF
Generating public/private ed25519-sk key pair.
You may need to touch your authenticator to authorize key generation.
Enter file in which to save the key (/home/user/.ssh/id_ed25519_sk): 
/home/user/.ssh/id_ed25519_sk already exists.
Overwrite (y/n)? y
Enter passphrase (empty for no passphrase): 
Enter same passphrase again: 
...
$ cp ~/.ssh/id_ed25519_sk.pub ~/.ssh/authorized_keys
$ for i in `seq 1 20`; do ssh localhost true; done
```