### PR TITLE
Add timeouts to all CI jobs

### DIFF
--- a/.github/workflows/bot-auto-assign.yml
+++ b/.github/workflows/bot-auto-assign.yml
@@ -12,6 +12,7 @@ jobs:
     # run only in 'trezor/trezor-firmware' repository, skipped for bots
     if: github.repository == 'trezor/trezor-firmware' && !endsWith(github.event.pull_request.user.login, '[bot]')
     runs-on: ubuntu-latest
+    timeout-minutes: 5
     steps:
       - name: Assign PR author to PR
         uses: actions/github-script@ed597411d8f924073f98dfc5c65a23a2325f34cd  # actions/github-script@v8.0.0

--- a/.github/workflows/bot-common-sync.yml
+++ b/.github/workflows/bot-common-sync.yml
@@ -11,6 +11,7 @@ permissions:
 jobs:
   sync-common:
     runs-on: ubuntu-latest
+    timeout-minutes: 5
     env:
       BOT_USERNAME: "trezor-bot[bot]"
       BOT_EMAIL: "208941332+trezor-bot[bot]@users.noreply.github.com"

--- a/.github/workflows/bot-needs-qa.yml
+++ b/.github/workflows/bot-needs-qa.yml
@@ -14,6 +14,7 @@ jobs:
     # run only in 'trezor/trezor-firmware' repository
     if: github.repository == 'trezor/trezor-firmware'
     runs-on: ubuntu-latest
+    timeout-minutes: 5
     steps:
       - name: Generate GitHub App token
         id: trezor-bot-token

--- a/.github/workflows/bot-project-automation.yml
+++ b/.github/workflows/bot-project-automation.yml
@@ -17,6 +17,7 @@ jobs:
     # run only in 'trezor/trezor-firmware' repository
     if: github.repository == 'trezor/trezor-firmware'
     runs-on: ubuntu-latest
+    timeout-minutes: 5
     steps:
       - name: Generate GitHub App token
         id: trezor-bot-token

--- a/.github/workflows/bot-tropic-emulator.yml
+++ b/.github/workflows/bot-tropic-emulator.yml
@@ -32,6 +32,7 @@ jobs:
   pr_comment:
     name: Post a comment to the pull request
     runs-on: ubuntu-latest
+    timeout-minutes: 5
     if: github.event.action == 'opened' || github.event.action == 'synchronize'
     permissions:
       pull-requests: write  # needed to post a comment
@@ -57,6 +58,7 @@ jobs:
   issue_open:
     name: Open an issue for trezor-user-env
     runs-on: ubuntu-latest
+    timeout-minutes: 5
     if: github.event.action == 'closed' && github.event.merged == true && github.repository == 'trezor/trezor-firmware'
     env:
       URL: ${{ github.event.pull_request.html_url }}

--- a/.github/workflows/cflite.yml
+++ b/.github/workflows/cflite.yml
@@ -18,6 +18,7 @@ jobs:
     # run only in public repositories - fuzzer will fail in private forks (missing auth)
     if: github.event.repository.private == false
     runs-on: ubuntu-latest
+    timeout-minutes: 30
     strategy:
       fail-fast: false
       matrix:

--- a/.github/workflows/common.yml
+++ b/.github/workflows/common.yml
@@ -23,6 +23,7 @@ jobs:
   crypto_build:
     name: Crypto library
     runs-on: ubuntu-latest
+    timeout-minutes: 15
     env:
       CC: gcc
       ADDRESS_SANITIZER: 1
@@ -50,6 +51,7 @@ jobs:
     name: Crypto test
     needs: [crypto_build]
     runs-on: ubuntu-latest
+    timeout-minutes: 15
     env:
       ASAN_OPTIONS: "verify_asan_link_order=0"
       CK_TIMEOUT_MULTIPLIER: 5
@@ -72,6 +74,7 @@ jobs:
   python_test:
     name: Python test
     runs-on: ubuntu-latest
+    timeout-minutes: 15
     env:
       LC_ALL: C.UTF-8
       LANG: C.UTF-8
@@ -86,6 +89,7 @@ jobs:
   rust_test:
     name: Rust crates test
     runs-on: ubuntu-latest
+    timeout-minutes: 15
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # actions/checkout@v6.0.2
         with:
@@ -97,6 +101,7 @@ jobs:
     name: Storage test
     # TODO: only for changes in storage/
     runs-on: ubuntu-latest
+    timeout-minutes: 15
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # actions/checkout@v6.0.2
         with:
@@ -109,6 +114,7 @@ jobs:
   docs_build:
     name: Docs build
     runs-on: ubuntu-latest
