### PR TITLE
feat(core): support NFC discovery in MicroPython

### DIFF
--- a/core/embed/io/nfc/unix/nfc.c
+++ b/core/embed/io/nfc/unix/nfc.c
@@ -20,3 +20,6 @@
 #include <io/nfc.h>
 
 bool nfc_get_event(nfc_event_t* event) { return false; }
+
+ts_t nfc_start_discovery(void) { return TS_OK; }
+ts_t nfc_stop_discovery(void) { return TS_OK; }

--- a/core/embed/upymod/modtrezorio/modtrezorio-nfc.h
+++ b/core/embed/upymod/modtrezorio/modtrezorio-nfc.h
@@ -1,0 +1,61 @@
+/*
+ * This file is part of the Trezor project, https://trezor.io/
+ *
+ * Copyright (c) SatoshiLabs
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#include <io/nfc.h>
+
+/// package: trezorio.nfc
+///
+/// def start() -> None:
+///     """Start NFC discovery."""
+///
+/// def stop() -> None:
+///     """Stop NFC discovery."""
+
+static inline void raise_on_error(ts_t status) {
+  if (ts_error(status)) {
+    mp_raise_OSError(ts_code(status));
+  }
+}
+
+static mp_obj_t mod_trezorio_nfc_start() {
+  raise_on_error(nfc_start_discovery());
+  return mp_const_none;
+}
+static MP_DEFINE_CONST_FUN_OBJ_0(mod_trezorio_nfc_start_obj,
+                                 mod_trezorio_nfc_start);
+
+static mp_obj_t mod_trezorio_nfc_stop() {
+  raise_on_error(nfc_stop_discovery());
+  return mp_const_none;
+}
+static MP_DEFINE_CONST_FUN_OBJ_0(mod_trezorio_nfc_stop_obj,
+                                 mod_trezorio_nfc_stop);
+
+static const mp_rom_map_elem_t mod_trezorio_nfc_globals_table[] = {
+    {MP_ROM_QSTR(MP_QSTR___name__), MP_ROM_QSTR(MP_QSTR_nfc)},
+    {MP_ROM_QSTR(MP_QSTR_start), MP_ROM_PTR(&mod_trezorio_nfc_start_obj)},
+    {MP_ROM_QSTR(MP_QSTR_stop), MP_ROM_PTR(&mod_trezorio_nfc_stop_obj)},
+};
+static MP_DEFINE_CONST_DICT(mod_trezorio_nfc_globals,
+                            mod_trezorio_nfc_globals_table);
+
+static const mp_obj_module_t mod_trezorio_nfc_module = {
+    .base = {&mp_type_module},
+    .globals = (mp_obj_dict_t *)&mod_trezorio_nfc_globals,
+};

--- a/core/embed/upymod/modtrezorio/modtrezorio.c
+++ b/core/embed/upymod/modtrezorio/modtrezorio.c
@@ -69,6 +69,9 @@
 #ifdef USE_POWER_MANAGER
 #include "modtrezorio-pm.h"
 #endif
+#ifdef USE_NFC
+#include "modtrezorio-nfc.h"
+#endif
 #ifdef USE_IPC
 #include "modtrezorio-ipc.h"
 #endif
@@ -156,6 +159,7 @@ static const mp_rom_map_elem_t mp_module_trezorio_globals_table[] = {
     {MP_ROM_QSTR(MP_QSTR_PM_EVENT), MP_ROM_INT(SYSHANDLE_POWER_MANAGER)},
 #endif
 #ifdef USE_NFC
+    {MP_ROM_QSTR(MP_QSTR_nfc), MP_ROM_PTR(&mod_trezorio_nfc_module)},
     {MP_ROM_QSTR(MP_QSTR_NFC_EVENT), MP_ROM_INT(SYSHANDLE_NFC)},
 #endif
 #ifdef USE_IPC

--- a/core/mocks/generated/trezorio/nfc.pyi
+++ b/core/mocks/generated/trezorio/nfc.pyi
@@ -1,0 +1,14 @@
+from typing import *
+from buffer_types import *
+
+
+
+# upymod/modtrezorio/modtrezorio-nfc.h
+def start() -> None:
+    """Start NFC discovery."""
+
+
+
+# upymod/modtrezorio/modtrezorio-nfc.h
+def stop() -> None:
+    """Stop NFC discovery."""


### PR DESCRIPTION
Can be tested using N1W1-enabled FW @ 785aec58c898040e8c90f12bb201d3e226a07fd5:
```
xtask build firmware --model T3W1 --n1w1 --debug-link --pyopt=false --dbg-console=vcp
trezorctl device recover -m n1w1
```
