### PR TITLE
Flash savings for --debug build on T2xx models

### DIFF
--- a/core/embed/.cargo/config.toml
+++ b/core/embed/.cargo/config.toml
@@ -28,6 +28,8 @@ rustflags = [
     # - https://github.com/japaric/stack-sizes/
     "-Z",
     "emit-stack-sizes",
+    "-Z",
+    "location-detail=line"
 ]
 
 [target.thumbv8m.main-none-eabihf]

--- a/core/embed/sys/linker/stm32f4/firmware.ld
+++ b/core/embed/sys/linker/stm32f4/firmware.ld
@@ -36,7 +36,7 @@ SECTIONS {
     . = ALIGN(COREAPP_ALIGNMENT);
     KEEP(*(.coreapp_header));
     . = ALIGN(4);
-    *frozen_mpy.o(.rodata*);
+    *(.text*);
     . = ALIGN(4);
     KEEP(*(.bootloader));
     *(.bootloader*);
@@ -44,8 +44,7 @@ SECTIONS {
   } >FLASH AT>FLASH
 
   .flash2 : ALIGN(512) {
-    . = ALIGN(4);
-    *(.text*);
+    *frozen_mpy.o(.rodata*);
     . = ALIGN(4);
     *(.rodata*);
     . = ALIGN(512);


### PR DESCRIPTION
This PR saves some space (~15 KB) in flash on models with STM32F4 by dropping filenames stored in the `.rodata` section for reporting purposes when the Rust application panics (on `unwrap!`, `panic!`, `assert!`, etc.). This saving applies only if the `--debug` option is passed to `xtask` (otherwise, these strings are not present at all since we use `panic=immediate-abort`).

After decreasing the `.rodata` section, it was possible to reorganize the sections in both flash regions again. After a small transposition, we now have a better distribution of free space between both flash regions.

On T2T1 with `--debug --debug-link --dbg-console=vcp --pyopt=false`, we get these results:

```
xtask: Memory usage from `firmware.map`
Region                   Used        Total    Usage
FLASH                754.0 KB     768.0 KB   98.18%
FLASH2               876.5 KB     896.0 KB   97.82%
```

Before this commit, the `FLASH` region was almost full.