### PR TITLE
ci(core): check ELF files for debug-related symbols

### DIFF
--- a/.github/workflows/core.yml
+++ b/.github/workflows/core.yml
@@ -104,6 +104,8 @@ jobs:
       # - run: nix-shell --run "uv run ./tools/print-rust-type-sizes.sh core/build/firmware/rust-type-sizes.log" | awk '$1 >= 1000' | sort -k1 -n
       - run: nix-shell --run "uv run ./tools/check-bitcoin-only core/build-xtask/artifacts/latest/firmware.bin"
         if: matrix.coins == 'btconly' && matrix.type != 'debuglink'
+      - run: nix-shell --run "uv run ./tools/check-elf-symbols.py absent core/build-xtask/artifacts/latest/*.elf -p debug -p mock"
+        if: matrix.type != 'debuglink'
       - uses: actions/upload-artifact@bbbca2ddaa5d8feaa63e36b76fdaad77386f024f  # actions/upload-artifact@v7.0.0
         with:
           name: core-firmware-${{ matrix.model }}-${{ matrix.coins }}-${{ matrix.type }}${{ matrix.n1w1 && '-n1w1' || '' }}

--- a/tools/check-elf-symbols.py
+++ b/tools/check-elf-symbols.py
@@ -1,0 +1,40 @@
+#!/usr/bin/env python3
+import subprocess
+from pathlib import Path
+
+import click
+
+ROOT = Path(__file__).parent.parent.resolve()
+
+
+def load_symbols(elf_file: Path) -> list[str]:
+    """Load symbol names from firmware ELF file using `nm`."""
+    out = subprocess.check_output(
+        args=["arm-none-eabi-nm", "--demangle", str(elf_file)]
+    )
+    symbols = (line.decode().split(maxsplit=2) for line in out.splitlines())
+    return [name for _addr, type, name in symbols]
+
+
+@click.group()
+def cli() -> None:
+    pass
+
+
+@cli.command()
+@click.argument("elf_files", required=True, nargs=-1, type=click.Path(path_type=Path))
+@click.option("-p", "--pattern", multiple=True, help="Must not appear in the ELF file")
+def absent(elf_files: tuple[Path, ...], pattern: tuple[str, ...]) -> None:
+    error = False
+    for elf_file in elf_files:
+        for symbol in load_symbols(elf_file):
+            if any(p in symbol for p in pattern):
+                click.echo(f"Unexpected symbol: `{symbol}` in {elf_file}")
+                error = True
+
+    if error:
+        raise click.exceptions.Exit(1)
+
+
+if __name__ == "__main__":
+    cli()


### PR DESCRIPTION
- [ ] use `elftools` (instead of `nm`)

C, Rust & MicroPython symbols should be visible in `nm` output:
```
$ arm-none-eabi-nm -C core/build-xtask/artifacts/latest/firmware.elf

0c0d338c T zkp_bip340_verify_digest
0c0d3414 T zkp_bip340_verify_publickey
0c0d2a4c T zkp_context_acquire_writable
0c0d2938 T zkp_context_destroy
0c0d2a0c T zkp_context_get_read_only
0c0d2994 T zkp_context_init

0c09638c t trezor_lib::ui::layout_delizia::flow::confirm_action::create_flow
0c096528 t trezor_lib::ui::layout_delizia::flow::confirm_action::create_menu
0c09662c t trezor_lib::ui::layout_delizia::flow::confirm_action::create_confirm
0c09acf0 t trezor_lib::ui::layout_delizia::flow::set_brightness::footer_update_fn

0c1bc094 t frozen_module_apps_bitcoin___init__
0c1b96b0 t frozen_module_apps_bitcoin_keychain
0c1b924c t frozen_module_apps_bitcoin_multisig
0c1b8e3c t frozen_module_apps_bitcoin_ownership
0c1b8d7c t frozen_module_apps_bitcoin_readers
```