### PR TITLE
Bolt UI: external menu

### DIFF
--- a/core/embed/rust/src/ui/layout_bolt/component/mod.rs
+++ b/core/embed/rust/src/ui/layout_bolt/component/mod.rs
@@ -27,6 +27,8 @@ mod page;
 mod progress;
 mod result;
 mod scroll;
+#[cfg(feature = "micropython")]
+mod select_menu;
 #[cfg(feature = "storage")]
 mod set_brightness;
 #[cfg(feature = "translations")]
@@ -64,6 +66,8 @@ pub use page::ButtonPage;
 pub use progress::Progress;
 pub use result::{ResultFooter, ResultScreen, ResultStyle};
 pub use scroll::ScrollBar;
+#[cfg(feature = "micropython")]
+pub use select_menu::{SelectMenu, SelectMenuMsg};
 #[cfg(feature = "storage")]
 pub use set_brightness::SetBrightnessDialog;
 #[cfg(feature = "translations")]

--- a/core/embed/rust/src/ui/layout_bolt/component/select_menu.rs
+++ b/core/embed/rust/src/ui/layout_bolt/component/select_menu.rs
@@ -1,0 +1,148 @@
+use heapless::Vec;
+
+use super::{theme, Button, ButtonMsg};
+use crate::error::Error;
+use crate::strutil::TString;
+use crate::ui::component::{Component, Event, EventCtx};
+use crate::ui::geometry::{Insets, Rect};
+use crate::ui::shape::Renderer;
+use crate::ui::ui_firmware::MAX_MENU_ITEMS;
+
+/// Maximum number of buttons shown on the screen at once.
+/// TODO: pagination for menus with more items.
+const MAX_VISIBLE_BUTTONS: usize = 3;
+
+#[cfg_attr(feature = "debug", derive(ufmt::derive::uDebug))]
+pub enum SelectMenuMsg {
+    /// Menu item selected (index into `items`, excluding the cancel item).
+    Selected(usize),
+    /// The cancel menu item was selected.
+    Cancelled,
+    /// The menu was closed without selecting anything.
+    Closed,
+}
+
+/// Simple vertical menu of buttons, with an optional cancel item at the
+/// bottom and a close button in the top-right corner.
+pub struct SelectMenu {
+    choice_buttons: Vec<Button, MAX_MENU_ITEMS>,
+    cancel_button: Option<Button>,
+    close_button: Button,
+}
+
+impl SelectMenu {
+    pub fn new(
+        items: Vec<TString<'static>, MAX_MENU_ITEMS>,
+        cancel: Option<TString<'static>>,
+    ) -> Result<Self, Error> {
+        if items.len() + cancel.map_or(0, |_| 1) > 3 {
+            return Err(Error::NotImplementedError);
+        }
+        let choice_buttons = items
+            .into_iter()
+            .map(|text| Button::with_text(text).styled(theme::button_default()))
+            .collect();
+        let cancel_button =
+            cancel.map(|text| Button::with_text(text).styled(theme::button_cancel()));
+        let close_button =
+            Button::with_icon(theme::ICON_CORNER_CANCEL).styled(theme::button_moreinfo());
+
+        Ok(Self {
+            choice_buttons,
+            cancel_button,
+            close_button,
+        })
+    }
+
+    /// Number of choice buttons that fit on the screen. The cancel button is
+    /// always visible, so it reserves a slot for itself.
+    fn visible_choices(&self) -> usize {
+        let max = if self.cancel_button.is_some() {
+            MAX_VISIBLE_BUTTONS - 1
+        } else {
+            MAX_VISIBLE_BUTTONS
+        };
+        self.choice_buttons.len().min(max)
+    }
+}
+
+impl Component for SelectMenu {
+    type Msg = SelectMenuMsg;
+
+    fn place(&mut self, bounds: Rect) -> Rect {
+        let bounds = bounds.inset(theme::borders());
+
+        // Close button in the top-right corner, same as in `Frame`.
+        let (_, button_area) = bounds.split_right(theme::CORNER_BUTTON_SIDE);
+        let (button_area, _) = button_area.split_top(theme::CORNER_BUTTON_SIDE);
+        self.close_button.place(button_area);
+
+        let content = bounds.inset(Insets::top(
+            theme::CORNER_BUTTON_SIDE + theme::BUTTON_SPACING,
+        ));
+
+        // Buttons are stacked from the top down in fixed-height slots (same
+        // height as in `select_word`), so they never stretch to fill the
+        // whole area.
+        let mut slots = content;
+        let n_choices = self.visible_choices();
+        for button in self.choice_buttons.iter_mut().take(n_choices) {
+            let (slot, rest) = slots.split_top(theme::BUTTON_HEIGHT);
+            button.place(slot);
+            slots = rest.inset(Insets::top(theme::BUTTON_SPACING));
+        }
+        if let Some(cancel) = &mut self.cancel_button {
+            let (slot, _) = slots.split_top(theme::BUTTON_HEIGHT);
+            cancel.place(slot);
+        }
+
+        bounds
+    }
+
+    fn event(&mut self, ctx: &mut EventCtx, event: Event) -> Option<Self::Msg> {
+        let n_choices = self.visible_choices();
+        for (i, button) in self.choice_buttons.iter_mut().take(n_choices).enumerate() {
+            if matches!(button.event(ctx, event), Some(ButtonMsg::Clicked)) {
+                return Some(SelectMenuMsg::Selected(i));
+            }
+        }
+        if let Some(cancel) = &mut self.cancel_button {
+            if matches!(cancel.event(ctx, event), Some(ButtonMsg::Clicked)) {
+                return Some(SelectMenuMsg::Cancelled);
+            }
+        }
+        if matches!(
+            self.close_button.event(ctx, event),
+            Some(ButtonMsg::Clicked)
+        ) {
+            return Some(SelectMenuMsg::Closed);
+        }
+        None
+    }
+
+    fn render<'s>(&'s self, target: &mut impl Renderer<'s>) {
+        for button in self.choice_buttons.iter().take(self.visible_choices()) {
+            button.render(target);
+        }
+        if let Some(cancel) = &self.cancel_button {
+            cancel.render(target);
+        }
+        self.close_button.render(target);
+    }
+}
+
+#[cfg(feature = "ui_debug")]
+impl crate::trace::Trace for SelectMenu {
+    fn trace(&self, t: &mut dyn crate::trace::Tracer) {
+        t.component("SelectMenu");
+        t.in_list("buttons", &|button_list| {
+            for button in self.choice_buttons.iter().take(self.visible_choices()) {
+                button_list.child(button);
+            }
+            if let Some(cancel) = &self.cancel_button {
+                button_list.child(cancel);
+            }
+        });
+        t.child("close_button", &self.close_button);
+    }
+}

