### PR TITLE
fix(core): return a boolean from `nrf_send_msg()` instead of an integer

### DIFF
--- a/core/embed/io/ble/stm32/ble.c
+++ b/core/embed/io/ble/stm32/ble.c
@@ -127,8 +127,7 @@ static void ble_pairing_end(ble_driver_t *drv) {
 static bool ble_send_state_request(ble_driver_t *drv) {
   (void)drv;
   uint8_t cmd = INTERNAL_CMD_SEND_STATE;
-  return nrf_send_msg(NRF_SERVICE_BLE_MANAGER, &cmd, sizeof(cmd), NULL, NULL) >=
-         0;
+  return nrf_send_msg(NRF_SERVICE_BLE_MANAGER, &cmd, sizeof(cmd), NULL, NULL);
 }
 
 static bool ble_send_advertising_on(ble_driver_t *drv, bool whitelist) {
@@ -152,44 +151,39 @@ static bool ble_send_advertising_on(ble_driver_t *drv, bool whitelist) {
   memcpy(data.name, drv->adv_name, BLE_ADV_NAME_LEN);
 
   return nrf_send_msg(NRF_SERVICE_BLE_MANAGER, (uint8_t *)&data, sizeof(data),
-                      NULL, NULL) >= 0;
+                      NULL, NULL);
 }
 
 static bool ble_send_speed_request(ble_driver_t *drv, bool high_speed) {
   (void)drv;
   uint8_t cmd =
       high_speed ? INTERNAL_CMD_SET_SPEED_HIGH : INTERNAL_CMD_SET_SPEED_LOW;
-  return nrf_send_msg(NRF_SERVICE_BLE_MANAGER, &cmd, sizeof(cmd), NULL, NULL) >=
-         0;
+  return nrf_send_msg(NRF_SERVICE_BLE_MANAGER, &cmd, sizeof(cmd), NULL, NULL);
 }
 
 static bool ble_send_power_level_request(ble_driver_t *drv,
                                          ble_tx_power_level_t power_level) {
   (void)drv;
   uint8_t cmd[2] = {INTERNAL_CMD_SET_TX_POWER, (uint8_t)power_level};
-  return nrf_send_msg(NRF_SERVICE_BLE_MANAGER, cmd, sizeof(cmd), NULL, NULL) >=
-         0;
+  return nrf_send_msg(NRF_SERVICE_BLE_MANAGER, cmd, sizeof(cmd), NULL, NULL);
 }
 
 static bool ble_send_advertising_off(ble_driver_t *drv) {
   (void)drv;
   uint8_t cmd = INTERNAL_CMD_ADVERTISING_OFF;
-  return nrf_send_msg(NRF_SERVICE_BLE_MANAGER, &cmd, sizeof(cmd), NULL, NULL) >=
-         0;
+  return nrf_send_msg(NRF_SERVICE_BLE_MANAGER, &cmd, sizeof(cmd), NULL, NULL);
 }
 
 static bool ble_send_erase_bonds(ble_driver_t *drv) {
   (void)drv;
   uint8_t cmd = INTERNAL_CMD_ERASE_BONDS;
-  return nrf_send_msg(NRF_SERVICE_BLE_MANAGER, &cmd, sizeof(cmd), NULL, NULL) >=
-         0;
+  return nrf_send_msg(NRF_SERVICE_BLE_MANAGER, &cmd, sizeof(cmd), NULL, NULL);
 }
 
 static bool ble_send_disconnect(ble_driver_t *drv) {
   (void)drv;
   uint8_t cmd = INTERNAL_CMD_DISCONNECT;
-  return nrf_send_msg(NRF_SERVICE_BLE_MANAGER, &cmd, sizeof(cmd), NULL, NULL) >=
-         0;
+  return nrf_send_msg(NRF_SERVICE_BLE_MANAGER, &cmd, sizeof(cmd), NULL, NULL);
 }
 
 static bool ble_send_pairing_reject(ble_driver_t *drv) {
@@ -1302,14 +1296,14 @@ bool ble_unpair(const bt_le_addr_t *addr) {
   bool result;
   if (addr == NULL) {
     uint8_t cmd = INTERNAL_CMD_UNPAIR;
-    result = nrf_send_msg(NRF_SERVICE_BLE_MANAGER, &cmd, sizeof(cmd), NULL,
-                          NULL) >= 0;
+    result =
+        nrf_send_msg(NRF_SERVICE_BLE_MANAGER, &cmd, sizeof(cmd), NULL, NULL);
   } else {
     uint8_t data[1 + sizeof(bt_le_addr_t)] = {0};
     data[0] = INTERNAL_CMD_UNPAIR;
     memcpy(&data[1], addr, sizeof(bt_le_addr_t));
-    result = nrf_send_msg(NRF_SERVICE_BLE_MANAGER, data, sizeof(data), NULL,
-                          NULL) >= 0;
+    result =
+        nrf_send_msg(NRF_SERVICE_BLE_MANAGER, data, sizeof(data), NULL, NULL);
   }
 
   if (!result) {

--- a/core/embed/io/nrf/inc/io/nrf.h
+++ b/core/embed/io/nrf/inc/io/nrf.h
@@ -122,10 +122,10 @@ void nrf_unregister_listener(nrf_service_id_t service);
  * @param len       Length of the data buffer
  * @param callback  Function to call upon transmission completion
  * @param context   Context pointer passed to the callback
- * @return ID of the message if successfully queued; -1 otherwise
+ * @return true if successfully queued; false otherwise
  */
-int32_t nrf_send_msg(nrf_service_id_t service, const uint8_t *data,
-                     uint32_t len, nrf_tx_callback_t callback, void *context);
+bool nrf_send_msg(nrf_service_id_t service, const uint8_t *data, uint32_t len,
+                  nrf_tx_callback_t callback, void *context);
 
 /**
  * @brief Abort a queued message by its ID.

--- a/core/embed/io/nrf/stm32u5/nrf.c
+++ b/core/embed/io/nrf/stm32u5/nrf.c
@@ -475,7 +475,7 @@ bool nrf_get_info(nrf_info_t *info) {
   drv->info_valid = false;
 
   uint8_t data[1] = {MGMT_CMD_INFO};
-  if (nrf_send_msg(NRF_SERVICE_MANAGEMENT, data, 1, NULL, NULL) < 0) {
+  if (!nrf_send_msg(NRF_SERVICE_MANAGEMENT, data, 1, NULL, NULL)) {
     return false;
   }
 
@@ -500,7 +500,7 @@ uint32_t nrf_get_version(void) {
   drv->info_valid = false;
 
   uint8_t data[1] = {MGMT_CMD_INFO};
-  if (nrf_send_msg(NRF_SERVICE_MANAGEMENT, data, 1, NULL, NULL) < 0) {
+  if (!nrf_send_msg(NRF_SERVICE_MANAGEMENT, data, 1, NULL, NULL)) {
     return 0;
   }
 
@@ -574,8 +574,7 @@ bool nrf_authenticate(void) {
   drv->auth_data_valid = false;
   memset(drv->auth_data, 0, sizeof(drv->auth_data));
 
-  if (nrf_send_msg(NRF_SERVICE_MANAGEMENT, data, sizeof(data), NULL, NULL) <
-      0) {
+  if (!nrf_send_msg(NRF_SERVICE_MANAGEMENT, data, sizeof(data), NULL, NULL)) {
     return false;
   }
 

--- a/core/embed/io/nrf/stm32u5/nrf_spi.c
+++ b/core/embed/io/nrf/stm32u5/nrf_spi.c
@@ -143,27 +143,27 @@ void nrf_spi_deinit(void) {
   NRF_SPI_CLK_DIS();
 }
 
-int32_t nrf_send_msg(nrf_service_id_t service, const uint8_t *data,
-                     uint32_t len, nrf_tx_callback_t callback, void *context) {
+bool nrf_send_msg(nrf_service_id_t service, const uint8_t *data, uint32_t len,
+                  nrf_tx_callback_t callback, void *context) {
   nrf_driver_t *drv = &g_nrf_driver;
   if (!drv->initialized) {
-    return -1;
+    return false;
   }
 
   if (len > NRF_MAX_TX_DATA_SIZE) {
-    return -1;
+    return false;
   }
 
   if (service > NRF_SERVICE_CNT) {
-    return -1;
+    return false;
   }
 
   if (!nrf_is_running()) {
-    return -1;
+    return false;
   }
 
   if (!drv->comm_running) {
-    return -1;
+    return false;
   }
 
   int32_t id = 0;
@@ -180,8 +180,8 @@ int32_t nrf_send_msg(nrf_service_id_t service, const uint8_t *data,
       crc8((uint8_t *)&tx_request.packet, sizeof(tx_request.packet) - 1, 0x07,
            0x00, false);
 
-  tsqueue_enqueue(&drv->tx_queue, (uint8_t *)&tx_request,
-                  sizeof(nrf_tx_request_t), &id);
+  bool queued = tsqueue_enqueue(&drv->tx_queue, (uint8_t *)&tx_request,
+                                sizeof(nrf_tx_request_t), &id);
 
   irq_key_t key = irq_lock();
   if (drv->tx_request_id <= 0 && !tsqueue_empty(&drv->tx_queue)) {
@@ -189,7 +189,7 @@ int32_t nrf_send_msg(nrf_service_id_t service, const uint8_t *data,
   }
   irq_unlock(key);
 
-  return id;
+  return queued;
 }
 
 bool nrf_abort_msg(int32_t id) {


### PR DESCRIPTION
This change fixes some of call sites, which were treating its result as a boolean.

