### PR TITLE
feat(xtask): allow --asan for all projects

### DIFF
--- a/core/embed/models/build.rs
+++ b/core/embed/models/build.rs
@@ -1,4 +1,4 @@
-use xbuild::{CLibrary, Result, bail_unsupported, cargo_out};
+use xbuild::{CLibrary, Result, bail, bail_unsupported, cargo_out};
 
 fn main() -> Result<()> {
     // Emit model identity for dependent build scripts (readable as
@@ -90,6 +90,10 @@ fn main() -> Result<()> {
                 lib.add_flag("-fstack-protector-strong");
             } else {
                 lib.add_flag("-fstack-protector-all");
+            }
+
+            if cfg!(feature = "asan") {
+                bail!("ASAN is not supported in non-emulator build");
             }
 
             if cfg!(feature = "mcu_stm32f4") {

--- a/core/embed/projects/boardloader/Cargo.toml
+++ b/core/embed/projects/boardloader/Cargo.toml
@@ -28,6 +28,7 @@ sys.workspace = true
 # Build options
 # --------------------------------------------------------------------------
 
+asan = ["models/asan"]
 bootloader_devel = ["sec/bootloader_devel"]
 clippy = []
 emulator = ["io/emulator"]

--- a/core/embed/projects/boardloader/project.toml
+++ b/core/embed/projects/boardloader/project.toml
@@ -23,6 +23,7 @@ elf_sections = [".vector_table", ".text", ".data", ".rodata", ".capabilities"]
 # Build options mapped to the cargo features they activate on this project.
 # vcp is intentionally unmapped: the boardloader has no VCP console.
 [build-options]
+asan             = { true = ["asan"] }
 production       = { true = ["production"] }
 bootloader-devel = { true = ["bootloader_devel"] }
 dbg-console      = { swo = ["dbg_console_swo"], system-view = ["dbg_console_system_view"] }

--- a/core/embed/projects/bootloader/Cargo.toml
+++ b/core/embed/projects/bootloader/Cargo.toml
@@ -23,6 +23,7 @@ trezor_lib.workspace = true
 # Build options
 # --------------------------------------------------------------------------
 
+asan = ["models/asan"]
 bootloader_devel = ["sec/bootloader_devel"]
 clippy = ["trezor_lib/clippy"]
 dbg_console_swo = ["dbg_console", "sys/dbg_console_swo"]

--- a/core/embed/projects/bootloader/project.toml
+++ b/core/embed/projects/bootloader/project.toml
@@ -47,6 +47,7 @@ elf_sections = [".header", ".flash", ".data"]
 
 # xtask build options mapped to the cargo features
 [build-options]
+asan              = { true = ["asan"] }
 bootloader-devel  = { true = ["bootloader_devel"] }
 dbg-console       = { vcp = ["dbg_console_vcp"], swo = ["dbg_console_swo"], system-view = ["dbg_console_system_view"] }
 debug-link        = { true = ["debuglink", "ui_debug"] }

--- a/core/embed/projects/bootloader_ci/Cargo.toml
+++ b/core/embed/projects/bootloader_ci/Cargo.toml
@@ -28,6 +28,7 @@ sys.workspace = true
 # Build options
 # --------------------------------------------------------------------------
 
+asan = ["models/asan"]
 bootloader_devel = ["sec/bootloader_devel"]
 clippy = []
 dbg_console_swo = ["dbg_console", "sys/dbg_console_swo"]

--- a/core/embed/projects/bootloader_ci/project.toml
+++ b/core/embed/projects/bootloader_ci/project.toml
@@ -31,6 +31,7 @@ elf_sections = [".header", ".flash", ".data"]
 
 # xtask build options mapped to the cargo features
 [build-options]
+asan             = { true = ["asan"] }
 bootloader-devel = { true = ["bootloader_devel"] }
 dbg-console      = { vcp = ["dbg_console_vcp"], swo = ["dbg_console_swo"], system-view = ["dbg_console_system_view"] }
 production       = { true = ["production"] }

--- a/core/embed/projects/firmware/Cargo.toml
+++ b/core/embed/projects/firmware/Cargo.toml
@@ -24,6 +24,7 @@ upymod.workspace = true
 # Build options
 # --------------------------------------------------------------------------
 
+asan = ["models/asan"]
 benchmark = ["upymod/benchmark", "crypto/aes_gcm"]
 block_on_vcp = ["sys/block_on_vcp"]
 bootloader_devel = ["sec/bootloader_devel"]

--- a/core/embed/projects/firmware/project.toml
+++ b/core/embed/projects/firmware/project.toml
@@ -56,6 +56,7 @@ split_part2_sections = [".flash2"]
 
 # xtask build options mapped to the cargo features
 [build-options]
+asan                          = { true = ["asan"] }
 apps                          = { true = ["app_loading"] }
 benchmark                     = { true = ["benchmark"] }
 block-on-vcp                  = { true = ["block_on_vcp"] }

--- a/core/embed/projects/kernel/Cargo.toml
+++ b/core/embed/projects/kernel/Cargo.toml
@@ -22,6 +22,7 @@ sys.workspace = true
 # Build options
 # --------------------------------------------------------------------------
 
+asan = ["models/asan"]
 app_loading = ["io/app_loading", "io/ipc"]
 bootloader_devel = ["sec/bootloader_devel"]
 clippy = []

--- a/core/embed/projects/kernel/project.toml
+++ b/core/embed/projects/kernel/project.toml
@@ -44,6 +44,7 @@ elf_sections = [".flash", ".data"]
 
 # xtask build options mapped to the cargo features
 [build-options]
+asan                          = { true = ["asan"] }
 apps                          = { true = ["app_loading"] }
 block-on-vcp                  = { true = ["block_on_vcp"] }
 bootloader-devel              = { true = ["bootloader_devel"] }

--- a/core/embed/projects/prodtest/Cargo.toml
+++ b/core/embed/projects/prodtest/Cargo.toml
@@ -22,6 +22,7 @@ trezor_lib.workspace = true
 # Build options
 # --------------------------------------------------------------------------
 
+asan = ["models/asan"]
 bootloader_devel = ["sec/bootloader_devel"]
 clippy = ["trezor_lib/clippy"]
 dbg_console_swo = ["dbg_console", "sys/dbg_console_swo"]

--- a/core/embed/projects/prodtest/project.toml
+++ b/core/embed/projects/prodtest/project.toml
@@ -55,6 +55,7 @@ secmon_header_sections = [".vendorheader", ".header"]
 
 # xtask build options mapped to the cargo features.
 [build-options]
+asan             = { true = ["asan"] }
 bootloader-devel = { true = ["bootloader_devel"] }
 dbg-console      = { swo = ["dbg_console_swo"], system-view = ["dbg_console_system_view"] }
 debug-link       = { true = ["debuglink", "ui_debug"] }

--- a/core/embed/projects/secmon/Cargo.toml
+++ b/core/embed/projects/secmon/Cargo.toml
@@ -27,6 +27,7 @@ sys.workspace = true
 # Build options
 # --------------------------------------------------------------------------
 
+asan = ["models/asan"]
 bootloader_devel = ["sec/bootloader_devel"]
 clippy = []
 emulator = ["sec/emulator"]

--- a/core/embed/projects/secmon/project.toml
+++ b/core/embed/projects/secmon/project.toml
@@ -24,6 +24,7 @@ elf_sections = [".secmon_header", ".flash", ".data", ".gnu.sgstubs"]
 
 # xtask build options mapped to the cargo features
 [build-options]
+asan                          = { true = ["asan"] }
 bootloader-devel              = { true = ["bootloader_devel"] }
 btc-only                      = { false = ["universal_fw"] }
 dbg-console                   = { swo = ["dbg_console_swo"], system-view = ["dbg_console_system_view"] }

--- a/core/embed/xtask/src/features.rs
+++ b/core/embed/xtask/src/features.rs
@@ -38,10 +38,6 @@ pub fn resolve_features(args: &ResolvedBuildArgs) -> Result<ResolvedBuildFeature
 
     if args.emulator {
         features.push("emulator".into());
-
-        if args.asan {
-            features.push("asan".into());
-        }
     }
 
     // Option-mapped features, validated against the target package's declared

--- a/core/embed/xtask/src/options.rs
+++ b/core/embed/xtask/src/options.rs
@@ -227,7 +227,7 @@ build_options! {
 
     /// Enable Address Sanitizer (ASAN) instrumentation
     #[arg(long, num_args = 0..=1, default_missing_value = "true")]
-    opt asan: bool,
+    map asan: bool,
 
     /// Enable external app loading
     #[arg(long, num_args = 0..=1, default_missing_value = "true")]


### PR DESCRIPTION
This PR allows the `--asan` option to be used with any project, including prodtest and emulator, not just firmware.

The `--asan` option can now be mapped in `project.toml` files - it behaves almost like any other option.

Address sanitizer currently doesn't work with non-emulator builds (although it might be possible to make it work partially). Therefore, if `--asan` is specified without `--emulator`, the build fails and an error is reported.

