### PR TITLE
feat (firmware): add Casa multisig account type

### DIFF
--- a/core/src/apps/bitcoin/keychain.py
+++ b/core/src/apps/bitcoin/keychain.py
@@ -48,6 +48,9 @@ if TYPE_CHECKING:
 # BIP-45 for multisig: https://github.com/bitcoin/bips/blob/master/bip-0045.mediawiki
 PATTERN_BIP45 = "m/45'/[0-100]/change/address_index"
 
+# Export at m/45' path for Casa multisig
+PATTERN_BIP45_PURPOSE_XPUB = "m/45'/0/0"
+
 # BIP-48 for multisig: https://github.com/bitcoin/bips/blob/master/bip-0048.mediawiki
 # The raw script type is not part of the BIP (and Electrum, as a notable implementation,
 # does not use it), it is included here for completeness.
@@ -443,6 +446,15 @@ def address_n_to_name(
             require_segwit=False,
             require_bech32=True,
             require_taproot=True,
+            account_level=account_level,
+        ),
+        AccountType(
+            "Multisig",
+            PATTERN_BIP45_PURPOSE_XPUB,
+            InputScriptType.SPENDADDRESS,
+            require_segwit=False,
+            require_bech32=False,
+            require_taproot=False,
             account_level=account_level,
         ),
     )

--- a/core/tests/test_apps.bitcoin.keychain_naming.py
+++ b/core/tests/test_apps.bitcoin.keychain_naming.py
@@ -1,0 +1,34 @@
+# flake8: noqa: F403,F405
+from common import *  # isort:skip
+
+from trezor.enums import InputScriptType
+
+from apps.bitcoin.keychain import _get_coin_by_name, address_n_to_name
+
+
+class TestAccountNaming(unittest.TestCase):
+    def setUp(self):
+        self.coin = _get_coin_by_name("Bitcoin")
+
+    def test_bip45_purpose_xpub_named(self):
+        # m/45' export (BIP-45 purpose-level xpub) is named at account level
+        name = address_n_to_name(
+            self.coin,
+            [H_(45)],
+            InputScriptType.SPENDADDRESS,
+            account_level=True,
+        )
+        self.assertEqual(name, "Multisig")
+
+    def test_bip45_purpose_xpub_non_default_script_type(self):
+        name = address_n_to_name(
+            self.coin,
+            [H_(45)],
+            InputScriptType.SPENDP2SHWITNESS,
+            account_level=True,
+        )
+        self.assertIsNone(name)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
This commit adds an m/45’ AccountType labeled “Multisig” to allow exporting at m/45’ without a derivation path warning message.

<!--
For external contributors:
- Please open an issue before submitting a PR so we can discuss whether we want to proceed with it.

For core developers:
1. Initial PR setup
- Assign yourself to the PR.
- Add it to the "Firmware" project
  - Set Priority (match issue priority if it exists)
  - Set Team
  - Set Sprint (target release)

2. Development status
- Draft PRs: Set status to "In Progress"
- Final PRs: Set status to "Needs Review"

3. Post-merge status
- Testable: Set status to "Needs QA" and add a `Notes for QA` section with clear instructions on how to test the functionality.
- Not Testable: Set status to "Done (no QA)"
-->
