### PR TITLE
CI: T2B1 nightly build for Suite + don't spam t-u-e from forks

### DIFF
--- a/.github/workflows/bot-tropic-emulator.yml
+++ b/.github/workflows/bot-tropic-emulator.yml
@@ -57,7 +57,7 @@ jobs:
   issue_open:
     name: Open an issue for trezor-user-env
     runs-on: ubuntu-latest
-    if: github.event.action == 'closed' && github.event.merged == true
+    if: github.event.action == 'closed' && github.event.merged == true && github.repository == 'trezor/trezor-firmware'
     env:
       URL: ${{ github.event.pull_request.html_url }}
     steps:

--- a/.github/workflows/core-hw.yml
+++ b/.github/workflows/core-hw.yml
@@ -31,6 +31,8 @@ jobs:
   param:
     name: Determine pipeline parameters
     runs-on: ubuntu-latest
+    # No scheduled runs on forks.
+    if: github.repository == 'trezor/trezor-firmware' || github.event_name != 'schedule'
     outputs:
       core_models: ${{ steps.set_vars.outputs.core_models }}
       run_legacy: ${{ steps.set_vars.outputs.run_legacy }}

--- a/.github/workflows/core.yml
+++ b/.github/workflows/core.yml
@@ -63,6 +63,9 @@ jobs:
           - model: T2B1
             coins: universal
             type: normal
+          - model: T2B1
+            coins: btconly
+            type: normal
           - model: T3W1
             coins: universal
             type: debuglink


### PR DESCRIPTION
Nightly firmware upload is failing because we don't build T2B1-btconly: https://github.com/trezor/trezor-firmware/actions/runs/33026565388/job/98370492994

<!--
For external contributors:
- Please open an issue before submitting a PR so we can discuss whether we want to proceed with it.

For core developers:
1. Initial PR setup
- Assign yourself to the PR.
- Add it to the "Firmware" project
  - Set Priority (match issue priority if it exists)
  - Set Team
  - Set Sprint (target release)

2. Development status
- Draft PRs: Set status to "In Progress"
- Final PRs: Set status to "Needs Review"

3. Post-merge status
- Testable: Set status to "Needs QA" and add a `Notes for QA` section with clear instructions on how to test the functionality.
- Not Testable: Set status to "Done (no QA)"
-->