--- a/core/embed/rust/src/ui/layout_bolt/component_msg_obj.rs
+++ b/core/embed/rust/src/ui/layout_bolt/component_msg_obj.rs
@@ -5,7 +5,8 @@ use super::component::{
     DialogMsg, FidoConfirm, FidoMsg, Frame, FrameMsg, Homescreen, HomescreenMsg, IconDialog,
     Lockscreen, MnemonicInput, MnemonicKeyboard, MnemonicKeyboardMsg, NumberInputDialog,
     NumberInputDialogMsg, PassphraseKeyboard, PassphraseKeyboardMsg, PinKeyboard, PinKeyboardMsg,
-    Progress, SelectWordCountMsg, SelectWordMsg, SetBrightnessDialog, SimplePage,
+    Progress, SelectMenu, SelectMenuMsg, SelectWordCountMsg, SelectWordMsg, SetBrightnessDialog,
+    SimplePage,
 };
 use crate::error::Error;
 use crate::micropython::obj::Obj;
@@ -48,6 +49,18 @@ impl TryFrom<SelectWordMsg> for Obj {
     fn try_from(value: SelectWordMsg) -> Result<Self, Self::Error> {
         match value {
             SelectWordMsg::Selected(i) => i.try_into(),
+        }
+    }
+}
+
+impl ComponentMsgObj for SelectMenu {
+    fn msg_try_into_obj(&self, msg: Self::Msg) -> Result<Obj, Error> {
+        match msg {
+            SelectMenuMsg::Selected(i) => i.try_into(),
+            SelectMenuMsg::Cancelled => Ok(CANCELLED.as_obj()),
+            // Closing the menu without a choice is a confirmation, not a
+            // cancellation (same as on other layouts).
+            SelectMenuMsg::Closed => Ok(CONFIRMED.as_obj()),
         }
     }
 }

