### PR TITLE
THP: close channel when unable to allocate large enough buffer

### DIFF
--- a/core/src/trezor/wire/thp/interface_context.py
+++ b/core/src/trezor/wire/thp/interface_context.py
@@ -272,7 +272,7 @@ class InterfaceContext:
         except Exception as exc:
             if __debug__:
                 log.exception(__name__, exc)
-            self.active_channel.kill(exc)
+            self.active_channel.clear(exc=exc)
             self.active_channel = None
         self.clear_closed_sessions()
 

--- a/tests/device_tests/bitcoin/test_signmessage.py
+++ b/tests/device_tests/bitcoin/test_signmessage.py
@@ -22,6 +22,7 @@ from trezorlib import btc, messages
 from trezorlib.debuglink import DebugSession as Session
 from trezorlib.debuglink import LayoutType, message_filters
 from trezorlib.exceptions import Cancelled
+from trezorlib.thp.exceptions import ThpError, ThpErrorCode
 from trezorlib.tools import parse_path
 
 from ...common import is_core
@@ -52,6 +53,9 @@ def case(
 MESSAGE_NFKD = "Pr\u030ci\u0301s\u030cerne\u030c z\u030clut\u030couc\u030cky\u0301 ku\u030an\u030c u\u0301pe\u030cl d\u030ca\u0301belske\u0301 o\u0301dy za\u0301ker\u030cny\u0301 uc\u030cen\u030c be\u030cz\u030ci\u0301 pode\u0301l zo\u0301ny u\u0301lu\u030a"
 MESSAGE_NFC = "P\u0159\xed\u0161ern\u011b \u017elu\u0165ou\u010dk\xfd k\u016f\u0148 \xfap\u011bl \u010f\xe1belsk\xe9 \xf3dy z\xe1ke\u0159n\xfd u\u010de\u0148 b\u011b\u017e\xed pod\xe9l z\xf3ny \xfal\u016f"
 NFKD_NFC_SIGNATURE = "2046a0b46e81492f82e0412c73701b9740e6462c603575ee2d36c7d7b4c20f0f33763ca8cb3027ea8e1ce5e83fda8b6746fea8f5c82655d78fd419e7c766a5e17a"
+
+# depends on memory_manager._PROTOBUF_BUFFER_SIZE and the size of SignMessage fields
+THP_LEN_MAX = 8641
 
 VECTORS = (  # case name, coin_name, path, script_type, address, message, signature
     # ==== Bitcoin script types ====
@@ -383,6 +387,7 @@ MESSAGE_LENGTHS = (
     ),
     pytest.param("PříšerněŽluťoučkýKůňÚpělĎábelskéÓdy" * 16, True, id="utf_nospace"),
     pytest.param("1\n2\n3\n4\n5\n6\n7", False, id="single_line_over"),
+    pytest.param("a" * THP_LEN_MAX, True, id="longest"),
 )
 
 MESSAGE_LENGTHS_ECKHART = (
@@ -399,6 +404,7 @@ MESSAGE_LENGTHS_ECKHART = (
     ),
     pytest.param("PříšerněŽluťoučkýKůňÚpělĎábelskéÓdy" * 23, True, id="utf_nospace"),
     pytest.param("1\n2\n3\n4\n5\n6\n7\n8\n9", False, id="single_line_over"),
+    pytest.param("a" * THP_LEN_MAX, True, id="longest"),
 )
 
 
@@ -493,3 +499,16 @@ def test_signmessage_path_warning(session: Session):
             message=message,
             script_type=messages.InputScriptType.SPENDWITNESS,
         )
+
+
+@pytest.mark.protocol("thp")
+def test_signmessage_too_long(session: Session):
+    message = (THP_LEN_MAX + 1) * "a"
+    with pytest.raises(ThpError) as exc_info:
+        btc.sign_message(
+            session,
+            coin_name="Bitcoin",
+            n=parse_path("m/44h/0h/0h/0/0"),
+            message=message,
+        )
+    assert exc_info.value.code == ThpErrorCode.UNALLOCATED_CHANNEL


### PR DESCRIPTION
Current main silently fails and the host keeps retransmitting. After this change, `UNALLOCATED_CHANNEL` is sent after first retransmission after which the host should give up.

<!--
For external contributors:
- Please open an issue before submitting a PR so we can discuss whether we want to proceed with it.

For core developers:
1. Initial PR setup
- Assign yourself to the PR.
- Add it to the "Firmware" project
  - Set Priority (match issue priority if it exists)
  - Set Team
  - Set Sprint (target release)

2. Development status
- Draft PRs: Set status to "In Progress"
- Final PRs: Set status to "Needs Review"

3. Post-merge status
- Testable: Set status to "Needs QA" and add a `Notes for QA` section with clear instructions on how to test the functionality.
- Not Testable: Set status to "Done (no QA)"
-->
