### PR TITLE
Use native currency address parameter for token formatting

### DIFF
--- a/common/protob/messages-definitions.proto
+++ b/common/protob/messages-definitions.proto
@@ -186,6 +186,7 @@ message EthereumERC7730FieldInfo {
     optional EthereumERC7730Path token_path = 4;
     optional bytes threshold = 5;
     optional string threshold_message = 13;
+    repeated bytes native_currency_address = 14;
 
     // UnitFormatter params
     optional uint32 decimals = 6;

--- a/common/tests/fixtures/ethereum/sign_tx_external_definitions.json
+++ b/common/tests/fixtures/ethereum/sign_tx_external_definitions.json
@@ -627,7 +627,7 @@
         {
             "name": "aave_lpv3_repayWithPermit",
             "parameters": {
-                "comment": "supported | unlimited external message | https://etherscan.io/tx/0x4e74a1a38d78e856268c527fa03ae8acfd5f392eeccb6f25f41af9c73cc84e2d",
+                "comment": " unlimited external message | https://etherscan.io/tx/0x4e74a1a38d78e856268c527fa03ae8acfd5f392eeccb6f25f41af9c73cc84e2d",
                 "data": "ee3e210b000000000000000000000000a0b86991c6218b36c1d19d4a2e9eb0ce3606eb48ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff000000000000000000000000000000000000000000000000000000000000000200000000000000000000000011ce13cb0cd73f29dd05219213fa277b16f7b800000000000000000000000000000000000000000000000000000000006a9f2e0b000000000000000000000000000000000000000000000000000000000000001bd42acca912579a4c60ffb16035fb7e8df3dccfa067f9e17648766f4c27db94380729666c13c10b8cd28ef26157a003057ab75a2e19d57904063bf912a50f0a32",
                 "path": "m/44'/60'/0'/0/0",
                 "to_address": "0x87870Bca3F3fD6335C3F4ce8392D69350B4fA4E2",
@@ -642,6 +642,26 @@
                 "sig_v": 37,
                 "sig_r": "33e075f9434c224a6e9d127e1e8c8284848bf8360716fe0adb9afb58f1b4309a",
                 "sig_s": "24c6e1bf8c5033e88e1b8db7a493b057b81ff7d24ec241314062a4669cd85308"
+            }
+        },
+        {
+            "name": "aave_WrappedTokenGatewayV3_withdrawETH",
+            "parameters": {
+                "comment": "uses native currency parameter in token formatter | https://etherscan.io/tx/0x5c80804266f525ac45262cde1601fb07ccdec6fd5c5f863717d563c82f6577a9",
+                "data": "80500d2000000000000000000000000087870bca3f3fd6335c3f4ce8392d69350b4fa4e2ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff0000000000000000000000006f2eccc962975c9e2841db64b0e82c0b1218b4d3",
+                "path": "m/44'/60'/0'/0/0",
+                "to_address": "0xd01607c3C5eCABa394D8be377a08590149325722",
+                "chain_id": 1,
+                "nonce": "0x0",
+                "gas_price": "0x14",
+                "gas_limit": "0x14",
+                "tx_type": null,
+                "value": "0x0"
+            },
+            "result": {
+                "sig_v": 38,
+                "sig_r": "bf0257e259b0f04dd026f436cf890982107136da2381312b7a6133582b490e5a",
+                "sig_s": "4d9f0dad1f563fb378eb1e34194bea6ae6fefc460bda07c8c5faa15c2b1ce371"
             }
         }
     ]

--- a/core/src/apps/ethereum/clear_signing.py
+++ b/core/src/apps/ethereum/clear_signing.py
@@ -877,6 +877,10 @@ class FieldDefinition:
                 formatter_params["threshold"] = int.from_bytes(info.threshold, "big")
             if info.threshold_message is not None:
                 formatter_params["threshold_message"] = info.threshold_message
+            if info.native_currency_address:
+                formatter_params["native_currency_address"] = [
+                    bytes(addr) for addr in info.native_currency_address
+                ]
             formatter = TokenAmountFormatter(**formatter_params)
         elif fmt_type == FT.FORMATTER_UNIT:
             formatter_params = {}