+    timeout-minutes: 5
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # actions/checkout@v6.0.2
       - uses: ./.github/actions/environment
@@ -130,6 +136,7 @@ jobs:
     # scheduled, manual runs, push to release branches
     if: github.event_name != 'pull_request'
     runs-on: ubuntu-latest
+    timeout-minutes: 45
     strategy:
       fail-fast: false
       matrix:

--- a/.github/workflows/core-hw.yml
+++ b/.github/workflows/core-hw.yml
@@ -31,6 +31,7 @@ jobs:
   param:
     name: Determine pipeline parameters
     runs-on: ubuntu-latest
+    timeout-minutes: 5
     # No scheduled runs on forks.
     if: github.repository == 'trezor/trezor-firmware' || github.event_name != 'schedule'
     outputs:
@@ -118,6 +119,7 @@ jobs:
     runs-on:
       - self-hosted
       - ${{ matrix.model == 'T2B1' && 'hw-t2b1' || matrix.model == 'T3T1' && 'hw-t3t1' || matrix.model == 'T3B1' && 'hw-t3b1' || matrix.model == 'T3W1' && 'hw-t3w1' || 'hw-t2t1' }}
+    timeout-minutes: 360
     if: needs.param.outputs.core_models != '[]' && false  # FIXME https://github.com/trezor/trezor-firmware/issues/3128
     strategy:
       fail-fast: false
@@ -163,6 +165,7 @@ jobs:
     runs-on:
       - self-hosted
       - hw-t1b1
+    timeout-minutes: 240
     if: needs.param.outputs.run_legacy == '1'
     strategy:
       fail-fast: false

--- a/.github/workflows/core.yml
+++ b/.github/workflows/core.yml
@@ -34,6 +34,7 @@ jobs:
   param:
     name: Determine pipeline parameters
     runs-on: ubuntu-latest
+    timeout-minutes: 5
     outputs:
       test_lang: ${{ steps.set_vars.outputs.test_lang }}
       asan: ${{ steps.set_vars.outputs.asan }}
@@ -49,6 +50,7 @@ jobs:
   core_firmware:
     name: Build firmware (${{ matrix.model }}, ${{ matrix.coins }}, ${{ matrix.type }}${{matrix.n1w1 && ', n1w1' || '' }})
     runs-on: ubuntu-latest
+    timeout-minutes: 15
     strategy:
       fail-fast: false
       matrix:
@@ -114,6 +116,7 @@ jobs:
   core_emu:
     name: Build emu (${{ matrix.model }}, ${{ matrix.coins }}, ${{ matrix.type }}, ${{ matrix.asan }}${{matrix.n1w1 && ', n1w1' || '' }})
     runs-on: ubuntu-latest
+    timeout-minutes: 15
     needs: param
     strategy:
       fail-fast: false
@@ -164,6 +167,7 @@ jobs:
     if: github.event_name == 'schedule'
     name: Build emu ARM (${{ matrix.model }}, ${{ matrix.coins }}, ${{ matrix.type }}, ${{ matrix.asan }}${{matrix.n1w1 && ', n1w1' || '' }})
     runs-on: ubuntu-latest-arm64
+    timeout-minutes: 15
     needs: param
     strategy:
       fail-fast: false
@@ -237,6 +241,7 @@ jobs:
   core_unit_python_test:
     name: Python unit tests (${{ matrix.model }}, ${{ matrix.coins }}, ${{ matrix.asan }})
     runs-on: ubuntu-latest
+    timeout-minutes: 15
     needs: param
     strategy:
       fail-fast: false
@@ -265,6 +270,7 @@ jobs:
   core_unit_rust_test:
     name: Rust unit tests (${{ matrix.model }}, ${{ matrix.asan }})
     runs-on: ubuntu-latest
+    timeout-minutes: 15
     needs:
       - param
       - core_emu
@@ -291,6 +297,7 @@ jobs:
   core_rust_client_test:
     name: Rust trezor-client tests
     runs-on: ubuntu-latest
+    timeout-minutes: 15
     needs: core_emu
     strategy:
       fail-fast: false
@@ -523,6 +530,7 @@ jobs:
     if: false  # XXX currently failing
     continue-on-error: true
     runs-on: ubuntu-latest
+    timeout-minutes: 60
     needs: core_emu
     strategy:
       fail-fast: false
@@ -552,6 +560,7 @@ jobs:
     name: Memory allocation report
     if: false  # NOTE manual job, comment out to run
     runs-on: ubuntu-latest
+    timeout-minutes: 60
     env:
       TREZOR_MODEL: T2T1
       TREZOR_MEMPERF: 1
