### PR TITLE
feat(core): increase maximum passphrase length to 128 bytes

### DIFF
--- a/core/.changelog.d/4084.changed
+++ b/core/.changelog.d/4084.changed
@@ -1,0 +1,1 @@
+Increase passphrase maximal size to 128 bytes.

--- a/core/embed/rust/src/ui/component/base.rs
+++ b/core/embed/rust/src/ui/component/base.rs
@@ -1,9 +1,9 @@
-use heapless::Vec;
+use heapless::{String, Vec};
 use sys::time::Duration;
 
 use super::Paginate;
 use crate::error::Error;
-use crate::strutil::{ShortString, TString};
+use crate::strutil::TString;
 use crate::ui::button_request::{ButtonRequest, ButtonRequestCode};
 use crate::ui::component::{MsgMap, PageMap};
 #[cfg(feature = "ble")]
@@ -601,6 +601,10 @@ impl EventCtx {
     }
 }
 
+/// A single string type for UI flows.
+/// Allows using passphrases longer than 50 characters (ShortString limit).
+pub type FlowMsgText = String<128>;
+
 /// Component::Msg for component parts of a swipe flow. Converting results of
 /// different screens to a shared type makes things easier to work with.
 ///
@@ -614,7 +618,7 @@ pub enum FlowMsg {
     Back,
     Next,
     Choice(usize),
-    Text(ShortString),
+    Text(FlowMsgText),
 }
 
 #[cfg(feature = "micropython")]

--- a/core/embed/rust/src/ui/component/text/common.rs
+++ b/core/embed/rust/src/ui/component/text/common.rs
@@ -1,4 +1,4 @@
-use crate::strutil::ShortString;
+use crate::ui::component::base::FlowMsgText;
 use crate::ui::component::EventCtx;
 use crate::ui::util::ResultExt;
 
