### PR TITLE
fix(core): show RSOD in coreapp (not in the terminal)

### DIFF
--- a/core/embed/projects/kernel/main.c
+++ b/core/embed/projects/kernel/main.c
@@ -256,7 +256,6 @@ static void kernel_loop(applet_t *coreapp) {
 
 // Shows RSOD (Red Screen of Death)
 static void show_rsod(const systask_postmortem_t *pminfo) {
-#ifdef RSOD_IN_COREAPP
   applet_t coreapp;
 
   // Reset and run the coreapp in RSOD mode
@@ -273,7 +272,6 @@ static void show_rsod(const systask_postmortem_t *pminfo) {
       return;
     }
   }
-#endif
 
   // If coreapp crashed, fallback to showing the error using a terminal
   rsod_terminal(pminfo);


### PR DESCRIPTION
This PR fixes a regression introduced by the new build system: the RSOD was rendered by the terminal fallback instead of by coreapp as a “fancy fatal error.”

The new build system does not define `RSOD_IN_COREAPP` for the kernel. Since firmware on all models renders the RSOD in coreapp, this PR removes the conditional entirely.

The regression affected all models except T3W1.
