### PR TITLE
docs(core): explain thp key selection flexibility

### DIFF
--- a/core/src/apps/thp/pairing.py
+++ b/core/src/apps/thp/pairing.py
@@ -434,6 +434,14 @@ async def _handle_credential_request(
         app_name=ctx.app_name,
         autoconnect=autoconnect,
     )
+
+    # The `host_static_public_key` used in the credential can be different from the
+    # one used in the handshake. This is a deliberate choice, as it gives more
+    # flexibility to the host.
+    # Example usage: the host uses a randomly generated key to pair with an unknown
+    # device, but the static keys used for credentials (known devices) are chosen,
+    # e.g., a single key used for all known Trezors, or keys derived from a key
+    # hierarchy.
     credential = issue_credential(message.host_static_public_key, credential_metadata)
 
     return await ctx.call_any(

--- a/docs/common/thp/specification.md
+++ b/docs/common/thp/specification.md
@@ -1302,6 +1302,12 @@ The behavior of the host in the state **HC2** is defined as follows:
 - When the message ThpEndResponse() is received, take the following actions:
     1. Transition to the transport state.
 
+### Notes
+
+The *host_static_pubkey* used in the credential can be different from the one used in the handshake. This is a deliberate choice, as it gives more flexibility to the host.
+
+Example usage: the host uses a randomly generated key to pair with an unknown device, but the static keys used for credentials (known devices) are chosen, e.g., a single key used for all known Trezors, or keys derived from a key hierarchy.
+
 # Other features
 
 ## Channel replacement


### PR DESCRIPTION
Added a comment (and docs entry) explaining why the host's static key used in thp credentials (issued after pairing) can be different from the key used in the handshake.