### PR TITLE
Remove libtropic's pin to develop branch

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -33,7 +33,6 @@
 [submodule "vendor/libtropic"]
 	path = vendor/libtropic
 	url = https://github.com/tropicsquare/libtropic.git
-	branch = develop
 [submodule "vendor/ts-tvl"]
 	path = vendor/ts-tvl
 	url = https://github.com/tropicsquare/ts-tvl


### PR DESCRIPTION
Change based on a report.

- The pin to branch was added here: https://github.com/trezor/trezor-firmware/pull/5542/changes/380d908d7d881551994607aa045d338f08540aa5 and seems to be unnecessary, as check-outed release tag is on the default `master` branch anyway. 
- Note that we do not specify the branch for other submodules (with the intentional exception for `sphincsplus`).