### PR TITLE
feat(core,python): support definitions version 2

### DIFF
--- a/core/embed/rust/src/definitions/constants.rs
+++ b/core/embed/rust/src/definitions/constants.rs
@@ -3,6 +3,7 @@ use crypto::ed25519;
 // Definition format versions, encoded on the wire as ASCII digit bytes.
 pub enum DefsVersion {
     V1,
+    V2,
 }
 
 impl DefsVersion {
@@ -10,12 +11,14 @@ impl DefsVersion {
     pub const fn threshold(self) -> u8 {
         match self {
             DefsVersion::V1 => 2,
+            DefsVersion::V2 => 1,
         }
     }
 
     pub const fn from_byte(byte: u8) -> Option<Self> {
         match byte {
             b'1' => Some(DefsVersion::V1),
+            b'2' => Some(DefsVersion::V2),
             _ => None,
         }
     }

--- a/core/src/apps/common/definitions_constants.py
+++ b/core/src/apps/common/definitions_constants.py
@@ -7,7 +7,7 @@ MAGIC = b"trzd"
 
 # Supported format versions of the definitions, encoded on the wire as
 # ASCII digit bytes ('1' = 0x31, '2' = 0x32, etc.).
-SUPPORTED_FORMAT_VERSIONS = (b"1",)
+SUPPORTED_FORMAT_VERSIONS = (b"1", b"2")
 
 # The public keys and signature thresholds for definitions verification
 # live in Rust (core/embed/rust/src/definitions/constants.rs).

--- a/core/src/apps/common/definitions_constants.py.mako
+++ b/core/src/apps/common/definitions_constants.py.mako
@@ -7,7 +7,7 @@ MAGIC = b"trzd"
 
 # Supported format versions of the definitions, encoded on the wire as
 # ASCII digit bytes ('1' = 0x31, '2' = 0x32, etc.).
-SUPPORTED_FORMAT_VERSIONS = (b"1",)
+SUPPORTED_FORMAT_VERSIONS = (b"1", b"2")
 
 # The public keys and signature thresholds for definitions verification
 # live in Rust (core/embed/rust/src/definitions/constants.rs).

--- a/core/tests/test_apps.common.definitions.py
+++ b/core/tests/test_apps.common.definitions.py
@@ -57,6 +57,14 @@ class TestDecodeDefinition(unittest.TestCase):
         proof, signature = sign_payload(payload, [], threshold=1)
         self.assertFailed(payload + proof + signature)
 
+    def test_v2_single_signature(self):
+        payload = make_payload(format_version=b"2")
+        proof, signature = sign_payload(payload, [], threshold=1)
+        self.assertEqual(
+            decode_definition(payload + proof + signature, EthereumNetworkInfo),
+            make_eth_network(),
+        )
+
     def test_missing_signature(self):
         payload = make_payload()
         proof, _ = sign_payload(payload, [])

--- a/docs/common/external-definitions.md
+++ b/docs/common/external-definitions.md
@@ -119,7 +119,7 @@ A Merkle tree is constructed from all binary definitions (see below) and its roo
 signed by the CoSi algorithm.
 
 The format version is bumped on backward incompatible change.
-For versions 1 and 2, the data structure is identical.
+For versions 1 and 2, the data structure is identical but the number of necessary signatures is changed from 2 to 1.
 
 The full format of the definition is as follows:
 

--- a/python/src/trezorlib/definitions.py
+++ b/python/src/trezorlib/definitions.py
@@ -40,8 +40,10 @@ DEFINITIONS_DEV_PUBLIC_KEYS = [
 
 # Number of CoSi signatures required by definition format version.
 # Version 1 requires 2 signatures.
+# Version 2 requires 1 signature.
 DEFINITIONS_SIGS_REQUIRED = {
     b"1": 2,
+    b"2": 1,
 }
 DEFINITIONS_PUBLIC_KEYS = [
     bytes.fromhex(key)


### PR DESCRIPTION
<!--
For external contributors:
- Please open an issue before submitting a PR so we can discuss whether we want to proceed with it.

For core developers:
1. Initial PR setup
- Assign yourself to the PR.
- Add it to the "Firmware" project
  - Set Priority (match issue priority if it exists)
  - Set Team
  - Set Sprint (target release)

2. Development status
- Draft PRs: Set status to "In Progress"
- Final PRs: Set status to "Needs Review"

3. Post-merge status
- Testable: Set status to "Needs QA" and add a `Notes for QA` section with clear instructions on how to test the functionality.
- Not Testable: Set status to "Done (no QA)"
-->
Closes #7514 

# Notes for QA
- wait for signed definitions v2 to be deployed
- properly test ETH token/chain external definitions on all Core models
- properly re-test clear signing (ERC-7730) external display formats
- similar to https://github.com/trezor/trezor-firmware/pull/7844 but for Core firmware