### PR TITLE
bound the length of SPI frames from the nRF

### DIFF
--- a/core/embed/io/nrf/stm32u5/nrf_spi.c
+++ b/core/embed/io/nrf/stm32u5/nrf_spi.c
@@ -312,7 +312,9 @@ void nrf_spi_transfer_complete(SPI_HandleTypeDef *hspi) {
   uint8_t crc = crc8((uint8_t *)&packet, MAX_SPI_DATA_SIZE + SPI_HEADER_SIZE,
                      0x07, 0x00, false);
 
-  if (nrf_is_valid_startbyte(packet.service_id) && packet.crc == crc) {
+  // `msg_len` is a full byte, so it can claim more than `data` holds
+  if (nrf_is_valid_startbyte(packet.service_id) && packet.crc == crc &&
+      packet.msg_len <= MAX_SPI_DATA_SIZE) {
     nrf_process_msg(drv, packet.data, packet.msg_len, packet.service_id & 0x0F);
   }
 }


### PR DESCRIPTION
nrf_process_msg() hands the frame's msg_len field to the registered service listener without checking it against MAX_SPI_DATA_SIZE. The field is a full byte, so it can claim up to 255 bytes for a data array that is only 251 long, and the only integrity protection on that boundary is a CRC8 - forgeable by whatever drives the SPI lines, including a compromised nRF.

Every current listener happens to be safe: the status and info handlers cap their memcpy with MIN(), the bond list handler does too and guards the subtraction that precedes it, and the BLE data handler requires an exact length. But the contract is one future listener away from a memcpy that overruns its destination, so reject the frame at the choke point rather than rely on each listener to distrust the length.

Reject rather than truncate: a truncating clamp would silently turn a forged frame into a plausible short one, and every listener already handles short frames correctly.

This is the counterpart of the same check on the nRF side of the link, in trz_comm/spi.c.
