### PR TITLE
build(core): remove `emit-memory-analysis` xtask flag

### DIFF
--- a/core/embed/xtask/src/features.rs
+++ b/core/embed/xtask/src/features.rs
@@ -154,22 +154,6 @@ pub fn configure_cargo(args: &ResolvedBuildArgs, cmd: &mut process::Command) -> 
         cmd.args(["--target", triple]);
     }
 
-    if args.emit_memory_analysis {
-        // See https://nnethercote.github.io/perf-book/type-sizes.html#measuring-type-sizes for more details
-        // Also adds an ELF section with Rust functions' stack sizes. See:
-        // - https://doc.rust-lang.org/nightly/unstable-book/compiler-flags/emit-stack-sizes.html
-        // - https://blog.japaric.io/stack-analysis/
-        // - https://github.com/japaric/stack-sizes/
-        //
-        // Use --config instead of RUSTFLAGS env so that rustflags in .cargo/config.toml
-        // are not overridden (RUSTFLAGS env has higher precedence and replaces
-        // them entirely).
-        cmd.args([
-            "--config",
-            "build.rustflags=[\"-Zprint-type-sizes\", \"-Zemit-stack-sizes\"]",
-        ]);
-    }
-
     if args.emulator && args.asan {
         // -Zsanitizer=address is a rustc flag passed via RUSTFLAGS.
         //

--- a/core/embed/xtask/src/options.rs
+++ b/core/embed/xtask/src/options.rs
@@ -249,10 +249,6 @@ build_options! {
     #[arg(long, num_args = 0..=1, default_missing_value = "true")]
     map storage_insecure_testing_mode: bool,
 
-    /// Emits memory analysis output (type sizes and stack sizes)
-    #[arg(long, num_args = 0..=1, default_missing_value = "true")]
-    opt emit_memory_analysis: bool,
-
     /// Output cargo timings
     #[arg(long, num_args = 0..=1, default_missing_value = "true")]
     opt timings: bool,


### PR DESCRIPTION
Its `--config build.rustflags=[...]` are currently ignored in favor of `core/embed/.cargo/config.toml`.
