### PR TITLE
bootloader flash savings

### DIFF
--- a/core/embed/projects/bootloader/build.rs
+++ b/core/embed/projects/bootloader/build.rs
@@ -16,6 +16,9 @@ fn main() -> Result<()> {
             ("PB_FIELD_16BIT", Some("1")),
             ("PB_ENCODE_ARRAYS_UNPACKED", Some("1")),
             ("PB_VALIDATE_UTF8", Some("1")),
+            // Drops nanopb's error message strings (~1 kB of flash). Nothing
+            // in the bootloader reads `pb_(i|o)stream_t::errmsg`.
+            ("PB_NO_ERRMSG", Some("1")),
         ]);
 
         lib.add_sources([

--- a/core/embed/projects/bootloader/wire/codec_v1.c
+++ b/core/embed/projects/bootloader/wire/codec_v1.c
@@ -111,8 +111,7 @@ secbool codec_send_msg(wire_iface_t *iface, uint16_t msg_id,
   pb_ostream_t sizestream = {.callback = NULL,
                              .state = NULL,
                              .max_size = SIZE_MAX,
-                             .bytes_written = 0,
-                             .errmsg = NULL};
+                             .bytes_written = 0};
   if (!pb_encode(&sizestream, fields, msg)) {
     return secfalse;
   }
@@ -138,8 +137,7 @@ secbool codec_send_msg(wire_iface_t *iface, uint16_t msg_id,
   pb_ostream_t stream = {.callback = &write,
                          .state = &state,
                          .max_size = SIZE_MAX,
-                         .bytes_written = 0,
-                         .errmsg = NULL};
+                         .bytes_written = 0};
 
   if (!pb_encode(&stream, fields, msg)) {
     return secfalse;
@@ -209,10 +207,8 @@ secbool codec_recv_message(wire_iface_t *iface, uint32_t msg_size, uint8_t *buf,
   packet_read_state_t state = {
       .iface = iface, .packet_pos = MSG_HEADER1_LEN, .buf = buf};
 
-  pb_istream_t stream = {.callback = &read,
-                         .state = &state,
-                         .bytes_left = msg_size,
-                         .errmsg = NULL};
+  pb_istream_t stream = {
+      .callback = &read, .state = &state, .bytes_left = msg_size};
 
   if (!pb_decode_noinit(&stream, fields, msg)) {
     return secfalse;

--- a/core/embed/rust/src/ui/shape/canvas/common.rs
+++ b/core/embed/rust/src/ui/shape/canvas/common.rs
@@ -600,8 +600,15 @@ pub trait Canvas: BasicCanvas {
             return;
         }
 
+        let full_turn = end - start >= 360.0;
+
         start = (360.0 + start % 360.0) % 360.0;
         end = (360.0 + end % 360.0) % 360.0;
+
+        if full_turn {
+            start = 0.0;
+            end = 360.0;
+        }
 
         let alpha = 255;
         let alpha_mul = |a: u8| -> u8 { ((u16::from(a) * u16::from(alpha)) / 255) as u8 };


### PR DESCRIPTION
This PR recovers some flash space in bootloader, mainly due to T3T1 running low (no meaningful margin before this PR)

Two measures applicated:
- `PB_NO_ERRMSG` is set, recovering about 1kB of flash by removing unused nanopb feature
- normalize_angle function is introduced, to avoid pulling in expensive fmodf function


About 1.4kB saved in total, the second applies to firmware too.