### PR TITLE
fix(defs): remove Holesky network

### DIFF
--- a/common/defs/ethereum/networks.json
+++ b/common/defs/ethereum/networks.json
@@ -10,15 +10,6 @@
         "slip44": 60
     },
     {
-        "chain": "hol",
-        "chain_id": 17000,
-        "is_testnet": true,
-        "name": "Holesky",
-        "shortcut": "tHOL",
-        "symbol": "tHOL",
-        "slip44": 60
-    },
-    {
         "chain": "hod",
         "chain_id": 560048,
         "is_testnet": true,

--- a/common/defs/support.json
+++ b/common/defs/support.json
@@ -116,7 +116,6 @@
       "misc:XTZ": "not implemented",
       "misc:tADA": "not implemented",
       "misc:tXRP": "not implemented",
-      "eth:tHOL:17000": "Deprecated testnet",
       "misc:TRX": "not implemented"
     }
   },
@@ -237,8 +236,7 @@
       "nem:DIMTOK": "not for T2B1 (#2793)",
       "nem:PAC:CHS": "not for T2B1 (#2793)",
       "nem:PAC:HRT": "not for T2B1 (#2793)",
-      "nem:XEM": "not for T2B1 (#2793)",
-      "eth:tHOL:17000": "Deprecated testnet"
+      "nem:XEM": "not for T2B1 (#2793)"
     }
   },
   "T2T1": {
@@ -358,8 +356,7 @@
       "bitcoin:PART": "incompatible fork",
       "bitcoin:TRC": "address_type collides with Bitcoin",
       "bitcoin:tPART": "incompatible fork",
-      "misc:LSK": "Incompatible mainnet hard-fork",
-      "eth:tHOL:17000": "Deprecated testnet"
+      "misc:LSK": "Incompatible mainnet hard-fork"
     }
   },
   "T3B1": {
@@ -479,8 +476,7 @@
       "nem:DIMTOK": "not for T3B1 (#2793)",
       "nem:PAC:CHS": "not for T3B1 (#2793)",
       "nem:PAC:HRT": "not for T3B1 (#2793)",
-      "nem:XEM": "not for T3B1 (#2793)",
-      "eth:tHOL:17000": "Deprecated testnet"
+      "nem:XEM": "not for T3B1 (#2793)"
     }
   },
   "T3T1": {
@@ -600,8 +596,7 @@
       "nem:DIMTOK": "not for T3T1 (#2793)",
       "nem:PAC:CHS": "not for T3T1 (#2793)",
       "nem:PAC:HRT": "not for T3T1 (#2793)",
-      "nem:XEM": "not for T3T1 (#2793)",
-      "eth:tHOL:17000": "Deprecated testnet"
+      "nem:XEM": "not for T3T1 (#2793)"
     }
   },
   "T3W1": {
@@ -721,8 +716,7 @@
       "nem:DIMTOK": "not for T3W1 (#2793)",
       "nem:PAC:CHS": "not for T3W1 (#2793)",
       "nem:PAC:HRT": "not for T3W1 (#2793)",
-      "nem:XEM": "not for T3W1 (#2793)",
-      "eth:tHOL:17000": "Deprecated testnet"
+      "nem:XEM": "not for T3W1 (#2793)"
     }
   },
 
@@ -843,8 +837,7 @@
       "nem:DIMTOK": "not for T3W1 (#2793)",
       "nem:PAC:CHS": "not for T3W1 (#2793)",
       "nem:PAC:HRT": "not for T3W1 (#2793)",
-      "nem:XEM": "not for T3W1 (#2793)",
-      "eth:tHOL:17000": "Deprecated testnet"
+      "nem:XEM": "not for T3W1 (#2793)"
     }
   },
 
@@ -965,8 +958,7 @@
       "nem:DIMTOK": "not for T3W1 (#2793)",
       "nem:PAC:CHS": "not for T3W1 (#2793)",
       "nem:PAC:HRT": "not for T3W1 (#2793)",
-      "nem:XEM": "not for T3W1 (#2793)",
-      "eth:tHOL:17000": "Deprecated testnet"
+      "nem:XEM": "not for T3W1 (#2793)"
     }
   }
 }

--- a/core/.changelog.d/6137.removed
+++ b/core/.changelog.d/6137.removed
@@ -1,0 +1,1 @@
+Remove the deprecated Holesky testnet definition.


### PR DESCRIPTION
## Description

Fixes #6137 by removing the deprecated Holesky testnet definition and its unsupported-device entries. A core changelog fragment records the removal.

## Validation

- JSON syntax validation for `common/defs/ethereum/networks.json` and `common/defs/support.json`
- `common/tools/support.py check`
- `common/tools/cointool.py check --no-icons` — everything is OK
