### PR TITLE
fix(core): reorder linker script sections for stm32f4 firmware

### DIFF
--- a/core/embed/sys/linker/stm32f4/firmware.ld
+++ b/core/embed/sys/linker/stm32f4/firmware.ld
@@ -38,6 +38,9 @@ SECTIONS {
     . = ALIGN(4);
     *frozen_mpy.o(.rodata*);
     . = ALIGN(4);
+    KEEP(*(.bootloader));
+    *(.bootloader*);
+    . = ALIGN(512);
   } >FLASH AT>FLASH
 
   .flash2 : ALIGN(512) {
@@ -46,9 +49,6 @@ SECTIONS {
     . = ALIGN(4);
     *(.rodata*);
     . = ALIGN(4);
-    KEEP(*(.bootloader));
-    *(.bootloader*);
-    . = ALIGN(512);
   } >FLASH2 AT>FLASH2
 
   .stack : ALIGN(8) {


### PR DESCRIPTION
This PR reorganizes the sections in the linker script used by the firmware on models with an STM32F4 MCU.

Currently, sections in the `FLASH2` region can overflow when the `--debug` option is enabled, as `.text` and `.rodata` grow significantly.

Analysis for T2T1:

| FLASH1 |  768KB total |
| --- | --- |
| headers |   6KB |
| kernel   | 117KB - 121KB |
| mpy   | 516KB - 540KB |

| FLASH2   | 896KB total |
| --- | --- |
| text  | 445KB - 521KB |
| rodata  | 308KB - 355KB |
| bootloader  | 90KB |

With this small change - moving the `bootloader` from `FLASH2` to `FLASH1` - the `--debug` option works again, 
with an  trade-off: the FLASH1 region becomes more tightly packed.