--- a/core/src/trezor/messages.py
+++ b/core/src/trezor/messages.py
@@ -3402,6 +3402,7 @@ if TYPE_CHECKING:
         token_path: "EthereumERC7730Path | None"
         threshold: "AnyBytes | None"
         threshold_message: "str | None"
+        native_currency_address: "list[AnyBytes]"
         decimals: "int | None"
         base: "str | None"
         prefix: "bool | None"
@@ -3416,6 +3417,7 @@ if TYPE_CHECKING:
             path: "EthereumERC7730Path",
             label: "str",
             formatter: "EthereumERC7730FieldFormatterType",
+            native_currency_address: "list[AnyBytes] | None" = None,
             enum_values: "list[EthereumERC7730EnumEntry] | None" = None,
             token_path: "EthereumERC7730Path | None" = None,
             threshold: "AnyBytes | None" = None,

--- a/python/src/trezorlib/messages.py
+++ b/python/src/trezorlib/messages.py
@@ -4871,6 +4871,7 @@ class EthereumERC7730FieldInfo(protobuf.MessageType):
         4: protobuf.Field("token_path", "EthereumERC7730Path", repeated=False, required=False, default=None),
         5: protobuf.Field("threshold", "bytes", repeated=False, required=False, default=None),
         13: protobuf.Field("threshold_message", "string", repeated=False, required=False, default=None),
+        14: protobuf.Field("native_currency_address", "bytes", repeated=True, required=False, default=None),
         6: protobuf.Field("decimals", "uint32", repeated=False, required=False, default=None),
         7: protobuf.Field("base", "string", repeated=False, required=False, default=None),
         8: protobuf.Field("prefix", "bool", repeated=False, required=False, default=None),
@@ -4886,6 +4887,7 @@ class EthereumERC7730FieldInfo(protobuf.MessageType):
         path: "EthereumERC7730Path",
         label: "str",
         formatter: "EthereumERC7730FieldFormatterType",
+        native_currency_address: Optional[Sequence["bytes"]] = None,
         enum_values: Optional[Sequence["EthereumERC7730EnumEntry"]] = None,
         token_path: Optional["EthereumERC7730Path"] = None,
         threshold: Optional["bytes"] = None,
@@ -4897,6 +4899,7 @@ class EthereumERC7730FieldInfo(protobuf.MessageType):
         callee_path: Optional["EthereumERC7730Path"] = None,
         selector: Optional["bytes"] = None,
     ) -> None:
+        self.native_currency_address: Sequence["bytes"] = native_currency_address if native_currency_address is not None else []
         self.enum_values: Sequence["EthereumERC7730EnumEntry"] = enum_values if enum_values is not None else []
         self.path = path
         self.label = label

