### PR TITLE
chore(crypto): ecdsa uncompres_coords input check

### DIFF
--- a/crypto/ecdsa.c
+++ b/crypto/ecdsa.c
@@ -936,18 +936,45 @@ void compress_coords(const curve_point *cp, uint8_t *compressed) {
   bn_write_be(&cp->x, compressed + 1);
 }
 
-void uncompress_coords(const ecdsa_curve *curve, uint8_t odd,
-                       const bignum256 *x, bignum256 *y) {
+// Computes the y coordinate with the given parity of the curve point with the
+// given x coordinate. On success (x, y) is a valid public key, in case of
+// failure y is set to zero.
+int uncompress_coords(const ecdsa_curve *curve, uint8_t odd, const bignum256 *x,
+                      bignum256 *y) {
+  bignum256 y_2 = {0}, y_2_check = {0};
+
+  // verify x is in range [0,p-1]
+  if (!bn_is_less(x, &curve->prime)) {
+    bn_zero(y);
+    return 0;
+  }
+
   // y^2 = x^3 + a*x + b
-  memcpy(y, x, sizeof(bignum256));       // y is x
-  bn_multiply(x, y, &curve->prime);      // y is x^2
-  bn_subi(y, -curve->a, &curve->prime);  // y is x^2 + a
-  bn_multiply(x, y, &curve->prime);      // y is x^3 + ax
-  bn_add(y, &curve->b);                  // y is x^3 + ax + b
-  bn_sqrt(y, &curve->prime);             // y = sqrt(y)
+  memcpy(&y_2, x, sizeof(bignum256));         // y_2 is x
+  bn_multiply(x, &y_2, &curve->prime);        // y_2 is x^2
+  bn_subi(&y_2, -curve->a, &curve->prime);    // y_2 is x^2 + a
+  bn_multiply(x, &y_2, &curve->prime);        // y_2 is x^3 + ax
+  bn_addmod(&y_2, &curve->b, &curve->prime);  // y_2 is x^3 + ax + b
+  bn_mod(&y_2, &curve->prime);
+
+  bn_copy(&y_2, y);
+  bn_sqrt(y, &curve->prime);  // y = sqrt(y_2)
+
+  // bn_sqrt() returns a meaningless value if y_2 is not a quadratic residue
+  bn_copy(y, &y_2_check);
+  bn_multiply(y, &y_2_check, &curve->prime);  // y_2_check is y^2
+  bn_mod(&y_2_check, &curve->prime);
+  if (!bn_is_equal(&y_2_check, &y_2)) {
+    // x is invalid (x^3 + ax + b is a non-residue)
+    bn_zero(y);
+    return 0;
+  }
+
   if ((odd & 0x01) != (y->val[0] & 1)) {
     bn_subtract(&curve->prime, y, y);  // y = -y
   }
+
+  return 1;
 }
 
 int ecdsa_read_pubkey(const ecdsa_curve *curve, const uint8_t *pub_key,
@@ -962,8 +989,8 @@ int ecdsa_read_pubkey(const ecdsa_curve *curve, const uint8_t *pub_key,
   }
   if (pub_key[0] == 0x02 || pub_key[0] == 0x03) {  // compute missing y coords
     bn_read_be(pub_key + 1, &(pub->x));
-    uncompress_coords(curve, pub_key[0], &(pub->x), &(pub->y));
-    return ecdsa_validate_pubkey(curve, pub);
+    // uncompress_coords validates the resulting point
+    return uncompress_coords(curve, pub_key[0], &(pub->x), &(pub->y));
   }
   // error
   return 0;
@@ -1045,13 +1072,9 @@ int tc_ecdsa_recover_pub_from_sig(const ecdsa_curve *curve, uint8_t *pub_key,
   memcpy(&cp.x, &r, sizeof(bignum256));
   if (recid & 2) {
     bn_add(&cp.x, &curve->order);
-    if (!bn_is_less(&cp.x, &curve->prime)) {
-      return 1;
-    }
   }
-  // compute y from x
-  uncompress_coords(curve, recid & 1, &cp.x, &cp.y);
-  if (!ecdsa_validate_pubkey(curve, &cp)) {
+  // compute y from x and validate the point
+  if (!uncompress_coords(curve, recid & 1, &cp.x, &cp.y)) {
     return 1;
   }
   // e = -digest

--- a/crypto/ecdsa.h
+++ b/crypto/ecdsa.h
@@ -86,8 +86,8 @@ int scalar_multiply(const ecdsa_curve *curve, const bignum256 *k,
 int ecdh_multiply(const ecdsa_curve *curve, const uint8_t *priv_key,
                   const uint8_t *pub_key, uint8_t *session_key);
 void compress_coords(const curve_point *cp, uint8_t *compressed);
-void uncompress_coords(const ecdsa_curve *curve, uint8_t odd,
-                       const bignum256 *x, bignum256 *y);
+int uncompress_coords(const ecdsa_curve *curve, uint8_t odd, const bignum256 *x,
+                      bignum256 *y);
 int ecdsa_uncompress_pubkey(const ecdsa_curve *curve, const uint8_t *pub_key,
                             uint8_t *uncompressed);
 

--- a/crypto/tests/test_check.c
+++ b/crypto/tests/test_check.c
@@ -10413,7 +10413,7 @@ static void test_compress_coord(const char *k_raw) {
 
   bignum256 x = {0}, y = {0};
   bn_read_be(compress + 1, &x);
-  uncompress_coords(curve, compress[0], &x, &y);
+  ck_assert_int_eq(uncompress_coords(curve, compress[0], &x, &y), 1);
 
   ck_assert(bn_is_equal(&expected_coords.x, &x));
   ck_assert(bn_is_equal(&expected_coords.y, &y));
@@ -10435,6 +10435,57 @@ START_TEST(test_compress_coords) {
 
   for (int i = 0; i < (int)(sizeof(k_raw) / sizeof(*k_raw)); i++)
     test_compress_coord(k_raw[i]);
+}
+END_TEST
+
+static void test_uncompress_coord_invalid(const ecdsa_curve *curve,
+                                          const bignum256 *x) {
+  bignum256 y = {0};
+
+  for (uint8_t odd = 0x02; odd <= 0x03; odd++) {
+    bn_one(&y);
+    ck_assert_int_eq(uncompress_coords(curve, odd, x, &y), 0);
+    ck_assert(bn_is_zero(&y));
+  }
+}
+
+static void test_uncompress_coord_non_residue(const ecdsa_curve *curve,
+                                              uint32_t x_raw) {
+  bignum256 x = {0};
+  bn_read_uint32(x_raw, &x);
+  test_uncompress_coord_invalid(curve, &x);
+}
+
+static void test_uncompress_coord_out_of_range(const ecdsa_curve *curve) {
+  bignum256 x = {0};
+
+  // x == prime
+  bn_copy(&curve->prime, &x);
+  test_uncompress_coord_invalid(curve, &x);
+
+  // x == prime + 1
+  bn_addi(&x, 1);
+  test_uncompress_coord_invalid(curve, &x);
+
+  // x == 2^256 - 1
+  bn_read_be(
+      fromhex(
+          "ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff"),
+      &x);
+  test_uncompress_coord_invalid(curve, &x);
+}
+
+START_TEST(test_uncompress_coords_invalid) {
+  // x coordinates for which x^3 + a*x + b is not a quadratic residue,
+  // i.e. there is no curve point with the given x coordinate
+  test_uncompress_coord_non_residue(&secp256k1, 5);
+  test_uncompress_coord_non_residue(&secp256k1, 7);
+  test_uncompress_coord_non_residue(&nist256p1, 1);
+  test_uncompress_coord_non_residue(&nist256p1, 2);
+
+  // x coordinates which are not fully reduced modulo prime
+  test_uncompress_coord_out_of_range(&secp256k1);
+  test_uncompress_coord_out_of_range(&nist256p1);
 }
 END_TEST
 
@@ -12461,6 +12512,7 @@ Suite *test_suite(void) {
 
   tc = tcase_create("compress_coords");
   tcase_add_test(tc, test_compress_coords);
+  tcase_add_test(tc, test_uncompress_coords_invalid);
   suite_add_tcase(s, tc);
 
   tc = tcase_create("zkp_bip340");


### PR DESCRIPTION
- Calling `uncompres_coords` will now return 0 (error) if the input `x` is a non-residue (has no sqrt) - as non-residue `x` results in an invalid `y` value. In case of failure, `y` is zeroed-out.
