### PR TITLE
fix(core/optiga): use `optiga_result` variant on error

### DIFF
--- a/core/embed/models/build.rs
+++ b/core/embed/models/build.rs
@@ -50,7 +50,6 @@ fn main() -> Result<()> {
             "-Wpointer-arith",
             "-Wno-unused-parameter",
             "-Wno-sign-compare",
-            "-Wno-enum-conversion",
             "-Wno-type-limits",
             "-Wfloat-conversion",
             "-Wdouble-promotion",

--- a/core/embed/sec/optiga/inc/sec/optiga_common.h
+++ b/core/embed/sec/optiga/inc/sec/optiga_common.h
@@ -34,6 +34,7 @@ typedef enum _optiga_result {
   OPTIGA_ERR_PROCESS,     // Processing error.
   OPTIGA_ERR_PARAM,       // Invalid command parameters.
   OPTIGA_ERR_CMD,         // Command error. See error code data object 0xF1C2.
+  OPTIGA_ERR_MEMORY,      // Insufficient memory to process the command.
 } optiga_result;
 
 typedef secbool (*optiga_ui_progress_t)(void);

--- a/core/embed/sec/optiga/optiga_commands.c
+++ b/core/embed/sec/optiga/optiga_commands.c
@@ -606,7 +606,7 @@ optiga_result optiga_set_auto_state(uint16_t nonce_oid, uint16_t key_oid,
   // the receipt of the response. In such a case, the auto-state couldn't be
   // cleared using optiga_clear_all_auto_states().
   if (!auto_states_add(key_oid)) {
-    return OPTIGA_ERR_CODE_MEMORY;
+    return OPTIGA_ERR_MEMORY;
   }
   ret = optiga_execute_command(tx_buffer, tx_size, tx_buffer, sizeof(tx_buffer),
                                &tx_size);


### PR DESCRIPTION
Found by enabling `enum-conversion` warning:
```
  core/embed/sec/optiga/optiga_commands.c: In function 'optiga_set_auto_state':
  core/embed/sec/optiga/optiga_commands.c:609:12: error: implicit conversion from 'enum <anonymous>' to 'optiga_result' {aka 'enum _optiga_result'} [-Werror=enum-conversion]
    609 |     return OPTIGA_ERR_CODE_MEMORY;
        |            ^~~~~~~~~~~~~~~~~~~~~~
```

Please let me know if it's better to use one of the `enum _optiga_result` existing variants.