### PR TITLE
Clear signing: External threshold message

### DIFF
--- a/common/protob/messages-definitions.proto
+++ b/common/protob/messages-definitions.proto
@@ -185,6 +185,7 @@ message EthereumERC7730FieldInfo {
     // TokenAmountFormatter params
     optional EthereumERC7730Path token_path = 4;
     optional bytes threshold = 5;
+    optional string threshold_message = 13;
 
     // UnitFormatter params
     optional uint32 decimals = 6;

--- a/common/tests/fixtures/ethereum/sign_tx_external_definitions.json
+++ b/common/tests/fixtures/ethereum/sign_tx_external_definitions.json
@@ -623,6 +623,26 @@
                 "sig_r": "ffa6ee4bdc7fd229a89a93648ffb6953ce54771ab527d30173e48b6db6515c24",
                 "sig_s": "442b96cd4dd3b79fdabc81b93ad7571678d0892b003fb8a2ce9685ef9eaee7a8"
             }
+        },
+        {
+            "name": "aave_lpv3_repayWithPermit",
+            "parameters": {
+                "comment": "supported | unlimited external message | https://etherscan.io/tx/0x4e74a1a38d78e856268c527fa03ae8acfd5f392eeccb6f25f41af9c73cc84e2d",
+                "data": "ee3e210b000000000000000000000000a0b86991c6218b36c1d19d4a2e9eb0ce3606eb48ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff000000000000000000000000000000000000000000000000000000000000000200000000000000000000000011ce13cb0cd73f29dd05219213fa277b16f7b800000000000000000000000000000000000000000000000000000000006a9f2e0b000000000000000000000000000000000000000000000000000000000000001bd42acca912579a4c60ffb16035fb7e8df3dccfa067f9e17648766f4c27db94380729666c13c10b8cd28ef26157a003057ab75a2e19d57904063bf912a50f0a32",
+                "path": "m/44'/60'/0'/0/0",
+                "to_address": "0x87870Bca3F3fD6335C3F4ce8392D69350B4fA4E2",
+                "chain_id": 1,
+                "nonce": "0x0",
+                "gas_price": "0x14",
+                "gas_limit": "0x14",
+                "tx_type": null,
+                "value": "0x0"
+            },
+            "result": {
+                "sig_v": 37,
+                "sig_r": "33e075f9434c224a6e9d127e1e8c8284848bf8360716fe0adb9afb58f1b4309a",
+                "sig_s": "24c6e1bf8c5033e88e1b8db7a493b057b81ff7d24ec241314062a4669cd85308"
+            }
         }
     ]
 }

--- a/core/src/apps/ethereum/clear_signing.py
+++ b/core/src/apps/ethereum/clear_signing.py
@@ -335,11 +335,13 @@ class TokenAmountFormatter(FieldFormatter):
         const_token_address: bytes | None = None,
         native_currency_address: list[bytes] | None = None,
         threshold: int | None = None,
+        threshold_message: str | None = None,
     ) -> None:
         self.token_path = token_path
         self.const_token_address = const_token_address
         self.native_currency_address = native_currency_address
         self.threshold = threshold
