### PR TITLE
Make T3W1 release emulators Tropic-enabled by default

### DIFF
--- a/.github/actions/build-core-emu/action.yml
+++ b/.github/actions/build-core-emu/action.yml
@@ -14,10 +14,6 @@ inputs:
     description: 'Binary suffix appended to version, e.g. -arm'
     required: false
     default: ''
-  s3-subpath:
-    description: 'Optional extra S3 subpath under model path, e.g. T3W1_tropic_on/'
-    required: false
-    default: ''
   build-bootloader:
     description: 'Build bootloader before unix emulator build'
     required: false
@@ -51,12 +47,7 @@ runs:
     - name: Upload emulator binaries
       if: github.repository == 'trezor/trezor-firmware'
       run: |
-        SUBPATH="${{ inputs.s3-subpath }}"
-        SUBPATH="${SUBPATH#/}"
-        if [ -n "$SUBPATH" ] && [ "${SUBPATH%/}" = "$SUBPATH" ]; then
-          SUBPATH="${SUBPATH}/"
-        fi
-        aws s3 cp "${{ steps.prepare_binary.outputs.binary_path }}" "s3://data.trezor.io/dev/firmware/releases/emulators-new/${{ inputs.model }}/${SUBPATH}"
+        aws s3 cp "${{ steps.prepare_binary.outputs.binary_path }}" "s3://data.trezor.io/dev/firmware/releases/emulators-new/${{ inputs.model }}/"
       shell: sh
 
     - uses: actions/upload-artifact@bbbca2ddaa5d8feaa63e36b76fdaad77386f024f  # actions/upload-artifact@v7.0.0

--- a/.github/workflows/release-emu.yml
+++ b/.github/workflows/release-emu.yml
@@ -22,12 +22,7 @@ on:
         description: models as a JSON list
         type: string
         required: true
-        default: "[\"T2B1\",\"T2T1\",\"T3B1\",\"T3T1\"]"
-      tropic_models:
-        description: tropic-capable models as a JSON list
-        type: string
-        required: false
-        default: "[\"T3W1\"]"
+        default: "[\"T2B1\",\"T2T1\",\"T3B1\",\"T3T1\",\"T3W1\"]"
 
 permissions:
   id-token: write       # for fetching the OIDC token
@@ -39,7 +34,6 @@ jobs:
     runs-on: ubuntu-latest
     outputs:
       models: ${{ steps.get_models.outputs.models }}
