### PR TITLE
fix(core): fix FLASH region overflow on T2T1

### DIFF
--- a/core/embed/sys/linker/stm32f4/firmware.ld
+++ b/core/embed/sys/linker/stm32f4/firmware.ld
@@ -65,7 +65,7 @@ SECTIONS {
     . = ALIGN(4);
   } >AUX1_RAM
 
-  .buf : ALIGN(4) {
+  .buf (NOLOAD) : ALIGN(4) {
     *(.buf*);
     . = ALIGN(4);
   } >AUX1_RAM


### PR DESCRIPTION
Fixes https://github.com/trezor/trezor-firmware/issues/7792.

> Hardware device (T2T1) tests fail, because the firmware that is supposed to be used overflows the available FLASH region size - overflow of 28 bytes.

```
section `.buf' will not fit in region `FLASH'
region `FLASH' overflowed by 28 bytes
```

Note: This fix is applied also to T2B1 and D001 as they share the f4 config - however, those devices did not overflow in the first place.