+        self.threshold_message = threshold_message
 
     async def format(
         self,
@@ -369,10 +371,15 @@ class TokenAmountFormatter(FieldFormatter):
         else:
             raise InvalidFormatDefinition
 
+        # TODO: Dead code. We don't pull this externally but we need to.
         if self.native_currency_address is not None:
             if token_address in self.native_currency_address:
                 if self.threshold is not None and amount > self.threshold:
-                    return AboveThreshold(TR.words__unlimited), None, None
+                    return (
+                        AboveThreshold(self.threshold_message or TR.words__unlimited),
+                        None,
+                        None,
+                    )
                 else:
                     return (
                         format_ethereum_amount(amount, None, defs.network),
@@ -392,7 +399,11 @@ class TokenAmountFormatter(FieldFormatter):
                     token = received_definitions.get_token(token_address)
 
         if self.threshold is not None and amount > self.threshold:
-            return AboveThreshold(TR.words__unlimited), token, token_address
+            return (
+                AboveThreshold(self.threshold_message or TR.words__unlimited),
+                token,
+                token_address,
+            )
         else:
             return (
                 format_ethereum_amount(amount, token, defs.network),
@@ -864,6 +875,8 @@ class FieldDefinition:
                 )
             if info.threshold is not None:
                 formatter_params["threshold"] = int.from_bytes(info.threshold, "big")
+            if info.threshold_message is not None:
+                formatter_params["threshold_message"] = info.threshold_message
             formatter = TokenAmountFormatter(**formatter_params)
         elif fmt_type == FT.FORMATTER_UNIT:
             formatter_params = {}

--- a/core/src/trezor/messages.py
+++ b/core/src/trezor/messages.py
@@ -3401,6 +3401,7 @@ if TYPE_CHECKING:
         formatter: "EthereumERC7730FieldFormatterType"
         token_path: "EthereumERC7730Path | None"
         threshold: "AnyBytes | None"
+        threshold_message: "str | None"
         decimals: "int | None"
         base: "str | None"
         prefix: "bool | None"
@@ -3418,6 +3419,7 @@ if TYPE_CHECKING:
             enum_values: "list[EthereumERC7730EnumEntry] | None" = None,
             token_path: "EthereumERC7730Path | None" = None,
             threshold: "AnyBytes | None" = None,
+            threshold_message: "str | None" = None,
             decimals: "int | None" = None,
             base: "str | None" = None,
             prefix: "bool | None" = None,

--- a/python/src/trezorlib/messages.py
+++ b/python/src/trezorlib/messages.py
@@ -4870,6 +4870,7 @@ class EthereumERC7730FieldInfo(protobuf.MessageType):
         3: protobuf.Field("formatter", "EthereumERC7730FieldFormatterType", repeated=False, required=True),
         4: protobuf.Field("token_path", "EthereumERC7730Path", repeated=False, required=False, default=None),
         5: protobuf.Field("threshold", "bytes", repeated=False, required=False, default=None),
+        13: protobuf.Field("threshold_message", "string", repeated=False, required=False, default=None),
         6: protobuf.Field("decimals", "uint32", repeated=False, required=False, default=None),
         7: protobuf.Field("base", "string", repeated=False, required=False, default=None),
         8: protobuf.Field("prefix", "bool", repeated=False, required=False, default=None),
@@ -4888,6 +4889,7 @@ class EthereumERC7730FieldInfo(protobuf.MessageType):
         enum_values: Optional[Sequence["EthereumERC7730EnumEntry"]] = None,
         token_path: Optional["EthereumERC7730Path"] = None,
         threshold: Optional["bytes"] = None,
+        threshold_message: Optional["str"] = None,
         decimals: Optional["int"] = None,
         base: Optional["str"] = None,
         prefix: Optional["bool"] = None,
@@ -4901,6 +4903,7 @@ class EthereumERC7730FieldInfo(protobuf.MessageType):
         self.formatter = formatter
         self.token_path = token_path
         self.threshold = threshold
+        self.threshold_message = threshold_message
         self.decimals = decimals
         self.base = base
         self.prefix = prefix

--- a/rust/trezor-client/src/protos/generated/messages_definitions.rs
+++ b/rust/trezor-client/src/protos/generated/messages_definitions.rs
@@ -1659,6 +1659,8 @@ pub struct EthereumERC7730FieldInfo {
     pub token_path: ::protobuf::MessageField<EthereumERC7730Path>,
     // @@protoc_insertion_point(field:hw.trezor.messages.definitions.EthereumERC7730FieldInfo.threshold)
     pub threshold: ::std::option::Option<::std::vec::Vec<u8>>,
+    // @@protoc_insertion_point(field:hw.trezor.messages.definitions.EthereumERC7730FieldInfo.threshold_message)
+    pub threshold_message: ::std::option::Option<::std::string::String>,
     // @@protoc_insertion_point(field:hw.trezor.messages.definitions.EthereumERC7730FieldInfo.decimals)
     pub decimals: ::std::option::Option<u32>,
     // @@protoc_insertion_point(field:hw.trezor.messages.definitions.EthereumERC7730FieldInfo.base)
@@ -1781,6 +1783,42 @@ impl EthereumERC7730FieldInfo {
     // Take field
     pub fn take_threshold(&mut self) -> ::std::vec::Vec<u8> {
         self.threshold.take().unwrap_or_else(|| ::std::vec::Vec::new())
+    }
+
+    // optional string threshold_message = 13;
+
+    pub fn threshold_message(&self) -> &str {
+        match self.threshold_message.as_ref() {
+            Some(v) => v,
+            None => "",
+        }
+    }
+
+    pub fn clear_threshold_message(&mut self) {
+        self.threshold_message = ::std::option::Option::None;
+    }
+
+    pub fn has_threshold_message(&self) -> bool {
+        self.threshold_message.is_some()
+    }
+
+    // Param is passed by value, moved
+    pub fn set_threshold_message(&mut self, v: ::std::string::String) {
+        self.threshold_message = ::std::option::Option::Some(v);
+    }
+
+    // Mutable pointer to the field.
+    // If field is not initialized, it is initialized with default value first.
+    pub fn mut_threshold_message(&mut self) -> &mut ::std::string::String {
+        if self.threshold_message.is_none() {
+            self.threshold_message = ::std::option::Option::Some(::std::string::String::new());
+        }
+        self.threshold_message.as_mut().unwrap()
+    }
+
+    // Take field
+    pub fn take_threshold_message(&mut self) -> ::std::string::String {
+        self.threshold_message.take().unwrap_or_else(|| ::std::string::String::new())
     }
 
     // optional uint32 decimals = 6;
@@ -1930,7 +1968,7 @@ impl EthereumERC7730FieldInfo {
     }
 
     fn generated_message_descriptor_data() -> ::protobuf::reflect::GeneratedMessageDescriptorData {
-        let mut fields = ::std::vec::Vec::with_capacity(12);
+        let mut fields = ::std::vec::Vec::with_capacity(13);
         let mut oneofs = ::std::vec::Vec::with_capacity(0);
         fields.push(::protobuf::reflect::rt::v2::make_message_field_accessor::<_, EthereumERC7730Path>(
             "path",
@@ -1956,6 +1994,11 @@ impl EthereumERC7730FieldInfo {
             "threshold",
             |m: &EthereumERC7730FieldInfo| { &m.threshold },
             |m: &mut EthereumERC7730FieldInfo| { &mut m.threshold },
+        ));
+        fields.push(::protobuf::reflect::rt::v2::make_option_accessor::<_, _>(
+            "threshold_message",
+            |m: &EthereumERC7730FieldInfo| { &m.threshold_message },
+            |m: &mut EthereumERC7730FieldInfo| { &mut m.threshold_message },
         ));
         fields.push(::protobuf::reflect::rt::v2::make_option_accessor::<_, _>(
             "decimals",
@@ -2054,6 +2097,9 @@ impl ::protobuf::Message for EthereumERC7730FieldInfo {
                 42 => {
                     self.threshold = ::std::option::Option::Some(is.read_bytes()?);
                 },
+                106 => {
+                    self.threshold_message = ::std::option::Option::Some(is.read_string()?);
+                },
                 48 => {
                     self.decimals = ::std::option::Option::Some(is.read_uint32()?);
                 },
@@ -2104,6 +2150,9 @@ impl ::protobuf::Message for EthereumERC7730FieldInfo {
         if let Some(v) = self.threshold.as_ref() {
             my_size += ::protobuf::rt::bytes_size(5, &v);
         }
+        if let Some(v) = self.threshold_message.as_ref() {
+            my_size += ::protobuf::rt::string_size(13, &v);
+        }
         if let Some(v) = self.decimals {
             my_size += ::protobuf::rt::uint32_size(6, v);
         }
@@ -2148,6 +2197,9 @@ impl ::protobuf::Message for EthereumERC7730FieldInfo {
         if let Some(v) = self.threshold.as_ref() {
             os.write_bytes(5, v)?;
         }
+        if let Some(v) = self.threshold_message.as_ref() {
+            os.write_string(13, v)?;
+        }
         if let Some(v) = self.decimals {
             os.write_uint32(6, v)?;
         }
@@ -2191,6 +2243,7 @@ impl ::protobuf::Message for EthereumERC7730FieldInfo {
         self.formatter = ::std::option::Option::None;
         self.token_path.clear();
         self.threshold = ::std::option::Option::None;
+        self.threshold_message = ::std::option::Option::None;
         self.decimals = ::std::option::Option::None;
         self.base = ::std::option::Option::None;
         self.prefix = ::std::option::Option::None;
@@ -2208,6 +2261,7 @@ impl ::protobuf::Message for EthereumERC7730FieldInfo {
             formatter: ::std::option::Option::None,
             token_path: ::protobuf::MessageField::none(),
             threshold: ::std::option::Option::None,
+            threshold_message: ::std::option::Option::None,
             decimals: ::std::option::Option::None,
             base: ::std::option::Option::None,
             prefix: ::std::option::Option::None,
@@ -3320,23 +3374,24 @@ static file_descriptor_proto_data: &'static [u8] = b"\
     h\x18\x02\x20\x01(\x0e2<.hw.trezor.messages.definitions.EthereumERC7730C\
     ontainerPathR\rcontainerPath\x12\x1f\n\x0bconst_value\x18\x03\x20\x01(\t\
     R\nconstValue\x12\x1f\n\x0bslice_start\x18\x04\x20\x01(\x11R\nsliceStart\
-    \x12\x1b\n\tslice_end\x18\x05\x20\x01(\x11R\x08sliceEnd\"\x91\x05\n\x18E\
+    \x12\x1b\n\tslice_end\x18\x05\x20\x01(\x11R\x08sliceEnd\"\xbe\x05\n\x18E\
     thereumERC7730FieldInfo\x12G\n\x04path\x18\x01\x20\x02(\x0b23.hw.trezor.\
     messages.definitions.EthereumERC7730PathR\x04path\x12\x14\n\x05label\x18\
     \x02\x20\x02(\tR\x05label\x12_\n\tformatter\x18\x03\x20\x02(\x0e2A.hw.tr\
     ezor.messages.definitions.EthereumERC7730FieldFormatterTypeR\tformatter\
     \x12R\n\ntoken_path\x18\x04\x20\x01(\x0b23.hw.trezor.messages.definition\
     s.EthereumERC7730PathR\ttokenPath\x12\x1c\n\tthreshold\x18\x05\x20\x01(\
-    \x0cR\tthreshold\x12\x1a\n\x08decimals\x18\x06\x20\x01(\rR\x08decimals\
-    \x12\x12\n\x04base\x18\x07\x20\x01(\tR\x04base\x12\x16\n\x06prefix\x18\
-    \x08\x20\x01(\x08R\x06prefix\x12.\n\x13const_token_address\x18\t\x20\x01\
-    (\x0cR\x11constTokenAddress\x12T\n\x0bcallee_path\x18\n\x20\x01(\x0b23.h\
-    w.trezor.messages.definitions.EthereumERC7730PathR\ncalleePath\x12\x1a\n\
-    \x08selector\x18\x0b\x20\x01(\x0cR\x08selector\x12Y\n\x0benum_values\x18\
-    \x0c\x20\x03(\x0b28.hw.trezor.messages.definitions.EthereumERC7730EnumEn\
-    tryR\nenumValues\"B\n\x18EthereumERC7730EnumEntry\x12\x10\n\x03key\x18\
-    \x01\x20\x02(\rR\x03key\x12\x14\n\x05value\x18\x02\x20\x02(\tR\x05value\
-    \"\xfa\x02\n\x19EthereumDisplayFormatInfo\x12\x19\n\x08chain_id\x18\x01\
+    \x0cR\tthreshold\x12+\n\x11threshold_message\x18\r\x20\x01(\tR\x10thresh\
+    oldMessage\x12\x1a\n\x08decimals\x18\x06\x20\x01(\rR\x08decimals\x12\x12\
+    \n\x04base\x18\x07\x20\x01(\tR\x04base\x12\x16\n\x06prefix\x18\x08\x20\
+    \x01(\x08R\x06prefix\x12.\n\x13const_token_address\x18\t\x20\x01(\x0cR\
+    \x11constTokenAddress\x12T\n\x0bcallee_path\x18\n\x20\x01(\x0b23.hw.trez\
+    or.messages.definitions.EthereumERC7730PathR\ncalleePath\x12\x1a\n\x08se\
+    lector\x18\x0b\x20\x01(\x0cR\x08selector\x12Y\n\x0benum_values\x18\x0c\
+    \x20\x03(\x0b28.hw.trezor.messages.definitions.EthereumERC7730EnumEntryR\
+    \nenumValues\"B\n\x18EthereumERC7730EnumEntry\x12\x10\n\x03key\x18\x01\
+    \x20\x02(\rR\x03key\x12\x14\n\x05value\x18\x02\x20\x02(\tR\x05value\"\
+    \xfa\x02\n\x19EthereumDisplayFormatInfo\x12\x19\n\x08chain_id\x18\x01\
     \x20\x02(\x04R\x07chainId\x12\x18\n\x07address\x18\x02\x20\x02(\x0cR\x07\
     address\x12\x19\n\x08func_sig\x18\x03\x20\x02(\x0cR\x07funcSig\x12\x16\n\
     \x06intent\x18\x04\x20\x02(\tR\x06intent\x12i\n\x15parameter_definitions\


### PR DESCRIPTION
This would fix showing `Unlimited` for all threshold messsage and use the external definition value instead.
Test fixture has been updated however we don't have an updated binary file that would contain an external message to test. That will be added later as a quick PR.

## Notes for QA

https://etherscan.io/tx/0x9dd34a634bebd476faf68c32e4c0d25cef326b7add39706cdf3c8d72a93f7749
1/ Borrow any amount on Aave (I've tried USDC)
2/ Repay ALL loan, first step will always be EIP-712 approval
3/ You should see `Repay: All` not `Repay: Unlimited`