### PR TITLE
fix(python): expose --chunkify option for `trezorctl tron sign-tx`

### DIFF
--- a/python/.changelog.d/7588.added
+++ b/python/.changelog.d/7588.added
@@ -1,0 +1,1 @@
+Tron: expose chunkification flag to CLI.

--- a/python/src/trezorlib/cli/tron.py
+++ b/python/src/trezorlib/cli/tron.py
@@ -43,13 +43,14 @@ def get_address(
     help=PATH_HELP,
 )
 @click.argument("raw_data_hex", type=str)
+@click.option("-C", "--chunkify", is_flag=True)
 @with_session
-def sign_tx(session: "Session", address: str, raw_data_hex: str) -> str:
+def sign_tx(session: "Session", address: str, raw_data_hex: str, chunkify: bool) -> str:
     """Sign a raw transaction."""
 
     raw_data = bytes.fromhex(raw_data_hex)
     tx, contract = tron.from_raw_data(raw_data)
     address_n = tools.parse_path(address)
-    signed_tx = tron.sign_tx(session, tx, contract, address_n)
+    signed_tx = tron.sign_tx(session, tx, contract, address_n, chunkify)
 
     return signed_tx.signature.hex()


### PR DESCRIPTION
Adds the missing `-C/--chunkify` flag to `trezorctl tron sign-tx`, matching `tron get-address`. The underlying `trezorlib.tron.sign_tx()` and firmware already supported it — only the CLI wrapper was hardcoding `chunkify=False`.