### PR TITLE
fix(core): allow emulator restart with model_server

### DIFF
--- a/core/emu.py
+++ b/core/emu.py
@@ -36,6 +36,17 @@ TREZOR_STORAGE_FILES = (
 )
 
 
+def erase_storage(profile_dir: Path) -> list[str]:
+    """Erase the emulator storage, return the names of the files that were removed."""
+    erased = []
+    for entry in TREZOR_STORAGE_FILES:
+        path = profile_dir / entry
+        if path.exists():
+            path.unlink()
+            erased.append(entry)
+    return erased
+
+
 def run_command_with_emulator(emulator: CoreEmulator, command: list[str]) -> int:
     with emulator:
         # first start the subprocess
@@ -256,8 +267,7 @@ def cli(
         profile_dir = Path("/var/tmp")
 
     if erase:
-        for entry in TREZOR_STORAGE_FILES:
-            (profile_dir / entry).unlink(missing_ok=True)
+        erase_storage(profile_dir)
 
     if quiet:
         output = None
@@ -306,11 +316,24 @@ def cli(
             profile_dir=str(profile_dir),
             configfile=tropic_emulator_config,
             port=TropicModel.DEFAULT_PORT,
+            reuse_existing=True,
         )
         try:
             tropic_model.start()
         except Exception as exc:
             click.echo(f"Failed to start Tropic01 model: {exc.__class__.__name__}: {exc}", err=True)
+        else:
+            if tropic_model.reused:
+                click.echo(f"Reusing Tropic01 model on port {tropic_model.port}")
+            else:
+                # The model we just started has empty R-memory, so the keys that
+                # storage keeps in there are gone and it could not be unlocked. The
+                # storage and the model state are only valid as a pair.
+                erased = erase_storage(profile_dir)
+                if erased:
+                    click.echo(
+                        f"Erased {', '.join(erased)}: started a fresh Tropic01 model"
+                    )
 
     if debugger or valgrind:
         run_debugger(emulator, script_gdb_file, valgrind, command, tropic_model)

--- a/python/src/trezorlib/_internal/emulator.py
+++ b/python/src/trezorlib/_internal/emulator.py
@@ -63,17 +63,35 @@ class TropicModel:
         port: int = DEFAULT_PORT,
         logfile: TextIO | str | Path | None = None,
         configfile_output: Path | None = None,
+        reuse_existing: bool = False,
     ) -> None:
         self.profile_dir = Path(profile_dir).resolve()
         self.port = port
+        self.reuse_existing = reuse_existing
         self.configfile = configfile.resolve()
         self.configfile_output = (
             configfile_output or self.profile_dir / "tropic_model_config_output.yml"
         )
         self.logfile = logfile or self.profile_dir / "trezor-tropic-model.log"
         self.process: Optional[subprocess.Popen] = None
+        self.reused = False
+        """A model was already listening on the port, so we did not start our own."""
 
     def start(self) -> None:
+        # The model server binds with SO_REUSEPORT, so starting a second one on the
+        # same port succeeds and the kernel then splits connections between them.
+        # The emulator would talk to either model at random, and only one of them
+        # holds the keys written by previous runs.
+        if self._is_listening():
+            if self.reuse_existing:
+                LOG.info(f"Tropic model already listening on port {self.port}, reusing")
+                self.reused = True
+                return
+            LOG.warning(
+                f"Port {self.port} is already taken, most likely by another Tropic "
+                "model. Connections will be split between the two of them."
+            )
+
         self.process = self._launch_process()
         _RUNNING_PIDS.add(self.process)
         try:
@@ -123,6 +141,13 @@ class TropicModel:
             stdout=cast(TextIO, output),
             stderr=subprocess.STDOUT,
         )
+
+    def _is_listening(self) -> bool:
+        try:
+            with socket.create_connection(("127.0.0.1", self.port), timeout=1):
+                return True
+        except OSError:
+            return False
 
     def _wait_until_ready(self, timeout: float = TROPIC_MODEL_WAIT_TIME) -> None:
         assert self.process is not None, "Tropic model not started"


### PR DESCRIPTION
When starting an emulator, check if a model_server is running on 28992. Start a new model_server only if the port is free.

Also, if starting a new model_server, erase the emulator storage to avoid failure on boot caused by the KEK mask not present in model_server.
