### PR TITLE
fix(core): show ETH public key derivation path

### DIFF
--- a/core/.changelog.d/7582.fixed
+++ b/core/.changelog.d/7582.fixed
@@ -1,0 +1,1 @@
+Ethereum: Add derivation path to public key layout.

--- a/core/src/apps/ethereum/get_public_key.py
+++ b/core/src/apps/ethereum/get_public_key.py
@@ -15,6 +15,9 @@ async def get_public_key(msg: EthereumGetPublicKey) -> EthereumPublicKey:
     resp = await bitcoin_get_public_key.get_public_key(btc_pubkey_msg)
 
     if msg.show_display:
-        await show_pubkey(resp.node.public_key.hex())
+        from apps.common.paths import address_n_to_str
+
+        path = address_n_to_str(msg.address_n)
+        await show_pubkey(resp.node.public_key.hex(), path=path)
 
     return EthereumPublicKey(node=resp.node, xpub=resp.xpub)


### PR DESCRIPTION
<img width="354" height="481" alt="image" src="https://github.com/user-attachments/assets/a3b8b217-0b37-408e-94ec-75ed4fa973ae" />

## Notes to QA
- run `trezorctl eth get-public-node -n m/44h/60h/0h/0/0 -d`
- go to menu, then `Account info`