### PR TITLE
Backlight  level offset fix

### DIFF
--- a/core/embed/io/backlight/stm32u5/tps61062.c
+++ b/core/embed/io/backlight/stm32u5/tps61062.c
@@ -53,8 +53,8 @@
 // Rs (1 steps ~15.6mV)
 #define MAX_STEPS 31
 
-// DAC value after reset
-#define DEFAULT_STEP 16
+// DAC value after reset ((250mV - 15.6mV) / 15.6mV = 15)
+#define DEFAULT_STEP 15
 
 // Approximated default level after reset
 #define DEFAULT_LEVEL ((DEFAULT_STEP) * (BACKLIGHT_MAX_LEVEL) / (MAX_STEPS))


### PR DESCRIPTION
TPS61062 IC defaults to 250mV at feedback resistor after EN=1. The IC supports 32 levels (0-31) which physically represent 15.6mV, 2x15.6mV, ..., 32x15.6mV=500mV.  That means the default level is: (250mV - 15.6mV) / 15.6mV = 15.

Value 16 was wrong. Under certain conditions, it wasn't possible to reach the maximum backlight value.

<!--
For external contributors:
- Please open an issue before submitting a PR so we can discuss whether we want to proceed with it.

For core developers:
1. Initial PR setup
- Assign yourself to the PR.
- Add it to the "Firmware" project
  - Set Priority (match issue priority if it exists)
  - Set Team
  - Set Sprint (target release)

2. Development status
- Draft PRs: Set status to "In Progress"
- Final PRs: Set status to "Needs Review"

3. Post-merge status
- Testable: Set status to "Needs QA" and add a `Notes for QA` section with clear instructions on how to test the functionality.
- Not Testable: Set status to "Done (no QA)"
-->
