### PR TITLE
Remove Optional from core

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -68,7 +68,7 @@ pystyle_check: ## run code style check on application sources and tests
 	@isort --check-only $(PY_FILES)
 	@echo [BLACK]
 	@black --check $(BLACK_FLAGS) $(PY_FILES)
-	@echo [RUFF - PEP 585]
+	@echo [RUFF]
 	@ruff check $(PY_FILES)
 	@echo [PYLINT]
 	@pylint $(PY_FILES)
@@ -85,7 +85,7 @@ pystyle: ## apply code style on application sources and tests
 	@isort $(PY_FILES)
 	@echo [BLACK]
 	@black $(BLACK_FLAGS) $(PY_FILES)
-	@echo [RUFF - PEP 585]
+	@echo [RUFF]
 	@ruff check --fix $(PY_FILES)
 	@echo [TYPECHECK]
 	@make -C core typecheck

--- a/core/src/apps/bitcoin/sign_tx/approvers.py
+++ b/core/src/apps/bitcoin/sign_tx/approvers.py
@@ -13,7 +13,6 @@ from .tx_info import OriginalTxInfo
 
 if TYPE_CHECKING:
     from buffer_types import AnyBytes
-    from typing import Optional
 
     from trezor.crypto import bip32
     from trezor.messages import PaymentRequest, SignTx, TxInput, TxOutput
@@ -145,7 +144,7 @@ class Approver:
         self,
         tx_info: TxInfo,
         orig_txs: list[OriginalTxInfo],
-        signer: Optional[Bitcoin],
+        signer: Bitcoin | None,
     ) -> None:
         self.finish_payment_request()
 
@@ -327,7 +326,7 @@ class BasicApprover(Approver):
         self,
         tx_info: TxInfo,
         orig_txs: list[OriginalTxInfo],
-        signer: Optional[Bitcoin],
+        signer: Bitcoin | None,
     ) -> None:
         from trezor.wire import NotEnoughFunds
 
@@ -513,7 +512,7 @@ class CoinJoinApprover(Approver):
         self,
         tx_info: TxInfo,
         orig_txs: list[OriginalTxInfo],
-        signer: Optional[Bitcoin],
+        signer: Bitcoin | None,
     ) -> None:
         from ..authorization import FEE_RATE_DECIMALS
 

--- a/core/tools/analyze-memory-dump.py
+++ b/core/tools/analyze-memory-dump.py
@@ -6,7 +6,7 @@ from __future__ import annotations
 import json
 import sys
 from collections.abc import Iterator
-from typing import Any, Optional, TypeGuard
+from typing import Any, TypeGuard
 
 if len(sys.argv) < 2:
     print("""\
@@ -126,7 +126,7 @@ class Item:
     def find_modules(self) -> list["Item"]:
         return [it for it in self.backlinks if it.type == "module"]
 
-    def name(self) -> Optional[str]:
+    def name(self) -> str | None:
         if "__name__" in self.dict:
             return self.dict["__name__"]
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -110,6 +110,15 @@ per-file-target-version = { "python/**/*.py" = "py39" }
 
 [tool.ruff.lint]
 select = [
+  # PEP 585
   "UP006",  # non-pep585-annotation: typing.Tuple -> tuple, typing.Type -> type, ...
   "UP035",  # deprecated-import: typing.Sequence -> collections.abc.Sequence, ...
+
+  # PEP 604 (used in /core only)
+  "UP007",  # non-pep604-annotation-union: Union[int, str] -> int | str
+  "UP045",  # non-pep604-annotation-optional: Optional[str] -> str | None
 ]
+
+[tool.ruff.lint.per-file-ignores]
+# PEP 604 syntax needs Python 3.10 - cannot be enforced e.g. in /python as it still supports Python 3.9.
+"!core/**/*.py" = ["UP007", "UP045"]


### PR DESCRIPTION
Enforces PEP 604 in core - prohibits the usage of `Optional` an `Union` (pre-Python 3.10 syntax).