@@ -582,6 +591,7 @@ jobs:
   core_flash_size_check:
     name: Flash size check
     runs-on: ubuntu-latest
+    timeout-minutes: 15
     needs: core_firmware
     strategy:
       fail-fast: false
@@ -602,6 +612,7 @@ jobs:
   core_monero_test:
     name: Monero test (${{ matrix.model }}, ${{ matrix.asan }})
     runs-on: ubuntu-latest
+    timeout-minutes: 15
     needs:
       - param
       - core_emu
@@ -641,6 +652,7 @@ jobs:
   core_u2f_test:
     name: U2F test (${{ matrix.model }}, ${{ matrix.asan }})
     runs-on: ubuntu-latest
+    timeout-minutes: 15
     needs:
       - param
       - core_emu
@@ -676,6 +688,7 @@ jobs:
   core_fido2_test:
     name: FIDO2 test (${{ matrix.model }}, ${{ matrix.asan }})
     runs-on: ubuntu-latest
+    timeout-minutes: 15
     needs:
       - param
       - core_emu
@@ -710,6 +723,7 @@ jobs:
   core_coverage_report:
     name: Coverage report
     runs-on: ubuntu-latest
+    timeout-minutes: 20
     needs:
       - core_emu
       - core_click_test
@@ -754,6 +768,7 @@ jobs:
   binaries_size_report:
     name: Binaries' size report
     runs-on: ubuntu-latest
+    timeout-minutes: 5
     needs:
       - core_firmware
     steps:
@@ -776,6 +791,7 @@ jobs:
     # run UI comment job only for 'trezor/trezor-firmware' scheduled workflows and internal PRs (see #5381)
     if: (github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository) && github.repository == 'trezor/trezor-firmware'
     runs-on: ubuntu-latest
+    timeout-minutes: 10
     needs:
       - param
     steps:
@@ -806,6 +822,7 @@ jobs:
     name: Upload emulator binaries
     if: github.event_name == 'schedule' && github.repository == 'trezor/trezor-firmware'
     runs-on: ubuntu-latest
+    timeout-minutes: 10
     needs:
       - core_emu
       - core_emu_arm
@@ -838,6 +855,7 @@ jobs:
     # Not building it for nightly CI
     if: github.event_name != 'schedule' && github.repository == 'trezor/trezor-firmware'
     runs-on: ubuntu-latest
+    timeout-minutes: 10
     needs:
       # Do not include ARM, they are only built on nightly
       - core_emu
@@ -873,6 +891,7 @@ jobs:
   rust_deps_check:
     name: Rust dependencies check
     runs-on: ubuntu-latest
+    timeout-minutes: 20
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # actions/checkout@v6.0.2
         with:
@@ -885,6 +904,7 @@ jobs:
     name: Unsigned firmware archive  # for release QA purposes
     if: github.event_name == 'push'  # release branches only, only those currently trigger push
     runs-on: ubuntu-latest
+    timeout-minutes: 60
     needs: core_firmware
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # actions/checkout@v6.0.2
@@ -916,6 +936,7 @@ jobs:
     name: Upload nightly firmware
     if: github.event_name == 'schedule'  # scheduled nightly runs only
     runs-on: ubuntu-latest
+    timeout-minutes: 20
     needs: core_firmware
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # actions/checkout@v6.0.2

--- a/.github/workflows/crowdin-pull.yml
+++ b/.github/workflows/crowdin-pull.yml
@@ -25,6 +25,7 @@ concurrency:
 jobs:
   crowdin-pull-and-pr:
     runs-on: ubuntu-latest
+    timeout-minutes: 20
     steps:
       - name: Checkout
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # actions/checkout@v6.0.2

--- a/.github/workflows/crowdin-push.yml
+++ b/.github/workflows/crowdin-push.yml
@@ -15,6 +15,7 @@ jobs:
     name: Split and upload sources
     if: github.ref_name == 'main'  # run only when dispatched from main
     runs-on: ubuntu-latest
+    timeout-minutes: 20
     environment: crowdin
     steps:
       - name: Checkout

--- a/.github/workflows/crowdin-ui-check-reuse.yml
+++ b/.github/workflows/crowdin-ui-check-reuse.yml
@@ -18,6 +18,7 @@ jobs:
   core_context_tests:
     name: Context tests (${{ matrix.model }}, universal, noasan, ${{ matrix.language }})
     runs-on: ubuntu-latest
+    timeout-minutes: 40
     strategy:
       fail-fast: false
       matrix:
@@ -60,6 +61,7 @@ jobs:
   core_ui_comment:
     name: Comment with UI flows
     runs-on: ubuntu-latest
