### PR TITLE
fix(core): add colons to info_items in Bolt layout

### DIFF
--- a/core/src/trezor/ui/layouts/bolt/__init__.py
+++ b/core/src/trezor/ui/layouts/bolt/__init__.py
@@ -850,7 +850,7 @@ async def confirm_value(
 
     info_ctx = trezorui_api.show_info_with_cancel(
         title=info_title if info_title else TR.words__title_information,
-        items=list(info_items) if info_items else [],
+        items=with_colon(info_items) or [],
         chunkify=chunkify_info,
     )
 


### PR DESCRIPTION
before
<img width="242" height="236" alt="image" src="https://github.com/user-attachments/assets/c043648d-00da-47a4-8dab-a95a38e36a14" />
<img width="243" height="239" alt="image" src="https://github.com/user-attachments/assets/544f405f-6709-46bd-b602-af6ed8362828" />

after
<img width="246" height="248" alt="image" src="https://github.com/user-attachments/assets/6f5ba4c3-ed18-46ec-97a4-d1d37b5ca94c" />
<img width="250" height="249" alt="image" src="https://github.com/user-attachments/assets/f4c551b6-acdc-4a5f-b6de-73caed997c84" />

Unfortunately no Bolt device test enter the menu to be able to create a UI diff for this.