### PR TITLE
fix(core): Avoid raising IndexError during cash address decoding

### DIFF
--- a/core/src/apps/bitcoin/scripts.py
+++ b/core/src/apps/bitcoin/scripts.py
@@ -91,8 +91,11 @@ def output_derive_script(address: str, coin: CoinInfo) -> AnyBytes:
         and coin.cashaddr_prefix is not None
         and address.startswith(coin.cashaddr_prefix + ":")
     ):
-        prefix, addr = address.split(":")
-        version, data = cashaddr.decode(prefix, addr)
+        try:
+            prefix, addr = address.split(":")
+            version, data = cashaddr.decode(prefix, addr)
+        except ValueError:
+            raise DataError("Invalid cashaddr address")
         if version == cashaddr.ADDRESS_TYPE_P2KH:
             version = coin.address_type
         elif version == cashaddr.ADDRESS_TYPE_P2SH:

--- a/core/src/trezor/crypto/cashaddr.py
+++ b/core/src/trezor/crypto/cashaddr.py
@@ -27,6 +27,7 @@ from .bech32 import convertbits
 CHARSET = "qpzry9x8gf2tvdw0s3jn54khce6mua7l"
 ADDRESS_TYPE_P2KH = const(0)
 ADDRESS_TYPE_P2SH = const(8)
+CASHADDR_CHECKSUM_SIZE = const(8)
 
 
 def cashaddr_polymod(values: list[int]) -> int:
@@ -51,10 +52,12 @@ def prefix_expand(prefix: str) -> list[int]:
 
 
 def _calculate_checksum(prefix: str, payload: list[int]) -> list[int]:
-    poly = cashaddr_polymod(prefix_expand(prefix) + payload + [0, 0, 0, 0, 0, 0, 0, 0])
+    poly = cashaddr_polymod(
+        prefix_expand(prefix) + payload + [0] * CASHADDR_CHECKSUM_SIZE
+    )
     out = []
-    for i in range(8):
-        out.append((poly >> 5 * (7 - i)) & 0x1F)
+    for i in range(CASHADDR_CHECKSUM_SIZE):
+        out.append((poly >> 5 * (CASHADDR_CHECKSUM_SIZE - 1 - i)) & 0x1F)
     return out
 
 
@@ -83,10 +86,16 @@ def decode(prefix: str, addr: str) -> tuple[int, bytes]:
     addr = addr.lower()
     decoded = _b32decode(addr)
 
+    # Payload must include the 8-symbol checksum.
+    if len(decoded) < CASHADDR_CHECKSUM_SIZE:
+        raise ValueError  # Cashaddr payload too short
+
     # verify_checksum
     checksum_verified = cashaddr_polymod(prefix_expand(prefix) + decoded) == 0
     if not checksum_verified:
-        raise ValueError("Bad cashaddr checksum")
+        raise ValueError  # Bad cashaddr checksum
 
-    data = bytes(convertbits(decoded, 5, 8))
-    return data[0], data[1:-6]
+    data = bytes(convertbits(decoded[:-CASHADDR_CHECKSUM_SIZE], 5, 8, False))
+    if not data:
+        raise ValueError  # Empty cashaddr payload
+    return data[0], data[1:]

--- a/core/tests/test_trezor.crypto.cashaddr.py
+++ b/core/tests/test_trezor.crypto.cashaddr.py
@@ -34,6 +34,36 @@ VALID_CHECKSUM = [
     "bchreg:555555555555555555555555555555555555555555555udxmlmrz",
 ]
 
+INVALID_ADDRESS = [
+    "prefix:x32nx6hz",
+    "prEfix:x64nx6hz",
+    "prefix:x64nx6Hz",
+    "pref1x:6m8cxv73",
+    "prefix:x64nx6hz",
+    "prefix:",
+    ":u9wsx07j",
+    "bchreg:555555555555555555x55555555555555555555555555udxmlmrz",
+    "bchreg:555555555555555555555555555555551555555555555udxmlmrz",
+    "pre:fix:x32nx6hz",
+    "prefixx64nx6hz",
+    "",
+    ":",
+    "p",
+    "p:",
+    "p:g",
+    "p:gp",
+    "p:gpf",
+    "p:gpf8",
+    "p:gpf8m",
+    "p:gpf8m4",
+    "p:gpf8m4h",
+    "p:gpf8m4h7",
+    "rpzrrzpr:",
+    "rqiqkqiqr:",
+    "c:qvdy2z3",
+    "ecash:q9mcgrsqm",
+]
+
 VALID_ADDRESS = [
     (
         "1BpEi6DfDAUFd7GtittLSdBeYJvcoaVggu",
@@ -66,12 +96,30 @@ class TestCryptoCashAddr(unittest.TestCase):
     def test_valid_checksum(self):
         for test in VALID_CHECKSUM:
             prefix, addr = test.split(":")
-            cashaddr.decode(prefix, addr)
+            decoded = cashaddr._b32decode(addr.lower())
+            self.assertEqual(
+                cashaddr.cashaddr_polymod(cashaddr.prefix_expand(prefix) + decoded),
+                0,
+            )
 
     def test_invalid_checksum(self):
         for test in VALID_CHECKSUM:
             test += "xxx"
             prefix, addr = test.split(":")
+            decoded = cashaddr._b32decode(addr.lower())
+            self.assertNotEqual(
+                cashaddr.cashaddr_polymod(cashaddr.prefix_expand(prefix) + decoded),
+                0,
+            )
+            with self.assertRaises(ValueError):
+                cashaddr.decode(prefix, addr)
+
+    def test_invalid_address(self):
+        for test in INVALID_ADDRESS:
+            if ":" in test:
+                prefix, addr = test.split(":", 1)
+            else:
+                prefix, addr = "", test
             with self.assertRaises(ValueError):
                 cashaddr.decode(prefix, addr)
 


### PR DESCRIPTION
It is possible to craft an invalid cash address that would raise an IndexError and return a confusing error message.

Fill the gap and add tests to ensure a proper ValueError is returned.

Fixes #7749.
