### PR TITLE
drop the unreachable turn_on command list

### DIFF
--- a/core/embed/projects/bootloader/main.c
+++ b/core/embed/projects/bootloader/main.c
@@ -195,14 +195,9 @@ static secbool boot_sequence(void) {
 
   boot_command_t cmd = bootargs_get_command();
 
-  bool turn_on =
-      (cmd == BOOT_COMMAND_INSTALL_UPGRADE || cmd == BOOT_COMMAND_REBOOT ||
-       cmd == BOOT_COMMAND_SHOW_RSOD || cmd == BOOT_COMMAND_WIPE ||
-       cmd == BOOT_COMMAND_STOP_AND_WAIT);
-
-  if (cmd != BOOT_COMMAND_POWER_OFF) {
-    turn_on = true;
-  }
+  // Turns on unless the command is power off or unless the power button is
+  // held down.
+  bool turn_on = (cmd != BOOT_COMMAND_POWER_OFF);
 
   if (button_is_down(BTN_POWER)) {
     turn_on = false;


### PR DESCRIPTION
The command enumeration has been dead since https://github.com/trezor/trezor-firmware/commit/ad3cb11056f1d63f461379988c01f083f25a88b7 ("start the device on
short press"). That commit widened the condition below it from
`manufacturing_mode && cmd != BOOT_COMMAND_POWER_OFF` to just the latter, which
subsumes the list entirely -- nothing the list selects can still change the
outcome.

The widening was deliberate. What the list was trying to express is already
covered: BOOT_COMMAND_POWER_OFF is set in exactly one place
(reboot_and_power_off), so it alone marks the state that has no reason to boot.
Every other command boots through -- and a boot with the button held still reaches
the press loop via the button_is_down check just
below, so long-press bootloader entry is unaffected.

Keeping the enumeration around only implies it still selects something, and any
command added to it is a silent no-op.