### PR TITLE
feat(core): increase `ShortString` size to 128 bytes

### DIFF
--- a/core/embed/rust/src/strutil.rs
+++ b/core/embed/rust/src/strutil.rs
@@ -8,7 +8,7 @@ use crate::micropython::{buffer::StrBuffer, obj::Obj};
 use crate::translations::TR;
 
 /// Unified-length String type, long enough for most simple use-cases.
-pub type ShortString = String<50>;
+pub type ShortString = String<128>;
 
 pub fn hexlify(data: &[u8], buffer: &mut [u8]) {
     const HEX_LOWER: [u8; 16] = *b"0123456789abcdef";

--- a/core/embed/rust/src/ui/util.rs
+++ b/core/embed/rust/src/ui/util.rs
@@ -71,7 +71,7 @@ pub fn split_two_lines(text: &str, text_font: Font, available_width: i16) -> (&s
 /// Returns text to be fit on one line of a given length.
 /// When the text is too long to fit, it is truncated with ellipsis
 /// on the left side.
-/// This assumes no lines are longer than 50 chars (ShortString limit)
+/// This assumes no lines are longer than 128 bytes (ShortString limit)
 pub fn long_line_content_with_ellipsis(
     text: &str,
     ellipsis: &str,


### PR DESCRIPTION
It will allow supporting longer passphrases on Core models.

PIN length is still limited to 50 bytes.

## TODOs
- [x] analyze Rust stack utilization
- [x] analyze Rust types sizes (#7438)
