### PR TITLE
fix(core): allow tropic_random_buffer() calls with size > 255

### DIFF
--- a/core/embed/sec/tropic/tropic.c
+++ b/core/embed/sec/tropic/tropic.c
@@ -1134,8 +1134,17 @@ bool tropic_random_buffer(void *buffer, size_t length) {
     return false;
   }
 
-  if (LT_OK != lt_random_value_get(&drv->handle, buffer, length)) {
-    return false;
+  uint8_t *dst = (uint8_t *)buffer;
+  size_t remaining = length;
+
+  while (remaining > 0) {
+    // lt_random_value_get() uses uint8_t as a size parameter
+    size_t chunk = remaining > 255 ? 255 : remaining;
+    if (LT_OK != lt_random_value_get(&drv->handle, dst, chunk)) {
+      return false;
+    }
+    dst += chunk;
+    remaining -= chunk;
   }
 
   return true;


### PR DESCRIPTION
This PR fixes a latent bug in `tropic_random_buffer()` that could manifest in the future.

`tropic_random_buffer()` in tropic.c accepts a 32-bit size argument, but internally calls `lt_random_value_get()`, which only supports 8-bit sizes. The size argument is always truncated to 8 bits, which can result in values with low or zero entropy when the requested size is greater than 255.

After this fix `tropic_random_buffer()` accepts buffer with any size.

The bug is not an exploitable vulnerability and does not cause any functional degradation in the current firmware.