### PR TITLE
fix(core): correct `get_slip39_remaining_shares()` return value handling

### DIFF
--- a/core/src/apps/management/recovery_device/recover.py
+++ b/core/src/apps/management/recovery_device/recover.py
@@ -63,9 +63,7 @@ def process_slip39(words: str) -> tuple[bytes | None, slip39.Share]:
     if share.group_count != storage_recovery.get_slip39_group_count():
         raise RuntimeError("Slip39: Group count does not match")
 
-    remaining_for_share = (
-        storage_recovery.get_slip39_remaining_shares(group_index) or share.threshold
-    )
+    remaining_for_share = storage_recovery.get_slip39_remaining_shares(share)
     storage_recovery.set_slip39_remaining_shares(remaining_for_share - 1, group_index)
     remaining[group_index] = remaining_for_share - 1
     storage_recovery_shares.set(share.index, group_index, words)

--- a/core/src/storage/recovery.py
+++ b/core/src/storage/recovery.py
@@ -4,6 +4,7 @@ from typing import TYPE_CHECKING
 from storage import common
 
 if TYPE_CHECKING:
+    from trezor.crypto import slip39
     from trezor.enums import RecoveryType
 
 # Namespace:
@@ -117,13 +118,15 @@ def set_slip39_remaining_shares(shares_remaining: int, group_index: int) -> None
     common.set(_NAMESPACE, _REMAINING, remaining)
 
 
-def get_slip39_remaining_shares(group_index: int) -> int | None:
+def get_slip39_remaining_shares(share: slip39.Share) -> int:
+    """Return number of remaining shares in this group."""
     from trezor.crypto.slip39 import MAX_SHARE_COUNT
 
     _require_progress()
+    group_index = share.group_index  # local_cache_attribute
     remaining = common.get(_NAMESPACE, _REMAINING)
     if remaining is None or remaining[group_index] == MAX_SHARE_COUNT:
-        return None
+        return share.threshold
     else:
         return remaining[group_index]
 

--- a/core/tests/test_apps.management.recovery_device.py
+++ b/core/tests/test_apps.management.recovery_device.py
@@ -43,7 +43,7 @@ class TestSlip39(unittest.TestCase):
         )
         self.assertEqual(share.identifier, storage.recovery.get_slip39_identifier())
         self.assertEqual(share.extendable, False)
-        self.assertEqual(storage.recovery.get_slip39_remaining_shares(0), 2)
+        self.assertEqual(storage.recovery.get_slip39_remaining_shares(share), 2)
         self.assertEqual(
             storage.recovery_shares.get(share.index, share.group_index), first
         )
@@ -52,7 +52,7 @@ class TestSlip39(unittest.TestCase):
         second = MNEMONIC_SLIP39_BASIC_20_3of6[1]
         secret, share = process_slip39(second)
         self.assertIsNone(secret)
-        self.assertEqual(storage.recovery.get_slip39_remaining_shares(0), 1)
+        self.assertEqual(storage.recovery.get_slip39_remaining_shares(share), 1)
         self.assertEqual(
             storage.recovery_shares.get(share.index, share.group_index), second
         )
@@ -64,7 +64,7 @@ class TestSlip39(unittest.TestCase):
         third = MNEMONIC_SLIP39_BASIC_20_3of6[2]
         secret, share = process_slip39(third)
         self.assertEqual(secret, b"I\x1by[\x80\xfc!\xcc\xdfFl\x0f\xbc\x98\xc8\xfc")
-        self.assertEqual(storage.recovery.get_slip39_remaining_shares(0), 0)
+        self.assertEqual(storage.recovery.get_slip39_remaining_shares(share), 0)
         self.assertEqual(
             storage.recovery_shares.get(share.index, share.group_index), third
         )


### PR DESCRIPTION
It should always return an integer value, to avoid confusion between 0 and None.

Following https://satoshilabs.slack.com/archives/C0AU13ENJJW/p1786444452143289.