### PR TITLE
make flash area bounds checks overflow-safe

### DIFF
--- a/storage/flash_area.c
+++ b/storage/flash_area.c
@@ -70,8 +70,10 @@ const void *flash_area_get_address(const flash_area_t *area, uint32_t offset,
     uint32_t subarea_size = flash_sector_size(first_sector, num_sectors);
     // Does the requested block start in the sub-area?
     if (offset < subarea_size) {
-      // Does the requested block fit in the sub-area?
-      if (offset + size <= subarea_size) {
+      // Does the requested block fit in the sub-area? Written as a subtraction
+      // so that a large `size` cannot wrap the sum past the limit. The
+      // subtraction cannot underflow, `offset` is below `subarea_size` here.
+      if (size <= subarea_size - offset) {
         const uint8_t *ptr =
             (const uint8_t *)flash_get_address(first_sector, 0, 0);
         // We expect that all sectors/pages in the sub-area make
@@ -155,7 +157,9 @@ secbool __wur flash_area_write_data_padded(const flash_area_t *area,
   if (data_size > total_size) {
     return secfalse;
   }
-  if (offset + total_size > flash_area_get_size(area)) {
+  // Written as a subtraction so that the sum cannot wrap past the area size
+  const uint32_t area_size = flash_area_get_size(area);
+  if (offset > area_size || total_size > area_size - offset) {
     return secfalse;
   }
 


### PR DESCRIPTION
Both bounds checks added an offset to a size in `uint32_t` before comparing against the limit:

  flash_area_get_address():      offset + size <= subarea_size
  flash_area_write_data_padded(): offset + total_size > flash_area_get_size()

A sufficiently large second operand wraps the sum to a small value, so the comparison passes and the function reports the range as fitting. Rewrite both as subtractions, which cannot wrap. In `flash_area_get_address()` the subtraction cannot underflow either, since the enclosing condition has already established that the offset is below the sub-area size.

Neither check is reachable with such arguments today. The address lookup is gated by `offset < subarea_size` first, so wrapping needs an almost 4 GB size rather than a large offset, and no caller passes one - `secret_read()` is not exposed as a syscall and every one of its call sites uses a constant or a range-checked length. The padded write is backed by `get_sector_and_offset()`, which re-derives the sector for every block written and fails for an offset past the area. Both checks are nonetheless the documented bound that a future caller would reasonably trust.


<!--
For external contributors:
- Please open an issue before submitting a PR so we can discuss whether we want to proceed with it.

For core developers:
1. Initial PR setup
- Assign yourself to the PR.
- Add it to the "Firmware" project
  - Set Priority (match issue priority if it exists)
  - Set Team
  - Set Sprint (target release)

2. Development status
- Draft PRs: Set status to "In Progress"
- Final PRs: Set status to "Needs Review"

3. Post-merge status
- Testable: Set status to "Needs QA" and add a `Notes for QA` section with clear instructions on how to test the functionality.
- Not Testable: Set status to "Done (no QA)"
-->
