### PR TITLE
 assert the monotonic versions fit what monoctr can store

### DIFF
--- a/core/embed/projects/bootloader/version_check.c
+++ b/core/embed/projects/bootloader/version_check.c
@@ -23,6 +23,21 @@
 #include "model_version.h"
 #include "version_check.h"
 
+// The way monoctr encodes its counters, not the uint8_t the value travels in,
+// is what caps them at MONOCTR_MAX_VALUE. monoctr_write rejects anything above
+// that, so at runtime the version would simply fail to be stored -- and the
+// read-back checks below would then fail the ensure() and halt the device with
+// a downgrade-protection error on a perfectly good image. Catch it here
+// instead, at build time, for every model.
+_Static_assert(BOOTLOADER_MONOTONIC_VERSION <= MONOCTR_MAX_VALUE,
+               "BOOTLOADER_MONOTONIC_VERSION exceeds what monoctr can store");
+_Static_assert(FIRMWARE_MONOTONIC_VERSION <= MONOCTR_MAX_VALUE,
+               "FIRMWARE_MONOTONIC_VERSION exceeds what monoctr can store");
+#ifdef SECMON_MONOTONIC_VERSION  // only models with a secmon define it
+_Static_assert(SECMON_MONOTONIC_VERSION <= MONOCTR_MAX_VALUE,
+               "SECMON_MONOTONIC_VERSION exceeds what monoctr can store");
+#endif
+
 void ensure_bootloader_min_version(void) {
   monoctr_write(MONOCTR_BOOTLOADER_VERSION, BOOTLOADER_MONOTONIC_VERSION);
   uint8_t val = 0;


### PR DESCRIPTION
monoctr stores its counters UNARY -- value N is N written 16-byte blocks -- so the encoding, not the uint8_t the value travels in, is what caps them at MONOCTR_MAX_VALUE (63). A model that raises a monotonic version past that gets no build error; it fails later, at runtime, and confusingly:

  * the boardloader compares the boot header against the stored floor, cannot write the new value, and reports "BOOTLOADER DOWNGRADED" on a perfectly good image;
  * the firmware and secmon floors silently stop advancing, so anti-rollback quietly weakens instead of failing.

Assert all three at build time instead. Every model is well inside the limit today (highest is 3), so this only fixes the failure mode of a future bump.

version_check.c is the only place all three can be checked. The firmware and secmon values reach their images through header.S, where _Static_assert cannot go, and model_version.h is itself pulled into that assembly via version.h, so the checks cannot live there either. This translation unit both sees all three constants and owns the monoctr policy they feed.

SECMON_MONOTONIC_VERSION is guarded: only models with a secmon define it (4 of 9 today).

Verified by temporarily setting a model to 64 and confirming the build stops, and by building models with and without a secmon so both sides of the #ifdef compile.
