### PR TITLE
build: add ASAN toggle to tbench manifest

### DIFF
--- a/core/embed/xtask/tbench/manifest.yaml
+++ b/core/embed/xtask/tbench/manifest.yaml
@@ -269,3 +269,10 @@ options:
     group: Debugging
     when: component(firmware)
     type: checkbox
+
+  - id: asan
+    name: Address Sanitizer
+    description: Enables Address Sanitizer.
+    group: Debugging
+    when: target(emulator)
+    type: checkbox


### PR DESCRIPTION
add a toggle to the tbench extension that allows disabling ASAN
(which is currently GCC specific)

<!--
For external contributors:
- Please open an issue before submitting a PR so we can discuss whether we want to proceed with it.

For core developers:
1. Initial PR setup
- Assign yourself to the PR.
- Add it to the "Firmware" project
  - Set Priority (match issue priority if it exists)
  - Set Team
  - Set Sprint (target release)

2. Development status
- Draft PRs: Set status to "In Progress"
- Final PRs: Set status to "Needs Review"

3. Post-merge status
- Testable: Set status to "Needs QA" and add a `Notes for QA` section with clear instructions on how to test the functionality.
- Not Testable: Set status to "Done (no QA)"
-->
