### PR TITLE
fix(core): remove rust warnings

### DIFF
--- a/core/embed/rust/src/lib.rs
+++ b/core/embed/rust/src/lib.rs
@@ -8,11 +8,18 @@
 // Allowing dead code not to cause a lot of warnings when building for a specific target
 // (when building for TR, a lot of code only used in TT would get marked as unused).
 #![allow(dead_code)]
-#![feature(lang_items)]
-#![feature(trait_alias)]
 #![feature(custom_test_frameworks)]
 #![no_main]
 #![reexport_test_harness_main = "test_main"]
+#![cfg_attr(
+    all(
+        not(target_arch = "arm"),
+        not(test),
+        any(not(feature = "test"), feature = "clippy")
+    ),
+    feature(lang_items)
+)]
+#![cfg_attr(all(feature = "ui", feature = "layout_bolt"), feature(trait_alias))]
 
 #[macro_use]
 extern crate num_derive;


### PR DESCRIPTION
This PR removes two Rust warnings caused by unconditionally defining feature flags that are not used in every build configuration:

1. `#![feature(lang_items)]` is required for the redefinition of `eh_personality`

```
  --> rust/src/lib.rs:11:12
   |
11 | #![feature(lang_items)]
   |            ^^^^^^^^^^
   |
   = note: `#[warn(unused_features)]` (part of `#[warn(unused)]`) on by default
```

2. `#![feature(trait_alias)]` is an unstable feature used in bolt layout (in buttons.rs)

```
warning: feature `trait_alias` is declared but not used
  --> rust/src/lib.rs:12:12
   |
12 | #![feature(trait_alias)]
   |            ^^^^^^^^^^^
```




