### PR TITLE
feat(core): allow NULL for empty `storage_set()` value

### DIFF
--- a/core/embed/sys/smcall/stm32/smcall_verifiers.c
+++ b/core/embed/sys/smcall/stm32/smcall_verifiers.c
@@ -429,7 +429,8 @@ access_violation:
 
 secbool storage_set__verified(const uint16_t key, const void *val,
                               const uint16_t len) {
-  if (!probe_read_access(val, len)) {
+  // NULL is allowed for a zero-length value.
+  if (!probe_read_access_opt(val, len)) {
     goto access_violation;
   }
 

--- a/core/embed/sys/syscall/stm32/syscall_verifiers.c
+++ b/core/embed/sys/syscall/stm32/syscall_verifiers.c
@@ -826,7 +826,8 @@ access_violation:
 
 secbool storage_set__verified(const uint16_t key, const void *val,
                               const uint16_t len) {
-  if (!probe_read_access(val, len)) {
+  // NULL is allowed for a zero-length value.
+  if (!probe_read_access_opt(val, len)) {
     goto access_violation;
   }
 


### PR DESCRIPTION
Following https://satoshilabs.slack.com/archives/CL1D61PQF/p1788113883934609.

Related to https://github.com/trezor/trezor-firmware/pull/7672.

## Notes to QA
See Slack link above.