### PR TITLE
chore(core): update qr-code-generator crate

### DIFF
--- a/core/embed/Cargo.lock
+++ b/core/embed/Cargo.lock
@@ -654,8 +654,8 @@ dependencies = [
 ]
 
 [[package]]
-name = "qrcodegen"
-version = "1.8.0"
+name = "qrcodegen-no-heap"
+version = "1.8.1"
 
 [[package]]
 name = "quote"
@@ -1022,7 +1022,7 @@ dependencies = [
  "num-derive",
  "num-traits",
  "pareen",
- "qrcodegen",
+ "qrcodegen-no-heap",
  "rtl",
  "sec",
  "serde_json",

--- a/core/embed/Cargo.toml
+++ b/core/embed/Cargo.toml
@@ -74,7 +74,7 @@ minicbor = { version = "1.0.0", default-features = false }
 num-derive = "0.4.2"
 num-traits = { version = "0.2.19", default-features = false, features = ["libm"] }
 pareen = { version = "0.3.3", path = "../../rust/pareen", default-features = false, features = ["libm", "easer"] }
-qrcodegen = { version = "1.8.0", path = "../vendor/QR-Code-generator/rust-no-heap" }
+qrcodegen-no-heap = { version = "1.8.1", path = "../vendor/QR-Code-generator/rust-no-heap" }
 spin = { version = "0.9.9", features = ["rwlock", "spin_mutex", "lazy"], default-features = false }
 static-alloc = "0.2.6"
 trezor-thp = { path = "../../rust/trezor-thp" }

--- a/core/embed/rust/Cargo.toml
+++ b/core/embed/rust/Cargo.toml
@@ -27,7 +27,7 @@ minicbor.workspace = true
 num-derive.workspace = true
 num-traits.workspace = true
 pareen.workspace = true
-qrcodegen.workspace = true
+qrcodegen-no-heap.workspace = true
 spin.workspace = true
 static-alloc.workspace = true
 trezor-thp = { workspace = true, optional = true }

--- a/core/embed/rust/src/ui/component/qr_code.rs
+++ b/core/embed/rust/src/ui/component/qr_code.rs
@@ -1,5 +1,5 @@
 use heapless::String;
-use qrcodegen::{QrCode, QrCodeEcc, Version};
+use qrcodegen_no_heap::{QrCode, QrCodeEcc, Version};
 
 use super::paginated::SinglePage;
 use crate::error::Error;

--- a/core/embed/rust/src/ui/shape/qrcode.rs
+++ b/core/embed/rust/src/ui/shape/qrcode.rs
@@ -1,4 +1,4 @@
-use qrcodegen::QrCode;
+use qrcodegen_no_heap::QrCode;
 use without_alloc::alloc::LocalAllocLeakExt;
 
 use super::utils::line_points;


### PR DESCRIPTION
This PR updates the `qr-code-generator` crate to a commit that fixes the unspecified Rust edition issue, which was causing three warnings during the firmware build.

Between the current and previous commits, three additional changes were introduced:

1. 99f0579 — doc crate-name fix. The first doc example used extern crate qrcodegen / use qrcodegen::..., but the package is qrcodegen-no-heap (lib target qrcodegen_no_heap). Correct fix — it actually turns a previously non-compiling doctest into a passing one.

2. 8329a71 — alignment-pattern spacing formula (lib.rs:799-800). Replaces the ver == 32 special case plus (ver*4 + numalign*2 + 1) / (numalign*2 - 2) * 2 with a single expression (ver*8 + numalign*3 + 5) / (numalign*4 - 4) * 2, adapted from Lean QR. The trick is that doubling the dividend/divisor and adding 5 shifts the rounding just enough that version 32 naturally lands on step 26 without the special case.

3. f40366c — chunks() rewrite of make_numeric (lib.rs:1113) and make_alphanumeric (lib.rs:1131), replacing manual accumulator/counter loops with slice::chunks(3)/chunks(2) + fold, and unifying the bit-width as len*3+1 (10/7/4 bits) and len*5+1 (11/6 bits).

All three changes were reviewed by Fable 5 and GPT 5.6 Sol and found to be correct, with no regressions identified.