### PR TITLE
Update rand to v0.10.1

### DIFF
--- a/core/embed/Cargo.lock
+++ b/core/embed/Cargo.lock
@@ -665,9 +665,9 @@ dependencies = [
 
 [[package]]
 name = "rand"
-version = "0.10.0"
+version = "0.10.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bc266eb313df6c5c09c1c7b1fbe2510961e5bcd3add930c1e31f7ed9da0feff8"
+checksum = "d2e8e8bcc7961af1fdac401278c6a831614941f6164ee3bf4ce61b7edb162207"
 dependencies = [
  "rand_core",
 ]

--- a/core/embed/Cargo.toml
+++ b/core/embed/Cargo.toml
@@ -114,7 +114,7 @@ hex = "0.4.3"
 owo-colors = "4.3.0"
 pathdiff = "0.2.3"
 pkg-config = "0.3.28"
-rand = { version = "0.10.0", default-features = false }
+rand = { version = "0.10.1", default-features = false }
 serde = "1.0.228"
 serde_json = "1.0.145"
 tempfile = { version = "3.25.0", default-features = false }

--- a/core/embed/supply-chain/imports.lock
+++ b/core/embed/supply-chain/imports.lock
@@ -117,6 +117,12 @@ who = "Chris Fallin <chris@cfallin.org>"
 criteria = "safe-to-deploy"
 delta = "0.3.29 -> 0.3.32"
 
+[[audits.bytecodealliance.audits.rand]]
+who = "Alex Crichton <alex@alexcrichton.com>"
+criteria = "safe-to-deploy"
+delta = "0.10.0 -> 0.10.1"
+notes = "Minor logging-based updated fixing a recent advisory for the crate."
+
 [[audits.bytecodealliance.audits.shlex]]
 who = "Alex Crichton <alex@alexcrichton.com>"
 criteria = "safe-to-deploy"


### PR DESCRIPTION
- Updated rand v0.10.0 -> v0.10.1.
- Release: https://github.com/rust-random/rand/releases#release-0.10.1
- Changelog: https://github.com/rust-random/rand/blob/master/CHANGELOG.md
- Changes: https://github.com/rust-random/rand/compare/0.10.0...0.10.1

Brings a few minor security improvements. Resolves: https://github.com/trezor/trezor-firmware/security/dependabot/152

**Note:** Not updating to rand v0.10.2 as audit for v0.10.2 is not available yet.