### PR TITLE
build(core): exclude meminfo-related code from FW builds

### DIFF
--- a/core/embed/projects/firmware/mpconfigport.h
+++ b/core/embed/projects/firmware/mpconfigport.h
@@ -166,16 +166,18 @@
 // allocate traceback data only on debug builds
 #define MICROPY_PY_SYS_TRACEBACK_DISABLE (PYOPT)
 
-#define MICROPY_PY_TREZORCONFIG      (1)
-#define MICROPY_PY_TREZORCRYPTO      (1)
-#define MICROPY_PY_TREZORDEFINITIONS (!BITCOIN_ONLY)
-#define MICROPY_PY_TREZORIO          (1)
-#define MICROPY_PY_TREZORUI          (1)
-#define MICROPY_PY_TREZORUTILS       (1)
-#define MICROPY_PY_TREZORPROTO       (1)
-#define MICROPY_PY_TREZORTRANSLATE   (1)
-#define MICROPY_PY_TREZORUI_API      (1)
-#define MICROPY_PY_TREZORAPP         (USE_APP_LOADING)
+#define MICROPY_PY_TREZORCONFIG         (1)
+#define MICROPY_PY_TREZORCRYPTO         (1)
+#define MICROPY_PY_TREZORDEFINITIONS    (!BITCOIN_ONLY)
+#define MICROPY_PY_TREZORIO             (1)
+#define MICROPY_PY_TREZORUI             (1)
+#define MICROPY_PY_TREZORUTILS          (1)
+// exclude by default (takes ~7kB of flash)
+#define MICROPY_PY_TREZORUTILS_MEMINFO  (0)
+#define MICROPY_PY_TREZORPROTO          (1)
+#define MICROPY_PY_TREZORTRANSLATE      (1)
+#define MICROPY_PY_TREZORUI_API         (1)
+#define MICROPY_PY_TREZORAPP            (USE_APP_LOADING)
 
 #define MP_STATE_PORT MP_STATE_VM
 

--- a/core/embed/projects/unix/mpconfigport.h
+++ b/core/embed/projects/unix/mpconfigport.h
@@ -216,16 +216,18 @@ extern const struct _mp_print_t mp_stderr_print;
 
 // extern const struct _mp_print_t mp_stderr_print;
 
-#define MICROPY_PY_TREZORCONFIG      (1)
-#define MICROPY_PY_TREZORCRYPTO      (1)
-#define MICROPY_PY_TREZORDEFINITIONS (!BITCOIN_ONLY)
-#define MICROPY_PY_TREZORIO          (1)
-#define MICROPY_PY_TREZORUI          (1)
-#define MICROPY_PY_TREZORUTILS       (1)
-#define MICROPY_PY_TREZORPROTO       (1)
-#define MICROPY_PY_TREZORTRANSLATE   (1)
-#define MICROPY_PY_TREZORUI_API      (1)
-#define MICROPY_PY_TREZORAPP         (USE_APP_LOADING)
+#define MICROPY_PY_TREZORCONFIG         (1)
+#define MICROPY_PY_TREZORCRYPTO         (1)
+#define MICROPY_PY_TREZORDEFINITIONS    (!BITCOIN_ONLY)
+#define MICROPY_PY_TREZORIO             (1)
+#define MICROPY_PY_TREZORUI             (1)
+#define MICROPY_PY_TREZORUTILS          (1)
+// exclude on optimized emulator
+#define MICROPY_PY_TREZORUTILS_MEMINFO  (!PYOPT)
+#define MICROPY_PY_TREZORPROTO          (1)
+#define MICROPY_PY_TREZORTRANSLATE      (1)
+#define MICROPY_PY_TREZORUI_API         (1)
+#define MICROPY_PY_TREZORAPP            (USE_APP_LOADING)
 
 #define MP_STATE_PORT MP_STATE_VM
 

--- a/core/embed/upymod/modtrezorutils/modtrezorutils-meminfo.h
+++ b/core/embed/upymod/modtrezorutils/modtrezorutils-meminfo.h
@@ -17,11 +17,6 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-#if PYOPT
-#define MEMINFO_DICT_ENTRIES /* empty */
-
-#else
-
 #include <trezor_types.h>
 
 #include "py/bc.h"
@@ -37,6 +32,9 @@
 #include <io/usb.h>
 #include "../../rust/librust.h"
 #include "../trezorobj.h"
+
+// TODO: does it work with current MicroPython?
+// https://github.com/trezor/trezor-firmware/issues/7462
 
 #if !TREZOR_EMULATOR
 #define fopen(path, mode) &mp_plat_print
@@ -749,25 +747,3 @@ static void dump_meminfo_json(FILE *out) {
 
   gc_dump_alloc_table(&mp_plat_print);
 }