+    timeout-minutes: 5
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # actions/checkout@v6.0.2
         with:

--- a/.github/workflows/crowdin-ui-check.yml
+++ b/.github/workflows/crowdin-ui-check.yml
@@ -25,6 +25,7 @@ jobs:
   core_emu:
     name: Build emulator (${{ matrix.model }}, universal, debuglink, noasan)
     runs-on: ubuntu-latest
+    timeout-minutes: 20
     strategy:
       fail-fast: false
       matrix:
@@ -56,6 +57,8 @@ jobs:
     if: ${{ !inputs.all-languages }}
     permissions:
       id-token: write  # for fetching OIDC token for AWS in reusable workflow jobs
+    # A reusable-workflow call cannot declare `timeout-minutes` -- the called
+    # workflow's jobs carry them. TODO: pass it as a `workflow_call` input.
     uses: ./.github/workflows/crowdin-ui-check-reuse.yml
     with:
       languages: '["en", "${{ inputs.language }}"]'
@@ -65,6 +68,8 @@ jobs:
     if: ${{ inputs.all-languages }}
     permissions:
       id-token: write  # for fetching OIDC token for AWS in reusable workflow jobs
+    # A reusable-workflow call cannot declare `timeout-minutes` -- the called
+    # workflow's jobs carry them. TODO: pass it as a `workflow_call` input.
     uses: ./.github/workflows/crowdin-ui-check-reuse.yml
     with:
       languages: '["en", "cs", "fr", "de", "es", "pt"]'

--- a/.github/workflows/legacy.yml
+++ b/.github/workflows/legacy.yml
@@ -38,6 +38,7 @@ jobs:
   legacy_firmware:
     name: Firmware
     runs-on: ubuntu-latest
+    timeout-minutes: 20
     strategy:
       matrix:
         coins: [universal, btconly]
@@ -64,6 +65,7 @@ jobs:
   legacy_emu:
     name: Emulator
     runs-on: ubuntu-latest
+    timeout-minutes: 20
     strategy:
       matrix:
         coins: [universal, btconly]
@@ -95,6 +97,7 @@ jobs:
     if: github.event_name == 'schedule'
     name: Emulator arm
     runs-on: ubuntu-latest-arm64
+    timeout-minutes: 20
     strategy:
       matrix:
         coins: [universal]
@@ -184,6 +187,7 @@ jobs:
     if: false  # XXX currently failing
     continue-on-error: true
     runs-on: ubuntu-latest
+    timeout-minutes: 30
     needs: legacy_emu
     env:
       EMULATOR: 1
@@ -206,6 +210,7 @@ jobs:
     name: Upload emulator binaries
     if: github.event_name == 'schedule' && github.repository == 'trezor/trezor-firmware'
     runs-on: ubuntu-latest
+    timeout-minutes: 15
     needs:
       - legacy_emu
       - legacy_emu_arm

--- a/.github/workflows/prebuild.yml
+++ b/.github/workflows/prebuild.yml
@@ -20,6 +20,7 @@ jobs:
     name: Block fixup
     if: github.event_name == 'pull_request'
     runs-on: ubuntu-latest
+    timeout-minutes: 5
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # actions/checkout@v6.0.2
       - name: Block Fixup Commit Merge
@@ -32,6 +33,7 @@ jobs:
   style_check:
     name: Style check
     runs-on: ubuntu-latest
+    timeout-minutes: 20
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # actions/checkout@v6.0.2
       - name: Initialize and update ts-tvl
@@ -49,6 +51,7 @@ jobs:
   defs_check:
     name: Defs check
     runs-on: ubuntu-latest
+    timeout-minutes: 20
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # actions/checkout@v6.0.2
         with:
@@ -61,6 +64,7 @@ jobs:
   gen_check:
     name: Gen check
     runs-on: ubuntu-latest
+    timeout-minutes: 20
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # actions/checkout@v6.0.2
         with:
@@ -73,6 +77,7 @@ jobs:
   uvlock_check:
     name: uv.lock check
     runs-on: ubuntu-latest
+    timeout-minutes: 15
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # actions/checkout@v6.0.2
         with:
@@ -89,6 +94,7 @@ jobs:
     name: Changelog check
     if: ${{ github.ref != 'main' && github.event_name == 'pull_request' }}
     runs-on: ubuntu-latest
+    timeout-minutes: 15
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # actions/checkout@v6.0.2
         with:

--- a/.github/workflows/release-emu.yml
+++ b/.github/workflows/release-emu.yml
@@ -32,6 +32,7 @@ jobs:
   get_models:
     name: Get models
     runs-on: ubuntu-latest
