### PR TITLE
feat(core,python): definitions payload version

### DIFF
--- a/core/embed/rust/src/definitions/constants.rs
+++ b/core/embed/rust/src/definitions/constants.rs
@@ -1,6 +1,25 @@
 use crypto::ed25519;
 
-pub const THRESHOLD: u8 = 2;
+// Definition format versions, encoded on the wire as ASCII digit bytes.
+pub enum DefsVersion {
+    V1,
+}
+
+impl DefsVersion {
+    // CoSi signature threshold for this version.
+    pub const fn threshold(self) -> u8 {
+        match self {
+            DefsVersion::V1 => 2,
+        }
+    }
+
+    pub const fn from_byte(byte: u8) -> Option<Self> {
+        match byte {
+            b'1' => Some(DefsVersion::V1),
+            _ => None,
+        }
+    }
+}
 
 #[cfg(feature = "dev_keys")]
 pub const PUBLIC_KEYS_DEVEL: [ed25519::PublicKey; 3] = [

--- a/core/embed/rust/src/definitions/obj.rs
+++ b/core/embed/rust/src/definitions/obj.rs
@@ -1,54 +1,62 @@
 use crypto::{cosi, ed25519};
 
 use super::constants;
-use crate::error::Error;
+use crate::error::{value_error, Error};
 use crate::micropython::buffer::get_buffer;
-use crate::micropython::macros::{obj_fn_3, obj_module};
+use crate::micropython::macros::{obj_fn_var, obj_module};
+use crate::micropython::map::Map;
 use crate::micropython::module::Module;
 use crate::micropython::obj::Obj;
 use crate::micropython::qstr::Qstr;
 use crate::micropython::util;
 
 fn verify_with_keys(
+    threshold: u8,
     digest: &[u8],
     sig: &cosi::Signature,
     public_keys: &[ed25519::PublicKey; 3],
 ) -> Result<(), Error> {
-    Ok(cosi::verify(
-        constants::THRESHOLD,
-        digest,
-        public_keys,
-        sig,
-    )?)
+    Ok(cosi::verify(threshold, digest, public_keys, sig)?)
 }
 
-extern "C" fn verify(digest: Obj, sig: Obj, sigmask: Obj) -> Obj {
-    let block = || {
-        // SAFETY: reference is discarded at the end of the block
-        let digest = unsafe { get_buffer(digest)? };
-        let signature = unsafe { get_buffer(sig)? };
+fn threshold_for_version(version: u8) -> Result<u8, Error> {
+    let version = constants::DefsVersion::from_byte(version)
+        .ok_or(value_error!(c"Unsupported definition format version"))?;
+    Ok(version.threshold())
+}
 
-        let sig = cosi::Signature::new(
-            u8::try_from(sigmask)?,
-            signature.try_into().map_err(|_| Error::TypeError)?,
-        );
+extern "C" fn verify(n_args: usize, args: *const Obj) -> Obj {
+    let block = |args: &[Obj], _kwargs: &Map| {
+        if args.len() != 4 {
+            return Err(Error::TypeError);
+        }
+        // SAFETY: reference is discarded at the end of the block
+        let digest = unsafe { get_buffer(args[0])? };
+        let signature = unsafe { get_buffer(args[1])? };
+        let sigmask = u8::try_from(args[2])?;
+        let format_version = u8::try_from(args[3])?;
+        let threshold = threshold_for_version(format_version)?;
+
+        let sig =
+            cosi::Signature::new(sigmask, signature.try_into().map_err(|_| Error::TypeError)?);
         #[allow(unused_mut)]
-        let mut result = verify_with_keys(digest, &sig, &constants::PUBLIC_KEYS_PRODUCTION);
+        let mut result =
+            verify_with_keys(threshold, digest, &sig, &constants::PUBLIC_KEYS_PRODUCTION);
         #[cfg(feature = "dev_keys")]
         if result.is_err() {
             // allow development keys
-            result = verify_with_keys(digest, &sig, &constants::PUBLIC_KEYS_DEVEL);
+            result = verify_with_keys(threshold, digest, &sig, &constants::PUBLIC_KEYS_DEVEL);
         }
         result.map(|()| Obj::const_none())
     };
 
-    unsafe { util::try_or_raise(block) }
+    unsafe { util::try_with_args_and_kwargs(n_args, args, &Map::EMPTY, block) }
 }
 
 #[no_mangle]
 #[rustfmt::skip]
 pub static mp_module_trezordefinitions: Module = obj_module! {
-    /// def verify(digest: AnyBytes, sig: AnyBytes, sigmask: int) -> None:
+    /// def verify(digest: AnyBytes, sig: AnyBytes, sigmask: int, version: int) -> None:
     ///     """Verify the definitions signature."""
-    Qstr::MP_QSTR_verify => obj_fn_3!(verify).as_obj(),
+    Qstr::MP_QSTR_verify => obj_fn_var!(4, 4, verify).as_obj(),
 };

--- a/core/mocks/generated/trezordefinitions.pyi
+++ b/core/mocks/generated/trezordefinitions.pyi
@@ -3,5 +3,5 @@ from buffer_types import *
 
 
 # rust/src/definitions/obj.rs
-def verify(digest: AnyBytes, sig: AnyBytes, sigmask: int) -> None:
+def verify(digest: AnyBytes, sig: AnyBytes, sigmask: int, version: int) -> None:
     """Verify the definitions signature."""

--- a/core/src/apps/common/definitions.py
+++ b/core/src/apps/common/definitions.py
@@ -46,15 +46,20 @@ def decode_definition(definition: AnyBytes, expected_type: type[DefType]) -> Def
         expected_type_number = DefinitionType.ETHEREUM_DISPLAY_FORMAT
 
     try:
-        # first check format version
-        if r.read_memoryview(len(consts.FORMAT_VERSION)) != consts.FORMAT_VERSION:
+        # first check magic
+        if r.read_memoryview(len(consts.MAGIC)) != consts.MAGIC:
             raise DataError("Invalid definition")
 
-        # second check the type of the data
+        # second check the format version
+        format_version = r.read_memoryview(1)
+        if format_version not in consts.SUPPORTED_FORMAT_VERSIONS:
+            raise DataError("Invalid definition")
+
+        # third check the type of the data
         if r.get() != expected_type_number:
             raise DataError("Definition type mismatch")
 
-        # third check data version
+        # fourth check data version
         if readers.read_uint32_le(r) < consts.MIN_DATA_VERSION:
             raise DataError("Definition is outdated")
 
@@ -88,7 +93,7 @@ def decode_definition(definition: AnyBytes, expected_type: type[DefType]) -> Def
 
     # verify signature
     try:
-        verify(hash, signature, sigmask)
+        verify(hash, signature, sigmask, format_version[0])
     except ValueError:
         raise DataError("Invalid definition signature")
 

--- a/core/src/apps/common/definitions_constants.py
+++ b/core/src/apps/common/definitions_constants.py
@@ -3,7 +3,11 @@
 # do not edit manually!
 
 MIN_DATA_VERSION = 1783520408
-FORMAT_VERSION = b"trzd1"
+MAGIC = b"trzd"
 
-# The public keys and signature threshold for definitions verification
+# Supported format versions of the definitions, encoded on the wire as
+# ASCII digit bytes ('1' = 0x31, '2' = 0x32, etc.).
+SUPPORTED_FORMAT_VERSIONS = (b"1",)
+
+# The public keys and signature thresholds for definitions verification
 # live in Rust (core/embed/rust/src/definitions/constants.rs).

--- a/core/src/apps/common/definitions_constants.py.mako
+++ b/core/src/apps/common/definitions_constants.py.mako
@@ -3,7 +3,11 @@
 # do not edit manually!
 
 MIN_DATA_VERSION = ${defs_timestamp}
-FORMAT_VERSION = b"trzd1"
+MAGIC = b"trzd"
 
-# The public keys and signature threshold for definitions verification
+# Supported format versions of the definitions, encoded on the wire as
+# ASCII digit bytes ('1' = 0x31, '2' = 0x32, etc.).
+SUPPORTED_FORMAT_VERSIONS = (b"1",)
+
+# The public keys and signature thresholds for definitions verification
 # live in Rust (core/embed/rust/src/definitions/constants.rs).

--- a/core/tests/ethereum_common.py
+++ b/core/tests/ethereum_common.py
@@ -46,7 +46,8 @@ def make_solana_token(
 
 
 def make_payload(
-    prefix: bytes = b"trzd1",
+    magic: bytes = b"trzd",
+    format_version: bytes = b"1",
     data_type: DefinitionType = DefinitionType.ETHEREUM_NETWORK,
     timestamp: int = 0xFFFF_FFFF,
     message: (
@@ -56,7 +57,8 @@ def make_payload(
         | bytes
     ) = make_eth_network(),
 ) -> bytes:
-    payload = prefix
+    payload = magic
+    payload += format_version
     payload += data_type.to_bytes(1, "little")
     payload += timestamp.to_bytes(4, "little")
     if isinstance(message, bytes):

--- a/core/tests/test_apps.common.definitions.py
+++ b/core/tests/test_apps.common.definitions.py
@@ -53,7 +53,7 @@ class TestDecodeDefinition(unittest.TestCase):
         self.assertFailed(payload + proof + bad_signature)
 
     def test_not_enough_signatures(self):
-        payload = make_payload()
+        payload = make_payload(format_version=b"1")
         proof, signature = sign_payload(payload, [], threshold=1)
         self.assertFailed(payload + proof + signature)
 
@@ -86,10 +86,16 @@ class TestDecodeDefinition(unittest.TestCase):
         bad_proof = proof[:-1]
         self.assertFailed(payload + bad_proof + signature)
 
-    def test_bad_prefix(self):
-        payload = make_payload(prefix=b"trzd2")
+    def test_bad_magic(self):
+        payload = make_payload(magic=b"trze")
         proof, signature = sign_payload(payload, [])
         self.assertFailed(payload + proof + signature)
+
+    def test_unsupported_format_version(self):
+        for version in (b"0", b"3", b"\x01", b"\xff"):
+            payload = make_payload(format_version=version)
+            proof, signature = sign_payload(payload, [])
+            self.assertFailed(payload + proof + signature)
 
     def test_bad_type(self):
         payload = make_payload(

--- a/docs/common/external-definitions.md
+++ b/docs/common/external-definitions.md
@@ -108,14 +108,18 @@ and packaged in the following binary format.
 
 All numbers are unsigned little endian.
 
-1. magic string `trzd1` (5 bytes)
-2. definition type according to `DefinitionType` enum (1 byte)
-3. data version of the definition (4 bytes)
-4. protobuf payload length (2 bytes)
-5. protobuf payload (N bytes)
+1. magic string `trzd` (4 bytes)
+2. format version, an ASCII digit byte: e.g. `1` (0x31), `2` (0x32), etc. (1 byte)
+3. definition type according to `DefinitionType` enum (1 byte)
+4. data version of the definition (4 bytes)
+5. protobuf payload length (2 bytes)
+6. protobuf payload (N bytes)
 
 A Merkle tree is constructed from all binary definitions (see below) and its root is
 signed by the CoSi algorithm.
+
+The format version is bumped on backward incompatible change.
+For versions 1 and 2, the data structure is identical.
 
 The full format of the definition is as follows:
 

--- a/python/src/trezorlib/definitions.py
+++ b/python/src/trezorlib/definitions.py
@@ -29,7 +29,7 @@ from .messages import DefinitionType
 
 LOG = logging.getLogger(__name__)
 
-FORMAT_MAGIC = b"trzd1"
+MAGIC = b"trzd"
 DEFS_BASE_URL = "https://data.trezor.io/firmware/definitions/"
 
 DEFINITIONS_DEV_SIGS_REQUIRED = 1
@@ -38,7 +38,11 @@ DEFINITIONS_DEV_PUBLIC_KEYS = [
     for key in ("db995fe25169d141cab9bbba92baa01f9f2e1ece7df4cb2ac05190f37fcc1f9d",)
 ]
 
-DEFINITIONS_SIGS_REQUIRED = 2
+# Number of CoSi signatures required by definition format version.
+# Version 1 requires 2 signatures.
+DEFINITIONS_SIGS_REQUIRED = {
+    b"1": 2,
+}
 DEFINITIONS_PUBLIC_KEYS = [
     bytes.fromhex(key)
     for key in (
@@ -54,12 +58,14 @@ ProofFormat = c.PrefixedArray(c.Int8ul, c.Bytes(32))
 
 class DefinitionPayload(Struct):
     magic: bytes
+    version: bytes  # ASCII digit byte of the format version, e.g. b"1"
     data_type: DefinitionType
     timestamp: int
     data: bytes
 
     SUBCON = c.Struct(
-        "magic" / c.Const(FORMAT_MAGIC),
+        "magic" / c.Const(MAGIC),
+        "version" / c.Bytes(1),
         "data_type" / EnumAdapter(c.Int8ul, DefinitionType),
         "timestamp" / c.Int32ul,
         "data" / c.Prefixed(c.Int16ul, c.GreedyBytes),
@@ -82,11 +88,24 @@ class Definition(Struct):
     def verify(self, dev: bool = False) -> None:
         payload = self.payload.build()
         root = merkle_tree.evaluate_proof(payload, self.proof)
+        if dev:
+            sigs_required, public_keys = (
+                DEFINITIONS_DEV_SIGS_REQUIRED,
+                DEFINITIONS_DEV_PUBLIC_KEYS,
+            )
+        else:
+            try:
+                sigs_required = DEFINITIONS_SIGS_REQUIRED[self.payload.version]
+            except KeyError:
+                raise ValueError(
+                    f"Unsupported definition format version {self.payload.version.decode()!r}"
+                ) from None
+            public_keys = DEFINITIONS_PUBLIC_KEYS
         cosi.verify(
             self.signature,
             root,
-            DEFINITIONS_DEV_SIGS_REQUIRED,
-            DEFINITIONS_DEV_PUBLIC_KEYS,
+            sigs_required,
+            public_keys,
             self.sigmask,
         )
 

--- a/tests/definitions.py
+++ b/tests/definitions.py
@@ -39,6 +39,8 @@ def make_eth_token(
 
 
 def make_payload(
+    magic: bytes = b"trzd",
+    format_version: bytes = b"1",
     data_type: messages.DefinitionType = messages.DefinitionType.ETHEREUM_NETWORK,
     timestamp: int = 0xFFFF_FFFF,
     message: (
@@ -57,7 +59,8 @@ def make_payload(
         message_bytes = writer.getvalue()
 
     payload = definitions.DefinitionPayload(
-        magic=b"trzd1",
+        magic=magic,
+        version=format_version,
         data_type=data_type,
         timestamp=timestamp,
         data=message_bytes,

--- a/tests/device_tests/ethereum/test_definitions_bad.py
+++ b/tests/device_tests/ethereum/test_definitions_bad.py
@@ -182,7 +182,8 @@ def test_trimmed_proof(session: Session) -> None:
 def test_bad_prefix(session: Session) -> None:
     for make, check in _cases(session):
         payload = make()
-        payload = b"trzd2" + payload[5:]
+        # mangle the magic, keep a valid version byte
+        payload = b"trze1" + payload[5:]
         proof, signature = sign_payload(payload, [])
         check(session, payload + proof + signature, "Invalid definition")
 


### PR DESCRIPTION
- reinterpret the definitions magic `trzd1` as magic + version, i.e. `trzd` + `1`
- this allows us to release backwards incompatible definitions with a bumped version
- this is a necessary preparation for a signature quorum change

[no changelog]

<!--
For external contributors:
- Please open an issue before submitting a PR so we can discuss whether we want to proceed with it.

For core developers:
1. Initial PR setup
- Assign yourself to the PR.
- Add it to the "Firmware" project
  - Set Priority (match issue priority if it exists)
  - Set Team
  - Set Sprint (target release)

2. Development status
- Draft PRs: Set status to "In Progress"
- Final PRs: Set status to "Needs Review"

3. Post-merge status
- Testable: Set status to "Needs QA" and add a `Notes for QA` section with clear instructions on how to test the functionality.
- Not Testable: Set status to "Done (no QA)"
-->
