### PR TITLE
fix(crypto): make aes functions reject negative length

### DIFF
--- a/core/embed/upymod/modtrezorcrypto/modtrezorcrypto-aes.h
+++ b/core/embed/upymod/modtrezorcrypto/modtrezorcrypto-aes.h
@@ -112,6 +112,7 @@ static mp_obj_t aes_update(mp_obj_t self, mp_obj_t data, bool encrypt) {
     return mp_const_empty_bytes;
   }
   vstr_t vstr = {0};
+  int ret = 0;
   vstr_init_len(&vstr, buf.len);
   mp_obj_AES_t *o = MP_OBJ_TO_PTR(self);
   switch (o->mode) {
@@ -120,11 +121,11 @@ static mp_obj_t aes_update(mp_obj_t self, mp_obj_t data, bool encrypt) {
         mp_raise_ValueError(MP_ERROR_TEXT("Invalid data length"));
       }
       if (encrypt) {
-        aes_ecb_encrypt(buf.buf, (uint8_t *)vstr.buf, buf.len,
-                        &(o->encrypt_ctx));
+        ret = aes_ecb_encrypt(buf.buf, (uint8_t *)vstr.buf, buf.len,
+                              &(o->encrypt_ctx));
       } else {
-        aes_ecb_decrypt(buf.buf, (uint8_t *)vstr.buf, buf.len,
-                        &(o->decrypt_ctx));
+        ret = aes_ecb_decrypt(buf.buf, (uint8_t *)vstr.buf, buf.len,
+                              &(o->decrypt_ctx));
       }
       break;
     case CBC:
@@ -132,30 +133,33 @@ static mp_obj_t aes_update(mp_obj_t self, mp_obj_t data, bool encrypt) {
         mp_raise_ValueError(MP_ERROR_TEXT("Invalid data length"));
       }
       if (encrypt) {
-        aes_cbc_encrypt(buf.buf, (uint8_t *)vstr.buf, buf.len, o->iv,
-                        &(o->encrypt_ctx));
+        ret = aes_cbc_encrypt(buf.buf, (uint8_t *)vstr.buf, buf.len, o->iv,
+                              &(o->encrypt_ctx));
       } else {
-        aes_cbc_decrypt(buf.buf, (uint8_t *)vstr.buf, buf.len, o->iv,
-                        &(o->decrypt_ctx));
+        ret = aes_cbc_decrypt(buf.buf, (uint8_t *)vstr.buf, buf.len, o->iv,
+                              &(o->decrypt_ctx));
       }
       break;
     case CFB:
       if (encrypt) {
-        aes_cfb_encrypt(buf.buf, (uint8_t *)vstr.buf, buf.len, o->iv,
-                        &(o->encrypt_ctx));
+        ret = aes_cfb_encrypt(buf.buf, (uint8_t *)vstr.buf, buf.len, o->iv,
+                              &(o->encrypt_ctx));
       } else {
-        aes_cfb_decrypt(buf.buf, (uint8_t *)vstr.buf, buf.len, o->iv,
-                        &(o->encrypt_ctx));  // decrypt uses encrypt_ctx
+        ret = aes_cfb_decrypt(buf.buf, (uint8_t *)vstr.buf, buf.len, o->iv,
+                              &(o->encrypt_ctx));  // decrypt uses encrypt_ctx
       }
       break;
     case OFB:  // (encrypt == decrypt)
-      aes_ofb_crypt(buf.buf, (uint8_t *)vstr.buf, buf.len, o->iv,
-                    &(o->encrypt_ctx));
+      ret = aes_ofb_crypt(buf.buf, (uint8_t *)vstr.buf, buf.len, o->iv,
+                          &(o->encrypt_ctx));
       break;
     case CTR:  // (encrypt == decrypt)
-      aes_ctr_crypt(buf.buf, (uint8_t *)vstr.buf, buf.len, o->iv,
-                    aes_ctr_cbuf_inc, &(o->encrypt_ctx));
+      ret = aes_ctr_crypt(buf.buf, (uint8_t *)vstr.buf, buf.len, o->iv,
+                          aes_ctr_cbuf_inc, &(o->encrypt_ctx));
       break;
+  }
+  if (ret != 0) {
+    mp_raise_type(&mp_type_RuntimeError);
   }
   return mp_obj_new_bytes_from_vstr(&vstr);
 }

