### PR TITLE
feat(core): clear C stack on MicroPython event loop restart

### DIFF
--- a/core/embed/upymod/modtrezorutils/modtrezorutils.c
+++ b/core/embed/upymod/modtrezorutils/modtrezorutils.c
@@ -65,7 +65,7 @@
 #include <io/nrf.h>
 #endif
 
-#if !PYOPT && LOG_STACK_USAGE
+#ifndef TREZOR_EMULATOR
 #include <sys/stack_utils.h>
 #endif
 
@@ -409,23 +409,26 @@ static mp_obj_t mod_trezorutils_presize_module(mp_obj_t mod, mp_obj_t n) {
 static MP_DEFINE_CONST_FUN_OBJ_2(mod_trezorutils_presize_module_obj,
                                  mod_trezorutils_presize_module);
 
-#if !PYOPT
-#if LOG_STACK_USAGE
 /// def zero_unused_stack() -> None:
 ///     """
 ///     Zero unused stack memory.
 ///     """
 static mp_obj_t mod_trezorutils_zero_unused_stack(void) {
+#ifndef TREZOR_EMULATOR
   clear_unused_stack();
+#endif
   return mp_const_none;
 }
 static MP_DEFINE_CONST_FUN_OBJ_0(mod_trezorutils_zero_unused_stack_obj,
                                  mod_trezorutils_zero_unused_stack);
 
-/// def estimate_unused_stack() -> int:
-///     """
-///     Estimate unused stack size.
-///     """
+#if !PYOPT
+#if LOG_STACK_USAGE
+/// if __debug__:
+///     def estimate_unused_stack() -> int:
+///         """
+///         Estimate unused stack size.
+///         """
 static mp_obj_t mod_trezorutils_estimate_unused_stack(void) {
   const uint8_t *stack_top = (const uint8_t *)MP_STATE_THREAD(stack_top);
   size_t stack_limit = MP_STATE_THREAD(stack_limit);
@@ -977,10 +980,10 @@ static const mp_rom_map_elem_t mp_module_trezorutils_globals_table[] = {
 #else
     {MP_ROM_QSTR(MP_QSTR_USE_N1W1), mp_const_false},
 #endif
-#if !PYOPT
-#if LOG_STACK_USAGE
     {MP_ROM_QSTR(MP_QSTR_zero_unused_stack),
      MP_ROM_PTR(&mod_trezorutils_zero_unused_stack_obj)},
+#if !PYOPT
+#if LOG_STACK_USAGE
     {MP_ROM_QSTR(MP_QSTR_estimate_unused_stack),
      MP_ROM_PTR(&mod_trezorutils_estimate_unused_stack_obj)},
 #endif

--- a/core/mocks/generated/trezorutils.pyi
+++ b/core/mocks/generated/trezorutils.pyi
@@ -144,13 +144,11 @@ def zero_unused_stack() -> None:
     """
     Zero unused stack memory.
     """
-
-
-# upymod/modtrezorutils/modtrezorutils.c
-def estimate_unused_stack() -> int:
-    """
-    Estimate unused stack size.
-    """
+if __debug__:
+    def estimate_unused_stack() -> int:
+        """
+        Estimate unused stack size.
+        """
 if __debug__:
     def enable_oom_dump() -> None:
         """

--- a/core/src/session.py
+++ b/core/src/session.py
@@ -1,6 +1,8 @@
 # isort: skip_file
 from trezor import log, loop, utils, wire, workflow
 
+utils.zero_unused_stack()  # clear the stack between event loop restarts
+
 import apps.base
 from apps.common import lock_manager
 import usb

--- a/core/src/trezor/utils.py
+++ b/core/src/trezor/utils.py
@@ -61,6 +61,7 @@ from trezorutils import (  # noqa: F401
     unit_color,
     unit_packaging,
     unit_production_date,
+    zero_unused_stack,
 )
 
 if USE_TELEMETRY:
@@ -87,7 +88,7 @@ if __debug__:
     )
 
     if LOG_STACK_USAGE:
-        from trezorutils import estimate_unused_stack, zero_unused_stack  # noqa: F401
+        from trezorutils import estimate_unused_stack  # noqa: F401
 
     if EMULATOR:
         import os


### PR DESCRIPTION
Related to https://github.com/trezor/trezor-firmware/issues/7660 (zero C stack before starting MicroPython event loop).

Not active on emulators - since `clear_unused_stack()` is implemented only for STM32.