### PR TITLE
fix(xbuild): fix SCM revision propagation for incremental builds

### DIFF
--- a/core/embed/Cargo.lock
+++ b/core/embed/Cargo.lock
@@ -717,6 +717,7 @@ dependencies = [
  "bindgen",
  "color-eyre",
  "cty",
+ "hex",
  "models",
  "xbuild",
 ]
@@ -1102,6 +1103,7 @@ version = "0.0.0"
 dependencies = [
  "color-eyre",
  "crypto",
+ "hex",
  "io",
  "models",
  "rtl",

--- a/core/embed/rtl/Cargo.toml
+++ b/core/embed/rtl/Cargo.toml
@@ -7,6 +7,7 @@ links = "rtl"
 [build-dependencies]
 bindgen.workspace = true
 color-eyre.workspace = true
+hex.workspace = true
 xbuild.workspace = true
 
 [dependencies]

--- a/core/embed/rtl/build.rs
+++ b/core/embed/rtl/build.rs
@@ -1,6 +1,4 @@
-use std::process::Command;
-
-use xbuild::{Result, WrapErr, ensure};
+use xbuild::{Result, scm_revision};
 
 fn main() -> Result<()> {
     xbuild::build(|lib| {
@@ -34,37 +32,14 @@ fn main() -> Result<()> {
     })
 }
 
-/// Extracts the first four bytes of the Git revision and formats them
+/// Extracts the first four bytes of SCM_REVISION and formats them
 /// as a C initializer list, e.g. {0x12, 0x34, 0x56, 0x78}.
 fn get_scm_revision_short() -> Result<String> {
-    let git_output = Command::new("git")
-        .args(["rev-parse", "HEAD"])
-        .output()
-        .context("Failed to execute git command")?;
+    let revision = scm_revision()?;
 
-    ensure!(
-        git_output.status.success(),
-        "Git command failed: {}",
-        String::from_utf8_lossy(&git_output.stderr)
-    );
-
-    let git_hash = String::from_utf8_lossy(&git_output.stdout);
-    let git_hash = git_hash.trim();
-
-    ensure!(
-        git_hash.len() >= 8 && git_hash.chars().all(|c| c.is_ascii_hexdigit()),
-        "Unexpected git hash format: {}",
-        git_hash
-    );
-
-    let init_val = git_hash.as_bytes()[..8]
-        .chunks(2)
-        .map(|chunk| {
-            format!(
-                "0x{},",
-                std::str::from_utf8(chunk).expect("git hash must be valid ASCII")
-            )
-        })
+    let init_val = hex::decode(&revision[..8])?
+        .iter()
+        .map(|byte| format!("0x{byte:02x},"))
         .collect::<String>();
 
     Ok(format!("{{{}}}", init_val))

--- a/core/embed/supply-chain/config.toml
+++ b/core/embed/supply-chain/config.toml
@@ -65,10 +65,6 @@ criteria = "safe-to-deploy"
 version = "1.2.2"
 criteria = "safe-to-deploy"
 
-[[exemptions.cargo-platform]]
-version = "0.3.2"
-criteria = "safe-to-deploy"
-
 [[exemptions.cargo_metadata]]
 version = "0.23.1"
 criteria = "safe-to-deploy"
@@ -137,10 +133,6 @@ criteria = "safe-to-deploy"
 
 [[exemptions.indenter]]
 version = "0.3.4"
-criteria = "safe-to-deploy"
-
-[[exemptions.indexmap]]
-version = "2.14.0"
 criteria = "safe-to-deploy"
 
 [[exemptions.itertools]]

--- a/core/embed/supply-chain/imports.lock
+++ b/core/embed/supply-chain/imports.lock
@@ -231,11 +231,30 @@ https://source.chromium.org/chromium/chromium/src/+/28841c33c77833cc30b286f9ae24
 """
 aggregated-from = "https://chromium.googlesource.com/chromium/src/+/main/third_party/rust/chromium_crates_io/supply-chain/audits.toml?format=TEXT"
 
-[[audits.google.audits.hex]]
-who = "ChromeOS"
-criteria = "safe-to-run"
-version = "0.4.3"
-aggregated-from = "https://chromium.googlesource.com/chromiumos/third_party/rust_crates/+/refs/heads/main/cargo-vet/audits.toml?format=TEXT"
+[[audits.google.audits.indexmap]]
+who = "Lukasz Anforowicz <lukasza@chromium.org>"
+criteria = "safe-to-deploy"
+version = "2.7.1"
+notes = '''
+Grepped for `-i cipher`, `-i crypto`, `'\bfs\b'`, `'\bnet\b'`
+and there were no hits.
+
+There is a little bit of `unsafe` Rust code - the audit can be found at
+https://chromium-review.googlesource.com/c/chromium/src/+/6187726/2
+'''
+aggregated-from = "https://chromium.googlesource.com/chromium/src/+/main/third_party/rust/chromium_crates_io/supply-chain/audits.toml?format=TEXT"
+
+[[audits.google.audits.indexmap]]
+who = "Lukasz Anforowicz <lukasza@chromium.org>"
+criteria = "safe-to-deploy"
+delta = "2.7.1 -> 2.8.0"
+notes = """
+No `unsafe` introduced or affected in:
+* `indexmap_with_default!` and `indexset_with_default!` macros
+* New `PartialEq` implementations
+* `fn slice_eq` in `util.rs`
+"""
+aggregated-from = "https://chromium.googlesource.com/chromium/src/+/main/third_party/rust/chromium_crates_io/supply-chain/audits.toml?format=TEXT"
 
 [[audits.google.audits.log]]
 who = "danakj <danakj@chromium.org>"
@@ -904,6 +923,13 @@ delta = "0.69.4 -> 0.72.0"
 notes = "I'm the primary maintainer of this crate."
 aggregated-from = "https://hg.mozilla.org/mozilla-central/raw-file/tip/supply-chain/audits.toml"
 
+[[audits.mozilla.audits.cargo-platform]]
+who = "Ben Dean-Kawamura <bdk@mozilla.com>"
+criteria = "safe-to-deploy"
+version = "0.3.2"
+notes = "Defines a Platform enum for `cargo-metadata` to use.  No unsafe code."
+aggregated-from = "https://hg.mozilla.org/mozilla-central/raw-file/tip/supply-chain/audits.toml"
+
 [[audits.mozilla.audits.gimli]]
 who = "Alex Franchuk <afranchuk@mozilla.com>"
 criteria = "safe-to-deploy"
@@ -949,6 +975,25 @@ aggregated-from = "https://hg.mozilla.org/mozilla-central/raw-file/tip/supply-ch
 who = "Erich Gubler <erichdongubler@gmail.com>"
 criteria = "safe-to-deploy"
 delta = "0.17.0 -> 0.17.1"
+aggregated-from = "https://hg.mozilla.org/mozilla-central/raw-file/tip/supply-chain/audits.toml"
+
+[[audits.mozilla.audits.hex]]
+who = "Simon Friedberger <simon@mozilla.com>"
+criteria = "safe-to-deploy"
+version = "0.4.3"
+aggregated-from = "https://hg.mozilla.org/mozilla-central/raw-file/tip/supply-chain/audits.toml"
+
+[[audits.mozilla.audits.indexmap]]
+who = "Erich Gubler <erichdongubler@gmail.com>"
+criteria = "safe-to-deploy"
+delta = "2.8.0 -> 2.11.4"
+aggregated-from = "https://hg.mozilla.org/mozilla-central/raw-file/tip/supply-chain/audits.toml"
+
+[[audits.mozilla.audits.indexmap]]
+who = "Ben Dean-Kawamura <bdk@mozilla.com>"
+criteria = "safe-to-deploy"
+delta = "2.11.4 -> 2.14.0"
+notes = "Mostly internal refactorings.  No new unsafe code."
 aggregated-from = "https://hg.mozilla.org/mozilla-central/raw-file/tip/supply-chain/audits.toml"
 
 [[audits.mozilla.audits.log]]

--- a/core/embed/upymod/Cargo.toml
+++ b/core/embed/upymod/Cargo.toml
@@ -6,6 +6,7 @@ links = "upymod"
 
 [build-dependencies]
 color-eyre.workspace = true
+hex.workspace = true
 xbuild.workspace = true
 
 [dependencies]

--- a/core/embed/upymod/build.rs
+++ b/core/embed/upymod/build.rs
@@ -7,7 +7,7 @@ use std::path::{Path, PathBuf};
 
 use xbuild::{
     CLibrary, InputFiles, OutputType, Result, WrapErr, bail, bail_unsupported, current_model_id,
-    ensure, model_ids,
+    model_ids, scm_revision,
 };
 
 fn main() -> Result<()> {
@@ -312,27 +312,9 @@ fn main() -> Result<()> {
 /// Extracts the Git revision, obfuscates it, and defines
 /// SCM_REVISION_INIT together with two per-build XOR key bytes.
 fn define_scm_revision(lib: &mut CLibrary) -> Result<u8> {
-    let git_output = std::process::Command::new("git")
-        .args(["rev-parse", "HEAD"])
-        .output()
-        .context("Failed to execute git command")?;
+    let revision = scm_revision()?;
 
-    ensure!(
-        git_output.status.success(),
-        "Git command failed: {}",
-        String::from_utf8_lossy(&git_output.stderr)
-    );
-
-    let revision = String::from_utf8_lossy(&git_output.stdout);
-    let revision = revision.trim();
-
-    let mut revision = revision.as_bytes()[8..]
-        .chunks_exact(2)
-        .map(|chunk| {
-            let hex = std::str::from_utf8(chunk).expect("git hash must be ASCII hex");
-            u8::from_str_radix(hex, 16).expect("valid hex")
-        })
-        .collect::<Vec<u8>>();
+    let mut revision = hex::decode(&revision[8..])?;
 
     // Derive the XOR bytes from a standard FNV-1 hash of the whole revision.
     let fnv_hash = revision.iter().fold(0x811C9DC5u32, |hash, &byte| {

--- a/core/embed/xbuild/src/helpers.rs
+++ b/core/embed/xbuild/src/helpers.rs
@@ -43,6 +43,29 @@ pub fn links_name() -> Result<String> {
     env::var("CARGO_MANIFEST_LINKS").context("Failed to get CARGO_MANIFEST_LINKS")
 }
 
+/// Returns the Git revision supplied by xtask through `SCM_REVISION`.
+///
+/// Emits Cargo's environment dependency directive and validates that the value
+/// is a full SHA-1 revision.
+pub fn scm_revision() -> Result<String> {
+    cargo_out::rerun_if_env_changed("SCM_REVISION");
+
+    let revision = env::var("SCM_REVISION")
+        .context("SCM_REVISION environment variable is not set")?
+        .trim()
+        .to_string();
+
+    if revision.len() != 40
+        || !revision
+            .chars()
+            .all(|character| character.is_ascii_hexdigit())
+    {
+        return Err(eyre!("Unexpected SCM_REVISION format: {revision}"));
+    }
+
+    Ok(revision)
+}
+
 /// Reads a `DEP_<CRATE>_PUBLIC_C_<KEY>` metadata variable exported by a
 /// dependency's build script.
 pub fn library_metadata(lib_name: &str, kind: &str) -> Result<String> {

--- a/core/embed/xbuild/src/lib.rs
+++ b/core/embed/xbuild/src/lib.rs
@@ -18,7 +18,7 @@ pub use dep_tracking::{
 };
 pub use helpers::{
     cargo_target_dir, derive_output_path, diagnostics_color_flag, emit_rerun_if_changed,
-    is_rust_analyzer, trace_enabled,
+    is_rust_analyzer, scm_revision, trace_enabled,
 };
 pub use input_files::InputFiles;
 pub use parallel::{optimal_parallel_job_count, run_parallel};

--- a/core/embed/xtask/src/cargo.rs
+++ b/core/embed/xtask/src/cargo.rs
@@ -44,6 +44,7 @@ pub fn test(args: TestArgs) -> Result<()> {
             .arg("--")
             .arg("--test-threads=1")
             .arg("--nocapture")
+            .env("SCM_REVISION", helpers::git_revision()?)
             .current_dir(helpers::workspace_dir()?);
 
         println!("xtask: Running test on `{}`", &package);

--- a/core/embed/xtask/src/features.rs
+++ b/core/embed/xtask/src/features.rs
@@ -143,6 +143,7 @@ pub fn configure_cargo(args: &ResolvedBuildArgs, cmd: &mut process::Command) -> 
     cmd.args(["--features", &resolved.features.join(",")]);
     cmd.args(["--profile", args.cargo_profile_name()]);
     cmd.env("TREZOR_BOARD_HEADER", &resolved.board_header);
+    cmd.env("SCM_REVISION", helpers::git_revision()?);
 
     if args.cargo_profile_name() == "release" {
         // Required by panic-immediate-abort in the release profile


### PR DESCRIPTION
This PR fixes issue #7665.

before this change, incremental builds could retain stale scm revision: `SCM_REVISION_SHORT` and/or the long obfuscated revision could remain from an earlier git commit even after the source revision changed.

The PR introduces `SCM_REVISION` environment variable as the single source of the firmware revision during builds.

- reads the git hash once in xtask and pass it to affected build steps through `SCM_REVISION`.
- replaces per-module `git rev-parse` calls with the environment variable.
- tracks `SCM_REVISION` as a Cargo build dependency so revision changes rebuild the affected modules during incremental builds.
