### PR TITLE
fix(rust/micropython): drop as_mut_slice

### DIFF
--- a/core/embed/rust/src/micropython/tuple.rs
+++ b/core/embed/rust/src/micropython/tuple.rs
@@ -36,14 +36,8 @@ impl Tuple {
         // SAFETY:
         // - micropython promises that items have the right len
         // - items are part of the same allocation so the lifetime bound is correct
+        // - tuples are immutable so nobody is going to be modifying the result
         unsafe { self.items.as_slice(self.len) }
-    }
-
-    pub fn as_mut_slice(&mut self) -> &mut [Obj] {
-        // SAFETY:
-        // - micropython promises that items have the right len
-        // - items are part of the same allocation so the lifetime bound is correct
-        unsafe { self.items.as_mut_slice(self.len) }
     }
 }
 


### PR DESCRIPTION
because ~slices~ tuples aren't supposed to be mutable

<!--
For external contributors:
- Please open an issue before submitting a PR so we can discuss whether we want to proceed with it.

For core developers:
1. Initial PR setup
- Assign yourself to the PR.
- Add it to the "Firmware" project
  - Set Priority (match issue priority if it exists)
  - Set Team
  - Set Sprint (target release)

2. Development status
- Draft PRs: Set status to "In Progress"
- Final PRs: Set status to "Needs Review"

3. Post-merge status
- Testable: Set status to "Needs QA" and add a `Notes for QA` section with clear instructions on how to test the functionality.
- Not Testable: Set status to "Done (no QA)"
-->
