### PR TITLE
fix(core): fix build with --debug  option

### DIFF
--- a/core/embed/projects/bootloader/src/main.rs
+++ b/core/embed/projects/bootloader/src/main.rs
@@ -1,4 +1,6 @@
 #![no_std]
 #![no_main]
 
+// force pull in Rust generated symbols (incl. the panic handler)
+use sys as _;
 use trezor_lib as _;

--- a/core/embed/projects/firmware/src/main.rs
+++ b/core/embed/projects/firmware/src/main.rs
@@ -1,4 +1,6 @@
 #![no_std]
 #![no_main]
 
+// force pull in Rust generated symbols (incl. the panic handler)
+use sys as _;
 use trezor_lib as _;

--- a/core/embed/projects/kernel/src/main.rs
+++ b/core/embed/projects/kernel/src/main.rs
@@ -1,5 +1,6 @@
 #![no_std]
 #![no_main]
 
-// force pull in Rust generated symbols
+// force pull in Rust generated symbols (incl. the panic handler)
 use io as _;
+use sys as _;

--- a/core/embed/projects/prodtest/src/main.rs
+++ b/core/embed/projects/prodtest/src/main.rs
@@ -1,5 +1,7 @@
 #![no_std]
 #![no_main]
 
+// force pull in Rust generated symbols (incl. the panic handler)
 use io as _;
+use sys as _;
 use trezor_lib as _;

--- a/core/embed/projects/unix/src/main.rs
+++ b/core/embed/projects/unix/src/main.rs
@@ -1,4 +1,6 @@
 #![no_std]
 #![no_main]
 
+// force pull in Rust generated symbols (incl. the panic handler)
+use sys as _;
 use trezor_lib as _;


### PR DESCRIPTION
A mistake slipped in - PR #7674 didn't fully solve the issue with the `--debug` build option. There were still missing panic handler symbols. This PR force-imports the `sys` crate in all affected top-level crates.