+    timeout-minutes: 5
     outputs:
       models: ${{ steps.get_models.outputs.models }}
       version: ${{ steps.get_models.outputs.version }}
@@ -59,6 +60,7 @@ jobs:
     name: Build emu
     needs: get_models
     runs-on: ubuntu-latest
+    timeout-minutes: 30
     strategy:
       fail-fast: false
       matrix:
@@ -84,6 +86,7 @@ jobs:
     name: Build core emu arm
     needs: get_models
     runs-on: ubuntu-latest-arm64
+    timeout-minutes: 30
     strategy:
       fail-fast: false
       matrix:
@@ -110,6 +113,7 @@ jobs:
     name: Build legacy emu
     needs: get_models
     runs-on: ubuntu-latest
+    timeout-minutes: 20
     strategy:
       matrix:
         coins: [universal]
@@ -133,6 +137,7 @@ jobs:
     name: Build legacy emu arm
     needs: get_models
     runs-on: ubuntu-latest-arm64
+    timeout-minutes: 20
     strategy:
       matrix:
         coins: [universal]

--- a/Makefile
+++ b/Makefile
@@ -24,7 +24,8 @@
 	certs certs_check \
 	python_doc python_doc_check \
 	gen gen_check \
-	uvlock_check
+	uvlock_check \
+	workflow_timeout_check
 
 ## help commands:
 
@@ -38,7 +39,7 @@ C_FILES =  $(shell find . -type f -name '*.[ch]' | grep -f ./tools/style.c.inclu
 PROTO_FILES = $(shell find common core -type f -name '*.proto')
 RUST_CRATES = $(shell find core -type f -name Cargo.toml -printf "%h\n")
 
-style_check: pystyle_check ruststyle_check cstyle_check protostyle_check changelog_check translations_style_check yaml_check docs_summary_check editor_check ## run all style checks
+style_check: pystyle_check ruststyle_check cstyle_check protostyle_check changelog_check translations_style_check yaml_check workflow_timeout_check docs_summary_check editor_check ## run all style checks
 
 style: pystyle ruststyle cstyle protostyle changelog_style translations_style ## apply all code styles (Python+Rust+C+protobuf+changelog+translation JSON)
 
@@ -100,6 +101,10 @@ translations_style_check: ## Check that translation files are properly formatted
 yaml_check: ## check yaml formatting
 	@echo [YAML-STYLE-CHECK]
 	yamllint --strict .
+
+workflow_timeout_check: ## check that all CI jobs declare a timeout
+	@echo [WORKFLOW-TIMEOUT-CHECK]
+	@./tools/check-workflow-timeouts.py
 
 editor_check: ## check editorconfig formatting
 	@echo [EDITORCONFIG-STYLE-CHECK]

--- a/tools/check-workflow-timeouts.py
+++ b/tools/check-workflow-timeouts.py
@@ -1,0 +1,45 @@
+#!/usr/bin/env python3
+"""Check that every GitHub Actions job declares a `timeout-minutes`.
+
+Without it a job inherits GitHub's 6h default, so a hung test blocks the
+runner for hours instead of failing.
+"""
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+import yaml
+
+REPO = Path(__file__).resolve().parent.parent
+WORKFLOWS = REPO / ".github" / "workflows"
+
+# Reusable-workflow calls cannot declare `timeout-minutes`.
+REUSABLE_WORKFLOWS = ("./.github/workflows/crowdin-ui-check-reuse.yml",)
+
+
+def main() -> int:
+    failed = False
+
+    for path in sorted(WORKFLOWS.glob("*.yml")):
+        workflow = yaml.safe_load(path.read_text()) or {}
+        for name, job in workflow.get("jobs", {}).items():
+            timeout = str(job.get("timeout-minutes") or "").strip()
+            if job.get("uses") in REUSABLE_WORKFLOWS or timeout:
+                continue
+            print(
+                f"{path.relative_to(REPO)}: job '{name}' has no valid timeout-minutes"
+            )
+            failed = True
+
+    if failed:
+        print(
+            "\nEvery job needs an explicit `timeout-minutes` -- GitHub's default is 6h."
+        )
+        return 1
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())


### PR DESCRIPTION
### Changes
- Added explicit timeout to all CI jobs.
- Added a check that verifies each job has an explicit timeout.

### Rationale
Sometimes a CI job gets stuck, but cannot be re-run until it fails. In such cases, it is only possible to re-run the whole workflow, wait for the 6h GitHub timeout, or hope it crashes soon - which is suboptimal.

- Adding an explicit timeout to all jobs resolves this. 
- Adding a script that checks explicit timeouts are present prevents regression and forces developers of new jobs to use explicit timeouts as well.