### PR TITLE
Fail cargo audit on warnings

### DIFF
--- a/core/Makefile
+++ b/core/Makefile
@@ -216,7 +216,7 @@ clippy:
 	xtask clippy -e -m $(TREZOR_MODEL) firmware
 
 audit_rust: ## run cargo audit on rust dependencies
-	cd embed ; cargo audit
+	cd embed ; cargo audit --deny warnings
 
 vet_rust: ## run cargo vet on rust dependencies
 	cd embed ; cargo vet --locked

--- a/core/embed/Cargo.lock
+++ b/core/embed/Cargo.lock
@@ -40,9 +40,9 @@ checksum = "5192cca8006f1fd4f7237516f40fa183bb07f8fbdfedaa0036de5ea9b0b45e78"
 
 [[package]]
 name = "anyhow"
-version = "1.0.102"
+version = "1.0.104"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7f202df86484c868dbad7eaa557ef785d5c66295e41b460ef922eca0723b842c"
+checksum = "330a5ed07fa54e4702c9d6c4174f74427fc0ef6e214bbd677ae50a5099946470"
 
 [[package]]
 name = "autocfg"
@@ -848,9 +848,9 @@ checksum = "0fda2ff0d084019ba4d7c6f371c95d8fd75ce3524c3cb8fb653a3023f6323e64"
 
 [[package]]
 name = "spin"
-version = "0.9.8"
+version = "0.9.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6980e8d7511241f8acf4aebddbb1ff938df5eebe98691418c4468d0b72a96a67"
+checksum = "3763264f6b73151db08c50ff20d7d8a0b8796e021cdea7ceedad07b80155fa0e"
 
 [[package]]
 name = "stable_deref_trait"

--- a/core/embed/Cargo.toml
+++ b/core/embed/Cargo.toml
@@ -82,7 +82,7 @@ num-derive = "0.4.2"
 num-traits = { version = "0.2.19", default-features = false, features = ["libm"] }
 pareen = { version = "0.3.3", path = "../../rust/pareen", default-features = false, features = ["libm", "easer"] }
 qrcodegen = { version = "1.8.0", path = "../vendor/QR-Code-generator/rust-no-heap" }
-spin = { version = "0.9.8", features = ["rwlock", "spin_mutex", "lazy"], default-features = false }
+spin = { version = "0.9.9", features = ["rwlock", "spin_mutex", "lazy"], default-features = false }
 static-alloc = "0.2.6"
 trezor-thp = { path = "../../rust/trezor-thp" }
 trezor-tjpgdec = { version = "0.1.0", path = "../../rust/trezor-tjpgdec" }

--- a/core/embed/supply-chain/config.toml
+++ b/core/embed/supply-chain/config.toml
@@ -45,7 +45,7 @@ version = "1.0.13"
 criteria = "safe-to-deploy"
 
 [[exemptions.anyhow]]
-version = "1.0.102"
+version = "1.0.104"
 criteria = "safe-to-deploy"
 
 [[exemptions.backtrace]]
@@ -231,7 +231,7 @@ version = "0.6.8"
 criteria = "safe-to-deploy"
 
 [[exemptions.spin]]
-version = "0.9.8"
+version = "0.9.9"
 criteria = "safe-to-deploy"
 
 [[exemptions.static-alloc]]

--- a/rust/Makefile
+++ b/rust/Makefile
@@ -38,5 +38,5 @@ audit:
 	@set -e; for D in $(CRATES); do ( \
 		echo "[AUDIT $$D]"; \
 		cd $$D; \
-		cargo audit \
+		cargo audit --deny warnings \
 	); done

