### PR TITLE
ci(core): exclude UI fixtures & coverage upload for unstable builds

### DIFF
--- a/.github/workflows/core.yml
+++ b/.github/workflows/core.yml
@@ -345,6 +345,7 @@ jobs:
       ADDRESS_SANITIZER: ${{ matrix.asan == 'asan' && '1' || '0' }}
       PYTEST_TIMEOUT: ${{ matrix.asan == 'asan' && 600 || 400 }}
       ACTIONS_DO_UI_TEST: ${{ matrix.coins == 'universal' && matrix.asan == 'noasan' }}
+      STABLE_FEATURES: ${{ !matrix.n1w1 }}  # TODO(N1W1): stabilize n1w1
       TEST_LANG: ${{ matrix.lang }}
       TESTOPTS: "--durations 10 --session-timeout ${{ matrix.model == 'T3W1' && '3000' || '1800' }}"  # pytest global timeout
     timeout-minutes: ${{ matrix.model == 'T3W1' && 60 || 40 }}  # CI job timeout
@@ -359,10 +360,10 @@ jobs:
       - run: chmod +x core/build-xtask/artifacts/latest/firmware-emu*
       - uses: ./.github/actions/environment
       - name: Run device tests
-        if: ${{ !matrix.n1w1 }}
+        if: ${{ env.STABLE_FEATURES == 'true' }}
         run: nix-shell --run "uv run make -C core ${{ env.ACTIONS_DO_UI_TEST == 'true' && 'test_emu_ui_multicore' || 'test_emu' }}"
-      - name: Run device tests (N1W1)
-        if: ${{ matrix.n1w1 }}  # TODO(N1W1): test N1W1 UI fixtures as well
+      - name: Run device tests (without UI fixtures)
+        if: ${{ env.STABLE_FEATURES != 'true' }}
         run: nix-shell --run "uv run make -C core ${{ env.ACTIONS_DO_UI_TEST == 'true' && 'test_emu_multicore' || 'test_emu' }}"
       - run: tail -v -n50 tests/trezor*.log || true
         if: failure()
@@ -377,10 +378,10 @@ jobs:
           model: ${{ matrix.model }}
           lang: ${{ matrix.lang }}
           status: ${{ job.status }}
-        if: ${{ always() && env.ACTIONS_DO_UI_TEST == 'true' && !matrix.n1w1 }}
+        if: ${{ always() && env.ACTIONS_DO_UI_TEST == 'true' && env.STABLE_FEATURES == 'true' }}
         continue-on-error: true
       - uses: ./.github/actions/upload-coverage
-        if: ${{ !matrix.n1w1 }}
+        if: ${{ env.STABLE_FEATURES == 'true' }}
 
   # Click tests - UI.
   # See [docs/tests/click-tests](../tests/click-tests.md) for more info.


### PR DESCRIPTION
Will be used to exclude miniscript in https://github.com/trezor/trezor-firmware/pull/7835.