--- a/rust/trezor-client/src/protos/generated/messages_definitions.rs
+++ b/rust/trezor-client/src/protos/generated/messages_definitions.rs
@@ -1661,6 +1661,8 @@ pub struct EthereumERC7730FieldInfo {
     pub threshold: ::std::option::Option<::std::vec::Vec<u8>>,
     // @@protoc_insertion_point(field:hw.trezor.messages.definitions.EthereumERC7730FieldInfo.threshold_message)
     pub threshold_message: ::std::option::Option<::std::string::String>,
+    // @@protoc_insertion_point(field:hw.trezor.messages.definitions.EthereumERC7730FieldInfo.native_currency_address)
+    pub native_currency_address: ::std::vec::Vec<::std::vec::Vec<u8>>,
     // @@protoc_insertion_point(field:hw.trezor.messages.definitions.EthereumERC7730FieldInfo.decimals)
     pub decimals: ::std::option::Option<u32>,
     // @@protoc_insertion_point(field:hw.trezor.messages.definitions.EthereumERC7730FieldInfo.base)
@@ -1968,7 +1970,7 @@ impl EthereumERC7730FieldInfo {
     }
 
     fn generated_message_descriptor_data() -> ::protobuf::reflect::GeneratedMessageDescriptorData {
-        let mut fields = ::std::vec::Vec::with_capacity(13);
+        let mut fields = ::std::vec::Vec::with_capacity(14);
         let mut oneofs = ::std::vec::Vec::with_capacity(0);
         fields.push(::protobuf::reflect::rt::v2::make_message_field_accessor::<_, EthereumERC7730Path>(
             "path",
@@ -1999,6 +2001,11 @@ impl EthereumERC7730FieldInfo {
             "threshold_message",
             |m: &EthereumERC7730FieldInfo| { &m.threshold_message },
             |m: &mut EthereumERC7730FieldInfo| { &mut m.threshold_message },
+        ));
+        fields.push(::protobuf::reflect::rt::v2::make_vec_simpler_accessor::<_, _>(
+            "native_currency_address",
+            |m: &EthereumERC7730FieldInfo| { &m.native_currency_address },
+            |m: &mut EthereumERC7730FieldInfo| { &mut m.native_currency_address },
         ));
         fields.push(::protobuf::reflect::rt::v2::make_option_accessor::<_, _>(
             "decimals",
@@ -2100,6 +2107,9 @@ impl ::protobuf::Message for EthereumERC7730FieldInfo {
                 106 => {
                     self.threshold_message = ::std::option::Option::Some(is.read_string()?);
                 },
+                114 => {
+                    self.native_currency_address.push(is.read_bytes()?);
+                },
                 48 => {
                     self.decimals = ::std::option::Option::Some(is.read_uint32()?);
                 },
@@ -2153,6 +2163,9 @@ impl ::protobuf::Message for EthereumERC7730FieldInfo {
         if let Some(v) = self.threshold_message.as_ref() {
             my_size += ::protobuf::rt::string_size(13, &v);
         }
+        for value in &self.native_currency_address {
+            my_size += ::protobuf::rt::bytes_size(14, &value);
+        };
         if let Some(v) = self.decimals {
             my_size += ::protobuf::rt::uint32_size(6, v);
         }
@@ -2200,6 +2213,9 @@ impl ::protobuf::Message for EthereumERC7730FieldInfo {
         if let Some(v) = self.threshold_message.as_ref() {
             os.write_string(13, v)?;
         }
+        for v in &self.native_currency_address {
+            os.write_bytes(14, &v)?;
+        };
         if let Some(v) = self.decimals {
             os.write_uint32(6, v)?;
         }
@@ -2244,6 +2260,7 @@ impl ::protobuf::Message for EthereumERC7730FieldInfo {
         self.token_path.clear();
         self.threshold = ::std::option::Option::None;
         self.threshold_message = ::std::option::Option::None;
+        self.native_currency_address.clear();
         self.decimals = ::std::option::Option::None;
         self.base = ::std::option::Option::None;
         self.prefix = ::std::option::Option::None;
@@ -2262,6 +2279,7 @@ impl ::protobuf::Message for EthereumERC7730FieldInfo {
             token_path: ::protobuf::MessageField::none(),
             threshold: ::std::option::Option::None,
             threshold_message: ::std::option::Option::None,
+            native_currency_address: ::std::vec::Vec::new(),
             decimals: ::std::option::Option::None,
             base: ::std::option::Option::None,
             prefix: ::std::option::Option::None,
@@ -3374,7 +3392,7 @@ static file_descriptor_proto_data: &'static [u8] = b"\
     h\x18\x02\x20\x01(\x0e2<.hw.trezor.messages.definitions.EthereumERC7730C\
     ontainerPathR\rcontainerPath\x12\x1f\n\x0bconst_value\x18\x03\x20\x01(\t\
     R\nconstValue\x12\x1f\n\x0bslice_start\x18\x04\x20\x01(\x11R\nsliceStart\
-    \x12\x1b\n\tslice_end\x18\x05\x20\x01(\x11R\x08sliceEnd\"\xbe\x05\n\x18E\
+    \x12\x1b\n\tslice_end\x18\x05\x20\x01(\x11R\x08sliceEnd\"\xf6\x05\n\x18E\
     thereumERC7730FieldInfo\x12G\n\x04path\x18\x01\x20\x02(\x0b23.hw.trezor.\
     messages.definitions.EthereumERC7730PathR\x04path\x12\x14\n\x05label\x18\
     \x02\x20\x02(\tR\x05label\x12_\n\tformatter\x18\x03\x20\x02(\x0e2A.hw.tr\
@@ -3382,16 +3400,17 @@ static file_descriptor_proto_data: &'static [u8] = b"\
     \x12R\n\ntoken_path\x18\x04\x20\x01(\x0b23.hw.trezor.messages.definition\
     s.EthereumERC7730PathR\ttokenPath\x12\x1c\n\tthreshold\x18\x05\x20\x01(\
     \x0cR\tthreshold\x12+\n\x11threshold_message\x18\r\x20\x01(\tR\x10thresh\
-    oldMessage\x12\x1a\n\x08decimals\x18\x06\x20\x01(\rR\x08decimals\x12\x12\
-    \n\x04base\x18\x07\x20\x01(\tR\x04base\x12\x16\n\x06prefix\x18\x08\x20\
-    \x01(\x08R\x06prefix\x12.\n\x13const_token_address\x18\t\x20\x01(\x0cR\
-    \x11constTokenAddress\x12T\n\x0bcallee_path\x18\n\x20\x01(\x0b23.hw.trez\
-    or.messages.definitions.EthereumERC7730PathR\ncalleePath\x12\x1a\n\x08se\
-    lector\x18\x0b\x20\x01(\x0cR\x08selector\x12Y\n\x0benum_values\x18\x0c\
-    \x20\x03(\x0b28.hw.trezor.messages.definitions.EthereumERC7730EnumEntryR\
-    \nenumValues\"B\n\x18EthereumERC7730EnumEntry\x12\x10\n\x03key\x18\x01\
-    \x20\x02(\rR\x03key\x12\x14\n\x05value\x18\x02\x20\x02(\tR\x05value\"\
-    \xfa\x02\n\x19EthereumDisplayFormatInfo\x12\x19\n\x08chain_id\x18\x01\
+    oldMessage\x126\n\x17native_currency_address\x18\x0e\x20\x03(\x0cR\x15na\
+    tiveCurrencyAddress\x12\x1a\n\x08decimals\x18\x06\x20\x01(\rR\x08decimal\
+    s\x12\x12\n\x04base\x18\x07\x20\x01(\tR\x04base\x12\x16\n\x06prefix\x18\
+    \x08\x20\x01(\x08R\x06prefix\x12.\n\x13const_token_address\x18\t\x20\x01\
+    (\x0cR\x11constTokenAddress\x12T\n\x0bcallee_path\x18\n\x20\x01(\x0b23.h\
+    w.trezor.messages.definitions.EthereumERC7730PathR\ncalleePath\x12\x1a\n\
+    \x08selector\x18\x0b\x20\x01(\x0cR\x08selector\x12Y\n\x0benum_values\x18\
+    \x0c\x20\x03(\x0b28.hw.trezor.messages.definitions.EthereumERC7730EnumEn\
+    tryR\nenumValues\"B\n\x18EthereumERC7730EnumEntry\x12\x10\n\x03key\x18\
+    \x01\x20\x02(\rR\x03key\x12\x14\n\x05value\x18\x02\x20\x02(\tR\x05value\
+    \"\xfa\x02\n\x19EthereumDisplayFormatInfo\x12\x19\n\x08chain_id\x18\x01\
     \x20\x02(\x04R\x07chainId\x12\x18\n\x07address\x18\x02\x20\x02(\x0cR\x07\
     address\x12\x19\n\x08func_sig\x18\x03\x20\x02(\x0cR\x07funcSig\x12\x16\n\
     \x06intent\x18\x04\x20\x02(\tR\x06intent\x12i\n\x15parameter_definitions\


### PR DESCRIPTION
Only Token Formatter has the threshold formatting in spec, which is what the descriptors use.

We will stop "pre-parsing" native-currency-address-using-token-formatter as AmountFormatters and will use them as the ERC intends.

Very much a mirror of #7839 , awaits definition improvement and needs similar QA albeit with `withdrawETH` (native ETH vault in Aave)