### PR TITLE
chore(core/rust): remove unused `heapless::String` import

### DIFF
--- a/core/embed/rust/src/ui/layout_eckhart/firmware/keyboard/pin.rs
+++ b/core/embed/rust/src/ui/layout_eckhart/firmware/keyboard/pin.rs
@@ -1,4 +1,3 @@
-use heapless::String;
 use sys::time::Duration;
 
 use super::super::super::component::ButtonContent;


### PR DESCRIPTION
Should have been done in #7796.
