### PR TITLE
fix(core): allow NULL pointers for optional arguments in syscalls and…

### DIFF
--- a/core/embed/io/ble/inc/io/ble.h
+++ b/core/embed/io/ble/inc/io/ble.h
@@ -203,6 +203,9 @@ bool ble_switch_on(void);
  *
  * @param name Advertising name to use
  * @param name_len Length of the advertising name
+ *
+ * If name is NULL and name_len is 0, the advertising name remains unchanged.
+ *
  * @return true if the command was successfully executed, false otherwise
  */
 bool ble_enter_pairing_mode(const uint8_t *name, size_t name_len);

--- a/core/embed/io/ble/stm32/ble.c
+++ b/core/embed/io/ble/stm32/ble.c
@@ -1012,6 +1012,10 @@ bool ble_enter_pairing_mode(const uint8_t *name, size_t name_len) {
     return false;
   }
 
+  if (name == NULL && name_len > 0) {
+    return false;
+  }
+
   irq_key_t key = irq_lock();
 
   if (name != NULL && name_len > 0) {

--- a/core/embed/io/ble/unix/ble.c
+++ b/core/embed/io/ble/unix/ble.c
@@ -213,8 +213,22 @@ bool ble_enter_pairing_mode(const uint8_t *name, size_t name_len) {
   if (!drv->initialized) {
     return false;
   }
+
+  if (name_len > BLE_ADV_NAME_LEN) {
+    return false;
+  }
+
+  if (name == NULL && name_len > 0) {
+    return false;
+  }
+
   drv->mode_current = BLE_MODE_PAIRING;
-  memcpy(drv->adv_name, name, MIN(name_len, BLE_ADV_NAME_LEN));
+
+  if (name != NULL && name_len > 0) {
+    memset(drv->adv_name, 0, sizeof(drv->adv_name));
+    memcpy(drv->adv_name, name, name_len);
+  }
+
   return send_to_emu('p');
 }
 
@@ -360,6 +374,14 @@ void ble_get_state(ble_state_t *state) {
 
 void ble_set_name(const uint8_t *name, size_t len) {
   ble_driver_t *drv = &g_ble_driver;
+
+  if (!drv->initialized) {
+    return;
+  }
+
+  if (len > BLE_ADV_NAME_LEN) {
+    return;
+  }
 
   memcpy(drv->adv_name, name, MIN(len, BLE_ADV_NAME_LEN));
 }

--- a/core/embed/sec/backup_ram/inc/sec/backup_ram.h
+++ b/core/embed/sec/backup_ram/inc/sec/backup_ram.h
@@ -122,8 +122,9 @@ bool backup_ram_write(uint16_t key, backup_ram_item_type_t type,
  * @param buffer_size Size of the buffer in bytes
  * @param data_size Pointer to a variable where the size of the data
  *
- * If data_size is NULL, the size will not be retrieved. If buffer is NULL,
- * the data will not be copied, but the size will still be retrieved.
+ * If data_size is NULL, the size will not be retrieved. If buffer is NULL
+ * and buffer_size is zero, the function will only retrieve the size of the
+ * data.
  *
  * @return backup_ram_status_t BACKUP_RAM_OK if the operation was
  * successful.

--- a/core/embed/sec/telemetry/unix/telemetry.c
+++ b/core/embed/sec/telemetry/unix/telemetry.c
@@ -23,10 +23,13 @@
 #include <trezor_types.h>
 
 bool telemetry_get(telemetry_data_t* out) {
-  out->min_temp_c = 20.0f;
-  out->max_temp_c = 35.0f;
-  out->battery_errors.all = 0;
-  out->battery_cycles = 30.00f;
+  if (out != NULL) {
+    out->min_temp_c = 20.0f;
+    out->max_temp_c = 35.0f;
+    out->battery_errors.all = 0;
+    out->battery_cycles = 30.00f;
+  }
+
   return true;
 }
 

--- a/core/embed/sys/smcall/stm32/smcall_probe.c
+++ b/core/embed/sys/smcall/stm32/smcall_probe.c
@@ -32,7 +32,8 @@ bool probe_read_access(const void *addr, size_t len) {
   // NULL is not a valid non-secure address. Rejected explicitly so that this
   // function enforces the rule, instead of inheriting it from the range check
   // below. Smcall arguments that are optional by contract must use
-  // `probe_read_access_opt()` instead.
+  // `probe_read_access_opt()` or the corresponding
+  // `_opt_const_size` variant instead.
   if (addr == NULL) {
     return false;
   }
@@ -54,7 +55,8 @@ bool probe_write_access(void *addr, size_t len) {
   // NULL is not a valid non-secure address. Rejected explicitly so that this
   // function enforces the rule, instead of inheriting it from the range check
   // below. Smcall arguments that are optional by contract must use
-  // `probe_write_access_opt()` instead.
+  // `probe_write_access_opt()` or the corresponding
+  // `_opt_const_size` variant instead.
   if (addr == NULL) {
     return false;
   }

--- a/core/embed/sys/smcall/stm32/smcall_probe.h
+++ b/core/embed/sys/smcall/stm32/smcall_probe.h
@@ -29,14 +29,18 @@
 // given memory range.
 //
 // `addr` must be a non-secure address. NULL is always rejected.
-// Use `probe_read_access_opt()` for optional arguments.
+// For optional arguments, use `probe_read_access_opt()` if NULL implies
+// zero length, or `probe_read_access_opt_const_size()` if NULL is allowed
+// regardless of the length.
 bool probe_read_access(const void *addr, size_t len);
 
 // Checks if the non-secure code has write access to the
 // given memory range.
 //
 // `addr` must be a non-secure address. NULL is always rejected.
-// Use `probe_write_access_opt()` for optional arguments.
+// For optional arguments, use `probe_write_access_opt()` if NULL implies
+// zero length, or `probe_write_access_opt_const_size()` if NULL is allowed
+// regardless of the length.
 bool probe_write_access(void *addr, size_t len);
 
 // Checks if the provided address is in non-secure address range
@@ -45,22 +49,45 @@ bool probe_write_access(void *addr, size_t len);
 bool probe_execute_access(const void *addr);
 
 // Variants for smcall arguments that are optional by contract, i.e. where
-// NULL is a meaningful value passed on to the smcall implementation.
+// NULL and len == 0 is a meaningful value passed on to the smcall
+// implementation.
 //
-// These exist so that every such argument is explicit at the call site and
-// a NULL reaching any other probe is caught as an access violation instead
-// of being dereferenced by the secure monitor.
+// These functions are used where the length is explicit and passed as a
+// separate argument.
 
 static inline bool probe_read_access_opt(const void *addr, size_t len) {
-  return (addr == NULL) || probe_read_access(addr, len);
+  if (addr == NULL) {
+    return len == 0;
+  }
+
+  return probe_read_access(addr, len);
 }
 
 static inline bool probe_write_access_opt(void *addr, size_t len) {
-  return (addr == NULL) || probe_write_access(addr, len);
+  if (addr == NULL) {
+    return len == 0;
+  }
+
+  return probe_write_access(addr, len);
 }
 
 static inline bool probe_execute_access_opt(const void *addr) {
   return (addr == NULL) || probe_execute_access(addr);
+}
+
+// Variants for smcall arguments that are optional by contract, i.e. where
+// NULL is a meaningful value passed on to the smcall implementation.
+//
+// These functions are used for arguments whose length is implicit
+// (i.e. by the type of the argument) and is always constant.
+
+static inline bool probe_write_access_opt_const_size(void *addr, size_t len) {
+  return (addr == NULL) || probe_write_access(addr, len);
+}
+
+static inline bool probe_read_access_opt_const_size(const void *addr,
+                                                    size_t len) {
+  return (addr == NULL) || probe_read_access(addr, len);
 }
 
 // Exits the current application task with an fatal error

--- a/core/embed/sys/smcall/stm32/smcall_verifiers.c
+++ b/core/embed/sys/smcall/stm32/smcall_verifiers.c
@@ -35,7 +35,8 @@
 
 void bootargs_set__verified(boot_command_t command, const void *args,
                             size_t args_size) {
-  if (!probe_read_access(args, args_size)) {
+  // args are optional, so we allow NULL with size 0
+  if (!probe_read_access_opt(args, args_size)) {
     goto access_violation;
   }
 
@@ -332,12 +333,13 @@ access_violation:
 storage_unlock_result_t storage_unlock__verified(const uint8_t *pin,
                                                  size_t pin_len,
                                                  const uint8_t *ext_salt) {
-  if (!probe_read_access(pin, pin_len)) {
+  // `storage_unlock()` accepts a NULL pin and returns an error code
+  if (!probe_read_access_opt(pin, pin_len)) {
     goto access_violation;
   }
 
   // NULL ext_salt is allowed and means no external salt is used
-  if (!probe_read_access_opt(ext_salt, EXTERNAL_SALT_SIZE)) {
+  if (!probe_read_access_opt_const_size(ext_salt, EXTERNAL_SALT_SIZE)) {
     goto access_violation;
   }
 
@@ -350,12 +352,13 @@ access_violation:
 
 storage_pin_change_result_t storage_change_pin__verified(
     const uint8_t *newpin, size_t newpin_len, const uint8_t *new_ext_salt) {
-  if (!probe_read_access(newpin, newpin_len)) {
+  // `storage_change_pin()` accepts a NULL newpin and returns an error code
+  if (!probe_read_access_opt(newpin, newpin_len)) {
     goto access_violation;
   }
 
   // NULL new_ext_salt is allowed and means no external salt is used
-  if (!probe_read_access_opt(new_ext_salt, EXTERNAL_SALT_SIZE)) {
+  if (!probe_read_access_opt_const_size(new_ext_salt, EXTERNAL_SALT_SIZE)) {
     goto access_violation;
   }
 
@@ -383,16 +386,18 @@ secbool storage_change_wipe_code__verified(const uint8_t *pin, size_t pin_len,
                                            const uint8_t *ext_salt,
                                            const uint8_t *wipe_code,
                                            size_t wipe_code_len) {
-  if (!probe_read_access(pin, pin_len)) {
+  // `storage_change_wipe_code()` accepts a NULL pin and returns secfalse
+  if (!probe_read_access_opt(pin, pin_len)) {
     goto access_violation;
   }
 
   // NULL ext_salt is allowed and means no external salt is used
-  if (!probe_read_access_opt(ext_salt, EXTERNAL_SALT_SIZE)) {
+  if (!probe_read_access_opt_const_size(ext_salt, EXTERNAL_SALT_SIZE)) {
     goto access_violation;
   }
 
-  if (!probe_read_access(wipe_code, wipe_code_len)) {
+  // `storage_change_wipe_code()` accepts a NULL wipe_code and returns secfalse
+  if (!probe_read_access_opt(wipe_code, wipe_code_len)) {
     goto access_violation;
   }
 
@@ -406,7 +411,7 @@ access_violation:
 
 secbool storage_get__verified(const uint16_t key, void *val,
                               const uint16_t max_len, uint16_t *len) {
-  // NULL val is allowed and queries the value length only
+  // NULL val and max_len 0 is allowed and queries the value length only
   if (!probe_write_access_opt(val, max_len)) {
     goto access_violation;
   }
@@ -479,7 +484,8 @@ access_violation:
 
 int firmware_hash_start__verified(const uint8_t *challenge,
                                   size_t challenge_len) {
-  if (!probe_read_access(challenge, challenge_len)) {
+  // challenge is optional, so we allow NULL with size 0
+  if (!probe_read_access_opt(challenge, challenge_len)) {
     goto access_violation;
   }
 
@@ -578,13 +584,14 @@ access_violation:
 
 bool backup_ram_read__verified(uint16_t key, void *buffer, size_t buffer_size,
                                size_t *data_size) {
-  // NULL buffer is allowed and only queries the size, NULL data_size is
-  // allowed and skips reporting it
+  // When buffer is NULL, buffer_size must be 0, and we only query the size
+  // of the data
   if (!probe_write_access_opt(buffer, buffer_size)) {
     goto access_violation;
   }
 
-  if (!probe_write_access_opt(data_size, sizeof(*data_size))) {
+  // NULL data_size is allowed and skips reporting it
+  if (!probe_write_access_opt_const_size(data_size, sizeof(*data_size))) {
     goto access_violation;
   }
 
@@ -641,7 +648,8 @@ access_violation:
 #include <sec/telemetry.h>
 
 bool telemetry_get__verified(telemetry_data_t *out) {
-  if (out != NULL && !probe_write_access(out, sizeof(*out))) {
+  // NULL out is allowed and only queries whether telemetry is available
+  if (!probe_write_access_opt_const_size(out, sizeof(*out))) {
     goto access_violation;
   }
 

--- a/core/embed/sys/startup/inc/sys/bootargs.h
+++ b/core/embed/sys/startup/inc/sys/bootargs.h
@@ -66,6 +66,7 @@ void bootargs_init(uint32_t r11_register);
 
 // Configures the boot command and associated arguments for the next reboot.
 // The arguments must adhere to the boot_args_t structure layout.
+// Args are optional, so NULL with size 0 is allowed.
 void bootargs_set(boot_command_t command, const void* args, size_t args_size);
 
 // Returns the last boot command saved during bootloader startup

--- a/core/embed/sys/syscall/stm32/syscall_probe.c
+++ b/core/embed/sys/syscall/stm32/syscall_probe.c
@@ -46,7 +46,8 @@ bool probe_read_access(const void *addr, size_t len) {
   // NULL is not part of any applet area. Rejected explicitly so that this
   // function enforces the rule, instead of inheriting it from the area checks
   // below. Syscall arguments that are optional by contract must use
-  // `probe_read_access_opt()` instead.
+  // `probe_read_access_opt()` or the corresponding
+  // `_opt_const_size` variant instead.
   if (addr == NULL) {
     return false;
   }
@@ -100,7 +101,8 @@ bool probe_write_access(void *addr, size_t len) {
   // NULL is not part of any applet area. Rejected explicitly so that this
   // function enforces the rule, instead of inheriting it from the area checks
   // below. Syscall arguments that are optional by contract must use
-  // `probe_write_access_opt()` instead.
+  // `probe_write_access_opt()` or the corresponding
+  // `_opt_const_size` variant instead.
   if (addr == NULL) {
     return false;
   }

--- a/core/embed/sys/syscall/stm32/syscall_probe.h
+++ b/core/embed/sys/syscall/stm32/syscall_probe.h
@@ -32,14 +32,18 @@
 // given memory range.
 //
 // `addr` must point inside the task's memory. NULL is always rejected.
-// Use `probe_read_access_opt()` for optional arguments.
+// For optional arguments, use `probe_read_access_opt()` if NULL implies
+// zero length, or `probe_read_access_opt_const_size()` if NULL is allowed
+// regardless of the length.
 bool probe_read_access(const void *addr, size_t len);
 
 // Checks if the current application task has write access to the
 // given memory range.
 //
 // `addr` must point inside the task's memory. NULL is always rejected.
-// Use `probe_write_access_opt()` for optional arguments.
+// For optional arguments, use `probe_write_access_opt()` if NULL implies
+// zero length, or `probe_write_access_opt_const_size()` if NULL is allowed
+// regardless of the length.
 bool probe_write_access(void *addr, size_t len);
 
 // Checks if the current application task can execute code at the
@@ -49,22 +53,45 @@ bool probe_write_access(void *addr, size_t len);
 bool probe_execute_access(const void *addr);
 
 // Variants for syscall arguments that are optional by contract, i.e. where
-// NULL is a meaningful value passed on to the syscall implementation.
+// NULL and len == 0 is a meaningful value passed on to the syscall
+// implementation.
 //
-// These exist so that every such argument is explicit at the call site and
-// a NULL reaching any other probe is caught as an access violation instead
-// of being dereferenced by the kernel.
+// These functions are used where the length is explicit and passed as a
+// separate argument.
 
 static inline bool probe_read_access_opt(const void *addr, size_t len) {
-  return (addr == NULL) || probe_read_access(addr, len);
+  if (addr == NULL) {
+    return len == 0;
+  }
+
+  return probe_read_access(addr, len);
 }
 
 static inline bool probe_write_access_opt(void *addr, size_t len) {
-  return (addr == NULL) || probe_write_access(addr, len);
+  if (addr == NULL) {
+    return len == 0;
+  }
+
+  return probe_write_access(addr, len);
 }
 
 static inline bool probe_execute_access_opt(const void *addr) {
   return (addr == NULL) || probe_execute_access(addr);
+}
+
+// Variants for syscall arguments that are optional by contract, i.e. where
+// NULL is a meaningful value passed on to the syscall implementation.
+//
+// These functions are used for arguments whose length is implicit
+// (i.e. by the type of the argument) and is always constant.
+
+static inline bool probe_write_access_opt_const_size(void *addr, size_t len) {
+  return (addr == NULL) || probe_write_access(addr, len);
+}
+
+static inline bool probe_read_access_opt_const_size(const void *addr,
+                                                    size_t len) {
+  return (addr == NULL) || probe_read_access(addr, len);
 }
 
 // Handles access violation by exiting the current application task

--- a/core/embed/sys/syscall/stm32/syscall_verifiers.c
+++ b/core/embed/sys/syscall/stm32/syscall_verifiers.c
@@ -141,6 +141,10 @@ bool syslog_start_record__verified(const log_source_t *source,
     goto access_violation;
   }
 
+  if (!probe_read_access(source->name, source->name_len)) {
+    goto access_violation;
+  }
+
   return syslog_start_record(source, level);
 access_violation:
   apptask_access_violation();
@@ -149,7 +153,9 @@ access_violation:
 
 ssize_t syslog_write_chunk__verified(const char *text, size_t text_len,
                                      bool end_record) {
-  if (!probe_read_access(text, text_len)) {
+  // NULL text is allowed for a zero-length write, `syslog_write_chunk()`
+  // still processes it and may end the record
+  if (!probe_read_access_opt(text, text_len)) {
     goto access_violation;
   }
 
@@ -224,8 +230,8 @@ access_violation:
 
 bool ipc_send__verified(systask_id_t remote, uint32_t fn, const void *data,
                         size_t data_size) {
-  // NULL data is allowed for a zero-length message, `ipc_send()` rejects it
-  // for any other size
+  // NULL data is allowed for a zero-length message, `ipc_send()` accepts it and
+  // sends an empty message.
   if (!probe_read_access_opt(data, data_size)) {
     goto access_violation;
   }
@@ -296,34 +302,31 @@ void system_exit_error__verified(const char *title, size_t title_len,
   char message_copy[64] = {0};
   char footer_copy[64] = {0};
 
+  if (!probe_read_access_opt(title, title_len)) {
+    goto access_violation;
+  }
+
   if (title != NULL) {
-    if (!probe_read_access(title, title_len)) {
-      goto access_violation;
-    }
     title_len = MIN(title_len, sizeof(title_copy) - 1);
     title = strncpy(title_copy, title, title_len);
-  } else {
-    title_len = 0;
+  }
+
+  if (!probe_read_access_opt(message, message_len)) {
+    goto access_violation;
   }
 
   if (message != NULL) {
-    if (!probe_read_access(message, message_len)) {
-      goto access_violation;
-    }
     message_len = MIN(message_len, sizeof(message_copy) - 1);
     message = strncpy(message_copy, message, message_len);
-  } else {
-    message_len = 0;
+  }
+
+  if (!probe_read_access_opt(footer, footer_len)) {
+    goto access_violation;
   }
 
   if (footer != NULL) {
-    if (!probe_read_access(footer, footer_len)) {
-      goto access_violation;
-    }
     footer_len = MIN(footer_len, sizeof(footer_copy) - 1);
     footer = strncpy(footer_copy, footer, footer_len);
-  } else {
-    footer_len = 0;
   }
 
   systask_t *task = systask_active();
@@ -342,24 +345,22 @@ void system_exit_fatal__verified(const char *message, size_t message_len,
   char message_copy[64] = {0};
   char file_copy[64] = {0};
 
+  if (!probe_read_access_opt(message, message_len)) {
+    goto access_violation;
+  }
+
   if (message != NULL) {
-    if (!probe_read_access(message, message_len)) {
-      goto access_violation;
-    }
     message_len = MIN(message_len, sizeof(message_copy) - 1);
     message = strncpy(message_copy, message, message_len);
-  } else {
-    message_len = 0;
+  }
+
+  if (!probe_read_access_opt(file, file_len)) {
+    goto access_violation;
   }
 
   if (file != NULL) {
-    if (!probe_read_access(file, file_len)) {
-      goto access_violation;
-    }
     file_len = MIN(file_len, sizeof(file_copy) - 1);
     file = strncpy(file_copy, file, file_len);
-  } else {
-    file_len = 0;
   }
 
   systask_t *task = systask_active();
@@ -456,7 +457,7 @@ access_violation:
 
 secbool usb_start__verified(const usb_start_params_t *params) {
   // NULL params is allowed and keeps the settings from usb_init()
-  if (!probe_read_access_opt(params, sizeof(*params))) {
+  if (!probe_read_access_opt_const_size(params, sizeof(*params))) {
     goto access_violation;
   }
 
@@ -686,7 +687,7 @@ access_violation:
 #ifdef USE_TELEMETRY
 bool telemetry_get__verified(telemetry_data_t *out) {
   // NULL out is allowed and only queries whether telemetry is available
-  if (!probe_write_access_opt(out, sizeof(*out))) {
+  if (!probe_write_access_opt_const_size(out, sizeof(*out))) {
     goto access_violation;
   }
 
@@ -729,12 +730,13 @@ access_violation:
 storage_unlock_result_t storage_unlock__verified(const uint8_t *pin,
                                                  size_t pin_len,
                                                  const uint8_t *ext_salt) {
-  if (!probe_read_access(pin, pin_len)) {
+  // `storage_unlock()` accepts a NULL pin and returns an error code
+  if (!probe_read_access_opt(pin, pin_len)) {
     goto access_violation;
   }
 
   // NULL ext_salt is allowed and means no external salt is used
-  if (!probe_read_access_opt(ext_salt, EXTERNAL_SALT_SIZE)) {
+  if (!probe_read_access_opt_const_size(ext_salt, EXTERNAL_SALT_SIZE)) {
     goto access_violation;
   }
 
@@ -747,12 +749,13 @@ access_violation:
 
 storage_pin_change_result_t storage_change_pin__verified(
     const uint8_t *newpin, size_t newpin_len, const uint8_t *new_ext_salt) {
-  if (!probe_read_access(newpin, newpin_len)) {
+  // `storage_change_pin()` accepts a NULL newpin and returns an error code
+  if (!probe_read_access_opt(newpin, newpin_len)) {
     goto access_violation;
   }
 
   // NULL new_ext_salt is allowed and means no external salt is used
-  if (!probe_read_access_opt(new_ext_salt, EXTERNAL_SALT_SIZE)) {
+  if (!probe_read_access_opt_const_size(new_ext_salt, EXTERNAL_SALT_SIZE)) {
     goto access_violation;
   }
 
@@ -780,16 +783,18 @@ secbool storage_change_wipe_code__verified(const uint8_t *pin, size_t pin_len,
                                            const uint8_t *ext_salt,
                                            const uint8_t *wipe_code,
                                            size_t wipe_code_len) {
-  if (!probe_read_access(pin, pin_len)) {
+  // `storage_change_wipe_code()` accepts a NULL pin and returns secfalse
+  if (!probe_read_access_opt(pin, pin_len)) {
     goto access_violation;
   }
 
   // NULL ext_salt is allowed and means no external salt is used
-  if (!probe_read_access_opt(ext_salt, EXTERNAL_SALT_SIZE)) {
+  if (!probe_read_access_opt_const_size(ext_salt, EXTERNAL_SALT_SIZE)) {
     goto access_violation;
   }
 
-  if (!probe_read_access(wipe_code, wipe_code_len)) {
+  // `storage_change_wipe_code()` accepts a NULL wipe_code and returns secfalse
+  if (!probe_read_access_opt(wipe_code, wipe_code_len)) {
     goto access_violation;
   }
 
@@ -803,7 +808,7 @@ access_violation:
 
 secbool storage_get__verified(const uint16_t key, void *val,
                               const uint16_t max_len, uint16_t *len) {
-  // NULL val is allowed and queries the value length only
+  // NULL val and max_len 0 is allowed and queries the value length only
   if (!probe_write_access_opt(val, max_len)) {
     goto access_violation;
   }
@@ -901,7 +906,8 @@ access_violation:
 
 int firmware_hash_start__verified(const uint8_t *challenge,
                                   size_t challenge_len) {
-  if (!probe_read_access(challenge, challenge_len)) {
+  // challenge is optional, so we allow NULL with size 0
+  if (!probe_read_access_opt(challenge, challenge_len)) {
     goto access_violation;
   }
 
@@ -941,7 +947,8 @@ access_violation:
 #ifdef USE_BLE
 
 bool ble_enter_pairing_mode__verified(const uint8_t *name, size_t name_len) {
-  // NULL name is allowed and keeps the advertising name unchanged
+  // NULL name with name_len 0 is allowed and keeps the advertising name
+  // unchanged
   if (!probe_read_access_opt(name, name_len)) {
     goto access_violation;
   }
@@ -1030,7 +1037,7 @@ access_violation:
 
 bool ble_unpair__verified(const bt_le_addr_t *addr) {
   // NULL addr is allowed and unpairs the currently connected device
-  if (!probe_read_access_opt(addr, sizeof(*addr))) {
+  if (!probe_read_access_opt_const_size(addr, sizeof(*addr))) {
     goto access_violation;
   }
 
@@ -1130,7 +1137,8 @@ access_violation:
 
 pm_status_t pm_suspend__verified(wakeup_flags_t *wakeup_reason) {
   // NULL wakeup_reason is allowed and means the caller isn't interested
-  if (!probe_write_access_opt(wakeup_reason, sizeof(*wakeup_reason))) {
+  if (!probe_write_access_opt_const_size(wakeup_reason,
+                                         sizeof(*wakeup_reason))) {
     goto access_violation;
   }
 


### PR DESCRIPTION
This PR fixes overly strict syscall and smcall verifier checks introduced in PR #7548 before the release.

The verifier helpers now distinguish between three pointer contracts:

- `probe_xxx_access(ptr, len)`: requires a non-`NULL`, accessible buffer, including for zero-length data.
- `probe_xxx_access_opt(ptr, len)`: accepts `NULL` only when `len == 0`, for optional buffers with an explicit length.
- `probe_xxx_access_opt_const_size(ptr, len)`: accepts `NULL` regardless of `len`, for optional fixed-size arguments whose size is determined by their type.

This preserves strict validation for required buffers while allowing syscall/smcall implementations to receive optional arguments according to their documented contracts.

## Relaxed checks

The following calls now accept `NULL` when their size is zero:

- `syslog_write_chunk()`
- `bootargs_set()`
- `firmware_hash_start()`
- `storage_unlock()`
- `storage_change_pin()`
- `storage_change_wipe_code()`

Reasoning:

- Some functions use optional arguments and such function may be called with NULL and 0.
- Some functions accept `NULL` and either return an error or do nothing. The syscall/smcall wrapper should behave the same as a direct function call.

## Stricter checks

The following syscalls/smcalls previously accepted `NULL` arguments. They now accept them only when the size is zero:

- `backup_ram_read()`
- `storage_get()`
- `system_exit_error()`
- `system_exit_fatal()`
- `ipc_send()`
- `ble_enter_pairing_mode()`

Reasoning:

- A `NULL` argument with a non-zero size should not normally be passed. In most cases, it may cause a secmon or kernel crash.

## Added checks

`syslog_start_record` now checks source module name as well (this syscall is only available in debug builds)