-      tropic_models: ${{ steps.get_models.outputs.tropic_models }}
       version: ${{ steps.get_models.outputs.version }}
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # actions/checkout@v6.0.2
@@ -52,17 +46,11 @@ jobs:
           elif [[ $GITHUB_REF == refs/tags/legacy/* ]]; then
             VERSION=${GITHUB_REF#refs/tags/legacy/v}
             MODELS=$(jq -cr --arg version "$VERSION" '.firmware[$version]' ./common/releases.json)
-            TROPIC_MODELS='[]'
           else
             VERSION="${{ inputs.version }}"
             MODELS='${{ inputs.models_json }}'
-            TROPIC_MODELS='${{ inputs.tropic_models }}'
-          fi
-          if [[ -z "$TROPIC_MODELS" ]]; then
-            TROPIC_MODELS='["T3W1"]'
           fi
           echo "models=$MODELS" >> $GITHUB_OUTPUT
-          echo "tropic_models=$TROPIC_MODELS" >> $GITHUB_OUTPUT
           echo "version=$VERSION" >> $GITHUB_OUTPUT
           cat $GITHUB_OUTPUT
 
@@ -81,7 +69,6 @@ jobs:
       TREZOR_MODEL: ${{ matrix.model }}
       BITCOIN_ONLY: ${{ matrix.coins == 'universal' && '0' || '1' }}
       PYOPT: ${{ matrix.type == 'debuglink' && '0' || '1' }}
-      DISABLE_TROPIC: 1
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # actions/checkout@v6.0.2
         with:
@@ -107,7 +94,6 @@ jobs:
       TREZOR_MODEL: ${{ matrix.model }}
       BITCOIN_ONLY: ${{ matrix.coins == 'universal' && '0' || '1' }}
       PYOPT: ${{ matrix.type == 'debuglink' && '0' || '1' }}
-      DISABLE_TROPIC: 1
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # actions/checkout@v6.0.2
         with:
@@ -118,59 +104,6 @@ jobs:
           version: ${{ needs.get_models.outputs.version }}
           artifact-name: core-emu-arm-${{ matrix.model }}-${{ matrix.coins }}-${{ matrix.type }}
           binary-suffix: -arm
-
-  core_emu_tropic_capable:
-    if: startsWith(github.ref, 'refs/tags/core/v') || inputs.project == 'core'
-    name: Build emu (tropic capable)
-    needs: get_models
-    runs-on: ubuntu-latest
-    strategy:
-      fail-fast: false
-      matrix:
-        model: ${{ fromJson(needs.get_models.outputs.tropic_models) }}
-        coins: [universal]
-        type: [debuglink]
-    env:
-      TREZOR_MODEL: ${{ matrix.model }}
-      BITCOIN_ONLY: ${{ matrix.coins == 'universal' && '0' || '1' }}
-      PYOPT: ${{ matrix.type == 'debuglink' && '0' || '1' }}
-    steps:
-      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # actions/checkout@v6.0.2
-        with:
-          submodules: recursive
-      - uses: ./.github/actions/build-core-emu
-        with:
-          model: ${{ matrix.model }}
-          version: ${{ needs.get_models.outputs.version }}
-          artifact-name: core-emu-tropic-capable-${{ matrix.model }}-${{ matrix.coins }}-${{ matrix.type }}
-          s3-subpath: ${{ matrix.model}}_tropic_on/
-
-  core_emu_arm_tropic_capable:
-    if: startsWith(github.ref, 'refs/tags/core/v') || inputs.project == 'core'
-    name: Build core emu arm (tropic capable)
-    needs: get_models
-    runs-on: ubuntu-latest-arm64
-    strategy:
-      fail-fast: false
-      matrix:
-        model: ${{ fromJson(needs.get_models.outputs.tropic_models) }}
-        coins: [universal]
-        type: [debuglink]
-    env:
-      TREZOR_MODEL: ${{ matrix.model }}
-      BITCOIN_ONLY: ${{ matrix.coins == 'universal' && '0' || '1' }}
-      PYOPT: ${{ matrix.type == 'debuglink' && '0' || '1' }}
-    steps:
-      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # actions/checkout@v6.0.2
-        with:
-          submodules: recursive
-      - uses: ./.github/actions/build-core-emu
-        with:
-          model: ${{ matrix.model }}
-          version: ${{ needs.get_models.outputs.version }}
-          artifact-name: core-emu-arm-tropic-capable-${{ matrix.model }}-${{ matrix.coins }}-${{ matrix.type }}
-          binary-suffix: -arm
-          s3-subpath: ${{ matrix.model}}_tropic_on/
 
   legacy_emu:
     if: startsWith(github.ref, 'refs/tags/legacy/v') || inputs.project == 'legacy'

--- a/tests/download_emulators.py
+++ b/tests/download_emulators.py
@@ -22,8 +22,6 @@ OLDEST_AVAILABLE = {
 }
 
 EMULATORS_URL_PREFIX = "https://data.trezor.io/dev/firmware/releases/emulators-new"
-TROPIC_CAPABLE_MODELS = {"T3W1"}
-TROPIC_REMOTE_SUBPATH_SUFFIX = "_tropic_on"
 
 TESTS_DIR = Path(__file__).resolve().parent
 SAVE_DIR = TESTS_DIR / "emulators"
@@ -143,7 +141,6 @@ def get_all_releases() -> EmulatorDict:
 
 def get_emulators_for_model(model: str, firmwares: EmulatorDict) -> list[Emulator]:
     emulators: list[Emulator] = []
-    is_tropic_capable = model in TROPIC_CAPABLE_MODELS
 
     def create_and_check_emulator(
         version: str, subpath_suffix: str = "", artifact_label: str = "Artifact"
@@ -167,13 +164,6 @@ def get_emulators_for_model(model: str, firmwares: EmulatorDict) -> list[Emulato
     for version, models in firmwares.items():
         if model in models:
             create_and_check_emulator(version=version)
-
-            if is_tropic_capable:
-                create_and_check_emulator(
-                    version=version,
-                    subpath_suffix=TROPIC_REMOTE_SUBPATH_SUFFIX,
-                    artifact_label="Tropic artifact",
-                )
     return emulators
 
 

--- a/tests/emulators.py
+++ b/tests/emulators.py
@@ -81,37 +81,19 @@ def get_emulator_path(
 ) -> Path:
     expected_name = f"trezor-emu-{gen}-{model}-{tag}"
     top_level_path = BINDIR / model / expected_name
-    nested_paths = sorted(
-        p for p in (BINDIR / model).glob(f"*/{expected_name}") if p.is_file()
-    )
 
-    if is_tropic_capable_model(model):
-        if nested_paths:
-            return nested_paths[0]
-        raise ValueError(
-            f"tropic-capable emulator executable not found: {BINDIR / model / '*/' / expected_name}"
-        )
-    else:
-        return top_level_path
+    return top_level_path
 
 
 def get_tags() -> dict[str, list[str]]:
     result = defaultdict(list)
     for model_dir in sorted(p for p in BINDIR.iterdir() if p.is_dir()):
         seen_tags = set()
-        model_name = model_dir.name
 
         top_level_files = sorted(
             p for p in model_dir.glob("trezor-emu-*") if p.is_file()
         )
-        nested_files = sorted(
-            p for p in model_dir.glob("*/trezor-emu-*") if p.is_file()
-        )
-
-        if is_tropic_capable_model(model_name):
-            files = nested_files
-        else:
-            files = [*top_level_files, *nested_files]
+        files = list(top_level_files)
 
         for f in files:
             try:


### PR DESCRIPTION
From now there will only be Tropic-enabled emulators on `data.trezor.io/dev/firmware/releases/emulators-new/T3W1/`.

<!--
For external contributors:
- Please open an issue before submitting a PR so we can discuss whether we want to proceed with it.

For core developers:
1. Initial PR setup
- Assign yourself to the PR.
- Add it to the "Firmware" project
  - Set Priority (match issue priority if it exists)
  - Set Team
  - Set Sprint (target release)

2. Development status
- Draft PRs: Set status to "In Progress"
- Final PRs: Set status to "Needs Review"

3. Post-merge status
- Testable: Set status to "Needs QA" and add a `Notes for QA` section with clear instructions on how to test the functionality.
- Not Testable: Set status to "Done (no QA)"
-->
