### PR TITLE
Remove redundant declarations and enable -Wredundant-decls

### DIFF
--- a/core/embed/io/suspend/inc/io/suspend_io.h
+++ b/core/embed/io/suspend/inc/io/suspend_io.h
@@ -32,14 +32,6 @@
 #endif
 
 /**
- * @brief Switches the CPU to STOP2 low-power mode.
- *
- * This function blocks until an interrupt wakes the CPU.
- * Upon wake-up, it restores the system clock so the CPU can run at full speed.
- */
-void suspend_cpu(void);
-
-/**
  * @brief State of the drivers before entering a low-power mode
  *        used to restore them after wake-up.
  */
@@ -88,20 +80,3 @@ void suspend_drivers_phase2(void);
  *                      drivers before entering low-power mode.
  */
 void resume_drivers(const power_save_wakeup_params_t *wakeup_params);
-
-/**
- * @brief Suspends secure peripherals.
- *
- * This function is called before the device enters a low-power state.
- * It suspends secure peripherals to reduce power consumption.
- */
-void suspend_secure_drivers(void);
-
-/**
- * @brief Resumes secure peripherals.
- *
- * This function is called when the device exits a low-power state.
- * It resumes secure peripherals that were suspended before entering
- * the low-power state.
- */
-void resume_secure_drivers(void);

