### PR TITLE
Add missing buffer length checks

### DIFF
--- a/core/embed/io/gfx/jpegdec/stm32u5/jpegdec.c
+++ b/core/embed/io/gfx/jpegdec/stm32u5/jpegdec.c
@@ -297,6 +297,10 @@ jpegdec_state_t jpegdec_process(jpegdec_input_t *inp) {
     return JPEGDEC_STATE_ERROR;
   }
 
+  if (inp->offset > inp->size) {
+    return JPEGDEC_STATE_ERROR;
+  }
+
   // Check input buffer alignment
   if (inp->offset < inp->size) {
     if (!IS_ALIGNED(inp->offset, 4) ||

--- a/core/embed/io/gfx/jpegdec/unix/jpegdec.c
+++ b/core/embed/io/gfx/jpegdec/unix/jpegdec.c
@@ -162,6 +162,10 @@ jpegdec_state_t jpegdec_process(jpegdec_input_t *input) {
     return JPEGDEC_STATE_ERROR;
   }
 
+  if (input->offset > input->size) {
+    return JPEGDEC_STATE_ERROR;
+  }
+
   dec->source_mgr.input = input;
 
   if (dec->state == JPEGDEC_STATE_SLICE_READY) {

--- a/core/embed/io/nrf/stm32u5/nrf_update.c
+++ b/core/embed/io/nrf/stm32u5/nrf_update.c
@@ -169,6 +169,10 @@ static int version_cmp(const nrf_app_version_t *v1,
 }
 
 bool nrf_update_required(const uint8_t *image_ptr, size_t image_len) {
+  if (image_len < sizeof(struct image_header)) {
+    return false;
+  }
+
   for (int i = 0; i < 3; i++) {
     nrf_info_t info;
     uint8_t expected_hash[SHA256_DIGEST_LENGTH];

--- a/core/embed/io/sdcard/stm32f4/sdcard.c
+++ b/core/embed/io/sdcard/stm32f4/sdcard.c
@@ -293,6 +293,10 @@ secbool sdcard_read_blocks(uint32_t *dest, uint32_t block_num,
     return secfalse;
   }
 
+  if (num_blocks == 0) {
+    return sectrue;
+  }
+
   // check that dest pointer is aligned on a 4-byte boundary
   if (((uint32_t)dest & 3) != 0) {
     return secfalse;
@@ -347,6 +351,10 @@ secbool sdcard_write_blocks(const uint32_t *src, uint32_t block_num,
   // check that SD card is initialised
   if (sd_handle.Instance == NULL) {
     return secfalse;
+  }
+
+  if (num_blocks == 0) {
+    return sectrue;
   }
 
   // check that src pointer is aligned on a 4-byte boundary

--- a/core/embed/io/sdcard/stm32u5/sdcard.c
+++ b/core/embed/io/sdcard/stm32u5/sdcard.c
@@ -296,6 +296,10 @@ secbool sdcard_read_blocks(uint32_t *dest, uint32_t block_num,
     return secfalse;
   }
 
+  if (num_blocks == 0) {
+    return sectrue;
+  }
+
   // check that dest pointer is aligned on a 4-byte boundary
   if (((uint32_t)dest & 3) != 0) {
     return secfalse;
@@ -318,6 +322,10 @@ secbool sdcard_write_blocks(const uint32_t *src, uint32_t block_num,
   // check that SD card is initialised
   if (sd_handle.Instance == NULL) {
     return secfalse;
+  }
+
+  if (num_blocks == 0) {
+    return sectrue;
   }
 
   // check that src pointer is aligned on a 4-byte boundary

--- a/core/embed/sec/optiga/optiga.c
+++ b/core/embed/sec/optiga/optiga.c
@@ -139,6 +139,11 @@ optiga_sign_result optiga_sign(uint8_t index, const uint8_t *digest,
   }
 #endif  // SECRET_KEY_MASKING
 
+  if (max_der_signature_size < 2) {
+    ret = OPTIGA_SIGN_ERROR;
+    goto cleanup;
+  }
+
   optiga_result res = optiga_calc_sign(
       OPTIGA_OID_ECC_KEY + index, digest, digest_size, &der_signature[2],
       max_der_signature_size - 2, der_signature_size);

--- a/core/embed/sys/dbg/stm32/dbg_console_backend.c
+++ b/core/embed/sys/dbg/stm32/dbg_console_backend.c
@@ -60,16 +60,15 @@ static ssize_t itm_swo_write(const void *data, size_t data_size) {
 
 #ifdef USE_DBG_CONSOLE_SYSTEM_VIEW
 static ssize_t sysview_write(const void *data, size_t data_size) {
-#if 1
-  static char str[512];
-  strncpy(str, (const char *)data, sizeof(str) - 1);
-  str[sizeof(str) - 1] = 0;
+  static char str[SEGGER_SYSVIEW_MAX_STRING_LEN + 1];
+
+  size_t copy_size = MIN(data_size, sizeof(str) - 1);
+  memcpy(str, data, copy_size);
+  str[copy_size] = 0;
+
   SEGGER_SYSVIEW_Print(str);
-#endif
-#if 0
-  SEGGER_RTT_Write(0, data, data_size);
-#endif
-  return MIN(data_size, sizeof(str) - 1);
+
+  return copy_size;
 }
 #endif
 

--- a/core/embed/sys/dbg/stm32/systemview/config/SEGGER_SYSVIEW_Conf.h
+++ b/core/embed/sys/dbg/stm32/systemview/config/SEGGER_SYSVIEW_Conf.h
@@ -77,7 +77,7 @@ Additional information:
 
 #define SEGGER_SYSVIEW_RTT_BUFFER_SIZE          4096
 
-#define SEGGER_SYSVIEW_MAX_STRING_LEN           1024
+#define SEGGER_SYSVIEW_MAX_STRING_LEN           512
 
 #define SEGGER_SYSVIEW_BUFFER_SECTION "CCMRAM"
 

--- a/core/embed/sys/syscall/stm32/syscall_verifiers.c
+++ b/core/embed/sys/syscall/stm32/syscall_verifiers.c
@@ -1156,10 +1156,6 @@ jpegdec_state_t jpegdec_process__verified(jpegdec_input_t *input) {
   // the ones the implementation uses.
   jpegdec_input_t input_copy = *input;
 
-  if (input_copy.offset > input_copy.size) {
-    goto access_violation;
-  }
-
   // `jpegdec_process()` consumes `data[offset]` up to `data[size]`
   if (!probe_read_access(input_copy.data, input_copy.size)) {
     goto access_violation;


### PR DESCRIPTION
This PR adds some missing buffer size checks to a few driver functions callable as syscalls:

- `sdcard_read/write()` returns immediately when 0 blocks are requested
- `optiga_sign()` checks `max_der_signature_size` for the minimum required value
- `nrf_update_required()` checks the buffer for the minimum required size
- `jpegdec_input_t` offset verification is moved into the driver



