### PR TITLE
Fix WipeDevice on older firmware

### DIFF
--- a/python/src/trezorlib/debuglink.py
+++ b/python/src/trezorlib/debuglink.py
@@ -574,6 +574,10 @@ class DebugLink:
         return self.version >= (1, 11, 0)
 
     @property
+    def has_wipe(self) -> bool:
+        return self.version >= (2, 9, 1)
+
+    @property
     def layout_type(self) -> LayoutType:
         assert self.model is not None
         return LayoutType.from_model(self.model)
@@ -1753,7 +1757,7 @@ class TrezorTestContext:
         """
         if reseed and self.is_emulator:
             self.debug.reseed(0)
-        if self.model is models.T1B1:
+        if self.model is models.T1B1 or not self.debug.has_wipe:
             self.client._get_any_session().call(
                 messages.WipeDevice(),
                 expect=messages.Success,


### PR DESCRIPTION
Wiping over DebugLink was only added in 601ef837dbd39b1d6dc356d7ab4c64ee748f1461 and release 2.9.1.

<!--
For external contributors:
- Please open an issue before submitting a PR so we can discuss whether we want to proceed with it.

For core developers:
1. Initial PR setup
- Assign yourself to the PR.
- Add it to the "Firmware" project
  - Set Priority (match issue priority if it exists)
  - Set Team
  - Set Sprint (target release)

2. Development status
- Draft PRs: Set status to "In Progress"
- Final PRs: Set status to "Needs Review"

3. Post-merge status
- Testable: Set status to "Needs QA" and add a `Notes for QA` section with clear instructions on how to test the functionality.
- Not Testable: Set status to "Done (no QA)"
-->
