### PR TITLE
fix(core): mark .buf and .no_dma_buffers sections as NOLOAD

### DIFF
--- a/core/embed/sys/linker/stm32f4/boardloader.ld
+++ b/core/embed/sys/linker/stm32f4/boardloader.ld
@@ -56,7 +56,7 @@ SECTIONS {
     . = ALIGN(4);
   } >FB1
 
-  .buf : ALIGN(4) {
+  .buf (NOLOAD) : ALIGN(4) {
     *(.buf*);
     . = ALIGN(4);
   } >AUX1_RAM

--- a/core/embed/sys/linker/stm32f4/bootloader.ld
+++ b/core/embed/sys/linker/stm32f4/bootloader.ld
@@ -61,7 +61,7 @@ SECTIONS {
     . = ALIGN(4);
   } >FB1
 
-  .buf : ALIGN(4) {
+  .buf (NOLOAD) : ALIGN(4) {
     *(.buf*);
     . = ALIGN(4);
     *(.no_dma_buffers*);

--- a/core/embed/sys/linker/stm32f4/firmware.ld
+++ b/core/embed/sys/linker/stm32f4/firmware.ld
@@ -40,7 +40,7 @@ SECTIONS {
     . = ALIGN(4);
     KEEP(*(.bootloader));
     *(.bootloader*);
-    . = ALIGN(512);
+    . = ALIGN(4);
   } >FLASH AT>FLASH
 
   .flash2 : ALIGN(512) {
@@ -48,7 +48,7 @@ SECTIONS {
     *(.text*);
     . = ALIGN(4);
     *(.rodata*);
-    . = ALIGN(4);
+    . = ALIGN(512);
   } >FLASH2 AT>FLASH2
 
   .stack : ALIGN(8) {

--- a/core/embed/sys/linker/stm32f4/firmware.ld
+++ b/core/embed/sys/linker/stm32f4/firmware.ld
@@ -75,7 +75,7 @@ SECTIONS {
     . = ABSOLUTE(ORIGIN(AUX1_RAM) + LENGTH(AUX1_RAM)); /* this explicitly sets the end of the heap */
   } >AUX1_RAM
 
-  .data_ccm : ALIGN(4) {
+  .data_ccm (NOLOAD) : ALIGN(4) {
     *(.no_dma_buffers*);
     . = ALIGN(4);
   } >AUX2_RAM

--- a/core/embed/sys/linker/stm32f4/kernel.ld
+++ b/core/embed/sys/linker/stm32f4/kernel.ld
@@ -57,7 +57,7 @@ SECTIONS {
     . = ALIGN(4);
   } >MAIN_RAM
 
-  .buf : ALIGN(4) {
+  .buf (NOLOAD) : ALIGN(4) {
     *(.buf*);
     . = ALIGN(4);
   } >DMABUF

--- a/core/embed/sys/linker/stm32f4/prodtest.ld
+++ b/core/embed/sys/linker/stm32f4/prodtest.ld
@@ -74,6 +74,13 @@ SECTIONS {
     . = ALIGN(4);
   } >AUX1_RAM
 
+  .buf (NOLOAD) : ALIGN(4) {
+    *(.no_dma_buffers*);
+    . = ALIGN(4);
+    *(.buf*);
+    . = ALIGN(4);
+  } >AUX1_RAM
+
   .fb : ALIGN(4) {
     *(.fb1*);
     . = ALIGN(4);

--- a/core/embed/sys/linker/stm32u58/boardloader.ld
+++ b/core/embed/sys/linker/stm32u58/boardloader.ld
@@ -52,7 +52,7 @@ SECTIONS {
     . = ALIGN(4);
   } >MAIN_RAM
 
-  .buf : ALIGN(4) {
+  .buf (NOLOAD) : ALIGN(4) {
     *(.buf*);
     . = ALIGN(4);
   } >AUX1_RAM

--- a/core/embed/sys/linker/stm32u58/bootloader.ld
+++ b/core/embed/sys/linker/stm32u58/bootloader.ld
@@ -65,7 +65,7 @@ SECTIONS {
     . = ALIGN(4);
   } >MAIN_RAM
 
-  .buf : ALIGN(4) {
+  .buf (NOLOAD): ALIGN(4) {
     *(.buf*);
     . = ALIGN(4);
     *(.no_dma_buffers*);

--- a/core/embed/sys/linker/stm32u58/firmware.ld
+++ b/core/embed/sys/linker/stm32u58/firmware.ld
@@ -64,8 +64,12 @@ SECTIONS {
   } > AUX1_RAM
 
   .bss : ALIGN(4) {
-    *(.no_dma_buffers*);
     *(.bss*);
+    . = ALIGN(4);
+  } >AUX1_RAM
+
+  .no_dma_buffers (NOLOAD): ALIGN(4) {
+    *(.no_dma_buffers*);
     . = ALIGN(4);
   } >AUX1_RAM
 
@@ -73,7 +77,7 @@ SECTIONS {
     . += 32K; /* Overflow causes UsageFault */
   } >AUX2_RAM
 
-  .buf : ALIGN(4) {
+  .buf (NOLOAD): ALIGN(4) {
     *(.buf*);
     . = ALIGN(4);
   } >AUX2_RAM

--- a/core/embed/sys/linker/stm32u58/kernel.ld
+++ b/core/embed/sys/linker/stm32u58/kernel.ld
@@ -64,9 +64,14 @@ SECTIONS {
   }
 
   .bss : ALIGN(4) {
-    *(.no_dma_buffers*);
-    *(.buf*);
     *(.bss*);
+    . = ALIGN(4);
+  } >MAIN_RAM
+
+  .buf (NOLOAD): ALIGN(4) {
+    *(.no_dma_buffers*);
+    . = ALIGN(4);
+    *(.buf*);
     . = ALIGN(4);
   } >MAIN_RAM
 

--- a/core/embed/sys/linker/stm32u58/prodtest.ld
+++ b/core/embed/sys/linker/stm32u58/prodtest.ld
@@ -85,7 +85,7 @@ SECTIONS {
     . = ALIGN(4);
   } >AUX1_RAM
 
-  .buf : ALIGN(4) {
+  .buf (NOLOAD) : ALIGN(4) {
     *(.buf*);
     . = ALIGN(4);
     *(.no_dma_buffers*);

--- a/core/embed/sys/linker/stm32u5a/boardloader.ld
+++ b/core/embed/sys/linker/stm32u5a/boardloader.ld
@@ -53,7 +53,7 @@ SECTIONS {
     . = ALIGN(4);
   } >MAIN_RAM
 
-  .buf : ALIGN(4) {
+  .buf (NOLOAD): ALIGN(4) {
     *(.buf*);
     . = ALIGN(4);
   } >AUX1_RAM

--- a/core/embed/sys/linker/stm32u5a/bootloader.ld
+++ b/core/embed/sys/linker/stm32u5a/bootloader.ld
@@ -52,7 +52,7 @@ SECTIONS {
     . = ALIGN(4);
   } >MAIN_RAM
 
-  .buf : ALIGN(4) {
+  .buf (NOLOAD) : ALIGN(4) {
     *(.buf*);
     . = ALIGN(4);
     *(.no_dma_buffers*);

--- a/core/embed/sys/linker/stm32u5a/firmware.ld
+++ b/core/embed/sys/linker/stm32u5a/firmware.ld
@@ -74,12 +74,13 @@ SECTIONS {
   } > AUX1_RAM
 
   .bss : ALIGN(4) {
-    *(.no_dma_buffers*);
     *(.bss*);
     . = ALIGN(4);
   } >AUX1_RAM
 
-  .buf : ALIGN(4) {
+  .buf (NOLOAD): ALIGN(4) {
+    *(.no_dma_buffers*);
+    . = ALIGN(4);
     *(.buf*);
     . = ALIGN(4);
   } >AUX1_RAM

--- a/core/embed/sys/linker/stm32u5a/kernel.ld
+++ b/core/embed/sys/linker/stm32u5a/kernel.ld
@@ -61,7 +61,6 @@ SECTIONS {
   }
 
   .bss : ALIGN(4) {
-    *(.no_dma_buffers*);
     *(.bss*);
     . = ALIGN(4);
   } >MAIN_RAM
@@ -76,7 +75,9 @@ SECTIONS {
     . = ALIGN(4);
   } >FB2_RAM
 
-  .buf : ALIGN(4) {
+  .buf (NOLOAD): ALIGN(4) {
+    *(.no_dma_buffers*);
+    . = ALIGN(4);
     *(.buf*);
     . = ALIGN(4);
   } >MAIN_RAM

--- a/core/embed/sys/linker/stm32u5a/prodtest.ld
+++ b/core/embed/sys/linker/stm32u5a/prodtest.ld
@@ -71,7 +71,7 @@ SECTIONS {
   } >AUX1_RAM
 
   /* D003 has no AUX2_RAM, so .buf shares AUX1_RAM with .data/.bss. */
-  .buf : ALIGN(4) {
+  .buf (NOLOAD) : ALIGN(4) {
     *(.buf*);
     . = ALIGN(4);
     *(.no_dma_buffers*);

--- a/core/embed/sys/linker/stm32u5g/boardloader.ld
+++ b/core/embed/sys/linker/stm32u5g/boardloader.ld
@@ -53,7 +53,7 @@ SECTIONS {
     . = ALIGN(4);
   } >MAIN_RAM
 
-  .buf : ALIGN(4) {
+  .buf (NOLOAD): ALIGN(4) {
     *(.buf*);
     . = ALIGN(4);
   } >AUX1_RAM

--- a/core/embed/sys/linker/stm32u5g/bootloader.ld
+++ b/core/embed/sys/linker/stm32u5g/bootloader.ld
@@ -61,7 +61,7 @@ SECTIONS {
     . = ALIGN(4);
   } >MAIN_RAM
 
-  .buf : ALIGN(4) {
+  .buf (NOLOAD): ALIGN(4) {
     *(.buf*);
     . = ALIGN(4);
     *(.no_dma_buffers*);

--- a/core/embed/sys/linker/stm32u5g/firmware.ld
+++ b/core/embed/sys/linker/stm32u5g/firmware.ld
@@ -74,12 +74,13 @@ SECTIONS {
   } > AUX1_RAM
 
   .bss : ALIGN(4) {
-    *(.no_dma_buffers*);
     *(.bss*);
     . = ALIGN(4);
   } >AUX1_RAM
 
-  .buf : ALIGN(4) {
+  .buf (NOLOAD): ALIGN(4) {
+    *(.no_dma_buffers*);
+    . = ALIGN(4);
     *(.buf*);
     . = ALIGN(4);
   } >AUX1_RAM

--- a/core/embed/sys/linker/stm32u5g/kernel.ld
+++ b/core/embed/sys/linker/stm32u5g/kernel.ld
@@ -61,7 +61,6 @@ SECTIONS {
   }
 
   .bss : ALIGN(4) {
-    *(.no_dma_buffers*);
     *(.bss*);
     . = ALIGN(4);
   } >MAIN_RAM
@@ -76,7 +75,9 @@ SECTIONS {
     . = ALIGN(4);
   } >FB2_RAM
 
-  .buf : ALIGN(4) {
+  .buf (NOLOAD): ALIGN(4) {
+    *(.no_dma_buffers*);
+    . = ALIGN(4);
     *(.buf*);
     . = ALIGN(4);
   } >MAIN_RAM

--- a/core/embed/sys/linker/stm32u5g/prodtest.ld
+++ b/core/embed/sys/linker/stm32u5g/prodtest.ld
@@ -80,7 +80,6 @@ SECTIONS {
   _image_flash_end = LOADADDR(.data) + SIZEOF(.data);
 
   .bss : ALIGN(4) {
-    *(.no_dma_buffers*);
     *(.bss*);
     . = ALIGN(4);
   } >AUX1_RAM
@@ -95,7 +94,9 @@ SECTIONS {
     . = ALIGN(4);
   } >FB2_RAM
 
-  .buf : ALIGN(4) {
+  .buf (NOLOAD) : ALIGN(4) {
+    *(.no_dma_buffers*);
+    . = ALIGN(4);
     *(.buf*);
     . = ALIGN(4);
   } >AUX1_RAM


### PR DESCRIPTION
This PR marks the `.buf` and `.no_dma_buffers` output sections used for runtime scratch buffers as `NOLOAD` and keeps them separate from initialized `.data`. It is a follow-up to [#7794](https://github.com/trezor/trezor-firmware/pull/7794) and also fixes an issue with unaligned firmware image for stm32f4 devices that can't be uploaded to the device (the bug introduced in https://github.com/trezor/trezor-firmware/pull/7688/changes).

Objects placed in `.buf` and `.no_dma_buffers` do not require initial contents to be loaded from flash. Their memory may be uninitialized at startup - actually they're zeroed . These sections are also excluded from the final binaries produced by `objcopy`.

This worked as intended until we added the following Rust statics:

```rust
    #[cfg_attr(not(target_os = "macos"), link_section = ".no_dma_buffers")]
    static mut BUMP_A: Bump<[u8; BUMP_A_SIZE]> = Bump::uninit();
    #[cfg_attr(not(target_os = "macos"), link_section = ".buf")]
    static mut BUMP_B: Bump<[u8; BUMP_B_SIZE]> = Bump::uninit();
```

`Bump::uninit()` initializes the allocator counter to zero while leaving its backing storage uninitialized. Rust therefore emits these custom input sections as `SHT_PROGBITS`, rather than `SHT_NOBITS`. 

In linker scripts where these sections followed `.data` in the same RAM memory region, linker could infer flash load addresses for them. Their contents were then accounted for against the FLASH region, even though `objcopy` excluded them from the final binary. This could cause a linker FLASH overflow when the actual firmware content was close to the region limit or invalid reporting of used FLASH.

This PR gives `.buf` and `.no_dma_buffers` explicit, consistent `NOLOAD` placement across all platforms and projects. This ensures that they reserve runtime RAM without creating flash load images.

