### PR TITLE
feat(core): Allow Menus to return values

### DIFF
--- a/core/embed/rust/librust_qstr.h
+++ b/core/embed/rust/librust_qstr.h
@@ -27,6 +27,7 @@ static void _librust_qstrs(void) {
   MP_QSTR_CONFIRMED;
   MP_QSTR_CheckBackup;
   MP_QSTR_Close;
+  MP_QSTR_DANGER;
   MP_QSTR_DIM;
   MP_QSTR_DONE;
   MP_QSTR_DeviceMenuResult;
@@ -48,6 +49,7 @@ static void _librust_qstrs(void) {
   MP_QSTR_MESSAGE_READY;
   MP_QSTR_MESSAGE_READY_ACK;
   MP_QSTR_MESSAGE_WIRE_TYPE;
+  MP_QSTR_MenuItemIntent;
   MP_QSTR_MessageType;
   MP_QSTR_Msg;
   MP_QSTR_MsgDef;
@@ -64,6 +66,7 @@ static void _librust_qstrs(void) {
   MP_QSTR_RemoveWipeCode;
   MP_QSTR_ReviewFailedBackup;
   MP_QSTR_SEND_BUFFER_OVERHEAD;
+  MP_QSTR_STANDARD;
   MP_QSTR_SUCCESS;
   MP_QSTR_SWIPE_DOWN;
   MP_QSTR_SWIPE_LEFT;

--- a/core/embed/rust/src/ui/api/firmware_micropython.rs
+++ b/core/embed/rust/src/ui/api/firmware_micropython.rs
@@ -1,6 +1,6 @@
 use heapless::Vec;
 
-use crate::error::{value_error, Error};
+use crate::error::Error;
 use crate::io::BinaryData;
 use crate::micropython::buffer::StrBuffer;
 use crate::micropython::gc::Gc;
@@ -20,13 +20,14 @@ use crate::ui::component::Empty;
 use crate::ui::display::{fade_backlight_duration, get_backlight, set_backlight};
 use crate::ui::layout::base::LAYOUT_STATE;
 use crate::ui::layout::device_menu_result::DEVICE_MENU_RESULT;
+use crate::ui::layout::menu_item_intent::{MenuItemIntent, MENU_ITEM_INTENT_OBJ};
 use crate::ui::layout::obj::{ComponentMsgObj, LayoutObj, ATTACH_TYPE_OBJ};
 use crate::ui::layout::result::{BACK, CANCELLED, CONFIRMED, INFO};
 use crate::ui::layout::util::{upy_disable_animation, RecoveryType};
 use crate::ui::notification::{Notification, NotificationLevel, NOTIFICATION_LEVEL_OBJ};
 use crate::ui::ui_firmware::{
-    FirmwareUI, MenuItemIntent, MAX_CHECKLIST_ITEMS, MAX_GROUP_SHARE_LINES, MAX_MENU_ITEMS,
-    MAX_PAIRED_DEVICES, MAX_WORD_QUIZ_ITEMS, MENU_ITEM_INTENT_OBJ,
+    FirmwareUI, MAX_CHECKLIST_ITEMS, MAX_GROUP_SHARE_LINES, MAX_MENU_ITEMS, MAX_PAIRED_DEVICES,
+    MAX_WORD_QUIZ_ITEMS,
 };
 use crate::ui::ModelUI;
 
@@ -745,7 +746,7 @@ extern "C" fn new_select_menu(n_args: usize, args: *const Obj, kwargs: *mut Map)
             let [text, intent]: [Obj; 2] = util::iter_into_array(item)?;
             items
                 .push((text.try_into()?, intent.try_into()?))
-                .map_err(|_| value_error!(c"Too many menu items"))?;
+                .map_err(|_| Error::OutOfRange)?;
         }
         let current = kwargs.get(Qstr::MP_QSTR_current)?.try_into()?;
 

--- a/core/embed/rust/src/ui/api/firmware_micropython.rs
+++ b/core/embed/rust/src/ui/api/firmware_micropython.rs
@@ -1,6 +1,6 @@
 use heapless::Vec;
 
-use crate::error::Error;
+use crate::error::{value_error, Error};
 use crate::io::BinaryData;
 use crate::micropython::buffer::StrBuffer;
 use crate::micropython::gc::Gc;
@@ -25,7 +25,8 @@ use crate::ui::layout::result::{BACK, CANCELLED, CONFIRMED, INFO};
 use crate::ui::layout::util::{upy_disable_animation, RecoveryType};
 use crate::ui::notification::{Notification, NotificationLevel, NOTIFICATION_LEVEL_OBJ};
 use crate::ui::ui_firmware::{
-    FirmwareUI, MAX_CHECKLIST_ITEMS, MAX_GROUP_SHARE_LINES, MAX_PAIRED_DEVICES, MAX_WORD_QUIZ_ITEMS,
+    FirmwareUI, MenuItemIntent, MAX_CHECKLIST_ITEMS, MAX_GROUP_SHARE_LINES, MAX_MENU_ITEMS,
+    MAX_PAIRED_DEVICES, MAX_WORD_QUIZ_ITEMS, MENU_ITEM_INTENT_OBJ,
 };
 use crate::ui::ModelUI;
 
@@ -739,14 +740,16 @@ extern "C" fn new_request_string(n_args: usize, args: *const Obj, kwargs: *mut M
 extern "C" fn new_select_menu(n_args: usize, args: *const Obj, kwargs: *mut Map) -> Obj {
     let block = move |_args: &[Obj], kwargs: &Map| {
         let items_iterable: Obj = kwargs.get(Qstr::MP_QSTR_items)?;
-        let items = util::iter_into_vec(items_iterable)?;
+        let mut items = Vec::<(TString, MenuItemIntent), MAX_MENU_ITEMS>::new();
+        for item in IterBuf::new().try_iterate(items_iterable)? {
+            let [text, intent]: [Obj; 2] = util::iter_into_array(item)?;
+            items
+                .push((text.try_into()?, intent.try_into()?))
+                .map_err(|_| value_error!(c"Too many menu items"))?;
+        }
         let current = kwargs.get(Qstr::MP_QSTR_current)?.try_into()?;
-        let cancel = kwargs
-            .get(Qstr::MP_QSTR_cancel)
-            .and_then(Obj::try_into_option)
-            .unwrap_or(None);
 
-        let layout = ModelUI::select_menu(items, current, cancel)?;
+        let layout = ModelUI::select_menu(items, current)?;
         Ok(LayoutObj::new_root(layout)?.into())
     };
     unsafe { util::try_with_args_and_kwargs(n_args, args, kwargs, block) }
@@ -1868,11 +1871,11 @@ pub static mp_module_trezorui_api: Module = obj_module! {
 
     /// def select_menu(
     ///     *,
-    ///     items: Iterable[str],
+    ///     items: Iterable[tuple[str, int]],
     ///     current: int,
-    ///     cancel: str | None = None
-    /// ) -> LayoutContext[int]:
-    ///     """Select an item from a menu. Returns index in range `0..len(items)`."""
+    /// ) -> LayoutContext[int | UiResult]:
+    ///     """Select an item from a menu. Each item is its label and its
+    ///     `MenuItemIntent`. Returns index in range `0..len(items)`."""
     Qstr::MP_QSTR_select_menu => obj_fn_kw!(0, new_select_menu).as_obj(),
 
     /// def select_word(
@@ -2190,6 +2193,12 @@ pub static mp_module_trezorui_api: Module = obj_module! {
     ///     INFO: ClassVar[int]
     ///     SUCCESS: ClassVar[int]
     Qstr::MP_QSTR_NotificationLevel => NOTIFICATION_LEVEL_OBJ.as_obj(),
+
+    /// class MenuItemIntent:
+    ///     """What a menu entry means; each model renders it in its own way."""
+    ///     STANDARD: ClassVar[int]
+    ///     DANGER: ClassVar[int]
+    Qstr::MP_QSTR_MenuItemIntent => MENU_ITEM_INTENT_OBJ.as_obj(),
 
     /// class LayoutState:
     ///     """Layout state."""

--- a/core/embed/rust/src/ui/api/firmware_micropython.rs
+++ b/core/embed/rust/src/ui/api/firmware_micropython.rs
@@ -20,14 +20,14 @@ use crate::ui::component::Empty;
 use crate::ui::display::{fade_backlight_duration, get_backlight, set_backlight};
 use crate::ui::layout::base::LAYOUT_STATE;
 use crate::ui::layout::device_menu_result::DEVICE_MENU_RESULT;
-use crate::ui::layout::menu_item_intent::{MenuItemIntent, MENU_ITEM_INTENT_OBJ};
+use crate::ui::layout::menu_item_intent::MENU_ITEM_INTENT_OBJ;
 use crate::ui::layout::obj::{ComponentMsgObj, LayoutObj, ATTACH_TYPE_OBJ};
 use crate::ui::layout::result::{BACK, CANCELLED, CONFIRMED, INFO};
 use crate::ui::layout::util::{upy_disable_animation, RecoveryType};
 use crate::ui::notification::{Notification, NotificationLevel, NOTIFICATION_LEVEL_OBJ};
 use crate::ui::ui_firmware::{
-    FirmwareUI, MAX_CHECKLIST_ITEMS, MAX_GROUP_SHARE_LINES, MAX_MENU_ITEMS, MAX_PAIRED_DEVICES,
-    MAX_WORD_QUIZ_ITEMS,
+    FirmwareUI, SelectMenuItem, MAX_CHECKLIST_ITEMS, MAX_GROUP_SHARE_LINES, MAX_MENU_ITEMS,
+    MAX_PAIRED_DEVICES, MAX_WORD_QUIZ_ITEMS,
 };
 use crate::ui::ModelUI;
 
@@ -741,11 +741,11 @@ extern "C" fn new_request_string(n_args: usize, args: *const Obj, kwargs: *mut M
 extern "C" fn new_select_menu(n_args: usize, args: *const Obj, kwargs: *mut Map) -> Obj {
     let block = move |_args: &[Obj], kwargs: &Map| {
         let items_iterable: Obj = kwargs.get(Qstr::MP_QSTR_items)?;
-        let mut items = Vec::<(TString, MenuItemIntent), MAX_MENU_ITEMS>::new();
+        let mut items = Vec::<SelectMenuItem, MAX_MENU_ITEMS>::new();
         for item in IterBuf::new().try_iterate(items_iterable)? {
             let [text, intent]: [Obj; 2] = util::iter_into_array(item)?;
             items
-                .push((text.try_into()?, intent.try_into()?))
+                .push(SelectMenuItem::new(text.try_into()?, intent.try_into()?))
                 .map_err(|_| Error::OutOfRange)?;
         }
         let current = kwargs.get(Qstr::MP_QSTR_current)?.try_into()?;

--- a/core/embed/rust/src/ui/layout/menu_item_intent.rs
+++ b/core/embed/rust/src/ui/layout/menu_item_intent.rs
@@ -1,0 +1,51 @@
+use crate::error::Error;
+#[cfg(feature = "micropython")]
+use crate::micropython::{
+    macros::{obj_dict, obj_map, obj_type},
+    obj::Obj,
+    qstr::Qstr,
+    simple_type::SimpleTypeObj,
+    typ::FullType,
+};
+
+/// What a menu entry means, which each model renders in its own way.
+#[repr(u8)]
+#[derive(Clone, Copy, PartialEq, Eq, Debug)]
+pub enum MenuItemIntent {
+    /// An ordinary entry.
+    Standard = 0,
+    /// An entry with destructive consequences, e.g. cancelling a signature.
+    Danger = 1,
+}
+
+impl TryFrom<u8> for MenuItemIntent {
+    type Error = Error;
+    fn try_from(value: u8) -> Result<Self, Self::Error> {
+        match value {
+            0 => Ok(MenuItemIntent::Standard),
+            1 => Ok(MenuItemIntent::Danger),
+            _ => Err(Error::OutOfRange),
+        }
+    }
+}
+
+#[cfg(feature = "micropython")]
+impl TryFrom<Obj> for MenuItemIntent {
+    type Error = Error;
+
+    fn try_from(obj: Obj) -> Result<Self, Self::Error> {
+        Self::try_from(u8::try_from(obj)?)
+    }
+}
+
+#[cfg(feature = "micropython")]
+static MENU_ITEM_INTENT_TYPE: FullType = obj_type! {
+    name: Qstr::MP_QSTR_MenuItemIntent,
+    locals: &obj_dict!(obj_map! {
+        Qstr::MP_QSTR_STANDARD => Obj::small_int(MenuItemIntent::Standard as u16),
+        Qstr::MP_QSTR_DANGER => Obj::small_int(MenuItemIntent::Danger as u16),
+    }),
+};
+
+#[cfg(feature = "micropython")]
+pub static MENU_ITEM_INTENT_OBJ: SimpleTypeObj = SimpleTypeObj::new(&MENU_ITEM_INTENT_TYPE);

--- a/core/embed/rust/src/ui/layout/menu_item_intent.rs
+++ b/core/embed/rust/src/ui/layout/menu_item_intent.rs
@@ -10,7 +10,8 @@ use crate::micropython::{
 
 /// What a menu entry means, which each model renders in its own way.
 #[repr(u8)]
-#[derive(Clone, Copy, PartialEq, Eq, Debug)]
+#[derive(Clone, Copy, PartialEq, Eq)]
+#[cfg_attr(feature = "test", derive(core::fmt::Debug))]
 pub enum MenuItemIntent {
     /// An ordinary entry.
     Standard = 0,

--- a/core/embed/rust/src/ui/layout/mod.rs
+++ b/core/embed/rust/src/ui/layout/mod.rs
@@ -5,6 +5,7 @@ pub mod obj;
 
 #[cfg(feature = "micropython")]
 pub mod device_menu_result;
+pub mod menu_item_intent;
 #[cfg(feature = "micropython")]
 pub mod result;
 

--- a/core/embed/rust/src/ui/layout_bolt/component/select_menu.rs
+++ b/core/embed/rust/src/ui/layout_bolt/component/select_menu.rs
@@ -6,7 +6,7 @@ use crate::strutil::TString;
 use crate::ui::component::{Component, Event, EventCtx};
 use crate::ui::geometry::{Insets, Rect};
 use crate::ui::shape::Renderer;
-use crate::ui::ui_firmware::MAX_MENU_ITEMS;
+use crate::ui::ui_firmware::{MenuItemIntent, MAX_MENU_ITEMS};
 
 /// Maximum number of buttons shown on the screen at once.
 /// TODO: pagination for menus with more items.
@@ -14,55 +14,47 @@ const MAX_VISIBLE_BUTTONS: usize = 3;
 
 #[cfg_attr(feature = "debug", derive(ufmt::derive::uDebug))]
 pub enum SelectMenuMsg {
-    /// Menu item selected (index into `items`, excluding the cancel item).
+    /// Menu item selected (index into `items`).
     Selected(usize),
-    /// The cancel menu item was selected.
-    Cancelled,
     /// The menu was closed without selecting anything.
     Closed,
 }
 
-/// Simple vertical menu of buttons, with an optional cancel item at the
-/// bottom and a close button in the top-right corner.
+/// Simple vertical menu of buttons, with a close button in the top-right
+/// corner. An entry asking for `MenuItemIntent::Danger` is styled accordingly.
 pub struct SelectMenu {
     choice_buttons: Vec<Button, MAX_MENU_ITEMS>,
-    cancel_button: Option<Button>,
     close_button: Button,
 }
 
 impl SelectMenu {
     pub fn new(
-        items: Vec<TString<'static>, MAX_MENU_ITEMS>,
-        cancel: Option<TString<'static>>,
+        items: Vec<(TString<'static>, MenuItemIntent), MAX_MENU_ITEMS>,
     ) -> Result<Self, Error> {
-        if items.len() + cancel.map_or(0, |_| 1) > 3 {
+        if items.len() > MAX_VISIBLE_BUTTONS {
             return Err(Error::NotImplementedError);
         }
         let choice_buttons = items
             .into_iter()
-            .map(|text| Button::with_text(text).styled(theme::button_default()))
+            .map(|(text, intent)| {
+                Button::with_text(text).styled(match intent {
+                    MenuItemIntent::Danger => theme::button_cancel(),
+                    MenuItemIntent::Standard => theme::button_default(),
+                })
+            })
             .collect();
-        let cancel_button =
-            cancel.map(|text| Button::with_text(text).styled(theme::button_cancel()));
         let close_button =
             Button::with_icon(theme::ICON_CORNER_CANCEL).styled(theme::button_moreinfo());
 
         Ok(Self {
             choice_buttons,
-            cancel_button,
             close_button,
         })
     }
 
-    /// Number of choice buttons that fit on the screen. The cancel button is
-    /// always visible, so it reserves a slot for itself.
+    /// Number of choice buttons that fit on the screen.
     fn visible_choices(&self) -> usize {
-        let max = if self.cancel_button.is_some() {
-            MAX_VISIBLE_BUTTONS - 1
-        } else {
-            MAX_VISIBLE_BUTTONS
-        };
-        self.choice_buttons.len().min(max)
+        self.choice_buttons.len().min(MAX_VISIBLE_BUTTONS)
     }
 }
 
@@ -91,10 +83,6 @@ impl Component for SelectMenu {
             button.place(slot);
             slots = rest.inset(Insets::top(theme::BUTTON_SPACING));
         }
-        if let Some(cancel) = &mut self.cancel_button {
-            let (slot, _) = slots.split_top(theme::BUTTON_HEIGHT);
-            cancel.place(slot);
-        }
 
         bounds
     }
@@ -104,11 +92,6 @@ impl Component for SelectMenu {
         for (i, button) in self.choice_buttons.iter_mut().take(n_choices).enumerate() {
             if matches!(button.event(ctx, event), Some(ButtonMsg::Clicked)) {
                 return Some(SelectMenuMsg::Selected(i));
-            }
-        }
-        if let Some(cancel) = &mut self.cancel_button {
-            if matches!(cancel.event(ctx, event), Some(ButtonMsg::Clicked)) {
-                return Some(SelectMenuMsg::Cancelled);
             }
         }
         if matches!(
@@ -124,9 +107,6 @@ impl Component for SelectMenu {
         for button in self.choice_buttons.iter().take(self.visible_choices()) {
             button.render(target);
         }
-        if let Some(cancel) = &self.cancel_button {
-            cancel.render(target);
-        }
         self.close_button.render(target);
     }
 }
@@ -138,9 +118,6 @@ impl crate::trace::Trace for SelectMenu {
         t.in_list("buttons", &|button_list| {
             for button in self.choice_buttons.iter().take(self.visible_choices()) {
                 button_list.child(button);
-            }
-            if let Some(cancel) = &self.cancel_button {
-                button_list.child(cancel);
             }
         });
         t.child("close_button", &self.close_button);

--- a/core/embed/rust/src/ui/layout_bolt/component/select_menu.rs
+++ b/core/embed/rust/src/ui/layout_bolt/component/select_menu.rs
@@ -5,8 +5,9 @@ use crate::error::Error;
 use crate::strutil::TString;
 use crate::ui::component::{Component, Event, EventCtx};
 use crate::ui::geometry::{Insets, Rect};
+use crate::ui::layout::menu_item_intent::MenuItemIntent;
 use crate::ui::shape::Renderer;
-use crate::ui::ui_firmware::{MenuItemIntent, MAX_MENU_ITEMS};
+use crate::ui::ui_firmware::MAX_MENU_ITEMS;
 
 /// Maximum number of buttons shown on the screen at once.
 /// TODO: pagination for menus with more items.

--- a/core/embed/rust/src/ui/layout_bolt/component/select_menu.rs
+++ b/core/embed/rust/src/ui/layout_bolt/component/select_menu.rs
@@ -7,7 +7,7 @@ use crate::ui::component::{Component, Event, EventCtx};
 use crate::ui::geometry::{Insets, Rect};
 use crate::ui::layout::menu_item_intent::MenuItemIntent;
 use crate::ui::shape::Renderer;
-use crate::ui::ui_firmware::MAX_MENU_ITEMS;
+use crate::ui::ui_firmware::{SelectMenuItem, MAX_MENU_ITEMS};
 
 /// Maximum number of buttons shown on the screen at once.
 /// TODO: pagination for menus with more items.
@@ -29,16 +29,14 @@ pub struct SelectMenu {
 }
 
 impl SelectMenu {
-    pub fn new(
-        items: Vec<(TString<'static>, MenuItemIntent), MAX_MENU_ITEMS>,
-    ) -> Result<Self, Error> {
+    pub fn new(items: Vec<SelectMenuItem, MAX_MENU_ITEMS>) -> Result<Self, Error> {
         if items.len() > MAX_VISIBLE_BUTTONS {
             return Err(Error::NotImplementedError);
         }
         let choice_buttons = items
             .into_iter()
-            .map(|(text, intent)| {
-                Button::with_text(text).styled(match intent {
+            .map(|item| {
+                Button::with_text(item.text).styled(match item.intent {
                     MenuItemIntent::Danger => theme::button_cancel(),
                     MenuItemIntent::Standard => theme::button_default(),
                 })

--- a/core/embed/rust/src/ui/layout_bolt/component_msg_obj.rs
+++ b/core/embed/rust/src/ui/layout_bolt/component_msg_obj.rs
@@ -57,7 +57,6 @@ impl ComponentMsgObj for SelectMenu {
     fn msg_try_into_obj(&self, msg: Self::Msg) -> Result<Obj, Error> {
         match msg {
             SelectMenuMsg::Selected(i) => i.try_into(),
-            SelectMenuMsg::Cancelled => Ok(CANCELLED.as_obj()),
             // Closing the menu without a choice is a confirmation, not a
             // cancellation (same as on other layouts).
             SelectMenuMsg::Closed => Ok(CONFIRMED.as_obj()),

--- a/core/embed/rust/src/ui/layout_bolt/ui_firmware.rs
+++ b/core/embed/rust/src/ui/layout_bolt/ui_firmware.rs
@@ -28,12 +28,13 @@ use crate::ui::component::text::TextStyle;
 use crate::ui::component::{
     Border, ComponentExt, Empty, FormattedText, Jpeg, Label, Never, Timeout,
 };
+use crate::ui::layout::menu_item_intent::MenuItemIntent;
 use crate::ui::layout::obj::{LayoutMaybeTrace, LayoutObj, RootComponent};
 use crate::ui::layout::util::{ConfirmValueParams, PropsList, RecoveryType};
 use crate::ui::notification::Notification;
 use crate::ui::ui_firmware::{
-    FirmwareUI, MenuItemIntent, MAX_CHECKLIST_ITEMS, MAX_GROUP_SHARE_LINES, MAX_MENU_ITEMS,
-    MAX_PAIRED_DEVICES, MAX_WORD_QUIZ_ITEMS,
+    FirmwareUI, MAX_CHECKLIST_ITEMS, MAX_GROUP_SHARE_LINES, MAX_MENU_ITEMS, MAX_PAIRED_DEVICES,
+    MAX_WORD_QUIZ_ITEMS,
 };
 use crate::ui::{geometry, ModelUI};
 

--- a/core/embed/rust/src/ui/layout_bolt/ui_firmware.rs
+++ b/core/embed/rust/src/ui/layout_bolt/ui_firmware.rs
@@ -32,8 +32,8 @@ use crate::ui::layout::obj::{LayoutMaybeTrace, LayoutObj, RootComponent};
 use crate::ui::layout::util::{ConfirmValueParams, PropsList, RecoveryType};
 use crate::ui::notification::Notification;
 use crate::ui::ui_firmware::{
-    FirmwareUI, MAX_CHECKLIST_ITEMS, MAX_GROUP_SHARE_LINES, MAX_MENU_ITEMS, MAX_PAIRED_DEVICES,
-    MAX_WORD_QUIZ_ITEMS,
+    FirmwareUI, MenuItemIntent, MAX_CHECKLIST_ITEMS, MAX_GROUP_SHARE_LINES, MAX_MENU_ITEMS,
+    MAX_PAIRED_DEVICES, MAX_WORD_QUIZ_ITEMS,
 };
 use crate::ui::{geometry, ModelUI};
 
@@ -719,11 +719,10 @@ impl FirmwareUI for UIBolt {
     }
 
     fn select_menu(
-        items: heapless::Vec<TString<'static>, MAX_MENU_ITEMS>,
+        items: heapless::Vec<(TString<'static>, MenuItemIntent), MAX_MENU_ITEMS>,
         _current: usize,
-        cancel: Option<TString<'static>>,
     ) -> Result<impl LayoutMaybeTrace, Error> {
-        let layout = RootComponent::new(SelectMenu::new(items, cancel)?);
+        let layout = RootComponent::new(SelectMenu::new(items)?);
         Ok(layout)
     }
 

--- a/core/embed/rust/src/ui/layout_bolt/ui_firmware.rs
+++ b/core/embed/rust/src/ui/layout_bolt/ui_firmware.rs
@@ -33,8 +33,8 @@ use crate::ui::layout::obj::{LayoutMaybeTrace, LayoutObj, RootComponent};
 use crate::ui::layout::util::{ConfirmValueParams, PropsList, RecoveryType};
 use crate::ui::notification::Notification;
 use crate::ui::ui_firmware::{
-    FirmwareUI, MAX_CHECKLIST_ITEMS, MAX_GROUP_SHARE_LINES, MAX_MENU_ITEMS, MAX_PAIRED_DEVICES,
-    MAX_WORD_QUIZ_ITEMS,
+    FirmwareUI, SelectMenuItem, MAX_CHECKLIST_ITEMS, MAX_GROUP_SHARE_LINES, MAX_MENU_ITEMS,
+    MAX_PAIRED_DEVICES, MAX_WORD_QUIZ_ITEMS,
 };
 use crate::ui::{geometry, ModelUI};
 
@@ -720,7 +720,7 @@ impl FirmwareUI for UIBolt {
     }
 
     fn select_menu(
-        items: heapless::Vec<(TString<'static>, MenuItemIntent), MAX_MENU_ITEMS>,
+        items: heapless::Vec<SelectMenuItem, MAX_MENU_ITEMS>,
         _current: usize,
     ) -> Result<impl LayoutMaybeTrace, Error> {
         let layout = RootComponent::new(SelectMenu::new(items)?);

--- a/core/embed/rust/src/ui/layout_caesar/component/input_methods/simple_choice.rs
+++ b/core/embed/rust/src/ui/layout_caesar/component/input_methods/simple_choice.rs
@@ -9,8 +9,15 @@ use crate::ui::geometry::Rect;
 use crate::ui::shape::Renderer;
 
 // So that there is only one implementation, and not multiple generic ones
-// as would be via `const N: usize` generics.
-const MAX_LENGTH: usize = 5;
+// as would be via `const N: usize` generics. Callers must size their `Vec`
+// with this constant rather than repeating the literal.
+pub const MAX_LENGTH: usize = 6;
+
+/// `select_menu()` renders through `SimpleChoice`, handing it a list already
+/// bounded by `MAX_MENU_ITEMS`. Keep the capacity at or above that bound so
+/// raising `MAX_MENU_ITEMS` alone cannot stop this model from building.
+#[cfg(feature = "micropython")]
+const _: () = assert!(MAX_LENGTH >= crate::ui::ui_firmware::MAX_MENU_ITEMS);
 
 struct ChoiceFactorySimple {
     choices: Vec<TString<'static>, MAX_LENGTH>,

--- a/core/embed/rust/src/ui/layout_caesar/component/mod.rs
+++ b/core/embed/rust/src/ui/layout_caesar/component/mod.rs
@@ -57,7 +57,7 @@ pub use input_methods::{
     number_input::NumberInput,
     passphrase::PassphraseEntry,
     pin::PinEntry,
-    simple_choice::SimpleChoice,
+    simple_choice::{SimpleChoice, MAX_LENGTH as SIMPLE_CHOICE_MAX_LENGTH},
     wordlist::{WordlistEntry, WordlistType},
 };
 #[cfg(feature = "translations")]

--- a/core/embed/rust/src/ui/layout_caesar/ui_firmware.rs
+++ b/core/embed/rust/src/ui/layout_caesar/ui_firmware.rs
@@ -32,8 +32,8 @@ use crate::ui::layout::obj::{LayoutMaybeTrace, LayoutObj, RootComponent};
 use crate::ui::layout::util::{ConfirmValueParams, PropsList, RecoveryType};
 use crate::ui::notification::Notification;
 use crate::ui::ui_firmware::{
-    FirmwareUI, MAX_CHECKLIST_ITEMS, MAX_GROUP_SHARE_LINES, MAX_MENU_ITEMS, MAX_PAIRED_DEVICES,
-    MAX_WORD_QUIZ_ITEMS,
+    FirmwareUI, MenuItemIntent, MAX_CHECKLIST_ITEMS, MAX_GROUP_SHARE_LINES, MAX_MENU_ITEMS,
+    MAX_PAIRED_DEVICES, MAX_WORD_QUIZ_ITEMS,
 };
 use crate::ui::{geometry, ModelUI};
 
@@ -912,17 +912,25 @@ impl FirmwareUI for UICaesar {
     }
 
     fn select_menu(
-        items: heapless::Vec<TString<'static>, MAX_MENU_ITEMS>,
+        items: heapless::Vec<(TString<'static>, MenuItemIntent), MAX_MENU_ITEMS>,
         current: usize,
-        _cancel: Option<TString<'static>>,
     ) -> Result<impl LayoutMaybeTrace, Error> {
+        // the entry's intent is not rendered on this model
+        let mut labels = heapless::Vec::<TString<'static>, MAX_MENU_ITEMS>::new();
+        for (text, _intent) in items {
+            unwrap!(labels.push(text));
+        }
         // Returning the index of the selected menu item
         let layout = RootComponent::new(
-            SimpleChoice::new(items, ChoiceControls::Cancellable, TR::buttons__view.into())
-                .with_initial_page_counter(current)
-                .with_show_incomplete()
-                .with_return_index()
-                .with_ignore_cancelled(),
+            SimpleChoice::new(
+                labels,
+                ChoiceControls::Cancellable,
+                TR::buttons__view.into(),
+            )
+            .with_initial_page_counter(current)
+            .with_show_incomplete()
+            .with_return_index()
+            .with_ignore_cancelled(),
         );
         Ok(layout)
     }

--- a/core/embed/rust/src/ui/layout_caesar/ui_firmware.rs
+++ b/core/embed/rust/src/ui/layout_caesar/ui_firmware.rs
@@ -6,7 +6,7 @@ use super::component::{
     AddressDetails, ButtonActions, ButtonDetails, ButtonLayout, ButtonPage, ChoiceControls,
     CoinJoinProgress, ConfirmHomescreen, Flow, FlowPages, Frame, Homescreen, Lockscreen,
     NumberInput, Page, PassphraseEntry, PinEntry, Progress, ScrollableFrame, ShareWords, ShowMore,
-    SimpleChoice, WordlistEntry, WordlistType,
+    SimpleChoice, WordlistEntry, WordlistType, SIMPLE_CHOICE_MAX_LENGTH,
 };
 use super::{constant, fonts, theme, UICaesar};
 use crate::error::Error;
@@ -939,7 +939,7 @@ impl FirmwareUI for UICaesar {
         description: TString<'static>,
         words: [TString<'static>; MAX_WORD_QUIZ_ITEMS],
     ) -> Result<impl LayoutMaybeTrace, Error> {
-        let words: Vec<TString<'static>, 5> = Vec::from_iter(words);
+        let words: Vec<TString<'static>, SIMPLE_CHOICE_MAX_LENGTH> = Vec::from_iter(words);
         // Returning the index of the selected word, not the word itself
         let layout = RootComponent::new(
             Frame::new(
@@ -955,7 +955,7 @@ impl FirmwareUI for UICaesar {
 
     fn select_word_count(recovery_type: RecoveryType) -> Result<impl LayoutMaybeTrace, Error> {
         let title: TString = TR::word_count__title.into();
-        let choices: Vec<TString<'static>, 5> = {
+        let choices: Vec<TString<'static>, SIMPLE_CHOICE_MAX_LENGTH> = {
             let nums: &[&str] = if matches!(recovery_type, RecoveryType::UnlockRepeatedBackup) {
                 &["20", "33"]
             } else {

--- a/core/embed/rust/src/ui/layout_caesar/ui_firmware.rs
+++ b/core/embed/rust/src/ui/layout_caesar/ui_firmware.rs
@@ -28,12 +28,13 @@ use crate::ui::component::text::TextStyle;
 use crate::ui::component::{
     Component, ComponentExt, Empty, FormattedText, Label, LineBreaking, Paginate, Timeout,
 };
+use crate::ui::layout::menu_item_intent::MenuItemIntent;
 use crate::ui::layout::obj::{LayoutMaybeTrace, LayoutObj, RootComponent};
 use crate::ui::layout::util::{ConfirmValueParams, PropsList, RecoveryType};
 use crate::ui::notification::Notification;
 use crate::ui::ui_firmware::{
-    FirmwareUI, MenuItemIntent, MAX_CHECKLIST_ITEMS, MAX_GROUP_SHARE_LINES, MAX_MENU_ITEMS,
-    MAX_PAIRED_DEVICES, MAX_WORD_QUIZ_ITEMS,
+    FirmwareUI, MAX_CHECKLIST_ITEMS, MAX_GROUP_SHARE_LINES, MAX_MENU_ITEMS, MAX_PAIRED_DEVICES,
+    MAX_WORD_QUIZ_ITEMS,
 };
 use crate::ui::{geometry, ModelUI};
 
@@ -916,10 +917,8 @@ impl FirmwareUI for UICaesar {
         current: usize,
     ) -> Result<impl LayoutMaybeTrace, Error> {
         // the entry's intent is not rendered on this model
-        let mut labels = heapless::Vec::<TString<'static>, MAX_MENU_ITEMS>::new();
-        for (text, _intent) in items {
-            unwrap!(labels.push(text));
-        }
+        let labels: heapless::Vec<TString<'static>, MAX_MENU_ITEMS> =
+            items.into_iter().map(|(text, _intent)| text).collect();
         // Returning the index of the selected menu item
         let layout = RootComponent::new(
             SimpleChoice::new(

--- a/core/embed/rust/src/ui/layout_caesar/ui_firmware.rs
+++ b/core/embed/rust/src/ui/layout_caesar/ui_firmware.rs
@@ -33,8 +33,8 @@ use crate::ui::layout::obj::{LayoutMaybeTrace, LayoutObj, RootComponent};
 use crate::ui::layout::util::{ConfirmValueParams, PropsList, RecoveryType};
 use crate::ui::notification::Notification;
 use crate::ui::ui_firmware::{
-    FirmwareUI, MAX_CHECKLIST_ITEMS, MAX_GROUP_SHARE_LINES, MAX_MENU_ITEMS, MAX_PAIRED_DEVICES,
-    MAX_WORD_QUIZ_ITEMS,
+    FirmwareUI, SelectMenuItem, MAX_CHECKLIST_ITEMS, MAX_GROUP_SHARE_LINES, MAX_MENU_ITEMS,
+    MAX_PAIRED_DEVICES, MAX_WORD_QUIZ_ITEMS,
 };
 use crate::ui::{geometry, ModelUI};
 
@@ -913,12 +913,12 @@ impl FirmwareUI for UICaesar {
     }
 
     fn select_menu(
-        items: heapless::Vec<(TString<'static>, MenuItemIntent), MAX_MENU_ITEMS>,
+        items: heapless::Vec<SelectMenuItem, MAX_MENU_ITEMS>,
         current: usize,
     ) -> Result<impl LayoutMaybeTrace, Error> {
         // the entry's intent is not rendered on this model
         let labels: heapless::Vec<TString<'static>, MAX_MENU_ITEMS> =
-            items.into_iter().map(|(text, _intent)| text).collect();
+            items.into_iter().map(|item| item.text).collect();
         // Returning the index of the selected menu item
         let layout = RootComponent::new(
             SimpleChoice::new(

--- a/core/embed/rust/src/ui/layout_delizia/component/vertical_menu.rs
+++ b/core/embed/rust/src/ui/layout_delizia/component/vertical_menu.rs
@@ -314,7 +314,15 @@ impl crate::trace::Trace for VerticalMenu {
     }
 }
 
-pub type VerticalMenuItems = Vec<VerticalMenuItem, 6>;
+pub const VERTICAL_MENU_ITEMS: usize = 6;
+
+/// `select_menu()` builds these out of a list already bounded by
+/// `MAX_MENU_ITEMS`, pushing with `unwrap!`, which panics on overflow rather
+/// than returning an error. Keep the capacity at or above that bound so raising
+/// `MAX_MENU_ITEMS` alone cannot turn a rejected menu into a fatal error.
+const _: () = assert!(VERTICAL_MENU_ITEMS >= crate::ui::ui_firmware::MAX_MENU_ITEMS);
+
+pub type VerticalMenuItems = Vec<VerticalMenuItem, VERTICAL_MENU_ITEMS>;
 
 pub enum VerticalMenuItem {
     Item(TString<'static>),

--- a/core/embed/rust/src/ui/layout_delizia/component/vertical_menu.rs
+++ b/core/embed/rust/src/ui/layout_delizia/component/vertical_menu.rs
@@ -320,6 +320,7 @@ pub const VERTICAL_MENU_ITEMS: usize = 6;
 /// `MAX_MENU_ITEMS`, pushing with `unwrap!`, which panics on overflow rather
 /// than returning an error. Keep the capacity at or above that bound so raising
 /// `MAX_MENU_ITEMS` alone cannot turn a rejected menu into a fatal error.
+#[cfg(feature = "micropython")]
 const _: () = assert!(VERTICAL_MENU_ITEMS >= crate::ui::ui_firmware::MAX_MENU_ITEMS);
 
 pub type VerticalMenuItems = Vec<VerticalMenuItem, VERTICAL_MENU_ITEMS>;

--- a/core/embed/rust/src/ui/layout_delizia/ui_firmware.rs
+++ b/core/embed/rust/src/ui/layout_delizia/ui_firmware.rs
@@ -35,12 +35,13 @@ use crate::ui::component::{
 };
 use crate::ui::flow::FlowMsg;
 use crate::ui::geometry::{self, Direction, Offset};
+use crate::ui::layout::menu_item_intent::MenuItemIntent;
 use crate::ui::layout::obj::{LayoutMaybeTrace, LayoutObj, RootComponent};
 use crate::ui::layout::util::{ContentType, PropsList, RecoveryType};
 use crate::ui::notification::Notification;
 use crate::ui::ui_firmware::{
-    FirmwareUI, MenuItemIntent, MAX_CHECKLIST_ITEMS, MAX_GROUP_SHARE_LINES, MAX_MENU_ITEMS,
-    MAX_PAIRED_DEVICES, MAX_WORD_QUIZ_ITEMS,
+    FirmwareUI, MAX_CHECKLIST_ITEMS, MAX_GROUP_SHARE_LINES, MAX_MENU_ITEMS, MAX_PAIRED_DEVICES,
+    MAX_WORD_QUIZ_ITEMS,
 };
 use crate::ui::ModelUI;
 

--- a/core/embed/rust/src/ui/layout_delizia/ui_firmware.rs
+++ b/core/embed/rust/src/ui/layout_delizia/ui_firmware.rs
@@ -39,8 +39,8 @@ use crate::ui::layout::obj::{LayoutMaybeTrace, LayoutObj, RootComponent};
 use crate::ui::layout::util::{ContentType, PropsList, RecoveryType};
 use crate::ui::notification::Notification;
 use crate::ui::ui_firmware::{
-    FirmwareUI, MAX_CHECKLIST_ITEMS, MAX_GROUP_SHARE_LINES, MAX_MENU_ITEMS, MAX_PAIRED_DEVICES,
-    MAX_WORD_QUIZ_ITEMS,
+    FirmwareUI, MenuItemIntent, MAX_CHECKLIST_ITEMS, MAX_GROUP_SHARE_LINES, MAX_MENU_ITEMS,
+    MAX_PAIRED_DEVICES, MAX_WORD_QUIZ_ITEMS,
 };
 use crate::ui::ModelUI;
 
@@ -718,34 +718,27 @@ impl FirmwareUI for UIDelizia {
     }
 
     fn select_menu(
-        items: heapless::Vec<TString<'static>, MAX_MENU_ITEMS>,
-        mut current: usize,
-        cancel: Option<TString<'static>>,
+        items: heapless::Vec<(TString<'static>, MenuItemIntent), MAX_MENU_ITEMS>,
+        current: usize,
     ) -> Result<impl LayoutMaybeTrace, Error> {
         let mut menu_items = VerticalMenuItems::new();
-        if let Some(text) = cancel {
-            unwrap!(menu_items.push(VerticalMenuItem::Cancel(text)));
-            current += 1;
-        }
-        for text in items {
-            unwrap!(menu_items.push(VerticalMenuItem::Item(text)));
+        for (text, intent) in items {
+            unwrap!(menu_items.push(match intent {
+                // TODO: mapping `Danger` onto the `Cancel` variant is temporary -
+                // the variant is named after what the entry did, not how it looks.
+                // `VerticalMenuItem` should carry the intent instead.
+                MenuItemIntent::Danger => VerticalMenuItem::Cancel(text),
+                MenuItemIntent::Standard => VerticalMenuItem::Item(text),
+            }));
         }
         let menu = ScrolledVerticalMenu::new(menu_items, current);
         let frame = Frame::with_header(
             Header::left_aligned(TString::empty()).with_cancel_button(),
             menu,
         );
-        let layout = MsgMap::new(frame, move |msg| {
-            let choice = match msg {
-                FrameMsg::Content(VerticalMenuChoiceMsg::Selected(i)) => i,
-                // `FlowMsg::Cancelled` should be sent only if `cancel` is not `None`
-                FrameMsg::Button(_) => return Some(FlowMsg::Confirmed),
-            };
-            Some(match (choice, cancel) {
-                (0, Some(_)) => FlowMsg::Cancelled,
-                (1.., Some(_)) => FlowMsg::Choice(choice - 1),
-                (_, None) => FlowMsg::Choice(choice),
-            })
+        let layout = MsgMap::new(frame, move |msg| match msg {
+            FrameMsg::Content(VerticalMenuChoiceMsg::Selected(i)) => Some(FlowMsg::Choice(i)),
+            FrameMsg::Button(_) => Some(FlowMsg::Confirmed),
         });
         flow::util::single_page(layout)
     }

--- a/core/embed/rust/src/ui/layout_delizia/ui_firmware.rs
+++ b/core/embed/rust/src/ui/layout_delizia/ui_firmware.rs
@@ -40,8 +40,8 @@ use crate::ui::layout::obj::{LayoutMaybeTrace, LayoutObj, RootComponent};
 use crate::ui::layout::util::{ContentType, PropsList, RecoveryType};
 use crate::ui::notification::Notification;
 use crate::ui::ui_firmware::{
-    FirmwareUI, MAX_CHECKLIST_ITEMS, MAX_GROUP_SHARE_LINES, MAX_MENU_ITEMS, MAX_PAIRED_DEVICES,
-    MAX_WORD_QUIZ_ITEMS,
+    FirmwareUI, SelectMenuItem, MAX_CHECKLIST_ITEMS, MAX_GROUP_SHARE_LINES, MAX_MENU_ITEMS,
+    MAX_PAIRED_DEVICES, MAX_WORD_QUIZ_ITEMS,
 };
 use crate::ui::ModelUI;
 
@@ -719,17 +719,17 @@ impl FirmwareUI for UIDelizia {
     }
 
     fn select_menu(
-        items: heapless::Vec<(TString<'static>, MenuItemIntent), MAX_MENU_ITEMS>,
+        items: heapless::Vec<SelectMenuItem, MAX_MENU_ITEMS>,
         current: usize,
     ) -> Result<impl LayoutMaybeTrace, Error> {
         let mut menu_items = VerticalMenuItems::new();
-        for (text, intent) in items {
-            unwrap!(menu_items.push(match intent {
+        for item in items {
+            unwrap!(menu_items.push(match item.intent {
                 // TODO: mapping `Danger` onto the `Cancel` variant is temporary -
                 // the variant is named after what the entry did, not how it looks.
                 // `VerticalMenuItem` should carry the intent instead.
-                MenuItemIntent::Danger => VerticalMenuItem::Cancel(text),
-                MenuItemIntent::Standard => VerticalMenuItem::Item(text),
+                MenuItemIntent::Danger => VerticalMenuItem::Cancel(item.text),
+                MenuItemIntent::Standard => VerticalMenuItem::Item(item.text),
             }));
         }
         let menu = ScrolledVerticalMenu::new(menu_items, current);

--- a/core/embed/rust/src/ui/layout_eckhart/firmware/vertical_menu.rs
+++ b/core/embed/rust/src/ui/layout_eckhart/firmware/vertical_menu.rs
@@ -15,7 +15,13 @@ use crate::ui::util::animation_disabled;
 /// Presently, VerticalMenu holds only fixed number of buttons.
 pub const LONG_MENU_ITEMS: usize = 100;
 pub const MEDIUM_MENU_ITEMS: usize = 10;
-pub const SHORT_MENU_ITEMS: usize = 5;
+pub const SHORT_MENU_ITEMS: usize = 6;
+
+/// `select_menu()` builds a `ShortMenuVec` out of a list already bounded by
+/// `MAX_MENU_ITEMS`, and `MenuItems::push` panics on overflow rather than
+/// returning an error. Keep the capacity at or above that bound so raising
+/// `MAX_MENU_ITEMS` alone cannot turn a rejected menu into a fatal error.
+const _: () = assert!(SHORT_MENU_ITEMS >= crate::ui::ui_firmware::MAX_MENU_ITEMS);
 
 pub type LongMenuGc = GcBox<Vec<Button, LONG_MENU_ITEMS>>;
 pub type ShortMenuVec = Vec<Button, SHORT_MENU_ITEMS>;

--- a/core/embed/rust/src/ui/layout_eckhart/firmware/vertical_menu.rs
+++ b/core/embed/rust/src/ui/layout_eckhart/firmware/vertical_menu.rs
@@ -21,6 +21,7 @@ pub const SHORT_MENU_ITEMS: usize = 6;
 /// `MAX_MENU_ITEMS`, and `MenuItems::push` panics on overflow rather than
 /// returning an error. Keep the capacity at or above that bound so raising
 /// `MAX_MENU_ITEMS` alone cannot turn a rejected menu into a fatal error.
+#[cfg(feature = "micropython")]
 const _: () = assert!(SHORT_MENU_ITEMS >= crate::ui::ui_firmware::MAX_MENU_ITEMS);
 
 pub type LongMenuGc = GcBox<Vec<Button, LONG_MENU_ITEMS>>;

--- a/core/embed/rust/src/ui/layout_eckhart/ui_firmware.rs
+++ b/core/embed/rust/src/ui/layout_eckhart/ui_firmware.rs
@@ -41,8 +41,8 @@ use crate::ui::layout::util::{
 };
 use crate::ui::notification::Notification;
 use crate::ui::ui_firmware::{
-    FirmwareUI, MAX_CHECKLIST_ITEMS, MAX_GROUP_SHARE_LINES, MAX_MENU_ITEMS, MAX_PAIRED_DEVICES,
-    MAX_WORD_QUIZ_ITEMS,
+    FirmwareUI, MenuItemIntent, MAX_CHECKLIST_ITEMS, MAX_GROUP_SHARE_LINES, MAX_MENU_ITEMS,
+    MAX_PAIRED_DEVICES, MAX_WORD_QUIZ_ITEMS,
 };
 use crate::ui::ModelUI;
 use crate::util::interpolate;
@@ -878,30 +878,26 @@ impl FirmwareUI for UIEckhart {
     }
 
     fn select_menu(
-        items: heapless::Vec<TString<'static>, MAX_MENU_ITEMS>,
+        items: heapless::Vec<(TString<'static>, MenuItemIntent), MAX_MENU_ITEMS>,
         _current: usize,
-        cancel: Option<TString<'static>>,
     ) -> Result<impl LayoutMaybeTrace, Error> {
         let mut menu = VerticalMenu::<ShortMenuVec>::empty();
-        for text in &items {
-            menu.item(Button::new_menu_item(*text, theme::menu_item_title()));
-        }
-        if let Some(text) = cancel {
-            menu.item(Button::new_cancel_menu_item(text));
+        for (text, intent) in &items {
+            menu.item(match intent {
+                // TODO: reusing the cancel button to render a dangerous entry is
+                // temporary - `Danger` describes how the entry looks, while
+                // `new_cancel_menu_item` names what it used to do. The styling
+                // should be lifted out of the cancel-specific constructor.
+                MenuItemIntent::Danger => Button::new_cancel_menu_item(*text),
+                MenuItemIntent::Standard => Button::new_menu_item(*text, theme::menu_item_title()),
+            });
         }
         let screen = VerticalMenuScreen::new(menu)
             .with_header(Header::new(TString::empty()).with_close_button())
-            .map(move |msg| {
-                let choice = match msg {
-                    VerticalMenuScreenMsg::Selected(i) => i,
-                    VerticalMenuScreenMsg::Close => return Some(FlowMsg::Confirmed),
-                    _ => return None,
-                };
-                Some(if cancel.is_some() && choice == items.len() {
-                    FlowMsg::Cancelled
-                } else {
-                    FlowMsg::Choice(choice)
-                })
+            .map(move |msg| match msg {
+                VerticalMenuScreenMsg::Selected(i) => Some(FlowMsg::Choice(i)),
+                VerticalMenuScreenMsg::Close => Some(FlowMsg::Confirmed),
+                _ => None,
             });
 
         flow::util::single_page(screen)

--- a/core/embed/rust/src/ui/layout_eckhart/ui_firmware.rs
+++ b/core/embed/rust/src/ui/layout_eckhart/ui_firmware.rs
@@ -35,14 +35,15 @@ use crate::ui::component::{BLEHandler, BLEHandlerMode};
 use crate::ui::component::{ComponentExt as _, Empty, FormattedText, Timeout};
 use crate::ui::flow::FlowMsg;
 use crate::ui::geometry::{Alignment, LinearPlacement, Offset};
+use crate::ui::layout::menu_item_intent::MenuItemIntent;
 use crate::ui::layout::obj::{LayoutMaybeTrace, LayoutObj, RootComponent};
 use crate::ui::layout::util::{
     ConfirmValueParams, ContentType, PropsList, RecoveryType, StrOrBytes,
 };
 use crate::ui::notification::Notification;
 use crate::ui::ui_firmware::{
-    FirmwareUI, MenuItemIntent, MAX_CHECKLIST_ITEMS, MAX_GROUP_SHARE_LINES, MAX_MENU_ITEMS,
-    MAX_PAIRED_DEVICES, MAX_WORD_QUIZ_ITEMS,
+    FirmwareUI, MAX_CHECKLIST_ITEMS, MAX_GROUP_SHARE_LINES, MAX_MENU_ITEMS, MAX_PAIRED_DEVICES,
+    MAX_WORD_QUIZ_ITEMS,
 };
 use crate::ui::ModelUI;
 use crate::util::interpolate;

--- a/core/embed/rust/src/ui/layout_eckhart/ui_firmware.rs
+++ b/core/embed/rust/src/ui/layout_eckhart/ui_firmware.rs
@@ -42,8 +42,8 @@ use crate::ui::layout::util::{
 };
 use crate::ui::notification::Notification;
 use crate::ui::ui_firmware::{
-    FirmwareUI, MAX_CHECKLIST_ITEMS, MAX_GROUP_SHARE_LINES, MAX_MENU_ITEMS, MAX_PAIRED_DEVICES,
-    MAX_WORD_QUIZ_ITEMS,
+    FirmwareUI, SelectMenuItem, MAX_CHECKLIST_ITEMS, MAX_GROUP_SHARE_LINES, MAX_MENU_ITEMS,
+    MAX_PAIRED_DEVICES, MAX_WORD_QUIZ_ITEMS,
 };
 use crate::ui::ModelUI;
 use crate::util::interpolate;
@@ -879,18 +879,20 @@ impl FirmwareUI for UIEckhart {
     }
 
     fn select_menu(
-        items: heapless::Vec<(TString<'static>, MenuItemIntent), MAX_MENU_ITEMS>,
+        items: heapless::Vec<SelectMenuItem, MAX_MENU_ITEMS>,
         _current: usize,
     ) -> Result<impl LayoutMaybeTrace, Error> {
         let mut menu = VerticalMenu::<ShortMenuVec>::empty();
-        for (text, intent) in &items {
-            menu.item(match intent {
+        for item in &items {
+            menu.item(match item.intent {
                 // TODO: reusing the cancel button to render a dangerous entry is
                 // temporary - `Danger` describes how the entry looks, while
                 // `new_cancel_menu_item` names what it used to do. The styling
                 // should be lifted out of the cancel-specific constructor.
-                MenuItemIntent::Danger => Button::new_cancel_menu_item(*text),
-                MenuItemIntent::Standard => Button::new_menu_item(*text, theme::menu_item_title()),
+                MenuItemIntent::Danger => Button::new_cancel_menu_item(item.text),
+                MenuItemIntent::Standard => {
+                    Button::new_menu_item(item.text, theme::menu_item_title())
+                }
             });
         }
         let screen = VerticalMenuScreen::new(menu)

--- a/core/embed/rust/src/ui/ui_firmware.rs
+++ b/core/embed/rust/src/ui/ui_firmware.rs
@@ -15,7 +15,7 @@ use crate::ui::notification::Notification;
 pub const MAX_CHECKLIST_ITEMS: usize = 3;
 pub const MAX_WORD_QUIZ_ITEMS: usize = 3;
 pub const MAX_GROUP_SHARE_LINES: usize = 4;
-pub const MAX_MENU_ITEMS: usize = 5;
+pub const MAX_MENU_ITEMS: usize = 6;
 
 pub const MAX_PAIRED_DEVICES: usize = 8; // Maximum number of paired devices in the device menu
 

--- a/core/embed/rust/src/ui/ui_firmware.rs
+++ b/core/embed/rust/src/ui/ui_firmware.rs
@@ -8,6 +8,13 @@ use crate::micropython::buffer::StrBuffer;
 use crate::micropython::gc::Gc;
 use crate::micropython::list::List;
 use crate::micropython::obj::Obj;
+#[cfg(feature = "micropython")]
+use crate::micropython::{
+    macros::{obj_dict, obj_map, obj_type},
+    qstr::Qstr,
+    simple_type::SimpleTypeObj,
+    typ::FullType,
+};
 use crate::strutil::TString;
 use crate::ui::notification::Notification;
 
@@ -17,6 +24,48 @@ pub const MAX_GROUP_SHARE_LINES: usize = 4;
 pub const MAX_MENU_ITEMS: usize = 5;
 
 pub const MAX_PAIRED_DEVICES: usize = 8; // Maximum number of paired devices in the device menu
+
+/// What a menu entry means, which each model renders in its own way.
+#[repr(u8)]
+#[derive(Clone, Copy, PartialEq, Eq, Debug)]
+pub enum MenuItemIntent {
+    /// An ordinary entry.
+    Standard = 0,
+    /// An entry with destructive consequences, e.g. cancelling a signature.
+    Danger = 1,
+}
+
+impl TryFrom<u8> for MenuItemIntent {
+    type Error = Error;
+    fn try_from(value: u8) -> Result<Self, Self::Error> {
+        match value {
+            0 => Ok(MenuItemIntent::Standard),
+            1 => Ok(MenuItemIntent::Danger),
+            _ => Err(Error::OutOfRange),
+        }
+    }
+}
+
+#[cfg(feature = "micropython")]
+impl TryFrom<Obj> for MenuItemIntent {
+    type Error = Error;
+
+    fn try_from(obj: Obj) -> Result<Self, Self::Error> {
+        Self::try_from(u8::try_from(obj)?)
+    }
+}
+
+#[cfg(feature = "micropython")]
+static MENU_ITEM_INTENT_TYPE: FullType = obj_type! {
+    name: Qstr::MP_QSTR_MenuItemIntent,
+    locals: &obj_dict!(obj_map! {
+        Qstr::MP_QSTR_STANDARD => Obj::small_int(MenuItemIntent::Standard as u16),
+        Qstr::MP_QSTR_DANGER => Obj::small_int(MenuItemIntent::Danger as u16),
+    }),
+};
+
+#[cfg(feature = "micropython")]
+pub static MENU_ITEM_INTENT_OBJ: SimpleTypeObj = SimpleTypeObj::new(&MENU_ITEM_INTENT_TYPE);
 
 pub trait FirmwareUI {
     #[allow(clippy::too_many_arguments)]
@@ -276,10 +325,10 @@ pub trait FirmwareUI {
         prefill: Option<TString<'static>>,
     ) -> Result<impl LayoutMaybeTrace, Error>;
 
+    /// Each item is its label plus what the entry means.
     fn select_menu(
-        items: heapless::Vec<TString<'static>, MAX_MENU_ITEMS>,
+        items: heapless::Vec<(TString<'static>, MenuItemIntent), MAX_MENU_ITEMS>,
         current: usize,
-        cancel: Option<TString<'static>>,
     ) -> Result<impl LayoutMaybeTrace, Error>;
 
     fn select_word(

--- a/core/embed/rust/src/ui/ui_firmware.rs
+++ b/core/embed/rust/src/ui/ui_firmware.rs
@@ -1,5 +1,6 @@
 use heapless::Vec;
 
+use super::layout::menu_item_intent::MenuItemIntent;
 use super::layout::obj::{LayoutMaybeTrace, LayoutObj};
 use super::layout::util::RecoveryType;
 use crate::error::Error;
@@ -8,13 +9,6 @@ use crate::micropython::buffer::StrBuffer;
 use crate::micropython::gc::Gc;
 use crate::micropython::list::List;
 use crate::micropython::obj::Obj;
-#[cfg(feature = "micropython")]
-use crate::micropython::{
-    macros::{obj_dict, obj_map, obj_type},
-    qstr::Qstr,
-    simple_type::SimpleTypeObj,
-    typ::FullType,
-};
 use crate::strutil::TString;
 use crate::ui::notification::Notification;
 
@@ -24,48 +18,6 @@ pub const MAX_GROUP_SHARE_LINES: usize = 4;
 pub const MAX_MENU_ITEMS: usize = 5;
 
 pub const MAX_PAIRED_DEVICES: usize = 8; // Maximum number of paired devices in the device menu
-
-/// What a menu entry means, which each model renders in its own way.
-#[repr(u8)]
-#[derive(Clone, Copy, PartialEq, Eq, Debug)]
-pub enum MenuItemIntent {
-    /// An ordinary entry.
-    Standard = 0,
-    /// An entry with destructive consequences, e.g. cancelling a signature.
-    Danger = 1,
-}
-
-impl TryFrom<u8> for MenuItemIntent {
-    type Error = Error;
-    fn try_from(value: u8) -> Result<Self, Self::Error> {
-        match value {
-            0 => Ok(MenuItemIntent::Standard),
-            1 => Ok(MenuItemIntent::Danger),
-            _ => Err(Error::OutOfRange),
-        }
-    }
-}
-
-#[cfg(feature = "micropython")]
-impl TryFrom<Obj> for MenuItemIntent {
-    type Error = Error;
-
-    fn try_from(obj: Obj) -> Result<Self, Self::Error> {
-        Self::try_from(u8::try_from(obj)?)
-    }
-}
-
-#[cfg(feature = "micropython")]
-static MENU_ITEM_INTENT_TYPE: FullType = obj_type! {
-    name: Qstr::MP_QSTR_MenuItemIntent,
-    locals: &obj_dict!(obj_map! {
-        Qstr::MP_QSTR_STANDARD => Obj::small_int(MenuItemIntent::Standard as u16),
-        Qstr::MP_QSTR_DANGER => Obj::small_int(MenuItemIntent::Danger as u16),
-    }),
-};
-
-#[cfg(feature = "micropython")]
-pub static MENU_ITEM_INTENT_OBJ: SimpleTypeObj = SimpleTypeObj::new(&MENU_ITEM_INTENT_TYPE);
 
 pub trait FirmwareUI {
     #[allow(clippy::too_many_arguments)]

--- a/core/embed/rust/src/ui/ui_firmware.rs
+++ b/core/embed/rust/src/ui/ui_firmware.rs
@@ -19,6 +19,24 @@ pub const MAX_MENU_ITEMS: usize = 6;
 
 pub const MAX_PAIRED_DEVICES: usize = 8; // Maximum number of paired devices in the device menu
 
+/// One entry of `select_menu()`: its label plus what the entry means.
+///
+/// TODO: named after `select_menu` only to avoid colliding with the existing
+/// `MenuItem` types in `layout_eckhart` (device menu) and `layout_caesar`
+/// (passphrase keyboard), both of which are private and file-local. Once those
+/// are renamed to something model-specific, this should take the generic
+/// `MenuItem` name, since nothing about it is specific to `select_menu`.
+pub struct SelectMenuItem {
+    pub text: TString<'static>,
+    pub intent: MenuItemIntent,
+}
+
+impl SelectMenuItem {
+    pub fn new(text: TString<'static>, intent: MenuItemIntent) -> Self {
+        Self { text, intent }
+    }
+}
+
 pub trait FirmwareUI {
     #[allow(clippy::too_many_arguments)]
     fn confirm_action(
@@ -277,9 +295,8 @@ pub trait FirmwareUI {
         prefill: Option<TString<'static>>,
     ) -> Result<impl LayoutMaybeTrace, Error>;
 
-    /// Each item is its label plus what the entry means.
     fn select_menu(
-        items: heapless::Vec<(TString<'static>, MenuItemIntent), MAX_MENU_ITEMS>,
+        items: heapless::Vec<SelectMenuItem, MAX_MENU_ITEMS>,
         current: usize,
     ) -> Result<impl LayoutMaybeTrace, Error>;
 

--- a/core/mocks/generated/trezorui_api.pyi
+++ b/core/mocks/generated/trezorui_api.pyi
@@ -528,11 +528,11 @@ def request_string(
 # rust/src/ui/api/firmware_micropython.rs
 def select_menu(
     *,
-    items: Iterable[str],
+    items: Iterable[tuple[str, int]],
     current: int,
-    cancel: str | None = None
-) -> LayoutContext[int]:
-    """Select an item from a menu. Returns index in range `0..len(items)`."""
+) -> LayoutContext[int | UiResult]:
+    """Select an item from a menu. Each item is its label and its
+    `MenuItemIntent`. Returns index in range `0..len(items)`."""
 
 
 # rust/src/ui/api/firmware_micropython.rs
@@ -880,6 +880,13 @@ class NotificationLevel:
     WARNING: ClassVar[int]
     INFO: ClassVar[int]
     SUCCESS: ClassVar[int]
+
+
+# rust/src/ui/api/firmware_micropython.rs
+class MenuItemIntent:
+    """What a menu entry means; each model renders it in its own way."""
+    STANDARD: ClassVar[int]
+    DANGER: ClassVar[int]
 
 
 # rust/src/ui/api/firmware_micropython.rs

--- a/core/src/apps/debug/n1w1_mock.py
+++ b/core/src/apps/debug/n1w1_mock.py
@@ -68,7 +68,7 @@ class N1W1Context:
         """Show a layout waiting for N1W1 connection, allowing cancellation."""
 
         from trezor import TR
-        from trezor.ui.layouts.menu import Menu, confirm_with_menu
+        from trezor.ui.layouts.menu import Menu, cancel_leaf, confirm_with_menu
         from trezorui_api import show_info
 
         self_ctx: N1W1Context = self
@@ -97,7 +97,7 @@ class N1W1Context:
         ) as main:
             return await confirm_with_menu(
                 main,
-                Menu.root(cancel=TR.buttons__cancel),
+                Menu([cancel_leaf(TR.buttons__cancel)]),
                 br_name=br_name,
                 layout_type=_Connect,
             )

--- a/core/src/trezor/ui/layouts/caesar/__init__.py
+++ b/core/src/trezor/ui/layouts/caesar/__init__.py
@@ -1481,7 +1481,7 @@ if not utils.BITCOIN_ONLY:
         account_path: str,
         nonce: int,
     ) -> None:
-        from trezor.ui.layouts.menu import Menu, cancel_leaf, confirm_with_menu
+        from trezor.ui.layouts.menu import Menu, confirm_with_menu
 
         with trezorui_api.show_warning(
             title=TR.words__warning,
@@ -1524,7 +1524,8 @@ if not utils.BITCOIN_ONLY:
             ]
             await confirm_with_menu(
                 layout,
-                Menu(children + [cancel_leaf(TR.buttons__cancel)]),
+                # no cancel entry: this model cancels with the hardware button
+                Menu(children),
                 "ethereum/auth7702/details",
                 ButtonRequestType.SignTx,
             )
@@ -1535,7 +1536,7 @@ if not utils.BITCOIN_ONLY:
         account_path: str,
         nonce: int,
     ) -> None:
-        from trezor.ui.layouts.menu import Menu, cancel_leaf, confirm_with_menu
+        from trezor.ui.layouts.menu import Menu, confirm_with_menu
 
         account_info = with_colon(
             (
@@ -1543,12 +1544,12 @@ if not utils.BITCOIN_ONLY:
                 (TR.address_details__derivation_path, account_path, False),
             )
         )
+        # no cancel entry: this model cancels with the hardware button
         menu = Menu(
             children=[
                 create_info_menu_leaf(TR.address_details__account_info, account_info),
                 # TODO: switch to non-Cardano specific string
                 create_info_menu_leaf(TR.cardano__nonce, str(nonce)),
-                cancel_leaf(TR.buttons__cancel),
             ],
         )
 

--- a/core/src/trezor/ui/layouts/caesar/__init__.py
+++ b/core/src/trezor/ui/layouts/caesar/__init__.py
@@ -16,7 +16,7 @@ if TYPE_CHECKING:
     from apps.stellar.tokens import StellarToken
 
     from ..common import ExceptionType, PropertyType, StrPropertyType
-    from ..menu import Details
+    from ..menu import MenuLeaf
     from ..properties import AboveThreshold
     from ..slip24 import Refund, Trade
 
@@ -583,7 +583,9 @@ async def confirm_payment_request(
         menu_items = []
         if recipient_address is not None:
             menu_items.append(
-                create_details(TR.address__title_provider_address, recipient_address)
+                create_info_menu_leaf(
+                    TR.address__title_provider_address, recipient_address
+                )
             )
         for refund in refunds:
             refund_account_items: list[StrPropertyType] = [("", refund.address, None)]
@@ -594,13 +596,13 @@ async def confirm_payment_request(
                     (TR.address_details__derivation_path, refund.account_path, None)
                 )
             menu_items.append(
-                create_details(
+                create_info_menu_leaf(
                     TR.address__title_refund_address,
                     refund_account_items,
                 )
             )
         if menu_items:
-            menu = Menu.root(menu_items)
+            menu = Menu(menu_items)
 
             with trezorui_api.confirm_with_info(
                 title=title,
@@ -640,11 +642,11 @@ async def confirm_payment_request(
         )
 
         summary_menu_items = [
-            create_details(TR.confirm_total__title_fee, fee_info_items),
-            create_details(TR.address_details__account_info, account_items),
+            create_info_menu_leaf(TR.confirm_total__title_fee, fee_info_items),
+            create_info_menu_leaf(TR.address_details__account_info, account_items),
         ]
 
-        summary_menu = Menu.root(summary_menu_items)
+        summary_menu = Menu(summary_menu_items)
 
         with summary_ctx as summary_layout:
             await confirm_with_menu(
@@ -967,7 +969,7 @@ async def confirm_value(
                 br_code,
             )
 
-    from trezor.ui.layouts.menu import Details, Menu, confirm_with_menu
+    from trezor.ui.layouts.menu import Menu, confirm_with_menu, leaf_from_layout
 
     if chunkify:
         main_ctx = trezorui_api.confirm_address(
@@ -1001,8 +1003,8 @@ async def confirm_value(
             chunkify=chunkify_info,
         )
 
-    menu = Menu.root(
-        Details.from_layout(name or "", item_factory(name or "", value or ""))
+    menu = Menu(
+        leaf_from_layout(name or "", item_factory(name or "", value or ""))
         for name, value, _is_data in info_items
     )
     with main_ctx as main:
@@ -1068,10 +1070,12 @@ async def confirm_trade(
         account_items.append(
             (TR.address_details__derivation_path, trade.account_path, None)
         )
-    menu_items = [create_details(TR.address__title_receive_address, account_items)]
+    menu_items = [
+        create_info_menu_leaf(TR.address__title_receive_address, account_items)
+    ]
     for k, v in extra_menu_items:
-        menu_items.append(create_details(k, v))
-    menu = Menu.root(menu_items)
+        menu_items.append(create_info_menu_leaf(k, v))
+    menu = Menu(menu_items)
 
     with trade_ctx as trade_layout:
         await confirm_with_menu(trade_layout, menu, "confirm_trade")
@@ -1477,7 +1481,7 @@ if not utils.BITCOIN_ONLY:
         account_path: str,
         nonce: int,
     ) -> None:
-        from trezor.ui.layouts.menu import Menu, confirm_with_menu
+        from trezor.ui.layouts.menu import Menu, cancel_leaf, confirm_with_menu
 
         with trezorui_api.show_warning(
             title=TR.words__warning,
@@ -1515,12 +1519,12 @@ if not utils.BITCOIN_ONLY:
                 )
             )
             children = [
-                create_details(TR.address_details__account_info, account_info),
-                create_details(TR.buttons__more_info, more_info),
+                create_info_menu_leaf(TR.address_details__account_info, account_info),
+                create_info_menu_leaf(TR.buttons__more_info, more_info),
             ]
             await confirm_with_menu(
                 layout,
-                Menu.root(children, cancel=TR.buttons__cancel),
+                Menu(children + [cancel_leaf(TR.buttons__cancel)]),
                 "ethereum/auth7702/details",
                 ButtonRequestType.SignTx,
             )
@@ -1531,7 +1535,7 @@ if not utils.BITCOIN_ONLY:
         account_path: str,
         nonce: int,
     ) -> None:
-        from trezor.ui.layouts.menu import Menu, confirm_with_menu
+        from trezor.ui.layouts.menu import Menu, cancel_leaf, confirm_with_menu
 
         account_info = with_colon(
             (
@@ -1539,13 +1543,13 @@ if not utils.BITCOIN_ONLY:
                 (TR.address_details__derivation_path, account_path, False),
             )
         )
-        menu = Menu.root(
+        menu = Menu(
             children=[
-                create_details(TR.address_details__account_info, account_info),
+                create_info_menu_leaf(TR.address_details__account_info, account_info),
                 # TODO: switch to non-Cardano specific string
-                create_details(TR.cardano__nonce, str(nonce)),
+                create_info_menu_leaf(TR.cardano__nonce, str(nonce)),
+                cancel_leaf(TR.buttons__cancel),
             ],
-            cancel=TR.buttons__cancel,
         )
 
         with trezorui_api.confirm_action(
@@ -1681,8 +1685,9 @@ if not utils.BITCOIN_ONLY:
             fee_label="",
             external_menu=True,
         )
-        menu = Menu.root(
-            create_details(name or "", value or "") for name, value, _is_data in items
+        menu = Menu(
+            create_info_menu_leaf(name or "", value or "")
+            for name, value, _is_data in items
         )
         with main_ctx as main:
             await confirm_with_menu(main, menu, br_name, br_code)
@@ -1704,7 +1709,7 @@ if not utils.BITCOIN_ONLY:
             (TR.confirm_total__title_fee, fee_details),
             (TR.address_details__account_info, account_details),
         ]
-        menu = Menu.root(create_details(name, props) for name, props in iter)
+        menu = Menu(create_info_menu_leaf(name, props) for name, props in iter)
         with main_ctx as main:
             await confirm_with_menu(main, menu, br_name, br_code)
 
@@ -2573,9 +2578,11 @@ async def confirm_firmware_update(description: str, fingerprint: str) -> None:
         )
 
 
-def create_details(name: str, value: Sequence[StrPropertyType] | str) -> Details:
-    from trezor.ui.layouts.menu import Details
+def create_info_menu_leaf(
+    name: str, value: Sequence[StrPropertyType] | str
+) -> MenuLeaf[None]:
+    from trezor.ui.layouts.menu import leaf_from_layout
 
-    return Details.from_layout(
+    return leaf_from_layout(
         name, lambda: trezorui_api.show_properties(title=name, value=value)
     )

--- a/core/src/trezor/ui/layouts/delizia/__init__.py
+++ b/core/src/trezor/ui/layouts/delizia/__init__.py
@@ -531,7 +531,7 @@ async def confirm_payment_request(
                 refund_account_items,
             )
         )
-    menu = Menu(menu_items + [cancel_leaf(TR.buttons__cancel_sign)])
+    menu = Menu([cancel_leaf(TR.buttons__cancel_sign)] + menu_items)
 
     with main_ctx as main_layout:
         await confirm_with_menu(main_layout, menu, "confirm_payment_request")
@@ -857,13 +857,13 @@ async def confirm_value(
     for name, p, page_title in info_items or []:
         menu_items.append(create_info_menu_leaf(name, p, page_title))
     menu = Menu(
-        menu_items
-        + [
+        [
             cancel_leaf(
                 cancel_text or TR.buttons__cancel,
                 confirm=trezorui_api.confirm_cancel,
             )
         ]
+        + menu_items
     )
     with main_ctx as main_layout:
         return await interact_with_menu(main_layout, menu, br_name, br_code)
@@ -989,7 +989,7 @@ async def confirm_trade(
     ]
     for k, v in extra_menu_items:
         menu_items.append(create_info_menu_leaf(k, v))
-    menu = Menu(menu_items + [cancel_leaf(TR.buttons__cancel_sign)])
+    menu = Menu([cancel_leaf(TR.buttons__cancel_sign)] + menu_items)
 
     with trade_ctx as trade_layout:
         await confirm_with_menu(trade_layout, menu, "confirm_trade")
@@ -1371,7 +1371,7 @@ if not utils.BITCOIN_ONLY:
             ) as layout:
                 return await interact_with_menu(
                     layout,
-                    Menu(menu_items + [cancel_leaf(TR.buttons__cancel_sign)]),
+                    Menu([cancel_leaf(TR.buttons__cancel_sign)] + menu_items),
                     f"{br_name}/intro",
                     ButtonRequestType.SignTx,
                 )
@@ -1386,7 +1386,7 @@ if not utils.BITCOIN_ONLY:
             ) as layout:
                 return await interact_with_menu(
                     layout,
-                    Menu(menu_items + [cancel_leaf(TR.buttons__cancel_sign)]),
+                    Menu([cancel_leaf(TR.buttons__cancel_sign)] + menu_items),
                     f"{br_name}/vault_name",
                 )
 
@@ -1402,7 +1402,7 @@ if not utils.BITCOIN_ONLY:
             ) as layout:
                 return await interact_with_menu(
                     layout,
-                    Menu(menu_items + [cancel_leaf(TR.buttons__cancel_sign)]),
+                    Menu([cancel_leaf(TR.buttons__cancel_sign)] + menu_items),
                     f"{br_name}/amount",
                     br_code,
                 )
@@ -1420,7 +1420,7 @@ if not utils.BITCOIN_ONLY:
                 ) as layout:
                     return await interact_with_menu(
                         layout,
-                        Menu(menu_items + [cancel_leaf(TR.buttons__cancel_sign)]),
+                        Menu([cancel_leaf(TR.buttons__cancel_sign)] + menu_items),
                         f"{br_name}/extra_data",
                         br_code,
                     )
@@ -1440,7 +1440,7 @@ if not utils.BITCOIN_ONLY:
             ) as layout:
                 return await interact_with_menu(
                     layout,
-                    Menu(menu_items + [cancel_leaf(TR.buttons__cancel_sign)]),
+                    Menu([cancel_leaf(TR.buttons__cancel_sign)] + menu_items),
                     f"{br_name}/summary",
                     br_code,
                 )
@@ -1484,7 +1484,7 @@ if not utils.BITCOIN_ONLY:
             ) as layout:
                 return await interact_with_menu(
                     layout,
-                    Menu(menu_items + [cancel_leaf(TR.buttons__cancel_sign)]),
+                    Menu([cancel_leaf(TR.buttons__cancel_sign)] + menu_items),
                     f"{br_name}/intro",
                     br_code,
                 )
@@ -1500,7 +1500,7 @@ if not utils.BITCOIN_ONLY:
             ) as layout:
                 return await interact_with_menu(
                     layout,
-                    Menu(menu_items + [cancel_leaf(TR.buttons__cancel_sign)]),
+                    Menu([cancel_leaf(TR.buttons__cancel_sign)] + menu_items),
                     f"{br_name}/tokens",
                     br_code,
                 )
@@ -1518,7 +1518,7 @@ if not utils.BITCOIN_ONLY:
             ) as layout:
                 return await interact_with_menu(
                     layout,
-                    Menu(menu_items + [cancel_leaf(TR.buttons__cancel_sign)]),
+                    Menu([cancel_leaf(TR.buttons__cancel_sign)] + menu_items),
                     f"{br_name}/summary",
                     br_code,
                 )
@@ -1568,7 +1568,7 @@ if not utils.BITCOIN_ONLY:
             ]
             await confirm_with_menu(
                 layout,
-                Menu(children + [cancel_leaf(TR.buttons__cancel)]),
+                Menu([cancel_leaf(TR.buttons__cancel)] + children),
                 "ethereum/auth7702/details",
                 ButtonRequestType.SignTx,
             )
@@ -1587,9 +1587,9 @@ if not utils.BITCOIN_ONLY:
         ]
         menu = Menu(
             children=[
+                cancel_leaf(TR.buttons__cancel),
                 create_info_menu_leaf(TR.address_details__account_info, account_info),
                 create_info_menu_leaf(TR.cardano__nonce, str(nonce)),
-                cancel_leaf(TR.buttons__cancel),
             ],
         )
 
@@ -1879,7 +1879,7 @@ if not utils.BITCOIN_ONLY:
         ) as layout:
             await interact_with_menu(
                 layout,
-                Menu(menu_items + [cancel_leaf(TR.buttons__cancel_sign)]),
+                Menu([cancel_leaf(TR.buttons__cancel_sign)] + menu_items),
                 br_name,
                 br_code,
             )
@@ -2248,8 +2248,7 @@ async def confirm_signverify(
     )
 
     menu = Menu(
-        items
-        + [
+        [
             cancel_leaf(
                 TR.buttons__cancel,
                 confirm=lambda: trezorui_api.show_mismatch(
@@ -2257,6 +2256,7 @@ async def confirm_signverify(
                 ),
             )
         ]
+        + items
     )
 
     with address_ctx as address_layout:

--- a/core/src/trezor/ui/layouts/delizia/__init__.py
+++ b/core/src/trezor/ui/layouts/delizia/__init__.py
@@ -21,7 +21,7 @@ if TYPE_CHECKING:
     from apps.stellar.tokens import StellarToken
 
     from ..common import ExceptionType, PropertyType, StrPropertyType
-    from ..menu import Details
+    from ..menu import MenuLeaf
     from ..properties import AboveThreshold
     from ..slip24 import Refund, Trade
 
@@ -53,7 +53,7 @@ async def confirm_action(
     prompt_screen: bool = False,
     prompt_title: str | None = None,
 ) -> ui.UiResult:
-    from trezor.ui.layouts.menu import Menu, interact_with_menu
+    from trezor.ui.layouts.menu import Menu, cancel_leaf, interact_with_menu
 
     if description is not None and description_param is not None:
         description = description.format(description_param)
@@ -82,9 +82,7 @@ async def confirm_action(
                 exc,
             )
         else:
-            menu = Menu.root(
-                cancel=verb_cancel or TR.buttons__cancel,
-            )
+            menu = Menu([cancel_leaf(verb_cancel or TR.buttons__cancel, exc)])
 
             return await interact_with_menu(
                 flow,
@@ -488,7 +486,7 @@ async def confirm_payment_request(
     fee_info_items: Sequence[StrPropertyType] | None,
     extra_menu_items: list[tuple[str, str]] | None = None,
 ) -> None:
-    from trezor.ui.layouts.menu import Menu, confirm_with_menu
+    from trezor.ui.layouts.menu import Menu, cancel_leaf, confirm_with_menu
 
     from ..slip24 import is_swap
 
@@ -517,7 +515,7 @@ async def confirm_payment_request(
     menu_items = []
     if recipient_address is not None:
         menu_items.append(
-            create_details(TR.address__title_provider_address, recipient_address)
+            create_info_menu_leaf(TR.address__title_provider_address, recipient_address)
         )
     for refund in refunds:
         refund_account_items: list[StrPropertyType] = [("", refund.address, None)]
@@ -528,12 +526,12 @@ async def confirm_payment_request(
                 (TR.address_details__derivation_path, refund.account_path, None)
             )
         menu_items.append(
-            create_details(
+            create_info_menu_leaf(
                 TR.address__title_refund_address,
                 refund_account_items,
             )
         )
-    menu = Menu.root(menu_items, TR.buttons__cancel_sign)
+    menu = Menu(menu_items + [cancel_leaf(TR.buttons__cancel_sign)])
 
     with main_ctx as main_layout:
         await confirm_with_menu(main_layout, menu, "confirm_payment_request")
@@ -839,7 +837,7 @@ async def confirm_value(
 ) -> ui.UiResult:
     """General confirmation dialog, used by many other confirm_* functions."""
 
-    from trezor.ui.layouts.menu import Cancel, Menu, interact_with_menu
+    from trezor.ui.layouts.menu import Menu, cancel_leaf, interact_with_menu
 
     main_ctx = trezorui_api.confirm_value(
         title=title,
@@ -857,13 +855,15 @@ async def confirm_value(
 
     menu_items = []
     for name, p, page_title in info_items or []:
-        menu_items.append(create_details(name, p, page_title))
-    menu = Menu.root(
-        menu_items,
-        cancel=Cancel.from_layout(
-            name=(cancel_text or TR.buttons__cancel),
-            layout_factory=trezorui_api.confirm_cancel,
-        ),
+        menu_items.append(create_info_menu_leaf(name, p, page_title))
+    menu = Menu(
+        menu_items
+        + [
+            cancel_leaf(
+                cancel_text or TR.buttons__cancel,
+                confirm=trezorui_api.confirm_cancel,
+            )
+        ]
     )
     with main_ctx as main_layout:
         return await interact_with_menu(main_layout, menu, br_name, br_code)
@@ -968,7 +968,7 @@ async def confirm_trade(
     trade: Trade,
     extra_menu_items: list[tuple[str, str]],
 ) -> None:
-    from trezor.ui.layouts.menu import Menu, confirm_with_menu
+    from trezor.ui.layouts.menu import Menu, cancel_leaf, confirm_with_menu
 
     trade_ctx = trezorui_api.confirm_trade(
         title=title,
@@ -984,10 +984,12 @@ async def confirm_trade(
         account_items.append(
             (TR.address_details__derivation_path, trade.account_path, None)
         )
-    menu_items = [create_details(TR.address__title_receive_address, account_items)]
+    menu_items = [
+        create_info_menu_leaf(TR.address__title_receive_address, account_items)
+    ]
     for k, v in extra_menu_items:
-        menu_items.append(create_details(k, v))
-    menu = Menu.root(menu_items, TR.buttons__cancel_sign)
+        menu_items.append(create_info_menu_leaf(k, v))
+    menu = Menu(menu_items + [cancel_leaf(TR.buttons__cancel_sign)])
 
     with trade_ctx as trade_layout:
         await confirm_with_menu(trade_layout, menu, "confirm_trade")
@@ -1345,13 +1347,13 @@ if not utils.BITCOIN_ONLY:
         br_code: ButtonRequestType = ButtonRequestType.SignTx,
         extra_data: str | None = None,
     ) -> None:
-        from trezor.ui.layouts.menu import Menu, interact_with_menu
+        from trezor.ui.layouts.menu import Menu, cancel_leaf, interact_with_menu
 
         menu_items = []
         account_info_items = _get_account_info_items(account, account_path)
         if account_info_items:
             menu_items.append(
-                create_details(
+                create_info_menu_leaf(
                     TR.address_details__account_info,
                     account_info_items[0][1],
                     title=TR.address_details__account_info,
@@ -1369,7 +1371,7 @@ if not utils.BITCOIN_ONLY:
             ) as layout:
                 return await interact_with_menu(
                     layout,
-                    Menu.root(menu_items, TR.buttons__cancel_sign),
+                    Menu(menu_items + [cancel_leaf(TR.buttons__cancel_sign)]),
                     f"{br_name}/intro",
                     ButtonRequestType.SignTx,
                 )
@@ -1384,7 +1386,7 @@ if not utils.BITCOIN_ONLY:
             ) as layout:
                 return await interact_with_menu(
                     layout,
-                    Menu.root(menu_items, TR.buttons__cancel_sign),
+                    Menu(menu_items + [cancel_leaf(TR.buttons__cancel_sign)]),
                     f"{br_name}/vault_name",
                 )
 
@@ -1400,7 +1402,7 @@ if not utils.BITCOIN_ONLY:
             ) as layout:
                 return await interact_with_menu(
                     layout,
-                    Menu.root(menu_items, TR.buttons__cancel_sign),
+                    Menu(menu_items + [cancel_leaf(TR.buttons__cancel_sign)]),
                     f"{br_name}/amount",
                     br_code,
                 )
@@ -1418,7 +1420,7 @@ if not utils.BITCOIN_ONLY:
                 ) as layout:
                     return await interact_with_menu(
                         layout,
-                        Menu.root(menu_items, TR.buttons__cancel_sign),
+                        Menu(menu_items + [cancel_leaf(TR.buttons__cancel_sign)]),
                         f"{br_name}/extra_data",
                         br_code,
                     )
@@ -1438,7 +1440,7 @@ if not utils.BITCOIN_ONLY:
             ) as layout:
                 return await interact_with_menu(
                     layout,
-                    Menu.root(menu_items, TR.buttons__cancel_sign),
+                    Menu(menu_items + [cancel_leaf(TR.buttons__cancel_sign)]),
                     f"{br_name}/summary",
                     br_code,
                 )
@@ -1458,13 +1460,13 @@ if not utils.BITCOIN_ONLY:
         br_name: str,
         br_code: ButtonRequestType = ButtonRequestType.SignTx,
     ) -> None:
-        from trezor.ui.layouts.menu import Menu, interact_with_menu
+        from trezor.ui.layouts.menu import Menu, cancel_leaf, interact_with_menu
 
         menu_items = []
         account_info_items = _get_account_info_items(account, account_path)
         if account_info_items:
             menu_items.append(
-                create_details(
+                create_info_menu_leaf(
                     TR.address_details__account_info,
                     account_info_items[0][1],
                     title=TR.address_details__account_info,
@@ -1482,7 +1484,7 @@ if not utils.BITCOIN_ONLY:
             ) as layout:
                 return await interact_with_menu(
                     layout,
-                    Menu.root(menu_items, TR.buttons__cancel_sign),
+                    Menu(menu_items + [cancel_leaf(TR.buttons__cancel_sign)]),
                     f"{br_name}/intro",
                     br_code,
                 )
@@ -1498,7 +1500,7 @@ if not utils.BITCOIN_ONLY:
             ) as layout:
                 return await interact_with_menu(
                     layout,
-                    Menu.root(menu_items, TR.buttons__cancel_sign),
+                    Menu(menu_items + [cancel_leaf(TR.buttons__cancel_sign)]),
                     f"{br_name}/tokens",
                     br_code,
                 )
@@ -1516,7 +1518,7 @@ if not utils.BITCOIN_ONLY:
             ) as layout:
                 return await interact_with_menu(
                     layout,
-                    Menu.root(menu_items, TR.buttons__cancel_sign),
+                    Menu(menu_items + [cancel_leaf(TR.buttons__cancel_sign)]),
                     f"{br_name}/summary",
                     br_code,
                 )
@@ -1531,7 +1533,7 @@ if not utils.BITCOIN_ONLY:
         account_path: str,
         nonce: int,
     ) -> None:
-        from trezor.ui.layouts.menu import Menu, confirm_with_menu
+        from trezor.ui.layouts.menu import Menu, cancel_leaf, confirm_with_menu
 
         with trezorui_api.show_warning(
             title=TR.words__warning,
@@ -1561,12 +1563,12 @@ if not utils.BITCOIN_ONLY:
                 (TR.cardano__nonce, str(nonce), False),
             ]
             children = [
-                create_details(TR.address_details__account_info, account_info),
-                create_details(TR.buttons__more_info, more_info),
+                create_info_menu_leaf(TR.address_details__account_info, account_info),
+                create_info_menu_leaf(TR.buttons__more_info, more_info),
             ]
             await confirm_with_menu(
                 layout,
-                Menu.root(children, cancel=TR.buttons__cancel),
+                Menu(children + [cancel_leaf(TR.buttons__cancel)]),
                 "ethereum/auth7702/details",
                 ButtonRequestType.SignTx,
             )
@@ -1577,18 +1579,18 @@ if not utils.BITCOIN_ONLY:
         account_path: str,
         nonce: int,
     ) -> None:
-        from trezor.ui.layouts.menu import Menu, confirm_with_menu
+        from trezor.ui.layouts.menu import Menu, cancel_leaf, confirm_with_menu
 
         account_info = [
             (TR.words__account, account, True),
             (TR.address_details__derivation_path, account_path, True),
         ]
-        menu = Menu.root(
+        menu = Menu(
             children=[
-                create_details(TR.address_details__account_info, account_info),
-                create_details(TR.cardano__nonce, str(nonce)),
+                create_info_menu_leaf(TR.address_details__account_info, account_info),
+                create_info_menu_leaf(TR.cardano__nonce, str(nonce)),
+                cancel_leaf(TR.buttons__cancel),
             ],
-            cancel=TR.buttons__cancel,
         )
 
         with trezorui_api.confirm_action(
@@ -1854,13 +1856,13 @@ if not utils.BITCOIN_ONLY:
         br_name: str = "tron/claim",
         br_code: ButtonRequestType = ButtonRequestType.SignTx,
     ) -> None:
-        from trezor.ui.layouts.menu import Menu, interact_with_menu
+        from trezor.ui.layouts.menu import Menu, cancel_leaf, interact_with_menu
 
         menu_items = []
         account_info_items = _get_account_info_items(account, account_path)
         if account_info_items:
             menu_items.append(
-                create_details(
+                create_info_menu_leaf(
                     TR.address_details__account_info,
                     account_info_items[0][1],
                     title=TR.address_details__account_info,
@@ -1877,7 +1879,7 @@ if not utils.BITCOIN_ONLY:
         ) as layout:
             await interact_with_menu(
                 layout,
-                Menu.root(menu_items, TR.buttons__cancel_sign),
+                Menu(menu_items + [cancel_leaf(TR.buttons__cancel_sign)]),
                 br_name,
                 br_code,
             )
@@ -2215,7 +2217,7 @@ async def confirm_signverify(
     account: str | None = None,
     chunkify: bool = False,
 ) -> None:
-    from trezor.ui.layouts.menu import Cancel, Menu, confirm_with_menu
+    from trezor.ui.layouts.menu import Menu, cancel_leaf, confirm_with_menu
 
     if verify:
         address_title = TR.sign_message__verify_address
@@ -2233,26 +2235,28 @@ async def confirm_signverify(
         external_menu=True,
     )
 
-    items: list[Details] = []
+    items: list[MenuLeaf] = []
     if account is not None:
-        items.append(create_details(TR.words__account, account))
+        items.append(create_info_menu_leaf(TR.words__account, account))
     if path is not None:
-        items.append(create_details(TR.address_details__derivation_path, path))
+        items.append(create_info_menu_leaf(TR.address_details__derivation_path, path))
     items.append(
-        create_details(
+        create_info_menu_leaf(
             TR.sign_message__message_size,
             TR.sign_message__bytes_template.format(len(message)),
         )
     )
 
-    menu = Menu.root(
-        items,
-        cancel=Cancel.from_layout(
-            name=TR.buttons__cancel,
-            layout_factory=lambda: trezorui_api.show_mismatch(
-                title=TR.addr_mismatch__mismatch
-            ),
-        ),
+    menu = Menu(
+        items
+        + [
+            cancel_leaf(
+                TR.buttons__cancel,
+                confirm=lambda: trezorui_api.show_mismatch(
+                    title=TR.addr_mismatch__mismatch
+                ),
+            )
+        ]
     )
 
     with address_ctx as address_layout:
@@ -2481,14 +2485,14 @@ async def tutorial(br_code: ButtonRequestType = BR_CODE_OTHER) -> None:
         return await raise_if_not_confirmed(layout, "tutorial", br_code)
 
 
-def create_details(
+def create_info_menu_leaf(
     name: str,
     value: Sequence[StrPropertyType] | str,
     title: str | None = None,
-) -> Details:
-    from trezor.ui.layouts.menu import Details
+) -> MenuLeaf[None]:
+    from trezor.ui.layouts.menu import leaf_from_layout
 
-    return Details.from_layout(
+    return leaf_from_layout(
         name,
         lambda: trezorui_api.show_properties(title=(title or name), value=value),
     )

--- a/core/src/trezor/ui/layouts/delizia/__init__.py
+++ b/core/src/trezor/ui/layouts/delizia/__init__.py
@@ -1855,7 +1855,7 @@ if not utils.BITCOIN_ONLY:
         br_name: str = "tron/claim",
         br_code: ButtonRequestType = ButtonRequestType.SignTx,
     ) -> None:
-        from trezor.ui.layouts.menu import Menu, cancel_leaf, interact_with_menu
+        from trezor.ui.layouts.menu import Menu, cancel_leaf, confirm_with_menu
 
         menu_items = [cancel_leaf(TR.buttons__cancel_sign)]
         account_info_items = _get_account_info_items(account, account_path)
@@ -1876,7 +1876,7 @@ if not utils.BITCOIN_ONLY:
             hold=True,
             external_menu=True,
         ) as layout:
-            await interact_with_menu(
+            await confirm_with_menu(
                 layout,
                 Menu(menu_items),
                 br_name,

--- a/core/src/trezor/ui/layouts/delizia/__init__.py
+++ b/core/src/trezor/ui/layouts/delizia/__init__.py
@@ -512,7 +512,7 @@ async def confirm_payment_request(
         external_menu=True,
     )
 
-    menu_items = []
+    menu_items = [cancel_leaf(TR.buttons__cancel_sign)]
     if recipient_address is not None:
         menu_items.append(
             create_info_menu_leaf(TR.address__title_provider_address, recipient_address)
@@ -531,7 +531,7 @@ async def confirm_payment_request(
                 refund_account_items,
             )
         )
-    menu = Menu([cancel_leaf(TR.buttons__cancel_sign)] + menu_items)
+    menu = Menu(menu_items)
 
     with main_ctx as main_layout:
         await confirm_with_menu(main_layout, menu, "confirm_payment_request")
@@ -853,18 +853,15 @@ async def confirm_value(
         external_menu=True,
     )
 
-    menu_items = []
+    menu_items = [
+        cancel_leaf(
+            cancel_text or TR.buttons__cancel,
+            confirm=trezorui_api.confirm_cancel,
+        )
+    ]
     for name, p, page_title in info_items or []:
         menu_items.append(create_info_menu_leaf(name, p, page_title))
-    menu = Menu(
-        [
-            cancel_leaf(
-                cancel_text or TR.buttons__cancel,
-                confirm=trezorui_api.confirm_cancel,
-            )
-        ]
-        + menu_items
-    )
+    menu = Menu(menu_items)
     with main_ctx as main_layout:
         return await interact_with_menu(main_layout, menu, br_name, br_code)
 
@@ -985,11 +982,12 @@ async def confirm_trade(
             (TR.address_details__derivation_path, trade.account_path, None)
         )
     menu_items = [
-        create_info_menu_leaf(TR.address__title_receive_address, account_items)
+        cancel_leaf(TR.buttons__cancel_sign),
+        create_info_menu_leaf(TR.address__title_receive_address, account_items),
     ]
     for k, v in extra_menu_items:
         menu_items.append(create_info_menu_leaf(k, v))
-    menu = Menu([cancel_leaf(TR.buttons__cancel_sign)] + menu_items)
+    menu = Menu(menu_items)
 
     with trade_ctx as trade_layout:
         await confirm_with_menu(trade_layout, menu, "confirm_trade")
@@ -1349,7 +1347,7 @@ if not utils.BITCOIN_ONLY:
     ) -> None:
         from trezor.ui.layouts.menu import Menu, cancel_leaf, interact_with_menu
 
-        menu_items = []
+        menu_items = [cancel_leaf(TR.buttons__cancel_sign)]
         account_info_items = _get_account_info_items(account, account_path)
         if account_info_items:
             menu_items.append(
@@ -1371,7 +1369,7 @@ if not utils.BITCOIN_ONLY:
             ) as layout:
                 return await interact_with_menu(
                     layout,
-                    Menu([cancel_leaf(TR.buttons__cancel_sign)] + menu_items),
+                    Menu(menu_items),
                     f"{br_name}/intro",
                     ButtonRequestType.SignTx,
                 )
@@ -1386,7 +1384,7 @@ if not utils.BITCOIN_ONLY:
             ) as layout:
                 return await interact_with_menu(
                     layout,
-                    Menu([cancel_leaf(TR.buttons__cancel_sign)] + menu_items),
+                    Menu(menu_items),
                     f"{br_name}/vault_name",
                 )
 
@@ -1402,7 +1400,7 @@ if not utils.BITCOIN_ONLY:
             ) as layout:
                 return await interact_with_menu(
                     layout,
-                    Menu([cancel_leaf(TR.buttons__cancel_sign)] + menu_items),
+                    Menu(menu_items),
                     f"{br_name}/amount",
                     br_code,
                 )
@@ -1420,7 +1418,7 @@ if not utils.BITCOIN_ONLY:
                 ) as layout:
                     return await interact_with_menu(
                         layout,
-                        Menu([cancel_leaf(TR.buttons__cancel_sign)] + menu_items),
+                        Menu(menu_items),
                         f"{br_name}/extra_data",
                         br_code,
                     )
@@ -1440,7 +1438,7 @@ if not utils.BITCOIN_ONLY:
             ) as layout:
                 return await interact_with_menu(
                     layout,
-                    Menu([cancel_leaf(TR.buttons__cancel_sign)] + menu_items),
+                    Menu(menu_items),
                     f"{br_name}/summary",
                     br_code,
                 )
@@ -1462,7 +1460,7 @@ if not utils.BITCOIN_ONLY:
     ) -> None:
         from trezor.ui.layouts.menu import Menu, cancel_leaf, interact_with_menu
 
-        menu_items = []
+        menu_items = [cancel_leaf(TR.buttons__cancel_sign)]
         account_info_items = _get_account_info_items(account, account_path)
         if account_info_items:
             menu_items.append(
@@ -1484,7 +1482,7 @@ if not utils.BITCOIN_ONLY:
             ) as layout:
                 return await interact_with_menu(
                     layout,
-                    Menu([cancel_leaf(TR.buttons__cancel_sign)] + menu_items),
+                    Menu(menu_items),
                     f"{br_name}/intro",
                     br_code,
                 )
@@ -1500,7 +1498,7 @@ if not utils.BITCOIN_ONLY:
             ) as layout:
                 return await interact_with_menu(
                     layout,
-                    Menu([cancel_leaf(TR.buttons__cancel_sign)] + menu_items),
+                    Menu(menu_items),
                     f"{br_name}/tokens",
                     br_code,
                 )
@@ -1518,7 +1516,7 @@ if not utils.BITCOIN_ONLY:
             ) as layout:
                 return await interact_with_menu(
                     layout,
-                    Menu([cancel_leaf(TR.buttons__cancel_sign)] + menu_items),
+                    Menu(menu_items),
                     f"{br_name}/summary",
                     br_code,
                 )
@@ -1563,12 +1561,13 @@ if not utils.BITCOIN_ONLY:
                 (TR.cardano__nonce, str(nonce), False),
             ]
             children = [
+                cancel_leaf(TR.buttons__cancel),
                 create_info_menu_leaf(TR.address_details__account_info, account_info),
                 create_info_menu_leaf(TR.buttons__more_info, more_info),
             ]
             await confirm_with_menu(
                 layout,
-                Menu([cancel_leaf(TR.buttons__cancel)] + children),
+                Menu(children),
                 "ethereum/auth7702/details",
                 ButtonRequestType.SignTx,
             )
@@ -1858,7 +1857,7 @@ if not utils.BITCOIN_ONLY:
     ) -> None:
         from trezor.ui.layouts.menu import Menu, cancel_leaf, interact_with_menu
 
-        menu_items = []
+        menu_items = [cancel_leaf(TR.buttons__cancel_sign)]
         account_info_items = _get_account_info_items(account, account_path)
         if account_info_items:
             menu_items.append(
@@ -1879,7 +1878,7 @@ if not utils.BITCOIN_ONLY:
         ) as layout:
             await interact_with_menu(
                 layout,
-                Menu([cancel_leaf(TR.buttons__cancel_sign)] + menu_items),
+                Menu(menu_items),
                 br_name,
                 br_code,
             )
@@ -2235,7 +2234,14 @@ async def confirm_signverify(
         external_menu=True,
     )
 
-    items: list[MenuLeaf] = []
+    items: list[MenuLeaf] = [
+        cancel_leaf(
+            TR.buttons__cancel,
+            confirm=lambda: trezorui_api.show_mismatch(
+                title=TR.addr_mismatch__mismatch
+            ),
+        )
+    ]
     if account is not None:
         items.append(create_info_menu_leaf(TR.words__account, account))
     if path is not None:
@@ -2247,17 +2253,7 @@ async def confirm_signverify(
         )
     )
 
-    menu = Menu(
-        [
-            cancel_leaf(
-                TR.buttons__cancel,
-                confirm=lambda: trezorui_api.show_mismatch(
-                    title=TR.addr_mismatch__mismatch
-                ),
-            )
-        ]
-        + items
-    )
+    menu = Menu(items)
 
     with address_ctx as address_layout:
         await confirm_with_menu(address_layout, menu, br_name, br_code=BR_CODE_OTHER)

--- a/core/src/trezor/ui/layouts/eckhart/__init__.py
+++ b/core/src/trezor/ui/layouts/eckhart/__init__.py
@@ -884,9 +884,9 @@ async def confirm_properties(
     br_code: ButtonRequestType = ButtonRequestType.ConfirmOutput,
     verb: str | None = None,
 ) -> None:
-    from trezor.ui.layouts.menu import Menu, confirm_with_menu
+    from trezor.ui.layouts.menu import Menu, cancel_leaf, confirm_with_menu
 
-    menu = Menu.root(cancel=TR.buttons__cancel)
+    menu = Menu([cancel_leaf(TR.buttons__cancel)])
 
     with trezorui_api.confirm_properties(
         title=title,

--- a/core/src/trezor/ui/layouts/eckhart/__init__.py
+++ b/core/src/trezor/ui/layouts/eckhart/__init__.py
@@ -611,7 +611,7 @@ async def confirm_output(
         menu_items
         + [
             cancel_leaf(
-                TR.buttons__cancel,
+                cancel_text or TR.buttons__cancel,
                 confirm=trezorui_api.confirm_cancel,
             )
         ]

--- a/core/src/trezor/ui/layouts/eckhart/__init__.py
+++ b/core/src/trezor/ui/layouts/eckhart/__init__.py
@@ -18,7 +18,7 @@ if TYPE_CHECKING:
     from collections.abc import Awaitable, Iterable, Sequence
     from typing import NoReturn, TypeVar
 
-    from trezor.ui.layouts.menu import Details
+    from trezor.ui.layouts.menu import MenuLeaf
 
     from apps.stellar.tokens import StellarToken
 
@@ -71,9 +71,9 @@ async def confirm_action(
         prompt_title=prompt_title or title,
         external_menu=True,
     ) as layout:
-        from trezor.ui.layouts.menu import Menu, confirm_with_menu
+        from trezor.ui.layouts.menu import Menu, cancel_leaf, confirm_with_menu
 
-        menu = Menu.root(cancel=verb_cancel or TR.buttons__cancel)
+        menu = Menu([cancel_leaf(verb_cancel or TR.buttons__cancel, exc)])
         return await confirm_with_menu(
             layout, menu, br_name, br_code, raise_on_cancel=exc
         )
@@ -452,7 +452,7 @@ async def confirm_payment_request(
     fee_info_items: Sequence[StrPropertyType] | None,
     extra_menu_items: list[tuple[str, str]] | None = None,
 ) -> None:
-    from trezor.ui.layouts.menu import Menu, confirm_with_menu
+    from trezor.ui.layouts.menu import Menu, cancel_leaf, confirm_with_menu
 
     from ..slip24 import is_swap
 
@@ -485,7 +485,7 @@ async def confirm_payment_request(
     menu_items = []
     if recipient_address is not None:
         menu_items.append(
-            create_details(TR.address__title_provider_address, recipient_address)
+            create_info_menu_leaf(TR.address__title_provider_address, recipient_address)
         )
     for refund in refunds:
         refund_account_info: list[StrPropertyType] = [("", refund.address, True)]
@@ -496,12 +496,12 @@ async def confirm_payment_request(
                 (TR.address_details__derivation_path, refund.account_path, True)
             )
         menu_items.append(
-            create_details(
+            create_info_menu_leaf(
                 TR.address__title_refund_address,
                 refund_account_info,
             )
         )
-    menu = Menu.root(menu_items, TR.buttons__cancel_sign)
+    menu = Menu(menu_items + [cancel_leaf(TR.buttons__cancel_sign)])
 
     with main_ctx as main_layout:
         while True:
@@ -571,7 +571,7 @@ async def confirm_output(
     cancel_text: str | None = None,
     description: str | None = None,
 ) -> None:
-    from trezor.ui.layouts.menu import Cancel, Menu, interact_with_menu
+    from trezor.ui.layouts.menu import Menu, cancel_leaf, interact_with_menu
 
     if address_label is not None:
         title = address_label
@@ -597,7 +597,7 @@ async def confirm_output(
         )
     if account_properties:
         menu_items = [
-            create_details(
+            create_info_menu_leaf(
                 TR.address_details__account_info,
                 account_properties,
                 title=TR.address_details__account_info,
@@ -607,12 +607,14 @@ async def confirm_output(
     else:
         menu_items = []
 
-    menu = Menu.root(
-        menu_items,
-        cancel=Cancel.from_layout(
-            name=TR.buttons__cancel,
-            layout_factory=trezorui_api.confirm_cancel,
-        ),
+    menu = Menu(
+        menu_items
+        + [
+            cancel_leaf(
+                TR.buttons__cancel,
+                confirm=trezorui_api.confirm_cancel,
+            )
+        ]
     )
 
     address_ctx = trezorui_api.confirm_value(
@@ -839,14 +841,18 @@ async def confirm_value(
     footer: tuple[str, bool] | None = None,
 ) -> None:
     """General confirmation dialog, used by many other confirm_* functions."""
-    from trezor.ui.layouts.menu import Menu, confirm_with_menu
+    from trezor.ui.layouts.menu import Menu, cancel_leaf, confirm_with_menu
 
     menu_items = (
-        [create_details(info_title or TR.words__title_information, list(info_items))]
+        [
+            create_info_menu_leaf(
+                info_title or TR.words__title_information, list(info_items)
+            )
+        ]
         if info_items
         else []
     )
-    menu = Menu.root(menu_items, TR.buttons__cancel)
+    menu = Menu(menu_items + [cancel_leaf(TR.buttons__cancel)])
 
     with trezorui_api.confirm_value(
         title=title,
@@ -970,7 +976,7 @@ async def confirm_trade(
     extra_menu_items: list[tuple[str, str]],
     back_button: bool,
 ) -> ui.UiResult:
-    from trezor.ui.layouts.menu import Menu, interact_with_menu
+    from trezor.ui.layouts.menu import Menu, cancel_leaf, interact_with_menu
 
     trade_ctx = trezorui_api.confirm_trade(
         title=title,
@@ -987,10 +993,12 @@ async def confirm_trade(
         account_info.append(
             (TR.address_details__derivation_path, trade.account_path, True)
         )
-    menu_items = [create_details(TR.address__title_receive_address, account_info)]
+    menu_items = [
+        create_info_menu_leaf(TR.address__title_receive_address, account_info)
+    ]
     for k, v in extra_menu_items:
-        menu_items.append(create_details(k, v))
-    menu = Menu.root(menu_items, TR.buttons__cancel_sign)
+        menu_items.append(create_info_menu_leaf(k, v))
+    menu = Menu(menu_items + [cancel_leaf(TR.buttons__cancel_sign)])
 
     with trade_ctx as trade_layout:
         return await interact_with_menu(trade_layout, menu, "confirm_trade")
@@ -1082,7 +1090,7 @@ if not utils.BITCOIN_ONLY:
         chunkify: bool = False,
         native_amount: str | None = None,
     ) -> None:
-        from trezor.ui.layouts.menu import Menu, interact_with_menu
+        from trezor.ui.layouts.menu import Menu, cancel_leaf, interact_with_menu
 
         if native_amount is not None:
             # A non-zero native ETH value carried alongside a token transfer;
@@ -1099,7 +1107,7 @@ if not utils.BITCOIN_ONLY:
         account_properties = _get_account_info_items(account, account_path)
         if account_properties:
             menu_items = [
-                create_details(
+                create_info_menu_leaf(
                     TR.address_details__account_info,
                     account_properties,
                     title=TR.address_details__account_info,
@@ -1124,7 +1132,7 @@ if not utils.BITCOIN_ONLY:
             ) as layout:
                 return await interact_with_menu(
                     layout,
-                    Menu.root(menu_items, TR.buttons__cancel_sign),
+                    Menu(menu_items + [cancel_leaf(TR.buttons__cancel_sign)]),
                     "confirm_output",
                     br_code,
                 )
@@ -1337,13 +1345,13 @@ if not utils.BITCOIN_ONLY:
         br_code: ButtonRequestType = ButtonRequestType.SignTx,
         extra_data: str | None = None,
     ) -> None:
-        from trezor.ui.layouts.menu import Menu, interact_with_menu
+        from trezor.ui.layouts.menu import Menu, cancel_leaf, interact_with_menu
 
         menu_items = []
         account_properties = _get_account_info_items(account, account_path)
         if account_properties:
             menu_items.append(
-                create_details(
+                create_info_menu_leaf(
                     TR.address_details__account_info,
                     account_properties,
                     title=TR.address_details__account_info,
@@ -1361,7 +1369,7 @@ if not utils.BITCOIN_ONLY:
             ) as layout:
                 return await interact_with_menu(
                     layout,
-                    Menu.root(menu_items, TR.buttons__cancel_sign),
+                    Menu(menu_items + [cancel_leaf(TR.buttons__cancel_sign)]),
                     f"{br_name}/intro",
                     br_code,
                 )
@@ -1375,7 +1383,7 @@ if not utils.BITCOIN_ONLY:
             ) as layout:
                 return await interact_with_menu(
                     layout,
-                    Menu.root(menu_items, TR.buttons__cancel_sign),
+                    Menu(menu_items + [cancel_leaf(TR.buttons__cancel_sign)]),
                     f"{br_name}/vault_name",
                     br_code,
                 )
@@ -1392,7 +1400,7 @@ if not utils.BITCOIN_ONLY:
             ) as layout:
                 return await interact_with_menu(
                     layout,
-                    Menu.root(menu_items, TR.buttons__cancel_sign),
+                    Menu(menu_items + [cancel_leaf(TR.buttons__cancel_sign)]),
                     f"{br_name}/amount",
                     br_code,
                 )
@@ -1410,7 +1418,7 @@ if not utils.BITCOIN_ONLY:
                 ) as layout:
                     return await interact_with_menu(
                         layout,
-                        Menu.root(menu_items, TR.buttons__cancel_sign),
+                        Menu(menu_items + [cancel_leaf(TR.buttons__cancel_sign)]),
                         f"{br_name}/extra_data",
                         br_code,
                     )
@@ -1430,7 +1438,7 @@ if not utils.BITCOIN_ONLY:
             ) as layout:
                 return await interact_with_menu(
                     layout,
-                    Menu.root(menu_items, TR.buttons__cancel_sign),
+                    Menu(menu_items + [cancel_leaf(TR.buttons__cancel_sign)]),
                     f"{br_name}/summary",
                     br_code,
                 )
@@ -1451,13 +1459,13 @@ if not utils.BITCOIN_ONLY:
         br_code: ButtonRequestType = ButtonRequestType.SignTx,
     ) -> None:
 
-        from trezor.ui.layouts.menu import Menu, interact_with_menu
+        from trezor.ui.layouts.menu import Menu, cancel_leaf, interact_with_menu
 
         menu_items = []
         account_properties = _get_account_info_items(account, account_path)
         if account_properties:
             menu_items.append(
-                create_details(
+                create_info_menu_leaf(
                     TR.address_details__account_info,
                     account_properties,
                     title=TR.address_details__account_info,
@@ -1475,7 +1483,7 @@ if not utils.BITCOIN_ONLY:
             ) as layout:
                 return await interact_with_menu(
                     layout,
-                    Menu.root(menu_items, TR.buttons__cancel_sign),
+                    Menu(menu_items + [cancel_leaf(TR.buttons__cancel_sign)]),
                     f"{br_name}/intro",
                     br_code,
                 )
@@ -1491,7 +1499,7 @@ if not utils.BITCOIN_ONLY:
             ) as layout:
                 return await interact_with_menu(
                     layout,
-                    Menu.root(menu_items, TR.buttons__cancel_sign),
+                    Menu(menu_items + [cancel_leaf(TR.buttons__cancel_sign)]),
                     f"{br_name}/tokens",
                     br_code,
                 )
@@ -1509,7 +1517,7 @@ if not utils.BITCOIN_ONLY:
             ) as layout:
                 return await interact_with_menu(
                     layout,
-                    Menu.root(menu_items, TR.buttons__cancel_sign),
+                    Menu(menu_items + [cancel_leaf(TR.buttons__cancel_sign)]),
                     f"{br_name}/summary",
                     br_code,
                 )
@@ -1524,7 +1532,7 @@ if not utils.BITCOIN_ONLY:
         account_path: str,
         nonce: int,
     ) -> None:
-        from trezor.ui.layouts.menu import Menu, confirm_with_menu
+        from trezor.ui.layouts.menu import Menu, cancel_leaf, confirm_with_menu
 
         with trezorui_api.show_warning(
             title=TR.words__warning,
@@ -1556,12 +1564,12 @@ if not utils.BITCOIN_ONLY:
                 (TR.cardano__nonce, str(nonce), False),
             ]
             children = [
-                create_details(TR.address_details__account_info, account_info),
-                create_details(TR.buttons__more_info, more_info),
+                create_info_menu_leaf(TR.address_details__account_info, account_info),
+                create_info_menu_leaf(TR.buttons__more_info, more_info),
             ]
             await confirm_with_menu(
                 layout,
-                Menu.root(children, cancel=TR.buttons__cancel),
+                Menu(children + [cancel_leaf(TR.buttons__cancel)]),
                 "ethereum/auth7702/details",
                 ButtonRequestType.SignTx,
             )
@@ -1572,19 +1580,19 @@ if not utils.BITCOIN_ONLY:
         account_path: str,
         nonce: int,
     ) -> None:
-        from trezor.ui.layouts.menu import Menu, confirm_with_menu
+        from trezor.ui.layouts.menu import Menu, cancel_leaf, confirm_with_menu
 
         account_info = [
             (TR.words__account, account, False),
             (TR.address_details__derivation_path, account_path, False),
         ]
-        menu = Menu.root(
+        menu = Menu(
             children=[
-                create_details(TR.address_details__account_info, account_info),
+                create_info_menu_leaf(TR.address_details__account_info, account_info),
                 # TODO: switch to non-Cardano specific string
-                create_details(TR.cardano__nonce, str(nonce)),
+                create_info_menu_leaf(TR.cardano__nonce, str(nonce)),
+                cancel_leaf(TR.buttons__cancel),
             ],
-            cancel=TR.buttons__cancel,
         )
 
         with trezorui_api.confirm_action(
@@ -1627,18 +1635,18 @@ if not utils.BITCOIN_ONLY:
         br_name: str = "confirm_ethereum_staking_tx",
         br_code: ButtonRequestType = ButtonRequestType.SignTx,
     ) -> None:
-        from trezor.ui.layouts.menu import Menu, interact_with_menu
+        from trezor.ui.layouts.menu import Menu, cancel_leaf, interact_with_menu
 
         assert verb in (
             TR.ethereum__staking_claim,
             TR.ethereum__staking_stake,
             TR.ethereum__staking_unstake,
         )
-        menu_items = [create_details(address_title, address, None)]
+        menu_items = [create_info_menu_leaf(address_title, address, None)]
         account_properties = _get_account_info_items(account, account_path)
         if account_properties:
             menu_items.append(
-                create_details(
+                create_info_menu_leaf(
                     TR.address_details__account_info,
                     account_properties,
                     title=TR.address_details__account_info,
@@ -1663,7 +1671,7 @@ if not utils.BITCOIN_ONLY:
             ) as layout:
                 return await interact_with_menu(
                     layout,
-                    Menu.root(menu_items, TR.buttons__cancel_sign),
+                    Menu(menu_items + [cancel_leaf(TR.buttons__cancel_sign)]),
                     br_name,
                     ButtonRequestType.SignTx,
                 )
@@ -1744,10 +1752,10 @@ if not utils.BITCOIN_ONLY:
         br_name: str = "confirm_solana_staking_tx",
         br_code: ButtonRequestType = ButtonRequestType.SignTx,
     ) -> None:
-        from trezor.ui.layouts.menu import Menu, interact_with_menu
+        from trezor.ui.layouts.menu import Menu, cancel_leaf, interact_with_menu
 
         menu_items = [
-            create_details(
+            create_info_menu_leaf(
                 TR.address_details__account_info,
                 _get_account_info_items(account, account_path),
                 title=TR.address_details__account_info,
@@ -1756,14 +1764,14 @@ if not utils.BITCOIN_ONLY:
         ]
         if stake_item:
             menu_items.append(
-                create_details(
+                create_info_menu_leaf(
                     stake_item[0] or "", [(None, stake_item[1], stake_item[2])], None
                 )
             )
 
         summary_menu_items = [
-            create_details(blockhash_item[0] or "", [blockhash_item], None),
-            create_details(TR.confirm_total__title_fee, list(fee_details), None),
+            create_info_menu_leaf(blockhash_item[0] or "", [blockhash_item], None),
+            create_info_menu_leaf(TR.confirm_total__title_fee, list(fee_details), None),
         ]
 
         extra = TR.words__provider if vote_account else ""
@@ -1793,7 +1801,7 @@ if not utils.BITCOIN_ONLY:
             with ctx as layout:
                 return await interact_with_menu(
                     layout,
-                    Menu.root(menu_items, TR.buttons__cancel_sign),
+                    Menu(menu_items + [cancel_leaf(TR.buttons__cancel_sign)]),
                     br_name,
                     br_code,
                 )
@@ -1810,7 +1818,7 @@ if not utils.BITCOIN_ONLY:
             ) as layout:
                 return await interact_with_menu(
                     layout,
-                    Menu.root(summary_menu_items, TR.buttons__cancel),
+                    Menu(summary_menu_items + [cancel_leaf(TR.buttons__cancel)]),
                     br_name,
                     br_code,
                 )
@@ -1961,13 +1969,13 @@ if not utils.BITCOIN_ONLY:
         br_name: str = "tron/claim",
         br_code: ButtonRequestType = ButtonRequestType.SignTx,
     ) -> None:
-        from trezor.ui.layouts.menu import Menu, interact_with_menu
+        from trezor.ui.layouts.menu import Menu, cancel_leaf, interact_with_menu
 
         menu_items = []
         account_properties = _get_account_info_items(account, account_path)
         if account_properties:
             menu_items.append(
-                create_details(
+                create_info_menu_leaf(
                     TR.address_details__account_info,
                     account_properties,
                     title=TR.address_details__account_info,
@@ -1984,7 +1992,7 @@ if not utils.BITCOIN_ONLY:
         ) as layout:
             await interact_with_menu(
                 layout,
-                Menu.root(menu_items, TR.buttons__cancel_sign),
+                Menu(menu_items + [cancel_leaf(TR.buttons__cancel_sign)]),
                 br_name,
                 br_code,
             )
@@ -2606,15 +2614,15 @@ async def tutorial(br_code: ButtonRequestType = BR_CODE_OTHER) -> None:
         return await raise_if_not_confirmed(layout, "tutorial", br_code)
 
 
-def create_details(
+def create_info_menu_leaf(
     name: str,
     value: Sequence[StrPropertyType] | str,
     title: str | None = None,
     subtitle: str | None = None,
-) -> Details:
-    from trezor.ui.layouts.menu import Details
+) -> MenuLeaf[None]:
+    from trezor.ui.layouts.menu import leaf_from_layout
 
-    return Details.from_layout(
+    return leaf_from_layout(
         name,
         lambda: trezorui_api.show_properties(
             title=(title or name), subtitle=subtitle, value=value

--- a/core/src/trezor/ui/layouts/eckhart/__init__.py
+++ b/core/src/trezor/ui/layouts/eckhart/__init__.py
@@ -501,7 +501,8 @@ async def confirm_payment_request(
                 refund_account_info,
             )
         )
-    menu = Menu(menu_items + [cancel_leaf(TR.buttons__cancel_sign)])
+    menu_items.append(cancel_leaf(TR.buttons__cancel_sign))
+    menu = Menu(menu_items)
 
     with main_ctx as main_layout:
         while True:
@@ -852,7 +853,8 @@ async def confirm_value(
         if info_items
         else []
     )
-    menu = Menu(menu_items + [cancel_leaf(TR.buttons__cancel)])
+    menu_items.append(cancel_leaf(TR.buttons__cancel))
+    menu = Menu(menu_items)
 
     with trezorui_api.confirm_value(
         title=title,
@@ -998,7 +1000,8 @@ async def confirm_trade(
     ]
     for k, v in extra_menu_items:
         menu_items.append(create_info_menu_leaf(k, v))
-    menu = Menu(menu_items + [cancel_leaf(TR.buttons__cancel_sign)])
+    menu_items.append(cancel_leaf(TR.buttons__cancel_sign))
+    menu = Menu(menu_items)
 
     with trade_ctx as trade_layout:
         return await interact_with_menu(trade_layout, menu, "confirm_trade")
@@ -1116,6 +1119,7 @@ if not utils.BITCOIN_ONLY:
             ]
         else:
             menu_items = []
+        menu_items.append(cancel_leaf(TR.buttons__cancel_sign))
 
         async def _step1() -> trezorui_api.UiResult:
             with trezorui_api.confirm_value(
@@ -1132,7 +1136,7 @@ if not utils.BITCOIN_ONLY:
             ) as layout:
                 return await interact_with_menu(
                     layout,
-                    Menu(menu_items + [cancel_leaf(TR.buttons__cancel_sign)]),
+                    Menu(menu_items),
                     "confirm_output",
                     br_code,
                 )
@@ -1358,6 +1362,7 @@ if not utils.BITCOIN_ONLY:
                     subtitle=TR.send__send_from,
                 )
             )
+        menu_items.append(cancel_leaf(TR.buttons__cancel_sign))
 
         async def _step1() -> trezorui_api.UiResult:
             with trezorui_api.confirm_action(
@@ -1369,7 +1374,7 @@ if not utils.BITCOIN_ONLY:
             ) as layout:
                 return await interact_with_menu(
                     layout,
-                    Menu(menu_items + [cancel_leaf(TR.buttons__cancel_sign)]),
+                    Menu(menu_items),
                     f"{br_name}/intro",
                     br_code,
                 )
@@ -1383,7 +1388,7 @@ if not utils.BITCOIN_ONLY:
             ) as layout:
                 return await interact_with_menu(
                     layout,
-                    Menu(menu_items + [cancel_leaf(TR.buttons__cancel_sign)]),
+                    Menu(menu_items),
                     f"{br_name}/vault_name",
                     br_code,
                 )
@@ -1400,7 +1405,7 @@ if not utils.BITCOIN_ONLY:
             ) as layout:
                 return await interact_with_menu(
                     layout,
-                    Menu(menu_items + [cancel_leaf(TR.buttons__cancel_sign)]),
+                    Menu(menu_items),
                     f"{br_name}/amount",
                     br_code,
                 )
@@ -1418,7 +1423,7 @@ if not utils.BITCOIN_ONLY:
                 ) as layout:
                     return await interact_with_menu(
                         layout,
-                        Menu(menu_items + [cancel_leaf(TR.buttons__cancel_sign)]),
+                        Menu(menu_items),
                         f"{br_name}/extra_data",
                         br_code,
                     )
@@ -1438,7 +1443,7 @@ if not utils.BITCOIN_ONLY:
             ) as layout:
                 return await interact_with_menu(
                     layout,
-                    Menu(menu_items + [cancel_leaf(TR.buttons__cancel_sign)]),
+                    Menu(menu_items),
                     f"{br_name}/summary",
                     br_code,
                 )
@@ -1472,6 +1477,7 @@ if not utils.BITCOIN_ONLY:
                     subtitle=TR.send__send_from,
                 )
             )
+        menu_items.append(cancel_leaf(TR.buttons__cancel_sign))
 
         async def _step1() -> trezorui_api.UiResult:
             with trezorui_api.confirm_action(
@@ -1483,7 +1489,7 @@ if not utils.BITCOIN_ONLY:
             ) as layout:
                 return await interact_with_menu(
                     layout,
-                    Menu(menu_items + [cancel_leaf(TR.buttons__cancel_sign)]),
+                    Menu(menu_items),
                     f"{br_name}/intro",
                     br_code,
                 )
@@ -1499,7 +1505,7 @@ if not utils.BITCOIN_ONLY:
             ) as layout:
                 return await interact_with_menu(
                     layout,
-                    Menu(menu_items + [cancel_leaf(TR.buttons__cancel_sign)]),
+                    Menu(menu_items),
                     f"{br_name}/tokens",
                     br_code,
                 )
@@ -1517,7 +1523,7 @@ if not utils.BITCOIN_ONLY:
             ) as layout:
                 return await interact_with_menu(
                     layout,
-                    Menu(menu_items + [cancel_leaf(TR.buttons__cancel_sign)]),
+                    Menu(menu_items),
                     f"{br_name}/summary",
                     br_code,
                 )
@@ -1566,10 +1572,11 @@ if not utils.BITCOIN_ONLY:
             children = [
                 create_info_menu_leaf(TR.address_details__account_info, account_info),
                 create_info_menu_leaf(TR.buttons__more_info, more_info),
+                cancel_leaf(TR.buttons__cancel),
             ]
             await confirm_with_menu(
                 layout,
-                Menu(children + [cancel_leaf(TR.buttons__cancel)]),
+                Menu(children),
                 "ethereum/auth7702/details",
                 ButtonRequestType.SignTx,
             )
@@ -1653,6 +1660,7 @@ if not utils.BITCOIN_ONLY:
                     subtitle=TR.send__send_from,
                 )
             )
+        menu_items.append(cancel_leaf(TR.buttons__cancel_sign))
 
         amount, amount_label = (
             total_amount,
@@ -1671,7 +1679,7 @@ if not utils.BITCOIN_ONLY:
             ) as layout:
                 return await interact_with_menu(
                     layout,
-                    Menu(menu_items + [cancel_leaf(TR.buttons__cancel_sign)]),
+                    Menu(menu_items),
                     br_name,
                     ButtonRequestType.SignTx,
                 )
@@ -1774,6 +1782,9 @@ if not utils.BITCOIN_ONLY:
             create_info_menu_leaf(TR.confirm_total__title_fee, list(fee_details), None),
         ]
 
+        menu_items.append(cancel_leaf(TR.buttons__cancel_sign))
+        summary_menu_items.append(cancel_leaf(TR.buttons__cancel))
+
         extra = TR.words__provider if vote_account else ""
 
         async def _step1() -> trezorui_api.UiResult:
@@ -1801,7 +1812,7 @@ if not utils.BITCOIN_ONLY:
             with ctx as layout:
                 return await interact_with_menu(
                     layout,
-                    Menu(menu_items + [cancel_leaf(TR.buttons__cancel_sign)]),
+                    Menu(menu_items),
                     br_name,
                     br_code,
                 )
@@ -1818,7 +1829,7 @@ if not utils.BITCOIN_ONLY:
             ) as layout:
                 return await interact_with_menu(
                     layout,
-                    Menu(summary_menu_items + [cancel_leaf(TR.buttons__cancel)]),
+                    Menu(summary_menu_items),
                     br_name,
                     br_code,
                 )
@@ -1982,6 +1993,7 @@ if not utils.BITCOIN_ONLY:
                     subtitle=TR.send__send_from,
                 )
             )
+        menu_items.append(cancel_leaf(TR.buttons__cancel_sign))
         with trezorui_api.confirm_action(
             title=title,
             action=intro_question,
@@ -1992,7 +2004,7 @@ if not utils.BITCOIN_ONLY:
         ) as layout:
             await interact_with_menu(
                 layout,
-                Menu(menu_items + [cancel_leaf(TR.buttons__cancel_sign)]),
+                Menu(menu_items),
                 br_name,
                 br_code,
             )

--- a/core/src/trezor/ui/layouts/eckhart/__init__.py
+++ b/core/src/trezor/ui/layouts/eckhart/__init__.py
@@ -1980,7 +1980,7 @@ if not utils.BITCOIN_ONLY:
         br_name: str = "tron/claim",
         br_code: ButtonRequestType = ButtonRequestType.SignTx,
     ) -> None:
-        from trezor.ui.layouts.menu import Menu, cancel_leaf, interact_with_menu
+        from trezor.ui.layouts.menu import Menu, cancel_leaf, confirm_with_menu
 
         menu_items = []
         account_properties = _get_account_info_items(account, account_path)
@@ -2002,7 +2002,7 @@ if not utils.BITCOIN_ONLY:
             external_menu=True,
             cancel=False,
         ) as layout:
-            await interact_with_menu(
+            await confirm_with_menu(
                 layout,
                 Menu(menu_items),
                 br_name,

--- a/core/src/trezor/ui/layouts/menu.py
+++ b/core/src/trezor/ui/layouts/menu.py
@@ -8,9 +8,9 @@ from trezor.wire import ActionCancelled
 
 if TYPE_CHECKING:
     from collections.abc import Awaitable, Callable, Iterable, Sequence
-    from typing import Generic, overload
+    from typing import Generic, TypeAlias, overload
 
-    from typing_extensions import Never, TypeAlias, TypeVar
+    from typing_extensions import Never, TypeVar
 
     from .common import ExceptionType
 

--- a/core/src/trezor/ui/layouts/menu.py
+++ b/core/src/trezor/ui/layouts/menu.py
@@ -64,6 +64,7 @@ def leaf_from_layout(
     layout_factory: Callable[[], trezorui_api.LayoutContext[R]],
     *,
     return_result: bool = False,
+    intent: int = trezorui_api.MenuItemIntent.STANDARD,
     br_name: str | None = None,
     br_code: ButtonRequestType = ButtonRequestType.Other,
     raise_on_cancel: ExceptionType | None = None,
@@ -73,6 +74,9 @@ def leaf_from_layout(
     Unless `return_result` is set, the layout's result is discarded and the menu
     tree is resumed. Otherwise the result is returned by `show_menu()`, so
     `layout_factory()` must produce a layout whose result type matches the tree's.
+
+    `intent` is independent of what the leaf does: an entry may look dangerous
+    and still produce a value rather than abort, as `cancel_leaf()` does.
     """
 
     async def _interact() -> "R | None":
@@ -95,7 +99,7 @@ def leaf_from_layout(
             return None
         return result if return_result else None
 
-    return MenuLeaf(name, _interact)
+    return MenuLeaf(name, _interact, intent=intent)
 
 
 def cancel_leaf(

--- a/core/src/trezor/ui/layouts/menu.py
+++ b/core/src/trezor/ui/layouts/menu.py
@@ -8,130 +8,239 @@ from trezor.wire import ActionCancelled
 
 if TYPE_CHECKING:
     from collections.abc import Awaitable, Callable, Iterable, Sequence
-    from typing import TypeVar
+    from typing import Generic, overload
 
-    from typing_extensions import Self
+    from typing_extensions import Never, TypeAlias, TypeVar
 
     from .common import ExceptionType
 
     T = TypeVar("T")
+    # value produced by a menu leaf and propagated out of the tree
+    R = TypeVar("R", default=None, covariant=True)
+
+    # a node of the menu tree: either a subtree, or a leaf
+    MenuNode: TypeAlias = "Menu[R] | MenuLeaf[R]"
+else:
+    R = 0
+    Generic = {R: object}
 
 
-async def _cancel_default() -> trezorui_api.UiResult:
-    return trezorui_api.CONFIRMED
+class Menu(Generic[R]):
+    # a subtree is always an ordinary entry (see `MenuLeaf.intent`)
+    intent = trezorui_api.MenuItemIntent.STANDARD
+
+    def __init__(
+        self,
+        children: "Iterable[MenuNode[R]]" = (),
+        name: str = "",
+    ) -> None:
+        self.name = name
+        self.children: "Sequence[MenuNode[R]]" = tuple(children)
 
 
-class Menu:
+class MenuLeaf(Generic[R]):
+    """A leaf node of the menu tree.
+
+    `interact()` returns `None` to indicate that the menu tree should be resumed
+    (one level up), or a value of type `R`, which is propagated out of the whole
+    tree by `show_menu()`.
+    """
+
     def __init__(
         self,
         name: str,
-        children: Sequence["Details"],
-        cancel: "Cancel | None" = None,
+        interact: Callable[[], Awaitable[R | None]],
+        *,
+        intent: int = trezorui_api.MenuItemIntent.STANDARD,
     ) -> None:
         self.name = name
-        self.children = children
-        self.cancel = cancel
-
-    @classmethod
-    def root(
-        cls, children: Iterable["Details"] = (), cancel: "str | Cancel | None" = None
-    ) -> Self:
-        if isinstance(cancel, str):
-            cancel = Cancel(cancel, _cancel_default)
-        return cls("", children=tuple(children), cancel=cancel)
-
-
-class Details:
-    def __init__(self, name: str, interact: Callable[[], Awaitable[T]]) -> None:
-        self.name = name
         self._interact = interact
-
-    @classmethod
-    def from_layout(
-        cls, name: str, layout_factory: Callable[[], trezorui_api.LayoutContext[T]]
-    ) -> Self:
-        """IMPORTANT: `layout_factory()` MUST create a new layout on each invocation."""
-
-        async def _interact() -> T:
-            with layout_factory() as obj:
-                # details' layout is de-allocated after interact() returns.
-                return await interact(obj, br_name=None, raise_on_cancel=None)
-
-        return cls(name, _interact)
+        # what this entry means; each layout renders it in its own way
+        self.intent = intent
 
 
-class Cancel(Details):
-    pass
+def leaf_from_layout(
+    name: str,
+    layout_factory: Callable[[], trezorui_api.LayoutContext[R]],
+    *,
+    return_result: bool = False,
+    br_name: str | None = None,
+    br_code: ButtonRequestType = ButtonRequestType.Other,
+    raise_on_cancel: ExceptionType | None = None,
+) -> "MenuLeaf[R]":
+    """IMPORTANT: `layout_factory()` MUST create a new layout on each invocation.
+
+    Unless `return_result` is set, the layout's result is discarded and the menu
+    tree is resumed. Otherwise the result is returned by `show_menu()`, so
+    `layout_factory()` must produce a layout whose result type matches the tree's.
+    """
+
+    async def _interact() -> "R | None":
+        with layout_factory() as obj:
+            # the leaf's layout is de-allocated after interact() returns.
+            result = await interact(obj, br_name, br_code, raise_on_cancel)
+        if result is trezorui_api.CANCELLED:
+            # `raise_on_cancel` is None by default, so cancelling returns the
+            # sentinel instead of raising. Resume the tree rather than handing
+            # `CANCELLED` to the caller as if it were a value of type `R`.
+            #
+            # TODO: `CANCELLED` is the wrong signal here. Dismissing a leaf's
+            # layout - the close button in its header - means "go back to the
+            # menu", not "abort the workflow", but the screens have no way to
+            # say so: `TextScreenMsg` only has `Cancelled`, and `BACK` (which
+            # already exists next to CONFIRMED/CANCELLED/INFO) is never
+            # produced. So every caller has to re-interpret the same sentinel
+            # for itself. Fixing it properly means teaching the action
+            # vocabulary to distinguish "dismissed" from "aborted".
+            return None
+        return result if return_result else None
+
+    return MenuLeaf(name, _interact)
+
+
+def cancel_leaf(
+    name: str,
+    exc: ExceptionType = ActionCancelled,
+    *,
+    confirm: "Callable[[], trezorui_api.LayoutContext[trezorui_api.UiResult]] | None" = None,
+) -> "MenuLeaf[Never]":
+    """A menu entry that aborts the workflow.
+
+    Selecting it raises `exc`. If `confirm` is given, that layout is shown first
+    and the workflow is aborted only if the user confirms it; otherwise the menu
+    is resumed, as with any leaf that returns `None`.
+    """
+
+    async def _interact() -> None:
+        if confirm is not None:
+            with confirm() as obj:
+                result = await interact(obj, br_name=None, raise_on_cancel=None)
+            if result is not trezorui_api.CONFIRMED:
+                return None  # declined - back to the menu
+        raise exc
+
+    return MenuLeaf(name, _interact, intent=trezorui_api.MenuItemIntent.DANGER)
+
+
+class MenuResult(Generic[R]):
+    """A value produced by a menu leaf, paired with the leaf that produced it."""
+
+    def __init__(self, leaf: "MenuLeaf[R]", value: R) -> None:
+        self.leaf = leaf
+        self.value = value
 
 
 async def show_menu(
-    root: Menu,
-    raise_on_cancel: ExceptionType = ActionCancelled,
-) -> None:
-    menu_path = []
+    root: Menu[R],
+) -> MenuResult[R] | None:
+    """Walk the menu tree until a leaf produces a value, or the user leaves the root.
+
+    Returns the leaf and the value it produced, so that the caller can tell the
+    leaves apart, or `None` if the tree was left without producing a value.
+    """
+    menu_path: list[int] = []
     current_item = 0
     while True:
-        menu = root
+        menu: MenuNode[R] = root
         for i in menu_path:
+            assert isinstance(menu, Menu)
             menu = menu.children[i]
 
         if isinstance(menu, Menu):
             with trezorui_api.select_menu(
-                items=[child.name for child in menu.children],
+                items=[(child.name, child.intent) for child in menu.children],
                 current=current_item,
-                cancel=menu.cancel and menu.cancel.name,
             ) as layout:
                 choice = await interact(layout, br_name=None, raise_on_cancel=None)
 
-            if choice is trezorui_api.CANCELLED:
-                if menu.cancel:
-                    result = await menu.cancel._interact()
-                    assert result in (trezorui_api.CONFIRMED, trezorui_api.CANCELLED)
-                    if result is trezorui_api.CONFIRMED:
-                        # cancellation is confirmed - raise an exception
-                        raise raise_on_cancel
-                    # cancellation is not confirmed - back to the menu
-                    continue
-            elif isinstance(choice, int):
+            if isinstance(choice, int):
                 # go one level down
                 menu_path.append(choice)
                 current_item = 0
                 continue
         else:
-            assert isinstance(menu, Details)
-            # Details' layout is created on-demand (saving memory)
-            await menu._interact()  # the result is ignored
+            # the leaf's layout is created on-demand (saving memory)
+            leaf_result = await menu._interact()
+            if leaf_result is not None:
+                # the leaf produced a value - leave the whole tree
+                return MenuResult(menu, leaf_result)
 
-        # go one level up, or exit the menu
+        # go one level up, or exit the tree
         if menu_path:
             current_item = menu_path.pop()
         else:
-            return
+            return None
+
+
+if TYPE_CHECKING:
+    # TEMPORARY COMPATIBILITY SHIM - to be removed.
+    #
+    # `interact_with_menu()` returns `T | MenuResult[R]`, but most call sites still
+    # declare `-> UiResult` and hand the result straight back, so the union does not
+    # typecheck there. Every one of them passes an info-only menu (`create_info_menu_leaf()`
+    # leaves, which discard their layout's result), so the first overload keeps them
+    # on the old plain-`T` typing while the second serves menus that do produce a
+    # value.
+    #
+    # Drop both overloads once those call sites handle `MenuResult` themselves.
+    # To find them, delete the overloads and let the typechecker enumerate the
+    # failures - every value-less menu today.
+    #
+    # Note the overload is picked from the menu's *declared* type: annotating a
+    # value-less menu as anything but `Menu[None]` pushes its caller onto the
+    # second overload.
+
+    @overload
+    async def interact_with_menu(
+        main: trezorui_api.LayoutObj[T],
+        menu: "Menu[None]",
+        br_name: str | None,
+        br_code: ButtonRequestType = ButtonRequestType.Other,
+        raise_on_cancel: ExceptionType = ActionCancelled,
+        *,
+        layout_type: type[Layout] = Layout,
+    ) -> T:
+        """The menu cannot produce a value, so only the main layout's result."""
+
+    @overload
+    async def interact_with_menu(
+        main: trezorui_api.LayoutObj[T],
+        menu: "Menu[R]",
+        br_name: str | None,
+        br_code: ButtonRequestType = ButtonRequestType.Other,
+        raise_on_cancel: ExceptionType = ActionCancelled,
+        *,
+        layout_type: type[Layout] = Layout,
+    ) -> T | MenuResult[R]:
+        """Either the main layout's result, or a leaf and the value it produced."""
 
 
 async def interact_with_menu(
     main: trezorui_api.LayoutObj[T],
-    menu: Menu,
+    menu: Menu[R],
     br_name: str | None,
     br_code: ButtonRequestType = ButtonRequestType.Other,
     raise_on_cancel: ExceptionType = ActionCancelled,
     *,
     layout_type: type[Layout] = Layout,
-) -> T:
+) -> T | MenuResult[R]:
     while True:
         result = await interact(
             main, br_name, br_code, raise_on_cancel, layout_type=layout_type
         )
         br_name = None  # ButtonRequest should be sent once (for the main layout)
         if result is trezorui_api.INFO:
-            await show_menu(menu, raise_on_cancel)
+            menu_result = await show_menu(menu)
+            if menu_result is not None:
+                return menu_result
+            # the tree was left without a value - back to the main layout
         else:
             return result
 
 
 async def confirm_with_menu(
     main: trezorui_api.LayoutObj[T],
-    menu: Menu,
+    menu: Menu[None],
     br_name: str | None,
     br_code: ButtonRequestType = ButtonRequestType.Other,
     raise_on_cancel: ExceptionType = ActionCancelled,

--- a/core/src/trezor/ui/layouts/menu.py
+++ b/core/src/trezor/ui/layouts/menu.py
@@ -10,7 +10,7 @@ if TYPE_CHECKING:
     from collections.abc import Awaitable, Callable, Iterable, Sequence
     from typing import Generic, TypeAlias, overload
 
-    from typing_extensions import Never, TypeVar
+    from typing_extensions import TypeVar
 
     from .common import ExceptionType
 
@@ -44,6 +44,12 @@ class MenuLeaf(Generic[R]):
     `interact()` returns `None` to indicate that the menu tree should be resumed
     (one level up), or a value of type `R`, which is propagated out of the whole
     tree by `show_menu()`.
+
+    Because `None` is that sentinel, it can never be a *value*, whatever `R` is.
+    `MenuLeaf[None]` is therefore a leaf that only ever resumes the tree - which
+    is what the information-only entries are. Note the type system does not
+    enforce this: `Menu[int | None]` typechecks and `MenuResult.value` is then
+    declared `int | None`, but `None` is unreachable there at runtime.
     """
 
     def __init__(
@@ -107,21 +113,31 @@ def cancel_leaf(
     exc: ExceptionType = ActionCancelled,
     *,
     confirm: "Callable[[], trezorui_api.LayoutContext[trezorui_api.UiResult]] | None" = None,
-) -> "MenuLeaf[Never]":
+) -> "MenuLeaf[R]":
     """A menu entry that aborts the workflow.
 
     Selecting it raises `exc`. If `confirm` is given, that layout is shown first
     and the workflow is aborted only if the user confirms it; otherwise the menu
     is resumed, as with any leaf that returns `None`.
+
+    Produces no value, so it fits a tree of any `R`. Declared `MenuLeaf[R]`
+    rather than the more precise `MenuLeaf[Never]` on purpose: `Never` would make
+    `[cancel_leaf(...)]` infer `list[MenuLeaf[Never]]`, which then rejects every
+    information leaf appended to it. With `R` the list infers `list[MenuLeaf[None]]`
+    by the TypeVar default, and still narrows when the tree does return values.
     """
 
     async def _interact() -> None:
-        if confirm is not None:
-            with confirm() as obj:
-                result = await interact(obj, br_name=None, raise_on_cancel=None)
-            if result is not trezorui_api.CONFIRMED:
-                return None  # declined - back to the menu
-        raise exc
+        if confirm is None:
+            raise exc
+
+        with confirm() as obj:
+            result = await interact(obj, br_name=None, raise_on_cancel=None)
+        if result is trezorui_api.CANCELLED:
+            return None  # declined - back to the menu
+        if result is trezorui_api.CONFIRMED:
+            raise exc
+        raise RuntimeError  # unexpected result from the confirmation layout
 
     return MenuLeaf(name, _interact, intent=trezorui_api.MenuItemIntent.DANGER)
 
@@ -141,6 +157,9 @@ async def show_menu(
 
     Returns the leaf and the value it produced, so that the caller can tell the
     leaves apart, or `None` if the tree was left without producing a value.
+
+    A leaf that returns `None` resumes the tree instead of ending it, so a
+    returned `MenuResult.value` is never `None` - see `MenuLeaf`.
     """
     menu_path: list[int] = []
     current_item = 0
@@ -162,6 +181,9 @@ async def show_menu(
                 menu_path.append(choice)
                 current_item = 0
                 continue
+            if choice is not trezorui_api.CONFIRMED:
+                # `select_menu` returns an index, or CONFIRMED when closed
+                raise RuntimeError
         else:
             # the leaf's layout is created on-demand (saving memory)
             leaf_result = await menu._interact()

--- a/core/tests/test_apps.solana.transaction.py
+++ b/core/tests/test_apps.solana.transaction.py
@@ -11,7 +11,8 @@ if not utils.BITCOIN_ONLY:
 
 if TYPE_CHECKING:
     from buffer_types import AnyBytes
-    from typing import Any, Callable, Sequence, TypeVar
+    from collections.abc import Callable, Sequence
+    from typing import Any, TypeVar
 
     from trezor.utils import Writer
 

--- a/core/tests/test_trezor.ui.select_menu.py
+++ b/core/tests/test_trezor.ui.select_menu.py
@@ -102,9 +102,10 @@ class TestSelectMenu(unittest.TestCase):
             )
 
     def test_too_many_items(self):
-        # beyond MAX_MENU_ITEMS the list is rejected before it reaches the layout
+        # beyond MAX_MENU_ITEMS the list is rejected before it reaches the layout,
+        # so this is an OverflowError rather than this model's NotImplementedError
         with self.assertRaises(OverflowError):
-            self.make_menu(items=[("Item", STANDARD)] * 6)
+            self.make_menu(items=[("Item", STANDARD)] * 7)
 
     def test_unknown_intent(self):
         with self.assertRaises(OverflowError):

--- a/core/tests/test_trezor.ui.select_menu.py
+++ b/core/tests/test_trezor.ui.select_menu.py
@@ -4,6 +4,9 @@ from common import *  # isort:skip
 import trezorui_api
 from trezor import io, utils
 
+STANDARD = trezorui_api.MenuItemIntent.STANDARD
+DANGER = trezorui_api.MenuItemIntent.DANGER
+
 
 def click(layout, x, y):
     layout.touch_event(io.TOUCH_START, x, y)
@@ -26,15 +29,16 @@ CLOSE_BUTTON_Y = 28
 
 @unittest.skipUnless(utils.UI_LAYOUT == "BOLT", "Bolt layout only")
 class TestSelectMenu(unittest.TestCase):
-    ITEMS = ["Alpha", "Beta"]
+    # a cancel entry is an ordinary item asking for the `DANGER` intent;
+    # it is selected by index like any other.
+    ITEMS = [("Alpha", STANDARD), ("Beta", STANDARD), ("Cancel", DANGER)]
 
-    def make_menu(self, items=None, cancel="Cancel"):
+    def make_menu(self, items=None):
         if items is None:
             items = self.ITEMS
         layout = trezorui_api.select_menu(
             items=items,
             current=0,
-            cancel=cancel,
         )
         layout.paint()
         return layout
@@ -43,41 +47,73 @@ class TestSelectMenu(unittest.TestCase):
         layout = self.make_menu()
         self.assertEqual(click(layout, CENTER_X, SLOT_TOP_Y), 0)
 
-    def test_select_last_item(self):
+    def test_select_middle_item(self):
         layout = self.make_menu()
         self.assertEqual(click(layout, CENTER_X, SLOT_MIDDLE_Y), 1)
 
-    def test_select_cancel_item(self):
+    def test_select_danger_item(self):
+        # a `DANGER` entry only looks different; it still returns its index
         layout = self.make_menu()
-        self.assertIs(click(layout, CENTER_X, SLOT_BOTTOM_Y), trezorui_api.CANCELLED)
+        self.assertEqual(click(layout, CENTER_X, SLOT_BOTTOM_Y), 2)
 
     def test_close_button(self):
         layout = self.make_menu()
-        # top-right corner button closes the menu without cancelling
+        # top-right corner button closes the menu without selecting anything
         self.assertIs(
             click(layout, CLOSE_BUTTON_X, CLOSE_BUTTON_Y), trezorui_api.CONFIRMED
         )
 
-    def test_no_cancel_item(self):
-        layout = self.make_menu(cancel=None)
+    def test_all_standard_items(self):
+        # a menu without a `DANGER` entry indexes exactly the same
+        items = [("Alpha", STANDARD), ("Beta", STANDARD)]
+        layout = self.make_menu(items=items)
         self.assertEqual(click(layout, CENTER_X, SLOT_TOP_Y), 0)
-        layout = self.make_menu(cancel=None)
+        layout = self.make_menu(items=items)
         self.assertEqual(click(layout, CENTER_X, SLOT_MIDDLE_Y), 1)
+        layout = self.make_menu(items=items)
+        self.assertIsNone(click(layout, CENTER_X, SLOT_BOTTOM_Y))
 
     def test_single_button_takes_one_slot(self):
         # a lone button sits in the top slot and does not stretch
-        layout = self.make_menu(items=[])
+        items = [("Cancel", DANGER)]
+        layout = self.make_menu(items=items)
         self.assertIsNone(click(layout, CENTER_X, SLOT_BOTTOM_Y))
-        layout = self.make_menu(items=[])
-        self.assertIs(click(layout, CENTER_X, SLOT_TOP_Y), trezorui_api.CANCELLED)
+        layout = self.make_menu(items=items)
+        self.assertEqual(click(layout, CENTER_X, SLOT_TOP_Y), 0)
+
+    def test_three_items_fit(self):
+        # the cancel entry no longer reserves a slot of its own, so three
+        # entries - danger or not - now fit where two plus a cancel used to
+        layout = self.make_menu(
+            items=[("Alpha", STANDARD), ("Beta", STANDARD), ("Gamma", STANDARD)]
+        )
+        self.assertEqual(click(layout, CENTER_X, SLOT_BOTTOM_Y), 2)
 
     def test_buttons_clamped_to_three_slots(self):
-        # three choices plus a cancel button would exceed the three slots
+        # four entries exceed the three available slots
         with self.assertRaises(NotImplementedError):
-            self.make_menu(items=["Alpha", "Beta", "Gamma"])
-        # four choices alone also exceed the limit
-        with self.assertRaises(NotImplementedError):
-            self.make_menu(items=["Alpha", "Beta", "Gamma", "Delta"], cancel=None)
+            self.make_menu(
+                items=[
+                    ("Alpha", STANDARD),
+                    ("Beta", STANDARD),
+                    ("Gamma", STANDARD),
+                    ("Delta", STANDARD),
+                ]
+            )
+
+    def test_too_many_items(self):
+        # beyond MAX_MENU_ITEMS the list is rejected before it reaches the layout
+        with self.assertRaises(OverflowError):
+            self.make_menu(items=[("Item", STANDARD)] * 6)
+
+    def test_unknown_intent(self):
+        with self.assertRaises(OverflowError):
+            self.make_menu(items=[("Alpha", 42)])
+
+    def test_malformed_item(self):
+        # each item must be a (label, intent) pair
+        with self.assertRaises(ValueError):
+            self.make_menu(items=["Alpha"])
 
     def test_trace(self):
         layout = self.make_menu()
@@ -85,7 +121,7 @@ class TestSelectMenu(unittest.TestCase):
         layout.trace(parts.append)
         trace = "".join(parts)
         self.assertIn('"SelectMenu"', trace)
-        for name in self.ITEMS + ["Cancel"]:
+        for name, _intent in self.ITEMS:
             self.assertIn(name, trace)
 
 


### PR DESCRIPTION
Allow menu leaves to return typed values in preparation for modularisation of the firmware and UI.

Reimagines the menu as a proper tree. The menu is now able to, based on user interaction, return an arbitrary value and infrormation about from which submenu/menu leaf it comes from.

Menu[R] is the internal node, MenuLeaf[R] (renamed from Details) is the leaf, MenuNode[R] is a type alias for either. R is the type of the value the menu tree returns.

A leaf's interact() returning None still just resumes the tree (pops one level), as before (usually pressing the back button). 

Returning a value makes show_menu() unwind the whole tree and report a MenuResult pairing the value with the leaf that produced it, so callers with multiple value-returning leaves can match on leaf identity first, then value.

interact_with_menu() now returns the MenuResult instead of re-showing the main layout; it keeps a temporary overload for the ~25 existing call sites that only use original menus and pass the result straight through. This is marked explicitly as compatibility shim and is due for removal during further rework.

No behavior change: every existing menu is still built from information-only leaves that discard their layout's result.

Update: Reworked the cancellation to be more generic, created the notion of an intent for each menu item. This shall translate to the level of the urgency conveyed by the menu item. Currently the only intents are Standard and Danger, with standard being the usual white menu items and Danger being used for the red cancellation menu items. 

# Notes 4 QA

The PR is done such that there should be 0 functional user experienceable change. 

## Scope by model

- T3T1, T3W1 — all menus, main targets.
- T2B1 / T3B1 — never drew a cancel entry, does not style by intent. Smoke test only.
- T2T1 — no menus in the Python layer. Not affected.

## Affected paths

- Sign message, T3T1 — `trezorctl btc sign-message -n "m/44h/0h/0h/0/0" "hello"`
- Send transaction, T3T1 + T3W1 (Suite) — menu on both address and amount screens
- Ethereum transaction and staking, T3T1 + T3W1
- Ethereum EIP-7702 authorise / revoke, T3T1 + T3W1
- Ethereum vault claim / transaction, T3T1 + T3W1
- Solana staking, T3W1 + T2B1/T3B1
- Payment request and swap, T3T1 + T3W1 (Suite)
- Trade confirmation, T3T1 + T3W1
- Tron claim, T3T1 + T3W1

## Edge cases - stuff that could break (or did break during development)

- Menu at capacity — payment request with provider address + 4 refunds is exactly
  6 entries. Renders and scrolls. Limit went 5 → 6 only because cancel is now a real menu entry, not a special case. The number of information entries is unchanged.
- Dismissing an information entry with the header close button returns to
  the menu. On `main` this could escape and read as cancelling the whole flow.
- Cancel entry with confirmation, output screen — decline returns to the menu,
  accept aborts signing with a cancellation on the host.
- Cancel entry position — T3T1 first, T3W1 last, same as `main`.
- Cancel entry label, T3W1 output screen — "Cancel sign", not "Cancel".
- Closing the menu itself returns to the confirmation screen, never aborts.

## Testing done

- Unit tests as found in branch vojczejk/ui-menu-ut
- Builds: firmware and bootloader for T2T1, T2B1, T3T1, T3W1.
- Not run locally: Already present UI tests for all models.
