### PR TITLE
extract fw check from main, improve ui/layout separation

### DIFF
--- a/core/embed/projects/bootloader/bootui.c
+++ b/core/embed/projects/bootloader/bootui.c
@@ -27,8 +27,6 @@
 #include "rust_ui_bootloader.h"
 #include "version.h"
 
-#define TOIF_LENGTH(ptr) ((*(uint32_t *)((ptr) + 8)) + 12)
-
 // common shared functions
 
 #define VERSION_STRING_LEN 16
@@ -54,26 +52,19 @@ void ui_set_initial_setup(bool initial) { initial_setup = initial; }
 
 bool ui_get_initial_setup(void) { return initial_setup; }
 
-void ui_screen_boot(const vendor_header *const vhdr,
-                    const image_header *const hdr, int wait) {
-  bool show_string = ((vhdr->vtrust & VTRUST_NO_STRING) == 0);
-  const char *vendor_str = show_string ? vhdr->vstr : NULL;
-  const size_t vendor_str_len = show_string ? vhdr->vstr_len : 0;
-  bool red_screen = ((vhdr->vtrust & VTRUST_NO_RED) == 0);
-  uint32_t vimg_len = TOIF_LENGTH(vhdr->vimg);
-
-  screen_boot(red_screen, vendor_str, vendor_str_len, hdr->version, vhdr->vimg,
-              vimg_len, wait);
+void ui_screen_boot(const fw_ui_info_t *const info, int wait) {
+  screen_boot(info->no_red != sectrue, info->vendor_str, info->vendor_str_len,
+              info->version, info->vendor_img, info->vendor_img_len, wait);
 }
 
-uint32_t ui_screen_intro(const vendor_header *const vhdr,
-                         const image_header *const hdr, bool fw_ok) {
+uint32_t ui_screen_intro(const fw_ui_info_t *const info, bool fw_ok) {
   char bld_ver[VERSION_STRING_LEN];
   char ver_str[VERSION_STRING_LEN];
   format_ver(VERSION_UINT32, bld_ver, sizeof(bld_ver));
-  format_ver(hdr->version, ver_str, sizeof(ver_str));
+  format_ver(info->version, ver_str, sizeof(ver_str));
 
-  return screen_intro(bld_ver, vhdr->vstr, vhdr->vstr_len, ver_str, fw_ok);
+  return screen_intro(bld_ver, info->vendor_str, info->vendor_str_len, ver_str,
+                      fw_ok);
 }
 
 // install UI

--- a/core/embed/projects/bootloader/bootui.h
+++ b/core/embed/projects/bootloader/bootui.h
@@ -23,6 +23,7 @@
 
 #include <sec/image.h>
 
+#include "fw_check.h"
 #include "rust_ui_bootloader.h"
 
 #ifdef TREZOR_MODEL_T3W1
@@ -42,11 +43,9 @@
 //   0 do not show any message
 //   > 0 show a message like "starting in %d s"
 //   < 0 show a message like "press button to continue"
-void ui_screen_boot(const vendor_header* const vhdr,
-                    const image_header* const hdr, int wait);
+void ui_screen_boot(const fw_ui_info_t* const info, int wait);
 
-uint32_t ui_screen_intro(const vendor_header* const vhdr,
-                         const image_header* const hdr, bool fw_ok);
+uint32_t ui_screen_intro(const fw_ui_info_t* const info, bool fw_ok);
 
 confirm_result_t ui_screen_install_confirm(const vendor_header* const vhdr,
                                            const image_header* const hdr,
@@ -54,6 +53,7 @@ confirm_result_t ui_screen_install_confirm(const vendor_header* const vhdr,
                                            secbool is_newvendor,
                                            secbool is_newinstall,
                                            int version_cmp);
+
 void ui_screen_install_start(bool wireless);
 void ui_screen_install_progress_erase(int pos, int len, bool wireless);
 void ui_screen_install_progress_upload(int pos, bool wireless);

--- a/core/embed/projects/bootloader/fw_check.c
+++ b/core/embed/projects/bootloader/fw_check.c
@@ -32,7 +32,7 @@
 #include "emulator.h"
 #endif
 
-secbool check_vendor_header_lock(const vendor_header *vhdr) {
+secbool check_vendor_header_lock(const vendor_header *const vhdr) {
   uint8_t lock[FLASH_OTP_BLOCK_SIZE];
   ensure(flash_otp_read(FLASH_OTP_BLOCK_VENDOR_HEADER_LOCK, 0, lock,
                         FLASH_OTP_BLOCK_SIZE),

--- a/core/embed/projects/bootloader/fw_check.c
+++ b/core/embed/projects/bootloader/fw_check.c
@@ -49,9 +49,10 @@ secbool check_vendor_header_lock(const vendor_header *vhdr) {
   return sectrue * (0 == memcmp(lock, hash, 32));
 }
 
-void fw_check(fw_info_t *fw_info) {
+void fw_check(fw_check_info_t *fw_info) {
   memset(fw_info, 0, sizeof(*fw_info));
 
+  vendor_header vhdr = {0};
   const image_header *hdr = NULL;
 
   // detect whether the device contains a valid firmware
@@ -65,22 +66,21 @@ void fw_check(fw_info_t *fw_info) {
   volatile secbool secmon_valid = secfalse;
 
   vhdr_present = read_vendor_header((const uint8_t *)FIRMWARE_START,
-                                    VENDOR_HEADER_MAX_SIZE, &fw_info->vhdr);
+                                    VENDOR_HEADER_MAX_SIZE, &vhdr);
 
   if (sectrue == vhdr_present) {
-    vhdr_keys_ok = check_vendor_header_keys(&fw_info->vhdr);
+    vhdr_keys_ok = check_vendor_header_keys(&vhdr);
   }
 
   if (sectrue == vhdr_keys_ok) {
-    vhdr_lock_ok = check_vendor_header_lock(&fw_info->vhdr);
+    vhdr_lock_ok = check_vendor_header_lock(&vhdr);
   }
 
   if (sectrue == vhdr_lock_ok) {
     hdr = read_image_header(
-        (const uint8_t *)(size_t)(FIRMWARE_START + fw_info->vhdr.hdrlen),
+        (const uint8_t *)(size_t)(FIRMWARE_START + vhdr.hdrlen),
         FIRMWARE_IMAGE_MAGIC, FIRMWARE_MAXSIZE);
-    if (hdr ==
-        (const image_header *)(size_t)(FIRMWARE_START + fw_info->vhdr.hdrlen)) {
+    if (hdr == (const image_header *)(size_t)(FIRMWARE_START + vhdr.hdrlen)) {
       img_hdr_ok = sectrue;
     }
   }
@@ -89,8 +89,8 @@ void fw_check(fw_info_t *fw_info) {
   }
 
   if (sectrue == model_ok) {
-    signatures_ok = check_image_header_sig(
-        hdr, fw_info->vhdr.vsig_m, fw_info->vhdr.vsig_n, fw_info->vhdr.vpub);
+    signatures_ok =
+        check_image_header_sig(hdr, vhdr.vsig_m, vhdr.vsig_n, vhdr.vpub);
   }
 
   if (sectrue == signatures_ok) {
@@ -102,8 +102,8 @@ void fw_check(fw_info_t *fw_info) {
   }
 
 #ifdef USE_SECMON_VERIFICATION
-  size_t secmon_start = (size_t)IMAGE_CODE_ALIGN(
-      FIRMWARE_START + fw_info->vhdr.hdrlen + IMAGE_HEADER_SIZE);
+  size_t secmon_start = (size_t)IMAGE_CODE_ALIGN(FIRMWARE_START + vhdr.hdrlen +
+                                                 IMAGE_HEADER_SIZE);
 
   const secmon_header_t *secmon_hdr =
       read_secmon_header((const uint8_t *)secmon_start, FIRMWARE_MAXSIZE);
@@ -148,9 +148,121 @@ void fw_check(fw_info_t *fw_info) {
   if (sectrue == secmon_valid) {
     ensure_firmware_min_version(hdr->monotonic);
     fw_info->firmware_present = check_image_contents(
-        hdr, IMAGE_HEADER_SIZE + fw_info->vhdr.hdrlen, &FIRMWARE_AREA);
+        hdr, IMAGE_HEADER_SIZE + vhdr.hdrlen, &FIRMWARE_AREA);
     fw_info->firmware_present_backup = fw_info->firmware_present;
   }
 
-  fw_info->hdr = hdr;
+  // Layout-agnostic display info for the bootloader intro screen.
+  if (hdr != NULL) {
+    fw_info->ui.version = hdr->version;
+    fw_info->ui.vendor_str = vhdr.vstr;
+    fw_info->ui.vendor_str_len = vhdr.vstr_len;
+    fw_info->ui.vendor_img = vhdr.vimg;
+    fw_info->ui.vendor_img_len = vhdr.vimg_len;
+    fw_info->ui.no_red =
+        ((vhdr.vtrust & VTRUST_NO_RED) == VTRUST_NO_RED) * sectrue;
+  }
+}
+
+void fw_run_prepare(fw_run_info_t *info) {
+  memset(info, 0, sizeof(*info));
+
+  vendor_header vhdr = {0};
+
+  ensure(read_vendor_header((const uint8_t *)FIRMWARE_START,
+                            VENDOR_HEADER_MAX_SIZE, &vhdr),
+         "Firmware is corrupted");
+
+  ensure(check_vendor_header_keys(&vhdr), "Firmware is corrupted");
+
+  ensure(check_vendor_header_lock(&vhdr), "Unauthorized vendor keys");
+
+  const image_header *hdr =
+      read_image_header((const uint8_t *)(size_t)(FIRMWARE_START + vhdr.hdrlen),
+                        FIRMWARE_IMAGE_MAGIC, FIRMWARE_MAXSIZE);
+
+  ensure(hdr == (const image_header *)(size_t)(FIRMWARE_START + vhdr.hdrlen)
+             ? sectrue
+             : secfalse,
+         "Firmware is corrupted");
+
+  ensure(check_image_model(hdr), "Wrong firmware model");
+
+  ensure(check_image_header_sig(hdr, vhdr.vsig_m, vhdr.vsig_n, vhdr.vpub),
+         "Firmware is corrupted");
+
+  ensure(check_firmware_min_version(hdr->monotonic),
+         "Firmware downgrade protection");
+
+  ensure(check_image_contents(hdr, IMAGE_HEADER_SIZE + vhdr.hdrlen,
+                              &FIRMWARE_AREA),
+         "Firmware is corrupted");
+
+  size_t secmon_code_offset = 0;
+
+#ifdef USE_SECMON_VERIFICATION
+  size_t secmon_start = (size_t)IMAGE_CODE_ALIGN(FIRMWARE_START + vhdr.hdrlen +
+                                                 IMAGE_HEADER_SIZE);
+  const secmon_header_t *secmon_hdr =
+      read_secmon_header((const uint8_t *)secmon_start, FIRMWARE_MAXSIZE);
+
+  if (secmon_hdr != NULL) {
+    secmon_code_offset = IMAGE_CODE_ALIGN(SECMON_HEADER_SIZE);
+  }
+
+  ensure((secmon_hdr != NULL) * sectrue, "Secmon header not found");
+
+  ensure(check_secmon_model(secmon_hdr), "Wrong secmon model");
+
+  ensure(check_secmon_header_sig(secmon_hdr), "Invalid secmon signature");
+
+  ensure(check_secmon_min_version(secmon_hdr->monotonic),
+         "Secmon downgrade protection");
+
+  ensure(check_secmon_contents(secmon_hdr, secmon_start - FIRMWARE_START,
+                               &FIRMWARE_AREA),
+         "Secmon is corrupted");
+#endif
+
+  // ensure minimal versions are properly stored for both firmware and secmon
+  ensure_firmware_min_version(hdr->monotonic);
+#ifdef USE_SECMON_VERIFICATION
+  ensure_secmon_min_version(secmon_hdr->monotonic);
+#endif
+
+#ifdef USE_SECRET
+  info->provisioning_access =
+      ((vhdr.vtrust & (VTRUST_ALLOW_PROVISIONING | VTRUST_SECRET_MASK)) ==
+       (VTRUST_SECRET_ALLOW | VTRUST_ALLOW_PROVISIONING)) *
+      sectrue;
+
+  info->secret_run_access =
+      ((vhdr.vtrust & VTRUST_SECRET_MASK) == VTRUST_SECRET_ALLOW) * sectrue;
+#endif
+
+  // Warn unless all warnings are disabled in the VTRUST flags. The warning
+  // details are resolved here into the layout-agnostic fw_ui_info_t so the UI
+  // never touches a vendor header.
+  info->no_warning =
+      ((vhdr.vtrust & VTRUST_NO_WARNING) == VTRUST_NO_WARNING) * sectrue;
+  // The delay is encoded in bitwise complement form.
+  info->warn_delay = (vhdr.vtrust & VTRUST_WAIT_MASK) ^ VTRUST_WAIT_MASK;
+  info->no_click =
+      ((vhdr.vtrust & VTRUST_NO_CLICK) == VTRUST_NO_CLICK) * sectrue;
+
+  bool show_string = (vhdr.vtrust & VTRUST_NO_STRING) == 0;
+  info->ui.version = hdr->version;
+  info->ui.vendor_str = show_string ? vhdr.vstr : NULL;
+  info->ui.vendor_str_len = show_string ? vhdr.vstr_len : 0;
+  info->ui.vendor_img = vhdr.vimg;
+  info->ui.vendor_img_len = vhdr.vimg_len;
+  info->ui.no_red = ((vhdr.vtrust & VTRUST_NO_RED) == VTRUST_NO_RED) * sectrue;
+
+  info->allow_unlimited_run = ((vhdr.vtrust & VTRUST_ALLOW_UNLIMITED_RUN) ==
+                               VTRUST_ALLOW_UNLIMITED_RUN) *
+                              sectrue;
+
+  info->entry_address =
+      IMAGE_CODE_ALIGN(FIRMWARE_START + vhdr.hdrlen + IMAGE_HEADER_SIZE) +
+      secmon_code_offset;
 }

--- a/core/embed/projects/bootloader/fw_check.h
+++ b/core/embed/projects/bootloader/fw_check.h
@@ -24,25 +24,40 @@
 #include <sec/image.h>
 
 /**
+ * @brief Layout-agnostic firmware information for the screens that show it.
+ *
+ * Filled from whatever the installed firmware layout provides (the vendor +
+ * image headers). Keeps the `ui_*` layer (the vendor warning shown before
+ * running the firmware, and the bootloader intro) independent of the header
+ * format, so it never touches a scheme-specific header.
+ */
+typedef struct {
+  uint32_t version;          /**< firmware version (major|minor<<8|...) */
+  const char *vendor_str;    /**< vendor name; NULL to hide it */
+  size_t vendor_str_len;     /**< length of vendor_str */
+  const uint8_t *vendor_img; /**< vendor logo (TOIF); NULL for none */
+  uint32_t vendor_img_len;   /**< length of vendor_img, validated at parse */
+  secbool no_red;            /**< sectrue = black background, not the red
+                                  warning one (untrusted vendor) */
+} fw_ui_info_t;
+
+/**
  * @brief Firmware information collected by the bootloader when validating
  * images present in flash.
  *
  * This structure is filled by `fw_check()` and then used by the bootloader to
- * decide whether it can safely boot the firmware image.
+ * decide whether it can safely run the installed firmware, or must stay in the
+ * bootloader instead.
  */
 typedef struct {
-  vendor_header vhdr; /**< Parsed vendor header copied from flash.
-                           Contains vendor/product identifiers,
-                           versioning and policy flags (e.g.,
-                           lock, minimum versions). */
+  fw_ui_info_t ui; /**< Layout-agnostic display info (version, vendor). */
 
-  const image_header *hdr; /**< Pointer to the validated image header of
-                                the selected firmware (primary or
-                                backup). NULL if no valid header was
-                                found. */
-
-  volatile secbool header_present; /**< True if a header structure was
-                               found and passed basic checks. */
+  volatile secbool header_present; /**< True if the device is provisioned, i.e.
+                               a firmware is present with valid metadata to show
+                               (vendor/version) -- even if its body is corrupt.
+                               Drives menu-vs-empty-device routing, the Features
+                               reply, and the storage-wipe decision. (A valid
+                               signed firmware header.) */
 
   volatile secbool firmware_present; /**< True if a valid, bootable
 firmware image is present. */
@@ -50,7 +65,7 @@ firmware image is present. */
   volatile secbool firmware_present_backup; /**< True if a valid, bootable
                                         firmware image is present - backup for
                                       glitch protection. */
-} fw_info_t;
+} fw_check_info_t;
 
 /**
  * @brief Verify whether the vendor header is the same as the locked version.
@@ -72,4 +87,31 @@ secbool check_vendor_header_lock(const vendor_header *vhdr);
  *                provided by the caller and remain valid for subsequent boot
  *                decisions.
  */
-void fw_check(fw_info_t *fw_info);
+void fw_check(fw_check_info_t *fw_info);
+
+/**
+ * @brief Everything `real_jump_to_firmware()` needs to hand control to the
+ * installed firmware, resolved by the layout-specific verification/policy code.
+ */
+typedef struct {
+  uint32_t entry_address;      /**< vector table to jump to */
+  secbool secret_run_access;   /**< grant the firmware secret access */
+  secbool provisioning_access; /**< grant device-provisioning access */
+  secbool allow_unlimited_run; /**< if not sectrue, IWDG limits runtime */
+  secbool no_warning;          /**< sectrue = skip the boot warning */
+  int warn_delay;              /**< seconds to wait on the warning screen */
+  secbool no_click;            /**< sectrue = no click to leave the warning */
+  fw_ui_info_t ui;             /**< layout-agnostic info for the warning */
+} fw_run_info_t;
+
+/**
+ * @brief Verify the installed firmware and resolve the policy for running it.
+ *
+ * Performs the full image verification and downgrade check, then fills `info`
+ * with the entry point, secret/provisioning access, runtime-limit and warning
+ * decisions. Fatal-errors (via `ensure`) on any verification or downgrade
+ * failure, so on return the firmware is authentic and bootable.
+ *
+ * Implemented by the layout-specific verification code (fw_check.c).
+ */
+void fw_run_prepare(fw_run_info_t *info);

--- a/core/embed/projects/bootloader/fw_check.h
+++ b/core/embed/projects/bootloader/fw_check.h
@@ -74,7 +74,7 @@ firmware image is present. */
  * @return sectrue when the vendor header is the same or there is no lock;
  *         secfalse otherwise.
  */
-secbool check_vendor_header_lock(const vendor_header *vhdr);
+secbool __wur check_vendor_header_lock(const vendor_header *const vhdr);
 
 /**
  * @brief Perform comprehensive verification of the firmware image available

--- a/core/embed/projects/bootloader/main.c
+++ b/core/embed/projects/bootloader/main.c
@@ -415,101 +415,34 @@ cleanup:
 #endif
 
 void real_jump_to_firmware(void) {
-  const image_header *hdr = NULL;
-  vendor_header vhdr = {0};
+  // Verification + boot-policy resolution is layout-specific and lives behind
+  // fw_run_prepare (fw_check.c), so this stays layout-agnostic.
+  fw_run_info_t info = {0};
+  fw_run_prepare(&info);
 
-  ensure(read_vendor_header((const uint8_t *)FIRMWARE_START,
-                            VENDOR_HEADER_MAX_SIZE, &vhdr),
-         "Firmware is corrupted");
-
-  ensure(check_vendor_header_keys(&vhdr), "Firmware is corrupted");
-
-  ensure(check_vendor_header_lock(&vhdr), "Unauthorized vendor keys");
-
-  hdr =
-      read_image_header((const uint8_t *)(size_t)(FIRMWARE_START + vhdr.hdrlen),
-                        FIRMWARE_IMAGE_MAGIC, FIRMWARE_MAXSIZE);
-
-  ensure(hdr == (const image_header *)(size_t)(FIRMWARE_START + vhdr.hdrlen)
-             ? sectrue
-             : secfalse,
-         "Firmware is corrupted");
-
-  ensure(check_image_model(hdr), "Wrong firmware model");
-
-  ensure(check_image_header_sig(hdr, vhdr.vsig_m, vhdr.vsig_n, vhdr.vpub),
-         "Firmware is corrupted");
-
-  ensure(check_firmware_min_version(hdr->monotonic),
-         "Firmware downgrade protection");
-
-  ensure(check_image_contents(hdr, IMAGE_HEADER_SIZE + vhdr.hdrlen,
-                              &FIRMWARE_AREA),
-         "Firmware is corrupted");
-
-  size_t secmon_code_offset = 0;
-
-#ifdef USE_SECMON_VERIFICATION
-  size_t secmon_start = (size_t)IMAGE_CODE_ALIGN(FIRMWARE_START + vhdr.hdrlen +
-                                                 IMAGE_HEADER_SIZE);
-  const secmon_header_t *secmon_hdr =
-      read_secmon_header((const uint8_t *)secmon_start, FIRMWARE_MAXSIZE);
-
-  if (secmon_hdr != NULL) {
-    secmon_code_offset = IMAGE_CODE_ALIGN(SECMON_HEADER_SIZE);
-  }
-
-  ensure((secmon_hdr != NULL) * sectrue, "Secmon header not found");
-
-  ensure(check_secmon_model(secmon_hdr), "Wrong secmon model");
-
-  ensure(check_secmon_header_sig(secmon_hdr), "Invalid secmon signature");
-
-  ensure(check_secmon_min_version(secmon_hdr->monotonic),
-         "Secmon downgrade protection");
-
-  ensure(check_secmon_contents(secmon_hdr, secmon_start - FIRMWARE_START,
-                               &FIRMWARE_AREA),
-         "Secmon is corrupted");
-#endif
-
-  // ensure minimal versions are properly stored for both firmware and secmon
-  ensure_firmware_min_version(hdr->monotonic);
-#ifdef USE_SECMON_VERIFICATION
-  ensure_secmon_min_version(secmon_hdr->monotonic);
-#endif
-
+  // Must run before secret_prepare_fw(), which disables access to the secret
+  // storage the certificate is read from.
 #ifdef USE_MCU_ATTESTATION
   pass_mcu_attestation_cert();
 #endif
 
 #ifdef USE_SECRET
-  secbool provisioning_access =
-      ((vhdr.vtrust & (VTRUST_ALLOW_PROVISIONING | VTRUST_SECRET_MASK)) ==
-       (VTRUST_SECRET_ALLOW | VTRUST_ALLOW_PROVISIONING)) *
-      sectrue;
-
-  secbool secret_run_access =
-      ((vhdr.vtrust & VTRUST_SECRET_MASK) == VTRUST_SECRET_ALLOW) * sectrue;
-
-  secret_prepare_fw(secret_run_access, provisioning_access);
+  secret_prepare_fw(info.secret_run_access, info.provisioning_access);
 #endif
 
-  // if all warnings are disabled in VTRUST flags then skip the procedure
-  if ((vhdr.vtrust & VTRUST_NO_WARNING) != VTRUST_NO_WARNING) {
+  if (info.no_warning != sectrue) {
 #ifdef LAZY_DISPLAY_INIT
     display_touch_init(secfalse, NULL);
 #endif
 
     ui_fadeout();
-    ui_screen_boot(&vhdr, hdr, 0);
+    ui_screen_boot(&info.ui, 0);
     ui_fadein();
 
-    // The delay is encoded in bitwise complement form.
-    int delay = (vhdr.vtrust & VTRUST_WAIT_MASK) ^ VTRUST_WAIT_MASK;
+    int delay = info.warn_delay;
     if (delay > 1) {
       while (delay > 0) {
-        ui_screen_boot(&vhdr, hdr, delay);
+        ui_screen_boot(&info.ui, delay);
         hal_delay(1000);
         delay--;
       }
@@ -517,8 +450,8 @@ void real_jump_to_firmware(void) {
       hal_delay(1000);
     }
 
-    if ((vhdr.vtrust & VTRUST_NO_CLICK) == 0) {
-      ui_screen_boot(&vhdr, hdr, -1);
+    if (info.no_click != sectrue) {
+      ui_screen_boot(&info.ui, -1);
       ui_click();
     }
 
@@ -530,10 +463,7 @@ void real_jump_to_firmware(void) {
   }
 
 #ifdef USE_IWDG
-  secbool allow_unlimited_run = ((vhdr.vtrust & VTRUST_ALLOW_UNLIMITED_RUN) ==
-                                 VTRUST_ALLOW_UNLIMITED_RUN) *
-                                sectrue;
-  if (sectrue != allow_unlimited_run) {
+  if (sectrue != info.allow_unlimited_run) {
     iwdg_start(60 * 60);  // 1 hour runtime limit
   }
 #endif
@@ -542,11 +472,7 @@ void real_jump_to_firmware(void) {
 
   system_deinit();
 
-  uint32_t vectbl_addr =
-      IMAGE_CODE_ALIGN(FIRMWARE_START + vhdr.hdrlen + IMAGE_HEADER_SIZE) +
-      secmon_code_offset;
-
-  jump_to_next_stage(vectbl_addr, startup_args_export());
+  jump_to_next_stage(info.entry_address, startup_args_export());
 }
 
 __attribute__((noreturn)) void reboot_with_fade(void) {
@@ -631,7 +557,7 @@ int bootloader_main(void) {
 
   volatile secbool auto_upgrade = secfalse;
 
-  fw_info_t fw;
+  fw_check_info_t fw;
   fw_check(&fw);
 
 #if PRODUCTION && !defined STM32U5

--- a/core/embed/projects/bootloader/protob/protob.c
+++ b/core/embed/projects/bootloader/protob/protob.c
@@ -64,7 +64,7 @@ secbool send_msg_success(protob_io_t *iface, const char *msg) {
   return MSG_SEND(Success);
 }
 
-secbool send_msg_features(protob_io_t *iface, const fw_info_t *fw) {
+secbool send_msg_features(protob_io_t *iface, const fw_check_info_t *fw) {
   MSG_SEND_INIT(Features);
   MSG_SEND_ASSIGN_STRING(vendor, "trezor.io");
   MSG_SEND_ASSIGN_REQUIRED_VALUE(major_version, VERSION_MAJOR);
@@ -74,13 +74,16 @@ secbool send_msg_features(protob_io_t *iface, const fw_info_t *fw) {
   MSG_SEND_ASSIGN_VALUE(bootloader_mode, true);
   MSG_SEND_ASSIGN_STRING(model, MODEL_NAME);
   MSG_SEND_ASSIGN_STRING(internal_model, MODEL_INTERNAL_NAME);
-  if (fw != NULL && fw->hdr != NULL && fw->header_present == sectrue) {
+  if (fw != NULL && fw->header_present == sectrue) {
     MSG_SEND_ASSIGN_VALUE(firmware_present, true);
-    MSG_SEND_ASSIGN_VALUE(fw_major, (fw->hdr->version & 0xFF));
-    MSG_SEND_ASSIGN_VALUE(fw_minor, ((fw->hdr->version >> 8) & 0xFF));
-    MSG_SEND_ASSIGN_VALUE(fw_patch, ((fw->hdr->version >> 16) & 0xFF));
-    MSG_SEND_ASSIGN_VALUE(fw_build, ((fw->hdr->version >> 24) & 0xFF));
-    MSG_SEND_ASSIGN_STRING_LEN(fw_vendor, fw->vhdr.vstr, fw->vhdr.vstr_len);
+    MSG_SEND_ASSIGN_VALUE(fw_major, (fw->ui.version & 0xFF));
+    MSG_SEND_ASSIGN_VALUE(fw_minor, ((fw->ui.version >> 8) & 0xFF));
+    MSG_SEND_ASSIGN_VALUE(fw_patch, ((fw->ui.version >> 16) & 0xFF));
+    MSG_SEND_ASSIGN_VALUE(fw_build, ((fw->ui.version >> 24) & 0xFF));
+    if (fw->ui.vendor_str != NULL) {
+      MSG_SEND_ASSIGN_STRING_LEN(fw_vendor, fw->ui.vendor_str,
+                                 fw->ui.vendor_str_len);
+    }
     MSG_SEND_ASSIGN_VALUE(firmware_corrupted, sectrue != fw->firmware_present);
   } else {
     MSG_SEND_ASSIGN_VALUE(firmware_present, false);

--- a/core/embed/projects/bootloader/protob/protob.h
+++ b/core/embed/projects/bootloader/protob/protob.h
@@ -42,7 +42,7 @@ typedef struct {
 
 secbool send_user_abort(protob_io_t *iface, const char *msg);
 
-secbool send_msg_features(protob_io_t *iface, const fw_info_t *fw);
+secbool send_msg_features(protob_io_t *iface, const fw_check_info_t *fw);
 
 secbool send_msg_failure(protob_io_t *iface, FailureType type, const char *msg);
 

--- a/core/embed/projects/bootloader/workflow/debuglink.c
+++ b/core/embed/projects/bootloader/workflow/debuglink.c
@@ -160,7 +160,7 @@ static debuglink_result_t debuglink_process_record_screen(protob_io_t *io) {
 }
 
 debuglink_result_t debuglink_process(void) {
-  fw_info_t fw = {0};
+  fw_check_info_t fw = {0};
   fw_check(&fw);
 
   debuglink_result_t res = DEBUGLINK_RESULT_NONE;

--- a/core/embed/projects/bootloader/workflow/wf_auto_update.c
+++ b/core/embed/projects/bootloader/workflow/wf_auto_update.c
@@ -29,7 +29,7 @@
 #include "wire/wire_iface_usb.h"
 #include "workflow.h"
 
-workflow_result_t workflow_auto_update(const fw_info_t *fw) {
+workflow_result_t workflow_auto_update(const fw_check_info_t *fw) {
   ui_set_initial_setup(true);
 
   uint32_t ui_result = CONNECT_CANCEL;

--- a/core/embed/projects/bootloader/workflow/wf_ble_pairing_request.c
+++ b/core/embed/projects/bootloader/workflow/wf_ble_pairing_request.c
@@ -44,7 +44,7 @@ static bool encode_pairing_code(uint32_t code, uint8_t *outbuf) {
   return true;
 }
 
-workflow_result_t workflow_ble_pairing_request(const fw_info_t *fw) {
+workflow_result_t workflow_ble_pairing_request(const fw_check_info_t *fw) {
   ble_set_enabled(true);
 
   if (!ble_iface_start_pairing()) {
@@ -122,7 +122,7 @@ workflow_result_t workflow_ble_pairing_request(const fw_info_t *fw) {
   return WF_OK_PAIRING_COMPLETED;
 }
 
-workflow_result_t workflow_wireless_setup(const fw_info_t *fw,
+workflow_result_t workflow_wireless_setup(const fw_check_info_t *fw,
                                           protob_ios_t *ios) {
   ble_set_enabled(true);
 

--- a/core/embed/projects/bootloader/workflow/wf_bootloader.c
+++ b/core/embed/projects/bootloader/workflow/wf_bootloader.c
@@ -39,7 +39,7 @@
 #include "rust_ui_bootloader.h"
 #include "workflow.h"
 
-workflow_result_t workflow_menu(const fw_info_t* fw, protob_ios_t* ios) {
+workflow_result_t workflow_menu(const fw_check_info_t* fw, protob_ios_t* ios) {
   while (true) {
     uint32_t ui_result = 0;
     workflow_result_t result =
@@ -100,9 +100,9 @@ typedef enum {
 
 // Each handler returns either a next screen, or SCREEN_DONE and an out‑param
 // for the result.
-static screen_t handle_intro(const fw_info_t* fw,
+static screen_t handle_intro(const fw_check_info_t* fw,
                              workflow_result_t* out_result) {
-  intro_result_t ui = ui_screen_intro(&fw->vhdr, fw->hdr, fw->firmware_present);
+  intro_result_t ui = ui_screen_intro(&fw->ui, fw->firmware_present);
   if (ui == INTRO_MENU) return SCREEN_MENU;
   if (ui == INTRO_HOST) return SCREEN_WAIT_FOR_HOST;
   // no other valid INTRO result -> fatal
@@ -110,7 +110,7 @@ static screen_t handle_intro(const fw_info_t* fw,
   return SCREEN_DONE;
 }
 
-static screen_t handle_menu(const fw_info_t* fw,
+static screen_t handle_menu(const fw_check_info_t* fw,
                             workflow_result_t* out_result) {
   workflow_result_t res = workflow_menu(fw, NULL);
   switch (res) {
@@ -124,7 +124,7 @@ static screen_t handle_menu(const fw_info_t* fw,
   }
 }
 
-static screen_t handle_wait_for_host(const fw_info_t* fw,
+static screen_t handle_wait_for_host(const fw_check_info_t* fw,
                                      workflow_result_t* out_result) {
   uint32_t ui_res = 0;
 
@@ -201,7 +201,7 @@ static screen_t handle_wait_for_host(const fw_info_t* fw,
   return next_screen;
 }
 
-workflow_result_t workflow_bootloader(const fw_info_t* fw) {
+workflow_result_t workflow_bootloader(const fw_check_info_t* fw) {
   ui_set_initial_setup(false);
   screen_t screen = SCREEN_INTRO;
   workflow_result_t final_res = WF_ERROR_FATAL;

--- a/core/embed/projects/bootloader/workflow/wf_get_features.c
+++ b/core/embed/projects/bootloader/workflow/wf_get_features.c
@@ -24,7 +24,7 @@
 #include "workflow.h"
 
 workflow_result_t workflow_get_features(protob_io_t *iface,
-                                        const fw_info_t *fw) {
+                                        const fw_check_info_t *fw) {
   GetFeatures msg_recv;
   recv_msg_get_features(iface, &msg_recv);
   send_msg_features(iface, fw);

--- a/core/embed/projects/bootloader/workflow/wf_host_control.c
+++ b/core/embed/projects/bootloader/workflow/wf_host_control.c
@@ -47,7 +47,7 @@ static workflow_result_t bootloader_process_comm(wire_iface_t *wire_iface) {
     return WF_OK;
   }
 
-  fw_info_t fw;
+  fw_check_info_t fw;
   memset(&fw, 0, sizeof(fw));
 
   switch (msg_id) {

--- a/core/embed/projects/bootloader/workflow/wf_initialize.c
+++ b/core/embed/projects/bootloader/workflow/wf_initialize.c
@@ -23,7 +23,8 @@
 #include "protob.h"
 #include "workflow.h"
 
-workflow_result_t workflow_initialize(protob_io_t *iface, const fw_info_t *fw) {
+workflow_result_t workflow_initialize(protob_io_t *iface,
+                                      const fw_check_info_t *fw) {
   Initialize msg_recv;
   recv_msg_initialize(iface, &msg_recv);
   send_msg_features(iface, fw);

--- a/core/embed/projects/bootloader/workflow/workflow.h
+++ b/core/embed/projects/bootloader/workflow/workflow.h
@@ -36,26 +36,27 @@ workflow_result_t workflow_unlock_bootloader(protob_io_t *iface);
 
 workflow_result_t workflow_ping(protob_io_t *iface);
 
-workflow_result_t workflow_initialize(protob_io_t *iface, const fw_info_t *fw);
+workflow_result_t workflow_initialize(protob_io_t *iface,
+                                      const fw_check_info_t *fw);
 
 workflow_result_t workflow_get_features(protob_io_t *iface,
-                                        const fw_info_t *fw);
+                                        const fw_check_info_t *fw);
 
-workflow_result_t workflow_menu(const fw_info_t *fw, protob_ios_t *ios);
+workflow_result_t workflow_menu(const fw_check_info_t *fw, protob_ios_t *ios);
 
-workflow_result_t workflow_bootloader(const fw_info_t *fw);
+workflow_result_t workflow_bootloader(const fw_check_info_t *fw);
 
 workflow_result_t workflow_empty_device(void);
 
-workflow_result_t workflow_auto_update(const fw_info_t *fw);
+workflow_result_t workflow_auto_update(const fw_check_info_t *fw);
 
 #ifdef USE_BLE
 
 bool wipe_bonds(protob_io_t *iface);
 
-workflow_result_t workflow_ble_pairing_request(const fw_info_t *fw);
+workflow_result_t workflow_ble_pairing_request(const fw_check_info_t *fw);
 
-workflow_result_t workflow_wireless_setup(const fw_info_t *fw,
+workflow_result_t workflow_wireless_setup(const fw_check_info_t *fw,
                                           protob_ios_t *ios);
 #endif
 

--- a/core/embed/sec/image/image.c
+++ b/core/embed/sec/image/image.c
@@ -274,6 +274,9 @@ secbool check_secmon_contents(const secmon_header_t *const hdr,
 
 #endif  // USE_SECMON_VERIFICATION
 
+// TOIF preamble: magic(4) + width(2) + height(2) + payload length(4).
+#define TOIF_PREAMBLE_SIZE 12
+
 secbool __wur read_vendor_header(const uint8_t *const data, size_t data_size,
                                  vendor_header *const vhdr) {
   // Need at least 23 bytes to safely read all fixed-offset fields through
@@ -310,10 +313,12 @@ secbool __wur read_vendor_header(const uint8_t *const data, size_t data_size,
     return secfalse;
   }
 
+  const uint32_t body_len = vhdr->hdrlen - IMAGE_SIG_SIZE;
+
   // The public-key array and the vstr_len byte that follows it must all fit
-  // within the header body (the region before the trailing signature).
+  // within the header body.
   uint32_t vstr_len_offset = 32 + (uint32_t)vhdr->vsig_n * 32;
-  if (vstr_len_offset >= vhdr->hdrlen - IMAGE_SIG_SIZE) {
+  if (vstr_len_offset >= body_len) {
     return secfalse;
   }
 
@@ -326,11 +331,38 @@ secbool __wur read_vendor_header(const uint8_t *const data, size_t data_size,
 
   memcpy(&vhdr->vstr_len, data + 32 + vhdr->vsig_n * 32, 1);
 
+  // check that the vendor string fits within the header body
+  if ((uint32_t)vhdr->vstr_len > body_len - (vstr_len_offset + 1)) {
+    return secfalse;
+  }
+
   vhdr->vstr = (const char *)(data + 32 + vhdr->vsig_n * 32 + 1);
 
-  vhdr->vimg = data + 32 + vhdr->vsig_n * 32 + 1 + vhdr->vstr_len;
-  // align to 4 bytes
-  vhdr->vimg += (-(uintptr_t)vhdr->vimg) & 3;
+  // Vendor logo (TOIF), 4-byte aligned, immediately after the vendor string.
+  // Parse and BOUND its length here: this is the only place that knows both the
+  // header extent (hdrlen, validated against data_size above) and the payload,
+  // so no consumer has to trust the length baked into the image itself.
+  //
+  // A logo that does not fit is reported as absent rather than invalidating the
+  // whole header: it is cosmetic, a header may legitimately carry none, and
+  // vendor_header_hash does not cover it -- so this cannot change any hash or
+  // signature outcome.
+  const uint8_t *vimg = data + 32 + vhdr->vsig_n * 32 + 1 + vhdr->vstr_len;
+  vimg += (-(uintptr_t)vimg) & 3;
+  const size_t vimg_offset = (size_t)(vimg - data);
+
+  vhdr->vimg = NULL;
+  vhdr->vimg_len = 0;
+  if (vimg_offset + TOIF_PREAMBLE_SIZE <= body_len) {
+    uint32_t toif_datalen = 0;
+    memcpy(&toif_datalen, vimg + 8, sizeof(toif_datalen));
+    // Subtract rather than add, so an attacker-chosen datalen cannot overflow
+    // the comparison. The if above guarantees the right-hand side is >= 0.
+    if (toif_datalen <= body_len - vimg_offset - TOIF_PREAMBLE_SIZE) {
+      vhdr->vimg = vimg;
+      vhdr->vimg_len = TOIF_PREAMBLE_SIZE + toif_datalen;
+    }
+  }
 
   memcpy(&vhdr->sigmask, data + vhdr->hdrlen - IMAGE_SIG_SIZE, 1);
 

--- a/core/embed/sec/image/inc/sec/image.h
+++ b/core/embed/sec/image/inc/sec/image.h
@@ -116,7 +116,8 @@ typedef struct {
   const uint8_t *vpub[MAX_VENDOR_PUBLIC_KEYS];
   uint8_t vstr_len;
   const char *vstr;
-  const uint8_t *vimg;
+  const uint8_t *vimg;  // vendor logo (TOIF); NULL when absent or malformed
+  uint32_t vimg_len;    // validated length of vimg; 0 when there is none
   uint8_t sigmask;
   uint8_t sig[64];
   const uint8_t *origin;  // pointer to the underlying data


### PR DESCRIPTION
This PR does a bit of preparation work for full PQ signing scheme.

When that arrives, vendor headers will be abandoned so the UI code is made independent of header structure.

FW integrity checks are removed from main as these will differ for legacy and PQ native signing schemes. 