### PR TITLE
copy the whole payload in ble_notify()

### DIFF
--- a/core/embed/io/ble/stm32/ble.c
+++ b/core/embed/io/ble/stm32/ble.c
@@ -1361,10 +1361,12 @@ void ble_notify(const uint8_t *data, size_t len) {
   }
 
   uint8_t cmd[32] = {0};
-  cmd[0] = INTERNAL_CMD_NOTIFY;
-  memcpy(&cmd[1], data, MIN(len, sizeof(data) - 1));
+  const size_t payload_len = MIN(len, sizeof(cmd) - 1);
 
-  nrf_send_msg(NRF_SERVICE_BLE_MANAGER, cmd, MIN(32, len + 1), NULL, NULL);
+  cmd[0] = INTERNAL_CMD_NOTIFY;
+  memcpy(&cmd[1], data, payload_len);
+
+  nrf_send_msg(NRF_SERVICE_BLE_MANAGER, cmd, payload_len + 1, NULL, NULL);
 }
 
 void ble_set_enabled(bool enabled) {


### PR DESCRIPTION
`memcpy(&cmd[1], data, MIN(len, sizeof(data) - 1))` took the size of the `data` pointer rather than of the destination buffer, so the copy was clamped to 3 bytes on a 32-bit target. The frame length was computed from the real `len`, so a payload longer than that was sent with the remainder as zeros from the buffer's initialiser - a silently wrong value rather than a short frame or an error.

Nothing is affected today: the only caller is notify_send(), and its notification_data_t is exactly 3 bytes, which is why MIN(len, 3) happened to cover the whole payload. That struct has reserved bits and a documented event-specific data field, so it is one added byte away from truncating.

Clamp once against the destination and derive the frame length from the same value, so the copy and the declared length can no longer disagree.

[no changelog]

<!--
For external contributors:
- Please open an issue before submitting a PR so we can discuss whether we want to proceed with it.

For core developers:
1. Initial PR setup
- Assign yourself to the PR.
- Add it to the "Firmware" project
  - Set Priority (match issue priority if it exists)
  - Set Team
  - Set Sprint (target release)

2. Development status
- Draft PRs: Set status to "In Progress"
- Final PRs: Set status to "Needs Review"

3. Post-merge status
- Testable: Set status to "Needs QA" and add a `Notes for QA` section with clear instructions on how to test the functionality.
- Not Testable: Set status to "Done (no QA)"
-->
