### PR TITLE
Add "make.me.blink" U2F dummy app ID

### DIFF
--- a/core/.changelog.d/3331.fixed
+++ b/core/.changelog.d/3331.fixed
@@ -1,0 +1,1 @@
+Show "not registered" message instead of a registration prompt when Firefox sends its dummy U2F register request.

--- a/core/src/apps/webauthn/fido2.py
+++ b/core/src/apps/webauthn/fido2.py
@@ -169,7 +169,9 @@ _FIDO_ATT_CERT = b"0\x82\x01\xcd0\x82\x01s\xa0\x03\x02\x01\x02\x02\x04\x03E`\xc4
 _BOGUS_RP_ID = ".dummy"
 _BOGUS_APPID_CHROME = b"A" * 32
 _BOGUS_APPID_FIREFOX = b"\0" * 32
-_BOGUS_APPIDS = (_BOGUS_APPID_CHROME, _BOGUS_APPID_FIREFOX)
+# SHA-256 of "make.me.blink", used by Firefox's authenticator-rs.
+_BOGUS_APPID_FIREFOX_BLINK = b"\xe8\x45\x41\xea\xf2\x07\xf7\xd7\x5a\xd0\x51\x43\x47\x70\xf6\xd1\xa9\xbf\x62\xf7\xea\x9b\xe5\x14\xfd\x4e\x0c\xa8\x27\x2b\x1d\xeb"
+_BOGUS_APPIDS = (_BOGUS_APPID_CHROME, _BOGUS_APPID_FIREFOX, _BOGUS_APPID_FIREFOX_BLINK)
 _AAGUID = b"\xd6\xd0\xbd\xc3b\xee\xc4\xdb\xde\x8dzenJD\x87"  # First 16 bytes of SHA-256("TREZOR 2")
 
 # authentication control byte

--- a/legacy/firmware/.changelog.d/3331.fixed
+++ b/legacy/firmware/.changelog.d/3331.fixed
@@ -1,0 +1,1 @@
+Show "not registered" message instead of a registration prompt when Firefox sends its dummy U2F register request.

--- a/legacy/firmware/u2f.c
+++ b/legacy/firmware/u2f.c
@@ -70,6 +70,10 @@ static uint8_t u2f_out_packets[U2F_OUT_PKT_BUFFER_LEN][HID_RPT_SIZE];
 #define BOGUS_APPID_CHROME "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA"
 #define BOGUS_APPID_FIREFOX \
   "\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0"
+// SHA-256 of "make.me.blink", used by Firefox's authenticator-rs.
+#define BOGUS_APPID_FIREFOX_BLINK                                    \
+  "\xe8\x45\x41\xea\xf2\x07\xf7\xd7\x5a\xd0\x51\x43\x47\x70\xf6\xd1" \
+  "\xa9\xbf\x62\xf7\xea\x9b\xe5\x14\xfd\x4e\x0c\xa8\x27\x2b\x1d\xeb"
 
 // Auth/Register request state machine
 typedef enum {
@@ -560,7 +564,8 @@ void u2f_register(const APDU *a) {
     // error: testof-user-presence is required
     buttonUpdate();  // Clear button state
     if (0 == memcmp(req->appId, BOGUS_APPID_CHROME, U2F_APPID_SIZE) ||
-        0 == memcmp(req->appId, BOGUS_APPID_FIREFOX, U2F_APPID_SIZE)) {
+        0 == memcmp(req->appId, BOGUS_APPID_FIREFOX, U2F_APPID_SIZE) ||
+        0 == memcmp(req->appId, BOGUS_APPID_FIREFOX_BLINK, U2F_APPID_SIZE)) {
       if (cid == last_good_auth_check_cid) {
         layoutDialog(&bmp_icon_warning, NULL, _("OK"), NULL,
                      _("Already registered."), NULL, _("This U2F device is"),


### PR DESCRIPTION
Fixes https://github.com/trezor/trezor-firmware/issues/3331. Shows "not registered" message instead of a registration prompt when Firefox sends its dummy U2F register request.

Tested with T1 and TS7 using https://webauthn.io/ in Firefox. I had to build core with `_ALLOW_FIDO2 = const(0)` to ensure U2F was being tested, but there might be a way to force U2F in Firefox.