### PR TITLE
feat(trezorlib): improve terse headertool output (secmon)

### DIFF
--- a/python/src/trezorlib/_internal/firmware_headers.py
+++ b/python/src/trezorlib/_internal/firmware_headers.py
@@ -211,6 +211,7 @@ def format_secmon_header(
     code_hash: bytes,
     digest: bytes,
     sig_status: Status,
+    verbose: bool,
 ) -> str:
     header_dict = asdict(header)
     header_out = header_dict.copy()
@@ -232,12 +233,21 @@ def format_secmon_header(
 
     all_ok = SYM_OK if hash_status.is_ok() and sig_status.is_ok() else SYM_FAIL
 
-    output = [
-        "SECMON Header " + format_container(header_out),
-        f"Code hash:   {click.style(chunkify(code_hash), bold=True)}",
-        f"Fingerprint: {click.style(chunkify(digest), bold=True)}",
-        f"{all_ok} Signature is {sig_status.value}, hash is {hash_status.value}",
-    ]
+    if verbose:
+        output = ["Secmon Header " + format_container(header_out)]
+    else:
+        model = str(header_out["hw_model"])
+        version = header_out["version"]
+        output = [
+            f"Secmon Header for {click.style(model, bold=True)} "
+            f"version {click.style(version, bold=True)}"
+        ]
+
+    output.append(f"Code hash:   {click.style(chunkify(code_hash), bold=True)}")
+    output.append(f"Fingerprint: {click.style(chunkify(digest), bold=True)}")
+    output.append(
+        f"{all_ok} Signature is {sig_status.value}, hash is {hash_status.value}"
+    )
 
     return "\n".join(output)
 
@@ -445,6 +455,7 @@ class SecmonImage(firmware.SecmonImage, CosiSignedMixin):
             self.code_hash(),
             self.digest(),
             check_signature_any(self),
+            verbose,
         )
 
     def verify(self, dev_keys: bool = False) -> None:


### PR DESCRIPTION
This PR simplifies headertool output used to sign images during the build process (it's #7822 follow up)

Without the `--verbose` option, the tool now prints a concise summary for secmon:

```
xtask: Signing binary `secmon.bin`
Signing with local private keys...
Detected image type: secmon
Secmon Header for Model.T3W1 version 1.0.14.0
Code hash:   98af 8d0b f157 22e3 d681 19ef b035 dd8e 0601 cb24 17f5 802e 69f4 5755 1f1f 1bd2
Fingerprint: e311 4e4c 71ce b6b4 2ca8 8888 10be e7ee 512f 50ed fd4a 5764 c6a4 3ba7 395b baae
✔ Signature is DEVEL, hash is VALID
```

With `--verbose`, `headertool` continues to print the complete `SecmonHeader`, including all fields, as before.