### PR TITLE
Don't poke idle timer as often when using BLE

### DIFF
--- a/core/src/apps/bitcoin/get_public_key.py
+++ b/core/src/apps/bitcoin/get_public_key.py
@@ -18,8 +18,10 @@ async def get_public_key(
     from trezor.enums import InputScriptType
     from trezor.messages import HDNodeType, PublicKey, UnlockPath
 
-    from apps.common import coininfo, paths
+    from apps.common import coininfo, lock_manager, paths
     from apps.common.keychain import ForbiddenKeyPath, get_keychain
+
+    lock_manager.touch_idle_timer_if_ble()
 
     coin_name = msg.coin_name or "Bitcoin"
     script_type = msg.script_type or InputScriptType.SPENDADDRESS

--- a/core/src/apps/cardano/get_public_key.py
+++ b/core/src/apps/cardano/get_public_key.py
@@ -17,9 +17,11 @@ async def get_public_key(
     from trezor import log, wire
     from trezor.ui.layouts import show_pubkey
 
-    from apps.common import paths
+    from apps.common import lock_manager, paths
 
     from .helpers.paths import SCHEMA_MINT, SCHEMA_PUBKEY
+
+    lock_manager.touch_idle_timer_if_ble()
 
     address_n = msg.address_n  # local_cache_attribute
 

--- a/core/src/apps/common/lock_manager.py
+++ b/core/src/apps/common/lock_manager.py
@@ -140,6 +140,21 @@ def with_prolonged_suspend_time(
         return func
 
 
+if utils.USE_BLE:
+
+    def touch_idle_timer_if_ble() -> None:
+        """Prevent auto-lock during account discovery over Bluetooth.
+        See also https://github.com/trezor/trezor-firmware/issues/7522"""
+        ctx = context.get_context()
+        if ctx.iface is ble.interface:
+            workflow.idle_timer.touch()
+
+else:
+
+    def touch_idle_timer_if_ble() -> None:
+        pass
+
+
 def set_homescreen() -> None:
     import storage.recovery as storage_recovery
 

--- a/core/src/apps/eos/get_public_key.py
+++ b/core/src/apps/eos/get_public_key.py
@@ -13,10 +13,12 @@ async def get_public_key(msg: EosGetPublicKey, keychain: Keychain) -> EosPublicK
     from trezor.crypto.curve import secp256k1
     from trezor.messages import EosPublicKey
 
-    from apps.common import paths
+    from apps.common import lock_manager, paths
 
     from .helpers import public_key_to_wif
     from .layout import require_get_public_key
+
+    lock_manager.touch_idle_timer_if_ble()
 
     await paths.validate_path(keychain, msg.address_n)
 

--- a/core/src/apps/ethereum/get_public_key.py
+++ b/core/src/apps/ethereum/get_public_key.py
@@ -11,6 +11,7 @@ async def get_public_key(msg: EthereumGetPublicKey) -> EthereumPublicKey:
     from apps.bitcoin import get_public_key as bitcoin_get_public_key
 
     # we use the Bitcoin format for Ethereum xpubs
+    # it calls lock_manager.touch_idle_timer_if_ble() so we don't have to
     btc_pubkey_msg = GetPublicKey(address_n=msg.address_n)
     resp = await bitcoin_get_public_key.get_public_key(btc_pubkey_msg)
 

--- a/core/src/apps/solana/get_public_key.py
+++ b/core/src/apps/solana/get_public_key.py
@@ -2,7 +2,7 @@ from typing import TYPE_CHECKING
 
 from trezor.crypto import base58
 
-from apps.common import seed
+from apps.common import lock_manager, seed
 from apps.common.keychain import with_slip44_keychain
 
 from . import CURVE, PATTERNS, SLIP44_ID
@@ -19,6 +19,8 @@ async def get_public_key(
 ) -> SolanaPublicKey:
     from trezor.messages import SolanaPublicKey
     from trezor.ui.layouts import show_pubkey
+
+    lock_manager.touch_idle_timer_if_ble()
 
     public_key = derive_public_key(keychain, msg.address_n)
 

--- a/core/src/apps/tezos/get_public_key.py
+++ b/core/src/apps/tezos/get_public_key.py
@@ -15,9 +15,11 @@ async def get_public_key(msg: TezosGetPublicKey, keychain: Keychain) -> TezosPub
     from trezor.messages import TezosPublicKey
     from trezor.ui.layouts import show_pubkey
 
-    from apps.common import paths, seed
+    from apps.common import lock_manager, paths, seed
 
     from . import helpers
+
+    lock_manager.touch_idle_timer_if_ble()
 
     await paths.validate_path(keychain, msg.address_n)
 

--- a/core/src/trezor/wire/thp/interface_context.py
+++ b/core/src/trezor/wire/thp/interface_context.py
@@ -16,7 +16,6 @@ if __debug__:
 
 if utils.USE_BLE:
     import trezorble as ble
-    from trezor.workflow import idle_timer
 
 if TYPE_CHECKING:
     from buffer_types import AnyBytes
@@ -183,10 +182,6 @@ class InterfaceContext:
                 yield self._read_box
 
             packet_len = yield self._read
-            if utils.USE_BLE and self._iface is ble.interface:
-                # prevent auto-lock while handling longer workflows on Bluetooth
-                idle_timer.touch()
-
             assert packet_len == self._iface.RX_PACKET_LEN
 
             self._iface.read(packet_buffer, 0)


### PR DESCRIPTION
Interim fix for #7522, proper fix likely needs cooperation with Suite. Related to #5847.

Only touch idle timer on messages used for account discovery (which IIUC are just `*GetPublicKey`?) instead of on every BLE packet.

Alternative implementation of this would keep explicit list of message types somewhere, not sure where's the best place.

<!--
For external contributors:
- Please open an issue before submitting a PR so we can discuss whether we want to proceed with it.

For core developers:
1. Initial PR setup
- Assign yourself to the PR.
- Add it to the "Firmware" project
  - Set Priority (match issue priority if it exists)
  - Set Team
  - Set Sprint (target release)

2. Development status
- Draft PRs: Set status to "In Progress"
- Final PRs: Set status to "Needs Review"

3. Post-merge status
- Testable: Set status to "Needs QA" and add a `Notes for QA` section with clear instructions on how to test the functionality.
- Not Testable: Set status to "Done (no QA)"
-->