--- a/core/embed/rust/src/ui/layout_bolt/ui_firmware.rs
+++ b/core/embed/rust/src/ui/layout_bolt/ui_firmware.rs
@@ -4,8 +4,8 @@ use super::component::{
     check_homescreen_format, AddressDetails, Bip39Input, Button, ButtonMsg, ButtonPage,
     ButtonStyleSheet, CancelConfirmMsg, CoinJoinProgress, Dialog, FidoConfirm, Frame, Homescreen,
     IconDialog, Lockscreen, MnemonicKeyboard, NumberInputDialog, PassphraseKeyboard, PinKeyboard,
-    Progress, SelectWordCount, SelectWordCountLayout, SetBrightnessDialog, ShareWords, SimplePage,
-    Slip39Input,
+    Progress, SelectMenu, SelectWordCount, SelectWordCountLayout, SetBrightnessDialog, ShareWords,
+    SimplePage, Slip39Input,
 };
 use super::{fonts, theme, UIBolt};
 use crate::error::{value_error, Error};
@@ -719,11 +719,12 @@ impl FirmwareUI for UIBolt {
     }
 
     fn select_menu(
-        _items: heapless::Vec<TString<'static>, MAX_MENU_ITEMS>,
+        items: heapless::Vec<TString<'static>, MAX_MENU_ITEMS>,
         _current: usize,
-        _cancel: Option<TString<'static>>,
+        cancel: Option<TString<'static>>,
     ) -> Result<impl LayoutMaybeTrace, Error> {
-        Err::<RootComponent<Empty, ModelUI>, Error>(Error::NotImplementedError)
+        let layout = RootComponent::new(SelectMenu::new(items, cancel)?);
+        Ok(layout)
     }
 
     fn select_word(

--- a/core/tests/test_trezor.ui.select_menu.py
+++ b/core/tests/test_trezor.ui.select_menu.py
@@ -1,0 +1,94 @@
+# flake8: noqa: F403,F405
+from common import *  # isort:skip
+
+import trezorui_api
+from trezor import io, utils
+
+
+def click(layout, x, y):
+    layout.touch_event(io.TOUCH_START, x, y)
+    if layout.touch_event(io.TOUCH_END, x, y) is not None:
+        # the layout is done, fetch the result
+        return layout.return_value()
+    return None
+
+
+# Coordinates are specific to the Bolt layout (240x240 screen).
+# The menu shows at most 3 buttons in fixed 50px slots stacked from the
+# top of the content area.
+CENTER_X = 120
+SLOT_TOP_Y = 81
+SLOT_MIDDLE_Y = 137
+SLOT_BOTTOM_Y = 193
+CLOSE_BUTTON_X = 212
+CLOSE_BUTTON_Y = 28
+
+
+@unittest.skipUnless(utils.UI_LAYOUT == "BOLT", "Bolt layout only")
+class TestSelectMenu(unittest.TestCase):
+
+    ITEMS = ["Alpha", "Beta"]
+
+    def make_menu(self, items=None, cancel="Cancel"):
+        if items is None:
+            items = self.ITEMS
+        layout = trezorui_api.select_menu(
+            items=items,
+            current=0,
+            cancel=cancel,
+        )
+        layout.paint()
+        return layout
+
+    def test_select_first_item(self):
+        layout = self.make_menu()
+        self.assertEqual(click(layout, CENTER_X, SLOT_TOP_Y), 0)
+
+    def test_select_last_item(self):
+        layout = self.make_menu()
+        self.assertEqual(click(layout, CENTER_X, SLOT_MIDDLE_Y), 1)
+
+    def test_select_cancel_item(self):
+        layout = self.make_menu()
+        self.assertIs(click(layout, CENTER_X, SLOT_BOTTOM_Y), trezorui_api.CANCELLED)
+
+    def test_close_button(self):
+        layout = self.make_menu()
+        # top-right corner button closes the menu without cancelling
+        self.assertIs(
+            click(layout, CLOSE_BUTTON_X, CLOSE_BUTTON_Y), trezorui_api.CONFIRMED
+        )
+
+    def test_no_cancel_item(self):
+        layout = self.make_menu(cancel=None)
+        self.assertEqual(click(layout, CENTER_X, SLOT_TOP_Y), 0)
+        layout = self.make_menu(cancel=None)
+        self.assertEqual(click(layout, CENTER_X, SLOT_MIDDLE_Y), 1)
+
+    def test_single_button_takes_one_slot(self):
+        # a lone button sits in the top slot and does not stretch
+        layout = self.make_menu(items=[])
+        self.assertIsNone(click(layout, CENTER_X, SLOT_BOTTOM_Y))
+        layout = self.make_menu(items=[])
+        self.assertIs(click(layout, CENTER_X, SLOT_TOP_Y), trezorui_api.CANCELLED)
+
+    def test_buttons_clamped_to_three_slots(self):
+        # three choices plus a cancel button would exceed the three slots
+        with self.assertRaises(NotImplementedError):
+            self.make_menu(items=["Alpha", "Beta", "Gamma"])
+        # four choices alone also exceed the limit
+        with self.assertRaises(NotImplementedError):
+            self.make_menu(items=["Alpha", "Beta", "Gamma", "Delta"], cancel=None)
+
+    def test_trace(self):
+        layout = self.make_menu()
+        parts = []
+        layout.trace(parts.append)
+        trace = "".join(parts)
+        self.assertIn('"SelectMenu"', trace)
+        for name in self.ITEMS + ["Cancel"]:
+            self.assertIn(name, trace)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
<!--
For external contributors:
- Please open an issue before submitting a PR so we can discuss whether we want to proceed with it.

For core developers:
1. Initial PR setup
- Assign yourself to the PR.
- Add it to the "Firmware" project
  - Set Priority (match issue priority if it exists)
  - Set Team
  - Set Sprint (target release)

2. Development status
- Draft PRs: Set status to "In Progress"
- Final PRs: Set status to "Needs Review"

3. Post-merge status
- Testable: Set status to "Needs QA" and add a `Notes for QA` section with clear instructions on how to test the functionality.
- Not Testable: Set status to "Done (no QA)"
-->
This PR adds support for external menus for Bolt layout (T2T1), i.e. `FirmwareUI::select_menu` implementation. It's not yet used in any flow in this PR.

This effort is to align individual layouts to a common API to make UX flows creation more streamlined.

It can be tested using `trezorctl ping 'test' -b` with the following diff:
```diff
diff --git a/core/src/apps/base.py b/core/src/apps/base.py
index 28eaa360d0..8ff74b574c 100644
--- a/core/src/apps/base.py
+++ b/core/src/apps/base.py
@@ -446,10 +446,33 @@ async def handle_EndSession(msg: EndSession) -> Success:
 
 async def handle_Ping(msg: Ping) -> Success:
     if msg.button_protection:
+        import trezorui_api
         from trezor.enums import ButtonRequestType as B
         from trezor.ui.layouts import confirm_action
-
-        await confirm_action("ping", TR.words__confirm, "ping", br_code=B.ProtectCall)
+        from trezor.ui.layouts.menu import Details, Menu, show_menu
+
+        # await confirm_action("ping", TR.words__confirm, "ping", br_code=B.ProtectCall)
+
+        items = [
+            Details.from_layout(
+                "Item 1",
+                lambda: trezorui_api.show_info_with_cancel(
+                    title="Title",
+                    items=[
+                        ("Key", "value", None),
+                    ],
+                ),
+            ),
+            Details.from_layout(
+                "Item 2 - with a very long text",
+                lambda: trezorui_api.show_warning(title="Title", button="Button"),
+            ),
+        ]
+        menu = Menu.root(
+            items,
+            cancel=TR.buttons__cancel,
+        )
+        await show_menu(menu)
     return Success(message=msg.message)
 ```
 
Examples:
<img width="403" height="636" alt="image" src="https://github.com/user-attachments/assets/2090152e-46a5-43e2-88e7-ada5602d2d36" />

<img width="408" height="609" alt="image" src="https://github.com/user-attachments/assets/4b75156b-0c07-4034-8354-5c9e15c86796" />
