### PR TITLE
chore(core): remove untrue comment from storage/cache

### DIFF
--- a/core/src/storage/cache_common.py
+++ b/core/src/storage/cache_common.py
@@ -93,9 +93,6 @@ class DataCache:
     def set_int(self, key: int, value: int) -> None:
         length = self._get_length(key)
         encoded = value.to_bytes(length, "big")
-
-        # Ensure that the value fits within the length. Micropython's int.to_bytes()
-        # doesn't raise OverflowError.
         assert int.from_bytes(encoded, "big") == value
 
         self.set(key, encoded)


### PR DESCRIPTION
Since micropython 1.24, `int.to_bytes` raises `OverflowError` on insufficient length parameter.

<!--
For external contributors:
- Please open an issue before submitting a PR so we can discuss whether we want to proceed with it.

For core developers:
1. Initial PR setup
- Assign yourself to the PR.
- Add it to the "Firmware" project
  - Set Priority (match issue priority if it exists)
  - Set Team
  - Set Sprint (target release)

2. Development status
- Draft PRs: Set status to "In Progress"
- Final PRs: Set status to "Needs Review"

3. Post-merge status
- Testable: Set status to "Needs QA" and add a `Notes for QA` section with clear instructions on how to test the functionality.
- Not Testable: Set status to "Done (no QA)"
-->
