### PR TITLE
assert that bitblt probe lengths cannot overflow

### DIFF
--- a/core/embed/sys/syscall/stm32/syscall_verifiers.c
+++ b/core/embed/sys/syscall/stm32/syscall_verifiers.c
@@ -44,6 +44,18 @@
     goto access_violation;                                                     \
   }
 
+// The macros above multiply a stride by a height into a `size_t`. That cannot
+// overflow while both dimensions stay 16-bit, since an unsigned product needs
+// only as many bits as its operands have together. Widening any of the fields
+// would need a checked multiply here instead.
+_Static_assert(sizeof(((gfx_bitblt_t *)0)->dst_stride) +
+                           sizeof(((gfx_bitblt_t *)0)->height) <=
+                       sizeof(size_t) &&
+                   sizeof(((gfx_bitblt_t *)0)->src_stride) +
+                           sizeof(((gfx_bitblt_t *)0)->height) <=
+                       sizeof(size_t),
+               "bitblt dimensions may overflow the probe length");
+
 // ---------------------------------------------------------------------
 
 void sysevents_poll__verified(const sysevents_t *awaited,


### PR DESCRIPTION
CHECK_BB_DST and CHECK_BB_SRC multiply a stride by a height into a `size_t` to get the length they probe. That is safe today only because every dimension in `gfx_bitblt_t` is 16-bit: an unsigned product needs as many bits as its operands have together, so 16 + 16 fits a 32-bit `size_t` exactly, with a maximum product of 4294836225.

The relationship was implicit. Widening any of those fields would turn the product into a wrapped, much smaller value, and the macros would then probe a fraction of the memory the blit goes on to touch - the probe would start approving what it is meant to reject. State the requirement as a static assert so that change breaks the build instead.

No behavioural change.

<!--
For external contributors:
- Please open an issue before submitting a PR so we can discuss whether we want to proceed with it.

For core developers:
1. Initial PR setup
- Assign yourself to the PR.
- Add it to the "Firmware" project
  - Set Priority (match issue priority if it exists)
  - Set Team
  - Set Sprint (target release)

2. Development status
- Draft PRs: Set status to "In Progress"
- Final PRs: Set status to "Needs Review"

3. Post-merge status
- Testable: Set status to "Needs QA" and add a `Notes for QA` section with clear instructions on how to test the functionality.
- Not Testable: Set status to "Done (no QA)"
-->
