### PR TITLE
syscall hardening

### DIFF
--- a/core/embed/io/gfx/jpegdec/stm32u5/jpegdec.c
+++ b/core/embed/io/gfx/jpegdec/stm32u5/jpegdec.c
@@ -261,8 +261,16 @@ static inline bool jpegdec_feed_fifo(jpegdec_t *dec, jpegdec_input_t *inp) {
       inp->offset += 4;
     }
     if (inp->offset < inp->size) {
-      size_t bits = (inp->size - inp->offset) * 8;
-      JPEG->DIR = *ptr & (0xFFFFFFFF >> (32 - bits));
+      // Assemble the last, possibly incomplete word byte by byte so that
+      // nothing past the end of the input buffer is read. Missing bytes stay
+      // zero.
+      const uint8_t *tail = &inp->data[inp->offset];
+      size_t remaining = inp->size - inp->offset;
+      uint32_t word = 0;
+      for (size_t i = 0; i < remaining; i++) {
+        word |= (uint32_t)tail[i] << (8 * i);
+      }
+      JPEG->DIR = word;
       inp->offset = inp->size;
     }
     return true;

--- a/core/embed/projects/prodtest/cmd/prodtest_backup_ram.c
+++ b/core/embed/projects/prodtest/cmd/prodtest_backup_ram.c
@@ -171,7 +171,11 @@ static void prodtest_backup_ram_write(cli_t* cli) {
     return;
   }
 
