### PR TITLE
report the actual error from a failed wipe step

### DIFF
--- a/core/embed/projects/bootloader/workflow/wf_wipe_device.c
+++ b/core/embed/projects/bootloader/workflow/wf_wipe_device.c
@@ -42,10 +42,9 @@
 #include "rust_ui_bootloader.h"
 #include "workflow.h"
 
-static void send_error_conditionally(protob_io_t* iface, char* msg) {
+static void send_error_conditionally(protob_io_t* iface, const char* msg) {
   if (iface != NULL) {
-    send_msg_failure(iface, FailureType_Failure_ProcessError,
-                     "Could not read BLE status");
+    send_msg_failure(iface, FailureType_Failure_ProcessError, msg);
   }
 }
 


### PR DESCRIPTION
`send_error_conditionally` ignored its `msg` argument and always sent "Could not read BLE status", so a host watching a WipeDevice was told the wrong thing whenever anything but the BLE status read failed -- an inability to issue a BLE command, to erase bonds, or to erase flash.

<!--
For external contributors:
- Please open an issue before submitting a PR so we can discuss whether we want to proceed with it.

For core developers:
1. Initial PR setup
- Assign yourself to the PR.
- Add it to the "Firmware" project
  - Set Priority (match issue priority if it exists)
  - Set Team
  - Set Sprint (target release)

2. Development status
- Draft PRs: Set status to "In Progress"
- Final PRs: Set status to "Needs Review"

3. Post-merge status
- Testable: Set status to "Needs QA" and add a `Notes for QA` section with clear instructions on how to test the functionality.
- Not Testable: Set status to "Done (no QA)"
-->
