### PR TITLE
allow interaction-less firmware even if the firmware body is corrupted

### DIFF
--- a/core/embed/projects/bootloader/.changelog.d/7737.changed
+++ b/core/embed/projects/bootloader/.changelog.d/7737.changed
@@ -1,0 +1,1 @@
+Host-initiated firmware upgrades now proceed without user interaction even when the installed firmware body is corrupted.

--- a/core/embed/projects/bootloader/main.c
+++ b/core/embed/projects/bootloader/main.c
@@ -650,7 +650,7 @@ int bootloader_main(void) {
       stay_in_bootloader = sectrue;
       break;
     case BOOT_COMMAND_INSTALL_UPGRADE:
-      if (fw.firmware_present == sectrue) {
+      if (fw.header_present == sectrue) {
         // continue without user interaction
         auto_upgrade = sectrue;
       }
@@ -716,7 +716,7 @@ int bootloader_main(void) {
 #endif
 
     if (fw.header_present == sectrue) {
-      if (auto_upgrade == sectrue && fw.firmware_present == sectrue) {
+      if (auto_upgrade == sectrue) {
         result = workflow_auto_update(&fw);
       } else {
         result = workflow_bootloader(&fw);


### PR DESCRIPTION
As a preparation for full PQ signature scheme, where fw body will get corrupted during the update by staging bootloader and nRF binaries into firmware area. This should not invalidate user consent with the update.