-  if (!backup_ram_write(key, type, data, len)) {
+  // Omitting the value removes the key
+  bool ok = (len == 0) ? backup_ram_erase_item(key)
+                       : backup_ram_write(key, type, data, len);
+
+  if (!ok) {
     cli_error(cli, PRODTEST_ERR_BACKUP_RAM_KEY_WRITE, "Failed to write key #%d",
               key);
     return;

--- a/core/embed/sec/backup_ram/inc/sec/backup_ram.h
+++ b/core/embed/sec/backup_ram/inc/sec/backup_ram.h
@@ -100,8 +100,10 @@ uint16_t backup_ram_search(uint16_t min_key);
  * @param key Key to identify the data
  * @param data Pointer to the data to be stored
  * @param type Type of the data being stored
- * @param data_size Size of the data in bytes. If the key does not exist, this
- * value will be set to 0. If data_size == 0, the item will be removed.
+ * @param data_size Size of the data in bytes
+ *
+ * `data` must not be NULL and `data_size` must not be zero. Use
+ * `backup_ram_erase_item()` to remove an item.
  *
  * @return true if the operation was successful, false otherwise.
  */

--- a/core/embed/sec/backup_ram/stm32u5/backup_ram.c
+++ b/core/embed/sec/backup_ram/stm32u5/backup_ram.c
@@ -358,6 +358,21 @@ uint16_t backup_ram_search(uint16_t min_key) {
   return key;
 }
 
+// Drops an item from the payload, moving the following items down.
+//
+// The caller must hold the IRQ lock, must have located `item` with
+// `backup_ram_find_item()`, and must commit the change afterwards.
+static void backup_ram_drop_item(backup_ram_item_t* item) {
+  backup_ram_driver_t* drv = &g_backup_ram_driver;
+
+  size_t deleted_size = ITEM_SIZE(item->data_size);
+  uint8_t* next_item = (uint8_t*)item + deleted_size;
+  uint8_t* end_of_payload = drv->payload + drv->payload_size;
+  assert(next_item <= end_of_payload);
+  memmove(item, next_item, end_of_payload - next_item);
+  drv->payload_size -= deleted_size;
+}
+
 bool backup_ram_erase_item(uint16_t key) {
   backup_ram_driver_t* drv = &g_backup_ram_driver;
 
@@ -365,13 +380,20 @@ bool backup_ram_erase_item(uint16_t key) {
     return false;
   }
 
+  bool success = true;
+
   irq_key_t irq_key = irq_lock();
-  // Writing data_size==0 will just remove the item with the given key
-  // Type is don't care in this case.
-  bool status = backup_ram_write(key, BACKUP_RAM_ITEM_PUBLIC, NULL, 0);
+
+  backup_ram_item_t* item = backup_ram_find_item(key);
+
+  if (item != NULL) {
+    backup_ram_drop_item(item);
+    success = backup_ram_commit();
+  }
+
   irq_unlock(irq_key);
 
-  return status;
+  return success;
 }
 
 bool backup_ram_erase_protected(void) {
@@ -447,6 +469,12 @@ bool backup_ram_write(uint16_t key, backup_ram_item_type_t type,
     return false;
   }
 
+  if (data == NULL || data_size == 0) {
+    // There is nothing to store. Use `backup_ram_erase_item()` to remove an
+    // item.
+    return false;
+  }
+
   if (data_size > BACKUP_RAM_MAX_KEY_DATA_SIZE) {
     // Data size exceeds maximum allowed size
     return false;
@@ -458,7 +486,7 @@ bool backup_ram_write(uint16_t key, backup_ram_item_type_t type,
 
   backup_ram_item_t* item = backup_ram_find_item(key);
 
-  if (item != NULL && item->item_type != type && data_size != 0) {
+  if (item != NULL && item->item_type != type) {
     // Item exists but has a different type, not supported
     goto cleanup;
   }
@@ -482,25 +510,18 @@ bool backup_ram_write(uint16_t key, backup_ram_item_type_t type,
 
     // Remove the item if it exists
     if (item != NULL) {
-      size_t deleted_size = ITEM_SIZE(item->data_size);
-      uint8_t* next_item = (uint8_t*)item + deleted_size;
-      uint8_t* end_of_payload = drv->payload + drv->payload_size;
-      assert(next_item <= end_of_payload);
-      memmove(item, next_item, end_of_payload - next_item);
-      drv->payload_size -= deleted_size;
+      backup_ram_drop_item(item);
     }
 
     // Add a new item at the end of the payload
-    if (data_size > 0) {
-      item = (backup_ram_item_t*)&drv->payload[drv->payload_size];
-      item->key = key;
-      item->data_size = data_size;
-      item->item_type = type;
-      item->reserved = 0;
-      memcpy(item->data, data, data_size);
-      memset(&item->data[data_size], 0, ALIGN_UP(data_size, 4) - data_size);
-      drv->payload_size += ITEM_SIZE(data_size);
-    }
+    item = (backup_ram_item_t*)&drv->payload[drv->payload_size];
+    item->key = key;
+    item->data_size = data_size;
+    item->item_type = type;
+    item->reserved = 0;
+    memcpy(item->data, data, data_size);
+    memset(&item->data[data_size], 0, ALIGN_UP(data_size, 4) - data_size);
+    drv->payload_size += ITEM_SIZE(data_size);
   }
 
   // Commit the changes to backup RAM

--- a/core/embed/sys/mpu/inc/sys/mpu.h
+++ b/core/embed/sys/mpu/inc/sys/mpu.h
@@ -107,6 +107,9 @@ void mpu_set_active_fb(const void* addr, size_t size);
 
 // Returns true if the given address and size are inside
 // the active framebuffer previously set by `mpu_set_active_fb()`.
+//
+// Returns false whenever no framebuffer is set, for any address and size,
+// including a zero-length range at address 0.
 bool mpu_inside_active_fb(const void* addr, size_t size);
 
 #endif  // KERNEL_MODE

--- a/core/embed/sys/mpu/stm32f4/mpu.c
+++ b/core/embed/sys/mpu/stm32f4/mpu.c
@@ -232,6 +232,9 @@ bool mpu_inside_active_fb(const void* addr, size_t size) {
   irq_key_t lock = irq_lock();
 
   bool result =
+      // an inaccessible framebuffer contains nothing, see
+      // `mpu_set_active_fb()`
+      (drv->active_fb_addr != 0) && (drv->active_fb_size > 0) &&
       ((uintptr_t)addr + size >= (uintptr_t)addr) &&  // overflow check
       ((uintptr_t)addr >= drv->active_fb_addr) &&
       ((uintptr_t)addr + size <= drv->active_fb_addr + drv->active_fb_size);

--- a/core/embed/sys/mpu/stm32u5/mpu.c
+++ b/core/embed/sys/mpu/stm32u5/mpu.c
@@ -412,6 +412,9 @@ bool mpu_inside_active_fb(const void* addr, size_t size) {
   irq_key_t lock = irq_lock();
 
   bool result =
+      // an inaccessible framebuffer contains nothing, see
+      // `mpu_set_active_fb()`
+      (drv->active_fb.start != 0) && (drv->active_fb.size > 0) &&
       ((uintptr_t)addr + size >= (uintptr_t)addr) &&  // overflow check
       ((uintptr_t)addr >= drv->active_fb.start) &&
       ((uintptr_t)addr + size <= drv->active_fb.start + drv->active_fb.size);

--- a/core/embed/sys/smcall/stm32/smcall_probe.c
+++ b/core/embed/sys/smcall/stm32/smcall_probe.c
@@ -29,8 +29,12 @@
 #ifdef SECMON
 
 bool probe_read_access(const void *addr, size_t len) {
+  // NULL is not a valid non-secure address. Rejected explicitly so that this
+  // function enforces the rule, instead of inheriting it from the range check
+  // below. Smcall arguments that are optional by contract must use
+  // `probe_read_access_opt()` instead.
   if (addr == NULL) {
-    return true;
+    return false;
   }
 
   // Address overflow check
@@ -47,8 +51,12 @@ bool probe_read_access(const void *addr, size_t len) {
 }
 
 bool probe_write_access(void *addr, size_t len) {
+  // NULL is not a valid non-secure address. Rejected explicitly so that this
+  // function enforces the rule, instead of inheriting it from the range check
+  // below. Smcall arguments that are optional by contract must use
+  // `probe_write_access_opt()` instead.
   if (addr == NULL) {
-    return true;
+    return false;
   }
 
   // Address overflow check
@@ -65,8 +73,11 @@ bool probe_write_access(void *addr, size_t len) {
 }
 
 bool probe_execute_access(const void *addr) {
+  // NULL is not a valid non-secure address. Rejected explicitly, as in the read
+  // and write probes, so that all three state the same rule. Smcall arguments
+  // that accept NULL by contract must use `probe_execute_access_opt()` instead.
   if (addr == NULL) {
-    return true;
+    return false;
   }
 
   // Just check if the address is in non-secure address range

--- a/core/embed/sys/smcall/stm32/smcall_probe.h
+++ b/core/embed/sys/smcall/stm32/smcall_probe.h
@@ -27,14 +27,41 @@
 
 // Checks if the non-secure code has read access to the
 // given memory range.
+//
+// `addr` must be a non-secure address. NULL is always rejected.
+// Use `probe_read_access_opt()` for optional arguments.
 bool probe_read_access(const void *addr, size_t len);
 
 // Checks if the non-secure code has write access to the
 // given memory range.
+//
+// `addr` must be a non-secure address. NULL is always rejected.
+// Use `probe_write_access_opt()` for optional arguments.
 bool probe_write_access(void *addr, size_t len);
 
 // Checks if the provided address is in non-secure address range
+//
+// NULL is rejected. Use `probe_execute_access_opt()` for optional arguments.
 bool probe_execute_access(const void *addr);
+
+// Variants for smcall arguments that are optional by contract, i.e. where
+// NULL is a meaningful value passed on to the smcall implementation.
+//
+// These exist so that every such argument is explicit at the call site and
+// a NULL reaching any other probe is caught as an access violation instead
+// of being dereferenced by the secure monitor.
+
+static inline bool probe_read_access_opt(const void *addr, size_t len) {
+  return (addr == NULL) || probe_read_access(addr, len);
+}
+
+static inline bool probe_write_access_opt(void *addr, size_t len) {
+  return (addr == NULL) || probe_write_access(addr, len);
+}
+
+static inline bool probe_execute_access_opt(const void *addr) {
+  return (addr == NULL) || probe_execute_access(addr);
+}
 
 // Exits the current application task with an fatal error
 // with the message "Access violation".

--- a/core/embed/sys/smcall/stm32/smcall_verifiers.c
+++ b/core/embed/sys/smcall/stm32/smcall_verifiers.c
@@ -65,11 +65,15 @@ bool boot_image_check__verified(const boot_image_t *image) {
     goto access_violation;
   }
 
-  if (!probe_read_access(image->image_ptr, image->image_size)) {
+  // Work on a copy so that the verified fields cannot differ from
+  // the ones the implementation uses.
+  boot_image_t image_copy = *image;
+
+  if (!probe_read_access(image_copy.image_ptr, image_copy.image_size)) {
     goto access_violation;
   }
 
-  return boot_image_check(image);
+  return boot_image_check(&image_copy);
 
 access_violation:
   apptask_access_violation();
@@ -81,11 +85,15 @@ void boot_image_replace__verified(const boot_image_t *image) {
     goto access_violation;
   }
 
-  if (!probe_read_access(image->image_ptr, image->image_size)) {
+  // Work on a copy so that the verified fields cannot differ from
+  // the ones the implementation uses.
+  boot_image_t image_copy = *image;
+
+  if (!probe_read_access(image_copy.image_ptr, image_copy.image_size)) {
     goto access_violation;
   }
 
-  boot_image_replace(image);
+  boot_image_replace(&image_copy);
   return;
 
 access_violation:

--- a/core/embed/sys/smcall/stm32/smcall_verifiers.c
+++ b/core/embed/sys/smcall/stm32/smcall_verifiers.c
@@ -307,7 +307,8 @@ static secbool storage_callback_wrapper(uint32_t wait, uint32_t progress,
 }
 
 void storage_setup__verified(PIN_UI_WAIT_CALLBACK callback) {
-  if (!probe_execute_access(callback)) {
+  // NULL callback is allowed and disables the UI progress callback
+  if (!probe_execute_access_opt(callback)) {
     goto access_violation;
   }
 
@@ -327,7 +328,8 @@ storage_unlock_result_t storage_unlock__verified(const uint8_t *pin,
     goto access_violation;
   }
 
-  if (!probe_read_access(ext_salt, EXTERNAL_SALT_SIZE)) {
+  // NULL ext_salt is allowed and means no external salt is used
+  if (!probe_read_access_opt(ext_salt, EXTERNAL_SALT_SIZE)) {
     goto access_violation;
   }
 
@@ -344,7 +346,8 @@ storage_pin_change_result_t storage_change_pin__verified(
     goto access_violation;
   }
 
-  if (!probe_read_access(new_ext_salt, EXTERNAL_SALT_SIZE)) {
+  // NULL new_ext_salt is allowed and means no external salt is used
+  if (!probe_read_access_opt(new_ext_salt, EXTERNAL_SALT_SIZE)) {
     goto access_violation;
   }
 
@@ -376,7 +379,8 @@ secbool storage_change_wipe_code__verified(const uint8_t *pin, size_t pin_len,
     goto access_violation;
   }
 
-  if (!probe_read_access(ext_salt, EXTERNAL_SALT_SIZE)) {
+  // NULL ext_salt is allowed and means no external salt is used
+  if (!probe_read_access_opt(ext_salt, EXTERNAL_SALT_SIZE)) {
     goto access_violation;
   }
 
@@ -394,7 +398,8 @@ access_violation:
 
 secbool storage_get__verified(const uint16_t key, void *val,
                               const uint16_t max_len, uint16_t *len) {
-  if (!probe_write_access(val, max_len)) {
+  // NULL val is allowed and queries the value length only
+  if (!probe_write_access_opt(val, max_len)) {
     goto access_violation;
   }
 
@@ -565,11 +570,13 @@ access_violation:
 
 bool backup_ram_read__verified(uint16_t key, void *buffer, size_t buffer_size,
                                size_t *data_size) {
-  if (!probe_write_access(buffer, buffer_size)) {
+  // NULL buffer is allowed and only queries the size, NULL data_size is
+  // allowed and skips reporting it
+  if (!probe_write_access_opt(buffer, buffer_size)) {
     goto access_violation;
   }
 
-  if (!probe_write_access(data_size, sizeof(*data_size))) {
+  if (!probe_write_access_opt(data_size, sizeof(*data_size))) {
     goto access_violation;
   }
 

--- a/core/embed/sys/syscall/stm32/syscall_probe.c
+++ b/core/embed/sys/syscall/stm32/syscall_probe.c
@@ -43,8 +43,12 @@ bool probe_read_access(const void *addr, size_t len) {
     return false;
   }
 
+  // NULL is not part of any applet area. Rejected explicitly so that this
+  // function enforces the rule, instead of inheriting it from the area checks
+  // below. Syscall arguments that are optional by contract must use
+  // `probe_read_access_opt()` instead.
   if (addr == NULL) {
-    return true;
+    return false;
   }
 
   // Address overflow check
@@ -93,8 +97,12 @@ bool probe_write_access(void *addr, size_t len) {
     return false;
   }
 
+  // NULL is not part of any applet area. Rejected explicitly so that this
+  // function enforces the rule, instead of inheriting it from the area checks
+  // below. Syscall arguments that are optional by contract must use
+  // `probe_write_access_opt()` instead.
   if (addr == NULL) {
-    return true;
+    return false;
   }
 
   // Address overflow check
@@ -122,8 +130,15 @@ bool probe_write_access(void *addr, size_t len) {
 bool probe_execute_access(const void *addr) {
   applet_t *applet = syscall_get_context();
 
+  if (applet == NULL) {
+    return false;
+  }
+
+  // NULL is not part of any applet area. Rejected explicitly, as in the read
+  // and write probes, so that all three state the same rule. Syscall arguments
+  // that accept NULL by contract must use `probe_execute_access_opt()` instead.
   if (addr == NULL) {
-    return true;
+    return false;
   }
 
   // Check if the first 4 bytes at the address are within

--- a/core/embed/sys/syscall/stm32/syscall_probe.h
+++ b/core/embed/sys/syscall/stm32/syscall_probe.h
@@ -30,15 +30,42 @@
 
 // Checks if the current application task has read access to the
 // given memory range.
+//
+// `addr` must point inside the task's memory. NULL is always rejected.
+// Use `probe_read_access_opt()` for optional arguments.
 bool probe_read_access(const void *addr, size_t len);
 
 // Checks if the current application task has write access to the
 // given memory range.
+//
+// `addr` must point inside the task's memory. NULL is always rejected.
+// Use `probe_write_access_opt()` for optional arguments.
 bool probe_write_access(void *addr, size_t len);
 
 // Checks if the current application task can execute code at the
 // given address.
+//
+// NULL is rejected. Use `probe_execute_access_opt()` for optional arguments.
 bool probe_execute_access(const void *addr);
+
+// Variants for syscall arguments that are optional by contract, i.e. where
+// NULL is a meaningful value passed on to the syscall implementation.
+//
+// These exist so that every such argument is explicit at the call site and
+// a NULL reaching any other probe is caught as an access violation instead
+// of being dereferenced by the kernel.
+
+static inline bool probe_read_access_opt(const void *addr, size_t len) {
+  return (addr == NULL) || probe_read_access(addr, len);
+}
+
+static inline bool probe_write_access_opt(void *addr, size_t len) {
+  return (addr == NULL) || probe_write_access(addr, len);
+}
+
+static inline bool probe_execute_access_opt(const void *addr) {
+  return (addr == NULL) || probe_execute_access(addr);
+}
 
 // Handles access violation by exiting the current application task
 // with a fatal error and the message "Access violation".

--- a/core/embed/sys/syscall/stm32/syscall_verifiers.c
+++ b/core/embed/sys/syscall/stm32/syscall_verifiers.c
@@ -199,7 +199,11 @@ void ipc_message_free__verified(ipc_message_t *msg) {
   // because the msg->data is treated as a "token" and validated
   // in the ipc_message_free() itself.
 
-  ipc_message_free(msg);
+  // Work on a copy so that the token cannot be changed after it has been
+  // validated by the implementation.
+  ipc_message_t msg_copy = *msg;
+
+  ipc_message_free(&msg_copy);
   return;
 
 access_violation:
@@ -230,11 +234,15 @@ bool boot_image_check__verified(const boot_image_t *image) {
     goto access_violation;
   }
 
-  if (!probe_read_access(image->image_ptr, image->image_size)) {
+  // Work on a copy so that the verified fields cannot differ from
+  // the ones the implementation uses.
+  boot_image_t image_copy = *image;
+
+  if (!probe_read_access(image_copy.image_ptr, image_copy.image_size)) {
     goto access_violation;
   }
 
-  return boot_image_check(image);
+  return boot_image_check(&image_copy);
 
 access_violation:
   apptask_access_violation();
@@ -246,11 +254,15 @@ void boot_image_replace__verified(const boot_image_t *image) {
     goto access_violation;
   }
 
-  if (!probe_read_access(image->image_ptr, image->image_size)) {
+  // Work on a copy so that the verified fields cannot differ from
+  // the ones the implementation uses.
+  boot_image_t image_copy = *image;
+
+  if (!probe_read_access(image_copy.image_ptr, image_copy.image_size)) {
     goto access_violation;
   }
 
-  boot_image_replace(image);
+  boot_image_replace(&image_copy);
   return;
 
 access_violation:

--- a/core/embed/sys/syscall/stm32/syscall_verifiers.c
+++ b/core/embed/sys/syscall/stm32/syscall_verifiers.c
@@ -208,7 +208,9 @@ access_violation:
 
 bool ipc_send__verified(systask_id_t remote, uint32_t fn, const void *data,
                         size_t data_size) {
-  if (!probe_read_access(data, data_size)) {
+  // NULL data is allowed for a zero-length message, `ipc_send()` rejects it
+  // for any other size
+  if (!probe_read_access_opt(data, data_size)) {
     goto access_violation;
   }
 
@@ -429,7 +431,8 @@ access_violation:
 }
 
 secbool usb_start__verified(const usb_start_params_t *params) {
-  if (!probe_read_access(params, sizeof(*params))) {
+  // NULL params is allowed and keeps the settings from usb_init()
+  if (!probe_read_access_opt(params, sizeof(*params))) {
     goto access_violation;
   }
 
@@ -658,7 +661,8 @@ access_violation:
 
 #ifdef USE_TELEMETRY
 bool telemetry_get__verified(telemetry_data_t *out) {
-  if (!probe_write_access(out, sizeof(*out))) {
+  // NULL out is allowed and only queries whether telemetry is available
+  if (!probe_write_access_opt(out, sizeof(*out))) {
     goto access_violation;
   }
 
@@ -685,7 +689,8 @@ static secbool storage_callback_wrapper(uint32_t wait, uint32_t progress,
 }
 
 void storage_setup__verified(PIN_UI_WAIT_CALLBACK callback) {
-  if (!probe_execute_access(callback)) {
+  // NULL callback is allowed and disables the UI progress callback
+  if (!probe_execute_access_opt(callback)) {
     goto access_violation;
   }
   storage_callback = callback;
@@ -704,7 +709,8 @@ storage_unlock_result_t storage_unlock__verified(const uint8_t *pin,
     goto access_violation;
   }
 
-  if (!probe_read_access(ext_salt, EXTERNAL_SALT_SIZE)) {
+  // NULL ext_salt is allowed and means no external salt is used
+  if (!probe_read_access_opt(ext_salt, EXTERNAL_SALT_SIZE)) {
     goto access_violation;
   }
 
@@ -721,7 +727,8 @@ storage_pin_change_result_t storage_change_pin__verified(
     goto access_violation;
   }
 
-  if (!probe_read_access(new_ext_salt, EXTERNAL_SALT_SIZE)) {
+  // NULL new_ext_salt is allowed and means no external salt is used
+  if (!probe_read_access_opt(new_ext_salt, EXTERNAL_SALT_SIZE)) {
     goto access_violation;
   }
 
@@ -753,7 +760,8 @@ secbool storage_change_wipe_code__verified(const uint8_t *pin, size_t pin_len,
     goto access_violation;
   }
 
-  if (!probe_read_access(ext_salt, EXTERNAL_SALT_SIZE)) {
+  // NULL ext_salt is allowed and means no external salt is used
+  if (!probe_read_access_opt(ext_salt, EXTERNAL_SALT_SIZE)) {
     goto access_violation;
   }
 
@@ -771,7 +779,8 @@ access_violation:
 
 secbool storage_get__verified(const uint16_t key, void *val,
                               const uint16_t max_len, uint16_t *len) {
-  if (!probe_write_access(val, max_len)) {
+  // NULL val is allowed and queries the value length only
+  if (!probe_write_access_opt(val, max_len)) {
     goto access_violation;
   }
 
@@ -908,7 +917,8 @@ access_violation:
 #ifdef USE_BLE
 
 bool ble_enter_pairing_mode__verified(const uint8_t *name, size_t name_len) {
-  if (!probe_read_access(name, name_len)) {
+  // NULL name is allowed and keeps the advertising name unchanged
+  if (!probe_read_access_opt(name, name_len)) {
     goto access_violation;
   }
 
@@ -995,7 +1005,8 @@ access_violation:
 }
 
 bool ble_unpair__verified(const bt_le_addr_t *addr) {
-  if (!probe_read_access(addr, sizeof(*addr))) {
+  // NULL addr is allowed and unpairs the currently connected device
+  if (!probe_read_access_opt(addr, sizeof(*addr))) {
     goto access_violation;
   }
 
@@ -1089,7 +1100,8 @@ access_violation:
 }
 
 pm_status_t pm_suspend__verified(wakeup_flags_t *wakeup_reason) {
-  if (!probe_write_access(wakeup_reason, sizeof(*wakeup_reason))) {
+  // NULL wakeup_reason is allowed and means the caller isn't interested
+  if (!probe_write_access_opt(wakeup_reason, sizeof(*wakeup_reason))) {
     goto access_violation;
   }
 

--- a/core/embed/sys/syscall/stm32/syscall_verifiers.c
+++ b/core/embed/sys/syscall/stm32/syscall_verifiers.c
@@ -1019,7 +1019,12 @@ access_violation:
 }
 
 uint8_t ble_get_bond_list__verified(bt_le_addr_t *bonds, size_t count) {
-  if (!probe_write_access(bonds, sizeof(bt_le_addr_t) * count)) {
+  // Reject counts for which the size below would overflow
+  if (count > SIZE_MAX / sizeof(*bonds)) {
+    goto access_violation;
+  }
+
+  if (!probe_write_access(bonds, sizeof(*bonds) * count)) {
     goto access_violation;
   }
 

--- a/core/embed/sys/syscall/stm32/syscall_verifiers.c
+++ b/core/embed/sys/syscall/stm32/syscall_verifiers.c
@@ -1123,15 +1123,25 @@ jpegdec_state_t jpegdec_process__verified(jpegdec_input_t *input) {
     goto access_violation;
   }
 
-  if (input->offset > input->size) {
+  // Work on a copy so that the verified fields cannot differ from
+  // the ones the implementation uses.
+  jpegdec_input_t input_copy = *input;
+
+  if (input_copy.offset > input_copy.size) {
     goto access_violation;
   }
 
-  if (!probe_read_access(input->data, input->size - input->offset)) {
+  // `jpegdec_process()` consumes `data[offset]` up to `data[size]`
+  if (!probe_read_access(input_copy.data, input_copy.size)) {
     goto access_violation;
   }
 
-  return jpegdec_process(input);
+  jpegdec_state_t state = jpegdec_process(&input_copy);
+
+  // `jpegdec_process()` advances `offset` by the number of consumed bytes
+  *input = input_copy;
+
+  return state;
 
 access_violation:
   apptask_access_violation();


### PR DESCRIPTION
This PR implements several syscall hardening measures.

Most importantly - NULL pointers are rejected by default and has to be made explicitly optional.

Some other fixes:
 - Jpgdec read past the data it was handed
 - jpgdec check range
 - BLE bound count potential wrap
 - validation over copied structs rather than raw data modifiable by the applet


<!--
For external contributors:
- Please open an issue before submitting a PR so we can discuss whether we want to proceed with it.

For core developers:
1. Initial PR setup
- Assign yourself to the PR.
- Add it to the "Firmware" project
  - Set Priority (match issue priority if it exists)
  - Set Team
  - Set Sprint (target release)

2. Development status
- Draft PRs: Set status to "In Progress"
- Final PRs: Set status to "Needs Review"

3. Post-merge status
- Testable: Set status to "Needs QA" and add a `Notes for QA` section with clear instructions on how to test the functionality.
- Not Testable: Set status to "Done (no QA)"
-->