--- a/crypto/aes/aes_modes.c
+++ b/crypto/aes/aes_modes.c
@@ -136,10 +136,12 @@ AES_RETURN aes_mode_reset(aes_encrypt_ctx ctx[1])
 
 AES_RETURN aes_ecb_encrypt(const unsigned char *ibuf, unsigned char *obuf,
                     int len, const aes_encrypt_ctx ctx[1])
-{   int nb = len >> AES_BLOCK_SIZE_P2;
+{   int nb = 0;
 
-    if(len & (AES_BLOCK_SIZE - 1))
+    if(len < 0 || (len & (AES_BLOCK_SIZE - 1)))
         return EXIT_FAILURE;
+
+    nb = len >> AES_BLOCK_SIZE_P2;
 
 #if defined( USE_VIA_ACE_IF_PRESENT )
 
@@ -198,10 +200,12 @@ AES_RETURN aes_ecb_encrypt(const unsigned char *ibuf, unsigned char *obuf,
 
 AES_RETURN aes_ecb_decrypt(const unsigned char *ibuf, unsigned char *obuf,
                     int len, const aes_decrypt_ctx ctx[1])
-{   int nb = len >> AES_BLOCK_SIZE_P2;
+{   int nb = 0;
 
-    if(len & (AES_BLOCK_SIZE - 1))
+    if(len < 0 || (len & (AES_BLOCK_SIZE - 1)))
         return EXIT_FAILURE;
+
+    nb = len >> AES_BLOCK_SIZE_P2;
 
 #if defined( USE_VIA_ACE_IF_PRESENT )
 
@@ -260,10 +264,12 @@ AES_RETURN aes_ecb_decrypt(const unsigned char *ibuf, unsigned char *obuf,
 
 AES_RETURN aes_cbc_encrypt(const unsigned char *ibuf, unsigned char *obuf,
                     int len, unsigned char *iv, const aes_encrypt_ctx ctx[1])
-{   int nb = len >> AES_BLOCK_SIZE_P2;
+{   int nb = 0;
 
-    if(len & (AES_BLOCK_SIZE - 1))
+    if(len < 0 || (len & (AES_BLOCK_SIZE - 1)))
         return EXIT_FAILURE;
+
+    nb = len >> AES_BLOCK_SIZE_P2;
 
 #if defined( USE_VIA_ACE_IF_PRESENT )
 
@@ -358,10 +364,12 @@ AES_RETURN aes_cbc_encrypt(const unsigned char *ibuf, unsigned char *obuf,
 AES_RETURN aes_cbc_decrypt(const unsigned char *ibuf, unsigned char *obuf,
                     int len, unsigned char *iv, const aes_decrypt_ctx ctx[1])
 {   unsigned char tmp[AES_BLOCK_SIZE] = {0};
-    int nb = len >> AES_BLOCK_SIZE_P2;
+    int nb = 0;
 
-    if(len & (AES_BLOCK_SIZE - 1))
+    if(len < 0 || (len & (AES_BLOCK_SIZE - 1)))
         return EXIT_FAILURE;
+
+    nb = len >> AES_BLOCK_SIZE_P2;
 
 #if defined( USE_VIA_ACE_IF_PRESENT )
 
@@ -457,6 +465,9 @@ AES_RETURN aes_cbc_decrypt(const unsigned char *ibuf, unsigned char *obuf,
 AES_RETURN aes_cfb_encrypt(const unsigned char *ibuf, unsigned char *obuf,
                     int len, unsigned char *iv, aes_encrypt_ctx ctx[1])
 {   int cnt = 0, b_pos = (int)ctx->inf.b[2], nb = 0;
+
+    if(len < 0)
+        return EXIT_FAILURE;
 
     if(b_pos)           /* complete any partial block   */
     {
@@ -582,6 +593,9 @@ AES_RETURN aes_cfb_encrypt(const unsigned char *ibuf, unsigned char *obuf,
 AES_RETURN aes_cfb_decrypt(const unsigned char *ibuf, unsigned char *obuf,
                     int len, unsigned char *iv, aes_encrypt_ctx ctx[1])
 {   int cnt = 0, b_pos = (int)ctx->inf.b[2], nb = 0;
+
+    if(len < 0)
+        return EXIT_FAILURE;
 
     if(b_pos)           /* complete any partial block   */
     {   uint8_t t = 0;
@@ -724,6 +738,9 @@ AES_RETURN aes_ofb_crypt(const unsigned char *ibuf, unsigned char *obuf,
                     int len, unsigned char *iv, aes_encrypt_ctx ctx[1])
 {   int cnt = 0, b_pos = (int)ctx->inf.b[2], nb = 0;
 
+    if(len < 0)
+        return EXIT_FAILURE;
+
     if(b_pos)           /* complete any partial block   */
     {
         while(b_pos < AES_BLOCK_SIZE && cnt < len)
@@ -859,6 +876,9 @@ AES_RETURN aes_ctr_crypt(const unsigned char *ibuf, unsigned char *obuf,
 #else
     uint8_t buf[BFR_LENGTH] = {0};
 #endif
+
+    if(len < 0)
+        return EXIT_FAILURE;
 
     if(b_pos)
     {

--- a/crypto/tests/test_check.c
+++ b/crypto/tests/test_check.c
@@ -24,6 +24,7 @@
 #include <assert.h>
 #include <check.h>
 #include <inttypes.h>
+#include <limits.h>
 #include <stdint.h>
 #include <stdio.h>
 #include <stdlib.h>
@@ -4518,6 +4519,7 @@ START_TEST(test_aes) {
   aes_decrypt_ctx ctxd;
   uint8_t ibuf[16], obuf[16], iv[16], cbuf[16];
   const char **ivp, **plainp, **cipherp;
+  int res = 0;
 
   // ECB
   static const char *ecb_vector[] = {
@@ -4537,20 +4539,24 @@ START_TEST(test_aes) {
   cipherp = ecb_vector + 1;
   while (*plainp && *cipherp) {
     // encrypt
-    aes_encrypt_key256(
+    res = aes_encrypt_key256(
         fromhex(
             "603deb1015ca71be2b73aef0857d77811f352c073b6108d72d9810a30914dff4"),
         &ctxe);
+    ck_assert_int_eq(res, EXIT_SUCCESS);
     memcpy(ibuf, fromhex(*plainp), 16);
-    aes_ecb_encrypt(ibuf, obuf, 16, &ctxe);
+    res = aes_ecb_encrypt(ibuf, obuf, 16, &ctxe);
+    ck_assert_int_eq(res, EXIT_SUCCESS);
     ck_assert_mem_eq(obuf, fromhex(*cipherp), 16);
     // decrypt
-    aes_decrypt_key256(
+    res = aes_decrypt_key256(
         fromhex(
             "603deb1015ca71be2b73aef0857d77811f352c073b6108d72d9810a30914dff4"),
         &ctxd);
+    ck_assert_int_eq(res, EXIT_SUCCESS);
     memcpy(ibuf, fromhex(*cipherp), 16);
-    aes_ecb_decrypt(ibuf, obuf, 16, &ctxd);
+    res = aes_ecb_decrypt(ibuf, obuf, 16, &ctxd);
+    ck_assert_int_eq(res, EXIT_SUCCESS);
     ck_assert_mem_eq(obuf, fromhex(*plainp), 16);
     plainp += 2;
     cipherp += 2;
@@ -4580,22 +4586,26 @@ START_TEST(test_aes) {
   cipherp = cbc_vector + 2;
   while (*plainp && *cipherp) {
     // encrypt
-    aes_encrypt_key256(
+    res = aes_encrypt_key256(
         fromhex(
             "603deb1015ca71be2b73aef0857d77811f352c073b6108d72d9810a30914dff4"),
         &ctxe);
+    ck_assert_int_eq(res, EXIT_SUCCESS);
     memcpy(iv, fromhex(*ivp), 16);
     memcpy(ibuf, fromhex(*plainp), 16);
-    aes_cbc_encrypt(ibuf, obuf, 16, iv, &ctxe);
+    res = aes_cbc_encrypt(ibuf, obuf, 16, iv, &ctxe);
+    ck_assert_int_eq(res, EXIT_SUCCESS);
     ck_assert_mem_eq(obuf, fromhex(*cipherp), 16);
     // decrypt
-    aes_decrypt_key256(
+    res = aes_decrypt_key256(
         fromhex(
             "603deb1015ca71be2b73aef0857d77811f352c073b6108d72d9810a30914dff4"),
         &ctxd);
+    ck_assert_int_eq(res, EXIT_SUCCESS);
     memcpy(iv, fromhex(*ivp), 16);
     memcpy(ibuf, fromhex(*cipherp), 16);
-    aes_cbc_decrypt(ibuf, obuf, 16, iv, &ctxd);
+    res = aes_cbc_decrypt(ibuf, obuf, 16, iv, &ctxd);
+    ck_assert_int_eq(res, EXIT_SUCCESS);
     ck_assert_mem_eq(obuf, fromhex(*plainp), 16);
     ivp += 3;
     plainp += 3;
@@ -4625,22 +4635,26 @@ START_TEST(test_aes) {
   cipherp = cfb_vector + 2;
   while (*plainp && *cipherp) {
     // encrypt
-    aes_encrypt_key256(
+    res = aes_encrypt_key256(
         fromhex(
             "603deb1015ca71be2b73aef0857d77811f352c073b6108d72d9810a30914dff4"),
         &ctxe);
+    ck_assert_int_eq(res, EXIT_SUCCESS);
     memcpy(iv, fromhex(*ivp), 16);
     memcpy(ibuf, fromhex(*plainp), 16);
-    aes_cfb_encrypt(ibuf, obuf, 16, iv, &ctxe);
+    res = aes_cfb_encrypt(ibuf, obuf, 16, iv, &ctxe);
+    ck_assert_int_eq(res, EXIT_SUCCESS);
     ck_assert_mem_eq(obuf, fromhex(*cipherp), 16);
     // decrypt (uses encryption)
-    aes_encrypt_key256(
+    res = aes_encrypt_key256(
         fromhex(
             "603deb1015ca71be2b73aef0857d77811f352c073b6108d72d9810a30914dff4"),
         &ctxe);
+    ck_assert_int_eq(res, EXIT_SUCCESS);
     memcpy(iv, fromhex(*ivp), 16);
     memcpy(ibuf, fromhex(*cipherp), 16);
-    aes_cfb_decrypt(ibuf, obuf, 16, iv, &ctxe);
+    res = aes_cfb_decrypt(ibuf, obuf, 16, iv, &ctxe);
+    ck_assert_int_eq(res, EXIT_SUCCESS);
     ck_assert_mem_eq(obuf, fromhex(*plainp), 16);
     ivp += 3;
     plainp += 3;
@@ -4670,22 +4684,26 @@ START_TEST(test_aes) {
   cipherp = ofb_vector + 2;
   while (*plainp && *cipherp) {
     // encrypt
-    aes_encrypt_key256(
+    res = aes_encrypt_key256(
         fromhex(
             "603deb1015ca71be2b73aef0857d77811f352c073b6108d72d9810a30914dff4"),
         &ctxe);
+    ck_assert_int_eq(res, EXIT_SUCCESS);
     memcpy(iv, fromhex(*ivp), 16);
     memcpy(ibuf, fromhex(*plainp), 16);
-    aes_ofb_encrypt(ibuf, obuf, 16, iv, &ctxe);
+    res = aes_ofb_encrypt(ibuf, obuf, 16, iv, &ctxe);
+    ck_assert_int_eq(res, EXIT_SUCCESS);
     ck_assert_mem_eq(obuf, fromhex(*cipherp), 16);
     // decrypt (uses encryption)
-    aes_encrypt_key256(
+    res = aes_encrypt_key256(
         fromhex(
             "603deb1015ca71be2b73aef0857d77811f352c073b6108d72d9810a30914dff4"),
         &ctxe);
+    ck_assert_int_eq(res, EXIT_SUCCESS);
     memcpy(iv, fromhex(*ivp), 16);
     memcpy(ibuf, fromhex(*cipherp), 16);
-    aes_ofb_decrypt(ibuf, obuf, 16, iv, &ctxe);
+    res = aes_ofb_decrypt(ibuf, obuf, 16, iv, &ctxe);
+    ck_assert_int_eq(res, EXIT_SUCCESS);
     ck_assert_mem_eq(obuf, fromhex(*plainp), 16);
     ivp += 3;
     plainp += 3;
@@ -4710,13 +4728,15 @@ START_TEST(test_aes) {
   plainp = ctr_vector;
   cipherp = ctr_vector + 1;
   memcpy(cbuf, fromhex("f0f1f2f3f4f5f6f7f8f9fafbfcfdfeff"), 16);
-  aes_encrypt_key256(
+  res = aes_encrypt_key256(
       fromhex(
           "603deb1015ca71be2b73aef0857d77811f352c073b6108d72d9810a30914dff4"),
       &ctxe);
+  ck_assert_int_eq(res, EXIT_SUCCESS);
   while (*plainp && *cipherp) {
     memcpy(ibuf, fromhex(*plainp), 16);
-    aes_ctr_encrypt(ibuf, obuf, 16, cbuf, aes_ctr_cbuf_inc, &ctxe);
+    res = aes_ctr_encrypt(ibuf, obuf, 16, cbuf, aes_ctr_cbuf_inc, &ctxe);
+    ck_assert_int_eq(res, EXIT_SUCCESS);
     ck_assert_mem_eq(obuf, fromhex(*cipherp), 16);
     plainp += 2;
     cipherp += 2;
@@ -4725,16 +4745,57 @@ START_TEST(test_aes) {
   plainp = ctr_vector;
   cipherp = ctr_vector + 1;
   memcpy(cbuf, fromhex("f0f1f2f3f4f5f6f7f8f9fafbfcfdfeff"), 16);
-  aes_encrypt_key256(
+  res = aes_encrypt_key256(
       fromhex(
           "603deb1015ca71be2b73aef0857d77811f352c073b6108d72d9810a30914dff4"),
       &ctxe);
+  ck_assert_int_eq(res, EXIT_SUCCESS);
   while (*plainp && *cipherp) {
     memcpy(ibuf, fromhex(*cipherp), 16);
-    aes_ctr_decrypt(ibuf, obuf, 16, cbuf, aes_ctr_cbuf_inc, &ctxe);
+    res = aes_ctr_decrypt(ibuf, obuf, 16, cbuf, aes_ctr_cbuf_inc, &ctxe);
+    ck_assert_int_eq(res, EXIT_SUCCESS);
     ck_assert_mem_eq(obuf, fromhex(*plainp), 16);
     plainp += 2;
     cipherp += 2;
+  }
+}
+END_TEST
+
+// the AES mode functions take a signed length parameter,
+// negative values have to be rejected
+START_TEST(test_aes_negative_length) {
+  aes_encrypt_ctx ctxe;
+  aes_decrypt_ctx ctxd;
+  uint8_t ibuf[16] = {0};
+  uint8_t obuf[16] = {0};
+  uint8_t iv[16] = {0};
+  uint8_t cbuf[16] = {0};
+
+  // -16 is a negative multiple of AES_BLOCK_SIZE
+  static const int lengths[] = {-1, -16, INT_MIN};
+
+  const uint8_t *key = fromhex(
+      "603deb1015ca71be2b73aef0857d77811f352c073b6108d72d9810a30914dff4");
+  ck_assert_int_eq(aes_encrypt_key256(key, &ctxe), EXIT_SUCCESS);
+  ck_assert_int_eq(aes_decrypt_key256(key, &ctxd), EXIT_SUCCESS);
+
+  for (size_t i = 0; i < sizeof(lengths) / sizeof(lengths[0]); i++) {
+    int len = lengths[i];
+
+    ck_assert_int_eq(aes_ecb_encrypt(ibuf, obuf, len, &ctxe), EXIT_FAILURE);
+    ck_assert_int_eq(aes_ecb_decrypt(ibuf, obuf, len, &ctxd), EXIT_FAILURE);
+    ck_assert_int_eq(aes_cbc_encrypt(ibuf, obuf, len, iv, &ctxe), EXIT_FAILURE);
+    ck_assert_int_eq(aes_cbc_decrypt(ibuf, obuf, len, iv, &ctxd), EXIT_FAILURE);
+    ck_assert_int_eq(aes_cfb_encrypt(ibuf, obuf, len, iv, &ctxe), EXIT_FAILURE);
+    ck_assert_int_eq(aes_cfb_decrypt(ibuf, obuf, len, iv, &ctxe), EXIT_FAILURE);
+    ck_assert_int_eq(aes_ofb_encrypt(ibuf, obuf, len, iv, &ctxe), EXIT_FAILURE);
+    ck_assert_int_eq(aes_ofb_decrypt(ibuf, obuf, len, iv, &ctxe), EXIT_FAILURE);
+    ck_assert_int_eq(
+        aes_ctr_encrypt(ibuf, obuf, len, cbuf, aes_ctr_cbuf_inc, &ctxe),
+        EXIT_FAILURE);
+    ck_assert_int_eq(
+        aes_ctr_decrypt(ibuf, obuf, len, cbuf, aes_ctr_cbuf_inc, &ctxe),
+        EXIT_FAILURE);
   }
 }
 END_TEST
@@ -12520,6 +12581,7 @@ Suite *test_suite(void) {
 
   tc = tcase_create("aes");
   tcase_add_test(tc, test_aes);
+  tcase_add_test(tc, test_aes_negative_length);
   suite_add_tcase(s, tc);
 
   tc = tcase_create("aes_ccm");

--- a/legacy/firmware/fsm_msg_crypto.h
+++ b/legacy/firmware/fsm_msg_crypto.h
@@ -54,16 +54,23 @@ void fsm_msgCipherKeyValue(const CipherKeyValue *msg) {
   }
 
   RESP_INIT(CipheredKeyValue);
+  bool ok = false;
   if (encrypt) {
     aes_encrypt_ctx ctx;
-    aes_encrypt_key256(data, &ctx);
-    aes_cbc_encrypt(msg->value.bytes, resp->value.bytes, msg->value.size,
-                    data + 32, &ctx);
+    ok = aes_encrypt_key256(data, &ctx) == EXIT_SUCCESS &&
+         aes_cbc_encrypt(msg->value.bytes, resp->value.bytes, msg->value.size,
+                         data + 32, &ctx) == EXIT_SUCCESS;
   } else {
     aes_decrypt_ctx ctx;
-    aes_decrypt_key256(data, &ctx);
-    aes_cbc_decrypt(msg->value.bytes, resp->value.bytes, msg->value.size,
-                    data + 32, &ctx);
+    ok = aes_decrypt_key256(data, &ctx) == EXIT_SUCCESS &&
+         aes_cbc_decrypt(msg->value.bytes, resp->value.bytes, msg->value.size,
+                         data + 32, &ctx) == EXIT_SUCCESS;
+  }
+  if (!ok) {
+    fsm_sendFailure(FailureType_Failure_ProcessError,
+                    _("Failed to cipher key value"));
+    layoutHome();
+    return;
   }
   resp->value.size = msg->value.size;
   msg_write(MessageType_MessageType_CipheredKeyValue, resp);


### PR DESCRIPTION
## Notes

- `nb` in CBC/ECB functions is now derived **after** the length `len` is checked - to not derive anything from an unchecked `len`.
- This PR is a minimal change that does not modify the current API. The aes functions are used in many places and a full rework is not worth it. In our code, the functions are used correctly.

**Potential future improvements:**
- Add a wrapper that checks the parameters (e.g. the size of output buffer),... and only after that calls the "potentially unsafe" aes functions. (low-priority, discussed and decided that they are not worth the effort.)