-
-/// def meminfo(filename: str | None) -> None:
-///     """
-///     Dumps map of micropython GC arena to a file.
-///     The JSON file can be decoded by analyze-memory-dump.py
-///     """
-static mp_obj_t mod_trezorutils_meminfo(mp_obj_t filename) {
-  size_t fn_len;
-  FILE *out = (filename == mp_const_none)
-                  ? NULL
-                  : fopen(mp_obj_str_get_data(filename, &fn_len), "w");
-  (void)fn_len;
-  dump_meminfo_json(out);
-  return mp_const_none;
-}
-static MP_DEFINE_CONST_FUN_OBJ_1(mod_trezorutils_meminfo_obj,
-                                 mod_trezorutils_meminfo);
-
-#define MEMINFO_DICT_ENTRIES \
-  {MP_ROM_QSTR(MP_QSTR_meminfo), MP_ROM_PTR(&mod_trezorutils_meminfo_obj)},
-
-#endif

--- a/core/embed/upymod/modtrezorutils/modtrezorutils.c
+++ b/core/embed/upymod/modtrezorutils/modtrezorutils.c
@@ -33,7 +33,10 @@
 #if MICROPY_PY_TREZORUTILS
 
 #include "../trezorobj.h"
+
+#if MICROPY_PY_TREZORUTILS_MEMINFO
 #include "modtrezorutils-meminfo.h"
+#endif
 
 #include <io/notify.h>
 #include <io/usb.h>
@@ -447,7 +450,7 @@ static MP_DEFINE_CONST_FUN_OBJ_0(mod_trezorutils_estimate_unused_stack_obj,
 #if MICROPY_OOM_CALLBACK
 static void gc_oom_callback(void) {
   gc_dump_info(&mp_plat_print);
-#if BLOCK_ON_VCP
+#if MICROPY_PY_TREZORUTILS_MEMINFO
   dump_meminfo_json(NULL);  // dump to stdout
 #endif
 }
@@ -783,6 +786,28 @@ static mp_obj_t mod_trezorutil_get_scm_revision(mp_obj_t xor2) {
 static MP_DEFINE_CONST_FUN_OBJ_1(mod_trezorutil_get_scm_revision_obj,
                                  mod_trezorutil_get_scm_revision);
 
+#if MICROPY_PY_TREZORUTILS_MEMINFO
+/// def meminfo(filename: str | None) -> None:
+///     """
+///     Dumps map of micropython GC arena to a file.
+///     The JSON file can be decoded by analyze-memory-dump.py
+///     """
+static mp_obj_t mod_trezorutils_meminfo(mp_obj_t filename) {
+  FILE *out = NULL;
+  if (filename != mp_const_none) {
+    size_t fn_len = 0;
+    out = fopen(mp_obj_str_get_data(filename, &fn_len), "w");
+    if (out == NULL) {
+      mp_raise_msg(&mp_type_OSError, MP_ERROR_TEXT("Cannot open file"));
+    }
+  }
+  dump_meminfo_json(out);
+  return mp_const_none;
+}
+static MP_DEFINE_CONST_FUN_OBJ_1(mod_trezorutils_meminfo_obj,
+                                 mod_trezorutils_meminfo);
+#endif
+
 static const mp_obj_str_t mod_trezorutils_model_name_obj = {
     {&mp_type_str}, 0, sizeof(MODEL_NAME) - 1, (const byte *)MODEL_NAME};
 
@@ -1114,7 +1139,9 @@ static const mp_rom_map_elem_t mp_module_trezorutils_globals_table[] = {
 #error Unknown layout
 #endif
 #if !PYOPT
-    MEMINFO_DICT_ENTRIES
+#if MICROPY_PY_TREZORUTILS_MEMINFO
+    {MP_ROM_QSTR(MP_QSTR_meminfo), MP_ROM_PTR(&mod_trezorutils_meminfo_obj)},
+#endif
 #if DISABLE_ANIMATION
     {MP_ROM_QSTR(MP_QSTR_DISABLE_ANIMATION), mp_const_true},
 #else

--- a/core/mocks/generated/trezorutils.pyi
+++ b/core/mocks/generated/trezorutils.pyi
@@ -1,13 +1,5 @@
 from typing import *
 from buffer_types import *
-
-
-# upymod/modtrezorutils/modtrezorutils-meminfo.h
-def meminfo(filename: str | None) -> None:
-    """
-    Dumps map of micropython GC arena to a file.
-    The JSON file can be decoded by analyze-memory-dump.py
-    """
 from trezor import utils
 
 
@@ -251,6 +243,14 @@ def set_log_filter(filter: str) -> None:
 def get_scm_revision(xor2: int) -> bytes:
     """
     Returns SCM revision of the firmware.
+    """
+
+
+# upymod/modtrezorutils/modtrezorutils.c
+def meminfo(filename: str | None) -> None:
+    """
+    Dumps map of micropython GC arena to a file.
+    The JSON file can be decoded by analyze-memory-dump.py
     """
 VERSION: VersionTuple
 """Firmware version as a tuple (major, minor, patch, build)."""


### PR DESCRIPTION
Following https://github.com/trezor/trezor-firmware/issues/7792#issuecomment-5511850540.

Saves ~7.3KB on T2T1.

Keep it for emulators (it wasn't used recently on HW, and it probably needs some adjustments following the [recent MicroPython update](https://github.com/trezor/trezor-firmware/pull/7316)).
