### PR TITLE
Publish nightly firmware

### DIFF
--- a/.github/workflows/core.yml
+++ b/.github/workflows/core.yml
@@ -892,17 +892,69 @@ jobs:
           path: downloaded-artifacts
       - name: Run unpack-artifacts.py
         run: |
-          mkdir -p to-upload/firmware
+          mkdir -p to-upload/firmware/unsigned
           python tools/unpack-artifacts.py \
               --releases common/releases.json \
               --translations core/translations \
-              --output to-upload/firmware \
+              --output to-upload/firmware/unsigned \
               downloaded-artifacts
       - uses: actions/upload-artifact@bbbca2ddaa5d8feaa63e36b76fdaad77386f024f  # actions/upload-artifact@v7.0.0
         with:
           name: unsigned
           path: to-upload/firmware*  # path hierarchy preserved after the first wildcard
           retention-days: 7
+
+  upload_nightly_firmware:
+    name: Upload nightly firmware
+    if: github.event_name == 'schedule'  # scheduled nightly runs only
+    runs-on: ubuntu-latest
+    needs: core_firmware
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # actions/checkout@v6.0.2
+        with:
+          submodules: recursive
+          persist-credentials: false
+      - uses: ./.github/actions/environment
+      - name: Generate translation blobs
+        run: nix-shell --run "uv run make -C core translations"
+      - uses: actions/download-artifact@70fc10c6e5e1ce46ad2ea6f2b72d43f7d47b13c3  # actions/download-artifact@v8.0.0
+        with:
+          pattern: core-firmware-*-*-normal
+          path: downloaded-artifacts
+      - name: Detect version
+        run: |
+          VERSION=`nix-shell --run "uv run xtask print-version firmware"`
+          echo VERSION="$VERSION" >> $GITHUB_ENV
+          # NOTE: this is commithash of the merge commit for pull_request events
+          echo COMMIT="${{ github.sha }}" >> $GITHUB_ENV
+          cat $GITHUB_ENV
+      - name: Run unpack-artifacts.py
+        run: |
+          mkdir -p firmware-nightly
+          python tools/unpack-artifacts.py \
+              --version "$VERSION" \
+              --translations core/translations \
+              --output firmware-nightly \
+              downloaded-artifacts
+      - name: Generate JSONs
+        run: |
+          nix-shell --run "uv run tools/gen-nightly-release-jsons.py --revision $COMMIT --root firmware-nightly $VERSION"
+          find firmware-nightly | sort
+          cat firmware-nightly/t*/universal/*.json || true
+      - name: Configure aws credentials
+        uses: aws-actions/configure-aws-credentials@8df5847569e6427dd6c4fb1cf565c83acfa8afa7  # aws-actions/configure-aws-credentials@v6.0.0
+        with:
+          role-to-assume: arn:aws:iam::538326561891:role/gh_actions_deploy_dev_firmware_data
+          aws-region: eu-west-1
+        continue-on-error: true
+      - name: Upload to S3
+        run: |
+          aws s3 sync \
+              --no-progress \
+              --delete \
+              --cache-control max-age=600 \
+              firmware-nightly \
+              s3://data.trezor.io/dev/firmware/firmware-nightly
 
 
   # Connect

--- a/core/embed/xtask/src/args.rs
+++ b/core/embed/xtask/src/args.rs
@@ -148,6 +148,8 @@ pub enum Cmd {
     Upload(UploadArgs),
     /// Combine multiple firmware projects into a single binary for flashing
     Combine(CombineArgs),
+    /// Print current version of specified project
+    PrintVersion(PrintVersionArgs),
 }
 
 #[derive(Args, Debug, Clone)]
@@ -229,4 +231,10 @@ pub struct CombineArgs {
     /// Target model
     #[arg(long, short = 'm', ignore_case = true)]
     pub model: Model,
+}
+
+#[derive(Args, Debug)]
+#[command(hide = true)] // Should probably go under some kind of misc subcommand.
+pub struct PrintVersionArgs {
+    pub project: Project,
 }

--- a/core/embed/xtask/src/helpers.rs
+++ b/core/embed/xtask/src/helpers.rs
@@ -4,7 +4,7 @@ use std::{env, fs};
 use anyhow::{Context, Result, anyhow};
 use cargo_metadata::MetadataCommand;
 
-use crate::args::{Model, Project};
+use crate::args::{Model, PrintVersionArgs, Project};
 use crate::options::ResolvedBuildArgs;
 
 /// Returns the path to the built ELF file for the given build arguments.
@@ -186,6 +186,12 @@ pub fn get_version_file(project: Project) -> Result<PathBuf> {
         .join("projects")
         .join(project.binary_name())
         .join("version.h"))
+}
+
+pub fn print_version(args: PrintVersionArgs) -> Result<()> {
+    let version_str = parse_version_file(&get_version_file(args.project)?)?;
+    println!("{}", version_str);
+    Ok(())
 }
 
 #[cfg(test)]

--- a/core/embed/xtask/src/main.rs
+++ b/core/embed/xtask/src/main.rs
@@ -1,7 +1,7 @@
 use anyhow::Result;
 use clap::Parser;
 use xtask::args::{Cli, Cmd};
-use xtask::{cargo, combine, flash, upload};
+use xtask::{cargo, combine, flash, helpers, upload};
 
 fn main() -> Result<()> {
     let cli = Cli::parse();
@@ -18,5 +18,6 @@ fn main() -> Result<()> {
         Cmd::Reset(args) => flash::reset(args),
         Cmd::Upload(args) => upload::upload(args),
         Cmd::Combine(args) => combine::combine(args),
+        Cmd::PrintVersion(args) => helpers::print_version(args),
     }
 }

--- a/tools/gen-nightly-release-jsons.py
+++ b/tools/gen-nightly-release-jsons.py
@@ -1,0 +1,309 @@
+#!/usr/bin/env python3
+"""
+Based on simplified gen-fw-release-jsons.py from trezor-suite-firmware-release repo.
+Consider merging the scripts before extending this one.
+
+Expects that the binaries have the correct names and are placed in the correct directories,
+including translation blobs.
+"""
+
+import datetime
+import json
+import re
+from collections import defaultdict
+from enum import StrEnum, auto
+from pathlib import Path
+from typing import Any, Dict, Sequence
+
+import click
+
+from trezorlib import firmware
+
+# Update these versions as needed
+BOOTLOADER_VERSION = {
+    "T3W1": (2, 1, 17),
+    "T3T1": (2, 1, 16),
+    "T3B1": (2, 1, 16),
+    "T2T1": (2, 1, 16),
+    "T2B1": (2, 1, 16),
+    "T1B1": (1, 12, 1),
+}
+
+BOOTLOADER_MIN_VERSION = {
+    "T3W1": (2, 1, 13),
+    "T3T1": (2, 1, 6),
+    "T3B1": (2, 1, 7),
+    "T2T1": (2, 0, 0),
+    "T2B1": (2, 1, 1),
+    "T1B1": (1, 12, 0),
+}
+
+FIRMWARE_MIN_VERSION = {
+    "T3W1": (2, 9, 3),
+    "T3T1": (2, 7, 2),
+    "T3B1": (2, 8, 3),
+    "T2T1": (2, 0, 8),
+    "T2B1": (2, 6, 1),
+    "T1B1": (1, 12, 0),
+}
+
+MODELS = list(FIRMWARE_MIN_VERSION.keys())
+CHANGELOG = "* Nightly trezor-firmware git snapshot."
+MIN_SUITE_VERSION = "25.9.0"
+URL_PREFIX = "dev/firmware/firmware-nightly"
+
+
+class DeployType(StrEnum):
+    NIGHTLY = "nightly"
+    UNKNOWN = auto()
+
+
+def splitversion(version: str) -> list[int]:
+    return [int(x) for x in version.split(".")]
+
+
+def joinversion(version: list[int]) -> str:
+    return ".".join(str(x) for x in version)
+
+
+def json_write(data: dict, path: Path) -> None:
+    """Write JSON with proper formatting."""
+    path.parent.mkdir(parents=True, exist_ok=True)
+    json_str = json.dumps(data, ensure_ascii=False, indent=2)
+    path.write_text(json_str)
+
+
+def parse_firmware_filename(filename: str) -> dict | None:
+    """Parse firmware filename to extract metadata.
+    Pattern: firmware-T2T1-2.9.0-5e4c97f.bin or firmware-T2T1-2.9.0-a09e6f0-signed.bin
+    or firmware-T3B1-btconly-2.9.0-5e4c97f.bin
+    """
+    pattern = r"firmware-([A-Z0-9]+)(?:-(?:btconly|bitcoinonly))?-(\d+\.\d+\.\d+)-([a-f0-9]+)(?:-signed)?\.bin"
+    if not (match := re.match(pattern, filename)):
+        return None
+
+    model, version, revision = match.groups()
+    return {
+        "model": model,
+        "version": splitversion(version),
+        "revision": revision,
+        "variant": (
+            "bitcoinonly"
+            if ("-btconly-" in filename or "-bitcoinonly-" in filename)
+            else "universal"
+        ),
+        "is_signed": filename.endswith("-signed.bin"),
+    }
+
+
+def parse_translation_filename(filename: str) -> dict | None:
+    """Parse translation filename to extract metadata.
+    Pattern: translation-T2T1-cs-CZ-2.9.0-unsigned.bin or translation-T2T1-cs-CZ-2.9.0.bin
+    """
+    pattern = r"translation-([A-Z0-9]+)-([a-z]{2})-([A-Z]{2})-(\d+\.\d+\.\d+)(-unsigned)?\.bin"
+    if not (match := re.match(pattern, filename)):
+        return None
+
+    model, lang, country, version, sign_type = match.groups()
+    return {
+        "model": model,
+        "language": f"{lang}-{country}",
+        "version": splitversion(version),
+        "is_signed": sign_type != "-unsigned",
+    }
+
+
+def collect_firmware_files(
+    root: Path, version: list[int], deploy_type: DeployType
+) -> dict:
+    """Collect all firmware files for the given version."""
+    firmware_files: Dict[str, Any] = defaultdict(
+        lambda: {
+            DeployType.NIGHTLY: {},
+            "translations": {
+                DeployType.NIGHTLY: {},
+            },
+        }
+    )
+
+    # Scan firmware files
+    firmware_dir = root
+    for model_dir in firmware_dir.iterdir():
+        if not model_dir.is_dir() or model_dir.name == "translations":
+            continue
+
+        model = model_dir.name.upper()
+        if model not in MODELS:
+            continue
+
+        for fw_file in model_dir.glob("*.bin"):
+            fw_info = parse_firmware_filename(fw_file.name)
+            if fw_info and fw_info["version"] == version:
+                firmware_files[model][deploy_type][fw_info["variant"]] = fw_file
+
+    # Scan translations
+    translations_dir = root / "translations"
+    if translations_dir.exists():
+        for model_dir in translations_dir.iterdir():
+            if not model_dir.is_dir():
+                continue
+
+            model = model_dir.name.upper()
+            if model not in MODELS:
+                continue
+
+            for tr_file in model_dir.glob("*.bin"):
+                tr_info = parse_translation_filename(tr_file.name)
+                if tr_info and tr_info["version"] == version:
+                    firmware_files[model]["translations"][deploy_type][
+                        tr_info["language"]
+                    ] = tr_file
+
+    return dict(firmware_files)
+
+
+def get_url_path(root: Path, filepath: Path) -> str:
+    return f"{URL_PREFIX}/{filepath.relative_to(root)}"
+
+
+def generate_release_json(
+    root: Path,
+    model: str,  # e.g. T2T1, T3B1
+    version: list[int],
+    firmware_files: dict,
+    variant: str,  # universal or bitcoinonly
+    changelog: str,
+    bld_version: list[int],
+    revision: str,
+    deploy_type: DeployType,
+) -> dict:
+    """Generate release JSON for a specific model and variant."""
+
+    fw_file = firmware_files[model][deploy_type][variant]
+    fingerprint = firmware.parse(fw_file.read_bytes()).digest().hex()
+
+    translations = {
+        lang: get_url_path(root, tr_file)
+        for lang, tr_file in firmware_files[model]["translations"][deploy_type].items()
+    }
+
+    result = {
+        "required": False,
+        "version": version,
+        "min_bootloader_version": BOOTLOADER_MIN_VERSION[model],
+        "min_firmware_version": FIRMWARE_MIN_VERSION[model],
+        "bootloader_version": bld_version,
+        "firmware_revision": revision,
+        "url": get_url_path(root, fw_file),
+        "fingerprint": fingerprint,
+        "changelog": changelog,
+    }
+    # Avoid adding an empty "translations" entry to legacy JSONs
+    if translations:
+        result["translations"] = dict(sorted(translations.items()))
+
+    return result
+
+
+def get_output_path(root: Path, model: str, version: list[int], variant: str) -> Path:
+    version_str = joinversion(version)
+    model_lower = model.lower()
+    base_dir = root / model_lower / variant
+    filename = f"{model_lower}-{version_str}-{variant}.json"
+
+    return base_dir / filename
+
+
+def generate_index(root: Path, models: Sequence[str], version: list[int]) -> Path:
+    """Write releases.v1.json index file."""
+    version_str = joinversion(version)
+    now = datetime.datetime.now(datetime.UTC)
+    now = now.strftime("%Y-%m-%dT%H:%M:%S.%f")
+    now = now[:-3] + "Z"
+    result = {
+        "version": 1,
+        "timestamp": now,
+        "sequence": 21000000,
+        "releases": {},
+        "intermediaries": {},
+    }
+    for model in models:
+        model_json = {}
+        model_lower = model.lower()
+        for variant in ["universal", "bitcoin-only"]:
+            variant_dir = variant.replace("-", "")
+            model_json[variant] = {
+                "firmware_type": variant,
+                "conditions": {
+                    "environment": {
+                        "min_suite_version": MIN_SUITE_VERSION,
+                        "min_suite_native_version": MIN_SUITE_VERSION,
+                    },
+                    "rollout_probability": 100,
+                },
+                "releasePath": f"{URL_PREFIX}/{model_lower}/{variant_dir}/{model_lower}-{version_str}-{variant_dir}.json",
+            }
+        result["releases"][model.upper()] = model_json
+
+    output_file = root / "releases.v1.json"
+    json_write(result, output_file)
+    return output_file
+
+
+@click.command()
+@click.argument("version", type=splitversion)
+@click.option(
+    "-r", "--root", type=Path, default=".", help="Root directory of firmware releases"
+)
+@click.option("--revision", help="Git revision")
+def generate_releases(
+    version: list[int],
+    root: Path,
+    revision: str | None,
+) -> None:
+    """Generate individual release JSON files for each firmware version."""
+
+    version_str = joinversion(version)
+
+    if revision is None:
+        raise click.ClickException("Missing --revision.")
+
+    deploy_type = DeployType.NIGHTLY
+    firmware_files = collect_firmware_files(root, version, deploy_type)
+
+    if not firmware_files:
+        click.echo(f"No firmware files found for version {version_str}")
+        return
+
+    for model in firmware_files:
+        click.echo(f"Processing {model}...")
+        changelog_universal = CHANGELOG
+        changelog_bitcoinonly = CHANGELOG
+
+        bld_version = list(BOOTLOADER_VERSION[model])
+        for variant, changelog_text in zip(
+            ["universal", "bitcoinonly"], [changelog_universal, changelog_bitcoinonly]
+        ):
+            if variant not in firmware_files[model][deploy_type]:
+                continue
+            json_data = generate_release_json(
+                root,
+                model,
+                version,
+                firmware_files,
+                variant,
+                changelog_text,
+                bld_version,
+                revision,
+                deploy_type,
+            )
+            output_file = get_output_path(root, model, version, variant)
+            json_write(json_data, output_file)
+            click.echo(f"Generated {output_file}")
+
+    index_fname = generate_index(root, sorted(firmware_files.keys()), version)
+    click.echo(f"Generated index {index_fname}")
+
+
+if __name__ == "__main__":
+    generate_releases()

--- a/tools/unpack-artifacts.py
+++ b/tools/unpack-artifacts.py
@@ -10,6 +10,8 @@ from pathlib import Path
 
 import click
 
+ALL_MODELS = ["T2B1", "T2T1", "T3B1", "T3T1", "T3W1"]
+
 
 @click.command(help=__doc__)
 @click.argument(
@@ -20,14 +22,19 @@ import click
     "--output",
     "output_dir",
     type=click.Path(exists=True, file_okay=False, dir_okay=True),
-    default="firmware",
+    default="firmware/unsigned",
 )
 @click.option(
     "-r",
     "--releases",
     "releases_json",
     type=click.Path(exists=True, file_okay=True, dir_okay=False),
-    default="common/releases.json",
+)
+@click.option(
+    "-v",
+    "--version",
+    "version",
+    help="manually specify version instead of using releases.json",
 )
 @click.option(
     "-t",
@@ -39,24 +46,30 @@ import click
 def main(
     artifact_dir: str | Path,
     output_dir: str | Path,
-    releases_json: str | Path,
+    releases_json: str | Path | None,
     translations_dir: str | Path,
+    version: str | None,
 ) -> None:
     artifact_dir = Path(artifact_dir)
     output_dir = Path(output_dir)
-    releases_json = Path(releases_json)
     translations_dir = Path(translations_dir)
 
-    releases = json.loads(releases_json.read_text())["firmware"]
-    latest, models = max(
-        releases.items(), key=lambda item: [int(n) for n in item[0].split(".")]
-    )
-    click.echo(f"Version: {latest}")
+    if releases_json is not None:
+        releases_json = Path(releases_json)
+        releases = json.loads(releases_json.read_text())["firmware"]
+        version, models = max(
+            releases.items(), key=lambda item: [int(n) for n in item[0].split(".")]
+        )
+    elif version is not None:
+        models = ALL_MODELS
+    else:
+        raise click.ClickException("Either --releases or --version is required")
+    click.echo(f"Version: {version}")
     click.echo(f"Models: {', '.join(models)}")
 
     for model in models:
         # firmware
-        model_dir = output_dir / "unsigned" / model.lower()
+        model_dir = output_dir / model.lower()
         model_dir.mkdir(parents=True, exist_ok=True)
 
         for coins in ("universal", "btconly"):
@@ -69,7 +82,7 @@ def main(
             shutil.copy(fw_file, model_dir / fw_file.name)
 
         # translations
-        model_dir = output_dir / "unsigned" / "translations" / model.lower()
+        model_dir = output_dir / "translations" / model.lower()
         model_dir.mkdir(parents=True, exist_ok=True)
 
         for f in translations_dir.glob(f"translation-{model}-*-unsigned.bin"):


### PR DESCRIPTION
Needs #4554. Uploads to `https://data.trezor.io/dev/firmware/firmware-nightly/`. Contains simplified copy of `gen-fw-release-jsons.py` from t-s-f-r repo, we might want to merge these scripts at some point but currently this was the easiest way to get something working quickly.

TODO:
- [x] top-level `releases.v1.json`
- [x] rebase when #4554 is merged
- [x] remove FIXMEs needed for testing in `pull_request` event instead of `schedule`
- [ ] T1B1: #7858
- [ ] remove max-age

<!--
For external contributors:
- Please open an issue before submitting a PR so we can discuss whether we want to proceed with it.

For core developers:
1. Initial PR setup
- Assign yourself to the PR.
- Add it to the "Firmware" project
  - Set Priority (match issue priority if it exists)
  - Set Team
  - Set Sprint (target release)

2. Development status
- Draft PRs: Set status to "In Progress"
- Final PRs: Set status to "Needs Review"

3. Post-merge status
- Testable: Set status to "Needs QA" and add a `Notes for QA` section with clear instructions on how to test the functionality.
- Not Testable: Set status to "Done (no QA)"
-->
