### PR TITLE
fix(core): remove obsolete commented out test

### DIFF
--- a/core/embed/rust/src/translations/translated_string.rs
+++ b/core/embed/rust/src/translations/translated_string.rs
@@ -50,19 +50,6 @@ impl TranslatedString {
     }
 }
 
-// #[cfg(test)]
-// mod tests {
-//     use super::TranslatedString;
-
-//     #[test]
-//     fn test_soundness() {
-//         let tr = TranslatedString::address__public_key;
-//         let mut opt: Option<&str> = None;
-//         tr.map_translated(|s| opt = Some(s));
-//         assert!(matches!(opt, Some("Address / Public key")));
-//     }
-// }
-
 #[cfg(test)]
 mod test {
     use super::*;


### PR DESCRIPTION
I noticed a commented out block of code in `core/embed/rust/src/translations/translated_string.rs`.

Claude says git blame shows it was added commented-out, hasn't been touched since and wouldn't work now. A working test is right below.