--- a/rust/trezor-client/Cargo.lock
+++ b/rust/trezor-client/Cargo.lock
@@ -13,9 +13,9 @@ dependencies = [
 
 [[package]]
 name = "anyhow"
-version = "1.0.98"
+version = "1.0.104"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e16d2d3311acee920a9eb8d33b8cbc1787ce4a264e85f964c2404b969bdcd487"
+checksum = "330a5ed07fa54e4702c9d6c4174f74427fc0ef6e214bbd677ae50a5099946470"
 
 [[package]]
 name = "arrayvec"
@@ -149,31 +149,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "37909eebbb50d72f9059c3b6d82c0463f2ff062c9e95845c43a6c9c0355411be"
 
 [[package]]
-name = "futures"
-version = "0.3.31"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "65bc07b1a8bc7c85c5f2e110c476c7389b4554ba72af57d8445ea63a576b0876"
-dependencies = [
- "futures-channel",
- "futures-core",
- "futures-executor",
- "futures-io",
- "futures-sink",
- "futures-task",
- "futures-util",
-]
-
-[[package]]
-name = "futures-channel"
-version = "0.3.31"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2dff15bf788c671c1934e366d07e30c1814a8ef514e1af724a602e8a2fbe1b10"
-dependencies = [
- "futures-core",
- "futures-sink",
-]
-
-[[package]]
 name = "futures-core"
 version = "0.3.31"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -191,18 +166,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "futures-io"
-version = "0.3.31"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9e5c1b78ca4aae1ac06c48a526a655760685149f0d465d21f37abfe57ce075c6"
-
-[[package]]
-name = "futures-sink"
-version = "0.3.31"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e575fab7d1e0dcb8d0c7bcf9a63ee213816ab51902e6d244a95819acacf1d4f7"
-
-[[package]]
 name = "futures-task"
 version = "0.3.31"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -214,12 +177,8 @@ version = "0.3.31"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9fa08315bb612088cc391249efdc3bc77536f16c91f6cf495e6fbe85b20a4a81"
 dependencies = [
- "futures-channel",
  "futures-core",
- "futures-io",
- "futures-sink",
  "futures-task",
- "memchr",
  "pin-project-lite",
  "pin-utils",
  "slab",
@@ -547,25 +506,10 @@ dependencies = [
 ]
 
 [[package]]
-name = "scc"
-version = "2.3.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "22b2d775fb28f245817589471dd49c5edf64237f4a19d10ce9a92ff4651a27f4"
-dependencies = [
- "sdd",
-]
-
-[[package]]
 name = "scopeguard"
 version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "94143f37725109f92c262ed2cf5e59bce7498c01bcc1502d7b9afe439a4e9f49"
-
-[[package]]
-name = "sdd"
-version = "3.0.8"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "584e070911c7017da6cb2eb0788d09f43d789029b5877d3e5ecc8acf86ceee21"
 
 [[package]]
 name = "secp256k1"
@@ -588,23 +532,23 @@ dependencies = [
 
 [[package]]
 name = "serial_test"
-version = "3.2.0"
+version = "3.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1b258109f244e1d6891bf1053a55d63a5cd4f8f4c30cf9a1280989f80e7a1fa9"
+checksum = "699f4197115b8a7e7ff19c9a315a4bd6fffec26cc4626ef45ecaea389e081c6d"
 dependencies = [
- "futures",
+ "futures-executor",
+ "futures-util",
  "log",
  "once_cell",
  "parking_lot",
- "scc",
  "serial_test_derive",
 ]
 
 [[package]]
 name = "serial_test_derive"
-version = "3.2.0"
+version = "3.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5d69265a08751de7844521fd15003ae0a888e035773ba05695c5c759a6f89eef"
+checksum = "94e153fc76e1c6a068703d6d29c508a0b15c061c4b7e43da59cc097bc342673c"
 dependencies = [
  "proc-macro2",
  "quote",


### PR DESCRIPTION
## Treat warnings as errors
- Warnings - yanked, unsound, unmaintained, and notice - are now treated
as errors. 
  - See yanked and unsound fail in this CI jobs: 
    - Rust dependencies check:  
    https://github.com/trezor/trezor-firmware/actions/runs/31597041231/job/94115240752?pr=7547
    - Rust crates test: 
    https://github.com/trezor/trezor-firmware/actions/runs/31597041191/job/94114980520?pr=7547
  
## Updated/removed packages
### core/embed
- Updating anyhow v1.0.102 -> v1.0.104.
- Updating spin v0.9.8 -> v0.9.9.
### rust/trezor-client
- Removing futures v0.3.31.
- Removing futures-channel v0.3.31.
- Removing futures-io v0.3.31.
- Removing futures-sink v0.3.31.
- Removing scc v2.3.4.
- Removing sdd v3.0.8.
- Updating anyhow v1.0.98 -> v1.0.104.
- Updating serial_test v3.2.0 -> v3.5.0.

## Diffs and changes to check

### anyhow
- Diff (github): https://github.com/dtolnay/anyhow/compare/1.0.102...1.0.104 (ignoring additional diff from 1.0.98 to 1.0.102 in `trezor-client`. If deemed relevant, it should be checked too.)
- Diff (diff.rs): https://diff.rs/anyhow/1.0.102/1.0.104/
- Description of the fixed issue: https://github.com/dtolnay/anyhow/issues/451

### spin 
- Diff (codeberg): https://codeberg.org/zesterer/spin/compare/502c9dca...d882207a
- Diff (diff.rs): https://diff.rs/spin/0.9.8/0.9.9/
- Commit fixing the issue (that lead to 0.9.8 being yanked): https://codeberg.org/zesterer/spin/commit/5a4291384eff

### serial_test, serial_test_derive
- Diff (github, combined): https://github.com/palfrey/serial_test/compare/v3.2.0...v3.5.0
- Diff (diff.rs, serial_test): https://diff.rs/serial_test/3.2.0/3.5.0/ 
- Diff (diff.rs, serial_test_derive): https://diff.rs/serial_test_derive/3.2.0/3.5.0/
- Notes: update of `serial_test` and `serial_test_derive` allows to drop `scc` dependency, which has an unsound warning (codeberg issue: https://codeberg.org/wvwwvwwv/scalable-concurrent-containers/issues/232). It also allows to drop `futures`, `futures-channel`, `futures-io`, `futures-sink`, and `sdd` dependencies.