--- a/core/embed/models/build.rs
+++ b/core/embed/models/build.rs
@@ -53,6 +53,7 @@ fn main() -> Result<()> {
             "-Wno-type-limits",
             "-Wfloat-conversion",
             "-Wdouble-promotion",
+            "-Wredundant-decls",
             "-fno-common",
             "-fdata-sections",
             "-ffunction-sections",

--- a/core/embed/projects/firmware/boot_image_embdata.c
+++ b/core/embed/projects/firmware/boot_image_embdata.c
@@ -37,7 +37,6 @@
 // symbols from bootloader.bin => bootloader.o
 extern const void bootloader_start;
 extern const void bootloader_size;
-extern const void bootloader_size;
 
 static const boot_image_t g_bootloader_image = {
     .image_ptr = (const void *)&bootloader_start,

--- a/core/embed/projects/firmware/mphalport.c
+++ b/core/embed/projects/firmware/mphalport.c
@@ -57,3 +57,5 @@ void mp_hal_delay_us(mp_uint_t usec) { systick_delay_us(usec); }
 mp_uint_t mp_hal_ticks_ms(void) { return systick_ms(); }
 
 mp_uint_t mp_hal_ticks_us(void) { return systick_us(); }
+
+mp_uint_t mp_hal_ticks_cpu(void) { return systick_us(); }

--- a/core/embed/projects/firmware/mphalport.h
+++ b/core/embed/projects/firmware/mphalport.h
@@ -18,5 +18,3 @@
  */
 
 #include "shared/runtime/interrupt_char.h"
-
-static inline mp_uint_t mp_hal_ticks_cpu(void) { return 0; }

--- a/core/embed/projects/prodtest/commands.c
+++ b/core/embed/projects/prodtest/commands.c
@@ -29,15 +29,15 @@ void register_cli_command(const cli_command_t *cmd) {
   _cmd_list[_cmd_count++] = *cmd;
 }
 
+#else
+extern cli_command_t _prodtest_cli_cmd_section_start;
+extern cli_command_t _prodtest_cli_cmd_section_end;
 #endif
 
 const cli_command_t *commands_get_ptr(void) {
 #ifdef TREZOR_EMULATOR
   return _cmd_list;
-
 #else
-  extern cli_command_t _prodtest_cli_cmd_section_start;
-
   return &_prodtest_cli_cmd_section_start;
 #endif
 }
@@ -45,11 +45,7 @@ const cli_command_t *commands_get_ptr(void) {
 size_t commands_count(void) {
 #ifdef TREZOR_EMULATOR
   return _cmd_count;
-
 #else
-  extern cli_command_t _prodtest_cli_cmd_section_start;
-  extern cli_command_t _prodtest_cli_cmd_section_end;
-
   return &_prodtest_cli_cmd_section_end - &_prodtest_cli_cmd_section_start;
 #endif
 }

--- a/core/embed/rtl/error_handling.c
+++ b/core/embed/rtl/error_handling.c
@@ -19,6 +19,8 @@
 
 #include <trezor_rtl.h>
 
+#include <assert.h>
+
 #ifndef TREZOR_EMULATOR
 // Stack check guard value set in startup code.
 // This is used if stack protection is enabled.
@@ -97,4 +99,8 @@ void __attribute__((noreturn)) __fatal_error(const char *msg, const char *file,
   size_t msg_len = msg != NULL ? strlen(msg) : 0;
   size_t file_len = file != NULL ? strlen(file) : 0;
   system_exit_fatal_ex(msg, msg_len, file, file_len, line);
+}
+
+void __attribute__((noreturn)) __assert_impl(const char *file, int line) {
+  __fatal_error("Assert", file, line);
 }

--- a/core/embed/rtl/inc/assert.h
+++ b/core/embed/rtl/inc/assert.h
@@ -36,11 +36,9 @@ extern "C" {
 
 #ifndef NDEBUG
 
-void __attribute__((noreturn)) __fatal_error(const char *msg, const char *file,
-                                             int line);
+void __attribute__((noreturn)) __assert_impl(const char *file, int line);
 
-#define assert(expr) \
-  ((expr) ? (void)0 : __fatal_error("Assert", __FILE_NAME__, __LINE__))
+#define assert(expr) ((expr) ? (void)0 : __assert_impl(__FILE_NAME__, __LINE__))
 
 #else
 

--- a/core/embed/rtl/inc/rtl/cli.h
+++ b/core/embed/rtl/inc/rtl/cli.h
@@ -72,7 +72,6 @@ typedef struct {
 #ifdef TREZOR_EMULATOR
 #define PRODTEST_CLI_CMD(...) PRODTEST_CLI_CMD_IMPL(__COUNTER__, __VA_ARGS__)
 #define PRODTEST_CLI_CMD_IMPL(cnt, ...)                                     \
-  extern void register_cli_command(const cli_command_t* cmd);               \
   static const cli_command_t CONCAT(_cli_cmd_handler, cnt) = {__VA_ARGS__}; \
   __attribute__((constructor)) static void CONCAT(                          \
       __register, CONCAT(_cli_cmd_handler, cnt))(void) {                    \
@@ -272,3 +271,7 @@ void cli_disable_crc(cli_t* cli);
  * Returns true if CRC check is enabled.
  */
 bool cli_crc_enabled(cli_t* cli);
+
+#ifdef TREZOR_EMULATOR
+void register_cli_command(const cli_command_t* cmd);
+#endif

--- a/core/embed/rtl/printf_config.h
+++ b/core/embed/rtl/printf_config.h
@@ -26,5 +26,3 @@
 #define PRINTF_USE_DOUBLE_INTERNALLY 0
 #define PRINTF_INTEGER_BUFFER_SIZE 32
 #define PRINTF_DECIMAL_BUFFER_SIZE 0
-
-static inline void putchar_(char c) {}

--- a/core/embed/rust/librust.h
+++ b/core/embed/rust/librust.h
@@ -7,22 +7,6 @@ mp_obj_t protobuf_debug_msg_type();
 mp_obj_t protobuf_debug_msg_def_type();
 #endif
 
-extern const mp_obj_module_t mp_module_trezorproto;
-extern const mp_obj_module_t mp_module_trezorui_api;
-extern const mp_obj_module_t mp_module_trezordefinitions;
-extern const mp_obj_module_t mp_module_trezortranslate;
-extern const mp_obj_module_t mp_module_trezorble;
-extern const mp_obj_module_t mp_module_trezorthp;
-
-#ifdef USE_DBG_CONSOLE
-extern const mp_obj_module_t mp_module_trezorlog;
-#endif
-
 #if !PYOPT
 mp_obj_t ui_debug_layout_type();
-
-#ifdef TREZOR_EMULATOR
-extern const mp_obj_module_t mp_module_coveragedata;
-#endif
-
 #endif

--- a/core/embed/sec/storage/inc/sec/storage.h
+++ b/core/embed/sec/storage/inc/sec/storage.h
@@ -17,6 +17,8 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
+#pragma once
+
 #include <trezor-storage/storage.h>
 
 /**

--- a/core/embed/sys/bsp/build.rs
+++ b/core/embed/sys/bsp/build.rs
@@ -1,4 +1,4 @@
-use xbuild::{CLibrary, Result, bail_unsupported};
+use xbuild::{CLibrary, CompileAttrs, Result, bail_unsupported};
 
 pub fn def_module(lib: &mut CLibrary) -> Result<()> {
     lib.add_include("bsp/inc");
@@ -122,8 +122,6 @@ fn add_stm32f4_bsp(lib: &mut CLibrary) -> Result<()> {
             "stm32f4xx_hal_cortex.c",
             "stm32f4xx_hal_dma.c",
             "stm32f4xx_hal_dma2d.c",
-            "stm32f4xx_hal_flash.c",
-            "stm32f4xx_hal_flash_ex.c",
             "stm32f4xx_hal_gpio.c",
             "stm32f4xx_hal_i2c.c",
             "stm32f4xx_hal_ltdc.c",
@@ -142,6 +140,12 @@ fn add_stm32f4_bsp(lib: &mut CLibrary) -> Result<()> {
             "stm32f4xx_ll_sdmmc.c",
             "stm32f4xx_ll_usb.c",
         ],
+    );
+
+    lib.add_sources_in_dir_with_attrs(
+        "../../vendor/micropython/lib/stm32lib/STM32F4xx_HAL_Driver/Src/",
+        ["stm32f4xx_hal_flash.c", "stm32f4xx_hal_flash_ex.c"],
+        Some(CompileAttrs::new().with_flag("-Wno-redundant-decls")),
     );
 
     Ok(())

--- a/core/embed/sys/linker/inc/sys/linker_utils.h
+++ b/core/embed/sys/linker/inc/sys/linker_utils.h
@@ -28,6 +28,8 @@
 // symbols defined in the linker script
 extern uint8_t _stack_section_start;
 extern uint8_t _stack_section_end;
+extern uint8_t _bootargs_ram_start;
+extern uint8_t _bootargs_ram_end;
 
 // Initialize linker script-defined sections (.bss, .data, etc.)
 //
@@ -177,14 +179,10 @@ void memregion_fill(memregion_t* region, uint32_t value);
 
 #define MEMREGION_ADD_SECTION(region, section_name)                          \
   {                                                                          \
-    extern uint8_t section_name##_start;                                     \
-    extern uint8_t section_name##_end;                                       \
     memregion_add_range(region, &section_name##_start, &section_name##_end); \
   }
 
 #define MEMREGION_DEL_SECTION(region, section_name)                          \
   {                                                                          \
-    extern uint8_t section_name##_start;                                     \
-    extern uint8_t section_name##_end;                                       \
     memregion_del_range(region, &section_name##_start, &section_name##_end); \
   }

--- a/core/embed/upymod/modtrezorcrypto/modtrezorcrypto-aesgcm.h
+++ b/core/embed/upymod/modtrezorcrypto/modtrezorcrypto-aesgcm.h
@@ -23,8 +23,6 @@
 #include "consteq.h"
 #include "memzero.h"
 
-extern const mp_obj_type_t mp_type_AuthenticationError;
-
 /// package: trezorcrypto.__init__
 
 /// class aesgcm_encrypt:

--- a/core/embed/upymod/modtrezorcrypto/modtrezorcrypto-chacha20poly1305.h
+++ b/core/embed/upymod/modtrezorcrypto/modtrezorcrypto-chacha20poly1305.h
@@ -23,8 +23,6 @@
 #include "consteq.h"
 #include "memzero.h"
 
-extern const mp_obj_type_t mp_type_AuthenticationError;
-
 /// package: trezorcrypto.__init__
 
 /// class chacha20poly1305_encrypt:

--- a/core/embed/upymod/modtrezorcrypto/modtrezorcrypto.c
+++ b/core/embed/upymod/modtrezorcrypto/modtrezorcrypto.c
@@ -32,6 +32,8 @@ static void wrapped_ui_wait_callback(uint32_t current, uint32_t total) {
   }
 }
 
+extern const mp_obj_type_t mp_type_AuthenticationError;
+
 #include "modtrezorcrypto-aes.h"
 #ifdef USE_AES_GCM
 #include "modtrezorcrypto-aesgcm.h"

--- a/core/embed/upymod/modtrezorio/modtrezorio-poll.h
+++ b/core/embed/upymod/modtrezorio/modtrezorio-poll.h
@@ -43,7 +43,9 @@
 #define POLL_READ (0x0000)
 #define POLL_WRITE (0x0100)
 
-extern uint32_t last_touch_sample_time;
+#ifdef USE_TOUCH
+static uint32_t last_touch_sample_time = 0;
+#endif
 
 #ifdef USE_BLE
 

--- a/core/embed/upymod/modtrezorio/modtrezorio.c
+++ b/core/embed/upymod/modtrezorio/modtrezorio.c
@@ -37,8 +37,6 @@
 
 #include <io/usb.h>
 
-uint32_t last_touch_sample_time = 0;
-
 #define CHECK_PARAM_RANGE(value, minimum, maximum) \
   if (value < minimum || value > maximum) {        \
     const char *msg = (#value " is out of range"); \

--- a/core/embed/upymod/modtrezorutils/modtrezorutils-meminfo.h
+++ b/core/embed/upymod/modtrezorutils/modtrezorutils-meminfo.h
@@ -305,7 +305,6 @@ typedef struct _mp_obj_closure_t {
   mp_obj_t closed[];
 } mp_obj_closure_t;
 
-extern const mp_obj_type_t mp_type_bound_meth;
 extern const mp_obj_type_t mp_type_closure;
 extern const mp_obj_type_t mp_type_cell;
 extern const mp_obj_type_t mod_trezorio_USB_type;


### PR DESCRIPTION
This PR enables the `-Wredundant-decls` warning (which, in our case, manifests as a compile error). This warning can help us catch a very specific kind of bug: when a global function is accidentally shadowed by a locally defined `static` function with the same name.

```c
static inline void module_func(void) {
   // some behaviour
}

#include <module.h> // declares module_func() that's defined in `module.c` compilation unit

void dummy() {
   module_func();   // local static inline is used; now triggers a warning/error with -Wredundant-decls
}
```

Enabling `-Wredundant-decls` required a few fixes in the existing code, most of which were straightforward.

Other changes:
- `mp_hal_ticks_cpu()` now returns microseconds instead of 0. 

NOTE: This PR also incorporates a few changes to micropython (https://github.com/trezor/micropython/pull/34). I'm not sure we'll be able to upstream them, since `-Wredundant-decls` cannot be easily enabled for micropython as is. There are a lot of issues, even in the submodules it uses (e.g. littlefs).