@@ -15,13 +15,13 @@ pub enum TextEdit {
 /// operations over it. Text ops usually take a `EventCtx` to request a paint
 /// pass in case of any state modification.
 pub struct TextBox {
-    text: ShortString,
+    text: FlowMsgText,
 }
 
 impl TextBox {
     /// Create a new `TextBox` with content `text`.
     pub fn new(text: &str, max_len: usize) -> Self {
-        let text = unwrap!(ShortString::try_from(text));
+        let text = unwrap!(FlowMsgText::try_from(text));
         debug_assert!(text.capacity() >= max_len);
         Self { text }
     }

--- a/core/embed/rust/src/ui/layout_caesar/component/changing_text.rs
+++ b/core/embed/rust/src/ui/layout_caesar/component/changing_text.rs
@@ -1,6 +1,6 @@
 use super::super::fonts;
 use super::theme;
-use crate::strutil::ShortString;
+use crate::ui::component::base::FlowMsgText;
 use crate::ui::component::{Component, Event, EventCtx, Never, Pad};
 use crate::ui::display::Font;
 use crate::ui::geometry::{Alignment, Point, Rect};
@@ -12,7 +12,7 @@ use crate::ui::util::long_line_content_with_ellipsis;
 /// and without being affected by other components.
 pub struct ChangingTextLine {
     pad: Pad,
-    text: ShortString,
+    text: FlowMsgText,
     font: Font,
     /// Whether to show the text. Can be disabled.
     show_content: bool,
@@ -25,7 +25,7 @@ pub struct ChangingTextLine {
 
 impl ChangingTextLine {
     pub fn new(text: &str, font: Font, alignment: Alignment, max_len: usize) -> Self {
-        let text = unwrap!(ShortString::try_from(text));
+        let text = unwrap!(FlowMsgText::try_from(text));
         debug_assert!(text.capacity() >= max_len);
         Self {
             pad: Pad::with_background(theme::BG),

--- a/core/embed/rust/src/ui/layout_caesar/component/input_methods/passphrase.rs
+++ b/core/embed/rust/src/ui/layout_caesar/component/input_methods/passphrase.rs
@@ -2,9 +2,10 @@ use super::super::{
     theme, ButtonDetails, ButtonLayout, CancelConfirmMsg, ChangingTextLine, ChoiceControls,
     ChoiceFactory, ChoiceItem, ChoiceMsg, ChoicePage,
 };
-use crate::strutil::{ShortString, TString};
+use crate::strutil::TString;
 use crate::translations::TR;
 use crate::trezorhal::random;
+use crate::ui::component::base::FlowMsgText;
 use crate::ui::component::text::common::TextBox;
 use crate::ui::component::{Child, Component, ComponentExt, Event, EventCtx};
 use crate::ui::display::Icon;
@@ -287,17 +288,17 @@ impl PassphraseEntry {
 
     fn update_passphrase_dots(&mut self, ctx: &mut EventCtx) {
         debug_assert!({
-            let s = ShortString::new();
+            let s = FlowMsgText::new();
             s.capacity() >= self.max_len
         });
 
         let text_to_show = if self.show_plain_passphrase {
-            unwrap!(ShortString::try_from(self.passphrase()))
+            unwrap!(FlowMsgText::try_from(self.passphrase()))
         } else if self.is_empty() {
-            unwrap!(ShortString::try_from(""))
+            unwrap!(FlowMsgText::try_from(""))
         } else {
             // Showing asterisks and possibly the last digit.
-            let mut dots = ShortString::new();
+            let mut dots = FlowMsgText::new();
             for _ in 0..self.textbox.len() - 1 {
                 unwrap!(dots.push('*'));
             }

--- a/core/embed/rust/src/ui/layout_delizia/component/keyboard/passphrase.rs
+++ b/core/embed/rust/src/ui/layout_delizia/component/keyboard/passphrase.rs
@@ -8,8 +8,8 @@ use super::super::super::component::keyboard::common::{render_pending_marker, Mu
 use super::super::super::component::theme;
 use super::super::super::constant::SCREEN;
 use super::super::super::cshape;
-use crate::strutil::{ShortString, TString};
-use crate::ui::component::base::ComponentExt;
+use crate::strutil::TString;
+use crate::ui::component::base::{ComponentExt, FlowMsgText};
 use crate::ui::component::swipe_detect::SwipeConfig;
 use crate::ui::component::text::common::TextBox;
 use crate::ui::component::text::layout::{LayoutFit, LineBreaking};
@@ -24,7 +24,7 @@ use crate::ui::shape::{Bar, Renderer, Text, ToifImage};
 use crate::ui::util::{DisplayStyle, Pager};
 
 pub enum PassphraseKeyboardMsg {
-    Confirmed(ShortString),
+    Confirmed(FlowMsgText),
     Cancelled,
 }
 
@@ -356,12 +356,12 @@ impl Component for PassphraseKeyboard {
         // Confirm button was clicked, we're done.
         if let Some(ButtonMsg::Clicked) = self.confirm_empty_btn.event(ctx, event) {
             return Some(PassphraseKeyboardMsg::Confirmed(unwrap!(
-                ShortString::try_from(self.passphrase())
+                FlowMsgText::try_from(self.passphrase())
             )));
         }
         if let Some(ButtonMsg::Clicked) = self.confirm_btn.event(ctx, event) {
             return Some(PassphraseKeyboardMsg::Confirmed(unwrap!(
-                ShortString::try_from(self.passphrase())
+                FlowMsgText::try_from(self.passphrase())
             )));
         }
         if let Some(ButtonMsg::Clicked) = self.cancel_btn.event(ctx, event) {

--- a/core/embed/rust/src/ui/layout_delizia/flow/request_passphrase.rs
+++ b/core/embed/rust/src/ui/layout_delizia/flow/request_passphrase.rs
@@ -2,7 +2,8 @@ use super::super::component::{
     Frame, Header, PassphraseKeyboard, PassphraseKeyboardMsg, PromptScreen,
 };
 use crate::error;
-use crate::strutil::{ShortString, TString};
+use crate::strutil::TString;
+use crate::ui::component::base::FlowMsgText;
 use crate::ui::component::ComponentExt;
 use crate::ui::flow::base::{Decision, DecisionBuilder as _};
 use crate::ui::flow::{FlowController, FlowMsg, SwipeFlow};
@@ -36,7 +37,7 @@ impl FlowController for RequestPassphrase {
             (Self::Keypad, FlowMsg::Cancelled) => self.return_msg(FlowMsg::Cancelled),
             (Self::ConfirmEmpty, FlowMsg::Cancelled) => Self::Keypad.goto(),
             (Self::ConfirmEmpty, FlowMsg::Confirmed) => {
-                self.return_msg(FlowMsg::Text(ShortString::new()))
+                self.return_msg(FlowMsg::Text(FlowMsgText::new()))
             }
             _ => self.do_nothing(),
         }

--- a/core/embed/rust/src/ui/layout_eckhart/firmware/keyboard/string.rs
+++ b/core/embed/rust/src/ui/layout_eckhart/firmware/keyboard/string.rs
@@ -5,7 +5,8 @@ use super::super::keyboard::common::{
 };
 use super::super::keyboard::keypad::{Keypad, KeypadButton, KeypadMsg, KeypadState};
 use super::super::theme;
-use crate::strutil::{ShortString, TString};
+use crate::strutil::TString;
+use crate::ui::component::base::FlowMsgText;
 use crate::ui::component::swipe_detect::SwipeConfig;
 use crate::ui::component::{Component, Event, EventCtx, Label, Swipe};
 use crate::ui::flow::Swipable;
@@ -14,7 +15,7 @@ use crate::ui::shape::Renderer;
 use crate::ui::util::Pager;
 
 pub enum StringKeyboardMsg {
-    Confirmed(ShortString),
+    Confirmed(FlowMsgText),
     Cancelled,
 }
 
@@ -205,7 +206,7 @@ impl<I: StringInput> Component for StringKeyboard<I> {
             }
             Some(KeypadMsg::Confirm) => {
                 return Some(StringKeyboardMsg::Confirmed(unwrap!(
-                    ShortString::try_from(self.input.content())
+                    FlowMsgText::try_from(self.input.content())
                 )));
             }
             _ => {}

--- a/core/embed/rust/src/ui/layout_eckhart/flow/request_passphrase.rs
+++ b/core/embed/rust/src/ui/layout_eckhart/flow/request_passphrase.rs
@@ -5,8 +5,9 @@ use super::super::firmware::{
 };
 use super::super::theme;
 use crate::error;
-use crate::strutil::{ShortString, TString};
+use crate::strutil::TString;
 use crate::translations::TR;
+use crate::ui::component::base::FlowMsgText;
 use crate::ui::component::text::paragraphs::{Paragraph, ParagraphSource};
 use crate::ui::component::ComponentExt;
 use crate::ui::flow::base::{Decision, DecisionBuilder as _};
@@ -41,7 +42,7 @@ impl FlowController for RequestPassphrase {
             (Self::Keypad, FlowMsg::Cancelled) => self.return_msg(FlowMsg::Cancelled),
             (Self::ConfirmEmpty, FlowMsg::Cancelled) => Self::Keypad.goto(),
             (Self::ConfirmEmpty, FlowMsg::Confirmed) => {
-                self.return_msg(FlowMsg::Text(ShortString::new()))
+                self.return_msg(FlowMsg::Text(FlowMsgText::new()))
             }
             _ => self.do_nothing(),
         }

--- a/core/src/apps/common/passphrase.py
+++ b/core/src/apps/common/passphrase.py
@@ -5,7 +5,7 @@ import storage.device as storage_device
 from trezor import utils
 from trezor.wire import DataError
 
-_MAX_PASSPHRASE_LEN = const(50)
+_MAX_PASSPHRASE_LEN = const(128)
 
 if TYPE_CHECKING:
     from trezor.messages import ThpCreateNewSession


### PR DESCRIPTION
Uses a new type for FlowMsg-related strings.

Fixes https://github.com/trezor/trezor-firmware/issues/4084.

Legacy is still limited to 50 bytes.