### PR TITLE
feat(trezorlib): improve terse headertool output

### DIFF
--- a/python/src/trezorlib/_internal/firmware_headers.py
+++ b/python/src/trezorlib/_internal/firmware_headers.py
@@ -163,6 +163,7 @@ def format_header(
     code_hashes: t.Sequence[bytes],
     digest: bytes,
     sig_status: Status,
+    verbose: bool,
 ) -> str:
     header_dict = asdict(header)
     header_out = header_dict.copy()
@@ -187,11 +188,20 @@ def format_header(
 
     all_ok = SYM_OK if hash_status.is_ok() and sig_status.is_ok() else SYM_FAIL
 
-    output = [
-        "Firmware Header " + format_container(header_out),
-        f"Fingerprint: {click.style(chunkify(digest), bold=True)}",
-        f"{all_ok} Signature is {sig_status.value}, hashes are {hash_status.value}",
-    ]
+    if verbose:
+        output = ["Firmware Header " + format_container(header_out)]
+    else:
+        model = str(header_out["hw_model"])
+        version = header_out["version"]
+        output = [
+            f"Firmware Header for {click.style(model, bold=True)} "
+            f"version {click.style(version, bold=True)}"
+        ]
+
+    output.append(f"Fingerprint: {click.style(chunkify(digest), bold=True)}")
+    output.append(
+        f"{all_ok} Signature is {sig_status.value}, hashes are {hash_status.value}"
+    )
 
     return "\n".join(output)
 
@@ -374,6 +384,7 @@ class VendorFirmware(firmware.VendorFirmware, CosiSignedMixin):
                 self.firmware.code_hashes(),
                 self.digest(),
                 check_signature_any(self, is_devel),
+                verbose,
             )
         )
 
@@ -400,6 +411,7 @@ class BootloaderImage(firmware.FirmwareImage, CosiSignedMixin):
             self.code_hashes(),
             self.digest(),
             check_signature_any(self),
+            verbose,
         )
 
     def verify(self, dev_keys: bool = False) -> None:
@@ -611,6 +623,7 @@ class LegacyV2Firmware(firmware.LegacyV2Firmware):
             self.code_hashes(),
             self.digest(),
             check_signature_any(self),
+            verbose,
         )
 
     def public_keys(


### PR DESCRIPTION
This PR simplifies headertool output used to sign images during the build process.

Without the `--verbose` option, the tool now prints a concise summary:

```
Signing with local private keys...
Detected image type: firmware
Vendor Header for UNSAFE, DO NOT USE! version 0.0 (2560 bytes)
✔ Signature is VALID
Firmware Header for Model.T2T1 version 2.12.5.0
Fingerprint: 316d f491 d31b 8668 c2f7 df1f 9d94 4738 2b5f 8620 2e86 d7d2 b55f fc77 f06d c78d
✔ Signature is DEVEL, hashes are VALID
```

With `--verbose`, `headertool` continues to print the complete `FirmwareHeader`, including all fields, as before.

NOTE: `xtask` currently invokes `headertool` without `--verbose`, so firmware builds use the concise output. `xtask` does not currently expose an option to enable verbose `headertool` output. This can be added later if it becomes useful.