### PR TITLE
chore(core): update xtask presets

### DIFF
--- a/core/embed/xtask/presets.toml
+++ b/core/embed/xtask/presets.toml
@@ -14,6 +14,7 @@
 [[defaults]]
 when = { emulator = true }
 dbg-console = "swo" # required by prodtest test
+debug = true
 source-lines = true # required by test coverage
 
 [[defaults]]
@@ -22,7 +23,6 @@ frozen = true
 pyopt = true
 
 [[test]]
-debug = true
 debug-link = true
 disable-animation = true
 frozen = true
@@ -34,11 +34,9 @@ storage-insecure-testing-mode = true
 disable-optiga = true
 disable-tropic = true
 
-
 [[dev]]
 when = { emulator = true }
 asan = true
-debug = true
 frozen = false
 pyopt = false
 source-lines = true
@@ -46,7 +44,6 @@ source-lines = true
 [[dev]]
 when = { emulator = false, project = ["firmware", "prodtest"] }
 dbg-console = "swo"
-debug = true
 pyopt = false
 
 # Example of a model- and project-specific fragment:


### PR DESCRIPTION
This tiny PR updates xtask presets so they work better and make more sense:

1)  `--debug=true` is now enabled by default for all emulator builds. You can disable it if needed. The change has a significant implication: emulator tests running in CI now use more checks and assertions than before.

2) for hardware builds, `--debug` is now disabled by default, since not all models/projects have enough flash space for these settings. This caused problems especially on T2T1 and T3T1.

We may want to enable `--debug` for hardware tests (perhaps only for some models) as well in the future, but only after some investigation and testing.