### PR TITLE
chore(core): remove unused `nrf_abort_msg()`

### DIFF
--- a/core/embed/io/nrf/inc/io/nrf.h
+++ b/core/embed/io/nrf/inc/io/nrf.h
@@ -128,19 +128,6 @@ bool nrf_send_msg(nrf_service_id_t service, const uint8_t *data, uint32_t len,
                   nrf_tx_callback_t callback, void *context);
 
 /**
- * @brief Abort a queued message by its ID.
- *
- * If the message is already sent or the ID is not found, this function does
- * nothing and returns false. If the message is queued, it will be removed from
- * the queue. If the message is in the process of being sent, it will complete,
- * but its callback will not be invoked.
- *
- * @param id  Identifier of the message to abort
- * @return false if the message was already sent or not found, true if aborted
- */
-bool nrf_abort_msg(int32_t id);
-
-/**
  * @brief Read version and other information from the NRF application.
  *
  * Blocking function that fills the provided nrf_info_t structure.

--- a/core/embed/io/nrf/stm32u5/nrf_spi.c
+++ b/core/embed/io/nrf/stm32u5/nrf_spi.c
@@ -192,29 +192,6 @@ bool nrf_send_msg(nrf_service_id_t service, const uint8_t *data, uint32_t len,
   return queued;
 }
 
-bool nrf_abort_msg(int32_t id) {
-  nrf_driver_t *drv = &g_nrf_driver;
-  if (!drv->initialized) {
-    return false;
-  }
-
-  bool aborted = tsqueue_abort(&drv->tx_queue, id, NULL, 0, NULL);
-
-  if (aborted) {
-    return true;
-  }
-
-  irq_key_t key = irq_lock();
-  if (drv->tx_request_id == id) {
-    drv->tx_request_id = -1;
-    irq_unlock(key);
-    return true;
-  }
-
-  irq_unlock(key);
-  return false;
-}
-
 static bool nrf_is_valid_startbyte(uint8_t val) {
   if ((val & 0xF0) != START_BYTE) {
     return false;


### PR DESCRIPTION
Following #7656.