### PR TITLE
fix(python): replace pyright ignore by type ignore

### DIFF
--- a/python/src/trezorlib/testing/device_handler.py
+++ b/python/src/trezorlib/testing/device_handler.py
@@ -83,7 +83,7 @@ class BackgroundDeviceHandler:
             client: The client object to configure.
         """
         self.client = client
-        self.client.ui = NullUI()  # pyright: ignore [reportAttributeAccessIssue]
+        self.client.ui = NullUI()  # type: ignore ["NullUI" is not assignable to "DebugUI"]
         self.client.app.button_callback = self.client.ui.button_request
         self.client.debug.input_wait_type = DebugWaitType.CURRENT_LAYOUT
 


### PR DESCRIPTION
Line error suppression is done by `type: ignore` everywhere. Fixed one (recently added) deviation from this rule.


Note: discovered during the review of #7807